### PR TITLE
[Frost Death Knight] Fixed crash with classResources in T20 file

### DIFF
--- a/src/Parser/DeathKnight/Frost/Modules/Items/Tier20_2p.js
+++ b/src/Parser/DeathKnight/Frost/Modules/Items/Tier20_2p.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+import RESOURCE_TYPES from 'common/RESOURCE_TYPES';
 
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
@@ -46,17 +47,23 @@ class Tier20_2p extends Analyzer {
   }
 
   on_byPlayer_cast(event){
-    const resource = event.classResources[0];
-    if(resource.type !== 6 || this.pillarActive === false){
+    if(this.pillarActive === false){
       return;
     }
-    this.rpBanked = resource.hasOwnProperty("cost") ? this.rpBanked + resource.cost: this.rpBanked;
-    if(this.rpBanked >= 600){
-      this.rpBanked -= 600;
-      this.currentAddedDuration += 1000;
+    if (event.classResources) {
+      event.classResources
+      .filter(resource => resource.type === RESOURCE_TYPES.RUNIC_POWER.id)
+      .forEach(({ cost }) => {  
+        if(cost){   
+          this.rpBanked += cost;
+          if(this.rpBanked >= 600){
+            this.rpBanked -= 600;
+            this.currentAddedDuration += 1000;
+          }
+        }
+      });      
     }
   }
-
 
   on_byPlayer_damage(event){ // BoS only shows up as damage events with no classResource prop but it ticks 1/sec and costs 15rp/sec so i can get the rp spent
     const spellId = event.ability.guid;


### PR DESCRIPTION
Fixes a crash that occurs with odd melee casts in logs with the T20 2p bonus.  I also verified that classResources[0] is no longer used anywhere in the Frost modules