### PR TITLE
[Sub Rogue] Specter usage

### DIFF
--- a/src/Parser/Rogue/Subtlety/CombatLogParser.js
+++ b/src/Parser/Rogue/Subtlety/CombatLogParser.js
@@ -19,6 +19,7 @@ import NightbladeDuringSymbols from './Modules/BaseRotation/NightbladeDuringSymb
 import CastsInShadowDance from './Modules/BaseRotation/CastsInShadowDance';
 import MantleDamageTracker from './Modules/Legendaries/MantleDamageTracker';
 import DeathFromAboveMantle from './Modules/Talents/DFA/DeathFromAboveMantle';
+import DarkShadowSpecterOfBetrayal from './Modules/Talents/DarkShadow/DarkShadowSpecterOfBetrayal';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -38,6 +39,9 @@ class CombatLogParser extends CoreCombatLogParser {
     symbolsDamageTracker: SymbolsDamageTracker,
     danceDamageTracker: DanceDamageTracker,
     mantleDamageTracker: MantleDamageTracker,
+
+    //Items
+    darkShadowSpecterOfBetrayal: DarkShadowSpecterOfBetrayal,
 
     //Casts
     nightbladeDuringSymbols: NightbladeDuringSymbols,

--- a/src/Parser/Rogue/Subtlety/Modules/Talents/DarkShadow/DarkShadowSpecterOfBetrayal.js
+++ b/src/Parser/Rogue/Subtlety/Modules/Talents/DarkShadow/DarkShadowSpecterOfBetrayal.js
@@ -5,9 +5,9 @@ import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';
 import ItemLink from 'common/ItemLink';
 import ITEMS from 'common/ITEMS';
+import { formatPercentage } from 'common/format';
 
 import DarkShadow from './DarkShadow';
-import { formatPercentage } from './../../../../../../common/format';
 
 class DarkShadowSpecterOfBetrayal extends DarkShadow {
   

--- a/src/Parser/Rogue/Subtlety/Modules/Talents/DarkShadow/DarkShadowSpecterOfBetrayal.js
+++ b/src/Parser/Rogue/Subtlety/Modules/Talents/DarkShadow/DarkShadowSpecterOfBetrayal.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink'; 
+import Wrapper from 'common/Wrapper';
+import ItemLink from 'common/ItemLink';
+import ITEMS from 'common/ITEMS';
+
+import DarkShadow from './DarkShadow';
+import { formatPercentage } from './../../../../../../common/format';
+
+class DarkShadowSpecterOfBetrayal extends DarkShadow {
+  
+  suggestions(when) {
+    const totalSpecterCastsInShadowDance  = this.danceDamageTracker.getAbility(SPELLS.SUMMON_DREAD_REFLECTION.id).casts;
+    const totalSpecterCast  = this.damageTracker.getAbility(SPELLS.SUMMON_DREAD_REFLECTION.id).casts;
+    const castsInDanceShare = totalSpecterCastsInShadowDance / totalSpecterCast;
+    when(castsInDanceShare).isLessThan(0.95)
+    .addSuggestion((suggest, actual, recommended) => {
+      return suggest(<Wrapper>Use <ItemLink id={ITEMS.SPECTER_OF_BETRAYAL.id} /> during <SpellLink id={SPELLS.SHADOW_DANCE.id} /> when you are using <SpellLink id={SPELLS.DARK_SHADOW_TALENT.id} />. </Wrapper>)
+        .icon(ITEMS.SPECTER_OF_BETRAYAL.icon)
+        .actual(`You used Specter of Betrayal in Shadow Dance ${formatPercentage(actual)}% of the time`)
+        .recommended(`>${formatPercentage(recommended)}% is recommended`)
+        .regular(0.9)
+        .major(0.85);
+    });
+  }
+
+}
+
+export default DarkShadowSpecterOfBetrayal;

--- a/src/Parser/Rogue/Subtlety/Modules/Talents/DarkShadow/DarkShadowSpecterOfBetrayal.js
+++ b/src/Parser/Rogue/Subtlety/Modules/Talents/DarkShadow/DarkShadowSpecterOfBetrayal.js
@@ -15,14 +15,14 @@ class DarkShadowSpecterOfBetrayal extends DarkShadow {
     const totalSpecterCastsInShadowDance  = this.danceDamageTracker.getAbility(SPELLS.SUMMON_DREAD_REFLECTION.id).casts;
     const totalSpecterCast  = this.damageTracker.getAbility(SPELLS.SUMMON_DREAD_REFLECTION.id).casts;
     const castsInDanceShare = totalSpecterCastsInShadowDance / totalSpecterCast;
-    when(castsInDanceShare).isLessThan(0.95)
+    when(castsInDanceShare).isLessThan(0.90)
     .addSuggestion((suggest, actual, recommended) => {
       return suggest(<Wrapper>Use <ItemLink id={ITEMS.SPECTER_OF_BETRAYAL.id} /> during <SpellLink id={SPELLS.SHADOW_DANCE.id} /> when you are using <SpellLink id={SPELLS.DARK_SHADOW_TALENT.id} />. </Wrapper>)
         .icon(ITEMS.SPECTER_OF_BETRAYAL.icon)
         .actual(`You used Specter of Betrayal in Shadow Dance ${formatPercentage(actual)}% of the time`)
         .recommended(`>${formatPercentage(recommended)}% is recommended`)
-        .regular(0.9)
-        .major(0.85);
+        .regular(0.80);
+        //Its around 1% dps loss when pressing it on cooldown, so never Major.
     });
   }
 


### PR DESCRIPTION
Specter  remains the BIS trinket for Antorus on ST fights.
Checking that it is used together with Dance to benefit from 30% Dark Shadow buff.