### PR TITLE
[Blood Death Knight][Protection Warrior][BfA] Dragon Roar & Consumption

### DIFF
--- a/src/Parser/DeathKnight/Blood/CombatLogParser.js
+++ b/src/Parser/DeathKnight/Blood/CombatLogParser.js
@@ -44,6 +44,7 @@ import RapidDecomposition from './Modules/Talents/RapidDecomposition';
 import WillOfTheNecropolis from './Modules/Talents/WillOfTheNecropolis';
 import Ossuary from './Modules/Talents/Ossuary';
 import RuneStrike from './Modules/Talents/RuneStrike';
+import Consumption from './Modules/Talents/Consumption';
 
 // Items
 import T20_2pc from './Modules/Items/T20_2pc';
@@ -113,6 +114,7 @@ class CombatLogParser extends CoreCombatLogParser {
     willOfTheNecropolis: WillOfTheNecropolis,
     ossuary: Ossuary,
     runeStrike: RuneStrike,
+    consumption: Consumption,
 
     // Traits
     RelicTraits: RelicTraits,

--- a/src/Parser/DeathKnight/Blood/Modules/Abilities.js
+++ b/src/Parser/DeathKnight/Blood/Modules/Abilities.js
@@ -46,15 +46,11 @@ class Abilities extends CoreAbilities {
         timelineSortIndex: 4,
       },
       {
-        spell: SPELLS.CONSUMPTION,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        spell: SPELLS.CONSUMPTION_TALENT,
+        category: Abilities.SPELL_CATEGORIES.SEMI_DEFENSIVE,
+        enabled: combatant.hasTalent(SPELLS.CONSUMPTION_TALENT.id),
         cooldown: 45,
         isOnGCD: true,
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: 0.90,
-          extraSuggestion: 'Should be casting this on CD for the dps unless your saving the leach for something or saving it for a pack of adds.',
-        },
         timelineSortIndex: 5,
       },
       {
@@ -62,7 +58,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.SEMI_DEFENSIVE,
         buffSpellId: SPELLS.DANCING_RUNE_WEAPON_BUFF.id,
         isOnGCD: true,
-        cooldown: 180,
+        cooldown: 120,
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.90,

--- a/src/Parser/DeathKnight/Blood/Modules/Features/Checklist.js
+++ b/src/Parser/DeathKnight/Blood/Modules/Features/Checklist.js
@@ -26,6 +26,7 @@ import BoneStorm from '../Talents/Bonestorm';
 import MarkOfBloodUptime from '../Talents/MarkOfBlood';
 import Ossuary from '../Talents/Ossuary';
 import RuneStrike from '../Talents/RuneStrike';
+import Consumption from '../Talents/Consumption';
 
 import RunicPowerDetails from '../RunicPower/RunicPowerDetails';
 import RuneTracker from '../../../Shared/RuneTracker';
@@ -47,6 +48,7 @@ class Checklist extends CoreChecklist {
     deathsCaress: DeathsCaress,
 
     bonestorm: BoneStorm,
+    consumption: Consumption,
     markOfBloodUptime: MarkOfBloodUptime,
 
     crimsonScourge: CrimsonScourge,
@@ -124,9 +126,10 @@ class Checklist extends CoreChecklist {
             spell: SPELLS.DANCING_RUNE_WEAPON,
             onlyWithSuggestion: false,
           }),
-          new GenericCastEfficiencyRequirement({
-            spell: SPELLS.CONSUMPTION,
-            onlyWithSuggestion: false,
+          new Requirement({
+            name: <React.Fragment>Possible <SpellLink id={SPELLS.CONSUMPTION_TALENT.id} /> hits</React.Fragment>,
+            check: () => this.consumption.hitSuggestionThreshold, 
+            when: this.combatants.selected.hasTalent(SPELLS.CONSUMPTION_TALENT.id),
           }),
           new Requirement({
             name: <React.Fragment><SpellLink id={SPELLS.BONESTORM_TALENT.id} /> efficiency</React.Fragment>,

--- a/src/Parser/DeathKnight/Blood/Modules/Features/DancingRuneWeapon.js
+++ b/src/Parser/DeathKnight/Blood/Modules/Features/DancingRuneWeapon.js
@@ -11,7 +11,7 @@ const ALLOWED_CASTS_DURING_DRW = [
   SPELLS.HEART_STRIKE.id,
   SPELLS.BLOOD_BOIL.id,
   SPELLS.MARROWREND.id,
-  SPELLS.CONSUMPTION.id,
+  SPELLS.CONSUMPTION_TALENT.id, // todo => test if new consumption talent actually works with DRW
 ];
 
 class DancingRuneWeapon extends Analyzer {
@@ -54,7 +54,7 @@ class DancingRuneWeapon extends Analyzer {
   }
 
   spellLinks(id, index) {
-    if (id === SPELLS.CONSUMPTION.id) {
+    if (id === SPELLS.CONSUMPTION_TALENT.id) {
       return <span>and (if in AoE)<SpellLink id={id} /></span>;
     } else if (index + 2 === ALLOWED_CASTS_DURING_DRW.length) {
       return <span><SpellLink id={id} /> </span>;

--- a/src/Parser/DeathKnight/Blood/Modules/Talents/Consumption.js
+++ b/src/Parser/DeathKnight/Blood/Modules/Talents/Consumption.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import Enemies from 'Parser/Core/Modules/Enemies';
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import calculateMaxCasts from 'Parser/Core/calculateMaxCasts';
+import Abilities from 'Parser/Core/Modules/Abilities';
+import SpellLink from 'common/SpellLink';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import { formatNumber, formatPercentage } from 'common/format';
+
+class Consumption extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    enemies: Enemies,
+    abilities: Abilities,
+  };
+
+  bonusDmg = 0;
+  totalHits = 0;
+  maxCasts = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.CONSUMPTION_TALENT.id);
+  }
+
+  on_byPlayer_damage(event) {
+    if (event.ability.guid !== SPELLS.CONSUMPTION_TALENT.id) {
+      return;
+    }
+    
+    this.bonusDmg += event.amount + (event.absorbed || 0);
+    this.totalHits += 1;
+  }
+
+  get hitSuggestionThreshold() {
+    return {
+      actual: this.totalHits / this.maxCasts,
+      isLessThan: {
+        minor: 0.95,
+        average: 0.9,
+        major: .8,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.hitSuggestionThreshold)
+        .addSuggestion((suggest, actual, recommended) => {
+          return suggest(<React.Fragment>It's benefitial to delay <SpellLink id={SPELLS.CONSUMPTION_TALENT.id} /> to hit multiple targets, but don't delay it too long or you'll miss out on casts and possible hits.</React.Fragment>)
+            .icon(SPELLS.CONSUMPTION_TALENT.icon)
+            .actual(`${this.totalHits} total hits`)
+            .recommended(`${this.maxCasts} or more hits were possible`);
+        });
+  }
+
+  statistic() {
+    const consumptionCooldown = this.abilities.abilities.find(e => e.spell.id === SPELLS.CONSUMPTION_TALENT.id)._cooldown;
+    this.maxCasts = Math.ceil(calculateMaxCasts(consumptionCooldown, this.owner.fightDuration));
+
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.CONSUMPTION_TALENT.id} />}
+        value={`${formatNumber(this.bonusDmg / this.owner.fightDuration * 1000)} DPS`}
+        label="Damage contributed"
+        tooltip={`
+          ${SPELLS.CONSUMPTION_TALENT.name} added a total of ${formatNumber(this.bonusDmg)} damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.bonusDmg))}%). </br>
+        `}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(5);
+}
+
+export default Consumption;

--- a/src/Parser/Warrior/Protection/CombatLogParser.js
+++ b/src/Parser/Warrior/Protection/CombatLogParser.js
@@ -22,6 +22,7 @@ import HeavyRepercussions from './Modules/Talents/HeavyRepercussions';
 import IntoTheFray from './Modules/Talents/IntoTheFray';
 import Vengeance from './Modules/Talents/Vengeance';
 import Punish from './Modules/Talents/Punish';
+import DragonRoar from './Modules/Talents/DragonRoar';
 
 import T21_2pc from './Modules/Items/T21_2pc';
 import ThundergodsVigor from './Modules/Items/ThundergodsVigor';
@@ -51,6 +52,7 @@ class CombatLogParser extends CoreCombatLogParser {
     intoTheFray: IntoTheFray,
     vengeance: Vengeance,
     punish: Punish,
+    dragonRoar: DragonRoar,
     //Items
     t21: T21_2pc,
     thunderlordsVigor: ThundergodsVigor,

--- a/src/Parser/Warrior/Protection/Modules/Abilities.js
+++ b/src/Parser/Warrior/Protection/Modules/Abilities.js
@@ -193,10 +193,6 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         isOnGCD: true,
         cooldown: 35,
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: .9,
-        },
         timelineSortIndex: 9,
       },
     ];

--- a/src/Parser/Warrior/Protection/Modules/Features/Checklist.js
+++ b/src/Parser/Warrior/Protection/Modules/Features/Checklist.js
@@ -18,6 +18,9 @@ import Shield_Block from '../Spells/ShieldBlock';
 import IgnorePain from './IgnorePain';
 import RageDetails from '../Core/RageDetails';
 
+//Talents
+import DragonRoar from '../Talents/DragonRoar';
+
 class Checklist extends CoreChecklist {
   static dependencies = {
     abilities: Abilities,
@@ -32,6 +35,7 @@ class Checklist extends CoreChecklist {
     shieldBlock: Shield_Block,
     ignorePain: IgnorePain,
     rageDetails: RageDetails,
+    dragonRoar: DragonRoar,
   };
 
   rules = [
@@ -94,6 +98,11 @@ class Checklist extends CoreChecklist {
             spell: SPELLS.DEMORALIZING_SHOUT,
             when: this.combatants.selected.hasTalent(SPELLS.BOOMING_VOICE_TALENT.id),
             onlyWithSuggestion: false,
+          }),
+          new Requirement({
+            name: <React.Fragment>Possible <SpellLink id={SPELLS.DRAGON_ROAR_TALENT.id} /> hits</React.Fragment>,
+            check: () => this.dragonRoar.hitSuggestionThreshold,
+            when: this.combatants.selected.hasTalent(SPELLS.DRAGON_ROAR_TALENT.id),
           }),
         ];
       },

--- a/src/Parser/Warrior/Protection/Modules/Talents/AngerManagement.js
+++ b/src/Parser/Warrior/Protection/Modules/Talents/AngerManagement.js
@@ -10,7 +10,7 @@ import SpellUsable from 'Parser/Core/Modules/SpellUsable';
 
 const COOLDOWNS_AFFECTED_BY_ANGER_MANAGEMENT = [
   SPELLS.DEMORALIZING_SHOUT.id,
-  SPELLS.BATTLE_CRY.id,
+  SPELLS.AVATAR_TALENT.id,
   SPELLS.LAST_STAND.id,
   SPELLS.SHIELD_WALL.id,
 ];

--- a/src/Parser/Warrior/Protection/Modules/Talents/DragonRoar.js
+++ b/src/Parser/Warrior/Protection/Modules/Talents/DragonRoar.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import Enemies from 'Parser/Core/Modules/Enemies';
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import calculateMaxCasts from 'Parser/Core/calculateMaxCasts';
+import Abilities from 'Parser/Core/Modules/Abilities';
+import SpellLink from 'common/SpellLink';
+
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import { formatNumber, formatPercentage } from 'common/format';
+
+class DragonRoar extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    enemies: Enemies,
+    abilities: Abilities,
+  };
+
+  bonusDmg = 0;
+  totalHits = 0;
+  maxCasts = 0;
+
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.DRAGON_ROAR_TALENT.id);
+  }
+
+  on_byPlayer_damage(event) {
+    if (event.ability.guid !== SPELLS.DRAGON_ROAR_TALENT.id) {
+      return;
+    }
+    this.bonusDmg += event.amount + (event.absorbed || 0);
+    this.totalHits += 1;
+  }
+
+  get hitSuggestionThreshold() {
+    return {
+      actual: this.totalHits / this.maxCasts,
+      isLessThan: {
+        minor: 0.95,
+        average: 0.9,
+        major: .8,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.hitSuggestionThreshold)
+        .addSuggestion((suggest, actual, recommended) => {
+          return suggest(<React.Fragment>It's benefitial to delay <SpellLink id={SPELLS.DRAGON_ROAR_TALENT.id} /> to hit multiple targets, but don't delay it too long or you'll miss out on casts and possible hits.</React.Fragment>)
+            .icon(SPELLS.DRAGON_ROAR_TALENT.icon)
+            .actual(`${this.totalHits} total hits`)
+            .recommended(`${this.maxCasts} or more hits were possible`);
+        });
+  }
+
+  statistic() {
+    const dragonRoarCooldown = this.abilities.abilities.find(e => e.spell.id === SPELLS.DRAGON_ROAR_TALENT.id)._cooldown;
+    this.maxCasts = Math.ceil(calculateMaxCasts(dragonRoarCooldown, this.owner.fightDuration));
+
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.DRAGON_ROAR_TALENT.id} />}
+        value={`${formatNumber(this.bonusDmg / this.owner.fightDuration * 1000)} DPS`}
+        label="Damage contributed"
+        tooltip={`
+          ${SPELLS.DRAGON_ROAR_TALENT.name} added a total of ${formatNumber(this.bonusDmg)} damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.bonusDmg))}%). </br>
+        `}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(5);
+}
+
+export default DragonRoar;

--- a/src/common/SPELLS/DEATH_KNIGHT.js
+++ b/src/common/SPELLS/DEATH_KNIGHT.js
@@ -6,12 +6,6 @@
 
 export default {
   // Blood:
-  // Artifact
-  CONSUMPTION: { //when are we going to lose the artifact-ID and get the talent one?
-    id: 205223,
-    name: 'Consumption',
-    icon: 'inv_axe_2h_artifactmaw_d_01',
-  },
 
   //Summons
   //Bloodworm summon spell by the Bloodworms talent


### PR DESCRIPTION
- adds proper breakdowns for Consumption & Dragon Roar (since tracking only cooldown time is kinda meh, its actually benefitial to miss out on a cast if you can hit multiple targets with it)
- removes consumption as artifact ability
- replaces Battle Cry with Avatar for Angermanagement 
- adjusts DRW from 3min to 2min

![image](https://user-images.githubusercontent.com/29842841/41544107-5533e544-7318-11e8-8eb9-de87972b834b.png)
![image](https://user-images.githubusercontent.com/29842841/41544177-62906ce4-7318-11e8-8c39-041e31cbba52.png)
![image](https://user-images.githubusercontent.com/29842841/41544198-6f1c60e4-7318-11e8-9372-8e61953b481a.png)
Consumption has the same suggestions & checklist items
