### PR TITLE
[Core] expandableStatisticBox z-index fix

### DIFF
--- a/src/Interface/Others/ExpandableStatisticBox.js
+++ b/src/Interface/Others/ExpandableStatisticBox.js
@@ -48,7 +48,7 @@ class ExpandableStatisticBox extends React.PureComponent {
 
   render() {
     return (
-      <div className="col-lg-3 col-md-4 col-sm-6 col-xs-12" style={{ zIndex: 1 }}>
+      <div className="col-lg-3 col-md-4 col-sm-6 col-xs-12" style={{ zIndex: this.state.expanded ? 2 : 1 }}>
         <div className="panel statistic-box expandable">
           <div className="panel-body">
             <div className="flex">


### PR DESCRIPTION
Bugged me for a while now since blood has quite a few expandable boxes already.
Simply increases the z-index for the boxes that are open.

**Old**
![image](https://user-images.githubusercontent.com/29842841/43306823-bb9c76a2-917c-11e8-91bd-1a8f5f27f98d.png)

**New**
![image](https://user-images.githubusercontent.com/29842841/43306839-d424b568-917c-11e8-954e-68c4714f1fe6.png)

