### PR TITLE
Scale Raid Health graph with Group / Raid size

### DIFF
--- a/src/Parser/Core/Modules/Features/RaidHealthTab/TabComponent/Graph.js
+++ b/src/Parser/Core/Modules/Features/RaidHealthTab/TabComponent/Graph.js
@@ -151,7 +151,7 @@ class Graph extends React.PureComponent {
               return `${value}%`;
             },
             min: 0,
-            max: 20 * 100,
+            max: players.length * 100,
             fontSize: 14,
           },
           stacked: true,


### PR DESCRIPTION
Small change that lets the raid health tab graph scale with the member size, as its currently hardcoded for 20 people which creates issues.

Before, 25 people and the graph gets cut off at 20:
![image](https://user-images.githubusercontent.com/2842471/45261100-ccdc0500-b3f9-11e8-952a-896ecd07600c.png)
After:
![image](https://user-images.githubusercontent.com/2842471/45261102-e67d4c80-b3f9-11e8-9bee-2109feb41af4.png)
Log: https://www.warcraftlogs.com/reports/TKAabrZjwdJcFq67/#fight=18&source=56

5 man example:
![image](https://user-images.githubusercontent.com/2842471/45261115-2d6b4200-b3fa-11e8-8cbb-17190a80451e.png)
After:
![image](https://user-images.githubusercontent.com/2842471/45261116-322ff600-b3fa-11e8-87c7-614dc73537ec.png)
Log: https://www.warcraftlogs.com/reports/KQgVRXZzHraNhP7x/#fight=1&source=1