### PR TITLE
[Feral] Predator talent

### DIFF
--- a/src/Parser/Druid/Feral/CHANGELOG.js
+++ b/src/Parser/Druid/Feral/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-06-27'),
+    changes: <React.Fragment>Added tracking for the <SpellLink id={SPELLS.PREDATOR_TALENT.id} /> talent.</React.Fragment>,
+    contributors: [Anatta336],
+  },
+  {
     date: new Date('2018-06-11'),
     changes: <React.Fragment>Added statistics breaking down snapshot uptime by buff for <SpellLink id={SPELLS.RAKE.id} />, <SpellLink id={SPELLS.RIP.id} />, and <SpellLink id={SPELLS.MOONFIRE_FERAL.id} />.</React.Fragment>,
     contributors: [Anatta336],

--- a/src/Parser/Druid/Feral/CombatLogParser.js
+++ b/src/Parser/Druid/Feral/CombatLogParser.js
@@ -6,6 +6,7 @@ import RakeBleed from './Modules/Normalizers/RakeBleed';
 import Abilities from './Modules/Features/Abilities';
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
 import CooldownThroughputTracker from './Modules/Features/CooldownThroughputTracker';
+import SpellUsable from './Modules/Features/SpellUsable';
 
 import RakeUptime from './Modules/Bleeds/RakeUptime';
 import RipUptime from './Modules/Bleeds/RipUptime';
@@ -20,6 +21,7 @@ import SavageRoarUptime from './Modules/Talents/SavageRoarUptime';
 import MoonfireUptime from './Modules/Talents/MoonfireUptime';
 import SavageRoarDmg from './Modules/Talents/SavageRoarDmg';
 import MoonfireSnapshot from './Modules/Talents/MoonfireSnapshot';
+import Predator from './Modules/Talents/Predator';
 
 import AshamanesRip from './Modules/Traits/AshamanesRip';
 
@@ -38,6 +40,7 @@ class CombatLogParser extends CoreCombatLogParser {
     abilities: Abilities,
     cooldownThroughputTracker: CooldownThroughputTracker,
     ferociousBiteEnergy: FerociousBiteEnergy,
+    spellUsable: SpellUsable,
 
     // bleeds
     rakeUptime: RakeUptime,
@@ -50,6 +53,7 @@ class CombatLogParser extends CoreCombatLogParser {
     savageRoarUptime: SavageRoarUptime,
     moonfireUptime: MoonfireUptime,
     savageRoarDmg: SavageRoarDmg,
+    predator: Predator,
 
     // resources
     comboPointTracker: ComboPointTracker,

--- a/src/Parser/Druid/Feral/Constants.js
+++ b/src/Parser/Druid/Feral/Constants.js
@@ -1,0 +1,10 @@
+export const RAKE_BASE_DURATION = 15000;
+export const RIP_BASE_DURATION = 24000;
+// cat moonfire lasts for 14 seconds, unlike caster and bear moonfire with a base of 16 seconds.
+export const MOONFIRE_FERAL_BASE_DURATION = 14000;
+export const THRASH_FERAL_BASE_DURATION = 15000;
+
+export const BITE_EXECUTE_RANGE = 0.25;
+export const SAVAGE_ROAR_DAMAGE_BONUS = 0.15;
+export const JAGGED_WOUNDS_MODIFIER = 0.80;
+export const PANDEMIC_FRACTION = 0.3;

--- a/src/Parser/Druid/Feral/Modules/Bleeds/RakeSnapshot.js
+++ b/src/Parser/Druid/Feral/Modules/Bleeds/RakeSnapshot.js
@@ -3,7 +3,8 @@ import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
 import { STATISTIC_ORDER } from 'Main/StatisticsListBox';
-import Snapshot, { JAGGED_WOUNDS_MODIFIER, PANDEMIC_FRACTION } from '../FeralCore/Snapshot';
+import { RAKE_BASE_DURATION, JAGGED_WOUNDS_MODIFIER, PANDEMIC_FRACTION } from '../../Constants';
+import Snapshot from '../FeralCore/Snapshot';
 
 /**
  * Identify inefficient refreshes of the Rake DoT:
@@ -18,7 +19,6 @@ import Snapshot, { JAGGED_WOUNDS_MODIFIER, PANDEMIC_FRACTION } from '../FeralCor
  */
 const FORGIVE_PROWL_LOSS_TIME = 1000;
 
-const RAKE_BASE_DURATION = 15000;
 class RakeSnapshot extends Snapshot {
   static spellCastId = SPELLS.RAKE.id;
   static debuffId = SPELLS.RAKE_BLEED.id;

--- a/src/Parser/Druid/Feral/Modules/Bleeds/RipSnapshot.js
+++ b/src/Parser/Druid/Feral/Modules/Bleeds/RipSnapshot.js
@@ -6,8 +6,9 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import { formatPercentage } from 'common/format';
 import { encodeTargetString } from 'Parser/Core/Modules/EnemyInstances';
 import { STATISTIC_ORDER } from 'Main/StatisticsListBox';
-import Snapshot, { JAGGED_WOUNDS_MODIFIER, PANDEMIC_FRACTION } from '../FeralCore/Snapshot';
+import Snapshot from '../FeralCore/Snapshot';
 import ComboPointTracker from '../ComboPoints/ComboPointTracker';
+import { RIP_BASE_DURATION, BITE_EXECUTE_RANGE, JAGGED_WOUNDS_MODIFIER, PANDEMIC_FRACTION } from '../../Constants';
 
 const debug = false;
 
@@ -36,9 +37,7 @@ const debug = false;
  * Casting the 4 combo point rip was a mistake. But early-refreshing it with a non-buffed 5 combo point rip is also an error.
  */
 
-const RIP_BASE_DURATION = 24000;
 const RIP_POWER_PER_COMBO = 0.20;
-const BITE_EXECUTE_RANGE = 0.25;
 
 class RipSnapshot extends Snapshot {
   static dependencies = {

--- a/src/Parser/Druid/Feral/Modules/Features/Abilities.js
+++ b/src/Parser/Druid/Feral/Modules/Features/Abilities.js
@@ -115,6 +115,8 @@ class Abilities extends CoreAbilities {
         cooldown: 30,
         castEfficiency: {
           suggestion: true,
+          // Predator may reset the cooldown very frequently, more often than is useful to use the ability
+          recommendedEfficiency: (combatant.hasTalent(SPELLS.PREDATOR_TALENT.id) ? 0.50 : 0.80),
         },
         isOnGCD: false,
         timelineSortIndex: 20,

--- a/src/Parser/Druid/Feral/Modules/Features/SpellUsable.js
+++ b/src/Parser/Druid/Feral/Modules/Features/SpellUsable.js
@@ -1,0 +1,121 @@
+import SPELLS from 'common/SPELLS';
+import CoreSpellUsable from 'Parser/Core/Modules/SpellUsable';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import { encodeTargetString } from 'Parser/Core/Modules/EnemyInstances';
+import { RAKE_BASE_DURATION, RIP_BASE_DURATION, THRASH_FERAL_BASE_DURATION, JAGGED_WOUNDS_MODIFIER, PANDEMIC_FRACTION } from '../../Constants';
+
+const EARLY_BLEED_EXPIRE_TO_COUNT_AS_DEATH = 500;
+
+/**
+ * Predator:
+ * The cooldown on Tiger's Fury resets when a target dies with one of your Bleed effects active
+ * 
+ * We cannot directly detect enemy death, but can infer it from a bleed debuff ending early.
+ * Death is not the only cause of a bleed ending early, for instance a Monk's paralysis ability
+ * removes DoTs when it's applied to a target.
+ * We know for certain that an enemy died when Tiger's Fury is used earlier than should be possible.
+ * When that happens assume the most recent possible enemy death was when the cooldown reset.
+ */
+class SpellUsable extends CoreSpellUsable {
+  // BFA: replace this.combatants.selected with this.selectedCombatant, and remove combatants dependency
+  static dependencies = {
+    ...CoreSpellUsable.dependencies,
+    combatants: Combatants,
+  };
+
+  static bleedBaseDurations = {
+    [SPELLS.RAKE.id]: RAKE_BASE_DURATION,
+    [SPELLS.RIP.id]: RIP_BASE_DURATION,
+    [SPELLS.THRASH_FERAL.id]: THRASH_FERAL_BASE_DURATION,
+  }
+
+  earlyCastsOfTigersFury = 0;
+
+  // e.g. activeBleedsExpire[targetString][SPELLS.RAKE.id] = timestamp
+  activeBleedsExpire = {};
+  hasPredator = null;
+  hasJaggedWounds = null;
+
+  // timestamp of most recent possible kill event
+  possibleRecentKill = null;
+
+  // BFA: replace with constructor (and use this.selectedCombatant)
+  on_initialized() {
+    if (super.on_initialized) {
+      super.on_initialized();
+    }
+    this.hasPredator = this.combatants.selected.hasTalent(SPELLS.PREDATOR_TALENT.id);
+    this.hasJaggedWounds = this.combatants.selected.hasTalent(SPELLS.JAGGED_WOUNDS_TALENT.id);
+  }
+
+  on_byPlayer_applydebuff(event) {
+    if (super.on_byPlayer_applydebuff) {
+      super.on_byPlayer_applydebuff(event);
+    }
+    const spellId = event.ability.guid;
+    if (!this.hasPredator || !this.isBleed(spellId)) {
+      return;
+    }
+    const target = encodeTargetString(event.targetID, event.targetInstance);
+    if (!this.activeBleedsExpire[target]) {
+      this.activeBleedsExpire[target] = {};
+    }
+    const duration = this.constructor.bleedBaseDurations[spellId] * (this.hasJaggedWounds ? JAGGED_WOUNDS_MODIFIER : 1);
+    this.activeBleedsExpire[target][spellId] = event.timestamp + duration;
+  }
+
+  on_byPlayer_refreshdebuff(event) {
+    if (super.on_byPlayer_refreshdebuff) {
+      super.on_byPlayer_refreshdebuff(event);
+    }
+    const spellId = event.ability.guid;
+    if (!this.hasPredator || !this.isBleed(spellId)) {
+      return;
+    }
+    const target = encodeTargetString(event.targetID, event.targetInstance);
+    if (!this.activeBleedsExpire[target]) {
+      this.activeBleedsExpire[target] = {};
+    }
+    // existingExpire may be null if combat log missed the original applydebuff
+    const existingExpire = this.activeBleedsExpire[target][spellId];
+    const remainingOnPrevious = Math.max(0, existingExpire ? (event.timestamp - existingExpire) : 0);
+    const durationWithoutPandemic = this.constructor.bleedBaseDurations[spellId] * (this.hasJaggedWounds ? JAGGED_WOUNDS_MODIFIER : 1);
+    const pandemic = Math.min(durationWithoutPandemic * PANDEMIC_FRACTION, remainingOnPrevious);
+    this.activeBleedsExpire[target][spellId] = event.timestamp + durationWithoutPandemic + pandemic;
+  }
+
+  on_byPlayer_removedebuff(event) {
+    if (super.on_byPlayer_removedebuff) {
+      super.on_byPlayer_removedebuff(event);
+    }
+    const spellId = event.ability.guid;
+    if (!this.hasPredator || !this.isBleed(spellId)) {
+      return;
+    }
+    const target = encodeTargetString(event.targetID, event.targetInstance);
+    if (!this.activeBleedsExpire[target]) {
+      this.activeBleedsExpire[target] = {};
+    }
+    const expire = this.activeBleedsExpire[target][spellId];
+    const beforeExpire = expire ? (expire - event.timestamp) : 0;
+    if (beforeExpire > EARLY_BLEED_EXPIRE_TO_COUNT_AS_DEATH) {
+      this.possibleRecentKill = event.timestamp;
+    }
+  }
+
+  isBleed(spellId) {
+    return !!Object.keys(this.constructor.bleedBaseDurations).includes(spellId.toString());
+  }
+
+  beginCooldown(spellId, timestamp) {
+    if (SPELLS.TIGERS_FURY.id === spellId &&
+        this.hasPredator && this.isOnCooldown(spellId)) {
+      const resetTime = this.possibleRecentKill ? this.possibleRecentKill : timestamp;
+      this.earlyCastsOfTigersFury += 1;
+      this.endCooldown(spellId, null, resetTime);
+    }
+    super.beginCooldown(spellId, timestamp);
+  }
+}
+
+export default SpellUsable;

--- a/src/Parser/Druid/Feral/Modules/FeralCore/Snapshot.js
+++ b/src/Parser/Druid/Feral/Modules/FeralCore/Snapshot.js
@@ -8,6 +8,7 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import { encodeTargetString } from 'Parser/Core/Modules/EnemyInstances';
 import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 import StatisticsListBox from 'Main/StatisticsListBox';
+import { PANDEMIC_FRACTION } from '../../Constants';
 
 const debug = false;
 
@@ -25,11 +26,6 @@ const debug = false;
 const PROWL_MULTIPLIER = 2.00;
 const TIGERS_FURY_MULTIPLIER = 1.15;
 const BLOODTALONS_MULTIPLIER = 1.20;
-
-// "[...]deal the same damage as normal but in 20% less time."
-const JAGGED_WOUNDS_MODIFIER = 0.80;
-
-const PANDEMIC_FRACTION = 0.3;
 
 /**
  * leeway in ms after loss of bloodtalons/prowl buff to count a cast as being buffed.
@@ -281,4 +277,3 @@ class Snapshot extends Analyzer {
   }
 }
 export default Snapshot;
-export { JAGGED_WOUNDS_MODIFIER, PANDEMIC_FRACTION };

--- a/src/Parser/Druid/Feral/Modules/Talents/MoonfireSnapshot.js
+++ b/src/Parser/Druid/Feral/Modules/Talents/MoonfireSnapshot.js
@@ -4,16 +4,14 @@ import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
 import { STATISTIC_ORDER } from 'Main/StatisticsListBox';
 
-import Snapshot, { PANDEMIC_FRACTION } from '../FeralCore/Snapshot';
+import Snapshot from '../FeralCore/Snapshot';
+import { MOONFIRE_FERAL_BASE_DURATION, PANDEMIC_FRACTION } from '../../Constants';
 
 /**
  * Moonfire benefits from the damage bonus of Tiger's Fury over its whole duration, even if the
  * buff wears off in that time. It's a damage loss to refresh Moonfire before the pandemic window
  * if you don't have Tiger's Fury active when the existing DoT does have it active.
  */
-
-// cat moonfire lasts for 14 seconds, unlike caster and bear moonfire with a base of 16 seconds.
-const MOONFIRE_FERAL_BASE_DURATION = 14000;
 
 class MoonfireSnapshot extends Snapshot {
   static spellCastId = SPELLS.MOONFIRE_FERAL.id;

--- a/src/Parser/Druid/Feral/Modules/Talents/Predator.js
+++ b/src/Parser/Druid/Feral/Modules/Talents/Predator.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import SpellUsable from '../Features/SpellUsable';
+import Abilities from '../Features/Abilities';
+
+class Predator extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    spellUsable: SpellUsable,
+    abilities: Abilities,
+  };
+
+  totalCasts = 0;
+
+  // BFA: replace with constructor and this.selectedCombatant
+  on_initialized() {
+    this.active = this.combatants.selected.hasTalent(SPELLS.PREDATOR_TALENT.id);
+  }
+
+  on_byPlayer_cast(event) {
+    if (SPELLS.TIGERS_FURY.id !== event.ability.guid) {
+      return;
+    }
+    this.totalCasts += 1;
+  }
+
+  get baseCasts() {
+    const tigersFury = this.abilities.getAbility(SPELLS.TIGERS_FURY.id);
+    return 1 + Math.floor(this.owner.fightDuration / (tigersFury.cooldown * 1000));
+  }
+
+  get earlyCasts() {
+    return this.spellUsable.earlyCastsOfTigersFury;
+  }
+
+  get extraCasts() {
+    return Math.max(0, this.totalCasts - this.baseCasts);
+  }
+  get extraCastsPerMinute() {
+    return (this.extraCasts / this.owner.fightDuration) * 1000 * 60;
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.extraCastsPerMinute,
+      isLessThan: {
+        minor: 1.0,
+        average: 0.5,
+        major: 0.2,
+      },
+      style: 'number',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <React.Fragment>
+          You're not gaining much benefit from <SpellLink id={SPELLS.PREDATOR_TALENT.id} />. If the fight has adds make sure they have bleeds on them when they die, and make use of your <SpellLink id={SPELLS.TIGERS_FURY.id} /> cooldown being reset. If the fight doesn't have adds it would be a good idea to switch to another talent.
+        </React.Fragment>
+      )
+        .icon(SPELLS.PREDATOR_TALENT.icon)
+        .actual(`${actual.toFixed(1)} extra casts of Tiger's Fury per minute.`)
+        .recommended(`>${recommended.toFixed(1)} is recommended`);
+    });
+  }
+
+  statistic() {
+    // There may be early casts without any extra casts overall
+    const earlyCastsComment = this.earlyCasts > 0 ? `<br/>Thanks to Predator <b>${this.earlyCasts}</b> of your Tiger's Fury casts ${this.earlyCasts !== 1 ? 'were' : 'was'} before when the cooldown would have been ready.` : '';
+    const tooltip = this.extraCasts > 0 ?
+        `Your Predator talent allowed you to use Tiger's Fury at least <b>${this.extraCasts}</b> extra time${this.extraCasts !== 1 ? 's' : ''}. Without it you would have had time for <b>${this.baseCasts}</b> cast${this.baseCasts !== 1 ? 's' : ''} but with it you were able to use Tiger's Fury <b>${this.totalCasts}</b> time${this.totalCasts !== 1 ? 's' : ''}.${earlyCastsComment}` : 
+        `Your Predator talent didn't allow you to cast more Tiger's Fury overall than you would have been able to without it, with the fight lasting long enough for all <b>${this.totalCasts}</b> of your cast${this.totalCasts !== 1 ? 's' : ''}. Either there were no enemies dying with your bleeds on them during this fight or you didn't make use of Tiger's Fury when it came off cooldown.${earlyCastsComment}`;
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.PREDATOR_TALENT.id} />}
+        value={`${this.extraCastsPerMinute.toFixed(2)}`}
+        label="Extra Tiger's Fury casts per minute"
+        tooltip={`${tooltip}`}
+      />
+    );
+  }
+
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(3);
+}
+
+export default Predator;

