### PR TITLE
VP Effiency, Apocalypse change to suggestiontresh and some rogue Console.logs

### DIFF
--- a/src/Parser/DeathKnight/Unholy/CombatLogParser.js
+++ b/src/Parser/DeathKnight/Unholy/CombatLogParser.js
@@ -17,6 +17,7 @@ import ScourgeStrikeEfficiency from './Modules/Features/ScourgeStrikeEfficiency'
 import ClawingShadowsEfficiency from './Modules/Features/ClawingShadowsEfficiency';
 import RpPoolingDA from './Modules/Features/RpPoolingDA';
 import Apocalypse from './Modules/Features/Apocalypse';
+import VirulentPlagueEfficiency from './Modules/Features/VirulentPlagueEfficiency';
 
 import RunicPowerDetails from './Modules/RunicPower/RunicPowerDetails';
 import RunicPowerTracker from './Modules/RunicPower/RunicPowerTracker';
@@ -41,8 +42,9 @@ class CombatLogParser extends CoreCombatLogParser {
     checklist: Checklist,
     scourgeStrikeEfficiency: ScourgeStrikeEfficiency,
     clawingShadowsEfficiency: ClawingShadowsEfficiency,
-	  rpPoolingDa: RpPoolingDA,
+	rpPoolingDa: RpPoolingDA,
   	apocalypse: Apocalypse,
+	virulentPlagueEfficiency: VirulentPlagueEfficiency,
 
     // RunicPower
     runicPowerTracker: RunicPowerTracker,

--- a/src/Parser/DeathKnight/Unholy/Modules/Features/RpPoolingDA.js
+++ b/src/Parser/DeathKnight/Unholy/Modules/Features/RpPoolingDA.js
@@ -69,7 +69,7 @@ class RpPoolingDA extends Analyzer {
 			return suggest(<Wrapper> You are casting <SpellLink id={SPELLS.DARK_ARBITER_TALENT.id}/> without enough runic power. Make sure to pool some runic power before you cast <SpellLink id={SPELLS.DARK_ARBITER_TALENT.id}/>.</Wrapper>)
 				.icon(SPELLS.DARK_ARBITER_TALENT.icon)
 				.actual(`${this.averageRpPooled.toFixed(0)} of runic power were pooled on average`)
-				.recommended(`>${(recommended)} is recommended`)
+				.recommended(`>${(recommended)} is recommended`);
         });
   }
 

