### PR TITLE
[Arcane Mage] Rule of Threes & Arcane Missiles/Clearcasting

### DIFF
--- a/src/Parser/Mage/Arcane/CHANGELOG.js
+++ b/src/Parser/Mage/Arcane/CHANGELOG.js
@@ -2,6 +2,11 @@ import { Sharrq } from 'CONTRIBUTORS';
 
 export default [
   {
+    date: new Date('2018-08-01'),
+    changes: 'Added Support for Rule of Threes and fixed Arcane Missiles Module. ',
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2018-07-28'),
     changes: 'Added Support for Arcane Power. ',
     contributors: [Sharrq],

--- a/src/Parser/Mage/Arcane/CombatLogParser.js
+++ b/src/Parser/Mage/Arcane/CombatLogParser.js
@@ -20,6 +20,8 @@ import MirrorImage from '../Shared/Modules/Features/MirrorImage';
 import ArcaneIntellect from '../Shared/Modules/Features/ArcaneIntellect';
 import RuneOfPower from '../Shared/Modules/Features/RuneOfPower';
 import ArcaneOrb from './Modules/Features/ArcaneOrb';
+import RuleOfThrees from './Modules/Features/RuleOfThrees';
+
 
 
 class CombatLogParser extends CoreCombatLogParser {
@@ -43,6 +45,7 @@ class CombatLogParser extends CoreCombatLogParser {
     arcaneIntellect: ArcaneIntellect,
     runeOfPower: RuneOfPower,
     arcaneOrb: ArcaneOrb,
+    ruleOfThrees: RuleOfThrees,
   };
 }
 

--- a/src/Parser/Mage/Arcane/Modules/Features/ArcaneMissiles.js
+++ b/src/Parser/Mage/Arcane/Modules/Features/ArcaneMissiles.js
@@ -19,7 +19,7 @@ class ArcaneMissiles extends Analyzer {
 		if (spellId !== SPELLS.ARCANE_BARRAGE.id) {
 			return;
 		}
-		if (this.selectedCombatant.hasBuff(SPELLS.ARCANE_MISSILES_BUFF.id,event.timestamp - 100)) {
+		if (this.selectedCombatant.hasBuff(SPELLS.CLEARCASTING_ARCANE.id,event.timestamp - 100)) {
 			debug && console.log("Arcane Barrage with Missiles Procs @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
 			this.barrageWithMissilesProc += 1;
 		}
@@ -44,7 +44,7 @@ class ArcaneMissiles extends Analyzer {
 	suggestions(when) {
 		when(this.suggestionThresholds)
 			.addSuggestion((suggest, actual, recommended) => {
-				return suggest(<React.Fragment>You cast <SpellLink id={SPELLS.ARCANE_BARRAGE.id} /> {this.barrageWithMissilesProc} times while you had <SpellLink id={SPELLS.ARCANE_MISSILES.id} /> procs available. Make sure you are using all of your missiles procs before casting Arcane Barrage.</React.Fragment>)
+				return suggest(<React.Fragment>You cast <SpellLink id={SPELLS.ARCANE_BARRAGE.id} /> {this.barrageWithMissilesProc} times while you had <SpellLink id={SPELLS.CLEARCASTING_ARCANE.id} /> procs available. Make sure you are using your Clearcasting procs before casting Arcane Barrage.</React.Fragment>)
 					.icon(SPELLS.ARCANE_MISSILES.icon)
 					.actual(`${formatPercentage(this.utilization)}% Utilization`)
 					.recommended(`${formatPercentage(recommended)}% is recommended`);

--- a/src/Parser/Mage/Arcane/Modules/Features/RuleOfThrees.js
+++ b/src/Parser/Mage/Arcane/Modules/Features/RuleOfThrees.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import { formatPercentage, formatMilliseconds } from 'common/format';
+import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
+import Analyzer from 'Parser/Core/Analyzer';
+
+const debug = false;
+
+class RuleOfThrees extends Analyzer {
+	static dependencies = {
+		abilityTracker: AbilityTracker,
+  };
+
+	barrageWithRuleOfThrees = 0;
+
+	constructor(...args) {
+    super(...args);
+	   this.active = this.selectedCombatant.hasTalent(SPELLS.RULE_OF_THREES_TALENT.id);
+  	}
+
+	on_byPlayer_cast(event) {
+		const spellId = event.ability.guid;
+		if (spellId !== SPELLS.ARCANE_BARRAGE.id) {
+			return;
+		}
+		if (this.selectedCombatant.hasBuff(SPELLS.RULE_OF_THREES_BUFF.id)) {
+			debug && console.log("Arcane Barrage with Rule of Threes Buff @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
+			this.barrageWithRuleOfThrees += 1;
+		}
+	}
+
+	get utilization() {
+		return 1 - (this.barrageWithRuleOfThrees / this.abilityTracker.getAbility(SPELLS.ARCANE_BARRAGE.id).casts);
+	}
+
+	get suggestionThresholds() {
+    return {
+      actual: this.utilization,
+      isLessThan: {
+        minor: 0.95,
+        average: 0.90,
+        major: 0.80,
+      },
+      style: 'percentage',
+    };
+  }
+
+	suggestions(when) {
+		when(this.suggestionThresholds)
+			.addSuggestion((suggest, actual, recommended) => {
+				return suggest(<React.Fragment>You cast <SpellLink id={SPELLS.ARCANE_BARRAGE.id} /> {this.barrageWithRuleOfThrees} times while you had the <SpellLink id={SPELLS.RULE_OF_THREES_BUFF.id} /> buff. This buff makes your next <SpellLink id={SPELLS.ARCANE_BLAST.id} /> or <SpellLink id={SPELLS.ARCANE_MISSILES.id} /> free after you gain your third Arcane Charge, so you should ensure that you use the buff before clearing your charges.</React.Fragment>)
+					.icon(SPELLS.RULE_OF_THREES_TALENT.icon)
+					.actual(`${formatPercentage(this.utilization)}% Utilization`)
+					.recommended(`${formatPercentage(recommended)}% is recommended`);
+			});
+	}
+}
+
+export default RuleOfThrees;

--- a/src/common/SPELLS/MAGE.js
+++ b/src/common/SPELLS/MAGE.js
@@ -451,6 +451,16 @@ export default {
     name: 'Quick Thinker',
     icon: 'ability_mage_studentofthemind',
   },
+  CLEARCASTING_ARCANE: {
+    id: 263725,
+    name: 'Clearcasting',
+    icon: 'spell_shadow_manaburn',
+  },
+  RULE_OF_THREES_BUFF: {
+    id: 264774,
+    name: 'Rule of Threes',
+    icon: 'spell_arcane_starfire',
+  },
 
   //Tier Sets
   FROST_MAGE_T20_2SET_BONUS_BUFF: {


### PR DESCRIPTION
Added support for Rule of Threes and fixed the Arcane Missiles Module to point to Clearcasting instead of "ArcaneMissiles!" which was removed

Towards #1961 