### PR TITLE
[Core] Meticulous Scheming trait

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -9,6 +9,11 @@ import Contributor from 'Interface/Contributor/Button';
 
 export default [
   {
+    date: new Date('2018-09-16'),
+    changes: <React.Fragment>Added a <SpellLink id={SPELLS.METICULOUS_SCHEMING.id} />-module.</React.Fragment>,
+    contributors: [joshinator],
+  },
+  {
     date: new Date('2018-09-12'),
     changes: 'Added support for item Seabreeze',
     contributors: [blazyb],

--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -78,6 +78,7 @@ import Seabreeze from './Modules/Items/BFA/Dungeons/Seabreeze';
 import DarkmoonDeckTides from './Modules/Items/BFA/Crafted/DarkmoonDeckTides';
 // Azerite Traits
 import Gemhide from './Modules/Spells/BFA/AzeriteTraits/Gemhide';
+import MeticulousScheming from './Modules/Spells/BFA/AzeriteTraits/MeticulousScheming';
 // Uldir
 import TwitchingTentacleofXalzaix from './Modules/Items/BFA/Raids/Uldir/TwitchingTentacleofXalzaix';
 import VigilantsBloodshaper from './Modules/Items/BFA/Raids/Uldir/VigilantsBloodshaper';
@@ -167,6 +168,7 @@ class CombatLogParser {
     darkmoonDeckTides: DarkmoonDeckTides,
     // Azerite Traits
     gemhide: Gemhide,
+    meticulousScheming: MeticulousScheming,
     // Uldir
     twitchingTentacleofXalzaix: TwitchingTentacleofXalzaix,
     vigilantsBloodshaper: VigilantsBloodshaper,

--- a/src/Parser/Core/Modules/Spells/BFA/AzeriteTraits/MeticulousScheming.js
+++ b/src/Parser/Core/Modules/Spells/BFA/AzeriteTraits/MeticulousScheming.js
@@ -46,7 +46,7 @@ class MeticulousScheming extends Analyzer {
   }
 
   on_byPlayer_refreshbuff(event) {
-    // this.handleBuff(event);
+    this.handleBuff(event);
   }
 
   handleBuff(event) {

--- a/src/Parser/Core/Modules/Spells/BFA/AzeriteTraits/MeticulousScheming.js
+++ b/src/Parser/Core/Modules/Spells/BFA/AzeriteTraits/MeticulousScheming.js
@@ -1,0 +1,109 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import { formatPercentage } from 'common/format';
+import { calculateAzeriteEffects } from 'common/stats';
+import Analyzer from 'Parser/Core/Analyzer';
+import TraitStatisticBox, { STATISTIC_ORDER } from 'Interface/Others/TraitStatisticBox';
+
+const meticulousSchemingStats = traits => Object.values(traits).reduce((obj, rank) => {
+  const [haste] = calculateAzeriteEffects(SPELLS.METICULOUS_SCHEMING.id, rank);
+  obj.haste += haste;
+  return obj;
+}, {
+  haste: 0,
+});
+
+export const STAT_TRACKER = {
+  haste: combatant => meticulousSchemingStats(combatant.traitsBySpellId[SPELLS.METICULOUS_SCHEMING.id]).haste,
+};
+
+/**
+ * Meticulous Scheming
+ * Gain x haste for 20sec after casting 3 different spells within 8sec after gaining "Meticulous Scheming"
+ *
+ * Example report: https://www.warcraftlogs.com/reports/jBthQCZcWRNGyAk1#fight=29&type=auras&source=18
+ */
+class MeticulousScheming extends Analyzer {
+  haste = 0;
+  meticulousSchemingProcs = 0;
+  seizeTheMomentProcs = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrait(SPELLS.METICULOUS_SCHEMING.id);
+    if (!this.active) {
+      return;
+    }
+
+    const { haste } = meticulousSchemingStats(this.selectedCombatant.traitsBySpellId[SPELLS.METICULOUS_SCHEMING.id]);
+    this.haste = haste;
+  }
+
+  on_byPlayer_applybuff(event) {
+    this.handleBuff(event);
+  }
+
+  on_byPlayer_refreshbuff(event) {
+    // this.handleBuff(event);
+  }
+
+  handleBuff(event) {
+    if (event.ability.guid === SPELLS.METICULOUS_SCHEMING_BUFF.id) {
+      this.meticulousSchemingProcs += 1;
+      return;
+    }
+
+    if (event.ability.guid === SPELLS.SEIZE_THE_MOMENT.id) {
+      this.seizeTheMomentProcs += 1;
+      return;
+    }
+  }
+
+  get uptime() {
+    return this.selectedCombatant.getBuffUptime(SPELLS.SEIZE_THE_MOMENT.id) / this.owner.fightDuration;
+  }
+
+  get averageHaste() {
+    return (this.haste * this.uptime).toFixed(0);
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.seizeTheMomentProcs / this.meticulousSchemingProcs,
+      isLessThan: {
+        minor: 1,
+        average: 0.8,
+        major: .6,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestionThresholds)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<React.Fragment>You procced <SpellLink id={SPELLS.METICULOUS_SCHEMING.id} /> {this.meticulousSchemingProcs} times but got <SpellLink id={SPELLS.SEIZE_THE_MOMENT.id} /> only {this.seizeTheMomentProcs} times. That means you failed to cast 3 different spells within the 8sec window to trigger the haste buff. Pay more attention to the proc to get the most ouf of this trait.</React.Fragment>)
+          .icon(SPELLS.METICULOUS_SCHEMING.icon)
+          .actual(`${(formatPercentage(actual))}% ${SPELLS.METICULOUS_SCHEMING.name} efficiency`)
+          .recommended(`100% is recommended`);
+      });
+  }
+
+  statistic() {
+    return (
+      <TraitStatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
+        trait={SPELLS.METICULOUS_SCHEMING.id}
+        value={`${this.averageHaste} Haste`}
+        tooltip={`
+          ${SPELLS.METICULOUS_SCHEMING.name} grants <b>${this.haste} haste</b> while active.<br/>
+          You procced <b>${SPELLS.METICULOUS_SCHEMING_BUFF.name} ${this.meticulousSchemingProcs} times</b> and activated <b>${SPELLS.SEIZE_THE_MOMENT.name} ${this.seizeTheMomentProcs} times</b>.
+        `}
+      />
+    );
+  }
+}
+
+export default MeticulousScheming;

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -6,6 +6,7 @@ import SPECS from 'game/SPECS';
 import RACES from 'game/RACES';
 import Analyzer from 'Parser/Core/Analyzer';
 import { STAT_TRACKER as GEMHIDE_STATS } from 'Parser/Core/Modules/Spells/BFA/AzeriteTraits/Gemhide';
