### PR TITLE
[Restoration Shaman] Hotfixes & Flash Flood bug fix

### DIFF
--- a/src/Parser/Shaman/Restoration/Modules/Talents/EarthShield.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/EarthShield.js
@@ -51,12 +51,7 @@ class EarthShield extends Analyzer {
       return;
     }
 
-    // earth shield bonus appears to be tripled for the riptide initial and chain heal healing
-    if((spellId === SPELLS.RIPTIDE.id && !event.tick) || spellId === SPELLS.CHAIN_HEAL.id) {
-      this.buffHealing += calculateEffectiveHealing(event, 0.32);
-    } else {
-      this.buffHealing += calculateEffectiveHealing(event, EARTHSHIELD_HEALING_INCREASE);
-    }
+    this.buffHealing += calculateEffectiveHealing(event, EARTHSHIELD_HEALING_INCREASE);
   }
 
   get uptime() {

--- a/src/Parser/Shaman/Restoration/Modules/Talents/FlashFlood.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/FlashFlood.js
@@ -7,6 +7,7 @@ import Analyzer from 'Parser/Core/Analyzer';
 import GlobalCooldown from 'Parser/Core/Modules/GlobalCooldown';
 
 const FLASH_FLOOD_HASTE = 0.2;
+const BUFFER_MS = 50;
 
 // All heal spells with cast time...
 const SPELLS_CONSUMING_FLASH_FLOOD = [
@@ -41,17 +42,17 @@ class FlashFlood extends Analyzer {
       return;
     }
 
-    const hasFlashFlood = this.selectedCombatant.hasBuff(SPELLS.FLASH_FLOOD_BUFF.id, event.timestamp);
-    if (!hasFlashFlood) {
-      return;
-    }
-
     this.beginCastTimestamp = event.timestamp;
     this.beginCastGlobalCooldown = this.globalCooldown.getGlobalCooldownDuration(spellId);
   }
 
   on_byPlayer_cast(event) {
     if (!this.beginCastTimestamp) {
+      return;
+    }
+
+    const hasFlashFlood = this.selectedCombatant.hasBuff(SPELLS.FLASH_FLOOD_BUFF.id, this.beginCastTimestamp+BUFFER_MS);
+    if (!hasFlashFlood) {
       return;
     }
 


### PR DESCRIPTION
- Removed Earth Shield's special cases:
![image](https://user-images.githubusercontent.com/2842471/43130527-2b6ae8c6-8f37-11e8-8a93-b70348bfc325.png)

- Flash Flood has a high chance to bug out, give you its buff correctly but immediately removes it again - for the hasBuff function that counts as having the buff so results of the Flash Flood module showed wrong results. This bug can happen up to 50% of the time.
- Changed Flash Flood's logic so that it doesn't catch bugged buffs anymore. 1ms should be enough to catch it but i checked for 50ms after cast start just to be safe.

**Example of the bug** (Healing Rain would think it consumed the FF buff):
![image](https://user-images.githubusercontent.com/2842471/43130699-85c4e0ec-8f37-11e8-8ff5-7630beb714af.png)
**Before fix:**
![image](https://user-images.githubusercontent.com/2842471/43130776-bc00b744-8f37-11e8-9a30-3e82610aa3b7.png)
**After fix**:
![image](https://user-images.githubusercontent.com/2842471/43130757-adf881ae-8f37-11e8-98cf-8b8878d179ae.png)

