### PR TITLE
[frost mage] Added Splitting Ice module

### DIFF
--- a/src/Parser/Mage/Frost/CHANGELOG.js
+++ b/src/Parser/Mage/Frost/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+28-10-2017 - Added Splitting Ice module. (by Sref)
 17-10-2017 - Added Frozen Bomb, Unstable Magic, and Arctic Gale modules. (by Sref)
 17-10-2017 - Added Rune of Power and Mirror Image modules. (by Sref)
 16-10-2017 - Added Cooldown Reduction Tracking for Frozen Orb and Icy Veins. (by Sharrq)

--- a/src/Parser/Mage/Frost/CombatLogParser.js
+++ b/src/Parser/Mage/Frost/CombatLogParser.js
@@ -19,6 +19,7 @@ import FrostBomb from './Modules/Features/FrostBomb';
 import RuneOfPower from '../Shared/Modules/Features/RuneOfPower';
 import MirrorImage from '../Shared/Modules/Features/MirrorImage';
 import UnstableMagic from '../Shared/Modules/Features/UnstableMagic';
+import SplittingIce from './Modules/Features/SplittingIce';
 
 import FrozenOrb from './Modules/Cooldowns/FrozenOrb';
 import IcyVeins from './Modules/Cooldowns/IcyVeins';
