### PR TITLE
[Issue #387] Cooldown Tracker should not include boss abilities

### DIFF
--- a/src/Parser/Core/Modules/CooldownTracker.js
+++ b/src/Parser/Core/Modules/CooldownTracker.js
@@ -50,6 +50,7 @@ class CooldownTracker extends Module {
     // general spells that you don't want to see in the Cooldown overview (could be boss mechanics etc.) should belong here
     // if you want to add some spells specific to your spec, redefine this array in your spec CooldownTracker similarly to cooldownSpells (see Marksmanship Hunter for example)
     SPELLS.ASTRAL_VULNERABILITY.id,
+    SPELLS.ANNIHILATION_TRILLIAX.id,
   ];
 
   pastCooldowns = [];

--- a/src/Parser/Core/Modules/CooldownTracker.js
+++ b/src/Parser/Core/Modules/CooldownTracker.js
@@ -46,8 +46,9 @@ class CooldownTracker extends Module {
     },
   ];
 
-  ignoredSpells = [
-    // add spells that you don't want to see in the Cooldown description here (could be specific boss mechanics etc.)
+  static ignoredSpells = [
+    // general spells that you don't want to see in the Cooldown overview (could be boss mechanics etc.) should belong here
+    // if you want to add some spells specific to your spec, redefine this array in your spec CooldownTracker similarly to cooldownSpells (see Marksmanship Hunter for example)
     SPELLS.ASTRAL_VULNERABILITY.id,
   ];
 
@@ -96,7 +97,7 @@ class CooldownTracker extends Module {
 
   // region Event tracking
   trackEvent(event) {
-    if (this.ignoredSpells.includes(event.ability.guid)) {
+    if (this.constructor.ignoredSpells.includes(event.ability.guid)) {
       return;
     }
     this.activeCooldowns.forEach((cooldown) => {

--- a/src/Parser/Core/Modules/CooldownTracker.js
+++ b/src/Parser/Core/Modules/CooldownTracker.js
@@ -97,14 +97,14 @@ class CooldownTracker extends Module {
 
   // region Event tracking
   trackEvent(event) {
-    if (this.constructor.ignoredSpells.includes(event.ability.guid)) {
-      return;
-    }
     this.activeCooldowns.forEach((cooldown) => {
       cooldown.events.push(event);
     });
   }
   on_byPlayer_cast(event) {
+    if (this.constructor.ignoredSpells.includes(event.ability.guid)) {
+      return;
+    }
     this.trackEvent(event);
   }
   on_byPlayer_heal(event) {

--- a/src/Parser/Core/Modules/CooldownTracker.js
+++ b/src/Parser/Core/Modules/CooldownTracker.js
@@ -46,6 +46,11 @@ class CooldownTracker extends Module {
     },
   ];
 
+  ignoredSpells = [
+    // add spells that you don't want to see in the Cooldown description here (could be specific boss mechanics etc.)
+    SPELLS.ASTRAL_VULNERABILITY.id,
+  ];
+
   pastCooldowns = [];
   activeCooldowns = [];
 
@@ -91,6 +96,9 @@ class CooldownTracker extends Module {
 
   // region Event tracking
   trackEvent(event) {
+    if (this.ignoredSpells.includes(event.ability.guid)) {
+      return;
+    }
     this.activeCooldowns.forEach((cooldown) => {
       cooldown.events.push(event);
     });

--- a/src/Parser/MarksmanshipHunter/Modules/Features/CooldownTracker.js
+++ b/src/Parser/MarksmanshipHunter/Modules/Features/CooldownTracker.js
@@ -2,8 +2,6 @@ import SPELLS from 'common/SPELLS';
 
 import CoreCooldownTracker, { BUILT_IN_SUMMARY_TYPES } from 'Parser/Core/Modules/CooldownTracker';
 
-const debug = false;
-
 class CooldownTracker extends CoreCooldownTracker {
   static cooldownSpells = [
     ...CooldownTracker.cooldownSpells,
@@ -15,18 +13,10 @@ class CooldownTracker extends CoreCooldownTracker {
     },
   ];
 
-  castEventSpells = [
+  static ignoredSpells = [
+    ...CooldownTracker.ignoredSpells,
     SPELLS.WINDBURST_MOVEMENT_SPEED.id,
   ];
-
-  on_byPlayer_cast(event) {
-    const spellID = event.ability.guid;
-    if (this.castEventSpells.indexOf(spellID) !== -1)  {
-      debug && console.log('Exiting');
-      return;
-    }
-    super.on_byPlayer_cast(event);
-  }
 }
 
 export default CooldownTracker;

--- a/src/Parser/MistweaverMonk/Modules/Features/CooldownTracker.js
+++ b/src/Parser/MistweaverMonk/Modules/Features/CooldownTracker.js
@@ -2,8 +2,6 @@ import SPELLS from 'common/SPELLS';
 
 import CoreCooldownTracker, { BUILT_IN_SUMMARY_TYPES } from 'Parser/Core/Modules/CooldownTracker';
 
-const debug = false;
-
 class CooldownTracker extends CoreCooldownTracker {
   static cooldownSpells = [
     ...CooldownTracker.cooldownSpells,
@@ -17,24 +15,14 @@ class CooldownTracker extends CoreCooldownTracker {
     },
   ];
 
-  castEventSpells = [
+  static ignoredSpells = [
+    ...CooldownTracker.ignoredSpells,
     SPELLS.CHI_BURST_HEAL.id,
     SPELLS.REFRESHING_JADE_WIND_HEAL.id,
     SPELLS.SPIRIT_TETHER.id,
     SPELLS.TRANSCENDENCE.id,
     SPELLS.SOOTHING_MIST_CAST.id,
   ];
-
-  // Clean up display of casts during CDs.  For Monks, both Chi Burst and RJW have a cooresponding cast event
-  // per heal event.  This prevents some unneeded spam of Cooldown view.
-  on_byPlayer_cast(event) {
-    const spellId = event.ability.guid;
-    if (this.castEventSpells.indexOf(spellId) !== -1) {
-      debug && console.log('Exiting');
-      return;
-    }
-    super.on_byPlayer_cast(event);
-  }
 }
 
 export default CooldownTracker;

--- a/src/common/SPELLS_OTHERS.js
+++ b/src/common/SPELLS_OTHERS.js
@@ -305,7 +305,11 @@ export default {
     name: 'Astral Vulnerability',
     icon: 'spell_frost_wisp',
   },
-
+  ANNIHILATION_TRILLIAX: {
+    id: 207631,
+    name: 'Annihilation',
+    icon: 'spell_arcane_arcanetorrent',
+  },
   // Netherlight Cruicible Traits
   MURDEROUS_INTENT_TRAIT: {
     id: 252191,

--- a/src/common/SPELLS_OTHERS.js
+++ b/src/common/SPELLS_OTHERS.js
@@ -300,6 +300,11 @@ export default {
     name: 'Melee',
     icon: 'inv_axe_02',
   },
+  ASTRAL_VULNERABILITY: {
+    id: 236330,
+    name: 'Astral Vulnerability',
+    icon: 'spell_frost_wisp',
+  },
 
   // Netherlight Cruicible Traits
   MURDEROUS_INTENT_TRAIT: {


### PR DESCRIPTION
**Original issue**: #387 

Not sure if there is some general solution to boss abilities, because even in the mentioned example, the casts are of Astral Vulnerability and it's from a player to a friendly player, so there's no way of knowing if that's a boss specific mechanic (just by looking at the event object). 

Instead I added a simple static array that contains spell IDs you wish to ignore. This can be furthermore extended by spec CooldownTrackers to add additional ignored spells (I suggested that in PR #405 and eventually rewrote that in this PR - works completely the same), for example see Marksmanship Hunter Cooldown Tracker.

Before: 
![cooldowns-before](https://user-images.githubusercontent.com/5068584/30887543-3436989a-a31c-11e7-8dc1-8afa0b4a96b0.png)

After:
![cooldowns-after](https://user-images.githubusercontent.com/5068584/30887553-411e791a-a31c-11e7-9efc-ecbb22bd115c.png)
