### PR TITLE
[MMS Hunter] Fixed Hunter's Mark Bug

### DIFF
--- a/src/Parser/Hunter/Marksmanship/Modules/Talents/HuntersMark.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Talents/HuntersMark.js
@@ -97,17 +97,18 @@ class HuntersMark extends Analyzer {
     this.markWindow[enemyID].push({ status: "active", start: event.timestamp });
   }
 
-  calculateMarkDamage(event, enemy) {
+  calculateMarkDamage(event) {
+    const enemyID = encodeTargetString(event.targetID, event.targetInstance);
     if (!this.precastConfirmed) {
-      if (!this.damageToTarget[enemy.id]) {
-        this.damageToTarget[enemy.id] = 0;
+      if (!this.damageToTarget[enemyID]) {
+        this.damageToTarget[enemyID] = 0;
       }
-      this.damageToTarget[enemy.id] += calculateEffectiveDamage(event, HUNTERS_MARK_MODIFIER);
+      this.damageToTarget[enemyID] += calculateEffectiveDamage(event, HUNTERS_MARK_MODIFIER);
     }
-    if (!this.markWindow[enemy.id]) {
+    if (!this.markWindow[enemyID]) {
       return;
     }
-    this.markWindow[enemy.id].forEach(window => {
+    this.markWindow[enemyID].forEach(window => {
       if (window.start < event.timestamp && window.status === "active") {
         this.damage += calculateEffectiveDamage(event, HUNTERS_MARK_MODIFIER);
       }
@@ -135,7 +136,7 @@ class HuntersMark extends Analyzer {
     if (!enemy) {
       return;
     }
-    this.calculateMarkDamage(event, enemy);
+    this.calculateMarkDamage(event);
   }
 
   get uptimePercentage() {


### PR DESCRIPTION
The Hunter's Mark module was broken when the enemyID variable was changed from `event.targetID ` to `encodeTargetString(event.targetID, event.targetInstance)` because calculateMarkDamage was still using enemy.id, which corresponded to event.targetID. Now the sourcing for the enemyID variable (used primarily as an array index) is standardized across the module. 

Example bug: 
WoWA: https://wowanalyzer.com/report/Ck7VZnyRXfc4YjAz/17-Mythic+Portal+Keeper+Hasabel+-+Kill+(5:22)/40-Blaz/events

WCL Hunter's Mark Uptime: https://www.warcraftlogs.com/reports/Ck7VZnyRXfc4YjAz/#fight=17&type=auras&spells=debuffs&hostility=1&ability=257284