### PR TITLE
[Fury Warrior] Add Basic Checklist, Prune Unnecessary Warnings

### DIFF
--- a/src/Parser/Warrior/Fury/CombatLogParser.js
+++ b/src/Parser/Warrior/Fury/CombatLogParser.js
@@ -1,6 +1,7 @@
 import CoreCombatLogParser from 'Parser/Core/CombatLogParser';
 import DamageDone from 'Parser/Core/Modules/DamageDone';
 
+import Checklist from './Modules/Features/Checklist/Module';
 import Abilities from './Modules/Abilities';
 import AlwaysBeCasting from './Modules/Features/AlwaysBeCasting';
 import CooldownThroughputTracker from './Modules/Features/CooldownThroughputTracker';
@@ -10,6 +11,7 @@ import EnrageUptime from './Modules/BuffDebuff/EnrageUptime';
 import FrothingBerserkerUptime from './Modules/BuffDebuff/FrothingBerserkerUptime';
 import Juggernaut from './Modules/BuffDebuff/Juggernaut';
 
+import MissedRampage from './Modules/Spells/MissedRampage';
 import RampageFrothingBerserker from './Modules/Features/RampageFrothingBerserker';
 import RampageCancelled from './Modules/Features/RampageCancelled';
 import AngerManagement from './Modules/Talents/AngerManagement';
@@ -23,6 +25,7 @@ class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     damageDone: [DamageDone, {showStatistic: true}],
 
+    checklist: Checklist,
     abilities: Abilities,
     alwaysBeCasting: AlwaysBeCasting,
     cooldownThroughputTracker: CooldownThroughputTracker,
