### PR TITLE
Allow highlighting spellcasts in Timeline to indicate a buffed or enhanced cast

### DIFF
--- a/src/Main/Timeline/Events.js
+++ b/src/Main/Timeline/Events.js
@@ -49,7 +49,7 @@ class Events extends React.PureComponent {
       fixedEvents.push({
         ...beginCooldownEvent,
         trigger: 'endcooldown',
-        timestamp : beginCooldownEvent.start + beginCooldownEvent.expectedDuration,
+        timestamp: beginCooldownEvent.start + beginCooldownEvent.expectedDuration,
         end: beginCooldownEvent.start + beginCooldownEvent.expectedDuration,
       });
     });
@@ -60,12 +60,17 @@ class Events extends React.PureComponent {
   render() {
     const { events, buffEvents, start, totalWidth, secondWidth, className, showCooldowns } = this.props;
     const fixedEvents = this.fabricateEndCooldown(events);
-
     return (
       <div className={`events ${className || ''}`} style={{ width: totalWidth }}>
         {fixedEvents.map((event, index) => {
           const meta = event.meta || {};
           if (event.type === 'cast') {
+            let className;
+            if (meta.isInefficientCast) {
+              className = 'inefficient';
+            } else if (meta.isEnhancedCast) {
+              className = 'enhanced';
+            }
             const top = buffEvents ? 1 : -1;
             const height = 22; // only used if buffEvents
             return (
@@ -79,9 +84,9 @@ class Events extends React.PureComponent {
               >
                 <SpellIcon
                   id={event.ability.guid}
-                  className={meta.isInefficientCast ? 'inefficient' : undefined}
+                  className={className}
                   data-tip={meta.inefficientCastReason}
-                  style={buffEvents ? {height} : {}}
+                  style={buffEvents ? { height } : {}}
                 />
               </div>
             );
@@ -142,10 +147,10 @@ class Events extends React.PureComponent {
                   left,
                   width,
                   height: 3,
-                  background: `${event.type === 'changebuffstack' ? buffColor : debuffColor }`,
+                  background: `${event.type === 'changebuffstack' ? buffColor : debuffColor}`,
                   zIndex: 9,
                 }}
-                data-tip={`${event.ability.name} - ${event.type === 'changebuffstack' ? 'Buff' : 'Debuff' } Duration: ${((event.timestamp - event.start) / 1000).toFixed(1)}s`} 
+                data-tip={`${event.ability.name} - ${event.type === 'changebuffstack' ? 'Buff' : 'Debuff'} Duration: ${((event.timestamp - event.start) / 1000).toFixed(1)}s`}
               />
             );
           }

--- a/src/Main/Timeline/Events.js
+++ b/src/Main/Timeline/Events.js
@@ -65,11 +65,15 @@ class Events extends React.PureComponent {
         {fixedEvents.map((event, index) => {
           const meta = event.meta || {};
           if (event.type === 'cast') {
-            let className;
+            
+            let castClassName;
+            let castReason;
             if (meta.isInefficientCast) {
-              className = 'inefficient';
+              castClassName = 'inefficient';
+              castReason = meta.inefficientCastReason;
             } else if (meta.isEnhancedCast) {
-              className = 'enhanced';
+              castClassName = 'enhanced';
+              castReason = meta.enhancedCastReason;
             }
             const top = buffEvents ? 1 : -1;
             const height = 22; // only used if buffEvents
@@ -84,8 +88,8 @@ class Events extends React.PureComponent {
               >
                 <SpellIcon
                   id={event.ability.guid}
-                  className={className}
-                  data-tip={meta.inefficientCastReason}
+                  className={castClassName}
+                  data-tip={castReason}
                   style={buffEvents ? { height } : {}}
                 />
               </div>

--- a/src/Main/Timeline/SpellTimeline.css
+++ b/src/Main/Timeline/SpellTimeline.css
@@ -87,11 +87,11 @@
 }
 
 .spell-timeline .events .enhanced {
-  border: 2px solid rgb(240, 240, 240);
+  border: 2px solid rgb(226, 226, 226);
   box-sizing: content-box;
   margin-left: -1px;
   margin-top: -1px;
-  box-shadow: 0 0 11px rgb(255, 255, 255);
+  box-shadow: 0 0 11px rgb(173, 173, 173);
   border-radius: 2px;
 }
 .spell-timeline .death, .spell-timeline .resurrection {

--- a/src/Main/Timeline/SpellTimeline.css
+++ b/src/Main/Timeline/SpellTimeline.css
@@ -85,6 +85,15 @@
   box-shadow: 0 0 11px red;
   border-radius: 2px;
 }
+
+.spell-timeline .events .enhanced {
+  border: 2px solid rgb(240, 240, 240);
+  box-sizing: content-box;
+  margin-left: -1px;
+  margin-top: -1px;
+  box-shadow: 0 0 11px rgb(255, 255, 255);
+  border-radius: 2px;
+}
 .spell-timeline .death, .spell-timeline .resurrection {
   position: absolute;
   top: 0;

--- a/src/Parser/Monk/Windwalker/CHANGELOG.js
+++ b/src/Parser/Monk/Windwalker/CHANGELOG.js
@@ -8,6 +8,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-05-10'),
+    changes: <React.Fragment>Added highlighting Combo Breaker casts of <SpellLink id={SPELLS.BLACKOUT_KICK.id} /> in Spellcast Timeline</React.Fragment>,
+    contributors: [Coryn],
+  },
+  {
     date: new Date('2018-03-15'),
     changes: <React.Fragment>Added module tracking bad casts of <SpellLink id={SPELLS.BLACKOUT_KICK.id} /> </React.Fragment>,
     contributors: [Juko8],

--- a/src/Parser/Monk/Windwalker/Modules/Spells/BlackoutKick.js
+++ b/src/Parser/Monk/Windwalker/Modules/Spells/BlackoutKick.js
@@ -39,7 +39,7 @@ class BlackoutKick extends Analyzer {
     if (combatant.hasBuff(SPELLS.COMBO_BREAKER_BUFF.id) && combatant.hasBuff(SPELLS.WW_TIER21_2PC.id)) {
       event.meta = event.meta || {};
       event.meta.isEnhancedCast = true;
-      event.meta.inefficientCastReason = 'You had Combo Breaker Buff up for this Blackout Kick';
+      event.meta.enhancedCastReason = 'You had Combo Breaker and T21-2pc for this Blackout Kick';
       return;
     }
     

--- a/src/Parser/Monk/Windwalker/Modules/Spells/BlackoutKick.js
+++ b/src/Parser/Monk/Windwalker/Modules/Spells/BlackoutKick.js
@@ -37,6 +37,9 @@ class BlackoutKick extends Analyzer {
     const combatant = this.combatants.selected;
     // Blackout Kick sometimes take priority if you're using T21
     if (combatant.hasBuff(SPELLS.COMBO_BREAKER_BUFF.id) && combatant.hasBuff(SPELLS.WW_TIER21_2PC.id)) {
+      event.meta = event.meta || {};
+      event.meta.isEnhancedCast = true;
+      event.meta.inefficientCastReason = 'You had Combo Breaker Buff up for this Blackout Kick';
       return;
     }
     


### PR DESCRIPTION
Implemented specifically for Blackout Kick for Windwalker monk when having the Combo Breaker proc up and T21 2-piece equipped.

Implemented the generic "isEnhancedCast" and "enhancedCastReason" fields to the Spelltimeline event definition so other classes can make use of it too.

Added CSS rule for .enhanced cast in spell timeline.

![image](https://user-images.githubusercontent.com/1769510/39881914-30263458-547a-11e8-89f3-655b3fcfa0c0.png)
