### PR TITLE
[Windwalker] Updating Combo Breaker tooltip

### DIFF
--- a/src/Parser/Monk/Windwalker/Modules/Spells/ComboBreaker.js
+++ b/src/Parser/Monk/Windwalker/Modules/Spells/ComboBreaker.js
@@ -74,7 +74,8 @@ class ComboBreaker extends Analyzer {
   
   statistic() {
     const unusedCBProcs = 1 - (this.consumedCBProc / this.CBProcsTotal);
-    let procsFromTigerPalm = this.CBProcsTotal
+    let procsFromTigerPalm = this.CBProcsTotal;
+    // Strike of the Windlord procs Combo Breaker if legendary head "The Wind Blows" is equipped
     if (this.combatants.selected.hasHead(ITEMS.THE_WIND_BLOWS.id)) {
       procsFromTigerPalm = this.CBProcsTotal - this.abilityTracker.getAbility(SPELLS.STRIKE_OF_THE_WINDLORD.id).casts;
     }

--- a/src/Parser/Monk/Windwalker/Modules/Spells/ComboBreaker.js
+++ b/src/Parser/Monk/Windwalker/Modules/Spells/ComboBreaker.js
@@ -85,7 +85,7 @@ class ComboBreaker extends Analyzer {
         icon={<SpellIcon id={SPELLS.COMBO_BREAKER_BUFF.id} />}
         value={`${formatPercentage(unusedCBProcs)}%`}
         label={`Unused Procs`}
-        tooltip={`You got a total of <b>${this.CBProcsTotal} Combo Breaker procs</b> and <b>used ${this.consumedCBProc}</b> of them. Average number of procs from your tiger palms this fight is <b>${averageCBProcs.toFixed(2)}</b>, and you got <b>${procsFromTigerPalm}</b>.`}
+        tooltip={`You got a total of <b>${this.CBProcsTotal} Combo Breaker procs</b> and <b>used ${this.consumedCBProc}</b> of them. Average number of procs from your Tiger Palms this fight is <b>${averageCBProcs.toFixed(2)}</b>, and you got <b>${procsFromTigerPalm}</b>.`}
       />
    );
   }

--- a/src/common/SPELLS/MONK.js
+++ b/src/common/SPELLS/MONK.js
@@ -656,7 +656,7 @@ export default {
   STRENGTH_OF_XUEN: {
     id: 195267,
     name: 'Strength of Xuen',
-    icon: 'ability_monk_summontigerstatue'
+    icon: 'ability_monk_summontigerstatue',
   },
   INNER_PEACE: {
     id: 195243,

--- a/src/common/SPELLS/MONK.js
+++ b/src/common/SPELLS/MONK.js
@@ -653,6 +653,11 @@ export default {
     name: 'Split Personality',
     icon: 'spell_nature_giftofthewild',
   },
+  STRENGTH_OF_XUEN: {
+    id: 195267,
+    name: 'Strength of Xuen',
+    icon: 'ability_monk_summontigerstatue'
+  },
   INNER_PEACE: {
     id: 195243,
     name: 'Inner Peace',


### PR DESCRIPTION
The part telling how many blackout kicks were used without the proc is irrelevant and pretty much just a leftover from the clearcasting/uplifting trance modules i initially took inspiration from. Providing a simple measure of how lucky/unlucky the player was with procs is more interesting.