### PR TITLE
[resto druid] Fixed bug in clearcasting module

### DIFF
--- a/src/Main/Timeline/SpellTimeline.js
+++ b/src/Main/Timeline/SpellTimeline.js
@@ -142,7 +142,7 @@ class SpellTimeline extends React.PureComponent {
                 const maxWidth = totalWidth - left; // don't expand beyond the container width
                 return (
                   <div
-                    key={`${eventStart}-${event.duration}`}
+                    key={`${event.reason.type}-${eventStart}-${event.duration}`}
                     className="casting-time"
                     style={{
                       left,

--- a/src/Parser/Druid/Restoration/CHANGELOG.js
+++ b/src/Parser/Druid/Restoration/CHANGELOG.js
@@ -10,6 +10,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-02-02'),
+    changes: <Wrapper>Fixed a bug in <SpellLink id={SPELLS.CLEARCASTING_BUFF.id} icon /> Util module where overwritten procs weren't shown if player doesn't take <SpellLink id={SPELLS.MOMENT_OF_CLARITY_TALENT_RESTORATION.id} icon />.</Wrapper>,
+    contributors: [sref],
+  },
+  {
     date: new Date('2018-01-26'),
     changes: <Wrapper>Updated HoT tracking framework to allow attribution of HoT extensions, allowing updates to <SpellLink id={SPELLS.FLOURISH_TALENT.id} icon />. Also added modules for <ItemLink id={ITEMS.EDRAITH_BONDS_OF_AGLAYA.id} icon />, <ItemLink id={ITEMS.AMANTHULS_WISDOM.id} icon />, and <SpellLink id={SPELLS.DEEP_ROOTED_TRAIT.id} icon />.</Wrapper>,
     contributors: [sref],

--- a/src/Parser/Druid/Restoration/Modules/Features/Clearcasting.js
+++ b/src/Parser/Druid/Restoration/Modules/Features/Clearcasting.js
@@ -9,7 +9,7 @@ import SPELLS from 'common/SPELLS';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
-const debug = true;
+const debug = false;
 
 class Clearcasting extends Analyzer {
   static dependencies = {

--- a/src/Parser/Druid/Restoration/Modules/Features/Clearcasting.js
+++ b/src/Parser/Druid/Restoration/Modules/Features/Clearcasting.js
@@ -9,7 +9,7 @@ import SPELLS from 'common/SPELLS';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
-const debug = false;
+const debug = true;
 
 class Clearcasting extends Analyzer {
   static dependencies = {
@@ -48,7 +48,7 @@ class Clearcasting extends Analyzer {
     this.availableProcs = this.procsPerCC;
   }
 
-  // it looks right now like the refreshbuff handling will never be used, because for whatever reason CC doesn't fire an event when it refreshes...
+  // refreshbuff does show without MoC, but doesn't show with it.... at least I can get overwrites when player doesn't have it...
   on_byPlayer_refreshbuff(event) {
     const spellId = event.ability.guid;
     if (spellId !== SPELLS.CLEARCASTING_BUFF.id) {
@@ -159,6 +159,7 @@ class Clearcasting extends Analyzer {
         tooltip={`Clearcasting procced <b>${this.totalProcs} free Regrowths</b>
             <ul>
               <li>Used: <b>${this.usedProcs} ${this.hadInvisibleRefresh ? '*' : ''}</b></li>
+              ${this.hadInvisibleRefresh ? '' : `<li>Overwritten: <b>${this.overwrittenProcs}</b></li>`}
               <li>Expired: <b>${this.expiredProcs}</b></li>
             </ul>
             <b>${this.nonCCRegrowths} of your Regrowths were cast without a Clearcasting proc</b>.


### PR DESCRIPTION
Apparently Clearcasting does or doesn't get a refreshbuff when it's refreshed depending on if player took MoC ????

Anyway, fixed things so it will display properly when player doesn't have MoC.

Also made a stopgap fix to SpellTimeline so it doesn't spam the console with "same ID" errors if the overlapping GCD bug happens. Note this doesn't fix the overlapping GCDs... that will require more effort. It just makes the console more usable until it is fixed.