### PR TITLE
[Feral] Snapshot tracking for Moonfire

### DIFF
--- a/src/Parser/Druid/Feral/CHANGELOG.js
+++ b/src/Parser/Druid/Feral/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-06-09'),
+    changes: <React.Fragment>Added snapshot tracking for <SpellLink id={SPELLS.MOONFIRE_FERAL.id} /></React.Fragment>,
+    contributors: [Anatta336],
+  },
+  {
     date: new Date('2018-06-06'),
     changes: <React.Fragment>Added snapshot tracking for <SpellLink id={SPELLS.RIP.id} /></React.Fragment>,
     contributors: [Anatta336],

--- a/src/Parser/Druid/Feral/CombatLogParser.js
+++ b/src/Parser/Druid/Feral/CombatLogParser.js
@@ -9,6 +9,7 @@ import RipUptime from './Modules/Bleeds/RipUptime';
 import FerociousBiteEnergy from './Modules/Features/FerociousBiteEnergy';
 import RakeSnapshot from './Modules/Bleeds/RakeSnapshot';
 import RipSnapshot from './Modules/Bleeds/RipSnapshot';
+import MoonfireSnapshot from './Modules/Bleeds/MoonfireSnapshot';
 
 import ComboPointTracker from './Modules/ComboPoints/ComboPointTracker';
 import ComboPointDetails from './Modules/ComboPoints/ComboPointDetails';
@@ -37,6 +38,7 @@ class CombatLogParser extends CoreCombatLogParser {
     ripUptime: RipUptime,
     rakeSnapshot: RakeSnapshot,
     ripSnapshot: RipSnapshot,
+    moonfireSnapshot: MoonfireSnapshot,
 
     // talents
     savageRoarUptime: SavageRoarUptime,

--- a/src/Parser/Druid/Feral/Modules/Bleeds/MoonfireSnapshot.js
+++ b/src/Parser/Druid/Feral/Modules/Bleeds/MoonfireSnapshot.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import { formatPercentage } from 'common/format';
+
+import Snapshot, { PANDEMIC_FRACTION } from '../FeralCore/Snapshot';
+
+/**
+ * Moonfire benefits from the damage bonus of Tiger's Fury over its whole duration, even if the
+ * buff wears off in that time. It's a damage loss to refresh Moonfire before the pandemic window
+ * if you don't have Tiger's Fury active when the existing DoT does have it active.
+ */
+
+// cat moonfire lasts for 14 seconds, unlike caster and bear moonfire with a base of 16 seconds.
+const MOONFIRE_FERAL_BASE_DURATION = 14000;
+
+class MoonfireSnapshot extends Snapshot {
+  moonfireCastCount = 0;
+  downgradeCastCount = 0;
+
+  on_initialized() {
+    if (!this.combatants.selected.hasTalent(SPELLS.LUNAR_INSPIRATION_TALENT.id)) {
+      this.active = false;
+      return;
+    }
+
+    this.spellCastId = SPELLS.MOONFIRE_FERAL.id;
+    this.debuffId = SPELLS.MOONFIRE_FERAL.id;
+
+    // unlike bleeds, Moonfire's duration is not affected by the Jagged Wounds talent
+    this.durationOfFresh = MOONFIRE_FERAL_BASE_DURATION;
+    this.isProwlAffected = false;
+    this.isTigersFuryAffected = true;
+
+    // bloodtalons only affects melee abilities
+    this.isBloodtalonsAffected = false;
+  }
+
+  on_byPlayer_cast(event) {
+    if (SPELLS.MOONFIRE_FERAL.id === event.ability.guid) {
+      ++this.moonfireCastCount;
+    }
+    super.on_byPlayer_cast(event);
+  }
+
+  checkRefreshRule(stateNew) {
+    const stateOld = stateNew.prev;
+    if (!stateOld || stateOld.expireTime < stateNew.startTime) {
+      // not a refresh, so nothing to check
+      return;
+    }
+    
+    if (stateNew.startTime >= stateOld.pandemicTime ||
+        stateNew.power >= stateOld.power) {
+      // good refresh
+      return;
+    }
+    
+    ++this.downgradeCastCount;
+    
+    // this downgrade is relatively minor, so don't overwrite cast info from elsewhere
+    const event = stateNew.castEvent;
+    if (event.meta && (event.meta.isInefficientCast || event.meta.isEnhancedCast)) {
+      return;
+    }
+    event.meta = event.meta || {};
+    event.meta.isInefficientCast = true;
+    event.meta.inefficientCastReason = 'You refreshed with a weaker version of Moonfire before the pandemic window.';
+  }
+
+  get downgradeProportion() {
+    return this.downgradeCastCount / this.moonfireCastCount;
+  }
+  get downgradeSuggestionThresholds() {
+    return {
+      actual: this.downgradeProportion,
+      isGreaterThan: {
+        minor: 0,
+        average: 0.30,
+        major: 0.60,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.downgradeSuggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <React.Fragment>
+          Try not to refresh <SpellLink id={SPELLS.MOONFIRE_FERAL.id} /> before the <dfn data-tip={`The last ${(this.durationOfFresh * PANDEMIC_FRACTION / 1000).toFixed(1)} seconds of Moonfire's duration. When you refresh during this time you don't lose any duration in the process.`}>pandemic window</dfn> unless you have more powerful <dfn data-tip={"Applying Moonfire with Tiger's Fury will boost its damage until you reapply it."}>snapshot buffs</dfn> than were present when it was first cast.
+        </React.Fragment>
+      )
+        .icon(SPELLS.MOONFIRE_FERAL.icon)
+        .actual(`${formatPercentage(actual)}% of Moonfire refreshes were early downgrades.`)
+        .recommended(`${recommended}% is recommended`);
+    });
+  }
+}
+export default MoonfireSnapshot;


### PR DESCRIPTION
Moonfire (granted to Feral only with the Lunar Inspiration talent) is the simplest of the snapshot-benefiting abilities as it only benefits from the damage bonus of Tiger's Fury, and unlike Rip has no other mechanics affecting its base damage.

The same rule applies for Moonfire as the rest: only refresh before pandemic if you would upgrade the snapshot. Using the Snapshot class shared with RakeSnapshot and RipSnapshot, this analyzer checks for the combatant "downgrading" their Moonfire DoTs. Inefficient casts are marked on the timeline and a suggestion is generated if they do it often.

![moonfiresnapshot01](https://user-images.githubusercontent.com/35700764/41185827-75471bb2-6b84-11e8-9578-a49cf5b82a32.png)
![moonfiresnapshot02](https://user-images.githubusercontent.com/35700764/41185828-7569ef5c-6b84-11e8-9cc4-b2a8a29f58a5.png)
