### PR TITLE
WW Energizing Elixir Resource gains (Chi calc'ed not shown)

### DIFF
--- a/src/Parser/Monk/Windwalker/CHANGELOG.js
+++ b/src/Parser/Monk/Windwalker/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+06-11-2017 - Added Energizing Elixir Energy gained calculation and statistics box (Coryn)
 05-11-2017 - Added basic display for Invoke Xuen, The White Tiger to Cooldown Throughput with plans for refinement (Talby)
 05-11-2017 - Added WindwalkerCore for future feature at request of Bablyonius (Talby)
 05-11-2017 - Added basic display Energizing Elixir to Cast Efficiency (Talby)

--- a/src/Parser/Monk/Windwalker/CombatLogParser.js
+++ b/src/Parser/Monk/Windwalker/CombatLogParser.js
@@ -14,6 +14,7 @@ import FistsofFury from './Modules/Spells/FistsofFury';
 
 // Talents
 import HitCombo from './Modules/Talents/HitCombo';
+import EnergizingElixir from './Modules/Talents/EnergizingElixir';
 
 // Legendaries
 import KatsuosEclipse from './Modules/Items/KatsuosEclipse';
@@ -32,6 +33,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Talents:
     hitCombo: HitCombo,
+    energizingElixir: EnergizingElixir,
 
     // Spells;
     comboBreaker: ComboBreaker,

--- a/src/Parser/Monk/Windwalker/Modules/Talents/EnergizingElixir.js
+++ b/src/Parser/Monk/Windwalker/Modules/Talents/EnergizingElixir.js
@@ -20,8 +20,7 @@ class EnergizingElixir extends Analyzer {
   eeCasts = 0;
 
   on_initialized() {
-    this.active = this.combatants.selected.hasTalent(SPELLS.ENERGIZING_ELIXIR_TALENT
-      .id);
+    this.active = this.combatants.selected.hasTalent(SPELLS.ENERGIZING_ELIXIR_TALENT.id);
   }
 
   on_byPlayer_cast(event) {
@@ -52,10 +51,10 @@ class EnergizingElixir extends Analyzer {
 
   statistic() {
     return (<StatisticBox icon={<SpellIcon id={SPELLS.ENERGIZING_ELIXIR_TALENT.id }/>}
-      value={`${this.energyGained} Energy gained`}
+      value={this.energyGained}
       label={(
-        <dfn>
-          from {this.eeCasts} Energizing Elixir Casts 
+        <dfn data-tip={`from ${this.eeCasts} Energizing Elixir Casts`}>
+          Energy gained
         </dfn>
         )}
         />

--- a/src/Parser/Monk/Windwalker/Modules/Talents/EnergizingElixir.js
+++ b/src/Parser/Monk/Windwalker/Modules/Talents/EnergizingElixir.js
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import ResourceTypes from 'common/RESOURCE_TYPES';
+import StatisticBox from 'Main/StatisticBox';
+
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import Analyzer from 'Parser/Core/Analyzer';
+
+class EnergizingElixir extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+  chiGained = 0;
+  energyGained = 0;
+  energyWasted = 0;
+  chiSaved = 0;
+  eeCasts = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.ENERGIZING_ELIXIR_TALENT
+      .id);
+  }
+
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.ENERGIZING_ELIXIR_TALENT.id) {
+      return;
+    }
+    this.eeCasts += 1;
+  }
+
+  /**
+   * Calculate the amount of Energy and Chi gained and wasted
+   * for each cast event of Energizing Elixir.
+   */
+  on_toPlayer_energize(event) {
+    const spellId = event.ability.guid;
+    if (spellId === SPELLS.ENERGIZING_ELIXIR_TALENT.id) {
+      if (event.resourceChangeType === ResourceTypes.ENERGY) {
+        this.energyWasted += event.waste;
+        this.energyGained += event.resourceChange - event.waste;
+      }
+      if (event.resourceChangeType === ResourceTypes.CHI) {
+        this.chiWasted += event.waste;
+        this.chiGained += event.resourceChange - event.waste;
+      }
+    }
+  }
+
+  statistic() {
+    return (<StatisticBox icon={<SpellIcon id={SPELLS.ENERGIZING_ELIXIR_TALENT.id }/>}
+      value={`${this.energyGained} Energy gained`}
+      label={(
+        <dfn>
+          from {this.eeCasts} Energizing Elixir Casts 
+        </dfn>
+        )}
+        />
+      );
+    }
+  }
+  export default EnergizingElixir;


### PR DESCRIPTION
Calculates the amount of energy and chi gained from the Energizing Elixir talent for Windwalker parses, using the energize event.

NOTE: The chi is calculated and available in the `chiGained` field but the engine is currently always returning a static amount of chi wasted on cast (incorrectly) and therefore it is not shown yet.

Coryn - Peak of Serenity