### PR TITLE
[Beast Mastery] Fixes a crash, and some fine tuning

### DIFF
--- a/src/Parser/Hunter/BeastMastery/Modules/Items/Tier20_4p.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Items/Tier20_4p.js
@@ -12,7 +12,7 @@ import SpellLink from "common/SpellLink";
 
 const T204P_MODIFIER = 0.15;
 
-const debug = true;
+const debug = false;
 
 class Tier20_4p extends Analyzer {
   static dependencies = {

--- a/src/Parser/Hunter/BeastMastery/Modules/Traits/TitansThunder.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Traits/TitansThunder.js
@@ -7,7 +7,7 @@ import StatisticBox from "Main/StatisticBox";
 import SpellIcon from "common/SpellIcon";
 import SpellLink from "common/SpellLink";
 
-const debug = true;
+const debug = false;
 
 const TITANS_THUNDER_USE_REGARDLESS_THRESHHOLD = 30;
 

--- a/src/Parser/Hunter/BeastMastery/Modules/Traits/TitansThunder.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Traits/TitansThunder.js
@@ -7,7 +7,7 @@ import StatisticBox from "Main/StatisticBox";
 import SpellIcon from "common/SpellIcon";
 import SpellLink from "common/SpellLink";
 
-const debug = false;
+const debug = true;
 
 const TITANS_THUNDER_USE_REGARDLESS_THRESHHOLD = 30;
 
@@ -23,6 +23,7 @@ class TitansThunder extends Analyzer {
   totalTTCasts = 0;
   stacksOnTTCast = 0;
   shouldHaveSavedTT = 0;
+  weirdCast = 0;
 
   on_toPlayer_applybuff(event) {
     const buffId = event.ability.guid;
@@ -31,6 +32,7 @@ class TitansThunder extends Analyzer {
     }
     this._currentStacks += 1;
   }
+
   on_toPlayer_removebuff(event) {
     const buffId = event.ability.guid;
     if (buffId !== SPELLS.DIRE_BEAST_BUFF.id) {
@@ -46,9 +48,15 @@ class TitansThunder extends Analyzer {
     }
     debug && console.log(`stacks:`, this._currentStacks);
     this.totalTTCasts += 1;
-    if (this.spellUsable.cooldownRemaining(SPELLS.BESTIAL_WRATH.id) < TITANS_THUNDER_USE_REGARDLESS_THRESHHOLD) {
-      this.shouldHaveSavedTT += 1;
-      return;
+    const bestialWrathIsOnCooldown = this.spellUsable.isOnCooldown(SPELLS.BESTIAL_WRATH.id);
+    if (bestialWrathIsOnCooldown) {
+      if (this.spellUsable.cooldownRemaining(SPELLS.BESTIAL_WRATH.id) < TITANS_THUNDER_USE_REGARDLESS_THRESHHOLD) {
+        this.shouldHaveSavedTT += 1;
+        return;
+      } else if (!this.combatants.selected.hasBuff(SPELLS.BESTIAL_WRATH.id) && (this.spellUsable.cooldownRemaining(SPELLS.BESTIAL_WRATH.id) > TITANS_THUNDER_USE_REGARDLESS_THRESHHOLD)) {
+        this.goodTTCasts += 1;
+        return;
+      }
     }
     if (!this.combatants.selected.hasTalent(SPELLS.DIRE_FRENZY_TALENT.id)) {
       if (this.combatants.selected.hasBuff(SPELLS.DIRE_BEAST_BUFF.id)) {
@@ -65,6 +73,8 @@ class TitansThunder extends Analyzer {
         this.badTTCasts += 1;
       }
     }
+
+    debug && console.log('good tt casts:', this.goodTTCasts, ' and bad tt casts: ', this.badTTCasts, ' and total casts is: ', this.totalTTCasts, ' and weird casts: ', this.weirdCast);
   }
   statistic() {
     return (


### PR DESCRIPTION
I fucked up so it would crash here: https://wowanalyzer.com/report/4XcyFdNLQYWAJBzH/31-Mythic+Kil'jaeden+-+Kill+(9:24)/Wulfeh

This fixes it and removes some debug=true, aswell as fixing structure in if statements to ensure all Titan's Thunder casts are counted properly. 