### PR TITLE
[Survival] adding the 5 spec specific legendaries 

### DIFF
--- a/src/Parser/Hunter/Survival/CHANGELOG.js
+++ b/src/Parser/Hunter/Survival/CHANGELOG.js
@@ -4,8 +4,15 @@ import { Putro } from 'MAINTAINERS';
 import Wrapper from 'common/Wrapper';
 import SpellLink from 'common/SpellLink';
 import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
+import ItemLink from 'common/ItemLink';
 
 export default [
+  {
+    date: new Date('2018-02-02'),
+    changes: <Wrapper>Added support for <ItemLink id={ITEMS.BUTCHERS_BONE_APRON.id} icon />, <ItemLink id={ITEMS.FRIZZOS_FINGERTRAP.id} icon />, <ItemLink id={ITEMS.HELBRINE_ROPE_OF_THE_MIST_MARAUDER.id} icon />, <ItemLink id={ITEMS.NESINGWARYS_TRAPPING_TREADS.id} icon />, <ItemLink id={ITEMS.UNSEEN_PREDATORS_CLOAK.id} icon />.</Wrapper>,
+    contributors: [Putro],
+  },
   {
     date: new Date('2018-01-31'),
     changes: <Wrapper>Added a module for tracking <SpellLink id={SPELLS.WAY_OF_THE_MOKNATHAL_TALENT.id} icon />. </Wrapper>,

--- a/src/Parser/Hunter/Survival/CombatLogParser.js
+++ b/src/Parser/Hunter/Survival/CombatLogParser.js
@@ -26,6 +26,11 @@ import RootsOfShaladrassil from '../Shared/Modules/Items/RootsOfShaladrassil';
 import CallOfTheWild from '../Shared/Modules/Items/CallOfTheWild';
 import TheApexPredatorsClaw from '../Shared/Modules/Items/TheApexPredatorsClaw';
 import TheShadowHuntersVoodooMask from '../Shared/Modules/Items/TheShadowHuntersVoodooMask';
+import UnseenPredatorsCloak from './Modules/Items/UnseenPredatorsCloak';
+import HelbrineRopeOfTheMistMarauder from './Modules/Items/HelbrineRopeOfTheMistMarauder';
+import NesingwarysTrappingTreads from './Modules/Items/NesingwarysTrappingTreads';
+import ButchersBoneApron from './Modules/Items/ButchersBoneApron';
+import FrizzosFingertrap from './Modules/Items/FrizzosFingertrap';
 
 //Talents
 import WayOfTheMokNathal from './Modules/Talents/WayOfTheMokNathal';
@@ -65,6 +70,11 @@ class CombatLogParser extends CoreCombatLogParser {
     rootsOfShaladrassil: RootsOfShaladrassil,
     theApexPredatorsClaw: TheApexPredatorsClaw,
     theShadowHuntersVoodooMask: TheShadowHuntersVoodooMask,
+    unseenPredatorsCloak: UnseenPredatorsCloak,
+    helbrineRopeOfTheMistMarauder: HelbrineRopeOfTheMistMarauder,
+    nesingwarysTrappingTreads: NesingwarysTrappingTreads,
+    butchersBoneApron: ButchersBoneApron,
+    frizzosFingertrap: FrizzosFingertrap,
 
     //Talents
     wayOfTheMokNathal: WayOfTheMokNathal,

--- a/src/Parser/Hunter/Survival/Modules/Items/ButchersBoneApron.js
+++ b/src/Parser/Hunter/Survival/Modules/Items/ButchersBoneApron.js
@@ -1,0 +1,93 @@
+import React from 'react';
+
+import ITEMS from 'common/ITEMS';
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import SPELLS from 'common/SPELLS';
+import getDamageBonus from 'Parser/Hunter/Shared/Modules/getDamageBonus';
+import ItemDamageDone from 'Main/ItemDamageDone';
+
+/**
+ * Butcher's Bone Apron
+ * Equip: Mongoose Bite increases the damage of your next Butchery or Carve by 10%.
+ * Stacks up to 10 times.
+ */
+
+const MAX_STACKS = 10;
+
+const MODIFIER_PER_STACK = 0.1;
+
+class ButchersBoneApron extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  _currentStacks = 0;
+  _savedStacks = 0;
+  wastedStacks = 0;
+  bonusDamage = 0;
+  totalStacks = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasChest(ITEMS.BUTCHERS_BONE_APRON.id);
+  }
+
+  on_byPlayer_cast(event) {
+    const spellID = event.ability.guid;
+    if (spellID === SPELLS.MONGOOSE_BITE.id && this._currentStacks === MAX_STACKS) {
+      this.wastedStacks++;
+    }
+    if (spellID === SPELLS.BUTCHERY_TALENT.id || spellID === SPELLS.CARVE.id) {
+      this._savedStacks = this._currentStacks;
+    }
+  }
+
+  on_byPlayer_applybuff(event) {
+    const spellID = event.ability.guid;
+    if (spellID !== SPELLS.BUTCHERS_BONE_APRON_BUFF.id) {
+      return;
+    }
+    this._currentStacks = 1;
+    this._savedStacks = 0;
+    this.totalStacks++;
+  }
+
+  on_byPlayer_applybuffstack(event) {
+    const spellID = event.ability.guid;
+    if (spellID !== SPELLS.BUTCHERS_BONE_APRON_BUFF.id) {
+      return;
+    }
+    this._currentStacks = event.stack;
+    this.totalStacks++;
+
+  }
+
+  on_byPlayer_removebuff(event) {
+    const spellID = event.ability.guid;
+    if (spellID !== SPELLS.BUTCHERS_BONE_APRON_BUFF.id) {
+      return;
+    }
+    this._currentStacks = 0;
+  }
+
+  on_byPlayer_damage(event) {
+    const spellID = event.ability.guid;
+    if (spellID !== SPELLS.BUTCHERY_TALENT.id && spellID !== SPELLS.CARVE.id) {
+      return;
+    }
+    this.bonusDamage += getDamageBonus(event, MODIFIER_PER_STACK * this._savedStacks);
+  }
+
+  item() {
+    return {
+      item: ITEMS.BUTCHERS_BONE_APRON,
+      result: (
+        <dfn data-tip={`You applied the Butchers Bone Apron buff ${this.totalStacks} times, and wasted ${this.wastedStacks} stacks by casting Mongoose Bite while you were already at 10 stacks.`}>
+          <ItemDamageDone amount={this.bonusDamage} />
+        </dfn>
+      ),
+    };
+  }
+}
+
+export default ButchersBoneApron;

--- a/src/Parser/Hunter/Survival/Modules/Items/FrizzosFingertrap.js
+++ b/src/Parser/Hunter/Survival/Modules/Items/FrizzosFingertrap.js
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import ITEMS from 'common/ITEMS';
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import Wrapper from 'common/Wrapper';
+
+/**
+ * Frizzo's Fingertrap
+ * Equip: When you Butchery or Carve an enemy affected by Lacerate, Lacerate spreads to 1 other targets hit by Butchery.
+ */
+
+const MS_BUFFER = 50;
+
+class FrizzosFingertrap extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  spreadLacerates = 0;
+  castTimestamp = 0;
+  on_initialized() {
+    this.active = this.combatants.selected.hasFinger(ITEMS.FRIZZOS_FINGERTRAP.id);
+  }
+  on_byPlayer_cast(event) {
+    const spellID = event.ability.guid;
+    if (spellID === SPELLS.BUTCHERY_TALENT.id || spellID === SPELLS.CARVE.id) {
+      this.castTimestamp = event.timestamp;
+    }
+  }
+  on_byPlayer_applydebuff(event) {
+    const spellID = event.ability.guid;
+    if (spellID !== SPELLS.LACERATE.id) {
+      return;
+    }
+    if (event.timestamp < this.castTimestamp + MS_BUFFER) {
+      this.spreadLacerates++;
+    }
+  }
+  item() {
+    return {
+      item: ITEMS.FRIZZOS_FINGERTRAP,
+      result: <Wrapper>Spread <SpellLink id={SPELLS.LACERATE.id} icon /> to {this.spreadLacerates} additional targets. </Wrapper>,
+    };
+  }
+}
+
+export default FrizzosFingertrap;

