### PR TITLE
Fixes the z-index of the header overlay

### DIFF
--- a/src/Main/App.css
+++ b/src/Main/App.css
@@ -291,7 +291,7 @@ hr {
 }
 .navbar-progress + * {
   position: relative;
-  z-index: 1;
+  z-index: 10;
 }
 
 .list {


### PR DESCRIPTION
This gets fixed:
![firefox_2017-10-26_18-16-37](https://user-images.githubusercontent.com/317216/32065073-f65d1dce-ba7b-11e7-8e41-095b4bf05c13.png)

The header's z-index of 10 got caped to 1 before this commit.