### PR TITLE
[BFA][Core] Azerite Rank change

### DIFF
--- a/src/common/stats.js
+++ b/src/common/stats.js
@@ -30,9 +30,9 @@ const AZ_BASE_BUDGET = 179.2;
 export function calculateAzeriteEffects(spellId, rank) {
   const spell = AZERITE_SCALING[spellId];
 
-  let budget = calculatePrimaryStat(AZ_BASE_ILVL, AZ_BASE_BUDGET, AZ_BASE_ILVL + rank);
+  let budget = calculatePrimaryStat(AZ_BASE_ILVL, AZ_BASE_BUDGET, rank);
   if(spell.secondary) {
-    budget *= getMultiplier(multiplierTables.general, AZ_BASE_ILVL + rank);
+    budget *= getMultiplier(multiplierTables.general, rank);
   } 
 
   return Object.values(spell.effects).filter(({avg}) => avg > 0).map(({avg}) => Math.round(avg * budget));

--- a/src/common/stats.test.js
+++ b/src/common/stats.test.js
@@ -85,10 +85,10 @@ describe('stats', () => {
 
   it('scales azerite effects correctly', () => {
     // elusive footwork
-    expect(calculateAzeriteEffects(278571, 59)).toEqual([684]); // ilvl 310
-    expect(calculateAzeriteEffects(278571, 79)).toEqual([823]); // ilvl 330
-    expect(calculateAzeriteEffects(278571, 104)).toEqual([1038]); // ilvl 355
+    expect(calculateAzeriteEffects(278571, 310)).toEqual([684]); // ilvl 310
+    expect(calculateAzeriteEffects(278571, 330)).toEqual([823]); // ilvl 330
+    expect(calculateAzeriteEffects(278571, 355)).toEqual([1038]); // ilvl 355
     // gemhide
-    expect(calculateAzeriteEffects(268596, 79)).toEqual([115, 508]); // ilvl 330
+    expect(calculateAzeriteEffects(268596, 330)).toEqual([115, 508]); // ilvl 330
   });
 });


### PR DESCRIPTION
WCL now reports ranks as the full ilvl rather than the difference from ilvl 251. Updated the scaling function and tests to match this.