### PR TITLE
Not Actively Maintained Spec Updates

### DIFF
--- a/src/Parser/DeathKnight/Frost/CONFIG.js
+++ b/src/Parser/DeathKnight/Frost/CONFIG.js
@@ -10,7 +10,7 @@ export default {
   maintainers: [Bonebasher],
 
   // good = it matches most common manual reviews in class discords, great = it support all important class features
-  completeness: SPEC_ANALYSIS_COMPLETENESS.NEEDS_MORE_WORK,
+  completeness: SPEC_ANALYSIS_COMPLETENESS.NOT_ACTIVELY_MAINTAINED,
   specDiscussionUrl: 'https://github.com/WoWAnalyzer/WoWAnalyzer/milestone/6',
   
   // Shouldn't have to change these:

--- a/src/Parser/DemonHunter/Vengeance/CONFIG.js
+++ b/src/Parser/DemonHunter/Vengeance/CONFIG.js
@@ -25,7 +25,7 @@ export default {
 			<center>NOW YOU ARE PREPARED!</center>
 		</div>
 	),
-  completeness: SPEC_ANALYSIS_COMPLETENESS.GOOD, // good = it matches most common manual reviews in class discords, great = it support all important class features
+  completeness: SPEC_ANALYSIS_COMPLETENESS.NOT_ACTIVELY_MAINTAINED, // good = it matches most common manual reviews in class discords, great = it support all important class features
   specDiscussionUrl: 'https://github.com/WoWAnalyzer/WoWAnalyzer/milestone/7',
   changelog: CHANGELOG,
   parser: CombatLogParser,

--- a/src/Parser/Paladin/Protection/CONFIG.js
+++ b/src/Parser/Paladin/Protection/CONFIG.js
@@ -8,7 +8,7 @@ import CHANGELOG from './CHANGELOG';
 export default {
   spec: SPECS.PROTECTION_PALADIN,
   maintainers: [Yajinni, Noichxd],
-  completeness: SPEC_ANALYSIS_COMPLETENESS.NEEDS_MORE_WORK, // good = it matches most common manual reviews in class discords, great = it support all important class features
+  completeness: SPEC_ANALYSIS_COMPLETENESS.NOT_ACTIVELY_MAINTAINED, // good = it matches most common manual reviews in class discords, great = it support all important class features
   changelog: CHANGELOG,
   parser: CombatLogParser,
   path: __dirname, // used for generating a GitHub link directly to your spec

--- a/src/Parser/Shaman/Enhancement/CONFIG.js
+++ b/src/Parser/Shaman/Enhancement/CONFIG.js
@@ -8,7 +8,7 @@ import CHANGELOG from './CHANGELOG';
 export default {
   spec: SPECS.ENHANCEMENT_SHAMAN,
   maintainers: [Nighteyez07],
-  completeness: SPEC_ANALYSIS_COMPLETENESS.NEEDS_MORE_WORK, // good = it matches most common manual reviews in class discords, great = it support all important class features
+  completeness: SPEC_ANALYSIS_COMPLETENESS.NOT_ACTIVELY_MAINTAINED, // good = it matches most common manual reviews in class discords, great = it support all important class features
   changelog: CHANGELOG,
   parser: CombatLogParser,
   path: __dirname, // used for generating a GitHub link directly to your spec

--- a/src/Parser/Warrior/Protection/CONFIG.js
+++ b/src/Parser/Warrior/Protection/CONFIG.js
@@ -8,7 +8,7 @@ import CHANGELOG from './CHANGELOG';
 export default {
   spec: SPECS.PROTECTION_WARRIOR,
   maintainers: [Salarissia],
-  completeness: SPEC_ANALYSIS_COMPLETENESS.NEEDS_MORE_WORK, // good = it matches most common manual reviews in class discords, great = it support all important class features
+  completeness: SPEC_ANALYSIS_COMPLETENESS.NOT_ACTIVELY_MAINTAINED, // good = it matches most common manual reviews in class discords, great = it support all important class features
   changelog: CHANGELOG,
   parser: CombatLogParser,
   path: __dirname, // used for generating a GitHub link directly to your spec


### PR DESCRIPTION
Updating specs to Not Actively Maintained.

Current criteria is if there have been no updated in 2.5 months, we review the specs and reach out to the maintainers to see if the spec either needs updating, or if it still being maintained. After confirmation, we make the swap to ensure any users are informed that the information being presented may be out of date.

Thanks.