### PR TITLE
[Feral] Add details to Abilities

### DIFF
--- a/src/Parser/Druid/Feral/CHANGELOG.js
+++ b/src/Parser/Druid/Feral/CHANGELOG.js
@@ -6,13 +6,18 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-05-30'),
+    changes: 'Configured buffs so they appear on timeline and arranged ordering of abilities on timeline.',
+    contributors: [Anatta336],
+  },
+  {
     date: new Date('2018-05-28'),
     changes: <React.Fragment>Added snapshot tracking for <SpellLink id={SPELLS.RAKE.id} /></React.Fragment>,
     contributors: [Anatta336],
   },
   {
     date: new Date('2018-05-23'),
-    changes: 'Corrected GCD tracking of Moonfire and instant Regrowth/Entangling Roots',
+    changes: <React.Fragment>Corrected GCD tracking of <SpellLink id={SPELLS.MOONFIRE.id} /> and instant <SpellLink id={SPELLS.REGROWTH.id} />/<SpellLink id={SPELLS.ENTANGLING_ROOTS.id} /></React.Fragment>,
     contributors: [Anatta336],
   },
   {

--- a/src/Parser/Druid/Feral/Modules/Features/Abilities.js
+++ b/src/Parser/Druid/Feral/Modules/Features/Abilities.js
@@ -3,52 +3,70 @@ import SPELLS from 'common/SPELLS';
 import CoreAbilities from 'Parser/Core/Modules/Abilities';
 
 class Abilities extends CoreAbilities {
+
   spellbook() {
     const combatant = this.combatants.selected;
     return [
       {
         spell: SPELLS.SHRED,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        isOnGCD: true,
+        // fixed 1.0
+        isOnGCD: true, 
+        timelineSortIndex: 1,
       },
       {
         spell: SPELLS.RAKE,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        // fixed 1.0
         isOnGCD: true,
+        timelineSortIndex: 2,
       },
       {
         spell: SPELLS.RIP,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        isOnGCD: true,
+        // fixed 1.0
+        isOnGCD: true, 
+        timelineSortIndex: 5,
       },
       {
         spell: SPELLS.FEROCIOUS_BITE,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        isOnGCD: true,
+        // fixed 1.0
+        isOnGCD: true, 
+        timelineSortIndex: 6,
       },
       {
         spell: SPELLS.SAVAGE_ROAR_TALENT,
+        buffSpellId: SPELLS.SAVAGE_ROAR_TALENT.id,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         enabled: combatant.hasTalent(SPELLS.SAVAGE_ROAR_TALENT.id),
-        isOnGCD: true,
+        // fixed 1.0
+        isOnGCD: true, 
+        timelineSortIndex: 7,
       },
       {
         spell: SPELLS.MOONFIRE_FERAL,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         enabled: combatant.hasTalent(SPELLS.LUNAR_INSPIRATION_TALENT.id),
-        isOnGCD: true,
+        // 1.0 reduced by haste
+        isOnGCD: true, 
+        timelineSortIndex: 3,
       },
 
       {
         spell: SPELLS.THRASH_FERAL,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
-        isOnGCD: true,
+        // 1.0 fixed
+        isOnGCD: true, 
+        timelineSortIndex: 10,
       },
       {
         spell: SPELLS.CAT_SWIPE,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
         enabled: !combatant.hasTalent(SPELLS.BRUTAL_SLASH_TALENT.id),
-        isOnGCD: true,
+        // 1.0 fixed
+        isOnGCD: true, 
+        timelineSortIndex: 11,
       },
       {
         spell: SPELLS.BRUTAL_SLASH_TALENT,
@@ -59,11 +77,14 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: true,
         },
-        isOnGCD: true,
+        // 1.0 fixed
+        isOnGCD: true, 
+        timelineSortIndex: 11,
       },
 
       {
         spell: SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT,
+        buffSpellId: SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 180,
         enabled: combatant.hasTalent(SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id),
@@ -72,9 +93,11 @@ class Abilities extends CoreAbilities {
           recommendedEfficiency: 0.90,
         },
         isOnGCD: false,
+        timelineSortIndex: 22,
       },
       {
         spell: SPELLS.BERSERK,
+        buffSpellId: SPELLS.BERSERK.id,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 180,
         enabled: !combatant.hasTalent(SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id),
@@ -83,15 +106,18 @@ class Abilities extends CoreAbilities {
           recommendedEfficiency: 0.90,
         },
         isOnGCD: false,
+        timelineSortIndex: 22,
       },
       {
         spell: SPELLS.TIGERS_FURY,
+        buffSpellId: SPELLS.TIGERS_FURY.id,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 30,
         castEfficiency: {
           suggestion: true,
         },
         isOnGCD: false,
+        timelineSortIndex: 20,
       },
       {
         spell: SPELLS.ASHAMANES_FRENZY,
@@ -100,7 +126,9 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: true,
         },
-        isOnGCD: true,
+        // 1.0 fixed
+        isOnGCD: true, 
+        timelineSortIndex: 21,
       },
       {
         spell: SPELLS.ELUNES_GUIDANCE_TALENT,
@@ -111,41 +139,79 @@ class Abilities extends CoreAbilities {
           suggestion: true,
         },
         isOnGCD: false,
+        timelineSortIndex: 23,
       },
 
       {
         spell: SPELLS.REGROWTH,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        isOnGCD: true,
+        // 1.0 reduced by haste
+        isOnGCD: true, 
+        timelineSortIndex: 30,
       },
       {
         spell: SPELLS.ENTANGLING_ROOTS,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        isOnGCD: true,
+        // 1.0 reduced by haste
+        isOnGCD: true, 
+        timelineSortIndex: 31,
       },
       {
         spell: SPELLS.MAIM,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 10,
-        isOnGCD: true,
+        // 1.0 fixed
+        isOnGCD: true, 
+        timelineSortIndex: 32,
       },
       {
         spell: SPELLS.DASH,
+        buffSpellId: SPELLS.DASH.id,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: 180,
+        isOnGCD: false,
+        isDefensive: true,
+        timelineSortIndex: 43,
+      },
+      {
+        spell: [SPELLS.STAMPEDING_ROAR_CAT, SPELLS.STAMPEDING_ROAR_BEAR],
+        buffSpellId: SPELLS.STAMPEDING_ROAR_CAT.id, // STAMPEDING_ROAR_BEAR.id if cast from bear
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 120,
-        isOnGCD: true,
+        // 1.0 reduced by haste
+        isOnGCD: true, 
+        //isDefensive: true, // setting isDefensive breaks the death recap pane. It doesn't like multiple spells in one ability?
+        timelineSortIndex: 44,
       },
       {
         spell: SPELLS.SKULL_BASH_FERAL,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         isOnGCD: false,
+        timelineSortIndex: 33,
+      },
+      {
+        spell: SPELLS.PROWL,
+        buffSpellId: SPELLS.PROWL.id,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: 6,
+        isOnGCD: false,
+        timelineSortIndex: 25,
+      },
+      {
+        spell: SPELLS.PROWL_INCARNATION,
+        buffSpellId: SPELLS.PROWL_INCARNATION.id,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        isOnGCD: false,
+        timelineSortIndex: 26,
       },
       {
         spell: SPELLS.SHADOWMELD,
+        buffSpellId: SPELLS.SHADOWMELD.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 120,
         isUndetectable: true,
         isOnGCD: false,
+        timelineSortIndex: 24,
       },
       {
         spell: SPELLS.SURVIVAL_INSTINCTS,
@@ -154,32 +220,52 @@ class Abilities extends CoreAbilities {
         cooldown: 120,
         charges: 2,
         isOnGCD: false,
+        isDefensive: true,
+        timelineSortIndex: 40,
+      },
+      {
+        // spell is not cast, but automatically activated on leaving cat form
+        spell: SPELLS.PROTECTION_OF_ASHAMANE,
+        buffSpellId: SPELLS.PROTECTION_OF_ASHAMANE_BUFF.id,
+        category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
+        cooldown: 30,
+        enabled: combatant.traitsBySpellId[SPELLS.PROTECTION_OF_ASHAMANE.id] > 0,
+        isOnGCD: false,
+        isDefensive: true,
+        timelineSortIndex: 41,
       },
       {
         spell: SPELLS.REBIRTH,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         isOnGCD: true,
+        timelineSortIndex: 60,
       },
       {
         spell: SPELLS.MIGHTY_BASH_TALENT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.MIGHTY_BASH_TALENT.id),
         cooldown: 50,
-        isOnGCD: true,
+        // 1.5 reduced by haste
+        isOnGCD: true, 
+        timelineSortIndex: 34,
       },
       {
         spell: SPELLS.MASS_ENTANGLEMENT_TALENT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.MASS_ENTANGLEMENT_TALENT.id),
         cooldown: 30,
-        isOnGCD: true,
+        // 1.5 reduced by haste
+        isOnGCD: true, 
+        timelineSortIndex: 34,
       },
       {
         spell: SPELLS.TYPHOON,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.TYPHOON_TALENT.id),
         cooldown: 30,
-        isOnGCD: true,
+        // 1.5 reduced by haste
+        isOnGCD: true, 
+        timelineSortIndex: 35,
       },
       {
         spell: SPELLS.RENEWAL_TALENT,
@@ -187,13 +273,18 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(SPELLS.RENEWAL_TALENT.id),
         cooldown: 90,
         isOnGCD: false,
+        isDefensive: true,
+        timelineSortIndex: 42,
       },
       {
         spell: SPELLS.DISPLACER_BEAST_TALENT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.DISPLACER_BEAST_TALENT.id),
         cooldown: 30,
