### PR TITLE
[Restoration Shaman] Cloudburst Totem normalizer

### DIFF
--- a/src/Parser/Shaman/Restoration/CombatLogParser.js
+++ b/src/Parser/Shaman/Restoration/CombatLogParser.js
@@ -55,6 +55,8 @@ import HealingWave from './Modules/Spells/HealingWave';
 import LavaSurge from './Modules/Spells/LavaSurge';
 import Resurgence from './Modules/Spells/Resurgence';
 
+import CloudburstNormalizer from './Normalizers/CloudburstNormalizer';
+
 import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from './Constants';
 
 class CombatLogParser extends CoreCombatLogParser {
@@ -108,6 +110,9 @@ class CombatLogParser extends CoreCombatLogParser {
     healingWave: HealingWave,
     lavaSurge: LavaSurge,
     resurgence: Resurgence,
+
+    // Normalizers:
+    cloudburstNormalizer: CloudburstNormalizer,
   };
 
   generateResults() {

--- a/src/Parser/Shaman/Restoration/Normalizers/CloudburstNormalizer.js
+++ b/src/Parser/Shaman/Restoration/Normalizers/CloudburstNormalizer.js
@@ -24,6 +24,7 @@ class CloudburstNormalizer extends EventsNormalizer {
   }
 
   fabricatedEvent = null;
+  recallTimestamp = null;
 
   normalize(events) {
     const fixedEvents = [];
@@ -48,7 +49,7 @@ class CloudburstNormalizer extends EventsNormalizer {
           
           if ((nextEvent.timestamp - castTimestamp) > MAX_DELAY) {
             // No CLOUDBURST_TOTEM_HEAL found within the period, meaning this cast wasn't able to find targets and did not have any healing events -> create a 100% overheal event
-            const newTimestamp = event.timestamp+CBT_DELAY;
+            const newTimestamp = (this.recallTimestamp) ? this.recallTimestamp : event.timestamp+CBT_DELAY;
 
             this.fabricatedEvent = {
               timestamp: newTimestamp, 
@@ -71,6 +72,9 @@ class CloudburstNormalizer extends EventsNormalizer {
               __fabricated: true,
             };
             break;
+          } else if (nextEvent.type === 'cast' && nextEvent.ability.guid === SPELLS.CLOUDBURST_TOTEM_RECALL.id) {
+            this.recallTimestamp = nextEvent.timestamp;
+            continue;
           } else if (nextEvent.type === 'heal' && nextEvent.ability.guid === SPELLS.CLOUDBURST_TOTEM_HEAL.id) {
             // CLOUDBURST_TOTEM_HEAL found, this was fine
             break;

--- a/src/Parser/Shaman/Restoration/Normalizers/CloudburstNormalizer.js
+++ b/src/Parser/Shaman/Restoration/Normalizers/CloudburstNormalizer.js
@@ -1,0 +1,90 @@
+import EventsNormalizer from 'Parser/Core/EventsNormalizer';
+
+import SPELLS from 'common/SPELLS';
+
+const MAX_DELAY = 20000;
+const CBT_DELAY = 15000;
+
+/*
+* Cloudburst Totem had some weird behaviour (even if it rarely happens), 
+* because of that you can have a cast event without heal events.
+* This happens if everyone in range is at 100% HP, it will just not heal at all.
+*
+* That throws off the CooldownThroughputTracker, gathering all events
+* until the CBT after that explodes and giving results that are completely wrong.
+*
+* This Normalizer creates a 100% overhealed healing event where the heal would have been,
+* if no healing events happened within 20 seconds after casting the totem.
+ */
+
+class CloudburstNormalizer extends EventsNormalizer {
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.CLOUDBURST_TOTEM_TALENT.id);
+  }
+
+  fabricatedTimestamp = null;
+  fabricatedEvent = null;
+
+  normalize(events) {
+    const fixedEvents = [];
+    events.forEach((event, eventIndex) => {
+
+      if(this.fabricatedTimestamp) {
+        if(event.timestamp >= this.fabricatedTimestamp) {
+          fixedEvents.push(this.fabricatedEvent);
+          this.fabricatedTimestamp = null;
+          this.fabricatedEvent = null;
+        }
+      }
+
+      fixedEvents.push(event);
+
+
+      if (event.type === 'cast' && event.ability.guid === SPELLS.CLOUDBURST_TOTEM_TALENT.id) {
+        const castTimestamp = event.timestamp;
+
+        // Look ahead through the events to see if there is an CLOUDBURST_TOTEM_HEAL within a 20 second period
+        for (let nextEventIndex = eventIndex; nextEventIndex < events.length-1; nextEventIndex += 1) {
+          const nextEvent = events[nextEventIndex];
+          
+          if ((nextEvent.timestamp - castTimestamp) > MAX_DELAY) {
+            // No CLOUDBURST_TOTEM_HEAL found within the period, meaning this cast wasn't able to find targets and did not have any healing events -> create a 100% overheal event
+            const newTimestamp = event.timestamp+CBT_DELAY;
+
+            this.fabricatedEvent = {
+              timestamp: newTimestamp, 
+              type: "heal", 
+              sourceID: event.sourceID, 
+              sourceIsFriendly: true, 
+              targetID: event.sourceID,
+              ability: {
+                abilityIcon: SPELLS.CLOUDBURST_TOTEM_HEAL.icon,
+                guid: SPELLS.CLOUDBURST_TOTEM_HEAL.id,
+                name: SPELLS.CLOUDBURST_TOTEM_HEAL.name,
+                type: 8,
+              },
+              amount: 0,
+              hitType: 1,
+              itemLevel: event.itemLevel,
+              overheal: 1,
+              resourceActor: 2,
+              targetIsFriendly: true,
+              truetimestamp: newTimestamp,
+              modified: true,
+            };
+            this.fabricatedTimestamp = newTimestamp;
+            break;
+          } else if (nextEvent.type === 'heal' && nextEvent.ability.guid === SPELLS.CLOUDBURST_TOTEM_HEAL.id) {
+            // CLOUDBURST_TOTEM_HEAL found, this was fine
+            break;
+          }
+        }
+      }
+    });
+
+    return fixedEvents;
+  }
+
+}
+export default CloudburstNormalizer;

--- a/src/Parser/Shaman/Restoration/Normalizers/CloudburstNormalizer.js
+++ b/src/Parser/Shaman/Restoration/Normalizers/CloudburstNormalizer.js
@@ -23,17 +23,15 @@ class CloudburstNormalizer extends EventsNormalizer {
     this.active = this.combatants.selected.hasTalent(SPELLS.CLOUDBURST_TOTEM_TALENT.id);
   }
 
-  fabricatedTimestamp = null;
   fabricatedEvent = null;
 
   normalize(events) {
     const fixedEvents = [];
     events.forEach((event, eventIndex) => {
 
-      if(this.fabricatedTimestamp) {
-        if(event.timestamp >= this.fabricatedTimestamp) {
+      if(this.fabricatedEvent) {
+        if(event.timestamp >= this.fabricatedEvent.timestamp) {
           fixedEvents.push(this.fabricatedEvent);
-          this.fabricatedTimestamp = null;
           this.fabricatedEvent = null;
         }
       }
@@ -72,7 +70,6 @@ class CloudburstNormalizer extends EventsNormalizer {
               maxHitPoints: event.maxHitPoints,
               __fabricated: true,
             };
-            this.fabricatedTimestamp = newTimestamp;
             break;
           } else if (nextEvent.type === 'heal' && nextEvent.ability.guid === SPELLS.CLOUDBURST_TOTEM_HEAL.id) {
             // CLOUDBURST_TOTEM_HEAL found, this was fine

--- a/src/Parser/Shaman/Restoration/Normalizers/CloudburstNormalizer.js
+++ b/src/Parser/Shaman/Restoration/Normalizers/CloudburstNormalizer.js
@@ -24,7 +24,6 @@ class CloudburstNormalizer extends EventsNormalizer {
   }
 
   fabricatedEvent = null;
-  recallTimestamp = null;
 
   normalize(events) {
     const fixedEvents = [];
@@ -42,7 +41,7 @@ class CloudburstNormalizer extends EventsNormalizer {
 
       if (event.type === 'cast' && event.ability.guid === SPELLS.CLOUDBURST_TOTEM_TALENT.id) {
         const castTimestamp = event.timestamp;
-        this.recallTimestamp = null;
+        let recallTimestamp = null;
 
         // Look ahead through the events to see if there is an CLOUDBURST_TOTEM_HEAL within a 20 second period
         for (let nextEventIndex = eventIndex; nextEventIndex < events.length-1; nextEventIndex += 1) {
@@ -50,7 +49,7 @@ class CloudburstNormalizer extends EventsNormalizer {
           
           if ((nextEvent.timestamp - castTimestamp) > MAX_DELAY) {
             // No CLOUDBURST_TOTEM_HEAL found within the period, meaning this cast wasn't able to find targets and did not have any healing events -> create a 100% overheal event
-            const newTimestamp = (this.recallTimestamp) ? this.recallTimestamp : event.timestamp+CBT_DELAY;
+            const newTimestamp = (recallTimestamp) ? recallTimestamp : event.timestamp+CBT_DELAY;
             
             this.fabricatedEvent = {
               timestamp: newTimestamp, 
@@ -74,7 +73,7 @@ class CloudburstNormalizer extends EventsNormalizer {
             };
             break;
           } else if (nextEvent.type === 'cast' && nextEvent.ability.guid === SPELLS.CLOUDBURST_TOTEM_RECALL.id) {
-            this.recallTimestamp = nextEvent.timestamp;
+            recallTimestamp = nextEvent.timestamp;
             continue;
           } else if (nextEvent.type === 'heal' && nextEvent.ability.guid === SPELLS.CLOUDBURST_TOTEM_HEAL.id) {
             // CLOUDBURST_TOTEM_HEAL found, this was fine

--- a/src/Parser/Shaman/Restoration/Normalizers/CloudburstNormalizer.js
+++ b/src/Parser/Shaman/Restoration/Normalizers/CloudburstNormalizer.js
@@ -42,6 +42,7 @@ class CloudburstNormalizer extends EventsNormalizer {
 
       if (event.type === 'cast' && event.ability.guid === SPELLS.CLOUDBURST_TOTEM_TALENT.id) {
         const castTimestamp = event.timestamp;
+        this.recallTimestamp = null;
 
         // Look ahead through the events to see if there is an CLOUDBURST_TOTEM_HEAL within a 20 second period
         for (let nextEventIndex = eventIndex; nextEventIndex < events.length-1; nextEventIndex += 1) {
@@ -50,7 +51,7 @@ class CloudburstNormalizer extends EventsNormalizer {
           if ((nextEvent.timestamp - castTimestamp) > MAX_DELAY) {
             // No CLOUDBURST_TOTEM_HEAL found within the period, meaning this cast wasn't able to find targets and did not have any healing events -> create a 100% overheal event
             const newTimestamp = (this.recallTimestamp) ? this.recallTimestamp : event.timestamp+CBT_DELAY;
-            this.recallTimestamp = null;
+            
             this.fabricatedEvent = {
               timestamp: newTimestamp, 
               type: "heal", 

--- a/src/Parser/Shaman/Restoration/Normalizers/CloudburstNormalizer.js
+++ b/src/Parser/Shaman/Restoration/Normalizers/CloudburstNormalizer.js
@@ -56,8 +56,9 @@ class CloudburstNormalizer extends EventsNormalizer {
               timestamp: newTimestamp, 
               type: "heal", 
               sourceID: event.sourceID, 
-              sourceIsFriendly: true, 
               targetID: event.sourceID,
+              sourceIsFriendly: true, 
+              targetIsFriendly: true,
               ability: {
                 abilityIcon: SPELLS.CLOUDBURST_TOTEM_HEAL.icon,
                 guid: SPELLS.CLOUDBURST_TOTEM_HEAL.id,
@@ -65,13 +66,11 @@ class CloudburstNormalizer extends EventsNormalizer {
                 type: 8,
               },
               amount: 0,
-              hitType: 1,
-              itemLevel: event.itemLevel,
               overheal: 1,
-              resourceActor: 2,
-              targetIsFriendly: true,
-              truetimestamp: newTimestamp,
-              modified: true,
+              hitType: 1,
+              hitPoints: event.maxHitPoints,
+              maxHitPoints: event.maxHitPoints,
+              __fabricated: true,
             };
             this.fabricatedTimestamp = newTimestamp;
             break;

--- a/src/Parser/Shaman/Restoration/Normalizers/CloudburstNormalizer.js
+++ b/src/Parser/Shaman/Restoration/Normalizers/CloudburstNormalizer.js
@@ -50,7 +50,7 @@ class CloudburstNormalizer extends EventsNormalizer {
           if ((nextEvent.timestamp - castTimestamp) > MAX_DELAY) {
             // No CLOUDBURST_TOTEM_HEAL found within the period, meaning this cast wasn't able to find targets and did not have any healing events -> create a 100% overheal event
             const newTimestamp = (this.recallTimestamp) ? this.recallTimestamp : event.timestamp+CBT_DELAY;
-
+            this.recallTimestamp = null;
             this.fabricatedEvent = {
               timestamp: newTimestamp, 
               type: "heal", 

--- a/src/common/SPELLS/SHAMAN.js
+++ b/src/common/SPELLS/SHAMAN.js
@@ -651,7 +651,7 @@ export default {
   },
   CLOUDBURST_TOTEM_HEAL: {
     id: 157503,
-    name: 'Cloudburst Totem',
+    name: 'Cloudburst',
     icon: 'ability_shaman_condensationtotem',
     manaCost: 18920,
   },


### PR DESCRIPTION
Cloudburst has odd behaviour, where, if there is no injured target in range after its done gathering healing, it will explode but create no healing events at all. That is throwing off the cooldown tracker badly, either not creating the CBT cooldown at all if its the first one in combat, or combining that and the next CBT into a mega-CBT.

The normalizer fixes that by creating a dummy heal event with 100% overheal (which is basically what happened anyway) if there aren't any healing events to be found within 20 seconds after casting.

Now i wasn't 100% sure what properties an event needs, so i added all that i thought of important enough, and hitpoints/maxhitpoints so the masteryeffectiveness module doesn't give it NaN.

Example 1 (before and after)
![image](https://user-images.githubusercontent.com/2842471/37562753-511d8ac8-2a70-11e8-81f9-81a47ab76149.png)
![image](https://user-images.githubusercontent.com/2842471/37562757-64572d2e-2a70-11e8-82b6-3b8a2779b935.png)

Example 2 (before and after)
![image](https://user-images.githubusercontent.com/2842471/37562760-81839252-2a70-11e8-8d67-42bf79b39068.png)
![image](https://user-images.githubusercontent.com/2842471/37562761-8b92963a-2a70-11e8-8f62-30267801390a.png)
