### PR TITLE
[Frost Mage] fix sindragosa head bug

### DIFF
--- a/src/Parser/Mage/Frost/Modules/Items/ShatteredFragmentsOfSindragosa.js
+++ b/src/Parser/Mage/Frost/Modules/Items/ShatteredFragmentsOfSindragosa.js
@@ -49,7 +49,7 @@ class ShatteredFragmentsOfSindragosa extends Analyzer {
   }
 
   get legendaryDamage() {
-    return (this.damage / (this.comerStormCasts + this.legendaryProcs)) * this.legendaryProcs;
+    return (this.damage / (this.cometStormCasts + this.legendaryProcs)) * this.legendaryProcs;
   }
 
   item() {


### PR DESCRIPTION
A simple spelling error caused this module to not work, this fixes that. 