### PR TITLE
[Frost Mage] Fix Icy Veins

### DIFF
--- a/src/Parser/Mage/Frost/Modules/Cooldowns/IcyVeins.js
+++ b/src/Parser/Mage/Frost/Modules/Cooldowns/IcyVeins.js
@@ -6,7 +6,7 @@ import SpellUsable from 'Parser/Core/Modules/SpellUsable';
 
 const FROSTBOLT_CRIT_REDUCTION_MS = 500;
 
-class FrozenOrb extends Analyzer {
+class IcyVeins extends Analyzer {
 
 	static dependencies = {
 		combatants: Combatants,
@@ -30,4 +30,4 @@ class FrozenOrb extends Analyzer {
   }
 }
 
-export default FrozenOrb;
+export default IcyVeins;


### PR DESCRIPTION
Minor fix for the Icy Veins Cooldown Reduction file. Just noticed that the class name was never changed from FrozenOrb