### PR TITLE
[Feral] Energy cap suggestion

### DIFF
--- a/src/Parser/Druid/Feral/Modules/ComboPoints/ComboPointDetails.js
+++ b/src/Parser/Druid/Feral/Modules/ComboPoints/ComboPointDetails.js
@@ -3,6 +3,8 @@ import Analyzer from 'Parser/Core/Analyzer';
 import Tab from 'Main/Tab';
 import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
 import { formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
 
 import ResourceBreakdown from './ComboPointBreakdown';
 import WastedPointsIcon from '../Images/feralComboPointIcon.png';
@@ -39,40 +41,55 @@ class ComboPointDetails extends Analyzer {
   }
   statisticOrder = STATISTIC_ORDER.CORE(6);
 
-  get suggestionThresholds() {
+  get wastingSuggestionThresholds() {
     return {
       actual: this.pointsWastedPerMinute,
       isGreaterThan: {
-        minor: 5,
-        average: 10,
-        major: 15,
+        minor: 0,
+        average: 5,
+        major: 10,
       },
       style: 'number',
     };
   }
 
-  suggestions(when) {
-    when(this.suggestionThresholds)
-      .addSuggestion((suggest, actual, recommended) => {
-        return suggest('You are wasting Combo Points. Try to use them and not let them cap and go to waste unless you\'re preparing for bursting adds etc.')
-          .icon('creatureportrait_bubble')
-          .actual(`${this.pointsWasted} Combo Points wasted (${this.pointsWastedPerMinute.toFixed(2)} per minute)`)
-          .recommended(`< ${recommended.toFixed(2)} Combo Points per minute wasted are recommended`);
-      });
-
-
+  get finishersBelowMaxSuggestionThresholds() {
     const maxComboPointCasts = Object.values(this.comboPointTracker.spendersObj).reduce((acc, spell) => acc + spell.spentByCast.filter(cps => cps === 5).length, 0);
     const totalCasts = this.comboPointTracker.spendersCasts;
     const maxComboPointPercent = maxComboPointCasts / totalCasts;
+    return {
+      actual: maxComboPointPercent,
+      isLessThan: {
+        minor: 0.95,
+        average: 0.90,
+        major: 0.85,
+      },
+      style: 'percentage',
+    };
+  }
 
-    when(maxComboPointPercent).isLessThan(0.95)
-      .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<React.Fragment>You are casting too many finishers with less that 5 combo points. Try to make sure that you are generating 5 combo points before casting a finisher unless it is an emergency.</React.Fragment>)
-          .icon('creatureportrait_bubble')
-          .actual(`${formatPercentage(actual)}% of finishers were cast with 5 combo points`)
-          .recommended(`>${formatPercentage(recommended)}% is recommended`)
-          .regular(recommended - 0.05).major(recommended - 0.10);
-      });
+  suggestions(when) {
+    when(this.wastingSuggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <React.Fragment>
+          You are wasting combo points. Avoid using generators once you reach the maximum.
+        </React.Fragment>
+      )
+        .icon('creatureportrait_bubble')
+        .actual(`${actual.toFixed(1)} combo points wasted per minute`)
+        .recommended('zero waste is recommended');
+    });
+
+    when(this.finishersBelowMaxSuggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <React.Fragment>
+          You are casting too many finishers with less that 5 combo points. Apart from <SpellLink id={SPELLS.SAVAGE_ROAR_TALENT.id} /> during the opening of a fight you should always use finishers with a full 5 combo points.
+        </React.Fragment>
+      )
+        .icon('creatureportrait_bubble')
+        .actual(`${formatPercentage(actual)}% of finishers were cast with 5 combo points`)
+        .recommended(`>${formatPercentage(recommended)}% is recommended`);
+    });
   }
 
   tab() {

--- a/src/Parser/Druid/Feral/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Druid/Feral/Modules/Features/AlwaysBeCasting.js
@@ -1,37 +1,11 @@
-import React from 'react';
-
 import CoreAlwaysBeCasting from 'Parser/Core/Modules/AlwaysBeCasting';
-
-import { formatPercentage } from 'common/format';
 import { STATISTIC_ORDER } from 'Main/StatisticBox';
 
 class AlwaysBeCasting extends CoreAlwaysBeCasting {
-
-  get suggestionThresholds() {
-    return {
-      actual: this.totalTimeWasted / this.owner.fightDuration,
-      isGreaterThan: {
-        minor: 0.45,
-        average: 0.40,
-        major: 0.30,
-      },
-      style: 'percentage',
-    };
-  }
-
   suggestions(when) {
-    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
-        return suggest(
-          <React.Fragment>
-            Your downtime can be improved. Although it's normal to need to wait for energy to regenerate, so long spent not using any abilities indicates you're missing out on chances to deal damage.
-          </React.Fragment>
-        )
-          .icon('spell_mage_altertime')
-          .actual(`${formatPercentage(actual)}% downtime`)
-          .recommended(`<${formatPercentage(recommended)}% is recommended`);
-      });
+    // override the suggestions from CoreAlwaysBeCasting so there's never any generated, but we still get the statistic.
+    return undefined;
   }
