### PR TITLE
[Restoration Shaman] Stat Values

### DIFF
--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -328,7 +328,21 @@ export const joshinator = {
 export const niseko = {
   nickname: 'niseko',
   github: 'niseko',
+  discord: 'nisekoi#4130',
   avatar: require('./Images/niseko-avatar.jpg'),
+  mains: [{
+    name: "Niseko",
+    spec: SPECS.RESTORATION_SHAMAN,
+    link: "https://worldofwarcraft.com/en-gb/character/stormscale/niseko",
+  },
+  {
+    name: "Nisefy",
+    spec: SPECS.MISTWEAVER_MONK,
+    link: "https://worldofwarcraft.com/en-gb/character/stormscale/nisefy",
+  }],
+  links: {
+    "Ancestral Guidance": "https://ancestralguidance.com/",
+  },
 };
 export const Aelexe = {
   nickname: 'Aelexe',

--- a/src/Parser/Core/Modules/Features/BaseHealerStatValues.js
+++ b/src/Parser/Core/Modules/Features/BaseHealerStatValues.js
@@ -419,7 +419,7 @@ class BaseHealerStatValues extends Analyzer {
               <thead>
                 <tr>
                   <th style={{ minWidth: 30 }}><b>Stat</b></th>
-                  <th className="text-right" style={{ minWidth: 30 }}><dfn data-tip="Normalized so Intellect is always 1.00. Hover to see the amount of healing 1 rating resulted in."><b>Value</b></dfn></th>
+                  <th className="text-right" style={{ minWidth: 30 }}><dfn data-tip="Normalized so Intellect is always 1.00."><b>Value</b></dfn></th>
                   <th className="text-right" style={{ minWidth: 30 }}>HPS per rating</th>
                   <th className="text-right" style={{ minWidth: 30 }}><dfn data-tip="Amount of stat rating required to increase your total healing by 1%"><b>Rating per 1%</b></dfn></th>
                 </tr>

--- a/src/Parser/Shaman/Restoration/CHANGELOG.js
+++ b/src/Parser/Shaman/Restoration/CHANGELOG.js
@@ -9,6 +9,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-04-10'),
+    changes: 'Implemented Stat Values for Restoration Shaman.',
+    contributors: [niseko],
+  },
+  {
     date: new Date('2018-03-28'),
     changes: <Wrapper>Added a Tab detailing the <SpellLink id={SPELLS.DEEP_HEALING.id} /> effectiveness per player.</Wrapper>,
     contributors: [niseko],

--- a/src/Parser/Shaman/Restoration/CHANGELOG.js
+++ b/src/Parser/Shaman/Restoration/CHANGELOG.js
@@ -9,7 +9,7 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
-    date: new Date('2018-04-10'),
+    date: new Date('2018-04-11'),
     changes: 'Implemented Stat Values for Restoration Shaman.',
     contributors: [niseko],
   },

--- a/src/Parser/Shaman/Restoration/CombatLogParser.js
+++ b/src/Parser/Shaman/Restoration/CombatLogParser.js
@@ -16,6 +16,7 @@ import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
 import CooldownThroughputTracker from './Modules/Features/CooldownThroughputTracker';
 import Checklist from './Modules/Features/Checklist';
 import SpellUsable from './Modules/Features/SpellUsable';
+import StatValues from './Modules/Features/StatValues';
 
 import AncestralVigor from './Modules/Features/AncestralVigor';
 import TidalWaves from './Modules/Features/TidalWaves';
@@ -73,7 +74,7 @@ class CombatLogParser extends CoreCombatLogParser {
     castBehavior: CastBehavior,
     checklist: Checklist,
     spellUsable: SpellUsable,
-
+    statValues: StatValues,
 
     // Talents:
     earthenShieldTotem: EarthenShieldTotem,

--- a/src/Parser/Shaman/Restoration/Modules/Features/CooldownThroughputTracker.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/CooldownThroughputTracker.js
@@ -119,6 +119,9 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
       });
   }
 
