### PR TITLE
[Bugfix] [Destruction] Fixed the Lord of Flames bug.

### DIFF
--- a/src/Parser/Warlock/Destruction/Modules/Features/UnusedLordOfFlames.js
+++ b/src/Parser/Warlock/Destruction/Modules/Features/UnusedLordOfFlames.js
@@ -18,8 +18,8 @@ class UnusedLordOfFlames extends Analyzer {
   };
 
   suggestions(when) {
-    const maxLordOfFlamesCasts = calculateMaxCasts(LORD_OF_FLAMES_COOLDOWN, this.owner.fightDuration);
-    const infernalCasts = this.abilityTracker.getAbility(SPELLS.SUMMON_INFERNAL_UNTALENTED.id).casts;
+    const maxLordOfFlamesCasts = Math.ceil(calculateMaxCasts(LORD_OF_FLAMES_COOLDOWN, this.owner.fightDuration));
+    const infernalCasts = this.abilityTracker.getAbility(SPELLS.SUMMON_INFERNAL_UNTALENTED.id).casts || 0;
     const percentage = infernalCasts / maxLordOfFlamesCasts;
     when(percentage).isLessThan(1)
       .addSuggestion((suggest, actual, recommended) => {


### PR DESCRIPTION
Self-explanatory, probably due to the rework, getAbility().casts was returning undefined when it wasn't cast.