### PR TITLE
[BrM] Damage Type Classification now ignores very small hits

### DIFF
--- a/src/Main/DamageTakenTable.js
+++ b/src/Main/DamageTakenTable.js
@@ -8,6 +8,7 @@ import { formatNumber } from 'common/format';
 export const MITIGATED_NONE = 0;
 export const MITIGATED_MAGICAL = 1;
 export const MITIGATED_PHYSICAL = 2;
+export const MITIGATED_UNKNOWN = 99;
 
 class DamageTakenTable extends React.Component {
   static propTypes = {
@@ -20,6 +21,7 @@ class DamageTakenTable extends React.Component {
     [MITIGATED_NONE]: "None",
     [MITIGATED_MAGICAL]: "Magical",
     [MITIGATED_PHYSICAL]: "Physical",
+    [MITIGATED_UNKNOWN]: "Unknown",
   };
 
 

--- a/src/Parser/Monk/Brewmaster/CHANGELOG.js
+++ b/src/Parser/Monk/Brewmaster/CHANGELOG.js
@@ -9,6 +9,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-04-22'),
+    changes: 'Fixed how the "Damage Taken by Ability" table treats very small hits (notably: Aggramar\'s Sacrifice is now always classified as Physical).',
+    contributors: [emallson],
+  },
+  {
     date: new Date('2018-04-08'),
     changes: 'Updated checklist for brew generation to clarify some common points of confusion.',
     contributors: [emallson],

--- a/src/Parser/Monk/Brewmaster/Modules/Features/DamageTakenTable.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/DamageTakenTable.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
-import DamageTakenTableComponent, { MITIGATED_PHYSICAL, MITIGATED_MAGICAL } from 'Main/DamageTakenTable';
+import DamageTakenTableComponent, { MITIGATED_UNKNOWN, MITIGATED_PHYSICAL, MITIGATED_MAGICAL } from 'Main/DamageTakenTable';
 import Tab from 'Main/Tab';
 import SPELLS from 'common/SPELLS';
 import SPECS from 'common/SPECS';
@@ -9,6 +9,8 @@ import SpellLink from 'common/SpellLink';
 
 import HighTolerance from '../Spells/HighTolerance';
 import DamageTaken from '../Core/DamageTaken';
+
+const MIN_CLASSIFICATION_AMOUNT = 100;
 
 class DamageTakenTable extends Analyzer {
   static dependencies = {
@@ -67,6 +69,9 @@ class DamageTakenTable extends Analyzer {
   }
 
   _classifyMitigation(event) {
+    if(event.absorbed + event.amount <= MIN_CLASSIFICATION_AMOUNT) {
+      return MITIGATED_UNKNOWN;
+    }
     // additive increase of 35%
     const isbActive = this.combatants.selected.hasBuff(SPELLS.IRONSKIN_BREW_BUFF.id);
     // additive increase of 10%


### PR DESCRIPTION
Fixes #1593.

The tl;dr of the problem (almost exclusively with Agg's Sacrifice on Argus) is that for very small hits you could have less-than-physical stagger mitigation just due to the fact that damage is dealt in whole numbers. Because of how Agg's Sacrifice deals damage it frequently hits for ~2 at least once per fight, causing it to be incorrectly classified as magic mitigation.

**Before:** (Agg sac in magic, at the very bottom so I'm not including the whole list)
![screenshot from 2018-04-22 11-26-07](https://user-images.githubusercontent.com/4909458/39096591-fd0cbeba-461f-11e8-8b0a-8d749436fb30.png)

**After:**
![screenshot from 2018-04-22 11-26-16](https://user-images.githubusercontent.com/4909458/39096590-fcfaa2de-461f-11e8-8ba4-50f41dae35b7.png)

