### PR TITLE
[WW] Adding EnergyCapTracker

### DIFF
--- a/src/Parser/Core/Modules/RegenResourceCapTracker.js
+++ b/src/Parser/Core/Modules/RegenResourceCapTracker.js
@@ -3,7 +3,7 @@ import Haste from 'Parser/Core/Modules/Haste';
 import HIT_TYPES from 'Parser/Core/HIT_TYPES';
 
 // turn on debug to find if there's inaccuracies, then verboseDebug to help track the cause.
-const debug = true;
+const debug = false;
 const verboseDebug = false;
 
 /*

--- a/src/Parser/Core/Modules/RegenResourceCapTracker.js
+++ b/src/Parser/Core/Modules/RegenResourceCapTracker.js
@@ -3,7 +3,7 @@ import Haste from 'Parser/Core/Modules/Haste';
 import HIT_TYPES from 'Parser/Core/HIT_TYPES';
 
 // turn on debug to find if there's inaccuracies, then verboseDebug to help track the cause.
-const debug = false;
+const debug = true;
 const verboseDebug = false;
 
 /*

--- a/src/Parser/Monk/Windwalker/CHANGELOG.js
+++ b/src/Parser/Monk/Windwalker/CHANGELOG.js
@@ -8,6 +8,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-07-19'),
+    changes: 'Added tracking of time spent at maximum energy.',
+    contributors: [Juko8],
+  },
+  {
     date: new Date('2018-06-16'),
     changes: <React.Fragment>Updated for 8.0 Battle for Azeroth prepatch. All artifact traits and related analysis removed. Bad <SpellLink id={SPELLS.BLACKOUT_KICK.id} icon /> casts statistic and suggestions has been replaced with statistic and suggestions on <SpellLink id={SPELLS.BLACKOUT_KICK.id} icon />'s new cooldown reductions mechanic </React.Fragment>,
     contributors: [Juko8],

--- a/src/Parser/Monk/Windwalker/CombatLogParser.js
+++ b/src/Parser/Monk/Windwalker/CombatLogParser.js
@@ -5,6 +5,7 @@ import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
 import Abilities from './Modules/Abilities';
 import CooldownThroughputTracker from './Modules/Features/CooldownThroughputTracker';
 import Checklist from './Modules/Features/Checklist';
+import EnergyCapTracker from './Modules/Features/EnergyCapTracker';
 // Chi
 import ChiDetails from './Modules/Chi/ChiDetails';
 import ChiTracker from './Modules/Chi/ChiTracker';
@@ -43,6 +44,7 @@ class CombatLogParser extends CoreCombatLogParser {
     abilities: Abilities,
     cooldownThroughputTracker: CooldownThroughputTracker,
     checklist: Checklist,
+    energyCapTracker: EnergyCapTracker,
 
     // Resources
     chiTracker: ChiTracker,

--- a/src/Parser/Monk/Windwalker/Modules/Features/EnergyCapTracker.js
+++ b/src/Parser/Monk/Windwalker/Modules/Features/EnergyCapTracker.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import Icon from 'common/Icon';
+import ITEMS from 'common/ITEMS';
+import SPELLS from 'common/SPELLS';
+import RESOURCE_TYPES from 'common/RESOURCE_TYPES';
+import { formatDuration, formatPercentage } from 'common/format';
+import StatisticBox, { STATISTIC_ORDER } from 'Main/StatisticBox';
+import RegenResourceCapTracker from 'Parser/Core/Modules/RegenResourceCapTracker';
+
+/**
+ * The analyzer is set up for BfA-prepatch where legendaries and other special 110 items are still
+ * active. You can disable the efects when checking accuracy on logs with players above 115.
+ */
+const debugIsPlayerAbove115 = false;
+
+// If you want to see debug information from RegenResourceCapTracker, you need to set debug there.
+
+const BASE_ENERGY_REGEN = 10;
+const ASCENSION_REGEN_MULTIPLIER = 1.1;
+
+const BASE_ENERGY_MAX = 100;
+const ASCENSION_ENERGY_MAX_ADDITION = 20;
+const STABILIZED_ENERGY_PENDANT_MAX_MULTIPLIER = 1.05;
+
+const RESOURCE_REFUND_ON_MISS = 0.8;
+
+/**
+ * Sets up RegenResourceCapTracker to accurately track the regenerating energy of a Windwalker monk.
+ * Taking into account the effect of buffs, talents, and items on the energy cost of abilities,
+ * the maximum energy amount, and the regeneration rate.
+ * Note that some cost reduction effects are already accounted for in the log.
+ */
+class EnergyCapTracker extends RegenResourceCapTracker {
+  static resourceType = RESOURCE_TYPES.ENERGY;
+  static baseRegenRate = BASE_ENERGY_REGEN;
+  static isRegenHasted = true;
+  static cumulativeEventWindow = 400;
+  static resourceRefundOnMiss = RESOURCE_REFUND_ON_MISS;
+
+  naturalRegenRate() {
+    let regen = super.naturalRegenRate();
+    if (this.selectedCombatant.hasTalent(SPELLS.ASCENSION_TALENT.id)) {
+      regen *= ASCENSION_REGEN_MULTIPLIER;
+    }
+    return regen;
+  }
+
+  currentMaxResource() {
+    let max = BASE_ENERGY_MAX;
+    if (!debugIsPlayerAbove115 && this.selectedCombatant.getItem(ITEMS.STABILIZED_ENERGY_PENDANT.id)) {
+      // BFA: Pendant's effect will stop working after level 115.
+      // multiplier is applied after the additions
+      max *= STABILIZED_ENERGY_PENDANT_MAX_MULTIPLIER;
+    }
+    if (this.selectedCombatant.hasTalent(SPELLS.ASCENSION_TALENT.id)) {
+      max += ASCENSION_ENERGY_MAX_ADDITION;
+    }
+    // What should be x.5 becomes x in-game.
+    return Math.floor(max);
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<Icon icon="spell_shadow_shadowworddominate" alt="Capped Energy" />}
+        value={`${formatPercentage(this.cappedProportion)}%`}
+        label="Time with capped energy"
+        tooltip={`Although it can be beneficial to wait and let your energy pool ready to be used at the right time, you should still avoid letting it reach the cap.<br/>
+        You spent <b>${formatPercentage(this.cappedProportion)}%</b> of the fight at capped energy, causing you to miss out on <b>${this.missedRegenPerMinute.toFixed(1)}</b> energy per minute from regeneration.`}
+        footer={(
+          <div className="statistic-bar">
+            <div
+              className="stat-healing-bg"
+              style={{ width: `${(1 - this.cappedProportion) * 100}%` }}
+              data-tip={`Not at capped energy for ${formatDuration((this.owner.fightDuration - this.atCap) / 1000)}`}
+            >
+              <img src="/img/sword.png" alt="Uncapped Energy" />
+            </div>
+
+            <div
+              className="remainder DeathKnight-bg"
+              data-tip={`At capped energy for ${formatDuration(this.atCap / 1000)}`}
+            >
+              <img src="/img/overhealing.png" alt="Capped Energy" />
+            </div>
+          </div>
+        )}
+        footerStyle={{ overflow: 'hidden' }}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.CORE(8);
+}
+export default EnergyCapTracker;


### PR DESCRIPTION
There didn't seem to be any errors when using discounted crackling jade lighting casts with the legendary chest, so skipping `getReducedCost`

![billede](https://user-images.githubusercontent.com/30317641/42928554-e3b29e8c-8b37-11e8-9b1d-132501cfbc19.png)