### PR TITLE
[Ret] Quick fix for Divine Purpose

### DIFF
--- a/src/Parser/Paladin/Retribution/Modules/Talents/DivinePurpose.js
+++ b/src/Parser/Paladin/Retribution/Modules/Talents/DivinePurpose.js
@@ -10,6 +10,7 @@ import Analyzer from 'Parser/Core/Analyzer';
 import StatisticBox, { STATISTIC_ORDER } from 'Interface/Others/StatisticBox';
 
 class DivinePurpose extends Analyzer {
+  divinePurposeProcs = 0;
 
   constructor(...args) {
     super(...args);
@@ -18,8 +19,18 @@ class DivinePurpose extends Analyzer {
     this.active = hasDivinePurpose || hasSoulOfTheHighlord;
   }
 
-  get divinePurposeProcs() {
-    return this.selectedCombatant.getBuffTriggerCount(SPELLS.DIVINE_PURPOSE_BUFF.id);
+  on_byPlayer_applybuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId === SPELLS.DIVINE_PURPOSE_BUFF.id) {
+      this.divinePurposeProcs++;
+    }
+  }
+
+  on_byPlayer_refreshbuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId === SPELLS.DIVINE_PURPOSE_BUFF.id) {
+      this.divinePurposeProcs++;
+    }
   }
 
   statistic() {


### PR DESCRIPTION
The statistic wasn't counting back to back procs with `getBuffTriggerCount` since that only tracks when the buff is applied and not when it's refreshed. 