### PR TITLE
[Guardian Druid] Highlight bad filler casts.

### DIFF
--- a/src/Parser/Druid/Guardian/CHANGELOG.js
+++ b/src/Parser/Druid/Guardian/CHANGELOG.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { faide, WOPR } from 'CONTRIBUTORS';
+import { faide, WOPR, Gebuz } from 'CONTRIBUTORS';
 import Wrapper from 'common/Wrapper';
 import ItemLink from 'common/ItemLink';
 import ITEMS from 'common/ITEMS';
@@ -8,6 +8,11 @@ import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 
 export default [
+  { 
+    date: new Date('2018-03-26'),
+    changes: 'Highlight bad filler casts on the timeline.',
+    contributors: [Gebuz],
+  },
   { 
     date: new Date('2017-08-29'),
     changes: <Wrapper>Added <ItemLink id={ITEMS.FURY_OF_NATURE.id} icon /> and <ItemLink id={ITEMS.LUFFA_WRAPPINGS.id} icon /> statistics.</Wrapper>,

--- a/src/Parser/Druid/Guardian/Modules/Abilities.js
+++ b/src/Parser/Druid/Guardian/Modules/Abilities.js
@@ -42,14 +42,25 @@ class Abilities extends CoreAbilities {
           averageIssueEfficiency: 0.6,
           majorIssueEfficiency: 0.5,
         },
+        timelineSortIndex: 1,
       },
       {
-        spell: SPELLS.SWIPE_BEAR,
+        spell: SPELLS.THRASH_BEAR,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        cooldown: (haste, selectedCombatant) => {
+          if (selectedCombatant.hasBuff(SPELLS.INCARNATION_GUARDIAN_OF_URSOC_TALENT.id)) {
+            return null;
+          }
+          return hastedCooldown(6, haste);
+        },
         isOnGCD: true,
         antiFillerSpam: {
-          isFiller: (event, selectedCombatant, targets) => targets.length < 4,
+          isHighPriority: true,
         },
+        castEfficiency: {
+          suggestion: true,
+        },
+        timelineSortIndex: 2,
       },
       {
         spell: SPELLS.MOONFIRE,
@@ -75,28 +86,22 @@ class Abilities extends CoreAbilities {
             return selectedCombatant.hasBuff(SPELLS.GALACTIC_GUARDIAN.id, timestamp - REACTION_TIME_THRESHOLD);
           },
         },
+        timelineSortIndex: 3,
       },
       {
-        spell: SPELLS.THRASH_BEAR,
+        spell: SPELLS.SWIPE_BEAR,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        cooldown: (haste, selectedCombatant) => {
-          if (selectedCombatant.hasBuff(SPELLS.INCARNATION_GUARDIAN_OF_URSOC_TALENT.id)) {
-            return null;
-          }
-          return hastedCooldown(6, haste);
-        },
         isOnGCD: true,
         antiFillerSpam: {
-          isHighPriority: true,
+          isFiller: (event, selectedCombatant, targets) => targets.length < 4,
         },
-        castEfficiency: {
-          suggestion: true,
-        },
+        timelineSortIndex: 4,
       },
       {
         spell: SPELLS.MAUL,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         isOnGCD: true,
+        timelineSortIndex: 5,
       },
       // Cooldowns
       {
@@ -107,6 +112,7 @@ class Abilities extends CoreAbilities {
           const cdTrait = combatant.traitsBySpellId[SPELLS.PERPETUAL_SPRING_TRAIT.id] || 0;
           return baseCd * (1 - (cdTrait * 3 / 100));
         },
+        timelineSortIndex: 9,
       },
       {
         spell: SPELLS.SURVIVAL_INSTINCTS,
@@ -118,6 +124,7 @@ class Abilities extends CoreAbilities {
         },
         charges: 3,
         enabled: combatant.hasFinger(ITEMS.DUAL_DETERMINATION.id),
+        timelineSortIndex: 9,
       },
       {
         spell: SPELLS.SURVIVAL_INSTINCTS,
@@ -129,39 +136,46 @@ class Abilities extends CoreAbilities {
         },
         charges: 2,
         enabled: !combatant.hasFinger(ITEMS.DUAL_DETERMINATION.id),
+        timelineSortIndex: 9,
       },
       {
         spell: SPELLS.INCARNATION_GUARDIAN_OF_URSOC_TALENT,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 180,
         enabled: combatant.hasTalent(SPELLS.INCARNATION_GUARDIAN_OF_URSOC_TALENT.id),
+        timelineSortIndex: 9,
       },
       {
         spell: SPELLS.BRISTLING_FUR_TALENT,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 40,
         enabled: combatant.hasTalent(SPELLS.BRISTLING_FUR_TALENT.id),
+        timelineSortIndex: 9,
       },
       {
         spell: SPELLS.IRONFUR,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
+        timelineSortIndex: 7,
       },
       {
         spell: SPELLS.RAGE_OF_THE_SLEEPER,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 90,
+        timelineSortIndex: 9,
       },
       {
         spell: SPELLS.FRENZIED_REGENERATION,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         charges: 2,
         enabled: !combatant.traitsBySpellId[SPELLS.FLESHKNITTING_TRAIT],
+        timelineSortIndex: 8,
       },
       {
         spell: SPELLS.FRENZIED_REGENERATION,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         charges: 3,
         enabled: combatant.traitsBySpellId[SPELLS.FLESHKNITTING_TRAIT],
+        timelineSortIndex: 8,
       },
       {
         spell: SPELLS.PULVERIZE_TALENT,
@@ -180,6 +194,7 @@ class Abilities extends CoreAbilities {
             return pulverizeTalented && targetHasThrashStacks;
           },
         },
+        timelineSortIndex: 6,
       },
       // Raid utility
       {

--- a/src/Parser/Druid/Guardian/Modules/Abilities.js
+++ b/src/Parser/Druid/Guardian/Modules/Abilities.js
@@ -37,6 +37,7 @@ class Abilities extends CoreAbilities {
           isHighPriority: true,
         },
         castEfficiency: {
+          suggestion: true,
           recommendedEfficiency: 0.7,
           averageIssueEfficiency: 0.6,
           majorIssueEfficiency: 0.5,

--- a/src/Parser/Druid/Guardian/Modules/Ability.js
+++ b/src/Parser/Druid/Guardian/Modules/Ability.js
@@ -10,7 +10,7 @@ class Ability extends CoreAbility {
         PropTypes.func,
         PropTypes.number,
       ]),
-      condition: PropTypes.oneOfType([
+      isHighPriority: PropTypes.oneOfType([
         PropTypes.func,
         PropTypes.number,
       ]),


### PR DESCRIPTION
I slightly rewrote it to use two different props for isFiller and "Should be prioritized over a filler" (isHighPriority) since there are situations where it might be okay to cast either moonfire or swipe (for instance even with 4> targets you might want to cast moonfire for ST dps).

I also reduced the suggestionThreshold for Mangle to account for resets until we implement a way to account for the GCD after the proc. It was basically always a major issue unless you had terrible procs.

![image](https://user-images.githubusercontent.com/6773230/37899536-19370a30-30ec-11e8-95a4-4c120870621f.png)
