### PR TITLE
[Fire Mage] Marquee Bindings of the Sun King

### DIFF
--- a/src/Parser/Mage/Fire/CombatLogParser.js
+++ b/src/Parser/Mage/Fire/CombatLogParser.js
@@ -22,6 +22,7 @@ import SoulOfTheArchmage from './Modules/Items/SoulOfTheArchmage';
 import DarcklisDragonfireDiadem from './Modules/Items/DarcklisDragonfireDiadem';
 import ContainedInfernalCore from './Modules/Items/ContainedInfernalCore';
 import PyrotexIgnitionCloth from './Modules/Items/PyrotexIgnitionCloth';
+import MarqueeBindingsOfTheSunKing from './Modules/Items/MarqueeBindingsOfTheSunKing';
 
 
 class CombatLogParser extends CoreCombatLogParser {

--- a/src/Parser/Mage/Fire/CombatLogParser.js
+++ b/src/Parser/Mage/Fire/CombatLogParser.js
@@ -55,6 +55,7 @@ class CombatLogParser extends CoreCombatLogParser {
     darcklisDragonfireDiadem: DarcklisDragonfireDiadem,
     containedInfernalCore: ContainedInfernalCore,
     pyrotexIgnitionCloth: PyrotexIgnitionCloth,
+	marqueeBindingsOfTheSunKing: MarqueeBindingsOfTheSunKing,
 
   };
 }

--- a/src/Parser/Mage/Fire/Modules/Items/MarqueeBindingsOfTheSunKing.js
+++ b/src/Parser/Mage/Fire/Modules/Items/MarqueeBindingsOfTheSunKing.js
@@ -3,127 +3,137 @@ import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
-import ItemDamageDone from 'Main/ItemDamageDone';
 import ItemLink from 'common/ItemLink';
-import { formatPercentage } from 'common/format';
+import { formatPercentage, formatNumber } from 'common/format';
+import Wrapper from 'common/Wrapper';
+import SpellLink from 'common/SpellLink';
 
 class MarqueeBindingsOfTheSunKing extends Analyzer {
   static dependencies = {
     combatants: Combatants,
   };
   
-  damage = 0;
-  legendaryProcs = 0;
-  overwrittenProcs = 0;
+  baseProcs = 0;
+  refreshedProcs = 0;
   buffedPyroblasts = 0;
-  expiredProcs = 0
-  
-  lastBuffTimestamp;
-  lastPyroCastTimestamp;
+  buffChecked = 0;
+  combustionRefresh = 0;
   
   on_initialized() {
   this.active = this.combatants.selected.hasWrists(ITEMS.MARQUEE_BINDINGS_OF_THE_SUN_KING.id);
   }
 
-	// get total count of procs
-  
-    on_toPlayer_applybuff(event) {
-	  if (event.ability.guid !== SPELLS.KAELTHAS_ULTIMATE_ABILITY.id) {
-	  return;
+  // count procs + refreshes  
+  on_toPlayer_applybuff(event) {
+    if (event.ability.guid !== SPELLS.KAELTHAS_ULTIMATE_ABILITY.id) {
+    return;
     }
-  this.legendaryProcs += 1;
-  }
+    this.baseProcs += 1;
+  } 
   
-   // get count of refreshes
-  	on_byPlayer_refreshbuff(event) {
+  on_byPlayer_refreshbuff(event) {
     if (event.ability.guid !== SPELLS.KAELTHAS_ULTIMATE_ABILITY.id) {
-			return;
-		}
-		this.overwrittenProcs += 1;
-		this.legendaryProcs += 1;
+      return;
+    }
+    if (this.combatants.selected.hasBuff(SPELLS.COMBUSTION.id))
+    {this.combustionRefresh +=1;
+    return;
+    }
+    this.refreshedProcs += 1;
 	}
-	
-	
-	// this section needs explaining:
-	// from looking through logs, the order of events is buff expires -> pyroblast cast begins within ~100ms -> pyroblast hits within 4.5 seconds
-	// i'm not sure this is the best way to accomplish this but it seems to work
-	
-	//get timestamp when buff expires
-	
-	on_byPlayer_removebuff(event) {
+  
+  // when buff expires, start check for matching pyroblast
+ 
+  on_byPlayer_removebuff(event) {
     if (event.ability.guid !== SPELLS.KAELTHAS_ULTIMATE_ABILITY.id) {
-			return;
-		}
-		this.lastBuffTimestamp = this.owner.currentTimestamp;
-			}
-	
-	// for each pyroblast, check if buff expired within the past 100ms. if so, count it as buffed by the legendary
-	// additionally, set timestamp of cast to do a damage check
-	// i suppose it's possible for a player to instant cast pyroblast with hot streak within 100ms of the buff ending so it checks that this isn't the case.
-	
-	on_byPlayer_cast(event) {
+      return;
+    }
+    this.buffChecked=1;
+    }
+  
+  on_byPlayer_cast(event) {
     if (event.ability.guid !== SPELLS.PYROBLAST.id) {
-			return;
-		}
-    if (this.lastBuffTimestamp > this.owner.currentTimestamp - 100 && !this.combatants.selected.hasBuff(SPELLS.HOT_STREAK) ) {
-			this.buffedPyroblasts += 1;
-			this.lastPyroCastTimestamp = this.owner.currentTimestamp;
-		}
-		}
-
-	// after being cast, pyroblast takes a few seconds to travel and hit the target.
-	// allows 3 seconds for the pyroblast to hit, then resets timestamp so additional instant pyroblasts within the time limit don't count.
-	// this is messy and i don't know if there's an easier way
+      return;
+     }
+	 	 
+   if (this.buffChecked === 0) {
+       return;
+     }  
+   
+  // make sure that this isn't a hot streak instant pyroblast that just happened to cast as buff fell off
+     
+     if (this.combatants.selected.hasBuff(SPELLS.KAELTHAS_ULTIMATE_ABILITY.id, event.timestamp, 100) && !this.combatants.selected.hasBuff(SPELLS.HOT_STREAK)) {
+      this.buffedPyroblasts += 1;
+      this.buffChecked = 0;
+    }
+    }	
 	