--- a/src/Parser/Hunter/Survival/Modules/Items/HelbrineRopeOfTheMistMarauder.js
+++ b/src/Parser/Hunter/Survival/Modules/Items/HelbrineRopeOfTheMistMarauder.js
@@ -62,7 +62,6 @@ class HelbrineRopeOfTheMistMarauder extends Analyzer {
           <Wrapper>
             You had {formatPercentage(this.uptimePercentage)}% uptime on <SpellLink id={SPELLS.MARK_OF_HELBRINE.id} />. <br />
             It contributed with up to <ItemDamageDone amount={this.bonusDamage} />
-
           </Wrapper>
         </dfn>
       ),

--- a/src/Parser/Hunter/Survival/Modules/Items/HelbrineRopeOfTheMistMarauder.js
+++ b/src/Parser/Hunter/Survival/Modules/Items/HelbrineRopeOfTheMistMarauder.js
@@ -6,7 +6,6 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 import { formatPercentage } from 'common/format';
 import Wrapper from 'common/Wrapper';
-import SpellLink from 'common/SpellLink';
 import Enemies from 'Parser/Core/Modules/Enemies';
 import ItemDamageDone from 'Main/ItemDamageDone';
 import GetDamageBonus from 'Parser/Hunter/Shared/Modules/getDamageBonus';
