### PR TITLE
Removed double icons

### DIFF
--- a/src/Main/Cooldown.js
+++ b/src/Main/Cooldown.js
@@ -153,7 +153,7 @@ class Cooldown extends React.Component {
                           +{((event.timestamp - cooldown.start) / 1000).toFixed(3)}
                         </div>
                         <div className="col-xs-10">
-                          <SpellLink key={`${event.ability.guid}-${event.timestamp}-${i}`} id={event.ability.guid}>
+                          <SpellLink key={`${event.ability.guid}-${event.timestamp}-${i}`} id={event.ability.guid} icon={false}>
                             <Icon icon={event.ability.abilityIcon} alt={event.ability.name} style={{ height: 23, marginRight: 4 }} /> {event.ability.name}
                           </SpellLink>
                         </div>
@@ -176,7 +176,7 @@ class Cooldown extends React.Component {
                       +{((event.timestamp - cooldown.start) / 1000).toFixed(3)}
                     </div>
                     <div className={`col-xs-4 ${event.type === 'heal' ? 'col-xs-offset-1' : ''}`}>
-                      <SpellLink key={`${event.ability.guid}-${event.timestamp}-${i}`} id={event.ability.guid}>
+                      <SpellLink key={`${event.ability.guid}-${event.timestamp}-${i}`} id={event.ability.guid} icon={false}>
                         <Icon icon={event.ability.abilityIcon} alt={event.ability.name} style={{ height: 23, marginRight: 4 }} /> {event.ability.name}
                       </SpellLink>
                       {event.type === 'heal' && (

--- a/src/Main/DamageTakenTable.js
+++ b/src/Main/DamageTakenTable.js
@@ -43,7 +43,7 @@ class DamageTakenTable extends React.Component {
             </div>
           </td>
           <td>
-            <SpellLink id={ability.guid}>
+            <SpellLink id={ability.guid} icon={false}>
               <Icon icon={ability.abilityIcon} alt={ability.name} /> {ability.name}
             </SpellLink>
           </td>

--- a/src/Main/LowHealthHealing.js
+++ b/src/Main/LowHealthHealing.js
@@ -123,7 +123,7 @@ class LowHealthHealing extends React.Component {
                         {formatDuration((event.timestamp - fightStart) / 1000)}
                       </td>
                       <td style={{ width: '25%' }}>
-                        <SpellLink id={event.ability.guid}>
+                        <SpellLink id={event.ability.guid} icon={false}>
                           <Icon icon={event.ability.abilityIcon} alt={event.ability.abilityIcon} /> {event.ability.name}
                         </SpellLink>
                       </td>

--- a/src/Parser/Core/Modules/ResourceTracker/ResourceBreakdown.js
+++ b/src/Parser/Core/Modules/ResourceTracker/ResourceBreakdown.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
 
@@ -66,7 +65,6 @@ class ResourceBreakdown extends React.Component {
               .map(ability => (
                 <tr>
                   <td style={{ width: '30%' }}>
-                    <SpellIcon id={ability.abilityId} />{' '}
                     <SpellLink id={ability.abilityId} />
                   </td>
                   <td style={{ width: 50, paddingRight: 5, textAlign: 'center' }}>
@@ -105,7 +103,6 @@ class ResourceBreakdown extends React.Component {
               .map(ability => (
                 <tr>
                   <td style={{ width: '30%' }}>
-                    <SpellIcon id={ability.abilityId} />{' '}
                     <SpellLink id={ability.abilityId} />
                   </td>
                   <td style={{ width: 50, paddingRight: 5, textAlign: 'center' }}>

--- a/src/Parser/DeathKnight/Shared/RuneBreakdown.js
+++ b/src/Parser/DeathKnight/Shared/RuneBreakdown.js
@@ -79,7 +79,6 @@ class RuneBreakdown extends ResourceBreakdown {
               .map(ability => (
                 <tr>
                   <td style={{ width: '30%' }}>
-                    <SpellIcon id={ability.abilityId} />{' '}
                     <SpellLink id={ability.abilityId} />
                   </td>
                   <td style={{ width: 50, paddingRight: 5, textAlign: 'center' }}>
@@ -118,7 +117,6 @@ class RuneBreakdown extends ResourceBreakdown {
               .map(ability => (
                 <tr>
                   <td style={{ width: '30%' }}>
-                    <SpellIcon id={ability.abilityId} />{' '}
                     <SpellLink id={ability.abilityId} />
                   </td>
                   <td style={{ width: 50, paddingRight: 5, textAlign: 'center' }}>

--- a/src/Parser/Druid/Feral/Modules/ComboPoints/ComboPointBreakdown.js
+++ b/src/Parser/Druid/Feral/Modules/ComboPoints/ComboPointBreakdown.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
 
@@ -104,7 +103,6 @@ class ResourceBreakdown extends React.Component {
               .map(ability => (
                 <tr>
                   <td style={{ width: '30%' }}>
-                    <SpellIcon id={ability.abilityId} />{' '}
                     <SpellLink id={ability.abilityId} />
                   </td>
                   <td style={{ width: 50, paddingRight: 5, textAlign: 'right' }}>

--- a/src/Parser/Monk/Windwalker/Modules/Spells/SpinningCraneKick.js
+++ b/src/Parser/Monk/Windwalker/Modules/Spells/SpinningCraneKick.js
@@ -2,7 +2,6 @@ import React from 'react';
 
 import Wrapper from 'common/Wrapper';
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import Analyzer from 'Parser/Core/Analyzer';
@@ -174,9 +173,7 @@ class SpinningCraneKick extends Analyzer {
       return (
         <StatisticsListBox
           title={
-            <SpellLink id={SPELLS.SPINNING_CRANE_KICK.id}>
-              <SpellIcon id={SPELLS.SPINNING_CRANE_KICK.id} noLink /> Spinning Crane Kick
-          </SpellLink>
+            <SpellLink id={SPELLS.SPINNING_CRANE_KICK.id} />
           }
           style={{ minHeight: 150 }}
         >

--- a/src/Parser/Monk/Windwalker/Modules/Spells/StormEarthAndFire.js
+++ b/src/Parser/Monk/Windwalker/Modules/Spells/StormEarthAndFire.js
@@ -88,9 +88,7 @@ class StormEarthAndFire extends Analyzer{
     return (
       <div className="flex">
         <div className="flex-main">
-          <SpellLink id={SPELLS.RISING_SUN_KICK.id}>
-            <SpellIcon id={SPELLS.RISING_SUN_KICK.id} noLink /> Rising Sun Kick
-          </SpellLink>
+          <SpellLink id={SPELLS.RISING_SUN_KICK.id} />
         </div>
         <div className="flex-sub text-right">
           {this.risingSunKicks}/{this.castCount * (2 + this.drinkingHornCover) + 1}
@@ -103,9 +101,7 @@ class StormEarthAndFire extends Analyzer{
     return (
       <div className="flex">
         <div className="flex-main">
-          <SpellLink id={SPELLS.FISTS_OF_FURY_CAST.id}>
-            <SpellIcon id={SPELLS.FISTS_OF_FURY_CAST.id} noLink /> Fist of Fury
-          </SpellLink>
+          <SpellLink id={SPELLS.FISTS_OF_FURY_CAST.id} />
         </div>
         <div className="flex-sub text-right">
           {this.fistsOfFuries}/{this.castCount + this.drinkingHornCover}
@@ -119,9 +115,7 @@ class StormEarthAndFire extends Analyzer{
       return(
       <div className= "flex" >
           <div className="flex-main">
-            <SpellLink id={SPELLS.WHIRLING_DRAGON_PUNCH_TALENT.id}>
-              <SpellIcon id={SPELLS.WHIRLING_DRAGON_PUNCH_TALENT.id} noLink /> Whirling Dragon Punch
-          </SpellLink>
+            <SpellLink id={SPELLS.WHIRLING_DRAGON_PUNCH_TALENT.id} />
           </div>
           <div className="flex-sub text-right">
             {this.whirlingDragonPunches}/{this.castCount}
@@ -134,9 +128,7 @@ class StormEarthAndFire extends Analyzer{
       return (
         <div className="flex">
           <div className="flex-main">
-            <SpellLink id={SPELLS.STRIKE_OF_THE_WINDLORD.id}>
-              <SpellIcon id={SPELLS.STRIKE_OF_THE_WINDLORD.id} noLink /> Strike of the Windlord
-          </SpellLink>
+            <SpellLink id={SPELLS.STRIKE_OF_THE_WINDLORD.id} />
           </div>
           <div className="flex-sub text-right">
             {this.strikeOfTheWindlords}/{this.castCount}

--- a/src/Parser/Priest/Discipline/Modules/Features/AtonementHealingBreakdown.js
+++ b/src/Parser/Priest/Discipline/Modules/Features/AtonementHealingBreakdown.js
@@ -60,7 +60,7 @@ class AtonementHealingBreakdown extends React.Component {
               <Wrapper>
                 <tr key={ability.guid}>
                   <td style={{ width: '30%' }}>
-                    <SpellLink id={ability.guid}>
+                    <SpellLink id={ability.guid} icon={false}>
                       <Icon icon={ability.abilityIcon} />{' '}
                       {ability.name}
                     </SpellLink>
@@ -98,7 +98,7 @@ class AtonementHealingBreakdown extends React.Component {
                   return (
                     <tr>
                       <td style={{ width: '30%', paddingLeft: 50 }}>
-                        <SpellLink id={ability.guid}>
+                        <SpellLink id={ability.guid} icon={false}>
                           <Icon icon={ability.abilityIcon} />{' '}
                           {ability.name} bolt {index + 1}
                         </SpellLink>

--- a/src/Parser/Shaman/Shared/MaelstromChart/MaelstromComponent.js
+++ b/src/Parser/Shaman/Shared/MaelstromChart/MaelstromComponent.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import SpellLink from 'common/SpellLink';
-import SpellIcon from 'common/SpellIcon';
 
 const MaelstromComponent = ({ categories, abilities}) => {
 
@@ -27,9 +26,7 @@ const MaelstromComponent = ({ categories, abilities}) => {
                 return (
                   <tr key={name}>
                     <td style={{ width: '35%' }}>
-                      <SpellLink id={ability.spellId} style={{ color: '#fff' }}>
-                        <SpellIcon id={ability.spellId} noLink /> {name}
-                      </SpellLink>
+                      <SpellLink id={ability.spellId} style={{ color: '#fff' }} />
                     </td>
                     <td className="text-center" style={{ minWidth: 80 }}>
                       {casts}

--- a/src/Parser/Warlock/Destruction/Modules/Features/DimensionalRift.js
+++ b/src/Parser/Warlock/Destruction/Modules/Features/DimensionalRift.js
@@ -63,9 +63,7 @@ class DimensionalRift extends Analyzer {
         {rifts.map(rift => (
           <div className="flex">
             <div className="flex-main">
-              <SpellLink id={rift.id}>
-                <SpellIcon id={rift.id} noLink /> {rift.name}
-              </SpellLink>
+              <SpellLink id={rift.id} />
             </div>
             <div className="flex-sub text-right">
               {formatNumber(rift.damage)} ({formatPercentage(rift.damage / totalDmg)} %)

--- a/src/Parser/Warlock/Destruction/Modules/SoulShards/SoulShardBreakdown.js
+++ b/src/Parser/Warlock/Destruction/Modules/SoulShards/SoulShardBreakdown.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
 
@@ -63,7 +62,6 @@ class SoulShardBreakdown extends React.Component {
               .map(ability => (
                 <tr>
                   <td style={{ width: '30%' }}>
-                    <SpellIcon id={ability.abilityId} />{' '}
                     <SpellLink id={ability.abilityId}>{ability.name}</SpellLink>
                   </td>
                   <td style={{ width: 50, paddingRight: 5, textAlign: 'right' }}>


### PR DESCRIPTION
A lot of places have double icons after the icon prop change, i looked for and fixed those that i found.

![image](https://user-images.githubusercontent.com/2842471/38403225-406ff124-3962-11e8-938d-5f3fff5abf4b.png)![image](https://user-images.githubusercontent.com/2842471/38403240-56c6ecb6-3962-11e8-9e4c-25fdba88c79e.png)
(and so on)