### PR TITLE
[Vengeance DH] Soul Bomb tracker bugfix

### DIFF
--- a/src/Parser/DemonHunter/Vengeance/Modules/Features/SoulFragmentsTracker.js
+++ b/src/Parser/DemonHunter/Vengeance/Modules/Features/SoulFragmentsTracker.js
@@ -1,34 +1,51 @@
 import Analyzer from 'Parser/Core/Analyzer';
 import SPELLS from 'common/SPELLS/index';
 
+const MAX_SOUL_FRAGMENTS = 5;
+
 class SoulFragmentsTracker extends Analyzer {
 
+  // includes wasted generation
   soulsGenerated = 0;
+
+  // souls generated above the maximum 5 that can be held
   soulsWasted = 0;
+
   soulsSpent = 0;
   currentSouls = 0;
 
   soulsConsumedBySpell = [];
 
-  on_byPlayer_cast(event) {
+  on_byPlayer_changebuffstack(event) {
     const spellId = event.ability.guid;
-    if (spellId === SPELLS.SOUL_FRAGMENT.id) {
-      this.soulsGenerated += 1;
-      if (this.currentSouls < 5) {
-        this.currentSouls += 1;
-      } else {
-        this.soulsWasted += 1;
-      }
+    if (spellId !== SPELLS.SOUL_FRAGMENT_STACK.id) {
+      return;
     }
-  }
 
-  on_byPlayer_removebuffstack(event) {
-    const spellId = event.ability.guid;
-    if (spellId === SPELLS.SOUL_FRAGMENT_STACK.id) {
-      this.soulsSpent += 1;
-      this.currentSouls -= 1;
+    this.currentSouls = event.newStacks;
+
+    if (event.oldStacks > MAX_SOUL_FRAGMENTS) {
+      // transitioning from above the max means this isn't souls being spent, but an excess being corrected
+      return;
+    }
+
+    if (event.oldStacks > event.newStacks) {
+      // souls are being spent
+      const spent = event.oldStacks - event.newStacks;
+      this.soulsSpent += spent;
+      return;
+    }
+    
+    // souls are being generated
+    const gained = event.newStacks - event.oldStacks;
+    this.soulsGenerated += gained;
+    
+    if (event.newStacks > MAX_SOUL_FRAGMENTS) {
+      // generating souls above the max
+      this.soulsWasted += (event.newStacks - MAX_SOUL_FRAGMENTS);
     }
   }
 }
 
 export default SoulFragmentsTracker;
+export { MAX_SOUL_FRAGMENTS };

--- a/src/Parser/DemonHunter/Vengeance/Modules/Statistics/SoulFragmentsConsume.js
+++ b/src/Parser/DemonHunter/Vengeance/Modules/Statistics/SoulFragmentsConsume.js
@@ -7,6 +7,7 @@ import SPELLS from 'common/SPELLS/index';
 import SpellIcon from 'common/SpellIcon';
 
 import SoulFragmentsTracker from '../Features/SoulFragmentsTracker';
+import MAX_SOUL_FRAGMENTS from '../Features/SoulFragmentsTracker';
 
 const REMOVE_STACK_BUFFER = 100;
 
@@ -26,21 +27,26 @@ class SoulFragmentsConsume extends Analyzer {
       return;
     }
     if (!this.soulsConsumedBySpell[spellId]) {
-      this.soulsConsumedBySpell[spellId] = {name: 0, souls: 0};
+      this.soulsConsumedBySpell[spellId] = {
+        name: event.ability.name,
+        souls: 0,
+      };
     }
-    this.soulsConsumedBySpell[spellId].name = event.ability.name;
     this.castTimestamp = event.timestamp;
     this.trackedSpell = spellId;
   }
 
-  on_byPlayer_removebuffstack(event) {
+  on_byPlayer_changebuffstack(event) {
     const spellId = event.ability.guid;
-    if (spellId !== SPELLS.SOUL_FRAGMENT_STACK.id) {
+    if (spellId !== SPELLS.SOUL_FRAGMENT_STACK.id || // only interested in Soul Fragments
+        event.oldStacks < event.newStacks || // not interested in soul gains
+        event.oldStacks > MAX_SOUL_FRAGMENTS) { // not interested in overcap corrections
       return;
     }
-    if (this.castTimestamp !== undefined && event.timestamp - this.castTimestamp < REMOVE_STACK_BUFFER) {
-      this.soulsConsumedBySpell[this.trackedSpell].souls += 1;
-      this.totalSoulsConsumed += 1;
+    if (this.castTimestamp !== undefined && (event.timestamp - this.castTimestamp) < REMOVE_STACK_BUFFER) {
+      const consumed = event.oldStacks - event.newStacks;
+      this.soulsConsumedBySpell[this.trackedSpell].souls += consumed;
+      this.totalSoulsConsumed += consumed;
     }
   }
 

--- a/src/Parser/DemonHunter/Vengeance/Modules/Statistics/SoulFragmentsConsume.js
+++ b/src/Parser/DemonHunter/Vengeance/Modules/Statistics/SoulFragmentsConsume.js
@@ -40,11 +40,6 @@ class SoulFragmentsConsume extends Analyzer {
     }
     if (this.castTimestamp !== undefined && event.timestamp - this.castTimestamp < REMOVE_STACK_BUFFER) {
       this.soulsConsumedBySpell[this.trackedSpell].souls += 1;
-
-      console.log("Remove buff stack:");
-      console.log(this.trackedSpell);
-      console.log(this.soulsConsumedBySpell[this.trackedSpell].souls);
-
       this.totalSoulsConsumed += 1;
     }
   }

--- a/src/Parser/DemonHunter/Vengeance/Modules/Statistics/SoulFragmentsConsume.js
+++ b/src/Parser/DemonHunter/Vengeance/Modules/Statistics/SoulFragmentsConsume.js
@@ -26,8 +26,7 @@ class SoulFragmentsConsume extends Analyzer {
       return;
     }
     if (!this.soulsConsumedBySpell[spellId]) {
-      this.soulsConsumedBySpell[spellId] = {name: 0};
-      this.soulsConsumedBySpell[spellId] = {souls: 0};
+      this.soulsConsumedBySpell[spellId] = {name: 0, souls: 0};
     }
     this.soulsConsumedBySpell[spellId].name = event.ability.name;
     this.castTimestamp = event.timestamp;
@@ -41,16 +40,21 @@ class SoulFragmentsConsume extends Analyzer {
     }
     if (this.castTimestamp !== undefined && event.timestamp - this.castTimestamp < REMOVE_STACK_BUFFER) {
       this.soulsConsumedBySpell[this.trackedSpell].souls += 1;
+
+      console.log("Remove buff stack:");
+      console.log(this.trackedSpell);
+      console.log(this.soulsConsumedBySpell[this.trackedSpell].souls);
+
       this.totalSoulsConsumed += 1;
-      }
     }
+  }
 
   soulCleaveSouls() {
     if(this.soulsConsumedBySpell[SPELLS.SOUL_CLEAVE.id] === undefined) {
       return 0;
     }
     return this.soulsConsumedBySpell[SPELLS.SOUL_CLEAVE.id].souls;
-    }
+  }
 
   statistic() {
     const overcap= this.soulFragmentsTracker.soulsWasted;

--- a/src/Parser/DemonHunter/Vengeance/Modules/Talents/SpiritBombSoulsConsume.js
+++ b/src/Parser/DemonHunter/Vengeance/Modules/Talents/SpiritBombSoulsConsume.js
@@ -52,16 +52,6 @@ class SpiritBombSoulsConsume extends Analyzer {
     }
   }
 
-  on_byPlayer_removebuff(event) {
-    const spellId = event.ability.guid;
-    if (spellId !== SPELLS.SOUL_FRAGMENT_STACK.id) {
-      return;
-    }
-    if (event.timestamp - this.castTimestamp < MS_BUFFER) {
-      this.castSoulsConsumed += 1;
-    }
-  }
-
   countHits() {
     if (!this.soulsConsumedByAmount[this.castSoulsConsumed]) {
       this.soulsConsumedByAmount[this.castSoulsConsumed] = 1;
@@ -81,6 +71,11 @@ class SpiritBombSoulsConsume extends Analyzer {
   }
 
   get totalCasts() {
+
+    console.log("Total Casts:");
+    console.log(this.soulsConsumedByAmount);
+    console.log(this.soulsConsumedByAmount.reduce((total, casts) => total+casts, 0));
+
     return Object.values(this.soulsConsumedByAmount).reduce((total, casts) => total+casts, 0);
   }
 

--- a/src/Parser/DemonHunter/Vengeance/Modules/Talents/SpiritBombSoulsConsume.js
+++ b/src/Parser/DemonHunter/Vengeance/Modules/Talents/SpiritBombSoulsConsume.js
@@ -71,10 +71,6 @@ class SpiritBombSoulsConsume extends Analyzer {
   }
 
   get totalCasts() {
-
-    console.log("Total Casts:");
-    console.log((this.soulsConsumedByAmount[1]) + (this.soulsConsumedByAmount[2] * 2) + (this.soulsConsumedByAmount[3] * 3) + (this.soulsConsumedByAmount[4] * 4) + (this.soulsConsumedByAmount[5] * 5));
-
     return Object.values(this.soulsConsumedByAmount).reduce((total, casts) => total+casts, 0);
   }
 

--- a/src/Parser/DemonHunter/Vengeance/Modules/Talents/SpiritBombSoulsConsume.js
+++ b/src/Parser/DemonHunter/Vengeance/Modules/Talents/SpiritBombSoulsConsume.js
@@ -73,8 +73,7 @@ class SpiritBombSoulsConsume extends Analyzer {
   get totalCasts() {
 
     console.log("Total Casts:");
-    console.log(this.soulsConsumedByAmount);
-    console.log(this.soulsConsumedByAmount.reduce((total, casts) => total+casts, 0));
+    console.log((this.soulsConsumedByAmount[1]) + (this.soulsConsumedByAmount[2] * 2) + (this.soulsConsumedByAmount[3] * 3) + (this.soulsConsumedByAmount[4] * 4) + (this.soulsConsumedByAmount[5] * 5));
 
     return Object.values(this.soulsConsumedByAmount).reduce((total, casts) => total+casts, 0);
   }

--- a/src/Parser/DemonHunter/Vengeance/Modules/Talents/SpiritBombSoulsConsume.js
+++ b/src/Parser/DemonHunter/Vengeance/Modules/Talents/SpiritBombSoulsConsume.js
@@ -42,13 +42,15 @@ class SpiritBombSoulsConsume extends Analyzer {
     this.cast += 1;
   }
 
-  on_byPlayer_removebuffstack(event) {
+  on_byPlayer_changebuffstack(event) {
     const spellId = event.ability.guid;
-    if (spellId !== SPELLS.SOUL_FRAGMENT_STACK.id) {
+    if (spellId !== SPELLS.SOUL_FRAGMENT_STACK.id || event.oldStacks < event.newStacks) {
+      // only interested in lost stacks of souls
       return;
     }
     if (event.timestamp - this.castTimestamp < MS_BUFFER) {
-      this.castSoulsConsumed += 1;
+      const soulsConsumed = event.oldStacks - event.newStacks;
+      this.castSoulsConsumed += soulsConsumed;
     }
   }
 


### PR DESCRIPTION
- Soul Bomb tracker was showing wrong casts:
``` js
Soul Fragment buff removal counts +2 for the -1 stack with 1 buff stack
-1 for the on_byPlayer_removebuffstack(event)
-1 for the on_byPlayer_removebuff(event)
```
So, removing the on_byPlayer_removebuff(event) counter fixes the Soul Fragments consumed count.

Before:
![image](https://user-images.githubusercontent.com/12674637/43992729-f71a3614-9d58-11e8-9c86-20fb572051a1.png)
![image](https://user-images.githubusercontent.com/12674637/43992731-fc6f4ce4-9d58-11e8-8658-57054801a63d.png)

After:
![image](https://user-images.githubusercontent.com/12674637/43992734-089189ce-9d59-11e8-8ecc-3f8629da7d13.png)
![image](https://user-images.githubusercontent.com/12674637/43992738-0ada33a2-9d59-11e8-8c4c-4e808262ebc7.png)
