### PR TITLE
[Vengeance] Soul Cleave fix (small)

### DIFF
--- a/src/Parser/DemonHunter/Vengeance/Modules/Spells/SoulCleaveSoulsConsumed.js
+++ b/src/Parser/DemonHunter/Vengeance/Modules/Spells/SoulCleaveSoulsConsumed.js
@@ -6,10 +6,12 @@ import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
 
 import SoulFragmentsConsume from '../Statistics/SoulFragmentsConsume';
+import SoulFragmentsTracker from '../Features/SoulFragmentsTracker';
 
 class SoulCleaveSoulsConsumed extends Analyzer {
   static dependencies = {
     soulFragmentsConsume: SoulFragmentsConsume,
+    soulFragmentsTracker: SoulFragmentsTracker,
   };
   /* Feed The Demon talent is taken in defensive builds. In those cases you want to generate and consume souls as quickly
    as possible. So how you consume your souls down matter. If you dont take that talent your taking a more balanced
@@ -22,10 +24,11 @@ class SoulCleaveSoulsConsumed extends Analyzer {
     this.active = this.selectedCombatant.hasTalent(SPELLS.SPIRIT_BOMB_TALENT.id) && !this.selectedCombatant.hasTalent(SPELLS.FEED_THE_DEMON_TALENT.id);
   }
 
-  get suggestionThresholdsEfficiency() {
-    const soulsConsumedPercent = this.soulFragmentsConsume.soulCleaveSouls() / (this.soulFragmentsConsume.soulsGenerated - this.soulFragmentsConsume.soulsWasted);
+  get suggestionThresholdsEfficiency() {    
+    const totalAvailable = this.soulFragmentsTracker.soulsGenerated - this.soulFragmentsTracker.soulsWasted;
+    const fractionOnSoulCleave = (totalAvailable === 0) ? 0 : (this.soulFragmentsConsume.soulCleaveSouls() / totalAvailable);
     return {
-      actual: soulsConsumedPercent,
+      actual: fractionOnSoulCleave,
       isGreaterThan: {
         minor: 0.10,
         average: 0.15,

--- a/src/Parser/DemonHunter/Vengeance/Modules/Talent/SoulBarrier.js
+++ b/src/Parser/DemonHunter/Vengeance/Modules/Talent/SoulBarrier.js
@@ -76,8 +76,8 @@ class SoulBarrier extends Analyzer {
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<React.Fragment>Your uptime with <SpellLink id={SPELLS.SOUL_BARRIER_TALENT.id} /> can be improved.</React.Fragment>)
           .icon(SPELLS.SOUL_BARRIER_TALENT.icon)
-          .actual(`${formatPercentage(actual)}% Soull Barrier`)
-          .recommended(`<${formatPercentage(recommended)}% is recommended`);
+          .actual(`${formatPercentage(actual)}% Soul Barrier`)
+          .recommended(`>${formatPercentage(recommended)}% is recommended`);
       });
   }
 


### PR DESCRIPTION
The Soul Cleave suggestion was trying to use `SoulFragmentsConsume` to find `soulsGenerated` and `soulsWasted`, but those are actually properties of `SoulFragmentsTracker` so it was always producing `NaN`. Also added a division by zero check.

Corrected a couple of typos in the Soul Barrier suggestion (the uptime should be above the recommended value, not below.)