### PR TITLE
[Feral] Snapshot Tracking for Rake

### DIFF
--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -328,6 +328,8 @@ export const HawkCorrigan = {
 };
 export const Anatta336 = {
   nickname: 'Anatta336',
+  github: 'Anatta336',
+  discord: 'Anatta#5878',
 };
 export const Herusx = {
   nickname: 'Herusx',

--- a/src/Parser/Druid/Feral/CHANGELOG.js
+++ b/src/Parser/Druid/Feral/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-05-28'),
+    changes: <React.Fragment>Added snapshot tracking for <SpellLink id={SPELLS.RAKE.id} /></React.Fragment>,
+    contributors: [Anatta336],
+  },
+  {
     date: new Date('2018-05-23'),
     changes: 'Corrected GCD tracking of Moonfire and instant Regrowth/Entangling Roots',
     contributors: [Anatta336],

--- a/src/Parser/Druid/Feral/CombatLogParser.js
+++ b/src/Parser/Druid/Feral/CombatLogParser.js
@@ -7,6 +7,7 @@ import CooldownThroughputTracker from './Modules/Features/CooldownThroughputTrac
 import RakeUptime from './Modules/Bleeds/RakeUptime';
 import RipUptime from './Modules/Bleeds/RipUptime';
 import FerociousBiteEnergy from './Modules/Features/FerociousBiteEnergy';
+import RakeSnapshot from './Modules/Bleeds/RakeSnapshot';
 
 import ComboPointTracker from './Modules/ComboPoints/ComboPointTracker';
 import ComboPointDetails from './Modules/ComboPoints/ComboPointDetails';
@@ -33,6 +34,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // bleeds
     rakeUptime: RakeUptime,
     ripUptime: RipUptime,
+    rakeSnapshot: RakeSnapshot,
 
     // talents
     savageRoarUptime: SavageRoarUptime,

--- a/src/Parser/Druid/Feral/Modules/Bleeds/RakeSnapshot.js
+++ b/src/Parser/Druid/Feral/Modules/Bleeds/RakeSnapshot.js
@@ -1,0 +1,125 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import { formatPercentage } from 'common/format';
+import Snapshot, { JAGGED_WOUNDS_MODIFIER } from '../FeralCore/Snapshot';
+
+/*
+Identify inefficient refreshes of the Rake DoT:
+  Refresh of a Rake doing double damage due to Prowl with one that will not do double damage.
+  Early refresh of a Rake doing bonus damage from snapshot buffs with one that will do less damage.
+*/
+
+const RAKE_BASE_DURATION = 15000;
+class RakeSnapshot extends Snapshot {
+  rakeCastCount = 0;        // count of rake casts of all kinds
+  prowlLostCastCount = 0;   // count of rake buffed with Prowl ending early due to refresh without Prowl buff
+  prowlLostTimeSum = 0;     // total time cut out from the end of prowl-buffed rake bleeds by refreshing early (milliseconds)
+  downgradeCastCount = 0;   // count of rake DoTs refreshed with weaker snapshot before pandemic
+
+  hasBloodtalonsTalent = false;
+
+  on_initialized() {
+    this.spellCastId = SPELLS.RAKE.id;
+    this.durationOfFresh = RAKE_BASE_DURATION;
+    this.isProwlAffected = true;
+    this.isTigersFuryAffected = true;
+
+    const combatant = this.combatants.selected;
+    if (combatant.hasTalent(SPELLS.BLOODTALONS_TALENT.id)) {
+      this.isBloodtalonsAffected = true;
+      this.hasBloodtalonsTalent = true;
+    }
+    if (combatant.hasTalent(SPELLS.JAGGED_WOUNDS_TALENT.id)) {
+      this.durationOfFresh *= JAGGED_WOUNDS_MODIFIER;
+    }
+  }
+
+  on_byPlayer_cast(event) {
+    if (SPELLS.RAKE.id === event.ability.guid) {
+      ++this.rakeCastCount;
+    }
+
+    super.on_byPlayer_cast(event);
+  }
+
+  checkRefreshRule(event, stateOld, stateNew) {
+    if (stateOld.prowl && !stateNew.prowl) {
+      // refresh removed a powerful prowl-buffed bleed
+      const timeLost = stateOld.expireTime - event.timestamp;
+      this.prowlLostTimeSum += timeLost;
+      ++this.prowlLostCastCount;
+
+      event.meta = event.meta || {};
+      event.meta.isInefficientCast = true;
+      event.meta.inefficientCastReason = `You lost ${(timeLost / 1000).toFixed(1)} seconds of a Rake empowered with Prowl by refreshing early.`;
+    } else if (stateOld.pandemicTime > event.timestamp &&
+      stateOld.power > stateNew.power &&
+      !stateNew.hasProwl) {
+      // refreshed with weaker DoT before pandemic window - but ignore this rule if the new Rake has Prowl buff as that's more important.
+      ++this.downgradeCastCount;
+
+      if (!event.meta || (!event.meta.isInefficientCast && !event.meta.isEnhancedCast)) {
+        // this downgrade is relatively minor, so don't overwrite output from elsewhere.
+        event.meta = event.meta || {};
+        event.meta.isInefficientCast = true;
+        event.meta.inefficientCastReason = `You refreshed with a weaker version of Rake before the pandemic window.`;
+      }
+    }
+  }
+
+  // seconds of double-damage Rake lost per minute
+  get prowlLostTimePerMinute() {
+    return (this.prowlLostTimeSum / this.owner.fightDuration) * 60;
+  }
+  get downgradeProportion() {
+    return this.downgradeCastCount / this.rakeCastCount;
+  }
+  get prowlLostSuggestionThresholds() {
+    return {
+      actual: this.prowlLostTimePerMinute,
+      isGreaterThan: {
+        minor: 0,
+        average: 1.0,
+        major: 3.0,
+      },
+      style: 'decimal',
+    };
+  }
+  get downgradeSuggestionThresholds() {
+    return {
+      actual: this.downgradeProportion,
+      isGreaterThan: {
+        minor: 0,
+        average: 0.15,
+        major: 0.30,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.prowlLostSuggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <React.Fragment>
+          You sometimes replaced a powerful <SpellLink id={SPELLS.RAKE.id} /> cast with the <SpellLink id={SPELLS.PROWL.id} /> effect with one without it. You ended {this.prowlLostCastCount} empowered <SpellLink id={SPELLS.RAKE.id} /> bleed{this.prowlLostCastCount!==1?'s':''} early.
+        </React.Fragment>
+      )
+        .icon(SPELLS.RAKE.icon)
+        .actual(`${actual.toFixed(1)} seconds of Prowl buffed Rake bleed was lost per minute.`)
+        .recommended(`${recommended} is recommended`);
+    });
+
+    when(this.downgradeSuggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <React.Fragment>
+          <SpellLink id={SPELLS.RAKE.id} /> DoT was replaced with a less powerful version without waiting for the pandemic window. <SpellLink id={SPELLS.RAKE.id} /> snapshots the bonus from <SpellLink id={SPELLS.PROWL.id} />, <SpellLink id={SPELLS.BLOODTALONS_TALENT.id}/>, and <SpellLink id={SPELLS.TIGERS_FURY.id} />.
+        </React.Fragment>
+      )
+        .icon(SPELLS.RAKE.icon)
+        .actual(`${formatPercentage(actual)}% of Rake casts caused early downgrading.`)
+        .recommended(`${recommended}% is recommended`);
+    });
+  }
+}
+export default RakeSnapshot;

