### PR TITLE
[Vengeance DH] Pain chart improvement

### DIFF
--- a/src/Parser/DemonHunter/Vengeance/Modules/PainChart/Pain.js
+++ b/src/Parser/DemonHunter/Vengeance/Modules/PainChart/Pain.js
@@ -156,7 +156,7 @@ class Pain extends React.PureComponent {
         const lastPain = lastSecFight === secIntoFight ? painBySecond[lastSecFight - 1] : painBySecond[lastSecFight];
         const spendResource = spell !== undefined ? ((spell.painCost !== undefined) ? spell.painCost : (spell.max_pain < lastPain ? spell.max_pain : lastPain)) : 0;
         abilitiesAll[`${event.ability.guid}_spend`].spent += spendResource;
-        abilitiesAll[`${event.ability.guid}_spend`].wasted += spell !== undefined && spell.max_pain !== undefined ? spell.max_pain - spendResource : 0;
+        abilitiesAll[`${event.ability.guid}_spend`].wasted += (spell !== undefined && spell.max_pain) !== undefined ? spell.max_pain - spendResource : 0;
       } else if (event.type === 'energize') {
         if (!abilitiesAll[`${event.ability.guid}_gen`]) {
           const spell = SPELLS[event.ability.guid];

--- a/src/Parser/DemonHunter/Vengeance/Modules/PainChart/Pain.js
+++ b/src/Parser/DemonHunter/Vengeance/Modules/PainChart/Pain.js
@@ -156,7 +156,7 @@ class Pain extends React.PureComponent {
         const lastPain = lastSecFight === secIntoFight ? painBySecond[lastSecFight - 1] : painBySecond[lastSecFight];
         const spendResource = spell !== undefined ? ((spell.painCost !== undefined) ? spell.painCost : (spell.max_pain < lastPain ? spell.max_pain : lastPain)) : 0;
         abilitiesAll[`${event.ability.guid}_spend`].spent += spendResource;
-        abilitiesAll[`${event.ability.guid}_spend`].wasted += (spell !== undefined && spell.max_pain) !== undefined ? spell.max_pain - spendResource : 0;
+        abilitiesAll[`${event.ability.guid}_spend`].wasted += spell.max_pain !== undefined ? spell.max_pain - spendResource : 0;
       } else if (event.type === 'energize') {
         if (!abilitiesAll[`${event.ability.guid}_gen`]) {
           const spell = SPELLS[event.ability.guid];

--- a/src/Parser/DemonHunter/Vengeance/Modules/PainChart/Pain.js
+++ b/src/Parser/DemonHunter/Vengeance/Modules/PainChart/Pain.js
@@ -154,9 +154,9 @@ class Pain extends React.PureComponent {
         }
         abilitiesAll[`${event.ability.guid}_spend`].casts += 1;
         const lastPain = lastSecFight === secIntoFight ? painBySecond[lastSecFight - 1] : painBySecond[lastSecFight];
-        const spendResource = (spell.painCost !== undefined) ? spell.painCost : (spell.max_pain < lastPain ? spell.max_pain : lastPain);
+        const spendResource = spell !== undefined ? ((spell.painCost !== undefined) ? spell.painCost : (spell.max_pain < lastPain ? spell.max_pain : lastPain)) : 0;
         abilitiesAll[`${event.ability.guid}_spend`].spent += spendResource;
-        abilitiesAll[`${event.ability.guid}_spend`].wasted += spell.max_pain ? spell.max_pain - spendResource : 0;
+        abilitiesAll[`${event.ability.guid}_spend`].wasted += spell !== undefined && spell.max_pain !== undefined ? spell.max_pain - spendResource : 0;
       } else if (event.type === 'energize') {
         if (!abilitiesAll[`${event.ability.guid}_gen`]) {
           const spell = SPELLS[event.ability.guid];

--- a/src/Parser/DemonHunter/Vengeance/Modules/PainChart/PainComponent.js
+++ b/src/Parser/DemonHunter/Vengeance/Modules/PainChart/PainComponent.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import SpellLink from 'common/SpellLink';
-import SpellIcon from 'common/SpellIcon';
 
 const PainComponent = ({ categories, abilities }) => {
   if (!abilities) {
@@ -29,7 +28,7 @@ const PainComponent = ({ categories, abilities }) => {
                 <tr key={name}>
                   <td style={{ width: '35%' }}>
                     <SpellLink id={ability.spellId} style={{ color: '#fff' }}>
-                      <SpellIcon id={ability.spellId} noLink /> {name}
+                      {name}
                     </SpellLink>
                   </td>
                   <td className="text-center" style={{ minWidth: 80 }}>

--- a/src/common/SPELLS/DEMON_HUNTER.js
+++ b/src/common/SPELLS/DEMON_HUNTER.js
@@ -158,12 +158,7 @@ export default {
     name: 'Imprison',
     icon: 'ability_demonhunter_imprison',
   },
-  FRACTURE: {
-    id: 209795,
-    painCost: 30,
-    name: "Fracture",
-    icon: "ability_creature_felsunder",
-  },
+
   // Havoc
   //T21 Bonus
   HAVOC_T21_2PC_BONUS: {

--- a/src/common/SPELLS/DEMON_HUNTER.js
+++ b/src/common/SPELLS/DEMON_HUNTER.js
@@ -158,7 +158,12 @@ export default {
     name: 'Imprison',
     icon: 'ability_demonhunter_imprison',
   },
-
+  FRACTURE: {
+    id: 209795,
+    painCost: 30,
+    name: "Fracture",
+    icon: "ability_creature_felsunder",
+  },
   // Havoc
   //T21 Bonus
   HAVOC_T21_2PC_BONUS: {


### PR DESCRIPTION
Pain chart won't break anymore with undefined spells with painCost or maxPain undefined.
Removed SpellIcon from pain chart breakdown. The img was duplicated, now that SpellLink has it own img.