### PR TITLE
[frost mage] Updated Winter's Chill display

### DIFF
--- a/src/Parser/Mage/Frost/Modules/Features/WintersChill.js
+++ b/src/Parser/Mage/Frost/Modules/Features/WintersChill.js
@@ -5,7 +5,7 @@ import EnemyInstances from 'Parser/Core/Modules/EnemyInstances';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
-import { formatNumber } from 'common/format';
+import { formatNumber, formatMilliseconds, formatPercentage } from 'common/format';
 
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
@@ -15,18 +15,28 @@ class WintersChillTracker extends Analyzer {
     enemies: EnemyInstances,
   };
 
+  totalProcs = 0;
+
+  frostboltHits = 0;
+  missedFrostboltCasts = 0;
+  singleFrostboltCasts = 0;
+
   iceLanceHits = 0;
-  missedCasts = 0;
-  doubleIceLanceHits = 0;
+  missedIceLanceCasts = 0;
+  singleIceLanceCasts = 0;
+  doubleIceLanceCasts = 0;
 
   on_byPlayer_damage(event) {
     const spellId = event.ability.guid;
-    if (spellId !== SPELLS.ICE_LANCE_DAMAGE.id) {
+    const enemy = this.enemies.getEntity(event);
+    if (!enemy || !enemy.hasBuff(SPELLS.WINTERS_CHILL.id)) {
       return;
     }
-    const enemy = this.enemies.getEntity(event);
-    if (enemy.hasBuff(SPELLS.WINTERS_CHILL.id)) {
+
+    if (spellId === SPELLS.ICE_LANCE_DAMAGE.id) {
       this.iceLanceHits += 1;
+    } else if(spellId === SPELLS.FROSTBOLT_DAMAGE.id) {
+      this.frostboltHits += 1;
     }
   }
 
@@ -36,6 +46,7 @@ class WintersChillTracker extends Analyzer {
 		  return;
 	  }
     this.iceLanceHits = 0;
+    this.frostboltHits = 0;
 	}
 
   on_byPlayer_removedebuff(event) {
@@ -43,29 +54,81 @@ class WintersChillTracker extends Analyzer {
     if(spellId !== SPELLS.WINTERS_CHILL.id) {
       return;
     }
+
+    this.totalProcs += 1;
+
     if (this.iceLanceHits === 0) {
-      this.missedCasts += 1;
+      this.missedIceLanceCasts += 1;
+    } else if (this.iceLanceHits === 1) {
+      this.singleIceLanceCasts += 1;
     } else if (this.iceLanceHits === 2) {
-      this.doubleIceLanceHits += 1;
+      this.doubleIceLanceCasts += 1;
+    } else {
+      console.error(`Unexpected number of Ice Lances inside Winter's Chill @ ${formatMilliseconds(this.owner.currentTimestamp - this.owner.fight.start_time)} -> ${this.iceLanceHits}`);
+    }
+
+    if (this.frostboltHits === 0) {
+      this.missedFrostboltCasts += 1;
+    } else if (this.frostboltHits === 1) {
+      this.singleFrostboltCasts += 1;
+    } else {
+      console.error(`Unexpected number of Frostbolt hits inside Winter's Chill @ ${formatMilliseconds(this.owner.currentTimestamp - this.owner.fight.start_time)} -> ${this.frostboltHits}`);
     }
   }
 
   suggestions(when) {
-    when(this.missedCasts).isGreaterThan(0)
+    const missedIceLancesPerMinute = this.missedIceLanceCasts / (this.owner.fightDuration / 1000 / 60);
+    when(missedIceLancesPerMinute).isGreaterThan(0)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span> You failed to Shatter {this.missedCasts} <SpellLink id={SPELLS.WINTERS_CHILL.id}/>.  Make sure you cast <SpellLink id={SPELLS.ICE_LANCE_CAST.id}/> after each <SpellLink id={SPELLS.FLURRY.id}/> so Ice Lance can benefit from the <SpellLink id={SPELLS.SHATTER.id}/> Bonus.</span>)
+        return suggest(<span> You failed to Ice Lance into {this.missedIceLanceCasts} <SpellLink id={SPELLS.WINTERS_CHILL.id}/> ({missedIceLancesPerMinute.toFixed(1)} missed per minute).  Make sure you cast <SpellLink id={SPELLS.ICE_LANCE_CAST.id}/> after each <SpellLink id={SPELLS.FLURRY.id}/> to benefit from <SpellLink id={SPELLS.SHATTER.id}/>.</span>)
           .icon(SPELLS.ICE_LANCE_CAST.icon)
-          .actual(`${formatNumber(this.missedCasts)} Winter's Chill not Shattered`)
+          .actual(`${formatNumber(this.missedIceLanceCasts)} Winter's Chill not shattered with Ice Lance`)
           .recommended(`${formatNumber(recommended)} is recommended`)
-          .regular(1).major(3);
+          .regular(0.5).major(1);
+      });
+
+    const missedFrostboltsPerMinute = this.missedFrostboltCasts / (this.owner.fightDuration / 1000 / 60);
+    when(missedFrostboltsPerMinute).isGreaterThan(0)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<span> You failed to Frostbolt into {this.missedFrostboltCasts} <SpellLink id={SPELLS.WINTERS_CHILL.id}/> ({missedFrostboltsPerMinute.toFixed(1)} missed per minute).  Make sure you cast <SpellLink id={SPELLS.FROSTBOLT.id}/> just before each instant <SpellLink id={SPELLS.FLURRY.id}/> to benefit from <SpellLink id={SPELLS.SHATTER.id}/>.</span>)
+          .icon(SPELLS.FROSTBOLT.icon)
+          .actual(`${formatNumber(this.missedFrostboltCasts)} Winter's Chill not shattered with Frostbolt`)
+          .recommended(`${formatNumber(recommended)} is recommended`)
+          .regular(0.5).major(1);
       });
   }
