### PR TITLE
[Protection Warrior] Into the Fray, Heavy Repercussions, Avatar, Shield Slam Resets update

### DIFF
--- a/src/Parser/Warrior/Protection/CHANGELOG.js
+++ b/src/Parser/Warrior/Protection/CHANGELOG.js
@@ -8,12 +8,12 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
-    date: new Date('2018-05-10'),
+    date: new Date('2018-05-16'),
     changes: <React.Fragment>Added <SpellLink id={SPELLS.INTO_THE_FRAY_TALENT.id} />, <SpellLink id={SPELLS.HEAVY_REPERCUSSIONS_TALENT.id} /> and <SpellLink id={SPELLS.AVATAR_TALENT.id} />.</React.Fragment>,
     contributors: [joshinator],
   },
   {
-    date: new Date('2018-05-10'),
+    date: new Date('2018-05-15'),
     changes: <React.Fragment>Added <SpellLink id={SPELLS.BOOMING_VOICE_TALENT.id} />, <SpellLink id={SPELLS.RENEWED_FURY_TALENT.id} />, reordered and added buffs to the timeline and added <SpellLink id={SPELLS.SHIELD_SLAM.id} /> resets (not 100% accurate).</React.Fragment>,
     contributors: [joshinator],
   },

--- a/src/Parser/Warrior/Protection/CHANGELOG.js
+++ b/src/Parser/Warrior/Protection/CHANGELOG.js
@@ -9,6 +9,11 @@ import SpellLink from 'common/SpellLink';
 export default [
   {
     date: new Date('2018-05-10'),
+    changes: <React.Fragment>Added <SpellLink id={SPELLS.INTO_THE_FRAY_TALENT.id} />, <SpellLink id={SPELLS.HEAVY_REPERCUSSIONS_TALENT.id} /> and <SpellLink id={SPELLS.AVATAR_TALENT.id} />.</React.Fragment>,
+    contributors: [joshinator],
+  },
+  {
+    date: new Date('2018-05-10'),
     changes: <React.Fragment>Added <SpellLink id={SPELLS.BOOMING_VOICE_TALENT.id} />, <SpellLink id={SPELLS.RENEWED_FURY_TALENT.id} />, reordered and added buffs to the timeline and added <SpellLink id={SPELLS.SHIELD_SLAM.id} /> resets (not 100% accurate).</React.Fragment>,
     contributors: [joshinator],
   },

--- a/src/Parser/Warrior/Protection/CombatLogParser.js
+++ b/src/Parser/Warrior/Protection/CombatLogParser.js
@@ -4,6 +4,7 @@ import DamageDone from 'Parser/Core/Modules/DamageDone';
 import DamageTaken from 'Parser/Core/Modules/DamageTaken';
 
 import DeathRecapTracker from 'Main/DeathRecapTracker';
+import Haste from './Modules/Core/Haste';
 import Abilities from './Modules/Abilities';
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
 import SpellUsable from './Modules/Features/SpellUsable';
@@ -13,6 +14,9 @@ import Shield_Block from './Modules/Spells/ShieldBlock';
 import AngerManagement from './Modules/Talents/AngerManagement';
 import BoomingVoice from './Modules/Talents/BoomingVoice';
 import RenewedFury from './Modules/Talents/RenewedFury';
+import HeavyRepercussions from './Modules/Talents/HeavyRepercussions';
+import IntoTheFray from './Modules/Talents/IntoTheFray';
+import Avatar from './Modules/Talents/Avatar';
 
 import T21_2pc from './Modules/Items/T21_2pc';
 import ThundergodsVigor from './Modules/Items/ThundergodsVigor';
@@ -23,6 +27,7 @@ class CombatLogParser extends CoreCombatLogParser {
     damageTaken: [DamageTaken, { showStatistic: true }],
     healingDone: [HealingDone, { showStatistic: true }],
     damageDone: [DamageDone, { showStatistic: true }],
+    haste: Haste,
     // Features
     abilities: Abilities,
     alwaysBeCasting: AlwaysBeCasting,
@@ -33,6 +38,9 @@ class CombatLogParser extends CoreCombatLogParser {
     angerManagement: AngerManagement,
     boomingVoice: BoomingVoice,
     renewedFury: RenewedFury,
+    heavyRepercussions: HeavyRepercussions,
+    intoTheFray: IntoTheFray,
+    avatar: Avatar,
     //Items
     t21: T21_2pc,
     thunderlordsVigor: ThundergodsVigor,

--- a/src/Parser/Warrior/Protection/Modules/Abilities.js
+++ b/src/Parser/Warrior/Protection/Modules/Abilities.js
@@ -163,7 +163,10 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.AVATAR_TALENT,
         enabled: combatant.hasTalent(SPELLS.AVATAR_TALENT.id),
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
-        isOnGCD: true,
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: .9,
+        },
         cooldown: 90,
         timelineSortIndex: 9,
       },
@@ -179,6 +182,10 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         isOnGCD: true,
         cooldown: 60,
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: .9,
+        },
         timelineSortIndex: 9,
       },
     ];

