### PR TITLE
 [core] Fixed a bug where a crash could sometimes occur when player switches items during encounter

### DIFF
--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -378,6 +378,8 @@ class StatTracker extends Analyzer {
         itemDetails = this.combatants.selected.getItem(buffObj.itemId);
         if (!itemDetails) {
           console.error('Failed to retrieve item information for item with ID:', buffObj.itemId);
+          console.warn('Unable to handle buff, making no stat change...');
+          return 0;
         }
       }
       return statVal(selectedCombatant, itemDetails);

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -377,8 +377,8 @@ class StatTracker extends Analyzer {
       if (buffObj.itemId) {
         itemDetails = this.combatants.selected.getItem(buffObj.itemId);
         if (!itemDetails) {
-          console.error('Failed to retrieve item information for item with ID:', buffObj.itemId);
-          console.warn('Unable to handle buff, making no stat change...');
+          console.warn('Failed to retrieve item information for item with ID:', buffObj.itemId,
+            ' ...unable to handle stats buff, making no stat change.');
           return 0;
         }
       }


### PR DESCRIPTION
Analyzer was crashing on StatTracker if stat buff was detected, but its associated item didn't exist. This could happen if the player switches to the trinket that makes the buff mid encounter, which can easily happen during M+.

There's no good way to fully handle this case because we still don't get the itemlevel of the trinket in question, but I can at least make this not crash by just ignoring the buff entirely.