### PR TITLE
[frost mage] Fixes to Tier20_2set and ShardOfTheExodar

### DIFF
--- a/src/Parser/FrostMage/Modules/Items/ShardOfTheExodar.js
+++ b/src/Parser/FrostMage/Modules/Items/ShardOfTheExodar.js
@@ -37,6 +37,12 @@ class ShardOfTheExodar extends Module {
     }
   }
 
+  on_toPlayer_refreshbuff(event) {
+    if (BLOODLUST_BUFFS.some(buff => event.ability.guid === buff)) {
+      this.actualCasts += 1;
+    }
+  }
+
   item() {
     const fightInSeconds = this.owner.fightDuration / 1000;
     const teamCasts = 1 + Math.floor(fightInSeconds / TEAM_COOLDOWN);

--- a/src/Parser/FrostMage/Modules/Items/ShardOfTheExodar.js
+++ b/src/Parser/FrostMage/Modules/Items/ShardOfTheExodar.js
@@ -15,13 +15,16 @@ const BLOODLUST_BUFFS = [
   SPELLS.DRUMS_OF_THE_MOUNTAIN.id,
 ];
 
+const TEAM_COOLDOWN = 600;
+const PERSONAL_COOLDOWN = 300;
+const DURATION = 40;
+
 class ShardOfTheExodar extends Module {
 
   static dependencies = {
 		combatants: Combatants,
 	};
 
-	possibleCasts = 0;
   actualCasts = 0;
 
   on_initialized() {
@@ -35,14 +38,13 @@ class ShardOfTheExodar extends Module {
   }
 
   item() {
-    if (this.owner.fightDuration / 1000 > 330) {
-      this.possibleCasts = 3;
-    } else {
-      this.possibleCasts = 2;
-    }
+    const fightInSeconds = this.owner.fightDuration / 1000;
+    const teamCasts = 1 + Math.floor(fightInSeconds / TEAM_COOLDOWN);
+    const personalCasts = 1 + Math.floor((fightInSeconds - DURATION) / PERSONAL_COOLDOWN);
+    const possibleCasts = teamCasts + personalCasts;
     return {
       item: ITEMS.SHARD_OF_THE_EXODAR,
-      result: `Gained Lust ${formatNumber(this.actualCasts)} Times. (${formatNumber(this.possibleCasts)} Possible)`,
+      result: `Gained Time Warp effect ${formatNumber(this.actualCasts)} Times. (${formatNumber(possibleCasts)} Possible)`,
     };
   }
 }

--- a/src/Parser/FrostMage/Modules/Items/Tier20_2set.js
+++ b/src/Parser/FrostMage/Modules/Items/Tier20_2set.js
@@ -3,7 +3,6 @@ import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import Combatants from 'Parser/Core/Modules/Combatants';
-import { formatNumber } from 'common/format';
 import Module from 'Parser/Core/Module';
 import HIT_TYPES from 'Parser/Core/HIT_TYPES';
 import getDamageBonus from '../MageCore/GetDamageBonus';
@@ -32,10 +31,10 @@ class Tier20_2set extends Module {
 
   item() {
     return {
-      id: `spell-${SPELLS.FROZEN_MASS.id}`,
+      id: `${SPELLS.FROZEN_MASS.id}`,
       icon: <SpellIcon id={SPELLS.FROZEN_MASS.id} />,
       title: <SpellLink id={SPELLS.FROZEN_MASS.id} />,
-      result: `${formatNumber(this.damage)} damage - ${this.owner.formatItemDamageDone(this.damage)}`,
+      result: `${this.owner.formatItemDamageDone(this.damage)}`,
     };
   }
 }


### PR DESCRIPTION
In Tier20_2set fixed incorrectly defined id, standardized result format.

In ShardOfTheExodar made 'possible lusts' calculation correct for fights longer than 10 minutes.