### PR TITLE
Added most common haste proc trinkets to stat tracker

### DIFF
--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -42,7 +42,7 @@ class StatTracker extends Analyzer {
     [SPELLS.INT_FEAST.id]: { intellect: 500 },
     //endregion
 
-    // region Trinkets
+    // region Dungeon Trinkets
     [SPELLS.SHADOWS_STRIKE.id]: {
       itemId: ITEMS.DREADSTONE_OF_ENDLESS_SHADOWS.id,
       crit: (_, item) => calculateSecondaryStatDefault(845, 3480, item.itemLevel),
@@ -55,6 +55,49 @@ class StatTracker extends Analyzer {
       itemId: ITEMS.DREADSTONE_OF_ENDLESS_SHADOWS.id,
       haste: (_, item) => calculateSecondaryStatDefault(845, 3480, item.itemLevel),
     },
+    [SPELLS.QUITE_SATISFIED_VERSATILITY.id]: {
+      itemId: ITEMS.MAJORDOMOS_DINNER_BELL.id,
+      versatility: (_, item) => calculateSecondaryStatDefault(845, 5252, item.itemLevel),
+    },
+    [SPELLS.QUITE_SATISFIED_CRIT.id]: {
+      itemId: ITEMS.MAJORDOMOS_DINNER_BELL.id,
+      crit: (_, item) => calculateSecondaryStatDefault(845, 5252, item.itemLevel),
+    },
+    [SPELLS.QUITE_SATISFIED_HASTE.id]: {
+      itemId: ITEMS.MAJORDOMOS_DINNER_BELL.id,
+      haste: (_, item) => calculateSecondaryStatDefault(845, 5252, item.itemLevel),
+    },
+    [SPELLS.QUITE_SATISFIED_MASTERY.id]: {
+      itemId: ITEMS.MAJORDOMOS_DINNER_BELL.id,
+      mastery: (_, item) => calculateSecondaryStatDefault(845, 5252, item.itemLevel),
+    },
+    [SPELLS.HOWL_OF_INGVAR.id]: {
+      itemId: ITEMS.MEMENTO_OF_ANGERBODA.id,
+      crit: (_, item) => calculateSecondaryStatDefault(845, 4207, item.itemLevel),
+    },
+    [SPELLS.DIRGE_OF_ANGERBODA.id]: {
+      itemId: ITEMS.MEMENTO_OF_ANGERBODA.id,
+      mastery: (_, item) => calculateSecondaryStatDefault(845, 4207, item.itemLevel),
+    },
+    [SPELLS.WAIL_OF_SVALA.id]: {
+      itemId: ITEMS.MEMENTO_OF_ANGERBODA.id,
+      haste: (_, item) => calculateSecondaryStatDefault(845, 4207, item.itemLevel),
+    },
+    [SPELLS.DOWN_DRAFT.id]: {
+      itemId: ITEMS.NIGHTMARE_EGG_SHELL.id,
+      haste: (_, item) => calculateSecondaryStatDefault(845, 361, item.itemLevel),
+    },
+    [SPELLS.ACCELERATION.id]: {
+      itemId: ITEMS.CHRONO_SHARD.id,
+      haste: (_, item) => calculateSecondaryStatDefault(845, 5269, item.itemLevel),
+    },
+    [SPELLS.GREASE_THE_GEARS.id]: {
+      itemId: ITEMS.FELOILED_INFERNAL_MACHINE.id,
+      haste: (_, item) => calculateSecondaryStatDefault(845, 3074, item.itemLevel),
+    },
+    //endregion
+
+    // region Raid Trinkets
     // Event weirdness makes it impossible to handle CotRT normally, it's handled instead by the CharmOfTheRisingTide module
     //[SPELLS.RISING_TIDES.id]: {
     //  itemId: ITEMS.CHARM_OF_THE_RISING_TIDE.id,
@@ -63,6 +106,14 @@ class StatTracker extends Analyzer {
     [SPELLS.ACCELERANDO.id]: {
       itemId: ITEMS.ERRATIC_METRONOME.id,
       haste: (_, item) => calculateSecondaryStatDefault(870, 657, item.itemLevel),
+    },
+    [SPELLS.SOLAR_INFUSION.id]: {
+      itemId: ITEMS.CHALICE_OF_MOONLIGHT.id,
+      crit: (_, item) => calculateSecondaryStatDefault(900, 3619, item.itemLevel),
+    },
+    [SPELLS.LUNAR_INFUSION.id]: {
+      itemId: ITEMS.CHALICE_OF_MOONLIGHT.id,
+      haste: (_, item) => calculateSecondaryStatDefault(900, 3619, item.itemLevel),
     },
     [SPELLS.TOME_OF_UNRAVELING_SANITY_BUFF.id]: {
       itemId: ITEMS.TOME_OF_UNRAVELING_SANITY.id,
@@ -90,7 +141,7 @@ class StatTracker extends Analyzer {
       itemId: ITEMS.GAROTHI_FEEDBACK_CONDUIT.id,
       haste: (_, item) => calculateSecondaryStatDefault(930, 856, item.itemLevel),
     },
-    // endregion
+    // endregion 
 
     // region Misc
     [SPELLS.CONCORDANCE_OF_THE_LEGIONFALL_STRENGTH.id]: { // check numbers

--- a/src/common/ITEMS/OTHERS.js
+++ b/src/common/ITEMS/OTHERS.js
@@ -170,6 +170,36 @@ export default {
     icon: 'inv_7_0raid_trinket_010d',
     quality: ITEM_QUALITIES.EPIC,
   },
+  MAJORDOMOS_DINNER_BELL: {
+    id: 142168,
+    name: 'Majordomo\'s Dinner Bell',
+    icon: 'inv_misc_bell_01',
+    quality: ITEM_QUALITIES.EPIC,
+  },
+  MEMENTO_OF_ANGERBODA: {
+    id: 133644,
+    name: 'Memento of Angerboda',
+    icon: 'inv_jewelry_trinket_05',
+    quality: ITEM_QUALITIES.EPIC,
+  },
+  NIGHTMARE_EGG_SHELL: {
+    id: 137312,
+    name: 'Nightmare Egg Shell',
+    icon: 'inv_misc_cat_trinket09',
+    quality: ITEM_QUALITIES.EPIC,
+  },
+  CHRONO_SHARD: {
+    id: 137419,
+    name: 'Chrono Shard',
+    icon: 'inv_7_0raid_trinket_05a',
+    quality: ITEM_QUALITIES.EPIC,
+  },
+  FELOILED_INFERNAL_MACHINE: {
+    id: 144482,
+    name: 'Fel-Oiled Infernal Machine',
+    icon: 'inv_misc_enggizmos_14',
+    quality: ITEM_QUALITIES.EPIC,
+  },
 
   // T20 Trinkets
   // Heal Trinkets

--- a/src/common/SPELLS/OTHERS.js
+++ b/src/common/SPELLS/OTHERS.js
@@ -239,6 +239,56 @@ export default {
     name: 'Legion\'s Gaze',
     icon: 'inv_pet_inquisitoreye',
   },
+  QUITE_SATISFIED_VERSATILITY: { //Majordomo's Dinner Bell vers proc
+    id: 230105,
+    name: 'Quite Satisfied',
+    icon: 'inv_misc_food_03',
+  },
+  QUITE_SATISFIED_CRIT: { //Majordomo's Dinner Bell crit proc
+    id: 230102,
+    name: 'Quite Satisfied',
+    icon: 'inv_misc_food_03',
+  },
+  QUITE_SATISFIED_HASTE: { //Majordomo's Dinner Bell haste proc
+    id: 230103,
+    name: 'Quite Satisfied',
+    icon: 'inv_misc_food_03',
+  },
+  QUITE_SATISFIED_MASTERY: { //Majordomo's Dinner Bell mastery proc
+    id: 230104,
+    name: 'Quite Satisfied',
+    icon: 'inv_misc_food_03',
+  },
+  DIRGE_OF_ANGERBODA: { //Memento of Angerboda mastery proc
+    id: 214807,
+    name: 'Dirge of Angerboda',
+    icon: 'spell_deathknight_unholypresence',
+  },
+  HOWL_OF_INGVAR: { //Memento of Angerboda crit proc
+    id: 214802,
+    name: 'Howl of Ingvar',
+    icon: 'spell_deathknight_bloodpresence',
+  },
+  WAIL_OF_SVALA: { //Memento of Angerboda haste proc
+    id: 214803,
+    name: 'Wail of Svala',
+    icon: 'spell_deathknight_frostpresence',
+  },
+  DOWN_DRAFT: { //Nightmare Egg Shell buff
+    id: 214340,
+    name: 'Down Draft',
+    icon: 'ability_skyreach_wind',
+  },
+  ACCELERATION: { //Chrono Shard buff
+    id: 137419,
+    name: 'Acceleration',
+    icon: 'inv_7_0raid_trinket_05a',
+  },
+  GREASE_THE_GEARS: { //Fel-Oiled Infernal Machine buff
+    id: 238534,
+    name: 'Grease the Gears',
+    icon: 'inv_misc_enggizmos_14',
+  },
 
   // Nighthold Trinkets
   RECURSIVE_STRIKES: {
@@ -321,6 +371,16 @@ export default {
     id: 242642,
     name: 'Strength of Will',
     icon: 'inv_wand_36',
+  },
+  SOLAR_INFUSION: { //Chalice of Moonlight crit proc
+    id: 242544,
+    name: 'Solar Infusion',
+    icon: 'achievment_raid_houroftwilight',
+  },
+  LUNAR_INFUSION: { //Chalice of Moonlight haste proc
+    id: 242543,
+    name: 'Lunar Infusion',
+    icon: 'ability_druid_lunarguidance',
   },
   // T21 Healing trinkets
   TARRATUS_KEYSTONE: {
@@ -565,11 +625,6 @@ export default {
     name: 'Extracted Sanity',
     icon: 'inv_archaeology_70_demon_flayedskinchronicle',
   },
-  LUNAR_INFUSION: {
-    id: 242543,
-    name: 'Lunar Infusion',
-    icon: 'ability_druid_lunarguidance',
-  },
   RISING_TIDES: {
     id: 242458,
     name: 'Rising Tides',
@@ -580,12 +635,6 @@ export default {
     id: 242612,
     name: 'Demonic Vigor',
     icon: 'inv_relics_warpring',
-  },
-  // Chrono Shard buff
-  ACCELERATION: {
-    id: 137419,
-    name: 'Acceleration',
-    icon: 'inv_7_0raid_trinket_05a',
   },
   MARCH_OF_THE_LEGION: {
     id: 228446,


### PR DESCRIPTION
Missing Khaz'goroth's Shaping which for some reason uses the same buff ID for all 4 secondary procs and I didn't have time to implement it tonight.