### PR TITLE
Fixes #1843.  ReactTooltip enabled for EventsTab.

### DIFF
--- a/src/Main/EventsTab.js
+++ b/src/Main/EventsTab.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer';
 import Table, { defaultRowRenderer as defaultTableRowRenderer, Column } from 'react-virtualized/dist/commonjs/Table';
 import Toggle from 'react-toggle';
+import ReactTooltip from 'react-tooltip';
 import 'react-toggle/style.css';
 
 import InformationIcon from 'Interface/Icons/Information';
@@ -107,6 +108,10 @@ class EventsTab extends React.Component {
       search: '',
     };
     this.handleRowClick = this.handleRowClick.bind(this);
+  }
+
+  componentDidMount() {
+    ReactTooltip.rebuild();
   }
 
   findEntity(id) {


### PR DESCRIPTION
Fixes this bug.  Was only happening specifically in this component.