### PR TITLE
[Mage] Fix for Ice Lance/Winters Chill

### DIFF
--- a/src/Parser/FrostMage/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/FrostMage/Modules/Features/AlwaysBeCasting.js
@@ -11,7 +11,7 @@ import SpellLink from 'common/SpellLink';
 class AlwaysBeCasting extends CoreAlwaysBeCasting {
   static ABILITIES_ON_GCD = [
     SPELLS.FROSTBOLT.id,
-    SPELLS.ICE_LANCE.id,
+    SPELLS.ICE_LANCE_CAST.id,
     SPELLS.FROZEN_ORB.id,
     SPELLS.FROST_NOVA.id,
     SPELLS.BLINK.id,

--- a/src/Parser/FrostMage/Modules/Features/CastEfficiency.js
+++ b/src/Parser/FrostMage/Modules/Features/CastEfficiency.js
@@ -32,7 +32,7 @@ class CastEfficiency extends CoreCastEfficiency {
       noCanBeImproved: true,
     },
     {
-      spell: SPELLS.ICE_LANCE,
+      spell: SPELLS.ICE_LANCE_CAST,
       category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
       getCooldown: haste => null,
     },

--- a/src/Parser/FrostMage/Modules/Features/WintersChill.js
+++ b/src/Parser/FrostMage/Modules/Features/WintersChill.js
@@ -19,7 +19,7 @@ class WintersChillTracker extends Module {
   iceLanceCasts = 0;
 
   on_byPlayer_damage(event) {
-    if (event.ability.guid !== SPELLS.ICE_LANCE.id) {
+    if (event.ability.guid !== SPELLS.ICE_LANCE2.id) {
       return;
     }
     const enemy = this.enemies.getEntity(event);

--- a/src/Parser/FrostMage/Modules/Features/WintersChill.js
+++ b/src/Parser/FrostMage/Modules/Features/WintersChill.js
@@ -19,7 +19,7 @@ class WintersChillTracker extends Module {
   iceLanceCasts = 0;
 
   on_byPlayer_damage(event) {
-    if (event.ability.guid !== SPELLS.ICE_LANCE2.id) {
+    if (event.ability.guid !== SPELLS.ICE_LANCE_DAMAGE.id) {
       return;
     }
     const enemy = this.enemies.getEntity(event);
@@ -38,8 +38,8 @@ class WintersChillTracker extends Module {
     const missed = this.wintersChillApplied - this.iceLanceCasts;
     when(missed).isGreaterThan(0)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span> You failed to Shatter {this.missed} <SpellLink id={SPELLS.WINTERS_CHILL.id}/>.  Make sure you cast <SpellLink id={SPELLS.ICE_LANCE.id}/> after each <SpellLink id={SPELLS.FLURRY.id}/> so Ice Lance can benefit from the <SpellLink id={SPELLS.SHATTER.id}/> Bonus.</span>)
-          .icon(SPELLS.ICE_LANCE.icon)
+        return suggest(<span> You failed to Shatter {this.missed} <SpellLink id={SPELLS.WINTERS_CHILL.id}/>.  Make sure you cast <SpellLink id={SPELLS.ICE_LANCE_CAST.id}/> after each <SpellLink id={SPELLS.FLURRY.id}/> so Ice Lance can benefit from the <SpellLink id={SPELLS.SHATTER.id}/> Bonus.</span>)
+          .icon(SPELLS.ICE_LANCE_CAST.icon)
           .actual(`${formatNumber(this.missed)} Winter's Chill not Shattered`)
           .recommended(`${formatNumber(recommended)} is recommended`)
           .regular(recommended + 1).major(recommended + 3);

--- a/src/common/SPELLS_MAGE.js
+++ b/src/common/SPELLS_MAGE.js
@@ -58,12 +58,12 @@ export default {
 	  name: 'Frostbolt',
 	  icon: 'spell_frost_frostbolt02',
   },
-  ICE_LANCE: {
+  ICE_LANCE_CAST: {
     id: 30455,
     name: 'Ice Lance',
     icon: 'spell_frost_frostblast',
   },
-  ICE_LANCE2: {
+  ICE_LANCE_DAMAGE: {
 	  id: 228598,
 	  name: 'Ice Lance',
 	  icon: 'spell_frost_frostblast',

--- a/src/common/SPELLS_MAGE.js
+++ b/src/common/SPELLS_MAGE.js
@@ -59,6 +59,11 @@ export default {
 	  icon: 'spell_frost_frostbolt02',
   },
   ICE_LANCE: {
+    id: 30455,
+    name: 'Ice Lance',
+    icon: 'spell_frost_frostblast',
+  },
+  ICE_LANCE2: {
 	  id: 228598,
 	  name: 'Ice Lance',
 	  icon: 'spell_frost_frostblast',


### PR DESCRIPTION
The Ice Lance ID that Winter's Chill was using was different than the ID that was being used in Cast Efficiency and Always Be Casting. As a result, Cast Efficiency said there were 0 casts of Ice Lance and Always Be Casting said that the Dead Time was high.