### PR TITLE
[Feral] Snapshot tracking for Rip

### DIFF
--- a/src/Parser/Druid/Feral/CHANGELOG.js
+++ b/src/Parser/Druid/Feral/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-06-06'),
+    changes: <React.Fragment>Added snapshot tracking for <SpellLink id={SPELLS.RIP.id} /></React.Fragment>,
+    contributors: [Anatta336],
+  },
+  {
     date: new Date('2018-05-30'),
     changes: 'Configured buffs so they appear on timeline and arranged ordering of abilities on timeline.',
     contributors: [Anatta336],

--- a/src/Parser/Druid/Feral/CombatLogParser.js
+++ b/src/Parser/Druid/Feral/CombatLogParser.js
@@ -8,6 +8,7 @@ import RakeUptime from './Modules/Bleeds/RakeUptime';
 import RipUptime from './Modules/Bleeds/RipUptime';
 import FerociousBiteEnergy from './Modules/Features/FerociousBiteEnergy';
 import RakeSnapshot from './Modules/Bleeds/RakeSnapshot';
+import RipSnapshot from './Modules/Bleeds/RipSnapshot';
 
 import ComboPointTracker from './Modules/ComboPoints/ComboPointTracker';
 import ComboPointDetails from './Modules/ComboPoints/ComboPointDetails';
@@ -35,6 +36,7 @@ class CombatLogParser extends CoreCombatLogParser {
     rakeUptime: RakeUptime,
     ripUptime: RipUptime,
     rakeSnapshot: RakeSnapshot,
+    ripSnapshot: RipSnapshot,
 
     // talents
     savageRoarUptime: SavageRoarUptime,

--- a/src/Parser/Druid/Feral/Modules/Bleeds/RipSnapshot.js
+++ b/src/Parser/Druid/Feral/Modules/Bleeds/RipSnapshot.js
@@ -48,7 +48,6 @@ class RipSnapshot extends Snapshot {
   ripCastCount = 0;
   downgradeCount = 0;
   shouldBeBiteCount = 0;
-
   /**
    * Order of processed events when player casts rip is always:
    *   on_byPlayer_cast

--- a/src/Parser/Druid/Feral/Modules/Bleeds/RipSnapshot.js
+++ b/src/Parser/Druid/Feral/Modules/Bleeds/RipSnapshot.js
@@ -58,7 +58,6 @@ class RipSnapshot extends Snapshot {
    * which is called by Snapshot in response to debuffapply and debuffrefresh.
    */
   comboLastRip = 0;
-
   hasSabertooth = false;
   healthFraction = {};
 

--- a/src/Parser/Druid/Feral/Modules/Bleeds/RipSnapshot.js
+++ b/src/Parser/Druid/Feral/Modules/Bleeds/RipSnapshot.js
@@ -1,0 +1,237 @@
+import React from 'react';
+import RESOURCE_TYPES from 'common/RESOURCE_TYPES';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import { formatPercentage } from 'common/format';
+import { encodeTargetString } from 'Parser/Core/Modules/EnemyInstances';
+import Snapshot, { JAGGED_WOUNDS_MODIFIER, PANDEMIC_FRACTION } from '../FeralCore/Snapshot';
+import ComboPointTracker from '../ComboPoints/ComboPointTracker';
+
+const debug = false;
+
+/**
+ * Rip's base damage per second varies depending on how many combo points it was cast with.
+ * Rip should always be cast with 5 combo points to get the most damage from it, but this analyzer takes into account
+ * the power difference of using fewer combo points so it can give accurate results from imperfect play.
+ *
+ * Rip's damage snapshots the effects of Tiger's Fury and Bloodtalons. It's not affected by prowl.
+ * Refreshing Rip with a less powerful version before the pandemic window is a damage loss.
+ *
+ * Ferocious Bite will extend a Rip bleed if the target is <25% health, or at any health with the Sabertooth talent.
+ * Bite extending Rip will maintain the existing snapshot from when Rip was cast.
+ * Applying a fresh Rip when you could have extended by using Bite is a damage loss, unless the Rip improved the snapshot.
+ * Bite extending a weak Rip when you could have applied a stronger Rip can sometimes be a damage loss. There's a lot of
+ * factors in play so this analyzer doesn't attempt to detect Bites that should have been Rips.
+ *
+ * When Bite extends the duration of a Rip, it doesn't trigger the refreshdebuff event in the combat log.
+ *
+ * This analyzer represents the effect of combo points with a "power" multiplier just as Tiger's Fury and Bloodtalons are.
+ * 5 combo point rip cast with no snapshot buffs has 1.00 power.
+ * 4 combo with no buffs is 0.80 power, decreasing linearly to 1 combo point giving a 0.20 power rip.
+ *
+ * It is possible for a buffed 4 combo rip to be more powerful than a non-buffed 5 combo rip. Using 7.3.5 numbers:
+ * 4 combo with TF and BT: 0.80 * 1.15 * 1.20 = 1.104
+ * Casting the 4 combo point rip was a mistake. But early-refreshing it with a non-buffed 5 combo point rip is also an error.
+ */
+
+const RIP_BASE_DURATION = 24000;
+const RIP_POWER_PER_COMBO = 0.20;
+const BITE_EXECUTE_RANGE = 0.25;
+
+class RipSnapshot extends Snapshot {
+  static dependencies = {
+    combatants: Combatants,
+    comboPointTracker: ComboPointTracker,
+  };
+
+  ripCastCount = 0;
+  downgradeCount = 0;
+  shouldBeBiteCount = 0;
+
+  /**
+   * Order of processed events when player casts rip is always:
+   *   on_byPlayer_cast
+   *   on_byPlayer_spendresource
+   *   on_byPlayer_debuffapply, or on_byPlayer_debuffrefresh
+   * So it's safe to store the comboLastRip on spendresource then use it in calcPower,
+   * which is called by Snapshot in response to debuffapply and debuffrefresh.
+   */
+  comboLastRip;
+
+  hasSabertooth = false;
+  healthFraction = {};
+
+  on_initialized() {
+    this.spellCastId = SPELLS.RIP.id;
+    this.debuffId = SPELLS.RIP.id;
+    this.durationOfFresh = RIP_BASE_DURATION;
+    this.isProwlAffected = false;
+    this.isTigersFuryAffected = true;
+    this.isBloodtalonsAffected = true;
+
+    const combatant = this.combatants.selected;
+    if (combatant.hasTalent(SPELLS.JAGGED_WOUNDS_TALENT.id)) {
+      this.durationOfFresh *= JAGGED_WOUNDS_MODIFIER;
+    }
+    if (combatant.hasTalent(SPELLS.SABERTOOTH_TALENT.id)) {
+      this.hasSabertooth = true;
+    }
+  }
+
+  on_byPlayer_cast(event) {
+    super.on_byPlayer_cast(event);
+    if (SPELLS.RIP.id === event.ability.guid) {
+      this.ripCastCount += 1;
+      debug && console.log(`${this.owner.formatTimestamp(event.timestamp)} rip cast.`);
+    }
+    if (SPELLS.FEROCIOUS_BITE.id === event.ability.guid) {
+      debug && console.log(`${this.owner.formatTimestamp(event.timestamp)} bite cast.`);
+      this.handleBiteExtend(event);
+    }
+  }
+
+  on_byPlayer_spendresource(event) {
+    if (SPELLS.RIP.id === event.ability.guid &&
+        event.resourceChangeType === RESOURCE_TYPES.COMBO_POINTS.id) {
+      this.comboLastRip = event.resourceChange;
+    }
+  }
+
+  // use damage events to keep track of each target's health to tell when they're in "execute" range
+  on_byPlayer_damage(event) {
+    // no need to track health if combatant has sabertooth, and don't track health of friendlies.
+    if (this.hasSabertooth || event.targetIsFriendly) {
+      return;
+    }
+    this.healthFraction[encodeTargetString(event.targetID, event.targetInstance)] = event.hitPoints / event.maxHitPoints;
+  }
+
+  biteCanRefresh(target) {
+    return this.hasSabertooth || 
+      (this.healthFraction[target] && this.healthFraction[target] < BITE_EXECUTE_RANGE);
+  }
+
+  handleBiteExtend(event) {
+    const target = encodeTargetString(event.targetID, event.targetInstance);
+    if (!this.biteCanRefresh(target)) {
+      return;
+    }
+    const existing = this.stateByTarget[target];
+    if (!existing || existing.expireTime < event.timestamp) {
+      return;
+    }
+
+    // Bite "refreshes the duration of your Rip on the target" which means setting to the base duration.
+    existing.expireTime = event.timestamp + this.durationOfFresh;
+    existing.pandemicTime = event.timestamp + this.durationOfFresh * (1.0 - PANDEMIC_FRACTION);
+    debug && console.log(`${this.owner.formatTimestamp(event.timestamp)} bite extended rip to ${this.owner.formatTimestamp(existing.expireTime)}`);
+  }
+
+  checkRefreshRule(stateNew) {
+    const stateOld = stateNew.prev;
+    if (!stateOld || stateOld.expireTime < stateNew.startTime) {
+      return;
+    }
+    const event = stateNew.castEvent;
+    if (!event) {
+      debug && console.warn('RipSnapshot checking refresh rule with a state that was never assigned a cast event.');
+      return;
+    }
+
+    const target = encodeTargetString(event.targetID, event.targetInstance);
+    if (this.biteCanRefresh(target) &&
+        stateOld.power >= stateNew.power) {
+      this.shouldBeBiteCount += 1;
+      event.meta = event.meta || {};
+      event.meta.isInefficientCast = true;
+      const strengthComment = (stateOld.power > stateNew.power) ? 'a stronger' : 'the same strength';
+      event.meta.inefficientCastReason = `Used Rip when you could have extended using Ferocious Bite and kept ${strengthComment} snapshot.`;
+    }
+    
+    if (stateOld.pandemicTime > stateNew.startTime &&
+        stateOld.power > stateNew.power) {
+      this.downgradeCount += 1;
+
+      // this downgrade is relatively minor, so don't overwrite cast info from elsewhere
+      if (!event.meta || (!event.meta.isInefficientCast && !event.meta.isEnhancedCast)) {
+        event.meta = event.meta || {};
+        event.meta.isInefficientCast = true;
+        event.meta.inefficientCastReason = 'You refreshed with a weaker version of Rip before the pandemic window.';
+      }
+    }
+  }
+
+  calcPower(stateNew) {
+    let power = super.calcPower(stateNew);
+    power *= (this.comboLastRip * RIP_POWER_PER_COMBO);
+    debug && console.log(`${this.owner.formatTimestamp(stateNew.startTime)} Rip applied with ${this.comboLastRip} combo points, at ${power} power.`);
+    return power;
+  }
+
+  get shouldBeBiteProportion() {
+    return this.shouldBeBiteCount / this.ripCastCount;
+  }
+  get shouldBeBiteSuggestionThresholds() {
+    return {
+      actual: this.shouldBeBiteProportion,
+      isGreaterThan: {
+        minor: 0,
+        average: 0.10,
+        major: 0.20,
+      },
+      style: 'percentage',
+    };
+  }
+
+  get downgradeProportion() {
+    return this.downgradeCount / this.ripCastCount;
+  }
+  get downgradeSuggestionThresholds() {
+    return {
+      actual: this.downgradeProportion,
+      isGreaterThan: {
+        minor: 0,
+        average: 0.15,
+        major: 0.30,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.downgradeSuggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <React.Fragment>
+          Try not to refresh <SpellLink id={SPELLS.RIP.id} /> before the <dfn data-tip={`The last ${(this.durationOfFresh * PANDEMIC_FRACTION / 1000).toFixed(1)} seconds of Rip's duration. When you refresh during this time you don't lose any duration in the process.`}>pandemic window</dfn> unless you have more powerful <dfn data-tip={"Applying Rip with Tiger's Fury or Bloodtalons will boost its damage until you reapply it."}>snapshot buffs</dfn> than were present when it was first cast.
+        </React.Fragment>
+      )
+        .icon(SPELLS.RIP.icon)
+        .actual(`${formatPercentage(actual)}% of Rip refreshes were early downgrades.`)
+        .recommended(`${recommended}% is recommended`);
+    });
+
+    when(this.shouldBeBiteSuggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      let suggestText;
+      if (this.hasSabertooth) {
+        suggestText = (
+          <React.Fragment>
+            With <SpellLink id={SPELLS.SABERTOOTH_TALENT.id} /> you should use <SpellLink id={SPELLS.FEROCIOUS_BITE.id} /> to extend the duration of <SpellLink id={SPELLS.RIP.id} />. Only use <SpellLink id={SPELLS.RIP.id} /> when the bleed is missing or when you can improve the <dfn data-tip={"Applying Rip with Tiger's Fury or Bloodtalons will boost its damage until you reapply it. This boost is maintained when Bite extends the bleed."}>snapshot.</dfn>
+          </React.Fragment>
+        );
+      } else {
+        suggestText = (
+          <React.Fragment>
+            When the enemy is below {Math.round(BITE_EXECUTE_RANGE * 100)}% health you should use <SpellLink id={SPELLS.FEROCIOUS_BITE.id} /> to extend the duration of <SpellLink id={SPELLS.RIP.id} />. Only use <SpellLink id={SPELLS.RIP.id} /> when the bleed is missing or when you can improve the <dfn data-tip={"Applying Rip with Tiger's Fury or Bloodtalons will boost its damage until you reapply it. This boost is maintained when Bite extends the bleed."}>snapshot.</dfn>
+          </React.Fragment>
+        );
+      }
+
+      return suggest(suggestText)
+        .icon(SPELLS.RIP.icon)
+        .actual(`${formatPercentage(actual)}% of Rip uses could have been replaced with Bite.`)
+        .recommended(`${recommended}% is recommended`);
+    });
+  }
+}
+export default RipSnapshot;


### PR DESCRIPTION
This analyzer keeps track of the power of the player's Rip bleeds. It provides suggestions when they are downgrading a snapshot or failing to use Bite when they could have extended a good snapshot.

Feral's Rip bleed benefits from snapshotting the effect of Tiger's Fury and Bloodtalons over its full duration, even after the buffs have worn off. Unlike Feral's other DoTs Rip's base damage also varies by how many combo points were used when it was cast. At <25% health, or always with the Sabertooth talent, Rip's duration can be extended with Ferocious Bite. Extending with Bite maintains the existing snapshot effect.

As well as adding RipSnapshot, there's some refactoring in Snapshot (which is now used by RipSnapshot and RakeSnapshot) to expose the power calculation so RipSnapshot can add to it. Plus a few small fixes and style guide things like using `.forEach` when possible.

![ripsnapshot01](https://user-images.githubusercontent.com/35700764/41048752-5bfe802a-69a7-11e8-8513-5273e36b22a9.png)
![ripsnapshot02](https://user-images.githubusercontent.com/35700764/41048753-5c25838c-69a7-11e8-9ff1-07b7eaf78c8d.png)
![ripsnapshot03](https://user-images.githubusercontent.com/35700764/41048754-5c48f876-69a7-11e8-8e97-2c2519dfcb18.png)
![ripsnapshot04](https://user-images.githubusercontent.com/35700764/41048755-5c6ce8da-69a7-11e8-9576-62d3bb880d3d.png)
![ripsnapshot05](https://user-images.githubusercontent.com/35700764/41048756-5c95449c-69a7-11e8-8b90-0855d4e746c5.png)