--- a/src/Parser/Druid/Feral/Modules/Bleeds/RakeSnapshot.js
+++ b/src/Parser/Druid/Feral/Modules/Bleeds/RakeSnapshot.js
@@ -2,7 +2,7 @@ import React from 'react';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
-import Snapshot, { JAGGED_WOUNDS_MODIFIER } from '../FeralCore/Snapshot';
+import Snapshot, { JAGGED_WOUNDS_MODIFIER, PANDEMIC_FRACTION } from '../FeralCore/Snapshot';
 
 /*
 Identify inefficient refreshes of the Rake DoT:
@@ -102,22 +102,22 @@ class RakeSnapshot extends Snapshot {
     when(this.prowlLostSuggestionThresholds).addSuggestion((suggest, actual, recommended) => {
       return suggest(
         <React.Fragment>
-          You sometimes replaced a powerful <SpellLink id={SPELLS.RAKE.id} /> cast with the <SpellLink id={SPELLS.PROWL.id} /> effect with one without it. You ended {this.prowlLostCastCount} empowered <SpellLink id={SPELLS.RAKE.id} /> bleed{this.prowlLostCastCount!==1?'s':''} early.
+          When <SpellLink id={SPELLS.RAKE.id} /> is empowered by <SpellLink id={SPELLS.PROWL.id} /> avoid refreshing it unless the replacement would also be empowered. You ended {this.prowlLostCastCount} empowered <SpellLink id={SPELLS.RAKE.id} /> bleed{this.prowlLostCastCount!==1?'s':''} early.
         </React.Fragment>
       )
         .icon(SPELLS.RAKE.icon)
-        .actual(`${actual.toFixed(1)} seconds of Prowl buffed Rake bleed was lost per minute.`)
+        .actual(`${actual.toFixed(1)} seconds of Prowl buffed Rake was lost per minute.`)
         .recommended(`${recommended} is recommended`);
     });
 
     when(this.downgradeSuggestionThresholds).addSuggestion((suggest, actual, recommended) => {
       return suggest(
         <React.Fragment>
-          <SpellLink id={SPELLS.RAKE.id} /> DoT was replaced with a less powerful version without waiting for the pandemic window. <SpellLink id={SPELLS.RAKE.id} /> snapshots the bonus from <SpellLink id={SPELLS.PROWL.id} />, <SpellLink id={SPELLS.BLOODTALONS_TALENT.id}/>, and <SpellLink id={SPELLS.TIGERS_FURY.id} />.
+          Try to only refresh <SpellLink id={SPELLS.RAKE.id} /> before the <dfn data-tip={`The last ${(this.durationOfFresh * PANDEMIC_FRACTION / 1000).toFixed(1)} seconds of Rake's duration. When you refresh during this time you don't lose any duration in the process.`}>pandemic window</dfn> if you have more powerful <dfn data-tip={"Applying Rake with Prowl, Tiger's Fury or Bloodtalons will boost its damage until you reapply it."}>snapshot buffs</dfn> than were present when it was first cast.
         </React.Fragment>
       )
         .icon(SPELLS.RAKE.icon)
-        .actual(`${formatPercentage(actual)}% of Rake casts caused early downgrading.`)
+        .actual(`${formatPercentage(actual)}% of Rake refreshes were early downgrades.`)
         .recommended(`${recommended}% is recommended`);
     });
   }

--- a/src/Parser/Druid/Feral/Modules/FeralCore/Snapshot.js
+++ b/src/Parser/Druid/Feral/Modules/FeralCore/Snapshot.js
@@ -1,0 +1,127 @@
+import SPELLS from 'common/SPELLS';
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import { encodeTargetString } from 'Parser/Core/Modules/EnemyInstances';
+
+const debug = false;
+
+/*
+Feral has a snapshotting mechanic which means the effect of some buffs are maintained over the duration of
+some DoTs even after the buff has worn off.
+Players should follow a number of rules with regards when they refresh a DoT and when they do not, depending
+on what buffs the DoT has snapshot and what buffs are currently active.
+
+RAKE snapshots:
+  Prowl, Tiger's Fury, Bloodtalons
+RIP snapshots:
+  Tiger's Fury, Bloodtalons
+MOONFIRE_FERAL snapshots:
+  Tiger's Fury
+THRASH_FERAL snapshots: (but isn't used in single target situations)
+  Tiger's Fury, Moment of Clarity
+
+The Snapshot class is 'abstract', and shouldn't be directly instantiated. Instead classes should extend
+it and test how well the combatant is making use of the snapshot mechanic.
+*/
+
+const TIGERS_FURY_MULTIPLIER = 1.15;
+const PROWL_MULTIPLIER = 2.00; // also applied by Incarnation: King of the Jungle, and Shadowmeld
+const BLOODTALONS_MULTIPLIER = 1.20;
+
+const JAGGED_WOUNDS_MODIFIER = 0.80;  // "[...]deal the same damage as normal but in 20% less time."
+const PANDEMIC_FRACTION = 0.3;
+
+// leeway in ms after loss of bloodtalons/prowl buff to count a cast as being buffed. Keep well below GCD to avoid false positives.
+const BUFF_WINDOW_TIME = 300;
+
+class Snapshot extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  // extending class should fill these in:
+  spellCastId;
+  isProwlAffected;
+  isTigersFuryAffected;
+  isBloodtalonsAffected;
+  durationOfFresh;
+
+  // initialised to before combat log starts to avoid false positives
+  bloodtalonsFadedAt = -10000;
+  prowlFadedAt = -10000;
+
+  stateByTarget = [];
+
+  // It's common for buffs that are consumed by an ability to be reported as not present when the ability's event is processed.
+  // So record when the buff wears off, and if that's sufficiently close to the ability being used we can assume it was active.
+  on_byPlayer_removebuff(event) {
+    const spellId = event.ability.guid;
+    if (this.isProwlAffected && (
+        SPELLS.PROWL.id === spellId ||
+        SPELLS.PROWL_INCARNATION.id === spellId || 
+        SPELLS.SHADOWMELD.id === spellId)) {
+      this.prowlFadedAt = event.timestamp;
+    } else if (this.isBloodtalonsAffected && SPELLS.BLOODTALONS_BUFF.id === spellId) {
+      this.bloodtalonsFadedAt = event.timestamp;
+    }
+  }
+
+  on_byPlayer_cast(event) {
+    if (this.spellCastId !== event.ability.guid) {
+      return;
+    }
+    this.dotApplied(event);
+  }
+
+  dotApplied(event) {
+    const targetString = encodeTargetString(event.targetID, event.targetInstance);
+    const stateOld = this.stateByTarget[targetString];
+    const timeRemainOnOld = stateOld ? (stateOld.expireTime - event.timestamp) : 0;
+    const stateNew = this.makeNewState(event, timeRemainOnOld);
+    this.stateByTarget[targetString] = stateNew;
+    debug && console.log(`DoT ${this.spellCastId} applied at ${this.owner.formatTimestamp(event.timestamp)} Prowl:${stateNew.prowl}, TF: ${stateNew.tigersFury}, BT: ${stateNew.bloodtalons}. Expires at ${this.owner.formatTimestamp(stateNew.expireTime)}, pandemic from: ${this.owner.formatTimestamp(stateNew.pandemicTime)}`);
+
+    if (timeRemainOnOld > 0) {
+      this.checkRefreshRule(event, stateOld, stateNew);
+    }
+  }
+
+  makeNewState(event, timeRemainOnOld) {
+    const combatant = this.combatants.selected;
+
+    let expireNew = event.timestamp + this.durationOfFresh;
+    if (timeRemainOnOld > 0) {
+      expireNew += Math.min(this.durationOfFresh * PANDEMIC_FRACTION, timeRemainOnOld);
+    }
+
+    const stateNew = {
+      expireTime: expireNew,
+      pandemicTime: expireNew - this.durationOfFresh * PANDEMIC_FRACTION, // after this time the DoT is in the "pandemic window"
+      tigersFury: false,
+      prowl: false,
+      bloodtalons: false,
+      power: 1,
+    };
+    if (this.isProwlAffected && (combatant.hasBuff(SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id, event.timestamp) ||
+        event.timestamp < this.prowlFadedAt + BUFF_WINDOW_TIME)) {
+      stateNew.prowl = true;
+      stateNew.power *= PROWL_MULTIPLIER;
+    }
+    if (this.isTigersFuryAffected && combatant.hasBuff(SPELLS.TIGERS_FURY.id, event.timestamp)) {
+      stateNew.tigersFury = true;
+      stateNew.power *= TIGERS_FURY_MULTIPLIER;
+    }
+    if (this.isBloodtalonsAffected && (combatant.hasBuff(SPELLS.BLOODTALONS_BUFF.id, event.timestamp) ||
+        event.timestamp < this.bloodtalonsFadedAt + BUFF_WINDOW_TIME)) {
+      stateNew.bloodtalons = true;
+      stateNew.power *= BLOODTALONS_MULTIPLIER;
+    }
+    return stateNew;
+  }
+
+  checkRefreshRule(event, stateOld, stateNew) {
+    debug && console.warn('Expected checkRefreshRule function to be overridden.');
+  }
+}
+export default Snapshot;
+export { JAGGED_WOUNDS_MODIFIER };

