### PR TITLE
[Protection Warrior] some stuff

### DIFF
--- a/src/Parser/Warrior/Protection/CHANGELOG.js
+++ b/src/Parser/Warrior/Protection/CHANGELOG.js
@@ -9,6 +9,11 @@ import SpellLink from 'common/SpellLink';
 export default [
   {
     date: new Date('2018-05-10'),
+    changes: <React.Fragment>Added <SpellLink id={SPELLS.BOOMING_VOICE_TALENT.id} />, <SpellLink id={SPELLS.RENEWED_FURY_TALENT.id} />, reordered and added buffs to the timeline and added <SpellLink id={SPELLS.SHIELD_SLAM.id} /> resets (not 100% accurate).</React.Fragment>,
+    contributors: [joshinator],
+  },
+  {
+    date: new Date('2018-05-10'),
     changes: <React.Fragment>Added <SpellLink id={SPELLS.ANGER_MANAGEMENT_TALENT.id} />, <ItemLink id={ITEMS.THUNDERGODS_VIGOR.id} /> and <SpellLink id={SPELLS.PROTECTION_WARRIOR_T21_2P_WALL_OF_IRON.id} /> support.</React.Fragment>,
     contributors: [joshinator],
   },

--- a/src/Parser/Warrior/Protection/CONFIG.js
+++ b/src/Parser/Warrior/Protection/CONFIG.js
@@ -1,16 +1,18 @@
 import React from 'react';
 
-import { Salarissia } from 'CONTRIBUTORS';
+import { Salarissia, joshinator } from 'CONTRIBUTORS';
 import SPECS from 'common/SPECS';
 import Warning from 'common/Alert/Warning';
+import SpellLink from 'common/SpellLink';
+import SPELLS from 'common/SPELLS';
 
 import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list.
-  contributors: [Salarissia],
+  contributors: [Salarissia, joshinator],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '7.3',
+  patchCompatibility: '7.3.5',
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
@@ -18,6 +20,9 @@ export default {
       <Warning>
         Hey there! Right now the Protection Warrior parser only holds very basic functionality. What we do show should be good to use, but it does not show the complete picture.<br />
         If there is something missing, incorrect, or inaccurate, please report it on <a href="https://github.com/WoWAnalyzer/WoWAnalyzer/issues/new">GitHub</a> or contact us on <a href="https://discord.gg/AxphPxU">Discord</a>.
+      </Warning>
+      <Warning>
+        Because resets of <SpellLink id={SPELLS.SHIELD_SLAM.id} /> <dfn data-tip="The combatlog does not contain any events for random cooldown resets.">can't be tracked</dfn> properly, any cooldown information of <SpellLink id={SPELLS.SHIELD_SLAM.id} /> should be treated as <dfn data-tip="Whenever Shield Slams would be cast before its cooldown would have expired normally, the cooldown expiry will be set back to the last possible trigger of Revenge, Devastate, Devastator or Thunder Clap. This may lead to higher times on cooldown than you actually experienced in-game.">educated guesses</dfn>.
       </Warning>
     </React.Fragment>
   ),

--- a/src/Parser/Warrior/Protection/CombatLogParser.js
+++ b/src/Parser/Warrior/Protection/CombatLogParser.js
@@ -6,10 +6,13 @@ import DamageTaken from 'Parser/Core/Modules/DamageTaken';
 import DeathRecapTracker from 'Main/DeathRecapTracker';
 import Abilities from './Modules/Abilities';
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
+import SpellUsable from './Modules/Features/SpellUsable';
 
 import Shield_Block from './Modules/Spells/ShieldBlock';
 
 import AngerManagement from './Modules/Talents/AngerManagement';
+import BoomingVoice from './Modules/Talents/BoomingVoice';
+import RenewedFury from './Modules/Talents/RenewedFury';
 
 import T21_2pc from './Modules/Items/T21_2pc';
 import ThundergodsVigor from './Modules/Items/ThundergodsVigor';
@@ -25,8 +28,11 @@ class CombatLogParser extends CoreCombatLogParser {
     alwaysBeCasting: AlwaysBeCasting,
     shield_block: Shield_Block,
     deathRecapTracker: DeathRecapTracker,
+    spellUsable: SpellUsable,
     //Talents
     angerManagement: AngerManagement,
+    boomingVoice: BoomingVoice,
+    renewedFury: RenewedFury,
     //Items
     t21: T21_2pc,
     thunderlordsVigor: ThundergodsVigor,

--- a/src/Parser/Warrior/Protection/Modules/Abilities.js
+++ b/src/Parser/Warrior/Protection/Modules/Abilities.js
@@ -7,8 +7,10 @@ class Abilities extends CoreAbilities {
     return [
       {
         spell: SPELLS.DEVASTATE,
+        enabled: !combatant.hasTalent(SPELLS.DEVASTATOR_TALENT.id),
         isOnGCD: true,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        timelineSortIndex: 3,
       },
       {
         spell: SPELLS.REVENGE,

--- a/src/Parser/Warrior/Protection/Modules/Abilities.js
+++ b/src/Parser/Warrior/Protection/Modules/Abilities.js
@@ -106,7 +106,6 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.INTERCEPT,
-        isOnGCD: true,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 15,
         charges: 2,

--- a/src/Parser/Warrior/Protection/Modules/Abilities.js
+++ b/src/Parser/Warrior/Protection/Modules/Abilities.js
@@ -7,63 +7,86 @@ class Abilities extends CoreAbilities {
     return [
       {
         spell: SPELLS.DEVASTATE,
+        isOnGCD: true,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
       },
       {
         spell: SPELLS.REVENGE,
+        isOnGCD: true,
+        buffSpellId: SPELLS.REVENGE_FREE_CAST.id,
+        cooldown: haste => 3 / (1 + haste),
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        timelineSortIndex: 3,
       },
       {
         spell: SPELLS.SHIELD_SLAM,
+        isOnGCD: true,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         cooldown: haste => 9 / (1 + haste),
         castEfficiency: {
           suggestion: true,
+          recommendedEfficiency: .9,
           extraSuggestion: 'Casting Shield Slam regularly is very important for performing well.',
         },
+        timelineSortIndex: 1,
       },
       {
         spell: SPELLS.THUNDER_CLAP,
+        isOnGCD: true,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         cooldown: haste => 6 / (1 + haste),
         castEfficiency: {
           suggestion: true,
+          recommendedEfficiency: .9,
           extraSuggestion: 'Casting Thunder Clap regularly is very important for performing well.',
         },
+        timelineSortIndex: 2,
       },
       {
         spell: SPELLS.IGNORE_PAIN,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         buffSpellId: SPELLS.IGNORE_PAIN.id,
+        timelineSortIndex: 4,
       },
       {
         spell: SPELLS.NELTHARIONS_FURY,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 45,
+        timelineSortIndex: 6,
       },
       {
         spell: SPELLS.SHIELD_BLOCK,
         buffSpellId: SPELLS.SHIELD_BLOCK_BUFF.id,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         cooldown: haste => 13 / (1 + haste),
+        charges: 2,
+        timelineSortIndex: 5,
       },
       {
         spell: SPELLS.DEMORALIZING_SHOUT,
         buffSpellId: SPELLS.DEMORALIZING_SHOUT.id,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
+        castEfficiency: {
+          suggestion: combatant.hasTalent(SPELLS.BOOMING_VOICE_TALENT.id),
+          recommendedEfficiency: combatant.hasTalent(SPELLS.ANGER_MANAGEMENT_TALENT.id) ? .95 : .80,
+          extraSuggestion: 'Cast Demoralizing Shout more liberally to maximize it\'s DPS boost unless you need it so survive a specific mechanic.',
+        },
         cooldown: 90,
+        timelineSortIndex: 8,
       },
       {
         spell: SPELLS.LAST_STAND,
         buffSpellId: SPELLS.LAST_STAND.id,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         cooldown: 180,
+        timelineSortIndex: 9,
       },
       {
         spell: SPELLS.SHIELD_WALL,
         buffSpellId: SPELLS.SHIELD_WALL.id,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         cooldown: 240,
+        timelineSortIndex: 9,
       },
       {
         spell: SPELLS.SPELL_REFLECTION,
@@ -72,15 +95,18 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.HEROIC_LEAP,
+        isOnGCD: true,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 45,
       },
       {
         spell: SPELLS.HEROIC_THROW,
+        isOnGCD: true,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
       },
       {
         spell: SPELLS.INTERCEPT,
+        isOnGCD: true,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 15,
         charges: 2,
@@ -97,7 +123,9 @@ class Abilities extends CoreAbilities {
         cooldown: 60,
         castEfficiency: {
           suggestion: true,
+          recommendedEfficiency: .9,
         },
+        timelineSortIndex: 7,
       },
       {
         spell: SPELLS.BERSERKER_RAGE,
@@ -106,6 +134,7 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: combatant.hasTalent(SPELLS.PROTECTION_WARRIOR_T20_2P_BONUS.id),
         },
+        timelineSortIndex: 8,
       },
       {
         spell: SPELLS.PUMMEL,
@@ -115,6 +144,41 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.VICTORY_RUSH,
         category: Abilities.SPELL_CATEGORIES.OTHERS,
+      },
+      {
+        spell: SPELLS.SHOCKWAVE_TALENT,
+        enabled: combatant.hasTalent(SPELLS.SHOCKWAVE_TALENT.id),
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        isOnGCD: true,
+      },
+      {
+        spell: SPELLS.STORM_BOLT_TALENT,
+        enabled: combatant.hasTalent(SPELLS.STORM_BOLT_TALENT.id),
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        isOnGCD: true,
+        cooldown: 30,
+      },
+      {
+        spell: SPELLS.AVATAR_TALENT,
+        enabled: combatant.hasTalent(SPELLS.AVATAR_TALENT.id),
+        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
+        isOnGCD: true,
+        cooldown: 90,
+        timelineSortIndex: 9,
+      },
+      {
+        spell: SPELLS.IMPENDING_VICTORY_TALENT,
+        enabled: combatant.hasTalent(SPELLS.IMPENDING_VICTORY_TALENT.id),
+        category: Abilities.SPELL_CATEGORIES.OTHERS,
+        isOnGCD: true,
+      },
+      {
+        spell: SPELLS.RAVAGER_TALENT_PROTECTION,
+        enabled: combatant.hasTalent(SPELLS.RAVAGER_TALENT_PROTECTION.id),
+        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
+        isOnGCD: true,
+        cooldown: 60,
+        timelineSortIndex: 9,
       },
     ];
   }

--- a/src/Parser/Warrior/Protection/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Warrior/Protection/Modules/Features/AlwaysBeCasting.js
@@ -1,29 +1,9 @@
 import React from 'react';
 import { formatPercentage } from 'common/format';
 import CoreAlwaysBeCasting from 'Parser/Core/Modules/AlwaysBeCasting';
-import SPELLS from 'common/SPELLS';
 
 class AlwaysBeCasting extends CoreAlwaysBeCasting {
-  static ABILITIES_ON_GCD = [
-    //Rotational
-    SPELLS.DEVASTATE.id,
-    SPELLS.REVENGE.id,
-    SPELLS.SHIELD_SLAM.id,
-    SPELLS.THUNDER_CLAP.id,
-    //Utility
-    SPELLS.HEROIC_LEAP.id,
-    SPELLS.HEROIC_THROW.id,
-    SPELLS.INTERCEPT.id,
-
-    //Talents
-    SPELLS.SHOCKWAVE_TALENT.id,
-    SPELLS.STORM_BOLT_TALENT.id,
-    SPELLS.AVATAR_TALENT.id,
-    SPELLS.IMPENDING_VICTORY_TALENT.id,
-    SPELLS.RAVAGER_TALENT_PROTECTION.id,
-  ];
-
-  suggestions(when) {
+    suggestions(when) {
     const deadTimePercentage = this.totalTimeWasted / this.owner.fightDuration;
 
     when(deadTimePercentage).isGreaterThan(0.2)

--- a/src/Parser/Warrior/Protection/Modules/Features/SpellUsable.js
+++ b/src/Parser/Warrior/Protection/Modules/Features/SpellUsable.js
@@ -19,7 +19,7 @@ class SpellUsable extends CoreSpellUsable {
     }
 
     const spellId = event.ability.guid;
-    if ((spellId === SPELLS.MELEE.id && this.hasDevastator) || spellId === SPELLS.THUNDER_CLAP.id || spellId === SPELLS.REVENGE.id) {
+    if ((spellId === SPELLS.MELEE.id && this.hasDevastator) || spellId === SPELLS.DEVASTATE.id || spellId === SPELLS.THUNDER_CLAP.id || spellId === SPELLS.REVENGE.id) {
       this.lastPotentialTriggerForShieldSlam = event;
     } else if (spellId === SPELLS.SHIELD_SLAM.id) {
       this.lastPotentialTriggerForShieldSlam = null;

--- a/src/Parser/Warrior/Protection/Modules/Features/SpellUsable.js
+++ b/src/Parser/Warrior/Protection/Modules/Features/SpellUsable.js
@@ -1,0 +1,40 @@
+import SPELLS from 'common/SPELLS';
+import CoreSpellUsable from 'Parser/Core/Modules/SpellUsable';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+class SpellUsable extends CoreSpellUsable {
+  static dependencies = {
+    ...CoreSpellUsable.dependencies,
+    combatants: Combatants,
+  };
+
+  on_initialized() {
+    this.hasDevastator = this.combatants.selected.hasTalent(SPELLS.DEVASTATOR_TALENT.id);  
+  }
+
+  lastPotentialTriggerForShieldSlam = null;
+  on_byPlayer_cast(event) {
+    if (super.on_byPlayer_cast) {
+      super.on_byPlayer_cast(event);
+    }
+
+    const spellId = event.ability.guid;
+    if ((spellId === SPELLS.MELEE.id && this.hasDevastator) || spellId === SPELLS.THUNDER_CLAP.id || spellId === SPELLS.REVENGE.id) {
+      this.lastPotentialTriggerForShieldSlam = event;
+    } else if (spellId === SPELLS.SHIELD_SLAM.id) {
+      this.lastPotentialTriggerForShieldSlam = null;
+    }
+  }
+
+  beginCooldown(spellId, timestamp) {
+    if (spellId === SPELLS.SHIELD_SLAM.id) {
+      if (this.isOnCooldown(spellId)) {
+        this.endCooldown(spellId, undefined, this.lastPotentialTriggerForShieldSlam ? this.lastPotentialTriggerForShieldSlam.timestamp : undefined);
+      }
+    }
+
+    super.beginCooldown(spellId, timestamp);
+  }
+}
+
+export default SpellUsable;

--- a/src/Parser/Warrior/Protection/Modules/Talents/BoomingVoice.js
+++ b/src/Parser/Warrior/Protection/Modules/Talents/BoomingVoice.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import Enemies from 'Parser/Core/Modules/Enemies';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+import { formatNumber } from 'common/format';
+
+const BOOMING_VOICE_DAMAGE_INCREASE = 0.25;
+const BOOMING_VOICE_RAGE_GENERATION = 60;
+
+class BoomingVoice extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    enemies: Enemies,
+  };
+
+  rageGenerated = 0;
+  rageWasted = 0;
+  bonusDmg = 0;
+  maxRage = 100;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.BOOMING_VOICE_TALENT.id);
+    this.maxRage += this.combatants.selected.traitsBySpellId[SPELLS.INTOLERANCE_TRAIT.id] * 10;
+  }
+
+  on_energize(event) {
+    if (event.ability.guid !== SPELLS.DEMORALIZING_SHOUT.id) {
+      return;
+    }
+    
+    this.rageGenerated += event.resourceChange;
+    this.rageWasted += event.waste;
+  }
+
+  on_byPlayer_damage(event) {
+    if (event.targetIsFriendly) {
+      return;
+    }
+    const enemy = this.enemies.getEntity(event);
+    if (enemy && enemy.hasBuff(SPELLS.DEMORALIZING_SHOUT.id)) {
+      this.bonusDmg += calculateEffectiveDamage(event, BOOMING_VOICE_DAMAGE_INCREASE);
+    }
+  }
+
+  get uptimeSuggestionThresholds() {
+    return {
+      actual: this.rageWasted,
+      isGreaterThan: {
+        minor: 0,
+        average: 10,
+        major: 20,
+      },
+      style: 'number',
+    };
+  }
+
+  suggestions(when) {
+    when(this.uptimeSuggestionThresholds)
+        .addSuggestion((suggest, actual, recommended) => {
+          return suggest(<React.Fragment>You wasted Rage by casting <SpellLink id={SPELLS.DEMORALIZING_SHOUT.id} /> with more than {this.maxRage - BOOMING_VOICE_RAGE_GENERATION} Rage.</React.Fragment>)
+            .icon(SPELLS.BOOMING_VOICE_TALENT.icon)
+            .actual(`${actual} Rage wasted`)
+            .recommended(`<${recommended} wasted Rage is recommended`);
+        });
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.BOOMING_VOICE_TALENT.id} />}
+        value={`${this.rageGenerated}`}
+        label={`Rage generated`}
+        tooltip={`${formatNumber(this.bonusDmg)} damage contributed<br/>${this.rageWasted} Rage wasted
+        `}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(5);
+}
+
+export default BoomingVoice;

--- a/src/Parser/Warrior/Protection/Modules/Talents/RenewedFury.js
+++ b/src/Parser/Warrior/Protection/Modules/Talents/RenewedFury.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+import { formatNumber, formatPercentage } from 'common/format';
+
+const RENEWED_FURY_DAMAGE_INCREASE = 0.1;
+
+class RenewedFury extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  bonusDmg = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.RENEWED_FURY_TALENT.id);
+  }
+
+  get uptime() {
+    return this.combatants.getBuffUptime(SPELLS.RENEWED_FURY_TALENT_BUFF.id) / this.owner.fightDuration;
+  }
+
+  on_byPlayer_damage(event) {
+    if (!this.combatants.selected.hasBuff(SPELLS.RENEWED_FURY_TALENT_BUFF.id)) {
+      return;
+    }
+    
+    this.bonusDmg += calculateEffectiveDamage(event, RENEWED_FURY_DAMAGE_INCREASE);
+  }
+
+  get uptimeSuggestionThresholds() {
+    return {
+      actual: this.uptime,
+      isLessThan: {
+        minor: .95,
+        average: .85,
+        major: .75,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.uptimeSuggestionThresholds)
+        .addSuggestion((suggest, actual, recommended) => {
+          return suggest(<React.Fragment>Maximize your <SpellLink id={SPELLS.RENEWED_FURY_TALENT.id} /> uptime by weaving <SpellLink id={SPELLS.IGNORE_PAIN.id} /> into your rotation instead of casting it multiple times in a short timeframe.</React.Fragment>)
+            .icon(SPELLS.RENEWED_FURY_TALENT.icon)
+            .actual(`${formatPercentage(actual)}% uptime`)
+            .recommended(`>${formatPercentage(recommended)}% is recommended`);
+        });
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.RENEWED_FURY_TALENT.id} />}
+        value={`${formatPercentage(this.uptime)}%`}
+        label={`Uptime`}
+        tooltip={`${formatNumber(this.bonusDmg)} damage contributed
+        `}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(5);
+}
+
+export default RenewedFury;

--- a/src/common/SPELLS/WARRIOR.js
+++ b/src/common/SPELLS/WARRIOR.js
@@ -335,6 +335,11 @@ export default {
     name: 'Revenge',
     icon: 'ability_warrior_revenge',
   },
+  REVENGE_FREE_CAST: {
+    id: 5302,
+    name: 'Revenge!',
+    icon: 'ability_warrior_revenge',
+  },
   SHIELD_SLAM: {
     id: 23922,
     name: 'Shield Slam',
@@ -351,6 +356,11 @@ export default {
     name: 'Ignore Pain',
     icon: 'ability_warrior_renewedvigor',
   },
+  RENEWED_FURY_TALENT_BUFF: {
+    id: 202289,
+    name: 'Renewed Fury',
+    icon: 'ability_warrior_intensifyrage',
+  },
   NELTHARIONS_FURY: {
     id: 203526,
     name: 'Neltharion\'s Fury',
@@ -365,6 +375,11 @@ export default {
     id: 132404,
     name: 'Shield Block Buff',
     icon: 'ability_defend',
+  },
+  DEVASTATOR_DAMAGE: {
+    id: 236282,
+    name: 'Devastator',
+    icon: 'inv_sword_11',
   },
   //Cooldown Spells
   DEMORALIZING_SHOUT: {
@@ -433,6 +448,13 @@ export default {
     id: 242302,
     name: 'T20 2P Bonus',
     icon: 'ability_warrior_defensivestance',
+  },
+
+  //Traits
+  INTOLERANCE_TRAIT: {
+    id: 203227,
+    name: 'Intolerance',
+    icon: 'warrior_talent_icon_furyintheblood',
   },
 
   // Shared:


### PR DESCRIPTION
- added Booming Voice (with tighter suggestion for AM and casts that cap rage in timeline)
- added Renewed Fury
- updated timeline
- updated several abilities to reflect changes from 7.1.5 (Revenge rework)
- removed onGCD abilities from ABC and updated it in abilties
- added pseudo tracking of Shield Slam resets (acts log-wise like protadins AS, the resets emit no events, if SS was used while its still "on cooldown" it'll use the last possible reset as reset (added warning that its not 100% acurate and SS might have a lower CD))
- added charges to Shield Block
- ordered timeline to be more organized

![boom](https://user-images.githubusercontent.com/29842841/40077823-100a87de-5883-11e8-83b1-0c364b7bdea3.PNG)
![renew](https://user-images.githubusercontent.com/29842841/40077825-103990b0-5883-11e8-8f9e-f614d3a3cd01.PNG)
![sugg](https://user-images.githubusercontent.com/29842841/40077826-1050e6d4-5883-11e8-9441-e503a80eeba2.PNG)
![sugg2](https://user-images.githubusercontent.com/29842841/40077828-106ac0cc-5883-11e8-8f1f-4868bfef35ab.PNG)
![devastate](https://user-images.githubusercontent.com/29842841/40077824-10225d32-5883-11e8-8b25-28276c49cdba.PNG)
![timeline](https://user-images.githubusercontent.com/29842841/40077829-10816fb6-5883-11e8-8911-54554d6b1614.PNG)
