### PR TITLE
Penance Bugfix

### DIFF
--- a/src/Parser/Core/EventGrouper.js
+++ b/src/Parser/Core/EventGrouper.js
@@ -1,0 +1,44 @@
+/**
+ * Groups events based on a given timestamp threshold
+ * e.g.
+ *   { timestamp: 0 }, { timestamp: 100 }, { timestamp: 200 }, { timestamp: 300 }
+ * with a threshold of 100 would result in:
+ * 0: [ { timestamp: 0 }, { timestamp: 100 } ]
+ * 200: [ { timestamp: 200 }, { timestamp: 300 } ]
+ */
+
+export default class EventGrouper {
+  constructor(threshold) {
+    this.threshold = threshold;
+    this.cache = {};
+  }
+
+  [Symbol.iterator]() {
+    return Object.entries(this.cache).map(item => item[1])[Symbol.iterator]();
+  }
+
+  processEvent(event) {
+    const stemTimestamp = this.getStemTimestamp(event);
+    if (!stemTimestamp) {
+      this.addNewStemTimestamp(event);
+      return;
+    }
+
+    this.cache[stemTimestamp] = [
+      ...this.cache[stemTimestamp],
+      event,
+    ];
+  }
+
+  getStemTimestamp(event) {
+    return Object.keys(this.cache).map(Number).filter(this.withinThreshold(event.timestamp))[0] || null;
+  }
+
+  withinThreshold(timestamp) {
+    return (stemTimestamp) => (timestamp <= (stemTimestamp + this.threshold)) && (timestamp > stemTimestamp);
+  }
+
+  addNewStemTimestamp(event) {
+    this.cache[event.timestamp] = [event];
+  }
+}

--- a/src/Parser/Core/EventGrouper.test.js
+++ b/src/Parser/Core/EventGrouper.test.js
@@ -20,25 +20,27 @@ describe('EventGrouper', () => {
   });
 
   it('Gets a stem for a branch timestamp', () => {
-    const eventGrouper = new EventGrouper(100);
-    eventGrouper.processEvent({ timestamp: 0 });
+    const eventGrouper = new EventGrouper(200);
+    eventGrouper.processEvent({ timestamp: 1 });
 
     const stem = eventGrouper.getStemTimestamp({ timestamp: 99 });
 
-    expect(stem).toEqual("0");
+    expect(stem).toEqual(1);
   });
 
   it('Processes events correctly', () => {
     const eventGrouper = new EventGrouper(100);
-    const events = [ { timestamp: 0 }, { timestamp: 99 }, { timestamp: 101 }, { timestamp: 200 } ];
+    const events = [ { timestamp: 1 }, { timestamp: 99 }, { timestamp: 102 }, { timestamp: 200 } ];
     const eventProcessor = eventGrouper.processEvent.bind(eventGrouper);
 
     // Add the boys in
     events.forEach(eventProcessor);
 
-    expect(eventGrouper.cache[0][0]).toEqual({ timestamp: 0 });
-    expect(eventGrouper.cache[0][1]).toEqual({ timestamp: 99 });
-    expect(eventGrouper.cache[101][0]).toEqual({ timestamp: 101 });
-    expect(eventGrouper.cache[101][1]).toEqual({ timestamp: 200 });
+    console.log(eventGrouper.cache);
+
+    expect(eventGrouper.cache[1][0]).toEqual({ timestamp: 1 });
+    expect(eventGrouper.cache[1][1]).toEqual({ timestamp: 99 });
+    expect(eventGrouper.cache[102][0]).toEqual({ timestamp: 102 });
+    expect(eventGrouper.cache[102][1]).toEqual({ timestamp: 200 });
   });
 });

