### PR TITLE
[BfA][Protection Warrior] initial update

### DIFF
--- a/src/Parser/Warrior/Protection/CombatLogParser.js
+++ b/src/Parser/Warrior/Protection/CombatLogParser.js
@@ -13,14 +13,15 @@ import Checklist from './Modules/Features/Checklist';
 import IgnorePain from './Modules/Features/IgnorePain';
 import RageTracker from './Modules/Core/RageTracker';
 import RageDetails from './Modules/Core/RageDetails';
+import Avatar from './Modules/Features/Avatar';
 
 import AngerManagement from './Modules/Talents/AngerManagement';
 import BoomingVoice from './Modules/Talents/BoomingVoice';
 import RenewedFury from './Modules/Talents/RenewedFury';
 import HeavyRepercussions from './Modules/Talents/HeavyRepercussions';
 import IntoTheFray from './Modules/Talents/IntoTheFray';
-import Avatar from './Modules/Talents/Avatar';
 import Vengeance from './Modules/Talents/Vengeance';
+import Punish from './Modules/Talents/Punish';
 
 import T21_2pc from './Modules/Items/T21_2pc';
 import ThundergodsVigor from './Modules/Items/ThundergodsVigor';
@@ -41,14 +42,15 @@ class CombatLogParser extends CoreCombatLogParser {
     ignorePain: IgnorePain,
     rageTracker: RageTracker,
     rageDetails: RageDetails,
+    avatar: Avatar,
     //Talents
     angerManagement: AngerManagement,
     boomingVoice: BoomingVoice,
     renewedFury: RenewedFury,
     heavyRepercussions: HeavyRepercussions,
     intoTheFray: IntoTheFray,
-    avatar: Avatar,
     vengeance: Vengeance,
+    punish: Punish,
     //Items
     t21: T21_2pc,
     thunderlordsVigor: ThundergodsVigor,

--- a/src/Parser/Warrior/Protection/Modules/Abilities.js
+++ b/src/Parser/Warrior/Protection/Modules/Abilities.js
@@ -24,6 +24,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.SHIELD_SLAM,
         isOnGCD: true,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        buffSpellId: SPELLS.PUNISH_DEBUFF.id,
         cooldown: haste => 9 / (1 + haste),
         castEfficiency: {
           suggestion: true,
@@ -124,17 +125,6 @@ class Abilities extends CoreAbilities {
         cooldown: 8,
       },
       {
-        spell: SPELLS.BATTLE_CRY,
-        buffSpellId: SPELLS.BATTLE_CRY.id,
-        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
-        cooldown: 60,
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: .9,
-        },
-        timelineSortIndex: 7,
-      },
-      {
         spell: SPELLS.BERSERKER_RAGE,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 45,
@@ -150,6 +140,7 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.VICTORY_RUSH,
+        enabled: !combatant.hasTalent(SPELLS.IMPENDING_VICTORY_TALENT.id),
         category: Abilities.SPELL_CATEGORIES.OTHERS,
       },
       {
@@ -182,6 +173,7 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(SPELLS.IMPENDING_VICTORY_TALENT.id),
         category: Abilities.SPELL_CATEGORIES.OTHERS,
         isOnGCD: true,
+        cooldown: 30,
       },
       {
         spell: SPELLS.RAVAGER_TALENT_PROTECTION,

--- a/src/Parser/Warrior/Protection/Modules/Abilities.js
+++ b/src/Parser/Warrior/Protection/Modules/Abilities.js
@@ -35,8 +35,13 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.THUNDER_CLAP,
         isOnGCD: true,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        cooldown: haste => 6 / (1 + haste),
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL, // 6 / (1 + haste)
+        cooldown: (haste, selectedCombatant) => {
+          if (selectedCombatant.hasTalent(SPELLS.UNSTOPPABLE_FORCE_TALENT.id) && selectedCombatant.hasBuff(SPELLS.AVATAR_TALENT.id)) {
+            return 6 / 2 / (1 + haste);
+          }
+          return 6 / (1 + haste);
+        },
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: .9,
@@ -73,14 +78,15 @@ class Abilities extends CoreAbilities {
           recommendedEfficiency: combatant.hasTalent(SPELLS.ANGER_MANAGEMENT_TALENT.id) ? .95 : .80,
           extraSuggestion: 'Cast Demoralizing Shout more liberally to maximize it\'s DPS boost unless you need it so survive a specific mechanic.',
         },
-        cooldown: 90,
+        isOnGCD: true,
+        cooldown: 45,
         timelineSortIndex: 8,
       },
       {
         spell: SPELLS.LAST_STAND,
         buffSpellId: SPELLS.LAST_STAND.id,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
-        cooldown: 180,
+        cooldown: combatant.hasTalent(SPELLS.BOLSTER_TALENT.id) ? 180 - 60 : 180,
         timelineSortIndex: 9,
       },
       {
@@ -99,7 +105,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.HEROIC_LEAP,
         isOnGCD: true,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        cooldown: 45,
+        cooldown: combatant.hasTalent(SPELLS.BOUNDING_STRIDE_TALENT.id) ? 45 - 15 : 45,
       },
       {
         spell: SPELLS.HEROIC_THROW,
@@ -161,12 +167,13 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.AVATAR_TALENT,
-        enabled: combatant.hasTalent(SPELLS.AVATAR_TALENT.id),
+        buffSpellId: SPELLS.AVATAR_TALENT.id,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: .9,
         },
+        isOnGCD: true,
         cooldown: 90,
         timelineSortIndex: 9,
       },
