### PR TITLE
[Balance Druid] Add early dot refreshes to checklist

### DIFF
--- a/src/Parser/Core/Modules/EarlyDotRefreshes/EarlyDotRefreshesInstants.js
+++ b/src/Parser/Core/Modules/EarlyDotRefreshes/EarlyDotRefreshesInstants.js
@@ -22,8 +22,8 @@ class EarlyDotRefreshesInstants extends EarlyDotRefreshes {
     distanceMoved: DistanceMoved,
   };
 
-  // Returns true if cast was successfully checked, false otherwise.
-  checkIfLastCastWasBad(event) {
+  // Determines whether the last cast should be checked or not.
+  checkLastCast(event) {
     if (!this.lastGCD || !this.lastCast) {
       return false;
     }
@@ -32,8 +32,15 @@ class EarlyDotRefreshesInstants extends EarlyDotRefreshes {
     if (timeSinceCast < this.lastGCD.duration - BUFFER_MS){
       return false;
     }
+    this.isLastCastBad(event);
+    this.lastGCD = null;
+    this.lastCast = null;
+  }
+
+  // Checks the status of the last cast and marks it accordingly.
+  isLastCastBad(event) {
     if (this.lastCastGoodExtension) {
-      return true;
+      return; // Should not be marked as bad.
     }
     const dot = this.dots.find(element => {
       return element.castId === this.lastCast.ability.guid;
@@ -62,7 +69,6 @@ class EarlyDotRefreshesInstants extends EarlyDotRefreshes {
     if (text !== '') {
       this.addBadCast(this.lastCast, text);
     }
-    return true;
   }
 
   movedSinceCast(event) {

--- a/src/Parser/Druid/Balance/Modules/Features/Checklist.js
+++ b/src/Parser/Druid/Balance/Modules/Features/Checklist.js
@@ -25,6 +25,9 @@ import StellarEmpowermentUptime from './StellarEmpowermentUptime';
 import MoonSpells from './MoonSpells';
 import LunarEmpowerment from './LunarEmpowerment';
 import SolarEmpowerment from './SolarEmpowerment';
+import EarlyDotRefreshes from './EarlyDotRefreshes';
+import EarlyDotRefreshesInstants from './EarlyDotRefreshesInstants';
+
 import L90Talents from '../Talents/L90Talents';
 
 import SoulOfTheArchdruid from '../../../Shared/Modules/Items/SoulOfTheArchdruid';
@@ -45,6 +48,9 @@ class Checklist extends CoreChecklist {
     lunarEmpowerment: LunarEmpowerment,
     solarEmpowerment: SolarEmpowerment,
     moonSpells: MoonSpells,
+    earlyDotRefreshes: EarlyDotRefreshes,
+    earlyDotRefreshesInstants: EarlyDotRefreshesInstants,
+
     l90Talents: L90Talents,
 
     soulOfTheArchdruid: SoulOfTheArchdruid,
@@ -78,7 +84,6 @@ class Checklist extends CoreChecklist {
       name: 'Maintain your DoTs on the boss',
       description: 'DoTs are a big part of your damage. You should try to keep as high uptime on them as possible.',
       requirements: () => {
-        const combatant = this.combatants.selected;
         return [
           new Requirement({
             name: <Wrapper><SpellLink id={SPELLS.MOONFIRE_BEAR.id} /> uptime</Wrapper>,
@@ -91,17 +96,37 @@ class Checklist extends CoreChecklist {
           new Requirement({
             name: <Wrapper><SpellLink id={SPELLS.STELLAR_FLARE_TALENT.id}  /> uptime</Wrapper>,
             check: () => this.stellarFlareUptime.suggestionThresholds,
-            when: combatant.hasTalent(SPELLS.STELLAR_FLARE_TALENT.id),
+            when: this.stellarFlareUptime.active,
           }),
           new Requirement({
             name: <Wrapper><SpellLink id={SPELLS.STELLAR_EMPOWERMENT.id}  /> uptime</Wrapper>,
             check: () => this.stellarEmpowermentUptime.suggestionThresholds,
-            when: this.combatants.selected.hasTalent(SPELLS.SOUL_OF_THE_FOREST_TALENT_BALANCE.id) ||
-                    this.combatants.selected.hasFinger(ITEMS.SOUL_OF_THE_ARCHDRUID.id),
+            when: this.stellarEmpowermentUptime.active,
           }),
         ];
       },
     }),
+    new Rule({
+          name: 'Avoid refreshing your DoTs too early',
+          description: 'DoTs do very little direct damage, and you should avoid ever refreshing them with more than 30% duration remaining unless you have nothing else to cast while moving.',
+          requirements: () => {
+            return [
+              new Requirement({
+                name: <Wrapper><SpellLink id={SPELLS.MOONFIRE_BEAR.id} /> good refreshes</Wrapper>,
+                check: () => this.earlyDotRefreshesInstants.suggestionThresholdsMoonfireEfficiency,
+              }),
+              new Requirement({
+                name: <Wrapper><SpellLink id={SPELLS.SUNFIRE.id} /> good refreshes</Wrapper>,
+                check: () => this.earlyDotRefreshesInstants.suggestionThresholdsSunfireEfficiency,
+              }),
+              new Requirement({
+                name: <Wrapper><SpellLink id={SPELLS.STELLAR_FLARE_TALENT.id}  /> good refreshes</Wrapper>,
+                check: () => this.earlyDotRefreshes.suggestionThresholdsStellarFlareEfficiency,
+                when: this.earlyDotRefreshes.active,
+              }),
+            ];
+          },
+        }),
     new Rule({
       name: 'Do not overcap your resources',
       description: <Wrapper>You should try to always avoid overcapping your Astral Power, Moon spell charges, and your solar and lunar empowerments. Sometimes you can not avoid overcapping all of them. In that case, you should prioritize them as they are listed.</Wrapper>,
@@ -132,15 +157,12 @@ class Checklist extends CoreChecklist {
       name: 'Use your cooldowns',
       description: <Wrapper>Your cooldowns are a major contributor to your DPS, and should be used as frequently as possible throughout a fight. A cooldown should be held on to only if a priority DPS phase is coming <em>soon</em>. Holding cooldowns too long will hurt your DPS.</Wrapper>,
       requirements: () => {
-        const combatant = this.combatants.selected;
         return [
           new GenericCastEfficiencyRequirement({
             spell: SPELLS.CELESTIAL_ALIGNMENT,
-            when: !combatant.hasTalent(SPELLS.INCARNATION_CHOSEN_OF_ELUNE_TALENT.id),
           }),
           new GenericCastEfficiencyRequirement({
             spell: SPELLS.INCARNATION_CHOSEN_OF_ELUNE_TALENT,
-            when: combatant.hasTalent(SPELLS.INCARNATION_CHOSEN_OF_ELUNE_TALENT.id),
           }),
         ];
       },
@@ -149,19 +171,15 @@ class Checklist extends CoreChecklist {
       name: 'Use your supportive abilities',
       description: <Wrapper>While you should not aim to cast defensives and externals on cooldown, be aware of them and try to use them whenever effective. Not using them at all indicates you might not be aware of them enough.</Wrapper>,
       requirements: () => {
-        const combatant = this.combatants.selected;
         return [
           new GenericCastEfficiencyRequirement({
             spell: SPELLS.INNERVATE,
-            onlyWithSuggestion: false,
           }),
           new GenericCastEfficiencyRequirement({
             spell: SPELLS.BARKSKIN,
-            onlyWithSuggestion: false,
           }),
           new GenericCastEfficiencyRequirement({
             spell: SPELLS.RENEWAL_TALENT,
-            when: combatant.hasTalent(SPELLS.RENEWAL_TALENT.id),
           }),
         ];
       },

--- a/src/Parser/Druid/Balance/Modules/Features/EarlyDotRefreshes.js
+++ b/src/Parser/Druid/Balance/Modules/Features/EarlyDotRefreshes.js
@@ -15,6 +15,13 @@ const DOTS = [
 class EarlyDotRefreshes extends EarlyDotRefreshesCore {
   dots = DOTS;
 
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.STELLAR_FLARE_TALENT.id);
+    if(this.active) {
+      super.on_initialized();
+    }
+  }
+
   get suggestionThresholdsStellarFlare() {
     return {
       spell: SPELLS.STELLAR_FLARE_TALENT,
@@ -25,7 +32,20 @@ class EarlyDotRefreshes extends EarlyDotRefreshesCore {
         average: 0.1,
         major: 0.2,
       },
-      style: 'percent',
+      style: 'percentage',
+    };
+  }
+
+  get suggestionThresholdsStellarFlareEfficiency() {
+    return {
+      spell: SPELLS.STELLAR_FLARE_TALENT,
+      actual: 1 - this.badCastsPercent(DOTS[0].castId),
+      isLessThan: {
+        minor: 0.95,
+        average: 0.9,
+        major: 0.8,
+      },
+      style: 'percentage',
     };
   }
 

--- a/src/Parser/Druid/Balance/Modules/Features/EarlyDotRefreshesInstants.js
+++ b/src/Parser/Druid/Balance/Modules/Features/EarlyDotRefreshesInstants.js
@@ -82,7 +82,7 @@ class EarlyDotRefreshesInstants extends CoreEarlyDotRefreshesInstants {
         average: 0.1,
         major: 0.2,
       },
-      style: 'percent',
+      style: 'percentage',
     };
   }
 
@@ -96,7 +96,33 @@ class EarlyDotRefreshesInstants extends CoreEarlyDotRefreshesInstants {
         average: 0.1,
         major: 0.2,
       },
-      style: 'percent',
+      style: 'percentage',
+    };
+  }
+
+  get suggestionThresholdsMoonfireEfficiency() {
+    return {
+      spell: SPELLS.MOONFIRE_BEAR,
+      actual: 1 - this.badCastsPercent(DOTS[0].castId),
+      isLessThan: {
+        minor: 0.95,
+        average: 0.9,
+        major: 0.8,
+      },
+      style: 'percentage',
+    };
+  }
+
+  get suggestionThresholdsSunfireEfficiency() {
+    return {
+      spell: SPELLS.SUNFIRE,
+      actual: 1 - this.badCastsPercent(DOTS[1].castId),
+      isLessThan: {
+        minor: 0.95,
+        average: 0.9,
+        major: 0.8,
+      },
+      style: 'percentage',
     };
   }
 

--- a/src/Parser/Druid/Balance/Modules/Features/UnempoweredSolarWrath.js
+++ b/src/Parser/Druid/Balance/Modules/Features/UnempoweredSolarWrath.js
@@ -12,6 +12,10 @@ class UnempoweredSolarWrath extends Analyzer {
 
   badCasts = 0;
 
+  on_initialized() {
+    this.active = !this.combatants.selected.hasTalent(SPELLS.WARRIOR_OF_ELUNE_TALENT.id);
+  }
+
   addBadCast(event){
     this.badCasts += 1;
     event.meta = event.meta || {};


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6773230/38777304-0940a14e-40a6-11e8-8cd0-15697c08d287.png)

Also:
 - Refactored EarlyDotRefreshes slightly.
 - Updated the checklist to the new standard.
 - Disabled bad unempowered Solar Wrath casts when using Warrior of Elune as the talent makes pooling Lunar Empowerments viable.