### PR TITLE
[mage] Fixed a bug in UnstableMagic where the wrong ID was being used for Fire

### DIFF
--- a/src/Parser/Mage/Shared/Modules/Features/UnstableMagic.js
+++ b/src/Parser/Mage/Shared/Modules/Features/UnstableMagic.js
@@ -15,6 +15,12 @@ const PROCCERS = [
   SPELLS.ARCANE_BLAST.id,
 ];
 
+const PROCS = [
+  SPELLS.UNSTABLE_MAGIC_DAMAGE_FIRE.id,
+  SPELLS.UNSTABLE_MAGIC_DAMAGE_FROST.id,
+  SPELLS.UNSTABLE_MAGIC_DAMAGE_ARCANE.id,
+];
+
 class UnstableMagic extends Analyzer {
   static dependencies = {
     combatants: Combatants,
@@ -31,7 +37,7 @@ class UnstableMagic extends Analyzer {
   }
 
   on_byPlayer_damage(event) {
-    if(event.ability.guid === SPELLS.UNSTABLE_MAGIC_DAMAGE.id) {
+    if(PROCS.includes(event.ability.guid)) {
       this.damage += event.amount + (event.absorbed || 0);
       this.hits += 1;
       if(!this.hitTimestamp || this.hitTimestamp + PROC_WINDOW_MS < this.owner.currentTimestamp) {

--- a/src/common/SPELLS/MAGE.js
+++ b/src/common/SPELLS/MAGE.js
@@ -56,8 +56,18 @@ export default {
     name: 'Mirror Image',
     icon: 'spell_magic_managain',
   },
-  UNSTABLE_MAGIC_DAMAGE: {
+  UNSTABLE_MAGIC_DAMAGE_FIRE: {
+    id: 157977,
+    name: 'Unstable Magic',
+    icon: 'spell_mage_unstablemagic',
+  },
+  UNSTABLE_MAGIC_DAMAGE_FROST: {
     id: 157978,
+    name: 'Unstable Magic',
+    icon: 'spell_mage_unstablemagic',
+  },
+  UNSTABLE_MAGIC_DAMAGE_ARCANE: {
+    id: 157979,
     name: 'Unstable Magic',
     icon: 'spell_mage_unstablemagic',
   },


### PR DESCRIPTION
It appears Unstable Magic has a different damage ID depending on spec. I've fixed the module to handle the IDs for each spec.