### PR TITLE
Make the output of performanceForThresholds more sane

### DIFF
--- a/src/Parser/Core/Modules/Features/Checklist/performanceForThresholds.js
+++ b/src/Parser/Core/Modules/Features/Checklist/performanceForThresholds.js
@@ -30,10 +30,10 @@ function performanceForGreaterThanThresholds(actual, { minor, average, major }) 
     return 0.333 * major / actual;
   } else if (actual > average) {
     // average issue (between major and average issue)
-    return 0.333 + 0.333 * ((actual - average) / (major - average));
+    return 0.666 - 0.333 * ((actual - average) / (major - average));
   } else if (actual > minor) {
     // minor issue (between average and minor issue)
-    return 0.666 + 0.333 * ((actual - minor) / (average - minor));
+    return 1 - 0.333 * ((actual - minor) / (average - minor));
   } else {
     // no issue
     return 1;

--- a/src/Parser/Core/Modules/Features/Checklist/performanceForThresholds.test.js
+++ b/src/Parser/Core/Modules/Features/Checklist/performanceForThresholds.test.js
@@ -1,0 +1,83 @@
+import performanceForThresholds from './performanceForThresholds';
+
+const EPS = 1e-16;
+const MARGIN = 0.01;
+
+function lessThanThreshold(offset, from, thresholds = { minor: 0.9, average: 0.8, major: 0.7 }) {
+  return {
+    actual: thresholds[from] + offset,
+    isLessThan: thresholds,
+    style: 'percentage',
+  };
+}
+
+function greaterThanThreshold(offset, from, thresholds = { minor: 0.1, average: 0.2, major: 0.3 }) {
+  return {
+    actual: thresholds[from] + offset,
+    isGreaterThan: thresholds,
+    style: 'percentage',
+  };
+}
+
+describe('performanceForThresholds', () => {
+
+  describe('isLessThan', () => {
+    it('should report 1.0 for >= minor', () => {
+      expect(performanceForThresholds(lessThanThreshold(0, 'minor'))).toBe(1.0);
+    });
+
+    it('should report *almost* 1.0 for ~ minor', () => {
+      expect(performanceForThresholds(lessThanThreshold(-EPS, 'minor'))).toBeGreaterThan(0.99);
+    });
+
+    it('should report *almost* 0.666 for ~ average (above)', () => {
+      expect(Math.abs(performanceForThresholds(lessThanThreshold(EPS, 'average')) - 0.666)).toBeLessThan(MARGIN);
+    });
+
+    it('should report *almost* 0.666 for ~ average (below)', () => {
+      expect(Math.abs(performanceForThresholds(lessThanThreshold(-EPS, 'average')) - 0.666)).toBeLessThan(MARGIN);
+    });
+
+    it('should report *almost* 0.333 for ~ major (above)', () => {
+      expect(Math.abs(performanceForThresholds(lessThanThreshold(EPS, 'major')) - 0.333)).toBeLessThan(MARGIN);
+    });
+
+    it('should report *almost* 0.333 for ~ major (below)', () => {
+      expect(Math.abs(performanceForThresholds(lessThanThreshold(-EPS, 'major')) - 0.333)).toBeLessThan(MARGIN);
+    });
+
+    it('should report 0 for 0', () => {
+      expect(performanceForThresholds(lessThanThreshold(-0.7, 'major'))).toBe(0);
+    })
+  });
+
+  describe('isGreaterThan', () => {
+    it('should report 1.0 for <= minor', () => {
+      expect(performanceForThresholds(greaterThanThreshold(0, 'minor'))).toBe(1.0);
+    });
+
+    it('should report *almost* 1.0 for ~ minor', () => {
+      expect(performanceForThresholds(greaterThanThreshold(EPS, 'minor'))).toBeGreaterThan(0.99);
+    });
+
+    it('should report *almost* 0.666 for ~ average (above)', () => {
+      expect(Math.abs(performanceForThresholds(greaterThanThreshold(-EPS, 'average')) - 0.666)).toBeLessThan(MARGIN);
+    });
+
+    it('should report *almost* 0.666 for ~ average (below)', () => {
+      expect(Math.abs(performanceForThresholds(greaterThanThreshold(+EPS, 'average')) - 0.666)).toBeLessThan(MARGIN);
+    });
+
+    it('should report *almost* 0.333 for ~ major (above)', () => {
+      expect(Math.abs(performanceForThresholds(greaterThanThreshold(-EPS, 'major')) - 0.333)).toBeLessThan(MARGIN);
+    });
+
+    it('should report *almost* 0.333 for ~ major (below)', () => {
+      expect(Math.abs(performanceForThresholds(greaterThanThreshold(+EPS, 'major')) - 0.333)).toBeLessThan(MARGIN);
+    });
+
+    it('should report 0 for ∞', () => {
+      expect(performanceForThresholds(greaterThanThreshold(Infinity, 'major'))).toBe(0);
+    })
+  });
+});

--- a/src/Parser/Core/Modules/Features/Checklist/performanceForThresholds.test.js
+++ b/src/Parser/Core/Modules/Features/Checklist/performanceForThresholds.test.js
@@ -5,7 +5,7 @@ const MARGIN = 0.01;
 
 function lessThanThreshold(offset, from, thresholds = { minor: 0.9, average: 0.8, major: 0.7 }) {
   return {
-    actual: thresholds[from] + offset,
+    actual: (from === 'absolute') ? offset : thresholds[from] + offset,
     isLessThan: thresholds,
     style: 'percentage',
   };
@@ -13,7 +13,7 @@ function lessThanThreshold(offset, from, thresholds = { minor: 0.9, average: 0.8
 
 function greaterThanThreshold(offset, from, thresholds = { minor: 0.1, average: 0.2, major: 0.3 }) {
   return {
-    actual: thresholds[from] + offset,
+    actual: (from === 'absolute') ? offset : thresholds[from] + offset,
     isGreaterThan: thresholds,
     style: 'percentage',
   };
@@ -61,23 +61,40 @@ describe('performanceForThresholds', () => {
     });
 
     it('should report *almost* 0.666 for ~ average (above)', () => {
-      expect(Math.abs(performanceForThresholds(greaterThanThreshold(-EPS, 'average')) - 0.666)).toBeLessThan(MARGIN);
+      expect(Math.abs(performanceForThresholds(greaterThanThreshold(EPS, 'average')) - 0.666)).toBeLessThan(MARGIN);
     });
 
     it('should report *almost* 0.666 for ~ average (below)', () => {
-      expect(Math.abs(performanceForThresholds(greaterThanThreshold(+EPS, 'average')) - 0.666)).toBeLessThan(MARGIN);
+      expect(Math.abs(performanceForThresholds(greaterThanThreshold(-EPS, 'average')) - 0.666)).toBeLessThan(MARGIN);
     });
 
     it('should report *almost* 0.333 for ~ major (above)', () => {
-      expect(Math.abs(performanceForThresholds(greaterThanThreshold(-EPS, 'major')) - 0.333)).toBeLessThan(MARGIN);
+      expect(Math.abs(performanceForThresholds(greaterThanThreshold(EPS, 'major')) - 0.333)).toBeLessThan(MARGIN);
     });
 
     it('should report *almost* 0.333 for ~ major (below)', () => {
-      expect(Math.abs(performanceForThresholds(greaterThanThreshold(+EPS, 'major')) - 0.333)).toBeLessThan(MARGIN);
+      expect(Math.abs(performanceForThresholds(greaterThanThreshold(-EPS, 'major')) - 0.333)).toBeLessThan(MARGIN);
     });
 
     it('should report 0 for ∞', () => {
       expect(performanceForThresholds(greaterThanThreshold(Infinity, 'major'))).toBe(0);
     })
+  });
+
+  describe('the yajinni test-case', () => {
+    it('should report the DK\'s performance to be better than the Paladin\'s', () => {
+      const pallyThresh = greaterThanThreshold(0.3109, 'absolute', {
+        minor: 0.15,
+        average: 0.25,
+        major: 0.35
+      });
+      const dkThresh = greaterThanThreshold(0.3106, 'absolute', {
+        minor: 0.2,
+        average: 0.3,
+        major: 0.4
+      });
+
+      expect(performanceForThresholds(dkThresh)).toBeGreaterThan(performanceForThresholds(pallyThresh));
+    });
   });
 });


### PR DESCRIPTION
**tl;dr** - prior to this PR, the `isGreaterThan` section of `performanceForThresholds` was actually pretty wonky. If you plotted it out, you'd go from `1` down to `0.666` then slowly back up to `1` then down to `0.333` up to `0.666` and then start dropping below `0.333`.

This PR adds a bunch of behavior tests to check that on each side of the main threshold points (minor, average, major) we get similar values out. For example, if the actual is very slightly (say, `10^-16`) above the average value, that value should be virtually the same as `0.666`. Likewise for very slightly below. 

These tests codify that intuition, along with an additional regression test from the example @yajinni showed me.