### PR TITLE
[Restoration Shaman] Tidecallers fix for the 7.3.5 totem change

### DIFF
--- a/src/Parser/Shaman/Restoration/Modules/Items/Tidecallers.js
+++ b/src/Parser/Shaman/Restoration/Modules/Items/Tidecallers.js
@@ -22,7 +22,11 @@ class Tidecallers extends Analyzer {
     this.active = this.owner.modules.combatants.selected.hasHands(ITEMS.PRAETORIANS_TIDECALLERS.id);
   }
 
-  on_byPlayer_heal(event) {
+  on_heal(event) {
+    if (!this.owner.byPlayer(event) && !this.owner.byPlayerPet(event)) {
+      return;
+    }
+
     const spellId = event.ability.guid;
     const healingDone = event.amount + (event.absorbed || 0);
 


### PR DESCRIPTION
Fix for tidecallers not working anymore since 7.3.5 because totems became pets.

Before ![image](https://user-images.githubusercontent.com/2842471/37547682-6e49ff76-2973-11e8-9507-e68eb1484378.png)
After ![image](https://user-images.githubusercontent.com/2842471/37547688-77da3b1e-2973-11e8-9ae4-f12301067951.png)
https://wowanalyzer.com/report/gkmp4DxyGhVAjbnz/4-Mythic+Antoran+High+Command+-+Kill+(5:55)/14-Xuany