### PR TITLE
[resto druid] ToL rewrite + some minor fixes

### DIFF
--- a/src/Parser/Druid/Restoration/Modules/Features/Clearcasting.js
+++ b/src/Parser/Druid/Restoration/Modules/Features/Clearcasting.js
@@ -9,7 +9,7 @@ import SPELLS from 'common/SPELLS';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
-const debug = true;
+const debug = false;
 
 class Clearcasting extends Analyzer {
   static dependencies = {

--- a/src/Parser/Druid/Restoration/Modules/Features/Innervate.js
+++ b/src/Parser/Druid/Restoration/Modules/Features/Innervate.js
@@ -217,7 +217,7 @@ class Innervate extends Analyzer {
     return(
       <StatisticBox
         icon={<SpellIcon id={SPELLS.INNERVATE.id} />}
-        value={`${this.averageManaSaved.toFixed(0)} mana`}
+        value={`${formatNumber(this.averageManaSaved)} mana`}
         label="Mana saved per Innervate"
         tooltip={
           `<ul>

--- a/src/Parser/Druid/Restoration/Modules/Talents/TreeOfLife.js
+++ b/src/Parser/Druid/Restoration/Modules/Talents/TreeOfLife.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { formatPercentage, formatDuration } from 'common/format';
+import { formatPercentage } from 'common/format';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';
@@ -218,7 +218,7 @@ class TreeOfLife extends Analyzer {
         icon={<SpellIcon id={SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id} />}
         value={`${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this._getTotalHealing(this.hardcast)))} %`}
         label="Tree of Life Healing"
-        tooltip={`The Tree of Life buff ${this.hasCs ? '(not including from Chameleon Song procs) ' : ''}was active for <b>${formatDuration(this.hardcastUptime/1000)}</b>, or <b>${formatPercentage(this.hardcastUptimePercent)}%</b> of the encounter. The displayed healing number ${this.hasCs ? 'does not include healing from Chameleon Song procs and ' : ''} is the sum of several benefits, listed below.
+        tooltip={`The Tree of Life buff ${this.hasCs ? '(not including from Chameleon Song procs) ' : ''}was active for <b>${(this.hardcastUptime/1000).toFixed(0)}s</b>, or <b>${formatPercentage(this.hardcastUptimePercent)}%</b> of the encounter. The displayed healing number ${this.hasCs ? 'does not include healing from Chameleon Song procs and ' : ''} is the sum of several benefits, listed below:
           <ul>
             <li>Overall Increased Healing: <b>${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.hardcast.allBoostHealing))}%</b></li>
             <li>Rejuv Increased Healing: <b>${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.hardcast.rejuvBoostHealing))}%</b></li>
@@ -241,7 +241,7 @@ class TreeOfLife extends Analyzer {
     return {
       item: ITEMS.CHAMELEON_SONG,
       result: (
-        <dfn data-tip={`The Tree of Life buff ${this.hasTol ? '(from procs only, not including Tree of Life casts) ' : ''}was active for <b>${formatDuration(this.csUptime/1000)}</b>, or <b>${formatPercentage(this.csUptimePercent)}%</b> of the encounter. The displayed healing number ${this.hasTol ? 'includes healing from procs only, and ' : ''} is the sum of several benefits, listed below.
+        <dfn data-tip={`The Tree of Life buff ${this.hasTol ? '(from procs only, not including Tree of Life casts) ' : ''}was active for <b>${(this.csUptime/1000).toFixed(0)}s</b>, or <b>${formatPercentage(this.csUptimePercent)}%</b> of the encounter. The displayed healing number ${this.hasTol ? 'includes healing from procs only, and ' : ''} is the sum of several benefits, listed below:
           <ul>
             <li>Overall Increased Healing: <b>${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.chameleonSong.allBoostHealing))}%</b></li>
             <li>Rejuv Increased Healing: <b>${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.chameleonSong.rejuvBoostHealing))}%</b></li>

--- a/src/Parser/Druid/Restoration/Modules/Talents/TreeOfLife.js
+++ b/src/Parser/Druid/Restoration/Modules/Talents/TreeOfLife.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { formatPercentage } from 'common/format';
+import { formatPercentage, formatNumber } from 'common/format';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';
@@ -21,6 +21,7 @@ const ALL_BOOST = 0.15;
 const ALL_MULT = 1.15;
 const REJUV_BOOST = 0.50;
 const REJUV_MANA_SAVED = 0.30;
+const REJUV_MANA_COST = 220000 * 0.1;
 const WG_INCREASE = (8 / 6) - 1; // TODO get more accuracy by implementing with attributor
 const TOL_DURATION = 30000;
 
@@ -54,7 +55,6 @@ class TreeOfLife extends Analyzer {
   completedCsUptime = 0;
 
   hardcast = {
-    //procs: 0,
     allBoostHealing: 0,
     rejuvBoostHealing: 0,
     rejuvManaSaved: 0,
@@ -62,7 +62,6 @@ class TreeOfLife extends Analyzer {
   };
 
   chameleonSong = {
-    //procs: 0,
     allBoostHealing: 0,
     rejuvBoostHealing: 0,
     rejuvManaSaved: 0,
@@ -177,6 +176,10 @@ class TreeOfLife extends Analyzer {
     return accumulator.rejuvManaSaved * this.rejuvenation.avgRejuvHealing;
   }
 
+  _getManaSaved(accumulator) {
+    return accumulator.rejuvManaSaved * REJUV_MANA_COST;
+  }
+
   _getTotalHealing(accumulator) {
     return accumulator.allBoostHealing + accumulator.rejuvBoostHealing + accumulator.extraWgHealing + this._getManaSavedHealing(accumulator);
   }
@@ -185,9 +188,9 @@ class TreeOfLife extends Analyzer {
     return {
       actual: this.owner.getPercentageOfTotalHealingDone(this._getTotalHealing(this.hardcast)),
       isLessThan: {
-        minor: 0.11,
-        average: 0.07,
-        major: 0.04,
+        minor: 0.09,
+        average: 0.06,
+        major: 0.03,
       },
       style: 'percentage',
     };
@@ -219,7 +222,7 @@ class TreeOfLife extends Analyzer {
           <ul>
             <li>Overall Increased Healing: <b>${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.hardcast.allBoostHealing))}%</b></li>
             <li>Rejuv Increased Healing: <b>${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.hardcast.rejuvBoostHealing))}%</b></li>
-            <li>Rejuv Mana Saved est. throughtput: <b>~${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this._getManaSavedHealing(this.hardcast)))}%</b></li>
+            <li>Rejuv Mana Saved: <b>${formatNumber(this._getManaSaved(this.hardcast))}</b> (assuming mana used to fill with Rejuvs: <b>≈${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this._getManaSavedHealing(this.hardcast)))}%</b> healing)</li>
             <li>Increased Wild Growths: <b>${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.hardcast.extraWgHealing))}%</b></li>
           </ul>
         `}
@@ -240,7 +243,7 @@ class TreeOfLife extends Analyzer {
           <ul>
             <li>Overall Increased Healing: <b>${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.chameleonSong.allBoostHealing))}%</b></li>
             <li>Rejuv Increased Healing: <b>${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.chameleonSong.rejuvBoostHealing))}%</b></li>
-            <li>Rejuv Mana Saved est. throughtput: <b>~${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this._getManaSavedHealing(this.chameleonSong)))}%</b></li>
+            <li>Rejuv Mana Saved: <b>${this._getManaSaved(this.chameleonSong)}</b> (assuming mana used to fill with Rejuvs: <b>≈${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this._getManaSavedHealing(this.chameleonSong)))}%</b> healing)</li>
             <li>Increased Wild Growths: <b>${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.chameleonSong.extraWgHealing))}%</b></li>
           </ul>`}>
           <ItemHealingDone amount={this._getTotalHealing(this.chameleonSong)} />

--- a/src/Parser/Druid/Restoration/Modules/Talents/TreeOfLife.js
+++ b/src/Parser/Druid/Restoration/Modules/Talents/TreeOfLife.js
@@ -210,9 +210,6 @@ class TreeOfLife extends Analyzer {
       return;
     }
 
-    // TODO get uptimes and proc rates
-
-
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id} />}
@@ -235,8 +232,6 @@ class TreeOfLife extends Analyzer {
     if(!this.hasCs) {
       return;
     }
-
-    // TODO get uptimes and proc rates
 
     return {
       item: ITEMS.CHAMELEON_SONG,

--- a/src/Parser/Druid/Restoration/Modules/Talents/TreeOfLife.js
+++ b/src/Parser/Druid/Restoration/Modules/Talents/TreeOfLife.js
@@ -12,21 +12,30 @@ import HealingDone from 'Parser/Core/Modules/HealingDone';
 import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import ItemHealingDone from 'Main/ItemHealingDone';
+import calculateEffectiveHealing from 'Parser/Core/calculateEffectiveHealing';
 
 import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from '../../Constants';
 import Rejuvenation from '../Core/Rejuvenation';
 
-const debug = false;
+const ALL_BOOST = 0.15;
+const ALL_MULT = 1.15;
+const REJUV_BOOST = 0.50;
+const REJUV_MANA_SAVED = 0.30;
+const WG_INCREASE = (8 / 6) - 1; // TODO get more accuracy by implementing with attributor
+const TOL_DURATION = 30000;
 
-const WG_TARGETS = 6;
-const REJUV_BASE_MANA = 10;
-const REJUVENATION_REDUCED_MANA = 0.3;
-const HEALING_INCREASE = 1.15;
-const REJUV_HEALING_INCREASE = 1.5;
-const WILD_GROWTH_HEALING_INCREASE = (WG_TARGETS + 2) / WG_TARGETS;
-const TREE_OF_LIFE_COOLDOWN = 180000;
-const TREE_OF_LIFE_DURATION = 30000;
+// have to be careful about applying stacking boosts so we don't double count. Arbitrarily considering all boost to be applied "first"
+// for example, lets say a rejuv tick during ToL heals for 1000 base, but is boosted by 1.15 * 1.5 => 1725... a total of 725 raw boost
+// if we count each as a seperate boost, we get 1.15 => 225 boost, 1.5 => 575, total of 800 ... the overlapping boost was double counted
+// we correct for this by dividing out the all boost before calcing either the rejuv boost or the wg increase
 
+/*
+ * Tree of Life bonuses:
+ *  - ALL: +15% healing
+ *  - Rejuv: +50% healing and -30% mana
+ *  - Regrowth: instant
+ *  - Wild Growth: +2 targets
+ */
 class TreeOfLife extends Analyzer {
   static dependencies = {
     healingDone: HealingDone,
@@ -35,205 +44,107 @@ class TreeOfLife extends Analyzer {
     rejuvenation: Rejuvenation,
   };
 
-  hasGermination = false;
   hasTol = false;
+  lastTolCast = null;
+
   hasCs = false;
 
-  totalHealingEncounter = 0;
-  totalHealingDuringToL = 0;
-  totalHealingFromRejuvenationDuringToL = 0;
-  totalHealingFromRejuvenationEncounter = 0;
-  totalRejuvenationsEncounter = 0;
-  totalRejuvenationsDuringToL = 0;
-  totalHealingFromWildgrowthsDuringToL = 0;
-  throughput = 0;
-  tolManualApplyTimestamp = null;
-  tolCasts = 0;
+  hardcast = {
+    //procs: 0,
+    allBoostHealing: 0,
+    rejuvBoostHealing: 0,
+    rejuvManaSaved: 0,
+    extraWgHealing: 0,
+  };
 
-  // Chameleon song
-  totalHealingDuringToLHelmet = 0;
-  totalHealingFromRejuvenationDuringToLHelmet = 0;
-  totalRejuvenationsDuringToLHelmet = 0;
-  totalHealingFromWildgrowthsDuringToLHelmet = 0;
-  throughputHelmet = 0;
-  adjustHelmetUptime = 0;
-  proccs = 0;
+  chameleonSong = {
+    //procs: 0,
+    allBoostHealing: 0,
+    rejuvBoostHealing: 0,
+    rejuvManaSaved: 0,
+    extraWgHealing: 0,
+  };
 
   on_initialized() {
     this.hasTol = this.combatants.selected.hasTalent(SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id);
     this.hasCs = this.combatants.selected.hasHead(ITEMS.CHAMELEON_SONG.id);
-
     this.active = this.hasTol || this.hasCs;
+  }
 
-    this.hasGermination = this.combatants.selected.hasTalent(SPELLS.GERMINATION_TALENT.id);
+  // gets the appropriate accumulator for tallying this event
+  // if ToL buff isn't active, returns null,
+  // if ToL buff is due to hardcast, returns the hardcast accumulator,
+  // if ToL buff is due to CS, returns the CS accumulator.
+  _getAccumulator(event) {
+    if (!this.combatants.selected.hasBuff(SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id)) {
+      return null;
+    } else if ((!this.hasCs) || (this.lastTolCast && this.lastTolCast + TOL_DURATION > event.timestamp)) {
+      return this.hardcast;
+    } else {
+      return this.chameleonSong;
+    }
   }
 
   on_byPlayer_heal(event) {
     const spellId = event.ability.guid;
-    const amount = event.amount + (event.absorbed || 0);
     if (ABILITIES_AFFECTED_BY_HEALING_INCREASES.indexOf(spellId) === -1) {
       return;
     }
 
-    // Get total healing from rejuv + germ (if specced).
-    if (SPELLS.REJUVENATION.id === spellId) {
-      this.totalHealingFromRejuvenationEncounter += amount;
-    } else if (this.hasGermination && SPELLS.REJUVENATION_GERMINATION.id === spellId) {
-      this.totalHealingFromRejuvenationEncounter += amount;
+    // chooses which attribution accumulator to use based on if the ToL buff is due to a hardcast or a CS proc
+    const accumulator = this._getAccumulator(event);
+    if (!accumulator) {
+      return;
     }
 
-    // Get total healing from rejuv + germ (if specced) during ToL
-    if (this.combatants.selected.hasBuff(SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id)) {
-      if (this.tolManualApplyTimestamp !== null && event.timestamp <= this.tolManualApplyTimestamp + TREE_OF_LIFE_DURATION) {
-        if (SPELLS.REJUVENATION.id === spellId) {
-          this.totalHealingFromRejuvenationDuringToL += amount;
-        } else if (this.hasGermination && SPELLS.REJUVENATION_GERMINATION.id === spellId) {
-          this.totalHealingFromRejuvenationDuringToL += amount;
-        } else if (SPELLS.WILD_GROWTH.id === spellId) {
-          this.totalHealingFromWildgrowthsDuringToL += amount;
-        }
-        // Get total healing during ToL
-        this.totalHealingDuringToL += amount;
-      } else {
-        if (SPELLS.REJUVENATION.id === spellId) {
-          this.totalHealingFromRejuvenationDuringToLHelmet += amount;
-        } else if (this.hasGermination && SPELLS.REJUVENATION_GERMINATION.id === spellId) {
-          this.totalHealingFromRejuvenationDuringToLHelmet += amount;
-        } else if (SPELLS.WILD_GROWTH.id === spellId) {
-          this.totalHealingFromWildgrowthsDuringToLHelmet += amount;
-        }
-        // Get total healing during ToL
-        this.totalHealingDuringToLHelmet += amount;
-      }
+    accumulator.allBoostHealing += calculateEffectiveHealing(event, ALL_BOOST);
+
+    if(spellId === SPELLS.REJUVENATION.id || spellId === SPELLS.REJUVENATION_GERMINATION.id) {
+      accumulator.rejuvBoostHealing += (calculateEffectiveHealing(event, REJUV_BOOST) / ALL_MULT);
+    } else if (spellId === SPELLS.WILD_GROWTH.id) {
+      accumulator.extraWgHealing += (calculateEffectiveHealing(event, WG_INCREASE) / ALL_MULT);
     }
   }
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
-    if (SPELLS.REJUVENATION.id === spellId) {
-      this.totalRejuvenationsEncounter += 1;
-    }
-
-    if (this.combatants.selected.hasBuff(SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id)) {
-      if (this.tolManualApplyTimestamp !== null && event.timestamp <= this.tolManualApplyTimestamp + TREE_OF_LIFE_DURATION) {
-        if (SPELLS.REJUVENATION.id === spellId) {
-          this.totalRejuvenationsDuringToL += 1;
-        }
-      } else {
-        if (SPELLS.REJUVENATION.id === spellId) {
-          this.totalRejuvenationsDuringToLHelmet += 1;
-        }
+    if (spellId === SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id) {
+      this.lastTolCast = event.timestamp;
+      return;
+    } else if (spellId === SPELLS.REJUVENATION.id) {
+      const accumulator = this._getAccumulator(event);
+      if (!accumulator) {
+        return;
       }
-    }
-
-    if (SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id === spellId && (this.tolManualApplyTimestamp === null || (this.tolManualApplyTimestamp + TREE_OF_LIFE_COOLDOWN) < event.timestamp)) {
-      this.tolManualApplyTimestamp = event.timestamp;
-      this.tolCasts += 1;
-      this.proccs -= 1;
+      accumulator.rejuvManaSaved += REJUV_MANA_SAVED;
     }
   }
 
   on_byPlayer_applybuff(event) {
     const spellId = event.ability.guid;
-    if (SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id === spellId) {
-      this.proccs += 1;
+    if (spellId === SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id && event.prepull && this.hasTol) {
+      this.lastTolCast = event.timestamp; // if player has ToL talent and buff was present on pull, assume it was from a precast
     }
   }
 
-  on_finished() {
-    // Adjust uptime if we're specced into ToL + using Chameleon Head and not getting a full use of ToL before end duration of fight.
-    if (this.tolManualApplyTimestamp + TREE_OF_LIFE_DURATION > this.owner.fight.end_time) {
-      this.adjustHelmetUptime = TREE_OF_LIFE_DURATION - (this.owner.fight.end_time - this.tolManualApplyTimestamp);
+  on_byPlayer_removebuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId === SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id) {
+      this.lastTolCast = null;
     }
-    // Encounter finished, let's tie up the variables
-    debug && console.log(`Has germination: ${this.hasGermination}`);
-    debug && console.log(`Total healing encounter: ${this.healingDone.total.effective}`);
-    debug && console.log(`Total healing during ToL: ${this.totalHealingDuringToL}`);
-    debug && console.log(`Total healing from rejuvenation encounter: ${this.totalHealingFromRejuvenationEncounter}`);
-    debug && console.log(`Total healing from rejuvenation during ToL: ${this.totalHealingFromRejuvenationDuringToL}`);
-    debug && console.log(`Total rejuvenation casted encounter: ${this.totalRejuvenationsEncounter}`);
-    debug && console.log(`Total rejuvenation casted during ToL: ${this.totalRejuvenationsDuringToL}`);
-    debug && console.log(`Total rejuvenation casted during ToL helmet: ${this.totalRejuvenationsDuringToLHelmet}`);
-    debug && console.log(`Total healing from wild growth during ToL: ${this.totalHealingFromWildgrowthsDuringToL}`);
-
-    // Get 1 rejuv throughput worth
-    const oneRejuvenationThroughput = this.owner.getPercentageOfTotalHealingDone(this.rejuvenation.avgRejuvHealing);
-    debug && console.log(`1 Rejuvenation throughput: ${(oneRejuvenationThroughput * 100).toFixed(2)}%`);
-
-    // 50% of total healing from rejuv+germ during ToL and divide it with the encounter total healing.
-    const rejuvenationIncreasedEffect = this.owner.getPercentageOfTotalHealingDone(this.totalHealingFromRejuvenationDuringToL / HEALING_INCREASE - this.totalHealingFromRejuvenationDuringToL / (HEALING_INCREASE * REJUV_HEALING_INCREASE));
-    debug && console.log(`rejuvenationIncreasedEffect: ${(rejuvenationIncreasedEffect * 100).toFixed(2)}%`);
-
-    // 15% of total healing during ToL and divide it with the encounter total healing
-    const tolIncreasedHealingDone = this.owner.getPercentageOfTotalHealingDone(this.totalHealingDuringToL - this.totalHealingDuringToL / HEALING_INCREASE);
-    debug && console.log(`tolIncreasedHealingDone: ${(tolIncreasedHealingDone * 100).toFixed(2)}%`);
-
-    // The amount of free rejuvs gained by the reduced mana cost, calculated into throughput by the "1 Rejuv throughput worth"
-    const rejuvenationMana = (((this.totalRejuvenationsDuringToL * REJUV_BASE_MANA) * REJUVENATION_REDUCED_MANA) / REJUV_BASE_MANA) * oneRejuvenationThroughput;
-    debug && console.log(`rejuvenationMana: ${(rejuvenationMana * 100).toFixed(2)}%`);
-
-    // 33% of total healing from WG during ToL and divide it with the encounter total healing.
-    const wildGrowthIncreasedEffect = this.owner.getPercentageOfTotalHealingDone(this.totalHealingFromWildgrowthsDuringToL / HEALING_INCREASE - this.totalHealingFromWildgrowthsDuringToL / (HEALING_INCREASE * WILD_GROWTH_HEALING_INCREASE));
-    debug && console.log(`wildGrowthIncreasedEffect: ${(wildGrowthIncreasedEffect * 100).toFixed(2)}%`);
-
-    // Total throughput from using Tree of Life
-    this.throughput = rejuvenationIncreasedEffect + tolIncreasedHealingDone + rejuvenationMana + wildGrowthIncreasedEffect;
-    debug && console.log(`uptime: ${((this.combatants.selected.getBuffUptime(SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id) / this.owner.fightDuration) * 100).toFixed(2)}%`);
-    debug && console.log(`throughput: ${(this.throughput * 100).toFixed(2)}%`);
-
-    // Chameleon song
-    const rejuvenationIncreasedEffectHelmet = this.owner.getPercentageOfTotalHealingDone(this.totalHealingFromRejuvenationDuringToLHelmet / HEALING_INCREASE - this.totalHealingFromRejuvenationDuringToLHelmet / (HEALING_INCREASE * REJUV_HEALING_INCREASE));
-    debug && console.log(`rejuvenationIncreasedEffectHelmet: ${(rejuvenationIncreasedEffectHelmet * 100).toFixed(2)}%`);
-    const tolIncreasedHealingDoneHelmet = this.owner.getPercentageOfTotalHealingDone(this.totalHealingDuringToLHelmet - this.totalHealingDuringToLHelmet / HEALING_INCREASE);
-    debug && console.log(`tolIncreasedHealingDone: ${(tolIncreasedHealingDoneHelmet * 100).toFixed(2)}%`);
-    const rejuvenationManaHelmet = (((this.totalRejuvenationsDuringToLHelmet * REJUV_BASE_MANA) * REJUVENATION_REDUCED_MANA) / REJUV_BASE_MANA) * oneRejuvenationThroughput;
-    debug && console.log(`rejuvenationManaHelmet: ${(rejuvenationManaHelmet * 100).toFixed(2)}%`);
-    const wildGrowthIncreasedEffectHelmet = this.owner.getPercentageOfTotalHealingDone(this.totalHealingFromWildgrowthsDuringToLHelmet / HEALING_INCREASE - this.totalHealingFromWildgrowthsDuringToLHelmet / (HEALING_INCREASE * WILD_GROWTH_HEALING_INCREASE));
-    debug && console.log(`wildGrowthIncreasedEffectHelmet: ${(wildGrowthIncreasedEffectHelmet * 100).toFixed(2)}%`);
-    this.throughputHelmet = rejuvenationIncreasedEffectHelmet + tolIncreasedHealingDoneHelmet + rejuvenationManaHelmet + wildGrowthIncreasedEffectHelmet;
-    debug && console.log(`uptimeHelmet: ${(((this.combatants.selected.getBuffUptime(SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id) - (this.tolCasts * TREE_OF_LIFE_DURATION)) / this.owner.fightDuration) * 100).toFixed(2)}%`);
-    debug && console.log(`throughputHelmet: ${(this.throughputHelmet * 100).toFixed(2)}%`);
-    debug && console.log(`tolcasts: ${this.tolCasts}`);
   }
 
-  get rejuvenationIncreasedThroughput() {
-    return (this.totalHealingFromRejuvenationDuringToL / 1.15) - (this.totalHealingFromRejuvenationDuringToL / (1.15 * 1.5)); // TODO what's up with this calc?
-  }
-  get rejuvenationIncreasedThroughputPercent() {
-    return this.owner.getPercentageOfTotalHealingDone(this.rejuvenationIncreasedThroughput);
+  _getManaSavedHealing(accumulator) {
+    return accumulator.rejuvManaSaved * this.rejuvenation.avgRejuvHealing;
   }
 
-  get tolIncreasedThroughput() {
-    return this.totalHealingDuringToL - this.totalHealingDuringToL / 1.15;
-  }
-  get tolIncreasedThroughputPercent() {
-    return this.owner.getPercentageOfTotalHealingDone(this.tolIncreasedThroughput);
-  }
-
-  get rejuvManaThroughput() {
-    return (((this.totalRejuvenationsDuringToL * 10) * 0.3) / 10) * this.rejuvenation.avgRejuvHealing; // TODO what's up with this calc?
-  }
-  get rejuvManaThroughputPercent() {
-    return this.owner.getPercentageOfTotalHealingDone(this.rejuvManaThroughput);
-  }
-
-  get wildGrowthIncreasedThroughput() {
-    return this.totalHealingFromWildgrowthsDuringToL / 1.15 - this.totalHealingFromWildgrowthsDuringToL / (1.15 * (8 / 6)); // TODO what's up with this calc?
-  }
-  get wildGrowthIncreasedThroughputPercent() {
-    return this.owner.getPercentageOfTotalHealingDone(this.wildGrowthIncreasedThroughput);
-  }
-
-  get totalThroughput() {
-    return this.rejuvenationIncreasedThroughput + this.tolIncreasedThroughput + this.rejuvManaThroughput + this.wildGrowthIncreasedThroughput;
-  }
-  get totalThroughputPercent() {
-    return this.owner.getPercentageOfTotalHealingDone(this.totalThroughput);
+  _getTotalHealing(accumulator) {
+    return accumulator.allBoostHealing + accumulator.rejuvBoostHealing + accumulator.extraWgHealing + this._getManaSavedHealing(accumulator);
   }
 
   get suggestionThresholds() {
     return {
-      actual: this.totalThroughputPercent,
+      actual: this.owner.getPercentageOfTotalHealingDone(this._getTotalHealing(this.hardcast)),
       isLessThan: {
         minor: 0.11,
         average: 0.07,
@@ -260,24 +171,19 @@ class TreeOfLife extends Analyzer {
       return;
     }
 
-    let treeOfLifeUptime = this.combatants.selected.getBuffUptime(SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id) / this.owner.fightDuration;
-    const chameleonSongUptime = (this.combatants.selected.getBuffUptime(SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id) - (this.tolCasts * 30000) + this.adjustHelmetUptime) / this.owner.fightDuration;
-    if (this.combatants.selected.hasHead(ITEMS.CHAMELEON_SONG.id)) {
-      treeOfLifeUptime -= chameleonSongUptime;
-    }
+    // TODO get uptimes and proc rates
 
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id} />}
-        value={`${formatPercentage(this.totalThroughputPercent)} %`}
+        value={`${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this._getTotalHealing(this.hardcast)))} %`}
         label="Tree of Life Healing"
         tooltip={`
           <ul>
