### PR TITLE
Sub rogue, Death from Above usage

### DIFF
--- a/src/Parser/Rogue/Subtlety/CombatLogParser.js
+++ b/src/Parser/Rogue/Subtlety/CombatLogParser.js
@@ -14,6 +14,7 @@ import DanceDamageTracker from './Modules/RogueCore/DanceDamageTracker';
 import DarkShadowNightblade from './Modules/Talents/DarkShadow/DarkShadowNightblade';
 import DarkShadowContribution from "./Modules/Talents/DarkShadow/DarkShadowContribution";
 import DarkShadowEvis from "./Modules/Talents/DarkShadow/DarkShadowEvis";
+import DeathFormAbove from "./Modules/Talents/DFA/DeathFormAbove";
 import NightbladeDuringSymbols from './Modules/BaseRotation/NightbladeDuringSymbols';
 import CastsInShadowDance from './Modules/BaseRotation/CastsInShadowDance';
 
@@ -38,6 +39,7 @@ class CombatLogParser extends CoreCombatLogParser {
     //Casts
     nightbladeDuringSymbols: NightbladeDuringSymbols,
     castsInShadowDance: CastsInShadowDance,
+    deathFormAbove: DeathFormAbove,
     
     //Talents
     darkShadowContribution: DarkShadowContribution,

--- a/src/Parser/Rogue/Subtlety/Modules/Talents/DFA/DeathFormAbove.js
+++ b/src/Parser/Rogue/Subtlety/Modules/Talents/DFA/DeathFormAbove.js
@@ -55,7 +55,9 @@ class DeathFormAbove extends Analyzer {
         return suggest(<Wrapper>          
           Always use <SpellLink id={SPELLS.DEATH_FROM_ABOVE_TALENT.id} /> together with <SpellLink id={SPELLS.SYMBOLS_OF_DEATH.id} /> and <SpellLink id={SPELLS.SHADOW_DANCE.id} />. 
           <br /> 
-          Unless you hit multiple targets with your initial <SpellLink id={SPELLS.DEATH_FROM_ABOVE_TALENT.id} /> hit, you should use <SpellLink id={SPELLS.SHADOW_DANCE.id} /> when you are in the air. <SpellLink id={SPELLS.SYMBOLS_OF_DEATH.id} /> is usually used before <SpellLink id={SPELLS.DEATH_FROM_ABOVE_TALENT.id} />, but is some cases can also be used in the air. 
+          <SpellLink id={SPELLS.SHADOW_DANCE.id} /> is used when you are in the air, so that you do not loose uptime to the Death from Above animation (achieved by spamming the Shadow Dance button in the air).
+          <br /> 
+          <SpellLink id={SPELLS.SYMBOLS_OF_DEATH.id} /> is used before <SpellLink id={SPELLS.DEATH_FROM_ABOVE_TALENT.id} />. 
           </Wrapper>)
           .icon(SPELLS.DEATH_FROM_ABOVE_TALENT.icon)
           .actual(`${actual} Death from Above combos failed.`)

--- a/src/Parser/Rogue/Subtlety/Modules/Talents/DFA/DeathFormAbove.js
+++ b/src/Parser/Rogue/Subtlety/Modules/Talents/DFA/DeathFormAbove.js
@@ -12,7 +12,6 @@ class DeathFormAbove extends Analyzer {
     combatants: Combatants,
   };
 
-  hasDarkShadow = false;
   dfaTimestamp = 0;
   dfaMaxWindow = 3000;
 

--- a/src/Parser/Rogue/Subtlety/Modules/Talents/DFA/DeathFormAbove.js
+++ b/src/Parser/Rogue/Subtlety/Modules/Talents/DFA/DeathFormAbove.js
@@ -43,7 +43,7 @@ class DeathFormAbove extends Analyzer {
 
     //If the Dfa Eviscerate hits without Symbols or Dark Shadow DFA - we have a problem!
     if (!this.combatants.selected.hasBuff(SPELLS.SYMBOLS_OF_DEATH.id) 
-    || ( this.hasDarkShadow && !this.combatants.selected.hasBuff(SPELLS.SYMBOLS_OF_DEATH.id) )) {
+    || ( this.hasDarkShadow && !this.combatants.selected.hasBuff(SPELLS.SHADOW_DANCE_BUFF.id) )) {
       this.failedCombos += 1;    
     }   
   }
@@ -53,9 +53,10 @@ class DeathFormAbove extends Analyzer {
     when(this.failedCombos).isGreaterThan(0)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<Wrapper>          
-          <SpellLink id={SPELLS.DEATH_FROM_ABOVE_TALENT.id} />. <br /> 
-           while in <SpellLink id={SPELLS.DEATH_FROM_ABOVE_TALENT.id} /> 
-           or starting <SpellLink id={SPELLS.DEATH_FROM_ABOVE_TALENT.id} />  </Wrapper>)
+          Always use <SpellLink id={SPELLS.DEATH_FROM_ABOVE_TALENT.id} /> together with <SpellLink id={SPELLS.SYMBOLS_OF_DEATH.id} /> and <SpellLink id={SPELLS.SHADOW_DANCE.id} />. 
+          <br /> 
+          Unless you hit multiple targets with your initial <SpellLink id={SPELLS.DEATH_FROM_ABOVE_TALENT.id} /> hit, you should use <SpellLink id={SPELLS.SHADOW_DANCE.id} /> when you are in the air. <SpellLink id={SPELLS.SYMBOLS_OF_DEATH.id} /> is usually used before <SpellLink id={SPELLS.DEATH_FROM_ABOVE_TALENT.id} />, but is some cases can also be used in the air. 
+          </Wrapper>)
           .icon(SPELLS.DEATH_FROM_ABOVE_TALENT.icon)
           .actual(`${actual} Death from Above combos failed.`)
           .recommended(`${recommended} is recommended`)

--- a/src/Parser/Rogue/Subtlety/Modules/Talents/DFA/DeathFormAbove.js
+++ b/src/Parser/Rogue/Subtlety/Modules/Talents/DFA/DeathFormAbove.js
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import Combatants from "Parser/Core/Modules/Combatants";
+import Wrapper from 'common/Wrapper';
+import SpellLink from 'common/SpellLink'; 
+
+//DfA needs to be used with both Symbols of Death and Shadow Dance (Dark Shadow).
+class DeathFormAbove extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  hasDarkShadow = false;
+  dfaTimestamp = 0;
+  dfaMaxWindow = 3000;
+
+  failedCombos = 0;
+  
+  on_initialized() {
+    this.active = this.owner.modules.combatants.selected.hasTalent(SPELLS.DEATH_FROM_ABOVE_TALENT.id);
+    this.hasDarkShadow = this.active = this.owner.modules.combatants.selected.hasTalent(SPELLS.DARK_SHADOW_TALENT.id);
+  }
+  
+  
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+
+    //Find DfA, and save the timestamp. 
+    if (spellId === SPELLS.DEATH_FROM_ABOVE_TALENT.id) {
+        this.dfaTimestamp = event.timestamp;
+    }
+  }
+
+  on_byPlayer_damage(event) {
+    //Skip non dfa events
+    if(event.timestamp > this.dfaTimestamp + this.dfaMaxWindow) return;
+
+    //Find Eviscerate inside DFA
+    const spellId = event.ability.guid;
+    if(spellId !== SPELLS.EVISCERATE.id) return;
+
+    //If the Dfa Eviscerate hits without Symbols or Dark Shadow DFA - we have a problem!
+    if (!this.combatants.selected.hasBuff(SPELLS.SYMBOLS_OF_DEATH.id) 
+    || ( this.hasDarkShadow && !this.combatants.selected.hasBuff(SPELLS.SYMBOLS_OF_DEATH.id) )) {
+      this.failedCombos += 1;    
+    }   
+  }
+
+  
+  suggestions(when) {
+    when(this.failedCombos).isGreaterThan(0)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<Wrapper>          
+          <SpellLink id={SPELLS.DEATH_FROM_ABOVE_TALENT.id} />. <br /> 
+           while in <SpellLink id={SPELLS.DEATH_FROM_ABOVE_TALENT.id} /> 
+           or starting <SpellLink id={SPELLS.DEATH_FROM_ABOVE_TALENT.id} />  </Wrapper>)
+          .icon(SPELLS.DEATH_FROM_ABOVE_TALENT.icon)
+          .actual(`${actual} Death from Above combos failed.`)
+          .recommended(`${recommended} is recommended`)
+          //Core rotation, should never happen.
+          .major(0.1);
+      });
+    }
+}
+
+export default DeathFormAbove;

