### PR TITLE
[Arcane Mage] Fixes & Tweaks

### DIFF
--- a/src/Parser/Core/Modules/Haste.js
+++ b/src/Parser/Core/Modules/Haste.js
@@ -36,6 +36,7 @@ class Haste extends Analyzer {
     [SPELLS.ENRAGE.id]: 0.25, // Fury Warrior
     [SPELLS.FROTHING_BERSERKER.id]: 0.05, // Fury Warrior
     [SPELLS.CELERITY_OF_THE_WINDRUNNERS_BUFF.id]: 0.03, //3% haste hunter legendary
+    [SPELLS.QUICK_THINKER_BUFF.id]: 0.15,
     // Haste RATING buffs are handled by the StatTracker module
 
     // Boss abilities:

--- a/src/Parser/Mage/Arcane/Modules/ManaChart/ManaValues.js
+++ b/src/Parser/Mage/Arcane/Modules/ManaChart/ManaValues.js
@@ -1,13 +1,20 @@
 import Analyzer from 'Parser/Core/Analyzer';
+import DeathTracker from 'Parser/Core/Modules/DeathTracker';
 import RESOURCE_TYPES from 'common/RESOURCE_TYPES';
 import { formatPercentage, formatNumber } from 'common/format';
 
 class ManaValues extends Analyzer {
+  static dependencies = {
+		deathTracker: DeathTracker,
+  };
+  
   lowestMana = null; // start at `null` and fill it with the first value to account for users starting at a non-default amount for whatever reason
   endingMana = 0;
 
   maxMana = 110000;
   manaUpdates = [];
+
+  deadOnKill = false;
 
   on_byPlayer_cast(event) {
     if (event.classResources) {
@@ -34,6 +41,12 @@ class ManaValues extends Analyzer {
     }
   }
 
+  on_finished() {
+    if (!this.deathTracker.isAlive) {
+      this.deadOnKill = true;
+    }
+  }
+
   get manaLeftPercentage() {
     return this.endingMana/this.maxMana;
   }
@@ -48,8 +61,10 @@ class ManaValues extends Analyzer {
       style: 'percentage',
     };
   }
+  
   suggestions(when) {
-    when(this.suggestionThresholds.actual).isGreaterThan(this.suggestionThresholds.isGreaterThan.minor)
+    if (!this.deadOnKill) {
+      when(this.suggestionThresholds)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest('You had mana left at the end of the fight. You should be aiming to complete the fight with as little mana as possible regardless of whether your cooldowns will be coming up or not. So dont be afraid to burn your mana before the boss dies.')
           .icon('inv_elemental_mote_mana')
@@ -58,6 +73,7 @@ class ManaValues extends Analyzer {
           .regular(this.suggestionThresholds.isGreaterThan.average)
           .major(this.suggestionThresholds.isGreaterThan.major);
       });
+    }
   }
 }
 

--- a/src/common/SPELLS/MAGE.js
+++ b/src/common/SPELLS/MAGE.js
@@ -446,6 +446,11 @@ export default {
     name: 'Arcane Familiar',
     icon: 'ability_sorcererking_arcanemines',
   },
+  QUICK_THINKER_BUFF: {
+    id: 253299,
+    name: 'Quick Thinker',
+    icon: 'ability_mage_studentofthemind',
+  },
 
   //Tier Sets
   FROST_MAGE_T20_2SET_BONUS_BUFF: {


### PR DESCRIPTION
- Arcane Power has an Unacceptable List now instead of an Acceptable List.
- Moved 40% mana threshold to constant as per previous PR feedback
- Added check for Arcane Power to see if it was available when the boss died
- Modified ManaLevels to not show the ending mana suggestion if the player was dead when the boss died.
- Added Arcane 4pc tier to Haste

Towards #1961 