### PR TITLE
[Core] remove line-height from under stats section title

### DIFF
--- a/src/Main/Report/Results/Results.css
+++ b/src/Main/Report/Results/Results.css
@@ -7,7 +7,6 @@
   margin-bottom: 20px;
   text-indent: 12px;
   font-size: 24px;
-  line-height: 1; /* so the line underneath fits easier */
   text-transform: uppercase;
   font-weight: 600;
 }


### PR DESCRIPTION
**Before:**
![screenshot from 2018-05-28 10-32-52](https://user-images.githubusercontent.com/4909458/40619825-8dbded5c-6264-11e8-985e-cc70487054bc.png)
**After:**
![screenshot from 2018-05-28 10-36-25](https://user-images.githubusercontent.com/4909458/40619824-8db02ef6-6264-11e8-90ca-7ee3dd2c988c.png)

Would appreciate someone spot-checking this locally before merging, I did the fix on a linux machine, though I saw the issue initially on my home (Windows) machine