### PR TITLE
[Marksmanship] Trueshot CD reduction from artifact traits

### DIFF
--- a/src/Parser/MarksmanshipHunter/CHANGELOG.js
+++ b/src/Parser/MarksmanshipHunter/CHANGELOG.js
@@ -1,5 +1,4 @@
 export default `
-05-10-2017 - Added Artifact Trait cooldown reduction for trueshot. (by Putro) 
 05-10-2017 - remove Cyclonic Burst from Cooldown view. (by Putro) 
 05-10-2017 - Added Artifact Trait cooldown reduction for trueshot. (by Putro) 
 04-10-2017 - Added Aimed Shot and Vulnerable tracker. (by Putro) 

--- a/src/Parser/MarksmanshipHunter/CHANGELOG.js
+++ b/src/Parser/MarksmanshipHunter/CHANGELOG.js
@@ -1,5 +1,6 @@
 export default `
 05-10-2017 - remove Cyclonic Burst from Cooldown view. (by Putro) 
+05-10-2017 - Added Artifact Trait cooldown reduction for trueshot. (by Putro) 
 04-10-2017 - Added Aimed Shot and Vulnerable tracker. (by Putro) 
 03-10-2017 - Added tier20 support. (by Putro)
 02-10-2017 - Added bullseye buff to hunter_spells for future usage. - (by Putro)

--- a/src/Parser/MarksmanshipHunter/CombatLogParser.js
+++ b/src/Parser/MarksmanshipHunter/CombatLogParser.js
@@ -7,15 +7,19 @@ import Talents from 'Main/Talents';
 import CoreCombatLogParser from 'Parser/Core/CombatLogParser';
 import DamageDone from 'Parser/Core/Modules/DamageDone';
 
+//Features
 import CastEfficiency from './Modules/Features/CastEfficiency';
-
 import CooldownTracker from './Modules/Features/CooldownTracker';
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
 import VulnerableUptime from './Modules/Features/VulnerableUptime';
 import VulnerableTracker from './Modules/Features/AimedInVulnerableTracker';
 
+//Tier
 import Tier20_2p from './Modules/Items/Tier20_2p';
 import Tier20_4p from './Modules/Items/Tier20_4p';
