### PR TITLE
[Mage] Fixed Crit in Stat Tracker

### DIFF
--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -17,7 +17,7 @@ class StatTracker extends Analyzer {
 
   static STAT_BUFFS = {
     // region Potions
-    [SPELLS.POTION_OF_PROLONGED_POWER.id]: { strength: 2500, agility: 2500, intellect: 2500 },
+    [SPELLS.POTION_OF_PROLONGED_POWER.id]: { stamina: 2500, strength: 2500, agility: 2500, intellect: 2500 },
     // endregion
     // TODO: add flasks
     // TODO: add food

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -187,7 +187,14 @@ class StatTracker extends Analyzer {
    * These values don't change.
    */
   get baseCritPercentage() {
-    return 0.08; // TODO is this the same for all classes?
+    switch (this.combatants.selected.spec) {
+      case SPECS.FROST_MAGE:
+        return 0.05;
+      case SPECS.FIRE_MAGE:
+        return 0.2;
+      default:
+        return 0.08;
+    }
   }
   get baseHastePercentage() {
     return 0;


### PR DESCRIPTION
Frost Mage and Fire Mage have 5% base crit instead of 8%, and Fire has an additional 15% from a passive (Critical Mass).

I confirmed both of these values vs my character sheet and after these changes, the values match perfectly