--- a/src/Parser/Druid/Feral/Modules/Talents/Predator.js
+++ b/src/Parser/Druid/Feral/Modules/Talents/Predator.js
@@ -73,15 +73,14 @@ class Predator extends Analyzer {
   statistic() {
     // There may be early casts without any extra casts overall
     const earlyCastsComment = this.earlyCasts > 0 ? `<br/>Thanks to Predator <b>${this.earlyCasts}</b> of your Tiger's Fury casts ${this.earlyCasts !== 1 ? 'were' : 'was'} before when the cooldown would have been ready.` : '';
-    const tooltip = this.extraCasts > 0 ?
-        `Your Predator talent allowed you to use Tiger's Fury at least <b>${this.extraCasts}</b> extra time${this.extraCasts !== 1 ? 's' : ''}. Without it you would have had time for <b>${this.baseCasts}</b> cast${this.baseCasts !== 1 ? 's' : ''} but with it you were able to use Tiger's Fury <b>${this.totalCasts}</b> time${this.totalCasts !== 1 ? 's' : ''}.${earlyCastsComment}` : 
-        `Your Predator talent didn't allow you to cast more Tiger's Fury overall than you would have been able to without it, with the fight lasting long enough for all <b>${this.totalCasts}</b> of your cast${this.totalCasts !== 1 ? 's' : ''}. Either there were no enemies dying with your bleeds on them during this fight or you didn't make use of Tiger's Fury when it came off cooldown.${earlyCastsComment}`;
+    const hadExtraCasts = `Your Predator talent allowed you to use Tiger's Fury at least <b>${this.extraCasts}</b> extra time${this.extraCasts !== 1 ? 's' : ''}. Without it you would have had time for <b>${this.baseCasts}</b> cast${this.baseCasts !== 1 ? 's' : ''} but with it you were able to use Tiger's Fury <b>${this.totalCasts}</b> time${this.totalCasts !== 1 ? 's' : ''}.${earlyCastsComment}`;
+    const noExtraCasts = `Your Predator talent didn't allow you to cast more Tiger's Fury overall than you would have been able to without it, with the fight lasting long enough for all <b>${this.totalCasts}</b> of your cast${this.totalCasts !== 1 ? 's' : ''}. Either there were no enemies dying with your bleeds on them during this fight or you didn't make use of Tiger's Fury when it came off cooldown.${earlyCastsComment}`;
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.PREDATOR_TALENT.id} />}
-        value={`${this.extraCastsPerMinute.toFixed(2)}`}
+        value={ this.extraCastsPerMinute.toFixed(2) }
         label="Extra Tiger's Fury casts per minute"
