### PR TITLE
[Core] [Bug] Character spec space fix

### DIFF
--- a/src/Interface/Character/Parses.js
+++ b/src/Interface/Character/Parses.js
@@ -183,7 +183,7 @@ class Parses extends React.Component {
 
       return {
         name: elem.encounterName,
-        spec: elem.spec,
+        spec: elem.spec.replace(' ', ''),
         difficulty: DIFFICULTIES[elem.difficulty],
         report_code: elem.reportID,
         report_fight: elem.fightID,


### PR DESCRIPTION
The spec filter does currently not work on spec-names with spaces in it (like Beast Mastery).
Pretty sure it used to be `BeastMastery` before the character-endpoint rewrite (was first a specID and was changed later on to a readable-format)