@@ -46,6 +47,7 @@ class CombatLogParser extends CoreCombatLogParser {
     unstableMagic: UnstableMagic,
     arcticGale: ArcticGale,
     frostBomb: FrostBomb,
+    splittingIce: SplittingIce,
 
 	  //Cooldowns
     frozenOrb: FrozenOrb,

--- a/src/Parser/Mage/Frost/Modules/Features/BrainFreeze.js
+++ b/src/Parser/Mage/Frost/Modules/Features/BrainFreeze.js
@@ -37,7 +37,7 @@ class BrainFreezeTracker extends Analyzer {
 		if(this.combatants.selected.hasTalent(SPELLS.GLACIAL_SPIKE_TALENT.id)) {
 			when(missedProcsPercent).isGreaterThan(.05)
 				.addSuggestion((suggest, actual, recommended) => {
-					return suggest(<span>You wasted {formatPercentage(missedProcsPercent)}% of your <SpellLink id={SPELLS.BRAIN_FREEZE.id}/> procs. While this is mostly acceptable when using <SpellLink id={SPELLS.GLACIAL_SPIKE_TALENT.id}/>, try to minimize this by only holding your Brain Freeze Proc if you have 3 or more <SpellLink id={SPELLS.ICICLES.id}/>. If you have less than 3 Icicles then use your Brian Freeze Proc Normally.</span>)
+					return suggest(<span>You wasted {formatPercentage(missedProcsPercent)}% of your <SpellLink id={SPELLS.BRAIN_FREEZE.id}/> procs. While this is mostly acceptable when using <SpellLink id={SPELLS.GLACIAL_SPIKE_TALENT.id}/>, try to minimize this by only holding your Brain Freeze Proc if you have 3 or more <SpellLink id={SPELLS.ICICLES_BUFF.id}/>. If you have less than 3 Icicles then use your Brian Freeze Proc Normally.</span>)
 						.icon(SPELLS.BRAIN_FREEZE.icon)
 						.actual(`${formatPercentage(missedProcsPercent)}% missed`)
 						.recommended(`Wasting none is recommended`)

--- a/src/Parser/Mage/Frost/Modules/Features/IcicleTracker.js
+++ b/src/Parser/Mage/Frost/Modules/Features/IcicleTracker.js
@@ -31,7 +31,7 @@ class IcicleTracker extends Analyzer {
     when(wastedPerMinute).isGreaterThan(0)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span> You wasted {wastedPerMinute.toFixed(2)} <SpellLink id={SPELLS.ICICLES.id}/> Per Minute.  Try to cast <SpellLink id={SPELLS.GLACIAL_SPIKE_TALENT.id}/> once you get to 5 Icicles to avoid wasting them. Getting some wasted Icicles is unavoidable since <SpellLink id={SPELLS.FROSTBOLT.id}/> has a chance to generate 2 Icicles, but you should try and keep this number as low as possible.</span>)
-          .icon(SPELLS.ICICLES.icon)
+          .icon(SPELLS.ICICLES_BUFF.icon)
           .actual(`${formatNumber(actual)} Icicles Wasted`)
           .recommended(`${formatNumber(3)} is recommended`)
           .regular(3).major(5);
@@ -41,7 +41,7 @@ class IcicleTracker extends Analyzer {
     const wastedPerMinute = (this.wasted) / (this.owner.fightDuration / 60000);
     return (
       <StatisticBox
-        icon={<SpellIcon id={SPELLS.ICICLES.id} />}
+        icon={<SpellIcon id={SPELLS.ICICLES_BUFF.id} />}
         value={`${wastedPerMinute.toFixed(2)}`}
         label="Icicles Wasted Per Minute" />
     );

--- a/src/Parser/Mage/Frost/Modules/Features/IcicleTracker.js
+++ b/src/Parser/Mage/Frost/Modules/Features/IcicleTracker.js
@@ -30,7 +30,7 @@ class IcicleTracker extends Analyzer {
     const wastedPerMinute = (this.wasted) / (this.owner.fightDuration / 60000);
     when(wastedPerMinute).isGreaterThan(0)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span> You wasted {wastedPerMinute.toFixed(2)} <SpellLink id={SPELLS.ICICLES.id}/> Per Minute.  Try to cast <SpellLink id={SPELLS.GLACIAL_SPIKE_TALENT.id}/> once you get to 5 Icicles to avoid wasting them. Getting some wasted Icicles is unavoidable since <SpellLink id={SPELLS.FROSTBOLT.id}/> has a chance to generate 2 Icicles, but you should try and keep this number as low as possible.</span>)
+        return suggest(<span> You wasted {wastedPerMinute.toFixed(2)} <SpellLink id={SPELLS.ICICLES_BUFF.id}/> Per Minute.  Try to cast <SpellLink id={SPELLS.GLACIAL_SPIKE_TALENT.id}/> once you get to 5 Icicles to avoid wasting them. Getting some wasted Icicles is unavoidable since <SpellLink id={SPELLS.FROSTBOLT.id}/> has a chance to generate 2 Icicles, but you should try and keep this number as low as possible.</span>)
           .icon(SPELLS.ICICLES_BUFF.icon)
           .actual(`${formatNumber(actual)} Icicles Wasted`)
           .recommended(`${formatNumber(3)} is recommended`)

--- a/src/Parser/Mage/Frost/Modules/Features/SplittingIce.js
+++ b/src/Parser/Mage/Frost/Modules/Features/SplittingIce.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import { formatPercentage } from 'common/format';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import Analyzer from 'Parser/Core/Analyzer';
+import { encodeTargetString } from 'Parser/Core/Modules/EnemyInstances';
+
+import getDamageBonus from 'Parser/Mage/Shared/Modules/GetDamageBonus';
+
+const debug = false;
+
+const DAMAGE_BONUS = 0.05;
+const GLACIAL_SPIKE_BONUS_PORTION = 0.65; // GS benefits from Icicles in it, but totals less than the full 5%. This number currently a guess.
+
+class SplittingIce extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+	}
+
+  cleaveDamage = 0; // all damage to secondary target
+  boostDamage = 0; // damage to primary target attributable to boost
+
+  castTarget; // player's last directly targeted foe, used to tell which hit was on primary target
+
+  on_initialized() {
+	   this.active = this.combatants.selected.hasTalent(SPELLS.SPLITTING_ICE_TALENT.id);
+     this.hasGlacialSpike = this.combatants.selected.hasTalent(SPELLS.GLACIAL_SPIKE_TALENT.id);
+  }
+
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    // we check Frostbolt cast even though it doesn't split because it can launch overcapped icicles.
+    if(spellId !== SPELLS.ICE_LANCE_CAST.id && spellId !== SPELLS.FROSTBOLT.id && spellId !== SPELLS.GLACIAL_SPIKE_TALENT.id) {
+      return;
+    }
+
+    if(event.targetID) {
+      this.castTarget = encodeTargetString(event.targetID, event.targetInstance);
+    }
+  }
+
+  on_byPlayer_damage(event) {
+    const spellId = event.ability.guid;
+    if(spellId !== SPELLS.ICE_LANCE_DAMAGE.id && spellId !== SPELLS.ICICLE_DAMAGE.id && spellId !== SPELLS.GLACIAL_SPIKE_DAMAGE.id) {
+      return;
+    }
+
+    const damageTarget = encodeTargetString(event.targetID, event.targetInstance);
+    if(this.castTarget === damageTarget) {
+      let damageBonus = DAMAGE_BONUS;
+      if(spellId === SPELLS.GLACIAL_SPIKE_DAMAGE.id) {
+        damageBonus *= GLACIAL_SPIKE_BONUS_PORTION;
+      }
+      this.boostDamage += getDamageBonus(event, damageBonus);
+    } else {
+      this.cleaveDamage += event.amount + (event.absorbed || 0);
+      if(debug) { console.log(`Splitting Ice cleave for ${event.amount + (event.absorbed || 0)} : castTarget=${this.castTarget} damageTarget=${damageTarget}`); }
+    }
+  }
+
+  get damage() {
+    return this.cleaveDamage + this.boostDamage;
+  }
+
+  statistic() {
+    const damagePercent = this.owner.getPercentageOfTotalDamageDone(this.damage);
+    const cleaveDamagePercent = this.owner.getPercentageOfTotalDamageDone(this.cleaveDamage);
+    const boostDamagePercent = this.owner.getPercentageOfTotalDamageDone(this.boostDamage);
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.SPLITTING_ICE_TALENT.id} />}
+        value={`${this.hasGlacialSpike ? '≈' : ''}${formatPercentage(damagePercent)} %`}
+        label="Splitting Ice damage"
+        tooltip={`This is all the secondary target damage summed with the portion of primary target damage attributable to Splitting Ice.${this.hasGlacialSpike ? ' Because only the icicles inside each Glacial Spike are boosted, the damage bonus to Glacial Spike is estimated.' : ''}
+          <ul>
+            <li>Primary Target Boosted: <b>${this.hasGlacialSpike ? '≈' : ''}${formatPercentage(boostDamagePercent)}%</b></li>
+            <li>Secondary Target Total: <b>${formatPercentage(cleaveDamagePercent)}%</b></li>
+          </ul>
+        `}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(0);
+
+}
+
+export default SplittingIce;

--- a/src/common/SPELLS/MAGE.js
+++ b/src/common/SPELLS/MAGE.js
@@ -239,7 +239,7 @@ export default {
     name: 'Glacial Eruption',
     icon: 'creatureportrait_creature_iceblock',
   },
-  ICICLES: {
+  ICICLE_DAMAGE: {
     id: 148022,
     name: 'Icicle',
     icon: 'spell_frost_iceshard',


### PR DESCRIPTION
Added a splitting ice module that calculates total damage boost and also breaks it down by primary target boost and secondary target cleave.

Also renamed ICICLES spell to ICICLE_DAMAGE, as the actual spell name is "Icicle" and I want to make it more easily differentiated from ICICLES_BUFF