--- a/src/Parser/DeathKnight/Unholy/Modules/Features/RpPoolingDA.js
+++ b/src/Parser/DeathKnight/Unholy/Modules/Features/RpPoolingDA.js
@@ -64,7 +64,7 @@ class RpPoolingDA extends Analyzer {
   }
 
   suggestions(when) {
-    when(this.suggestionThresholds.actual).isLessThan(this.suggestionThresholds.isLessThan.minor)
+    when(this.suggestionThresholds)
  		  .addSuggestion((suggest, actual, recommended) => {
 			return suggest(<Wrapper> You are casting <SpellLink id={SPELLS.DARK_ARBITER_TALENT.id}/> without enough runic power. Make sure to pool some runic power before you cast <SpellLink id={SPELLS.DARK_ARBITER_TALENT.id}/>.</Wrapper>)
 				.icon(SPELLS.DARK_ARBITER_TALENT.icon)

--- a/src/Parser/DeathKnight/Unholy/Modules/Features/RpPoolingDA.js
+++ b/src/Parser/DeathKnight/Unholy/Modules/Features/RpPoolingDA.js
@@ -70,7 +70,6 @@ class RpPoolingDA extends Analyzer {
 				.icon(SPELLS.DARK_ARBITER_TALENT.icon)
 				.actual(`${this.averageRpPooled.toFixed(0)} of runic power were pooled on average`)
 				.recommended(`>${(recommended)} is recommended`)
-				.regular(recommended - 20).major(recommended - 40);
         });
   }
 

--- a/src/Parser/DeathKnight/Unholy/Modules/Features/VirulentPlagueEfficiency.js
+++ b/src/Parser/DeathKnight/Unholy/Modules/Features/VirulentPlagueEfficiency.js
@@ -20,54 +20,57 @@ class VirulentPlagueEfficiency extends Analyzer {
   targets = {};
   
   totalOutBreakCasts = 0;
-  totalVirulentDuration = 0;
   totalTimeWasted = 0;
   
   get VirulentDuration(){
-	if (this.combatants.selected.hasTalent(SPELLS.EBON_FEVER_TALENT.id)) {
-		return(19.65);
-	} else{
-		return(33.3);
-	}
+	  if (this.combatants.selected.hasTalent(SPELLS.EBON_FEVER_TALENT.id)) {
+		  return(13.65);
+	  } else{
+		  return(27.3);
+	  }
   }
   
   on_byPlayer_refreshdebuff(event){
     const spellId = event.ability.guid;
     if(spellId === SPELLS.VIRULENT_PLAGUE.id){
-		this.targets[encodeTargetString(event.targetID, event.targetInstance)] = event.timestamp;
-	}
+		  this.targets[encodeTargetString(event.targetID, event.targetInstance)] = event.timestamp + 1000*this.VirulentDuration;
+	  }
   }
   
    on_byPlayer_applydebuff(event){
     const spellId = event.ability.guid;
     if(spellId === SPELLS.VIRULENT_PLAGUE.id){
-		this.targets[encodeTargetString(event.targetID, event.targetInstance)] = event.timestamp + 1000*0.3*this.VirulentDuration;
-		//Adding 3.15 seconds when buff is only applied. This is for cases when the target does not benefit from the epidemic effect (Dots spreading to adds not staying by target for instance.)
-	}
+		  this.targets[encodeTargetString(event.targetID, event.targetInstance)] = event.timestamp + 1000*this.VirulentDuration - 1000*0.3*this.VirulentDuration;
+		  //Removing 3.15 seconds when buff is only applied. This is for cases when the target does not benefit from the epidemic effect (Dots spreading to adds not staying by target for instance.)
+	  }
   }
   
 
   
   on_byPlayer_cast(event) {
-	const spellID = event.ability.guid;
-	if(spellID === SPELLS.OUTBREAK.id){	
-		this.totalOutBreakCasts += 1;
-		if (this.targets[encodeTargetString(event.targetID, event.targetInstance)]) {
-			//We subtract 6 seconds from the total duration since this is the time left after Outbreak finishes.
-			if (((this.VirulentDuration - 6) - (event.timestamp -  this.targets[encodeTargetString(event.targetID, event.targetInstance)]) / 1000) >= 0) {
-				this.totalTimeWasted += (this.VirulentDuration - 6) - (event.timestamp -  this.targets[encodeTargetString(event.targetID, event.targetInstance)]) / 1000;
-			}	
-		}
-	}  
+	  const spellID = event.ability.guid;
+	  if(spellID === SPELLS.OUTBREAK.id){	
+		  this.totalOutBreakCasts += 1;
+		  if (this.targets[encodeTargetString(event.targetID, event.targetInstance)]) {
+		  	//We subtract 6 seconds from the total duration since this is the time left after Outbreak finishes.
+			  if (((event.timestamp -  this.targets[encodeTargetString(event.targetID, event.targetInstance)]) / 1000) >= 0) {
+			  	this.totalTimeWasted += (event.timestamp -  this.targets[encodeTargetString(event.targetID, event.targetInstance)]) / 1000;
+			  }	
+		  }
+	  }  
   }
  
