### PR TITLE
[frost mage] Fixed a bug where 4t20 CDR wasn't being applied on Brain Freeze refresh

### DIFF
--- a/src/Parser/Mage/Frost/Modules/Items/Tier20_4set.js
+++ b/src/Parser/Mage/Frost/Modules/Items/Tier20_4set.js
@@ -31,7 +31,15 @@ class Tier20_4set extends Analyzer {
     }
   }
 
+  on_toPlayer_refreshbuff(event) {
+    this._handleBuff(event);
+  }
+
   on_toPlayer_applybuff(event) {
+    this._handleBuff(event);
+  }
+
+  _handleBuff(event) {
 		if (event.ability.guid !== SPELLS.BRAIN_FREEZE.id) {
 			return;
 		}


### PR DESCRIPTION
To be clear, the actual bonus procs on apply or refresh, and until this change our code was only checking apply.