### PR TITLE
[Fire Mage] Support for Koralon's Burning Touch

### DIFF
--- a/src/Parser/Mage/Fire/CHANGELOG.js
+++ b/src/Parser/Mage/Fire/CHANGELOG.js
@@ -9,6 +9,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-2-25'),
+    changes: <Wrapper>Added Support for <ItemLink id={ITEMS.KORALONS_BURNING_TOUCH.id}/>.</Wrapper>,
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2018-1-25'),
     changes: 'Added Checklist.',
     contributors: [Sharrq],

--- a/src/Parser/Mage/Fire/CombatLogParser.js
+++ b/src/Parser/Mage/Fire/CombatLogParser.js
@@ -32,6 +32,7 @@ import DarcklisDragonfireDiadem from './Modules/Items/DarcklisDragonfireDiadem';
 import ContainedInfernalCore from './Modules/Items/ContainedInfernalCore';
 import PyrotexIgnitionCloth from './Modules/Items/PyrotexIgnitionCloth';
 import MarqueeBindingsOfTheSunKing from './Modules/Items/MarqueeBindingsOfTheSunKing';
+import KoralonsBurningTouch from './Modules/Items/KoralonsBurningTouch';
 
 class CombatLogParser extends CoreCombatLogParser {
   feedbackWarning = true;
@@ -74,6 +75,7 @@ class CombatLogParser extends CoreCombatLogParser {
     containedInfernalCore: ContainedInfernalCore,
     pyrotexIgnitionCloth: PyrotexIgnitionCloth,
     marqueeBindingsOfTheSunKing: MarqueeBindingsOfTheSunKing,
+    koralonsBurningTouch: KoralonsBurningTouch,
 
   };
 }

