### PR TITLE
[Restoration Shaman] Tidal Waves thresholds & various fixes

### DIFF
--- a/src/Main/PlayerBreakdown.js
+++ b/src/Main/PlayerBreakdown.js
@@ -44,7 +44,7 @@ class PlayerBreakdown extends React.Component {
           <tr>
             <th>Name</th>
             <th colSpan="2">Mastery effectiveness</th>
-            <th colSpan="3"><dfn data-tip="This is the amount of healing done with abilities that are affected by mastery. Things like Holy Paladin beacons or Restoration Shaman feeding are NOT included.">Healing done</dfn></th>
+            <th colSpan="3"><dfn data-tip="This is the amount of healing done by mastery. Things like Holy Paladin beacons or Restoration Shaman feeding are NOT included.">Healing done</dfn></th>
           </tr>
         </thead>
         <tbody>

--- a/src/Parser/Shaman/Restoration/Modules/Features/CastBehavior.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/CastBehavior.js
@@ -27,7 +27,7 @@ class CastBehavior extends Analyzer {
         <dfn data-tip={tooltip}>{label}</dfn>
       ) : label;
       label = spellId ? (
-        <SpellLink id={spellId}>{label}</SpellLink>
+        <SpellLink id={spellId} icon={false}>{label}</SpellLink>
       ) : label;
       return (
         <div

--- a/src/Parser/Shaman/Restoration/Modules/Features/MasteryEffectiveness.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/MasteryEffectiveness.js
@@ -33,7 +33,7 @@ class MasteryEffectiveness extends Analyzer {
 
       if (isAbilityAffectedByMastery) {
         const healthBeforeHeal = event.hitPoints - event.amount;
-        const masteryEffectiveness = 1 - healthBeforeHeal / event.maxHitPoints;
+        const masteryEffectiveness = Math.max(0, 1 - healthBeforeHeal / event.maxHitPoints);
 
         // The base healing of the spell (excluding any healing added by mastery)
         const masteryPercent = this.statTracker.currentMasteryPercentage;

--- a/src/Parser/Shaman/Restoration/Modules/Spells/HealingSurge.js
+++ b/src/Parser/Shaman/Restoration/Modules/Spells/HealingSurge.js
@@ -26,9 +26,9 @@ class HealingSurge extends Analyzer {
     return {
       actual: unbuffedHealingSurgesPerc ,
       isGreaterThan: {
-        minor: 0,
-        average: 0.15,
-        major: 0.30,
+        minor: 0.20,
+        average: 0.40,
+        major: 0.60,
       },
       style: 'percentage',
     };

--- a/src/Parser/Shaman/Restoration/Modules/Spells/HealingWave.js
+++ b/src/Parser/Shaman/Restoration/Modules/Spells/HealingWave.js
@@ -24,9 +24,9 @@ class HealingWave extends Analyzer {
     return {
       actual: unbuffedHealingWavesPerc ,
       isGreaterThan: {
-        minor: 0.0,
-        average: 0.20,
-        major: 0.40,
+        minor: 0.20,
+        average: 0.40,
+        major: 0.60,
       },
       style: 'percentage',
     };
@@ -38,12 +38,11 @@ class HealingWave extends Analyzer {
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>Casting <SpellLink id={SPELLS.HEALING_WAVE.id} /> without <SpellLink id={SPELLS.TIDAL_WAVES_BUFF.id} icon/> is slow and generally inefficient. Consider casting a riptide first to generate <SpellLink id={SPELLS.TIDAL_WAVES_BUFF.id} icon/></span>)
           .icon(SPELLS.HEALING_WAVE.icon)
-          .actual(`${formatPercentage(suggestedThreshold.actual)}% of unbuffed Healing Surges`)
-          .recommended(`${suggestedThreshold.isGreaterThan.minor}% of unbuffed Healing Surges`)
+          .actual(`${formatPercentage(suggestedThreshold.actual)}% of unbuffed Healing Waves`)
+          .recommended(`${suggestedThreshold.isGreaterThan.minor}% of unbuffed Healing Waves`)
           .regular(suggestedThreshold.isGreaterThan.average).major(suggestedThreshold.isGreaterThan.major);
       });
   }
 }
 
 export default HealingWave;
-

--- a/src/Parser/Shaman/Restoration/Modules/Spells/Resurgence.js
+++ b/src/Parser/Shaman/Restoration/Modules/Spells/Resurgence.js
@@ -109,8 +109,8 @@ class Resurgence extends Analyzer {
         label={`Mana gained from Resurgence`}
       >
         <div>
-          <SpellLink id={SPELLS.RESURGENCE.id} /> accounted for {formatPercentage((this.totalResurgenceGain - (this.hasbottomlessDepths ? this.bottomlessDepths : 0)) / this.totalMana, 0)}% of your mana pool ({formatNumber(this.totalMana)} mana). <br />
-          <SpellLink id={SPELLS.BOTTOMLESS_DEPTHS_TALENT.id} /> {expandText}
+          <SpellLink id={SPELLS.RESURGENCE.id} iconStyle={{ height: '1.25em' }}/> accounted for {formatPercentage((this.totalResurgenceGain - (this.hasbottomlessDepths ? this.bottomlessDepths : 0)) / this.totalMana, 0)}% of your mana pool ({formatNumber(this.totalMana)} mana). <br />
+          <SpellLink id={SPELLS.BOTTOMLESS_DEPTHS_TALENT.id} iconStyle={{ height: '1.25em' }}/> {expandText}
         </div>
         <table className="table table-condensed" style={{ fontWeight: 'bold' }}>
           <thead>


### PR DESCRIPTION
Adjusted some thresholds as T21 shifted the priority a bit.

Removed the spell icons from TW
![image](https://user-images.githubusercontent.com/2842471/38596062-ba4d460e-3d4f-11e8-92ec-ece0c6070633.png)![image](https://user-images.githubusercontent.com/2842471/38596055-b23bfb4a-3d4f-11e8-9229-58e1124bc7ee.png)

Fixed the exploding Resurgence Icons 
![image](https://user-images.githubusercontent.com/2842471/38596119-0de219ca-3d50-11e8-9614-fe6effd2b960.png)![image](https://user-images.githubusercontent.com/2842471/38596086-da5717e0-3d4f-11e8-95c4-80c9e8a5bd90.png)

As the new mastery tab nicely visualized, mastery effectiveness can break if something in the log is corrupt. I haven't been able to confirm what actually caused this, but added a Math.max to circumvent negative effectiveness.
(log: https://www.warcraftlogs.com/reports/M1w2Vcd9jDPTFftA/#fight=12&type=healing&source=19)
![image](https://user-images.githubusercontent.com/2842471/38596452-e7e07972-3d51-11e8-9bcb-30f4aa8efd71.png)
![image](https://user-images.githubusercontent.com/2842471/38596457-f21523b6-3d51-11e8-9c3a-1df800cb0666.png)
![image](https://user-images.githubusercontent.com/2842471/38596466-00770d8e-3d52-11e8-81f4-5724e390a932.png)![image](https://user-images.githubusercontent.com/2842471/38596467-06f5148a-3d52-11e8-9d70-d84a060cab42.png)
