### PR TITLE
[BrM] Elusive Footwork trait

### DIFF
--- a/src/Parser/Core/Combatant.js
+++ b/src/Parser/Core/Combatant.js
@@ -233,25 +233,6 @@ class Combatant extends Entity {
   hasTrinket(itemId) {
     return this.getTrinket(itemId) !== undefined;
   }
-  get mainHand() {
-    return this._getGearItemBySlotId(GEAR_SLOTS.MAINHAND);
-  }
-  get offHand() {
-    return this._getGearItemBySlotId(GEAR_SLOTS.OFFHAND);
-  }
-  getWeapon(itemId) {
-    if(this.mainHand && this.mainHand.id === itemId) {
-      return this.mainHand;
-    }
-    if(this.offHand && this.offHand.id === itemId) {
-      return this.offHand;
-    }
-
-    return undefined;
-  }
-  hasWeapon(itemId) {
-    return this.getWeapon(itemId) !== undefined;
-  }
   getItem(itemId) {
     return Object.keys(this._gearItemsBySlotId)
       .map(key => this._gearItemsBySlotId[key])

--- a/src/Parser/Core/Combatant.js
+++ b/src/Parser/Core/Combatant.js
@@ -233,6 +233,25 @@ class Combatant extends Entity {
   hasTrinket(itemId) {
     return this.getTrinket(itemId) !== undefined;
   }
+  get mainHand() {
+    return this._getGearItemBySlotId(GEAR_SLOTS.MAINHAND);
+  }
+  get offHand() {
+    return this._getGearItemBySlotId(GEAR_SLOTS.OFFHAND);
+  }
+  getWeapon(itemId) {
+    if(this.mainHand && this.mainHand.id === itemId) {
+      return this.mainHand;
+    }
+    if(this.offHand && this.offHand.id === itemId) {
+      return this.offHand;
+    }
+
+    return undefined;
+  }
+  hasWeapon(itemId) {
+    return this.getWeapon(itemId) !== undefined;
+  }
   getItem(itemId) {
     return Object.keys(this._gearItemsBySlotId)
       .map(key => this._gearItemsBySlotId[key])

--- a/src/Parser/Monk/Brewmaster/CHANGELOG.js
+++ b/src/Parser/Monk/Brewmaster/CHANGELOG.js
@@ -8,6 +8,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-09-13'),
+    changes: <React.Fragment>Added support for <SpellLink id={SPELLS.ELUSIVE_FOOTWORK.id} />.</React.Fragment>,
+    contributors: [emallson],
+  },
+  {
     date: new Date('2018-08-11'),
     changes: <React.Fragment>Added support for <SpellLink id={SPELLS.STAGGERING_STRIKES.id} />.</React.Fragment>,
     contributors: [emallson],

--- a/src/Parser/Monk/Brewmaster/CombatLogParser.js
+++ b/src/Parser/Monk/Brewmaster/CombatLogParser.js
@@ -25,6 +25,7 @@ import Guard from './Modules/Spells/Guard';
 // Azerite Traits
 import TrainingOfNiuzao from './Modules/Spells/AzeriteTraits/TrainingOfNiuzao';
 import StaggeringStrikes from './Modules/Spells/AzeriteTraits/StaggeringStrikes';
+import ElusiveFootwork from './Modules/Spells/AzeriteTraits/ElusiveFootwork';
 // Features
 import Checklist from './Modules/Features/Checklist';
 import Abilities from './Modules/Abilities';
@@ -80,6 +81,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Azerite Traits
     trainingOfNiuzao: TrainingOfNiuzao,
     staggeringStrikes: StaggeringStrikes,
+    elusiveFootwork: ElusiveFootwork,
 
     // Items
     t20_2pc: T20_2pc,

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/AzeriteTraits/ElusiveFootwork.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/AzeriteTraits/ElusiveFootwork.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+
+import SPELLS from 'common/SPELLS';
+import HIT_TYPES from 'Parser/Core/HIT_TYPES';
+import { calculateAzeriteEffects } from 'common/stats';
+import { formatNumber } from 'common/format';
+import TraitStatisticBox, { STATISTIC_ORDER } from 'Interface/Others/TraitStatisticBox';
+import ItemDamageDone from 'Interface/Others/ItemDamageDone';
+
+/**
+ * Elusive Footwork
+ *
+ * Increases your Blackout Strike damage by X. When your Blackout Strike
+ * critically strikes, gain a stack of Mastery: Elusive Brawler.
+ *
+ * Example Report: https://www.warcraftlogs.com/reports/vyx6wk2PVZMDfzhK#fight=12&source=11
+ */
+class ElusiveFootwork extends Analyzer {
+  // damage added by traits
+  _bonusDamagePerCast = 0;
+  _bonusDamage = 0; // sum over all casts
+
+  // stacks gained
+  _ebStacksGenerated = 0;
+
+  _casts = 0;
+  
+  constructor(...args) {
+    super(...args);
+    if(!this.selectedCombatant.hasTrait(SPELLS.ELUSIVE_FOOTWORK.id)) {
+      this.active = false;
+      return;
+    }
+
+    this._bonusDamagePerCast = this.selectedCombatant.traitsBySpellId[SPELLS.ELUSIVE_FOOTWORK.id]
+      .reduce((sum, rank) => sum + calculateAzeriteEffects(SPELLS.ELUSIVE_FOOTWORK.id, rank)[0], 0);
+  }
+
+  on_byPlayer_damage(event) {
+    if(event.ability.guid !== SPELLS.BLACKOUT_STRIKE.id) {
+      return;
+    }
+
+    this._ebStacksGenerated += 1;
+    this._bonusDamage += this._expectedBonusDamage(event);
+    this._casts += 1;
+  }
+
+  // this is an *approximation*. the attackPower field i'm getting is
+  // basically always 0, so we're going to only include damage reduction
+  // on the target and ignore damage bonuses (e.g. from spec aura or
+  // bonuses).
+  _expectedBonusDamage(event) {
+    const critMultiplier = (event.hitType === HIT_TYPES.CRIT) ? 2 : 1;
+    return event.amount / event.unmitigatedAmount * this._bonusDamagePerCast * critMultiplier;
+  }
+
+  statistic() {
+    return (
+      <TraitStatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
+        trait={SPELLS.ELUSIVE_FOOTWORK.id}
+        value={(
+          <ItemDamageDone amount={this._bonusDamage} />
+        )}
+        tooltip={`Your Blackout Strike casts each dealt an average ${formatNumber(this._bonusDamage / this._casts)} additional damage.<br/>
+            You generated an additional ${this._ebStacksGenerated} stacks of Elusive Brawler.`}
+      />
+    );
+  }
+}
+
+export default ElusiveFootwork;

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/AzeriteTraits/ElusiveFootwork.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/AzeriteTraits/ElusiveFootwork.js
@@ -14,7 +14,7 @@ import ItemDamageDone from 'Interface/Others/ItemDamageDone';
  * Increases your Blackout Strike damage by X. When your Blackout Strike
  * critically strikes, gain a stack of Mastery: Elusive Brawler.
  *
- * Example Report: https://www.warcraftlogs.com/reports/vyx6wk2PVZMDfzhK#fight=12&source=11
+ * Example Report: https://www.warcraftlogs.com/reports/TfcmpjkbNhq18yBF#fight=4&type=summary&source=14
  */
 class ElusiveFootwork extends Analyzer {
   // damage added by traits


### PR DESCRIPTION
![screenshot from 2018-09-13 15-09-13](https://user-images.githubusercontent.com/4909458/45510310-d81b9180-b767-11e8-907a-78b7926b9aff.png)

This is one of the traits related to issue #2088.

In the logs I tested, I didn't get any `attackPower` values from the log (they were all 0) so I instead just used the ratio of `amount / unmitigatedAmount` to estimate the ratio of damage mitigated by e.g. boss armor. Checking the end of the [MOTHER](https://www.warcraftlogs.com/reports/TfcmpjkbNhq18yBF#fight=4&type=summary&source=14) fight (where she takes increased damage), the ratio is > 1 so the extra damage taken is accounted for.

I don't know that this is totally correct, but I'm willing to bet that it is close enough.

This PR also adds mainHand/offHand props for combatants, which were previously missing. I was going to use them to calculate WDPS but then switched to the ratio method above.