### PR TITLE
[resto druid] Reworked NaturesEssence

### DIFF
--- a/src/Parser/Druid/Restoration/Modules/Features/NaturesEssence.js
+++ b/src/Parser/Druid/Restoration/Modules/Features/NaturesEssence.js
@@ -6,46 +6,83 @@ import Analyzer from 'Parser/Core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
-const MINOR = 0.07;
-const AVERAGE = 0.12;
-const MAJOR = 0.17;
+import SuggestionThresholds from '../../SuggestionThresholds';
+
+const HEAL_WINDOW_MS = 500;
+const RECOMMENDED_HIT_THRESHOLD = 3;
 
 class NaturesEssence extends Analyzer {
   static dependencies = {
     combatants: Combatants,
   };
 
-  effectiveHealing = 0;
-  overHealing = 0;
+  casts = 0;
+  castsWithTargetsHit = []; // index is number of targets hit, value is number of casts that hit that many targets
+
+  castHits = 0;
+  totalHits = 0;
+  healTimestamp = undefined;
 
   on_initialized() {
     this.active = this.combatants.selected.traitsBySpellId[SPELLS.NATURES_ESSENCE_TRAIT.id] > 0;
   }
 
   on_byPlayer_heal(event) {
-    const spellId = event.ability.guid;
+    if (event.ability.guid !== SPELLS.NATURES_ESSENCE_DRUID.id) {
+      return;
+    }
 
-    if (SPELLS.NATURES_ESSENCE_DRUID.id === spellId) {
-      this.effectiveHealing += event.amount + (event.absorbed || 0);
-      this.overHealing += (event.overheal !== undefined ? event.overheal : 0);
+    if(!this.healTimestamp || this.healTimestamp + HEAL_WINDOW_MS < this.owner.currentTimestamp) {
+      this._tallyHits();
+      this.healTimestamp = this.owner.currentTimestamp;
+    }
+    if(event.amount !== 0) {
+      this.castHits += 1;
+      this.totalHits += 1;
     }
   }
 
-  suggestions(when) {
-    const overhealPercent = (this.overHealing + this.effectiveHealing !== 0)
-        ? this.overHealing / (this.effectiveHealing + this.overHealing)
-        : 0;
+  on_byPlayer_cast(event) {
+    if (event.ability.guid === SPELLS.WILD_GROWTH.id) {
+      this.casts += 1;
+    }
+  }
 
-    when(overhealPercent).isGreaterThan(MINOR)
+  on_finished() {
+    this._tallyHits();
+  }
+
+  _tallyHits() {
+    if(!this.healTimestamp) {
+      return;
+    }
+    this.castsWithTargetsHit[this.castHits]
+       ? this.castsWithTargetsHit[this.castHits] += 1
+       : this.castsWithTargetsHit[this.castHits] = 1;
+    this.castHits = 0;
+    this.healTimestamp = undefined;
+  }
+
+  get averageEffectiveHits() {
+    return (this.totalHits / this.casts) || 0;
+  }
+
+  // TODO add a statistic box too?
+
+  suggestions(when) {
+    const belowRecommendedCasts = this.castsWithTargetsHit.reduce((accum, casts, hits) => {
+        return (hits < RECOMMENDED_HIT_THRESHOLD) ? accum + casts : accum;
+    }, 0);
+    const percentBelowRecommendedCasts = (belowRecommendedCasts / this.casts) || 0;
+
+    when(percentBelowRecommendedCasts).isGreaterThan(SuggestionThresholds.WG_TOO_FEW_TARGETS.minor)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span>Your overhealing from <SpellLink id={SPELLS.NATURES_ESSENCE_DRUID.id} /> is high.
-          You may be casting <SpellLink id={SPELLS.WILD_GROWTH.id} /> when few raiders are injured, or you may be casting it before damage.
-          Unlike our other HoTs, <SpellLink id={SPELLS.WILD_GROWTH.id} /> heals quickly and has a strong initial heal,
-          so you should wait until damage has already happened to cast it.</span>)
+        return suggest(<span>You sometimes cast <SpellLink id={SPELLS.WILD_GROWTH.id} /> on too few targets. <SpellLink id={SPELLS.WILD_GROWTH.id} /> is not mana efficient when hitting few targets, you should only cast it when you can hit at least {RECOMMENDED_HIT_THRESHOLD} wounded targets. Make sure you are not casting on a primary target isolated from the raid. <SpellLink id={SPELLS.WILD_GROWTH.id} /> has a maximum hit radius, the injured raiders could have been out of range. Also, <SpellLink id={SPELLS.WILD_GROWTH.id} /> healing is frontloaded due to <SpellLink id={SPELLS.NATURES_ESSENCE_DRUID.id} />, you should never pre-hot with <SpellLink id={SPELLS.WILD_GROWTH.id} />.
+          </span>)
           .icon(SPELLS.NATURES_ESSENCE_DRUID.icon)
-          .actual(`${formatPercentage(overhealPercent)}% overhealing`)
-          .recommended(`<${Math.round(formatPercentage(recommended))}% is recommended`)
-          .regular(AVERAGE).major(MAJOR);
+          .actual(`${formatPercentage(percentBelowRecommendedCasts, 0)}% casts on fewer than ${RECOMMENDED_HIT_THRESHOLD} targets.`)
+          .recommended(`never casting on fewer than ${RECOMMENDED_HIT_THRESHOLD} is recommended`)
+          .regular(SuggestionThresholds.WG_TOO_FEW_TARGETS.regular).major(SuggestionThresholds.WG_TOO_FEW_TARGETS.major);
       });
   }
 }

--- a/src/Parser/Druid/Restoration/SuggestionThresholds.js
+++ b/src/Parser/Druid/Restoration/SuggestionThresholds.js
@@ -71,4 +71,9 @@ export default {
     regular: 0.80,
     major: 0.60,
   },
+  WG_TOO_FEW_TARGETS: {
+    minor: 0.00,
+    regular: 0.10,
+    major: 0.30,
+  },
 };


### PR DESCRIPTION
The NaturesEssence module was intended to make sure you were hitting enough injured targets with WildGrowth, but its method of detection had a high rate of false positives and false negatives.

I've used a completely different method that is more complicated but more directly measures what it's supposed to measure.