### PR TITLE
[Havoc] Blind Fury

### DIFF
--- a/src/Parser/DemonHunter/Havoc/CHANGELOG.js
+++ b/src/Parser/DemonHunter/Havoc/CHANGELOG.js
@@ -9,6 +9,11 @@ import { Hewhosmites, Mamtooth } from 'MAINTAINERS';
 
 export default [
 	{
+		date: new Date('2018-03-01'),
+		changes: <Wrapper>Added <SpellLink id ={SPELLS.BLIND_FURY_TALENT.id} icon/> to the fury tracker.</Wrapper>,
+		contributors: [Hewhosmites]
+	},
+	{
 		date: new Date('2018-02-27'),
 		changes: <Wrapper>Added <ItemLink id={ITEMS.CHAOS_THEORY.id} icon/></Wrapper>,
 		contributors: [Hewhosmites],

--- a/src/Parser/DemonHunter/Havoc/CHANGELOG.js
+++ b/src/Parser/DemonHunter/Havoc/CHANGELOG.js
@@ -11,7 +11,7 @@ export default [
 	{
 		date: new Date('2018-03-01'),
 		changes: <Wrapper>Added <SpellLink id ={SPELLS.BLIND_FURY_TALENT.id} icon/> to the fury tracker.</Wrapper>,
-		contributors: [Hewhosmites]
+		contributors: [Hewhosmites],
 	},
 	{
 		date: new Date('2018-02-27'),

--- a/src/Parser/DemonHunter/Havoc/Modules/ResourceTracker/FuryDetails.js
+++ b/src/Parser/DemonHunter/Havoc/Modules/ResourceTracker/FuryDetails.js
@@ -1,7 +1,9 @@
 import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
 import Tab from 'Main/Tab';
+import SPELLS from 'common/SPELLS';
 import { formatPercentage, formatNumber } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import ResourceBreakdown from 'Parser/Core/Modules/ResourceTracker/ResourceBreakdown';
@@ -14,6 +16,7 @@ const furyIcon = 'inv_helm_leather_raiddemonhuntermythic_r_01';
 class FuryDetails extends Analyzer {
   static dependencies = {
     furyTracker: FuryTracker,
+    combatants: Combatants,
   };
 
   get wastedFuryPercent() {
@@ -21,15 +24,27 @@ class FuryDetails extends Analyzer {
   }
 
   get suggestionThresholds() {
-    return {
-      actual: this.wastedFuryPercent,
-      isGreaterThan: {
-        minor: 0.06,
-        average: 0.10,
-        major: 0.14,
-      },
-      style: 'percentage',
-    };
+    if (this.combatants.selected.hasTalent(SPELLS.BLIND_FURY_TALENT.id)) {
+      return {
+        actual: this.wastedFuryPercent,
+        isGreaterThan: {
+          minor: 0.06,
+          average: 0.10,
+          major: 0.14,
+        },
+        style: 'percentage',
+      };
+    } else {
+      return {
+        actual: this.wastedFuryPercent,
+        isGreaterThan: {
+          minor: 0.02,
+          average: 0.05,
+          major: 0.08,
+        },
+        style: 'percentage',
+      };
+    }
   }
 
   suggestions(when) {

--- a/src/Parser/DemonHunter/Havoc/Modules/ResourceTracker/FuryDetails.js
+++ b/src/Parser/DemonHunter/Havoc/Modules/ResourceTracker/FuryDetails.js
@@ -24,9 +24,9 @@ class FuryDetails extends Analyzer {
     return {
       actual: this.wastedFuryPercent,
       isGreaterThan: {
-        minor: 0.02,
-        average: 0.05,
-        major: 0.08,
+        minor: 0.06,
+        average: 0.10,
+        major: 0.14,
       },
       style: 'percentage',
     };
@@ -37,7 +37,7 @@ class FuryDetails extends Analyzer {
       return suggest(`You wasted ${formatNumber(this.furyTracker.wasted)} Fury.`)
         .icon(furyIcon)
         .actual(`${formatPercentage(actual)}% Fury wasted`)
-        .recommended(`Wasting less than ${formatPercentage(recommended)}% is recommended.`);
+        .recommended(`<${formatPercentage(recommended)}% is recommended.`);
     });
   }
 

--- a/src/Parser/DemonHunter/Havoc/Modules/ResourceTracker/FuryTracker.js
+++ b/src/Parser/DemonHunter/Havoc/Modules/ResourceTracker/FuryTracker.js
@@ -23,6 +23,7 @@ class FuryTracker extends ResourceTracker {
 	on_byPlayer_cast(event) {
 		const spellId = event.ability.guid;
 		const blindFuryId = SPELLS.BLIND_FURY_TALENT.id
+		//TODO: Account for Eye Beam clipping
 		// Blind Fury resource gain does not have an energize event so it is handled here
 		if(spellId === SPELLS.EYE_BEAM.id && this.combatants.selected.hasTalent(blindFuryId)) {
 			this.processInvisibleEnergize(blindFuryId, 105);

--- a/src/Parser/DemonHunter/Havoc/Modules/ResourceTracker/FuryTracker.js
+++ b/src/Parser/DemonHunter/Havoc/Modules/ResourceTracker/FuryTracker.js
@@ -20,6 +20,16 @@ class FuryTracker extends ResourceTracker {
 		this.resource = RESOURCE_TYPES.FURY;
 	}
 
+	on_byPlayer_cast(event) {
+		const spellId = event.ability.guid;
+		const blindFuryId = SPELLS.BLIND_FURY_TALENT.id
+		// Blind Fury resource gain does not have an energize event so it is handled here
+		if(spellId === SPELLS.EYE_BEAM.id && this.combatants.selected.hasTalent(blindFuryId)) {
+			this.processInvisibleEnergize(blindFuryId, 105);
+		}
+		super.on_byPlayer_cast(event);
+	}
+
 	getReducedCost(event) {
 		if(!this.getResource(event).cost) {
 			return 0;

--- a/src/Parser/DemonHunter/Havoc/Modules/ResourceTracker/FuryTracker.js
+++ b/src/Parser/DemonHunter/Havoc/Modules/ResourceTracker/FuryTracker.js
@@ -22,7 +22,7 @@ class FuryTracker extends ResourceTracker {
 
 	on_byPlayer_cast(event) {
 		const spellId = event.ability.guid;
-		const blindFuryId = SPELLS.BLIND_FURY_TALENT.id
+		const blindFuryId = SPELLS.BLIND_FURY_TALENT.id;
 		//TODO: Account for Eye Beam clipping
 		// Blind Fury resource gain does not have an energize event so it is handled here
 		if(spellId === SPELLS.EYE_BEAM.id && this.combatants.selected.hasTalent(blindFuryId)) {


### PR DESCRIPTION
[Blind Fury](http://www.wowhead.com/spell=203550/blind-fury) does not have an energize event so I added a process fake events for it. Also increased the tolerance since it usually wastes 300 over the fight but it is more important to keep eye beam on cooldown.

![image](https://user-images.githubusercontent.com/19510201/36876563-36a0173a-1d7b-11e8-969b-235ea1eb92c4.png)
[Test Log](https://www.warcraftlogs.com/reports/BHyhvwRqYjrMVfk8#fight=18&type=damage-done&source=1)