+
   statistic() {
+    const icelanceUtil = (1 - (this.missedIceLanceCasts / this.totalProcs)) || 0;
+    const frostboltUtil = (1 - (this.missedFrostboltCasts / this.totalProcs)) || 0;
+    const doubleIcelancePerc = (this.doubleIceLanceCasts / this.totalProcs) || 0;
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.WINTERS_CHILL.id} />}
-        value={formatNumber(this.missedCasts)}
-        label="Winter's Chill Missed"/>
+        value={(
+          <span>
+            {formatPercentage(icelanceUtil, 0)}{'% '}
+            <SpellIcon
+              id={SPELLS.ICE_LANCE_CAST.id}
+              style={{
+                height: '1.3em',
+                marginTop: '-.1em',
+              }}
+            />
+            {' '}
+            {formatPercentage(frostboltUtil, 0)}{'% '}
+            <SpellIcon
+              id={SPELLS.FROSTBOLT.id}
+              style={{
+                height: '1.3em',
+                marginTop: '-.1em',
+              }}
+            />
+          </span>
+        )}
+        label="Winter's Chill Utilization"
+        tooltip={`Every Brain Freeze Flurry should be preceded by a Frostbolt and followed by an Ice Lance. <br><br> You were able to double Ice Lance into Winter's Chill ${this.doubleIceLanceCasts} times (${formatPercentage(doubleIcelancePerc, 1)}%). Note this is only possible when close to the target and at very high levels of haste.`}
+      />
     );
   }
   statisticOrder = STATISTIC_ORDER.CORE(2);

