### PR TITLE
[Retribution] Fixed a bug where divine hammers didn't appear on my holy power graph

### DIFF
--- a/src/Parser/RetributionPaladin/Modules/HolyPower/HolyPowerTracker.js
+++ b/src/Parser/RetributionPaladin/Modules/HolyPower/HolyPowerTracker.js
@@ -26,10 +26,14 @@ class HolyPowerTracker extends Module {
   		generated: 0,
   		wasted: 0,
   	},
-  	[SPELLS.DIVINE_HAMMER_TALENT.id]: {
+  	[SPELLS.DIVINE_HAMMER_3_HP.id]: {
   		generated: 0,
   		wasted: 0,
   	},
+    [SPELLS.DIVINE_HAMMER_2_HP.id]: {
+      generated: 0,
+      wasted: 0,
+    },
   	[SPELLS.WAKE_OF_ASHES_HP_GEN.id]: {
   		generated: 0,
   		wasted: 0,
@@ -55,6 +59,7 @@ class HolyPowerTracker extends Module {
   	[SPELLS.JUSTICARS_VENGEANCE_TALENT.id]: 0,
   	[SPELLS.WORD_OF_GLORY_TALENT.id]: 0,
   };
+
 
   on_toPlayer_energize(event) {
   	const spellId = event.ability.guid;

--- a/src/common/SPELLS_PALADIN.js
+++ b/src/common/SPELLS_PALADIN.js
@@ -242,6 +242,16 @@ export default {
     name: 'Divine Hammer',
     icon: 'spell_holy_auraoflight',
   },
+  DIVINE_HAMMER_3_HP: {
+    id: 246345,
+    name: 'Divine Hammer',
+    icon: 'classicon_paladin',
+  },
+  DIVINE_HAMMER_2_HP: {
+    id: 228231,
+    name: 'Divine Hammer',
+    icon: 'classicon_paladin',
+  },
   DIVINE_STORM_DAMAGE: {
     id: 224239,
     name: 'Divine Storm',


### PR DESCRIPTION
For some reason there is a weird spell ID for divine hammers generating 2 and 3 holy power that I wasn't tracking my module. I fixed and updated it however.