### PR TITLE
Add a DamageTakenTable component (and implementation for BrM)

### DIFF
--- a/src/Main/DamageTakenTable.js
+++ b/src/Main/DamageTakenTable.js
@@ -13,6 +13,7 @@ class DamageTakenTable extends React.Component {
   static propTypes = {
     data: PropTypes.array.isRequired,
     spec: PropTypes.object.isRequired,
+    total: PropTypes.number.isRequired,
   };
 
   mitigationNames = {
@@ -24,21 +25,20 @@ class DamageTakenTable extends React.Component {
 
   render() {
     const specClassName = this.props.spec.className.replace(' ', '');
-    const sumTotalDmg = this.props.data.reduce((sum, cur) => sum + cur.totalDmg, 0);
     const row = (abilityData)  => {
       const { ability, totalDmg, largestSpike } = abilityData;
       return (
         <tr key={ability.guid}>
           <td>
             <div className="flex performance-bar-container"
-                 data-tip={`Total Damage Taken: ${formatNumber(totalDmg)} of ${formatNumber(sumTotalDmg)}.`} >
+                 data-tip={`Total Damage Taken: ${formatNumber(totalDmg)} of ${formatNumber(this.props.total)}.`} >
               <div
                 className={`flex-sub performance-bar ${specClassName}-bg`}
-                style={{ width: `${(totalDmg - largestSpike) / sumTotalDmg * 100}%` }}
+                style={{ width: `${(totalDmg - largestSpike) / this.props.total * 100}%` }}
               />
               <div
                 className="flex-sub performance-bar Hunter-bg"
-                style={{ width: `${(largestSpike / sumTotalDmg * 100)}%`, opacity: 0.4 }}
+                style={{ width: `${(largestSpike / this.props.total * 100)}%`, opacity: 0.4 }}
               />
             </div>
           </td>

--- a/src/Main/DamageTakenTable.js
+++ b/src/Main/DamageTakenTable.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import Icon from 'common/Icon';
 import { formatNumber } from 'common/format';
@@ -24,7 +23,7 @@ class DamageTakenTable extends React.Component {
 
   render() {
     const row = (abilityData)  => {
-      const { ability, mitigatedAs, totalDmg, largestSpike } = abilityData;
+      const { ability, totalDmg, largestSpike } = abilityData;
       return (
         <tr key={ability.guid}>
           <td></td>

--- a/src/Main/DamageTakenTable.js
+++ b/src/Main/DamageTakenTable.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import Icon from 'common/Icon';
+import { formatNumber } from 'common/format';
+
+export const MITIGATED_NONE = 0;
+export const MITIGATED_MAGICAL = 1;
+export const MITIGATED_PHYSICAL = 2;
+
+class DamageTakenTable extends React.Component {
+  static propTypes = {
+    data: PropTypes.object.isRequired,
+  };
+
+  mitigationNames = {
+    [MITIGATED_NONE]: "None",
+    [MITIGATED_MAGICAL]: "Magical",
+    [MITIGATED_PHYSICAL]: "Physical",
+  };
+
+
+  render() {
+    const row = (abilityData)  => {
+      const { ability, mitigatedAs, totalDmg, largestSpike } = abilityData;
+      return (
+        <tr key={ability.guid}>
+          <td></td>
+          <td>
+            <SpellLink id={ability.guid}>
+              <Icon icon={ability.abilityIcon} alt={ability.name} /> {ability.name}
+            </SpellLink>
+          </td>
+          <td>
+            {formatNumber(totalDmg)}
+          </td>
+          <td>
+            {formatNumber(largestSpike)}
+          </td>
+        </tr>
+      );
+    };
+
+    return (
+      <div>
+        <table className="data-table">
+          <thead>
+            <tr>
+              <th><b>Physical</b></th>
+              <th>Ability</th>
+              <th>Total Damage Taken</th>
+              <th>Largest Spike</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              this.props.data
+                .filter(abilityData => abilityData.mitigatedAs === MITIGATED_PHYSICAL)
+                .map(row)
+            }
+          </tbody>
+          <thead>
+            <tr>
+              <th><b>Magical</b></th>
+              <th>Ability</th>
+              <th>Total Damage Taken</th>
+              <th>Largest Spike</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              this.props.data
+                .filter(abilityData => abilityData.mitigatedAs === MITIGATED_MAGICAL)
+                .map(row)
+            }
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+}
+
+export default DamageTakenTable;

--- a/src/Main/DamageTakenTable.js
+++ b/src/Main/DamageTakenTable.js
@@ -11,7 +11,8 @@ export const MITIGATED_PHYSICAL = 2;
 
 class DamageTakenTable extends React.Component {
   static propTypes = {
-    data: PropTypes.object.isRequired,
+    data: PropTypes.array.isRequired,
+    spec: PropTypes.object.isRequired,
   };
 
   mitigationNames = {
@@ -22,11 +23,25 @@ class DamageTakenTable extends React.Component {
 
 
   render() {
+    const specClassName = this.props.spec.className.replace(' ', '');
+    const sumTotalDmg = this.props.data.reduce((sum, cur) => sum + cur.totalDmg, 0);
     const row = (abilityData)  => {
       const { ability, totalDmg, largestSpike } = abilityData;
       return (
         <tr key={ability.guid}>
-          <td></td>
+          <td>
+            <div className="flex performance-bar-container"
+                 data-tip={`Total Damage Taken: ${formatNumber(totalDmg)} of ${formatNumber(sumTotalDmg)}.`} >
+              <div
+                className={`flex-sub performance-bar ${specClassName}-bg`}
+                style={{ width: `${(totalDmg - largestSpike) / sumTotalDmg * 100}%` }}
+              />
+              <div
+                className="flex-sub performance-bar Hunter-bg"
+                style={{ width: `${(largestSpike / sumTotalDmg * 100)}%`, opacity: 0.4 }}
+              />
+            </div>
+          </td>
           <td>
             <SpellLink id={ability.guid}>
               <Icon icon={ability.abilityIcon} alt={ability.name} /> {ability.name}
@@ -47,7 +62,7 @@ class DamageTakenTable extends React.Component {
         <table className="data-table">
           <thead>
             <tr>
-              <th><b>Physical</b></th>
+              <th><dfn data-tip="Damage mitigated by stats &amp; abilities that reduce or absorb Physical damage, such as armor, Death Knights' Blood Shield, and Demon Hunters' Demon Spikes."><b>Physical</b></dfn></th>
               <th>Ability</th>
               <th>Total Damage Taken</th>
               <th>Largest Spike</th>
@@ -62,7 +77,7 @@ class DamageTakenTable extends React.Component {
           </tbody>
           <thead>
             <tr>
-              <th><b>Magical</b></th>
+              <th><dfn data-tip="Damage mitigated by stats &amp; abilities that reduce or absorb Magical damage, such as Paladins' Blessing of Spellwarding, Brewmasters' Stagger (especially with Mystic Vitality), and Demon Hunters' Empower Wards."><b>Magical</b></dfn></th>
               <th>Ability</th>
               <th>Total Damage Taken</th>
               <th>Largest Spike</th>

--- a/src/Parser/Core/Modules/DamageValue.js
+++ b/src/Parser/Core/Modules/DamageValue.js
@@ -18,11 +18,11 @@ class DamageValue {
     return this._largestHit;
   }
 
-  constructor(regular = 0, absorbed = 0, overkill = 0, largestHit = 0) {
+  constructor(regular = 0, absorbed = 0, overkill = 0, largestHit = null) {
     this._regular = regular;
     this._absorbed = absorbed;
     this._overkill = overkill;
-    this._largestHit = largestHit;
+    this._largestHit = (largestHit === null) ? regular + absorbed + overkill : largestHit;
   }
 
   add(regular, absorbed, overkill) {

--- a/src/Parser/Core/Modules/DamageValue.js
+++ b/src/Parser/Core/Modules/DamageValue.js
@@ -1,4 +1,5 @@
 class DamageValue {
+  _largestHit = 0;
   _regular = 0;
   /** Do not use this without really good reason! `effective` is almost always better; we WANT to include absorbed damage as this is most commonly related to mechanics that need to be removed and therefore significant. */
   get regular() { return this._regular; }
@@ -13,17 +14,22 @@ class DamageValue {
     return this.effective + this.overkill;
   }
 
-  constructor(regular = 0, absorbed = 0, overkill = 0) {
+  get largestHit() {
+    return this._largestHit;
+  }
+
+  constructor(regular = 0, absorbed = 0, overkill = 0, largestHit = 0) {
     this._regular = regular;
     this._absorbed = absorbed;
     this._overkill = overkill;
+    this._largestHit = largestHit;
   }
 
   add(regular, absorbed, overkill) {
-    return new this.constructor(this.regular + regular, this.absorbed + absorbed, this.overkill + overkill);
+    return new this.constructor(this.regular + regular, this.absorbed + absorbed, this.overkill + overkill, Math.max(this.largestHit, regular + absorbed + overkill));
   }
   subtract(regular, absorbed, overkill) {
-    return new this.constructor(this.regular - regular, this.absorbed - absorbed, this.overkill - overkill);
+    return new this.constructor(this.regular - regular, this.absorbed - absorbed, this.overkill - overkill, this.largestHit);
   }
 }
 

--- a/src/Parser/Monk/Brewmaster/CHANGELOG.js
+++ b/src/Parser/Monk/Brewmaster/CHANGELOG.js
@@ -2,6 +2,11 @@ import { WOPR, emallson } from 'MAINTAINERS';
 
 export default [
   {
+    date: new Date('2018-01-22'),
+    changes: 'Added \'Damage Taken by Ability\' table.',
+    contributors: [emallson],
+  },
+  {
     date: new Date('2018-01-18'),
     changes: 'Added High Tolerance haste statistic & changed Brew CDR to use average haste to determine target CDR value.',
     contributors: [emallson],

--- a/src/Parser/Monk/Brewmaster/CombatLogParser.js
+++ b/src/Parser/Monk/Brewmaster/CombatLogParser.js
@@ -24,6 +24,7 @@ import HighTolerance from './Modules/Spells/HighTolerance';
 import Checklist from './Modules/Features/Checklist';
 import Abilities from './Modules/Features/Abilities';
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
+import DamageTakenTable from './Modules/Features/DamageTakenTable';
 // Items
 import T20_2pc from './Modules/Items/T20_2pc';
 import T20_4pc from './Modules/Items/T20_4pc';
@@ -51,6 +52,7 @@ class CombatLogParser extends CoreCombatLogParser {
     checklist: Checklist,
     alwaysBeCasting: AlwaysBeCasting,
     abilities: Abilities,
+    damageTakenTable: DamageTakenTable,
 
     // Spells
     ironSkinBrew: IronSkinBrew,

--- a/src/Parser/Monk/Brewmaster/Modules/Core/DamageTaken.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/DamageTaken.js
@@ -2,6 +2,7 @@ import CoreDamageTaken from 'Parser/Core/Modules/DamageTaken';
 import SPELLS from 'common/SPELLS';
 
 class DamageTaken extends CoreDamageTaken {
+  _staggeredDamage = {};
   on_toPlayer_absorbed(event) {
     // The `damage` events of Brewmaster Monks always includes the amount staggered as "absorbed" damage,
     // but this absorbed damage might also include absorbs received from other people (e.g. Power Word:
@@ -13,8 +14,17 @@ class DamageTaken extends CoreDamageTaken {
 
     const spellId = event.ability.guid;
     if (spellId === SPELLS.STAGGER.id) {
-      this._subtractDamage(event.extraAbility, 0, event.amount, 0);
+      return;
     }
+    this._subtractDamage(event.extraAbility, 0, event.amount, 0);
+    if(!(event.extraAbility.guid in this._staggeredDamage)) {
+      this._staggeredDamage[event.extraAbility.guid] = 0;
+    }
+    this._staggeredDamage[event.extraAbility.guid] += event.amount;
+  }
+
+  staggeredByAbility(guid) {
+    return (guid in this._staggeredDamage) ? this._staggeredDamage[guid] : 0;
   }
 }
 

--- a/src/Parser/Monk/Brewmaster/Modules/Core/DamageTaken.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/DamageTaken.js
@@ -13,7 +13,7 @@ class DamageTaken extends CoreDamageTaken {
     // so this also works nicely with external absorbs.
 
     const spellId = event.ability.guid;
-    if (spellId === SPELLS.STAGGER.id) {
+    if (spellId !== SPELLS.STAGGER.id) {
       return;
     }
     this._subtractDamage(event.extraAbility, 0, event.amount, 0);

--- a/src/Parser/Monk/Brewmaster/Modules/Features/DamageTakenTable.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/DamageTakenTable.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import DamageTakenTableComponent, { MITIGATED_NONE, MITIGATED_PHYSICAL, MITIGATED_MAGICAL } from 'Main/DamageTakenTable';
+import Tab from 'Main/Tab';
+import SPELLS from 'common/SPELLS';
+
+import HighTolerance from '../Spells/HighTolerance';
+
+class DamageTakenTable extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    ht: HighTolerance,
+  };
+
+  // additive increase of 5% while isb is up
+  _has2pcT19 = false;
+  abilityData = {};
+
+  get tableData() {
+    const vals = Object.values(this.abilityData);
+    vals.sort((a, b) => b.largestSpike - a.largestSpike);
+    return vals;
+  }
+
+  on_initialized() {
+    this._has2pcT19 = this.combatants.selected.hasBuff(SPELLS.T19_2_PIECE_BUFF_BRM.id);
+  }
+
+  on_toPlayer_damage(event) {
+    if(event.ability.guid === SPELLS.STAGGER_TAKEN.id) {
+      return;
+    }
+    if(event.amount === 0) {
+      return;
+    }
+    // stagger always does *something* if an ability can be mitigated,
+    // so we detect unmitigable abilities by checking if it did anything
+    if(event.absorbed === 0) {
+      this._addToAbility(event.ability.guid, event.ability.name, event.amount, MITIGATED_NONE);
+      return;
+    }
+
+    const damage = event.amount;
+    const mitigatedAs = this._classifyMitigation(event);
+    this._addToAbility(event.ability, damage, mitigatedAs);
+  }
+
+  _addToAbility(ability, damage, mitigationType) {
+    const spellId = ability.guid;
+    if(!(spellId in this.abilityData)) {
+      this.abilityData[spellId] = {
+        totalDmg: damage,
+        largestSpike: damage,
+        mitigatedAs: mitigationType,
+        ability: ability,
+      };
+      return;
+    }
+    this.abilityData[spellId].totalDmg += damage;
+    this.abilityData[spellId].largestSpike = Math.max(this.abilityData[spellId].largestSpike, damage);
+
+    const curMitAs = this.abilityData[spellId].mitigatedAs;
+    if(curMitAs === MITIGATED_PHYSICAL) {
+      // we *can* drop down, but not go up
+      this.abilityData[spellId].mitigatedAs = this._minMitigationType(curMitAs, mitigationType);
+    }
+  }
+
+  _minMitigationType(a, b) {
+    return Math.min(a, b);
+  }
+
+  _classifyMitigation(event) {
+    // additive increase of 35%
+    const isbActive = this.combatants.selected.hasBuff(SPELLS.IRONSKIN_BREW_BUFF.id);
+    // additive increase of 10%
+    const fbActive = this.combatants.selected.hasBuff(SPELLS.FORTIFYING_BREW_BRM.id);
+    // additive increase of 10%
+    const hasHT = this.ht.active;
+    // multiplicative increase of 40% for magic damage
+    // const hasMV = this.combatants.selected.hasTalent(SPELLS.MYSTIC_VITALITY_TALENT.id) || this.combatants.selected.hasRing(ITEMS.SOUL_OF_THE_GRANDMASTER.id);
+
+    const physicalStaggerPct = 0.4 + hasHT * 0.1 + isbActive * 0.35 + isbActive * this._has2pcT19 * 0.05 + fbActive * 0.1;
+    // const magicalStaggerPct = physicalStaggerPct * 0.4 * (hasMV ? 1.4 : 1);
+
+    const actualPct = event.absorbed / (event.absorbed + event.amount);
+    console.log(actualPct, physicalStaggerPct, event, hasHT, isbActive, this._has2pcT19, fbActive);
+
+    // multiply by 0.95 to allow for minor floating-point / integer
+    // division error
+    if(actualPct >= physicalStaggerPct * 0.95) {
+      return MITIGATED_PHYSICAL;
+    } else {
+      return MITIGATED_MAGICAL;
+    }
+  }
+
+  tab() {
+    return {
+      title: 'Damage Taken by Ability',
+      url: 'damage-taken-by-ability',
+      render: () => (
+        <Tab title="Damage Taken by Ability">
+          <DamageTakenTableComponent data={this.tableData} />
+        </Tab>
+      ),
+    };
+  }
+}
+
+export default DamageTakenTable;

--- a/src/Parser/Monk/Brewmaster/Modules/Features/DamageTakenTable.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/DamageTakenTable.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
-import DamageTaken from 'Parser/Core/Modules/DamageTaken';
 import DamageTakenTableComponent, { MITIGATED_PHYSICAL, MITIGATED_MAGICAL } from 'Main/DamageTakenTable';
 import Tab from 'Main/Tab';
 import SPELLS from 'common/SPELLS';
@@ -9,6 +8,7 @@ import SPECS from 'common/SPECS';
 import SpellLink from 'common/SpellLink';
 
 import HighTolerance from '../Spells/HighTolerance';
+import DamageTaken from '../Core/DamageTaken';
 
 class DamageTakenTable extends Analyzer {
   static dependencies = {
@@ -25,7 +25,9 @@ class DamageTakenTable extends Analyzer {
     const vals = Object.values(this.abilityData)
       .map(raw => {
         const value = this.dmg.byAbility(raw.ability.guid);
-        return { totalDmg: value.effective, largestSpike: value.largestHit,  ...raw};
+        const staggered = this.dmg.staggeredByAbility(raw.ability.guid);
+        // console.log(staggered);
+        return { totalDmg: value.effective + staggered, largestSpike: value.largestHit,  ...raw};
       });
     vals.sort((a, b) => b.largestSpike - a.largestSpike);
     return vals;
@@ -90,9 +92,12 @@ class DamageTakenTable extends Analyzer {
       url: 'damage-taken-by-ability',
       render: () => (
         <Tab title="Damage Taken by Ability">
-          <DamageTakenTableComponent data={this.tableData} spec={SPECS[this.combatants.selected.specId]}/>
+          <DamageTakenTableComponent 
+            data={this.tableData} 
+            spec={SPECS[this.combatants.selected.specId]} 
+            total={this.dmg.total.effective} />
           <div style={{padding: "10px"}}>
-            <strong>Note:</strong> Damage taken by <SpellLink id={SPELLS.STAGGER_TAKEN.id} icon /> is not accounted for in this table.
+            <strong>Note:</strong> Damage taken includes all damage put into the <SpellLink id={SPELLS.STAGGER_TAKEN.id} icon /> pool.
           </div>
         </Tab>
       ),

--- a/src/Parser/Monk/Brewmaster/Modules/Features/DamageTakenTable.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/DamageTakenTable.js
@@ -5,6 +5,8 @@ import DamageTaken from 'Parser/Core/Modules/DamageTaken';
 import DamageTakenTableComponent, { MITIGATED_PHYSICAL, MITIGATED_MAGICAL } from 'Main/DamageTakenTable';
 import Tab from 'Main/Tab';
 import SPELLS from 'common/SPELLS';
+import SPECS from 'common/SPECS';
+import SpellLink from 'common/SpellLink';
 
 import HighTolerance from '../Spells/HighTolerance';
 
@@ -88,7 +90,10 @@ class DamageTakenTable extends Analyzer {
       url: 'damage-taken-by-ability',
       render: () => (
         <Tab title="Damage Taken by Ability">
-          <DamageTakenTableComponent data={this.tableData} />
+          <DamageTakenTableComponent data={this.tableData} spec={SPECS[this.combatants.selected.specId]}/>
+          <div style={{padding: "10px"}}>
+            <strong>Note:</strong> Damage taken by <SpellLink id={SPELLS.STAGGER_TAKEN.id} icon /> is not accounted for in this table.
+          </div>
         </Tab>
       ),
     };

--- a/src/Parser/Monk/Brewmaster/Modules/Features/DamageTakenTable.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/DamageTakenTable.js
@@ -78,14 +78,9 @@ class DamageTakenTable extends Analyzer {
     const fbActive = this.combatants.selected.hasBuff(SPELLS.FORTIFYING_BREW_BRM.id);
     // additive increase of 10%
     const hasHT = this.ht.active;
-    // multiplicative increase of 40% for magic damage
-    // const hasMV = this.combatants.selected.hasTalent(SPELLS.MYSTIC_VITALITY_TALENT.id) || this.combatants.selected.hasRing(ITEMS.SOUL_OF_THE_GRANDMASTER.id);
 
     const physicalStaggerPct = 0.4 + hasHT * 0.1 + isbActive * 0.35 + isbActive * this._has2pcT19 * 0.05 + fbActive * 0.1;
-    // const magicalStaggerPct = physicalStaggerPct * 0.4 * (hasMV ? 1.4 : 1);
-
     const actualPct = event.absorbed / (event.absorbed + event.amount);
-    console.log(actualPct, physicalStaggerPct, event, hasHT, isbActive, this._has2pcT19, fbActive);
 
     // multiply by 0.95 to allow for minor floating-point / integer
     // division error

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/IronSkinBrew.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/IronSkinBrew.js
@@ -143,9 +143,9 @@ class IronSkinBrew extends Analyzer {
     return {
       actual: this.durationLost / this.totalDuration,
       isGreaterThan: {
-        minor: 0.02,
-        average: 0.05,
-        major: 0.1,
+        minor: 0.05,
+        average: 0.1,
+        major: 0.15,
       },
       style: 'percentage',
     };

--- a/src/common/SPELLS/MONK.js
+++ b/src/common/SPELLS/MONK.js
@@ -484,6 +484,11 @@ export default {
     name: 'Monk T20 Brewmaster 4P Bonus',
     icon: 'spell_monk_brewmaster_spec',
   },
+  T19_2_PIECE_BUFF_BRM: {
+    id: 211415,
+    name: 'Monk T19 Brewmaster 2P Bonus',
+    icon: 'spell_monk_brewmaster_spec',
+  },
   GIFT_OF_THE_OX_1: {
     id: 124507,
     name: 'Gift of the Ox',


### PR DESCRIPTION
This stems from the discussion we had today in discord. tldr its a table that shows the abilities you, as a tank, took damage from, categorized by whether it was mitigated by physical or magical mitigation, the total amount you took, and the maximum single hit you got.

It looks [like](https://imgur.com/a/p8rsi) [this](https://imgur.com/a/xiT3q). Importantly, (at least for BrMs) it doesn't rely on the spell data so it catches things like Jagged Abrasion (Harjatan) being mitigated by physical reduction unlike *literally every other bleed effect.*

The component itself can be used by other tank specs by importing the component and then feeding it your own data. The way I classified abilities for BrM depends on stagger, and so won't work for other tanks. Spell data isn't reliable (see also: Jagged Abrasion) but can be a good starting point if you don't have an easy way to distinguish them (like BrMs do)