### PR TITLE
[resto druid] Added Sunfire and Moonfire to ABC. Fixed spell categories in Abilities, and also added Sunfire and Moonfire

### DIFF
--- a/src/Parser/Druid/Restoration/Modules/Features/Abilities.js
+++ b/src/Parser/Druid/Restoration/Modules/Features/Abilities.js
@@ -58,7 +58,7 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.BARKSKIN,
-        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
+        category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         cooldown: 60,
         castEfficiency: {
           suggestion: true,
@@ -86,11 +86,11 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.WILD_GROWTH,
-        category: Abilities.SPELL_CATEGORIES.OTHERS,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
       },
       {
         spell: SPELLS.REJUVENATION,
-        category: Abilities.SPELL_CATEGORIES.OTHERS,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
       },
       {
         spell: SPELLS.INCARNATION_TREE_OF_LIFE_TALENT,
@@ -115,11 +115,11 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.HEALING_TOUCH,
-        category: Abilities.SPELL_CATEGORIES.OTHERS,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
       },
       {
         spell: SPELLS.REGROWTH,
-        category: Abilities.SPELL_CATEGORIES.OTHERS,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
       },
       {
         spell: SPELLS.SWIFTMEND,
@@ -138,6 +138,18 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: true,
         },
+      },
+      {
+        spell: SPELLS.SOLAR_WRATH,
+        category: Abilities.SPELL_CATEGORIES.HEALER_DAMAGING_SPELL,
+      },
+      {
+        spell: SPELLS.MOONFIRE,
+        category: Abilities.SPELL_CATEGORIES.HEALER_DAMAGING_SPELL,
+      },
+      {
+        spell: SPELLS.SUNFIRE_CAST,
+        category: Abilities.SPELL_CATEGORIES.HEALER_DAMAGING_SPELL,
       },
     ];
   }

--- a/src/Parser/Druid/Restoration/Modules/Features/Abilities.js
+++ b/src/Parser/Druid/Restoration/Modules/Features/Abilities.js
@@ -86,7 +86,11 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.WILD_GROWTH,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
+      },
+      {
+        spell: SPELLS.EFFLORESCENCE_CAST,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
       },
       {
         spell: SPELLS.REJUVENATION,

--- a/src/Parser/Druid/Restoration/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Druid/Restoration/Modules/Features/AlwaysBeCasting.js
@@ -37,6 +37,8 @@ class AlwaysBeCasting extends CoreAlwaysBeCastingHealing {
     SPELLS.RIP.id,
     SPELLS.SHRED.id,
     SPELLS.SOLAR_WRATH.id,
+    SPELLS.SUNFIRE_CAST.id,
+    SPELLS.MOONFIRE.id,
     SPELLS.CAT_SWIPE.id,
     SPELLS.SWIPE_BEAR.id,
     SPELLS.URSOLS_VORTEX.id,


### PR DESCRIPTION
Sunfire and Moonfire are very common damaging spells for a Resto Druid to cast during healing downtime, but they were missing from Abilities and ABC.

Also, several spells in Abilities were in the wrong categories, this fixes that.