@@ -182,6 +189,18 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         isOnGCD: true,
         cooldown: 60,
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: .9,
+        },
+        timelineSortIndex: 9,
+      },
+      {
+        spell: SPELLS.DRAGON_ROAR_TALENT,
+        enabled: combatant.hasTalent(SPELLS.DRAGON_ROAR_TALENT.id),
+        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
+        isOnGCD: true,
+        cooldown: 35,
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: .9,

--- a/src/Parser/Warrior/Protection/Modules/Core/RageTracker.js
+++ b/src/Parser/Warrior/Protection/Modules/Core/RageTracker.js
@@ -4,7 +4,7 @@ import ResourceTracker from 'Parser/Core/Modules/ResourceTracker/ResourceTracker
 import SPELLS from 'common/SPELLS';
 import SpellUsable from 'Parser/Core/Modules/SpellUsable';
 
-const VENGEANCE_RAGE_REDUCTION = 0.35; //percent
+const VENGEANCE_RAGE_REDUCTION = 0.33; //percent
 const IGNORE_PAIN_MAX_COST = 60;
 
 class RageTracker extends ResourceTracker {

--- a/src/Parser/Warrior/Protection/Modules/Features/Avatar.js
+++ b/src/Parser/Warrior/Protection/Modules/Features/Avatar.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+import { formatNumber, formatPercentage } from 'common/format';
+
+const AVATAR_DAMAGE_INCREASE = 0.2;
+
+class Avatar extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  bonusDmg = 0;
+
+  get uptime() {
+    return this.combatants.getBuffUptime(SPELLS.AVATAR_TALENT.id) / this.owner.fightDuration;
+  }
+
+  on_byPlayer_damage(event) {
+    if (!this.combatants.selected.hasBuff(SPELLS.AVATAR_TALENT.id)) {
+      return;
+    } 
+    
+    this.bonusDmg += calculateEffectiveDamage(event, AVATAR_DAMAGE_INCREASE);
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.AVATAR_TALENT.id} />}
+        value={`${formatNumber(this.bonusDmg / this.owner.fightDuration * 1000)} DPS`}
+        label="Damage contributed"
+        tooltip={`
+          Avatar contributed ${formatNumber(this.bonusDmg)} total damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.bonusDmg))}%). </br>
+          Uptime was ${formatPercentage(this.uptime)}%
+        `}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(5);
+}
+
+export default Avatar;

