### PR TITLE
Update ColdHeartEfficiency.js

### DIFF
--- a/src/Parser/DeathKnight/Unholy/Modules/Items/ColdHeartEfficiency.js
+++ b/src/Parser/DeathKnight/Unholy/Modules/Items/ColdHeartEfficiency.js
@@ -112,11 +112,14 @@ class ColdHeartEfficiency extends Analyzer {
 			if ((unholyStrengthRemaining > 0 && unholyStrengthRemaining < remainingDurationAllowed) || (concordanceRemaining > 0 && concordanceRemaining < remainingDurationAllowed) || (khazgorothRemaining > 0 && khazgorothRemaining < remainingDurationAllowed)){
 				  this.correctColdHeartCasts++;
 			  }
+        else if (this.buffColdHeart < coldHeartMaxStack) {
+		  	this.castsTooEarly++;
+        }
 		  }
 		  else if (this.buffColdHeart < coldHeartMaxStack) {
 		  	this.castsTooEarly++;
 		  }
-		  else if (this.buffColdHeart === coldHeartMaxStack && timeAtMaxStacks <= maxDurationAtMaxStacksAllowed) {
+		  else if (this.buffColdHeart === coldHeartMaxStack && ((timeAtMaxStacks <= maxDurationAtMaxStacksAllowed) || ((event.timestamp - this.owner.fight.start_time) < 7000))) {
 		  	this.correctColdHeartCasts++;
 		  }
 		  else if(this.buffColdHeart === coldHeartMaxStack){


### PR DESCRIPTION
Fixed an issue where the suggestions wouldn't correctly count the amount of casts that were made too early. Furthermore, added some leniency to the first cast since an opener where Cold Heart is used after Apocalypse is also viable. Current code will fail that cast since it happens after more than 4 seconds.