### PR TITLE
[BFA] [BrM] Stagger Data Table

### DIFF
--- a/src/Parser/Monk/Brewmaster/CombatLogParser.js
+++ b/src/Parser/Monk/Brewmaster/CombatLogParser.js
@@ -27,6 +27,7 @@ import Abilities from './Modules/Features/Abilities';
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
 import DamageTakenTable from './Modules/Features/DamageTakenTable';
 import StaggerPoolGraph from './Modules/Features/StaggerPoolGraph';
+import StaggerTable from './Modules/Features/StaggerTable';
 // Items
 import T20_2pc from './Modules/Items/T20_2pc';
 import T20_4pc from './Modules/Items/T20_4pc';
@@ -58,6 +59,7 @@ class CombatLogParser extends CoreCombatLogParser {
     abilities: Abilities,
     damageTakenTable: DamageTakenTable,
     staggerPoolGraph: StaggerPoolGraph,
+    staggerTable: StaggerTable,
 
     // Spells
     ironSkinBrew: IronSkinBrew,

--- a/src/Parser/Monk/Brewmaster/Modules/Core/StaggerFabricator.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/StaggerFabricator.js
@@ -123,6 +123,7 @@ class StaggerFabricator extends Analyzer {
       type: type,
       amount: amount,
       newPooledDamage: this._staggerPool,
+      _reason: reason,
     };
   }
 

--- a/src/Parser/Monk/Brewmaster/Modules/Core/StaggerFabricator.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/StaggerFabricator.js
@@ -60,41 +60,45 @@ class StaggerFabricator extends Analyzer {
   }
 
   on_toPlayer_damage(event) {
-    if (event.ability.guid === SPELLS.STAGGER_TAKEN.id) {
-      const amount = event.amount + (event.absorbed || 0);
-
-      // fabricate absorb events for melee attacks. these are currently
-      // bugged in BFA but existed in Legion.
-      //
-      // There is ONE edge case that can cause errors to accumulate: if
-      // the sequence is MELEE -> PURIFY -> STAGGER TICK then the purify
-      // and melee absorb will be shown as the wrong amounts, but the
-      // stagger pool shouldn't drift because the absorb (aka damage
-      // added) will be missing the amount that was purified.
-      if(this._lastMelee) {
-        const amountAbsorbed = STAGGER_TICKS * amount - this._staggerPool;
-        this.owner.fabricateEvent(this._fabMelee(this._lastMelee, amountAbsorbed), event);
-        this._lastMelee = null;
-      }
-
-      this._staggerPool -= amount;
-      // sometimes a stagger tick is recorded immediately after death.
-      // this ensures we don't go into negative stagger
-      this._staggerPool = Math.max(this._staggerPool, 0);
-      debug && console.log("triggering stagger pool update due to stagger tick");
-      this.owner.fabricateEvent(this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount), event);
-    } else if (event.ability.guid === SPELLS.MELEE.id) {
+    if (event.ability.guid === SPELLS.MELEE.id) {
       this._lastMelee = event;
+      return;
     }
+    if (event.ability.guid !== SPELLS.STAGGER_TAKEN.id) {
+      return;
+    }
+    const amount = event.amount + (event.absorbed || 0);
+
+    // fabricate absorb events for melee attacks. these are currently
+    // bugged in BFA but existed in Legion.
+    //
+    // There is ONE edge case that can cause errors to accumulate: if
+    // the sequence is MELEE -> PURIFY -> STAGGER TICK then the purify
+    // and melee absorb will be shown as the wrong amounts, but the
+    // stagger pool shouldn't drift because the absorb (aka damage
+    // added) will be missing the amount that was purified.
+    if(this._lastMelee) {
+      const amountAbsorbed = STAGGER_TICKS * amount - this._staggerPool;
+      this.owner.fabricateEvent(this._fabMelee(this._lastMelee, amountAbsorbed), event);
+      this._lastMelee = null;
+    }
+
+    this._staggerPool -= amount;
+    // sometimes a stagger tick is recorded immediately after death.
+    // this ensures we don't go into negative stagger
+    this._staggerPool = Math.max(this._staggerPool, 0);
+    debug && console.log("triggering stagger pool update due to stagger tick");
+    this.owner.fabricateEvent(this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount), event);
   }
 
   on_byPlayer_cast(event) {
-    if (event.ability.guid === SPELLS.PURIFYING_BREW.id) {
-      const amount = this._staggerPool * this.purifyPercentage;
-      this._staggerPool -= amount;
-      debug && console.log("triggering stagger pool update due to purify");
-      this.owner.fabricateEvent(this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount), event);
-    } // leaving this as an IF because i expect an ELSE from azerite traits
+    if (event.ability.guid !== SPELLS.PURIFYING_BREW.id) {
+      return;
+    }
+    const amount = this._staggerPool * this.purifyPercentage;
+    this._staggerPool -= amount;
+    debug && console.log("triggering stagger pool update due to purify");
+    this.owner.fabricateEvent(this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount), event);
   }
 
   on_toPlayer_death(event) {

--- a/src/Parser/Monk/Brewmaster/Modules/Features/Abilities.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/Abilities.js
@@ -142,6 +142,15 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.PARALYSIS,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
       },
