### PR TITLE
[Beast Mastery] Feeding Frenzy and Primal Instincts

### DIFF
--- a/src/Parser/Hunter/BeastMastery/CHANGELOG.js
+++ b/src/Parser/Hunter/BeastMastery/CHANGELOG.js
@@ -6,6 +6,11 @@ import SPELLS from 'common/SPELLS';
 
 export default [
   {
+    date: new Date('2018-09-20'),
+    changes: <React.Fragment>Added two azerite trait modules, one for <SpellLink id={SPELLS.PRIMAL_INSTINCTS.id} /> and an initial version for <SpellLink id={SPELLS.FEEDING_FRENZY.id} /></React.Fragment>,
+    contributors: [Putro],
+  },
+  {
     date: new Date('2018-08-12'),
     changes: <React.Fragment>Updated the <SpellLink id={SPELLS.BARBED_SHOT.id} /> statistic to be an expandable statistic box, to showcase uptime of 0->3 stacks separately.</React.Fragment>,
     contributors: [Putro],

--- a/src/Parser/Hunter/BeastMastery/CombatLogParser.js
+++ b/src/Parser/Hunter/BeastMastery/CombatLogParser.js
@@ -39,6 +39,7 @@ import TraitsAndTalents from './Modules/Features/TraitsAndTalents';
 import DanceOfDeath from './Modules/Spells/AzeriteTraits/DanceOfDeath';
 import HazeOfRage from './Modules/Spells/AzeriteTraits/HazeOfRage';
 import FeedingFrenzy from './Modules/Spells/AzeriteTraits/FeedingFrenzy';
+import PrimalInstincts from './Modules/Spells/AzeriteTraits/PrimalInstincts';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -82,6 +83,7 @@ class CombatLogParser extends CoreCombatLogParser {
     danceOfDeath: DanceOfDeath,
     hazeOfRage: HazeOfRage,
     feedingFrenzy: FeedingFrenzy,
+    primalInstincts: PrimalInstincts,
   };
 }
 

--- a/src/Parser/Hunter/BeastMastery/CombatLogParser.js
+++ b/src/Parser/Hunter/BeastMastery/CombatLogParser.js
@@ -38,6 +38,7 @@ import TraitsAndTalents from './Modules/Features/TraitsAndTalents';
 //Azerite Traits
 import DanceOfDeath from './Modules/Spells/AzeriteTraits/DanceOfDeath';
 import HazeOfRage from './Modules/Spells/AzeriteTraits/HazeOfRage';
+import FeedingFrenzy from './Modules/Spells/AzeriteTraits/FeedingFrenzy';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -80,6 +81,7 @@ class CombatLogParser extends CoreCombatLogParser {
     //Azerite Traits
     danceOfDeath: DanceOfDeath,
     hazeOfRage: HazeOfRage,
+    feedingFrenzy: FeedingFrenzy,
   };
 }
 

