### PR TITLE
[Mage] Misc Fixes/Tweaks

### DIFF
--- a/src/Parser/Mage/Fire/CombatLogParser.js
+++ b/src/Parser/Mage/Fire/CombatLogParser.js
@@ -4,6 +4,7 @@ import DamageDone from 'Parser/Core/Modules/DamageDone';
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
 import Abilities from './Modules/Features/Abilities';
 import CooldownThroughputTracker from './Modules/Features/CooldownThroughputTracker';
+import CancelledCasts from '../Shared/Modules/Features/CancelledCasts';
 
 import MirrorImage from '../Shared/Modules/Features/MirrorImage';
 import UnstableMagic from '../Shared/Modules/Features/UnstableMagic';
@@ -19,6 +20,7 @@ class CombatLogParser extends CoreCombatLogParser {
     abilities: Abilities,
     cooldownThroughputTracker: CooldownThroughputTracker,
     damageDone: [DamageDone, { showStatistic: true }],
+    cancelledCasts: CancelledCasts,
 
     // Talents
     mirrorImage: MirrorImage,

--- a/src/Parser/Mage/Fire/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Mage/Fire/Modules/Features/AlwaysBeCasting.js
@@ -3,9 +3,8 @@ import React from 'react';
 import CoreAlwaysBeCasting from 'Parser/Core/Modules/AlwaysBeCasting';
 
 import SPELLS from 'common/SPELLS';
-import Icon from 'common/Icon';
 import { formatPercentage } from 'common/format';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellLink from 'common/SpellLink';
 
 class AlwaysBeCasting extends CoreAlwaysBeCasting {
@@ -20,6 +19,9 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
     SPELLS.SCORCH.id,
     SPELLS.PHOENIXS_FLAMES.id,
     SPELLS.DRAGONS_BREATH.id,
+    SPELLS.SPELL_STEAL.id,
+    SPELLS.INVISIBILITY.id,
+    SPELLS.SLOW_FALL.id,
     // talents
     SPELLS.BLAST_WAVE_TALENT.id,
     SPELLS.MIRROR_IMAGE_TALENT.id,
@@ -42,19 +44,8 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
           .regular(recommended + 0.15).major(recommended + 0.2);
       });
   }
-  statistic() {
-    const deadTimePercentage = this.totalTimeWasted / this.owner.fightDuration;
 
-    return (
-      <StatisticBox
-        icon={<Icon icon="petbattle_health-down" alt="Dead time" />}
-        value={`${formatPercentage(deadTimePercentage)} %`}
-        label="Downtime"
-        tooltip="Downtime is available casting time not used for casting any spell. This can be caused by latency, cast interrupting, not casting anything (e.g. due to movement/being stunned), etc."
-      />
-    );
-  }
-
+  showStatistic = true;
   statisticOrder = STATISTIC_ORDER.CORE(1);
 }
 

