### PR TITLE
[Retribution] Tooltip updates

### DIFF
--- a/src/Parser/RetributionPaladin/Modules/Features/CastEfficiency.js
+++ b/src/Parser/RetributionPaladin/Modules/Features/CastEfficiency.js
@@ -43,7 +43,7 @@ class CastEfficiency extends CoreCastEfficiency {
       spell: SPELLS.AVENGING_WRATH,
       category: CastEfficiency.SPELL_CATEGORIES.COOLDOWNS,
       getCooldown: haste => 120,
-      hideWithZeroCasts: true,
+      isActive: combatant => !combatant.hasTalent(SPELLS.CRUSADE_TALENT.id),
       recommendedCastEfficiency: 0.9,
     },
     {
@@ -92,7 +92,7 @@ class CastEfficiency extends CoreCastEfficiency {
       spell: SPELLS.BLADE_OF_JUSTICE,
       category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
       getCooldown: haste => null, // 10.5 / (1 + haste)
-      hideWithZeroCasts: true,
+      isActive: combatant => !combatant.hasTalent(SPELLS.DIVINE_HAMMER_TALENT.id),
     },
     {
       spell: SPELLS.DIVINE_HAMMER_TALENT,
@@ -104,13 +104,11 @@ class CastEfficiency extends CoreCastEfficiency {
       spell: SPELLS.TEMPLARS_VERDICT,
       category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
       getCooldown: haste => null,
-      hideWithZeroCasts: true,
     },
     {
       spell: SPELLS.DIVINE_STORM,
       category: CastEfficiency.SPELL_CATEGORIES.ROTATIONAL,
       getCooldown: haste => null,
-      hideWithZeroCasts: true,
     },
     {
       spell: SPELLS.EXECUTION_SENTENCE_TALENT,
@@ -122,6 +120,7 @@ class CastEfficiency extends CoreCastEfficiency {
       spell: SPELLS.SHIELD_OF_VENGEANCE,
       category: CastEfficiency.SPELL_CATEGORIES.UTILITY,
       getCooldown: (haste, combatant) => 120 - (combatant.traitsBySpellId[SPELLS.DEFLECTION.id] || 0) * 10,
+      recommendedCastEfficiency: 0.5,
       noCanBeImproved: true,
       importance: ISSUE_IMPORTANCE.MINOR,
     },
@@ -132,7 +131,6 @@ class CastEfficiency extends CoreCastEfficiency {
       isActive: combatant => combatant.hasTalent(SPELLS.JUSTICARS_VENGEANCE_TALENT.id),
       noSuggestion: true,
       noCanBeImproved: true,
-      hideWithZeroCasts: true,
     },
     {
       spell: SPELLS.EYE_FOR_AN_EYE_TALENT,
@@ -141,7 +139,6 @@ class CastEfficiency extends CoreCastEfficiency {
       isActive: combatant => combatant.hasTalent(SPELLS.EYE_FOR_AN_EYE_TALENT.id),
       noSuggestion: true,
       noCanBeImproved: true,
-      hideWithZeroCasts: true,
     },
     {
       spell: SPELLS.WORD_OF_GLORY_TALENT,
@@ -150,12 +147,12 @@ class CastEfficiency extends CoreCastEfficiency {
       isActive: combatant => combatant.hasTalent(SPELLS.WORD_OF_GLORY_TALENT.id),
       noSuggestion: true,
       noCanBeImproved: true,
-      hideWithZeroCasts: true,
     },
     {
       spell: SPELLS.ARCANE_TORRENT_MANA,
       category: CastEfficiency.SPELL_CATEGORIES.COOLDOWNS,
       getCooldown: haste => 90,
+      recommendedCastEfficiency: 0.6,
       hideWithZeroCasts: true,
     },
   ];

--- a/src/Parser/RetributionPaladin/Modules/Features/Judgment.js
+++ b/src/Parser/RetributionPaladin/Modules/Features/Judgment.js
@@ -7,7 +7,7 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
-import { formatPercentage } from 'common/format';
+import { formatPercentage, formatNumber } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class Judgment extends Module {
@@ -64,8 +64,8 @@ class Judgment extends Module {
 			.addSuggestion((suggest,actual,recommended) => {
 				return suggest(<span>You're spending Holy Power outisde of the <SpellLink id={SPELLS.JUDGMENT_CAST.id} /> debuff. It is optimal to only spend Holy Power while the enemy is debuffed with <SpellLink id={SPELLS.JUDGMENT_CAST.id} />.</span>)
 					.icon(SPELLS.JUDGMENT_DEBUFF.icon)
-					.actual(`${formatPercentage(actual)}% Holy Power spenders used outside of Judgment.`)
-					.recommended(`<${formatPercentage(recommended)}% is recommened`)
+					.actual(`${formatNumber(this.spenderOutsideJudgment)} Holy Power spenders used outside of Judgment (${formatPercentage(actual)}%).`)
+					.recommended(`<${formatPercentage(recommended)}% is recommended`)
 					.regular(recommended + 0.05).major(recommended + 0.1);
 			});
 	}

--- a/src/Parser/RetributionPaladin/Modules/Items/Tier20_2set.js
+++ b/src/Parser/RetributionPaladin/Modules/Items/Tier20_2set.js
@@ -45,9 +45,9 @@ class Tier20_2set extends Module {
       result: (
         <dfn data-tip={`
           The effective damage contributed by tier 20 2 peice.<br/>
-          Damage: ${this.owner.formatItemDamageDone(this.damageDone)}<br/>
           Total Damage: ${formatNumber(this.damageDone)}<br/>
           The percent uptime is your actual uptime over the max uptime based on your haste.<br/>
+          Note: This does not account for haste procs over the fight so it may be over 100%.<br/>
           Percent Uptime: ${formatPercentage(this.percentUptime)}%`}
         >
           {this.owner.formatItemDamageDone(this.damageDone)}

--- a/src/Parser/RetributionPaladin/Modules/Items/WhisperOfTheNathrezim.js
+++ b/src/Parser/RetributionPaladin/Modules/Items/WhisperOfTheNathrezim.js
@@ -19,27 +19,40 @@ class WhisperOfTheNathrezim extends Module {
   };
 
   damageDone = 0;
+  spenderInsideBuff = 0;
+  totalSpender = 0;
 
   on_initialized() {
     this.active = this.combatants.selected.hasBack(ITEMS.WHISPER_OF_THE_NATHREZIM.id);
   }
 
-  on_byPlayer_damage(event) {
-    if (this.combatants.selected.hasBuff(SPELLS.WHISPER_OF_THE_NATHREZIM_BUFF.id)) {
-      if (event.ability.guid === SPELLS.TEMPLARS_VERDICT_DAMAGE.id || event.ability.guid === SPELLS.DIVINE_STORM_DAMAGE.id) {
-        this.damageDone += GetDamageBonus(event, WHISPER_OF_THE_NATHREZIM_MODIFIER);
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    if(spellId === SPELLS.TEMPLARS_VERDICT.id || spellId === SPELLS.DIVINE_STORM.id){
+      if(this.combatants.selected.hasBuff(SPELLS.WHISPER_OF_THE_NATHREZIM_BUFF.id)){
+        this.spenderInsideBuff++;
       }
+      this.totalSpender++;
+    }
+  }
+
+  on_byPlayer_damage(event) {
+    const spellId = event.ability.guid;
+    if (!this.combatants.selected.hasBuff(SPELLS.WHISPER_OF_THE_NATHREZIM_BUFF.id)) {
+      return;
+    }
+    if (spellId === SPELLS.TEMPLARS_VERDICT_DAMAGE.id || spellId === SPELLS.DIVINE_STORM_DAMAGE.id) {
+      this.damageDone += GetDamageBonus(event, WHISPER_OF_THE_NATHREZIM_MODIFIER);
     }
   }
 
   item() {
-    const uptime = this.combatants.selected.getBuffUptime(SPELLS.WHISPER_OF_THE_NATHREZIM_BUFF.id) / this.owner.fightDuration;
     return {
       item: ITEMS.WHISPER_OF_THE_NATHREZIM,
       result: (<dfn data-tip={`
         The effective damage contributed by Whisper of the Nathrezim.<br/>
-				Total Damage: ${formatNumber(this.damageDone)}<br/>
-				Percent Uptime: ${formatPercentage(uptime)}%`}>
+        Total Damage: ${formatNumber(this.damageDone)}<br/>
+        Spenders With Buff: ${formatNumber(this.spenderInsideBuff)} spenders (${formatPercentage(this.spenderInsideBuff / this.totalSpender)}%)`}>
         {this.owner.formatItemDamageDone(this.damageDone)}
       </dfn>),
     };


### PR DESCRIPTION
- [x] Removed all of the hideWithZeroCast checks
- [x] Updated Judgment tooltip to show number of spenders used outside of the debuff as well as percent
- [x] Updated tier 20 2pc to with a not saying it can go over 100%
- [x] Updated Whispers tooltip to show spenders cast with the buff vs percent uptime