### PR TITLE
[BrM Monk] Replaced CD-based RJW suggestion with uptime-based suggestion

### DIFF
--- a/src/Parser/Monk/Brewmaster/CHANGELOG.js
+++ b/src/Parser/Monk/Brewmaster/CHANGELOG.js
@@ -2,6 +2,11 @@ import { WOPR, emallson } from 'MAINTAINERS';
 
 export default [
   {
+    date: new Date('2017-12-29'),
+    changes: 'Changed RJW suggestion from cast efficiency to uptime.',
+    contributors: [emallson],
+  },
+  {
     date: new Date('2017-12-24'),
     changes: 'Added ISB uptime and clipping checklist items.',
     contributors: [emallson],

--- a/src/Parser/Monk/Brewmaster/CombatLogParser.js
+++ b/src/Parser/Monk/Brewmaster/CombatLogParser.js
@@ -9,6 +9,7 @@ import StaggerFabricator from './Modules/Core/StaggerFabricator';
 // Spells
 import IronSkinBrew from './Modules/Spells/IronSkinBrew';
 import BlackoutCombo from './Modules/Spells/BlackoutCombo';
+import RushingJadeWind from './Modules/Spells/RushingJadeWind';
 // Features
 import Checklist from './Modules/Features/Checklist';
 import Abilities from './Modules/Features/Abilities';
@@ -37,6 +38,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Spells
     ironSkinBrew: IronSkinBrew,
     blackoutCombo: BlackoutCombo,
+    rjw: RushingJadeWind,
 
     // Items
     t20_2pc: T20_2pc,

--- a/src/Parser/Monk/Brewmaster/Modules/Core/StaggerFabricator.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/StaggerFabricator.js
@@ -20,7 +20,7 @@ export const EVENT_STAGGER_POOL_REMOVED = "removestagger";
 class StaggerFabricator extends Analyzer {
   static dependencies = {
     combatants: Combatants,
-  }
+  };
 
   // causes an orb consumption to clear 5% of stagger
   _hasTier20_4pc = false;

--- a/src/Parser/Monk/Brewmaster/Modules/Features/Abilities.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/Abilities.js
@@ -35,6 +35,7 @@ class Abilities extends CoreAbilities {
       category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
       getCooldown: haste => 6 / (1 + haste),
       isActive: combatant => combatant.hasTalent(SPELLS.RUSHING_JADE_WIND_TALENT.id),
+      noSuggestion: true,
     },
     {
       spell: SPELLS.CRACKLING_JADE_LIGHTNING,

--- a/src/Parser/Monk/Brewmaster/Modules/Normalizers/IronskinBrew.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Normalizers/IronskinBrew.js
@@ -37,10 +37,10 @@ class IronskinBrew extends EventsNormalizer {
       const targetID = event.targetID;
       const spellId = event.ability ? event.ability.guid : null;
 
-      if(event.type === "cast" && SPELLS.IRONSKIN_BREW.id === spellId) {
+      if(event.type === "cast" && spellId === SPELLS.IRONSKIN_BREW.id) {
         isbCasts[sourceID] = isbCasts[sourceID] ? isbCasts[sourceID] : [];
         isbCasts[sourceID].push(event);
-      } else if(["applybuff", "refreshbuff", "removebuff"].includes(event.type) && SPELLS.IRONSKIN_BREW_BUFF.id === spellId) {
+      } else if(["applybuff", "refreshbuff", "removebuff"].includes(event.type) && spellId === SPELLS.IRONSKIN_BREW_BUFF.id) {
         isbBuffs[targetID] = isbBuffs[targetID] ? isbBuffs[targetID] : [];
         isbBuffs[targetID].push(event);
         isbBuffAbility = isbBuffAbility ? isbBuffAbility : event.ability;

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/BlackoutCombo.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/BlackoutCombo.js
@@ -28,7 +28,7 @@ class BlackoutCombo extends Analyzer {
 
   on_byPlayer_applybuff(event) {
     const spellId = event.ability.guid;
-    if (SPELLS.BLACKOUT_COMBO_BUFF.id === spellId) {
+    if (spellId === SPELLS.BLACKOUT_COMBO_BUFF.id) {
       debug && console.log('Blackout combo applied');
       this.blackoutComboBuffs += 1;
       this.lastBlackoutComboCast = event.timestamp;
@@ -37,7 +37,7 @@ class BlackoutCombo extends Analyzer {
 
   on_byPlayer_refreshbuff(event) {
     const spellId = event.ability.guid;
-    if (SPELLS.BLACKOUT_COMBO_BUFF.id === spellId) {
+    if (spellId === SPELLS.BLACKOUT_COMBO_BUFF.id) {
       debug && console.log('Blackout combo refreshed');
       this.blackoutComboBuffs += 1;
       this.lastBlackoutComboCast = event.timestamp;

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/IronSkinBrew.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/IronSkinBrew.js
@@ -38,7 +38,7 @@ class IronSkinBrew extends Analyzer {
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
-    if (SPELLS.IRONSKIN_BREW.id === spellId || SPELLS.PURIFYING_BREW.id === spellId) {
+    if (spellId === SPELLS.IRONSKIN_BREW.id || SPELLS.PURIFYING_BREW.id === spellId) {
       // determine the current duration on ISB
       if (this._currentDuration > 0) {
         this._currentDuration -= event.timestamp - this._lastDurationCheck;
@@ -46,9 +46,9 @@ class IronSkinBrew extends Analyzer {
       }
       // add the duration from this buff application (?)
       let addedDuration = 0;
-      if (SPELLS.IRONSKIN_BREW.id === spellId) {
+      if (spellId === SPELLS.IRONSKIN_BREW.id) {
         addedDuration = this._durationPerCast;
-      } else if (SPELLS.PURIFYING_BREW.id === spellId) {
+      } else if (spellId === SPELLS.PURIFYING_BREW.id) {
         addedDuration = this._durationPerPurify;
       }
       this._currentDuration += addedDuration;
@@ -64,14 +64,14 @@ class IronSkinBrew extends Analyzer {
 
   on_byPlayer_applybuff(event) {
     const spellId = event.ability.guid;
-    if (SPELLS.IRONSKIN_BREW_BUFF.id === spellId) {
+    if (spellId === SPELLS.IRONSKIN_BREW_BUFF.id) {
       this.lastIronSkinBrewBuffApplied = event.timestamp;
     }
   }
 
   on_byPlayer_removebuff(event) {
     const spellId = event.ability.guid;
-    if (SPELLS.IRONSKIN_BREW_BUFF.id === spellId) {
+    if (spellId === SPELLS.IRONSKIN_BREW_BUFF.id) {
       this.lastIronSkinBrewBuffApplied = 0;
       this._currentDuration = 0;
     }

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/RushingJadeWind.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/RushingJadeWind.js
@@ -4,8 +4,7 @@ import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
-
-const debug = false;
+import Wrapper from 'common/Wrapper';
 
 // the buff events all use this spell
 export const RUSHING_JADE_WIND_BUFF = SPELLS.RUSHING_JADE_WIND_TALENT; 
@@ -15,51 +14,17 @@ class RushingJadeWind extends Analyzer {
     combatants: Combatants,
   };
 
-  inactiveDuration = 0;
-  _lastDropped = 0;
-  _active = false;
-
   on_initialized() {
-    this._lastDropped = this.owner.fight.start_time;
     this.active = this.combatants.selected.hasTalent(SPELLS.RUSHING_JADE_WIND_TALENT.id);
-  }
-
-  on_byPlayer_applybuff(event) {
-    if(event.ability.guid === RUSHING_JADE_WIND_BUFF.id) {
-      this.inactiveDuration += event.timestamp - this._lastDropped;
-      this._active = true;
-      debug && console.log("RJW re-applied", event.timestamp, this.inactiveDuration);
-    }
-  }
-
-  on_byPlayer_removebuff(event) {
-    if(event.ability.guid === RUSHING_JADE_WIND_BUFF.id) {
-      this._lastDropped = event.timestamp;
-      this._active = false;
-      debug && console.log("RJW dropped", event.timestamp);
-    }
-  }
-
-  on_finished() {
-    if(!this._active) {
-      this.inactiveDuration += this.owner.fight.end_time - this._lastDropped;
-    }
-  }
-
-  get uptime() {
-    if(this.owner.fightDuration === 0) {
-      return 0;
-    }
-    const downtime = this.inactiveDuration / this.owner.fightDuration;
-    return 1.0 - downtime;
   }
 
   // using a suggestion rather than a checklist item for this as RJW is
   // purely offensive
   suggestions(when) {
-    when(this.uptime).isLessThan(0.95)
+    const uptime = this.combatants.selected.getBuffUptime(RUSHING_JADE_WIND_BUFF.id) / this.owner.fightDuration;
+    when(uptime).isLessThan(0.95)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span>You had low uptime on <SpellLink id={SPELLS.RUSHING_JADE_WIND.id} />. Try to maintain 100% uptime by refreshing the buff before it drops.</span>)
+        return suggest(<Wrapper>You had low uptime on <SpellLink id={SPELLS.RUSHING_JADE_WIND.id} />. Try to maintain 100% uptime by refreshing the buff before it drops.</Wrapper>)
           .icon(SPELLS.RUSHING_JADE_WIND.icon)
           .actual(`${formatPercentage(actual)}% uptime`)
           .recommended(`${Math.round(formatPercentage(recommended))}% is recommended`)

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/RushingJadeWind.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/RushingJadeWind.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import { formatPercentage } from 'common/format';
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+const debug = true;
+
+// the buff events all use this spell
+const RUSHING_JADE_WIND_BUFF = SPELLS.RUSHING_JADE_WIND_TALENT; 
+
+class RushingJadeWind extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  inactiveDuration = 0;
+  _lastDropped = 0;
+
+  on_initialized() {
+    this._lastDropped = this.owner.fight.start_time;
+    this.active = this.combatants.selected.hasTalent(SPELLS.RUSHING_JADE_WIND_TALENT.id);
+  }
+
+  on_byPlayer_applybuff(event) {
+    if(event.ability.guid === RUSHING_JADE_WIND_BUFF.id) {
+      this.inactiveDuration += event.timestamp - this._lastDropped;
+      debug && console.log("RJW re-applied", this.inactiveDuration);
+    }
+  }
+
+  on_byPlayer_removebuff(event) {
+    if(event.ability.guid === RUSHING_JADE_WIND_BUFF.id) {
+      this._lastDropped = event.timestamp;
+      debug && console.log("RJW dropped");
+    }
+  }
+
+  // using a suggestion rather than a checklist item for this as RJW is
+  // purely offensive
+  suggestions(when) {
+    console.log(this.owner.fightDuration);
+    const fightDuration = this.owner.fight.end_time - this.owner.fight.start_time;
+    const downtime = this.inactiveDuration / fightDuration;
+    const uptime = 1.0 - downtime;
+    console.log(this.inactiveDuration);
+    when(uptime).isLessThan(0.95)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<span>You had low uptime on <SpellLink id={SPELLS.RUSHING_JADE_WIND.id} />. Try to maintain 100% uptime by refreshing the buff before it drops.</span>)
+          .icon(SPELLS.RUSHING_JADE_WIND.icon)
+          .actual(`${formatPercentage(actual)}% uptime`)
+          .recommended(`${Math.round(formatPercentage(recommended))}% is recommended`)
+          .regular(recommended - 0.1).major(recommended - 0.2);
+      });
+  }
+}
+
+export default RushingJadeWind;

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/RushingJadeWind.test.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/RushingJadeWind.test.js
@@ -9,22 +9,6 @@ const talented_combatant = {
   hasTalent: (id) => id === SPELLS.RUSHING_JADE_WIND_TALENT.id,
 };
 
-const BUFF = {...RUSHING_JADE_WIND_BUFF, guid: RUSHING_JADE_WIND_BUFF.id};
-
-const player = 1;
-
-// should have 50% uptime, sequences of applybuff/applybuff or
-// removebuff/removebuff are assumed to never happen
-const halfUptime = [
-  {sourceID: player, targetID: player, timestamp: 1000, type: "applybuff", ability: BUFF},
-  {sourceID: player, targetID: player, timestamp: 2000, type: "removebuff", ability: BUFF},
-  {sourceID: player, targetID: player, timestamp: 3000, type: "applybuff", ability: BUFF},
-  {sourceID: player, targetID: player, timestamp: 4000, type: "removebuff", ability: BUFF},
-  {sourceID: player, targetID: player, timestamp: 5000, type: "applybuff", ability: BUFF},
-  {sourceID: player, targetID: player, timestamp: 6000, type: "removebuff", ability: BUFF},
-  {sourceID: player, targetID: player, timestamp: 8000, type: "applybuff", ability: BUFF},
-];
-
 describe("Rushing Jade Wind", () => {
   let rjw;
   beforeEach(() => {
@@ -33,14 +17,8 @@ describe("Rushing Jade Wind", () => {
       toPlayer: () => true,
       byPlayerPet: () => false,
       toPlayerPet: () => false,
-      fight: {
-        start_time: 0,
-        end_time: 10000,
-      },
-      fightDuration: 10000,
     });
-    rjw.combatants = {selected: talented_combatant};
-    rjw.triggerEvent("initialized");
+    rjw.combatants = {};
   });
 
   it("should be inactive for a user without the talent", () => {
@@ -50,24 +28,8 @@ describe("Rushing Jade Wind", () => {
   });
 
   it("should be active for a user with the talent", () => {
-    // the default is for rjw to use the talent
+    rjw.combatants.selected = talented_combatant;
     rjw.triggerEvent("initialized");
     expect(rjw.active).toBe(true);
-  });
-
-  it("should show 0% uptime if no events have been processed", () => {
-    rjw.owner.fightDuration = 0;
-    expect(rjw.uptime).toBe(0);
-  });
-
-  it("should show 0% uptime if the fight ends without it ever activating", () => {
-    rjw.triggerEvent("finished");
-    expect(rjw.uptime).toBe(0);
-  });
-
-  it("should track uptime via the buff", () => {
-    halfUptime.forEach((event) => rjw.triggerEvent("byPlayer_" + event.type, event));
-    rjw.triggerEvent("finished");
-    expect(rjw.uptime).toBe(0.5);
   });
 });

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/RushingJadeWind.test.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/RushingJadeWind.test.js
@@ -1,0 +1,73 @@
+import SPELLS from 'common/SPELLS';
+import RushingJadeWind, { RUSHING_JADE_WIND_BUFF } from './RushingJadeWind';
+
+const talentless_combatant = {
+  hasTalent: (id) => false,
+};
+
+const talented_combatant = {
+  hasTalent: (id) => id === SPELLS.RUSHING_JADE_WIND_TALENT.id,
+};
+
+const BUFF = {...RUSHING_JADE_WIND_BUFF, guid: RUSHING_JADE_WIND_BUFF.id};
+
+const player = 1;
+
+// should have 50% uptime, sequences of applybuff/applybuff or
+// removebuff/removebuff are assumed to never happen
+const halfUptime = [
+  {sourceID: player, targetID: player, timestamp: 1000, type: "applybuff", ability: BUFF},
+  {sourceID: player, targetID: player, timestamp: 2000, type: "removebuff", ability: BUFF},
+  {sourceID: player, targetID: player, timestamp: 3000, type: "applybuff", ability: BUFF},
+  {sourceID: player, targetID: player, timestamp: 4000, type: "removebuff", ability: BUFF},
+  {sourceID: player, targetID: player, timestamp: 5000, type: "applybuff", ability: BUFF},
+  {sourceID: player, targetID: player, timestamp: 6000, type: "removebuff", ability: BUFF},
+  {sourceID: player, targetID: player, timestamp: 8000, type: "applybuff", ability: BUFF},
+];
+
+describe("Rushing Jade Wind", () => {
+  let rjw;
+  beforeEach(() => {
+    rjw = new RushingJadeWind({
+      byPlayer: () => true,
+      toPlayer: () => true,
+      byPlayerPet: () => false,
+      toPlayerPet: () => false,
+      fight: {
+        start_time: 0,
+        end_time: 10000,
+      },
+      fightDuration: 10000,
+    });
+    rjw.combatants = {selected: talented_combatant};
+    rjw.triggerEvent("initialized");
+  });
+
+  it("should be inactive for a user without the talent", () => {
+    rjw.combatants.selected = talentless_combatant;
+    rjw.triggerEvent("initialized");
+    expect(rjw.active).toBe(false);
+  });
+
+  it("should be active for a user with the talent", () => {
+    // the default is for rjw to use the talent
+    rjw.triggerEvent("initialized");
+    expect(rjw.active).toBe(true);
+  });
+
+  it("should show 0% uptime if no events have been processed", () => {
+    rjw.owner.fightDuration = 0;
+    expect(rjw.uptime).toBe(0);
+  });
+
+  it("should show 0% uptime if the fight ends without it ever activating", () => {
+    rjw.triggerEvent("finished");
+    expect(rjw.uptime).toBe(0);
+  });
+
+  it("should track uptime via the buff", () => {
+    halfUptime.forEach((event) => rjw.triggerEvent("byPlayer_" + event.type, event));
+    rjw.triggerEvent("finished");
+    expect(rjw.uptime).toBe(0.5);
+  });
+});


### PR DESCRIPTION
Rushing Jade Wind has a fixed duration, but variable uptime. It is possible (and recommended) to leave RJW off cooldown quite a bit and still maintain high uptime. (See for example, [this fight](https://wowanalyzer.com/report/g6kqfdVyBYbLKrTh/7-Heroic+Felhounds+of+Sargeras+-+Kill+(3:59)/Eisenpelz/cast-efficiency) where I have <60% cast efficiency but > 85% uptime) This PR replaces the Abilities-based suggestion with an uptime-based suggestion.

I didn't see a way to do uptime-based stuff mostly automatically, so this is done as a new module.

(Also fixed final reviews from previous PR)