@@ -32,6 +35,7 @@ class CombatLogParser extends CoreCombatLogParser {
     frothingBerserkerUptime: FrothingBerserkerUptime,
     juggernaut: Juggernaut,
 
+    missedRampage: MissedRampage,
     rampageFrothingBerserker: RampageFrothingBerserker,
     rampageCancelled: RampageCancelled,
     angerManagement: AngerManagement,

--- a/src/Parser/Warrior/Fury/Modules/Abilities.js
+++ b/src/Parser/Warrior/Fury/Modules/Abilities.js
@@ -32,10 +32,6 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: 0.8,
-        },
       },
       {
         spell: SPELLS.RAMPAGE,

--- a/src/Parser/Warrior/Fury/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Warrior/Fury/Modules/Features/AlwaysBeCasting.js
@@ -8,10 +8,6 @@ import { formatPercentage } from 'common/format';
 import { STATISTIC_ORDER } from 'Interface/Others/StatisticBox';
 
 class AlwaysBeCasting extends CoreAlwaysBeCasting {
-  get deadTimePercentage() {
-    return this.totalTimeWasted / this.owner.fightDuration;
-  }
-
   get downtimeSuggestionThresholds() {
     return {
       actual: this.downtimePercentage,

--- a/src/Parser/Warrior/Fury/Modules/Features/AlwaysBeCasting.js
+++ b/src/Parser/Warrior/Fury/Modules/Features/AlwaysBeCasting.js
@@ -8,12 +8,27 @@ import { formatPercentage } from 'common/format';
 import { STATISTIC_ORDER } from 'Interface/Others/StatisticBox';
 
 class AlwaysBeCasting extends CoreAlwaysBeCasting {
-  suggestions(when) {
-    const deadTimePercentage = this.totalTimeWasted / this.owner.fightDuration;
+  get deadTimePercentage() {
+    return this.totalTimeWasted / this.owner.fightDuration;
+  }
 
-    when(deadTimePercentage).isGreaterThan(0.1)
+  get downtimeSuggestionThresholds() {
+    return {
+      actual: this.downtimePercentage,
+      isGreaterThan: {
+        minor: 0.10,
+        average: 0.15,
+        major: 0.20,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+
+    when(this.downtimeSuggestionThresholds)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span>Your downtime can be improved. Try to Always Be Casting (ABC), try to reduce the delay between casting spells. Try casting your filler whether it be <SpellLink id={SPELLS.FURIOUS_SLASH_TALENT.id} /> or <SpellLink id={SPELLS.WHIRLWIND_FURY.id} /> in between cooldowns. If on the move, try casting <SpellLink id={SPELLS.HEROIC_THROW.id} />.</span>)
+        return suggest(<span>Your downtime can be improved. Try to Always Be Casting (ABC). It's better to cast low-priority abilities such as <SpellLink id={SPELLS.WHIRLWIND_FURY.id} /> than it is to do nothing./>.</span>)
           .icon('spell_mage_altertime')
           .actual(`${formatPercentage(actual)}% downtime`)
           .recommended(`<${formatPercentage(recommended)}% is recommended`)

--- a/src/Parser/Warrior/Fury/Modules/Features/Checklist/Component.js
+++ b/src/Parser/Warrior/Fury/Modules/Features/Checklist/Component.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
-import ResourceLink from 'common/ResourceLink';
-import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import Checklist from 'Parser/Core/Modules/Features/Checklist2';
 import Rule from 'Parser/Core/Modules/Features/Checklist2/Rule';
 import Requirement from 'Parser/Core/Modules/Features/Checklist2/Requirement';

--- a/src/Parser/Warrior/Fury/Modules/Features/Checklist/Component.js
+++ b/src/Parser/Warrior/Fury/Modules/Features/Checklist/Component.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import ResourceLink from 'common/ResourceLink';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import Checklist from 'Parser/Core/Modules/Features/Checklist2';
+import Rule from 'Parser/Core/Modules/Features/Checklist2/Rule';
+import Requirement from 'Parser/Core/Modules/Features/Checklist2/Requirement';
+import PreparationRule from 'Parser/Core/Modules/Features/Checklist2/PreparationRule';
+import GenericCastEfficiencyRequirement from 'Parser/Core/Modules/Features/Checklist2/GenericCastEfficiencyRequirement';
+
+class FuryWarriorChecklist extends React.PureComponent {
+  static propTypes = {
+    castEfficiency: PropTypes.object.isRequired,
+    combatant: PropTypes.shape({
+      hasTalent: PropTypes.func.isRequired,
+      hasTrinket: PropTypes.func.isRequired,
+    }).isRequired,
+    thresholds: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { combatant, castEfficiency, thresholds } = this.props;
+
+    const AbilityRequirement = props => (
+      <GenericCastEfficiencyRequirement
+        castEfficiency={castEfficiency.getCastEfficiencyForSpellId(props.spell)}
+        {...props}
+      />
+    );
+
+    return (
+      <Checklist>
+        <Rule
+          name="Use cooldowns effectively"
+          description={(
+            <React.Fragment>
+              Your cooldowns are an important contributor to your damage throughput. Try to get in as many efficient casts as the fight allows.
+            </React.Fragment>
+          )}
+        >
+          {combatant.hasTalent(SPELLS.SIEGEBREAKER_TALENT.id) && (
+            <AbilityRequirement spell={SPELLS.SIEGEBREAKER_TALENT.id} />
+          )}
+          <AbilityRequirement spell={SPELLS.RECKLESSNESS.id} />
+          {/* We can't detect race, so disable this when it has never been cast. */}
+          {castEfficiency.getCastEfficiencyForSpellId(SPELLS.ARCANE_TORRENT_MANA1.id) && (
+            <AbilityRequirement spell={SPELLS.ARCANE_TORRENT_MANA1.id} />
+          )}
+        </Rule>
+        <Rule
+          name="Use Rampage"
+          description={(
+            <React.Fragment>
+              Using <SpellLink id={SPELLS.RAMPAGE.id} /> is an important part of the Fury rotation. If you aren't Enraged, <SpellLink id={SPELLS.RAMPAGE.id} /> should be used as soon as you have enough rage. Also, use <SpellLink id={SPELLS.RAMPAGE.id} /> if you would reach maximum rage otherwise.
+            </React.Fragment>
+          )}
+        >
+          <Requirement
+            name={(
+              <React.Fragment>
+                Number of missed <SpellLink id={SPELLS.RAMPAGE.id} /> casts
+              </React.Fragment>
+            )}
+            thresholds={thresholds.missedRampage}
+          />
+        </Rule>
+        <Rule
+          name="Avoid downtime"
+          description={(
+            <React.Fragment>
+              As a melee DPS, it is important to stay within range of the target and cast your abiltiies promptly. If you find yourself out of range, try using <SpellLink id={SPELLS.CHARGE.id} /> and <SpellLink id={SPELLS.HEROIC_LEAP.id} /> to get back more quickly.
+            </React.Fragment>
+          )}
+        >
+          <Requirement name="Downtime" thresholds={thresholds.downtimeSuggestionThresholds} />
+        </Rule>
+        <PreparationRule thresholds={thresholds} />
+      </Checklist>
+    );
+  }
+}
+
+export default FuryWarriorChecklist;

--- a/src/Parser/Warrior/Fury/Modules/Features/Checklist/Component.js
+++ b/src/Parser/Warrior/Fury/Modules/Features/Checklist/Component.js
@@ -33,19 +33,15 @@ class FuryWarriorChecklist extends React.PureComponent {
       <Checklist>
         <Rule
           name="Use cooldowns effectively"
-          description={(
-            <React.Fragment>
-              Your cooldowns are an important contributor to your damage throughput. Try to get in as many efficient casts as the fight allows.
-            </React.Fragment>
-          )}
+          description="Your cooldowns are an important contributor to your damage throughput. Try to get in as many efficient casts as the fight allows."
         >
           {combatant.hasTalent(SPELLS.SIEGEBREAKER_TALENT.id) && (
             <AbilityRequirement spell={SPELLS.SIEGEBREAKER_TALENT.id} />
           )}
           <AbilityRequirement spell={SPELLS.RECKLESSNESS.id} />
           {/* We can't detect race, so disable this when it has never been cast. */}
-          {castEfficiency.getCastEfficiencyForSpellId(SPELLS.ARCANE_TORRENT_MANA1.id) && (
-            <AbilityRequirement spell={SPELLS.ARCANE_TORRENT_MANA1.id} />
+          {castEfficiency.getCastEfficiencyForSpellId(SPELLS.ARCANE_TORRENT_RAGE.id) && (
+            <AbilityRequirement spell={SPELLS.ARCANE_TORRENT_RAGE.id} />
           )}
         </Rule>
         <Rule

--- a/src/Parser/Warrior/Fury/Modules/Features/Checklist/Module.js
+++ b/src/Parser/Warrior/Fury/Modules/Features/Checklist/Module.js
@@ -3,7 +3,6 @@ import React from 'react';
 import Analyzer from 'Parser/Core/Analyzer';
 import CastEfficiency from 'Parser/Core/Modules/CastEfficiency';
 import Combatants from 'Parser/Core/Modules/Combatants';
-import ManaValues from 'Parser/Core/Modules/ManaValues';
 import PreparationRuleAnalyzer from 'Parser/Core/Modules/Features/Checklist2/PreparationRuleAnalyzer';
 
 import AlwaysBeCasting from '../AlwaysBeCasting';

--- a/src/Parser/Warrior/Fury/Modules/Features/Checklist/Module.js
+++ b/src/Parser/Warrior/Fury/Modules/Features/Checklist/Module.js
@@ -16,7 +16,6 @@ class Checklist extends Analyzer {
     alwaysBeCasting: AlwaysBeCasting,
     combatants: Combatants,
     castEfficiency: CastEfficiency,
-    manaValues: ManaValues,
     missedRampage: MissedRampage,
     preparationRuleAnalyzer: PreparationRuleAnalyzer,
   };

--- a/src/Parser/Warrior/Fury/Modules/Features/Checklist/Module.js
+++ b/src/Parser/Warrior/Fury/Modules/Features/Checklist/Module.js
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import CastEfficiency from 'Parser/Core/Modules/CastEfficiency';
+import Combatants from 'Parser/Core/Modules/Combatants';
+import ManaValues from 'Parser/Core/Modules/ManaValues';
+import PreparationRuleAnalyzer from 'Parser/Core/Modules/Features/Checklist2/PreparationRuleAnalyzer';
+
+import AlwaysBeCasting from '../AlwaysBeCasting';
+import MissedRampage from '../../Spells/MissedRampage';
+
+import Component from './Component';
+
+class Checklist extends Analyzer {
+  static dependencies = {
+    alwaysBeCasting: AlwaysBeCasting,
+    combatants: Combatants,
+    castEfficiency: CastEfficiency,
+    manaValues: ManaValues,
+    missedRampage: MissedRampage,
+    preparationRuleAnalyzer: PreparationRuleAnalyzer,
+  };
+
+  render() {
+    return (
+      <Component
+        combatant={this.combatants.selected}
+        castEfficiency={this.castEfficiency}
+        thresholds={{
+          ...this.preparationRuleAnalyzer.thresholds,
+
+          downtimeSuggestionThresholds: this.alwaysBeCasting.downtimeSuggestionThresholds,
+          missedRampage: this.missedRampage.suggestionThresholds,
+        }}
+      />
+    );
+  }
+}
+
+export default Checklist;

--- a/src/Parser/Warrior/Fury/Modules/Spells/MissedRampage.js
+++ b/src/Parser/Warrior/Fury/Modules/Spells/MissedRampage.js
@@ -6,7 +6,6 @@ import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 import SpellLink from 'common/SpellLink';
-const debug = false;
 
 const GENERATORS = [
   SPELLS.RAGING_BLOW,
@@ -16,17 +15,6 @@ const GENERATORS = [
 
 class MissedRampage extends Analyzer {
   missedRampages = 0;
-  Enraged = false;
-  rampage_cost = 85;
-
-  constructor(...args) {
-    super(...args);
-    if (this.selectedCombatant.hasTalent(SPELLS.CARNAGE_TALENT.id)) {
-      this.rampage_cost = 75;
-    } else if (this.selectedCombatant.hasTalent(SPELLS.FROTHING_BERSERKER_TALENT.id)) {
-      this.rampage_cost = 95;
-    }
-  }
 
   isGenerator(spellId) {
     return !!GENERATORS.find(generator => generator.id === spellId);

--- a/src/Parser/Warrior/Fury/Modules/Spells/MissedRampage.js
+++ b/src/Parser/Warrior/Fury/Modules/Spells/MissedRampage.js
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import Analyzer from 'Parser/Core/Analyzer';
+
+import SPELLS from 'common/SPELLS';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+
+import SpellLink from 'common/SpellLink';
+const debug = false;
+
+const GENERATORS = [
+  SPELLS.RAGING_BLOW,
+  SPELLS.BLOODTHIRST,
+  SPELLS.EXECUTE,
+];
+
+class MissedRampage extends Analyzer {
+  missedRampages = 0;
+  Enraged = false;
+  rampage_cost = 85;
+
+  constructor(...args) {
+    super(...args);
+    if (this.selectedCombatant.hasTalent(SPELLS.CARNAGE_TALENT.id)) {
+      this.rampage_cost = 75;
+    } else if (this.selectedCombatant.hasTalent(SPELLS.FROTHING_BERSERKER_TALENT.id)) {
+      this.rampage_cost = 95;
+    }
+  }
+
+  isGenerator(spellId) {
+    return !!GENERATORS.find(generator => generator.id === spellId);
+  }
+
+  on_byPlayer_cast(event) {
+    const resource = event.classResources && event.classResources.find(classResources => classResources.type === RESOURCE_TYPES.RAGE.id);
+    if (!resource) {
+      return;
+    }
+    const rage = Math.floor(resource.amount/10);
+    if (rage >= 90 && this.isGenerator(event.ability.guid)) {
+      this.missedRampages += 1;
+    }
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.missedRampages,
+      isGreaterThan: {
+        minor: 0,
+        average: 5,
+        major: 10,
+      },
+      style: 'number',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <React.Fragment>
+          There were {actual} times when you cast another ability when you should have cast <SpellLink id={SPELLS.RAMPAGE.id} />.
+        </React.Fragment>
+      )
+        .icon(SPELLS.RAMPAGE.icon)
+        .actual(`${actual} missed Rampages.`)
+        .recommended(`${recommended} is recommended.`);
+    });
+  }
+}
+
+export default MissedRampage;

--- a/src/Parser/Warrior/Fury/Modules/Spells/MissedRampage.js
+++ b/src/Parser/Warrior/Fury/Modules/Spells/MissedRampage.js
@@ -8,16 +8,16 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import SpellLink from 'common/SpellLink';
 
 const GENERATORS = [
-  SPELLS.RAGING_BLOW,
-  SPELLS.BLOODTHIRST,
-  SPELLS.EXECUTE,
+  SPELLS.RAGING_BLOW.id,
+  SPELLS.BLOODTHIRST.id,
+  SPELLS.EXECUTE.id,
 ];
 
 class MissedRampage extends Analyzer {
   missedRampages = 0;
 
   isGenerator(spellId) {
-    return !!GENERATORS.find(generator => generator.id === spellId);
+    return GENERATORS.includes(spellId);
   }
 
   on_byPlayer_cast(event) {


### PR DESCRIPTION
Hi,

I am not a fury warrior expert, but I thought it would be useful to add a basic checklist to the spec, since previously nothing at all was available. As such, I added the basic cooldowns, downtime, and preparation checklists that are available for most other specs. Furthermore, in the attempt to add at least something specific to Fury, I added a checklist that counts how often generators were used when there is no doubt that it would have been better to use Rampage (I follow the Icy Veins guide, which says that Rampage should be used any time your rage is >= 90).

In addition to the checklist changes, I removed the Raging Blow efficiency suggestion. You can consult either fury warrior guides or top logs to see that efficiency Raging Blow usage is not an important part of the spec at this time. 

I've never contributed to this project before, or used javascript, so if there are changes that you think would be appropriate, feel free to let me know.