### PR TITLE
[Discipline Priest] Removed Suggestion for Penance

### DIFF
--- a/src/Parser/Priest/Discipline/Modules/Abilities.js
+++ b/src/Parser/Priest/Discipline/Modules/Abilities.js
@@ -18,11 +18,6 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.PENANCE,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         cooldown: 9,
-        castEfficiency: {
-          suggestion: true,
-          casts: (_, parser) => parser.modules.penance.casts,
-          maxCasts: (cooldown, fightDuration) => calculateMaxCasts(cooldown, fightDuration), // temp until bolts past first can be ignored by cast checker
-        },
       },
       {
         spell: SPELLS.POWER_WORD_RADIANCE,


### PR DESCRIPTION
After talking with the disc priest community, we all came to the conclusion that with the new T21, Penance should not be used on cooldown like it should have been before. 

Removing the suggestion for now but will be doing some work on suggesting to at least do 1 penance after each radiance in another PR