### PR TITLE
[BDK] remove MoB from checklist if not specced

### DIFF
--- a/src/Parser/DeathKnight/Blood/Modules/Features/Checklist.js
+++ b/src/Parser/DeathKnight/Blood/Modules/Features/Checklist.js
@@ -139,6 +139,7 @@ class Checklist extends CoreChecklist {
           }),
           new Requirement({
             name: <React.Fragment><SpellLink id={SPELLS.MARK_OF_BLOOD_TALENT.id}/> Uptime</React.Fragment>,
+            when: this.combatants.selected.hasTalent(SPELLS.MARK_OF_BLOOD_TALENT.id),
             check: () => this.markOfBloodUptime.uptimeSuggestionThresholds,
           }),
           new Requirement({


### PR DESCRIPTION
MoB should only be displayed in the checklist when MoB is actually specced