### PR TITLE
[Feral] HitCountAoE bug fix

### DIFF
--- a/src/Parser/Druid/Feral/Modules/Abilities.js
+++ b/src/Parser/Druid/Feral/Modules/Abilities.js
@@ -233,7 +233,7 @@ class Abilities extends CoreAbilities {
         timelineSortIndex: 44,
       },
       {
-        spell: SPELLS.SKULL_BASH_FERAL,
+        spell: [SPELLS.SKULL_BASH, SPELLS.SKULL_BASH_FERAL],
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         gcd: null,
         cooldown: 15,

--- a/src/Parser/Druid/Feral/Modules/FeralCore/HitCountAoE.js
+++ b/src/Parser/Druid/Feral/Modules/FeralCore/HitCountAoE.js
@@ -34,7 +34,7 @@ class HitCountAoE extends Analyzer {
 
   on_byPlayer_damage(event) {
     if ((this.constructor.spell.id !== event.ability.guid) || event.tick ||
-        ((event.timestamp - this.lastCastEvent.timestamp) > DAMAGE_WINDOW)) {
+        !this.lastCastEvent || ((event.timestamp - this.lastCastEvent.timestamp) > DAMAGE_WINDOW)) {
       // only interested in direct damage from the spellId shortly after cast
       return;
     }


### PR DESCRIPTION
Fixes a crash that can happen if damage from an AoE cast is reported before the cast. That ordering seems to only happen if the ability is used while stealthed, which is unusual player behaviour. Ideally would be fixed with a normalizer but just avoid crashing for now.
Example log which triggers the bug: https://www.warcraftlogs.com/reports/v7nLNGj3ACBY91kq/#fight=9&source=92

Also added the other spellId for Skull Bash to the abilities spellbook.