### PR TITLE
Added Armor to stat tracker

### DIFF
--- a/src/Parser/Core/Modules/Items/Legion/DarkmoonDeckImmortality.js
+++ b/src/Parser/Core/Modules/Items/Legion/DarkmoonDeckImmortality.js
@@ -19,6 +19,14 @@ const BASE_ARMOR_PER_CARD = {
   191631: 2414, // 8 -- 2911
 };
 
+export const STAT_TRACKER_BUFFS = Object.entries(BASE_ARMOR_PER_CARD).reduce((result, [id, baseArmor]) => {
+  result[id] = {
+    itemId: ITEMS.DARKMOON_DECK_IMMORTALITY.id,
+    armor: (_, item) => calculateSecondaryStatDefault(BASE_IMMORTALITY_ILVL, baseArmor, item.itemLevel),
+  };
+  return result;
+}, {});
+
 const NUM_CARDS = 8;
 const MIN_CARD = 191624;
 const MAX_CARD = 191631;

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -239,7 +239,7 @@ class StatTracker extends Analyzer {
   }
 
   applySpecModifiers() {
-    const modifiers = this.constructor.SPEC_MULTIPLIERS[this.combatants.selected.spec.id];
+    const modifiers = this.constructor.SPEC_MULTIPLIERS[this.combatants.selected.spec.id] || {};
     Object.entries(modifiers).forEach(([stat, multiplier]) => this._pullStats[stat] *= multiplier);
   }
 

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -6,6 +6,7 @@ import { formatMilliseconds } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+import { STAT_TRACKER_BUFFS as DARKMOON_DECK_IMMORTALITY_BUFFS } from 'Parser/Core/Modules/Items/Legion/DarkmoonDeckImmortality';
 
 const debug = false;
 
