### PR TITLE
[Marksmanship] fix Crows to work again

### DIFF
--- a/src/Parser/Hunter/Marksmanship/CHANGELOG.js
+++ b/src/Parser/Hunter/Marksmanship/CHANGELOG.js
@@ -9,6 +9,11 @@ import { Blazballs, JLassie82, Putro } from 'CONTRIBUTORS';
 
 export default [
   {
+    date: new Date('2018-04-10'),
+    changes: <Wrapper>Fixes <SpellLink id={SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.id} /> to properly calculate the boss health.</Wrapper>,
+    contributros: [Putro],
+  },
+  {
     date: new Date('2018-03-22'),
     changes: <Wrapper>Fixed <SpellLink id={SPELLS.SENTINEL_TALENT.id} /> module after Blizzard fixed the bugs with the spell. </Wrapper>,
     contributors: [Putro],

--- a/src/Parser/Hunter/Marksmanship/Modules/Talents/AMurderOfCrows.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Talents/AMurderOfCrows.js
@@ -61,6 +61,8 @@ class AMurderOfCrows extends Analyzer {
     if (!this.crowsNotYetChecked || !event.maxHitPoints || !this.bossIDs.includes(event.targetID)) {
       return;
     }
+    console.log(event.hitPoints);
+    console.log(event.hitPoints / event.maxHitPoints);
     if ((event.hitPoints / event.maxHitPoints) <= CROWS_SAVE_PERCENT && (event.hitPoints / event.maxHitPoints) > EXECUTE_PERCENT) {
       this.shouldHaveSaved += 1;
       this.bossHP = (event.hitPoints / event.maxHitPoints);

--- a/src/Parser/Hunter/Marksmanship/Modules/Talents/AMurderOfCrows.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Talents/AMurderOfCrows.js
@@ -19,8 +19,10 @@ const CROWS_SAVE_PERCENT = 0.25;
 const EXECUTE_PERCENT = 0.2;
 
 /**
- * Summons a flock of crows to attack your target, dealing [(162% of Attack power) * 16] Physical damage over 15 sec. When a target dies while affected by this ability, its cooldown will reset.
+ * Summons a flock of crows to attack your target, dealing [(162% of Attack power) * 16] Physical damage over 15 sec. When a target dies
+ * while affected by this ability, its cooldown will reset.
  */
+
 class AMurderOfCrows extends Analyzer {
 
   static dependencies = {
@@ -34,6 +36,7 @@ class AMurderOfCrows extends Analyzer {
   bossHP = 0;
   goodCrowsCasts = 0;
   totalCrowsCasts = 0;
+  crowsNotYetChecked = false;
 
   on_initialized() {
     this.active = this.combatants.selected.hasTalent(SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.id) && SPECS.MARKSMANSHIP_HUNTER;
@@ -55,6 +58,16 @@ class AMurderOfCrows extends Analyzer {
       this.spellUsable.beginCooldown(SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.id, this.owner.fight.start_time);
     }
     this.damage += event.amount;
+    if (!this.crowsNotYetChecked || !event.maxHitPoints || !this.bossIDs.includes(event.targetID)) {
+      return;
+    }
+    if ((event.hitPoints / event.maxHitPoints) <= CROWS_SAVE_PERCENT && (event.hitPoints / event.maxHitPoints) > EXECUTE_PERCENT) {
+      this.shouldHaveSaved += 1;
+      this.bossHP = (event.hitPoints / event.maxHitPoints);
+    } else {
+      this.goodCrowsCasts += 1;
+    }
+    this.crowsNotYetChecked = false;
   }
 
   on_byPlayer_cast(event) {
@@ -63,14 +76,7 @@ class AMurderOfCrows extends Analyzer {
       return;
     }
     this.totalCrowsCasts += 1;
-    if (event.maxHitPoints && this.bossIDs.includes(event.targetID)) {
-      if ((event.hitPoints / event.maxHitPoints) <= CROWS_SAVE_PERCENT && (event.hitPoints / event.maxHitPoints) > EXECUTE_PERCENT) {
-        this.shouldHaveSaved += 1;
-        this.bossHP = (event.hitPoints / event.maxHitPoints);
-        return;
-      }
-    }
-    this.goodCrowsCasts += 1;
+    this.crowsNotYetChecked = true;
   }
 
   statistic() {
@@ -137,7 +143,7 @@ class AMurderOfCrows extends Analyzer {
     when(this.shouldHaveSavedThreshold).addSuggestion((suggest) => {
       return suggest(<Wrapper>You should <b>generally</b> save <SpellLink id={SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.id} /> when the boss has under 25% hp so that it is ready to use when the boss hits 20% and you can start getting <SpellLink id={SPELLS.BULLSEYE_BUFF.id} /> quicker.</Wrapper>)
         .icon(SPELLS.A_MURDER_OF_CROWS_TALENT_SHARED.icon)
-        .actual(`You cast crows while boss ${formatPercentage(this.bossHP)}% HP.`)
+        .actual(`You cast crows while boss had ${formatPercentage(this.bossHP)}% HP.`)
         .recommended(`0 casts when boss has between 20 and 25% hp is recommended`);
     });
   }

--- a/src/Parser/Hunter/Marksmanship/Modules/Talents/AMurderOfCrows.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Talents/AMurderOfCrows.js
@@ -61,8 +61,6 @@ class AMurderOfCrows extends Analyzer {
     if (!this.crowsNotYetChecked || !event.maxHitPoints || !this.bossIDs.includes(event.targetID)) {
       return;
     }
-    console.log(event.hitPoints);
-    console.log(event.hitPoints / event.maxHitPoints);
     if ((event.hitPoints / event.maxHitPoints) <= CROWS_SAVE_PERCENT && (event.hitPoints / event.maxHitPoints) > EXECUTE_PERCENT) {
       this.shouldHaveSaved += 1;
       this.bossHP = (event.hitPoints / event.maxHitPoints);


### PR DESCRIPTION
As realised in #1564 , the marksmanship AMoC module was actually broken and not working as intended. 
This fixes that. 