### PR TITLE
[Affliction, Destruction] Fixed the ELT suggestion text.

### DIFF
--- a/src/Parser/Warlock/Affliction/Modules/Talents/EmpoweredLifeTap.js
+++ b/src/Parser/Warlock/Affliction/Modules/Talents/EmpoweredLifeTap.js
@@ -50,7 +50,7 @@ class EmpoweredLifeTap extends Analyzer {
   suggestions(when) {
     when(this.suggestionThresholds)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<Wrapper>Your uptime on the <SpellLink id={SPELLS.EMPOWERED_LIFE_TAP_BUFF.id} /> buff could be improved. You should cast <SpellLink id={SPELLS.LIFE_TAP.id} /> more often.<br /><br /><small><em>NOTE:</em> If you're getting 0% uptime, it might be wrong if you used <SpellLink id={SPELLS.LIFE_TAP.id} /> before combat started and maintained the buff. Due to technical limitations it's not possible to track the bonus damage nor uptime in this case.</small></Wrapper>)
+        return suggest(<Wrapper>Your uptime on the <SpellLink id={SPELLS.EMPOWERED_LIFE_TAP_BUFF.id} /> buff could be improved. You should cast <SpellLink id={SPELLS.LIFE_TAP.id} /> more often to maintain the buff.</Wrapper>)
           .icon(SPELLS.EMPOWERED_LIFE_TAP_TALENT.icon)
           .actual(`${formatPercentage(actual)}% Empowered Life Tap uptime`)
           .recommended(`>${formatPercentage(recommended)}% is recommended`);

--- a/src/Parser/Warlock/Destruction/Modules/Talents/EmpoweredLifeTap.js
+++ b/src/Parser/Warlock/Destruction/Modules/Talents/EmpoweredLifeTap.js
@@ -49,7 +49,7 @@ class EmpoweredLifeTap extends Analyzer {
   suggestions(when) {
     when(this.suggestionThresholds)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<Wrapper>Your uptime on the <SpellLink id={SPELLS.EMPOWERED_LIFE_TAP_BUFF.id} /> buff could be improved. You should cast <SpellLink id={SPELLS.LIFE_TAP.id} /> more often.<br /><br /><small><em>NOTE:</em> If you're getting 0% uptime, it might be wrong if you used <SpellLink id={SPELLS.LIFE_TAP.id} /> before combat started and maintained the buff. Due to technical limitations it's not possible to track the bonus damage nor uptime in this case.</small></Wrapper>)
+        return suggest(<Wrapper>Your uptime on the <SpellLink id={SPELLS.EMPOWERED_LIFE_TAP_BUFF.id} /> buff could be improved. You should cast <SpellLink id={SPELLS.LIFE_TAP.id} /> more often to maintain the buff.</Wrapper>)
           .icon(SPELLS.EMPOWERED_LIFE_TAP_TALENT.icon)
           .actual(`${formatPercentage(actual)}% Empowered Life Tap uptime`)
           .recommended(`>${formatPercentage(recommended)}% is recommended`);


### PR DESCRIPTION
Before the rework with fabricated `applybuff` events on fight start, we weren't able to track buffs that didn't have `applybuff` event, leading to reported 0% uptime, when in fact it should be 100% (buff applied pre-pull and maintained throughout the fight without `removebuff`)). It's fixed now so the part where I explained the behavior is removed.