### PR TITLE
[Frost Mage] Fix for Magtheridon's Banished Bracers

### DIFF
--- a/src/Parser/Mage/Frost/Modules/Items/MagtheridonsBanishedBracers.js
+++ b/src/Parser/Mage/Frost/Modules/Items/MagtheridonsBanishedBracers.js
@@ -19,19 +19,12 @@ class MagtheridonsBanishedBracers extends Analyzer {
     this.active = this.combatants.selected.hasWrists(ITEMS.MAGTHERIDONS_BANISHED_BRACERS.id);
   }
 
-  on_byPlayer_cast(event) {
-    if (event.ability.guid !== SPELLS.ICE_LANCE.id) {
-      return;
-    }
-    const buff = this.combatants.selected.getBuff(SPELLS.MAGTHERIDONS_MIGHT_BUFF.id);
-    this.stackCount = (buff && buff.stacks) || 0;
-  }
-
   on_byPlayer_damage(event) {
     if (event.ability.guid !== SPELLS.ICE_LANCE_DAMAGE.id) {
       return;
     }
-      this.damage += getDamageBonus(event, DAMAGE_BONUS * this.stackCount);
+      const buff = this.combatants.selected.getBuff(SPELLS.MAGTHERIDONS_MIGHT_BUFF.id);
+      this.damage += getDamageBonus(event, DAMAGE_BONUS * buff.stacks);
   }
 
   item() {


### PR DESCRIPTION
Magtheridon's Banished Bracers' buff stacks after the spell is cast, not when it hits.