### PR TITLE
[core] Added some documentation to format and Entity, and added support for sourceID filtering to Entity

### DIFF
--- a/src/Parser/Core/Entity.js
+++ b/src/Parser/Core/Entity.js
@@ -9,38 +9,67 @@ class Entity {
    */
 
   buffs = [];
+
+  /**
+   * @param {number} forTimestamp - Timestamp (in ms) to be considered, or the current timestamp if null. Won't work right for timestamps after the currentTimestamp.
+   * @param {number} bufferTime - Time (in ms) after buff's expiration where it will still be included. There's a bug in the combat log where if a spell consumes a buff that buff may disappear a short time before the heal or damage event it's buffing is logged. This can sometimes go up to hundreds of milliseconds.
+   * @param {number} minimalActiveTime - Time (in ms) the buff must have been active before timestamp for it to be included.
+   * @returns {Array} - All buffs on the Entity at the given timestamp
+   */
   activeBuffs(forTimestamp = null, bufferTime = 0, minimalActiveTime = 0) {
     const currentTimestamp = forTimestamp || this.owner.currentTimestamp;
     return this.buffs.filter(buff => (currentTimestamp - minimalActiveTime) >= buff.start && (buff.end === null || (buff.end + bufferTime) >= currentTimestamp));
   }
+
   /**
-   * @param spellId
-   * @param forTimestamp
-   * @param bufferTime Time (in MS) the buff may have expired. There's a bug in the combat log where if a spell consumes a buff that buff may disappear a few MS earlier than the heal event is logged. I've seen this go up to 32ms.
-   * @param minimalActiveTime
-   * @returns {boolean}
+   * @param {number} spellId buff ID to check for
+   * @param {number} forTimestamp Timestamp (in ms) to be considered, or the current timestamp if null. Won't work right for timestamps after the currentTimestamp.
+   * @param {number} bufferTime Time (in ms) after buff's expiration where it will still be included. There's a bug in the combat log where if a spell consumes a buff that buff may disappear a short time before the heal or damage event it's buffing is logged. This can sometimes go up to hundreds of milliseconds.
+   * @param {number} minimalActiveTime - Time (in ms) the buff must have been active before timestamp for it to be included.
+   * @param {number} sourceID - source ID the buff must have come from, or any source if null
+   * @returns {boolean} - Whether the buff is present with the given specifications.
    */
-  hasBuff(spellId, forTimestamp = null, bufferTime = 0, minimalActiveTime = 0) {
-    return this.getBuff(spellId, forTimestamp, bufferTime, minimalActiveTime) !== undefined;
+  hasBuff(spellId, forTimestamp = null, bufferTime = 0, minimalActiveTime = 0, sourceID = null) {
+    return this.getBuff(spellId, forTimestamp, bufferTime, minimalActiveTime, sourceID) !== undefined;
   }
-  getBuff(spellId, forTimestamp = null, bufferTime = 0, minimalActiveTime = 0) {
+
+  /**
+   * @param {number} spellId - buff ID to check for
+   * @param {number} forTimestamp Timestamp (in ms) to be considered, or the current timestamp if null. Won't work right for timestamps after the currentTimestamp.
+   * @param {number} bufferTime Time (in ms) after buff's expiration where it will still be included. There's a bug in the combat log where if a spell consumes a buff that buff may disappear a short time before the heal or damage event it's buffing is logged. This can sometimes go up to hundreds of milliseconds.
+   * @param {number} minimalActiveTime - Time (in ms) the buff must have been active before timestamp for it to be included.
+   * @param {number} sourceID - source ID the buff must have come from, or any source if null.
+   * @returns {Object} - A buff with the given specifications. The buff object will have all the properties of the associated applybuff event, along with a start timestamp, an end timestamp if the buff has fallen, and an isDebuff flag. If multiple buffs meet the specifications, there's no guarantee which you'll get (this could happen if multiple spells with the same spellId but from different sources are on the same target)
+   */
+  getBuff(spellId, forTimestamp = null, bufferTime = 0, minimalActiveTime = 0, sourceID = null) {
     const currentTimestamp = forTimestamp || this.owner.currentTimestamp;
     const nSpellId = Number(spellId);
-    return this.buffs.find(buff => buff.ability.guid === nSpellId && (currentTimestamp - minimalActiveTime) >= buff.start && (buff.end === null || (buff.end + bufferTime) >= currentTimestamp));
+    return this.buffs.find(buff =>
+      buff.ability.guid === nSpellId &&
+      (currentTimestamp - minimalActiveTime) >= buff.start &&
+      (buff.end === null || (buff.end + bufferTime) >= currentTimestamp) &&
+      (sourceID === null || sourceID === buff.sourceID));
   }
-  getBuffs(spellId, forTimestamp = null, bufferTime = 0, minimalActiveTime = 0) {
-    const currentTimestamp = forTimestamp || this.owner.currentTimestamp;
-    const nSpellId = Number(spellId);
-    return this.buffs.filter(buff => buff.ability.guid === nSpellId && (currentTimestamp - minimalActiveTime) >= buff.start && (buff.end === null || (buff.end + bufferTime) >= currentTimestamp));
-  }
-  getBuffUptime(buffAbilityId) {
+
+  /**
+   * @param {number} buffAbilityId - buff ID to check for
+   * @param {number} sourceID - source ID the buff must have come from, or any source if null.
+   * @returns {number} - Time (in ms) the specified buff has been active.
+   */
+  getBuffUptime(buffAbilityId, sourceID = null) {
     return this.buffs
-      .filter(buff => buff.ability.guid === buffAbilityId)
+      .filter(buff => (buff.ability.guid === buffAbilityId) && (sourceID === null || sourceID === buff.sourceID))
       .reduce((uptime, buff) => uptime + (buff.end !== null ? buff.end : this.owner.currentTimestamp) - buff.start, 0);
   }
-  getBuffTriggerCount(buffAbilityId) {
+
+  /**
+   * @param {number} buffAbilityId - buff ID to check for
+   * @param {number} sourceID - source ID the buff must have come from, or any source if null.
+   * @returns {number} - The number of times the specified buff has been applied (only applications count, not stack changes or refreshes).
+   */
+  getBuffTriggerCount(buffAbilityId, sourceID = null) {
     return this.buffs
-      .filter(buff => buff.ability.guid === buffAbilityId)
+      .filter(buff => (buff.ability.guid === buffAbilityId) && (sourceID === null || sourceID === buff.sourceID))
       .length;
   }
 }

--- a/src/Parser/Paladin/Holy/Modules/Talents/DevotionAura.js
+++ b/src/Parser/Paladin/Holy/Modules/Talents/DevotionAura.js
@@ -61,7 +61,8 @@ class DevotionAura extends Analyzer {
     if (spellId === FALLING_DAMAGE_ABILITY_ID) {
       return;
     }
-    const isAuraMasteryActive = this.combatants.selected.getBuffs(PROTECTION_OF_TYR_ID, event.timestamp).find(buff => buff.sourceID === this.owner.playerId);
+
+    const isAuraMasteryActive = this.combatants.selected.hasBuff(PROTECTION_OF_TYR_ID, event.timestamp, 0, 0, this.owner.playerId);
     if (!isAuraMasteryActive) {
       this.totalDamageTakenOutsideAuraMastery = this.totalDamageTakenOutsideAuraMastery + event.amount + (event.absorbed || 0);
     }

--- a/src/common/format.js
+++ b/src/common/format.js
@@ -39,6 +39,12 @@ export function formatDuration(duration) {
   const seconds = Math.floor(duration % 60);
   return `${Math.floor(duration / 60)}:${seconds < 10 ? `0${seconds}` : seconds}`;
 }
+
+/*
+ * Formats a duration in milliseconds to be a String expressed as minutes, seconds, and milliseconds.
+ * Formatting maintains ordering but is pretty ugly, mostly suitable for debug logging instead of user facing content.
+ * Ex. 317327 => 05:17.327
+ */
 export function formatMilliseconds(duration) {
   const sumSeconds = duration / 1000;
   const minutes = Math.floor(sumSeconds / 60);


### PR DESCRIPTION
Seemed silly that Entity didn't have support for sourceID filtering, so I added it.

`getBuffs` was only called in one place and it was obviously intended for sourceID filtering, so I removed it and replaced it in the once place it was used.