### PR TITLE
Added ISB-tracking checklist items for Brewmasters

### DIFF
--- a/src/MAINTAINERS.js
+++ b/src/MAINTAINERS.js
@@ -165,3 +165,7 @@ export const hatra344 = {
   nickname: 'hatra344',
   github: 'hatra344',
 };
+export const emallson = {
+  nickname: 'emallson',
+  github: 'emallson',
+};

--- a/src/Parser/Monk/Brewmaster/CHANGELOG.js
+++ b/src/Parser/Monk/Brewmaster/CHANGELOG.js
@@ -1,11 +1,16 @@
 import React from 'react';
-import { WOPR, Zerotorescue } from 'MAINTAINERS';
+import { WOPR, Zerotorescue, emallson } from 'MAINTAINERS';
 
 export default [
   {
     date: new Date('3000-01-01'),
     changes: <span style={{ color: 'red' }}>Changed completion status to <i>Not actively maintained</i> as @wopr resigned. Any help is welcome to continue support for this spec, see GitHub for more information.</span>,
     contributors: [Zerotorescue],
+  },
+  {
+    date: new Date('2017-12-24'),
+    changes: 'Added ISB uptime and clipping checklist items.',
+    contributors: [emallson],
   },
   {
     date: new Date('2017-08-24'),

--- a/src/Parser/Monk/Brewmaster/Modules/Features/Checklist.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/Checklist.js
@@ -2,11 +2,11 @@ import React from 'react';
 
 import Wrapper from 'common/Wrapper';
 import SPELLS from 'common/SPELLS';
-import ITEMS from 'common/ITEMS';
+// import ITEMS from 'common/ITEMS';
 import SpellLink from 'common/SpellLink';
-import ItemLink from 'common/ItemLink';
+// import ItemLink from 'common/ItemLink';
 
-import CoreChecklist, { Rule, Requirement, GenericCastEfficiencyRequirement } from 'Parser/Core/Modules/Features/Checklist';
+import CoreChecklist, { Rule, Requirement /*, GenericCastEfficiencyRequirement */ } from 'Parser/Core/Modules/Features/Checklist';
 import IronSkinBrew from '../Spells/IronSkinBrew';
 
 class Checklist extends CoreChecklist {
@@ -29,7 +29,7 @@ class Checklist extends CoreChecklist {
       requirements: () => {
         return [
           new Requirement({
-            name: '>98% of hits mitigated',
+            name: 'Hits mitigated with ISB',
             check: () => this.isb.suggestionThreshold,
           }),
         ];
@@ -49,10 +49,10 @@ class Checklist extends CoreChecklist {
       requirements: () => {
         return [
           new Requirement({
-            name: '<5% of duration lost due to clipping',
+            name: 'ISB duration lost due to clipping',
             check: () => this.isb.clipSuggestionThreshold,
-          })
-        ]
+          }),
+        ];
       },
     }),
   ];

--- a/src/Parser/Monk/Brewmaster/Modules/Features/Checklist.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/Checklist.js
@@ -1,18 +1,60 @@
-// import React from 'react';
+import React from 'react';
 
-// import Wrapper from 'common/Wrapper';
-// import SPELLS from 'common/SPELLS';
-// import ITEMS from 'common/ITEMS';
-// import SpellLink from 'common/SpellLink';
-// import ItemLink from 'common/ItemLink';
+import Wrapper from 'common/Wrapper';
+import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
+import SpellLink from 'common/SpellLink';
+import ItemLink from 'common/ItemLink';
 
