### PR TITLE
[Discipline][BFA Prepatch] Contrition Talent

### DIFF
--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -396,7 +396,7 @@ class StatTracker extends Analyzer {
       case SPECS.SHADOW_PRIEST:
         return 0.2;
       case SPECS.DISCIPLINE_PRIEST:
-        return 0.128;
+        return 0.12;
       case SPECS.RESTORATION_SHAMAN:
         return 0.24;
       case SPECS.ENHANCEMENT_SHAMAN:

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -396,7 +396,7 @@ class StatTracker extends Analyzer {
       case SPECS.SHADOW_PRIEST:
         return 0.2;
       case SPECS.DISCIPLINE_PRIEST:
-        return 0.12;
+        return 0.096;
       case SPECS.RESTORATION_SHAMAN:
         return 0.24;
       case SPECS.ENHANCEMENT_SHAMAN:

--- a/src/Parser/Priest/Discipline/CombatLogParser.js
+++ b/src/Parser/Priest/Discipline/CombatLogParser.js
@@ -52,6 +52,8 @@ import Evangelism from './Modules/Spells/Evangelism';
 import Penance from './Modules/Spells/Penance';
 import TouchOfTheGrave from './Modules/Spells/TouchOfTheGrave';
 import LuminousBarrier from './Modules/Spells/LuminousBarrier';
+import Contrition from './Modules/Spells/Contrition';
+
 
 import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from './Constants';
 
@@ -110,6 +112,7 @@ class CombatLogParser extends CoreCombatLogParser {
     evangelism: Evangelism,
     touchOfTheGrave: TouchOfTheGrave,
     luminousBarrier: LuminousBarrier,
+    contrition: Contrition,
   };
 
   generateResults() {

--- a/src/Parser/Priest/Discipline/Constants.js
+++ b/src/Parser/Priest/Discipline/Constants.js
@@ -10,3 +10,5 @@ export const ABILITIES_AFFECTED_BY_HEALING_INCREASES = [
   // While the following spells don't double dip in healing increases, they gain the same percentual bonus from the transfer
   SPELLS.LEECH.id,
 ];
+
+export const ATONEMENT_COEFFICIENT = 0.4;

--- a/src/Parser/Priest/Discipline/Modules/Spells/Contrition.js
+++ b/src/Parser/Priest/Discipline/Modules/Spells/Contrition.js
@@ -22,7 +22,6 @@ class Contrition extends Analyzer {
 
   healing = 0;
   damagePenalty = 0;
-  player = null;
   penanceBoltEstimation;
 
   on_initialized() {
@@ -48,11 +47,11 @@ class Contrition extends Analyzer {
     this.healing += event.amount;
 
     // Get an estimated amount of damage and healing for a bolt
-    const { damage, healing } = this.penanceBoltEstimation();
+    const { boltDamage, boltHealing } = this.penanceBoltEstimation();
 
     // Calculate the difference between contrition and an offensive penance
     if (event.ability.guid === SPELLS.CONTRITION_HEAL.id) {
-      const overhealing = healing - event.overheal;
+      const overhealing = boltHealing - event.overheal;
       const estimatedDifference = event.amount - (overhealing > 0 ? overhealing : 0);
 
       this.healing -= estimatedDifference;
@@ -60,7 +59,7 @@ class Contrition extends Analyzer {
 
     // Calculate (if applicable), the damage penalty per bolt of friendly penance
     if (event.ability.guid === SPELLS.PENANCE_HEAL.id) {
-      this.damagePenalty += damage;
+      this.damagePenalty += boltDamage;
     }
   }
 

--- a/src/Parser/Priest/Discipline/Modules/Spells/Contrition.js
+++ b/src/Parser/Priest/Discipline/Modules/Spells/Contrition.js
@@ -24,6 +24,14 @@ class Contrition extends Analyzer {
   damagePenalty = 0;
   penanceBoltEstimation;
 
+  static calculateOverhealing(estimateHealing, healing, overhealing = 0) {
+    if (estimateHealing - healing < 0) {
+      return 0;
+    }
+
+    return estimateHealing - healing;
+  }
+
   on_initialized() {
     this.active = this.owner.modules.combatants.selected.hasTalent(
       SPELLS.CONTRITION_TALENT.id
@@ -31,14 +39,6 @@ class Contrition extends Analyzer {
     this.penanceBoltEstimation = OffensivePenanceBoltEstimation(
       this.statTracker
     );
-  }
-
-  calculateOverhealing(estimateHealing, healing, overhealing = 0) {
-    if (estimateHealing - healing < 0) {
-      return 0;
-    }
-
-    return estimateHealing - healing;
   }
 
   /**
@@ -67,7 +67,7 @@ class Contrition extends Analyzer {
     // Calculate the difference between contrition and an offensive penance
     if (event.ability.guid === SPELLS.CONTRITION_HEAL.id) {
       const estimatedBoltHealing = boltHealing * event.hitType;
-      const estimatedOverhealing = this.calculateOverhealing(
+      const estimatedOverhealing = Contrition.calculateOverhealing(
         estimatedBoltHealing,
         event.amount,
         event.overheal

--- a/src/Parser/Priest/Discipline/Modules/Spells/Contrition.js
+++ b/src/Parser/Priest/Discipline/Modules/Spells/Contrition.js
@@ -1,0 +1,87 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+
+import Combatants from 'Parser/Core/Modules/Combatants';
+import StatTracker from 'Parser/Core/Modules/StatTracker';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import { formatPercentage, formatNumber } from 'common/format';
+import Analyzer from 'Parser/Core/Analyzer';
+
+import Penance from '../Spells/Penance';
+import { OffensivePenanceBoltEstimation } from '../../SpellCalculations';
+
+class Contrition extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    statTracker: StatTracker,
+    penance: Penance, // we need this to add `penanceBoltNumber` to the damage and heal events
+  };
+
+  healing = 0;
+  damagePenalty = 0;
+  player = null;
+  penanceBoltEstimation;
+
+  on_initialized() {
+    this.active = this.owner.modules.combatants.selected.hasTalent(SPELLS.CONTRITION_TALENT.id);
+    this.penanceBoltEstimation = OffensivePenanceBoltEstimation(this.statTracker);
+  }
+
+  /**
+   * Theory behind this is as follows
+   * By casting a contrition penance, you lose an offensive penance worth of healing
+   * To hone in on the true value of contrition, we estimate the healing of an offensive
+   * penance hit, and subtract that from the contrition amount.
+   *
+   * We keep the penance heal as that is a true gain from choosing a contrition
+   * penance over a regular offensive one.
+   */
+  on_byPlayer_heal(event) {
+    if (event.ability.guid !== SPELLS.CONTRITION_HEAL.id && event.ability.guid !== SPELLS.PENANCE_HEAL.id) {
+      return;
+    }
+
+    // Add the healing to our count
+    this.healing += event.amount;
+
+    // Get an estimated amount of damage and healing for a bolt
+    const { damage, healing } = this.penanceBoltEstimation();
+
+    // Calculate the difference between contrition and an offensive penance
+    if (event.ability.guid === SPELLS.CONTRITION_HEAL.id) {
+      const overhealing = healing - event.overheal;
+      const estimatedDifference = event.amount - (overhealing > 0 ? overhealing : 0);
+
+      this.healing -= estimatedDifference;
+    }
+
+    // Calculate (if applicable), the damage penalty per bolt of friendly penance
+    if (event.ability.guid === SPELLS.PENANCE_HEAL.id) {
+      this.damagePenalty += damage;
+    }
+  }
+
+  statistic() {
+    const healing = this.healing || 0;
+
+    return(
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.CONTRITION_TALENT.id} />}
+        value={`${formatNumber(healing / this.owner.fightDuration * 1000)} HPS`}
+        label={(
+          <dfn data-tip={
+            `The effective healing contributed by Contrition (${formatPercentage(this.owner.getPercentageOfTotalHealingDone(healing))}% of total healing done). You lost roughly ${formatNumber(this.damagePenalty / this.owner.fightDuration * 1000)} DPS, or ${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.damagePenalty))}% more damage.`
+          }>
+            Contrition healing
+          </dfn>
+        )}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.OPTIONAL();
+}
+
+export default Contrition;

--- a/src/Parser/Priest/Discipline/Modules/Spells/Contrition.test.js
+++ b/src/Parser/Priest/Discipline/Modules/Spells/Contrition.test.js
@@ -1,0 +1,21 @@
+import Contrition from './Contrition';
+
+describe('[Discipline Module] Contrition', () => {
+  it('Calculates overhealing when the estimated amount is greater', () => {
+    const overheal = Contrition.calculateOverhealing(150, 50, 50);
+
+    expect(overheal).toBe(100);
+  });
+
+  it('Calculates overhealing when the estimated amount is less than the effective healing', () => {
+    const overheal = Contrition.calculateOverhealing(20, 50, 50);
+
+    expect(overheal).toBe(0);
+  });
+
+  it('Calculates overhealing when the estimated amount is the same as the original', () => {
+    const overheal = Contrition.calculateOverhealing(100, 50, 50);
+
+    expect(overheal).toBe(50);
+  });
+});

--- a/src/Parser/Priest/Discipline/SpellCalculations.js
+++ b/src/Parser/Priest/Discipline/SpellCalculations.js
@@ -1,0 +1,34 @@
+import SPELLS from 'common/SPELLS';
+import { ATONEMENT_COEFFICIENT } from './Constants';
+
+/*
+ * Wraps a spell calculation to accept the stats module
+ * Essentially lets you compose modules with spell estimations
+ */
+
+const statWrapper = spellCalculation => stats => (...args) => {
+  return spellCalculation(stats, ...args);
+};
+
+// Estimation of how much output an offensive penance bolt will do
+export const OffensivePenanceBoltEstimation = statWrapper(
+  (stats) => {
+    const currentIntellect = stats.currentIntellectRating;
+    const currentVers = 1 + stats.currentVersatilityPercentage;
+    const currentMastery = 1 + stats.currentMasteryPercentage;
+    const penanceCoefficient = SPELLS.PENANCE.coefficient;
+
+    const penanceBoltDamage = Math.round(
+      currentIntellect * penanceCoefficient * currentVers * currentMastery
+    );
+
+    const penanceBoltHealing = Math.round(
+      penanceBoltDamage * ATONEMENT_COEFFICIENT
+    );
+
+    return {
+      damage: penanceBoltDamage,
+      healing: penanceBoltHealing,
+    };
+  }
+);

--- a/src/Parser/Priest/Discipline/SpellCalculations.js
+++ b/src/Parser/Priest/Discipline/SpellCalculations.js
@@ -27,8 +27,8 @@ export const OffensivePenanceBoltEstimation = statWrapper(
     );
 
     return {
-      damage: penanceBoltDamage,
-      healing: penanceBoltHealing,
+      boltDamage: penanceBoltDamage,
+      boltHealing: penanceBoltHealing,
     };
   }
 );

--- a/src/Parser/Priest/Discipline/SpellCalculations.test.js
+++ b/src/Parser/Priest/Discipline/SpellCalculations.test.js
@@ -1,0 +1,46 @@
+import { OffensivePenanceBoltEstimation } from './SpellCalculations';
+
+const mockStatTracker = (intellect = 100, vers = 0, mastery = 0) => ({
+  currentIntellectRating: intellect,
+  currentVersatilityPercentage: vers,
+  currentMasteryPercentage: mastery,
+});
+
+describe('Spell Calculations', () => {
+  it('Estimates Offensive Penance Bolts Correctly', () => {
+    const boltEstimator = OffensivePenanceBoltEstimation(mockStatTracker());
+
+    expect(boltEstimator()).toEqual({
+      damage: 40,
+      healing: 16,
+    });
+  });
+
+  it('Estimates Offensive Penance Bolts Correctly with Versatility', () => {
+    const boltEstimator = OffensivePenanceBoltEstimation(mockStatTracker(100, .25));
+
+    expect(boltEstimator()).toEqual({
+      damage: 50,
+      healing: 20,
+    });
+  });
+
+  it('Estimates Offensive Penance Bolts Correctly with Mastery', () => {
+    const boltEstimator = OffensivePenanceBoltEstimation(mockStatTracker(100, 0, .25));
+
+    expect(boltEstimator()).toEqual({
+      damage: 50,
+      healing: 20,
+    });
+  });
+
+  it('Estimates Offensive Penance Bolts Correctly with Versatility and Mastery', () => {
+    const boltEstimator = OffensivePenanceBoltEstimation(mockStatTracker(100, .25, .25));
+
+    expect(boltEstimator()).toEqual({
+      damage: 63,
+      healing: 25,
+    });
+  });
+
+});

--- a/src/Parser/Priest/Discipline/SpellCalculations.test.js
+++ b/src/Parser/Priest/Discipline/SpellCalculations.test.js
@@ -11,8 +11,8 @@ describe('Spell Calculations', () => {
     const boltEstimator = OffensivePenanceBoltEstimation(mockStatTracker());
 
     expect(boltEstimator()).toEqual({
-      damage: 40,
-      healing: 16,
+      boltDamage: 40,
+      boltHealing: 16,
     });
   });
 
@@ -20,8 +20,8 @@ describe('Spell Calculations', () => {
     const boltEstimator = OffensivePenanceBoltEstimation(mockStatTracker(100, .25));
 
     expect(boltEstimator()).toEqual({
-      damage: 50,
-      healing: 20,
+      boltDamage: 50,
+      boltHealing: 20,
     });
   });
 
@@ -29,8 +29,8 @@ describe('Spell Calculations', () => {
     const boltEstimator = OffensivePenanceBoltEstimation(mockStatTracker(100, 0, .25));
 
     expect(boltEstimator()).toEqual({
-      damage: 50,
-      healing: 20,
+      boltDamage: 50,
+      boltHealing: 20,
     });
   });
 
@@ -38,8 +38,8 @@ describe('Spell Calculations', () => {
     const boltEstimator = OffensivePenanceBoltEstimation(mockStatTracker(100, .25, .25));
 
     expect(boltEstimator()).toEqual({
-      damage: 63,
-      healing: 25,
+      boltDamage: 63,
+      boltHealing: 25,
     });
   });
 

--- a/src/common/SPELLS/PRIEST.js
+++ b/src/common/SPELLS/PRIEST.js
@@ -11,6 +11,7 @@ export default {
     name: 'Penance',
     icon: 'spell_holy_penance',
     manaCost: 30800,
+    coefficient: 0.4,
   },
   PENANCE_HEAL: { // Penance on a friendly player
     id: 47750,
@@ -154,6 +155,11 @@ export default {
     id: 120692,
     name: 'Halo',
     icon: 'ability_priest_halo',
+  },
+  CONTRITION_HEAL: {
+    id: 270501,
+    name: 'Contrition',
+    icon: 'ability_priest_savinggrace',
   },
   DISC_PRIEST_T19_2SET_BONUS_BUFF: {
     id: 211556,

--- a/src/common/SPELLS/TALENTS/PRIEST.js
+++ b/src/common/SPELLS/TALENTS/PRIEST.js
@@ -55,7 +55,7 @@ export default {
   CIRCLE_OF_HEALING_TALENT: { id: 204883, name: "Circle of Healing", icon: "spell_holy_circleofrenewal", manaCost: 33000 },
   // Discipline
   SCHISM_TALENT: { id: 214621, name: "Schism", icon: "spell_warlock_focusshadow", manaCost: 27500 },
-  SANCTUARY_TALENT: { id: 246393, name: "Sanctuary", icon: "spell_holy_holysmite" },
+  CONTRITION_TALENT: { id: 197419, name: "Contrition", icon: "ability_priest_savinggrace"},
   PURGE_THE_WICKED_TALENT: { id: 204197, name: "Purge the Wicked", icon: "ability_mage_firestarter", manaCost: 22000 },
   EVANGELISM_TALENT: { id: 246287, name: "Evangelism", icon: "spell_holy_divineillumination" },
 };


### PR DESCRIPTION
Relevant Issue: https://github.com/WoWAnalyzer/WoWAnalyzer/issues/1662

---

**Description**
The Contrition talent is a new addition in Battle for Azeroth. The talent causes each Penance bolt that directly heals a friendly player to heal each player with Atonement for 20% spellpower. Beyond displaying the basic healing breakdown, which is quite misleading, it would be more valuable to display the real increase, as the heal incurs a large opportunity cost.


