### PR TITLE
[BfA][Protection Warrior] Rage generation

### DIFF
--- a/src/Parser/Warrior/Protection/Modules/Core/RageTracker.js
+++ b/src/Parser/Warrior/Protection/Modules/Core/RageTracker.js
@@ -2,9 +2,12 @@ import RESOURCE_TYPES from 'common/RESOURCE_TYPES';
 import ResourceTracker from 'Parser/Core/Modules/ResourceTracker/ResourceTracker';
 import SPELLS from 'common/SPELLS';
 import SpellUsable from 'Parser/Core/Modules/SpellUsable';
+import HIT_TYPES from 'Parser/Core/HIT_TYPES';
 
 const VENGEANCE_RAGE_REDUCTION = 0.33; //percent
-const IGNORE_PAIN_MAX_COST = 60;
+const RAGE_GEN_FROM_MELEE_HIT_ICD = 1000; //ms
+const RAGE_PER_MELEE_HIT = 2;
+const RAGE_PER_MELEE_HIT_TAKEN = 3;
 
 class RageTracker extends ResourceTracker {
   static dependencies = {
@@ -12,6 +15,7 @@ class RageTracker extends ResourceTracker {
   };
 
   vengeanceRageSaved = 0;
+  lastMeleeTaken = 0;
 
   constructor(...args) {
     super(...args);
@@ -32,17 +36,31 @@ class RageTracker extends ResourceTracker {
       }
     } else if (abilityId === SPELLS.IGNORE_PAIN.id) {
       if (this.selectedCombatant.hasBuff(SPELLS.VENGEANCE_IGNORE_PAIN.id, event.timestamp)) {
-        const currentRage = this.getResource(event).amount / 10;
-        const newCost = currentRage >= IGNORE_PAIN_MAX_COST * (1 - VENGEANCE_RAGE_REDUCTION) ? IGNORE_PAIN_MAX_COST * (1 - VENGEANCE_RAGE_REDUCTION) : currentRage;
-        const normalCost = currentRage >= IGNORE_PAIN_MAX_COST ? IGNORE_PAIN_MAX_COST : currentRage;
-
-        this.vengeanceRageSaved += normalCost - newCost;
+        const newCost = cost * (1 - VENGEANCE_RAGE_REDUCTION);
+        this.vengeanceRageSaved += cost - newCost;
         cost = newCost;
-        //use either the max reduced max cost 39 Rage if enough rage was available or use all the available rage
-        //WCL return the wrong rage cost for a cast with Vengeance up (with 60+ rage available 46 instead of 39 (60 * 0.65))
       }
     }
     return cost;
+  }
+
+  on_byPlayer_damage(event) {
+    if (event.ability.guid !== SPELLS.MELEE.id) {
+      return;
+    }
+    
+    this.processInvisibleEnergize(SPELLS.RAGE_AUTO_ATTACKS.id, RAGE_PER_MELEE_HIT);
+  }
+
+  on_toPlayer_damage(event) {
+    if (event.ability.guid !== SPELLS.MELEE.id || event.hitType === HIT_TYPES.DODGE || event.hitType === HIT_TYPES.PARRY) {
+      return;
+    }
+
+    if (event.timestamp - this.lastMeleeTaken >= RAGE_GEN_FROM_MELEE_HIT_ICD) {
+      this.processInvisibleEnergize(SPELLS.RAGE_DAMAGE_TAKEN.id, RAGE_PER_MELEE_HIT_TAKEN);
+      this.lastMeleeTaken = event.timestamp;
+    }
   }
 
   get rageSavedByVengeance() {

--- a/src/common/SPELLS/WARRIOR.js
+++ b/src/common/SPELLS/WARRIOR.js
@@ -350,9 +350,14 @@ export default {
     name: 'Thunder Clap',
     icon: 'spell_nature_thunderclap',
   },
-  RAGE: {
+  RAGE_DAMAGE_TAKEN: {
     id: 195707,
-    name: 'Rage from damage taken',
+    name: 'Rage from melee hits taken',
+    icon: 'ability_racial_avatar',
+  },
+  RAGE_AUTO_ATTACKS: {
+    id: 198395, //could use a proper spellID for the tooltip
+    name: 'Rage from auto attacks',
     icon: 'ability_racial_avatar',
   },
   //Mitigation Spells


### PR DESCRIPTION
Warriors dont generate rage from damage taken anymore in BfA.
Instead they'll generate 2 rage per melee swing, and 3 rage for every melee hit taken (with an 1sec ICD).

Adjusts the IP cost to the static 40 rage from the old 20-60 range.

![image](https://user-images.githubusercontent.com/29842841/42023644-a90d83b4-7ac0-11e8-86d2-8d4ffe5d39f6.png)
