### PR TITLE
[Core] EnemyInstance and EnemyInstances

### DIFF
--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -10,6 +10,7 @@ import AbilityTracker from './Modules/AbilityTracker';
 import Haste from './Modules/Haste';
 import AlwaysBeCasting from './Modules/AlwaysBeCasting';
 import Enemies from './Modules/Enemies';
+import EnemyInstances from './Modules/EnemyInstances';
 import Pets from './Modules/Pets';
 import HealEventTracker from './Modules/HealEventTracker';
 import ManaValues from './Modules/ManaValues';
@@ -77,6 +78,7 @@ class CombatLogParser {
 
     combatants: Combatants,
     enemies: Enemies,
+    enemyInstances: EnemyInstances,
     pets: Pets,
     spellManaCost: SpellManaCost,
     abilityTracker: AbilityTracker,

--- a/src/Parser/Core/EnemyInstance.js
+++ b/src/Parser/Core/EnemyInstance.js
@@ -1,0 +1,15 @@
+import Enemy from './Enemy';
+
+class EnemyInstance extends Enemy {
+  get instanceID() {
+    return this._instanceID;
+  }
+
+  constructor(owner, baseInfo, instanceID = 0) {
+    super(owner, baseInfo);
+
+    this._instanceID = instanceID;
+  }
+}
+
+export default EnemyInstance;

--- a/src/Parser/Core/Modules/Enemies.js
+++ b/src/Parser/Core/Modules/Enemies.js
@@ -20,6 +20,7 @@ class Enemies extends Entities {
         debug && console.warn('Enemy not noteworthy enough:', targetId, event);
         return null;
       }
+      debugger;
       this.enemies[targetId] = enemy = new Enemy(this.owner, baseInfo);
     }
     return enemy;

--- a/src/Parser/Core/Modules/Enemies.js
+++ b/src/Parser/Core/Modules/Enemies.js
@@ -20,7 +20,6 @@ class Enemies extends Entities {
         debug && console.warn('Enemy not noteworthy enough:', targetId, event);
         return null;
       }
-      debugger;
       this.enemies[targetId] = enemy = new Enemy(this.owner, baseInfo);
     }
     return enemy;

--- a/src/Parser/Core/Modules/EnemyInstances.js
+++ b/src/Parser/Core/Modules/EnemyInstances.js
@@ -20,7 +20,6 @@ class EnemyInstances extends Enemies {
         debug && console.warn('Enemy not noteworthy enough:', targetId, event);
         return null;
       }
-      debugger;
       this.enemies[enemyId] = enemy = new EnemyInstance(this.owner, baseInfo, targetInstance);
     }
     return enemy;
@@ -34,9 +33,6 @@ export function encodeTargetString(id, instance = 0) {
 }
 
 export function decodeTargetString(string) {
-  const components = string.split('.');
-  return {
-    id: components[0],
-    instance: components[1] || 0,
-  };
+  const [ id, instance = 0 ] = string.split('.');
+  return { id, instance };
 }

--- a/src/Parser/Core/Modules/EnemyInstances.js
+++ b/src/Parser/Core/Modules/EnemyInstances.js
@@ -1,0 +1,42 @@
+import Enemies from './Enemies';
+import EnemyInstance from '../EnemyInstance';
+
+const debug = true;
+
+class EnemyInstances extends Enemies {
+  getEntity(event) {
+    if (event.targetIsFriendly) {
+      return null;
+    }
+    const targetId = event.targetID;
+    const targetInstance = event.targetInstance;
+
+    const enemyId = encodeTargetString(targetId, targetInstance);
+
+    let enemy = this.enemies[enemyId];
+    if (!enemy) {
+      const baseInfo = this.owner.report.enemies.find(enemy => enemy.id === targetId);
+      if (!baseInfo) {
+        debug && console.warn('Enemy not noteworthy enough:', targetId, event);
+        return null;
+      }
+      debugger;
+      this.enemies[enemyId] = enemy = new EnemyInstance(this.owner, baseInfo, targetInstance);
+    }
+    return enemy;
+  }
+}
+
+export default EnemyInstances;
+
+export function encodeTargetString(id, instance = 0) {
+  return `${id}.${instance}`;
+}
+
+export function decodeTargetString(string) {
+  const components = string.split('.');
+  return {
+    id: components[0],
+    instance: components[1] || 0,
+  };
+}


### PR DESCRIPTION
Adds a new Entity type `EnemyInstance`, and its corresponding module `EnemyInstances`.

I discovered when working on another feature that there is no support in the existing `Enemies` module for tracking individual adds throughout an encounter, since adds share a `targetId` and are only separated by `targetInstance`.   This PR adds that support by accounting for `targetInstance` when handling Enemy data.

The existing `Enemies` module has not been touched, to preserve compatibility with existing code.