### PR TITLE
[Mage] Azerite Traits & Arcane Changelog Update

### DIFF
--- a/src/Parser/Mage/Arcane/CHANGELOG.js
+++ b/src/Parser/Mage/Arcane/CHANGELOG.js
@@ -12,52 +12,52 @@ export default [
   },
   {
     date: new Date('2018-08-11'),
-    changes: <React.Fragment>Added Arcane Missiles Module and Time Anomaly Mana Management.</React.Fragment>,
+    changes: <React.Fragment>Added <SpellLink id={SPELLS.ARCANE_MISSILES.id} /> Module and <SpellLink id={SPELLS.TIME_ANOMALY_TALENT.id} /> Mana Management.</React.Fragment>,
     contributors: [Sharrq],
   },
   {
     date: new Date('2018-08-10'),
-    changes: <React.Fragment>Added Check to see if the player went OOM during Arcane Power.</React.Fragment>,
+    changes: <React.Fragment>Added Check to see if the player went OOM during <SpellLink id={SPELLS.ARCANE_POWER.id} />.</React.Fragment>,
     contributors: [Sharrq],
   },
   {
     date: new Date('2018-08-09'),
-    changes: <React.Fragment>Added Checklist</React.Fragment>,
+    changes: 'Added Checklist',
     contributors: [Sharrq],
   },
   {
     date: new Date('2018-08-02'),
-    changes: <React.Fragment>Removed Arcane Missiles module as it is no longer relevant. Also fixed Arcane Charge event order.</React.Fragment>,
+    changes: <React.Fragment>Removed <SpellLink id={SPELLS.ARCANE_MISSILES.id} /> module as it is no longer relevant. Also fixed Arcane Charge event order.</React.Fragment>,
     contributors: [Sharrq],
   },
   {
     date: new Date('2018-08-01'),
-    changes: <React.Fragment>Added Support for Rule of Threes.</React.Fragment>,
+    changes: <React.Fragment>Added Support for <SpellLink id={SPELLS.RULE_OF_THREES_TALENT.id} />.</React.Fragment>,
     contributors: [Sharrq],
   },
   {
     date: new Date('2018-07-28'),
-    changes: <React.Fragment>Added Support for Arcane Power.</React.Fragment>,
+    changes: <React.Fragment>Added Support for <SpellLink id={SPELLS.ARCANE_POWER.id} />.</React.Fragment>,
     contributors: [Sharrq],
   },
   {
     date: new Date('2018-07-25'),
-    changes: <React.Fragment>Added Arcane Charge Tracking and Mana Chart.</React.Fragment>,
+    changes: 'Added Arcane Charge Tracking and Mana Chart.',
     contributors: [Sharrq],
   },
   {
     date: new Date('2018-07-23'),
-    changes: <React.Fragment>Added Support for Arcane Familiar, Arcane Orb, and Arcane Intellect.</React.Fragment>,
+    changes: <React.Fragment>Added Support for <SpellLink id={SPELLS.ARCANE_FAMILIAR_TALENT.id} />, <SpellLink id={SPELLS.ARCANE_ORB_TALENT.id} />, and <SpellLink id={SPELLS.ARCANE_INTELLECT.id} />.</React.Fragment>,
     contributors: [Sharrq],
   },
   {
     date: new Date('2018-07-23'),
-    changes: <React.Fragment>Removed Evocate Suggestion, Updated for 8.0.1, Resolved some Abilities Bugs</React.Fragment>,
+    changes: <React.Fragment>Removed <SpellLink id={SPELLS.EVOCATION.id} /> Suggestion, Updated for 8.0.1, Resolved some Abilities Bugs</React.Fragment>,
     contributors: [Sharrq],
   },
   {
     date: new Date('2018-01-27'),
-    changes: <React.Fragment>Added Spec</React.Fragment>,
+    changes: 'Added Spec',
     contributors: [Sharrq],
   },
 ];

