### PR TITLE
[BFA] [BrM] Quick Guard Fix

### DIFF
--- a/src/Parser/Monk/Brewmaster/Modules/Spells/Guard.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/Guard.js
@@ -51,7 +51,7 @@ class Guard extends Analyzer {
       return;
     }
 
-    if(event.timestamp - this._lastApplication === GUARD_DURATION) {
+    if(event.timestamp - this._lastApplication >= GUARD_DURATION) {
       // almost certainly natural buff expiration, any remaining guard
       // is wasted
       this._guardWasted += this._guardRemaining;
@@ -95,8 +95,8 @@ class Guard extends Analyzer {
     const aps = this._absorbed / (this.owner.fightDuration / 1000);
     return <StatisticBox
       icon={<SpellIcon id={SPELLS.GUARD_TALENT.id} />}
-      value={`${formatNumber(aps)} HPS`}
-      label={"Effective Healing by Guard"}
+      value={`${formatNumber(aps)} DTPS`}
+      label={"Effective Mitigation by Guard"}
       tooltip={`Your average Guard could absorb up to <b>${formatNumber(avgGuardSize)}</b> damage.<br/>
                 You wasted <b>${formatNumber(this._guardWasted)}</b> of Guard's absorb.<br/>
                 Your Guard absorbed a total of <b>${formatNumber(this._absorbed)}</b> damage.`}


### PR DESCRIPTION
This PR addresses two things:

1. Sometimes the buff fades not exactly 15000 MS after the application but a bit after; those events are now counted.
2. Changed the presentation of Guard's effect. I realized that although technically it can be counted as healing, presenting it this way is misleading. Guarded damage doesn't show up as damage taken, and so showing it as healing made it appear more effective than it actually was (e.g. 1.2k HPS with 4.5k DTPS is "25% of damage healed" but it actually only mitigated 21%).