### PR TITLE
[Death Knight] Fixed a typo and updated Howling Blast module to not penalize dot application

### DIFF
--- a/src/Parser/DeathKnight/Frost/CHANGELOG.js
+++ b/src/Parser/DeathKnight/Frost/CHANGELOG.js
@@ -8,6 +8,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
     {
+      date: new Date('2018-09-07'),
+      changes: <React.Fragment>Updated the <SpellLink id={SPELLS.HOWLING_BLAST.id} /> module allow for hardcasting <SpellLink id={SPELLS.HOWLING_BLAST.id} /> to apply <SpellLink id={SPELLS.FROST_FEVER.id} /></React.Fragment>,
+      contributors: [Khazak],
+    },
+    {
       date: new Date('2018-08-27'),
       changes: <React.Fragment>Added module for <SpellLink id={SPELLS.KILLING_MACHINE.id} /> efficiency and overhauled the <SpellLink id={SPELLS.RIME.id} /> efficiency module </React.Fragment>,
       contributors: [Khazak],

--- a/src/Parser/DeathKnight/Frost/Modules/Features/HardHowlingBlastCasts.js
+++ b/src/Parser/DeathKnight/Frost/Modules/Features/HardHowlingBlastCasts.js
@@ -1,24 +1,30 @@
 import React from 'react';
 import Analyzer from 'Parser/Core/Analyzer';
+import Enemies from 'Parser/Core/Modules/Enemies';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
 import StatisticBox, { STATISTIC_ORDER } from 'Interface/Others/StatisticBox';
 
+const debug = false;
+
 class HardHowlingBlastCasts extends Analyzer {
   static dependencies = {
     abilityTracker: AbilityTracker,
+    enemies: Enemies,
   };
 
   castsWithoutRime = 0;
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
+    const target = this.enemies.getEntity(event);
     if (spellId !== SPELLS.HOWLING_BLAST.id) {
       return;
     }
-    if (!this.selectedCombatant.hasBuff(SPELLS.RIME.id, event.timestamp)) {
+    if (!this.selectedCombatant.hasBuff(SPELLS.RIME.id, event.timestamp) && target.hasBuff(SPELLS.FROST_FEVER.id)) {
       this.castsWithoutRime += 1;
+      debug && console.log(`Caught a HB hardcast at ${event.timestamp}`);
     }
   }
 
@@ -29,7 +35,7 @@ class HardHowlingBlastCasts extends Analyzer {
         icon={<SpellIcon id={SPELLS.RIME.id} />}
         value={this.castsWithoutRime}
         label="Howling Blasts without Rime proc"
-        tooltip="You should aim to get this as close to 0 as possible.  It is almost always a DPS loss to cast Howling Blast without Rime.  The only time you should do this is during extended periods of being out of melee range, long enough that you get capped on runes.  In this case, it is acceptable to dump runes to build RP and stop yourself from capping.  "
+        tooltip="You should aim to get this as close to 0 as possible.  It is almost always a DPS loss to cast Howling Blast without Rime.  It is okay to do this during extended periods of being out of melee range.  In this case, it is acceptable to dump runes to build RP and stop yourself from capping runes.  It is also okay to hardcast to apply Frost Fever to a target.  The analyzer does not count it against you when you do this"
       />
     );
   }

--- a/src/Parser/DeathKnight/Unholy/Modules/Features/Apocalypse.js
+++ b/src/Parser/DeathKnight/Unholy/Modules/Features/Apocalypse.js
@@ -36,7 +36,7 @@ class Apocalypse extends Analyzer {
 	//Getting 6 wounds on every Apocalypse isn't difficult and should be expected
     when(averageWoundsPopped).isLessThan(6)
         .addSuggestion((suggest, actual, recommended) => {
-          return suggest(<span>You are casting <SpellLink id={SPELLS.APOCALYPSE.id} /> with too few <SpellLink id={SPELLS.FESTERING_WOUND.id} /> on the target. When casting <SpellLink id={SPELLS.APOCALYPSE.id} />, make sure to have at least 6 <SpellLink id={SPELLS.FESTERING_WOUND.id} /> on the target.</span>)
+          return suggest(<span>You are casting <SpellLink id={SPELLS.APOCALYPSE.id} /> with too few <SpellLink id={SPELLS.FESTERING_WOUND.id} /> on the target. When casting <SpellLink id={SPELLS.APOCALYPSE.id} />, make sure to have at least 4 <SpellLink id={SPELLS.FESTERING_WOUND.id} /> on the target.</span>)
             .icon(SPELLS.APOCALYPSE.icon)
             .actual(`An average ${(actual)} of Festering Wounds were popped by Apocalypse`)
             .recommended(`${(recommended)} is recommended`)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10967144/45232496-3e4e7300-b295-11e8-885b-44496f224dff.png)

After the first week of raiding, I've noticed that Rime procs are coming much more infrequently with the reduction in haste from Legion.  Due to the slower spec speed and general tendency of FDK to stack mastery now, the old rotation of never casting HB without Rime no longer applies.  The APL was updated to priorities casting HB if the target does not have the dot so I've updated the module to reflect that policy.  There is also a typo correction for UH.  