### PR TITLE
[resto druid] Fixed some Tree of Life bugs

### DIFF
--- a/src/Parser/Druid/Restoration/CHANGELOG.js
+++ b/src/Parser/Druid/Restoration/CHANGELOG.js
@@ -10,6 +10,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-02-11'),
+    changes: <Wrapper>Fixed a bug that could cause incorrect proc counts and uptimes for players using <SpellLink id={SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id} icon /> and <ItemLink id={ITEMS.CHAMELEON_SONG.id} icon /> together.</Wrapper>,
+    contributors: [sref],
+  },
+  {
     date: new Date('2018-02-03'),
     changes: 'Added a Checklist to the top of the page, which is a more organized and better explained version of the Suggestion system.',
     contributors: [sref],

--- a/src/Parser/Druid/Restoration/CombatLogParser.js
+++ b/src/Parser/Druid/Restoration/CombatLogParser.js
@@ -11,6 +11,7 @@ import WildGrowthNormalizer from './Normalizers/WildGrowth';
 import ClearcastingNormalizer from './Normalizers/ClearcastingNormalizer';
 import HotApplicationNormalizer from './Normalizers/HotApplicationNormalizer';
 import PotaNormalizer from './Normalizers/PotaNormalizer';
+import TreeOfLifeNormalizer from './Normalizers/TreeOfLifeNormalizer';
 
 import Checklist from './Modules/Features/Checklist';
 
@@ -96,6 +97,7 @@ class CombatLogParser extends CoreCombatLogParser {
     clearcastingNormalizer: ClearcastingNormalizer,
     potaNormalizer: PotaNormalizer,
     hotApplicationNormalizer: HotApplicationNormalizer, // this needs to be loaded after potaNormalizer, as potaNormalizer can sometimes unfix the events if loaded before...
+    treeOfLifeNormalizer: TreeOfLifeNormalizer,
 
     // Core
     healingDone: [HealingDone, { showStatistic: true }],

--- a/src/Parser/Druid/Restoration/Modules/Talents/TreeOfLife.js
+++ b/src/Parser/Druid/Restoration/Modules/Talents/TreeOfLife.js
@@ -138,7 +138,7 @@ class TreeOfLife extends Analyzer {
 
   on_byPlayer_applybuff(event) {
     const spellId = event.ability.guid;
-    if (spellId === SPELLS.INCARNATION.id) {
+    if (spellId === SPELLS.INCARNATION_TOL_ALLOWED.id) {
       this.lastTolApply = event.timestamp;
       if (event.prepull && this.hasTol) {
         this.lastTolCast = event.timestamp; // if player has ToL talent and buff was present on pull, assume it was from a precast
@@ -148,7 +148,7 @@ class TreeOfLife extends Analyzer {
 
   on_byPlayer_removebuff(event) {
     const spellId = event.ability.guid;
-    if (spellId === SPELLS.INCARNATION.id) {
+    if (spellId === SPELLS.INCARNATION_TOL_ALLOWED.id) {
       const buffUptime = event.timestamp - this.lastTolApply;
       // find out how much of this buff uptime was due to ToL and how much due to CS
       if (this.lastTolCast) {

--- a/src/Parser/Druid/Restoration/Modules/Talents/TreeOfLife.js
+++ b/src/Parser/Druid/Restoration/Modules/Talents/TreeOfLife.js
@@ -22,7 +22,7 @@ const ALL_MULT = 1.15;
 const REJUV_BOOST = 0.50;
 const REJUV_MANA_SAVED = 0.30;
 const REJUV_MANA_COST = 220000 * 0.1;
-const WG_INCREASE = (8 / 6) - 1; // TODO get more accuracy by implementing with attributor
+const WG_INCREASE = (8 / 6) - 1;
 const TOL_DURATION = 30000;
 const CS_DURATION = 12000;
 
@@ -138,7 +138,7 @@ class TreeOfLife extends Analyzer {
 
   on_byPlayer_applybuff(event) {
     const spellId = event.ability.guid;
-    if (spellId === SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id) {
+    if (spellId === SPELLS.INCARNATION.id) {
       this.lastTolApply = event.timestamp;
       if (event.prepull && this.hasTol) {
         this.lastTolCast = event.timestamp; // if player has ToL talent and buff was present on pull, assume it was from a precast
@@ -148,7 +148,7 @@ class TreeOfLife extends Analyzer {
 
   on_byPlayer_removebuff(event) {
     const spellId = event.ability.guid;
-    if (spellId === SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id) {
+    if (spellId === SPELLS.INCARNATION.id) {
       const buffUptime = event.timestamp - this.lastTolApply;
       // find out how much of this buff uptime was due to ToL and how much due to CS
       if (this.lastTolCast) {
@@ -184,13 +184,12 @@ class TreeOfLife extends Analyzer {
   get csUptimePercent() {
     return this.csUptime / this.owner.fightDuration;
   }
-  // CS always adds its duration without clipping, but could be clipped by fight end.
-  // Hopefully rounding will get me the right whole number! This is why I called it "estimated"
-  get estimatedCsProcs() {
-    return Math.round(this.csUptime / CS_DURATION);
+  get csProcs() {
+    const csUptimeRoundedToSeconds = Math.round(this.csUptime / 1000) * 1000; // rounding so that a few errant ms doesn't cause the following ceil to inproperly add a proc
+    return Math.ceil(csUptimeRoundedToSeconds / CS_DURATION); // ceil so that a proc cut off due to fight end or player death still counts as a proc
   }
   get estimatedCsProcRate() {
-    return (this.estimatedCsProcs / this.wgCasts) || 0;
+    return (this.csProcs / this.wgCasts) || 0;
   }
 
   _getManaSavedHealing(accumulator) {
@@ -260,7 +259,7 @@ class TreeOfLife extends Analyzer {
     return {
       item: ITEMS.CHAMELEON_SONG,
       result: (
-        <dfn data-tip={`The Tree of Life buff ${this.hasTol ? '(from procs only, not including Tree of Life casts) ' : ''}was active for <b>${(this.csUptime/1000).toFixed(0)}s</b>, or <b>${formatPercentage(this.csUptimePercent)}%</b> of the encounter. You got an estimated <b>${this.estimatedCsProcs} procs</b>, for a proc rate of <b>${formatPercentage(this.estimatedCsProcRate, 1)}%</b>. The displayed healing number ${this.hasTol ? 'includes healing from procs only, and ' : ''} is the sum of several benefits, listed below:
+        <dfn data-tip={`The Tree of Life buff ${this.hasTol ? '(from procs only, not including Tree of Life casts) ' : ''}was active for <b>${(this.csUptime/1000).toFixed(0)}s</b>, or <b>${formatPercentage(this.csUptimePercent)}%</b> of the encounter. You got <b>${this.csProcs} procs</b>, for a proc rate of <b>${formatPercentage(this.estimatedCsProcRate, 1)}%</b>. The displayed healing number ${this.hasTol ? 'includes healing from procs only, and ' : ''} is the sum of several benefits, listed below:
           <ul>
             <li>Overall Increased Healing: <b>${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.chameleonSong.allBoostHealing))}%</b></li>
             <li>Rejuv Increased Healing: <b>${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.chameleonSong.rejuvBoostHealing))}%</b></li>

--- a/src/Parser/Druid/Restoration/Normalizers/TreeOfLifeNormalizer.js
+++ b/src/Parser/Druid/Restoration/Normalizers/TreeOfLifeNormalizer.js
@@ -10,9 +10,9 @@ const MAX_DELAY = 200;
  * This can casue Incarnation cast events to show up in places we don't expect, and can throw off tracking and cast efficiency.
  *
  * Incarnation produces two buffs. The INCARNATION_TREE_OF_LIFE_TALENT id buff tracks if the player is in Incarnation form (as opposed to the other druid forms)
- * The INCARNATION id buff tracks if the player is ALLOWED to assume Incarnation form, this is applied both by the talent and the legendary.
- * We can discern real casts from form reassumption by checking for proximity to application of INCARNATION.
- * Casts that happen just before application of INCARNATION are real, all others are form reassumption.
+ * The INCARNATION_TOL_ALLOWED id buff tracks if the player is ALLOWED to assume Incarnation form, this is applied both by the talent and the legendary.
+ * We can discern real casts from form reassumption by checking for proximity to application of INCARNATION_TOL_ALLOWED.
+ * Casts that happen just before application of INCARNATION_TOL_ALLOWED are real, all others are form reassumption.
  *
  * This Normalizer deletes all the form reassumption events. Form can still be tracked using the INCARNATION_TREE_OF_LIFE_TALENT buff.
  */
@@ -26,15 +26,15 @@ class TreeOfLifeNormalizer extends EventsNormalizer {
       if (event.type === 'cast' && event.ability.guid === SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id) {
         const castTimestamp = event.timestamp;
 
-        // Look ahead through the events to see if there is an INCARNATION application within a brief buffer period
+        // Look ahead through the events to see if there is an INCARNATION_TOL_ALLOWED application within a brief buffer period
         for (let nextEventIndex = eventIndex; nextEventIndex < events.length-1; nextEventIndex += 1) {
           const nextEvent = events[nextEventIndex];
           if ((nextEvent.timestamp - castTimestamp) > MAX_DELAY) {
-            // No INCARNATION application found within buffer, meaining this is a form reassumption: delete the event
+            // No INCARNATION_TOL_ALLOWED application found within buffer, meaining this is a form reassumption: delete the event
             fixedEvents.pop();
             break;
-          } else if (nextEvent.type === 'applybuff' && nextEvent.ability.guid === SPELLS.INCARNATION.id) {
-            // INCARNATION application found, this cast event stays
+          } else if (nextEvent.type === 'applybuff' && nextEvent.ability.guid === SPELLS.INCARNATION_TOL_ALLOWED.id) {
+            // INCARNATION_TOL_ALLOWED application found, this cast event stays
             break;
           }
         }

--- a/src/Parser/Druid/Restoration/Normalizers/TreeOfLifeNormalizer.js
+++ b/src/Parser/Druid/Restoration/Normalizers/TreeOfLifeNormalizer.js
@@ -1,0 +1,48 @@
+import EventsNormalizer from 'Parser/Core/EventsNormalizer';
+
+import SPELLS from 'common/SPELLS';
+
+const MAX_DELAY = 200;
+
+/*
+ * The Incarnation: Tree of Life talent can show strangely in events.
+ * a 'cast' with INCARNATION_TREE_OF_LIFE_TALENT id shows up on activating the talent, BUT ALSO ON REAQUIRING THE FORM DURING THE BUFF.
+ * This can casue Incarnation cast events to show up in places we don't expect, and can throw off tracking and cast efficiency.
+ *
+ * Incarnation produces two buffs. The INCARNATION_TREE_OF_LIFE_TALENT id buff tracks if the player is in Incarnation form (as opposed to the other druid forms)
+ * The INCARNATION id buff tracks if the player is ALLOWED to assume Incarnation form, this is applied both by the talent and the legendary.
+ * We can discern real casts from form reassumption by checking for proximity to application of INCARNATION.
+ * Casts that happen just before application of INCARNATION are real, all others are form reassumption.
+ *
+ * This Normalizer deletes all the form reassumption events. Form can still be tracked using the INCARNATION_TREE_OF_LIFE_TALENT buff.
+ */
+class TreeOfLifeNormalizer extends EventsNormalizer {
+
+  normalize(events) {
+    const fixedEvents = [];
+    events.forEach((event, eventIndex) => {
+      fixedEvents.push(event);
+
+      if (event.type === 'cast' && event.ability.guid === SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id) {
+        const castTimestamp = event.timestamp;
+
+        // Look ahead through the events to see if there an INCARNATION application within a brief buffer period
+        for (let nextEventIndex = eventIndex; nextEventIndex < events.length-1; nextEventIndex += 1) {
+          const nextEvent = events[nextEventIndex];
+          if ((nextEvent.timestamp - castTimestamp) > MAX_DELAY) {
+            // No INCARNATION application found within buffer, meaining this is a form reassumption: delete the event
+            fixedEvents.pop();
+            break;
+          } else if (nextEvent.type === 'applybuff' && nextEvent.ability.guid === SPELLS.INCARNATION.id) {
+            // INCARNATION application found, this cast event stays
+            break;
+          }
+        }
+      }
+    });
+
+    return fixedEvents;
+  }
+
+}
+export default TreeOfLifeNormalizer;

--- a/src/Parser/Druid/Restoration/Normalizers/TreeOfLifeNormalizer.js
+++ b/src/Parser/Druid/Restoration/Normalizers/TreeOfLifeNormalizer.js
@@ -26,7 +26,7 @@ class TreeOfLifeNormalizer extends EventsNormalizer {
       if (event.type === 'cast' && event.ability.guid === SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id) {
         const castTimestamp = event.timestamp;
 
-        // Look ahead through the events to see if there an INCARNATION application within a brief buffer period
+        // Look ahead through the events to see if there is an INCARNATION application within a brief buffer period
         for (let nextEventIndex = eventIndex; nextEventIndex < events.length-1; nextEventIndex += 1) {
           const nextEvent = events[nextEventIndex];
           if ((nextEvent.timestamp - castTimestamp) > MAX_DELAY) {

--- a/src/common/SPELLS/DRUID.js
+++ b/src/common/SPELLS/DRUID.js
@@ -252,6 +252,13 @@ export default {
     name: 'Soul of the Forest',
     icon: 'ability_druid_manatree',
   },
+  // This buff indicates if the player is ABLE to assume Incarnation: Tree of Life form.
+  // Actually BEING in the form is indicated by the INCARNATION_TREE_OF_LIFE_TALENT id.
+  INCARNATION: {
+    id: 117679,
+    name: 'Incarnation',
+    icon: 'spell_druid_incarnation',
+  },
 
   // Sets/Items:
   // Hidden buffs that indicate set is equipped:

--- a/src/common/SPELLS/DRUID.js
+++ b/src/common/SPELLS/DRUID.js
@@ -254,7 +254,7 @@ export default {
   },
   // This buff indicates if the player is ABLE to assume Incarnation: Tree of Life form.
   // Actually BEING in the form is indicated by the INCARNATION_TREE_OF_LIFE_TALENT id.
-  INCARNATION: {
+  INCARNATION_TOL_ALLOWED: {
     id: 117679,
     name: 'Incarnation',
     icon: 'spell_druid_incarnation',


### PR DESCRIPTION
In some circumstances, Tree of Life could generate extra casts events, so I added a Normalizer to remove them. For the gritty details, see my documentation in the Normalizer.

Also made the CS proc count calculator less dumb, it should no longer under count if the fight ends during a proc.

Finally, made the reported uptime be the amount of time the player was allowed to be in the form rather than the time the player was actually in form. This may seem odd, but some of a resto's movement / defensive abilities cause the player to briefly drop form, and it was making the numbers look confusing / weird.

Fixes #1369