-            <li>${formatPercentage(this.rejuvenationIncreasedThroughputPercent)}% from increased rejuvenation healing</li>
-            <li>${formatPercentage(this.rejuvManaThroughputPercent)}% from reduced rejuvenation cost</li>
-            <li>${formatPercentage(this.wildGrowthIncreasedThroughputPercent)}% from increased wildgrowth healing</li>
-            <li>${formatPercentage(this.tolIncreasedThroughputPercent)}% from overall increased healing</li>
-            <li>${formatPercentage(treeOfLifeUptime)}% uptime</li>
+            <li>Overall Increased Healing: <b>${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.hardcast.allBoostHealing))}%</b></li>
+            <li>Rejuv Increased Healing: <b>${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.hardcast.rejuvBoostHealing))}%</b></li>
+            <li>Rejuv Mana Saved est. throughtput: <b>~${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this._getManaSavedHealing(this.hardcast)))}%</b></li>
+            <li>Increased Wild Growths: <b>${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.hardcast.extraWgHealing))}%</b></li>
           </ul>
         `}
       />
@@ -286,40 +192,23 @@ class TreeOfLife extends Analyzer {
   statisticOrder = STATISTIC_ORDER.OPTIONAL();
 
   item() {
-    if(!this.hasCs) { return; }
+    if(!this.hasCs) {
+      return;
+    }
 
-    const oneRejuvenationThroughput = this.rejuvenation.avgRejuvHealing;
-
-    const rejuvenationIncreasedEffectHelmet = this.totalHealingFromRejuvenationDuringToLHelmet / 1.15 - this.totalHealingFromRejuvenationDuringToLHelmet / (1.15 * 1.5);
-    const tolIncreasedHealingDoneHelmet = this.totalHealingDuringToLHelmet - this.totalHealingDuringToLHelmet / 1.15;
-    const rejuvenationManaHelmet = (((this.totalRejuvenationsDuringToLHelmet * 10) * 0.3) / 10) * oneRejuvenationThroughput;
-    const wildGrowthIncreasedEffectHelmet = this.totalHealingFromWildgrowthsDuringToLHelmet / 1.15 - this.totalHealingFromWildgrowthsDuringToLHelmet / (1.15 * (8 / 6));
-
-    const treeOfLifeThroughputHelmet = rejuvenationIncreasedEffectHelmet + tolIncreasedHealingDoneHelmet + rejuvenationManaHelmet + wildGrowthIncreasedEffectHelmet;
-
-    const rejuvenationIncreasedEffectHelmetPercent = this.owner.getPercentageOfTotalHealingDone(rejuvenationIncreasedEffectHelmet);
-    const tolIncreasedHealingDoneHelmetPercent = this.owner.getPercentageOfTotalHealingDone(tolIncreasedHealingDoneHelmet);
-    const rejuvenationManaHelmetPercent = this.owner.getPercentageOfTotalHealingDone(rejuvenationManaHelmet);
-    const wildGrowthIncreasedEffectHelmetPercent = this.owner.getPercentageOfTotalHealingDone(wildGrowthIncreasedEffectHelmet);
-
-    const chameleonSongUptime = (this.combatants.selected.getBuffUptime(SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id) - (this.tolCasts * 30000) + this.adjustHelmetUptime) / this.owner.fightDuration;
-
-    const wildGrowths = this.abilityTracker.getAbility(SPELLS.WILD_GROWTH.id).casts || 0;
-    const treeOfLifeProcHelmet = this.proccs / wildGrowths;
+    // TODO get uptimes and proc rates
 
     return {
       item: ITEMS.CHAMELEON_SONG,
       result: (
         <dfn data-tip={`
           <ul>
