### PR TITLE
[Prepatch] [Fire Mage] Fixes for Heating Up, Pyroclasm, Searing Touch

### DIFF
--- a/src/Parser/Mage/Fire/Modules/Features/HeatingUp.js
+++ b/src/Parser/Mage/Fire/Modules/Features/HeatingUp.js
@@ -36,6 +36,7 @@ class HeatingUp extends Analyzer {
     super(...args);
     this.hasFirestarterTalent = this.selectedCombatant.hasTalent(SPELLS.FIRESTARTER_TALENT.id);
     this.hasLegendaryBelt = this.selectedCombatant.hasWaist(ITEMS.KORALONS_BURNING_TOUCH.id);
+    this.hasPhoenixFlames = this.selectedCombatant.hasTalent(SPELLS.PHOENIX_FLAMES_TALENT.id);
   }
 
   on_byPlayer_cast(event) {
@@ -154,43 +155,57 @@ class HeatingUp extends Analyzer {
 	}
 
   statistic() {
-    return (
-      <StatisticBox
-        icon={<SpellIcon id={SPELLS.HEATING_UP.id} />}
-        value={(
-          <span>
-            <SpellIcon
-              id={SPELLS.FIRE_BLAST.id}
-              style={{
-                height: '1.2em',
-                marginBottom: '.15em',
-              }}
-            />
-            {' '}{formatPercentage(this.fireBlastUtil, 0)}{' %'}
-            <br />
-            <SpellIcon
-              id={SPELLS.PHOENIX_FLAMES_TALENT.id}
-              style={{
-                height: '1.2em',
-                marginBottom: '.15em',
-              }}
-            />
-            {' '}{formatPercentage(this.phoenixFlamesUtil, 0)}{' %'}
-          </span>
-        )}
-        label="Heating Up Utilization"
-        tooltip={`Spells that are guaranteed to crit like Fire Blast and Phoenix Flames should only be used to convert Heating Up to Hot Streak. While there are minor exceptions to this (like if you are about to cap on Phoenix Flames charges or using Fireball & Phoenixs Flames to bait Heating Up/Hot Streak just before Combustion), the goal should be to waste as few of these as possible.
+    if (this.hasPhoenixFlames) {
+      return (
+        <StatisticBox
+          icon={<SpellIcon id={SPELLS.HEATING_UP.id} />}
+          value={(
+            <span>
+              <SpellIcon
+                id={SPELLS.FIRE_BLAST.id}
+                style={{
+                  height: '1.2em',
+                  marginBottom: '.15em',
+                }}
+              />
+              {' '}{formatPercentage(this.fireBlastUtil, 0)}{' %'}
+              <br />
+              <SpellIcon
+                id={SPELLS.PHOENIX_FLAMES_TALENT.id}
+                style={{
+                  height: '1.2em',
+                  marginBottom: '.15em',
+                }}
+              />
+              {' '}{formatPercentage(this.phoenixFlamesUtil, 0)}{' %'}
+            </span>
+          )}
+          label="Heating Up Utilization"
+          tooltip={`Spells that are guaranteed to crit like Fire Blast and Phoenix Flames should only be used to convert Heating Up to Hot Streak. While there are minor exceptions to this (like if you are about to cap on Phoenix Flames charges or using Fireball & Phoenixs Flames to bait Heating Up/Hot Streak just before Combustion), the goal should be to waste as few of these as possible.
+            <ul>
+              <li>Fireblast Used with no procs: ${this.fireBlastWithoutHeatingUp}</li>
+              <li>Fireblast used during Hot Streak: ${this.fireBlastWithHotStreak}</li>
+              <li>Phoenix Flames used with no procs: ${this.phoenixFlamesWithoutHeatingUp}</li>
+              <li>Phoenix Flames used during Hot Streak: ${this.phoenixFlamesWithHotStreak}</li>
+            </ul>`}
+        />
+      );
+    } else {
+      return (
+        <StatisticBox
+          icon={<SpellIcon id={SPELLS.HEATING_UP.id} />}
+          value={`${formatPercentage(this.fireBlastUtil, 0)} %`}
+          label="Heating Up Utilization"
+          tooltip={`Spells that are guaranteed to crit like Fire Blast should only be used to convert Heating Up to Hot Streak.
           <ul>
             <li>Fireblast Used with no procs: ${this.fireBlastWithoutHeatingUp}</li>
             <li>Fireblast used during Hot Streak: ${this.fireBlastWithHotStreak}</li>
-            <li>Phoenix Flames used with no procs: ${this.phoenixFlamesWithoutHeatingUp}</li>
-            <li>Phoenix Flames used during Hot Streak: ${this.phoenixFlamesWithHotStreak}</li>
           </ul>`}
-      />
-    );
+        />
+      );
+    }
   }
   statisticOrder = STATISTIC_ORDER.CORE(14);
-
 }
 
 export default HeatingUp;

--- a/src/Parser/Mage/Fire/Modules/Features/Pyroclasm.js
+++ b/src/Parser/Mage/Fire/Modules/Features/Pyroclasm.js
@@ -5,7 +5,6 @@ import SpellLink from 'common/SpellLink';
 import SpellIcon from 'common/SpellIcon';
 import Analyzer from 'Parser/Core/Analyzer';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
-import Combatants from 'Parser/Core/Modules/Combatants';
 import { formatMilliseconds, formatNumber, formatPercentage } from 'common/format';
 import getDamageBonus from 'Parser/Mage/Shared/Modules/GetDamageBonus';
 
@@ -15,10 +14,6 @@ const CAST_BUFFER = 250;
 const debug = false;
 
 class Pyroclasm extends Analyzer {
-
-  static dependencies = {
-		combatants: Combatants,
-	};
 
   damage = 0;
   beginCastTimestamp = 0;
@@ -31,8 +26,9 @@ class Pyroclasm extends Analyzer {
   usedProcs = 0;
   totalProcs = 0;
 
-  on_initialized() {
-    this.active = this.combatants.selected.hasTalent(SPELLS.PYROCLASM_TALENT.id);
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.PYROCLASM_TALENT.id);
   }
 
   on_byPlayer_applybuff(event) {
@@ -117,7 +113,7 @@ class Pyroclasm extends Analyzer {
     this.castTimestamp = event.timestamp;
     const castTime = this.castTimestamp - this.beginCastTimestamp;
     //Checks the begincast and cast timestamps to determine if it is instant cast or not. This doesnt matter for ABT and ToS because hot streak pyroblasts dont have a begincast, but in Nighthold they do. So this needs to remain for backwards compatibility
-    if (castTime >= CAST_BUFFER && this.combatants.selected.hasBuff(SPELLS.PYROCLASM_BUFF.id)) {
+    if (castTime >= CAST_BUFFER && this.selectedCombatant.hasBuff(SPELLS.PYROCLASM_BUFF.id)) {
       this.isBuffed = true;
       this.buffUsed = true;
       debug && console.log("Buff Used @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
@@ -139,7 +135,7 @@ class Pyroclasm extends Analyzer {
   }
 
   on_finished() {
-    if (this.combatants.selected.hasBuff(SPELLS.PYROCLASM_BUFF.id)) {
+    if (this.selectedCombatant.hasBuff(SPELLS.PYROCLASM_BUFF.id)) {
       const adjustedFightEnding = this.owner.currentTimestamp - 7500;
       if (this.buffAppliedTimestamp < adjustedFightEnding) {
         this.wastedProcs += 1;

--- a/src/Parser/Mage/Fire/Modules/Features/SearingTouch.js
+++ b/src/Parser/Mage/Fire/Modules/Features/SearingTouch.js
@@ -3,22 +3,21 @@ import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage, formatMilliseconds } from 'common/format';
 import Analyzer from 'Parser/Core/Analyzer';
-import Combatants from 'Parser/Core/Modules/Combatants';
 import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
 
 const debug = false;
 
 class SearingTouch extends Analyzer {
   static dependencies = {
-    combatants: Combatants,
     abilityTracker: AbilityTracker,
   };
 
   badCasts = 0;
   totalCasts = 0;
 
-  on_initialized() {
-    this.active = this.combatants.selected.hasTalent(SPELLS.SEARING_TOUCH_TALENT.id);
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.SEARING_TOUCH_TALENT.id);
   }
 
   on_byPlayer_damage(event) {


### PR DESCRIPTION
- Fixed the Statistic Box for Heating Up so it displays the double stat box if they have Phoenix Flames, and a single box if they dont.
- Updated Pyroclasm and Searing Touch to use the new constructor instead of on_initialized() and selectedCombatant instead of combatants.selected