### PR TITLE
[core] Sort timeline to match abilities.js ordering

### DIFF
--- a/src/Main/Timeline/SpellTimeline.js
+++ b/src/Main/Timeline/SpellTimeline.js
@@ -63,15 +63,27 @@ class SpellTimeline extends React.PureComponent {
 
   get spells() {
     const { spellId, historyBySpellId, abilities } = this.props;
-    const spellIds = spellId ? [spellId] : Object.keys(historyBySpellId).map(Number);
+    const spellIds = (spellId ? [spellId] : Object.keys(historyBySpellId).map(Number))
+      .filter(key => key > 0); //filter out fake spells (spell id <= 0)
+    const sorting = abilities.abilities;
+    console.log(sorting);
+    console.log(spellIds);
 
-    return spellIds
-      .filter(key => key > 0) //filter out fake spells (spell id <= 0)
-      .sort((a, b) => {
-      const aCooldown = abilities.getExpectedCooldownDuration(Number(a));
-      const bCooldown = abilities.getExpectedCooldownDuration(Number(b));
-      return aCooldown - bCooldown;
+    const result = [];
+    sorting.forEach((ability) => {
+      if(ability.spell.id){
+        if(spellIds.includes(ability.spell.id) && !result.includes(ability.spell.id)){
+          result.push(ability.spell.id);
+        }
+      } else {
+        if(spellIds.includes(ability.spell[0].id) && !result.includes(ability.spell.id)){
+          result.push(ability.spell[0].id);
+        }
+      }
     });
+    console.log(result);
+
+    return result;
   }
 
   gemini = null;

--- a/src/Main/Timeline/SpellTimeline.js
+++ b/src/Main/Timeline/SpellTimeline.js
@@ -66,8 +66,6 @@ class SpellTimeline extends React.PureComponent {
     const spellIds = (spellId ? [spellId] : Object.keys(historyBySpellId).map(Number))
       .filter(key => key > 0); //filter out fake spells (spell id <= 0)
     const sorting = abilities.abilities;
-    console.log(sorting);
-    console.log(spellIds);
 
     const result = [];
     sorting.forEach((ability) => {
@@ -81,7 +79,6 @@ class SpellTimeline extends React.PureComponent {
         }
       }
     });
-    console.log(result);
 
     return result;
   }

--- a/src/Main/Timeline/SpellTimeline.js
+++ b/src/Main/Timeline/SpellTimeline.js
@@ -63,9 +63,8 @@ class SpellTimeline extends React.PureComponent {
 
   get spells() {
     const { spellId, historyBySpellId, abilities } = this.props;
-    const spellIds = (spellId ? [spellId] : Object.keys(historyBySpellId).map(Number))
-      .filter(key => key > 0); //filter out fake spells (spell id <= 0)
-    const sorting = abilities.abilities;
+    const spellIds = spellId ? [spellId] : Object.keys(historyBySpellId).map(Number);
+    /*const sorting = abilities.abilities;
 
     const result = [];
     sorting.forEach((ability) => {
@@ -80,7 +79,18 @@ class SpellTimeline extends React.PureComponent {
       }
     });
 
-    return result;
+    return result;*/
+
+    return spellIds
+      .filter(key => key > 0) //filter out fake spells (spell id <= 0)
+      .sort((a, b) => {
+        const aIndex = abilities.getTimelineSortIndex(Number(a)) || Number.MAX_VALUE;
+        const bIndex = abilities.getTimelineSortIndex(Number(b)) || Number.MAX_VALUE;
+        const aCooldown = abilities.getExpectedCooldownDuration(Number(a));
+        const bCooldown = abilities.getExpectedCooldownDuration(Number(b));
+        return aIndex - bIndex || aCooldown - bCooldown;
+      });
+
   }
 
   gemini = null;

--- a/src/Main/Timeline/SpellTimeline.js
+++ b/src/Main/Timeline/SpellTimeline.js
@@ -64,22 +64,6 @@ class SpellTimeline extends React.PureComponent {
   get spells() {
     const { spellId, historyBySpellId, abilities } = this.props;
     const spellIds = spellId ? [spellId] : Object.keys(historyBySpellId).map(Number);
-    /*const sorting = abilities.abilities;
-
-    const result = [];
-    sorting.forEach((ability) => {
-      if(ability.spell.id){
-        if(spellIds.includes(ability.spell.id) && !result.includes(ability.spell.id)){
-          result.push(ability.spell.id);
-        }
-      } else {
-        if(spellIds.includes(ability.spell[0].id) && !result.includes(ability.spell.id)){
-          result.push(ability.spell[0].id);
-        }
-      }
-    });
-
-    return result;*/
 
     return spellIds
       .filter(key => key > 0) //filter out fake spells (spell id <= 0)

--- a/src/Parser/Core/Modules/Abilities.js
+++ b/src/Parser/Core/Modules/Abilities.js
@@ -79,6 +79,14 @@ class Abilities extends Analyzer {
     const ability = this.getAbility(spellId);
     return ability ? (ability.charges || 1) : undefined;
   }
+
+  /*
+   * Returns the timeline sort index, or null if none is set. (or undefined if there is no such spellInfo)
+   */
+  getTimelineSortIndex(spellId) {
+    const ability = this.getAbility(spellId);
+    return ability ? (ability.timelineSortIndex || null) : undefined;
+  }
 }
 
 export default Abilities;

--- a/src/Parser/Core/Modules/Ability.js
+++ b/src/Parser/Core/Modules/Ability.js
@@ -87,6 +87,10 @@ class Ability {
      * A boolean to indicate it can not be detected whether the player his this spells. This makes it so the spell is hidden when there are 0 casts in the fight. This should only be used for spells that can't be detected if a player has access to them, like racials.
      */
     isUndetectable: PropTypes.bool,
+    /**
+     * The ability's priority on the timeline. The lower the number the higher on the timeline it will be displayed.
+     */
+    timelineSortIndex: PropTypes.number,
   };
 
   _owner = null;

--- a/src/Parser/Druid/Balance/Modules/Features/Abilities.js
+++ b/src/Parser/Druid/Balance/Modules/Features/Abilities.js
@@ -27,42 +27,50 @@ class Abilities extends CoreAbilities {
             </Wrapper>
           ),
         },
+        timelineSortIndex: 1,
       },
       {
         spell: SPELLS.STARSURGE_MOONKIN,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         isOnGCD: true,
+        timelineSortIndex: 2,
       },
       {
         spell: SPELLS.STARFALL_CAST,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         isOnGCD: true,
+        timelineSortIndex: 3,
       },
       {
         spell: SPELLS.SOLAR_WRATH_MOONKIN,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         isOnGCD: true,
+        timelineSortIndex: 4,
       },
       {
         spell: SPELLS.LUNAR_STRIKE,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         isOnGCD: true,
+        timelineSortIndex: 5,
       },
       {
         spell: SPELLS.MOONFIRE,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         isOnGCD: true,
+        timelineSortIndex: 6,
       },
       {
         spell: SPELLS.SUNFIRE_CAST,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         isOnGCD: true,
+        timelineSortIndex: 7,
       },
       {
         spell: SPELLS.STELLAR_FLARE_TALENT,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         enabled: combatant.hasTalent(SPELLS.STELLAR_FLARE_TALENT.id),
         isOnGCD: true,
+        timelineSortIndex: 8,
       },
 
       // Cooldowns
@@ -75,6 +83,7 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: 0.9,
         },
+        timelineSortIndex: 9,
       },
       {
         spell: SPELLS.CELESTIAL_ALIGNMENT,
@@ -85,6 +94,7 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: 0.9,
         },
