### PR TITLE
[Feral] Update SavageRoarDmg to use a whitelist

### DIFF
--- a/src/Parser/Druid/Feral/CHANGELOG.js
+++ b/src/Parser/Druid/Feral/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-07-22'),
+    changes: <React.Fragment>Corrected <SpellLink id={SPELLS.SAVAGE_ROAR_TALENT.id} /> to only claim credit for damage from abilities it affects in 8.0.1</React.Fragment>,
+    contributors: [Anatta336],
+  },
+  {
     date: new Date('2018-07-15'),
     changes: <React.Fragment>Fixed bugs with combo generation from AoE attacks and detecting when <SpellLink id={SPELLS.PRIMAL_FURY.id} /> waste is unavoidable.</React.Fragment>,
     contributors: [Anatta336],

--- a/src/Parser/Druid/Feral/Modules/Talents/SavageRoarDmg.js
+++ b/src/Parser/Druid/Feral/Modules/Talents/SavageRoarDmg.js
@@ -11,8 +11,32 @@ import StatisticBox, { STATISTIC_ORDER } from 'Interface/Others/StatisticBox';
 import getDamageBonus from '../FeralCore/getDamageBonus';
 import { SAVAGE_ROAR_DAMAGE_BONUS } from '../../Constants';
 
+/**
+ * Since 8.0 only affects "cat" abilities.
+ * Tested and found not to be affected:
+ *  Damage procs from trinkets
+ *  DoT from bear's Thrash
+ *  Sunfire from balance affinity
+ * 
+ * Presumably would affect Brutal Slash, but they're rival talents.
+ */
+const AFFECTED_BY_SAVAGE_ROAR = [
+  SPELLS.MELEE.id,
+  SPELLS.SHRED.id,
+  SPELLS.RAKE.id,
+  SPELLS.RIP.id,
+  SPELLS.FEROCIOUS_BITE.id,
+  SPELLS.MOONFIRE_FERAL.id,
+  SPELLS.THRASH_FERAL.id,
+  SPELLS.CAT_SWIPE.id,
+  SPELLS.FERAL_FRENZY_TALENT.id,
+  SPELLS.MAIM.id,
+  SPELLS.MOONFIRE.id, // not really a cat ability, but is affected
+];
 
-
+/**
+ * "Finishing move that increases damage by 15% while in Cat Form."
+ */
 class SavageRoar extends Analyzer {
   static dependencies = {
     enemies: Enemies,
@@ -26,12 +50,12 @@ class SavageRoar extends Analyzer {
   }
 
   on_byPlayer_damage(event) {
-    if (event.targetIsFriendly) {
+    if (!AFFECTED_BY_SAVAGE_ROAR.includes(event.ability.guid) ||
+        !this.selectedCombatant.hasBuff(SPELLS.SAVAGE_ROAR_TALENT.id) ||
+        !this.selectedCombatant.hasBuff(SPELLS.CAT_FORM.id)) {
       return;
     }
-    if (this.selectedCombatant.hasBuff(SPELLS.SAVAGE_ROAR_TALENT.id, event.timestamp)) {
-      this.bonusDmg += getDamageBonus(event, SAVAGE_ROAR_DAMAGE_BONUS);
-    }
+    this.bonusDmg += getDamageBonus(event, SAVAGE_ROAR_DAMAGE_BONUS);
   }
 
   statistic() {
@@ -40,7 +64,7 @@ class SavageRoar extends Analyzer {
         icon={<SpellIcon id={SPELLS.SAVAGE_ROAR_TALENT.id} />}
         value={`${formatNumber(this.bonusDmg / this.owner.fightDuration * 1000)} DPS`}
         label="Damage contributed"
-        tooltip={`Your Savage Roar talent contributed ${formatNumber(this.bonusDmg)} total damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.bonusDmg))} %).`}
+        tooltip={`Your Savage Roar talent contributed <b>${formatNumber(this.bonusDmg)}</b> total damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.bonusDmg))}%).`}
       />
     );
   }


### PR DESCRIPTION
As with other "increases damage done" buffs in 8.0 Savage Roar no longer increases all damage, it now just affects the spec's abilities. The most noticeable difference is it no longer increases damage from trinkets.

A whitelist of abilities it's known to affect has been added. The check for damage against a friendly target can be removed as that was there to prevent damage from things like Blessing of Sacrifice being counted, but those are now excluded by the whitelist. Also added a check for the player being in cat form, as the buff has no effect when outside the form.

Example log with high amounts of damage from trinkets: https://www.warcraftlogs.com/reports/v7nLNGj3ACBY91kq/#fight=9&source=14&type=damage-done

Before:
![savage-roar-before](https://user-images.githubusercontent.com/35700764/43046055-7244f0c0-8dbb-11e8-8ad7-c23e7be71d17.png)

After:
![savage-roar-after](https://user-images.githubusercontent.com/35700764/43046056-725ebb04-8dbb-11e8-8474-49af84a6ce80.png)
