### PR TITLE
[Core] Update legendary max level

### DIFF
--- a/src/Parser/Core/Modules/Items/LegendaryUpgradeChecker.js
+++ b/src/Parser/Core/Modules/Items/LegendaryUpgradeChecker.js
@@ -6,7 +6,7 @@ import ITEM_QUALITIES from 'common/ITEM_QUALITIES';
 import Analyzer from 'Parser/Core/Analyzer';
 import SUGGESTION_IMPORTANCE from 'Parser/Core/ISSUE_IMPORTANCE';
 
-const MAX_LEGENDARY_ILVL = 1000;
+const MAX_LEGENDARY_ILVL = 265;
 const debug = false;
 
 class LegendaryUpgradeChecker extends Analyzer {


### PR DESCRIPTION
After the squish item level 1000 legendaries are now 265.
This is slightly different than what would be expected, with other level 1000 items becoming 280. But it appears to be deliberate, and they cannot be upgraded above 265.