### PR TITLE
[Blood DK][BfA] updated BS & FB-Modules

### DIFF
--- a/src/Parser/DeathKnight/Blood/CHANGELOG.js
+++ b/src/Parser/DeathKnight/Blood/CHANGELOG.js
@@ -8,6 +8,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-04-30'),
+    changes: <React.Fragment>Added <SpellLink id={SPELLS.FOUL_BULWARK_TALENT.id} />-Module and a more detailed breakdown for <SpellLink id={SPELLS.BONE_SHIELD.id} />.</React.Fragment>,
+    contributors: [joshinator],
+  },
+  {
     date: new Date('2018-04-22'),
     changes: <React.Fragment>Updated relic stat calculations.</React.Fragment>,
     contributors: [Yajinni],

--- a/src/Parser/DeathKnight/Blood/CombatLogParser.js
+++ b/src/Parser/DeathKnight/Blood/CombatLogParser.js
@@ -49,6 +49,8 @@ import Bonebreaker from './Modules/Traits/Bonebreaker';
 import AllConsumingRot from './Modules/Traits/AllConsumingRot';
 import Veinrender from './Modules/Traits/Veinrender';
 import Coagulopathy from './Modules/Traits/Coagulopathy';
+import FoulBulwark from './Modules/Talents/FoulBulwark';
+import BoneShieldStacksBySeconds from './Modules/Features/BoneShieldStacksBySeconds';
 
 
 class CombatLogParser extends CoreCombatLogParser {
@@ -76,6 +78,7 @@ class CombatLogParser extends CoreCombatLogParser {
     marrowrendUsage: MarrowrendUsage,
     souldrinker: Souldrinker,
     boneShield: BoneShield,
+    boneShieldStacksBySecond: BoneShieldStacksBySeconds,
 
     // DOT
     bloodplagueUptime: BloodPlagueUptime,
@@ -91,6 +94,7 @@ class CombatLogParser extends CoreCombatLogParser {
     boneStorm: BoneStorm,
     markOfBloodUptime: MarkOfBloodUptime,
     hemostasis: Hemostasis,
+    foulBulwark: FoulBulwark,
 
     // Traits
     RelicTraits: RelicTraits,

--- a/src/Parser/DeathKnight/Blood/Modules/Features/BoneShieldStacksBySeconds.js
+++ b/src/Parser/DeathKnight/Blood/Modules/Features/BoneShieldStacksBySeconds.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import Analyzer from 'Parser/Core/Analyzer';
 import SPELLS from 'common/SPELLS';
 
@@ -45,7 +44,7 @@ class BoneShieldStacksBySeconds extends Analyzer {
   }
 
   get boneShieldStacksBySeconds() {
-    return this.boneShield
+    return this.boneShield;
   }
 
   

--- a/src/Parser/DeathKnight/Blood/Modules/Features/BoneShieldStacksBySeconds.js
+++ b/src/Parser/DeathKnight/Blood/Modules/Features/BoneShieldStacksBySeconds.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import SPELLS from 'common/SPELLS';
+
+/* 
+  boneShieldStacksBySeconds() returns an array with the amount of stacks with an entry for each second
+*/
+
+class BoneShieldStacksBySeconds extends Analyzer {
+  boneShield = [];
+  boneShieldStacks = [];
+  lastBoneShieldStack = 0;
+
+  handleStacks(event, stack = null) {
+    if (event.type === 'removebuff' || isNaN(event.stack)) { //NaN check if player is dead during on_finish
+      event.stack = 0;
+    }
+    if (event.type === 'applybuff') {
+      event.stack = 1;
+    }
+
+    if (stack) {
+      event.stack = stack;
+    }
+    const second = Math.floor((event.timestamp - this.owner.fight.start_time) / 1000) - 1;
+    //we have multiple BS-events per second, update existing entry if it exists or make a new one
+    const secondExists = this.boneShieldStacks.findIndex(elem => elem.second === second);
+    if (secondExists === -1) {
+      this.boneShieldStacks.push({
+        second: second,
+        stack: event.stack,
+      });
+    } else {
+      this.boneShieldStacks[secondExists] = {
+        second: second,
+        stack: event.stack,
+      };
+    }
+
+    this.boneShield = Array.from({length: Math.ceil(this.owner.fightDuration / 1000)}, (x, i) => 0);
+    this.boneShield.forEach((elem, index) => {
+      this.lastBoneShieldStack = this.boneShieldStacks.find(e => e.second === index) ? this.boneShieldStacks.find(e => e.second === index).stack : this.lastBoneShieldStack;
+      this.boneShield[index] = this.lastBoneShieldStack;
+    });
+  }
+
+  get boneShieldStacksBySeconds() {
+    return this.boneShield
+  }
+
+  
+  on_byPlayer_applybuff(event) {
+    if (event.ability.guid !== SPELLS.BONE_SHIELD.id) {
+      return;
+    }
+    this.handleStacks(event);
+  }
+
+  on_byPlayer_applybuffstack(event) {
+    if (event.ability.guid !== SPELLS.BONE_SHIELD.id) {
+      return;
+    }
+    this.handleStacks(event);
+  }
+
+  on_byPlayer_removebuff(event) {
+    if (event.ability.guid !== SPELLS.BONE_SHIELD.id) {
+      return;
+    }
+    this.handleStacks(event);
+  }
+
+  on_byPlayer_removebuffstack(event) {
+    if (event.ability.guid !== SPELLS.BONE_SHIELD.id) {
+      return;
+    }
+    this.handleStacks(event);
+  }
+
+  on_finished(event) {
+    this.handleStacks(event, this.lastBoneShieldStack);
+  }
+}
+
+export default BoneShieldStacksBySeconds;

--- a/src/Parser/DeathKnight/Blood/Modules/Talents/FoulBulwark.js
+++ b/src/Parser/DeathKnight/Blood/Modules/Talents/FoulBulwark.js
@@ -1,17 +1,18 @@
 import React from 'react';
 import Analyzer from 'Parser/Core/Analyzer';
-import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
-import { formatPercentage, formatDuration } from 'common/format';
 import { STATISTIC_ORDER } from 'Main/StatisticBox';
 import ExpandableStatisticBox from 'Main/ExpandableStatisticBox';
-import BoneShieldStacksBySeconds from './BoneShieldStacksBySeconds';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import { formatPercentage, formatDuration } from 'common/format';
+import BoneShieldStacksBySeconds from '../Features/BoneShieldStacksBySeconds';
 
+const HP_PER_BONE_SHIELD_STACK = 0.01;
 const MAX_BONE_SHIELD_STACKS = 10;
 const MAX_BONE_SHIELD_STACKS_OSSUARY = 15;
-class BoneShield extends Analyzer {
 
+class FoulBulwark extends Analyzer {
   static dependencies = {
     combatants: Combatants,
     boneShieldStacksBySeconds: BoneShieldStacksBySeconds,
@@ -22,49 +23,29 @@ class BoneShield extends Analyzer {
   on_initialized() {
     //just in case blizzard decides to move talents around or add a legendary-ring in BfA
     this.maxStacks = this.combatants.selected.hasTalent(SPELLS.OSSUARY_TALENT.id) ? MAX_BONE_SHIELD_STACKS_OSSUARY : MAX_BONE_SHIELD_STACKS;
-  }
-
-  get uptime() {
-    return this.combatants.selected.getBuffUptime(SPELLS.BONE_SHIELD.id) / this.owner.fightDuration;
+    this.active = this.combatants.selected.hasTalent(SPELLS.FOUL_BULWARK_TALENT.id);
   }
 
   get boneShieldStacks() {
     return this.boneShieldStacksBySeconds.boneShieldStacksBySeconds;
   }
 
-  get uptimeSuggestionThresholds() {
-    return {
-      actual: this.uptime,
-      isLessThan: {
-        minor: 0.95,
-        average: 0.9,
-        major: .8,
-      },
-      style: 'percentage',
-    };
-  }
-
-  suggestions(when) {
-    when(this.uptimeSuggestionThresholds)
-      .addSuggestion((suggest, actual, recommended) => {
-        return suggest('Your Bone Shield uptime can be improved. Try to keep it up at all times.')
-          .icon(SPELLS.BONE_SHIELD.icon)
-          .actual(`${formatPercentage(actual)}% Bone Shield uptime`)
-          .recommended(`>${formatPercentage(recommended)}% is recommended`);
-      });
+  get averageFoulBullwark() {
+    const sum = this.boneShieldStacks.reduce((a, b) => a + b, 0);
+    return formatPercentage(sum * HP_PER_BONE_SHIELD_STACK / this.boneShieldStacks.length);
   }
 
   statistic() {
     return (
       <ExpandableStatisticBox
-        icon={<SpellIcon id={SPELLS.BONE_SHIELD.id} />}
-        value={`${formatPercentage(this.uptime)} %`}
-        label="Bone Shield Uptime"
+        icon={<SpellIcon id={SPELLS.FOUL_BULWARK_TALENT.id} />}
+        value={`${this.averageFoulBullwark}%`}
+        label="average Foul Bulwark buff"
       >
         <table className="table table-condensed">
           <thead>
             <tr>
-              <th>Stacks</th>
+              <th>HP-bonus</th>
               <th>Time (s)</th>
               <th>Time (%)</th>
             </tr>
@@ -72,7 +53,7 @@ class BoneShield extends Analyzer {
           <tbody>
             {Array.from({length: this.maxStacks + 1}, (x, i) => i).map((e, i) =>
               <tr key={i}>
-                <th>{i}</th>
+                <th>{formatPercentage(i * HP_PER_BONE_SHIELD_STACK)}%</th>
                 <td>{formatDuration(this.boneShieldStacks.filter(e => e === i).length)}</td>
                 <td>{formatPercentage(this.boneShieldStacks.filter(e => e === i).length / Math.ceil(this.owner.fightDuration / 1000))}%</td>
               </tr>
@@ -82,7 +63,7 @@ class BoneShield extends Analyzer {
       </ExpandableStatisticBox>
     );
   }
-  statisticOrder = STATISTIC_ORDER.CORE(2);
+  statisticOrder = STATISTIC_ORDER.CORE(3);
 }
 
-export default BoneShield;
+export default FoulBulwark;


### PR DESCRIPTION
The expandable on FB is maybe unnecessary since it relies on the Boneshields stacks.
But I think it's usefull to have it for both, doesn't force the user to check the number in two places.

I'll make a PR to add this on live aswell, just needs some minor changes.

![bs](https://user-images.githubusercontent.com/29842841/39421978-cbbb8b46-4c6b-11e8-8264-2b048e54de06.PNG)
![bs_big](https://user-images.githubusercontent.com/29842841/39421981-cbd88c00-4c6b-11e8-939c-cca0b0d43bac.PNG)
![fb](https://user-images.githubusercontent.com/29842841/39421982-cbf43bf8-4c6b-11e8-9072-5beb5a8328f4.PNG)
