### PR TITLE
[BFA][Feral] Missing spells

### DIFF
--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -505,6 +505,8 @@ class StatTracker extends Analyzer {
         return 0.048;
       case SPECS.BALANCE_DRUID:
         return 0.18;
+      case SPECS.FERAL_DRUID:
+        return 0.16;
       case SPECS.RETRIBUTION_PALADIN:
         return 0.14;
       case SPECS.PROTECTION_PALADIN:

--- a/src/Parser/Druid/Feral/Modules/Abilities.js
+++ b/src/Parser/Druid/Feral/Modules/Abilities.js
@@ -9,7 +9,6 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.SHRED,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        // fixed 1.0
         gcd: {
           static: 1000,
         },
@@ -26,7 +25,6 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.RIP,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        // fixed 1.0
         gcd: {
           static: 1000,
         },
@@ -35,7 +33,6 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.FEROCIOUS_BITE,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        // fixed 1.0
         gcd: {
           static: 1000,
         },
@@ -46,7 +43,6 @@ class Abilities extends CoreAbilities {
         buffSpellId: SPELLS.SAVAGE_ROAR_TALENT.id,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         enabled: combatant.hasTalent(SPELLS.SAVAGE_ROAR_TALENT.id),
-        // fixed 1.0
         gcd: {
           static: 1000,
         },
@@ -56,7 +52,6 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.MOONFIRE_FERAL,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         enabled: combatant.hasTalent(SPELLS.LUNAR_INSPIRATION_TALENT.id),
-        // 1.0 reduced by haste
         gcd: {
           base: 1000,
         },
@@ -66,7 +61,6 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.THRASH_FERAL,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
-        // 1.0 fixed
         gcd: {
           static: 1000,
         },
@@ -76,7 +70,6 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.CAT_SWIPE,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
         enabled: !combatant.hasTalent(SPELLS.BRUTAL_SLASH_TALENT.id),
-        // 1.0 fixed
         gcd: {
           static: 1000,
         },
@@ -91,7 +84,6 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: true,
         },
-        // 1.0 fixed
         gcd: {
           static: 1000,
         },
@@ -108,7 +100,7 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: 0.90,
         },
-        // 1.0 reduced by haste (possibly a bug, likely should be 1.0 fixed)
+        // likely a Blizzard bug, probably intended to match Berserk's 1000 fixed
         gcd: {
           base: 1000,
         },
@@ -124,7 +116,6 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: 0.90,
         },
-        // 1.0 fixed
         gcd: {
           static: 1000,
         },
@@ -149,7 +140,6 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: true,
         },
-        // 1.0 fixed
         gcd: {
           static: 1000,
         },
@@ -158,7 +148,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.REGROWTH,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        // 1.0 reduced by haste
+        // 1.0 hasted in cat form, 1.5 hasted in caster (which is rarer for Feral)
         gcd: {
           base: 1000,
         },
@@ -167,7 +157,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.ENTANGLING_ROOTS,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        // 1.0 reduced by haste
+        // 1.0 hasted in cat form, 1.5 hasted in caster (which is rarer for Feral)
         gcd: {
           base: 1000,
         },
@@ -177,7 +167,6 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.MAIM,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 20,
-        // 1.0 fixed
         gcd: {
           static: 1000,
         },
@@ -189,7 +178,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: !combatant.hasTalent(SPELLS.TIGERS_DASH_TALENT.id),
         cooldown: 120,
-        // triggers a 1.5 fixed GCD if used when not in cat form (which is rare for a Feral druid)
+        // 1.5 fixed GCD if used when not in cat form (which is rare for a Feral druid)
         gcd: null,
         isDefensive: true,
         timelineSortIndex: 43,
@@ -200,18 +189,20 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.TIGERS_DASH_TALENT.id),
         cooldown: 45,
