### PR TITLE
[Core] Add search function to events tab

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Anomoly, blazyb, Dyspho, fasib, Fyruna, Gurupitka, Juko8, Mamtooth, sref, Versaya, aryu, Zerotorescue, Hartra344, Putro, Sharrq, Hewhosmites, joshinator, kyleglick, CubeLuke } from 'CONTRIBUTORS';
+import { Anomoly, blazyb, Dyspho, fasib, Fyruna, Gurupitka, Juko8, Mamtooth, sref, Versaya, aryu, Zerotorescue, Hartra344, Putro, Sharrq, Hewhosmites, joshinator, kyleglick, CubeLuke, Aelexe } from 'CONTRIBUTORS';
 import Wrapper from 'common/Wrapper';
 import ItemLink from 'common/ItemLink';
 import ITEMS from 'common/ITEMS';
@@ -8,11 +8,6 @@ import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 
 export default [
-  {
-    date: new Date('2018-04-12'),
-    changes: 'Added search function to events tab.',
-    contributors: [Aelexe],
-  },
   {
     date: new Date('2018-04-18'),
     changes: 'Added error page when attempting to view an invalid contributor page.',
@@ -22,6 +17,11 @@ export default [
     date: new Date('2018-04-14'),
     changes: 'Abilities in the timeline are now sorted by times cast by default instead of cooldown duration.',
     contributors: [Zerotorescue],
+  },
+  {
+    date: new Date('2018-04-12'),
+    changes: 'Added search function to events tab.',
+    contributors: [Aelexe],
   },
   {
     date: new Date('2018-04-11'),

--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -9,6 +9,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-04-12'),
+    changes: 'Added search function to events tab.',
+    contributors: [Aelexe],
+  },
+  {
     date: new Date('2018-04-18'),
     changes: 'Added error page when attempting to view an invalid contributor page.',
     contributors: [CubeLuke],

--- a/src/Main/EventsTab.js
+++ b/src/Main/EventsTab.js
@@ -179,6 +179,21 @@ class EventsTab extends React.Component {
     console.log(rowData);
   }
 
+  renderSearchBox() {
+    return (
+      <input
+        type="text"
+        name="search"
+        className="form-control"
+        onChange={event => this.setState({ search: event.target.value.trim().toLowerCase() })}
+        placeholder="Search events (comma separated)"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck="false"
+      />
+    );
+  }
+
   render() {
     const { parser } = this.props;
 
@@ -190,7 +205,31 @@ class EventsTab extends React.Component {
         if (!this.state.showFabricated && event.__fabricated === true) {
           return false;
         }
-        return true;
+
+        // Search Logic
+        if(this.state.search === undefined || this.state.search === '') {
+          return true;
+        }
+
+        const source = this.findEntity(event.sourceID);
+        const target = this.findEntity(event.targetID);
+
+        const searchTerms = this.state.search.split(',');
+        for(let i = 0; i < searchTerms.length; i++) {
+          const searchTerm = searchTerms[i].trim();
+          if(searchTerm === '') {
+            return false;
+          }
+          if(event.ability !== undefined && event.ability.name.toLowerCase().includes(searchTerm)) {
+            return true;
+          } else if(source !== null && source.name.toLowerCase().includes(searchTerm)) {
+            return true;
+          } else if(target !== null && target.name.toLowerCase().includes(searchTerm)) {
+            return true;
+          }
+        }
+
+        return false;
       });
 
     // TODO: Show active buffs like WCL
@@ -203,6 +242,8 @@ class EventsTab extends React.Component {
           <Info className="small" style={{ width: 240 }}>
             This only includes events involving the selected player.
           </Info>
+          <br />
+          {this.renderSearchBox()}
           <br />
           {Object.keys(FILTERABLE_TYPES).map(type => this.renderEventTypeToggle(type))}
           <br />

--- a/src/Main/EventsTab.js
+++ b/src/Main/EventsTab.js
@@ -103,6 +103,7 @@ class EventsTab extends React.Component {
       }, {}),
       rawNames: false,
       showFabricated: false,
+      search: '',
     };
     this.handleRowClick = this.handleRowClick.bind(this);
   }
@@ -197,6 +198,10 @@ class EventsTab extends React.Component {
   render() {
     const { parser } = this.props;
 
+    const searchTerms = this.state.search
+      .split(' ')
+      .filter(searchTerm => searchTerm !== '');
+
     const events = parser.eventHistory
       .filter(event => {
         if (this.state[event.type] === false) {
@@ -207,19 +212,14 @@ class EventsTab extends React.Component {
         }
 
         // Search Logic
-        if(this.state.search === undefined || this.state.search === '') {
+        if(searchTerms.length === 0) {
           return true;
         }
 
         const source = this.findEntity(event.sourceID);
         const target = this.findEntity(event.targetID);
 
-        const searchTerms = this.state.search.split(',');
-        for(let i = 0; i < searchTerms.length; i++) {
-          const searchTerm = searchTerms[i].trim();
-          if(searchTerm === '') {
-            return false;
-          }
+        return searchTerms.some(searchTerm => {
           if(event.ability !== undefined && event.ability.name.toLowerCase().includes(searchTerm)) {
             return true;
           } else if(source !== null && source.name.toLowerCase().includes(searchTerm)) {
@@ -227,9 +227,8 @@ class EventsTab extends React.Component {
           } else if(target !== null && target.name.toLowerCase().includes(searchTerm)) {
             return true;
           }
-        }
-
-        return false;
+          return false;
+        });
       });
 
     // TODO: Show active buffs like WCL


### PR DESCRIPTION
Added search functionality to the events tab because I really wanted it. The search box takes a comma delimited list of search terms and matches any event in which the ability, source or target includes one of those terms.

![image](https://user-images.githubusercontent.com/2950145/38674942-546ece8c-3eaa-11e8-857d-f5bc134f49f8.png)
