### PR TITLE
[MMS] Hunter's Mark Bug Fix

### DIFF
--- a/src/Parser/Hunter/Marksmanship/Modules/Talents/HuntersMark.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Talents/HuntersMark.js
@@ -68,7 +68,7 @@ class HuntersMark extends Analyzer {
 
   on_byPlayer_damage(event) {
     const enemy = this.enemies.getEntity(event);
-    if (!enemy && !enemy.hasBuff(SPELLS.HUNTERS_MARK_TALENT.id, event.timestamp)) {
+    if (!enemy || !enemy.hasBuff(SPELLS.HUNTERS_MARK_TALENT.id, event.timestamp)) {
       return;
     }
     this.damage += getDamageBonus(event, HUNTERS_MARK_MODIFIER);


### PR DESCRIPTION
Critical Error preventing (as far as I can tell all) most logs using Hunter's Mark, stalling the analyzer. Non-existant enemy still has hasBuff called.

Example: https://wowanalyzer.com/report/AVca2P6YXfxmkdDQ/1/7

Hunter's Mark is still bugged if cast before the fight, but this is a quick fix to get the analyzer working.

Accidentally closed the previous PR, #1920