### PR TITLE
Brewmaster downtime fix

### DIFF
--- a/src/Parser/Monk/Brewmaster/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/AlwaysBeCasting.js
@@ -28,8 +28,8 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
   ];
 
   // BrM has a fixed 1s GCD
-  static BASE_GCD = 1000;
-  static MINIMUM_GCD = 1000;
+  //static BASE_GCD = 1500;
+  //static MINIMUM_GCD = 1000;
 
   suggestions(when) {
     const deadTimePercentage = this.totalTimeWasted / this.owner.fightDuration;

--- a/src/Parser/Monk/Brewmaster/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/AlwaysBeCasting.js
@@ -27,9 +27,7 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
     SPELLS.TIGERS_LUST_TALENT.id,
   ];
 
-  // BrM has a fixed 1s GCD
-  //static BASE_GCD = 1500;
-  //static MINIMUM_GCD = 1000;
+  static MINIMUM_GCD = 1000; // it's capped to 1sec, reduced with haste from player
 
   suggestions(when) {
     const deadTimePercentage = this.totalTimeWasted / this.owner.fightDuration;


### PR DESCRIPTION
Brewmaster Base GCD is 1500 which is in the module correctly defined for every class. Brewmaster are reducing the GCD to max  1000 with haste. Just a fix because WOPR set it to 1sec always, which isn't true.

it's required because otherwise the downtime would be doubled in the summary.