@@ -60,8 +59,8 @@ class HelbrineRopeOfTheMistMarauder extends Analyzer {
       result: (
         <dfn data-tip={`You applied the Mark of Helbrine debuff ${this.applications} times. </br> The reason this shows as "up to X dmg" is because the tooltip has no information on the potency of the applied Mark of Helbrine. To maximize the potential of this legendary, you want to stand as far away as possible and cast Harpoon when engaging the first time with mobs.`}>
           <Wrapper>
-            You had {formatPercentage(this.uptimePercentage)}% uptime on <SpellLink id={SPELLS.MARK_OF_HELBRINE.id} />. <br />
-            It contributed with up to <ItemDamageDone amount={this.bonusDamage} />
+            {formatPercentage(this.uptimePercentage)}% uptime<br />
+            Up to <ItemDamageDone amount={this.bonusDamage} />
           </Wrapper>
         </dfn>
       ),

--- a/src/Parser/Hunter/Survival/Modules/Items/HelbrineRopeOfTheMistMarauder.js
+++ b/src/Parser/Hunter/Survival/Modules/Items/HelbrineRopeOfTheMistMarauder.js
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import ITEMS from 'common/ITEMS';
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import SPELLS from 'common/SPELLS';
+import { formatPercentage } from 'common/format';
+import Wrapper from 'common/Wrapper';
+import SpellLink from 'common/SpellLink';
+import Enemies from 'Parser/Core/Modules/Enemies';
+
+/**
+ * Helbrine, Rope of the Mist Marauder
+ * Equip: The first time Harpoon hits a target, your damage done to the target is increased by up to 30% for until cancelled based on distance to the target.
+ */
+//TODO - do damage calculations for Helbrine based on positioning after in-game testing (if possible at all)
+class HelbrineRopeOfTheMistMarauder extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    enemies: Enemies,
+  };
+
+  applications = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasWaist(ITEMS.HELBRINE_ROPE_OF_THE_MIST_MARAUDER.id);
+  }
+
+  get uptimePercentage() {
+    return this.enemies.getBuffUptime(SPELLS.MARK_OF_HELBRINE.id) / this.owner.fightDuration;
+  }
+
+  on_byPlayer_applydebuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.MARK_OF_HELBRINE.id) {
+      return;
+    }
+    this.applications++;
+  }
+
+  item() {
+    return {
+      item: ITEMS.HELBRINE_ROPE_OF_THE_MIST_MARAUDER,
+      result: (
+        <dfn data-tip={`You applied the Mark of Helbrine debuff ${this.applications} times.`}>
+          <Wrapper>You had {formatPercentage(this.uptimePercentage)}% uptime on <SpellLink id={SPELLS.MARK_OF_HELBRINE.id} />.</Wrapper>
+        </dfn>
+      ),
+    };
+  }
+}
+
+export default HelbrineRopeOfTheMistMarauder;

