### PR TITLE
[Elemental] Only warn about elemental focus for >1 Flames Shock casts

### DIFF
--- a/src/Parser/Shaman/Elemental/Modules/ShamanCore/FlameShock.js
+++ b/src/Parser/Shaman/Elemental/Modules/ShamanCore/FlameShock.js
@@ -50,7 +50,7 @@ class FlameShock extends Analyzer {
 
   suggestions(when) {
     const flameShockCasts = this.elementalFocusCasts;
-    when(flameShockCasts.unbuffed).isGreaterThan(0)
+    when(flameShockCasts.unbuffed).isGreaterThan(1)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>Try to cast <SpellLink id={SPELLS.FLAME_SHOCK.id}/> when you have <SpellLink id={SPELLS.ELEMENTAL_FOCUS.id}/>.</span>)
           .icon(SPELLS.ELEMENTAL_FOCUS.icon)


### PR DESCRIPTION
Instead of warning when a single flame shock was cast without elemental
focus, we suggest no more than 1 flame shocks are cast without it.
Reason for the change is elemental shaman's opener, as it is possible
to cast

prepot/fire elemental -> precast EB -> FS -> LB and on

leading to unbuffed initial (short) flame shock.