--- a/src/Parser/Warrior/Protection/Modules/Core/Haste.js
+++ b/src/Parser/Warrior/Protection/Modules/Core/Haste.js
@@ -1,0 +1,15 @@
+import SPELLS from 'common/SPELLS';
+
+import CoreHaste from 'Parser/Core/Modules/Haste';
+
+class Haste extends CoreHaste {
+  static HASTE_BUFFS = {
+    ...CoreHaste.HASTE_BUFFS,
+    // Ignorrior specific
+    [SPELLS.INTO_THE_FRAY_BUFF.id]: { // from Into the Fray (3% per stack for each enemy nearby)
+      hastePerStack: 0.03,
+    },
+  };
+}
+
+export default Haste;

--- a/src/Parser/Warrior/Protection/Modules/Features/SpellUsable.js
+++ b/src/Parser/Warrior/Protection/Modules/Features/SpellUsable.js
@@ -1,11 +1,13 @@
 import SPELLS from 'common/SPELLS';
 import CoreSpellUsable from 'Parser/Core/Modules/SpellUsable';
 import Combatants from 'Parser/Core/Modules/Combatants';
+import GlobalCooldown from 'Parser/Core/Modules/GlobalCooldown';
 
 class SpellUsable extends CoreSpellUsable {
   static dependencies = {
     ...CoreSpellUsable.dependencies,
     combatants: Combatants,
+    globalCooldown: GlobalCooldown,
   };
 
   on_initialized() {
@@ -19,8 +21,12 @@ class SpellUsable extends CoreSpellUsable {
     }
 
     const spellId = event.ability.guid;
-    if ((spellId === SPELLS.MELEE.id && this.hasDevastator) || spellId === SPELLS.DEVASTATE.id || spellId === SPELLS.THUNDER_CLAP.id || spellId === SPELLS.REVENGE.id) {
+    if (spellId === SPELLS.MELEE.id && this.hasDevastator) {
       this.lastPotentialTriggerForShieldSlam = event;
+    } else if (spellId === SPELLS.DEVASTATE.id || spellId === SPELLS.THUNDER_CLAP.id || spellId === SPELLS.REVENGE.id) {
+      this.lastPotentialTriggerForShieldSlam = { ...event };
+      //reset the cooldown to after the GCD of the resetting ability
+      this.lastPotentialTriggerForShieldSlam.timestamp += this.globalCooldown.getCurrentGlobalCooldown(spellId);
     } else if (spellId === SPELLS.SHIELD_SLAM.id) {
       this.lastPotentialTriggerForShieldSlam = null;
     }

--- a/src/Parser/Warrior/Protection/Modules/Items/T21_2pc.js
+++ b/src/Parser/Warrior/Protection/Modules/Items/T21_2pc.js
@@ -5,6 +5,7 @@ import SpellLink from 'common/SpellLink';
 import SpellIcon from 'common/SpellIcon';
 
 import Analyzer from 'Parser/Core/Analyzer';
+import GlobalCooldown from 'Parser/Core/Modules/GlobalCooldown';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import SpellUsable from 'Parser/Core/Modules/SpellUsable';
 
@@ -12,6 +13,7 @@ class T21_2pc extends Analyzer {
   static dependencies = {
     combatants: Combatants,
     spellUsable: SpellUsable,
+    globalCooldown: GlobalCooldown,
   };
 
   resets = 0;
@@ -25,7 +27,8 @@ class T21_2pc extends Analyzer {
       return;
     }
 
-    this.spellUsable.endCooldown(SPELLS.SHIELD_SLAM.id);
+    const globalCooldown = this.globalCooldown.getCurrentGlobalCooldown(SPELLS.SHIELD_SLAM.id);
+    this.spellUsable.reduceCooldown(SPELLS.SHIELD_SLAM.id, (this.spellUsable.cooldownRemaining(SPELLS.SHIELD_SLAM.id) - globalCooldown));
     this.resets += 1;
   }
 

--- a/src/Parser/Warrior/Protection/Modules/Talents/Avatar.js
+++ b/src/Parser/Warrior/Protection/Modules/Talents/Avatar.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+import { formatNumber, formatPercentage } from 'common/format';
+
+const AVATAR_DAMAGE_INCREASE = 0.2;
+
+class Avatar extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  bonusDmg = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.AVATAR_TALENT.id);
+  }
+
+  get uptime() {
+    return this.combatants.getBuffUptime(SPELLS.AVATAR_TALENT.id) / this.owner.fightDuration;
+  }
+
+  on_byPlayer_damage(event) {
+    if (!this.combatants.selected.hasBuff(SPELLS.AVATAR_TALENT.id)) {
+      return;
+    }
+    
+    this.bonusDmg += calculateEffectiveDamage(event, AVATAR_DAMAGE_INCREASE);
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.AVATAR_TALENT.id} />}
+        value={`${formatPercentage(this.uptime)}%`}
+        label={`Uptime`}
+        tooltip={`${formatNumber(this.bonusDmg)} damage contributed
+        `}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(5);
+}
+
+export default Avatar;