-	on_byPlayer_damage(event) {
-    if (event.ability.guid !== SPELLS.PYROBLAST.id) {
-			return;
-		}
-		
-	if (this.owner.currentTimestamp - 3000 < this.lastPyroCastTimestamp)	
-			this.damage += event.amount + (event.absorbed || 0);
-			this.lastPyroCastTimestamp = 0;
-			console.log(this.damage);
-		}
+  // math
+	
+  get totalProcs() {
+    return (this.baseProcs + this.refreshedProcs + this.combustionRefresh);
+  }
+ 
+  get expiredProcs() {
+    return (this.totalProcs - this.refreshedProcs - this.buffedPyroblasts - this.combustionRefresh);
+  }
 
-  item() {
-	  
-	  // i don't think this is the best section to put this code
-	  	this.expiredProcs = (this.legendaryProcs - this.overwrittenProcs - this.buffedPyroblasts);
+  get refreshPercentage() {
+    return (this.refreshedProcs) / (this.totalProcs);
+  }
 
+// item display
+   
+item() {
+  return {
+  item: ITEMS.MARQUEE_BINDINGS_OF_THE_SUN_KING,
+  result: <Wrapper>{this.buffedPyroblasts} buffed Pyroblasts<br />{this.totalProcs} total procs<br />{this.expiredProcs} expired</Wrapper>,
+};
+}
+    
+  // suggestions
+  
+    get refreshSuggestionThresholds() {
     return {
-		
-	 //	i debugged this and the console log is returning the expected damage done but the math for dps isn't working as i expect?
-	 // instead it returns something within about one % of the correct number
-		
-      item: ITEMS.MARQUEE_BINDINGS_OF_THE_SUN_KING,
-	  result: <ItemDamageDone amount={this.damage} />,
+      actual: this.refreshPercentage,
+      isGreaterThan: {
+        minor: 0.10,
+        average: 0.15,
+        major: 0.20,
+      },
+      style: 'percentage',
     };
   }
   
-	// this is wordy, improve? also: change recommended numbers
-	// i couldn't find the icon for the bindings so i used pyroblast
-  
-    suggestions(when) {
-    when(this.overwrittenProcs).isGreaterThan(0)
-      .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span>Your buff from <ItemLink id={ITEMS.MARQUEE_BINDINGS_OF_THE_SUN_KING.id} /> was overwritten {formatPercentage(this.overwrittenProcs/this.legendaryProcs)}% of the time. This happens when the buff procs from an instant cast Pyroblast during Hot Streak before it is hard cast. If possible avoid using Fire Blast or Phoenix's Flames during Heating Up while you have the Marquee Bindings of the Sun King buff active.</span>)
-          .icon(SPELLS.PYROBLAST.icon)
-          .actual(`${this.overwrittenProcs} overwritten buffs`)
-          .recommended(`0 is recommended`)
-		  .regular(recommended - 0.0).major(recommended - 0.0);
-      });
-	  
-	  when(this.expiredProcs).isGreaterThan(0)
-      .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span>Your buff from <ItemLink id={ITEMS.MARQUEE_BINDINGS_OF_THE_SUN_KING.id} /> expired {formatPercentage(this.expiredProcs/this.legendaryProcs)}% of the time. This happens when Pyroblast isn't hard cast during the fifteen seconds the buff is up. Note that this can also happen if the buff procs shortly before the fight ends when you wouldn't have had time to use it.</span>)
-          .icon(SPELLS.PYROBLAST.icon)
-          .actual(`${this.expiredProcs} expired procs`)
-          .recommended(`0 is recommended`)
-		  .regular(recommended - 0.0).major(recommended - 0.0);
-      });
+    get expireSuggestionThresholds() {
+    return {
+      actual: this.expiredProcs,
+      isGreaterThan: {
+        minor: 0,
+        average: 0,
+        major: 1,
+      },
+    };
   }
