### PR TITLE
[BrM] Item Panel Updates

### DIFF
--- a/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/AggramarsConviction.js
+++ b/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/AggramarsConviction.js
@@ -18,8 +18,8 @@ import ItemHealingDone from 'Main/ItemHealingDone';
  * When empowered by the Pantheon, your maximum health is increased by 1619540 for 15 sec, and you are healed to full health.
  */
 
-const VERSATILITY_BASE = 4354;
-const BASE_ILVL = 940;
+export const VERSATILITY_BASE = 4354;
+export const BASE_ILVL = 940;
 
 class AggramarsConviction extends Analyzer {
   static dependencies = {

--- a/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/DiimasGlacialAegis.js
+++ b/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/DiimasGlacialAegis.js
@@ -5,7 +5,7 @@ import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
-import { formatPercentage } from 'common/format';
+import { formatNumber, formatPercentage } from 'common/format';
 import { calculateSecondaryStatDefault } from 'common/stats';
 import Abilities from 'Parser/Core/Modules/Abilities';
 import ItemDamageDone from 'Main/ItemDamageDone';
@@ -67,8 +67,8 @@ class DiimasGlacialAegis extends Analyzer {
       item: ITEMS.DIIMAS_GLACIAL_AEGIS,
       result: (
         <React.Fragment>
-          <dfn data-tip={`You casted "${SPELLS.CHILLING_NOVA.name}" ${this.casts} times for a uptime of ${formatPercentage(this.uptime)}%`}>
-            {(this.uptime * this.armorbuff).toFixed(0)} average Armor from <SpellLink id={SPELLS.FROZEN_ARMOR.id} />
+          <dfn data-tip={`You cast "${SPELLS.CHILLING_NOVA.name}" ${this.casts} times for an uptime of ${formatPercentage(this.uptime)}%`}>
+            {formatNumber(this.uptime * this.armorbuff)} Average Armor
           </dfn><br />
           <ItemDamageDone amount={this.damage} />
         </React.Fragment>

--- a/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/DiimasGlacialAegis.js
+++ b/src/Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/DiimasGlacialAegis.js
@@ -2,7 +2,6 @@ import React from 'react';
 
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
-import SpellLink from 'common/SpellLink';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import { formatNumber, formatPercentage } from 'common/format';

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -7,6 +7,7 @@ import { formatMilliseconds } from 'common/format';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import { STAT_TRACKER_BUFFS as DARKMOON_DECK_IMMORTALITY_BUFFS } from 'Parser/Core/Modules/Items/Legion/DarkmoonDeckImmortality';
+import { BASE_ILVL as AGG_CONV_BASE_ILVL, VERSATILITY_BASE as AGG_CONV_VERS } from 'Parser/Core/Modules/Items/Legion/AntorusTheBurningThrone/AggramarsConviction';
 
 const debug = false;
 
@@ -166,6 +167,10 @@ class StatTracker extends Analyzer {
     [SPELLS.RUSH_OF_KNOWLEDGE.id]: {
       itemId: ITEMS.NORGANNONS_PROWESS.id,
       intellect: (_, item) => calculatePrimaryStat(940, 11483, item.itemLevel),
+    },
+    [SPELLS.CELESTIAL_BULWARK.id]: {
+      itemId: ITEMS.AGGRAMARS_CONVICTION.id,
+      versatility: (_, item) => calculateSecondaryStatDefault(AGG_CONV_BASE_ILVL, AGG_CONV_VERS, item.itemLevel),
     },
     // Khaz'goroth's Courage is handled in it's own module since all 4 stat buffs use the same ID.
     //[SPELLS.KHAZGOROTHS_SHAPING.id]: {

--- a/src/Parser/Monk/Brewmaster/Modules/Items/SalsalabimsLostTunic.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Items/SalsalabimsLostTunic.js
@@ -38,9 +38,7 @@ class SalsalabimsLostTunic extends Analyzer {
     return {
       item: ITEMS.SALSALABIMS_LOST_TUNIC,
       result: (
-        <dfn>
-          <SpellLink id={SPELLS.BREATH_OF_FIRE.id} /> cooldown reset {this.cooldownResets} times.
-        </dfn>
+          <React.Fragment>{this.cooldownResets} <SpellLink id={SPELLS.BREATH_OF_FIRE.id} /> resets</React.Fragment>
       ),
     };
   }

--- a/src/Parser/Monk/Brewmaster/Modules/Items/T20_2pc.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Items/T20_2pc.js
@@ -61,10 +61,10 @@ class T20_2pc extends Analyzer {
       icon: <SpellIcon id={SPELLS.XUENS_BATTLEGEAR_2_PIECE_BUFF_BRM.id} />,
       title: <SpellLink id={SPELLS.XUENS_BATTLEGEAR_2_PIECE_BUFF_BRM.id} icon={false} />,
       result: (
-        <dfn data-tip={`The 2pc set bonus causes <b>${this.orbTriggeredBy2Pc}</b> additional Gift of the Ox orbs to spawn.</br>
-        This was from a total of <b>${this.brewCount}</b> brew casts, a <b>${Math.round(procRate)}%</b> chance.`}
+        <dfn data-tip={`The 2pc set bonus caused <b>${this.orbTriggeredBy2Pc}</b> additional Gift of the Ox orbs to spawn.</br>
+        This was from a total of <b>${this.brewCount}</b> brew casts, a rate of <b>${Math.round(procRate)}%</b>.`}
         >
-          {this.orbTriggeredBy2Pc} extra Gift of the Ox
+          {this.orbTriggeredBy2Pc} extra Gift of the Ox Orbs
         </dfn>
       ),
     };

--- a/src/Parser/Monk/Brewmaster/Modules/Items/T20_4pc.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Items/T20_4pc.js
@@ -44,7 +44,7 @@ class T20_4pc extends Analyzer {
       icon: <SpellIcon id={SPELLS.XUENS_BATTLEGEAR_4_PIECE_BUFF_BRM.id} />,
       title: <SpellLink id={SPELLS.XUENS_BATTLEGEAR_4_PIECE_BUFF_BRM.id} icon={false} />,
       result: (
-        <dfn data-tip={`Total stagger damage lowered through T20 4Pc: ${formatThousands(this.staggerSaved)}`}>
+        <dfn data-tip={`Total stagger damage lowered through T20 4pc: ${formatThousands(this.staggerSaved)}`}>
           Stagger lowered by {formatNumber(damageSavedPerSecond)} DPS
         </dfn>
       ),


### PR DESCRIPTION
These are almost exclusively stylistic updates, very little changed in terms of functionality. The exception to that is the Aggramar's Conviction versatility buff, which was added to the stat tracker.

One style thing I'm uncertain on is the Agg's trinket: whether to include the SpellLinks. They were included so I left them and used them as "headers", but it may be more consistent (and nicer-looking) if they were omitted (much like Diima's)

**Before**
![screenshot from 2018-05-28 11-38-41](https://user-images.githubusercontent.com/4909458/40621649-b32349e6-626b-11e8-8085-c61c6b0f9edd.png)

**After**
![screenshot from 2018-05-28 11-38-01](https://user-images.githubusercontent.com/4909458/40621650-b33868ee-626b-11e8-9e0e-950bdbde60dd.png)