### PR TITLE
[Demonology] Added T20 set bonuses

### DIFF
--- a/src/Parser/Core/Modules/Haste.js
+++ b/src/Parser/Core/Modules/Haste.js
@@ -31,8 +31,8 @@ class Haste extends Module {
     [SPELLS.BERSERKING.id]: 0.15,
     [202842]: 0.1, // Rapid Innervation (Balance Druid trait increasing Haste from Innervate)
     [SPELLS.POWER_INFUSION_TALENT.id]: 0.25,
-    [240673]: 800 / 37500, // Shadow Priest artifact trait that's shared with 4 allies: http://www.wowhead.com/spell=240673/mind-quickening
-    [SPELLS.MARK_OF_THE_CLAW.id]: 1000 / 37500,
+    [240673]: 800 / this.HASTE_RATING_PER_PERCENT, // Shadow Priest artifact trait that's shared with 4 allies: http://www.wowhead.com/spell=240673/mind-quickening
+    [SPELLS.MARK_OF_THE_CLAW.id]: 1000 / this.HASTE_RATING_PER_PERCENT,
     [SPELLS.WARLOCK_AFFLI_T20_4P_BUFF.id]: 0.15,
     [SPELLS.WARLOCK_DEMO_T20_4P_BUFF.id]: 0.1,
     [SPELLS.TRUESHOT.id]: 0.4, // MM Hunter main CD

--- a/src/Parser/Core/Modules/Haste.js
+++ b/src/Parser/Core/Modules/Haste.js
@@ -31,8 +31,8 @@ class Haste extends Module {
     [SPELLS.BERSERKING.id]: 0.15,
     [202842]: 0.1, // Rapid Innervation (Balance Druid trait increasing Haste from Innervate)
     [SPELLS.POWER_INFUSION_TALENT.id]: 0.25,
-    [240673]: 800 / this.HASTE_RATING_PER_PERCENT, // Shadow Priest artifact trait that's shared with 4 allies: http://www.wowhead.com/spell=240673/mind-quickening
-    [SPELLS.MARK_OF_THE_CLAW.id]: 1000 / this.HASTE_RATING_PER_PERCENT,
+    [240673]: 800 / 37500, // Shadow Priest artifact trait that's shared with 4 allies: http://www.wowhead.com/spell=240673/mind-quickening
+    [SPELLS.MARK_OF_THE_CLAW.id]: 1000 / 37500,
     [SPELLS.WARLOCK_AFFLI_T20_4P_BUFF.id]: 0.15,
     [SPELLS.WARLOCK_DEMO_T20_4P_BUFF.id]: 0.1,
     [SPELLS.TRUESHOT.id]: 0.4, // MM Hunter main CD

--- a/src/Parser/Core/Modules/Haste.js
+++ b/src/Parser/Core/Modules/Haste.js
@@ -33,6 +33,7 @@ class Haste extends Module {
     [SPELLS.POWER_INFUSION_TALENT.id]: 0.25,
     [240673]: 800 / 37500, // Shadow Priest artifact trait that's shared with 4 allies: http://www.wowhead.com/spell=240673/mind-quickening
     [SPELLS.WARLOCK_AFFLI_T20_4P_BUFF.id]: 0.15,
+    [SPELLS.WARLOCK_DEMO_T20_4P_BUFF.id]: 0.1,
     [SPELLS.TRUESHOT.id]: 0.4, // MM Hunter main CD
     [SPELLS.LINGERING_INSANITY.id]: 0.01,
     [SPELLS.VOIDFORM_BUFF.id]: 0.01,

--- a/src/Parser/Core/Modules/Haste.js
+++ b/src/Parser/Core/Modules/Haste.js
@@ -47,7 +47,7 @@ class Haste extends Module {
 
     [SPELLS.RISING_TIDES.id]: {
       itemId: ITEMS.CHARM_OF_THE_RISING_TIDE.id,
-      hastePerStack: (_, item) => calculateSecondaryStatDefault(900, 576, item.itemLevel) / this.HASTE_RATING_PER_PERCENT,
+      hastePerStack: (_, item) => calculateSecondaryStatDefault(900, 576, item.itemLevel) / 37500,
     },
   };
 

--- a/src/Parser/Core/Modules/Haste.js
+++ b/src/Parser/Core/Modules/Haste.js
@@ -32,6 +32,7 @@ class Haste extends Module {
     [202842]: 0.1, // Rapid Innervation (Balance Druid trait increasing Haste from Innervate)
     [SPELLS.POWER_INFUSION_TALENT.id]: 0.25,
     [240673]: 800 / 37500, // Shadow Priest artifact trait that's shared with 4 allies: http://www.wowhead.com/spell=240673/mind-quickening
+    [SPELLS.MARK_OF_THE_CLAW.id]: 1000 / 37500,
     [SPELLS.WARLOCK_AFFLI_T20_4P_BUFF.id]: 0.15,
     [SPELLS.WARLOCK_DEMO_T20_4P_BUFF.id]: 0.1,
     [SPELLS.TRUESHOT.id]: 0.4, // MM Hunter main CD

--- a/src/Parser/DemonologyWarlock/CHANGELOG.js
+++ b/src/Parser/DemonologyWarlock/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+29-09-2017 - Added T20 set bonuses. (by Chizu)
 25-09-2017 - Added rest of the talent modules - Hand of Doom, GoSac, GoSyn, Darkglare and Demonbolt. (by Chizu)
 23-09-2017 - Added second talent row modules - Impending Doom, Improved Dreadstalkers and Implosion. (by Chizu)
 19-09-2017 - Added first talent row modules - Shadowy Inspiration, Shadowflame and Demonic Calling. (by Chizu)

--- a/src/Parser/DemonologyWarlock/CombatLogParser.js
+++ b/src/Parser/DemonologyWarlock/CombatLogParser.js
@@ -37,6 +37,7 @@ import TheMasterHarvester from './Modules/Items/Legendaries/TheMasterHarvester';
 import SoulOfTheNetherlord from './Modules/Items/Legendaries/SoulOfTheNetherlord';
 
 import T20_2set from './Modules/Items/T20_2set';
+import T20_4set from './Modules/Items/T20_4set';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -77,6 +78,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Items
     t20_2set: T20_2set,
+    t20_4set: T20_4set,
   };
 
   generateResults() {

--- a/src/Parser/DemonologyWarlock/CombatLogParser.js
+++ b/src/Parser/DemonologyWarlock/CombatLogParser.js
@@ -36,6 +36,8 @@ import Demonbolt from './Modules/Talents/Demonbolt';
 import TheMasterHarvester from './Modules/Items/Legendaries/TheMasterHarvester';
 import SoulOfTheNetherlord from './Modules/Items/Legendaries/SoulOfTheNetherlord';
 
+import T20_2set from './Modules/Items/T20_2set';
+
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     // Features
@@ -74,6 +76,7 @@ class CombatLogParser extends CoreCombatLogParser {
     soulOfTheNetherlord: SoulOfTheNetherlord,
 
     // Items
+    t20_2set: T20_2set,
   };
 
   generateResults() {

--- a/src/Parser/DemonologyWarlock/Modules/Items/T20_2set.js
+++ b/src/Parser/DemonologyWarlock/Modules/Items/T20_2set.js
@@ -36,7 +36,7 @@ class T20_2set extends Module {
       id: `spell-${SPELLS.WARLOCK_DEMO_T20_2P_BONUS.id}`,
       icon: <SpellIcon id={SPELLS.WARLOCK_DEMO_T20_2P_BONUS.id} />,
       title: <SpellLink id={SPELLS.WARLOCK_DEMO_T20_2P_BONUS.id} />,
-      result: `${this.procs} resetted cooldowns on Call Dreadstalkers`,
+      result: <span>{this.procs} resets of <SpellLink id={SPELLS.CALL_DREADSTALKERS.id} /> cooldown.</span>,
     };
   }
 }

--- a/src/Parser/DemonologyWarlock/Modules/Items/T20_2set.js
+++ b/src/Parser/DemonologyWarlock/Modules/Items/T20_2set.js
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+
+const CALL_DREADSTALKERS_COOLDOWN = 15000;
+
+class T20_2set extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  _expectedCooldownEnd = null;
+  procs = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasBuff(SPELLS.WARLOCK_DEMO_T20_2P_BONUS.id);
+  }
+
+  on_byPlayer_cast(event) {
+    if (event.ability.guid !== SPELLS.CALL_DREADSTALKERS.id) {
+      return;
+    }
+    if (this._expectedCooldownEnd && event.timestamp < this._expectedCooldownEnd) {
+      this.procs += 1;
+    }
+    this._expectedCooldownEnd = event.timestamp + CALL_DREADSTALKERS_COOLDOWN;
+  }
+
+  item() {
+    return {
+      id: `spell-${SPELLS.WARLOCK_DEMO_T20_2P_BONUS.id}`,
+      icon: <SpellIcon id={SPELLS.WARLOCK_DEMO_T20_2P_BONUS.id} />,
+      title: <SpellLink id={SPELLS.WARLOCK_DEMO_T20_2P_BONUS.id} />,
+      result: `${this.procs} resetted cooldowns on Call Dreadstalkers`,
+    };
+  }
+}
+
+export default T20_2set;

--- a/src/Parser/DemonologyWarlock/Modules/Items/T20_4set.js
+++ b/src/Parser/DemonologyWarlock/Modules/Items/T20_4set.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import { formatPercentage } from 'common/format';
+
+class T20_4set extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasBuff(SPELLS.WARLOCK_DEMO_T20_4P_BONUS.id);
+  }
+
+  item() {
+    const uptime = this.combatants.selected.getBuffUptime(SPELLS.WARLOCK_DEMO_T20_4P_BUFF.id) / this.owner.fightDuration;
+    return {
+      id: `spell-${SPELLS.WARLOCK_DEMO_T20_4P_BONUS.id}`,
+      icon: <SpellIcon id={SPELLS.WARLOCK_DEMO_T20_4P_BONUS.id} />,
+      title: <SpellLink id={SPELLS.WARLOCK_DEMO_T20_4P_BONUS.id} />,
+      result: <span>{formatPercentage(uptime)} % uptime on <SpellLink id={SPELLS.WARLOCK_DEMO_T20_4P_BUFF.id}/>.</span>,
+    };
+  }
+}
+
+export default T20_4set;

