### PR TITLE
Disc Crash Fix

### DIFF
--- a/src/Parser/Priest/Discipline/CHANGELOG.js
+++ b/src/Parser/Priest/Discipline/CHANGELOG.js
@@ -1,7 +1,9 @@
 export default `
+10-13-2017 - Fixed a bug with some trinket damage events causing a crash. (By Gao)
 10-11-2017 - Added T21 4pc bonus. (By Oratio)
 01-11-2017 - Added T21 2pc bonus. (By Oratio)
-27-10-2017 - Refactored disc module. (Gao)
+02-11-2017 - Added Estel Avg Haste bugg (By Gao)
+27-10-2017 - Refactored disc module. (By Gao)
 27-10-2017 - Added an atonement normalizer to fix atonement ordering issues. (By Oratio)
 26-10-2017 - Adjusted the T20 2pc bonus for the recent nerfs. (By Oratio)
 16-10-2017 - Fixed T20 4pc bug, added a suggestion to utilise the buff. (By Reglitch)

--- a/src/Parser/Priest/Discipline/Modules/Features/AtonementHealingDone.js
+++ b/src/Parser/Priest/Discipline/Modules/Features/AtonementHealingDone.js
@@ -24,7 +24,9 @@ class AtonementHealingDone extends Analyzer {
       return;
     }
     const source = this.atonementSource.atonementDamageSource;
-    this._addHealing(source, event.amount, event.absorbed, event.overheal);
+    if (source) {
+      this._addHealing(source, event.amount, event.absorbed, event.overheal);
+    }
   }
   // FIXME: 'byAbility()' added to HealingDone, this should no longer require custom code
   _addHealing(source, amount = 0, absorbed = 0, overheal = 0) {

--- a/src/Parser/Priest/Discipline/Modules/Items/MarchOfTheLegion.js
+++ b/src/Parser/Priest/Discipline/Modules/Items/MarchOfTheLegion.js
@@ -35,11 +35,12 @@ class MarchOfTheLegion extends Analyzer {
       debug && console.log('Skipping Atonement heal event since combatant couldn\'t be found:', event);
       return;
     }
-    if (this.atonementSource.atonementDamageSource.ability.guid !== SPELLS.MARCH_OF_THE_LEGION.id) {
-      return;
+    if (this.atonementSource.atonementDamageSource) {
+      if (this.atonementSource.atonementDamageSource.ability.guid !== SPELLS.MARCH_OF_THE_LEGION.id) {
+        return;
+      }
+      this.healing += event.amount + (event.absorbed || 0);
     }
-
-    this.healing += event.amount + (event.absorbed || 0);
   }
 
   item() {

--- a/src/Parser/Priest/Discipline/Modules/Items/NeroBandOfPromises.js
+++ b/src/Parser/Priest/Discipline/Modules/Items/NeroBandOfPromises.js
@@ -36,12 +36,13 @@ class NeroBandOfPromises extends Analyzer {
       // If someone already has the Atonement buff then N'ero will not cause Penance to heal that person twice (N'ero does NOT stack with pre-existing Atonement)
       return;
     }
-    if (this.atonementSource.atonementDamageSource.ability.guid !== SPELLS.PENANCE.id) {
-      // N'ero only procs from Penance
-      return;
+    if (this.atonementSource.atonementDamageSource) {
+      if (this.atonementSource.atonementDamageSource.ability.guid !== SPELLS.PENANCE.id) {
+        // N'ero only procs from Penance
+        return;
+      }
+      this.healing += event.amount + (event.absorbed || 0);
     }
-
-    this.healing += event.amount + (event.absorbed || 0);
   }
   
   item() {

--- a/src/Parser/Priest/Discipline/Modules/Items/TarnishedSentinelMedallion.js
+++ b/src/Parser/Priest/Discipline/Modules/Items/TarnishedSentinelMedallion.js
@@ -35,11 +35,12 @@ class TarnishedSentinelMedallion extends Analyzer {
       debug && console.log('Skipping Atonement heal event since combatant couldn\'t be found:', event);
       return;
     }
-    if (!this.damageAbilities.has(this.atonementSource.atonementDamageSource.ability.guid)) {
-      return;
+    if (this.atonementSource.atonementDamageSource) {
+      if (!this.damageAbilities.has(this.atonementSource.atonementDamageSource.ability.guid)) {
+        return;
+      }
+      this.healing += event.amount + (event.absorbed || 0);
     }
-
-    this.healing += event.amount + (event.absorbed || 0);
   }
 
   on_byPlayer_damage(event) {

--- a/src/Parser/Priest/Discipline/Modules/Spells/TouchOfTheGrave.js
+++ b/src/Parser/Priest/Discipline/Modules/Spells/TouchOfTheGrave.js
@@ -31,10 +31,12 @@ class TouchOfTheGrave extends Analyzer {
     if (!isAtonement(event)) {
       return;
     }
-    if (this.atonementSource.atonementDamageSource.ability.guid !== SPELLS.TOUCH_OF_THE_GRAVE.id) {
-      return;
+    if (this.atonementSource.atonementDamageSource) {
+      if (this.atonementSource.atonementDamageSource.ability.guid !== SPELLS.TOUCH_OF_THE_GRAVE.id) {
+        return;
+      }
+      this.healing += event.amount + (event.absorbed || 0);
     }
-    this.healing += event.amount + (event.absorbed || 0);
   }
 
   statistic() {


### PR DESCRIPTION
Fixes this bug: https://sentry.io/share/issue/33ce182b00b64e65843b0c403b2b69c5/

Ideally the atonement source would always be there. I haven't figured out exactly why it's not always there, but for now I've more gracefully handled the exceptions so that the healing just won't be added in, which is much better than crashing the page.