### PR TITLE
Fixing Gnawed Thumb Ring

### DIFF
--- a/src/Parser/Core/Modules/Items/GnawedThumbRing.js
+++ b/src/Parser/Core/Modules/Items/GnawedThumbRing.js
@@ -2,6 +2,8 @@ import React from 'react';
 
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
+import SCHOOLS from 'common/MAGIC_SCHOOLS';
+
 
 import Module from 'Parser/Core/Module';
 import calculateEffectiveHealing from 'Parser/Core/calculateEffectiveHealing';
@@ -33,6 +35,9 @@ class GnawedThumbRing extends Module {
   }
 
   on_byPlayer_damage(event) {
+    if (event.ability.type === SCHOOLS.ids.PHYSICAL) {
+      return;
+    }
     if (this.combatants.selected.hasBuff(SPELLS.GNAWED_THUMB_RING.id)) {
       this.damage += event.amount - (event.amount / (1 + GNAWED_THUMB_RING_DAMAGE_INCREASE));
     }


### PR DESCRIPTION
Fixes #585 

Gnawed thumb ring only increases magic damage these days, so this excludes physical damage done while the buff is up.

Live: 
![image](https://user-images.githubusercontent.com/29204244/31860539-93d6c4c4-b71b-11e7-8803-59e74a19d540.png)

Post-fix:
![image](https://user-images.githubusercontent.com/29204244/31860537-868de478-b71b-11e7-9920-489780ca7b9e.png)
