### PR TITLE
[resto druid] Added Dreamer (T21) to Flourish tracking

### DIFF
--- a/src/Parser/Druid/Restoration/Modules/Talents/Flourish.js
+++ b/src/Parser/Druid/Restoration/Modules/Talents/Flourish.js
@@ -22,6 +22,7 @@ const REJUV_WEIGHT = 20 * 1.15; // the +15% from first artifact point
 const REGROWTH_WEIGHT = 5;
 const LB_WEIGHT = 25;
 const SB_WEIGHT = 10;
+const DREAMER_WEIGHT = 12.5;
 
 
 // TODO: Idea - Give suggestions on low amount/duration extended with flourish on other HoTs
@@ -39,6 +40,7 @@ class Flourish extends Analyzer {
   cenarionWard = 0;
   lifebloom = 0;
   springBlossoms = 0;
+  dreamer = 0;
 
   flourishes = [];
 
@@ -85,10 +87,13 @@ class Flourish extends Analyzer {
     const cultCount = this._hotCount(SPELLS.CULTIVATION.id, event.timestamp);
     this.cultivation += cultCount;
 
+    const dreamerCount = this._hotCount(SPELLS.DREAMER.id, event.timestamp);
+    this.dreamer += dreamerCount;
+
     // Due to cultivation's refresh mechanic, we don't count it in total
-    const totalCount = wgCount + rejuvCount + germCount + rgCount + lbCount + sbCount + cwCount;
+    const totalCount = wgCount + rejuvCount + germCount + rgCount + lbCount + sbCount + cwCount + dreamerCount;
     const weightedPowerPerSecond = (wgCount * WG_WEIGHT) + (rejuvCount * REJUV_WEIGHT) + (germCount * REJUV_WEIGHT) +
-        (rgCount * REGROWTH_WEIGHT) + (lbCount * LB_WEIGHT) + (sbCount * SB_WEIGHT) + (cwCount * CW_WEIGHT);
+        (rgCount * REGROWTH_WEIGHT) + (lbCount * LB_WEIGHT) + (sbCount * SB_WEIGHT) + (cwCount * CW_WEIGHT) + (dreamerCount * DREAMER_WEIGHT);
     const weightedPower = weightedPowerPerSecond * FLOURISH_EXTENSION_SECONDS;
     this.flourishes.push({ 'count': totalCount, 'weightedPower': weightedPower });
   }
@@ -158,6 +163,10 @@ class Flourish extends Analyzer {
             }
             ${this.springBlossoms > 0
               ? `<li>${this.springBlossoms} Spring Blossoms</li>`
+              : ``
+            }
+            ${this.dreamer > 0
+              ? `<li>${this.dreamer} Dreamer (T21)</li>`
               : ``
             }
             ${this.cultivation > 0


### PR DESCRIPTION
Resto Druid T21 adds another HoT for the spec, and Flourish is a spell that extends all active resto HoTs. This PR simply adds tracking of Dreamer to the Flourish module.