### PR TITLE
[Core][Bug] Fix for logs without advanced logging

### DIFF
--- a/src/Interface/Character/Parses.js
+++ b/src/Interface/Character/Parses.js
@@ -166,7 +166,7 @@ class Parses extends React.Component {
         character_name: elem.characterName,
         talents: elem.talents,
         gear: elem.gear,
-        advanced: Object.values(elem.talents).filter(talent => talent.id === 0).length === 0 ? true : false,
+        advanced: Object.values(elem.talents).filter(talent => talent.id === null).length === 0 ? true : false,
       };
     });
 

--- a/src/Interface/Character/ParsesList.js
+++ b/src/Interface/Character/ParsesList.js
@@ -64,7 +64,7 @@ class ParsesList extends React.PureComponent {
     const { parses } = this.props;
     return (
       parses.map(elem => {
-        const url = makePlainUrl(elem.report_code, elem.report_fight, elem.difficulty + ' ' + elem.name, elem.character_name);
+        const url = makePlainUrl(elem.report_code, elem.report_fight, elem.difficulty + ' ' + elem.name, elem.advanced ? elem.character_name : '');
         return (
           <Link
             key={url}


### PR DESCRIPTION
Now links logs without advanced logging to the combatantSelector of the log (which is already checking if the log was made with advanced logging or not)