### PR TITLE
[Windwalker] Fixing DHC gain calculation

### DIFF
--- a/src/Parser/Monk/Windwalker/Modules/Items/DrinkingHornCover.js
+++ b/src/Parser/Monk/Windwalker/Modules/Items/DrinkingHornCover.js
@@ -25,12 +25,14 @@ class DrinkingHornCover extends Analyzer {
   }
   on_toPlayer_removebuff(event) {
     const spellId = event.ability.guid;
-    if (SPELLS.STORM_EARTH_AND_FIRE_CAST.id === spellId) {
-      this.totalTimeGained += (event.timestamp - this.lastCastTime) / 1000 - 15;
+    const duration = event.timestamp - this.lastCastTime;
+    // the duration checks are to not have negative values from SEFs/Serenities ended early because of death or cancelling the buff. 
+    if (SPELLS.STORM_EARTH_AND_FIRE_CAST.id === spellId && duration > 15000) {
+      this.totalTimeGained += duration / 1000 - 15;
       this.averageTimeGained = this.totalTimeGained / this.abilityTracker.getAbility(SPELLS.STORM_EARTH_AND_FIRE_CAST.id).casts;
     }
-    if (SPELLS.SERENITY_TALENT.id === spellId) {
-      this.totalTimeGained += (event.timestamp - this.lastCastTime) / 1000 - 8;
+    if (SPELLS.SERENITY_TALENT.id === spellId && duration > 8000) {
+      this.totalTimeGained += duration / 1000 - 8;
       this.averageTimeGained = this.totalTimeGained / this.abilityTracker.getAbility(SPELLS.SERENITY_TALENT.id).casts;
     }
   }


### PR DESCRIPTION
It would create a negative gain for SEF/Serenity uses that were ended early, typically only in case of death, which would then lower the average time gained more than it should. 
old result:
![image](https://user-images.githubusercontent.com/30317641/35558286-ed46824e-05a7-11e8-857b-b097e43d4696.png)

new result:
![image](https://user-images.githubusercontent.com/30317641/35558312-01e11a52-05a8-11e8-9d96-8c0152b87588.png)

https://wowanalyzer.com/report/cHqZ2A4C8TvtLjYx/4-Mythic+Felhounds+of+Sargeras+-+Kill+(4:54)/Rollinrey
