### PR TITLE
[BrM] Updated Gift of the Ox handling to eliminate spurious warnings about missing spells

### DIFF
--- a/src/Parser/Monk/Brewmaster/CHANGELOG.js
+++ b/src/Parser/Monk/Brewmaster/CHANGELOG.js
@@ -8,6 +8,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-07-22'),
+    changes: <React.Fragment>Updated support for <ItemLink id={ITEMS.SOUL_OF_THE_GRANDMASTER.id} /> and temporarily disabled the <SpellLink id={SPELLS.MASTERY_ELUSIVE_BRAWLER.id} /> module pending new formula coefficients.</React.Fragment>,
+    contributors: [emallson],
+  },
+  {
     date: new Date('2018-07-18'),
     changes: <React.Fragment>Added support for <SpellLink id={SPELLS.LIGHT_BREWING_TALENT.id} />.</React.Fragment>,
     contributors: [emallson],

--- a/src/Parser/Monk/Brewmaster/CONFIG.js
+++ b/src/Parser/Monk/Brewmaster/CONFIG.js
@@ -14,7 +14,7 @@ export default {
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <React.Fragment>
-      Hello, and welcome to the Brewmaster Analyzer! This analyzer is maintained by <a href="//raider.io/characters/us/arthas/Eisenpelz"><code>emallson</code></a>, and there are currently no known issues.<br/>
+      Hello, and welcome to the Brewmaster Analyzer! This analyzer is maintained by <a href="//raider.io/characters/us/arthas/Eisenpelz"><code>emallson</code></a>, and there are currently no known issues.<br />
 
       If you have questions about the output, please ask in the <code>#brew_questions</code> channel of the <a href="http://discord.gg/peakofserenity">Peak of Serenity</a>. If you have theorycrafting questions or want to contribute, come say hi in <code>#craft-brewing</code>.
     </React.Fragment>

--- a/src/Parser/Monk/Brewmaster/CONFIG.js
+++ b/src/Parser/Monk/Brewmaster/CONFIG.js
@@ -9,16 +9,18 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list.
   contributors: [emallson],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '7.3.5',
+  patchCompatibility: '8.0.1',
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <React.Fragment>
-      This spec is maintained by <a href="//raider.io/characters/us/arthas/Eisenpelz"><code>emallson</code></a>. If you have implementation or theorycrafting questions, hit me up in the <code>#brewcraft</code> channel of the <a href="http://discord.gg/peakofserenity">Peak of Serenity</a> Discord server. For general help in evaluating your logs, use the <code>#brew_questions</code> channel.
+      Hello, and welcome to the Brewmaster Analyzer! This analyzer is maintained by <a href="//raider.io/characters/us/arthas/Eisenpelz"><code>emallson</code></a>, and there are currently no known issues.<br/>
+
+      If you have questions about the output, please ask in the <code>#brew_questions</code> channel of the <a href="http://discord.gg/peakofserenity">Peak of Serenity</a>. If you have theorycrafting questions or want to contribute, come say hi in <code>#craft-brewing</code>.
     </React.Fragment>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/wXPNHQqrjmVbafJL/38-Mythic+Garothi+Worldbreaker+-+Kill+(5:05)/12-Rabinn',
+  exampleReport: '/report/DYjprw1mTt4Gxnb9/13-Mythic+Argus+the+Unmaker+-+Kill+(8:23)/2-Pumpsx',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/Parser/Monk/Brewmaster/CombatLogParser.js
+++ b/src/Parser/Monk/Brewmaster/CombatLogParser.js
@@ -40,6 +40,7 @@ import SalsalabimsLostTunic from './Modules/Items/SalsalabimsLostTunic';
 // normalizers
 import IronskinBrewNormalizer from './Modules/Normalizers/IronskinBrew';
 import GarothiWorldbreakerMeleeNormalizer from './Modules/Normalizers/GarothiWorldbreakerMelee';
+import GiftOfTheOx from './Modules/Normalizers/GiftOfTheOx';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -88,6 +89,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // normalizers
     isbNormalizer: IronskinBrewNormalizer,
     garothi: GarothiWorldbreakerMeleeNormalizer,
+    gotox: GiftOfTheOx,
   };
 }
 