-        isOnGCD: true,
+        // 1.5 reduced by haste
+        isOnGCD: true, 
+        isDefensive: true,
+        timelineSortIndex: 42,
       },
       {
         spell: [SPELLS.WILD_CHARGE_TALENT, SPELLS.WILD_CHARGE_MOONKIN, SPELLS.WILD_CHARGE_CAT, SPELLS.WILD_CHARGE_BEAR, SPELLS.WILD_CHARGE_TRAVEL],
@@ -201,33 +292,50 @@ class Abilities extends CoreAbilities {
         cooldown: 15,
         enabled: combatant.hasTalent(SPELLS.WILD_CHARGE_TALENT.id),
         isOnGCD: false,
+        timelineSortIndex: 42,
       },
-
       {
         spell: SPELLS.BEAR_FORM,
+        buffSpellId: SPELLS.BEAR_FORM.id,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
-        isOnGCD: true,
+        // 1.5 reduced by haste
+        isOnGCD: true, 
+        isDefensive: true,
+        timelineSortIndex: 51,
       },
       {
         spell: SPELLS.CAT_FORM,
+        buffSpellId: SPELLS.CAT_FORM.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        isOnGCD: true,
+        // 1.5 reduced by haste
+        isOnGCD: true, 
+        timelineSortIndex: 50,
       },
       {
-        spell: SPELLS.MOONKIN_FORM,
+        spell: SPELLS.MOONKIN_FORM_AFFINITY,
+        buffSpellId: SPELLS.MOONKIN_FORM_AFFINITY.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: 90, // only has a cooldown for feral spec - not guardian or resto
         enabled: combatant.hasTalent(SPELLS.BALANCE_AFFINITY_TALENT_SHARED.id),
-        isOnGCD: true,
+        // 1.5 reduced by haste
+        isOnGCD: true, 
+        timelineSortIndex: 54,
       },
       {
         spell: SPELLS.TRAVEL_FORM,
+        buffSpellId: SPELLS.TRAVEL_FORM.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        isOnGCD: true,
+        // 1.5 reduced by haste
+        isOnGCD: true, 
+        timelineSortIndex: 52,
       },
       {
         spell: SPELLS.STAG_FORM,
+        buffSpellId: SPELLS.STAG_FORM.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        isOnGCD: true,
+        // 1.5 reduced by haste
+        isOnGCD: true, 
+        timelineSortIndex: 53,
       },
     ];
   }

