### PR TITLE
[Restoration Shaman] Talents

### DIFF
--- a/src/Parser/Shaman/Restoration/CHANGELOG.js
+++ b/src/Parser/Shaman/Restoration/CHANGELOG.js
@@ -9,6 +9,16 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-04-13'),
+    changes: <Wrapper>Added statistics showing the healing impact of each talent, with support for all talents that directly impact HPS apart from <SpellLink id={SPELLS.CRASHING_WAVES_TALENT.id} />, <SpellLink id={SPELLS.DELUGE_TALENT.id} /> and <SpellLink id={SPELLS.ECHO_OF_THE_ELEMENTS_TALENT.id} />.</Wrapper>,
+    contributors: [niseko],
+  },
+  {
+    date: new Date('2018-04-13'),
+    changes: <Wrapper>Added a module breaking down your <SpellLink id={SPELLS.UNLEASH_LIFE_TALENT.id} /> usage by spell.</Wrapper>,
+    contributors: [niseko],
+  },
+  {
     date: new Date('2018-04-11'),
     changes: 'Implemented Stat Values for Restoration Shaman.',
     contributors: [niseko],

--- a/src/Parser/Shaman/Restoration/CONFIG.js
+++ b/src/Parser/Shaman/Restoration/CONFIG.js
@@ -22,7 +22,6 @@ export default {
       If you want to learn more about Resto Shaman, join the Resto Shaman community at the <a href="https://discord.gg/AcTek6e" target="_blank" rel="noopener noreferrer">Ancestral Guidance</a> discord server and make sure to visit the <a href="https://ancestralguidance.com/">website</a>.<br /><br />
 
       <Warning>
-        The Restoration Shaman analysis isn't complete yet. What we do show should be good to use, but it does not show the complete picture.<br />
         If there is something missing, incorrect, or inaccurate, please report it on <a href="https://github.com/WoWAnalyzer/WoWAnalyzer/issues/new">GitHub</a> or contact us on <a href="https://discord.gg/AxphPxU">Discord</a>.
       </Warning>
     </Wrapper>

--- a/src/Parser/Shaman/Restoration/CombatLogParser.js
+++ b/src/Parser/Shaman/Restoration/CombatLogParser.js
@@ -22,7 +22,15 @@ import AncestralVigor from './Modules/Features/AncestralVigor';
 import TidalWaves from './Modules/Features/TidalWaves';
 import CastBehavior from './Modules/Features/CastBehavior'; 
 
+import TalentStatisticBox from './Modules/Talents/TalentStatisticBox';
+import Torrent from './Modules/Talents/Torrent';
+import UnleashLife from './Modules/Talents/UnleashLife';
+import Undulation from './Modules/Talents/Undulation';
+import AncestralGuidance from './Modules/Talents/AncestralGuidance';
 import EarthenShieldTotem from './Modules/Talents/EarthenShieldTotem';
+import CloudburstTotem from './Modules/Talents/CloudburstTotem';
+import Ascendance from './Modules/Talents/Ascendance';
+import Wellspring from './Modules/Talents/Wellspring';
 import HighTide from './Modules/Talents/HighTide';
 
 import Nazjatar from './Modules/Items/Nazjatar';
@@ -77,7 +85,15 @@ class CombatLogParser extends CoreCombatLogParser {
     statValues: StatValues,
 
     // Talents:
+    talentStatisticBox: TalentStatisticBox,
+    torrent: Torrent,
+    unleashLife: UnleashLife,
+    undulation: Undulation,
+    ancestralGuidance: AncestralGuidance,
     earthenShieldTotem: EarthenShieldTotem,
+    cloudburstTotem: CloudburstTotem,
+    ascendance: Ascendance,
+    wellspring: Wellspring,
     highTide: HighTide,
 
     // Items:

--- a/src/Parser/Shaman/Restoration/Modules/Features/CastBehavior.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/CastBehavior.js
@@ -69,7 +69,7 @@ class CastBehavior extends Analyzer {
           datasets: [{
             data: items.map(item => item.value),
             backgroundColor: items.map(item => item.color),
-            borderColor: '#666',
+            borderColor: '#000000',
             borderWidth: 1.5,
           }],
           labels: items.map(item => item.label),
@@ -109,13 +109,13 @@ class CastBehavior extends Analyzer {
 
     const items = [
       {
-        color: '#2055CC',
+        color: SPELLS.HEALING_WAVE.color,
         label: 'Healing Wave',
         spellId: SPELLS.HEALING_WAVE.id,
         value: twHealingWaves,
       },
       {
-        color: '#42E0FF',
+        color: SPELLS.HEALING_SURGE_RESTORATION.color,
         label: 'Healing Surge',
         spellId: SPELLS.HEALING_SURGE_RESTORATION.id,
         value: twHealingSurges,
@@ -154,13 +154,13 @@ class CastBehavior extends Analyzer {
 
     const items = [
       {
-        color: '#2055CC',
+        color: SPELLS.HEALING_WAVE.color,
         label: 'Healing Wave',
         spellId: SPELLS.HEALING_WAVE.id,
         value: fillerHealingWaves,
       },
       {
-        color: '#42E0FF',
+        color: SPELLS.HEALING_SURGE_RESTORATION.color,
         label: 'Healing Surge',
         spellId: SPELLS.HEALING_SURGE_RESTORATION.id,
         value: fillerHealingSurges,

--- a/src/Parser/Shaman/Restoration/Modules/Features/CastBehavior.js
+++ b/src/Parser/Shaman/Restoration/Modules/Features/CastBehavior.js
@@ -70,7 +70,7 @@ class CastBehavior extends Analyzer {
             data: items.map(item => item.value),
             backgroundColor: items.map(item => item.color),
             borderColor: '#000000',
-            borderWidth: 1.5,
+            borderWidth: 0,
           }],
           labels: items.map(item => item.label),
         }}

--- a/src/Parser/Shaman/Restoration/Modules/Spells/HealingSurge.js
+++ b/src/Parser/Shaman/Restoration/Modules/Spells/HealingSurge.js
@@ -41,7 +41,7 @@ class HealingSurge extends Analyzer {
         return suggest(<span>Casting <SpellLink id={SPELLS.HEALING_SURGE_RESTORATION.id} /> without <SpellLink id={SPELLS.TIDAL_WAVES_BUFF.id} /> is very inefficient, try not to cast more than is necessary.</span>)
           .icon(SPELLS.HEALING_SURGE_RESTORATION.icon)
           .actual(`${formatPercentage(suggestedThreshold.actual)}% of unbuffed Healing Surges`)
-          .recommended(`${suggestedThreshold.isGreaterThan.minor}% of unbuffed Healing Surges`)
+          .recommended(`${formatPercentage(suggestedThreshold.isGreaterThan.minor)}% of unbuffed Healing Surges`)
           .regular(suggestedThreshold.isGreaterThan.average).major(suggestedThreshold.isGreaterThan.major);
       });
   }

--- a/src/Parser/Shaman/Restoration/Modules/Spells/HealingWave.js
+++ b/src/Parser/Shaman/Restoration/Modules/Spells/HealingWave.js
@@ -39,7 +39,7 @@ class HealingWave extends Analyzer {
         return suggest(<span>Casting <SpellLink id={SPELLS.HEALING_WAVE.id} /> without <SpellLink id={SPELLS.TIDAL_WAVES_BUFF.id} icon/> is slow and generally inefficient. Consider casting a riptide first to generate <SpellLink id={SPELLS.TIDAL_WAVES_BUFF.id} icon/></span>)
           .icon(SPELLS.HEALING_WAVE.icon)
           .actual(`${formatPercentage(suggestedThreshold.actual)}% of unbuffed Healing Waves`)
-          .recommended(`${suggestedThreshold.isGreaterThan.minor}% of unbuffed Healing Waves`)
+          .recommended(`${formatPercentage(suggestedThreshold.isGreaterThan.minor)}% of unbuffed Healing Waves`)
           .regular(suggestedThreshold.isGreaterThan.average).major(suggestedThreshold.isGreaterThan.major);
       });
   }

--- a/src/Parser/Shaman/Restoration/Modules/Talents/AncestralGuidance.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/AncestralGuidance.js
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import SpellLink from 'common/SpellLink';
+import SPELLS from 'common/SPELLS';
+import { formatPercentage } from 'common/format';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import CooldownThroughputTracker from '../Features/CooldownThroughputTracker';
+
+class AncestralGuidance extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    cooldownThroughputTracker: CooldownThroughputTracker,
+  };
+  healing = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.ANCESTRAL_GUIDANCE_TALENT.id);
+  }
+
+  on_byPlayer_heal(event) {
+    const spellId = event.ability.guid;
+
+    if (spellId !== SPELLS.ANCESTRAL_GUIDANCE_HEAL.id) {
+      return;
+    }
+
+    this.healing += event.amount;
+  }
+
+  subStatistic() {
+    const feeding = this.cooldownThroughputTracker.getIndirectHealing(SPELLS.ANCESTRAL_GUIDANCE_HEAL.id);
+    return (
+      <div className="flex">
+        <div className="flex-main">
+          <SpellLink id={SPELLS.ANCESTRAL_GUIDANCE_TALENT.id} />
+        </div>
+        <div className="flex-sub text-right">
+          {formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing + feeding))} %
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default AncestralGuidance;
+

