### PR TITLE
[Core/FrostMage] Cancelled Casts

### DIFF
--- a/src/Parser/Core/Modules/CancelledCasts.js
+++ b/src/Parser/Core/Modules/CancelledCasts.js
@@ -26,7 +26,7 @@ class CancelledCasts extends Analyzer {
     if (this.constructor.IGNORED_ABILITIES.includes(spellId)) {
       return;
     }
-    if (this.wasCastStarted === true) {
+    if (this.wasCastStarted) {
       this.castsCancelled += 1;
     }
     this.beginCastSpellId = event.ability.guid;
@@ -38,10 +38,10 @@ class CancelledCasts extends Analyzer {
     if (this.constructor.IGNORED_ABILITIES.includes(spellId)) {
       return;
     }
-    if (this.beginCastSpellId !== spellId && this.wasCastStarted === true) {
+    if (this.beginCastSpellId !== spellId && this.wasCastStarted) {
       this.castsCancelled += 1;
     }
-    if (this.beginCastSpellId === spellId && this.wasCastStarted === true) {
+    if (this.beginCastSpellId === spellId && this.wasCastStarted) {
       this.castsFinished += 1;
     }
     this.wasCastStarted = false;

--- a/src/Parser/Core/Modules/CancelledCasts.js
+++ b/src/Parser/Core/Modules/CancelledCasts.js
@@ -1,0 +1,76 @@
+import React from 'react';
+
+import Icon from 'common/Icon';
+import { formatMilliseconds, formatNumber, formatPercentage } from 'common/format';
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+
+const debug = false;
+
+class CancelledCasts extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  castsStarted = 0;
+  castsFinished = 0;
+  beginCastTimestamp = 0;
+  castTimestamp = 0;
+
+  static CANCELABLE_ABILITIES = [
+  ];
+
+  on_byPlayer_begincast(event) {
+    const spellId = event.ability.guid;
+    if (!this.constructor.CANCELABLE_ABILITIES.includes(spellId)) {
+      return;
+    }
+    this.beginCastTimestamp = event.timestamp;
+    this.castsStarted += 1;
+  }
+
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    const castTimestamp = event.timestamp;
+    const castTime = castTimestamp - this.beginCastTimestamp;
+    if (!this.constructor.CANCELABLE_ABILITIES.includes(spellId)) {
+      return;
+    }
+    if (castTime < 100) {
+      this.castsStarted -= 1;
+    } else {
+      this.castsFinished += 1;
+    }
+  }
+
+  get cancelledCasts() {
+    return this.castsStarted - this.castsFinished;
+  }
+
+  on_finished() {
+    debug && console.log(formatMilliseconds(this.owner.fightDuration), 'Casts Started:', `${formatNumber(this.castsStarted)}`);
+    debug && console.log(formatMilliseconds(this.owner.fightDuration), 'Casts Completed:', `${formatNumber(this.castsFinished)}`);
+  }
+
+  statistic() {
+    const cancelledPercentage = this.cancelledCasts / this.castsStarted;
+
+    return (
+      <StatisticBox
+        icon={<Icon icon="inv_misc_map_01" alt="Cancelled Casts" />}
+        value={`${formatPercentage(cancelledPercentage)} %`}
+        label="Casts Cancelled"
+        tooltip={`You cast ${this.castsStarted} spells.
+          <ul>
+            <li>${this.castsFinished} casts were completed</li>
+            <li>${this.cancelledCasts} casts were cancelled</li>
+          </ul>
+        `}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(10);
+}
+
+export default CancelledCasts;

--- a/src/Parser/Mage/Frost/CHANGELOG.js
+++ b/src/Parser/Mage/Frost/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+30-10-2017 - Added Cancelled Casts Module. (by Sharrq)
 29-10-2017 - Added Ice Lance Utiliztion Module. (by Sharrq)
 28-10-2017 - Enhanced display of Winter's Chill and Brain Freeze statistics. (by Sref)
 28-10-2017 - Added Splitting Ice module. (by Sref)

--- a/src/Parser/Mage/Frost/CONFIG.js
+++ b/src/Parser/Mage/Frost/CONFIG.js
@@ -20,7 +20,7 @@ export default {
 	  Additionally I am not a pro when it comes to programming these modules and analysis. So if something is missing that you think should be added, you run into an issue with something i made, or if you make a module that you think should be added, please send it to me! <br /> <br />
     </div>
   ),
-  specDiscussionUrl: 'https://github.com/WoWAnalyzer/WoWAnalyzer/issues/467',
+  specDiscussionUrl: 'https://github.com/WoWAnalyzer/WoWAnalyzer/milestone/3',
   parser: CombatLogParser,
   path: __dirname, // used for generating a GitHub link directly to your spec
 };

--- a/src/Parser/Mage/Frost/CombatLogParser.js
+++ b/src/Parser/Mage/Frost/CombatLogParser.js
@@ -3,6 +3,7 @@ import DamageDone from 'Parser/Core/Modules/DamageDone';
 
 import CastEfficiency from './Modules/Features/CastEfficiency';
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
+import CancelledCasts from './Modules/Features/CancelledCasts';
 import CooldownTracker from './Modules/Features/CooldownTracker';
 import WintersChillTracker from './Modules/Features/WintersChill';
 import BrainFreeze from './Modules/Features/BrainFreeze';
@@ -31,6 +32,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Features
     castEfficiency: CastEfficiency,
     alwaysBeCasting: AlwaysBeCasting,
+    cancelledCasts: CancelledCasts,
     cooldownTracker: CooldownTracker,
 	  wintersChillTracker: WintersChillTracker,
 	  brainFreeze: BrainFreeze,

--- a/src/Parser/Mage/Frost/CombatLogParser.js
+++ b/src/Parser/Mage/Frost/CombatLogParser.js
@@ -3,7 +3,6 @@ import DamageDone from 'Parser/Core/Modules/DamageDone';
 
 import CastEfficiency from './Modules/Features/CastEfficiency';
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
-import CancelledCasts from './Modules/Features/CancelledCasts';
 import CooldownTracker from './Modules/Features/CooldownTracker';
 import WintersChillTracker from './Modules/Features/WintersChill';
 import BrainFreeze from './Modules/Features/BrainFreeze';
@@ -16,6 +15,7 @@ import RuneOfPower from '../Shared/Modules/Features/RuneOfPower';
 import MirrorImage from '../Shared/Modules/Features/MirrorImage';
 import UnstableMagic from '../Shared/Modules/Features/UnstableMagic';
 import SplittingIce from './Modules/Features/SplittingIce';
+import CancelledCasts from '../Shared/Modules/Features/CancelledCasts';
 
 import FrozenOrb from './Modules/Cooldowns/FrozenOrb';
 import IcyVeins from './Modules/Cooldowns/IcyVeins';
@@ -26,6 +26,8 @@ import ZannesuJourney from './Modules/Items/ZannesuJourney';
 import MagtheridonsBanishedBracers from './Modules/Items/MagtheridonsBanishedBracers';
 import ShatteredFragmentsOfSindragosa from './Modules/Items/ShatteredFragmentsOfSindragosa';
 import SoulOfTheArchmage from './Modules/Items/SoulOfTheArchmage';
+
+
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {

--- a/src/Parser/Mage/Frost/Modules/Features/CancelledCasts.js
+++ b/src/Parser/Mage/Frost/Modules/Features/CancelledCasts.js
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import CoreCancelledCasts from 'Parser/Core/Modules/CancelledCasts';
+
+import SPELLS from 'common/SPELLS';
+import { formatPercentage } from 'common/format';
+import { STATISTIC_ORDER } from 'Main/StatisticBox';
+
+class CancelledCasts extends CoreCancelledCasts {
+  static CANCELABLE_ABILITIES = [
+    //Castable/Non Instant Spells that you want to track to see if they were cancelled.
+    //Spells that have a cast time which is sometimes instant can also be included.
+    SPELLS.FROSTBOLT.id,
+    SPELLS.EBONBOLT.id,
+    SPELLS.BLIZZARD.id,
+    //Talents
+    SPELLS.GLACIAL_SPIKE_TALENT.id,
+    SPELLS.RUNE_OF_POWER_TALENT.id,
+    SPELLS.RAY_OF_FROST_TALENT.id,
+    SPELLS.RING_OF_FROST_TALENT.id,
+    SPELLS.FROST_BOMB_TALENT.id,
+  ];
+
+  suggestions(when) {
+    const cancelledPercentage = this.cancelledCasts / this.castsStarted;
+
+    when(cancelledPercentage).isGreaterThan(0.05)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<span>You cancelled {formatPercentage(cancelledPercentage)}% of your spells. While it is expected that you will have to cancel a few casts to react to a boss mechanic or to move, you should try to ensure that you are cancelling as few casts as possible.</span>)
+          .icon('inv_misc_map_01')
+          .actual(`${formatPercentage(actual)}% casts cancelled`)
+          .recommended(`<${formatPercentage(recommended)}% is recommended`)
+          .regular(.1).major(recommended + 0.2);
+      });
+  }
+
+  statisticOrder = STATISTIC_ORDER.CORE(1);
+}
+
+export default CancelledCasts;

--- a/src/Parser/Mage/Shared/Modules/Features/CancelledCasts.js
+++ b/src/Parser/Mage/Shared/Modules/Features/CancelledCasts.js
@@ -27,7 +27,7 @@ class CancelledCasts extends CoreCancelledCasts {
       });
   }
 
