### PR TITLE
[Feral] Update base energy regen (minor)

### DIFF
--- a/src/Parser/Druid/Feral/Modules/Features/EnergyCapTracker.js
+++ b/src/Parser/Druid/Feral/Modules/Features/EnergyCapTracker.js
@@ -13,7 +13,7 @@ import RegenResourceCapTracker from 'Parser/Core/Modules/RegenResourceCapTracker
  */
 const debugIsPlayerAbove115 = false;
 
-const BASE_ENERGY_REGEN = 10;
+const BASE_ENERGY_REGEN = 11;
 const CHATOYANT_SIGNET_REGEN_MULTIPLIER = 1.05;
 
 const BASE_ENERGY_MAX = 100;


### PR DESCRIPTION
As per the August 30th 2018 hotfixes, Feral's base energy regeneration has been increased from 10 per second to 11 per second: https://worldofwarcraft.com/en-us/news/21973195

The other Feral changes in that hotfix have no effect on existing modules.