### PR TITLE
[Balance][BFA] Twin Moons, Stellar Drift and config update

### DIFF
--- a/src/Parser/Core/Modules/Haste.js
+++ b/src/Parser/Core/Modules/Haste.js
@@ -30,7 +30,6 @@ class Haste extends Analyzer {
     [SPELLS.DRUMS_OF_RAGE.id]: 0.25,
     [SPELLS.HOLY_AVENGER_TALENT.id]: 0.3,
     [SPELLS.BERSERKING.id]: 0.20,
-    [202842]: 0.1, // Rapid Innervation (Balance Druid trait increasing Haste from Innervate)
     [SPELLS.POWER_INFUSION_TALENT.id]: 0.25,
     [SPELLS.WARLOCK_AFFLI_T20_4P_BUFF.id]: 0.15,
     [SPELLS.WARLOCK_DEMO_T20_4P_BUFF.id]: 0.1,

--- a/src/Parser/Druid/Balance/CONFIG.js
+++ b/src/Parser/Druid/Balance/CONFIG.js
@@ -9,14 +9,14 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list.
   contributors: [Gebuz, Iskalla],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '7.3.5',
+  patchCompatibility: '8.0.1',
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <React.Fragment>
       Hello Moonkins! This tool is intended to show major statistics and potential issues in your rotation. Please mind that it can always be improved upon, so if you see anything that you disagree with or think is missing please let us know!<br /><br />
 
-      As a rule of thumb: Never overcap Astral Power, keep your moon spells on cooldown, don't overcap empowerments and keep your dots up on the target(s) at all times. Remember to pool Astral Power prior to movement.<br /><br />
+      As a rule of thumb: Never overcap Astral Power, don't overcap empowerments and keep your dots up on the target(s) at all times. Remember to pool Astral Power prior to movement.<br /><br />
 
       If you want to learn more about how to play Moonkin, visit <a href="https://goo.gl/xNHVnK" target="_blank" rel="noopener noreferrer">DreamGrove, the Druid's Discord</a>. Don't forget to check the <kbd>#resources</kbd> channel while you are there!
     </React.Fragment>

--- a/src/Parser/Druid/Balance/CombatLogParser.js
+++ b/src/Parser/Druid/Balance/CombatLogParser.js
@@ -13,14 +13,16 @@ import SolarEmpowerment from './Modules/Features/SolarEmpowerment';
 import CooldownThroughputTracker from './Modules/Features/CooldownThroughputTracker';
 import MoonfireUptime from './Modules/Features/MoonfireUptime';
 import SunfireUptime from './Modules/Features/SunfireUptime';
-import StellarFlareUptime from './Modules/Features/StellarFlareUptime';
 import StellarEmpowermentUptime from './Modules/Features/StellarEmpowermentUptime';
 import UnempoweredLunarStrike from './Modules/Features/UnempoweredLunarStrike';
-
-//Talents
-
 import EarlyDotRefreshes from './Modules/Features/EarlyDotRefreshes';
 import EarlyDotRefreshesInstants from './Modules/Features/EarlyDotRefreshesInstants';
+
+//Talents
+import StellarFlareUptime from './Modules/Talents/StellarFlareUptime';
+import TwinMoons from './Modules/Talents/TwinMoons';
+
+
 
 //Resources
 import AstralPowerDetails from './Modules/ResourceTracker/AstralPowerDetails';
@@ -55,14 +57,14 @@ class CombatLogParser extends MainCombatLogParser {
     cooldownThroughputTracker: CooldownThroughputTracker,
     moonfireUptime: MoonfireUptime,
     sunfireUptime: SunfireUptime,
-    stellarFlareUptime: StellarFlareUptime,
     stellarEmpowermentUptime: StellarEmpowermentUptime,
     unempoweredLunarStrike: UnempoweredLunarStrike,
-
-    //Talents
-
     earlyDotRefreshes: EarlyDotRefreshes,
     earlyDotRefreshesInstants: EarlyDotRefreshesInstants,
+
+    //Talents
+    stellarFlareUptime: StellarFlareUptime,
+    twinMoons: TwinMoons,
 
     //Resources
     astralPowerTracker: AstralPowerTracker,

--- a/src/Parser/Druid/Balance/CombatLogParser.js
+++ b/src/Parser/Druid/Balance/CombatLogParser.js
@@ -21,8 +21,7 @@ import EarlyDotRefreshesInstants from './Modules/Features/EarlyDotRefreshesInsta
 //Talents
 import StellarFlareUptime from './Modules/Talents/StellarFlareUptime';
 import TwinMoons from './Modules/Talents/TwinMoons';
-
-
+import StellarDrift from './Modules/Talents/StellarDrift';
 
 //Resources
 import AstralPowerDetails from './Modules/ResourceTracker/AstralPowerDetails';
@@ -65,6 +64,7 @@ class CombatLogParser extends MainCombatLogParser {
     //Talents
     stellarFlareUptime: StellarFlareUptime,
     twinMoons: TwinMoons,
+    stellarDrift: StellarDrift,
 
     //Resources
     astralPowerTracker: AstralPowerTracker,

--- a/src/Parser/Druid/Balance/Modules/Features/Checklist.js
+++ b/src/Parser/Druid/Balance/Modules/Features/Checklist.js
@@ -19,7 +19,7 @@ import CancelledCasts from './CancelledCasts';
 import AlwaysBeCasting from './AlwaysBeCasting';
 import MoonfireUptime from './MoonfireUptime';
 import SunfireUptime from './SunfireUptime';
-import StellarFlareUptime from './StellarFlareUptime';
+import StellarFlareUptime from '../Talents/StellarFlareUptime';
 import LunarEmpowerment from './LunarEmpowerment';
 import SolarEmpowerment from './SolarEmpowerment';
 import EarlyDotRefreshes from './EarlyDotRefreshes';

--- a/src/Parser/Druid/Balance/Modules/Talents/StellarDrift.js
+++ b/src/Parser/Druid/Balance/Modules/Talents/StellarDrift.js
@@ -1,0 +1,55 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import { formatPercentage, formatNumber } from 'common/format';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+
+const STARFALL_BONUS_DAMAGE = 0.25;
+
+class StellarDrift extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  bonusDamage = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.STELLAR_DRIFT_TALENT.id);
+  }
+
+  on_byPlayer_damage(event) {
+    if (event.ability.guid !== SPELLS.STARFALL.id) {
+      return;
+    }
+      this.bonusDamage += calculateEffectiveDamage(event, STARFALL_BONUS_DAMAGE);
+  }
+
+  get damagePercent() {
+    return this.owner.getPercentageOfTotalDamageDone(this.bonusDamage);
+  }
+
+  get perSecond() {
+    return this.bonusDamage / (this.owner.fightDuration / 1000);
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.STELLAR_DRIFT_TALENT.id} />}
+        value={`${formatPercentage(this.damagePercent)} %`}
+        label="Of total damage"
+        tooltip={`Contributed ${formatNumber(this.perSecond)} DPS (${formatNumber(this.bonusDamage)} total damage). This does not account for any extra damage gained from the increased radius or the ability to move while casting.`}
+      />
+    );
+  }
+
+  statisticOrder = STATISTIC_ORDER.OPTIONAL();
+}
+
+export default StellarDrift;

