### PR TITLE
[Guardian] Fix a crash with filler spam detection

### DIFF
--- a/src/Parser/Druid/Guardian/CHANGELOG.js
+++ b/src/Parser/Druid/Guardian/CHANGELOG.js
@@ -8,62 +8,67 @@ import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 
 export default [
-  { 
+  {
+    date: new Date('2018-04-10'),
+    changes: <Wrapper>Fixed an issue where looking for the presence of <SpellLink id={SPELLS.MOONFIRE.id} /> on some enemies would crash the analyzer.</Wrapper>,
+    contributors: [faide],
+  },
+  {
     date: new Date('2018-04-07'),
     changes: <Wrapper>Fixed an issue where <SpellLink id={SPELLS.MANGLE_BEAR.id} /> and <SpellLink id={SPELLS.THRASH_BEAR.id} /> max casts were not calculated correctly when using <SpellLink id={SPELLS.INCARNATION_GUARDIAN_OF_URSOC_TALENT.id} />.</Wrapper>,
     contributors: [Gebuz],
   },
-  { 
+  {
     date: new Date('2018-03-26'),
     changes: 'Highlight bad filler casts on the timeline.',
     contributors: [Gebuz],
   },
-  { 
+  {
     date: new Date('2017-08-29'),
     changes: <Wrapper>Added <ItemLink id={ITEMS.FURY_OF_NATURE.id} /> and <ItemLink id={ITEMS.LUFFA_WRAPPINGS.id} /> statistics.</Wrapper>,
     contributors: [faide],
   },
-  { 
+  {
     date: new Date('2017-08-29'),
     changes: <Wrapper>Added <SpellLink id={SPELLS.EARTHWARDEN_TALENT.id} /> metrics and suggestions.</Wrapper>,
     contributors: [faide],
   },
-  { 
+  {
     date: new Date('2017-08-28'),
     changes: <Wrapper>Fixed <SpellLink id={SPELLS.STAMPEDING_ROAR_BEAR.id} /> cast efficiency to work with <SpellLink id={SPELLS.GUTTURAL_ROARS_TALENT.id} />.</Wrapper>,
     contributors: [faide],
   },
-  { 
+  {
     date: new Date('2017-08-23'),
     changes: 'Added rage waste statistic and suggestion.',
     contributors: [faide],
   },
-  { 
+  {
     date: new Date('2017-08-22'),
     changes: <Wrapper>Fixed issue with calculation of <SpellLink id={SPELLS.FRENZIED_REGENERATION.id} /> by <SpellLink id={SPELLS.GUARDIAN_OF_ELUNE_TALENT.id} />.</Wrapper>,
     contributors: [WOPR],
   },
-  { 
+  {
     date: new Date('2017-08-22'),
     changes: <Wrapper>Fix to <SpellLink id={SPELLS.IRONFUR.id} /> uptime suggestion.</Wrapper>,
     contributors: [WOPR],
   },
-  { 
+  {
     date: new Date('2017-08-19'),
     changes: <Wrapper>Added <ItemLink id={ITEMS.SKYSECS_HOLD.id} /> statistic and suggestion.</Wrapper>,
     contributors: [faide],
   },
-  { 
+  {
     date: new Date('2017-08-19'),
     changes: <Wrapper>Added detail on <SpellLink id={SPELLS.IRONFUR.id} /> usage.</Wrapper>,
     contributors: [],
   },
-  { 
+  {
     date: new Date('2017-08-18'),
     changes: 'Updates to align with new module structure and added overkill into DTPS display.',
     contributors: [],
   },
-  { 
+  {
     date: new Date('2017-08-13'),
     changes: <Wrapper>Added damage type into the tooltip of damage taken, added logic for <SpellLink id={SPELLS.PULVERIZE_TALENT.id} /> and minor fixes.</Wrapper>,
     contributors: [WOPR],

--- a/src/Parser/Druid/Guardian/Modules/Abilities.js
+++ b/src/Parser/Druid/Guardian/Modules/Abilities.js
@@ -72,7 +72,9 @@ class Abilities extends CoreAbilities {
               return false;
             }
             // Check if moonfire is present on the current target
-            if (!this.enemies.getEntity(event).hasBuff(SPELLS.MOONFIRE_BEAR.id, event.timestamp)) {
+            // Note that if the current target has no enemy data we can't track whether the dot
+            // is ticking or not, in that case we consider it non-filler as a concession.
+            if (!this.enemies.getEntity(event) || !this.enemies.getEntity(event).hasBuff(SPELLS.MOONFIRE_BEAR.id, event.timestamp)) {
               return false;
             }
             // Check if moonfire was missing on a secondary target (if using LatC)


### PR DESCRIPTION
Addresses an issue during Moonfire filler spam detection where if the return value of `this.enemies.getEntity(event)` is `null` (ie, if the target did not have enemy combatant info), then the analyzer would crash.

