### PR TITLE
Fix: Issue #558: Clicking "more information" on an UnsupportedSpec report crashes the app

### DIFF
--- a/src/Parser/UnsupportedSpec/CHANGELOG.js
+++ b/src/Parser/UnsupportedSpec/CHANGELOG.js
@@ -1,0 +1,3 @@
+export default `
+Not Yet Supported
+`;

--- a/src/Parser/UnsupportedSpec/CONFIG.js
+++ b/src/Parser/UnsupportedSpec/CONFIG.js
@@ -1,12 +1,26 @@
 // import SPECS from 'common/SPECS';
+import React from 'react';
 import SPEC_ANALYSIS_COMPLETENESS from 'common/SPEC_ANALYSIS_COMPLETENESS';
 
 import CombatLogParser from './CombatLogParser';
+import CHANGELOG from './CHANGELOG';
 
 export default {
   spec: { id: 0, className: 'Unsupported', specName: 'Spec' }, // SPECS.HOLY_PALADIN,
   maintainer: '@Zerotorescue',
+  description: (
+    <div>
+      You don't need to to do anything special to add a spec. The real issue preventing specs from being added is that in order to add a spec, you need to have the following 3 properties:<br />
+      1. Know the spec well enough to actually create something useful<br />
+      2. Know how to program well enough to implement the analysis<br />
+      3. Have the time and motivation to actually do it<br /><br />
+
+      If you want to give it a try you can find documentation here:{' '}
+      <a href="https://github.com/WoWAnalyzer/WoWAnalyzer/blob/master/README.md">https://github.com/WoWAnalyzer/WoWAnalyzer/blob/master/README.md</a>
+    </div>
+  ),
   completeness: SPEC_ANALYSIS_COMPLETENESS.NOT_YET_SUPPORTED, // When changing this please make a PR with ONLY this value changed, we will do a review of your analysis to find out of it is complete enough.
   parser: CombatLogParser,
+  changelog: CHANGELOG,
   path: __dirname, // used for generating a GitHub link directly to your spec
 };


### PR DESCRIPTION
Implemented a fix for this issue #558. 

This is just a quick fix. I left the current statistics box with the Unsupported Spec information along, as I feel that needs to be front and center.

This just ensures if a user clicks `More Information` the app does not crash.