### PR TITLE
[Balance Druid] Completeness

### DIFF
--- a/src/Parser/BalanceDruid/CONFIG.js
+++ b/src/Parser/BalanceDruid/CONFIG.js
@@ -7,7 +7,7 @@ import CHANGELOG from './CHANGELOG';
 export default {
   spec: SPECS.BALANCE_DRUID,
   maintainer: '@Iskalla',
-  completeness: SPEC_ANALYSIS_COMPLETENESS.NEEDS_MORE_WORK, // When changing this please make a PR with ONLY this value changed, we will do a review of your analysis to find out of it is complete enough.
+  completeness: SPEC_ANALYSIS_COMPLETENESS.GOOD, // When changing this please make a PR with ONLY this value changed, we will do a review of your analysis to find out of it is complete enough.
   changelog: CHANGELOG,
   parser: CombatLogParser,
 };


### PR DESCRIPTION
The balance module currently tracks:

Standard modules: Damage done, Downtime
Cast Efficiency for all rotational spells (Moons and Incarnation with IFE need work)
Moons usage
Uptimes (Moonfire, Sunfire)
Astral Power overcapping
Lunar and Solar Empowerment Overcapping
Lunar Strike casts without Lunar Empowerment that hit less than 3 targets


Modules that are planned:

Dots casted outside of pandemic
Short casts (unemp SW, NM) over 200% haste
OI (Legendary bracers) Procs wasted
ED (Legendary helm) buff dropped
Couple  minor things to fix

It's also needed to add whispers and other haste trinkets to the haste module

I believe the current status should be Good.
Every core module is in, the only thing left is dot spamming (this is a fairly complex module since monkin dots spread, so even when casted outside pandemic in main target, they may be well used).
There are still legendarys to add and some in-depth stuff too, but is pretty detailed.
I'd also like to make a much more complex and detailed Astral Power module, but the current one is good enough to check how much was wasted - not the reason

Everything planned is in:
https://github.com/Iskalla/WoWAnalyzer/projects/1

I was doubting between letting it as WIP or good... but i think every main thing is in.