-import CoreChecklist, { /*Rule, Requirement, GenericCastEfficiencyRequirement*/ } from 'Parser/Core/Modules/Features/Checklist';
+import CoreChecklist, { Rule, Requirement, GenericCastEfficiencyRequirement } from 'Parser/Core/Modules/Features/Checklist';
+import IronSkinBrew from '../Spells/IronSkinBrew';
 
 class Checklist extends CoreChecklist {
   static dependencies = {
+    isb: IronSkinBrew,
   };
 
   rules = [
+    new Rule({
+      name: (
+        <Wrapper>
+          Maintain 100% uptime on <SpellLink id={SPELLS.IRONSKIN_BREW.id} icon />.
+        </Wrapper>
+      ),
+      description: (
+        <Wrapper>
+          <SpellLink id={SPELLS.STAGGER.id} /> is our main damage mitigation tool. <SpellLink id={SPELLS.IRONSKIN_BREW.id} icon /> increases the amount of damage that we can mitigate with Stagger while active. It is possible to maintain 100% uptime without reaching any particular haste threshold due to the cooldown reduction applied by <SpellLink id={SPELLS.KEG_SMASH.id} icon /> and <SpellLink id={SPELLS.TIGER_PALM.id} icon />. If you are having difficulty maintaining your buff, you may need to improve your cast efficiency or reduce the amount of purification you are doing.
+        </Wrapper>
+      ),
+      requirements: () => {
+        return [
+          new Requirement({
+            name: '>98% of hits mitigated',
+            check: () => this.isb.suggestionThreshold,
+          }),
+        ];
+      },
+    }),
+    new Rule({
+      name: (
+        <Wrapper>Avoid clipping the <SpellLink id={SPELLS.IRONSKIN_BREW.id} icon/> buff.</Wrapper>
+      ),
+      description: (
+        <Wrapper>
+          The duration of the <SpellLink id={SPELLS.IRONSKIN_BREW.id} icon /> buff is capped at 3 times the duration of the buff. Avoid casting ISB when you are near this cap, as doing so wastes much of the duration of the buff (called 'clipping' the buff). A WeakAura can help track this duration cap.
+
+          If doing so will not cause the ISB buff to expire, spend excess brew charges on <SpellLink id={SPELLS.PURIFYING_BREW.id} icon /> to remove damage from the Stagger pool.
+        </Wrapper>
+      ),
+      requirements: () => {
+        return [
+          new Requirement({
+            name: '<5% of duration lost due to clipping',
+            check: () => this.isb.clipSuggestionThreshold,
+          })
+        ]
+      },
+    }),
   ];
 }
 

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/IronSkinBrew.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/IronSkinBrew.js
@@ -56,7 +56,6 @@ class IronSkinBrew extends Analyzer {
         this.durationLost += this.currentDuration - this.durationCap;
         this.currentDuration = this.durationCap;
       }
-      console.log(`ISB buff applied: ${this.currentDuration}`);
       // add this duration to the total duration
       this.totalDuration += addedDuration;
       this.lastDurationCheck = event.timestamp;

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/IronSkinBrew.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/IronSkinBrew.js
@@ -21,6 +21,48 @@ class IronSkinBrew extends Analyzer {
   hitsWithoutIronSkinBrew = 0;
   damageWithoutIronSkinBrew = 0;
 
+  // duration tracking to record clipping of buff
+  lastDurationCheck = 0;
+  totalDuration = 0;
+  durationLost = 0;
+  currentDuration = 0;
+  durationPerCast = 6000; // base
+  durationPerPurify = 0;
+  durationCap = -1;
+
+  on_initialized() {
+    this.durationPerCast += 500 * this.combatants.selected.traitsBySpellId[SPELLS.POTENT_KICK.id];
+    this.durationCap = 3 * this.durationPerCast;
+    this.durationPerPurify = 1000 * this.combatants.selected.traitsBySpellId[SPELLS.QUICK_SIP.id];
+  }
+
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    if (SPELLS.IRONSKIN_BREW.id === spellId || SPELLS.PURIFYING_BREW.id === spellId) {
+      // determine the current duration on ISB
+      if (this.currentDuration > 0) {
+        this.currentDuration -= event.timestamp - this.lastDurationCheck;
+        this.currentDuration = Math.max(this.currentDuration, 0);
+      }
+      // add the duration from this buff application (?)
+      let addedDuration = 0;
+      if (SPELLS.IRONSKIN_BREW.id === spellId) {
+        addedDuration = this.durationPerCast;
+      } else if (SPELLS.PURIFYING_BREW.id === spellId) {
+        addedDuration = this.durationPerPurify;
+      }
+      this.currentDuration += addedDuration;
+      if (this.currentDuration > this.durationCap) {
+        this.durationLost += this.currentDuration - this.durationCap;
+        this.currentDuration = this.durationCap;
+      }
+      console.log(`ISB buff applied: ${this.currentDuration}`);
+      // add this duration to the total duration
+      this.totalDuration += addedDuration;
+      this.lastDurationCheck = event.timestamp;
+    }
+  }
+
   on_byPlayer_applybuff(event) {
     const spellId = event.ability.guid;
     if (SPELLS.IRONSKIN_BREW_BUFF.id === spellId) {
@@ -32,6 +74,7 @@ class IronSkinBrew extends Analyzer {
     const spellId = event.ability.guid;
     if (SPELLS.IRONSKIN_BREW_BUFF.id === spellId) {
       this.lastIronSkinBrewBuffApplied = 0;
+      this.currentDuration = 0;
     }
   }
 
@@ -80,6 +123,30 @@ class IronSkinBrew extends Analyzer {
       });
   }
 
