### PR TITLE
[Restoration Shaman] Purify Spirit cooldown on successful Dispel

### DIFF
--- a/src/Parser/Shaman/Restoration/Modules/Abilities.js
+++ b/src/Parser/Shaman/Restoration/Modules/Abilities.js
@@ -247,8 +247,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.PURIFY_SPIRIT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         timelineSortIndex: 80,
-        // Need to check if it actually dispelled something before we can give it a cooldown
-        // cooldown: 8,
+        cooldown: 8,
         isOnGCD: true,
       },
       {

--- a/src/Parser/Shaman/Restoration/Modules/Features/SpellUsable.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/SpellUsable.js
@@ -15,11 +15,27 @@ class SpellUsable extends CoreSpellUsable {
     this.hasEcho = this.combatants.selected.hasTalent(SPELLS.ECHO_OF_THE_ELEMENTS_TALENT.id) || this.combatants.selected.hasFinger(ITEMS.SOUL_OF_THE_FARSEER.id);
   }
 
+  on_dispel(event) {
+    if (!this.owner.byPlayer(event)) {
+      return;
+    }
+
+    const spellId = event.ability.guid;
+    if (spellId === SPELLS.PURIFY_SPIRIT.id) {
+      super.beginCooldown(spellId, event.timestamp);
+    }
+  }
+
   beginCooldown(spellId, timestamp) {
     if (this.hasEcho && spellId === SPELLS.RIPTIDE.id) {
       if (!this.isAvailable(spellId)) {
         this.endCooldown(spellId);
       }
+    }
+
+    // Essentially having the purify spirit cast not be able to trigger the cooldown, the dispel event does it instead.
+    if (spellId === SPELLS.PURIFY_SPIRIT.id) {
+      return;
     }
 
     super.beginCooldown(spellId, timestamp);


### PR DESCRIPTION
This correctly triggers the purify spirit cooldown only when it actually dispelled something.
![image](https://user-images.githubusercontent.com/2842471/38168484-a40065fc-354d-11e8-9a36-3761699b8e65.png)