--- a/src/Parser/Rogue/Subtlety/Modules/Talents/DFA/DeathFormAbove.js
+++ b/src/Parser/Rogue/Subtlety/Modules/Talents/DFA/DeathFormAbove.js
@@ -19,8 +19,9 @@ class DeathFormAbove extends Analyzer {
   failedCombos = 0;
   
   on_initialized() {
-    this.active = this.owner.modules.combatants.selected.hasTalent(SPELLS.DEATH_FROM_ABOVE_TALENT.id);
-    this.hasDarkShadow = this.active = this.owner.modules.combatants.selected.hasTalent(SPELLS.DARK_SHADOW_TALENT.id);
+    //Everyone plays Dark Shadow, so I'm not supporting non-dark shadow and just disabling this.
+    this.active = this.combatants.selected.hasTalent(SPELLS.DEATH_FROM_ABOVE_TALENT.id)
+      && this.combatants.selected.hasTalent(SPELLS.DARK_SHADOW_TALENT.id);
   }
   
   
@@ -35,15 +36,15 @@ class DeathFormAbove extends Analyzer {
 
   on_byPlayer_damage(event) {
     //Skip non dfa events
-    if(event.timestamp > this.dfaTimestamp + this.dfaMaxWindow) return;
+    if(event.timestamp > this.dfaTimestamp + this.dfaMaxWindow || event.timestamp < this.dfaTimestamp) return;
 
     //Find Eviscerate inside DFA
     const spellId = event.ability.guid;
     if(spellId !== SPELLS.EVISCERATE.id) return;
 
-    //If the Dfa Eviscerate hits without Symbols or Dark Shadow DFA - we have a problem!
+    //If the Dfa Eviscerate hits without Symbols or Dark Shadow Dance - we have a problem!
     if (!this.combatants.selected.hasBuff(SPELLS.SYMBOLS_OF_DEATH.id) 
-    || ( this.hasDarkShadow && !this.combatants.selected.hasBuff(SPELLS.SHADOW_DANCE_BUFF.id) )) {
+    || !this.combatants.selected.hasBuff(SPELLS.SHADOW_DANCE_BUFF.id)) {
       this.failedCombos += 1;    
     }   
   }

--- a/src/common/SPELLS/ROGUE.js
+++ b/src/common/SPELLS/ROGUE.js
@@ -171,14 +171,9 @@ export default {
     name: 'Shadow Satyr\'s Walk',
     icon: 'inv_boots_mail_dungeonmail_c_04',
   },
-  // Buffs
-  SHADOW_DANCE_BUFF: {
-    id: 185422,
-    name: 'Shadow Dance',
-    icon: 'ability_rogue_shadowdance',
-  }, 
-  // Sets  
 
+  // Sets
+  
   //Tooltips for T20 are swapped on Wowhead.
   //Names of variables correctly reflect in-game.  
   SUB_ROGUE_T20_2SET_BONUS: {

--- a/src/common/SPELLS/ROGUE.js
+++ b/src/common/SPELLS/ROGUE.js
@@ -113,6 +113,11 @@ export default {
     name: 'Shadow Dance',
     icon: 'ability_rogue_shadowdance',
   },
+  SHADOW_DANCE_BUFF: {
+    id: 185422,
+    name: 'Shadow Dance',
+    icon: 'ability_rogue_shadowdance',
+  },
   SYMBOLS_OF_DEATH: {
     id: 212283,
     name: 'Symbols of Death',


### PR DESCRIPTION
Small PR that tracks correct DfA usage. 
This is currently core for Subtlety and the only viable build.
Makes sure that the DfA eviscerate hit is buffed by both Dark Shadow and Symbols of Death.