### PR TITLE
[Core] Add healthstone/health pots to spellbook and death recap.

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -1,12 +1,17 @@
 import React from 'react';
 
-import { Anomoly, blazyb, Dyspho, fasib, Fyruna, Gurupitka, Juko8, Mamtooth, sref, Versaya, aryu, Zerotorescue, Hartra344, Putro, Sharrq, Hewhosmites, joshinator, kyleglick, CubeLuke, Aelexe, niseko } from 'CONTRIBUTORS';
+import { Anomoly, blazyb, Dyspho, fasib, Fyruna, Gurupitka, Juko8, Mamtooth, sref, Versaya, aryu, Zerotorescue, Hartra344, Putro, Sharrq, Hewhosmites, joshinator, kyleglick, CubeLuke, Aelexe, niseko, Gebuz } from 'CONTRIBUTORS';
 import ItemLink from 'common/ItemLink';
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 
 export default [
+  {
+    date: new Date('2018-06-04'),
+    changes: 'Added Healthstone/Health pots to abilities and the death recap.',
+    contributors: [Gebuz],
+  },
   {
     date: new Date('2018-06-02'),
     changes: 'Improved error handling so the app will no longer permanently stay stuck in a loading state when something unexpected happens.',

--- a/src/Main/DeathRecap.js
+++ b/src/Main/DeathRecap.js
@@ -201,15 +201,15 @@ class DeathRecap extends React.PureComponent {
                         </td>
                         <td style={{ width: '20%' }}>
                           {event.buffsUp && event.buffsUp.sort(sortByTimelineIndex).map(e =>
-                            <SpellIcon style={{ border: '1px solid rgba(0, 0, 0, 0)' }} id={e.spell instanceof Array ? e.spell[0].id : e.spell.id} />
+                            <SpellIcon style={{ border: '1px solid rgba(0, 0, 0, 0)' }} id={e.id} />
                           )}<br />
                           {event.debuffsUp && event.debuffsUp.sort(sortByTimelineIndex).map(e =>
-                            <SpellIcon style={{ border: '1px solid red' }} id={e.ability.guid} />
+                            <SpellIcon style={{ border: '1px solid red' }} id={e.id} />
                           )}
                         </td>
                         <td style={{ width: '15%' }}>
                           {event.defensiveCooldowns.sort(sortByTimelineIndex).map(e =>
-                            <SpellIcon style={{ opacity: e.cooldownReady ? 1 : .2 }} id={e.spell instanceof Array ? e.spell[0].id : e.spell.id} />
+                            <SpellIcon style={{ opacity: e.cooldownReady ? 1 : .2 }} id={e.id} />
                           )}
                         </td>
                       </tr>

--- a/src/Main/DeathRecap.js
+++ b/src/Main/DeathRecap.js
@@ -201,15 +201,15 @@ class DeathRecap extends React.PureComponent {
                         </td>
                         <td style={{ width: '20%' }}>
                           {event.buffsUp && event.buffsUp.sort(sortByTimelineIndex).map(e =>
-                            <SpellIcon style={{ border: '1px solid rgba(0, 0, 0, 0)' }} id={e.spell ? e.spell.id : e} />
+                            <SpellIcon style={{ border: '1px solid rgba(0, 0, 0, 0)' }} id={e.spell instanceof Array ? e.spell[0].id : e.spell.id} />
                           )}<br />
                           {event.debuffsUp && event.debuffsUp.sort(sortByTimelineIndex).map(e =>
-                            <SpellIcon style={{ border: '1px solid red' }} id={e.ability ? e.ability.guid : e} />
+                            <SpellIcon style={{ border: '1px solid red' }} id={e.ability.guid} />
                           )}
                         </td>
                         <td style={{ width: '15%' }}>
                           {event.defensiveCooldowns.sort(sortByTimelineIndex).map(e =>
-                            <SpellIcon style={{ opacity: e.cooldownReady ? 1 : .2 }} id={e.spell.id} />
+                            <SpellIcon style={{ opacity: e.cooldownReady ? 1 : .2 }} id={e.spell instanceof Array ? e.spell[0].id : e.spell.id} />
                           )}
                         </td>
                       </tr>

--- a/src/Main/DeathRecapTracker.js
+++ b/src/Main/DeathRecapTracker.js
@@ -44,17 +44,17 @@ class DeathRecapTracker extends Analyzer {
     extendedEvent.time = event.timestamp - this.owner.fight.start_time;
 
     const cooldownsOnly = this.cooldowns.filter(e => e.cooldown);
-    extendedEvent.defensiveCooldowns = cooldownsOnly.map(e => {
-      return ({...e, cooldownReady: this.spellUsable.isAvailable(e.spell instanceof Array ? e.spell[0].id : e.spell.id)});
-    });
+    extendedEvent.defensiveCooldowns = cooldownsOnly.map(e => ({id: e.primarySpell.id, cooldownReady: this.spellUsable.isAvailable(e.primarySpell.id)}));
     if (event.hitPoints > 0) {
-      this.lastBuffs = this.buffs.filter(e => this.combatants.selected.hasBuff(e.buffSpellId) || this.combatants.selected.hasBuff(e.spell instanceof Array ? e.spell[0].id : e.spell.id));
+      this.lastBuffs = this.buffs.filter(e => this.combatants.selected.hasBuff(e.buffSpellId) || this.combatants.selected.hasBuff(e.spell.id))
+        .map(e => ({id: e.buffSpellId || e.spell.id}));
     }
     extendedEvent.buffsUp = this.lastBuffs;
 
     if (!event.sourceIsFriendly && this.enemies.enemies[event.sourceID]) {
-      const sourceHasDebuff = debuff => (!debuff.end || event.timestamp <= debuff.end) && event.timestamp >= debuff.start && debuff.isDebuff && this.buffs.some(e => e.buffSpellId === debuff.ability.guid || (e.spell instanceof Array ? e.spell[0].id : e.spell.id) === debuff.ability.guid);
-      extendedEvent.debuffsUp = this.enemies.enemies[event.sourceID].buffs.filter(sourceHasDebuff);
+      const sourceHasDebuff = debuff => (!debuff.end || event.timestamp <= debuff.end) && event.timestamp >= debuff.start && debuff.isDebuff && this.buffs.some(e => e.buffSpellId === debuff.ability.guid || e.spell.id === debuff.ability.guid);
+      extendedEvent.debuffsUp = this.enemies.enemies[event.sourceID].buffs.filter(sourceHasDebuff)
+        .map(e => ({id: e.ability.guid }));
     }
 
     this.events.push(extendedEvent);

--- a/src/Main/DeathRecapTracker.js
+++ b/src/Main/DeathRecapTracker.js
@@ -48,7 +48,7 @@ class DeathRecapTracker extends Analyzer {
     const cooldownsOnly = this.cooldowns.filter(e => e.cooldown);
     extendedEvent.defensiveCooldowns = cooldownsOnly.map(e => ({id: e.primarySpell.id, cooldownReady: this.spellUsable.isAvailable(e.primarySpell.id)}));
     if (event.hitPoints > 0) {
-      this.lastBuffs = this.buffs.filter(e => this.combatants.selected.hasBuff(e.buffSpellId) || this.combatants.selected.hasBuff(e.spell instanceof Array ? e.spell[0].id : e.spell.id))
+      this.lastBuffs = this.buffs.filter(e => this.combatants.selected.hasBuff(e.buffSpellId) || this.combatants.selected.hasBuff(e.spell instanceof Array ? e.spell[0].id : e.spell.id)) // Since we don't know if e is an instance of spell or ability we can't use ability.primarySpell
         .map(e => ({id: e.buffSpellId || e.spell.id}));
     }
     extendedEvent.buffsUp = this.lastBuffs;

--- a/src/Main/DeathRecapTracker.js
+++ b/src/Main/DeathRecapTracker.js
@@ -44,14 +44,16 @@ class DeathRecapTracker extends Analyzer {
     extendedEvent.time = event.timestamp - this.owner.fight.start_time;
 
     const cooldownsOnly = this.cooldowns.filter(e => e.cooldown);
-    extendedEvent.defensiveCooldowns = cooldownsOnly.map(e => ({...e, cooldownReady: this.spellUsable.isAvailable(e.spell.id)}));
+    extendedEvent.defensiveCooldowns = cooldownsOnly.map(e => {
+      return ({...e, cooldownReady: this.spellUsable.isAvailable(e.spell instanceof Array ? e.spell[0].id : e.spell.id)});
+    });
     if (event.hitPoints > 0) {
-      this.lastBuffs = this.buffs.filter(e => this.combatants.selected.hasBuff(e.buffSpellId) || this.combatants.selected.hasBuff(e.spell.id));
+      this.lastBuffs = this.buffs.filter(e => this.combatants.selected.hasBuff(e.buffSpellId) || this.combatants.selected.hasBuff(e.spell instanceof Array ? e.spell[0].id : e.spell.id));
     }
     extendedEvent.buffsUp = this.lastBuffs;
 
     if (!event.sourceIsFriendly && this.enemies.enemies[event.sourceID]) {
-      const sourceHasDebuff = debuff => (!debuff.end || event.timestamp <= debuff.end) && event.timestamp >= debuff.start && debuff.isDebuff && this.buffs.some(e => e.buffSpellId === debuff.ability.guid || e.spell.id === debuff.ability.guid);
+      const sourceHasDebuff = debuff => (!debuff.end || event.timestamp <= debuff.end) && event.timestamp >= debuff.start && debuff.isDebuff && this.buffs.some(e => e.buffSpellId === debuff.ability.guid || (e.spell instanceof Array ? e.spell[0].id : e.spell.id) === debuff.ability.guid);
       extendedEvent.debuffsUp = this.enemies.enemies[event.sourceID].buffs.filter(sourceHasDebuff);
     }
 

--- a/src/Main/DeathRecapTracker.js
+++ b/src/Main/DeathRecapTracker.js
@@ -46,7 +46,7 @@ class DeathRecapTracker extends Analyzer {
     const cooldownsOnly = this.cooldowns.filter(e => e.cooldown);
     extendedEvent.defensiveCooldowns = cooldownsOnly.map(e => ({id: e.primarySpell.id, cooldownReady: this.spellUsable.isAvailable(e.primarySpell.id)}));
     if (event.hitPoints > 0) {
-      this.lastBuffs = this.buffs.filter(e => this.combatants.selected.hasBuff(e.buffSpellId) || this.combatants.selected.hasBuff(e.spell.id))
+      this.lastBuffs = this.buffs.filter(e => this.combatants.selected.hasBuff(e.buffSpellId) || this.combatants.selected.hasBuff(e.spell instanceof Array ? e.spell[0].id : e.spell.id))
         .map(e => ({id: e.buffSpellId || e.spell.id}));
     }
     extendedEvent.buffsUp = this.lastBuffs;

--- a/src/Main/DeathRecapTracker.js
+++ b/src/Main/DeathRecapTracker.js
@@ -6,6 +6,7 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import Abilities from 'Parser/Core/Modules/Abilities';
 import SpellUsable from 'Parser/Core/Modules/SpellUsable';
 import Enemies from 'Parser/Core/Modules/Enemies';
+import Healthstone from 'Parser/Core/Modules/Items/Healthstone';
 import Tab from 'Main/Tab';
 
 import DeathRecap from './DeathRecap';
@@ -24,6 +25,7 @@ class DeathRecapTracker extends Analyzer {
     abilities: Abilities,
     spellUsable: SpellUsable,
     enemies: Enemies,
+    healthstone: Healthstone,
   };
 
   on_initialized() {

--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -51,6 +51,7 @@ import PrePotion from './Modules/Items/PrePotion';
 import LegendaryUpgradeChecker from './Modules/Items/LegendaryUpgradeChecker';
 import LegendaryCountChecker from './Modules/Items/LegendaryCountChecker';
 import EnchantChecker from './Modules/Items/EnchantChecker';
+import Healthstone from './Modules/Items/Healthstone';
 
 // Legendaries
 import PrydazXavaricsMagnumOpus from './Modules/Items/Legion/Legendaries/PrydazXavaricsMagnumOpus';
@@ -175,7 +176,6 @@ class CombatLogParser {
     vantusRune: VantusRune,
     distanceMoved: DistanceMoved,
     timelineBuffEvents: TimelineBuffEvents,
-    deathRecapTracker: DeathRecapTracker,
 
     critEffectBonus: CritEffectBonus,
 
@@ -185,6 +185,12 @@ class CombatLogParser {
     checklist: Checklist,
 
     encounterPanel: EncounterPanel,
+
+    prePotion: PrePotion,
+    legendaryUpgradeChecker: LegendaryUpgradeChecker,
+    legendaryCountChecker: LegendaryCountChecker,
+    enchantChecker: EnchantChecker,
+    healthstone: Healthstone,
 
     // Items:
     // Legendaries:
@@ -201,10 +207,6 @@ class CombatLogParser {
     amalgamsSeventhSpine: AmalgamsSeventhSpine,
     darkmoonDeckPromises: DarkmoonDeckPromises,
     darkmoonDeckImmortality: DarkmoonDeckImmortality,
-    prePotion: PrePotion,
-    legendaryUpgradeChecker: LegendaryUpgradeChecker,
-    legendaryCountChecker: LegendaryCountChecker,
-    enchantChecker: EnchantChecker,
     gnawedThumbRing: GnawedThumbRing,
     ishkarsFelshieldEmitter: IshkarsFelshieldEmitter,
     erraticMetronome: ErraticMetronome,
@@ -269,6 +271,9 @@ class CombatLogParser {
 
     infernalCinders: InfernalCinders,
     umbralMoonglaives: UmbralMoonglaives,
+
+    //added last so that it includes items that are added to the spellbook on initialization.
+    deathRecapTracker: DeathRecapTracker,
   };
   // Override this with spec specific modules when extending
   static specModules = {};

--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -176,6 +176,7 @@ class CombatLogParser {
     vantusRune: VantusRune,
     distanceMoved: DistanceMoved,
     timelineBuffEvents: TimelineBuffEvents,
+    deathRecapTracker: DeathRecapTracker,
 
     critEffectBonus: CritEffectBonus,
 
@@ -272,8 +273,6 @@ class CombatLogParser {
     infernalCinders: InfernalCinders,
     umbralMoonglaives: UmbralMoonglaives,
 
-    //added last so that it includes items that are added to the spellbook on initialization.
-    deathRecapTracker: DeathRecapTracker,
   };
   // Override this with spec specific modules when extending
   static specModules = {};

--- a/src/Parser/Core/Modules/Items/Healthstone.js
+++ b/src/Parser/Core/Modules/Items/Healthstone.js
@@ -34,7 +34,9 @@ class Healthstone extends Analyzer {
       cooldown: ONE_HOUR_MS / 1000, // The cooldown does not start while in combat so setting it to one hour.
       castEfficiency: {
         suggestion: true,
-        recommendedEfficiency: 0.5,
+        recommendedEfficiency: 0.6,
+          averageIssueEfficiency: 0.4,
+          majorIssueEfficiency: 0.1,
         maxCasts: (cooldown, fightDuration, getAbility, parser) => {
           return this.maxCasts;
         },

--- a/src/Parser/Core/Modules/Items/Healthstone.js
+++ b/src/Parser/Core/Modules/Items/Healthstone.js
@@ -25,7 +25,7 @@ class Healthstone extends Analyzer {
       category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
       cooldown: COOLDOWN_MS / 1000, // The cooldown does not start while in combat.
       castEfficiency: {
-        suggestion: true,
+        suggestion: false,
       },
     });
   }

--- a/src/Parser/Core/Modules/Items/Healthstone.js
+++ b/src/Parser/Core/Modules/Items/Healthstone.js
@@ -25,16 +25,17 @@ class Healthstone extends Analyzer {
       category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
       cooldown: COOLDOWN_MS / 1000, // The cooldown does not start while in combat.
       castEfficiency: {
-        suggestion: false,
+        suggestion: true,
       },
     });
   }
 
   on_toPlayer_death(event) {
-    if (!this.spellUsable.isOnCooldown(HEALTHSTONE_SPELLS[0].id)){
+    if (!this.spellUsable.isOnCooldown(SPELLS.HEALTHSTONE.id)){
       return;
     }
-    this.spellUsable.reduceCooldown(HEALTHSTONE_SPELLS[0].id, COOLDOWN_MS - OUT_OF_COMBAT_COOLDOWN_MS);
+    // The one minute cooldown starts when the player dies or leaves combat.
+    this.spellUsable.reduceCooldown(SPELLS.HEALTHSTONE.id, COOLDOWN_MS - OUT_OF_COMBAT_COOLDOWN_MS);
   }
 
 }

--- a/src/Parser/Core/Modules/Items/Healthstone.js
+++ b/src/Parser/Core/Modules/Items/Healthstone.js
@@ -1,0 +1,42 @@
+import SPELLS from 'common/SPELLS';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Abilities from 'Parser/Core/Modules/Abilities';
+import SpellUsable from 'Parser/Core/Modules/SpellUsable';
+
+const HEALTHSTONE_SPELLS = [
+  SPELLS.HEALTHSTONE,
+  SPELLS.ANCIENT_HEALING_POTION,
+  SPELLS.ASTRAL_HEALING_POTION,
+];
+
+const COOLDOWN_MS = 3600000; // one hour
+const OUT_OF_COMBAT_COOLDOWN_MS = 60000; // one minute
+
+class Healthstone extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+    spellUsable: SpellUsable,
+  };
+
+  on_initialized() {
+    this.abilities.add({
+      spell: HEALTHSTONE_SPELLS,
+      category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
+      cooldown: COOLDOWN_MS / 1000, // The cooldown does not start while in combat.
+      castEfficiency: {
+        suggestion: true,
+      },
+    });
+  }
+
+  on_toPlayer_death(event) {
+    if (!this.spellUsable.isOnCooldown(HEALTHSTONE_SPELLS[0].id)){
+      return;
+    }
+    this.spellUsable.reduceCooldown(HEALTHSTONE_SPELLS[0].id, COOLDOWN_MS - OUT_OF_COMBAT_COOLDOWN_MS);
+  }
+
+}
+
+export default Healthstone;

--- a/src/Parser/Monk/Brewmaster/Modules/Features/Abilities.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/Abilities.js
@@ -69,13 +69,13 @@ class Abilities extends CoreAbilities {
         // id
         spell: [SPELLS.IRONSKIN_BREW, SPELLS.PURIFYING_BREW],
         buffSpellId: SPELLS.IRONSKIN_BREW_BUFF.id,
-        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
+        category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         cooldown: haste => 21 / (1 + haste),
         charges: 3,
       },
       {
         spell: SPELLS.BLACK_OX_BREW_TALENT,
-        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
+        category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         cooldown: 90,
         castEfficiency: {
           suggestion: false,

--- a/src/common/DEFENSIVE_BUFFS.js
+++ b/src/common/DEFENSIVE_BUFFS.js
@@ -52,10 +52,6 @@ const DEFENSIVE_BUFFS = [
   {
     spell: SPELLS.GHOST_IN_THE_MIST_BUFF,
   },
-  //Brewmaster Monk
-  {
-    spell: SPELLS.IRONSKIN_BREW_BUFF,
-  },
   //Arms Warrior
   {
     spell: SPELLS.DEFENSIVE_STANCE_TALENT,

--- a/src/common/SPELLS/OTHERS.js
+++ b/src/common/SPELLS/OTHERS.js
@@ -41,6 +41,11 @@ export default {
     name: 'Ancient Healing Potion',
     icon: 'inv_alchemy_70_red',
   },
+  ASTRAL_HEALING_POTION: {
+    id: 251645,
+    name: 'Astral Healing Potion',
+    icon: 'inv_alchemy_70_red',
+  },
   POTION_OF_PROLONGED_POWER: {
     id: 229206,
     name: 'Potion of Prolonged Power',


### PR DESCRIPTION
Also fixed an issue with death recap not working with multi id spells in the spellbook (such as healthstone/pot).
![image](https://user-images.githubusercontent.com/6773230/40891306-806fa43c-6783-11e8-8ad4-c3de53647c60.png)
![image](https://user-images.githubusercontent.com/6773230/40891310-8ac92c96-6783-11e8-92d2-d36b268714df.png)
