### PR TITLE
EstelNormalizer Null event.ability handling

### DIFF
--- a/src/Parser/Priest/Discipline/Normalizers/EstelNormalizer.js
+++ b/src/Parser/Priest/Discipline/Normalizers/EstelNormalizer.js
@@ -16,7 +16,8 @@ class EstelNormalizer extends EventsNormalizer {
 
     events.forEach((event, eventIndex) => {
 
-      if ((event.sourceID === event.targetID) 
+      if (event.ability && event.ability.guid
+          && (event.sourceID === event.targetID) 
           && (event.ability.guid === SPELLS.ESTEL_DEJAHNAS_INSPIRATION_BUFF.id)) {
 
         if (haveOpenBuff) {


### PR DESCRIPTION
fixes the sentry.io error from this log: https://www.warcraftlogs.com/reports/PFv7HpMc4ntX9k3W/#fight=31&type=summary
https://sentry.io/share/issue/5b77dc87172c4e4d90f7b95cef359a48/