### PR TITLE
[Protection Warrior][Bug] Ragetracker fix

### DIFF
--- a/src/Parser/Warrior/Protection/Modules/Talents/AngerManagement.js
+++ b/src/Parser/Warrior/Protection/Modules/Talents/AngerManagement.js
@@ -34,11 +34,13 @@ class AngerManagement extends Analyzer {
   }
 
   on_byPlayer_cast(event) {
-    if (event.classResources[0].type !== RESOURCE_TYPES.RAGE.id || !event.classResources[0].cost) {
+    if (!event.classResources || 
+        !event.classResources.filter(e => e.type !== RESOURCE_TYPES.RAGE.id) || 
+        !event.classResources.find(e => e.type === RESOURCE_TYPES.RAGE.id).cost) {
       return;
     }
 
-    const rageSpend = event.classResources[0].cost / 10;
+    const rageSpend = event.classResources.find(e => e.type === RESOURCE_TYPES.RAGE.id).cost / 10;
     const reduction = rageSpend / 10 * 1000;
     COOLDOWNS_AFFECTED_BY_ANGER_MANAGEMENT.forEach(e => {
       if (!this.spellUsable.isOnCooldown(e)) {


### PR DESCRIPTION
https://wowanalyzer.com/report/VBxMtwKyr3aq4gTb/4-Heroic+Garothi+Worldbreaker+-+Kill+(6:21)/1-Ata

Would crash due to the missing `classResources` prop on some spells (in this case KJBW). 

Also updated the `classResources`-check to look into all elements and check if it has infos on rage-cost.
Doesn't cause any issues right now, but should be more robust this way if Blizzard decides to mess with the `classResources`-field.