--- a/src/common/SPELLS_OTHERS.js
+++ b/src/common/SPELLS_OTHERS.js
@@ -75,6 +75,11 @@ export default {
     name: 'Ancient Rejuvenation Potion',
     icon: 'inv_alchemy_70_purple',
   },
+  MARK_OF_THE_CLAW: {
+    id: 190909,
+    name: 'Mark of the Claw',
+    icon: 'classicon_druid',
+  },
   // Items buffs:
   JACINS_RUSE: {
     id: 224149,

--- a/src/common/SPELLS_WARLOCK.js
+++ b/src/common/SPELLS_WARLOCK.js
@@ -688,4 +688,9 @@ export default {
     name: 'Demonology Warlock T19 4P Bonus',
     icon: 'inv_helm_cloth_raidwarlock_q_01',
   },
+  WARLOCK_DEMO_T20_4P_BUFF: {
+    id: 246962,
+    name: 'Dreaded Haste',
+    icon: 'spell_shadow_metamorphosis',
+  },
 };

--- a/src/common/SPELLS_WARLOCK.js
+++ b/src/common/SPELLS_WARLOCK.js
@@ -688,6 +688,11 @@ export default {
     name: 'Demonology Warlock T19 4P Bonus',
     icon: 'inv_helm_cloth_raidwarlock_q_01',
   },
