### PR TITLE
[MMS HUNTER] Added Focus Capped Statisticbox

### DIFF
--- a/src/Parser/MarksmanshipHunter/CHANGELOG.js
+++ b/src/Parser/MarksmanshipHunter/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+14-10-2017 - Added Focus Capped Statistic Box (By leapis)
 08-10-2017 - Added FocusTracker Module and FocusTracker Graph module and additional supporting modules (By leapis)
 05-10-2017 - remove Cyclonic Burst from Cooldown view. (by Putro) 
 05-10-2017 - Added Artifact Trait cooldown reduction for trueshot. (by Putro) 

--- a/src/Parser/MarksmanshipHunter/CombatLogParser.js
+++ b/src/Parser/MarksmanshipHunter/CombatLogParser.js
@@ -13,6 +13,7 @@ import CooldownTracker from './Modules/Features/CooldownTracker';
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
 import VulnerableUptime from './Modules/Features/VulnerableUptime';
 import VulnerableTracker from './Modules/Features/AimedInVulnerableTracker';
+import TimeFocusCapped from './Modules/Features/TimeFocusCapped';
 
 //Focus Chart
 import FocusChart from './Modules/FocusChart/Focus';
@@ -38,6 +39,7 @@ class CombatLogParser extends CoreCombatLogParser {
     cooldownTracker: CooldownTracker,
     vulnerabluptime: VulnerableUptime,
     vulnerableTracker: VulnerableTracker,
+    TimeFocusCapped: TimeFocusCapped,
 
     //Focus Chart
     focusTracker: FocusTracker,

--- a/src/Parser/MarksmanshipHunter/Modules/Features/TimeFocusCapped.js
+++ b/src/Parser/MarksmanshipHunter/Modules/Features/TimeFocusCapped.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Module from 'Parser/Core/Module';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Icon from 'common/Icon';
+import { formatPercentage } from 'common/format';
 
 import FocusTracker from '../FocusChart/FocusTracker';
 
@@ -20,13 +21,13 @@ class TimeFocusCapped extends Module {
 
   statistic() {
     const totalFocusWaste = this.getTotalWaste;
-    const percentCapped = Math.round(this.focusTracker.secondsCapped/(this.owner.fightDuration/1000) * 10000)/100;
+    const percentCapped = formatPercentage(this.focusTracker.secondsCapped/(this.owner.fightDuration/1000));
     return (
       <StatisticBox
         icon = {<Icon icon='ability_hunter_focusfire' alt = 'Focus Wasted' />}
         label = 'Time Focus Capped'
         tooltip= {`You wasted <b> ${totalFocusWaste}  </b> focus. <br /> 
-        That's <b>  ${formatPercentage(totalFocusWaste/(this.owner.fightDuration/1000 * this.focusTracker.focusGen) * 10000)/100}% </b> of your total focus generated. 
+        That's <b>  ${formatPercentage(totalFocusWaste/(this.owner.fightDuration/1000 * this.focusTracker.focusGen))}% </b> of your total focus generated. 
         <br /> For more details, see the Focus Chart tab.`}
         value =  {`${percentCapped} %`}
       //Time not Focus-Capped: {Math.round((this.owner.fightDuration / 1000 - this.focusTracker.secondsCapped) * 100) / 100}s / {Math.floor(this.owner.fightDuration / 1000)}

--- a/src/Parser/MarksmanshipHunter/Modules/Features/TimeFocusCapped.js
+++ b/src/Parser/MarksmanshipHunter/Modules/Features/TimeFocusCapped.js
@@ -1,0 +1,103 @@
+import React from 'react';
+import {HorizontalBar} from 'react-chartjs-2';
+import Module from 'Parser/Core/Module';
+import StatisticsListBox, { STATISTIC_ORDER } from 'Main/StatisticsListBox';
+
+import FocusTracker from '../FocusChart/FocusTracker';
+
+class TimeFocusCapped extends Module {
+  static dependencies = {
+    focusTracker: FocusTracker,
+  };
+  centerStyle = {textAlign:'center'};
+
+  getData(){
+    this.cData = {
+      labels: [''],
+      datasets: [
+        {
+          label: 'Time Not Focus Capped',
+          backgroundColor: 'rgba(127,255,0,1)',
+          borderColor: 'rgba(0,0,0,1)',
+          borderWidth: 2,
+
+          data: [Math.round((this.owner.fightDuration / 1000)-this.focusTracker.secondsCapped)],
+        },
+        {
+          label: 'test2',
+          backgroundColor: 'rgba(255,255,255,1)',
+          borderColor: 'rgba(0,0,0,1)',
+          borderWidth: 2,
+
+          data: [Math.round(this.focusTracker.secondsCapped)],
+        },
+      ],
+    };
+    this.cOptions = {
+      scaleBeginAtZero: true,
+      tooltips:{
+        enabled: false,
+      },
+      legend: {
+        display: false,
+      },
+      scales: {
+        xAxes: [{
+          gridlines:{
+            display:false,
+          },
+          ticks:{
+            display:false,
+            max: Math.ceil(this.owner.fightDuration / 1000),
+          },  
+          barPercentage: 1,
+          categoryPercentage: 1,
+          stacked: true,
+        }],
+        yAxes: [{
+          gridlines:{
+            display:false,
+          },  
+          ticks:{
+            display:false,
+          }, 
+          barPercentage: 1,
+          categoryPercentage: 1,
+          stacked: true,  
+        }],
+      },
+    };
+    
+  }
+
+  chartData(){
+    this.getData();
+    return(
+      <HorizontalBar 
+        data = {this.cData}
+        height = {15}
+        width = {75}
+        options = {this.cOptions}
+      />
+    );
+  }
+
+  statistic() {
+    const tooltipData = "You wasted " + Math.round(this.focusTracker.secondsCapped) + " seconds focus capped. <br /> That's approx. " + Math.round(this.focusTracker.secondsCapped/(this.owner.fightDuration/1000) * 100) + "% of the fight. <br /> For more details, see the Focus Chart tab.";
+    return (
+      <StatisticsListBox
+        title="FOCUS-CAPPED"
+        tooltip= {tooltipData}
+      >
+      <div style = {this.centerStyle}>
+      Time not Focus-Capped: {Math.round((this.owner.fightDuration / 1000 - this.focusTracker.secondsCapped) * 100) / 100}s / {Math.floor(this.owner.fightDuration / 1000)}s
+      </div>
+      {this.chartData()}
+      </StatisticsListBox>
+    );
+  }
+
+  statisticOrder = STATISTIC_ORDER.CORE(4);
+}
+
+export default TimeFocusCapped;

--- a/src/Parser/MarksmanshipHunter/Modules/Features/TimeFocusCapped.js
+++ b/src/Parser/MarksmanshipHunter/Modules/Features/TimeFocusCapped.js
@@ -39,14 +39,14 @@ class TimeFocusCapped extends Module {
           style={{ width: `${(100-percentCapped)}%` }}
           data-tip={`You spent <b>${100-percentCapped}%</b> of your time, or <b>${Math.round(Math.floor(this.owner.fightDuration/1000) - this.focusTracker.secondsCapped)}s</b> under the focucs cap.`}
         >
-          <img src="/img/sword.png" alt="Non-heal cast time" />
+          <img src="/img/sword.png" alt="Time not focus capped" />
         </div>
           <div
             className="stat-overhealing-bg"
             style={{ width: `${percentCapped}%` }}
             data-tip={`You spent <b>${percentCapped}%</b>, or <b>${Math.round(this.focusTracker.secondsCapped)}s</b> of your time focus Capped.`}
           >
-            <img src="/img/afk.png" alt="Healing time" />
+            <img src="/img/afk.png" alt="Time focus capped" />
           </div>
         </div>
       )}

--- a/src/Parser/MarksmanshipHunter/Modules/Features/TimeFocusCapped.js
+++ b/src/Parser/MarksmanshipHunter/Modules/Features/TimeFocusCapped.js
@@ -10,43 +10,39 @@ class TimeFocusCapped extends Module {
     focusTracker: FocusTracker,
   };
 
-  getTotalWaste(){
+  get getTotalWaste(){
     let waste = this.focusTracker.secondsCapped * this.focusTracker.focusGen;
     if (this.focusTracker.generatorCasts) {
-      Object.keys(this.focusTracker.activeFocusWasted).forEach((generator) => {
-        waste += this.focusTracker.activeFocusWasted[generator];
-
-      });
+      waste += Object.values(this.focusTracker.activeFocusWasted).reduce((sum, waste) => sum + waste, 0);
     }
     return Math.round(waste);
   }
 
   statistic() {
-    const totalFocusWaste = this.getTotalWaste();
-    const tooltipData = "You wasted <b>" + totalFocusWaste + " </b> focus. <br /> That's <b>" + Math.round(totalFocusWaste/(this.owner.fightDuration/1000 * this.focusTracker.focusGen) * 10000)/100 + "% </b> of your total focus generated. <br /> For more details, see the Focus Chart tab.";
+    const totalFocusWaste = this.getTotalWaste;
     const percentCapped = Math.round(this.focusTracker.secondsCapped/(this.owner.fightDuration/1000) * 10000)/100;
     return (
       <StatisticBox
         icon = {<Icon icon='ability_hunter_focusfire' alt = 'Focus Wasted' />}
-        label = {'Time Focus Capped'}
-        tooltip= {tooltipData}
-        value =  {percentCapped + " %"}
+        label = 'Time Focus Capped'
+        tooltip= {`You wasted <b> ${totalFocusWaste}  </b> focus. <br /> 
+        That's <b>  ${formatPercentage(totalFocusWaste/(this.owner.fightDuration/1000 * this.focusTracker.focusGen) * 10000)/100}% </b> of your total focus generated. 
+        <br /> For more details, see the Focus Chart tab.`}
+        value =  {`${percentCapped} %`}
       //Time not Focus-Capped: {Math.round((this.owner.fightDuration / 1000 - this.focusTracker.secondsCapped) * 100) / 100}s / {Math.floor(this.owner.fightDuration / 1000)}
       footer={(
         <div className="statistic-bar">
         <div
           className="stat-health-bg"
           style={{ width: `${(100-percentCapped)}%` }}
-          data-tip={`You spent <b>${100-percentCapped}%</b> of your time, or <b>${Math.round(Math.floor(this.owner.fightDuration/1000) - this.focusTracker.secondsCapped)}s</b> under the focucs cap.`}
+          data-tip={`You spent <b>${100-percentCapped}%</b> of your time, or <b>${Math.round(Math.floor(this.owner.fightDuration/1000) - this.focusTracker.secondsCapped)}s</b> under the focus cap.`}
         >
-          <img src="/img/sword.png" alt="Time not focus capped" />
         </div>
           <div
             className="stat-overhealing-bg"
             style={{ width: `${percentCapped}%` }}
-            data-tip={`You spent <b>${percentCapped}%</b>, or <b>${Math.round(this.focusTracker.secondsCapped)}s</b> of your time focus Capped.`}
+            data-tip={`You spent <b>${percentCapped}%</b>, or <b>${Math.round(this.focusTracker.secondsCapped)}s</b> of your time focus capped.`}
           >
-            <img src="/img/afk.png" alt="Time focus capped" />
           </div>
         </div>
       )}

--- a/src/Parser/MarksmanshipHunter/Modules/FocusChart/FocusTracker.js
+++ b/src/Parser/MarksmanshipHunter/Modules/FocusChart/FocusTracker.js
@@ -104,7 +104,7 @@ class FocusTracker extends Module {
   }
 
   extrapolateFocus(event) {
-    const focusGenerationPerSecond = Math.round((10 + .1 * this.combatants.selected.hasteRating / 375) * 100) / 100;
+    this.focusGen = Math.round((10 + .1 * this.combatants.selected.hasteRating / 375) * 100) / 100;
     this.secondsCapped = 0;
     const maxFocus = this._maxFocus;
     this.focusBySecond[0] = maxFocus;
@@ -114,7 +114,7 @@ class FocusTracker extends Module {
           this.focusBySecond[i] = maxFocus;
         }
         else {
-          this.focusBySecond[i] = this.focusBySecond[i - 1] + focusGenerationPerSecond / 1000;
+          this.focusBySecond[i] = this.focusBySecond[i - 1] + this.focusGen / 1000;
         }
       }
       if (this.focusBySecond[i] - maxFocus > 0) {


### PR DESCRIPTION
Added a statisticbox for the focus tracking module. Right now it doesn't have a suggestion yet, but Putro has confirmed that he'll take care of that (and he has the best numbers for it, too). 

Screenshots:

![image](https://user-images.githubusercontent.com/28397721/31577509-c8bbdd08-b0dd-11e7-8022-2f4b5a3d692e.png)


![image](https://user-images.githubusercontent.com/28397721/31577507-bf6308c6-b0dd-11e7-9f8d-50d74c9ac084.png)
