### PR TITLE
[Windwalker] Refactoring order of statistics

### DIFF
--- a/src/Parser/Monk/Windwalker/Modules/Chi/ChiDetails.js
+++ b/src/Parser/Monk/Windwalker/Modules/Chi/ChiDetails.js
@@ -72,7 +72,7 @@ class ChiDetails extends Analyzer {
         };
     }
 
-    statisticOrder = STATISTIC_ORDER.CORE(2);
+    statisticOrder = STATISTIC_ORDER.CORE(1);
 }
 
 export default ChiDetails;

--- a/src/Parser/Monk/Windwalker/Modules/Features/Checklist.js
+++ b/src/Parser/Monk/Windwalker/Modules/Features/Checklist.js
@@ -84,7 +84,7 @@ class Checklist extends CoreChecklist {
       requirements: () => {
         return [
           new Requirement({
-            name: <Wrapper>Wasted <SpellLink id={SPELLS.COMBO_BREAKER_BUFF.id} icon /> procs </Wrapper>,
+            name: <Wrapper><SpellLink id={SPELLS.COMBO_BREAKER_BUFF.id} icon /> procs used </Wrapper>,
             check: () => this.comboBreaker.suggestionThresholds,
           }),
           new Requirement({

--- a/src/Parser/Monk/Windwalker/Modules/Spells/BlackoutKick.js
+++ b/src/Parser/Monk/Windwalker/Modules/Spells/BlackoutKick.js
@@ -70,7 +70,7 @@ class BlackoutKick extends Analyzer {
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
       return suggest('You are casting Blackout Kick while having important casts available')
         .icon(SPELLS.BLACKOUT_KICK.icon)
-        .actual(`${this.inefficientCastsPerMinute.toFixed(2)} Bad Blackout Kick casts`)
+        .actual(`${this.inefficientCastsPerMinute.toFixed(2)} Bad Blackout Kick casts per minute`)
         .recommended(`${recommended} is recommended`);
     });
   }
@@ -85,7 +85,7 @@ class BlackoutKick extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(10);
+  statisticOrder = STATISTIC_ORDER.CORE(5);
 }
 
 export default BlackoutKick;

--- a/src/Parser/Monk/Windwalker/Modules/Spells/ComboBreaker.js
+++ b/src/Parser/Monk/Windwalker/Modules/Spells/ComboBreaker.js
@@ -59,14 +59,14 @@ class ComboBreaker extends Analyzer {
     }
   }
   get suggestionThresholds() {
-    const unusedCBprocs = 1 - (this.consumedCBProc / this.CBProcsTotal);
+    const usedCBprocs =  this.consumedCBProc / this.CBProcsTotal;
     const baseThreshold = this.combatants.selected.hasBuff(SPELLS.WW_TIER21_2PC.id) ? 0.05 : 0.1;
     return {
-      actual: unusedCBprocs,
-      isGreaterThan: {
-        minor: baseThreshold,
-        average: baseThreshold * 2,
-        major: baseThreshold * 3,
+      actual: usedCBprocs,
+      isLessThan: {
+        minor: 1 - baseThreshold,
+        average: 1 - baseThreshold * 2,
+        major: 1 - baseThreshold * 3,
       },
       style: 'percentage',
     };
@@ -77,13 +77,13 @@ class ComboBreaker extends Analyzer {
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>Your <SpellLink id={SPELLS.COMBO_BREAKER_BUFF.id} /> procs should be used before you tiger palm again so they are not overwritten. While some will be overwritten due to higher priority of getting Chi for spenders, wasting <SpellLink id={SPELLS.COMBO_BREAKER_BUFF.id} /> procs is not optimal.</span>)
           .icon(SPELLS.COMBO_BREAKER_BUFF.icon)
-          .actual(`${formatPercentage(unusedCBprocs)}% Unused Combo Breaker procs`)
-          .recommended(`<${formatPercentage(recommended)}% wasted Combo Breaker Procs is recommended`);
+          .actual(`${formatPercentage(unusedCBprocs)}% used Combo Breaker procs`)
+          .recommended(`>${formatPercentage(recommended)}% used Combo Breaker Procs is recommended`);
     });
   }
   
   statistic() {
-    const unusedCBProcs = 1 - (this.consumedCBProc / this.CBProcsTotal);
+    const usedCBProcs = this.consumedCBProc / this.CBProcsTotal;
     let procsFromTigerPalm = this.CBProcsTotal;
     // Strike of the Windlord procs Combo Breaker if legendary head "The Wind Blows" is equipped
     if (this.combatants.selected.hasHead(ITEMS.THE_WIND_BLOWS.id)) {
@@ -93,13 +93,13 @@ class ComboBreaker extends Analyzer {
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.COMBO_BREAKER_BUFF.id} />}
-        value={`${formatPercentage(unusedCBProcs)}%`}
-        label={`Unused Procs`}
+        value={`${formatPercentage(usedCBProcs)}%`}
+        label={`Combo Breaker Procs Used`}
         tooltip={`You got a total of <b>${this.CBProcsTotal} Combo Breaker procs</b> and <b>used ${this.consumedCBProc}</b> of them. Average number of procs from your Tiger Palms this fight is <b>${averageCBProcs.toFixed(2)}</b>, and you got <b>${procsFromTigerPalm}</b>.`}
       />
    );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(20);
+  statisticOrder = STATISTIC_ORDER.CORE(4);
 }
 
 export default ComboBreaker;

--- a/src/Parser/Monk/Windwalker/Modules/Spells/FistsofFury.js
+++ b/src/Parser/Monk/Windwalker/Modules/Spells/FistsofFury.js
@@ -78,7 +78,7 @@ class FistsofFury extends Analyzer {
             />
         );
     }
-    statisticOrder = STATISTIC_ORDER.OPTIONAL(2);
+    statisticOrder = STATISTIC_ORDER.CORE(6);
 }
 
 

--- a/src/Parser/Monk/Windwalker/Modules/Spells/StormEarthAndFire.js
+++ b/src/Parser/Monk/Windwalker/Modules/Spells/StormEarthAndFire.js
@@ -164,7 +164,7 @@ class StormEarthAndFire extends Analyzer{
       </StatisticsListBox>
     );
   }
-  statisticOrder = STATISTIC_ORDER.CORE(14);
+  statisticOrder = STATISTIC_ORDER.CORE(11);
 }
 
 export default StormEarthAndFire;

--- a/src/Parser/Monk/Windwalker/Modules/Spells/TouchOfKarma.js
+++ b/src/Parser/Monk/Windwalker/Modules/Spells/TouchOfKarma.js
@@ -56,7 +56,7 @@ class TouchOfKarma extends Analyzer {
         />
     );
   }
-  statisticOrder = STATISTIC_ORDER.CORE(10);
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(2);
 }
 
 export default TouchOfKarma;

--- a/src/Parser/Monk/Windwalker/Modules/Talents/HitCombo.js
+++ b/src/Parser/Monk/Windwalker/Modules/Talents/HitCombo.js
@@ -66,7 +66,7 @@ class HitCombo extends Analyzer {
       />
       );
     }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(61);
+  statisticOrder = STATISTIC_ORDER.CORE(3);
 }
 
 export default HitCombo;


### PR DESCRIPTION
Also editing Combo Breaker to %procs used rather than %wasted

Before: 
![image](https://user-images.githubusercontent.com/30317641/37511692-0c619ce2-2900-11e8-928c-339b8aa2be59.png)

After:
![image](https://user-images.githubusercontent.com/30317641/37511697-17d5e0ec-2900-11e8-8699-c4419bd86c50.png)

