### PR TITLE
[Survival] Prepull traps and traits/talent listbox

### DIFF
--- a/src/Parser/Hunter/BeastMastery/Modules/Features/TraitsAndTalents.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Features/TraitsAndTalents.js
@@ -53,7 +53,7 @@ class TraitsAndTalents extends Analyzer {
     return (
       <StatisticsListBox
         title="Traits and Talents"
-        tooltip="This provides an overview of the damage contributions of various talents and traits. This isn't meant as a way to 1:1 evaluate talents, as some talents bring other strengths to the table than pure dmg."
+        tooltip="This provides an overview of the damage contributions of various talents and traits. This isn't meant as a way to 1:1 evaluate talents, as some talents bring other strengths to the table than pure damage."
       >
         {this.wayOfTheCobra.active && this.wayOfTheCobra.subStatistic()}
         {this.stomp.active && this.stomp.subStatistic()}

--- a/src/Parser/Hunter/BeastMastery/Modules/Features/TraitsAndTalents.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Features/TraitsAndTalents.js
@@ -53,7 +53,7 @@ class TraitsAndTalents extends Analyzer {
     return (
       <StatisticsListBox
         title="Traits and Talents"
-        tooltip="This provides an overview of the damage contributions of various talents and traits"
+        tooltip="This provides an overview of the damage contributions of various talents and traits. This isn't meant as a way to 1:1 evaluate talents, as some talents bring other strengths to the table than pure dmg."
       >
         {this.wayOfTheCobra.active && this.wayOfTheCobra.subStatistic()}
         {this.stomp.active && this.stomp.subStatistic()}

--- a/src/Parser/Hunter/Marksmanship/Modules/Features/TraitsAndTalents.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Features/TraitsAndTalents.js
@@ -51,7 +51,7 @@ class TraitsAndTalents extends Analyzer {
     return (
       <StatisticsListBox
         title="Traits and Talents"
-        tooltip="This provides an overview of the damage contributions of various talents and traits. This isn't meant as a way to 1:1 evaluate talents, as some talents bring other strengths to the table than pure dmg. Sidewinders is the most obvious example of this for Marksmanship hunters."
+        tooltip="This provides an overview of the damage contributions of various talents and traits. This isn't meant as a way to 1:1 evaluate talents, as some talents bring other strengths to the table than pure damage. Sidewinders is the most obvious example of this for Marksmanship hunters."
       >
         {this.loneWolf.active && this.loneWolf.subStatistic()}
         {this.trueAim.active && this.trueAim.subStatistic()}

--- a/src/Parser/Hunter/Survival/CHANGELOG.js
+++ b/src/Parser/Hunter/Survival/CHANGELOG.js
@@ -9,6 +9,11 @@ import ItemLink from 'common/ItemLink';
 
 export default [
   {
+    date: new Date('2018-02-11'),
+    changes: <Wrapper>Added a preliminary Talents and Traits list which will include damage information about various talents and traits as they get implemented. Implemented modules for <SpellLink id={SPELLS.STEEL_TRAP_TALENT.id} icon />, <SpellLink id={SPELLS.EXPLOSIVE_TRAP_CAST.id} icon />, <SpellLink id={SPELLS.CALTROPS_TALENT.id} icon /> and added prepull handling for all three. </Wrapper>,
+    contributors: [Putro],
+  },
+  {
     date: new Date('2018-02-05'),
     changes: <Wrapper>Added additional information to the <ItemLink id={ITEMS.CALL_OF_THE_WILD.id} icon /> module, to show cooldown reduction on the various affected spells. </Wrapper>,
     contributors: [Putro],

--- a/src/Parser/Hunter/Survival/CombatLogParser.js
+++ b/src/Parser/Hunter/Survival/CombatLogParser.js
@@ -32,13 +32,19 @@ import NesingwarysTrappingTreads from './Modules/Items/NesingwarysTrappingTreads
 import ButchersBoneApron from './Modules/Items/ButchersBoneApron';
 import FrizzosFingertrap from './Modules/Items/FrizzosFingertrap';
 
+//Spells
+import ExplosiveTrap from './Modules/Spells/ExplosiveTrap';
+
 //Talents
 import WayOfTheMokNathal from './Modules/Talents/WayOfTheMokNathal';
 import SpittingCobra from './Modules/Talents/SpittingCobra';
+import Caltrops from './Modules/Talents/Caltrops';
+import SteelTrap from './Modules/Talents/SteelTrap';
 
 //Traits
 
 //Traits and Talents list
+import TraitsAndTalents from './Modules/Features/TraitsAndTalents';
 
 //Checklist
 
@@ -77,12 +83,18 @@ class CombatLogParser extends CoreCombatLogParser {
     butchersBoneApron: ButchersBoneApron,
     frizzosFingertrap: FrizzosFingertrap,
 
+    //Spells
+    explosiveTrap: ExplosiveTrap,
+
     //Talents
     wayOfTheMokNathal: WayOfTheMokNathal,
     spittingCobra: SpittingCobra,
+    caltrops: Caltrops,
+    steelTrap: SteelTrap,
     //Traits
 
     //Traits and Talents list
+    traitsAndTalents: TraitsAndTalents,
 
     //Checklist
   };

--- a/src/Parser/Hunter/Survival/Modules/Features/TraitsAndTalents.js
+++ b/src/Parser/Hunter/Survival/Modules/Features/TraitsAndTalents.js
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import StatisticsListBox from 'Main/StatisticsListBox';
+import STATISTIC_ORDER from "Main/STATISTIC_ORDER";
+
+import Analyzer from 'Parser/Core/Analyzer';
+
+import Caltrops from 'Parser/Hunter/Survival/Modules/Talents/Caltrops';
+import SteelTrap from 'Parser/Hunter/Survival/Modules/Talents/SteelTrap';
+import ExplosiveTrap from 'Parser/Hunter/Survival/Modules/Spells/ExplosiveTrap';
+
+class TraitsAndTalents extends Analyzer {
+  static dependencies = {
+    caltrops: Caltrops,
+    steelTrap: SteelTrap,
+    explosiveTrap: ExplosiveTrap,
+  };
+
+  on_initialized() {
+    // Deactivate this module if none of the underlying modules are active.
+    this.active = Object.keys(this.constructor.dependencies)
+      .map(key => this[key])
+      .some(dependency => dependency.active);
+  }
+
+  statistic() {
+    return (
+      <StatisticsListBox
+        title="Traits and Talents"
+        tooltip="This provides an overview of the damage contributions of various talents and traits. This isn't meant as a way to 1:1 evaluate talents, as some talents bring other strengths to the table than pure dmg."
+      >
+        {this.caltrops.active && this.caltrops.subStatistic()}
+        {this.steelTrap.active && this.steelTrap.subStatistic()}
+        {this.explosiveTrap.active && this.explosiveTrap.subStatistic()}
+      </StatisticsListBox>
+
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(3);
+}
+
+export default TraitsAndTalents;

--- a/src/Parser/Hunter/Survival/Modules/Features/TraitsAndTalents.js
+++ b/src/Parser/Hunter/Survival/Modules/Features/TraitsAndTalents.js
@@ -27,7 +27,7 @@ class TraitsAndTalents extends Analyzer {
     return (
       <StatisticsListBox
         title="Traits and Talents"
-        tooltip="This provides an overview of the damage contributions of various talents and traits. This isn't meant as a way to 1:1 evaluate talents, as some talents bring other strengths to the table than pure dmg."
+        tooltip="This provides an overview of the damage contributions of various talents and traits. This isn't meant as a way to 1:1 evaluate talents, as some talents bring other strengths to the table than pure damage."
       >
         {this.caltrops.active && this.caltrops.subStatistic()}
         {this.steelTrap.active && this.steelTrap.subStatistic()}

--- a/src/Parser/Hunter/Survival/Modules/Spells/ExplosiveTrap.js
+++ b/src/Parser/Hunter/Survival/Modules/Spells/ExplosiveTrap.js
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import Analyzer from 'Parser/Core/Analyzer';
+import SpellIcon from 'common/SpellIcon';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import SpellUsable from 'Parser/Core/Modules/SpellUsable';
+import SpellLink from 'common/SpellLink';
+import ItemDamageDone from 'Main/ItemDamageDone';
+
+class ExplosiveTrap extends Analyzer {
+
+  static dependencies = {
+    combatants: Combatants,
+    spellUsable: SpellUsable,
+  };
+
+  bonusDamage = 0;
+  casts = 0;
+
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.EXPLOSIVE_TRAP_CAST.id) {
+      return;
+    }
+    this.casts++;
+  }
+
+  on_byPlayer_damage(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.EXPLOSIVE_TRAP_DAMAGE.id) {
+      return;
+    }
+    if (this.casts === 0) {
+      this.casts++;
+      this.spellUsable.beginCooldown(SPELLS.EXPLOSIVE_TRAP_CAST.id);
+    }
+    this.bonusDamage += event.amount + (event.absorbed || 0);
+  }
+
+  subStatistic() {
+    return (
+      <div className="flex">
+        <div className="flex-main">
+          <SpellLink id={SPELLS.EXPLOSIVE_TRAP_DAMAGE.id}>
+            <SpellIcon id={SPELLS.EXPLOSIVE_TRAP_DAMAGE.id} noLink /> Explosive Trap
+          </SpellLink>
+        </div>
+        <div className="flex-sub text-right">
+          <ItemDamageDone amount={this.bonusDamage} />
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ExplosiveTrap;

--- a/src/Parser/Hunter/Survival/Modules/Talents/Caltrops.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/Caltrops.js
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import Analyzer from 'Parser/Core/Analyzer';
+import SpellIcon from 'common/SpellIcon';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import SpellUsable from 'Parser/Core/Modules/SpellUsable';
+import SpellLink from 'common/SpellLink';
+import ItemDamageDone from 'Main/ItemDamageDone';
+
+class Caltrops extends Analyzer {
+
+  static dependencies = {
+    combatants: Combatants,
+    spellUsable: SpellUsable,
+  };
+
+  bonusDamage = 0;
+  caltropsCasts = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.CALTROPS_TALENT.id);
+  }
+
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.CALTROPS_TALENT.id) {
+      return;
+    }
+    this.caltropsCasts++;
+  }
+
+  on_byPlayer_damage(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.CALTROPS_DAMAGE.id) {
+      return;
+    }
+    if (this.caltropsCasts === 0) {
+      this.caltropsCasts++;
+      this.spellUsable.beginCooldown(SPELLS.CALTROPS_TALENT.id);
+    }
+    this.bonusDamage += event.amount + (event.absorbed || 0);
+  }
+
+  subStatistic() {
+    return (
+      <div className="flex">
+        <div className="flex-main">
+          <SpellLink id={SPELLS.CALTROPS_TALENT.id}>
+            <SpellIcon id={SPELLS.CALTROPS_TALENT.id} noLink /> Caltrops
+          </SpellLink>
+        </div>
+        <div className="flex-sub text-right">
+          <ItemDamageDone amount={this.bonusDamage} />
+        </div>
+      </div>
+    );
+  }
+}
+
+export default Caltrops;

--- a/src/Parser/Hunter/Survival/Modules/Talents/SteelTrap.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/SteelTrap.js
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import Analyzer from 'Parser/Core/Analyzer';
+import SpellIcon from 'common/SpellIcon';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import SpellUsable from 'Parser/Core/Modules/SpellUsable';
+import SpellLink from 'common/SpellLink';
+import ItemDamageDone from 'Main/ItemDamageDone';
+
+class SteelTrap extends Analyzer {
+
+  static dependencies = {
+    combatants: Combatants,
+    spellUsable: SpellUsable,
+  };
+
+  bonusDamage = 0;
+  casts = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.STEEL_TRAP_TALENT.id);
+  }
+
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.STEEL_TRAP_TALENT.id) {
+      return;
+    }
+    this.casts++;
+  }
+
+  on_byPlayer_damage(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.STEEL_TRAP_DEBUFF.id) {
+      return;
+    }
+    if (this.casts === 0) {
+      this.casts++;
+      this.spellUsable.beginCooldown(SPELLS.STEEL_TRAP_TALENT.id);
+    }
+    this.bonusDamage += event.amount + (event.absorbed || 0);
+  }
+
+  subStatistic() {
+    return (
+      <div className="flex">
+        <div className="flex-main">
+          <SpellLink id={SPELLS.STEEL_TRAP_TALENT.id}>
+            <SpellIcon id={SPELLS.STEEL_TRAP_TALENT.id} noLink /> Steel Trap
+          </SpellLink>
+        </div>
+        <div className="flex-sub text-right">
+          <ItemDamageDone amount={this.bonusDamage} />
+        </div>
+      </div>
+    );
+  }
+}
+
+export default SteelTrap;

--- a/src/Parser/Hunter/Survival/Modules/Talents/WayOfTheMokNathal.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/WayOfTheMokNathal.js
@@ -81,11 +81,11 @@ class WayOfTheMokNathal extends Analyzer {
   }
 
   suggestions(when) {
-    when(this.timesDroppedThreshold).addSuggestion((suggest, actual, recommended) => {
+    when(this.timesDroppedThreshold).addSuggestion((suggest, actual) => {
       return suggest(<Wrapper>Try your best to maintain 4 stacks on <SpellLink id={SPELLS.MOKNATHAL_TACTICS.id} icon />. This can be achieved by casting <SpellLink id={SPELLS.RAPTOR_STRIKE.id} icon /> right before having to halt attacking for an extended period of time. </Wrapper>)
         .icon(SPELLS.WAY_OF_THE_MOKNATHAL_TALENT.icon)
-        .actual(`You dropped Mok'Nathals Tactic ${this._timesDropped} times`)
-        .recommended(`${recommended} is recommended`);
+        .actual(`You dropped Mok'Nathals Tactic ${actual} times`)
+        .recommended(`0 is recommended`);
     });
   }
 

--- a/src/common/SPELLS/HUNTER.js
+++ b/src/common/SPELLS/HUNTER.js
@@ -621,6 +621,16 @@ export default {
     name: 'Cobra Spit',
     icon: 'ability_creature_poison_02',
   },
+  STEEL_TRAP_DAMAGE: { //the event is a damage event, but it merely applies the debuff
+    id: 162480,
+    name: 'Steel Trap',
+    icon: 'inv_pet_pettrap02',
+  },
+  STEEL_TRAP_DEBUFF: {
+    id: 162487,
+    name: 'Steel Trap',
+    icon: 'inv_pet_pettrap02',
+  },
   //Survival traits:
   ECHOES_OF_OHNARA_TRAIT: {
     id: 238125,


### PR DESCRIPTION
Taking the approach as I did with Beast Mastery and Marksmanship hunters for some basic talent contribution statistics by making a list - this time around it includes a baseline spell in Explosive Trap, because it doesn't really deserve it's entire own statistic module, but I was fixing prepull events regardless so decided to add it, atleast for now. 

Log: https://www.warcraftlogs.com/reports/kN9d6pfYwgt4yDGJ/#fight=1&source=3
![image](https://user-images.githubusercontent.com/29204244/36074615-f760a58a-0f42-11e8-8cef-adcd53853a4c.png)


Example of prepull events not registering: 
Live: 
![image](https://user-images.githubusercontent.com/29204244/36074639-4161038c-0f43-11e8-9a52-41b1e29136a4.png)

Post-fix:
![image](https://user-images.githubusercontent.com/29204244/36074636-351da904-0f43-11e8-8221-7ff07049f4b8.png)

fixes #1216 