### PR TITLE
[MMS Hunter] Fixed TraitsAndTalents Error 

### DIFF
--- a/src/Parser/Hunter/Marksmanship/CombatLogParser.js
+++ b/src/Parser/Hunter/Marksmanship/CombatLogParser.js
@@ -18,6 +18,7 @@ import Trueshot from './Modules/Spells/Trueshot';
 import LoneWolf from './Modules/Spells/LoneWolf';
 //Talents
 import AMurderOfCrows from '../Shared/Modules/Talents/AMurderOfCrows';
+import Barrage from '../Shared/Modules/Talents/Barrage';
 import Volley from './Modules/Talents/Volley';
 import ExplosiveShot from './Modules/Talents/ExplosiveShot';
 import LockAndLoad from './Modules/Talents/LockAndLoad';
@@ -95,6 +96,7 @@ class CombatLogParser extends CoreCombatLogParser {
     aMurderOfCrows: AMurderOfCrows,
     lockAndLoad: LockAndLoad,
     piercingShot: PiercingShot,
+    barrage: Barrage,
     masterMarksman: MasterMarksman,
     lethalShots: LethalShots,
     doubleTap: DoubleTap,

--- a/src/Parser/Hunter/Marksmanship/Modules/Features/TraitsAndTalents.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Features/TraitsAndTalents.js
@@ -38,7 +38,7 @@ class TraitsAndTalents extends Analyzer {
     return (
       <StatisticsListBox
         title="Traits and Talents"
-        tooltip="This provides an overview of the damage contributions of various talents and traits. This isn't meant as a way to 1:1 evaluate talents, as some talents bring other strengths to the table than pure damage. Sidewinders is the most obvious example of this for Marksmanship hunters."
+        tooltip="This provides an overview of the damage contributions of various talents and traits. This isn't meant as a way to 1:1 evaluate talents, as some talents bring other strengths to the table than pure damage."
       >
         {this.loneWolf.active && this.loneWolf.subStatistic()}
         {this.volley.active && this.volley.subStatistic()}


### PR DESCRIPTION
Fixed TraitsAndTalents error preventing the MMS analyzer from loading by adding the barrage module to CombatLogParser.js

Bug in question can currently be viewed here: https://wowanalyzer.com/report/cRPkKVbmZXMCzj1D/1-Heroic+Garothi+Worldbreaker+-+Kill+(2:57)/20-Kooniba

Additionally, I also removed a text reference to Sidewinders, a talent which no longer exists.