-  statisticOrder = STATISTIC_ORDER.CORE(1);
+  statisticOrder = STATISTIC_ORDER.CORE(2);
 }
 
 export default CancelledCasts;

--- a/src/Parser/Mage/Shared/Modules/Features/CancelledCasts.js
+++ b/src/Parser/Mage/Shared/Modules/Features/CancelledCasts.js
@@ -7,22 +7,15 @@ import { formatPercentage } from 'common/format';
 import { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class CancelledCasts extends CoreCancelledCasts {
-  static CANCELABLE_ABILITIES = [
-    //Castable/Non Instant Spells that you want to track to see if they were cancelled.
-    //Spells that have a cast time which is sometimes instant can also be included.
-    SPELLS.FROSTBOLT.id,
-    SPELLS.EBONBOLT.id,
-    SPELLS.BLIZZARD.id,
-    //Talents
-    SPELLS.GLACIAL_SPIKE_TALENT.id,
-    SPELLS.RUNE_OF_POWER_TALENT.id,
-    SPELLS.RAY_OF_FROST_TALENT.id,
-    SPELLS.RING_OF_FROST_TALENT.id,
-    SPELLS.FROST_BOMB_TALENT.id,
+  static IGNORED_ABILITIES = [
+    //Include the spells that you do not want to be tracked and spells that are castable while casting (Like Fire Blast, Combustion, or Shimmer)
+    SPELLS.FIRE_BLAST.id,
+    SPELLS.COMBUSTION.id,
+    SPELLS.SHIMMER_TALENT.id,
   ];
 
   suggestions(when) {
-    const cancelledPercentage = this.cancelledCasts / this.castsStarted;
+    const cancelledPercentage = this.castsCancelled / this.totalCasts;
 
     when(cancelledPercentage).isGreaterThan(0.05)
       .addSuggestion((suggest, actual, recommended) => {


### PR DESCRIPTION
Module for showing the % of casts that were cancelled. Tooltip also shows the breakdown of spells cast, completed, and cancelled. Also filters out spells with a cast time, but the cast time was made instant by some proc or other event (Like Blizzard - Instant if Frozen Orb is up) .... but if the dev includes a pure instant cast spell in the list, then it will likely screw with the results because Instant Cast Spells dont have a "begincast", but spells that are sometimes instant do.