### PR TITLE
[Destruction] Eradication

### DIFF
--- a/src/Parser/Warlock/Destruction/Modules/Talents/Eradication.js
+++ b/src/Parser/Warlock/Destruction/Modules/Talents/Eradication.js
@@ -34,8 +34,7 @@ class Eradication extends Analyzer {
     this._hasCDF = this.combatants.selected.hasTalent(SPELLS.CHANNEL_DEMONFIRE_TALENT.id);
   }
 
-  // TODO: SPELL QUEUE ON CAST, SPELLS SNAPSHOT ON CAST, NOT ON HIT SO THIS IS INACCURATE
-  on_byPlayer_damage(event) {
+  on_byPlayer_cast(event) {
     const enemy = this.enemies.getEntity(event);
     if (!enemy) {
       return;


### PR DESCRIPTION
Currently spells benefitting from Eradication are only added to the statistics if the debuff Eradication is applied to the target. But the dmg bonus of Eradication is added at the end of a cast.
Just calculating the statistics on _cast and not on _damage will fix this.