### PR TITLE
[frost mage] Fixed IceLance suggestion tip

### DIFF
--- a/src/Parser/Mage/Frost/Modules/Features/IceLance.js
+++ b/src/Parser/Mage/Frost/Modules/Features/IceLance.js
@@ -56,15 +56,14 @@ class IceLance extends Analyzer {
 	}
 
 	suggestions(when) {
-		const shattered = 1 - (this.nonShatteredCasts / this.abilityTracker.getAbility(SPELLS.ICE_LANCE_CAST.id).casts);
 		const nonShatteredPercent = (this.nonShatteredCasts / this.abilityTracker.getAbility(SPELLS.ICE_LANCE_CAST.id).casts);
-		when(shattered).isLessThan(0.9)
+		when(nonShatteredPercent).isGreaterThan(0.1)
 			.addSuggestion((suggest, actual, recommended) => {
 				return suggest(<span>You cast <SpellLink id={SPELLS.ICE_LANCE_CAST.id} /> {this.nonShatteredCasts} times ({formatPercentage(nonShatteredPercent)}%) without <SpellLink id={SPELLS.SHATTER.id} />. Make sure that you are only casting Ice Lance when the target has <SpellLink id={SPELLS.WINTERS_CHILL.id} /> (or other Shatter effects), if you have a <SpellLink id={SPELLS.FINGERS_OF_FROST.id} /> proc, or if you are moving and you cant cast anything else.</span>)
 					.icon(SPELLS.ICE_LANCE_CAST.icon)
-					.actual(`${formatPercentage(shattered)}% Ice Lances shattered`)
-					.recommended(`>${formatPercentage(recommended)}% is recommended`)
-					.regular(.9).major(.8);
+					.actual(`${formatPercentage(nonShatteredPercent)}% missed`)
+					.recommended(`<${formatPercentage(recommended)}% is recommended`)
+					.regular(0.1).major(0.2);
 			});
 	}
 

--- a/src/Parser/Mage/Frost/Modules/Features/IceLance.js
+++ b/src/Parser/Mage/Frost/Modules/Features/IceLance.js
@@ -62,8 +62,8 @@ class IceLance extends Analyzer {
 			.addSuggestion((suggest, actual, recommended) => {
 				return suggest(<span>You cast <SpellLink id={SPELLS.ICE_LANCE_CAST.id} /> {this.nonShatteredCasts} times ({formatPercentage(nonShatteredPercent)}%) without <SpellLink id={SPELLS.SHATTER.id} />. Make sure that you are only casting Ice Lance when the target has <SpellLink id={SPELLS.WINTERS_CHILL.id} /> (or other Shatter effects), if you have a <SpellLink id={SPELLS.FINGERS_OF_FROST.id} /> proc, or if you are moving and you cant cast anything else.</span>)
 					.icon(SPELLS.ICE_LANCE_CAST.icon)
-					.actual(`${formatPercentage(shattered)}% missed`)
-					.recommended(`${formatPercentage(recommended)}% is Recommended`)
+					.actual(`${formatPercentage(shattered)}% Ice Lances shattered`)
+					.recommended(`>${formatPercentage(recommended)}% is recommended`)
 					.regular(.9).major(.8);
 			});
 	}


### PR DESCRIPTION
Ice Lance suggestion tip showed actual as 'missed' when it was actually the percentage hit. Uncapitalized 'recommended' to match style.

These changes are entirely to output text, and not to code.