### PR TITLE
[Feral] Add tracking of Ashamane's Rip uptime

### DIFF
--- a/src/Parser/Druid/Feral/CHANGELOG.js
+++ b/src/Parser/Druid/Feral/CHANGELOG.js
@@ -1,5 +1,5 @@
 export default `
-24-01-2018 - Feral Druid: Added Ashamane's Rip uptime tracking.
+24-01-2018 - Feral Druid: Added Ashamane's Rip uptime tracking (bt Anatta336).
 22-09-2019 - Feral Druid: Added 5 combo point finisher tracking (by Thieseract).
 11-09-2019 - Feral Druid: Refactored combo point tracking properties (by Thieseract).
 11-09-2019 - Feral Druid: Added Savage Roar damage contribution (by Thieseract).

--- a/src/Parser/Druid/Feral/CHANGELOG.js
+++ b/src/Parser/Druid/Feral/CHANGELOG.js
@@ -1,4 +1,5 @@
 export default `
+24-01-2018 - Feral Druid: Added Ashamane's Rip uptime tracking.
 22-09-2019 - Feral Druid: Added 5 combo point finisher tracking (by Thieseract).
 11-09-2019 - Feral Druid: Refactored combo point tracking properties (by Thieseract).
 11-09-2019 - Feral Druid: Added Savage Roar damage contribution (by Thieseract).

--- a/src/Parser/Druid/Feral/CombatLogParser.js
+++ b/src/Parser/Druid/Feral/CombatLogParser.js
@@ -14,6 +14,8 @@ import SavageRoarUptime from './Modules/Talents/SavageRoarUptime';
 import MoonfireUptime from './Modules/Talents/MoonfireUptime';
 import SavageRoarDmg from './Modules/Talents/SavageRoarDmg';
 
+import AshamanesRip from './Modules/Traits/AshamanesRip';
+
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     // FeralCore
@@ -36,6 +38,9 @@ class CombatLogParser extends CoreCombatLogParser {
     // resources
     comboPointTracker: ComboPointTracker,
     comboPointDetails: ComboPointDetails,
+
+    // traits
+    ashamanesRip: AshamanesRip,
   };
 }
 

--- a/src/Parser/Druid/Feral/Modules/Traits/AshamanesRip.js
+++ b/src/Parser/Druid/Feral/Modules/Traits/AshamanesRip.js
@@ -1,0 +1,76 @@
+import React from 'react';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Enemies from 'Parser/Core/Modules/Enemies';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import { formatNumber, formatPercentage } from 'common/format';
+import Wrapper from 'common/Wrapper';
+import SmallStatisticBox, { STATISTIC_ORDER } from 'Main/SmallStatisticBox';
+
+/**
+ * Ashamane's Bite (Artifact Trait)
+ * Combo point generators on targets with your Rip have a 10% chance to place a duplicate of that Rip on the target.
+ * There is a maximum of one Ashamane's Rip active on a target at once, and it will be overriden if it procs again. 
+ * Ashamane's Rip copies the damage and duration of the Rip at the moment it is created.
+ * For this reason it's beneficial to pool energy before refreshing Rip so you can use many combo point generators when the Rip still has a long duration in the hope of copying a long duration rip.
+ */
+class AshamanesRip extends Analyzer {
+  static dependencies = {
+    enemies: Enemies,
+    combatants: Combatants,
+  };
+
+  damage = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.traitsBySpellId[SPELLS.ASHAMANES_BITE.id] === 1;
+  }
+
+  on_byPlayer_damage(event) {
+    const spellId = event.ability.guid;
+
+    if (spellId !== SPELLS.ASHAMANES_RIP.id){
+      return;
+    }
+    
+    this.damage += (event.amount || 0) + (event.absorbed || 0) + (event.overkill || 0);
+  }
+
+  get ashamanesRipUptime() {
+    return this.enemies.getBuffUptime(SPELLS.ASHAMANES_RIP.id) / this.owner.fightDuration;
+  }
+
+  suggestions(when) {
+    when(this.ashamanesRipUptime).isLessThan(0.40)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<Wrapper>
+          Your <SpellLink id={SPELLS.ASHAMANES_BITE.id} /> uptime can be improved. Pooling energy before refreshing Rip lets you maximise the chance of triggering a long duration Ashamane's Rip.
+          </Wrapper>
+        )
+          .icon(SPELLS.ASHAMANES_BITE.icon)
+          .actual(`${formatPercentage(actual)}% Ashamane's Rip uptime`)
+          .recommended(`>${formatPercentage(recommended)}% is recommended`)
+          .regular(0.30)
+          .major(0.20);
+      });
+  }
+
+  statistic() {
+    return (
+      <SmallStatisticBox
+        icon={<SpellIcon id={SPELLS.ASHAMANES_RIP.id} />}
+        value={`${formatPercentage(this.ashamanesRipUptime)} %`}
+        label={`Ashamane's Rip uptime`}
+        tooltip={`Your Ashamane's Rip contributed ${formatNumber(this.damage)} damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.damage))} %)`}
+      />
+    );
+  }
+
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(0);
+}
+
+export default AshamanesRip;

