### PR TITLE
[Arcane Mage] Time Anomaly Mana Mgmt, Arcane Missiles, and Fixes

### DIFF
--- a/src/Parser/Mage/Arcane/CHANGELOG.js
+++ b/src/Parser/Mage/Arcane/CHANGELOG.js
@@ -2,6 +2,11 @@ import { Sharrq } from 'CONTRIBUTORS';
 
 export default [
   {
+    date: new Date('2018-08-11'),
+    changes: 'Added Arcane Missiles Module and Time Anomaly Mana Management.',
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2018-08-10'),
     changes: 'Added Check to see if the player went OOM during Arcane Power.',
     contributors: [Sharrq],

--- a/src/Parser/Mage/Arcane/CombatLogParser.js
+++ b/src/Parser/Mage/Arcane/CombatLogParser.js
@@ -14,6 +14,7 @@ import ArcaneCharges from './Normalizers/ArcaneCharges';
 
 import ArcaneChargeTracker from './Modules/Features/ArcaneChargeTracker';
 import ArcanePower from './Modules/Features/ArcanePower';
+import ArcaneMissiles from './Modules/Features/ArcaneMissiles';
 
 import ArcaneFamiliar from './Modules/Features/ArcaneFamiliar';
 
@@ -44,6 +45,7 @@ class CombatLogParser extends CoreCombatLogParser {
     cancelledCasts: CancelledCasts,
     arcaneChargeTracker: ArcaneChargeTracker,
     arcanePower: ArcanePower,
+    arcaneMissiles: ArcaneMissiles,
 
     // Talents
     arcaneFamiliar: ArcaneFamiliar,

--- a/src/Parser/Mage/Arcane/CombatLogParser.js
+++ b/src/Parser/Mage/Arcane/CombatLogParser.js
@@ -23,6 +23,7 @@ import ArcaneIntellect from '../Shared/Modules/Features/ArcaneIntellect';
 import RuneOfPower from '../Shared/Modules/Features/RuneOfPower';
 import ArcaneOrb from './Modules/Features/ArcaneOrb';
 import RuleOfThrees from './Modules/Features/RuleOfThrees';
+import TimeAnomaly from './Modules/Features/TimeAnomaly';
 
 
 
@@ -51,6 +52,7 @@ class CombatLogParser extends CoreCombatLogParser {
     runeOfPower: RuneOfPower,
     arcaneOrb: ArcaneOrb,
     ruleOfThrees: RuleOfThrees,
+    timeAnomaly: TimeAnomaly,
   };
 }
 

--- a/src/Parser/Mage/Arcane/Modules/Checklist/Component.js
+++ b/src/Parser/Mage/Arcane/Modules/Checklist/Component.js
@@ -101,6 +101,7 @@ class ArcaneMageChecklist extends React.PureComponent {
         >
           <Requirement name="Mana left on boss kill" thresholds={thresholds.manaOnKill} />
           <Requirement name="Arcane Power Mana Mgmt." thresholds={thresholds.arcanePowerManaUtilization} />
+          <Requirement name="Arcane Missiles only with Clearcasting" thresholds={thresholds.arcaneMissilesUtilization} />
           {combatant.hasTalent(SPELLS.TIME_ANOMALY_TALENT.id) && <Requirement name="Time Anomaly Mana Mgmt." thresholds={thresholds.timeAnomalyManaUtilization} />}
         </Rule>
         

--- a/src/Parser/Mage/Arcane/Modules/Checklist/Component.js
+++ b/src/Parser/Mage/Arcane/Modules/Checklist/Component.js
@@ -101,6 +101,7 @@ class ArcaneMageChecklist extends React.PureComponent {
         >
           <Requirement name="Mana left on boss kill" thresholds={thresholds.manaOnKill} />
           <Requirement name="Arcane Power Mana Mgmt." thresholds={thresholds.arcanePowerManaUtilization} />
+          {combatant.hasTalent(SPELLS.TIME_ANOMALY_TALENT.id) && <Requirement name="Time Anomaly Mana Mgmt." thresholds={thresholds.timeAnomalyManaUtilization} />}
         </Rule>
         
         <PreparationRule thresholds={thresholds} />

--- a/src/Parser/Mage/Arcane/Modules/Checklist/Module.js
+++ b/src/Parser/Mage/Arcane/Modules/Checklist/Module.js
@@ -13,6 +13,7 @@ import ArcaneOrb from '../Features/ArcaneOrb';
 import ArcanePower from '../Features/ArcanePower';
 import RuleOfThrees from '../Features/RuleOfThrees';
 import TimeAnomaly from '../Features/TimeAnomaly';
+import ArcaneMissiles from '../Features/ArcaneMissiles';
 import AlwaysBeCasting from '../Features/AlwaysBeCasting';
 import ManaValues from '../ManaChart/ManaValues';
 import ArcaneIntellect from '../../../Shared/Modules/Features/ArcaneIntellect';
@@ -31,6 +32,7 @@ class Checklist extends Analyzer {
     arcanePower: ArcanePower,
     ruleOfThrees: RuleOfThrees,
     timeAnomaly: TimeAnomaly,
+    arcaneMissiles: ArcaneMissiles,
     manaValues: ManaValues,
     arcaneIntellect: ArcaneIntellect,
     cancelledCasts: CancelledCasts,
@@ -58,6 +60,7 @@ class Checklist extends Analyzer {
           arcanePowerOnKill: this.arcanePower.arcanePowerOnKillSuggestionThresholds,
           ruleOfThreesUsage: this.ruleOfThrees.suggestionThresholds,
           timeAnomalyManaUtilization: this.timeAnomaly.manaUtilizationThresholds,
+          arcaneMissilesUtilization: this.arcaneMissiles.suggestionThresholds,
           manaOnKill: this.manaValues.suggestionThresholds,
           arcaneIntellectUptime: this.arcaneIntellect.suggestionThresholds,
           cancelledCasts: this.cancelledCasts.suggestionThresholds,

--- a/src/Parser/Mage/Arcane/Modules/Checklist/Module.js
+++ b/src/Parser/Mage/Arcane/Modules/Checklist/Module.js
@@ -12,6 +12,7 @@ import ArcaneFamiliar from '../Features/ArcaneFamiliar';
 import ArcaneOrb from '../Features/ArcaneOrb';
 import ArcanePower from '../Features/ArcanePower';
 import RuleOfThrees from '../Features/RuleOfThrees';
+import TimeAnomaly from '../Features/TimeAnomaly';
 import AlwaysBeCasting from '../Features/AlwaysBeCasting';
 import ManaValues from '../ManaChart/ManaValues';
 import ArcaneIntellect from '../../../Shared/Modules/Features/ArcaneIntellect';
@@ -29,6 +30,7 @@ class Checklist extends Analyzer {
     arcaneOrb: ArcaneOrb,
     arcanePower: ArcanePower,
     ruleOfThrees: RuleOfThrees,
+    timeAnomaly: TimeAnomaly,
     manaValues: ManaValues,
     arcaneIntellect: ArcaneIntellect,
     cancelledCasts: CancelledCasts,
@@ -55,6 +57,7 @@ class Checklist extends Analyzer {
           arcanePowerCasts: this.arcanePower.castSuggestionThresholds,
           arcanePowerOnKill: this.arcanePower.arcanePowerOnKillSuggestionThresholds,
           ruleOfThreesUsage: this.ruleOfThrees.suggestionThresholds,
+          timeAnomalyManaUtilization: this.timeAnomaly.manaUtilizationThresholds,
           manaOnKill: this.manaValues.suggestionThresholds,
           arcaneIntellectUptime: this.arcaneIntellect.suggestionThresholds,
           cancelledCasts: this.cancelledCasts.suggestionThresholds,

--- a/src/Parser/Mage/Arcane/Modules/Features/ArcaneFamiliar.js
+++ b/src/Parser/Mage/Arcane/Modules/Features/ArcaneFamiliar.js
@@ -42,6 +42,7 @@ class ArcaneFamiliar extends Analyzer {
 	statistic() {
     return (
 			<StatisticBox
+  position={STATISTIC_ORDER.CORE(100)}
   icon={<SpellIcon id={SPELLS.ARCANE_FAMILIAR_TALENT.id} />}
   value={`${formatPercentage(this.uptime, 0)} %`}
   label="Arcane Familiar Uptime"
@@ -49,7 +50,6 @@ class ArcaneFamiliar extends Analyzer {
 			/>
 		);
 	}
-	statisticOrder = STATISTIC_ORDER.CORE(12);
 }
 
 export default ArcaneFamiliar;

--- a/src/Parser/Mage/Arcane/Modules/Features/ArcaneMissiles.js
+++ b/src/Parser/Mage/Arcane/Modules/Features/ArcaneMissiles.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
-import SpellIcon from 'common/SpellIcon';
 import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
 import { formatPercentage, formatMilliseconds } from 'common/format';
-import StatisticBox, { STATISTIC_ORDER } from 'Interface/Others/StatisticBox';
 import Analyzer from 'Parser/Core/Analyzer';
 
 const debug = false;
@@ -52,18 +50,6 @@ class ArcaneMissiles extends Analyzer {
 					.recommended(`${formatPercentage(recommended)}% is recommended`);
 			});
 	}
-
-	statistic() {
-    return (
-			<StatisticBox
-  icon={<SpellIcon id={SPELLS.ARCANE_FAMILIAR_TALENT.id} />}
-  value={`${formatPercentage(this.uptime, 0)} %`}
-  label="Arcane Familiar Uptime"
-  tooltip={`Your Arcane Familiar was up for ${formatPercentage(this.uptime)}% of the fight. If your Arcane Familiar dies, make sure you recast it. If you are having trouble keeping the Arcane Familiar up for the entire fight, consider taking a different talent.`}
-			/>
-		);
-	}
-	statisticOrder = STATISTIC_ORDER.CORE(12);
 }
 
 export default ArcaneMissiles;

--- a/src/Parser/Mage/Arcane/Modules/Features/ArcaneMissiles.js
+++ b/src/Parser/Mage/Arcane/Modules/Features/ArcaneMissiles.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import SpellIcon from 'common/SpellIcon';
+import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
+import { formatPercentage, formatMilliseconds } from 'common/format';
+import StatisticBox, { STATISTIC_ORDER } from 'Interface/Others/StatisticBox';
+import Analyzer from 'Parser/Core/Analyzer';
+
+const debug = false;
+
+class ArcaneMissiles extends Analyzer {
+	static dependencies = {
+		abilityTracker: AbilityTracker,
+	};
+
+	castWithoutClearcasting = 0;
+
+	on_byPlayer_cast(event) {
+		const spellId = event.ability.guid;
+		if (spellId !== SPELLS.ARCANE_MISSILES.id) {
+			return;
+		}
+		if (!this.selectedCombatant.hasBuff(SPELLS.CLEARCASTING_ARCANE.id)) {
+			debug && console.log("Arcane Missiles cast without Clearcasting @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
+			this.castWithoutClearcasting += 1;
+		}
+	}
+
+	get utilization() {
+		return 1 - (this.castWithoutClearcasting / this.abilityTracker.getAbility(SPELLS.ARCANE_MISSILES.id).casts);
+	}
+
+	get suggestionThresholds() {
+    return {
+      actual: this.utilization,
+      isLessThan: {
+        minor: 1,
+        average: 0.95,
+        major: 0.90,
+      },
+      style: 'percentage',
+    };
+  }
+
+	suggestions(when) {
+		when(this.suggestionThresholds)
+			.addSuggestion((suggest, actual, recommended) => {
+				return suggest(<React.Fragment>You cast <SpellLink id={SPELLS.ARCANE_MISSILES.id} /> without <SpellLink id={SPELLS.CLEARCASTING_ARCANE.id} /> {this.castWithoutClearcasting} times. Arcane Missiles is a very expensive spell (more expensive than a 4 Charge Arcane Blast) and therefore it should only be cast when you have the Clearcasting buff which makes the spell free.</React.Fragment>)
+					.icon(SPELLS.ARCANE_MISSILES.icon)
+					.actual(`${formatPercentage(this.utilization)}% Uptime`)
+					.recommended(`${formatPercentage(recommended)}% is recommended`);
+			});
+	}
+
+	statistic() {
+    return (
+			<StatisticBox
+  icon={<SpellIcon id={SPELLS.ARCANE_FAMILIAR_TALENT.id} />}
+  value={`${formatPercentage(this.uptime, 0)} %`}
+  label="Arcane Familiar Uptime"
+  tooltip={`Your Arcane Familiar was up for ${formatPercentage(this.uptime)}% of the fight. If your Arcane Familiar dies, make sure you recast it. If you are having trouble keeping the Arcane Familiar up for the entire fight, consider taking a different talent.`}
+			/>
+		);
+	}
+	statisticOrder = STATISTIC_ORDER.CORE(12);
+}
+
+export default ArcaneMissiles;

--- a/src/Parser/Mage/Arcane/Modules/Features/ArcaneOrb.js
+++ b/src/Parser/Mage/Arcane/Modules/Features/ArcaneOrb.js
@@ -77,6 +77,7 @@ class ArcaneOrb extends Analyzer {
 	statistic() {
     return (
 			<StatisticBox
+  position={STATISTIC_ORDER.CORE(100)}
   icon={<SpellIcon id={SPELLS.ARCANE_ORB_TALENT.id} />}
   value={`${formatNumber(this.averageHitPerCast,2)}`}
   label="Arcane Orb hits per cast"
@@ -84,7 +85,6 @@ class ArcaneOrb extends Analyzer {
 			/>
 		);
 	}
-	statisticOrder = STATISTIC_ORDER.CORE(12);
 }
 
 export default ArcaneOrb;

--- a/src/Parser/Mage/Arcane/Modules/Features/ArcanePower.js
+++ b/src/Parser/Mage/Arcane/Modules/Features/ArcanePower.js
@@ -231,6 +231,7 @@ class ArcanePower extends Analyzer {
 	statistic() {
     return (
 			<StatisticBox
+  position={STATISTIC_ORDER.CORE(15)}
   icon={<SpellIcon id={SPELLS.ARCANE_POWER.id} />}
   value={(
     <span>
@@ -265,7 +266,6 @@ class ArcanePower extends Analyzer {
   		/>
 		);
 	}
-	statisticOrder = STATISTIC_ORDER.CORE(12);
 }
 
 export default ArcanePower;

--- a/src/Parser/Mage/Arcane/Modules/Features/TimeAnomaly.js
+++ b/src/Parser/Mage/Arcane/Modules/Features/TimeAnomaly.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
+import { formatPercentage } from 'common/format';
+import Analyzer from 'Parser/Core/Analyzer';
+
+const MANA_THRESHOLD = 0.70;
+
+class TimeAnomaly extends Analyzer {
+	static dependencies = {
+		abilityTracker: AbilityTracker,
+	};
+
+	constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.TIME_ANOMALY_TALENT.id);
+	}
+	
+	conservedTooHigh = 0;
+
+	on_byPlayer_cast(event) {
+		const spellId = event.ability.guid;
+		if (spellId !== SPELLS.ARCANE_BARRAGE.id) {
+			return;
+		}
+		const manaPercent = event.classResources[0].amount / event.classResources[0].max;
+		if (manaPercent > MANA_THRESHOLD) {
+			this.conservedTooHigh += 1;
+		}
+	}
+
+	get manaUtilization() {
+		return 1 - (this.conservedTooHigh / this.abilityTracker.getAbility(SPELLS.ARCANE_BARRAGE.id).casts);
+	}
+
+	get manaUtilizationThresholds() {
+    return {
+      actual: this.manaUtilization,
+      isLessThan: {
+        minor: 0.90,
+        average: 0.80,
+        major: 0.70,
+      },
+      style: 'percentage',
+    };
+  }
+
+	suggestions(when) {
+		when(this.manaUtilizationThresholds)
+			.addSuggestion((suggest, actual, recommended) => {
+				return suggest(<React.Fragment>You cast <SpellLink id={SPELLS.ARCANE_BARRAGE.id} /> with greater than 70% mana {this.conservedTooHigh} times. Because of the way <SpellLink id={SPELLS.TIME_ANOMALY_TALENT.id} /> works, you can randomly gain the <SpellLink id={SPELLS.EVOCATION.id} /> effect causing your mana to rapidly increase. If you are conserving your mana too high, this can cause your mana to cap out at 100% which is a waste. So if you are using the Time Anomaly talent, you should make sure you conserve below 70% mana to help prevent mana capping.</React.Fragment>)
+					.icon(SPELLS.TIME_ANOMALY_TALENT.icon)
+					.actual(`${formatPercentage(this.manaUtilization)}% Utilization`)
+					.recommended(`${formatPercentage(recommended)}% is recommended`);
+			});
+	}
+}
+
+export default TimeAnomaly;

--- a/src/Parser/Mage/Shared/Modules/Features/ArcaneIntellect.js
+++ b/src/Parser/Mage/Shared/Modules/Features/ArcaneIntellect.js
@@ -37,6 +37,7 @@ class ArcaneIntellect extends Analyzer {
 	statistic() {
     return (
 			<StatisticBox
+  position={STATISTIC_ORDER.CORE(80)}
   icon={<SpellIcon id={SPELLS.ARCANE_INTELLECT.id} />}
   value={`${formatPercentage(this.uptime, 0)} %`}
   label="Arcane Intellect"
@@ -44,7 +45,6 @@ class ArcaneIntellect extends Analyzer {
 			/>
 		);
 	}
-	statisticOrder = STATISTIC_ORDER.CORE(12);
 }
 
 export default ArcaneIntellect;

--- a/src/Parser/Mage/Shared/Modules/Features/MirrorImage.js
+++ b/src/Parser/Mage/Shared/Modules/Features/MirrorImage.js
@@ -64,6 +64,7 @@ class MirrorImage extends Analyzer {
   statistic() {
     return (
       <StatisticBox
+        position={STATISTIC_ORDER.CORE(100)}
         icon={<SpellIcon id={SPELLS.MIRROR_IMAGE_TALENT.id} />}
         value={`${formatPercentage(this.damagePercent)} %`}
         label="Mirror Image damage"
@@ -71,7 +72,6 @@ class MirrorImage extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(100);
 }
 
 export default MirrorImage;

--- a/src/Parser/Mage/Shared/Modules/Features/RuneOfPower.js
+++ b/src/Parser/Mage/Shared/Modules/Features/RuneOfPower.js
@@ -101,6 +101,7 @@ class RuneOfPower extends Analyzer {
     if (!this.showStatistic) return null;
     return (
       <StatisticBox
+        position={STATISTIC_ORDER.CORE(100)}
         icon={<SpellIcon id={SPELLS.RUNE_OF_POWER_TALENT.id} />}
         value={`${formatPercentage(this.damagePercent)} %`}
         label="Rune of Power damage"
@@ -108,7 +109,6 @@ class RuneOfPower extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(100);
 }
 
 export default RuneOfPower;


### PR DESCRIPTION
Added Time Anomaly Module to ensure the player is conserving mana below 70% so that if Evocation procs, it wont cap out the player's mana.

Also added check to make sure Arcane Missiles is only cast if the player has Clearcasting.

Also added some fixes
- Buff End Time was returning null in Arcane Power, so I added some buff tracking to calculate the end time
- Removed some leftover console log entries that I forgot to remove
- Fixed Mana Utilization suggestion to point to the correct actual value

Completes #1961 