### PR TITLE
[Core] Remove Downtime Suggestion for Eonar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,3 @@ temp
 .vs/slnx.sqlite-journal
 .vs/VSWorkspaceState.json
 .vs/WoWAnalyzer/v15/.suo
-src/Icons/Warning.js

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ temp
 .vs/slnx.sqlite-journal
 .vs/VSWorkspaceState.json
 .vs/WoWAnalyzer/v15/.suo
+src/Icons/Warning.js

--- a/src/Main/Results.js
+++ b/src/Main/Results.js
@@ -203,6 +203,7 @@ class Results extends React.Component {
                     </div>
                   </div>
                   <div>
+                    {modules.warningDisplay.render()}
                     {this.state.mainTab === MAIN_TAB.CHECKLIST && (
                       modules.checklist.render()
                     )}
@@ -213,9 +214,7 @@ class Results extends React.Component {
                       <AboutTab config={config} />
                     )}
                   </div>
-                  <div>
-                    {modules.warningDisplay.render()}
-                  </div>
+
                 </div>
               </div>
             </div>

--- a/src/Main/Results.js
+++ b/src/Main/Results.js
@@ -213,6 +213,9 @@ class Results extends React.Component {
                       <AboutTab config={config} />
                     )}
                   </div>
+                  <div>
+                    {modules.warningDisplay.render()}
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/Main/Results.js
+++ b/src/Main/Results.js
@@ -213,10 +213,10 @@ class Results extends React.Component {
                       <AboutTab config={config} />
                     )}
                   </div>
+                  <div>
+                    {modules.warningDisplay.render()}
+                  </div>
                 </div>
-              </div>
-              <div>
-                {modules.warningDisplay.render()}
               </div>
             </div>
           </div>

--- a/src/Main/Results.js
+++ b/src/Main/Results.js
@@ -213,10 +213,10 @@ class Results extends React.Component {
                       <AboutTab config={config} />
                     )}
                   </div>
-                  <div>
-                    {modules.warningDisplay.render()}
-                  </div>
                 </div>
+              </div>
+              <div>
+                {modules.warningDisplay.render()}
               </div>
             </div>
           </div>

--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -32,6 +32,7 @@ import ManaValues from './Modules/ManaValues';
 import SpellManaCost from './Modules/SpellManaCost';
 
 import DistanceMoved from './Modules/Others/DistanceMoved';
+import WarningDisplay from './Modules/Features/WarningDisplay';
 
 import StatsDisplay from './Modules/Features/StatsDisplay';
 import TalentsDisplay from './Modules/Features/TalentsDisplay';
