### PR TITLE
[Elemental Shaman] Storm Elemental bugfix

### DIFF
--- a/src/Parser/ElementalShaman/Modules/Features/CastEfficiency.js
+++ b/src/Parser/ElementalShaman/Modules/Features/CastEfficiency.js
@@ -68,6 +68,14 @@ class CastEfficiency extends CoreCastEfficiency {
       category: CastEfficiency.SPELL_CATEGORIES.COOLDOWNS,
       getCooldown: haste => 60 * 5, // TODO: Add Elementalist -> Lava Burst cast ^= -2 sec cd
       recommendedCastEfficiency: 1.0,
+      isActive: combatant => !combatant.hasTalent(SPELLS.STORM_ELEMENTAL_TALENT.id),
+    },
+    {
+      spell: SPELLS.STORM_ELEMENTAL_TALENT,
+      category: CastEfficiency.SPELL_CATEGORIES.COOLDOWNS,
+      getCooldown: haste => 60 * 2.5, // TODO: Add Elementalist -> Lava Burst cast ^= -2 sec cd
+      recommendedCastEfficiency: 1.0,
+      isActive: combatant => combatant.hasTalent(SPELLS.STORM_ELEMENTAL_TALENT.id),
     },
     {
       spell: SPELLS.FLAME_SHOCK,

--- a/src/common/SPELLS_SHAMAN.js
+++ b/src/common/SPELLS_SHAMAN.js
@@ -240,6 +240,12 @@ export default {
     name: 'Nature\'s Essence',
     icon: 'spell_nature_healingway',
   },
+  // Elemental Pet Spells
+  WIND_GUST: {
+    id: 226180,
+    name: 'Wind Gust',
+    icon: 'spell_nature_cyclone',
+  },
   // Elemental Legendaries
   PRISTINE_PROTOSCALE_GIRDLE: {
     id: 224852,


### PR DESCRIPTION
Just two very simple fixes of bugs with existing implementation for shamans using Storm Elemental (SE) talent

1. Maelstorm overview now works by registering maelstorm generating spell of the SE in SPELLS (doesn't work at all, when SE is selected on live)
2. Cast efficiency analysis switches between SE and Fire Elemental, based on talents selected (on live you are blamed for not casting FE if you have SE talented).
