### PR TITLE
[BFA] Trinket: Darkmoon Deck: Tides

### DIFF
--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -125,6 +125,8 @@ import FirstMatesSpyglass from './Modules/Items/BFA/FirstMatesSpyglass';
 // Dungeons
 import LingeringSporepods from './Modules/Items/BFA/Dungeons/LingeringSporepods';
 import FangsOfIntertwinedEssence from './Modules/Items/BFA/Dungeons/FangsOfIntertwinedEssence';
+// Crafted
+import DarkmoonDeckTides from './Modules/Items/BFA/Crafted/DarkmoonDeckTides';
 
 import ParseResults from './ParseResults';
 import Analyzer from './Analyzer';
@@ -256,6 +258,8 @@ class CombatLogParser {
     // Dungeons
     lingeringSporepods: LingeringSporepods,
     fangsOfIntertwinedEssence: FangsOfIntertwinedEssence,
+    // Crafted
+    darkmoonDeckTides: DarkmoonDeckTides,
   };
   // Override this with spec specific modules when extending
   static specModules = {};

--- a/src/Parser/Core/Modules/Features/SpellInfo.js
+++ b/src/Parser/Core/Modules/Features/SpellInfo.js
@@ -108,4 +108,11 @@ export default {
     mastery: false,
     vers: true,
   },
+  [SPELLS.REJUVENATING_TIDES.id]: { // Darkmoon Deck: Tides
+    int: false,
+    crit: true,
+    hasteHpct: false,
+    mastery: false,
+    vers: true,
+  },
 };

--- a/src/Parser/Core/Modules/Items/BFA/Crafted/DarkmoonDeckTides.js
+++ b/src/Parser/Core/Modules/Items/BFA/Crafted/DarkmoonDeckTides.js
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
+import Analyzer from 'Parser/Core/Analyzer';
+import ItemHealingDone from 'Main/ItemHealingDone';
+import ItemManaGained from 'Main/ItemManaGained';
+
+const DARKMOON_DECK_TIDES_CARDS = [
+  276136, // Ace
+  276137, // 2
+  276138, // 3
+  276139, // 4
+  276140, // 5
+  276141, // 6
+  276142, // 7
+  276143, // 8
+];
+
+/**
+ * Darkmoon Deck: Tides -
+ * Equip: Restores a moderate amount of mana when the deck is shuffled. Chance to throw a card to a random party member,
+ * healing them and bouncing to other party members. Amount of mana restored and number of bounces depends on the topmost card in the deck.
+ * Equip: Periodically shuffle the deck while in combat.
+ */
+
+class DarkmoonDeckTides extends Analyzer {
+  healing = 0;
+  manaGained = 0;
+
+  constructor(...args) {
+    super(...args);
+    const selectedCombatant = this.selectedCombatant;
+    this.active = selectedCombatant.hasTrinket(ITEMS.DARKMOON_DECK_TIDES.id);
+  }
+
+  on_byPlayer_heal(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.REJUVENATING_TIDES.id) {
+      return;
+    }
+
+    this.healing += event.amount + (event.absorbed || 0);
+  }
+
+  on_toPlayer_energize(event) {
+    const spellId = event.ability.guid;
+    if (!DARKMOON_DECK_TIDES_CARDS.includes(spellId)) {
+      return;
+    }
+
+    this.manaGained += event.resourceChange;
+  }
+
+  item() {
+    return {
+      item: ITEMS.DARKMOON_DECK_TIDES,
+      result: (
+        <React.Fragment>
+          <ItemHealingDone amount={this.healing} /><br />
+          <ItemManaGained amount={this.manaGained} />
+        </React.Fragment>
+      ),
+    };
+  }
+}
+
+export default DarkmoonDeckTides;

