### PR TITLE
[Core] Death recap fix for different spellIds

### DIFF
--- a/src/Main/DeathRecapTracker.js
+++ b/src/Main/DeathRecapTracker.js
@@ -49,12 +49,12 @@ class DeathRecapTracker extends Analyzer {
     extendedEvent.cooldownsAvailable = cooldownsOnly.filter(e => this.spellUsable.isAvailable(e.spell.id));
     extendedEvent.cooldownsUsed = cooldownsOnly.filter(e => !this.spellUsable.isAvailable(e.spell.id));
     if (event.hitPoints > 0) {
-      this.lastBuffs = this.buffs.filter(e => this.combatants.selected.hasBuff(e.spell.buffSpellId) || this.combatants.selected.hasBuff(e.spell.id));
+      this.lastBuffs = this.buffs.filter(e => this.combatants.selected.hasBuff(e.buffSpellId) || this.combatants.selected.hasBuff(e.spell.id));
     }
     extendedEvent.buffsUp = this.lastBuffs;
 
     if (!event.sourceIsFriendly && this.enemies.enemies[event.sourceID]) {
-      const sourceHasDebuff = debuff => (!debuff.end || event.timestamp <= debuff.end) && event.timestamp >= debuff.start && debuff.isDebuff && this.buffs.some(e => e.spell.id === debuff.ability.guid || e.spell.buffSpellId === debuff.ability.guid);
+      const sourceHasDebuff = debuff => (!debuff.end || event.timestamp <= debuff.end) && event.timestamp >= debuff.start && debuff.isDebuff && this.buffs.some(e => e.buffSpellId === debuff.ability.guid || e.spell.id === debuff.ability.guid);
       extendedEvent.debuffsUp = this.enemies.enemies[event.sourceID].buffs.filter(sourceHasDebuff);
     }
 

--- a/src/Parser/Monk/Brewmaster/Modules/Features/Abilities.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/Abilities.js
@@ -36,6 +36,7 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.BREATH_OF_FIRE,
+        isDefensive: true,
         buffSpellId: SPELLS.BREATH_OF_FIRE_DEBUFF.id,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         cooldown: 15,


### PR DESCRIPTION
Checked previously in the spell for the prop `buffSpellId`, which would always return undefined and then check if the spells ID.