### PR TITLE
[BDK] added Souldrinker

### DIFF
--- a/src/Parser/DeathKnight/Blood/CHANGELOG.js
+++ b/src/Parser/DeathKnight/Blood/CHANGELOG.js
@@ -9,6 +9,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-03-14'),
+    changes: <Wrapper>Added <SpellLink id={SPELLS.SOULDRINKER_TRAIT.id} icon />-Module to track the average HP-bonus.</Wrapper>,
+    contributors: [joshinator],
+  },
+  {
     date: new Date('2018-03-11'),
     changes: <Wrapper>Added <SpellLink id={SPELLS.MARROWREND.id} icon />-Module to track bad casts</Wrapper>,
     contributors: [joshinator],

--- a/src/Parser/DeathKnight/Blood/CombatLogParser.js
+++ b/src/Parser/DeathKnight/Blood/CombatLogParser.js
@@ -18,6 +18,7 @@ import UnendingThirstTracker from './Modules/Features/UnendingThirstTracker';
 import Checklist from './Modules/Features/Checklist';
 import DeathStrikeTimingGraph from './Modules/Features/DeathStrikeTimingGraph';
 import MarrowrendUsage from './Modules/Features/MarrowrendUsage';
+import Souldrinker from './Modules/Features/Souldrinker';
 
 // Resources
 import RunicPowerDetails from './Modules/RunicPower/RunicPowerDetails';
@@ -61,6 +62,7 @@ class CombatLogParser extends CoreCombatLogParser {
     checklist: Checklist,
     deathStrikeTimingGraph: DeathStrikeTimingGraph,
     marrowrendUsage: MarrowrendUsage,
+    souldrinker: Souldrinker,
 
 
     // DOT

--- a/src/Parser/DeathKnight/Blood/Modules/Features/Souldrinker.js
+++ b/src/Parser/DeathKnight/Blood/Modules/Features/Souldrinker.js
@@ -74,8 +74,6 @@ class Souldrinker extends Analyzer {
         icon={<SpellIcon id={SPELLS.SOULDRINKER_TRAIT.id} />}
         value={`${ this.avgSoulDrinker.toFixed(2) }%`}
         label="average Soul Drinker buff"
-        tooltip={`The goal of this statistic is to deliver information about your average Souldrinker bonus.<br>
-        Don't aim for 30% as raw Death Strike healing is more valuable.`}
       />
     );
   }

--- a/src/Parser/DeathKnight/Blood/Modules/Features/Souldrinker.js
+++ b/src/Parser/DeathKnight/Blood/Modules/Features/Souldrinker.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+class Souldrinker extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  avgSoulDrinker = 0;
+  _soulDrinker = [];
+  _dsOverheals = [];
+
+  SOULDRINKER_DURATION = 15;
+  SOULDRINKER_EFFECTIVENESS = .5;
+  SOULDRINKER_CAP = 30;
+
+  /*
+    _dsOverheals contains all healing events (DS & Consumption can trigger Souldrinker)
+    _soulDrinker contains for each second the %-buff
+  */
+
+  on_initialized() {
+    this.active = this.combatants.selected.traitsBySpellId[SPELLS.SOULDRINKER_TRAIT.id];
+  }
+
+  on_byPlayer_heal(event) {
+    if (event.ability.guid !== SPELLS.DEATH_STRIKE_HEAL.id && event.ability.guid !== SPELLS.CONSUMPTION_HEAL.id) {
+      return;
+    }
+
+    if (event.overheal === undefined) {
+      return;
+    }
+
+    this._dsOverheals.push(event);
+    this._soulDrinker = Array.from({length: Math.ceil(this.owner.fightDuration / 1000)}, (x, i) => 0);
+
+    //only add DS heals that did overheal
+    const temp = this._dsOverheals.map(({ timestamp, maxHitPoints, overheal }) => {
+      return {
+        second: Math.floor((timestamp - this.owner.fight.start_time) / 1000) - 1,
+        overhealPercent: (overheal * this.SOULDRINKER_EFFECTIVENESS / maxHitPoints) * 100,
+      };
+    });
+
+    temp.forEach(({ second, overhealPercent }) => {
+      const updateFrame = this._soulDrinker.slice(second, second + this.SOULDRINKER_DURATION);
+      updateFrame.forEach((elem, index) => {
+        let newPercent = updateFrame[index] += overhealPercent;
+        if (newPercent > this.SOULDRINKER_CAP) {
+          newPercent = this.SOULDRINKER_CAP;
+        }
+        updateFrame[index] = newPercent;
+      });
+
+      this._soulDrinker.splice(second, this.SOULDRINKER_DURATION, ...updateFrame);
+    });
+
+    const sum = this._soulDrinker.reduce((a, b) => {
+      return a + b;
+    });
+
+    this.avgSoulDrinker = sum / this._soulDrinker.length;
+  }
+
+  statistic() {
+
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.SOULDRINKER_TRAIT.id} />}
+        value={`${ this.avgSoulDrinker.toFixed(2) }%`}
+        label="average Soul Drinker buff"
+        tooltip={`The goal of this statistic is to deliver information about your average Souldrinker bonus.<br>
+        Don't aim for 30% as raw Death Strike healing is more valuable.`}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(3);
+}
+
+export default Souldrinker;

--- a/src/common/SPELLS/DEATH_KNIGHT.js
+++ b/src/common/SPELLS/DEATH_KNIGHT.js
@@ -13,7 +13,8 @@ export default {
     icon: 'inv_axe_2h_artifactmaw_d_01',
   },
 
-  UMBILICUS_ETERNUS: { //Artifact Trait
+  //Artifact Trait
+  UMBILICUS_ETERNUS: {
     id: 193213,
     name: 'Umbilicus Eternus',
     icon: 'artifactability_blooddeathknight_umbilicuseternus',
@@ -23,6 +24,12 @@ export default {
     id: 193320,
     name: 'Umbilicus Eternus Buff',
     icon: 'artifactability_blooddeathknight_umbilicuseternus',
+  },
+
+  SOULDRINKER_TRAIT: {
+    id: 238114,
+    name: 'Souldrinker',
+    icon: 'spell_deathknight_butcher2',
   },
 
   // Damage Dealing
@@ -572,6 +579,12 @@ export default {
     id: 45470,
     name: 'Death Strike Heal',
     icon: 'spell_deathknight_butcher2',
+  },
+
+  CONSUMPTION_HEAL: {
+    id: 205224,
+    name: 'Consumption Heal',
+    icon: 'inv_axe_2h_artifactmaw_d_01',
   },
 
   ICEBOUND_FORTITUDE: {


### PR DESCRIPTION
Tracking for the Souldrinker-Trait
(tracking the % is done manually since the combatlog event doesn't contain the exact values)

![sd](https://user-images.githubusercontent.com/29842841/37413432-58376d0e-27a7-11e8-962b-5325ab497d53.PNG)
