### PR TITLE
[Affliction] Update thresholds

### DIFF
--- a/src/Parser/Warlock/Affliction/CHANGELOG.js
+++ b/src/Parser/Warlock/Affliction/CHANGELOG.js
@@ -9,6 +9,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-01-28'),
+    changes: <Wrapper>Updated the thresholds for DOTs to be more strict.</Wrapper>,
+    contributors: [Chizu],
+  },
+  {
     date: new Date('2018-01-27'),
     changes: <Wrapper>Updated the Checklist to show a Rule about buffing <SpellLink id={SPELLS.UNSTABLE_AFFLICTION_CAST.id} icon/>, low mana Rule and also refined some texts.</Wrapper>,
     contributors: [Chizu],

--- a/src/Parser/Warlock/Affliction/Modules/Features/AgonyUptime.js
+++ b/src/Parser/Warlock/Affliction/Modules/Features/AgonyUptime.js
@@ -21,19 +21,7 @@ class AgonyUptime extends Analyzer {
     return this.enemies.getBuffUptime(SPELLS.AGONY.id) / this.owner.fightDuration;
   }
 
-  get defaultSuggestionThresholds() {
-    return {
-      actual: this.uptime,
-      isLessThan: {
-        minor: 0.85,
-        average: 0.8,
-        major: 0.7,
-      },
-      style: 'percentage',
-    };
-  }
-
-  get writheSuggestionThresholds() {
+  get suggestionThresholds() {
     return {
       actual: this.uptime,
       isLessThan: {
@@ -46,23 +34,20 @@ class AgonyUptime extends Analyzer {
   }
 
   suggestions(when) {
+    let text;
     if (this.combatants.selected.hasTalent(SPELLS.WRITHE_IN_AGONY_TALENT.id)) {
-      when(this.writheSuggestionThresholds)
-        .addSuggestion((suggest, actual, recommended) => {
-          return suggest(<Wrapper>Your <SpellLink id={SPELLS.AGONY.id} /> uptime can be improved. Try to pay more attention to your Agony on the boss, especially since you're using <SpellLink id={SPELLS.WRITHE_IN_AGONY_TALENT.id} /> talent.</Wrapper>)
-            .icon(SPELLS.AGONY.icon)
-            .actual(`${formatPercentage(actual)}% Agony uptime`)
-            .recommended(`> ${formatPercentage(recommended)}% is recommended`);
-        });
-    } else {
-      when(this.defaultSuggestionThresholds)
-        .addSuggestion((suggest, actual, recommended) => {
-          return suggest(<Wrapper>Your <SpellLink id={SPELLS.AGONY.id} /> uptime can be improved. Try to pay more attention to your Agony on the boss, perhaps use some debuff tracker.</Wrapper>)
-            .icon(SPELLS.AGONY.icon)
-            .actual(`${formatPercentage(actual)}% Agony uptime`)
-            .recommended(`> ${formatPercentage(recommended)}% is recommended`);
-        });
+      text = <Wrapper>Your <SpellLink id={SPELLS.AGONY.id} /> uptime can be improved as it is your main source of Soul Shards. Try to pay more attention to your Agony on the boss, especially since you're using <SpellLink id={SPELLS.WRITHE_IN_AGONY_TALENT.id} /> talent.</Wrapper>;
     }
+    else {
+      text = <Wrapper>Your <SpellLink id={SPELLS.AGONY.id} /> uptime can be improved as it is your main source of Soul Shards. Try to pay more attention to your Agony on the boss, perhaps use some debuff tracker.</Wrapper>;
+    }
+    when(this.suggestionThresholds)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(text)
+          .icon(SPELLS.AGONY.icon)
+          .actual(`${formatPercentage(actual)}% Agony uptime`)
+          .recommended(`> ${formatPercentage(recommended)}% is recommended`);
+      });
   }
 
   statistic() {

--- a/src/Parser/Warlock/Affliction/Modules/Features/Checklist.js
+++ b/src/Parser/Warlock/Affliction/Modules/Features/Checklist.js
@@ -58,23 +58,11 @@ class Checklist extends CoreChecklist {
         return [
           new Requirement({
             name: <Wrapper><SpellLink id={SPELLS.AGONY.id} icon/> uptime</Wrapper>,
-            check: () => this.agonyUptime.defaultSuggestionThresholds,
-            when: !combatant.hasTalent(SPELLS.WRITHE_IN_AGONY_TALENT.id),
-          }),
-          new Requirement({
-            name: <Wrapper><SpellLink id={SPELLS.AGONY.id} icon/> uptime</Wrapper>,
-            check: () => this.agonyUptime.writheSuggestionThresholds,
-            when: combatant.hasTalent(SPELLS.WRITHE_IN_AGONY_TALENT.id),
+            check: () => this.agonyUptime.suggestionThresholds,
           }),
           new Requirement({
             name: <Wrapper><SpellLink id={SPELLS.CORRUPTION_CAST.id} icon/> uptime</Wrapper>,
-            check: () => this.corruptionUptime.defaultSuggestionThresholds,
-            when: !combatant.hasBuff(SPELLS.WARLOCK_AFFLI_T20_2P_BONUS.id),
-          }),
-          new Requirement({
-            name: <Wrapper><SpellLink id={SPELLS.CORRUPTION_CAST.id} icon/> uptime</Wrapper>,
-            check: () => this.corruptionUptime.t20SuggestionThresholds,
-            when: combatant.hasBuff(SPELLS.WARLOCK_AFFLI_T20_2P_BONUS.id),
+            check: () => this.corruptionUptime.suggestionThresholds,
           }),
           new Requirement({
             name: <Wrapper><SpellLink id={SPELLS.SIPHON_LIFE_TALENT.id} icon/> uptime</Wrapper>,

--- a/src/Parser/Warlock/Affliction/Modules/Features/CorruptionUptime.js
+++ b/src/Parser/Warlock/Affliction/Modules/Features/CorruptionUptime.js
@@ -21,19 +21,7 @@ class CorruptionUptime extends Analyzer {
     return this.enemies.getBuffUptime(SPELLS.CORRUPTION_DEBUFF.id) / this.owner.fightDuration;
   }
 
-  get defaultSuggestionThresholds() {
-    return {
-      actual: this.uptime,
-      isLessThan: {
-        minor: 0.85,
-        average: 0.8,
-        major: 0.7,
-      },
-      style: 'percentage',
-    };
-  }
-
-  get t20SuggestionThresholds() {
+  get suggestionThresholds() {
     return {
       actual: this.uptime,
       isLessThan: {
@@ -46,23 +34,20 @@ class CorruptionUptime extends Analyzer {
   }
 
   suggestions(when) {
+    let text;
     if (this.combatants.selected.hasBuff(SPELLS.WARLOCK_AFFLI_T20_2P_BONUS.id)) {
-      when(this.t20SuggestionThresholds)
-        .addSuggestion((suggest, actual, recommended) => {
-          return suggest(<Wrapper>Your <SpellLink id={SPELLS.CORRUPTION_CAST.id} /> uptime can be improved. Try to pay more attention to your Corruption on the boss, which is especially important with the <SpellLink id={SPELLS.WARLOCK_AFFLI_T20_2P_BONUS.id}>T20 2-piece set bonus</SpellLink>.</Wrapper>)
-            .icon(SPELLS.CORRUPTION_CAST.icon)
-            .actual(`${formatPercentage(actual)}% Corruption uptime`)
-            .recommended(`>${formatPercentage(recommended)}% is recommended`);
-        });
-    } else {
-      when(this.defaultSuggestionThresholds)
-        .addSuggestion((suggest, actual, recommended) => {
-          return suggest(<Wrapper>Your <SpellLink id={SPELLS.CORRUPTION_CAST.id} /> uptime can be improved. Try to pay more attention to your Corruption on the boss, perhaps use some debuff tracker.</Wrapper>)
-            .icon(SPELLS.CORRUPTION_CAST.icon)
-            .actual(`${formatPercentage(actual)}% Corruption uptime`)
-            .recommended(`>${formatPercentage(recommended)}% is recommended`);
-        });
+      text = <Wrapper>Your <SpellLink id={SPELLS.CORRUPTION_CAST.id} /> uptime can be improved. Try to pay more attention to your Corruption on the boss, which is especially important with the <SpellLink id={SPELLS.WARLOCK_AFFLI_T20_2P_BONUS.id}>T20 2-piece set bonus</SpellLink>.</Wrapper>;
     }
+    else {
+      text = <Wrapper>Your <SpellLink id={SPELLS.CORRUPTION_CAST.id} /> uptime can be improved. Try to pay more attention to your Corruption on the boss, perhaps use some debuff tracker.</Wrapper>;
+    }
+    when(this.suggestionThresholds)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(text)
+          .icon(SPELLS.CORRUPTION_CAST.icon)
+          .actual(`${formatPercentage(actual)}% Corruption uptime`)
+          .recommended(`>${formatPercentage(recommended)}% is recommended`);
+      });
   }
 
   statistic() {

--- a/src/Parser/Warlock/Affliction/Modules/Talents/MaleficGrasp.js
+++ b/src/Parser/Warlock/Affliction/Modules/Talents/MaleficGrasp.js
@@ -96,10 +96,9 @@ class MaleficGrasp extends Analyzer {
     return {
       actual: (this.unbuffedTicks / this.totalTicks) || 1,
       isGreaterThan: {
-        // TODO
-        minor: 0.15,
-        average: 0.2,
-        major: 0.25,
+        minor: 0.25,
+        average: 0.3,
+        major: 0.35,
       },
       style: 'percentage',
     };
@@ -110,9 +109,9 @@ class MaleficGrasp extends Analyzer {
     return {
       actual: (this.buffedTicks / this.totalTicks) || 0,
       isLessThan: {
-        minor: 0.85,
-        average: 0.8,
-        major: 0.75,
+        minor: 0.75,
+        average: 0.7,
+        major: 0.65,
       },
       style: 'percentage',
     };

--- a/src/Parser/Warlock/Affliction/Modules/Talents/SiphonLifeUptime.js
+++ b/src/Parser/Warlock/Affliction/Modules/Talents/SiphonLifeUptime.js
@@ -29,9 +29,9 @@ class SiphonLifeUptime extends Analyzer {
     return {
       actual: this.uptime,
       isLessThan: {
-        minor: 0.85,
-        average: 0.8,
-        major: 0.7,
+        minor: 0.95,
+        average: 0.9,
+        major: 0.8,
       },
       style: 'percentage',
     };


### PR DESCRIPTION
After talking to Motoko, I updated the thresholds for dot uptimes. Since the thresholds were the same regardless of talents/set bonuses, I removed the extra threshold object (and the respective Requirement in checklist), but since the suggestions have different wording, I extracted it to variable. 