### PR TITLE
Changelog off-by-one error in some timezones

### DIFF
--- a/src/Main/Changelog.js
+++ b/src/Main/Changelog.js
@@ -79,7 +79,7 @@ class Changelog extends React.PureComponent {
                     className={`flex wrapable ${includeCore && isFromCoreChangelog ? 'text-muted' : ''}`}
                   >
                     <div className="flex-sub" style={{ minWidth: 100, paddingRight: 15 }}>
-                      {date.toLocaleDateString()}
+                      {date.getUTCMonth() + 1}/{date.getUTCDate()}/{date.getUTCFullYear()}
                     </div>
                     <div className="flex-main" style={{ minWidth: 200 }}>
                       {changes}


### PR DESCRIPTION
See issue #1273 
This change forces the date to be displayed in terms of UTC rather than attempting to convert to a user's local timezone, which was showing different dates depending on the viewer's location.
For consistency the date is still displayed in the US style (month/day/year), matching the defaults that were used by `date.toLocaleDateString()`.