### PR TITLE
Focustracker performance fix

### DIFF
--- a/src/Parser/Hunter/Marksmanship/CHANGELOG.js
+++ b/src/Parser/Hunter/Marksmanship/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+08-11-2017 - Fixed large FocusChart performance bugs
 25-10-2017 - Added 5 new talent modules, fixed trueshot CD, added Focus Dump Checker
 25-10-2017 - Updated True Aim to include damage contributed information
 25-10-2017 - Adjust t202p to account for nerfs 

--- a/src/Parser/Hunter/Marksmanship/CombatLogParser.js
+++ b/src/Parser/Hunter/Marksmanship/CombatLogParser.js
@@ -114,7 +114,6 @@ class CombatLogParser extends CoreCombatLogParser {
               activeFocusWasted={this.modules.focusTracker.activeFocusWasted}
               generatorCasts={this.modules.focusTracker.generatorCasts}
               activeFocusWastedTimeline={this.modules.focusTracker.activeFocusWastedTimeline}
-              isFinished={this.modules.focusTracker.isFinished}
             />
           </Tab>
         ),

--- a/src/Parser/Hunter/Marksmanship/CombatLogParser.js
+++ b/src/Parser/Hunter/Marksmanship/CombatLogParser.js
@@ -114,6 +114,7 @@ class CombatLogParser extends CoreCombatLogParser {
               activeFocusWasted={this.modules.focusTracker.activeFocusWasted}
               generatorCasts={this.modules.focusTracker.generatorCasts}
               activeFocusWastedTimeline={this.modules.focusTracker.activeFocusWastedTimeline}
+              isFinished={this.modules.focusTracker.isFinished}
             />
           </Tab>
         ),