-        // triggers a 1.5 fixed GCD if used when not in cat form (which is rare for a Feral druid)
+        // 1.5 fixed GCD if used when not in cat form (which is rare for a Feral druid)
         gcd: null,
         isDefensive: true,
         timelineSortIndex: 43,
       },
       {
         spell: [SPELLS.STAMPEDING_ROAR_HUMANOID, SPELLS.STAMPEDING_ROAR_CAT, SPELLS.STAMPEDING_ROAR_BEAR],
-        // buffSpellId matches the version that was cast, but vast majority for Feral will be the cat version
+        // buffSpellId should match the version that was cast
         buffSpellId: SPELLS.STAMPEDING_ROAR_CAT.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 120,
-        // 1.0 reduced by haste
+        // 1.0 reduced by haste if cast in cat form (most common for a Feral druid)
+        // 1.5 reduced by haste if cast in bear form
+        // 1.5 fixed if cast in any other form, including caster
         gcd: {
           base: 1000,
         },
@@ -222,13 +213,14 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.SKULL_BASH_FERAL,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         gcd: null,
+        cooldown: 15,
         timelineSortIndex: 33,
       },
       {
         spell: SPELLS.PROWL,
         buffSpellId: SPELLS.PROWL.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        cooldown: 6,
+        // 6 second cooldown, but triggered by leaving stealth not by using Prowl.
         gcd: null,
         timelineSortIndex: 25,
       },
@@ -264,6 +256,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        // 10 minute cooldown usually, but shares the group-wide charge system during raid bosses and M+
         timelineSortIndex: 60,
       },
       {
@@ -271,7 +264,6 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.MIGHTY_BASH_TALENT.id),
         cooldown: 50,
-        // 1.5 reduced by haste
         gcd: {
           base: 1500,
         },
@@ -282,7 +274,6 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.MASS_ENTANGLEMENT_TALENT.id),
         cooldown: 30,
-        // 1.5 reduced by haste
         gcd: {
           base: 1500,
         },
@@ -293,7 +284,6 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.TYPHOON_TALENT.id),
         cooldown: 30,
-        // 1.5 reduced by haste
         gcd: {
           base: 1500,
         },
@@ -302,7 +292,6 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.HIBERNATE,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        // 1.5 reduced by haste
         gcd: {
           base: 1500,
         },
@@ -312,7 +301,6 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.SOOTHE,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 10,
-        // 1.5 reduced by haste
         gcd: {
           base: 1500,
         },
@@ -332,7 +320,6 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 15,
         enabled: combatant.hasTalent(SPELLS.WILD_CHARGE_TALENT.id),
-        // 0.5 fixed
         gcd: {
           static: 500,
         },
@@ -342,7 +329,6 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.BEAR_FORM,
         buffSpellId: SPELLS.BEAR_FORM.id,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
-        // 1.5 reduced by haste
         gcd: {
           base: 1500,
         },
@@ -353,7 +339,6 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.CAT_FORM,
         buffSpellId: SPELLS.CAT_FORM.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        // 1.5 reduced by haste
         gcd: {
           base: 1500,
         },
@@ -363,9 +348,9 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.MOONKIN_FORM_AFFINITY,
         buffSpellId: SPELLS.MOONKIN_FORM_AFFINITY.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        cooldown: 90, // only has a cooldown for feral spec - not guardian or resto
+        // only has a cooldown for feral spec
+        cooldown: 90,
         enabled: combatant.hasTalent(SPELLS.BALANCE_AFFINITY_TALENT_SHARED.id),
-        // 1.5 reduced by haste
         gcd: {
           base: 1500,
         },
@@ -375,7 +360,6 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.TRAVEL_FORM,
         buffSpellId: SPELLS.TRAVEL_FORM.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        // 1.5 reduced by haste
         gcd: {
           base: 1500,
         },
@@ -385,11 +369,172 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.STAG_FORM,
         buffSpellId: SPELLS.STAG_FORM.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        // 1.5 reduced by haste
         gcd: {
           base: 1500,
         },
         timelineSortIndex: 53,
