### PR TITLE
Disc priest azerite trait Gift of Forgiveness

### DIFF
--- a/src/Interface/common/TooltipProvider/Wowhead.js
+++ b/src/Interface/common/TooltipProvider/Wowhead.js
@@ -6,8 +6,17 @@ class Wowhead extends Base {
   static libraryUrl = '//wow.zamimg.com/widgets/power.js';
   static baseUrl = 'http://wowhead.com/';
 
-  static spellRelative(id) {
-    return `spell=${id}`;
+  static spellRelative(id, details) {
+    const base = `spell=${id}`;
+    if (!details) {
+      return base;
+    } else {
+      const queryString = [base];
+      if (details.ilvl) {
+        queryString.push(`ilvl=${details.ilvl}`);
+      }
+      return queryString.join('&');
+    }
   }
   static itemRelative(id, details) {
     const base = `item=${id}`;

--- a/src/Parser/Priest/Discipline/CombatLogParser.js
+++ b/src/Parser/Priest/Discipline/CombatLogParser.js
@@ -52,6 +52,8 @@ import Contrition from './Modules/Spells/Contrition';
 import Grace from './Modules/Spells/Grace';
 import Schism from './Modules/Spells/Schism';
 
+import GiftOfForgiveness from './Modules/AzeriteTraits/GiftOfForgiveness';
+
 import SinsOfTheMany from './Modules/Spells/SinsOfTheMany';
 
 import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from './Constants';
@@ -118,6 +120,9 @@ class CombatLogParser extends CoreCombatLogParser {
     grace: Grace,
     schism: Schism,
     sinsOfTheMany: SinsOfTheMany,
+
+    // Azerite Traits
+    gift: GiftOfForgiveness,
   };
 }
 

--- a/src/Parser/Priest/Discipline/Modules/AzeriteTraits/GiftOfForgiveness.js
+++ b/src/Parser/Priest/Discipline/Modules/AzeriteTraits/GiftOfForgiveness.js
@@ -1,0 +1,160 @@
+import React from 'react';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import { formatNumber } from 'common/format';
+import { calculateAzeriteEffects } from 'common/stats';
+import TraitStatisticBox, { STATISTIC_ORDER } from 'Interface/Others/TraitStatisticBox';
+import StatTracker from 'Parser/Core/Modules/StatTracker';
+import SPELLS from 'common/SPELLS';
+import Enemies from 'Parser/Core/Modules/Enemies';
+import DualStatisticBox from 'Interface/Others/DualStatisticBox';
+import SpellIcon from 'common/SpellIcon';
+import STATISTIC_CATEGORY from 'Interface/Others/STATISTIC_CATEGORY';
+
+import { SmiteEstimation } from '../../SpellCalculations';
+import SinsOfTheMany from '../Spells/SinsOfTheMany';
+import Atonement from '../Spells/Atonement';
+import isAtonement from '../Core/isAtonement';
+import AtonementDamageSource from '../Features/AtonementDamageSource';
+
+class GiftOfForgiveness extends Analyzer {
+  static dependencies = {
+    atonementDamageSource: AtonementDamageSource,
+    statTracker: StatTracker,
+    atonement: Atonement,
+    sins: SinsOfTheMany,
+    enemies: Enemies,
+  };
+
+  smites;
+  gifted;
+  giftedDamage;
+  smiteEstimation;
+
+  constructor(...args) {
+    super(...args);
+
+    // always active, to display the "potential"
+    this.active = true;
+
+    this.giftRanks = this.selectedCombatant.traitRanks(SPELLS.GIFT_OF_FORGIVENESS.id);
+    this.giftTooltipBonusDmg = this.giftRanks.map((rank) => calculateAzeriteEffects(SPELLS.GIFT_OF_FORGIVENESS.id, rank)[0]).reduce((total, bonus) => total + bonus[0], 0);
+
+    this.hasGift = this.giftRanks.length > 0;
+
+    this.smites = 0;
+    this.gifted = 0;
+    this.giftedDamage = 0;
+    this.giftedHealing = 0;
+
+    this.smiteEstimation = SmiteEstimation(this.statTracker, this.sins, this.giftRanks);
+  }
+
+  on_byPlayer_damage(event) {
+    const spellId = event.ability.guid;
+
+    if (spellId === SPELLS.SMITE.id) {
+      this.smites++;
+
+      if (this.atonement.giftActive) {
+        this.gifted++;
+
+        const { smiteDamage, giftDamage } = this.smiteEstimation(this.atonement.giftActive);
+
+        // use smite damage estimation to take into account multipliers that are applied to gift too (because it's base damage increase)
+        //  and multiply based on event.amount / smiteDamage to take into account external multipliers (schism, debuffs, buffs, etc) and crits
+        this.giftedDamage += (giftDamage * (event.amount / smiteDamage));
+      }
+    }
+  }
+
+  on_byPlayer_heal(event) {
+    if (!isAtonement(event)) {
+      return;
+    }
+
+    const atonenementDamageEvent = this.atonementDamageSource.event;
+    if (!atonenementDamageEvent) {
+      this.error('Atonement damage event unknown for Atonement heal:', event);
+      return;
+    }
+
+    const spellId = atonenementDamageEvent.ability.guid;
+
+    if (spellId === SPELLS.SMITE.id) {
+      if (this.atonement.giftActive) {
+
+        const { giftHealing } = this.smiteEstimation(this.atonement.giftActive);
+
+        // use smite damage estimation to take into account multipliers that are applied to gift too (because it's base damage increase)
+        //  and multiply based on event.amount / smiteDamage to take into account external multipliers and crits
+        let giftedHealing = (giftHealing * (event.amount / giftHealing));
+
+        // any overhealing means the trait didn't do much for us
+        giftedHealing -= event.overheal;
+
+        if (giftedHealing > 0) {
+          this.giftedHealing += giftedHealing;
+        }
+      }
+    }
+  }
+
+  statistic() {
+    if (this.hasGift) {
+      // to make the tooltip reflect multiple ranks of the trait we use a bit of a hacky way to figure out which ilvl would result in displaying the sum of the bonus damage
+      let ilvl = 0;
+      if (this.giftRanks.length === 1) {
+        ilvl = this.giftRanks[0];
+      } else {
+        let ilvlDmgBonus = calculateAzeriteEffects(SPELLS.GIFT_OF_FORGIVENESS.id, this.giftRanks[0])[0];
+        for (ilvl = this.giftRanks[0]; ilvlDmgBonus < this.giftTooltipBonusDmg; ilvl++) {
+          ilvlDmgBonus = calculateAzeriteEffects(SPELLS.GIFT_OF_FORGIVENESS.id, ilvl)[0];
+        }
+      }
+
+      return (
+        <DualStatisticBox
+          category={STATISTIC_CATEGORY.AZERITE_POWERS}
+          position={STATISTIC_ORDER.OPTIONAL()}
+          icon={<SpellIcon id={SPELLS.GIFT_OF_FORGIVENESS.id} ilvl={ilvl} />}
+          values={[
+            `${formatNumber(
+              (this.giftedHealing / this.owner.fightDuration) * 1000
+            )} HPS`,
+            `${formatNumber(
+              ((this.giftedDamage) / this.owner.fightDuration) * 1000
+            )} DPS`,
+          ]}
+          footer={(
+            <dfn
+              data-tip={`You casted Smite ${this.smites} times, out of which ${this.gifted} you had 3+ atonements up.`}
+            >
+              {this.gifted} Gifted Smites
+            </dfn>
+          )}
+        />
+      );
+    } else {
+
+      return (
+        <TraitStatisticBox
+          position={STATISTIC_ORDER.OPTIONAL()}
+          trait={SPELLS.GIFT_OF_FORGIVENESS.id}
+          value={`No Gift Traits`}
+          label={
+            (
+              <dfn
+                data-tip={`You casted Smite ${this.smites} times, out of which ${this.gifted} you had 3+ atonements up.`}
+              >
+                {this.gifted} Potentially Gifted Smites
+              </dfn>
+            )
+          }
+        />
+      );
+    }
+  }
+}
+
+export default GiftOfForgiveness;

--- a/src/Parser/Priest/Discipline/Modules/Features/AtonementDamageSource.js
+++ b/src/Parser/Priest/Discipline/Modules/Features/AtonementDamageSource.js
@@ -18,7 +18,6 @@ class AtonementDamageSource extends Analyzer {
   }
 
   on_damage(event) {
-    this.debug(event);
     if (!this.owner.byPlayer(event) && !this.owner.byPlayerPet(event)) {
       return;
     }

--- a/src/Parser/Priest/Discipline/Modules/Spells/Atonement.js
+++ b/src/Parser/Priest/Discipline/Modules/Spells/Atonement.js
@@ -47,6 +47,10 @@ class Atonement extends Analyzer {
     return this.currentAtonementTargets.length;
   }
 
+  get giftActive() {
+    return this.numAtonementsActive >= 3;
+  }
+
   constructor(...args) {
     super(...args);
     this.active = true;

--- a/src/Parser/Priest/Discipline/Modules/Spells/SinsOfTheMany.js
+++ b/src/Parser/Priest/Discipline/Modules/Spells/SinsOfTheMany.js
@@ -13,16 +13,25 @@ import calculateEffectiveHealing from 'Parser/Core/calculateEffectiveHealing';
 import isAtonement from '../Core/isAtonement';
 import Atonement from './Atonement';
 
-const SINS_OF_THE_MANY_BASE_BONUS = 0.12;
 const SINS_OF_THE_MANY_FLOOR_BONUS = 0.03;
 
 /**
- * Sins allows you to have one Atonement active whilst keeping the full bonus
- * from the passive. Hence this map should be seen as overrides for a linear
- * progression from the max to the floor per Atonement active.
+ * Sins isn't linear,
+ * it allows you to have one Atonement active whilst keeping the full bonus
+ * from the passive and from 6 onwards it only decreases 0.005.
+ * Hence this map with the values for each Atonement count.
  */
 const BONUS_DAMAGE_MAP = {
+  0: 0.12,
   1: 0.12,
+  2: 0.10,
+  3: 0.08,
+  4: 0.07,
+  5: 0.06,
+  6: 0.055,
+  7: 0.05,
+  8: 0.045,
+  9: 0.04,
 };
 
 class SinsOfTheMany extends Analyzer {
@@ -40,20 +49,13 @@ class SinsOfTheMany extends Analyzer {
   }
 
   get currentBonus() {
-    const baseBonus = SINS_OF_THE_MANY_BASE_BONUS * 100;
-    const floorBonus = SINS_OF_THE_MANY_FLOOR_BONUS * 100;
     const activeBuffs = this.atonement.numAtonementsActive;
 
     // Return an override, if necessary
     if (BONUS_DAMAGE_MAP[activeBuffs]) return BONUS_DAMAGE_MAP[activeBuffs];
 
-    // Return the floor if we're below it
-    if (floorBonus >= baseBonus - activeBuffs) {
-      return SINS_OF_THE_MANY_FLOOR_BONUS;
-    }
-
-    // Return the calculated bonus
-    return (baseBonus - activeBuffs) / 100;
+    // Return the floor if we have more atonements than in the map
+    return SINS_OF_THE_MANY_FLOOR_BONUS;
   }
 
   /**

--- a/src/Parser/Priest/Discipline/SpellCalculations.js
+++ b/src/Parser/Priest/Discipline/SpellCalculations.js
@@ -1,6 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import { ATONEMENT_COEFFICIENT } from './Constants';
 
+// 50% dmg increase passive
 const SMITE_DAMAGE_BUFF = 0.5;
 
 /*

--- a/src/Parser/Priest/Discipline/SpellCalculations.test.js
+++ b/src/Parser/Priest/Discipline/SpellCalculations.test.js
@@ -51,8 +51,8 @@ describe('[SMITE] Spell Calculations', () => {
     const smiteEstimator = SmiteEstimation(mockStatTracker());
 
     expect(smiteEstimator()).toEqual({
-      smiteDamage: 84,
-      smiteHealing: 34,
+      smiteDamage: 71,
+      smiteHealing: 28,
     });
   });
 
@@ -60,8 +60,8 @@ describe('[SMITE] Spell Calculations', () => {
     const smiteEstimator = SmiteEstimation(mockStatTracker(100, .25));
 
     expect(smiteEstimator()).toEqual({
-      smiteDamage: 105,
-      smiteHealing: 42,
+      smiteDamage: 88,
+      smiteHealing: 35,
     });
   });
 });

--- a/src/Parser/Priest/Discipline/SpellCalculations.test.js
+++ b/src/Parser/Priest/Discipline/SpellCalculations.test.js
@@ -47,21 +47,92 @@ describe('[PENANCE] Spell Calculations', () => {
 });
 
 describe('[SMITE] Spell Calculations', () => {
-  it('Estimates Smites Correctly', () => {
-    const smiteEstimator = SmiteEstimation(mockStatTracker());
+  const fixtures = [
+    {sins: 0, giftRanks: [0], giftActive: false, int: 100, vers: 0, expected: {
+        smiteDamage: 71,
+        smiteHealing: 28,
+        giftDamage: 0,
+        giftHealing: 0,
+      }},
+    {sins: 0, giftRanks: [0], giftActive: false, int: 100, vers: .25, expected: {
+        smiteDamage: 88,
+        smiteHealing: 35,
+        giftDamage: 0,
+        giftHealing: 0,
+      }},
+    {sins: 0, giftRanks: [0], giftActive: false, int: 100, vers: 0, expected: {
+        smiteDamage: 71,
+        smiteHealing: 28,
+        giftDamage: 0,
+        giftHealing: 0,
+      }},
+    {sins: 0, giftRanks: [300], giftActive: false, int: 100, vers: 0, expected: {
+        smiteDamage: 71,
+        smiteHealing: 28,
+        giftDamage: 0,
+        giftHealing: 0,
+      }},
+    {sins: 0, giftRanks: [300], giftActive: true, int: 100, vers: 0, expected: {
+        smiteDamage: 458,
+        smiteHealing: 183,
+        giftDamage: 387,
+        giftHealing: 155,
+      }},
+    {sins: 0, giftRanks: [300], giftActive: true, int: 100, vers: .25, expected: {
+        smiteDamage: 572,
+        smiteHealing: 229,
+        giftDamage: 484,
+        giftHealing: 194,
+      }},
+    {sins: .12, giftRanks: [300], giftActive: false, int: 100, vers: 0, expected: {
+        smiteDamage: 79,
+        smiteHealing: 32,
+        giftDamage: 0,
+        giftHealing: 0,
+      }},
+    {sins: .12, giftRanks: [300], giftActive: false, int: 100, vers: .25, expected: {
+        smiteDamage: 99,
+        smiteHealing: 40,
+        giftDamage: 0,
+        giftHealing: 0,
+      }},
+    {sins: .08, giftRanks: [300], giftActive: false, int: 100, vers: .25, expected: {
+        smiteDamage: 95,
+        smiteHealing: 38,
+        giftDamage: 0,
+        giftHealing: 0,
+      }},
+    {sins: .12, giftRanks: [300], giftActive: true, int: 100, vers: .25, expected: {
+        smiteDamage: 641,
+        smiteHealing: 257,
+        giftDamage: 542,
+        giftHealing: 217,
+      }},
+    {sins: .08, giftRanks: [300], giftActive: true, int: 100, vers: .25, expected: {
+        smiteDamage: 617,
+        smiteHealing: 247,
+        giftDamage: 522,
+        giftHealing: 209,
+      }},
+    {sins: .08, giftRanks: [300, 290], giftActive: true, int: 100, vers: .25, expected: {
+        smiteDamage: 1095,
+        smiteHealing: 438,
+        giftDamage: 1000,
+        giftHealing: 400,
+      }},
+    {sins: .08, giftRanks: [300, 290, 280], giftActive: true, int: 100, vers: .25, expected: {
+        smiteDamage: 1527,
+        smiteHealing: 611,
+        giftDamage: 1432,
+        giftHealing: 573,
+      }},
+  ];
 
-    expect(smiteEstimator()).toEqual({
-      smiteDamage: 71,
-      smiteHealing: 28,
-    });
-  });
+  fixtures.forEach((fixture, i) => {
+    it(`Estimates Smite Correctly #${i}`, () => {
+      const smiteEstimator = SmiteEstimation(mockStatTracker(fixture.int, fixture.vers), {currentBonus: fixture.sins}, fixture.giftRanks);
 
-  it('Estimates Smites Correctly with Versatility', () => {
-    const smiteEstimator = SmiteEstimation(mockStatTracker(100, .25));
-
-    expect(smiteEstimator()).toEqual({
-      smiteDamage: 88,
-      smiteHealing: 35,
+      expect(smiteEstimator(fixture.giftActive)).toEqual(fixture.expected);
     });
   });
 });

--- a/src/common/SPELLS/BFA/AzeriteTraits/Priest.js
+++ b/src/common/SPELLS/BFA/AzeriteTraits/Priest.js
@@ -1,0 +1,14 @@
+/**
+ * All Priest azerite powers go in here.
+ * You need to do this manually, usually an easy way to do this is by opening a WCL report and clicking the icons of spells to open the relevant Wowhead pages, here you can get the icon name by clicking the icon, copy the name of the spell and the ID is in the URL.
+ * You can access these entries like other entries in the spells files by importing `common/SPELLS` and using the assigned property on the SPELLS object. Please try to avoid abbreviating properties.
+ */
+
+export default {
+  // Disc
+  GIFT_OF_FORGIVENESS: {
+    id: 277680,
+    name: 'Gift of the Forgiveness',
+    icon: 'spell_holy_holysmite',
+  },
+};

--- a/src/common/SPELLS/BFA/AzeriteTraits/index.js
+++ b/src/common/SPELLS/BFA/AzeriteTraits/index.js
@@ -6,5 +6,6 @@ import Shaman from './Shaman';
 import Warlock from './Warlock';
 import Monk from './Monk';
 import DeathKnight from './DeathKnight';
+import Priest from './Priest';
 
-export default safeMerge(General, Hunter, Paladin, Shaman, Warlock, Monk, DeathKnight);
+export default safeMerge(General, Hunter, Paladin, Shaman, Warlock, Monk, DeathKnight, Priest);

--- a/src/common/SPELLS/PRIEST.js
+++ b/src/common/SPELLS/PRIEST.js
@@ -56,7 +56,7 @@ export default {
     name: 'Smite',
     icon: 'spell_holy_holysmite',
     manaCost: 500,
-    coefficient: 0.56,
+    coefficient: 0.47,
   },
   POWER_WORD_RADIANCE: {
     id: 194509,

--- a/src/common/SpellIcon.js
+++ b/src/common/SpellIcon.js
@@ -5,7 +5,7 @@ import SPELLS from './SPELLS';
 import SpellLink from './SpellLink';
 import Icon from './Icon';
 
-const SpellIcon = ({ id, noLink, alt, ...others }) => {
+const SpellIcon = ({ id, noLink, alt, ilvl, ...others }) => {
   if (process.env.NODE_ENV === 'development' && !SPELLS[id]) {
     throw new Error(`Unknown spell: ${id}`);
   }
@@ -28,7 +28,7 @@ const SpellIcon = ({ id, noLink, alt, ...others }) => {
   }
 
   return (
-    <SpellLink id={id} icon={false}>
+    <SpellLink id={id} ilvl={ilvl} icon={false}>
       {icon}
     </SpellLink>
   );
@@ -37,6 +37,7 @@ SpellIcon.propTypes = {
   id: PropTypes.number.isRequired,
   noLink: PropTypes.bool,
   alt: PropTypes.string,
+  ilvl: PropTypes.number,
 };
 
 export default SpellIcon;

--- a/src/common/SpellLink.js
+++ b/src/common/SpellLink.js
@@ -13,6 +13,7 @@ class SpellLink extends React.PureComponent {
     category: PropTypes.string,
     icon: PropTypes.bool,
     iconStyle: PropTypes.object,
+    ilvl: PropTypes.number,
   };
   static defaultProps = {
     icon: true,
@@ -28,15 +29,20 @@ class SpellLink extends React.PureComponent {
   }
 
   render() {
-    const { id, children, category = undefined, icon, iconStyle, ...other } = this.props;
+    const { id, children, category = undefined, icon, iconStyle, ilvl, ...other } = this.props;
 
     if (process.env.NODE_ENV === 'development' && !children && !SPELLS[id]) {
       throw new Error(`Unknown spell: ${id}`);
     }
 
+    const tooltipDetails = {};
+    if (ilvl) {
+      tooltipDetails.ilvl = ilvl;
+    }
+
     return (
       <a
-        href={TooltipProvider.spell(id)}
+        href={TooltipProvider.spell(id, tooltipDetails)}
         target="_blank"
         rel="noopener noreferrer"
         className={category}


### PR DESCRIPTION
Depends on https://github.com/WoWAnalyzer/WoWAnalyzer/pull/2107 (first 2 commits are from that PR) for:
- Smite spellpower coefficient was incorrect (only used right now to offset Schism direct damage by damage of 1 Smite to account for the fact that you would be casting Smite instead)
 - Sins of the Many doesn't scale linear at all

----------

Gift of Forgiveness adds to Smite base damage so I've added it to `SmiteEstimation` so that it's included into the Schism direct damage offset.

When you have no Gift traits it still displays a box to show how many of your Smites were casted with 3+ atonements,  
considering the Gift trait is a bit hyped atm I think it's interesting to know how many of your Smite casts would have boosted if you'd have the trait. 

I still need to review it 1 final time myself, but it should be ready for review, I've tested values manually to check that they're correct.

screenie; https://imgur.com/a/E1AjIzH