### PR TITLE
[BFA] Trinket: Fangs of Intertwined Essence

### DIFF
--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -122,6 +122,8 @@ import VantusRune from './Modules/Spells/VantusRune';
 // BFA
 import ZandalariLoaFigurine from './Modules/Items/BFA/ZandalariLoaFigurine';
 import FirstMatesSpyglass from './Modules/Items/BFA/FirstMatesSpyglass';
+// Dungeons
+import LingeringSporepods from './Modules/Items/BFA/Dungeons/LingeringSporepods';
 
 import ParseResults from './ParseResults';
 import Analyzer from './Analyzer';
@@ -250,6 +252,8 @@ class CombatLogParser {
     // BFA
     zandalariLoaFigurine: ZandalariLoaFigurine,
     firstMatesSpyglass: FirstMatesSpyglass,
+    // Dungeons
+    lingeringSporepods: LingeringSporepods,
   };
   // Override this with spec specific modules when extending
   static specModules = {};

--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -124,6 +124,7 @@ import ZandalariLoaFigurine from './Modules/Items/BFA/ZandalariLoaFigurine';
 import FirstMatesSpyglass from './Modules/Items/BFA/FirstMatesSpyglass';
 // Dungeons
 import LingeringSporepods from './Modules/Items/BFA/Dungeons/LingeringSporepods';
+import FangsOfIntertwinedEssence from './Modules/Items/BFA/Dungeons/FangsOfIntertwinedEssence';
 
 import ParseResults from './ParseResults';
 import Analyzer from './Analyzer';
@@ -254,6 +255,7 @@ class CombatLogParser {
     firstMatesSpyglass: FirstMatesSpyglass,
     // Dungeons
     lingeringSporepods: LingeringSporepods,
+    fangsOfIntertwinedEssence: FangsOfIntertwinedEssence,
   };
   // Override this with spec specific modules when extending
   static specModules = {};

--- a/src/Parser/Core/Modules/Items/BFA/Dungeons/FangsOfIntertwinedEssence.js
+++ b/src/Parser/Core/Modules/Items/BFA/Dungeons/FangsOfIntertwinedEssence.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
+import ItemLink from 'common/ItemLink';
+import { formatPercentage } from 'common/format';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Abilities from 'Parser/Core/Modules/Abilities';
+import ItemManaGained from 'Main/ItemManaGained';
+
+const MAX_RESTORES_PER_USE = 6;
+const ACTIVATION_COOLDOWN = 120; // seconds
+const BUFF_DURATION = 20; // seconds
+
+/**
+ * Use: Your next 6 healing spells restore [x] mana. (2 Min Cooldown)
+ * 
+ * The restored mana appears as energize events in the combat log.
+ * The buff expires after 20 seconds or after casting 6 spells, whichever is sooner.
+ */
+class FangsOfIntertwinedEssence extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+  }
+
+  manaRestored = 0;
+  useCount = 0;
+  restoreCount = 0;
+  
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrinket(ITEMS.FANGS_OF_INTERTWINED_ESSENCE.id);
+
+    if (this.active) {
+      this.abilities.add({
+        spell: SPELLS.FANGS_OF_INTERTWINED_ESSENCE_BUFF,
+        name: ITEMS.FANGS_OF_INTERTWINED_ESSENCE.name,
+        category: Abilities.SPELL_CATEGORIES.ITEMS,
+        cooldown: ACTIVATION_COOLDOWN,
+        castEfficiency: {
+          suggestion: true,
+        },
+      });
+    }
+  }
+
+  on_toPlayer_applybuff(event) {
+    if (SPELLS.FANGS_OF_INTERTWINED_ESSENCE_BUFF.id !== event.ability.guid) {
+      return;
+    }
+    this.useCount += 1;
+  }
+
+  on_toPlayer_energize(event) {
+    if (SPELLS.FANGS_OF_INTERTWINED_ESSENCE_ENERGIZE.id !== event.ability.guid) {
+      return;
+    }
+    this.restoreCount += 1;
+    this.manaRestored += event.resourceChange;
+  }
+
+  get possibleUseCount() {
+    return 1 + Math.floor(this.owner.fightDuration / (ACTIVATION_COOLDOWN * 1000));
+  }
+
+  get restoresPerUse() {
+    return this.restoreCount / this.useCount;
+  }
+  
+  item() {
+    return {
+      item: ITEMS.FANGS_OF_INTERTWINED_ESSENCE,
+      result: (
+        <dfn data-tip={`Activated <b>${this.useCount}</b> time${this.useCount === 1 ? '' : 's'} of a possible <b>${this.possibleUseCount}</b>.<br />
+          You cast an average of <b>${this.restoresPerUse.toFixed(1)}</b> eligible spells during each activation, out of a possible <b>${MAX_RESTORES_PER_USE}</b>.`}>
+          <ItemManaGained amount={this.manaRestored} />
+        </dfn>
+      ),
+    };
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.restoresPerUse / MAX_RESTORES_PER_USE,
+      isLessThan: {
+        minor: 1.0,
+        average: 0.8,
+        major: 0.5,
+      },
+      style: 'percentage',
+    };
+  }
+  suggestions(when) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <React.Fragment>
+          Your usage of <ItemLink id={ITEMS.FANGS_OF_INTERTWINED_ESSENCE.id} /> can be improved. Try to cast at least {MAX_RESTORES_PER_USE} spells in the {BUFF_DURATION} seconds after activating it to benefit from the full mana restoration it can provide.
+        </React.Fragment>
+      )
+        .icon(ITEMS.FANGS_OF_INTERTWINED_ESSENCE.icon)
+        .actual(`${formatPercentage(actual)}% of mana restoration triggered`)
+        .recommended(`${formatPercentage(recommended)}% is recommended`);
+    });
+  }
+}
+
+export default FangsOfIntertwinedEssence;

