### PR TITLE
[resto druid] Added ironbark module

### DIFF
--- a/src/Parser/RestoDruid/CHANGELOG.js
+++ b/src/Parser/RestoDruid/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+06-10-2017 - Resto Druid: Added Ironbark module. (by Sref)
 29-09-2017 - Resto Druid: More Flourish updates. (by Sref)
 26-09-2017 - Resto Druid: Updated display of flourish. (by Blazyb)
 26-09-2017 - Resto Druid: Added suggestions on Soul of the forest/archdruid on WG usage. (by Blazyb)

--- a/src/Parser/RestoDruid/CombatLogParser.js
+++ b/src/Parser/RestoDruid/CombatLogParser.js
@@ -45,6 +45,7 @@ import Cultivation from './Modules/Features/Cultivation';
 import SpringBlossoms from './Modules/Features/SpringBlossoms';
 import CenarionWard from './Modules/Features/CenarionWard';
 import NaturesEssence from './Modules/Features/NaturesEssence';
+import Ironbark from './Modules/Features/Ironbark';
 
 import RelicTraits from './Modules/Traits/RelicTraits';
 import ArmorOfTheAncients from './Modules/Traits/ArmorOfTheAncients';
@@ -92,6 +93,7 @@ class CombatLogParser extends CoreCombatLogParser {
     cultivation: Cultivation,
     cenarionWard: CenarionWard,
     naturesEssence: NaturesEssence,
+    ironbark: Ironbark,
 
     // Legendaries:
     ekowraith: Ekowraith,

--- a/src/Parser/RestoDruid/Modules/Features/Ironbark.js
+++ b/src/Parser/RestoDruid/Modules/Features/Ironbark.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import LazyLoadStatisticBox, { STATISTIC_ORDER } from 'Main/LazyLoadStatisticBox';
+import { formatNumber, formatPercentage } from 'common/format';
+import SpellIcon from 'common/SpellIcon';
+
+import SPELLS from 'common/SPELLS';
+import makeWclUrl from 'common/makeWclUrl';
+import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+const IRONBARK_BASE_DR = 0.20;
+const AOTA_BONUS_DR = 0.02;
+
+class Ironbark extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  ironbarkDr = 0;
+  ironbarkCount = 0;
+  damageTakenDuringIronbark = 0;
+
+  on_initialized() {
+    const aotaRanks = this.combatants.selected.traitsBySpellId[SPELLS.ARMOR_OF_THE_ANCIENTS.id];
+    this.ironbarkDr = IRONBARK_BASE_DR + (AOTA_BONUS_DR * aotaRanks);
+  }
+
+  on_byPlayer_cast(event) {
+    if(event.ability.guid === SPELLS.IRONBARK.id) {
+      this.ironbarkCount ++;
+    }
+  }
+
+  get damageReduced() {
+    return this.damageTakenDuringIronbark / (1 - this.ironbarkDr) * this.ironbarkDr;
+  }
+
+  load() {
+    return fetch(makeWclUrl(`report/tables/damage-taken/${this.owner.report.code}`, {
+      start: this.owner.fight.start_time,
+      end: this.owner.fight.end_time,
+      filter: `(IN RANGE FROM type='applybuff' AND ability.id=${SPELLS.IRONBARK.id} AND source.name='${this.combatants.selected.name}' TO type='removebuff' AND ability.id=${SPELLS.IRONBARK.id} AND source.name='${this.combatants.selected.name}' GROUP BY target ON target END)`,
+    }))
+      .then(response => response.json())
+      .then((json) => {
+        if (json.status === 400 || json.status === 401) {
+          throw json.error;
+        } else {
+          this.damageTakenDuringIronbark = json.entries.reduce((damageTaken, entry) => damageTaken + entry.total, 0);
+        }
+      });
+  }
+
+  statistic() {
+    return (
+      <LazyLoadStatisticBox
+        loader={this.load.bind(this)}
+        icon={<SpellIcon id={SPELLS.IRONBARK.id} />}
+        value={`${formatNumber(this.damageReduced / this.ironbarkCount)}`}
+        label="Average Ironbark Mitigation"
+        tooltip={
+          `This is the average amount of damage you prevented per Ironbark cast. The total damage prevented over your <b>${this.ironbarkCount} casts</b> was <b>${formatNumber(this.damageReduced)}</b>. While this amount is not counted in your healing done, this is equivalent to <b>${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.damageReduced))}%</b> of your total healing.`
+        }
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(20);
+
+}
+
+export default Ironbark;

--- a/src/common/SPELLS_DRUID.js
+++ b/src/common/SPELLS_DRUID.js
@@ -407,6 +407,11 @@ export default {
     name:'Knowledge of the Ancients',
     icon: 'ability_druid_manatree',
   },
+  ARMOR_OF_THE_ANCIENTS: {
+    id: 189754,
+    name: 'Armor of the Ancients',
+    icon: 'spell_druid_ironbark',
+  },
 
   // GUARDIAN //
   MANGLE_BEAR: {


### PR DESCRIPTION
Added Ironbark module using a LazyLoaded stats box because an extra query is required. The stats generated here could be used to generate the NYI ArmorOfTheAncients trait, but I don't want to implement lazy loading in the Relic Trait box at the moment.