### PR TITLE
[Fire Mage] Add Warning for Spec Completeness

### DIFF
--- a/src/Parser/Core/Modules/Channeling.js
+++ b/src/Parser/Core/Modules/Channeling.js
@@ -2,7 +2,7 @@ import Analyzer from 'Parser/Core/Analyzer';
 import { formatMilliseconds } from 'common/format';
 import CASTS_THAT_ARENT_CASTS from 'Parser/Core/CASTS_THAT_ARENT_CASTS';
 
-const debug = true;
+const debug = false;
 
 class Channeling extends Analyzer {
   _currentChannel = null;

--- a/src/Parser/Core/Modules/Features/WarningDisplay.js
+++ b/src/Parser/Core/Modules/Features/WarningDisplay.js
@@ -1,9 +1,12 @@
 import React from 'react';
+import Wrapper from 'common/Wrapper';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import WarningIcon from 'Icons/Warning';
 
 class WarningDisplay extends Analyzer {
+
+  needsWorkWarning = false;
 
   render() {
     const boss = this.owner.boss;
@@ -17,6 +20,23 @@ class WarningDisplay extends Analyzer {
                 </div>
                 <div>
                   {boss.fight.displayWarning}
+                </div>
+            </div>
+            <div style={{ background: 'rgba(255, 255, 255, 0.2)', height: 1 }} />
+          </div>
+        </div>
+      );
+    }
+    if (this.needsWorkWarning) {
+      return (
+        <div>
+          <div style={{ padding: 0 }}>
+            <div className="flex-sub content-middle" style={{ margin: '0px 30px 0px 0px', color: '#FFA100', opacity: 0.8 }}>
+                <div style={{ fontSize: '5.5em', lineHeight: 1, marginRight: 10, marginLeft: 10 }}>
+                  <WarningIcon />
+                </div>
+                <div>
+                  The analysis for this spec is still under development. Information regarding your overall play may be flawed, inaccurate, missing, or incomplete. Contact the spec maintainer for feature requests and bug reports (About Tab).
                 </div>
             </div>
             <div style={{ background: 'rgba(255, 255, 255, 0.2)', height: 1 }} />

--- a/src/Parser/Core/Modules/Features/WarningDisplay.js
+++ b/src/Parser/Core/Modules/Features/WarningDisplay.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import Wrapper from 'common/Wrapper';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import WarningIcon from 'Icons/Warning';

--- a/src/Parser/Mage/Fire/CHANGELOG.js
+++ b/src/Parser/Mage/Fire/CHANGELOG.js
@@ -2,6 +2,11 @@ import { Sharrq, sref, Fyruna } from 'MAINTAINERS';
 
 export default [
   {
+    date: new Date('2017-1-1'),
+    changes: 'Added Warning regarding spec completeness',
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2017-12-27'),
     changes: 'Converted Changelog to new format',
     contributors: [Sharrq],

--- a/src/Parser/Mage/Fire/CombatLogParser.js
+++ b/src/Parser/Mage/Fire/CombatLogParser.js
@@ -1,5 +1,6 @@
 import CoreCombatLogParser from 'Parser/Core/CombatLogParser';
 import DamageDone from 'Parser/Core/Modules/DamageDone';
+import WarningDisplay from 'Parser/Core/Modules/Features/WarningDisplay';
 
 import FlamestrikeNormalizer from './Normalizers/Flamestrike';
 
@@ -24,6 +25,9 @@ import PyrotexIgnitionCloth from './Modules/Items/PyrotexIgnitionCloth';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
+    //Warning
+    warningDisplay: [WarningDisplay, { needsWorkWarning: true }],
+
     //Normalizers
     FlameStrikeNormalizer: FlamestrikeNormalizer,
 


### PR DESCRIPTION
Added a warning message to show anyone using the fire analyzer to inform them that the spec is under development/incomplete and may have missing or inaccurate information

![image](https://user-images.githubusercontent.com/1304554/34474671-b627f2a0-ef47-11e7-815a-b86409a3865e.png)
