### PR TITLE
[Hunter] remove errors from timeline

### DIFF
--- a/src/Parser/Hunter/BeastMastery/CombatLogParser.js
+++ b/src/Parser/Hunter/BeastMastery/CombatLogParser.js
@@ -1,6 +1,7 @@
 import CoreCombatLogParser from 'Parser/Core/CombatLogParser';
 import DamageDone from 'Parser/Core/Modules/DamageDone';
 import GlobalCooldown from './Modules/Core/GlobalCooldown';
+import SpellUsable from '../Shared/Modules/Core/SpellUsable';
 
 //Features
 import Abilities from './Modules/Abilities';
@@ -67,6 +68,7 @@ class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     damageDone: [DamageDone, { showStatistic: true }],
     globalCooldown: GlobalCooldown,
+    spellUsable: SpellUsable,
 
     //Features
     alwaysBeCasting: AlwaysBeCasting,

--- a/src/Parser/Hunter/Marksmanship/CombatLogParser.js
+++ b/src/Parser/Hunter/Marksmanship/CombatLogParser.js
@@ -1,6 +1,8 @@
 import CoreCombatLogParser from 'Parser/Core/CombatLogParser';
 import DamageDone from 'Parser/Core/Modules/DamageDone';
 import Abilities from './Modules/Abilities';
+import SpellUsable from '../Shared/Modules/Core/SpellUsable';
+
 //Features
 import CooldownThroughputTracker from './Modules/Features/CooldownThroughputTracker';
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
@@ -71,6 +73,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Core statistics
     damageDone: [DamageDone, { showStatistic: true }],
     abilities: Abilities,
+    spellUsable: SpellUsable,
 
     // Features
     alwaysBeCasting: AlwaysBeCasting,

--- a/src/Parser/Hunter/Shared/Modules/Core/SpellUsable.js
+++ b/src/Parser/Hunter/Shared/Modules/Core/SpellUsable.js
@@ -1,0 +1,9 @@
+import SpellUsableCore from 'Parser/Core/Modules/SpellUsable';
+
+class SpellUsable extends SpellUsableCore {
+  get isAccurate() {
+    return true;
+  }
+}
+
+export default SpellUsable;

--- a/src/Parser/Hunter/Survival/CombatLogParser.js
+++ b/src/Parser/Hunter/Survival/CombatLogParser.js
@@ -2,6 +2,7 @@ import CoreCombatLogParser from 'Parser/Core/CombatLogParser';
 import DamageDone from 'Parser/Core/Modules/DamageDone';
 import Abilities from './Modules/Abilities';
 import Channeling from './Modules/Helper/Channeling';
+import SpellUsable from '../Shared/Modules/Core/SpellUsable';
 
 //Features
 import CooldownThroughputTracker from './Modules/Features/CooldownThroughputTracker';
@@ -68,6 +69,7 @@ class CombatLogParser extends CoreCombatLogParser {
     damageDone: [DamageDone, { showStatistic: true }],
     abilities: Abilities,
     channeling: Channeling,
+    spellUsable: SpellUsable,
 
     // Features
     alwaysBeCasting: AlwaysBeCasting,


### PR DESCRIPTION
All 3 hunter specs were getting their GCD and Cooldown duration disabled under the new requirements. 
Returning true always on them as I am actively maintaining them and they aren't inaccurate (in any trackable degree), some things are merely untrackable (Convergence which is widely used in the specs and Animal Instincts for SV aswell as BM/SV using haste affected CD spells often enough to trigger off racials) 


and I don't feel like completely ruining a ton of metrics by  disabling the CD properties on these spells like I've reluctantly done on DireFrenzy/DireBeast/MongooseBite already. That would reach a point of no big point in having the analyzer if start disabling that much. 