--- a/src/Parser/Mage/Frost/Modules/Features/WintersChill.js
+++ b/src/Parser/Mage/Frost/Modules/Features/WintersChill.js
@@ -35,7 +35,7 @@ class WintersChillTracker extends Analyzer {
 
     if (spellId === SPELLS.ICE_LANCE_DAMAGE.id) {
       this.iceLanceHits += 1;
-    } else if(spellId === SPELLS.FROSTBOLT_DAMAGE.id) {
+    } else if(spellId === SPELLS.FROSTBOLT_DAMAGE.id || spellId === SPELLS.EBONBOLT_DAMAGE.id) {
       this.frostboltHits += 1;
     }
   }
@@ -90,9 +90,9 @@ class WintersChillTracker extends Analyzer {
     const missedFrostboltsPerMinute = this.missedFrostboltCasts / (this.owner.fightDuration / 1000 / 60);
     when(missedFrostboltsPerMinute).isGreaterThan(0)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span> You failed to Frostbolt into {this.missedFrostboltCasts} <SpellLink id={SPELLS.WINTERS_CHILL.id}/> ({missedFrostboltsPerMinute.toFixed(1)} missed per minute).  Make sure you cast <SpellLink id={SPELLS.FROSTBOLT.id}/> just before each instant <SpellLink id={SPELLS.FLURRY.id}/> to benefit from <SpellLink id={SPELLS.SHATTER.id}/>.</span>)
+        return suggest(<span> You failed to Frostbolt or Ebonbolt into {this.missedFrostboltCasts} <SpellLink id={SPELLS.WINTERS_CHILL.id}/> ({missedFrostboltsPerMinute.toFixed(1)} missed per minute).  Make sure you cast <SpellLink id={SPELLS.FROSTBOLT.id}/> just before each instant <SpellLink id={SPELLS.FLURRY.id}/> to benefit from <SpellLink id={SPELLS.SHATTER.id}/>.</span>)
           .icon(SPELLS.FROSTBOLT.icon)
-          .actual(`${formatNumber(this.missedFrostboltCasts)} Winter's Chill not shattered with Frostbolt`)
+          .actual(`${formatNumber(this.missedFrostboltCasts)} Winter's Chill not shattered with Frostbolt or Ebonbolt`)
           .recommended(`${formatNumber(recommended)} is recommended`)
           .regular(0.5).major(1);
       });
@@ -127,7 +127,7 @@ class WintersChillTracker extends Analyzer {
           </span>
         )}
         label="Winter's Chill Utilization"
-        tooltip={`Every Brain Freeze Flurry should be preceded by a Frostbolt and followed by an Ice Lance. <br><br> You were able to double Ice Lance into Winter's Chill ${this.doubleIceLanceCasts} times (${formatPercentage(doubleIcelancePerc, 1)}%). Note this is only possible when close to the target and at very high levels of haste.`}
+        tooltip={`Every Brain Freeze Flurry should be preceded by a Frostbolt or Ebonbolt and followed by an Ice Lance. <br><br> You double Ice Lance'd into Winter's Chill ${this.doubleIceLanceCasts} times (${formatPercentage(doubleIcelancePerc, 1)}%). Note this is usually impossible, but can happen when close to the target and at very high levels of haste.`}
       />
     );
   }

--- a/src/common/SPELLS/MAGE.js
+++ b/src/common/SPELLS/MAGE.js
@@ -143,6 +143,11 @@ export default {
     name: 'Ebonbolt',
     icon: 'artifactability_frostmage_ebonbolt',
   },
+  EBONBOLT_DAMAGE: {
+    id: 228599,
+    name: 'Ebonbolt',
+    icon: 'artifactability_frostmage_ebonbolt',
+  },
   COMET_STORM_DAMAGE: {
     id: 153596,
     name: 'Comet Storm',


### PR DESCRIPTION
We now also track frostbolt hits into Winter's Chill, and added a suggestion for it as well. Suggestion now triggers on missed PPM rather than total missed. Updated display of statistic to show % utilization, and added a stat for double icelance hits.

![winters-chill](https://user-images.githubusercontent.com/7143486/32054523-a4f0fb62-ba2c-11e7-9e32-ef85eeba2c4f.png)