--- a/src/Parser/Core/Modules/Items/BFA/Dungeons/LingeringSporepods.js
+++ b/src/Parser/Core/Modules/Items/BFA/Dungeons/LingeringSporepods.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import ItemDamageDone from 'Main/ItemDamageDone';
+import ItemHealingDone from 'Main/ItemHealingDone';
+
+/**
+ * Equip: Your attacks and attacks made against you have a chance to trigger spores to grow for 4 sec before bursting.
+ * When they burst, they restore [x] health to you and deal [y] damage split among enemies within 8 yds.
+ * 
+ * The growing spores buff is always applied to the player.
+ * It's possible to get a second proc while the "growing spores" buff is already active. In that case
+ * the old buff is triggered early, does its damage and healing, and is replaced by the new buff.
+ * In short: overlapping procs are not wasted.
+ */
+class LingeringSporepods extends Analyzer {
+  damage = 0;
+  healing = 0;
+  totalProcs = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrinket(ITEMS.LINGERING_SPOREPODS.id);
+  }
+
+  on_toPlayer_applybuff(event) {
+    if (SPELLS.LINGERING_SPOREPODS_BUFF.id !== event.ability.guid) {
+      return;
+    }
+    this.totalProcs += 1;
+  }
+
+  on_toPlayer_refreshbuff(event) {
+    if (SPELLS.LINGERING_SPOREPODS_BUFF.id !== event.ability.guid) {
+      return;
+    }
+    this.totalProcs += 1;
+  }
+
+  on_byPlayer_damage(event) {
+    if (SPELLS.LINGERING_SPOREPODS_DAMAGE.id !== event.ability.guid) {
+      return;
+    }
+    this.damage += event.amount + (event.absorbed || 0);
+  }
+
+  on_byPlayer_heal(event) {
+    if (SPELLS.LINGERING_SPOREPODS_HEAL.id !== event.ability.guid) {
+      return;
+    }
+    this.healing += (event.amount || 0) + (event.absorbed || 0);
+  }
+  
+  item() {
+    return {
+      item: ITEMS.LINGERING_SPOREPODS,
+      result: (
+        <dfn data-tip={`Procced <b>${this.totalProcs}</b> time${this.totalProcs === 1 ? '' : 's'}.`}>
+        <React.Fragment>
+          <ItemDamageDone amount={this.damage} /><br />
+          <ItemHealingDone amount={this.healing} />
+        </React.Fragment>
+        </dfn>
+      ),
+    };
+  }
+}
+
+export default LingeringSporepods;

--- a/src/common/ITEMS/BFA/Dungeons/index.js
+++ b/src/common/ITEMS/BFA/Dungeons/index.js
@@ -82,7 +82,7 @@ export default {
     quality: ITEM_QUALITIES.BLUE,
   },
 