+      {
+        spell: SPELLS.EXPLODING_KEG,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        cooldown: 75,
+        enabled: !!combatant.getItem(ITEMS.FU_ZAN_THE_WANDERERS_COMPANION.id),
+        castEfficiency: {
+          suggestion: true,
+        },
+      },
       // Its unlikely that these spells will ever be cast but if they are they will show.
       {
         spell: SPELLS.DETOX,

--- a/src/Parser/Monk/Brewmaster/Modules/Features/StaggerTable.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/StaggerTable.js
@@ -1,0 +1,128 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import StatTracker from 'Parser/Core/Modules/StatTracker';
+import Tab from 'Main/Tab';
+import SPELLS from 'common/SPELLS';
+import SCHOOLS from 'common/MAGIC_SCHOOLS';
+import SpellLink from 'common/SpellLink';
+import Icon from 'common/Icon';
+import { formatNumber, formatPercentage } from 'common/format';
+
+class StaggerTable extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    stats: StatTracker,
+  };
+
+  _isUsingHT = false;
+  _staggerEvent = null;
+  _staggerData = [];
+
+  get tableData() {
+    return this._staggerData;
+  }
+
+  on_toPlayer_damage(event) {
+    if(event.ability.guid === SPELLS.STAGGER_TAKEN.id || event.ability.guid === SPELLS.MELEE.id) {
+      return;
+    }
+    if(!this._staggerEvent) {
+      console.error("Damage event occurred without any associated stagger absorb", event);
+      return;
+    } 
+    if(event.timestamp !== this._staggerEvent.timestamp) {
+      this._staggerEvent = null; // we've passed the point where the staggered damage occurred, so clear it and move on
+      return;
+    }
+    this._pushStaggerDatum(event);
+  }
+
+  on_addstagger(event) {
+    if(event._reason.ability.guid === SPELLS.MELEE.id) {
+      return;
+    }
+    this._staggerEvent = event;
+  }
+
+  _pushStaggerDatum(dmgEvent) {
+    const absorbEvent = this._staggerEvent;
+    this._staggerEvent = null;
+    this._staggerData.push({
+      timestamp: absorbEvent.timestamp,
+      amount: absorbEvent.amount,
+      hasISB: this.combatants.selected.hasBuff(SPELLS.IRONSKIN_BREW_BUFF.id, absorbEvent.timestamp),
+      rawDamage: dmgEvent.amount + (dmgEvent.absorbed || 0),
+      abilityId: dmgEvent.ability.guid,
+      abilityType: dmgEvent.ability.type,
+      ability: dmgEvent.ability,
+      percentAbsorbed: absorbEvent.amount / (dmgEvent.amount + dmgEvent.absorbed),
+      agility: this.stats.currentAgilityRating,
+      hasHT: this._isUsingHT,
+    });
+  }
+
+  _staggerCSV() {
+    const keys = [
+      'timestamp',
+      'abilityId',
+      'abilityType',
+      'amount',
+      'rawDamage',
+      'percentAbsorbed',
+      'agility',
+      'hasISB',
+      'hasHT',
+    ];
+    const csvText = this._staggerData.map(datum => keys.map(k => String(datum[k])).join(',')).join('\n');
+    return "data:text/plain;base64," + btoa(keys.join(',') + '\n' + csvText);
+  }
+
+  tab() {
+    return {
+      title: 'Staggered Hits',
+      url: 'staggered-hits',
+      render: () => (
+        <Tab>
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>Ability</th>
+                <th>Amount Absorbed</th>
+                <th>Total Hit</th>
+                <th>%</th>
+                <th>Agility</th>
+                <th>Was <SpellLink id={SPELLS.IRONSKIN_BREW.id} />?</th>
+                <th>Physical?</th>
+              </tr>
+            </thead>
+            <tbody>
+              {
+                this.tableData.map((datum, i) => (
+                  <tr key={i}>
+                    <td>
+                      <SpellLink id={datum.ability.guid} icon={false}>
+                        <Icon icon={datum.ability.abilityIcon} alt={datum.ability.name} /> {datum.ability.name}
+                      </SpellLink>
+                    </td>
+                    <td>{formatNumber(datum.amount)}</td>
+                    <td>{formatNumber(datum.rawDamage)}</td>
+                    <td>{formatPercentage(datum.percentAbsorbed)}%</td>
+                    <td>{formatNumber(datum.agility)}</td>
+                    <td>{datum.hasISB ? "Yes" : "No"}</td>
+                    <td>{(datum.ability.type === SCHOOLS.ids.PHYSICAL) ? "Yes" : "No"}</td>
+                  </tr>
+                ))
+              }
+            </tbody>
+          </table>
+          <div style={{padding: "10px"}}>
+            <a download="stagger.csv" href={this._staggerCSV()}>Download CSV</a>
+          </div>
+        </Tab>
+      ),
+    };
+  }
+}
+
+export default StaggerTable;

--- a/src/common/ITEMS/MONK.js
+++ b/src/common/ITEMS/MONK.js
@@ -9,6 +9,13 @@ export default {
     quality: ITEM_QUALITIES.LEGENDARY,
   },
 
+  // Brewmaster Artifact
+  FU_ZAN_THE_WANDERERS_COMPANION: {
+    id: 128938,
+    name: 'Fu Zan, the Wanderer\'s Companion',
+    icon: 'inv_staff_2h_artifactmonkeyking_d_01',
+    quality: ITEM_QUALITIES.ARTIFACT,
+  },
   // Brewmaster legendaries
   FIRESTONE_WALKERS: {
     id: 137027,


### PR DESCRIPTION
Two things in this PR:

1. Addressed @Gebuz's comments from my previous PR that I wanted to get in quickly so it'd be functional for early testing (and that I didnt have much time to work on in the last couple weeks because of IRL deadlines).
2. Added a stagger events table. The tl;dr on this is that we have literally no idea how the stagger formula works right now, and this gives valuable data as output with a downloadable CSV. Once we do know the formula, the table will be removed and the machinery merged into other things where appropriate.

![screenshot from 2018-05-26 21-54-56](https://user-images.githubusercontent.com/4909458/40581857-f36684b4-6130-11e8-94b7-04079e98f51a.png)