### PR TITLE
[Affliction] Deathbolt and Haunt modules

### DIFF
--- a/src/Parser/Warlock/Affliction/CHANGELOG.js
+++ b/src/Parser/Warlock/Affliction/CHANGELOG.js
@@ -1,8 +1,15 @@
-// import React from 'react';
+import React from 'react';
 
 import { Chizu } from 'CONTRIBUTORS';
+import SpellLink from 'common/SpellLink';
+import SPELLS from 'common/SPELLS';
 
 export default [
+  {
+    date: new Date('2018-09-20'),
+    changes: <React.Fragment>Added <SpellLink id={SPELLS.DEATHBOLT_TALENT.id} icon /> module and made updates to <SpellLink id={SPELLS.HAUNT_TALENT.id} icon /> module.</React.Fragment>,
+    contributors: [Chizu],
+  },
   {
     date: new Date('2018-06-22'),
     changes: 'Updated the basics of the spec for BFA.',

--- a/src/Parser/Warlock/Affliction/CombatLogParser.js
+++ b/src/Parser/Warlock/Affliction/CombatLogParser.js
@@ -17,6 +17,7 @@ import Sniping from './Modules/Features/Sniping';
 import AbsoluteCorruption from './Modules/Talents/AbsoluteCorruption';
 import SiphonLifeUptime from './Modules/Talents/SiphonLifeUptime';
 import SoulConduit from './Modules/Talents/SoulConduit';
+import Deathbolt from './Modules/Talents/Deathbolt';
 
 import TheMasterHarvester from '../Shared/Modules/Items/TheMasterHarvester';
 import StretensSleeplessShackles from './Modules/Items/Legendaries/StretensSleeplessShackles';
@@ -55,6 +56,7 @@ class CombatLogParser extends CoreCombatLogParser {
     absoluteCorruption: AbsoluteCorruption,
     siphonLifeUptime: SiphonLifeUptime,
     soulConduit: SoulConduit,
+    deathbolt: Deathbolt,
 
     // Legendaries
     masterHarvester: TheMasterHarvester,

--- a/src/Parser/Warlock/Affliction/CombatLogParser.js
+++ b/src/Parser/Warlock/Affliction/CombatLogParser.js
@@ -18,6 +18,7 @@ import AbsoluteCorruption from './Modules/Talents/AbsoluteCorruption';
 import SiphonLifeUptime from './Modules/Talents/SiphonLifeUptime';
 import SoulConduit from './Modules/Talents/SoulConduit';
 import Deathbolt from './Modules/Talents/Deathbolt';
+import Haunt from './Modules/Talents/Haunt';
 
 import TheMasterHarvester from '../Shared/Modules/Items/TheMasterHarvester';
 import StretensSleeplessShackles from './Modules/Items/Legendaries/StretensSleeplessShackles';
@@ -57,6 +58,7 @@ class CombatLogParser extends CoreCombatLogParser {
     siphonLifeUptime: SiphonLifeUptime,
     soulConduit: SoulConduit,
     deathbolt: Deathbolt,
+    haunt: Haunt,
 
     // Legendaries
     masterHarvester: TheMasterHarvester,

--- a/src/Parser/Warlock/Affliction/Modules/Talents/Deathbolt.js
+++ b/src/Parser/Warlock/Affliction/Modules/Talents/Deathbolt.js
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import { formatThousands } from 'common/format';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
+
+import StatisticBox from 'Interface/Others/StatisticBox';
+
+class Deathbolt extends Analyzer {
+  static dependencies = {
+    abilityTracker: AbilityTracker,
+  };
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.DEATHBOLT_TALENT.id);
+  }
+
+  statistic() {
+    const deathbolt = this.abilityTracker.getAbility(SPELLS.DEATHBOLT_TALENT.id);
+    const total = deathbolt.damageEffective || 0;
+    const avg = total / (deathbolt.casts || 1);
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.DEATHBOLT_TALENT.id} />}
+        value={formatThousands(avg)}
+        label="Average Deathbolt damage"
+        tooltip={`Total Deathbolt damage: ${formatThousands(total)}`}
+      />
+    );
+  }
+}
+
+export default Deathbolt;

--- a/src/Parser/Warlock/Affliction/Modules/Talents/Haunt.js
+++ b/src/Parser/Warlock/Affliction/Modules/Talents/Haunt.js
@@ -49,29 +49,16 @@ class Haunt extends Analyzer {
     }
   }
 
-  get unbuffedTicks() {
-    return this.totalTicks - this.buffedTicks;
+  get uptime() {
+    return this.enemies.getBuffUptime(SPELLS.HAUNT_TALENT.id) / this.owner.fightDuration;
   }
 
   get suggestionThresholds() {
     return {
-      actual: (this.unbuffedTicks / this.totalTicks) || 1,
-      isGreaterThan: {
-        minor: 0.15,
-        average: 0.2,
-        major: 0.25,
-      },
-      style: 'percentage',
-    };
-  }
-
-  // used in Checklist, mirrors the numbers from suggestionThresholds()
-  get positiveSuggestionThresholds() {
-    return {
-      actual: (this.buffedTicks / this.totalTicks) || 0,
+      actual: this.uptime,
       isLessThan: {
-        minor: 0.85,
-        average: 0.8,
+        minor: 0.9,
+        average: 0.85,
         major: 0.75,
       },
       style: 'percentage',
@@ -81,10 +68,14 @@ class Haunt extends Analyzer {
   suggestions(when) {
     when(this.suggestionThresholds)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<React.Fragment>Your <SpellLink id={SPELLS.UNSTABLE_AFFLICTION_CAST.id} /> aren't buffed enough by <SpellLink id={SPELLS.HAUNT_TALENT.id} />. You should try to cast your Unstable Affliction in the burst windows provided by Haunt (but <strong>don't overcap</strong> your Soul Shards while waiting).</React.Fragment>)
+        return suggest(
+          <React.Fragment>
+            Your <SpellLink id={SPELLS.HAUNT_TALENT.id} /> debuff uptime is too low. While it's usually not possible to get 100% uptime due to travel and cast time, you should aim for as much uptime on the debuff as possible.
+          </React.Fragment>
+        )
           .icon(SPELLS.HAUNT_TALENT.icon)
-          .actual(`${formatPercentage(actual)}% unbuffed Unstable Affliction ticks.`)
-          .recommended(`< ${formatPercentage(recommended)}% is recommended`);
+          .actual(`${formatPercentage(actual)}% Haunt uptime.`)
+          .recommended(`> ${formatPercentage(recommended)}% is recommended`);
       });
   }
 
@@ -93,9 +84,9 @@ class Haunt extends Analyzer {
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.HAUNT_TALENT.id} />}
-        value={`${formatPercentage(buffedTicksPercentage)} %`}
-        label="UA ticks buffed by Haunt"
-        tooltip={`Your Haunt talent contributed ${formatNumber(this.bonusDmg)} total damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.bonusDmg))} %).`}
+        value={`${formatPercentage(this.uptime)} %`}
+        label="Haunt uptime"
+        tooltip={`Your Haunt talent contributed ${formatNumber(this.bonusDmg)} total damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.bonusDmg))} %). You buffed ${formatPercentage(buffedTicksPercentage)} % of your Unstable Affliction ticks with Haunt.`}
       />
     );
   }


### PR DESCRIPTION
Added a small Deathbolt module and updated Haunt module, reflecting a change in playstyle. We no longer care about burst windows and care about the uptime more. Still showed the bonus damage (10%) and percentage of buffed UA ticks, but it's not as important as it was.