### PR TITLE
[Enhancement] Alpha Wolf usage check

### DIFF
--- a/src/Parser/EnhancementShaman/CHANGELOG.js
+++ b/src/Parser/EnhancementShaman/CHANGELOG.js
@@ -1,5 +1,6 @@
 export default `
-16-09-2017 - Add early Flametongue refresh (Pandemic)
+28-09-2017 - Alpha Wolf issue tracking to verify Crash Lightning cast after Feral Spirits
+16-09-2017 - Add early Flametongue refresh detection
 04-09-2017 - Tweak Cast Efficiency for utility spells (hide when not used, don't suggest improvement)
 29-08-2017 - All suggestions percentages updated to corrected values. Add Rockbiter Maelstrom wastage. Disable Master/Haste stat listing for now.
 27-08-2017 - Add Tier 20 2pc uptime, include Feral Spirits in damage done, fixed Cooldown tracking for Ascendance, and update Mastery/Haste stat display

--- a/src/Parser/EnhancementShaman/CombatLogParser.js
+++ b/src/Parser/EnhancementShaman/CombatLogParser.js
@@ -15,6 +15,7 @@ import Maelstrom from './Modules/Main/Maelstrom';
 import CooldownTracker from './Modules/Features/CooldownTracker';
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
 // import ShamanStats from './Modules/ShamanCore/ShamanStats';
+import AlphaWolf from './Modules/ShamanCore/AlphaWolf';
 import Flametongue from './Modules/ShamanCore/Flametongue';
 import FlametongueRefresh from './Modules/ShamanCore/FlametongueRefresh';
 import Landslide from './Modules/ShamanCore/Landslide';
@@ -37,6 +38,7 @@ class CombatLogParser extends CoreCombatLogParser {
     furyOfAir: FuryOfAir,
     rockbiter: Rockbiter,
     flametongueRefresh: FlametongueRefresh,
+    alphaWolf: AlphaWolf,
     // Features
     alwaysBeCasting: AlwaysBeCasting,
     castEfficiency: CastEfficiency,

--- a/src/Parser/EnhancementShaman/Modules/ShamanCore/AlphaWolf.js
+++ b/src/Parser/EnhancementShaman/Modules/ShamanCore/AlphaWolf.js
@@ -1,0 +1,41 @@
+import SPELLS from 'common/SPELLS';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import Module from 'Parser/Core/Module';
+
+class AlphaWolf extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  }
+
+  feralSpiritCastCount = 0;
+  feralSpiritCastFlag = false;
+  missedAlphaWolfCount = 0;
+
+  on_byPlayer_cast(event) {
+    if(this.feralSpiritCastFlag) {
+      if(event.ability.guid !== SPELLS.CRASH_LIGHTNING.id) {
+        this.missedAlphaWolfCount += 1;
+      }
+      this.feralSpiritCastFlag = false;
+    }
+
+    if(event.ability.guid === SPELLS.FERAL_SPIRIT.id) {
+      this.feralSpiritCastFlag = true;
+      this.feralSpiritCastCount += 1;
+    }
+  }
+
+  suggestions(when) {
+    when(this.missedAlphaWolfCount).isGreaterThan(0)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest('Make sure Crash Lightning is always cast directly after Feral Spirits to activate Alpha Wolf, even on single target')
+          .icon(SPELLS.ALPHA_WOLF_TRAIT.icon)
+          .actual(`${actual} out of ${this.feralSpiritCastCount} missed priority casts`)
+          .recommended(`${recommended} recommended`)
+          .regular(recommended).major(recommended);
+      });
+  }
+}
+
+export default AlphaWolf;

--- a/src/common/SPELLS_SHAMAN.js
+++ b/src/common/SPELLS_SHAMAN.js
@@ -486,6 +486,12 @@ export default {
     name: 'T20 2 set bonus',
     icon: 'spell_shaman_improvedstormstrike',
   },
+  //Enhancement Traits
+  ALPHA_WOLF_TRAIT: {
+    id: 198434,
+    name: 'Alpha Wolf',
+    icon: 'spell_beastmaster_wolf',
+  },
   // Restoration Shaman
   CHAIN_HEAL: {
     id: 1064,


### PR DESCRIPTION
Add detection for proper usage of Crash Lightning as priority spell directly after Feral Spirits used