### PR TITLE
[BFA] [BrM] Guard!

### DIFF
--- a/src/Parser/Monk/Brewmaster/CombatLogParser.js
+++ b/src/Parser/Monk/Brewmaster/CombatLogParser.js
@@ -21,6 +21,7 @@ import RushingJadeWind from './Modules/Spells/RushingJadeWind';
 import BreathOfFire from './Modules/Spells/BreathOfFire';
 import BlackOxBrew from './Modules/Spells/BlackOxBrew';
 import HighTolerance from './Modules/Spells/HighTolerance';
+import Guard from './Modules/Spells/Guard';
 // Features
 import Checklist from './Modules/Features/Checklist';
 import Abilities from './Modules/Features/Abilities';
@@ -71,6 +72,7 @@ class CombatLogParser extends CoreCombatLogParser {
     bof: BreathOfFire,
     bob: BlackOxBrew,
     highTolerance: HighTolerance,
+    guard: Guard,
 
     // Items
     t20_2pc: T20_2pc,

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/Guard.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/Guard.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import { formatNumber } from 'common/format';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import StaggerFabricator from '../Core/StaggerFabricator';
+
+const GUARD_DURATION = 15000;
+
+class Guard extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    fab: StaggerFabricator,
+  };
+
+  _guardSizes = [];
+  _absorbed = 0;
+  _guardWasted = 0;
+  _guardRemaining = 0;
+  _lastApplication = 0;
+
+  get _hasGuard() {
+    return this.combatants.selected.hasBuff(SPELLS.GUARD_TALENT.id);
+  }
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.GUARD_TALENT.id);
+  }
+
+  on_byPlayer_applybuff(event) {
+    if(event.ability.guid !== SPELLS.GUARD_TALENT.id) {
+      return;
+    }
+    this._guardSizes.push(event.absorb || 0);
+    this._guardRemaining = event.absorb || 0;
+  }
+
+  on_byPlayer_removebuff(event) {
+    if(event.ability.guid !== SPELLS.GUARD_TALENT.id) {
+      return;
+    }
+
+    if(event.timestamp - this._lastApplication === GUARD_DURATION) {
+      // almost certainly natural buff expiration, any remaining guard
+      // is wasted
+      this._guardWasted += this._guardRemaining;
+      this._guardRemaining = 0;
+    }
+    this._lastApplication = 0;
+  }
+
+  on_byPlayer_absorbed(event) {
+    if(event.ability.guid !== SPELLS.STAGGER.id) {
+      return;
+    }
+    if(!this._hasGuard && this._guardRemaining === 0) {
+      // sequencing issue with the log:
+      // guard buff is removed before the absorb that removes it, so we
+      // check for there being guard left over (see
+      // `on_byPlayer_removebuff`)
+      return;
+    }
+
+    this._guardRemaining -= event.amount;
+    let leftOverDamage = 0;
+    if(this._guardRemaining < 0) {
+      leftOverDamage = -this._guardRemaining;
+      this._guardRemaining = 0;
+    }
+
+    const amountAbsorbed = event.amount - leftOverDamage;
+    this._absorbed += amountAbsorbed;
+    this.fab.removeStagger(event, amountAbsorbed);
+  }
+
+  statistic() {
+    const avgGuardSize = this._guardSizes.reduce((v, sum) => sum + v, 0) / this._guardSizes.length;
+    const aps = this._absorbed / (this.owner.fightDuration / 1000);
+    return <StatisticBox
+      icon={<SpellIcon id={SPELLS.GUARD_TALENT.id} />}
+      value={`${formatNumber(aps)} HPS`}
+      label={"Effective Healing by Guard"}
+      tooltip={`Your average Guard could absorb up to <b>${formatNumber(avgGuardSize)}</b> damage.<br/>
+                You wasted <b>${formatNumber(this._guardWasted)}</b> of Guard's absorb.<br/>
+                Your Guard absorbed a total of <b>${formatNumber(this._absorbed)}</b> damage.`}
+              />;
+  }
+  statisticOrder = STATISTIC_ORDER.OPTIONAL();
+}
+
+export default Guard;

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/Guard.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/Guard.js
@@ -8,6 +8,15 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import StaggerFabricator from '../Core/StaggerFabricator';
 
 const GUARD_DURATION = 15000;
+const GUARD_REMOVESTAGGER_REASON = {
+  type: 'absorbed',
+  ability: {
+    guid: SPELLS.GUARD_TALENT.id,
+    name: SPELLS.GUARD_TALENT.name,
+    icon: SPELLS.GUARD_TALENT.icon,
+  },
+  __fabricated: true,
+};
 
 class Guard extends Analyzer {
   static dependencies = {
@@ -72,7 +81,13 @@ class Guard extends Analyzer {
 
     const amountAbsorbed = event.amount - leftOverDamage;
     this._absorbed += amountAbsorbed;
-    this.fab.removeStagger(event, amountAbsorbed);
+    const reason = {
+      timestamp: event.timestamp,
+      amount: amountAbsorbed,
+      __reason: event,
+      ...GUARD_REMOVESTAGGER_REASON,
+    };
+    this.fab.removeStagger(reason, amountAbsorbed);
   }
 
   statistic() {
@@ -88,6 +103,7 @@ class Guard extends Analyzer {
               />;
   }
   statisticOrder = STATISTIC_ORDER.OPTIONAL();
+
 }
 
 export default Guard;


### PR DESCRIPTION
![screenshot from 2018-06-16 16-10-33](https://user-images.githubusercontent.com/4909458/41502082-236ead80-7180-11e8-87e8-4b70bd468b00.png)

This adds a stat for Guard to the BrM analysis.

The way guard is logged is mildly annoying: when the buff is applied (if applied in the fight--due to the 15s duration it could be applied prior) we get an `absorb` field on the `applybuff` event that tells how much damage it will absorb. Then, each stagger `absorbed` event is logged exactly as normal. When the last of the Guard absorb is consumed, we get a `removebuff` event with `absorb` equal to the amount absorbed by the last Stagger absorb (I'm 99% sure, I don't actually use that bit so I didn't do more than a cursory check).

I represent the absorbed stagger damage by immediately removing stagger after adding it. While not technically correct, it does have the correct impact on other modules in the codebase (including the plot, which renders as expected).

There is one possible issue with this that may need ironing out in the future: if Guard is precast long enough before a fight to not show up in the log, then the first Guard won't be counted.