### PR TITLE
Fixes #1724 Add Darkmoon Deck: Blockades healing component

### DIFF
--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -80,6 +80,7 @@ import HarlansLoadedDice from './Modules/Items/BFA/Dungeons/HarlansLoadedDice';
 // Crafted
 import DarkmoonDeckTides from './Modules/Items/BFA/Crafted/DarkmoonDeckTides';
 import DarkmoonDeckFathoms from './Modules/Items/BFA/Crafted/DarkmoonDeckFathoms';
+import DarkmoonDeckBlockades from './Modules/Items/BFA/Crafted/DarkmoonDeckBlockades';
 // Azerite Traits
 import Gemhide from './Modules/Spells/BFA/AzeriteTraits/Gemhide';
 import Gutripper from './Modules/Spells/BFA/AzeriteTraits/Gutripper';
@@ -180,6 +181,7 @@ class CombatLogParser {
     // Crafted
     darkmoonDeckTides: DarkmoonDeckTides,
     darkmoonDeckFathoms: DarkmoonDeckFathoms,
+    darkmoonDeckBlockades: DarkmoonDeckBlockades,
     // Enchants
 
     // Azerite Traits

--- a/src/Parser/Core/Modules/Items/BFA/Crafted/DarkmoonDeckBlockades.js
+++ b/src/Parser/Core/Modules/Items/BFA/Crafted/DarkmoonDeckBlockades.js
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import ITEMS from 'common/ITEMS';
+import Analyzer from 'Parser/Core/Analyzer';
+import ItemHealingDone from 'Interface/Others/ItemHealingDone';
+
+const DARKMOON_DECK_BLOCKADES_CARDS = [
+  276204, // Ace
+  276205, // 2
+  276206, // 3
+  276207, // 4
+  276208, // 5
+  276209, // 6
+  276210, // 7
+  276211, // 8
+];
+/**
+ * Darkmoon Deck: Blockades
+ * Equip: Whenever the deck is shuffled, heal a small amount of health and gain additional stamina. Amount of both stamina and healing depends on the topmost card of the deck.
+ * Equip: Periodically shuffle the deck while in combat.
+ *
+ * Example: https://www.warcraftlogs.com/reports/j7XQrN8LcJKw1qM3#fight=29&source=1&type=healing&view=timeline
+ */
+
+class DarkmoonDeckBlockades extends Analyzer {
+  healing = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrinket(ITEMS.DARKMOON_DECK_BLOCKADES.id);
+  }
+
+  on_byPlayer_heal(event) {
+    const spellId = event.ability.guid;
+    if (!DARKMOON_DECK_BLOCKADES_CARDS.includes(spellId)) {
+      return;
+    }
+    this.healing += (event.amount || 0) + (event.absorbed || 0);
+  }
+
+  item() {
+    return {
+      item: ITEMS.DARKMOON_DECK_BLOCKADES,
+      result:(
+        <React.Fragment>
+          <ItemHealingDone amount={this.healing} />
+        </React.Fragment>
+      ),
+    };
+  }
+}
+
+export default DarkmoonDeckBlockades;

--- a/src/common/SPELLS/BFA/Crafted/ITEMS.js
+++ b/src/common/SPELLS/BFA/Crafted/ITEMS.js
@@ -11,4 +11,9 @@ export default {
     name: 'Fathom Fall',
     icon: 'inv_misc_anchor',
   },
+  BLOCKADES_DECK: { // Darkmoon Deck: Blockades
+    id: 276202,
+    name: 'Blockades Deck',
+    icon: 'Inv_inscription_80_deck_blockades',
+  },
 };


### PR DESCRIPTION
The items section should now correctly track the healing percentage and
HPS that Darkmoon Deck: Blockades provides when equiped.