### PR TITLE
[BFA] Trinket Balefire Branch

### DIFF
--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -125,6 +125,7 @@ import FirstMatesSpyglass from './Modules/Items/BFA/FirstMatesSpyglass';
 // Dungeons
 import LingeringSporepods from './Modules/Items/BFA/Dungeons/LingeringSporepods';
 import FangsOfIntertwinedEssence from './Modules/Items/BFA/Dungeons/FangsOfIntertwinedEssence';
+import BalefireBranch from './Modules/Items/BFA/Dungeons/BalefireBranch';
 
 import ParseResults from './ParseResults';
 import Analyzer from './Analyzer';
@@ -256,6 +257,7 @@ class CombatLogParser {
     // Dungeons
     lingeringSporepods: LingeringSporepods,
     fangsOfIntertwinedEssence: FangsOfIntertwinedEssence,
+    balefireBranch: BalefireBranch,
   };
   // Override this with spec specific modules when extending
   static specModules = {};

--- a/src/Parser/Core/Modules/Items/BFA/Dungeons/BalefireBranch.js
+++ b/src/Parser/Core/Modules/Items/BFA/Dungeons/BalefireBranch.js
@@ -1,0 +1,167 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
+import { formatDuration } from 'common/format';
+import { calculatePrimaryStat } from 'common/stats';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import Abilities from 'Parser/Core/Modules/Abilities';
+import SpellUsable from 'Parser/Core/Modules/SpellUsable';
+
+const ACTIVATION_COOLDOWN = 90; // seconds
+
+const STACKS_START = 100;
+const DURATION_TO_DECAY = 20; // seconds
+const STACKS_LOST_PER_SEC = 5;
+
+// sum of finite linear sequence {0, 5, 10, ... 100} to find sum stacks if no damage taken
+const EXPECTED_SUM_STACKS_PER_USE = (DURATION_TO_DECAY + 1) * STACKS_START * 0.5;
+
+// to calculate size of intellect buff based on trinket's item level
+const BASE_ITEM_LEVEL = 340;
+const BASE_INTELLECT_PER_STACK = 12;
+
+/**
+ * Use: Kindle your soul, gaining [x] Intellect, which decays over 20 sec or when taking damage.
+ * (1 Min, 30 Sec Cooldown)
+ * 
+ * When activated the buff starts at 100 stacks. Every 1 second 5 stacks are lost.
+ * Taking damage removes stacks. It appears that taking larger hits removes more stacks.
+ * Stacks are removed even if the damage is 100% absorbed.
+ * 
+ * The initial buff shows in the log (and changebuffstack fabricated events) as a "1 stack" buff.
+ * The log shows the correct stack count once it has been lowered from that initial value.
+ */
+class BalefireBranch extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+    spellUsable: SpellUsable,
+  }
+  applyCount = 0;
+  currentStack = 0;
+  totalUptime = 0;
+
+  lastApply = null;
+  lastChange = null;
+
+  // used to find average stacks over whole fight. 1 second at 5 stacks and 2 seconds at 10 would be sumStacks = 25
+  sumStacks = 0;
+
+  // sumStacks value if the player had taken no damage.
+  expectedSumStacks = 0;
+
+  // scales with trinket's ilvl
+  intellectPerStack = 0;
+  
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrinket(ITEMS.BALEFIRE_BRANCH.id);
+
+    if (this.active) {
+      const itemLevel = this.selectedCombatant.getItem(ITEMS.BALEFIRE_BRANCH.id).itemLevel;
+      this.intellectPerStack = calculatePrimaryStat(BASE_ITEM_LEVEL, BASE_INTELLECT_PER_STACK, itemLevel);
+
+      // remind the player to activate the trinket
+      this.abilities.add({
+        spell: SPELLS.BALEFIRE_BRANCH_SPELL,
+        name: SPELLS.BALEFIRE_BRANCH_SPELL.name,
+        buffSpellId: SPELLS.KINDLED_SOUL.id,
+        category: Abilities.SPELL_CATEGORIES.ITEMS,
+        cooldown: ACTIVATION_COOLDOWN,
+        castEfficiency: {
+          suggestion: true,
+        },
+      });
+    }
+  }
+
+  on_toPlayer_applybuff(event) {
+    if (SPELLS.KINDLED_SOUL.id !== event.ability.guid) {
+      return;
+    }
+    this.stackChange(STACKS_START, event.timestamp);
+    this.expectedSumStacks += EXPECTED_SUM_STACKS_PER_USE;
+    this.applyCount += 1;
+    this.lastApply = event.timestamp;
+
+    // using the trinket doesn't trigger a cast event, so make our own
+    this.owner.fabricateEvent({
+      ...event,
+      ability: {
+        abilityIcon: SPELLS.BALEFIRE_BRANCH_SPELL.icon,
+        guid: SPELLS.BALEFIRE_BRANCH_SPELL.id,
+        name: SPELLS.BALEFIRE_BRANCH_SPELL.name,
+      },
+      type: 'cast',
+    }, event);
+  }
+
+  on_toPlayer_removebuffstack(event) {
+    if (SPELLS.KINDLED_SOUL.id !== event.ability.guid) {
+      return;
+    }
+    this.stackChange(event.stack, event.timestamp);
+  }
+
+  on_toPlayer_removebuff(event) {
+    if (SPELLS.KINDLED_SOUL.id !== event.ability.guid) {
+      return;
+    }
+    this.stackChange(0, event.timestamp);
+    this.totalUptime += (event.timestamp - this.lastApply);
+  }
+
+  on_finished() {
+    if (!this.lastChange || !this.currentStack) {
+      return;
+    }
+    const now = this.owner.fight.end_time;
+    this.stackChange(0, now);
+    this.totalUptime += (now - this.lastApply);
+
+    if (this.lastApply + DURATION_TO_DECAY > now) {
+      // buff still active when fight ends, so revert some of the expectedSumStacks
+      const remainingDuration = (this.lastApply + DURATION_TO_DECAY - now) / 1000;
+      const wholeSeconds = Math.floor(remainingDuration);
+
+      // sum of finite linear sequence for the 'whole seconds' part
+      const stackSumFromWholeSeconds = wholeSeconds * STACKS_LOST_PER_SEC * (1 + wholeSeconds) * 0.5;
+      const fractionOfSecond = remainingDuration - wholeSeconds;
+      const stacksDuringFraction = (wholeSeconds + 1) * STACKS_LOST_PER_SEC;
+      this.expectedSumStacks -= (stackSumFromWholeSeconds + fractionOfSecond * stacksDuringFraction);
+    }
+  }
+
+  stackChange(newStack, timestamp) {
+    if (this.lastChange) {
+      const timeAtLastStack = timestamp - this.lastChange;
+      this.sumStacks += this.currentStack * timeAtLastStack / 1000;
+    }
+    this.currentStack = newStack;
+    this.lastChange = timestamp;
+  }
+
+  get possibleUseCount() {
+    return 1 + Math.floor(this.owner.fightDuration / (ACTIVATION_COOLDOWN * 1000));
+  }
+
+  get averageIntellect() {
+    return this.intellectPerStack * (this.sumStacks / (this.owner.fightDuration / 1000));
+  }
+
+  item() {
+    const expectedIntellectWithoutDamage = this.intellectPerStack * (this.expectedSumStacks / (this.owner.fightDuration / 1000));
+    return {
+      item: ITEMS.BALEFIRE_BRANCH,
+      result: (
+        <dfn data-tip={`Activated <b>${this.applyCount}</b> time${this.applyCount === 1 ? '' : 's'} of a possible <b>${this.possibleUseCount}</b>.<br/>
+          The buff was active for <b>${formatDuration(this.totalUptime / 1000)}</b>.<br/>
+          Average intellect reduced by <b>${(expectedIntellectWithoutDamage - this.averageIntellect).toFixed(1)}</b> due to damage taken while the buff was active.`}>
+          {this.averageIntellect.toFixed(1)} average intellect
+        </dfn>
+      ),
+    };
+  }
+}
+
+export default BalefireBranch;

