### PR TITLE
[resto druid] Added spec info to CONFIG.js

### DIFF
--- a/src/Parser/RestoDruid/CONFIG.js
+++ b/src/Parser/RestoDruid/CONFIG.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import SPECS from 'common/SPECS';
 import SPEC_ANALYSIS_COMPLETENESS from 'common/SPEC_ANALYSIS_COMPLETENESS';
 
@@ -7,7 +9,16 @@ import CHANGELOG from './CHANGELOG';
 export default {
   spec: SPECS.RESTORATION_DRUID,
   maintainer: '@blazyb and @sref',
+  description: (
+    <div>
+      Welcome to the Resto Druid analyzer! We hope you find these suggestions and statistics useful.
+      <br /><br />
+
+      If you want to learn more about Resto Druids, join the Druid community at the <a href="https://discord.gg/dreamgrove" target="_blank" rel="noopener noreferrer">Dreamgrove discord channel</a>. Remember to check the pins (ctrl-P while in #resto channel) for guides, FAQs, and gearing guidelines.
+    </div>
+  ),
   completeness: SPEC_ANALYSIS_COMPLETENESS.GREAT, // When changing this please make a PR with ONLY this value changed, we will do a review of your analysis to find out of it is complete enough.
+  specDiscussionUrl: 'https://github.com/WoWAnalyzer/WoWAnalyzer/issues/55',
   changelog: CHANGELOG,
   parser: CombatLogParser,
   path: __dirname, // used for generating a GitHub link directly to your spec


### PR DESCRIPTION
Added simple spec info for Resto Druids. Included link to Discord, reminded them to press ctrl-P for pins  😛 

There isn't yet support for adding 2 maintainer avatars to same spec, so no avatar yet.