--- a/src/Parser/Hunter/BeastMastery/Modules/Abilities.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Abilities.js
@@ -35,7 +35,7 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: 0.95,
+          recommendedEfficiency: 0.9,
         },
       },
       {
@@ -98,7 +98,7 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: 0.8,
+          recommendedEfficiency: 0.9,
         },
       },
       {
@@ -111,7 +111,7 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: 0.95,
+          recommendedEfficiency: 0.75,
         },
       },
       {
@@ -124,7 +124,7 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: 0.9,
+          recommendedEfficiency: 0.8,
         },
       },
       {
@@ -150,7 +150,7 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: 0.95,
+          recommendedEfficiency: 0.85,
         },
       },
       {

--- a/src/Parser/Hunter/BeastMastery/Modules/Spells/AzeriteTraits/DanceOfDeath.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Spells/AzeriteTraits/DanceOfDeath.js
@@ -45,10 +45,6 @@ class DanceOfDeath extends Analyzer{
     return this.uptime * this.agility;
   }
 
-  get numProcs(){
-    return this.selectedCombatant.getBuffTriggerCount(SPELLS.DANCE_OF_DEATH_BUFF.id);
-  }
-
   statistic(){
     return (
       <TraitStatisticBox

--- a/src/Parser/Hunter/BeastMastery/Modules/Spells/AzeriteTraits/FeedingFrenzy.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Spells/AzeriteTraits/FeedingFrenzy.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import { formatNumber } from 'common/format';
+import TraitStatisticBox, { STATISTIC_ORDER } from 'Interface/Others/TraitStatisticBox';
+import SPELLS from 'common/SPELLS';
+
+const MS = 1000;
+
+const ORIGINAL_FRENZY_DURATION = 8000;
+
+/**
+ * Barbed Shot deals X additional damage over its duration,
+ * and Frenzy's duration is increased to 9 seconds.
+ *
+ * Example report: https://www.warcraftlogs.com/reports/m9KrNBVCtDALZpzT#source=5&type=summary&fight=1
+ */
+
+class FeedingFrenzy extends Analyzer {
+
+  extraBuffUptime = 0;
+  lastBSCast = null;
+  hasFrenzyUp = false;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrait(SPELLS.FEEDING_FRENZY.id);
+  }
+
+  extra_BS_uptime(timestamp, lastCast) {
+    const delta = timestamp - lastCast;
+    if (delta > (ORIGINAL_FRENZY_DURATION)) {
+      const ret = Math.min(delta - (ORIGINAL_FRENZY_DURATION), MS);
+      return ret;
+    } else {
+      return 0;
+    }
+  }
+  on_toPlayerPet_removebuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.BARBED_SHOT_PET_BUFF.id) {
+      return;
+    }
+    this.hasFrenzyUp = false;
+  }
+
+  on_byPlayer_applybuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.BARBED_SHOT_PET_BUFF.id) {
+      return;
+    }
+    this.hasFrenzyUp = true;
+  }
+
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.BARBED_SHOT.id || !this.hasFrenzyUp) {
+      return;
+    }
+    this.extraBuffUptime += this.extra_BS_uptime(event.timestamp, this.lastBSCast);
+    this.lastBSCast = event.timestamp;
+  }
+
+  on_finished() {
+    if (this.lastBSCast !== null) {
+      this.extraBuffUptime += this.extra_BS_uptime(this.owner.fight.end_time, this.lastBSCast);
+    }
+  }
+
+  statistic() {
+    return (
+      <TraitStatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
+        trait={SPELLS.FEEDING_FRENZY.id}
+        value={`${formatNumber(this.extraBuffUptime / MS)}s added Frenzy Uptime`}
+        tooltip={`This only accounts for the duration `}
+      />
+    );
+  }
+}
+
+export default FeedingFrenzy;

--- a/src/Parser/Hunter/BeastMastery/Modules/Spells/AzeriteTraits/FeedingFrenzy.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Spells/AzeriteTraits/FeedingFrenzy.js
@@ -5,7 +5,7 @@ import TraitStatisticBox, { STATISTIC_ORDER } from 'Interface/Others/TraitStatis
 import SPELLS from 'common/SPELLS';
 
 const MS = 1000;