--- a/src/Parser/Shaman/Restoration/Modules/Talents/Ascendance.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/Ascendance.js
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import SpellLink from 'common/SpellLink';
+import SPELLS from 'common/SPELLS';
+import { formatPercentage } from 'common/format';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import CooldownThroughputTracker from '../Features/CooldownThroughputTracker';
+
+class Ascendance extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    cooldownThroughputTracker: CooldownThroughputTracker,
+  };
+  healing = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.ASCENDANCE_TALENT_RESTORATION.id);
+  }
+
+  on_byPlayer_heal(event) {
+    const spellId = event.ability.guid;
+
+    if (spellId !== SPELLS.ASCENDANCE_HEAL.id) {
+      return;
+    }
+
+    this.healing += event.amount;
+  }
+
+  subStatistic() {
+    const feeding = this.cooldownThroughputTracker.getIndirectHealing(SPELLS.ASCENDANCE_HEAL.id);
+    return (
+      <div className="flex">
+        <div className="flex-main">
+          <SpellLink id={SPELLS.ASCENDANCE_TALENT_RESTORATION.id} />
+        </div>
+        <div className="flex-sub text-right">
+          {formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing + feeding))} %
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default Ascendance;
+

--- a/src/Parser/Shaman/Restoration/Modules/Talents/CloudburstTotem.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/CloudburstTotem.js
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import SpellLink from 'common/SpellLink';
+import SPELLS from 'common/SPELLS';
+import { formatPercentage } from 'common/format';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import CooldownThroughputTracker from '../Features/CooldownThroughputTracker';
+
+class CloudburstTotem extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    cooldownThroughputTracker: CooldownThroughputTracker,
+  };
+  healing = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.CLOUDBURST_TOTEM_TALENT.id);
+  }
+
+  on_byPlayer_heal(event) {
+    const spellId = event.ability.guid;
+
+    if (spellId !== SPELLS.CLOUDBURST_TOTEM_HEAL.id) {
+      return;
+    }
+
+    this.healing += event.amount;
+  }
+
+  subStatistic() {
+    const feeding = this.cooldownThroughputTracker.getIndirectHealing(SPELLS.CLOUDBURST_TOTEM_HEAL.id);
+    return (
+      <div className="flex">
+        <div className="flex-main">
+          <SpellLink id={SPELLS.CLOUDBURST_TOTEM_TALENT.id} />
+        </div>
+        <div className="flex-sub text-right">
+          {formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing + feeding))} %
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default CloudburstTotem;
+

