### PR TITLE
[Mistweaver Monk] Statistic Box Format Updates

### DIFF
--- a/src/Parser/Monk/Mistweaver/CHANGELOG.js
+++ b/src/Parser/Monk/Mistweaver/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+24-10-2017 - Updated Thunder Focus Tea, Dancing Mist, and Uplifting Trance statistics formating (by anomoly)
 17-10-2017 - Added T21 2 and 4 set healing contribution statistics (by anomoly)
 30-09-2017 - Added Zen Pulse and Chi Wave to the Cast Efficiency tab. Updated the Maintainer information (by anomoly)
 27-09-2017 - Clean up some old code and update the Second Gust of Mist Overhealing calculation to show overhealing of the Second Gust proc as a % of the total healing of that second Gust (by anomoly)

--- a/src/Parser/Monk/Mistweaver/Modules/Spells/RenewingMist.js
+++ b/src/Parser/Monk/Mistweaver/Modules/Spells/RenewingMist.js
@@ -6,7 +6,7 @@ import { formatNumber } from 'common/format';
 
 import Module from 'Parser/Core/Module';
 
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import SmallStatisticBox, { STATISTIC_ORDER } from 'Main/SmallStatisticBox';
 
 const debug = false;
 
@@ -101,19 +101,17 @@ class RenewingMist extends Module {
   }
 
   statistic() {
+
     return (
-      <StatisticBox
+      <SmallStatisticBox
         icon={<SpellIcon id={SPELLS.DANCING_MISTS.id} />}
         value={`${formatNumber(this.dancingMistHeal)}`}
-        label={(
-          <dfn data-tip={`You had a total of ${(this.dancingMistProc)} procs on ${this.castsREM} REM casts.`}>
-            Total Healing
-          </dfn>
-        )}
+        label="Dancing Mist Healing"
+        tooltip={`You had a total of ${(this.dancingMistProc)} procs on ${this.castsREM} REM casts.`}
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(5);
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(50);
 }
 
 export default RenewingMist;

--- a/src/Parser/Monk/Mistweaver/Modules/Spells/UpliftingTrance.js
+++ b/src/Parser/Monk/Mistweaver/Modules/Spells/UpliftingTrance.js
@@ -77,20 +77,40 @@ class UpliftingTrance extends Module {
   }
 
   statistic() {
-    const unusedUTProcs = 1 - (this.consumedUTProc / this.UTProcsTotal);
+    const unusedUTProcsPerc = 1 - (this.consumedUTProc / this.UTProcsTotal);
+    const unusedUTProc = this.UTProcsTotal - this.consumedUTProc;
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.UPLIFTING_TRANCE_BUFF.id} />}
-        value={`${formatPercentage(unusedUTProcs)}%`}
+        value={`${formatPercentage(unusedUTProcsPerc)}%`}
         label={(
-          <dfn data-tip={`You got total <b>${this.UTProcsTotal} uplifting trance procs</b> and <b>used ${this.consumedUTProc}</b> of them. ${this.nonUTVivify} of your vivify's were used without an uplifting trance procs.`}>
+          <dfn data-tip={`${this.nonUTVivify} of your vivify's were used without an uplifting trance procs.`}>
             Unused Procs
           </dfn>
         )}
+        footer={(
+          <div className="statistic-bar">
+            <div
+              className="stat-healing-bg"
+              style={{ width: `${this.consumedUTProc / this.UTProcsTotal * 100}%` }}
+              data-tip={`You consumed a total of ${this.consumedUTProc} procs.`}
+            >
+              <img src="/img/healing.png" alt="Healing" />
+            </div>
+            
+            <div
+              className="remainder stat-overhealing-bg"
+              data-tip={`You missed a total of ${unusedUTProc} procs.`}
+            >
+              <img src="/img/overhealing.png" alt="Overhealing" />
+            </div>
+          </div>
+        )}
+        footerStyle={{ overflow: 'hidden' }}
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(40);
+  statisticOrder = STATISTIC_ORDER.CORE(15);
 }
 
 export default UpliftingTrance;


### PR DESCRIPTION
Changed the format on 3 statistic boxes. No additional changes other than just the presentation of the current statistics.

Relevant SS's below:
Thunder Focus Tea Changes:
![image](https://user-images.githubusercontent.com/3225957/31910748-84447ed8-b80c-11e7-964d-89615fcff6e9.png)

Uplifting Trance Changes:
![image](https://user-images.githubusercontent.com/3225957/31910709-5f9a0bb6-b80c-11e7-9efc-157aabe29942.png)

Dancing Mist Changes:
![image](https://user-images.githubusercontent.com/3225957/31910793-9e286e22-b80c-11e7-838e-c20792c01f6d.png)
