### PR TITLE
[Feral] Statistic for uptime of snapshot on DoTs

### DIFF
--- a/src/Parser/Druid/Feral/CHANGELOG.js
+++ b/src/Parser/Druid/Feral/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-06-11'),
+    changes: <React.Fragment>Added statistics breaking down snapshot uptime by buff for <SpellLink id={SPELLS.RAKE.id} />, <SpellLink id={SPELLS.RIP.id} />, and <SpellLink id={SPELLS.MOONFIRE_FERAL.id} />.</React.Fragment>,
+    contributors: [Anatta336],
+  },
+  {
     date: new Date('2018-06-09'),
     changes: <React.Fragment>Added snapshot tracking for <SpellLink id={SPELLS.MOONFIRE_FERAL.id} /></React.Fragment>,
     contributors: [Anatta336],

--- a/src/Parser/Druid/Feral/CombatLogParser.js
+++ b/src/Parser/Druid/Feral/CombatLogParser.js
@@ -12,7 +12,6 @@ import RipUptime from './Modules/Bleeds/RipUptime';
 import FerociousBiteEnergy from './Modules/Features/FerociousBiteEnergy';
 import RakeSnapshot from './Modules/Bleeds/RakeSnapshot';
 import RipSnapshot from './Modules/Bleeds/RipSnapshot';
-import MoonfireSnapshot from './Modules/Bleeds/MoonfireSnapshot';
 
 import ComboPointTracker from './Modules/ComboPoints/ComboPointTracker';
 import ComboPointDetails from './Modules/ComboPoints/ComboPointDetails';
@@ -20,6 +19,7 @@ import ComboPointDetails from './Modules/ComboPoints/ComboPointDetails';
 import SavageRoarUptime from './Modules/Talents/SavageRoarUptime';
 import MoonfireUptime from './Modules/Talents/MoonfireUptime';
 import SavageRoarDmg from './Modules/Talents/SavageRoarDmg';
+import MoonfireSnapshot from './Modules/Talents/MoonfireSnapshot';
 
 import AshamanesRip from './Modules/Traits/AshamanesRip';
 

--- a/src/Parser/Druid/Feral/Modules/Bleeds/RakeSnapshot.js
+++ b/src/Parser/Druid/Feral/Modules/Bleeds/RakeSnapshot.js
@@ -2,6 +2,7 @@ import React from 'react';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
+import { STATISTIC_ORDER } from 'Main/StatisticsListBox';
 import Snapshot, { JAGGED_WOUNDS_MODIFIER, PANDEMIC_FRACTION } from '../FeralCore/Snapshot';
 
 /**
@@ -130,5 +131,10 @@ class RakeSnapshot extends Snapshot {
         .recommended(`${recommended}% is recommended`);
     });
   }
+
+  statistic() {
+    return super.generateStatistic(SPELLS.RAKE.name);
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(10);
 }
 export default RakeSnapshot;

--- a/src/Parser/Druid/Feral/Modules/Bleeds/RipSnapshot.js
+++ b/src/Parser/Druid/Feral/Modules/Bleeds/RipSnapshot.js
@@ -5,6 +5,7 @@ import SpellLink from 'common/SpellLink';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import { formatPercentage } from 'common/format';
 import { encodeTargetString } from 'Parser/Core/Modules/EnemyInstances';
+import { STATISTIC_ORDER } from 'Main/StatisticsListBox';
 import Snapshot, { JAGGED_WOUNDS_MODIFIER, PANDEMIC_FRACTION } from '../FeralCore/Snapshot';
 import ComboPointTracker from '../ComboPoints/ComboPointTracker';
 
@@ -96,6 +97,8 @@ class RipSnapshot extends Snapshot {
 
   // use damage events to keep track of each target's health to tell when they're in "execute" range
   on_byPlayer_damage(event) {
+    super.on_byPlayer_damage(event);
+
     // no need to track health if combatant has sabertooth, and don't track health of friendlies.
     if (this.constructor.hasSabertooth || event.targetIsFriendly) {
       return;
@@ -231,5 +234,10 @@ class RipSnapshot extends Snapshot {
         .recommended(`${recommended}% is recommended`);
     });
   }
+
+  statistic() {
+    return super.generateStatistic(SPELLS.RIP.name);
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(11);
 }
 export default RipSnapshot;

--- a/src/Parser/Druid/Feral/Modules/FeralCore/Snapshot.js
+++ b/src/Parser/Druid/Feral/Modules/FeralCore/Snapshot.js
@@ -1,7 +1,12 @@
+import React from 'react';
 import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import SpellIcon from 'common/SpellIcon';
+import { formatNumber, formatPercentage } from 'common/format';
 import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import { encodeTargetString } from 'Parser/Core/Modules/EnemyInstances';
+import StatisticsListBox from 'Main/StatisticsListBox';
 
 const debug = false;
 
@@ -34,6 +39,14 @@ const BUFF_WINDOW_TIME = 60;
 // leeway in ms between a cast event and debuff apply/refresh for them to be associated
 const CAST_WINDOW_TIME = 100;
 
+/**
+ * Leeway in ms between when a debuff was expected to wear off and when damage events will no longer be counted
+ * Largest found in logs is 149ms:
+ * https://www.warcraftlogs.com/reports/8Ddyzh9nRjrxv3JA/#fight=16&source=21
+ * Moonfire DoT tick at 8:13.300, expected to expire at 8:13.151
+ */
+const DAMAGE_AFTER_EXPIRE_WINDOW = 200;
+
 class Snapshot extends Analyzer {
   static dependencies = {
     combatants: Combatants,
@@ -51,6 +64,13 @@ class Snapshot extends Analyzer {
   lastDoTCastEvent;
 
   castCount = 0;
+  ticks = 0;
+  ticksWithProwl = 0;
+  ticksWithTigersFury = 0;
+  ticksWithBloodtalons = 0;
+  damageFromProwl = 0;
+  damageFromTigersFury = 0;
+  damageFromBloodtalons = 0;
 
   on_byPlayer_cast(event) {
     if (this.constructor.spellCastId !== event.ability.guid) {
@@ -64,6 +84,37 @@ class Snapshot extends Analyzer {
     if (!this.constructor.spellCastId || !this.constructor.debuffId) {
       this.active = false;
       throw new Error('Snapshot should be extended and provided with spellCastId and debuffId.');
+    }
+  }
+
+  on_byPlayer_damage(event) {
+    if (event.targetIsFriendly || this.constructor.debuffId !== event.ability.guid || !event.tick) {
+      // ignore damage on friendlies, damage not from the tracked DoT, and any non-DoT damage
+      return;
+    }
+    const damage = (event.amount || 0) + (event.absorbed || 0);
+    if (damage === 0) {
+      // what buffs a zero-damage tick has doesn't matter, so don't count them (usually means target is currently immune to damage)
+      return;
+    }
+    const state = this.stateByTarget[encodeTargetString(event.targetID, event.targetInstance)];
+    if (!state || event.timestamp > state.expireTime + DAMAGE_AFTER_EXPIRE_WINDOW) {
+      debug && console.warn(`At ${this.owner.formatTimestamp(event.timestamp, 3)} damage detected from DoT ${this.constructor.debuffId} but no active state recorded for the target. Previous state expired: ${state ? this.owner.formatTimestamp(state.expireTime, 3) : 'n/a'}`);
+      return;
+    }
+
+    this.ticks += 1;
+    if (state.prowl) {
+      this.ticksWithProwl += 1;
+      this.damageFromProwl += damage * (1 - 1 / PROWL_MULTIPLIER);
+    }
+    if (state.tigersFury) {
+      this.ticksWithTigersFury += 1;
+      this.damageFromTigersFury += damage * (1 - 1 / TIGERS_FURY_MULTIPLIER);
+    }
+    if (state.bloodtalons) {
+      this.ticksWithBloodtalons += 1;
+      this.damageFromBloodtalons += damage * (1 - 1 / BLOODTALONS_MULTIPLIER);
     }
   }
 
@@ -146,6 +197,62 @@ class Snapshot extends Analyzer {
 
   checkRefreshRule(state) {
     debug && console.warn('Expected checkRefreshRule function to be overridden.');
+  }
+
+  subStatistic(ticksWithBuff, damageIncrease, buffId, buffName, spellName) {
+    const info = (
+      // subStatistics for this DoT will be combined, so each should have a unique key
+      <div className="flex" key={buffId}>
+        <div className="flex-main">
+        <SpellLink id={buffId} />
+        </div>
+        <div className="flex-sub text-right">
+        <dfn data-tip={`${formatNumber(damageIncrease / this.owner.fightDuration * 1000)} DPS contributed by ${buffName} on your ${spellName} DoT`}>
+          {formatPercentage(ticksWithBuff / this.ticks)}%
+        </dfn>
+        </div>
+      </div>
+    );
+    return info;
+  }
+
+  generateStatistic(spellName) {
+    const subStats = [];
+    const buffNames = [];
+    if (this.constructor.isProwlAffected) {
+      const buffName = 'Prowl';
+      buffNames.push(buffName);
+      subStats.push(this.subStatistic(this.ticksWithProwl, this.damageFromProwl, SPELLS.PROWL.id, buffName, spellName));
+    }
+    if (this.constructor.isTigersFuryAffected) {
+      const buffName = 'Tiger\'s Fury';
+      buffNames.push(buffName);
+      subStats.push(this.subStatistic(this.ticksWithTigersFury, this.damageFromTigersFury, SPELLS.TIGERS_FURY.id, buffName, spellName));
+    }
+    if (this.constructor.isBloodtalonsAffected && this.combatants.selected.hasTalent(SPELLS.BLOODTALONS_TALENT.id)) {
+      const buffName = 'Bloodtalons';
+      buffNames.push(buffName);
+      subStats.push(this.subStatistic(this.ticksWithBloodtalons, this.damageFromBloodtalons, SPELLS.BLOODTALONS_TALENT.id, buffName, spellName));
+    }
+    let buffsComment = '';
+    buffNames.forEach((name, index) => {
+      const hasComma = (buffNames.length > 2 && index < buffNames.length - 1);
+      const hasAnd = (index === buffNames.length - 2);
+      buffsComment = `${buffsComment}${name}${hasComma ? ', ' : ''}${hasAnd ? ' and ' : ''}`;
+    });
+    const isPlural = buffNames.length > 1;
+    return (
+      <StatisticsListBox
+        title={
+          <React.Fragment>
+            <SpellIcon id={this.constructor.spellCastId} noLink /> {spellName} Snapshot
+          </React.Fragment>
+        }
+        tooltip={`${spellName} maintains the damage bonus from ${buffsComment} if ${isPlural ? 'they were' : 'it was'} present when the DoT was applied. This lists how many of your ${spellName} ticks benefited from ${isPlural ? 'each' : 'the'} buff. ${isPlural ? 'As a tick can benefit from multiple buffs at once these percentages can add up to more than 100%.' : ''}`}
+      >
+        {subStats}
+      </StatisticsListBox>
+    );
   }
 }
 export default Snapshot;

--- a/src/Parser/Druid/Feral/Modules/FeralCore/Snapshot.js
+++ b/src/Parser/Druid/Feral/Modules/FeralCore/Snapshot.js
@@ -208,7 +208,7 @@ class Snapshot extends Analyzer {
         </div>
         <div className="flex-sub text-right">
         <dfn data-tip={`${formatNumber(damageIncrease / this.owner.fightDuration * 1000)} DPS contributed by ${buffName} on your ${spellName} DoT`}>
-          {formatPercentage(ticksWithBuff / this.ticks)}%
+          {formatPercentage(this.ticks === 0 ? 0 : ticksWithBuff / this.ticks)}%
         </dfn>
         </div>
       </div>

--- a/src/Parser/Druid/Feral/Modules/Talents/MoonfireSnapshot.js
+++ b/src/Parser/Druid/Feral/Modules/Talents/MoonfireSnapshot.js
@@ -2,6 +2,7 @@ import React from 'react';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
+import { STATISTIC_ORDER } from 'Main/StatisticsListBox';
 
 import Snapshot, { PANDEMIC_FRACTION } from '../FeralCore/Snapshot';
 
@@ -88,5 +89,10 @@ class MoonfireSnapshot extends Snapshot {
         .recommended(`${recommended}% is recommended`);
     });
   }
+
+  statistic() {
+    return super.generateStatistic(SPELLS.MOONFIRE_FERAL.name);
+  }
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(10)
 }
 export default MoonfireSnapshot;


### PR DESCRIPTION
Adds tick and damage counting to the existing Snapshot analyzer, and uses that to generate statistics for how each DoT benefited from the snapshot buffs.

How much a DoT benefited is measured by counting the damage tick events and checking what snapshot buffs were active for the DoT on that target at the time. The increase in damage due to each buff is also calculated from the tick. It only deals with the DoT ticks, not the initial damage that Rake and Moonfire also apply.

The % of ticks benefiting from each snapshot buff could be a useful measure in a future checklist for the spec. Although care should be taken as there's quite a lot of variability in what's possible even on a simple fight depending on legendaries and talents.

![snapshotuptimestats01](https://user-images.githubusercontent.com/35700764/41304493-39a007f4-6e68-11e8-8dea-ce209f73b19e.png)
![snapshotuptimestats02](https://user-images.githubusercontent.com/35700764/41304494-39cb170a-6e68-11e8-9e39-3ffa26e49b4b.png)
![snapshotuptimestats03](https://user-images.githubusercontent.com/35700764/41304496-39e87f3e-6e68-11e8-83e2-6ef5930c399d.png)
![snapshotuptimestats04](https://user-images.githubusercontent.com/35700764/41304497-3a02c6c8-6e68-11e8-8078-c6f39316766e.png)
![snapshotuptimestats05](https://user-images.githubusercontent.com/35700764/41304498-3a1b8df2-6e68-11e8-81e2-74cd871507bb.png)