+  // Fabricate new events to make it easy to listen to just feed heal events while being away of the original heals. 
+  // While we could also modify the original heal event and add a reference to the feed amount, this would be less clean as mutating objects makes things harder and more confusing to use, and may lead to conflicts.
+  // Due to how the Shaman CooldonwThroughputTracker works, these events will be bunched together at the very end of the events list.
   generateFeedEvents(cooldown, feedingFactor, percentOverheal){
     cooldown.events.forEach((event) => {
       if (event.type !== 'heal' || !cooldown.feed[event.ability.guid]) {

--- a/src/Parser/Shaman/Restoration/Modules/Features/CooldownThroughputTracker.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/CooldownThroughputTracker.js
@@ -99,15 +99,16 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
           totals.totalEffective += effectiveHealing;
         });
 
-        // if this is CBT, check if the cooldown ended while AG was active
-        // if it was, 60% of CBT got redistributed again so we multiply the feeding factor by 1.6
+        // if this cooldown is CBT, check if it ended while AG was active
+        // if so, 60% of CBT got redistributed again so we multiply the feeding factor by 1.6
         let ancestralGuidanceSynergy = 1;
         if (cooldown.spell.id === SPELLS.CLOUDBURST_TOTEM_TALENT.id) {
           this.pastCooldowns
             .filter(_cooldown => _cooldown.end && _cooldown.spell.id === SPELLS.ANCESTRAL_GUIDANCE_TALENT.id)
             .forEach((_cooldown) => {
               if (cooldown.end >= _cooldown.start && cooldown.end <= _cooldown.end) {
-                ancestralGuidanceSynergy = 1.6;
+                const ancestralGuidanceOverheal = _cooldown.overheal / (_cooldown.healing + _cooldown.overheal);
+                ancestralGuidanceSynergy = 1 + (0.6 * ancestralGuidanceOverheal);
               }
             });
         }
@@ -129,14 +130,15 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
         return;
       }
 
-      // if this is Ascendance, check if the same event is in any AG timeframe, and if so, adjust the feeding factor
+      // if this cooldown is Ascendance, check if the same heal event is in any AG cooldown, and if so, adjust the feeding factor to account for double dipping
       let ancestralGuidanceSynergy = 1;
       if (cooldown.spell.id === SPELLS.ASCENDANCE_TALENT_RESTORATION.id) {
         this.pastCooldowns
           .filter(_cooldown => _cooldown.end && _cooldown.spell.id === SPELLS.ANCESTRAL_GUIDANCE_TALENT.id)
           .forEach((_cooldown) => {
             if (event.timestamp >= _cooldown.start && event.timestamp <= _cooldown.end) {
-              ancestralGuidanceSynergy = 1.6;
+              const ancestralGuidanceOverheal = _cooldown.overheal / (_cooldown.healing + _cooldown.overheal);
+              ancestralGuidanceSynergy = 1 + (0.6 * ancestralGuidanceOverheal);
             }
           });
       }

--- a/src/Parser/Shaman/Restoration/Modules/Features/CooldownThroughputTracker.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/CooldownThroughputTracker.js
@@ -108,7 +108,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
             .forEach((_cooldown) => {
               if (cooldown.end >= _cooldown.start && cooldown.end <= _cooldown.end) {
                 const ancestralGuidanceOverheal = _cooldown.overheal / (_cooldown.healing + _cooldown.overheal);
-                ancestralGuidanceSynergy = 1 + (0.6 * ancestralGuidanceOverheal);
+                ancestralGuidanceSynergy += (0.6 * (1 - ancestralGuidanceOverheal));
               }
             });
         }
