### PR TITLE
NLC improvements

### DIFF
--- a/src/Parser/Core/Modules/NetherlightCrucibleTraits/MurderousIntent.js
+++ b/src/Parser/Core/Modules/NetherlightCrucibleTraits/MurderousIntent.js
@@ -3,7 +3,7 @@ import React from 'react';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
-import { formatPercentage } from 'common/format';
+import { formatNumber } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
@@ -12,17 +12,23 @@ import Combatants from 'Parser/Core/Modules/Combatants';
  * Murderous Intent
  * Your Versatility is increased by 1500 while Concordance of the Legionfall is active.
  */
+
+const VERSATILITY_AMOUNT = 1500;
+
 class MurderousIntent extends Analyzer {
   static dependencies = {
     combatants: Combatants,
   };
 
   on_initialized() {
-    this.active = this.combatants.selected.traitsBySpellId[SPELLS.MURDEROUS_INTENT_TRAIT.id] > 0;
+    this.traitLevel = this.combatants.selected.traitsBySpellId[SPELLS.MURDEROUS_INTENT_TRAIT.id];
+    this.active = this.traitLevel > 0;
   }
 
   subStatistic() {
     const murderousIntentUptime = this.combatants.selected.getBuffUptime(SPELLS.MURDEROUS_INTENT_BUFF.id) / this.owner.fightDuration;
+    const averageVersatilityGained = murderousIntentUptime * VERSATILITY_AMOUNT * this.traitLevel;
+
     return (
       <div className="flex">
         <div className="flex-main">
@@ -31,7 +37,7 @@ class MurderousIntent extends Analyzer {
           </SpellLink>
         </div>
         <div className="flex-sub text-right">
-          {formatPercentage(murderousIntentUptime)} % uptime
+          {formatNumber(averageVersatilityGained)} avg. vers gained
         </div>
       </div>
     );

--- a/src/Parser/Core/Modules/NetherlightCrucibleTraits/Shocklight.js
+++ b/src/Parser/Core/Modules/NetherlightCrucibleTraits/Shocklight.js
@@ -3,7 +3,7 @@ import React from 'react';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
-import { formatPercentage } from 'common/format';
+import { formatNumber } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
@@ -12,17 +12,24 @@ import Combatants from 'Parser/Core/Modules/Combatants';
  * Shocklight
  * While Concordance of the Legionfall is active, your critical strike is increased by 1500.
  */
+
+const CRIT_AMOUNT = 1500;
+
 class Shocklight extends Analyzer {
   static dependencies = {
     combatants: Combatants,
   };
 
+  traitLevel = 0
+
   on_initialized() {
-    this.active = this.combatants.selected.traitsBySpellId[SPELLS.SHOCKLIGHT_TRAIT.id] > 0;
+    this.traitLevel = this.combatants.selected.traitsBySpellId[SPELLS.SHOCKLIGHT_TRAIT.id];
+    this.active = this.traitLevel > 0;
   }
 
   subStatistic() {
-    const murderousIntentUptime = this.combatants.selected.getBuffUptime(SPELLS.SHOCKLIGHT_BUFF.id) / this.owner.fightDuration;
+    const shockLightUptime = this.combatants.selected.getBuffUptime(SPELLS.SHOCKLIGHT_BUFF.id) / this.owner.fightDuration;
+    const averageCritGained = shockLightUptime * CRIT_AMOUNT * this.traitLevel;
     return (
       <div className="flex">
         <div className="flex-main">
@@ -31,7 +38,7 @@ class Shocklight extends Analyzer {
           </SpellLink>
         </div>
         <div className="flex-sub text-right">
-          {formatPercentage(murderousIntentUptime)} % uptime
+          {formatNumber(averageCritGained)} avg. crit gained
         </div>
       </div>
     );

--- a/src/Parser/Druid/Restoration/CHANGELOG.js
+++ b/src/Parser/Druid/Restoration/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+05-12-2016 - Resto Druid: Added throughput rates for some NLC traits. (By Blazyb)
 23-10-2017 - Resto Druid: Added Stat Weights calculator. (by Sref)
 14-10-2017 - Resto Druid: Now uses the base Sephuz's Secret module, which displays average haste gained. (by Sref)
 06-10-2017 - Resto Druid: Added Ironbark module. (by Sref)

--- a/src/Parser/Druid/Restoration/CombatLogParser.js
+++ b/src/Parser/Druid/Restoration/CombatLogParser.js
@@ -65,6 +65,12 @@ import EternalRestoration from './Modules/Traits/EternalRestoration';
 import StatWeights from './Modules/Features/StatWeights';
 
 import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from './Constants';
+import MurderousIntent from "./Modules/NetherlightCrucibleTraits/MurderousIntent";
+import Shocklight from "./Modules/NetherlightCrucibleTraits/Shocklight";
+import LightSpeed from "./Modules/NetherlightCrucibleTraits/LightSpeed";
+import NLCTraits from "./Modules/NetherlightCrucibleTraits/NLCTraits";
+import MasterOfShadows from "./Modules/NetherlightCrucibleTraits/MasterOfShadows";
+
 
 class CombatLogParser extends CoreCombatLogParser {
   static abilitiesAffectedByHealingIncreases = ABILITIES_AFFECTED_BY_HEALING_INCREASES;
@@ -117,6 +123,13 @@ class CombatLogParser extends CoreCombatLogParser {
     // TODO:
     // Edraith
     // Aman'Thul's Wisdom
+
+    // NLC
+    murderousIntent: MurderousIntent,
+    shocklight: Shocklight,
+    lightSpeed: LightSpeed,
+    masterOfShadows: MasterOfShadows,
+    nlcTraits: NLCTraits,
 
     // Shared:
     darkmoonDeckPromises: DarkmoonDeckPromises,

--- a/src/Parser/Druid/Restoration/Modules/NetherlightCrucibleTraits/LightSpeed.js
+++ b/src/Parser/Druid/Restoration/Modules/NetherlightCrucibleTraits/LightSpeed.js
@@ -6,7 +6,6 @@ import SpellLink from 'common/SpellLink';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
-import { formatNumber, formatPercentage } from 'common/format';
 import HealingDone from 'Parser/Core/Modules/HealingDone';
 import STAT from "Parser/Core/Modules/Features/STAT";
 import StatWeights from '../Features/StatWeights';
@@ -43,7 +42,7 @@ class LightSpeed extends Analyzer {
           </SpellLink>
         </div>
         <div className="flex-sub text-right">
-          {formatPercentage(healing / this.healingDone.total.effective)} % / {formatNumber(healing / this.owner.fightDuration * 1000)} HPS
+          {this.owner.formatItemHealingDone(healing)}
         </div>
       </div>
     );

--- a/src/Parser/Druid/Restoration/Modules/NetherlightCrucibleTraits/LightSpeed.js
+++ b/src/Parser/Druid/Restoration/Modules/NetherlightCrucibleTraits/LightSpeed.js
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import { formatNumber, formatPercentage } from 'common/format';
+import HealingDone from 'Parser/Core/Modules/HealingDone';
+import STAT from "Parser/Core/Modules/Features/STAT";
+import StatWeights from '../Features/StatWeights';
+
+/**
+ * Light speed
+ * Haste increased by 500, movement speed increased by 650.
+ * Only the haste part is handled here.
+ */
+
+const HASTE_AMOUNT = 500;
+
+class LightSpeed extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    healingDone: HealingDone,
+    statWeights: StatWeights,
+  };
+
+  on_initialized() {
+    this.traitLevel = this.combatants.selected.traitsBySpellId[SPELLS.LIGHT_SPEED.id];
+    this.active = this.traitLevel > 0;
+  }
+
+  subStatistic() {
+    const hasteGained = HASTE_AMOUNT * this.traitLevel;
+    const healing = this.statWeights._getGain(STAT.HASTE_HPM) * hasteGained;
+
+    return (
+      <div className="flex">
+        <div className="flex-main">
+          <SpellLink id={SPELLS.LIGHT_SPEED.id}>
+            <SpellIcon id={SPELLS.LIGHT_SPEED.id} noLink /> Light Speed
+          </SpellLink>
+        </div>
+        <div className="flex-sub text-right">
+          {formatPercentage(healing / this.healingDone.total.effective)} % / {formatNumber(healing / this.owner.fightDuration * 1000)} HPS
+        </div>
+      </div>
+    );
+  }
+}
+
+export default LightSpeed;

--- a/src/Parser/Druid/Restoration/Modules/NetherlightCrucibleTraits/MasterOfShadows.js
+++ b/src/Parser/Druid/Restoration/Modules/NetherlightCrucibleTraits/MasterOfShadows.js
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import { formatNumber, formatPercentage } from 'common/format';
+import HealingDone from 'Parser/Core/Modules/HealingDone';
+import STAT from "Parser/Core/Modules/Features/STAT";
+import StatWeights from '../Features/StatWeights';
+
+/**
+ * Mastery of Shadow
+ * Mastery increased by 500, avoidance increased by 100.
+ * Only the Mastery part is handled here.
+ */
+
+const MASTERY_AMOUNT = 500;
+
+class MasterOfShadows extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    healingDone: HealingDone,
+    statWeights: StatWeights,
+  };
+
+  on_initialized() {
+    this.traitLevel = this.combatants.selected.traitsBySpellId[SPELLS.MASTER_OF_SHADOWS.id];
+    this.active = this.traitLevel > 0;
+  }
+
+  subStatistic() {
+    const masteryGained = MASTERY_AMOUNT * this.traitLevel;
+    const healing = this.statWeights._getGain(STAT.MASTERY) * masteryGained;
+
+    return (
+      <div className="flex">
+        <div className="flex-main">
+          <SpellLink id={SPELLS.MASTER_OF_SHADOWS.id}>
+            <SpellIcon id={SPELLS.MASTER_OF_SHADOWS.id} noLink /> Master of Shadows
+          </SpellLink>
+        </div>
+        <div className="flex-sub text-right">
+          {formatPercentage(healing / this.healingDone.total.effective)} % / {formatNumber(healing / this.owner.fightDuration * 1000)} HPS
+        </div>
+      </div>
+    );
+  }
+}
+
+export default MasterOfShadows;

--- a/src/Parser/Druid/Restoration/Modules/NetherlightCrucibleTraits/MasterOfShadows.js
+++ b/src/Parser/Druid/Restoration/Modules/NetherlightCrucibleTraits/MasterOfShadows.js
@@ -6,7 +6,6 @@ import SpellLink from 'common/SpellLink';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
-import { formatNumber, formatPercentage } from 'common/format';
 import HealingDone from 'Parser/Core/Modules/HealingDone';
 import STAT from "Parser/Core/Modules/Features/STAT";
 import StatWeights from '../Features/StatWeights';
@@ -43,7 +42,7 @@ class MasterOfShadows extends Analyzer {
           </SpellLink>
         </div>
         <div className="flex-sub text-right">
-          {formatPercentage(healing / this.healingDone.total.effective)} % / {formatNumber(healing / this.owner.fightDuration * 1000)} HPS
+          {this.owner.formatItemHealingDone(healing)}
         </div>
       </div>
     );

--- a/src/Parser/Druid/Restoration/Modules/NetherlightCrucibleTraits/MurderousIntent.js
+++ b/src/Parser/Druid/Restoration/Modules/NetherlightCrucibleTraits/MurderousIntent.js
@@ -7,7 +7,6 @@ import STAT from "Parser/Core/Modules/Features/STAT";
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
-import { formatNumber, formatPercentage } from 'common/format';
 import StatWeights from '../Features/StatWeights';
 
 const VERSATILITY_AMOUNT = 1500;
@@ -32,7 +31,7 @@ class MurderousIntent extends CoreMurderousIntent {
           </SpellLink>
         </div>
         <div className="flex-sub text-right">
-          {formatPercentage(healing / this.healingDone.total.effective)} % / {formatNumber(healing / this.owner.fightDuration * 1000)} HPS
+          {this.owner.formatItemHealingDone(healing)}
         </div>
       </div>
     );

--- a/src/Parser/Druid/Restoration/Modules/NetherlightCrucibleTraits/MurderousIntent.js
+++ b/src/Parser/Druid/Restoration/Modules/NetherlightCrucibleTraits/MurderousIntent.js
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import CoreMurderousIntent from "Parser/Core/Modules//NetherlightCrucibleTraits/MurderousIntent";
+import HealingDone from 'Parser/Core/Modules/HealingDone';
+import STAT from "Parser/Core/Modules/Features/STAT";
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import { formatNumber, formatPercentage } from 'common/format';
+import StatWeights from '../Features/StatWeights';
+
+const VERSATILITY_AMOUNT = 1500;
+
+class MurderousIntent extends CoreMurderousIntent {
+  static dependencies = {
+    ...CoreMurderousIntent.dependencies,
+    healingDone: HealingDone,
+    statWeights: StatWeights,
+  };
+
+  subStatistic() {
+    const murderousIntentUptime = this.combatants.selected.getBuffUptime(SPELLS.MURDEROUS_INTENT_BUFF.id) / this.owner.fightDuration;
+    const averageVersatilityGained = murderousIntentUptime * VERSATILITY_AMOUNT * this.traitLevel;
+    const healing = this.statWeights._getGain(STAT.VERSATILITY) * averageVersatilityGained;
+
+    return (
+      <div className="flex">
+        <div className="flex-main">
+          <SpellLink id={SPELLS.MURDEROUS_INTENT_BUFF.id}>
+            <SpellIcon id={SPELLS.MURDEROUS_INTENT_BUFF.id} noLink /> Murderous Intent
+          </SpellLink>
+        </div>
+        <div className="flex-sub text-right">
+          {formatPercentage(healing / this.healingDone.total.effective)} % / {formatNumber(healing / this.owner.fightDuration * 1000)} HPS
+        </div>
+      </div>
+    );
+  }
+}
+
+export default MurderousIntent;

--- a/src/Parser/Druid/Restoration/Modules/NetherlightCrucibleTraits/NLCTraits.js
+++ b/src/Parser/Druid/Restoration/Modules/NetherlightCrucibleTraits/NLCTraits.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import StatisticsListBox from 'Main/StatisticsListBox';
+
+import CoreNLCTraits from "Parser/Core/Modules//NetherlightCrucibleTraits/NLCTraits";
+import LightSpeed from "./LightSpeed";
+import MasterOfShadows from "./MasterOfShadows";
+
+class NLCTraits extends CoreNLCTraits {
+  static dependencies = {
+    ...CoreNLCTraits.dependencies,
+    lightSpeed: LightSpeed,
+    masterOfShadows: MasterOfShadows,
+  };
+
+  statistic() {
+    return (
+      <StatisticsListBox
+        title="Netherlight Crucible"
+        tooltip="This provides an overview of the increased provide by the Netherlight Crucible traits."
+      >
+        {this.murderousIntent.active && this.murderousIntent.subStatistic()}
+        {this.shocklight.active && this.shocklight.subStatistic()}
+        {this.refractiveShell.active && this.refractiveShell.subStatistic()}
+        {this.secureInTheLight.active && this.secureInTheLight.subStatistic()}
+        {this.infusionOfLight.active && this.infusionOfLight.subStatistic()}
+        {this.lightsEmbrace.active && this.lightsEmbrace.subStatistic()}
+        {this.shadowbind.active && this.shadowbind.subStatistic()}
+        {this.chaoticDarkness.active && this.chaoticDarkness.subStatistic()}
+        {this.tormentTheWeak.active && this.tormentTheWeak.subStatistic()}
+        {this.darkSorrows.active && this.darkSorrows.subStatistic()}
+        {this.lightSpeed.active && this.lightSpeed.subStatistic()}
+        {this.masterOfShadows.active && this.masterOfShadows.subStatistic()}
+      </StatisticsListBox>
+    );
+  }
+}
+
+export default NLCTraits;

--- a/src/Parser/Druid/Restoration/Modules/NetherlightCrucibleTraits/Shocklight.js
+++ b/src/Parser/Druid/Restoration/Modules/NetherlightCrucibleTraits/Shocklight.js
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import STAT from "Parser/Core/Modules/Features/STAT";
+import CoreShocklight from "Parser/Core/Modules//NetherlightCrucibleTraits/Shocklight";
+import HealingDone from 'Parser/Core/Modules/HealingDone';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import { formatNumber, formatPercentage } from 'common/format';
+
+import StatWeights from '../Features/StatWeights';
+
+const CRIT_AMOUNT = 1500;
+
+class MurderousIntent extends CoreShocklight {
+  static dependencies = {
+    ...CoreShocklight.dependencies,
+    healingDone: HealingDone,
+    statWeights: StatWeights,
+  };
+
+  subStatistic() {
+    const shockLightUptime = this.combatants.selected.getBuffUptime(SPELLS.SHOCKLIGHT_BUFF.id) / this.owner.fightDuration;
+    const averageCritGained = shockLightUptime * CRIT_AMOUNT * this.traitLevel;
+    const healing = this.statWeights._getGain(STAT.CRITICAL_STRIKE) * averageCritGained;
+
+    return (
+      <div className="flex">
+        <div className="flex-main">
+          <SpellLink id={SPELLS.SHOCKLIGHT_TRAIT.id}>
+            <SpellIcon id={SPELLS.SHOCKLIGHT_TRAIT.id} noLink /> Shocklight
+          </SpellLink>
+        </div>
+        <div className="flex-sub text-right">
+          {formatPercentage(healing / this.healingDone.total.effective)} % / {formatNumber(healing / this.owner.fightDuration * 1000)} HPS
+        </div>
+      </div>
+    );
+  }
+}
+
+export default MurderousIntent;

--- a/src/Parser/Druid/Restoration/Modules/NetherlightCrucibleTraits/Shocklight.js
+++ b/src/Parser/Druid/Restoration/Modules/NetherlightCrucibleTraits/Shocklight.js
@@ -7,7 +7,6 @@ import HealingDone from 'Parser/Core/Modules/HealingDone';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
-import { formatNumber, formatPercentage } from 'common/format';
 
 import StatWeights from '../Features/StatWeights';
 
@@ -33,7 +32,7 @@ class MurderousIntent extends CoreShocklight {
           </SpellLink>
         </div>
         <div className="flex-sub text-right">
-          {formatPercentage(healing / this.healingDone.total.effective)} % / {formatNumber(healing / this.owner.fightDuration * 1000)} HPS
+          {this.owner.formatItemHealingDone(healing)}
         </div>
       </div>
     );

--- a/src/common/SPELLS/OTHERS.js
+++ b/src/common/SPELLS/OTHERS.js
@@ -586,6 +586,16 @@ export default {
     name: 'Concordance of the Legionfall',
     icon: 'achievement_faction_legionfall',
   },
+  MASTER_OF_SHADOWS: {
+    id: 252091,
+    name: 'Master of Shadows',
+    icon: 'spell_shadow_shadesofdarkness',
+  },
+  LIGHT_SPEED: {
+    id: 252088,
+    name: 'Light Speed',
+    icon: 'ability_rogue_sprint',
+  },
   // Dot spell for Carafe of Searing Light
   REFRESHING_AGONY_DOT: {
     id: 253284,

--- a/src/common/SPELLS/OTHERS.js
+++ b/src/common/SPELLS/OTHERS.js
@@ -605,6 +605,7 @@ export default {
     id: 252088,
     name: 'Light Speed',
     icon: 'ability_rogue_sprint',
+  },
   FEEDBACK_LOOP: {
     id: 253269,
     name: 'Feedback Loop',


### PR DESCRIPTION
* Core: Murderous Intent and Shocklight shows the average stat gained instead of uptime (this infromation is already shown on WCL). This also takes additional levels into account.

* Resto Druid: Murderous Intent, Shocklight, Master of Shadows (new), Light Speed (new) shows the throughput healing based on the statweights module.

![img](https://i.gyazo.com/094372b50f5bff153eb86f38704f8797.png)