### PR TITLE
[BFA][Feral] Update to use selectedCombatant and constructor (minor)

### DIFF
--- a/src/Parser/Druid/Feral/Modules/Features/SpellUsable.js
+++ b/src/Parser/Druid/Feral/Modules/Features/SpellUsable.js
@@ -1,6 +1,5 @@
 import SPELLS from 'common/SPELLS';
 import CoreSpellUsable from 'Parser/Core/Modules/SpellUsable';
-import Combatants from 'Parser/Core/Modules/Combatants';
 import { encodeTargetString } from 'Parser/Core/Modules/EnemyInstances';
 import { RAKE_BASE_DURATION, RIP_BASE_DURATION, THRASH_FERAL_BASE_DURATION, JAGGED_WOUNDS_MODIFIER, PANDEMIC_FRACTION } from '../../Constants';
 
@@ -22,12 +21,6 @@ const BLEED_BASE_DURATIONS = {
  * When that happens assume the most recent possible enemy death was when the cooldown reset.
  */
 class SpellUsable extends CoreSpellUsable {
-  // BFA: replace this.combatants.selected with this.selectedCombatant, and remove combatants dependency
-  static dependencies = {
-    ...CoreSpellUsable.dependencies,
-    combatants: Combatants,
-  };
-
   earlyCastsOfTigersFury = 0;
 
   // e.g. activeBleedsExpire[targetString][SPELLS.RAKE.id] = timestamp
@@ -38,13 +31,10 @@ class SpellUsable extends CoreSpellUsable {
   // timestamp of most recent possible kill event
   possibleRecentKill = null;
 
-  // BFA: replace with constructor (and use this.selectedCombatant)
-  on_initialized() {
-    if (super.on_initialized) {
-      super.on_initialized();
-    }
-    this.hasPredator = this.combatants.selected.hasTalent(SPELLS.PREDATOR_TALENT.id);
-    this.hasJaggedWounds = this.combatants.selected.hasTalent(SPELLS.JAGGED_WOUNDS_TALENT.id);
+  constructor(...args) {
+    super(...args);
+    this.hasPredator = this.selectedCombatant.hasTalent(SPELLS.PREDATOR_TALENT.id);
+    this.hasJaggedWounds = this.selectedCombatant.hasTalent(SPELLS.JAGGED_WOUNDS_TALENT.id);
   }
 
   on_byPlayer_applydebuff(event) {

--- a/src/Parser/Druid/Feral/Modules/Talents/Predator.js
+++ b/src/Parser/Druid/Feral/Modules/Talents/Predator.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Analyzer from 'Parser/Core/Analyzer';
-import Combatants from 'Parser/Core/Modules/Combatants';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
@@ -10,16 +9,15 @@ import Abilities from '../Abilities';
 
 class Predator extends Analyzer {
   static dependencies = {
-    combatants: Combatants,
     spellUsable: SpellUsable,
     abilities: Abilities,
   };
 
   totalCasts = 0;
 
-  // BFA: replace with constructor and this.selectedCombatant
-  on_initialized() {
-    this.active = this.combatants.selected.hasTalent(SPELLS.PREDATOR_TALENT.id);
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.PREDATOR_TALENT.id);
   }
 
   on_byPlayer_cast(event) {


### PR DESCRIPTION
A couple of classes snuck through the change and were still using `on_initialised` and `this.combatants.selected`
