### PR TITLE
[Core][Bug] Fix for missing traitIds

### DIFF
--- a/src/Parser/Core/Combatant.js
+++ b/src/Parser/Core/Combatant.js
@@ -108,6 +108,9 @@ class Combatant extends Entity {
   _parseTraits(traits) {
     traits.forEach(({ traitID, rank }) => {
       const spellId = traitIdMap[traitID];
+      if (spellId === undefined) {
+        return;
+      }
       if (!this.traitsBySpellId[spellId]) {
         this.traitsBySpellId[spellId] = [];
       }


### PR DESCRIPTION
This fixes an issue when a trait is missing the `traits.json`-file.
Simply iterating over the `traitsBySpellId` and assuming that the ID is defined could lead to issues in several modules in the future.

Issues happens currently in the Azerite-module in the character pane when a character has [Unstable Catalyst](https://www.wowhead.com/spell=281514/unstable-catalyst). Thats just one of the traits thats missing in the `traits.json`-file.