### PR TITLE
[Item] Construct Overcharger number fix (minor)

### DIFF
--- a/src/Parser/Core/Modules/Items/BFA/Raids/Uldir/ConstructOvercharger.js
+++ b/src/Parser/Core/Modules/Items/BFA/Raids/Uldir/ConstructOvercharger.js
@@ -18,7 +18,7 @@ class ConstructOvercharger extends Analyzer{
     super(...args);
     this.active = this.selectedCombatant.hasTrinket(ITEMS.CONSTRUCT_OVERCHARGER.id);
     if(this.active){
-      this.statBuff = calculateSecondaryStatDefault(350, 21, this.selectedCombatant.getItem(ITEMS.CONSTRUCT_OVERCHARGER.id).itemLevel);
+      this.statBuff = calculateSecondaryStatDefault(355, 35, this.selectedCombatant.getItem(ITEMS.CONSTRUCT_OVERCHARGER.id).itemLevel);
     }
   }
 


### PR DESCRIPTION
At some point the amount of haste provided by this trinket was changed. Updated to match in-game values.