-            <li>${formatPercentage(rejuvenationIncreasedEffectHelmetPercent)}% from increased rejuvenation effect</li>
-            <li>${formatPercentage(rejuvenationManaHelmetPercent)}% from reduced rejuvenation cost</li>
-            <li>${formatPercentage(wildGrowthIncreasedEffectHelmetPercent)}% from increased wildgrowth effect</li>
-            <li>${formatPercentage(tolIncreasedHealingDoneHelmetPercent)}% from overall increased healing effect</li>
-            <li>${formatPercentage(chameleonSongUptime)}% uptime</li>
-            <li>${formatPercentage(treeOfLifeProcHelmet)}% proc rate</li>
+            <li>Overall Increased Healing: <b>${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.chameleonSong.allBoostHealing))}%</b></li>
+            <li>Rejuv Increased Healing: <b>${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.chameleonSong.rejuvBoostHealing))}%</b></li>
+            <li>Rejuv Mana Saved est. throughtput: <b>~${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this._getManaSavedHealing(this.chameleonSong)))}%</b></li>
+            <li>Increased Wild Growths: <b>${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.chameleonSong.extraWgHealing))}%</b></li>
           </ul>`}>
-          <ItemHealingDone amount={treeOfLifeThroughputHelmet} />
+          <ItemHealingDone amount={this._getTotalHealing(this.chameleonSong)} />
         </dfn>
       ),
     };


### PR DESCRIPTION
MoC module was unable to see refreshes how I thought, switched up the display to account for this (fixes #1172 )

Innervate stat display wasn't formatted right, fixed that.

Tree of Life had some uptime tallying issues when player took both talent and legendary helm, also the module was in *desperate* need of a rewrite, so I gave it a complete rewrite and also fixed the issue while I was there (fixes #1159 ) It may be easier to look at the changes here as a new file, because it really is a full rewrite: https://github.com/kfinch/WoWAnalyzer/blob/038878f90290691d8e835c710f96704592f7b32a/src/Parser/Druid/Restoration/Modules/Talents/TreeOfLife.js