### PR TITLE
[frost mage] Fix for t20 4set nerf

### DIFF
--- a/src/Parser/Mage/Frost/Modules/Cooldowns/FrozenOrb.js
+++ b/src/Parser/Mage/Frost/Modules/Cooldowns/FrozenOrb.js
@@ -8,7 +8,7 @@ import SpellUsable from 'Parser/Core/Modules/SpellUsable';
 import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
 
 const BLIZZARD_REDUCTION_MS = 500;
-const BRAIN_FREEZE_REDUCTION_MS = 5000;
+const BRAIN_FREEZE_REDUCTION_MS = 4000;
 
 class FrozenOrb extends Analyzer {
 


### PR DESCRIPTION
Frost Mage Tier20 4set used to cause Brain Freeze to reduce remaining CD on Frozen Orb by 5 seconds. In 7.3.2, this was reduced to 4 seconds.