-        tooltip={`${tooltip}`}
+        tooltip={ this.extraCasts > 0 ? hadExtraCasts : noExtraCasts }
       />
     );
   }

--- a/src/Parser/Druid/Feral/Modules/Talents/SavageRoarDmg.js
+++ b/src/Parser/Druid/Feral/Modules/Talents/SavageRoarDmg.js
@@ -10,8 +10,9 @@ import { formatNumber, formatPercentage } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 import getDamageBonus from '../FeralCore/getDamageBonus';
+import { SAVAGE_ROAR_DAMAGE_BONUS } from '../../Constants';
 
-const SAVAGE_ROAR_DAMAGE_BONUS = 0.15;
+
 
 class SavageRoar extends Analyzer {
   static dependencies = {


### PR DESCRIPTION
"The cooldown on Tiger's Fury resets when a target dies with one of your Bleed effects active, and Tiger's Fury last 4 additional seconds."

Set up SpellUsable for Feral which attempts to track when an enemy last died with a bleed active, and uses that timestamp to reset Tiger's Fury cooldown when it's used early with the Predator talent. Possible deaths are based on bleed debuffs fading early. There can be other causes of DoTs being removed early so it doesn't make any firm claims about how many enemies died with bleeds on them.

Made a Predator analyzer that assesses how many extra Tiger's Fury casts Predator has given the player, providing a statistic and suggestion. It tracks both overall cast count increase and how many casts were earlier than would have been possible without the talent. There are stronger single target talents available as alternatives to Predator so when few Tiger's Fury resets are detected the suggestion will recommend switching talents.

With Predator it's possible to have Tiger's Fury reset extremely often, so that keeping it on cooldown all the time would have little benefit. So when Predator is active the suggestion threshold for cast efficiency on Tiger's Fury is reduced.

![predator01](https://user-images.githubusercontent.com/35700764/41862353-851ac966-789b-11e8-9c1a-47dbc8201075.png)
![predator02](https://user-images.githubusercontent.com/35700764/41862354-8535ecbe-789b-11e8-804c-877c4b3c199e.png)
![predator03](https://user-images.githubusercontent.com/35700764/41862352-84f2ed10-789b-11e8-88a5-b829e2cb7df5.png)

The tracking of bleed durations needed some constants that were already being used in various Feral modules, so I moved them and some others out to a shared Constants file.

The talent isn't changed in BfA, and this will continue to work without any changes (although there's a couple of on_initialised that can be turned into constructors, and combatants dependencies will be able to be removed.)
