### PR TITLE
[Arms Warrior] Add unshattered Mortal Strike suggestion

### DIFF
--- a/src/Parser/Warrior/Arms/CHANGELOG.js
+++ b/src/Parser/Warrior/Arms/CHANGELOG.js
@@ -7,6 +7,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-04-12'),
+    changes: <Wrapper>Added a suggestion for avoiding using <SpellLink id={SPELLS.MORTAL_STRIKE.id} icon /> without <SpellLink id={SPELLS.SHATTERED_DEFENSES.id} icon /> where possible.</Wrapper>,
+    contributors: [Aelexe],
+  },
+  {
     date: new Date('2018-04-10'),
     changes: <Wrapper>Added a suggestion for not using <SpellLink id={SPELLS.REND_TALENT.id} icon /> on a target in <SpellLink id={SPELLS.EXECUTE.id} icon /> range.</Wrapper>,
     contributors: [Aelexe],

--- a/src/Parser/Warrior/Arms/CombatLogParser.js
+++ b/src/Parser/Warrior/Arms/CombatLogParser.js
@@ -9,6 +9,7 @@ import CooldownThroughputTracker from './Modules/Features/CooldownThroughputTrac
 import ColossusSmashUptime from './Modules/BuffDebuff/ColossusSmashUptime';
 import Execute from './Modules/Core/Execute';
 import Rend from './Modules/Talents/Rend';
+import MortalStrike from './Modules/Core/MortalStrike';
 import TacticianProc from './Modules/BuffDebuff/TacticianProc';
 import SpellUsable from './Modules/Features/SpellUsable';
 import Channeling from './Modules/Features/Channeling';
@@ -30,6 +31,7 @@ class CombatLogParser extends CoreCombatLogParser {
     colossusSmashUptime: ColossusSmashUptime,
     execute: Execute,
     rend: Rend,
+    mortalStrike: MortalStrike,
     tacticianProc: TacticianProc,
     spellUsable: SpellUsable,
     channeling: Channeling,

--- a/src/Parser/Warrior/Arms/Modules/Core/MortalStrike.js
+++ b/src/Parser/Warrior/Arms/Modules/Core/MortalStrike.js
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import { formatPercentage } from 'common/format';
+import SpellLink from 'common/SpellLink';
+import SPELLS from 'common/SPELLS';
+import Wrapper from 'common/Wrapper';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import SpellUsable from '../Features/SpellUsable';
+
+class MortalStrikeAnalyzer extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    spellUsable: SpellUsable,
+  };
+
+  mortalStrikes = 0;
+  unshatteredMortalStrikes = 0;
+
+  on_byPlayer_cast(event) {
+    if(SPELLS.MORTAL_STRIKE.id !== event.ability.guid) {
+      return;
+    }
+
+    this.mortalStrikes += 1;
+    // If the player used mortal strike when shattered defenses was inactive and colossus smash was available increment the counter.
+    // We don't check for Warbreaker here as it is often saved for AOE burst.
+    if(!this.combatants.selected.hasBuff(SPELLS.SHATTERED_DEFENSES.id) && this.spellUsable.isAvailable(SPELLS.COLOSSUS_SMASH.id)) {
+      this.unshatteredMortalStrikes += 1;
+
+      event.meta = event.meta || {};
+      event.meta.isInefficientCast = true;
+      event.meta.inefficientCastReason = 'This Mortal Strike was used without Shattered Defenses while Colossus Smash was available.';
+    }
+  }
+
+  get unshatteredMortalStrikeThresholds() {
+    return {
+			actual: this.unshatteredMortalStrikes / this.mortalStrikes,
+			isGreaterThan: {
+        minor: 0,
+        average: 0.05,
+        major: 0.1,
+      },
+			style: 'percentage',
+		};
+  }
+
+  suggestions(when) {
+    when(this.unshatteredMortalStrikeThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(<Wrapper>Try to avoid using <SpellLink id={SPELLS.MORTAL_STRIKE.id} icon/> if <SpellLink id={SPELLS.SHATTERED_DEFENSES.id} icon/> is inactive and <SpellLink id={SPELLS.COLOSSUS_SMASH.id} icon/> is available.</Wrapper>)
+        .icon(SPELLS.MORTAL_STRIKE.icon)
+        .actual(`${formatPercentage(actual)}% of Mortal Strikes were used without Shattered Defenses unnecessarily.`)
+        .recommended(`${formatPercentage(recommended)}% is recommended`);
+    });
+  }
+}
+
+export default MortalStrikeAnalyzer;


### PR DESCRIPTION
Suggests not using mortal strike without shattered defenses where possible.

![image](https://user-images.githubusercontent.com/2950145/38672294-dc16c6f4-3ea1-11e8-98f6-0493a7d08bb4.png)
