### PR TITLE
[Tanks] Antorus Trinkets

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -9,6 +9,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-03-26'),
+    changes: <Wrapper>Added <ItemLink id={ITEMS.SMOLDERING_TITANGUARD.id} icon />, <ItemLink id={ITEMS.DIIMAS_GLACIAL_AEGIS.id} icon /> and  <ItemLink id={ITEMS.RIFTWORLD_CODEX.id} icon />.</Wrapper>,
+    contributors: [joshinator],
+  },
+  {
     date: new Date('2018-03-24'),
     changes: 'Added statistics for talents, legendaries and trinkets based on the current encounter.',
     contributors: [joshinator],

--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -108,6 +108,9 @@ import AcridCatalystInjector from './Modules/Items/Legion/AntorusTheBurningThron
 import ShadowSingedFang from './Modules/Items/Legion/AntorusTheBurningThrone/ShadowSingedFang';
 // Tanking
 import AggramarsConviction from './Modules/Items/Legion/AntorusTheBurningThrone/AggramarsConviction';
+import SmolderingTitanguard from './Modules/Items/Legion/AntorusTheBurningThrone/SmolderingTitanguard';
+import DiimasGlacialAegis from './Modules/Items/Legion/AntorusTheBurningThrone/DiimasGlacialAegis';
+import RiftworldCodex from './Modules/Items/Legion/AntorusTheBurningThrone/RiftworldCodex';
 
 // Shared Buffs
 import Concordance from './Modules/Spells/Concordance';
@@ -239,6 +242,9 @@ class CombatLogParser {
 
     // T21 Tanking Trinkets
     aggramarsConviction: AggramarsConviction,
+    smolderingTitanguard: SmolderingTitanguard,
+    diimasGlacialAegis: DiimasGlacialAegis,
+    riftworldCodex: RiftworldCodex,
 
     // Concordance of the Legionfall
     concordance: Concordance,

--- a/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/DiimasGlacialAegis.js
+++ b/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/DiimasGlacialAegis.js
@@ -1,0 +1,77 @@
+import React from 'react';
+
+import ITEMS from 'common/ITEMS';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import Analyzer from 'Parser/Core/Analyzer';
+import Wrapper from 'common/Wrapper';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import { formatPercentage } from 'common/format';
+import Abilities from 'Parser/Core/Modules/Abilities';
+import ItemDamageDone from 'Main/ItemDamageDone';
+
+/**
+ * Diima's Glacial Aegis
+ * Use: grants x armor and deals AoE frost damage + slow
+*/
+class DiimasGlacialAegis extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    abilities: Abilities,
+  };
+
+  damage = 0;
+  casts = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTrinket(ITEMS.DIIMAS_GLACIAL_AEGIS.id);
+
+    if (this.active) {
+      this.abilities.add({
+        spell: SPELLS.CHILLING_NOVA,
+        name: ITEMS.DIIMAS_GLACIAL_AEGIS.name,
+        category: Abilities.SPELL_CATEGORIES.ITEMS,
+        cooldown: 60,
+        castEfficiency: {
+          suggestion: true,
+        },
+      });
+    }
+  }
+
+  on_byPlayer_damage(event) {
+    if (event.ability.guid !== SPELLS.CHILLING_NOVA.id) {
+      return;
+    }
+
+    this.damage += event.amount + event.absorbed;
+  }
+
+  on_byPlayer_cast(event) {
+    if (event.ability.guid !== SPELLS.CHILLING_NOVA.id) {
+      return;
+    }
+
+    this.casts += 1;
+  }
+
+  get uptime() {
+    return this.combatants.selected.getBuffUptime(SPELLS.FROZEN_ARMOR.id) / this.owner.fightDuration;
+  }
+
+  item() {
+    return {
+      item: ITEMS.DIIMAS_GLACIAL_AEGIS,
+      result: (
+        <Wrapper>
+          <dfn data-tip={`You casted "${SPELLS.CHILLING_NOVA.name}" ${this.casts} times`}>
+            {formatPercentage(this.uptime)}% uptime on <SpellLink id={SPELLS.FROZEN_ARMOR.id} />
+          </dfn><br/>
+          <ItemDamageDone amount={this.damage} />
+        </Wrapper>
+      ),
+    };
+  }
+}
+
+export default DiimasGlacialAegis;

--- a/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/DiimasGlacialAegis.js
+++ b/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/DiimasGlacialAegis.js
@@ -7,6 +7,7 @@ import Analyzer from 'Parser/Core/Analyzer';
 import Wrapper from 'common/Wrapper';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import { formatPercentage } from 'common/format';
