### PR TITLE
Arms Warrior - Tactician procs value

### DIFF
--- a/src/Parser/Warrior/Arms/CHANGELOG.js
+++ b/src/Parser/Warrior/Arms/CHANGELOG.js
@@ -1,3 +1,4 @@
 export default `
+21-10-2017 - Added tactician procs
 19-10-2017 - Added Arms Warrior Initial Setup. (by TheBadBossy)
 `;

--- a/src/Parser/Warrior/Arms/CONFIG.js
+++ b/src/Parser/Warrior/Arms/CONFIG.js
@@ -20,7 +20,7 @@ export default {
   ),
   // When changing this please make a PR with ONLY this value changed, we will do a review of your analysis to find out of it is complete enough.
   completeness: SPEC_ANALYSIS_COMPLETENESS.NEEDS_MORE_WORK,
-  specDiscussionUrl: 'https://github.com/WoWAnalyzer/WoWAnalyzer/issues/571',
+  specDiscussionUrl: 'https://github.com/WoWAnalyzer/WoWAnalyzer/issues/579',
 
   // Shouldn't have to change these:
   changelog: CHANGELOG,

--- a/src/Parser/Warrior/Arms/CombatLogParser.js
+++ b/src/Parser/Warrior/Arms/CombatLogParser.js
@@ -11,8 +11,8 @@ import CastEfficiency from './Modules/Features/CastEfficiency';
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
 import CooldownTracker from './Modules/Features/CooldownTracker';
 import ColossusSmashUptime from './Modules/BuffDebuff/ColossusSmashUptime';
-import TacticianProcc from './Modules/BuffDebuff/TacticianProc';
-  
+import TacticianProc from './Modules/BuffDebuff/TacticianProc';
+
 
 //import RelicTraits from './Modules/Traits/RelicTraits';
 
@@ -27,7 +27,7 @@ class CombatLogParser extends CoreCombatLogParser {
     alwaysBeCasting: AlwaysBeCasting,
     cooldownTracker: CooldownTracker,
     colossusSmashUptime: ColossusSmashUptime,
-    tacticianProcc: TacticianProcc,
+    tacticianProc: TacticianProc,
 
     // Talents
 

--- a/src/Parser/Warrior/Arms/CombatLogParser.js
+++ b/src/Parser/Warrior/Arms/CombatLogParser.js
@@ -11,6 +11,8 @@ import CastEfficiency from './Modules/Features/CastEfficiency';
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
 import CooldownTracker from './Modules/Features/CooldownTracker';
 import ColossusSmashUptime from './Modules/BuffDebuff/ColossusSmashUptime';
+import TacticianProcc from './Modules/BuffDebuff/TacticianProc';
+  
 
 //import RelicTraits from './Modules/Traits/RelicTraits';
 
@@ -25,6 +27,7 @@ class CombatLogParser extends CoreCombatLogParser {
     alwaysBeCasting: AlwaysBeCasting,
     cooldownTracker: CooldownTracker,
     colossusSmashUptime: ColossusSmashUptime,
+    tacticianProcc: TacticianProcc,
 
     // Talents
 

--- a/src/Parser/Warrior/Arms/Modules/BuffDebuff/ColossusSmashUptime.js
+++ b/src/Parser/Warrior/Arms/Modules/BuffDebuff/ColossusSmashUptime.js
@@ -34,6 +34,7 @@ class ColossusSmashUptime extends Module {
         icon={<SpellIcon id={SPELLS.COLOSSUS_SMASH_DEBUFF.id} />}
         value={`${formatPercentage(colossusSmashUptime)} %`}
         label="Colossus Smash uptime"
+        tooltip={`Colossus Smash increases your dealt damage by 15% + Mastery against that debuffed target.`}
       />
     );
   }

--- a/src/Parser/Warrior/Arms/Modules/BuffDebuff/ColossusSmashUptime.js
+++ b/src/Parser/Warrior/Arms/Modules/BuffDebuff/ColossusSmashUptime.js
@@ -34,7 +34,6 @@ class ColossusSmashUptime extends Module {
         icon={<SpellIcon id={SPELLS.COLOSSUS_SMASH_DEBUFF.id} />}
         value={`${formatPercentage(colossusSmashUptime)} %`}
         label="Colossus Smash uptime"
-        tooltip={`Colossus Smash increases your dealt damage by 15% + Mastery against that debuffed target.`}
       />
     );
   }

--- a/src/Parser/Warrior/Arms/Modules/BuffDebuff/TacticianProc.js
+++ b/src/Parser/Warrior/Arms/Modules/BuffDebuff/TacticianProc.js
@@ -4,17 +4,12 @@ import SpellIcon from 'common/SpellIcon';
 
 import SPELLS from 'common/SPELLS';
 import Module from 'Parser/Core/Module';
-import Combatants from 'Parser/Core/Modules/Combatants';
 
 const debug = false;
 
