### PR TITLE
Added suggestions on mana levels on encounter finished. Fixes #82

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -11,7 +11,7 @@ export default [
   {
     date: new Date('2017-11-07'),
     changes: 'Added a suggestion for healers if their mana percentage is too high at the end of an encounter.',
-    contributors: 'Blazyb',
+    contributors: ['Blazyb'],
   },
   {
     date: new Date('2017-11-06'),

--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+07-11-2017 - Added a suggestion for healers if their mana percentage is too high at the end of an encounter. (By Blazyb)
 04-11-2017 - Added a spell cooldown timeline to cast efficiency suggestions. (by Zerotorescue)
 02-11-2017 - Changed the <i>default</i> recommended <a href="http://www.wowhead.com/item=144258" target="_blank" rel="noopener noreferrer" class="legendary">Velen's Future Sight</a> healing contribution to be at least 4% (down from 4.5%). (by Zerotorescue)
 01-11-2017 - Always show the navigation bar and stick it to the top of the window. (by Zerotorescue)

--- a/src/Parser/Core/Modules/ManaValues.js
+++ b/src/Parser/Core/Modules/ManaValues.js
@@ -1,10 +1,21 @@
+import React from 'react';
+
 import Analyzer from 'Parser/Core/Analyzer';
 import RESOURCE_TYPES from 'common/RESOURCE_TYPES';
+import { formatPercentage } from 'common/format';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import ROLES from 'common/ROLES';
 
 class ManaValues extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  }
+  static SUGGESTION_MANA_BREAKPOINT = 0.1;
+
   lowestMana = null; // start at `null` and fill it with the first value to account for users starting at a non-default amount for whatever reason
   endingMana = 0;
 
+  baseMana = 110000;
   manaUpdates = [];
 
   on_byPlayer_cast(event) {
@@ -26,8 +37,28 @@ class ManaValues extends Analyzer {
             max: max,
             used: manaCost,
           });
+          // The variable 'max' is constant but can differentiate by racial/items.
+          this.baseMana = max;
         });
     }
+  }
+
+  suggestions(when) {
+    if(this.combatants.selected.spec.role !== ROLES.HEALER) {
+      return;
+    }
+    const manaPercentageLeft = this.endingMana/this.baseMana;
+
+    when(manaPercentageLeft).isGreaterThan(this.constructor.SUGGESTION_MANA_BREAKPOINT)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<span>You ended the fight with too much mana. If possible, try to deplete all your mana when the boss dies. A good rule of thumb is having the same mana % as the bosses health %.
+          Mana is indirectly tied with healing throughput and should be optimized. </span>)
+          .icon('inv_elemental_mote_mana')
+          .actual(`${formatPercentage(manaPercentageLeft)}% (${this.endingMana}) mana left`)
+          .recommended(`<${formatPercentage(recommended)}% is recommended`)
+          .regular(recommended + 0.1)
+          .major(recommended + 0.2);
+      });
   }
 }
 

--- a/src/Parser/Core/Modules/ManaValues.js
+++ b/src/Parser/Core/Modules/ManaValues.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import RESOURCE_TYPES from 'common/RESOURCE_TYPES';
-import { formatPercentage } from 'common/format';
+import { formatPercentage, formatNumber } from 'common/format';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import ROLES from 'common/ROLES';
 
@@ -15,8 +15,12 @@ class ManaValues extends Analyzer {
   lowestMana = null; // start at `null` and fill it with the first value to account for users starting at a non-default amount for whatever reason
   endingMana = 0;
 
-  baseMana = 110000;
+  maxMana = 110000;
   manaUpdates = [];
+
+  on_initialized() {
+    this.active = this.combatants.selected.spec.role === ROLES.HEALER;
+  }
 
   on_byPlayer_cast(event) {
     if (event.classResources) {
@@ -38,23 +42,20 @@ class ManaValues extends Analyzer {
             used: manaCost,
           });
           // The variable 'max' is constant but can differentiate by racial/items.
-          this.baseMana = max;
+          this.maxMana = max;
         });
     }
   }
 
   suggestions(when) {
-    if(this.combatants.selected.spec.role !== ROLES.HEALER) {
-      return;
-    }
-    const manaPercentageLeft = this.endingMana/this.baseMana;
+    const manaPercentageLeft = this.endingMana/this.maxMana;
 
     when(manaPercentageLeft).isGreaterThan(this.constructor.SUGGESTION_MANA_BREAKPOINT)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span>You ended the fight with too much mana. If possible, try to deplete all your mana when the boss dies. A good rule of thumb is having the same mana % as the bosses health %.
+        return suggest(<span>You had mana left at the end of the fight. A good rule of thumb is having the same mana percentage as the bosses health percentage.
           Mana is indirectly tied with healing throughput and should be optimized. </span>)
           .icon('inv_elemental_mote_mana')
-          .actual(`${formatPercentage(manaPercentageLeft)}% (${this.endingMana}) mana left`)
+          .actual(`${formatPercentage(manaPercentageLeft)}% (${formatNumber(this.endingMana)}) mana left`)
           .recommended(`<${formatPercentage(recommended)}% is recommended`)
           .regular(recommended + 0.1)
           .major(recommended + 0.2);


### PR DESCRIPTION
[![Screenshot from Gyazo](https://gyazo.com/1848f79eff7d6154832cc1b2eabeca16/raw)](https://gyazo.com/1848f79eff7d6154832cc1b2eabeca16)

(Ignore the branch name, I got the issue numbers mixed up). This is not 100% accurate since it gets the endingMana from the last cast event from the player, so the endingMana variable can be potentially higher (if the player didn't cast anything in the last X seconds of the encounter). 

This can be solved by calculating the players MP5 (or mana gained per second) and checking the time differences between the last cast event and the on_finished timestamp, and calculating the players endingMana. However this is not an easy task as there's many edge cases to consider that may alter the MP5 (unless there's a property for that). (Such as items, traits, spells etc.)