### PR TITLE
[Discipline][BFA Prepatch] Mastery: Reverence

### DIFF
--- a/src/Parser/Priest/Discipline/CombatLogParser.js
+++ b/src/Parser/Priest/Discipline/CombatLogParser.js
@@ -53,7 +53,7 @@ import Penance from './Modules/Spells/Penance';
 import TouchOfTheGrave from './Modules/Spells/TouchOfTheGrave';
 import LuminousBarrier from './Modules/Spells/LuminousBarrier';
 import Contrition from './Modules/Spells/Contrition';
-
+import Reverence from './Modules/Spells/Reverence';
 
 import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from './Constants';
 
@@ -113,6 +113,7 @@ class CombatLogParser extends CoreCombatLogParser {
     touchOfTheGrave: TouchOfTheGrave,
     luminousBarrier: LuminousBarrier,
     contrition: Contrition,
+    reverence: Reverence,
   };
 
   generateResults() {

--- a/src/Parser/Priest/Discipline/Modules/Spells/Reverence.js
+++ b/src/Parser/Priest/Discipline/Modules/Spells/Reverence.js
@@ -65,32 +65,34 @@ class Reverence extends Analyzer {
   }
 
   statistic() {
+    const reverenceHealingPerc = this.owner.getPercentageOfTotalHealingDone(
+      this.reverenceHealing
+    );
+    const baseHealingPerc = this.owner.getPercentageOfTotalHealingDone(
+      this.baseHealing
+    );
+    const healingWithoutMastery = baseHealingPerc / (1 - reverenceHealingPerc);
+
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.REVERENCE.id} />}
         value={`${formatNumber(
           this.reverenceHealing / this.owner.fightDuration * 1000
         )} HPS`}
