### PR TITLE
[Guardian] Fix display bugs in Ironfur and Frenzied Regen modules

### DIFF
--- a/src/Parser/GuardianDruid/Modules/Features/FrenziedRegenGoEProcs.js
+++ b/src/Parser/GuardianDruid/Modules/Features/FrenziedRegenGoEProcs.js
@@ -21,6 +21,9 @@ class FrenziedRegenGoEProcs extends Module {
   statistic() {
     const nonGoEFRegen = this.guardianOfElune.nonGoEFRegen;
     const GoEFRegen = this.guardianOfElune.GoEFRegen;
+    if (nonGoEFRegen + GoEFRegen === 0) {
+      return null;
+    }
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.FRENZIED_REGENERATION.id} />}

--- a/src/Parser/GuardianDruid/Modules/Features/FrenziedRegenGoEProcs.js
+++ b/src/Parser/GuardianDruid/Modules/Features/FrenziedRegenGoEProcs.js
@@ -21,7 +21,7 @@ class FrenziedRegenGoEProcs extends Module {
   statistic() {
     const nonGoEFRegen = this.guardianOfElune.nonGoEFRegen;
     const GoEFRegen = this.guardianOfElune.GoEFRegen;
-    if (nonGoEFRegen + GoEFRegen === 0) {
+    if ((nonGoEFRegen + GoEFRegen) === 0) {
       return null;
     }
     return (

--- a/src/Parser/GuardianDruid/Modules/Spells/IronFur.js
+++ b/src/Parser/GuardianDruid/Modules/Spells/IronFur.js
@@ -118,7 +118,7 @@ class IronFur extends Module {
   }
 
   get hitsUnmitigated() {
-    return this._hitsPerStack[0];
+    return this._hitsPerStack[0] || 0;
   }
 
   get ironfurStacksApplied() {
@@ -172,7 +172,7 @@ class IronFur extends Module {
   statistic() {
     const totalIronFurTime = this.combatants.selected.getBuffUptime(SPELLS.IRONFUR.id);
     const uptimes = this.computeIronfurUptimeArray().reduce((str, uptime, stackCount) => (
-      str + `<li>${stackCount} stacks: ${formatPercentage(uptime)}%</li>`
+      str + `<li>${stackCount} stack${stackCount !== 1 ? 's' : ''}: ${formatPercentage(uptime)}%</li>`
     ), '');
 
     return (


### PR DESCRIPTION
 - Unbuffed Frenzied Regeneration statistic hides itself if there are 0 FR casts
 - Ironfur stack count returns 0 instead of undefined if there are no hits registered at 0 stacks
 - `1 stacks` -> `1 stack` in Ironfur statistic