### PR TITLE
[Frost Mage] Thermal Void and Winters Chill Fixes

### DIFF
--- a/src/Parser/Mage/Frost/Modules/Features/ThermalVoid.js
+++ b/src/Parser/Mage/Frost/Modules/Features/ThermalVoid.js
@@ -22,18 +22,11 @@ class ThermalVoid extends Module {
   }
 
   on_toPlayer_applybuff(event) {
-    if(event.ability.guid === SPELLS.ICY_VEINS.id && event.prepull) { // catch prepull cast by buff being present on pull
+    const spellId = event.ability.guid;
+    if(spellId === SPELLS.ICY_VEINS.id) {
       this.casts += 1;
       this.buffApplied = event.timestamp;
     }
-  }
-
-  on_byPlayer_cast(event) {
-    if (event.ability.guid !== SPELLS.ICY_VEINS.id) {
-      return;
-    }
-    this.casts += 1;
-    this.buffApplied = event.timestamp;
   }
 
   on_finished() {

--- a/src/Parser/Mage/Frost/Modules/Features/ThermalVoid.js
+++ b/src/Parser/Mage/Frost/Modules/Features/ThermalVoid.js
@@ -14,29 +14,38 @@ class ThermalVoid extends Module {
 	}
 
   casts = 0;
+  buffApplied = 0;
+  extraUptime = 0;
 
   on_initialized() {
 	   this.active = this.combatants.selected.hasTalent(SPELLS.THERMAL_VOID_TALENT.id);
   }
 
   on_toPlayer_applybuff(event) {
-    const spellId = event.ability.guid;
-    if(spellId === SPELLS.ICY_VEINS.id && event.prepull) { // catch prepull cast by buff being present on pull
+    if(event.ability.guid === SPELLS.ICY_VEINS.id && event.prepull) { // catch prepull cast by buff being present on pull
       this.casts += 1;
+      this.buffApplied = event.timestamp;
     }
   }
 
   on_byPlayer_cast(event) {
-    const spellId = event.ability.guid;
-    if (spellId !== SPELLS.ICY_VEINS.id) {
+    if (event.ability.guid !== SPELLS.ICY_VEINS.id) {
       return;
     }
     this.casts += 1;
+    this.buffApplied = event.timestamp;
+  }
+
+  on_finished() {
+    if (this.combatants.selected.hasBuff(SPELLS.ICY_VEINS.id)) {
+      this.casts -= 1;
+      this.extraUptime = this.owner.currentTimestamp - this.buffApplied;
+    }
   }
 
   suggestions(when) {
-    const averageDuration = (this.combatants.selected.getBuffUptime(SPELLS.ICY_VEINS.id) / 1000) / this.casts;
-
+    const uptime = this.combatants.selected.getBuffUptime(SPELLS.ICY_VEINS.id) - this.extraUptime;
+    const averageDuration = (uptime / this.casts) / 1000;
     when(averageDuration).isLessThan(45)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>Your <SpellLink id={SPELLS.ICY_VEINS.id}/> duration can be improved. Make sure you use Frozen Orb to get Fingers of Frost Procs</span>)
@@ -48,12 +57,14 @@ class ThermalVoid extends Module {
   }
 
   statistic() {
-    const averageDuration = (this.combatants.getBuffUptime(SPELLS.ICY_VEINS.id) / 1000) / this.casts;
+    const uptime = this.combatants.selected.getBuffUptime(SPELLS.ICY_VEINS.id) - this.extraUptime;
+    const averageDuration = (uptime / this.casts) / 1000;
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.ICY_VEINS.id} />}
         value={`${formatNumber(averageDuration)}s`}
         label="Avg Icy Veins Duration"
+        tooltip={"Icy Veins Casts that do not complete before the fight ends are removed from this statistic"}
       />
     );
   }

--- a/src/Parser/Mage/Frost/Modules/Features/WintersChill.js
+++ b/src/Parser/Mage/Frost/Modules/Features/WintersChill.js
@@ -15,8 +15,9 @@ class WintersChillTracker extends Module {
     enemies: EnemyInstances,
   };
 
-  wintersChillApplied = 0;
-  iceLanceCasts = 0;
+  iceLanceHits = 0;
+  missedCasts = 0;
+  doubleIceLanceHits = 0;
 
   on_byPlayer_damage(event) {
     if (event.ability.guid !== SPELLS.ICE_LANCE_DAMAGE.id) {
@@ -24,7 +25,7 @@ class WintersChillTracker extends Module {
     }
     const enemy = this.enemies.getEntity(event);
     if (enemy.hasBuff(SPELLS.WINTERS_CHILL.id)) {
-      this.iceLanceCasts += 1;
+      this.iceLanceHits += 1;
     }
   }
 
@@ -32,27 +33,36 @@ class WintersChillTracker extends Module {
 	  if(event.ability.guid !== SPELLS.WINTERS_CHILL.id) {
 		  return;
 	  }
-		this.wintersChillApplied += 1;
+    this.iceLanceHits = 0;
 	}
 
+  on_byPlayer_removedebuff(event) {
+    if(event.ability.guid !== SPELLS.WINTERS_CHILL.id) {
+      return;
+    }
+    if (this.iceLanceHits === 0) {
+      this.missedCasts += 1;
+    } else if (this.iceLanceHits === 2) {
+      this.doubleIceLanceHits += 1;
+    }
+  }
+
   suggestions(when) {
-    const missed = this.wintersChillApplied - this.iceLanceCasts;
-    when(missed).isGreaterThan(0)
+    when(this.missedCasts).isGreaterThan(0)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span> You failed to Shatter {missed} <SpellLink id={SPELLS.WINTERS_CHILL.id}/>.  Make sure you cast <SpellLink id={SPELLS.ICE_LANCE_CAST.id}/> after each <SpellLink id={SPELLS.FLURRY.id}/> so Ice Lance can benefit from the <SpellLink id={SPELLS.SHATTER.id}/> Bonus.</span>)
+        return suggest(<span> You failed to Shatter {this.missedCasts} <SpellLink id={SPELLS.WINTERS_CHILL.id}/>.  Make sure you cast <SpellLink id={SPELLS.ICE_LANCE_CAST.id}/> after each <SpellLink id={SPELLS.FLURRY.id}/> so Ice Lance can benefit from the <SpellLink id={SPELLS.SHATTER.id}/> Bonus.</span>)
           .icon(SPELLS.ICE_LANCE_CAST.icon)
-          .actual(`${formatNumber(missed)} Winter's Chill not Shattered`)
+          .actual(`${formatNumber(this.missedCasts)} Winter's Chill not Shattered`)
           .recommended(`${formatNumber(recommended)} is recommended`)
-          .regular(recommended + 1).major(recommended + 3);
+          .regular(1).major(3);
       });
   }
   statistic() {
-    const missed = this.wintersChillApplied - this.iceLanceCasts;
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.WINTERS_CHILL.id} />}
-        value={formatNumber(missed)}
-        label="Winter's Chill Missed" />
+        value={formatNumber(this.missedCasts)}
+        label="Winter's Chill Missed"/>
     );
   }
   statisticOrder = STATISTIC_ORDER.CORE(2);

