### PR TITLE
[Fire Mage] Pyroclasm Tuning

### DIFF
--- a/src/Parser/Mage/Fire/Modules/Features/Pyroclasm.js
+++ b/src/Parser/Mage/Fire/Modules/Features/Pyroclasm.js
@@ -8,7 +8,7 @@ import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import { formatMilliseconds, formatNumber, formatPercentage } from 'common/format';
 import getDamageBonus from 'Parser/Mage/Shared/Modules/GetDamageBonus';
 
-const BONUS_DAMAGE = 2.5;
+const BONUS_DAMAGE = 2.25;
 const CAST_BUFFER = 250;
 
 const debug = false;


### PR DESCRIPTION
Blizzard released another wave of tuning updates and Pyroclasm went from 250% bonus damage to 225%