### PR TITLE
[Frost Mage] [Bug] Checklist fix

### DIFF
--- a/src/Parser/Mage/Frost/Modules/Features/Abilities.js
+++ b/src/Parser/Mage/Frost/Modules/Features/Abilities.js
@@ -21,7 +21,8 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(SPELLS.EBONBOLT_TALENT.id),
         castEfficiency: {
           //If using Glacial Spike, it is recommended to hold Ebonbolt as an emergency proc if GS is available and you dont have a Brain Freeze Proc. Therefore, with good luck, it is possible to go the entire fight without casting Ebonbolt.
-          disabled: combatant.hasTalent(SPELLS.GLACIAL_SPIKE_TALENT.id) ? true : false,
+          // disabled: combatant.hasTalent(SPELLS.GLACIAL_SPIKE_TALENT.id) ? true : false,
+          // disabled the disabled, caused a crash in the checklist
           suggestion: true,
           recommendedEfficiency: 0.90,
         },


### PR DESCRIPTION
Disabling Ebonbolt based on glacial spike is causing a crash in the checklist.
This will fix the crash, but might show a "wrong" suggestion for Ebonbolt. But I'm not sure how likely the "dont have to cast ebonbolt once with good procs" is.