@@ -141,7 +141,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
           .forEach((_cooldown) => {
             if (event.timestamp >= _cooldown.start && event.timestamp <= _cooldown.end) {
               const ancestralGuidanceOverheal = _cooldown.overheal / (_cooldown.healing + _cooldown.overheal);
-              ancestralGuidanceSynergy = 1 + (0.6 * ancestralGuidanceOverheal);
+              ancestralGuidanceSynergy += (0.6 * (1 - ancestralGuidanceOverheal));
             }
           });
       }

--- a/src/Parser/Shaman/Restoration/Modules/Features/StatValues.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/StatValues.js
@@ -1,0 +1,136 @@
+import SPELLS from 'common/SPELLS';
+
+import BaseHealerStatValues from 'Parser/Core/Modules/Features/BaseHealerStatValues';
+import STAT from 'Parser/Core/Modules/Features/STAT';
+import StatTracker from 'Parser/Core/Modules/StatTracker';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import HealingValue from 'Parser/Core/Modules/HealingValue';
+import CritEffectBonus from 'Parser/Core/Modules/Helpers/CritEffectBonus';
+
+import SPELL_INFO from './StatValuesSpellInfo';
+import MasteryEffectiveness from './MasteryEffectiveness';
+
+/**
+ * Restoration Shaman Stat Values
+ *
+ */
+
+ const BUFFER_MS = 100;
+ const MINIMUM_GCD = 750;
+
+class StatValues extends BaseHealerStatValues {
+  static dependencies = {
+    statTracker: StatTracker,
+    combatants: Combatants,
+    critEffectBonus: CritEffectBonus,
+    masteryEffectiveness: MasteryEffectiveness,
+  };
+
+  spellInfo = SPELL_INFO;
+
+  on_feed_heal(event) {
+    const spellInfo = this._getSpellInfo(event);
+    const healVal = new HealingValue(event.feed, 0, 0);
+    const targetHealthPercentage = (event.hitPoints - event.amount) / event.maxHitPoints; // hitPoints contains HP *after* the heal
+    this._handleHeal(spellInfo, event, healVal, targetHealthPercentage);
+  }
+
+  // calculating the value of QA (cast speed to your next direct heal after a crit) just like HPCT, but giving the cast speed value to crit instead
+  queenAscendantTrait(event, healVal) {
+    const spellId = event.ability.guid;
+    const spellInfo = this._getSpellInfo(event);
+    // checking for quite a big buffer as the buffs can run out mid cast but still apply
+    const hasQueensAscendant = this.combatants.selected.hasBuff(SPELLS.QUEEN_ASCENDANT_BUFF.id, event.timestamp, MINIMUM_GCD, BUFFER_MS);
+    const hasTidalWaves = this.combatants.selected.hasBuff(SPELLS.TIDAL_WAVES_BUFF.id, event.timestamp, MINIMUM_GCD, BUFFER_MS);
+    
+    // disregard wave casts with tidal waves as its always below GCD regardless of QA
+    if(spellId === SPELLS.HEALING_WAVE.id && hasTidalWaves){
+      return 0;
+    }
+    
+    if (!spellInfo.hasteHpct || !hasQueensAscendant) {
+      return 0;
+    }
+
+    const currHastePerc = this.statTracker.currentHastePercentage;
+    const queenAscendantTraits = this.combatants.selected.traitsBySpellId[SPELLS.QUEEN_ASCENDANT_TRAIT.id];
+    const queenAscendantReduction = queenAscendantTraits * 0.05;
+    const healIncreaseFromOneHaste = 1 / this.statTracker.hasteRatingPerPercent;
+    const baseHeal = (healVal.effective / (1 - queenAscendantReduction) - healVal.effective) / (1 + currHastePerc);
+
+    return baseHeal * healIncreaseFromOneHaste;
+  }
+
+  _getCritChance(event) {
+    const spellId = event.ability.guid;
+    const critChanceBreakdown = super._getCritChance(event);
+
+    // Traits that increase the base crit chance of spells
+    const traitLevelED = this.combatants.selected.traitsBySpellId[SPELLS.EMPOWERED_DROPLETS.id];
+    const traitLevelFW = this.combatants.selected.traitsBySpellId[SPELLS.FLOODWATERS.id];
+    const traitLevelTC = this.combatants.selected.traitsBySpellId[SPELLS.TIDAL_CHAINS.id];
+    const hasTidalWaves = this.combatants.selected.hasBuff(SPELLS.TIDAL_WAVES_BUFF.id,  event.timestamp, BUFFER_MS, BUFFER_MS);
+
+    if (spellId === SPELLS.HEALING_RAIN_HEAL.id) {
+      critChanceBreakdown.baseCritChance += traitLevelED * 0.02;
+    }
+    if (spellId === SPELLS.CHAIN_HEAL.id) {
+      critChanceBreakdown.baseCritChance += traitLevelFW * 0.0333;
+    }
+    if (spellId === SPELLS.HEALING_SURGE_RESTORATION.id && hasTidalWaves) {
+      critChanceBreakdown.baseCritChance += 0.4 + 0.04 * traitLevelTC;
+    }
+
+    return critChanceBreakdown;
+  }
+
+  _criticalStrike(event, healVal) {
+      return super._criticalStrike(event, healVal) + this.queenAscendantTrait(event,healVal);
+  }
+
+  _mastery(event, healVal) {
+    if (healVal.overheal) {
+      // If a spell overheals, it could not have healed for more. Seeing as Mastery only adds HP on top of the existing heal we can skip it as increasing the power of this heal would only be more overhealing.
+      return 0;
+    }
+    if (event.masteryEffectiveness === undefined) {
+      console.error('This spell does not have a known masteryEffectiveness:', event.ability.guid, event.ability.name);
+      return 0;
+    }
+
+    const masteryEffectiveness = event.masteryEffectiveness;
+    const healIncreaseFromOneMastery = 1 / this.statTracker.masteryRatingPerPercent * masteryEffectiveness;
+    const baseHeal = healVal.effective / (1 + this.statTracker.currentMasteryPercentage * masteryEffectiveness);
+
+    return baseHeal * healIncreaseFromOneMastery;
+  }
+
+  _prepareResults() {
+    return [
+      STAT.INTELLECT,
+      {
+        stat: STAT.CRITICAL_STRIKE,
+        tooltip: `
+          The Critical Strike value does not include mana gained by Resurgence.
+          `,
+      },
+      {
+        stat: STAT.HASTE_HPCT,
+        tooltip: `
+          HPCT stands for "Healing per Cast Time". This is the max value that 1% Haste would be worth if you would cast everything you are already casting and that can be casted quicker 1% faster. Mana and overhealing are not accounted for in any way.<br /><br />
+          
+          The real value of Haste (HPCT) will be between 0 and the shown value. It depends on if you have the mana left to spend, if the gained casts would overheal and how well you are at casting spells limited by Hasted cooldowns end-to-end. If you are going OOM before the end of the fight you might instead want to drop some Haste or cast less bad heals. If you had mana left-over, Haste could help you convert that into healing. If your Haste usage is optimal Haste will then be worth the shown max value.<br /><br />
+          
+          If there are intense moments of damage taken where people are dying due to lack of healing and you're GCD capped, Haste might also help increase your throughput during this period saving lifes and helping you kill the boss.
+        `,
+      },
+      STAT.HASTE_HPM,
+      STAT.MASTERY,
+      STAT.VERSATILITY,
+      STAT.VERSATILITY_DR,
+      STAT.LEECH,
+    ];
+  }
+}
+
+export default StatValues;

