### PR TITLE
Low Health Healing Tab - Adding Pet Heals

### DIFF
--- a/src/Parser/Core/Modules/HealEventTracker.js
+++ b/src/Parser/Core/Modules/HealEventTracker.js
@@ -5,6 +5,9 @@ class HealEventTracker extends Analyzer {
   on_byPlayer_heal(event) {
     this.events.push(event);
   }
+  on_byPlayerPet_heal(event) {
+    this.events.push(event);
+  }
   // TODO: Absorbs don't give us the health of the player at the time of the event, find a workaround for this as absorbs are pretty likely to be life savers
   // on_byPlayer_absorbed(event) {
   //   this.events.push(event);


### PR DESCRIPTION
Doing this in a separate PR as it will affect all healers since i couldn't find a good way to only change it for Shamans without extending multiple files. I want this so that Healing Tide / Healing Stream and Spirit Link totems show in the tab as well, which they should (especially Spirit Link).

Not sure why pets are filtered out in the first place, but I guess they're not as impactful for other classes.