### PR TITLE
[core] Added handling for Haste rating changes to Haste analyzer

### DIFF
--- a/src/Parser/Core/Modules/Haste.js
+++ b/src/Parser/Core/Modules/Haste.js
@@ -4,16 +4,16 @@ import { formatPercentage, formatMilliseconds } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+import StatTracker from 'Parser/Core/Modules/StatTracker';
 
 const debug = false;
 
 class Haste extends Analyzer {
   static dependencies = {
     combatants: Combatants,
+    statTracker: StatTracker,
   };
 
-  // It would be nice to have this point to a value in the Combatant class, but that would be tricky since this is `static`.
-  static HASTE_RATING_PER_PERCENT = 37500;
   // TODO: Maybe extract "time" changing abilities since they also scale the minimum GCD cap? Probably better to dive into the tooltips to find out how the stat that does that is actually called. Spell Haste, Casting Speed, Attack Speed, Haste, ... are all different variants that look like Haste but act different.
   // TODO: Support time freeze kinda effects, like Elisande's Time Stop or unavoidable stuns?
   /* eslint-disable no-useless-computed-key */
@@ -77,6 +77,23 @@ class Haste extends Analyzer {
   }
   on_toPlayer_removedebuff(event) {
     this._removeActiveBuff(event);
+  }
+
+  on_toPlayer_changestats(event) { // fabbed event from StatTracker
+    if(!event.change.haste) {
+      return;
+    }
+
+    // as haste rating stacks additively with itself, changing rating works similar to changing buff stack
+    const oldHastePercentage = this.statTracker.getHastePercentage(event.before.haste);
+    this._applyHasteLoss(event.reason, oldHastePercentage);
+    const newHastePercentage = this.statTracker.getHastePercentage(event.after.haste);
+    this._applyHasteGain(event.reason, newHastePercentage);
+
+    if(debug) {
+      const spellName = event.reason.ability ? event.reason.ability.name : 'unknown';
+      console.log(`Haste: Current haste: ${formatPercentage(this.current)}% (haste RATING changed by ${event.change.haste} from ${spellName})`);
+    }
   }
 
   _applyActiveBuff(event) {

--- a/src/Parser/Core/Modules/Haste.js
+++ b/src/Parser/Core/Modules/Haste.js
@@ -80,7 +80,7 @@ class Haste extends Analyzer {
   }
 
   on_toPlayer_changestats(event) { // fabbed event from StatTracker
-    if(!event.change.haste) {
+    if(!event.delta.haste) {
       return;
     }
 

--- a/src/Parser/Core/Modules/Haste.js
+++ b/src/Parser/Core/Modules/Haste.js
@@ -85,14 +85,14 @@ class Haste extends Analyzer {
     }
 
     // as haste rating stacks additively with itself, changing rating works similar to changing buff stack
-    const oldHastePercentage = this.statTracker.getHastePercentage(event.before.haste);
+    const oldHastePercentage = this.statTracker.baseHastePercentage + (event.before.haste / this.statTracker.hasteRatingPerPercent);
     this._applyHasteLoss(event.reason, oldHastePercentage);
-    const newHastePercentage = this.statTracker.getHastePercentage(event.after.haste);
+    const newHastePercentage = this.statTracker.baseHastePercentage + (event.after.haste / this.statTracker.hasteRatingPerPercent);
     this._applyHasteGain(event.reason, newHastePercentage);
 
     if(debug) {
       const spellName = event.reason.ability ? event.reason.ability.name : 'unknown';
-      console.log(`Haste: Current haste: ${formatPercentage(this.current)}% (haste RATING changed by ${event.change.haste} from ${spellName})`);
+      console.log(`Haste: Current haste: ${formatPercentage(this.current)}% (haste RATING changed by ${event.delta.haste} from ${spellName})`);
     }
   }
 

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -252,55 +252,28 @@ class StatTracker extends Analyzer {
   }
 
   /*
-   * Helpers to get stat percentage from an arbitrary rating.
-   */
-   getCritPercentage(rating) {
-     return this.baseCritPercentage + (rating / this.critRatingPerPercent);
-   }
-   getHastePercentage(rating) {
-     return this.baseHastePercentage + (rating / this.hasteRatingPerPercent);
-   }
-   getMasteryPercentage(rating) {
-     return this.baseMasteryPercentage + (rating / this.masteryRatingPerPercent);
-   }
-   getVersatilityPercentage(rating) {
-     return this.baseVersatilityPercentage + (rating / this.versatilityRatingPerPercent);
-   }
-   getAvoidancePercentage(rating) {
-     return this.baseAvoidancePercentage + (rating / this.avoidanceRatingPerPercent);
-   }
-   getLeechPercentage(rating) {
-     return this.baseLeechPercentage + (rating / this.leechRatingPerPercent);
-   }
-   getSpeedPercentage(rating) {
-     return this.baseSpeedPercentage + (rating / this.speedRatingPerPercent);
-   }
-
-  /*
    * For percentage stats, the current stat percentage as tracked by this module.
-   * Also includes helpers for getting stat percentage from an arbitrary rating.
    */
-
   get currentCritPercentage() {
-    return this.getCritPercentage(this.currentCritRating);
+    return this.baseCritPercentage + (this.currentCritRating / this.critRatingPerPercent);
   }
   get currentHastePercentage() {
-    return this.getHastePercentage(this.currentHasteRating);
+    return this.baseHastePercentage + (this.currentHasteRating / this.hasteRatingPerPercent);
   }
   get currentMasteryPercentage() {
-    return this.getMasteryPercentage(this.currentMasteryRating);
+    return this.baseMasteryPercentage + (this.currentMasteryRating / this.masteryRatingPerPercent);
   }
   get currentVersatilityPercentage() {
-    return this.getVersatilityPercentage(this.currentVersatilityRating);
+    return this.baseVersatilityPercentage + (this.currentVersatilityRating / this.versatilityRatingPerPercent);
   }
   get currentAvoidancePercentage() {
-    return this.getAvoidancePercentage(this.currentAvoidanceRating);
+    return this.baseAvoidancePercentage + (this.currentAvoidanceRating / this.avoidanceRatingPerPercent);
   }
   get currentLeechPercentage() {
-    return this.getLeechPercentage(this.currentLeechRating);
+    return this.baseLeechPercentage + (this.currentLeechRating / this.leechRatingPerPercent);
   }
   get currentSpeedPercentage() {
-    return this.getSpeedPercentage(this.currentSpeedRating);
+    return this.baseSpeedPercentage + (this.currentSpeedRating / this.speedRatingPerPercent);
   }
 
   on_toPlayer_changebuffstack(event) {

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -252,28 +252,55 @@ class StatTracker extends Analyzer {
   }
 
   /*
-   * For percentage stats, the current stat percentage as tracked by this module.
+   * Helpers to get stat percentage from an arbitrary rating.
    */
+   getCritPercentage(rating) {
+     return this.baseCritPercentage + (rating / this.critRatingPerPercent);
+   }
+   getHastePercentage(rating) {
+     return this.baseHastePercentage + (rating / this.hasteRatingPerPercent);
+   }
+   getMasteryPercentage(rating) {
+     return this.baseMasteryPercentage + (rating / this.masteryRatingPerPercent);
+   }
+   getVersatilityPercentage(rating) {
+     return this.baseVersatilityPercentage + (rating / this.versatilityRatingPerPercent);
+   }
+   getAvoidancePercentage(rating) {
+     return this.baseAvoidancePercentage + (rating / this.avoidanceRatingPerPercent);
+   }
+   getLeechPercentage(rating) {
+     return this.baseLeechPercentage + (rating / this.leechRatingPerPercent);
+   }
+   getSpeedPercentage(rating) {
+     return this.baseSpeedPercentage + (rating / this.speedRatingPerPercent);
+   }
+
+  /*
+   * For percentage stats, the current stat percentage as tracked by this module.
+   * Also includes helpers for getting stat percentage from an arbitrary rating.
+   */
+
   get currentCritPercentage() {
-    return this.baseCritPercentage + (this.currentCritRating / this.critRatingPerPercent);
+    return this.getCritPercentage(this.currentCritRating);
   }
   get currentHastePercentage() {
-    return this.baseHastePercentage + (this.currentHasteRating / this.hasteRatingPerPercent);
+    return this.getHastePercentage(this.currentHasteRating);
   }
   get currentMasteryPercentage() {
-    return this.baseMasteryPercentage + (this.currentMasteryRating / this.masteryRatingPerPercent);
+    return this.getMasteryPercentage(this.currentMasteryRating);
   }
   get currentVersatilityPercentage() {
-    return this.baseVersatilityPercentage + (this.currentVersatilityRating / this.versatilityRatingPerPercent);
+    return this.getVersatilityPercentage(this.currentVersatilityRating);
   }
   get currentAvoidancePercentage() {
-    return this.baseAvoidancePercentage + (this.currentAvoidanceRating / this.avoidanceRatingPerPercent);
+    return this.getAvoidancePercentage(this.currentAvoidanceRating);
   }
   get currentLeechPercentage() {
-    return this.baseLeechPercentage + (this.currentLeechRating / this.leechRatingPerPercent);
+    return this.getLeechPercentage(this.currentLeechRating);
   }
   get currentSpeedPercentage() {
-    return this.baseSpeedPercentage + (this.currentSpeedRating / this.speedRatingPerPercent);
+    return this.getSpeedPercentage(this.currentSpeedRating);
   }
 
   on_toPlayer_changebuffstack(event) {
@@ -295,9 +322,9 @@ class StatTracker extends Analyzer {
         return;
       }
 
-      const before = this._stats;
+      const before = Object.assign({}, this._stats);
       const delta = this._changeStats(statBuff, event.newStacks - event.oldStacks);
-      const after = this._stats;
+      const after = Object.assign({}, this._stats);
       this._triggerChangeStats(event, before, delta, after);
       debug && console.log(`StatTracker: (${event.oldStacks} -> ${event.newStacks}) ${SPELLS[spellId] ? SPELLS[spellId].name : spellId} - Change: ${this._statPrint(delta)}`);
       debug && this._debugPrintStats(this._stats);

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -356,7 +356,7 @@ class StatTracker extends Analyzer {
   /*
    * Fabricates an event indicating when stats change
    */
-  _triggerChangeStats(event, before, change, after) {
+  _triggerChangeStats(event, before, delta, after) {
     this.owner.triggerEvent('changestats', {
       timestamp: event ? event.timestamp : this.owner.currentTimestamp,
       type: 'changestats',
@@ -364,7 +364,7 @@ class StatTracker extends Analyzer {
       targetID: this.owner.playerId,
       reason: event,
       before,
-      change,
+      delta,
       after,
     });
   }


### PR DESCRIPTION
Handling for rating changes had previously been moved to the StatTracker module, but this meant that the Haste module no longer was tracking haste rating changes at all.

I've modified StatTracker so it generates a fabricated event any time stats change, and I've modified Haste to listen for those events and apply the appropriate change (including firing its own changehaste event).

It's plausible that the Haste module as a whole is due for a refactor, but in this PR I make the 'lightest touch' change I can while still implementing the desired functionality in a non-hacky manner.