### PR TITLE
[Protection Warrior] added Vengeance

### DIFF
--- a/src/Parser/Warrior/Protection/CHANGELOG.js
+++ b/src/Parser/Warrior/Protection/CHANGELOG.js
@@ -8,6 +8,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-05-20'),
+    changes: <React.Fragment>Added <SpellLink id={SPELLS.VENGEANCE_TALENT.id} />.</React.Fragment>,
+    contributors: [joshinator],
+  },
+  {
     date: new Date('2018-05-16'),
     changes: <React.Fragment>Added <SpellLink id={SPELLS.INTO_THE_FRAY_TALENT.id} />, <SpellLink id={SPELLS.HEAVY_REPERCUSSIONS_TALENT.id} /> and <SpellLink id={SPELLS.AVATAR_TALENT.id} />.</React.Fragment>,
     contributors: [joshinator],

--- a/src/Parser/Warrior/Protection/CombatLogParser.js
+++ b/src/Parser/Warrior/Protection/CombatLogParser.js
@@ -17,6 +17,7 @@ import RenewedFury from './Modules/Talents/RenewedFury';
 import HeavyRepercussions from './Modules/Talents/HeavyRepercussions';
 import IntoTheFray from './Modules/Talents/IntoTheFray';
 import Avatar from './Modules/Talents/Avatar';
+import Vengeance from './Modules/Talents/Vengeance';
 
 import T21_2pc from './Modules/Items/T21_2pc';
 import ThundergodsVigor from './Modules/Items/ThundergodsVigor';
@@ -41,6 +42,7 @@ class CombatLogParser extends CoreCombatLogParser {
     heavyRepercussions: HeavyRepercussions,
     intoTheFray: IntoTheFray,
     avatar: Avatar,
+    vengeance: Vengeance,
     //Items
     t21: T21_2pc,
     thunderlordsVigor: ThundergodsVigor,

--- a/src/Parser/Warrior/Protection/Modules/Talents/Vengeance.js
+++ b/src/Parser/Warrior/Protection/Modules/Talents/Vengeance.js
@@ -49,7 +49,7 @@ class Vengeance extends Analyzer {
   }
 
   get buffUsage() {
-    return (this.ignoreBuffsOverwritten + this.revengeBuffsOverwritten) / (this.buffedIgnoreCasts + this.buffedRevengeCasts + this.ignoreBuffsOverwritten + this.revengeBuffsOverwritten)
+    return (this.ignoreBuffsOverwritten + this.revengeBuffsOverwritten) / (this.buffedIgnoreCasts + this.buffedRevengeCasts + this.ignoreBuffsOverwritten + this.revengeBuffsOverwritten);
   }
 
   get uptimeSuggestionThresholds() {

--- a/src/Parser/Warrior/Protection/Modules/Talents/Vengeance.js
+++ b/src/Parser/Warrior/Protection/Modules/Talents/Vengeance.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import { formatPercentage } from 'common/format';
+
+class Vengeance extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  buffedIgnoreCasts = 0;
+  buffedRevengeCasts = 0;
+  ignoreBuffsOverwritten = 0;
+  revengeBuffsOverwritten = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.VENGEANCE_TALENT.id);
+  }
+
+  on_byPlayer_cast(event) {
+    if (event.ability.guid !== SPELLS.IGNORE_PAIN.id && event.ability.guid !== SPELLS.REVENGE.id) {
+      return;
+    }
+
+    if (this.combatants.selected.hasBuff(SPELLS.VENGEANCE_IGNORE_PAIN.id) && event.ability.guid === SPELLS.REVENGE.id) {
+      this.ignoreBuffsOverwritten += 1;
+      return;
+    }
+
+    if (this.combatants.selected.hasBuff(SPELLS.VENGEANCE_REVENGE.id) && event.ability.guid === SPELLS.IGNORE_PAIN.id) {
+      this.revengeBuffsOverwritten += 1;
+      return;
+    }
+
+    if (event.ability.guid === SPELLS.REVENGE.id && this.combatants.selected.hasBuff(SPELLS.VENGEANCE_REVENGE.id)) {
+      this.buffedRevengeCasts += 1;
+      return;
+    }
+
+    if (event.ability.guid === SPELLS.IGNORE_PAIN.id && this.combatants.selected.hasBuff(SPELLS.VENGEANCE_IGNORE_PAIN.id)) {
+      this.buffedIgnoreCasts += 1;
+      return;
+    }
+  }
+
+  get buffUsage() {
+    return (this.ignoreBuffsOverwritten + this.revengeBuffsOverwritten) / (this.buffedIgnoreCasts + this.buffedRevengeCasts + this.ignoreBuffsOverwritten + this.revengeBuffsOverwritten)
+  }
+
+  get uptimeSuggestionThresholds() {
+    return {
+      actual: this.buffUsage,
+      isGreaterThan: {
+        minor: 0,
+        average: .1,
+        major: .2,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.uptimeSuggestionThresholds)
+        .addSuggestion((suggest, actual, recommended) => {
+          return suggest(<React.Fragment>Avoid casting <SpellLink id={SPELLS.IGNORE_PAIN.id} /> and <SpellLink id={SPELLS.REVENGE.id} /> back to back without using it's counterpart. <SpellLink id={SPELLS.VENGEANCE_TALENT.id} /> requires you to weave between those two spells to get the most rage and damage out of it.</React.Fragment>)
+            .icon(SPELLS.VENGEANCE_TALENT.icon)
+            .actual(`${formatPercentage(actual)}% overwritten`)
+            .recommended(`${formatPercentage(recommended)}% recommended`);
+        });
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.VENGEANCE_TALENT.id} />}
+        value={`${formatPercentage(this.buffUsage)}%`}
+        label={`Buffs unused`}
+        tooltip={`
+          ${this.buffedIgnoreCasts} buffed ${SPELLS.IGNORE_PAIN.name} casts<br/>
+          ${this.buffedRevengeCasts} buffed ${SPELLS.REVENGE.name} casts<br/>
+          You refreshed your "${SPELLS.VENGEANCE_IGNORE_PAIN.name}" buff ${this.ignoreBuffsOverwritten} times<br/>
+          You refreshed your "${SPELLS.VENGEANCE_REVENGE.name}" buff ${this.revengeBuffsOverwritten} times
+        `}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(5);
+}
+
+export default Vengeance;

--- a/src/common/SPELLS/WARRIOR.js
+++ b/src/common/SPELLS/WARRIOR.js
@@ -434,6 +434,16 @@ export default {
     name: 'Deep Wounds',
     icon: 'ability_backstab',
   },
+  VENGEANCE_IGNORE_PAIN: {
+    id: 202574,
+    name: 'Vengeance: Ignore Pain',
+    icon: 'ability_warrior_unrelentingassault',
+  },
+  VENGEANCE_REVENGE: {
+    id: 202573,
+    name: 'Vengeance: Revenge',
+    icon: 'ability_warrior_unrelentingassault',
+  },
   //Relics
   // Protection Tier Sets
   // T21 2P Set Bonus


### PR DESCRIPTION
Adds a breakdown and a statistic for Vengeance usage (Ignore Pain reduces the rage cost of the next Revenge and Revenge the next rage cost of Ignore Pain).
Would've added the a "rage saved" value for Vengeance but WCL isn't sending the correct amount of rage for each cast (eg Revenge has always the 30 baseline cost and IP has 60 when not buffed and 46 when buffed (even when the player had 60+ rage)).
Will add that later on when I figured that out or when WCL is sending something back thats usable.

![image](https://user-images.githubusercontent.com/29842841/40280551-7af9c3d6-5c55-11e8-899a-f894db44d5ca.png)

![image](https://user-images.githubusercontent.com/29842841/40280466-37064696-5c54-11e8-82c0-9ea6d231ac3c.png)