@@ -149,6 +150,7 @@ class CombatLogParser {
     manaValues: ManaValues,
     vantusRune: VantusRune,
     distanceMoved: DistanceMoved,
+    warningDisplay: WarningDisplay,
 
     critEffectBonus: CritEffectBonus,
 

--- a/src/Parser/Core/Modules/AlwaysBeCasting.js
+++ b/src/Parser/Core/Modules/AlwaysBeCasting.js
@@ -172,7 +172,8 @@ class AlwaysBeCasting extends Analyzer {
     downtime: '/img/afk.png',
   };
   statistic() {
-    if (!this.showStatistic || this.owner.boss.fight.noDowntimeSuggestion === true) {
+    const boss = this.owner.boss;
+    if (!this.showStatistic || (boss && boss.fight.disableDowntimeStatistic)) {
       return null;
     }
 

--- a/src/Parser/Core/Modules/AlwaysBeCasting.js
+++ b/src/Parser/Core/Modules/AlwaysBeCasting.js
@@ -172,40 +172,41 @@ class AlwaysBeCasting extends Analyzer {
     downtime: '/img/afk.png',
   };
   statistic() {
-    if (!this.showStatistic) {
+    if (!this.showStatistic || this.owner.boss.fight.noDowntimeSuggestion === true) {
       return null;
     }
 
     return (
-      <StatisticBox
-        icon={<Icon icon="spell_mage_altertime" alt="Downtime" />}
-        value={`${formatPercentage(this.downtimePercentage)} %`}
-        label="Downtime"
-        tooltip={`Downtime is available time not used to cast anything (including not having your GCD rolling). This can be caused by delays between casting spells, latency, cast interrupting or just simply not casting anything (e.g. due to movement/stunned).<br/>
-        <li>You spent <b>${formatPercentage(this.activeTimePercentage)}%</b> of your time casting something.</li>
-        <li>You spent <b>${formatPercentage(this.downtimePercentage)}%</b> of your time casting nothing at all.</li>
-        `}
-        footer={(
-          <div className="statistic-bar">
-            <div
-              className="stat-health-bg"
-              style={{ width: `${this.activeTimePercentage * 100}%` }}
-              data-tip={`You spent <b>${formatPercentage(this.activeTimePercentage)}%</b> of your time casting something.`}
-            >
-              <img src={this.constructor.icons.activeTime} alt="Active time" />
-            </div>
-            <div
-              className="remainder DeathKnight-bg"
-              data-tip={`You spent <b>${formatPercentage(this.downtimePercentage)}%</b> of your time casting nothing at all.`}
-            >
-              <img src={this.constructor.icons.downtime} alt="Downtime" />
-            </div>
+    <StatisticBox
+      icon={<Icon icon="spell_mage_altertime" alt="Downtime" />}
+      value={`${formatPercentage(this.downtimePercentage)} %`}
+      label="Downtime"
+      tooltip={`Downtime is available time not used to cast anything (including not having your GCD rolling). This can be caused by delays between casting spells, latency, cast interrupting or just simply not casting anything (e.g. due to movement/stunned).<br/>
+      <li>You spent <b>${formatPercentage(this.activeTimePercentage)}%</b> of your time casting something.</li>
+      <li>You spent <b>${formatPercentage(this.downtimePercentage)}%</b> of your time casting nothing at all.</li>
+      `}
+      footer={(
+        <div className="statistic-bar">
+          <div
+            className="stat-health-bg"
+            style={{ width: `${this.activeTimePercentage * 100}%` }}
+            data-tip={`You spent <b>${formatPercentage(this.activeTimePercentage)}%</b> of your time casting something.`}
+          >
+            <img src={this.constructor.icons.activeTime} alt="Active time" />
           </div>
-        )}
-        footerStyle={{ overflow: 'hidden' }}
-      />
+          <div
+            className="remainder DeathKnight-bg"
+            data-tip={`You spent <b>${formatPercentage(this.downtimePercentage)}%</b> of your time casting nothing at all.`}
+          >
+            <img src={this.constructor.icons.downtime} alt="Downtime" />
+          </div>
+        </div>
+      )}
+      footerStyle={{ overflow: 'hidden' }}
+    />
     );
   }
+
   statisticOrder = STATISTIC_ORDER.CORE(10);
 }
 

--- a/src/Parser/Core/Modules/AlwaysBeCasting.js
+++ b/src/Parser/Core/Modules/AlwaysBeCasting.js
@@ -177,35 +177,35 @@ class AlwaysBeCasting extends Analyzer {
       return null;
     }
 
-    return (
-    <StatisticBox
-      icon={<Icon icon="spell_mage_altertime" alt="Downtime" />}
-      value={`${formatPercentage(this.downtimePercentage)} %`}
-      label="Downtime"
-      tooltip={`Downtime is available time not used to cast anything (including not having your GCD rolling). This can be caused by delays between casting spells, latency, cast interrupting or just simply not casting anything (e.g. due to movement/stunned).<br/>
-      <li>You spent <b>${formatPercentage(this.activeTimePercentage)}%</b> of your time casting something.</li>
-      <li>You spent <b>${formatPercentage(this.downtimePercentage)}%</b> of your time casting nothing at all.</li>
-      `}
-      footer={(
-        <div className="statistic-bar">
-          <div
-            className="stat-health-bg"
-            style={{ width: `${this.activeTimePercentage * 100}%` }}
-            data-tip={`You spent <b>${formatPercentage(this.activeTimePercentage)}%</b> of your time casting something.`}
-          >
-            <img src={this.constructor.icons.activeTime} alt="Active time" />
+      return (
+      <StatisticBox
+        icon={<Icon icon="spell_mage_altertime" alt="Downtime" />}
+        value={`${formatPercentage(this.downtimePercentage)} %`}
+        label="Downtime"
+        tooltip={`Downtime is available time not used to cast anything (including not having your GCD rolling). This can be caused by delays between casting spells, latency, cast interrupting or just simply not casting anything (e.g. due to movement/stunned).<br/>
+        <li>You spent <b>${formatPercentage(this.activeTimePercentage)}%</b> of your time casting something.</li>
+        <li>You spent <b>${formatPercentage(this.downtimePercentage)}%</b> of your time casting nothing at all.</li>
+        `}
+        footer={(
+          <div className="statistic-bar">
+            <div
+              className="stat-health-bg"
+              style={{ width: `${this.activeTimePercentage * 100}%` }}
+              data-tip={`You spent <b>${formatPercentage(this.activeTimePercentage)}%</b> of your time casting something.`}
+            >
+              <img src={this.constructor.icons.activeTime} alt="Active time" />
+            </div>
+            <div
+              className="remainder DeathKnight-bg"
+              data-tip={`You spent <b>${formatPercentage(this.downtimePercentage)}%</b> of your time casting nothing at all.`}
+            >
+              <img src={this.constructor.icons.downtime} alt="Downtime" />
+            </div>
           </div>
-          <div
-            className="remainder DeathKnight-bg"
-            data-tip={`You spent <b>${formatPercentage(this.downtimePercentage)}%</b> of your time casting nothing at all.`}
-          >
-            <img src={this.constructor.icons.downtime} alt="Downtime" />
-          </div>
-        </div>
-      )}
-      footerStyle={{ overflow: 'hidden' }}
-    />
-    );
+        )}
+        footerStyle={{ overflow: 'hidden' }}
+      />
+      );
   }
 
   statisticOrder = STATISTIC_ORDER.CORE(10);

--- a/src/Parser/Core/Modules/Features/WarningDisplay.js
+++ b/src/Parser/Core/Modules/Features/WarningDisplay.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import Analyzer from 'Parser/Core/Analyzer';
+
+class WarningDisplay extends Analyzer {
+
+  render() {
+    const boss = this.owner.boss;
+    if (boss && boss.fight.displayAccuracyWarning) {
+      return (
+        <div className="panel">
+          <div className="panel-heading">
+            <h2>
+                Warning
+            </h2>
+          </div>
+          <div className="panel-body" style={{ padding: 0 }}>
+            <div className="flex wrapable text-left" style={{ margin: '10px 30px 10px 30px' }}>
+                <h5>
+                  Because of the way this encounter was designed, some statistics and suggestions may be inaccurate. Therefore it is recommended that you do not use this encounter as a guide for improving your overall play, and that you instead use these statistics and suggestions to compare yourself against other members of your raid and for improving your play for this encounter specifically.
+                </h5>
+            </div>
+            <div style={{ background: 'rgba(255, 255, 255, 0.2)', height: 1 }} />
+          </div>
+        </div>
+      );
+    }
+  }
+}
+
+export default WarningDisplay;

--- a/src/Parser/Core/Modules/Features/WarningDisplay.js
+++ b/src/Parser/Core/Modules/Features/WarningDisplay.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
+import WarningIcon from 'Icons/Warning';
 
 class WarningDisplay extends Analyzer {
 
@@ -8,17 +9,17 @@ class WarningDisplay extends Analyzer {
     const boss = this.owner.boss;
     if (boss && boss.fight.displayAccuracyWarning) {
       return (
-        <div className="panel">
-          <div className="panel-heading">
-            <h2>
-                Warning
-            </h2>
-          </div>
-          <div className="panel-body" style={{ padding: 0 }}>
-            <div className="flex wrapable text-left" style={{ margin: '10px 30px 10px 30px' }}>
-                <h5>
-                  Because of the way this encounter was designed, some statistics and suggestions may be inaccurate. Therefore it is recommended that you do not use this encounter as a guide for improving your overall play, and that you instead use these statistics and suggestions to compare yourself against other members of your raid and for improving your play for this encounter specifically.
-                </h5>
+        <div>
+          <div style={{ padding: 0 }}>
+            <div className="flex-sub content-middle" style={{ margin: '10px 30px 10px 30px', color: '#D9A730', opacity: 0.8 }}>
+                <div style={{ fontSize: '4em', lineHeight: 1, marginRight: 20 }}>
+                  <WarningIcon />
+                </div>
+                <div>
+                  <h5>
+                    Because of the way this encounter was designed, some statistics and suggestions may be inaccurate. Therefore it is recommended that you do not use this encounter as a guide for improving your overall play, and that you instead use these statistics and suggestions to compare yourself against other members of your raid and for improving your play for this encounter specifically.
+                  </h5>
+                </div>
             </div>
             <div style={{ background: 'rgba(255, 255, 255, 0.2)', height: 1 }} />
           </div>

--- a/src/Parser/Core/Modules/Features/WarningDisplay.js
+++ b/src/Parser/Core/Modules/Features/WarningDisplay.js
@@ -7,18 +7,16 @@ class WarningDisplay extends Analyzer {
 
   render() {
     const boss = this.owner.boss;
-    if (boss && boss.fight.displayAccuracyWarning) {
+    if (boss && boss.fight.displayWarning) {
       return (
         <div>
           <div style={{ padding: 0 }}>
-            <div className="flex-sub content-middle" style={{ margin: '10px 30px 10px 30px', color: '#FC9F06', opacity: 0.8 }}>
-                <div style={{ fontSize: '4em', lineHeight: 1, marginRight: 20 }}>
+            <div className="flex-sub content-middle" style={{ margin: '0px 30px 0px 0px', color: '#FFA100', opacity: 0.8 }}>
+                <div style={{ fontSize: '5.5em', lineHeight: 1, marginRight: 10, marginLeft: 10 }}>
                   <WarningIcon />
                 </div>
                 <div>
-                  <h5>
-                    Because of the way this encounter was designed, some statistics and suggestions may be inaccurate. Therefore it is recommended that you do not use this encounter as a guide for improving your overall play, and that you instead use these statistics and suggestions to compare yourself against other members of your raid and for improving your play for this encounter specifically.
-                  </h5>
+                  {boss.fight.displayWarning}
                 </div>
             </div>
             <div style={{ background: 'rgba(255, 255, 255, 0.2)', height: 1 }} />

--- a/src/Parser/Core/Modules/Features/WarningDisplay.js
+++ b/src/Parser/Core/Modules/Features/WarningDisplay.js
@@ -11,7 +11,7 @@ class WarningDisplay extends Analyzer {
       return (
         <div>
           <div style={{ padding: 0 }}>
-            <div className="flex-sub content-middle" style={{ margin: '10px 30px 10px 30px', color: '#D9A730', opacity: 0.8 }}>
+            <div className="flex-sub content-middle" style={{ margin: '10px 30px 10px 30px', color: '#FC9F06', opacity: 0.8 }}>
                 <div style={{ fontSize: '4em', lineHeight: 1, marginRight: 20 }}>
                   <WarningIcon />
                 </div>

--- a/src/Parser/Mage/Fire/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Mage/Fire/Modules/Features/AlwaysBeCasting.js
@@ -35,14 +35,16 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
   suggestions(when) {
     const deadTimePercentage = this.totalTimeWasted / this.owner.fightDuration;
 
-    when(deadTimePercentage).isGreaterThan(0.2)
-      .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span>Your downtime can be improved. Try to Always Be Casting (ABC), try to reduce the delay between casting spells. If you have to move, try casting <SpellLink id={SPELLS.SCORCH.id} />.</span>)
-          .icon('spell_mage_altertime')
-          .actual(`${formatPercentage(actual)}% downtime`)
-          .recommended(`<${formatPercentage(recommended)}% is recommended`)
-          .regular(recommended + 0.15).major(recommended + 0.2);
-      });
+    if (this.owner.boss.fight.noDowntimeSuggestion !== true) {
+      when(deadTimePercentage).isGreaterThan(0.2)
+        .addSuggestion((suggest, actual, recommended) => {
+          return suggest(<span>Your downtime can be improved. Try to Always Be Casting (ABC), try to reduce the delay between casting spells. If you have to move, try casting <SpellLink id={SPELLS.SCORCH.id} />.</span>)
+            .icon('spell_mage_altertime')
+            .actual(`${formatPercentage(actual)}% downtime`)
+            .recommended(`<${formatPercentage(recommended)}% is recommended`)
+            .regular(recommended + 0.15).major(recommended + 0.2);
+        });
+    }
   }
 
   statisticOrder = STATISTIC_ORDER.CORE(1);

--- a/src/Parser/Mage/Fire/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Mage/Fire/Modules/Features/AlwaysBeCasting.js
@@ -34,8 +34,9 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
 
   suggestions(when) {
     const deadTimePercentage = this.totalTimeWasted / this.owner.fightDuration;
+    const boss = this.owner.boss;
 
-    if (this.owner.boss.fight.noDowntimeSuggestion !== true) {
+    if (!boss || !boss.fight.disableDowntimeSuggestion) {
       when(deadTimePercentage).isGreaterThan(0.2)
         .addSuggestion((suggest, actual, recommended) => {
           return suggest(<span>Your downtime can be improved. Try to Always Be Casting (ABC), try to reduce the delay between casting spells. If you have to move, try casting <SpellLink id={SPELLS.SCORCH.id} />.</span>)

--- a/src/Parser/Mage/Frost/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Mage/Frost/Modules/Features/AlwaysBeCasting.js
@@ -49,8 +49,8 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
 
   suggestions(when) {
     const deadTimePercentage = this.totalTimeWasted / this.owner.fightDuration;
-
-    if (this.owner.boss.fight.noDowntimeSuggestion !== true) {
+    const boss = this.owner.boss;
+    if (!boss || !boss.fight.disableDowntimeSuggestion) {
       when(deadTimePercentage).isGreaterThan(this.downtimeSuggestionThresholds.isGreaterThan.minor)
         .addSuggestion((suggest, actual, recommended) => {
           return suggest(<span>Your downtime can be improved. Try to Always Be Casting (ABC), try to reduce the delay between casting spells. Even if you have to move, try casting instants, even unbuffed <SpellLink id={SPELLS.ICE_LANCE.id} /> spam is better than nothing.</span>)

--- a/src/Parser/Mage/Frost/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Mage/Frost/Modules/Features/AlwaysBeCasting.js
@@ -50,14 +50,16 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
   suggestions(when) {
     const deadTimePercentage = this.totalTimeWasted / this.owner.fightDuration;
 
-    when(deadTimePercentage).isGreaterThan(this.downtimeSuggestionThresholds.isGreaterThan.minor)
-      .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span>Your downtime can be improved. Try to Always Be Casting (ABC), try to reduce the delay between casting spells. Even if you have to move, try casting instants, even unbuffed <SpellLink id={SPELLS.ICE_LANCE.id} /> spam is better than nothing.</span>)
-          .icon('spell_mage_altertime')
-          .actual(`${formatPercentage(actual)}% downtime`)
-          .recommended(`<${formatPercentage(recommended)}% is recommended`)
-          .regular(this.downtimeSuggestionThresholds.isGreaterThan.average).major(this.downtimeSuggestionThresholds.isGreaterThan.major);
-      });
+    if (this.owner.boss.fight.noDowntimeSuggestion !== true) {
+      when(deadTimePercentage).isGreaterThan(this.downtimeSuggestionThresholds.isGreaterThan.minor)
+        .addSuggestion((suggest, actual, recommended) => {
+          return suggest(<span>Your downtime can be improved. Try to Always Be Casting (ABC), try to reduce the delay between casting spells. Even if you have to move, try casting instants, even unbuffed <SpellLink id={SPELLS.ICE_LANCE.id} /> spam is better than nothing.</span>)
+            .icon('spell_mage_altertime')
+            .actual(`${formatPercentage(actual)}% downtime`)
+            .recommended(`<${formatPercentage(recommended)}% is recommended`)
+            .regular(this.downtimeSuggestionThresholds.isGreaterThan.average).major(this.downtimeSuggestionThresholds.isGreaterThan.major);
+        });
+    }
   }
 
   statisticOrder = STATISTIC_ORDER.CORE(1);

--- a/src/Raids/AntorusTheBurningThrone/EonarLifebinder.js
+++ b/src/Raids/AntorusTheBurningThrone/EonarLifebinder.js
@@ -8,7 +8,7 @@ export default {
   headshot: Headshot,
   fight: {
     vantusRuneBuffId: 250150,
-    displayAccuracyWarning: true,
+    displayWarning: 'Because of the way this encounter was designed, some statistics and suggestions may be inaccurate. Therefore this encounter is not recommended for improving overall play. Instead use this encounter for improving on this encounter only',
     disableDowntimeSuggestion: true,
     // TODO: Add fight specific props
     // e.g. baseDowntime (seconds, percentage, based on (de)buff, etc)

--- a/src/Raids/AntorusTheBurningThrone/EonarLifebinder.js
+++ b/src/Raids/AntorusTheBurningThrone/EonarLifebinder.js
@@ -8,7 +8,7 @@ export default {
   headshot: Headshot,
   fight: {
     vantusRuneBuffId: 250150,
-    disableDowntimeStatistic: true,
+    displayAccuracyWarning: true,
     disableDowntimeSuggestion: true,
     // TODO: Add fight specific props
     // e.g. baseDowntime (seconds, percentage, based on (de)buff, etc)

--- a/src/Raids/AntorusTheBurningThrone/EonarLifebinder.js
+++ b/src/Raids/AntorusTheBurningThrone/EonarLifebinder.js
@@ -8,6 +8,7 @@ export default {
   headshot: Headshot,
   fight: {
     vantusRuneBuffId: 250150,
+    noDowntimeSuggestion: true,
     // TODO: Add fight specific props
     // e.g. baseDowntime (seconds, percentage, based on (de)buff, etc)
     // e.g. ads

--- a/src/Raids/AntorusTheBurningThrone/EonarLifebinder.js
+++ b/src/Raids/AntorusTheBurningThrone/EonarLifebinder.js
@@ -8,7 +8,7 @@ export default {
   headshot: Headshot,
   fight: {
     vantusRuneBuffId: 250150,
-    displayWarning: 'Because of the way this encounter was designed, some statistics and suggestions may be inaccurate. Therefore this encounter is not recommended for improving overall play. Instead use this encounter for improving on this encounter only',
+    displayWarning: 'Because of the way this encounter was designed, some statistics and suggestions may be inaccurate. Therefore this encounter is not recommended for improving overall play. Instead you should use this encounter for improving on this encounter only.',
     disableDowntimeSuggestion: true,
     // TODO: Add fight specific props
     // e.g. baseDowntime (seconds, percentage, based on (de)buff, etc)

--- a/src/Raids/AntorusTheBurningThrone/EonarLifebinder.js
+++ b/src/Raids/AntorusTheBurningThrone/EonarLifebinder.js
@@ -8,7 +8,8 @@ export default {
   headshot: Headshot,
   fight: {
     vantusRuneBuffId: 250150,
-    noDowntimeSuggestion: true,
+    disableDowntimeStatistic: true,
+    disableDowntimeSuggestion: true,
     // TODO: Add fight specific props
     // e.g. baseDowntime (seconds, percentage, based on (de)buff, etc)
     // e.g. ads


### PR DESCRIPTION
This uses the new boss fight settings to disable the Downtime StatisticBox/Suggestion for Eonar since the stat is pretty useless on that fight.

This is just the first of some other boss specific settings that I think will help. Part of Issue #391