### PR TITLE
[BFA][Feral] Tracking for Predatory Swiftness

### DIFF
--- a/src/Parser/Druid/Feral/CHANGELOG.js
+++ b/src/Parser/Druid/Feral/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-06-30'),
+    changes: <React.Fragment>Added tracking for <SpellLink id={SPELLS.PREDATORY_SWIFTNESS.id} />.</React.Fragment>,
+    contributors: [Anatta336],
+  },
+  {
     date: new Date('2018-06-11'),
     changes: <React.Fragment>Added statistics breaking down snapshot uptime by buff for <SpellLink id={SPELLS.RAKE.id} />, <SpellLink id={SPELLS.RIP.id} />, and <SpellLink id={SPELLS.MOONFIRE_FERAL.id} />.</React.Fragment>,
     contributors: [Anatta336],

--- a/src/Parser/Druid/Feral/CombatLogParser.js
+++ b/src/Parser/Druid/Feral/CombatLogParser.js
@@ -21,6 +21,8 @@ import MoonfireUptime from './Modules/Talents/MoonfireUptime';
 import SavageRoarDmg from './Modules/Talents/SavageRoarDmg';
 import MoonfireSnapshot from './Modules/Talents/MoonfireSnapshot';
 
+import PredatorySwiftness from './Modules/Spells/PredatorySwiftness';
+
 import SoulOfTheArchdruid from '../Shared/Modules/Items/SoulOfTheArchdruid';
 
 class CombatLogParser extends CoreCombatLogParser {
@@ -44,11 +46,14 @@ class CombatLogParser extends CoreCombatLogParser {
     ripSnapshot: RipSnapshot,
     moonfireSnapshot: MoonfireSnapshot,
 
+    // spells
+    predatorySwiftness: PredatorySwiftness,
+
     // talents
     savageRoarUptime: SavageRoarUptime,
     moonfireUptime: MoonfireUptime,
     savageRoarDmg: SavageRoarDmg,
-
+    
     // resources
     comboPointTracker: ComboPointTracker,
     comboPointDetails: ComboPointDetails,

--- a/src/Parser/Druid/Feral/Modules/Spells/PredatorySwiftness.js
+++ b/src/Parser/Druid/Feral/Modules/Spells/PredatorySwiftness.js
@@ -1,0 +1,171 @@
+import React from 'react';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import { formatPercentage } from 'common/format';
+import Analyzer from 'Parser/Core/Analyzer';
+
+const debug = false;
+
+const PREDATORY_SWIFTNESS_BUFF_DURATION = 12000;
+const EXPIRE_WINDOW = 100;
+const IGNORE_DOUBLE_GAIN_WINDOW = 100;
+const POTENTIAL_SPENDERS = [
+  SPELLS.REGROWTH,
+  SPELLS.ENTANGLING_ROOTS,
+];
+
+/**
+ * Using a finishing move has a 20% chance per combo point to give the buff "Predatory Swiftness"
+ * which makes the next Regrowth or Entangling Roots instant cast and usable in cat form. Normally
+ * this provides occasional extra utility. But with the Bloodtalons talent it becomes an important
+ * part of the damage rotation.
+ * 
+ * The Feral legendary Ailuro Pouncers breaks this Analyzer. The Pouncers allow Predatory Swiftness
+ * to have up to 3 stacks, but the combat log still only shows an event for gaining or losing the buff
+ * overall, not the change in stacks. We cannot reliably predict when the stacks will change because
+ * there can be randomness as to whether a stack is generated.
+ */
+class PredatorySwiftness extends Analyzer {
+  hasSwiftness = false;
+
+  generated = 0;
+  used = 0;
+  expired = 0;
+  remainAfterFight = 0;
+  overwritten = 0;
+
+  /**
+   * The combat log reports the player gaining Predatory Swiftness twice when they use a free
+   * Ferocious Bite from the T21 4pc set bonus. Avoid this by tracking time of last gain event.
+   */
+  timeLastGain = null;
+
+  constructor(...args) {
+    super(...args);
+    if (this.selectedCombatant.hasFeet(ITEMS.AILURO_POUNCERS.id)) {
+      // disable entirely as the legendary breaks our ability to track Predatory Swiftness
+      this.isActive = false;
+    }
+  }
+
+  on_finished() {
+    if (this.hasSwiftness) {
+      debug && console.log(`${this.owner.formatTimestamp(this.owner.fight.end_time, 3)} fight ended with a Predatory Swiftness buff unused.`);
+      this.remainAfterFight = 1;
+    }
+
+    if (debug && this.generated !== (this.used + this.expired + this.remainAfterFight + this.overwritten)) {
+      console.warn(`Not all Predatory Swiftness charges accounted for. Generated: ${this.generated}, used: ${this.used}, expired: ${this.expired}, remainAfterFight: ${this.remainAfterFight}, overwritten: ${this.overwritten}`);
+    }
+  }
+
+  on_toPlayer_applybuff(event) {
+    if (SPELLS.PREDATORY_SWIFTNESS.id !== event.ability.guid) {
+      return;
+    }
+    debug && console.log(`${this.owner.formatTimestamp(event.timestamp, 3)} gained Predatory Swiftness`);
+    this.hasSwiftness = true;
+    this.generated += 1;
+    this.timeLastGain = event.timestamp;
+    this.expireTime = event.timestamp + PREDATORY_SWIFTNESS_BUFF_DURATION;
+  }
+
+  on_toPlayer_refreshbuff(event) {
+    if (SPELLS.PREDATORY_SWIFTNESS.id !== event.ability.guid ||
+        Math.abs(event.timestamp - this.timeLastGain) < IGNORE_DOUBLE_GAIN_WINDOW) {
+      return;
+    }
+    debug && console.log(`${this.owner.formatTimestamp(event.timestamp, 3)} gained Predatory Swiftness, overwriting existing`);
+    this.hasSwiftness = true;
+    this.generated += 1;
+    this.overwritten += 1;
+    this.timeLastGain = event.timestamp;
+    // buff duration not affected by pandemic
+    this.expireTime = event.timestamp + PREDATORY_SWIFTNESS_BUFF_DURATION;
+  }
+
+  on_toPlayer_removebuff(event) {
+    if (SPELLS.PREDATORY_SWIFTNESS.id !== event.ability.guid ||
+        !this.hasSwiftness || !this.expireTime ||
+        Math.abs(this.expireTime - event.timestamp) > EXPIRE_WINDOW) {
+      return;
+    }
+    debug && console.log(`${this.owner.formatTimestamp(event.timestamp, 3)} Predatory Swiftness expired, unused`);
+    this.expired += 1;
+    this.hasSwiftness = false;
+    this.expireTime = null;
+  }
+
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    if (!this.isSpender(spellId) || !this.hasSwiftness) {
+      return;
+    }
+    debug && console.log(`${this.owner.formatTimestamp(event.timestamp, 3)} Predatory Swiftness used`);
+    this.used += 1;
+    this.hasSwiftness = false;
+    this.expireTime = null;
+  }
+
+  isSpender(spellId) {
+    return !!POTENTIAL_SPENDERS.find(spender => spender.id === spellId);
+  }
+
+  get wasted() {
+    return this.expired + this.overwritten + this.remainAfterFight;
+  }
+
+  get wastedFraction() {
+    return this.wasted / this.generated;
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.wastedFraction,
+      isGreaterThan: {
+        minor: 0,
+        average: 0.10,
+        major: 0.20,
+      },
+      style: 'percent',
+    };
+  }
+
+  suggestions(when) {
+    if (!this.selectedCombatant.hasTalent(SPELLS.BLOODTALONS_TALENT.id)) {
+      // Predatory Swiftness is only important to damage rotation if the player has Bloodtalons
+      return null;
+    }
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <React.Fragment>
+          You are not making use of all your chances to trigger <SpellLink id={SPELLS.BLOODTALONS_TALENT.id} /> through <SpellLink id={SPELLS.PREDATORY_SWIFTNESS.id} />. Try to use it to instant-cast <SpellLink id={SPELLS.REGROWTH.id} /> or <SpellLink id={SPELLS.ENTANGLING_ROOTS.id} /> before you generate another charge of the buff, and before it wears off.
+        </React.Fragment>
+      )
+        .icon(SPELLS.PREDATORY_SWIFTNESS.icon)
+        .actual(`${formatPercentage(actual)}% of Predatory Swiftness buffs wasted.`)
+        .recommended(`${recommended}% is recommended`);
+    });
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.PREDATORY_SWIFTNESS.id} />}
+        value={`${formatPercentage(1 - this.wastedFraction)}%`}
+        label="Predatory Swiftness buffs used"
+        tooltip={`You used <b>${this.used}</b> out of <b>${this.generated}</b> Predatory Swiftness buffs to instant-cast Regrowth or Entangling Roots${this.selectedCombatant.hasTalent(SPELLS.BLOODTALONS_TALENT.id) ? ' and trigger the Bloodtalons buff' : ''}.<br/>
+          <li>The buff was allowed to expire <b>${this.expired}</b> time${this.expired !== 1 ? 's' : ''}.
+          <li>You used another finisher while the buff was still active and overwrote it <b>${this.overwritten}</b> time${this.overwritten !== 1 ? 's' : ''}.
+          <li>You had <b>${this.remainAfterFight}</b> remaining unused at the end of the fight.`}
+      />
+    );
+  }
+
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(5);
+}
+
+export default PredatorySwiftness;


