### PR TITLE
[BFA] [Frost Mage] Frost Mage Prepatch Changes

### DIFF
--- a/src/Parser/Mage/Frost/CHANGELOG.js
+++ b/src/Parser/Mage/Frost/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-06-10'),
+    changes: <React.Fragment>Updated for 8.0 Prepatch</React.Fragment>,
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2018-01-27'),
     changes: <React.Fragment>Marked spec completeness as Great!</React.Fragment>,
     contributors: [Sharrq],

--- a/src/Parser/Mage/Frost/CONFIG.js
+++ b/src/Parser/Mage/Frost/CONFIG.js
@@ -9,7 +9,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list.
   contributors: [Sharrq, sref],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '7.3.5',
+  patchCompatibility: '8.0',
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more. If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <React.Fragment>

--- a/src/Parser/Mage/Frost/CombatLogParser.js
+++ b/src/Parser/Mage/Frost/CombatLogParser.js
@@ -17,6 +17,7 @@ import SplittingIce from './Modules/Features/SplittingIce';
 import CancelledCasts from '../Shared/Modules/Features/CancelledCasts';
 
 import FrozenOrb from './Modules/Cooldowns/FrozenOrb';
+import ColdSnap from './Modules/Cooldowns/ColdSnap';
 
 import ShardOfTheExodar from '../Shared/Modules/Items/ShardOfTheExodar';
 import Tier20_2set from './Modules/Items/Tier20_2set';
@@ -53,6 +54,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
 	  //Cooldowns
     frozenOrb: FrozenOrb,
+    coldSnap: ColdSnap,
 
 	  //Items
 	  tier20_2set: Tier20_2set,

--- a/src/Parser/Mage/Frost/Modules/Cooldowns/ColdSnap.js
+++ b/src/Parser/Mage/Frost/Modules/Cooldowns/ColdSnap.js
@@ -1,0 +1,25 @@
+import SPELLS from 'common/SPELLS';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import Analyzer from 'Parser/Core/Analyzer';
+import SpellUsable from 'Parser/Core/Modules/SpellUsable';
+
+class ColdSnap extends Analyzer {
+
+	static dependencies = {
+		combatants: Combatants,
+		spellUsable: SpellUsable,
+	}
+
+  	on_byPlayer_cast(event) {
+		const spellId = event.ability.guid;
+		if(spellId !== SPELLS.COLD_SNAP.id) {
+			return;
+		}
+		if (this.spellUsable.isOnCooldown(SPELLS.ICE_BARRIER.id)) { this.spellUsable.endCooldown(SPELLS.ICE_BARRIER.id); }
+		if (this.spellUsable.isOnCooldown(SPELLS.CONE_OF_COLD.id)) { this.spellUsable.endCooldown(SPELLS.CONE_OF_COLD.id); }
+		if (this.spellUsable.isOnCooldown(SPELLS.FROST_NOVA.id)) { this.spellUsable.endCooldown(SPELLS.FROST_NOVA.id); }
+		if (this.spellUsable.isOnCooldown(SPELLS.ICE_BLOCK.id)) { this.spellUsable.endCooldown(SPELLS.ICE_BLOCK.id); }
+  }
+}
+
+export default ColdSnap;

--- a/src/common/SPELLS/MAGE.js
+++ b/src/common/SPELLS/MAGE.js
@@ -460,21 +460,6 @@ export default {
   },
 
   //Removed in 8.0 (Keep Temporarily until not needed anymore)
