### PR TITLE
[Protection Warrior] proper rage tracking + breakdown & checklist

### DIFF
--- a/src/Parser/Core/Modules/ResourceTracker/ResourceBreakdown.js
+++ b/src/Parser/Core/Modules/ResourceTracker/ResourceBreakdown.js
@@ -106,7 +106,7 @@ class ResourceBreakdown extends React.Component {
                     <SpellLink id={ability.abilityId} />
                   </td>
                   <td style={{ width: 50, paddingRight: 5, textAlign: 'center' }}>
-                    <dfn data-tip={`${formatPercentage(ability.spent / totalSpent)} %`}>{ability.spent}</dfn>
+                    <dfn data-tip={`${formatPercentage(ability.spent / totalSpent)} %`}>{ability.spent.toFixed(0)}</dfn>
                   </td>
                   <td style={{ width: '40%' }}>
                     <div

--- a/src/Parser/Warrior/Protection/CHANGELOG.js
+++ b/src/Parser/Warrior/Protection/CHANGELOG.js
@@ -8,6 +8,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-05-23'),
+    changes: <React.Fragment>Made rage-tracking more accurate, added a rage usage breakdown, implemented checklist and added rage saved to <SpellLink id={SPELLS.VENGEANCE_TALENT.id} />.</React.Fragment>,
+    contributors: [joshinator],
+  },
+  {
     date: new Date('2018-05-20'),
     changes: <React.Fragment>Added <SpellLink id={SPELLS.VENGEANCE_TALENT.id} />.</React.Fragment>,
     contributors: [joshinator],

--- a/src/Parser/Warrior/Protection/CombatLogParser.js
+++ b/src/Parser/Warrior/Protection/CombatLogParser.js
@@ -10,6 +10,10 @@ import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
 import SpellUsable from './Modules/Features/SpellUsable';
 
 import Shield_Block from './Modules/Spells/ShieldBlock';
+import Checklist from './Modules/Features/Checklist';
+import IgnorePain from './Modules/Features/IgnorePain';
+import RageTracker from './Modules/Core/RageTracker';
+import RageDetails from './Modules/Core/RageDetails';
 
 import AngerManagement from './Modules/Talents/AngerManagement';
 import BoomingVoice from './Modules/Talents/BoomingVoice';
@@ -35,6 +39,10 @@ class CombatLogParser extends CoreCombatLogParser {
     shield_block: Shield_Block,
     deathRecapTracker: DeathRecapTracker,
     spellUsable: SpellUsable,
+    checklist: Checklist,
+    ignorePain: IgnorePain,
+    rageTracker: RageTracker,
+    rageDetails: RageDetails,
     //Talents
     angerManagement: AngerManagement,
     boomingVoice: BoomingVoice,

--- a/src/Parser/Warrior/Protection/Modules/Core/RageDetails.js
+++ b/src/Parser/Warrior/Protection/Modules/Core/RageDetails.js
@@ -1,0 +1,84 @@
+import React from 'react';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Tab from 'Main/Tab';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import { formatPercentage } from 'common/format';
+import Icon from 'common/Icon';
+import ResourceBreakdown from 'Parser/Core/Modules/ResourceTracker/ResourceBreakdown';
+
+import RageTracker from './RageTracker';
+
+class RageDetails extends Analyzer {
+  static dependencies = {
+    rageTracker: RageTracker,
+  };
+
+  get wastedPercent(){
+    return this.rageTracker.wasted / (this.rageTracker.wasted + this.rageTracker.generated) || 0;
+  }
+
+  get efficiencySuggestionThresholds() {
+    return {
+      actual: 1 - this.wastedPercent,
+      isLessThan: {
+        minor: 0.95,
+        average: 0.90,
+        major: .85,
+      },
+      style: 'percentage',
+    };
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.wastedPercent,
+      isGreaterThan: {
+        minor: 0.05,
+        average: 0.1,
+        major: .15,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+        return suggest(`You wasted ${formatPercentage(this.wastedPercent)}% of your Rage.`)
+          .icon('spell_nature_reincarnation')
+          .actual(`${formatPercentage(actual)}% wasted`)
+          .recommended(`<${formatPercentage(recommended)}% is recommended`);
+      });
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<Icon icon="spell_nature_reincarnation" />}
+        value={`${formatPercentage(this.wastedPercent)} %`}
+        label="Rage wasted"
+        tooltip={`${this.rageTracker.wasted} out of ${this.rageTracker.wasted + this.rageTracker.generated} Rage wasted.`}
+      />
+
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(3);
+
+  tab() {
+    return {
+      title: 'Rage usage',
+      url: 'rage-usage',
+      render: () => (
+        <Tab>
+          <ResourceBreakdown
+            tracker={this.rageTracker}
+            showSpenders
+          />
+        </Tab>
+      ),
+    };
+ }
+
+}
+
+export default RageDetails;

--- a/src/Parser/Warrior/Protection/Modules/Core/RageTracker.js
+++ b/src/Parser/Warrior/Protection/Modules/Core/RageTracker.js
@@ -1,0 +1,55 @@
+import Combatants from 'Parser/Core/Modules/Combatants';
+import RESOURCE_TYPES from 'common/RESOURCE_TYPES';
+import ResourceTracker from 'Parser/Core/Modules/ResourceTracker/ResourceTracker';
+import SPELLS from 'common/SPELLS';
+import SpellUsable from 'Parser/Core/Modules/SpellUsable';
+
+const VENGEANCE_RAGE_REDUCTION = 0.35; //percent
+const IGNORE_PAIN_MAX_COST = 60;
+
+class RageTracker extends ResourceTracker {
+  static dependencies = {
+    combatants: Combatants,
+    spellUsable: SpellUsable,
+  };
+
+  vengeanceRageSaved = 0;
+
+  on_initialized() {
+    this.resource = RESOURCE_TYPES.RAGE;
+  }
+
+  getReducedCost(event) {
+    if (!this.getResource(event).cost) {
+      return 0;
+    }
+    let cost = this.getResource(event).cost / 10;
+    const abilityId = event.ability.guid;
+    if (abilityId === SPELLS.REVENGE.id) {
+      if (this.combatants.selected.hasBuff(SPELLS.VENGEANCE_REVENGE.id, event.timestamp)) {
+        const newCost = cost * (1 - VENGEANCE_RAGE_REDUCTION);
+        this.vengeanceRageSaved += cost - newCost;
+        cost = newCost;
+      }
+    } else if (abilityId === SPELLS.IGNORE_PAIN.id) {
+      if (this.combatants.selected.hasBuff(SPELLS.VENGEANCE_IGNORE_PAIN.id, event.timestamp)) {
+        const currentRage = this.getResource(event).amount / 10;
+        const newCost = currentRage >= IGNORE_PAIN_MAX_COST * (1 - VENGEANCE_RAGE_REDUCTION) ? IGNORE_PAIN_MAX_COST * (1 - VENGEANCE_RAGE_REDUCTION) : currentRage;
+        const normalCost = currentRage >= IGNORE_PAIN_MAX_COST ? IGNORE_PAIN_MAX_COST : currentRage;
+
+        this.vengeanceRageSaved += normalCost - newCost;
+        cost = newCost;
+        //use either the max reduced max cost 39 Rage if enough rage was available or use all the available rage
+        //WCL return the wrong rage cost for a cast with Vengeance up (with 60+ rage available 46 instead of 39 (60 * 0.65))
+      }
+    }
+    return cost;
+  }
+
+  get rageSavedByVengeance() {
+    return this.vengeanceRageSaved.toFixed(0);
+  }
+
+}
+
+export default RageTracker;

--- a/src/Parser/Warrior/Protection/Modules/Features/Checklist.js
+++ b/src/Parser/Warrior/Protection/Modules/Features/Checklist.js
@@ -1,0 +1,131 @@
+import React from 'react';
+import SpellLink from 'common/SpellLink';
+import SPELLS from 'common/SPELLS';
+
+import CoreChecklist, { Rule, Requirement } from 'Parser/Core/Modules/Features/Checklist';
+import Abilities from 'Parser/Core/Modules/Abilities';
+import { PreparationRule } from 'Parser/Core/Modules/Features/Checklist/Rules';
+import { GenericCastEfficiencyRequirement } from 'Parser/Core/Modules/Features/Checklist/Requirements';
+import CastEfficiency from 'Parser/Core/Modules/CastEfficiency';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import LegendaryUpgradeChecker from 'Parser/Core/Modules/Items/LegendaryUpgradeChecker';
+import LegendaryCountChecker from 'Parser/Core/Modules/Items/LegendaryCountChecker';
+import PrePotion from 'Parser/Core/Modules/Items/PrePotion';
+import EnchantChecker from 'Parser/Core/Modules/Items/EnchantChecker';
+import AlwaysBeCasting from './AlwaysBeCasting';
+
+import Shield_Block from '../Spells/ShieldBlock';
+import IgnorePain from './IgnorePain';
+import RageDetails from '../Core/RageDetails';
+
+class Checklist extends CoreChecklist {
+  static dependencies = {
+    abilities: Abilities,
+    castEfficiency: CastEfficiency,
+    combatants: Combatants,
+    legendaryCountChecker: LegendaryCountChecker,
+    legendaryUpgradeChecker: LegendaryUpgradeChecker,
+    prePotion: PrePotion,
+    alwaysBeCasting: AlwaysBeCasting,
+    enchantChecker: EnchantChecker,
+
+    shieldBlock: Shield_Block,
+    ignorePain: IgnorePain,
+    rageDetails: RageDetails,
+  };
+
+  rules = [
+    new Rule({
+      name: 'Let the rage flow',
+      description: 'These should generally always be on cooldown to maximize rage generation while avoiding overcapping.',
+      requirements: () => {
+        return [
+          new GenericCastEfficiencyRequirement({
+            spell: SPELLS.SHIELD_SLAM,
+          }),
+          new GenericCastEfficiencyRequirement({
+            spell: SPELLS.THUNDER_CLAP,
+          }),
+          new Requirement({
+            name: 'Rage efficiency',
+            check: () => this.rageDetails.efficiencySuggestionThresholds,
+          }),
+        ];
+      },
+    }),
+
+    new Rule({
+      name: (
+        <React.Fragment>
+          Mitigate incoming damage with <SpellLink id={SPELLS.SHIELD_BLOCK.id} /> and <SpellLink id={SPELLS.IGNORE_PAIN.id} />
+        </React.Fragment>
+      ),
+      description: (
+        <React.Fragment>
+          Blocking incoming damage is our main mitigation tool.
+          Maintain <SpellLink id={SPELLS.SHIELD_BLOCK.id} /> as much as possible while tanking or dealing with mechanics that are blockable.
+          Avoid casting <SpellLink id={SPELLS.SHIELD_BLOCK.id} /> while not tanking actively to refill your charges. Spend your excess rage with <SpellLink id={SPELLS.IGNORE_PAIN.id} /> to smooth out damage, especially damage that's not blockable.
+        </React.Fragment>
+      ),
+      requirements: () => {
+        return [
+          new Requirement({
+            name: 'Hits mitigated with Shield Block up',
+            check: () => this.shieldBlock.suggestionThresholds,
+          }),
+          new Requirement({
+            name: <React.Fragment><SpellLink id={SPELLS.IGNORE_PAIN.id}/> Uptime</React.Fragment>,
+            check: () => this.ignorePain.uptimeSuggestionThresholds,
+          }),
+        ];
+      },  
+    }),
+
+    new Rule({
+      name: 'Use your offensive cooldowns',
+      description: 'You should aim to use these cooldowns as often as you can to maximize your damage output unless you are saving them for their defensive value.',
+      requirements: () => {
+        return [
+          new GenericCastEfficiencyRequirement({
+            spell: SPELLS.BATTLE_CRY,
+            onlyWithSuggestion: false,
+          }),
+          new GenericCastEfficiencyRequirement({
+            spell: SPELLS.DEMORALIZING_SHOUT,
+            when: this.combatants.selected.hasTalent(SPELLS.BOOMING_VOICE_TALENT.id),
+            onlyWithSuggestion: false,
+          }),
+        ];
+      },
+    }),
+
+    new Rule({
+      name: 'Use your defensive cooldowns',
+      description: 'Use these to block damage spikes and keep damage smooth to reduce external healing required.',
+      requirements: () => {
+        return [
+          new GenericCastEfficiencyRequirement({
+            spell: SPELLS.DEMORALIZING_SHOUT,
+            onlyWithSuggestion: false,
+          }),
+          new GenericCastEfficiencyRequirement({
+            spell: SPELLS.LAST_STAND,
+            onlyWithSuggestion: false,
+          }),
+          new GenericCastEfficiencyRequirement({
+            spell: SPELLS.SHIELD_WALL,
+            onlyWithSuggestion: false,
+          }),
+          new GenericCastEfficiencyRequirement({
+            spell: SPELLS.SPELL_REFLECTION,
+            onlyWithSuggestion: false,
+          }),
+        ];
+      },
+    }),
+
+    new PreparationRule(),
+  ]
+}
+
+export default Checklist;

--- a/src/Parser/Warrior/Protection/Modules/Features/IgnorePain.js
+++ b/src/Parser/Warrior/Protection/Modules/Features/IgnorePain.js
@@ -1,0 +1,28 @@
+import Analyzer from 'Parser/Core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+class IgnorePain extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  get uptime() {
+    return this.combatants.getBuffUptime(SPELLS.IGNORE_PAIN.id) / this.owner.fightDuration;
+  }
+
+
+  get uptimeSuggestionThresholds() {
+    return {
+      actual: this.uptime,
+      isLessThan: {
+        minor: 0.95,
+        average: 0.9,
+        major: .8,
+      },
+      style: 'percentage',
+    };
+  }
+}
+
+export default IgnorePain;