--- a/src/Parser/Shaman/Restoration/Modules/Talents/EarthenShieldTotem.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/EarthenShieldTotem.js
@@ -71,7 +71,7 @@ class EarthenShieldTotem extends Analyzer {
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>Try to cast <SpellLink id={SPELLS.EARTHEN_SHIELD_TOTEM_TALENT.id} /> at times - and positions where there will be as many people taking damage possible inside of it to maximize the amount it absorbs.</span>)
           .icon(SPELLS.EARTHEN_SHIELD_TOTEM_TALENT.icon)
-          .actual(`${this.earthenShieldEfficiency}%`)
+          .actual(`${this.earthenShieldEfficiency.toFixed(2)}%`)
           .recommended(`${recommended}%`)
           .regular(recommended - .15).major(recommended - .3);
       });
@@ -93,6 +93,19 @@ class EarthenShieldTotem extends Analyzer {
     );
   }
   statisticOrder = STATISTIC_ORDER.OPTIONAL(70);
+
+  subStatistic() {
+    return (
+      <div className="flex">
+        <div className="flex-main">
+          <SpellLink id={SPELLS.EARTHEN_SHIELD_TOTEM_TALENT.id} />
+        </div>
+        <div className="flex-sub text-right">
+          {formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing))} %
+        </div>
+      </div>
+    );
+  }
 }
 
 export default EarthenShieldTotem;

