### PR TITLE
[resto druid] Changed Soul of the Archdruid display to be like for other classes

### DIFF
--- a/src/Parser/Druid/Restoration/CombatLogParser.js
+++ b/src/Parser/Druid/Restoration/CombatLogParser.js
@@ -16,6 +16,7 @@ import Ekowraith from './Modules/Items/Ekowraith';
 import XonisCaress from './Modules/Items/XonisCaress';
 import DarkTitanAdvice from './Modules/Items/DarkTitanAdvice';
 import EssenceOfInfusion from './Modules/Items/EssenceOfInfusion';
+import SoulOfTheArchdruid from './Modules/Items/SoulOfTheArchdruid';
 import Tearstone from './Modules/Items/Tearstone';
 import DarkmoonDeckPromises from './Modules/Items/DarkmoonDeckPromises';
 
@@ -105,6 +106,7 @@ class CombatLogParser extends CoreCombatLogParser {
     xonisCaress: XonisCaress,
     darkTitanAdvice: DarkTitanAdvice,
     essenceOfInfusion: EssenceOfInfusion,
+    soulOfTheArchdruid: SoulOfTheArchdruid,
     tearstone: Tearstone,
     t19_2set: T19_2Set,
     t20_2set: T20_2Set,

--- a/src/Parser/Druid/Restoration/Modules/Items/SoulOfTheArchdruid.js
+++ b/src/Parser/Druid/Restoration/Modules/Items/SoulOfTheArchdruid.js
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import ITEMS from 'common/ITEMS';
+import SPELLS from 'common/SPELLS';
+import Wrapper from 'common/Wrapper';
+import SpellLink from 'common/SpellLink';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+class SoulOfTheArchdruid extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasFinger(ITEMS.SOUL_OF_THE_ARCHDRUID.id);
+  }
+
+  item() {
+    return {
+      item: ITEMS.SOUL_OF_THE_ARCHDRUID,
+      result: <Wrapper>This gave you <SpellLink id={SPELLS.SOUL_OF_THE_FOREST_TALENT_RESTORATION.id} />.</Wrapper>,
+    };
+  }
+}
+
+export default SoulOfTheArchdruid;

--- a/src/Parser/Druid/Restoration/Modules/Talents/SoulOfTheForest.js
+++ b/src/Parser/Druid/Restoration/Modules/Talents/SoulOfTheForest.js
@@ -134,8 +134,6 @@ class SoulOfTheForest extends Analyzer {
   }
 
   statistic() {
-    if(!this.hasSotf) { return; }
-
     const total = this.wildGrowthHealing + this.rejuvenationHealing + this.regrowthHealing;
     const totalPercent = this.owner.getPercentageOfTotalHealingDone(total);
 
@@ -160,32 +158,6 @@ class SoulOfTheForest extends Analyzer {
     );
   }
   statisticOrder = STATISTIC_ORDER.OPTIONAL();
-
-  item() {
-    if(!this.hasSota) { return; }
-
-    const total = this.wildGrowthHealing + this.rejuvenationHealing + this.regrowthHealing;
-
-    const wgPercent = this.owner.getPercentageOfTotalHealingDone(this.wildGrowthHealing);
-    const rejuvPercent = this.owner.getPercentageOfTotalHealingDone(this.rejuvenationHealing);
-    const regrowthPercent = this.owner.getPercentageOfTotalHealingDone(this.regrowthHealing);
-
-    return {
-      item: ITEMS.SOUL_OF_THE_ARCHDRUID,
-      result: (
-        <dfn data-tip={
-          `You gained ${this.proccs} total Soul of the Forest procs.
-          <ul>
-            <li>Consumed ${this.wildGrowths} procs with Wild Growth for ${formatPercentage(wgPercent)}% healing</li>
-            <li>Consumed ${this.rejuvenations} procs with Rejuvenation for ${formatPercentage(rejuvPercent)}% healing</li>
-            <li>Consumed ${this.regrowths} procs with Regrowth for ${formatPercentage(regrowthPercent)}% healing</li>
-          </ul>`
-        }>
-          {this.owner.formatItemHealingDone(total)}
-        </dfn>
-      ),
-    };
-  }
 
 }
 


### PR DESCRIPTION
Previously if player had SotA, there would be no SotF display and instead a rough duplicate of it would be put in the Items bar.

Now, you get the SotF statistic if you talented for SotF or if you have SotA, and if you have SotA you get an item entry saying "This gave you Soul of the Forest".