### PR TITLE
[BeastMastery] qapla updates

### DIFF
--- a/src/Parser/Hunter/BeastMastery/Modules/Items/QaplaEredunWarOrder.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Items/QaplaEredunWarOrder.js
@@ -48,7 +48,7 @@ class QaplaEredunWarOrder extends Analyzer {
     return {
       item: ITEMS.QAPLA_EREDUN_WAR_ORDER,
       result: (
-        <dfn data-tip={`You wasted ${formatNumber(this.wastedKillCommandReductionMs / 1000)} seconds of CDR by using Dire Beast when Kill Command wasn't on cooldown or had less than 3 seconds remaning on CD.`}>
+        <dfn data-tip={`You wasted ${formatNumber(this.wastedKillCommandReductionMs / 1000)} seconds of CDR by using Dire Beast when Kill Command wasn't on cooldown or had less than 3(+GCD) seconds remaning on CD.`}>
           reduced <SpellLink id={SPELLS.KILL_COMMAND.id} /> CD by {formatNumber(this.effectiveKillCommandReductionMs / 1000)}s in total.
         </dfn>
       ),

--- a/src/Parser/Hunter/BeastMastery/Modules/Items/QaplaEredunWarOrder.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Items/QaplaEredunWarOrder.js
@@ -7,6 +7,7 @@ import SpellUsable from 'Parser/Core/Modules/SpellUsable';
 import { formatNumber } from 'common/format';
 import ITEMS from "common/ITEMS/HUNTER";
 import SpellLink from "common/SpellLink";
+import GlobalCooldown from 'Parser/Core/Modules/GlobalCooldown';
 
 const COOLDOWN_REDUCTION_MS = 3000;
 
@@ -14,6 +15,7 @@ class QaplaEredunWarOrder extends Analyzer {
   static dependencies = {
     combatants: Combatants,
     spellUsable: SpellUsable,
+    globalCooldown: GlobalCooldown,
   };
 
   effectiveKillCommandReductionMs = 0;
@@ -28,11 +30,16 @@ class QaplaEredunWarOrder extends Analyzer {
     if (spellId !== SPELLS.DIRE_BEAST.id && spellId !== SPELLS.DIRE_FRENZY_TALENT.id) {
       return;
     }
-    const killCommandIsOnCooldown = this.spellUsable.isOnCooldown(SPELLS.KILL_COMMAND.id);
-    if (killCommandIsOnCooldown) {
-      const reductionMs = this.spellUsable.reduceCooldown(SPELLS.KILL_COMMAND.id, COOLDOWN_REDUCTION_MS);
-      this.effectiveKillCommandReductionMs += reductionMs;
-      this.wastedKillCommandReductionMs += (COOLDOWN_REDUCTION_MS - reductionMs);
+    if (this.spellUsable.isOnCooldown(SPELLS.KILL_COMMAND.id)) {
+      const globalCooldown = this.globalCooldown.getCurrentGlobalCooldown(spellId);
+      if (this.spellUsable.cooldownRemaining(SPELLS.KILL_COMMAND.id) < (COOLDOWN_REDUCTION_MS + globalCooldown)) {
+        const effectiveReductionMs = this.spellUsable.cooldownRemaining(SPELLS.KILL_COMMAND.id) - globalCooldown;
+        this.effectiveKillCommandReductionMs += effectiveReductionMs;
+        this.wastedKillCommandReductionMs += (COOLDOWN_REDUCTION_MS - effectiveReductionMs);
+      } else {
+        const reductionMs = this.spellUsable.reduceCooldown(SPELLS.KILL_COMMAND.id, COOLDOWN_REDUCTION_MS);
+        this.effectiveKillCommandReductionMs += reductionMs;
+      }
     } else {
       this.wastedKillCommandReductionMs += COOLDOWN_REDUCTION_MS;
     }


### PR DESCRIPTION
Firstly looking for feedback on this solution and how to word things in this module and if it's makes sense to you guys.. 

The scenario is this: 

You're wearing a legendary that upon using Dire Beast (or Dire Frenzy) reduces the cooldown of Kill Command by 3 seconds. 

Now if your current CD is less than 3s+GCD, then the cast efficiency module assumes you could cast more Kill Commands than you actually could (seeing as it spent that GCD off cooldown). 

What this aims to fix is provide a more realistic maxPossibleCast metric for Kill Command, aswell as a more realistic number for how much Kill Command was effectively reduced through this legendary.

Taken from a high-end parse: 
![image](https://user-images.githubusercontent.com/29204244/34681924-a1efb0f6-f49d-11e7-9c63-9304f5ecd0f5.png)
![image](https://user-images.githubusercontent.com/29204244/34681941-ab8e4942-f49d-11e7-8413-46f0bf1df08b.png)

After this change: 
![image](https://user-images.githubusercontent.com/29204244/34681966-b883af2a-f49d-11e7-9a64-774fd21b4ebd.png)
![image](https://user-images.githubusercontent.com/29204244/34681972-bd4ae424-f49d-11e7-9cc9-da0e9461246c.png)
 