### PR TITLE
[Ret] Fixing Righteous Verdict and Whispers of the Nathrezim

### DIFF
--- a/src/Parser/Paladin/Retribution/Modules/Items/WhisperOfTheNathrezim.js
+++ b/src/Parser/Paladin/Retribution/Modules/Items/WhisperOfTheNathrezim.js
@@ -12,24 +12,27 @@ import calculateEffectiveDamage from 'Parser/Core/calculateEffectiveDamage';
 import ItemDamageDone from 'Interface/Others/ItemDamageDone';
 
 const WHISPER_OF_THE_NATHREZIM_MODIFIER = 0.15;
+const MINIMUM_TIME_BETWEEN_CASTS = 500; // Used to see if Divine Storm hits are from separate casts
 
 class WhisperOfTheNathrezim extends Analyzer {
+  previousCastTimestamp = null;
   damageDone = 0;
-  spenderInsideBuff = 0;
-  totalSpender = 0;
+  spendersInsideBuff = 0;
+  totalSpenders = 0;
 
   constructor(...args) {
     super(...args);
     this.active = this.selectedCombatant.hasBack(ITEMS.WHISPER_OF_THE_NATHREZIM.id);
   }
 
+  isNewDivineStormCast(timestamp) {
+    return !this.previousCastTimestamp || (timestamp - this.previousCastTimestamp) > MINIMUM_TIME_BETWEEN_CASTS;
+  }
+
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.TEMPLARS_VERDICT.id || spellId === SPELLS.DIVINE_STORM.id) {
-      if (this.selectedCombatant.hasBuff(SPELLS.WHISPER_OF_THE_NATHREZIM_BUFF.id)) {
-        this.spenderInsideBuff++;
-      }
-      this.totalSpender++;
+      this.totalSpenders++;
     }
   }
 
@@ -38,8 +41,16 @@ class WhisperOfTheNathrezim extends Analyzer {
     if (!this.selectedCombatant.hasBuff(SPELLS.WHISPER_OF_THE_NATHREZIM_BUFF.id)) {
       return;
     }
-    if (spellId === SPELLS.TEMPLARS_VERDICT_DAMAGE.id || spellId === SPELLS.DIVINE_STORM_DAMAGE.id) {
+    if (spellId === SPELLS.TEMPLARS_VERDICT_DAMAGE.id) {
+      this.spendersInsideBuff++;
       this.damageDone += calculateEffectiveDamage(event, WHISPER_OF_THE_NATHREZIM_MODIFIER);
+    }
+    else if (spellId === SPELLS.DIVINE_STORM_DAMAGE.id) {
+      this.damageDone += calculateEffectiveDamage(event, WHISPER_OF_THE_NATHREZIM_MODIFIER);
+      if (this.isNewDivineStormCast(event.timestamp)) {
+        this.spendersInsideBuff++;
+        this.previousCastTimestamp = event.timestamp;
+      }
     }
   }
 
@@ -50,7 +61,7 @@ class WhisperOfTheNathrezim extends Analyzer {
         <dfn data-tip={`
           The effective damage contributed by Whisper of the Nathrezim.<br/>
           Total Damage: ${formatNumber(this.damageDone)}<br/>
-          Spenders With Buff: ${formatNumber(this.spenderInsideBuff)} spenders (${formatPercentage(this.spenderInsideBuff / this.totalSpender)}%)`}>
+          Spenders With Buff: ${formatNumber(this.spendersInsideBuff)} spenders (${formatPercentage(this.spendersInsideBuff / this.totalSpenders)}%)`}>
           <ItemDamageDone amount={this.damageDone} />
         </dfn>
       ),
@@ -59,11 +70,11 @@ class WhisperOfTheNathrezim extends Analyzer {
 
   get suggestionThresholds() {
     return {
-      actual: this.spenderInsideBuff / this.totalSpender,
+      actual: this.spendersInsideBuff / this.totalSpenders,
       isLessThan: {
-        minor: 0.80,
-        average: 0.75,
-        major: 0.70,
+        minor: 0.70,
+        average: 0.65,
+        major: 0.60,
       },
       style: 'percentage',
     };

--- a/src/Parser/Paladin/Retribution/Modules/Talents/RighteousVerdict.js
+++ b/src/Parser/Paladin/Retribution/Modules/Talents/RighteousVerdict.js
@@ -24,12 +24,8 @@ class RighteousVerdict extends Analyzer {
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
-    if (spellId !== SPELLS.TEMPLARS_VERDICT.id) {
-      return;
-    }
-    this.totalSpenders++;
-    if (this.selectedCombatant.hasBuff(SPELLS.RIGHTEOUS_VERDICT_BUFF.id)) {
-      this.spendersInsideBuff++; 
+    if (spellId === SPELLS.TEMPLARS_VERDICT.id) {
+      this.totalSpenders++;
     }
   }
 
@@ -39,6 +35,7 @@ class RighteousVerdict extends Analyzer {
       return;
     }
     if (spellId === SPELLS.TEMPLARS_VERDICT_DAMAGE.id) {
+      this.spendersInsideBuff++; 
       this.damageDone += calculateEffectiveDamage(event, RIGHTEOUS_VERDICT_MODIFIER);
     }
   }
@@ -47,9 +44,9 @@ class RighteousVerdict extends Analyzer {
     return {
       actual: this.spendersInsideBuff / this.totalSpenders,
       isLessThan: {
-        minor: 0.80,
-        average: 0.75,
-        major: 0.70,
+        minor: 0.70,
+        average: 0.65,
+        major: 0.60,
       },
       style: 'percentage',
     };


### PR DESCRIPTION
For some reason, it wasn't checking for the buff correctly in `on_byPlayer_cast`, so it's been moved to check in `on_byPlayer_damage` instead. 

Suggestions thresholds have been changed by request of class experts. 