### PR TITLE
[Marksmanship] remove bindingShot from CooldownThroughput

### DIFF
--- a/src/Parser/Hunter/Marksmanship/Modules/Features/CooldownThroughputTracker.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Features/CooldownThroughputTracker.js
@@ -24,6 +24,8 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     SPELLS.WINDBURST_MOVEMENT_SPEED.id,
     SPELLS.CYCLONIC_BURST_TRAIT.id,
     SPELLS.CYCLONIC_BURST_IMPACT_TRAIT.id,
+    SPELLS.BINDING_SHOT_STUN.id,
+    SPELLS.BINDING_SHOT_TETHER.id,
   ];
 }
 

--- a/src/common/SPELLS/HUNTER.js
+++ b/src/common/SPELLS/HUNTER.js
@@ -430,4 +430,14 @@ export default {
     name: 'Dismiss Pet',
     icon: 'spell_nature_spiritwolf',
   },
+  BINDING_SHOT_STUN: {
+    id: 117526,
+    name: 'Binding Shot Stun',
+    icon: 'spell_shaman_bindelemental',
+  },
+  BINDING_SHOT_TETHER: {
+    id: 117405,
+    name: 'Binding Shot Tether',
+    icon: 'spell_shaman_bindelemental',
+  },
 };


### PR DESCRIPTION
Fixes that the tethers and stuns from Binding Shot show up as casts in the cooldown window, even they aren't something the player actually cast. 

going from
![image](https://user-images.githubusercontent.com/29204244/32979612-d39de11c-cc58-11e7-85e3-d2e30aeec92e.png)


to 
![image](https://user-images.githubusercontent.com/29204244/32979608-bc95fb9e-cc58-11e7-8143-592a2878c6cc.png)