-
+const MS_BUFFER = 100;
 const ORIGINAL_FRENZY_DURATION = 8000;
 
 /**
@@ -20,6 +20,9 @@ class FeedingFrenzy extends Analyzer {
   extraBuffUptime = 0;
   lastBSCast = null;
   hasFrenzyUp = false;
+  buffApplication = null;
+  timesExtended = 0;
+  casts = 0;
 
   constructor(...args) {
     super(...args);
@@ -30,6 +33,7 @@ class FeedingFrenzy extends Analyzer {
     const delta = timestamp - lastCast;
     if (delta > (ORIGINAL_FRENZY_DURATION)) {
       const ret = Math.min(delta - (ORIGINAL_FRENZY_DURATION), MS);
+      this.timesExtended += 1;
       return ret;
     } else {
       return 0;
@@ -49,11 +53,16 @@ class FeedingFrenzy extends Analyzer {
       return;
     }
     this.hasFrenzyUp = true;
+    this.buffApplication = event.timestamp;
   }
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
-    if (spellId !== SPELLS.BARBED_SHOT.id || !this.hasFrenzyUp) {
+    if (spellId !== SPELLS.BARBED_SHOT.id) {
+      return;
+    }
+    this.casts++;
+    if (!this.hasFrenzyUp || event.timestamp < this.buffApplication + MS_BUFFER) {
       return;
     }
     this.extraBuffUptime += this.extra_BS_uptime(event.timestamp, this.lastBSCast);
@@ -72,7 +81,13 @@ class FeedingFrenzy extends Analyzer {
         position={STATISTIC_ORDER.OPTIONAL()}
         trait={SPELLS.FEEDING_FRENZY.id}
         value={`${formatNumber(this.extraBuffUptime / MS)}s added Frenzy Uptime`}
-        tooltip={`This only accounts for the duration `}
+        tooltip={`This only accounts for the added uptime granted when casting Barbed Shot after 8 seconds had passed, so each cast can potentially be worth up to 1 second. <br/>
+                  This happened a total of ${this.timesExtended} ${this.timesExtended > 1 ? 'times' : 'time'}.
+                  <ul>
+                  <li>This means that you gained an average extra uptime of ${(this.extraBuffUptime / this.timesExtended / 1000).toFixed(2)}s per cast of Barbed Shot that was cast more than 8 seconds after the last one.</li>
+                  <li>Out of all your Barbed Shot casts, you gained an extra ${(this.extraBuffUptime / this.casts / 1000).toFixed(2)}s of uptime per cast.</li>
+                  </ul>
+`}
       />
     );
   }

--- a/src/Parser/Hunter/BeastMastery/Modules/Spells/AzeriteTraits/PrimalInstincts.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Spells/AzeriteTraits/PrimalInstincts.js
@@ -21,7 +21,7 @@ export const STAT_TRACKER = {
 /**
  * Aspect of the Wild increases your Mastery by X, and grants you a charge of Barbed Shot.
  *
- * Example report: https://www.warcraftlogs.com/reports/Nt9KGvDncPmVyjpd#boss=-2&difficulty=0&type=summary&source=9
+ * Example report: https://www.warcraftlogs.com/reports/QdrGMj1wFqnacXNW#fight=1&type=auras&source=13
  */
 class PrimalInstincts extends Analyzer {
   mastery = 0;

--- a/src/Parser/Hunter/BeastMastery/Modules/Spells/AzeriteTraits/PrimalInstincts.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Spells/AzeriteTraits/PrimalInstincts.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import { formatNumber, formatPercentage } from 'common/format';
+import { calculateAzeriteEffects } from 'common/stats';
+import TraitStatisticBox, { STATISTIC_ORDER } from 'Interface/Others/TraitStatisticBox';
+import SPELLS from 'common/SPELLS/index';
+import SpellLink from 'common/SpellLink';
+
+const danceOfDeathStats = traits => Object.values(traits).reduce((obj, rank) => {
+  const [mastery] = calculateAzeriteEffects(SPELLS.PRIMAL_INSTINCTS.id, rank);
+  obj.mastery += mastery;
+  return obj;
+}, {
+  mastery: 0,
+});
+
+export const STAT_TRACKER = {
+  mastery: combatant => danceOfDeathStats(combatant.traitsBySpellId[SPELLS.PRIMAL_INSTINCTS.id]).mastery,
+};
+
+/**
+ * Aspect of the Wild increases your Mastery by X, and grants you a charge of Barbed Shot.
+ *
+ * Example report: https://www.warcraftlogs.com/reports/Nt9KGvDncPmVyjpd#boss=-2&difficulty=0&type=summary&source=9
+ */
+class PrimalInstincts extends Analyzer {
+  mastery = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrait(SPELLS.PRIMAL_INSTINCTS.id);
+    if (!this.active) {
+      return;
+    }
+    const { mastery } = danceOfDeathStats(this.selectedCombatant.traitsBySpellId[SPELLS.PRIMAL_INSTINCTS.id]);
+    this.mastery = mastery;
+  }
+
+  get uptime() {
+    return this.selectedCombatant.getBuffUptime(SPELLS.PRIMAL_INSTINCTS_BUFF.id) / this.owner.fightDuration;
+  }
+
+  get avgMastery() {
+    return this.uptime * this.mastery;
+  }
+
+  get numProcs() {
+    return this.selectedCombatant.getBuffTriggerCount(SPELLS.PRIMAL_INSTINCTS_BUFF.id);
+  }
+
+  statistic() {
+    return (
+      <TraitStatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
+        trait={SPELLS.PRIMAL_INSTINCTS.id}
+        value={(
+          <React.Fragment>
+            {formatNumber(this.avgMastery)} Average Mastery <br />
+            {formatPercentage(this.uptime)}% Uptime <br />
+            Up to {this.numProcs} <SpellLink id={SPELLS.BARBED_SHOT.id} /> charges regained
+          </React.Fragment>
+        )}
+        tooltip={`Primal Instincts granted <b>${this.mastery}</b> mastery for <b>${formatPercentage(this.uptime)}%</b> of the fight.`}
+      />
+    );
+  }
+}
+
+export default PrimalInstincts;

