### PR TITLE
[Survival] Spitting cobra

### DIFF
--- a/src/Parser/Hunter/Marksmanship/Modules/Spells/Trueshot.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Spells/Trueshot.js
@@ -12,6 +12,7 @@ import Icon from "common/Icon";
 import { formatNumber, formatPercentage } from "common/format";
 import RESOURCE_TYPES from 'common/RESOURCE_TYPES';
 import Wrapper from 'common/Wrapper';
+import SpellUsable from 'Parser/Core/Modules/SpellUsable';
 
 /*
  * Increases haste by 40% and causes Arcane Shot and Multi-Shot to always apply Hunter's Mark.
@@ -21,6 +22,7 @@ import Wrapper from 'common/Wrapper';
 class Trueshot extends Analyzer {
   static dependencies = {
     combatants: Combatants,
+    spellUsable: SpellUsable,
   };
 
   trueshotCasts = 0;
@@ -43,6 +45,8 @@ class Trueshot extends Analyzer {
     //adds 1 to trueshotCasts to properly show that it was cast prepull
     this.trueshotCasts += 1;
     this.prepullTrueshots += 1;
+    //starts the cooldown to ensure proper cast efficiency statistics
+    this.spellUsable.beginCooldown(SPELLS.TRUESHOT.id);
   }
 
   on_byPlayer_cast(event) {

--- a/src/Parser/Hunter/Survival/CHANGELOG.js
+++ b/src/Parser/Hunter/Survival/CHANGELOG.js
@@ -10,6 +10,11 @@ import ItemLink from 'common/ItemLink';
 export default [
   {
     date: new Date('2018-02-02'),
+    changes: <Wrapper>Added a module for tracking <SpellLink id={SPELLS.SPITTING_COBRA_TALENT.id} icon />, and ensure cast efficiency works properly for the talent even if precast. </Wrapper>,
+    contributors: [Putro],
+  },
+  {
+    date: new Date('2018-02-02'),
     changes: <Wrapper>Added support for <ItemLink id={ITEMS.BUTCHERS_BONE_APRON.id} icon />, <ItemLink id={ITEMS.FRIZZOS_FINGERTRAP.id} icon />, <ItemLink id={ITEMS.HELBRINE_ROPE_OF_THE_MIST_MARAUDER.id} icon />, <ItemLink id={ITEMS.NESINGWARYS_TRAPPING_TREADS.id} icon />, <ItemLink id={ITEMS.UNSEEN_PREDATORS_CLOAK.id} icon />.</Wrapper>,
     contributors: [Putro],
   },

--- a/src/Parser/Hunter/Survival/CombatLogParser.js
+++ b/src/Parser/Hunter/Survival/CombatLogParser.js
@@ -34,6 +34,7 @@ import FrizzosFingertrap from './Modules/Items/FrizzosFingertrap';
 
 //Talents
 import WayOfTheMokNathal from './Modules/Talents/WayOfTheMokNathal';
+import SpittingCobra from './Modules/Talents/SpittingCobra';
 
 //Traits
 
@@ -78,6 +79,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     //Talents
     wayOfTheMokNathal: WayOfTheMokNathal,
+    spittingCobra: SpittingCobra,
     //Traits
 
     //Traits and Talents list

--- a/src/Parser/Hunter/Survival/Modules/Talents/SpittingCobra.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/SpittingCobra.js
@@ -1,0 +1,83 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import Analyzer from 'Parser/Core/Analyzer';
+import StatisticBox from 'Main/StatisticBox';
+import SpellIcon from 'common/SpellIcon';
+import STATISTIC_ORDER from 'Main/STATISTIC_ORDER';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import SpellUsable from 'Parser/Core/Modules/SpellUsable';
+import { formatNumber } from 'common/format';
+
+class SpittingCobra extends Analyzer {
+
+  static dependencies = {
+    combatants: Combatants,
+    spellUsable: SpellUsable,
+  };
+
+  bonusDamage = 0;
+  cobraCasts = 0;
+  focusGain = 0;
+  focusWaste = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.SPITTING_COBRA_TALENT.id);
+  }
+
+  on_byPlayer_applybuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.SPITTING_COBRA_TALENT.id || !event.prepull) {
+      return;
+    }
+    //starts the cooldown to ensure proper cast efficiency statistics
+    this.spellUsable.beginCooldown(SPELLS.SPITTING_COBRA_TALENT.id);
+    //adds one to cobraCasts so we can calculate the average casts properly
+    this.cobraCasts++;
+  }
+
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.SPITTING_COBRA_TALENT.id) {
+      return;
+    }
+    this.cobraCasts++;
+  }
+
+  on_toPlayer_energize(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.SPITTING_COBRA_TALENT.id) {
+      return;
+    }
+    this.focusGain += event.resourceChange - event.waste;
+    this.focusWaste += event.waste;
+  }
+
+  on_byPlayerPet_damage(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.SPITTING_COBRA_DAMAGE.id) {
+      return;
+    }
+    this.bonusDamage += event.amount + (event.absorbed || 0);
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.SPITTING_COBRA_TALENT.id} />}
+        value={`${formatNumber(this.bonusDamage / this.owner.fightDuration * 1000)} DPS`}
+        label="Spitting Cobra"
+        tooltip={`Spitting Cobra breakdown:
+          <ul>
+          <li>Focus gain per minute: ${formatNumber(this.focusGain / this.owner.fightDuration * 60000)}</li><ul>
+                   <li>In total you gained ${this.focusGain} focus.</li>
+                   <li>In total you wasted ${this.focusWaste} focus.</li>
+</ul>
+            <li> Average damage per cast: ${formatNumber(this.bonusDamage / this.cobraCasts)}</li>
+          </ul> `} />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(8);
+}
+
+export default SpittingCobra;

--- a/src/common/SPELLS/HUNTER.js
+++ b/src/common/SPELLS/HUNTER.js
@@ -621,6 +621,11 @@ export default {
     name: 'Serpent Sting',
     icon: 'ability_hunter_serpentswiftness',
   },
+  SPITTING_COBRA_DAMAGE: {
+    id: 206685,
+    name: 'Cobra Spit',
+    icon: 'ability_creature_poison_02',
+  },
   //Survival traits:
   ECHOES_OF_OHNARA_TRAIT: {
     id: 238125,


### PR DESCRIPTION
Short and sweet one to finish off the day with.

This adds a module to track damage and focus gained through the Spitting Cobra talent.

It fixes cast efficiency issues with Trueshot and Spitting Cobra if they were cast before combat started. 
Report: https://www.warcraftlogs.com/reports/RFBPbDJYt93G4xnv/#fight=8&type=damage-done&source=7
![image](https://user-images.githubusercontent.com/29204244/35752002-a5cd122e-085a-11e8-8698-39e5ff064798.png)


Live:
![image](https://user-images.githubusercontent.com/29204244/35752028-c1b7a288-085a-11e8-8914-d4a9925b2857.png)
This version:
![image](https://user-images.githubusercontent.com/29204244/35752043-cdbe2d90-085a-11e8-8761-e70047b1d248.png)


