### PR TITLE
[Retribution] Added in a relic traits stat box

### DIFF
--- a/src/Main/App.js
+++ b/src/Main/App.js
@@ -97,6 +97,7 @@ class App extends Component {
       progress: 0,
       dataVersion: 0,
       bossId: null,
+      config: null,
     };
 
     this.handleReportSelecterSubmit = this.handleReportSelecterSubmit.bind(this);
@@ -489,7 +490,7 @@ class App extends Component {
 
     const progress = (this.state.progress * 100);
 
-    if (!_footerDeprectatedWarningSent) {
+    if (this.state.config && this.state.config.footer && !_footerDeprectatedWarningSent) {
       console.error('Using `config.footer` is deprectated. You should add the information you want to share to the description property in the config, which is shown on the spec information overlay.');
       _footerDeprectatedWarningSent = true;
     }

--- a/src/Parser/RetributionPaladin/CHANGELOG.js
+++ b/src/Parser/RetributionPaladin/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+09-06-2017 = (@Hewhosmites) Added Deliver the Justice/Might of the Templar/Righteous Verdict/Highlord's Judgment relic traits
 09-05-2017 - (@Hewhosmites) Added a Retribution damage tracker.
 08-28-2017 - (@Hewhosmites) Added a Blade of Wrath proc tracker
 08-22-2017 - (@Hewhosmites) Added a module to check that you're spending inside of Judgment

--- a/src/Parser/RetributionPaladin/Modules/Items/AshesToDust.js
+++ b/src/Parser/RetributionPaladin/Modules/Items/AshesToDust.js
@@ -8,7 +8,7 @@ import Module from 'Parser/Core/Module';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import Enemies from 'Parser/Core/Modules/Enemies';
 
-import GetDamageBonus from '../PaladinCore/GetDamageBonus';
+import getDamageBonus from '../PaladinCore/getDamageBonus';
 
 const ASHES_TO_DUST_MODIFIER = 0.15;
 
@@ -30,7 +30,7 @@ class AshesToDust extends Module {
     		return;
 		}
 		else if(enemy.hasBuff(SPELLS.WAKE_OF_ASHES.id)) {
-			this.damageDone += GetDamageBonus(event, ASHES_TO_DUST_MODIFIER);
+			this.damageDone += getDamageBonus(event, ASHES_TO_DUST_MODIFIER);
 		}
 	}
 

--- a/src/Parser/RetributionPaladin/Modules/Items/AshesToDust.js
+++ b/src/Parser/RetributionPaladin/Modules/Items/AshesToDust.js
@@ -8,7 +8,7 @@ import Module from 'Parser/Core/Module';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import Enemies from 'Parser/Core/Modules/Enemies';
 
-import getDamageBonus from '../PaladinCore/getDamageBonus';
+import GetDamageBonus from '../PaladinCore/GetDamageBonus';
 
 const ASHES_TO_DUST_MODIFIER = 0.15;
 
@@ -30,7 +30,7 @@ class AshesToDust extends Module {
     		return;
 		}
 		else if(enemy.hasBuff(SPELLS.WAKE_OF_ASHES.id)) {
-			this.damageDone += getDamageBonus(event, ASHES_TO_DUST_MODIFIER);
+			this.damageDone += GetDamageBonus(event, ASHES_TO_DUST_MODIFIER);
 		}
 	}
 

--- a/src/Parser/RetributionPaladin/Modules/Items/ChainOfThrayn.js
+++ b/src/Parser/RetributionPaladin/Modules/Items/ChainOfThrayn.js
@@ -7,7 +7,7 @@ import { formatNumber } from 'common/format';
 import Module from 'Parser/Core/Module';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
-import GetDamageBonus from '../PaladinCore/GetDamageBonus';
+import getDamageBonus from '../PaladinCore/getDamageBonus';
 
 const CHAIN_OF_THRAYN_INCREASE = 0.1;
 
