### PR TITLE
[Restoration Shaman] High Tide module, Spirit Link removal & spacing fixes

### DIFF
--- a/src/Parser/Shaman/Restoration/CombatLogParser.js
+++ b/src/Parser/Shaman/Restoration/CombatLogParser.js
@@ -1,9 +1,3 @@
-/*
-  TODO:
-  Remove Spirit Link Damage from Overall Healing
-
-*/
-
 import React from 'react';
 
 import Tab from 'Main/Tab';
@@ -12,9 +6,9 @@ import Feeding from 'Main/Feeding';
 
 import CoreCombatLogParser from 'Parser/Core/CombatLogParser';
 import LowHealthHealing from 'Parser/Core/Modules/LowHealthHealing';
-import HealingDone from 'Parser/Core/Modules/HealingDone';
 import Abilities from './Modules/Abilities';
 
+import HealingDone from './Modules/ShamanCore/HealingDone';
 import ShamanAbilityTracker from './Modules/ShamanCore/ShamanAbilityTracker';
 
 import MasteryEffectiveness from './Modules/Features/MasteryEffectiveness';

--- a/src/Parser/Shaman/Restoration/Modules/Features/MasteryEffectiveness.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/MasteryEffectiveness.js
@@ -56,7 +56,7 @@ class MasteryEffectiveness extends Analyzer {
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.DEEP_HEALING.id} />}
-        value={`${formatPercentage(masteryEffectivenessPercent)}%`}
+        value={`${formatPercentage(masteryEffectivenessPercent)} %`}
         label={(
           <dfn data-tip={`The percent of your mastery that you benefited from on average (so always between 0% and 100%). Since you have ${formatPercentage(masteryPercent)}% mastery, this means that on average your heals were increased by ${formatPercentage(avgEffectiveMasteryPercent)}% by your mastery.`}>
             Mastery benefit

--- a/src/Parser/Shaman/Restoration/Modules/Features/TidalWaves.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/TidalWaves.js
@@ -85,7 +85,7 @@ class TidalWaves extends Analyzer {
             />
           </SpellLink>
         )}
-        value={`${formatPercentage(unusedTwRate)}%`}
+        value={`${formatPercentage(unusedTwRate)} %`}
         label={(
           <dfn data-tip={`The amount of Tidal Waves charges you did not use out of the total available. You cast ${riptideCasts} Riptides and ${chainHealCasts} Chain Heals which gave you ${totalTwGenerated} Tidal Waves charges, of which you used ${totalTwUsed}.<br /><br />The ratio may be below zero if you started the fight with Tidal Waves charges.`}>
             Unused Tidal Waves

--- a/src/Parser/Shaman/Restoration/Modules/Features/TidalWaves.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/TidalWaves.js
@@ -25,8 +25,8 @@ class TidalWaves extends Analyzer {
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span><SpellLink id={SPELLS.TIDAL_WAVES_BUFF.id} /> buffed <SpellLink id={SPELLS.HEALING_WAVE.id} /> can make for some very efficient healing, consider casting more of them ({formatPercentage(suggestedThresholds.actual)}% unused Tidal Waves).</span>)
           .icon(SPELLS.TIDAL_WAVES_BUFF.icon)
-          .actual(`${formatPercentage(suggestedThresholds.actual)} % unused Tidal waves`)
-          .recommended(`Less than ${formatPercentage(suggestedThresholds.isGreaterThan.minor, 0)} % unused Tidal Waves`)
+          .actual(`${formatPercentage(suggestedThresholds.actual)}% unused Tidal waves`)
+          .recommended(`Less than ${formatPercentage(suggestedThresholds.isGreaterThan.minor, 0)}% unused Tidal Waves`)
           .regular(suggestedThresholds.isGreaterThan.average).major(suggestedThresholds.isGreaterThan.major);
       });
   }
@@ -85,7 +85,7 @@ class TidalWaves extends Analyzer {
             />
           </SpellLink>
         )}
