### PR TITLE
[Restoration Shaman] Changed Tidal Waves statistics boxes, added missing abilities

### DIFF
--- a/src/Parser/Shaman/Restoration/CHANGELOG.js
+++ b/src/Parser/Shaman/Restoration/CHANGELOG.js
@@ -9,6 +9,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-03-24'),
+    changes: <Wrapper>Reworked the <SpellLink id={SPELLS.TIDAL_WAVES_BUFF.id} icon /> statistics, making them easier to read.</Wrapper>,
+    contributors: [niseko],
+  },
+  {
     date: new Date('2018-03-16'),
     changes: <Wrapper>Added a <SpellLink id={SPELLS.RESURGENCE.id} icon /> module, detailing how much each spell contributed to your mana pool.</Wrapper>,
     contributors: [niseko],

--- a/src/Parser/Shaman/Restoration/Modules/Abilities.js
+++ b/src/Parser/Shaman/Restoration/Modules/Abilities.js
@@ -358,6 +358,7 @@ class Abilities extends CoreAbilities {
       {
         spell: [SPELLS.HEX, SPELLS.HEX_RAPTOR, SPELLS.HEX_SNAKE, SPELLS.HEX_SPIDER, SPELLS.HEX_COCKROACH, SPELLS.HEX_SKELETAL],
         category: Abilities.SPELL_CATEGORIES.UTILITY,
+        isOnGCD: true,
         timelineSortIndex: 80,
         cooldown: 30,
       },

--- a/src/Parser/Shaman/Restoration/Modules/Abilities.js
+++ b/src/Parser/Shaman/Restoration/Modules/Abilities.js
@@ -14,6 +14,7 @@ class Abilities extends CoreAbilities {
         charges: 2,
         cooldown: 6,
         enabled: combatant.hasTalent(SPELLS.ECHO_OF_THE_ELEMENTS_TALENT.id) || combatant.hasFinger(ITEMS.SOUL_OF_THE_FARSEER.id),
+        timelineSortIndex: 15,
         castEfficiency: {
           suggestion: true,
           majorIssueEfficiency: 0.50,
@@ -27,6 +28,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         cooldown: 6,
         enabled: !(combatant.hasTalent(SPELLS.ECHO_OF_THE_ELEMENTS_TALENT.id) || combatant.hasFinger(ITEMS.SOUL_OF_THE_FARSEER.id)),
+        timelineSortIndex: 15,
         castEfficiency: {
           suggestion: true,
           majorIssueEfficiency: 0.30,
@@ -38,6 +40,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.HEALING_STREAM_TOTEM_CAST,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         charges: 2,
+        timelineSortIndex: 18,
         cooldown: (haste, combatant) => {
           const has4PT19 = combatant.hasBuff(SPELLS.RESTORATION_SHAMAN_T19_4SET_BONUS_BUFF.id);
 
@@ -69,7 +72,8 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.ASTRAL_SHIFT,
-        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        timelineSortIndex: 82,
         cooldown: 90,
         castEfficiency: {
           suggestion: true,
@@ -78,18 +82,10 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.ARCANE_TORRENT_MANA,
-        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
-        cooldown: 90,
-        isUndetectable: true,
-        castEfficiency: {
-          suggestion: true,
-        },
-      },
-      {
         spell: SPELLS.HEALING_RAIN_CAST,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 10,
+        timelineSortIndex: 20,
         castEfficiency: {
           suggestion: true,
           majorIssueEfficiency: 0.30,
@@ -101,6 +97,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.WELLSPRING_TALENT,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 20,
+        timelineSortIndex: 20,
         enabled: combatant.lv100Talent === SPELLS.WELLSPRING_TALENT.id,
         castEfficiency: {
           suggestion: true,
@@ -113,6 +110,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.GIFT_OF_THE_QUEEN,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 45,
+        timelineSortIndex: 20,
         castEfficiency: {
           suggestion: true,
           majorIssueEfficiency: 0.3,
@@ -124,6 +122,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.CLOUDBURST_TOTEM_TALENT,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 30,
+        timelineSortIndex: 20,
         enabled: combatant.lv90Talent === SPELLS.CLOUDBURST_TOTEM_TALENT.id,
         castEfficiency: {
           suggestion: true,
@@ -136,6 +135,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.EARTHEN_SHIELD_TOTEM_TALENT,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 60,
+        timelineSortIndex: 20,
         enabled: combatant.lv75Talent === SPELLS.EARTHEN_SHIELD_TOTEM_TALENT.id,
         castEfficiency: {
           suggestion: true,
@@ -148,6 +148,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.UNLEASH_LIFE_TALENT,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 15,
+        timelineSortIndex: 20,
         enabled: combatant.lv15Talent === SPELLS.UNLEASH_LIFE_TALENT.id,
         castEfficiency: {
           suggestion: true,
@@ -204,7 +205,7 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.HEALING_WAVE,
-        name: `Filler ${SPELLS.HEALING_WAVE.name}`,
+        timelineSortIndex: 41,
         category: Abilities.SPELL_CATEGORIES.OTHERS,
         castEfficiency: {
           casts: castCount => (castCount.casts || 0) - (castCount.healingTwHits || 0),
@@ -212,7 +213,8 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.HEALING_WAVE,
-        name: `Tidal Waves ${SPELLS.HEALING_WAVE.name}`,
+        name: `Tidal Waved ${SPELLS.HEALING_WAVE.name}`,
+        timelineSortIndex: 42,
         category: Abilities.SPELL_CATEGORIES.OTHERS,
         castEfficiency: {
           casts: castCount => castCount.healingTwHits || 0,
@@ -220,7 +222,7 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.HEALING_SURGE_RESTORATION,
-        name: `Filler ${SPELLS.HEALING_SURGE_RESTORATION.name}`,
+        timelineSortIndex: 43,
         category: Abilities.SPELL_CATEGORIES.OTHERS,
         castEfficiency: {
           casts: castCount => (castCount.casts || 0) - (castCount.healingTwHits || 0),
@@ -228,7 +230,8 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.HEALING_SURGE_RESTORATION,
-        name: `Tidal Waves ${SPELLS.HEALING_SURGE_RESTORATION.name}`,
+        name: `Tidal Waved ${SPELLS.HEALING_SURGE_RESTORATION.name}`,
+        timelineSortIndex: 44,
         category: Abilities.SPELL_CATEGORIES.OTHERS,
         castEfficiency: {
           casts: castCount => castCount.healingTwHits || 0,
@@ -237,11 +240,13 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.CHAIN_HEAL,
         category: Abilities.SPELL_CATEGORIES.OTHERS,
+        timelineSortIndex: 40,
         isOnGCD: true,
       },
       {
         spell: SPELLS.PURIFY_SPIRIT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
+        timelineSortIndex: 80,
         // Need to check if it actually dispelled something before we can give it a cooldown
         // cooldown: 8,
         isOnGCD: true,
@@ -249,6 +254,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.FLAME_SHOCK_RESTORATION,
         category: Abilities.SPELL_CATEGORIES.HEALER_DAMAGING_SPELL,
+        timelineSortIndex: 60,
         cooldown: 6,
         isOnGCD: true,
       },
@@ -256,6 +262,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.LAVA_BURST,
         category: Abilities.SPELL_CATEGORIES.HEALER_DAMAGING_SPELL,
         charges: combatant.hasTalent(SPELLS.ECHO_OF_THE_ELEMENTS_TALENT.id) || combatant.hasFinger(ITEMS.SOUL_OF_THE_FARSEER.id) ? 2 : 1,
+        timelineSortIndex: 60,
         cooldown: 8,
         isOnGCD: true,
       },
@@ -263,6 +270,96 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.LIGHTNING_BOLT_RESTORATION,
         category: Abilities.SPELL_CATEGORIES.HEALER_DAMAGING_SPELL,
         isOnGCD: true,
+        timelineSortIndex: 60,
+      },
+      {
+        spell: SPELLS.GHOST_WOLF,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        timelineSortIndex: 80,
+        isOnGCD: true,
+      },
+      {
+        spell: SPELLS.SPIRITWALKERS_GRACE,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: combatant.hasTalent(SPELLS.GRACEFUL_SPIRIT_TALENT.id) ? 60 : 120,
+        timelineSortIndex: 81,
+      },
+      {
+        spell: SPELLS.EARTHBIND_TOTEM,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        timelineSortIndex: 80,
+        isOnGCD: true,
+        cooldown: 30,
+      },
+      {
+        spell: SPELLS.PURGE,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        timelineSortIndex: 80,
+        isOnGCD: true,
+      },
+      {
+        spell: SPELLS.GUST_OF_WIND_TALENT,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        timelineSortIndex: 81,
+        isOnGCD: true,
+        enabled: combatant.hasTalent(SPELLS.GUST_OF_WIND_TALENT.id),
+        cooldown: 15,
+      },
+      {
+        spell: SPELLS.LIGHTNING_SURGE_TOTEM_TALENT,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        timelineSortIndex: 80,
+        isOnGCD: true,
+        enabled: combatant.hasTalent(SPELLS.LIGHTNING_SURGE_TOTEM_TALENT.id),
+        cooldown: 45,
+      },
+      {
+        spell: SPELLS.VOODOO_TOTEM_TALENT,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        timelineSortIndex: 80,
+        isOnGCD: true,
+        enabled: combatant.hasTalent(SPELLS.VOODOO_TOTEM_TALENT.id),
+        cooldown: 30,
+      },
+      {
+        spell: SPELLS.WIND_RUSH_TOTEM_TALENT,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        timelineSortIndex: 80,
+        isOnGCD: true,
+        enabled: combatant.hasTalent(SPELLS.WIND_RUSH_TOTEM_TALENT.id),
+        cooldown: 120,
+      }, 
+      {
+        spell: SPELLS.EARTHGRAB_TOTEM_TALENT,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        timelineSortIndex: 80,
+        isOnGCD: true,
+        enabled: combatant.hasTalent(SPELLS.EARTHGRAB_TOTEM_TALENT.id),
+        cooldown: 30,
+      }, 
+      {
+        spell: SPELLS.ANCESTRAL_PROTECTION_TOTEM_TALENT,
+        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
+        isOnGCD: true,
+        enabled: combatant.hasTalent(SPELLS.ANCESTRAL_PROTECTION_TOTEM_TALENT.id),
+        cooldown: 300,
+      },
+      {
+        spell: SPELLS.REINCARNATION,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: combatant.traitsBySpellId[SPELLS.SERVANT_OF_THE_QUEEN.id] ? 1200 : 1800,
+      },
+      {
+        spell: SPELLS.WIND_SHEAR, 
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        timelineSortIndex: 80,
+        cooldown: 12,
+      },
+      {
+        spell: [SPELLS.HEX, SPELLS.HEX_RAPTOR, SPELLS.HEX_SNAKE, SPELLS.HEX_SPIDER, SPELLS.HEX_COCKROACH, SPELLS.HEX_SKELETAL],
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        timelineSortIndex: 80,
+        cooldown: 30,
       },
     ];
   }

--- a/src/Parser/Shaman/Restoration/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/AlwaysBeCasting.js
@@ -25,24 +25,29 @@ class AlwaysBeCasting extends CoreAlwaysBeCastingHealing {
   static HEALING_ABILITIES_ON_GCD = HEALING_ABILITIES_ON_GCD;
   static ABILITIES_ON_GCD = [
     ...HEALING_ABILITIES_ON_GCD,
-    192063, // Gust of Wind
-    192077, // Wind Rush Totem
-    192058, // Lightning Surge Totem
-    51485, // Earthgrab totem
-    196932, // Voodoo totem
-    207399, // APT
-    403, // Lightning Bolt
-    188838, // Flame shock
-    2484, // Earthbind totem
-    51505, // Lava Burst
-    6196, // Far sight
-    2645, // Ghost wolf
-    77130, // Purify spirit
-    421, // Chain lightning
-    546, // water walking
-    211004, 51514, 211010, 210873, 211015, // Variants of hex
-    556, // Astral recall
-    370, // purge
+    SPELLS.GUST_OF_WIND_TALENT.id,
+    SPELLS.WIND_RUSH_TOTEM_TALENT.id,
+    SPELLS.LIGHTNING_SURGE_TOTEM_TALENT.id,
+    SPELLS.EARTHGRAB_TOTEM_TALENT.id,
+    SPELLS.VOODOO_TOTEM_TALENT.id,
+    SPELLS.ANCESTRAL_PROTECTION_TOTEM_TALENT.id,
+    SPELLS.LIGHTNING_BOLT_RESTORATION.id,
+    SPELLS.FLAME_SHOCK_RESTORATION.id,
+    SPELLS.EARTHBIND_TOTEM.id,
+    SPELLS.LAVA_BURST.id,
+    SPELLS.FAR_SIGHT.id,
+    SPELLS.GHOST_WOLF.id,
+    SPELLS.PURIFY_SPIRIT.id,
+    SPELLS.CHAIN_LIGHTNING.id,
+    SPELLS.WATER_WALKING.id,
+    SPELLS.HEX.id,
+    SPELLS.HEX_RAPTOR.id,
+    SPELLS.HEX_SPIDER.id,
+    SPELLS.HEX_COCKROACH.id,
+    SPELLS.HEX_SNAKE.id,
+    SPELLS.HEX_SKELETAL.id,
+    SPELLS.ASTRAL_RECALL.id,
+    SPELLS.PURGE.id,
   ];
 
   static STATIC_GCD_ABILITIES = {

--- a/src/Parser/Shaman/Restoration/Modules/Features/CastBehavior.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/CastBehavior.js
@@ -20,8 +20,6 @@ class CastBehavior extends Analyzer {
     abilityTracker: AbilityTracker,
   };
 
-
-
   legend(items, total) {
     const numItems = items.length;
     return items.map(({ color, label, tooltip, value, spellId }, index) => {
@@ -124,7 +122,7 @@ class CastBehavior extends Analyzer {
       },
       {
         color: '#CC3D20',
-        label: 'Wasted Tidal Waves',
+        label: 'Unused Tidal Waves',
         tooltip: `The amount of Tidal Waves you did not use out of the total available. You cast ${riptideCasts} Riptides and ${chainHealCasts} Chain Heals which gave you ${totalTwGenerated} Tidal Waves charges, of which you used ${totalTwUsed}.`,
         value: unusedTw,
       },

--- a/src/Parser/Shaman/Restoration/Modules/Features/CastBehavior.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/CastBehavior.js
@@ -1,41 +1,209 @@
 import React from 'react';
+import { Doughnut as DoughnutChart } from 'react-chartjs-2';
 
-import SpellIcon from 'common/SpellIcon';
 import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import { formatPercentage } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
-
 import Combatants from 'Parser/Core/Modules/Combatants';
 import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
 
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import StatisticsListBox, { STATISTIC_ORDER } from 'Main/StatisticsListBox';
 
-class TidalWaves extends Analyzer {
+
+const CHART_SIZE = 75;
+
+class CastBehavior extends Analyzer {
   static dependencies = {
-    abilityTracker: AbilityTracker,
     combatants: Combatants,
+    abilityTracker: AbilityTracker,
   };
 
-  statistic() {
+
+
+  legend(items, total) {
+    const numItems = items.length;
+    return items.map(({ color, label, tooltip, value, spellId }, index) => {
+      label = tooltip ? (
+        <dfn data-tip={tooltip}>{label}</dfn>
+      ) : label;
+      label = spellId ? (
+        <SpellLink id={spellId}>{label}</SpellLink>
+      ) : label;
+      return (
+        <div
+          className="flex"
+          style={{
+            borderBottom: '3px solid rgba(255,255,255,0.1)',
+            marginBottom: ((numItems - 1) === index) ? 0 : 5,
+          }}
+          key={index}
+        >
+          <div className="flex-sub">
+            <div
+              style={{
+                display: 'inline-block',
+                background: color,
+                borderRadius: '50%',
+                width: 16,
+                height: 16,
+                marginBottom: -3,
+              }}
+            />
+          </div>
+          <div className="flex-main" style={{ paddingLeft: 5 }}>
+            {label}
+          </div>
+          <div className="flex-sub">
+            <dfn data-tip={value}>
+              {formatPercentage(value / total, 0)}%
+            </dfn>
+          </div>
+        </div>
+      );
+    });
+  }
+  chart(items) {
+    return (
+      <DoughnutChart
+        data={{
+          datasets: [{
+            data: items.map(item => item.value),
+            backgroundColor: items.map(item => item.color),
+            borderColor: '#666',
+            borderWidth: 1.5,
+          }],
+          labels: items.map(item => item.label),
+        }}
+        options={{
+          legend: {
+            display: false,
+          },
+          tooltips: {
+            bodyFontSize: 8,
+          },
+          cutoutPercentage: 45,
+          animation: false,
+          responsive: false,
+        }}
+        width={CHART_SIZE}
+        height={CHART_SIZE}
+      />
+    );
+  }
+
+  twUsageRatioChart() {
+    const riptide = this.abilityTracker.getAbility(SPELLS.RIPTIDE.id);
+    const healingWave = this.abilityTracker.getAbility(SPELLS.HEALING_WAVE.id);
+    const healingSurge = this.abilityTracker.getAbility(SPELLS.HEALING_SURGE_RESTORATION.id);
+    const chainHeal = this.abilityTracker.getAbility(SPELLS.CHAIN_HEAL.id);
+
+    const chainHealCasts = chainHeal.casts || 0;
+    const riptideCasts = riptide.casts || 0;
+    const twPerRiptide = this.combatants.selected.hasTalent(SPELLS.CRASHING_WAVES_TALENT.id) ? 2 : 1;
+    const totalTwGenerated = twPerRiptide * riptideCasts + chainHealCasts;
+    const twHealingWaves = healingWave.healingTwHits || 0;
+    const twHealingSurges = healingSurge.healingTwHits || 0;
+
+    const totalTwUsed = twHealingWaves + twHealingSurges;
+    const unusedTw = totalTwGenerated - totalTwUsed;
+
+    const items = [
+      {
+        color: '#009688',
+        label: 'Healing Wave',
+        spellId: SPELLS.HEALING_WAVE.id,
+        value: twHealingWaves,
+      },
+      {
+        color: '#ecd1b6',
+        label: 'Healing Surge',
+        spellId: SPELLS.HEALING_SURGE_RESTORATION.id,
+        value: twHealingSurges,
+      },
+      {
+        color: '#f44336',
+        label: 'Wasted Tidal Waves',
+        tooltip: `The amount of Tidal Waves you did not use out of the total available. You cast ${riptideCasts} Riptides and ${chainHealCasts} Chain Heals which gave you ${totalTwGenerated} Tidal Waves charges, of which you used ${totalTwUsed}.`,
+        value: unusedTw,
+      },
+    ];
+
+    return (
+      <div className="flex">
+        <div className="flex-sub" style={{ paddingRight: 12 }}>
+          {this.chart(items)}
+        </div>
+        <div className="flex-main" style={{ fontSize: '80%', paddingTop: 3 }}>
+          {this.legend(items, totalTwGenerated)}
+        </div>
+      </div>
+    );
+  }
+
+  fillerCastRatioChart() {
     const healingWave = this.abilityTracker.getAbility(SPELLS.HEALING_WAVE.id);
     const healingSurge = this.abilityTracker.getAbility(SPELLS.HEALING_SURGE_RESTORATION.id);
     const twHealingWaves = healingWave.healingTwHits || 0;
     const twHealingSurges = healingSurge.healingTwHits || 0;
 
+    const healingWaveHeals = healingWave.casts || 0;
+    const healingSurgeHeals = healingSurge.casts || 0;
+    const fillerHealingWaves = healingWaveHeals - twHealingWaves;
+    const fillerHealingSurges = healingSurgeHeals - twHealingSurges;
+    const totalFillers = fillerHealingWaves + fillerHealingSurges;
+
+    const items = [
+      {
+        color: '#009688',
+        label: 'Healing Wave',
+        spellId: SPELLS.HEALING_WAVE.id,
+        value: fillerHealingWaves,
+      },
+      {
+        color: '#ecd1b6',
+        label: 'Healing Surge',
+        spellId: SPELLS.HEALING_SURGE_RESTORATION.id,
+        value: fillerHealingSurges,
+      },
+    ];
+
     return (
-          <StatisticBox
-            icon={<SpellIcon id={SPELLS.TIDAL_WAVES_BUFF.id} />}
-            value={`${twHealingWaves} : ${twHealingSurges}`}
-            label={(
-              <dfn data-tip={`The Tidal Waves Healing Wave to Healing Surge usage ratio is how many Healing Waves you cast compared to Healing Surges during the Tidal Waves proc. You cast ${twHealingWaves} Healing Waves and ${twHealingSurges} Healing Surges during Tidal Waves.`}>
-                TW HW : TW HS cast ratio
-              </dfn>
-            )}
-          />
+      <div className="flex">
+        <div className="flex-sub" style={{ paddingRight: 12 }}>
+          {this.chart(items)}
+        </div>
+        <div className="flex-main" style={{ fontSize: '80%', paddingTop: 3 }}>
+          {this.legend(items, totalFillers)}
+        </div>
+      </div>
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(70);
+
+  statistic() {
+    return (
+      <div className="col-lg-3 col-md-4 col-sm-6 col-xs-12">
+        <div className="row">
+          <StatisticsListBox
+            title={<span><SpellLink id={SPELLS.TIDAL_WAVES_BUFF.id}/> usage</span>}
+            containerProps={{ className: 'col-xs-12' }}
+          >
+            {this.twUsageRatioChart()}
+          </StatisticsListBox>
+        </div>
+        <div className="row">
+          <StatisticsListBox
+            title="Fillers"
+            containerProps={{ className: 'col-xs-12' }}
+          >
+            {this.fillerCastRatioChart()}
+          </StatisticsListBox>
+        </div>
+      </div>
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(40);
 }
 
-export default TidalWaves;
-
+export default CastBehavior;

--- a/src/Parser/Shaman/Restoration/Modules/Features/CastBehavior.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/CastBehavior.js
@@ -111,19 +111,19 @@ class CastBehavior extends Analyzer {
 
     const items = [
       {
-        color: '#009688',
+        color: '#2055CC',
         label: 'Healing Wave',
         spellId: SPELLS.HEALING_WAVE.id,
         value: twHealingWaves,
       },
       {
-        color: '#ecd1b6',
+        color: '#42E0FF',
         label: 'Healing Surge',
         spellId: SPELLS.HEALING_SURGE_RESTORATION.id,
         value: twHealingSurges,
       },
       {
-        color: '#f44336',
+        color: '#CC3D20',
         label: 'Wasted Tidal Waves',
         tooltip: `The amount of Tidal Waves you did not use out of the total available. You cast ${riptideCasts} Riptides and ${chainHealCasts} Chain Heals which gave you ${totalTwGenerated} Tidal Waves charges, of which you used ${totalTwUsed}.`,
         value: unusedTw,
@@ -156,13 +156,13 @@ class CastBehavior extends Analyzer {
 
     const items = [
       {
-        color: '#009688',
+        color: '#2055CC',
         label: 'Healing Wave',
         spellId: SPELLS.HEALING_WAVE.id,
         value: fillerHealingWaves,
       },
       {
-        color: '#ecd1b6',
+        color: '#42E0FF',
         label: 'Healing Surge',
         spellId: SPELLS.HEALING_SURGE_RESTORATION.id,
         value: fillerHealingSurges,

--- a/src/Parser/Shaman/Restoration/Modules/Features/TidalWaves.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/TidalWaves.js
@@ -9,10 +9,6 @@ import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
 
-import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
-
-import UnusedTidalWavesImage from '../../Images/spell_shaman_tidalwaves-bw.jpg';
-
 class TidalWaves extends Analyzer {
   static dependencies = {
     abilityTracker: AbilityTracker,
@@ -58,43 +54,6 @@ class TidalWaves extends Analyzer {
       style: 'percentage',
     };
   }
-
-  statistic() {
-    const riptide = this.abilityTracker.getAbility(SPELLS.RIPTIDE.id);
-    const healingWave = this.abilityTracker.getAbility(SPELLS.HEALING_WAVE.id);
-    const healingSurge = this.abilityTracker.getAbility(SPELLS.HEALING_SURGE_RESTORATION.id);
-    const chainHeal = this.abilityTracker.getAbility(SPELLS.CHAIN_HEAL.id);
-
-    const chainHealCasts = chainHeal.casts || 0;
-    const riptideCasts = riptide.casts || 0;
-    const twPerRiptide = this.combatants.selected.hasTalent(SPELLS.CRASHING_WAVES_TALENT.id) ? 2 : 1;
-    const totalTwGenerated = twPerRiptide * riptideCasts + chainHealCasts;
-    const twHealingWaves = healingWave.healingTwHits || 0;
-    const twHealingSurges = healingSurge.healingTwHits || 0;
-
-    const totalTwUsed = twHealingWaves + twHealingSurges;
-    const unusedTwRate = 1 - totalTwUsed / totalTwGenerated;
-
-    return (
-      <StatisticBox
-        icon={(
-          <SpellLink id={SPELLS.TIDAL_WAVES_BUFF.id}>
-            <img
-              src={UnusedTidalWavesImage}
-              alt="Unused Tidal Waves"
-            />
-          </SpellLink>
-        )}
-        value={`${formatPercentage(unusedTwRate)} %`}
-        label={(
-          <dfn data-tip={`The amount of Tidal Waves charges you did not use out of the total available. You cast ${riptideCasts} Riptides and ${chainHealCasts} Chain Heals which gave you ${totalTwGenerated} Tidal Waves charges, of which you used ${totalTwUsed}.<br /><br />The ratio may be below zero if you started the fight with Tidal Waves charges.`}>
-            Unused Tidal Waves
-          </dfn>
-        )}
-      />
-    );
-  }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(70);
 }
 
 export default TidalWaves;

--- a/src/common/SPELLS/SHAMAN.js
+++ b/src/common/SPELLS/SHAMAN.js
@@ -25,6 +25,57 @@ export default {
     name: 'Earthbind Totem',
     icon: 'spell_nature_strengthofearthtotem02', 
   },
+  PURGE: {
+    id: 370,
+    name: 'Purge',
+    icon: 'spell_nature_purge', 
+  },
+  FAR_SIGHT: {
+    id: 6196,
+    name: 'Far Sight',
+    icon: 'spell_nature_farsight', 
+  },
+  WATER_WALKING: {
+    id: 546,
+    name: 'Water Walking',
+    icon: 'spell_frost_windwalkon', 
+  },
+  ASTRAL_RECALL: {
+    id: 556,
+    name: 'Astral Recall',
+    icon: 'spell_nature_astralrecal', 
+  },
+  // Hex and its variations
+  HEX: {
+    id: 51514,
+    name: 'Hex',
+    icon: 'spell_shaman_hex', 
+  },
+  HEX_RAPTOR: {
+    id: 210873,
+    name: 'Hex',
+    icon: 'ability_hunter_pet_raptor', 
+  },
+  HEX_SPIDER: {
+    id: 211004,
+    name: 'Hex',
+    icon: 'ability_hunter_pet_spider', 
+  },
+  HEX_SNAKE: {
+    id: 211010,
+    name: 'Hex',
+    icon: 'inv_pet_pythonblack', 
+  },
+  HEX_COCKROACH: {
+    id: 211015,
+    name: 'Hex',
+    icon: 'inv_pet_cockroach', 
+  },
+  HEX_SKELETAL: {
+    id: 269352,
+    name: 'Hex',
+    icon: 'ability_mount_fossilizedraptor', 
+  },
   //Eye of the Twisting Nether Buffs
   SHOCK_OF_THE_TWISTING_NETHER: {
     id: 207999,
@@ -570,7 +621,7 @@ export default {
   },
   HEALING_WAVE: {
     id: 77472,
-    name: 'Healing Waves',
+    name: 'Healing Wave',
     icon: 'spell_nature_healingwavelesser',
     manaCost: 19800,
   },
@@ -759,6 +810,11 @@ export default {
     id: 207356,
     name: 'Refreshing Currents',
     icon: 'ability_monk_cracklingjadelightning',
+  },
+  SERVANT_OF_THE_QUEEN: {
+    id: 207357,
+    name: 'Servant of the Queen',
+    icon: 'inv_crown_02',
   },
   // Restoration Shaman Set Bonus:
   RAINFALL: { // T21 2pc


### PR DESCRIPTION
Removed 
![image](https://user-images.githubusercontent.com/2842471/37869200-c9f6798a-2fb3-11e8-909b-912c142d2366.png) 
in favour of this style
![image](https://user-images.githubusercontent.com/2842471/37869349-51750d84-2fb6-11e8-9739-b89ff1a19aa9.png)

Added a bunch of abilities and ordered the timeline to group similar spells together.
![image](https://user-images.githubusercontent.com/2842471/37869265-d42c98fc-2fb4-11e8-8034-7a6906ffecab.png)
->
![image](https://user-images.githubusercontent.com/2842471/37869270-dc73820a-2fb4-11e8-9a6e-b47937270296.png)
