### PR TITLE
[frost mage] Upgraded completeness to 'good'

### DIFF
--- a/src/Parser/Mage/Frost/CONFIG.js
+++ b/src/Parser/Mage/Frost/CONFIG.js
@@ -12,7 +12,7 @@ export default {
   spec: SPECS.FROST_MAGE,
   maintainer: '@Sharrq and @sref',
   maintainerAvatar: SharrqAvatar,
-  completeness: SPEC_ANALYSIS_COMPLETENESS.NEEDS_MORE_WORK, // When changing this please make a PR with ONLY this value changed, we will do a review of your analysis to find out of it is complete enough.
+  completeness: SPEC_ANALYSIS_COMPLETENESS.GOOD, // When changing this please make a PR with ONLY this value changed, we will do a review of your analysis to find out of it is complete enough.
   changelog: CHANGELOG,
   description: (
     <div>


### PR DESCRIPTION
@Sharrq and I believe Frost Mage completeness should be upgraded to 'Good'.

We've implemented the many suggestions from Mage discord, and we now offer statistics and suggestions for every facet of the core Frost Mage rotation. Analysis is provided for all reasonably analyzable talents. All legendaries are supported, along with t20 2set and 4set (pending the PRs listed below).

While t19 2set is still commonly used, there is unfortunately no reasonable way to make a statistic out of it.

We have not implemented a Stat Value module or a Relic Traits Value module, and this is an intentional decision. Frost Mage SimC is actively maintained and is the go-to gearing tool for the Mage community. Due to the heavily proc based nature of Frost Mage gameplay we believe sims will be able to provide better gearing advice than we could through logs analysis.

Depends on #737 #736 #735 