### PR TITLE
[Arms Warrior] Add Rend tracking and Rend/Execute range suggestion

### DIFF
--- a/src/Parser/Warrior/Arms/CHANGELOG.js
+++ b/src/Parser/Warrior/Arms/CHANGELOG.js
@@ -7,6 +7,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-04-10'),
+    changes: <Wrapper>Added a suggestion for not using <SpellLink id={SPELLS.REND_TALENT.id} icon /> on a target in <SpellLink id={SPELLS.EXECUTE.id} icon /> range.</Wrapper>,
+    contributors: [Aelexe],
+  },
+  {
     date: new Date('2018-04-12'),
     changes: <Wrapper>Added a suggestion for avoiding wasted <SpellLink id={SPELLS.EXECUTIONERS_PRECISION.id} icon /> stacks.</Wrapper>,
     contributors: [Aelexe],

--- a/src/Parser/Warrior/Arms/CombatLogParser.js
+++ b/src/Parser/Warrior/Arms/CombatLogParser.js
@@ -8,6 +8,7 @@ import ColossusSmash from './Modules/Core/ColossusSmash';
 import CooldownThroughputTracker from './Modules/Features/CooldownThroughputTracker';
 import ColossusSmashUptime from './Modules/BuffDebuff/ColossusSmashUptime';
 import Execute from './Modules/Core/Execute';
+import Rend from './Modules/Talents/Rend';
 import TacticianProc from './Modules/BuffDebuff/TacticianProc';
 import SpellUsable from './Modules/Features/SpellUsable';
 import Channeling from './Modules/Features/Channeling';
@@ -28,6 +29,7 @@ class CombatLogParser extends CoreCombatLogParser {
     cooldownThroughputTracker: CooldownThroughputTracker,
     colossusSmashUptime: ColossusSmashUptime,
     execute: Execute,
+    rend: Rend,
     tacticianProc: TacticianProc,
     spellUsable: SpellUsable,
     channeling: Channeling,

--- a/src/Parser/Warrior/Arms/Modules/Abilities.js
+++ b/src/Parser/Warrior/Arms/Modules/Abilities.js
@@ -29,6 +29,12 @@ class Abilities extends CoreAbilities {
         isOnGCD: true,
       },
       {
+        spell: SPELLS.REND_TALENT,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        isOnGCD: true,
+        enabled: combatant.hasTalent(SPELLS.REND_TALENT.id),
+      },
+      {
         spell: SPELLS.CLEAVE,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
         cooldown: 6,

--- a/src/Parser/Warrior/Arms/Modules/Talents/Rend.js
+++ b/src/Parser/Warrior/Arms/Modules/Talents/Rend.js
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import Enemies from 'Parser/Core/Modules/Enemies';
+import { encodeTargetString } from 'Parser/Core/Modules/EnemyInstances';
 import Analyzer from 'Parser/Core/Analyzer';
 
 const EXECUTE_RANGE = 0.2;
@@ -26,28 +27,30 @@ class RendAnalyzer extends Analyzer {
   on_byPlayer_cast(event) {
     if(SPELLS.REND_TALENT.id === event.ability.guid) {
       // If Rend is used flag the target to check their health on the next damage event.
-      this.targets.push(event.targetID);
+      this.targets.push(encodeTargetString(event.targetID, event.targetInstance));
     }
   }
 
   on_byPlayer_damage(event) {
-    const targetId = event.targetID;
+    const targetString = encodeTargetString(event.targetID, event.targetInstance);
 
-    if(SPELLS.REND_TALENT.id === event.ability.guid && this.targets.indexOf(targetId) !== -1) {
+    if(SPELLS.REND_TALENT.id === event.ability.guid && this.targets.indexOf(targetString) !== -1) {
+      // Unflag the target for checking.
+      this.targets.splice(this.targets.indexOf(targetString), 1);
+
       // Check if the target's health was within execute range.
-      if(event.hitPoints / event.maxHitPoints < EXECUTE_RANGE) {
-        if(this.failedTargets.indexOf(targetId) === -1) {
-          // If this is the first time Rend was used on this target in execute range we flag that target.
-          // This is to prevent false positives from Rend being applied just as the target enters execute range.
-          this.failedTargets.push(targetId);
-        } else {
-          // Increment the counter
-          this.rendsInExecuteRange += 1;
-        }
+      if(event.hitPoints / event.maxHitPoints >= EXECUTE_RANGE) {
+        return;
       }
 
-      // Unflag the target for checking.
-      this.targets.splice(this.targets.indexOf(targetId), 1);
+      if(this.failedTargets.indexOf(targetString) === -1) {
+        // If this is the first time Rend was used on this target in execute range we flag that target.
+        // This is to prevent false positives from Rend being applied just as the target enters execute range.
+        this.failedTargets.push(targetString);
+      } else {
+        // Increment the counter
+        this.rendsInExecuteRange += 1;
+      }
     }
   }
 
@@ -64,7 +67,7 @@ class RendAnalyzer extends Analyzer {
         return suggest(<Wrapper>You should avoid using <SpellLink id={SPELLS.REND_TALENT.id} icon/> on a target in <SpellLink id={SPELLS.EXECUTE.id} icon/> range.</Wrapper>)
           .icon(SPELLS.REND_TALENT.icon)
           .actual(`Rend was used ${actual} times on a target in execute range`)
-          .recommended('0 is recommended.');
+          .recommended(`${recommended} is recommended.`);
       });
   }
 }

--- a/src/Parser/Warrior/Arms/Modules/Talents/Rend.js
+++ b/src/Parser/Warrior/Arms/Modules/Talents/Rend.js
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import Wrapper from 'common/Wrapper';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import Enemies from 'Parser/Core/Modules/Enemies';
+import Analyzer from 'Parser/Core/Analyzer';
+
+const EXECUTE_RANGE = 0.2;
+
+class RendAnalyzer extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    enemies: Enemies,
+  };
+
+  rendsInExecuteRange = 0;
+  targets = [];
+  failedTargets = [];
+
+  on_initialized() {
+		this.active = this.combatants.selected.hasTalent(SPELLS.REND_TALENT.id);
+	}
+
+  on_byPlayer_cast(event) {
+    if(SPELLS.REND_TALENT.id === event.ability.guid) {
+      // If Rend is used flag the target to check their health on the next damage event.
+      this.targets.push(event.targetID);
+    }
+  }
+
+  on_byPlayer_damage(event) {
+    const targetId = event.targetID;
+
+    if(SPELLS.REND_TALENT.id === event.ability.guid && this.targets.indexOf(targetId) !== -1) {
+      // Check if the target's health was within execute range.
+      if(event.hitPoints / event.maxHitPoints < EXECUTE_RANGE) {
+        if(this.failedTargets.indexOf(targetId) === -1) {
+          // If this is the first time Rend was used on this target in execute range we flag that target.
+          // This is to prevent false positives from Rend being applied just as the target enters execute range.
+          this.failedTargets.push(targetId);
+        } else {
+          // Increment the counter
+          this.rendsInExecuteRange += 1;
+        }
+      }
+
+      // Unflag the target for checking.
+      this.targets.splice(this.targets.indexOf(targetId), 1);
+    }
+  }
+
+  get executeRendsThresholds() {
+    return {
+			actual: this.rendsInExecuteRange,
+			isGreaterThan: {minor: 0, average:1, major: 2},
+			style: 'number',
+		};
+  }
+
+  suggestions(when) {
+    when(this.executeRendsThresholds).addSuggestion((suggest, actual, recommended) => {
+        return suggest(<Wrapper>You should avoid using <SpellLink id={SPELLS.REND_TALENT.id} icon/> on a target in <SpellLink id={SPELLS.EXECUTE.id} icon/> range.</Wrapper>)
+          .icon(SPELLS.REND_TALENT.icon)
+          .actual(`Rend was used ${actual} times on a target in execute range`)
+          .recommended('0 is recommended.');
+      });
+  }
+}
+
+export default RendAnalyzer;

--- a/src/Parser/Warrior/Arms/Modules/Talents/Rend.js
+++ b/src/Parser/Warrior/Arms/Modules/Talents/Rend.js
@@ -1,12 +1,14 @@
 import React from 'react';
 
-import Wrapper from 'common/Wrapper';
+import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
+import Wrapper from 'common/Wrapper';
+
+import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import Enemies from 'Parser/Core/Modules/Enemies';
 import { encodeTargetString } from 'Parser/Core/Modules/EnemyInstances';
-import Analyzer from 'Parser/Core/Analyzer';
 
 const EXECUTE_RANGE = 0.2;
 
@@ -16,6 +18,7 @@ class RendAnalyzer extends Analyzer {
     enemies: Enemies,
   };
 
+  rends = 0;
   rendsInExecuteRange = 0;
   targets = [];
   failedTargets = [];
@@ -28,6 +31,8 @@ class RendAnalyzer extends Analyzer {
     if(SPELLS.REND_TALENT.id === event.ability.guid) {
       // If Rend is used flag the target to check their health on the next damage event.
       this.targets.push(encodeTargetString(event.targetID, event.targetInstance));
+
+      this.rends += 1;
     }
   }
 
@@ -56,9 +61,13 @@ class RendAnalyzer extends Analyzer {
 
   get executeRendsThresholds() {
     return {
-			actual: this.rendsInExecuteRange,
-			isGreaterThan: {minor: 0, average:1, major: 2},
-			style: 'number',
+			actual: this.rendsInExecuteRange / this.rends,
+			isGreaterThan: {
+        minor: 0,
+        average:0.05,
+        major: 0.1,
+      },
+			style: 'percent',
 		};
   }
 
@@ -66,8 +75,8 @@ class RendAnalyzer extends Analyzer {
     when(this.executeRendsThresholds).addSuggestion((suggest, actual, recommended) => {
         return suggest(<Wrapper>You should avoid using <SpellLink id={SPELLS.REND_TALENT.id} icon/> on a target in <SpellLink id={SPELLS.EXECUTE.id} icon/> range.</Wrapper>)
           .icon(SPELLS.REND_TALENT.icon)
-          .actual(`Rend was used ${actual} times on a target in execute range`)
-          .recommended(`${recommended} is recommended.`);
+          .actual(`Rend was used ${formatPercentage(actual)}% of the time on a target in execute range.`)
+          .recommended(`${formatPercentage(recommended)}% is recommended`);
       });
   }
 }


### PR DESCRIPTION
Added Rend to the ability list along with a suggestion to not use it during Execute range. 

I was limited by the cast and debuff events not having access to the enemy health, so I flagged the target id to be checked in the next damage event. This lead to an issue where damage from a good Rend would leak over into the Execute range.

As a workaround I would only flag a Rend as bad if it wasn't the first one whose first damage instance occurred in Execute range, which is probably fine as the player's triggering this suggestion are likely using Rend more than once in Execute range on the same target.

![image](https://user-images.githubusercontent.com/2950145/38588921-6225a98a-3d7c-11e8-9114-c5cc35693ade.png)
