### PR TITLE
Disc priest smite coefficient & sins fix

### DIFF
--- a/src/Parser/Priest/Discipline/Modules/Spells/SinsOfTheMany.js
+++ b/src/Parser/Priest/Discipline/Modules/Spells/SinsOfTheMany.js
@@ -13,16 +13,25 @@ import calculateEffectiveHealing from 'Parser/Core/calculateEffectiveHealing';
 import isAtonement from '../Core/isAtonement';
 import Atonement from './Atonement';
 
-const SINS_OF_THE_MANY_BASE_BONUS = 0.12;
 const SINS_OF_THE_MANY_FLOOR_BONUS = 0.03;
 
 /**
- * Sins allows you to have one Atonement active whilst keeping the full bonus
- * from the passive. Hence this map should be seen as overrides for a linear
- * progression from the max to the floor per Atonement active.
+ * Sins isn't linear,
+ * it allows you to have one Atonement active whilst keeping the full bonus
+ * from the passive and from 6 onwards it only decreases 0.005.
+ * Hence this map with the values for each Atonement count.
  */
 const BONUS_DAMAGE_MAP = {
+  0: 0.12,
   1: 0.12,
+  2: 0.10,
+  3: 0.08,
+  4: 0.07,
+  5: 0.06,
+  6: 0.055,
+  7: 0.05,
+  8: 0.045,
+  9: 0.04,
 };
 
 class SinsOfTheMany extends Analyzer {
@@ -40,20 +49,13 @@ class SinsOfTheMany extends Analyzer {
   }
 
   get currentBonus() {
-    const baseBonus = SINS_OF_THE_MANY_BASE_BONUS * 100;
-    const floorBonus = SINS_OF_THE_MANY_FLOOR_BONUS * 100;
     const activeBuffs = this.atonement.numAtonementsActive;
 
     // Return an override, if necessary
     if (BONUS_DAMAGE_MAP[activeBuffs]) return BONUS_DAMAGE_MAP[activeBuffs];
 
-    // Return the floor if we're below it
-    if (floorBonus >= baseBonus - activeBuffs) {
-      return SINS_OF_THE_MANY_FLOOR_BONUS;
-    }
-
-    // Return the calculated bonus
-    return (baseBonus - activeBuffs) / 100;
+    // Return the floor if we have more atonements than in the map
+    return SINS_OF_THE_MANY_FLOOR_BONUS;
   }
 
   /**

--- a/src/Parser/Priest/Discipline/SpellCalculations.js
+++ b/src/Parser/Priest/Discipline/SpellCalculations.js
@@ -1,6 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import { ATONEMENT_COEFFICIENT } from './Constants';
 
+// 50% dmg increase passive
 const SMITE_DAMAGE_BUFF = 0.5;
 
 /*

--- a/src/Parser/Priest/Discipline/SpellCalculations.test.js
+++ b/src/Parser/Priest/Discipline/SpellCalculations.test.js
@@ -51,8 +51,8 @@ describe('[SMITE] Spell Calculations', () => {
     const smiteEstimator = SmiteEstimation(mockStatTracker());
 
     expect(smiteEstimator()).toEqual({
-      smiteDamage: 84,
-      smiteHealing: 34,
+      smiteDamage: 71,
+      smiteHealing: 28,
     });
   });
 
@@ -60,8 +60,8 @@ describe('[SMITE] Spell Calculations', () => {
     const smiteEstimator = SmiteEstimation(mockStatTracker(100, .25));
 
     expect(smiteEstimator()).toEqual({
-      smiteDamage: 105,
-      smiteHealing: 42,
+      smiteDamage: 88,
+      smiteHealing: 35,
     });
   });
 });

--- a/src/common/SPELLS/PRIEST.js
+++ b/src/common/SPELLS/PRIEST.js
@@ -56,7 +56,7 @@ export default {
     name: 'Smite',
     icon: 'spell_holy_holysmite',
     manaCost: 500,
-    coefficient: 0.56,
+    coefficient: 0.47,
   },
   POWER_WORD_RADIANCE: {
     id: 194509,


### PR DESCRIPTION
self explanatory fixes;

- Smite spellpower coefficient was incorrect (only used right now to offset Schism direct damage by damage of 1 Smite to account for the fact that you would be casting Smite instead)
 - Sins of the Many doesn't scale linear at all