### PR TITLE
[Affliction] Bugfix in T21 2p

### DIFF
--- a/src/Parser/Warlock/Affliction/Modules/Items/Tier21_2set.js
+++ b/src/Parser/Warlock/Affliction/Modules/Items/Tier21_2set.js
@@ -44,9 +44,7 @@ class Tier21_2set extends Analyzer {
       return;
     }
     const enemy = encodeTargetString(event.targetID, event.targetInstance);
-    if (!this._debuffs[enemy]) {
-      this._debuffs[enemy] = {};
-    }
+    this._ensureEnemyExists(enemy);
     this._debuffs[enemy][id] = 0;
     debug && console.log(`${enemy} - apply ${id}`);
   }
@@ -57,6 +55,7 @@ class Tier21_2set extends Analyzer {
       return;
     }
     const enemy = encodeTargetString(event.targetID, event.targetInstance);
+    this._ensureEnemyExists(enemy);
     this._debuffs[enemy][id] = null;
     debug && console.log(`${enemy} - remove  ${id}`);
   }
@@ -67,6 +66,7 @@ class Tier21_2set extends Analyzer {
       return;
     }
     const enemy = encodeTargetString(event.targetID, event.targetInstance);
+    this._ensureEnemyExists(enemy);
     this._debuffs[enemy][id] = 0;
   }
 
@@ -76,12 +76,20 @@ class Tier21_2set extends Analyzer {
       return;
     }
     const enemy = encodeTargetString(event.targetID, event.targetInstance);
+    this._ensureEnemyExists(enemy);
     this._debuffs[enemy][id] += 1;
     debug && console.log(`${enemy} - damage - ${id}, now at ${this._debuffs[enemy][id]} ticks`);
     if (this._debuffs[enemy][id] > TICKS_PER_UA) {
       this._bonusDamage += event.amount + (event.absorbed || 0);
       this._bonusTicks += 1;
       debug && console.log(`EXTRA - currently ${this._bonusTicks} bonus ticks`);
+    }
+  }
+
+  _ensureEnemyExists(enemy) {
+    if (!this._debuffs[enemy]) {
+      this._debuffs[enemy] = {};
+      UNSTABLE_AFFLICTION_DEBUFF_IDS.forEach(id => this._debuffs[enemy][id] = 0);
     }
   }
 


### PR DESCRIPTION
If by any chance `damage` event happened before `applydebuff` event for UA, the object representing the target didn't exist causing the tick tracking to crash. This ensures the object exists with all the debuff fields reset so it shouldn't crash again and its behavior for normal logs should be the same.