### PR TITLE
PlayerSelector Loading Spinner Styling Consistency

### DIFF
--- a/src/Main/PlayerSelecter.js
+++ b/src/Main/PlayerSelecter.js
@@ -32,10 +32,12 @@ class PlayerSelecter extends Component {
 
     if (!combatants) {
       return (
-        <div>
-          <h1>Fetching players...</h1>
+        <div className="container">
+          <div>
+            <h1>Fetching players...</h1>
 
-          <div className="spinner" />
+            <div className="spinner" />
+          </div>
         </div>
       );
     }


### PR DESCRIPTION
Wrapping the loading spinner inside of a `container` div makes the text location more visible to the user and more consistent with the headers of the player and fight selection pages.

## Original
Notice the text sits off to the left of the screen and is not very visible to the user.
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/12898988/33527934-f225404c-d826-11e7-8db7-6d67345b1506.png">


## With Changes
Now the text is aligned with the headers of both the Player Selection and Fight Selection pages.
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/12898988/33527892-4a2d4ea2-d826-11e7-8fca-6dd97d970ba6.png">

## For Context
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/12898988/33527957-675884a0-d827-11e7-88c6-1e27873d7cd6.png">