-        value={`${formatPercentage(unusedTwRate)} %`}
+        value={`${formatPercentage(unusedTwRate)}%`}
         label={(
           <dfn data-tip={`The amount of Tidal Waves charges you did not use out of the total available. You cast ${riptideCasts} Riptides and ${chainHealCasts} Chain Heals which gave you ${totalTwGenerated} Tidal Waves charges, of which you used ${totalTwUsed}.<br /><br />The ratio may be below zero if you started the fight with Tidal Waves charges.`}>
             Unused Tidal Waves

--- a/src/Parser/Shaman/Restoration/Modules/Items/UncertainReminder.js
+++ b/src/Parser/Shaman/Restoration/Modules/Items/UncertainReminder.js
@@ -152,8 +152,8 @@ class UncertainReminder extends Analyzer {
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>You didn't benefit from <ItemLink id={ITEMS.UNCERTAIN_REMINDER.id} /> a lot consider using a different legendary on long fights or on fights where there is not much to heal during the additional heroism uptime.</span>)
           .icon(ITEMS.UNCERTAIN_REMINDER.icon)
-          .actual(`${uncertainReminderHealingPercentage} %`)
-          .recommended(`${recommended} %`)
+          .actual(`${uncertainReminderHealingPercentage}%`)
+          .recommended(`${recommended}%`)
           .regular(recommended - .01).major(recommended - .02);
       });
   }

--- a/src/Parser/Shaman/Restoration/Modules/ShamanCore/HealingDone.js
+++ b/src/Parser/Shaman/Restoration/Modules/ShamanCore/HealingDone.js
@@ -1,0 +1,18 @@
+import SPELLS from 'common/SPELLS';
+
+import CoreHealingDone from 'Parser/Core/Modules/HealingDone';
+
+class HealingDone extends CoreHealingDone {
+  on_damage(event) {
+    // Removing Spirit link from total healing done by subtracting the damage done of it
+    const spellId = event.ability.guid;
+    if (!this.owner.byPlayerPet(event)) {
+      return;
+    }
+    if (spellId === SPELLS.SPIRIT_LINK_TOTEM_REDISTRIBUTE.id) {
+      this._subtractHealing(event, event.amount, 0, 0);
+    }
+  }
+}
+
+export default HealingDone;

--- a/src/Parser/Shaman/Restoration/Modules/Spells/GiftOfTheQueen.js
+++ b/src/Parser/Shaman/Restoration/Modules/Spells/GiftOfTheQueen.js
@@ -61,8 +61,8 @@ class GiftOfTheQueen extends Analyzer {
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>Try to always cast <SpellLink id={SPELLS.GIFT_OF_THE_QUEEN.id} /> at a position where both the initial hit and the echo from <SpellLink id={SPELLS.DEEP_WATERS.id} /> will hit all 6 potential targets.</span>)
           .icon(SPELLS.GIFT_OF_THE_QUEEN.icon)
-          .actual(`${formatPercentage(gotqTargetEffiencyThresholds.actual)} % of targets hit`)
-          .recommended(`> ${formatPercentage(gotqTargetEffiencyThresholds.isLessThan.minor)} % of targets hit`)
+          .actual(`${formatPercentage(gotqTargetEffiencyThresholds.actual)}% of targets hit`)
+          .recommended(`> ${formatPercentage(gotqTargetEffiencyThresholds.isLessThan.minor)}% of targets hit`)
           .regular(gotqTargetEffiencyThresholds.isLessThan.average).major(gotqTargetEffiencyThresholds.isLessThan.major);
       });
     