+
+//Spells
+import Trueshot from './Modules/Spells/Trueshot';
 
 
 class CombatLogParser extends CoreCombatLogParser {
@@ -33,6 +37,9 @@ class CombatLogParser extends CoreCombatLogParser {
     //Items
     tier20_2p: Tier20_2p,
     tier20_4p: Tier20_4p,
+
+    //Spells
+    trueshot: Trueshot,
 
 
   };

--- a/src/Parser/MarksmanshipHunter/Modules/Features/CastEfficiency.js
+++ b/src/Parser/MarksmanshipHunter/Modules/Features/CastEfficiency.js
@@ -2,9 +2,7 @@ import React from 'react';
 
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
-//import QuickShot from 'Parser/MarksmanshipHunter/Modules/Traits/QuickShot';
 import CoreCastEfficiency from 'Parser/Core/Modules/CastEfficiency';
-
 
 /* eslint-disable no-unused-vars */
 
@@ -58,7 +56,7 @@ class CastEfficiency extends CoreCastEfficiency {
       getCooldown: haste => 60,
       isActive: combatant => combatant.hasTalent(SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.id),
       recommendedCastEfficiency: 1.0,
-      extraSuggestion: <span> The only time <SpellLink id={SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.id}/> should be delayed is when the boss is under 25% hp, as you will then use it to generate <SpellLink id={SPELLS.BULLSEYE_BUFF.id}/> stacks as early on, and as often, as possible. </span>,
+      extraSuggestion: <span> The only time <SpellLink id={SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.id} /> should be delayed is when the boss is under 25% hp, as you will then use it to generate <SpellLink id={SPELLS.BULLSEYE_BUFF.id} /> stacks as early on, and as often, as possible. </span>,
     },
     {
       spell: SPELLS.BARRAGE_TALENT,
@@ -83,9 +81,8 @@ class CastEfficiency extends CoreCastEfficiency {
     {
       spell: SPELLS.TRUESHOT,
       category: CastEfficiency.SPELL_CATEGORIES.COOLDOWNS,
-      getCooldown: (haste, combatant) => {
-        const availableCasts = combatant.owner.modules.trueshot.tsAvailableCasts;
-        return (combatant.owner.fightDuration / 1000) / availableCasts;
+      getCooldown: (_, combatant) => {
+        return combatant.owner.modules.trueshot.reducedCooldownWithTraits;
       },
       recommendedCastEfficiency: 1.0,
     },

--- a/src/Parser/MarksmanshipHunter/Modules/Features/CastEfficiency.js
+++ b/src/Parser/MarksmanshipHunter/Modules/Features/CastEfficiency.js
@@ -83,7 +83,11 @@ class CastEfficiency extends CoreCastEfficiency {
     {
       spell: SPELLS.TRUESHOT,
       category: CastEfficiency.SPELL_CATEGORIES.COOLDOWNS,
-      getCooldown: haste => 180, // TODO calculate cd reduction based on artifact
+     // getCooldown: haste => 180, // TODO calculate cd reduction based on artifact
+      getCooldown: (haste, combatant) => {
+        const availableCasts = combatant.owner.modules.trueshot.tsAvailableCasts;
+        return (combatant.owner.fightDuration / 1000) / availableCasts;
+      },
       recommendedCastEfficiency: 1.0,
     },
     {

--- a/src/Parser/MarksmanshipHunter/Modules/Features/CastEfficiency.js
+++ b/src/Parser/MarksmanshipHunter/Modules/Features/CastEfficiency.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
-import QuickShot from 'Parser/MarksmanshipHunter/Modules/Traits/QuickShot';
+//import QuickShot from 'Parser/MarksmanshipHunter/Modules/Traits/QuickShot';
 import CoreCastEfficiency from 'Parser/Core/Modules/CastEfficiency';
 
 
@@ -83,7 +83,7 @@ class CastEfficiency extends CoreCastEfficiency {
     {
       spell: SPELLS.TRUESHOT,
       category: CastEfficiency.SPELL_CATEGORIES.COOLDOWNS,
-      getCooldown: haste => 180-QuickShot.trueShotCDReduction, // TODO calculate cd reduction based on artifact
+      getCooldown: haste => 180, // TODO calculate cd reduction based on artifact
       recommendedCastEfficiency: 1.0,
     },
     {

--- a/src/Parser/MarksmanshipHunter/Modules/Features/CastEfficiency.js
+++ b/src/Parser/MarksmanshipHunter/Modules/Features/CastEfficiency.js
@@ -83,7 +83,6 @@ class CastEfficiency extends CoreCastEfficiency {
     {
       spell: SPELLS.TRUESHOT,
       category: CastEfficiency.SPELL_CATEGORIES.COOLDOWNS,
-     // getCooldown: haste => 180, // TODO calculate cd reduction based on artifact
       getCooldown: (haste, combatant) => {
         const availableCasts = combatant.owner.modules.trueshot.tsAvailableCasts;
         return (combatant.owner.fightDuration / 1000) / availableCasts;

--- a/src/Parser/MarksmanshipHunter/Modules/Features/CastEfficiency.js
+++ b/src/Parser/MarksmanshipHunter/Modules/Features/CastEfficiency.js
@@ -2,12 +2,14 @@ import React from 'react';
 
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
+import QuickShot from 'Parser/MarksmanshipHunter/Modules/Traits/QuickShot';
 import CoreCastEfficiency from 'Parser/Core/Modules/CastEfficiency';
 
 
 /* eslint-disable no-unused-vars */
 
 class CastEfficiency extends CoreCastEfficiency {
+
   static CPM_ABILITIES = [
     ...CoreCastEfficiency.CPM_ABILITIES,
 
@@ -81,7 +83,7 @@ class CastEfficiency extends CoreCastEfficiency {
     {
       spell: SPELLS.TRUESHOT,
       category: CastEfficiency.SPELL_CATEGORIES.COOLDOWNS,
-      getCooldown: haste => 180, // TODO calculate cd reduction based on artifact
+      getCooldown: haste => 180-QuickShot.trueShotCDReduction, // TODO calculate cd reduction based on artifact
       recommendedCastEfficiency: 1.0,
     },
     {

--- a/src/Parser/MarksmanshipHunter/Modules/Features/CastEfficiency.js
+++ b/src/Parser/MarksmanshipHunter/Modules/Features/CastEfficiency.js
@@ -81,9 +81,7 @@ class CastEfficiency extends CoreCastEfficiency {
     {
       spell: SPELLS.TRUESHOT,
       category: CastEfficiency.SPELL_CATEGORIES.COOLDOWNS,
-      getCooldown: (_, combatant) => {
-        return combatant.owner.modules.trueshot.reducedCooldownWithTraits;
-      },
+      getCooldown: (_, combatant) => combatant.owner.modules.trueshot.reducedCooldownWithTraits,
       recommendedCastEfficiency: 1.0,
     },
     {

--- a/src/Parser/MarksmanshipHunter/Modules/Spells/Trueshot.js
+++ b/src/Parser/MarksmanshipHunter/Modules/Spells/Trueshot.js
@@ -2,39 +2,42 @@ import Module from 'Parser/Core/Module';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 
-class QuickShot extends Module {
+class Trueshot extends Module {
   static dependencies = {
     combatants: Combatants,
   };
 
   trueShotCDReduction = 0;
-  totalFromCD = 0;
 
-  get tsAvailableCasts() {
+  get reducedCooldownWithTraits() {
     const player = this.combatants.selected;
     const quickShotRank = player.traitsBySpellId[SPELLS.QUICK_SHOT_TRAIT.id];
 
-    if (quickShotRank === 0) {
-      return;
-    }
-    else if (quickShotRank > 0 && quickShotRank < 4) {
+    //Calculates the reduction in cooldown on Trueshot, based upon the rank of the trait Quick Shot. Each rank gives diminishing values, the more ranks you get. Rank 1-3 is 10 each, then each switch case is for the subsequential 4 possibilities.
+    if (quickShotRank < 4) {
       this.trueShotCDReduction = quickShotRank * 10;
-    } else if (quickShotRank === 4) {
-      this.trueShotCDReduction = 38;
     }
-    else if (quickShotRank === 5) {
-      this.trueShotCDReduction = 45;
+    else {
+      switch(quickShotRank) {
+        case 4:
+          this.trueShotCDReduction = 38;
+          break;
+        case 5:
+          this.trueShotCDReduction = 45;
+          break;
+        case 6:
+          this.trueShotCDReduction = 52;
+          break;
+        case 7:
+          this.trueShotCDReduction = 58;
+          break;
+        default:
+          break;
+      }
     }
-    else if (quickShotRank === 6) {
-      this.trueShotCDReduction = 52;
-    }
-    else if (quickShotRank === 7) {
-      this.trueShotCDReduction = 58;
-    }
-    const cooldownWithTraits = 180 - this.trueShotCDReduction;
-    const tsAvailableCasts = (this.owner.fightDuration / 1000) / cooldownWithTraits;
-    return tsAvailableCasts;
+    const reducedCooldownWithTraits = 180 - this.trueShotCDReduction;
+    return reducedCooldownWithTraits;
   }
 }
 
-export default QuickShot;
+export default Trueshot;

--- a/src/Parser/MarksmanshipHunter/Modules/Spells/Trueshot.js
+++ b/src/Parser/MarksmanshipHunter/Modules/Spells/Trueshot.js
@@ -1,25 +1,24 @@
 //import React from 'react';
-
+import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 
-
-import Module from 'Parser/Core/Module';
-
-
 class QuickShot extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  };
 
   trueShotCDReduction = 0;
+  totalFromCD = 0;
 
-  on_initialized() {
+  get tsAvailableCasts() {
     const player = this.combatants.selected;
     const quickShotRank = player.traitsBySpellId[SPELLS.QUICK_SHOT_TRAIT.id];
-    const baselineCD = 180;
 
     if (quickShotRank === 0) {
       return;
     }
-    else if (quickShotRank>0 && quickShotRank<4)
-    {
+    else if (quickShotRank > 0 && quickShotRank < 4) {
       this.trueShotCDReduction = quickShotRank * 10;
     } else if (quickShotRank === 4) {
       this.trueShotCDReduction = 38;
@@ -33,7 +32,10 @@ class QuickShot extends Module {
     else if (quickShotRank === 7) {
       this.trueShotCDReduction = 58;
     }
-    const cooldownWithTraits = baselineCD - this.trueShotCDReduction;
+    const cooldownWithTraits = 180 - this.trueShotCDReduction;
+    this.totalFromCD = (this.owner.fightDuration / 1000) / cooldownWithTraits;
+   let tsAvailableCasts = this.totalFromCD;
+    return tsAvailableCasts;
   }
 }
 

--- a/src/Parser/MarksmanshipHunter/Modules/Spells/Trueshot.js
+++ b/src/Parser/MarksmanshipHunter/Modules/Spells/Trueshot.js
@@ -1,4 +1,3 @@
-//import React from 'react';
 import Module from 'Parser/Core/Module';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
@@ -33,8 +32,7 @@ class QuickShot extends Module {
       this.trueShotCDReduction = 58;
     }
     const cooldownWithTraits = 180 - this.trueShotCDReduction;
-    this.totalFromCD = (this.owner.fightDuration / 1000) / cooldownWithTraits;
-   const tsAvailableCasts = this.totalFromCD;
+    const tsAvailableCasts = (this.owner.fightDuration / 1000) / cooldownWithTraits;
     return tsAvailableCasts;
   }
 }

--- a/src/Parser/MarksmanshipHunter/Modules/Spells/Trueshot.js
+++ b/src/Parser/MarksmanshipHunter/Modules/Spells/Trueshot.js
@@ -34,7 +34,7 @@ class QuickShot extends Module {
     }
     const cooldownWithTraits = 180 - this.trueShotCDReduction;
     this.totalFromCD = (this.owner.fightDuration / 1000) / cooldownWithTraits;
-   let tsAvailableCasts = this.totalFromCD;
+   const tsAvailableCasts = this.totalFromCD;
     return tsAvailableCasts;
   }
 }

--- a/src/Parser/MarksmanshipHunter/Modules/Traits/QuickShot.js
+++ b/src/Parser/MarksmanshipHunter/Modules/Traits/QuickShot.js
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+
+
+import Module from 'Parser/Core/Module';
+
+
+class QuickShot extends Module {
+
+  trueShotCDReduction = 0;
+
+  on_initialized() {
+    const player = this.combatants.selected;
+    const quickShotRank = player.traitsBySpellId[SPELLS.QUICK_SHOT_TRAIT.id];
+
+    if (quickShotRank === 0) {
+      return;
+    }
+    else if (quickShotRank>0 && quickShotRank<4)
+    {
+      this.trueShotCDReduction = quickShotRank * 10;
+    } else if (quickShotRank === 4) {
+      this.trueShotCDReduction = 38;
+    }
+    else if (quickShotRank === 5) {
+      this.trueShotCDReduction = 45;
+    }
+    else if (quickShotRank === 6) {
+      this.trueShotCDReduction = 52;
+    }
+    else if (quickShotRank === 7) {
+      this.trueShotCDReduction = 58;
+    }
+  }
+}
+
+export default QuickShot;

--- a/src/Parser/MarksmanshipHunter/Modules/Traits/QuickShot.js
+++ b/src/Parser/MarksmanshipHunter/Modules/Traits/QuickShot.js
@@ -1,4 +1,4 @@
-import React from 'react';
+//import React from 'react';
 
 import SPELLS from 'common/SPELLS';
 
@@ -13,6 +13,7 @@ class QuickShot extends Module {
   on_initialized() {
     const player = this.combatants.selected;
     const quickShotRank = player.traitsBySpellId[SPELLS.QUICK_SHOT_TRAIT.id];
+    const baselineCD = 180;
 
     if (quickShotRank === 0) {
       return;
@@ -32,6 +33,7 @@ class QuickShot extends Module {
     else if (quickShotRank === 7) {
       this.trueShotCDReduction = 58;
     }
+    const cooldownWithTraits = baselineCD - this.trueShotCDReduction;
   }
 }
 

--- a/src/common/SPELLS_HUNTER.js
+++ b/src/common/SPELLS_HUNTER.js
@@ -137,9 +137,15 @@ export default {
     name: 'Cyclonic burst',
     icon: 'inv_bow_1h_artifactwindrunner_d_02',
   },
+  QUICK_SHOT_TRAIT: {
+    id: 190462,
+    name: 'Quick shot',
+    icon: 'ability_trueshot',
+  },
 
   // Survival:
   // ...
+
 
   // Shared:
   // ...

--- a/src/common/SPELLS_HUNTER.js
+++ b/src/common/SPELLS_HUNTER.js
@@ -132,11 +132,6 @@ export default {
     name: 'Bullseye',
     icon: 'ability_hunter_focusedaim',
   },
-  CYCLONIC_BURST_TRAIT: {
-    id: 238124,
-    name: 'Cyclonic burst',
-    icon: 'inv_bow_1h_artifactwindrunner_d_02',
-  },
   QUICK_SHOT_TRAIT: {
     id: 190462,
     name: 'Quick shot',


### PR DESCRIPTION
This adds a trueshot module for future usage for the advanced cooldown tracking, for now it simply has rank 0-7 of Quick Shot which reduces the CD of Trueshot with diminished values pr rank after initial 3. 

From my testing of various logs, it's accurate now when Convergence, Legendary boots and/or T192p aren't involved. They are on a future to-do list, but this solves the first hurdle when it comes to the CD of Trueshot. 

Example of before: 
![image](https://user-images.githubusercontent.com/29204244/31235834-c4b37820-a9f2-11e7-88af-176aecbdc521.png)

Example of after: 
![image](https://user-images.githubusercontent.com/29204244/31236037-43af8b8c-a9f3-11e7-8c2f-a41b8af16abe.png)