+  get suggestionThreshold() {
+    return {
+      actual: this.hitsWithIronSkinBrew / (this.hitsWithIronSkinBrew + this.hitsWithoutIronSkinBrew),
+      isLessThan: {
+        minor: 0.99,
+        average: 0.98,
+        major: 0.95,
+      },
+      style: 'percentage',
+    };
+  }
+
+  get clipSuggestionThreshold() {
+    return {
+      actual: this.durationLost / this.totalDuration,
+      isGreaterThan: {
+        minor: 0.02,
+        average: 0.05,
+        major: 0.1,
+      },
+      style: 'percentage',
+    };
+  }
+
   statistic() {
     const isbUptime = this.combatants.selected.getBuffUptime(SPELLS.IRONSKIN_BREW_BUFF.id) / this.owner.fightDuration;
     const hitsMitigatedPercent = this.hitsWithIronSkinBrew / (this.hitsWithIronSkinBrew + this.hitsWithoutIronSkinBrew);
@@ -94,7 +161,7 @@ class IronSkinBrew extends Analyzer {
                 <li>You were hit <b>${this.hitsWithoutIronSkinBrew}</b> times <b><i>without</i></b> your Ironskin Brew buff (<b>${formatThousands(this.damageWithoutIronSkinBrew)}</b> damage).</li>
             </ul>
             <b>${formatPercentage(hitsMitigatedPercent)}%</b> of attacks were mitigated with Ironskin Brew.`}
-      />
+          />
     );
   }
   statisticOrder = STATISTIC_ORDER.OPTIONAL();

--- a/src/common/SPELLS/MONK.js
+++ b/src/common/SPELLS/MONK.js
@@ -509,6 +509,16 @@ export default {
     name: 'Blackout Combo',
     icon: 'ability_monk_blackoutkick',
   },
+  POTENT_KICK: {
+      id: 213047,
+      name: 'Potent Kick',
+      icon: 'ability_monk_ironskinbrew',
+  },
+  QUICK_SIP: {
+      id: 238129,
+      name: 'Quick Sip',
+      icon: 'spell_misc_drink',
+  },
 
   // Windwalker Spells
   COMBO_STRIKES: {
@@ -696,15 +706,5 @@ export default {
     id: 252768,
     name: 'Focus of Xuen',
     icon: 'ability_monk_roundhousekick',
-  },
-  POTENT_KICK: {
-      id: 213047,
-      name: 'Potent Kick',
-      icon: 'ability_monk_ironskinbrew',
-  },
-  QUICK_SIP: {
-      id: 238129,
-      name: 'Quick Sip',
-      icon: 'spell_misc_drink',
   },
 };

--- a/src/common/SPELLS/MONK.js
+++ b/src/common/SPELLS/MONK.js
@@ -697,4 +697,14 @@ export default {
     name: 'Focus of Xuen',
     icon: 'ability_monk_roundhousekick',
   },
+  POTENT_KICK: {
+      id: 213047,
+      name: 'Potent Kick',
+      icon: 'ability_monk_ironskinbrew',
+  },
+  QUICK_SIP: {
+      id: 238129,
+      name: 'Quick Sip',
+      icon: 'spell_misc_drink',
+  },
 };


### PR DESCRIPTION
This PR introduces two checklist items that track the use of Ironskin Brew for Brewmaster Monks. These checklist items give an at-a-glance view of:

1. The percentage of hits mitigated via Ironskin Brew (100% is the goal, in practice 99%+ is obtainable). Discounting fights with a large number of negligible hits while not actively tanking (which don't exist in the current relevant tiers as far as I know), this takes into account time not actively tanking better than a simple uptime check. The high requirements on uptime are set because having ISB inactive (ever) while actively tanking can easily result in a dead tank.

2. The amount of duration wasted by over-capping the ISB buff. Most (all?) tank AM buffs have a cap of 3x the duration of a single application of a buff (taking into account traits that increase the duration,  ie Potent Kick in this case). I added code to track the amount of duration lost by exceeding this cap. Ideally, none will be wasted.

The first item is the first thing checked in the Brewmaster discord when someone asks a damage-intake-related-question. The second item supports diagnosing the cause of low uptime.

(I am `emallson` on the brm discord if anyone cares to double-check or discuss numbers there; haven't joined the WoWAnalyzer discord yet but it'll be the same name when I do.)