### PR TITLE
[Balance] Added RM, merged moon spells and changed SpellUsable.reduceCooldown to return correct value for charge spells.

### DIFF
--- a/src/Parser/Core/Modules/SpellUsable.test.js
+++ b/src/Parser/Core/Modules/SpellUsable.test.js
@@ -143,6 +143,14 @@ describe('Core/Modules/SpellUsable', () => {
       expect(result).toBe(7500);
       expect(instance.isOnCooldown(SPELLS.FAKE_SPELL.id)).toBe(false);
     });
+    it('reducing a spell with multiple charges on cooldown reduces the CD time on the next charge if it fully recharges the first charge', () => {
+      abilitiesMock.getMaxCharges = jest.fn(() => 2);
+      triggerCast(SPELLS.FAKE_SPELL.id);
+      triggerCast(SPELLS.FAKE_SPELL.id);
+      parserMock.currentTimestamp = 6000; //Leaves 1500ms cooldown remaining of the total 7500ms of the first charge recharging.
+      const reduction = instance.reduceCooldown(SPELLS.FAKE_SPELL.id, 5000); 
+      expect(reduction).toBe(5000);    
+    });
     it('reduceCooldown on a spell not on cooldown throws', () => {
       // We throw instead of returning something like null so that implementers *have* to take this into consideration.
       expect(() => {
@@ -359,15 +367,6 @@ describe('Core/Modules/SpellUsable', () => {
           targetID: parserMock.playerId,
         });
       }
-    });
-    it('A charge spell that has the cooldown of more than a single charge reduced should return the full reduction value', () => {
-      abilitiesMock.getMaxCharges = jest.fn(() => 3);
-      triggerCast(SPELLS.FAKE_SPELL.id);
-      triggerCast(SPELLS.FAKE_SPELL.id);
-      triggerCast(SPELLS.FAKE_SPELL.id);
-      parserMock.currentTimestamp = 6000; //Leaves 1500ms cooldown remainig
-      const reduction = instance.reduceCooldown(SPELLS.FAKE_SPELL.id, 5000); 
-      expect(reduction).toBe(5000);    
     });
   });
 

--- a/src/Parser/Core/Modules/SpellUsable.test.js
+++ b/src/Parser/Core/Modules/SpellUsable.test.js
@@ -360,6 +360,15 @@ describe('Core/Modules/SpellUsable', () => {
         });
       }
     });
