### PR TITLE
[BFA] [Frost Mage] Fix Checklist Crash

### DIFF
--- a/src/Parser/Mage/Frost/Modules/Features/Checklist.js
+++ b/src/Parser/Mage/Frost/Modules/Features/Checklist.js
@@ -115,7 +115,7 @@ class Checklist extends CoreChecklist {
             onlyWithSuggestion: false,
           }),
           new GenericCastEfficiencyRequirement({
-            spell: SPELLS.EBONBOLT,
+            spell: SPELLS.EBONBOLT_TALENT,
             onlyWithSuggestion: false,
             when: combatant.hasTalent(SPELLS.EBONBOLT_TALENT.id),
           }),

--- a/src/common/SPELLS/MAGE.js
+++ b/src/common/SPELLS/MAGE.js
@@ -143,13 +143,18 @@ export default {
     name: 'Frozen Orb',
     icon: 'spell_frost_frozenorb',
   },
+  FROZEN_ORB_DAMAGE: {
+    id: 84721,
+    name: 'Frozen orb',
+    icon: 'spell_frost_frozenorb',
+  },
   SUMMON_WATER_ELEMENTAL: {
     id: 31687,
     name: 'Summon Water Elemental',
     icon: 'spell_frost_summonwaterelemental_2',
   },
   EBONBOLT_DAMAGE: {
-    id: 228599,
+    id: 257538,
     name: 'Ebonbolt',
     icon: 'artifactability_frostmage_ebonbolt',
   },


### PR DESCRIPTION
Missed a reference to SPELLS.EBONBOLT which caused a crash when loading logs.