### PR TITLE
[BfA][Windwalker] Further updating Blackout Kick module and SPELLS.MONK

### DIFF
--- a/src/Parser/Monk/Windwalker/Modules/Features/Checklist.js
+++ b/src/Parser/Monk/Windwalker/Modules/Features/Checklist.js
@@ -141,7 +141,7 @@ class Checklist extends CoreChecklist {
             check: () => this.chiDetails.suggestionThresholds,
           }),
           new Requirement({
-            name: <React.Fragment>Bad <SpellLink id={SPELLS.BLACKOUT_KICK.id} /> casts per minute</React.Fragment>,
+            name: <React.Fragment>Wasted cooldown reduction from <SpellLink id={SPELLS.BLACKOUT_KICK.id} /> per minute</React.Fragment>,
             check: () => this.blackoutKick.suggestionThresholds,
           }),
           new Requirement({

--- a/src/Parser/Monk/Windwalker/Modules/Spells/BlackoutKick.js
+++ b/src/Parser/Monk/Windwalker/Modules/Spells/BlackoutKick.js
@@ -131,7 +131,7 @@ class BlackoutKick extends Analyzer {
         />
       );
   }
-  STATISTIC_ORDER = STATISTIC_ORDER.CORE(5);
+  statisticOrder = STATISTIC_ORDER.CORE(5);
 }
 
 export default BlackoutKick;

--- a/src/Parser/Monk/Windwalker/Modules/Spells/BlackoutKick.js
+++ b/src/Parser/Monk/Windwalker/Modules/Spells/BlackoutKick.js
@@ -29,7 +29,6 @@ class BlackoutKick extends Analyzer {
   ];
 
   on_initialized() {
-    console.log("Ranks in artifact ability: " + this.combatants.selected.traitsBySpellId[SPELLS.STRIKE_OF_THE_WINDLORD.id]);
     if (this.combatants.selected.traitsBySpellId[SPELLS.STRIKE_OF_THE_WINDLORD.id] === 1) {
       this.IMPORTANT_SPELLS.push(SPELLS.STRIKE_OF_THE_WINDLORD.id);
     }

--- a/src/Parser/Monk/Windwalker/Modules/Spells/BlackoutKick.js
+++ b/src/Parser/Monk/Windwalker/Modules/Spells/BlackoutKick.js
@@ -116,6 +116,7 @@ class BlackoutKick extends Analyzer {
               }}
             />
             {' '}
+            <br></br>
             {(this.effectiveFistsOfFuryReductionMs / 1000).toFixed(1)}s{' '}
             <SpellIcon
               id={SPELLS.FISTS_OF_FURY_CAST.id}

--- a/src/common/SPELLS/MONK.js
+++ b/src/common/SPELLS/MONK.js
@@ -714,6 +714,16 @@ export default {
     name: 'Chi Orbit',
     icon: 'ability_monk_forcesphere',
   },
+  FIST_OF_THE_WHITE_TIGER_ENERGIZE: {
+    id: 261978,
+    name: 'Fist of the White Tiger',
+    icon: 'ability_monk_jab',
+  },
+  CHI_BURST_ENERGIZE: {
+    id: 261682,
+    name: 'Chi Burst',
+    icon: 'spell_arcane_arcanetorrent',
+  },
   // Windwalker legendaries
   KATSUOS_ECLIPSE: {
     id: 208045,


### PR DESCRIPTION
Adding some energize ID's from talents to prevent crashing when loading chi tab. 

Blackout Kick module will have more work done before 8.0 goes live. Right now the statistic box is just a copy from Crusaders Might 

![image](https://user-images.githubusercontent.com/30317641/39695211-1c24b55c-51ea-11e8-98c5-0a2c09104958.png)
