### PR TITLE
[Core] Update sephuz

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -9,6 +9,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-02-02'),
+    changes: <Wrapper>Updated <ItemLink id={ITEMS.SEPHUZS_SECRET.id} icon /> to also showcase the multiplicative effect that is added as part of the baseline and the proc on top of the flat bonuses</Wrapper>,
+    contributors: [Putro],
+  },
+  {
     date: new Date('2018-01-28'),
     changes: <Wrapper>Added <i>How It's Made</i>, <i>How To Change</i>, <i>Spec Maintainer</i> and <i>State Of The Spec</i> boxes to the results page.</Wrapper>,
     contributors: [Zerotorescue],

--- a/src/Parser/Core/Modules/Items/Legion/Legendaries/SephuzsSecret.js
+++ b/src/Parser/Core/Modules/Items/Legion/Legendaries/SephuzsSecret.js
@@ -28,13 +28,13 @@ class SephuzsSecret extends Analyzer {
   item() {
     const uptimePercent = this.combatants.selected.getBuffUptime(SPELLS.SEPHUZS_SECRET_BUFF.id) / this.owner.fightDuration;
     const startHaste = this.statTracker.startingHasteRating / 37500;
-    const avgHaste = (uptimePercent * ACTIVE_HASTE) + ((1 - uptimePercent) * ((1 + startHaste) * PASSIVE_HASTE));
+    const avgHaste = (uptimePercent * ((1 + startHaste) * ACTIVE_HASTE)) + ((1 - uptimePercent) * ((1 + startHaste) * PASSIVE_HASTE));
     return {
       item: ITEMS.SEPHUZS_SECRET,
       result: (
         <span>
           <dfn
-            data-tip={`This is the average haste percentage gained, factoring in both the passive and active bonuses. The active's uptime was <b>${formatPercentage(uptimePercent)}%</b>`}
+            data-tip={`This is the average haste percentage gained, factoring in both the passive and active bonuses. The active's uptime was <b>${formatPercentage(uptimePercent)}%</b>. <br/> The average haste gained with 0% uptime can still be higher than 2%, as Sephuz also increases your existing haste by 2% before applying the flat 2%.`}
           >
             {formatPercentage(avgHaste)} % average haste
           </dfn>

--- a/src/Parser/Core/Modules/Items/Legion/Legendaries/SephuzsSecret.js
+++ b/src/Parser/Core/Modules/Items/Legion/Legendaries/SephuzsSecret.js
@@ -28,7 +28,7 @@ class SephuzsSecret extends Analyzer {
   item() {
     const uptimePercent = this.combatants.selected.getBuffUptime(SPELLS.SEPHUZS_SECRET_BUFF.id) / this.owner.fightDuration;
     const startHaste = this.statTracker.startingHasteRating / 37500;
-    const avgHaste = (1 + startHaste * (((uptimePercent * ACTIVE_HASTE * PASSIVE_HASTE)) + ((1 - uptimePercent) * PASSIVE_HASTE))) - 1 + PASSIVE_HASTE;
+    const avgHaste = (1 + startHaste * PASSIVE_HASTE + PASSIVE_HASTE) + (uptimePercent * ACTIVE_HASTE) - 1;
     return {
       item: ITEMS.SEPHUZS_SECRET,
       result: (

--- a/src/Parser/Core/Modules/Items/Legion/Legendaries/SephuzsSecret.js
+++ b/src/Parser/Core/Modules/Items/Legion/Legendaries/SephuzsSecret.js
@@ -28,7 +28,7 @@ class SephuzsSecret extends Analyzer {
   item() {
     const uptimePercent = this.combatants.selected.getBuffUptime(SPELLS.SEPHUZS_SECRET_BUFF.id) / this.owner.fightDuration;
     const startHaste = this.statTracker.startingHasteRating / 37500;
-    const avgHaste = (uptimePercent * ((1 + startHaste) * ACTIVE_HASTE)) + ((1 - uptimePercent) * ((1 + startHaste) * PASSIVE_HASTE));
+    const avgHaste = (1 + startHaste * (((uptimePercent * ACTIVE_HASTE * PASSIVE_HASTE)) + ((1 - uptimePercent) * PASSIVE_HASTE))) - 1 + PASSIVE_HASTE;
     return {
       item: ITEMS.SEPHUZS_SECRET,
       result: (

--- a/src/Parser/Core/Modules/Items/Legion/Legendaries/SephuzsSecret.js
+++ b/src/Parser/Core/Modules/Items/Legion/Legendaries/SephuzsSecret.js
@@ -6,6 +6,7 @@ import { formatPercentage } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+import StatTracker from 'Parser/Core/Modules/StatTracker';
 
 const PASSIVE_HASTE = 0.02;
 const ACTIVE_HASTE = 0.25;
@@ -17,6 +18,7 @@ const ACTIVE_HASTE = 0.25;
 class SephuzsSecret extends Analyzer {
   static dependencies = {
     combatants: Combatants,
+    statTracker: StatTracker,
   };
 
   on_initialized() {
@@ -25,8 +27,8 @@ class SephuzsSecret extends Analyzer {
 
   item() {
     const uptimePercent = this.combatants.selected.getBuffUptime(SPELLS.SEPHUZS_SECRET_BUFF.id) / this.owner.fightDuration;
-    const avgHaste = (uptimePercent * ACTIVE_HASTE) + ((1 - uptimePercent) * PASSIVE_HASTE);
-
+    const startHaste = this.statTracker.startingHasteRating / 37500;
+    const avgHaste = (uptimePercent * ACTIVE_HASTE) + ((1 - uptimePercent) * ((1 + startHaste) * PASSIVE_HASTE));
     return {
       item: ITEMS.SEPHUZS_SECRET,
       result: (


### PR DESCRIPTION
See here: 

![image](https://user-images.githubusercontent.com/29204244/35738934-7342d3cc-0830-11e8-9c65-989bb61efd00.png)

26.69% - 24.21% = 2.48%. This means I gain 0.48% haste additional from Sephuz before the 2% are added. 

It can also be shown through this formula 24,21*0,02 = 0,4842. 

Additionally this effect also occurs on the proc which I've also accounted for now showcased here:

![image](https://user-images.githubusercontent.com/29204244/35739142-f65f9420-0830-11e8-887b-8ce9b7204a32.png)
55,83% - 24,21% = 31,62%, which means I gained more than the advertised 25%.

However, 24,21`*`1,25 +25 = 55,2625 - so we're still a few decimals off. 
However if you do 24,21`*`1,02`*`1,25 + 25 = 55,86775 - which is closer than anything else.


Showcasing formula using my stats:
``(1 + startHaste * PASSIVE_HASTE + PASSIVE_HASTE) + (uptimePercent * ACTIVE_HASTE) - 1``

(1 + 0,2421 * 0,02+0,02 ) + (0 * 0,25)-1 = 0,02842 * 100 = 2,4842 (same as above)
Assuming 10% uptime (We'd expect `` 0,9*2+0,1*25 = 4,3`` using the old calculation):

New calculation: (1 + 0,2421 * 0,02+0,02 ) + (0,1* 0,25) - 1 = 0,049842 * 100 = 4,9842

The old calculation would have been almost 0.7% average haste off target, whereas my above calculation shows us merely being 0.03% off 

Log here:
Report: 
https://www.warcraftlogs.com/reports/dJkh3NZX76zwAM4r#fight=11&type=damage-done&source=4

Live: 
![image](https://user-images.githubusercontent.com/29204244/35742866-222e3092-083c-11e8-8c50-de32ab24ecb5.png)

New version:
![image](https://user-images.githubusercontent.com/29204244/35742878-2aa5b92a-083c-11e8-88e1-9d929048bc33.png)

