### PR TITLE
[Hunter] More cleaning and Caltrops module

### DIFF
--- a/src/Parser/Hunter/BeastMastery/CHANGELOG.js
+++ b/src/Parser/Hunter/BeastMastery/CHANGELOG.js
@@ -9,6 +9,11 @@ import ITEMS from 'common/ITEMS';
 
 export default [
   {
+    date: new Date('2018-02-20'),
+    changes: 'Spring cleaning in many modules. Added icons to Focus Usage modules and elsewhere around the analyzer',
+    contributors: [Putro],
+  },
+  {
     date: new Date('2018-02-05'),
     changes: <Wrapper>Added additional information to the <ItemLink id={ITEMS.CALL_OF_THE_WILD.id} icon /> module, to show cooldown reduction on the various affected spells. </Wrapper>,
     contributors: [Putro],

--- a/src/Parser/Hunter/BeastMastery/CHANGELOG.js
+++ b/src/Parser/Hunter/BeastMastery/CHANGELOG.js
@@ -60,12 +60,12 @@ export default [
   },
   {
     date: new Date('2017-12-03'),
-    changes: 'Upgraded spec completeness to good, added t192p support, added t21 support and added a suggestion for Killer Cobra',
+    changes: <Wrapper>Upgraded spec completeness to good, added <SpellLink id={SPELLS.HUNTER_BM_T19_2P_BONUS.id} icon /> support, added <SpellLink id={SPELLS.HUNTER_BM_T21_2P_BONUS.id} icon /> and <SpellLink id={SPELLS.HUNTER_BM_T21_4P_BONUS.id} icon /> support and added a suggestion for <SpellLink id={SPELLS.KILLER_COBRA_TALENT.id} icon />.</Wrapper>,
     contributors: [Putro],
   },
   {
     date: new Date('2017-11-01'),
-    changes: 'Added Mark of the claw, Bestial Wrath modules, Dire Beast modules, Qapla module, Titan\'s Thunder module, Killer Cobra module.',
+    changes: <Wrapper>Added <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon /> modules, <SpellLink id={SPELLS.DIRE_BEAST.id} icon /> modules, <ItemLink id={ITEMS.QAPLA_EREDUN_WAR_ORDER.id} icon /> module, <SpellLink id={SPELLS.TITANS_THUNDER.id} icon /> module, <SpellLink id={SPELLS.KILLER_COBRA_TALENT.id} icon /> module.</Wrapper>,
     contributors: [Putro],
   },
   {

--- a/src/Parser/Hunter/BeastMastery/Modules/Abilities.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Abilities.js
@@ -14,13 +14,29 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         cooldown: 60,
         isOnGCD: false,
-        enabled: this.combatants.selected.traitsBySpellId[SPELLS.TITANS_THUNDER.id],
+        enabled: this.combatants.selected.traitsBySpellId[SPELLS.TITANS_THUNDER.id] && !this.combatants.selected.hasTalent(SPELLS.DIRE_FRENZY_TALENT.id),
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.9,
           extraSuggestion: (
             <Wrapper>
-              <SpellLink id={SPELLS.TITANS_THUNDER.id} icon /> should always be cast when you have <SpellLink id={SPELLS.DIRE_BEAST_BUFF.id} icon /> buff up, try to cast it right after using a <SpellLink id={SPELLS.DIRE_BEAST.id} icon /> for maximum efficiency. If you have <SpellLink id={SPELLS.DIRE_FRENZY_TALENT.id} icon /> talented, you should cast <SpellLink id={SPELLS.TITANS_THUNDER.id} /> within <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon /> so long as you can get off a <SpellLink id={SPELLS.DIRE_FRENZY_TALENT.id} icon /> cast with it while <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon /> is still up.
+              <SpellLink id={SPELLS.TITANS_THUNDER.id} icon /> should always be cast when you have <SpellLink id={SPELLS.DIRE_BEAST_BUFF.id} icon /> buff up, try to cast it right after using a <SpellLink id={SPELLS.DIRE_BEAST.id} icon /> for maximum efficiency.
+            </Wrapper>
+          ),
+        },
+      },
+      {
+        spell: SPELLS.TITANS_THUNDER,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        cooldown: 60,
+        isOnGCD: false,
+        enabled: this.combatants.selected.traitsBySpellId[SPELLS.TITANS_THUNDER.id] && this.combatants.selected.hasTalent(SPELLS.DIRE_FRENZY_TALENT.id),
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.9,
+          extraSuggestion: (
+            <Wrapper>
+              Since you have <SpellLink id={SPELLS.DIRE_FRENZY_TALENT.id} icon /> talented, you should cast <SpellLink id={SPELLS.TITANS_THUNDER.id} /> within <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon /> so long as you can get off a <SpellLink id={SPELLS.DIRE_FRENZY_TALENT.id} icon /> cast while <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon /> is still up.
             </Wrapper>
           ),
         },

--- a/src/Parser/Hunter/BeastMastery/Modules/Abilities.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Abilities.js
@@ -20,7 +20,7 @@ class Abilities extends CoreAbilities {
           recommendedEfficiency: 0.9,
           extraSuggestion: (
             <Wrapper>
-              <SpellLink id={SPELLS.TITANS_THUNDER.id} /> should always be cast when you have <SpellLink id={SPELLS.DIRE_BEAST_BUFF.id} /> buff up, try to cast it right after using a <SpellLink id={SPELLS.DIRE_BEAST.id} /> for maximum efficiency. If you have <SpellLink id={SPELLS.DIRE_FRENZY_TALENT.id} /> talented, you should cast <SpellLink id={SPELLS.TITANS_THUNDER.id} /> within <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon /> so long as you can get off a <SpellLink id={SPELLS.DIRE_FRENZY_TALENT.id} /> cast with it while <SpellLink id={SPELLS.BESTIAL_WRATH.id} /> is still up.
+              <SpellLink id={SPELLS.TITANS_THUNDER.id} icon /> should always be cast when you have <SpellLink id={SPELLS.DIRE_BEAST_BUFF.id} icon /> buff up, try to cast it right after using a <SpellLink id={SPELLS.DIRE_BEAST.id} icon /> for maximum efficiency. If you have <SpellLink id={SPELLS.DIRE_FRENZY_TALENT.id} icon /> talented, you should cast <SpellLink id={SPELLS.TITANS_THUNDER.id} /> within <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon /> so long as you can get off a <SpellLink id={SPELLS.DIRE_FRENZY_TALENT.id} icon /> cast with it while <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon /> is still up.
             </Wrapper>
           ),
         },
@@ -35,7 +35,7 @@ class Abilities extends CoreAbilities {
           recommendedEfficiency: 1,
           extraSuggestion: (
             <Wrapper>
-              <SpellLink id={SPELLS.BESTIAL_WRATH.id} /> should be cast on cooldown as its cooldown is quickly reset again through <SpellLink id={SPELLS.DIRE_BEAST.id} />. You want to start each <SpellLink id={SPELLS.BESTIAL_WRATH.id} /> window with as much focus as possible.
+              <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon /> should be cast on cooldown as its cooldown is quickly reset again through <SpellLink id={SPELLS.DIRE_BEAST.id} icon />. You want to start each <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon /> window with as much focus as possible.
             </Wrapper>
           ),
         },
@@ -97,7 +97,7 @@ class Abilities extends CoreAbilities {
           recommendedEfficiency: 0.9,
           extraSuggestion: (
             <Wrapper>
-              You should be casting <SpellLink id={SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.id} /> on cooldown unless <SpellLink id={SPELLS.BESTIAL_WRATH.id} /> has less than 30 seconds remaining on CD, in which case you can delay it slightly to line them up. It will dynamically update its damage to reflect damage increases such as <SpellLink id={SPELLS.BESTIAL_WRATH.id} />.
+              You should be casting <SpellLink id={SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.id} icon /> on cooldown unless <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon /> has less than 30 seconds remaining on CD, in which case you can delay it slightly to line them up. It will dynamically update its damage to reflect damage increases such as <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon />.
             </Wrapper>
           ),
         },
@@ -112,7 +112,7 @@ class Abilities extends CoreAbilities {
           recommendedEfficiency: 0.8,
           extraSuggestion: (
             <Wrapper>
-              <SpellLink id={SPELLS.ASPECT_OF_THE_WILD.id} /> should always be cast in conjunction with <SpellLink id={SPELLS.BESTIAL_WRATH.id} /> to maximize the potency of these increased damage windows.
+              <SpellLink id={SPELLS.ASPECT_OF_THE_WILD.id} icon /> should always be cast in conjunction with <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon /> to maximize the potency of these increased damage windows.
             </Wrapper>
           ),
         },

--- a/src/Parser/Hunter/BeastMastery/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Features/AlwaysBeCasting.js
@@ -30,7 +30,7 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
   suggestions(when) {
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
         return suggest(
-          <Wrapper>Your downtime can be improved. Try to reduce the delay between casting spells. If everything is on cooldown, try and use <SpellLink id={SPELLS.COBRA_SHOT.id} /> to stay off the focus cap and do some damage.
+          <Wrapper>Your downtime can be improved. Try to reduce the delay between casting spells. If everything is on cooldown, try and use <SpellLink id={SPELLS.COBRA_SHOT.id} icon /> to stay off the focus cap and do some damage.
           </Wrapper>)
           .icon('spell_mage_altertime')
           .actual(`${formatPercentage(actual)}% downtime`)

--- a/src/Parser/Hunter/BeastMastery/Modules/Items/ParselsTongue.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Items/ParselsTongue.js
@@ -110,7 +110,7 @@ class ParselsTongue extends Analyzer {
   }
   suggestions(when) {
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
-      return suggest(<Wrapper>You lost <SpellLink id={SPELLS.PARSELS_TONGUE_BUFF.id} /> buff {this.timesDropped} times, try and avoid this if possible.</Wrapper>)
+      return suggest(<Wrapper>You lost <SpellLink id={SPELLS.PARSELS_TONGUE_BUFF.id} icon /> buff {this.timesDropped} times, try and avoid this if possible.</Wrapper>)
         .icon(ITEMS.PARSELS_TONGUE.icon)
         .actual(`${actual} times dropped`)
         .recommended(`${recommended} is recommended`);

--- a/src/Parser/Hunter/BeastMastery/Modules/Items/QaplaEredunWarOrder.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Items/QaplaEredunWarOrder.js
@@ -49,7 +49,7 @@ class QaplaEredunWarOrder extends Analyzer {
       item: ITEMS.QAPLA_EREDUN_WAR_ORDER,
       result: (
         <dfn data-tip={`You wasted ${formatNumber(this.wastedKillCommandReductionMs / 1000)} seconds of CDR by using Dire Beast when Kill Command wasn't on cooldown or had less than 3(+GCD) seconds remaning on CD.`}>
-          reduced <SpellLink id={SPELLS.KILL_COMMAND.id} /> CD by {formatNumber(this.effectiveKillCommandReductionMs / 1000)}s in total.
+          reduced <SpellLink id={SPELLS.KILL_COMMAND.id} icon /> CD by {formatNumber(this.effectiveKillCommandReductionMs / 1000)}s in total.
         </dfn>
       ),
     };

--- a/src/Parser/Hunter/BeastMastery/Modules/Items/Tier21_4p.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Items/Tier21_4p.js
@@ -45,7 +45,7 @@ class Tier21_4p extends Analyzer {
       title: <SpellLink id={SPELLS.HUNTER_BM_T21_4P_BONUS.id} />,
       result: (
         <dfn data-tip={`You wasted ${formatNumber(this.wastedAspectReductionMs / 1000)} seconds of CDR by using Kill Command when Aspect of the Wild wasn't on cooldown or had less than 3 seconds remaning on CD.`}>
-          reduced <SpellLink id={SPELLS.ASPECT_OF_THE_WILD.id} /> CD by {formatNumber(this.effectiveAspectReductionMs / 1000)}s in total.
+          reduced <SpellLink id={SPELLS.ASPECT_OF_THE_WILD.id} icon /> CD by {formatNumber(this.effectiveAspectReductionMs / 1000)}s in total.
         </dfn>
       ),
     };

--- a/src/Parser/Hunter/BeastMastery/Modules/Spells/AspectOfTheWild.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Spells/AspectOfTheWild.js
@@ -77,7 +77,7 @@ class AspectOfTheWild extends Analyzer {
 
   suggestions(when) {
     when(this.badCastThreshold).addSuggestion((suggest, actual, recommended) => {
-      return suggest(<Wrapper>Don't cast <SpellLink id={SPELLS.ASPECT_OF_THE_WILD.id} /> without <SpellLink id={SPELLS.BESTIAL_WRATH.id} /> up and atleast 7 seconds remaining on the buff (or with under than 15 seconds remaining of the encounter) </Wrapper>)
+      return suggest(<Wrapper>Don't cast <SpellLink id={SPELLS.ASPECT_OF_THE_WILD.id} icon /> without <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon /> up and atleast 7 seconds remaining on the buff (or with under than 15 seconds remaining of the encounter) </Wrapper>)
         .icon(SPELLS.ASPECT_OF_THE_WILD.icon)
         .actual(`You cast Aspect of the Wild ${this.badAspectCasts} times without Bestial Wrath up or with less than 7s remaining of Bestial Wrath duration`)
         .recommended(`${recommended} is recommended`);

--- a/src/Parser/Hunter/BeastMastery/Modules/Spells/BestialWrath/BestialWrathAverageFocus.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Spells/BestialWrath/BestialWrathAverageFocus.js
@@ -69,7 +69,7 @@ class BestialWrathAverageFocus extends Analyzer {
 
   suggestions(when) {
     when(this.focusOnBestialWrathCastThreshold).addSuggestion((suggest, actual, recommended) => {
-      return suggest(<Wrapper>You started your average <SpellLink id={SPELLS.BESTIAL_WRATH.id} /> at {this.averageFocusAtBestialWrathCast} focus, try and pool a bit more before casting <SpellLink id={SPELLS.BESTIAL_WRATH.id} />. This can be achieved by not casting abilities a few moments before <SpellLink id={SPELLS.BESTIAL_WRATH.id} /> comes off cooldown.</Wrapper>)
+      return suggest(<Wrapper>You started your average <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon /> at {this.averageFocusAtBestialWrathCast} focus, try and pool a bit more before casting <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon />. This can be achieved by not casting abilities a few moments before <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon /> comes off cooldown.</Wrapper>)
         .icon(SPELLS.BESTIAL_WRATH.icon)
         .actual(`Average of ${this.averageFocusAtBestialWrathCast} focus at start of Bestial Wrath`)
         .recommended(`>${recommended} focus is recommended`);

--- a/src/Parser/Hunter/BeastMastery/Modules/Spells/BestialWrath/GainedBestialWraths.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Spells/BestialWrath/GainedBestialWraths.js
@@ -43,12 +43,13 @@ class GainedBestialWraths extends Analyzer {
 
   statistic() {
     const gainedBestialWraths = this.effectiveBWReduction / BESTIAL_WRATH_BASE_CD;
+    const spellLink = this.combatants.selected.hasTalent(SPELLS.DIRE_FRENZY_TALENT.id) ? SPELLS.DIRE_FRENZY_TALENT.name : SPELLS.DIRE_BEAST.name;
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.BESTIAL_WRATH.id} />}
         value={formatNumber(gainedBestialWraths)}
         label={`extra Bestial Wraths`}
-        tooltip={`<ul><li>You reduced Bestial Wraths cooldown by ${(this.effectiveBWReduction / 1000).toFixed(1)} seconds in total, which resulted in you gaining ${formatNumber(gainedBestialWraths, 2)} extra Bestial Wrath casts. </li> <li>You lost out on ${this.wastedBWReduction / 1000} seconds of CD reduction by casting Dire Beast/Dire Frenzy while Bestial Wrath wasn't on cooldown or while the cooldown had less than ${COOLDOWN_REDUCTION_MS / 1000} seconds remaining. </li></ul>`}
+        tooltip={`<ul><li>You reduced Bestial Wraths cooldown by ${(this.effectiveBWReduction / 1000).toFixed(1)} seconds in total, which resulted in you gaining ${formatNumber(gainedBestialWraths, 2)} extra Bestial Wrath casts. </li> <li>You lost out on ${(this.wastedBWReduction / 1000).toFixed(1)} seconds of CD reduction by casting ${spellLink} while Bestial Wrath wasn't on cooldown or while the cooldown had less than ${COOLDOWN_REDUCTION_MS / 1000} seconds remaining. </li></ul>`}
       />
     );
   }

--- a/src/Parser/Hunter/BeastMastery/Modules/Spells/DireBeast/DireBeast.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Spells/DireBeast/DireBeast.js
@@ -90,7 +90,7 @@ class DireBeast extends Analyzer {
   }
   suggestions(when) {
     when(this.badDireBeastThreshold).addSuggestion((suggest, actual, recommended) => {
-      return suggest(<Wrapper>Delay casting <SpellLink id={SPELLS.DIRE_BEAST.id} /> if there is less than 3 seconds cooldown remaining on <SpellLink id={SPELLS.BESTIAL_WRATH.id} />. It is generally better to cast something else while the remaining cooldown ticks down, so as to optimise the cooldown reduction aspect of <SpellLink id={SPELLS.DIRE_BEAST.id} />.</Wrapper>)
+      return suggest(<Wrapper>Delay casting <SpellLink id={SPELLS.DIRE_BEAST.id} icon /> if there is less than 3 seconds cooldown remaining on <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon />. It is generally better to cast something else while the remaining cooldown ticks down, so as to optimise the cooldown reduction aspect of <SpellLink id={SPELLS.DIRE_BEAST.id} icon />.</Wrapper>)
         .icon(SPELLS.DIRE_BEAST_SUMMON.icon)
         .actual(`You cast Dire Beast ${this.badDBCasts} times when Bestial Wrath had less than 3 seconds CD remaining.`)
         .recommended(`${recommended} is recommended`);

--- a/src/Parser/Hunter/BeastMastery/Modules/Talents/AMurderOfCrows.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Talents/AMurderOfCrows.js
@@ -113,7 +113,7 @@ class AMurderOfCrows extends Analyzer {
   }
   suggestions(when) {
     when(this.badCastThreshold).addSuggestion((suggest, actual, recommended) => {
-      return suggest(<Wrapper>Don't cast <SpellLink id={SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.id} /> without <SpellLink id={SPELLS.BESTIAL_WRATH.id} /> up (or ready to cast straight after the <SpellLink id={SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.id} /> cast), and atleast 7 seconds remaining on the buff.</Wrapper>)
+      return suggest(<Wrapper>Don't cast <SpellLink id={SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.id}icon /> without <SpellLink id={SPELLS.BESTIAL_WRATH.id}icon /> up (or ready to cast straight after the <SpellLink id={SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.id}icon /> cast), and atleast 7 seconds remaining on the buff.</Wrapper>)
         .icon(SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.icon)
         .actual(`You cast A Murder of Crows ${actual} times without Bestial Wrath up or Bestial Wrath ready to cast after`)
         .recommended(`${recommended} is recommended`);

--- a/src/Parser/Hunter/BeastMastery/Modules/Talents/DireFrenzy.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Talents/DireFrenzy.js
@@ -156,14 +156,14 @@ class DireFrenzy extends Analyzer {
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<Wrapper>Your pet has a general low uptime of the buff from <SpellLink id={SPELLS.DIRE_FRENZY_TALENT.id} icon />, you should never be sitting on 2 stacks of this spells, if you've chosen this talent, it's your most important spell to continously be casting. </Wrapper>)
           .icon(SPELLS.DIRE_FRENZY_TALENT.icon)
-          .actual(`Your pet had the buff from Dire Frenzy for ${actual}% of the fight`)
-          .recommended(`${recommended}% is recommended`);
+          .actual(`Your pet had the buff from Dire Frenzy for ${formatPercentage(actual)}% of the fight`)
+          .recommended(`${formatPercentage(recommended)}% is recommended`);
       });
     when(this.direFrenzy3StackThreshold).addSuggestion((suggest, actual, recommended) => {
       return suggest(<Wrapper>Your pet has a general low uptime of the 3 stacked buff from <SpellLink id={SPELLS.DIRE_FRENZY_TALENT.id} icon />. It's important to try and maintain the buff at 3 stacks for as long as possible, this is done by spacing out your casts, but at the same time never letting them cap on charges. </Wrapper>)
         .icon(SPELLS.DIRE_FRENZY_TALENT.icon)
-        .actual(`Your pet had 3 stacks of the buff from Dire Frenzy for ${actual}% of the fight`)
-        .recommended(`${recommended}% is recommended`);
+        .actual(`Your pet had 3 stacks of the buff from Dire Frenzy for ${formatPercentage(actual)}% of the fight`)
+        .recommended(`${formatPercentage(recommended)}% is recommended`);
     });
   }
   statistic() {

--- a/src/Parser/Hunter/BeastMastery/Modules/Talents/KillerCobra.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Talents/KillerCobra.js
@@ -68,7 +68,7 @@ class KillerCobra extends Analyzer {
   }
   suggestions(when) {
     when(this.wastedKillerCobraThreshold).addSuggestion((suggest, actual, recommended) => {
-      return suggest(<Wrapper>Avoid casting <SpellLink id={SPELLS.COBRA_SHOT.id} /> whilst <SpellLink id={SPELLS.KILL_COMMAND.id} /> isn't on cooldown, when you have <SpellLink id={SPELLS.BESTIAL_WRATH.id} /> up. Utilize the reset effect of <SpellLink id={SPELLS.KILLER_COBRA_TALENT.id} /> by only casting <SpellLink id={SPELLS.COBRA_SHOT.id} /> to reset <SpellLink id={SPELLS.KILL_COMMAND.id} /> when <SpellLink id={SPELLS.BESTIAL_WRATH.id} /> is up. </Wrapper>)
+      return suggest(<Wrapper>Avoid casting <SpellLink id={SPELLS.COBRA_SHOT.id} icon /> whilst <SpellLink id={SPELLS.KILL_COMMAND.id} icon /> isn't on cooldown, when you have <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon /> up. Utilize the reset effect of <SpellLink id={SPELLS.KILLER_COBRA_TALENT.id} icon /> by only casting <SpellLink id={SPELLS.COBRA_SHOT.id} icon /> to reset <SpellLink id={SPELLS.KILL_COMMAND.id} icon /> when <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon /> is up. </Wrapper>)
         .icon(SPELLS.KILLER_COBRA_TALENT.icon)
         .actual(`You cast Cobra Shot while Kill Command wasn't on cooldown, whilst Bestial Wrath was up ${actual} times.`)
         .recommended(`${recommended} is recommended.`);

--- a/src/Parser/Hunter/BeastMastery/Modules/Traits/TitansThunder.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Traits/TitansThunder.js
@@ -177,13 +177,13 @@ class TitansThunder extends Analyzer {
 
   suggestions(when) {
     when(this.badCastThreshold).addSuggestion((suggest, actual, recommended) => {
-      return suggest(<Wrapper>Don't cast <SpellLink id={SPELLS.TITANS_THUNDER.id} /> without <SpellLink id={SPELLS.DIRE_BEAST.id} /> up, or if using <SpellLink id={SPELLS.DIRE_FRENZY_TALENT.id} /> without <SpellLink id={SPELLS.BESTIAL_WRATH.id} /> up.</Wrapper>)
+      return suggest(<Wrapper>Don't cast <SpellLink id={SPELLS.TITANS_THUNDER.id} icon /> without <SpellLink id={SPELLS.DIRE_BEAST.id} icon /> up, or if using <SpellLink id={SPELLS.DIRE_FRENZY_TALENT.id} icon /> without <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon /> up.</Wrapper>)
         .icon(SPELLS.TITANS_THUNDER.icon)
         .actual(`You cast Titan's Thunder ${actual} times without Dire Beasts up, or if using Dire Frenzy without Bestial Wrath up.`)
         .recommended(`${recommended} is recommended`);
     });
     when(this.shouldHaveSavedThreshold).addSuggestion((suggest, actual, recommended) => {
-      return suggest(<Wrapper>Don't cast <SpellLink id={SPELLS.TITANS_THUNDER.id} /> when there is less than 30 seconds cooldown remaining on <SpellLink id={SPELLS.BESTIAL_WRATH.id} />.</Wrapper>)
+      return suggest(<Wrapper>Don't cast <SpellLink id={SPELLS.TITANS_THUNDER.id} icon /> when there is less than 30 seconds cooldown remaining on <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon />.</Wrapper>)
         .icon(SPELLS.TITANS_THUNDER.icon)
         .actual(`You cast Titan's Thunder ${actual} times when there was less than 30 seconds cooldown on Bestial Wrath`)
         .recommended(`${recommended} is recommended`);

--- a/src/Parser/Hunter/Marksmanship/Modules/Features/VulnerableUptime.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Features/VulnerableUptime.js
@@ -43,7 +43,7 @@ class VulnerableUpTime extends Analyzer {
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.VULNERABLE.id} />}
-        value={`${formatPercentage(this.uptimePercentage)} %`}
+        value={`${formatPercentage(this.uptimePercentage)}%`}
         label="Vulnerable uptime"
       />
     );

--- a/src/Parser/Hunter/Marksmanship/Modules/Talents/PatientSniper/PatientSniperDetails.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Talents/PatientSniper/PatientSniperDetails.js
@@ -76,10 +76,10 @@ class PatientSniperDetails extends Analyzer {
   statistic() {
     let tooltipText = `Your Aimed Shots ${this.hasPiercingShot ? 'and Piercing Shots ' : ''}did ${formatNumber(this.bonusDamage)} (${this.owner.formatItemDamageDone(this.bonusDamage)}) bonus damage thanks to the Patient Sniper talent. Below you'll see them individually, and if you want to see more Patient Sniper information (such as without Trueshot windows), please check the "Patient Sniper Usage" tab in the menu. <br />`;
     const aimed = this.abilityTracker.getAbility(SPELLS.AIMED_SHOT.id);
-    tooltipText += `<ul> <li>Aimed Shot bonus damage: ${formatNumber(this.bonusAimedDamage)} (${formatPercentage(this.bonusAimedDamage / aimed.damageEffective)} %) </li>`;
+    tooltipText += `<ul> <li>Aimed Shot bonus damage: ${formatNumber(this.bonusAimedDamage)} (${formatPercentage(this.bonusAimedDamage / aimed.damageEffective)}%) </li>`;
     if (this.hasPiercingShot) {
       const piercing = this.abilityTracker.getAbility(SPELLS.PIERCING_SHOT_TALENT.id);
-      tooltipText += `<li> Piercing Shot bonus damage: ${formatNumber(this.bonusPiercingDamage)} (${formatPercentage(this.bonusPiercingDamage / piercing.damageEffective)} %)</li>`;
+      tooltipText += `<li> Piercing Shot bonus damage: ${formatNumber(this.bonusPiercingDamage)} (${formatPercentage(this.bonusPiercingDamage / piercing.damageEffective)}%)</li>`;
     }
     return (
       <StatisticBox

--- a/src/Parser/Hunter/Marksmanship/Modules/Talents/TrueAim.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Talents/TrueAim.js
@@ -124,7 +124,7 @@ class TrueAim extends Analyzer {
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.TRUE_AIM_DEBUFF.id} />}
-        value={`${percentTimeAtMaxTAStacks} %`}
+        value={`${percentTimeAtMaxTAStacks}%`}
         label="10 stack uptime"
         tooltip={tooltipText}
       />

--- a/src/Parser/Hunter/Marksmanship/Modules/Traits/Bullseye.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Traits/Bullseye.js
@@ -88,7 +88,7 @@ class Bullseye extends Analyzer {
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.BULLSEYE_BUFF.id} />}
-        value={`${this.percentBullseyeAtMax} %`}
+        value={`${this.percentBullseyeAtMax}%`}
         label={`% of Bullseye at ${this.MAX_STACKS} stacks`}
         tooltip={`You reset Bullseye ${this.bullseyeResets} times during the execute phase (boss below 20% health). <br /> You had ${formatNumber(this.bullseyeUptime / 1000)} seconds of Bullseye uptime during the fight, and ${formatNumber(this.bullseyeMaxUptime / 1000)} seconds of uptime at ${this.MAX_STACKS} stacks.`}
       />

--- a/src/Parser/Hunter/Shared/Modules/Features/TimeFocusCapped.js
+++ b/src/Parser/Hunter/Shared/Modules/Features/TimeFocusCapped.js
@@ -37,7 +37,7 @@ class TimeFocusCapped extends Analyzer {
         tooltip={`You wasted <b> ${totalFocusWaste}  </b> focus. <br />
         That's <b>  ${formatPercentage(totalFocusWaste / (this.owner.fightDuration / 1000 * this.focusTracker.focusGen))}% </b> of your total focus generated.
         <br /> For more details, see the Focus Chart tab.`}
-        value={`${percentCapped} %`}
+        value={`${percentCapped}%`}
         //Time not Focus-Capped: {Math.round((this.owner.fightDuration / 1000 - this.focusTracker.secondsCapped) * 100) / 100}s / {Math.floor(this.owner.fightDuration / 1000)}
         footer={(
           <div className="statistic-bar">

--- a/src/Parser/Hunter/Shared/Modules/Items/SoulOfTheHuntmaster.js
+++ b/src/Parser/Hunter/Shared/Modules/Items/SoulOfTheHuntmaster.js
@@ -61,7 +61,7 @@ class SoulOfTheHuntmaster extends Analyzer {
 
   suggestions(when) {
     when(this.hasPickedOtherTalent).isFalse().addSuggestion((suggest) => {
-      return suggest(<Wrapper>When using <ItemLink id={ITEMS.SOUL_OF_THE_HUNTMASTER.id} /> please make sure to pick another talent in the talent row. Your choices are <SpellLink id={this.option1} /> or <SpellLink id={this.option2} />.</Wrapper>)
+      return suggest(<Wrapper>When using <ItemLink id={ITEMS.SOUL_OF_THE_HUNTMASTER.id} icon /> please make sure to pick another talent in the talent row. Your choices are <SpellLink id={this.option1} icon /> or <SpellLink id={this.option2} icon />.</Wrapper>)
         .icon(ITEMS.SOUL_OF_THE_HUNTMASTER.icon)
         .staticImportance(SUGGESTION_IMPORTANCE.MAJOR);
     });

--- a/src/Parser/Hunter/Shared/Modules/Talents/AspectOfTheBeast.js
+++ b/src/Parser/Hunter/Shared/Modules/Talents/AspectOfTheBeast.js
@@ -40,7 +40,7 @@ class AspectOfTheBeast extends Analyzer {
 
   suggestions(when) {
     when(this.aspectOfTheBeastDamageThreshold).addSuggestion((suggest) => {
-      return suggest(<Wrapper><SpellLink id={SPELLS.ASPECT_OF_THE_BEAST_TALENT.id} /> had no damage contribution, which indiciates you did not have your pet specced into Ferocity, which it should always be.</Wrapper>)
+      return suggest(<Wrapper><SpellLink id={SPELLS.ASPECT_OF_THE_BEAST_TALENT.id} icon /> had no damage contribution, which indiciates you did not have your pet specced into Ferocity, which it should always be.</Wrapper>)
         .icon(SPELLS.ASPECT_OF_THE_BEAST_TALENT.icon)
         .actual(`Aspect of the Beast did no additional damage`)
         .recommended(`Speccing your pet into Ferocity is recommended`);

--- a/src/Parser/Hunter/Shared/Modules/Talents/Volley.js
+++ b/src/Parser/Hunter/Shared/Modules/Talents/Volley.js
@@ -57,7 +57,7 @@ class Volley extends Analyzer {
   suggestions(when) {
     when(this.volleyRemoved).isGreaterThan(0)
       .addSuggestion((suggest) => {
-        return suggest(<Wrapper>It looks like you turned <SpellLink id={SPELLS.VOLLEY_TALENT.id} /> off during the encounter, this should never be done. <SpellLink id={SPELLS.VOLLEY_TALENT.id} /> should always be active, no matter what. </Wrapper>)
+        return suggest(<Wrapper>It looks like you turned <SpellLink id={SPELLS.VOLLEY_TALENT.id} icon /> off during the encounter, this should never be done. <SpellLink id={SPELLS.VOLLEY_TALENT.id} icon /> should always be active, no matter what. </Wrapper>)
           .icon(SPELLS.VOLLEY_TALENT.icon)
           .actual(`Volley was toggled off ${this.volleyRemoved} times`)
           .recommended(`Volley should never be turned off`)
@@ -65,7 +65,7 @@ class Volley extends Analyzer {
       });
     when(this.volleyApplied).isLessThan(this.deaths)
       .addSuggestion((suggest) => {
-        return suggest(<Wrapper>It looks like you forgot to turn <SpellLink id={SPELLS.VOLLEY_TALENT.id} /> on again after dying. <SpellLink id={SPELLS.VOLLEY_TALENT.id} /> should always be active, no matter what. </Wrapper>)
+        return suggest(<Wrapper>It looks like you forgot to turn <SpellLink id={SPELLS.VOLLEY_TALENT.id} icon /> on again after dying. <SpellLink id={SPELLS.VOLLEY_TALENT.id} icon /> should always be active, no matter what. </Wrapper>)
           .icon(SPELLS.VOLLEY_TALENT.icon)
           .actual(`You died ${this.deaths} time(s), and toggled Volley on ${this.volleyApplied} times.`)
           .recommended(`Remember to toggle Volley back on after dying`)

--- a/src/Parser/Hunter/Survival/CHANGELOG.js
+++ b/src/Parser/Hunter/Survival/CHANGELOG.js
@@ -9,6 +9,11 @@ import ItemLink from 'common/ItemLink';
 
 export default [
   {
+    date: new Date('2018-02-20'),
+    changes: <Wrapper>Spring cleaning in many modules. Added icons to Focus Usage modules and elsewhere around the analyzer and added support for <SpellLink id={SPELLS.CALTROPS_TALENT.id} icon />.</Wrapper>,
+    contributors: [Putro],
+  },
+  {
     date: new Date('2018-02-14'),
     changes: <Wrapper>Added a module for <SpellLink id={SPELLS.FURY_OF_THE_EAGLE_TRAIT.id} icon />.</Wrapper>,
     contributors: [Putro],

--- a/src/Parser/Hunter/Survival/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Hunter/Survival/Modules/Features/AlwaysBeCasting.js
@@ -31,7 +31,7 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
   suggestions(when) {
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
       return suggest(
-        <Wrapper>Your downtime can be improved. Try to reduce the delay between casting spells. If everything is on cooldown, try and use <SpellLink id={SPELLS.RAPTOR_STRIKE.id} /> to stay off the focus cap and do some damage.
+        <Wrapper>Your downtime can be improved. Try to reduce the delay between casting spells. If everything is on cooldown, try and use <SpellLink id={SPELLS.RAPTOR_STRIKE.id} icon /> or <SpellLink id={SPELLS.LACERATE.id} icon /> to stay off the focus cap and do some damage.
         </Wrapper>)
         .icon('spell_mage_altertime')
         .actual(`${formatPercentage(actual)}% downtime`)

--- a/src/Parser/Hunter/Survival/Modules/Talents/Caltrops.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/Caltrops.js
@@ -2,17 +2,23 @@ import React from 'react';
 
 import SPELLS from 'common/SPELLS';
 import Analyzer from 'Parser/Core/Analyzer';
+import Enemies from 'Parser/Core/Modules/Enemies';
+
 import SpellIcon from 'common/SpellIcon';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import SpellUsable from 'Parser/Core/Modules/SpellUsable';
 import SpellLink from 'common/SpellLink';
 import ItemDamageDone from 'Main/ItemDamageDone';
+import { formatPercentage } from 'common/format';
+import StatisticBox from 'Main/StatisticBox';
+import Wrapper from 'common/Wrapper';
 
 class Caltrops extends Analyzer {
 
   static dependencies = {
     combatants: Combatants,
     spellUsable: SpellUsable,
+    enemies: Enemies,
   };
 
   bonusDamage = 0;
@@ -40,6 +46,41 @@ class Caltrops extends Analyzer {
       this.spellUsable.beginCooldown(SPELLS.CALTROPS_TALENT.id);
     }
     this.bonusDamage += event.amount + (event.absorbed || 0);
+  }
+
+  get uptimePercentage() {
+    return this.enemies.getBuffUptime(SPELLS.CALTROPS_DAMAGE.id) / this.owner.fightDuration;
+  }
+
+  get uptimeThreshold() {
+    return {
+      actual: this.uptimePercentage,
+      isLessThan: {
+        minor: 0.9,
+        average: 0.8,
+        major: 0.7,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.uptimeThreshold).addSuggestion((suggest, actual, recommended) => {
+      return suggest(<Wrapper>If you have chosen <SpellLink id={SPELLS.CALTROPS_TALENT.id} icon /> as a talent, you want to ensure that you have a high uptime of the DOT ticking on enemies.</Wrapper>)
+        .icon(SPELLS.CALTROPS_TALENT.icon)
+        .actual(`${formatPercentage(this.uptimePercentage)}%`)
+        .recommended(`>${formatPercentage(recommended)}% is recommended`);
+    });
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.CALTROPS_TALENT.id} />}
+        value={`${formatPercentage(this.uptimePercentage)}%`}
+        label="Caltrops uptime"
+      />
+    );
   }
 
   subStatistic() {


### PR DESCRIPTION
Part 2 of more icons

Also adds a small uptime module for Survival on Caltrops dot:
![image](https://user-images.githubusercontent.com/29204244/36438348-ed5fdce4-1669-11e8-8f34-e9cf4c24c508.png)

Fixes a missing formatPercentage in Dire Frenzy module aswell. 