+        timelineSortIndex: 9,
       },
       {
         spell: SPELLS.WARRIOR_OF_ELUNE_TALENT,
@@ -95,6 +105,7 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: 0.9,
         },
+        timelineSortIndex: 10,
       },
       {
         spell: SPELLS.FORCE_OF_NATURE_TALENT,
@@ -106,6 +117,7 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: 0.9,
         },
+        timelineSortIndex: 10,
       },
       {
         spell: SPELLS.ASTRAL_COMMUNION_TALENT,
@@ -116,6 +128,7 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: 0.9,
         },
+        timelineSortIndex: 11,
       },
 
       //Utility
@@ -129,6 +142,7 @@ class Abilities extends CoreAbilities {
           averageIssueEfficiency: 0.50,
           majorIssueEfficiency: 0.30,
         },
+        timelineSortIndex: 12,
       },
       {
         spell: SPELLS.BARKSKIN,
@@ -139,12 +153,14 @@ class Abilities extends CoreAbilities {
           recommendedEfficiency: 0.6,
           importance: ISSUE_IMPORTANCE.MINOR,
         },
+        timelineSortIndex: 13,
       },
       {
         spell: SPELLS.RENEWAL_TALENT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 90,
         enabled: combatant.hasTalent(SPELLS.RENEWAL_TALENT.id),
+        timelineSortIndex: 14,
       },
       {
         spell: SPELLS.DISPLACER_BEAST_TALENT,


### PR DESCRIPTION
Currently it is sorted by Cooldown length and secondary is spellID, which is not ideal for utility spells with no cooldown as they will show up at the top of the timeline (Druid forms for instance).
This change will allow devs to customize the order as they see fit.

Before:
![image](https://user-images.githubusercontent.com/6773230/37462923-d0d384ee-2853-11e8-90f0-31e971315ccf.png)
After:
![image](https://user-images.githubusercontent.com/6773230/37462936-dedcd9e6-2853-11e8-96fd-77356159cda5.png)
