### PR TITLE
[BrM] Fix Stagger Pool Plot Hitboxes

### DIFF
--- a/src/Parser/Monk/Brewmaster/Modules/Features/StaggerPoolGraph.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/StaggerPoolGraph.js
@@ -237,6 +237,8 @@ class StaggerPoolGraph extends Analyzer {
               },
               point: {
                 radius: 0,
+                hitRadius: 4,
+                hoverRadius: 4,
               },
             },
             scales: {


### PR DESCRIPTION
This is a super simple PR. tl;dr the plot as it is now on the site is extremely difficult to mouseover the data points (aside from Purifies) since the point radius for them is set to 0. This sets the hit/hover radius to 4 so that you can actually see the exact values by mousing over the lines.

There is nothing I can really screenshot about this change. On live you *can* get the tooltip, its just a pain in the ass.