--- a/src/common/SPELLS/BFA/AzeriteTraits/Hunter.js
+++ b/src/common/SPELLS/BFA/AzeriteTraits/Hunter.js
@@ -10,22 +10,24 @@ export default {
     name: 'Haze of Rage',
     icon: 'ability_druid_ferociousbite',
   },
-
   HAZE_OF_RAGE_BUFF: {
     id: 273264,
     name: 'Haze of Rage',
     icon: 'ability_druid_ferociousbite',
   },
-
   DANCE_OF_DEATH: {
     id: 274441,
     name: 'Dance of Death',
     icon: 'ability_druid_mangle',
   },
-
   DANCE_OF_DEATH_BUFF: {
     id: 274443,
     name: "Dance of Death",
     icon: "ability_druid_mangle",
+  },
+  FEEDING_FRENZY: {
+    id: 278529,
+    name: 'Feeding Frenzy',
+    icon: 'ability_hunter_barbedshot',
   },
 };

--- a/src/common/SPELLS/BFA/AzeriteTraits/Hunter.js
+++ b/src/common/SPELLS/BFA/AzeriteTraits/Hunter.js
@@ -30,4 +30,14 @@ export default {
     name: 'Feeding Frenzy',
     icon: 'ability_hunter_barbedshot',
   },
+  PRIMAL_INSTINCTS: {
+    id: 279806,
+    name: 'Primal Instincts',
+    icon: 'spell_nature_protectionformnature',
+  },
+  PRIMAL_INSTINCTS_BUFF: {
+    id: 279810,
+    name: 'Primal Instincts',
+    icon: 'spell_nature_protectionformnature',
+  },
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29204244/45832857-59909800-bd03-11e8-88e2-6a118e27d7c6.png)
![image](https://user-images.githubusercontent.com/29204244/45832919-82b12880-bd03-11e8-997f-922c64f55153.png)

The damage aspect of feeding frenzy is still NYI - since it follows the pattern of being a static amount of damage, and therefore had to track exact value. 

Logs:
https://www.warcraftlogs.com/reports/m9KrNBVCtDALZpzT#source=5&type=summary&fight=1
https://www.warcraftlogs.com/reports/QdrGMj1wFqnacXNW#fight=1&type=auras&source=13