### PR TITLE
[API] special character support?

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -69,7 +69,7 @@ class ApiRequestHandler {
   }
   async fetchFromWcl(cachedWclApiResponse) {
     const query = Object.assign({}, this.req.query, { api_key: this.apiKey });
-    const path = `v1/${this.req.params[0]}?${querystring.stringify(query)}`;
+    const path = `v1/${encodeURI(this.req.params[0])}?${querystring.stringify(query)}`;
     console.log('GET', path);
     try {
       const wclStart = Date.now();


### PR DESCRIPTION
This might already fix the special-character issue that #1525 needs.
Since calling our API from the app doesn't throw the "Corrupted response" error but "Character not found", which might be because our API takes the correctly encoded URL, decodes it and sends that request to WCL ( [Express does it apparently by default](https://github.com/expressjs/express/issues/1479)). But WCL requires the name and real uriencoded, hence the "Character not found" (the same error we get when we try to call the WCL URL manually with special-characters).

Might work, might not work. But it definitely shouldn't break anything since encodeURI doesn't touch alphanumerical values and `/`
So the normal `reports/XXXXXXXXX` endpoint shouldn't call a different URL.