### PR TITLE
[Feral] Test for RakeBleed normalizer, plus fixes from review

### DIFF
--- a/src/Parser/Druid/Feral/Modules/Bleeds/MoonfireSnapshot.js
+++ b/src/Parser/Druid/Feral/Modules/Bleeds/MoonfireSnapshot.js
@@ -15,25 +15,26 @@ import Snapshot, { PANDEMIC_FRACTION } from '../FeralCore/Snapshot';
 const MOONFIRE_FERAL_BASE_DURATION = 14000;
 
 class MoonfireSnapshot extends Snapshot {
+  static spellName = SPELLS.MOONFIRE_FERAL.name;
+  static spellCastId = SPELLS.MOONFIRE_FERAL.id;
+  static debuffId = SPELLS.MOONFIRE_FERAL.id;
+
+  // unlike bleeds, Moonfire's duration is not affected by the Jagged Wounds talent
+  static durationOfFresh = MOONFIRE_FERAL_BASE_DURATION;
+  static isProwlAffected = false;
+  static isTigersFuryAffected = true;
+
+  // bloodtalons only affects melee abilities
+  static isBloodtalonsAffected = false;
+
   downgradeCastCount = 0;
 
   on_initialized() {
+    super.on_initialized();
     if (!this.combatants.selected.hasTalent(SPELLS.LUNAR_INSPIRATION_TALENT.id)) {
       this.active = false;
       return;
     }
-
-    this.spellCastId = SPELLS.MOONFIRE_FERAL.id;
-    this.debuffId = SPELLS.MOONFIRE_FERAL.id;
-
-    // unlike bleeds, Moonfire's duration is not affected by the Jagged Wounds talent
-    this.durationOfFresh = MOONFIRE_FERAL_BASE_DURATION;
-    this.isProwlAffected = false;
-    this.isTigersFuryAffected = true;
-
-    // bloodtalons only affects melee abilities
-    this.isBloodtalonsAffected = false;
-    super.on_initialized();
   }
 
   checkRefreshRule(stateNew) {
@@ -80,7 +81,7 @@ class MoonfireSnapshot extends Snapshot {
     when(this.downgradeSuggestionThresholds).addSuggestion((suggest, actual, recommended) => {
       return suggest(
         <React.Fragment>
-          Try not to refresh <SpellLink id={SPELLS.MOONFIRE_FERAL.id} /> before the <dfn data-tip={`The last ${(this.durationOfFresh * PANDEMIC_FRACTION / 1000).toFixed(1)} seconds of Moonfire's duration. When you refresh during this time you don't lose any duration in the process.`}>pandemic window</dfn> unless you have more powerful <dfn data-tip={"Applying Moonfire with Tiger's Fury will boost its damage until you reapply it."}>snapshot buffs</dfn> than were present when it was first cast.
+          Try not to refresh <SpellLink id={SPELLS.MOONFIRE_FERAL.id} /> before the <dfn data-tip={`The last ${(this.constructor.durationOfFresh * PANDEMIC_FRACTION / 1000).toFixed(1)} seconds of Moonfire's duration. When you refresh during this time you don't lose any duration in the process.`}>pandemic window</dfn> unless you have more powerful <dfn data-tip={"Applying Moonfire with Tiger's Fury will boost its damage until you reapply it."}>snapshot buffs</dfn> than were present when it was first cast.
         </React.Fragment>
       )
         .icon(SPELLS.MOONFIRE_FERAL.icon)

--- a/src/Parser/Druid/Feral/Modules/Bleeds/MoonfireSnapshot.js
+++ b/src/Parser/Druid/Feral/Modules/Bleeds/MoonfireSnapshot.js
@@ -15,7 +15,6 @@ import Snapshot, { PANDEMIC_FRACTION } from '../FeralCore/Snapshot';
 const MOONFIRE_FERAL_BASE_DURATION = 14000;
 
 class MoonfireSnapshot extends Snapshot {
-  static spellName = SPELLS.MOONFIRE_FERAL.name;
   static spellCastId = SPELLS.MOONFIRE_FERAL.id;
   static debuffId = SPELLS.MOONFIRE_FERAL.id;
 

--- a/src/Parser/Druid/Feral/Modules/Bleeds/RakeSnapshot.js
+++ b/src/Parser/Druid/Feral/Modules/Bleeds/RakeSnapshot.js
@@ -19,7 +19,6 @@ const FORGIVE_PROWL_LOSS_TIME = 1000;
 
 const RAKE_BASE_DURATION = 15000;
 class RakeSnapshot extends Snapshot {
-  static spellName = SPELLS.RAKE.name;
   static spellCastId = SPELLS.RAKE.id;
   static debuffId = SPELLS.RAKE_BLEED.id;
   static durationOfFresh = RAKE_BASE_DURATION;

--- a/src/Parser/Druid/Feral/Modules/Bleeds/RipSnapshot.js
+++ b/src/Parser/Druid/Feral/Modules/Bleeds/RipSnapshot.js
@@ -45,7 +45,6 @@ class RipSnapshot extends Snapshot {
     comboPointTracker: ComboPointTracker,
   };
 
-  static spellName = SPELLS.RIP.name;
   static spellCastId = SPELLS.RIP.id;
   static debuffId = SPELLS.RIP.id;
   static durationOfFresh = RIP_BASE_DURATION;

--- a/src/Parser/Druid/Feral/Modules/FeralCore/Snapshot.js
+++ b/src/Parser/Druid/Feral/Modules/FeralCore/Snapshot.js
@@ -40,7 +40,6 @@ class Snapshot extends Analyzer {
   };
 
   // extending class should fill these in:
-  static spellName = null;
   static spellCastId = null;
   static debuffId = null;
   static isProwlAffected = false;

--- a/src/Parser/Druid/Feral/Modules/Normalizers/RakeBleed.js
+++ b/src/Parser/Druid/Feral/Modules/Normalizers/RakeBleed.js
@@ -7,7 +7,11 @@ class RakeBleed extends EventsNormalizer {
    * When used from stealth SPELLS.RAKE cast event often appears after the SPELLS.RAKE_BLEED
    * applydebuff event that it causes. (Possibly this misordering has something to do with Rake
    * from stealth also attempting to apply a stun debuff.)
-   * This normalizes events so the applydebuff always comes after cast.
+   * This normalizes events so the bleed applydebuff always comes after cast.
+   * 
+   * Example log: https://www.warcraftlogs.com/reports/bt2x7pkqJ6XBjPam#fight=last
+   * Player Anatta at times: 0:00.900, 0:33.296, 3:35.127
+   * 
    * @param {Array} events
    * @returns {Array} Events possibly with some reordered.
    */
@@ -20,15 +24,17 @@ class RakeBleed extends EventsNormalizer {
     if(event.type === 'cast' && event.ability.guid === SPELLS.RAKE.id) {
       const castTimestamp = event.timestamp;
 
-      // look for any recent applydebuff or refreshdebuff of RAKE_BLEED
+      // look for matching recent applydebuff or refreshdebuff of RAKE_BLEED
       for (let previousEventIndex = eventIndex; previousEventIndex >= 0; previousEventIndex -= 1) {
         const previousEvent = fixedEvents[previousEventIndex];
         if ((castTimestamp - previousEvent.timestamp) > CAST_WINDOW) {
           break;
         }
         if ((previousEvent.type === 'applydebuff' || previousEvent.type === 'refreshdebuff') &&
-        previousEvent.ability.guid === SPELLS.RAKE_BLEED.id &&
-        previousEvent.sourceID === event.sourceID) {
+            previousEvent.ability.guid === SPELLS.RAKE_BLEED.id &&
+            previousEvent.targetID === event.targetID &&
+            previousEvent.targetInstance === event.targetInstance &&
+            previousEvent.sourceID === event.sourceID) {
           fixedEvents.splice(previousEventIndex, 1);
           fixedEvents.push(previousEvent);
           previousEvent.__modified = true;
@@ -37,7 +43,7 @@ class RakeBleed extends EventsNormalizer {
       }
     }
     });
-
+    
     return fixedEvents;
   }
 }

--- a/src/Parser/Druid/Feral/Modules/Normalizers/RakeBleed.test.js
+++ b/src/Parser/Druid/Feral/Modules/Normalizers/RakeBleed.test.js
@@ -1,0 +1,181 @@
+import SPELLS from 'common/SPELLS';
+
+import RakeBleed from './RakeBleed';
+
+describe('Druid/Feral/Normalizers/RakeBleed', () => {
+  const reorderScenarios = [
+    {
+      it: 'moves applydebuff after cast',
+      playerId: 1,
+      events: [
+        { testid: 1, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+        { testid: 2, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+      ],
+      result: [2, 1],
+    },
+    {
+      it: 'moves refreshdebuff after cast',
+      playerId: 1,
+      events: [
+        { testid: 1, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'refreshdebuff' },
+        { testid: 2, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+      ],
+      result: [2, 1],
+    },
+    {
+      it: 'doesn\'t move events that are already in the correct order',
+      playerId: 1,
+      events: [
+        { testid: 1, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+        { testid: 2, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+      ],
+      result: [1, 2],
+    },
+    {
+      it: 'doesn\'t move events when there\'s no matching debuff event',
+      playerId: 1,
+      events: [
+        // wrong spellId
+        { testid: 1, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RIP.id }, type: 'applydebuff' },
+        // wrong source
+        { testid: 2, timestamp: 1, sourceID: 2, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+        { testid: 3, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+      ],
+      result: [1, 2, 3],
+    },
+    {
+      it: 'doesn\'t move events that are already correct, despite cast noise between them',
+      playerId: 1,
+      events: [
+        { testid: 1, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+        { testid: 2, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.SHRED.id }, type: 'cast' },
+        { testid: 3, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+      ],
+      result: [1, 2, 3],
+    },
+    {
+      it: 'doesn\'t move events that are already correct, despite debuff noise between them',
+      playerId: 1,
+      events: [
+        { testid: 1, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+        { testid: 2, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RIP.id }, type: 'applydebuff' },
+        { testid: 3, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+      ],
+      result: [1, 2, 3],
+    },
+    {
+      it: 'corrects order despite an unrelated cast event between them',
+      playerId: 1,
+      events: [
+        { testid: 1, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+        { testid: 2, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.SHRED.id }, type: 'cast' },
+        { testid: 3, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+      ],
+      result: [2, 3, 1],
+    },
+    {
+      it: 'corrects order despite an unrelated debuff event between them',
+      playerId: 1,
+      events: [
+        { testid: 1, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+        { testid: 2, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RIP.id }, type: 'applydebuff' },
+        { testid: 3, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+      ],
+      result: [2, 3, 1],
+    },
+    {
+      it: 'moves just the closest debuff event when there\'s multiple before the cast',
+      playerId: 1,
+      events: [
+        { testid: 1, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+        { testid: 2, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+        { testid: 3, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+      ],
+      result: [1, 3, 2],
+    },
+    {
+      it: 'reorders when there\'s a small difference in timestamp',
+      playerId: 1,
+      events: [
+        { testid: 1, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+        { testid: 2, timestamp: 20, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+      ],
+      result: [2, 1],
+    },
+    {
+      it: 'doesn\'t move events when timestamp difference is large',
+      playerId: 1,
+      events: [
+        { testid: 1, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+        { testid: 2, timestamp: 2000, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+      ],
+      result: [1, 2],
+    },
+    {
+      it: 'doesn\'t move events when they are from different sources',
+      playerId: 1,
+      events: [
+        { testid: 1, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+        { testid: 2, timestamp: 1, sourceID: 2, targetID: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+      ],
+      result: [1, 2],
+    },
+    {
+      it: 'doesn\'t move events when they have different targetIDs',
+      playerId: 1,
+      events: [
+        { testid: 1, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+        { testid: 2, timestamp: 1, sourceID: 1, targetID: 2, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+      ],
+      result: [1, 2],
+    },
+    { // e.g. on a fight like Defence of Eonar where many enemies have the same targetID but different targetInstance values
+      it: 'doesn\'t move events when they have different targetsInstance values',
+      playerId: 1,
+      events: [
+        { testid: 1, timestamp: 1, sourceID: 1, targetID: 1, targetInstance: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+        { testid: 2, timestamp: 1, sourceID: 1, targetID: 1, targetInstance: 2, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+      ],
+      result: [1, 2],
+    },
+    { // debuff from A, debuff from B, cast from A, cast from B
+      it: 'moves events when two players are acting at the same time and both need normalizing',
+      playerId: 1,
+      events: [
+        { testid: 1, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+        { testid: 2, timestamp: 1, sourceID: 2, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+        { testid: 3, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+        { testid: 4, timestamp: 1, sourceID: 2, targetID: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+      ],
+      result: [3, 1, 4, 2],
+    },
+    { // debuff from A, cast from B, cast from A, debuff from B
+      it: 'moves only the necessary event when two players are acting at the same time but only one needs normalizing',
+      playerId: 1,
+      events: [
+        { testid: 1, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+        { testid: 2, timestamp: 1, sourceID: 2, targetID: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+        { testid: 3, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+        { testid: 4, timestamp: 1, sourceID: 2, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+      ],
+      result: [2, 3, 1, 4],
+    },
+    { // cast from A, cast from B, debuff from A, debuff from B
+      it: 'doesn\'t move events when two players are acting at the same time and neither need normalizing',
+      playerId: 1,
+      events: [
+        { testid: 1, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+        { testid: 2, timestamp: 1, sourceID: 2, targetID: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+        { testid: 3, timestamp: 1, sourceID: 1, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+        { testid: 4, timestamp: 1, sourceID: 2, targetID: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+      ],
+      result: [1, 2, 3, 4],
+    },
+  ];
+  reorderScenarios.forEach(scenario => {
+    it(scenario.it, () => {
+      const parser = new RakeBleed();
+      expect(parser.normalize(scenario.events).map(event => event.testid)).toEqual(scenario.result);
+    });
+  });
+});


### PR DESCRIPTION
Adds a test for Feral's RakeBleed normalizer. A second set of eyes for any missed missed combinations to test is very welcome. It get picked up by and passes locally with `npm run test`

There are also a number of fixes from the review of #1770, with the bulk of the changes coming from making the properties of Snapshot which don't change during event parsing be static. 