### PR TITLE
[Discipline Priest] Added Blacklist for Atonement Sources

### DIFF
--- a/src/Parser/Priest/Discipline/Modules/Features/AtonementSource.js
+++ b/src/Parser/Priest/Discipline/Modules/Features/AtonementSource.js
@@ -14,6 +14,12 @@ class AtonementSource extends Analyzer {
     [SPELLS.SHADOW_MEND.id, SPELLS.SHADOW_MEND.atonementDuration],
   ]);
 
+  // Spells / Items that do not generate atonement
+  blacklist = [
+    SPELLS.ENTROPIC_EMBRACE_DAMAGE.id, //Void Elf Racial
+    SPELLS.COLLAPSE.id, //Ring of Collapsing Futures
+  ];
+
   get atonementDuration() {
     return this.atonementApplicators;
   }
@@ -48,6 +54,11 @@ class AtonementSource extends Analyzer {
     if (!this.owner.byPlayer(event) && !this.owner.byPlayerPet(event)) {
       return;
     }
+
+    if(this.blacklist.includes(event.ability.guid)){
+      return;
+    }
+
     // Some Atonement events have the type 'damage', this prevents them registering as a source
     if (event.ability.guid === SPELLS.ATONEMENT_HEAL_NON_CRIT.id) {
       return;

--- a/src/common/SPELLS/OTHERS.js
+++ b/src/common/SPELLS/OTHERS.js
@@ -289,6 +289,11 @@ export default {
     name: 'Grease the Gears',
     icon: 'inv_misc_enggizmos_14',
   },
+  COLLAPSE: { //Ring of Collapsing Futures
+    id: 234142,
+    name: 'Collapse',
+    icon: 'spell_priest_void-blast',
+  },
 
   // Nighthold Trinkets
   RECURSIVE_STRIKES: {

--- a/src/common/SPELLS/RACIALS.js
+++ b/src/common/SPELLS/RACIALS.js
@@ -160,6 +160,11 @@ export default {
     name: 'Entropic Embrace',
     icon: 'ability_racial_entropicembrace',
   },
+  ENTROPIC_EMBRACE_DAMAGE: {
+    id: 259756,
+    name: 'Entropic Embrace',
+    icon: 'ability_racial_entropicembrace',
+  },
   // Lightforged Draenei
   LIGHTS_RECKONING: {
     id: 255652,


### PR DESCRIPTION
Some spells do not generate atonement even though they are spells that generate damage. Added a blacklist to fix this issue in the atonement sources modules