### PR TITLE
[Arcane Mage] AP Mana Utilization & Checklist Fixes

### DIFF
--- a/src/Parser/Mage/Arcane/CHANGELOG.js
+++ b/src/Parser/Mage/Arcane/CHANGELOG.js
@@ -2,6 +2,11 @@ import { Sharrq } from 'CONTRIBUTORS';
 
 export default [
   {
+    date: new Date('2018-08-10'),
+    changes: 'Added Check to see if the player went OOM during Arcane Power.',
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2018-08-09'),
     changes: 'Added Checklist ',
     contributors: [Sharrq],

--- a/src/Parser/Mage/Arcane/Modules/Checklist/Component.js
+++ b/src/Parser/Mage/Arcane/Modules/Checklist/Component.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
-import ResourceLink from 'common/ResourceLink';
-import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import Checklist from 'Parser/Core/Modules/Features/Checklist2';
 import Rule from 'Parser/Core/Modules/Features/Checklist2/Rule';
 import Requirement from 'Parser/Core/Modules/Features/Checklist2/Requirement';
@@ -94,10 +92,15 @@ class ArcaneMageChecklist extends React.PureComponent {
           {combatant.hasTalent(SPELLS.ARCANE_FAMILIAR_TALENT.id) && <Requirement name="Arcane Familiar Uptime" thresholds={thresholds.arcaneFamiliarUptime} />}
         </Rule>
         <Rule
-          name={<React.Fragment>Manage your <ResourceLink id={RESOURCE_TYPES.MANA.id} /> effectively</React.Fragment>}
-          description="If you have a large amount of mana left at the end of the fight that's mana you could have turned into healing. Try to use all your mana during a fight. A good rule of thumb is to try to match your mana level with the boss's health."
+          name={<React.Fragment>Manage your mana</React.Fragment>}
+          description={(
+            <React.Fragment>
+              The biggest aspect of playing Arcane properly is managing your mana effectively. Essentially your mana dictates how much damage you can do and therefore needs to be managed properly. Things such as running out of mana during <SpellLink id={SPELLS.ARCANE_POWER.id} />, letting your mana cap out at 100% for too long, or ending the fight with mana remaining all have negative effects on your DPS. 
+            </React.Fragment>
+          )}
         >
           <Requirement name="Mana left on boss kill" thresholds={thresholds.manaOnKill} />
+          <Requirement name="Arcane Power Mana Mgmt." thresholds={thresholds.arcanePowerManaUtilization} />
         </Rule>
         
         <PreparationRule thresholds={thresholds} />

--- a/src/Parser/Mage/Arcane/Modules/Checklist/Module.js
+++ b/src/Parser/Mage/Arcane/Modules/Checklist/Module.js
@@ -51,6 +51,7 @@ class Checklist extends Analyzer {
           arcaneFamiliarUptime: this.arcaneFamiliar.suggestionThresholds,
           arcaneOrbAverageHits: this.arcaneOrb.averageHitThresholds,
           arcanePowerCooldown: this.arcanePower.cooldownSuggestionThresholds,
+          arcanePowerManaUtilization: this.arcanePower.manaUtilizationThresholds,
           arcanePowerCasts: this.arcanePower.castSuggestionThresholds,
           arcanePowerOnKill: this.arcanePower.arcanePowerOnKillSuggestionThresholds,
           ruleOfThreesUsage: this.ruleOfThrees.suggestionThresholds,


### PR DESCRIPTION
Fixed the Mana Checklist Item so the description doesnt reference healing.

Also added Mana Management Checks for Arcane Power. The idea here is that the single worst thing you can do as an arcane mage is run out of mana during Arcane Power. That said, this analysis isnt perfect but I dont think it can get much better.

The gist of how it works is during AP if you cast Blast or Explosion, I do the following
- Calculate the estimated mana cost assuming you cast the same thing as you did previously (If you are casting Blast during AP then ill assume you are casting Blast next, likewise for explosion)
- Calculate how much mana you will have left after the current cast completes (the event object only has the base mana cost before the Arcane Charge multiplier, so i had to do it manually)
- Takes Overpowered mana cost reduction into account and the Rule of 3s buff
- If there is less than a second remaining in Arcane Power, you almost definitely arent gonna get another cast in anyway, so i ignore it if you are oom within a second of AP ending
- If you have less mana remaining than the estimated cost of the next spell, then i flag that as being at the very least "Dangerously Low" on mana if not actually OOM.  Its kinda hard to tell whether they actually went OOM because of mastery and mana regen and such, so the suggestion is worded to say they were dangerously low on mana or might have run out of mana since i cant be 100% sure.

Towards #1961 