--- a/src/Parser/Core/EventGrouper.test.js
+++ b/src/Parser/Core/EventGrouper.test.js
@@ -1,0 +1,44 @@
+import EventGrouper from './EventGrouper';
+
+describe('EventGrouper', () => {
+  it('Adds a new stem event', () => {
+    const eventGrouper = new EventGrouper(0);
+
+    eventGrouper.addNewStemTimestamp({ timestamp: 420 });
+
+    expect(eventGrouper.cache[420]).toBeTruthy();
+  });
+
+  it('Checks for events within a threshold correctly', () => {
+    const eventGrouper = new EventGrouper(100);
+    const branch = 99;
+
+    const isStemOfBranch = eventGrouper.withinThreshold(branch);
+
+    expect(isStemOfBranch(0)).toBe(true);
+    expect(isStemOfBranch(300)).toBe(false);
+  });
+
+  it('Gets a stem for a branch timestamp', () => {
+    const eventGrouper = new EventGrouper(100);
+    eventGrouper.processEvent({ timestamp: 0 });
+
+    const stem = eventGrouper.getStemTimestamp({ timestamp: 99 });
+
+    expect(stem).toEqual("0");
+  });
+
+  it('Processes events correctly', () => {
+    const eventGrouper = new EventGrouper(100);
+    const events = [ { timestamp: 0 }, { timestamp: 99 }, { timestamp: 101 }, { timestamp: 200 } ];
+    const eventProcessor = eventGrouper.processEvent.bind(eventGrouper);
+
+    // Add the boys in
+    events.forEach(eventProcessor);
+
+    expect(eventGrouper.cache[0][0]).toEqual({ timestamp: 0 });
+    expect(eventGrouper.cache[0][1]).toEqual({ timestamp: 99 });
+    expect(eventGrouper.cache[101][0]).toEqual({ timestamp: 101 });
+    expect(eventGrouper.cache[101][1]).toEqual({ timestamp: 200 });
+  });
+});

