### PR TITLE
[Marksmanship] Steady Focus GCD

### DIFF
--- a/src/Parser/Hunter/Marksmanship/CHANGELOG.js
+++ b/src/Parser/Hunter/Marksmanship/CHANGELOG.js
@@ -8,13 +8,18 @@ import { Blazballs, JLassie82, Putro } from 'CONTRIBUTORS';
 
 export default [
   {
+    date: new Date('2018-08-06'),
+    changes: <React.Fragment>Adds initial tracking for <SpellLink id={SPELLS.STEADY_FOCUS_TALENT.id} /> to ensure the GCD is accurate in the analyzer.</React.Fragment>,
+    contributors: [Putro],
+  },
+  {
     date: new Date('2018-08-12'),
     changes: 'Removed all legendaries and tier gear in preparation for Battle for Azeroth launch',
     contributors: [Putro],
   },
   {
     date: new Date('2018-08-06'),
-    changes: <React.Fragment>Created a <SpellLink id={SPELLS.CAREFUL_AIM_TALENT.id} /> module, adds buff indicators to relevant spells in the timeline, adjusted placement of statistic boxes and added example logs to everything BFA related.</React.Fragment>,
+    changes: <React.Fragment>Adds buff indicators to relevant spells in the timeline, adjusted placement of statistic boxes and added example logs to everything BFA related.</React.Fragment>,
     contributors: [Putro],
   },
   {

--- a/src/Parser/Hunter/Marksmanship/CombatLogParser.js
+++ b/src/Parser/Hunter/Marksmanship/CombatLogParser.js
@@ -1,5 +1,6 @@
 import CoreCombatLogParser from 'Parser/Core/CombatLogParser';
 import DamageDone from 'Parser/Core/Modules/DamageDone';
+import GlobalCooldown from 'Parser/Hunter/Marksmanship/Modules/Core/GlobalCooldown';
 import Channeling from './Modules/Features/Channeling';
 import Abilities from './Modules/Abilities';
 
@@ -31,6 +32,7 @@ import HuntersMark from './Modules/Talents/HuntersMark';
 import SerpentSting from './Modules/Talents/SerpentSting';
 import NaturalMending from '../Shared/Modules/Talents/NaturalMending';
 import Trailblazer from '../Shared/Modules/Talents/Trailblazer';
+import SteadyFocus from './Modules/Talents/SteadyFocus';
 
 //Focus
 import FocusTracker from '../Shared/Modules/Features/FocusChart/FocusTracker';
@@ -45,6 +47,7 @@ class CombatLogParser extends CoreCombatLogParser {
     damageDone: [DamageDone, { showStatistic: true }],
     abilities: Abilities,
     channeling: Channeling,
+    globalCooldown: GlobalCooldown,
 
     // Features
     alwaysBeCasting: AlwaysBeCasting,
@@ -77,6 +80,7 @@ class CombatLogParser extends CoreCombatLogParser {
     callingTheShots: CallingTheShots,
     huntersMark: HuntersMark,
     serpentSting: SerpentSting,
+    steadyFocus: SteadyFocus,
     naturalMending: NaturalMending,
     trailblazer: Trailblazer,
 

--- a/src/Parser/Hunter/Marksmanship/Modules/Core/GlobalCooldown.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Core/GlobalCooldown.js
@@ -1,0 +1,44 @@
+import CoreGlobalCooldown from 'Parser/Core/Modules/GlobalCooldown';
+import StatTracker from 'Parser/Core/Modules/StatTracker';
+import Channeling from 'Parser/Core/Modules/Channeling';
+import SPELLS from 'common/SPELLS';
+import Haste from 'Parser/Core/Modules/Haste';
+import SteadyFocus from 'Parser/Hunter/Marksmanship/Modules/Talents/SteadyFocus';
+import Abilities from '../Abilities';
+
+const STEADY_FOCUS_GCD_REDUCTION_PER_STACK = 0.2;
+
+const MIN_GCD = 750;
+
+/**
+ * Steady Focus:
+ * Using Steady Shot reduces the cast time of Steady Shot by 20%, stacking up to 2 times.  Using any other shot removes this effect.
+ */
+
+class GlobalCooldown extends CoreGlobalCooldown {
+  static dependencies = {
+    abilities: Abilities,
+    haste: Haste,
+    statTracker: StatTracker,
+    channeling: Channeling,
+    steadyFocus: SteadyFocus,
+  };
+
+  stacks = 0;
+
+  getGlobalCooldownDuration(spellId) {
+    const gcd = super.getGlobalCooldownDuration(spellId);
+    if (!gcd) {
+      return 0;
+    }
+    if (spellId && spellId === SPELLS.STEADY_SHOT.id && this.selectedCombatant.hasBuff(SPELLS.STEADY_FOCUS_BUFF.id)) {
+      this.stacks = this.steadyFocus.getSteadyFocusStacks;
+      //console.log("in GCD module: ", this.stacks);
+      return Math.max(MIN_GCD, (gcd * (1 - (STEADY_FOCUS_GCD_REDUCTION_PER_STACK * this.stacks))) / (1 + this.statTracker.currentHastePercentage));
+    }
+    return Math.max(MIN_GCD, gcd);
+  }
+
+}
+
+export default GlobalCooldown;

--- a/src/Parser/Hunter/Marksmanship/Modules/Core/GlobalCooldown.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Core/GlobalCooldown.js
@@ -33,7 +33,6 @@ class GlobalCooldown extends CoreGlobalCooldown {
     }
     if (spellId && spellId === SPELLS.STEADY_SHOT.id && this.selectedCombatant.hasBuff(SPELLS.STEADY_FOCUS_BUFF.id)) {
       this.stacks = this.steadyFocus.getSteadyFocusStacks;
-      //console.log("in GCD module: ", this.stacks);
       return Math.max(MIN_GCD, (gcd * (1 - (STEADY_FOCUS_GCD_REDUCTION_PER_STACK * this.stacks))) / (1 + this.statTracker.currentHastePercentage));
     }
     return Math.max(MIN_GCD, gcd);

--- a/src/Parser/Hunter/Marksmanship/Modules/Talents/SteadyFocus.js
+++ b/src/Parser/Hunter/Marksmanship/Modules/Talents/SteadyFocus.js
@@ -1,0 +1,45 @@
+import Analyzer from 'Parser/Core/Analyzer';
+
+import SPELLS from 'common/SPELLS';
+
+/**
+ * Using Steady Shot reduces the cast time of Steady Shot by 20%, stacking up to 2 times.  Using any other shot removes this effect. *
+ * Example log: https://www.warcraftlogs.com/reports/ChbVRqzQ8Z6najGB#fight=3&type=auras&source=3
+ */
+class SteadyFocus extends Analyzer {
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.STEADY_FOCUS_TALENT.id);
+  }
+
+  stacks = 0;
+
+  getSteadyFocusStacks() {
+    return this.stacks;
+  }
+
+  on_byPlayer_applybuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.STEADY_FOCUS_BUFF.id) {
+      return;
+    }
+    this.stacks = 1;
+  }
+  on_byPlayer_applybuffstack(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.STEADY_FOCUS_BUFF.id) {
+      return;
+    }
+    this.stacks = event.stack;
+  }
+  on_byPlayer_removebuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.STEADY_FOCUS_BUFF.id) {
+      return;
+    }
+    this.stacks = 0;
+  }
+}
+
+export default SteadyFocus;


### PR DESCRIPTION
The talent, Steady Focus, reduces GCD and cast time of the spell Steady Shot. 

This PR addresses that issue and reduces the amount of errors related to that to 0.