### PR TITLE
[BrM] Converted Breath of Fire from uptime to # of hits mitigated

### DIFF
--- a/src/Parser/Monk/Brewmaster/CHANGELOG.js
+++ b/src/Parser/Monk/Brewmaster/CHANGELOG.js
@@ -9,6 +9,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-03-19'),
+    changes: <Wrapper>Converted <SpellLink id={SPELLS.BREATH_OF_FIRE.id} icon /> from uptime to hit tracking and updated hit tracking for <SpellLink id={SPELLS.IRONSKIN_BREW.id} icon />.</Wrapper>,
+    contributors: [emallson],
+  },
+  {
     date: new Date('2018-01-29'),
     changes: 'Added plot of damage in Stagger pool over time.',
     contributors: [emallson],

--- a/src/Parser/Monk/Brewmaster/Modules/Constants/AbilityBlacklist.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Constants/AbilityBlacklist.js
@@ -1,0 +1,28 @@
+/**
+ * This list is used to skip abilities for the purposes of *hit
+ * counting*. These abilities produce many hits but generally aren't
+ * worth mitigating, skewing the results of tracking.
+ */
+export default [
+  // ANTORUS
+  // Garothi Worldbreaker
+  247159, // Luring Destruction, intermission pulse
+  // Felhounds of Sargeras
+  // Antoran High Command
+  // Eonar (SKIP)
+  // Portal Keeper
+  // Imonar
+  248424, // Gathering Power (Imonar bridge phase)
+  // Kin'Garoth
+  246646, // Flames of the Forge (Kin'garoth intermission pulsing aoe)
+  246779, // Empowered bombs (Kin'garoth)
+  // Varimathras
+  // Coven of Shivarra
+  258018, // Sense of Dread, pulsing aoe from inactive shivarra
+  // Aggramar
+  244912, // Blazing Eruption, the pulse of Embers on Aggramar
+  254329, // Unleashed Flame, Embers on Aggramar
+  245632, // Unchecked Flame, Flames on Aggramar (there are two that can't be stack, can't bof both)
+  // Argus
+  256396, // Reorigination pulse, aoe hit from orbs. generally don't get bof on these
+];

--- a/src/Parser/Monk/Brewmaster/Modules/Features/Checklist.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/Checklist.js
@@ -23,7 +23,7 @@ class Checklist extends CoreChecklist {
     new Rule({
       name: (
         <Wrapper>
-          Maintain 100% uptime on <SpellLink id={SPELLS.IRONSKIN_BREW.id} icon />.
+          Mitigate damage with <SpellLink id={SPELLS.IRONSKIN_BREW.id} icon />.
         </Wrapper>
       ),
       description: (
@@ -43,7 +43,7 @@ class Checklist extends CoreChecklist {
     new Rule({
       name: (
         <Wrapper>
-          Maintain 100% uptime on <SpellLink id={SPELLS.BREATH_OF_FIRE.id} icon />.
+          Mitigate damage with <SpellLink id={SPELLS.BREATH_OF_FIRE.id} icon />.
         </Wrapper>
       ),
       description: (
@@ -54,7 +54,7 @@ class Checklist extends CoreChecklist {
       requirements: () => {
         return [
           new Requirement({
-            name: 'Breath of Fire uptime',
+            name: 'Hits mitigated by Breath of Fire',
             check: () => this.bof.suggestionThreshold,
           }),
         ];

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/BreathOfFire.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/BreathOfFire.js
@@ -9,7 +9,7 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import Enemies from 'Parser/Core/Modules/Enemies';
 import ABILITY_BLACKLIST from '../Constants/AbilityBlacklist';
 
-const DEBUG_ABILITIES = true;
+const DEBUG_ABILITIES = false;
 
 class BreathOfFire extends Analyzer {
   static dependencies = {

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/IronSkinBrew.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/IronSkinBrew.js
@@ -9,6 +9,7 @@ import Enemies from 'Parser/Core/Modules/Enemies';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellUsable from 'Parser/Core/Modules/SpellUsable';
 import SharedBrews from '../Core/SharedBrews';
+import ABILITY_BLACKLIST from '../Constants/AbilityBlacklist';
 
 const debug = false;
 
@@ -85,7 +86,7 @@ class IronSkinBrew extends Analyzer {
   }
 
   on_toPlayer_damage(event) {
-    if(event.ability.guid === SPELLS.STAGGER_TAKEN.id || !(event.sourceID in this.enemies.getEntities())) {
+    if(event.ability.guid === SPELLS.STAGGER_TAKEN.id || !(event.sourceID in this.enemies.getEntities()) || ABILITY_BLACKLIST.includes(event.ability.guid)) {
       return; // either stagger or not a notable entity (e.g. imonar traps, environment damage)
     }
 
@@ -135,9 +136,9 @@ class IronSkinBrew extends Analyzer {
     return {
       actual: this.hitsWithIronSkinBrew / (this.hitsWithIronSkinBrew + this.hitsWithoutIronSkinBrew),
       isLessThan: {
-        minor: 0.99,
-        average: 0.98,
-        major: 0.95,
+        minor: 0.98,
+        average: 0.96,
+        major: 0.94,
       },
       style: 'percentage',
     };

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/IronSkinBrew.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/IronSkinBrew.js
@@ -5,6 +5,7 @@ import SpellIcon from 'common/SpellIcon';
 import { formatPercentage, formatThousands } from 'common/format';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
+import Enemies from 'Parser/Core/Modules/Enemies';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import SpellUsable from 'Parser/Core/Modules/SpellUsable';
 import SharedBrews from '../Core/SharedBrews';
@@ -13,6 +14,7 @@ const debug = false;
 
 class IronSkinBrew extends Analyzer {
   static dependencies = {
+    enemies: Enemies,
     combatants: Combatants,
     spellUsable: SpellUsable,
     brews: SharedBrews,
@@ -83,14 +85,16 @@ class IronSkinBrew extends Analyzer {
   }
 
   on_toPlayer_damage(event) {
-    if (event.ability.guid !== SPELLS.STAGGER_TAKEN.id) {
-      if (this.lastIronSkinBrewBuffApplied > 0) {
-        this.hitsWithIronSkinBrew += 1;
-        this.damageWithIronSkinBrew += event.amount + (event.absorbed || 0) + (event.overkill || 0);
-      } else {
-        this.hitsWithoutIronSkinBrew += 1;
-        this.damageWithoutIronSkinBrew += event.amount + (event.absorbed || 0) + (event.overkill || 0);
-      }
+    if(event.ability.guid === SPELLS.STAGGER_TAKEN.id || !(event.sourceID in this.enemies.getEntities())) {
+      return; // either stagger or not a notable entity (e.g. imonar traps, environment damage)
+    }
+
+    if (this.lastIronSkinBrewBuffApplied > 0) {
+      this.hitsWithIronSkinBrew += 1;
+      this.damageWithIronSkinBrew += event.amount + (event.absorbed || 0) + (event.overkill || 0);
+    } else {
+      this.hitsWithoutIronSkinBrew += 1;
+      this.damageWithoutIronSkinBrew += event.amount + (event.absorbed || 0) + (event.overkill || 0);
     }
   }
 

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/IronSkinBrew.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/IronSkinBrew.js
@@ -162,14 +162,15 @@ class IronSkinBrew extends Analyzer {
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.IRONSKIN_BREW.id} />}
-        value={`${formatPercentage(isbUptime)}%`}
-        label="Ironskin Brew uptime"
+        value={`${formatPercentage(hitsMitigatedPercent)}%`}
+        label="Hits Mitigated w/ Ironskin Brew"
         tooltip={`Ironskin Brew breakdown (these values are direct damage and does not include damage added to stagger):
             <ul>
                 <li>You were hit <b>${this.hitsWithIronSkinBrew}</b> times with your Ironskin Brew buff (<b>${formatThousands(this.damageWithIronSkinBrew)}</b> damage).</li>
                 <li>You were hit <b>${this.hitsWithoutIronSkinBrew}</b> times <b><i>without</i></b> your Ironskin Brew buff (<b>${formatThousands(this.damageWithoutIronSkinBrew)}</b> damage).</li>
             </ul>
-            <b>${formatPercentage(hitsMitigatedPercent)}%</b> of attacks were mitigated with Ironskin Brew.`}
+            <b>${formatPercentage(hitsMitigatedPercent)}%</b> of attacks were mitigated with Ironskin Brew.<br/>
+            <b>${formatPercentage(isbUptime)}%</b> uptime on the Ironskin Brew buff.`}
           />
     );
   }


### PR DESCRIPTION
The main idea of this change is to switch the breath of fire checklist item from uptime % to # of hits mitigated. This ends up being trickier than ISB because:

- lots of bosses do abilities during intermissions that you can't realistically mitigate with BoF
- lots of adds due pulsing AoE's (looking at you Aggy)
- lots of irrelevant ability hits are generated by "NPC"s (aka imonar traps, aggy adds)

While I was doing this, I also fixed #1211 

**Before (H Imonar):**
![screenshot from 2018-03-19 23-36-31](https://user-images.githubusercontent.com/4909458/37634961-3fb861ee-2bcf-11e8-8cd0-4915161a0b05.png)
![screenshot from 2018-03-19 23-36-40](https://user-images.githubusercontent.com/4909458/37634960-3f9724a2-2bcf-11e8-9866-3d0e1b6ccb5b.png)


**After:**
![screenshot from 2018-03-19 23-37-23](https://user-images.githubusercontent.com/4909458/37634969-4b5d264c-2bcf-11e8-819c-8eb92c3efae7.png)
![screenshot from 2018-03-19 23-37-31](https://user-images.githubusercontent.com/4909458/37634968-4b416182-2bcf-11e8-987b-caf4ffd32e22.png)
