### PR TITLE
[BFA] [BrM] Last bit of brew cleanup, plus version bump

### DIFF
--- a/src/Parser/Monk/Brewmaster/CHANGELOG.js
+++ b/src/Parser/Monk/Brewmaster/CHANGELOG.js
@@ -8,6 +8,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-07-22'),
+    changes: <React.Fragment>Updated support for <ItemLink id={ITEMS.SOUL_OF_THE_GRANDMASTER.id} /> and temporarily disabled the <SpellLink id={SPELLS.MASTERY_ELUSIVE_BRAWLER.id} /> module pending new formula coefficients.</React.Fragment>,
+    contributors: [emallson],
+  },
+  {
     date: new Date('2018-07-18'),
     changes: <React.Fragment>Added support for <SpellLink id={SPELLS.LIGHT_BREWING_TALENT.id} />.</React.Fragment>,
     contributors: [emallson],

--- a/src/Parser/Monk/Brewmaster/CONFIG.js
+++ b/src/Parser/Monk/Brewmaster/CONFIG.js
@@ -14,7 +14,7 @@ export default {
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <React.Fragment>
-      Hello, and welcome to the Brewmaster Analyzer! This analyzer is maintained by <a href="//raider.io/characters/us/arthas/Eisenpelz"><code>emallson</code></a>, and there are currently no known issues.<br/>
+      Hello, and welcome to the Brewmaster Analyzer! This analyzer is maintained by <a href="//raider.io/characters/us/arthas/Eisenpelz"><code>emallson</code></a>, and there are currently no known issues.<br />
 
       If you have questions about the output, please ask in the <code>#brew_questions</code> channel of the <a href="http://discord.gg/peakofserenity">Peak of Serenity</a>. If you have theorycrafting questions or want to contribute, come say hi in <code>#craft-brewing</code>.
     </React.Fragment>

--- a/src/Parser/Monk/Brewmaster/CONFIG.js
+++ b/src/Parser/Monk/Brewmaster/CONFIG.js
@@ -9,16 +9,18 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list.
   contributors: [emallson],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '7.3.5',
+  patchCompatibility: '8.0.1',
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <React.Fragment>
-      This spec is maintained by <a href="//raider.io/characters/us/arthas/Eisenpelz"><code>emallson</code></a>. If you have implementation or theorycrafting questions, hit me up in the <code>#brewcraft</code> channel of the <a href="http://discord.gg/peakofserenity">Peak of Serenity</a> Discord server. For general help in evaluating your logs, use the <code>#brew_questions</code> channel.
+      Hello, and welcome to the Brewmaster Analyzer! This analyzer is maintained by <a href="//raider.io/characters/us/arthas/Eisenpelz"><code>emallson</code></a>, and there are currently no known issues.<br/>
+
+      If you have questions about the output, please ask in the <code>#brew_questions</code> channel of the <a href="http://discord.gg/peakofserenity">Peak of Serenity</a>. If you have theorycrafting questions or want to contribute, come say hi in <code>#craft-brewing</code>.
     </React.Fragment>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/wXPNHQqrjmVbafJL/38-Mythic+Garothi+Worldbreaker+-+Kill+(5:05)/12-Rabinn',
+  exampleReport: '/report/DYjprw1mTt4Gxnb9/13-Mythic+Argus+the+Unmaker+-+Kill+(8:23)/2-Pumpsx',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/Parser/Monk/Brewmaster/Modules/Core/MasteryValue.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/MasteryValue.js
@@ -140,6 +140,11 @@ class MasteryValue extends Analyzer {
   _hitCounts = {};
   _dodgeCounts = {};
 
+  constructor(...args) {
+    super(...args);
+    this.active = false; // temporarily disable this module until we get updated coefficients
+  }
+
   baseDodge(agility) {
     const tooltip = MONK_DODGE_COEFFS.tooltip.intercept + MONK_DODGE_COEFFS.tooltip.slope * (agility - MONK_DODGE_COEFFS.base_agi);
     return (tooltip * MONK_DODGE_COEFFS.diminished.C_d) / (tooltip + MONK_DODGE_COEFFS.diminished.k * MONK_DODGE_COEFFS.diminished.C_d) + MONK_DODGE_COEFFS.base_dodge;

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/HighTolerance.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/HighTolerance.js
@@ -2,6 +2,7 @@ import React from 'react';
 import SpellIcon from 'common/SpellIcon';
 import StatisticBox, { STATISTIC_ORDER } from 'Interface/Others/StatisticBox';
 import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
 import { formatPercentage, formatThousands } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
@@ -12,8 +13,12 @@ export const HIGH_TOLERANCE_HASTE = {
   [SPELLS.HEAVY_STAGGER_DEBUFF.id]: 0.15,
 };
 
+function hasHighTolerance(combatant) {
+  return combatant.hasTalent(SPELLS.HIGH_TOLERANCE_TALENT.id) || combatant.hasFinger(ITEMS.SOUL_OF_THE_GRANDMASTER.id);
+}
+
 function hasteFnGenerator(value) {
-  return { haste: combatant => combatant.hasTalent(SPELLS.HIGH_TOLERANCE_TALENT.id) ? value : 0.0 };
+  return { haste: combatant => hasHighTolerance(combatant) ? value : 0.0 };
 }
 
 export const HIGH_TOLERANCE_HASTE_FNS = {
@@ -56,7 +61,7 @@ class HighTolerance extends Analyzer {
 
   constructor(...args) {
     super(...args);
-    this.active = this.selectedCombatant.hasTalent(SPELLS.HIGH_TOLERANCE_TALENT.id);
+    this.active = hasHighTolerance(this.selectedCombatant);
   }
 
   on_toPlayer_applydebuff(event) {


### PR DESCRIPTION
Three small pieces:

1. Places that care about HT now also check for the talent ring.
2. Temporarily disable the mastery module (just `this.active = false`) until I get new coefficients in.
3. bump version + update example log + update description so people maybe stop asking questions in #craft-brewing.