### PR TITLE
[Arms Warrior] Add wasted Executioner's Precision suggestion

### DIFF
--- a/src/Parser/Warrior/Arms/CHANGELOG.js
+++ b/src/Parser/Warrior/Arms/CHANGELOG.js
@@ -8,6 +8,11 @@ import SpellLink from 'common/SpellLink';
 export default [
   {
     date: new Date('2018-04-12'),
+    changes: <Wrapper>Added a suggestion for avoiding wasted <SpellLink id={SPELLS.EXECUTIONERS_PRECISION.id} icon /> stacks.</Wrapper>,
+    contributors: [Aelexe],
+  },
+  {
+    date: new Date('2018-04-12'),
     changes: <Wrapper>Added a suggestion for avoiding wasted <SpellLink id={SPELLS.SHATTERED_DEFENSES.id} icon /> with <SpellLink id={SPELLS.COLOSSUS_SMASH.id} icon />.</Wrapper>,
     contributors: [Aelexe],
   },

--- a/src/Parser/Warrior/Arms/CombatLogParser.js
+++ b/src/Parser/Warrior/Arms/CombatLogParser.js
@@ -7,6 +7,7 @@ import BattleCry from './Modules/Features/BattleCry';
 import ColossusSmash from './Modules/Core/ColossusSmash';
 import CooldownThroughputTracker from './Modules/Features/CooldownThroughputTracker';
 import ColossusSmashUptime from './Modules/BuffDebuff/ColossusSmashUptime';
+import Execute from './Modules/Core/Execute';
 import TacticianProc from './Modules/BuffDebuff/TacticianProc';
 import SpellUsable from './Modules/Features/SpellUsable';
 import Channeling from './Modules/Features/Channeling';
@@ -26,6 +27,7 @@ class CombatLogParser extends CoreCombatLogParser {
     colossusSmash: ColossusSmash,
     cooldownThroughputTracker: CooldownThroughputTracker,
     colossusSmashUptime: ColossusSmashUptime,
+    execute: Execute,
     tacticianProc: TacticianProc,
     spellUsable: SpellUsable,
     channeling: Channeling,

--- a/src/Parser/Warrior/Arms/Modules/Core/Execute.js
+++ b/src/Parser/Warrior/Arms/Modules/Core/Execute.js
@@ -26,9 +26,13 @@ class ExecutionAnalyzer extends Analyzer {
 
     this.executes += 1;
     const enemy = this.enemies.getEntity(event);
-    const executionersPrecision = enemy.getBuff(SPELLS.EXECUTIONERS_PRECISION.id, null, 0, 0, event.sourceID);
+    const executionersPrecision = enemy.getBuff(SPELLS.EXECUTIONERS_PRECISION.id);
     if(executionersPrecision !== undefined && executionersPrecision.stacks === 2 && this.spellUsable.isAvailable(SPELLS.MORTAL_STRIKE.id)) {
       this.wastedExecutionersPrecisions += 1;
+
+      event.meta = event.meta || {};
+      event.meta.isInefficientCast = true;
+      event.meta.inefficientCastReason = 'This Execute was used on a target with 2 stacks of Executioner\'s Precision while Mortal Strike was available.';
     }
   }
 

--- a/src/Parser/Warrior/Arms/Modules/Core/Execute.js
+++ b/src/Parser/Warrior/Arms/Modules/Core/Execute.js
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { formatPercentage } from 'common/format';
+import SpellLink from 'common/SpellLink';
+import SPELLS from 'common/SPELLS';
+import Wrapper from 'common/Wrapper';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Enemies from 'Parser/Core/Modules/Enemies';
+
+import SpellUsable from '../Features/SpellUsable';
+
+class ExecutionAnalyzer extends Analyzer {
+  static dependencies = {
+    enemies: Enemies,
+    spellUsable: SpellUsable,
+  };
+
+  executes = 0;
+  wastedExecutionersPrecisions = 0;
+
+  on_byPlayer_cast(event) {
+    if(SPELLS.EXECUTE.id !== event.ability.guid) {
+      return;
+    }
+
+    this.executes += 1;
+    const enemy = this.enemies.getEntity(event);
+    const executionersPrecision = enemy.getBuff(SPELLS.EXECUTIONERS_PRECISION.id, null, 0, 0, event.sourceID);
+    if(executionersPrecision !== undefined && executionersPrecision.stacks === 2 && this.spellUsable.isAvailable(SPELLS.MORTAL_STRIKE.id)) {
+      this.wastedExecutionersPrecisions += 1;
+    }
+  }
+
+  get wastedExecutionersPrecisionTresholds() {
+    return {
+			actual: this.wastedExecutionersPrecisions / this.executes,
+			isGreaterThan: {
+        minor: 0,
+        average: 0.05,
+        major: 0.1,
+      },
+			style: 'percentage',
+		};
+  }
+
+  suggestions(when) {
+    when(this.wastedExecutionersPrecisionTresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(<Wrapper>Try to avoid using <SpellLink id={SPELLS.EXECUTE.id} icon/> at 2 stacks of <SpellLink id={SPELLS.EXECUTIONERS_PRECISION.id} icon/> if <SpellLink id={SPELLS.MORTAL_STRIKE.id} icon/> is available.</Wrapper>)
+        .icon(SPELLS.EXECUTE.icon)
+        .actual(`${formatPercentage(actual)}% of Executioner's Precisions stacks were wasted.`)
+        .recommended(`${formatPercentage(recommended)}% is recommended`);
+    });
+  }
+}
+
+export default ExecutionAnalyzer;


### PR DESCRIPTION
Adds a suggestion to avoid using execute if the target has two stack of executioner's precision and mortal strike is available.

I actually thought I'd coded it wrong, but it turns out my test subject might need a bit of practice on his execute phase execution.

![image](https://user-images.githubusercontent.com/2950145/38660102-31781912-3e80-11e8-9b81-79bad9438d69.png)
