### PR TITLE
Combined shear and fracture into one

### DIFF
--- a/src/Parser/DemonHunter/Vengeance/Modules/Abilities.js
+++ b/src/Parser/DemonHunter/Vengeance/Modules/Abilities.js
@@ -23,22 +23,14 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.FRACTURE_TALENT,
+        spell: [combatant.hasTalent(SPELLS.FRACTURE_TALENT.id) ? SPELLS.FRACTURE_TALENT : SPELLS.SHEAR],
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        enabled: combatant.hasTalent(SPELLS.FRACTURE_TALENT.id),
-        cooldown: haste => 4.5 / (1 + haste),
-        charges: 2,
+        cooldown:  combatant.hasTalent(SPELLS.FRACTURE_TALENT.id) ? haste => 4.5 / (1 + haste) : 0,
+        charges: combatant.hasTalent(SPELLS.FRACTURE_TALENT.id) ? 2 : 0,
         castEfficiency: {
-          suggestion: true,
+          suggestion: !!combatant.hasTalent(SPELLS.FRACTURE_TALENT.id),
           recommendedEfficiency: 0.90,
         },
-        gcd: {
-          base: 1500,
-        },
-      },
-      {
-        spell: SPELLS.SHEAR,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         gcd: {
           base: 1500,
         },

--- a/src/Parser/DemonHunter/Vengeance/Modules/Abilities.js
+++ b/src/Parser/DemonHunter/Vengeance/Modules/Abilities.js
@@ -49,6 +49,10 @@ class Abilities extends CoreAbilities {
         buffSpellId: SPELLS.METAMORPHOSIS_TANK.id,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         cooldown: 180,
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.50,
+        },
       },
       {
         spell: SPELLS.FIERY_BRAND,
@@ -65,7 +69,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.DEMON_SPIKES,
         buffSpellId: SPELLS.DEMON_SPIKES_BUFF.id,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
-        cooldown: haste => 15 / (1 + haste),
+        cooldown: haste => 20 / (1 + haste),
         charges: combatant.hasTalent(SPELLS.RAZOR_SPIKES_TALENT.id) ? 3 : 2,
       },
 
@@ -98,22 +102,21 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: 0.50,
-          extraSuggestion: <React.Fragment>This ability can be used more to soak burst instant damage when used with <SpellLink id={SPELLS.DEMON_SPIKES.id} /> for physical damage. </React.Fragment>,
+          recommendedEfficiency: 0.80,
         },
       },
       {
         spell: SPELLS.FELBLADE_TALENT,
         enabled: combatant.hasTalent(SPELLS.FELBLADE_TALENT.id),
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        cooldown: 15,
+        cooldown: haste => 15 / (1 + haste),
         gcd: {
           base: 1500,
         },
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.90,
-          extraSuggestion: <React.Fragment>This is a great Pain generator spell and it does a single target DPS increase by just 30 Pain per cast. The only moment you can delay it's cast is if you already have 5 unused <SpellLink id={SPELLS.SOUL_FRAGMENT.id} />. </React.Fragment>,
+          extraSuggestion: <React.Fragment>This is a great Pain generator spell. </React.Fragment>,
         },
       },
       {
@@ -126,8 +129,8 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: 0.75,
-          extraSuggestion: <React.Fragment>This is a great healing and AoE damage burst spell. It costs just 30 Pain and should be definitively used as soon as it gets available. The only moment you can delay it's cast is if your <SpellLink id={SPELLS.FIERY_BRAND.id} /> (with the <SpellLink id={SPELLS.FIERY_DEMISE.id} /> artifact trait) is almost available. </React.Fragment>,
+          recommendedEfficiency: 0.80,
+          extraSuggestion: <React.Fragment>This is a great healing and AoE damage burst spell. The only moment you can delay it's cast is if your <SpellLink id={SPELLS.FIERY_BRAND.id} /> (with the <SpellLink id={SPELLS.CHARRED_FLESH_TALENT.id} /> talent) is almost available. </React.Fragment>,
         },
       },
 


### PR DESCRIPTION
Shear is the default ability. It has no cd and no charges. Fully spamable.
Fracture is a talent that can be taken. It replaces shear.
It has a 4.5 sec cd that is affected by haste. And has 2 charges.
Also updated some abilities/efficiencies.

When they were separate it showed both spells in the abilities list. So one would always be 0. Combined them to avoid this. Logs to show how it works now:

Without fracture talent:
https://www.warcraftlogs.com/reports/p7LdrP8JXZqMNmaC/#fight=12&source=4
![image](https://user-images.githubusercontent.com/9600587/43424813-89281a42-941e-11e8-8ee6-2aff946ab510.png)

With fracture talent:
https://www.warcraftlogs.com/reports/TMwm6JfZdy43aLVY/#fight=1&source=12
![image](https://user-images.githubusercontent.com/9600587/43424850-a157d436-941e-11e8-9bf6-6e6804ab03d7.png)

How it looked when broken:
![image](https://user-images.githubusercontent.com/9600587/43424923-eb304548-941e-11e8-8e8f-b87ffef15c6b.png)
