### PR TITLE
[BrM Monk] Mastery Evaluation

### DIFF
--- a/src/Parser/Monk/Brewmaster/CHANGELOG.js
+++ b/src/Parser/Monk/Brewmaster/CHANGELOG.js
@@ -9,6 +9,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-01-27'),
+    changes: <Wrapper>Added statistic for <SpellLink id={SPELLS.MASTERY_ELUSIVE_BRAWLER.id} icon /> effectiveness</Wrapper>,
+    contributors: [emallson],
+  },
+  {
     date: new Date('2018-01-22'),
     changes: 'Added \'Damage Taken by Ability\' table.',
     contributors: [emallson],

--- a/src/Parser/Monk/Brewmaster/CombatLogParser.js
+++ b/src/Parser/Monk/Brewmaster/CombatLogParser.js
@@ -10,6 +10,7 @@ import SharedBrews from './Modules/Core/SharedBrews';
 import StaggerFabricator from './Modules/Core/StaggerFabricator';
 import GlobalCooldown from './Modules/Core/GlobalCooldown';
 import Channeling from './Modules/Core/Channeling';
+import MasteryValue from './Modules/Core/MasteryValue';
 // Spells
 import IronSkinBrew from './Modules/Spells/IronSkinBrew';
 import PurifyingBrew from './Modules/Spells/PurifyingBrew';
@@ -47,6 +48,7 @@ class CombatLogParser extends CoreCombatLogParser {
     brews: SharedBrews,
     channeling: Channeling,
     globalCooldown: GlobalCooldown,
+    masteryValue: MasteryValue,
 
     // Features
     checklist: Checklist,

--- a/src/Parser/Monk/Brewmaster/CombatLogParser.js
+++ b/src/Parser/Monk/Brewmaster/CombatLogParser.js
@@ -34,6 +34,7 @@ import StormstoutsLastGasp from './Modules/Items/StormstoutsLastGasp';
 import SalsalabimsLostTunic from './Modules/Items/SalsalabimsLostTunic';
 // normalizers
 import IronskinBrewNormalizer from './Modules/Normalizers/IronskinBrew';
+import GarothiWorldbreakerMeleeNormalizer from './Modules/Normalizers/GarothiWorldbreakerMelee';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -76,6 +77,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // normalizers
     isbNormalizer: IronskinBrewNormalizer,
+    garothi: GarothiWorldbreakerMeleeNormalizer,
   };
 }
 

