### PR TITLE
[MMS] Hunters Mark Damage Calculation Fix

### DIFF
--- a/src/Parser/Hunter/Marksmanship/Modules/Talents/HuntersMark.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Talents/HuntersMark.js
@@ -34,7 +34,6 @@ class HuntersMark extends Analyzer {
   recasts = 0;
   refunds = 0;
   precastConfirmed = false;
-  precast = false;
   markWindow = [];
   damageToTarget = [];
 
@@ -60,7 +59,6 @@ class HuntersMark extends Analyzer {
     const enemyID = event.targetID;
     if (this.precastConfirmed === false){
       this.precastConfirmed = true;
-      this.precast = true;
       this.damage = this.damageToTarget[enemyID];
       return;
     }

--- a/src/Parser/Hunter/Marksmanship/Modules/Talents/HuntersMark.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Talents/HuntersMark.js
@@ -33,6 +33,10 @@ class HuntersMark extends Analyzer {
   damage = 0;
   recasts = 0;
   refunds = 0;
+  precastConfirmed = false;
+  precast = false;
+  markWindow = [];
+  damageToTarget = [];
 
   constructor(...args) {
     super(...args);
@@ -46,6 +50,55 @@ class HuntersMark extends Analyzer {
     }
     this.casts++;
     this.timeOfCast = event.timestamp;
+  }
+
+  on_byPlayer_removedebuff(event){
+    const spellID = event.ability.guid;
+    if (spellID !== SPELLS.HUNTERS_MARK_TALENT.id){
+      return;
+    }
+    const enemyID = event.targetID;
+    if (this.precastConfirmed === false){
+      this.precastConfirmed = true;
+      this.precast = true;
+      this.damage = this.damageToTarget[enemyID];
+      return;
+    }
+    this.markWindow[enemyID].forEach(window => {
+      if (window.status === "active"){
+        window.status = "inactive";
+      }
+    });
+
+  }
+
+  on_byPlayer_applydebuff(event){
+    const spellID = event.ability.guid;
+    if (spellID !== SPELLS.HUNTERS_MARK_TALENT.id){
+      return;
+    }
+    const enemyID = event.targetID;
+    if (!this.markWindow[enemyID]){
+      this.markWindow[enemyID] = [];
+    }
+    this.markWindow[enemyID].push({status: "active", start: event.timestamp});
+  }
+
+  calculateMarkDamage(event, enemy){
+    if (this.precastConfirmed === false){
+      if (!this.damageToTarget[enemy.id]){
+        this.damageToTarget[enemy.id] = 0;
+      }
+      this.damageToTarget[enemy.id] += getDamageBonus(event, HUNTERS_MARK_MODIFIER);
+    }
+    if (!this.markWindow[enemy.id]){
+      return;
+    }
+    this.markWindow[enemy.id].forEach(window => {
+      if (window.start < event.timestamp && window.status === "active"){
+        this.damage += getDamageBonus(event, HUNTERS_MARK_MODIFIER);
+      }
+    });
   }
 
   on_byPlayer_removebuff(event) {
@@ -68,10 +121,10 @@ class HuntersMark extends Analyzer {
 
   on_byPlayer_damage(event) {
     const enemy = this.enemies.getEntity(event);
-    if (!enemy || !enemy.hasBuff(SPELLS.HUNTERS_MARK_TALENT.id, event.timestamp)) {
+    if (!enemy){
       return;
     }
-    this.damage += getDamageBonus(event, HUNTERS_MARK_MODIFIER);
+    this.calculateMarkDamage(event, enemy);
   }
 
   get uptimePercentage() {

--- a/src/Parser/Hunter/Marksmanship/Modules/Talents/HuntersMark.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Talents/HuntersMark.js
@@ -77,6 +77,9 @@ class HuntersMark extends Analyzer {
     if (spellID !== SPELLS.HUNTERS_MARK_TALENT.id){
       return;
     }
+    if (this.precastConfirmed === false){
+      this.precastConfirmed = true;
+    }
     const enemyID = event.targetID;
     if (!this.markWindow[enemyID]){
       this.markWindow[enemyID] = [];


### PR DESCRIPTION
Hunter's Mark is a permanent debuff that does not draw boss aggro, and as such it is often optimally cast before the fight has started. WCL's API seems unable to handle this, as hasBuff and stackHistory both have issues detecting this buff being active. The live implementation does not account for any damage done to a marked target if the target was marked before the fight began.

The fix for this involves determining whether the debuff was precast by looking for the first removedebuff event cast and (after ensuring that it comes before the first applydebuff cast of marked shot) determining the target, and then retroactively adding the marked damage done to that target to the marked damage total.

While this fixes the bug, it is my personal opinion that this seems like a bug in WCL's API, since WCL calculates uptime perfectly, but I think it would require further investigation by someone more familiar before bringing it up to Kihra.