### PR TITLE
[Windwalker] Updated AlwaysBeCasting

### DIFF
--- a/src/Parser/WindwalkerMonk/CombatLogParser.js
+++ b/src/Parser/WindwalkerMonk/CombatLogParser.js
@@ -21,7 +21,7 @@ import StormEarthAndFire from './Modules/Spells/StormEarthAndFire';
 import HitCombo from './Modules/Talents/HitCombo';
 
 // Legendaries
-import Katsuos from './Modules/Items/Katsuos';
+import KatsuosEclipse from './Modules/Items/KatsuosEclipse';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -40,7 +40,7 @@ class CombatLogParser extends CoreCombatLogParser {
     stormEarthAndFire: StormEarthAndFire,
 
     // Legendaries / Items:
-    katsuos: Katsuos,
+    katsuosEclipse: KatsuosEclipse,
 
   };
 

--- a/src/Parser/WindwalkerMonk/Modules/Items/KatsuosEclipse.js
+++ b/src/Parser/WindwalkerMonk/Modules/Items/KatsuosEclipse.js
@@ -4,7 +4,7 @@ import Module from 'Parser/Core/Module';
 
 import Combatants from 'Parser/Core/Modules/Combatants';
 
-class Katsuos extends Module {
+class KatsuosEclipse extends Module {
   static dependencies = {
     combatatants: Combatants,
   };
@@ -31,4 +31,4 @@ class Katsuos extends Module {
   }
 }
 
-export default Katsuos;
+export default KatsuosEclipse;

--- a/src/Parser/WindwalkerMonk/Modules/Items/KatsuosEclipse.js
+++ b/src/Parser/WindwalkerMonk/Modules/Items/KatsuosEclipse.js
@@ -26,7 +26,7 @@ class KatsuosEclipse extends Module {
   item() {
     return {
       item: ITEMS.KATSUOS_ECLIPSE,
-      result: `Chi saved: ${this.chiSaved}`,
+      result: `${this.chiSaved} Chi saved`,
     };
   }
 }

--- a/src/Parser/WindwalkerMonk/Modules/Items/KatsuosEclipse.js
+++ b/src/Parser/WindwalkerMonk/Modules/Items/KatsuosEclipse.js
@@ -18,7 +18,7 @@ class KatsuosEclipse extends Module {
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
 
-    if (spellId === SPELLS.FISTS_OF_FURY_CAST.id && !this.combatatants.selected.hasBuff(SPELLS.SERENITY_TALENT.id)) {
+    if (spellId === SPELLS.FISTS_OF_FURY_CAST.id && !this.combatatants.selected.hasBuff(SPELLS.SERENITY_TALENT.id, event.timestamp)) {
       this.chiSaved += 1;
     }
   }

--- a/src/Parser/WindwalkerMonk/Modules/Items/KatsuosEclipse.js
+++ b/src/Parser/WindwalkerMonk/Modules/Items/KatsuosEclipse.js
@@ -18,7 +18,7 @@ class KatsuosEclipse extends Module {
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
 
-    if (spellId === SPELLS.FISTS_OF_FURY_CAST.id &&! this.combatatants.selected.hasBuff(SPELLS.SERENITY_TALENT.id)) {
+    if (spellId === SPELLS.FISTS_OF_FURY_CAST.id && !this.combatatants.selected.hasBuff(SPELLS.SERENITY_TALENT.id)) {
       this.chiSaved += 1;
     }
   }


### PR DESCRIPTION
I tried using the `on_toPlayer_removebuff(event)` as seen in the Shadow Priest Module, but was not getting correct results from it.

Also, since Windwalker is an energy class with a fixed 1 second GCD, should all spells be listed as `STATIC_GCD_ABILITIES` instead of `ABILITIES_ON_GCD`?