-class Tactician extends Module {
-  static dependencies = {
-    combatants: Combatants,
-  };
-
-  totalTacticianProccs = 0;
-  lastTacticianTimestamp = 0;
+class TacticianProc extends Module {
+  totalProcs = 0;
+  lastTimestamp = 0;
 
   on_byPlayer_applybuff(event) {
     const spellId = event.ability.guid;
@@ -22,9 +17,9 @@ class Tactician extends Module {
       return;
     }
     // Get the applied timestamp
-    this.lastTacticianTimestamp = event.timestamp;
+    this.lastTimestamp = event.timestamp;
     debug && console.log('Tactician was applied');
-    this.totalTacticianProccs += 1;
+    this.totalProcs += 1;
   }
 
   on_byPlayer_refreshbuff(event) {
@@ -33,22 +28,22 @@ class Tactician extends Module {
       return;
     }
     // Get the applied timestamp
-    this.lastTacticianTimestamp = event.timestamp;
+    this.lastTimestamp = event.timestamp;
     debug && console.log('Tactician was refreshed');
-    this.totalTacticianProccs += 1;
+    this.totalProcs += 1;
   }
 
   statistic() {
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.TACTICIAN.id} />}
-        value={this.totalTacticianProccs}
-        label="Total Tactician Proccs"
-        tooltip={`Tactician resets the cooldown on Colossus Smash and Mortal Strike. You got ${this.totalTacticianProccs} more Mortal Strike and Colossus Smash.`}
+        value={this.totalProcs}
+        label="Total Tactician Procs"
+        tooltip={`Tactician resets the cooldown on Colossus Smash and Mortal Strike. You got ${this.totalProcs} more Mortal Strike and Colossus Smash.`}
       />
     );
   }
   statisticOrder = STATISTIC_ORDER.CORE(20);
 }
 
-export default Tactician;
+export default TacticianProc;

--- a/src/Parser/Warrior/Arms/Modules/BuffDebuff/TacticianProc.js
+++ b/src/Parser/Warrior/Arms/Modules/BuffDebuff/TacticianProc.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import SpellIcon from 'common/SpellIcon';
+
+import SPELLS from 'common/SPELLS';
+import Module from 'Parser/Core/Module';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+const debug = false;
+
+class Tactician extends Module {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  totalTacticianProccs = 0;
+  lastTacticianTimestamp = 0;
+
+  on_byPlayer_applybuff(event) {
+    const spellId = event.ability.guid;
+    if (SPELLS.TACTICIAN.id !== spellId) {
+      return;
+    }
+    // Get the applied timestamp
+    this.lastTacticianTimestamp = event.timestamp;
+    debug && console.log('Tactician was applied');
+    this.totalTacticianProccs += 1;
+  }
+
+  on_byPlayer_refreshbuff(event) {
+    const spellId = event.ability.guid;
+    if (SPELLS.TACTICIAN.id !== spellId) {
+      return;
+    }
+    // Get the applied timestamp
+    this.lastTacticianTimestamp = event.timestamp;
+    debug && console.log('Tactician was refreshed');
+    this.totalTacticianProccs += 1;
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.TACTICIAN.id} />}
+        value={this.totalTacticianProccs}
+        label="Total Tactician Proccs"
+        tooltip={`Tactician resets the cooldown on Colossus Smash and Mortal Strike. You got ${this.totalTacticianProccs} more Mortal Strike and Colossus Smash.`}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(20);
+}
+
+export default Tactician;

--- a/src/Parser/Warrior/Arms/Modules/BuffDebuff/TacticianProc.js
+++ b/src/Parser/Warrior/Arms/Modules/BuffDebuff/TacticianProc.js
@@ -9,15 +9,12 @@ const debug = false;
 
 class TacticianProc extends Module {
   totalProcs = 0;
-  lastTimestamp = 0;
 
   on_byPlayer_applybuff(event) {
     const spellId = event.ability.guid;
     if (SPELLS.TACTICIAN.id !== spellId) {
       return;
     }
-    // Get the applied timestamp
-    this.lastTimestamp = event.timestamp;
     debug && console.log('Tactician was applied');
     this.totalProcs += 1;
   }
@@ -27,8 +24,6 @@ class TacticianProc extends Module {
     if (SPELLS.TACTICIAN.id !== spellId) {
       return;
     }
-    // Get the applied timestamp
-    this.lastTimestamp = event.timestamp;
     debug && console.log('Tactician was refreshed');
     this.totalProcs += 1;
   }

--- a/src/common/SPELLS/WARRIOR.js
+++ b/src/common/SPELLS/WARRIOR.js
@@ -54,6 +54,12 @@ WARBREAKER: {
     name: 'Charge',
     icon: 'ability_warrior_charge',
   },
+  // Passives
+  TACTICIAN: {
+    id: 199854,
+    name: 'Tactician',
+    icon: 'ability_warrior_unrelentingassault',
+  },
   // Fury:
   // ...
 


### PR DESCRIPTION
- tactician proc resets the cd on mortal strike and colossus smash
- Including the Notes from https://github.com/WoWAnalyzer/WoWAnalyzer/issues/571