### PR TITLE
[Core] Fix for SpellUsable Reduction of Charge Spells

### DIFF
--- a/src/Parser/Core/Modules/SpellUsable.js
+++ b/src/Parser/Core/Modules/SpellUsable.js
@@ -101,7 +101,7 @@ class SpellUsable extends Analyzer {
    * @param {boolean} resetAllCharges Whether all charges should be reset or just the last stack. Does nothing for spells with just 1 stack.
    * @param {number} timestamp Override the timestamp if it may be different from the current timestamp.
    */
-  endCooldown(spellId, resetAllCharges = false, timestamp = this.owner.currentTimestamp) {
+  endCooldown(spellId, resetAllCharges = false, timestamp = this.owner.currentTimestamp, remainingCDR = 0) {
     if (!this.isOnCooldown(spellId)) {
       throw new Error(`Tried to end the cooldown of ${spellId}, but it's not on cooldown.`);
     }
@@ -118,6 +118,7 @@ class SpellUsable extends Analyzer {
       cooldown.chargesOnCooldown -= 1;
       this._triggerEvent('updatespellusable', this._makeEvent(spellId, timestamp, 'restorecharge', cooldown));
       this.refreshCooldown(spellId, timestamp);
+      this.reduceCooldown(spellId,remainingCDR,timestamp);
     }
   }
   /**
@@ -154,7 +155,8 @@ class SpellUsable extends Analyzer {
     }
     const cooldownRemaining = this.cooldownRemaining(spellId, timestamp);
     if (cooldownRemaining < reductionMs) {
-      this.endCooldown(spellId, false, timestamp);
+      const remainingCDR = reductionMs - cooldownRemaining;
+      this.endCooldown(spellId, false, timestamp, remainingCDR);
       return cooldownRemaining;
     } else {
       this._currentCooldowns[spellId].totalReductionTime += reductionMs;

--- a/src/Parser/Core/Modules/SpellUsable.js
+++ b/src/Parser/Core/Modules/SpellUsable.js
@@ -100,6 +100,7 @@ class SpellUsable extends Analyzer {
    * @param {number} spellId The ID of the spell.
    * @param {boolean} resetAllCharges Whether all charges should be reset or just the last stack. Does nothing for spells with just 1 stack.
    * @param {number} timestamp Override the timestamp if it may be different from the current timestamp.
+   * @param {number} remainingCDR For abilities with charges, the remaining cooldown reduction if the reduction is more than the remaining cooldown of the charge and more than 1 charge is on cooldown
    */
   endCooldown(spellId, resetAllCharges = false, timestamp = this.owner.currentTimestamp, remainingCDR = 0) {
     if (!this.isOnCooldown(spellId)) {
@@ -118,7 +119,7 @@ class SpellUsable extends Analyzer {
       cooldown.chargesOnCooldown -= 1;
       this._triggerEvent('updatespellusable', this._makeEvent(spellId, timestamp, 'restorecharge', cooldown));
       this.refreshCooldown(spellId, timestamp);
-      this.reduceCooldown(spellId,remainingCDR,timestamp);
+      if (remainingCDR !== 0) {this.reduceCooldown(spellId,remainingCDR,timestamp);}
     }
   }
   /**


### PR DESCRIPTION
I noticed that the console log was frequently telling me that Phoenix's Flames was used while it was on cooldown, so i went to look at SpellUsable to figure out why.

The way Phoenix's Flames works is it has 3 charges, 45 second cooldown each. And ignite damage has a chance to erupt and reduce the cooldown of Phoenix's Flames by 10 seconds.

I believe the issue is that if multiple charges of Phoenix's Flames are on cooldown, and there is less than 10 seconds left on the cooldown of a charge, then SpellUsable ends the cooldown and grants a charge, and then stops.

But in game, if you have less than 10 seconds left on a Phoenix Flames charge, then it ends the cooldown on that charge, and the remainder of that 10 seconds reduces the next charge. So for example. If i have 3 charges on cooldown and 5 seconds until i gain a charge, and ignite procs. Then it is supposed to reduce the one charge by 5 seconds, gain a charge, and then reduce the cooldown on the next charge by the remaining 5 seconds.

I believe what i have done here fixes it (and it fixed my issue with Phoenix Flames .. or seems to have), but im not sure if this is how ALL charge spells work, nor am i sure if there is a better way to accomplish this.