### PR TITLE
[Havoc] Bug Fixes

### DIFF
--- a/src/Parser/DemonHunter/Havoc/Modules/Abilities.js
+++ b/src/Parser/DemonHunter/Havoc/Modules/Abilities.js
@@ -48,7 +48,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.CHAOS_BLADES_TALENT,
         enabled: combatant.hasTalent(SPELLS.CHAOS_BLADES_TALENT.id),
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
-        cooldown: 180,
+        cooldown: 120,
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.95,
@@ -171,7 +171,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.CHAOS_NOVA,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        cooldown: combatant.hasTalent(SPELLS.UNLEASHED_POWER_TALENT) ? 40 : 60,
+        cooldown: combatant.hasTalent(SPELLS.UNLEASHED_POWER_TALENT.id) ? 40 : 60,
         isOnGCD: true,
       },
       {

--- a/src/Parser/DemonHunter/Havoc/Modules/Items/DelusionsOfGrandeur.js
+++ b/src/Parser/DemonHunter/Havoc/Modules/Items/DelusionsOfGrandeur.js
@@ -44,8 +44,8 @@ class DelusionsOfGrandeur extends Analyzer {
 
 	get suggestionThresholds() {
     return {
-      actual: this.owner.fightDuration < this.metaCooldownWithShoulders,
-      isEqual: false,
+      actual: this.owner.fightDuration / 1000 < this.metaCooldownWithShoulders,
+      isEqual: true,
       style: 'boolean',
     };
   }

--- a/src/Parser/DemonHunter/Havoc/Modules/Traits/FeastOnTheSouls.js
+++ b/src/Parser/DemonHunter/Havoc/Modules/Traits/FeastOnTheSouls.js
@@ -63,6 +63,10 @@ class FeastOnTheSouls extends Analyzer {
 		this.totalCooldownReduction += reduction;
 	}
 
+	on_finished() {
+		this.active = this.totalCooldownReduction > 0 || this.totalCooldownReductionWasted > 0;
+	}
+
 	statistic() {
 		return (
 			<StatisticBox

--- a/src/Parser/DemonHunter/Havoc/Modules/Traits/FeastOnTheSouls.js
+++ b/src/Parser/DemonHunter/Havoc/Modules/Traits/FeastOnTheSouls.js
@@ -44,6 +44,8 @@ class FeastOnTheSouls extends Analyzer {
 			return;
 		}
 		const reduction = this.spellUsable.reduceCooldown(SPELLS.EYE_BEAM.id, FEAST_ON_THE_SOULS_CDR);
+	
+		this.totalCooldownReductionWasted += FEAST_ON_THE_SOULS_CDR - reduction;
 		this.totalCooldownReduction += reduction;
 	}
 
@@ -60,6 +62,8 @@ class FeastOnTheSouls extends Analyzer {
 			return;
 		}
 		const reduction = this.spellUsable.reduceCooldown(SPELLS.EYE_BEAM.id, FEAST_ON_THE_SOULS_CDR);
+
+		this.totalCooldownReductionWasted += FEAST_ON_THE_SOULS_CDR - reduction;
 		this.totalCooldownReduction += reduction;
 	}
 

--- a/src/Parser/Paladin/Retribution/Modules/PaladinCore/Retribution.js
+++ b/src/Parser/Paladin/Retribution/Modules/PaladinCore/Retribution.js
@@ -30,6 +30,10 @@ class Retribution extends Analyzer {
     this.bonusDmg += GetDamageBonus(event, RETRIBUTION_DAMAGE_BONUS);
   }
 
+  on_finished() {
+    this.active = this.bonusDmg > 0;
+  }
+
   statistic() {
     return (
       <StatisticBox


### PR DESCRIPTION
The Delusions of Grandeur suggestion was showing up regardless of fight time and the meta CD was in seconds vs the fight duration in ms.

The CDR from the feast on the souls trait didn't account for it there was < 5 seconds left on the cooldown on eye beam when you picked up a soul and now it does.

Also hid the stat boxes for the Feat of Souls CDR and Retribution paladins retribution if they didn't attribute anything to the fight. 