### PR TITLE
(Holy Priest) Divine Hymn buff contribution

### DIFF
--- a/src/Parser/Core/Combatant.js
+++ b/src/Parser/Core/Combatant.js
@@ -79,7 +79,7 @@ class Combatant extends Entity {
       case SPECS.HOLY_PALADIN:
         return 0.12 + this.masteryRating / 26667;
       case SPECS.HOLY_PRIEST:
-        return 0.05 + this.masteryRating / 32000;
+        return 0.10 + this.masteryRating / 32000;
       case SPECS.RESTORATION_SHAMAN:
         return 0.24 + this.masteryRating / 13333.3333333;
       case SPECS.ENHANCEMENT_SHAMAN:

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -221,7 +221,7 @@ class StatTracker extends Analyzer {
         return standard + 0.05; //baseline +5%
       case SPECS.WINDWALKER_MONK:
         return standard + 0.05; //baseline +5%
-      default:      
+      default:
         return standard;
     }
   }
@@ -233,7 +233,7 @@ class StatTracker extends Analyzer {
       case SPECS.HOLY_PALADIN:
         return 0.12;
       case SPECS.HOLY_PRIEST:
-        return 0.05;
+        return 0.10;
       case SPECS.SHADOW_PRIEST:
         return 0.2;
       case SPECS.DISCIPLINE_PRIEST:

--- a/src/Parser/Priest/Holy/CHANGELOG.js
+++ b/src/Parser/Priest/Holy/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+12-01-2018 - Added Divine Hymn buff contribution (by enragednuke)
 06-11-2017 - Added support for T21 (by Dyspho)
 03-09-2017 - Added Echo of Light (Mastery) breakdown (by enragednuke)
 22-07-2017 - Added Holy Word: Sanctify efficiency metric and fixed an issue with Prayer of Mending cast efficiency (by enragednuke)

--- a/src/Parser/Priest/Holy/CombatLogParser.js
+++ b/src/Parser/Priest/Holy/CombatLogParser.js
@@ -28,6 +28,7 @@ import MasteryBreakdown from './Modules/PriestCore/MasteryBreakdown';
 import Serendipity from './Modules/PriestCore/Serendipity';
 import SanctifyReduction from './Modules/PriestCore/SerendipityReduction/SanctifyReduction';
 import SerenityReduction from './Modules/PriestCore/SerendipityReduction/SerenityReduction';
+import HymnBuffBenefit from './Modules/PriestCore/HymnBuffBenefit';
 
 // Items
 import TrousersOfAnjuna from './Modules/Items/TrousersOfAnjuna';
@@ -57,6 +58,7 @@ class CombatLogParser extends CoreCombatLogParser {
     serendipity: Serendipity,
     sancReduction: SanctifyReduction,
     sereReduction: SerenityReduction,
+    hymnBuffBenefit: HymnBuffBenefit,
 
     // Spells
     prayerOfMending: PrayerOfMending,

--- a/src/Parser/Priest/Holy/Modules/PriestCore/HymnBuffBenefit.js
+++ b/src/Parser/Priest/Holy/Modules/PriestCore/HymnBuffBenefit.js
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import fetchWcl from 'common/fetchWcl';
+import SpellIcon from 'common/SpellIcon';
+import { formatNumber } from 'common/format';
+
+import LazyLoadStatisticBox from 'Main/LazyLoadStatisticBox';
+
+import Analyzer from 'Parser/Core/Analyzer';
+
+const DIVINE_HYMN_HEALING_INCREASE = 0.1;
+
+class HymnBuffBenefit extends Analyzer {
+  // This is an approximation. See the reasoning below.
+  totalHealingFromHymnBuff = 0;
+
+  load() {
+    return fetchWcl(`report/tables/healing/${this.owner.report.code}`, {
+      start: this.owner.fight.start_time,
+      end: this.owner.fight.end_time,
+      filter: `IN RANGE FROM type='applybuff' AND ability.id=${SPELLS.DIVINE_HYMN_HEAL.id} TO type='removebuff' AND ability.id=${SPELLS.DIVINE_HYMN_HEAL.id} GROUP BY target ON target END`,
+    })
+      .then(json => {
+        this.totalHealingFromHymnBuff = json.entries.reduce(
+          // Because this is a % healing increase and we are unable to parse each healing event individually for its effective healing,
+          // we need to do some "approximations" using the total overheal in tandem with the total healing. We do not want to naively
+          // assume all healing was fully effective, as this would drastically overweight the power of the buff in situations where a
+          // lot of overhealing occurs.
+          (healingFromBuff, entry) => healingFromBuff + ((entry.total - entry.total / (1 + DIVINE_HYMN_HEALING_INCREASE)) * (entry.total / (entry.total + (entry.overheal || 0)))),
+        0);
+      });
+  }
+
+  statistic() {
+    const fightDuration = this.owner.fightDuration;
+
+    return (
+      <LazyLoadStatisticBox
+        loader={this.load.bind(this)}
+        icon={<SpellIcon id={SPELLS.DIVINE_HYMN_CAST.id} />}
+        value={`≈${formatNumber(this.totalHealingFromHymnBuff / fightDuration * 1000)} HPS`}
+        label="Hymn Buff Contribution"
+        tooltip={
+          `The Divine Hymn buff contributed ${formatNumber(this.totalHealingFromHymnBuff)} healing. This includes healing from other healers.<br/>
+          NOTE: This metric uses an approximation to calculate contribution from the buff due to technical limitations.`
+        }
+      />
+    );
+  }
+}
+
+export default HymnBuffBenefit;


### PR DESCRIPTION
Adds a module that allows users to see the (approximate, see comments) effective healing contributed by the Divine Hymn healing increase buff. Suggested by Roras on the H2P discord.

Also fixes the existing issue of Mastery appearing 5% lower than it should on the analyzer.

![image](https://user-images.githubusercontent.com/9220151/34872126-ce0a1920-f75d-11e7-9be1-e62824622cab.png)