--- a/src/Parser/Mage/Frost/Modules/Features/WintersChill.js
+++ b/src/Parser/Mage/Frost/Modules/Features/WintersChill.js
@@ -20,7 +20,8 @@ class WintersChillTracker extends Module {
   doubleIceLanceHits = 0;
 
   on_byPlayer_damage(event) {
-    if (event.ability.guid !== SPELLS.ICE_LANCE_DAMAGE.id) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.ICE_LANCE_DAMAGE.id) {
       return;
     }
     const enemy = this.enemies.getEntity(event);
@@ -30,14 +31,16 @@ class WintersChillTracker extends Module {
   }
 
   on_byPlayer_applydebuff(event) {
-	  if(event.ability.guid !== SPELLS.WINTERS_CHILL.id) {
+    const spellId = event.ability.guid;
+	  if(spellId !== SPELLS.WINTERS_CHILL.id) {
 		  return;
 	  }
     this.iceLanceHits = 0;
 	}
 
   on_byPlayer_removedebuff(event) {
-    if(event.ability.guid !== SPELLS.WINTERS_CHILL.id) {
+    const spellId = event.ability.guid;
+    if(spellId !== SPELLS.WINTERS_CHILL.id) {
       return;
     }
     if (this.iceLanceHits === 0) {


### PR DESCRIPTION
Adjusted Thermal Void to exclude the uptime and cast for Icy Veins if it does not complete before the fight ends as it skews the average in a negative way.

Also adjusted Winters Chill to account for "Double Ice Lance" Hits within the Winter's Chill Window (which was causing this number to go negative or potentially hide a missed window).... This also counts the number of times the player managed to get 2 Ice Lance's in the window, but i havent decided how i want to use that data yet ... so for now it counts it and doesnt do anything further with it. Ill do something with that data at some point.