### PR TITLE
Enchant Checker - Remove cheap enchants

### DIFF
--- a/src/Parser/Core/Modules/Items/EnchantChecker.js
+++ b/src/Parser/Core/Modules/Items/EnchantChecker.js
@@ -35,10 +35,6 @@ class EnchantChecker extends Analyzer {
     3370, // Rune of Razorice - Death Knight Only
     3847, // Rune of the Stoneskin Gargoyle - Death Knight Only
 
-    5938, // Seal of Critical Strike
-    5939, // Seal of Haste
-    5940, // Seal of Mastery
-    5941, // Seal of Versatility
     5942, // Pact of Critical Strike
     5943, // Pact of Haste
     5944, // Pact of Mastery


### PR DESCRIPTION
Noticed the `Be Well Prepared` checklist section didn't complain at me with my cheap enchants, seems they slipped into the maximum enchants list. 