### PR TITLE
[Feral] Remove single target Thrash suggestion

### DIFF
--- a/src/Parser/Druid/Feral/Modules/Spells/ThrashHitCount.js
+++ b/src/Parser/Druid/Feral/Modules/Spells/ThrashHitCount.js
@@ -48,17 +48,6 @@ class ThrashHitCount extends HitCountAoE {
         .actual(`${actual.toFixed(1)} uses per minute that hit nothing.`)
         .recommended(`${recommended} is recommended`);
     });
-
-    when(this.hitJustOneThresholds).addSuggestion((suggest, actual, recommended) => {
-      return suggest(
-        <React.Fragment>
-          You are using <SpellLink id={SPELLS.THRASH_FERAL.id} /> against a single target. If there's only one target in range you'll do more damage by using <SpellLink id={SPELLS.SHRED.id} /> instead.
-        </React.Fragment>
-      )
-        .icon(SPELLS.THRASH_FERAL.icon)
-        .actual(`${actual.toFixed(1)} uses per minute that hit just one target.`)
-        .recommended(`${recommended} is recommended`);
-    });
   }
 
   statisticOrder = STATISTIC_ORDER.OPTIONAL(11);


### PR DESCRIPTION
With pre-patch tuning using Thrash on a single target is roughly damage-neutral with using Shred (varies a bit depending how much mastery and haste they have). It's a worthwhile damage gain with certain legendaries.

A new analyzer can be added in the future to find exactly when it's worth using based on the player's stats, but for now we should stop yelling at people for doing it.