### PR TITLE
[Arms Warrior] Add Battle Cry damage statistic block

### DIFF
--- a/src/Parser/Warrior/Arms/CHANGELOG.js
+++ b/src/Parser/Warrior/Arms/CHANGELOG.js
@@ -7,6 +7,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-04-10'), 
+    changes: <Wrapper>Added <SpellLink id={SPELLS.BATTLE_CRY.id} icon /> statistic block.</Wrapper>,
+    contributors: [Aelexe],
+  },
+  {
     date: new Date('2018-04-09'),
     changes: <Wrapper>Added a suggestion for preparing <SpellLink id={SPELLS.SHATTERED_DEFENSES.id} icon /> for <SpellLink id={SPELLS.BATTLE_CRY.id} icon />.</Wrapper>,
     contributors: [Aelexe],


### PR DESCRIPTION
Added a Battle Cry damage statistic block that lets you see how much damage you dealt during your burst window. I likely won't add a suggestion for this as smaller suggestions I'll be adding would lead to this metric being reached anyway.

Also addressed a few code review comments from #1560.