### PR TITLE
[resto druid] Migrated StatWeights to use the new core version

### DIFF
--- a/src/Parser/Core/Modules/Features/BaseHealerStatWeights.js
+++ b/src/Parser/Core/Modules/Features/BaseHealerStatWeights.js
@@ -136,6 +136,9 @@ class BaseHealerStatWeights extends Analyzer {
     if (spellInfo.hasteHpct) {
       this.totalOneHasteHpct += this._hasteHpct(event, healVal);
     }
+    if (spellInfo.hasteHpm) {
+      this.totalOneHasteHpm += this._hasteHpm(event, healVal);
+    }
     if (spellInfo.mastery) {
       this.totalOneMastery += this._mastery(event, healVal);
     }
@@ -207,6 +210,11 @@ class BaseHealerStatWeights extends Analyzer {
     const healIncreaseFromOneHaste = 1 / this.statTracker.hasteRatingPerPercent;
 
     return healVal.effective * healIncreaseFromOneHaste;
+  }
+  _hasteHpm(event, healVal) {
+    const healIncreaseFromOneHaste = 1 / this.statTracker.hasteRatingPerPercent;
+    const noHasteHealing = healVal.effective / (1 + this.statTracker.currentHastePercentage);
+    return noHasteHealing * healIncreaseFromOneHaste;
   }
   _mastery(event, healVal) {
     throw new Error('Missing custom Mastery implementation. This is different per spec.');

--- a/src/Parser/Druid/Restoration/SpellInfo.js
+++ b/src/Parser/Druid/Restoration/SpellInfo.js
@@ -23,7 +23,7 @@ const DEFAULT_INFO = { // we assume unlisted spells scale with vers only (this w
   vers: true,
 };
 
-export const HEAL_INFO = {
+export const DRUID_HEAL_INFO = {
   [SPELLS.REJUVENATION.id]: {
     int: true,
     crit: true,
@@ -214,15 +214,6 @@ export const HEAL_INFO = {
     masteryStack: false,
     vers: false,
   },
-  [SPELLS.XAVARICS_MAGNUM_OPUS.id]: { // same as default, but included to emphasize it does scale with vers, despite %hp scaling...
-    int: false,
-    crit: false,
-    hasteHpm: false,
-    hasteHpct: false,
-    mastery: false,
-    masteryStack: false,
-    vers: true,
-  },
   [SPELLS.DREAMER.id]: { // T21 2pc TODO double check this once its live
     int: true,
     crit: true,
@@ -232,14 +223,8 @@ export const HEAL_INFO = {
     masteryStack: true,
     vers: true,
   },
-  [SPELLS.LEECH.id]: { // procs a percent of all your healing, so we ignore for weights and total healing
-    multiplier: true,
-  },
-  [SPELLS.VELENS_FUTURE_SIGHT.id]: { // while active procs from any healing, so we ignore for weights and total healing
-    multiplier: true,
-  },
 };
 
 export const getSpellInfo = id => {
-  return HEAL_INFO[id] || DEFAULT_INFO;
+  return DRUID_HEAL_INFO[id] || DEFAULT_INFO;
 };


### PR DESCRIPTION
Currently, I completely copy the standalone version's functionality, overriding core version where appropriate.

I also needed to add missing `_hasteHpm` function to BaseHealerStatWeights.