### PR TITLE
Fixing bug where GotQ/Cloudburst percent is show incorrectly

### DIFF
--- a/src/Parser/Shaman/Restoration/Modules/Spells/GiftOfTheQueen.js
+++ b/src/Parser/Shaman/Restoration/Modules/Spells/GiftOfTheQueen.js
@@ -61,7 +61,7 @@ class GiftOfTheQueen extends Analyzer {
         .addSuggestion((suggest, actual, recommended) => {
           return suggest(<span>Try to cast <SpellLink id={SPELLS.GIFT_OF_THE_QUEEN.id} /> while <SpellLink id={SPELLS.CLOUDBURST_TOTEM_TALENT.id} /> is up as much as possible.</span>)
             .icon(SPELLS.GIFT_OF_THE_QUEEN.icon)
-            .actual(`${formatPercentage(giftOfTheQueenTargetEfficiency)} % of GotQ healing fed into CBT`)
+            .actual(`${formatPercentage(giftOfTheQueenCBTFeedingPercent)} % of GotQ healing fed into CBT`)
             .recommended(`> ${formatPercentage(recommended)} % of GotQ healing fed into CBT`)
             .regular(recommended - .2).major(recommended - .4);
         }); 


### PR DESCRIPTION
Found and fixed this in the Checklist PR but since this is a live bug now I decided to push it as a separate PR