### PR TITLE
[Vengeance DH] Soul Tracker bugfix and Pain Chart update

### DIFF
--- a/src/Parser/DemonHunter/Vengeance/Modules/Features/SoulFragmentsTracker.js
+++ b/src/Parser/DemonHunter/Vengeance/Modules/Features/SoulFragmentsTracker.js
@@ -35,14 +35,6 @@ class SoulFragmentsTracker extends Analyzer {
       this.currentSouls -= 1;
     }
   }
-
-  on_byPlayer_removebuff(event) {
-    const spellId = event.ability.guid;
-    if (spellId === SPELLS.SOUL_FRAGMENT_STACK.id) {
-      this.soulsSpent += 1;
-      this.currentSouls -= 1;
-    }
-  }
 }
 
 export default SoulFragmentsTracker;

--- a/src/Parser/DemonHunter/Vengeance/Modules/PainChart/PainComponent.js
+++ b/src/Parser/DemonHunter/Vengeance/Modules/PainChart/PainComponent.js
@@ -15,10 +15,9 @@ const PainComponent = ({ categories, abilities }) => {
             <tr>
               <th>{categories[key]}</th>
               <th className="text-center">Casts</th>
-              <th className="text-center">{key === 'spent' ? <dfn data-tip="Approximately.">Spent</dfn> : ''}</th>
-              <th className="text-center">{key === 'generated' ? <dfn data-tip="Approximately.">Generated</dfn> : ''}</th>
-              <th className="text-center"><dfn data-tip="Approximately.">Wasted</dfn></th>
-              <th />
+              <th className="text-center">{key === 'spent' ? <dfn>Spent</dfn> : ''}</th>
+              <th className="text-center">{key === 'generated' ? <dfn>Generated</dfn> : ''}</th>
+              <th className="text-center"><dfn>Wasted</dfn></th>
             </tr>
             {abilities
               .filter(item => item.ability.category === categories[key])

--- a/src/common/SPELLS/DEMON_HUNTER.js
+++ b/src/common/SPELLS/DEMON_HUNTER.js
@@ -138,7 +138,7 @@ export default {
     id: 228477,
     name: 'Soul Cleave',
     icon: 'ability_demonhunter_soulcleave',
-    painCost: 43,
+    painCost: 30,
   },
   IMMOLATION_AURA: {
     id: 178740,


### PR DESCRIPTION
- Fixed a bug with the Soul Fragments Tracker
    - The removebuffstack and removebuff events were duplicated for 1 buff stack removal. It triggers removebuffstack and removebuff for the same soul fragment consume. So, we were counting them as +2 spent and -2 buff stacks, but they refer only to +1 spent and +1 buff stack.

Before:
![image](https://user-images.githubusercontent.com/12674637/43495129-b84495c8-950c-11e8-8dda-f0b1f6a55c3f.png)

After:
![image](https://user-images.githubusercontent.com/12674637/43495135-bdc71d5e-950c-11e8-8050-1f8c783ba315.png)


- Updated Soul Cleave painCost to Pain Chart breakdown.
- Removed wrong data-tip from Pain Chart (they are now exact and correct for pain costs, not 'approximately' anymore).