### PR TITLE
[Arms Warrior] Add wasted Colossus Smash/Shattered Defenses suggestion

### DIFF
--- a/src/Parser/Warrior/Arms/CHANGELOG.js
+++ b/src/Parser/Warrior/Arms/CHANGELOG.js
@@ -7,7 +7,12 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
-    date: new Date('2018-04-10'), 
+    date: new Date('2018-04-12'),
+    changes: <Wrapper>Added a suggestion for avoiding wasted <SpellLink id={SPELLS.SHATTERED_DEFENSES.id} icon /> with <SpellLink id={SPELLS.COLOSSUS_SMASH.id} icon />.</Wrapper>,
+    contributors: [Aelexe],
+  },
+  {
+    date: new Date('2018-04-10'),
     changes: <Wrapper>Added <SpellLink id={SPELLS.BATTLE_CRY.id} icon /> statistic block.</Wrapper>,
     contributors: [Aelexe],
   },

--- a/src/Parser/Warrior/Arms/CombatLogParser.js
+++ b/src/Parser/Warrior/Arms/CombatLogParser.js
@@ -4,6 +4,7 @@ import DamageDone from 'Parser/Core/Modules/DamageDone';
 import Abilities from './Modules/Abilities';
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
 import BattleCry from './Modules/Features/BattleCry';
+import ColossusSmash from './Modules/Core/ColossusSmash';
 import CooldownThroughputTracker from './Modules/Features/CooldownThroughputTracker';
 import ColossusSmashUptime from './Modules/BuffDebuff/ColossusSmashUptime';
 import TacticianProc from './Modules/BuffDebuff/TacticianProc';
@@ -22,6 +23,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Features
     alwaysBeCasting: AlwaysBeCasting,
     battleCry: BattleCry,
+    colossusSmash: ColossusSmash,
     cooldownThroughputTracker: CooldownThroughputTracker,
     colossusSmashUptime: ColossusSmashUptime,
     tacticianProc: TacticianProc,

--- a/src/Parser/Warrior/Arms/Modules/Core/ColossusSmash.js
+++ b/src/Parser/Warrior/Arms/Modules/Core/ColossusSmash.js
@@ -7,18 +7,15 @@ import Wrapper from 'common/Wrapper';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
-import Enemies from 'Parser/Core/Modules/Enemies';
 
 import SpellUsable from '../Features/SpellUsable';
 
 class ColossusSmashAnalyzer extends Analyzer {
   static dependencies = {
     combatants: Combatants,
-    enemies: Enemies,
     spellUsable: SpellUsable,
   };
 
-  // Statistics
   colossusSmashes = 0;
   shatteredColossusOverlaps = 0;
 

--- a/src/Parser/Warrior/Arms/Modules/Core/ColossusSmash.js
+++ b/src/Parser/Warrior/Arms/Modules/Core/ColossusSmash.js
@@ -23,7 +23,7 @@ class ColossusSmashAnalyzer extends Analyzer {
     if(SPELLS.COLOSSUS_SMASH.id === event.ability.guid) {
       this.colossusSmashes += 1;
       // Ignore the cast if the player didn't have shattered defenses.
-      if(!this.combatants.selected.hasBuff(SPELLS.SHATTERED_DEFENSES.id, event.timestamp - 1)) {
+      if(!this.combatants.selected.hasBuff(SPELLS.SHATTERED_DEFENSES.id)) {
         return;
       }
       // If the player used colossus smash when shattered defenses was active increment the counter.

--- a/src/Parser/Warrior/Arms/Modules/Core/ColossusSmash.js
+++ b/src/Parser/Warrior/Arms/Modules/Core/ColossusSmash.js
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import { formatPercentage } from 'common/format';
+import SpellLink from 'common/SpellLink';
+import SPELLS from 'common/SPELLS';
+import Wrapper from 'common/Wrapper';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import Enemies from 'Parser/Core/Modules/Enemies';
+
+import SpellUsable from '../Features/SpellUsable';
+
+class ColossusSmashAnalyzer extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    enemies: Enemies,
+    spellUsable: SpellUsable,
+  };
+
+  // Statistics
+  colossusSmashes = 0;
+  shatteredColossusOverlaps = 0;
+
+  on_byPlayer_cast(event) {
+    if(SPELLS.COLOSSUS_SMASH.id === event.ability.guid) {
+      this.colossusSmashes += 1;
+      // Ignore the cast if the player didn't have shattered defenses.
+      if(!this.combatants.selected.hasBuff(SPELLS.SHATTERED_DEFENSES.id, event.timestamp - 1)) {
+        return;
+      }
+      // If the player used colossus smash when shattered defenses was active increment the counter.
+      this.shatteredColossusOverlaps += 1;
+    }
+  }
+
+  get shatteredColossusOverlapThresholds() {
+    return {
+			actual: this.shatteredColossusOverlaps / this.colossusSmashes,
+			isGreaterThan: {
+        minor: 0,
+        average: 0.05,
+        major: 0.1,
+      },
+			style: 'percentage',
+		};
+  }
+
+  suggestions(when) {
+    when(this.shatteredColossusOverlapThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(<Wrapper>You should avoid using <SpellLink id={SPELLS.COLOSSUS_SMASH.id} icon/> before you have consumed <SpellLink id={SPELLS.SHATTERED_DEFENSES.id} icon/> with <SpellLink id={SPELLS.MORTAL_STRIKE.id} icon/>.</Wrapper>)
+        .icon(SPELLS.COLOSSUS_SMASH.icon)
+        .actual(`Shattered Defenses was already active for ${formatPercentage(actual)}% of Colossus Smashes.`)
+        .recommended(`${formatPercentage(recommended)}% is recommended`);
+    });
+  }
+}
+
+export default ColossusSmashAnalyzer;

--- a/src/Parser/Warrior/Arms/Modules/Core/ColossusSmash.js
+++ b/src/Parser/Warrior/Arms/Modules/Core/ColossusSmash.js
@@ -8,27 +8,26 @@ import Wrapper from 'common/Wrapper';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 
-import SpellUsable from '../Features/SpellUsable';
-
 class ColossusSmashAnalyzer extends Analyzer {
   static dependencies = {
     combatants: Combatants,
-    spellUsable: SpellUsable,
   };
 
   colossusSmashes = 0;
   shatteredColossusOverlaps = 0;
 
   on_byPlayer_cast(event) {
-    if(SPELLS.COLOSSUS_SMASH.id === event.ability.guid) {
-      this.colossusSmashes += 1;
-      // Ignore the cast if the player didn't have shattered defenses.
-      if(!this.combatants.selected.hasBuff(SPELLS.SHATTERED_DEFENSES.id)) {
-        return;
-      }
-      // If the player used colossus smash when shattered defenses was active increment the counter.
-      this.shatteredColossusOverlaps += 1;
+    if(SPELLS.COLOSSUS_SMASH.id !== event.ability.guid) {
+      return;
     }
+    
+    this.colossusSmashes += 1;
+    // Ignore the cast if the player didn't have shattered defenses.
+    if(!this.combatants.selected.hasBuff(SPELLS.SHATTERED_DEFENSES.id)) {
+      return;
+    }
+    // If the player used colossus smash when shattered defenses was active increment the counter.
+    this.shatteredColossusOverlaps += 1;
   }
 
   get shatteredColossusOverlapThresholds() {


### PR DESCRIPTION
Adds a suggestion to avoid using Colossus Smash with Shattered Defenses already active.

![image](https://user-images.githubusercontent.com/2950145/38654596-40e336e6-3e64-11e8-8e1c-2d13e50bc086.png)