--- a/src/Parser/Mage/Arcane/CHANGELOG.js
+++ b/src/Parser/Mage/Arcane/CHANGELOG.js
@@ -1,54 +1,63 @@
+import React from 'react';
+
 import { Sharrq } from 'CONTRIBUTORS';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-08-28'),
+    changes: <React.Fragment>Added support for <SpellLink id={SPELLS.GALVANIZING_SPARK.id} /> and <SpellLink id={SPELLS.ANOMALOUS_IMPACT.id} /></React.Fragment>,
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2018-08-11'),
-    changes: 'Added Arcane Missiles Module and Time Anomaly Mana Management.',
+    changes: <React.Fragment>Added Arcane Missiles Module and Time Anomaly Mana Management.</React.Fragment>,
     contributors: [Sharrq],
   },
   {
     date: new Date('2018-08-10'),
-    changes: 'Added Check to see if the player went OOM during Arcane Power.',
+    changes: <React.Fragment>Added Check to see if the player went OOM during Arcane Power.</React.Fragment>,
     contributors: [Sharrq],
   },
   {
     date: new Date('2018-08-09'),
-    changes: 'Added Checklist ',
+    changes: <React.Fragment>Added Checklist</React.Fragment>,
     contributors: [Sharrq],
   },
   {
     date: new Date('2018-08-02'),
-    changes: 'Removed Arcane Missiles module as it is no longer relevant. Also fixed Arcane Charge event order. ',
+    changes: <React.Fragment>Removed Arcane Missiles module as it is no longer relevant. Also fixed Arcane Charge event order.</React.Fragment>,
     contributors: [Sharrq],
   },
   {
     date: new Date('2018-08-01'),
-    changes: 'Added Support for Rule of Threes. ',
+    changes: <React.Fragment>Added Support for Rule of Threes.</React.Fragment>,
     contributors: [Sharrq],
   },
   {
     date: new Date('2018-07-28'),
-    changes: 'Added Support for Arcane Power. ',
+    changes: <React.Fragment>Added Support for Arcane Power.</React.Fragment>,
     contributors: [Sharrq],
   },
   {
     date: new Date('2018-07-25'),
-    changes: 'Added Arcane Charge Tracking and Mana Chart. ',
+    changes: <React.Fragment>Added Arcane Charge Tracking and Mana Chart.</React.Fragment>,
     contributors: [Sharrq],
   },
   {
     date: new Date('2018-07-23'),
-    changes: 'Added Support for Arcane Familiar, Arcane Orb, and Arcane Intellect. ',
+    changes: <React.Fragment>Added Support for Arcane Familiar, Arcane Orb, and Arcane Intellect.</React.Fragment>,
     contributors: [Sharrq],
   },
   {
     date: new Date('2018-07-23'),
-    changes: 'Removed Evocate Suggestion, Updated for 8.0.1, Resolved some Abilities Bugs. ',
+    changes: <React.Fragment>Removed Evocate Suggestion, Updated for 8.0.1, Resolved some Abilities Bugs</React.Fragment>,
     contributors: [Sharrq],
   },
   {
     date: new Date('2018-01-27'),
-    changes: 'Added Spec',
+    changes: <React.Fragment>Added Spec</React.Fragment>,
     contributors: [Sharrq],
   },
 ];