@@ -24,7 +24,7 @@ class ChainOfThrayn extends Module {
 
 	on_byPlayer_damage(event) {
 		if(this.combatants.selected.hasBuff(SPELLS.CRUSADE_TALENT.id) || this.combatants.selected.hasBuff(SPELLS.AVENGING_WRATH_RET.id)){
-			this.damageDone += GetDamageBonus(event, CHAIN_OF_THRAYN_INCREASE);
+			this.damageDone += getDamageBonus(event, CHAIN_OF_THRAYN_INCREASE);
 		}
 	}
 

--- a/src/Parser/RetributionPaladin/Modules/Items/ChainOfThrayn.js
+++ b/src/Parser/RetributionPaladin/Modules/Items/ChainOfThrayn.js
@@ -7,7 +7,7 @@ import { formatNumber } from 'common/format';
 import Module from 'Parser/Core/Module';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
-import getDamageBonus from '../PaladinCore/getDamageBonus';
+import GetDamageBonus from '../PaladinCore/GetDamageBonus';
 
 const CHAIN_OF_THRAYN_INCREASE = 0.1;
 
@@ -24,7 +24,7 @@ class ChainOfThrayn extends Module {
 
 	on_byPlayer_damage(event) {
 		if(this.combatants.selected.hasBuff(SPELLS.CRUSADE_TALENT.id) || this.combatants.selected.hasBuff(SPELLS.AVENGING_WRATH_RET.id)){
-			this.damageDone += getDamageBonus(event, CHAIN_OF_THRAYN_INCREASE);
+			this.damageDone += GetDamageBonus(event, CHAIN_OF_THRAYN_INCREASE);
 		}
 	}
 

--- a/src/Parser/RetributionPaladin/Modules/Items/Tier20_2set.js
+++ b/src/Parser/RetributionPaladin/Modules/Items/Tier20_2set.js
@@ -8,7 +8,7 @@ import { formatNumber, formatPercentage } from 'common/format';
 import Module from 'Parser/Core/Module';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
-import getDamageBonus from '../PaladinCore/getDamageBonus';
+import GetDamageBonus from '../PaladinCore/GetDamageBonus';
 
 const RET_PALADIN_T20_2SET_MODIFIER = 0.2;
 
@@ -33,7 +33,7 @@ class Tier20_2set extends Module {
 
   on_byPlayer_damage(event) {
     if (this.combatants.selected.hasBuff(SPELLS.RET_PALADIN_T20_2SET_BONUS_BUFF.id) && (event.ability.guid === SPELLS.BLADE_OF_JUSTICE.id || event.ability.guid === SPELLS.DIVINE_HAMMER_HIT.id)) {
-      this.damageDone += getDamageBonus(event, RET_PALADIN_T20_2SET_MODIFIER);
+      this.damageDone += GetDamageBonus(event, RET_PALADIN_T20_2SET_MODIFIER);
     }
   }
 

--- a/src/Parser/RetributionPaladin/Modules/Items/Tier20_2set.js
+++ b/src/Parser/RetributionPaladin/Modules/Items/Tier20_2set.js
@@ -8,7 +8,7 @@ import { formatNumber, formatPercentage } from 'common/format';
 import Module from 'Parser/Core/Module';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
-import GetDamageBonus from '../PaladinCore/GetDamageBonus';
+import getDamageBonus from '../PaladinCore/getDamageBonus';
 
 const RET_PALADIN_T20_2SET_MODIFIER = 0.2;
 
@@ -33,7 +33,7 @@ class Tier20_2set extends Module {
 
   on_byPlayer_damage(event) {
     if (this.combatants.selected.hasBuff(SPELLS.RET_PALADIN_T20_2SET_BONUS_BUFF.id) && (event.ability.guid === SPELLS.BLADE_OF_JUSTICE.id || event.ability.guid === SPELLS.DIVINE_HAMMER_HIT.id)) {
-      this.damageDone += GetDamageBonus(event, RET_PALADIN_T20_2SET_MODIFIER);
+      this.damageDone += getDamageBonus(event, RET_PALADIN_T20_2SET_MODIFIER);
     }
   }
 

--- a/src/Parser/RetributionPaladin/Modules/Items/WhisperOfTheNathrezim.js
+++ b/src/Parser/RetributionPaladin/Modules/Items/WhisperOfTheNathrezim.js
@@ -9,7 +9,7 @@ import { formatNumber, formatPercentage } from 'common/format';
 import Module from 'Parser/Core/Module';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
-import getDamageBonus from '../PaladinCore/getDamageBonus';
+import GetDamageBonus from '../PaladinCore/GetDamageBonus';
 
 const WHISPER_OF_THE_NATHREZIM_MODIFIER = 0.15;
 
@@ -27,7 +27,7 @@ class WhisperOfTheNathrezim extends Module {
   on_byPlayer_damage(event) {
     if (this.combatants.selected.hasBuff(SPELLS.WHISPER_OF_THE_NATHREZIM_BUFF.id)) {
       if (event.ability.guid === SPELLS.TEMPLARS_VERDICT_DAMAGE.id || event.ability.guid === SPELLS.DIVINE_STORM_DAMAGE.id) {
-        this.damageDone += getDamageBonus(event, WHISPER_OF_THE_NATHREZIM_MODIFIER);
+        this.damageDone += GetDamageBonus(event, WHISPER_OF_THE_NATHREZIM_MODIFIER);
       }
     }
   }

--- a/src/Parser/RetributionPaladin/Modules/Items/WhisperOfTheNathrezim.js
+++ b/src/Parser/RetributionPaladin/Modules/Items/WhisperOfTheNathrezim.js
@@ -9,7 +9,7 @@ import { formatNumber, formatPercentage } from 'common/format';
 import Module from 'Parser/Core/Module';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
-import GetDamageBonus from '../PaladinCore/GetDamageBonus';
+import getDamageBonus from '../PaladinCore/getDamageBonus';
 
 const WHISPER_OF_THE_NATHREZIM_MODIFIER = 0.15;
 
@@ -27,7 +27,7 @@ class WhisperOfTheNathrezim extends Module {
   on_byPlayer_damage(event) {
     if (this.combatants.selected.hasBuff(SPELLS.WHISPER_OF_THE_NATHREZIM_BUFF.id)) {
       if (event.ability.guid === SPELLS.TEMPLARS_VERDICT_DAMAGE.id || event.ability.guid === SPELLS.DIVINE_STORM_DAMAGE.id) {
-        this.damageDone += GetDamageBonus(event, WHISPER_OF_THE_NATHREZIM_MODIFIER);
+        this.damageDone += getDamageBonus(event, WHISPER_OF_THE_NATHREZIM_MODIFIER);
       }
     }
   }

--- a/src/Parser/RetributionPaladin/Modules/PaladinCore/GetDamageBonus.js
+++ b/src/Parser/RetributionPaladin/Modules/PaladinCore/GetDamageBonus.js
@@ -1,4 +1,4 @@
-export default function getDamageBonus(event, increase) {
+export default function GetDamageBonus(event, increase) {
   const raw = (event.amount || 0) + (event.absorbed || 0);
   return raw - (raw / (1 + increase));
 }

--- a/src/Parser/RetributionPaladin/Modules/PaladinCore/Retribution.js
+++ b/src/Parser/RetributionPaladin/Modules/PaladinCore/Retribution.js
@@ -8,7 +8,7 @@ import SpellIcon from 'common/SpellIcon';
 import { formatNumber, formatPercentage } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
-import getDamageBonus from '../PaladinCore/GetDamageBonus';
+import getDamageBonus from '../PaladinCore/getDamageBonus';
 
 const RETRIBUTION_DAMAGE_BONUS = 0.2;
 

--- a/src/Parser/RetributionPaladin/Modules/PaladinCore/Retribution.js
+++ b/src/Parser/RetributionPaladin/Modules/PaladinCore/Retribution.js
@@ -8,7 +8,7 @@ import SpellIcon from 'common/SpellIcon';
 import { formatNumber, formatPercentage } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
-import getDamageBonus from '../PaladinCore/getDamageBonus';
+import GetDamageBonus from '../PaladinCore/GetDamageBonus';
 
 const RETRIBUTION_DAMAGE_BONUS = 0.2;
 
@@ -22,7 +22,7 @@ class Retribution extends Module {
 	on_byPlayer_damage(event){
 		if(!this.combatants.selected.hasBuff(SPELLS.RETRIBUTION_BUFF.id))
 			return;
-		this.bonusDmg += getDamageBonus(event, RETRIBUTION_DAMAGE_BONUS);
+		this.bonusDmg += GetDamageBonus(event, RETRIBUTION_DAMAGE_BONUS);
 	}
 
 	statistic() {

--- a/src/Parser/RetributionPaladin/Modules/PaladinCore/getDamageBonusStacked.js
+++ b/src/Parser/RetributionPaladin/Modules/PaladinCore/getDamageBonusStacked.js
@@ -1,4 +1,4 @@
-export default function GetDamageBonusStacked(event, increase, stacks) {
+export default function getDamageBonusStacked(event, increase, stacks) {
 	const raw = (event.amount || 0) + (event.absorbed || 0);
 	const relativeDamageIncreaseFactor = 1 + (increase * stacks);
 	const totalIncrease = raw - raw / relativeDamageIncreaseFactor;

--- a/src/Parser/RetributionPaladin/Modules/PaladinCore/getDamageBonusStacked.js
+++ b/src/Parser/RetributionPaladin/Modules/PaladinCore/getDamageBonusStacked.js
@@ -1,4 +1,4 @@
-export default function getDamageBonusStacked(event, increase, stacks) {
+export default function GetDamageBonusStacked(event, increase, stacks) {
 	const raw = (event.amount || 0) + (event.absorbed || 0);
 	const relativeDamageIncreaseFactor = 1 + (increase * stacks);
 	const totalIncrease = raw - raw / relativeDamageIncreaseFactor;

--- a/src/Parser/RetributionPaladin/Modules/Traits/DeliverTheJustice.js
+++ b/src/Parser/RetributionPaladin/Modules/Traits/DeliverTheJustice.js
@@ -7,7 +7,7 @@ import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
-import GetDamageBonusStacked from '../PaladinCore/GetDamageBonusStacked';
+import getDamageBonusStacked from '../PaladinCore/getDamageBonusStacked';
 
 const DELIVER_THE_JUSTICE_INCREASE = 0.08;
 /**
@@ -30,7 +30,7 @@ class DeliverTheJustice extends Module {
 
 	on_byPlayer_damage(event) {
 		if(event.ability.guid === SPELLS.BLADE_OF_JUSTICE.id || event.ability.guid === SPELLS.DIVINE_HAMMER_HIT.id){
-			this.damage += GetDamageBonusStacked(event, DELIVER_THE_JUSTICE_INCREASE, this.rank);
+			this.damage += getDamageBonusStacked(event, DELIVER_THE_JUSTICE_INCREASE, this.rank);
 		}
 	}
 

--- a/src/Parser/RetributionPaladin/Modules/Traits/DeliverTheJustice.js
+++ b/src/Parser/RetributionPaladin/Modules/Traits/DeliverTheJustice.js
@@ -7,7 +7,7 @@ import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
-import getDamageBonusStacked from '../PaladinCore/getDamageBonusStacked';
+import GetDamageBonusStacked from '../PaladinCore/GetDamageBonusStacked';
 
 const DELIVER_THE_JUSTICE_INCREASE = 0.08;
 /**
@@ -30,7 +30,7 @@ class DeliverTheJustice extends Module {
 
 	on_byPlayer_damage(event) {
 		if(event.ability.guid === SPELLS.BLADE_OF_JUSTICE.id || event.ability.guid === SPELLS.DIVINE_HAMMER_HIT.id){
-			this.damage += getDamageBonusStacked(event, DELIVER_THE_JUSTICE_INCREASE, this.rank);
+			this.damage += GetDamageBonusStacked(event, DELIVER_THE_JUSTICE_INCREASE, this.rank);
 		}
 	}
 

--- a/src/Parser/RetributionPaladin/Modules/Traits/HighlordsJudgment.js
+++ b/src/Parser/RetributionPaladin/Modules/Traits/HighlordsJudgment.js
@@ -7,7 +7,7 @@ import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
-import getDamageBonusStacked from '../PaladinCore/getDamageBonusStacked';
+import GetDamageBonusStacked from '../PaladinCore/GetDamageBonusStacked';
 
 const HIGHLORDS_JUDGMENT_INCREASE = 0.08;
 /**
@@ -32,7 +32,7 @@ const HIGHLORDS_JUDGMENT_INCREASE = 0.08;
  		if(event.ability.guid !== SPELLS.JUDGMENT_CAST.id){
  			return;
  		}
- 		this.damage += getDamageBonusStacked(event, HIGHLORDS_JUDGMENT_INCREASE, this.rank);
+ 		this.damage += GetDamageBonusStacked(event, HIGHLORDS_JUDGMENT_INCREASE, this.rank);
  	}
 
  	subStatistic() {

--- a/src/Parser/RetributionPaladin/Modules/Traits/HighlordsJudgment.js
+++ b/src/Parser/RetributionPaladin/Modules/Traits/HighlordsJudgment.js
@@ -7,7 +7,7 @@ import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
-import GetDamageBonusStacked from '../PaladinCore/GetDamageBonusStacked';
+import getDamageBonusStacked from '../PaladinCore/getDamageBonusStacked';
 
 const HIGHLORDS_JUDGMENT_INCREASE = 0.08;
 /**
@@ -32,7 +32,7 @@ const HIGHLORDS_JUDGMENT_INCREASE = 0.08;
  		if(event.ability.guid !== SPELLS.JUDGMENT_CAST.id){
  			return;
  		}
- 		this.damage += GetDamageBonusStacked(event, HIGHLORDS_JUDGMENT_INCREASE, this.rank);
+ 		this.damage += getDamageBonusStacked(event, HIGHLORDS_JUDGMENT_INCREASE, this.rank);
  	}
 
  	subStatistic() {

--- a/src/Parser/RetributionPaladin/Modules/Traits/MightOfTheTemplar.js
+++ b/src/Parser/RetributionPaladin/Modules/Traits/MightOfTheTemplar.js
@@ -7,7 +7,7 @@ import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
-import getDamageBonusStacked from '../PaladinCore/getDamageBonusStacked';
+import GetDamageBonusStacked from '../PaladinCore/GetDamageBonusStacked';
 
 
 const MIGHT_OF_THE_TEMPLAR_INCREASE = 0.02;
@@ -34,7 +34,7 @@ class MightOfTheTemplar extends Module {
  			return;
  		}
 
- 		this.damage += getDamageBonusStacked(event, MIGHT_OF_THE_TEMPLAR_INCREASE, this.rank);
+ 		this.damage += GetDamageBonusStacked(event, MIGHT_OF_THE_TEMPLAR_INCREASE, this.rank);
  	}
 
  	subStatistic() {

--- a/src/Parser/RetributionPaladin/Modules/Traits/MightOfTheTemplar.js
+++ b/src/Parser/RetributionPaladin/Modules/Traits/MightOfTheTemplar.js
@@ -7,7 +7,7 @@ import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
-import GetDamageBonusStacked from '../PaladinCore/GetDamageBonusStacked';
+import getDamageBonusStacked from '../PaladinCore/getDamageBonusStacked';
 
 
 const MIGHT_OF_THE_TEMPLAR_INCREASE = 0.02;
@@ -34,7 +34,7 @@ class MightOfTheTemplar extends Module {
  			return;
  		}
 
- 		this.damage += GetDamageBonusStacked(event, MIGHT_OF_THE_TEMPLAR_INCREASE, this.rank);
+ 		this.damage += getDamageBonusStacked(event, MIGHT_OF_THE_TEMPLAR_INCREASE, this.rank);
  	}
 
  	subStatistic() {

--- a/src/Parser/RetributionPaladin/Modules/Traits/RighteousVerdict.js
+++ b/src/Parser/RetributionPaladin/Modules/Traits/RighteousVerdict.js
@@ -7,7 +7,7 @@ import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
-import getDamageBonusStacked from '../PaladinCore/getDamageBonusStacked';
+import GetDamageBonusStacked from '../PaladinCore/GetDamageBonusStacked';
 
 const RIGHTEOUS_VERDICT_INCREASE = 0.08;
 /**
@@ -34,7 +34,7 @@ const RIGHTEOUS_VERDICT_INCREASE = 0.08;
  			return;
  		}
  		if(event.ability.guid === SPELLS.BLADE_OF_JUSTICE.id || event.ability.guid === SPELLS.DIVINE_HAMMER_HIT.id){
- 			this.damage += getDamageBonusStacked(event, RIGHTEOUS_VERDICT_INCREASE, this.rank);
+ 			this.damage += GetDamageBonusStacked(event, RIGHTEOUS_VERDICT_INCREASE, this.rank);
  		}
  	}
 

--- a/src/Parser/RetributionPaladin/Modules/Traits/RighteousVerdict.js
+++ b/src/Parser/RetributionPaladin/Modules/Traits/RighteousVerdict.js
@@ -7,7 +7,7 @@ import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
-import GetDamageBonusStacked from '../PaladinCore/GetDamageBonusStacked';
+import getDamageBonusStacked from '../PaladinCore/getDamageBonusStacked';
 
 const RIGHTEOUS_VERDICT_INCREASE = 0.08;
 /**
@@ -34,7 +34,7 @@ const RIGHTEOUS_VERDICT_INCREASE = 0.08;
  			return;
  		}
  		if(event.ability.guid === SPELLS.BLADE_OF_JUSTICE.id || event.ability.guid === SPELLS.DIVINE_HAMMER_HIT.id){
- 			this.damage += GetDamageBonusStacked(event, RIGHTEOUS_VERDICT_INCREASE, this.rank);
+ 			this.damage += getDamageBonusStacked(event, RIGHTEOUS_VERDICT_INCREASE, this.rank);
  		}
  	}
 


### PR DESCRIPTION
The Wrath of the Ashbringer trait is a like hacky but I couldn't think of a better way to do it. It gets the average DPS of wings over the course of the fight then calculates how much damage 2 extra seconds of wings would be. I also couldn't figure out how to implement http://www.wowhead.com/spell=184759/sharpened-edge and am looking for suggestions on that. Otherwise should be good. Please let me know if there is anything you think I should change!