### PR TITLE
[Healing Trinket] Eonar's compassion

### DIFF
--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -63,6 +63,7 @@ import UmbralMoonglaives from './Modules/Items/UmbralMoonglaives';
 // T21 Healing trinkets
 import TarratusKeystone from './Modules/Items/TarratusKeystone';
 import HighFathersMachination from './Modules/Items/HighfathersMachination';
+import EonarsCompassion from './Modules/Items/EonarsCompassion';
 // Shared Buffs
 import Concordance from './Modules/Spells/Concordance';
 import VantusRune from './Modules/Spells/VantusRune';
@@ -150,6 +151,7 @@ class CombatLogParser {
     // T21 Healing Trinkets
     tarratusKeystone: TarratusKeystone,
     highfathersMachinations: HighFathersMachination,
+    eonarsCompassion : EonarsCompassion,
 
     // Concordance of the Legionfall
     concordance: Concordance,

--- a/src/Parser/Core/Modules/Items/EonarsCompassion.js
+++ b/src/Parser/Core/Modules/Items/EonarsCompassion.js
@@ -1,0 +1,84 @@
+import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import { formatNumber, formatPercentage } from 'common/format';
+
+const PANTHEON_MAX_SHIELD_PER_PROC = 4;
+
+class EonarsCompassion extends Analyzer {
+  static dependencies = {
+      combatants: Combatants,
+  };
+  trinketHealing = 0;
+  trinketProc = 0;
+  pantheonShieldHealing = 0;
+  pantheonProc = 0;
+  pantheonShieldCast = 0;
+
+  triggerBuffs = [
+    SPELLS.EONARS_COMPASSION_PANTHEONBUFF_RDROOD.id,
+    SPELLS.EONARS_COMPASSION_PANTHEONBUFF_RMONK.id,
+    SPELLS.EONARS_COMPASSION_PANTHEONBUFF_HPALADIN.id,
+    SPELLS.EONARS_COMPASSION_PANTHEONBUFF_DPRIEST.id,
+    SPELLS.EONARS_COMPASSION_PANTHEONBUFF_HPRIEST.id,
+    SPELLS.EONARS_COMPASSION_PANTHEONBUFF_RSHAMAN.id,
+  ]
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTrinket(ITEMS.EONARS_COMPASSION.id);
+  }
+
+  on_byPlayer_heal(event) {
+    const spellId = event.ability.guid;
+    if (spellId === SPELLS.EONARS_COMPASSION_HEAL.id) {
+      this.trinketHealing += (event.amount || 0) + (event.absorbed || 0);
+    }
+  }
+
+  on_byPlayer_absorbed(event) {
+    const spellId = event.ability.guid;
+    if (spellId === SPELLS.EONARS_COMPASSION_PANTHEONSHIELD.id) {
+      this.pantheonShieldHealing += (event.amount || 0) + (event.absorbed || 0);
+    }
+  }
+
+  on_byPlayer_applybuff(event) {
+      const spellId = event.ability.guid;
+      if (spellId === SPELLS.EONARS_COMPASSION_PROCBUFF.id) {
+        this.trinketProc += 1;
+      }
+      else if (spellId === SPELLS.EONARS_COMPASSION_PANTHEONSHIELD.id) {
+        this.pantheonShieldCast += 1;
+      }
+      else if (this.triggerBuffs.includes(spellId)) {
+        this.pantheonProc += 1;
+      }
+  }
+
+  item() {
+    const totalHeal = this.trinketHealing + this.pantheonShieldHealing;
+    const minutes = this.owner.fightDuration / 1000 / 60;
+    const ppm = this.trinketProc / minutes;
+    const trinketPercentHPS = formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.trinketHealing));
+    const trinketHPS = formatNumber(this.trinketHealing / this.owner.fightDuration * 1000);
+    const pantheonPpm = this.pantheonProc / minutes;
+    const pantheonPercentHPS = formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.pantheonShieldHealing));
+    const pantheonHPS = formatNumber(this.pantheonShieldHealing / this.owner.fightDuration * 1000);
+    const possiblesShield = this.pantheonProc * PANTHEON_MAX_SHIELD_PER_PROC;
+      return {
+          item: ITEMS.EONARS_COMPASSION,
+          result: (
+            <dfn data-tip={`The trinket effect procced ${this.trinketProc} times with an average of ${ppm.toFixed(2)} PPM.<br>
+            This did ${formatNumber(this.trinketHealing)} healing and was ${trinketPercentHPS}% of your total healing, provinding ${trinketHPS} HPS.<br><br>
+            The pantheon effect procced ${this.pantheonProc} times with an average of ${pantheonPpm.toFixed(2)} PPM.<br>
+            You casted ${this.pantheonShieldCast} shields out of the ${possiblesShield} possibles.<br>
+            This did ${formatNumber(this.pantheonShieldHealing)} absorb and was ${pantheonPercentHPS}% of your total healing, provinding ${pantheonHPS} HPS.`}>
+        {this.owner.formatItemHealingDone(totalHeal)}
+        </dfn>),
+    };
+  }
+}
+
+export default EonarsCompassion;

