### PR TITLE
[BFA][Feral] Small refactor of uptime trackers

### DIFF
--- a/src/Parser/Druid/Feral/Modules/Bleeds/RakeUptime.js
+++ b/src/Parser/Druid/Feral/Modules/Bleeds/RakeUptime.js
@@ -1,8 +1,6 @@
 import React from 'react';
-
 import Analyzer from 'Parser/Core/Analyzer';
 import Enemies from 'Parser/Core/Modules/Enemies';
-
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
@@ -14,25 +12,40 @@ class RakeUptime extends Analyzer {
     enemies: Enemies,
   };
 
-  suggestions(when) {
-    const rakeUptime = this.enemies.getBuffUptime(SPELLS.RAKE_BLEED.id) / this.owner.fightDuration;
+  get uptime() {
+    return this.enemies.getBuffUptime(SPELLS.RAKE_BLEED.id) / this.owner.fightDuration;
+  }
 
-    when(rakeUptime).isLessThan(0.95)
-      .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span>Your <SpellLink id={SPELLS.RAKE.id} /> uptime can be improved. Try to pay more attention to your bleeds on the Boss</span>)
-          .icon(SPELLS.RAKE_BLEED.icon)
-          .actual(`${formatPercentage(actual)}% Rake uptime`)
-          .recommended(`>${formatPercentage(recommended)}% is recommended`)
-          .regular(recommended - 0.05).major(recommended - 0.10);
-      });
+  get suggestionThresholds() {
+    return {
+      actual: this.uptime,
+      isLessThan: {
+        minor: 0.95,
+        average: 0.90,
+        major: 0.80,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <React.Fragment>
+          Your <SpellLink id={SPELLS.RAKE.id} /> uptime can be improved. Unless the current application was buffed by Prowl you should refresh the DoT once it has reached its <dfn data-tip={`The last 30% of the DoT's duration. When you refresh during this time you don't lose any duration in the process.`}>pandemic window</dfn>, don't wait for it to wear off.
+        </React.Fragment>
+      )
+        .icon(SPELLS.RAKE.icon)
+        .actual(`${formatPercentage(actual)}% uptime`)
+        .recommended(`>${formatPercentage(recommended)}% is recommended`);
+    });
   }
 
   statistic() {
-    const rakeUptime = this.enemies.getBuffUptime(SPELLS.RAKE_BLEED.id) / this.owner.fightDuration;
     return (
       <StatisticBox
-        icon={<SpellIcon id={SPELLS.RAKE_BLEED.id} />}
-        value={`${formatPercentage(rakeUptime)} %`}
+        icon={<SpellIcon id={SPELLS.RAKE.id} />}
+        value={`${formatPercentage(this.uptime)}%`}
         label="Rake uptime"
       />
     );

--- a/src/Parser/Druid/Feral/Modules/Bleeds/RipUptime.js
+++ b/src/Parser/Druid/Feral/Modules/Bleeds/RipUptime.js
@@ -1,8 +1,6 @@
 import React from 'react';
-
 import Analyzer from 'Parser/Core/Analyzer';
 import Enemies from 'Parser/Core/Modules/Enemies';
-
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
@@ -14,25 +12,40 @@ class RipUptime extends Analyzer {
     enemies: Enemies,
   };
 
-  suggestions(when) {
-    const ripUptime = this.enemies.getBuffUptime(SPELLS.RIP.id) / this.owner.fightDuration;
+  get uptime() {
+    return this.enemies.getBuffUptime(SPELLS.RIP.id) / this.owner.fightDuration;
+  }
 
-    when(ripUptime).isLessThan(0.95)
-      .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span>Your <SpellLink id={SPELLS.RIP.id} /> uptime can be improved. Try to pay more attention to your bleeds on the Boss</span>)
-          .icon(SPELLS.RIP.icon)
-          .actual(`${formatPercentage(actual)}% Rip uptime`)
-          .recommended(`>${formatPercentage(recommended)}% is recommended`)
-          .regular(recommended - 0.05).major(recommended - 0.10);
-      });
+  get suggestionThresholds() {
+    return {
+      actual: this.uptime,
+      isLessThan: {
+        minor: 0.95,
+        average: 0.90,
+        major: 0.80,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <React.Fragment>
+          Your <SpellLink id={SPELLS.RIP.id} /> uptime can be improved. You can refresh the DoT once it has reached its <dfn data-tip={`The last 30% of the DoT's duration. When you refresh during this time you don't lose any duration in the process.`}>pandemic window</dfn>, don't wait for it to wear off. Avoid spending combo points on <SpellLink id={SPELLS.FEROCIOUS_BITE.id} /> if <SpellLink id={SPELLS.RIP.id} /> will need refreshing soon.
+        </React.Fragment>
+      )
+        .icon(SPELLS.RIP.icon)
+        .actual(`${formatPercentage(actual)}% uptime`)
+        .recommended(`>${formatPercentage(recommended)}% is recommended`);
+    });
   }
 
   statistic() {
-    const ripUptime = this.enemies.getBuffUptime(SPELLS.RIP.id) / this.owner.fightDuration;
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.RIP.id} />}
-        value={`${formatPercentage(ripUptime)} %`}
+        value={`${formatPercentage(this.uptime)}%`}
         label="Rip uptime"
       />
     );

