### PR TITLE
[BfA][Windwalker] Updating cooldown handling with Serenity

### DIFF
--- a/src/Parser/Core/Modules/SpellUsable.js
+++ b/src/Parser/Core/Modules/SpellUsable.js
@@ -220,6 +220,25 @@ class SpellUsable extends Analyzer {
     }
   }
 
+  /**
+   * Extends the cooldown for the provided spell by the provided duration.
+   * @param {any} spellId The ID of the spell.
+   * @param {number} extensionMS The duration to extend the cooldown with, in milliseconds.
+   * @param {any} timestamp Override the timestamp if it may be different from the current timestamp.
+   * @returns {*}
+   */
+  extendCooldown(spellId, extensionMS, timestamp = this.owner.currentTimestamp) {
+    const canSpellId = this._getCanonicalId(spellId);
+    if (!this.isOnCooldown(canSpellId)) {
+      throw new Error(`Tried to extend the cooldown of ${canSpellId}, but it's not on cooldown.`);
+    }
+    const cooldownRemaining = this.cooldownRemaining(canSpellId, timestamp);
+    this._currentCooldowns[canSpellId].totalReductionTime -= extensionMS;
+    const fightDuration = formatMilliseconds(timestamp - this.owner.fight.start_time);
+    debug && console.log(fightDuration, 'SpellUsable', 'Extended', spellName(canSpellId), canSpellId, 'by', extensionMS, 'remaining:', this.cooldownRemaining(canSpellId, timestamp), 'old:', cooldownRemaining, 'new expected duration:', this._currentCooldowns[canSpellId].expectedDuration - this._currentCooldowns[canSpellId].totalReductionTime, 'total extension:', -this._currentCooldowns[canSpellId].totalReductionTime);
+    return extensionMS;
+  }
+
   _makeEvent(spellId, timestamp, trigger, others = {}) {
     const cooldown = this._currentCooldowns[spellId];
     const chargesOnCooldown = cooldown ? cooldown.chargesOnCooldown : 0;

--- a/src/Parser/Monk/Windwalker/CombatLogParser.js
+++ b/src/Parser/Monk/Windwalker/CombatLogParser.js
@@ -22,6 +22,7 @@ import BlackoutKick from './Modules/Spells/BlackoutKick';
 // Talents
 import HitCombo from './Modules/Talents/HitCombo';
 import EnergizingElixir from './Modules/Talents/EnergizingElixir';
+import Serenity from './Modules/Talents/Serenity';
 // Legendaries / Items
 import KatsuosEclipse from './Modules/Items/KatsuosEclipse';
 import CenedrilReflectorOfHatred from './Modules/Items/CenedrilReflectorOfHatred';
@@ -50,6 +51,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Talents:
     hitCombo: HitCombo,
     energizingElixir: EnergizingElixir,
+    serenity: Serenity,
 
     // Spells;
     comboBreaker: ComboBreaker,

--- a/src/Parser/Monk/Windwalker/Modules/Abilities.js
+++ b/src/Parser/Monk/Windwalker/Modules/Abilities.js
@@ -1,5 +1,4 @@
 import SPELLS from 'common/SPELLS';
-import ITEMS from 'common/ITEMS';
 
 import CoreAbilities from 'Parser/Core/Modules/Abilities';
 
@@ -7,13 +6,13 @@ class Abilities extends CoreAbilities {
   spellbook() {
     const combatant = this.selectedCombatant;
     // Windwalker GCD is 1 second by default and static in almost all cases, 750 is lowest recorded GCD
+    // Cooldown of chi spenders is doubled again when Serenity drops. This is handled in the Serenity module under Talents
     return [
       {
         spell: SPELLS.FISTS_OF_FURY_CAST,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        // This can get way too low calculated cooldown if the player has a very high amount of haste, but this is not expected for windwalkers
         cooldown: (haste, combatant) =>
-          24 / (1 + haste) - (combatant.hasBuff(SPELLS.SERENITY_TALENT.id) ? (combatant.hasWrists(ITEMS.DRINKING_HORN_COVER.id) ? 11 : 8) : 0),
+          24 / (1 + haste) * (combatant.hasBuff(SPELLS.SERENITY_TALENT.id) ? 0.5 : 1),
         gcd: {
           static: 1000,
         },

--- a/src/Parser/Monk/Windwalker/Modules/Spells/BlackoutKick.js
+++ b/src/Parser/Monk/Windwalker/Modules/Spells/BlackoutKick.js
@@ -55,14 +55,14 @@ class BlackoutKick extends Analyzer {
       event.meta.inefficientCastReason = 'You cast this Blackout Kick while more important spells were available';
     }
 
-    if (this.spellUsable.isAvailable(SPELLS.RISING_SUN_KICK.id)) {
+    if (!this.spellUsable.isOnCooldown(SPELLS.RISING_SUN_KICK.id)) {
       this.wastedRisingSunKickReductionMs += COOLDOWN_REDUCTION_MS;
     } else {
       const reductionMs = this.spellUsable.reduceCooldown(SPELLS.RISING_SUN_KICK.id, COOLDOWN_REDUCTION_MS);
       this.effectiveRisingSunKickReductionMs += reductionMs;
       this.wastedRisingSunKickReductionMs += COOLDOWN_REDUCTION_MS - reductionMs;
     }
-    if (this.spellUsable.isAvailable(SPELLS.FISTS_OF_FURY_CAST.id)) {
+    if (!this.spellUsable.isOnCooldown(SPELLS.FISTS_OF_FURY_CAST.id)) {
       this.wastedFistsOfFuryReductionMs += COOLDOWN_REDUCTION_MS;
     } else {
       const reductionMs = this.spellUsable.reduceCooldown(SPELLS.FISTS_OF_FURY_CAST.id, COOLDOWN_REDUCTION_MS);

--- a/src/Parser/Monk/Windwalker/Modules/Talents/Serenity.js
+++ b/src/Parser/Monk/Windwalker/Modules/Talents/Serenity.js
@@ -1,0 +1,46 @@
+import SPELLS from 'common/SPELLS';
+import SpellUsable from 'Parser/Core/Modules/SpellUsable';
+import Analyzer from 'Parser/Core/Analyzer';
+
+class Serenity extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+  };
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.SERENITY_TALENT.id);
+  }
+
+  on_byPlayer_applybuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.SERENITY_TALENT.id) {
+      return;
+    }
+    if (this.spellUsable.isOnCooldown(SPELLS.RISING_SUN_KICK.id)) {
+      const cooldownReduction = (this.spellUsable.cooldownRemaining(SPELLS.RISING_SUN_KICK.id)) * 0.5;
+      this.spellUsable.reduceCooldown(SPELLS.RISING_SUN_KICK.id, cooldownReduction);
+    }
+    if (this.spellUsable.isOnCooldown(SPELLS.FISTS_OF_FURY_CAST.id)) {
+      const cooldownReduction = (this.spellUsable.cooldownRemaining(SPELLS.FISTS_OF_FURY_CAST.id)) * 0.5;
+      this.spellUsable.reduceCooldown(SPELLS.FISTS_OF_FURY_CAST.id, cooldownReduction);
+    }
+  }
+
+  on_byPlayer_removebuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.SERENITY_TALENT.id) {
+      return;
+    }
+    if (this.spellUsable.isOnCooldown(SPELLS.RISING_SUN_KICK.id)) {
+      const cooldownExtension = (this.spellUsable.cooldownRemaining(SPELLS.RISING_SUN_KICK.id));
+      this.spellUsable.extendCooldown(SPELLS.RISING_SUN_KICK.id, cooldownExtension);
+    }
+    if (this.spellUsable.isOnCooldown(SPELLS.FISTS_OF_FURY_CAST.id)) {
+      const cooldownExtension = (this.spellUsable.cooldownRemaining(SPELLS.FISTS_OF_FURY_CAST.id));
+      this.spellUsable.extendCooldown(SPELLS.FISTS_OF_FURY_CAST.id, cooldownExtension);
+    }
+  }
+}
+
+export default Serenity;


### PR DESCRIPTION
Adding extendCooldown() to spellUsable for maintainability. The Serenity module so far has no statistics or suggestions, but might be adding some tracking on the CDR gained through it later. 