### PR TITLE
[core] Disabled DistanceMoved module

### DIFF
--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -17,7 +17,7 @@ import Pets from './Modules/Pets';
 import HealEventTracker from './Modules/HealEventTracker';
 import ManaValues from './Modules/ManaValues';
 import SpellManaCost from './Modules/SpellManaCost';
-import DistanceMoved from './Modules/DistanceMoved';
+//import DistanceMoved from './Modules/DistanceMoved';
 
 import CritEffectBonus from './Modules/Helpers/CritEffectBonus';
 import ApplyBuffFixer from './Modules/Helpers/ApplyBuffFixer';
@@ -96,7 +96,7 @@ class CombatLogParser {
     spellUsable: SpellUsable,
     manaValues: ManaValues,
     vantusRune: VantusRune,
-    distanceMoved: DistanceMoved,
+    //distanceMoved: DistanceMoved,
 
     critEffectBonus: CritEffectBonus,
     applyBuffFixer: ApplyBuffFixer,


### PR DESCRIPTION
The numbers from the DistanceMoved module couldn't possibly be correct. I'm consistently seeing reports that the player moved many miles over the course of a few minute fight. This is happening across all logs I see.

This PR simply disables the module until we figure out what's wrong.