### PR TITLE
Add Concordance of the Legionfall uptime tracker

### DIFF
--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -48,7 +48,7 @@ import TomeOfUnravelingSanity from './Modules/Items/TomeOfUnravelingSanity';
 import InfernalCinders from './Modules/Items/InfernalCinders';
 import UmbralMoonglaives from './Modules/Items/UmbralMoonglaives';
 
-import Concordance from './Modules/Concordance';
+import ConcordanceUptimeTracker from './Modules/ConcordanceUptimeTracker';
 
 // Shared Buffs
 import VantusRune from './Modules/VantusRune';
@@ -126,7 +126,7 @@ class CombatLogParser {
     tomeOfUnravelingSanity: TomeOfUnravelingSanity,
     
     // Concordance of the Legionfall
-    concordance: Concordance,
+    concordanceUptimeTracker: ConcordanceUptimeTracker,
     // Netherlight Crucible Traits
     darkSorrows: DarkSorrows,
     tormentTheWeak: TormentTheWeak,

--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -48,6 +48,8 @@ import TomeOfUnravelingSanity from './Modules/Items/TomeOfUnravelingSanity';
 import InfernalCinders from './Modules/Items/InfernalCinders';
 import UmbralMoonglaives from './Modules/Items/UmbralMoonglaives';
 
+import Concordance from './Modules/Concordance';
+
 // Shared Buffs
 import VantusRune from './Modules/VantusRune';
 
@@ -122,7 +124,9 @@ class CombatLogParser {
     spectralThurible: SpectralThurible,
     terrorFromBelow: TerrorFromBelow,
     tomeOfUnravelingSanity: TomeOfUnravelingSanity,
-
+    
+    // Concordance of the Legionfall
+    concordance: Concordance,
     // Netherlight Crucible Traits
     darkSorrows: DarkSorrows,
     tormentTheWeak: TormentTheWeak,

--- a/src/Parser/Core/Modules/Concordance.js
+++ b/src/Parser/Core/Modules/Concordance.js
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import { formatPercentage } from 'common/format';
+
+import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+
+const debug = false;
+const CONCORDANCE_SPELLS = {
+  INTELLECT: SPELLS.CONCORDANCE_OF_THE_LEGIONFALL_INTELLECT,
+  AGILITY: SPELLS.CONCORDANCE_OF_THE_LEGIONFALL_AGILITY,
+  STRENGTH: SPELLS.CONCORDANCE_OF_THE_LEGIONFALL_STRENGTH,
+  VERSATILITY: SPELLS.CONCORDANCE_OF_THE_LEGIONFALL_VERSATILITY,
+};
+class Concordance extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  appliedBuff = null;
+  statisticOrder = STATISTIC_ORDER.TRAITS(0);
+
+  statistic() {
+    const rank = this.combatants.selected.traitsBySpellId[SPELLS.CONCORDANCE_OF_THE_LEGIONFALL_TRAIT.id];
+    Object.values(CONCORDANCE_SPELLS).forEach(item => {
+      const uptime = this.combatants.selected.getBuffUptime(item.id) / this.owner.fightDuration;
+      if (uptime > 0) {
+        this.appliedBuff = {
+          id: item.id,
+          uptime: uptime,
+        };
+      }
+    });
+  
+    if (!this.appliedBuff) {
+      return;
+    }
+
+    if (debug) {
+      console.log("Concordance: Rank", rank, "; Uptime: ", this.appliedBuff.uptime);
+    }
+    return (
+      <StatisticBox
+      icon={<SpellIcon id={this.appliedBuff.id} />}
+      value={`${formatPercentage(this.appliedBuff.uptime)}%`}
+      label='Concordance of the Legionfall uptime'
+      tooltip={`Rank ${rank}`}
+    />);
+  }
+}
+
+export default Concordance;

--- a/src/Parser/Core/Modules/ConcordanceUptimeTracker.js
+++ b/src/Parser/Core/Modules/ConcordanceUptimeTracker.js
@@ -21,34 +21,41 @@ class ConcordanceUptimeTracker extends Module {
     combatants: Combatants,
   };
 
-  appliedBuff = null;
   statisticOrder = STATISTIC_ORDER.TRAITS(0);
 
-  statistic() {
-    const rank = this.combatants.selected.traitsBySpellId[SPELLS.CONCORDANCE_OF_THE_LEGIONFALL_TRAIT.id];
+  get rank () {
+    return this.combatants.selected.traitsBySpellId[SPELLS.CONCORDANCE_OF_THE_LEGIONFALL_TRAIT.id];
+  }
+  
+  get appliedBuff () {
+    let buff = null;
     Object.values(CONCORDANCE_SPELLS).forEach(item => {
       const uptime = this.combatants.selected.getBuffUptime(item.id) / this.owner.fightDuration;
       if (uptime > 0) {
-        this.appliedBuff = {
+        buff = {
           id: item.id,
           uptime: uptime,
         };
       }
     });
-  
+
+    return buff;
+  }
+
+  statistic() {
     if (!this.appliedBuff) {
       return;
     }
 
     if (debug) {
-      console.log("Concordance: Rank", rank, "; Uptime: ", this.appliedBuff.uptime);
+      console.log("Concordance: Rank", this.rank, "; Uptime: ", this.appliedBuff.uptime);
     }
     return (
       <StatisticBox
       icon={<SpellIcon id={this.appliedBuff.id} />}
       value={`${formatPercentage(this.appliedBuff.uptime)}%`}
       label='Concordance of the Legionfall uptime'
-      tooltip={`Rank ${rank}`}
+      tooltip={`Rank ${this.rank}`}
     />);
   }
 }

--- a/src/Parser/Core/Modules/ConcordanceUptimeTracker.js
+++ b/src/Parser/Core/Modules/ConcordanceUptimeTracker.js
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
-import SpellLink from 'common/SpellLink';
-import { formatPercentage } from 'common/format';
-
 import Module from 'Parser/Core/Module';
 import Combatants from 'Parser/Core/Modules/Combatants';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import { formatPercentage } from 'common/format';
+
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 const debug = false;
@@ -16,7 +16,7 @@ const CONCORDANCE_SPELLS = {
   STRENGTH: SPELLS.CONCORDANCE_OF_THE_LEGIONFALL_STRENGTH,
   VERSATILITY: SPELLS.CONCORDANCE_OF_THE_LEGIONFALL_VERSATILITY,
 };
-class Concordance extends Module {
+class ConcordanceUptimeTracker extends Module {
   static dependencies = {
     combatants: Combatants,
   };
@@ -53,4 +53,4 @@ class Concordance extends Module {
   }
 }
 
-export default Concordance;
+export default ConcordanceUptimeTracker;

--- a/src/common/SPELLS_DEMON_HUNTER.js
+++ b/src/common/SPELLS_DEMON_HUNTER.js
@@ -287,11 +287,6 @@ export default {
     name: 'Charred Warblades',
     icon: 'spell_fire_incinerate',
   },
-  CONCORDANCE_OF_THE_LEGIONFALL: {
-    id: 239042,
-    name: 'Concordance of the Legionfall',
-    icon: 'trade_archaeology_shark-jaws',
-  },
   DEFENSIVE_SPIKES: {
     id: 212829,
     name: 'Defensive Spikes',

--- a/src/common/SPELLS_OTHERS.js
+++ b/src/common/SPELLS_OTHERS.js
@@ -446,9 +446,29 @@ export default {
     name: 'Dark Sorrows',
     icon: 'inv_heart_of_the_thunder-king_icon',
   },
+  CONCORDANCE_OF_THE_LEGIONFALL_TRAIT: {
+    id: 239042,
+    name: 'Concordance of the Legionfall',
+    icon: 'trade_archaeology_shark-jaws',
+  },
   CONCORDANCE_OF_THE_LEGIONFALL_INTELLECT: {
     id: 242586,
     name: 'Concordance of the Legionfall',
     icon: 'achievement_faction_legionfall',
   },
+  CONCORDANCE_OF_THE_LEGIONFALL_STRENGTH: {
+    id: 242583,
+    name: 'Concordance of the Legionfall',
+    icon: 'achievement_faction_legionfall',
+  },
+  CONCORDANCE_OF_THE_LEGIONFALL_AGILITY: {
+    id: 242584,
+    name: 'Concordance of the Legionfall',
+    icon: 'achievement_faction_legionfall',
+  },
+  CONCORDANCE_OF_THE_LEGIONFALL_VERSATILITY: {
+    id: 243096,
+    name: 'Concordance of the Legionfall',
+    icon: 'achievement_faction_legionfall',
+  }
 };

--- a/src/common/SPELLS_OTHERS.js
+++ b/src/common/SPELLS_OTHERS.js
@@ -470,5 +470,5 @@ export default {
     id: 243096,
     name: 'Concordance of the Legionfall',
     icon: 'achievement_faction_legionfall',
-  }
+  },
 };


### PR DESCRIPTION
Adds a small tracker for the uptime of the Concordance of the Legionfall buff.
![image](https://user-images.githubusercontent.com/5927637/31575983-5a2fc45c-b0f2-11e7-82d5-b9266d86aa50.png)


Should resolve issue #31 

To-do:
- [ ] Check wording for the box and tooltip
- [ ] Check if these values are the ones that should be displayed