-  WATER_JET: {
-    id: 135029,
-    name: 'Water Jet',
-    icon: 'ability_mage_waterjet',
-  },
-  FROZEN_VEINS_TRAIT: {
-    id: 195345,
-    name: 'Frozen Veins',
-    icon: 'spell_frost_coldhearted',
-  },
-  ICE_NINE: {
-    id: 214664,
-    name: 'Ice Nine',
-    icon: 'spell_frost_iceshard',
-  },
   WARMTH_OF_THE_PHOENIX: {
     id: 240671,
     name: 'Warmth of the Phoenix',
@@ -505,25 +490,10 @@ export default {
     name: 'Phoenix\'s Flames',
     icon: 'artifactability_firemage_phoenixbolt',
   },
-  EBONBOLT: {
-    id: 214634,
-    name: 'Ebonbolt',
-    icon: 'artifactability_frostmage_ebonbolt',
-  },
   UNSTABLE_MAGIC_DAMAGE_FIRE: {
     id: 157977,
     name: 'Unstable Magic',
     icon: 'spell_mage_unstablemagic',
-  },
-  UNSTABLE_MAGIC_DAMAGE_FROST: {
-    id: 157978,
-    name: 'Unstable Magic',
-    icon: 'spell_mage_unstablemagic',
-  },
-  FROST_BOMB_DAMAGE: {
-    id: 113092,
-    name: 'Frost Bomb',
-    icon: 'spell_mage_frostbomb',
   },
   CINDERSTORM_DAMAGE: {
     id: 198928,

--- a/src/common/SPELLS/TALENTS/MAGE.js
+++ b/src/common/SPELLS/TALENTS/MAGE.js
@@ -2,11 +2,11 @@
 
 export default {
   // Shared
-  SHIMMER_TALENT: { id: 212653, name: "Shimmer", icon: "spell_arcane_massdispel", manaCost: 22000 },
-  MIRROR_IMAGE_TALENT: { id: 55342, name: "Mirror Image", icon: "spell_magic_lesserinvisibilty", manaCost: 22000 },
+  SHIMMER_TALENT: { id: 212653, name: "Shimmer", icon: "spell_arcane_massdispel" },
+  MIRROR_IMAGE_TALENT: { id: 55342, name: "Mirror Image", icon: "spell_magic_lesserinvisibilty" },
   RUNE_OF_POWER_TALENT: { id: 116011, name: "Rune of Power", icon: "spell_mage_runeofpower" },
   INCANTERS_FLOW_TALENT: { id: 1463, name: "Incanter's Flow", icon: "ability_mage_incantersabsorbtion" },
-  RING_OF_FROST_TALENT: { id: 113724, name: "Ring of Frost", icon: "spell_frost_ringoffrost", manaCost: 22000 },
+  RING_OF_FROST_TALENT: { id: 113724, name: "Ring of Frost", icon: "spell_frost_ringoffrost" },
   ICE_WARD_TALENT: { id: 205036, name: "Ice Ward", icon: "spell_frost_frostward" },
   
   // Fire
@@ -21,10 +21,10 @@ export default {
   FRENETIC_SPEED_TALENT: { id: 236058, name: "Frenetic Speed", icon: "spell_fire_burningspeed" },
   FLAME_PATCH_TALENT: { id: 205037, name: "Flame Patch", icon: "spell_mage_flameorb" },
   CONFLAGRATION_TALENT: { id: 205023, name: "Conflagration", icon: "spell_shaman_firenova" },
-  LIVING_BOMB_TALENT: { id: 44457, name: "Living Bomb", icon: "ability_mage_livingbomb", manaCost: 16500 },
+  LIVING_BOMB_TALENT: { id: 44457, name: "Living Bomb", icon: "ability_mage_livingbomb" },
   KINDLING_TALENT: { id: 155148, name: "Kindling", icon: "spell_mage_kindling" },
   PYROCLASM_TALENT: { id: 269650, name: "Pyroclasm", icon: "spell_shaman_lavasurge" },
-  METEOR_TALENT: { id: 153561, name: "Meteor", icon: "spell_mage_meteor", manaCost: 11000 },
+  METEOR_TALENT: { id: 153561, name: "Meteor", icon: "spell_mage_meteor" },
 
   // Arcane
   RULE_OF_THREES_TALENT: { id: 264354, name: "Rule of Threes", icon: "spell_arcane_starfire" },
@@ -38,10 +38,10 @@ export default {
   CHRONO_SHIFT_TALENT: { id: 235711, name: "Chrono Shift", icon: "ability_monk_deadlyreach" },
   EROSION_TALENT: { id: 205039, name: "Erosion", icon: "ability_mage_missilebarrage" },
   UNSTABLE_MAGIC_TALENT: { id: 157976, name: "Unstable Magic", icon: "spell_mage_unstablemagic" },
-  NETHER_TEMPEST_TALENT: { id: 114923, name: "Nether Tempest", icon: "spell_mage_nethertempest", manaCost: 16500 },
+  NETHER_TEMPEST_TALENT: { id: 114923, name: "Nether Tempest", icon: "spell_mage_nethertempest" },
   OVERPOWERED_TALENT: { id: 155147, name: "Overpowered", icon: "spell_mage_overpowered" },
   TEMPORAL_FLUX_TALENT: { id: 234302, name: "Temporal Flux", icon: "spell_arcane_arcanetorrent" },
-  ARCANE_ORB_TALENT: { id: 153626, name: "Arcane Orb", icon: "spell_mage_arcaneorb", manaCost: 11000 },
+  ARCANE_ORB_TALENT: { id: 153626, name: "Arcane Orb", icon: "spell_mage_arcaneorb" },
 
   // Frost
   BONE_CHILLING_TALENT: { id: 205027, name: "Bone Chilling", icon: "ability_mage_chilledtothebone" },
@@ -55,15 +55,13 @@ export default {
   FRIGID_WINDS_TALENT: { id: 235224, name: "Frigid Winds", icon: "ability_mage_deepfreeze" },
   FREEZING_RAIN_TALENT: { id: 270233, name: "Freezing Rain", icon: "spell_frost_frozenorb" },
   SPLITTING_ICE_TALENT: { id: 56377, name: "Splitting Ice", icon: "spell_frost_iceshards" },
-  COMET_STORM_TALENT: { id: 153595, name: "Comet Storm", icon: "spell_mage_cometstorm", manaCost: 11000 },
+  COMET_STORM_TALENT: { id: 153595, name: "Comet Storm", icon: "spell_mage_cometstorm" },
   THERMAL_VOID_TALENT: { id: 155149, name: "Thermal Void", icon: "spell_mage_thermalvoid" },
   RAY_OF_FROST_TALENT: { id: 205021, name: "Ray of Frost", icon: "ability_mage_rayoffrost" },
-  GLACIAL_SPIKE_TALENT: { id: 199786, name: "Glacial Spike", icon: "ability_mage_glacialspike", manaCost: 11000 },
+  GLACIAL_SPIKE_TALENT: { id: 199786, name: "Glacial Spike", icon: "ability_mage_glacialspike" },
 
   //Removed Talents (Keep Temporarily until not needed anymore)
   CONTROLLED_BURN_TALENT: { id: 205033, name: "Controlled Burn", icon: "inv_trinket_firelands_02" },
-  CINDERSTORM_TALENT: { id: 198929, name: "Cinderstorm", icon: "spell_fire_flare", manaCost: 11000 },
+  CINDERSTORM_TALENT: { id: 198929, name: "Cinderstorm", icon: "spell_fire_flare" },
   WORDS_OF_POWER_TALENT: { id: 205035, name: "Words of Power", icon: "spell_arcane_rune" },
-  FROST_BOMB_TALENT: { id: 112948, name: "Frost Bomb", icon: "spell_mage_frostbomb", manaCost: 13750 },
-  ARCTIC_GALE_TALENT: { id: 205038, name: "Arctic Gale", icon: "spell_frost_arcticwinds" },
 };


### PR DESCRIPTION
The below changes were made to the spec for prepatch support. I believe these are the last of the changes needed for prepatch (at least until numerical tuning).

- Removed some spells and talents from the MAGE common files
- Added a Cooldown Reset for Cold Snap (to get rid of a console warning about using Ice Block while its on cooldown)
- Removed the mana costs from talents (to get rid of a console warning about the mana costs not matching what was hard coded)
- Updated Config Patch Compatibility to 8.0
- Added Changelog entry