### PR TITLE
[Protection Warrior] Add tier condition for Berserker Rage suggestion

### DIFF
--- a/src/Parser/Warrior/Protection/Modules/Abilities.js
+++ b/src/Parser/Warrior/Protection/Modules/Abilities.js
@@ -3,6 +3,7 @@ import CoreAbilities from 'Parser/Core/Modules/Abilities';
 
 class Abilities extends CoreAbilities {
   spellbook() {
+    const combatant = this.combatants.selected;
     return [
       {
         spell: SPELLS.DEVASTATE,
@@ -97,7 +98,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 45,
         castEfficiency: {
-          suggestion: true,
+          suggestion: combatant.hasTalent(SPELLS.PROTECTION_WARRIOR_T20_2P_BONUS.id),
         },
       },
       {

--- a/src/common/SPELLS/WARRIOR.js
+++ b/src/common/SPELLS/WARRIOR.js
@@ -404,7 +404,13 @@ export default {
     icon: 'ability_backstab',
   },
   //Relics
-  //Tier Set Bonuses
+  // Protection Tier Sets
+  // T20 2P Set Bonus
+  PROTECTION_WARRIOR_T20_2P_BONUS: {
+    id: 242302,
+    name: 'T20 2P Bonus',
+    icon: 'ability_warrior_defensivestance',
+  },
 
   // Shared:
   BATTLE_CRY: {


### PR DESCRIPTION
Added [tier 20 2P](http://www.wowhead.com/spell=242302/item-warrior-t20-protection-2p-bonus) as a condition for the berserker rage suggestion, so it doesn't suggest it for no reason.