### PR TITLE
[resto druid] Fixed a bug where ToL could show up in a checklist item when you didn't have the talent

### DIFF
--- a/src/Parser/Druid/Restoration/Modules/Features/Checklist.js
+++ b/src/Parser/Druid/Restoration/Modules/Features/Checklist.js
@@ -213,7 +213,7 @@ class Checklist extends CoreChecklist {
             name: <Wrapper><SpellLink id={SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id} icon /> throughput</Wrapper>,
             check: () => this.treeOfLife.suggestionThresholds,
             tooltip: `This is the percent of your total healing that Tree of Life contributed. Below around ${formatPercentage(this.treeOfLife.suggestionThresholds.isLessThan.average, 0)}%, you either didn't pick good times to use ToL or you would have been better off picking Cultivation`,
-            when: this.treeOfLife.active,
+            when: this.treeOfLife.hasTol,
           }),
         ];
       },


### PR DESCRIPTION
`this.treeOfLife.active` was also true when player was wearing leggo helm that procs treeOfLife