### PR TITLE
[Marksmanship] Adding our execute into Cooldowntracker for now

### DIFF
--- a/src/Parser/MarksmanshipHunter/CombatLogParser.js
+++ b/src/Parser/MarksmanshipHunter/CombatLogParser.js
@@ -38,17 +38,16 @@ class CombatLogParser extends CoreCombatLogParser {
     cooldownTracker: CooldownTracker,
     vulnerabluptime: VulnerableUptime,
     vulnerableTracker: VulnerableTracker,
-    
+
     //Focus Chart
     focusTracker: FocusTracker,
 
     //Items
     tier20_2p: Tier20_2p,
     tier20_4p: Tier20_4p,
-    
+
     //Spells
     trueshot: Trueshot,
-
 
   };
 

--- a/src/Parser/MarksmanshipHunter/Modules/Features/AimedInVulnerableTracker.js
+++ b/src/Parser/MarksmanshipHunter/Modules/Features/AimedInVulnerableTracker.js
@@ -35,7 +35,7 @@ class AimedInVulnerableTracker extends Module {
     const percentAimedOutsideVulnerable = this.outsideVulnerabilityAimed / this.totalAimed;
     when(percentAimedOutsideVulnerable).isGreaterThan(0.02)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span> You have casted {this.outsideVulnerabilityAimed} <SpellLink id={SPELLS.AIMED_SHOT.id} />s outside <SpellLink id={SPELLS.VULNERABLE.id} />. Try and minimize these, as they deal significantly less damage than their <SpellLink id={SPELLS.VULNERABLE.id} /> counterparts. It should be noted that rarely, you will be casting non-vulnerable aimeds due to no procs and/or focus capping. </span>)
+        return suggest(<span> You cast {this.outsideVulnerabilityAimed} <SpellLink id={SPELLS.AIMED_SHOT.id} />s outside <SpellLink id={SPELLS.VULNERABLE.id} />. Try and minimize these, as they deal significantly less damage than their <SpellLink id={SPELLS.VULNERABLE.id} /> counterparts. It should be noted that rarely, you will be casting non-vulnerable aimeds due to no procs and/or focus capping. </span>)
           .icon(SPELLS.AIMED_SHOT.icon)
           .actual(`${formatPercentage(actual)}% of total Aimed Shots were outside Vulnerable`)
           .recommended(`<${formatPercentage(recommended)}% is recommended, with 0% being the ideal`)

--- a/src/Parser/MarksmanshipHunter/Modules/Features/CooldownTracker.js
+++ b/src/Parser/MarksmanshipHunter/Modules/Features/CooldownTracker.js
@@ -11,6 +11,12 @@ class CooldownTracker extends CoreCooldownTracker {
         BUILT_IN_SUMMARY_TYPES.DAMAGE,
       ],
     },
+    {
+      spell: SPELLS.BULLSEYE_BUFF,
+      summary: [
+        BUILT_IN_SUMMARY_TYPES.DAMAGE,
+      ],
+    },
   ];
 
   static ignoredSpells = [


### PR DESCRIPTION
I added a minor grammar fix to a module and added our execute into our cooldown window until I figure out a better way of dealing with it (some sort of graph/tab + tracking of buffstacks) - but for now, the information is accessible and good to see if you let your execute buff drop over the encounter. 

Example: 
![image](https://user-images.githubusercontent.com/29204244/31495062-553880c6-af56-11e7-800e-90130e14976f.png)