@@ -151,6 +152,10 @@ class StatTracker extends Analyzer {
     //  haste: (_, item) => calculateSecondaryStatDefault(940, 4219, item.itemLevel),
     //},
     // endregion 
+    
+    // region Crafted Trinkets
+    ...DARKMOON_DECK_IMMORTALITY_BUFFS,
+    // endregion
 
     // region Misc
     [SPELLS.CONCORDANCE_OF_THE_LEGIONFALL_STRENGTH.id]: { // check numbers
@@ -203,6 +208,7 @@ class StatTracker extends Analyzer {
       avoidance: this.combatants.selected._combatantInfo.avoidance,
       leech: this.combatants.selected._combatantInfo.leech,
       speed: this.combatants.selected._combatantInfo.speed,
+      armor: this.combatants.selected._combatantInfo.armor,
     };
     this._currentStats = {
       ...this._pullStats,
@@ -248,6 +254,9 @@ class StatTracker extends Analyzer {
   get startingSpeedRating() {
     return this._pullStats.speed;
   }
+  get startingArmorRating() {
+    return this._pullStats.armor;
+  }
 
   /*
    * Current stat rating, as tracked by this module.
@@ -284,6 +293,9 @@ class StatTracker extends Analyzer {
   }
   get currentSpeedRating() {
     return this._currentStats.speed;
+  }
+  get currentArmorRating() {
+    return this._currentStats.armor;
   }
 
   // TODO: I think these should be ratings. They behave like ratings and I think the only reason they're percentages here is because that's how they're **displayed** in-game, but not because it's more correct.
@@ -447,6 +459,9 @@ class StatTracker extends Analyzer {
   speedPercentage(rating, withBase = false) {
     return (withBase ? this.baseSpeedPercentage : 0) + rating / this.speedRatingPerPercent;
   }
+  armorPercentage(rating, attackerLevel = 110) {
+    return rating / (rating + (467.5 * attackerLevel - 22167.5));
+  }
 
   /*
    * For percentage stats, the current stat percentage as tracked by this module.
@@ -471,6 +486,9 @@ class StatTracker extends Analyzer {
   }
   get currentSpeedPercentage() {
     return this.speedPercentage(this.currentSpeedRating, true);
+  }
+  get currentArmorPercentage() {
+    return this.armorPercentage(this.currentArmorRating);
   }
 
   on_toPlayer_changebuffstack(event) {
@@ -533,6 +551,7 @@ class StatTracker extends Analyzer {
       avoidance: this._getBuffValue(change, change.avoidance) * factor,
       leech: this._getBuffValue(change, change.leech) * factor,
       speed: this._getBuffValue(change, change.speed) * factor,
+      armor: this._getBuffValue(change, change.armor) * factor,
     };
 
     Object.keys(this._currentStats).forEach(key => {
@@ -589,7 +608,7 @@ class StatTracker extends Analyzer {
   }
 
   _statPrint(stats) {
-    return `STR=${stats.strength} AGI=${stats.agility} INT=${stats.intellect} STM=${stats.stamina} CRT=${stats.crit} HST=${stats.haste} MST=${stats.mastery} VRS=${stats.versatility} AVD=${this._currentStats.avoidance} LCH=${stats.leech} SPD=${stats.speed}`;
+    return `STR=${stats.strength} AGI=${stats.agility} INT=${stats.intellect} STM=${stats.stamina} CRT=${stats.crit} HST=${stats.haste} MST=${stats.mastery} VRS=${stats.versatility} AVD=${this._currentStats.avoidance} LCH=${stats.leech} SPD=${stats.speed} ARMOR=${this._currentStats.armor}`;
   }
 }
 

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -29,8 +29,8 @@ class StatTracker extends Analyzer {
   // These are multipliers from *binary* (have it or don't) artifact
   // traits. These are *baked in* and do not multiply temporary buffs.
   static ARTIFACT_MULTIPLIERS = {
-    [SPELLS.ENDURANCE_OF_THE_BROKEN_TEMPLE_TRAIT.id]: { armor: 1.35 }, // also: damage: 1.1
-    [SPELLS.WANDERERS_HARDINESS_TRAIT.id]: { armor: 1.17 },
+    [SPELLS.ENDURANCE_OF_THE_BROKEN_TEMPLE_TRAIT.id]: { armor: 0.35 },
+    [SPELLS.WANDERERS_HARDINESS_TRAIT.id]: { armor: 0.17 },
   };
 
   static STAT_BUFFS = {
@@ -240,22 +240,14 @@ class StatTracker extends Analyzer {
 
   applySpecModifiers() {
     const modifiers = this.constructor.SPEC_MULTIPLIERS[this.combatants.selected.spec.id];
-    this.applyMultipliers(this._pullStats, modifiers);
+    Object.entries(modifiers).forEach(([stat, multiplier]) => this._pullStats[stat] *= multiplier);
   }
 
   applyArtifactModifiers() {
     Object.entries(this.constructor.ARTIFACT_MULTIPLIERS).forEach(([spellId, modifiers]) => {
-      if(this.combatants.selected.traitsBySpellId[spellId] > 0) {
-        this.applyMultipliers(this._pullStats, modifiers);
-      }
+      const rank = this.combatants.selected.traitsBySpellId[spellId] || 0;
+      Object.entries(modifiers).forEach(([stat, multiplier]) => this._pullStats[stat] *= 1 + multiplier * rank);
     });
-  }
-
-  applyMultipliers(stats, modifiers) {
-    if(!modifiers) {
-      return;
-    }
-    Object.entries(modifiers).forEach(([stat, multiplier]) => stats[stat] *= multiplier);
   }
 
   /*

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -23,14 +23,14 @@ class StatTracker extends Analyzer {
   // In general, it looks like armor is the only one that isn't applied
   // by WCL.
   static SPEC_MULTIPLIERS = {
-    [SPECS.BREWMASTER_MONK.id]: { armor: 1.25, },
+    [SPECS.BREWMASTER_MONK.id]: { armor: 1.25 },
   };
 
   // These are multipliers from *binary* (have it or don't) artifact
   // traits. These are *baked in* and do not multiply temporary buffs.
   static ARTIFACT_MULTIPLIERS = {
-    [SPELLS.ENDURANCE_OF_THE_BROKEN_TEMPLE_TRAIT.id]: { armor: 1.35, }, // also: damage: 1.1
-    [SPELLS.WANDERERS_HARDINESS_TRAIT.id]: { armor: 1.17, },
+    [SPELLS.ENDURANCE_OF_THE_BROKEN_TEMPLE_TRAIT.id]: { armor: 1.35 }, // also: damage: 1.1
+    [SPELLS.WANDERERS_HARDINESS_TRAIT.id]: { armor: 1.17 },
   };
 
   static STAT_BUFFS = {
@@ -240,7 +240,7 @@ class StatTracker extends Analyzer {
 
   applySpecModifiers() {
     const modifiers = this.constructor.SPEC_MULTIPLIERS[this.combatants.selected.spec.id];
-    this.applyMultipliers(this._pullStats, modifiers)
+    this.applyMultipliers(this._pullStats, modifiers);
   }
 
   applyArtifactModifiers() {

--- a/src/common/SPELLS/MONK.js
+++ b/src/common/SPELLS/MONK.js
@@ -559,6 +559,16 @@ export default {
     name: 'Mastery: Elusive Brawler',
     icon: 'ability_monk_shuffle',
   },
+  WANDERERS_HARDINESS_TRAIT: {
+    id: 214920,
+    name: "Wanderer's Hardiness",
+    icon: "inv_staff_2h_artifactmonkeyking_d_02",
+  },
+  ENDURANCE_OF_THE_BROKEN_TEMPLE_TRAIT: {
+    id: 241131,
+    name: "Endurance of the Broken Temple",
+    icon: "misc_legionfall_monk",
+  },
 
   // Windwalker Spells
   COMBO_STRIKES: {


### PR DESCRIPTION
Fairly self-explanatory. Armor gets tracked. The only buffs currently represented are from DMD:I. This is going to be more important as we ramp up for BfA as a bunch of tank AM is getting switched to bonus armor.

I worked around a bug (?) in the `combatantinfo` armor value. It doesn't include the bonuses from artifacts or passives. For BrM this nearly doubles the amount of armor I have pre-pull. However, while these passives do multiply together they do not multiply other temporary buffs and so cannot be used with the overall stattracker infrastructure to update stats.

I was waffling over whether to do this in `StatTracker` or adding a normalizer for a bit and ended up just doing it here. If it'd be better in a normalizer it's not much effort for me to move it before the PR is accepted.