### PR TITLE
[Vengeance] Pain chart error handling message

### DIFF
--- a/src/Parser/DemonHunter/Vengeance/Modules/PainChart/Pain.js
+++ b/src/Parser/DemonHunter/Vengeance/Modules/PainChart/Pain.js
@@ -84,15 +84,24 @@ class Pain extends React.PureComponent {
       );
     }
 
-    const { start, end } = this.props;
+		if(!this.state.pain.series[0]) {
+			return (
+				<div>
+					This pain chart data from Warcraft Logs is corrupted and it cannot be parsed.
+				</div>
+			);
+		}
 
+    const { start, end } = this.props;
     const painBySecond = {
       0: 0,
     };
+
     this.state.pain.series[0].data.forEach((item) => {
       const secIntoFight = Math.floor((item[0] - start) / 1000);
       painBySecond[secIntoFight] = item[1];
     });
+
     const bosses = [];
     const deadBosses = [];
     this.state.bossHealth.series.forEach((series) => {


### PR DESCRIPTION
It was an error with the WCL api response: the response for the pain data chart was returning an empty array because the log from WCL was corrupted. So I now output an error message and prevents the analyzer to crash.