@@ -73,8 +73,8 @@ class GiftOfTheQueen extends Analyzer {
         .addSuggestion((suggest, actual, recommended) => {
           return suggest(<span>Try to cast <SpellLink id={SPELLS.GIFT_OF_THE_QUEEN.id} /> while <SpellLink id={SPELLS.CLOUDBURST_TOTEM_TALENT.id} /> is up as much as possible.</span>)
             .icon(SPELLS.GIFT_OF_THE_QUEEN.icon)
-            .actual(`${formatPercentage(gotqFeedingEfficiency.actual)} % of GotQ healing fed into CBT`)
-            .recommended(`> ${formatPercentage(gotqFeedingEfficiency.isLessThan.minor)} % of GotQ healing fed into CBT`)
+            .actual(`${formatPercentage(gotqFeedingEfficiency.actual)}% of GotQ healing fed into CBT`)
+            .recommended(`> ${formatPercentage(gotqFeedingEfficiency.isLessThan.minor)}% of GotQ healing fed into CBT`)
             .regular(gotqFeedingEfficiency.isLessThan.average).major(gotqFeedingEfficiency.isLessThan.major);
         }); 
       }   

--- a/src/Parser/Shaman/Restoration/Modules/Spells/HealingSurge.js
+++ b/src/Parser/Shaman/Restoration/Modules/Spells/HealingSurge.js
@@ -40,8 +40,8 @@ class HealingSurge extends Analyzer {
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>Casting <SpellLink id={SPELLS.HEALING_SURGE_RESTORATION.id} /> without <SpellLink id={SPELLS.TIDAL_WAVES_BUFF.id} /> is very inefficient, try not to cast more than is necessary.</span>)
           .icon(SPELLS.HEALING_SURGE_RESTORATION.icon)
-          .actual(`${formatPercentage(suggestedThreshold.actual)} % of unbuffed Healing Surges`)
-          .recommended(`${suggestedThreshold.isGreaterThan.minor} % of unbuffed Healing Surges`)
+          .actual(`${formatPercentage(suggestedThreshold.actual)}% of unbuffed Healing Surges`)
+          .recommended(`${suggestedThreshold.isGreaterThan.minor}% of unbuffed Healing Surges`)
           .regular(suggestedThreshold.isGreaterThan.average).major(suggestedThreshold.isGreaterThan.major);
       });
   }

--- a/src/Parser/Shaman/Restoration/Modules/Spells/HealingWave.js
+++ b/src/Parser/Shaman/Restoration/Modules/Spells/HealingWave.js
@@ -38,8 +38,8 @@ class HealingWave extends Analyzer {
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>Casting <SpellLink id={SPELLS.HEALING_WAVE.id} icon /> without <SpellLink id={SPELLS.TIDAL_WAVES_BUFF.id} icon/> is slow and generally inefficient. Consider casting a riptide first to generate <SpellLink id={SPELLS.TIDAL_WAVES_BUFF.id} icon/></span>)
           .icon(SPELLS.HEALING_WAVE.icon)
-          .actual(`${formatPercentage(suggestedThreshold.actual)} % of unbuffed Healing Surges`)
-          .recommended(`${suggestedThreshold.isGreaterThan.minor} % of unbuffed Healing Surges`)
+          .actual(`${formatPercentage(suggestedThreshold.actual)}% of unbuffed Healing Surges`)
+          .recommended(`${suggestedThreshold.isGreaterThan.minor}% of unbuffed Healing Surges`)
           .regular(suggestedThreshold.isGreaterThan.average).major(suggestedThreshold.isGreaterThan.major);
       });
   }

--- a/src/Parser/Shaman/Restoration/Modules/Talents/EarthenShieldTotem.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/EarthenShieldTotem.js
@@ -71,8 +71,8 @@ class EarthenShieldTotem extends Analyzer {
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>Try to cast <SpellLink id={SPELLS.EARTHEN_SHIELD_TOTEM_TALENT.id} /> at times - and positions where there will be as many people taking damage possible inside of it to maximize the amount it absorbs.</span>)
           .icon(SPELLS.EARTHEN_SHIELD_TOTEM_TALENT.icon)
-          .actual(`${this.earthenShieldEfficiency} %`)
-          .recommended(`${recommended} %`)
+          .actual(`${this.earthenShieldEfficiency}%`)
+          .recommended(`${recommended}%`)
           .regular(recommended - .15).major(recommended - .3);
       });
   }

--- a/src/Parser/Shaman/Restoration/Modules/Talents/HighTide.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/HighTide.js
@@ -32,6 +32,7 @@ class HighTide extends Analyzer {
       return;
     }
 
