### PR TITLE
Expanded Windwalker CastEfficiency and change to a spell ID

### DIFF
--- a/src/Parser/WindwalkerMonk/Modules/Features/CastEfficiency.js
+++ b/src/Parser/WindwalkerMonk/Modules/Features/CastEfficiency.js
@@ -20,6 +20,30 @@ class CastEfficiency extends CoreCastEfficiency {
       getCooldown: haste => 10,
     },
     {
+        spell: SPELLS.WHIRLING_DRAGON_PUNCH,
+        category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
+        getCooldown: haste => 24,
+        isActive: combatant => combatant.hasTalent(SPELLS.WHIRLING_DRAGON_PUNCH_TALENT.id),
+    },
+    // cooldowns
+    {
+        spell: SPELLS.TOUCH_OF_KARMA_CAST,
+        category: CastEfficiency.SPELL_CATEGORIES.COOLDOWNS,
+        getCooldown: haste => 90,     
+    },
+    {
+        spell: SPELLS.TOUCH_OF_DEATH,
+        category: CastEfficiency.SPELL_CATEGORIES.COOLDOWNS,
+        getCooldown: haste => 120,
+    },
+    {
+        spell: SPELLS.SERENITY,
+        category: CastEfficiency.SPELL_CATEGORIES.COOLDOWNS,
+        getCooldown: haste => 70,
+        isActive: combatant => combatant.hasTalent(SPELLS.SERENITY.id),
+    },
+    // other spells
+    {
       spell: SPELLS.BLACKOUT_KICK,
       category: CastEfficiency.SPELL_CATEGORIES.OTHERS,
       getCooldown: haste => null,
@@ -34,6 +58,11 @@ class CastEfficiency extends CoreCastEfficiency {
       category: CastEfficiency.SPELL_CATEGORIES.OTHERS,
       getCooldown: haste => 15,
       isActive: combatant => combatant.hasTalent(SPELLS.CHI_WAVE_TALENT.id),
+    },
+    {
+        spell: SPELLS.SPINNING_CRANE_KICK,
+        category: CastEfficiency.SPELL_CATEGORIES.OTHERS,
+        getCooldown: haste => null,
     },
   ];
 }

--- a/src/common/SPELLS_MONK.js
+++ b/src/common/SPELLS_MONK.js
@@ -574,7 +574,7 @@ export default {
     icon: 'ability_monk_chiwave',
   },
   POWER_STRIKES: {
-    id: 121817,
+    id: 121283,
     name: 'Power Strikes',
     icon: 'ability_monk_powerstrikes',
   },


### PR DESCRIPTION
Power strikes looks like it has some different spell ID's for the talent itself, the buff it grants and the consumption of the buff. I've changed it to the buff consumption that grants chi so it can be used for resource tracking, but unsure if that's the correct approach.