--- a/src/Parser/Druid/Balance/Modules/Talents/StellarFlareUptime.js
+++ b/src/Parser/Druid/Balance/Modules/Talents/StellarFlareUptime.js
@@ -8,6 +8,7 @@ import SpellLink from 'common/SpellLink';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import { formatPercentage } from 'common/format';
+
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class StellarFlareUptime extends Analyzer {
@@ -53,7 +54,7 @@ class StellarFlareUptime extends Analyzer {
     );
   }
 
-  statisticOrder = STATISTIC_ORDER.CORE(6);
+  statisticOrder = STATISTIC_ORDER.OPTIONAL();
 }
 
 export default StellarFlareUptime;

--- a/src/Parser/Druid/Balance/Modules/Talents/TwinMoons.js
+++ b/src/Parser/Druid/Balance/Modules/Talents/TwinMoons.js
@@ -1,0 +1,55 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import { formatPercentage } from 'common/format';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+
+class TwinMoons extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  moonfireCasts = 0;
+  moonfireHits = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.TWIN_MOONS_TALENT.id);
+  }
+
+  on_byPlayer_damage(event) {
+    if (event.ability.guid !== SPELLS.MOONFIRE_BEAR.id || event.tick === true) {
+      return;
+    }
+      this.moonfireHits++;
+  }
+  on_byPlayer_cast(event) {
+    if (event.ability.guid !== SPELLS.MOONFIRE.id) {
+      return;
+    }
+      this.moonfireCasts++;
+  }
+
+  get percentTwoHits() {
+    return (this.moonfireHits - this.moonfireCasts) / this.moonfireCasts;
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.TWIN_MOONS_TALENT.id} />}
+        value={`${formatPercentage(this.percentTwoHits)} %`}
+        label="Double hits"
+        tooltip={`You hit ${this.moonfireHits} times with ${this.moonfireCasts} casts.`}
+      />
+    );
+  }
+
+  statisticOrder = STATISTIC_ORDER.OPTIONAL();
+}
+
+export default TwinMoons;

--- a/src/common/SPELLS/TALENTS/DRUID.js
+++ b/src/common/SPELLS/TALENTS/DRUID.js
@@ -74,4 +74,5 @@ export default {
   // Temporary
   NEW_MOON_TALENT: { id: 274281, name: "New Moon", icon: "artifactability_balancedruid_newmoon" },
   TIGERS_DASH_TALENT: { id: 252216, name: "Tiger's Dash", icon: "ability_druid_dash_orange" },
+  TWIN_MOONS_TALENT: { id: 279620, name: "Twin Moons", icon: "spell_nature_starfall" },
 };


### PR DESCRIPTION
- updated the config to reflect legion changes (managing moon charges is not really a thing anymore) and version number.
- Copied LatC legendary over to the talent Twin Moon (same effect).
- Added module that shows dmg contributed by the 25% increased Starfall damage from Stellar Drift:
![image](https://user-images.githubusercontent.com/6773230/41476397-bf364792-70c1-11e8-97b9-54431739725b.png)
