### PR TITLE
[Marksmanship] Sentinel fix

### DIFF
--- a/src/Parser/Hunter/BeastMastery/Modules/Talents/AMurderOfCrows.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Talents/AMurderOfCrows.js
@@ -113,7 +113,7 @@ class AMurderOfCrows extends Analyzer {
   }
   suggestions(when) {
     when(this.badCastThreshold).addSuggestion((suggest, actual, recommended) => {
-      return suggest(<Wrapper>Don't cast <SpellLink id={SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.id}icon /> without <SpellLink id={SPELLS.BESTIAL_WRATH.id}icon /> up (or ready to cast straight after the <SpellLink id={SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.id}icon /> cast), and atleast 7 seconds remaining on the buff.</Wrapper>)
+      return suggest(<Wrapper>Don't cast <SpellLink id={SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.id} icon /> without <SpellLink id={SPELLS.BESTIAL_WRATH.id} icon /> up (or ready to cast straight after the <SpellLink id={SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.id} icon /> cast), and atleast 7 seconds remaining on the buff.</Wrapper>)
         .icon(SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.icon)
         .actual(`You cast A Murder of Crows ${actual} times without Bestial Wrath up or Bestial Wrath ready to cast after`)
         .recommended(`${recommended} is recommended`);

--- a/src/Parser/Hunter/Marksmanship/CHANGELOG.js
+++ b/src/Parser/Hunter/Marksmanship/CHANGELOG.js
@@ -9,6 +9,11 @@ import { Blazballs, JLassie82, Putro } from 'MAINTAINERS';
 
 export default [
   {
+    date: new Date('2018-03-22'),
+    changes: <Wrapper>Fixed <SpellLink id={SPELLS.SENTINEL_TALENT.id} icon /> module after Blizzard fixed the bugs with the spell. </Wrapper>,
+    contributors: [Putro],
+  },
+  {
     date: new Date('2018-03-01'),
     changes: <Wrapper>Added a <SpellLink id={SPELLS.MARKING_TARGETS.id} icon /> and <SpellLink id={SPELLS.HUNTERS_MARK.id} icon /> module. Also updated handling for <ItemLink id={ITEMS.ZEVRIMS_HUNGER.id} icon />.</Wrapper>,
     contributors: [Putro],

--- a/src/Parser/Hunter/Marksmanship/CombatLogParser.js
+++ b/src/Parser/Hunter/Marksmanship/CombatLogParser.js
@@ -60,6 +60,8 @@ import Bullseye from './Modules/Traits/Bullseye';
 import CyclonicBurst from './Modules/Traits/CyclonicBurst';
 import CallOfTheHunter from './Modules/Traits/CallOfTheHunter';
 import LegacyOfTheWindrunners from './Modules/Traits/LegacyOfTheWindrunners';
+import Windburst from './Modules/Traits/Windburst';
+
 //Traits and Talents list
 import TraitsAndTalents from './Modules/Features/TraitsAndTalents';
 
@@ -133,6 +135,7 @@ class CombatLogParser extends CoreCombatLogParser {
     cyclonicBurst: CyclonicBurst,
     callOfTheHunter: CallOfTheHunter,
     legacyOfTheWindrunners: LegacyOfTheWindrunners,
+    windburst: Windburst,
 
     //Traits and Talents list
     traitsAndTalents: TraitsAndTalents,

--- a/src/Parser/Hunter/Marksmanship/Modules/Spells/Trueshot.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Spells/Trueshot.js
@@ -46,7 +46,7 @@ class Trueshot extends Analyzer {
     this.trueshotCasts += 1;
     this.prepullTrueshots += 1;
     //starts the cooldown to ensure proper cast efficiency statistics
-    this.spellUsable.beginCooldown(SPELLS.TRUESHOT.id);
+    this.spellUsable.beginCooldown(SPELLS.TRUESHOT.id, this.owner.fight.start_time);
   }
 
   on_byPlayer_cast(event) {

--- a/src/Parser/Hunter/Marksmanship/Modules/Talents/AMurderOfCrows.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Talents/AMurderOfCrows.js
@@ -11,6 +11,7 @@ import SpellLink from "common/SpellLink";
 import SPECS from 'common/SPECS';
 import ItemDamageDone from 'Main/ItemDamageDone';
 import Wrapper from 'common/Wrapper';
+import SpellUsable from 'Parser/Core/Modules/SpellUsable';
 
 //generally accepted rule is to save crows if boss is below 25% health.
 const CROWS_SAVE_PERCENT = 0.25;
@@ -24,6 +25,7 @@ class AMurderOfCrows extends Analyzer {
 
   static dependencies = {
     combatants: Combatants,
+    spellUsable: SpellUsable,
   };
 
   bossIDs = [];
@@ -46,6 +48,11 @@ class AMurderOfCrows extends Analyzer {
     const spellId = event.ability.guid;
     if (spellId !== SPELLS.A_MURDER_OF_CROWS_SPELL.id) {
       return;
+    }
+    if (this.totalCrowsCasts === 0) {
+      this.totalCrowsCasts++;
+      this.goodCrowsCasts++;
+      this.spellUsable.beginCooldown(SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.id, this.owner.fight.start_time);
     }
     this.damage += event.amount;
   }

--- a/src/Parser/Hunter/Marksmanship/Modules/Talents/Sentinel.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Talents/Sentinel.js
@@ -67,7 +67,6 @@ class Sentinel extends Analyzer {
         this.applyDebuffTimestamp = event.timestamp;
         this.timesTicked++;
         this.sentinelTicks++;
-        console.log("Sentinel tick at ", event.timestamp);
       }
     }
   }
@@ -87,7 +86,6 @@ class Sentinel extends Analyzer {
         this.wastedTicks++;
         this.lastBadTickTimestamp = event.timestamp;
         this.timesTicked++;
-        console.log("Sentinel tick (wasted) at ", event.timestamp);
       }
     }
   }
@@ -126,8 +124,8 @@ class Sentinel extends Analyzer {
           <div className="statistic-bar">
             <div
               className="stat-health-bg"
-              style={{ width: `${100 - formatPercentage((this.goodTicks / this.totalPossibleTicks))}%` }}
-              data-tip={`<b>${100 - formatPercentage(this.goodTicks / this.totalPossibleTicks)}%</b> of your Sentinel ticks happened while none of the targets had a hunter's mark on them, good job!`}
+              style={{ width: `${formatPercentage((this.goodTicks / this.totalPossibleTicks))}%` }}
+              data-tip={`<b>${formatPercentage(this.goodTicks / this.totalPossibleTicks)}%</b> of your Sentinel ticks happened while none of the targets had a hunter's mark on them, good job!`}
             >
             </div>
             <div
@@ -139,7 +137,7 @@ class Sentinel extends Analyzer {
             <div
               className="Druid-bg"
               style={{ width: `${formatPercentage(this.missedTicks / this.totalPossibleTicks)}%` }}
-              data-tip={`<b>${formatPercentage(this.missedTicks / this.totalPossibleTicks)}%</b> of your possible Sentinel ticks completely missed a target`}
+              data-tip={`<b>${formatPercentage(this.missedTicks / this.totalPossibleTicks)}%</b> of your possible Sentinel ticks completely missed a target.`}
             >
             </div>
           </div>

--- a/src/Parser/Hunter/Marksmanship/Modules/Talents/Sentinel.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Talents/Sentinel.js
@@ -86,8 +86,12 @@ class Sentinel extends Analyzer {
       this.timesTicked = 0;
       return;
     }
+    if (this.lastApplicationFromSentinel && event.timestamp < this.lastApplicationFromSentinel + MS_BUFFER) {
+      this.wastedApplications++;
+    }
     if (event.timestamp < (this.lastSentinelCastTimestamp + TIME_BETWEEN_TICKS * this.timesTicked + MS_BUFFER) && event.timestamp > (this.lastSentinelCastTimestamp + TIME_BETWEEN_TICKS * this.timesTicked - MS_BUFFER)) {
       this.wastedApplications++;
+      this.lastApplicationFromSentinel = event.timestamp;
       if (this.lastBadTickTimestamp < event.timestamp + MS_BUFFER) {
         this.wastedTicks++;
         this.lastBadTickTimestamp = event.timestamp;

--- a/src/Parser/Hunter/Marksmanship/Modules/Traits/Windburst.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Traits/Windburst.js
@@ -1,0 +1,42 @@
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import SPELLS from 'common/SPELLS';
+import SpellUsable from 'Parser/Core/Modules/SpellUsable';
+
+/**
+ * Focuses the power of Wind through Thas'dorah, dealing 800% Physical damage to your target, and leaving behind a trail of wind
+ * for 5 sec that increases the movement speed of allies by 50%.
+ */
+class Windburst extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    spellUsable: SpellUsable,
+  };
+  casts = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.traitsBySpellId[SPELLS.WINDBURST.id];
+  }
+
+  on_byPlayer_damage(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.CYCLONIC_BURST_IMPACT_TRAIT.id && spellId !== SPELLS.WINDBURST.id && spellId !== SPELLS.CYCLONIC_BURST_TRAIT.id) {
+      return;
+    }
+    if (this.casts === 0) {
+      this.casts++;
+      this.spellUsable.beginCooldown(SPELLS.WINDBURST.id, this.owner.fight.start_time);
+    }
+  }
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.WINDBURST.id) {
+      return;
+    }
+    this.casts++;
+  }
+
+}
+
+export default Windburst;

--- a/src/Parser/Hunter/Survival/Modules/Spells/ExplosiveTrap.js
+++ b/src/Parser/Hunter/Survival/Modules/Spells/ExplosiveTrap.js
@@ -33,7 +33,7 @@ class ExplosiveTrap extends Analyzer {
     }
     if (this.casts === 0) {
       this.casts++;
-      this.spellUsable.beginCooldown(SPELLS.EXPLOSIVE_TRAP_CAST.id);
+      this.spellUsable.beginCooldown(SPELLS.EXPLOSIVE_TRAP_CAST.id, this.owner.fight.start_time);
     }
     this.bonusDamage += event.amount + (event.absorbed || 0);
   }

--- a/src/Parser/Hunter/Survival/Modules/Talents/AMurderOfCrows.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/AMurderOfCrows.js
@@ -37,7 +37,7 @@ class AMurderOfCrows extends Analyzer {
     }
     if (this.casts === 0) {
       this.casts++;
-      this.spellUsable.beginCooldown(SPELLS.A_MURDER_OF_CROWS_TALENT_SURVIVAL.id);
+      this.spellUsable.beginCooldown(SPELLS.A_MURDER_OF_CROWS_TALENT_SURVIVAL.id, this.owner.fight.start_time);
     }
     this.bonusDamage += event.amount + (event.absorbed || 0);
   }

--- a/src/Parser/Hunter/Survival/Modules/Talents/Caltrops.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/Caltrops.js
@@ -43,7 +43,7 @@ class Caltrops extends Analyzer {
     }
     if (this.caltropsCasts === 0) {
       this.caltropsCasts++;
-      this.spellUsable.beginCooldown(SPELLS.CALTROPS_TALENT.id);
+      this.spellUsable.beginCooldown(SPELLS.CALTROPS_TALENT.id, this.owner.fight.start_time);
     }
     this.bonusDamage += event.amount + (event.absorbed || 0);
   }

--- a/src/Parser/Hunter/Survival/Modules/Talents/DragonsfireGrenade.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/DragonsfireGrenade.js
@@ -37,7 +37,7 @@ class DragonsfireGrenade extends Analyzer {
     }
     if (this.casts === 0) {
       this.casts++;
-      this.spellUsable.beginCooldown(SPELLS.DRAGONSFIRE_GRENADE_TALENT.id);
+      this.spellUsable.beginCooldown(SPELLS.DRAGONSFIRE_GRENADE_TALENT.id, this.owner.fight.start_time);
     }
     this.bonusDamage += event.amount + (event.absorbed || 0);
   }

