### PR TITLE
[Core] debuffs in Deathrecap 

### DIFF
--- a/src/Main/DeathRecap.js
+++ b/src/Main/DeathRecap.js
@@ -82,7 +82,8 @@ class DeathRecap extends React.PureComponent {
                   <th>Ability</th>
                   <th>HP</th>
                   <th>Amount</th>
-                  <th>Defensive Buffs up</th>
+                  <th>Defensive Buffs</th>
+                  <th>Targets Debuffs</th>
                   <th>Personals available</th>
                 </tr>
               </thead>
@@ -148,9 +149,14 @@ class DeathRecap extends React.PureComponent {
                       <td style={{ width: '15%'}}>
                         {output}
                       </td>
-                      <td style={{ width: '20%' }}>
-                        {event.buffsUp.map(e =>
+                      <td style={{ width: '10%' }}>
+                        {event.buffsUp && event.buffsUp.map(e =>
                           <SpellIcon id={e.spell ? e.spell.id : e} />
+                        )}
+                      </td>
+                      <td style={{ width: '10%' }}>
+                        {event.debuffsUp && event.debuffsUp.map(e =>
+                          <SpellIcon id={e.ability ? e.ability.guid : e} />
                         )}
                       </td>
                       <td style={{ width: '15%' }}>
@@ -166,7 +172,7 @@ class DeathRecap extends React.PureComponent {
                 })}
                 <tr>
                   <td></td>
-                  <td colSpan="5">
+                  <td colSpan="6">
                     You died
                   </td>
                 </tr>

--- a/src/Main/DeathRecapTracker.js
+++ b/src/Main/DeathRecapTracker.js
@@ -44,7 +44,7 @@ class DeathRecapTracker extends Analyzer {
     }
 
     if (!event.sourceIsFriendly && this.enemies.enemies[event.sourceID]) {
-      const sourceHasDebuff = debuff => (!debuff.end || event.timestamp <= debuff.end) && event.timestamp >= debuff.start && debuff.isDebuff && this.buffs.some(e => e.spell.id === debuff.ability.guid);
+      const sourceHasDebuff = debuff => (!debuff.end || event.timestamp <= debuff.end) && event.timestamp >= debuff.start && debuff.isDebuff && this.buffs.some(e => e.spell.id === debuff.ability.guid || e.spell.buffSpellId === debuff.ability.guid);
       extendedEvent.debuffsUp = this.enemies.enemies[event.sourceID].buffs.filter(sourceHasDebuff);
     }
     

--- a/src/Main/DeathRecapTracker.js
+++ b/src/Main/DeathRecapTracker.js
@@ -28,7 +28,7 @@ class DeathRecapTracker extends Analyzer {
   };
 
   on_initialized() {
-    const hasCooldown = ability =>  (ability.category === Abilities.SPELL_CATEGORIES.DEFENSIVE || ability.category === Abilities.SPELL_CATEGORIES.SEMI_DEFENSIVE) && ability.enabled === true;
+    const hasCooldown = ability => (ability.category === Abilities.SPELL_CATEGORIES.DEFENSIVE || ability.category === Abilities.SPELL_CATEGORIES.SEMI_DEFENSIVE) && ability.enabled === true;
     this.cooldowns = this.abilities.abilities.filter(hasCooldown);
     //add additional defensive buffs/debuffs to common/DEFENSIVE_BUFFS
     this.buffs = [...DEFENSIVE_BUFFS, ...this.cooldowns];
@@ -43,12 +43,10 @@ class DeathRecapTracker extends Analyzer {
       this.lastBuffs = this.buffs.filter(e => this.combatants.selected.hasBuff(e.spell.buffSpellId) || this.combatants.selected.hasBuff(e.spell.id));
     }
 
-    // if (!event.sourceIsFriendly) {
-    //   console.info(event);
-    //   console.info(this.enemies.enemies[event.sourceID]);
-    //   console.info(this.buffs);
-    //   console.info(this.enemies.enemies[event.sourceID].buffs.filter(buff => buff));
-    // }
+    if (!event.sourceIsFriendly && this.enemies.enemies[event.sourceID]) {
+      const sourceHasDebuff = debuff => (!debuff.end || event.timestamp <= debuff.end) && event.timestamp >= debuff.start && debuff.isDebuff && this.buffs.some(e => e.spell.id === debuff.ability.guid);
+      extendedEvent.debuffsUp = this.enemies.enemies[event.sourceID].buffs.filter(sourceHasDebuff);
+    }
     
     extendedEvent.buffsUp = this.lastBuffs;
     this.events.push(extendedEvent);
@@ -92,7 +90,9 @@ class DeathRecapTracker extends Analyzer {
       url: 'death-recap',
       render: () => (
         <Tab>
-          <DeathRecap events={this.secondsBeforeDeath} />
+          <DeathRecap 
+            events={this.secondsBeforeDeath} 
+          />
         </Tab>
       ),
     };

--- a/src/common/DEFENSIVE_BUFFS.js
+++ b/src/common/DEFENSIVE_BUFFS.js
@@ -45,6 +45,9 @@ const DEFENSIVE_BUFFS = [
   {
     spell: SPELLS.PAINBRINGER_Buff,
   },
+  {
+    spell: SPELLS.FRAILTY_SPIRIT_BOMB_DEBUFF,
+  },
 ];
 
 export default DEFENSIVE_BUFFS;


### PR DESCRIPTION
Adds a new column to the table with all defensive debuffs up on the target for the damage event. Still takes the IDs from all defensive cooldowns (with the same spellID as the ability, the buffSpellId or the `DEFENSIVE_BUFFS`-file).
Might add debuffs for the player aswell (like tank major debuffs that increase damage taken) but I'm right now not quite sure how to add that without making the recap too cluttered.

![image](https://user-images.githubusercontent.com/29842841/40272996-7886cbbe-5bb8-11e8-81d3-db561f4fdb5c.png)