--- a/src/Parser/Mage/Arcane/Modules/Checklist/Module.js
+++ b/src/Parser/Mage/Arcane/Modules/Checklist/Module.js
@@ -56,7 +56,7 @@ class Checklist extends Analyzer {
           arcanePowerOnKill: this.arcanePower.arcanePowerOnKillSuggestionThresholds,
           ruleOfThreesUsage: this.ruleOfThrees.suggestionThresholds,
           timeAnomalyManaUtilization: this.timeAnomaly.manaUtilizationThresholds,
-          arcaneMissilesUtilization: this.arcaneMissiles.suggestionThresholds,
+          arcaneMissilesUtilization: this.arcaneMissiles.missilesSuggestionThresholds,
           manaOnKill: this.manaValues.suggestionThresholds,
           arcaneIntellectUptime: this.arcaneIntellect.suggestionThresholds,
           cancelledCasts: this.cancelledCasts.suggestionThresholds,

--- a/src/Parser/Mage/Arcane/Modules/Features/ArcaneMissiles.js
+++ b/src/Parser/Mage/Arcane/Modules/Features/ArcaneMissiles.js
@@ -12,26 +12,50 @@ class ArcaneMissiles extends Analyzer {
 		abilityTracker: AbilityTracker,
 	};
 
+	constructor(...args) {
+    super(...args);
+    this.hasAnomalousImpactTrait = this.selectedCombatant.hasTrait(SPELLS.ANOMALOUS_IMPACT.id);
+  }
+
 	castWithoutClearcasting = 0;
+	barrageWithProcs = 0;
 
 	on_byPlayer_cast(event) {
 		const spellId = event.ability.guid;
-		if (spellId !== SPELLS.ARCANE_MISSILES.id) {
+		if (spellId !== SPELLS.ARCANE_MISSILES.id && spellId !== SPELLS.ARCANE_BARRAGE.id) {
 			return;
 		}
-		if (!this.selectedCombatant.hasBuff(SPELLS.CLEARCASTING_ARCANE.id)) {
+		if (spellId === SPELLS.ARCANE_MISSILES.id && !this.selectedCombatant.hasBuff(SPELLS.CLEARCASTING_ARCANE.id)) {
 			debug && console.log("Arcane Missiles cast without Clearcasting @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
 			this.castWithoutClearcasting += 1;
+		} else if (spellId === SPELLS.ARCANE_BARRAGE.id && this.selectedCombatant.hasBuff(SPELLS.CLEARCASTING_ARCANE.id,event.timestamp - 100) && this.hasAnomalousImpactTrait) {
+			this.barrageWithProcs += 1;
 		}
 	}
 
-	get utilization() {
+	get missilesUtilization() {
 		return 1 - (this.castWithoutClearcasting / this.abilityTracker.getAbility(SPELLS.ARCANE_MISSILES.id).casts);
 	}
 
-	get suggestionThresholds() {
+	get barrageUtilization() {
+		return 1 - (this.barrageWithProcs / this.abilityTracker.getAbility(SPELLS.ARCANE_BARRAGE.id).casts);
+	}
+
+	get missilesSuggestionThresholds() {
     return {
-      actual: this.utilization,
+      actual: this.missilesUtilization,
+      isLessThan: {
+        minor: 1,
+        average: 0.95,
+        major: 0.90,
+      },
+      style: 'percentage',
+    };
+	}
+	
+	get barrageSuggestionThresholds() {
+    return {
+      actual: this.barrageUtilization,
       isLessThan: {
         minor: 1,
         average: 0.95,
@@ -42,13 +66,22 @@ class ArcaneMissiles extends Analyzer {
   }
 
 	suggestions(when) {
-		when(this.suggestionThresholds)
+		when(this.missilesSuggestionThresholds)
 			.addSuggestion((suggest, actual, recommended) => {
 				return suggest(<React.Fragment>You cast <SpellLink id={SPELLS.ARCANE_MISSILES.id} /> without <SpellLink id={SPELLS.CLEARCASTING_ARCANE.id} /> {this.castWithoutClearcasting} times. Arcane Missiles is a very expensive spell (more expensive than a 4 Charge Arcane Blast) and therefore it should only be cast when you have the Clearcasting buff which makes the spell free.</React.Fragment>)
 					.icon(SPELLS.ARCANE_MISSILES.icon)
-					.actual(`${formatPercentage(this.utilization)}% Uptime`)
+					.actual(`${formatPercentage(this.missilesUtilization)}% Uptime`)
 					.recommended(`${formatPercentage(recommended)}% is recommended`);
 			});
+		if (this.hasAnomalousImpactTrait) {
+			when(this.barrageSuggestionThresholds)
+				.addSuggestion((suggest, actual, recommended) => {
+					return suggest(<React.Fragment>You cast <SpellLink id={SPELLS.ARCANE_BARRAGE.id} /> without clearing your <SpellLink id={SPELLS.CLEARCASTING_ARCANE.id} /> Proc {this.barrageWithProcs} times. While normally this does not matter, the <SpellLink id={SPELLS.ANOMALOUS_IMPACT.id} /> Azerite Trait adds extra damage to <SpellLink id={SPELLS.ARCANE_MISSILES.id} /> based on the number of Arcane Charges you have. Therefore, you should make sure you are clearing your Clearcasting procs before you clear your Arcane Charges.</React.Fragment>)
+						.icon(SPELLS.CLEARCASTING_ARCANE.icon)
+						.actual(`${formatPercentage(this.barrageUtilization)}% Uptime`)
+						.recommended(`${formatPercentage(recommended)}% is recommended`);
+				});
+		}
 	}
 }
 

--- a/src/Parser/Mage/Frost/CHANGELOG.js
+++ b/src/Parser/Mage/Frost/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-08-28'),
+    changes: <React.Fragment>Added support for <SpellLink id={SPELLS.WINTERS_REACH_TRAIT.id} /> and <SpellLink id={SPELLS.WHITEOUT.id} /></React.Fragment>,
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2018-08-11'),
     changes: <React.Fragment>Updated for Level 120</React.Fragment>,
     contributors: [Sharrq],

--- a/src/Parser/Mage/Frost/CombatLogParser.js
+++ b/src/Parser/Mage/Frost/CombatLogParser.js
@@ -16,6 +16,7 @@ import MirrorImage from '../Shared/Modules/Features/MirrorImage';
 import ArcaneIntellect from '../Shared/Modules/Features/ArcaneIntellect';
 import SplittingIce from './Modules/Features/SplittingIce';
 import CancelledCasts from '../Shared/Modules/Features/CancelledCasts';
+import WintersReach from './Modules/Traits/WintersReach';
 
 import FrozenOrb from './Modules/Cooldowns/FrozenOrb';
 import ColdSnap from './Modules/Cooldowns/ColdSnap';
@@ -41,6 +42,9 @@ class CombatLogParser extends CoreCombatLogParser {
     mirrorImage: MirrorImage,
     arcaneIntellect: ArcaneIntellect,
     splittingIce: SplittingIce,
+
+    //Traits
+    wintersReach: WintersReach,
 
 	  //Cooldowns
     frozenOrb: FrozenOrb,

--- a/src/Parser/Mage/Frost/Modules/Cooldowns/FrozenOrb.js
+++ b/src/Parser/Mage/Frost/Modules/Cooldowns/FrozenOrb.js
@@ -2,7 +2,7 @@ import SPELLS from 'common/SPELLS';
 import Analyzer from 'Parser/Core/Analyzer';
 import SpellUsable from 'Parser/Core/Modules/SpellUsable';
 
-const BLIZZARD_REDUCTION_MS = 500;
+const REDUCTION_MS = 500;
 
 class FrozenOrb extends Analyzer {
 	static dependencies = {
@@ -12,14 +12,24 @@ class FrozenOrb extends Analyzer {
 	baseCooldown = 60;
 	cooldownReduction = 0;
 
+	constructor(...args) {
+		super(...args);
+		this.hasWhiteoutTrait = this.selectedCombatant.hasTrait(SPELLS.WHITEOUT.id);
+	  }
+
   	on_byPlayer_damage(event) {
 		const spellId = event.ability.guid;
-		if(spellId !== SPELLS.BLIZZARD_DAMAGE.id) {
+		if(spellId !== SPELLS.BLIZZARD_DAMAGE.id && spellId !== SPELLS.ICE_LANCE_DAMAGE.id) {
 			return;
 		}
 		if (this.spellUsable.isOnCooldown(SPELLS.FROZEN_ORB.id)) {
-			this.cooldownReduction += this.spellUsable.reduceCooldown(SPELLS.FROZEN_ORB.id, BLIZZARD_REDUCTION_MS);
+			if (spellId === SPELLS.BLIZZARD_DAMAGE.id) {
+				this.cooldownReduction += this.spellUsable.reduceCooldown(SPELLS.FROZEN_ORB.id, REDUCTION_MS);
+			} else if (spellId === SPELLS.ICE_LANCE_DAMAGE.id && this.hasWhiteoutTrait) {
+				this.cooldownReduction += this.spellUsable.reduceCooldown(SPELLS.FROZEN_ORB.id, REDUCTION_MS);
+			}
 		}
+		
   }
 }
 

--- a/src/Parser/Mage/Frost/Modules/Features/BrainFreeze.js
+++ b/src/Parser/Mage/Frost/Modules/Features/BrainFreeze.js
@@ -19,6 +19,11 @@ class BrainFreezeTracker extends Analyzer {
 	totalProcs = 0;
 	flurryWithoutProc = 0;
 
+	constructor(...args) {
+    super(...args);
+    this.hasWintersReachTrait = this.selectedCombatant.hasTrait(SPELLS.WINTERS_REACH_TRAIT.id);
+  }
+
 	on_byPlayer_applybuff(event) {
 		const spellId = event.ability.guid;
     if (spellId !== SPELLS.BRAIN_FREEZE.id) {
@@ -43,7 +48,7 @@ class BrainFreezeTracker extends Analyzer {
 			return;
 		}
 		this.lastFlurryTimestamp = this.owner.currentTimestamp;
-		if (!this.selectedCombatant.hasBuff(SPELLS.BRAIN_FREEZE.id)) {
+		if (!this.selectedCombatant.hasBuff(SPELLS.BRAIN_FREEZE.id) && !this.selectedCombatant.hasBuff(SPELLS.WINTERS_REACH_BUFF.id)) {
 			this.flurryWithoutProc += 1;
 		}
 	}
@@ -176,7 +181,7 @@ class BrainFreezeTracker extends Analyzer {
 
 		when(this.flurryWithoutProcSuggestionThresholds)
 			.addSuggestion((suggest, actual, recommended) => {
-				return suggest(<React.Fragment>You cast <SpellLink id={SPELLS.FLURRY.id} /> without <SpellLink id={SPELLS.BRAIN_FREEZE.id} /> {this.flurryWithoutProc} times. You should never hard cast Flurry.</React.Fragment>)
+				return suggest(<React.Fragment>You cast <SpellLink id={SPELLS.FLURRY.id} /> without <SpellLink id={SPELLS.BRAIN_FREEZE.id} /> or <SpellLink id={SPELLS.WINTERS_REACH_TRAIT.id} /> {this.flurryWithoutProc} times. The only time it is acceptable to hard case Flurry is if you have a proc of the Winter's Reach Azerite Trait.</React.Fragment>)
 					.icon(SPELLS.FLURRY.icon)
 					.actual(`${formatNumber(this.flurryWithoutProc)} casts`)
 					.recommended(`Casting none is recommended`);

--- a/src/Parser/Mage/Frost/Modules/Features/BrainFreeze.js
+++ b/src/Parser/Mage/Frost/Modules/Features/BrainFreeze.js
@@ -19,11 +19,6 @@ class BrainFreezeTracker extends Analyzer {
 	totalProcs = 0;
 	flurryWithoutProc = 0;
 
-	constructor(...args) {
-    super(...args);
-    this.hasWintersReachTrait = this.selectedCombatant.hasTrait(SPELLS.WINTERS_REACH_TRAIT.id);
-  }
-
 	on_byPlayer_applybuff(event) {
 		const spellId = event.ability.guid;
     if (spellId !== SPELLS.BRAIN_FREEZE.id) {

--- a/src/Parser/Mage/Frost/Modules/Traits/WintersReach.js
+++ b/src/Parser/Mage/Frost/Modules/Traits/WintersReach.js
@@ -1,0 +1,157 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import SpellIcon from 'common/SpellIcon';
+import Analyzer from 'Parser/Core/Analyzer';
+import StatisticBox, { STATISTIC_ORDER } from 'Interface/Others/StatisticBox';
+import { formatMilliseconds, formatNumber, formatPercentage } from 'common/format';
+
+const CAST_BUFFER = 250;
+
+const debug = false;
+
+class WintersReach extends Analyzer {
+
+  beginCastTimestamp = 0;
+  castTimestamp = 0;
+  buffUsed = false;
+  beginCastFound = false;
+  count = 0;
+  wastedProcs = 0;
+  usedProcs = 0;
+  totalProcs = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrait(SPELLS.WINTERS_REACH_TRAIT.id);
+  }
+
+  on_byPlayer_applybuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.WINTERS_REACH_BUFF.id) {
+      return;
+    }
+    this.buffUsed = false;
+    this.totalProcs += 1;
+    this.buffAppliedTimestamp = event.timestamp;
+    debug && console.log("Buff Applied @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
+  }
+
+  on_byPlayer_refreshbuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.WINTERS_REACH_BUFF.id) {
+      return;
+    }
+    this.buffUsed = false;
+    this.wastedProcs += 1;
+    this.totalProcs += 1;
+    debug && console.log("Buff Refreshed " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
+  }
+
+  on_byPlayer_removebuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.WINTERS_REACH_BUFF.id) {
+      return;
+    }
+    debug && console.log("Buff Removed @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
+    if (this.buffUsed === false) {
+      this.wastedProcs += 1;
+      debug && console.log("Buff Expired @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
+    } else {
+      this.usedProcs += 1;
+    }
+  }
+
+  on_byPlayer_begincast(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.FLURRY.id) {
+      return;
+    }
+    this.beginCastTimestamp = event.timestamp;
+    this.beginCastFound = true;
+
+    debug && console.log("Flurry Begin Cast @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
+  }
+
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.FLURRY.id || this.beginCastFound === false) {
+      return;
+    }
+    this.beginCastFound = false;
+    debug && console.log("Flurry Casted @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
+    this.castTimestamp = event.timestamp;
+    const castTime = this.castTimestamp - this.beginCastTimestamp;
+    //Checks the begincast and cast timestamps to determine if it is instant cast or not. This doesnt matter for ABT and ToS because winters reach flurries dont have a begincast, but in Nighthold they do. So this needs to remain for backwards compatibility
+    if (castTime >= CAST_BUFFER && this.selectedCombatant.hasBuff(SPELLS.WINTERS_REACH_BUFF.id)) {
+      this.buffUsed = true;
+      debug && console.log("Buff Used @ " + formatMilliseconds(event.timestamp - this.owner.fight.start_time));
+    }
+  }
+
+  on_finished() {
+    if (this.selectedCombatant.hasBuff(SPELLS.WINTERS_REACH_BUFF.id)) {
+      const adjustedFightEnding = this.owner.currentTimestamp - 7500;
+      if (this.buffAppliedTimestamp < adjustedFightEnding) {
+        this.wastedProcs += 1;
+        debug && console.log("Fight Ended with Unused Proc @ " + formatMilliseconds(this.owner.currentTimestamp - this.owner.fight.start_time));
+      } else {
+        this.totalProcs -= 1;
+      }
+    }
+    debug && console.log("Total Procs: " + this.totalProcs);
+    debug && console.log("Used Procs: " + this.usedProcs);
+    debug && console.log("Wasted Procs: " + this.wastedProcs);
+  }
+
+  get procsPerMinute() {
+    console.log(this.owner.fightDuration / 60000);
+    return this.totalProcs / (this.owner.fightDuration / 60000);
+  }
+
+  get procUtilization() {
+    return 1 - (this.wastedProcs / this.totalProcs);
+  }
+
+  get procUtilizationThresholds() {
+    return {
+      actual: this.procUtilization,
+      isLessThan: {
+        minor: 0.95,
+        average: 0.90,
+        major: 0.80,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.procUtilizationThresholds)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<React.Fragment>You wasted {formatNumber(this.wastedProcs)} of your <SpellLink id={SPELLS.WINTERS_REACH_TRAIT.id} /> procs. These procs make your hard cast <SpellLink id={SPELLS.FLURRY.id} /> casts deal extra damage, so try and use them as quickly as possible to avoid losing over overwriting the procs.</React.Fragment>)
+          .icon(SPELLS.WINTERS_REACH_TRAIT.icon)
+          .actual(`${formatPercentage(this.procUtilization)}% Utilization`)
+          .recommended(`<${formatPercentage(recommended)}% is recommended`);
+      });
+  }
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.WINTERS_REACH_TRAIT.id} />}
+        value={`${formatPercentage(this.procUtilization, 0)} %`}
+        label="Winter's Reach Utilization"
+        tooltip={`This is a measure of how well you utilized your Winter's Reach Procs.
+        <ul>
+          <li>${this.procsPerMinute.toFixed(2)} Procs Per Minute</li>
+          <li>${formatNumber(this.usedProcs)} Procs Used</li>
+          <li>${formatNumber(this.wastedProcs)} Procs Wasted</li>
+        </ul>
+      `}
+      />
+    );
+  }
+  statisticOrder = STATISTIC_ORDER.OPTIONAL(0);
+}
+
+export default WintersReach;

--- a/src/common/SPELLS/MAGE.js
+++ b/src/common/SPELLS/MAGE.js
@@ -442,6 +442,38 @@ export default {
     icon: 'spell_arcane_starfire',
   },
 
+  //Azerite Traits
+  GLACIAL_ASSAULT: {
+    id: 279855,
+    name: 'Glacial Assault',
+    icon: 'spell_mage_cometstorm2',
+  },
+  WHITEOUT: {
+    id: 278541,
+    name: 'Whiteout',
+    icon: 'spell_frost_frostblast',
+  },
+  WINTERS_REACH_TRAIT: {
+    id: 273346,
+    name: 'Winter\'s Reach',
+    icon: 'ability_warlock_burningembersblue',
+  },
+  WINTERS_REACH_BUFF: {
+    id: 273347,
+    name: 'Winter\'s Reach',
+    icon: 'ability_warlock_burningembersblue',
+  },
+  ANOMALOUS_IMPACT: {
+    id: 279867,
+    name: 'Anomalous Impact',
+    icon: 'ability_sorcererking_arcanereplication',
+  },
+  GALVANIZING_SPARK: {
+    id: 278536,
+    name: 'Galvanizing Spark',
+    icon: 'spell_arcane_arcane03',
+  },
+
   //Tier Sets
   FIRE_MAGE_T20_2SET_BONUS_BUFF: {
     id: 242249,


### PR DESCRIPTION
Added support for the following azerite traits which have an affect on the analysis other than damage.

Anomalous Impact (Arcane) - Makes Arcane Missiles do extra damage based on Arcane Charges. This affects rotation.
Whiteout (Frost) - Reduces the cooldown on Frozen Orb by 0.5 Seconds when Ice Lance does damage.
Winter's Reach (Frost) - Proc that makes hard cast Flurry do extra damage (Its essentially Pyroclasm/Legion Fire Bracers but for Frost.

Also updated the Arcane Changelog to the new standard.

I had planned on adding support for Galvanizing Spark as well as it gives Arcane Blast a chance to generate a second Arcane Charge, but it looks like the energize events already covered it so i didnt have to add anything special for it.

Fixes #2099 