### PR TITLE
[BrM] Updated Suggestions for ISB/BoF

### DIFF
--- a/src/Parser/Monk/Brewmaster/CHANGELOG.js
+++ b/src/Parser/Monk/Brewmaster/CHANGELOG.js
@@ -8,6 +8,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-09-22'),
+    changes: <React.Fragment>Updated <SpellLink id={SPELLS.IRONSKIN_BREW.id} /> and <SpellLink id={SPELLS.BREATH_OF_FIRE.id} /> suggestions to use hits mitigated instead of uptime.</React.Fragment>,
+    contributors: [emallson],
+  },
+  {
     date: new Date('2018-09-13'),
     changes: <React.Fragment>Added support for <SpellLink id={SPELLS.ELUSIVE_FOOTWORK.id} />.</React.Fragment>,
     contributors: [emallson],

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/BreathOfFire.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/BreathOfFire.js
@@ -62,9 +62,9 @@ class BreathOfFire extends Analyzer {
   suggestions(when) {
     when(this.suggestionThreshold)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<React.Fragment>Your <SpellLink id={SPELLS.BREATH_OF_FIRE.id} /> uptime can be improved. The associated debuff is a key part of our damage mitigation.</React.Fragment>)
+        return suggest(<React.Fragment>Your <SpellLink id={SPELLS.BREATH_OF_FIRE.id} /> usage can be improved. The associated debuff is a key part of our damage mitigation.</React.Fragment>)
           .icon(SPELLS.BREATH_OF_FIRE.icon)
-          .actual(`${formatPercentage(actual)}% Breath of Fire uptime`)
+          .actual(`${formatPercentage(actual)}% of hits mitigated with Breath of Fire`)
           .recommended(`> ${formatPercentage(recommended)}% is recommended`);
       });
   }

--- a/src/Parser/Monk/Brewmaster/Modules/Spells/IronSkinBrew.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Spells/IronSkinBrew.js
@@ -112,13 +112,11 @@ class IronSkinBrew extends Analyzer {
   }
 
   suggestions(when) {
-    const isbUptimePercentage = this.selectedCombatant.getBuffUptime(SPELLS.IRONSKIN_BREW_BUFF.id) / this.owner.fightDuration;
-
-    when(isbUptimePercentage).isLessThan(0.9)
+    when(this.uptimeSuggestionThreshold)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span> Your <SpellLink id={SPELLS.IRONSKIN_BREW.id} /> uptime was {formatPercentage(isbUptimePercentage)}%, unless there are extended periods of downtime it should be near 100%.</span>)
+        return suggest(<span> You mitigated {formatPercentage(actual)}% of hits with <SpellLink id={SPELLS.IRONSKIN_BREW.id} />. Outside of very rare circumstances, this should be near 100%.</span>)
           .icon(SPELLS.IRONSKIN_BREW.icon)
-          .actual(`${formatPercentage(actual)}% uptime`)
+          .actual(`${formatPercentage(actual)}% Hits Mitigated`)
           .recommended(`${Math.round(formatPercentage(recommended))}% or more is recommended`)
           .regular(recommended - 0.1).major(recommended - 0.2);
       });


### PR DESCRIPTION
This has been popping up a lot on BrM discord because of the xpac launch. tl;dr the current implementation of the suggestion for ISB looks at uptime % (which is wrong) and the current suggestion for BoF says "uptime" but is actually "hits mitigated". This PR fixes both of those to say "hits mitigated". 

Example Log: https://www.warcraftlogs.com/reports/AbZ38fQBJYxPdGqp/#fight=6&source=104

New version:
![screenshot from 2018-09-22 21-52-55](https://user-images.githubusercontent.com/4909458/45923345-e0837300-beb1-11e8-9d46-1d3109d8ecf6.png)
![screenshot from 2018-09-22 21-52-43](https://user-images.githubusercontent.com/4909458/45923346-e0837300-beb1-11e8-89f0-62cca202fdbe.png)

