### PR TITLE
[Marksmanship] True aim update

### DIFF
--- a/src/Parser/Hunter/Marksmanship/Modules/Talents/TrueAim.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Talents/TrueAim.js
@@ -17,6 +17,7 @@ class TrueAim extends Analyzer {
     combatants: Combatants,
   };
 
+  //stack counters
   _currentStacks = 0;
   startOfMaxStacks = 0;
   timeAtMaxStacks = 0;
@@ -24,7 +25,11 @@ class TrueAim extends Analyzer {
   //starts -1 because the stacks drop at end of combat, but that shouldn't count as a time where it dropped
   timesDropped = -1;
   totalTimesDropped = -1;
+
+  //bonusDmg
   bonusDmg = 0;
+  aimedBonusDmg = 0;
+  arcaneBonusDmg = 0;
 
   on_initialized() {
     this.active = this.combatants.selected.hasTalent(SPELLS.TRUE_AIM_TALENT.id);
@@ -67,10 +72,10 @@ class TrueAim extends Analyzer {
       return;
     }
     if (spellId === SPELLS.AIMED_SHOT.id) {
-
+      this.aimedBonusDmg += getDamageBonus(event, (TRUE_AIM_MODIFIER*this._currentStacks));
     }
     if (spellId === SPELLS.ARCANE_SHOT.id) {
-
+      this.arcaneBonusDmg += getDamageBonus(event, (TRUE_AIM_MODIFIER*this._currentStacks));
     }
     this.bonusDmg += getDamageBonus(event, (TRUE_AIM_MODIFIER * this._currentStacks));
   }
@@ -82,7 +87,8 @@ class TrueAim extends Analyzer {
         icon={<SpellIcon id={SPELLS.TRUE_AIM_DEBUFF.id} />}
         value={`${percentTimeAtMaxTAStacks} %`}
         label="10 stack uptime"
-        tooltip={`You reset True Aim when you had 3 or more stacks (to exclude trickshot cleaving resets): ${this.timesDropped} times over the course of the encounter. <br />Your total amount of resets (including with trickshot cleaving) was: ${this.totalTimesDropped}. <br /> True Aim contributed with           ${formatNumber(this.bonusDmg)} - ${this.owner.formatItemDamageDone(this.bonusDmg)}`}
+        tooltip={`You reset True Aim when you had 3 or more stacks (to exclude trickshot cleaving resets): ${this.timesDropped} times over the course of the encounter. <br />Your total amount of resets (including with trickshot cleaving) was: ${this.totalTimesDropped}. <br /> True Aim contributed with           ${formatNumber(this.bonusDmg)} - ${this.owner.formatItemDamageDone(this.bonusDmg)}. <br/> Aimed Shot did ${formatPercentage(
+          this.aimedBonusDmg/this.bonusDmg)}% and Arcane Shot did ${formatPercentage(this.arcaneBonusDmg/this.bonusDmg)}%.`}
       />
     );
 

--- a/src/Parser/Hunter/Marksmanship/Modules/Talents/TrueAim.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Talents/TrueAim.js
@@ -72,10 +72,10 @@ class TrueAim extends Analyzer {
       return;
     }
     if (spellId === SPELLS.AIMED_SHOT.id) {
-      this.aimedBonusDmg += getDamageBonus(event, (TRUE_AIM_MODIFIER*this._currentStacks));
+      this.aimedBonusDmg += getDamageBonus(event, (TRUE_AIM_MODIFIER * this._currentStacks));
     }
     if (spellId === SPELLS.ARCANE_SHOT.id) {
-      this.arcaneBonusDmg += getDamageBonus(event, (TRUE_AIM_MODIFIER*this._currentStacks));
+      this.arcaneBonusDmg += getDamageBonus(event, (TRUE_AIM_MODIFIER * this._currentStacks));
     }
     this.bonusDmg += getDamageBonus(event, (TRUE_AIM_MODIFIER * this._currentStacks));
   }
@@ -87,8 +87,12 @@ class TrueAim extends Analyzer {
         icon={<SpellIcon id={SPELLS.TRUE_AIM_DEBUFF.id} />}
         value={`${percentTimeAtMaxTAStacks} %`}
         label="10 stack uptime"
-        tooltip={`You reset True Aim when you had 3 or more stacks (to exclude trickshot cleaving resets): ${this.timesDropped} times over the course of the encounter. <br />Your total amount of resets (including with trickshot cleaving) was: ${this.totalTimesDropped}. <br /> True Aim contributed with           ${formatNumber(this.bonusDmg)} - ${this.owner.formatItemDamageDone(this.bonusDmg)}. <br/> Aimed Shot did ${formatPercentage(
-          this.aimedBonusDmg/this.bonusDmg)}% of that and Arcane Shot did ${formatPercentage(this.arcaneBonusDmg/this.bonusDmg)}%.`}
+        tooltip={`You reset True Aim when you had 3 or more stacks (to exclude trickshot cleaving resets): ${this.timesDropped} times over the course of the encounter. <br />Your total amount of resets (including with trickshot cleaving) was: ${this.totalTimesDropped}. <br />
+True Aim contributed with ${formatNumber(this.bonusDmg)} - ${this.owner.formatItemDamageDone(this.bonusDmg)}.
+<ul>
+<li> Aimed Shot contributed ${formatPercentage(this.aimedBonusDmg / this.bonusDmg)}%.</li>
+<li>Arcane Shot contributed ${formatPercentage(this.arcaneBonusDmg / this.bonusDmg)}%.</li>
+</ul>`}
       />
     );
 

--- a/src/Parser/Hunter/Marksmanship/Modules/Talents/TrueAim.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Talents/TrueAim.js
@@ -88,7 +88,7 @@ class TrueAim extends Analyzer {
         value={`${percentTimeAtMaxTAStacks} %`}
         label="10 stack uptime"
         tooltip={`You reset True Aim when you had 3 or more stacks (to exclude trickshot cleaving resets): ${this.timesDropped} times over the course of the encounter. <br />Your total amount of resets (including with trickshot cleaving) was: ${this.totalTimesDropped}. <br /> True Aim contributed with           ${formatNumber(this.bonusDmg)} - ${this.owner.formatItemDamageDone(this.bonusDmg)}. <br/> Aimed Shot did ${formatPercentage(
-          this.aimedBonusDmg/this.bonusDmg)}% and Arcane Shot did ${formatPercentage(this.arcaneBonusDmg/this.bonusDmg)}%.`}
+          this.aimedBonusDmg/this.bonusDmg)}% of that and Arcane Shot did ${formatPercentage(this.arcaneBonusDmg/this.bonusDmg)}%.`}
       />
     );
 


### PR DESCRIPTION
Minor update adding damage contribution to this talent. 

I'm also posting this for feedback on wording of the last line ``Aimed shot did x% and Arcane shot did y%``. I want this to showcase which abilities gained what % of the total damage contribution from the talent, but the wording right now irks me - any ideas are welcome! 

Tooltip now reads like this: 
![image](https://user-images.githubusercontent.com/29204244/31993836-c375c576-b97e-11e7-989a-a22f65f320aa.png)
