### PR TITLE
[Frost Mage] Lower Thermal Void Avg Time

### DIFF
--- a/src/Parser/Mage/Frost/Modules/Features/ThermalVoid.js
+++ b/src/Parser/Mage/Frost/Modules/Features/ThermalVoid.js
@@ -45,7 +45,7 @@ class ThermalVoid extends Analyzer {
           .icon(SPELLS.ICY_VEINS.icon)
           .actual(`${formatNumber(actual)} seconds Average Icy Veins Duration`)
           .recommended(`${formatNumber(recommended)} is recommended`)
-          .regular(35).major(30);
+          .regular(37).major(33);
       });
   }
 

--- a/src/Parser/Mage/Frost/Modules/Features/ThermalVoid.js
+++ b/src/Parser/Mage/Frost/Modules/Features/ThermalVoid.js
@@ -39,13 +39,13 @@ class ThermalVoid extends Analyzer {
   suggestions(when) {
     const uptime = this.combatants.selected.getBuffUptime(SPELLS.ICY_VEINS.id) - this.extraUptime;
     const averageDuration = (uptime / this.casts) / 1000;
-    when(averageDuration).isLessThan(45)
+    when(averageDuration).isLessThan(40)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>Your <SpellLink id={SPELLS.ICY_VEINS.id}/> duration can be improved. Make sure you use Frozen Orb to get Fingers of Frost Procs</span>)
           .icon(SPELLS.ICY_VEINS.icon)
           .actual(`${formatNumber(actual)} seconds Average Icy Veins Duration`)
           .recommended(`${formatNumber(recommended)} is recommended`)
-          .regular(40).major(30);
+          .regular(35).major(30);
       });
   }
 


### PR DESCRIPTION
Lowered threshold for Thermal Void warnings partly because it wont be as possible to hit 45 seconds as T20 4pc fades away. Also because 45 seconds was a tad bit high considering its partly based on RNG