### PR TITLE
[Windwalker] Fixed missing "Wasted Chi" tracking

### DIFF
--- a/src/Parser/Monk/Windwalker/Modules/Chi/ChiDetails.js
+++ b/src/Parser/Monk/Windwalker/Modules/Chi/ChiDetails.js
@@ -16,7 +16,7 @@ class ChiDetails extends Analyzer {
   };
 
   get suggestionThresholds() {
-    const chiWastedPerMinute = (this.chiTracker.chiWasted / this.owner.fightDuration) * 1000 * 60;
+    const chiWastedPerMinute = (this.chiTracker.wasted / this.owner.fightDuration) * 1000 * 60;
     return {
       actual: chiWastedPerMinute,
       isGreaterThan: {
@@ -29,7 +29,7 @@ class ChiDetails extends Analyzer {
   }
 
   suggestions(when) {
-    const chiWasted = this.chiTracker.chiWasted;
+    const chiWasted = this.chiTracker.wasted;
     const chiWastedPerMinute = (chiWasted / this.owner.fightDuration) * 1000 * 60;
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
       return suggest('You are wasting Chi. Try to use it and not let it cap and go to waste')

--- a/src/Parser/Monk/Windwalker/Modules/Chi/ChiTracker.js
+++ b/src/Parser/Monk/Windwalker/Modules/Chi/ChiTracker.js
@@ -10,7 +10,6 @@ class ChiTracker extends ResourceTracker {
   };
 
   maxChi = 5;
-  chiWasted = 0;
 
   on_initialized() {
     this.resource = RESOURCE_TYPES.CHI;
@@ -50,7 +49,6 @@ class ChiTracker extends ResourceTracker {
       waste = waste - (10 - this.maxChi);
     }
     this._applyBuilder(spellId, this.getResource(event), gain, waste);
-    this.chiWasted += waste;
   }
 }
 

--- a/src/Parser/Monk/Windwalker/Modules/Chi/ChiTracker.js
+++ b/src/Parser/Monk/Windwalker/Modules/Chi/ChiTracker.js
@@ -10,6 +10,7 @@ class ChiTracker extends ResourceTracker {
   };
 
   maxChi = 5;
+  chiWasted = 0;
 
   on_initialized() {
     this.resource = RESOURCE_TYPES.CHI;
@@ -49,6 +50,7 @@ class ChiTracker extends ResourceTracker {
       waste = waste - (10 - this.maxChi);
     }
     this._applyBuilder(spellId, this.getResource(event), gain, waste);
+    this.chiWasted += waste;
   }
 }
 


### PR DESCRIPTION
Was being used by checklist and ChiDetails, but was accidentally removed when updating to use core resource tracker.