--- a/src/Parser/Druid/Feral/Modules/FeralCore/Snapshot.js
+++ b/src/Parser/Druid/Feral/Modules/FeralCore/Snapshot.js
@@ -124,4 +124,4 @@ class Snapshot extends Analyzer {
   }
 }
 export default Snapshot;
-export { JAGGED_WOUNDS_MODIFIER };
+export { JAGGED_WOUNDS_MODIFIER, PANDEMIC_FRACTION };

--- a/src/common/SPELLS/DRUID.js
+++ b/src/common/SPELLS/DRUID.js
@@ -797,6 +797,23 @@ export default {
     name: 'Berserk',
     icon: 'ability_druid_berserk',
   },
+  PROWL: {
+    id: 5215,
+    name: 'Prowl',
+    icon: 'ability_druid_prowl',
+  },
+  // a version of prowl that can be activated in combat through the Incarnation: King of the Jungle talent
+  PROWL_INCARNATION: {
+    id: 102547,
+    name: 'Prowl',
+    icon: 'ability_druid_prowl',
+  },
+  // buff from the bloodtalons talent (different id from BLOODTALONS_TALENT)
+  BLOODTALONS_BUFF: {
+    id: 145152,
+    name: 'Bloodtalons',
+    icon: 'spell_druid_bloodythrash',
+  },
   // Traits:
   // The Ashamane's Bite trait creates the Ashamane's Rip debuff.
   ASHAMANES_BITE: {


### PR DESCRIPTION
The snapshotting of DoTs is a unique feral mechanic. This is a snapshot analyzer that keeps track of what applicable buffs were active when rake is cast, marks "bad" casts on the timeline and offers suggestions to fix lost damage from poor management of snapshots.

The generic tracking is handled in Snapshot while the rake-specific parts are in RakeSnapshot. Additional analyzers for the important feral DoTs can be made that also extend Snapshot, but I didn't want to cram too much into a single PR.

RakeSnapshot enforces 2 rules that are recommended by the feral theorycraft community. In order of precedence:
- Only ever refresh a rake buffed by prowl/incarnation if the one you apply would have that buff too.
- When you have a less powerful set of buffs than is already present on the DoT, only refresh within the pandemic window (i.e. less than 30% of the DoT's base duration remaining.)

![rakesnapshot01](https://user-images.githubusercontent.com/35700764/40594768-0dc9f52c-6229-11e8-8aa6-45c18de5395c.png)
![rakesnapshot02](https://user-images.githubusercontent.com/35700764/40594769-0df57f8a-6229-11e8-8118-2d39a52a5bd1.png)
![rakesnapshot03](https://user-images.githubusercontent.com/35700764/40594770-0e0e4a38-6229-11e8-9234-6cb2a0dc7739.png)