--- a/src/Parser/Monk/Brewmaster/Modules/Abilities.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Abilities.js
@@ -12,25 +12,12 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.KEG_SMASH,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         cooldown: haste => 8 / (1 + haste),
-        enabled: !combatant.hasShoulder(ITEMS.STORMSTOUTS_LAST_GASP.id),
+        charges: combatant.hasShoulder(ITEMS.STORMSTOUTS_LAST_GASP.id) ? 2 : 1,
         castEfficiency: {
           suggestion: true,
         },
         gcd: {
           static: 1000,
-        },
-      },
-      {
-        spell: SPELLS.KEG_SMASH,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        cooldown: haste => 8 / (1 + haste),
-        charges: 2,
-        enabled: combatant.hasShoulder(ITEMS.STORMSTOUTS_LAST_GASP.id),
-        castEfficiency: {
-          suggestion: true,
-        },
-        gcd: {
-          base: 1000,
         },
       },
       {

--- a/src/Parser/Monk/Brewmaster/Modules/Core/MasteryValue.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Core/MasteryValue.js
@@ -140,6 +140,11 @@ class MasteryValue extends Analyzer {
   _hitCounts = {};
   _dodgeCounts = {};
 
+  constructor(...args) {
+    super(...args);
+    this.active = false; // temporarily disable this module until we get updated coefficients
+  }
+
   baseDodge(agility) {
     const tooltip = MONK_DODGE_COEFFS.tooltip.intercept + MONK_DODGE_COEFFS.tooltip.slope * (agility - MONK_DODGE_COEFFS.base_agi);
     return (tooltip * MONK_DODGE_COEFFS.diminished.C_d) / (tooltip + MONK_DODGE_COEFFS.diminished.k * MONK_DODGE_COEFFS.diminished.C_d) + MONK_DODGE_COEFFS.base_dodge;

--- a/src/Parser/Monk/Brewmaster/Modules/Items/T20_2pc.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Items/T20_2pc.js
@@ -33,12 +33,15 @@ class T20_2pc extends Analyzer {
       this.brewCount += 1;
       this.hastCastNewBrew = true;
     }
-    if (GIFT_OF_THE_OX_SPELLS.includes(spellId)) {
-      this.lastOrb = event.timestamp;
-    }
     if (this.hastCastNewBrew && Math.abs(this.lastTrigger - this.lastOrb) <= SUMMON_LATENCY) {
       this.orbTriggeredBy2Pc += 1;
       this.hastCastNewBrew = false;
+    }
+  }
+
+  on_byPlayer_tick(event) {
+    if (GIFT_OF_THE_OX_SPELLS.includes(event.ability.guid)) {
+      this.lastOrb = event.timestamp;
     }
   }
 

--- a/src/Parser/Monk/Brewmaster/Modules/Items/T20_2pc.test.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Items/T20_2pc.test.js
@@ -1,21 +1,24 @@
 import { SimpleFight } from 'tests/Parser/Brewmaster/Fixtures/SimpleFight';
 import TestCombatLogParser from 'tests/TestCombatLogParser';
+import GiftOfTheOx from '../Normalizers/GiftOfTheOx';
 
 import T20_2pc from './T20_2pc';
 
 describe('Brewmaster.T20_2pc', () => {
   let parser;
   let item;
+  let gotox;
   beforeEach(() => {
     parser = new TestCombatLogParser();
+    gotox = new GiftOfTheOx(parser);
     item = new T20_2pc(parser);
   });
   it('tracks the number of orbs spawned by the T202pc', () => {
-    parser.processEvents(SimpleFight);
+    parser.processEvents(gotox.normalize(SimpleFight));
     expect(item.orbTriggeredBy2Pc).toBe(1);
   });
   it('tracks how many brews were used, each has a 40% chance to spawn an orb', () => {
-    parser.processEvents(SimpleFight);
+    parser.processEvents(gotox.normalize(SimpleFight));
     expect(item.brewCount).toBe(2);
   });
 });

--- a/src/Parser/Monk/Brewmaster/Modules/Items/T20_4pc.test.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Items/T20_4pc.test.js
@@ -3,26 +3,29 @@ import { SimpleFight } from 'tests/Parser/Brewmaster/Fixtures/SimpleFight';
 import TestCombatLogParser from 'tests/TestCombatLogParser';
 
 import StaggerFabricator from '../Core/StaggerFabricator';
+import GiftOfTheOx from '../Normalizers/GiftOfTheOx';
 import T20_4pc from './T20_4pc';
 
 describe('Brewmaster.T20_4pc', () => {
   let parser;
   let item;
   let fab;
+  let gotox;
   beforeEach(() => {
     parser = new TestCombatLogParser();
     parser.selectedCombatant.traitsBySpellId = { [SPELLS.STAGGERING_AROUND.id]: 0 };
     fab = new StaggerFabricator(parser);
+    gotox = new GiftOfTheOx(parser);
     item = new T20_4pc(parser);
     item.fab = fab;
     fab._hasTier20_4pc = true;
   });
   it('how many gift of the ox orbs were absorbed as a heal', () => {
-    parser.processEvents(SimpleFight);
+    parser.processEvents(gotox.normalize(SimpleFight));
     expect(item.orbsEaten).toBe(1);
   });
   it('how much stagger was reduced by absorbing the gift of the ox orbs', () => {
-    parser.processEvents(SimpleFight);
+    parser.processEvents(gotox.normalize(SimpleFight));
     expect(item.staggerSaved).toBe(23.450000000000003);
   });
 });

--- a/src/Parser/Monk/Brewmaster/Modules/Normalizers/GiftOfTheOx.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Normalizers/GiftOfTheOx.js
@@ -1,0 +1,20 @@
+import EventsNormalizer from 'Parser/Core/EventsNormalizer';
+import { GIFT_OF_THE_OX_SPELLS } from '../../Constants';
+
+/**
+ * Gift of the Ox orbs show up as 'casts' which messes with other things
+ * that expect casts to be *actual abilities.*
+ */
+class GiftOfTheOx extends EventsNormalizer {
+  normalize(events) {
+    return events.map(event => {
+      if(event.type === 'cast' && GIFT_OF_THE_OX_SPELLS.includes(event.ability.guid)) {
+        event.type = 'tick';
+        event.__modified = true;
+      }
+      return event;
+    });
+  }
+}
+
+export default GiftOfTheOx;

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/HighTolerance.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/HighTolerance.js
@@ -2,6 +2,7 @@ import React from 'react';
 import SpellIcon from 'common/SpellIcon';
 import StatisticBox, { STATISTIC_ORDER } from 'Interface/Others/StatisticBox';
 import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
 import { formatPercentage, formatThousands } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
@@ -12,8 +13,12 @@ export const HIGH_TOLERANCE_HASTE = {
   [SPELLS.HEAVY_STAGGER_DEBUFF.id]: 0.15,
 };
 
+function hasHighTolerance(combatant) {
+  return combatant.hasTalent(SPELLS.HIGH_TOLERANCE_TALENT.id) || combatant.hasFinger(ITEMS.SOUL_OF_THE_GRANDMASTER.id);
+}
+
 function hasteFnGenerator(value) {
-  return { haste: combatant => combatant.hasTalent(SPELLS.HIGH_TOLERANCE_TALENT.id) ? value : 0.0 };
+  return { haste: combatant => hasHighTolerance(combatant) ? value : 0.0 };
 }
 
 export const HIGH_TOLERANCE_HASTE_FNS = {
@@ -56,7 +61,7 @@ class HighTolerance extends Analyzer {
 
   constructor(...args) {
     super(...args);
-    this.active = this.selectedCombatant.hasTalent(SPELLS.HIGH_TOLERANCE_TALENT.id);
+    this.active = hasHighTolerance(this.selectedCombatant);
   }
 
   on_toPlayer_applydebuff(event) {


### PR DESCRIPTION
This is what the console looks like currently:
![screenshot from 2018-07-22 16-46-10](https://user-images.githubusercontent.com/4909458/43050177-ad3e9142-8dd2-11e8-95ff-32e26377dc9e.png)

this eliminates those messages by marking the casts as 'ticks' (which really, they aren't, but they also aren't really casts so who even knows).

Depends on PR #1956 for no other reason than I didn't switch to master before committing.