### PR TITLE
Healthstones Suggestion Rework

### DIFF
--- a/src/Parser/Core/Modules/Items/Healthstone.js
+++ b/src/Parser/Core/Modules/Items/Healthstone.js
@@ -1,13 +1,22 @@
+import React from 'react';
 import SPELLS from 'common/SPELLS';
-
+import SpellLink from 'common/SpellLink';
 import Analyzer from 'Parser/Core/Analyzer';
 import Abilities from 'Parser/Core/Modules/Abilities';
+import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
 import SpellUsable from 'Parser/Core/Modules/SpellUsable';
+import ISSUE_IMPORTANCE from 'Parser/Core/ISSUE_IMPORTANCE';
 
 const HEALTHSTONE_SPELLS = [
   SPELLS.HEALTHSTONE,
   SPELLS.ANCIENT_HEALING_POTION,
   SPELLS.ASTRAL_HEALING_POTION,
+];
+
+const HEALTHSTONE_IDS = [
+  SPELLS.HEALTHSTONE.id,
+  SPELLS.ANCIENT_HEALING_POTION.id,
+  SPELLS.ASTRAL_HEALING_POTION.id,
 ];
 
 const ONE_HOUR_MS = 3600000; // one hour
@@ -22,21 +31,23 @@ class Healthstone extends Analyzer {
   static dependencies = {
     abilities: Abilities,
     spellUsable: SpellUsable,
+    abilityTracker: AbilityTracker,
   };
 
   maxCasts = 1;
+  casts = 0;
   lastDeathWithHealthstoneReady = null;
 
-  on_initialized() {
+  constructor(...args) {
+    super(...args);
     this.abilities.add({
       spell: HEALTHSTONE_SPELLS,
       category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
       cooldown: ONE_HOUR_MS / 1000, // The cooldown does not start while in combat so setting it to one hour.
       castEfficiency: {
-        suggestion: true,
+        suggestion: false,
         recommendedEfficiency: 0.6,
-          averageIssueEfficiency: 0.4,
-          majorIssueEfficiency: 0.1,
+        importance: ISSUE_IMPORTANCE.MINOR,
         maxCasts: (cooldown, fightDuration, getAbility, parser) => {
           return this.maxCasts;
         },
@@ -75,6 +86,30 @@ class Healthstone extends Analyzer {
     }
   }
 
+  get healthstoneCasts() {
+    HEALTHSTONE_IDS.forEach(spell => {
+      this.casts += this.abilityTracker.getAbility(spell).casts || 0;
+    });
+    return this.casts;
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.healthstoneCasts,
+      isLessThan: {
+        minor: this.maxCasts,
+      },
+      style: 'number',
+    };
+  }
+
+  suggestions(when) {
+		when(this.suggestionThresholds)
+			.addSuggestion((suggest, actual, recommended) => {
+				return suggest(<React.Fragment>You used a <SpellLink id={SPELLS.HEALTHSTONE.id} /> or Healing Potion {this.healthstoneCasts} times but could have used it {this.maxCasts > 1 ? this.maxCasts + ' time' : this.maxCasts + ' times'}. If you are low on health, make sure you use your Healthstones, Healing Potions, and Defensive Abilities to stay alive and to help the healers. </React.Fragment>)
+					.icon(SPELLS.HEALTHSTONE.icon);
+      });
+  }
 }
 
 export default Healthstone;

--- a/src/Parser/Core/Modules/Items/Healthstone.js
+++ b/src/Parser/Core/Modules/Items/Healthstone.js
@@ -106,7 +106,7 @@ class Healthstone extends Analyzer {
   suggestions(when) {
 		when(this.suggestionThresholds)
 			.addSuggestion((suggest, actual, recommended) => {
-				return suggest(<React.Fragment>You used a <SpellLink id={SPELLS.HEALTHSTONE.id} /> or Healing Potion {this.healthstoneCasts} times but could have used it {this.maxCasts > 1 ? this.maxCasts + ' time' : this.maxCasts + ' times'}. If you are low on health, make sure you use your Healthstones, Healing Potions, and Defensive Abilities to stay alive and to help the healers. </React.Fragment>)
+				return suggest(<React.Fragment>You used a <SpellLink id={SPELLS.HEALTHSTONE.id} /> or Healing Potion {this.healthstoneCasts > 1 || this.healthstoneCasts === 0 ? this.healthstoneCasts + ' times' : this.healthstoneCasts + ' time'} but could have used it {this.maxCasts > 1 ? this.maxCasts + ' times' : this.maxCasts + ' time'}. If you are low on health, make sure you use your Healthstones, Healing Potions, and Defensive Abilities to stay alive and to help the healers. </React.Fragment>)
 					.icon(SPELLS.HEALTHSTONE.icon);
       });
   }


### PR DESCRIPTION
I got a complaint from the mage discord that the wording on the healthstone suggestion was misleading. When I looked into it, it seems that this was some confusion caused by the default Cast Efficiency suggestion text which essentially stated you should keep Healthstone on cooldown for 60% of the fight or else you are doing it wrong. This made the player think that we were telling them that they should use the healthstone early in the fight so that it is on cooldown for more than 60% of the fight, which isnt what we were saying. 
![image](https://user-images.githubusercontent.com/1304554/42296743-dbd1041c-7fbe-11e8-8507-3918cabbc1d6.png)

So, I changed the importance to minor (to match the changes in BFA), turned off the default suggestion, and made a custom suggestion for it with different wording.
![image](https://user-images.githubusercontent.com/1304554/42296761-099857c4-7fbf-11e8-914d-04ebc9b50a4f.png)

Im assuming this is going to cause a conflict with the BFA Branch. Not sure if i should put up a second PR for the BFA Branch so they match? Or if it will be handled another way.