--- a/src/Parser/Hunter/Shared/FocusChart/Focus.js
+++ b/src/Parser/Hunter/Shared/FocusChart/Focus.js
@@ -29,17 +29,17 @@ class Focus extends React.PureComponent {
     activeFocusWasted: PropTypes.object,
     generatorCasts: PropTypes.object,
     activeFocusWastedTimeline: PropTypes.object,
+    isFinished : PropTypes.number,
   };
 
   render() {
-    if (!this.props.tracker) {
+    if (!this.props.tracker || this.props.isFinished === false) {
       return (
         <div>
           Loading...
         </div>
       );
     }
-
     const focusGen = Math.round((10 + .1 * this.props.playerHaste / 375) * 100) / 100; //TODO: replace constant passive FocusGen (right now we don't account for lust/hero or Trueshot)
 
     const maxFocus = this.props.focusMax;

--- a/src/Parser/Hunter/Shared/FocusChart/Focus.js
+++ b/src/Parser/Hunter/Shared/FocusChart/Focus.js
@@ -29,11 +29,10 @@ class Focus extends React.PureComponent {
     activeFocusWasted: PropTypes.object,
     generatorCasts: PropTypes.object,
     activeFocusWastedTimeline: PropTypes.object,
-    isFinished : PropTypes.number,
   };
 
   render() {
-    if (!this.props.tracker || this.props.isFinished === false) {
+    if (!this.props.tracker) {
       return (
         <div>
           Loading...

--- a/src/Parser/Hunter/Shared/FocusChart/Focus.js
+++ b/src/Parser/Hunter/Shared/FocusChart/Focus.js
@@ -29,17 +29,17 @@ class Focus extends React.PureComponent {
     activeFocusWasted: PropTypes.object,
     generatorCasts: PropTypes.object,
     activeFocusWastedTimeline: PropTypes.object,
-    isFinished : PropTypes.number,
   };
 
   render() {
-    if (!this.props.tracker || this.props.isFinished === false) {
+    if (!this.props.tracker) {
       return (
         <div>
           Loading...
         </div>
       );
     }
+
     const focusGen = Math.round((10 + .1 * this.props.playerHaste / 375) * 100) / 100; //TODO: replace constant passive FocusGen (right now we don't account for lust/hero or Trueshot)
 
     const maxFocus = this.props.focusMax;

--- a/src/Parser/Hunter/Shared/FocusChart/Focus.js
+++ b/src/Parser/Hunter/Shared/FocusChart/Focus.js
@@ -39,6 +39,7 @@ class Focus extends React.PureComponent {
         </div>
       );
     }
+    
     const focusGen = Math.round((10 + .1 * this.props.playerHaste / 375) * 100) / 100; //TODO: replace constant passive FocusGen (right now we don't account for lust/hero or Trueshot)
 
     const maxFocus = this.props.focusMax;

--- a/src/Parser/Hunter/Shared/FocusChart/FocusTracker.js
+++ b/src/Parser/Hunter/Shared/FocusChart/FocusTracker.js
@@ -8,6 +8,7 @@ class FocusTracker extends Analyzer {
     combatants: Combatants,
   }
 
+  isFinished = false;
   focusBySecond = [];
   activeFocusWasted = {};
   activeFocusWastedTimeline = {};
@@ -37,6 +38,11 @@ class FocusTracker extends Analyzer {
     this.checkActiveWaste(event);
   }
 
+  on_finished(){
+    this.extrapolateFocus();
+    this.isFinished = true;
+  }
+
   checkForMaxFocus(event) {
     if (event.sourceID === this.owner.player.id) {
       event.classResources.forEach(classResource => {
@@ -60,7 +66,6 @@ class FocusTracker extends Analyzer {
         this.focusBySecond[secIntoFight] = (event.classResources[0]['amount']);
       }
       this.checkForError(secIntoFight);
-      this.extrapolateFocus(event.timestamp);
     }
   }
 
@@ -103,12 +108,12 @@ class FocusTracker extends Analyzer {
     }
   }
 
-  extrapolateFocus(event) {
+  extrapolateFocus() {
     this.focusGen = Math.round((10 + .1 * this.combatants.selected.hasteRating / 375) * 100) / 100;
     this.secondsCapped = 0;
     const maxFocus = this._maxFocus;
     this.focusBySecond[0] = maxFocus;
-    for (let i = 0; i < (event - this.owner.fight.start_time); i++) {  //extrapolates focus given passive focus gain (TODO: Update for pulls with Volley)
+    for (let i = 0; i < (this.owner.fight.end_time - this.owner.fight.start_time); i++) {  //extrapolates focus given passive focus gain (TODO: Update for pulls with Volley)
       if (!this.focusBySecond[i]) {
         if (this.focusBySecond[i - 1] >= maxFocus) {
           this.focusBySecond[i] = maxFocus;

--- a/src/Parser/Hunter/Shared/FocusChart/FocusTracker.js
+++ b/src/Parser/Hunter/Shared/FocusChart/FocusTracker.js
@@ -8,7 +8,6 @@ class FocusTracker extends Analyzer {
     combatants: Combatants,
   }
 
-  isFinished = false;
   focusBySecond = [];
   activeFocusWasted = {};
   activeFocusWastedTimeline = {};
@@ -38,11 +37,6 @@ class FocusTracker extends Analyzer {
     this.checkActiveWaste(event);
   }
 
-  on_finished(){
-    this.extrapolateFocus();
-    this.isFinished = true;
-  }
-
   checkForMaxFocus(event) {
     if (event.sourceID === this.owner.player.id) {
       event.classResources.forEach(classResource => {
@@ -66,6 +60,7 @@ class FocusTracker extends Analyzer {
         this.focusBySecond[secIntoFight] = (event.classResources[0]['amount']);
       }
       this.checkForError(secIntoFight);
+      this.extrapolateFocus(event.timestamp);
     }
   }
 
@@ -108,12 +103,12 @@ class FocusTracker extends Analyzer {
     }
   }
 
-  extrapolateFocus() {
+  extrapolateFocus(event) {
     this.focusGen = Math.round((10 + .1 * this.combatants.selected.hasteRating / 375) * 100) / 100;
     this.secondsCapped = 0;
     const maxFocus = this._maxFocus;
     this.focusBySecond[0] = maxFocus;
-    for (let i = 0; i < (this.owner.fight.end_time - this.owner.fight.start_time); i++) {  //extrapolates focus given passive focus gain (TODO: Update for pulls with Volley)
+    for (let i = 0; i < (event - this.owner.fight.start_time); i++) {  //extrapolates focus given passive focus gain (TODO: Update for pulls with Volley)
       if (!this.focusBySecond[i]) {
         if (this.focusBySecond[i - 1] >= maxFocus) {
           this.focusBySecond[i] = maxFocus;


### PR DESCRIPTION
I figure it's probably easier to tell me what's stylistically wrong with this when you can see the code yourself. The issue was with extrapolateFocus(), as it was called after every event- now it only iterates appropriate indexes each call, instead of the entire thing. Vastly decreased load times on my machine.