### PR TITLE
[Hunter] Clarifiying notes, Parsel's Tongue and other smaller things

### DIFF
--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -107,11 +107,6 @@ export const Putro = {
   github: 'Pewtro',
   discord: 'Putro#6093',
   avatar: require('./Images/putro-avatar.png'),
-  maintainer: [
-    SPECS.MARKSMANSHIP_HUNTER,
-    SPECS.BEAST_MASTERY_HUNTER,
-    SPECS.SURVIVAL_HUNTER,
-  ],
   mains: [
     {
       name: "Putro",

--- a/src/Parser/Hunter/BeastMastery/CHANGELOG.js
+++ b/src/Parser/Hunter/BeastMastery/CHANGELOG.js
@@ -9,6 +9,11 @@ import ITEMS from 'common/ITEMS';
 
 export default [
   {
+    date: new Date('2018-04-10'),
+    changes: <Wrapper>Adds an additional statistic module for <ItemLink id={ITEMS.PARSELS_TONGUE.id} /> to better showcase the uptime of 4 stacks, and also updates the average refresh of <SpellLink id={SPELLS.DIRE_FRENZY_TALENT.id} /> to be more accurate.</Wrapper>,
+    contributors: [Putro],
+  },
+  {
     date: new Date('2018-04-05'),
     changes: <Wrapper>Updated <ItemLink id={ITEMS.PARSELS_TONGUE.id} icon /> and <SpellLink id={SPELLS.DIRE_FRENZY_TALENT.id} icon /> to include average time between refreshing, and some other minor wording changes. </Wrapper>,
     contributors: [Putro],

--- a/src/Parser/Hunter/BeastMastery/Modules/Items/ParselsTongue.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Items/ParselsTongue.js
@@ -16,8 +16,9 @@ import ItemLink from 'common/ItemLink';
 
 const DAMAGE_INCREASE_PER_STACK = 0.01;
 const LEECH_PER_STACK = 0.02;
+const MAX_STACKS = 4;
 
-/*
+/**
  * Parsel's Tongue
  * Equip: Cobra Shot increases the damage done by you and your pets by 1% and your leech by 2% for 8 sec, stacking up to 4 times.
  */
@@ -38,6 +39,19 @@ class ParselsTongue extends Analyzer {
 
   on_initialized() {
     this.active = this.combatants.selected.hasChest(ITEMS.PARSELS_TONGUE.id);
+  }
+
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.COBRA_SHOT.id) {
+      return;
+    }
+    if (this._currentStacks !== MAX_STACKS) {
+      return;
+    }
+    this.timesRefreshed++;
+    this.accumulatedTimeBetweenRefresh += event.timestamp - this.lastApplicationTimestamp;
+    this.lastApplicationTimestamp = event.timestamp;
   }
 
   on_byPlayer_applybuff(event) {

--- a/src/Parser/Hunter/BeastMastery/Modules/Items/ParselsTongue.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Items/ParselsTongue.js
@@ -14,7 +14,6 @@ import ItemDamageDone from 'Main/ItemDamageDone';
 import Wrapper from 'common/Wrapper';
 import ItemLink from 'common/ItemLink';
 import StatisticBox from 'Main/StatisticBox';
-import SpellIcon from 'common/SpellIcon';
 import ItemIcon from 'common/ItemIcon';
 
 const DAMAGE_INCREASE_PER_STACK = 0.01;

--- a/src/Parser/Hunter/BeastMastery/Modules/Items/QaplaEredunWarOrder.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Items/QaplaEredunWarOrder.js
@@ -14,6 +14,10 @@ import ItemLink from 'common/ItemLink';
 
 const COOLDOWN_REDUCTION_MS = 3000;
 
+/**
+ * Qa'pla, Eredun War Order
+ * Dire Beast or Dire Frenzy reduces the remaining cooldown on Kill Command by 3 sec.
+ */
 class QaplaEredunWarOrder extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/BeastMastery/Modules/Items/RoarOfTheSevenLions.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Items/RoarOfTheSevenLions.js
@@ -11,7 +11,7 @@ import Wrapper from 'common/Wrapper';
 import ItemLink from 'common/ItemLink';
 import SpellLink from 'common/SpellLink';
 
-/*
+/**
  * Roar of the Seven Lions
  * Equip: Bestial Wrath reduces the Focus cost of all your abilities by 15%.
  */

--- a/src/Parser/Hunter/BeastMastery/Modules/Items/TheMantleOfCommand.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Items/TheMantleOfCommand.js
@@ -11,7 +11,7 @@ import Wrapper from 'common/Wrapper';
 
 const DAMAGE_INCREASE = 0.05;
 
-/*
+/**
  * The Mantle of Command
  * Dire Beast (or Dire Frenzy) increases the damage done by your pets by 5% for 8 sec.
  */

--- a/src/Parser/Hunter/BeastMastery/Modules/Items/Tier19_2p.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Items/Tier19_2p.js
@@ -25,6 +25,11 @@ const DIRE_FRENZY_NOT_AFFECTED_PETS = [
   PETS.HATI_7.id,
 ];
 
+/**
+ * Dire Beast: When you use Bestial Wrath,  all of your currently summoned Dire Beasts gain 50% increased damage for 15 sec.
+ * Dire Frenzy: When you use Bestial Wrath, your pet gains 10% increased damage for 15 sec.
+ */
+
 class Tier19_2p extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/BeastMastery/Modules/Items/Tier20_2p.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Items/Tier20_2p.js
@@ -13,6 +13,10 @@ const T20_2P_MODIFIER_PR_STACK = 0.015;
 
 const debug = false;
 
+/**
+ * Cobra Shot, Multi-shot, and Kill Command increase the damage bonus of Bestial Wrath by 1.5% for its remaining duration.
+ */
+
 class Tier20_2p extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/BeastMastery/Modules/Items/Tier20_4p.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Items/Tier20_4p.js
@@ -13,6 +13,10 @@ const T204P_MODIFIER = 0.15;
 
 const debug = false;
 
+/**
+ * Cobra Shot, Multi-Shot, and Kill Command deal 15% increased damage while Bestial Wrath is active.
+ */
+
 class Tier20_4p extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/BeastMastery/Modules/Items/Tier21_2p.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Items/Tier21_2p.js
@@ -10,6 +10,10 @@ import ItemDamageDone from 'Main/ItemDamageDone';
 
 const T21_2P_MODIFIER = 0.1;
 
+/**
+ * Kill Command damage increased by 10%.
+ */
+
 class Tier21_2p extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/BeastMastery/Modules/Items/Tier21_4p.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Items/Tier21_4p.js
@@ -10,6 +10,10 @@ import SpellUsable from 'Parser/Core/Modules/SpellUsable';
 
 const COOLDOWN_REDUCTION_MS = 3000;
 
+/**
+ * When you use Kill Command, the cooldown of Aspect of the Wild is reduced by 3 sec.
+ */
+
 class Tier21_4p extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/BeastMastery/Modules/Spells/AspectOfTheWild.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Spells/AspectOfTheWild.js
@@ -26,7 +26,6 @@ class AspectOfTheWild extends Analyzer {
   static dependencies = {
     combatants: Combatants,
     spellUsable: SpellUsable,
-
   };
 
   totalAspectCasts = 0;
@@ -65,7 +64,7 @@ class AspectOfTheWild extends Analyzer {
 
   get badCastThreshold() {
     return {
-      actual: this.badCrowsCasts,
+      actual: this.badAspectCasts,
       isGreaterThan: {
         minor: 0,
         average: 0.9,

--- a/src/Parser/Hunter/BeastMastery/Modules/Spells/AspectOfTheWild.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Spells/AspectOfTheWild.js
@@ -21,6 +21,10 @@ const FIGHT_ENDING_USE_ASPECT = 15000;
 //allows early usage of AotW
 const USE_BEFORE_BW = 3000;
 
+/**
+ * Grants you and your pet 10 Focus per 1 sec and 10% increased critical strike chance on all attacks for 10 sec.
+ * Reduces GCD for the duration by 0.2seconds baseline.
+ */
 class AspectOfTheWild extends Analyzer {
 
   static dependencies = {

--- a/src/Parser/Hunter/BeastMastery/Modules/Spells/BeastCleave.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Spells/BeastCleave.js
@@ -6,6 +6,9 @@ import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import ItemDamageDone from 'Main/ItemDamageDone';
 
+/**
+ * After you Multi-Shot, your pet's melee attacks also strike all other nearby enemy targets for 100% as much for the next 4 sec.
+ */
 class BeastCleave extends Analyzer {
 
   static dependencies = {

--- a/src/Parser/Hunter/BeastMastery/Modules/Spells/BestialWrath/BestialWrathAverageFocus.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Spells/BestialWrath/BestialWrathAverageFocus.js
@@ -11,6 +11,11 @@ import SpellLink from "common/SpellLink";
 import STATISTIC_ORDER from 'Main/STATISTIC_ORDER';
 import Wrapper from 'common/Wrapper';
 
+/**
+ * Sends you and your pet into a rage, increasing all damage you both deal by 25% for 15 sec.
+ * Bestial Wrath's remaining cooldown is reduced by 12 sec each time you use Dire Frenzy or Dire Beast
+ */
+
 class BestialWrathAverageFocus extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/BeastMastery/Modules/Spells/BestialWrath/BestialWrathUptime.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Spells/BestialWrath/BestialWrathUptime.js
@@ -9,6 +9,11 @@ import SpellIcon from "common/SpellIcon";
 import { formatPercentage } from "common/format";
 import STATISTIC_ORDER from 'Main/STATISTIC_ORDER';
 
+/**
+ * Sends you and your pet into a rage, increasing all damage you both deal by 25% for 15 sec.
+ * Bestial Wrath's remaining cooldown is reduced by 12 sec each time you use Dire Frenzy or Dire Beast
+ */
+
 class BestialWrathUptime extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/BeastMastery/Modules/Spells/BestialWrath/GainedBestialWraths.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Spells/BestialWrath/GainedBestialWraths.js
@@ -11,6 +11,11 @@ import STATISTIC_ORDER from 'Main/STATISTIC_ORDER';
 let COOLDOWN_REDUCTION_MS = 12000;
 const BESTIAL_WRATH_BASE_CD = 90000;
 
+/**
+ * Sends you and your pet into a rage, increasing all damage you both deal by 25% for 15 sec.
+ * Bestial Wrath's remaining cooldown is reduced by 12 sec each time you use Dire Frenzy or Dire Beast
+ */
+
 class GainedBestialWraths extends Analyzer {
   static dependencies = {
     combatants: Combatants,
@@ -25,6 +30,7 @@ class GainedBestialWraths extends Analyzer {
       COOLDOWN_REDUCTION_MS = 16000;
     }
   }
+
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
     if (spellId !== SPELLS.DIRE_BEAST.id && spellId !== SPELLS.DIRE_FRENZY_TALENT.id) {

--- a/src/Parser/Hunter/BeastMastery/Modules/Spells/DireBeast/DireBeast.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Spells/DireBeast/DireBeast.js
@@ -12,6 +12,11 @@ import Wrapper from 'common/Wrapper';
 //Threshhold for when there is less than 3s remaining on Bestial Wrath to not cast Dire Beast
 const CD_ON_BESTIAL_WRATH_BAD_DB_THRESHHOLD = 3000;
 
+/**
+ * Summons a powerful wild beast to attack your target for 8 sec.
+ * Generates 12 Focus over 8 sec.
+ */
+
 class DireBeast extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/BeastMastery/Modules/Spells/DireBeast/DireBeastUptime.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Spells/DireBeast/DireBeastUptime.js
@@ -7,6 +7,10 @@ import SpellIcon from "common/SpellIcon";
 import { formatPercentage } from "common/format";
 import STATISTIC_ORDER from 'Main/STATISTIC_ORDER';
 
+/**
+ * Summons a powerful wild beast to attack your target for 8 sec.
+ * Generates 12 Focus over 8 sec.
+ */
 class DireBeastUptime extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/BeastMastery/Modules/Talents/AMurderOfCrows.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Talents/AMurderOfCrows.js
@@ -21,6 +21,11 @@ const BESTIAL_WRATH_REMAINING_USE_CROWS = 7000;
 //Duration of Bestial Wrath
 const BESTIAL_WRATH_DURATION = 15000;
 
+/**
+ * Summons a flock of crows to attack your target, dealing [(162% of Attack power) * 16] Physical damage over 15 sec. When a target dies
+ * while affected by this ability, its cooldown will reset.
+ */
+
 class AMurderOfCrows extends Analyzer {
 
   static dependencies = {

--- a/src/Parser/Hunter/BeastMastery/Modules/Talents/BestialFury.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Talents/BestialFury.js
@@ -14,6 +14,10 @@ const BESTIAL_FURY_MODIFIER = (1.4 / 1.25) - 1;
 
 const debug = false;
 
+/**
+ * Increase the damage bonus of Bestial Wrath by 15%.
+ */
+
 class BestialFury extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/BeastMastery/Modules/Talents/BlinkStrikes.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Talents/BlinkStrikes.js
@@ -21,6 +21,11 @@ const BLINK_STRIKES_NOT_AFFECTED_PETS = [
   PETS.HATI_7.id,
 ];
 
+/**
+ * Your pet's Basic Attack deals 100% increased damage, can now be used from 30 yards away, and will instantly teleport your pet behind its
+ * target. Your pet can teleport only once per 20 sec.
+ */
+
 class BlinkStrikes extends Analyzer {
 
   static dependencies = {

--- a/src/Parser/Hunter/BeastMastery/Modules/Talents/ChimaeraShot.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Talents/ChimaeraShot.js
@@ -5,6 +5,10 @@ import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import ItemDamageDone from 'Main/ItemDamageDone';
 
+/**
+ * A two-headed shot that hits your primary target and another nearby target, dealing 720% Nature damage to one and 720% Frost damage to
+ * the other.
+ */
 class ChimaeraShot extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/BeastMastery/Modules/Talents/DireFrenzy.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Talents/DireFrenzy.js
@@ -11,7 +11,7 @@ import StatisticBox from 'Main/StatisticBox';
 import ItemDamageDone from 'Main/ItemDamageDone';
 import Wrapper from 'common/Wrapper';
 
-/*
+/**
  * Dire Frenzy
  * Causes your pet to enter a frenzy, performing a flurry of 5 attacks on the target,
  * and gaining 30% increased attack speed for 8 sec, stacking up to 3 times.
@@ -51,6 +51,12 @@ class DireFrenzy extends Analyzer {
       return;
     }
     this.lastDireFrenzyCast = event.timestamp;
+
+    if (this.currentStacks === MAX_DIRE_FRENZY_STACKS) {
+      this.timesRefreshed++;
+      this.accumulatedTimeBetweenRefresh += event.timestamp - this.lastApplicationTimestamp;
+      this.lastApplicationTimestamp = event.timestamp;
+    }
   }
 
   on_byPlayerPet_damage(event) {

--- a/src/Parser/Hunter/BeastMastery/Modules/Talents/DireFrenzy.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Talents/DireFrenzy.js
@@ -51,7 +51,6 @@ class DireFrenzy extends Analyzer {
       return;
     }
     this.lastDireFrenzyCast = event.timestamp;
-
     if (this.currentStacks === MAX_DIRE_FRENZY_STACKS) {
       this.timesRefreshed++;
       this.accumulatedTimeBetweenRefresh += event.timestamp - this.lastApplicationTimestamp;
@@ -79,6 +78,7 @@ class DireFrenzy extends Analyzer {
     this.currentStacks = 0;
     this.timeCalculated = true;
   }
+
   on_byPlayer_applybuff(event) {
     const spellId = event.ability.guid;
     if (spellId !== SPELLS.DIRE_FRENZY_TALENT.id) {
@@ -94,8 +94,8 @@ class DireFrenzy extends Analyzer {
     this.currentStacks = 1;
     this.timeCalculated = false;
     this.lastApplicationTimestamp = event.timestamp;
-
   }
+
   on_byPlayer_applybuffstack(event) {
     const spellId = event.ability.guid;
     if (spellId !== SPELLS.DIRE_FRENZY_TALENT.id) {
@@ -133,6 +133,7 @@ class DireFrenzy extends Analyzer {
   get percentUptimeMaxStacks() {
     return this.timeAtMaxStacks / this.owner.fightDuration;
   }
+
   get percentUptimePet() {
     return this.timeBuffed / this.owner.fightDuration;
   }
@@ -157,6 +158,7 @@ class DireFrenzy extends Analyzer {
       style: 'percentage',
     };
   }
+
   get direFrenzy3StackThreshold() {
     return {
       actual: this.percentUptimeMaxStacks,
@@ -184,6 +186,7 @@ class DireFrenzy extends Analyzer {
         .recommended(`${formatPercentage(recommended)}% is recommended`);
     });
   }
+
   statistic() {
     return (
       <StatisticBox

--- a/src/Parser/Hunter/BeastMastery/Modules/Talents/DireStable.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Talents/DireStable.js
@@ -11,6 +11,9 @@ const ADDITIONAL_FOCUS_PER_SUMMON = 12;
 
 const DIREBEAST_DURATION = 8000;
 
+/**
+ * Dire Beast or Dire Frenzy generates 12 additional Focus over its duration.
+ */
 class DireStable extends Analyzer {
   static dependencies = {
     combatants: Combatants,
@@ -28,13 +31,16 @@ class DireStable extends Analyzer {
     return ADDITIONAL_FOCUS_PER_SUMMON / (DIREBEAST_DURATION / 1000);
   }
 
+  get gainedFocus() {
+    return this.focusPerSecondFromDireStable * this.buffUptimeInSeconds;
+  }
+
   statistic() {
-    const gainedFocus = this.focusPerSecondFromDireStable * this.buffUptimeInSeconds;
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.DIRE_STABLE_TALENT.id} />}
-        value={formatNumber(gainedFocus)}
-        label="Additional focus gained"
+        value={formatNumber(this.gainedFocus / this.owner.fightDuration * 60000)}
+        label="Focus gain/minute"
       />
     );
   }

--- a/src/Parser/Hunter/BeastMastery/Modules/Talents/KillerCobra.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Talents/KillerCobra.js
@@ -11,6 +11,10 @@ import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';
 import GlobalCooldown from 'Parser/Core/Modules/GlobalCooldown';
 
+/**
+ * While Bestial Wrath is active, Cobra Shot resets the cooldown on Kill Command.
+ */
+
 class KillerCobra extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/BeastMastery/Modules/Talents/Stampede.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Talents/Stampede.js
@@ -6,6 +6,10 @@ import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import ItemDamageDone from 'Main/ItemDamageDone';
 
+/**
+ * Summon a herd of stampeding animals from the wilds around you that deal damage to your enemies for 12 sec.
+ */
+
 class Stampede extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/BeastMastery/Modules/Talents/Stomp.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Talents/Stomp.js
@@ -6,6 +6,11 @@ import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import ItemDamageDone from 'Main/ItemDamageDone';
 
+/**
+ * When your Dire Beasts charge in, they will stomp the ground, dealing [(1.18) * ((300% of Attack power)) * 1.4] Physical damage to all
+ * nearby enemies.
+ */
+
 class Stomp extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/BeastMastery/Modules/Talents/WayOfTheCobra.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Talents/WayOfTheCobra.js
@@ -12,6 +12,9 @@ const WAY_OF_THE_COBRA_MODIFIER = 0.1;
 // We'll always have main pet and hati out
 const MINIMUM_PETS = 2;
 
+/**
+ * Cobra Shot deals 10% increased damage for every pet or guardian you have active.
+ */
 class WayOfTheCobra extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/BeastMastery/Modules/Traits/CobraCommander.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Traits/CobraCommander.js
@@ -6,6 +6,9 @@ import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import ItemDamageDone from 'Main/ItemDamageDone';
 
+/**
+ * Cobra Shot has a 10% chance to create 2-4 Sneaky Snakes that attack the target for 6 sec.
+ */
 class CobraCommander extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/BeastMastery/Modules/Traits/SurgeOfTheStormgod.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Traits/SurgeOfTheStormgod.js
@@ -6,6 +6,10 @@ import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import ItemDamageDone from 'Main/ItemDamageDone';
 
+/**
+ * When you use Multi-Shot, Titanstrike has a chance to discharge an electric current at your pets' locations, causing an explosion of
+ * electricity that deals (Ranged attack power * 2) Nature damage to all nearby enemies.
+ */
 class SurgeOfTheStormgod extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/BeastMastery/Modules/Traits/Thunderslash.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Traits/Thunderslash.js
@@ -6,6 +6,10 @@ import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import ItemDamageDone from 'Main/ItemDamageDone';
 
+/**
+ * While Aspect of the Wild is active, Hati and your primary pet also trigger a Thunderslash with each auto attack, dealing ((50% of Attack
+ * power) * (1 * 0.96 * 1.06)) Nature damage.
+ */
 class Thunderslash extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/BeastMastery/Modules/Traits/TitansThunder.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Traits/TitansThunder.js
@@ -15,6 +15,13 @@ const debug = false;
 
 const TITANS_THUNDER_USE_REGARDLESS_THRESHHOLD = 30000;
 
+/**
+ * Dire Beast: Discharge a massive jolt of electricity from Titanstrike into all your pets and Dire Beasts, causing them to deal up to (Ranged attack power * 1.15 * 0.5 * 1) Nature damage to their target every 1 sec. for 8 sec.
+ *
+ * Dire Frenzy: also causes your next Dire Frenzy to deal (200% of Attack power) additional Nature damage on each of the 5 Dire Frenzy
+ * attacks
+ */
+
 class TitansThunder extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/Marksmanship/Modules/Features/AimedInVulnerableTracker.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Features/AimedInVulnerableTracker.js
@@ -13,6 +13,11 @@ import { formatPercentage } from "common/format";
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Wrapper from 'common/Wrapper';
 
+/**
+ * Vulnerable
+ * Damage taken from Aimed Shot and Piercing Shot increased by 30% for 7 sec.
+ */
+
 class AimedInVulnerableTracker extends Analyzer {
   static dependencies = {
     enemies: Enemies,

--- a/src/Parser/Hunter/Marksmanship/Modules/Features/VulnerableApplications.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Features/VulnerableApplications.js
@@ -14,6 +14,11 @@ const CHART_SIZE = 50;
 
 //code grabbed from Parser/Paladin/Holy/Modules/PaladinCore/CastBehavior.js
 
+/**
+ * Vulnerable
+ * Damage taken from Aimed Shot and Piercing Shot increased by 30% for 7 sec.
+ */
+
 class VulnerableApplications extends Analyzer {
 
   windburstCasts = 0;

--- a/src/Parser/Hunter/Marksmanship/Modules/Features/VulnerableUptime.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Features/VulnerableUptime.js
@@ -10,6 +10,11 @@ import { formatPercentage } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Wrapper from 'common/Wrapper';
 
+/**
+ * Vulnerable
+ * Damage taken from Aimed Shot and Piercing Shot increased by 30% for 7 sec.
+ */
+
 class VulnerableUpTime extends Analyzer {
   static dependencies = {
     enemies: Enemies,

--- a/src/Parser/Hunter/Marksmanship/Modules/Spells/Trueshot.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Spells/Trueshot.js
@@ -114,7 +114,7 @@ class Trueshot extends Analyzer {
       <StatisticBox icon={<SpellIcon id={SPELLS.TRUESHOT.id} />}
         value={(
           <Wrapper>
-            {this.averageAimedShots}{' '}
+            {this.averageAimedShots.toFixed(2)}{' '}
             <SpellIcon
               id={SPELLS.AIMED_SHOT.id}
               style={{

--- a/src/Parser/Hunter/Shared/Modules/Talents/AspectOfTheBeast.js
+++ b/src/Parser/Hunter/Shared/Modules/Talents/AspectOfTheBeast.js
@@ -7,6 +7,16 @@ import SpellLink from 'common/SpellLink';
 import ItemDamageDone from 'Main/ItemDamageDone';
 import Wrapper from 'common/Wrapper';
 
+/**
+ *
+ * Beast Mastery: Kill Command causes an additional effect, based on your pet's Specialization.
+ * Survival: Flanking Strike causes an additional effect, based on your pet's Specialization.
+ *
+ * Ferocity: The target also bleeds for (270% of Attack power) Physical damage over 6 sec.
+ * Tenacity: Your pet also takes 30% reduced damage for 6 sec.
+ * Cunning: The target's movement speed is also reduced by 50% for 4 sec.
+ */
+
 class AspectOfTheBeast extends Analyzer {
 
   static dependencies = {

--- a/src/Parser/Hunter/Shared/Modules/Talents/Barrage.js
+++ b/src/Parser/Hunter/Shared/Modules/Talents/Barrage.js
@@ -7,7 +7,7 @@ import SPELLS from 'common/SPELLS';
 import SpellLink from "common/SpellLink";
 import ItemDamageDone from 'Main/ItemDamageDone';
 
-/*
+/**
  * Rapidly fires a spray of shots for 3 sec, dealing an average of (80% * 10) Physical damage to all enemies in front of you.
  * Usable while moving.
  */

--- a/src/Parser/Hunter/Shared/Modules/Talents/Volley.js
+++ b/src/Parser/Hunter/Shared/Modules/Talents/Volley.js
@@ -8,7 +8,7 @@ import SpellLink from "common/SpellLink";
 import ItemDamageDone from 'Main/ItemDamageDone';
 import Wrapper from 'common/Wrapper';
 
-/*
+/**
  * While active, your auto attacks spend 3 Focus to also launch a volley of shots that hit the target and all other nearby enemies, dealing (100% of Attack power) additional Physical damage.
  */
 class Volley extends Analyzer {

--- a/src/Parser/Hunter/Survival/CHANGELOG.js
+++ b/src/Parser/Hunter/Survival/CHANGELOG.js
@@ -9,6 +9,11 @@ import ItemLink from 'common/ItemLink';
 
 export default [
   {
+    date: new Date('2018-04-10'),
+    changes: <Wrapper>Adds a <SpellLink id={SPELLS.ASPECT_OF_THE_EAGLE.id} /> module to provide suggestions with poor usage, and also updates <SpellLink id={SPELLS.MOKNATHAL_TACTICS.id} /> module to be more accurate when displaying refreshes.</Wrapper>,
+    contributors: [Putro],
+  },
+  {
     date: new Date('2018-04-05'),
     changes: <Wrapper>Added tracking for <SpellLink id={SPELLS.ON_THE_TRAIL_DAMAGE.id} icon /> and <SpellLink id={SPELLS.LACERATE.id} icon /> to help identify when you're casting this too much. Added additional refreshing information into <SpellLink id={SPELLS.MOKNATHAL_TACTICS.id} icon /> module, aswell as average time remaining on <SpellLink id={SPELLS.MONGOOSE_FURY.id} icon /> upon using <SpellLink id={SPELLS.FURY_OF_THE_EAGLE_TRAIT.id} icon /> and other minor behind the scenes updates. </Wrapper>,
     contributors: [Putro],

--- a/src/Parser/Hunter/Survival/CombatLogParser.js
+++ b/src/Parser/Hunter/Survival/CombatLogParser.js
@@ -36,6 +36,7 @@ import FrizzosFingertrap from './Modules/Items/FrizzosFingertrap';
 //Spells
 import ExplosiveTrap from './Modules/Spells/ExplosiveTrap';
 import Lacerate from './Modules/Spells/Lacerate';
+import AspectOfTheEagle from './Modules/Spells/AspectOfTheEagle';
 
 //Talents
 import WayOfTheMokNathal from './Modules/Talents/WayOfTheMokNathal';
@@ -103,6 +104,7 @@ class CombatLogParser extends CoreCombatLogParser {
     //Spells
     explosiveTrap: ExplosiveTrap,
     lacerate: Lacerate,
+    aspectOfTheEagle: AspectOfTheEagle,
 
     //Talents
     wayOfTheMokNathal: WayOfTheMokNathal,

--- a/src/Parser/Hunter/Survival/Modules/Features/MongooseFury/SixBiteWindows.js
+++ b/src/Parser/Hunter/Survival/Modules/Features/MongooseFury/SixBiteWindows.js
@@ -8,6 +8,11 @@ import STATISTIC_ORDER from 'Main/STATISTIC_ORDER';
 
 const MAX_STACKS = 6;
 
+/**
+ * Mongoose Fury increases Mongoose Bite damage by 50% for 14 sec, stacking up to 6 times. Successive
+ * attacks do not increase duration.
+ */
+
 class SixBiteWindows extends Analyzer {
 
   _currentStacks = 0;

--- a/src/Parser/Hunter/Survival/Modules/Features/MongooseFury/SixStackBites.js
+++ b/src/Parser/Hunter/Survival/Modules/Features/MongooseFury/SixStackBites.js
@@ -10,6 +10,11 @@ const MAX_STACKS = 6;
 
 const MONGOOSE_FURY_DURATION = 14000;
 
+/**
+ * Mongoose Fury increases Mongoose Bite damage by 50% for 14 sec, stacking up to 6 times. Successive
+ * attacks do not increase duration.
+ */
+
 class SixStackBites extends Analyzer {
 
   _currentStacks = 0;

--- a/src/Parser/Hunter/Survival/Modules/Spells/AspectOfTheEagle.js
+++ b/src/Parser/Hunter/Survival/Modules/Spells/AspectOfTheEagle.js
@@ -1,0 +1,64 @@
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import SPELLS from 'common/SPELLS';
+import React from 'react';
+import Wrapper from 'common/Wrapper';
+import SixStackBites from 'Parser/Hunter/Survival/Modules/Features/MongooseFury/SixStackBites';
+import { formatPercentage } from 'common/format';
+import SpellLink from 'common/SpellLink';
+
+//Aspect of the Eagle lasts 10 seconds, but to allow for the player to have a bit of leeway, we'll allow down to 9 seconds remaining on Mongoose Fury for it to count as a good usage
+const MINIMUM_TIME_REMAINING = 9000;
+
+/**
+ * Grants you and your pet 10% increased Critical Strike chance on all abilities,
+ * and your pet's attacks have an additional 25% chance to grant you a charge of
+ * Mongoose Bite. Lasts 10 sec.
+ */
+class AspectOfTheEagle extends Analyzer {
+
+  static dependencies = {
+    combatants: Combatants,
+    sixStackBites: SixStackBites,
+  };
+
+  aspectCasts = 0;
+  badAspectCasts = 0;
+
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.ASPECT_OF_THE_EAGLE.id) {
+      return;
+    }
+    this.aspectCasts++;
+    if (!this.combatants.selected.hasBuff(SPELLS.MONGOOSE_FURY.id) || this.sixStackBites.mongooseFuryEndTimestamp < event.timestamp + MINIMUM_TIME_REMAINING) {
+      this.badAspectCasts++;
+    }
+  }
+
+  get badAspectCastsPercentage() {
+    return this.badAspectCasts / this.aspectCasts;
+  }
+  get badAspectCastsThreshold() {
+    return {
+      actual: this.badAspectCasts,
+      isLessThan: {
+        minor: 0.1,
+        average: 0.2,
+        major: 0.3,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.badAspectCastsThreshold).addSuggestion((suggest, actual, recommended) => {
+      return suggest(<Wrapper>You cast <SpellLink id={SPELLS.ASPECT_OF_THE_EAGLE.id} /> {this.badAspectCasts} {this.badAspectCasts > 1 ? 'times' : 'time'} without <SpellLink id={SPELLS.MONGOOSE_FURY.id} /> up or with less than {MINIMUM_TIME_REMAINING / 1000} seconds remaining, and thus not utilising the full duration of <SpellLink id={SPELLS.ASPECT_OF_THE_EAGLE.id} /> (and by extension <SpellLink id={SPELLS.ASPECT_OF_THE_SKYLORD_BUFF.id} />) inside a <SpellLink id={SPELLS.MONGOOSE_FURY.id} /> window. </Wrapper>)
+        .icon(SPELLS.ASPECT_OF_THE_EAGLE.icon)
+        .actual(`${formatPercentage(actual)}% of casts were bad`)
+        .recommended(`>${formatPercentage(recommended)}% is recommended`);
+    });
+  }
+}
+
+export default AspectOfTheEagle;

--- a/src/Parser/Hunter/Survival/Modules/Spells/ExplosiveTrap.js
+++ b/src/Parser/Hunter/Survival/Modules/Spells/ExplosiveTrap.js
@@ -8,6 +8,11 @@ import SpellUsable from 'Parser/Core/Modules/SpellUsable';
 import SpellLink from 'common/SpellLink';
 import ItemDamageDone from 'Main/ItemDamageDone';
 
+/**
+ * Hurls a fire trap to the target location  that explodes when an enemy approaches, causing (420% of
+ * Attack power) Fire damage and burning all enemies within 8 yards for (420% of Attack power)
+ * additional Fire damage over 10 sec. Trap will exist for 1 min.
+ */
 class ExplosiveTrap extends Analyzer {
 
   static dependencies = {

--- a/src/Parser/Hunter/Survival/Modules/Spells/Lacerate.js
+++ b/src/Parser/Hunter/Survival/Modules/Spells/Lacerate.js
@@ -10,6 +10,7 @@ import Wrapper from 'common/Wrapper';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import ITEMS from 'common/ITEMS/HUNTER';
 import SpellLink from 'common/SpellLink';
+import ItemLink from 'common/ItemLink';
 
 const T20_2P_INCREASE = 6000;
 
@@ -173,7 +174,7 @@ class Lacerate extends Analyzer {
   suggestions(when) {
     if (this.combatants.selected.hasBuff(SPELLS.HUNTER_SV_T20_2P_BONUS.id)) {
       when(this.uptimeThreshold).addSuggestion((suggest, actual, recommended) => {
-        return suggest(<Wrapper>memes</Wrapper>)
+        return suggest(<Wrapper>When you're using <ItemLink id={ITEMS.HUNTER_SV_T20_2P_BONUS.id} />, it's worth maintaining a higher uptime of <SpellLink id={SPELLS.LACERATE.id} /> than you otherwise would.</Wrapper>)
           .icon(SPELLS.LACERATE.icon)
           .actual(`${formatPercentage(actual)}% Lacerate uptime`)
           .recommended(`>${formatPercentage(recommended)}% is recommended`);

--- a/src/Parser/Hunter/Survival/Modules/Spells/Lacerate.js
+++ b/src/Parser/Hunter/Survival/Modules/Spells/Lacerate.js
@@ -13,10 +13,11 @@ import SpellLink from 'common/SpellLink';
 
 const T20_2P_INCREASE = 6000;
 
-const EARLIEST_REFRESH = 3600;
+const EARLIEST_REFRESH = 0.3;
 
-const debug = false;
-
+/**
+ * Tears a bleeding wound in the target, dealing [(964.8% of Attack power) + (187.2% of Attack power)] Physical damage over 12 sec.
+ */
 class Lacerate extends Analyzer {
 
   static dependencies = {
@@ -27,6 +28,7 @@ class Lacerate extends Analyzer {
   bonusDamage = 0;
   casts = 0;
   lacerateDuration = 12000;
+  _earliestRefresh = EARLIEST_REFRESH * this.lacerateDuration;
   lastCastTimestamp = 0;
   lacerateTargets = [];
   badRefresh = 0;
@@ -36,6 +38,10 @@ class Lacerate extends Analyzer {
   on_initialized() {
     if (this.combatants.selected.hasBuff(SPELLS.HUNTER_SV_T20_2P_BONUS.id)) {
       this.lacerateDuration += T20_2P_INCREASE;
+    }
+    //Using the boots grants you more focus, allowing you to more liberally be casting Lacerate
+    if (this.combatants.selected.hasFeet(ITEMS.NESINGWARYS_TRAPPING_TREADS.id)) {
+      this._earliestRefresh += 0.1 * this.lacerateDuration;
     }
   }
 
@@ -90,8 +96,7 @@ class Lacerate extends Analyzer {
     const lacerateTarget = { targetID: event.targetID, targetInstance: targetInstance, timestamp: event.timestamp };
     for (let i = 0; i <= this.lacerateTargets.length - 1; i++) {
       if (this.lacerateTargets[i].targetID === lacerateTarget.targetID && this.lacerateTargets[i].targetInstance === lacerateTarget.targetInstance) {
-        debug && console.log(event.timestamp - this.lacerateTargets[i].timestamp);
-        if (event.timestamp - this.lacerateTargets[i].timestamp > EARLIEST_REFRESH) {
+        if (event.timestamp - this.lacerateTargets[i].timestamp < (this.lacerateDuration - this._earliestRefresh)) {
           this.badRefresh++;
         }
         this.accumulatedTimeBetweenRefresh += event.timestamp - this.lacerateTargets[i].timestamp;
@@ -123,10 +128,10 @@ class Lacerate extends Analyzer {
     if (this.combatants.selected.hasBuff(SPELLS.HUNTER_SV_T20_2P_BONUS.id)) {
       return {
         actual: this.uptimePercentage,
-        isGreaterThan: {
-          minor: 0.9,
-          average: 0.95,
-          major: 0.99,
+        isLessThan: {
+          minor: 0.95,
+          average: 0.90,
+          major: 0.80,
         },
         style: 'percentage',
       };
@@ -134,8 +139,8 @@ class Lacerate extends Analyzer {
       return {
         actual: this.uptimePercentage,
         isGreaterThan: {
-          minor: 0.85,
-          average: 0.875,
+          minor: 0.875,
+          average: 0.9,
           major: 0.95,
         },
         style: 'percentage',
@@ -157,20 +162,35 @@ class Lacerate extends Analyzer {
     return {
       actual: this.badRefresh,
       isGreaterThan: {
-        minor: 0,
-        average: 2,
-        major: 4,
+        minor: 1,
+        average: 3,
+        major: 5,
       },
       style: 'number',
     };
   }
 
   suggestions(when) {
-    when(this.uptimeThreshold).addSuggestion((suggest, actual, recommended) => {
-      return suggest(<Wrapper>Having a high <SpellLink id={SPELLS.LACERATE.id} icon /> uptime isn't necessarily optimal, it's generally used purely as a filler to dump focus when you have nothing else to do apart from casting non-buffed <SpellLink id={SPELLS.RAPTOR_STRIKE.id} icon />.</Wrapper>)
+    if (this.combatants.selected.hasBuff(SPELLS.HUNTER_SV_T20_2P_BONUS.id)) {
+      when(this.uptimeThreshold).addSuggestion((suggest, actual, recommended) => {
+        return suggest(<Wrapper>memes</Wrapper>)
+          .icon(SPELLS.LACERATE.icon)
+          .actual(`${formatPercentage(actual)}% Lacerate uptime`)
+          .recommended(`>${formatPercentage(recommended)}% is recommended`);
+      });
+    } else {
+      when(this.uptimeThreshold).addSuggestion((suggest, actual, recommended) => {
+        return suggest(<Wrapper>Having a high <SpellLink id={SPELLS.LACERATE.id} icon /> uptime isn't necessarily optimal, it's generally used purely as a filler to dump focus when you have nothing else to do apart from casting non-buffed <SpellLink id={SPELLS.RAPTOR_STRIKE.id} icon />.</Wrapper>)
+          .icon(SPELLS.LACERATE.icon)
+          .actual(`${formatPercentage(actual)}% Lacerate uptime`)
+          .recommended(`<${formatPercentage(recommended)}% is recommended`);
+      });
+    }
+    when(this.refreshingThreshold).addSuggestion((suggest, actual, recommended) => {
+      return suggest(<Wrapper>Due to the overall low dmg output of <SpellLink id={SPELLS.LACERATE.id} /> and the fact that it pandemics, it is generally not recommended to refresh <SpellLink id={SPELLS.LACERATE.id} /> earlier than when there is less than {(this._earliestRefresh / 1000).toFixed(1)} seconds remaining on the debuff.</Wrapper>)
         .icon(SPELLS.LACERATE.icon)
-        .actual(`${formatPercentage(actual)}% Lacerate uptime`)
-        .recommended(`<${formatPercentage(recommended)}% is recommended`);
+        .actual(`${actual} Lacerate cast(s) were cast too early`)
+        .recommended(`>${recommended} is recommended`);
     });
   }
 

--- a/src/Parser/Hunter/Survival/Modules/Talents/AMurderOfCrows.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/AMurderOfCrows.js
@@ -8,6 +8,10 @@ import SpellUsable from 'Parser/Core/Modules/SpellUsable';
 import SpellLink from 'common/SpellLink';
 import ItemDamageDone from 'Main/ItemDamageDone';
 
+/**
+ * Summons a flock of crows to attack your target over the next 15 sec. If the target dies while under attack, A Murder of Crows' cooldown
+ * is reset.
+ */
 class AMurderOfCrows extends Analyzer {
 
   static dependencies = {

--- a/src/Parser/Hunter/Survival/Modules/Talents/ButcheryCarve.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/ButcheryCarve.js
@@ -13,6 +13,10 @@ import ITEMS from 'common/ITEMS/HUNTER';
 import Hellcarver from 'Parser/Hunter/Survival/Modules/Traits/Hellcarver';
 import { formatNumber, formatPercentage } from 'common/format';
 
+/**
+ * Carve: A sweeping attack that strikes all enemies in front of you for 324% Physical damage.
+ * Butchery: Strike all nearby enemies in a flurry of strikes, inflicting 694% Physical damage to each.
+ */
 class ButcheryCarve extends Analyzer {
 
   static dependencies = {

--- a/src/Parser/Hunter/Survival/Modules/Talents/Caltrops.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/Caltrops.js
@@ -13,6 +13,10 @@ import { formatPercentage } from 'common/format';
 import StatisticBox from 'Main/StatisticBox';
 import Wrapper from 'common/Wrapper';
 
+/**
+ * Scatters Caltrops in an area for 15 sec. Enemies who step on Caltrops will take (45% of Attack power) Bleed damage every 1 sec, and
+ * have 70% reduced movement speed for 6 sec.
+ */
 class Caltrops extends Analyzer {
 
   static dependencies = {

--- a/src/Parser/Hunter/Survival/Modules/Talents/DragonsfireGrenade.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/DragonsfireGrenade.js
@@ -8,6 +8,10 @@ import SpellUsable from 'Parser/Core/Modules/SpellUsable';
 import SpellLink from 'common/SpellLink';
 import ItemDamageDone from 'Main/ItemDamageDone';
 
+/**
+ * Hurls a dragonsfire grenade at the target that explodes into flames, inflicting [(1304% of Attack power) + (400% of Attack power)] Fire
+ * damage over 8 sec and reducing movement speed by 20%. The volatile flames on the target also scorch nearby enemies.
+ */
 class DragonsfireGrenade extends Analyzer {
 
   static dependencies = {

--- a/src/Parser/Hunter/Survival/Modules/Talents/MortalWounds.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/MortalWounds.js
@@ -8,6 +8,9 @@ import SpellIcon from 'common/SpellIcon';
 
 const RESET_CHANCE_PER_TICK = 0.02;
 
+/**
+ * Each time Lacerate deals damage, you have a 2% chance to gain a charge of Mongoose Bite.
+ */
 class MortalWounds extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/Survival/Modules/Talents/SerpentSting.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/SerpentSting.js
@@ -8,6 +8,9 @@ import SpellLink from 'common/SpellLink';
 import ItemDamageDone from 'Main/ItemDamageDone';
 import ITEMS from 'common/ITEMS/HUNTER';
 
+/**
+ * Targets hit by your Raptor Strike and Carve are also affected by Serpent Sting, dealing (864% of Attack power) Nature damage over 15 sec.
+ */
 class SerpentSting extends Analyzer {
 
   static dependencies = {

--- a/src/Parser/Hunter/Survival/Modules/Talents/SpittingCobra.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/SpittingCobra.js
@@ -9,6 +9,9 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import SpellUsable from 'Parser/Core/Modules/SpellUsable';
 import { formatNumber } from 'common/format';
 
+/**
+ * Summons a Spitting Cobra for 30 sec that attacks your target for (100% of Attack power) Nature damage every 2 sec. While the Cobra is active you gain an extra 3 Focus every 1 sec.
+ */
 class SpittingCobra extends Analyzer {
 
   static dependencies = {

--- a/src/Parser/Hunter/Survival/Modules/Talents/SteelTrap.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/SteelTrap.js
@@ -8,6 +8,14 @@ import SpellUsable from 'Parser/Core/Modules/SpellUsable';
 import SpellLink from 'common/SpellLink';
 import ItemDamageDone from 'Main/ItemDamageDone';
 
+/**
+ * Replaces Freezing Trap
+ * Hurls a Steel Trap to the target location that immobilizes the first enemy that approaches for 30 sec and deals (1500% of Attack power)
+ * bleed damage over 30 sec. Other damage may break the immobilization effect. Limit 1. Trap will exist for 1 min.
+ *
+ * Waylay: Fully arms after 2 sec, dealing 500% increased damage if triggered by an enemy that is not in combat.
+ */
+
 class SteelTrap extends Analyzer {
 
   static dependencies = {

--- a/src/Parser/Hunter/Survival/Modules/Talents/ThrowingAxes.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/ThrowingAxes.js
@@ -6,6 +6,9 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import SpellLink from 'common/SpellLink';
 import ItemDamageDone from 'Main/ItemDamageDone';
 
+/**
+ * Tosses 3 axes at an enemy, each dealing (312.5% of Attack power) Physical damage. 2 Charges. 15 seconds recharge.
+ */
 class ThrowingAxes extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/Survival/Modules/Talents/WayOfTheMokNathal.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/WayOfTheMokNathal.js
@@ -12,6 +12,8 @@ import Wrapper from 'common/Wrapper';
 
 const MAX_STACKS = 4;
 
+const debug = true;
+
 class WayOfTheMokNathal extends Analyzer {
   static dependencies = {
     combatants: Combatants,
@@ -27,10 +29,6 @@ class WayOfTheMokNathal extends Analyzer {
 
   on_initialized() {
     this.active = this.combatants.selected.hasTalent(SPELLS.WAY_OF_THE_MOKNATHAL_TALENT.id);
-  }
-
-  get overallUptime() {
-    return this.combatants.selected.getBuffUptime(SPELLS.MOKNATHAL_TACTICS.id) / this.owner.fightDuration;
   }
 
   on_byPlayer_applybuff(event) {
@@ -85,15 +83,18 @@ class WayOfTheMokNathal extends Analyzer {
     if (this._currentStacks === MAX_STACKS) {
       this._fourStackUptime += this.owner.fight.end_time - this._fourStackStart;
     }
-    console.log("4 stack uptime: ", this.fourStackUptimeInPercentage, "%");
   }
 
   get fourStackUptimeInPercentage() {
-    return formatPercentage(this._fourStackUptime / this.owner.fightDuration);
+    return this._fourStackUptime / this.owner.fightDuration;
   }
 
   get averageTimeBetweenRefresh() {
     return (this.accumulatedTimeBetweenRefresh / this.timesRefreshed / 1000).toFixed(2);
+  }
+
+  get overallUptime() {
+    return this.combatants.selected.getBuffUptime(SPELLS.MOKNATHAL_TACTICS.id) / this.owner.fightDuration;
   }
 
   get timesDroppedThreshold() {
@@ -121,7 +122,7 @@ class WayOfTheMokNathal extends Analyzer {
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.WAY_OF_THE_MOKNATHAL_TALENT.id} />}
-        value={`${this.fourStackUptimeInPercentage}%`}
+        value={`${formatPercentage(this.fourStackUptimeInPercentage)}%`}
         label="4 stack uptime"
         tooltip={`Way of the Mok'Nathal breakdown:
           <ul>

--- a/src/Parser/Hunter/Survival/Modules/Talents/WayOfTheMokNathal.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/WayOfTheMokNathal.js
@@ -40,7 +40,6 @@ class WayOfTheMokNathal extends Analyzer {
     }
     this._currentStacks = 1;
     this.lastApplicationTimestamp = event.timestamp;
-
   }
 
   on_byPlayer_applybuffstack(event) {
@@ -69,10 +68,28 @@ class WayOfTheMokNathal extends Analyzer {
     this._timesDropped += 1;
   }
 
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.RAPTOR_STRIKE.id) {
+      return;
+    }
+    if (this._currentStacks !== MAX_STACKS) {
+      return;
+    }
+    this.timesRefreshed++;
+    this.accumulatedTimeBetweenRefresh += event.timestamp - this.lastApplicationTimestamp;
+    this.lastApplicationTimestamp = event.timestamp;
+  }
+
   on_finished() {
     if (this._currentStacks === MAX_STACKS) {
       this._fourStackUptime += this.owner.fight.end_time - this._fourStackStart;
     }
+    console.log("4 stack uptime: ", this.fourStackUptimeInPercentage, "%");
+  }
+
+  get fourStackUptimeInPercentage() {
+    return formatPercentage(this._fourStackUptime / this.owner.fightDuration);
   }
 
   get averageTimeBetweenRefresh() {
@@ -104,7 +121,7 @@ class WayOfTheMokNathal extends Analyzer {
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.WAY_OF_THE_MOKNATHAL_TALENT.id} />}
-        value={`${formatPercentage(this._fourStackUptime / this.owner.fightDuration)}%`}
+        value={`${this.fourStackUptimeInPercentage}%`}
         label="4 stack uptime"
         tooltip={`Way of the Mok'Nathal breakdown:
           <ul>

--- a/src/Parser/Hunter/Survival/Modules/Talents/WayOfTheMokNathal.js
+++ b/src/Parser/Hunter/Survival/Modules/Talents/WayOfTheMokNathal.js
@@ -12,8 +12,6 @@ import Wrapper from 'common/Wrapper';
 
 const MAX_STACKS = 4;
 
-const debug = true;
-
 class WayOfTheMokNathal extends Analyzer {
   static dependencies = {
     combatants: Combatants,

--- a/src/Parser/Hunter/Survival/Modules/Traits/AspectOfTheSkylord.js
+++ b/src/Parser/Hunter/Survival/Modules/Traits/AspectOfTheSkylord.js
@@ -10,7 +10,7 @@ import ItemDamageDone from 'Main/ItemDamageDone';
 
 const ASPECT_MODIFIER = 0.3;
 
-/*
+/**
  * Aspect of the Eagle increases all damage you deal by 30% for its duration.
  */
 class AspectOfTheSkylord extends Analyzer {

--- a/src/Parser/Hunter/Survival/Modules/Traits/EaglesBite.js
+++ b/src/Parser/Hunter/Survival/Modules/Traits/EaglesBite.js
@@ -11,7 +11,7 @@ import { formatPercentage } from 'common/format';
 import StatisticBox from 'Main/StatisticBox';
 import SpellIcon from 'common/SpellIcon';
 
-/*
+/**
  * Harpoon applies On the Trail, a unique damage over time effect that deals [ 360% of Attack Power ] damage over until cancelled.
  * Your melee autoattacks extend its duration by 6 sec.
  */

--- a/src/Parser/Hunter/Survival/Modules/Traits/FuryOfTheEagle.js
+++ b/src/Parser/Hunter/Survival/Modules/Traits/FuryOfTheEagle.js
@@ -11,6 +11,10 @@ import ItemDamageDone from 'Main/ItemDamageDone';
 import SpellLink from 'common/SpellLink';
 import Wrapper from 'common/Wrapper';
 
+/**
+ * Furiously strikes all enemies in front of you, dealing ((125% of Attack power) * 9) Physical damage over 4 sec. Damage increased by
+ * Mongoose Fury. Extends the duration of Mongoose Fury for the duration of the channel.
+ */
 class FuryOfTheEagle extends Analyzer {
 
   static dependencies = {

--- a/src/Parser/Hunter/Survival/Modules/Traits/Hellcarver.js
+++ b/src/Parser/Hunter/Survival/Modules/Traits/Hellcarver.js
@@ -7,7 +7,7 @@ const HELLCARVER_MODIFIER_PER_RANK = (1 / 30); //3.33% repeat ofcourse
 
 const MS_BUFFER = 100;
 
-/*
+/**
  * Carve or Butchery deals 3% increased damage for each additional target hit.
  */
 class Hellcarver extends Analyzer {


### PR DESCRIPTION
Almost all of these are just notes added into various modules for hunter. 

The interesting changes that may require reviews are found in:
Dire Frenzy (nothing visually changed)
Way Of The Mok'Nathal (nothing visually changed)
Lacerate (minor changes)
Fixes a bug in AspectOfTheWild module not showing correct values in the checklist due to wrong variable name. 
Creates a Aspect Of The Eagle module that simply returns some suggestions if the survival hunter isn't pressing the cooldown at correct moments. 

Parsel's Tongue received a statistic module to show more information outside of the item-panel:
Picture: 
![image](https://user-images.githubusercontent.com/29204244/38576377-3f06a5cc-3cfe-11e8-973c-26ae1af840cc.png)
Log: https://www.warcraftlogs.com/reports/MXPjyrpnzNwbG4xD#fight=2&type=damage-done&source=13