--- a/src/Parser/Warrior/Protection/Modules/Features/Checklist.js
+++ b/src/Parser/Warrior/Protection/Modules/Features/Checklist.js
@@ -87,7 +87,7 @@ class Checklist extends CoreChecklist {
       requirements: () => {
         return [
           new GenericCastEfficiencyRequirement({
-            spell: SPELLS.BATTLE_CRY,
+            spell: SPELLS.AVATAR_TALENT,
             onlyWithSuggestion: false,
           }),
           new GenericCastEfficiencyRequirement({

--- a/src/Parser/Warrior/Protection/Modules/Talents/BoomingVoice.js
+++ b/src/Parser/Warrior/Protection/Modules/Talents/BoomingVoice.js
@@ -10,8 +10,8 @@ import Enemies from 'Parser/Core/Modules/Enemies';
 import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 import { formatNumber } from 'common/format';
 
-const BOOMING_VOICE_DAMAGE_INCREASE = 0.25;
-const BOOMING_VOICE_RAGE_GENERATION = 60;
+const BOOMING_VOICE_DAMAGE_INCREASE = 0.15;
+const BOOMING_VOICE_RAGE_GENERATION = 40;
 
 class BoomingVoice extends Analyzer {
   static dependencies = {

--- a/src/Parser/Warrior/Protection/Modules/Talents/Punish.js
+++ b/src/Parser/Warrior/Protection/Modules/Talents/Punish.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Analyzer from 'Parser/Core/Analyzer';
+import Enemies from 'Parser/Core/Modules/Enemies';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 
@@ -8,40 +9,40 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 import { formatNumber, formatPercentage } from 'common/format';
 
-const AVATAR_DAMAGE_INCREASE = 0.2;
+const PUNISH_DAMAGE_INCREASE = 0.2;
 
-class Avatar extends Analyzer {
+class Punish extends Analyzer {
   static dependencies = {
     combatants: Combatants,
+    enemies: Enemies,
   };
 
   bonusDmg = 0;
 
   on_initialized() {
-    this.active = this.combatants.selected.hasTalent(SPELLS.AVATAR_TALENT.id);
+    this.active = this.combatants.selected.hasTalent(SPELLS.PUNISH_TALENT.id);
   }
 
   get uptime() {
-    return this.combatants.getBuffUptime(SPELLS.AVATAR_TALENT.id) / this.owner.fightDuration;
+    return this.enemies.getBuffUptime(SPELLS.PUNISH_DEBUFF.id) / this.owner.fightDuration;
   }
 
   on_byPlayer_damage(event) {
-    if (!this.combatants.selected.hasBuff(SPELLS.AVATAR_TALENT.id)) {
+    if (event.ability.guid !== SPELLS.SHIELD_SLAM.id) {
       return;
-    } 
-    
-    this.bonusDmg += calculateEffectiveDamage(event, AVATAR_DAMAGE_INCREASE);
+    }
+    this.bonusDmg += calculateEffectiveDamage(event, PUNISH_DAMAGE_INCREASE);
   }
 
   statistic() {
     return (
       <StatisticBox
-        icon={<SpellIcon id={SPELLS.AVATAR_TALENT.id} />}
+        icon={<SpellIcon id={SPELLS.PUNISH_TALENT.id} />}
         value={`${formatNumber(this.bonusDmg / this.owner.fightDuration * 1000)} DPS`}
         label="Damage contributed"
         tooltip={`
-          Avatar contributed ${formatNumber(this.bonusDmg)} total damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.bonusDmg))}%). </br>
-          Uptime was ${formatPercentage(this.uptime)}%
+          Punish added a total of ${formatNumber(this.bonusDmg)} damage to your Shield Slams (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.bonusDmg))}%). </br>
+          ${formatPercentage(this.uptime)}% debuff uptime.
         `}
       />
     );
@@ -49,4 +50,4 @@ class Avatar extends Analyzer {
   statisticOrder = STATISTIC_ORDER.CORE(5);
 }
 
-export default Avatar;
+export default Punish;

--- a/src/common/SPELLS/TALENTS/WARRIOR.js
+++ b/src/common/SPELLS/TALENTS/WARRIOR.js
@@ -42,6 +42,12 @@ export default {
   BOOMING_VOICE_TALENT: { id: 202743, name: "Booming Voice", icon: "ability_warrior_battleshout" },
   HEAVY_REPERCUSSIONS_TALENT: { id: 203177, name: "Heavy Repercussions", icon: "inv_shield_32" },
   RAVAGER_TALENT_PROTECTION: { id: 228920, name: "Ravager", icon: "warrior_talent_icon_ravager" },
+  
+  UNSTOPPABLE_FORCE_TALENT: { id: 275336, name: "Unstoppable Force", icon: "warrior_talent_icon_thunderstruck" },
+  RUMBLING_EARTH_TALENT: { id: 275339, name: "Rumbling Earth", icon: "spell_shaman_earthquake" },
+  BOLSTER_TALENT: { id: 280001, name: "Bolster", icon: "shield_draenorcrafted_d_02_c_alliance" },
+  PUNSISH_TALENT: { id: 275334, name: "Punish", icon: "ability_deathknight_sanguinfortitude" },
+  MENACE_TALENT: { id: 275338, name: "Menace", icon: "ability_golemthunderclap" },
   // Fury
   WAR_MACHINE_TALENT: { id: 215556, name: "War Machine", icon: "ability_hunter_rapidkilling" },
   ENDLESS_RAGE_TALENT: { id: 202296, name: "Endless Rage", icon: "ability_warrior_endlessrage" },

--- a/src/common/SPELLS/TALENTS/WARRIOR.js
+++ b/src/common/SPELLS/TALENTS/WARRIOR.js
@@ -10,6 +10,7 @@ export default {
   SECOND_WIND_TALENT: { id: 29838, name: "Second Wind", icon: "ability_hunter_harass" },
   BOUNDING_STRIDE_TALENT: { id: 202163, name: "Bounding Stride", icon: "ability_heroicleap" },
   ANGER_MANAGEMENT_TALENT: { id: 152278, name: "Anger Management", icon: "warrior_talent_icon_angermanagement" },
+  DRAGON_ROAR_TALENT: { id: 118000, name: "Dragon Roar", icon: "ability_warrior_dragonroar" },
   // Arms
   DAUNTLESS_TALENT: { id: 202297, name: "Dauntless", icon: "ability_warrior_unrelentingassault" },
   OVERPOWER_TALENT: { id: 7384, name: "Overpower", icon: "ability_meleedamage" },
@@ -46,7 +47,7 @@ export default {
   UNSTOPPABLE_FORCE_TALENT: { id: 275336, name: "Unstoppable Force", icon: "warrior_talent_icon_thunderstruck" },
   RUMBLING_EARTH_TALENT: { id: 275339, name: "Rumbling Earth", icon: "spell_shaman_earthquake" },
   BOLSTER_TALENT: { id: 280001, name: "Bolster", icon: "shield_draenorcrafted_d_02_c_alliance" },
-  PUNSISH_TALENT: { id: 275334, name: "Punish", icon: "ability_deathknight_sanguinfortitude" },
+  PUNISH_TALENT: { id: 275334, name: "Punish", icon: "ability_deathknight_sanguinfortitude" },
   MENACE_TALENT: { id: 275338, name: "Menace", icon: "ability_golemthunderclap" },
   // Fury
   WAR_MACHINE_TALENT: { id: 215556, name: "War Machine", icon: "ability_hunter_rapidkilling" },
@@ -63,5 +64,4 @@ export default {
   INNER_RAGE_TALENT: { id: 215573, name: "Inner Rage", icon: "ability_warrior_innerrage" },
   BLADESTORM_TALENT: { id: 46924, name: "Bladestorm", icon: "ability_warrior_bladestorm" },
   RECKLESS_ABANDON_TALENT: { id: 202751, name: "Reckless Abandon", icon: "ability_warrior_battleshout" },
-  DRAGON_ROAR_TALENT: { id: 118000, name: "Dragon Roar", icon: "ability_warrior_dragonroar" },
 };

--- a/src/common/SPELLS/WARRIOR.js
+++ b/src/common/SPELLS/WARRIOR.js
@@ -386,6 +386,11 @@ export default {
     name: 'Shield Block Buff',
     icon: 'ability_defend',
   },
+  PUNISH_DEBUFF: {
+    id: 275335,
+    name: 'Punish',
+    icon: 'ability_deathknight_sanguinfortitude',
+  },
   DEVASTATOR_DAMAGE: {
     id: 236282,
     name: 'Devastator',


### PR DESCRIPTION
- makes Avatar baseline (and removes Battle Cry) (still using `AVATAR_TALENT` even if its a baseline ability for prot, but its a shared spell with Arms)
- adds the "Punish" talent
- updates talent nerfs
- adds "Bolster" and "Unstoppable force" CDR

![image](https://user-images.githubusercontent.com/29842841/41345980-7a45db88-6f05-11e8-8648-ee74271d7ae0.png)
