### PR TITLE
[Core] Separate Player list into Columns

### DIFF
--- a/src/Main/PlayerSelectionList.js
+++ b/src/Main/PlayerSelectionList.js
@@ -159,7 +159,7 @@ export class PlayerSelectionList extends React.PureComponent {
         return (
           <div key={roleID === null ? -1 : roleID} className="card">
             {this.renderRoleHeader(roleID, friendlies.length)}
-            <ul className="list selection players item-divider item-divider-top">
+            <ul className="list selection players item-divider item-divider-top" style={{ columnCount: 2, columnGap: 0, border: 0 }}>
               {friendlies
                 .sort((a, b) => {
                   if (a.name > b.name) {


### PR DESCRIPTION
Separate Player Selector List into columns so some of the players arent going off the screen.

Part of #824 
Fixes #828 