-    get suggestionThresholds() {
+  get averageTimeWasted(){
+    return(this.totalTimeWasted/this.totalOutBreakCasts);
+  }
+  
+  get suggestionThresholds() {
     return {
-      actual: 5-(this.totalTimeWasted/(this.totalOutBreakCasts)).toFixed(1),
-      isLessThan: {
-        minor: (4),
-        average: (2),
-        major: (0),
+      actual: this.averageTimeWasted,
+      isGreaterThan: {
+        minor: (1),
+        average: (3),
+        major: (5),
       },
       style: 'number',
       suffix: 'Average',
@@ -80,8 +83,8 @@ class VirulentPlagueEfficiency extends Analyzer {
  		  .addSuggestion((suggest, actual, recommended) => {
 			return suggest(<Wrapper> You are casting <SpellLink id={SPELLS.VIRULENT_PLAGUE.id}/> too often. Try to cast <SpellLink id={SPELLS.VIRULENT_PLAGUE.id}/> as close to it falling off as possible.</Wrapper>)
 				.icon(SPELLS.VIRULENT_PLAGUE.icon)
-				.actual(`${(this.totalTimeWasted/this.totalOutBreakCasts).toFixed(1)} seconds of Virulent Plague uptime was wasted on average for each cast of Outbreak`)
-				.recommended(`<${6-(recommended)} is recommended`);
+				.actual(`${(this.averageTimeWasted).toFixed(1)} seconds of Virulent Plague uptime was wasted on average for each cast of Outbreak`)
+				.recommended(`<${recommended} is recommended`);
         });
   }
 
@@ -89,9 +92,9 @@ class VirulentPlagueEfficiency extends Analyzer {
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.VIRULENT_PLAGUE.id} />}
-        value={`${(this.totalTimeWasted/this.totalOutBreakCasts).toFixed(1)} seconds`}
+        value={`${(this.averageTimeWasted).toFixed(1)} seconds`}
         label={'Average Virulent Plague Duration Waste'}
-		tooltip={`A total amount of ${this.totalTimeWasted.toFixed(1)} seconds of Virulent Plague uptime was wasted with an average amount of ${(this.totalTimeWasted/this.totalOutBreakCasts).toFixed(1)} per cast`}
+		tooltip={`A total amount of ${this.totalTimeWasted.toFixed(1)} seconds of Virulent Plague uptime was wasted with an average amount of ${(this.averageTimeWasted).toFixed(1)} seconds per cast`}
       />
     );
   }

--- a/src/Parser/DeathKnight/Unholy/Modules/Features/VirulentPlagueEfficiency.js
+++ b/src/Parser/DeathKnight/Unholy/Modules/Features/VirulentPlagueEfficiency.js
@@ -3,7 +3,6 @@ import React from 'react';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
-import { formatPercentage } from 'common/format';
 import Enemies from 'Parser/Core/Modules/Enemies';
 
 import Analyzer from 'Parser/Core/Analyzer';
@@ -82,7 +81,7 @@ class VirulentPlagueEfficiency extends Analyzer {
 			return suggest(<Wrapper> You are casting <SpellLink id={SPELLS.VIRULENT_PLAGUE.id}/> too often. Try to cast <SpellLink id={SPELLS.VIRULENT_PLAGUE.id}/> as close to it falling off as possible.</Wrapper>)
 				.icon(SPELLS.VIRULENT_PLAGUE.icon)
 				.actual(`${(this.totalTimeWasted/this.totalOutBreakCasts).toFixed(1)} seconds of Virulent Plague uptime was wasted on average for each cast of Outbreak`)
-				.recommended(`<${6-(recommended)} is recommended`)
+				.recommended(`<${6-(recommended)} is recommended`);
         });
   }
 
@@ -100,4 +99,4 @@ class VirulentPlagueEfficiency extends Analyzer {
 }
 
 
-export default VirulentPlagueEfficiency
+export default VirulentPlagueEfficiency;

