### PR TITLE
[General Azerite] Heed My Call trait module

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -9,6 +9,11 @@ import Contributor from 'Interface/Contributor/Button';
 
 export default [
   {
+    date: new Date('2018-09-24'),
+    changes: <React.Fragment>Added <SpellLink id={SPELLS.HEED_MY_CALL.id} /> module.</React.Fragment>,
+    contributors: [Dambroda],
+  },
+  {
     date: new Date('2018-09-22'),
     changes: <React.Fragment>Added <SpellLink id={SPELLS.GUTRIPPER.id} /> module.</React.Fragment>,
     contributors: [Dambroda],

--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -83,6 +83,7 @@ import DarkmoonDeckFathoms from './Modules/Items/BFA/Crafted/DarkmoonDeckFathoms
 // Azerite Traits
 import Gemhide from './Modules/Spells/BFA/AzeriteTraits/Gemhide';
 import Gutripper from './Modules/Spells/BFA/AzeriteTraits/Gutripper';
+import HeedMyCall from './Modules/Spells/BFA/AzeriteTraits/HeedMyCall';
 import LaserMatrix from './Modules/Spells/BFA/AzeriteTraits/LaserMatrix';
 import MeticulousScheming from './Modules/Spells/BFA/AzeriteTraits/MeticulousScheming';
 import OverWhelmingPower from './Modules/Spells/BFA/AzeriteTraits/OverwhelmingPower';
@@ -183,6 +184,7 @@ class CombatLogParser {
     // Azerite Traits
     gemhide: Gemhide,
     gutripper: Gutripper,
+    heedMyCall: HeedMyCall,
     laserMatrix: LaserMatrix,
     meticulousScheming: MeticulousScheming,
     overwhelmingPower: OverWhelmingPower,

--- a/src/Parser/Core/Modules/Spells/BFA/AzeriteTraits/HeedMyCall.js
+++ b/src/Parser/Core/Modules/Spells/BFA/AzeriteTraits/HeedMyCall.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import { formatNumber, formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import TraitStatisticBox, { STATISTIC_ORDER } from 'Interface/Others/TraitStatisticBox';
+
+/**
+ * Your damaging abilities have a chance to deal X1 Nature damage to your target,
+ * and X2 Nature damage to enemies within 3 yards of that target.
+ */
+class HeedMyCall extends Analyzer {
+
+  damage = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrait(SPELLS.HEED_MY_CALL.id);
+  }
+
+  on_byPlayer_damage(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.HEED_MY_CALL_PRIMARY_DAMAGE.id && spellId !== SPELLS.HEED_MY_CALL_AOE_DAMAGE.id) {
+      return;
+    }
+    this.damage += event.amount + (event.absorbed || 0);
+  }
+
+  statistic() {
+    const damageThroughputPercent = this.owner.getPercentageOfTotalDamageDone(this.damage);
+    const dps = this.damage / this.owner.fightDuration * 1000;
+    return (
+      <TraitStatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
+        trait={SPELLS.HEED_MY_CALL.id}
+        value={`${formatPercentage(damageThroughputPercent)} % / ${formatNumber(dps)} DPS`}
+        tooltip={`Damage done: ${formatNumber(this.damage)}`
+        }
+      />
+    );
+  }
+}
+
+export default HeedMyCall;

--- a/src/common/SPELLS/BFA/AzeriteTraits/General.js
+++ b/src/common/SPELLS/BFA/AzeriteTraits/General.js
@@ -196,4 +196,19 @@ export default {
     name: 'Gutripper',
     icon: 'ability_criticalstrike',
   },
+  HEED_MY_CALL: {
+    id: 263987,
+    name: 'Heed My Call',
+    icon: 'spell_shaman_thunderstorm',
+  },
+  HEED_MY_CALL_PRIMARY_DAMAGE: {
+    id: 271685,
+    name: 'Heed My Call',
+    icon: 'spell_shaman_thunderstorm',
+  },
+  HEED_MY_CALL_AOE_DAMAGE: {
+    id: 271686,
+    name: 'Heed My Call',
+    icon: 'spell_shaman_thunderstorm',
+  },
 };

--- a/src/common/SPELLS/BFA/AzeriteTraits/__UNUSED.js
+++ b/src/common/SPELLS/BFA/AzeriteTraits/__UNUSED.js
@@ -444,11 +444,6 @@ export default {
     name: 'Heavy Rain',
     icon: 'spell_shadow_rainoffire',
   },
-  HEED_MY_CALL: {
-    id: 263987,
-    name: 'Heed My Call',
-    icon: 'spell_shaman_thunderstorm',
-  },
   HORRID_EXPULSION: {
     id: 273095,
     name: 'Horrid Expulsion',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/43309639/45943736-64b22500-bf9c-11e8-980e-2c266c800262.png)

Very simple Heed My Call module. Totals all damage and shows a DPS and DPS % statistic with the total damage tooltip. 

Note: Code for this is basically identical to gutripper, and probably can be the same for all flat damage proc traits that have their own damage spell ids. Maybe they can be merged together?

Issue #2242 