### PR TITLE
[fire mage] Fixed minor CastEfficieny issues

### DIFF
--- a/src/Parser/Mage/Fire/Modules/Features/CastEfficiency.js
+++ b/src/Parser/Mage/Fire/Modules/Features/CastEfficiency.js
@@ -73,10 +73,12 @@ class CastEfficiency extends CoreCastEfficiency {
       category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL_AOE,
       getCooldown: haste => 12 / (1 + haste),
 	    isActive: combatant => combatant.hasTalent(SPELLS.LIVING_BOMB_TALENT.id),
+      noSuggestion: true,
+      noCanBeImproved: true,
     },
     {
       spell: SPELLS.CINDERSTORM_TALENT,
-      category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL_AOE,
+      category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
       getCooldown: haste => 9 / (1 + haste),
 	    isActive: combatant => combatant.hasTalent(SPELLS.CINDERSTORM_TALENT.id),
     },


### PR DESCRIPTION
Removed suggestion/canBeImproved from Living Bomb, as it's only supposed to be used in AoE and shouldn't be cast on CD.

Changed classification of Cinderstorm from ROTATIONAL_AOE to ROTATIONAL. When talented, Cinderstorm should be used even on single target.