### PR TITLE
Refactor events

### DIFF
--- a/src/Main/App.js
+++ b/src/Main/App.js
@@ -212,7 +212,9 @@ class App extends Component {
         offset += batchSize;
       }
 
-      parser.fabricateEvent('finished');
+      parser.fabricateEvent({
+        type: 'finished',
+      });
       timeAvailable && console.timeEnd('full parse');
       this.setState({
         progress: 1.0,

--- a/src/Main/App.js
+++ b/src/Main/App.js
@@ -212,7 +212,7 @@ class App extends Component {
         offset += batchSize;
       }
 
-      parser.triggerEvent('finished');
+      parser.fabricateEvent('finished');
       timeAvailable && console.timeEnd('full parse');
       this.setState({
         progress: 1.0,

--- a/src/Main/EventsTab.js
+++ b/src/Main/EventsTab.js
@@ -9,7 +9,6 @@ import InformationIcon from 'Icons/Information';
 import Wrapper from 'common/Wrapper';
 import { formatDuration, formatThousands } from 'common/format';
 import Icon from 'common/Icon';
-import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'common/RESOURCE_TYPES';
 import Info from 'common/Alert/Info';
 import HIT_TYPES from 'Parser/Core/HIT_TYPES';

--- a/src/Main/EventsTab.js
+++ b/src/Main/EventsTab.js
@@ -130,11 +130,10 @@ class EventsTab extends React.Component {
       return null;
     }
     const spellId = ability.guid;
-    const exists = !!SPELLS[spellId];
 
     return (
-      <a href={`http://www.wowhead.com/spell=${spellId}`} target="_blank" rel="noopener noreferrer" className={exists ? 'exists' : 'missing'}>
-        <Icon icon={ability.abilityIcon} /> {ability.name}
+      <a href={`http://www.wowhead.com/spell=${spellId}`} target="_blank" rel="noopener noreferrer">
+        {ability.abilityIcon && <Icon icon={ability.abilityIcon} />} {ability.name}
       </a>
     );
   }
@@ -149,7 +148,7 @@ class EventsTab extends React.Component {
   }
   renderToggle(prop, label, explanation = null) {
     return (
-      <div className="flex toggle-control">
+      <div key={prop} className="flex toggle-control">
         <label className="flex-main" htmlFor={`${prop}-toggle`}>
           {label}
         </label>

--- a/src/Main/Timeline/SpellTimeline.js
+++ b/src/Main/Timeline/SpellTimeline.js
@@ -152,7 +152,7 @@ class SpellTimeline extends React.PureComponent {
                 const maxWidth = totalWidth - left; // don't expand beyond the container width
                 return (
                   <div
-                    key={`${event.reason.type}-${eventStart}-${event.duration}`}
+                    key={`${event.trigger.type}-${eventStart}-${event.duration}`}
                     className="casting-time"
                     style={{
                       left,

--- a/src/Parser/Core/Analyzer.js
+++ b/src/Parser/Core/Analyzer.js
@@ -4,20 +4,21 @@ import Module from './Module';
 class Analyzer extends Module {
   static __dangerousInvalidUsage = false;
 
-  triggerEvent(eventType, event, ...args) {
-    this._callMethod(this._eventHandlerName('event'), eventType, event, ...args);
-    this._callMethod(this._eventHandlerName(eventType), event, ...args);
-    if (event && this.owner.byPlayer(event)) {
-      this._callMethod(this._eventHandlerName(`byPlayer_${eventType}`), event, ...args);
+  triggerEvent(event, ...args) {
+    // Triggering a lot of events here for development pleasure; does this have a significant performance impact?
+    this._callMethod(this._eventHandlerName('event'), event.type, event, ...args);
+    this._callMethod(this._eventHandlerName(event.type), event, ...args);
+    if (this.owner && this.owner.byPlayer(event)) {
+      this._callMethod(this._eventHandlerName(`byPlayer_${event.type}`), event, ...args);
     }
-    if (event && this.owner.toPlayer(event)) {
-      this._callMethod(this._eventHandlerName(`toPlayer_${eventType}`), event, ...args);
+    if (this.owner && this.owner.toPlayer(event)) {
+      this._callMethod(this._eventHandlerName(`toPlayer_${event.type}`), event, ...args);
     }
-    if (event && this.owner.byPlayerPet(event)) {
-      this._callMethod(this._eventHandlerName(`byPlayerPet_${eventType}`), event, ...args);
+    if (this.owner && this.owner.byPlayerPet(event)) {
+      this._callMethod(this._eventHandlerName(`byPlayerPet_${event.type}`), event, ...args);
     }
-    if (event && this.owner.toPlayerPet(event)) {
-      this._callMethod(this._eventHandlerName(`toPlayerPet_${eventType}`), event, ...args);
+    if (this.owner && this.owner.toPlayerPet(event)) {
+      this._callMethod(this._eventHandlerName(`toPlayerPet_${event.type}`), event, ...args);
     }
   }
   _eventHandlerName(eventType) {

--- a/src/Parser/Core/Analyzer.test.js
+++ b/src/Parser/Core/Analyzer.test.js
@@ -31,13 +31,17 @@ describe('Core.CombatLogParser', () => {
         on_success = on_success;
       }
       const myModule = new MyModule();
-      myModule.triggerEvent('success');
+      myModule.triggerEvent({
+        type: 'success',
+      });
       expect(on_success).toBeCalled();
     });
     it('does nothing if the event handler on the class does not exist', () => {
       class MyModule extends Analyzer {}
       const myModule = new MyModule();
-      myModule.triggerEvent('success');
+      myModule.triggerEvent({
+        type: 'success',
+      });
       // Ummm how do we test for it doing nothing? I guess it just shouldn't crash...
     });
     it('calls on_event on every event if it exists', () => {
@@ -46,7 +50,9 @@ describe('Core.CombatLogParser', () => {
         on_event = on_event;
       }
       const myModule = new MyModule();
-      myModule.triggerEvent('test');
+      myModule.triggerEvent({
+        type: 'test',
+      });
       expect(on_event).toBeCalled();
     });
     it('calls convenience handlers byPlayer and toPlayer', () => {
@@ -66,7 +72,9 @@ describe('Core.CombatLogParser', () => {
         byPlayerPet: () => true,
         toPlayerPet: () => true,
       });
-      myModule.triggerEvent('test', {});
+      myModule.triggerEvent({
+        type: 'test',
+      });
       expect(on_byPlayer_test).toBeCalled();
       expect(on_toPlayer_test).toBeCalled();
       expect(on_byPlayerPet_test).toBeCalled();
@@ -83,7 +91,9 @@ describe('Core.CombatLogParser', () => {
         byPlayerPet: () => true,
         toPlayerPet: () => true,
       });
-      myModule.triggerEvent('test', {});
+      myModule.triggerEvent({
+        type: 'test',
+      });
       expect(on_byPlayer_test).not.toBeCalled();
     });
     it('doesn\'t call convenience handlers toPlayer when event is to someone else', () => {
@@ -97,7 +107,9 @@ describe('Core.CombatLogParser', () => {
         byPlayerPet: () => true,
         toPlayerPet: () => true,
       });
-      myModule.triggerEvent('test', {});
+      myModule.triggerEvent({
+        type: 'test',
+      });
       expect(on_toPlayer_test).not.toBeCalled();
     });
     it('doesn\'t call convenience handlers byPlayerPet when event is by someone else', () => {
@@ -111,7 +123,9 @@ describe('Core.CombatLogParser', () => {
         byPlayerPet: () => false,
         toPlayerPet: () => true,
       });
-      myModule.triggerEvent('test', {});
+      myModule.triggerEvent({
+        type: 'test',
+      });
       expect(on_byPlayerPet_test).not.toBeCalled();
     });
     it('doesn\'t call convenience handlers toPlayerPet when event is to someone else', () => {
@@ -125,7 +139,9 @@ describe('Core.CombatLogParser', () => {
         byPlayerPet: () => true,
         toPlayerPet: () => false,
       });
-      myModule.triggerEvent('test', {});
+      myModule.triggerEvent({
+        type: 'test',
+      });
       expect(on_toPlayerPet_test).not.toBeCalled();
     });
     it('passes all arguments to event handler', () => {
@@ -139,9 +155,11 @@ describe('Core.CombatLogParser', () => {
         toPlayerPet: () => true,
         byPlayerPet: () => true,
       });
-      const firstArg = {};
+      const firstArg = {
+        type: 'success',
+      };
       const secondArg = 'my_second_arg';
-      myModule.triggerEvent('success', firstArg, secondArg);
+      myModule.triggerEvent(firstArg, secondArg);
       expect(on_success).toBeCalledWith(firstArg, secondArg);
     });
     it('sets `this` to the module', () => {
@@ -150,7 +168,9 @@ describe('Core.CombatLogParser', () => {
         on_success = on_success;
       }
       const myModule = new MyModule();
-      myModule.triggerEvent('success');
+      myModule.triggerEvent({
+        type: 'success',
+      });
       expect(on_success.mock.instances[0]).toBe(myModule);
     });
   });

--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -397,11 +397,7 @@ class CombatLogParser {
     this.triggerInitialized();
   }
   triggerInitialized() {
-    this.triggerEvent({
-      type: 'initialized',
-      timestamp: this.currentTimestamp,
-      __fabricated: true,
-    });
+    this.fabricateEvent('initialized');
   }
   parseEvents(events) {
     events.forEach(event => {
@@ -460,13 +456,13 @@ class CombatLogParser {
   }
   fabricateEvent(eventName, event = null, triggeredBy = null, ...args) {
     this.triggerEvent({
-      type: eventName,
-      __fabricated: true,
       timestamp: triggeredBy ? triggeredBy.timestamp : this.currentTimestamp,
       sourceID: triggeredBy ? triggeredBy.sourceID : undefined,
       targetID: triggeredBy ? triggeredBy.targetID : undefined,
       trigger: triggeredBy ? triggeredBy : undefined,
       ...event,
+      type: eventName,
+      __fabricated: true,
     }, ...args);
   }
 

--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -394,21 +394,19 @@ class CombatLogParser {
   }
   initializeAnalyzers(combatants) {
     this.parseEvents(combatants);
-    this.triggerEvent('initialized');
+    this.triggerInitialized();
+  }
+  triggerInitialized() {
+    this.triggerEvent({
+      type: 'initialized',
+      timestamp: this.currentTimestamp,
+      __fabricated: true,
+    });
   }
   parseEvents(events) {
-    this.eventHistory = [
-      ...this.eventHistory,
-      ...events,
-    ];
-    events.forEach((event) => {
-      if (this.error) {
-        throw new Error(this.error);
-      }
+    events.forEach(event => {
       this._timestamp = event.timestamp;
-
-      // Triggering a lot of events here for development pleasure; does this have a significant performance impact?
-      this.triggerEvent(event.type, event);
+      this.triggerEvent(event);
     });
   }
 
@@ -437,8 +435,10 @@ class CombatLogParser {
   /** @type {number} The amount of events parsed. This can reliably be used to determine if something should re-render. */
   eventCount = 0;
   _moduleTime = {};
-  triggerEvent(eventType, event, ...args) {
-    debugEvents && console.log(eventType, event, ...args);
+  triggerEvent(event, ...args) {
+    debugEvents && console.log(event.type, event, ...args);
+    // Creating arrays is expensive so we cheat and just push here
+    this.eventHistory.push(event);
 
     Object.keys(this._modules)
       .filter(key => this._modules[key].active)
@@ -448,15 +448,26 @@ class CombatLogParser {
         const module = this._modules[key];
         if (process.env.NODE_ENV === 'development') {
           const start = +new Date();
-          module.triggerEvent(eventType, event, ...args);
+          module.triggerEvent(event, ...args);
           const duration = +new Date() - start;
           this._moduleTime[key] = this._moduleTime[key] || 0;
           this._moduleTime[key] += duration;
         } else {
-          module.triggerEvent(eventType, event, ...args);
+          module.triggerEvent(event, ...args);
         }
       });
     this.eventCount += 1;
+  }
+  fabricateEvent(eventName, event = null, triggeredBy = null, ...args) {
+    this.triggerEvent({
+      type: eventName,
+      __fabricated: true,
+      timestamp: triggeredBy ? triggeredBy.timestamp : this.currentTimestamp,
+      sourceID: triggeredBy ? triggeredBy.sourceID : undefined,
+      targetID: triggeredBy ? triggeredBy.targetID : undefined,
+      trigger: triggeredBy ? triggeredBy : undefined,
+      ...event,
+    }, ...args);
   }
 
   byPlayer(event, playerId = this.player.id) {

--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -397,7 +397,9 @@ class CombatLogParser {
     this.triggerInitialized();
   }
   triggerInitialized() {
-    this.fabricateEvent('initialized');
+    this.fabricateEvent({
+      type: 'initialized',
+    });
   }
   parseEvents(events) {
     events.forEach(event => {
@@ -454,14 +456,13 @@ class CombatLogParser {
       });
     this.eventCount += 1;
   }
-  fabricateEvent(eventName, event = null, triggeredBy = null, ...args) {
+  fabricateEvent(event = null, trigger = null, ...args) {
     this.triggerEvent({
-      timestamp: triggeredBy ? triggeredBy.timestamp : this.currentTimestamp,
-      sourceID: triggeredBy ? triggeredBy.sourceID : undefined,
-      targetID: triggeredBy ? triggeredBy.targetID : undefined,
-      trigger: triggeredBy ? triggeredBy : undefined,
+      // When no timestamp is provided in the event (you should always try to), the current timestamp will be used by default.
+      timestamp: this.currentTimestamp,
+      // If this event was triggered you should pass it along
+      trigger: trigger ? trigger : undefined,
       ...event,
-      type: eventName,
       __fabricated: true,
     }, ...args);
   }

--- a/src/Parser/Core/Modules/AlwaysBeCasting.js
+++ b/src/Parser/Core/Modules/AlwaysBeCasting.js
@@ -54,7 +54,7 @@ class AlwaysBeCasting extends Analyzer {
   _lastGlobalCooldownDuration = 0;
   on_globalcooldown(event) {
     this._lastGlobalCooldownDuration = event.duration;
-    if (event.trigger === 'begincast') {
+    if (event.trigger.type === 'beginchannel') {
       // Only add active time for this channel, we do this when the channel is finished and use the highest of the GCD and channel time
       return false;
     }

--- a/src/Parser/Core/Modules/AlwaysBeCastingHealing.js
+++ b/src/Parser/Core/Modules/AlwaysBeCastingHealing.js
@@ -38,8 +38,8 @@ class AlwaysBeCastingHealing extends CoreAlwaysBeCasting {
     }
     return true;
   }
-  countsAsHealingAbility(cast) {
-    return this.constructor.HEALING_ABILITIES_ON_GCD.indexOf(cast.ability.guid) !== -1;
+  countsAsHealingAbility(event) {
+    return this.constructor.HEALING_ABILITIES_ON_GCD.indexOf(event.ability.guid) !== -1;
   }
 
   showStatistic = true;

--- a/src/Parser/Core/Modules/Channeling.js
+++ b/src/Parser/Core/Modules/Channeling.js
@@ -49,13 +49,12 @@ class Channeling extends Analyzer {
     debug && console.log(formatMilliseconds(event.timestamp - this.owner.fight.start_time), 'Channeling', 'Ending channel of', ability.name);
   }
   cancelChannel(event, ability) {
-    this.owner.triggerEvent({
-      type: 'cancelchannel',
+    this.owner.fabricateEvent('cancelchannel', {
       ability,
       sourceID: event.sourceID,
+      targetID: event.sourceID,
       timestamp: null, // unknown, we can only know when the next cast started so passing the timestamp would be a poor guess
-      reason: event,
-    });
+    }, event);
     debug && console.warn(formatMilliseconds(event.timestamp - this.owner.fight.start_time), 'Channeling', 'Canceled channel of', ability.name);
   }
 

--- a/src/Parser/Core/Modules/Channeling.js
+++ b/src/Parser/Core/Modules/Channeling.js
@@ -21,7 +21,7 @@ class Channeling extends Analyzer {
       reason: event,
     };
     this._currentChannel = channelingEvent;
-    this.owner.triggerEvent('beginchannel', channelingEvent);
+    this.owner.triggerEvent(channelingEvent);
     debug && console.log(formatMilliseconds(event.timestamp - this.owner.fight.start_time), 'Channeling', 'Beginning channel of', ability.name);
   }
   endChannel(event) {
@@ -36,7 +36,7 @@ class Channeling extends Analyzer {
     this._currentChannel = null;
     // Since `event` may not always be the spell being ended we default to the start of the casting since that must be the right spell
     const ability = currentChannel ? currentChannel.ability : event.ability;
-    this.owner.triggerEvent('endchannel', {
+    this.owner.triggerEvent({
       type: 'endchannel',
       timestamp: event.timestamp,
       ability,
@@ -49,7 +49,7 @@ class Channeling extends Analyzer {
     debug && console.log(formatMilliseconds(event.timestamp - this.owner.fight.start_time), 'Channeling', 'Ending channel of', ability.name);
   }
   cancelChannel(event, ability) {
-    this.owner.triggerEvent('cancelchannel', {
+    this.owner.triggerEvent({
       type: 'cancelchannel',
       ability,
       sourceID: event.sourceID,

--- a/src/Parser/Core/Modules/Channeling.js
+++ b/src/Parser/Core/Modules/Channeling.js
@@ -49,7 +49,8 @@ class Channeling extends Analyzer {
     debug && console.log(formatMilliseconds(event.timestamp - this.owner.fight.start_time), 'Channeling', 'Ending channel of', ability.name);
   }
   cancelChannel(event, ability) {
-    this.owner.fabricateEvent('cancelchannel', {
+    this.owner.fabricateEvent({
+      type: 'cancelchannel',
       ability,
       sourceID: event.sourceID,
       targetID: event.sourceID,

--- a/src/Parser/Core/Modules/Channeling.js
+++ b/src/Parser/Core/Modules/Channeling.js
@@ -18,10 +18,9 @@ class Channeling extends Analyzer {
       timestamp: event.timestamp,
       ability,
       sourceID: event.sourceID,
-      reason: event,
     };
     this._currentChannel = channelingEvent;
-    this.owner.triggerEvent(channelingEvent);
+    this.owner.fabricateEvent(channelingEvent, event);
     debug && console.log(formatMilliseconds(event.timestamp - this.owner.fight.start_time), 'Channeling', 'Beginning channel of', ability.name);
   }
   endChannel(event) {
@@ -36,16 +35,15 @@ class Channeling extends Analyzer {
     this._currentChannel = null;
     // Since `event` may not always be the spell being ended we default to the start of the casting since that must be the right spell
     const ability = currentChannel ? currentChannel.ability : event.ability;
-    this.owner.triggerEvent({
+    this.owner.fabricateEvent({
       type: 'endchannel',
       timestamp: event.timestamp,
       ability,
       sourceID: event.sourceID,
       duration: duration,
       start,
-      reason: event, // the reason may be for another spell, sometimes the indicator of 1 channel ending is the start of another
       beginChannel: currentChannel,
-    });
+    }, event); // the trigger may be another spell, sometimes the indicator of 1 channel ending is the start of another
     debug && console.log(formatMilliseconds(event.timestamp - this.owner.fight.start_time), 'Channeling', 'Ending channel of', ability.name);
   }
   cancelChannel(event, ability) {

--- a/src/Parser/Core/Modules/Entities.js
+++ b/src/Parser/Core/Modules/Entities.js
@@ -144,10 +144,9 @@ class Entities extends Analyzer {
    * This event is also fired for `removebuff` where `oldStacks` will be either the old stacks (if there were multiple) or 1 and `newStacks` will be 0. NOTE: This event is usually fired before the `removebuff` event!
    */
   _triggerChangeBuffStack(buff, timestamp, oldStacks, newStacks) {
-    const type = buff.isDebuff ? 'changedebuffstack' : 'changebuffstack';
-
-    this.owner.fabricateEvent(type, {
+    this.owner.fabricateEvent({
       ...buff,
+      type: buff.isDebuff ? 'changedebuffstack' : 'changebuffstack',
       timestamp,
       oldStacks,
       newStacks,

--- a/src/Parser/Core/Modules/Entities.js
+++ b/src/Parser/Core/Modules/Entities.js
@@ -146,16 +146,14 @@ class Entities extends Analyzer {
   _triggerChangeBuffStack(buff, timestamp, oldStacks, newStacks) {
     const type = buff.isDebuff ? 'changedebuffstack' : 'changebuffstack';
 
-    this.owner.triggerEvent({
+    this.owner.fabricateEvent(type, {
       ...buff,
       timestamp,
-      type,
       oldStacks,
       newStacks,
       stacksGained: newStacks - oldStacks,
       stack: undefined,
-      __fabricated: true,
-    });
+    }, buff);
   }
 
   // Surely this can be done with a couple less loops???

--- a/src/Parser/Core/Modules/Entities.js
+++ b/src/Parser/Core/Modules/Entities.js
@@ -146,7 +146,7 @@ class Entities extends Analyzer {
   _triggerChangeBuffStack(buff, timestamp, oldStacks, newStacks) {
     const type = buff.isDebuff ? 'changedebuffstack' : 'changebuffstack';
 
-    this.owner.triggerEvent(type, {
+    this.owner.triggerEvent({
       ...buff,
       timestamp,
       type,
@@ -154,6 +154,7 @@ class Entities extends Analyzer {
       newStacks,
       stacksGained: newStacks - oldStacks,
       stack: undefined,
+      __fabricated: true,
     });
   }
 

--- a/src/Parser/Core/Modules/GlobalCooldown.js
+++ b/src/Parser/Core/Modules/GlobalCooldown.js
@@ -73,7 +73,7 @@ class GlobalCooldown extends Analyzer {
     const spellId = event.ability.guid;
     const isOnGcd = this.isOnGlobalCooldown(spellId);
     // Cancelled casts reset the GCD (only for cast-time spells, "channels" always have a GCD but they also can't be *cancelled*, just ended early)
-    const isCancelled = event.reason.isCancelled;
+    const isCancelled = event.trigger.isCancelled;
     if (isOnGcd && !isCancelled) {
       this.triggerGlobalCooldown(event);
     }
@@ -116,7 +116,6 @@ class GlobalCooldown extends Analyzer {
       targetID: event.sourceID, // no guarantees the original targetID is the player
       timestamp: event.timestamp,
       duration: this.getCurrentGlobalCooldown(event.ability.guid),
-      reason: event,
     }, event);
   }
   /**
@@ -144,7 +143,7 @@ class GlobalCooldown extends Analyzer {
         console.error(
           formatMilliseconds(this.owner.fightDuration),
           'GlobalCooldown',
-          event.reason.ability.name, event.reason.ability.guid, 
+          event.trigger.ability.name, event.trigger.ability.guid,
           `was cast while the Global Cooldown from`,
           this.lastGlobalCooldown.ability.name, this.lastGlobalCooldown.ability.guid,
           `was already running. There's probably a Haste buff missing from StatTracker or the Haste module, this spell has a GCD different from the default, or the base GCD for this spec is different from default.`,

--- a/src/Parser/Core/Modules/GlobalCooldown.js
+++ b/src/Parser/Core/Modules/GlobalCooldown.js
@@ -75,7 +75,7 @@ class GlobalCooldown extends Analyzer {
     // Cancelled casts reset the GCD (only for cast-time spells, "channels" always have a GCD but they also can't be *cancelled*, just ended early)
     const isCancelled = event.reason.isCancelled;
     if (isOnGcd && !isCancelled) {
-      this.triggerGlobalCooldown(event, 'begincast');
+      this.triggerGlobalCooldown(event);
     }
   }
   /**
@@ -101,25 +101,22 @@ class GlobalCooldown extends Analyzer {
       // The GCD occured already at the start of this channel
       return;
     }
-    this.triggerGlobalCooldown(event, 'cast');
+    this.triggerGlobalCooldown(event);
   }
 
   /**
    * Trigger a `globalcooldown`-event at this timestamp for the `ability` in the provided event.
    * @param event
-   * @param trigger Either 'begincast' or 'cast', `begincast` are ignored in AlwaysBeCasting so that the channel time can be used instead (if it's higher than the GCD).
    */
-  triggerGlobalCooldown(event, trigger) {
-    this.owner.triggerEvent({
-      type: 'globalcooldown',
+  triggerGlobalCooldown(event) {
+    this.owner.fabricateEvent('globalcooldown', {
       ability: event.ability,
       sourceID: event.sourceID,
       targetID: event.sourceID, // no guarantees the original targetID is the player
       timestamp: event.timestamp,
       duration: this.getCurrentGlobalCooldown(event.ability.guid),
       reason: event,
-      trigger,
-    });
+    }, event);
   }
   /**
    * Returns the current Global Cooldown duration in milliseconds for the specified spell (some spells have custom GCDs).

--- a/src/Parser/Core/Modules/GlobalCooldown.js
+++ b/src/Parser/Core/Modules/GlobalCooldown.js
@@ -110,7 +110,7 @@ class GlobalCooldown extends Analyzer {
    * @param trigger Either 'begincast' or 'cast', `begincast` are ignored in AlwaysBeCasting so that the channel time can be used instead (if it's higher than the GCD).
    */
   triggerGlobalCooldown(event, trigger) {
-    this.owner.triggerEvent('globalcooldown', {
+    this.owner.triggerEvent({
       type: 'globalcooldown',
       ability: event.ability,
       sourceID: event.sourceID,

--- a/src/Parser/Core/Modules/GlobalCooldown.js
+++ b/src/Parser/Core/Modules/GlobalCooldown.js
@@ -109,7 +109,8 @@ class GlobalCooldown extends Analyzer {
    * @param event
    */
   triggerGlobalCooldown(event) {
-    this.owner.fabricateEvent('globalcooldown', {
+    this.owner.fabricateEvent({
+      type: 'globalcooldown',
       ability: event.ability,
       sourceID: event.sourceID,
       targetID: event.sourceID, // no guarantees the original targetID is the player

--- a/src/Parser/Core/Modules/Haste.js
+++ b/src/Parser/Core/Modules/Haste.js
@@ -210,7 +210,7 @@ class Haste extends Analyzer {
       newHaste,
     };
     debug && console.log('changehaste', fabricatedEvent);
-    this.owner.triggerEvent('changehaste', fabricatedEvent);
+    this.owner.triggerEvent(fabricatedEvent);
   }
 
   static addHaste(baseHaste, hasteGain) {

--- a/src/Parser/Core/Modules/Haste.js
+++ b/src/Parser/Core/Modules/Haste.js
@@ -93,7 +93,7 @@ class Haste extends Analyzer {
     this._setHaste(event, newHastePercentage);
 
     if (debug) {
-      const spellName = event.reason.ability ? event.reason.ability.name : 'unknown';
+      const spellName = event.trigger.ability ? event.trigger.ability.name : 'unknown';
       console.log(`Haste: Current haste: ${formatPercentage(this.current)}% (haste RATING changed by ${event.delta.haste} from ${spellName})`);
     }
   }
@@ -204,7 +204,6 @@ class Haste extends Analyzer {
       type: 'changehaste',
       sourceID: event ? event.sourceID : this.owner.playerId,
       targetID: this.owner.playerId,
-      reason: event,
       oldHaste,
       newHaste,
     };

--- a/src/Parser/Core/Modules/Haste.js
+++ b/src/Parser/Core/Modules/Haste.js
@@ -201,8 +201,6 @@ class Haste extends Analyzer {
   }
   _triggerChangeHaste(event, oldHaste, newHaste) {
     const fabricatedEvent = {
-      timestamp: event ? event.timestamp : this.owner.currentTimestamp,
-      type: 'changehaste',
       sourceID: event ? event.sourceID : this.owner.playerId,
       targetID: this.owner.playerId,
       reason: event,
@@ -210,7 +208,7 @@ class Haste extends Analyzer {
       newHaste,
     };
     debug && console.log('changehaste', fabricatedEvent);
-    this.owner.triggerEvent(fabricatedEvent);
+    this.owner.fabricateEvent('changehaste', fabricatedEvent, event);
   }
 
   static addHaste(baseHaste, hasteGain) {

--- a/src/Parser/Core/Modules/Haste.js
+++ b/src/Parser/Core/Modules/Haste.js
@@ -201,6 +201,7 @@ class Haste extends Analyzer {
   }
   _triggerChangeHaste(event, oldHaste, newHaste) {
     const fabricatedEvent = {
+      type: 'changehaste',
       sourceID: event ? event.sourceID : this.owner.playerId,
       targetID: this.owner.playerId,
       reason: event,
@@ -208,7 +209,7 @@ class Haste extends Analyzer {
       newHaste,
     };
     debug && console.log('changehaste', fabricatedEvent);
-    this.owner.fabricateEvent('changehaste', fabricatedEvent, event);
+    this.owner.fabricateEvent(fabricatedEvent, event);
   }
 
   static addHaste(baseHaste, hasteGain) {

--- a/src/Parser/Core/Modules/Items/Legion/Legendaries/KiljaedensBurningWish.js
+++ b/src/Parser/Core/Modules/Items/Legion/Legendaries/KiljaedensBurningWish.js
@@ -70,8 +70,7 @@ class KiljaedensBurningWish extends Analyzer {
       targetIsFriendly: event.targetIsFriendly,
       ability: event.ability,
     };
-    // TODO are these all the fields I need?
-    this.owner.triggerEvent(castEvent);
+    this.owner.fabricateEvent(castEvent, event);
   }
 
   item() {

--- a/src/Parser/Core/Modules/Items/Legion/Legendaries/KiljaedensBurningWish.js
+++ b/src/Parser/Core/Modules/Items/Legion/Legendaries/KiljaedensBurningWish.js
@@ -71,7 +71,7 @@ class KiljaedensBurningWish extends Analyzer {
       ability: event.ability,
     };
     // TODO are these all the fields I need?
-    this.owner.triggerEvent('cast', castEvent);
+    this.owner.triggerEvent(castEvent);
   }
 
   item() {

--- a/src/Parser/Core/Modules/ResourceTracker/ResourceTracker.js
+++ b/src/Parser/Core/Modules/ResourceTracker/ResourceTracker.js
@@ -134,7 +134,7 @@ class ResourceTracker extends Analyzer {
   }
 
   triggerSpendEvent(spent, event) {
-    this.owner.triggerEvent('spendresource', {
+    this.owner.triggerEvent({
       timestamp: event.timestamp,
       type: 'spendresource',
       sourceID: event.sourceID,

--- a/src/Parser/Core/Modules/ResourceTracker/ResourceTracker.js
+++ b/src/Parser/Core/Modules/ResourceTracker/ResourceTracker.js
@@ -134,16 +134,15 @@ class ResourceTracker extends Analyzer {
   }
 
   triggerSpendEvent(spent, event) {
-    this.owner.triggerEvent({
-      timestamp: event.timestamp,
+    this.owner.fabricateEvent({
       type: 'spendresource',
+      timestamp: event.timestamp,
       sourceID: event.sourceID,
       targetID: event.targetID,
-      reason: event,
       resourceChange: spent,
       resourceChangeType: this.resource.id,
       ability: event.ability,
-    });
+    }, event);
   }
 
   shouldProcessCastEvent(event) {

--- a/src/Parser/Core/Modules/SpellHistory.js
+++ b/src/Parser/Core/Modules/SpellHistory.js
@@ -59,7 +59,8 @@ class SpellHistory extends Analyzer {
     this._append(spellId, event);
   }
   on_toPlayer_updatespellusable(event) {
-    this._append(event.spellId, event);
+    const spellId = event.ability.guid;
+    this._append(spellId, event);
   }
 }
 

--- a/src/Parser/Core/Modules/SpellUsable.js
+++ b/src/Parser/Core/Modules/SpellUsable.js
@@ -112,12 +112,12 @@ class SpellUsable extends Analyzer {
         totalReductionTime: 0,
         chargesOnCooldown: 1,
       };
-      this._triggerEvent('updatespellusable', this._makeEvent(canSpellId, timestamp, 'begincooldown'));
+      this._triggerEvent(this._makeEvent(canSpellId, timestamp, 'begincooldown'));
     } else {
       if (this.isAvailable(canSpellId)) {
         // Another charge is available
         this._currentCooldowns[canSpellId].chargesOnCooldown += 1;
-        this._triggerEvent('updatespellusable', this._makeEvent(canSpellId, timestamp, 'addcooldowncharge'));
+        this._triggerEvent(this._makeEvent(canSpellId, timestamp, 'addcooldowncharge'));
       } else {
         const remainingCooldown = this.cooldownRemaining(canSpellId, timestamp);
         if (remainingCooldown > INVALID_COOLDOWN_CONFIG_LAG_MARGIN) {
@@ -156,7 +156,7 @@ class SpellUsable extends Analyzer {
     const cooldown = this._currentCooldowns[canSpellId];
     if (cooldown.chargesOnCooldown === 1 || resetAllCharges) {
       delete this._currentCooldowns[canSpellId];
-      this._triggerEvent('updatespellusable', this._makeEvent(canSpellId, timestamp, 'endcooldown', {
+      this._triggerEvent(this._makeEvent(canSpellId, timestamp, 'endcooldown', {
         ...cooldown,
         end: timestamp,
       }));
@@ -164,7 +164,7 @@ class SpellUsable extends Analyzer {
     } else {
       // We have another charge ready to go on cooldown, this simply adds a charge and then refreshes the cooldown (spells with charges don't cooldown simultaneously)
       cooldown.chargesOnCooldown -= 1;
-      this._triggerEvent('updatespellusable', this._makeEvent(canSpellId, timestamp, 'restorecharge', cooldown));
+      this._triggerEvent(this._makeEvent(canSpellId, timestamp, 'restorecharge', cooldown));
       this.refreshCooldown(canSpellId, timestamp);
       if (remainingCDR !== 0) {
         return this.reduceCooldown(canSpellId,remainingCDR,timestamp);
@@ -191,7 +191,7 @@ class SpellUsable extends Analyzer {
     this._currentCooldowns[canSpellId].start = timestamp;
     this._currentCooldowns[canSpellId].expectedDuration = expectedCooldownDuration;
     this._currentCooldowns[canSpellId].totalReductionTime = 0;
-    this._triggerEvent('updatespellusable', this._makeEvent(canSpellId, timestamp, 'refreshcooldown'));
+    this._triggerEvent(this._makeEvent(canSpellId, timestamp, 'refreshcooldown'));
   }
   /**
    * Reduces the cooldown for the provided spell by the provided duration.
@@ -237,7 +237,7 @@ class SpellUsable extends Analyzer {
       ...others,
     };
   }
-  _triggerEvent(eventType, event) {
+  _triggerEvent(event) {
     if (debug) {
       const spellId = event.spellId;
       const fightDuration = formatMilliseconds(event.timestamp - this.owner.fight.start_time);
@@ -261,7 +261,7 @@ class SpellUsable extends Analyzer {
       }
     }
 
-    this.owner.triggerEvent(eventType, event);
+    this.owner.triggerEvent(event);
   }
 
   on_byPlayer_cast(event) {

--- a/src/Parser/Core/Modules/SpellUsable.js
+++ b/src/Parser/Core/Modules/SpellUsable.js
@@ -223,7 +223,9 @@ class SpellUsable extends Analyzer {
     const maxCharges = this.abilities.getMaxCharges(spellId) || 1;
     return {
       type: 'updatespellusable',
-      spellId,
+      ability: {
+        guid: spellId,
+      },
       trigger,
       timestamp,
       isOnCooldown: this.isOnCooldown(spellId),
@@ -239,7 +241,7 @@ class SpellUsable extends Analyzer {
   }
   _triggerEvent(event) {
     if (debug) {
-      const spellId = event.spellId;
+      const spellId = event.ability.guid;
       const fightDuration = formatMilliseconds(event.timestamp - this.owner.fight.start_time);
       switch (event.trigger) {
         case 'begincooldown':
@@ -261,7 +263,7 @@ class SpellUsable extends Analyzer {
       }
     }
 
-    this.owner.triggerEvent(event);
+    this.owner.fabricateEvent(event.type, event);
   }
 
   on_byPlayer_cast(event) {

--- a/src/Parser/Core/Modules/SpellUsable.js
+++ b/src/Parser/Core/Modules/SpellUsable.js
@@ -263,7 +263,7 @@ class SpellUsable extends Analyzer {
       }
     }
 
-    this.owner.fabricateEvent(event.type, event);
+    this.owner.fabricateEvent(event);
   }
 
   on_byPlayer_cast(event) {

--- a/src/Parser/Core/Modules/SpellUsable.js
+++ b/src/Parser/Core/Modules/SpellUsable.js
@@ -33,10 +33,10 @@ class SpellUsable extends Analyzer {
    */
   _getCanonicalId(spellId) {
     const ability = this.abilities.getAbility(spellId);
-    if(!ability) {
+    if (!ability) {
       return spellId; // not a class ability
     }
-    if(ability.spell instanceof Array) {
+    if (ability.spell instanceof Array) {
       return ability.spell[0].id;
     } else {
       return ability.spell.id;
@@ -167,7 +167,7 @@ class SpellUsable extends Analyzer {
       this._triggerEvent(this._makeEvent(canSpellId, timestamp, 'restorecharge', cooldown));
       this.refreshCooldown(canSpellId, timestamp);
       if (remainingCDR !== 0) {
-        return this.reduceCooldown(canSpellId,remainingCDR,timestamp);
+        return this.reduceCooldown(canSpellId, remainingCDR, timestamp);
       }
     }
   }
@@ -175,7 +175,7 @@ class SpellUsable extends Analyzer {
    * Refresh (restart) the cooldown for the provided spell.
    * @param {number} spellId The ID of the spell.
    * @param {number} timestamp Override the timestamp if it may be different from the current timestamp.
-    calculated like normal.
+   calculated like normal.
    */
   refreshCooldown(spellId, timestamp = this.owner.currentTimestamp) {
     const canSpellId = this._getCanonicalId(spellId);
@@ -259,7 +259,8 @@ class SpellUsable extends Analyzer {
         case 'endcooldown':
           console.log(fightDuration, 'SpellUsable', 'Cooldown finished:', spellName(spellId), spellId);
           break;
-        default: break;
+        default:
+          break;
       }
     }
 

--- a/src/Parser/Core/Modules/SpellUsable.test.js
+++ b/src/Parser/Core/Modules/SpellUsable.test.js
@@ -194,7 +194,7 @@ describe('Core/Modules/SpellUsable', () => {
 
       expect(parserMock.fabricateEvent).toHaveBeenCalledTimes(1);
       const call = parserMock.fabricateEvent.mock.calls[0];
-      expect(call[0]).toEqual('updatespellusable');
+      expect(call[0]).toBe('updatespellusable');
       expect(call[1]).toEqual({
         type: 'updatespellusable',
         ability: {
@@ -223,7 +223,7 @@ describe('Core/Modules/SpellUsable', () => {
       expect(parserMock.fabricateEvent).toHaveBeenCalledTimes(2);
       {
         const call = parserMock.fabricateEvent.mock.calls[0];
-        expect(call[0]).toEqual('updatespellusable');
+        expect(call[0]).toBe('updatespellusable');
         expect(call[1]).toEqual({
           type: 'updatespellusable',
           ability: {
@@ -246,7 +246,7 @@ describe('Core/Modules/SpellUsable', () => {
       }
       {
         const call = parserMock.fabricateEvent.mock.calls[1];
-        expect(call[0]).toEqual('updatespellusable');
+        expect(call[0]).toBe('updatespellusable');
         expect(call[1]).toEqual({
           type: 'updatespellusable',
           ability: {
@@ -276,7 +276,7 @@ describe('Core/Modules/SpellUsable', () => {
 
       expect(parserMock.fabricateEvent).toHaveBeenCalledTimes(1);
       const call = parserMock.fabricateEvent.mock.calls[0];
-      expect(call[0]).toEqual('updatespellusable');
+      expect(call[0]).toBe('updatespellusable');
       expect(call[1]).toEqual({
         type: 'updatespellusable',
         ability: {
@@ -306,7 +306,7 @@ describe('Core/Modules/SpellUsable', () => {
 
       expect(parserMock.fabricateEvent).toHaveBeenCalledTimes(1);
       const call = parserMock.fabricateEvent.mock.calls[0];
-      expect(call[0]).toEqual('updatespellusable');
+      expect(call[0]).toBe('updatespellusable');
       expect(call[1]).toEqual({
         type: 'updatespellusable',
         ability: {
@@ -339,7 +339,7 @@ describe('Core/Modules/SpellUsable', () => {
       expect(parserMock.fabricateEvent).toHaveBeenCalledTimes(2);
       {
         const call = parserMock.fabricateEvent.mock.calls[0];
-        expect(call[0]).toEqual('updatespellusable');
+        expect(call[0]).toBe('updatespellusable');
         expect(call[1]).toEqual({
           type: 'updatespellusable',
           ability: {
@@ -362,7 +362,7 @@ describe('Core/Modules/SpellUsable', () => {
       }
       {
         const call = parserMock.fabricateEvent.mock.calls[1];
-        expect(call[0]).toEqual('updatespellusable');
+        expect(call[0]).toBe('updatespellusable');
         expect(call[1]).toEqual({
           type: 'updatespellusable',
           ability: {

--- a/src/Parser/Core/Modules/SpellUsable.test.js
+++ b/src/Parser/Core/Modules/SpellUsable.test.js
@@ -194,8 +194,7 @@ describe('Core/Modules/SpellUsable', () => {
 
       expect(parserMock.fabricateEvent).toHaveBeenCalledTimes(1);
       const call = parserMock.fabricateEvent.mock.calls[0];
-      expect(call[0]).toBe('updatespellusable');
-      expect(call[1]).toEqual({
+      expect(call[0]).toEqual({
         type: 'updatespellusable',
         ability: {
           guid: SPELLS.FAKE_SPELL.id,
@@ -223,8 +222,7 @@ describe('Core/Modules/SpellUsable', () => {
       expect(parserMock.fabricateEvent).toHaveBeenCalledTimes(2);
       {
         const call = parserMock.fabricateEvent.mock.calls[0];
-        expect(call[0]).toBe('updatespellusable');
-        expect(call[1]).toEqual({
+        expect(call[0]).toEqual({
           type: 'updatespellusable',
           ability: {
             guid: SPELLS.FAKE_SPELL.id,
@@ -246,8 +244,7 @@ describe('Core/Modules/SpellUsable', () => {
       }
       {
         const call = parserMock.fabricateEvent.mock.calls[1];
-        expect(call[0]).toBe('updatespellusable');
-        expect(call[1]).toEqual({
+        expect(call[0]).toEqual({
           type: 'updatespellusable',
           ability: {
             guid: SPELLS.FAKE_SPELL.id,
@@ -276,8 +273,7 @@ describe('Core/Modules/SpellUsable', () => {
 
       expect(parserMock.fabricateEvent).toHaveBeenCalledTimes(1);
       const call = parserMock.fabricateEvent.mock.calls[0];
-      expect(call[0]).toBe('updatespellusable');
-      expect(call[1]).toEqual({
+      expect(call[0]).toEqual({
         type: 'updatespellusable',
         ability: {
           guid: SPELLS.FAKE_SPELL.id,
@@ -306,8 +302,7 @@ describe('Core/Modules/SpellUsable', () => {
 
       expect(parserMock.fabricateEvent).toHaveBeenCalledTimes(1);
       const call = parserMock.fabricateEvent.mock.calls[0];
-      expect(call[0]).toBe('updatespellusable');
-      expect(call[1]).toEqual({
+      expect(call[0]).toEqual({
         type: 'updatespellusable',
         ability: {
           guid: SPELLS.FAKE_SPELL.id,
@@ -339,8 +334,7 @@ describe('Core/Modules/SpellUsable', () => {
       expect(parserMock.fabricateEvent).toHaveBeenCalledTimes(2);
       {
         const call = parserMock.fabricateEvent.mock.calls[0];
-        expect(call[0]).toBe('updatespellusable');
-        expect(call[1]).toEqual({
+        expect(call[0]).toEqual({
           type: 'updatespellusable',
           ability: {
             guid: SPELLS.FAKE_SPELL.id,
@@ -362,8 +356,7 @@ describe('Core/Modules/SpellUsable', () => {
       }
       {
         const call = parserMock.fabricateEvent.mock.calls[1];
-        expect(call[0]).toBe('updatespellusable');
-        expect(call[1]).toEqual({
+        expect(call[0]).toEqual({
           type: 'updatespellusable',
           ability: {
             guid: SPELLS.FAKE_SPELL.id,

--- a/src/Parser/Core/Modules/SpellUsable.test.js
+++ b/src/Parser/Core/Modules/SpellUsable.test.js
@@ -15,7 +15,7 @@ describe('Core/Modules/SpellUsable', () => {
     abilitiesMock = {
       getExpectedCooldownDuration: jest.fn(() => 7500),
       getMaxCharges: jest.fn(),
-      getAbility: jest.fn((id) => {spell: {id: id}}),
+      getAbility: jest.fn((id) => ({spell: {id: id}})),
     };
 
     instance = new SpellUsable(parserMock, {
@@ -120,7 +120,7 @@ describe('Core/Modules/SpellUsable', () => {
       abilitiesMock.getMaxCharges = jest.fn(() => 2);
       triggerCast(SPELLS.FAKE_SPELL.id);
       parserMock.currentTimestamp = 5000;
-      parserMock.triggerEvent = jest.fn();
+      parserMock.fabricateEvent = jest.fn();
       triggerCast(SPELLS.FAKE_SPELL.id);
 
       // It does NOT report when this happens, as it's normal behavior.
@@ -192,11 +192,14 @@ describe('Core/Modules/SpellUsable', () => {
     it('a new spell going on cooldown triggers an `updatespellusable` event indicating the spell going on cooldown', () => {
       triggerCast(SPELLS.FAKE_SPELL.id);
 
-      expect(parserMock.triggerEvent).toHaveBeenCalledTimes(1);
-      const call = parserMock.triggerEvent.mock.calls[0];
-      expect(call[0]).toEqual({
+      expect(parserMock.fabricateEvent).toHaveBeenCalledTimes(1);
+      const call = parserMock.fabricateEvent.mock.calls[0];
+      expect(call[0]).toEqual('updatespellusable');
+      expect(call[1]).toEqual({
         type: 'updatespellusable',
-        spellId: SPELLS.FAKE_SPELL.id,
+        ability: {
+          guid: SPELLS.FAKE_SPELL.id,
+        },
         timestamp: 0,
         start: 0,
         expectedDuration: 7500,
@@ -214,15 +217,18 @@ describe('Core/Modules/SpellUsable', () => {
     });
     it('casting a spell already on cooldown before the cooldown runs out restarts the cooldown and fires both endcooldown and begincooldown events', () => {
       triggerCast(SPELLS.FAKE_SPELL.id);
-      parserMock.triggerEvent = jest.fn();
+      parserMock.fabricateEvent = jest.fn();
       triggerCast(SPELLS.FAKE_SPELL.id);
 
-      expect(parserMock.triggerEvent).toHaveBeenCalledTimes(2);
+      expect(parserMock.fabricateEvent).toHaveBeenCalledTimes(2);
       {
-        const call = parserMock.triggerEvent.mock.calls[0];
-        expect(call[0]).toEqual({
+        const call = parserMock.fabricateEvent.mock.calls[0];
+        expect(call[0]).toEqual('updatespellusable');
+        expect(call[1]).toEqual({
           type: 'updatespellusable',
-          spellId: SPELLS.FAKE_SPELL.id,
+          ability: {
+            guid: SPELLS.FAKE_SPELL.id,
+          },
           timestamp: 0,
           start: 0,
           end: 0,
@@ -239,10 +245,13 @@ describe('Core/Modules/SpellUsable', () => {
         });
       }
       {
-        const call = parserMock.triggerEvent.mock.calls[1];
-        expect(call[0]).toEqual({
+        const call = parserMock.fabricateEvent.mock.calls[1];
+        expect(call[0]).toEqual('updatespellusable');
+        expect(call[1]).toEqual({
           type: 'updatespellusable',
-          spellId: SPELLS.FAKE_SPELL.id,
+          ability: {
+            guid: SPELLS.FAKE_SPELL.id,
+          },
           timestamp: 0,
           start: 0,
           expectedDuration: 7500,
@@ -262,14 +271,17 @@ describe('Core/Modules/SpellUsable', () => {
     it('using another charge of a spell already on cooldown triggers an `updatespellusable` event indicating the charge going on cooldown', () => {
       abilitiesMock.getMaxCharges = jest.fn(() => 2);
       triggerCast(SPELLS.FAKE_SPELL.id);
-      parserMock.triggerEvent = jest.fn();
+      parserMock.fabricateEvent = jest.fn();
       triggerCast(SPELLS.FAKE_SPELL.id);
 
-      expect(parserMock.triggerEvent).toHaveBeenCalledTimes(1);
-      const call = parserMock.triggerEvent.mock.calls[0];
-      expect(call[0]).toEqual({
+      expect(parserMock.fabricateEvent).toHaveBeenCalledTimes(1);
+      const call = parserMock.fabricateEvent.mock.calls[0];
+      expect(call[0]).toEqual('updatespellusable');
+      expect(call[1]).toEqual({
         type: 'updatespellusable',
-        spellId: SPELLS.FAKE_SPELL.id,
+        ability: {
+          guid: SPELLS.FAKE_SPELL.id,
+        },
         timestamp: 0,
         start: 0,
         expectedDuration: 7500,
@@ -289,14 +301,17 @@ describe('Core/Modules/SpellUsable', () => {
       parserMock.currentTimestamp = 0;
       triggerCast(SPELLS.FAKE_SPELL.id);
       parserMock.currentTimestamp = 10000;
-      parserMock.triggerEvent = jest.fn();
+      parserMock.fabricateEvent = jest.fn();
       triggerCooldownExpiryCheck();
 
-      expect(parserMock.triggerEvent).toHaveBeenCalledTimes(1);
-      const call = parserMock.triggerEvent.mock.calls[0];
-      expect(call[0]).toEqual({
+      expect(parserMock.fabricateEvent).toHaveBeenCalledTimes(1);
+      const call = parserMock.fabricateEvent.mock.calls[0];
+      expect(call[0]).toEqual('updatespellusable');
+      expect(call[1]).toEqual({
         type: 'updatespellusable',
-        spellId: SPELLS.FAKE_SPELL.id,
+        ability: {
+          guid: SPELLS.FAKE_SPELL.id,
+        },
         timestamp: 7500, // it should be simulated at the time of expiry
         start: 0,
         end: 7500,
@@ -318,15 +333,18 @@ describe('Core/Modules/SpellUsable', () => {
       triggerCast(SPELLS.FAKE_SPELL.id);
       triggerCast(SPELLS.FAKE_SPELL.id);
       parserMock.currentTimestamp = 10000;
-      parserMock.triggerEvent = jest.fn();
+      parserMock.fabricateEvent = jest.fn();
       triggerCooldownExpiryCheck();
 
-      expect(parserMock.triggerEvent).toHaveBeenCalledTimes(2);
+      expect(parserMock.fabricateEvent).toHaveBeenCalledTimes(2);
       {
-        const call = parserMock.triggerEvent.mock.calls[0];
-        expect(call[0]).toEqual({
+        const call = parserMock.fabricateEvent.mock.calls[0];
+        expect(call[0]).toEqual('updatespellusable');
+        expect(call[1]).toEqual({
           type: 'updatespellusable',
-          spellId: SPELLS.FAKE_SPELL.id,
+          ability: {
+            guid: SPELLS.FAKE_SPELL.id,
+          },
           timestamp: 7500, // it should be simulated at the time of expiry
           start: 0,
           expectedDuration: 7500,
@@ -343,10 +361,13 @@ describe('Core/Modules/SpellUsable', () => {
         });
       }
       {
-        const call = parserMock.triggerEvent.mock.calls[1];
-        expect(call[0]).toEqual({
+        const call = parserMock.fabricateEvent.mock.calls[1];
+        expect(call[0]).toEqual('updatespellusable');
+        expect(call[1]).toEqual({
           type: 'updatespellusable',
-          spellId: SPELLS.FAKE_SPELL.id,
+          ability: {
+            guid: SPELLS.FAKE_SPELL.id,
+          },
           timestamp: 7500, // it should be simulated at the time of expiry
           start: 7500,
           expectedDuration: 7500,

--- a/src/Parser/Core/Modules/SpellUsable.test.js
+++ b/src/Parser/Core/Modules/SpellUsable.test.js
@@ -22,7 +22,8 @@ describe('Core/Modules/SpellUsable', () => {
       abilities: abilitiesMock,
     });
     triggerCast = (spellId, extra) => {
-      instance.triggerEvent('cast', {
+      instance.triggerEvent({
+        type: 'cast',
         ability: {
           guid: spellId,
         },
@@ -31,7 +32,8 @@ describe('Core/Modules/SpellUsable', () => {
       });
     };
     triggerHasteChange = () => {
-      instance.triggerEvent('changehaste', {
+      instance.triggerEvent({
+        type: 'changehaste',
         // We don't need more; the new Haste is pulled straight from the Haste module
         timestamp: parserMock.currentTimestamp,
       });
@@ -39,7 +41,7 @@ describe('Core/Modules/SpellUsable', () => {
   });
 
   // This might be considered implementation detail, but it's also kinda the only way. Code doesn't magically run, so the only way to trigger our cooldown handling is with an event.
-  const triggerCooldownExpiryCheck = () => instance.triggerEvent();
+  const triggerCooldownExpiryCheck = () => instance.triggerEvent({});
 
   describe('regular spell status tracking', () => {
     it('a spell starts off cooldown', () => {
@@ -192,8 +194,7 @@ describe('Core/Modules/SpellUsable', () => {
 
       expect(parserMock.triggerEvent).toHaveBeenCalledTimes(1);
       const call = parserMock.triggerEvent.mock.calls[0];
-      expect(call[0]).toBe('updatespellusable');
-      expect(call[1]).toEqual({
+      expect(call[0]).toEqual({
         type: 'updatespellusable',
         spellId: SPELLS.FAKE_SPELL.id,
         timestamp: 0,
@@ -219,8 +220,7 @@ describe('Core/Modules/SpellUsable', () => {
       expect(parserMock.triggerEvent).toHaveBeenCalledTimes(2);
       {
         const call = parserMock.triggerEvent.mock.calls[0];
-        expect(call[0]).toBe('updatespellusable');
-        expect(call[1]).toEqual({
+        expect(call[0]).toEqual({
           type: 'updatespellusable',
           spellId: SPELLS.FAKE_SPELL.id,
           timestamp: 0,
@@ -240,8 +240,7 @@ describe('Core/Modules/SpellUsable', () => {
       }
       {
         const call = parserMock.triggerEvent.mock.calls[1];
-        expect(call[0]).toBe('updatespellusable');
-        expect(call[1]).toEqual({
+        expect(call[0]).toEqual({
           type: 'updatespellusable',
           spellId: SPELLS.FAKE_SPELL.id,
           timestamp: 0,
@@ -268,8 +267,7 @@ describe('Core/Modules/SpellUsable', () => {
 
       expect(parserMock.triggerEvent).toHaveBeenCalledTimes(1);
       const call = parserMock.triggerEvent.mock.calls[0];
-      expect(call[0]).toBe('updatespellusable');
-      expect(call[1]).toEqual({
+      expect(call[0]).toEqual({
         type: 'updatespellusable',
         spellId: SPELLS.FAKE_SPELL.id,
         timestamp: 0,
@@ -296,8 +294,7 @@ describe('Core/Modules/SpellUsable', () => {
 
       expect(parserMock.triggerEvent).toHaveBeenCalledTimes(1);
       const call = parserMock.triggerEvent.mock.calls[0];
-      expect(call[0]).toBe('updatespellusable');
-      expect(call[1]).toEqual({
+      expect(call[0]).toEqual({
         type: 'updatespellusable',
         spellId: SPELLS.FAKE_SPELL.id,
         timestamp: 7500, // it should be simulated at the time of expiry
@@ -327,8 +324,7 @@ describe('Core/Modules/SpellUsable', () => {
       expect(parserMock.triggerEvent).toHaveBeenCalledTimes(2);
       {
         const call = parserMock.triggerEvent.mock.calls[0];
-        expect(call[0]).toBe('updatespellusable');
-        expect(call[1]).toEqual({
+        expect(call[0]).toEqual({
           type: 'updatespellusable',
           spellId: SPELLS.FAKE_SPELL.id,
           timestamp: 7500, // it should be simulated at the time of expiry
@@ -348,8 +344,7 @@ describe('Core/Modules/SpellUsable', () => {
       }
       {
         const call = parserMock.triggerEvent.mock.calls[1];
-        expect(call[0]).toBe('updatespellusable');
-        expect(call[1]).toEqual({
+        expect(call[0]).toEqual({
           type: 'updatespellusable',
           spellId: SPELLS.FAKE_SPELL.id,
           timestamp: 7500, // it should be simulated at the time of expiry

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -614,7 +614,6 @@ class StatTracker extends Analyzer {
       type: 'changestats',
       sourceID: event ? event.sourceID : this.owner.playerId,
       targetID: this.owner.playerId,
-      reason: event,
       before,
       delta,
       after,

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -610,16 +610,14 @@ class StatTracker extends Analyzer {
    * Fabricates an event indicating when stats change
    */
   _triggerChangeStats(event, before, delta, after) {
-    this.owner.triggerEvent({
-      timestamp: event ? event.timestamp : this.owner.currentTimestamp,
-      type: 'changestats',
+    this.owner.fabricateEvent('changestats', {
       sourceID: event ? event.sourceID : this.owner.playerId,
       targetID: this.owner.playerId,
       reason: event,
       before,
       delta,
       after,
-    });
+    }, event);
   }
 
   /**

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -610,7 +610,7 @@ class StatTracker extends Analyzer {
    * Fabricates an event indicating when stats change
    */
   _triggerChangeStats(event, before, delta, after) {
-    this.owner.triggerEvent('changestats', {
+    this.owner.triggerEvent({
       timestamp: event ? event.timestamp : this.owner.currentTimestamp,
       type: 'changestats',
       sourceID: event ? event.sourceID : this.owner.playerId,

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -610,7 +610,8 @@ class StatTracker extends Analyzer {
    * Fabricates an event indicating when stats change
    */
   _triggerChangeStats(event, before, delta, after) {
-    this.owner.fabricateEvent('changestats', {
+    this.owner.fabricateEvent({
+      type: 'changestats',
       sourceID: event ? event.sourceID : this.owner.playerId,
       targetID: this.owner.playerId,
       reason: event,

--- a/src/Parser/Druid/Balance/Modules/Features/L90_talents.js
+++ b/src/Parser/Druid/Balance/Modules/Features/L90_talents.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
-import { formatNumber , formatPercentage } from 'common/format';
+import { formatNumber, formatPercentage } from 'common/format';
 import Wrapper from 'common/Wrapper';
 import SpellLink from 'common/SpellLink';
 
@@ -37,96 +37,96 @@ class L90_talents extends Analyzer {
   blessingOfElunePotential = 0;
 
   on_initialized() {
-    if (this.combatants.selected.hasTalent(SPELLS.SHOOTING_STARS_TALENT.id)){
+    if (this.combatants.selected.hasTalent(SPELLS.SHOOTING_STARS_TALENT.id)) {
       this.activeTalent = SPELLS.SHOOTING_STARS_TALENT;
     }
-    if (this.combatants.selected.hasTalent(SPELLS.ASTRAL_COMMUNION_TALENT.id)){
+    if (this.combatants.selected.hasTalent(SPELLS.ASTRAL_COMMUNION_TALENT.id)) {
       this.activeTalent = SPELLS.ASTRAL_COMMUNION_TALENT;
     }
-    if (this.combatants.selected.hasTalent(SPELLS.BLESSING_OF_THE_ANCIENTS_TALENT.id)){
+    if (this.combatants.selected.hasTalent(SPELLS.BLESSING_OF_THE_ANCIENTS_TALENT.id)) {
       this.activeTalent = SPELLS.BLESSING_OF_THE_ANCIENTS_TALENT;
     }
   }
 
   on_byPlayer_damage(event) {
-    if ( (event.ability.guid === SPELLS.MOONFIRE_BEAR.id || event.ability.guid === SPELLS.SUNFIRE.id ) && event.tick === true) {
+    if ((event.ability.guid === SPELLS.MOONFIRE_BEAR.id || event.ability.guid === SPELLS.SUNFIRE.id) && event.tick === true) {
       this.dotTicks++;
-    }       
+    }
   }
-  on_toPlayer_energize(event){
+  on_toPlayer_energize(event) {
     const spellId = event.ability.guid;
-    if(spellId !== SPELLS.LUNAR_STRIKE.id && spellId !== SPELLS.SOLAR_WRATH_MOONKIN.id){
+    if (spellId !== SPELLS.LUNAR_STRIKE.id && spellId !== SPELLS.SOLAR_WRATH_MOONKIN.id) {
       return;
     }
-    if(this.combatants.selected.hasBuff(SPELLS.BLESSING_OF_ELUNE.id)){
+    if (this.combatants.selected.hasBuff(SPELLS.BLESSING_OF_ELUNE.id)) {
       this.blessingOfEluneGenerated += this.getBonus(event.resourceChange, BLESSING_OF_ELUNE_MULTIPLIER, true);
-    }else {
+    } else {
       this.blessingOfElunePotential += this.getBonus(event.resourceChange, BLESSING_OF_ELUNE_MULTIPLIER, false);
     }
 
   }
-  on_changehaste(event){
-    if(this.lastHasteChangedTimestamp !== 0){
+  on_changehaste(event) {
+    if (this.lastHasteChangedTimestamp !== 0) {
       this.totalHaste += (event.timestamp - this.lastHasteChangedTimestamp) * event.oldHaste;
     }
     this.lastHasteChangedTimestamp = event.timestamp;
   }
 
-  get averageHaste(){
+  get averageHaste() {
     return this.totalHaste / this.owner.fightDuration;
   }
 
-  getGenerated(spellId){
+  getGenerated(spellId) {
     const generator = this.astralPowerTracker.buildersObj[spellId] || 0;
-    if(generator){
+    if (generator) {
       return generator.generated;
     }
     return 0;
   }
 
-  getBonus(value, increase, eluneActive){
-    if(eluneActive){
+  getBonus(value, increase, eluneActive) {
+    if (eluneActive) {
       return value - (value / (1 + increase));
     }
     return value * increase;
   }
 
-  get shootingStarsValue(){ 
+  get shootingStarsValue() {
     return this.dotTicks * SHOOTING_STARS_MULTIPLIER / this.owner.fightDuration * 1000 * 60;
   }
 
-  get astralCommunionValue(){
+  get astralCommunionValue() {
     return (1 + Math.floor(this.owner.fightDuration / 1000 / ASTRAL_COMMUNION_COOLDOWN)) * ASTRAL_COMMUNION_VALUE / this.owner.fightDuration * 1000 * 60;
   }
 
-  get BlessingOfAnsheValue(){
+  get BlessingOfAnsheValue() {
     return (1 + Math.floor(this.owner.fightDuration / 1000 / (BLESSING_OF_ANSHE_COOLDOWN / (1 + this.averageHaste)))) * BLESSING_OF_ANSHE_VALUE / this.owner.fightDuration * 1000 * 60;
   }
 
-  get BlessingOfEluneValue(){
-    return ( this.blessingOfElunePotential + this.blessingOfEluneGenerated ) / this.owner.fightDuration * 1000 * 60;
+  get BlessingOfEluneValue() {
+    return (this.blessingOfElunePotential + this.blessingOfEluneGenerated) / this.owner.fightDuration * 1000 * 60;
   }
 
-  get actualValue(){
-    if(this.activeTalent.id === SPELLS.SHOOTING_STARS_TALENT.id){
+  get actualValue() {
+    if (this.activeTalent.id === SPELLS.SHOOTING_STARS_TALENT.id) {
       return this.getGenerated(SPELLS.SHOOTING_STARS.id);
     }
-    if(this.activeTalent.id === SPELLS.ASTRAL_COMMUNION_TALENT.id){
+    if (this.activeTalent.id === SPELLS.ASTRAL_COMMUNION_TALENT.id) {
       return this.getGenerated(SPELLS.ASTRAL_COMMUNION_TALENT.id);
     }
     return this.getGenerated(SPELLS.BLESSING_OF_ANSHE.id) + this.blessingOfEluneGenerated;
   }
 
-  get generatedPerMinute(){
+  get generatedPerMinute() {
     return this.actualValue / this.owner.fightDuration * 1000 * 60;
   }
 
-  get percentOfPotential(){
+  get percentOfPotential() {
     const maxPotential = Math.max(this.shootingStarsValue, this.astralCommunionValue, this.BlessingOfAnsheValue, this.BlessingOfEluneValue);
-    if(this.activeTalent.id === SPELLS.SHOOTING_STARS_TALENT.id){
+    if (this.activeTalent.id === SPELLS.SHOOTING_STARS_TALENT.id) {
       return this.shootingStarsValue / maxPotential;
     }
-    if(this.activeTalent.id === SPELLS.ASTRAL_COMMUNION_TALENT.id){
+    if (this.activeTalent.id === SPELLS.ASTRAL_COMMUNION_TALENT.id) {
       return this.astralCommunionValue / maxPotential;
     }
     return Math.max(this.generatedPerMinute, this.BlessingOfEluneValue, this.BlessingOfAnsheValue) / maxPotential;
@@ -146,11 +146,11 @@ class L90_talents extends Analyzer {
 
   suggestions(when) {
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
-        return suggest(<Wrapper><SpellLink id={this.activeTalent.id} /> only generated {formatPercentage(actual)}% of the Astral Power that another talent in the row would have generated. Consider using one of the other available choices. See the statistic box below for more information.</Wrapper>)
-          .icon(this.activeTalent.icon)
-          .actual(`${formatPercentage(actual)}% of another talent's generation.`)
-          .recommended(`>${formatPercentage(recommended)}% is recommended`);
-      });
+      return suggest(<Wrapper><SpellLink id={this.activeTalent.id} /> only generated {formatPercentage(actual)}% of the Astral Power that another talent in the row would have generated. Consider using one of the other available choices. See the statistic box below for more information.</Wrapper>)
+        .icon(this.activeTalent.icon)
+        .actual(`${formatPercentage(actual)}% of another talent's generation.`)
+        .recommended(`>${formatPercentage(recommended)}% is recommended`);
+    });
   }
 
   statistic() {

--- a/src/Parser/Monk/Brewmaster/Modules/Core/BrewCDR.test.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/BrewCDR.test.js
@@ -7,6 +7,9 @@ import CombatLogParser from '../../CombatLogParser';
 import BrewCDR from './BrewCDR';
 import report from '../../test-logs/report_nxzcqJKmYwHbdWMp';
 
+// Disable spammy warnings
+console.error = jest.fn();
+console.warn = jest.fn();
 
 describe('BrewCDR', () => {
   let events;

--- a/src/Parser/Monk/Brewmaster/Modules/Core/Stagger.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/Stagger.js
@@ -1,10 +1,12 @@
 import React from 'react';
+
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import { formatNumber, formatPercentage, formatThousands } from 'common/format';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import Analyzer from 'Parser/Core/Analyzer';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+
 import StaggerFabricator from './StaggerFabricator';
 
 const debug = false;
@@ -14,7 +16,7 @@ class Stagger extends Analyzer {
   static dependencies = {
     combatants: Combatants,
     fab: StaggerFabricator,
-  }
+  };
 
   totalPhysicalStaggered = 0;
   totalMagicalStaggered = 0;
@@ -22,7 +24,7 @@ class Stagger extends Analyzer {
   staggerMissingFromFight = 0;
 
   on_addstagger(event) {
-    if(event.reason.extraAbility.type === PHYSICAL_DAMAGE) {
+    if (event.trigger.extraAbility.type === PHYSICAL_DAMAGE) {
       this.totalPhysicalStaggered += event.amount;
     } else {
       this.totalMagicalStaggered += event.amount;
@@ -30,7 +32,7 @@ class Stagger extends Analyzer {
   }
 
   on_removestagger(event) {
-    if (event.reason.ability && event.reason.ability.guid === SPELLS.STAGGER_TAKEN.id){
+    if (event.trigger.ability && event.trigger.ability.guid === SPELLS.STAGGER_TAKEN.id) {
       this.totalStaggerTaken += event.amount;
     }
   }

--- a/src/Parser/Monk/Brewmaster/Modules/Core/Stagger.test.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/Stagger.test.js
@@ -1,8 +1,9 @@
 import SPELLS from 'common/SPELLS';
-import StaggerFabricator from 'Parser/Monk/Brewmaster/Modules/Core/StaggerFabricator';
-import Stagger from 'Parser/Monk/Brewmaster/Modules/Core/Stagger';
-import processEvents from './Fixtures/processEvents';
-import { EarlyFinish, incomingDamage, SimpleFight } from './Fixtures/SimpleFight';
+import processEvents from 'tests/Parser/Brewmaster/Fixtures/processEvents';
+import { EarlyFinish, incomingDamage, SimpleFight } from 'tests/Parser/Brewmaster/Fixtures/SimpleFight';
+
+import StaggerFabricator from './StaggerFabricator';
+import Stagger from './Stagger';
 
 describe('Brewmaster.Stagger', () => {
   let stagger;
@@ -27,7 +28,7 @@ describe('Brewmaster.Stagger', () => {
       byPlayerPet: () => false,
     });
     stagger.fab = fab;
-    fab.owner.triggerEvent = (event, obj) => stagger.triggerEvent(event, obj);
+    fab.owner.fabricateEvent = (event, obj) => stagger.triggerEvent({ ...event, trigger: obj });
   });
   it('total amount of stagger taken with no events', () => {
     expect(stagger.totalStaggerTaken).toBe(0);
@@ -57,12 +58,6 @@ describe('Brewmaster.Stagger', () => {
     expect(stagger.totalMagicalStaggered).toBe(299);
   });
   it('Tracks the amount of stagger missing from the fight', () => {
-    const earlyFightEnd = 6000;
-    const myOwner = {
-      fight: {
-        end_time: earlyFightEnd,
-      },
-    };
     processEvents(EarlyFinish, fab, stagger);
     // this doesn't actually do anything for the test.... stagger.owner = myOwner;
     stagger.triggerEvent({

--- a/src/Parser/Monk/Brewmaster/Modules/Core/StaggerFabricator.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/StaggerFabricator.js
@@ -10,8 +10,8 @@ const ISB_QUICK_SIP_PURIFY = 0.05;
 const T20_4PC_PURIFY = 0.05;
 const debug = false;
 
-export const EVENT_STAGGER_POOL_ADDED = "addstagger";
-export const EVENT_STAGGER_POOL_REMOVED = "removestagger";
+export const EVENT_STAGGER_POOL_ADDED = 'addstagger';
+export const EVENT_STAGGER_POOL_REMOVED = 'removestagger';
 
 /**
  * Fabricate events corresponding to stagger pool updates. Each stagger
@@ -32,7 +32,7 @@ class StaggerFabricator extends Analyzer {
   get purifyPercentage() {
     const player = this.combatants.selected;
     let pct = PURIFY_BASE;
-    if(player.hasTalent(SPELLS.ELUSIVE_DANCE_TALENT.id)) {
+    if (player.hasTalent(SPELLS.ELUSIVE_DANCE_TALENT.id)) {
       // elusive dance clears an extra 20% of staggered damage
       pct += ELUSIVE_DANCE_PURIFY;
     }
@@ -61,7 +61,7 @@ class StaggerFabricator extends Analyzer {
     const amount = event.amount + (event.absorbed || 0);
     this._staggerPool += amount;
     debug && console.log("triggering stagger pool update due to absorb");
-    this.owner.triggerEvent(this._fab(EVENT_STAGGER_POOL_ADDED, event, amount));
+    this.owner.fabricateEvent(this._fab(EVENT_STAGGER_POOL_ADDED, event, amount), event);
   }
 
   on_toPlayer_damage(event) {
@@ -70,9 +70,9 @@ class StaggerFabricator extends Analyzer {
       this._staggerPool -= amount;
       // sometimes a stagger tick is recorded immediately after death.
       // this ensures we don't go into negative stagger
-      this._staggerPool = Math.max(this._staggerPool, 0); 
+      this._staggerPool = Math.max(this._staggerPool, 0);
       debug && console.log("triggering stagger pool update due to stagger tick");
-      this.owner.triggerEvent(this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount));
+      this.owner.fabricateEvent(this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount), event);
     }
   }
 
@@ -81,12 +81,12 @@ class StaggerFabricator extends Analyzer {
       const amount = this._staggerPool * this.purifyPercentage;
       this._staggerPool -= amount;
       debug && console.log("triggering stagger pool update due to purify");
-      this.owner.triggerEvent(this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount));
+      this.owner.fabricateEvent(this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount), event);
     } else if (this._hasQuickSipTrait && event.ability.guid === SPELLS.IRONSKIN_BREW.id) {
       const amount = this._staggerPool * ISB_QUICK_SIP_PURIFY;
       this._staggerPool -= amount;
       debug && console.log("triggering stagger pool update due to ISB + Quick Sip trait");
-      this.owner.triggerEvent(this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount));
+      this.owner.fabricateEvent(this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount), event);
     }
   }
 
@@ -97,13 +97,13 @@ class StaggerFabricator extends Analyzer {
     const amount = this._staggerPool * T20_4PC_PURIFY;
     this._staggerPool -= amount;
     debug && console.log("triggering stagger pool update due to T20 4pc");
-    this.owner.triggerEvent(this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount));
+    this.owner.fabricateEvent(this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount), event);
   }
-  
+
   on_toPlayer_death(event) {
     const amount = this._staggerPool;
     this._staggerPool = 0;
-    this.owner.triggerEvent(this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount));
+    this.owner.fabricateEvent(this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount), event);
   }
 
   _fab(type, reason, amount) {
@@ -112,7 +112,6 @@ class StaggerFabricator extends Analyzer {
       type: type,
       amount: amount,
       newPooledDamage: this._staggerPool,
-      reason: reason,
     };
   }
 }

--- a/src/Parser/Monk/Brewmaster/Modules/Core/StaggerFabricator.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/StaggerFabricator.js
@@ -61,7 +61,7 @@ class StaggerFabricator extends Analyzer {
     const amount = event.amount + (event.absorbed || 0);
     this._staggerPool += amount;
     debug && console.log("triggering stagger pool update due to absorb");
-    this.owner.triggerEvent(EVENT_STAGGER_POOL_ADDED, this._fab(EVENT_STAGGER_POOL_ADDED, event, amount));
+    this.owner.triggerEvent(this._fab(EVENT_STAGGER_POOL_ADDED, event, amount));
   }
 
   on_toPlayer_damage(event) {
@@ -72,7 +72,7 @@ class StaggerFabricator extends Analyzer {
       // this ensures we don't go into negative stagger
       this._staggerPool = Math.max(this._staggerPool, 0); 
       debug && console.log("triggering stagger pool update due to stagger tick");
-      this.owner.triggerEvent(EVENT_STAGGER_POOL_REMOVED, this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount));
+      this.owner.triggerEvent(this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount));
     }
   }
 
@@ -81,12 +81,12 @@ class StaggerFabricator extends Analyzer {
       const amount = this._staggerPool * this.purifyPercentage;
       this._staggerPool -= amount;
       debug && console.log("triggering stagger pool update due to purify");
-      this.owner.triggerEvent(EVENT_STAGGER_POOL_REMOVED, this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount));
+      this.owner.triggerEvent(this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount));
     } else if (this._hasQuickSipTrait && event.ability.guid === SPELLS.IRONSKIN_BREW.id) {
       const amount = this._staggerPool * ISB_QUICK_SIP_PURIFY;
       this._staggerPool -= amount;
       debug && console.log("triggering stagger pool update due to ISB + Quick Sip trait");
-      this.owner.triggerEvent(EVENT_STAGGER_POOL_REMOVED, this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount));
+      this.owner.triggerEvent(this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount));
     }
   }
 
@@ -97,13 +97,13 @@ class StaggerFabricator extends Analyzer {
     const amount = this._staggerPool * T20_4PC_PURIFY;
     this._staggerPool -= amount;
     debug && console.log("triggering stagger pool update due to T20 4pc");
-    this.owner.triggerEvent(EVENT_STAGGER_POOL_REMOVED, this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount));
+    this.owner.triggerEvent(this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount));
   }
   
   on_toPlayer_death(event) {
     const amount = this._staggerPool;
     this._staggerPool = 0;
-    this.owner.triggerEvent(EVENT_STAGGER_POOL_REMOVED, this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount));
+    this.owner.triggerEvent(this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount));
   }
 
   _fab(type, reason, amount) {

--- a/src/Parser/Monk/Brewmaster/Modules/Features/StaggerPoolGraph.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/StaggerPoolGraph.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Line as LineChart } from 'react-chartjs-2';
-import Analyzer from 'Parser/Core/Analyzer';
-import Tab from 'Main/Tab';
+import 'common/chartjs-plugin-vertical';
 
-import { formatNumber, formatDuration } from 'common/format';
+import { formatDuration, formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
-import 'common/chartjs-plugin-vertical';
+import Analyzer from 'Parser/Core/Analyzer';
+import Tab from 'Main/Tab';
 
 import StaggerFabricator from '../Core/StaggerFabricator';
 
@@ -24,7 +24,7 @@ class StaggerPoolGraph extends Analyzer {
   static dependencies = {
     fab: StaggerFabricator,
   };
-  
+
   _hpEvents = [];
   _staggerEvents = [];
   _deathEvents = [];
@@ -37,7 +37,7 @@ class StaggerPoolGraph extends Analyzer {
   on_removestagger(event) {
     this._staggerEvents.push(event);
 
-    if(event.reason.ability && event.reason.ability.guid === SPELLS.PURIFYING_BREW.id) {
+    if (event.trigger.ability && event.trigger.ability.guid === SPELLS.PURIFYING_BREW.id) {
       this._purifyTimestamps.push(event.timestamp);
     }
   }
@@ -56,7 +56,7 @@ class StaggerPoolGraph extends Analyzer {
 
   plot() {
     // x indices
-    const labels = Array.from({length: Math.ceil(this.owner.fightDuration / 1000)}, (x, i) => i);
+    const labels = Array.from({ length: Math.ceil(this.owner.fightDuration / 1000) }, (x, i) => i);
 
     // somethingBySeconds are all objects mapping from seconds ->
     // something, where if a value is unknown for that timestamp it is
@@ -69,7 +69,7 @@ class StaggerPoolGraph extends Analyzer {
 
     const purifies = this._purifyTimestamps.map(timestamp => Math.floor((timestamp - this.owner.fight.start_time) / 1000) - 1);
     const deaths = this._deathEvents.map(({ timestamp, killingAbility }) => {
-      return { 
+      return {
         seconds: Math.floor((timestamp - this.owner.fight.start_time) / 1000),
         ability: killingAbility,
       };
@@ -85,7 +85,7 @@ class StaggerPoolGraph extends Analyzer {
     this._hpEvents.forEach(({ timestamp, hitPoints, maxHitPoints }) => {
       const seconds = Math.floor((timestamp - this.owner.fight.start_time) / 1000);
       // we fill in the blanks later if hitPoints is not defined
-      if(!!hitPoints) {
+      if (!!hitPoints) {
         hpBySeconds[seconds] = { hitPoints, maxHitPoints };
       }
     });
@@ -101,27 +101,27 @@ class StaggerPoolGraph extends Analyzer {
     // also not taking damage
     let lastPoolContents = 0;
     let lastHpContents = { hitPoints: 0, maxHitPoints: 0 };
-    for(const label in labels) {
-      if(poolBySeconds[label] === undefined) {
+    for (const label in labels) {
+      if (poolBySeconds[label] === undefined) {
         poolBySeconds[label] = lastPoolContents;
       } else {
         lastPoolContents = poolBySeconds[label];
       }
 
-      if(hpBySeconds[label] === undefined) {
+      if (hpBySeconds[label] === undefined) {
         hpBySeconds[label] = lastHpContents;
       } else {
         lastHpContents = hpBySeconds[label];
       }
 
-      if(!!deaths.find(event => event.seconds === Number(label))) {
+      if (!!deaths.find(event => event.seconds === Number(label))) {
         lastPoolContents = 0;
         lastHpContents = { hitPoints: 0, maxHitPoints: lastHpContents.maxHitPoints };
       }
     }
 
     const purifiesBySeconds = Object.keys(poolBySeconds).map(sec => {
-      if(purifies.includes(Number(sec))) {
+      if (purifies.includes(Number(sec))) {
         return poolBySeconds[sec];
       } else {
         return undefined;
@@ -130,7 +130,7 @@ class StaggerPoolGraph extends Analyzer {
 
     const deathsBySeconds = Object.keys(hpBySeconds).map(sec => {
       const deathEvent = deaths.find(event => event.seconds === Number(sec));
-      if(!!deathEvent) {
+      if (!!deathEvent) {
         return { hp: hpBySeconds[sec].maxHitPoints, ...deathEvent };
       } else {
         return undefined;
@@ -144,7 +144,7 @@ class StaggerPoolGraph extends Analyzer {
     const STAGGER_LABEL = 'Stagger Pool Size';
     const chartData = {
       labels,
-      datasets: [ 
+      datasets: [
         {
           label: DEATH_LABEL,
           borderColor: '#ff2222',
@@ -189,7 +189,7 @@ class StaggerPoolGraph extends Analyzer {
     };
 
     function safeAbilityName(ability) {
-      if(ability === undefined || ability.name === undefined) {
+      if (ability === undefined || ability.name === undefined) {
         return 'an Unknown Ability';
       } else {
         return ability.name;
@@ -200,7 +200,7 @@ class StaggerPoolGraph extends Analyzer {
     function labelItem(tooltipItem, data) {
       const { index } = tooltipItem;
       const dataset = data.datasets[tooltipItem.datasetIndex];
-      switch(dataset.label) {
+      switch (dataset.label) {
         case DEATH_LABEL:
           return `Player died when hit by ${safeAbilityName(deathsBySeconds[index].ability)} at ${formatNumber(deathsBySeconds[index].hp)} HP.`;
         case PURIFY_LABEL:
@@ -246,7 +246,7 @@ class StaggerPoolGraph extends Analyzer {
                 labelString: 'Time',
                 ticks: {
                   fontColor: '#ccc',
-                  callback: function(x) {
+                  callback: function (x) {
                     const label = formatDuration(x, 1); // formatDuration got changed -- need precision=1 or it blows up, but that adds a .0 to it
                     return label.substring(0, label.length - 2);
                   },
@@ -273,7 +273,7 @@ class StaggerPoolGraph extends Analyzer {
       render: () => (
         <Tab title="Stagger Pool">
           {this.plot()}
-          <div style={{paddingLeft: "1em"}}>
+          <div style={{ paddingLeft: "1em" }}>
             Damage you take is placed into a <em>pool</em> by <SpellLink id={SPELLS.STAGGER.id} icon />. This damage is then removed by the damage-over-time component of <SpellLink id={SPELLS.STAGGER.id} icon /> or by <SpellLink id={SPELLS.PURIFYING_BREW.id} icon /> (or other sources of purification). This plot shows the amount of damage pooled over the course of the fight.
           </div>
         </Tab>

--- a/src/Parser/Monk/Brewmaster/Modules/Items/T20_4pc.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Items/T20_4pc.js
@@ -3,9 +3,10 @@ import React from 'react';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import SpellIcon from 'common/SpellIcon';
-import { formatThousands, formatNumber } from 'common/format';
+import { formatNumber, formatThousands } from 'common/format';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+
 import { GIFT_OF_THE_OX_SPELLS } from '../../Constants';
 
 const debug = false;
@@ -13,7 +14,7 @@ const debug = false;
 class T20_4pc extends Analyzer {
   static dependencies = {
     combatants: Combatants,
-  }
+  };
 
   staggerSaved = 0;
   orbsEaten = 0;
@@ -24,7 +25,7 @@ class T20_4pc extends Analyzer {
   }
 
   on_removestagger(event) {
-    if(!event.reason.ability || !GIFT_OF_THE_OX_SPELLS.includes(event.reason.ability.guid)) {
+    if (!event.trigger.ability || !GIFT_OF_THE_OX_SPELLS.includes(event.trigger.ability.guid)) {
       return;
     }
     this.orbsEaten += 1;

--- a/src/Parser/Monk/Brewmaster/Modules/Items/T20_4pc.test.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Items/T20_4pc.test.js
@@ -1,8 +1,9 @@
 import SPELLS from 'common/SPELLS';
-import StaggerFabricator from 'Parser/Monk/Brewmaster/Modules/Core/StaggerFabricator';
-import T20_4pc from 'Parser/Monk/Brewmaster/Modules/Items/T20_4pc';
-import processEvents from './Fixtures/processEvents';
-import { SimpleFight } from './Fixtures/SimpleFight';
+import processEvents from 'tests/Parser/Brewmaster/Fixtures/processEvents';
+import { SimpleFight } from 'tests/Parser/Brewmaster/Fixtures/SimpleFight';
+
+import StaggerFabricator from '../Core/StaggerFabricator';
+import T20_4pc from './T20_4pc';
 
 describe('Brewmaster.T20_4pc', () => {
   let item;
@@ -17,8 +18,8 @@ describe('Brewmaster.T20_4pc', () => {
     fab.combatants = {
       selected: {
         hasTalent: () => false,
-        traitsBySpellId: {[SPELLS.STAGGERING_AROUND.id]: 0},
-      }
+        traitsBySpellId: { [SPELLS.STAGGERING_AROUND.id]: 0 },
+      },
     };
     item = new T20_4pc({
       toPlayer: () => true,
@@ -27,7 +28,7 @@ describe('Brewmaster.T20_4pc', () => {
       byPlayerPet: () => false,
     });
     item.fab = fab;
-    fab.owner.triggerEvent = (event, obj) => item.triggerEvent(event, obj);
+    fab.owner.fabricateEvent = (event, obj) => item.triggerEvent({ ...event, trigger: obj });
     fab._hasTier20_4pc = true;
   });
   it('how many gift of the ox orbs were absorbed as a heal', () => {
@@ -39,4 +40,3 @@ describe('Brewmaster.T20_4pc', () => {
     expect(item.staggerSaved).toBe(23.450000000000003);
   });
 });
-

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/PurifyingBrew.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/PurifyingBrew.js
@@ -1,10 +1,12 @@
 import React from 'react';
+
 import { formatNumber, formatPercentage } from 'common/format';
 import SpellIcon from 'common/SpellIcon';
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SPELLS from 'common/SPELLS';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import Analyzer from 'Parser/Core/Analyzer';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+
 import SharedBrews from '../Core/SharedBrews';
 
 class PurifyingBrew extends Analyzer {
@@ -20,13 +22,13 @@ class PurifyingBrew extends Analyzer {
   _heavyStaggerDropped = false;
 
   on_byPlayer_removedebuff(event) {
-    if(event.ability.guid === SPELLS.HEAVY_STAGGER_DEBUFF.id) {
+    if (event.ability.guid === SPELLS.HEAVY_STAGGER_DEBUFF.id) {
       this._heavyStaggerDropped = true;
     }
   }
 
   get meanPurify() {
-    if(this.purifyAmounts.length === 0) {
+    if (this.purifyAmounts.length === 0) {
       return 0;
     }
 
@@ -34,7 +36,7 @@ class PurifyingBrew extends Analyzer {
   }
 
   get minPurify() {
-    if(this.purifyAmounts.length === 0) {
+    if (this.purifyAmounts.length === 0) {
       return 0;
     }
 
@@ -58,13 +60,13 @@ class PurifyingBrew extends Analyzer {
   }
 
   on_removestagger(event) {
-    if(!event.reason.ability || event.reason.ability.guid !== SPELLS.PURIFYING_BREW.id) {
+    if (!event.trigger.ability || event.trigger.ability.guid !== SPELLS.PURIFYING_BREW.id) {
       // reset this, death or another ability took us out of heavy stagger
-      this._heavyStaggerDropped = false; 
+      this._heavyStaggerDropped = false;
       return;
     }
     this.purifyAmounts.push(event.amount);
-    if(this.combatants.selected.hasBuff(SPELLS.HEAVY_STAGGER_DEBUFF.id) || this._heavyStaggerDropped) {
+    if (this.combatants.selected.hasBuff(SPELLS.HEAVY_STAGGER_DEBUFF.id) || this._heavyStaggerDropped) {
       this.heavyPurifies += 1;
     }
     this._heavyStaggerDropped = false;
@@ -79,7 +81,7 @@ class PurifyingBrew extends Analyzer {
         tooltip={`Purifying Brew removed <b>${formatNumber(this.totalPurified)}</b> damage in total over ${this.totalPurifies} casts.<br/>
                   The smallest purify removed <b>${formatNumber(this.minPurify)}</b> and the largest purify removed <b>${formatNumber(this.maxPurify)}</b>.<br/>
                   You purified <b>${this.badPurifies}</b> (${formatPercentage(this.badPurifies / this.totalPurifies)}%) times without reaching Heavy Stagger.`}
-          />
+      />
     );
   }
   statisticOrder = STATISTIC_ORDER.OPTIONAL();

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/RushingJadeWind.test.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/RushingJadeWind.test.js
@@ -23,13 +23,17 @@ describe("Rushing Jade Wind", () => {
 
   it("should be inactive for a user without the talent", () => {
     rjw.combatants.selected = talentless_combatant;
-    rjw.triggerEvent("initialized");
+    rjw.triggerEvent({
+      type: 'initialized',
+    });
     expect(rjw.active).toBe(false);
   });
 
   it("should be active for a user with the talent", () => {
     rjw.combatants.selected = talented_combatant;
-    rjw.triggerEvent("initialized");
+    rjw.triggerEvent({
+      type: 'initialized',
+    });
     expect(rjw.active).toBe(true);
   });
 });

--- a/src/Parser/Paladin/Holy/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Paladin/Holy/Modules/Features/AlwaysBeCasting.js
@@ -37,7 +37,7 @@ class AlwaysBeCasting extends CoreAlwaysBeCastingHealing {
 
   countsAsHealingAbility(event) {
     const spellId = event.ability.guid;
-    if (spellId === SPELLS.HOLY_SHOCK_CAST.id && !event.reason.targetIsFriendly) {
+    if (spellId === SPELLS.HOLY_SHOCK_CAST.id && !event.trigger.targetIsFriendly) {
       debug && console.log(`%cABC: ${event.ability.name} (${spellId}) skipped for healing time; target is not friendly`, 'color: orange');
       return false;
     }

--- a/src/Parser/Paladin/Holy/Modules/PaladinCore/BeaconHealOriginMatcher.js
+++ b/src/Parser/Paladin/Holy/Modules/PaladinCore/BeaconHealOriginMatcher.js
@@ -60,7 +60,7 @@ class BeaconHealOriginMatcher extends Analyzer {
       return;
     }
     // console.log('Matched beacon transfer', beaconTransferEvent, 'to heal', matchedHeal);
-    this.owner.triggerEvent('beacon_heal', beaconTransferEvent, matchedHeal);
+    this.owner.fabricateEvent('beacon_heal', beaconTransferEvent, beaconTransferEvent, matchedHeal);
 
     matchedHeal.remainingBeaconTransfers -= 1;
     if (matchedHeal.remainingBeaconTransfers < 1) {

--- a/src/Parser/Paladin/Holy/Modules/PaladinCore/BeaconHealOriginMatcher.js
+++ b/src/Parser/Paladin/Holy/Modules/PaladinCore/BeaconHealOriginMatcher.js
@@ -60,7 +60,10 @@ class BeaconHealOriginMatcher extends Analyzer {
       return;
     }
     // console.log('Matched beacon transfer', beaconTransferEvent, 'to heal', matchedHeal);
-    this.owner.fabricateEvent('beacon_heal', beaconTransferEvent, beaconTransferEvent, matchedHeal);
+    this.owner.fabricateEvent({
+      ...beaconTransferEvent,
+      type: 'beacon_heal',
+    }, beaconTransferEvent, matchedHeal);
 
     matchedHeal.remainingBeaconTransfers -= 1;
     if (matchedHeal.remainingBeaconTransfers < 1) {

--- a/src/Parser/Paladin/Holy/Modules/PaladinCore/BeaconTargets.js
+++ b/src/Parser/Paladin/Holy/Modules/PaladinCore/BeaconTargets.js
@@ -30,7 +30,7 @@ class BeaconTargets extends Analyzer {
     if (!this.currentBeaconTargets.includes(targetId)) {
       this.currentBeaconTargets.push(targetId);
       debug && console.log(`%c${this.combatants.players[targetId].name} gained a beacon`, 'color:green', this.currentBeaconTargets);
-      this.owner.triggerEvent('beacon_changed', event);
+      this.owner.fabricateEvent('beacon_changed', null, event);
     } else {
       debug && console.error(`Trying to assign a beacon to ${this.combatants.players[event.sourceID].name}, but he already has one.`, this.currentBeaconTargets);
     }
@@ -43,7 +43,7 @@ class BeaconTargets extends Analyzer {
     const targetId = event.targetID;
     this.currentBeaconTargets = this.currentBeaconTargets.filter(id => id !== targetId);
     debug && console.log(`%c${this.combatants.players[targetId].name} lost a beacon`, 'color:red', this.currentBeaconTargets);
-    this.owner.triggerEvent('beacon_changed', event);
+    this.owner.fabricateEvent('beacon_changed', null, event);
   }
 }
 

--- a/src/Parser/Paladin/Holy/Modules/PaladinCore/BeaconTargets.js
+++ b/src/Parser/Paladin/Holy/Modules/PaladinCore/BeaconTargets.js
@@ -30,7 +30,12 @@ class BeaconTargets extends Analyzer {
     if (!this.currentBeaconTargets.includes(targetId)) {
       this.currentBeaconTargets.push(targetId);
       debug && console.log(`%c${this.combatants.players[targetId].name} gained a beacon`, 'color:green', this.currentBeaconTargets);
-      this.owner.fabricateEvent('beacon_changed', null, event);
+      this.owner.fabricateEvent({
+        type: 'beacon_applied',
+        timestamp: event.timestamp,
+        sourceID: event.sourceID,
+        targetID: event.targetID,
+      }, event);
     } else {
       debug && console.error(`Trying to assign a beacon to ${this.combatants.players[event.sourceID].name}, but he already has one.`, this.currentBeaconTargets);
     }
@@ -43,7 +48,12 @@ class BeaconTargets extends Analyzer {
     const targetId = event.targetID;
     this.currentBeaconTargets = this.currentBeaconTargets.filter(id => id !== targetId);
     debug && console.log(`%c${this.combatants.players[targetId].name} lost a beacon`, 'color:red', this.currentBeaconTargets);
-    this.owner.fabricateEvent('beacon_changed', null, event);
+    this.owner.fabricateEvent({
+      type: 'beacon_removed',
+      timestamp: event.timestamp,
+      sourceID: event.sourceID,
+      targetID: event.targetID,
+    }, event);
   }
 }
 

--- a/src/Parser/Paladin/Holy/Modules/Traits/ShockTreatment.test.js
+++ b/src/Parser/Paladin/Holy/Modules/Traits/ShockTreatment.test.js
@@ -26,7 +26,9 @@ describe('Paladin/Holy/Modules/Traits/ShockTreatment', () => {
       combatants: combatantsMock,
       critEffectBonus: critEffectBonusMock,
     });
-    instance.triggerEvent('initialized');
+    instance.triggerEvent({
+      type: 'initialized',
+    });
   });
 
   it('adds a hook that increases the crit effect bonus of Holy Shock', () => {

--- a/src/Parser/Priest/Discipline/Modules/Spells/Atonement.js
+++ b/src/Parser/Priest/Discipline/Modules/Spells/Atonement.js
@@ -67,7 +67,12 @@ class Atonement extends Analyzer {
     this.currentAtonementTargets.push(atonement);
     this.totalAtones += 1;
     debug && console.log(`%c${this.combatants.players[atonement.target].name} gained an atonement`, 'color:green', this.currentAtonementTargets);
-    this.owner.fabricateEvent('atonement_applied', null, event);
+    this.owner.fabricateEvent({
+      type: 'atonement_applied',
+      timestamp: event.timestamp,
+      sourceID: event.sourceID,
+      targetID: event.targetID,
+    }, event);
   }
   on_byPlayer_refreshbuff(event) {
     const spellId = event.ability.guid;
@@ -88,7 +93,12 @@ class Atonement extends Analyzer {
     if (timeSinceApplication < ((this.atonementDuration * 1000) - IMPROPER_REFRESH_TIME)) {
       this.improperAtonementRefreshes.push(refreshedTarget);
       debug && console.log(`%c${this.combatants.players[event.targetID].name} refreshed an atonement too early %c${timeSinceApplication}`, 'color:red', this.currentAtonementTargets);
-      this.owner.fabricateEvent('atonement_refresh_improper', null, event);
+      this.owner.fabricateEvent({
+        type: 'atonement_refresh_improper',
+        timestamp: event.timestamp,
+        sourceID: event.sourceID,
+        targetID: event.targetID,
+      }, event);
     }
 
     const atonement = {
@@ -103,7 +113,12 @@ class Atonement extends Analyzer {
     this.totalAtones += 1;
     this.totalAtonementRefreshes += 1;
     debug && console.log(`%c${this.combatants.players[atonement.target].name} refreshed an atonement`, 'color:orange', this.currentAtonementTargets);
-    this.owner.fabricateEvent('atonement_refresh', null, event);
+    this.owner.fabricateEvent({
+      type: 'atonement_refresh',
+      timestamp: event.timestamp,
+      sourceID: event.sourceID,
+      targetID: event.targetID,
+    }, event);
   }
   on_byPlayer_removebuff(event) {
     const spellId = event.ability.guid;
@@ -116,7 +131,12 @@ class Atonement extends Analyzer {
     };
     this.currentAtonementTargets = this.currentAtonementTargets.filter(id => id.target !== atonement.target);
     debug && console.log(`%c${this.combatants.players[atonement.target].name} lost an atonement`, 'color:red', this.currentAtonementTargets);
-    this.owner.fabricateEvent('atonement_faded', null, event);
+    this.owner.fabricateEvent({
+      type: 'atonement_faded',
+      timestamp: event.timestamp,
+      sourceID: event.sourceID,
+      targetID: event.targetID,
+    }, event);
   }
 
   on_byPlayer_heal(event) {

--- a/src/Parser/Priest/Discipline/Modules/Spells/Atonement.js
+++ b/src/Parser/Priest/Discipline/Modules/Spells/Atonement.js
@@ -67,7 +67,7 @@ class Atonement extends Analyzer {
     this.currentAtonementTargets.push(atonement);
     this.totalAtones += 1;
     debug && console.log(`%c${this.combatants.players[atonement.target].name} gained an atonement`, 'color:green', this.currentAtonementTargets);
-    this.owner.triggerEvent('atonement_applied', event);
+    this.owner.fabricateEvent('atonement_applied', null, event);
   }
   on_byPlayer_refreshbuff(event) {
     const spellId = event.ability.guid;
@@ -88,7 +88,7 @@ class Atonement extends Analyzer {
     if (timeSinceApplication < ((this.atonementDuration * 1000) - IMPROPER_REFRESH_TIME)) {
       this.improperAtonementRefreshes.push(refreshedTarget);
       debug && console.log(`%c${this.combatants.players[event.targetID].name} refreshed an atonement too early %c${timeSinceApplication}`, 'color:red', this.currentAtonementTargets);
-      this.owner.triggerEvent('atonement_refresh_improper', event);
+      this.owner.fabricateEvent('atonement_refresh_improper', null, event);
     }
 
     const atonement = {
@@ -103,7 +103,7 @@ class Atonement extends Analyzer {
     this.totalAtones += 1;
     this.totalAtonementRefreshes += 1;
     debug && console.log(`%c${this.combatants.players[atonement.target].name} refreshed an atonement`, 'color:orange', this.currentAtonementTargets);
-    this.owner.triggerEvent('atonement_refresh', event);
+    this.owner.fabricateEvent('atonement_refresh', null, event);
   }
   on_byPlayer_removebuff(event) {
     const spellId = event.ability.guid;
@@ -116,7 +116,7 @@ class Atonement extends Analyzer {
     };
     this.currentAtonementTargets = this.currentAtonementTargets.filter(id => id.target !== atonement.target);
     debug && console.log(`%c${this.combatants.players[atonement.target].name} lost an atonement`, 'color:red', this.currentAtonementTargets);
-    this.owner.triggerEvent('atonement_faded', event);
+    this.owner.fabricateEvent('atonement_faded', null, event);
   }
 
   on_byPlayer_heal(event) {

--- a/src/Parser/Shaman/Restoration/Modules/Spells/Resurgence.js
+++ b/src/Parser/Shaman/Restoration/Modules/Spells/Resurgence.js
@@ -18,7 +18,7 @@ class Resurgence extends Analyzer {
   static dependencies = {
     combatants: Combatants,
     masteryEffectiveness: MasteryEffectiveness,
-  }
+  };
 
   maxMana = 1100000;
   regenedMana = 0;
@@ -35,7 +35,7 @@ class Resurgence extends Analyzer {
     this.hasbottomlessDepths = this.combatants.selected.hasTalent(SPELLS.BOTTOMLESS_DEPTHS_TALENT.id);
 
     // The arcway neck does increase resurgence gained as well
-    if(hasEnergyPendant){
+    if (hasEnergyPendant) {
       this.maxMana *= 1.05;
     }
 
@@ -53,7 +53,7 @@ class Resurgence extends Analyzer {
     const isAbilityProccingResurgence = this.SPELLS_PROCCING_RESURGENCE.hasOwnProperty(spellId);
     const masteryEffectiveness = event.masteryEffectiveness;
 
-    if(!isAbilityProccingResurgence || event.tick){
+    if (!isAbilityProccingResurgence || event.tick) {
       return;
     }
 
@@ -66,21 +66,21 @@ class Resurgence extends Analyzer {
     }
 
     if (event.hitType === HIT_TYPES.CRIT) {
+      this.resurgence[spellId].resurgenceTotal += this.SPELLS_PROCCING_RESURGENCE[spellId] * this.maxMana;
+      this.resurgence[spellId].castAmount += 1;
+    } else if (event.hitType === HIT_TYPES.NORMAL && masteryEffectiveness >= 0.4) {
+      if (this.hasbottomlessDepths) {
         this.resurgence[spellId].resurgenceTotal += this.SPELLS_PROCCING_RESURGENCE[spellId] * this.maxMana;
         this.resurgence[spellId].castAmount += 1;
-    } else if (event.hitType === HIT_TYPES.NORMAL && masteryEffectiveness >= 0.4) {
-      if(this.hasbottomlessDepths) {
-        this.resurgence[spellId].resurgenceTotal += this.SPELLS_PROCCING_RESURGENCE[spellId] * this.maxMana;
-        this.resurgence[spellId].castAmount += 1; 
       }
-      this.bottomlessDepths += this.SPELLS_PROCCING_RESURGENCE[spellId] * this.maxMana; 
+      this.bottomlessDepths += this.SPELLS_PROCCING_RESURGENCE[spellId] * this.maxMana;
     }
   }
 
   on_toPlayer_energize(event) {
     const spellId = event.ability.guid;
 
-    if (spellId !== SPELLS.RESURGENCE.id) {     
+    if (spellId !== SPELLS.RESURGENCE.id) {
       return this.extraMana += event.resourceChange;
     }
 
@@ -88,17 +88,17 @@ class Resurgence extends Analyzer {
   }
 
   get totalMana() {
-    this.regenedMana = ((this.owner.fightDuration/1000)/5) * 44000;
+    this.regenedMana = ((this.owner.fightDuration / 1000) / 5) * 44000;
 
     return this.regenedMana + this.totalResurgenceGain + this.maxMana + this.extraMana;
   }
 
   statistic() {
     let expandText = ` `;
-    if(this.hasbottomlessDepths) {
+    if (this.hasbottomlessDepths) {
       expandText += `added ${formatPercentage(this.bottomlessDepths / this.totalMana, 0)}% (${formatNumber(this.bottomlessDepths)}) mana on top of that.`;
     } else {
-      expandText += `would have added ${formatPercentage(this.bottomlessDepths / (this.totalMana+this.bottomlessDepths), 0)}% (${formatNumber(this.bottomlessDepths)}) mana.`;
+      expandText += `would have added ${formatPercentage(this.bottomlessDepths / (this.totalMana + this.bottomlessDepths), 0)}% (${formatNumber(this.bottomlessDepths)}) mana.`;
     }
 
     return (
@@ -123,7 +123,7 @@ class Resurgence extends Analyzer {
           <tbody>
             {
               this.resurgence
-                .map((spell) => (
+                .map(spell => (
                   <tr key={spell.spellId}>
                     <th scope="row"><SpellIcon id={spell.spellId} style={{ height: '2.5em' }} /></th>
                     <td>{formatNumber(spell.resurgenceTotal)}</td>
@@ -132,14 +132,11 @@ class Resurgence extends Analyzer {
                   </tr>
                 ))
             }
-
           </tbody>
         </table>
       </ExpandableStatisticBox>
     );
   }
 }
-
-
 
 export default Resurgence;

--- a/src/Parser/Warlock/Destruction/Modules/SoulShards/SoulShardEvents.js
+++ b/src/Parser/Warlock/Destruction/Modules/SoulShards/SoulShardEvents.js
@@ -141,7 +141,7 @@ class SoulShardEvents extends Analyzer {
     shardEvent.currentFragments = this._currentFragments;
 
     debug && console.log(`++ ${shardEvent.amount}(w: ${shardEvent.waste}) = ${shardEvent.currentFragments}, ${shardEvent.ability.name}, orig: `, event);
-    this.owner.triggerEvent('soulshardfragment_gained', shardEvent);
+    this.owner.triggerEvent(shardEvent);
   }
   processSpenders(event) {
     const spellId = event.ability.guid;
@@ -174,7 +174,7 @@ class SoulShardEvents extends Analyzer {
       balanceEvent.currentFragments = this._currentFragments;
 
       debug && console.log(`++ ${balanceEvent.amount}(w: ${balanceEvent.waste}) = ${balanceEvent.currentFragments}, ${balanceEvent.ability.name}`);
-      this.owner.triggerEvent('soulshardfragment_gained', balanceEvent);
+      this.owner.triggerEvent(balanceEvent);
     }
     this._currentFragments -= amount;
 
@@ -182,7 +182,7 @@ class SoulShardEvents extends Analyzer {
     shardEvent.currentFragments = this._currentFragments;
 
     debug && console.log(`-- ${shardEvent.amount} = ${shardEvent.currentFragments}, ${shardEvent.ability.name}, orig:`, event);
-    this.owner.triggerEvent('soulshardfragment_spent', shardEvent);
+    this.owner.triggerEvent(shardEvent);
   }
 }
 

--- a/src/Parser/Warlock/Destruction/Modules/SoulShards/SoulShardEvents.js
+++ b/src/Parser/Warlock/Destruction/Modules/SoulShards/SoulShardEvents.js
@@ -141,7 +141,7 @@ class SoulShardEvents extends Analyzer {
     shardEvent.currentFragments = this._currentFragments;
 
     debug && console.log(`++ ${shardEvent.amount}(w: ${shardEvent.waste}) = ${shardEvent.currentFragments}, ${shardEvent.ability.name}, orig: `, event);
-    this.owner.triggerEvent(shardEvent);
+    this.owner.fabricateEvent(shardEvent, event);
   }
   processSpenders(event) {
     const spellId = event.ability.guid;
@@ -174,7 +174,7 @@ class SoulShardEvents extends Analyzer {
       balanceEvent.currentFragments = this._currentFragments;
 
       debug && console.log(`++ ${balanceEvent.amount}(w: ${balanceEvent.waste}) = ${balanceEvent.currentFragments}, ${balanceEvent.ability.name}`);
-      this.owner.triggerEvent(balanceEvent);
+      this.owner.fabricateEvent(balanceEvent, event);
     }
     this._currentFragments -= amount;
 
@@ -182,7 +182,7 @@ class SoulShardEvents extends Analyzer {
     shardEvent.currentFragments = this._currentFragments;
 
     debug && console.log(`-- ${shardEvent.amount} = ${shardEvent.currentFragments}, ${shardEvent.ability.name}, orig:`, event);
-    this.owner.triggerEvent(shardEvent);
+    this.owner.fabricateEvent(shardEvent, event);
   }
 }
 

--- a/src/Parser/Warlock/Destruction/Modules/Talents/Shadowburn.js
+++ b/src/Parser/Warlock/Destruction/Modules/Talents/Shadowburn.js
@@ -63,7 +63,7 @@ class Shadowburn extends Analyzer {
         // Shadowburn debuff expired sooner than it should = target died = generate another 5 fragments
         debug && console.log('Shadowburn kill');
         event.isFromShadowburnKill = true;
-        this.owner.triggerEvent('shadowburn_kill', event);
+        this.owner.triggerEvent(event);
       }
       this._expectedShadowburnDebuffEnds.splice(debuffTargetIndex, 1); // remove the debuff from array
       debug && console.log('Shadowburn removedebuff (end), debuffEnds:', JSON.stringify(this._expectedShadowburnDebuffEnds));

--- a/src/Parser/Warlock/Destruction/Modules/Talents/Shadowburn.js
+++ b/src/Parser/Warlock/Destruction/Modules/Talents/Shadowburn.js
@@ -63,7 +63,10 @@ class Shadowburn extends Analyzer {
         // Shadowburn debuff expired sooner than it should = target died = generate another 5 fragments
         debug && console.log('Shadowburn kill');
         event.isFromShadowburnKill = true;
-        this.owner.triggerEvent(event);
+        this.owner.fabricateEvent({
+          ...event,
+          type: 'shadowburn_kill',
+        }, event);
       }
       this._expectedShadowburnDebuffEnds.splice(debuffTargetIndex, 1); // remove the debuff from array
       debug && console.log('Shadowburn removedebuff (end), debuffEnds:', JSON.stringify(this._expectedShadowburnDebuffEnds));

--- a/src/tests/Parser/Brewmaster/BlackoutCombo.test.js
+++ b/src/tests/Parser/Brewmaster/BlackoutCombo.test.js
@@ -21,7 +21,9 @@ describe('Brewmaster.BlackoutCombo', () => {
     hasTalentMethod.mockReturnValue(false);
     const combatant = { selected: { hasTalent: hasTalentMethod } };
     blackoutCombo.combatants = combatant;
-    blackoutCombo.triggerEvent('initialized');
+    blackoutCombo.triggerEvent({
+      type: 'initialized',
+    });
     expect(hasTalentMethod).toBeCalledWith(SPELLS.BLACKOUT_COMBO_TALENT.id);
     expect(blackoutCombo.active).toBe(false);
   });
@@ -30,7 +32,9 @@ describe('Brewmaster.BlackoutCombo', () => {
     hasTalentMethod.mockReturnValue(true);
     const combatant = { selected: { hasTalent: hasTalentMethod } };
     blackoutCombo.combatants = combatant;
-    blackoutCombo.triggerEvent('initialized');
+    blackoutCombo.triggerEvent({
+      type: 'initialized',
+    });
     expect(hasTalentMethod).toBeCalledWith(SPELLS.BLACKOUT_COMBO_TALENT.id);
     expect(blackoutCombo.active).toBe(true);
   });

--- a/src/tests/Parser/Brewmaster/Fixtures/processEvents.js
+++ b/src/tests/Parser/Brewmaster/Fixtures/processEvents.js
@@ -1,7 +1,7 @@
 export default function processEvents(events, ...modules) {
-  events.forEach((event) => {
+  events.forEach(event => {
     modules.forEach(module => {
-      module.triggerEvent(event.type, event);
+      module.triggerEvent(event);
     });
   });
 }

--- a/src/tests/Parser/Brewmaster/Stagger.test.js
+++ b/src/tests/Parser/Brewmaster/Stagger.test.js
@@ -2,7 +2,7 @@ import SPELLS from 'common/SPELLS';
 import StaggerFabricator from 'Parser/Monk/Brewmaster/Modules/Core/StaggerFabricator';
 import Stagger from 'Parser/Monk/Brewmaster/Modules/Core/Stagger';
 import processEvents from './Fixtures/processEvents';
-import { SimpleFight, EarlyFinish, incomingDamage } from './Fixtures/SimpleFight';
+import { EarlyFinish, incomingDamage, SimpleFight } from './Fixtures/SimpleFight';
 
 describe('Brewmaster.Stagger', () => {
   let stagger;
@@ -17,8 +17,8 @@ describe('Brewmaster.Stagger', () => {
     fab.combatants = {
       selected: {
         hasTalent: () => false,
-        traitsBySpellId: {[SPELLS.STAGGERING_AROUND.id]: 0},
-      }
+        traitsBySpellId: { [SPELLS.STAGGERING_AROUND.id]: 0 },
+      },
     };
     stagger = new Stagger({
       toPlayer: () => true,
@@ -58,10 +58,16 @@ describe('Brewmaster.Stagger', () => {
   });
   it('Tracks the amount of stagger missing from the fight', () => {
     const earlyFightEnd = 6000;
-    const myOwner = { fight: { end_time: earlyFightEnd } };
+    const myOwner = {
+      fight: {
+        end_time: earlyFightEnd,
+      },
+    };
     processEvents(EarlyFinish, fab, stagger);
-    stagger.owner = myOwner;
-    stagger.triggerEvent('finished');
+    // this doesn't actually do anything for the test.... stagger.owner = myOwner;
+    stagger.triggerEvent({
+      type: 'finished',
+    });
     expect(stagger.staggerMissingFromFight).toBe(484);
   });
 });

--- a/src/tests/Parser/Guardian/Fixtures/processEvents.js
+++ b/src/tests/Parser/Guardian/Fixtures/processEvents.js
@@ -1,6 +1,6 @@
 // TODO: Need to move this to a central shared test location
 export default function processEvents(events, module) {
-  events.forEach((event) => {
-    module.triggerEvent(event.type, event);
+  events.forEach(event => {
+    module.triggerEvent(event);
   });
 }

--- a/src/tests/Parser/Priest/Discipline/Fixtures/processEvents.js
+++ b/src/tests/Parser/Priest/Discipline/Fixtures/processEvents.js
@@ -1,6 +1,6 @@
 // TODO: Need to move this to a central shared test location
 export default function processEvents(events, module) {
-  events.forEach((event) => {
-    module.triggerEvent(event.type, event);
+  events.forEach(event => {
+    module.triggerEvent(event);
   });
 }

--- a/src/tests/Parser/Priest/Discipline/Modules/Items/Tier21_2set.test.js
+++ b/src/tests/Parser/Priest/Discipline/Modules/Items/Tier21_2set.test.js
@@ -1,23 +1,9 @@
 import Tier21_2set from 'Parser/Priest/Discipline/Modules/Items/Tier21_2set';
-import SPELLS from 'common/SPELLS';
 
 import processEvents from '../../Fixtures/processEvents';
-
-import {
-  DamagingEvent1,
-  DamagingEvent2,
-  DamagingEvent3,
-  AtonementOnSelf1,
-  AtonementOnSelf2,
-  AtonementOnPlayer1,
-  AtonementOnPlayer2,
-  AtonementOnPlayer3,
-  RadianceCast1,
-  RadianceCast2
-} from '../../Fixtures/TestingEvents';
+import { RadianceCast1, RadianceCast2 } from '../../Fixtures/TestingEvents';
 
 describe('DisciplinePriest.Reordering', () => {
-
   let tier21_2set;
 
   beforeEach(() => {
@@ -27,52 +13,45 @@ describe('DisciplinePriest.Reordering', () => {
       byPlayer: () => true,
       toPlayerPet: () => false,
       byPlayerPet: () => false,
-      fight:  { end_time: 0 }
+      fight: { end_time: 0 },
     });
   });
 
   it('If 1 radiance is cast at t=0 and fight ends at t=15, gross time saved should be 3', () => {
-
     RadianceCast1.timestamp = 0;
     tier21_2set.owner.fight = { end_time: 15000 };
 
-    let events = [
-      RadianceCast1
+    const events = [
+      RadianceCast1,
     ];
 
     processEvents(events, tier21_2set);
     expect(tier21_2set.grossTimeSaved).toBe(3000);
-
   });
 
   it('If 1 radiance is cast at t=0 and fight ends at t=14, gross time saved should be 0', () => {
-
     RadianceCast1.timestamp = 0;
     tier21_2set.owner.fight = { end_time: 14000 };
 
-    let events = [
-      RadianceCast1
+    const events = [
+      RadianceCast1,
     ];
 
     processEvents(events, tier21_2set);
     expect(tier21_2set.grossTimeSaved).toBe(0);
-
   });
 
   it('If 1 radiance cast at t=0, 1 radiance cast a t=2 and fight ends at t=17, gross time saved should be 6', () => {
-
     RadianceCast1.timestamp = 0;
     RadianceCast2.timestamp = 2000;
     tier21_2set.owner.fight = { end_time: 17000 };
 
-    let events = [
+    const events = [
       RadianceCast1,
-      RadianceCast2
+      RadianceCast2,
     ];
 
     processEvents(events, tier21_2set);
     expect(tier21_2set.grossTimeSaved).toBe(6000);
-
   });
-
 });

--- a/src/tests/getParserMock.js
+++ b/src/tests/getParserMock.js
@@ -5,6 +5,7 @@ export default function getParserMock() {
     toPlayerPet: jest.fn(() => true),
     byPlayerPet: jest.fn(() => true),
     triggerEvent: jest.fn(),
+    fabricateEvent: jest.fn(),
     currentTimestamp: 0,
     fight: {
       start_time: 0,


### PR DESCRIPTION
Removes the eventName prop from `triggerEvent`, and adds the `fabricateEvent` method to replace using `triggerEvent` for fabricated events. This deprecates `triggerEvent` for that purpose.