### PR TITLE
[frost mage] Updated suggestions to new format, added new Checklist entry

### DIFF
--- a/src/Parser/Mage/Frost/CHANGELOG.js
+++ b/src/Parser/Mage/Frost/CHANGELOG.js
@@ -7,6 +7,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+      date: new Date('2018-01-01'),
+      changes: <Wrapper>Added a 'Fish for procs' entry to the Checklist, and reworded/updated several suggestion metrics.</Wrapper>,
+      contributors: [sref],
+  },
+  {
       date: new Date('2017-12-29'),
       changes: <Wrapper>Added support for <SpellLink id={SPELLS.FROST_MAGE_T21_4SET_BONUS_BUFF.id} /></Wrapper>,
       contributors: [sref],

--- a/src/Parser/Mage/Frost/Modules/Features/Checklist.js
+++ b/src/Parser/Mage/Frost/Modules/Features/Checklist.js
@@ -3,6 +3,7 @@ import React from 'react';
 import SPELLS from 'common/SPELLS';
 
 import Wrapper from 'common/Wrapper';
+import SpellLink from 'common/SpellLink';
 
 import CoreChecklist, { Rule, Requirement } from 'Parser/Core/Modules/Features/Checklist';
 import { PreparationRule } from 'Parser/Core/Modules/Features/Checklist/Rules';
@@ -80,7 +81,7 @@ class Checklist extends CoreChecklist {
     }),
     new Rule({
       name: 'Use your procs',
-      description: <Wrapper>Frost Mage is a heavily proc dependent spec, so using your procs correctly is very important.</Wrapper>,
+      description: <Wrapper>Frost Mage is heavily dependent on correct usage of <SpellLink id={SPELLS.FINGERS_OF_FROST.id}/> and <SpellLink id={SPELLS.BRAIN_FREEZE.id}/>. Remember to use your procs promptly, and also remember to precede each <SpellLink id={SPELLS.FLURRY.id}/> with a hardcast and follow each with an <SpellLink id={SPELLS.ICE_LANCE.id}/> so that both can benefit from <SpellLink id={SPELLS.WINTERS_CHILL.id}/>.</Wrapper>,
       requirements: () => {
         return [
           new Requirement({

--- a/src/Parser/Mage/Frost/Modules/Features/Checklist.js
+++ b/src/Parser/Mage/Frost/Modules/Features/Checklist.js
@@ -47,7 +47,7 @@ class Checklist extends CoreChecklist {
 
   rules = [
     new Rule({
-      name: 'Always Be Casting',
+      name: 'Always be casting',
       description: <Wrapper><em><b>Continuously chaining casts throughout an encounter is the single most important thing for achieving good DPS as a caster</b></em>. There shoule be no delay at all between your spell casts, it's better to start casting the wrong spell than to think for a few seconds and then cast the right spell. You should be able to handle a fight's mechanics with the minimum possible interruption to your casting. Some fights (like Argus) have unavoidable downtime due to phase transitions and the like, so in these cases 0% downtime will not be possible.</Wrapper>,
       requirements: () => {
         return [
@@ -63,13 +63,29 @@ class Checklist extends CoreChecklist {
       },
     }),
     new Rule({
-      name: 'Use Your Procs',
+      name: 'Fish for procs',
+      description: <Wrapper>When you don't have any Brain Freeze, Fingers of Frost, or Glacial Spike procs, you should spam Frostbolt to fish for procs. Never cast Flurry without Brain Freeze, and the only reason you should ever cast Ice Lance without Shatter is if you're forced to move and have no other instants available.</Wrapper>,
+      requirements: () => {
+        return [
+          new Requirement({
+            name: "Flurries without Brain Freeze",
+            check: () => this.brainFreeze.flurryWithoutProcSuggestionThresholds,
+          }),
+          new Requirement({
+            name: "Ice Lances without Shatter",
+            check: () => this.iceLance.nonShatteredSuggestionThresholds,
+          }),
+        ];
+      },
+    }),
+    new Rule({
+      name: 'Use your procs',
       description: <Wrapper>Frost Mage is a heavily proc dependent spec, so using your procs correctly is very important.</Wrapper>,
       requirements: () => {
         return [
           new Requirement({
             name: "Used Brain Freeze procs",
-            check: () => this.brainFreeze.brainFreezeUtilSuggestionThresholds,
+            check: () => this.brainFreeze.utilSuggestionThresholds,
           }),
           new Requirement({
             name: "Used Fingers of Frost procs",
@@ -87,7 +103,7 @@ class Checklist extends CoreChecklist {
       },
     }),
     new Rule({
-      name: 'Use Your Cooldowns',
+      name: 'Use your cooldowns',
       description: <Wrapper>Your cooldowns are a major contributor to your DPS, and should be used as frequently as possible throughout a fight. A cooldown should be held on to only if a priority DPS phase is coming <em>soon</em>. Holding cooldowns too long will hurt your DPS.</Wrapper>,
       requirements: () => {
         const combatant = this.combatants.selected;
@@ -126,7 +142,7 @@ class Checklist extends CoreChecklist {
     }),
 
     new Rule({
-      name: 'Maximize Your Talents',
+      name: 'Maximize your talents',
       description: <Wrapper>Talent choice can effect playstyle, it is important to use your talents to their fullest.</Wrapper>,
       requirements: () => {
         const combatant = this.combatants.selected;

--- a/src/Parser/Mage/Frost/Modules/Features/GlacialSpike.js
+++ b/src/Parser/Mage/Frost/Modules/Features/GlacialSpike.js
@@ -57,13 +57,12 @@ class GlacialSpike extends Analyzer {
   }
 
   suggestions(when) {
-    when(this.overcappedPercentage).isGreaterThan(0.05)
+    when(this.utilSuggestionThresholds)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>You overcapped on {formatPercentage(this.overcappedPercentage, 1)}% of gained <SpellLink id={SPELLS.ICICLES_BUFF.id} />. Casting Frostbolt at max Icicles will cause an Icicle to automatically launch. While this Icicle still does damage, there is an opportunity cost to delaying your Glacial Spike cast. You should try to cast <SpellLink id={SPELLS.GLACIAL_SPIKE_TALENT.id} /> as soon as you reach 5 icicles. Overcapping some <SpellLink id={SPELLS.ICICLES_BUFF.id} /> is unavoidable due to <SpellLink id={SPELLS.ICE_NINE.id} />, but you should try and keep this number as low as possible.</span>)
           .icon(SPELLS.GLACIAL_SPIKE_TALENT.icon)
           .actual(`${formatPercentage(this.overcappedPercentage, 1)}% overcapped`)
-          .recommended(`<${formatPercentage(recommended, 1)}% is recommended`)
-          .regular(0.10).major(0.20);
+          .recommended(`<${formatPercentage(1-recommended, 1)}% is recommended`);
       });
   }
   statistic() {

--- a/src/Parser/Mage/Frost/Modules/Features/IceLance.js
+++ b/src/Parser/Mage/Frost/Modules/Features/IceLance.js
@@ -92,6 +92,10 @@ class IceLance extends Analyzer {
 		return 1 - (this.wastedFingersProcs / this.totalFingersProcs) || 0;
 	}
 
+	get nonShatteredPercent() {
+		return (this.nonShatteredCasts / this.abilityTracker.getAbility(SPELLS.ICE_LANCE.id).casts);
+	}
+
 	get fingersUtilSuggestionThresholds() {
     return {
       actual: this.fingersUtil,
@@ -104,15 +108,25 @@ class IceLance extends Analyzer {
     };
   }
 
+	get nonShatteredSuggestionThresholds() {
+		return {
+      actual: this.nonShatteredPercent,
+      isGreaterThan: {
+        minor: 0.05,
+        average: 0.15,
+        major: 0.25,
+      },
+      style: 'percentage',
+    };
+	}
+
 	suggestions(when) {
-		const nonShatteredPercent = (this.nonShatteredCasts / this.abilityTracker.getAbility(SPELLS.ICE_LANCE.id).casts);
-		when(nonShatteredPercent).isGreaterThan(0.1)
+		when(this.nonShatteredSuggestionThresholds)
 			.addSuggestion((suggest, actual, recommended) => {
-				return suggest(<span>You cast <SpellLink id={SPELLS.ICE_LANCE.id} /> {this.nonShatteredCasts} times ({formatPercentage(nonShatteredPercent)}%) without <SpellLink id={SPELLS.SHATTER.id} />. Make sure that you are only casting Ice Lance when the target has <SpellLink id={SPELLS.WINTERS_CHILL.id} /> (or other Shatter effects), if you have a <SpellLink id={SPELLS.FINGERS_OF_FROST.id} /> proc, or if you are moving and you cant cast anything else.</span>)
+				return suggest(<span>You cast <SpellLink id={SPELLS.ICE_LANCE.id} /> {this.nonShatteredCasts} times ({formatPercentage(this.nonShatteredPercent)}%) without <SpellLink id={SPELLS.SHATTER.id} />. Make sure that you are only casting Ice Lance when the target has <SpellLink id={SPELLS.WINTERS_CHILL.id} /> (or other Shatter effects), if you have a <SpellLink id={SPELLS.FINGERS_OF_FROST.id} /> proc, or if you are moving and you cant cast anything else.</span>)
 					.icon(SPELLS.ICE_LANCE.icon)
-					.actual(`${formatPercentage(nonShatteredPercent)}% missed`)
-					.recommended(`<${formatPercentage(recommended)}% is recommended`)
-					.regular(0.1).major(0.2);
+					.actual(`${formatPercentage(this.nonShatteredPercent)}% missed`)
+					.recommended(`<${formatPercentage(recommended)}% is recommended`);
 			});
 	}
 

--- a/src/Parser/Mage/Frost/Modules/Features/ThermalVoid.js
+++ b/src/Parser/Mage/Frost/Modules/Features/ThermalVoid.js
@@ -56,14 +56,12 @@ class ThermalVoid extends Analyzer {
   }
 
   suggestions(when) {
-    const averageDurationSeconds = this.averageDuration / 1000;
-    when(averageDurationSeconds).isLessThan(this.suggestionThresholds.isLessThan.minor)
+    when(this.suggestionThresholds)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span>Your <SpellLink id={SPELLS.ICY_VEINS.id} /> duration can be improved. Make sure you use Frozen Orb to get Fingers of Frost Procs</span>)
+        return suggest(<span>Your <SpellLink id={SPELLS.THERMAL_VOID_TALENT.id} /> duration boost can be improved. Make sure you use <SpellLink id={SPELLS.FROZEN_ORB.id} /> during <SpellLink id={SPELLS.ICY_VEINS.id} /> in order to get extra <SpellLink id={SPELLS.FINGERS_OF_FROST.id} /> Procs</span>)
           .icon(SPELLS.ICY_VEINS.icon)
           .actual(`${formatNumber(actual)} seconds Average Icy Veins Duration`)
-          .recommended(`${formatNumber(recommended)} is recommended`)
-          .regular(this.suggestionThresholds.isLessThan.average).major(this.suggestionThresholds.isLessThan.average);
+          .recommended(`${formatNumber(recommended)} is recommended`);
       });
   }
 

--- a/src/Parser/Mage/Frost/Modules/Features/WintersChill.js
+++ b/src/Parser/Mage/Frost/Modules/Features/WintersChill.js
@@ -6,6 +6,7 @@ import EnemyInstances from 'Parser/Core/Modules/EnemyInstances';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
+import Wrapper from 'common/Wrapper';
 import { formatNumber, formatMilliseconds, formatPercentage } from 'common/format';
 
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
@@ -93,8 +94,12 @@ class WintersChillTracker extends Analyzer {
     }
   }
 
+  get iceLanceMissedPercent() {
+    return (this.missedIceLanceCasts / this.totalProcs) || 0;
+  }
+
   get iceLanceUtil() {
-    return 1 - (this.missedIceLanceCasts / this.totalProcs) || 0;
+    return 1 - this.iceLanceMissedPercent;
   }
 
   get iceLanceUtilSuggestionThresholds() {
@@ -103,16 +108,22 @@ class WintersChillTracker extends Analyzer {
       isLessThan: {
         minor: 0.95,
         average: 0.85,
-        major: 0.70,
+        major: 0.75,
       },
       style: 'percentage',
     };
   }
 
-  get hardcastUtil() {
-    return 1 - (this.missedHardcasts / this.totalProcs) || 0;
+  get hardcastMissedPercent() {
+    return (this.missedHardcasts / this.totalProcs) || 0;
   }
 
+  get hardcastUtil() {
+    return 1 - this.hardcastMissedPercent;
+  }
+
+  // less strict than the ice lance suggestion both because it's less important,
+  // and also because using a Brain Freeze after being forced to move is a good excuse for missing the hardcast.
   get hardcastUtilSuggestionThresholds() {
     return {
       actual: this.hardcastUtil,
@@ -130,34 +141,29 @@ class WintersChillTracker extends Analyzer {
   }
 
   suggestions(when) {
-    const missedIceLancesPerMinute = this.missedIceLanceCasts / (this.owner.fightDuration / 1000 / 60);
-    when(missedIceLancesPerMinute).isGreaterThan(0)
+    when(this.iceLanceUtilSuggestionThresholds)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span> You failed to Ice Lance into {this.missedIceLanceCasts} <SpellLink id={SPELLS.WINTERS_CHILL.id}/> ({missedIceLancesPerMinute.toFixed(1)} missed per minute).  Make sure you cast <SpellLink id={SPELLS.ICE_LANCE.id}/> after each <SpellLink id={SPELLS.FLURRY.id}/> to benefit from <SpellLink id={SPELLS.SHATTER.id}/>.</span>)
+        return suggest(<Wrapper>You failed to Ice Lance into <SpellLink id={SPELLS.WINTERS_CHILL.id}/> {this.missedIceLanceCasts} times ({formatPercentage(this.iceLanceMissedPercent)}%). Make sure you cast <SpellLink id={SPELLS.ICE_LANCE.id}/> after each <SpellLink id={SPELLS.FLURRY.id}/> to benefit from <SpellLink id={SPELLS.SHATTER.id}/>.</Wrapper>)
           .icon(SPELLS.ICE_LANCE.icon)
-          .actual(`${formatNumber(this.missedIceLanceCasts)} Winter's Chill not shattered with Ice Lance`)
-          .recommended(`${formatNumber(recommended)} is recommended`)
-          .regular(0.5).major(1);
+          .actual(`${formatPercentage(this.iceLanceMissedPercent)}% Winter's Chill not shattered with Ice Lance`)
+          .recommended(`<${formatPercentage(1 - this.iceLanceUtilSuggestionThresholds.isLessThan.minor)}% is recommended`);
       });
 
-    const missedFrostboltsPerMinute = this.missedHardcasts / (this.owner.fightDuration / 1000 / 60);
-    if(this.hasGlacialSpike) { // Different suggestion depending on talent choice (which includes a SpellLink, so can't switch inside suggestion)
-      when(missedFrostboltsPerMinute).isGreaterThan(0)
+    if(this.hasGlacialSpike) { // Different suggestion text depending on talent choice (which includes a SpellLink, so can't switch inside suggestion)
+      when(this.hardcastUtilSuggestionThresholds)
         .addSuggestion((suggest, actual, recommended) => {
-          return suggest(<span> You failed to <SpellLink id={SPELLS.FROSTBOLT.id}/>, <SpellLink id={SPELLS.GLACIAL_SPIKE_TALENT.id}/>, or <SpellLink id={SPELLS.EBONBOLT.id}/> into {this.missedHardcasts} <SpellLink id={SPELLS.WINTERS_CHILL.id}/> ({missedFrostboltsPerMinute.toFixed(1)} missed per minute).  Make sure you hard cast just before each instant <SpellLink id={SPELLS.FLURRY.id}/> to benefit from <SpellLink id={SPELLS.SHATTER.id}/>.</span>)
+          return suggest(<Wrapper>You failed to <SpellLink id={SPELLS.FROSTBOLT.id}/>, <SpellLink id={SPELLS.GLACIAL_SPIKE_TALENT.id}/>, or <SpellLink id={SPELLS.EBONBOLT.id}/> into <SpellLink id={SPELLS.WINTERS_CHILL.id}/> {this.missedHardcasts} times ({formatPercentage(this.hardcastMissedPercent)}%}). Make sure you hard cast just before each instant <SpellLink id={SPELLS.FLURRY.id}/> to benefit from <SpellLink id={SPELLS.SHATTER.id}/>.</Wrapper>)
             .icon(SPELLS.FROSTBOLT.icon)
-            .actual(`${formatNumber(this.missedHardcasts)} Winter's Chill not shattered with Frostbolt, Glacial Spike, or Ebonbolt`)
-            .recommended(`${formatNumber(recommended)} is recommended`)
-            .regular(0.5).major(1);
+            .actual(`${formatPercentage(this.hardcastMissedPercent)}% Winter's Chill not shattered with Frostbolt, Glacial Spike, or Ebonbolt`)
+            .recommended(`${formatPercentage(1 - recommended)}% is recommended`);
         });
     } else {
-      when(missedFrostboltsPerMinute).isGreaterThan(0)
+      when(this.hardcastUtilSuggestionThresholds)
         .addSuggestion((suggest, actual, recommended) => {
-          return suggest(<span> You failed to <SpellLink id={SPELLS.FROSTBOLT.id}/> or <SpellLink id={SPELLS.EBONBOLT.id}/> into {this.missedHardcasts} <SpellLink id={SPELLS.WINTERS_CHILL.id}/> ({missedFrostboltsPerMinute.toFixed(1)} missed per minute).  Make sure you hard cast just before each instant <SpellLink id={SPELLS.FLURRY.id}/> to benefit from <SpellLink id={SPELLS.SHATTER.id}/>.</span>)
-            .icon(SPELLS.FROSTBOLT.icon)
-            .actual(`${formatNumber(this.missedHardcasts)} Winter's Chill not shattered with Frostbolt or Ebonbolt`)
-            .recommended(`${formatNumber(recommended)} is recommended`)
-            .regular(0.5).major(1);
+          return suggest(<Wrapper>You failed to <SpellLink id={SPELLS.FROSTBOLT.id}/> or <SpellLink id={SPELLS.EBONBOLT.id}/> into <SpellLink id={SPELLS.WINTERS_CHILL.id}/> {this.missedHardcasts} times ({formatPercentage(this.hardcastMissedPercent)}%}). Make sure you hard cast just before each instant <SpellLink id={SPELLS.FLURRY.id}/> to benefit from <SpellLink id={SPELLS.SHATTER.id}/>.</Wrapper>)
+          .icon(SPELLS.FROSTBOLT.icon)
+          .actual(`${formatPercentage(this.hardcastMissedPercent)}% Winter's Chill not shattered with Frostbolt or Ebonbolt`)
+          .recommended(`${formatPercentage(1 - recommended)}% is recommended`);
         });
     }
   }

--- a/src/Parser/Mage/Frost/Modules/Features/WintersChill.js
+++ b/src/Parser/Mage/Frost/Modules/Features/WintersChill.js
@@ -7,7 +7,7 @@ import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';
-import { formatNumber, formatMilliseconds, formatPercentage } from 'common/format';
+import { formatMilliseconds, formatPercentage } from 'common/format';
 
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 


### PR DESCRIPTION
New checklist entry "Fish for Procs" checks that you're spamming Frostbolt when you have no procs (rather than casting Ice Lance or Flurry without procs, which is almost always wrong)

Updated some suggestion texts / numbers too.