### PR TITLE
[Marksmanship] Bugfixes for Patient Sniper

### DIFF
--- a/src/Parser/Hunter/Marksmanship/Modules/Talents/PatientSniper/PatientSniperTracker.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Talents/PatientSniper/PatientSniperTracker.js
@@ -6,6 +6,8 @@ import getDamageBonus from 'Parser/Hunter/Shared/Core/getDamageBonus'; // relati
 
 const PATIENT_SNIPER_BONUS_PER_SEC = 0.06;
 const VULNERABLE_DURATION = 7000;
+const LAG_TOLERANCE = 100;
+const MAX_AIMED_SHOT_TRAVEL_TIME = 1000;
 
 class PatientSniperTracker extends Analyzer {
   static dependencies = {
@@ -229,12 +231,18 @@ class PatientSniperTracker extends Analyzer {
     if (vulnerable) {
       vulnerableStart = vulnerable.start;
     }
-    const timeIntoVulnerable = Math.floor((event.timestamp - vulnerableStart) / 1000);
-
+    let timeDifference = event.timestamp - vulnerableStart;
+    if (timeDifference >= VULNERABLE_DURATION && timeDifference <= (VULNERABLE_DURATION + LAG_TOLERANCE)) {
+      // if the difference is [7000, 7100] ms, count it as a 6 second into Vulnerable (this can happen due to slight lag, its 7000ms duration runs out but removedebuff() wasn't yet called
+      // so the buff lingers in currentVulnerables and timeDifference is > 7000ms which produces "7 seconds into vulnerable" which results in error
+      timeDifference = 6500; // set a neutral value halfway past 6000 so dividing and flooring gives correct result
+    }
+    const timeIntoVulnerable = Math.floor(timeDifference / 1000);
     // this "event" is intended for Aimed Shot only
     // since Vulnerable and Patient Sniper bonuses are snapshotted at the moment of the cast (and not when the shot lands)
     // store current target and time passed in Vulnerable (= damage bonus essentially)
     const castEvent = {
+      timestamp: event.timestamp,
       targetID: event.targetID,
       targetInstance: event.targetInstance,
       timeIntoVulnerable: undefined, // assume outside Vulnerable
@@ -279,6 +287,7 @@ class PatientSniperTracker extends Analyzer {
       // look at the "oldest" Aimed Shot cast event and try to match it with the damage event (as for the target ID + instance)
       // this is necessary because of Trick Shot talent which makes the Aimed Shot cleave (for 30 % damage) in certain conditions (and the cleaved shots have same ID as normal shots)
       // and we only calculate the bonus for the main target (otherwise it would double-dip from the bonus)
+      this.aimedShotQueue = this.aimedShotQueue.filter(e => e.timestamp >= (event.timestamp - MAX_AIMED_SHOT_TRAVEL_TIME)); // filter out events too old (can happen at Sisters of the Moon when boss disappears (cast happens, damage never lands))
       const firstAimed = this.aimedShotQueue[0];
       if (!firstAimed || firstAimed.targetID !== event.targetID || firstAimed.targetInstance !== event.targetInstance) {
         // either it's cleaved or it doesn't exist (this can happen if the main target damage arrives sooner than cleaved damage event)


### PR DESCRIPTION
Not proud of how I solved it but works as of now. 2 issues this solves:
1. If for some reason, Aimed Shot was cast but never landed and did damage (picture firing AS at Sisters of the Moon right before the boss despawns and another one spawns), it broke all Patient Sniper bonus damage from that point forward
=> solved by filtering out cast events that are too old - AS has a fast travel time, around <700ms so I added 1s max travel time
2. If Vulnerable debuff windows were slightly larger than 7000ms due to lag (removedebuff() was called let's say 70ms later than it *should've been*), then the difference between shot cast and start of the debuff window was > 7000ms which resulted in timeIntoVulnerable = 7 
=> solved by adding 100ms lag tolerance