### PR TITLE
[ele shami] Refactored Overloads and added option to align the StatisticBox Icon

### DIFF
--- a/src/Main/StatisticBox.js
+++ b/src/Main/StatisticBox.js
@@ -5,11 +5,11 @@ import './StatisticBox.css';
 
 export { default as STATISTIC_ORDER } from './STATISTIC_ORDER';
 
-const StatisticBox = ({ icon, value, tooltip, label, footer, footerStyle, containerProps, ...others }) => (
+const StatisticBox = ({ icon, value, tooltip, label, footer, footerStyle, containerProps, alignIcon, ...others }) => (
   <div className="col-lg-4 col-sm-6 col-xs-12" {...containerProps}>
     <div className="panel statistic-box" {...others}>
       <div className="panel-body flex">
-        <div className="flex-sub" style={{ display: 'flex', alignItems: 'center' }}>
+        <div className="flex-sub" style={{ display: 'flex', alignItems: alignIcon }}>
           {icon}
         </div>
         <div className="flex-main text-right">
@@ -37,6 +37,11 @@ StatisticBox.propTypes = {
   footer: PropTypes.node,
   footerStyle: PropTypes.object,
   containerProps: PropTypes.object,
+  alignIcon: PropTypes.string,
+};
+
+StatisticBox.defaultProps = {
+  alignIcon: 'center',
 };
 
 export default StatisticBox;

--- a/src/Parser/Shaman/Elemental/CHANGELOG.js
+++ b/src/Parser/Shaman/Elemental/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+27-10-2017 - Refactored overload procs to show as a list (by fasib).
 26-10-2017 - Fix Totem Mastery Uptime (by fasib).
 28-08-2017 - Added Flame Shock, Totem Mastery, Elemental Blast, Ascendance, Lightning Rod Uptimes (by fasib).
 28-08-2017 - Fixed Maelstrom Tab (by fasib).

--- a/src/Parser/Shaman/Elemental/CombatLogParser.js
+++ b/src/Parser/Shaman/Elemental/CombatLogParser.js
@@ -1,11 +1,6 @@
 import React from 'react';
 
-import SpellIcon from 'common/SpellIcon';
 import Icon from 'common/Icon';
-// import ITEMS from 'common/ITEMS';
-import SPELLS from 'common/SPELLS';
-// import ItemLink from 'common/ItemLink';
-// import ItemIcon from 'common/ItemIcon';
 import { formatPercentage } from 'common/format';
 
 import StatisticBox from 'Main/StatisticBox';
@@ -23,6 +18,7 @@ import CastEfficiency from './Modules/Features/CastEfficiency';
 import CooldownTracker from './Modules/Features/CooldownTracker';
 import ProcTracker from './Modules/Features/ProcTracker';
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
+import Overload from './Modules/Features/Overload';
 
 import FlameShock from './Modules/ShamanCore/FlameShock';
 
@@ -54,6 +50,7 @@ class CombatLogParser extends CoreCombatLogParser {
     cooldownTracker: CooldownTracker,
     procTracker: ProcTracker,
     flameShock: FlameShock,
+    overload: Overload,
 
     // Talents
     aftershock: Aftershock,
@@ -68,25 +65,7 @@ class CombatLogParser extends CoreCombatLogParser {
   generateResults() {
     const results = super.generateResults();
 
-    // const hasEchosElements = this.selectedCombatant.hasTalent(SPELLS.ECHO_OF_THE_ELEMENTS_TALENT.id);
-    // const hasAscendance = this.selectedCombatant.hasTalent(SPELLS.ASCENDANCE_ELEMENTAL_TALENT.id);
-    // const hasLightningRod = this.selectedCombatant.hasTalent(SPELLS.LIGHTNING_ROD.id);
-    const hasIcefury = this.modules.combatants.selected.hasTalent(SPELLS.ICEFURY_TALENT.id);
-
-    const abilityTracker = this.modules.abilityTracker;
-    const getAbility = spellId => abilityTracker.getAbility(spellId);
-
-    // const lavaBurst = getAbility(SPELLS.LAVA_BURST.id);
-    // const lightningBolt = getAbility(SPELLS.LIGHTNING_BOLT.id);
-    const overloadLavaBurst = getAbility(SPELLS.LAVA_BURST_OVERLOAD.id);
-    const overloadLightningBolt = getAbility(SPELLS.LIGHTNING_BOLT_OVERLOAD_HIT.id);
-    const overloadElementalBlast = getAbility(SPELLS.ELEMENTAL_BLAST_OVERLOAD.id);
-    const overloadChainLightning = getAbility(SPELLS.CHAIN_LIGHTNING_OVERLOAD.id);
-    const overloadIcefury = hasIcefury && getAbility(SPELLS.ICEFURY_OVERLOAD.id);
-
     const fightDuration = this.fightDuration;
-
-    // const flameShockUptime = this.selectedCombatant.getBuffUptime(SPELLS.FLAME_SHOCK.id) / this.fightDuration;
 
     const nonDpsTimePercentage = this.modules.alwaysBeCasting.totalDamagingTimeWasted / fightDuration;
     const deadTimePercentage = this.modules.alwaysBeCasting.totalTimeWasted / fightDuration;
@@ -115,69 +94,6 @@ class CombatLogParser extends CoreCombatLogParser {
             Downtime
           </dfn>
         )}
-      />,
-      <StatisticBox
-        icon={<SpellIcon id={SPELLS.ELEMENTAL_MASTERY.id} />}
-        value={(
-          <span className="flexJustify">
-            <span>
-              <SpellIcon
-                id={SPELLS.LAVA_BURST_OVERLOAD.id}
-                style={{
-                  height: '1.3em',
-                  marginTop: '-.1em',
-                }}
-              />
-              {overloadLavaBurst.damageHits}{' '}
-            </span>
-            {' '}
-            <span>
-              <SpellIcon
-                id={SPELLS.LIGHTNING_BOLT_OVERLOAD_HIT.id}
-                style={{
-                  height: '1.3em',
-                  marginTop: '-.1em',
-                }}
-              />
-              {overloadLightningBolt.damageHits}{' '}
-            </span>
-            {' '}
-            <span>
-              <SpellIcon
-                id={SPELLS.ELEMENTAL_BLAST_OVERLOAD.id}
-                style={{
-                  height: '1.3em',
-                  marginTop: '-.1em',
-                }}
-              />
-              {overloadElementalBlast.damageHits}{' '}
-            </span>
-            {' '}
-            <span className="hideWider1200">
-              <SpellIcon
-                id={SPELLS.CHAIN_LIGHTNING_OVERLOAD.id}
-                style={{
-                  height: '1.3em',
-                  marginTop: '-.1em',
-                }}
-              />
-              {overloadChainLightning.damageHits}{' '}
-            </span>
-            { hasIcefury &&
-              <span className="hideWider1200">
-                <SpellIcon
-                  id={SPELLS.ICEFURY_OVERLOAD.id}
-                  style={{
-                    height: '1.3em',
-                    marginTop: '-.1em',
-                  }}
-                />
-                {overloadIcefury ? overloadIcefury.damageHits : '-' }{' '}
-              </span>
-            }
-          </span>
-        )}
-        label={'Overload procs'}
       />,
       ...results.statistics,
     ];

--- a/src/Parser/Shaman/Elemental/Modules/Features/Overload.js
+++ b/src/Parser/Shaman/Elemental/Modules/Features/Overload.js
@@ -1,0 +1,95 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+
+class Overload extends Analyzer {
+  static dependencies = {
+    abilityTracker: AbilityTracker,
+    combatants: Combatants,
+  };
+
+  spells = [];
+
+  on_initialized() {
+    this.active = true;
+
+    this.getAbility = spellId => this.abilityTracker.getAbility(spellId);
+
+    this.hasIcefury = this.combatants.selected.hasTalent(SPELLS.ICEFURY_TALENT.id);
+    this.hasElementalBlast = this.combatants.selected.hasTalent(SPELLS.ELEMENTAL_BLAST_TALENT.id);
+
+    this.spells = [
+      this.getHits(SPELLS.LAVA_BURST_OVERLOAD.id, SPELLS.LAVA_BURST.id),
+    ];
+  }
+
+  getHits(overloadSpellId, normalSpellId) {
+    const overloadSpell = this.getAbility(overloadSpellId);
+    const normalSpell = this.getAbility(normalSpellId);
+    const normal = !normalSpell.ability ? 0 : normalSpell.damageHits;
+    const overloads = !overloadSpell.ability ? 0 : overloadSpell.damageHits;
+    return {
+      id: overloadSpellId,
+      name: !normalSpell.ability ? 'a spell' : normalSpell.ability.name,
+      normal,
+      overloads,
+      percent: overloads/normal,
+    };
+  }
+
+  on_finished() {
+    this.spells = [
+      this.getHits(SPELLS.LAVA_BURST_OVERLOAD.id, SPELLS.LAVA_BURST.id),
+      this.getHits(SPELLS.LIGHTNING_BOLT_OVERLOAD_HIT.id, SPELLS.LIGHTNING_BOLT.id),
+      this.getHits(SPELLS.CHAIN_LIGHTNING_OVERLOAD.id, SPELLS.CHAIN_LIGHTNING.id),
+      this.hasElementalBlast && this.getHits(SPELLS.ELEMENTAL_BLAST_OVERLOAD.id, SPELLS.ELEMENTAL_BLAST_TALENT.id),
+      this.hasIcefury && this.getHits(SPELLS.ICEFURY_OVERLOAD.id, SPELLS.ICEFURY_TALENT.id),
+    ];
+  }
+
+  renderOverloads(spell) {
+    return (
+      spell &&
+      <li>
+        {`${spell.overloads} / ${spell.normal}` }{' '}
+        <SpellIcon
+          id={spell.id}
+          style={{
+            height: '1.3em',
+            marginTop: '-.1em',
+          }}
+        />
+      </li>
+    );
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        alignIcon='flex-start'
+        icon={<SpellIcon id={SPELLS.ELEMENTAL_MASTERY.id} />}
+        value={(
+          <ul style={{listStyle: 'none'}}>
+            {
+              this.spells.filter(spell => spell && spell.normal > 0).map(spell => {
+                return this.renderOverloads(spell);
+              })
+            }
+          </ul>
+        )}
+        label={'Overload procs'}
+        tooltip={ `${this.spells[0].overloads} / ${this.spells[0].normal} means you hit the target ${this.spells[0].normal} times with ${this.spells[0].name} and got ${this.spells[0].overloads} extra overload hits.`}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.OPTIONAL();
+}
+
+export default Overload;


### PR DESCRIPTION
Added a option/property to align the StatisticBox icon and refactored the overload module (moved it outside the CombatLogParser)
![chrome_2017-10-27_23-02-22](https://user-images.githubusercontent.com/317216/32125512-952adfd6-bb6c-11e7-9014-33dd2a723dcf.png)