--- a/src/Parser/Shaman/Restoration/Modules/Talents/TalentStatisticBox.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/TalentStatisticBox.js
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import StatisticsListBox, { STATISTIC_ORDER } from 'Main/StatisticsListBox';
+import SPELLS from 'common/SPELLS';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import Torrent from './Torrent';
+import UnleashLife from './UnleashLife';
+import Undulation from './Undulation';
+import EarthenShieldTotem from './EarthenShieldTotem';
+import AncestralGuidance from './AncestralGuidance';
+import CloudburstTotem from './CloudburstTotem';
+import Ascendance from './Ascendance';
+import Wellspring from './Wellspring';
+import HighTide from './HighTide';
+
+
+class TalentStatisticBox extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    torrent: Torrent,
+    unleashLife: UnleashLife,
+    undulation: Undulation,
+    ancestralGuidance: AncestralGuidance,
+    earthenShieldTotem: EarthenShieldTotem,
+    cloudburstTotem: CloudburstTotem,
+    ascendance: Ascendance,
+    wellspring: Wellspring,
+    highTide: HighTide,
+  };
+
+  statistic() {
+    return (
+      <StatisticsListBox
+        title="Talents"
+        tooltip=
+        {`This includes feeding and any interaction they have. Since some of those talents can feed into each other, their combined value will be higher than the actual total healing.<br /><br />
+        <b>Not Supported:</b><br />
+        Crashing Waves<br />
+        Deluge<br />
+        Echo of the Elements
+        `}
+      >
+        {this.combatants.selected.hasTalent(SPELLS.TORRENT_TALENT.id) ? this.torrent.subStatistic() : ''}
+        {this.combatants.selected.hasTalent(SPELLS.UNLEASH_LIFE_TALENT.id) ? this.unleashLife.subStatistic() : ''}
+        {this.combatants.selected.hasTalent(SPELLS.UNDULATION_TALENT.id) ? this.undulation.subStatistic() : ''}
+        {this.combatants.selected.hasTalent(SPELLS.ANCESTRAL_GUIDANCE_TALENT.id) ? this.ancestralGuidance.subStatistic() : ''}
+        {this.combatants.selected.hasTalent(SPELLS.EARTHEN_SHIELD_TOTEM_TALENT.id) ? this.earthenShieldTotem.subStatistic() : ''}
+        {this.combatants.selected.hasTalent(SPELLS.CLOUDBURST_TOTEM_TALENT.id) ? this.cloudburstTotem.subStatistic() : ''}
+        {this.combatants.selected.hasTalent(SPELLS.ASCENDANCE_TALENT_RESTORATION.id) ? this.ascendance.subStatistic() : ''}
+        {this.combatants.selected.hasTalent(SPELLS.WELLSPRING_TALENT.id) ? this.wellspring.subStatistic() : ''}
+        {this.combatants.selected.hasTalent(SPELLS.HIGH_TIDE_TALENT.id) ? this.highTide.subStatistic() : ''}
+      </StatisticsListBox>
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(1000);
+}
+
+export default TalentStatisticBox;

--- a/src/Parser/Shaman/Restoration/Modules/Talents/TalentStatisticBox.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/TalentStatisticBox.js
@@ -36,7 +36,7 @@ class TalentStatisticBox extends Analyzer {
       <StatisticsListBox
         title="Talents"
         tooltip=
-        {`This includes feeding and any interaction they have. Since some of those talents can feed into each other, their combined value will be higher than the actual total healing.<br /><br />
+        {`This includes feeding and any interaction they have. Since some of those talents can feed into each other, their combined value will be higher than the actual combined healing.<br /><br />
         <b>Not Supported:</b><br />
         Crashing Waves<br />
         Deluge<br />

--- a/src/Parser/Shaman/Restoration/Modules/Talents/TalentStatisticBox.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/TalentStatisticBox.js
@@ -36,7 +36,7 @@ class TalentStatisticBox extends Analyzer {
       <StatisticsListBox
         title="Talents"
         tooltip=
-        {`This includes feeding and any interaction they have. Since some of those talents can feed into each other, their combined value will be higher than the actual combined healing.<br /><br />
+        {`The purpose of this is to show the overall HPS impact of each talent. So not only what the talent itself did, but also feeding and synergy or interactions with other spells or talents. The percentage shown is what you'd lose without the talent, ignoring what you'd gain from the other options.<br /><br />
         <b>Not Supported:</b><br />
         Crashing Waves<br />
         Deluge<br />

--- a/src/Parser/Shaman/Restoration/Modules/Talents/Torrent.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/Torrent.js
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import SpellLink from 'common/SpellLink';
+import SPELLS from 'common/SPELLS';
+import { formatPercentage } from 'common/format';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveHealing from 'Parser/Core/calculateEffectiveHealing';
+
+const TORRENT_HEALING_INCREASE = 0.3;
+
+class Torrent extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+  healing = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.TORRENT_TALENT.id);
+  }
+
+  on_byPlayer_heal(event) {
+    const spellId = event.ability.guid;
+
+    if (spellId !== SPELLS.RIPTIDE.id || event.tick) {
+      return;
+    }
+
+    this.healing += calculateEffectiveHealing(event, TORRENT_HEALING_INCREASE);
+  }
+
+  on_feed_heal(event) {
+    const spellId = event.ability.guid;
+
+    if (spellId !== SPELLS.RIPTIDE.id || event.tick) {
+      return;
+    }
+        
+    this.healing += event.feed * TORRENT_HEALING_INCREASE;
+  }
+
+  subStatistic() {
+    return (
+      <div className="flex">
+        <div className="flex-main">
+          <SpellLink id={SPELLS.TORRENT_TALENT.id} />
+        </div>
+        <div className="flex-sub text-right">
+          {formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing))} %
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default Torrent;
+

--- a/src/Parser/Shaman/Restoration/Modules/Talents/Undulation.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/Undulation.js
@@ -1,0 +1,76 @@
+import React from 'react';
+
+import SpellLink from 'common/SpellLink';
+import SPELLS from 'common/SPELLS';
+import { formatPercentage } from 'common/format';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveHealing from 'Parser/Core/calculateEffectiveHealing';
+
+const UNDULATION_HEALING_INCREASE = 0.5;
+const BUFFER_MS = 300;
+
+class Undulation extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+  healing = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.UNDULATION_TALENT.id);
+  }
+
+  on_byPlayer_heal(event) {
+    const spellId = event.ability.guid;
+
+    if (spellId === SPELLS.HEALING_WAVE.id || spellId === SPELLS.HEALING_SURGE_RESTORATION.id) {
+      const hasUndulation = this.combatants.selected.hasBuff(SPELLS.UNDULATION_BUFF.id, event.timestamp, BUFFER_MS, BUFFER_MS);
+
+      if (hasUndulation) {
+        this.healing += calculateEffectiveHealing(event, UNDULATION_HEALING_INCREASE);
+      }
+    } else if (spellId === SPELLS.DOWNPOUR.id) {
+      const hasUndulation = this.combatants.selected.hasBuff(SPELLS.UNDULATION_BUFF.id, event.timestamp, BUFFER_MS, BUFFER_MS);
+
+      if (hasUndulation) {
+        this.healing += calculateEffectiveHealing(event, UNDULATION_HEALING_INCREASE);
+      }
+    }
+  }
+
+  on_feed_heal(event) {
+    const spellId = event.ability.guid;
+
+    if (spellId === SPELLS.HEALING_WAVE.id || spellId === SPELLS.HEALING_SURGE_RESTORATION.id) {
+      const hasUndulation = this.combatants.selected.hasBuff(SPELLS.UNDULATION_BUFF.id, event.timestamp, BUFFER_MS, BUFFER_MS);
+
+      if (hasUndulation) {
+        this.healing += event.feed * UNDULATION_HEALING_INCREASE;
+      }
+    } else if (spellId === SPELLS.DOWNPOUR.id) {
+      const hasUndulation = this.combatants.selected.hasBuff(SPELLS.UNDULATION_BUFF.id, event.timestamp, BUFFER_MS, BUFFER_MS);
+
+      if (hasUndulation) {
+        this.healing += event.feed * UNDULATION_HEALING_INCREASE;
+      }
+    }
+  }
+
+  subStatistic() {
+    return (
+      <div className="flex">
+        <div className="flex-main">
+          <SpellLink id={SPELLS.UNDULATION_TALENT.id} />
+        </div>
+        <div className="flex-sub text-right">
+          {formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing))} %
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default Undulation;
+

--- a/src/Parser/Shaman/Restoration/Modules/Talents/UnleashLife.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/UnleashLife.js
@@ -45,7 +45,6 @@ class UnleashLife extends Analyzer {
   buffedRiptideTarget = null;
   buffedChainHealTimestamp = null;
   lastUnleashLifeTimestamp = null;
-  lastUnleashLifeHealTimestamp = null;
   lastUnleashLifeFeedTimestamp = null;
 
   on_initialized() {
@@ -62,10 +61,9 @@ class UnleashLife extends Analyzer {
 
     if(spellId === SPELLS.UNLEASH_LIFE_TALENT.id) {
       this.unleashLifeHealRemaining += 1;
-      this.lastUnleashLifeHealTimestamp = event.timestamp;
     }
 
-    if((this.lastUnleashLifeHealTimestamp + unleashLifeBuffDuration) <= event.timestamp) {
+    if((this.lastUnleashLifeTimestamp + unleashLifeBuffDuration) <= event.timestamp) {
       this.unleashLifeHealRemaining = 0;
     }
 

--- a/src/Parser/Shaman/Restoration/Modules/Talents/UnleashLife.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/UnleashLife.js
@@ -1,0 +1,301 @@
+import React from 'react';
+import { Doughnut as DoughnutChart } from 'react-chartjs-2';
+
+import SpellLink from 'common/SpellLink';
+import SPELLS from 'common/SPELLS';
+import { formatNumber, formatPercentage } from 'common/format';
+
+import StatisticsListBox, { STATISTIC_ORDER } from 'Main/StatisticsListBox';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveHealing from 'Parser/Core/calculateEffectiveHealing';
+
+import CooldownThroughputTracker from '../Features/CooldownThroughputTracker';
+
+const UNLEASH_LIFE_HEALING_INCREASE = 0.45;
+const BUFFER_MS = 300;
+const riptideDuration = 18000;
+
+const CHART_SIZE = 75;
+
+class UnleashLife extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    cooldownThroughputTracker: CooldownThroughputTracker,
+  };
+  healing = 0;
+
+  unleashLifeCasts = 0;
+  unleashLifeRemaining = 0;
+
+  buffedChainHeals = 0;
+  buffedHealingWaves = 0;
+  buffedHealingSurges = 0;
+  buffedRiptides = 0;
+
+  buffedRiptideTimestamp = null;
+  buffedRiptideTarget = null;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.UNLEASH_LIFE_TALENT.id);
+  }
+
+  on_byPlayer_heal(event) {
+    const spellId = event.ability.guid;
+
+    if (event.timestamp  > (this.buffedRiptideTimestamp + riptideDuration)) {
+      this.buffedRiptideTimestamp = null;
+      this.buffedRiptideTarget = null;
+    }
+
+    if (
+      spellId === SPELLS.HEALING_WAVE.id || 
+      spellId === SPELLS.HEALING_SURGE_RESTORATION.id ||
+      spellId === SPELLS.CHAIN_HEAL.id ||
+      (spellId === SPELLS.RIPTIDE.id && !event.tick)
+    ) {
+      const hasUnleashLife = this.combatants.selected.hasBuff(SPELLS.UNLEASH_LIFE_TALENT.id, event.timestamp, BUFFER_MS);
+
+      if (hasUnleashLife) {
+        this.healing += calculateEffectiveHealing(event, UNLEASH_LIFE_HEALING_INCREASE);
+        console.log(event);
+      }
+    } else if (SPELLS.RIPTIDE.id === spellId && event.tick && this.buffedRiptideTarget === event.targetID) {
+      this.healing += calculateEffectiveHealing(event, UNLEASH_LIFE_HEALING_INCREASE);
+    } else if (spellId === SPELLS.UNLEASH_LIFE_TALENT.id) {
+      this.healing += event.amount;
+    }
+  }
+
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+
+    if(spellId === SPELLS.UNLEASH_LIFE_TALENT.id) {
+      this.unleashLifeCasts += 1;
+      this.unleashLifeRemaining += 1;
+    }
+
+    const hasUnleashLife = this.combatants.selected.hasBuff(SPELLS.UNLEASH_LIFE_TALENT.id, event.timestamp, BUFFER_MS);
+
+    if(!hasUnleashLife) {
+      return;
+    }
+
+    if (this.unleashLifeRemaining) {
+      switch(spellId) {
+        case SPELLS.CHAIN_HEAL.id:
+            this.buffedChainHeals += 1;
+            this.unleashLifeRemaining -= 1;
+          break;
+        case SPELLS.HEALING_WAVE.id:
+            this.buffedHealingWaves += 1;
+            this.unleashLifeRemaining -= 1;
+          break;
+        case SPELLS.HEALING_SURGE_RESTORATION.id:
+            this.buffedHealingSurges += 1;
+            this.unleashLifeRemaining -= 1;
+          break;
+        case SPELLS.RIPTIDE.id:
+            this.buffedRiptides += 1;
+            this.unleashLifeRemaining -= 1;
+          break;
+        default:
+          return;
+      }
+    }
+  }
+
+  on_byPlayer_applybuff(event) {
+    const spellId = event.ability.guid;
+
+    if (spellId !== SPELLS.RIPTIDE.id) {
+      return;
+    }
+
+    const hasUnleashLife = this.combatants.selected.hasBuff(SPELLS.UNLEASH_LIFE_TALENT.id, event.timestamp, 0, BUFFER_MS);
+
+    // Saving the buffed riptide target to track the healing done on.
+    if (hasUnleashLife) {
+      this.buffedRiptideTimestamp = event.timestamp;
+      this.buffedRiptideTarget = event.targetID;
+    } else if (event.targetID === this.buffedRiptideTarget) { // if you overwrite the buffed riptide, all value of Unleash Life is lost
+      this.buffedRiptideTimestamp = null;
+      this.buffedRiptideTarget = null;
+    }
+  }
+
+  on_feed_heal(event) {
+    const spellId = event.ability.guid;
+
+    if (
+      spellId === SPELLS.HEALING_WAVE.id || 
+      spellId === SPELLS.HEALING_SURGE_RESTORATION.id ||
+      spellId === SPELLS.CHAIN_HEAL.id ||
+      (spellId === SPELLS.RIPTIDE.id && !event.tick)
+    ) {
+      const hasUnleashLife = this.combatants.selected.hasBuff(SPELLS.UNLEASH_LIFE_TALENT.id, event.timestamp, BUFFER_MS);
+
+      if (hasUnleashLife) {
+        this.healing += event.feed * UNLEASH_LIFE_HEALING_INCREASE;
+      }
+    } else if (SPELLS.RIPTIDE.id === spellId && event.tick && this.buffedRiptideTarget === event.targetID) {
+      this.healing += event.feed * UNLEASH_LIFE_HEALING_INCREASE;
+    }
+  }
+
+
+  legend(items, total) {
+    const numItems = items.length;
+    return items.map(({ color, label, tooltip, value, spellId }, index) => {
+      label = tooltip ? (
+        <dfn data-tip={tooltip}>{label}</dfn>
+      ) : label;
+      label = spellId ? (
+        <SpellLink id={spellId} icon={false}>{label}</SpellLink>
+      ) : label;
+      return (
+        <div
+          className="flex"
+          style={{
+            borderBottom: '3px solid rgba(255,255,255,0.1)',
+            marginBottom: ((numItems - 1) === index) ? 0 : 5,
+          }}
+          key={index}
+        >
+          <div className="flex-sub">
+            <div
+              style={{
+                display: 'inline-block',
+                background: color,
+                borderRadius: '50%',
+                width: 16,
+                height: 16,
+                marginBottom: -3,
+              }}
+            />
+          </div>
+          <div className="flex-main" style={{ paddingLeft: 5 }}>
+            {label}
+          </div>
+          <div className="flex-sub">
+            <dfn data-tip={`${formatPercentage(value / total, 0)}%`}>
+              {value}
+            </dfn>
+          </div>
+        </div>
+      );
+    });
+  }
+  chart(items) {
+    return (
+      <DoughnutChart
+        data={{
+          datasets: [{
+            data: items.map(item => item.value),
+            backgroundColor: items.map(item => item.color),
+            borderColor: '#666',
+            borderWidth: 1.5,
+          }],
+          labels: items.map(item => item.label),
+        }}
+        options={{
+          legend: {
+            display: false,
+          },
+          tooltips: {
+            bodyFontSize: 8,
+          },
+          cutoutPercentage: 45,
+          animation: false,
+          responsive: false,
+        }}
+        width={CHART_SIZE}
+        height={CHART_SIZE}
+      />
+    );
+  }
+
+  unleashLifeCastRatioChart() {
+    const totalUses = this.buffedChainHeals + this.buffedHealingWaves + this.buffedHealingSurges + this.buffedRiptides;
+    const unusedUL = totalUses - this.unleashLifeCasts;
+
+    const items = [
+      {
+        color: '#00B159',
+        label: 'Chain Heal',
+        spellId: SPELLS.CHAIN_HEAL.id,
+        value: this.buffedChainHeals,
+      },
+      {
+        color: '#2055CC',
+        label: 'Healing Wave',
+        spellId: SPELLS.HEALING_WAVE.id,
+        value: this.buffedHealingWaves,
+      },
+      {
+        color: '#42E0FF',
+        label: 'Healing Surge',
+        spellId: SPELLS.HEALING_SURGE_RESTORATION.id,
+        value: this.buffedHealingSurges,
+      },
+      {
+        color: '#D26CD1',
+        label: 'Riptide',
+        spellId: SPELLS.RIPTIDE.id,
+        value: this.buffedRiptides,
+      },
+      {
+        color: '#CC3D20',
+        label: 'Unused Buffs',
+        tooltip: `The amount of Unleash Life buffs you did not use out of the total available. You cast ${this.unleashLifeCasts} Unleash Lifes, of which you used ${totalUses}.`,
+        value: unusedUL,
+      },
+    ];
+
+    return (
+      <div className="flex">
+        <div className="flex-sub" style={{ paddingRight: 12 }}>
+          {this.chart(items)}
+        </div>
+        <div className="flex-main" style={{ fontSize: '80%', paddingTop: 3 }}>
+          {this.legend(items, totalUses)}
+        </div>
+      </div>
+    );
+  }
+
+  statistic() {
+    return (
+      <div className="col-lg-3 col-md-4 col-sm-6 col-xs-12">
+        <div className="row">
+          <StatisticsListBox
+            title={<span><SpellLink id={SPELLS.UNLEASH_LIFE_TALENT.id}/> usage</span>}
+            containerProps={{ className: 'col-xs-12' }}
+          >
+            {this.unleashLifeCastRatioChart()}
+          </StatisticsListBox>
+        </div>
+      </div>
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(40);
+
+  subStatistic() {
+    const feeding = this.cooldownThroughputTracker.getIndirectHealing(SPELLS.UNLEASH_LIFE_TALENT.id);
+    return (
+      <div className="flex">
+        <div className="flex-main">
+          <SpellLink id={SPELLS.UNLEASH_LIFE_TALENT.id} />
+        </div>
+        <div className="flex-sub text-right">
+          {formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing + feeding))} %
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default UnleashLife;
+

--- a/src/Parser/Shaman/Restoration/Modules/Talents/UnleashLife.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/UnleashLife.js
@@ -209,7 +209,7 @@ class UnleashLife extends Analyzer {
           datasets: [{
             data: items.map(item => item.value),
             backgroundColor: items.map(item => item.color),
-            borderColor: '#666',
+            borderColor: '#000000',
             borderWidth: 1.5,
           }],
           labels: items.map(item => item.label),
@@ -237,25 +237,25 @@ class UnleashLife extends Analyzer {
 
     const items = [
       {
-        color: '#023373',
+        color: SPELLS.CHAIN_HEAL.color,
         label: 'Chain Heal',
         spellId: SPELLS.CHAIN_HEAL.id,
         value: this.buffedChainHeals,
       },
       {
-        color: '#2055CC',
+        color: SPELLS.HEALING_WAVE.color,
         label: 'Healing Wave',
         spellId: SPELLS.HEALING_WAVE.id,
         value: this.buffedHealingWaves,
       },
       {
-        color: '#42E0FF',
+        color: SPELLS.HEALING_SURGE_RESTORATION.color,
         label: 'Healing Surge',
         spellId: SPELLS.HEALING_SURGE_RESTORATION.id,
         value: this.buffedHealingSurges,
       },
       {
-        color: '#e9effc',
+        color: SPELLS.RIPTIDE.color,
         label: 'Riptide',
         spellId: SPELLS.RIPTIDE.id,
         value: this.buffedRiptides,
@@ -285,7 +285,7 @@ class UnleashLife extends Analyzer {
       <div className="col-lg-3 col-md-4 col-sm-6 col-xs-12">
         <div className="row">
           <StatisticsListBox
-            title={<span><SpellLink id={SPELLS.UNLEASH_LIFE_TALENT.id}/> usage</span>}
+            title={<span><SpellLink id={SPELLS.UNLEASH_LIFE_TALENT.id} icon={false}/> usage</span>}
             containerProps={{ className: 'col-xs-12' }}
           >
             {this.unleashLifeCastRatioChart()}

--- a/src/Parser/Shaman/Restoration/Modules/Talents/UnleashLife.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/UnleashLife.js
@@ -210,7 +210,7 @@ class UnleashLife extends Analyzer {
             data: items.map(item => item.value),
             backgroundColor: items.map(item => item.color),
             borderColor: '#000000',
-            borderWidth: 1.5,
+            borderWidth: 0,
           }],
           labels: items.map(item => item.label),
         }}
@@ -285,7 +285,7 @@ class UnleashLife extends Analyzer {
       <div className="col-lg-3 col-md-4 col-sm-6 col-xs-12">
         <div className="row">
           <StatisticsListBox
-            title={<span><SpellLink id={SPELLS.UNLEASH_LIFE_TALENT.id} icon={false}/> usage</span>}
+            title={<span><SpellLink id={SPELLS.UNLEASH_LIFE_TALENT.id}/> usage</span>}
             containerProps={{ className: 'col-xs-12' }}
           >
             {this.unleashLifeCastRatioChart()}

--- a/src/Parser/Shaman/Restoration/Modules/Talents/UnleashLife.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/UnleashLife.js
@@ -16,6 +16,7 @@ import CooldownThroughputTracker from '../Features/CooldownThroughputTracker';
 const UNLEASH_LIFE_HEALING_INCREASE = 0.45;
 const BUFFER_MS = 200;
 const riptideDuration = 18000;
+const unleashLifeBuffDuration = 10000;
 
 const CHART_SIZE = 75;
 
@@ -34,6 +35,9 @@ class UnleashLife extends Analyzer {
   unleashLifeRemaining = 0;
   unleashLifeHealRemaining = 0;
   unleashLifeFeedRemaining = 0;
+  lastUnleashLifeTimestamp = null;
+  lastUnleashLifeHealTimestamp = null;
+  lastUnleashLifeFeedTimestamp = null;
 
   buffedChainHeals = 0;
   buffedHealingWaves = 0;
@@ -58,6 +62,12 @@ class UnleashLife extends Analyzer {
 
     if(spellId === SPELLS.UNLEASH_LIFE_TALENT.id) {
       this.unleashLifeHealRemaining += 1;
+      this.lastUnleashLifeHealTimestamp = event.timestamp;
+    }
+
+    if((this.lastUnleashLifeHealTimestamp + unleashLifeBuffDuration) <= event.timestamp) {
+      this.unleashLifeHealRemaining = 0;
+      return;
     }
 
     if (
@@ -85,6 +95,7 @@ class UnleashLife extends Analyzer {
     if(spellId === SPELLS.UNLEASH_LIFE_TALENT.id) {
       this.unleashLifeCasts += 1;
       this.unleashLifeRemaining += 1;
+      this.lastUnleashLifeTimestamp = event.timestamp;
     }
 
     const hasUnleashLife = this.combatants.selected.hasBuff(SPELLS.UNLEASH_LIFE_TALENT.id, event.timestamp, BUFFER_MS, BUFFER_MS);
@@ -94,6 +105,11 @@ class UnleashLife extends Analyzer {
     }
 
     if (this.unleashLifeRemaining) {
+      if((this.lastUnleashLifeTimestamp + unleashLifeBuffDuration) <= event.timestamp) {
+        this.unleashLifeRemaining = 0;
+        return;
+      }
+
       switch(spellId) {
         case SPELLS.CHAIN_HEAL.id:
             this.buffedChainHeals += 1;
@@ -141,6 +157,12 @@ class UnleashLife extends Analyzer {
 
     if(spellId === SPELLS.UNLEASH_LIFE_TALENT.id) {
       this.unleashLifeFeedRemaining += 1;
+      this.lastUnleashLifeFeedTimestamp = event.timestamp;
+    }
+
+    if((this.lastUnleashLifeFeedTimestamp + unleashLifeBuffDuration) <= event.timestamp) {
+      this.unleashLifeFeedRemaining = 0;
+      return;
     }
 
     if (

--- a/src/Parser/Shaman/Restoration/Modules/Talents/UnleashLife.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/UnleashLife.js
@@ -35,9 +35,6 @@ class UnleashLife extends Analyzer {
   unleashLifeRemaining = 0;
   unleashLifeHealRemaining = 0;
   unleashLifeFeedRemaining = 0;
-  lastUnleashLifeTimestamp = null;
-  lastUnleashLifeHealTimestamp = null;
-  lastUnleashLifeFeedTimestamp = null;
 
   buffedChainHeals = 0;
   buffedHealingWaves = 0;
@@ -47,6 +44,9 @@ class UnleashLife extends Analyzer {
   buffedRiptideTimestamp = null;
   buffedRiptideTarget = null;
   buffedChainHealTimestamp = null;
+  lastUnleashLifeTimestamp = null;
+  lastUnleashLifeHealTimestamp = null;
+  lastUnleashLifeFeedTimestamp = null;
 
   on_initialized() {
     this.active = this.combatants.selected.hasTalent(SPELLS.UNLEASH_LIFE_TALENT.id);
@@ -67,7 +67,6 @@ class UnleashLife extends Analyzer {
 
     if((this.lastUnleashLifeHealTimestamp + unleashLifeBuffDuration) <= event.timestamp) {
       this.unleashLifeHealRemaining = 0;
-      return;
     }
 
     if (
@@ -162,7 +161,6 @@ class UnleashLife extends Analyzer {
 
     if((this.lastUnleashLifeFeedTimestamp + unleashLifeBuffDuration) <= event.timestamp) {
       this.unleashLifeFeedRemaining = 0;
-      return;
     }
 
     if (

--- a/src/Parser/Shaman/Restoration/Modules/Talents/Wellspring.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/Wellspring.js
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import SpellLink from 'common/SpellLink';
+import SPELLS from 'common/SPELLS';
+import { formatPercentage } from 'common/format';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import CooldownThroughputTracker from '../Features/CooldownThroughputTracker';
+
+class Wellspring extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    cooldownThroughputTracker: CooldownThroughputTracker,
+  };
+  healing = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.WELLSPRING_TALENT.id);
+  }
+
+  on_byPlayer_heal(event) {
+    const spellId = event.ability.guid;
+
+    if (spellId !== SPELLS.WELLSPRING_HEAL.id) {
+      return;
+    }
+
+    this.healing += event.amount;
+  }
+
+  subStatistic() {
+    const feeding = this.cooldownThroughputTracker.getIndirectHealing(SPELLS.WELLSPRING_HEAL.id);
+    return (
+      <div className="flex">
+        <div className="flex-main">
+          <SpellLink id={SPELLS.WELLSPRING_TALENT.id} />
+        </div>
+        <div className="flex-sub text-right">
+          {formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing + feeding))} %
+        </div>
+      </div>
+    );
+  }
+
+}
+
+export default Wellspring;
+

--- a/src/common/SPELLS/SHAMAN.js
+++ b/src/common/SPELLS/SHAMAN.js
@@ -612,29 +612,33 @@ export default {
     name: 'Chain Heal',
     icon: 'spell_nature_healingwavegreater',
     manaCost: 55000,
-  },
-  HEALING_SURGE_RESTORATION: {
-    id: 8004,
-    name: 'Healing Surge',
-    icon: 'spell_nature_healingway',
-    manaCost: 44000,
+    color: '#023373',
   },
   HEALING_WAVE: {
     id: 77472,
     name: 'Healing Wave',
     icon: 'spell_nature_healingwavelesser',
     manaCost: 19800,
+    color: '#146585',
   },
-  TIDAL_WAVES_BUFF: {
-    id: 53390,
-    name: 'Tidal Waves',
-    icon: 'spell_shaman_tidalwaves',
+  HEALING_SURGE_RESTORATION: {
+    id: 8004,
+    name: 'Healing Surge',
+    icon: 'spell_nature_healingway',
+    manaCost: 44000,
+    color: '#3cb6c3',
   },
   RIPTIDE: {
     id: 61295,
     name: 'Riptide',
     icon: 'spell_nature_riptide',
     manaCost: 17600,
+    color: '#a3dbce',
+  },
+  TIDAL_WAVES_BUFF: {
+    id: 53390,
+    name: 'Tidal Waves',
+    icon: 'spell_shaman_tidalwaves',
   },
   HEALING_RAIN_CAST: {
     id: 73920,

--- a/src/common/SPELLS/SHAMAN.js
+++ b/src/common/SPELLS/SHAMAN.js
@@ -612,7 +612,7 @@ export default {
     name: 'Chain Heal',
     icon: 'spell_nature_healingwavegreater',
     manaCost: 55000,
-    color: '#023373',
+    color: '#203755',
   },
   HEALING_WAVE: {
     id: 77472,
@@ -626,7 +626,7 @@ export default {
     name: 'Healing Surge',
     icon: 'spell_nature_healingway',
     manaCost: 44000,
-    color: '#3cb6c3',
+    color: '#40b3bf',
   },
   RIPTIDE: {
     id: 61295,

--- a/src/common/SPELLS/SHAMAN.js
+++ b/src/common/SPELLS/SHAMAN.js
@@ -841,6 +841,11 @@ export default {
     name: 'Queen Ascendant',
     icon: 'ability_shaman_watershield',
   },
+  UNDULATION_BUFF: {
+    id: 216251,
+    name: 'Undulation',
+    icon: 'spell_nature_healingwavelesser',
+  },
   // Restoration Shaman Set Bonus:
   RAINFALL: { // T21 2pc
     id: 252154,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2842471/38738042-5f482470-3f31-11e8-9a55-87eabc61b976.png)![image](https://user-images.githubusercontent.com/2842471/38738013-5146e71c-3f31-11e8-9339-16ba4540bde2.png)

Added modules for all HPS increasing talents (crashing waves, deluge and echo aren't really possible to value), and a statistics list to display them. The purpose of this is to show the overall HPS impact of each talent. So not only what the talent itself did, but also feeding and synergy / interactions with other spells or talents, the percentage is what you'd lose without the talent, ignoring what you'd gain from the other options.

Since i had to work on Unleash Life already anyway, i also added a module detailing what Spells you used the healing increase on.
![image](https://user-images.githubusercontent.com/2842471/38738066-6fd5a38a-3f31-11e8-9de1-3f00879c2fc3.png)
