### PR TITLE
[core] Core items update (Q through Z) 

### DIFF
--- a/src/Parser/Core/Modules/Items/SeaStarOfTheDepthmother.js
+++ b/src/Parser/Core/Modules/Items/SeaStarOfTheDepthmother.js
@@ -6,6 +6,10 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 
 const debug = false;
 
+/*
+ * Sea Star of the Depth Mother -
+ * Equip: Your multi-target healing spell has a chance to grant you Ocean's Embrace, healing your nearest injured ally within 15 yds for 29716 every 0.25 sec for 8 sec.
+ */
 class SeaStarOfTheDepthmother extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Core/Modules/Items/SeepingScourgewing.js
+++ b/src/Parser/Core/Modules/Items/SeepingScourgewing.js
@@ -1,17 +1,22 @@
 import React from 'react';
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
-import { formatNumber } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
+/*
+ * Seeping Scourgewing -
+ * Equip: Your melee attacks have a chance to deal 329773 Shadow damage to the target. If there are no other enemies within 8 yds of them, this deals an additional 52253 to 57752 damage.
+ */
 class SeepingScourgewing extends Analyzer {
 	static dependencies = {
 		combatants: Combatants,
 	};
 
-	bonusDmg = 0;
+	damage = 0;
+	totalHits = 0;
+	isolatedHits = 0;
 
 	on_initialized() {
 		this.active = this.combatants.selected.hasTrinket(ITEMS.SEEPING_SCOURGEWING.id);
@@ -19,8 +24,12 @@ class SeepingScourgewing extends Analyzer {
 
 	on_byPlayer_damage(event) {
 		const spellId = event.ability.guid;
-		if (spellId === SPELLS.SHADOW_STRIKE.id || spellId === SPELLS.ISOLATED_STRIKE.id){
-			this.bonusDmg += event.amount;
+		if (spellId === SPELLS.SHADOW_STRIKE.id) {
+			this.damage += event.amount + (event.absorbed || 0);
+			this.totalHits += 1; // When target is isolated, it procs both Shadow Strike AND Isolated Strike
+		} else if (spellId === SPELLS.ISOLATED_STRIKE.id) {
+			this.damage += event.amount + (event.absorbed || 0);
+			this.isolatedHits += 1;
 		}
 	}
 
@@ -28,11 +37,8 @@ class SeepingScourgewing extends Analyzer {
 		return {
 			item: ITEMS.SEEPING_SCOURGEWING,
 			result: (
-				<dfn data-tip={`The effective damage contributed by Seeping Scourgewing.<br/>
-					Damage: ${this.owner.formatItemDamageDone(this.bonusDmg)}<br/>
-					Total Damage: ${formatNumber(this.bonusDmg)}`}
-				>
-					{this.owner.formatItemDamageDone(this.bonusDmg)}
+				<dfn data-tip={`Procced <b>${this.totalHits}</b> times, of which <b>${this.isolatedHits}</b> were on an isolated target.`}>
+					{this.owner.formatItemDamageDone(this.damage)}
 				</dfn>
 			),
 		};

--- a/src/Parser/Core/Modules/Items/SephuzsSecret.js
+++ b/src/Parser/Core/Modules/Items/SephuzsSecret.js
@@ -10,6 +10,10 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 const PASSIVE_HASTE = 0.02;
 const ACTIVE_HASTE = 0.25;
 
+/*
+ * Sephuz's Secret -
+ * Equip: Gain 10% increased movement speed and 2% Haste. Successfully applying a loss of control effect to an enemy, interrupting an enemy, or dispelling any target increases this effect to 70% increased movement speed and 25% Haste for 10 sec. This increase may occur once every 30 sec.
+ */
 class SephuzsSecret extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Core/Modules/Items/SpecterOfBetrayal.js
+++ b/src/Parser/Core/Modules/Items/SpecterOfBetrayal.js
@@ -1,50 +1,35 @@
-import React from 'react';
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
-import { formatNumber } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
+/*
+ * Scepter of Betrayal -
+ * Use: Create a Dread Reflection at your location for 1 min and cause each of your Dread Reflections to unleash a torrent of magic that deals (111484 * 4) Shadow damage over 3 sec, split evenly among nearby enemies. (45 Sec Cooldown)
+ */
 class SpecterOfBetrayal extends Analyzer {
   static dependencies = {
     combatants: Combatants,
   };
-  damageIncreased = 0;
-  totalCast = 0;
+
+  damage = 0;
 
   on_initialized() {
     this.active = this.combatants.selected.hasTrinket(ITEMS.SPECTER_OF_BETRAYAL.id);
   }
 
-  on_byPlayer_cast(event) {
-    const spellId = event.ability.guid;
-    if (spellId === SPELLS.SUMMON_DREAD_REFLECTION.id) {
-      this.totalCast += 1;
-    }
-  }
-
   on_byPlayer_damage(event) {
     const spellId = event.ability.guid;
-
     if (spellId === SPELLS.DREAD_TORRENT.id) {
-      this.damageIncreased += event.amount;
+      this.damage += event.amount + (event.absorbed || 0);
     }
   }
 
   item() {
     return {
       item: ITEMS.SPECTER_OF_BETRAYAL,
-      result: (
-        <dfn
-          data-tip={`The effective damage contributed by Specter of Betrayal.<br/>
-            Casts: ${this.totalCast}<br/>
-            Damage: ${this.owner.formatItemDamageDone(this.damageIncreased)}<br/>
-            Total Damage: ${formatNumber(this.damageIncreased)}`}
-        >
-          {this.owner.formatItemDamageDone(this.damageIncreased)}
-        </dfn>
-      ),
+      result: this.owner.formatItemDamageDone(this.damage),
     };
   }
 }

--- a/src/Parser/Core/Modules/Items/TarnishedSentinelMedallion.js
+++ b/src/Parser/Core/Modules/Items/TarnishedSentinelMedallion.js
@@ -1,17 +1,23 @@
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
-import { formatNumber } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
+/*
+ * Tarnished Sentinel Medallion -
+ * Use: Call upon a spectral owl to attack your target, inflicting 61201 Arcane damage every 1 sec for 20 sec. Your ranged attacks and spells against the same enemy have a chance to make the owl perform an additional attack for 75602 damage. (2 Min Cooldown)
+ */
 class TarnishedSentinelMedallion extends Analyzer {
   static dependencies = {
     combatants: Combatants,
   };
 
   damage = 0;
-  damageAbilities = new Set([SPELLS.SPECTRAL_BOLT.id, SPELLS.SPECTRAL_BLAST.id]);
+  damageIds = [
+    SPELLS.SPECTRAL_BOLT.id,
+    SPELLS.SPECTRAL_BLAST.id,
+  ];
 
   on_initialized() {
     this.active = this.combatants.selected.hasTrinket(ITEMS.TARNISHED_SENTINEL_MEDALLION.id);
@@ -19,7 +25,7 @@ class TarnishedSentinelMedallion extends Analyzer {
 
   on_byPlayer_damage(event) {
     const spellId = event.ability.guid;
-    if (!this.damageAbilities.has(spellId)) {
+    if (!this.damageIds.includes(spellId)) {
       return;
     }
 
@@ -29,7 +35,7 @@ class TarnishedSentinelMedallion extends Analyzer {
   item() {
     return {
       item: ITEMS.TARNISHED_SENTINEL_MEDALLION,
-      result: `${formatNumber(this.damage)} damage - ${this.owner.formatItemDamageDone(this.damage)}`,
+      result: this.owner.formatItemDamageDone(this.damage),
     };
   }
 }

--- a/src/Parser/Core/Modules/Items/TarratusKeystone.js
+++ b/src/Parser/Core/Modules/Items/TarratusKeystone.js
@@ -4,10 +4,15 @@ import ITEMS from 'common/ITEMS';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
+/*
+ * Tarratus Keystone -
+ * Use: Open a portal at an ally's location that releases brilliant light, restoring 1633313 health split amongst injured allies within 20 yds. (1 Min, 30 Sec Cooldown)
+ */
 class TarratusKeystone extends Analyzer {
   static dependencies = {
       combatants: Combatants,
   };
+
   healing = 0;
 
   on_initialized() {
@@ -16,7 +21,6 @@ class TarratusKeystone extends Analyzer {
 
   on_byPlayer_heal(event) {
     const spellId = event.ability.guid;
-
     if (spellId === SPELLS.TARRATUS_KEYSTONE.id) {
       this.healing += (event.amount || 0) + (event.absorbed || 0);
     }

--- a/src/Parser/Core/Modules/Items/TerrorFromBelow.js
+++ b/src/Parser/Core/Modules/Items/TerrorFromBelow.js
@@ -1,16 +1,19 @@
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
-import { formatNumber } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
+/*
+ * Terror from Below -
+ * Equip: Your ranged attacks and spells have a chance to summon a behemoth from the deep to swallow your target whole, dealing 736021 Nature damage split amongst you and all nearby enemies.
+ */
 class TerrorFromBelow extends Analyzer {
   static dependencies = {
     combatants: Combatants,
   };
 
-  bonusDmg = 0;
+  damage = 0;
 
   on_initialized() {
     this.active = this.combatants.selected.hasTrinket(ITEMS.TERROR_FROM_BELOW.id);
@@ -22,14 +25,14 @@ class TerrorFromBelow extends Analyzer {
     }
     // The trinket can damage damage to the player as well if he's near the mobs, count only the damage to enemy targets
     if (!event.targetIsFriendly) {
-      this.bonusDmg += event.amount + (event.absorbed || 0);
+      this.damage += event.amount + (event.absorbed || 0);
     }
   }
 
   item() {
     return {
       item: ITEMS.TERROR_FROM_BELOW,
-      result: `${formatNumber(this.bonusDmg)} damage - ${this.owner.formatItemDamageDone(this.bonusDmg)}`,
+      result: this.owner.formatItemDamageDone(this.damage),
     };
   }
 }

--- a/src/Parser/Core/Modules/Items/UmbralMoonglaives.js
+++ b/src/Parser/Core/Modules/Items/UmbralMoonglaives.js
@@ -34,11 +34,9 @@ class UmbralMoonglaives extends Analyzer {
     if (spellId === SPELLS.UMBRAL_GLAIVE_STORM_CAST.id) {
       this.casts += 1;
     } else if (spellId === SPELLS.UMBRAL_GLAIVE_STORM_TICK.id) { // each tick procs a cast event for player
-      this.ticks += 1;
-      this.lastTickTimestamp = event.timestamp;
+      this.ticks += 1; // should always be 8 ticks per cast, but just in case fight ends after cast but before all ticks
     } else if (spellId === SPELLS.SHATTERING_UMBRAL_GLAIVES.id) { // each shatter procs a cast event for player
       this.shatters += 1; // should be same number as casts, but just in case fight ends after cast but before shatter
-      this.lastShatterTimestamp = event.timestamp;
     }
   }
 

--- a/src/Parser/Core/Modules/Items/UmbralMoonglaives.js
+++ b/src/Parser/Core/Modules/Items/UmbralMoonglaives.js
@@ -1,17 +1,29 @@
 import React from 'react';
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
-import { formatNumber } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
+/*
+ * Umbral Moonglaives -
+ * Use: Conjure a storm of glaives at your location, causing 125220 Arcane damage every 1 sec to nearby enemies. After 8 sec the glaives shatter, causing another 313052 Arcane damage to enemies in the area. (1 Min, 30 Sec Cooldown)
+ */
 class UmbralMoonglaives extends Analyzer {
   static dependencies = {
     combatants: Combatants,
   };
-  damageIncreased = 0;
-  totalCasts = 0;
+
+  damage = 0;
+
+  casts = 0;
+
+  ticks = 0;
+  tickHits = 0;
+
+  shatters = 0;
+  shatterHits = 0;
+
 
   on_initialized() {
     this.active = this.combatants.selected.hasTrinket(ITEMS.UMBRAL_MOONGLAIVES.id);
@@ -19,29 +31,44 @@ class UmbralMoonglaives extends Analyzer {
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
-    if (spellId === SPELLS.UMBRAL_GLAIVE_STORM.id) {
-      this.totalCasts += 1;
+    if (spellId === SPELLS.UMBRAL_GLAIVE_STORM_CAST.id) {
+      this.casts += 1;
+    } else if (spellId === SPELLS.UMBRAL_GLAIVE_STORM_TICK.id) { // each tick procs a cast event for player
+      this.ticks += 1;
+      this.lastTickTimestamp = event.timestamp;
+    } else if (spellId === SPELLS.SHATTERING_UMBRAL_GLAIVES.id) { // each shatter procs a cast event for player
+      this.shatters += 1; // should be same number as casts, but just in case fight ends after cast but before shatter
+      this.lastShatterTimestamp = event.timestamp;
     }
   }
 
   on_byPlayer_damage(event) {
     const spellId = event.ability.guid;
 
-    if (spellId === SPELLS.UMBRAL_GLAIVE_STORM.id || spellId === SPELLS.SHATTERING_UMBRAL_GLAIVES.id) {
-      this.damageIncreased += event.amount;
+    if (spellId === SPELLS.UMBRAL_GLAIVE_STORM_TICK.id) {
+      this.damage += event.amount + (event.absorbed || 0);
+      this.tickHits += 1;
+    } else if (spellId === SPELLS.SHATTERING_UMBRAL_GLAIVES.id) {
+      this.damage += event.amount + (event.absorbed || 0);
+      this.shatterHits += 1;
     }
+  }
+
+  get averageHitsPerTick() {
+    return this.tickHits / this.ticks;
+  }
+
+  get averageHitsPerShatter() {
+    return this.shatterHits / this.shatters;
   }
 
   item() {
     return {
       item: ITEMS.UMBRAL_MOONGLAIVES,
       result: (
-        <dfn
-          data-tip={`The effective damage contributed by Umbral Moonglaives.<br/>
-            Casts: ${this.totalCasts}<br/>
-            Damage: ${this.owner.formatItemDamageDone(this.damageIncreased)}<br/>
-            Total Damage: ${formatNumber(this.damageIncreased)}`}>
-          {this.owner.formatItemDamageDone(this.damageIncreased)}
+        <dfn data-tip={`Glaive Storm ticks hit an average of <b>${this.averageHitsPerTick.toFixed(1)}</b> targets.<br>
+        Glaive Shatters hit an average of <b>${this.averageHitsPerShatter.toFixed(1)}</b> targets.`}>
+          {this.owner.formatItemDamageDone(this.damage)}
         </dfn>
       ),
     };

--- a/src/Parser/Core/Modules/Items/Velens.js
+++ b/src/Parser/Core/Modules/Items/Velens.js
@@ -10,16 +10,20 @@ import calculateEffectiveHealing from 'Parser/Core/calculateEffectiveHealing';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
 const LEGENDARY_VELENS_HEALING_INCREASE = 0.15;
+const SUGGESTION_VELENS_BREAKPOINT = 0.04;
 
+/*
+ * Velen's Future Sight -
+ * Use: Increase all healing done by 15% and causes 50% of overhealing on players to be redistributed to up to 3 nearby injured allies, for 10 sec. (1 Min, 15 Sec Cooldown)
+ */
 class Velens extends Analyzer {
   static dependencies = {
     combatants: Combatants,
   };
 
-  static SUGGESTION_VELENS_BREAKPOINT = 0.04;
-
   healingIncreaseHealing = 0;
   overhealHealing = 0;
+
   get healing() {
     return this.healingIncreaseHealing + this.overhealHealing;
   }
@@ -56,14 +60,20 @@ class Velens extends Analyzer {
     return {
       item: ITEMS.VELENS_FUTURE_SIGHT,
       result: (
-        <dfn data-tip={`The effective healing contributed by the Velen's Future Sight use effect. ${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healingIncreaseHealing))}% of total healing was contributed by the 15% healing increase and ${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.overhealHealing))}% of total healing was contributed by the overhealing distribution.`}>
+        <dfn data-tip={`Healing Breakdown -
+          <ul>
+            <li>Flat Healing Increase: <b>${this.owner.formatItemHealingDone(this.healingIncreaseHealing)}</b></li>
+            <li>Overheal Distribution: <b>${this.owner.formatItemHealingDone(this.overhealHealing)}</b></li>
+          </ul>
+        `}>
           {this.owner.formatItemHealingDone(this.healing)}
         </dfn>
       ),
     };
   }
+  
   suggestions(when) {
-    when(this.owner.getPercentageOfTotalHealingDone(this.healing)).isLessThan(this.constructor.SUGGESTION_VELENS_BREAKPOINT)
+    when(this.owner.getPercentageOfTotalHealingDone(this.healing)).isLessThan(SUGGESTION_VELENS_BREAKPOINT)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>Your usage of <ItemLink id={ITEMS.VELENS_FUTURE_SIGHT.id} /> can be improved. Try to maximize the amount of healing during the buff without excessively overhealing on purpose, or consider using an easier legendary.</span>)
           .icon(ITEMS.VELENS_FUTURE_SIGHT.icon)

--- a/src/Parser/Core/Modules/Items/VialOfCeaselessToxins.js
+++ b/src/Parser/Core/Modules/Items/VialOfCeaselessToxins.js
@@ -23,7 +23,7 @@ class VialOfCeaselessToxins extends Analyzer {
   on_byPlayer_damage(event) {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.CEASELESS_TOXIN.id) {
-      this.damage += event.amount;
+      this.damage += event.amount + (event.absorbed || 0);
     }
   }
 

--- a/src/Parser/Core/Modules/Items/VialOfCeaselessToxins.js
+++ b/src/Parser/Core/Modules/Items/VialOfCeaselessToxins.js
@@ -1,50 +1,36 @@
-import React from 'react';
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
-import { formatNumber } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
+/*
+ * Vial of Ceaseless Toxins -
+ * Use: Inflict 225700 Shadow damage to an enemy in melee range, plus 366752 damage over 20 sec. If they die while this effect is active, the cooldown of this ability is reduced by 45 sec. (1 Min Cooldown)
+ */
 class VialOfCeaselessToxins extends Analyzer {
   static dependencies = {
     combatants: Combatants,
   };
-  damageIncreased = 0;
+
+  damage = 0;
   totalCasts = 0;
 
   on_initialized() {
     this.active = this.combatants.selected.hasTrinket(ITEMS.VIAL_OF_CEASELESS_TOXINS.id);
   }
 
-  on_byPlayer_cast(event) {
-    const spellId = event.ability.guid;
-    if (spellId === SPELLS.CEASELESS_TOXIN.id) {
-      this.totalCasts += 1;
-    }
-  }
-
   on_byPlayer_damage(event) {
     const spellId = event.ability.guid;
-
     if (spellId === SPELLS.CEASELESS_TOXIN.id) {
-      this.damageIncreased += event.amount;
+      this.damage += event.amount;
     }
   }
 
   item() {
     return {
       item: ITEMS.VIAL_OF_CEASELESS_TOXINS,
-      result: (
-        <dfn
-          data-tip={`The effective damage contributed by Vial of Ceaseless Toxins.<br/>
-            Casts: ${this.totalCasts}<br/>
-            Damage: ${this.owner.formatItemDamageDone(this.damageIncreased)}<br/>
-            Total Damage: ${formatNumber(this.damageIncreased)}`}
-        >
-        {this.owner.formatItemDamageDone(this.damageIncreased)}
-      </dfn>
-      ),
+      result: this.owner.formatItemDamageDone(this.damage),
     };
   }
 }

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -45,6 +45,10 @@ class StatTracker extends Analyzer {
       itemId: ITEMS.ERRATIC_METRONOME.id,
       haste: (_, item) => calculateSecondaryStatDefault(870, 657, item.itemLevel),
     },
+    [SPELLS.TOME_OF_UNRAVELING_SANITY_BUFF.id]: {
+      itemId: ITEMS.TOME_OF_UNRAVELING_SANITY.id,
+      crit: (_, item) => calculateSecondaryStatDefault(910, 2756, item.itemLevel),
+    },
     // endregion
 
     // region Misc

--- a/src/common/SPELLS/OTHERS.js
+++ b/src/common/SPELLS/OTHERS.js
@@ -231,12 +231,17 @@ export default {
     name: 'Infernal Cinders',
     icon: 'inv_weapon_shortblade_54',
   },
-  UMBRAL_GLAIVE_STORM: {
+  UMBRAL_GLAIVE_STORM_CAST: {
+    id: 242553,
+    name: 'Umbral Glaive Storm',
+    icon: 'ability_upgrademoonglaive',
+  },
+  UMBRAL_GLAIVE_STORM_TICK: { // this is the damage ID, and also each tick of procs a cast event with this ID
     id: 242556,
     name: 'Umbral Glaive Storm',
     icon: 'ability_upgrademoonglaive',
   },
-  SHATTERING_UMBRAL_GLAIVES: {
+  SHATTERING_UMBRAL_GLAIVES: { // this is the shatter's damage ID, and also the shatter procs a cast event with this ID
     id: 242557,
     name: 'Shattering Umbral Glaives',
     icon: 'ability_upgrademoonglaive',
@@ -348,6 +353,11 @@ export default {
   TOME_OF_UNRAVELING_SANITY_DAMAGE: {
     id: 243941,
     name: 'Insidious Corruption',
+    icon: 'inv_archaeology_70_demon_flayedskinchronicle',
+  },
+  TOME_OF_UNRAVELING_SANITY_BUFF: {
+    id: 243942,
+    name: 'Extracted Sanity',
     icon: 'inv_archaeology_70_demon_flayedskinchronicle',
   },
   LUNAR_INFUSION: {


### PR DESCRIPTION
ALL - Added item's tooltip to comment at top of file

Seeping Scourgewing - Fixed a bug where absorbed damage wasn't being counted, and added a tracker for how many times player got 'isolated' procs.

Scepter of Betrayal - Fixed a bug where absorbed damage wasn't being counted, and updated display.

Spectral Thurible - Added 'average targets hit per proc' to tooltip.

Tarnished Sentinel Medallion - Updated to use an Array instead of a Set, and updated display.

Terror from Below - Updated display.

Tome of Unraveling Sanity - Updated display to also include average crit gain from proc. Also added proc to StatTracker.

Umbral Moonglaives - Fixed a bug where absorbed damage wasn't being counted, fixed a bug where 'cast' display was actually showing the number of ticks. Added 'average targets hit per tick' and 'average targets hit per shatter' to tooltip.

Velens - Overhauled tooltip for readability (same information still displayed)

Vial of Ceaseless Toxins - Fixed a bug where absorbed damage wasn't being counted