--- a/src/Parser/Core/Modules/Items/BFA/Crafted/DarkmoonDeckTides.js
+++ b/src/Parser/Core/Modules/Items/BFA/Crafted/DarkmoonDeckTides.js
@@ -30,8 +30,7 @@ class DarkmoonDeckTides extends Analyzer {
 
   constructor(...args) {
     super(...args);
-    const selectedCombatant = this.selectedCombatant;
-    this.active = selectedCombatant.hasTrinket(ITEMS.DARKMOON_DECK_TIDES.id);
+    this.active = this.selectedCombatant.hasTrinket(ITEMS.DARKMOON_DECK_TIDES.id);
   }
 
   on_byPlayer_heal(event) {

--- a/src/Parser/Shaman/Restoration/Constants.js
+++ b/src/Parser/Shaman/Restoration/Constants.js
@@ -20,6 +20,9 @@ export const ABILITIES_AFFECTED_BY_HEALING_INCREASES = [
   SPELLS.OVERFLOWING_SHORES.id,
   SPELLS.IMPASSIVE_VISAGE_HEAL.id,
 
+  // Items
+  SPELLS.REJUVENATING_TIDES.id,
+
   // While the following spells don't double dip in healing increases, they gain the same percentual bonus from the transfer
   SPELLS.CLOUDBURST_TOTEM_HEAL.id,
   SPELLS.ASCENDANCE_HEAL.id,

--- a/src/common/ITEMS/BFA/Crafted/index.js
+++ b/src/common/ITEMS/BFA/Crafted/index.js
@@ -7,7 +7,7 @@ export default {
   DARKMOON_DECK_TIDES: {
     id: 159127,
     name: 'Darkmoon Deck: Tides',
-    icon: '70_inscription_deck_promises',
+    icon: '70_inscription_deck_promises', //inv_inscription_80_deck_tides
   },
   DARKMOON_DECK_SQUALLS: {
     id: 159126,

--- a/src/common/SPELLS/BFA/Crafted/ITEMS.js
+++ b/src/common/SPELLS/BFA/Crafted/ITEMS.js
@@ -1,0 +1,9 @@
+// Spells such as on use casts or buffs triggered by items from crafted items
+
+export default {
+  REJUVENATING_TIDES: { // Darkmoon Deck: Tides heal
+    id: 276146,
+    name: 'Rejuvenating Tides',
+    icon: 'trade_engineering', // likely temporary icon
+  },
+};

--- a/src/common/SPELLS/BFA/Crafted/index.js
+++ b/src/common/SPELLS/BFA/Crafted/index.js
@@ -1,0 +1,4 @@
+import safeMerge from 'common/safeMerge';
+import ITEMS from './ITEMS';
+
+export default safeMerge(ITEMS);

--- a/src/common/SPELLS/BFA/index.js
+++ b/src/common/SPELLS/BFA/index.js
@@ -4,5 +4,6 @@ import Raids from './Raids';
 import AzeriteTraits from './AzeriteTraits';
 import Enchants from './Enchants';
 import Potions from './Potions';
+import Crafted from './Crafted';
 
-export default safeMerge(Dungeons, Raids, AzeriteTraits, Enchants, Potions);
+export default safeMerge(Dungeons, Raids, AzeriteTraits, Enchants, Potions, Crafted);


### PR DESCRIPTION
>Equip: Restores a moderate amount of mana when the deck is shuffled. Chance to throw a card to a random party member, healing them and bouncing to other party members. Amount of mana restored and number of bounces depends on the topmost card in the deck. 
>Equip: Periodically shuffle the deck while in combat.

Nothing extraordinary about this trinket, apart from that only the Ace card restores mana currently. I'm assuming that it gets fixed for live.

Using its actual Icon seems to break it though 
![image](https://user-images.githubusercontent.com/2842471/42612330-129c6fe0-859b-11e8-83cf-33bc3fb9b21c.png) 
since [wowdb](https://beta.wowdb.com/items/159127-darkmoon-deck-tides) doesn't have that icon for some reason.  
![image](https://user-images.githubusercontent.com/2842471/42612808-bf32444e-859d-11e8-9d7c-9046ba387901.png)

Keeping the promises icon as a placeholder for now.
![image](https://user-images.githubusercontent.com/2842471/42612361-450ef47a-859b-11e8-8670-c1fa28f570cb.png)

Log used: https://www.warcraftlogs.com/reports/h6RvrVTAJLHY4ndz#fight=last&type=healing&source=3

closes #1723 