+    // resets the bounces to 0 if its a new chain heal, can't use the cast event for this as its often somewhere in the middle of the healing events
     if(!this.chainHealTimestamp || event.timestamp - this.chainHealTimestamp > HEAL_WINDOW_MS) {
       this.chainHealTimestamp = event.timestamp;
       this.chainHealBounce = 0;

--- a/src/Parser/Shaman/Restoration/Modules/Talents/HighTide.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/HighTide.js
@@ -5,45 +5,47 @@ import SPELLS from 'common/SPELLS';
 import { formatPercentage } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
 
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
+const HEAL_WINDOW_MS = 100;
+const bounceReduction = 0.7;
+const bounceReductionHighTide = 0.85;
+
 class HighTide extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
   healing = 0;
-
-  // const FACTOR_CONTRIBUTED_BY_HT_HIT_1 = 0;
-  // const FACTOR_CONTRIBUTED_BY_HT_HIT_2 = 0.17647;
-  // const FACTOR_CONTRIBUTED_BY_HT_HIT_3 = 0.32179;
-  // const FACTOR_CONTRIBUTED_BY_HT_HIT_4 = 0.44148;
-  // const FACTOR_CONTRIBUTED_BY_HT_HIT_5 = 1;
-
+  chainHealBounce = 0;
+  chainHealTimestamp = 0;
 
   on_initialized() {
-    // WIP
-    this.active = false;
-    // this.active = this.owner.selectedCombatant.hasTalent(SPELLS.HIGH_TIDE_TALENT.id);
+    this.active = this.combatants.selected.hasTalent(SPELLS.HIGH_TIDE_TALENT.id);
   }
 
-
-  on_byPlayer_cast(event) {
+  on_byPlayer_heal(event) {
     const spellId = event.ability.guid;
 
-    if (!(spellId === SPELLS.EARTHEN_SHIELD_TOTEM_TALENT.id)) {
+    if (spellId !== SPELLS.CHAIN_HEAL.id) {
       return;
     }
 
-    this.potentialHealing += event.maxHitPoints;
-  }
-
-  on_byPlayer_summon(event) {
-    const spellId = event.ability.guid;
-
-    if (!(spellId === SPELLS.EARTHEN_SHIELD_TOTEM_TALENT.id)) {
-      return;
+    if(!this.chainHealTimestamp || event.timestamp - this.chainHealTimestamp > HEAL_WINDOW_MS) {
+      this.chainHealTimestamp = event.timestamp;
+      this.chainHealBounce = 0;
     }
 
-    // Store the id of the totem we summoned so that we don't include the EST of other rshamans.
-    this.activeEST = event.targetID;
+    const FACTOR_CONTRIBUTED_BY_HT_HIT = (1-(Math.pow(bounceReduction,this.chainHealBounce) / Math.pow(bounceReductionHighTide,this.chainHealBounce)));
+
+    if(this.chainHealBounce === 4) {
+      this.healing += event.amount;
+    } else {
+      this.healing += event.amount * FACTOR_CONTRIBUTED_BY_HT_HIT;
+    }
+
+    this.chainHealBounce++;
   }
 
   statistic() {
@@ -51,7 +53,7 @@ class HighTide extends Analyzer {
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.HIGH_TIDE_TALENT.id} />}
-        value={`${formatPercentage(this.healing)} %`}
+        value={`${(formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing)))} %`}
         label={(
           <dfn data-tip="The percentage of your healing that is caused by High Tide.">
 


### PR DESCRIPTION
Finished the High Tide module which appeared to be abondoned.
![image](https://user-images.githubusercontent.com/2842471/37864862-96fb06b6-2f74-11e8-8b03-4a97ef27f2ed.png)

Removed Spirit Link healing by subtracting the damage done of it and fixed some spacing inconsistencies in the modules, while also removing spaces before % signs in suggestions. 
![image](https://user-images.githubusercontent.com/2842471/37864902-32977046-2f75-11e8-93d3-c46d26805c41.png)
