### PR TITLE
[Core] Updated Norgannons

### DIFF
--- a/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/NorgannonsProwess.js
+++ b/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/NorgannonsProwess.js
@@ -3,7 +3,8 @@ import React from 'react';
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
-import { formatPercentage } from 'common/format';
+import { formatPercentage, formatNumber } from 'common/format';
+import { calculatePrimaryStat } from 'common/stats';
 import Wrapper from 'common/Wrapper';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
@@ -32,11 +33,15 @@ class NorgannonsProwess extends Analyzer {
   };
 
   intProc = 0;
+  intBuff = 0;
   pantheonProc = 0;
   damage = 0;
 
   on_initialized() {
     this.active = this.combatants.selected.hasTrinket(ITEMS.NORGANNONS_PROWESS.id);
+    if(this.active) {
+      this.intBuff = calculatePrimaryStat(940, 3257, this.combatants.selected.getItem(ITEMS.NORGANNONS_PROWESS.id).itemLevel);
+    }
   }
 
   on_byPlayer_applybuff(event) {
@@ -67,18 +72,22 @@ class NorgannonsProwess extends Analyzer {
     this.damage += event.amount + (event.absorbed || 0);
   }
 
+  get intUptimePercent() {
+    return this.combatants.selected.getBuffUptime(SPELLS.RUSH_OF_KNOWLEDGE.id) / this.owner.fightDuration;
+  }
+
   item() {
-    const intUptimePercent = this.combatants.selected.getBuffUptime(SPELLS.RUSH_OF_KNOWLEDGE.id) / this.owner.fightDuration;
+    const averageInt = this.intUptimePercent * this.intBuff;
 
     return {
       item: ITEMS.NORGANNONS_PROWESS,
       result: (
         <Wrapper>
-          <dfn data-tip={`Procced the int buff <b>${this.intProc}</b> times`}>
-            {formatPercentage(intUptimePercent)} % uptime on <SpellLink id={SPELLS.RUSH_OF_KNOWLEDGE.id} />
+          <dfn data-tip={`Procced the int buff <b>${this.intProc}</b> times with <b>${formatPercentage(this.intUptimePercent)}%</b> uptime`}>
+            {formatNumber(averageInt)} average Intellect gained from <SpellLink id={SPELLS.RUSH_OF_KNOWLEDGE.id} icon/>
           </dfn><br />
           <dfn data-tip={`Procced the pantheon buff <b>${this.pantheonProc}</b> times`}>
-            <ItemDamageDone amount={this.damage} /> from <SpellLink id={SPELLS.NORGANNONS_COMMAND.id} />
+            <ItemDamageDone amount={this.damage} /> from <SpellLink id={SPELLS.NORGANNONS_COMMAND.id}/>
           </dfn>
         </Wrapper>
       ),

--- a/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/NorgannonsProwess.js
+++ b/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/NorgannonsProwess.js
@@ -40,7 +40,7 @@ class NorgannonsProwess extends Analyzer {
   on_initialized() {
     this.active = this.combatants.selected.hasTrinket(ITEMS.NORGANNONS_PROWESS.id);
     if(this.active) {
-      this.intBuff = calculatePrimaryStat(940, 3257, this.combatants.selected.getItem(ITEMS.NORGANNONS_PROWESS.id).itemLevel);
+      this.intBuff = calculatePrimaryStat(940, 11483, this.combatants.selected.getItem(ITEMS.NORGANNONS_PROWESS.id).itemLevel);
     }
   }
 

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -143,7 +143,7 @@ class StatTracker extends Analyzer {
     },
     [SPELLS.RUSH_OF_KNOWLEDGE.id]: {
       itemId: ITEMS.NORGANNONS_PROWESS.id,
-      intellect: (_, item) => calculatePrimaryStat(940, 3257, item.itemLevel),
+      intellect: (_, item) => calculatePrimaryStat(940, 11483, item.itemLevel),
     },
     // Khaz'goroth's Courage is handled in it's own module since all 4 stat buffs use the same ID.
     //[SPELLS.KHAZGOROTHS_SHAPING.id]: {

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
 import SPECS from 'common/SPECS';
-import { calculateSecondaryStatDefault } from 'common/stats';
+import { calculateSecondaryStatDefault, calculatePrimaryStat } from 'common/stats';
 import { formatMilliseconds } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
@@ -140,6 +140,10 @@ class StatTracker extends Analyzer {
     [SPELLS.FEEDBACK_LOOP.id]: {
       itemId: ITEMS.GAROTHI_FEEDBACK_CONDUIT.id,
       haste: (_, item) => calculateSecondaryStatDefault(930, 856, item.itemLevel),
+    },
+    [SPELLS.RUSH_OF_KNOWLEDGE.id]: {
+      itemId: ITEMS.NORGANNONS_PROWESS.id,
+      intellect: (_, item) => calculatePrimaryStat(940, 3257, item.itemLevel),
     },
     // Khaz'goroth's Courage is handled in it's own module since all 4 stat buffs use the same ID.
     //[SPELLS.KHAZGOROTHS_SHAPING.id]: {


### PR DESCRIPTION
Instead of showing the percent uptime on the intellect buff it now shows the average amount of int gained.
new
![image](https://user-images.githubusercontent.com/19510201/35783883-eabf1c30-09d4-11e8-8a42-1b47f5036bc7.png)

old
cZhfdNGR4LQBwj32
![image](https://user-images.githubusercontent.com/19510201/35783886-0c6840fa-09d5-11e8-9643-47dacfa670ab.png)
test log
https://www.warcraftlogs.com/reports/cZhfdNGR4LQBwj32#fight=4&type=damage-done&source=2