### PR TITLE
[Retribution] Abilities update

### DIFF
--- a/src/Parser/Paladin/Retribution/Modules/Abilities.js
+++ b/src/Parser/Paladin/Retribution/Modules/Abilities.js
@@ -18,6 +18,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.WAKE_OF_ASHES,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 30,
+        isOnGCD: true,
         enabled: !combatant.hasShoulder(ITEMS.ASHES_TO_DUST.id),
         castEfficiency: {
           suggestion: true,
@@ -29,6 +30,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.WAKE_OF_ASHES,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 30,
+        isOnGCD: true,
         enabled: combatant.hasShoulder(ITEMS.ASHES_TO_DUST.id),
         castEfficiency: {
           suggestion: true,
@@ -63,6 +65,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.HOLY_WRATH_TALENT,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 180,
+        isOnGCD: true,
         enabled: combatant.hasTalent(SPELLS.HOLY_WRATH_TALENT.id),
         castEfficiency: {
           suggestion: true,
@@ -73,6 +76,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         charges: 2,
         cooldown: haste => 3.5 / (1 + haste),
+        isOnGCD: true,
         enabled: combatant.hasTalent(SPELLS.THE_FIRES_OF_JUSTICE_TALENT.id),
         castEfficiency: {
           suggestion: true,
@@ -83,6 +87,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         charges: 2,
         cooldown: haste => 4.5 / (1 + haste),
+        isOnGCD: true,
         enabled: combatant.hasTalent(SPELLS.GREATER_JUDGMENT_TALENT.id),
         castEfficiency: {
           suggestion: true,
@@ -93,6 +98,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         charges: 2,
         cooldown: haste => 4.5 / (1 + haste),
+        isOnGCD: true,
         enabled: combatant.hasTalent(SPELLS.ZEAL_TALENT.id),
         castEfficiency: {
           suggestion: true,
@@ -102,6 +108,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.JUDGMENT_CAST,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         cooldown: haste => 12 / (1 + haste),
+        isOnGCD: true,
         enabled: (!combatant.hasBuff(SPELLS.RET_PALADIN_T20_2SET_BONUS.id) && !combatant.hasBuff(SPELLS.RET_PALADIN_T21_2SET_BONUS.id)),
         castEfficiency: {
           suggestion: true,
@@ -112,6 +119,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.JUDGMENT_CAST,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         cooldown: haste => 12 / (1 + haste),
+        isOnGCD: true,
         enabled: (combatant.hasBuff(SPELLS.RET_PALADIN_T20_2SET_BONUS.id) || combatant.hasBuff(SPELLS.RET_PALADIN_T21_2SET_BONUS.id)),
         castEfficiency: {
           suggestion: true,
@@ -123,6 +131,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.BLADE_OF_JUSTICE,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         cooldown: haste => 10.5 / (1 + haste),
+        isOnGCD: true,
         enabled: !combatant.hasTalent(SPELLS.DIVINE_HAMMER_TALENT.id),
         castEfficiency: {
           suggestion: true,
@@ -132,6 +141,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.DIVINE_HAMMER_TALENT,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         cooldown: haste => 12 / (1 + haste),
+        isOnGCD: true,
         enabled: combatant.hasTalent(SPELLS.DIVINE_HAMMER_TALENT.id),
         castEfficiency: {
           suggestion: true,
@@ -140,15 +150,18 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.TEMPLARS_VERDICT,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        isOnGCD: true,
       },
       {
         spell: SPELLS.DIVINE_STORM,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        isOnGCD: true,
       },
       {
         spell: SPELLS.EXECUTION_SENTENCE_TALENT,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         cooldown: haste => 20 / (1 + haste),
+        isOnGCD: true,
         enabled: combatant.hasTalent(SPELLS.EXECUTION_SENTENCE_TALENT.id),
         castEfficiency: {
           suggestion: true,
@@ -167,17 +180,38 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.JUSTICARS_VENGEANCE_TALENT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
+        isOnGCD: true,
         enabled: combatant.hasTalent(SPELLS.JUSTICARS_VENGEANCE_TALENT.id),
       },
       {
         spell: SPELLS.EYE_FOR_AN_EYE_TALENT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: haste => 60,
+        isOnGCD: true,
         enabled: combatant.hasTalent(SPELLS.EYE_FOR_AN_EYE_TALENT.id),
       },
       {
         spell: SPELLS.WORD_OF_GLORY_TALENT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
+        isOnGCD: true,
         enabled: combatant.hasTalent(SPELLS.WORD_OF_GLORY_TALENT.id),
+      },
+      {
+        spell: SPELLS.DIVINE_STEED,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        charges: combatant.hasTalent(SPELLS.CAVALIER_TALENT.id) ? 2 : 1,
+        cooldown: haste => 45,
+        isOnGCD: true,
+      },
+      {
+        spell: SPELLS.LAY_ON_HANDS,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: 600,
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.1,
+          importance: ISSUE_IMPORTANCE.MINOR,
+        },
       },
       {
         spell: SPELLS.ARCANE_TORRENT_MANA,

--- a/src/Parser/Paladin/Retribution/Modules/Abilities.js
+++ b/src/Parser/Paladin/Retribution/Modules/Abilities.js
@@ -168,9 +168,20 @@ class Abilities extends CoreAbilities {
         },
       },
       {
+        spell: SPELLS.CONSECRATION_TALENT,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        cooldown: haste => 12 / (1 + haste),
+        isOnGCD: true,
+        enabled: combatant.hasTalent(SPELLS.CONSECRATION_TALENT.id),
+        castEfficiency: {
+          suggestion: true,
+        },
+      },
+      //Utility
+      {
         spell: SPELLS.SHIELD_OF_VENGEANCE,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        cooldown: (haste, combatant) => 120 - (combatant.traitsBySpellId[SPELLS.DEFLECTION.id] || 0) * 10,
+        cooldown: ( _, combatant) => 120 - (combatant.traitsBySpellId[SPELLS.DEFLECTION.id] || 0) * 10,
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.5,
@@ -186,7 +197,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.EYE_FOR_AN_EYE_TALENT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        cooldown: haste => 60,
+        cooldown: 60,
         isOnGCD: true,
         enabled: combatant.hasTalent(SPELLS.EYE_FOR_AN_EYE_TALENT.id),
       },
@@ -197,10 +208,24 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(SPELLS.WORD_OF_GLORY_TALENT.id),
       },
       {
+        spell: SPELLS.BLINDING_LIGHT_TALENT,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: 90,
+        isOnGCD: true,
+        enabled: combatant.hasTalent(SPELLS.BLINDING_LIGHT_TALENT.id),
+      },
+      {
+        spell: SPELLS.REPENTANCE_TALENT,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: 15,
+        isOnGCD: true,
+        enabled: combatant.hasTalent(SPELLS.REPENTANCE_TALENT.id),
+      },
+      {
         spell: SPELLS.DIVINE_STEED,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         charges: combatant.hasTalent(SPELLS.CAVALIER_TALENT.id) ? 2 : 1,
-        cooldown: haste => 45,
+        cooldown: 45,
         isOnGCD: true,
       },
       {
@@ -208,10 +233,41 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 600,
         castEfficiency: {
-          suggestion: true,
           recommendedEfficiency: 0.1,
-          importance: ISSUE_IMPORTANCE.MINOR,
         },
+      },
+      {
+        spell: SPELLS.BLESSING_OF_FREEDOM,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: 25,
+        isOnGCD: true,
+      },
+      {
+        spell: SPELLS.BLESSING_OF_PROTECTION,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: ( _, combatant) => 300 - (combatant.traitsBySpellId[SPELLS.PROTECTOR_OF_THE_ASHEN_BLADE.id] || 0) * 30 ,
+        isOnGCD: true,
+      },
+      {
+        spell: SPELLS.HAMMER_OF_JUSTICE,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: 60,
+      },
+      {
+        spell: SPELLS.HAND_OF_RECKONING,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: 8,
+      },
+      {
+        spell: SPELLS.DIVINE_SHIELD,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: combatant.hasTalent(SPELLS.DIVINE_INTERVENTION_TALENT.id) ? 300 : 240,
+        isOnGCD: true, 
+      },
+      {
+        spell: SPELLS.FLASH_OF_LIGHT,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        isOnGCD: true,
       },
       {
         spell: SPELLS.ARCANE_TORRENT_MANA,

--- a/src/Parser/Paladin/Retribution/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Paladin/Retribution/Modules/Features/AlwaysBeCasting.js
@@ -10,41 +10,6 @@ import CoreAlwaysBeCasting from 'Parser/Core/Modules/AlwaysBeCasting';
 import { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class AlwaysBeCasting extends CoreAlwaysBeCasting {
-  static ABILITIES_ON_GCD = [
-    // Holy Power Builders
-    SPELLS.CRUSADER_STRIKE.id,
-    SPELLS.ZEAL_TALENT.id,
-    SPELLS.BLADE_OF_JUSTICE.id,
-    SPELLS.DIVINE_HAMMER_TALENT.id,
-    SPELLS.WAKE_OF_ASHES.id,
-
-    // Holy Power Spenders
-    SPELLS.TEMPLARS_VERDICT.id,
-    SPELLS.DIVINE_STORM.id,
-    SPELLS.EXECUTION_SENTENCE_TALENT.id,
-    SPELLS.JUSTICARS_VENGEANCE_TALENT.id,
-    SPELLS.WORD_OF_GLORY_TALENT.id,
-
-    // Other DPS Abilities
-    SPELLS.JUDGMENT_CAST.id,
-    SPELLS.CONSECRATION_TALENT.id,
-    SPELLS.HOLY_WRATH_TALENT.id,
-
-    // Utility
-    SPELLS.DIVINE_STEED.id,
-    SPELLS.BLINDING_LIGHT_TALENT.id,
-    SPELLS.REPENTANCE_TALENT.id,
-    SPELLS.EYE_FOR_AN_EYE_TALENT.id,
-    SPELLS.FLASH_OF_LIGHT.id,
-    225141, // http://www.wowhead.com/spell=225141/fel-crazed-rage (Draught of Souls)
-    SPELLS.DIVINE_STEED.id,
-    SPELLS.DIVINE_SHIELD.id,
-    SPELLS.BLESSING_OF_FREEDOM.id,
-    SPELLS.BLESSING_OF_PROTECTION.id,
-    SPELLS.HAMMER_OF_JUSTICE.id,
-    SPELLS.HAND_OF_RECKONING.id,
-  ];
-
   get suggestionThresholds() {
     return {
       actual: this.downtimePercentage,

--- a/src/Parser/Paladin/Retribution/Modules/Features/Checklist.js
+++ b/src/Parser/Paladin/Retribution/Modules/Features/Checklist.js
@@ -156,21 +156,11 @@ class Checklist extends CoreChecklist {
 	        new GenericCastEfficiencyRequirement({
 	          spell: SPELLS.SHIELD_OF_VENGEANCE,
 	        }),
-	        new Requirement({
-				  	name: <Wrapper> <SpellLink id={SPELLS.LAY_ON_HANDS.id} icon/> </Wrapper>,
-						check: () => ({
-							actual: this.abilityTracker.getAbility(SPELLS.LAY_ON_HANDS.id).casts,
-							isLessThan:
-	            {
-	              major: 0,
-	              average: 1,
-	              minor: 1,
-	            },
-							style: 'number',
-						}),
+	        new GenericCastEfficiencyRequirement({
+            spell: SPELLS.LAY_ON_HANDS,
 					}),
           new Requirement({
-            name: <Wrapper> <SpellLink id={SPELLS.BLESSING_OF_THE_ASHBRINGER_BUFF.id} icon/> </Wrapper>,
+            name: <Wrapper> <SpellLink id={SPELLS.BLESSING_OF_THE_ASHBRINGER_BUFF.id} icon/></Wrapper>,
             check: () => this.bota.suggestionThresholds,
           }),
         ];

--- a/src/common/SPELLS/PALADIN.js
+++ b/src/common/SPELLS/PALADIN.js
@@ -483,6 +483,11 @@ export default {
     name: 'Blessing of the Ashbringer',
     icon: 'inv_sword_2h_artifactashbringer_d_01',
   },
+  PROTECTOR_OF_THE_ASHEN_BLADE: {
+    id: 186944,
+    name: 'Protector of the Ashen Blade',
+    icon: 'spell_holy_sealofprotection',
+  },
 
 	// Protection
   ARDENT_DEFENDER: {


### PR DESCRIPTION
removed the array of the abilities on the GCD from the cast efficiency and added the isOnGcd value to all the abilities. Also updated the abilities to include all utility spells. Also updated the lay on hands checklist value to a cast efficiency with a low requirement. There are a lot of additions but its mostly added isOnGcd.
current:
![image](https://user-images.githubusercontent.com/19510201/36336646-5fbce5b6-134f-11e8-8686-cfbbf6742a62.png)
updated:
![image](https://user-images.githubusercontent.com/19510201/36336679-8a09e7d8-134f-11e8-8bdd-6de7a57d8881.png)

test log: https://www.warcraftlogs.com/reports/Dyb9GFz4XR3LZaBM#fight=1&type=summary
