### PR TITLE
[frost mage] Redo statistic ordering

### DIFF
--- a/src/Parser/Mage/Frost/Modules/Features/ArcticGale.js
+++ b/src/Parser/Mage/Frost/Modules/Features/ArcticGale.js
@@ -39,7 +39,7 @@ class ArcticGale extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(0);
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(10);
 
   // TODO suggest when Arctic Gale damage is very low but non-zero?
   suggestions(when) {

--- a/src/Parser/Mage/Frost/Modules/Features/BrainFreeze.js
+++ b/src/Parser/Mage/Frost/Modules/Features/BrainFreeze.js
@@ -131,7 +131,7 @@ class BrainFreezeTracker extends Analyzer {
 			/>
 		);
 	}
-	statisticOrder = STATISTIC_ORDER.OPTIONAL(2);
+	statisticOrder = STATISTIC_ORDER.CORE(12);
 }
 
 export default BrainFreezeTracker;

--- a/src/Parser/Mage/Frost/Modules/Features/FrostBomb.js
+++ b/src/Parser/Mage/Frost/Modules/Features/FrostBomb.js
@@ -54,7 +54,7 @@ class FrostBomb extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(0);
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(10);
 }
 
 export default FrostBomb;

--- a/src/Parser/Mage/Frost/Modules/Features/IceLance.js
+++ b/src/Parser/Mage/Frost/Modules/Features/IceLance.js
@@ -78,7 +78,7 @@ class IceLance extends Analyzer {
 			/>
 		);
 	}
-	statisticOrder = STATISTIC_ORDER.OPTIONAL(2);
+	statisticOrder = STATISTIC_ORDER.CORE(10);
 }
 
 export default IceLance;

--- a/src/Parser/Mage/Frost/Modules/Features/IcicleTracker.js
+++ b/src/Parser/Mage/Frost/Modules/Features/IcicleTracker.js
@@ -46,7 +46,7 @@ class IcicleTracker extends Analyzer {
         label="Icicles Wasted Per Minute" />
     );
   }
-  statisticOrder = STATISTIC_ORDER.CORE(2);
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(0);
 }
 
 export default IcicleTracker;

--- a/src/Parser/Mage/Frost/Modules/Features/SplittingIce.js
+++ b/src/Parser/Mage/Frost/Modules/Features/SplittingIce.js
@@ -82,7 +82,7 @@ class SplittingIce extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(0);
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(10);
 
 }
 

--- a/src/Parser/Mage/Frost/Modules/Features/ThermalVoid.js
+++ b/src/Parser/Mage/Frost/Modules/Features/ThermalVoid.js
@@ -62,7 +62,7 @@ class ThermalVoid extends Analyzer {
     );
   }
 
-  statisticOrder = STATISTIC_ORDER.CORE(3);
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(0);
 }
 
 export default ThermalVoid;

--- a/src/Parser/Mage/Frost/Modules/Features/WintersChill.js
+++ b/src/Parser/Mage/Frost/Modules/Features/WintersChill.js
@@ -159,7 +159,7 @@ class WintersChillTracker extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.CORE(2);
+  statisticOrder = STATISTIC_ORDER.CORE(14);
 }
 
 export default WintersChillTracker;

--- a/src/Parser/Mage/Shared/Modules/Features/MirrorImage.js
+++ b/src/Parser/Mage/Shared/Modules/Features/MirrorImage.js
@@ -62,7 +62,7 @@ class MirrorImage extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(0);
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(100);
 }
 
 export default MirrorImage;

--- a/src/Parser/Mage/Shared/Modules/Features/RuneOfPower.js
+++ b/src/Parser/Mage/Shared/Modules/Features/RuneOfPower.js
@@ -51,7 +51,7 @@ class RuneOfPower extends Analyzer {
       if(!casts) {
         return;
       }
-      
+
       const uptimeMs = this.combatants.selected.getBuffUptime(SPELLS.RUNE_OF_POWER_BUFF.id);
       const roundedSecondsPerCast = ((uptimeMs / casts) / 1000).toFixed(1);
 
@@ -77,7 +77,7 @@ class RuneOfPower extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(0);
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(100);
 }
 
 export default RuneOfPower;

--- a/src/Parser/Mage/Shared/Modules/Features/UnstableMagic.js
+++ b/src/Parser/Mage/Shared/Modules/Features/UnstableMagic.js
@@ -66,7 +66,7 @@ class UnstableMagic extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(0);
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(100);
 }
 
 export default UnstableMagic;


### PR DESCRIPTION
The Frost Mage statistic ordering so far is mostly "unexamined copy pasting of previous statistic orders", so I'm doing something that makes sense.

At the top we'll have Damage Done, Downtime, and the soon to be implemented Cancelled Casts. Below that will be the 3 core spec utilization stats, Ice Lances Shattered, Brain Freeze Util, and Winters Chill Util. Below that will be all the talent based stats, with preference given to the Glacial Spike or Thermal Void stat because they're the biggest gameplay choice in Frost Mage talents.