### PR TITLE
[Arcane Mage] Arcane Charge Tracker

### DIFF
--- a/src/Parser/Mage/Arcane/CombatLogParser.js
+++ b/src/Parser/Mage/Arcane/CombatLogParser.js
@@ -7,6 +7,7 @@ import CooldownThroughputTracker from './Modules/Features/CooldownThroughputTrac
 import Channeling from './Modules/Features/Channeling';
 
 import ArcaneMissiles from './Modules/Features/ArcaneMissiles';
+import ArcaneChargeTracker from './Modules/Features/ArcaneChargeTracker';
 
 import ArcaneFamiliar from './Modules/Features/ArcaneFamiliar';
 
@@ -27,6 +28,7 @@ class CombatLogParser extends CoreCombatLogParser {
     channeling: Channeling,
     cancelledCasts: CancelledCasts,
     arcaneMissiles: ArcaneMissiles,
+    arcaneChargeTracker: ArcaneChargeTracker,
 
     // Talents
     arcaneFamiliar: ArcaneFamiliar,

--- a/src/Parser/Mage/Arcane/Modules/Features/ArcaneChargeTracker.js
+++ b/src/Parser/Mage/Arcane/Modules/Features/ArcaneChargeTracker.js
@@ -1,0 +1,44 @@
+import SPELLS from 'common/SPELLS';
+import { formatMilliseconds } from 'common/format';
+import Analyzer from 'Parser/Core/Analyzer';
+
+const debug = true;
+
+class ArcaneChargeTracker extends Analyzer {
+
+	charges = 0;
+
+	on_energize(event) {
+		const resourceType = event.resourceChangeType;
+		if (resourceType !== 16) {
+			return;
+		}
+			if (this.charges < 4) {
+				this.charges += event.resourceChange;
+				debug && console.log("Gained " + event.resourceChange + " charges from " + event.ability.name + ": " + this.charges + " total charges @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
+				if (this.charges > 4) {
+					debug && console.log("ERROR: Event caused overcapped charges. Adjusted charge count from " + this.charges + " to 4 @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
+					this.charges = 4;
+				}
+			} else if (this.charges < 4 && event.waste === 1) {
+				this.charges = 4;
+				debug && console.log("ERROR: Auto Corrected to 4 Charges @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
+			}
+	}
+
+	on_byPlayer_cast(event) {
+		const spellId = event.ability.guid;
+		if (spellId !== SPELLS.ARCANE_BARRAGE.id) {
+			return;
+		}
+		debug && console.log("Arcane Barrage cast with " + this.charges + " charges. Reset Charges to 0 @" + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
+		this.charges = 0;
+	}
+
+	on_toPlayer_death(event) {
+		this.charges = 0;
+		debug && console.log("Player Died. Reset Charges to 0. @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
+	}
+}
+
+export default ArcaneChargeTracker;


### PR DESCRIPTION
Accidentally deleted the branch for the previous PR so here is a new one.

This adds an arcane charge tracker since combat logs dont have the ability to see how many charges you have or list the times you lose arcane charges.

Adding just this for now to make sure its solid before i refer to it from other modules.

Towards #1961 