### PR TITLE
[Bug] [Disc Priest] Gift of Forgiveness fix

### DIFF
--- a/src/Parser/Priest/Discipline/Modules/AzeriteTraits/GiftOfForgiveness.js
+++ b/src/Parser/Priest/Discipline/Modules/AzeriteTraits/GiftOfForgiveness.js
@@ -37,8 +37,9 @@ class GiftOfForgiveness extends Analyzer {
     // always active, to display the "potential"
     this.active = true;
 
-    this.giftRanks = this.selectedCombatant.traitRanks(SPELLS.GIFT_OF_FORGIVENESS.id);
+    this.giftRanks = this.selectedCombatant.traitRanks(SPELLS.GIFT_OF_FORGIVENESS.id) || [];
     this.giftTooltipBonusDmg = this.giftRanks.map((rank) => calculateAzeriteEffects(SPELLS.GIFT_OF_FORGIVENESS.id, rank)[0]).reduce((total, bonus) => total + bonus[0], 0);
+    this.giftTooltipBonusDmg = 0;
 
     this.hasGift = this.giftRanks.length > 0;
 

--- a/src/Parser/Priest/Discipline/Modules/AzeriteTraits/GiftOfForgiveness.js
+++ b/src/Parser/Priest/Discipline/Modules/AzeriteTraits/GiftOfForgiveness.js
@@ -39,7 +39,6 @@ class GiftOfForgiveness extends Analyzer {
 
     this.giftRanks = this.selectedCombatant.traitRanks(SPELLS.GIFT_OF_FORGIVENESS.id) || [];
     this.giftTooltipBonusDmg = this.giftRanks.map((rank) => calculateAzeriteEffects(SPELLS.GIFT_OF_FORGIVENESS.id, rank)[0]).reduce((total, bonus) => total + bonus[0], 0);
-    this.giftTooltipBonusDmg = 0;
 
     this.hasGift = this.giftRanks.length > 0;
 

--- a/src/Parser/Priest/Discipline/SpellCalculations.js
+++ b/src/Parser/Priest/Discipline/SpellCalculations.js
@@ -46,7 +46,7 @@ export const OffensivePenanceBoltEstimation = statWrapper(
 );
 
 // Estimation of how much output a Smite will do
-export const SmiteEstimation = (stats, sins, giftRanks) => {
+export const SmiteEstimation = (stats, sins, giftRanks = [340]) => {
   return (giftActive) => {
     const currentIntellect = stats.currentIntellectRating;
     const currentVers = 1 + stats.currentVersatilityPercentage;


### PR DESCRIPTION
A quick and dirty fix for the trait, the .map on undefined caused a crash for all priests without the "Gift of Forgiveness" trait.

![image](https://user-images.githubusercontent.com/29842841/45146766-ce23ec80-b1c3-11e8-8b17-60ef4b945902.png)
![image](https://user-images.githubusercontent.com/29842841/45146800-d7ad5480-b1c3-11e8-8dab-dc8a1f95ad39.png)
@rubensayshi might want to double-check it if I messed something up. Should be good for a merge tho, worst case is that people without the trait might get a suggestion with wrong numbers.