### PR TITLE
[Hunter/Core] Arcane Torrent exclusion and buffSpellID

### DIFF
--- a/src/Parser/Core/Modules/Racials/BloodElf/ArcaneTorrent.js
+++ b/src/Parser/Core/Modules/Racials/BloodElf/ArcaneTorrent.js
@@ -2,6 +2,9 @@ import SPELLS from 'common/SPELLS';
 import RACES from 'game/RACES';
 import Analyzer from 'Parser/Core/Analyzer';
 import Abilities from 'Parser/Core/Modules/Abilities';
+import SPECS from 'game/SPECS';
+
+const CLASSES_NOT_BENEFITTING = [SPECS.FIRE_MAGE, SPECS.FROST_MAGE];
 
 class ArcaneTorrent extends Analyzer {
   static dependencies = {
@@ -10,8 +13,9 @@ class ArcaneTorrent extends Analyzer {
 
   constructor(...args) {
     super(...args);
+    const spec = this.selectedCombatant.spec;
     this.active = this.selectedCombatant.race && this.selectedCombatant.race === RACES.BloodElf;
-    if (!this.active) {
+    if (!this.active || CLASSES_NOT_BENEFITTING.includes(spec)) {
       return;
     }
 

--- a/src/Parser/Core/Modules/Racials/BloodElf/ArcaneTorrent.js
+++ b/src/Parser/Core/Modules/Racials/BloodElf/ArcaneTorrent.js
@@ -4,7 +4,7 @@ import Analyzer from 'Parser/Core/Analyzer';
 import Abilities from 'Parser/Core/Modules/Abilities';
 import SPECS from 'game/SPECS';
 
-const CLASSES_NOT_BENEFITTING = [SPECS.FIRE_MAGE, SPECS.FROST_MAGE];
+const CLASSES_NOT_BENEFITTING = [SPECS.FIRE_MAGE, SPECS.FROST_MAGE, SPECS.MARKSMANSHIP_HUNTER];
 
 class ArcaneTorrent extends Analyzer {
   static dependencies = {

--- a/src/Parser/Hunter/Survival/Modules/Abilities.js
+++ b/src/Parser/Hunter/Survival/Modules/Abilities.js
@@ -41,6 +41,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.SERPENT_STING_SV,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        buffSpellId: SPELLS.VIPERS_VENOM_BUFF.id, //to show users of the Vipers Venom talent when they were casting Serpent Sting with Viper's Venom active in the timeline
         gcd: {
           base: 1500,
         },


### PR DESCRIPTION
Adds a buffspellid for a survival spell
Adds an exclusion list for arcane torrent and I added fire/frost mage and MM hunter as they don't benefit from the racial (marks never casts it ideally) 