### PR TITLE
[Core] adds the 5 wod cloak enchants to the max enchant checker

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -9,6 +9,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2017-12-26'),
+    changes: 'Mark the Warlords of Draenor cloak enchants as a part of the good enchants',
+    contributors: [Putro],
+  },
+  {
     date: new Date('2017-12-25'),
     changes: <Wrapper>Added a <i>casting time</i> bar to the spell timeline that shows you the amount of time spent channeling or waiting for the GCD.</Wrapper>,
     contributors: [Zerotorescue],

--- a/src/Parser/Core/Modules/Items/EnchantChecker.js
+++ b/src/Parser/Core/Modules/Items/EnchantChecker.js
@@ -46,7 +46,7 @@ class EnchantChecker extends Analyzer {
     5311, //gift of haste
     5312, //gift of mastery
     5313, //gift of critical strike 2
-    5314, //gift of versatility 
+    5314, //gift of versatility
   ];
 
   get enchantableGear() {

--- a/src/Parser/Core/Modules/Items/EnchantChecker.js
+++ b/src/Parser/Core/Modules/Items/EnchantChecker.js
@@ -39,6 +39,14 @@ class EnchantChecker extends Analyzer {
     5428, // binding of haste
     5429, // binding of mastery
     5430, // binding of versatility
+
+    //some specs use warlords enchants because they're better than Legion ones currently
+    //if people are using them, it should be because they know they're better
+    5310, //gift of critical strike
+    5311, //gift of haste
+    5312, //gift of mastery
+    5313, //gift of critical strike 2
+    5314, //gift of versatility 
   ];
 
   get enchantableGear() {


### PR DESCRIPTION
Some specs use the Warlords cloak enchants these days, due to the massive power disparity between secondary and primary stats.

See my character:
https://worldofwarcraft.com/en-gb/character/ragnaros/putro

My assumption is that people who use warlords enchants know that it's the best for them specifically (I hope)