### PR TITLE
[Fire Mage] Enhancements and Additions for Hot Streak

### DIFF
--- a/src/Parser/Mage/Fire/CHANGELOG.js
+++ b/src/Parser/Mage/Fire/CHANGELOG.js
@@ -3,7 +3,12 @@ import { Sharrq, sref, Fyruna } from 'MAINTAINERS';
 export default [
   {
     date: new Date('2017-1-6'),
-    changes: 'Added analysis for Hot Streak to determine if there was a hard cast before Hot Streak was used and also to check for direct damage crits while Hot Streak is up',
+    changes: 'Added analysis for Hot Streak to determine if there was a hard cast before Hot Streak was used and also to check for direct damage crits while Hot Streak is up.',
+    contributors: [Sharrq],
+  },
+  {
+    date: new Date('2017-1-3'),
+    changes: 'Added support for Marquee Bindings of the Sun King',
     contributors: [Sharrq],
   },
   {

--- a/src/Parser/Mage/Fire/CHANGELOG.js
+++ b/src/Parser/Mage/Fire/CHANGELOG.js
@@ -2,6 +2,11 @@ import { Sharrq, sref, Fyruna } from 'MAINTAINERS';
 
 export default [
   {
+    date: new Date('2017-1-6'),
+    changes: 'Added analysis for Hot Streak to determine if there was a hard cast before Hot Streak was used and also to check for direct damage crits while Hot Streak is up',
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2017-1-2'),
     changes: 'Added Suggestion for Phoenix Flames Charge Count before Combustion',
     contributors: [Sharrq],

--- a/src/Parser/Mage/Fire/CombatLogParser.js
+++ b/src/Parser/Mage/Fire/CombatLogParser.js
@@ -3,6 +3,7 @@ import DamageDone from 'Parser/Core/Modules/DamageDone';
 import WarningDisplay from 'Parser/Core/Modules/Features/WarningDisplay';
 
 import FlamestrikeNormalizer from './Normalizers/Flamestrike';
+import Scorch from './Normalizers/Scorch';
 import KaelthasUltimateAbility from './Normalizers/KaelthasUltimateAbility';
 
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
@@ -34,6 +35,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     //Normalizers
     FlameStrikeNormalizer: FlamestrikeNormalizer,
+    scorch: Scorch,
     kaelthasUltimateAbility: KaelthasUltimateAbility,
 
     // Features

--- a/src/Parser/Mage/Fire/Modules/Features/HotStreak.js
+++ b/src/Parser/Mage/Fire/Modules/Features/HotStreak.js
@@ -56,7 +56,7 @@ class HotStreak extends Analyzer {
     if (!HOT_STREAK_CONTRIBUTORS.includes(spellId) || !this.combatants.selected.hasBuff(SPELLS.HOT_STREAK.id) || event.hitType !== HIT_TYPES.CRIT) {
       return;
     }
-    //If Pyromaniac caused the player to immediately get a new hot streak after spending one, then dont count the damage crits that were cast before Pyromaniac Proc's since the user cant do anything to prevent this
+    //If Pyromaniac caused the player to immediately get a new hot streak after spending one, then dont count the damage crits that were cast before Pyromaniac Proc's since the user cant do anything to prevent this.
     if ((spellId === SPELLS.FIREBALL.id || spellId === SPELLS.SCORCH.id || spellId === SPELLS.PYROBLAST.id) && this.pyromaniacProc) {
       debug && console.log("Wasted Crit Ignored @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
     } else if (HOT_STREAK_CONTRIBUTORS.includes(spellId)) {

--- a/src/Parser/Mage/Fire/Modules/Features/HotStreak.js
+++ b/src/Parser/Mage/Fire/Modules/Features/HotStreak.js
@@ -56,6 +56,7 @@ class HotStreak extends Analyzer {
     if (!HOT_STREAK_CONTRIBUTORS.includes(spellId) || !this.combatants.selected.hasBuff(SPELLS.HOT_STREAK.id) || event.hitType !== HIT_TYPES.CRIT) {
       return;
     }
+    //If Pyromaniac caused the player to immediately get a new hot streak after spending one, then dont count the damage crits that were cast before Pyromaniac Proc's since the user cant do anything to prevent this
     if ((spellId === SPELLS.FIREBALL.id || spellId === SPELLS.SCORCH.id || spellId === SPELLS.PYROBLAST.id) && this.pyromaniacProc) {
       debug && console.log("Wasted Crit Ignored @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
     } else if (HOT_STREAK_CONTRIBUTORS.includes(spellId)) {
@@ -69,6 +70,7 @@ class HotStreak extends Analyzer {
     if (spellId !== SPELLS.HOT_STREAK.id) {
       return;
     }
+    //If Hot Streak is removed and re-applied within 100ms of eachother then Pyromaniac Proc'd and granted a new hot streak
     if (this.combatants.selected.hasTalent(SPELLS.PYROMANIAC_TALENT.id) && this.buffAppliedTimestamp - this.hotStreakRemoved < PROC_WINDOW_MS) {
       this.pyromaniacProc = true;
     }
@@ -87,6 +89,8 @@ class HotStreak extends Analyzer {
       return;
     }
 
+    //Check for Expired Procs, also if Fireball or Scorch was cast at the same time that Hot Streak was removed, then it was cast alongside Hot Streak (For the cast before hot streak check). Excluded Hot Streak procs during Combustion.
+    //Also checks to see if the bracer proc was removed within 100ms of Hot Streak getting removed (i.e. they hard casted Pyroblast for the bracer proc and used Hot Streak on the end of it.)
     if (!this.lastCastTimestamp || this.lastCastTimestamp + PROC_WINDOW_MS < this.owner.currentTimestamp) {
       this.expiredProcs += 1;
       debug && console.log("Hot Streak proc expired @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));

--- a/src/Parser/Mage/Fire/Modules/Features/HotStreak.js
+++ b/src/Parser/Mage/Fire/Modules/Features/HotStreak.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import SpellIcon from 'common/SpellIcon';
 import Wrapper from 'common/Wrapper';
-import { formatMilliseconds, formatPercentage } from 'common/format';
+import { formatMilliseconds, formatPercentage, formatNumber } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import Analyzer from 'Parser/Core/Analyzer';
@@ -18,6 +19,7 @@ const HOT_STREAK_CONTRIBUTORS = [
   SPELLS.PYROBLAST.id,
   SPELLS.FIRE_BLAST.id,
   SPELLS.SCORCH.id,
+  SPELLS.PHOENIXS_FLAMES.id,
 ];
 
 class HotStreak extends Analyzer {
@@ -30,79 +32,69 @@ class HotStreak extends Analyzer {
   expiredProcs = 0;
   pyroWithoutProc = 0;
   lastCastTimestamp = 0;
-  phoenixFlamesHits = 0;
-  dragonsBreathHits = 0;
+  buffAppliedTimestamp = 0;
+  hotStreakRemoved = 0;
+  bracerProcRemoved = 0;
+  castsIntoHotStreak = 0;
+  castedBeforeHotStreak = 0;
+  noCastBeforeHotStreak = 0;
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
-    if (spellId !== SPELLS.PYROBLAST.id && spellId !== SPELLS.FLAMESTRIKE.id) {
+    if (!HOT_STREAK_CONTRIBUTORS.includes(spellId) && spellId !== SPELLS.FLAMESTRIKE.id) {
       return;
     }
+    if (spellId === SPELLS.FIREBALL.id || spellId === SPELLS.SCORCH.id) {
+      this.castTimestamp = event.timestamp;
+    }
     this.lastCastTimestamp = this.owner.currentTimestamp;
-    if (spellId === SPELLS.PHOENIXS_FLAMES.id) {
-      this.phoenixFlamesHits = 0;
-    }
-    if (spellId === SPELLS.DRAGONS_BREATH.id) {
-      this.dragonsBreathHits = 0;
-    }
+    this.pyromaniacProc = false;
   }
 
   on_byPlayer_damage(event) {
     const spellId = event.ability.guid;
-    if ((!HOT_STREAK_CONTRIBUTORS.includes(spellId) && spellId !== SPELLS.PHOENIXS_FLAMES.id && spellId !== SPELLS.DRAGONS_BREATH.id) || event.hitType !== HIT_TYPES.CRIT || !this.combatants.selected.hasBuff(SPELLS.HOT_STREAK.id)) {
+    if (!HOT_STREAK_CONTRIBUTORS.includes(spellId) || !this.combatants.selected.hasBuff(SPELLS.HOT_STREAK.id) || event.hitType !== HIT_TYPES.CRIT) {
       return;
     }
-    //If a direct damage ability crits while the player already has Hot Streak then a proc was overwritten
-    if (HOT_STREAK_CONTRIBUTORS.includes(spellId) && event.hitType === HIT_TYPES.CRIT) {
+    if ((spellId === SPELLS.FIREBALL.id || spellId === SPELLS.SCORCH.id || spellId === SPELLS.PYROBLAST.id) && this.pyromaniacProc) {
+      debug && console.log("Wasted Crit Ignored @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
+    } else if (HOT_STREAK_CONTRIBUTORS.includes(spellId)) {
       this.wastedCrits += 1;
-      if (debug) {
-        console.log("Hot Streak overwritten @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
-      }
-    }
-    //If the spell was Phoenix Flames, only check the first hit of Phoenix Flames and not the chains/splashes
-    if (spellId === SPELLS.PHOENIXS_FLAMES.id) {
-      if (this.phoenixFlamesHits === 0) {
-        this.wastedCrits += 1;
-        this.phoenixsFlamesHits += 1;
-        if (debug) {
-          console.log("Hot Streak overwritten @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
-        }
-      } else {
-        this.phoenixsFlamesHits += 1;
-      }
-    }
-    //If the spell was Dragon's Breath, only count the first hit and only if the player has Alexstrasza's Fury.
-    if (spellId === SPELLS.DRAGONS_BREATH.id && this.combatants.selected.hasTalent(SPELLS.ALEXSTRASZAS_FURY_TALENT.id)) {
-      if (this.dragonsBreathHits === 0) {
-        this.wastedCrits += 1;
-        this.dragonsBreathHits += 1;
-        if (debug) {
-          console.log("Hot Streak overwritten @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
-        }
-      } else {
-        this.dragonsBreathHits += 1;
-      }
+      debug && console.log("Hot Streak overwritten @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
     }
   }
 
-  on_byPlayer_applybuff(event) {
+  on_toPlayer_applybuff(event) {
     const spellId = event.ability.guid;
     if (spellId !== SPELLS.HOT_STREAK.id) {
       return;
+    }
+    if (this.combatants.selected.hasTalent(SPELLS.PYROMANIAC_TALENT.id) && this.buffAppliedTimestamp - this.hotStreakRemoved < PROC_WINDOW_MS) {
+      this.pyromaniacProc = true;
     }
     this.totalProcs += 1;
   }
 
-  on_byPlayer_removebuff(event) {
+  on_toPlayer_removebuff(event) {
     const spellId = event.ability.guid;
-    if (spellId !== SPELLS.HOT_STREAK.id) {
+    if (spellId !== SPELLS.HOT_STREAK.id && spellId !== SPELLS.KAELTHAS_ULTIMATE_ABILITY.id) {
       return;
     }
+    if (spellId === SPELLS.HOT_STREAK.id) {
+      this.hotStreakRemoved = event.timestamp;
+    } else if (spellId === SPELLS.KAELTHAS_ULTIMATE_ABILITY.id) {
+      this.bracerProcRemoved = event.timestamp;
+      return;
+    }
+
     if (!this.lastCastTimestamp || this.lastCastTimestamp + PROC_WINDOW_MS < this.owner.currentTimestamp) {
       this.expiredProcs += 1;
-      if (debug) {
-        console.log("Hot Streak proc expired @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
-      }
+      debug && console.log("Hot Streak proc expired @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
+    } else if (this.hotStreakRemoved - PROC_WINDOW_MS < this.castTimestamp || this.hotStreakRemoved - PROC_WINDOW_MS < this.bracerProcRemoved) {
+      this.castedBeforeHotStreak += 1;
+    } else if (!this.combatants.selected.hasBuff(SPELLS.COMBUSTION.id)) {
+      this.noCastBeforeHotStreak += 1;
+      debug && console.log("No hard cast before Hot Streak @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
     }
   }
 
@@ -110,35 +102,108 @@ class HotStreak extends Analyzer {
     return this.totalProcs - this.expiredProcs;
   }
 
+  get expiredProcsPercent() {
+    return (this.expiredProcs / this.totalProcs) || 0;
+  }
+
+  get hotStreakUtil() {
+    return 1 - (this.expiredProcs / this.totalProcs) || 0;
+  }
+
+  get castBeforeHotStreakUtil() {
+    return 1 - (this.noCastBeforeHotStreak / (this.castedBeforeHotStreak + this.noCastBeforeHotStreak));
+  }
+
+  get expiredProcsThresholds() {
+    return {
+      actual: this.expiredProcsPercent,
+      isGreaterThan: {
+        minor: 0.05,
+        average: 0.10,
+        major: 0.20,
+      },
+      style: 'percentage',
+    };
+  }
+
+  get wastedCritsThresholds() {
+    return {
+      actual: this.wastedCrits,
+      isGreaterThan: {
+        minor: 5,
+        average: 10,
+        major: 15,
+      },
+      style: 'number',
+    };
+  }
+
+  get castBeforeHotStreakThresholds() {
+    return {
+      actual: this.castBeforeHotStreakUtil,
+      isLessThan: {
+        minor: .90,
+        average: .80,
+        major:.70,
+      },
+      style: 'percentage',
+    };
+  }
+
   suggestions(when) {
-    const expiredProcsPercent = (this.expiredProcs / this.totalProcs) || 0;
-    when(expiredProcsPercent).isGreaterThan(0)
+    when(this.expiredProcsThresholds)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<Wrapper>You allowed {formatPercentage(expiredProcsPercent)}% of your <SpellLink id={SPELLS.HOT_STREAK.id} /> procs to expire. Try to use your procs as soon as possible to avoid this.</Wrapper>)
+        return suggest(<Wrapper>You allowed {formatPercentage(this.expiredProcsThresholds)}% of your <SpellLink id={SPELLS.HOT_STREAK.id} /> procs to expire. Try to use your procs as soon as possible to avoid this.</Wrapper>)
           .icon(SPELLS.HOT_STREAK.icon)
-          .actual(`${formatPercentage(expiredProcsPercent)}% expired`)
-          .recommended(`Letting none expire is recommended`)
-          .regular(.00).major(.05);
+          .actual(`${formatPercentage(this.expiredProcsPercent)}% expired`)
+          .recommended(`<${formatPercentage(recommended)}% is recommended`);
+      });
+      when(this.wastedCritsThresholds)
+        .addSuggestion((suggest, actual, recommended) => {
+          return suggest(<span>You crit with {formatNumber(this.wastedCrits)} direct damage abilities while <SpellLink id={SPELLS.HOT_STREAK.id} /> was active. This is a waste since those crits could have contibuted towards your next Hot Streak. Try to use your procs as soon as possible to avoid this.</span>)
+            .icon(SPELLS.HOT_STREAK.icon)
+            .actual(`${formatNumber(this.wastedCrits)} crits wasted`)
+            .recommended(`<${formatNumber(recommended)} is recommended`);
+      });
+      when(this.castBeforeHotStreakThresholds)
+        .addSuggestion((suggest, actual, recommended) => {
+          return suggest(<Wrapper>While <SpellLink id={SPELLS.COMBUSTION.id}/> was not active, you failed to <SpellLink id={SPELLS.FIREBALL.id}/> or <SpellLink id={SPELLS.SCORCH.id}/> just before using your <SpellLink id={SPELLS.HOT_STREAK.id}/> {this.noCastBeforeHotStreak} times ({formatPercentage(this.castBeforeHotStreakUtil)}%). Make sure you hard cast Fireball{this.combatants.selected.hasWrists(ITEMS.MARQUEE_BINDINGS_OF_THE_SUN_KING.id) ? `, a hard casted Pyroblast (if you have a bracer proc), ` : ` `}or Scorch just before each instant <SpellLink id={SPELLS.PYROBLAST.id}/> to increase the odds of getting a <SpellLink id={SPELLS.HEATING_UP.id}/> or <SpellLink id={SPELLS.HOT_STREAK.id}/> proc. Additionally, it is also acceptable to use your <SpellLink id={SPELLS.HOT_STREAK.id}/> procs if you need to move.</Wrapper>)
+            .icon(SPELLS.HOT_STREAK.icon)
+            .actual(`${formatPercentage(this.castBeforeHotStreakUtil)}% Utilization`)
+            .recommended(`${formatPercentage(recommended)}% is recommended`);
       });
   }
 
   statistic() {
-    const hotStreakUtil = (1 - (this.expiredProcs / this.totalProcs)) || 0;
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.HOT_STREAK.id} />}
-        value={`${formatPercentage(hotStreakUtil, 0)} %`}
+        value={(
+          <span>
+            <SpellIcon
+              id={SPELLS.HOT_STREAK.id}
+              style={{
+                height: '1.2em',
+                marginBottom: '.15em',
+              }}
+            />
+            {' '}{formatPercentage(this.hotStreakUtil, 0)}{' %'}
+            <br />
+            <SpellIcon
+              id={SPELLS.PYROBLAST.id}
+              style={{
+                height: '1.2em',
+                marginBottom: '.15em',
+              }}
+            />
+            {' '}{formatPercentage(this.castBeforeHotStreakUtil, 0)}{' %'}
+          </span>
+        )}
         label="Hot Streak Utilization"
-        tooltip={`You got ${this.totalProcs} total procs.
-					<ul>
-						<li>${this.usedProcs} used</li>
-						<li>${this.expiredProcs} expired</li>
-					</ul>
-				`}
+        tooltip={`Every Hot Streak should be preceded by Fireball${this.combatants.selected.hasWrists(ITEMS.MARQUEE_BINDINGS_OF_THE_SUN_KING.id) ? `, a hard casted Pyroblast (if you have a bracer proc), ` : ` `}or Scorch to increase the chances of gaining a Heating Up or Hot Streak buff. The only time you should not be doing this is during Combustion or when you need to move. Additionally, ensure that you are using all of your Hot Streak Procs and not letting them expire`}
       />
     );
   }
-
   statisticOrder = STATISTIC_ORDER.CORE(12);
 }
 

--- a/src/Parser/Mage/Fire/Modules/Features/HotStreak.js
+++ b/src/Parser/Mage/Fire/Modules/Features/HotStreak.js
@@ -69,7 +69,7 @@ class HotStreak extends Analyzer {
       debug && console.log("Wasted Crit Ignored @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
     } else if (HOT_STREAK_CONTRIBUTORS.includes(spellId) && event.timestamp - PROC_WINDOW_MS > this.hotStreakRemoved) {
       this.wastedCrits += 1;
-      debug && console.log("Hot Streak overwritten @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time) + this.combatants.selected.hasBuff(SPELLS.HOT_STREAK.id,null,-1));
+      debug && console.log("Hot Streak overwritten @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
     }
   }
 

--- a/src/Parser/Mage/Fire/Normalizers/Scorch.js
+++ b/src/Parser/Mage/Fire/Normalizers/Scorch.js
@@ -1,0 +1,38 @@
+import SPELLS from 'common/SPELLS';
+
+import EventsNormalizer from 'Parser/Core/EventsNormalizer';
+
+class Scorch extends EventsNormalizer {
+  /**
+   * @param {Array} events
+   * @returns {Array}
+   */
+  //Because Scorch has no travel time, ensures that the Scorch Damage event happens after Hot Streak is removed so the Scorch doesnt count as a direct damage crit during Hot Streak
+  normalize(events) {
+    const fixedEvents = [];
+    events.forEach((event, eventIndex) => {
+      fixedEvents.push(event);
+
+      if (event.type === 'removebuff' && event.ability.guid === SPELLS.HOT_STREAK.id) {
+        const castTimestamp = event.timestamp;
+
+        for (let previousEventIndex = eventIndex; previousEventIndex >= 0; previousEventIndex -= 1) {
+          const previousEvent = fixedEvents[previousEventIndex];
+          if ((castTimestamp - previousEvent.timestamp) > 50) {
+            break;
+          }
+          if (previousEvent.type === 'damage'  && previousEvent.ability.guid === SPELLS.SCORCH.id && previousEvent.sourceID === event.sourceID) {
+            fixedEvents.splice(previousEventIndex, 1);
+            fixedEvents.push(previousEvent);
+            previousEvent.__modified = true;
+            break;
+          }
+        }
+      }
+    });
+
+    return fixedEvents;
+  }
+}
+
+export default Scorch;


### PR DESCRIPTION
Hot Streak has been expanded to once again check for direct damage crits while Hot Streak is active (but now also disregards crits that happen when Pyromaniac procs and immediately re-activated Hot Streak).

Also added checks to make sure each use of hot streak has a hard cast ability like Fireball, Scorch, or Pyroblast (only if you have a bracer proc) immediately before it to increase the chance of getting a Heating Up or Hot Streak ... unless Combustion is active.