### PR TITLE
[core] Added better buff stack tracking to Entities.

### DIFF
--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -52,6 +52,7 @@ import AmalgamsSeventhSpine from './Modules/Items/AmalgamsSeventhSpine';
 import ArchiveOfFaith from './Modules/Items/ArchiveOfFaith';
 import BarbaricMindslaver from './Modules/Items/BarbaricMindslaver';
 import CharmOfTheRisingTide from './Modules/Items/CharmOfTheRisingTide';
+import ErraticMetronome from './Modules/Items/ErraticMetronome';
 import SeaStar from './Modules/Items/SeaStarOfTheDepthmother';
 import DeceiversGrandDesign from './Modules/Items/DeceiversGrandDesign';
 import PrePotion from './Modules/Items/PrePotion';
@@ -167,6 +168,7 @@ class CombatLogParser {
     enchantChecker: EnchantChecker,
     gnawedThumbRing: GnawedThumbRing,
     ishkarsFelshieldEmitter: IshkarsFelshieldEmitter,
+    erraticMetronome: ErraticMetronome,
     // Tomb trinkets:
     archiveOfFaith: ArchiveOfFaith,
     barbaricMindslaver: BarbaricMindslaver,
@@ -191,8 +193,8 @@ class CombatLogParser {
     seepingScourgewing: SeepingScourgewing,
     gorshalachsLegacy: GorshalachsLegacy,
     golgannethsVitality: GolgannethsVitality,
-    forgefiendsFabricator: ForgefiendsFabricator, 
-    khazgorothsCourage: KhazgorothsCourage,   
+    forgefiendsFabricator: ForgefiendsFabricator,
+    khazgorothsCourage: KhazgorothsCourage,
     terminusSignalingBeacon: TerminusSignalingBeacon,
     prototypePersonnelDecimator: PrototypePersonnelDecimator,
     sheathOfAsara: SheathOfAsara,

--- a/src/Parser/Core/Entity.js
+++ b/src/Parser/Core/Entity.js
@@ -65,6 +65,28 @@ class Entity {
   /**
    * @param {number} buffAbilityId - buff ID to check for
    * @param {number} sourceID - source ID the buff must have come from, or any source if null.
+   * @returns {number} - Time (in ms) the specified buff has been active weighted by the number of stacks active.
+   *      For example if buff was up for 10000ms with 1 stack and 20000ms with 2 stacks, would return 50000.
+   */
+  getStackWeightedBuffUptime(buffAbilityId, sourceID = null) {
+    return this.buffs
+      .filter(buff => (buff.ability.guid === buffAbilityId) && (sourceID === null || sourceID === buff.sourceID))
+      .reduce((totalUptime, buff) => {
+        let startTime;
+        let startStacks;
+        const buffUptime = buff.stackHistory.reduce((stackUptime, stack) => {
+          const result = !startTime ? 0 : (stack.timestamp - startTime) * startStacks;
+          startTime = stack.timestamp;
+          startStacks = stack.stacks;
+          return stackUptime + result;
+        }, 0);
+        return totalUptime + buffUptime;
+      }, 0);
+  }
+
+  /**
+   * @param {number} buffAbilityId - buff ID to check for
+   * @param {number} sourceID - source ID the buff must have come from, or any source if null.
    * @returns {number} - The number of times the specified buff has been applied (only applications count, not stack changes or refreshes).
    */
   getBuffTriggerCount(buffAbilityId, sourceID = null) {

--- a/src/Parser/Core/Modules/Items/ErraticMetronome.js
+++ b/src/Parser/Core/Modules/Items/ErraticMetronome.js
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import ITEMS from 'common/ITEMS';
+import SPELLS from 'common/SPELLS';
+import { calculatePrimaryStat } from 'common/stats';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+/*
+ * Erratic Metronome -
+ * Equip: Your damaging spells have a chance to grant you 657 Haste for 12 sec, stacking up to 5 times. Stacking does not refresh duration.
+ */
+class ErraticMetronome extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  procAmount;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTrinket(ITEMS.ERRATIC_METRONOME.id);
+    if(this.active) {
+      this.procAmount = calculatePrimaryStat(870, 657, this.combatants.selected.getItem(ITEMS.ERRATIC_METRONOME.id).itemLevel);
+    }
+  }
+
+  get averageStacks() {
+    return this.combatants.selected.getStackWeightedBuffUptime(SPELLS.ACCELERANDO.id) / this.owner.fightDuration;
+  }
+
+  get averageHaste() {
+    return this.averageStacks * this.procAmount;
+  }
+
+  item() {
+    return {
+      item: ITEMS.ERRATIC_METRONOME,
+      result: (
+        <dfn data-tip={`Average Stacks: ${this.averageStacks.toFixed(2)}`}>
+          {this.averageHaste.toFixed(0)} average Haste
+        </dfn>
+      ),
+    };
+  }
+
+}
+
+export default ErraticMetronome;


### PR DESCRIPTION
Added better buff stack tracking to Entity / Entities, including a utility function that can be used to calculate 'average stacks' of a buff. Also added an ErraticMetronome module (a trinket from Nighthold), as a demonstration of how average stack calculation can be done.

This should help with the implementation of PR #963 