+  WARLOCK_DEMO_T20_2P_BONUS: {
+    id: 242293,
+    name: 'Demonology Warlock T20 2P bonus',
+    icon: 'inv_helm_cloth_raidwarlock_r_01',
+  },
   WARLOCK_DEMO_T20_4P_BUFF: {
     id: 246962,
     name: 'Dreaded Haste',

--- a/src/common/SPELLS_WARLOCK.js
+++ b/src/common/SPELLS_WARLOCK.js
@@ -693,6 +693,11 @@ export default {
     name: 'Demonology Warlock T20 2P bonus',
     icon: 'inv_helm_cloth_raidwarlock_r_01',
   },
+  WARLOCK_DEMO_T20_4P_BONUS: {
+    id: 242294,
+    name: 'Demonology Warlock T20 4P bonus',
+    icon: 'inv_chest_cloth_raidwarlock_r_01',
+  },
   WARLOCK_DEMO_T20_4P_BUFF: {
     id: 246962,
     name: 'Dreaded Haste',


### PR DESCRIPTION
Keeping it small. I wanted to add the ability to somewhat count the correct number of possible Call Dreadstalkers since the T20 2pc resets the cooldown, but that proved to be difficult to say the least. I tried doing `fightDuration / baseCD + numberOfResets` but that's kinda fundamentally wrong, since each time you reset the CD, it alters the timestamps at which the cooldowns would be "normally" ready.

In conclusion - no clue how to deal with ability resets, I left it uncorrected with base cooldown of 15 seconds. Also, if you haven't heard on Discord, Dead time for Demo is still severely broken and I've got precisely 0 clue why. Any help appreciated O:)