### PR TITLE
(Holy Priest) Changing spec completion to 'Good'

### DIFF
--- a/src/Parser/HolyPriest/CONFIG.js
+++ b/src/Parser/HolyPriest/CONFIG.js
@@ -7,7 +7,7 @@ import CHANGELOG from './CHANGELOG';
 export default {
   spec: SPECS.HOLY_PRIEST,
   maintainer: '@enragednuke',
-  completeness: SPEC_ANALYSIS_COMPLETENESS.NEEDS_MORE_WORK, // When changing this please make a PR with ONLY this value changed, we will do a review of your analysis to find out of it is complete enough.
+  completeness: SPEC_ANALYSIS_COMPLETENESS.GOOD, // When changing this please make a PR with ONLY this value changed, we will do a review of your analysis to find out of it is complete enough.
   changelog: CHANGELOG,
   parser: CombatLogParser,
 };


### PR DESCRIPTION
*cracks knuckles*

As I'm sure many healers mains know, Holy Priest is a fairly simplistic spec. The realms for improvement are often as simple as "press this button on CD, press these big buttons for damage, press other buttons in the meantime", so the spec won't have nearly as extensive of a list as others.

**Statistics** (viewable on WCL)

 * Divinity Uptime

**Statistics** (not available on WCL, at least not with ease)

 * Average good HW:Sanctify hits per cast (not available because it filters >80% OH hits)
 * Say Your Prayers (trait) estimated contribution
 * Echo of Light breakdown
 * Light of T'uure gain, including from the % increase
 * Renew the Faith (trait) gain 
 * Enduring Renewal benefit 
 * Wasted Serendipity (with the merging of #383)

**Suggestions** (all unavailable to WCL)

 * Sanctify effectiveness (average good hits < 5.25)
 * Missed Hymn ticks (available but easy to miss on WCL)
 * Long strings of Serendipity when a holy word is off cooldown (e.g. casting 60 seconds worth of HW:Serenity serendipity while it is still off cooldown) (with the merging of #383)

I believe I have implemented all of the major functionality that Holy Priests would be looking for. The suggestions, while lacking in number, embody the major points in Holy Priest gameplay that can be improved other than simply looking at cast breakdowns, as Holy Priest is as simple as that for 80% of its improvement. This analyzer serves as a remaining 15% (I think I need the non-movement renews idea before it's 20% :^)). 

One of the main goals of this analyzer is to provide accurate metrics for the traits or passives that are hard to calculate normally (for example, Renew the Faith, Say Your Prayers, Light of T'uure, Enduring Renewal all of which are implemented) so that the Theorycrafting community can more properly value various aspects and give back to the community. This goal is mostly accomplished as well.

That being said, there are still plenty of smaller things I need to add to really refine the analyzer into a "Great" state.

**Potential Remaining Ideas** (as of this moment)
 - (*Statistic*) Power of the Naaru (trait) benefit (average, would be quick ~15min implementation, just thought of this 2min ago)
 - (*Statistic*) Surge of Light procs (minor, SoL is absurdly uncommon)
 - (*Suggestion*) Wasted Surge of Light procs (minor, SoL is absurdly uncommon)
 - (*Suggestion*) Non-movement renews cast (average, logic could look a bit wonky and is somewhat noticeable as the player in WCL casts)
 - (*Item*) T20 4P "casts used early" (similar to Disc Priest T20 4P implementation) (average, whenever #383 is implemented is when I can start)
 - (*Item*) T21 2/4P before Antorus (minor, lots of time before Antorus and I still need confirmation on whether or not the 2/4P works with Binding Heal since PTR was not helpful last time it was checked)
