### PR TITLE
[Warlock] Import reorder

### DIFF
--- a/src/Parser/Warlock/Affliction/CHANGELOG.js
+++ b/src/Parser/Warlock/Affliction/CHANGELOG.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { Chizu, Zerotorescue } from 'MAINTAINERS';
 import Wrapper from 'common/Wrapper';
 import ItemLink from 'common/ItemLink';
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
+
+import { Chizu, Zerotorescue } from 'MAINTAINERS';
 
 export default [
   {

--- a/src/Parser/Warlock/Affliction/CONFIG.js
+++ b/src/Parser/Warlock/Affliction/CONFIG.js
@@ -1,10 +1,11 @@
 import React from 'react';
 
-import { Chizu } from 'MAINTAINERS';
 import SPECS from 'common/SPECS';
 import SPEC_ANALYSIS_COMPLETENESS from 'common/SPEC_ANALYSIS_COMPLETENESS';
 import SpellLink from 'common/SpellLink';
 import SPELLS from 'common/SPELLS';
+
+import { Chizu } from 'MAINTAINERS';
 
 import CombatLogParser from './CombatLogParser';
 import CHANGELOG from './CHANGELOG';

--- a/src/Parser/Warlock/Affliction/Modules/Features/Abilities.js
+++ b/src/Parser/Warlock/Affliction/Modules/Features/Abilities.js
@@ -1,7 +1,7 @@
-import SPELLS from 'common/SPELLS';
-
 import CoreAbilities from 'Parser/Core/Modules/Abilities';
 import ISSUE_IMPORTANCE from 'Parser/Core/ISSUE_IMPORTANCE';
+
+import SPELLS from 'common/SPELLS';
 
 class Abilities extends CoreAbilities {
   spellbook() {

--- a/src/Parser/Warlock/Affliction/Modules/Features/AgonyUptime.js
+++ b/src/Parser/Warlock/Affliction/Modules/Features/AgonyUptime.js
@@ -7,9 +7,10 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import { formatPercentage } from 'common/format';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class AgonyUptime extends Analyzer {
   static dependencies = {

--- a/src/Parser/Warlock/Affliction/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Warlock/Affliction/Modules/Features/AlwaysBeCasting.js
@@ -4,16 +4,16 @@ import CoreAlwaysBeCasting from 'Parser/Core/Modules/AlwaysBeCasting';
 
 import SPELLS from 'common/SPELLS';
 import { formatPercentage } from 'common/format';
-import { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';
+
+import { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class AlwaysBeCasting extends CoreAlwaysBeCasting {
   get suggestionThresholds() {
     return {
       actual: this.downtimePercentage,
       isGreaterThan: {
-        // TODO
         minor: 0.1,
         average: 0.15,
         major: 0.2,

--- a/src/Parser/Warlock/Affliction/Modules/Features/Checklist.js
+++ b/src/Parser/Warlock/Affliction/Modules/Features/Checklist.js
@@ -1,9 +1,5 @@
 import React from 'react';
 
-import Wrapper from 'common/Wrapper';
-import SPELLS from 'common/SPELLS';
-import SpellLink from 'common/SpellLink';
-
 import CoreChecklist, { Rule, Requirement } from 'Parser/Core/Modules/Features/Checklist';
 import { PreparationRule } from 'Parser/Core/Modules/Features/Checklist/Rules';
 import { GenericCastEfficiencyRequirement } from 'Parser/Core/Modules/Features/Checklist/Requirements';
@@ -13,6 +9,10 @@ import LegendaryUpgradeChecker from 'Parser/Core/Modules/Items/LegendaryUpgradeC
 import LegendaryCountChecker from 'Parser/Core/Modules/Items/LegendaryCountChecker';
 import PrePotion from 'Parser/Core/Modules/Items/PrePotion';
 import EnchantChecker from 'Parser/Core/Modules/Items/EnchantChecker';
+
+import Wrapper from 'common/Wrapper';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
 
 import AlwaysBeCasting from './AlwaysBeCasting';
 import AgonyUptime from './AgonyUptime';

--- a/src/Parser/Warlock/Affliction/Modules/Features/CorruptionUptime.js
+++ b/src/Parser/Warlock/Affliction/Modules/Features/CorruptionUptime.js
@@ -7,9 +7,10 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import { formatPercentage } from 'common/format';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class CorruptionUptime extends Analyzer {
   static dependencies = {

--- a/src/Parser/Warlock/Affliction/Modules/Features/FatalEchoes.js
+++ b/src/Parser/Warlock/Affliction/Modules/Features/FatalEchoes.js
@@ -2,10 +2,11 @@ import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
 
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
 import SPELLS from 'common/SPELLS';
 import { formatNumber } from 'common/format';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 import { UNSTABLE_AFFLICTION_DEBUFF_IDS } from '../../Constants';
 

--- a/src/Parser/Warlock/Affliction/Modules/Features/LowMana.js
+++ b/src/Parser/Warlock/Affliction/Modules/Features/LowMana.js
@@ -1,4 +1,5 @@
 import Analyzer from 'Parser/Core/Analyzer';
+
 import RESOURCE_TYPES from 'common/RESOURCE_TYPES';
 
 const LOW_MANA_THRESHOLD = 0.05;

--- a/src/Parser/Warlock/Affliction/Modules/Features/ReapBuffTracker.js
+++ b/src/Parser/Warlock/Affliction/Modules/Features/ReapBuffTracker.js
@@ -8,6 +8,7 @@ import SpellIcon from 'common/SpellIcon';
 import { formatPercentage } from 'common/format';
 import Wrapper from 'common/Wrapper';
 import SpellLink from 'common/SpellLink';
+
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 import { UNSTABLE_AFFLICTION_DEBUFF_IDS } from '../../Constants';
@@ -39,7 +40,6 @@ class ReapBuffTracker extends Analyzer {
     return {
       actual: (this.unbuffedTicks / this.totalTicks) || 1,  // if no UAs were cast (totalTicks and unbuffedTicks = 0), it should return NaN and thus be 1 (100% unbuffed ticks)
       isGreaterThan: {
-        // TODO
         minor: 0.15,
         average: 0.2,
         major: 0.25,

--- a/src/Parser/Warlock/Affliction/Modules/Features/Sniping.js
+++ b/src/Parser/Warlock/Affliction/Modules/Features/Sniping.js
@@ -1,12 +1,16 @@
 import React from 'react';
+
 import Analyzer from 'Parser/Core/Analyzer';
 import Enemies from 'Parser/Core/Modules/Enemies';
+
 import Icon from 'common/Icon';
 import { formatPercentage } from 'common/format';
 import Wrapper from 'common/Wrapper';
 import SpellLink from 'common/SpellLink';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SPELLS from 'common/SPELLS';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+
 import SoulShardTracker from '../SoulShards/SoulShardTracker';
 import { UNSTABLE_AFFLICTION_DEBUFF_IDS } from '../../Constants';
 

--- a/src/Parser/Warlock/Affliction/Modules/Features/TormentedSouls.js
+++ b/src/Parser/Warlock/Affliction/Modules/Features/TormentedSouls.js
@@ -7,6 +7,7 @@ import SPELLS from 'common/SPELLS';
 import { formatDuration, formatPercentage } from 'common/format';
 import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';
+
 import StatisticsListBox from 'Main/StatisticsListBox';
 
 const MAX_SOULS = 12;

--- a/src/Parser/Warlock/Affliction/Modules/Items/Legendaries/PowerCordOfLethtendris.js
+++ b/src/Parser/Warlock/Affliction/Modules/Items/Legendaries/PowerCordOfLethtendris.js
@@ -1,6 +1,8 @@
 import React from 'react';
+
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
 import { formatNumber } from 'common/format';

--- a/src/Parser/Warlock/Affliction/Modules/Items/Legendaries/SacrolashsDarkStrike.js
+++ b/src/Parser/Warlock/Affliction/Modules/Items/Legendaries/SacrolashsDarkStrike.js
@@ -2,10 +2,12 @@ import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
+
 import ItemDamageDone from 'Main/ItemDamageDone';
-import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 const SACROLASH_DAMAGE_BONUS = 0.15;
 

--- a/src/Parser/Warlock/Affliction/Modules/Items/Legendaries/SoulOfTheNetherlord.js
+++ b/src/Parser/Warlock/Affliction/Modules/Items/Legendaries/SoulOfTheNetherlord.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
 import ITEMS from 'common/ITEMS';
 import SpellLink from 'common/SpellLink';
 import SPELLS from 'common/SPELLS';
 import Wrapper from 'common/Wrapper';
-import Analyzer from 'Parser/Core/Analyzer';
-import Combatants from 'Parser/Core/Modules/Combatants';
 
 class SoulOfTheNetherlord extends Analyzer {
   static dependencies = {

--- a/src/Parser/Warlock/Affliction/Modules/Items/Legendaries/StretensSleeplessShackles.js
+++ b/src/Parser/Warlock/Affliction/Modules/Items/Legendaries/StretensSleeplessShackles.js
@@ -1,11 +1,13 @@
 import React from 'react';
 
-import ITEMS from 'common/ITEMS';
 import Analyzer from 'Parser/Core/Analyzer';
 import Enemies from 'Parser/Core/Modules/Enemies';
 import Combatants from 'Parser/Core/Modules/Combatants';
-import ItemDamageDone from 'Main/ItemDamageDone';
 import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+
+import ITEMS from 'common/ITEMS';
+
+import ItemDamageDone from 'Main/ItemDamageDone';
 
 import { UNSTABLE_AFFLICTION_DEBUFF_IDS } from '../../../Constants';
 

--- a/src/Parser/Warlock/Affliction/Modules/Items/Tier20_2set.js
+++ b/src/Parser/Warlock/Affliction/Modules/Items/Tier20_2set.js
@@ -1,6 +1,8 @@
 import React from 'react';
+
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';

--- a/src/Parser/Warlock/Affliction/Modules/Items/Tier21_2set.js
+++ b/src/Parser/Warlock/Affliction/Modules/Items/Tier21_2set.js
@@ -1,13 +1,16 @@
 import React from 'react';
+
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+import { encodeTargetString } from 'Parser/Core/Modules/EnemyInstances';
+
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';
-import ItemDamageDone from 'Main/ItemDamageDone';
 import { formatNumber } from 'common/format';
-import { encodeTargetString } from 'Parser/Core/Modules/EnemyInstances';
+
+import ItemDamageDone from 'Main/ItemDamageDone';
 
 import { UNSTABLE_AFFLICTION_DEBUFF_IDS } from '../../Constants';
 

--- a/src/Parser/Warlock/Affliction/Modules/Items/Tier21_4set.js
+++ b/src/Parser/Warlock/Affliction/Modules/Items/Tier21_4set.js
@@ -1,14 +1,17 @@
 import React from 'react';
+
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import Enemies from 'Parser/Core/Modules/Enemies';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';
-import ItemDamageDone from 'Main/ItemDamageDone';
 import { formatNumber, formatPercentage } from 'common/format';
-import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+
+import ItemDamageDone from 'Main/ItemDamageDone';
 
 const AFFECTED_ABILITIES = [
   SPELLS.AGONY.id,

--- a/src/Parser/Warlock/Affliction/Modules/SoulShards/SoulShardDetails.js
+++ b/src/Parser/Warlock/Affliction/Modules/SoulShards/SoulShardDetails.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
+
 import Tab from 'Main/Tab';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 

--- a/src/Parser/Warlock/Affliction/Modules/Talents/AbsoluteCorruption.js
+++ b/src/Parser/Warlock/Affliction/Modules/Talents/AbsoluteCorruption.js
@@ -2,11 +2,13 @@ import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import { formatNumber, formatPercentage } from 'common/format';
+
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
-import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 const AC_DAMAGE_BONUS = 0.25;
 

--- a/src/Parser/Warlock/Affliction/Modules/Talents/Contagion.js
+++ b/src/Parser/Warlock/Affliction/Modules/Talents/Contagion.js
@@ -3,12 +3,13 @@ import React from 'react';
 import Analyzer from 'Parser/Core/Analyzer';
 import Enemies from 'Parser/Core/Modules/Enemies';
 import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import { formatNumber, formatPercentage } from 'common/format';
+
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
-import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 import { UNSTABLE_AFFLICTION_DEBUFF_IDS } from '../../Constants';
 

--- a/src/Parser/Warlock/Affliction/Modules/Talents/DeathsEmbrace.js
+++ b/src/Parser/Warlock/Affliction/Modules/Talents/DeathsEmbrace.js
@@ -2,13 +2,14 @@ import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
 import SpellIcon from 'common/SpellIcon';
 import { formatNumber, formatPercentage } from 'common/format';
+
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
-import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 import { UNSTABLE_AFFLICTION_DEBUFF_IDS } from '../../Constants';
 

--- a/src/Parser/Warlock/Affliction/Modules/Talents/EmpoweredLifeTap.js
+++ b/src/Parser/Warlock/Affliction/Modules/Talents/EmpoweredLifeTap.js
@@ -3,6 +3,7 @@ import React from 'react';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import { formatNumber, formatPercentage } from 'common/format';
+
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 import SharedEmpoweredLifeTap from '../../../Shared/Modules/Talents/EmpoweredLifeTap';

--- a/src/Parser/Warlock/Affliction/Modules/Talents/Haunt.js
+++ b/src/Parser/Warlock/Affliction/Modules/Talents/Haunt.js
@@ -3,14 +3,15 @@ import React from 'react';
 import Analyzer from 'Parser/Core/Analyzer';
 import Enemies from 'Parser/Core/Modules/Enemies';
 import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import Wrapper from 'common/Wrapper';
 import SpellLink from 'common/SpellLink';
 import { formatNumber, formatPercentage } from 'common/format';
+
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
-import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 import { UNSTABLE_AFFLICTION_DEBUFF_IDS } from '../../Constants';
 
@@ -58,7 +59,6 @@ class Haunt extends Analyzer {
     return {
       actual: (this.unbuffedTicks / this.totalTicks) || 1,
       isGreaterThan: {
-        // TODO
         minor: 0.15,
         average: 0.2,
         major: 0.25,

--- a/src/Parser/Warlock/Affliction/Modules/Talents/MaleficGrasp.js
+++ b/src/Parser/Warlock/Affliction/Modules/Talents/MaleficGrasp.js
@@ -3,14 +3,15 @@ import React from 'react';
 import Analyzer from 'Parser/Core/Analyzer';
 import Enemies from 'Parser/Core/Modules/Enemies';
 import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import { formatNumber, formatPercentage } from 'common/format';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Wrapper from 'common/Wrapper';
 import SpellLink from 'common/SpellLink';
-import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 import { UNSTABLE_AFFLICTION_DEBUFF_IDS } from '../../Constants';
 

--- a/src/Parser/Warlock/Affliction/Modules/Talents/SiphonLifeUptime.js
+++ b/src/Parser/Warlock/Affliction/Modules/Talents/SiphonLifeUptime.js
@@ -7,9 +7,10 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import { formatPercentage } from 'common/format';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Wrapper from 'common/Wrapper';
 import SpellLink from 'common/SpellLink';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class SiphonLifeUptime extends Analyzer {
   static dependencies = {

--- a/src/Parser/Warlock/Affliction/Modules/Talents/SoulConduit.js
+++ b/src/Parser/Warlock/Affliction/Modules/Talents/SoulConduit.js
@@ -1,10 +1,13 @@
 import React from 'react';
+
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+
 import SPELLS from 'common/SPELLS';
-import StatisticBox from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
 import { formatNumber } from 'common/format';
+
+import StatisticBox from 'Main/StatisticBox';
 
 import { UNSTABLE_AFFLICTION_DEBUFF_IDS } from '../../Constants';
 import SoulShardTracker from '../SoulShards/SoulShardTracker';

--- a/src/Parser/Warlock/Affliction/Modules/WarlockCore/Channeling.js
+++ b/src/Parser/Warlock/Affliction/Modules/WarlockCore/Channeling.js
@@ -1,5 +1,6 @@
-import SPELLS from 'common/SPELLS';
 import CoreChanneling from 'Parser/Core/Modules/Channeling';
+
+import SPELLS from 'common/SPELLS';
 import { formatMilliseconds } from 'common/format';
 
 /**

--- a/src/Parser/Warlock/Affliction/Modules/WarlockCore/GlobalCooldown.js
+++ b/src/Parser/Warlock/Affliction/Modules/WarlockCore/GlobalCooldown.js
@@ -1,5 +1,6 @@
-import SPELLS from 'common/SPELLS';
 import CoreGlobalCooldown from 'Parser/Core/Modules/GlobalCooldown';
+
+import SPELLS from 'common/SPELLS';
 
 /**
  * Drain Soul's cast event is actually a beginchannel event, so it shouldn't add the GCD as active time.

--- a/src/Parser/Warlock/Demonology/CHANGELOG.js
+++ b/src/Parser/Warlock/Demonology/CHANGELOG.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { Chizu } from 'MAINTAINERS';
 import Wrapper from 'common/Wrapper';
 import ItemLink from 'common/ItemLink';
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
+
+import { Chizu } from 'MAINTAINERS';
 
 export default [
   {

--- a/src/Parser/Warlock/Demonology/CONFIG.js
+++ b/src/Parser/Warlock/Demonology/CONFIG.js
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import { Chizu } from 'MAINTAINERS';
 import SPECS from 'common/SPECS';
 import SPEC_ANALYSIS_COMPLETENESS from 'common/SPEC_ANALYSIS_COMPLETENESS';
+
+import { Chizu } from 'MAINTAINERS';
 
 import CombatLogParser from './CombatLogParser';
 import CHANGELOG from './CHANGELOG';

--- a/src/Parser/Warlock/Demonology/Modules/Features/Abilities.js
+++ b/src/Parser/Warlock/Demonology/Modules/Features/Abilities.js
@@ -1,9 +1,10 @@
-import SPELLS from 'common/SPELLS';
 import React from 'react';
-import SpellLink from 'common/SpellLink';
-import Wrapper from 'common/Wrapper';
 
 import CoreAbilities from 'Parser/Core/Modules/Abilities';
+
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import Wrapper from 'common/Wrapper';
 
 class Abilities extends CoreAbilities {
   spellbook() {

--- a/src/Parser/Warlock/Demonology/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Warlock/Demonology/Modules/Features/AlwaysBeCasting.js
@@ -4,9 +4,10 @@ import CoreAlwaysBeCasting from 'Parser/Core/Modules/AlwaysBeCasting';
 
 import SPELLS from 'common/SPELLS';
 import { formatPercentage } from 'common/format';
-import { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';
+
+import { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class AlwaysBeCasting extends CoreAlwaysBeCasting {
   get suggestionThresholds() {

--- a/src/Parser/Warlock/Demonology/Modules/Features/DoomUptime.js
+++ b/src/Parser/Warlock/Demonology/Modules/Features/DoomUptime.js
@@ -7,8 +7,9 @@ import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Wrapper from 'common/Wrapper';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class DoomUptime extends Analyzer {
   static dependencies = {

--- a/src/Parser/Warlock/Demonology/Modules/Features/DoomguardInfernal.js
+++ b/src/Parser/Warlock/Demonology/Modules/Features/DoomguardInfernal.js
@@ -3,8 +3,8 @@ import React from 'react';
 import Analyzer from 'Parser/Core/Analyzer';
 import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
 import Combatants from 'Parser/Core/Modules/Combatants';
-
 import calculateMaxCasts from 'Parser/Core/calculateMaxCasts';
+
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';

--- a/src/Parser/Warlock/Demonology/Modules/Features/Felstorm.js
+++ b/src/Parser/Warlock/Demonology/Modules/Features/Felstorm.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
+import calculateMaxCasts from 'Parser/Core/calculateMaxCasts';
 
 import SPELLS from 'common/SPELLS';
-import calculateMaxCasts from 'Parser/Core/calculateMaxCasts';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
 

--- a/src/Parser/Warlock/Demonology/Modules/Items/Legendaries/KazzaksFinalCurse.js
+++ b/src/Parser/Warlock/Demonology/Modules/Items/Legendaries/KazzaksFinalCurse.js
@@ -1,12 +1,14 @@
 import React from 'react';
 
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
 import PETS from 'common/PETS';
-import Analyzer from 'Parser/Core/Analyzer';
-import Combatants from 'Parser/Core/Modules/Combatants';
+
 import ItemDamageDone from 'Main/ItemDamageDone';
-import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 import DemoPets from '../../WarlockCore/Pets';
 

--- a/src/Parser/Warlock/Demonology/Modules/Items/Legendaries/RecurrentRitual.js
+++ b/src/Parser/Warlock/Demonology/Modules/Items/Legendaries/RecurrentRitual.js
@@ -1,5 +1,6 @@
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
 

--- a/src/Parser/Warlock/Demonology/Modules/Items/Legendaries/SoulOfTheNetherlord.js
+++ b/src/Parser/Warlock/Demonology/Modules/Items/Legendaries/SoulOfTheNetherlord.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
 import ITEMS from 'common/ITEMS';
 import SpellLink from 'common/SpellLink';
 import SPELLS from 'common/SPELLS';
 import Wrapper from 'common/Wrapper';
-import Analyzer from 'Parser/Core/Analyzer';
-import Combatants from 'Parser/Core/Modules/Combatants';
 
 class SoulOfTheNetherlord extends Analyzer {
   static dependencies = {

--- a/src/Parser/Warlock/Demonology/Modules/Items/Legendaries/WakenersLoyalty.js
+++ b/src/Parser/Warlock/Demonology/Modules/Items/Legendaries/WakenersLoyalty.js
@@ -1,13 +1,15 @@
 import React from 'react';
 
-import ITEMS from 'common/ITEMS';
-import SPELLS from 'common/SPELLS';
-import { formatNumber } from 'common/format';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
-import ItemDamageDone from 'Main/ItemDamageDone';
 import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+
+import ITEMS from 'common/ITEMS';
+import SPELLS from 'common/SPELLS';
+import { formatNumber } from 'common/format';
+
+import ItemDamageDone from 'Main/ItemDamageDone';
 
 const DAMAGE_BONUS_PER_STACK = 0.03;
 

--- a/src/Parser/Warlock/Demonology/Modules/SoulShards/SoulShardDetails.js
+++ b/src/Parser/Warlock/Demonology/Modules/SoulShards/SoulShardDetails.js
@@ -1,11 +1,11 @@
 import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
+
 import Tab from 'Main/Tab';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 import WastedShardsIcon from 'Parser/Warlock/Shared/Images/warlock_soulshard_bw.jpg';
-
 import SoulShardBreakdown from './SoulShardBreakdown';
 import SoulShardTracker from './SoulShardTracker';
 

--- a/src/Parser/Warlock/Demonology/Modules/Talents/Demonbolt.js
+++ b/src/Parser/Warlock/Demonology/Modules/Talents/Demonbolt.js
@@ -2,12 +2,13 @@ import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 import SPELLS from 'common/SPELLS';
 import { formatNumber, formatPercentage } from 'common/format';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
-import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 import DemoPets from '../WarlockCore/Pets';
 

--- a/src/Parser/Warlock/Demonology/Modules/Talents/DemonicCalling.js
+++ b/src/Parser/Warlock/Demonology/Modules/Talents/DemonicCalling.js
@@ -4,10 +4,11 @@ import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
 import SPELLS from 'common/SPELLS';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 const BUFF_DURATION = 20000;
 

--- a/src/Parser/Warlock/Demonology/Modules/Talents/GrimoireOfService.js
+++ b/src/Parser/Warlock/Demonology/Modules/Talents/GrimoireOfService.js
@@ -7,8 +7,9 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 import PETS from 'common/PETS';
 import { formatNumber, formatPercentage } from 'common/format';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 import DemoPets from '../WarlockCore/Pets';
 

--- a/src/Parser/Warlock/Demonology/Modules/Talents/GrimoireOfSynergy.js
+++ b/src/Parser/Warlock/Demonology/Modules/Talents/GrimoireOfSynergy.js
@@ -3,14 +3,15 @@ import React from 'react';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import CorePets from 'Parser/Core/Modules/Pets';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
 import PETS from 'common/PETS';
 import SpellIcon from 'common/SpellIcon';
 import { formatNumber, formatPercentage } from 'common/format';
+
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
-import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 const GRIMOIRE_OF_SYNERGY_DAMAGE_BONUS = 0.25;
 

--- a/src/Parser/Warlock/Demonology/Modules/Talents/HandOfDoom.js
+++ b/src/Parser/Warlock/Demonology/Modules/Talents/HandOfDoom.js
@@ -4,8 +4,9 @@ import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
 import SPELLS from 'common/SPELLS';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 const DOOM_CAST_THRESHOLD = 50;
 

--- a/src/Parser/Warlock/Demonology/Modules/Talents/ImpendingDoom.js
+++ b/src/Parser/Warlock/Demonology/Modules/Talents/ImpendingDoom.js
@@ -7,8 +7,9 @@ import DamageDone from 'Parser/Core/Modules/DamageDone';
 import SPELLS from 'common/SPELLS';
 import PETS from 'common/PETS';
 import { formatNumber, formatPercentage } from 'common/format';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 import DemoPets from '../WarlockCore/Pets';
 

--- a/src/Parser/Warlock/Demonology/Modules/Talents/Implosion.js
+++ b/src/Parser/Warlock/Demonology/Modules/Talents/Implosion.js
@@ -4,9 +4,10 @@ import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
 import SPELLS from 'common/SPELLS';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
 import { formatNumber, formatPercentage } from 'common/format';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class Implosion extends Analyzer {
   static dependencies = {

--- a/src/Parser/Warlock/Demonology/Modules/Talents/ImprovedDreadstalkers.js
+++ b/src/Parser/Warlock/Demonology/Modules/Talents/ImprovedDreadstalkers.js
@@ -6,8 +6,9 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 import PETS from 'common/PETS';
 import { formatNumber, formatPercentage } from 'common/format';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 import DemoPets from '../WarlockCore/Pets';
 

--- a/src/Parser/Warlock/Demonology/Modules/Talents/Shadowflame.js
+++ b/src/Parser/Warlock/Demonology/Modules/Talents/Shadowflame.js
@@ -5,9 +5,10 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import Enemies from 'Parser/Core/Modules/Enemies';
 
 import SPELLS from 'common/SPELLS';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
 import { formatNumber, formatPercentage } from 'common/format';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class Shadowflame extends Analyzer {
   static dependencies = {

--- a/src/Parser/Warlock/Demonology/Modules/Talents/ShadowyInspiration.js
+++ b/src/Parser/Warlock/Demonology/Modules/Talents/ShadowyInspiration.js
@@ -4,10 +4,11 @@ import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
 import SPELLS from 'common/SPELLS';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 const BUFF_DURATION = 15000;
 

--- a/src/Parser/Warlock/Demonology/Modules/Talents/SummonDarkglare.js
+++ b/src/Parser/Warlock/Demonology/Modules/Talents/SummonDarkglare.js
@@ -6,8 +6,9 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 import PETS from 'common/PETS';
 import { formatNumber, formatPercentage } from 'common/format';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 import DemoPets from '../WarlockCore/Pets';
 

--- a/src/Parser/Warlock/Destruction/CHANGELOG.js
+++ b/src/Parser/Warlock/Destruction/CHANGELOG.js
@@ -1,9 +1,10 @@
 import React from 'react';
 
-import { Chizu } from 'MAINTAINERS';
 import Wrapper from 'common/Wrapper';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
+
+import { Chizu } from 'MAINTAINERS';
 
 export default [
   {

--- a/src/Parser/Warlock/Destruction/CONFIG.js
+++ b/src/Parser/Warlock/Destruction/CONFIG.js
@@ -1,10 +1,11 @@
 import React from 'react';
 
-import { Chizu } from 'MAINTAINERS';
 import SPECS from 'common/SPECS';
 import SPEC_ANALYSIS_COMPLETENESS from 'common/SPEC_ANALYSIS_COMPLETENESS';
 import SpellLink from 'common/SpellLink';
 import SPELLS from 'common/SPELLS';
+
+import { Chizu } from 'MAINTAINERS';
 
 import CombatLogParser from './CombatLogParser';
 import CHANGELOG from './CHANGELOG';

--- a/src/Parser/Warlock/Destruction/Modules/Features/Abilities.js
+++ b/src/Parser/Warlock/Destruction/Modules/Features/Abilities.js
@@ -1,9 +1,10 @@
-import SPELLS from 'common/SPELLS';
 import React from 'react';
-import SpellLink from 'common/SpellLink';
-import Wrapper from 'common/Wrapper';
 
 import CoreAbilities from 'Parser/Core/Modules/Abilities';
+
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import Wrapper from 'common/Wrapper';
 
 class Abilities extends CoreAbilities {
   spellbook() {

--- a/src/Parser/Warlock/Destruction/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Warlock/Destruction/Modules/Features/AlwaysBeCasting.js
@@ -4,9 +4,10 @@ import CoreAlwaysBeCasting from 'Parser/Core/Modules/AlwaysBeCasting';
 
 import SPELLS from 'common/SPELLS';
 import { formatPercentage } from 'common/format';
-import { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';
+
+import { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class AlwaysBeCasting extends CoreAlwaysBeCasting {
   get suggestionThresholds() {

--- a/src/Parser/Warlock/Destruction/Modules/Features/DimensionalRift.js
+++ b/src/Parser/Warlock/Destruction/Modules/Features/DimensionalRift.js
@@ -6,6 +6,7 @@ import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatNumber, formatPercentage } from 'common/format';
+
 import { STATISTIC_ORDER } from 'Main/StatisticBox';
 import StatisticsListBox from 'Main/StatisticsListBox';
 

--- a/src/Parser/Warlock/Destruction/Modules/Features/DoomguardInfernal.js
+++ b/src/Parser/Warlock/Destruction/Modules/Features/DoomguardInfernal.js
@@ -3,8 +3,8 @@ import React from 'react';
 import Analyzer from 'Parser/Core/Analyzer';
 import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
 import Combatants from 'Parser/Core/Modules/Combatants';
-
 import calculateMaxCasts from 'Parser/Core/calculateMaxCasts';
+
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';

--- a/src/Parser/Warlock/Destruction/Modules/Features/Havoc.js
+++ b/src/Parser/Warlock/Destruction/Modules/Features/Havoc.js
@@ -5,9 +5,10 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import Enemies from 'Parser/Core/Modules/Enemies';
 
 import SPELLS from 'common/SPELLS';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
 import { formatNumber, formatPercentage } from 'common/format';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class Havoc extends Analyzer {
   static dependencies = {

--- a/src/Parser/Warlock/Destruction/Modules/Features/ImmolateUptime.js
+++ b/src/Parser/Warlock/Destruction/Modules/Features/ImmolateUptime.js
@@ -7,8 +7,9 @@ import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Wrapper from 'common/Wrapper';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class ImmolateUptime extends Analyzer {
   static dependencies = {

--- a/src/Parser/Warlock/Destruction/Modules/Features/UnusedLordOfFlames.js
+++ b/src/Parser/Warlock/Destruction/Modules/Features/UnusedLordOfFlames.js
@@ -2,10 +2,10 @@ import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
+import calculateMaxCasts from 'Parser/Core/calculateMaxCasts';
 
 import SpellLink from 'common/SpellLink';
 import SPELLS from 'common/SPELLS';
-import calculateMaxCasts from 'Parser/Core/calculateMaxCasts';
 import Wrapper from 'common/Wrapper';
 
 // Lord of Flames is a trait that makes your Summon Infernal summon 3 additional infernals which makes it a higher priority summon, but it can be used only every 10 minutes

--- a/src/Parser/Warlock/Destruction/Modules/Items/Legendaries/AlythesssPyrogenics.js
+++ b/src/Parser/Warlock/Destruction/Modules/Items/Legendaries/AlythesssPyrogenics.js
@@ -1,12 +1,14 @@
 import React from 'react';
 
-import SPELLS from 'common/SPELLS';
-import ITEMS from 'common/ITEMS';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import Enemies from 'Parser/Core/Modules/Enemies';
-import ItemDamageDone from 'Main/ItemDamageDone';
 import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+
+import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
+
+import ItemDamageDone from 'Main/ItemDamageDone';
 
 const ALYTHESSS_PYROGENICS_DAMAGE_BONUS = 0.1;
 

--- a/src/Parser/Warlock/Destruction/Modules/Items/Legendaries/FeretoryOfSouls.js
+++ b/src/Parser/Warlock/Destruction/Modules/Items/Legendaries/FeretoryOfSouls.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
 import { formatNumber } from 'common/format';

--- a/src/Parser/Warlock/Destruction/Modules/Items/Legendaries/LessonsOfSpaceTime.js
+++ b/src/Parser/Warlock/Destruction/Modules/Items/Legendaries/LessonsOfSpaceTime.js
@@ -2,10 +2,12 @@ import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
+
 import ItemDamageDone from 'Main/ItemDamageDone';
-import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 const LESSONS_OF_SPACETIME_DAMAGE_BONUS = 0.1;
 

--- a/src/Parser/Warlock/Destruction/Modules/Items/Legendaries/MagistrikeRestraints.js
+++ b/src/Parser/Warlock/Destruction/Modules/Items/Legendaries/MagistrikeRestraints.js
@@ -1,9 +1,11 @@
 import React from 'react';
 
-import SPELLS from 'common/SPELLS';
-import ITEMS from 'common/ITEMS';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+
+import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
+
 import ItemDamageDone from 'Main/ItemDamageDone';
 
 class MagistrikeRestraints extends Analyzer {

--- a/src/Parser/Warlock/Destruction/Modules/Items/Legendaries/OdrShawlOfTheYmirjar.js
+++ b/src/Parser/Warlock/Destruction/Modules/Items/Legendaries/OdrShawlOfTheYmirjar.js
@@ -1,12 +1,14 @@
 import React from 'react';
 
-import SPELLS from 'common/SPELLS';
-import ITEMS from 'common/ITEMS';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import Enemies from 'Parser/Core/Modules/Enemies';
-import ItemDamageDone from 'Main/ItemDamageDone';
 import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+
+import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
+
+import ItemDamageDone from 'Main/ItemDamageDone';
 
 const ODR_SHAWL_OF_THE_YMIRJAR_DAMAGE_BONUS = 0.15;
 

--- a/src/Parser/Warlock/Destruction/Modules/Items/Legendaries/SoulOfTheNetherlord.js
+++ b/src/Parser/Warlock/Destruction/Modules/Items/Legendaries/SoulOfTheNetherlord.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
 import ITEMS from 'common/ITEMS';
 import SpellLink from 'common/SpellLink';
 import SPELLS from 'common/SPELLS';
 import Wrapper from 'common/Wrapper';
-import Analyzer from 'Parser/Core/Analyzer';
-import Combatants from 'Parser/Core/Modules/Combatants';
 
 class SoulOfTheNetherlord extends Analyzer {
   static dependencies = {

--- a/src/Parser/Warlock/Destruction/Modules/Items/T20_2set.js
+++ b/src/Parser/Warlock/Destruction/Modules/Items/T20_2set.js
@@ -1,12 +1,13 @@
 import React from 'react';
 
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import Enemies from 'Parser/Core/Modules/Enemies';
+
 import SPELLS from 'common/SPELLS';
 import { formatNumber } from 'common/format';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
-import Analyzer from 'Parser/Core/Analyzer';
-import Combatants from 'Parser/Core/Modules/Combatants';
-import Enemies from 'Parser/Core/Modules/Enemies';
 
 const CHAOS_BOLT_COST = 20;
 

--- a/src/Parser/Warlock/Destruction/Modules/Items/T21_2set.js
+++ b/src/Parser/Warlock/Destruction/Modules/Items/T21_2set.js
@@ -1,13 +1,14 @@
 import React from 'react';
 
-import SPELLS from 'common/SPELLS';
-import { formatPercentage } from 'common/format';
-import SpellIcon from 'common/SpellIcon';
-import SpellLink from 'common/SpellLink';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import Enemies from 'Parser/Core/Modules/Enemies';
 import HIT_TYPES from 'Parser/Core/HIT_TYPES';
+
+import SPELLS from 'common/SPELLS';
+import { formatPercentage } from 'common/format';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';
 
 // Chaos Bolt increases the critical strike chance of Incinerate on the target by 40% for 8 sec.

--- a/src/Parser/Warlock/Destruction/Modules/Items/T21_4set.js
+++ b/src/Parser/Warlock/Destruction/Modules/Items/T21_4set.js
@@ -1,12 +1,14 @@
 import React from 'react';
 
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
 import SPELLS from 'common/SPELLS';
 import { formatNumber } from 'common/format';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
-import Analyzer from 'Parser/Core/Analyzer';
-import Combatants from 'Parser/Core/Modules/Combatants';
 import Wrapper from 'common/Wrapper';
+
 import ItemDamageDone from 'Main/ItemDamageDone';
 
 // Chaos Bolt will deal an additional 12% of its direct damage caused to the target over 4 sec.

--- a/src/Parser/Warlock/Destruction/Modules/SoulShards/SoulShardDetails.js
+++ b/src/Parser/Warlock/Destruction/Modules/SoulShards/SoulShardDetails.js
@@ -1,11 +1,11 @@
 import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
+
 import Tab from 'Main/Tab';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 import WastedShardsIcon from 'Parser/Warlock/Shared/Images/warlock_soulshard_bw.jpg';
-
 import SoulShardBreakdown from './SoulShardBreakdown';
 import SoulShardTracker from './SoulShardTracker';
 

--- a/src/Parser/Warlock/Destruction/Modules/SoulShards/SoulShardEvents.js
+++ b/src/Parser/Warlock/Destruction/Modules/SoulShards/SoulShardEvents.js
@@ -1,8 +1,9 @@
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
-import SPELLS from 'common/SPELLS';
 import HIT_TYPES from 'Parser/Core/HIT_TYPES';
 import Enemies from 'Parser/Core/Modules/Enemies';
+
+import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'common/RESOURCE_TYPES';
 
 const debug = false;

--- a/src/Parser/Warlock/Destruction/Modules/SoulShards/SoulShardTracker.js
+++ b/src/Parser/Warlock/Destruction/Modules/SoulShards/SoulShardTracker.js
@@ -1,7 +1,8 @@
 import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
 
 import SPELLS from 'common/SPELLS';
-import Combatants from 'Parser/Core/Modules/Combatants';
+
 import SoulShardEvents from './SoulShardEvents';
 
 const SHADOWBURN_KILL = 'Shadowburn kill';

--- a/src/Parser/Warlock/Destruction/Modules/Talents/Backdraft.js
+++ b/src/Parser/Warlock/Destruction/Modules/Talents/Backdraft.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 

--- a/src/Parser/Warlock/Destruction/Modules/Talents/Eradication.js
+++ b/src/Parser/Warlock/Destruction/Modules/Talents/Eradication.js
@@ -3,6 +3,7 @@ import React from 'react';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import Enemies from 'Parser/Core/Modules/Enemies';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
@@ -10,7 +11,6 @@ import SpellLink from 'common/SpellLink';
 import SpellIcon from 'common/SpellIcon';
 import Wrapper from 'common/Wrapper';
 import { formatNumber, formatPercentage } from 'common/format';
-import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 const ERADICATION_DAMAGE_BONUS = 0.15;
 

--- a/src/Parser/Warlock/Destruction/Modules/Talents/ReverseEntropy.js
+++ b/src/Parser/Warlock/Destruction/Modules/Talents/ReverseEntropy.js
@@ -2,12 +2,12 @@ import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatNumber, formatPercentage } from 'common/format';
-import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 const REVERSE_ENTROPY_DAMAGE_BONUS = 0.1;
 

--- a/src/Parser/Warlock/Destruction/Modules/Talents/RoaringBlaze.js
+++ b/src/Parser/Warlock/Destruction/Modules/Talents/RoaringBlaze.js
@@ -3,12 +3,12 @@ import React from 'react';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import Enemies from 'Parser/Core/Modules/Enemies';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatNumber, formatPercentage } from 'common/format';
-import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 const debug = false;
 

--- a/src/Parser/Warlock/Destruction/Modules/Talents/Shadowburn.js
+++ b/src/Parser/Warlock/Destruction/Modules/Talents/Shadowburn.js
@@ -6,8 +6,8 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
-import SoulShardTracker from '../SoulShards/SoulShardTracker';
 
+import SoulShardTracker from '../SoulShards/SoulShardTracker';
 
 const debug = true;
 

--- a/src/Parser/Warlock/Destruction/Modules/Talents/SoulConduit.js
+++ b/src/Parser/Warlock/Destruction/Modules/Talents/SoulConduit.js
@@ -6,8 +6,8 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import SpellIcon from 'common/SpellIcon';
-
 import { formatPercentage } from 'common/format';
+
 import SoulShardTracker from '../SoulShards/SoulShardTracker';
 
 

--- a/src/Parser/Warlock/Destruction/Modules/Talents/TalentHub.js
+++ b/src/Parser/Warlock/Destruction/Modules/Talents/TalentHub.js
@@ -1,10 +1,9 @@
 import React from 'react';
 
-import StatisticsListBox, { STATISTIC_ORDER } from 'Main/StatisticsListBox';
-
 import Analyzer from 'Parser/Core/Analyzer';
 
-//credit to hpal mod, i modified the traits script
+import StatisticsListBox, { STATISTIC_ORDER } from 'Main/StatisticsListBox';
+
 import Backdraft from './Backdraft';
 import ChannelDemonfire from './ChannelDemonfire';
 import Eradication from './Eradication';

--- a/src/Parser/Warlock/Shared/Modules/Items/SindoreiSpite.js
+++ b/src/Parser/Warlock/Shared/Modules/Items/SindoreiSpite.js
@@ -2,10 +2,12 @@ import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
+
 import ItemDamageDone from 'Main/ItemDamageDone';
-import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 const SINDOREI_SPITE_DAMAGE_BONUS = 0.15;
 

--- a/src/Parser/Warlock/Shared/Modules/Items/TheMasterHarvester.js
+++ b/src/Parser/Warlock/Shared/Modules/Items/TheMasterHarvester.js
@@ -1,8 +1,10 @@
 import React from 'react';
 
-import ITEMS from 'common/ITEMS';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+
+import ITEMS from 'common/ITEMS';
+
 import ItemDamageDone from 'Main/ItemDamageDone';
 
 import SoulHarvest from '../Talents/SoulHarvest';

--- a/src/Parser/Warlock/Shared/Modules/Talents/EmpoweredLifeTap.js
+++ b/src/Parser/Warlock/Shared/Modules/Talents/EmpoweredLifeTap.js
@@ -2,12 +2,12 @@ import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';
 import { formatPercentage } from 'common/format';
-import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 const ELT_DAMAGE_BONUS = 0.1;
 

--- a/src/Parser/Warlock/Shared/Modules/Talents/SoulHarvest.js
+++ b/src/Parser/Warlock/Shared/Modules/Talents/SoulHarvest.js
@@ -1,8 +1,9 @@
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
-import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 const SOUL_HARVEST_DAMAGE_BONUS = 0.2;
 

--- a/src/Parser/Warlock/Shared/Modules/Talents/SoulHarvestTalent.js
+++ b/src/Parser/Warlock/Shared/Modules/Talents/SoulHarvestTalent.js
@@ -6,6 +6,7 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import { formatNumber, formatPercentage } from 'common/format';
+
 import StatisticBox from 'Main/StatisticBox';
 
 import SoulHarvest from './SoulHarvest';


### PR DESCRIPTION
I've been wanting to do this for a while, didn't have the time. Basically just reorders imports in all Warlock files (because I like the consistency - react related imports > Parser/Core imports > common imports > Main imports > relative/Warlock specific imports). Nothing should be really changed, just occasional blank line as a separator added or something. 