--- a/src/Parser/Shaman/Restoration/Modules/Features/StatValues.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/StatValues.js
@@ -12,7 +12,6 @@ import MasteryEffectiveness from './MasteryEffectiveness';
 
 /**
  * Restoration Shaman Stat Values
- *
  */
 
  const BUFFER_MS = 100;
@@ -43,7 +42,7 @@ class StatValues extends BaseHealerStatValues {
     const hasQueensAscendant = this.combatants.selected.hasBuff(SPELLS.QUEEN_ASCENDANT_BUFF.id, event.timestamp, MINIMUM_GCD, BUFFER_MS);
     const hasTidalWaves = this.combatants.selected.hasBuff(SPELLS.TIDAL_WAVES_BUFF.id, event.timestamp, MINIMUM_GCD, BUFFER_MS);
     
-    // disregard wave casts with tidal waves as its always below GCD regardless of QA
+    // disregard wave casts with tidal waves as its always below GCD regardless of QA (and neither change the GCD itself)
     if(spellId === SPELLS.HEALING_WAVE.id && hasTidalWaves){
       return 0;
     }
@@ -66,19 +65,20 @@ class StatValues extends BaseHealerStatValues {
     const critChanceBreakdown = super._getCritChance(event);
 
     // Traits that increase the base crit chance of spells
-    const traitLevelED = this.combatants.selected.traitsBySpellId[SPELLS.EMPOWERED_DROPLETS.id];
-    const traitLevelFW = this.combatants.selected.traitsBySpellId[SPELLS.FLOODWATERS.id];
-    const traitLevelTC = this.combatants.selected.traitsBySpellId[SPELLS.TIDAL_CHAINS.id];
-    const hasTidalWaves = this.combatants.selected.hasBuff(SPELLS.TIDAL_WAVES_BUFF.id,  event.timestamp, BUFFER_MS, BUFFER_MS);
+    const traitLevelEmpoweredDroplets = this.combatants.selected.traitsBySpellId[SPELLS.EMPOWERED_DROPLETS.id];
+    const traitLevelFloodwaters = this.combatants.selected.traitsBySpellId[SPELLS.FLOODWATERS.id];
+    const traitLevelTidalChains = this.combatants.selected.traitsBySpellId[SPELLS.TIDAL_CHAINS.id];
+    // Tidal Waves add 40% crit + 4% for every tidal chains trait to Healing Surge
+    const hasTidalWaves = this.combatants.selected.hasBuff(SPELLS.TIDAL_WAVES_BUFF.id, event.timestamp, BUFFER_MS, BUFFER_MS);
 
     if (spellId === SPELLS.HEALING_RAIN_HEAL.id) {
-      critChanceBreakdown.baseCritChance += traitLevelED * 0.02;
+      critChanceBreakdown.baseCritChance += traitLevelEmpoweredDroplets * 0.02;
     }
     if (spellId === SPELLS.CHAIN_HEAL.id) {
-      critChanceBreakdown.baseCritChance += traitLevelFW * 0.0333;
+      critChanceBreakdown.baseCritChance += traitLevelFloodwaters * (0.1 / 3); // 0.0333...
     }
     if (spellId === SPELLS.HEALING_SURGE_RESTORATION.id && hasTidalWaves) {
-      critChanceBreakdown.baseCritChance += 0.4 + 0.04 * traitLevelTC;
+      critChanceBreakdown.baseCritChance += 0.4 + 0.04 * traitLevelTidalChains;
     }
 
     return critChanceBreakdown;
@@ -111,8 +111,8 @@ class StatValues extends BaseHealerStatValues {
       {
         stat: STAT.CRITICAL_STRIKE,
         tooltip: `
-          The Critical Strike value does not include mana gained by Resurgence.
-          `,
+          Weight does not include Resurgence mana gain.
+        `,
       },
       {
         stat: STAT.HASTE_HPCT,

--- a/src/Parser/Shaman/Restoration/Modules/Features/StatValuesSpellInfo.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/StatValuesSpellInfo.js
@@ -3,9 +3,9 @@ import SPELLS from 'common/SPELLS';
 /*
  * Fields:
  * int: spell scales with Intellect
- * crit: spell scales with (is able to or procced from) Critical Strike
- * hasteHpm: spell does more healing due to Haste, e.g. HoTs that gain more ticks
- * hasteHpct: spell can be cast more frequently due to Haste, basically any spell except for non haste scaling CDs
+ * crit: spell scales with Critical Strike
+ * hasteHpm: spell does more healing due to Haste, e.g. Spells and Totems that gain more ticks
+ * hasteHpct: spell can be cast more frequently due to Haste
  * mastery: spell is boosted by Mastery
  * vers: spell scales with Versatility
  * multiplier: spell scales with whatever procs it, should be ignored for purpose of weights and for 'total healing' number
@@ -77,19 +77,19 @@ export default {
     vers: true,
   },
   [SPELLS.ANCESTRAL_GUIDANCE_HEAL.id]: {
-    // This gets special treatment with the `on_feed_heal` event
-    ignored: true,   
+    // This gets special treatment with the `feed_heal` event
+    ignored: true,
   },
   [SPELLS.ASCENDANCE_HEAL.id]: {
-    // This gets special treatment with the `on_feed_heal` event
+    // This gets special treatment with the `feed_heal` event
     ignored: true,
   },
-  [SPELLS.CLOUDBURST_TOTEM_HEAL.id]: { 
-    // This gets special treatment with the `on_feed_heal` event
+  [SPELLS.CLOUDBURST_TOTEM_HEAL.id]: {
+    // This gets special treatment with the `feed_heal` event
     ignored: true,
   },
-  [SPELLS.EARTHEN_SHIELD_TOTEM_ABSORB.id]: { 
-    //it scales with INT per hit but the total absorb is limited by the players max HP
+  [SPELLS.EARTHEN_SHIELD_TOTEM_ABSORB.id]: {
+    // EST scales with INT per hit but the total absorb is limited by the players max HP
     ignored: true,
   },
   [SPELLS.SPIRIT_LINK_TOTEM_REDISTRIBUTE.id]: {
@@ -98,52 +98,54 @@ export default {
   [SPELLS.SPIRIT_LINK_TOTEM.id]: {
     ignored: true,
   },
-  [SPELLS.UNLEASH_LIFE_TALENT.id]: { 
+  [SPELLS.UNLEASH_LIFE_TALENT.id]: {
     int: true,
     crit: true,
     hasteHpct: false, // static CD
     mastery: true,
     vers: true,
   },
-  [SPELLS.WELLSPRING_HEAL.id]: { 
+  [SPELLS.WELLSPRING_HEAL.id]: {
     int: true,
     crit: true,
     hasteHpct: false, // static CD
     mastery: true,
     vers: true,
   },
-  [SPELLS.GIFT_OF_THE_QUEEN.id]: { 
+  [SPELLS.GIFT_OF_THE_QUEEN.id]: {
     int: true,
     crit: true,
     hasteHpct: false, // static CD
     mastery: true,
     vers: true,
   },
-  [SPELLS.GIFT_OF_THE_QUEEN_DUPLICATE.id]: { 
+  [SPELLS.GIFT_OF_THE_QUEEN_DUPLICATE.id]: {
     int: true,
     crit: true,
     hasteHpct: false, // static CD
     mastery: true,
     vers: true,
   },
-  [SPELLS.TIDAL_TOTEM.id]: { 
+  [SPELLS.TIDAL_TOTEM.id]: {
     int: true,
     crit: true,
     hasteHpm: true,
     mastery: true,
     vers: true,
   },
-  [SPELLS.RAINFALL.id]: { // T21 2pc
+  [SPELLS.RAINFALL.id]: {
+    // T21 2pc
     int: true,
     crit: true,
     mastery: false,
     vers: true,
   },
-  [SPELLS.DOWNPOUR.id]: { // T21 4pc double dipping
+  [SPELLS.DOWNPOUR.id]: {
+    // T21 4pc double dipping
     crit: true,
     vers: true,
   },
-  [SPELLS.ROOTS_OF_SHALADRASSIL_HEAL.id]: { // Roots
+  [SPELLS.ROOTS_OF_SHALADRASSIL_HEAL.id]: {
     ignored: true,
   },
 };

--- a/src/Parser/Shaman/Restoration/Modules/Features/StatValuesSpellInfo.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/StatValuesSpellInfo.js
@@ -143,6 +143,7 @@ export default {
   [SPELLS.DOWNPOUR.id]: {
     // T21 4pc double dipping
     crit: true,
+    hasteHpct: true,
     vers: true,
   },
   [SPELLS.ROOTS_OF_SHALADRASSIL_HEAL.id]: {

--- a/src/Parser/Shaman/Restoration/Modules/Features/StatValuesSpellInfo.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/StatValuesSpellInfo.js
@@ -1,0 +1,149 @@
+import SPELLS from 'common/SPELLS';
+
+/*
+ * Fields:
+ * int: spell scales with Intellect
+ * crit: spell scales with (is able to or procced from) Critical Strike
+ * hasteHpm: spell does more healing due to Haste, e.g. HoTs that gain more ticks
+ * hasteHpct: spell can be cast more frequently due to Haste, basically any spell except for non haste scaling CDs
+ * mastery: spell is boosted by Mastery
+ * vers: spell scales with Versatility
+ * multiplier: spell scales with whatever procs it, should be ignored for purpose of weights and for 'total healing' number
+ * ignored: spell should be ignored for purpose of stat weights
+ */
+
+// This only works with actual healing events; casts are not recognized.
+
+export default {
+  [SPELLS.HEALING_SURGE_RESTORATION.id]: {
+    int: true,
+    crit: true,
+    hasteHpct: true,
+    mastery: true,
+    vers: true,
+  },
+  [SPELLS.HEALING_WAVE.id]: {
+    int: true,
+    crit: true,
+    hasteHpct: true,
+    mastery: true,
+    vers: true,
+  },
+  [SPELLS.RIPTIDE.id]: {
+    int: true,
+    crit: true,
+    hasteHpm: true,
+    hasteHpct: false, // static CD
+    mastery: true,
+    vers: true,
+  },
+  [SPELLS.HEALING_STREAM_TOTEM_HEAL.id]: {
+    int: true,
+    crit: true,
+    hasteHpm: true,
+    hasteHpct: false, // static CD
+    mastery: true,
+    vers: true,
+  },
+  [SPELLS.QUEENS_DECREE.id]: {
+    int: true,
+    crit: true,
+    hasteHpm: true,
+    hasteHpct: false,
+    mastery: true,
+    vers: true,
+  },
+  [SPELLS.CHAIN_HEAL.id]: {
+    int: true,
+    crit: true,
+    hasteHpct: true,
+    mastery: true,
+    vers: true,
+  },
+  [SPELLS.HEALING_RAIN_HEAL.id]: {
+    int: true,
+    crit: true,
+    hasteHpm: true,
+    hasteHpct: false, // static CD
+    mastery: true,
+    vers: true,
+  },
+  [SPELLS.HEALING_TIDE_TOTEM_HEAL.id]: {
+    int: true,
+    crit: true,
+    hasteHpm: true,
+    hasteHpct: false, // static CD
+    mastery: true,
+    vers: true,
+  },
+  [SPELLS.ANCESTRAL_GUIDANCE_HEAL.id]: {
+    // This gets special treatment with the `on_feed_heal` event
+    ignored: true,   
+  },
+  [SPELLS.ASCENDANCE_HEAL.id]: {
+    // This gets special treatment with the `on_feed_heal` event
+    ignored: true,
+  },
+  [SPELLS.CLOUDBURST_TOTEM_HEAL.id]: { 
+    // This gets special treatment with the `on_feed_heal` event
+    ignored: true,
+  },
+  [SPELLS.EARTHEN_SHIELD_TOTEM_ABSORB.id]: { 
+    //it scales with INT per hit but the total absorb is limited by the players max HP
+    ignored: true,
+  },
+  [SPELLS.SPIRIT_LINK_TOTEM_REDISTRIBUTE.id]: {
+    ignored: true,
+  },
+  [SPELLS.SPIRIT_LINK_TOTEM.id]: {
+    ignored: true,
+  },
+  [SPELLS.UNLEASH_LIFE_TALENT.id]: { 
+    int: true,
+    crit: true,
+    hasteHpct: false, // static CD
+    mastery: true,
+    vers: true,
+  },
+  [SPELLS.WELLSPRING_HEAL.id]: { 
+    int: true,
+    crit: true,
+    hasteHpct: false, // static CD
+    mastery: true,
+    vers: true,
+  },
+  [SPELLS.GIFT_OF_THE_QUEEN.id]: { 
+    int: true,
+    crit: true,
+    hasteHpct: false, // static CD
+    mastery: true,
+    vers: true,
+  },
+  [SPELLS.GIFT_OF_THE_QUEEN_DUPLICATE.id]: { 
+    int: true,
+    crit: true,
+    hasteHpct: false, // static CD
+    mastery: true,
+    vers: true,
+  },
+  [SPELLS.TIDAL_TOTEM.id]: { 
+    int: true,
+    crit: true,
+    hasteHpm: true,
+    mastery: true,
+    vers: true,
+  },
+  [SPELLS.RAINFALL.id]: { // T21 2pc
+    int: true,
+    crit: true,
+    mastery: false,
+    vers: true,
+  },
+  [SPELLS.DOWNPOUR.id]: { // T21 4pc double dipping
+    crit: true,
+    vers: true,
+  },
+  [SPELLS.ROOTS_OF_SHALADRASSIL_HEAL.id]: { // Roots
+    ignored: true,
+  },
+};

--- a/src/common/SPELLS/SHAMAN.js
+++ b/src/common/SPELLS/SHAMAN.js
@@ -816,6 +816,31 @@ export default {
     name: 'Servant of the Queen',
     icon: 'inv_crown_02',
   },
+  EMPOWERED_DROPLETS: {
+    id: 207255,
+    name: 'Empowered Droplets',
+    icon: 'spell_nature_giftofthewaterspirit',
+  },
+  FLOODWATERS: {
+    id: 207348,
+    name: 'Floodwaters',
+    icon: 'spell_nature_healingwavegreater',
+  },
+  TIDAL_CHAINS: {
+    id: 207088,
+    name: 'Tidal Chains',
+    icon: 'spell_frost_chainsofice',
+  },
+  QUEEN_ASCENDANT_TRAIT: {
+    id: 207285,
+    name: 'Queen Ascendant',
+    icon: 'ability_shaman_watershield',
+  },
+  QUEEN_ASCENDANT_BUFF: {
+    id: 207288,
+    name: 'Queen Ascendant',
+    icon: 'ability_shaman_watershield',
+  },
   // Restoration Shaman Set Bonus:
   RAINFALL: { // T21 2pc
     id: 252154,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2842471/38593988-77328330-3d44-11e8-922c-e1a2805d11dc.png)
Log shown: https://www.warcraftlogs.com/reports/Yj9hc4NWRvxLCaq3#fight=17&type=healing&source=22

Implemented Stat Values for resto shamans. 

It does not include resurgence as mana to HPS appears to be pretty subjective, i plan to add that later as a seperate weight if I find a good middle-ground.
I'm (ab-)using the CooldownThroughputTracker, which stores the healing events per cooldown already anyway - to create feeding events which get processed for statvalues. It's taking the effective feeding value including possible double dipping from combined cooldowns, while accounting for overheal.