### PR TITLE
[BrM Monk] Implemented High Tolerance Talent

### DIFF
--- a/src/Parser/Core/Modules/Haste.js
+++ b/src/Parser/Core/Modules/Haste.js
@@ -5,6 +5,7 @@ import { formatMilliseconds, formatPercentage } from 'common/format';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import StatTracker from 'Parser/Core/Modules/StatTracker';
+import { HIGH_TOLERANCE_HASTE_FNS } from 'Parser/Monk/Brewmaster/Modules/Spells/HighTolerance';
 
 const debug = false;
 
@@ -35,6 +36,7 @@ class Haste extends Analyzer {
     [SPELLS.TRUESHOT.id]: 0.4, // MM Hunter main CD
     [SPELLS.ICY_VEINS.id]: 0.3,
     [SPELLS.BONE_SHIELD.id]: 0.1, // Blood BK haste buff from maintaining boneshield
+    ...HIGH_TOLERANCE_HASTE_FNS,
     // Haste RATING buffs are handled by the StatTracker module
 
     // Boss abilities:

--- a/src/Parser/Monk/Brewmaster/CHANGELOG.js
+++ b/src/Parser/Monk/Brewmaster/CHANGELOG.js
@@ -2,6 +2,11 @@ import { WOPR, emallson } from 'MAINTAINERS';
 
 export default [
   {
+    date: new Date('2018-01-18'),
+    changes: 'Added High Tolerance haste statistic & changed Brew CDR to use average haste to determine target CDR value.',
+    contributors: [emallson],
+  },
+  {
     date: new Date('2018-01-12'),
     changes: 'Added Purifying Brew statistic.',
     contributors: [emallson],

--- a/src/Parser/Monk/Brewmaster/CombatLogParser.js
+++ b/src/Parser/Monk/Brewmaster/CombatLogParser.js
@@ -19,6 +19,7 @@ import TigerPalm from './Modules/Spells/TigerPalm';
 import RushingJadeWind from './Modules/Spells/RushingJadeWind';
 import BreathOfFire from './Modules/Spells/BreathOfFire';
 import BlackOxBrew from './Modules/Spells/BlackOxBrew';
+import HighTolerance from './Modules/Spells/HighTolerance';
 // Features
 import Checklist from './Modules/Features/Checklist';
 import Abilities from './Modules/Features/Abilities';
@@ -60,6 +61,7 @@ class CombatLogParser extends CoreCombatLogParser {
     rjw: RushingJadeWind,
     bof: BreathOfFire,
     bob: BlackOxBrew,
+    highTolerance: HighTolerance,
 
     // Items
     t20_2pc: T20_2pc,

--- a/src/Parser/Monk/Brewmaster/Modules/Core/BrewCDR.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/BrewCDR.js
@@ -23,6 +23,14 @@ class BrewCDR extends Analyzer {
     abilities: Abilities,
   }
 
+  _totalHaste = 0;
+  _newHaste = 0;
+  _lastHasteChange = 0;
+
+  get meanHaste() {
+    return this._totalHaste / this.owner.fightDuration;
+  }
+
   get totalCDR() {
     let totalCDR = 0;
     // add in KS CDR...
@@ -44,7 +52,8 @@ class BrewCDR extends Analyzer {
   // the amount of CDR required so that you can cast ISB often enough to
   // actually hit 100% uptime
   get cdrRequiredForUptime() {
-    return 1 - this.isb.durationPerCast / this.abilities.getExpectedCooldownDuration(SPELLS.IRONSKIN_BREW.id);
+    const ability = this.abilities.getAbility(SPELLS.IRONSKIN_BREW.id);
+    return 1 - this.isb.durationPerCast / (ability._cooldown(this.meanHaste) * 1000);
   }
 
   get suggestionThreshold() {
@@ -59,6 +68,17 @@ class BrewCDR extends Analyzer {
       style: 'percentage',
     };
   }
+
+  on_changehaste(event) {
+    this._totalHaste += event.oldHaste * (event.timestamp - this._lastHasteChange);
+    this._lastHasteChange = event.timestamp;
+    this._newHaste = event.newHaste;
+  }
+
+  on_finished() {
+    this._totalHaste += this._newHaste * (this.owner.fight.end_time - this._lastHasteChange);
+  }
+
 
   statistic() {
     let wristsDesc = "";

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/HighTolerance.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/HighTolerance.js
@@ -81,7 +81,7 @@ class HighTolerance extends Analyzer {
 
   on_finished() {
     if(this._staggerLevel !== null) {
-      this.staggerDurations[this._staggerLevel] += this.owner.currentTimestamp - this._lastDebuffApplied;
+      this.staggerDurations[this._staggerLevel] += this.owner.fight.end_time - this._lastDebuffApplied;
     }
   }
 

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/HighTolerance.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/HighTolerance.js
@@ -1,0 +1,97 @@
+import React from 'react';
+import Wrapper from 'common/Wrapper';
+import SpellIcon from 'common/SpellIcon';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import SPELLS from 'common/SPELLS';
+import { formatPercentage, formatThousands } from 'common/format';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+const HIGH_TOLERANCE_HASTE = {
+  [SPELLS.LIGHT_STAGGER_DEBUFF.id]: 0.08,
+  [SPELLS.MODERATE_STAGGER_DEBUFF.id]: 0.12,
+  [SPELLS.HEAVY_STAGGER_DEBUFF.id]: 0.15,
+};
+
+class HighTolerance extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  staggerDurations = {
+    [SPELLS.LIGHT_STAGGER_DEBUFF.id]: 0,
+    [SPELLS.MODERATE_STAGGER_DEBUFF.id]: 0,
+    [SPELLS.HEAVY_STAGGER_DEBUFF.id]: 0,
+  };
+
+  _staggerLevel = null;
+  _lastDebuffApplied = 0;
+
+  get meanHaste() {
+    return Object.keys(HIGH_TOLERANCE_HASTE)
+      .map(key => this.staggerDurations[key] * HIGH_TOLERANCE_HASTE[key])
+      .reduce((prev, cur) => prev + cur, 0) / this.owner.fightDuration;
+  }
+
+  get lightDuration() {
+    return this.staggerDurations[SPELLS.LIGHT_STAGGER_DEBUFF.id];
+  }
+
+  get moderateDuration() {
+    return this.staggerDurations[SPELLS.MODERATE_STAGGER_DEBUFF.id];
+  }
+
+  get heavyDuration() {
+    return this.staggerDurations[SPELLS.HEAVY_STAGGER_DEBUFF.id];
+  }
+
+  get noneDuration() {
+    return this.owner.fightDuration - this.lightDuration - this.moderateDuration - this.heavyDuration;
+  }
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.HIGH_TOLERANCE_TALENT.id);
+  }
+
+  on_toPlayer_applydebuff(event) {
+    if(!(event.ability.guid in HIGH_TOLERANCE_HASTE)) {
+      return;
+    }
+    this._lastDebuffApplied = event.timestamp;
+    this._staggerLevel = event.ability.guid;
+  }
+
+  on_toPlayer_removedebuff(event) {
+    if(!(event.ability.guid in HIGH_TOLERANCE_HASTE)) {
+      return;
+    }
+    this.staggerDurations[event.ability.guid] += event.timestamp - this._lastDebuffApplied;
+    this._staggerLevel = null;
+  }
+
+  on_finished() {
+    if(this._staggerLevel !== null) {
+      this.staggerDurations[this._staggerLevel] += this.owner.currentTimestamp - this._lastDebuffApplied;
+    }
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.HIGH_TOLERANCE_TALENT.id} />}
+        value={`${formatPercentage(this.meanHaste)}%`}
+        label="Avg. Haste from High Tolerance"
+        tooltip={`You spent: <ul>
+              <li><b>${formatThousands(this.noneDuration / 1000)}s</b> (${formatPercentage(this.noneDuration / this.owner.fightDuration)}%) without Stagger.</li>
+              <li><b>${formatThousands(this.lightDuration / 1000)}s</b> (${formatPercentage(this.lightDuration / this.owner.fightDuration)}%) in Light Stagger.</li>
+              <li><b>${formatThousands(this.moderateDuration / 1000)}s</b> (${formatPercentage(this.moderateDuration / this.owner.fightDuration)}%) in Moderate Stagger.</li>
+              <li><b>${formatThousands(this.heavyDuration / 1000)}s</b> (${formatPercentage(this.heavyDuration / this.owner.fightDuration)}%) in Heavy Stagger.</li>
+            </ul>`}
+          />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.OPTIONAL();
+}
+
+export default HighTolerance;

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/HighTolerance.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/HighTolerance.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import Wrapper from 'common/Wrapper';
 import SpellIcon from 'common/SpellIcon';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SPELLS from 'common/SPELLS';
@@ -8,10 +7,20 @@ import { formatPercentage, formatThousands } from 'common/format';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
-const HIGH_TOLERANCE_HASTE = {
+export const HIGH_TOLERANCE_HASTE = {
   [SPELLS.LIGHT_STAGGER_DEBUFF.id]: 0.08,
   [SPELLS.MODERATE_STAGGER_DEBUFF.id]: 0.12,
   [SPELLS.HEAVY_STAGGER_DEBUFF.id]: 0.15,
+};
+
+function hasteFnGenerator(value) {
+  return { haste: combatant => combatant.hasTalent(SPELLS.HIGH_TOLERANCE_TALENT.id) ? value : 0.0 };
+}
+
+export const HIGH_TOLERANCE_HASTE_FNS = {
+  [SPELLS.LIGHT_STAGGER_DEBUFF.id]: hasteFnGenerator(0.08),
+  [SPELLS.MODERATE_STAGGER_DEBUFF.id]: hasteFnGenerator(0.12),
+  [SPELLS.HEAVY_STAGGER_DEBUFF.id]: hasteFnGenerator(0.15),
 };
 
 class HighTolerance extends Analyzer {


### PR DESCRIPTION
This implements the haste gain from the High Tolerance for BrM monks. The haste is integrated into the core `Haste` module. I also changed the `BrewCDR` module to use the *mean* haste instead of the haste at the last event. This more accurately reflects the amount of additional CDR you need over the course of a fight, especially in conjuction with the extra 12%+ haste from using HT on an appropriately high-damage fight. A couple logs I've looked at it reduced the CDR suggestion threshold by almost 5% (additive).