### PR TITLE
[Core] Death Recap with SpellLinks, sourceName, new cooldown order & link to WCLs death pane

### DIFF
--- a/src/Main/DeathRecap.js
+++ b/src/Main/DeathRecap.js
@@ -4,6 +4,7 @@ import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import Icon from 'common/Icon';
 import { formatDuration, formatNumber, formatPercentage } from 'common/format';
+import WarcraftLogsLogo from 'Main/Images/WarcraftLogs-logo.png';
 import Slider from 'rc-slider';
 import 'rc-slider/assets/index.css';
 
@@ -16,6 +17,7 @@ class DeathRecap extends React.PureComponent {
     events: PropTypes.array.isRequired,
     enemies: PropTypes.object.isRequired,
     combatants: PropTypes.object.isRequired,
+    report: PropTypes.object.isRequired,
   };
 
   constructor(props) {
@@ -67,18 +69,34 @@ class DeathRecap extends React.PureComponent {
 
     return (
       <div>
-        <div style={{ margin: '2em 2em 0 2em' }}>
-          Filter events based on min amount (percentage of players health):
+        <div style={{ overflow: 'auto'}}>
+          <div style={{ float: 'left', width: 'calc(100% - 20em)' }}>
+            <div style={{ margin: '2em 0 0 2em' }}>
+              Filter events based on min amount (percentage of players health):
+            </div>
+            <Slider
+              {...sliderProps}
+              defaultValue={this.state.amountThreshold}
+              onChange={(value) => {
+                this.setState({
+                  amountThreshold: value,
+                });
+              }}
+            />
+          </div>
+          <div style={{ width: '18em', float: 'left', marginTop: '2em' }}>
+            <a
+              href={`https://www.warcraftlogs.com/reports/${this.props.report.report.code}#fight=${this.props.report.fight.id}&type=deaths&source=${this.props.report.player.id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn"
+              style={{ fontSize: 24 }}
+              data-tip="Open the deaths on Warcraft Logs"
+            >
+              <img src={WarcraftLogsLogo} alt="Warcraft Logs logo" style={{ height: '1.4em', marginTop: '-0.15em' }} /> Warcraft Logs
+            </a>
+          </div>
         </div>
-        <Slider
-          {...sliderProps}
-          defaultValue={this.state.amountThreshold}
-          onChange={(value) => {
-            this.setState({
-              amountThreshold: value,
-            });
-          }}
-        />
         {events.map((death, i) => (
           <div className="item-divider-top">
             <h2 onClick={() => this.handleClick(i)} style={{ padding: '10px 20px', cursor: 'pointer' }}>Death #{i + 1}</h2>

--- a/src/Main/DeathRecapTracker.js
+++ b/src/Main/DeathRecapTracker.js
@@ -18,8 +18,6 @@ class DeathRecapTracker extends Analyzer {
   cooldowns = [];
   buffs = [];
   lastBuffs = [];
-  debuffs = [];
-  enemyDebuffs = [];
 
   static dependencies = {
     combatants: Combatants,
@@ -46,8 +44,7 @@ class DeathRecapTracker extends Analyzer {
     extendedEvent.time = event.timestamp - this.owner.fight.start_time;
 
     const cooldownsOnly = this.cooldowns.filter(e => e.cooldown);
-    extendedEvent.cooldownsAvailable = cooldownsOnly.filter(e => this.spellUsable.isAvailable(e.spell.id));
-    extendedEvent.cooldownsUsed = cooldownsOnly.filter(e => !this.spellUsable.isAvailable(e.spell.id));
+    extendedEvent.defensiveCooldowns = cooldownsOnly.map(e => ({...e, cooldownReady: this.spellUsable.isAvailable(e.spell.id)}));
     if (event.hitPoints > 0) {
       this.lastBuffs = this.buffs.filter(e => this.combatants.selected.hasBuff(e.buffSpellId) || this.combatants.selected.hasBuff(e.spell.id));
     }
@@ -98,6 +95,8 @@ class DeathRecapTracker extends Analyzer {
         <Tab>
           <DeathRecap
             events={this.secondsBeforeDeath}
+            combatants={this.combatants.players}
+            enemies={this.enemies.enemies}
           />
         </Tab>
       ),

--- a/src/Main/DeathRecapTracker.js
+++ b/src/Main/DeathRecapTracker.js
@@ -94,6 +94,7 @@ class DeathRecapTracker extends Analyzer {
       render: () => (
         <Tab>
           <DeathRecap
+            report={this.owner}
             events={this.secondsBeforeDeath}
             combatants={this.combatants.players}
             enemies={this.enemies.enemies}


### PR DESCRIPTION
- abilities have now spell-links
- the amount reveals who healed/damaged you (and shows how much absorbed/overhealing was done, should also help explaining what `O` and `A` means)
- cooldowns are now ordered by their timelineIds, regardless of their cooldown-state
- new link to take the user to WCLs death-pane

![deathlink](https://user-images.githubusercontent.com/29842841/40613668-c8bc2d68-627f-11e8-9937-d8e9d33db4c1.PNG)

![deathlog](https://user-images.githubusercontent.com/29842841/40612932-c2558724-627c-11e8-9c06-bfead1c6dbab.PNG)
