### PR TITLE
[Assassination Rogue] Add tracking for Elaborate Planning talent

### DIFF
--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -346,6 +346,12 @@ export const Scaleable = {
 export const Cloake = {
   nickname: 'Cloake',
   github: 'adilasif',
+  discord: 'Cloake#9930',
+  mains: [{
+    name: 'Trixx',
+    spec: SPECS.ASSASSINATION_ROGUE,
+    link: 'https://worldofwarcraft.com/en-us/character/kelthuzad/Trixx',
+  }]
 };
 export const joshinator = {
   nickname: 'joshinator',

--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -351,7 +351,7 @@ export const Cloake = {
     name: 'Trixx',
     spec: SPECS.ASSASSINATION_ROGUE,
     link: 'https://worldofwarcraft.com/en-us/character/kelthuzad/Trixx',
-  }]
+  }],
 };
 export const joshinator = {
   nickname: 'joshinator',

--- a/src/Parser/Rogue/Assassination/CHANGELOG.js
+++ b/src/Parser/Rogue/Assassination/CHANGELOG.js
@@ -9,6 +9,11 @@ import { tsabo, Cloake, Hewhosmites, Zerotorescue } from 'CONTRIBUTORS';
 
 export default [
   {
+    date: new Date('2018-07-27'),
+    changes: <React.Fragment>Added <SpellLink id={SPELLS.ELABORATE_PLANNING_TALENT.id} /> support.</React.Fragment>,
+    contributors: [Cloake],
+  },
+  {
     date: new Date('2018-08-09'),
     changes: 'Added blindside support.',
     contributors: [tsabo],

--- a/src/Parser/Rogue/Assassination/CONFIG.js
+++ b/src/Parser/Rogue/Assassination/CONFIG.js
@@ -22,7 +22,7 @@ export default {
           <li>target values may be tuned incorrectly for things like energy waste or downtime. </li>
         </ul>
         <br />
-        If something is missing, incorrect, or inaccurate, please report it on <a href="https://github.com/WoWAnalyzer/WoWAnalyzer/issues/new">GitHub</a> or contact <kbd>@Cloake</kbd> on <a href="https://discord.gg/AxphPxU">Discord</a>.<br /><br />
+        If something is missing, incorrect, or inaccurate, please report it on <a href="https://github.com/WoWAnalyzer/WoWAnalyzer/issues/new">GitHub</a> or contact <kbd>@Cloake</kbd> on <a href="https://discord.gg/AxphPxU">Discord</a>.
       </Warning>
     </React.Fragment>
   ),

--- a/src/Parser/Rogue/Assassination/CONFIG.js
+++ b/src/Parser/Rogue/Assassination/CONFIG.js
@@ -16,9 +16,13 @@ export default {
   description: (
     <React.Fragment>
       <Warning>
-        Hey there! A good basis has been implemented for this spec, but it needs to be fleshed out more to provide all the feedback possible.<br /><br />
-
-        This spec needs a focused maintainer. If you want to give it a try, check <a href="https://github.com/WoWAnalyzer/WoWAnalyzer">GitHub</a> for more information.
+        Assassination rogue analysis isn't complete yet. Analysis should pick up most general mistakes, however:
+        <ul>
+          <li>there is no in-depth analysis for the Pre-Patch </li>
+          <li>target values may be tuned incorrectly for things like energy waste or downtime. </li>
+        </ul>
+        <br />
+        If something is missing, incorrect, or inaccurate, please report it on <a href="https://github.com/WoWAnalyzer/WoWAnalyzer/issues/new">GitHub</a> or contact <kbd>@Cloake</kbd> on <a href="https://discord.gg/AxphPxU">Discord</a>.<br /><br />
       </Warning>
     </React.Fragment>
   ),

--- a/src/Parser/Rogue/Assassination/CombatLogParser.js
+++ b/src/Parser/Rogue/Assassination/CombatLogParser.js
@@ -30,6 +30,7 @@ import ZoldyckFamilyTrainingShackles from './Modules/Legendaries/ZoldyckFamilyTr
 
 //Talents
 import Blindside from './Modules/Talents/Blindside';
+import ElaboratePlanning from './Modules/Talents/ElaboratePlanning';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -69,6 +70,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     //Talents
     blindside: Blindside,
+    elaboratePlanning: ElaboratePlanning,
   };
 }
 

--- a/src/Parser/Rogue/Assassination/Modules/Talents/ElaboratePlanning.js
+++ b/src/Parser/Rogue/Assassination/Modules/Talents/ElaboratePlanning.js
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import { formatPercentage } from 'common/format';
+import StatisticBox from 'Interface/Others/StatisticBox';
+import STATISTIC_ORDER from 'Interface/Others/STATISTIC_ORDER';
+
+class ElaboratePlanning extends Analyzer {
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.ELABORATE_PLANNING_TALENT.id);
+  }
+
+  get percentUptime() {
+    return this.selectedCombatant.getBuffUptime(SPELLS.ELABORATE_PLANNING_BUFF.id) / this.owner.fightDuration;
+  }
+
+  statistic() {
+    return (
+      <StatisticBox 
+        icon={<SpellIcon id={SPELLS.ELABORATE_PLANNING_TALENT.id} />}
+        title={<SpellLink id={SPELLS.ELABORATE_PLANNING_TALENT.id} icon={false} />}
+        value={`${formatPercentage(this.percentUptime)}%`}
+        label={(
+          <dfn data-tip="Ideally you should be aiming for somewhere around 80% uptime. This can generally be accomplished with minimal energy pooling.">
+            Elaborate Planning Uptime
+          </dfn>
+        )}
+      />
+    );
+  }
+
+  statisticOrder = STATISTIC_ORDER.OPTIONAL();
+}
+
+export default ElaboratePlanning;

--- a/src/Parser/Rogue/Assassination/Modules/Talents/ElaboratePlanning.js
+++ b/src/Parser/Rogue/Assassination/Modules/Talents/ElaboratePlanning.js
@@ -26,7 +26,7 @@ class ElaboratePlanning extends Analyzer {
         title={<SpellLink id={SPELLS.ELABORATE_PLANNING_TALENT.id} icon={false} />}
         value={`${formatPercentage(this.percentUptime)}%`}
         label={(
-          <dfn data-tip="Ideally you should be aiming for somewhere around 80% uptime. This can generally be accomplished with minimal energy pooling.">
+          <dfn data-tip="Ideally you should be aiming for over 80% uptime. This can generally be accomplished with minimal energy pooling.">
             Elaborate Planning Uptime
           </dfn>
         )}

--- a/src/common/SPELLS/ROGUE.js
+++ b/src/common/SPELLS/ROGUE.js
@@ -390,6 +390,11 @@ export default {
     name: 'Blindside',
     icon: 'ability_rogue_focusedattacks',
   },
+  ELABORATE_PLANNING_BUFF: {
+    id: 193641,
+    name: 'Elaborate Planning',
+    icon: 'inv_misc_map08',
+  },
 
   //Tier
   ASSA_ROGUE_T21_2SET_BONUS: {


### PR DESCRIPTION
Adds support for tracking Elaborate Planning buff uptime, including tooltip describing ideal uptime.
Adds Elaborate Planning buff to spells list.

Updates my entry in `CONTRIBUTORS.js`.