### PR TITLE
[Feral] Rake normalizer, minor changes in Snapshots

### DIFF
--- a/src/Parser/Druid/Feral/CombatLogParser.js
+++ b/src/Parser/Druid/Feral/CombatLogParser.js
@@ -1,9 +1,12 @@
 import CoreCombatLogParser from 'Parser/Core/CombatLogParser';
+
 import DamageDone from 'Parser/Core/Modules/DamageDone';
 
+import RakeBleed from './Modules/Normalizers/RakeBleed';
 import Abilities from './Modules/Features/Abilities';
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
 import CooldownThroughputTracker from './Modules/Features/CooldownThroughputTracker';
+
 import RakeUptime from './Modules/Bleeds/RakeUptime';
 import RipUptime from './Modules/Bleeds/RipUptime';
 import FerociousBiteEnergy from './Modules/Features/FerociousBiteEnergy';
@@ -24,6 +27,9 @@ import SoulOfTheArchdruid from '../Shared/Modules/Items/SoulOfTheArchdruid';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
+    // Normalizers
+    rakeBleed: RakeBleed,
+
     // FeralCore
     damageDone: [DamageDone, { showStatistic: true }],
 

--- a/src/Parser/Druid/Feral/Modules/Bleeds/MoonfireSnapshot.js
+++ b/src/Parser/Druid/Feral/Modules/Bleeds/MoonfireSnapshot.js
@@ -15,7 +15,6 @@ import Snapshot, { PANDEMIC_FRACTION } from '../FeralCore/Snapshot';
 const MOONFIRE_FERAL_BASE_DURATION = 14000;
 
 class MoonfireSnapshot extends Snapshot {
-  moonfireCastCount = 0;
   downgradeCastCount = 0;
 
   on_initialized() {
@@ -34,13 +33,7 @@ class MoonfireSnapshot extends Snapshot {
 
     // bloodtalons only affects melee abilities
     this.isBloodtalonsAffected = false;
-  }
-
-  on_byPlayer_cast(event) {
-    if (SPELLS.MOONFIRE_FERAL.id === event.ability.guid) {
-      ++this.moonfireCastCount;
-    }
-    super.on_byPlayer_cast(event);
+    super.on_initialized();
   }
 
   checkRefreshRule(stateNew) {
@@ -56,7 +49,7 @@ class MoonfireSnapshot extends Snapshot {
       return;
     }
     
-    ++this.downgradeCastCount;
+    this.downgradeCastCount += 1;
     
     // this downgrade is relatively minor, so don't overwrite cast info from elsewhere
     const event = stateNew.castEvent;
@@ -69,14 +62,14 @@ class MoonfireSnapshot extends Snapshot {
   }
 
   get downgradeProportion() {
-    return this.downgradeCastCount / this.moonfireCastCount;
+    return this.downgradeCastCount / this.castCount;
   }
   get downgradeSuggestionThresholds() {
     return {
       actual: this.downgradeProportion,
       isGreaterThan: {
         minor: 0,
-        average: 0.30,
+        average: 0.15,
         major: 0.60,
       },
       style: 'percentage',

--- a/src/Parser/Druid/Feral/Modules/Bleeds/RipSnapshot.js
+++ b/src/Parser/Druid/Feral/Modules/Bleeds/RipSnapshot.js
@@ -45,9 +45,9 @@ class RipSnapshot extends Snapshot {
     comboPointTracker: ComboPointTracker,
   };
 
-  ripCastCount = 0;
   downgradeCount = 0;
   shouldBeBiteCount = 0;
+
   /**
    * Order of processed events when player casts rip is always:
    *   on_byPlayer_cast
@@ -75,14 +75,11 @@ class RipSnapshot extends Snapshot {
     if (combatant.hasTalent(SPELLS.SABERTOOTH_TALENT.id)) {
       this.hasSabertooth = true;
     }
+    super.on_initialized();
   }
 
   on_byPlayer_cast(event) {
     super.on_byPlayer_cast(event);
-    if (SPELLS.RIP.id === event.ability.guid) {
-      this.ripCastCount += 1;
-      debug && console.log(`${this.owner.formatTimestamp(event.timestamp)} rip cast.`);
-    }
     if (SPELLS.FEROCIOUS_BITE.id === event.ability.guid) {
       debug && console.log(`${this.owner.formatTimestamp(event.timestamp)} bite cast.`);
       this.handleBiteExtend(event);
@@ -170,7 +167,7 @@ class RipSnapshot extends Snapshot {
   }
 
   get shouldBeBiteProportion() {
-    return this.shouldBeBiteCount / this.ripCastCount;
+    return this.shouldBeBiteCount / this.castCount;
   }
   get shouldBeBiteSuggestionThresholds() {
     return {
@@ -185,7 +182,7 @@ class RipSnapshot extends Snapshot {
   }
 
   get downgradeProportion() {
-    return this.downgradeCount / this.ripCastCount;
+    return this.downgradeCount / this.castCount;
   }
   get downgradeSuggestionThresholds() {
     return {
@@ -193,7 +190,7 @@ class RipSnapshot extends Snapshot {
       isGreaterThan: {
         minor: 0,
         average: 0.15,
-        major: 0.30,
+        major: 0.60,
       },
       style: 'percentage',
     };

--- a/src/Parser/Druid/Feral/Modules/FeralCore/Snapshot.js
+++ b/src/Parser/Druid/Feral/Modules/FeralCore/Snapshot.js
@@ -5,34 +5,32 @@ import { encodeTargetString } from 'Parser/Core/Modules/EnemyInstances';
 
 const debug = false;
 
-/*
-Feral has a snapshotting mechanic which means the effect of some buffs are maintained over the duration of
-some DoTs even after the buff has worn off.
-Players should follow a number of rules with regards when they refresh a DoT and when they do not, depending
-on what buffs the DoT has snapshot and what buffs are currently active.
+/**
+ * Feral has a snapshotting mechanic which means the effect of some buffs are maintained over the duration of
+ * some DoTs even after the buff has worn off.
+ * Players should follow a number of rules with regards when they refresh a DoT and when they do not, depending
+ * on what buffs the DoT has snapshot and what buffs are currently active.
+ * 
+ * The Snapshot class is 'abstract', and shouldn't be directly instantiated. Instead classes should extend
+ * it to examine how well the combatant is making use of the snapshot mechanic.
+ */
 
-RAKE snapshots:
-  Prowl, Tiger's Fury, Bloodtalons
-RIP snapshots:
-  Tiger's Fury, Bloodtalons
-MOONFIRE_FERAL snapshots:
-  Tiger's Fury
-THRASH_FERAL snapshots: (but isn't used in single target situations)
-  Tiger's Fury, Moment of Clarity
-
-The Snapshot class is 'abstract', and shouldn't be directly instantiated. Instead classes should extend
-it and test how well the combatant is making use of the snapshot mechanic.
-*/
-
+// also applied by Incarnation: King of the Jungle, and Shadowmeld
+const PROWL_MULTIPLIER = 2.00;
 const TIGERS_FURY_MULTIPLIER = 1.15;
-const PROWL_MULTIPLIER = 2.00; // also applied by Incarnation: King of the Jungle, and Shadowmeld
 const BLOODTALONS_MULTIPLIER = 1.20;
 
-const JAGGED_WOUNDS_MODIFIER = 0.80;  // "[...]deal the same damage as normal but in 20% less time."
+// "[...]deal the same damage as normal but in 20% less time."
+const JAGGED_WOUNDS_MODIFIER = 0.80;
+
 const PANDEMIC_FRACTION = 0.3;
 
-// leeway in ms after loss of bloodtalons/prowl buff to count a cast as being buffed. Keep as low as possible to avoid false positives from buffs fading due to causes other than being used to buff a DoT.
+/**
+ * leeway in ms after loss of bloodtalons/prowl buff to count a cast as being buffed.
+ * Danger of false positives from buffs fading due to causes other than being used to buff a DoT.
+ */
 const BUFF_WINDOW_TIME = 60;
+
 // leeway in ms between a cast event and debuff apply/refresh for them to be associated
 const CAST_WINDOW_TIME = 100;
 
@@ -42,30 +40,31 @@ class Snapshot extends Analyzer {
   };
 
   // extending class should fill these in:
-  spellCastId;
-  debuffId;
-  isProwlAffected;
-  isTigersFuryAffected;
-  isBloodtalonsAffected;
-  durationOfFresh;
+  spellCastId = null;
+  debuffId = null;
+  isProwlAffected = false;
+  isTigersFuryAffected = false;
+  isBloodtalonsAffected = false;
+  durationOfFresh = false;
 
   stateByTarget = {};
   lastDoTCastEvent;
+
+  castCount = 0;
 
   on_byPlayer_cast(event) {
     if (this.spellCastId !== event.ability.guid) {
       return;
     }
+    this.castCount += 1;
     this.lastDoTCastEvent = event;
-    
-    // attempt to associate with (very) recent debuff apply/refresh
-    // this cast could apply DoTs to multiple targets, so check them all
-    Object.values(this.stateByTarget).forEach(state => {
-      if (!state.castEvent && event.timestamp - state.startTime < CAST_WINDOW_TIME) {
-        event.castEvent = event;
-        this.checkRuleIfReady(state);
-      }
-    });
+  }
+
+  on_initialized() {
+    if (!this.spellCastId || !this.debuffId) {
+      this.active = false;
+      debug && console.warn('Snapshot missing spellCastId or debuffId.');
+    }
   }
 
   on_byPlayer_applydebuff(event) {
@@ -88,9 +87,9 @@ class Snapshot extends Analyzer {
     const stateNew = this.makeNewState(event, stateOld);
     this.stateByTarget[targetString] = stateNew;
 
-    debug && console.log(`DoT ${this.debuffId} applied at ${this.owner.formatTimestamp(event.timestamp)} Prowl:${stateNew.prowl}, TF: ${stateNew.tigersFury}, BT: ${stateNew.bloodtalons}. Expires at ${this.owner.formatTimestamp(stateNew.expireTime)}, pandemic from: ${this.owner.formatTimestamp(stateNew.pandemicTime)}`);
+    debug && console.log(`DoT ${this.debuffId} applied at ${this.owner.formatTimestamp(event.timestamp, 3)} Prowl:${stateNew.prowl}, TF: ${stateNew.tigersFury}, BT: ${stateNew.bloodtalons}. Expires at ${this.owner.formatTimestamp(stateNew.expireTime, 3)}`);
 
-    this.checkRuleIfReady(stateNew);
+    this.checkRefreshRule(stateNew);
   }
 
   makeNewState(debuffEvent, stateOld) {
@@ -116,18 +115,18 @@ class Snapshot extends Analyzer {
         combatant.hasBuff(SPELLS.BLOODTALONS_BUFF.id, null, BUFF_WINDOW_TIME),
       power: 1,
       startTime: debuffEvent.timestamp,
-      castEvent: null,  // should get assigned within the next 100ms
-      prev: stateOld,   // may be undefined
-      hasBeenRuleChecked: false,
+      castEvent: this.lastDoTCastEvent,
+      
+      // undefined if the first application of this debuff on this target
+      prev: stateOld,
     };
     stateNew.power = this.calcPower(stateNew);
 
-    // attempt to associate with recent cast event
-    if (this.lastDoTCastEvent && (debuffEvent.timestamp - this.lastDoTCastEvent.timestamp) < CAST_WINDOW_TIME) {
-      stateNew.castEvent = this.lastDoTCastEvent;
-      debug && console.log('linked DoT with cast event.');
+    if (!stateNew.castEvent ||
+        stateNew.startTime > stateNew.castEvent.timestamp + CAST_WINDOW_TIME ) {
+      debug && console.warn(`DoT ${this.debuffId} applied debuff at ${this.owner.formatTimestamp(debuffEvent.timestamp, 3)} doesn't have a recent matching cast event.`);
     }
-
+    
     return stateNew;
   }
 
@@ -143,14 +142,6 @@ class Snapshot extends Analyzer {
       power *= BLOODTALONS_MULTIPLIER;
     }
     return power;
-  }
-
-  checkRuleIfReady(state) {
-    // only check a state transition for rule-breaking once, and only after it has a cast event associated with it.
-    if (!state.hasBeenRuleChecked && state.castEvent) {
-      this.checkRefreshRule(state);
-      state.hasBeenRuleChecked = true;
-    }
   }
 
   checkRefreshRule(state) {

--- a/src/Parser/Druid/Feral/Modules/Normalizers/RakeBleed.js
+++ b/src/Parser/Druid/Feral/Modules/Normalizers/RakeBleed.js
@@ -1,0 +1,45 @@
+import SPELLS from 'common/SPELLS';
+import EventsNormalizer from 'Parser/Core/EventsNormalizer';
+
+const CAST_WINDOW = 100;
+class RakeBleed extends EventsNormalizer {
+  /**
+   * When used from stealth SPELLS.RAKE cast event often appears after the SPELLS.RAKE_BLEED
+   * applydebuff event that it causes. (Possibly this misordering has something to do with Rake
+   * from stealth also attempting to apply a stun debuff.)
+   * This normalizes events so the applydebuff always comes after cast.
+   * @param {Array} events
+   * @returns {Array} Events possibly with some reordered.
+   */
+  normalize(events) {
+    const fixedEvents = [];
+    events.forEach((event, eventIndex) => {
+    fixedEvents.push(event);
+
+    // find a cast event for rake
+    if(event.type === 'cast' && event.ability.guid === SPELLS.RAKE.id) {
+      const castTimestamp = event.timestamp;
+
+      // look for any recent applydebuff or refreshdebuff of RAKE_BLEED
+      for (let previousEventIndex = eventIndex; previousEventIndex >= 0; previousEventIndex -= 1) {
+        const previousEvent = fixedEvents[previousEventIndex];
+        if ((castTimestamp - previousEvent.timestamp) > CAST_WINDOW) {
+          break;
+        }
+        if ((previousEvent.type === 'applydebuff' || previousEvent.type === 'refreshdebuff') &&
+        previousEvent.ability.guid === SPELLS.RAKE_BLEED.id &&
+        previousEvent.sourceID === event.sourceID) {
+          fixedEvents.splice(previousEventIndex, 1);
+          fixedEvents.push(previousEvent);
+          previousEvent.__modified = true;
+          break;
+        }
+      }
+    }
+    });
+
+    return fixedEvents;
+  }
+}
+
+export default RakeBleed;


### PR DESCRIPTION
This adds a RakeBleed normalizer which ensures the `applydebuff` or `refreshdebuff` for Rake's bleed always appear after that Rake's `cast` event. With this normalizer in place the code in Snapshot that handled them being out of order is now removed. After checking with a lot of logs it's only ever Rake that had the events in the wrong order, and only when used from stealth.

I also made some minor changes to the Snapshot, RakeSnapshot, RipSnapshot, and MoonfireSnapshot modules from my recent pull requests.
- `castCount` is now maintained on Snapshot rather than having near identical code on each subclass.
- The threshold for "major" suggestions about snapshot downgrading has been significantly pushed up. With current Feral tuning even completely messing up the snapshot mechanic is a fairly small overall damage loss. This is expected to change in BfA, when the thresholds should be adjusted again. 
- Various tidying up I couldn't resist, initialising variables and so on.
