### PR TITLE
[BrM Monk] Basic Purifying Brew Stat

### DIFF
--- a/src/Parser/Monk/Brewmaster/CHANGELOG.js
+++ b/src/Parser/Monk/Brewmaster/CHANGELOG.js
@@ -2,6 +2,11 @@ import { WOPR, emallson } from 'MAINTAINERS';
 
 export default [
   {
+    date: new Date('2018-01-12'),
+    changes: 'Added Purifying Brew statistic.',
+    contributors: [emallson],
+  },
+  {
     date: new Date('2018-01-02'),
     changes: 'Added brew cooldown reduction tracking.',
     contributors: [emallson],

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/PurifyingBrew.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/PurifyingBrew.js
@@ -1,17 +1,87 @@
+import React from 'react';
+import { formatNumber, formatPercentage } from 'common/format';
+import SpellIcon from 'common/SpellIcon';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SPELLS from 'common/SPELLS';
+import Combatants from 'Parser/Core/Modules/Combatants';
 import Analyzer from 'Parser/Core/Analyzer';
 import SharedBrews from '../Core/SharedBrews';
+
+const HEAVY_STAGGER_LEVEL = 2/3;
 
 class PurifyingBrew extends Analyzer {
   static dependencies = {
     brews: SharedBrews,
+    combatants: Combatants,
   };
+
+  purifyAmounts = [];
+
+  heavyPurifies = 0;
 
   on_byPlayer_cast(event) {
     if(event.ability.guid === SPELLS.PURIFYING_BREW.id) {
       this.brews.consumeCharge(event);
     }
   }
+
+  get meanPurify() {
+    if(this.purifyAmounts.length === 0) {
+      return 0;
+    }
+
+    return this.totalPurified / this.totalPurifies;
+  }
+
+  get minPurify() {
+    if(this.purifyAmounts.length === 0) {
+      return 0;
+    }
+
+    return this.purifyAmounts.reduce((prev, cur) => (prev < cur) ? prev : cur, Infinity);
+  }
+
+  get maxPurify() {
+    return this.purifyAmounts.reduce((prev, cur) => (prev > cur) ? prev : cur, 0);
+  }
+
+  get totalPurified() {
+    return this.purifyAmounts.reduce((prev, cur) => prev + cur, 0);
+  }
+
+  get badPurifies() {
+    return this.totalPurifies - this.heavyPurifies;
+  }
+
+  get totalPurifies() {
+    return this.purifyAmounts.length;
+  }
+
+  on_removestagger(event) {
+    if(event.reason.ability.guid !== SPELLS.PURIFYING_BREW.id) {
+      return;
+    }
+    this.purifyAmounts.push(event.amount);
+    // cannot (easily) rely on this.combatants.selected.hasBuff due to
+    // ordering issues
+    if(event.amount + event.newPooledDamage >= HEAVY_STAGGER_LEVEL * event.reason.maxHitPoints) {
+      this.heavyPurifies += 1;
+    }
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.PURIFYING_BREW.id} />}
+        value={`${formatNumber(this.meanPurify)}`}
+        label="Avg. Mitigation per Purifying Brew"
+        tooltip={`Purifying Brew removed <b>${formatNumber(this.totalPurified)}</b> damage in total over ${this.totalPurifies} casts.<br/>
+                  The smallest purify removed <b>${formatNumber(this.minPurify)}</b> and the largest purify removed <b>${formatNumber(this.maxPurify)}</b>.<br/>
+                  You purified <b>${this.badPurifies}</b> (${formatPercentage(this.badPurifies / this.totalPurifies)}%) times without reaching Heavy Stagger.`}
+          />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.OPTIONAL();
 }
 
 export default PurifyingBrew;

--- a/src/common/SPELLS/MONK.js
+++ b/src/common/SPELLS/MONK.js
@@ -429,6 +429,21 @@ export default {
     name: 'Stagger',
     icon: 'ability_rogue_cheatdeath',
   },
+  LIGHT_STAGGER_DEBUFF: {
+    id: 124275,
+    name: 'Light Stagger',
+    icon: 'priest_icon_chakra_green',
+  },
+  MODERATE_STAGGER_DEBUFF: {
+    id: 124274,
+    name: 'Moderate Stagger',
+    icon: 'priest_icon_chakra',
+  },
+  HEAVY_STAGGER_DEBUFF: {
+    id: 124273,
+    name: 'Heavy Stagger',
+    icon: 'priest_icon_chakra_red',
+  },
   EXPEL_HARM_DAMAGE: {
     id: 115129,
     name: 'Expel Harm',


### PR DESCRIPTION
Shows the amount, mean, min, and max amount of damage purified with Purifying Brew. Also tracks the number of times you purified w/o being in heavy (red) stagger. 

Generally speaking not purifying when below heavy stagger is a good rule of thumb, but I'm not sure where to put the suggestion threshold yet (so there isn't an associated suggestion).