### PR TITLE
[BrM] Added Brew-Stache to mastery value

### DIFF
--- a/src/common/SPELLS/MONK.js
+++ b/src/common/SPELLS/MONK.js
@@ -569,6 +569,11 @@ export default {
     name: "Endurance of the Broken Temple",
     icon: "misc_legionfall_monk",
   },
+  BREW_STACHE: {
+    id: 214373,
+    name: "Brew-Stache",
+    icon: "inv_misc_archaeology_vrykuldrinkinghorn",
+  },
 
   // Windwalker Spells
   COMBO_STRIKES: {


### PR DESCRIPTION
Small change to the mastery value module. I'd forgotten about the Brew-Stache buff, which gives 10% dodge for 4.5 sec after drinking. This has some impact on mastery because it changes the effective mastery "cap" beyond which more mastery has no value (because you're increasing from e.g. 101% to 102% dodge).

This also makes the expected and actual dodge rates much closer in cases where someone had good brew-stache uptime.