### PR TITLE
[Frost Mage] Minor Blizzard Suggestion

### DIFF
--- a/src/Parser/Mage/Frost/CHANGELOG.js
+++ b/src/Parser/Mage/Frost/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+08-11-2017 - Added Suggestion for casting Blizzard on AoE fights. (by Sharrq)
 04-11-2017 - Reworked and updated Glacial Spike module. (by Sref)
 04-11-2017 - Added support for T20 4set. (by Sref)
 04-11-2017 - Added support for Ice Time and Lady Vashj's Grasp. (by Sref)

--- a/src/Parser/Mage/Frost/CombatLogParser.js
+++ b/src/Parser/Mage/Frost/CombatLogParser.js
@@ -16,6 +16,7 @@ import MirrorImage from '../Shared/Modules/Features/MirrorImage';
 import UnstableMagic from '../Shared/Modules/Features/UnstableMagic';
 import SplittingIce from './Modules/Features/SplittingIce';
 import CancelledCasts from '../Shared/Modules/Features/CancelledCasts';
+import Blizzard from './Modules/Features/Blizzard';
 
 import FrozenOrb from './Modules/Cooldowns/FrozenOrb';
 import IcyVeins from './Modules/Cooldowns/IcyVeins';
@@ -51,6 +52,7 @@ class CombatLogParser extends CoreCombatLogParser {
     arcticGale: ArcticGale,
     frostBomb: FrostBomb,
     splittingIce: SplittingIce,
+    blizzard: Blizzard,
 
 	  //Cooldowns
     frozenOrb: FrozenOrb,

--- a/src/Parser/Mage/Frost/Modules/Features/Blizzard.js
+++ b/src/Parser/Mage/Frost/Modules/Features/Blizzard.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import bosses from 'common/bosses';
+import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import Analyzer from 'Parser/Core/Analyzer';
+
+const AOE_FIGHTS = [
+	bosses.TombOfSargeras.HARJATAN,
+	bosses.TombOfSargeras.THE_DESOLATE_HOST,
+	bosses.TombOfSargeras.MISTRESS_SASSZINE,
+	bosses.TombOfSargeras.KILJAEDEN,
+	bosses.TheNighthold.SKORPYRON,
+	bosses.TheNighthold.SPELLBLADE_ALURIEL,
+	bosses.TheNighthold.TICHONDRIUS,
+	bosses.TheNighthold.KROSUS,
+	bosses.TheNighthold.HIGH_BOTANIST_TELARN,
+	bosses.TheNighthold.STAR_AUGUR_ETRAEUS,
+	bosses.TheNighthold.GULDAN,
+	bosses.TrialOfValor.HELYA,
+	bosses.EmeraldNightmare.ELERETHE_RENFERAL,
+	bosses.EmeraldNightmare.ILGYNOTH_THE_HEART_OF_CORRUPTION,
+	bosses.EmeraldNightmare.CENARIUS,
+	bosses.EmeraldNightmare.XAVIUS,
+];
+
+class Blizzard extends Analyzer {
+	static dependencies = {
+		combatants: Combatants,
+		abilityTracker: AbilityTracker,
+	}
+
+	on_initialized() {
+		this.active = (AOE_FIGHTS.includes(this.owner.fight.boss) || (this.owner.fight.boss === bosses.TombOfSargeras.DEMONIC_INQUISITION && this.owner.fight.difficulty === 5));
+	}
+
+	suggestions(when) {
+		const blizzardCasts = this.abilityTracker.getAbility(SPELLS.BLIZZARD.id).casts || 0;
+		when(blizzardCasts).isLessThan(1)
+			.addSuggestion((suggest, actual, recommended) => {
+				return suggest(<span>You did not cast <SpellLink id={SPELLS.BLIZZARD.id} /> during this fight. Because this is an AoE Fight, you should be casting Blizzard whenever there are 2 or more targets standing near eachother. This is primarily because in addition to doing some AoE Damage, Blizzard also reduces the cooldown on <SpellLink id={SPELLS.FROZEN_ORB.id} /> by 0.5 seconds every time Blizzard deals damage.</span>)
+					.icon(SPELLS.BLIZZARD.icon)
+					.major(1);
+			});
+	}
+}
+
+export default Blizzard;


### PR DESCRIPTION
This adds a suggestion if you are on a fight that is primarily or partially AoE and you never cast Blizzard. This is meant to be a start to evaluating talents and spell cast choices based on the current fight ... For example, telling the player that they took a talent that gave them no benefit because its a Single Target fight, etc, etc.

I also plan on doing more with the Blizzard Module in the future, but getting this working opens up some doors to do further evaluation on the other modules, so I would like to get this in first, so i can do the others. At some point ill circle back to this and add more analysis as far as Blizzard Usage and Damage.