--- a/src/Parser/Hunter/Survival/Modules/Items/HelbrineRopeOfTheMistMarauder.js
+++ b/src/Parser/Hunter/Survival/Modules/Items/HelbrineRopeOfTheMistMarauder.js
@@ -8,12 +8,18 @@ import { formatPercentage } from 'common/format';
 import Wrapper from 'common/Wrapper';
 import SpellLink from 'common/SpellLink';
 import Enemies from 'Parser/Core/Modules/Enemies';
+import ItemDamageDone from 'Main/ItemDamageDone';
+import GetDamageBonus from 'Parser/Hunter/Shared/Modules/getDamageBonus';
 
 /**
  * Helbrine, Rope of the Mist Marauder
  * Equip: The first time Harpoon hits a target, your damage done to the target is increased by up to 30% for until cancelled based on distance to the target.
  */
-//TODO - do damage calculations for Helbrine based on positioning after in-game testing (if possible at all)
+
+//TODO - do precise damage calculations for Helbrine based on positioning after in-game testing (if possible at all)
+
+const MAX_MODIFIER = 0.3;
+
 class HelbrineRopeOfTheMistMarauder extends Analyzer {
   static dependencies = {
     combatants: Combatants,
@@ -21,7 +27,7 @@ class HelbrineRopeOfTheMistMarauder extends Analyzer {
   };
 
   applications = 0;
-
+  bonusDamage = 0;
   on_initialized() {
     this.active = this.combatants.selected.hasWaist(ITEMS.HELBRINE_ROPE_OF_THE_MIST_MARAUDER.id);
   }
@@ -38,12 +44,26 @@ class HelbrineRopeOfTheMistMarauder extends Analyzer {
     this.applications++;
   }
 
+  on_byPlayer_damage(event) {
+    const enemy = this.enemies.getEntity(event);
+    if (!enemy) {
+      return;
+    }
+    if (enemy.hasBuff(SPELLS.MARK_OF_HELBRINE.id, event.timestamp)) {
+      this.bonusDamage += GetDamageBonus(event, MAX_MODIFIER);
+    }
+  }
+
   item() {
     return {
       item: ITEMS.HELBRINE_ROPE_OF_THE_MIST_MARAUDER,
       result: (
-        <dfn data-tip={`You applied the Mark of Helbrine debuff ${this.applications} times.`}>
-          <Wrapper>You had {formatPercentage(this.uptimePercentage)}% uptime on <SpellLink id={SPELLS.MARK_OF_HELBRINE.id} />.</Wrapper>
+        <dfn data-tip={`You applied the Mark of Helbrine debuff ${this.applications} times. </br> The reason this shows as "up to X dmg" is because the tooltip has no information on the potency of the applied Mark of Helbrine. To maximize the potential of this legendary, you want to stand as far away as possible and cast Harpoon when engaging the first time with mobs.`}>
+          <Wrapper>
+            You had {formatPercentage(this.uptimePercentage)}% uptime on <SpellLink id={SPELLS.MARK_OF_HELBRINE.id} />. <br />
+            It contributed with up to <ItemDamageDone amount={this.bonusDamage} />
+
+          </Wrapper>
         </dfn>
       ),
     };

--- a/src/Parser/Hunter/Survival/Modules/Items/NesingwarysTrappingTreads.js
+++ b/src/Parser/Hunter/Survival/Modules/Items/NesingwarysTrappingTreads.js
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import ITEMS from 'common/ITEMS';
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import SPELLS from 'common/SPELLS';
+
+/**
+ * Nesingwary's Trapping Treads
+ * Equip: Gain 25 Focus when one of your traps is triggered.
+ */
+
+const FOCUS_PER_PROC = 25;
+
+class NesingwarysTrappingTreads extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  focusGain = 0;
+  possibleGain = 0;
+  focusWaste = 0;
+  on_initialized() {
+    this.active = this.combatants.selected.hasFeet(ITEMS.NESINGWARYS_TRAPPING_TREADS.id);
+  }
+
+  on_toPlayer_energize(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.NESINGWARYS_TRAPPING_TREADS_FOCUS_GAIN.id) {
+      return;
+    }
+    this.focusGain += event.resourceChange - event.waste;
+    this.focusWaste += event.waste;
+    this.possibleGain += FOCUS_PER_PROC;
+  }
+
+  item() {
+    return {
+      item: ITEMS.NESINGWARYS_TRAPPING_TREADS,
+      result: (
+        <dfn data-tip={`You procced Nesingwary's Trapping Treads ${this.possibleGain / FOCUS_PER_PROC} times.`}>
+          <span>You gained {this.focusGain} out of {this.possibleGain} possible focus.</span>
+        </dfn>
+      ),
+    };
+  }
+}
+
+export default NesingwarysTrappingTreads;

--- a/src/Parser/Hunter/Survival/Modules/Items/NesingwarysTrappingTreads.js
+++ b/src/Parser/Hunter/Survival/Modules/Items/NesingwarysTrappingTreads.js
@@ -4,6 +4,7 @@ import ITEMS from 'common/ITEMS';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
+import { formatNumber } from 'common/format';
 
 /**
  * Nesingwary's Trapping Treads
@@ -38,8 +39,8 @@ class NesingwarysTrappingTreads extends Analyzer {
     return {
       item: ITEMS.NESINGWARYS_TRAPPING_TREADS,
       result: (
-        <dfn data-tip={`You procced Nesingwary's Trapping Treads ${this.possibleGain / FOCUS_PER_PROC} times.`}>
-          <span>You gained {this.focusGain} out of {this.possibleGain} possible focus.</span>
+        <dfn data-tip={`You procced Nesingwary's Trapping Treads ${this.possibleGain / FOCUS_PER_PROC} times. <br/>You wasted ${formatNumber(this.focusWaste / this.owner.fightDuration * 60000)} focus per minute by overcapping with the proc.`}>
+          You gained {formatNumber(this.focusGain / this.owner.fightDuration * 60000)} focus per minute.
         </dfn>
       ),
     };

--- a/src/Parser/Hunter/Survival/Modules/Items/UnseenPredatorsCloak.js
+++ b/src/Parser/Hunter/Survival/Modules/Items/UnseenPredatorsCloak.js
@@ -6,7 +6,6 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 import { formatPercentage } from 'common/format';
 import Wrapper from 'common/Wrapper';
-import SpellLink from 'common/SpellLink';
 import Enemies from 'Parser/Core/Modules/Enemies';
 
 /**
@@ -30,7 +29,7 @@ class UnseenPredatorsCloak extends Analyzer {
   item() {
     return {
       item: ITEMS.UNSEEN_PREDATORS_CLOAK,
-      result: <Wrapper>You had {formatPercentage(this.uptimePercentage)}% uptime on <SpellLink id={SPELLS.UNSEEN_PREDATORS_CLOAK_BUFF.id} />.</Wrapper>,
+      result: <Wrapper>{formatPercentage(this.uptimePercentage)}% uptime</Wrapper>,
     };
   }
 }

--- a/src/Parser/Hunter/Survival/Modules/Items/UnseenPredatorsCloak.js
+++ b/src/Parser/Hunter/Survival/Modules/Items/UnseenPredatorsCloak.js
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import ITEMS from 'common/ITEMS';
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import SPELLS from 'common/SPELLS';
+import { formatPercentage } from 'common/format';
+import Wrapper from 'common/Wrapper';
+import SpellLink from 'common/SpellLink';
+import Enemies from 'Parser/Core/Modules/Enemies';
+
+/**
+ * Unseen Predator's Cloak
+ * Equip: Gain 10% increased critical strike chance against enemies burning from your Explosive Trap.
+ */
+class UnseenPredatorsCloak extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    enemies: Enemies,
+  };
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasBack(ITEMS.UNSEEN_PREDATORS_CLOAK.id);
+  }
+
+  get uptimePercentage() {
+    return this.enemies.getBuffUptime(SPELLS.UNSEEN_PREDATORS_CLOAK_BUFF.id) / this.owner.fightDuration;
+  }
+
+  item() {
+    return {
+      item: ITEMS.UNSEEN_PREDATORS_CLOAK,
+      result: <Wrapper>You had {formatPercentage(this.uptimePercentage)}% uptime on <SpellLink id={SPELLS.UNSEEN_PREDATORS_CLOAK_BUFF.id} />.</Wrapper>,
+    };
+  }
+}
+
+export default UnseenPredatorsCloak;