--- a/src/Parser/DeathKnight/Unholy/Modules/Features/VirulentPlagueEfficiency.js
+++ b/src/Parser/DeathKnight/Unholy/Modules/Features/VirulentPlagueEfficiency.js
@@ -1,0 +1,103 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import { formatPercentage } from 'common/format';
+import Enemies from 'Parser/Core/Modules/Enemies';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import { encodeTargetString } from 'Parser/Core/Modules/EnemyInstances';
+import Wrapper from 'common/Wrapper';
+
+class VirulentPlagueEfficiency extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+	enemies: Enemies,
+  };
+  
+  targets = {};
+  
+  totalOutBreakCasts = 0;
+  totalVirulentDuration = 0;
+  totalTimeWasted = 0;
+  
+  get VirulentDuration(){
+	if (this.combatants.selected.hasTalent(SPELLS.EBON_FEVER_TALENT.id)) {
+		return(19.65);
+	} else{
+		return(33.3);
+	}
+  }
+  
+  on_byPlayer_refreshdebuff(event){
+    const spellId = event.ability.guid;
+    if(spellId === SPELLS.VIRULENT_PLAGUE.id){
+		this.targets[encodeTargetString(event.targetID, event.targetInstance)] = event.timestamp;
+	}
+  }
+  
+   on_byPlayer_applydebuff(event){
+    const spellId = event.ability.guid;
+    if(spellId === SPELLS.VIRULENT_PLAGUE.id){
+		this.targets[encodeTargetString(event.targetID, event.targetInstance)] = event.timestamp + 1000*0.3*this.VirulentDuration;
+		//Adding 3.15 seconds when buff is only applied. This is for cases when the target does not benefit from the epidemic effect (Dots spreading to adds not staying by target for instance.)
+	}
+  }
+  
+
+  
+  on_byPlayer_cast(event) {
+	const spellID = event.ability.guid;
+	if(spellID === SPELLS.OUTBREAK.id){	
+		this.totalOutBreakCasts += 1;
+		if (this.targets[encodeTargetString(event.targetID, event.targetInstance)]) {
+			//We subtract 6 seconds from the total duration since this is the time left after Outbreak finishes.
+			if (((this.VirulentDuration - 6) - (event.timestamp -  this.targets[encodeTargetString(event.targetID, event.targetInstance)]) / 1000) >= 0) {
+				this.totalTimeWasted += (this.VirulentDuration - 6) - (event.timestamp -  this.targets[encodeTargetString(event.targetID, event.targetInstance)]) / 1000;
+			}	
+		}
+	}  
+  }
+ 
+    get suggestionThresholds() {
+    return {
+      actual: 5-(this.totalTimeWasted/(this.totalOutBreakCasts)).toFixed(1),
+      isLessThan: {
+        minor: (4),
+        average: (2),
+        major: (0),
+      },
+      style: 'number',
+      suffix: 'Average',
+    };
+  }
+ 
+
+  suggestions(when) {
+    when(this.suggestionThresholds)
+ 		  .addSuggestion((suggest, actual, recommended) => {
+			return suggest(<Wrapper> You are casting <SpellLink id={SPELLS.VIRULENT_PLAGUE.id}/> too often. Try to cast <SpellLink id={SPELLS.VIRULENT_PLAGUE.id}/> as close to it falling off as possible.</Wrapper>)
+				.icon(SPELLS.VIRULENT_PLAGUE.icon)
+				.actual(`${(this.totalTimeWasted/this.totalOutBreakCasts).toFixed(1)} seconds of Virulent Plague uptime was wasted on average for each cast of Outbreak`)
+				.recommended(`<${6-(recommended)} is recommended`)
+        });
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.VIRULENT_PLAGUE.id} />}
+        value={`${(this.totalTimeWasted/this.totalOutBreakCasts).toFixed(1)} seconds`}
+        label={'Average Virulent Plague Duration Waste'}
+		tooltip={`A total amount of ${this.totalTimeWasted.toFixed(1)} seconds of Virulent Plague uptime was wasted with an average amount of ${(this.totalTimeWasted/this.totalOutBreakCasts).toFixed(1)} per cast`}
+      />
+    );
+  }
+    statisticOrder = STATISTIC_ORDER.CORE(7);
+}
+
+
+export default VirulentPlagueEfficiency

--- a/src/Parser/DeathKnight/Unholy/Modules/Items/ColdHeartEfficiency.js
+++ b/src/Parser/DeathKnight/Unholy/Modules/Items/ColdHeartEfficiency.js
@@ -102,8 +102,6 @@ class ColdHeartEfficiency extends Analyzer {
 		  this.totalColdHeartCasts++;
 	  
 		  const timeAtMaxStacks = event.timestamp - this.timeAtMaxStacksStart;
-		  console.log(timeAtMaxStacks);
-		  console.log(this.buffColdHeart);
 
 		  const unholyStrengthRemaining = unholyStrengthDuration - (event.timestamp - this.unholyStrengthStart);
 		  const concordanceRemaining = concordanceDuration - (event.timestamp - this.concordanceStart);
@@ -120,7 +118,6 @@ class ColdHeartEfficiency extends Analyzer {
 		  }
 		  else if (this.buffColdHeart === coldHeartMaxStack && timeAtMaxStacks <= maxDurationAtMaxStacksAllowed) {
 		  	this.correctColdHeartCasts++;
-			console.log(this.correctColdHeartCasts);
 		  }
 		  else if(this.buffColdHeart === coldHeartMaxStack){
 		  	this.castsTooLate++;


### PR DESCRIPTION
Removed some console.logs in Coldheart. Reworked the suggestiontreshold in Apocalypse so that they work correctly. Added a new module that tracks the reapplication of Virulent Plague.