--- a/src/Parser/Priest/Discipline/CHANGELOG.js
+++ b/src/Parser/Priest/Discipline/CHANGELOG.js
@@ -9,6 +9,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-07-18'),
+    changes: <React.Fragment>Now with 100% more Batle for Azeroth.</React.Fragment>,
+    contributors: [Reglitch],
+  },
+  {
     date: new Date('2018-04-08'),
     changes: <React.Fragment>Fixed a crash when using <ItemLink id={ITEMS.NERO_BAND_OF_PROMISES.id} />.</React.Fragment>,
     contributors: [Gebuz],

--- a/src/Parser/Priest/Discipline/CONFIG.js
+++ b/src/Parser/Priest/Discipline/CONFIG.js
@@ -9,7 +9,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list.
   contributors: [Oratio, Gao, Reglitch, Zerotorescue],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '7.3.5',
+  patchCompatibility: '8.0.1',
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (

--- a/src/Parser/Priest/Discipline/Modules/Spells/Penance.js
+++ b/src/Parser/Priest/Discipline/Modules/Spells/Penance.js
@@ -4,50 +4,42 @@ import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import Analyzer from 'Parser/Core/Analyzer';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import EventGrouper from 'Parser/Core/EventGrouper';
 
 const PENANCE_MINIMUM_RECAST_TIME = 3500; // Minimum duration from one Penance to Another
 
 class Penance extends Analyzer {
-  _previousPenanceTimestamp = null;
-  _penanceBoltHitNumber = 0;
-  _penanceBoltCastNumber = 0; // Used for the cast event, not the damage or healing ones
-  casts = 0;
+  _boltCount = 3;
   hits = 0;
+  eventGrouper = new EventGrouper(PENANCE_MINIMUM_RECAST_TIME);
+
+  constructor(...args) {
+    super(...args);
+
+    // Castigation Penance bolt count to 4 (from 3)
+    this._boltCount = this.selectedCombatant.hasTalent(
+      SPELLS.CASTIGATION_TALENT.id
+    )
+      ? 4
+      : 3;
+  }
 
   static isPenance = spellId =>
     spellId === SPELLS.PENANCE.id || spellId === SPELLS.PENANCE_HEAL.id;
 
-  isNewPenanceCast(ability, timestamp) {
-    if (!Penance.isPenance(ability.guid)) {
-      return false;
-    }
-
-    // Discount penances cast as the fight ends :)
-    if (this.owner.fight.end_time - timestamp <= PENANCE_MINIMUM_RECAST_TIME) {
-      return false;
-    }
-
-    return (
-      !this._previousPenanceTimestamp ||
-      timestamp - this._previousPenanceTimestamp > PENANCE_MINIMUM_RECAST_TIME
+  get missedBolts() {
+    return [...this.eventGrouper].reduce(
+      (missedBolts, cast) => missedBolts + (this._boltCount - cast.length),
+      0
     );
   }
 
-  on_byPlayer_cast(event) {
-    const spellId = event.ability.guid;
-    if (spellId !== SPELLS.PENANCE.id && spellId !== SPELLS.PENANCE_HEAL.id) {
-      return;
-    }
+  get casts() {
+    return [...this.eventGrouper].length;
+  }
 
-    // Guesstimate based on magic number
-    if (this.isNewPenanceCast(event.ability, event.timestamp)) {
-      this._previousPenanceTimestamp = event.timestamp;
-      this._penanceBoltCastNumber = 1;
-      this.casts += 1;
-      this._penanceBoltHitNumber = 0;
-    }
-
-    event.penanceBoltNumber = this._penanceBoltCastNumber;
+  get currentBoltNumber() {
+    return [...this.eventGrouper].slice(-1)[0].length - 1; // -1 here for legacy code
   }
 
   on_byPlayer_damage(event) {
@@ -55,9 +47,9 @@ class Penance extends Analyzer {
       return;
     }
 
-    event.penanceBoltNumber = this._penanceBoltHitNumber;
-    this._penanceBoltHitNumber += 1;
-    this.hits += 1;
+    this.eventGrouper.processEvent(event);
+
+    event.penanceBoltNumber = this.currentBoltNumber;
   }
 
   on_byPlayer_heal(event) {
@@ -65,28 +57,27 @@ class Penance extends Analyzer {
       return;
     }
 
-    event.penanceBoltNumber = this._penanceBoltHitNumber;
-    this._penanceBoltHitNumber += 1;
-    this.hits += 1;
+    this.eventGrouper.processEvent(event);
+
+    event.penanceBoltNumber = this.currentBoltNumber;
   }
 
   statistic() {
-    const hasCastigation = this.selectedCombatant.hasTalent(
-      SPELLS.CASTIGATION_TALENT.id
-    );
-
-    const missedPenanceTicks =
-      this.casts * (3 + (hasCastigation ? 1 : 0)) - this.hits;
-
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.PENANCE.id} />}
-        value={missedPenanceTicks}
-        label={(
-          <dfn data-tip={`Each Penance cast has 3 bolts (4 if you're using Castigation). You should try to let this channel finish as much as possible. You channeled Penance ${this.casts} times.`}>
+        value={this.missedBolts}
+        label={
+          (
+<dfn
+  data-tip={`Each Penance cast has 3 bolts (4 if you're using Castigation). You should try to let this channel finish as much as possible. You channeled Penance ${
+              this.casts
+            } times.`}
+          >
             Wasted Penance bolts
           </dfn>
-        )}
+)
+        }
       />
     );
   }


### PR DESCRIPTION
Penance has broken due to a regression in how the game handles Penance cast events. Previously, one was generated for each bolt, now this only seems to happen for heals. This PR will fix that and hopefully future proof it a little.

It's currently impossible to accurately account for Penance in the timeline because of this though :(

---

* Fixed Penance
* Updated the spec compatibility
* Added a changelog message to indicate bfa readiness
* Added a new EventGrouper tool that will automatically group incoming events to a previous stem event, this is based off a provided threshold. (It's also iterable, which is amazing)