--- a/src/Parser/Warrior/Protection/Modules/Talents/Avatar.js
+++ b/src/Parser/Warrior/Protection/Modules/Talents/Avatar.js
@@ -28,7 +28,7 @@ class Avatar extends Analyzer {
   on_byPlayer_damage(event) {
     if (!this.combatants.selected.hasBuff(SPELLS.AVATAR_TALENT.id)) {
       return;
-    }
+    } 
     
     this.bonusDmg += calculateEffectiveDamage(event, AVATAR_DAMAGE_INCREASE);
   }
@@ -37,9 +37,11 @@ class Avatar extends Analyzer {
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.AVATAR_TALENT.id} />}
-        value={`${formatPercentage(this.uptime)}%`}
-        label={`Uptime`}
-        tooltip={`${formatNumber(this.bonusDmg)} damage contributed
+        value={`${formatNumber(this.bonusDmg / this.owner.fightDuration * 1000)} DPS`}
+        label={`Damage contributed`}
+        tooltip={`
+          Avatar contributed ${formatNumber(this.bonusDmg)} total damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.bonusDmg))}%). </br>
+          Uptime was ${formatPercentage(this.uptime)}%
         `}
       />
     );

--- a/src/Parser/Warrior/Protection/Modules/Talents/HeavyRepercussions.js
+++ b/src/Parser/Warrior/Protection/Modules/Talents/HeavyRepercussions.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import Enemies from 'Parser/Core/Modules/Enemies';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+import { formatNumber, formatPercentage } from 'common/format';
+
+const HEAVY_REPERCUSSIONS_SHIELD_BLOCK_EXTEND_MS = 1000;
+const HEAVY_REPERCUSSIONS_SHIELD_SLAM_DAMAGE_BUFF = 0.3;
+
+class HeavyRepercussions extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    enemies: Enemies,
+  };
+
+  sbExtended = 0;
+  ssBuffRefreshed = 0;
+  nextShieldSlamBuffed = false;
+  bonusDmg = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.HEAVY_REPERCUSSIONS_TALENT.id);
+  }
+
+  get shieldBlockuptime() {
+    return this.combatants.getBuffUptime(SPELLS.SHIELD_BLOCK_BUFF.id);
+  }
+
+  on_byPlayer_damage(event) {
+    if (event.ability.guid !== SPELLS.SHIELD_SLAM.id || !this.nextShieldSlamBuffed ) {
+      return;
+    }
+
+    this.bonusDmg += calculateEffectiveDamage(event, HEAVY_REPERCUSSIONS_SHIELD_SLAM_DAMAGE_BUFF);
+    this.nextShieldSlamBuffed = false;
+  }
+
+  on_byPlayer_cast(event) {
+    if (event.ability.guid === SPELLS.SHIELD_BLOCK.id && this.nextShieldSlamBuffed) {
+      this.ssBuffRefreshed += 1;
+      return;
+    }
+
+    if (event.ability.guid === SPELLS.SHIELD_BLOCK.id) {
+      this.nextShieldSlamBuffed = true;
+      return;
+    }
+
+    if (event.ability.guid !== SPELLS.SHIELD_SLAM.id || !this.combatants.selected.hasBuff(SPELLS.SHIELD_BLOCK_BUFF.id)) {
+      return;
+    }
+
+    this.sbExtended += 1;
+  }
+
+  get uptimeSuggestionThresholds() {
+    return {
+      actual: this.ssBuffRefreshed,
+      isGreaterThan: {
+        minor: 0,
+        average: 4,
+        major: 8,
+      },
+      style: 'number',
+    };
+  }
+
+  suggestions(when) {
+    when(this.uptimeSuggestionThresholds)
+        .addSuggestion((suggest, actual, recommended) => {
+          return suggest(<React.Fragment>You refreshed <SpellLink id={SPELLS.HEAVY_REPERCUSSIONS_TALENT.id} />'s damage buff for <SpellLink id={SPELLS.SHIELD_SLAM.id} /> {actual} times. Make sure to weave <SpellLink id={SPELLS.SHIELD_SLAM.id} />'s between your <SpellLink id={SPELLS.SHIELD_BLOCK.id} /> casts to maximize your damage.</React.Fragment>)
+            .icon(SPELLS.HEAVY_REPERCUSSIONS_TALENT.icon)
+            .actual(`${actual} times refreshed`)
+            .recommended(`${recommended} recommended`);
+        });
+  }
+
+  statistic() {
+    const sbExtendedMS = this.sbExtended * HEAVY_REPERCUSSIONS_SHIELD_BLOCK_EXTEND_MS;
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.HEAVY_REPERCUSSIONS_TALENT.id} />}
+        value={`${formatPercentage(sbExtendedMS / (this.shieldBlockuptime - sbExtendedMS))}%`}
+        label={`more Shield Block uptime`}
+        tooltip={`
+          You casted Shield Slam ${this.sbExtended} times during Shield Block, resulting in additional ${sbExtendedMS / 1000}sec uptime.<br/>
+          ${formatNumber(this.bonusDmg)} damage contributed by casting buffed Shield Slams<br/>
+          ${this.ssBuffRefreshed > 0 ? `You casted Shield Block ${this.ssBuffRefreshed} times while having the damage bonus for Shield Block already up.` : ``}
+        `}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(5);
+}
+
+export default HeavyRepercussions;

--- a/src/Parser/Warrior/Protection/Modules/Talents/IntoTheFray.js
+++ b/src/Parser/Warrior/Protection/Modules/Talents/IntoTheFray.js
@@ -1,0 +1,118 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+
+import { STATISTIC_ORDER } from 'Main/StatisticBox';
+import ExpandableStatisticBox from 'Main/ExpandableStatisticBox';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import { formatPercentage, formatDuration } from 'common/format';
+
+const MAX_STACKS = 5;
+const HASTE_PER_STACK = 3;
+//update haste per stack in ./Core/Haste.js aswell
+
+class IntoTheFray extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  buffStacks = [];
+  lastStacks = 0;
+  lastUpdate = this.owner.fight.start_time;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.INTO_THE_FRAY_TALENT.id);
+    this.buffStacks = Array.from({length: MAX_STACKS + 1}, x => [0]);
+  }
+
+  handleStacks(event, stack = null) {
+    if (event.type === 'removebuff' || isNaN(event.stack)) { //NaN check if player is dead during on_finish
+      event.stack = 0;
+    }
+    if (event.type === 'applybuff') {
+      event.stack = 1;
+    }
+
+    if (stack) {
+      event.stack = stack;
+    }
+
+    this.buffStacks[this.lastStacks].push(event.timestamp - this.lastUpdate);
+    this.lastUpdate = event.timestamp;
+    this.lastStacks = event.stack;
+  }
+
+  
+  on_byPlayer_applybuff(event) {
+    if (event.ability.guid !== SPELLS.INTO_THE_FRAY_BUFF.id) {
+      return;
+    }
+    this.handleStacks(event);
+  }
+
+  on_byPlayer_applybuffstack(event) {
+    if (event.ability.guid !== SPELLS.INTO_THE_FRAY_BUFF.id) {
+      return;
+    }
+    this.handleStacks(event);
+  }
+
+  on_byPlayer_removebuff(event) {
+    if (event.ability.guid !== SPELLS.INTO_THE_FRAY_BUFF.id) {
+      return;
+    }
+    this.handleStacks(event);
+  }
+
+  on_byPlayer_removebuffstack(event) {
+    if (event.ability.guid !== SPELLS.INTO_THE_FRAY_BUFF.id) {
+      return;
+    }
+    this.handleStacks(event);
+  }
+
+  on_finished(event) {
+    this.handleStacks(event, this.lastStacks);
+  }
+
+  get averageHaste() {
+    let avgStacks = 0;
+    this.buffStacks.forEach((elem, index) => {
+      avgStacks += elem.reduce((a, b) => a + b) / this.owner.fightDuration * index;
+    });
+    return (avgStacks * HASTE_PER_STACK).toFixed(2);
+  }
+
+  statistic() {
+    return (
+      <ExpandableStatisticBox
+        icon={<SpellIcon id={SPELLS.INTO_THE_FRAY_TALENT.id} />}
+        value={`${this.averageHaste}%`}
+        label="average haste gained"
+      >
+        <table className="table table-condensed">
+          <thead>
+            <tr>
+              <th>Haste-Bonus</th>
+              <th>Time (s)</th>
+              <th>Time (%)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {this.buffStacks.map((e, i) =>
+              <tr key={i}>
+                <th>{(i * HASTE_PER_STACK).toFixed(0)}%</th>
+                <td>{formatDuration(e.reduce((a, b) => a + b, 0) / 1000)}</td>
+                <td>{formatPercentage(e.reduce((a, b) => a + b, 0) / this.owner.fightDuration)}%</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </ExpandableStatisticBox>
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(5);
+}
+
+export default IntoTheFray;

--- a/src/common/SPELLS/WARRIOR.js
+++ b/src/common/SPELLS/WARRIOR.js
@@ -361,6 +361,11 @@ export default {
     name: 'Renewed Fury',
     icon: 'ability_warrior_intensifyrage',
   },
+  INTO_THE_FRAY_BUFF: {
+    id: 202602,
+    name: "Into the Fray",
+    icon: "ability_warrior_bloodfrenzy",
+  },
   NELTHARIONS_FURY: {
     id: 203526,
     name: 'Neltharion\'s Fury',


### PR DESCRIPTION
- adds Into the fray
average haste gained + detailed stack uptime + stattracker takes stacks into account
- adds heavy repercussions
adds suggestion when refreshing the SS damage buff (by casting two SBs without an SS inbetween)
- adds avatar
- updates T21 2p & shield slam resets to take the GCD into account 
eg. TC cast would reset SS, SS is of CD but the GCD is still going, resulting in inaccurate SS efficiency

![hr](https://user-images.githubusercontent.com/29842841/40116746-e5474162-5914-11e8-83f3-19538b3a0763.PNG)
![intothefray](https://user-images.githubusercontent.com/29842841/40116747-e56143dc-5914-11e8-912d-54abd27f145e.PNG)
![avatar](https://user-images.githubusercontent.com/29842841/40116748-e57b06f0-5914-11e8-9487-3165166858cb.PNG)
