### PR TITLE
[Frost Mage] Add statistics for trait Whiteout; add Dambroda to frost mage contributors

### DIFF
--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -468,3 +468,13 @@ export const fel1ne = {
     link: 'https://www.worldofwarcraft.com/en-us/character/khazgoroth/Felerai',
   }],
 };
+export const Dambroda = {
+  nickname: 'Dambroda',
+  github: 'Dambroda',
+  discord: 'Dambroda#1290',
+  mains: [{
+    name: 'Dambroma',
+    spec: SPECS.FROST_MAGE,
+    link: 'https://worldofwarcraft.com/en-us/character/lightbringer/dambroma',
+  }],
+};

--- a/src/Parser/Mage/Frost/CHANGELOG.js
+++ b/src/Parser/Mage/Frost/CHANGELOG.js
@@ -1,10 +1,15 @@
 import React from 'react';
 
-import { Sharrq } from 'CONTRIBUTORS';
+import { Sharrq, Dambroda } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 
 export default [
+  {
+    date: new Date('2018-09-21'),
+    changes: <React.Fragment>Added statistics for <SpellLink id={SPELLS.WHITEOUT.id} /></React.Fragment>,
+    contributors: [Dambroda],
+  },
   {
     date: new Date('2018-09-10'),
     changes: <React.Fragment>Updated Checklist, Better <SpellLink id={SPELLS.GLACIAL_SPIKE_TALENT.id} /> Support, Added Support for <SpellLink id={SPELLS.BONE_CHILLING_TALENT.id} /></React.Fragment>,

--- a/src/Parser/Mage/Frost/CONFIG.js
+++ b/src/Parser/Mage/Frost/CONFIG.js
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import { Sharrq } from 'CONTRIBUTORS';
+import { Sharrq, Dambroda } from 'CONTRIBUTORS';
 import SPECS from 'game/SPECS';
 
 import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Sharrq],
+  contributors: [Sharrq, Dambroda],
   // The WoW client patch this spec was last updated to be fully compatible with.
   patchCompatibility: '8.0.1',
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more. If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
@@ -15,7 +15,7 @@ export default {
     <React.Fragment>
       Hello Everyone! We are always looking to improve the Frost Mage Analyzers and Modules; so if you find any issues or if there is something missing that you would like to see added, please open an Issue on GitHub or send a message to us on Discord (Sharrq#7530 or Sref#3865) <br /><br />
 
-	    Additionally, if you need further assistance in improving your gameplay as a Frost Mage, you can refer to the following resources:<br />
+      Additionally, if you need further assistance in improving your gameplay as a Frost Mage, you can refer to the following resources:<br />
       <a href="https://discord.gg/0gLMHikX2aZ23VdA" target="_blank" rel="noopener noreferrer">Mage Class Discord</a> <br />
       <a href="https://www.altered-time.com/forum/" target="_blank" rel="noopener noreferrer">Altered Time (Mage Forums/Guides)</a> <br />
       <a href="https://www.icy-veins.com/wow/frost-mage-pve-dps-guide" target="_blank" rel="noopener noreferrer">Icy Veins (Frost Mage Guide)</a>

--- a/src/Parser/Mage/Frost/CombatLogParser.js
+++ b/src/Parser/Mage/Frost/CombatLogParser.js
@@ -18,7 +18,7 @@ import ArcaneIntellect from '../Shared/Modules/Features/ArcaneIntellect';
 import SplittingIce from './Modules/Features/SplittingIce';
 import CancelledCasts from '../Shared/Modules/Features/CancelledCasts';
 import WintersReach from './Modules/Traits/WintersReach';
-
+import Whiteout from './Modules/Traits/Whiteout';
 import FrozenOrb from './Modules/Cooldowns/FrozenOrb';
 import ColdSnap from './Modules/Cooldowns/ColdSnap';
 
@@ -45,6 +45,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     //Traits
     wintersReach: WintersReach,
+    whiteout: Whiteout,
 
 	  //Cooldowns
     frozenOrb: FrozenOrb,

--- a/src/Parser/Mage/Frost/Modules/Traits/Whiteout.js
+++ b/src/Parser/Mage/Frost/Modules/Traits/Whiteout.js
@@ -1,0 +1,127 @@
+import React from 'react';
+
+import {formatNumber} from 'common/format';
+import SPELLS from 'common/SPELLS';
+import {calculateAzeriteEffects} from 'common/stats';
+
+import TraitStatisticBox, { STATISTIC_ORDER } from 'Interface/Others/TraitStatisticBox';
+
+import Analyzer from 'Parser/Core/Analyzer';
+import HIT_TYPES from 'Parser/Core/HIT_TYPES';
+import EnemyInstances from 'Parser/Core/Modules/EnemyInstances';
+import SpellUsable from 'Parser/Core/Modules/SpellUsable';
+import StatTracker from 'Parser/Core/Modules/StatTracker';
+
+// Enemy debuffs that provide the triple damage multiplier onto Ice Lance
+const SHATTER_EFFECTS = [
+  SPELLS.WINTERS_CHILL.id,
+  SPELLS.FROST_NOVA.id,
+  SPELLS.ICE_NOVA_TALENT.id,
+  SPELLS.GLACIAL_SPIKE_DAMAGE.id,
+  SPELLS.RING_OF_FROST_DAMAGE.id,
+];
+
+// The number of seconds of cooldown reduction given to Frozen Orb per Ice Lance
+const FO_REDUCTION_SEC = 0.5;
+
+/**
+ * See known issue below, this is a temporary fix
+ * To update, see https://ptr.wowhead.com/spell=137020/frost-mage
+ * AURA = 1 + (Damage modifier)
+ */
+const FROST_MAGE_AURA = 1 + (-0.24);
+
+/**
+ * Ice Lance deals an additional X1 (stacks and scales) damage and reduces the cooldown of Frozen Orb by 0.5 (does not stack or scale) sec.
+ *
+ * Known issue: X1 value in trait data is a flat value and does not apply class % aura, damage buffs, etc, and is not a separate damage event from Ice Lance.
+ * This makes it very difficult to determine what the actual damage gained from the trait is; see: https://github.com/WoWAnalyzer/WoWAnalyzer/issues/2088
+ */
+class Whiteout extends Analyzer {
+  static dependencies = {
+    enemies: EnemyInstances,
+    spellUsable: SpellUsable,
+    statTracker: StatTracker,
+  };
+
+  hadFingersProc = false;
+  bonusDamagePerIceLance = 0;
+  frozenOrbReductions = 0;
+  totalWhiteoutDamage = 0;
+
+  constructor(...args) {
+    super(...args);
+    if (!this.selectedCombatant.hasTrait(SPELLS.WHITEOUT.id)) {
+      this.active = false;
+      return;
+    }
+
+    const ranks = this.selectedCombatant.traitsBySpellId[SPELLS.WHITEOUT.id];
+    for (const rank of ranks) {
+      const [damage] = calculateAzeriteEffects(SPELLS.WHITEOUT.id, rank);
+      this.bonusDamagePerIceLance += damage;
+    }
+
+    this.bonusDamagePerIceLance *= FROST_MAGE_AURA;
+  }
+
+  on_byPlayer_cast(event) {
+    if (event.ability.guid !== SPELLS.ICE_LANCE.id) {
+      return;
+    }
+    if (this.spellUsable.isOnCooldown(SPELLS.FROZEN_ORB.id)) {
+      this.frozenOrbReductions += 1;
+    }
+
+    this.hadFingersProc = this.selectedCombatant.hasBuff(SPELLS.FINGERS_OF_FROST.id);
+  }
+
+  on_byPlayer_damage(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.ICE_LANCE_DAMAGE.id) {
+      return;
+    }
+
+    // The Whiteout damage is affected by versatility no other stats
+    let estimatedBonusDamage = this.bonusDamagePerIceLance * (1 + this.statTracker.currentVersatilityPercentage);
+
+    // This is the damage modifier after personal player buffs (i.e. only external increases or reductions like chaos brand and boss phases)
+    const damageModifier = (event.amount / event.unmitigatedAmount) / (event.hitType === HIT_TYPES.CRIT ? 2 : 1);
+
+    // Apply the damage modifier to the estimated Whiteout damage
+    estimatedBonusDamage *= damageModifier;
+
+    if (event.hitType === HIT_TYPES.CRIT) {
+      estimatedBonusDamage *= 2;
+    }
+
+    // Check for shatter effects, these multiply the damage of Ice Lance by 3
+    const enemy = this.enemies.getEntity(event);
+    if ((enemy && SHATTER_EFFECTS.some(effect => enemy.hasBuff(effect, event.timestamp))) || this.hadFingersProc) {
+      estimatedBonusDamage *= 3;
+    }
+
+    this.totalWhiteoutDamage += estimatedBonusDamage;
+  }
+
+  statistic() {
+    return (
+      <TraitStatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
+        trait={SPELLS.WHITEOUT.id}
+        value={(
+          <React.Fragment>
+            {formatNumber(this.totalWhiteoutDamage / this.owner.fightDuration * 1000)} DPS<br />
+            {(FO_REDUCTION_SEC * this.frozenOrbReductions).toFixed(1)} sec. CD reduction<br />
+          </React.Fragment>
+        )}
+        tooltip={
+          `DPS value does not take into account any extra Frozen Orb casts due to the lowered cooldown. Whiteout may provide much more DPS than suggested here if extra Frozen Orb casts are used effectively.</i><br />
+          Bonus Ice Lance damage: <b>${formatNumber(this.totalWhiteoutDamage)}</b>`
+        }
+      />
+    );
+  }
+}
+
+export default Whiteout;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/43309639/45913921-a9e62380-bdf1-11e8-90ad-e6f67aed917c.png)

With these commits, the azerite trait Whiteout will now have a statistics box that tracks how much bonus Ice Lance damage is dealt. It will also tally up the total Frozen Orb cooldown reduction applied to display to the user. 

Also, in the last commit I added myself to the contributors list for frost mage.

