### PR TITLE
Warlock Demo Icon Fix

### DIFF
--- a/src/Parser/Warlock/Demonology/Modules/Features/DoomUptime.js
+++ b/src/Parser/Warlock/Demonology/Modules/Features/DoomUptime.js
@@ -40,7 +40,7 @@ class DoomUptime extends Analyzer {
     when(this.suggestionThresholds)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<React.Fragment>Your <SpellLink id={SPELLS.DOOM_TALENT.id} /> uptime can be improved. Try to pay more attention to your Doom on the boss, as it is one of your Soul Shard generators.</React.Fragment>)
-          .icon(SPELLS.DOOM.icon)
+          .icon(SPELLS.DOOM_TALENT.icon)
           .actual(`${formatPercentage(actual)}% Doom uptime`)
           .recommended(`>${formatPercentage(recommended)}% is recommended`);
       });


### PR DESCRIPTION
Fixes this error:
TypeError: Cannot read property 'icon' of undefined

Log: https://wowanalyzer.com/report/FWy6qGfHm7JwB3an/2-Normal+Mythrax+-+Kill+(7:45)/21-Beware