### PR TITLE
[BFA][Core] Allow an ability's GCD prop to be a function

### DIFF
--- a/src/Parser/Core/Modules/Ability.js
+++ b/src/Parser/Core/Modules/Ability.js
@@ -47,11 +47,14 @@ class Ability {
      * `null` is the spell is off the GCD, or an object if the spell is on the GCD.
      * If this spell overlaps in the Spell Timeline it likes is incorrectly marked as on the GCD and should be removed.
      */
-    gcd: PropTypes.shape({
-      static: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
-      base: PropTypes.number,
-      minimum: PropTypes.number,
-    }),
+    gcd: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.shape({
+        static: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
+        base: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
+        minimum: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
+      }),
+    ]),
     // TODO: Add properties `staticGCD` and `baseGcd` since the baseGcd can be different per spell (e.g. Brewmaster's Effuse has a 1.5sec base GCD and most other spells are 1sec)
     castEfficiency: PropTypes.shape({
       /**


### PR DESCRIPTION
We recently gained support for having an ability's GCD vary with more than just haste by defining its GCD's `static` or `base` prop as a function:
```
gcd: {
  static: combatant => 1000 * (1 - (combatant.hasBuff(SPELLS.ADRENALINE_RUSH.id) ? 0.2 : 0)),
},
```
But some abilities switch between static and haste-affected GCDs depending on the situation. This PR gives support for an ability's whole GCD definition to be a function:
```
gcd: (combatant => {
  if (combatant.hasBuff(SPELLS.CAT_FORM.id)) {
    return {
      base: 1000,
    };
  }
  if (combatant.hasBuff(SPELLS.BEAR_FORM.id)) {
    return {
      base: 1500,
    };
  }
  return {
    static: 1500,
  };
}),
```
It doesn't support a function that returns `null`or`false` (meaning the ability is unaffected by the GCD), as quite a lot of existing code is built on the assumption that a spell always either always triggers a GCD or never does.

While adding this functionality to `getCurrentGlobalCooldown` I also flattened out the nested if statements that had built up. It should still provide the same behaviour as before. I wasn't certain what best to do with the default values for `baseGCD` and `minimumGCD`, and ended up putting them as default parameter values for `calculateGlobalCooldown`. (Currently this is the only place in the code that calls `calculateGlobalCooldown`)

I also updated the `propTypes` in `Ability` so that it accepts a function instead of a number, as well as accepting functions for `base` or `minimum` within a GCD object.
