### PR TITLE
[Mistweaver] Drape of Shame effective ilvl

### DIFF
--- a/src/Parser/Monk/Mistweaver/CombatLogParser.js
+++ b/src/Parser/Monk/Mistweaver/CombatLogParser.js
@@ -50,6 +50,7 @@ import Lifecycles from './Modules/Talents/Lifecycles';
 import SpiritOfTheCrane from './Modules/Talents/SpiritOfTheCrane';
 
 // Items
+import DrapeOfShame from './Modules/Items/DrapeOfShame';
 import Eithas from './Modules/Items/Eithas';
 import T20_4set from './Modules/Items/T20_4set';
 import T20_2set from './Modules/Items/T20_2set';
@@ -111,6 +112,7 @@ class CombatLogParser extends CoreCombatLogParser {
     spiritOfTheCrane: SpiritOfTheCrane,
 
     // Legendaries / Items:
+    drapeOfShame: DrapeOfShame,
     eithas: Eithas,
     t20_4set: T20_4set,
     t20_2set: T20_2set,

--- a/src/Parser/Monk/Mistweaver/Modules/Items/DrapeOfShame.js
+++ b/src/Parser/Monk/Mistweaver/Modules/Items/DrapeOfShame.js
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
+import Wrapper from 'common/Wrapper';
+import CoreDrapeOfShame from 'Parser/Core/Modules/Items/Legion/DrapeOfShame';
+import ItemHealingDone from 'Main/ItemHealingDone';
+
+import StatValues from '../Features/StatValues';
+
+class DrapeOfShame extends CoreDrapeOfShame {
+  static dependencies = {
+    ...CoreDrapeOfShame.dependencies,
+    statValues: StatValues,
+  };
+
+  get estimatedItemLevel() {
+    if (!this.owner.finished) {
+      return null;
+    }
+
+    // My DoS
+    const itemLevel = this.equippedItem.itemLevel;
+    const statsHps = this.statValues.calculateItemStatsHps(this.baseStats, itemLevel);
+    const effectHps = this.healing / this.owner.fightDuration * 1000;
+    const totalHps = statsHps + effectHps;
+
+    // An estimated DoS
+    let estimatedItemLevel = itemLevel;
+    let estimatedHps = 0;
+    while (estimatedHps < totalHps) {
+      estimatedItemLevel += 5;
+      estimatedHps = this.statValues.calculateItemStatsHps(this.baseStats, estimatedItemLevel);
+    }
+    // We need the `estimatedItemLevel` to *beat* the DoS, so the DoS is worth about 0-5 item levels less
+    return estimatedItemLevel - 5;
+  }
+
+  on_byPlayer_heal(event) {
+    const spellId = event.ability.guid;
+    if (this.owner.constructor.abilitiesAffectedByHealingIncreases.indexOf(spellId) === -1 || spellId === SPELLS.BEACON_OF_LIGHT_CAST_AND_HEAL.id) {
+      return;
+    }
+    super.on_byPlayer_heal(event);
+  }
+
+  item() {
+    const estimatedItemLevel = this.estimatedItemLevel;
+    return {
+      item: ITEMS.DRAPE_OF_SHAME,
+      result: (
+        <Wrapper>
+          <ItemHealingDone amount={this.healing} /><br />
+          <img
+            src="/img/ilvl.png"
+            alt="Item level"
+            className="icon"
+          />{' '}{estimatedItemLevel !== null ? `≈${estimatedItemLevel} cloak with similar stats` : 'Calculating...'}
+        </Wrapper>
+      ),
+    };
+  }
+}
+
+export default DrapeOfShame;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19510201/36578700-7b025322-1824-11e8-9ddf-1eb25f41a79e.png)
[test log](https://www.warcraftlogs.com/reports/DLRvBJX4x1Ft9pnh#fight=12&type=healing&source=30)

Added in a display to show the effective itemlevel of Drape of Shame for mistweaver monks. 