### PR TITLE
Hotfix: max void bolts casts.

### DIFF
--- a/src/Parser/Priest/Shadow/Modules/Features/Abilities.js
+++ b/src/Parser/Priest/Shadow/Modules/Features/Abilities.js
@@ -16,10 +16,7 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: 0.85,
           maxCasts: (cooldown, fightDuration, getAbility, parser) => {
-            const { averageVoidformHaste } = parser.modules.voidform;
-            const cooldownVoidBolt = 4.5 / averageVoidformHaste;
-
-            return calculateMaxCasts(cooldownVoidBolt, parser.modules.combatants.selected.getBuffUptime(SPELLS.VOIDFORM_BUFF.id));
+            return calculateMaxCasts(cooldown, parser.modules.combatants.selected.getBuffUptime(SPELLS.VOIDFORM_BUFF.id));
           },
         },
       },


### PR DESCRIPTION
Fixed the potential max void bolts casts. Previously it calculated based on average void form haste, but seems like the cast efficiency module was updated to take current haste into account at all times, which made the old solution double dip on haste.