-  
+   
+   suggestions(when) {
+     
+    when(this.refreshSuggestionThresholds)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<Wrapper>Your buff from <ItemLink id={ITEMS.MARQUEE_BINDINGS_OF_THE_SUN_KING.id} /> was refreshed {formatPercentage(this.refreshPercentage, 1)}% of the time outside of <SpellLink id={SPELLS.COMBUSTION.id} />. This can happen when <SpellLink id={SPELLS.PYROBLAST.id} /> is cast during <SpellLink id={SPELLS.HOT_STREAK.id} />. Even under ideal circumstances this cannot always be avoided. When possible, try to avoid triggering <SpellLink id={SPELLS.HOT_STREAK.id} /> through use of <SpellLink id={SPELLS.PHOENIXS_FLAMES.id} /> or <SpellLink id={SPELLS.FIRE_BLAST.id} /> until the buff is consumed.</Wrapper>)
+          .icon(SPELLS.PYROBLAST.icon)
+          .actual(`${formatPercentage(this.refreshPercentage, 1)}% buffs refreshed early`)
+          .recommended(`<${formatPercentage(recommended, 1)}% is recommended`);
+      });
+        
+       when(this.expireSuggestionThresholds)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<Wrapper>You let {(this.expiredProcs)} procs from <ItemLink id={ITEMS.MARQUEE_BINDINGS_OF_THE_SUN_KING.id} /> expire. Phase changes and other fight mechanics may sometimes make it impossible to hard cast <SpellLink id={SPELLS.PYROBLAST.id} /> before the buff expires, but you should try to avoid this. </Wrapper>)
+          .icon(SPELLS.PYROBLAST.icon)
+          .actual(`${formatNumber(this.expiredProcs)} expired buffs`)
+          .recommended(`${formatNumber(recommended)} is recommended`);
+      });   
+  }  
 }
 
 export default MarqueeBindingsOfTheSunKing;

