### PR TITLE
[core] Fixed an issue where spell timelines weren't rendered properly for spells with charges

### DIFF
--- a/src/Main/Timeline/Events.js
+++ b/src/Main/Timeline/Events.js
@@ -52,6 +52,8 @@ class Events extends React.PureComponent {
     const { events, start, totalWidth, secondWidth, className } = this.props;
     const fixedEvents = this.fabricateEndCooldown(events);
 
+    let beginTimestamp;
+
     return (
       <div className={`events ${className || ''}`} style={{ width: totalWidth }}>
         {fixedEvents.map((event, index) => {
@@ -69,9 +71,9 @@ class Events extends React.PureComponent {
             );
           }
           if (event.type === 'updatespellusable' && event.trigger === 'endcooldown') {
-            const left = (event.start - start) / 1000 * secondWidth;
+            const left = (beginTimestamp - start) / 1000 * secondWidth;
             const maxWidth = totalWidth - left; // don't expand beyond the container width
-            const width = Math.min(maxWidth, (event.end - event.start) / 1000 * secondWidth);
+            const width = Math.min(maxWidth, (event.end - beginTimestamp) / 1000 * secondWidth);
             return (
               <div
                 key={index}
@@ -81,9 +83,12 @@ class Events extends React.PureComponent {
                   background: 'rgba(150, 150, 150, 0.4)',
                   zIndex: 1,
                 }}
-                data-tip={`Cooldown: ${((event.end - event.start) / 1000).toFixed(1)}s`}
+                data-tip={`Cooldown: ${((event.end - beginTimestamp) / 1000).toFixed(1)}s`}
               />
             );
+          }
+          if (event.type === 'updatespellusable' && event.trigger === 'begincooldown') {
+            beginTimestamp = event.timestamp;
           }
 
           return null;

--- a/src/Main/Timeline/Events.js
+++ b/src/Main/Timeline/Events.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import SpellIcon from 'common/SpellIcon';
 
-const RESTORE_CHARGE_TICK_WIDTH = 70;
+const RESTORE_CHARGE_TICK_WIDTH = 3;
 
 class Events extends React.PureComponent {
   static propTypes = {
@@ -97,9 +97,9 @@ class Events extends React.PureComponent {
         })}
         {fixedEvents.map((event, index) => {
           if (event.type === 'updatespellusable' && (event.trigger === 'restorecharge')) {
-            const left = (event.timestamp - (RESTORE_CHARGE_TICK_WIDTH / 2) - start) / 1000 * secondWidth;
+            const left = (event.timestamp - start) / 1000 * secondWidth;
             const maxWidth = totalWidth - left; // don't expand beyond the container width
-            const width = Math.min(maxWidth, RESTORE_CHARGE_TICK_WIDTH / 1000 * secondWidth);
+            const width = Math.min(maxWidth, RESTORE_CHARGE_TICK_WIDTH);
             return (
               <div
                 key={index}

--- a/src/Main/Timeline/Events.js
+++ b/src/Main/Timeline/Events.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 
 import SpellIcon from 'common/SpellIcon';
 
+const RESTORE_CHARGE_TICK_WIDTH = 80;
+
 class Events extends React.PureComponent {
   static propTypes = {
     events: PropTypes.array,
@@ -83,6 +85,26 @@ class Events extends React.PureComponent {
                   zIndex: 1,
                 }}
                 data-tip={`Cooldown: ${((event.timestamp - event.start) / 1000).toFixed(1)}s`}
+              />
+            );
+          }
+          return null;
+        })}
+        {fixedEvents.map((event, index) => {
+          if (event.type === 'updatespellusable' && (/*event.trigger === 'endcooldown' || */event.trigger === 'restorecharge')) {
+            const left = (event.timestamp - (RESTORE_CHARGE_TICK_WIDTH / 2) - start) / 1000 * secondWidth;
+            const maxWidth = totalWidth - left; // don't expand beyond the container width
+            const width = Math.min(maxWidth, RESTORE_CHARGE_TICK_WIDTH / 1000 * secondWidth);
+            return (
+              <div
+                key={index}
+                style={{
+                  left,
+                  width,
+                  background: 'rgba(250, 250, 250, 0.6)',
+                  zIndex: 2,
+                }}
+                data-tip={`Charge Restored`}
               />
             );
           }

--- a/src/Main/Timeline/Events.js
+++ b/src/Main/Timeline/Events.js
@@ -96,7 +96,7 @@ class Events extends React.PureComponent {
           return null;
         })}
         {fixedEvents.map((event, index) => {
-          if (event.type === 'updatespellusable' && (/*event.trigger === 'endcooldown' || */event.trigger === 'restorecharge')) {
+          if (event.type === 'updatespellusable' && (event.trigger === 'restorecharge')) {
             const left = (event.timestamp - (RESTORE_CHARGE_TICK_WIDTH / 2) - start) / 1000 * secondWidth;
             const maxWidth = totalWidth - left; // don't expand beyond the container width
             const width = Math.min(maxWidth, RESTORE_CHARGE_TICK_WIDTH / 1000 * secondWidth);

--- a/src/Main/Timeline/Events.js
+++ b/src/Main/Timeline/Events.js
@@ -52,8 +52,6 @@ class Events extends React.PureComponent {
     const { events, start, totalWidth, secondWidth, className } = this.props;
     const fixedEvents = this.fabricateEndCooldown(events);
 
-    let beginTimestamp;
-
     return (
       <div className={`events ${className || ''}`} style={{ width: totalWidth }}>
         {fixedEvents.map((event, index) => {
@@ -70,10 +68,10 @@ class Events extends React.PureComponent {
               </div>
             );
           }
-          if (event.type === 'updatespellusable' && event.trigger === 'endcooldown') {
-            const left = (beginTimestamp - start) / 1000 * secondWidth;
+          if (event.type === 'updatespellusable' && (event.trigger === 'endcooldown' || event.trigger === 'restorecharge')) {
+            const left = (event.start - start) / 1000 * secondWidth;
             const maxWidth = totalWidth - left; // don't expand beyond the container width
-            const width = Math.min(maxWidth, (event.end - beginTimestamp) / 1000 * secondWidth);
+            const width = Math.min(maxWidth, (event.timestamp - event.start) / 1000 * secondWidth);
             return (
               <div
                 key={index}
@@ -83,14 +81,10 @@ class Events extends React.PureComponent {
                   background: 'rgba(150, 150, 150, 0.4)',
                   zIndex: 1,
                 }}
-                data-tip={`Cooldown: ${((event.end - beginTimestamp) / 1000).toFixed(1)}s`}
+                data-tip={`Cooldown: ${((event.timestamp - event.start) / 1000).toFixed(1)}s`}
               />
             );
           }
-          if (event.type === 'updatespellusable' && event.trigger === 'begincooldown') {
-            beginTimestamp = event.timestamp;
-          }
-
           return null;
         })}
       </div>

--- a/src/Main/Timeline/Events.js
+++ b/src/Main/Timeline/Events.js
@@ -26,7 +26,11 @@ class Events extends React.PureComponent {
       if (event.type !== 'updatespellusable') {
         return;
       }
-      if (event.trigger === 'begincooldown') {
+      if (event.trigger === 'begincooldown' || event.trigger === 'refreshcooldown') {
+        const index = missingEndCooldowns.findIndex(beginCooldownEvent => beginCooldownEvent.spellId === event.spellId);
+        if (index !== -1) {
+          missingEndCooldowns.splice(index, 1);
+        }
         missingEndCooldowns.push(event);
       }
       if (event.trigger === 'endcooldown') {

--- a/src/Main/Timeline/Events.js
+++ b/src/Main/Timeline/Events.js
@@ -41,6 +41,7 @@ class Events extends React.PureComponent {
       fixedEvents.push({
         ...beginCooldownEvent,
         trigger: 'endcooldown',
+        timestamp : beginCooldownEvent.start + beginCooldownEvent.expectedDuration,
         end: beginCooldownEvent.start + beginCooldownEvent.expectedDuration,
       });
     });

--- a/src/Main/Timeline/Events.js
+++ b/src/Main/Timeline/Events.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import SpellIcon from 'common/SpellIcon';
 
-const RESTORE_CHARGE_TICK_WIDTH = 80;
+const RESTORE_CHARGE_TICK_WIDTH = 70;
 
 class Events extends React.PureComponent {
   static propTypes = {

--- a/src/Main/Timeline/Events.js
+++ b/src/Main/Timeline/Events.js
@@ -64,6 +64,7 @@ class Events extends React.PureComponent {
                 key={index}
                 style={{
                   left: (event.timestamp - start) / 1000 * secondWidth,
+                  top: -1, // without this, icon vertical positioning slightly off...
                   zIndex: 10,
                 }}
               >

--- a/src/Parser/Core/Modules/SpellUsable.js
+++ b/src/Parser/Core/Modules/SpellUsable.js
@@ -84,6 +84,7 @@ class SpellUsable extends Analyzer {
             formatMilliseconds(this.owner.fightDuration),
             'SpellUsable',
             spellName(spellId), spellId, `was cast while already marked as on cooldown. It probably either has multiple charges, can be reset early, cooldown can be reduced, the configured CD is invalid, the Haste is too low, the combatlog records multiple casts per player cast (e.g. ticks of a channel) or this is a latency issue.`,
+            'fight time:', timestamp - this.owner.fight.start_time,
             'time passed:', (timestamp - this._currentCooldowns[spellId].start),
             'cooldown remaining:', remainingCooldown,
             'expectedDuration:', this._currentCooldowns[spellId].expectedDuration
@@ -115,9 +116,7 @@ class SpellUsable extends Analyzer {
     } else {
       // We have another charge ready to go on cooldown, this simply adds a charge and then refreshes the cooldown (spells with charges don't cooldown simultaneously)
       cooldown.chargesOnCooldown -= 1;
-      this._triggerEvent('updatespellusable', this._makeEvent(spellId, timestamp, 'restorecharge', {
-        ...cooldown,
-      }));
+      this._triggerEvent('updatespellusable', this._makeEvent(spellId, timestamp, 'restorecharge', cooldown));
       this.refreshCooldown(spellId, timestamp);
     }
   }

--- a/src/Parser/Core/Modules/SpellUsable.js
+++ b/src/Parser/Core/Modules/SpellUsable.js
@@ -115,7 +115,9 @@ class SpellUsable extends Analyzer {
     } else {
       // We have another charge ready to go on cooldown, this simply adds a charge and then refreshes the cooldown (spells with charges don't cooldown simultaneously)
       cooldown.chargesOnCooldown -= 1;
-      this._triggerEvent('updatespellusable', this._makeEvent(spellId, timestamp, 'restorecharge', cooldown));
+      this._triggerEvent('updatespellusable', this._makeEvent(spellId, timestamp, 'restorecharge', {
+        ...cooldown,
+      }));
       this.refreshCooldown(spellId, timestamp);
     }
   }


### PR DESCRIPTION
DON'T MERGE just yet

Fixes #793 - I chose option 1 for fixing this, because option 1 was obviously the correct choice.

The reason I say "don't merge this yet" is because the cooldown tooltip on charged spells is now a bit janky -- it shows the total amount of contiguous time the spell was recharging, which typically has nothing to do with the spell's actual cooldown. I put up this PR to solicit ideas as to how this should be handled. My current best idea is that some sort of marker should delineate each gained charge, and the tooltip on each segment should display the amount of time it took that charge to be gained.