### PR DESCRIPTION
> Your finishing moves have a 20% chance per combo point to make your next Regrowth or Entangling Roots instant, free, and castable in all forms.

Normally this passive just provides some free heals or utility, but with the Bloodtalons talent it becomes part of the core rotation. This Analyzer tracks if the Predatory Swiftness buffs are being wasted.

It only provides a suggestion if the buff is being being wasted while the player has the Bloodtalons talent. The statistic is always shown as the information might be interesting to the player.

Unfortunately the Feral legendary [Ailuro Pouncers](http://bfa.wowhead.com/item=137024/ailuro-pouncers) breaks this Analyzer. The Pouncers allow Predatory Swiftness to have up to 3 stacks, but the combat log still only shows an event for gaining or losing the buff overall, not the change in stacks. We cannot reliably predict when the stacks will change because there is randomness when using a finisher below 5 combo points. The legendary also generates its own stacks. Those generated stacks are created predictably every 15 seconds, but determining when that cycle begins will be difficult (impossible in some situations) without the stack change information.

It should be possible to get a "somewhat accurate" estimate when using the Ailuro Pouncers legendary with careful work (so long as the player only uses finishers at 5 combo points.) But as the legendary is rarely used at the moment and will be lost entirely by level 120, this analyzer simply disables itself if it detects the Pouncers.

![predatoryswiftness01](https://user-images.githubusercontent.com/35700764/42042852-f8006a28-7aec-11e8-8943-8f49afc9bfed.png)
![predatoryswiftness03](https://user-images.githubusercontent.com/35700764/42043123-91cd6b56-7aed-11e8-93ad-35ae010d346f.png)

An example log from BfA beta with a Feral druid making (imperfect) use of Predatory Swiftness:
https://www.warcraftlogs.com/reports/RzWAa74xLMBdJV8K/#fight=13&source=18