--- a/src/Parser/Druid/Feral/Modules/Features/Abilities.js
+++ b/src/Parser/Druid/Feral/Modules/Features/Abilities.js
@@ -174,13 +174,15 @@ class Abilities extends CoreAbilities {
         timelineSortIndex: 43,
       },
       {
-        spell: [SPELLS.STAMPEDING_ROAR_CAT, SPELLS.STAMPEDING_ROAR_BEAR],
-        buffSpellId: SPELLS.STAMPEDING_ROAR_CAT.id, // STAMPEDING_ROAR_BEAR.id if cast from bear
+        spell: [SPELLS.STAMPEDING_ROAR_HUMANOID, SPELLS.STAMPEDING_ROAR_CAT, SPELLS.STAMPEDING_ROAR_BEAR],
+        // buffSpellId matches the version that was cast, but vast majority for Feral will be the cat version
+        buffSpellId: SPELLS.STAMPEDING_ROAR_CAT.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 120,
         // 1.0 reduced by haste
         isOnGCD: true, 
-        //isDefensive: true, // setting isDefensive breaks the death recap pane. It doesn't like multiple spells in one ability?
+        // setting isDefensive breaks the death recap pane. It doesn't like multiple spells in one ability?
+        //isDefensive: true,
         timelineSortIndex: 44,
       },
       {
@@ -224,7 +226,7 @@ class Abilities extends CoreAbilities {
         timelineSortIndex: 40,
       },
       {
-        // spell is not cast, but automatically activated on leaving cat form
+        // automatically activated on leaving cat form
         spell: SPELLS.PROTECTION_OF_ASHAMANE,
         buffSpellId: SPELLS.PROTECTION_OF_ASHAMANE_BUFF.id,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,

--- a/src/common/SPELLS/DRUID.js
+++ b/src/common/SPELLS/DRUID.js
@@ -429,6 +429,12 @@ export default {
     name: 'Ironfur',
     icon: 'ability_druid_ironfur',
   },
+  // when casting stampeding outside of cat or bear form (puts caster into bear form)
+  STAMPEDING_ROAR_HUMANOID: {
+    id: 106898,
+    name: 'Stampeding Roar',
+    icon: 'spell_druid_stamedingroar',
+  },
   STAMPEDING_ROAR_CAT: {
     id: 77764,
     name: 'Stampeding Roar',

--- a/src/common/SPELLS/DRUID.js
+++ b/src/common/SPELLS/DRUID.js
@@ -11,6 +11,12 @@ export default {
     name: 'Starsurge',
     icon: 'spell_arcane_arcane03',
   },
+  // the moonkin form granted by Balance Affinity
+  MOONKIN_FORM_AFFINITY: {
+    id: 197625,
+    name: 'Moonkin Form',
+    icon: 'spell_nature_forceofnature',
+  },
 
   // RESTO DRUID //
 
@@ -424,7 +430,7 @@ export default {
     icon: 'ability_druid_ironfur',
   },
   STAMPEDING_ROAR_CAT: {
-    id: 106898,
+    id: 77764,
     name: 'Stampeding Roar',
     icon: 'spell_druid_stampedingroar_cat',
   },
@@ -830,6 +836,16 @@ export default {
     id: 240670,
     name: 'Fury of Ashamane',
     icon: 'ability_mount_jungletiger',
+  },
+  PROTECTION_OF_ASHAMANE: {
+    id: 210650,
+    name: 'Protection of Ashamane',
+    icon: 'ability_druid_catform',
+  },
+  PROTECTION_OF_ASHAMANE_BUFF: {
+    id: 210655,
+    name: 'Protection of Ashamane',
+    icon: 'ability_druid_catform',
   },
 
   //shared talent spells


### PR DESCRIPTION
Added buffSpellId to applicable Feral abilities.
Gave each a timelineSortIndex, grouping up similar abilities and putting the core rotation at the top.
Marked movement and additional survival abilities as isDefensive so they show up on the death recap.
Added in a couple of missing abilities.
Sprinkled in comments for GCDs (as they are in 7.3.5), to save finding it again when ability-specific GCD handling is added.

The icon name `spell_druid_stamedingroar` misspelling is intentional, it's how Blizzard named it.