--- a/src/Parser/Hunter/Survival/Modules/Talents/SpittingCobra.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/SpittingCobra.js
@@ -31,7 +31,7 @@ class SpittingCobra extends Analyzer {
       return;
     }
     //starts the cooldown to ensure proper cast efficiency statistics
-    this.spellUsable.beginCooldown(SPELLS.SPITTING_COBRA_TALENT.id);
+    this.spellUsable.beginCooldown(SPELLS.SPITTING_COBRA_TALENT.id, this.owner.fight.start_time);
     //adds one to cobraCasts so we can calculate the average casts properly
     this.cobraCasts++;
   }

--- a/src/Parser/Hunter/Survival/Modules/Talents/SteelTrap.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/SteelTrap.js
@@ -37,7 +37,7 @@ class SteelTrap extends Analyzer {
     }
     if (this.casts === 0) {
       this.casts++;
-      this.spellUsable.beginCooldown(SPELLS.STEEL_TRAP_TALENT.id);
+      this.spellUsable.beginCooldown(SPELLS.STEEL_TRAP_TALENT.id, this.owner.fight.start_time);
     }
     this.bonusDamage += event.amount + (event.absorbed || 0);
   }


### PR DESCRIPTION
Fixes the Sentinel module after Blizzard fixed the talent. 
Orange now represents completely missed hits
Also fixes some precast events better than before

Report: https://www.warcraftlogs.com/reports/pXWnbD2aNVF6jGzY/#fight=42&source=41
New: 
![image](https://user-images.githubusercontent.com/29204244/37772139-07ab92d2-2dda-11e8-96b7-319c95894b4c.png)
Old: 
![image](https://user-images.githubusercontent.com/29204244/37772191-2d7d9596-2dda-11e8-8226-6ad63f6cc7f6.png)


AoE scenario: 
Report: https://www.warcraftlogs.com/reports/gWxmnqPMfCYZGvtF/#fight=11&source=38
New: 
![image](https://user-images.githubusercontent.com/29204244/37772666-a2198120-2ddb-11e8-9d75-ee2a951269cd.png)

Old: 
![image](https://user-images.githubusercontent.com/29204244/37772689-b3b30582-2ddb-11e8-8424-1cbcccc3a214.png)

