### PR TITLE
[Prepatch] [Fire Mage] Final Fire Changes

### DIFF
--- a/src/Parser/Mage/Fire/CHANGELOG.js
+++ b/src/Parser/Mage/Fire/CHANGELOG.js
@@ -1,15 +1,18 @@
 import React from 'react';
 
 import { Sharrq, sref, Fyruna } from 'CONTRIBUTORS';
-import ItemLink from 'common/ItemLink';
-import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-6-28'),
+    changes: <React.Fragment>Updated for 8.0 BFA Prepatch.</React.Fragment>,
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2018-2-25'),
-    changes: <React.Fragment>Added Support for <ItemLink id={ITEMS.KORALONS_BURNING_TOUCH.id} />.</React.Fragment>,
+    changes: <React.Fragment>Added Support for Koralon's Burning Touch.</React.Fragment>,
     contributors: [Sharrq],
   },
   {
@@ -34,7 +37,7 @@ export default [
   },
   {
     date: new Date('2018-01-03'),
-    changes: <React.Fragment>Added support for <ItemLink id={ITEMS.MARQUEE_BINDINGS_OF_THE_SUN_KING.id} /></React.Fragment>,
+    changes: <React.Fragment>Added support for Marquee Bindings of the Sun King</React.Fragment>,
     contributors: [Sharrq],
   },
   {
@@ -69,7 +72,7 @@ export default [
   },
   {
     date: new Date('2017-11-23'),
-    changes: <React.Fragment>Added support for <ItemLink id={ITEMS.DARCKLIS_DRAGONFIRE_DIADEM.id} />, <ItemLink id={ITEMS.CONTAINED_INFERNAL_CORE.id} />, and <ItemLink id={ITEMS.PYROTEX_IGNITION_CLOTH.id} /></React.Fragment>,
+    changes: <React.Fragment>Added support for Darckli's Dragonfire Diadem, Contained Infernal Core, and Pyrotex Ignition Cloth</React.Fragment>,
     contributors: [Sharrq],
   },
   {

--- a/src/Parser/Mage/Fire/CONFIG.js
+++ b/src/Parser/Mage/Fire/CONFIG.js
@@ -9,7 +9,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list.
   contributors: [Sharrq],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '7.3.5',
+  patchCompatibility: '8.0.1',
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (

--- a/src/Parser/Mage/Fire/Modules/Features/CombustionCharges.js
+++ b/src/Parser/Mage/Fire/Modules/Features/CombustionCharges.js
@@ -82,13 +82,15 @@ class CombustionCharges extends Analyzer {
   }
 
   suggestions(when) {
-    when(this.hasPhoenixFlames && this.phoenixFlamesThresholds)
+    if (this.hasPhoenixFlames) {
+      when(this.phoenixFlamesThresholds)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<React.Fragment>You cast <SpellLink id={SPELLS.COMBUSTION.id} /> {this.lowPhoenixFlamesCharges} times with less than 2 charges of <SpellLink id={SPELLS.PHOENIX_FLAMES_TALENT.id} />. Make sure you are saving at least 2 charges while Combustion is on cooldown so you can get as many <SpellLink id={SPELLS.HOT_STREAK.id} /> procs as possible before Combustion ends.</React.Fragment>)
           .icon(SPELLS.COMBUSTION.icon)
           .actual(`${formatPercentage(this.phoenixFlamesChargeUtil)}% Utilization`)
           .recommended(`${formatPercentage(recommended)} is recommended`);
       });
+    }
     when(this.fireBlastThresholds)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<React.Fragment>You cast <SpellLink id={SPELLS.COMBUSTION.id} /> {this.lowFireBlastCharges} times with less than {this.selectedCombatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) ? 2 : 1} charges of <SpellLink id={SPELLS.FIRE_BLAST.id} />. Make sure you are saving at least {this.selectedCombatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) ? 2 : 1} charges while Combustion is on cooldown so you can get as many <SpellLink id={SPELLS.HOT_STREAK.id} /> procs as possible before Combustion ends.</React.Fragment>)

--- a/src/Parser/Mage/Fire/Modules/Features/Pyroclasm.js
+++ b/src/Parser/Mage/Fire/Modules/Features/Pyroclasm.js
@@ -9,7 +9,7 @@ import Combatants from 'Parser/Core/Modules/Combatants';
 import { formatMilliseconds, formatNumber, formatPercentage } from 'common/format';
 import getDamageBonus from 'Parser/Mage/Shared/Modules/GetDamageBonus';
 
-const BONUS_DAMAGE = 3;
+const BONUS_DAMAGE = 2.5;
 const CAST_BUFFER = 250;
 
 const debug = false;


### PR DESCRIPTION
- Updated Patch Compatibility to 8.0
- Removed Spell Links to legendary items in Changelog
- Added Changelog entry for updated spec
- Updated Pyroclasm to 250% damage buff instead of 300%, per most recent balacing update.