--- a/src/Parser/Druid/Feral/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Druid/Feral/Modules/Features/AlwaysBeCasting.js
@@ -6,16 +6,29 @@ import { formatPercentage } from 'common/format';
 import { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class AlwaysBeCasting extends CoreAlwaysBeCasting {
-  suggestions(when) {
-    const deadTimePercentage = this.totalTimeWasted / this.owner.fightDuration;
 
-    when(deadTimePercentage).isGreaterThan(0.2)
-      .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span>Your downtime can be improved. Try to Always Be Casting (ABC), try to reduce the delay between casting spells.</span>)
+  get suggestionThresholds() {
+    return {
+      actual: this.totalTimeWasted / this.owner.fightDuration,
+      isGreaterThan: {
+        minor: 0.45,
+        average: 0.40,
+        major: 0.30,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+        return suggest(
+          <React.Fragment>
+            Your downtime can be improved. Although it's normal to need to wait for energy to regenerate, so long spent not using any abilities indicates you're missing out on chances to deal damage.
+          </React.Fragment>
+        )
           .icon('spell_mage_altertime')
           .actual(`${formatPercentage(actual)}% downtime`)
-          .recommended(`<${formatPercentage(recommended)}% is recommended`)
-          .regular(recommended + 0.15).major(recommended + 0.2);
+          .recommended(`<${formatPercentage(recommended)}% is recommended`);
       });
   }
 

--- a/src/Parser/Druid/Feral/Modules/Talents/MoonfireUptime.js
+++ b/src/Parser/Druid/Feral/Modules/Talents/MoonfireUptime.js
@@ -1,15 +1,13 @@
 import React from 'react';
-
 import Analyzer from 'Parser/Core/Analyzer';
 import Enemies from 'Parser/Core/Modules/Enemies';
-
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
-class moonfireUptime extends Analyzer {
+class MoonfireUptime extends Analyzer {
   static dependencies = {
     enemies: Enemies,
   };
@@ -19,17 +17,33 @@ class moonfireUptime extends Analyzer {
     this.active = this.selectedCombatant.hasTalent(SPELLS.LUNAR_INSPIRATION_TALENT.id);
   }
 
-  suggestions(when) {
-    const moonfireUptime = this.enemies.getBuffUptime(SPELLS.MOONFIRE_FERAL.id) / this.owner.fightDuration;
+  get uptime() {
+    return this.enemies.getBuffUptime(SPELLS.MOONFIRE_FERAL.id) / this.owner.fightDuration;
+  }
 
-    when(moonfireUptime).isLessThan(0.95)
-      .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span>Your <SpellLink id={SPELLS.MOONFIRE_BEAR.id} /> uptime can be improved. Try to pay more attention to your bleeds on the Boss</span>)
-          .icon(SPELLS.MOONFIRE_BEAR.icon)
-          .actual(`${formatPercentage(actual)}% Moonfire uptime`)
-          .recommended(`>${formatPercentage(recommended)}% is recommended`)
-          .regular(recommended - 0.05).major(recommended - 0.10);
-      });
+  get suggestionThresholds() {
+    return {
+      actual: this.uptime,
+      isLessThan: {
+        minor: 0.95,
+        average: 0.90,
+        major: 0.80,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <React.Fragment>
+          Your <SpellLink id={SPELLS.MOONFIRE_FERAL.id} /> uptime can be improved. You should refresh the DoT once it has reached its <dfn data-tip={`The last 30% of the DoT's duration. When you refresh during this time you don't lose any duration in the process.`}>pandemic window</dfn>, don't wait for it to wear off. If you're finding keeping track of all the DoTs a challenge you might want to switch talents to <SpellLink id={SPELLS.BLOOD_SCENT_TALENT.id} /> until you've had more practice.
+        </React.Fragment>
+      )
+        .icon(SPELLS.MOONFIRE_FERAL.icon)
+        .actual(`${formatPercentage(actual)}% uptime`)
+        .recommended(`>${formatPercentage(recommended)}% is recommended`);
+    });
   }
 
   statistic() {
@@ -46,4 +60,4 @@ class moonfireUptime extends Analyzer {
   statisticOrder = STATISTIC_ORDER.OPTIONAL(2);
 }
 
-export default moonfireUptime;
+export default MoonfireUptime;

--- a/src/Parser/Druid/Feral/Modules/Talents/SavageRoarUptime.js
+++ b/src/Parser/Druid/Feral/Modules/Talents/SavageRoarUptime.js
@@ -1,43 +1,51 @@
 import React from 'react';
-
 import Analyzer from 'Parser/Core/Analyzer';
-import Enemies from 'Parser/Core/Modules/Enemies';
-
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 
-class savageRoarUptime extends Analyzer {
-  static dependencies = {
-    enemies: Enemies,
-  };
-
+class SavageRoarUptime extends Analyzer {
   constructor(...args) {
     super(...args);
     this.active = this.selectedCombatant.hasTalent(SPELLS.SAVAGE_ROAR_TALENT.id);
   }
 
-  suggestions(when) {
-    const savageRoarUptime = this.selectedCombatant.getBuffUptime(SPELLS.SAVAGE_ROAR_TALENT.id) / this.owner.fightDuration;
+  get uptime() {
+    return this.selectedCombatant.getBuffUptime(SPELLS.SAVAGE_ROAR_TALENT.id) / this.owner.fightDuration;
+  }
 
-    when(savageRoarUptime).isLessThan(0.95)
-      .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span>Your <SpellLink id={SPELLS.SAVAGE_ROAR_TALENT.id} /> uptime can be improved. Try to pay more attention to your bleeds on the Boss</span>)
-          .icon(SPELLS.SAVAGE_ROAR_TALENT.icon)
-          .actual(`${formatPercentage(actual)}% Savage Roar uptime`)
-          .recommended(`>${formatPercentage(recommended)}% is recommended`)
-          .regular(recommended - 0.05).major(recommended - 0.10);
-      });
+  get suggestionThresholds() {
+    return {
+      actual: this.uptime,
+      isLessThan: {
+        minor: 0.95,
+        average: 0.90,
+        major: 0.80,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <React.Fragment>
+          Your <SpellLink id={SPELLS.SAVAGE_ROAR_TALENT.id} /> uptime can be improved. You should refresh the buff once it has reached its <dfn data-tip={`The last 30% of the DoT's duration. When you refresh during this time you don't lose any duration in the process.`}>pandemic window</dfn>, don't wait for it to wear off. Avoid spending combo points on <SpellLink id={SPELLS.FEROCIOUS_BITE.id} /> if <SpellLink id={SPELLS.SAVAGE_ROAR_TALENT.id} /> will need refreshing soon.
+        </React.Fragment>
+      )
+        .icon(SPELLS.SAVAGE_ROAR_TALENT.icon)
+        .actual(`${formatPercentage(actual)}% uptime`)
+        .recommended(`>${formatPercentage(recommended)}% is recommended`);
+    });
   }
 
   statistic() {
-    const savageRoarUptime = this.selectedCombatant.getBuffUptime(SPELLS.SAVAGE_ROAR_TALENT.id) / this.owner.fightDuration;
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.SAVAGE_ROAR_TALENT.id} />}
-        value={`${formatPercentage(savageRoarUptime)} %`}
+        value={`${formatPercentage(this.uptime)}%`}
         label="Savage Roar uptime"
       />
     );
@@ -46,4 +54,4 @@ class savageRoarUptime extends Analyzer {
   statisticOrder = STATISTIC_ORDER.OPTIONAL(0);
 }
 
-export default savageRoarUptime;
+export default SavageRoarUptime;


### PR DESCRIPTION
Pulled out the suggestion thresholds for Feral's uptime trackers into getters so they'll be easily available to the checklist (#1883)
Also took the opportunity to add a little more detail to the suggestion texts.

![uptimes-01](https://user-images.githubusercontent.com/35700764/42728439-5188b024-87b2-11e8-8134-eb256ca3a932.png)
![uptimes-02](https://user-images.githubusercontent.com/35700764/42728440-51a26cda-87b2-11e8-97b2-d00e30fb5de3.png)
![uptimes-03](https://user-images.githubusercontent.com/35700764/42728441-51b9c204-87b2-11e8-9f65-4946d0892e7c.png)
