### PR TITLE
[Feral] Moved isOnGCD info to Abilities.js, added missing abilities

### DIFF
--- a/src/Parser/Druid/Feral/CHANGELOG.js
+++ b/src/Parser/Druid/Feral/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-05-23'),
+    changes: 'Corrected GCD tracking of Moonfire and instant Regrowth/Entangling Roots',
+    contributors: [Anatta336],
+  },
+  {
     date: new Date('2018-02-10'),
     changes: <React.Fragment><SpellLink id={SPELLS.PRIMAL_FURY.id} /> procs from an ability used at 4 CPs no longer count as 'wasted' CPs because it's not within the player's control. Also, <SpellLink id={SPELLS.PRIMAL_FURY.id} /> procs will no longer be shown in the Cooldowns tab.</React.Fragment>,
     contributors: [sref],

--- a/src/Parser/Druid/Feral/Modules/Features/Abilities.js
+++ b/src/Parser/Druid/Feral/Modules/Features/Abilities.js
@@ -9,38 +9,46 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.SHRED,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        isOnGCD: true,
       },
       {
         spell: SPELLS.RAKE,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        isOnGCD: true,
       },
       {
         spell: SPELLS.RIP,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        isOnGCD: true,
       },
       {
         spell: SPELLS.FEROCIOUS_BITE,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        isOnGCD: true,
       },
       {
         spell: SPELLS.SAVAGE_ROAR_TALENT,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         enabled: combatant.hasTalent(SPELLS.SAVAGE_ROAR_TALENT.id),
+        isOnGCD: true,
       },
       {
-        spell: SPELLS.MOONFIRE,
+        spell: SPELLS.MOONFIRE_FERAL,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         enabled: combatant.hasTalent(SPELLS.LUNAR_INSPIRATION_TALENT.id),
+        isOnGCD: true,
       },
 
       {
         spell: SPELLS.THRASH_FERAL,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
+        isOnGCD: true,
       },
       {
         spell: SPELLS.CAT_SWIPE,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
         enabled: !combatant.hasTalent(SPELLS.BRUTAL_SLASH_TALENT.id),
+        isOnGCD: true,
       },
       {
         spell: SPELLS.BRUTAL_SLASH_TALENT,
@@ -51,6 +59,7 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: true,
         },
+        isOnGCD: true,
       },
 
       {
@@ -62,6 +71,7 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: 0.90,
         },
+        isOnGCD: false,
       },
       {
         spell: SPELLS.BERSERK,
@@ -72,6 +82,7 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: 0.90,
         },
+        isOnGCD: false,
       },
       {
         spell: SPELLS.TIGERS_FURY,
@@ -80,6 +91,7 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: true,
         },
+        isOnGCD: false,
       },
       {
         spell: SPELLS.ASHAMANES_FRENZY,
@@ -88,6 +100,7 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: true,
         },
+        isOnGCD: true,
       },
       {
         spell: SPELLS.ELUNES_GUIDANCE_TALENT,
@@ -97,77 +110,118 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: true,
         },
+        isOnGCD: false,
       },
 
       {
         spell: SPELLS.REGROWTH,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
+        isOnGCD: true,
       },
       {
         spell: SPELLS.MAIM,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 10,
+        isOnGCD: true,
       },
       {
         spell: SPELLS.DASH,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 120,
+        isOnGCD: true,
       },
       {
         spell: SPELLS.SKULL_BASH_FERAL,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
+        isOnGCD: false,
       },
       {
         spell: SPELLS.SHADOWMELD,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 120,
         isUndetectable: true,
+        isOnGCD: false,
       },
       {
         spell: SPELLS.SURVIVAL_INSTINCTS,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         cooldown: 120,
         charges: 2,
+        isOnGCD: false,
       },
       {
         spell: SPELLS.REBIRTH,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
+        isOnGCD: true,
       },
       {
         spell: SPELLS.MIGHTY_BASH_TALENT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.MIGHTY_BASH_TALENT.id),
         cooldown: 50,
+        isOnGCD: true,
       },
       {
         spell: SPELLS.MASS_ENTANGLEMENT_TALENT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.MASS_ENTANGLEMENT_TALENT.id),
         cooldown: 30,
+        isOnGCD: true,
       },
       {
         spell: SPELLS.TYPHOON,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.TYPHOON_TALENT.id),
         cooldown: 30,
+        isOnGCD: true,
       },
       {
         spell: SPELLS.RENEWAL_TALENT,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         enabled: combatant.hasTalent(SPELLS.RENEWAL_TALENT.id),
         cooldown: 90,
+        isOnGCD: false,
       },
       {
         spell: SPELLS.DISPLACER_BEAST_TALENT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.DISPLACER_BEAST_TALENT.id),
         cooldown: 30,
