### PR TITLE
[BfA][Ret]Adding Inquisition and Righteous Verdict modules and updating checklist

### DIFF
--- a/src/Parser/Monk/Windwalker/Modules/Talents/HitCombo.js
+++ b/src/Parser/Monk/Windwalker/Modules/Talents/HitCombo.js
@@ -12,7 +12,6 @@ import { formatPercentage } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
 
-
 class HitCombo extends Analyzer {
 
   constructor(...args) {

--- a/src/Parser/Paladin/Retribution/CHANGELOG.js
+++ b/src/Parser/Paladin/Retribution/CHANGELOG.js
@@ -5,6 +5,11 @@ import { Hewhosmites, Zerotorescue, Juko8} from 'CONTRIBUTORS';
 
 export default [
   {
+    date: new Date('2018-06-25'),
+    changes: <React.Fragment>Added modules for <SpellLink id={SPELLS.RIGHTEOUS_VERDICT_TALENT.id} icon /> and <SpellLink id={SPELLS.INQUISITION_TALENT.id} icon /> </React.Fragment>,
+    contributors: [Juko8],
+  },
+  {
     date: new Date('2018-06-24'),
     changes: <React.Fragment>Updated modules for <SpellLink id={SPELLS.ART_OF_WAR.id} icon /> and <SpellLink id={SPELLS.JUDGMENT_CAST.id} icon /></React.Fragment>,
     contributors: [Juko8],

--- a/src/Parser/Paladin/Retribution/CombatLogParser.js
+++ b/src/Parser/Paladin/Retribution/CombatLogParser.js
@@ -14,6 +14,7 @@ import ArtOfWar from './Modules/PaladinCore/ArtOfWar';
 import Retribution from './Modules/PaladinCore/Retribution';
 import Crusade from './Modules/Talents/Crusade';
 import Inquisition from './Modules/Talents/Inquisition';
+import RighteousVerdict from './Modules/Talents/RighteousVerdict';
 
 import HolyPowerTracker from './Modules/HolyPower/HolyPowerTracker';
 import HolyPowerDetails from './Modules/HolyPower/HolyPowerDetails';
@@ -47,6 +48,7 @@ class CombatLogParser extends CoreCombatLogParser {
     divinePurpose: DivinePurpose,
     crusade: Crusade,
     inquisition: Inquisition,
+    righteousVerdict: RighteousVerdict,
 
     // HolyPower
     holyPowerTracker: HolyPowerTracker,

--- a/src/Parser/Paladin/Retribution/CombatLogParser.js
+++ b/src/Parser/Paladin/Retribution/CombatLogParser.js
@@ -13,6 +13,7 @@ import DivinePurpose from './Modules/Talents/DivinePurpose';
 import ArtOfWar from './Modules/PaladinCore/ArtOfWar';
 import Retribution from './Modules/PaladinCore/Retribution';
 import Crusade from './Modules/Talents/Crusade';
+import Inquisition from './Modules/Talents/Inquisition';
 
 import HolyPowerTracker from './Modules/HolyPower/HolyPowerTracker';
 import HolyPowerDetails from './Modules/HolyPower/HolyPowerDetails';
@@ -45,6 +46,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Talents
     divinePurpose: DivinePurpose,
     crusade: Crusade,
+    inquisition: Inquisition,
 
     // HolyPower
     holyPowerTracker: HolyPowerTracker,

--- a/src/Parser/Paladin/Retribution/Modules/Abilities.js
+++ b/src/Parser/Paladin/Retribution/Modules/Abilities.js
@@ -139,6 +139,14 @@ class Abilities extends CoreAbilities {
         },
       },
       {
+        spell: SPELLS.INQUISITION_TALENT,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        gcd: {
+          base: 1500,
+        },
+        enabled: combatant.hasTalent(SPELLS.INQUISITION_TALENT.id),
+      },
+      {
         spell: SPELLS.EXECUTION_SENTENCE_TALENT,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         cooldown: haste => 20 / (1 + haste),

--- a/src/Parser/Paladin/Retribution/Modules/Features/Checklist.js
+++ b/src/Parser/Paladin/Retribution/Modules/Features/Checklist.js
@@ -52,7 +52,7 @@ class Checklist extends CoreChecklist {
   rules = [
     new Rule({
       name: 'Always be casting',
-      description: <React.Fragment>You should try to avoid doing nothing during the fight. If you have to move, use your <SpellLink id={SPELLS.DIVINE_STEED.id} icon /> to minimize downtime. Also use ranged abilities like <SpellLink id={SPELLS.JUDGMENT_CAST.id} icon /> or <SpellLink id={SPELLS.BLADE_OF_JUSTICE.id} icon /> if out of melee range for extended periods.</React.Fragment>,
+      description: <React.Fragment>You should try to avoid doing nothing during the fight. If you have to move, use your <SpellLink id={SPELLS.DIVINE_STEED.id} icon /> to minimize downtime. Also use ranged abilities like <SpellLink id={SPELLS.JUDGMENT_CAST.id} icon /> or <SpellLink id={SPELLS.BLADE_OF_JUSTICE.id} icon /> if you are out of melee range for extended periods of time.</React.Fragment>,
       requirements: () => {
         return [
           new Requirement({
@@ -98,7 +98,7 @@ class Checklist extends CoreChecklist {
           new Requirement({
             name: <React.Fragment>Good first global with <SpellLink id={SPELLS.CRUSADE_TALENT.id} icon /> buff</React.Fragment>,
             check: () => this.crusade.suggestionThresholds,
-            when: this.crusade.active,
+            when: combatant.hasTalent(SPELLS.CRUSADE_TALENT.id),
           }),
           new GenericCastEfficiencyRequirement({
             spell: SPELLS.AVENGING_WRATH,

--- a/src/Parser/Paladin/Retribution/Modules/Features/Checklist.js
+++ b/src/Parser/Paladin/Retribution/Modules/Features/Checklist.js
@@ -25,6 +25,7 @@ import Whisper from '../Items/WhisperOfTheNathrezim';
 import SoulOfTheHighlord from '../Items/SoulOfTheHighlord';
 import Crusade from '../Talents/Crusade';
 import Inquisition from '../Talents/Inquisition';
+import RighteousVerdict from '../Talents/RighteousVerdict';
 
 class Checklist extends CoreChecklist {
 	static dependencies = {
@@ -45,6 +46,7 @@ class Checklist extends CoreChecklist {
     whisper: Whisper,
     crusade: Crusade,
     inquisition: Inquisition,
+    righteousVerdict: RighteousVerdict,
 	};
 
   rules = [
@@ -132,12 +134,17 @@ class Checklist extends CoreChecklist {
             check: () => this.inquisition.suggestionThresholds,
             when: combatant.hasTalent(SPELLS.INQUISITION_TALENT.id),
           }),
+          new Requirement({
+            name: <React.Fragment></React.Fragment>,
+            check: () => this.righteousVerdict.suggestionThresholds,
+            when: combatant.hasTalent(SPELLS.RIGHTEOUS_VERDICT_TALENT.id),
+          }),
         ];
       },
     }),
   	new Rule({
   		name: 'Use your Holy Power efficently',
-  		description: "Holy Power is your main resource, it's very important not to not waste it.",
+  		description: "Holy Power is your main resource, it's very important not to waste it.",
   		requirements: () => {
   			return [
   				new Requirement({

--- a/src/Parser/Paladin/Retribution/Modules/Features/Checklist.js
+++ b/src/Parser/Paladin/Retribution/Modules/Features/Checklist.js
@@ -94,7 +94,7 @@ class Checklist extends CoreChecklist {
             when: combatant.hasTalent(SPELLS.CRUSADE_TALENT.id),
           }),
           new Requirement({
-            name: <React.Fragment>Good first global with <SpellLink id={SPELLS.CRUSADE_TALENT} icon /> buff</React.Fragment>,
+            name: <React.Fragment>Good first global with <SpellLink id={SPELLS.CRUSADE_TALENT.id} icon /> buff</React.Fragment>,
             check: () => this.crusade.suggestionThresholds,
             when: this.crusade.active,
           }),

--- a/src/Parser/Paladin/Retribution/Modules/Features/Checklist.js
+++ b/src/Parser/Paladin/Retribution/Modules/Features/Checklist.js
@@ -135,7 +135,7 @@ class Checklist extends CoreChecklist {
             when: combatant.hasTalent(SPELLS.INQUISITION_TALENT.id),
           }),
           new Requirement({
-            name: <React.Fragment></React.Fragment>,
+            name: <React.Fragment><SpellLink id={SPELLS.RIGHTEOUS_VERDICT_TALENT.id} icon /> efficiency</React.Fragment>,
             check: () => this.righteousVerdict.suggestionThresholds,
             when: combatant.hasTalent(SPELLS.RIGHTEOUS_VERDICT_TALENT.id),
           }),

--- a/src/Parser/Paladin/Retribution/Modules/Features/Checklist.js
+++ b/src/Parser/Paladin/Retribution/Modules/Features/Checklist.js
@@ -24,6 +24,7 @@ import Liadrins from '../Items/LiadrinsFuryUnleashed';
 import Whisper from '../Items/WhisperOfTheNathrezim';
 import SoulOfTheHighlord from '../Items/SoulOfTheHighlord';
 import Crusade from '../Talents/Crusade';
+import Inquisition from '../Talents/Inquisition';
 
 class Checklist extends CoreChecklist {
 	static dependencies = {
@@ -43,87 +44,105 @@ class Checklist extends CoreChecklist {
     soulOfTheHighlord: SoulOfTheHighlord,
     whisper: Whisper,
     crusade: Crusade,
+    inquisition: Inquisition,
 	};
 
-	rules = [
+  rules = [
     new Rule({
-    	name: 'Always be casting',
-   		description: <React.Fragment>You should try to avoid doing nothing during the fight. If you have to move, use your <SpellLink id={SPELLS.DIVINE_STEED.id} icon /> to minimize downtime. Also use ranged abilities like <SpellLink id={SPELLS.JUDGMENT_CAST.id} icon /> or <SpellLink id={SPELLS.BLADE_OF_JUSTICE.id} icon /> if out of melee range for extended periods.</React.Fragment>,
-    		requirements: () => {
-      		return [
-        			new Requirement({
-          			name: 'Downtime',
-          			check: () => this.alwaysBeCasting.suggestionThresholds,
-        			}),
-      		];
-    		},
-  	}),
-  	new Rule({
-  		name: 'Use core abilities as often as possible',
-  		description:<React.Fragment>Spells with short cooldowns like <SpellLink id={SPELLS.JUDGMENT_CAST.id} icon />, <SpellLink id={SPELLS.BLADE_OF_JUSTICE.id} icon />, and <SpellLink id={SPELLS.CRUSADER_STRIKE.id} icon /> should be used as often as possible.</React.Fragment>,
-  		requirements: () => {
-  			const combatant = this.selectedCombatant;
-  			return [
-  				new GenericCastEfficiencyRequirement({
-  					spell: SPELLS.ZEAL_TALENT,
-  					when: combatant.hasTalent(SPELLS.ZEAL_TALENT.id),
-  				}),
-  				new GenericCastEfficiencyRequirement({
-  					spell: SPELLS.CRUSADER_STRIKE,
-  					when: !combatant.hasTalent(SPELLS.ZEAL_TALENT.id),
-  				}),
-  				new GenericCastEfficiencyRequirement({
-  					spell: SPELLS.JUDGMENT_CAST,
-            onlyWithSuggestion: false,
-  				}),
-  				new GenericCastEfficiencyRequirement({
-  					spell: SPELLS.BLADE_OF_JUSTICE,
-  				}),
-  			];
-  		},
-  	}),
-  	new Rule({
-  		name: 'Use your cooldowns',
-  		description: <React.Fragment>Retribution Paladin is a very cooldown dependant spec. Make sure you are keeping <SpellLink id={SPELLS.CRUSADE_TALENT.id} icon /> and <SpellLink id={SPELLS.WAKE_OF_ASHES_TALENT.id} /> on cooldown.</React.Fragment>,
-  		requirements: () => {
-  			const combatant = this.selectedCombatant;
-  			return [
-  				new GenericCastEfficiencyRequirement({
-  					spell: SPELLS.CRUSADE_TALENT,
-  					when: combatant.hasTalent(SPELLS.CRUSADE_TALENT.id),
-  				}),
+      name: 'Always be casting',
+      description: <React.Fragment>You should try to avoid doing nothing during the fight. If you have to move, use your <SpellLink id={SPELLS.DIVINE_STEED.id} icon /> to minimize downtime. Also use ranged abilities like <SpellLink id={SPELLS.JUDGMENT_CAST.id} icon /> or <SpellLink id={SPELLS.BLADE_OF_JUSTICE.id} icon /> if out of melee range for extended periods.</React.Fragment>,
+      requirements: () => {
+        return [
           new Requirement({
-            name: <React.Fragment>Good first global with <SpellLink id={SPELLS.CRUSADE_TALENT.id} icon /> buff</React.Fragment>,
+            name: 'Downtime',
+            check: () => this.alwaysBeCasting.suggestionThresholds,
+          }),
+        ];
+      },
+    }),
+    new Rule({
+      name: 'Use core abilities as often as possible',
+      description: <React.Fragment>Spells with short cooldowns like <SpellLink id={SPELLS.JUDGMENT_CAST.id} icon />, <SpellLink id={SPELLS.BLADE_OF_JUSTICE.id} icon />, and <SpellLink id={SPELLS.CRUSADER_STRIKE.id} icon /> should be used as often as possible.</React.Fragment>,
+      requirements: () => {
+        const combatant = this.selectedCombatant;
+        return [
+          new GenericCastEfficiencyRequirement({
+            spell: SPELLS.CRUSADER_STRIKE,
+          }),
+          new GenericCastEfficiencyRequirement({
+            spell: SPELLS.JUDGMENT_CAST,
+            onlyWithSuggestion: false,
+          }),
+          new GenericCastEfficiencyRequirement({
+            spell: SPELLS.BLADE_OF_JUSTICE,
+          }),
+          new GenericCastEfficiencyRequirement({
+            spell: SPELLS.CONSECRATION_TALENT,
+            when: combatant.hasTalent(SPELLS.CONSECRATION_TALENT.id),
+          }),
+        ];
+      },
+    }),
+    new Rule({
+      name: 'Use your cooldowns',
+      description: <React.Fragment>Retribution Paladin is a very cooldown dependant spec. Make sure you are keeping spells like <SpellLink id={this.selectedCombatant.hasTalent(SPELLS.CRUSADE_TALENT.id) ? SPELLS.CRUSADE_TALENT.id : SPELLS.AVENGING_WRATH.id} icon /> and <SpellLink id={SPELLS.WAKE_OF_ASHES_TALENT.id} /> on cooldown.</React.Fragment>,
+      requirements: () => {
+        const combatant = this.selectedCombatant;        
+        return [
+          new GenericCastEfficiencyRequirement({
+            spell: SPELLS.CRUSADE_TALENT,
+            when: combatant.hasTalent(SPELLS.CRUSADE_TALENT.id),
+          }),
+          new Requirement({
+            name: <React.Fragment>Good first global with <SpellLink id={SPELLS.CRUSADE_TALENT} icon /> buff</React.Fragment>,
             check: () => this.crusade.suggestionThresholds,
             when: this.crusade.active,
           }),
-  				new GenericCastEfficiencyRequirement({
-  					spell: SPELLS.AVENGING_WRATH,
-  					when: !combatant.hasTalent(SPELLS.CRUSADE_TALENT.id),
-  				}),
-  				new GenericCastEfficiencyRequirement({
-  					spell: SPELLS.WAKE_OF_ASHES_TALENT,
-            onlyWithSuggestion: false,
-  				}),
-  			];
-  		},
-  	}),
+          new GenericCastEfficiencyRequirement({
+            spell: SPELLS.AVENGING_WRATH,
+            when: !combatant.hasTalent(SPELLS.CRUSADE_TALENT.id),
+          }),
+          new GenericCastEfficiencyRequirement({
+            spell: SPELLS.WAKE_OF_ASHES_TALENT,
+            when: combatant.hasTalent(SPELLS.WAKE_OF_ASHES_TALENT.id),
+          }),
+          new GenericCastEfficiencyRequirement({
+            spell: SPELLS.EXECUTION_SENTENCE_TALENT,
+            when: combatant.hasTalent(SPELLS.EXECUTION_SENTENCE_TALENT.id),
+          }),
+        ];
+      },
+    }),
+    new Rule({
+      name: 'Use procs and buffs efficiently',
+      description: <React.Fragment>Buffs and procs like <SpellLink id={SPELLS.INQUISITION_TALENT.id} icon />, <SpellLink id={SPELLS.ART_OF_WAR.id} icon /> and <SpellLink id={SPELLS.RIGHTEOUS_VERDICT_TALENT.id} icon /> have a significant impact on your damage, use them well</React.Fragment>,
+      requirements: () => {
+        const combatant = this.selectedCombatant;
+        return [
+          new Requirement({
+            name: <React.Fragment><SpellLink id={SPELLS.ART_OF_WAR.id} icon /> procs used</React.Fragment>,
+            check: () => this.artOfWar.suggestionThresholds,
+          }),
+          new Requirement({
+            name: <React.Fragment><SpellLink id={SPELLS.JUDGMENT_CAST.id} icon /> debuffs consumed</React.Fragment>,
+            check: () => this.judgment.suggestionThresholds,
+          }),
+          new Requirement({
+            name: <React.Fragment>Damage empowered by <SpellLink id={SPELLS.INQUISITION_TALENT.id} icon /></React.Fragment>,
+            check: () => this.inquisition.suggestionThresholds,
+            when: combatant.hasTalent(SPELLS.INQUISITION_TALENT.id),
+          }),
+        ];
+      },
+    }),
   	new Rule({
-  		name: 'Use your resources efficently',
-  		description: <React.Fragment>Holy Power is your main resource and it's very important not to let it cap. You should also only be spending Holy Power inside of the <SpellLink id={SPELLS.JUDGMENT_CAST.id} icon /> debuff window.</React.Fragment>,
+  		name: 'Use your Holy Power efficently',
+  		description: "Holy Power is your main resource, it's very important not to not waste it.",
   		requirements: () => {
   			return [
   				new Requirement({
   					name: 'Holy Power efficiency',
   					check: () => this.holyPowerDetails.suggestionThresholds,
-  				}),
-  				new Requirement({
-  					name: <React.Fragment>Holy power spent with <SpellLink id={SPELLS.JUDGMENT_CAST.id} icon /></React.Fragment>,
-  					check: () => this.judgment.suggestionThresholds,
-  				}),
-  				new Requirement({
-             name: <React.Fragment><SpellLink id={SPELLS.ART_OF_WAR.id} icon /> procs used</React.Fragment>,
-             check: () => this.artOfWar.suggestionThresholds,
   				}),
   			];
   		},

--- a/src/Parser/Paladin/Retribution/Modules/Items/AshesToDust.js
+++ b/src/Parser/Paladin/Retribution/Modules/Items/AshesToDust.js
@@ -4,7 +4,7 @@ import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
 import Analyzer from 'Parser/Core/Analyzer';
 import Enemies from 'Parser/Core/Modules/Enemies';
-import GetDamageBonus from 'Parser/Paladin/Shared/Modules/GetDamageBonus';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 import ItemDamageDone from 'Main/ItemDamageDone';
 
 const ASHES_TO_DUST_MODIFIER = 0.15;
@@ -27,7 +27,7 @@ class AshesToDust extends Analyzer {
     }
     const enemy = this.enemies.getEntity(event);
     if (enemy && enemy.hasBuff(SPELLS.WAKE_OF_ASHES_TALENT.id)) {
-      this.damageDone += GetDamageBonus(event, ASHES_TO_DUST_MODIFIER);
+      this.damageDone += calculateEffectiveDamage(event, ASHES_TO_DUST_MODIFIER);
     }
   }
 

--- a/src/Parser/Paladin/Retribution/Modules/Items/ChainOfThrayn.js
+++ b/src/Parser/Paladin/Retribution/Modules/Items/ChainOfThrayn.js
@@ -5,7 +5,7 @@ import ITEMS from 'common/ITEMS';
 
 import Analyzer from 'Parser/Core/Analyzer';
 
-import GetDamageBonus from 'Parser/Paladin/Shared/Modules/GetDamageBonus';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 import ItemDamageDone from 'Main/ItemDamageDone';
 
 const CHAIN_OF_THRAYN_INCREASE = 0.1;
@@ -24,7 +24,7 @@ class ChainOfThrayn extends Analyzer {
       return;
     }
     if (this.selectedCombatant.hasBuff(SPELLS.CRUSADE_TALENT.id) || this.selectedCombatant.hasBuff(SPELLS.AVENGING_WRATH.id)) {
-      this.damageDone += GetDamageBonus(event, CHAIN_OF_THRAYN_INCREASE);
+      this.damageDone += calculateEffectiveDamage(event, CHAIN_OF_THRAYN_INCREASE);
     }
   }
 

--- a/src/Parser/Paladin/Retribution/Modules/Items/Tier20_2set.js
+++ b/src/Parser/Paladin/Retribution/Modules/Items/Tier20_2set.js
@@ -6,7 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { formatNumber, formatPercentage } from 'common/format';
 import Analyzer from 'Parser/Core/Analyzer';
 import Haste from 'Parser/Core/Modules/Haste';
-import GetDamageBonus from 'Parser/Paladin/Shared/Modules/GetDamageBonus';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 import ItemDamageDone from 'Main/ItemDamageDone';
 
 const RET_PALADIN_T20_2SET_MODIFIER = 0.2;
@@ -33,7 +33,7 @@ class Tier20_2set extends Analyzer {
 
   on_byPlayer_damage(event) {
     if (this.selectedCombatant.hasBuff(SPELLS.RET_PALADIN_T20_2SET_BONUS_BUFF.id) && (event.ability.guid === SPELLS.BLADE_OF_JUSTICE.id)) {
-      this.damageDone += GetDamageBonus(event, RET_PALADIN_T20_2SET_MODIFIER);
+      this.damageDone += calculateEffectiveDamage(event, RET_PALADIN_T20_2SET_MODIFIER);
     }
   }
 

--- a/src/Parser/Paladin/Retribution/Modules/Items/Tier21_2set.js
+++ b/src/Parser/Paladin/Retribution/Modules/Items/Tier21_2set.js
@@ -7,7 +7,7 @@ import { formatNumber } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
 
-import GetDamageBonus from 'Parser/Paladin/Shared/Modules/GetDamageBonus';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 import ItemDamageDone from 'Main/ItemDamageDone';
 
 const RET_PALADIN_T21_2SET_MODIFIER = 0.4;
@@ -25,7 +25,7 @@ class Tier21_2set extends Analyzer {
     if (spellId !== SPELLS.JUDGMENT_CAST.id) {
       return;
     }
-    this.damageDone += GetDamageBonus(event, RET_PALADIN_T21_2SET_MODIFIER);
+    this.damageDone += calculateEffectiveDamage(event, RET_PALADIN_T21_2SET_MODIFIER);
   }
 
   item() {

--- a/src/Parser/Paladin/Retribution/Modules/Items/WhisperOfTheNathrezim.js
+++ b/src/Parser/Paladin/Retribution/Modules/Items/WhisperOfTheNathrezim.js
@@ -8,7 +8,7 @@ import { formatNumber, formatPercentage } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
 
-import GetDamageBonus from 'Parser/Paladin/Shared/Modules/GetDamageBonus';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 import ItemDamageDone from 'Main/ItemDamageDone';
 
 const WHISPER_OF_THE_NATHREZIM_MODIFIER = 0.15;
@@ -39,7 +39,7 @@ class WhisperOfTheNathrezim extends Analyzer {
       return;
     }
     if (spellId === SPELLS.TEMPLARS_VERDICT_DAMAGE.id || spellId === SPELLS.DIVINE_STORM_DAMAGE.id) {
-      this.damageDone += GetDamageBonus(event, WHISPER_OF_THE_NATHREZIM_MODIFIER);
+      this.damageDone += calculateEffectiveDamage(event, WHISPER_OF_THE_NATHREZIM_MODIFIER);
     }
   }
 

--- a/src/Parser/Paladin/Retribution/Modules/PaladinCore/Haste.js
+++ b/src/Parser/Paladin/Retribution/Modules/PaladinCore/Haste.js
@@ -8,6 +8,7 @@ class Haste extends CoreHaste {
     [SPELLS.CRUSADE_TALENT.id]: {
       hastePerStack: 0.03,
     },
+    [SPELLS.INQUISITION_TALENT.id]: 0.08,
   };
 }
 

--- a/src/Parser/Paladin/Retribution/Modules/PaladinCore/Judgment.js
+++ b/src/Parser/Paladin/Retribution/Modules/PaladinCore/Judgment.js
@@ -2,7 +2,6 @@ import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import Enemies from 'Parser/Core/Modules/Enemies';
-import Combatants from 'Parser/Core/Modules/Combatants';
 
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
@@ -12,7 +11,6 @@ import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class Judgment extends Analyzer {
   static dependencies = {
-    combatants: Combatants,
     enemies: Enemies,
   };
   templarsVerdictConsumptions = 0;
@@ -83,7 +81,7 @@ class Judgment extends Analyzer {
   }
 
   statistic() {
-    const justicarsVengeanceText = this.combatants.selected.hasTalent(SPELLS.JUSTICARS_VENGEANCE_TALENT.id) ? `<br>Justicars Vengeance consumptions: ${this.justicarsVengeanceConsumptions}` : ``; 
+    const justicarsVengeanceText = this.selectedCombatant.hasTalent(SPELLS.JUSTICARS_VENGEANCE_TALENT.id) ? `<br>Justicars Vengeance consumptions: ${this.justicarsVengeanceConsumptions}` : ``; 
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.JUDGMENT_DEBUFF.id} />}

--- a/src/Parser/Paladin/Retribution/Modules/PaladinCore/Judgment.js
+++ b/src/Parser/Paladin/Retribution/Modules/PaladinCore/Judgment.js
@@ -77,7 +77,7 @@ class Judgment extends Analyzer {
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
       return suggest(<React.Fragment>You're not consuming all your <SpellLink id={SPELLS.JUDGMENT_CAST.id} icon /> debuffs.</React.Fragment>)
         .icon(SPELLS.JUDGMENT_DEBUFF.icon)
-        .actual(`${formatPercentage(this.percentageJudgmentsConsumed)}% Judgements consumed`)
+        .actual(`${formatPercentage(this.percentageJudgmentsConsumed)}% Judgments consumed`)
         .recommended(`>${formatPercentage(recommended)}% is recommended`);
     });
   }

--- a/src/Parser/Paladin/Retribution/Modules/PaladinCore/Retribution.js
+++ b/src/Parser/Paladin/Retribution/Modules/PaladinCore/Retribution.js
@@ -7,7 +7,7 @@ import SpellIcon from 'common/SpellIcon';
 import { formatNumber, formatPercentage } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
-import GetDamageBonus from 'Parser/Paladin/Shared/Modules/GetDamageBonus';
+import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 
 const RETRIBUTION_DAMAGE_BONUS = 0.2;
 
@@ -22,7 +22,7 @@ class Retribution extends Analyzer {
       // Friendly fire does not get increased
       return;
     }
-    this.bonusDmg += GetDamageBonus(event, RETRIBUTION_DAMAGE_BONUS);
+    this.bonusDmg += calculateEffectiveDamage(event, RETRIBUTION_DAMAGE_BONUS);
   }
 
   on_finished() {

--- a/src/Parser/Paladin/Retribution/Modules/Talents/Inquisition.js
+++ b/src/Parser/Paladin/Retribution/Modules/Talents/Inquisition.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import Analyzer from 'Parser/Core/Analyzer';
-import Combatants from 'Parser/Core/Modules/Combatants';
 
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
@@ -10,16 +9,14 @@ import { formatPercentage } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class Inquisition extends Analyzer {
-  static dependencies = {
-    combatants: Combatants,
-  }
 
-  on_initialized(event) {
-    this.active = this.combatants.selected.hasTalent(SPELLS.INQUISITION_TALENT.id);
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.INQUISITION_TALENT.id);
   }
 
   get uptime() {
-    return this.combatants.selected.getBuffUptime(SPELLS.INQUISITION_TALENT.id) / this.owner.fightDuration;
+    return this.selectedCombatant.getBuffUptime(SPELLS.INQUISITION_TALENT.id) / this.owner.fightDuration;
   }
 
   get suggestionThresholds() {

--- a/src/Parser/Paladin/Retribution/Modules/Talents/Inquisition.js
+++ b/src/Parser/Paladin/Retribution/Modules/Talents/Inquisition.js
@@ -27,6 +27,10 @@ class Inquisition extends Analyzer {
     return this.owner.getPercentageOfTotalDamageDone(this.buffedDamage);
   }
 
+  get uptime() {
+    return this.selectedCombatant.getBuffUptime(SPELLS.INQUISITION_TALENT.id) / this.owner.fightDuration;
+  }
+
   get suggestionThresholds() {
     return {
       actual: this.efficiency,
@@ -53,8 +57,8 @@ class Inquisition extends Analyzer {
       <StatisticBox
         icon={<SpellIcon id={SPELLS.INQUISITION_TALENT.id} />}
         value={`${formatPercentage(this.efficiency)}%`}
-        label="Buffed Damage"
-        tooltip="The relative amount of damage done while Inquisition was active"
+        label="Damage done while buffed"
+        tooltip={`Relative amount of damage done while Inquisition was active. You had Inquisition active for ${formatPercentage(this.uptime)}% of the fight`}
       />
     );
   }

--- a/src/Parser/Paladin/Retribution/Modules/Talents/Inquisition.js
+++ b/src/Parser/Paladin/Retribution/Modules/Talents/Inquisition.js
@@ -8,20 +8,28 @@ import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
+// This module looks at the relative amount of damage buffed rather than strict uptime to be more accurate for fights with high general downtime
+
 class Inquisition extends Analyzer {
+  buffedDamage = 0;
 
   constructor(...args) {
     super(...args);
     this.active = this.selectedCombatant.hasTalent(SPELLS.INQUISITION_TALENT.id);
   }
 
-  get uptime() {
-    return this.selectedCombatant.getBuffUptime(SPELLS.INQUISITION_TALENT.id) / this.owner.fightDuration;
+  on_byPlayer_damage(event) {
+    if (this.selectedCombatant.hasBuff(SPELLS.INQUISITION_TALENT.id)) {
+      this.buffedDamage += event.amount + (event.absorbed || 0);
+    }
+  }
+  get efficiency() {
+    return this.owner.getPercentageOfTotalDamageDone(this.buffedDamage);
   }
 
   get suggestionThresholds() {
     return {
-      actual: this.uptime,
+      actual: this.efficiency,
       isLessThan: {
         minor: 0.95,
         average: 0.9,
@@ -33,9 +41,9 @@ class Inquisition extends Analyzer {
 
   suggestions(when) {
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
-      return suggest(<React.Fragment>Your <SpellLink id={SPELLS.INQUISITION_TALENT.id} icon /> uptime is low</React.Fragment>)
+      return suggest(<React.Fragment>Your <SpellLink id={SPELLS.INQUISITION_TALENT.id} icon /> efficiency is low. You should aim to have it active as often as possible while dealing damage</React.Fragment>)
         .icon(SPELLS.INQUISITION_TALENT.icon)
-        .actual(`${formatPercentage(this.uptime)}% uptime`)
+        .actual(`${formatPercentage(this.efficiency)}% of damage buffed`)
         .recommended(`>${formatPercentage(recommended)}% is recommended`);
     });
   }
@@ -44,8 +52,9 @@ class Inquisition extends Analyzer {
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.INQUISITION_TALENT.id} />}
-        value={`${formatPercentage(this.uptime)}%`}
-        label="Inquisition Uptime"
+        value={`${formatPercentage(this.efficiency)}%`}
+        label="Buffed Damage"
+        tooltip="The relative amount of damage done while Inquisition was active"
       />
     );
   }

--- a/src/Parser/Paladin/Retribution/Modules/Talents/Inquisition.js
+++ b/src/Parser/Paladin/Retribution/Modules/Talents/Inquisition.js
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import { formatPercentage } from 'common/format';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+
+class Inquisition extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  }
+
+  on_initialized(event) {
+    this.active = this.combatants.selected.hasTalent(SPELLS.INQUISITION_TALENT.id);
+  }
+
+  get uptime() {
+    return this.combatants.selected.getBuffUptime(SPELLS.INQUISITION_TALENT.id) / this.owner.fightDuration;
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.uptime,
+      isLessThan: {
+        minor: 0.95,
+        average: 0.9,
+        major: 0.85,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(<React.Fragment>Your <SpellLink id={SPELLS.INQUISITION_TALENT.id} icon /> uptime is low</React.Fragment>)
+        .icon(SPELLS.INQUISITION_TALENT.icon)
+        .actual(`${formatPercentage(this.uptime)}% uptime`)
+        .recommended(`>${formatPercentage(recommended)}% is recommended`);
+    });
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.INQUISITION_TALENT.id} />}
+        value={`${formatPercentage(this.uptime)}%`}
+        label="Inquisition Uptime"
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(5);
+}
+
+export default Inquisition;

--- a/src/Parser/Paladin/Retribution/Modules/Talents/RighteousVerdict.js
+++ b/src/Parser/Paladin/Retribution/Modules/Talents/RighteousVerdict.js
@@ -24,7 +24,7 @@ class RighteousVerdict extends Analyzer {
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
-    if (spellId === SPELLS.TEMPLARS_VERDICT.id || spellId === SPELLS.DIVINE_STORM.id) {
+    if (spellId === SPELLS.TEMPLARS_VERDICT.id) {
       if (this.selectedCombatant.hasBuff(SPELLS.RIGHTEOUS_VERDICT_BUFF.id)) {
         this.spenderInsideBuff++;
       }
@@ -40,20 +40,6 @@ class RighteousVerdict extends Analyzer {
     if (spellId === SPELLS.TEMPLARS_VERDICT_DAMAGE.id) {
       this.damageDone += GetDamageBonus(event, RIGHTEOUS_VERDICT_MODIFIER);
     }
-  }
-
-  statistic() {
-    return (
-      <StatisticBox
-        icon={<SpellIcon id={SPELLS.RIGHTEOUS_VERDICT_TALENT.id} />}
-        value={this.damageDone}
-        label="Damage Done"
-        tooltip={`
-           The effective damage contributed by Righteous Verdict.<br/>
-           Total Damage: ${formatNumber(this.damageDone)}<br/>
-           Buffed Casts: ${formatNumber(this.spenderInsideBuff)} (${formatPercentage(this.spenderInsideBuff / this.totalSpender)}%)`}
-      />
-    );
   }
 
   get suggestionThresholds() {
@@ -75,6 +61,20 @@ class RighteousVerdict extends Analyzer {
         .actual(`${formatPercentage(actual)}% of Templars Verdicts with the buff`)
         .recommended(`>${formatPercentage(recommended)}% is recommended`);
     });
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.RIGHTEOUS_VERDICT_TALENT.id} />}
+        value={this.damageDone}
+        label="Damage Done"
+        tooltip={`
+           The effective damage contributed by Righteous Verdict.<br/>
+           Total Damage: ${formatNumber(this.damageDone)} (${formatPercentage(this.spenderInsideBuff / this.totalSpender)}%)<br/>
+           Buffed Casts: ${formatNumber(this.spenderInsideBuff)}`}
+      />
+    );
   }
   statisticOrder = STATISTIC_ORDER.CORE(7);
 }

--- a/src/Parser/Paladin/Retribution/Modules/Talents/RighteousVerdict.js
+++ b/src/Parser/Paladin/Retribution/Modules/Talents/RighteousVerdict.js
@@ -1,0 +1,82 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import SpellIcon from 'common/SpellIcon';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import { formatNumber, formatPercentage } from 'common/format';
+
+import Analyzer from 'Parser/Core/Analyzer';
+
+import GetDamageBonus from 'Parser/Paladin/Shared/Modules/GetDamageBonus';
+
+const RIGHTEOUS_VERDICT_MODIFIER = 0.15;
+
+class RighteousVerdict extends Analyzer {
+  damageDone = 0;
+  spenderInsideBuff = 0;
+  totalSpender = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.RIGHTEOUS_VERDICT_TALENT.id);
+  }
+
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    if (spellId === SPELLS.TEMPLARS_VERDICT.id || spellId === SPELLS.DIVINE_STORM.id) {
+      if (this.selectedCombatant.hasBuff(SPELLS.RIGHTEOUS_VERDICT_BUFF.id)) {
+        this.spenderInsideBuff++;
+      }
+      this.totalSpender++;
+    }
+  }
+
+  on_byPlayer_damage(event) {
+    const spellId = event.ability.guid;
+    if (!this.selectedCombatant.hasBuff(SPELLS.RIGHTEOUS_VERDICT_BUFF.id)) {
+      return;
+    }
+    if (spellId === SPELLS.TEMPLARS_VERDICT_DAMAGE.id) {
+      this.damageDone += GetDamageBonus(event, RIGHTEOUS_VERDICT_MODIFIER);
+    }
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.RIGHTEOUS_VERDICT_TALENT.id} />}
+        value={this.damageDone}
+        label="Damage Done"
+        tooltip={`
+           The effective damage contributed by Righteous Verdict.<br/>
+           Total Damage: ${formatNumber(this.damageDone)}<br/>
+           Buffed Casts: ${formatNumber(this.spenderInsideBuff)} (${formatPercentage(this.spenderInsideBuff / this.totalSpender)}%)`}
+      />
+    );
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.spenderInsideBuff / this.totalSpender,
+      isLessThan: {
+        minor: 0.80,
+        average: 0.75,
+        major: 0.70,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(<React.Fragment>Your usage of <SpellLink id={SPELLS.RIGHTEOUS_VERDICT_TALENT.id} icon /> can be improved. Make sure you aren't letting the <SpellLink id={SPELLS.RIGHTEOUS_VERDICT_TALENT.id} icon /> buff run out before casting <SpellLink id={SPELLS.TEMPLARS_VERDICT.id} icon/> again</React.Fragment>)
+        .icon(SPELLS.RIGHTEOUS_VERDICT_TALENT.icon)
+        .actual(`${formatPercentage(actual)}% of Templars Verdicts with the buff`)
+        .recommended(`>${formatPercentage(recommended)}% is recommended`);
+    });
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(7);
+}
+
+export default RighteousVerdict;

--- a/src/Parser/Paladin/Retribution/Modules/Talents/RighteousVerdict.js
+++ b/src/Parser/Paladin/Retribution/Modules/Talents/RighteousVerdict.js
@@ -72,7 +72,7 @@ class RighteousVerdict extends Analyzer {
         label="Damage Done"
         tooltip={`
            The effective damage contributed by Righteous Verdict.<br/>
-           Total Damage: ${formatNumber(this.damageDone)} (${formatPercentage(this.spendersInsideBuff / this.totalSpenders)}%)<br/>
+           Total Damage: ${formatNumber(this.damageDone)} (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.damageDone))} %)<br/>
            Buffed Casts: ${formatNumber(this.spendersInsideBuff)} (${formatPercentage(this.spendersInsideBuff / this.totalSpenders)}%)`}
       />
     );

--- a/src/Parser/Paladin/Shared/Modules/GetDamageBonus.js
+++ b/src/Parser/Paladin/Shared/Modules/GetDamageBonus.js
@@ -1,4 +1,0 @@
-export default function GetDamageBonus(event, increase) {
-  const raw = (event.amount || 0) + (event.absorbed || 0);
-  return raw - (raw / (1 + increase));
-}

--- a/src/Parser/Paladin/Shared/Modules/getDamageBonusStacked.js
+++ b/src/Parser/Paladin/Shared/Modules/getDamageBonusStacked.js
@@ -1,8 +1,0 @@
-export default function getDamageBonusStacked(event, increase, stacks) {
-	const raw = (event.amount || 0) + (event.absorbed || 0);
-	const relativeDamageIncreaseFactor = 1 + (increase * stacks);
-	const totalIncrease = raw - raw / relativeDamageIncreaseFactor;
-	const oneStackIncrease = totalIncrease / stacks;
-
-	return Math.max(0, oneStackIncrease);
-}

--- a/src/common/SPELLS/PALADIN.js
+++ b/src/common/SPELLS/PALADIN.js
@@ -357,6 +357,11 @@ export default {
     name: 'Art of War',
     icon: 'ability_paladin_artofwar',
   },
+  RIGHTEOUS_VERDICT_BUFF: {
+    id: 267611,
+    name: 'Righteous Verdict',
+    icon: 'spell_paladin_templarsverdict',
+  },
   // Ret Item Effects
   WHISPER_OF_THE_NATHREZIM_BUFF: {
     id: 207635,


### PR DESCRIPTION
New checklist rule: 
![image](https://user-images.githubusercontent.com/30317641/41854599-ea2e8a14-7890-11e8-8607-e2931c99fd8f.png)

New statistics: 
![image](https://user-images.githubusercontent.com/30317641/41854649-085618c2-7891-11e8-8cff-b1998ae117d8.png)

Unfortunately i couldn't find any logs where the player using Righteous Verdict wasn't AFK, so it's 0 in everything here because of that
![image](https://user-images.githubusercontent.com/30317641/41854615-f5f7c64e-7890-11e8-8629-c6a7e337cee3.png)