--- a/src/Parser/Mage/Frost/Modules/Features/Abilities.js
+++ b/src/Parser/Mage/Frost/Modules/Features/Abilities.js
@@ -17,6 +17,7 @@ class Abilities extends CoreAbilities {
       spell: SPELLS.EBONBOLT,
       category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
       getCooldown: haste => 45 + (3 / (1+haste)), // 45 Second Cooldown with a 3 Second Cast time (Reduced by Haste). Temp until CastEfficiency gets a redo
+      recommendedCastEfficiency: 0.90,
     },
     {
       spell: SPELLS.FLURRY,
@@ -48,7 +49,8 @@ class Abilities extends CoreAbilities {
     {
       spell: SPELLS.COMET_STORM_TALENT,
       category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-      getCooldown: haste => null,
+      getCooldown: haste => 30,
+      recommendedCastEfficiency: 0.90,
 	    isActive: combatant => combatant.hasTalent(SPELLS.COMET_STORM_TALENT.id),
     },
     {
@@ -71,18 +73,19 @@ class Abilities extends CoreAbilities {
       spell: SPELLS.FROZEN_ORB,
       category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
       getCooldown: haste => 60,
+      recommendedCastEfficiency: 0.90,
     },
     {
       spell: SPELLS.ICY_VEINS,
       category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
       getCooldown: haste => 180,
-      noSuggestion: true,
-      noCanBeImproved: true,
+      recommendedCastEfficiency: 0.90,
     },
     {
       spell: SPELLS.MIRROR_IMAGE_TALENT,
       category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
       getCooldown: haste => 120,
+      recommendedCastEfficiency: 0.90,
       isActive: combatant => combatant.hasTalent(SPELLS.MIRROR_IMAGE_TALENT.id),
     },
     {
@@ -90,6 +93,7 @@ class Abilities extends CoreAbilities {
       category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
       getCooldown: haste => 40,
       charges: 2,
+      recommendedCastEfficiency: 0.90,
       isActive: combatant => combatant.hasTalent(SPELLS.RUNE_OF_POWER_TALENT.id),
     },
 

--- a/src/Parser/Mage/Frost/Modules/Features/Abilities.js
+++ b/src/Parser/Mage/Frost/Modules/Features/Abilities.js
@@ -25,7 +25,7 @@ class Abilities extends CoreAbilities {
       getCooldown: haste => null,
     },
     {
-      spell: SPELLS.ICE_LANCE_CAST,
+      spell: SPELLS.ICE_LANCE,
       category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
       getCooldown: haste => null,
     },

--- a/src/Parser/Mage/Frost/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Mage/Frost/Modules/Features/AlwaysBeCasting.js
@@ -10,7 +10,7 @@ import SpellLink from 'common/SpellLink';
 class AlwaysBeCasting extends CoreAlwaysBeCasting {
   static ABILITIES_ON_GCD = [
     SPELLS.FROSTBOLT.id,
-    SPELLS.ICE_LANCE_CAST.id,
+    SPELLS.ICE_LANCE.id,
     SPELLS.FROZEN_ORB.id,
     SPELLS.FROST_NOVA.id,
     SPELLS.BLINK.id,
@@ -40,7 +40,7 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
 
     when(deadTimePercentage).isGreaterThan(0.2)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span>Your downtime can be improved. Try to Always Be Casting (ABC), try to reduce the delay between casting spells. Even if you have to move, try casting instants, even unbuffed <SpellLink id={SPELLS.ICE_LANCE_CAST.id} /> spam is better than nothing.</span>)
+        return suggest(<span>Your downtime can be improved. Try to Always Be Casting (ABC), try to reduce the delay between casting spells. Even if you have to move, try casting instants, even unbuffed <SpellLink id={SPELLS.ICE_LANCE.id} /> spam is better than nothing.</span>)
           .icon('spell_mage_altertime')
           .actual(`${formatPercentage(actual)}% downtime`)
           .recommended(`<${formatPercentage(recommended)}% is recommended`)

--- a/src/Parser/Mage/Frost/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Mage/Frost/Modules/Features/AlwaysBeCasting.js
@@ -20,6 +20,10 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
     SPELLS.ICE_BARRIER.id,
     SPELLS.CONE_OF_COLD.id,
 	  SPELLS.EBONBOLT.id,
+    SPELLS.SPELL_STEAL.id,
+    SPELLS.INVISIBILITY.id,
+    SPELLS.SUMMON_WATER_ELEMENTAL.id,
+    SPELLS.SLOW_FALL.id,
     // talents
     SPELLS.RAY_OF_FROST_TALENT.id,
     SPELLS.MIRROR_IMAGE_TALENT.id,

--- a/src/Parser/Mage/Frost/Modules/Features/IceLance.js
+++ b/src/Parser/Mage/Frost/Modules/Features/IceLance.js
@@ -31,7 +31,7 @@ class IceLance extends Analyzer {
 
 	on_byPlayer_cast(event) {
 		const spellId = event.ability.guid;
-		if (spellId !== SPELLS.ICE_LANCE_CAST.id) {
+		if (spellId !== SPELLS.ICE_LANCE.id) {
 			return;
 		}
 		if (event.targetID) {
@@ -56,11 +56,11 @@ class IceLance extends Analyzer {
 	}
 
 	suggestions(when) {
-		const nonShatteredPercent = (this.nonShatteredCasts / this.abilityTracker.getAbility(SPELLS.ICE_LANCE_CAST.id).casts);
+		const nonShatteredPercent = (this.nonShatteredCasts / this.abilityTracker.getAbility(SPELLS.ICE_LANCE.id).casts);
 		when(nonShatteredPercent).isGreaterThan(0.1)
 			.addSuggestion((suggest, actual, recommended) => {
-				return suggest(<span>You cast <SpellLink id={SPELLS.ICE_LANCE_CAST.id} /> {this.nonShatteredCasts} times ({formatPercentage(nonShatteredPercent)}%) without <SpellLink id={SPELLS.SHATTER.id} />. Make sure that you are only casting Ice Lance when the target has <SpellLink id={SPELLS.WINTERS_CHILL.id} /> (or other Shatter effects), if you have a <SpellLink id={SPELLS.FINGERS_OF_FROST.id} /> proc, or if you are moving and you cant cast anything else.</span>)
-					.icon(SPELLS.ICE_LANCE_CAST.icon)
+				return suggest(<span>You cast <SpellLink id={SPELLS.ICE_LANCE.id} /> {this.nonShatteredCasts} times ({formatPercentage(nonShatteredPercent)}%) without <SpellLink id={SPELLS.SHATTER.id} />. Make sure that you are only casting Ice Lance when the target has <SpellLink id={SPELLS.WINTERS_CHILL.id} /> (or other Shatter effects), if you have a <SpellLink id={SPELLS.FINGERS_OF_FROST.id} /> proc, or if you are moving and you cant cast anything else.</span>)
+					.icon(SPELLS.ICE_LANCE.icon)
 					.actual(`${formatPercentage(nonShatteredPercent)}% missed`)
 					.recommended(`<${formatPercentage(recommended)}% is recommended`)
 					.regular(0.1).major(0.2);
@@ -68,10 +68,10 @@ class IceLance extends Analyzer {
 	}
 
 	statistic() {
-		const shattered = 1 - (this.nonShatteredCasts / this.abilityTracker.getAbility(SPELLS.ICE_LANCE_CAST.id).casts);
+		const shattered = 1 - (this.nonShatteredCasts / this.abilityTracker.getAbility(SPELLS.ICE_LANCE.id).casts);
 		return(
 			<StatisticBox
-				icon={<SpellIcon id={SPELLS.ICE_LANCE_CAST.id} />}
+				icon={<SpellIcon id={SPELLS.ICE_LANCE.id} />}
 				value={`${formatPercentage(shattered, 0)} %`}
 				label='Ice Lance Shattered'
 				tooltip={'This is the percentage of Ice Lance casts that were shattered. You should only be casting Ice Lance without Shatter if you are moving and you cant use anything else.'}

--- a/src/Parser/Mage/Frost/Modules/Features/SplittingIce.js
+++ b/src/Parser/Mage/Frost/Modules/Features/SplittingIce.js
@@ -32,7 +32,7 @@ class SplittingIce extends Analyzer {
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
     // we check Frostbolt cast even though it doesn't split because it can launch overcapped icicles.
-    if(spellId !== SPELLS.ICE_LANCE_CAST.id && spellId !== SPELLS.FROSTBOLT.id && spellId !== SPELLS.GLACIAL_SPIKE_TALENT.id) {
+    if(spellId !== SPELLS.ICE_LANCE.id && spellId !== SPELLS.FROSTBOLT.id && spellId !== SPELLS.GLACIAL_SPIKE_TALENT.id) {
       return;
     }
 

--- a/src/Parser/Mage/Frost/Modules/Features/WintersChill.js
+++ b/src/Parser/Mage/Frost/Modules/Features/WintersChill.js
@@ -97,8 +97,8 @@ class WintersChillTracker extends Analyzer {
     const missedIceLancesPerMinute = this.missedIceLanceCasts / (this.owner.fightDuration / 1000 / 60);
     when(missedIceLancesPerMinute).isGreaterThan(0)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span> You failed to Ice Lance into {this.missedIceLanceCasts} <SpellLink id={SPELLS.WINTERS_CHILL.id}/> ({missedIceLancesPerMinute.toFixed(1)} missed per minute).  Make sure you cast <SpellLink id={SPELLS.ICE_LANCE_CAST.id}/> after each <SpellLink id={SPELLS.FLURRY.id}/> to benefit from <SpellLink id={SPELLS.SHATTER.id}/>.</span>)
-          .icon(SPELLS.ICE_LANCE_CAST.icon)
+        return suggest(<span> You failed to Ice Lance into {this.missedIceLanceCasts} <SpellLink id={SPELLS.WINTERS_CHILL.id}/> ({missedIceLancesPerMinute.toFixed(1)} missed per minute).  Make sure you cast <SpellLink id={SPELLS.ICE_LANCE.id}/> after each <SpellLink id={SPELLS.FLURRY.id}/> to benefit from <SpellLink id={SPELLS.SHATTER.id}/>.</span>)
+          .icon(SPELLS.ICE_LANCE.icon)
           .actual(`${formatNumber(this.missedIceLanceCasts)} Winter's Chill not shattered with Ice Lance`)
           .recommended(`${formatNumber(recommended)} is recommended`)
           .regular(0.5).major(1);
@@ -136,7 +136,7 @@ class WintersChillTracker extends Analyzer {
         value={(
           <span>
             <SpellIcon
-              id={SPELLS.ICE_LANCE_CAST.id}
+              id={SPELLS.ICE_LANCE.id}
               style={{
                 height: '1.2em',
                 marginBottom: '.15em',

--- a/src/Parser/Mage/Frost/Modules/Items/MagtheridonsBanishedBracers.js
+++ b/src/Parser/Mage/Frost/Modules/Items/MagtheridonsBanishedBracers.js
@@ -20,7 +20,7 @@ class MagtheridonsBanishedBracers extends Analyzer {
   }
 
   on_byPlayer_cast(event) {
-    if (event.ability.guid !== SPELLS.ICE_LANCE_CAST.id) {
+    if (event.ability.guid !== SPELLS.ICE_LANCE.id) {
       return;
     }
     const buff = this.combatants.selected.getBuff(SPELLS.MAGTHERIDONS_MIGHT_BUFF.id);

--- a/src/common/SPELLS/MAGE.js
+++ b/src/common/SPELLS/MAGE.js
@@ -88,7 +88,7 @@ export default {
     name: 'Frostbolt',
     icon: 'spell_frost_frostbolt02',
   },
-  ICE_LANCE_CAST: {
+  ICE_LANCE: {
     id: 30455,
     name: 'Ice Lance',
     icon: 'spell_frost_frostblast',


### PR DESCRIPTION
Misc Fixes and Tweaks for Frost and Fire Mage.

- Removed the Non Standard Icon/StatisticBox in the Fire AlwaysBeCasting Module
- Upped Frost Abilities to 90% Recommended Efficiency
- Removed noSuggestion/noCanBeImproved from Icy Veins
- Added some seldom used abilities to Fire/Frost AlwaysBeCasting, for those edge case fights where they are needed
- Added CancelledCasts to Fire
- Added missing cooldown timer for Comet Storm
- Renamed the SPELLS entry for ICE_LANCE_CAST to match all the other spells (where the base ICE_LANCE is the cast ID and ICE_LANCE_DAMAGE is the damage ID)