--- a/src/Parser/Monk/Brewmaster/Modules/Core/MasteryValue.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/MasteryValue.js
@@ -119,9 +119,8 @@ class MasteryValue extends Analyzer {
   _hitCounts = {};
   _dodgeCounts = {};
 
-  get baseDodge() {
-    return 0.15;
-  }
+  // in the future, this will be determined based on player agility
+  baseDodge = 0.15;
 
   dodgePenalty(_source) {
     return 0.045; // 1.5% per level, bosses are three levels over players. not sure how to get trash levels yet -- may not matter

--- a/src/Parser/Monk/Brewmaster/Modules/Core/MasteryValue.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/MasteryValue.js
@@ -26,7 +26,7 @@ const MONK_DODGE_COEFFS = {
   diminished: {
     k: 1.064161593,
     C_d: 0.5558721267,
-  }
+  },
 };
 
 function _clampProb(prob) {

--- a/src/Parser/Monk/Brewmaster/Modules/Core/MasteryValue.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/MasteryValue.js
@@ -9,6 +9,16 @@ import SpellIcon from 'common/SpellIcon';
 import { formatNumber, formatPercentage } from 'common/format';
 import DamageTaken from './DamageTaken';
 
+function _clampProb(prob) {
+  if(prob > 1.0) {
+    return 1.0;
+  } else if(prob < 0.0) {
+    return 0.0;
+  } else {
+    return prob;
+  }
+}
+
 /**
  * This class represents the Markov Chain with which the Mastery stacks
  * are modeled. The transition probabilities are defined by two
@@ -31,16 +41,6 @@ import DamageTaken from './DamageTaken';
  */
 class StackMarkovChain {
   _stackProbs = [1.0];
-
-  _clampProb(prob) {
-    if(prob > 1.0) {
-      return 1.0;
-    } else if(prob < 0.0) {
-      return 0.0;
-    } else {
-      return prob;
-    }
-  }
 
   _assertSum() {
     const sum = this._stackProbs.reduce((sum, p) => p + sum, 0);
@@ -70,7 +70,7 @@ class StackMarkovChain {
     let zeroProb = 0;
     // didn't dodge, gain a stack
     for(let stacks = n-1; stacks >= 0; stacks--) {
-      const prob = this._clampProb(dodgeProb + masteryValue * stacks);
+      const prob = _clampProb(dodgeProb + masteryValue * stacks);
       zeroProb += prob * this._stackProbs[stacks]; // dodge -> go to 0
       const hitProb = 1 - prob;
       this._stackProbs[stacks+1] = hitProb * this._stackProbs[stacks]; // hit -> go to stacks + 1
@@ -131,7 +131,7 @@ class MasteryValue extends Analyzer {
   // event is dodgeable
   dodgeChance(masteryStacks, masteryRating, sourceID) {
     const masteryPercentage = this.stats.masteryPercentage(masteryRating, true);
-    return masteryPercentage * masteryStacks + this.baseDodge - this.dodgePenalty(sourceID);
+    return _clampProb(masteryPercentage * masteryStacks + this.baseDodge - this.dodgePenalty(sourceID));
   }
 
 

--- a/src/Parser/Monk/Brewmaster/Modules/Core/MasteryValue.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/MasteryValue.js
@@ -172,7 +172,7 @@ class MasteryValue extends Analyzer {
   // returns true of the event represents a cast that applies a stack of
   // mastery
   //
-  // TODO: blackout combo + purify
+  // neither blackout combo + purify nor t21 are supported yet
   _appliesStack(event) {
     return [SPELLS.BLACKOUT_STRIKE.id, SPELLS.BREATH_OF_FIRE.id].includes(event.ability.guid);
   }
@@ -287,7 +287,8 @@ class MasteryValue extends Analyzer {
           <em>Technical Information:</em><br/>
           <b>Estimated Actual Damage</b> is calculated by calculating the average damage per hit of an ability, then multiplying that by the number of times you dodged each ability.<br/>
           <b>Expected</b> values are calculated by computing the expected number of mastery stacks each time you <em>could</em> dodge an ability.<br/>
-          An ability is considered <b>dodgeable</b> if you dodged it at least once.`}
+          An ability is considered <b>dodgeable</b> if you dodged it at least once.<br/>
+          Blackout Combo with Purifying Brew and Tier 21 are not supported (yet).`}
       />
     );
   }

--- a/src/Parser/Monk/Brewmaster/Modules/Core/MasteryValue.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/MasteryValue.js
@@ -1,0 +1,265 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import HIT_TYPES from 'Parser/Core/HIT_TYPES';
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import StatTracker from 'Parser/Core/Modules/StatTracker';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import SpellIcon from 'common/SpellIcon';
+import { formatNumber, formatPercentage } from 'common/format';
+import DamageTaken from './DamageTaken';
+
+/**
+ * This class represents the Markov Chain with which the Mastery stacks
+ * are modeled. The transition probabilities are defined by two
+ * potential operations:
+ *
+ * 1. Guaranteed Addition: from using an ability that generates a stack
+ * 100% of the time (e.g. BoS, BoF). The probability of having i stacks
+ * afterward is equal to the probability of having i-1 stacks before
+ * (the probability of having 0 stacks afterward is 0).
+ *
+ * 2. Attack: The probability of having i > 0 stacks afterward is equal to
+ * the probability of being hit with i - 1 stacks. The probability of
+ * having 0 stacks afterward is the sum of the probabilities of dodging
+ * with each number of stacks. Note that there is a natural cap on the
+ * number of stacks you can reach, since after that point every hit will
+ * be a dodge.
+ *
+ * The expected number of stacks you have is just the sum of the indices
+ * weighted by the values.
+ */
+class StackMarkovChain {
+  _stackProbs = [1.0];
+
+  _clampProb(prob) {
+    if(prob > 1.0) {
+      return 1.0;
+    } else if(prob < 0.0) {
+      return 0.0;
+    } else {
+      return prob;
+    }
+  }
+
+  _assertSum() {
+    const sum = this._stackProbs.reduce((sum, p) => p + sum, 0);
+    if (Math.abs(sum - 1.0) > 1e-6) {
+      const err = new Error("probabilities do not sum to 1 in StackMarkovChain");
+      err.data = {
+        sum: sum,
+        probs: this._stackProbs,
+      };
+      console.log(err.data);
+
+      throw err;
+    }
+  }
+
+  // add a stack with guaranteed probability
+  guaranteeStack() {
+    this._stackProbs.unshift(0.0);
+    this._assertSum();
+  }
+
+  processAttack(dodgeProb, masteryValue) {
+    this._stackProbs.push(0);
+    const n = this._stackProbs.length - 1;
+
+    // probability of ending at 0 stacks. initial 
+    let zeroProb = 0;
+    // didn't dodge, gain a stack
+    for(let stacks = n-1; stacks >= 0; stacks--) {
+      const prob = this._clampProb(dodgeProb + masteryValue * stacks);
+      zeroProb += prob * this._stackProbs[stacks]; // dodge -> go to 0
+      const hitProb = 1 - prob;
+      this._stackProbs[stacks+1] = hitProb * this._stackProbs[stacks]; // hit -> go to stacks + 1
+    }
+    // did dodge, reset stacks
+    this._stackProbs[0] = zeroProb;
+    this._assertSum();
+  }
+
+  get expected() {
+    return this._stackProbs.reduce((sum, prob, index) => sum + prob * index, 0);
+  }
+}
+
+/**
+ * Estimate the expected value of mastery on this fight. The *actual*
+ * estimated value is subject to greater variance.
+ * On the other hand, the expected value averages over all
+ * possible outcomes and gives a better sense of how valuable mastery is
+ * if you were to do this fight again. This values more stable over
+ * repeated attempts or kills and reflects the value of mastery (and the
+ * execution of the rotation) more closely than how well-favored you
+ * were on this particular attempt.
+ *
+ * We calculate the expected value by applying the Markov Chain above to
+ * the timeline to calculate the expected number of stacks at each
+ * dodgeable event. This is then combined with information about the
+ * expected damage of each dodged hit (dodge events have amount: 0,
+ * absorbed: 0, etc.) to provide a best-guess estimate of the damage
+ * you'll mitigate on average. The actual estimate (shown in the
+ * tooltip) may be over or under this, but is unlikely to be far from
+ * it.
+ *
+ * This madness was authored by emallson. If you need further explanation of
+ * the theory behind it, find me on discord.
+ */
+class MasteryValue extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    dmg: DamageTaken,
+    stats: StatTracker,
+  };
+
+  _dodgeableSpells = {};
+  _timeline = [];
+  _hitCounts = {};
+
+  get baseDodge() {
+    return 0.15;
+  }
+
+  dodgePenalty(_source) {
+    return 0.045; // 1.5% per level, bosses are three levels over players. not sure how to get trash levels yet
+  }
+
+  // returns the current chance to dodge a damage event assuming the
+  // event is dodgeable
+  dodgeChance(masteryStacks, event) {
+    return (event._masteryPercentage || this.stats.currentMasteryPercentage) * masteryStacks + this.baseDodge - this.dodgePenalty(event.sourceID);
+  }
+
+
+  on_byPlayer_cast(event) {
+    if(this._appliesStack(event)) {
+      this._timeline.push(event);
+    }
+  }
+
+  on_toPlayer_damage(event) {
+    event._masteryPercentage = this.stats.currentMasteryPercentage;
+    event._masteryRating = this.stats.currentMasteryRating;
+    if(event.hitType === HIT_TYPES.DODGE) {
+      this._addDodge(event);
+    } else {
+      this._addHit(event);
+    }
+  }
+
+  _addDodge(event) {
+    const spellId = event.ability.guid;
+    this._dodgeableSpells[spellId] = true;
+    this._timeline.push(event);
+  }
+
+  _addHit(event) {
+    const spellId = event.ability.guid;
+    if(!(spellId in this._hitCounts)) {
+      this._hitCounts[spellId] = 0;
+    }
+    this._hitCounts[spellId] += 1;
+    this._timeline.push(event);
+  }
+
+  // returns true of the event represents a cast that applies a stack of
+  // mastery
+  //
+  // TODO: blackout combo + purify
+  _appliesStack(event) {
+    return [SPELLS.BLACKOUT_STRIKE.id, SPELLS.BREATH_OF_FIRE.id].includes(event.ability.guid);
+  }
+
+  meanHitByAbility(spellId) {
+    if(spellId in this._hitCounts) {
+      return this.dmg.byAbility(spellId).effective / this._hitCounts[spellId];
+    }
+    return 0;
+  }
+
+  // events that either (a) add a stack or (b) can be dodged according
+  // to the data we have
+  get relevantTimeline() {
+    return this._timeline.filter(event => event.type === "cast" || this._dodgeableSpells[event.ability.guid]);
+  }
+
+  get _expectedValues() {
+    // expected damage mitigated according to the markov chain
+    let expectedDamageMitigated = 0;
+    // estimate of the damage that was actually dodged in this log
+    let estimatedDamageMitigated = 0;
+    // average dodge % across each event that could be dodged
+    let meanExpectedDodge = 0;
+    let dodgeableEvents = 0;
+    const stacks = new StackMarkovChain(); // mutating a const object irks me to no end
+
+    // timeline replay is expensive, compute several things here and
+    // provide individual getters for each of the values
+    this.relevantTimeline.forEach(event => {
+      if(event.type === "cast") {
+        stacks.guaranteeStack();
+      } else if(event.type === "damage") {
+        const expectedDodgeChance = this.dodgeChance(stacks.expected, event);
+        expectedDamageMitigated += expectedDodgeChance * (event.amount || this.meanHitByAbility(event.ability.guid));
+        estimatedDamageMitigated += (event.hitType === HIT_TYPES.DODGE) * this.meanHitByAbility(event.ability.guid);
+        meanExpectedDodge += expectedDodgeChance;
+        dodgeableEvents += 1;
+        stacks.processAttack(this.dodgeChance(0, event), event._masteryPercentage);
+      }
+    });
+
+    meanExpectedDodge /= dodgeableEvents;
+
+    return {
+      expectedDamageMitigated,
+      estimatedDamageMitigated,
+      meanExpectedDodge,
+    };
+  }
+
+  get expectedMitigation() {
+    return this._expectedValues.expectedDamageMitigated;
+  }
+  
+  get expectedMeanDodge() {
+    return this._expectedValues.meanExpectedDodge;
+  }
+
+  get estimatedActualMitigation() {
+    return this._expectedValues.estimatedDamageMitigated;
+  }
+
+  get averageMasteryRating() {
+    return this.relevantTimeline.reduce((sum, event) => {
+      if(event.type === "damage") {
+        return event._masteryRating + sum;
+      } else {
+        return sum;
+      }
+    }, 0) / this.relevantTimeline.filter(event => event.type === "damage").length;
+  }
+
+  get expectedMitigationPerSecond() {
+    return this.expectedMitigation / this.owner.fightDuration * 1000;
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.MASTERY_ELUSIVE_BRAWLER.id} />}
+        value={`${formatNumber(this.expectedMitigationPerSecond)} DTPS`}
+        label="Expected Damage Mitigated by Dodge"
+        tooltip={`On average, you would dodge about <b>${formatNumber(this.expectedMitigation)}</b> damage on this fight. You had an average expected dodge chance of <b>${formatPercentage(this.expectedMeanDodge)}%</b> and actually dodged about <b>${formatNumber(this.estimatedActualMitigation)}</b> damage. This amounts to an expected reduction of <b>${formatNumber(this.expectedMitigationPerSecond / this.averageMasteryRating)} DTPS per 1 Mastery</b> <em>on this fight</em>.<br/><br/>
+          
+          <em>Technical Information:</em><br/>
+          <b>Estimated Actual Damage</b> is calculated by calculating the average damage per hit of an ability, then multiplying that by the number of times you dodged each ability.<br/>
+          <b>Expected</b> values are calculated by computing the expected number of mastery stacks each time you <em>could</em> dodge an ability.<br/>
+          An ability is considered <b>dodgeable</b> if you dodged it at least once.`}/>
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.OPTIONAL();
+}
+
+export default MasteryValue;

--- a/src/Parser/Monk/Brewmaster/Modules/Core/MasteryValue.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/MasteryValue.js
@@ -281,13 +281,14 @@ class MasteryValue extends Analyzer {
       <StatisticBox
         icon={<SpellIcon id={SPELLS.MASTERY_ELUSIVE_BRAWLER.id} />}
         value={`${formatNumber(this.expectedMitigationPerSecond - this.noMasteryExpectedMitigationPerSecond)} DTPS`}
-        label="Expected Damage Mitigated by Mastery"
+        label="Expected Mitigation by Mastery"
         tooltip={`On average, you would dodge about <b>${formatNumber(this.expectedMitigation)}</b> damage on this fight. This value was increased by about <b>${formatNumber(this.expectedMitigation - this.noMasteryExpectedMitigation)}</b> due to Mastery. You had an average expected dodge chance of <b>${formatPercentage(this.expectedMeanDodge)}%</b> and actually dodged about <b>${formatNumber(this.estimatedActualMitigation)}</b> damage with an overall rate of <b>${formatPercentage(this.actualDodgeRate)}%</b>. This amounts to an expected reduction of <b>${formatNumber((this.expectedMitigationPerSecond - this.noMasteryExpectedMitigationPerSecond) / this.averageMasteryRating)} DTPS per 1 Mastery</b> <em>on this fight</em>.<br/><br/>
 
           <em>Technical Information:</em><br/>
           <b>Estimated Actual Damage</b> is calculated by calculating the average damage per hit of an ability, then multiplying that by the number of times you dodged each ability.<br/>
           <b>Expected</b> values are calculated by computing the expected number of mastery stacks each time you <em>could</em> dodge an ability.<br/>
-          An ability is considered <b>dodgeable</b> if you dodged it at least once.`}/>
+          An ability is considered <b>dodgeable</b> if you dodged it at least once.`}
+      />
     );
   }
   statisticOrder = STATISTIC_ORDER.OPTIONAL();

--- a/src/Parser/Monk/Brewmaster/Modules/Normalizers/GarothiWorldbreakerMelee.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Normalizers/GarothiWorldbreakerMelee.js
@@ -1,8 +1,7 @@
 import EventsNormalizer from 'Parser/Core/EventsNormalizer';
 import HIT_TYPES from 'Parser/Core/HIT_TYPES';
 import SPELLS from 'common/SPELLS';
-
-const GAROTHI_WORLDBREAKER = 2076;
+import GarothiWorldbreaker from 'Raids/AntorusTheBurningThrone/GarothiWorldbreaker';
 
 /**
  * The issue with Garothi Worldbreaker is that he has two melee
@@ -16,7 +15,7 @@ const GAROTHI_WORLDBREAKER = 2076;
  */
 class GarothiWorldbreakerMelee extends EventsNormalizer {
   normalize(events) {
-    if(this.owner.fight.boss !== GAROTHI_WORLDBREAKER) {
+    if(this.owner.fight.boss !== GarothiWorldbreaker.id) {
       return events;
     }
     return events.filter(event => {

--- a/src/Parser/Monk/Brewmaster/Modules/Normalizers/GarothiWorldbreakerMelee.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Normalizers/GarothiWorldbreakerMelee.js
@@ -1,0 +1,37 @@
+import EventsNormalizer from 'Parser/Core/EventsNormalizer';
+import HIT_TYPES from 'Parser/Core/HIT_TYPES';
+import SPELLS from 'common/SPELLS';
+
+const GAROTHI_WORLDBREAKER = 2076;
+
+/**
+ * The issue with Garothi Worldbreaker is that he has two melee
+ * abilities -- the normal one, and then the actual one. This is due to
+ * his fixed location to keep him from randomly 1-shotting melee dps due
+ * to range.
+ *
+ * This wouldn't be a problem, *except* every dodge gets double-counted.
+ * We simply remove every "normal" melee from the event list to account
+ * for this (each should be a dodge).
+ */
+class GarothiWorldbreakerMelee extends EventsNormalizer {
+  normalize(events) {
+    if(this.owner.fight.boss !== GAROTHI_WORLDBREAKER) {
+      return events;
+    }
+    return events.filter(event => {
+      if(event.type !== "damage" || event.sourceIsFriendly) {
+        return true;
+      }
+      if(event.ability) {
+        if(event.ability.guid === SPELLS.MELEE.id && event.hitType !== HIT_TYPES.DODGE) {
+          throw new Error("Garothi hit with a normal melee, wut?");
+        }
+        return event.ability.guid !== SPELLS.MELEE.id;
+      }
+      return true;
+    });
+  }
+}
+
+export default GarothiWorldbreakerMelee;

--- a/src/common/SPELLS/MONK.js
+++ b/src/common/SPELLS/MONK.js
@@ -549,6 +549,11 @@ export default {
     name: 'Staggering Around',
     icon: 'ability_monk_fortifyingale_new',
   },
+  MASTERY_ELUSIVE_BRAWLER: {
+    id: 117906,
+    name: 'Mastery: Elusive Brawler',
+    icon: 'ability_monk_shuffle',
+  },
 
   // Windwalker Spells
   COMBO_STRIKES: {


### PR DESCRIPTION
This PR adds a statistic for Brewmasters that shows both an estimate of the actual damage mitigated by [their mastery](www.wowhead.com/spell=117906/mastery-elusive-brawler) and the expected damage that would be mitigated if they repeated this fight a bunch of times.

Much of the code is dedicated to that latter part, which I opted to highlight over the actual because it depends only on player performance and gear, and not on RNG (if you didn't click the link, brewmaster mastery boosts dodge chance).

The math for calculating the expectation is relatively complicated, but I tried to comment well enough that it is reasonably clear what is going on. There are a couple of improvements that could tighten things up but aren't essential for giving useful output. I'd be fine with merging this without addressing either.

- [ ] Find the formula for the base (pre-mastery) dodge chance. I've reached out to the good fellows in `#brewcraft` but haven't gotten anything yet, and haven't tried to reverse-engineer it myself yet. Due to diminishing returns, the value of 15% is going to be reasonably close to the true value (fwiw my monk has 19% base dodge). The base dodge chance is mostly drowned out by mastery at this point in the expansion (each stack on my monk atm gives almost 40% dodge).
- [ ] Figure out how to determine mob level. We don't currently have any sub-boss-level mobs that are dangerous enough to worry about the extra 1.5-3% dodge chance, but it may become relevant in the future.

![it looks like this](https://i.imgur.com/lVsRLSj.png)