### PR TITLE
[Warlock] Refactors

### DIFF
--- a/src/Parser/AfflictionWarlock/Modules/Features/FatalEchoes.js
+++ b/src/Parser/AfflictionWarlock/Modules/Features/FatalEchoes.js
@@ -10,6 +10,7 @@ import { formatNumber } from 'common/format';
 import { UNSTABLE_AFFLICTION_DEBUFF_IDS } from '../../Constants';
 
 const UA_IDS_SET = new Set(UNSTABLE_AFFLICTION_DEBUFF_IDS);
+const TICKS_PER_UA = 4;
 
 class FatalEchoes extends Module {
   _playerCasts = 0;
@@ -39,7 +40,6 @@ class FatalEchoes extends Module {
   statistic() {
     const totalProcs = this._uasApplied - this._playerCasts;
     const avgDamage = this.totalDamage / (this._totalTicks > 0 ? this._totalTicks : 1);
-    const TICKS_PER_UA = 4;
     const estimatedUAdamage = totalProcs * TICKS_PER_UA * avgDamage;
     return (
       <StatisticBox

--- a/src/Parser/AfflictionWarlock/Modules/Features/UABuffTracker.js
+++ b/src/Parser/AfflictionWarlock/Modules/Features/UABuffTracker.js
@@ -72,7 +72,7 @@ class UABuffTracker extends Module {
   }
 
   suggestions(when) {
-    const unbuffedTicksPercentage = this.unbuffedTicks / this.totalTicks;
+    const unbuffedTicksPercentage = this.unbuffedTicks / (this.totalTicks > 0 ? this.totalTicks : 1);
     when(unbuffedTicksPercentage).isGreaterThan(0.15)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest('Your Unstable Afflictions could be buffed more. Unstable Affliction is your main source of damage so keeping it buffed as much as possible with Reap Souls, Drain Soul (if using the Malefic Grasp talent) or Haunt (if using the talent) is very important.')
@@ -84,7 +84,7 @@ class UABuffTracker extends Module {
   }
 
   statistic() {
-    const buffedTicksPercentage = 1 - (this.unbuffedTicks / this.totalTicks);
+    const buffedTicksPercentage = 1 - (this.unbuffedTicks / (this.totalTicks > 0 ? this.totalTicks : 1));
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.UNSTABLE_AFFLICTION_CAST.id} />}

--- a/src/Parser/AfflictionWarlock/Modules/Features/UABuffTracker.js
+++ b/src/Parser/AfflictionWarlock/Modules/Features/UABuffTracker.js
@@ -72,7 +72,7 @@ class UABuffTracker extends Module {
   }
 
   suggestions(when) {
-    const unbuffedTicksPercentage = this.unbuffedTicks / (this.totalTicks > 0 ? this.totalTicks : 1);
+    const unbuffedTicksPercentage = (this.unbuffedTicks / this.totalTicks ) || 1; // if no UAs were cast (totalTicks and unbuffedTicks = 0), it should return NaN and thus be 1 (100% unbuffed ticks)
     when(unbuffedTicksPercentage).isGreaterThan(0.15)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest('Your Unstable Afflictions could be buffed more. Unstable Affliction is your main source of damage so keeping it buffed as much as possible with Reap Souls, Drain Soul (if using the Malefic Grasp talent) or Haunt (if using the talent) is very important.')
@@ -84,7 +84,7 @@ class UABuffTracker extends Module {
   }
 
   statistic() {
-    const buffedTicksPercentage = 1 - (this.unbuffedTicks / (this.totalTicks > 0 ? this.totalTicks : 1));
+    const buffedTicksPercentage = 1 - ((this.unbuffedTicks / this.totalTicks) || 1); // if no UAs were cast the result should be 0% buffed ticks
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.UNSTABLE_AFFLICTION_CAST.id} />}

--- a/src/Parser/AfflictionWarlock/Modules/Items/Legendaries/PowerCordOfLethtendris.js
+++ b/src/Parser/AfflictionWarlock/Modules/Items/Legendaries/PowerCordOfLethtendris.js
@@ -41,9 +41,8 @@ class PowerCordOfLethtendris extends Module {
       item: ITEMS.POWER_CORD_OF_LETHTENDRIS,
       result: (
         <dfn data-tip={`${formatNumber(estimatedUAdamage)} damage - ${this.owner.formatItemDamageDone(estimatedUAdamage)} <br />This result is estimated by multiplying number of Soul Shards gained from this item by the average Unstable Affliction damage for the whole fight.`}>
-          {`${shardsGained} Soul Shards gained`}
+          {shardsGained} Soul Shards gained
         </dfn>
-
       ),
     };
   }

--- a/src/Parser/AfflictionWarlock/Modules/Items/Legendaries/SacrolashsDarkStrike.js
+++ b/src/Parser/AfflictionWarlock/Modules/Items/Legendaries/SacrolashsDarkStrike.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import Module from 'Parser/Core/Module';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
@@ -30,7 +32,11 @@ class SacrolashsDarkStrike extends Module {
   item() {
     return {
       item: ITEMS.SACROLASHS_DARK_STRIKE,
-      result: `${formatNumber(this.bonusDmg)} damage - ${this.owner.formatItemDamageDone(this.bonusDmg)}`,
+      result: (
+        <dfn data-tip={`Total bonus damage contributed: ${formatNumber(this.bonusDmg)}`}>
+          {this.owner.formatItemDamageDone(this.bonusDmg)}
+        </dfn>
+      ),
     };
   }
 }

--- a/src/Parser/AfflictionWarlock/Modules/Items/Legendaries/StretensSleeplessShackles.js
+++ b/src/Parser/AfflictionWarlock/Modules/Items/Legendaries/StretensSleeplessShackles.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import Module from 'Parser/Core/Module';
 import Enemies from 'Parser/Core/Modules/Enemies';
 import Combatants from 'Parser/Core/Modules/Combatants';
@@ -33,7 +35,11 @@ class StretensSleeplessShackles extends Module {
   item() {
     return {
       item: ITEMS.STRETENS_SLEEPLESS_SHACKLES,
-      result: `${formatNumber(this.bonusDmg)} damage - ${this.owner.formatItemDamageDone(this.bonusDmg)}`,
+      result: (
+        <dfn data-tip={`Total bonus damage contributed: ${formatNumber(this.bonusDmg)}`}>
+          {this.owner.formatItemDamageDone(this.bonusDmg)}
+        </dfn>
+      ),
     };
   }
 }

--- a/src/Parser/AfflictionWarlock/Modules/Items/Legendaries/TheMasterHarvester.js
+++ b/src/Parser/AfflictionWarlock/Modules/Items/Legendaries/TheMasterHarvester.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import Module from 'Parser/Core/Module';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
@@ -20,7 +22,11 @@ class TheMasterHarvester extends Module {
     const bonusDmg = this.soulHarvest.chestBonusDmg;
     return {
       item: ITEMS.THE_MASTER_HARVESTER,
-      result: `${formatNumber(bonusDmg)} damage contributed - ${this.owner.formatItemDamageDone(bonusDmg)}`,
+      result: (
+        <dfn data-tip={`Total bonus damage contributed: ${formatNumber(bonusDmg)}`}>
+          {this.owner.formatItemDamageDone(bonusDmg)}
+        </dfn>
+      ),
     };
   }
 }

--- a/src/Parser/AfflictionWarlock/Modules/Items/Tier20_2set.js
+++ b/src/Parser/AfflictionWarlock/Modules/Items/Tier20_2set.js
@@ -44,7 +44,7 @@ class Tier20_2set extends Module {
       title: <SpellLink id={SPELLS.WARLOCK_AFFLI_T20_2P_BONUS.id} />,
       result: (
         <dfn data-tip={`${formatNumber(estimatedUAdamage)} damage - ${this.owner.formatItemDamageDone(estimatedUAdamage)} <br />This result is estimated by multiplying number of Soul Shards gained from this item by the average Unstable Affliction damage for the whole fight.`}>
-          {`${shardsGained} Soul Shards gained`}
+          {shardsGained} Soul Shards gained
         </dfn>
       ),
     };

--- a/src/Parser/AfflictionWarlock/Modules/Items/Tier20_4set.js
+++ b/src/Parser/AfflictionWarlock/Modules/Items/Tier20_4set.js
@@ -6,38 +6,24 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import SpellIcon from 'common/SpellIcon';
-import { formatNumber } from 'common/format';
-
-import getDamageBonus from '../WarlockCore/getDamageBonus';
-
-const T20_4SET_HASTE_BONUS = 0.15;
+import { formatPercentage } from 'common/format';
 
 class Tier20_4set extends Module {
   static dependencies = {
     combatants: Combatants,
   };
-  bonusDmg = 0;
 
   on_initialized() {
     this.active = this.combatants.selected.hasBuff(SPELLS.WARLOCK_AFFLI_T20_4P_BONUS.id);
   }
 
-  on_byPlayer_damage(event) {
-    if (this.combatants.selected.hasBuff(SPELLS.WARLOCK_AFFLI_T20_4P_BUFF.id)) {
-      this.bonusDmg += getDamageBonus(event, T20_4SET_HASTE_BONUS);
-    }
-  }
-
   item() {
+    const uptime = this.combatants.selected.getBuffUptime(SPELLS.WARLOCK_AFFLI_T20_4P_BUFF.id) / this.owner.fightDuration;
     return {
       id: `spell-${SPELLS.WARLOCK_AFFLI_T20_4P_BONUS.id}`,
       icon: <SpellIcon id={SPELLS.WARLOCK_AFFLI_T20_4P_BONUS.id} />,
       title: <SpellLink id={SPELLS.WARLOCK_AFFLI_T20_4P_BONUS.id} />,
-      result: (
-        <dfn data-tip={`Estimated bonus damage contributed: ${formatNumber(this.bonusDmg)}.<br /><br />This result may be inaccurate as effect of haste buffs is difficult to calculate. This result is based on the premise that 15% haste allows you to do <code>(baseHaste * (100% + 15%) + 15%) - baseHaste</code> more things in the same amount of time, therefore the set bonus is estimated to be technically 15% damage increase for 8 seconds.`}>
-          {this.owner.formatItemDamageDone(this.bonusDmg)}
-        </dfn>
-      ),
+      result: <span>{formatPercentage(uptime)} % uptime on <SpellLink id={SPELLS.WARLOCK_AFFLI_T20_4P_BUFF.id}/>.</span>,
     };
   }
 }

--- a/src/Parser/AfflictionWarlock/Modules/Items/Tier20_4set.js
+++ b/src/Parser/AfflictionWarlock/Modules/Items/Tier20_4set.js
@@ -34,8 +34,8 @@ class Tier20_4set extends Module {
       icon: <SpellIcon id={SPELLS.WARLOCK_AFFLI_T20_4P_BONUS.id} />,
       title: <SpellLink id={SPELLS.WARLOCK_AFFLI_T20_4P_BONUS.id} />,
       result: (
-        <dfn data-tip={'This result may be inaccurate as effect of haste buffs is difficult to calculate. This result is based on the premise that 15% haste allows you to do <code>(baseHaste * (100% + 15%) + 15%) - baseHaste</code> more things in the same amount of time, therefore the set bonus is estimated to be technically 15% damage increase for 8 seconds.'}>
-          {`${formatNumber(this.bonusDmg)} damage - ${this.owner.formatItemDamageDone(this.bonusDmg)}`}
+        <dfn data-tip={`Estimated bonus damage contributed: ${formatNumber(this.bonusDmg)}.<br /><br />This result may be inaccurate as effect of haste buffs is difficult to calculate. This result is based on the premise that 15% haste allows you to do <code>(baseHaste * (100% + 15%) + 15%) - baseHaste</code> more things in the same amount of time, therefore the set bonus is estimated to be technically 15% damage increase for 8 seconds.`}>
+          {this.owner.formatItemDamageDone(this.bonusDmg)}
         </dfn>
       ),
     };

--- a/src/Parser/AfflictionWarlock/Modules/SoulShards/SoulShardDetails.js
+++ b/src/Parser/AfflictionWarlock/Modules/SoulShards/SoulShardDetails.js
@@ -11,6 +11,10 @@ import WastedShardsIcon from '../../Images/warlock_soulshard_bw.jpg';
 
 const soulShardIcon = 'inv_misc_gem_amethyst_02';
 
+const MINOR = 5 / 10; // 5 shards per 10 minutes
+const AVG = 5 / 3; // 5 shards per 3 minutes
+const MAJOR = 10 / 3; // 10 shards per 3 minutes
+
 class SoulShardDetails extends Module {
   static dependencies = {
     soulShardTracker: SoulShardTracker,
@@ -19,9 +23,6 @@ class SoulShardDetails extends Module {
   suggestions(when) {
     const shardsWasted = this.soulShardTracker.shardsWasted;
     const shardsWastedPerMinute = (shardsWasted / this.owner.fightDuration) * 1000 * 60;
-    const MINOR = 5 / 10; // 5 shards per 10 minutes
-    const AVG = 5 / 3; // 5 shards per 3 minutes
-    const MAJOR = 10 / 3; // 10 shards per 3 minutes
     when(shardsWastedPerMinute).isGreaterThan(MINOR)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest('You are wasting Soul Shards. Try to use them and not let them cap and go to waste unless you\'re preparing for bursting adds etc.')

--- a/src/Parser/AfflictionWarlock/Modules/Talents/EmpoweredLifeTap.js
+++ b/src/Parser/AfflictionWarlock/Modules/Talents/EmpoweredLifeTap.js
@@ -19,7 +19,6 @@ class EmpoweredLifeTap extends Module {
   };
 
   bonusDmg = 0;
-  uptime = 0;
 
   on_initialized() {
     this.active = this.combatants.selected.hasTalent(SPELLS.EMPOWERED_LIFE_TAP_TALENT.id);
@@ -31,12 +30,9 @@ class EmpoweredLifeTap extends Module {
     }
   }
 
-  on_finished() {
-    this.uptime = this.combatants.selected.getBuffUptime(SPELLS.EMPOWERED_LIFE_TAP_BUFF.id) / this.owner.fightDuration;
-  }
-
   suggestions(when) {
-    when(this.uptime).isLessThan(0.9)
+    const uptime = this.combatants.selected.getBuffUptime(SPELLS.EMPOWERED_LIFE_TAP_BUFF.id) / this.owner.fightDuration;
+    when(uptime).isLessThan(0.9)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>Your uptime on the <SpellLink id={SPELLS.EMPOWERED_LIFE_TAP_BUFF.id} /> buff could be improved. You should cast <SpellLink id={SPELLS.LIFE_TAP.id} /> more often.<br /><br /><small><em>NOTE:</em> If you're getting 0% uptime, it might be wrong if you used <SpellLink id={SPELLS.LIFE_TAP.id} /> before combat started and maintained the buff. Due to technical limitations it's not possible to track the bonus damage nor uptime in this case.</small></span>)
           .icon(SPELLS.EMPOWERED_LIFE_TAP_TALENT.icon)
@@ -47,10 +43,11 @@ class EmpoweredLifeTap extends Module {
   }
 
   statistic() {
+    const uptime = this.combatants.selected.getBuffUptime(SPELLS.EMPOWERED_LIFE_TAP_BUFF.id) / this.owner.fightDuration;
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.EMPOWERED_LIFE_TAP_TALENT.id} />}
-        value={`${formatPercentage(this.uptime)} %`}
+        value={`${formatPercentage(uptime)} %`}
         label="Empowered Life Tap uptime"
         tooltip={`Your Empowered Life Tap talent contributed ${formatNumber(this.bonusDmg)} total damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.bonusDmg))} %)`}
       />

--- a/src/Parser/AfflictionWarlock/Modules/Talents/SoulHarvest.js
+++ b/src/Parser/AfflictionWarlock/Modules/Talents/SoulHarvest.js
@@ -16,10 +16,9 @@ class SoulHarvest extends Module {
   talentBonusDmg = 0;
   chestBonusDmg = 0;
 
-  _petIds = new Set();
   _isFromTalent = false;
 
-  addToCorrectSource(bonusDmg) {
+  _addToCorrectSource(bonusDmg) {
     if (this._isFromTalent) {
       this.talentBonusDmg += bonusDmg;
     } else {
@@ -29,23 +28,17 @@ class SoulHarvest extends Module {
 
   on_initialized() {
     this.active = this.combatants.selected.hasTalent(SPELLS.SOUL_HARVEST_TALENT.id) || this.combatants.selected.hasChest(ITEMS.THE_MASTER_HARVESTER.id);
-    this.owner.playerPets.forEach((pet) => {
-      this._petIds.add(pet.id);
-    });
-  }
-
-  on_damage(event) {
-    if (!this._petIds.has(event.sourceID)) {
-      return;
-    }
-    if (this.combatants.selected.hasBuff(SPELLS.SOUL_HARVEST.id, event.timestamp)) {
-      this.addToCorrectSource(getDamageBonus(event, SOUL_HARVEST_DAMAGE_BONUS));
-    }
   }
 
   on_byPlayer_damage(event) {
     if (this.combatants.selected.hasBuff(SPELLS.SOUL_HARVEST.id, event.timestamp)) {
-      this.addToCorrectSource(getDamageBonus(event, SOUL_HARVEST_DAMAGE_BONUS));
+      this._addToCorrectSource(getDamageBonus(event, SOUL_HARVEST_DAMAGE_BONUS));
+    }
+  }
+
+  on_byPlayerPet_damage(event) {
+    if (this.combatants.selected.hasBuff(SPELLS.SOUL_HARVEST.id, event.timestamp)) {
+      this._addToCorrectSource(getDamageBonus(event, SOUL_HARVEST_DAMAGE_BONUS));
     }
   }
 

--- a/src/Parser/DemonologyWarlock/Modules/Features/DoomUptime.js
+++ b/src/Parser/DemonologyWarlock/Modules/Features/DoomUptime.js
@@ -15,8 +15,8 @@ class DoomUptime extends Module {
   };
 
   suggestions(when) {
-    const doomUptime = this.enemies.getBuffUptime(SPELLS.DOOM.id) / this.owner.fightDuration;
-    when(doomUptime).isLessThan(0.95)
+    const uptime = this.enemies.getBuffUptime(SPELLS.DOOM.id) / this.owner.fightDuration;
+    when(uptime).isLessThan(0.95)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>Your <SpellLink id={SPELLS.DOOM.id}/> uptime can be improved. Try to pay more attention to your Doom on the boss, as it is one of your Soul Shard generators.</span>)
           .icon(SPELLS.DOOM.icon)
@@ -27,11 +27,11 @@ class DoomUptime extends Module {
   }
 
   statistic() {
-    const doomUptime = this.enemies.getBuffUptime(SPELLS.DOOM.id) / this.owner.fightDuration;
+    const uptime = this.enemies.getBuffUptime(SPELLS.DOOM.id) / this.owner.fightDuration;
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.DOOM.id} />}
-        value={`${formatPercentage(doomUptime)} %`}
+        value={`${formatPercentage(uptime)} %`}
         label="Doom uptime"
       />
     );

--- a/src/Parser/DemonologyWarlock/Modules/Items/Legendaries/TheMasterHarvester.js
+++ b/src/Parser/DemonologyWarlock/Modules/Items/Legendaries/TheMasterHarvester.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import Module from 'Parser/Core/Module';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
@@ -20,7 +22,11 @@ class TheMasterHarvester extends Module {
     const bonusDmg = this.soulHarvest.chestBonusDmg;
     return {
       item: ITEMS.THE_MASTER_HARVESTER,
-      result: `${formatNumber(bonusDmg)} damage contributed - ${this.owner.formatItemDamageDone(bonusDmg)}`,
+      result: (
+        <dfn data-tip={`Total bonus damage contributed: ${formatNumber(bonusDmg)}`}>
+          {this.owner.formatItemDamageDone(bonusDmg)}
+        </dfn>
+      ),
     };
   }
 }

--- a/src/Parser/DemonologyWarlock/Modules/SoulShards/SoulShardDetails.js
+++ b/src/Parser/DemonologyWarlock/Modules/SoulShards/SoulShardDetails.js
@@ -11,6 +11,10 @@ import WastedShardsIcon from '../../Images/warlock_soulshard_bw.jpg';
 
 const soulShardIcon = 'inv_misc_gem_amethyst_02';
 
+const MINOR = 5 / 10; // 5 shards per 10 minutes
+const AVG = 5 / 3; // 5 shards per 3 minutes
+const MAJOR = 10 / 3; // 10 shards per 3 minutes
+
 class SoulShardDetails extends Module {
   static dependencies = {
     soulShardTracker: SoulShardTracker,
@@ -19,9 +23,6 @@ class SoulShardDetails extends Module {
   suggestions(when) {
     const shardsWasted = this.soulShardTracker.shardsWasted;
     const shardsWastedPerMinute = (shardsWasted / this.owner.fightDuration) * 1000 * 60;
-    const MINOR = 5 / 10; // 5 shards per 10 minutes
-    const AVG = 5 / 3; // 5 shards per 3 minutes
-    const MAJOR = 10 / 3; // 10 shards per 3 minutes
     when(shardsWastedPerMinute).isGreaterThan(MINOR)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest('You are wasting Soul Shards. Try to use them and not let them cap and go to waste unless you\'re preparing for bursting adds etc.')

--- a/src/Parser/DemonologyWarlock/Modules/Talents/Demonbolt.js
+++ b/src/Parser/DemonologyWarlock/Modules/Talents/Demonbolt.js
@@ -33,6 +33,7 @@ class Demonbolt extends Module {
     const bonusMultiplier = DEMONBOLT_DAMAGE_BONUS_PER_PET * this.demoPets.getPets(event.timestamp).length;
     this.bonusDmg += getDamageBonus(event, bonusMultiplier);
   }
+
   statistic() {
     return (
       <StatisticBox

--- a/src/Parser/DemonologyWarlock/Modules/Talents/SoulHarvest.js
+++ b/src/Parser/DemonologyWarlock/Modules/Talents/SoulHarvest.js
@@ -16,10 +16,9 @@ class SoulHarvest extends Module {
   talentBonusDmg = 0;
   chestBonusDmg = 0;
 
-  _petIds = new Set();
   _isFromTalent = false;
 
-  addToCorrectSource(bonusDmg) {
+  _addToCorrectSource(bonusDmg) {
     if (this._isFromTalent) {
       this.talentBonusDmg += bonusDmg;
     } else {
@@ -29,23 +28,17 @@ class SoulHarvest extends Module {
 
   on_initialized() {
     this.active = this.combatants.selected.hasTalent(SPELLS.SOUL_HARVEST_TALENT.id) || this.combatants.selected.hasChest(ITEMS.THE_MASTER_HARVESTER.id);
-    this.owner.playerPets.forEach((pet) => {
-      this._petIds.add(pet.id);
-    });
-  }
-
-  on_damage(event) {
-    if (!this._petIds.has(event.sourceID)) {
-      return;
-    }
-    if (this.combatants.selected.hasBuff(SPELLS.SOUL_HARVEST.id, event.timestamp)) {
-      this.addToCorrectSource(getDamageBonus(event, SOUL_HARVEST_DAMAGE_BONUS));
-    }
   }
 
   on_byPlayer_damage(event) {
     if (this.combatants.selected.hasBuff(SPELLS.SOUL_HARVEST.id, event.timestamp)) {
-      this.addToCorrectSource(getDamageBonus(event, SOUL_HARVEST_DAMAGE_BONUS));
+      this._addToCorrectSource(getDamageBonus(event, SOUL_HARVEST_DAMAGE_BONUS));
+    }
+  }
+
+  on_byPlayerPet_damage(event) {
+    if (this.combatants.selected.hasBuff(SPELLS.SOUL_HARVEST.id, event.timestamp)) {
+      this._addToCorrectSource(getDamageBonus(event, SOUL_HARVEST_DAMAGE_BONUS));
     }
   }
 

--- a/src/Parser/DestructionWarlock/Modules/Features/ImmolateUptime.js
+++ b/src/Parser/DestructionWarlock/Modules/Features/ImmolateUptime.js
@@ -14,14 +14,9 @@ class ImmolateUptime extends Module {
     enemies: Enemies,
   };
 
-  immolateUptime = 0;
-
-  on_finished() {
-    this.immolateUptime = this.enemies.getBuffUptime(SPELLS.IMMOLATE_DEBUFF.id) / this.owner.fightDuration;
-  }
-
   suggestions(when) {
-    when(this.immolateUptime).isLessThan(0.9)
+    const uptime = this.enemies.getBuffUptime(SPELLS.IMMOLATE_DEBUFF.id) / this.owner.fightDuration;
+    when(uptime).isLessThan(0.9)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>Your <SpellLink id={SPELLS.IMMOLATE_DEBUFF.id} /> uptime can be improved. Try to pay more attention to it as it provides a significant amount of Soul Shard Fragments over the fight and is also a big portion of your total damage.</span>)
           .icon(SPELLS.IMMOLATE_DEBUFF.icon)
@@ -32,10 +27,11 @@ class ImmolateUptime extends Module {
   }
 
   statistic() {
+    const uptime = this.enemies.getBuffUptime(SPELLS.IMMOLATE_DEBUFF.id) / this.owner.fightDuration;
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.IMMOLATE_DEBUFF.id} />}
-        value={`${formatPercentage(this.immolateUptime)} %`}
+        value={`${formatPercentage(uptime)} %`}
         label="Immolate uptime"
       />
     );

--- a/src/Parser/DestructionWarlock/Modules/Items/Legendaries/AlythesssPyrogenics.js
+++ b/src/Parser/DestructionWarlock/Modules/Items/Legendaries/AlythesssPyrogenics.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import Module from 'Parser/Core/Module';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import Enemies from 'Parser/Core/Modules/Enemies';
@@ -41,7 +43,11 @@ class AlythesssPyrogenics extends Module {
   item() {
     return {
       item: ITEMS.ALYTHESSS_PYROGENICS,
-      result: `${formatNumber(this.bonusDmg)} damage contributed - ${this.owner.formatItemDamageDone(this.bonusDmg)}`,
+      result: (
+        <dfn data-tip={`Total bonus damage contributed: ${formatNumber(this.bonusDmg)}`}>
+          {this.owner.formatItemDamageDone(this.bonusDmg)}
+        </dfn>
+      ),
     };
   }
 }

--- a/src/Parser/DestructionWarlock/Modules/Items/Legendaries/FeretoryOfSouls.js
+++ b/src/Parser/DestructionWarlock/Modules/Items/Legendaries/FeretoryOfSouls.js
@@ -39,8 +39,8 @@ class FeretoryOfSouls extends Module {
     return {
       item: ITEMS.FERETORY_OF_SOULS,
       result: (
-        <dfn data-tip={`${formatNumber(estimatedChaosBoltDamage)} damage - ${this.owner.formatItemDamageDone(estimatedChaosBoltDamage)} <br />This result is estimated by multiplying number of Soul Shard Fragments gained from this item, divided by 20 and floored down (because Chaos Bolt consumes 20 Soul Shard Fragments) by the average Chaos Bolt damage for the whole fight.`}>
-          {`${fragmentsGained} Soul Shard Fragments gained`}
+        <dfn data-tip={`Estimated bonus damage - ${formatNumber(estimatedChaosBoltDamage)} damage - ${this.owner.formatItemDamageDone(estimatedChaosBoltDamage)} <br />This result is estimated by multiplying number of Soul Shard Fragments gained from this item, divided by 20 and floored down (because Chaos Bolt consumes 20 Soul Shard Fragments) by the average Chaos Bolt damage for the whole fight.`}>
+          {fragmentsGained} Soul Shard Fragments gained
         </dfn>
       ),
     };

--- a/src/Parser/DestructionWarlock/Modules/Items/Legendaries/LessonsOfSpaceTime.js
+++ b/src/Parser/DestructionWarlock/Modules/Items/Legendaries/LessonsOfSpaceTime.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import Module from 'Parser/Core/Module';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
@@ -13,24 +14,10 @@ class LessonsOfSpaceTime extends Module {
     combatants: Combatants,
   };
 
-  _petIds = new Set();
-
   bonusDmg = 0;
 
   on_initialized() {
     this.active = this.combatants.selected.hasShoulder(ITEMS.LESSONS_OF_SPACETIME.id);
-    this.owner.playerPets.forEach((pet) => {
-      this._petIds.add(pet.id);
-    });
-  }
-
-  on_damage(event) {
-    if (!this._petIds.has(event.sourceID)) {
-      return;
-    }
-    if (this.combatants.selected.hasBuff(SPELLS.LESSONS_OF_SPACETIME_BUFF.id, event.timestamp)) {
-      this.bonusDmg += getDamageBonus(event, LESSONS_OF_SPACETIME_DAMAGE_BONUS);
-    }
   }
 
   on_byPlayer_damage(event) {
@@ -39,10 +26,20 @@ class LessonsOfSpaceTime extends Module {
     }
   }
 
+  on_byPlayerPet_damage(event) {
+    if (this.combatants.selected.hasBuff(SPELLS.LESSONS_OF_SPACETIME_BUFF.id, event.timestamp)) {
+      this.bonusDmg += getDamageBonus(event, LESSONS_OF_SPACETIME_DAMAGE_BONUS);
+    }
+  }
+
   item() {
     return {
       item: ITEMS.LESSONS_OF_SPACETIME,
-      result: `${formatNumber(this.bonusDmg)} damage contributed - ${this.owner.formatItemDamageDone(this.bonusDmg)}`,
+      result: (
+        <dfn data-tip={`Total bonus damage contributed: ${formatNumber(this.bonusDmg)}`}>
+          {this.owner.formatItemDamageDone(this.bonusDmg)}
+        </dfn>
+      ),
     };
   }
 }

--- a/src/Parser/DestructionWarlock/Modules/Items/Legendaries/MagistrikeRestraints.js
+++ b/src/Parser/DestructionWarlock/Modules/Items/Legendaries/MagistrikeRestraints.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import Module from 'Parser/Core/Module';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
@@ -24,7 +25,11 @@ class MagistrikeRestraints extends Module {
   item() {
     return {
       item: ITEMS.MAGISTRIKE_RESTRAINTS,
-      result: `${formatNumber(this.bonusDmg)} damage contributed - ${this.owner.formatItemDamageDone(this.bonusDmg)}`,
+      result: (
+        <dfn data-tip={`Total bonus damage contributed: ${formatNumber(this.bonusDmg)}`}>
+          {this.owner.formatItemDamageDone(this.bonusDmg)}
+        </dfn>
+      ),
     };
   }
 }

--- a/src/Parser/DestructionWarlock/Modules/Items/Legendaries/OdrShawlOfTheYmirjar.js
+++ b/src/Parser/DestructionWarlock/Modules/Items/Legendaries/OdrShawlOfTheYmirjar.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import Module from 'Parser/Core/Module';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import Enemies from 'Parser/Core/Modules/Enemies';
@@ -49,7 +50,11 @@ class OdrShawlOfTheYmirjar extends Module {
   item() {
     return {
       item: ITEMS.ODR_SHAWL_OF_THE_YMIRJAR,
-      result: `${formatNumber(this.bonusDmg)} damage contributed - ${this.owner.formatItemDamageDone(this.bonusDmg)}`,
+      result: (
+        <dfn data-tip={`Total bonus damage contributed: ${formatNumber(this.bonusDmg)}`}>
+          {this.owner.formatItemDamageDone(this.bonusDmg)}
+        </dfn>
+      ),
     };
   }
 }

--- a/src/Parser/DestructionWarlock/Modules/Items/Legendaries/TheMasterHarvester.js
+++ b/src/Parser/DestructionWarlock/Modules/Items/Legendaries/TheMasterHarvester.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import Module from 'Parser/Core/Module';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import ITEMS from 'common/ITEMS';
@@ -19,7 +21,11 @@ class TheMasterHarvester extends Module {
     const bonusDmg = this.soulHarvest.chestBonusDmg;
     return {
       item: ITEMS.THE_MASTER_HARVESTER,
-      result: `${formatNumber(bonusDmg)} damage contributed - ${this.owner.formatItemDamageDone(bonusDmg)}`,
+      result: (
+        <dfn data-tip={`Total bonus damage contributed: ${formatNumber(bonusDmg)}`}>
+          {this.owner.formatItemDamageDone(bonusDmg)}
+        </dfn>
+      ),
     };
   }
 }

--- a/src/Parser/DestructionWarlock/Modules/Items/T20_2set.js
+++ b/src/Parser/DestructionWarlock/Modules/Items/T20_2set.js
@@ -51,8 +51,8 @@ class T20_2set extends Module {
       icon: <SpellIcon id={SPELLS.WARLOCK_DESTRO_T20_2P_BONUS.id} />,
       title: <SpellLink id={SPELLS.WARLOCK_DESTRO_T20_2P_BONUS.id} />,
       result: (
-        <dfn data-tip={`${formatNumber(estimatedChaosBoltDamage)} damage - ${this.owner.formatItemDamageDone(estimatedChaosBoltDamage)} <br />This result is estimated by multiplying number of Soul Shard Fragments gained from this bonus, divided by 20 and floored down (because Chaos Bolt consumes 20 Soul Shard Fragments) by the average Chaos Bolt damage for the whole fight.`}>
-          {`${this._bonusFragments} Soul Shard Fragments gained`}
+        <dfn data-tip={`Estimated bonus damage - ${formatNumber(estimatedChaosBoltDamage)} damage - ${this.owner.formatItemDamageDone(estimatedChaosBoltDamage)} <br />This result is estimated by multiplying number of Soul Shard Fragments gained from this bonus, divided by 20 and floored down (because Chaos Bolt consumes 20 Soul Shard Fragments) by the average Chaos Bolt damage for the whole fight.`}>
+          {this._bonusFragments} Soul Shard Fragments gained
         </dfn>
       ),
     };

--- a/src/Parser/DestructionWarlock/Modules/SoulShards/SoulShardDetails.js
+++ b/src/Parser/DestructionWarlock/Modules/SoulShards/SoulShardDetails.js
@@ -11,6 +11,10 @@ import WastedShardsIcon from '../../Images/warlock_soulshard_bw.jpg';
 
 const soulShardIcon = 'inv_misc_gem_amethyst_02';
 
+const MINOR = 1; // 1 shard per 10 minutes
+const AVG = 3; // 3 shards per 10 minutes
+const MAJOR = 5; // 5 shards per 10 minutes
+
 class SoulShardDetails extends Module {
   static dependencies = {
     soulShardTracker: SoulShardTracker,
@@ -20,9 +24,6 @@ class SoulShardDetails extends Module {
     const fragmentsWasted = this.soulShardTracker.fragmentsWasted;
     const fragmentsWastedPerMinute = (fragmentsWasted / this.owner.fightDuration) * 1000 * 60;
     // Shards wasted for Destro are much more strict because the shard generation in Destro is much more reliant and less random, so there should be almost no wasted shards (if so, it's your own fault, not RNG)
-    const MINOR = 1; // 1 shard per 10 minutes
-    const AVG = 3; // 3 shards per 10 minutes
-    const MAJOR = 5; // 5 shards per 10 minutes
     when(fragmentsWastedPerMinute).isGreaterThan(MINOR)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest('You are wasting Soul Shards. Try to use them and not let them cap and go to waste unless you\'re preparing for bursting adds etc.')

--- a/src/Parser/DestructionWarlock/Modules/Talents/EmpoweredLifeTap.js
+++ b/src/Parser/DestructionWarlock/Modules/Talents/EmpoweredLifeTap.js
@@ -19,7 +19,6 @@ class EmpoweredLifeTap extends Module {
   };
 
   bonusDmg = 0;
-  uptime = 0;
 
   on_initialized() {
     this.active = this.combatants.selected.hasTalent(SPELLS.EMPOWERED_LIFE_TAP_TALENT.id);
@@ -31,12 +30,9 @@ class EmpoweredLifeTap extends Module {
     }
   }
 
-  on_finished() {
-    this.uptime = this.combatants.selected.getBuffUptime(SPELLS.EMPOWERED_LIFE_TAP_BUFF.id) / this.owner.fightDuration;
-  }
-
   suggestions(when) {
-    when(this.uptime).isLessThan(0.9)
+    const uptime = this.combatants.selected.getBuffUptime(SPELLS.EMPOWERED_LIFE_TAP_BUFF.id) / this.owner.fightDuration;
+    when(uptime).isLessThan(0.9)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>Your uptime on the <SpellLink id={SPELLS.EMPOWERED_LIFE_TAP_BUFF.id} /> buff could be improved. You should cast <SpellLink id={SPELLS.LIFE_TAP.id} /> more often.<br /><br /><small><em>NOTE:</em> If you're getting 0% uptime, it might be wrong if you used <SpellLink id={SPELLS.LIFE_TAP.id} /> before combat started and maintained the buff. Due to technical limitations it's not possible to track the bonus damage nor uptime in this case.</small></span>)
           .icon(SPELLS.EMPOWERED_LIFE_TAP_TALENT.icon)
@@ -47,10 +43,11 @@ class EmpoweredLifeTap extends Module {
   }
 
   statistic() {
+    const uptime = this.combatants.selected.getBuffUptime(SPELLS.EMPOWERED_LIFE_TAP_BUFF.id) / this.owner.fightDuration;
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.EMPOWERED_LIFE_TAP_TALENT.id} />}
-        value={`${formatPercentage(this.uptime)} %`}
+        value={`${formatPercentage(uptime)} %`}
         label="Empowered Life Tap uptime"
         tooltip={`Your Empowered Life Tap talent contributed ${formatNumber(this.bonusDmg)} total damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.bonusDmg))} %)`}
       />

--- a/src/Parser/DestructionWarlock/Modules/Talents/FireAndBrimstone.js
+++ b/src/Parser/DestructionWarlock/Modules/Talents/FireAndBrimstone.js
@@ -10,12 +10,6 @@ import SPELLS from 'common/SPELLS';
 
 import SoulShardEvents from '../SoulShards/SoulShardEvents';
 
-const debug = false;
-
-// estimated maximum time in ms between each Incinerate damage event to count as from one cast
-// the talent makes Incinerate cleave into all surrounding targets, so it makes sense that the Incinerates arrive at approximately same time, this is the tolerance for the "approximately"
-const CLEAVE_THRESHOLD = 50;
-
 class FireAndBrimstone extends Module {
   static dependencies = {
     combatants: Combatants,
@@ -23,9 +17,6 @@ class FireAndBrimstone extends Module {
   };
 
   _primaryTargets = [];
-  _lastIncinerate = 0;
-  _lastIncinerateIndex = 0;
-  _groupedTargets = [];
 
   generatedCleaveFragments = 0;
   bonusDmg = 0;
@@ -49,67 +40,16 @@ class FireAndBrimstone extends Module {
     if (event.ability.guid !== SPELLS.INCINERATE.id) {
       return;
     }
-    const incinerateEvent = {
-      timestamp: event.timestamp,
-      targetID: event.targetID,
-      targetInstance: event.targetInstance,
-      fragments: event.amount,  // only the real generated, don't care about the wasted fragments
-      damage: event.damage,
-    };
-    // first incinerate
-    if (this._lastIncinerate === 0) {
-      this._lastIncinerate = event.timestamp;
-      // index stays at 0
-      this._groupedTargets.push(
-        [
-          incinerateEvent,
-        ]
-      );
-    } else {
-      // another Incinerate landed on target within 50ms of a previous one, add to the same group, also probably don't overwrite the timestamp?
-      if (event.timestamp < this._lastIncinerate + CLEAVE_THRESHOLD) {
-        this._groupedTargets[this._lastIncinerateIndex].push(incinerateEvent);
-      } else {
-        // start another group
-        this._lastIncinerate = event.timestamp;
-        this._groupedTargets.push(
-          [
-            incinerateEvent,
-          ]
-        );
-        this._lastIncinerateIndex += 1;
-      }
+    // should find FIRST (oldest) Incinerate cast, so even though you can fire multiple Incinerates before the first hits, this should pair the events correctly even if they have the same ID and instance
+    const primaryTargetEventIndex = this._primaryTargets.findIndex(primary => primary.targetID === event.targetID && primary.targetInstance === event.targetInstance);
+    if (primaryTargetEventIndex !== -1) {
+      // it's a Incinerate damage on primary target, delete the event so it doesn't interfere with another casts
+      this._primaryTargets.splice(primaryTargetEventIndex, 1);
+      return;
     }
-  }
-
-  on_finished() {
-    debug && console.log('primary targets', this._primaryTargets);
-    debug && console.log('all targets', this._allTargets);
-    debug && console.log('grouped targets', this._groupedTargets);
-
-    // remove the primary targets, should be left with the cleaved targets
-    this._primaryTargets.forEach((event, index) => {
-      if (!this._groupedTargets[index]) {
-        // can happen if _primaryTargets is larger than _groupedTargets, not sure why
-        return;
-      }
-      // look into the same index in _groupedTargets, find an event with the same target ID and instance and delete it
-      const primaryTargetIndex = this._groupedTargets[index].findIndex(groupedEvent => groupedEvent.targetID === event.targetID && groupedEvent.targetInstance === event.targetInstance);
-      if (primaryTargetIndex === -1) {
-        // shouldn't happen that it doesn't exists, but if yes
-        return;
-      }
-      this._groupedTargets[index].splice(primaryTargetIndex, 1);
-    });
-
-    this._groupedTargets.forEach((group) => {
-      if (group.length > 0) {
-        group.forEach((event) => {
-          this.generatedCleaveFragments += event.fragments;
-          this.bonusDmg += event.damage;
-        });
-      }
-    });
+    // should be cleaved damage
+    this.generatedCleaveFragments += event.amount;
+    this.bonusDmg += event.damage;
   }
 
   statistic() {

--- a/src/Parser/DestructionWarlock/Modules/Talents/ReverseEntropy.js
+++ b/src/Parser/DestructionWarlock/Modules/Talents/ReverseEntropy.js
@@ -29,6 +29,7 @@ class ReverseEntropy extends Module {
     }
     this.bonusDmg += getDamageBonus(event, REVERSE_ENTROPY_DAMAGE_BONUS);
   }
+
   statistic() {
     // could show mana returned too, but that's kinda irrelevant for Warlocks anyway
     return (

--- a/src/Parser/DestructionWarlock/Modules/Talents/SoulHarvest.js
+++ b/src/Parser/DestructionWarlock/Modules/Talents/SoulHarvest.js
@@ -15,10 +15,9 @@ class SoulHarvest extends Module {
   talentBonusDmg = 0;
   chestBonusDmg = 0;
 
-  _petIds = new Set();
   _isFromTalent = false;
 
-  addToCorrectSource(bonusDmg) {
+  _addToCorrectSource(bonusDmg) {
     if (this._isFromTalent) {
       this.talentBonusDmg += bonusDmg;
     } else {
@@ -28,23 +27,17 @@ class SoulHarvest extends Module {
 
   on_initialized() {
     this.active = this.combatants.selected.hasTalent(SPELLS.SOUL_HARVEST_TALENT.id) || this.combatants.selected.hasChest(ITEMS.THE_MASTER_HARVESTER.id);
-    this.owner.playerPets.forEach((pet) => {
-      this._petIds.add(pet.id);
-    });
-  }
-
-  on_damage(event) {
-    if (!this._petIds.has(event.sourceID)) {
-      return;
-    }
-    if (this.combatants.selected.hasBuff(SPELLS.SOUL_HARVEST.id, event.timestamp)) {
-      this.addToCorrectSource(getDamageBonus(event, SOUL_HARVEST_DAMAGE_BONUS));
-    }
   }
 
   on_byPlayer_damage(event) {
     if (this.combatants.selected.hasBuff(SPELLS.SOUL_HARVEST.id, event.timestamp)) {
-      this.addToCorrectSource(getDamageBonus(event, SOUL_HARVEST_DAMAGE_BONUS));
+      this._addToCorrectSource(getDamageBonus(event, SOUL_HARVEST_DAMAGE_BONUS));
+    }
+  }
+
+  on_byPlayerPet_damage(event) {
+    if (this.combatants.selected.hasBuff(SPELLS.SOUL_HARVEST.id, event.timestamp)) {
+      this._addToCorrectSource(getDamageBonus(event, SOUL_HARVEST_DAMAGE_BONUS));
     }
   }
 


### PR DESCRIPTION
Mostly minor refactors:
- extraction of constants before class definition (FatalEchoes, SoulShardDetails in all specs etc.)
- trying to eliminate computations in `on_finished()` where unnecessary (Empowered Life Tap modules, Immolate uptime etc.)
- safety checks for division by zero (UABuffTracker)
- unified the text for item damage (SacrolashsDarkStrike, StretensSleeplessShackles etc., it's possible I missed something)
- minor text cleanup (PowerCordOfLethtendris, FeretoryOfSouls)
- refactor of SoulHarvest modules - private variables/methods renames and using `on_byPlayerPet_damage`
- empty lines here and there for better readability of the code (or to logically separate some parts)

Last but not least, I gave a second thought to Fire and Brimstone and realized it's way too unnecessarily complex and reduced it down. As mentioned in the commit, it does give different results than the previous implementation, but it seems that it's more likely the previous one was wrong and not this one.

Should not cause merge conflicts with #432 but if yes, they shouldn't be hard to resolve.