--- a/src/Parser/Core/Modules/Items/BFA/Dungeons/LingeringSporepods.js
+++ b/src/Parser/Core/Modules/Items/BFA/Dungeons/LingeringSporepods.js
@@ -58,10 +58,8 @@ class LingeringSporepods extends Analyzer {
       item: ITEMS.LINGERING_SPOREPODS,
       result: (
         <dfn data-tip={`Procced <b>${this.totalProcs}</b> time${this.totalProcs === 1 ? '' : 's'}.`}>
-        <React.Fragment>
           <ItemDamageDone amount={this.damage} /><br />
           <ItemHealingDone amount={this.healing} />
-        </React.Fragment>
         </dfn>
       ),
     };

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -310,6 +310,10 @@ class StatTracker extends Analyzer {
       itemId: ITEMS.IGNITION_MAGES_FUSE.id,
       haste: (_, item) => calculateSecondaryStatDefault(310, 233, item.itemLevel),
     },
+    [SPELLS.KINDLED_SOUL.id] : { // Balefire Branch trinket's buff (stack starts at 100)
+      itemId: ITEMS.BALEFIRE_BRANCH.id,
+      intellect: (_, item) => calculatePrimaryStat(340, 12, item.itemLevel),
+    },
     // endregion
     // endregion
 

