### PR TITLE
[Unholy Death Knight] Added cooldown tracker for unholy

### DIFF
--- a/src/Parser/DeathKnight/Unholy/Modules/Features/CooldownTracker.js
+++ b/src/Parser/DeathKnight/Unholy/Modules/Features/CooldownTracker.js
@@ -1,12 +1,60 @@
-import CoreCooldownTracker from 'Parser/Core/Modules/CooldownTracker';
+import CoreCooldownTracker, {BUILT_IN_SUMMARY_TYPES} from 'Parser/Core/Modules/CooldownTracker';
+
+import SPELLS from 'common/SPELLS';
+
+const debug = false;
 
 class CooldownTracker extends CoreCooldownTracker {
   static cooldownSpells = [
     ...CooldownTracker.cooldownSpells,
     // if im understanding correctly CooldownTracker tracks all abilities cast during the duration of some CD that buffs you in some way, (ex Battle Cry, Pillar of Frost)
-    // Unholy's CDs are all based around summons, so its not working by following default examples
-    // TODO: study demo warlock's CooldownTracker, they got it figured out
+    // Unholy's CDs are all based around summons so nothing goes here
   ];
+
+  static castCooldowns = [
+    {
+      spell: SPELLS.DARK_ARBITER_TALENT,
+      // tooltip duration is 20 seconds but with the way she works we want to capture 22 seconds
+      duration: 22,
+      summary: [
+        BUILT_IN_SUMMARY_TYPES.DAMAGE,
+      ],
+    },
+  ]
+
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    const cooldownSpell = this.constructor.castCooldowns.find(cooldownSpell => cooldownSpell.spell.id === spellId);
+    if (cooldownSpell) {
+      // adding the fixed cooldown, now we need to remove it from activeCooldowns too
+      const cooldown = this._addFixedCooldown(cooldownSpell, event.timestamp);
+      this.activeCooldowns.push(cooldown);
+      debug && console.log(`%cCooldown started: ${cooldownSpell.spell.name}`, 'color: green', cooldown);
+    }
+    // super.on_byPlayer_cast(event) would call trackEvent anyway
+    super.on_byPlayer_cast && super.on_byPlayer_cast(event);
+  }
+
+  _addFixedCooldown(cooldownSpell, timestamp) {
+    const cooldown = {
+      ...cooldownSpell,
+      start: timestamp,
+      end: timestamp + cooldownSpell.duration * 1000,
+      events: [],
+    };
+    this.pastCooldowns.push(cooldown);
+    return cooldown;
+  }
+
+  // on_event() might be more accurate but it would be most likely called much more
+  trackEvent(event) {
+    this.activeCooldowns = this.activeCooldowns.filter(cooldown => !cooldown.end || event.timestamp < cooldown.end);
+    super.trackEvent(event);
+  }
+
+  on_byPlayerPet_damage(event) {
+    this.trackEvent(event);
+  }
 }
 
 export default CooldownTracker;

--- a/src/common/SPELLS/DEATH_KNIGHT.js
+++ b/src/common/SPELLS/DEATH_KNIGHT.js
@@ -135,12 +135,14 @@ export default {
   // ...
 
   // Unholy:
+  // Aritfact ability
   APOCALYPSE: {
     id: 220143,
     name: 'Apocalypse',
     icon: 'artifactability_unholydeathknight_deathsembrace',
   },
 
+  // Spells
   ARMY_OF_THE_DEAD: {
     id: 42650,
     name: 'Army of the Dead',
@@ -194,13 +196,7 @@ export default {
     name: 'Scourge Strike',
     icon: 'spell_deathknight_scourgestrike',
   },
-
-  SUDDEN_DOOM: {
-    id: 49530,
-    name: 'Sudden Doom',
-    icon: 'spell_shadow_painspike',
-  },
-
+  
   SUMMON_GARGOYLE: {
     id: 49206,
     name: 'Summon Gargoyle',
@@ -211,8 +207,21 @@ export default {
     id: 191587,
     name: 'Virulent Plague',
     icon: 'ability_creature_disease_02',
-  },  
+  },
+  
+  // Artifact traits:
+  SUDDEN_DOOM: {
+    id: 49530,
+    name: 'Sudden Doom',
+    icon: 'spell_shadow_painspike',
+  },
 
+  ETERNAL_AGONY: {
+    id: 208598,
+    name: 'Eternal Agony',
+    icon: 'achievement_boss_festergutrotface',
+  },
+  
   // Shared:
   ANTI_MAGIC_SHELL: {
     id: 48707,
@@ -298,3 +307,4 @@ export default {
     icon: 'inv_helm_plate_raiddeathknight_p_01',
   },
 };
+	


### PR DESCRIPTION
Unholy only has one cooldown where we have a window where we care about what we cast so this is a pretty small feature.  Highly useful though as most of our damage comes from that CD.    