+        isOnGCD: true,
       },
       {
         spell: [SPELLS.WILD_CHARGE_TALENT, SPELLS.WILD_CHARGE_MOONKIN, SPELLS.WILD_CHARGE_CAT, SPELLS.WILD_CHARGE_BEAR, SPELLS.WILD_CHARGE_TRAVEL],
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 15,
         enabled: combatant.hasTalent(SPELLS.WILD_CHARGE_TALENT.id),
+        isOnGCD: false,
+      },
+
+      {
+        spell: SPELLS.BEAR_FORM,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        isOnGCD: true,
+      },
+      {
+        spell: SPELLS.CAT_FORM,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        isOnGCD: true,
+      },
+      {
+        spell: SPELLS.MOONKIN_FORM,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        enabled: combatant.hasTalent(SPELLS.BALANCE_AFFINITY_TALENT_SHARED.id),
+        isOnGCD: true,
+      },
+      {
+        spell: SPELLS.TRAVEL_FORM,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        isOnGCD: true,
+      },
+      {
+        spell: SPELLS.STAG_FORM,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        isOnGCD: true,
       },
     ];
   }

--- a/src/Parser/Druid/Feral/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Druid/Feral/Modules/Features/AlwaysBeCasting.js
@@ -5,36 +5,38 @@ import CoreAlwaysBeCasting from 'Parser/Core/Modules/AlwaysBeCasting';
 import SPELLS from 'common/SPELLS';
 import { formatPercentage } from 'common/format';
 import { STATISTIC_ORDER } from 'Main/StatisticBox';
-// import SpellLink from 'common/SpellLink';
 
 class AlwaysBeCasting extends CoreAlwaysBeCasting {
 
+  // Feral has some spells with base GCD of 1500, some with 1000. The base 1000 spells are rotational, so show that until we can do both.
   static BASE_GCD = 1000;
-  static MINIMUM_GCD = 1000;
+  static MINIMUM_GCD = 750;
 
-  static ABILITIES_ON_GCD = [
-    SPELLS.RAKE.id,
-    SPELLS.RIP.id,
-    SPELLS.SHRED.id,
-    SPELLS.CAT_SWIPE.id,
-    SPELLS.FEROCIOUS_BITE.id,
-    SPELLS.SAVAGE_ROAR_TALENT.id,
-    SPELLS.ASHAMANES_FRENZY.id,
+  // Feral has abilities with 3 distinct GCD durations:
+ /* 1000 GCD reduced by haste
     SPELLS.REGROWTH.id,
-    SPELLS.MAIM.id,
-    SPELLS.THRASH_BEAR.id,
-
-    SPELLS.MIGHTY_BASH_TALENT.id,
-    SPELLS.DISPLACER_BEAST_TALENT.id,
-    SPELLS.TYPHOON_TALENT.id,
-    SPELLS.MASS_ENTANGLEMENT_TALENT.id,
-
+    SPELLS.ENTANGLING_ROOTS.id,
+    SPELLS.MOONFIRE_FERAL.id,
+  */
+ /* 1500 GCD reduced by haste
     SPELLS.BEAR_FORM.id,
     SPELLS.CAT_FORM.id,
     SPELLS.MOONKIN_FORM.id,
     SPELLS.TRAVEL_FORM.id,
     SPELLS.STAG_FORM.id,
-  ];
+  */
+  static STATIC_GCD_ABILITIES = {
+    [SPELLS.RAKE.id]: 1000,
+    [SPELLS.RIP.id]: 1000,
+    [SPELLS.SHRED.id]: 1000,
+    [SPELLS.FEROCIOUS_BITE.id]: 1000,
+    [SPELLS.SAVAGE_ROAR_TALENT.id]: 1000,
+    [SPELLS.ASHAMANES_FRENZY.id]: 1000,
+    [SPELLS.MAIM.id]: 1000,
+    [SPELLS.CAT_SWIPE.id]: 1000,
+    [SPELLS.THRASH_FERAL.id]: 1000,
+    [SPELLS.BRUTAL_SLASH_TALENT.id]: 1000,
+  };
 
   suggestions(when) {
     const deadTimePercentage = this.totalTimeWasted / this.owner.fightDuration;


### PR DESCRIPTION
Most core feral abilities are on a fixed 1000ms GCD, but a couple are on a 1000ms GCD which is reduced by haste. This is now reflected in the GCD tracking. I also replaced the deprecated ``ABILITIES_ON_GCD`` with ``isOnGCD: true`` in the spec's Abilities.

Some utility abilities such as shapeshifts are on a 1500ms GCD that gets reduced by haste. I believe this variation of base GCD can't be handled by the current global cooldown system (there's a TODO in Parser\Core\Modules\AlwaysBeCasting.js which would allow it.) Getting the rotational GCDs right seems more useful for players looking to optimise, so I've left the spec's base GCD as 1000ms.

Shapeshifts were missing from the abilities list, and moonfire wasn't using the correct id for the version cast from cat form.
