### PR TITLE
Highlight inefficient Flash of Light casts in the timeline

### DIFF
--- a/src/Main/Timeline/Events.js
+++ b/src/Main/Timeline/Events.js
@@ -75,7 +75,7 @@ class Events extends React.PureComponent {
               >
                 <SpellIcon
                   id={event.ability.guid}
-                  className={meta._isInefficientCast ? 'inefficient' : undefined}
+                  className={meta.isInefficientCast ? 'inefficient' : undefined}
                   data-tip={meta.inefficientCastReason}
                 />
               </div>

--- a/src/Main/Timeline/Events.js
+++ b/src/Main/Timeline/Events.js
@@ -62,6 +62,7 @@ class Events extends React.PureComponent {
     return (
       <div className={`events ${className || ''}`} style={{ width: totalWidth }}>
         {fixedEvents.map((event, index) => {
+          const meta = event.meta || {};
           if (event.type === 'cast') {
             return (
               <div
@@ -72,7 +73,11 @@ class Events extends React.PureComponent {
                   zIndex: 10,
                 }}
               >
-                <SpellIcon id={event.ability.guid} />
+                <SpellIcon
+                  id={event.ability.guid}
+                  className={meta._isInefficientCast ? 'inefficient' : undefined}
+                  data-tip={meta.inefficientCastReason}
+                />
               </div>
             );
           }

--- a/src/Main/Timeline/SpellTimeline.css
+++ b/src/Main/Timeline/SpellTimeline.css
@@ -78,10 +78,12 @@
   border-right: 2px solid rgba(250, 250, 250, 0.6);
 }
 .spell-timeline .events .inefficient {
-  border: 4px solid red;
+  border: 2px solid red;
   box-sizing: content-box;
-  margin-left: -2px;
-  margin-top: -2px;
+  margin-left: -1px;
+  margin-top: -1px;
+  box-shadow: 0 0 11px red;
+  border-radius: 2px;
 }
 
 /* vertical scrollbar track */

--- a/src/Main/Timeline/SpellTimeline.css
+++ b/src/Main/Timeline/SpellTimeline.css
@@ -77,6 +77,12 @@
   background: rgba(120, 102, 255, 0.4);
   border-right: 2px solid rgba(250, 250, 250, 0.6);
 }
+.spell-timeline .events .inefficient {
+  border: 4px solid red;
+  box-sizing: content-box;
+  margin-left: -2px;
+  margin-top: -2px;
+}
 
 /* vertical scrollbar track */
 .gm-scrollbar.-vertical {

--- a/src/Parser/Paladin/Holy/CHANGELOG.js
+++ b/src/Parser/Paladin/Holy/CHANGELOG.js
@@ -10,6 +10,11 @@ import SpellLink from 'common/SpellLink';
 export default [
   {
     date: new Date('2018-03-12'),
+    changes: <Wrapper>Inefficient <SpellLink id={SPELLS.FLASH_OF_LIGHT.id} icon /> casts will now be highlighted in the timeline with a red border.</Wrapper>,
+    contributors: [Zerotorescue],
+  },
+  {
+    date: new Date('2018-03-12'),
     changes: <Wrapper>Fixed a bug where chained <SpellLink id={SPELLS.FLASH_OF_LIGHT.id} icon /> casts might incorrectly mark the second <SpellLink id={SPELLS.FLASH_OF_LIGHT.id} icon /> as being affected by <SpellLink id={SPELLS.INFUSION_OF_LIGHT.id} icon /> instead of being marked as inefficient.</Wrapper>,
     contributors: [Zerotorescue],
   },

--- a/src/Parser/Paladin/Holy/Modules/Abilities.js
+++ b/src/Parser/Paladin/Holy/Modules/Abilities.js
@@ -15,7 +15,6 @@ class Abilities extends CoreAbilities {
     return [
       {
         spell: SPELLS.HOLY_SHOCK_CAST,
-        name: 'BOOM', // TODO: Remvoe this when done with testing
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         cooldown: (haste, combatantCurrent) => {
           const hasSanctifiedWrath = combatant.hasTalent(SPELLS.SANCTIFIED_WRATH_TALENT.id);
@@ -30,7 +29,6 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.LIGHT_OF_DAWN_CAST,
-        name: 'FWOOSH', // TODO: Remvoe this when done with testing
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         // Item - Paladin T20 Holy 2P Bonus: Reduces the cooldown of Light of Dawn by 2.0 sec.
         cooldown: haste => (12 - (combatant.hasBuff(SPELLS.HOLY_PALADIN_T20_2SET_BONUS_BUFF.id) ? 2 : 0)) / (1 + haste),

--- a/src/Parser/Paladin/Holy/Modules/PaladinCore/FillerFlashOfLight.js
+++ b/src/Parser/Paladin/Holy/Modules/PaladinCore/FillerFlashOfLight.js
@@ -19,6 +19,8 @@ const HOLY_SHOCK_COOLDOWN_WAIT_TIME = 200;
  * The question is how much of a fraction of a second? I am fairly confident feelycrafting that waiting 200ms is more efficient, and I think up to 300ms is also going to be more efficient, maybe a bit further but hard to say.
  *
  * So then the question is what is a reasonable amount to ask of a player? I think 200ms is an amount that is very hard to differentiate from a spell just coming off cooldown. It's a delay similar to latency during raid fights. Spamming HS while its icon is as good as off cooldown would be the best course of action here and not take any uber skills form the player. So I reckon it's reasonable to include casts as being inefficient casts at this interval.
+ *
+ * Example log with 16 inefficient casts: report/kzKnrR4qdhXGjB38/16-Heroic+Aggramar+-+Kill+(6:50)/13-Seedÿ
  */
 class FillerFlashOfLight extends Analyzer {
   static dependencies = {

--- a/src/Parser/Paladin/Holy/Modules/PaladinCore/FillerFlashOfLight.js
+++ b/src/Parser/Paladin/Holy/Modules/PaladinCore/FillerFlashOfLight.js
@@ -28,7 +28,7 @@ class FillerFlashOfLight extends Analyzer {
   };
 
   inefficientCasts = [];
-  _isCurrentInefficientCast = false;
+  _isCurrentCastInefficient = false;
   on_byPlayer_begincast(event) {
     const spellId = event.ability.guid;
     if (spellId !== SPELLS.FLASH_OF_LIGHT.id) {
@@ -36,9 +36,9 @@ class FillerFlashOfLight extends Analyzer {
     }
     if (this._isInefficientCastEvent(event)) {
       this.inefficientCasts.push(event);
-      this._isCurrentInefficientCast = true;
+      this._isCurrentCastInefficient = true;
     } else {
-      this._isCurrentInefficientCast = false;
+      this._isCurrentCastInefficient = false;
     }
   }
   _isInefficientCastEvent(event) {
@@ -68,7 +68,7 @@ class FillerFlashOfLight extends Analyzer {
     if (spellId !== SPELLS.FLASH_OF_LIGHT.id) {
       return;
     }
-    if (this._isCurrentInefficientCast) {
+    if (this._isCurrentCastInefficient) {
       event.meta = event.meta || {};
       event.meta.isInefficientCast = true;
       event.meta.inefficientCastReason = 'Holy Shock was off cooldown when you started channeling this unbuffed Flash of Light. You should cast Holy Shock instead.';


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4565223/37297763-c015dbca-261e-11e8-8f86-a0cb9224713d.png)

It also has a tooltip to explain the issue:
![image](https://user-images.githubusercontent.com/4565223/37297789-d775b204-261e-11e8-8ee0-3d359dcc703a.png)

Example log: http://localhost:3000/report/kzKnrR4qdhXGjB38/16-Heroic+Aggramar+-+Kill+(6:50)/13-Seed%C3%BF