### PR TITLE
[BfA] Trinket: Lingering Sporepods

### DIFF
--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -122,6 +122,8 @@ import VantusRune from './Modules/Spells/VantusRune';
 // BFA
 import ZandalariLoaFigurine from './Modules/Items/BFA/ZandalariLoaFigurine';
 import FirstMatesSpyglass from './Modules/Items/BFA/FirstMatesSpyglass';
+// Dungeons
+import LingeringSporepods from './Modules/Items/BFA/Dungeons/LingeringSporepods';
 
 import ParseResults from './ParseResults';
 import Analyzer from './Analyzer';
@@ -250,6 +252,8 @@ class CombatLogParser {
     // BFA
     zandalariLoaFigurine: ZandalariLoaFigurine,
     firstMatesSpyglass: FirstMatesSpyglass,
+    // Dungeons
+    lingeringSporepods: LingeringSporepods,
   };
   // Override this with spec specific modules when extending
   static specModules = {};

--- a/src/Parser/Core/Modules/Items/BFA/Dungeons/LingeringSporepods.js
+++ b/src/Parser/Core/Modules/Items/BFA/Dungeons/LingeringSporepods.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import ItemDamageDone from 'Main/ItemDamageDone';
+import ItemHealingDone from 'Main/ItemHealingDone';
+
+/**
+ * Equip: Your attacks and attacks made against you have a chance to trigger spores to grow for 4 sec before bursting.
+ * When they burst, they restore [x] health to you and deal [y] damage split among enemies within 8 yds.
+ * 
+ * The growing spores buff is always applied to the player.
+ * It's possible to get a second proc while the "growing spores" buff is already active. In that case
+ * the old buff is triggered early, does its damage and healing, and is replaced by the new buff.
+ * In short: overlapping procs are not wasted.
+ */
+class LingeringSporepods extends Analyzer {
+  damage = 0;
+  healing = 0;
+  totalProcs = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrinket(ITEMS.LINGERING_SPOREPODS.id);
+  }
+
+  on_toPlayer_applybuff(event) {
+    if (SPELLS.LINGERING_SPOREPODS_BUFF.id !== event.ability.guid) {
+      return;
+    }
+    this.totalProcs += 1;
+  }
+
+  on_toPlayer_refreshbuff(event) {
+    if (SPELLS.LINGERING_SPOREPODS_BUFF.id !== event.ability.guid) {
+      return;
+    }
+    this.totalProcs += 1;
+  }
+
+  on_byPlayer_damage(event) {
+    if (SPELLS.LINGERING_SPOREPODS_DAMAGE.id !== event.ability.guid) {
+      return;
+    }
+    this.damage += event.amount + (event.absorbed || 0);
+  }
+
+  on_byPlayer_heal(event) {
+    if (SPELLS.LINGERING_SPOREPODS_HEAL.id !== event.ability.guid) {
+      return;
+    }
+    this.healing += (event.amount || 0) + (event.absorbed || 0);
+  }
+  
+  item() {
+    return {
+      item: ITEMS.LINGERING_SPOREPODS,
+      result: (
+        <dfn data-tip={`Procced <b>${this.totalProcs}</b> time${this.totalProcs === 1 ? '' : 's'}.`}>
+        <React.Fragment>
+          <ItemDamageDone amount={this.damage} /><br />
+          <ItemHealingDone amount={this.healing} />
+        </React.Fragment>
+        </dfn>
+      ),
+    };
+  }
+}
+
+export default LingeringSporepods;

--- a/src/common/ITEMS/BFA/Dungeons/index.js
+++ b/src/common/ITEMS/BFA/Dungeons/index.js
@@ -17,6 +17,12 @@ export default {
     icon: 'inv_misc_food_legion_leyblood',
     quality: ITEM_QUALITIES.BLUE,
   },
+  LINGERING_SPOREPODS: {
+    id: 159626,
+    name: 'Lingering Sporepods',
+    icon: 'inv_farm_seedofharmony',
+    quality: ITEM_QUALITIES.BLUE,
+  },
 
   // Tol Dagor
   IGNITION_MAGES_FUSE: {

--- a/src/common/SPELLS/BFA/Dungeons/ITEMS.js
+++ b/src/common/SPELLS/BFA/Dungeons/ITEMS.js
@@ -1,8 +1,22 @@
 // Spells such as on use casts or buffs triggered by items from any dungeon
 
 export default {
-  // <Dungeon 1> (insert name here)
-  // ...
+  // The Underrot
+  LINGERING_SPOREPODS_BUFF: {
+    id: 268062,
+    name: 'Lingering Spore Pods',
+    icon: 'spell_druid_wildmushroom_frenzy',
+  },
+  LINGERING_SPOREPODS_HEAL: {
+    id: 278708,
+    name: 'Lingering Spore Pods',
+    icon: 'spell_druid_wildmushroom_frenzy',
+  },
+  LINGERING_SPOREPODS_DAMAGE: {
+    id: 268068,
+    name: 'Lingering Spore Pods',
+    icon: 'spell_druid_wildmushroom_frenzy',
+  },
 
   // <Dungeon 2> (insert name here)
   // ...


### PR DESCRIPTION
Lingering Sporepods
>Equip: Your attacks and attacks made against you have a chance to trigger spores to grow for 4 sec before bursting. When they burst, they restore [x] health to you and deal [y] damage split among enemies within 8 yds.

A trinket intended for tanks and physical DPS specs that drops from Sporecaller Zancha in The Underrot (dungeon). Nothing fancy just tracks the damage and healing it causes and count how often it procs.

The buff and damage/heal spells are named the way Blizzard names them, which doesn't quite match the trinket's name.

Example BfA log, a M+ run with the trinket worn by the Vengeance Demon Hunter tank:
https://www.warcraftlogs.com/reports/cGp6XRFjZd4zbaWv#fight=last&source=2

![lingering-sporepods](https://user-images.githubusercontent.com/35700764/42455785-16d6a632-838b-11e8-9586-8eadc51cbc6d.png)