+      },
+      {
+        spell: SPELLS.GROWL,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        gcd: null,
+        cooldown: 8,
+      },
+      {
+        spell: SPELLS.MANGLE_BEAR,
+        category: Abilities.SPELL_CATEGORIES.OTHERS,
+        gcd: {
+          base: 1500,
+        },
+        cooldown: haste => 6 / (1 + haste),
+      },
+      {
+        spell: SPELLS.THRASH_BEAR,
+        category: Abilities.SPELL_CATEGORIES.OTHERS,
+        gcd: {
+          base: 1500,
+        },
+        cooldown: haste => 6 / (1 + haste),
+      },
+      {
+        // Moonfire from caster, bear, and moonkin forms. See MOONFIRE_FERAL for cat
+        spell: SPELLS.MOONFIRE,
+        category: Abilities.SPELL_CATEGORIES.OTHERS,
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
+        spell: SPELLS.REMOVE_CORRUPTION,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        gcd: {
+          base: 1500,
+        },
+        // 8 second cooldown if it removed something, no cooldown otherwise
+      },
+      {
+        // cannot be cast when player is in combat
+        spell: SPELLS.REVIVE,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
+        spell: SPELLS.LUNAR_STRIKE_AFFINITY,
+        category: Abilities.SPELL_CATEGORIES.OTHERS,
+        enabled: combatant.hasTalent(SPELLS.BALANCE_AFFINITY_TALENT_SHARED.id),
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
+        spell: SPELLS.SOLAR_WRATH_AFFINITY,
+        category: Abilities.SPELL_CATEGORIES.OTHERS,
+        enabled: combatant.hasTalent(SPELLS.BALANCE_AFFINITY_TALENT_SHARED.id),
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
+        spell: SPELLS.STARSURGE,
+        category: Abilities.SPELL_CATEGORIES.OTHERS,
+        enabled: combatant.hasTalent(SPELLS.BALANCE_AFFINITY_TALENT_SHARED.id),
+        gcd: {
+          base: 1500,
+        },
+        cooldown: 10,
+      },
+      {
+        spell: SPELLS.SUNFIRE_AFFINITY,
+        category: Abilities.SPELL_CATEGORIES.OTHERS,
+        enabled: combatant.hasTalent(SPELLS.BALANCE_AFFINITY_TALENT_SHARED.id),
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
+        spell: SPELLS.FLAP,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        // only usable in Moonkin form so need Balance affinity, also need to learn from a tome
+        enabled: combatant.hasTalent(SPELLS.BALANCE_AFFINITY_TALENT_SHARED.id),
+        gcd: {
+          static: 500,
+        },
+      },
+      {
+        spell: SPELLS.IRONFUR,
+        category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
+        enabled: combatant.hasTalent(SPELLS.GUARDIAN_AFFINITY_TALENT_FERAL.id),
+        gcd: null,
+        cooldown: 0.5,
+      },
+      {
+        spell: SPELLS.FRENZIED_REGENERATION,
+        category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
+        enabled: combatant.hasTalent(SPELLS.GUARDIAN_AFFINITY_TALENT_FERAL.id),
+        gcd: {
+          base: 1500,
+        },
+        // unlike Guardian's version doesn't have charges
+        cooldown: haste => 36 / (1 + haste),
+      },
+      {
+        spell: SPELLS.REJUVENATION,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        enabled: combatant.hasTalent(SPELLS.RESTORATION_AFFINITY_TALENT.id),
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
+        spell: SPELLS.SWIFTMEND,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        enabled: combatant.hasTalent(SPELLS.RESTORATION_AFFINITY_TALENT.id),
+        gcd: {
+          base: 1500,
+        },
+        cooldown: 25,
+      },
+      {
+        spell: SPELLS.WILD_GROWTH,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        enabled: combatant.hasTalent(SPELLS.RESTORATION_AFFINITY_TALENT.id),
+        gcd: {
+          base: 1500,
+        },
+        cooldown: 20,
+      },
+      {
+        // learnt from a tome
+        spell: SPELLS.TREANT_FORM,
+        category: Abilities.SPELL_CATEGORIES.OTHERS,
+        gcd: {
+          fixed: 1500,
+        },
+      },
+      {
+        // learnt from a tome
+        spell: SPELLS.CHARM_WOODLAND_CREATURE,
+        category: Abilities.SPELL_CATEGORIES.OTHERS,
+        gcd: null,
+      },
+      {
+        // replaced by Dreamwalk early on in the Legion class hall quest line
+        spell: SPELLS.TELEPORT_MOONGLADE,
+        category: Abilities.SPELL_CATEGORIES.OTHERS,
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
+        // reward from early in the Legion class hall quest line
+        spell: SPELLS.TELEPORT_DREAMWALK,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        gcd: {
+          base: 1500,
+        },
+        cooldown: 60,
       },
     ];
   }

--- a/src/Parser/Druid/Feral/Modules/Abilities.js
+++ b/src/Parser/Druid/Feral/Modules/Abilities.js
@@ -148,18 +148,16 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.REGROWTH,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        // 1.0 hasted in cat form, 1.5 hasted in caster (which is rarer for Feral)
         gcd: {
-          base: 1000,
+          base: (combatant => (combatant.hasBuff(SPELLS.CAT_FORM.id) ? 1000 : 1500)),
         },
         timelineSortIndex: 30,
       },
       {
         spell: SPELLS.ENTANGLING_ROOTS,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        // 1.0 hasted in cat form, 1.5 hasted in caster (which is rarer for Feral)
         gcd: {
-          base: 1000,
+          base: (combatant => (combatant.hasBuff(SPELLS.CAT_FORM.id) ? 1000 : 1500)),
         },
         timelineSortIndex: 31,
       },