+import { calculateSecondaryStatDefault } from 'common/stats';
 import Abilities from 'Parser/Core/Modules/Abilities';
 import ItemDamageDone from 'Main/ItemDamageDone';
 
@@ -22,11 +23,14 @@ class DiimasGlacialAegis extends Analyzer {
 
   damage = 0;
   casts = 0;
+  armorbuff = 0;
 
   on_initialized() {
     this.active = this.combatants.selected.hasTrinket(ITEMS.DIIMAS_GLACIAL_AEGIS.id);
 
     if (this.active) {
+      this.armorbuff = calculateSecondaryStatDefault(930, 4045, this.combatants.selected.getItem(ITEMS.DIIMAS_GLACIAL_AEGIS.id).itemLevel);
+
       this.abilities.add({
         spell: SPELLS.CHILLING_NOVA,
         name: ITEMS.DIIMAS_GLACIAL_AEGIS.name,
@@ -64,8 +68,8 @@ class DiimasGlacialAegis extends Analyzer {
       item: ITEMS.DIIMAS_GLACIAL_AEGIS,
       result: (
         <Wrapper>
-          <dfn data-tip={`You casted "${SPELLS.CHILLING_NOVA.name}" ${this.casts} times`}>
-            {formatPercentage(this.uptime)}% uptime on <SpellLink id={SPELLS.FROZEN_ARMOR.id} />
+          <dfn data-tip={`You casted "${SPELLS.CHILLING_NOVA.name}" ${this.casts} times for a uptime of ${formatPercentage(this.uptime)}%`}>
+            {(this.uptime * this.armorbuff).toFixed(0)} average Armor from <SpellLink id={SPELLS.FROZEN_ARMOR.id} />
           </dfn><br/>
           <ItemDamageDone amount={this.damage} />
         </Wrapper>

--- a/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/RiftworldCodex.js
+++ b/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/RiftworldCodex.js
@@ -1,0 +1,124 @@
+import React from 'react';
+
+import ITEMS from 'common/ITEMS';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import Analyzer from 'Parser/Core/Analyzer';
+import Wrapper from 'common/Wrapper';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import { formatPercentage } from 'common/format';
+import Abilities from 'Parser/Core/Modules/Abilities';
+import ItemHealingDone from 'Main/ItemHealingDone';
+import ItemDamageDone from 'Main/ItemDamageDone';
+
+/**
+ * Riftworld Codex
+ * Procs stuff
+*/
+class RiftworldCodex extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    abilities: Abilities,
+  };
+
+  hotprocs = 0;
+  absorbprocs = 0;
+  immolationprocs = 0;
+
+  hothealing = 0;
+  hotoverhealing = 0;
+
+  absorbhealing = 0;
+  absorboverhealing = 0;
+
+  immolationhealing = 0;
+  immolationoverhealing = 0;
+  immolationdamage = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTrinket(ITEMS.RIFTWORLD_CODEX.id);
+  }
+
+  countProcs(event) {
+    if (event.ability.guid === SPELLS.WINDS_OF_KARETH.id) {
+      this.hotprocs += 1;
+    }
+
+    if (event.ability.guid === SPELLS.LIGHT_OF_ABSOLARN.id) {
+      this.absorbprocs += 1;
+    }
+    
+    if (event.ability.guid === SPELLS.FLAMES_OF_RUVARAAD.id) {
+      this.immolationprocs += 1;
+    }
+  }
+
+  on_byPlayer_applybuff(event) {
+    if (event.ability.guid === SPELLS.WINDS_OF_KARETH.id || event.ability.guid === SPELLS.LIGHT_OF_ABSOLARN.id || event.ability.guid === SPELLS.FLAMES_OF_RUVARAAD.id) {
+      this.countProcs(event);
+    }
+  }
+
+  on_byPlayer_buffrefresh(event) {
+    if (event.ability.guid === SPELLS.WINDS_OF_KARETH.id || event.ability.guid === SPELLS.LIGHT_OF_ABSOLARN.id || event.ability.guid === SPELLS.FLAMES_OF_RUVARAAD.id) {
+      this.countProcs(event);
+    }
+  }
+
+  on_byPlayer_absorbed(event) {
+    if (event.ability.guid === SPELLS.LIGHT_OF_ABSOLARN.id) {
+      this.absorbhealing += event.amount;
+    }
+  }
+
+  on_byPlayer_removebuff(event) {
+    if (event.ability.guid === SPELLS.LIGHT_OF_ABSOLARN.id) {
+      this.absorboverhealing += event.absorb || 0;
+    }
+  }
+
+  on_byPlayer_heal(event) {
+    if (event.ability.guid === SPELLS.WINDS_OF_KARETH.id) {
+      this.hothealing += event.amount + (event.absorbed || 0);
+      this.hotoverhealing += event.overheal || 0;
+    }
+
+    if (event.ability.guid === SPELLS.FLAMES_OF_RUVARAAD_HEALING.id) {
+      this.immolationhealing += event.amount + (event.absorbed || 0);
+      this.immolationoverhealing += event.overheal || 0;
+    }
+  }
+
+  on_byPlayer_damage(event) {
+    if (event.ability.guid === SPELLS.FLAMES_OF_RUVARAAD_HEALING.id) {
+      this.immolationdamage += event.amount + (event.absorbed || 0);
+    }
+  }
+
+  item() {
+    return {
+      item: ITEMS.RIFTWORLD_CODEX,
+      result: (
+        <Wrapper>
+          <dfn data-tip={`Procced the HoT <b>${this.hotprocs}</b> times and did ${formatPercentage(this.hotoverhealing / (this.hothealing + this.hotoverhealing))}% overhealing`}>
+            <ItemHealingDone amount={this.hothealing} /> from <SpellLink id={SPELLS.WINDS_OF_KARETH.id} />
+          </dfn>
+          <br/>
+          <dfn data-tip={`Procced the absorb buff <b>${this.absorbprocs}</b> times and did ${formatPercentage(this.absorboverhealing / (this.absorbhealing + this.absorboverhealing))}% overhealing`}>
+            <ItemHealingDone amount={this.absorbhealing} /> from <SpellLink id={SPELLS.LIGHT_OF_ABSOLARN.id} />
+          </dfn>
+          <br/>
+          <dfn data-tip={`Procced the aura buff <b>${this.immolationprocs}</b> times`}>
+            <ItemDamageDone amount={this.immolationdamage} /> from <SpellLink id={SPELLS.FLAMES_OF_RUVARAAD.id} />
+          </dfn>
+          <br/>
+          <dfn data-tip={`Procced the aura buff <b>${this.immolationprocs}</b> times and did ${formatPercentage(this.immolationoverhealing / (this.immolationhealing + this.immolationoverhealing))}% overhealing`}>
+            <ItemHealingDone amount={this.immolationhealing} /> from <SpellLink id={SPELLS.FLAMES_OF_RUVARAAD.id} />
+          </dfn>
+        </Wrapper>
+      ),
+    };
+  }
+}
+
+export default RiftworldCodex;

--- a/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/RiftworldCodex.js
+++ b/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/RiftworldCodex.js
@@ -2,7 +2,6 @@ import React from 'react';
 
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
-import SpellLink from 'common/SpellLink';
 import Analyzer from 'Parser/Core/Analyzer';
 import Wrapper from 'common/Wrapper';
 import Combatants from 'Parser/Core/Modules/Combatants';

--- a/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/RiftworldCodex.js
+++ b/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/RiftworldCodex.js
@@ -6,7 +6,7 @@ import SpellLink from 'common/SpellLink';
 import Analyzer from 'Parser/Core/Analyzer';
 import Wrapper from 'common/Wrapper';
 import Combatants from 'Parser/Core/Modules/Combatants';
-import { formatPercentage } from 'common/format';
+import { formatPercentage, formatNumber } from 'common/format';
 import Abilities from 'Parser/Core/Modules/Abilities';
 import ItemHealingDone from 'Main/ItemHealingDone';
 import ItemDamageDone from 'Main/ItemDamageDone';
@@ -95,25 +95,25 @@ class RiftworldCodex extends Analyzer {
     }
   }
 
+  get totalhealing() {
+    return this.hothealing + this.absorbhealing + this.immolationhealing;
+  }
+
   item() {
     return {
       item: ITEMS.RIFTWORLD_CODEX,
       result: (
         <Wrapper>
-          <dfn data-tip={`Procced the HoT <b>${this.hotprocs}</b> times and did ${formatPercentage(this.hotoverhealing / (this.hothealing + this.hotoverhealing))}% overhealing`}>
-            <ItemHealingDone amount={this.hothealing} /> from <SpellLink id={SPELLS.WINDS_OF_KARETH.id} />
-          </dfn>
-          <br/>
-          <dfn data-tip={`Procced the absorb buff <b>${this.absorbprocs}</b> times and did ${formatPercentage(this.absorboverhealing / (this.absorbhealing + this.absorboverhealing))}% overhealing`}>
-            <ItemHealingDone amount={this.absorbhealing} /> from <SpellLink id={SPELLS.LIGHT_OF_ABSOLARN.id} />
-          </dfn>
-          <br/>
-          <dfn data-tip={`Procced the aura buff <b>${this.immolationprocs}</b> times`}>
-            <ItemDamageDone amount={this.immolationdamage} /> from <SpellLink id={SPELLS.FLAMES_OF_RUVARAAD.id} />
-          </dfn>
-          <br/>
-          <dfn data-tip={`Procced the aura buff <b>${this.immolationprocs}</b> times and did ${formatPercentage(this.immolationoverhealing / (this.immolationhealing + this.immolationoverhealing))}% overhealing`}>
-            <ItemHealingDone amount={this.immolationhealing} /> from <SpellLink id={SPELLS.FLAMES_OF_RUVARAAD.id} />
+          <ItemDamageDone amount={this.immolationdamage} /><br/>
+          <dfn data-tip={`
+            All 3 buffs did a total of ${formatNumber(this.totalhealing)} healing
+            <ul>
+              <li>HoT (${this.hotprocs} procs): ${formatNumber(this.hothealing)} healing (${formatPercentage(this.hotoverhealing / (this.hothealing + this.hotoverhealing))}% overhealing)</li>
+              <li>Absorb buff (${this.absorbprocs} procs): ${formatNumber(this.absorbhealing)} healing (${formatPercentage(this.absorboverhealing / (this.absorbhealing + this.absorboverhealing))}% overhealing)</li>
+              <li>Immolation-aura (${this.immolationprocs} procs): ${formatNumber(this.immolationhealing)} healing (${formatPercentage(this.immolationoverhealing / (this.immolationhealing + this.immolationoverhealing))}% overhealing)</li>
+            </ul>
+          `}>
+            <ItemHealingDone amount={this.totalhealing} />
           </dfn>
         </Wrapper>
       ),

--- a/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/SmolderingTitanguard.js
+++ b/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/SmolderingTitanguard.js
@@ -1,0 +1,82 @@
+import React from 'react';
+
+import ITEMS from 'common/ITEMS';
+import SPELLS from 'common/SPELLS';
+import Analyzer from 'Parser/Core/Analyzer';
+import Wrapper from 'common/Wrapper';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import { formatNumber, formatPercentage } from 'common/format';
+import Abilities from 'Parser/Core/Modules/Abilities';
+import ItemDamageDone from 'Main/ItemDamageDone';
+import ItemHealingDone from 'Main/ItemHealingDone';
+
+/**
+ * Smoldering Titanguard
+ * Use: absorb x damage over 3sec and deal fire damage when it expires
+ */
+class SmolderingTitanguard extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    abilities: Abilities,
+  };
+
+  damage = 0;
+  healing = 0;
+  overhealing = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTrinket(ITEMS.SMOLDERING_TITANGUARD.id);
+
+    if (this.active) {
+      this.abilities.add({
+        spell: SPELLS.BULLWARK_OF_FLAME,
+        name: ITEMS.SMOLDERING_TITANGUARD.name,
+        category: Abilities.SPELL_CATEGORIES.ITEMS,
+        cooldown: 120,
+        castEfficiency: {
+          suggestion: true,
+        },
+      });
+    }
+  }
+
+  on_byPlayer_damage(event) {
+    if (event.ability.guid !== SPELLS.WAVE_OF_FLAME.id) {
+      return;
+    }
+
+    this.damage += event.amount + event.absorbed;
+  }
+
+  on_byPlayer_absorbed(event) {
+    if (event.ability.guid !== SPELLS.BULLWARK_OF_FLAME.id) {
+      return;
+    }
+
+    this.healing += event.amount;
+  }
+
+  on_byPlayer_removebuff(event) {
+    if (event.ability.guid !== SPELLS.BULLWARK_OF_FLAME.id) {
+      return;
+    }
+
+    this.overhealing += event.absorb;
+  }
+
+  item() {
+    return {
+      item: ITEMS.SMOLDERING_TITANGUARD,
+      result: (
+        <Wrapper>
+          <ItemDamageDone amount={this.damage} /><br/>
+          <dfn data-tip={`You wasted ${formatPercentage(this.overhealing / (this.overhealing + this.healing))}% (${formatNumber(this.overhealing)}) of the total possible absorb.`}>
+            <ItemHealingDone amount={this.healing} />
+          </dfn>
+        </Wrapper>
+      ),
+    };
+  }
+}
+
+export default SmolderingTitanguard;

--- a/src/common/ITEMS/OTHERS.js
+++ b/src/common/ITEMS/OTHERS.js
@@ -1,8 +1,8 @@
 import ITEM_QUALITIES from '../ITEM_QUALITIES';
 
 export default {
+  //fallback icon for encounter stats
   UNKNOWN_TRINKET: {
-    //fallback icon for encounter stats
     id: 0,
     icon: 'inv_misc_trinket6oih_orb1',
   },
@@ -425,10 +425,26 @@ export default {
     name: 'Shadow-Singed Fang',
     icon: 'inv_misc_blacksaberonfang',
   },
+  //T21 Tank trinkets
   AGGRAMARS_CONVICTION: {
     id: 154173,
     name: 'Aggramar\'s Conviction',
     icon: 'inv_antorus_orange',
+  },
+  SMOLDERING_TITANGUARD: {
+    id: 151978,
+    name: 'Smoldering Titanguard',
+    icon: 'ability_warrior_shieldmastery',
+  },
+  DIIMAS_GLACIAL_AEGIS: {
+    id: 151977,
+    name: 'Diima\'s Glacial Aegis',
+    icon: 'ability_hunter_glacialtrap',
+  },
+  RIFTWORLD_CODEX: {
+    id: 151976,
+    name: 'Riftworld Codex',
+    icon: 'inv_offhand_pvp330_d_02',
   },
   // T19 Trinkets
   CONVERGENCE_OF_FATES: {

--- a/src/common/SPELLS/OTHERS.js
+++ b/src/common/SPELLS/OTHERS.js
@@ -921,6 +921,48 @@ export default {
     name: 'Celestial Bulwark',
     icon: 'inv_antorus_orange',
   },
+  //Smoldering Titanguard
+  BULLWARK_OF_FLAME: { //absorb
+    id: 251946,
+    name: 'Bullwark of Flame',
+    icon: 'ability_warrior_shieldmastery',
+  },
+  WAVE_OF_FLAME: { //damage waves
+    id: 251948,
+    name: 'Wave of Flame',
+    icon: 'ability_warlock_coil2',
+  },
+  // Diima's
+  CHILLING_NOVA: { //AoE damage
+    id: 251940,
+    name: 'Chilling Nova',
+    icon: 'spell_frost_frostward',
+  },
+  FROZEN_ARMOR: {
+    id: 251941,
+    name: 'Frozen Armor',
+    icon : 'ability_hunter_glacialtrap',
+  },
+  // Riftworld Codex
+  WINDS_OF_KARETH: { //6sec HoT
+    id: 251938,
+    name: 'Winds of Kareth',
+    icon: 'spell_nature_regeneration_02',
+  },
+  LIGHT_OF_ABSOLARN: { //Absorb Shield
+    id: 252545,
+    name: 'Light of Absolarn',
+    icon: 'spell_frost_frostarmor02',
+  },
+  FLAMES_OF_RUVARAAD: { //8sec Immolation - Buff
+    id: 256415,
+    name: 'Flames of Ruvaraad',
+    icon: 'spell_fire_ragnaros_supernova',
+  },
+  FLAMES_OF_RUVARAAD_HEALING: {
+    id: 252550,
+    icon: 'spell_fire_ragnaros_supernova',
+  },
   // Antorus: Argus the Unmaker boss fight
   STRENGTH_OF_THE_SEA: { // 2000 Haste/versa buff
     id: 253901,


### PR DESCRIPTION
Adds Antorus Trinkets (fixes #1516).

"Eye of F'harg" is not possible to implement as it appears as [Eye of'](http://www.wowhead.com/item=151974/eye-of&bonus=3610:1472) in the log. 
But the actual versions are [Eye of Shatug](http://www.wowhead.com/item=153544/eye-of-fharg&bonus=3610:1472) and [Eye of F'harg](http://www.wowhead.com/item=153544/eye-of-fharg&bonus=3610:1472), with the on-use to switch between both versions during combat. This makes it impossible to track unless the player used the trinket at least once (which happens very very rarely (looked into 20 logs, not a single cast)). The "empowerment" buff between both trinkets is also not trackable as the [buff](http://www.wowhead.com/spell=255769/eye-of-the-hounds) that grands the bonus armor/versatility is invisible and does not appear in the combat log.
TL;DR: it's a 🍝 -trinket with 🍝 -code and a waste of time to implement.

![rift](https://user-images.githubusercontent.com/29842841/37903764-5f1814a6-30f9-11e8-9773-53c39c1501e4.PNG)
![diima](https://user-images.githubusercontent.com/29842841/37903765-5f3481ea-30f9-11e8-8e82-1f964a018a94.PNG)
![titan](https://user-images.githubusercontent.com/29842841/37903766-5f527a4c-30f9-11e8-8dcf-e484b6e98f2b.PNG)