--- a/src/Parser/Core/Modules/Items/EonarsCompassion.js
+++ b/src/Parser/Core/Modules/Items/EonarsCompassion.js
@@ -18,7 +18,7 @@ class EonarsCompassion extends Analyzer {
   pantheonShieldCast = 0;
 
   triggerBuffs = [
-    SPELLS.EONARS_COMPASSION_PANTHEONBUFF_RDROOD.id,
+    SPELLS.EONARS_COMPASSION_PANTHEONBUFF_RDRUID.id,
     SPELLS.EONARS_COMPASSION_PANTHEONBUFF_RMONK.id,
     SPELLS.EONARS_COMPASSION_PANTHEONBUFF_HPALADIN.id,
     SPELLS.EONARS_COMPASSION_PANTHEONBUFF_DPRIEST.id,
@@ -40,7 +40,7 @@ class EonarsCompassion extends Analyzer {
   on_byPlayer_absorbed(event) {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.EONARS_COMPASSION_PANTHEONSHIELD.id) {
-      this.pantheonShieldHealing += (event.amount || 0) + (event.absorbed || 0);
+      this.pantheonShieldHealing += (event.amount || 0);
     }
   }
 

--- a/src/common/ITEMS/OTHERS.js
+++ b/src/common/ITEMS/OTHERS.js
@@ -199,6 +199,12 @@ export default {
     icon: 'spell_nature_astralrecalgroup',
     quality: ITEM_QUALITIES.EPIC,
   },
+  EONARS_COMPASSION: {
+    id: 154175,
+    name: 'Eonar\'s Compassion',
+    icon: 'inv_antorus_green',
+    quality: ITEM_QUALITIES.EPIC,
+  },
 
   // DPS Trinkets
   ERRATIC_METRONOME: {

--- a/src/common/SPELLS/OTHERS.js
+++ b/src/common/SPELLS/OTHERS.js
@@ -252,6 +252,51 @@ export default {
     name: 'Aman Thul\'s Presence',
     icon: 'spell_priest_psyfiend',
   },
+  EONARS_COMPASSION_HEAL: {
+    id: 257442,
+    name: 'Emerald Blossom',
+    icon: 'inv_antorus_green',
+  },
+  EONARS_COMPASSION_PROCBUFF: {
+    id: 256824,
+    name: 'Mark of Eonar',
+    icon: 'inv_antorus_green',
+  },
+  EONARS_COMPASSION_PANTHEONSHIELD: {
+    id: 257444,
+    name: 'Verdant Embrace',
+    icon: 'talentspec_druid_restoration',
+  },
+  EONARS_COMPASSION_PANTHEONBUFF_RDROOD: {
+    id: 257470,
+    name: 'Eonar\'s Verdant Embrace',
+    icon: 'talentspec_druid_restoration',
+  },
+  EONARS_COMPASSION_PANTHEONBUFF_RMONK: {
+    id: 257471,
+    name: 'Eonar\'s Verdant Embrace',
+    icon: 'talentspec_druid_restoration',
+  },
+  EONARS_COMPASSION_PANTHEONBUFF_HPALADIN: {
+    id: 257472,
+    name: 'Eonar\'s Verdant Embrace',
+    icon: 'talentspec_druid_restoration',
+  },
+  EONARS_COMPASSION_PANTHEONBUFF_DPRIEST: {
+    id: 257473,
+    name: 'Eonar\'s Verdant Embrace',
+    icon: 'talentspec_druid_restoration',
+  },
+  EONARS_COMPASSION_PANTHEONBUFF_HPRIEST: {
+    id: 257474,
+    name: 'Eonar\'s Verdant Embrace',
+    icon: 'talentspec_druid_restoration',
+  },
+  EONARS_COMPASSION_PANTHEONBUFF_RSHAMAN: {
+    id: 257475,
+    name: 'Eonar\'s Verdant Embrace',
+    icon: 'talentspec_druid_restoration',
+  },
 
   // Item Abilities
   SPECTRAL_OWL: {

--- a/src/common/SPELLS/OTHERS.js
+++ b/src/common/SPELLS/OTHERS.js
@@ -267,7 +267,7 @@ export default {
     name: 'Verdant Embrace',
     icon: 'talentspec_druid_restoration',
   },
-  EONARS_COMPASSION_PANTHEONBUFF_RDROOD: {
+  EONARS_COMPASSION_PANTHEONBUFF_RDRUID: {
     id: 257470,
     name: 'Eonar\'s Verdant Embrace',
     icon: 'talentspec_druid_restoration',


### PR DESCRIPTION
Added the antorus pantheon healing trinket (eonar's compassion).

logs:
https://www.warcraftlogs.com/reports/thQVp9F4GM8qryAR
any fight on character charite
the pantheon buff is only used in Varimathras wipe 3 fight.

The trinket icon is currently not displaying.
http://blzmedia-a.akamaihd.net/wow/icons/56/inv_antorus_green.jpg returns a 404 error
hope this should be patched in 7.3.5
(btw https://render-us.worldofwarcraft.com/icons/56/inv_antorus_green.jpg works fine)

