### PR TITLE
Mage Compat Version

### DIFF
--- a/src/Parser/Mage/Arcane/CONFIG.js
+++ b/src/Parser/Mage/Arcane/CONFIG.js
@@ -10,7 +10,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list.
   contributors: [Sharrq],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '7.3.5',
+  patchCompatibility: '8.0.1',
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (

--- a/src/Parser/Mage/Frost/CONFIG.js
+++ b/src/Parser/Mage/Frost/CONFIG.js
@@ -9,7 +9,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list.
   contributors: [Sharrq, sref],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '8.0.0',
+  patchCompatibility: '8.0.1',
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more. If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <React.Fragment>


### PR DESCRIPTION
Updated the Frost Compat Version to match the other specs (8.0.1 instead of 8.0.0)

Updated Arcane to Compatible with 8.0.1

I did the Arcane updates a few weeks ago, forgot to update the version.