### PR TITLE
[BFA][Restoration Shaman] Nature's Guardian

### DIFF
--- a/src/Parser/Shaman/Restoration/CHANGELOG.js
+++ b/src/Parser/Shaman/Restoration/CHANGELOG.js
@@ -8,6 +8,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-07-15'),
+    changes: <React.Fragment>Added support for <SpellLink id={SPELLS.NATURES_GUARDIAN_TALENT.id} />.</React.Fragment>,
+    contributors: [niseko],
+  },
+  {
     date: new Date('2018-06-18'),
     changes: (
       <React.Fragment>Updated Restoration Shaman for Battle for Azeroth.<br />

--- a/src/Parser/Shaman/Restoration/CombatLogParser.js
+++ b/src/Parser/Shaman/Restoration/CombatLogParser.js
@@ -36,6 +36,7 @@ import CloudburstTotem from './Modules/Talents/CloudburstTotem';
 import Ascendance from './Modules/Talents/Ascendance';
 import Wellspring from './Modules/Talents/Wellspring';
 import HighTide from './Modules/Talents/HighTide';
+import NaturesGuardian from './Modules/Talents/NaturesGuardian';
 // Items
 import Restoration_Shaman_T21_2Set from './Modules/Items/T21_2Set';
 import Restoration_Shaman_T21_4Set from './Modules/Items/T21_4Set';
@@ -97,6 +98,7 @@ class CombatLogParser extends CoreCombatLogParser {
     ascendance: Ascendance,
     wellspring: Wellspring,
     highTide: HighTide,
+    naturesGuardian: NaturesGuardian,
 
     // Items:
     t21_2Set: Restoration_Shaman_T21_2Set,

--- a/src/Parser/Shaman/Restoration/Modules/Abilities.js
+++ b/src/Parser/Shaman/Restoration/Modules/Abilities.js
@@ -327,7 +327,7 @@ class Abilities extends CoreAbilities {
         },
         enabled: combatant.hasTalent(SPELLS.WIND_RUSH_TOTEM_TALENT.id),
         cooldown: 120,
-      }, 
+      },
       {
         spell: SPELLS.EARTHGRAB_TOTEM_TALENT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
@@ -337,7 +337,7 @@ class Abilities extends CoreAbilities {
         },
         enabled: combatant.hasTalent(SPELLS.EARTHGRAB_TOTEM_TALENT.id),
         cooldown: 30,
-      }, 
+      },
       {
         spell: SPELLS.ANCESTRAL_PROTECTION_TOTEM_TALENT,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
@@ -353,7 +353,7 @@ class Abilities extends CoreAbilities {
         cooldown: 1800,
       },
       {
-        spell: SPELLS.WIND_SHEAR, 
+        spell: SPELLS.WIND_SHEAR,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         timelineSortIndex: 80,
         cooldown: 12,
@@ -368,7 +368,7 @@ class Abilities extends CoreAbilities {
         cooldown: 30,
       },
       {
-        spell: SPELLS.EARTH_SHIELD_TALENT, 
+        spell: SPELLS.EARTH_SHIELD_TALENT,
         category: Abilities.SPELL_CATEGORIES.OTHERS,
         gcd: {
           base: 1500,
@@ -377,11 +377,11 @@ class Abilities extends CoreAbilities {
         timelineSortIndex: 80,
       },
       {
-        spell: SPELLS.TREMOR_TOTEM, 
+        spell: SPELLS.TREMOR_TOTEM,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 60,
         gcd: {
-          static: 1000, // totem GCD
+          base: 1000, // totem GCD but affected by Haste for some reason
         },
         timelineSortIndex: 80,
       },
@@ -407,6 +407,12 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 180,
         isUndetectable: true,
+      },
+      {
+        spell: SPELLS.NATURES_GUARDIAN_TALENT,
+        category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
+        cooldown: 45,
+        enabled: combatant.hasTalent(SPELLS.NATURES_GUARDIAN_TALENT.id),
       },
     ];
   }

--- a/src/Parser/Shaman/Restoration/Modules/Talents/NaturesGuardian.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/NaturesGuardian.js
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import { formatPercentage } from 'common/format';
+
+import Analyzer from 'Parser/Core/Analyzer';
+
+import CooldownThroughputTracker from '../Features/CooldownThroughputTracker';
+/**
+ * When your health is brought below 35%, you instantly heal for 20% of your maximum health.
+ * Cannot occur more than once every 45 sec.
+ * 
+ * As this talent has no cast event, but you should still be able to see it on the timeline,
+ * this module creates that event whenever this talent heals the player.
+ */
+class NaturesGuardian extends Analyzer {
+  static dependencies = {
+    cooldownThroughputTracker: CooldownThroughputTracker,
+  };
+  healing = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.NATURES_GUARDIAN_TALENT.id);
+  }
+
+  on_byPlayer_heal(event) {
+    const spellId = event.ability.guid;
+
+    if (spellId !== SPELLS.NATURES_GUARDIAN_HEAL.id) {
+      return;
+    }
+
+    const castEvent = {...event};
+    castEvent.ability.guid = SPELLS.NATURES_GUARDIAN_TALENT.id;
+    castEvent.type = 'cast';
+    this.owner.fabricateEvent(castEvent, event);
+
+    this.healing += event.amount;
+  }
+
+  get feeding() {
+    return this.cooldownThroughputTracker.getIndirectHealing(SPELLS.NATURES_GUARDIAN_HEAL.id);
+  }
+
+  subStatistic() {
+    return (
+      <div className="flex">
+        <div className="flex-main">
+          <SpellLink id={SPELLS.NATURES_GUARDIAN_TALENT.id} />
+        </div>
+        <div className="flex-sub text-right">
+          {formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing + this.feeding))} %
+        </div>
+      </div>
+    );
+  }
+}
+
+export default NaturesGuardian;