--- a/src/Parser/Mage/Fire/Modules/Items/MarqueeBindingsOfTheSunKing.js
+++ b/src/Parser/Mage/Fire/Modules/Items/MarqueeBindingsOfTheSunKing.js
@@ -1,0 +1,129 @@
+import React from 'react';
+import ITEMS from 'common/ITEMS';
+import SPELLS from 'common/SPELLS';
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import ItemDamageDone from 'Main/ItemDamageDone';
+import ItemLink from 'common/ItemLink';
+import { formatPercentage } from 'common/format';
+
+class MarqueeBindingsOfTheSunKing extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+  
+  damage = 0;
+  legendaryProcs = 0;
+  overwrittenProcs = 0;
+  buffedPyroblasts = 0;
+  expiredProcs = 0
+  
+  lastBuffTimestamp;
+  lastPyroCastTimestamp;
+  
+  on_initialized() {
+  this.active = this.combatants.selected.hasWrists(ITEMS.MARQUEE_BINDINGS_OF_THE_SUN_KING.id);
+  }
+
+	// get total count of procs
+  
+    on_toPlayer_applybuff(event) {
+	  if (event.ability.guid !== SPELLS.KAELTHAS_ULTIMATE_ABILITY.id) {
+	  return;
+    }
+  this.legendaryProcs += 1;
+  }
+  
+   // get count of refreshes
+  	on_byPlayer_refreshbuff(event) {
+    if (event.ability.guid !== SPELLS.KAELTHAS_ULTIMATE_ABILITY.id) {
+			return;
+		}
+		this.overwrittenProcs += 1;
+		this.legendaryProcs += 1;
+	}
+	
+	
+	// this section needs explaining:
+	// from looking through logs, the order of events is buff expires -> pyroblast cast begins within ~100ms -> pyroblast hits within 4.5 seconds
+	// i'm not sure this is the best way to accomplish this but it seems to work
+	
+	//get timestamp when buff expires
+	
+	on_byPlayer_removebuff(event) {
+    if (event.ability.guid !== SPELLS.KAELTHAS_ULTIMATE_ABILITY.id) {
+			return;
+		}
+		this.lastBuffTimestamp = this.owner.currentTimestamp;
+			}
+	
+	// for each pyroblast, check if buff expired within the past 100ms. if so, count it as buffed by the legendary
+	// additionally, set timestamp of cast to do a damage check
+	// i suppose it's possible for a player to instant cast pyroblast with hot streak within 100ms of the buff ending so it checks that this isn't the case.
+	
+	on_byPlayer_cast(event) {
+    if (event.ability.guid !== SPELLS.PYROBLAST.id) {
+			return;
+		}
+    if (this.lastBuffTimestamp > this.owner.currentTimestamp - 100 && !this.combatants.selected.hasBuff(SPELLS.HOT_STREAK) ) {
+			this.buffedPyroblasts += 1;
+			this.lastPyroCastTimestamp = this.owner.currentTimestamp;
+		}
+		}
+
+	// after being cast, pyroblast takes a few seconds to travel and hit the target.
+	// allows 3 seconds for the pyroblast to hit, then resets timestamp so additional instant pyroblasts within the time limit don't count.
+	// this is messy and i don't know if there's an easier way
+	
+	on_byPlayer_damage(event) {
+    if (event.ability.guid !== SPELLS.PYROBLAST.id) {
+			return;
+		}
+		
+	if (this.owner.currentTimestamp - 3000 < this.lastPyroCastTimestamp)	
+			this.damage += event.amount + (event.absorbed || 0);
+			this.lastPyroCastTimestamp = 0;
+			console.log(this.damage);
+		}
+
+  item() {
+	  
+	  // i don't think this is the best section to put this code
+	  	this.expiredProcs = (this.legendaryProcs - this.overwrittenProcs - this.buffedPyroblasts);
+
+    return {
+		
+	 //	i debugged this and the console log is returning the expected damage done but the math for dps isn't working as i expect?
+	 // instead it returns something within about one % of the correct number
+		
+      item: ITEMS.MARQUEE_BINDINGS_OF_THE_SUN_KING,
+	  result: <ItemDamageDone amount={this.damage} />,
+    };
+  }
+  
+	// this is wordy, improve? also: change recommended numbers
+	// i couldn't find the icon for the bindings so i used pyroblast
+  
+    suggestions(when) {
+    when(this.overwrittenProcs).isGreaterThan(0)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<span>Your buff from <ItemLink id={ITEMS.MARQUEE_BINDINGS_OF_THE_SUN_KING.id} /> was overwritten {formatPercentage(this.overwrittenProcs/this.legendaryProcs)}% of the time. This happens when the buff procs from an instant cast Pyroblast during Hot Streak before it is hard cast. If possible avoid using Fire Blast or Phoenix's Flames during Heating Up while you have the Marquee Bindings of the Sun King buff active.</span>)
+          .icon(SPELLS.PYROBLAST.icon)
+          .actual(`${this.overwrittenProcs} overwritten buffs`)
+          .recommended(`0 is recommended`)
+		  .regular(recommended - 0.0).major(recommended - 0.0);
+      });
+	  
+	  when(this.expiredProcs).isGreaterThan(0)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<span>Your buff from <ItemLink id={ITEMS.MARQUEE_BINDINGS_OF_THE_SUN_KING.id} /> expired {formatPercentage(this.expiredProcs/this.legendaryProcs)}% of the time. This happens when Pyroblast isn't hard cast during the fifteen seconds the buff is up. Note that this can also happen if the buff procs shortly before the fight ends when you wouldn't have had time to use it.</span>)
+          .icon(SPELLS.PYROBLAST.icon)
+          .actual(`${this.expiredProcs} expired procs`)
+          .recommended(`0 is recommended`)
+		  .regular(recommended - 0.0).major(recommended - 0.0);
+      });
+  }
+  
+}
+
+export default MarqueeBindingsOfTheSunKing;


### PR DESCRIPTION
Hello and first of all I want to say this is my first time contributing to this (or anything like this) so forgive any mistakes and let me know what I can do to improve. This is a really cool project and I've wanted to learn how to code for awhile so I thought it'd be a good way practice.

This adds the legendary Marquee Bindings of the Sun King to Fire Mages.

- detects how many times it procs
- shows how many of those procs are overwritten, expired, or used up
- calculates DPS from the combined buffed Pyroblasts

I checked it with a few logs and the numbers look to be adding up correctly except for the DPS, which is somehow off by a percentage point despite the damage done being added up correctly.

I commented the whole thing so people here who know better can tell what I'm trying to do. Please let me know if there's anything to fix or improve, and thank you!