### PR TITLE
[Ele Shami] Changed the overload StatisticBox layout to match the new left text-alignment.

### DIFF
--- a/src/Parser/Shaman/Elemental/Modules/Features/Overload.js
+++ b/src/Parser/Shaman/Elemental/Modules/Features/Overload.js
@@ -65,7 +65,9 @@ class Overload extends Analyzer {
             marginTop: '-.1em',
           }}
         />
-        <span style={{width: 'calc(100% - 1.3em)', display: 'inline-block', textAlign: 'center'}}>{` ${spell.overloads} / ${spell.normal}`}</span>
+        <span style={{display: 'inline-block', textAlign: 'left', marginLeft: '0.5em'}}>
+          {`${spell.overloads} / ${spell.normal}`}
+        </span>
       </li>
     );
   }

--- a/src/Parser/Shaman/Elemental/Modules/Features/Overload.js
+++ b/src/Parser/Shaman/Elemental/Modules/Features/Overload.js
@@ -27,6 +27,10 @@ class Overload extends Analyzer {
 
     this.spells = [
       this.getHits(SPELLS.LAVA_BURST_OVERLOAD.id, SPELLS.LAVA_BURST.id),
+      this.getHits(SPELLS.LIGHTNING_BOLT_OVERLOAD_HIT.id, SPELLS.LIGHTNING_BOLT.id),
+      this.getHits(SPELLS.CHAIN_LIGHTNING_OVERLOAD.id, SPELLS.CHAIN_LIGHTNING.id),
+      this.hasElementalBlast && this.getHits(SPELLS.ELEMENTAL_BLAST_OVERLOAD.id, SPELLS.ELEMENTAL_BLAST_TALENT.id),
+      this.hasIcefury && this.getHits(SPELLS.ICEFURY_OVERLOAD.id, SPELLS.ICEFURY_TALENT.id),
     ];
   }
 
@@ -51,7 +55,7 @@ class Overload extends Analyzer {
       this.getHits(SPELLS.CHAIN_LIGHTNING_OVERLOAD.id, SPELLS.CHAIN_LIGHTNING.id),
       this.hasElementalBlast && this.getHits(SPELLS.ELEMENTAL_BLAST_OVERLOAD.id, SPELLS.ELEMENTAL_BLAST_TALENT.id),
       this.hasIcefury && this.getHits(SPELLS.ICEFURY_OVERLOAD.id, SPELLS.ICEFURY_TALENT.id),
-    ].filter(spell => spell && spell.normal > 0).sort((a,b) => b.overloads - a.overloads);
+    ];
   }
 
   renderOverloads(spell) {

--- a/src/Parser/Shaman/Elemental/Modules/Features/Overload.js
+++ b/src/Parser/Shaman/Elemental/Modules/Features/Overload.js
@@ -58,7 +58,6 @@ class Overload extends Analyzer {
     return (
       spell &&
       <li>
-        {`${spell.overloads} / ${spell.normal}` }{' '}
         <SpellIcon
           id={spell.id}
           style={{
@@ -66,6 +65,7 @@ class Overload extends Analyzer {
             marginTop: '-.1em',
           }}
         />
+        <span style={{width: 'calc(100% - 1.3em)', display: 'inline-block', textAlign: 'center'}}>{` ${spell.overloads} / ${spell.normal}`}</span>
       </li>
     );
   }
@@ -76,7 +76,7 @@ class Overload extends Analyzer {
         alignIcon='flex-start'
         icon={<SpellIcon id={SPELLS.ELEMENTAL_MASTERY.id} />}
         value={(
-          <ul style={{listStyle: 'none'}}>
+          <ul style={{listStyle: 'none', paddingLeft: 0}}>
             {
               this.spells.filter(spell => spell && spell.normal > 0).map(spell => {
                 return this.renderOverloads(spell);

--- a/src/Parser/Shaman/Elemental/Modules/Features/Overload.js
+++ b/src/Parser/Shaman/Elemental/Modules/Features/Overload.js
@@ -51,7 +51,7 @@ class Overload extends Analyzer {
       this.getHits(SPELLS.CHAIN_LIGHTNING_OVERLOAD.id, SPELLS.CHAIN_LIGHTNING.id),
       this.hasElementalBlast && this.getHits(SPELLS.ELEMENTAL_BLAST_OVERLOAD.id, SPELLS.ELEMENTAL_BLAST_TALENT.id),
       this.hasIcefury && this.getHits(SPELLS.ICEFURY_OVERLOAD.id, SPELLS.ICEFURY_TALENT.id),
-    ];
+    ].filter(spell => spell && spell.normal > 0).sort((a,b) => b.overloads - a.overloads);
   }
 
   renderOverloads(spell) {
@@ -80,7 +80,7 @@ class Overload extends Analyzer {
         value={(
           <ul style={{listStyle: 'none', paddingLeft: 0}}>
             {
-              this.spells.filter(spell => spell && spell.normal > 0).map(spell => {
+              this.spells.map(spell => {
                 return this.renderOverloads(spell);
               })
             }


### PR DESCRIPTION
Old-Layout:
![firefox_2017-10-29_23-24-57](https://user-images.githubusercontent.com/317216/32149126-6e1deaf6-bd00-11e7-9901-61f4e6614085.png)


New-Layout:
![firefox_2017-10-29_23-25-04](https://user-images.githubusercontent.com/317216/32149127-70a52780-bd00-11e7-9444-4de19c527bfb.png)