--- a/src/Parser/Shaman/Restoration/Modules/Talents/NaturesGuardian.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/NaturesGuardian.js
@@ -32,10 +32,14 @@ class NaturesGuardian extends Analyzer {
       return;
     }
 
-    const castEvent = {...event};
-    castEvent.ability.guid = SPELLS.NATURES_GUARDIAN_TALENT.id;
-    castEvent.type = 'cast';
-    this.owner.fabricateEvent(castEvent, event);
+    this.owner.fabricateEvent({
+      ...event,
+      type: 'cast',
+      ability: {
+        ...event.ability,
+        guid: SPELLS.NATURES_GUARDIAN_TALENT.id,
+      },
+    }, event);
 
     this.healing += event.amount;
   }

--- a/src/Parser/Shaman/Restoration/Modules/Talents/TalentStatisticBox.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/TalentStatisticBox.js
@@ -11,6 +11,7 @@ import Undulation from './Undulation';
 import Deluge from './Deluge';
 import EarthShield from './EarthShield';
 import EarthenWallTotem from './EarthenWallTotem';
+import NaturesGuardian from './NaturesGuardian';
 import Downpour from './Downpour';
 import FlashFlood from './FlashFlood';
 import CloudburstTotem from './CloudburstTotem';
@@ -27,6 +28,7 @@ class TalentStatisticBox extends Analyzer {
     deluge: Deluge,
     earthShield: EarthShield,
     earthenWallTotem: EarthenWallTotem,
+    naturesGuardian: NaturesGuardian,
     downpour: Downpour,
     flashFlood: FlashFlood,
     cloudburstTotem: CloudburstTotem,
@@ -50,6 +52,7 @@ class TalentStatisticBox extends Analyzer {
         {this.selectedCombatant.hasTalent(SPELLS.DELUGE_TALENT.id) ? this.deluge.subStatistic() : ''}
         {this.selectedCombatant.hasTalent(SPELLS.EARTH_SHIELD_TALENT.id) ? this.earthShield.subStatistic() : ''}
         {this.selectedCombatant.hasTalent(SPELLS.EARTHEN_WALL_TOTEM_TALENT.id) ? this.earthenWallTotem.subStatistic() : ''}
+        {this.selectedCombatant.hasTalent(SPELLS.NATURES_GUARDIAN_TALENT.id) ? this.naturesGuardian.subStatistic() : ''}
         {this.selectedCombatant.hasTalent(SPELLS.FLASH_FLOOD_TALENT.id) ? this.flashFlood.subStatistic() : ''}
         {this.selectedCombatant.hasTalent(SPELLS.DOWNPOUR_TALENT.id) ? this.downpour.subStatistic() : ''}
         {this.selectedCombatant.hasTalent(SPELLS.CLOUDBURST_TOTEM_TALENT.id) ? this.cloudburstTotem.subStatistic() : ''}


### PR DESCRIPTION
- Added support for the Nature's Guardian talent by creating a cast event for every heal event. Probably doesn't add much of value but might be interesting for some people.
- Changed Tremor Totem's GCD to be reduced by haste.

https://bfa.wowhead.com/spell=30884/natures-guardian
>When your health is brought below 35%, you instantly heal for 20% of your maximum health.  Cannot occur more than once every 45 sec.

![image](https://user-images.githubusercontent.com/2842471/42736822-c9f1f0c4-886c-11e8-89bb-6a1e6e7259f9.png)
![image](https://user-images.githubusercontent.com/2842471/42736826-d9864846-886c-11e8-83e3-e40ec57efe12.png) ![image](https://user-images.githubusercontent.com/2842471/42736832-e6710ce4-886c-11e8-93aa-1b8c0fcc43b2.png)