--- a/src/common/SPELLS/HUNTER.js
+++ b/src/common/SPELLS/HUNTER.js
@@ -595,6 +595,11 @@ export default {
     name: 'Harpoon',
     icon: 'ability_hunter_harpoon',
   },
+  HARPOON_DAMAGE: { //doesn't actually do damage, but it's categorized as that
+    id: 190927,
+    name: 'Harpoon',
+    icon: 'ability_hunter_harpoon',
+  },
   MUZZLE: {
     id: 187707,
     name: 'Muzzle',
@@ -713,6 +718,21 @@ export default {
     id: 212575,
     name: 'Nesingwary\'s Trapping Treads',
     icon: 'inv_boots_mail_panda_b_02',
+  },
+  UNSEEN_PREDATORS_CLOAK_BUFF: {
+    id: 248212,
+    name: 'Unseen Predator\'s Cloak',
+    icon: 'ability_vehicle_demolisherflamecatapult',
+  },
+  MARK_OF_HELBRINE: {
+    id: 213156,
+    name: 'Mark of Helbrine',
+    icon: 'inv_spear_04',
+  },
+  BUTCHERS_BONE_APRON_BUFF: {
+    id: 236446,
+    name: 'Butcher\'s Bone Apron',
+    icon: 'ability_hunter_carve',
   },
 
   //------------------------------------------------------------


### PR DESCRIPTION
This adds the 5 spec specific legendaries. 

Helbrine: 
![image](https://user-images.githubusercontent.com/29204244/35737370-87f09386-082b-11e8-900c-d03192f8031a.png)
Report: https://www.warcraftlogs.com/reports/QtDF2PBh4Aa1Xxgr/#fight=22&source=11

Frizzo's: 
![image](https://user-images.githubusercontent.com/29204244/35737402-a02bf35a-082b-11e8-96c0-34008fc1e579.png)
Report: https://www.warcraftlogs.com/reports/AbdZzH3WFxGhyYfN#fight=9&type=damage-done&source=16

Unseen Predator's Cloak: 
![image](https://user-images.githubusercontent.com/29204244/35737429-b539a2ce-082b-11e8-8e16-c45bbb320063.png)
Report: https://www.warcraftlogs.com/reports/ZxVMjQCLfqcRmtKH#fight=8&type=auras&translate=true&hostility=1&spells=debuffs&target=19

Butcher's Bone Apron: 
![image](https://user-images.githubusercontent.com/29204244/35737482-f2147606-082b-11e8-805e-c61503ab96c4.png)
Report: https://www.warcraftlogs.com/reports/Rt9cXWGzC7bhdL6v#fight=1&type=damage-done

Nesingwary's Trapping Treads:
![image](https://user-images.githubusercontent.com/29204244/35737528-1fdf5678-082c-11e8-96ef-611aba650491.png)

Report: https://www.warcraftlogs.com/reports/nWMF8h1vTq3cbCKw#fight=1&type=damage-done
