### PR TITLE
Contributors

### DIFF
--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -9,6 +9,7 @@
     export const NICKNAME = {
       nickname: 'NICKNAME',
       github: 'GITHUB_NAME',
+      discord: 'DISCORD_NAME INCL #xxxx',
       avatar: require('./Images/IMAGE'),
       desc: 'DESC',
       mains: [{
@@ -304,6 +305,7 @@ export const Cloake = {
 export const joshinator = {
   nickname: 'joshinator',
   github: 'joshinat0r',
+  discord: 'joshinator#7267',
   mains: [{
     name: "Êxtêndêd",
     spec: SPECS.BLOOD_DEATH_KNIGHT,

--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -11,9 +11,6 @@
       github: 'GITHUB_NAME',
       avatar: require('./Images/IMAGE'),
       desc: 'DESC',
-      maintainer: [
-        SPECS.BLOOD_DEATH_KNIGHT,
-      ],
       mains: [{
         name: "CHARNAME",
         spec: SPECS.BLOOD_DEATH_KNIGHT,

--- a/src/Main/App.css
+++ b/src/Main/App.css
@@ -995,3 +995,42 @@ code.inactive {
 .contributorlist > .row {
   margin: 10px 0;
 }
+
+.modal {
+  position: fixed;
+  top: 40px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, .8);
+  z-index: 200;
+  padding-top: 20px;
+}
+
+.btn-close {
+  display: block;
+  margin: 20px auto;
+  width: 200px;
+}
+
+.contributor-detail {
+  height: calc(100% - 80px);
+}
+
+.no-scroll .contributor-detail .panel {
+  background-color: rgba(20, 20, 20, 1);
+}
+
+.contributor-detail>.container, .contributor-detail>.container>.flex-main, .contributor-detail>.container>.flex-main>.row, .contributor-detail>.container>.flex-main>.row>.col-md-7 {
+  height: 100%;
+}
+
+.panel.scrollable {
+  overflow-x: hidden;
+  overflow-y: auto;
+  max-height: 100%;
+}
+
+.no-scroll {
+  overflow: hidden;
+}

--- a/src/Main/App.js
+++ b/src/Main/App.js
@@ -472,7 +472,7 @@ class App extends Component {
     }
 
     if (this.props.contributorId) {
-      return <ContributorDetails contributorId={this.props.contributorId} />;
+      return <ContributorDetails ownPage contributorId={this.props.contributorId} />;
     }
 
     if (this.props.articleId) {
@@ -556,6 +556,7 @@ class App extends Component {
           <DocumentTitleUpdater />
         </div>
         {!error && <Footer />}
+        <div id="portal"></div>
       </Wrapper>
     );
   }

--- a/src/Main/Contributor.js
+++ b/src/Main/Contributor.js
@@ -1,20 +1,50 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Link } from 'react-router-dom';
 import Wrapper from 'common/Wrapper';
-import makeContributorUrl from './Contributors/makeUrl';
 
-const Contributor = ({ nickname, avatar, github }) => (
-  <Link to={makeContributorUrl(nickname)} key={nickname} className="contributor" data-tip={github ? github : undefined}>
-    {avatar && <Wrapper><img src={avatar} alt="Avatar" />{' '}</Wrapper>}
-    {nickname}
-  </Link>
-);
-Contributor.propTypes = {
-  nickname: PropTypes.string.isRequired,
-  avatar: PropTypes.string,
-  github: PropTypes.string,
-};
+import ContributorDetails from './Contributors/ContributorDetails';
+import Portal from './Portal';
+
+//to={makeContributorUrl(nickname)}
+
+class Contributor extends React.PureComponent {
+
+  static propTypes = {
+    nickname: PropTypes.string.isRequired,
+    avatar: PropTypes.string,
+    github: PropTypes.string,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: false,
+    };
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  handleClick() {
+    this.setState({
+      open: true,
+    });
+  }
+
+  render() {
+    if (this.state.open) {
+      return (
+        <Portal onClose={() => this.setState({ open: false })}><ContributorDetails contributorId={this.props.nickname} /></Portal>
+      );
+    }
+
+    return(
+      <span key={this.props.nickname} onClick={() => this.handleClick()} className="contributor" data-tip={this.props.github ? this.props.github : undefined}>
+        {this.props.avatar && <Wrapper><img src={this.props.avatar} alt="Avatar" />{' '}</Wrapper>}
+        {this.props.nickname}
+      </span>
+    );
+  }
+
+}
 
 export default Contributor;

--- a/src/Main/Contributors/ContributorDetails.js
+++ b/src/Main/Contributors/ContributorDetails.js
@@ -171,16 +171,16 @@ class ContributorDetails extends React.PureComponent {
     ); 
   }
 
-  about(contributor) {
-    if (!contributor.desc) {
+  text(contributor, text) {
+    if (!contributor) {
       return;
     }
 
     return (
       <div className="row">
-        <div className="col-md-3"><b>About me:</b></div>
+        <div className="col-md-3"><b>{text}:</b></div>
         <div className="col-md-9">
-          {contributor.desc}
+          {contributor}
         </div>
       </div>
     );
@@ -246,13 +246,14 @@ class ContributorDetails extends React.PureComponent {
                     <img src={contributor.avatar} alt={'Avatar'} style={{ marginTop: 20, maxHeight: 200, borderRadius: '50%' }}/>
                   </div>
                   <div className="flex-main contributorlist" style={{ padding: '0 5px 20px 5px' }}>
-                    {this.about(contributor)}
+                    {this.text(contributor.about, "About")}
                     <div className="row">
                       <div className="col-md-3"><b>GitHub:</b></div>
                       <div className="col-md-9">
                         <a href={"https://github.com/" + contributor.github} target="_blank">{contributor.github}</a>
                       </div>
                     </div>
+                    {this.text(contributor.discord, "Discord")}
                     {this.maintainer}
                     {this.links(contributor.links)}
                     {this.additionalInfo(contributor.others)}

--- a/src/Main/Contributors/ContributorDetails.js
+++ b/src/Main/Contributors/ContributorDetails.js
@@ -1,65 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
 
 import * as contributors from 'CONTRIBUTORS';
 
 import SPECS from 'common/SPECS';
 
+import AVAILABLE_CONFIGS from 'Parser/AVAILABLE_CONFIGS';
 import CoreChangelog from 'CHANGELOG';
-
-import BloodDKChangelog from 'Parser/DeathKnight/Blood/CHANGELOG';
-import UnholyDKChangelog from 'Parser/DeathKnight/Unholy/CHANGELOG';
-import FrostDKChangelog from 'Parser/DeathKnight/Frost/CHANGELOG';
-
-import HavocDHChangelog from 'Parser/DemonHunter/Havoc/CHANGELOG';
-import VengeanceDHChangelog from 'Parser/DemonHunter/Vengeance/CHANGELOG';
-
-import BlanceDChangelog from 'Parser/Druid/Balance/CHANGELOG';
-import FeralDChangelog from 'Parser/Druid/Feral/CHANGELOG';
-import GuardianDChangelog from 'Parser/Druid/Guardian/CHANGELOG';
-import RestorationDChangelog from 'Parser/Druid/Restoration/CHANGELOG';
-
-import BeastmasteryHChangelog from 'Parser/Hunter/BeastMastery/CHANGELOG';
-import MarksmanshipHChangelog from 'Parser/Hunter/Marksmanship/CHANGELOG';
-import SurvivalHChangelog from 'Parser/Hunter/Survival/CHANGELOG';
-
-import ArcaneMChangelog from 'Parser/Mage/Arcane/CHANGELOG';
-import FireMChangelog from 'Parser/Mage/Fire/CHANGELOG';
-import FrostChangelog from 'Parser/Mage/Frost/CHANGELOG';
-
-import BrewmasterMChangelog from 'Parser/Monk/Brewmaster/CHANGELOG';
-import MistweaverMChangelog from 'Parser/Monk/Mistweaver/CHANGELOG';
-import WindwalkerMChangelog from 'Parser/Monk/Windwalker/CHANGELOG';
-
-import HolyPalChangelog from 'Parser/Paladin/Holy/CHANGELOG';
-import ProtectionPalChangelog from 'Parser/Paladin/Protection/CHANGELOG';
-import RetributionPalChangelog from 'Parser/Paladin/Retribution/CHANGELOG';
-
-import DisciplinePChangelog from 'Parser/Priest/Discipline/CHANGELOG';
-import HolyPChangelog from 'Parser/Priest/Holy/CHANGELOG';
-import ShadowPChangelog from 'Parser/Priest/Shadow/CHANGELOG';
-
-import AssassinationRChangelog from 'Parser/Rogue/Assassination/CHANGELOG';
-import OutlawRChangelog from 'Parser/Rogue/Outlaw/CHANGELOG';
-import SubtletyRChangelog from 'Parser/Rogue/Subtlety/CHANGELOG';
-
-import ElementalSChangelog from 'Parser/Shaman/Elemental/CHANGELOG';
-import EnhancementSChangelog from 'Parser/Shaman/Enhancement/CHANGELOG';
-import RestorationSChangelog from 'Parser/Shaman/Restoration/CHANGELOG';
-
-import AfflictionWChangelog from 'Parser/Warlock/Affliction/CHANGELOG';
-import DemonologyWChangelog from 'Parser/Warlock/Demonology/CHANGELOG';
-import DestructionWChangelog from 'Parser/Warlock/Destruction/CHANGELOG';
-
-import ArmsWChangelog from 'Parser/Warrior/Arms/CHANGELOG';
-import FuryWChangelog from 'Parser/Warrior/Fury/CHANGELOG';
-import ProtectionWChangelog from 'Parser/Warrior/Protection/CHANGELOG';
 
 class ContributorDetails extends React.PureComponent {
 
   static propTypes = {
     contributorId: PropTypes.string,
+    ownPage: PropTypes.bool, 
   };
 
   constructor(props) {
@@ -103,42 +56,46 @@ class ContributorDetails extends React.PureComponent {
   }
 
   contributionHeader(spec) {
-    if (spec === 'Core') {
-      return <span>
-        <img src="/favicon.png" style={{ height: '2em', width: '2em', marginRight: 10 }} alt="Icon" />
-        Core
-      </span>;
-    } else {
-      return <span>
+    if (spec === "0") {
+      return (
+        <span>
+          <img src="/favicon.png" style={{ height: '2em', width: '2em', marginRight: 10 }} alt="Icon" />
+          Core
+        </span>
+      );
+    }
+
+    return (
+      <span>
         <img src={this.iconPath(SPECS[spec])} style={{ height: '2em', width: '2em', marginRight: 10 }} alt="Icon" />
         {SPECS[spec].specName} {SPECS[spec].className}
-      </span>;
-    }
+      </span>
+    );
   }
 
   links(object) {
-    if (object === undefined) {
+    if (!object) {
       return;
-    } else {
-      const value = [];
-      Object.keys(object).forEach((key) => {
-        value.push(<div>
-          <a href={object[key]} target="_blank">{key}</a>
-        </div>);
-      });
-      return (
-        <div className="row" style={{ marginBottom: 30 }}>
-          <div class="col-md-3"><b>Links:</b></div>
-            <div class="col-md-9">
-              {value}
-            </div>
-        </div>
-      );
     }
+
+    const value = [];
+    Object.keys(object).forEach((key) => {
+      value.push(<div>
+        <a href={object[key]} target="_blank">{key}</a>
+      </div>);
+    });
+    return (
+      <div className="row" style={{ marginBottom: 20 }}>
+        <div className="col-md-3"><b>Links:</b></div>
+          <div className="col-md-9">
+            {value}
+          </div>
+      </div>
+    );
   }
 
   additionalInfo(object) {
-    if (object === undefined) {
+    if (!object) {
       return;
     }
 
@@ -151,16 +108,16 @@ class ContributorDetails extends React.PureComponent {
         });
 
         value.push(<div className="row">
-          <div class="col-md-3"><b>{key}:</b></div>
-            <div class="col-md-9">
+          <div className="col-md-3"><b>{key}:</b></div>
+            <div className="col-md-9">
               {subvalue}
             </div>
         </div>);
 
       } else if (typeof object[key] === "string") {
         value.push(<div className="row">
-          <div class="col-md-3"><b>{key}:</b></div>
-            <div class="col-md-9">
+          <div className="col-md-3"><b>{key}:</b></div>
+            <div className="col-md-9">
               {object[key]}
             </div>
         </div>);
@@ -169,49 +126,86 @@ class ContributorDetails extends React.PureComponent {
     return value;
   }
 
-  maintainer(contributor) {
-    if (contributor.maintainer === undefined) {
+  get maintainer() {
+
+    const maintainedSpecs = AVAILABLE_CONFIGS.filter((elem, index) => {
+      const includes = elem.contributors.filter((cont, key) => {
+        return cont.nickname === this.props.contributorId;
+      });
+
+      return includes.length > 0;
+    });
+
+    if (maintainedSpecs.length === 0) {
       return;
-    } else {
-      return <div class="row">
-        <div class="col-md-3"><b>Maintainer:</b></div>
-        <div class="col-md-9">
-          {contributor.maintainer.map((char, index) =>
-            <div className={this.removeWhiteSpaces(char.className)}>
-              <img style={{ height: '1.5em', width: '1.5em', marginRight: 10 }} src={this.iconPath(char)} alt={"Spec Icon"} />
-              {char.specName} {char.className}
+    }
+
+    return (
+      <div className="row">
+        <div className="col-md-3"><b>Maintainer:</b></div>
+        <div className="col-md-9">
+          {maintainedSpecs.map((char, index) => 
+            <div className={this.removeWhiteSpaces(char.spec.className)}>
+              <img style={{ height: '1.5em', width: '1.5em', marginRight: 10 }} src={this.iconPath(char.spec)} alt={"Spec Icon"} />
+              {char.spec.specName} {char.spec.className}
             </div>
           )}
         </div>
-      </div>;
-    }
+      </div>
+    );
   }
 
   chars(contributor, typ) {
-    if (contributor[typ] === undefined) {
+    if (!contributor[typ]) {
       return;
-    } else {
-      const stlye = typ === 'mains' ? { marginTop: 30 } : { marginBottom: 30 };
-      return <div class="row" style={stlye}>
-        <div class="col-md-3"><b>{typ[0].toUpperCase() + typ.slice(1)}:</b></div>
-        <div class="col-md-9">
+    }
+
+    const style = typ === 'mains' ? { marginTop: 20 } : { marginBottom: 20 };
+    return (
+      <div className="row" style={style}>
+        <div className="col-md-3"><b>{typ[0].toUpperCase() + typ.slice(1)}:</b></div>
+        <div className="col-md-9">
           {contributor[typ].map((char, index) => this.char(char) )}
         </div>
-      </div>; 
-    }
+      </div>
+    ); 
   }
 
   about(contributor) {
-    if (contributor.desc === undefined) {
+    if (!contributor.desc) {
       return;
-    } else {
-      return <div class="row">
-        <div class="col-md-3"><b>About me:</b></div>
-        <div class="col-md-9">
+    }
+
+    return (
+      <div className="row">
+        <div className="col-md-3"><b>About me:</b></div>
+        <div className="col-md-9">
           {contributor.desc}
         </div>
-      </div>;
+      </div>
+    );
+  }
+
+  componentDidMount() {
+    if (this.props.ownPage) {
+      return;
     }
+
+    document.body.classList.toggle('no-scroll');
+  }
+  componentWillReceiveProps(nextProps) {
+    if (this.props.ownPage) {
+      return;
+    }
+
+    document.body.classList.toggle('no-scroll');
+  }
+  componentWillUnmount() {
+    if (this.props.ownPage) {
+      return;
+    }
+
+    document.body.classList.remove('no-scroll');
   }
 
   //#endregion
@@ -220,60 +214,13 @@ class ContributorDetails extends React.PureComponent {
     const { contributorId } = this.props;
     const contributor = contributors[contributorId];
     const contributions = {
-      'Core': CoreChangelog,
-      BLOOD_DEATH_KNIGHT: BloodDKChangelog,
-      UNHOLY_DEATH_KNIGHT: UnholyDKChangelog,
-      FROST_DEATH_KNIGHT: FrostDKChangelog,
-
-      HAVOC_DEMON_HUNTER: HavocDHChangelog,
-      VENGEANCE_DEMON_HUNTER: VengeanceDHChangelog,
-
-      BALANCE_DRUID: BlanceDChangelog,
-      FERAL_DRUID: FeralDChangelog,
-      GUARDIAN_DRUID: GuardianDChangelog,
-      RESTORATION_DRUID: RestorationDChangelog,
-
-      BEAST_MASTERY_HUNTER: BeastmasteryHChangelog,
-      MARKSMANSHIP_HUNTER: MarksmanshipHChangelog,
-      SURVIVAL_HUNTER: SurvivalHChangelog,
-
-      ARCANE_MAGE: ArcaneMChangelog,
-      FIRE_MAGE: FireMChangelog,
-      FROST_MAGE: FrostChangelog,
-      
-      BREWMASTER_MONK: BrewmasterMChangelog,
-      MISTWEAVER_MONK: MistweaverMChangelog,
-      WINDWALKER_MONK: WindwalkerMChangelog,
-
-      HOLY_PALADIN: HolyPalChangelog,
-      PROTECTION_PALADIN: ProtectionPalChangelog,
-      RETRIBUTION_PALADIN: RetributionPalChangelog,
-
-      DISCIPLINE_PRIEST: DisciplinePChangelog,
-      HOLY_PRIEST: HolyPChangelog,
-      SHADOW_PRIEST: ShadowPChangelog,
-      
-      ASSASSINATION_ROGUE: AssassinationRChangelog,
-      OUTLAW_ROGUE: OutlawRChangelog,
-      SUBTLETY_ROGUE: SubtletyRChangelog,
-      
-      ELEMENTAL_SHAMAN: ElementalSChangelog,
-      ENHANCEMENT_SHAMAN: EnhancementSChangelog,
-      RESTORATION_SHAMAN: RestorationSChangelog,
-      
-      AFFLICTION_WARLOCK: AfflictionWChangelog,
-      DEMONOLOGY_WARLOCK: DemonologyWChangelog,
-      DESTRUCTION_WARLOCK: DestructionWChangelog,
-      
-      ARMS_WARRIOR: ArmsWChangelog,
-      FURY_WARRIOR: FuryWChangelog,
-      PROTECTION_WARRIOR: ProtectionWChangelog,
+      0: CoreChangelog,
     };
 
-    if (contributor.avatar === undefined) {
-      contributor.avatar = "/favicon.png";
-    }
-
+    AVAILABLE_CONFIGS.forEach((elem, index) => {
+      contributions[elem.spec.id] = elem.changelog;
+    });
+    
     Object.keys(contributions).forEach((key) => {
       contributions[key] = contributions[key].filter(this.filterChangelog);
       if (contributions[key].length === 0) {
@@ -281,59 +228,63 @@ class ContributorDetails extends React.PureComponent {
       }
     });
 
-    return(
-      <div className="container">
-        <Link to="/">
-          Home
-        </Link><br/><br/>
+    if (contributor.avatar === undefined) {
+      contributor.avatar = "/favicon.png";
+    }
 
-        <div className="flex-main">
-          <div className="row">
-            <div className="col-md-5">
-              <div className="panel">
-                <div style={{ textAlign: 'center' }}>
-                  <h2>{contributor.nickname}</h2>
-                  <img src={contributor.avatar} alt={'Avatar'} style={{ marginTop: 20, maxHeight: 200, borderRadius: '50%' }}/>
-                </div>
-                <div class="flex-main contributorlist" style={{ padding: 30 }}>
-                  {this.about(contributor)}
-                  <div class="row">
-                    <div class="col-md-3"><b>GitHub:</b></div>
-                    <div class="col-md-9">
-                      <a href={"https://github.com/" + contributor.github} target="_blank">{contributor.github}</a>
-                    </div>
+    
+
+    return (
+      <div className="contributor-detail">
+        <div className="container">
+          <div className="flex-main">
+            <div className="row">
+              <div className="col-md-5">
+                <div className="panel">
+                  <div style={{ textAlign: 'center' }}>
+                    <h2>{contributor.nickname}</h2>
+                    <img src={contributor.avatar} alt={'Avatar'} style={{ marginTop: 20, maxHeight: 200, borderRadius: '50%' }}/>
                   </div>
-                  {this.maintainer(contributor)}
-                  {this.links(contributor.links)}
-                  {this.additionalInfo(contributor.others)}
-                  {this.chars(contributor, "mains")}
-                  {this.chars(contributor, "alts")}
+                  <div className="flex-main contributorlist" style={{ padding: '0 5px 20px 5px' }}>
+                    {this.about(contributor)}
+                    <div className="row">
+                      <div className="col-md-3"><b>GitHub:</b></div>
+                      <div className="col-md-9">
+                        <a href={"https://github.com/" + contributor.github} target="_blank">{contributor.github}</a>
+                      </div>
+                    </div>
+                    {this.maintainer}
+                    {this.links(contributor.links)}
+                    {this.additionalInfo(contributor.others)}
+                    {this.chars(contributor, "mains")}
+                    {this.chars(contributor, "alts")}
+                  </div>
                 </div>
               </div>
-            </div>
 
 
-            <div className="col-md-7">
-              <div class="panel">
-                {Object.keys(contributions).map((type, index) => 
-                  <div key={index}>
-                    <div className="panel-heading" style={{ cursor: 'pointer' }} onClick={() => this.toggleClass(index)}>
-                      <h2>{this.contributionHeader(type)} ({contributions[type].length} commits)</h2>
+              <div className="col-md-7">
+                <div className="panel scrollable">
+                  {Object.keys(contributions).map((type, index) => 
+                    <div key={index}>
+                      <div className="panel-heading" style={{ cursor: 'pointer', userSelect: 'none' }} onClick={() => this.toggleClass(index)}>
+                        <h2>{this.contributionHeader(type)} ({contributions[type].length} commits)</h2>
+                      </div>
+                      <ul className="list text" style={{ marginBottom: 20, display: this.state.list[index] === true ? 'block' : 'none' }}>
+                        {contributions[type].map((contribution, index) => 
+                          <li key={index} className="row">
+                            <div className="col-md-2">
+                              {contribution.date.toLocaleDateString()}
+                            </div>
+                            <div className="col-md-10">
+                              {contribution.changes}
+                            </div>
+                          </li>
+                        )}
+                      </ul>
                     </div>
-                    <ul className="list text" style={{ marginBottom: 30, display: this.state.list[index] === true ? 'block' : 'none' }}>
-                      {contributions[type].map((contribution) => 
-                        <li className="row">
-                          <div className="col-md-2">
-                            {contribution.date.toLocaleDateString()}
-                          </div>
-                          <div className="col-md-10">
-                            {contribution.changes}
-                          </div>
-                        </li>
-                      )}
-                    </ul>
-                  </div>
-                )}
+                  )}
+                </div>
               </div>
             </div>
           </div>

--- a/src/Main/Contributors/ContributorDetails.js
+++ b/src/Main/Contributors/ContributorDetails.js
@@ -101,7 +101,7 @@ class ContributorDetails extends React.PureComponent {
 
     const value = [];
     Object.keys(object).forEach((key) => {
-      if (Array.isArray(object[key]) === true) {
+      if (Array.isArray(object[key])) {
         const subvalue = [];
         object[key].forEach((elem) => {
           subvalue.push(<div>{elem}</div>);
@@ -270,7 +270,7 @@ class ContributorDetails extends React.PureComponent {
                       <div className="panel-heading" style={{ cursor: 'pointer', userSelect: 'none' }} onClick={() => this.toggleClass(index)}>
                         <h2>{this.contributionHeader(type)} ({contributions[type].length} commits)</h2>
                       </div>
-                      <ul className="list text" style={{ marginBottom: 20, display: this.state.list[index] === true ? 'block' : 'none' }}>
+                      <ul className="list text" style={{ marginBottom: 20, display: this.state.list[index] ? 'block' : 'none' }}>
                         {contributions[type].map((contribution, index) => 
                           <li key={index} className="row">
                             <div className="col-md-2">

--- a/src/Main/Portal.js
+++ b/src/Main/Portal.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+
+/* 
+  Wraps child and appends it to DOMs #portal-div
+  necessary to avoid css inheritance
+*/
+
+const Portal = ({ children, onClose }) => {
+  return createPortal(
+    <div className="modal">
+      {children}
+      <div onClick={onClose} className="btn btn-primary btn-close">close</div>
+    </div>,
+    document.getElementById("portal")
+  );
+};
+
+export default Portal;

--- a/src/Parser/DeathKnight/Blood/CONFIG.js
+++ b/src/Parser/DeathKnight/Blood/CONFIG.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Yajinni } from 'CONTRIBUTORS';
+import { Yajinni, joshinator } from 'CONTRIBUTORS';
 import SPECS from 'common/SPECS';
 import Wrapper from 'common/Wrapper';
 import Warning from 'common/Alert/Warning';
@@ -10,7 +10,7 @@ import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list.
-  contributors: [Yajinni],
+  contributors: [Yajinni, joshinator],
   // The WoW client patch this spec was last updated to be fully compatible with.
   patchCompatibility: '7.3.5',
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.


### PR DESCRIPTION
Adresses suggested changes from the last version

- JSX returns wrapped in parenthesis
- removed unnecessary `== true` & `== undefined` & `else` checks
- changed paddings from 30px to the 20px for more layout-consistency
- using AVAILABLE_CONFIGS instead of manual importing all changelogs
- pulling maintained specs from AVAILABLE_CONFIGS instead of CONTRIBUTORS

Also changed to contributor-component to open a modal instead of a new link. 
The ability to link a contributor is still available, might be usefull for something.

Wrapping the modal inside of the portal-component was necessary due to CSS inheritance (e.g. the contributor-components in the changelog-tab would inherit the text-mute & text-align style). I think its cleaner than overwriting the styles that cause issues.
Also might be a usefull in the future for adding modals / alerts / overlays.

**Overlay triggered by contributor-components:**
![contrib_overlay](https://user-images.githubusercontent.com/29842841/38362054-cb51b9fa-38cf-11e8-90f3-e7d954db8d29.PNG)

**Old link:**
![contrib_page](https://user-images.githubusercontent.com/29842841/38362055-cb6e5c4a-38cf-11e8-9c8a-81538ac1e725.PNG)