+import { STAT_TRACKER as METICULOUS_SCHEMING_STATS } from 'Parser/Core/Modules/Spells/BFA/AzeriteTraits/MeticulousScheming';
 import {STAT_TRACKER as DANCE_OF_DEATH_STATS} from 'Parser/Hunter/BeastMastery/Modules/Spells/AzeriteTraits/DanceOfDeath';
 import { MASTERY_FNS as TON_MASTERY_FNS } from 'Parser/Monk/Brewmaster/Modules/Spells/AzeriteTraits/TrainingOfNiuzao';
 import { STAT_TRACKER as BOFD_ARMOR } from 'Parser/DeathKnight/Blood/Modules/Spells/AzeriteTraits/BonesOfTheDamned.js';
@@ -218,6 +219,7 @@ class StatTracker extends Analyzer {
     [SPELLS.CHAMPION_OF_AZEROTH.id]: { versatility: 87 },
     [SPELLS.VAMPIRIC_SPEED.id]: { speed: 196 },
     [SPELLS.GEMHIDE.id]: GEMHIDE_STATS, 
+    [SPELLS.METICULOUS_SCHEMING.id]: METICULOUS_SCHEMING_STATS, 
     [SPELLS.ELEMENTAL_WHIRL_CRIT.id]: { crit: 0 }, // TODO: Implement based on in-game data
     [SPELLS.ELEMENTAL_WHIRL_HASTE.id]: { haste: 0 }, // TODO: Implement based on in-game data
     [SPELLS.ELEMENTAL_WHIRL_MASTERY.id]: { mastery: 0 }, // TODO: Implement based on in-game data

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -219,7 +219,7 @@ class StatTracker extends Analyzer {
     [SPELLS.CHAMPION_OF_AZEROTH.id]: { versatility: 87 },
     [SPELLS.VAMPIRIC_SPEED.id]: { speed: 196 },
     [SPELLS.GEMHIDE.id]: GEMHIDE_STATS, 
-    [SPELLS.METICULOUS_SCHEMING.id]: METICULOUS_SCHEMING_STATS, 
+    [SPELLS.SEIZE_THE_MOMENT.id]: METICULOUS_SCHEMING_STATS, 
     [SPELLS.ELEMENTAL_WHIRL_CRIT.id]: { crit: 0 }, // TODO: Implement based on in-game data
     [SPELLS.ELEMENTAL_WHIRL_HASTE.id]: { haste: 0 }, // TODO: Implement based on in-game data
     [SPELLS.ELEMENTAL_WHIRL_MASTERY.id]: { mastery: 0 }, // TODO: Implement based on in-game data

--- a/src/common/SPELLS/BFA/AzeriteTraits/General.js
+++ b/src/common/SPELLS/BFA/AzeriteTraits/General.js
@@ -116,4 +116,19 @@ export default {
     name: 'Laser Matrix',
     icon: 'spell_nature_groundingtotem',
   },
+  METICULOUS_SCHEMING: {
+    id: 273682,
+    name: 'Meticulous Scheming',
+    icon: 'ability_rogue_masterofsubtlety',
+  },
+  METICULOUS_SCHEMING_BUFF: { // 8sec buff to trigger haste buff
+    id: 273685,
+    name: 'Meticulous Scheming',
+    icon: 'ability_rogue_masterofsubtlety',
+  },
+  SEIZE_THE_MOMENT: { // haste buff from Meticulous Scheming
+    id: 273714,
+    name: 'Seize the Moment!',
+    icon: 'achievement_bg_killflagcarriers_grabflag_capit',
+  },
 };

--- a/src/common/SPELLS/BFA/AzeriteTraits/__UNUSED.js
+++ b/src/common/SPELLS/BFA/AzeriteTraits/__UNUSED.js
@@ -589,11 +589,6 @@ export default {
     name: 'Meteoric Flare',
     icon: 'ability_warlock_handofguldan',
   },
-  METICULOUS_SCHEMING: {
-    id: 273682,
-    name: 'Meticulous Scheming',
-    icon: 'ability_rogue_masterofsubtlety',
-  },
   MISTY_PEAKS: {
     id: 275975,
     name: 'Misty Peaks',


### PR DESCRIPTION
Adds Meticulous Scheming's haste to the statTracker and adds a suggestion when the player failed to trigger `Seize the Moment` every `Meticulous Scheming`-proc

![image](https://user-images.githubusercontent.com/29842841/45596016-7f413880-b9b5-11e8-8e4e-ceb05c0a1c8e.png)
![image](https://user-images.githubusercontent.com/29842841/45596006-62a50080-b9b5-11e8-8cbe-555eee28360c.png)