--- a/src/Parser/Druid/Feral/Modules/Traits/AshamanesRip.js
+++ b/src/Parser/Druid/Feral/Modules/Traits/AshamanesRip.js
@@ -44,19 +44,29 @@ class AshamanesRip extends Analyzer {
     return this.enemies.getBuffUptime(SPELLS.ASHAMANES_RIP.id) / this.owner.fightDuration;
   }
 
+  get suggestionThresholds() {
+    return {
+      actual: this.ashamanesRipUptime,
+      isLessThan: {
+        minor: 0.40,
+        average: 0.30,
+        major: 0.20,
+      },
+      style: 'percentage',
+    };
+  }
+
   suggestions(when) {
-    when(this.ashamanesRipUptime).isLessThan(0.40)
-      .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<Wrapper>
-          Your <SpellLink id={SPELLS.ASHAMANES_BITE.id} /> uptime can be improved. Pooling energy before refreshing Rip lets you maximise the chance of triggering a long duration Ashamane's Rip.
-          </Wrapper>
-        )
-          .icon(SPELLS.ASHAMANES_BITE.icon)
-          .actual(`${formatPercentage(actual)}% Ashamane's Rip uptime`)
-          .recommended(`>${formatPercentage(recommended)}% is recommended`)
-          .regular(0.30)
-          .major(0.20);
-      });
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <Wrapper>
+          Your <SpellLink id={SPELLS.ASHAMANES_RIP.id} /> uptime can be improved. Pooling energy before refreshing Rip lets you maximise the chance of triggering a long duration Ashamane's Rip.
+        </Wrapper>
+      )
+        .icon(SPELLS.ASHAMANES_RIP.icon)
+        .actual(`${formatPercentage(actual)}% Ashamane's Rip uptime`)
+        .recommended(`>${formatPercentage(recommended)}% is recommended`);
+    });
   }
 
   statistic() {
@@ -65,11 +75,11 @@ class AshamanesRip extends Analyzer {
         icon={<SpellIcon id={SPELLS.ASHAMANES_RIP.id} />}
         value={`${formatPercentage(this.ashamanesRipUptime)} %`}
         label={`Ashamane's Rip uptime`}
-        tooltip={`Your Ashamane's Rip contributed ${formatNumber(this.damage)} damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.damage))} %)`}
+        tooltip={`Your Ashamane's Rip contributed ${formatNumber(this.damage)} damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.damage))}%)`}
       />
     );
   }
-
+  
   statisticOrder = STATISTIC_ORDER.OPTIONAL(0);
 }
 

--- a/src/common/SPELLS/DRUID.js
+++ b/src/common/SPELLS/DRUID.js
@@ -775,4 +775,16 @@ export default {
     name: 'Thrash',
     icon: 'spell_druid_thrash',
   },
+  // Traits:
+  // The Ashamane's Bite trait creates the Ashamane's Rip debuff.
+  ASHAMANES_BITE: {
+    id: 210702,
+    name: 'Ashamane\'s Bite',
+    icon: 'artifactability_feraldruid_ashamanesbite',
+  },
+  ASHAMANES_RIP: {
+    id: 210705,
+    name: 'Ashamane\'s Rip',
+    icon: 'artifactability_feraldruid_ashamanesbite',
+  },
 };


### PR DESCRIPTION
Added a statistic and suggestion for the uptime of Ashamane's Rip from the artifact trait Ashamane's Bite.

I'm a little uncertain what statisticOrder to set for it. It usually provides around 5% of total damage, so have put it as OPTIONAL(0) for now.