### PR TITLE
[Core] Fix Death Tracker

### DIFF
--- a/src/Parser/Core/Modules/DeathTracker.js
+++ b/src/Parser/Core/Modules/DeathTracker.js
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import SPELLS from 'common/SPELLS';
 import { formatMilliseconds, formatNumber, formatPercentage } from 'common/format';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
@@ -35,7 +34,34 @@ class DeathTracker extends Analyzer {
   on_byPlayer_cast(event) {
     this.castCount += 1;
 
-    if (event.ability.guid === SPELLS.REINCARNATION.id) {
+    if (!this.isAlive) {
+      this.lastResurrectionTimestamp = this.owner.currentTimestamp;
+      this.timeDead += this.lastResurrectionTimestamp - this.lastDeathTimestamp;
+      debug && console.log("Player was Resurrected @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
+      this.isAlive = true;
+    }
+  }
+
+  on_byPlayer_begincast(event) {
+    if (!this.isAlive) {
+      this.lastResurrectionTimestamp = this.owner.currentTimestamp;
+      this.timeDead += this.lastResurrectionTimestamp - this.lastDeathTimestamp;
+      debug && console.log("Player was Resurrected @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
+      this.isAlive = true;
+    }
+  }
+
+  on_toPlayer_heal(event) {
+    if (!this.isAlive) {
+      this.lastResurrectionTimestamp = this.owner.currentTimestamp;
+      this.timeDead += this.lastResurrectionTimestamp - this.lastDeathTimestamp;
+      debug && console.log("Player was Resurrected @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
+      this.isAlive = true;
+    }
+  }
+
+  on_toPlayer_damage(event) {
+    if (!this.isAlive) {
       this.lastResurrectionTimestamp = this.owner.currentTimestamp;
       this.timeDead += this.lastResurrectionTimestamp - this.lastDeathTimestamp;
       debug && console.log("Player was Resurrected @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));


### PR DESCRIPTION
Death Tracker was not counting Soulstone as a ressurect and there are no events to indicate that the player used their soulstone. So instead, I made it so that if you are healed, take damage, start casting something, or cast something while you are marked as dead, then it will count as a ressurect.

Fixes #1207 
Fixes #443 