### PR TITLE
(fix-ele) Remove Storm Totem which is a Summon Event and not a Buff.

### DIFF
--- a/src/Parser/Shaman/Elemental/CHANGELOG.js
+++ b/src/Parser/Shaman/Elemental/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+26-10-2017 - Fix Totem Mastery Uptime (by fasib).
 28-08-2017 - Added Flame Shock, Totem Mastery, Elemental Blast, Ascendance, Lightning Rod Uptimes (by fasib).
 28-08-2017 - Fixed Maelstrom Tab (by fasib).
 04-06-2017 - Added basic <span class="Shaman">Elemental Shaman</span> support by <b>@fasib</b>.

--- a/src/Parser/Shaman/Elemental/Modules/Talents/TotemMastery.js
+++ b/src/Parser/Shaman/Elemental/Modules/Talents/TotemMastery.js
@@ -12,7 +12,6 @@ import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 const BUFF_TOTEM_RESONANCE_SPELL_ID = 202188;
 const BUFF_TOTEM_EMBER_SPELL_ID = 210657;
 const BUFF_TOTEM_TAILWIND_SPELL_ID = 210660;
-const BUFF_TOTEM_STORM_SPELL_ID = 210651;
 
 class TotemMastery extends Analyzer {
   casts = 0;
@@ -25,8 +24,7 @@ class TotemMastery extends Analyzer {
     return Math.min(
       this.owner.modules.combatants.selected.getBuffUptime(BUFF_TOTEM_RESONANCE_SPELL_ID),
       this.owner.modules.combatants.selected.getBuffUptime(BUFF_TOTEM_EMBER_SPELL_ID),
-      this.owner.modules.combatants.selected.getBuffUptime(BUFF_TOTEM_TAILWIND_SPELL_ID),
-      this.owner.modules.combatants.selected.getBuffUptime(BUFF_TOTEM_STORM_SPELL_ID)
+      this.owner.modules.combatants.selected.getBuffUptime(BUFF_TOTEM_TAILWIND_SPELL_ID)
     ) / this.owner.fightDuration;
   }
 


### PR DESCRIPTION
So that Totem Mastery can show its uptime (and not 0.00%...)