### PR TITLE
[Feral Druid] Fixed several issues in Abilities

### DIFF
--- a/src/Parser/Druid/Feral/Modules/Features/Abilities.js
+++ b/src/Parser/Druid/Feral/Modules/Features/Abilities.js
@@ -7,13 +7,70 @@ class Abilities extends CoreAbilities {
     const combatant = this.combatants.selected;
     return [
       {
+        spell: SPELLS.SHRED,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+      },
+      {
+        spell: SPELLS.RAKE,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+      },
+      {
+        spell: SPELLS.RIP,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+      },
+      {
+        spell: SPELLS.FEROCIOUS_BITE,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+      },
+      {
+        spell: SPELLS.SAVAGE_ROAR_TALENT,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        enabled: combatant.hasTalent(SPELLS.SAVAGE_ROAR_TALENT.id),
+      },
+      {
+        spell: SPELLS.MOONFIRE,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        enabled: combatant.hasTalent(SPELLS.LUNAR_INSPIRATION_TALENT.id),
+      },
+
+      {
+        spell: SPELLS.THRASH_FERAL,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
+      },
+      {
+        spell: SPELLS.CAT_SWIPE,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
+        enabled: !combatant.hasTalent(SPELLS.BRUTAL_SLASH_TALENT.id),
+      },
+      {
+        spell: SPELLS.BRUTAL_SLASH_TALENT,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL, // when taken, still used on single target
+        enabled: combatant.hasTalent(SPELLS.BRUTAL_SLASH_TALENT.id),
+        cooldown: haste => 12 / (1 + haste),
+        charges: 3,
+        castEfficiency: {
+          suggestion: true,
+        },
+      },
+
+      {
         spell: SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 180,
         enabled: combatant.hasTalent(SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id),
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: 1.0,
+          recommendedEfficiency: 0.90,
+        },
+      },
+      {
+        spell: SPELLS.BERSERK,
+        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
+        cooldown: 180,
+        enabled: !combatant.hasTalent(SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id),
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.90,
         },
       },
       {
@@ -41,57 +98,15 @@ class Abilities extends CoreAbilities {
           suggestion: true,
         },
       },
-      {
-        spell: SPELLS.RAKE,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-      },
-      {
-        spell: SPELLS.RIP,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-      },
-      {
-        spell: SPELLS.SHRED,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-      },
+
       {
         spell: SPELLS.REGROWTH,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-      },
-      {
-        spell: SPELLS.FEROCIOUS_BITE,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-      },
-      {
-        spell: SPELLS.SAVAGE_ROAR_TALENT,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        enabled: combatant.hasTalent(SPELLS.SAVAGE_ROAR_TALENT.id),
-      },
-      {
-        spell: SPELLS.MOONFIRE,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        enabled: combatant.hasTalent(SPELLS.LUNAR_INSPIRATION_TALENT.id),
-      },
-      {
-        spell: SPELLS.BRUTAL_SLASH_TALENT,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        enabled: combatant.hasTalent(SPELLS.BRUTAL_SLASH_TALENT.id),
-        cooldown: 12,
-        castEfficiency: {
-          suggestion: true,
-        },
-      },
-      {
-        spell: SPELLS.THRASH_BEAR,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
       },
       {
         spell: SPELLS.MAIM,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 10,
-      },
-      {
-        spell: SPELLS.CAT_SWIPE,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
       },
       {
         spell: SPELLS.DASH,
@@ -106,11 +121,13 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.SHADOWMELD,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 120,
+        isUndetectable: true,
       },
       {
         spell: SPELLS.SURVIVAL_INSTINCTS,
-        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         cooldown: 120,
+        charges: 2,
       },
       {
         spell: SPELLS.REBIRTH,
@@ -136,8 +153,8 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.RENEWAL_TALENT,
-        category: Abilities.SPELL_CATEGORIES.UTILITY,
-        enabled: combatant.hasTalent(SPELLS.TYPHOON_TALENT.id),
+        category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
+        enabled: combatant.hasTalent(SPELLS.RENEWAL_TALENT.id),
         cooldown: 90,
       },
       {

--- a/src/common/SPELLS/DRUID.js
+++ b/src/common/SPELLS/DRUID.js
@@ -780,6 +780,11 @@ export default {
     name: 'Thrash',
     icon: 'spell_druid_thrash',
   },
+  BERSERK: {
+    id: 106951,
+    name: 'Berserk',
+    icon: 'ability_druid_berserk',
+  },
   // Traits:
   // The Ashamane's Bite trait creates the Ashamane's Rip debuff.
   ASHAMANES_BITE: {


### PR DESCRIPTION
Rearranged abilities to be roughly organized by category.

Also fixed the following issues:
- Brutal Slash wasn't shown scaling with haste OR having charges
- Shadowmeld wasn't marked 'isUndetectable'
- Berserk was missing entirely
- Thrash was included with the wrong ID (the Guardian version)
- Survival Instincts was missing charges
- Survival Instincts and Renewal were listed as UTILITY, now listed as DEFENSIVE
- Thrash and Swipe were listed as ROTATIONAL, now listed as ROTATIONAL_AOE
- Regrowth and Maim were listed as ROTATIONAL, now listed as UTILITY (I felt this appropriate as few players use Bloodtalons anymore, or Fiery Red Memers)
- Dropped Incarnation cast effic from 1.0 to 0.9 (effic requirement should never be 1.0)