### PR TITLE
[BrM] Added missing item to damage checklist (+ small vantus rune fix)

### DIFF
--- a/src/Parser/Core/Modules/Spells/VantusRune.js
+++ b/src/Parser/Core/Modules/Spells/VantusRune.js
@@ -87,7 +87,7 @@ class VantusRune extends Analyzer {
     return (
       <SmallStatisticBox
         icon={(
-          <SpellLink id={this.activeRune.ability.guid}>
+          <SpellLink id={this.activeRune.ability.guid} icon={false}>
             <Icon icon={this.activeRune.ability.abilityIcon} />
           </SpellLink>
         )}

--- a/src/Parser/Monk/Brewmaster/CHANGELOG.js
+++ b/src/Parser/Monk/Brewmaster/CHANGELOG.js
@@ -9,6 +9,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-04-02'),
+    changes: 'Added "Top the DPS Charts" checklist item.',
+    contributors: [emallson],
+  },
+  {
     date: new Date('2018-03-19'),
     changes: <Wrapper>Converted <SpellLink id={SPELLS.BREATH_OF_FIRE.id} /> from uptime to hit tracking and updated hit tracking for <SpellLink id={SPELLS.IRONSKIN_BREW.id} />.</Wrapper>,
     contributors: [emallson],

--- a/src/Parser/Monk/Brewmaster/Modules/Features/Checklist.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/Checklist.js
@@ -15,6 +15,7 @@ import BrewCDR from '../Core/BrewCDR';
 import BreathOfFire from '../Spells/BreathOfFire';
 import TigerPalm from '../Spells/TigerPalm';
 import RushingJadeWind from '../Spells/RushingJadeWind';
+import BlackoutCombo from '../Spells/BlackoutCombo';
 
 class Checklist extends CoreChecklist {
   static dependencies = {
@@ -25,18 +26,19 @@ class Checklist extends CoreChecklist {
     castEfficiency: CastEfficiency,
     tp: TigerPalm,
     rjw: RushingJadeWind,
+    boc: BlackoutCombo,
   };
 
   rules = [
     new Rule({
       name: (
         <Wrapper>
-          Mitigate damage with <SpellLink id={SPELLS.IRONSKIN_BREW.id} />.
+          Mitigate damage with <SpellLink id={SPELLS.IRONSKIN_BREW.id} icon />.
         </Wrapper>
       ),
       description: (
         <Wrapper>
-          <SpellLink id={SPELLS.STAGGER.id} /> is our main damage mitigation tool. <SpellLink id={SPELLS.IRONSKIN_BREW.id} /> increases the amount of damage that we can mitigate with Stagger while active. It is possible to maintain 100% uptime without reaching any particular haste threshold due to the cooldown reduction applied by <SpellLink id={SPELLS.KEG_SMASH.id} /> and <SpellLink id={SPELLS.TIGER_PALM.id} />. If you are having difficulty maintaining your buff you may need to improve your cast efficiency or reduce the amount of purification you are doing.
+          <SpellLink id={SPELLS.STAGGER.id} icon /> is our main damage mitigation tool. <SpellLink id={SPELLS.IRONSKIN_BREW.id} icon /> increases the amount of damage that we can mitigate with Stagger while active. It is possible to maintain 100% uptime without reaching any particular haste threshold due to the cooldown reduction applied by <SpellLink id={SPELLS.KEG_SMASH.id} icon /> and <SpellLink id={SPELLS.TIGER_PALM.id} icon />. If you are having difficulty maintaining your buff you may need to improve your cast efficiency or reduce the amount of purification you are doing.
         </Wrapper>
       ),
       requirements: () => {
@@ -51,12 +53,12 @@ class Checklist extends CoreChecklist {
     new Rule({
       name: (
         <Wrapper>
-          Mitigate damage with <SpellLink id={SPELLS.BREATH_OF_FIRE.id} />.
+          Mitigate damage with <SpellLink id={SPELLS.BREATH_OF_FIRE.id} icon />.
         </Wrapper>
       ),
       description: (
         <Wrapper>
-          <SpellLink id={SPELLS.BREATH_OF_FIRE.id} /> provides a 4-7% damage reduction through the <SpellLink id={SPELLS.HOT_BLOODED.id} /> trait. It is possible to maintain 100% uptime on this debuff both with and without <ItemLink id={ITEMS.SALSALABIMS_LOST_TUNIC.id} icon  />.
+          <SpellLink id={SPELLS.BREATH_OF_FIRE.id} icon /> provides a 4-7% damage reduction through the <SpellLink id={SPELLS.HOT_BLOODED.id} icon /> trait. It is possible to maintain 100% uptime on this debuff both with and without <ItemLink id={ITEMS.SALSALABIMS_LOST_TUNIC.id} icon  />.
         </Wrapper>
       ),
       requirements: () => {
@@ -74,9 +76,9 @@ class Checklist extends CoreChecklist {
       ),
       description: (
         <Wrapper>
-          The duration of the <SpellLink id={SPELLS.IRONSKIN_BREW.id} /> buff is capped at 3 times the duration of the buff. Avoid casting ISB when you are near this cap, as doing so wastes much of the duration of the buff (called 'clipping' the buff). A WeakAura can help track this duration cap.
+          The duration of the <SpellLink id={SPELLS.IRONSKIN_BREW.id} icon /> buff is capped at 3 times the duration of the buff. Avoid casting ISB when you are near this cap, as doing so wastes much of the duration of the buff (called 'clipping' the buff). A WeakAura can help track this duration cap.
 
-          If doing so will not cause the ISB buff to expire, spend excess brew charges on <SpellLink id={SPELLS.PURIFYING_BREW.id} /> to remove damage from the Stagger pool.
+          If doing so will not cause the ISB buff to expire, spend excess brew charges on <SpellLink id={SPELLS.PURIFYING_BREW.id} icon /> to remove damage from the Stagger pool.
         </Wrapper>
       ),
       requirements: () => {
@@ -92,7 +94,7 @@ class Checklist extends CoreChecklist {
       name: 'Generate enough brews through your rotation.',
       description: (
         <Wrapper>
-          The cooldown of all brews is reduced by your key rotational abilities: <SpellLink id={SPELLS.KEG_SMASH.id} /> and <SpellLink id={SPELLS.TIGER_PALM.id} />. Maintaining a proper rotation will help ensure you have enough brews available to maintain <SpellLink id={SPELLS.IRONSKIN_BREW.id} />.
+          The cooldown of all brews is reduced by your key rotational abilities: <SpellLink id={SPELLS.KEG_SMASH.id} icon /> and <SpellLink id={SPELLS.TIGER_PALM.id} icon />. Maintaining a proper rotation will help ensure you have enough brews available to maintain <SpellLink id={SPELLS.IRONSKIN_BREW.id} icon />.
         </Wrapper>
       ),
       requirements: () => {
@@ -119,13 +121,18 @@ class Checklist extends CoreChecklist {
 
         const boc = this.tp.bocEmpoweredThreshold;
         reqs.push(new Requirement({
-          name: <Wrapper><SpellLink id={SPELLS.BLACKOUT_COMBO_TALENT.id} />-empowered <SpellLink id={SPELLS.TIGER_PALM.id} icon>Tiger Palms</SpellLink></Wrapper>,
+          name: <Wrapper><SpellLink id={SPELLS.BLACKOUT_COMBO_TALENT.id} icon />-empowered <SpellLink id={SPELLS.TIGER_PALM.id} icon>Tiger Palms</SpellLink></Wrapper>,
           check: () => boc,
+          when: () => !!boc,
+        }));
+        reqs.push(new Requirement({
+          name: <dfn data-tip={"For the purposes of DPS, any Blackout Combo buff that goes unused or is used on a non-Tiger Palm ability is considered Wasted. Specific fight mechanics may call for using Blackout Combo on other abilities."}>Wasted <SpellLink id={SPELLS.BLACKOUT_COMBO_TALENT.id} icon /> empowerments</dfn>,
+          check: () => this.boc.dpsWasteThreshold,
           when: () => !!boc,
         }));
 
         reqs.push(new Requirement({
-          name: <Wrapper><SpellLink id={SPELLS.RUSHING_JADE_WIND.id} /> uptime</Wrapper>,
+          name: <Wrapper><SpellLink id={SPELLS.RUSHING_JADE_WIND.id} icon /> uptime</Wrapper>,
           check: () => this.rjw.uptimeThreshold,
           when: () => !!this.rjw.uptimeThreshold,
         }));

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/BlackoutCombo.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/BlackoutCombo.js
@@ -22,6 +22,21 @@ class BlackoutCombo extends Analyzer {
   lastBlackoutComboCast = 0;
   spellsBOCWasUsedOn = {};
 
+  get dpsWasteThreshold() {
+    if(!this.active) {
+      return null;
+    }
+    return {
+      actual: 1.0 - this.spellsBOCWasUsedOn[SPELLS.TIGER_PALM.id] / this.blackoutComboBuffs,
+      isGreaterThan: {
+        minor: 0.05,
+        average: 0.1,
+        major: 0.15,
+      },
+      style: 'percentage',
+    };
+  }
+
   on_initialized() {
     this.active = this.combatants.selected.hasTalent(SPELLS.BLACKOUT_COMBO_TALENT.id);
   }

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/TigerPalm.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/TigerPalm.js
@@ -50,7 +50,7 @@ class TigerPalm extends Analyzer {
     return {
       actual: this.totalBocHits / this.totalCasts,
       isLessThan: {
-        minor: 0.095,
+        minor: 0.95,
         average: 0.9,
         major: 0.85,
       },


### PR DESCRIPTION
Realized I missed one important item for BrM damage. The current checklist only checks that you didn't cast TP unless you had BoC. This adds the opposite direction: did you have BoC but not cast TP?

Also: fixed Vantus runes having a second icon because it was crashing the page in dev ("Current" screenshot is from current live)

**Current:**
![screenshot from 2018-04-02 00-42-23](https://user-images.githubusercontent.com/4909458/38436701-56c2ad2c-39a3-11e8-930f-7735c3db554e.png)
![screenshot from 2018-04-06 14-04-26](https://user-images.githubusercontent.com/4909458/38436744-74202782-39a3-11e8-8f17-cb38b1f595d0.png)
**New:**
![screenshot from 2018-04-06 14-03-12](https://user-images.githubusercontent.com/4909458/38436700-56ae9ca6-39a3-11e8-9f01-daf3c2304145.png)
![screenshot from 2018-04-06 14-04-35](https://user-images.githubusercontent.com/4909458/38436742-740d7542-39a3-11e8-8221-33e2461af17c.png)
