### PR TITLE
[core] Updated appearance of DamageDone and HealingDone tooltips

### DIFF
--- a/src/Parser/Core/Modules/DamageDone.js
+++ b/src/Parser/Core/Modules/DamageDone.js
@@ -52,7 +52,7 @@ class DamageDone extends Analyzer {
         )}
         value={`${formatNumber(this.total.effective / (this.owner.fightDuration / 1000))} DPS`}
         label="Damage done"
-        tooltip={`The total damage done was ${formatThousands(this.total.effective)}. Pets contributed ${formatNumber(this.totalByPets.effective / (this.owner.fightDuration / 1000))} DPS.`}
+        tooltip={`Total damage done: <b>${formatThousands(this.total.effective)}</b> ${this.totalByPets.effective ? `<br>Contribution from pets: ${this.owner.formatItemDamageDone(this.totalByPets.effective)}` : ''}`}
       />
     );
   }

--- a/src/Parser/Core/Modules/HealingDone.js
+++ b/src/Parser/Core/Modules/HealingDone.js
@@ -85,7 +85,7 @@ class HealingDone extends Analyzer {
         )}
         value={`${formatNumber(this.total.effective / this.owner.fightDuration * 1000)} HPS`}
         label="Healing done"
-        tooltip={`The total healing done recorded was ${formatThousands(this.total.effective)}.`}
+        tooltip={`Total healing done: <b>${formatThousands(this.total.effective)}</b>`}
         footer={(
           <div className="statistic-bar">
             <div


### PR DESCRIPTION
Changed the 'totals' part of each tooltip to be more concisely worded. For the 'pets contribution' part of DamageDone, updated the display and also made it only show if the player had >0 pet damage.