--- a/src/Parser/Warrior/Protection/Modules/Spells/ShieldBlock.js
+++ b/src/Parser/Warrior/Protection/Modules/Spells/ShieldBlock.js
@@ -57,17 +57,26 @@ class Shield_Block extends Analyzer {
     }
   }
 
-  suggestions(when) {
-    const physicalDamageMitigatedPercent = this.physicalDamageWithShield_Block / (this.physicalDamageWithShield_Block + this.physicalDamageWithoutShield_Block);
+  get suggestionThresholds() {
+    return {
+      actual: this.physicalDamageWithShield_Block / (this.physicalDamageWithShield_Block + this.physicalDamageWithoutShield_Block),
+      isLessThan: {
+        minor: 0.9,
+        average: 0.75,
+        major: 0.6,
+      },
+      style: 'percentage',
+    };
+  }
 
-    when(physicalDamageMitigatedPercent).isLessThan(0.90)
-      .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span>You only had the <SpellLink id={SPELLS.SHIELD_BLOCK_BUFF.id} /> buff for {formatPercentage(actual)}% of physical damage taken. You should have the Shield Block buff up to mitigate as much physical damage as possible.</span>)
-          .icon(SPELLS.SHIELD_BLOCK_BUFF.icon)
-          .actual(`${formatPercentage(actual)}% was mitigated by Shield Block`)
-          .recommended(`${Math.round(formatPercentage(recommended))}% or more is recommended`)
-          .regular(recommended - 0.10).major(recommended - 0.2);
-      });
+  suggestions(when) {
+    when(this.suggestionThresholds)
+        .addSuggestion((suggest, actual, recommended) => {
+          return suggest(<React.Fragment>You only had the <SpellLink id={SPELLS.SHIELD_BLOCK_BUFF.id} /> buff for {formatPercentage(actual)}% of physical damage taken. You should have the Shield Block buff up to mitigate as much physical damage as possible.</React.Fragment>)
+            .icon(SPELLS.SHIELD_BLOCK_BUFF.icon)
+            .actual(`${formatPercentage(actual)}% was mitigated by Shield Block`)
+            .recommended(`${Math.round(formatPercentage(recommended))}% or more is recommended`);
+        });
   }
 
   statistic() {

--- a/src/Parser/Warrior/Protection/Modules/Talents/Vengeance.js
+++ b/src/Parser/Warrior/Protection/Modules/Talents/Vengeance.js
@@ -7,10 +7,12 @@ import SpellLink from 'common/SpellLink';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import { formatPercentage } from 'common/format';
+import RageTracker from '../Core/RageTracker';
 
 class Vengeance extends Analyzer {
   static dependencies = {
     combatants: Combatants,
+    rageTracker: RageTracker,
   };
 
   buffedIgnoreCasts = 0;
@@ -84,7 +86,9 @@ class Vengeance extends Analyzer {
           ${this.buffedIgnoreCasts} buffed ${SPELLS.IGNORE_PAIN.name} casts<br/>
           ${this.buffedRevengeCasts} buffed ${SPELLS.REVENGE.name} casts<br/>
           You refreshed your "${SPELLS.VENGEANCE_IGNORE_PAIN.name}" buff ${this.ignoreBuffsOverwritten} times<br/>
-          You refreshed your "${SPELLS.VENGEANCE_REVENGE.name}" buff ${this.revengeBuffsOverwritten} times
+          You refreshed your "${SPELLS.VENGEANCE_REVENGE.name}" buff ${this.revengeBuffsOverwritten} times<br/><br/>
+
+          You saved <b>${this.rageTracker.rageSavedByVengeance}</b> Rage by casting ${SPELLS.IGNORE_PAIN.name} and ${SPELLS.REVENGE.name} with Vengeance up.
         `}
       />
     );

--- a/src/common/SPELLS/WARRIOR.js
+++ b/src/common/SPELLS/WARRIOR.js
@@ -350,6 +350,11 @@ export default {
     name: 'Thunder Clap',
     icon: 'spell_nature_thunderclap',
   },
+  RAGE: {
+    id: 195707,
+    name: 'Rage from damage taken',
+    icon: 'ability_racial_avatar',
+  },
   //Mitigation Spells
   IGNORE_PAIN: {
     id: 190456,


### PR DESCRIPTION
- adds rage tracker & rage breakdown (tracker adjusts the rage cost of Revenge and Ignore Pain when Vengeance is talented as WCL is sending wrong numbers)
- adds rage saved by using Vengeance
- adds a basic checklist

![image](https://user-images.githubusercontent.com/29842841/40430074-896ffd26-5ea4-11e8-8dd2-e09dd6f18a62.png)
![image](https://user-images.githubusercontent.com/29842841/40430086-9735af82-5ea4-11e8-9b24-9cde02249a5a.png)
![image](https://user-images.githubusercontent.com/29842841/40430106-a2c7e018-5ea4-11e8-8b9f-00e4bda7fcc3.png)