-  // Temple of Serthraliss
+  // Temple of Sethraliss
   FANGS_OF_INTERTWINED_ESSENCE: {
     id: 158368,
     name: 'Fangs of Intertwined Essence',

--- a/src/common/ITEMS/BFA/Dungeons/index.js
+++ b/src/common/ITEMS/BFA/Dungeons/index.js
@@ -17,6 +17,12 @@ export default {
     icon: 'inv_misc_food_legion_leyblood',
     quality: ITEM_QUALITIES.BLUE,
   },
+  LINGERING_SPOREPODS: {
+    id: 159626,
+    name: 'Lingering Sporepods',
+    icon: 'inv_farm_seedofharmony',
+    quality: ITEM_QUALITIES.BLUE,
+  },
 
   // Tol Dagor
   IGNITION_MAGES_FUSE: {

--- a/src/common/SPELLS/BFA/Dungeons/ITEMS.js
+++ b/src/common/SPELLS/BFA/Dungeons/ITEMS.js
@@ -18,8 +18,17 @@ export default {
     icon: 'spell_druid_wildmushroom_frenzy',
   },
 
-  // <Dungeon 2> (insert name here)
-  // ...
+  // Temple of Sethraliss
+  FANGS_OF_INTERTWINED_ESSENCE_BUFF: {
+    id: 271054,
+    name: 'Fangs of Intertwined Essence',
+    icon: 'inv_misc_redsaberonfang',
+  },
+  FANGS_OF_INTERTWINED_ESSENCE_ENERGIZE: {
+    id: 271058,
+    name: 'Fangs of Intertwined Essence',
+    icon: 'inv_misc_redsaberonfang',
+  },
 
   // Quests.............. upscaled in beta
   DIEMETRADON_FRENZY: {

--- a/src/common/SPELLS/BFA/Dungeons/ITEMS.js
+++ b/src/common/SPELLS/BFA/Dungeons/ITEMS.js
@@ -1,8 +1,22 @@
 // Spells such as on use casts or buffs triggered by items from any dungeon
 
 export default {
-  // <Dungeon 1> (insert name here)
-  // ...
+  // The Underrot
+  LINGERING_SPOREPODS_BUFF: {
+    id: 268062,
+    name: 'Lingering Spore Pods',
+    icon: 'spell_druid_wildmushroom_frenzy',
+  },
+  LINGERING_SPOREPODS_HEAL: {
+    id: 278708,
+    name: 'Lingering Spore Pods',
+    icon: 'spell_druid_wildmushroom_frenzy',
+  },
+  LINGERING_SPOREPODS_DAMAGE: {
+    id: 268068,
+    name: 'Lingering Spore Pods',
+    icon: 'spell_druid_wildmushroom_frenzy',
+  },
 
   // <Dungeon 2> (insert name here)
   // ...


### PR DESCRIPTION
Related issue: #1695 
Fangs of Intertwined Essence [(wowdb)](https://beta.wowdb.com/items/158368-fangs-of-intertwined-essence)
> Use: Your next 6 healing spells restore [x] mana. (2 Min Cooldown)

A trinket intended for healers that drops from Avatar of Sethraliss in the Temple of Sethraliss (dungeon.) As with other "on use" trinkets, the activation of the trinket is added as an ability with a cast efficiency suggestion. The analyzer tracks the total mana it restores and how many times the restoration is triggered. If the player doesn't trigger all 6 mana restorations in the time when the buff is active an additional suggestion is generated.

Example logs:
Holy Priest in M+ https://www.warcraftlogs.com/reports/yt9FDTXwfHcm8V6K#fight=1&source=57
Mistweaver Monk in M+ https://www.warcraftlogs.com/reports/cGp6XRFjZd4zbaWv#fight=last&source=8

![fangs-of-intertwined-essence-01](https://user-images.githubusercontent.com/35700764/42462447-3491ab44-839b-11e8-916f-34b295d3aba6.png)
![fangs-of-intertwined-essence-02](https://user-images.githubusercontent.com/35700764/42462448-34ae2526-839b-11e8-9638-71635985374c.png)
![fangs-of-intertwined-essence-03](https://user-images.githubusercontent.com/35700764/42462807-33f68212-839c-11e8-8f76-13775265e9e0.png)

To dodge merge conflicts in the shared files this PR includes a commit for #1873.
***Please merge that pull request before this one.***