@@ -203,9 +201,21 @@ class Abilities extends CoreAbilities {
         // 1.0 reduced by haste if cast in cat form (most common for a Feral druid)
         // 1.5 reduced by haste if cast in bear form
         // 1.5 fixed if cast in any other form, including caster
-        gcd: {
+        gcd: (combatant => {
+          if (combatant.hasBuff(SPELLS.CAT_FORM.id)) {
+            return {
           base: 1000,
-        },
+            };
+          }
+          if (combatant.hasBuff(SPELLS.BEAR_FORM.id)) {
+            return {
+              base: 1500,
+            };
+          }
+          return {
+            static: 1500,
+          };
+        }),
         isDefensive: true,
         timelineSortIndex: 44,
       },

--- a/src/Parser/Druid/Feral/Modules/Abilities.js
+++ b/src/Parser/Druid/Feral/Modules/Abilities.js
@@ -176,8 +176,15 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: !combatant.hasTalent(SPELLS.TIGERS_DASH_TALENT.id),
         cooldown: 120,
-        // 1.5 fixed GCD if used when not in cat form (which is rare for a Feral druid)
-        gcd: null,
+        gcd: (combatant => {
+          if (combatant.hasBuff(SPELLS.CAT_FORM.id)) {
+            // off the GCD if player is already in cat form
+            return null;
+          }
+          return {
+            static: 1500,
+          };
+        }),
         isDefensive: true,
         timelineSortIndex: 43,
       },
@@ -187,8 +194,15 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.TIGERS_DASH_TALENT.id),
         cooldown: 45,
-        // 1.5 fixed GCD if used when not in cat form (which is rare for a Feral druid)
-        gcd: null,
+        gcd: (combatant => {
+          if (combatant.hasBuff(SPELLS.CAT_FORM.id)) {
+            // off the GCD if player is already in cat form
+            return null;
+          }
+          return {
+            static: 1500,
+          };
+        }),
         isDefensive: true,
         timelineSortIndex: 43,
       },
