### PR TITLE
Added Vampiric Aura to StatTracker

### DIFF
--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -68,6 +68,9 @@ class StatTracker extends Analyzer {
     [SPELLS.MARK_OF_THE_CLAW.id]: { crit: 1000, haste: 1000 },
     // endregion
 
+    // region Death Knight
+    [SPELLS.VAMPIRIC_AURA.id]: { leech: (23000 * 0.20) }, // TODO make non static so can use this.leechRatingPerPercent ??
+
     // region Druid
     [SPELLS.ASTRAL_HARMONY.id]: { mastery: 4000 },
     // endregion

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -70,6 +70,7 @@ class StatTracker extends Analyzer {
 
     // region Death Knight
     [SPELLS.VAMPIRIC_AURA.id]: { leech: (23000 * 0.20) }, // TODO make non static so can use this.leechRatingPerPercent ??
+    // endregion
 
     // region Druid
     [SPELLS.ASTRAL_HARMONY.id]: { mastery: 4000 },

--- a/src/common/SPELLS/DEATH_KNIGHT.js
+++ b/src/common/SPELLS/DEATH_KNIGHT.js
@@ -108,6 +108,11 @@ export default {
     name: 'Unending Thirst',
     icon: 'inv_axe_2h_artifactmaw_d_02',
   },
+  VAMPIRIC_AURA: {
+    id: 238698,
+    name: 'Vampiric Aura',
+    icon: 'ability_ironmaidens_maraksbloodcalling',
+  },
 
   // CC
   GOREFIENDS_GRASP: {


### PR DESCRIPTION
Vampiric Aura not being tracked was causing inflated Leech stat weights when player was gaining it.

Fixes #959 