-
   statisticOrder = STATISTIC_ORDER.CORE(1);
 }
 

--- a/src/Parser/Druid/Feral/Modules/Features/EnergyCapTracker.js
+++ b/src/Parser/Druid/Feral/Modules/Features/EnergyCapTracker.js
@@ -103,14 +103,39 @@ class EnergyCapTracker extends RegenResourceCapTracker {
     return Math.floor(max);
   }
 
+  get suggestionThresholds() {
+    return {
+      actual: this.missedRegenPerMinute,
+      isGreaterThan: {
+        minor: 20,
+        average: 40,
+        major: 60,
+      },
+      style: 'number',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <React.Fragment>
+          You're allowing your energy to reach its cap. While at its maximum value you miss out on the energy that would have regenerated. Although it can be beneficial to let energy pool ready to be used at the right time, try to spend some before it reaches the cap.
+        </React.Fragment>
+      )
+        .icon('spell_shadow_shadowworddominate')
+        .actual(`${actual.toFixed(1)} regenerated energy lost per minute due to being capped.`)
+        .recommended(`<${recommended} is recommended.`);
+    });
+  }
+
   statistic() {
     return (
       <StatisticBox
         icon={<Icon icon="spell_shadow_shadowworddominate" alt="Capped Energy" />}
-        value={`${formatPercentage(this.cappedProportion)}%`}
-        label="Time with capped energy"
+        value={`${this.missedRegenPerMinute.toFixed(1)}`}
+        label="Wasted energy per minute from being capped"
         tooltip={`Although it can be beneficial to wait and let your energy pool ready to be used at the right time, you should still avoid letting it reach the cap.<br/>
-        You spent <b>${formatPercentage(this.cappedProportion)}%</b> of the fight at capped energy, causing you to miss out on <b>${this.missedRegenPerMinute.toFixed(1)}</b> energy per minute from regeneration.`}
+        You spent <b>${formatPercentage(this.cappedProportion)}%</b> of the fight at capped energy, causing you to miss out on a total of <b>${this.missedRegen.toFixed(0)}</b> energy from regeneration.`}
         footer={(
           <div className="statistic-bar">
             <div


### PR DESCRIPTION
This replaces the AlwaysBeCasting suggestion with one based on wasted energy due to being capped. The AlwaysBeCasting module isn't removed entirely as I think the statistic is still interesting for the user to see. Following on from a review comment the EnergyCapTracker statistic now displays the wasted energy as its primary value, as that is the most relevant measure. The time spent capped is still given by the green and red bars and as text in the tooltip.

Also added a small refactor of ComboPointDetails to make the thresholds available for use in a checklist.

![energy-cap-suggestion-01](https://user-images.githubusercontent.com/35700764/42854900-fead488e-8a35-11e8-88bb-fc96515ed167.png)
![energy-cap-suggestion-02](https://user-images.githubusercontent.com/35700764/42854759-5bffd868-8a35-11e8-9d43-8b213e144f8a.png)

Example logs:
Managing energy successfully https://www.warcraftlogs.com/reports/GmPYDcM73gQZCVy8/#fight=3&source=22
Not doing so well https://www.warcraftlogs.com/reports/w7cPaVWHCNZr3YqK#fight=last&source=16