### PR TITLE
[Discipline Priest] Fixed value for Undead Racial

### DIFF
--- a/src/Parser/Priest/Discipline/Modules/Spells/TouchOfTheGrave.js
+++ b/src/Parser/Priest/Discipline/Modules/Spells/TouchOfTheGrave.js
@@ -32,6 +32,7 @@ class TouchOfTheGrave extends Analyzer {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.TOUCH_OF_THE_GRAVE.id) {
       this.directHealing += event.amount + (event.absorbed || 0);
+      return;
     }
 
     if (!isAtonement(event)) {

--- a/src/Parser/Priest/Discipline/Modules/Spells/TouchOfTheGrave.js
+++ b/src/Parser/Priest/Discipline/Modules/Spells/TouchOfTheGrave.js
@@ -58,7 +58,7 @@ class TouchOfTheGrave extends Analyzer {
     // since we can't directly get undead racial status, if we found 0 damage,
     // assume they aren't undead and do not load the module
     if(damage === 0) { return; }
-    console.log(this.directHealing);
+
     return(
       <StatisticBox
         icon={<SpellIcon id={SPELLS.TOUCH_OF_THE_GRAVE.id} />}

--- a/src/Parser/Priest/Discipline/Modules/Spells/TouchOfTheGrave.js
+++ b/src/Parser/Priest/Discipline/Modules/Spells/TouchOfTheGrave.js
@@ -57,7 +57,7 @@ class TouchOfTheGrave extends Analyzer {
 
     // since we can't directly get undead racial status, if we found 0 damage,
     // assume they aren't undead and do not load the module
-    if(damage === 0) { return; }
+    if(damage === 0) { return null; }
 
     return(
       <StatisticBox


### PR DESCRIPTION
In the Touch of the Grave Undead racial, the direct healing wasn't added in the count. The spell generates healing from atonement but also direct healing on self. This PR adds the healing to the value of the racial and gives a breakdown in the mouse over.