@@ -198,13 +212,10 @@ class Abilities extends CoreAbilities {
         buffSpellId: SPELLS.STAMPEDING_ROAR_CAT.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 120,
-        // 1.0 reduced by haste if cast in cat form (most common for a Feral druid)
-        // 1.5 reduced by haste if cast in bear form
-        // 1.5 fixed if cast in any other form, including caster
         gcd: (combatant => {
           if (combatant.hasBuff(SPELLS.CAT_FORM.id)) {
             return {
-          base: 1000,
+              base: 1000,
             };
           }
           if (combatant.hasBuff(SPELLS.BEAR_FORM.id)) {

--- a/src/common/SPELLS/DRUID.js
+++ b/src/common/SPELLS/DRUID.js
@@ -27,6 +27,104 @@ export default {
     name: 'Soothe',
     icon: 'ability_hunter_beastsoothe',
   },
+  REVIVE: {
+    id: 50769,
+    name: 'Revive',
+    icon: 'ability_druid_lunarguidance',
+  },
+  // learnt from a tome, treant form is (mostly?) functionally identical to caster form
+  TREANT_FORM: {
+    id: 114282,
+    name: 'Treant Form',
+    icon: 'ability_druid_treeoflife',
+  },
+  // learnt from a tome
+  CHARM_WOODLAND_CREATURE: {
+    id: 127757,
+    name: 'Charm Woodland Creature',
+    icon: 'inv_misc_rabbit',
+  },
+  TELEPORT_MOONGLADE: {
+    id: 18960,
+    name: 'Teleport: Moonglade',
+    icon: 'spell_arcane_teleportmoonglade',
+  },
+  TELEPORT_DREAMWALK: {
+    id: 193753,
+    name: 'Dreamwalk',
+    icon: 'spell_arcane_teleportstormwind',
+  },
+  // passive for all Feral druids and any druid with Feral Affinity
+  FELINE_SWIFTNESS: {
+    id: 131768,
+    name: 'Feline Swiftness',
+    icon: 'spell_druid_tirelesspursuit',
+  },
+  // learnt from a tome, requires moonkin form to use
+  FLAP: {
+    id: 164862,
+    name: 'Flap',
+    icon: 'inv_feather_12',
+  },
+
+  //shared talent spells
+
+  // When used the player appears to cast 2 spells at once, this and TYPHOON_TALENT. The "Dazed" debuff that slows those hit has this ID.
+  TYPHOON: {
+    id: 61391,
+    name: 'Typhoon',
+    icon: 'ability_druid_typhoon',
+  },
+  WILD_CHARGE_MOONKIN: {
+    id: 102383,
+    name: 'Wild Charge',
+    icon: 'ability_druid_owlkinfrenzy',
+  },
+  WILD_CHARGE_CAT: {
+    id: 49376,
+    name: 'Wild Charge',
+    icon: 'spell_druid_feralchargecat',
+  },
+  WILD_CHARGE_BEAR: {
+    id: 16979,
+    name: 'Wild Charge',
+    icon: 'ability_hunter_pet_bear',
+  },
+  WILD_CHARGE_TRAVEL: {
+    id: 102417,
+    name: 'Wild Charge',
+    icon: 'trade_archaeology_antleredcloakclasp',
+  },
+  // granted by Balance Affinity to non-Balance druids
+  LUNAR_STRIKE_AFFINITY: {
+    id: 197628,
+    name: 'Lunar Strike',
+    icon: 'spell_arcane_starfire',
+  },
+  // granted by Balance Affinity to Guardian and Feral druids
+  SOLAR_WRATH_AFFINITY: {
+    id: 197629,
+    name: 'Solar Wrath',
+    icon: 'spell_nature_wrathv2',
+  },
+  // granted by Balance Affinity to Guardian and Feral druids
+  SUNFIRE_AFFINITY: {
+    id: 197630,
+    name: 'Sunfire',
+    icon: 'ability_mage_firestarter',
+  },
+  // passive for all Guardian druids and any druid with Guardian Affinity
+  THICK_HIDE: {
+    id: 16931,
+    name: 'Thick Hide',
+    icon: 'inv_misc_pelt_bear_03',
+  },
+  // passive for all Balance druids and any druid with Balance Affinity
+  ASTRAL_INFLUENCE: {
+    id: 197524,
+    name: 'Astral Influence',
+    icon: 'ability_skyreach_lens_flare',
+  },
 
   // RESTO DRUID //
 
@@ -428,7 +526,7 @@ export default {
     name: 'Ironfur',
     icon: 'ability_druid_ironfur',
   },
-  // when casting stampeding outside of cat or bear form (puts caster into bear form)
+  // when casting stampeding outside of cat or bear form, and puts caster into bear form
   STAMPEDING_ROAR_HUMANOID: {
     id: 106898,
     name: 'Stampeding Roar',
@@ -449,6 +547,7 @@ export default {
     name: 'Incapacitating Roar',
     icon: 'ability_druid_demoralizingroar',
   },
+  // "MOONFIRE_BEAR" is actually the debuff left by Moonfire for all forms, all specs
   MOONFIRE_BEAR: {
     id: 164812,
     name: 'Moonfire',
@@ -494,6 +593,7 @@ export default {
     name: 'Gore',
     icon: 'ability_druid_mangle2',
   },
+  // passive spell with this ID granted to any druid with Restoration Affinity
   YSERAS_GIFT_BEAR: {
     id: 145108,
     name: 'Ysera\'s gift',
@@ -752,7 +852,8 @@ export default {
     name: 'Solar Solstice',
     icon: 'spell_druid_sunfall',
   },
-  // Feral
+
+  // FERAL //
   TIGERS_FURY: {
     id: 5217,
     name: 'Tiger\'s Fury',
@@ -771,10 +872,20 @@ export default {
   MAIM: {
     id: 22570,
     name: 'Maim',
-    icon: 'ability_druid_mangle',
+    icon: 'ability_druid_mangle-tga',
+  },
+  MAIM_DEBUFF: {
+    id: 203123,
+    name: 'Maim',
+    icon: 'ability_druid_mangle-tga',
   },
   RAKE_BLEED: {
     id: 155722,
+    name: 'Rake',
+    icon: 'ability_druid_disembowel',
+  },
+  RAKE_STUN: {
+    id: 163505,
     name: 'Rake',
     icon: 'ability_druid_disembowel',
   },
@@ -810,31 +921,81 @@ export default {
     name: 'Bloodtalons',
     icon: 'spell_druid_bloodythrash',
   },
+  FERAL_FRENZY_DEBUFF: {
+    id: 274838,
+    name: 'Feral Frenzy',
+    icon: 'ability_druid_rake',
+  },
+  CLEARCASTING_FERAL: {
+    id: 135700,
+    name: 'Clearcasting',
+    icon: 'spell_shadow_manaburn',
+  },
+  INFECTED_WOUNDS_DEBUFF: {
+    id: 58180,
+    name: 'Infected Wounds',
+    icon: 'ability_druid_infectedwound',
+  },
+  MASTERY_RAZOR_CLAWS: {
+    id: 77493,
+    name: 'Mastery: Razor Claws',
+    icon: 'inv_misc_monsterclaw_05',
+  },
+  PREDATORY_SWIFTNESS: {
+    id: 69369,
+    name: 'Predatory Swiftness',
+    icon: 'ability_hunter_pet_cat',
+  },
+  JUNGLE_STALKER: {
+    id: 252071,
+    name: 'Jungle Stalker',
+    icon: 'ability_mount_siberiantigermount',
+  },
 
-  //shared talent spells
-  TYPHOON: {
-    id: 61391,
-    name: 'Typhoon',
-    icon: 'ability_druid_typhoon',
+  // feral legion tier sets
+  FERAL_DRUID_T19_2SET_BONUS_BUFF: {
+    id: 211140,
+    name: 'T19 2 set bonus',
+    icon: 'trade_engineering',
   },
-  WILD_CHARGE_MOONKIN: {
-    id: 102383,
-    name: 'Wild Charge',
-    icon: 'ability_druid_owlkinfrenzy',
+  FERAL_DRUID_T19_4SET_BONUS_BUFF: {
+    id: 211142,
+    name: 'T19 4 set bonus',
+    icon: 'trade_engineering',
   },
-  WILD_CHARGE_CAT: {
-    id: 49376,
-    name: 'Wild Charge',
-    icon: 'spell_druid_feralchargecat',
+  FERAL_DRUID_T20_2SET_BONUS_BUFF: {
+    id: 242234,
+    name: 'T20 2 set bonus',
+    icon: 'ability_druid_catform',
   },
-  WILD_CHARGE_BEAR: {
-    id: 16979,
-    name: 'Wild Charge',
-    icon: 'ability_hunter_pet_bear',
+  ENERGETIC_RIP: {
+    id: 245591,
+    name: 'Energetic Rip',
+    icon: 'ability_deathwing_bloodcorruption_earth',
   },
-  WILD_CHARGE_TRAVEL: {
-    id: 102417,
-    name: 'Wild Charge',
-    icon: 'trade_archaeology_antleredcloakclasp',
+  FERAL_DRUID_T20_4SET_BONUS_BUFF: {
+    id: 242235,
+    name: 'T20 4 set bonus',
+    icon: 'ability_druid_catform',
+  },
+  FERAL_DRUID_T21_2SET_BONUS_BUFF: {
+    id: 251789,
+    name: 'T21 2 set bonus',
+    icon: 'ability_druid_cower',
+  },  
+  BLOODY_GASH: {
+    id: 252750,
+    name: 'Bloody Gash',
+    icon: 'artifactability_feraldruid_ashamanesbite',
+  },
+  FERAL_DRUID_T21_4SET_BONUS_BUFF: {
+    id: 251790,
+    name: 'T21 4 set bonus',
+    icon: 'ability_druid_cower',
+  },
+  APEX_PREDATOR: {
+    id: 252752,
+    name: 'Apex Predator',
+    icon: 'ability_druid_primaltenacity',
   },
 };


### PR DESCRIPTION
Went through the in-game spell book systematically on a couple of Feral Druids, and believe I have everything now. I also re-checked GCDs for build 26936.

There's some spells in there which are unlikely to see use during a raid fight (e.g. teleporting to the Emerald Dreamway or befriending a passing rabbit) but I included them for the sake of completeness.

None of the Feral-specific legendaries trigger visible procs in 8.0.1 (Fiery Red Maimers do in 7.3.5, but are changed in the patch) so there's no SPELLS entries for them. But did add the hidden buffs and visible procs for all the Legion Feral tier sets.

The diff might show some "shared talent spells" in SPELLS being removed, but they're just moved up to the top to be next to the other shared spells. There was nothing related to the Feral artifact left, so this PR doesn't remove anything.