--- a/src/Parser/Mage/Fire/Modules/Features/HeatingUp.js
+++ b/src/Parser/Mage/Fire/Modules/Features/HeatingUp.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import SpellIcon from 'common/SpellIcon';
@@ -31,6 +32,13 @@ class HeatingUp extends Analyzer {
   targetId = 0;
   currentHealth = 0;
   maxHealth = 0;
+  hasFirestarterTalent;
+  hasLegendaryBelt;
+
+  on_initialized() {
+    this.hasFirestarterTalent = this.combatants.selected.hasTalent(SPELLS.FIRESTARTER_TALENT.id);
+    this.hasLegendaryBelt = this.combatants.selected.hasWaist(ITEMS.KORALONS_BURNING_TOUCH.id);
+  }
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
@@ -43,6 +51,8 @@ class HeatingUp extends Analyzer {
   on_byPlayer_damage(event) {
     const spellId = event.ability.guid;
     const damageTarget = encodeTargetString(event.targetID, event.targetInstance);
+    const combustionActive = this.combatants.selected.hasBuff(SPELLS.COMBUSTION.id);
+    const hasHotStreak = this.combatants.selected.hasBuff(SPELLS.HOT_STREAK.id);
     if (this.combatants.selected.hasTalent(SPELLS.FIRESTARTER_TALENT.id) && GUARANTEE_CRIT_SPELLS.includes(spellId)) {
       this.currentHealth = event.hitPoints;
       this.maxHealth = event.maxHitPoints;
@@ -51,7 +61,7 @@ class HeatingUp extends Analyzer {
       return;
     }
 
-    if ((this.combatants.selected.hasBuff(SPELLS.COMBUSTION.id) || (this.combatants.selected.hasTalent(SPELLS.FIRESTARTER_TALENT.id) && this.healthPercent > .90)) && !this.combatants.selected.hasBuff(SPELLS.HOT_STREAK.id)) {
+    if ((combustionActive || (this.hasFirestarterTalent && this.healthPercent > .90) || (this.hasLegendaryBelt && spellId === SPELLS.SCORCH.id && this.healthPercent < .30)) && !hasHotStreak) {
       debug && console.log("Event Ignored @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
     } else if (spellId === SPELLS.FIRE_BLAST.id) {
       if (this.combatants.selected.hasBuff(SPELLS.HOT_STREAK.id)) {

--- a/src/Parser/Mage/Fire/Modules/Features/HeatingUp.js
+++ b/src/Parser/Mage/Fire/Modules/Features/HeatingUp.js
@@ -61,7 +61,7 @@ class HeatingUp extends Analyzer {
       return;
     }
 
-    if ((combustionActive || (this.hasFirestarterTalent && this.healthPercent > .90) || (this.hasLegendaryBelt && spellId === SPELLS.SCORCH.id && this.healthPercent < .30)) && !hasHotStreak) {
+    if ((combustionActive || (this.hasFirestarterTalent && this.healthPercent > .90) || (this.hasLegendaryBelt && this.healthPercent < .30)) && !hasHotStreak) {
       debug && console.log("Event Ignored @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
     } else if (spellId === SPELLS.FIRE_BLAST.id) {
       if (this.combatants.selected.hasBuff(SPELLS.HOT_STREAK.id)) {

--- a/src/Parser/Mage/Fire/Modules/Items/KoralonsBurningTouch.js
+++ b/src/Parser/Mage/Fire/Modules/Items/KoralonsBurningTouch.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import ITEMS from 'common/ITEMS';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import ItemLink from 'common/ItemLink';
+import { formatPercentage } from 'common/format';
+import Analyzer from 'Parser/Core/Analyzer';
+import Wrapper from 'common/Wrapper';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
+
+class KoralonsBurningTouch extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    abilityTracker: AbilityTracker,
+  };
+
+  badCasts = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasWaist(ITEMS.KORALONS_BURNING_TOUCH.id);
+  }
+
+  on_byPlayer_damage(event) {
+    const spellId = event.ability.guid;
+    if (spellId === SPELLS.FIREBALL.id || spellId === SPELLS.SCORCH.id) {
+      this.currentHealth = event.hitPoints;
+      this.maxHealth = event.maxHitPoints;
+    }
+
+    if (spellId === SPELLS.FIREBALL.id && this.healthPercent < .30) {
+      this.badCasts += 1;
+    }
+  }
+
+  get healthPercent() {
+    return this.currentHealth / this.maxHealth;
+  }
+
+  get scorchCasts() {
+    return this.abilityTracker.getAbility(SPELLS.SCORCH.id).casts || 0;
+  }
+
+  get totalCasts() {
+    return this.scorchCasts + this.badCasts;
+  }
+
+  get scorchUtil() {
+    return 1 - (this.badCasts / this.totalCasts);
+  }
+
+  get suggestionThreshold() {
+    return {
+      actual: this.scorchUtil,
+      isLessThan: {
+        minor: 0.95,
+        average: 0.85,
+        major: 0.70,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+		when(this.suggestionThreshold)
+			.addSuggestion((suggest, actual, recommended) => {
+				return suggest(<Wrapper>You cast <SpellLink id={SPELLS.FIREBALL.id}/>  instead of <SpellLink id={SPELLS.SCORCH.id}/> while the target was under 30% health {this.badCasts} times. When using <ItemLink id={ITEMS.KORALONS_BURNING_TOUCH.id}/> you should always make sure you are using Scorch instead of Fireball when the target is under 30% health since Scorch does 350% damage and is guaranteed to crit.</Wrapper>)
+					.icon(ITEMS.KORALONS_BURNING_TOUCH.icon)
+					.actual(`${formatPercentage(this.scorchUtil)}% Utilization`)
+					.recommended(`${formatPercentage(recommended)} is recommended`);
+			});
+  }
+
+}
+
+export default KoralonsBurningTouch;

--- a/src/Parser/Mage/Fire/Modules/Items/KoralonsBurningTouch.js
+++ b/src/Parser/Mage/Fire/Modules/Items/KoralonsBurningTouch.js
@@ -3,11 +3,13 @@ import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import ItemLink from 'common/ItemLink';
-import { formatPercentage } from 'common/format';
+import { formatPercentage, formatMilliseconds } from 'common/format';
 import Analyzer from 'Parser/Core/Analyzer';
 import Wrapper from 'common/Wrapper';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
+
+const debug = false;
 
 class KoralonsBurningTouch extends Analyzer {
   static dependencies = {
@@ -16,6 +18,7 @@ class KoralonsBurningTouch extends Analyzer {
   };
 
   badCasts = 0;
+  totalCasts = 0;
 
   on_initialized() {
     this.active = this.combatants.selected.hasWaist(ITEMS.KORALONS_BURNING_TOUCH.id);
@@ -27,22 +30,17 @@ class KoralonsBurningTouch extends Analyzer {
       this.currentHealth = event.hitPoints;
       this.maxHealth = event.maxHitPoints;
     }
-
+    if (this.healthPercent < .30) {
+      this.totalCasts += 1;
+    }
     if (spellId === SPELLS.FIREBALL.id && this.healthPercent < .30) {
       this.badCasts += 1;
+      debug && console.log("Cast Fireball under 30% Health @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
     }
   }
 
   get healthPercent() {
     return this.currentHealth / this.maxHealth;
-  }
-
-  get scorchCasts() {
-    return this.abilityTracker.getAbility(SPELLS.SCORCH.id).casts || 0;
-  }
-
-  get totalCasts() {
-    return this.scorchCasts + this.badCasts;
   }
 
   get scorchUtil() {


### PR DESCRIPTION
Added a suggestion for casting Fireball instead of Scorch when the target is under 30% health when using Koralon's Burning Touch. Also adjusted Heating Up to take Scorch guaranteed crits into account when using Koralons.