### PR TITLE
[Retribution] Spec completeness upgraded to good

### DIFF
--- a/src/Parser/RetributionPaladin/CONFIG.js
+++ b/src/Parser/RetributionPaladin/CONFIG.js
@@ -20,7 +20,7 @@ export default {
   		Feel free to message me on discord or post in the spec discussion URL with any bugs or ideas for things I could work on!
   	</div>
   ),
-  completeness: SPEC_ANALYSIS_COMPLETENESS.NEEDS_MORE_WORK, // When changing this please make a PR with ONLY this value changed, we will do a review of your analysis to find out of it is complete enough.
+  completeness: SPEC_ANALYSIS_COMPLETENESS.GOOD, // When changing this please make a PR with ONLY this value changed, we will do a review of your analysis to find out of it is complete enough.
   specDiscussionUrl: 'https://github.com/WoWAnalyzer/WoWAnalyzer/issues/323',
   changelog: CHANGELOG,
   parser: CombatLogParser,


### PR DESCRIPTION
There are 5 main things you can do to improve your ret play:

1. Avoid capping your holy power
2. Using's Avenging Wrath/Crusade as much as possible
3. Making sure you're using holy power spenders inside of judgment
4. Using all of your blade of wrath procs
5. Using your artifact ability as much as possible.

I have implemented modules for all of these as well as all the top tier legendaries and some fluffy extra stats. I think using this implementation of the ret spec is a good starting spot but is no way complete yet. For this reason I think the spec completeness can be bumped up to good.