### PR TITLE
[Arcane Mage] Arcane Missiles Module

### DIFF
--- a/src/Parser/Mage/Arcane/CombatLogParser.js
+++ b/src/Parser/Mage/Arcane/CombatLogParser.js
@@ -5,6 +5,9 @@ import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
 import Abilities from './Modules/Features/Abilities';
 import CooldownThroughputTracker from './Modules/Features/CooldownThroughputTracker';
 import Channeling from './Modules/Features/Channeling';
+
+import ArcaneMissiles from './Modules/Features/ArcaneMissiles';
+
 import CancelledCasts from '../Shared/Modules/Features/CancelledCasts';
 import MirrorImage from '../Shared/Modules/Features/MirrorImage';
 import UnstableMagic from '../Shared/Modules/Features/UnstableMagic';
@@ -19,6 +22,7 @@ class CombatLogParser extends CoreCombatLogParser {
     damageDone: [DamageDone, { showStatistic: true }],
     channeling: Channeling,
     cancelledCasts: CancelledCasts,
+    arcaneMissiles: ArcaneMissiles,
 
     // Talents
     mirrorImage: MirrorImage,

--- a/src/Parser/Mage/Arcane/Modules/Features/ArcaneMissiles.js
+++ b/src/Parser/Mage/Arcane/Modules/Features/ArcaneMissiles.js
@@ -50,7 +50,7 @@ class ArcaneMissiles extends Analyzer {
 				return suggest(<Wrapper>You cast <SpellLink id={SPELLS.ARCANE_BARRAGE.id}/> {this.barrageWithMissilesProc} times while you had <SpellLink id={SPELLS.ARCANE_MISSILES.id}/> procs available. Make sure you are using all of your missiles procs before casting Arcane Barrage.</Wrapper>)
 					.icon(SPELLS.ARCANE_MISSILES.icon)
 					.actual(`${formatPercentage(this.utilization)}% Utilization`)
-					.recommended(`Letting none expire is recommended`);
+					.recommended(`${formatPercentage(recommended)}% is recommended`);
 			});
 	}
 }

--- a/src/Parser/Mage/Arcane/Modules/Features/ArcaneMissiles.js
+++ b/src/Parser/Mage/Arcane/Modules/Features/ArcaneMissiles.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import Wrapper from 'common/Wrapper';
+import { formatPercentage } from 'common/format';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
+import Analyzer from 'Parser/Core/Analyzer';
+
+class ArcaneMissiles extends Analyzer {
+	static dependencies = {
+		combatants: Combatants,
+		abilityTracker: AbilityTracker,
+  };
+
+	barrageWithMissilesProc = 0;
+
+	on_byPlayer_cast(event) {
+		const spellId = event.ability.guid;
+		if (spellId !== SPELLS.ARCANE_BARRAGE.id) {
+			return;
+		}
+		if (this.combatants.selected.hasBuff(SPELLS.ARCANE_MISSILES_BUFF.id)) {
+			this.barrageWithMissilesProc += 1;
+		}
+	}
+
+	get utilization() {
+		return 1 - (this.barrageWithMissilesProc / this.abilityTracker.getAbility(SPELLS.ARCANE_BARRAGE.id).casts);
+	}
+
+	get suggestionThresholds() {
+    return {
+      actual: this.utilization,
+      isLessThan: {
+        minor: 0.95,
+        average: 0.90,
+        major: 0.80,
+      },
+      style: 'percentage',
+    };
+  }
+
+	suggestions(when) {
+		when(this.suggestionThresholds)
+			.addSuggestion((suggest, actual, recommended) => {
+				return suggest(<Wrapper>You cast <SpellLink id={SPELLS.ARCANE_BARRAGE.id}/> {this.barrageWithMissilesProc} times while you had <SpellLink id={SPELLS.ARCANE_MISSILES.id}/> procs available. Make sure you are using all of your missiles procs before casting Arcane Barrage.</Wrapper>)
+					.icon(SPELLS.ARCANE_MISSILES.icon)
+					.actual(`${formatPercentage(this.utilization)}% Utilization`)
+					.recommended(`Letting none expire is recommended`);
+			});
+	}
+}
+
+export default ArcaneMissiles;

--- a/src/Parser/Mage/Arcane/Modules/Features/ArcaneMissiles.js
+++ b/src/Parser/Mage/Arcane/Modules/Features/ArcaneMissiles.js
@@ -2,10 +2,12 @@ import React from 'react';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';
-import { formatPercentage } from 'common/format';
+import { formatPercentage, formatMilliseconds } from 'common/format';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
 import Analyzer from 'Parser/Core/Analyzer';
+
+const debug = false;
 
 class ArcaneMissiles extends Analyzer {
 	static dependencies = {
@@ -20,7 +22,8 @@ class ArcaneMissiles extends Analyzer {
 		if (spellId !== SPELLS.ARCANE_BARRAGE.id) {
 			return;
 		}
-		if (this.combatants.selected.hasBuff(SPELLS.ARCANE_MISSILES_BUFF.id)) {
+		if (this.combatants.selected.hasBuff(SPELLS.ARCANE_MISSILES_BUFF.id,event.timestamp - 100)) {
+			debug && console.log("Arcane Barrage with Missiles Procs @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
 			this.barrageWithMissilesProc += 1;
 		}
 	}


### PR DESCRIPTION
Checks to ensure that the player doesnt have the Arcane Missiles buff when they cast Barrage as they should be using all of their missiles procs before they cast barrage.