-        label={
-          <dfn
-            data-tip={`
+        label="Mastery Healing"
+        tooltip={`
             Reverence contributed towards ${formatPercentage(
-              this.owner.getPercentageOfTotalHealingDone(this.reverenceHealing)
-            )}% of your healing.
-
+              reverenceHealingPerc
+            )}% of your healing. \n
 
             ${formatPercentage(
-              this.owner.getPercentageOfTotalHealingDone(this.baseHealing)
+              healingWithoutMastery
             )}% of your healing benefitted from Reverence.
             `}
-          >
-            Mastery Healing
-          </dfn>
-        }
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL();
+  statisticOrder = STATISTIC_ORDER.CORE();
 }
 
 export default Reverence;

--- a/src/Parser/Priest/Discipline/Modules/Spells/Reverence.js
+++ b/src/Parser/Priest/Discipline/Modules/Spells/Reverence.js
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import StatTracker from 'Parser/Core/Modules/StatTracker';
+import Analyzer from 'Parser/Core/Analyzer';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import { formatNumber, formatPercentage } from 'common/format';
+
+import calculateEffectiveHealing from 'Parser/Core/calculateEffectiveHealing';
+import PRIEST_SPELLS from 'common/SPELLS/PRIEST';
+import PRIEST_TALENTS from 'common/SPELLS/TALENTS/PRIEST';
+
+// Use the priest spell list to whitelist abilities
+const PRIEST_WHITELIST = Object.entries({
+  ...PRIEST_SPELLS,
+  ...PRIEST_TALENTS,
+}).map(ability => ability[1].id);
+
+class Reverence extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    statTracker: StatTracker,
+  };
+
+  healing = 0;
+
+  on_byPlayer_heal(event) {
+    // Check if the heal is whitelisted
+    if (!PRIEST_WHITELIST.includes(event.ability.guid)) {
+      return;
+    }
+
+    // Get the target
+    const target = this.combatants.getEntity(event);
+
+    // Mastery only buffs players benefitting from Atonement
+    if (!target.hasBuff(SPELLS.ATONEMENT_BUFF.id)) {
+      return;
+    }
+
+    // Get our mastery level at the moment, this is required for temporary buffs
+    const currentMastery = this.statTracker.currentMasteryPercentage;
+    const masteryContribution = calculateEffectiveHealing(
+      event,
+      currentMastery
+    );
+
+    this.healing += masteryContribution;
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.REVERENCE.id} />}
+        value={`${formatNumber(
+          this.healing / this.owner.fightDuration * 1000
+        )} HPS`}
+        label={
+          <dfn
+            data-tip={`Reverence contributed towards ${formatPercentage(
+              this.owner.getPercentageOfTotalHealingDone(this.healing)
+            )}% of your healing.`}
+          >
+            Mastery Healing
+          </dfn>
+        }
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.OPTIONAL();
+}
+
+export default Reverence;

--- a/src/Parser/Priest/Discipline/Modules/Spells/Reverence.js
+++ b/src/Parser/Priest/Discipline/Modules/Spells/Reverence.js
@@ -24,22 +24,10 @@ class Reverence extends Analyzer {
     statTracker: StatTracker,
   };
 
-  healing = 0;
+  reverenceHealing = 0;
+  baseHealing = 0; // Healing that mastery stemmed from
 
-  on_byPlayer_heal(event) {
-    // Check if the heal is whitelisted
-    if (!PRIEST_WHITELIST.includes(event.ability.guid)) {
-      return;
-    }
-
-    // Get the target
-    const target = this.combatants.getEntity(event);
-
-    // Mastery only buffs players benefitting from Atonement
-    if (!target.hasBuff(SPELLS.ATONEMENT_BUFF.id)) {
-      return;
-    }
-
+  getReverenceHealing(event) {
     // Get our mastery level at the moment, this is required for temporary buffs
     const currentMastery = this.statTracker.currentMasteryPercentage;
     const masteryContribution = calculateEffectiveHealing(
@@ -47,7 +35,31 @@ class Reverence extends Analyzer {
       currentMastery
     );
 
-    this.healing += masteryContribution;
+    return masteryContribution;
+  }
+
+  on_byPlayer_heal(event) {
+    // Check if the heal is whitelisted
+    if (!PRIEST_WHITELIST.includes(event.ability.guid)) {
+      return 0;
+    }
+
+    // Get the target
+    const target = this.combatants.getEntity(event);
+
+    // Mastery only buffs players benefitting from Atonement
+    if (!target.hasBuff(SPELLS.ATONEMENT_BUFF.id)) {
+      return 0;
+    }
+
+    // Calculate healing
+    const reverenceHealing = this.getReverenceHealing(event);
+
+    // Account for base healing without mastery (??? JD ???)
+    const baseHealing = event.amount - reverenceHealing;
+
+    this.baseHealing += baseHealing;
+    this.reverenceHealing += reverenceHealing;
   }
 
   statistic() {
@@ -55,13 +67,19 @@ class Reverence extends Analyzer {
       <StatisticBox
         icon={<SpellIcon id={SPELLS.REVERENCE.id} />}
         value={`${formatNumber(
-          this.healing / this.owner.fightDuration * 1000
+          this.reverenceHealing / this.owner.fightDuration * 1000
         )} HPS`}
         label={
           <dfn
-            data-tip={`Reverence contributed towards ${formatPercentage(
-              this.owner.getPercentageOfTotalHealingDone(this.healing)
-            )}% of your healing.`}
+            data-tip={`
+            Reverence contributed towards ${formatPercentage(
+              this.owner.getPercentageOfTotalHealingDone(this.reverenceHealing)
+            )}% of your healing.
+
+            ${formatPercentage(
+              this.owner.getPercentageOfTotalHealingDone(this.baseHealing)
+            )}% of your healing benefitted from Reverence.
+            `}
           >
             Mastery Healing
           </dfn>

--- a/src/Parser/Priest/Discipline/Modules/Spells/Reverence.js
+++ b/src/Parser/Priest/Discipline/Modules/Spells/Reverence.js
@@ -41,15 +41,17 @@ class Reverence extends Analyzer {
   on_byPlayer_heal(event) {
     // Check if the heal is whitelisted
     if (!PRIEST_WHITELIST.includes(event.ability.guid)) {
-      return 0;
+      return;
     }
 
     // Get the target
     const target = this.combatants.getEntity(event);
 
+    if (!target) return;
+
     // Mastery only buffs players benefitting from Atonement
     if (!target.hasBuff(SPELLS.ATONEMENT_BUFF.id)) {
-      return 0;
+      return;
     }
 
     // Calculate healing
@@ -75,6 +77,7 @@ class Reverence extends Analyzer {
             Reverence contributed towards ${formatPercentage(
               this.owner.getPercentageOfTotalHealingDone(this.reverenceHealing)
             )}% of your healing.
+
 
             ${formatPercentage(
               this.owner.getPercentageOfTotalHealingDone(this.baseHealing)

--- a/src/Parser/Priest/Discipline/Modules/Spells/Reverence.js
+++ b/src/Parser/Priest/Discipline/Modules/Spells/Reverence.js
@@ -92,7 +92,7 @@ class Reverence extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.CORE();
+  statisticOrder = STATISTIC_ORDER.CORE(3);
 }
 
 export default Reverence;

--- a/src/common/SPELLS/PRIEST.js
+++ b/src/common/SPELLS/PRIEST.js
@@ -6,6 +6,11 @@
 
 export default {
   // Discipline Priest:
+  REVERENCE: {
+    id: 271534,
+    name: 'Mastery: Reverence',
+    icon: 'spell_priest_chakra',
+  },
   PENANCE: {
     id: 47666,
     name: 'Penance',
@@ -13,7 +18,8 @@ export default {
     manaCost: 30800,
     coefficient: 0.4,
   },
-  PENANCE_HEAL: { // Penance on a friendly player
+  PENANCE_HEAL: {
+    // Penance on a friendly player
     id: 47750,
     name: 'Penance',
     icon: 'spell_holy_penance',
@@ -78,7 +84,7 @@ export default {
   },
   LIGHTS_WRATH: {
     id: 207946,
-    name: 'Light\'s Wrath',
+    name: "Light's Wrath",
     icon: 'inv_staff_2h_artifacttome_d_01',
   },
   MIND_CONTROL: {
@@ -203,7 +209,7 @@ export default {
   },
   KAM_XIRAFF_BUFF: {
     id: 233997,
-    name: 'Kam Xi\'raff',
+    name: "Kam Xi'raff",
     icon: 'ability_priest_savinggrace',
   },
   TWIST_OF_FATE_BUFF: {
@@ -218,7 +224,7 @@ export default {
   },
   ESTEL_DEJAHNAS_INSPIRATION_BUFF: {
     id: 214637,
-    name: 'Dejahna\'s Inspiration',
+    name: "Dejahna's Inspiration",
     icon: 'spell_holy_heal',
   },
   LUMINOUS_BARRIER: {
@@ -347,7 +353,7 @@ export default {
   // Trait related spells
   LIGHT_OF_TUURE_TRAIT: {
     id: 208065,
-    name: 'Light of T\'uure',
+    name: "Light of T'uure",
     icon: 'inv_staff_2h_artifactheartofkure_d_01',
     duration: 10,
   },
@@ -399,7 +405,7 @@ export default {
   // Buffs
   BLESSING_OF_TUURE_BUFF: {
     id: 196644,
-    name: 'Blessing of T\'uure',
+    name: "Blessing of T'uure",
     icon: 'inv_pet_naaru',
   },
 
@@ -418,7 +424,7 @@ export default {
   // Holy Legendaries
   XANSHI_CLOAK_BUFF: {
     id: 211336,
-    name: 'Xan\'shi, Shroud of Archbishop Benedictus',
+    name: "Xan'shi, Shroud of Archbishop Benedictus",
     icon: 'inv_enchant_essencemagiclarge',
   },
 
@@ -608,14 +614,14 @@ export default {
 
   HEART_OF_THE_VOID_HEAL: {
     id: 248219,
-    name: "Heart of the Void",
+    name: 'Heart of the Void',
     icon: 'spell_priest_void-blast',
   },
 
   THE_TWINS_PAINFUL_TOUCH: {
     id: 207724,
     name: "The Twins' Painful Touch",
-    icon: "spell_shadow_mindflay",
+    icon: 'spell_shadow_mindflay',
   },
 
   SHADOW_PRIEST_T21_2SET_BONUS_PASSIVE: {


### PR DESCRIPTION
**Relevant Issue:** https://github.com/WoWAnalyzer/WoWAnalyzer/issues/1661

---

**Description:**
Mastery: Reverence is the new mastery for Discipline Priests in Battle for Azeroth. Instead of directly increasing the amount of healing Atonement does, it increases healing done to targets with Atonement.

The passive is currently tuned at 1.2% per point of mastery.