### PR TITLE
BaseHealerStatValues exposes the amount of healing one rating does

### DIFF
--- a/src/Parser/Core/Modules/Features/BaseHealerStatValues.js
+++ b/src/Parser/Core/Modules/Features/BaseHealerStatValues.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import SPELLS from 'common/SPELLS';
-import { formatNumber } from 'common/format';
+import { formatNumber, formatThousands } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import HIT_TYPES from 'Parser/Core/HIT_TYPES';
@@ -375,7 +375,7 @@ class BaseHealerStatValues extends Analyzer {
                       {tooltip ? <dfn data-tip={tooltip}>{getName(stat)}</dfn> : getName(stat)}
                     </td>
                     <td className="text-right">
-                      <dfn data-tip={gain !== null ? gain.toFixed(0) + ' healing gained per 1 rating' : 'NYI'}>
+                      <dfn data-tip={gain !== null ? formatThousands(gain) + ' total healing gained per 1 rating' : 'NYI'}>
                         {stat === STAT.HASTE_HPCT && '0.00 - '}{gain !== null ? weight.toFixed(2) : 'NYI'}
                       </dfn>
                     </td>

--- a/src/Parser/Core/Modules/Features/BaseHealerStatValues.js
+++ b/src/Parser/Core/Modules/Features/BaseHealerStatValues.js
@@ -348,7 +348,7 @@ class BaseHealerStatValues extends Analyzer {
             <thead>
               <tr>
                 <th style={{ minWidth: 30 }}><b>Stat</b></th>
-                <th className="text-right" style={{ minWidth: 30 }}><dfn data-tip="Normalized so Intellect is always 1.00"><b>Value</b></dfn></th>
+                <th className="text-right" style={{ minWidth: 30 }}><dfn data-tip="Normalized so Intellect is always 1.00. Hover to see the amount of healing 1 rating resulted in."><b>Value</b></dfn></th>
                 <th className="text-right" style={{ minWidth: 30 }}><dfn data-tip="Amount of stat rating required to increase your total healing by 1%"><b>Rating per 1%</b></dfn></th>
               </tr>
             </thead>
@@ -374,7 +374,11 @@ class BaseHealerStatValues extends Analyzer {
                       />{' '}
                       {tooltip ? <dfn data-tip={tooltip}>{getName(stat)}</dfn> : getName(stat)}
                     </td>
-                    <td className="text-right">{stat === STAT.HASTE_HPCT && '0.00 - '}{gain !== null ? weight.toFixed(2) : 'NYI'}</td>
+                    <td className="text-right">
+                      <dfn data-tip={gain !== null ? gain.toFixed(0) + ' healing gained per 1 rating' : 'NYI'}>
+                        {stat === STAT.HASTE_HPCT && '0.00 - '}{gain !== null ? weight.toFixed(2) : 'NYI'}
+                      </dfn>
+                    </td>
                     <td className="text-right">{gain !== null ? (
                       ratingForOne === Infinity ? '∞' : formatNumber(ratingForOne)
                     ) : 'NYI'}</td>

--- a/src/Parser/Druid/Restoration/CHANGELOG.js
+++ b/src/Parser/Druid/Restoration/CHANGELOG.js
@@ -1,5 +1,6 @@
 export default `
-05-12-2016 - Resto Druid: Added throughput rates for some NLC traits. (By Blazyb)
+07-12-2017 - Resto Druid: Stat values shows healing gained per 1 rating on hover. (By Blazyb)
+05-12-2017 - Resto Druid: Added throughput rates for some NLC traits. (By Blazyb)
 23-10-2017 - Resto Druid: Added Stat Weights calculator. (by Sref)
 14-10-2017 - Resto Druid: Now uses the base Sephuz's Secret module, which displays average haste gained. (by Sref)
 06-10-2017 - Resto Druid: Added Ironbark module. (by Sref)

--- a/src/Parser/Paladin/Holy/CHANGELOG.js
+++ b/src/Parser/Paladin/Holy/CHANGELOG.js
@@ -7,6 +7,11 @@ import ITEMS from 'common/ITEMS';
 
 export default [
   {
+    date: new Date('2017-12-07'),
+    changes: 'Stat values shows healing gained per 1 rating on hover.',
+    contributors: ['blazyb'],
+  },
+  {
     date: new Date('2017-11-05'),
     changes: 'Reworded haste tooltip and changed the display to be 0.00 - value to be more obvious it\'s a max.',
     contributors: [Zerotorescue],


### PR DESCRIPTION
This is useful for comparing static stat values. I.e. if you're comparing a log where you had a trinket with healing procc with a stat stick. Or just interested in how much healing each stat did.

![img](https://i.gyazo.com/ad279d13d42acc91105530596d925169.png)