### PR TITLE
Fixed main page button alignment

### DIFF
--- a/src/Main/App.css
+++ b/src/Main/App.css
@@ -697,7 +697,7 @@ table.data-table .performance-bar {
   font-size: 1.6rem;
 }
 .external-links .btn:not(:first-of-type) {
-  margin-left: 20px;
+  margin-left: 3%;
 }
 @media (min-width: 1200px) and (max-width: 1400px) {
   .external-links .btn {


### PR DESCRIPTION
Noticed this while opening the page, triggered my OCD so here is a quick fix.

Tested on Google Chrome on Windows 10