### PR TITLE
[Restoration Shaman] Healing Rain tick calculation change

### DIFF
--- a/src/Parser/Shaman/Restoration/Modules/Spells/HealingRain.js
+++ b/src/Parser/Shaman/Restoration/Modules/Spells/HealingRain.js
@@ -8,16 +8,20 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 import Analyzer from 'Parser/Core/Analyzer';
 
+// 50 was too low, 100 was too high
+// had no issues with 85ms
+const BUFFER_MS = 85;
+
 class HealingRain extends Analyzer {
   static dependencies = {
     combatants: Combatants,
   };
 
-  HealingRainTicks = [];
+  healingRainTicks = [];
 
   get averageHitsPerTick() {
-    const totalHits = this.HealingRainTicks.reduce((total, x) => total + x.hits, 0);
-    return totalHits / this.HealingRainTicks.length;
+    const totalHits = this.healingRainTicks.reduce((total, tick) => total + tick.hits, 0);
+    return totalHits / this.healingRainTicks.length;
   }
 
   suggestions(when) {
@@ -46,17 +50,18 @@ class HealingRain extends Analyzer {
 
   on_byPlayer_heal(event) {
     const spellId = event.ability.guid;
-    if (spellId === SPELLS.HEALING_RAIN_HEAL.id) {
-      const healingRainTick = this.HealingRainTicks.filter(x => x.id === event.timestamp);
-      if (healingRainTick.length > 0) {
-        healingRainTick[0].hits = healingRainTick[0].hits + 1;
-      }
-      else {
-        this.HealingRainTicks.push({
-          id: event.timestamp,
-          hits: 1,
-        });
-      }
+    if (spellId !== SPELLS.HEALING_RAIN_HEAL.id) {
+      return;
+    }
+
+    const healingRainTick = this.healingRainTicks.find(tick => event.timestamp - BUFFER_MS <= tick.timestamp);
+    if (!healingRainTick) {
+      this.healingRainTicks.push({
+        timestamp: event.timestamp,
+        hits: 1,
+      });
+    } else {
+      healingRainTick.hits = healingRainTick.hits + 1;
     }
   }
 

--- a/src/Parser/Shaman/Restoration/Modules/Spells/HealingRain.test.js
+++ b/src/Parser/Shaman/Restoration/Modules/Spells/HealingRain.test.js
@@ -1,0 +1,45 @@
+import SPELLS from 'common/SPELLS';
+
+import HealingRain from './HealingRain';
+
+describe('Shaman/Restoration/Modules/Spells/HealingRain', () => {
+  const events = [
+    // Tick 1
+    { type: 'heal',  timestamp: 1, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+    { type: 'heal',  timestamp: 2, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+    { type: 'heal',  timestamp: 3, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+    { type: 'heal',  timestamp: 4, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+    { type: 'heal',  timestamp: 5, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+    { type: 'heal',  timestamp: 6, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+    // Tick 2
+    { type: 'heal',  timestamp: 100, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+    { type: 'heal',  timestamp: 100, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+    { type: 'heal',  timestamp: 100, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+    { type: 'heal',  timestamp: 100, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+    { type: 'heal',  timestamp: 100, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+    // Tick 3
+    { type: 'heal',  timestamp: 190, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+    { type: 'heal',  timestamp: 230, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+    { type: 'heal',  timestamp: 230, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+    { type: 'heal',  timestamp: 230, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+    { type: 'heal',  timestamp: 230, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+    { type: 'heal',  timestamp: 235, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+    // Tick 4
+    { type: 'heal',  timestamp: 340, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+    { type: 'heal',  timestamp: 350, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+    // Tick 5
+    { type: 'heal',  timestamp: 426, ability: { guid: SPELLS.HEALING_RAIN_HEAL.id } },
+  ];
+
+
+  it(`can detect ticks`, () => {
+    const healingRain = new HealingRain();
+    events.forEach(event => {
+      healingRain.on_byPlayer_heal(event);
+    });
+    
+    expect(healingRain.healingRainTicks.length).toEqual(5);
+    expect(healingRain.averageHitsPerTick).toEqual(4);
+  });
+
+});


### PR DESCRIPTION
Currently the healing rain module divides ticks by looking at the exact millisecond, but looking at logs it appears that ticks can be split up a bit (seen up to 83ms). Often you have 1 hit followed by 5 hits within 5ms, which it currently interprets as 2 different sets of ticks even though its just 1.
I gave it a buffer of 85ms to correct that behaviour, and average ticks went up in all logs as you'd expect, and checking the array i haven't found wrong groupings.

Varimathras rank 1 log where you'd expect 6 hits per tick (before & after):
![image](https://user-images.githubusercontent.com/2842471/40590438-238bee94-61ff-11e8-9c0e-78c3e9c80cb7.png)![image](https://user-images.githubusercontent.com/2842471/40590441-31acd9d4-61ff-11e8-9604-9badac504861.png)
Argus (again you'd expect high amount of hits):
![image](https://user-images.githubusercontent.com/2842471/40590459-6d8b15c4-61ff-11e8-9fee-804ecce184cf.png)![image](https://user-images.githubusercontent.com/2842471/40590456-6884e050-61ff-11e8-9914-803932f0de65.png)
Kingaroth:
![image](https://user-images.githubusercontent.com/2842471/40590485-d8db94b6-61ff-11e8-95ac-dbfaa2123754.png)![image](https://user-images.githubusercontent.com/2842471/40590489-e1c6e0bc-61ff-11e8-81b5-ed2ffa6f0c5e.png)