+    it('A charge spell that has the cooldown of more than a single charge reduced should return the full reduction value', () => {
+      abilitiesMock.getMaxCharges = jest.fn(() => 3);
+      triggerCast(SPELLS.FAKE_SPELL.id);
+      triggerCast(SPELLS.FAKE_SPELL.id);
+      triggerCast(SPELLS.FAKE_SPELL.id);
+      parserMock.currentTimestamp = 6000; //Leaves 1500ms cooldown remainig
+      const reduction = instance.reduceCooldown(SPELLS.FAKE_SPELL.id, 5000); 
+      expect(reduction).toBe(5000);    
+    });
   });
 
   describe('Haste scaling cooldowns', () => {

--- a/src/Parser/Druid/Balance/CONFIG.js
+++ b/src/Parser/Druid/Balance/CONFIG.js
@@ -20,7 +20,7 @@ export default {
       If you want to learn more about Moonkin, visit <a href="https://goo.gl/xNHVnK" target="_blank" rel="noopener noreferrer">DreamGrove, the Druid's Discord</a>. Don't forget to check the <kbd>#resources</kbd> channel while you are there!
     </div>
   ),
-  completeness: SPEC_ANALYSIS_COMPLETENESS.GOOD, // good = it matches most common manual reviews in class discords, great = it support all important class features
+  completeness: SPEC_ANALYSIS_COMPLETENESS.GREAT, // good = it matches most common manual reviews in class discords, great = it support all important class features
   specDiscussionUrl: 'https://github.com/WoWAnalyzer/WoWAnalyzer/issues/421',
   changelog: CHANGELOG,
   parser: CombatLogParser,

--- a/src/Parser/Druid/Balance/CombatLogParser.js
+++ b/src/Parser/Druid/Balance/CombatLogParser.js
@@ -30,6 +30,7 @@ import SoulOfTheArchdruid from './Modules/Items/SoulOfTheArchdruid';
 import LadyAndTheChild from './Modules/Items/LadyAndTheChild';
 import OnethsIntuition from './Modules/Items/OnethsIntuition';
 import PromiseOfElune from './Modules/Items/PromiseOfElune';
+import RadiantMoonlight from './Modules/Items/RadiantMoonlight';
 import Tier20_2set from './Modules/Items/Tier20_2set';
 import Tier20_4set from './Modules/Items/Tier20_4set';
 import Tier21_2set from './Modules/Items/Tier21_2set';
@@ -68,6 +69,7 @@ class CombatLogParser extends MainCombatLogParser {
     ladyAndTheChild : LadyAndTheChild,
     onethsIntuition : OnethsIntuition,
     promiseOfElune : PromiseOfElune,
+    radiantMoonlight : RadiantMoonlight,
     tier20_2set : Tier20_2set,
     tier20_4set : Tier20_4set,
     tier21_2set : Tier21_2set,

--- a/src/Parser/Druid/Balance/Modules/Features/Abilities.js
+++ b/src/Parser/Druid/Balance/Modules/Features/Abilities.js
@@ -1,5 +1,7 @@
-import ITEMS from 'common/ITEMS';
+import React from 'react';
+import Wrapper from 'common/Wrapper';
 import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
 import CoreAbilities from 'Parser/Core/Modules/Abilities';
 import ISSUE_IMPORTANCE from 'Parser/Core/ISSUE_IMPORTANCE';
 
@@ -9,34 +11,22 @@ class Abilities extends CoreAbilities {
     return [
       // Rotational Spells
       {
-        spell: SPELLS.NEW_MOON,
+        spell: [SPELLS.NEW_MOON, SPELLS.HALF_MOON, SPELLS.FULL_MOON],
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        cooldown: (haste, combatant) => {
-          const hasRM = combatant.hasBack(ITEMS.RADIANT_MOONLIGHT.id);
-          return hasRM ? 30 : 45;
-        },
+        cooldown: 15,
         isOnGCD: true,
-        charges: 2,
-      },
-      {
-        spell: SPELLS.HALF_MOON,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        cooldown: (haste, combatant) => {
-          const hasRM = combatant.hasBack(ITEMS.RADIANT_MOONLIGHT.id);
-          return hasRM ? 30 : 45;
+        charges: 3,
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.95,
+          averageIssueEfficiency: 0.9,
+          majorIssueEfficiency: 0.85,
+          extraSuggestion: (
+            <Wrapper>
+              Your <SpellLink id={SPELLS.NEW_MOON.id} />, <SpellLink id={SPELLS.HALF_MOON.id} /> and <SpellLink id={SPELLS.FULL_MOON.id} /> cast efficiency can be improved, try keeping yourself at low Moon charges at all times; you should (almost) never be at max (3) charges.
+            </Wrapper>
+          ),
         },
-        isOnGCD: true,
-        charges: 2,
-      },
-      {
-        spell: SPELLS.FULL_MOON,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        cooldown: (haste, combatant) => {
-          const hasRM = combatant.hasBack(ITEMS.RADIANT_MOONLIGHT.id);
-          return hasRM ? 15 : 45;
-        },
-        isOnGCD: true,
-        charges: 2,
       },
       {
         spell: SPELLS.STARSURGE_MOONKIN,

--- a/src/Parser/Druid/Balance/Modules/Features/Checklist.js
+++ b/src/Parser/Druid/Balance/Modules/Features/Checklist.js
@@ -52,11 +52,11 @@ class Checklist extends CoreChecklist {
         return [
           new Requirement({
             name: 'Downtime',
-            check: () => this.alwaysBeCasting.downtimeSuggestionThresholds,
+            check: () => this.alwaysBeCasting.suggestionThresholds,
           }),
           new Requirement({
             name: 'Cancelled Casts',
-            check: () => this.cancelledCasts.cancelledCastSuggestionThresholds,
+            check: () => this.cancelledCasts.suggestionThresholds,
           }),
         ];
       },

--- a/src/Parser/Druid/Balance/Modules/Features/MoonSpells.js
+++ b/src/Parser/Druid/Balance/Modules/Features/MoonSpells.js
@@ -1,14 +1,11 @@
 import React from 'react';
 import SpellIcon from 'common/SpellIcon';
-import SpellLink from 'common/SpellLink';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
-import { formatPercentage } from 'common/format';
 import Analyzer from 'Parser/Core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
 import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
 import Combatants from 'Parser/Core/Modules/Combatants';
-import Wrapper from 'common/Wrapper';
 
 class MoonSpells extends Analyzer {
   static dependencies = {
@@ -43,15 +40,6 @@ class MoonSpells extends Analyzer {
       },
       style: 'percentage',
     };
-  }
-
-  suggestions(when) {
-    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
-      return suggest(<Wrapper>Your <SpellLink id={SPELLS.NEW_MOON.id} />, <SpellLink id={SPELLS.HALF_MOON.id} /> and <SpellLink id={SPELLS.FULL_MOON.id} /> cast efficiency can be improved, try keeping yourself at low Moon charges at all times; you should (almost) never be at max (3) charges.</Wrapper>)
-        .icon(SPELLS.FULL_MOON.icon)
-        .actual(`${Math.round(formatPercentage(actual))}% casted`)
-        .recommended(`${Math.round(formatPercentage(recommended))}% Moon spells casts is recommended`);
-    });
   }
 
   statistic() {

--- a/src/Parser/Druid/Balance/Modules/Items/RadiantMoonlight.js
+++ b/src/Parser/Druid/Balance/Modules/Items/RadiantMoonlight.js
@@ -67,7 +67,7 @@ class RadiantMoonlight extends Analyzer {
   item() {
     return {
       item: ITEMS.RADIANT_MOONLIGHT,
-      result: <Wrapper>Gave you {formatNumber(this.freeFullMoons)} free <SpellLink id={SPELLS.FULL_MOON.id} /> casts and reduced the cooldown of your Moon spells by ~{this.averageCooldownReduction.toFixed(1)} seconds.</Wrapper>,
+      result: <Wrapper>Gave you {formatNumber(this.freeFullMoons)} free <SpellLink id={SPELLS.FULL_MOON.id} /> casts and reduced the cooldown of your Moon spells by an average of ~{this.averageCooldownReduction.toFixed(1)} seconds.</Wrapper>,
     };
   }
 }

--- a/src/Parser/Druid/Balance/Modules/Items/RadiantMoonlight.js
+++ b/src/Parser/Druid/Balance/Modules/Items/RadiantMoonlight.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
+import Wrapper from 'common/Wrapper';
+import SpellLink from 'common/SpellLink';
+import { formatNumber } from 'common/format';
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import SpellUsable from 'Parser/Core/Modules/SpellUsable';
+
+const COOLDOWN_REDUCTION_MS = 30000;
+
+class RadiantMoonlight extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    spellUsable: SpellUsable,
+  };
+
+  halfMoonCasted = true;
+  freeFullMoons = 0;
+  cooldownReduction = 0;
+  cooldownReductionWasted = 0;
+  newMoonCasts = 0;
+  halfMoonCasts = 0;
+  fullMoonCasts = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasBack(ITEMS.RADIANT_MOONLIGHT.id);
+  }
+
+  on_byPlayer_cast(event) {
+    if (event.ability.guid === SPELLS.HALF_MOON.id) {
+      this.halfMoonCasted = true;
+      this.halfMoonCasts++;
+    }
+    if (event.ability.guid === SPELLS.NEW_MOON.id) {
+      this.newMoonCasts++;
+    }
+    if (event.ability.guid === SPELLS.FULL_MOON.id) {
+      this.fullMoonCasts++;
+    }
+    if (!this.halfMoonCasted || event.ability.guid !== SPELLS.FULL_MOON.id) {
+      return;
+    }
+    this.halfMoonCasted = false;
+    this.freeFullMoons++;
+    if(!this.spellUsable.isOnCooldown(SPELLS.NEW_MOON.id)){
+      return;
+    }
+    const reduction = this.spellUsable.reduceCooldown(SPELLS.NEW_MOON.id, COOLDOWN_REDUCTION_MS);
+    this.cooldownReductionWasted = COOLDOWN_REDUCTION_MS - reduction;
+    this.cooldownReduction += reduction;   
+  }
+
+  get cooldownReductionOnRest(){
+    return (this.cooldownReduction - this.freeFullMoons * COOLDOWN_REDUCTION_MS / 2) / 1000;
+  }
+
+  get nonFreeMoonCasts(){
+    return this.newMoonCasts + this.halfMoonCasts + this.fullMoonCasts - this.freeFullMoons;
+  }
+
+  get averageCooldownReduction(){
+    return this.cooldownReductionOnRest / this.nonFreeMoonCasts;
+  }
+
+  item() {
+    return {
+      item: ITEMS.RADIANT_MOONLIGHT,
+      result: <Wrapper>Gave you {formatNumber(this.freeFullMoons)} free <SpellLink id={SPELLS.FULL_MOON.id} /> casts and reduced the cooldown of your Moon spells by ~{this.averageCooldownReduction.toFixed(1)} seconds.</Wrapper>,
+    };
+  }
+}
+
+export default RadiantMoonlight;

--- a/src/Parser/Monk/Brewmaster/Modules/Core/BrewCDR.test.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/BrewCDR.test.js
@@ -30,6 +30,6 @@ describe('BrewCDR', () => {
   });
 
   it("should report 427.09s of CDR", () => {
-    expect(Math.round(parser.findModule(BrewCDR).totalCDR)).toBe(427092);
+    expect(Math.round(parser.findModule(BrewCDR).totalCDR)).toBe(451469);
   });
 });


### PR DESCRIPTION
Also changed balance spec completeness to GREAT. Sorry it's all in one PR, should've done the reduceCooldown on it's own, but without it the cooldown reduction on Radiant Moonlight is incorrect.

The fix to cooldown reduction was that any cooldown reduction that overlapped a charge would only return the value from replenishing the rest of the charge. For instance when at 2 charges and 2 seconds from finishing cd, reducing it by 5 would only return 2, even thought you went to 3 charges and 3 seconds recharged. It should now return the correct value.