--- a/src/common/SPELLS/BFA/Dungeons/ITEMS.js
+++ b/src/common/SPELLS/BFA/Dungeons/ITEMS.js
@@ -30,6 +30,18 @@ export default {
     icon: 'inv_misc_redsaberonfang',
   },
 
+  // Waycrest Manor
+  KINDLED_SOUL: { // buff from trinket Balefire Branch
+    id: 268998,
+    name: 'Kindled Soul',
+    icon: 'sha_spell_fire_felfire',
+  },
+  BALEFIRE_BRANCH_SPELL: {
+    id: 268999,
+    name: 'Balefire Branch',
+    icon: 'inv_staff_26',
+  },
+
   // Quests.............. upscaled in beta
   DIEMETRADON_FRENZY: {
     id: 268619,


### PR DESCRIPTION
Related issue: #1698 
**Balefire Branch** [(wowdb)](https://beta.wowdb.com/items/159630-balefire-branch)
>Use: Kindle your soul, gaining [x] Intellect, which decays over 20 sec or when taking damage. (1 Min, 30 Sec Cooldown)

Fortunately the decaying intellect is represented as a stacking buff that is mostly reported correctly in the combat log (the exception is when it's first applied at 100 stacks, which shows as 1.)

As with other "on use" trinkets an ability is added with a default cast efficiency suggestion. There's no cast event shown in the log when the trinket is used, so an event is fabricated when trinket use is detected through applybuff.

Using the same technique as the Eye of Command trinket from Legion, the analyzer tracks the average number of stacks and so the average intellect buff from the trinket. It also calculates what the average intellect contribution would have been if the player hadn't taken any damage. That should help give an idea of how much effect the "decays when taking damage" part has.

Example logs:
Frost Mage in M+ https://www.warcraftlogs.com/reports/Mz1pajtcfJmgGVhF#fight=1&source=2&type=summary&start=1354306&end=1373420
Balance Druid in M+ https://www.warcraftlogs.com/reports/LWhT1yjB8V32FH4C#fight=last&source=91&type=auras

![balefire-branch-01](https://user-images.githubusercontent.com/35700764/42505132-c35d9032-8435-11e8-8d4c-9d0807318908.png)
![balefire-branch-02](https://user-images.githubusercontent.com/35700764/42508054-20181f3c-843f-11e8-92bf-854b2b4d5f8e.png)
![balefire-branch-03](https://user-images.githubusercontent.com/35700764/42508369-2b125028-8440-11e8-90d3-dfa6f00f45c0.png)


Also snuck in a small fix to remove a needless `<React.Fragment>` from the Lingering Sporepods trinket.