### PR TITLE
[Restoration Shaman] Modified talents to use the talent specific category

### DIFF
--- a/src/Parser/Shaman/Restoration/CombatLogParser.js
+++ b/src/Parser/Shaman/Restoration/CombatLogParser.js
@@ -73,7 +73,6 @@ class CombatLogParser extends CoreCombatLogParser {
     statValues: StatValues,
 
     // Talents:
-    talentStatisticBox: TalentStatisticBox,
     torrent: Torrent,
     unleashLife: UnleashLife,
     undulation: Undulation,
@@ -87,6 +86,7 @@ class CombatLogParser extends CoreCombatLogParser {
     wellspring: Wellspring,
     highTide: HighTide,
     naturesGuardian: NaturesGuardian,
+    talentStatisticBox: TalentStatisticBox,
 
     // Spells:
     chainHeal: ChainHeal,

--- a/src/Parser/Shaman/Restoration/Modules/Talents/Downpour.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/Downpour.js
@@ -7,6 +7,7 @@ import { formatPercentage } from 'common/format';
 
 import StatisticBox, { STATISTIC_ORDER } from 'Interface/Others/StatisticBox';
 import StatisticListBoxItem from 'Interface/Others/StatisticListBoxItem';
+import STATISTIC_CATEGORY from 'Interface/Others/STATISTIC_CATEGORY';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import SpellUsable from 'Parser/Core/Modules/SpellUsable';
@@ -78,7 +79,9 @@ class Downpour extends Analyzer {
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.DOWNPOUR_TALENT.id} />}
-        value={`${downpourAverageCooldown.toFixed(1)} seconds`} 
+        value={`${downpourAverageCooldown.toFixed(1)} seconds`}
+        category={STATISTIC_CATEGORY.TALENTS}
+        position={STATISTIC_ORDER.OPTIONAL(90)}
         label={(
           <dfn data-tip={`
             You cast a total of ${downpourCasts} Downpours, which on average hit ${(downpourAverageHits + downpourAverageOverhealedHits).toFixed(1)} out of 6 targets. <br /> 
@@ -90,7 +93,6 @@ class Downpour extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(70);
 
   subStatistic() {
     const feeding = this.cooldownThroughputTracker.getIndirectHealing(SPELLS.DOWNPOUR_TALENT.id);

--- a/src/Parser/Shaman/Restoration/Modules/Talents/EarthShield.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/EarthShield.js
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import StatisticBox from 'Interface/Others/StatisticBox';
-
 import SPELLS from 'common/SPELLS';
 import { formatPercentage } from 'common/format';
 import SpellIcon from 'common/SpellIcon';
@@ -11,7 +9,9 @@ import Analyzer from 'Parser/Core/Analyzer';
 import Combatants from 'Parser/Core/Modules/Combatants';
 import calculateEffectiveHealing from 'Parser/Core/calculateEffectiveHealing';
 
+import StatisticBox, { STATISTIC_ORDER } from 'Interface/Others/StatisticBox';
 import StatisticListBoxItem from 'Interface/Others/StatisticListBoxItem';
+import STATISTIC_CATEGORY from 'Interface/Others/STATISTIC_CATEGORY';
 
 import CooldownThroughputTracker from '../Features/CooldownThroughputTracker';
 import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from '../../Constants';
@@ -95,6 +95,8 @@ class EarthShield extends Analyzer {
         icon={<SpellIcon id={SPELLS.EARTH_SHIELD_TALENT.id} />}
         value={`${formatPercentage(this.uptimePercent)} %`}
         label="Earth Shield Uptime"
+        category={STATISTIC_CATEGORY.TALENTS}
+        position={STATISTIC_ORDER.OPTIONAL(30)}
       />
     );
   }

--- a/src/Parser/Shaman/Restoration/Modules/Talents/EarthenWallTotem.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/EarthenWallTotem.js
@@ -10,6 +10,7 @@ import Analyzer from 'Parser/Core/Analyzer';
 import AbilityTracker from 'Parser/Core/Modules/AbilityTracker';
 
 import StatisticBox, { STATISTIC_ORDER } from 'Interface/Others/StatisticBox';
+import STATISTIC_CATEGORY from 'Interface/Others/STATISTIC_CATEGORY';
 import StatisticListBoxItem from 'Interface/Others/StatisticListBoxItem';
 
 class EarthenWallTotem extends Analyzer {
@@ -91,6 +92,8 @@ class EarthenWallTotem extends Analyzer {
       <StatisticBox
         icon={<SpellIcon id={SPELLS.EARTHEN_WALL_TOTEM_TALENT.id} />}
         value={`${formatPercentage(this.earthenShieldEfficiency)} %`}
+        category={STATISTIC_CATEGORY.TALENTS}
+        position={STATISTIC_ORDER.OPTIONAL(60)}
         label={(
           <dfn data-tip={`The percentage of the potential absorb of Earthen Wall Totem that was actually used. You cast a total of ${casts} Earthen Wall Totems with a combined health of ${formatNumber(this.potentialHealing)}, which absorbed a total of ${formatNumber(this.healing)} damage.`}>
             Earthen Wall Totem efficiency
@@ -99,7 +102,6 @@ class EarthenWallTotem extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(70);
 
   subStatistic() {
     return (

--- a/src/Parser/Shaman/Restoration/Modules/Talents/FlashFlood.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/FlashFlood.js
@@ -7,8 +7,8 @@ import { formatPercentage } from 'common/format';
 
 import Analyzer from 'Parser/Core/Analyzer';
 import GlobalCooldown from 'Parser/Core/Modules/GlobalCooldown';
-import StatisticsListBox from 'Interface/Others/StatisticsListBox';
-import StatisticListBoxItem from 'Interface/Others/StatisticListBoxItem';
+import StatisticsListBox, { STATISTIC_ORDER } from 'Interface/Others/StatisticsListBox';
+import STATISTIC_CATEGORY from 'Interface/Others/STATISTIC_CATEGORY';
 
 const FLASH_FLOOD_HASTE = 0.2;
 const BUFFER_MS = 50;
@@ -107,16 +107,6 @@ class FlashFlood extends Analyzer {
 
   get totalTimeWasted() {
     return Object.values(this.spellsConsumingFlashFlood).reduce((sum, spell) => {return sum + spell.timeWasted;}, 0);
-  }
-
-  subStatistic() {
-    return (
-      <StatisticListBoxItem
-        title={<SpellLink id={SPELLS.FLASH_FLOOD_TALENT.id} />}
-        value={`${(this.totalTimeSaved / 1000).toFixed(2)} seconds`}
-        valueTooltip={`Cast time saved by Flash Flood. <br /> ${(this.totalTimeWasted / 1000).toFixed(2)} seconds 'saved' on reductions below GCD.`}
-      />
-    );
   }
 
   legend(items, total) {
@@ -247,16 +237,24 @@ class FlashFlood extends Analyzer {
 
   statistic() {
     return (
-      <div className="col-lg-3 col-md-4 col-sm-6 col-xs-12">
-        <div className="row">
-          <StatisticsListBox
-            title={<span><SpellLink id={SPELLS.FLASH_FLOOD_TALENT.id} /> usage</span>}
-            containerProps={{ className: 'col-xs-12' }}
-          >
-            {this.flashFloodUsageRatioChart()}
-          </StatisticsListBox>
+      <StatisticsListBox
+        title={<span><SpellLink id={SPELLS.FLASH_FLOOD_TALENT.id} /> usage</span>}
+        category={STATISTIC_CATEGORY.TALENTS}
+        position={STATISTIC_ORDER.OPTIONAL(90)}
+        containerProps={{ className: 'col-lg-3 col-md-4 col-sm-6 col-xs-12' }}
+      >
+        <div className="flex">
+          <div className="flex-main">
+            Total Cast Time Saved:
+          </div>
+          <div className="flex-sub text-right">
+            <dfn data-tip={`Cast time saved by Flash Flood. <br /> ${(this.totalTimeWasted / 1000).toFixed(2)} seconds 'saved' on reductions below GCD.`} >
+              {`${(this.totalTimeSaved / 1000).toFixed(2)} seconds`}
+            </dfn>
+          </div>
         </div>
-      </div>
+        {this.flashFloodUsageRatioChart()}
+      </StatisticsListBox>
     );
   }
 

--- a/src/Parser/Shaman/Restoration/Modules/Talents/TalentStatisticBox.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/TalentStatisticBox.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import StatisticsListBox, { STATISTIC_ORDER } from 'Interface/Others/StatisticsListBox';
+import STATISTIC_CATEGORY from 'Interface/Others/STATISTIC_CATEGORY';
 import SPELLS from 'common/SPELLS';
 
 import Analyzer from 'Parser/Core/Analyzer';
@@ -13,7 +14,6 @@ import EarthShield from './EarthShield';
 import EarthenWallTotem from './EarthenWallTotem';
 import NaturesGuardian from './NaturesGuardian';
 import Downpour from './Downpour';
-import FlashFlood from './FlashFlood';
 import CloudburstTotem from './CloudburstTotem';
 import Ascendance from './Ascendance';
 import Wellspring from './Wellspring';
@@ -30,7 +30,6 @@ class TalentStatisticBox extends Analyzer {
     earthenWallTotem: EarthenWallTotem,
     naturesGuardian: NaturesGuardian,
     downpour: Downpour,
-    flashFlood: FlashFlood,
     cloudburstTotem: CloudburstTotem,
     ascendance: Ascendance,
     wellspring: Wellspring,
@@ -40,11 +39,13 @@ class TalentStatisticBox extends Analyzer {
   statistic() {
     return (
       <StatisticsListBox
-        title="Talents"
+        title="Healing Contribution"
         tooltip={`The purpose of this is to show the overall HPS impact of each talent. So not only what the talent itself did, but also feeding and synergy or interactions with other spells or talents. The percentage shown is what you'd lose without the talent, ignoring what you'd gain from the other options.<br /><br />
         <b>Not Supported:</b><br />
         Echo of the Elements
         `}
+        position={STATISTIC_ORDER.CORE(1)}
+        category={STATISTIC_CATEGORY.TALENTS}
       >
         {this.selectedCombatant.hasTalent(SPELLS.TORRENT_TALENT.id) ? this.torrent.subStatistic() : ''}
         {this.selectedCombatant.hasTalent(SPELLS.UNLEASH_LIFE_TALENT.id) ? this.unleashLife.subStatistic() : ''}
@@ -53,7 +54,6 @@ class TalentStatisticBox extends Analyzer {
         {this.selectedCombatant.hasTalent(SPELLS.EARTH_SHIELD_TALENT.id) ? this.earthShield.subStatistic() : ''}
         {this.selectedCombatant.hasTalent(SPELLS.EARTHEN_WALL_TOTEM_TALENT.id) ? this.earthenWallTotem.subStatistic() : ''}
         {this.selectedCombatant.hasTalent(SPELLS.NATURES_GUARDIAN_TALENT.id) ? this.naturesGuardian.subStatistic() : ''}
-        {this.selectedCombatant.hasTalent(SPELLS.FLASH_FLOOD_TALENT.id) ? this.flashFlood.subStatistic() : ''}
         {this.selectedCombatant.hasTalent(SPELLS.DOWNPOUR_TALENT.id) ? this.downpour.subStatistic() : ''}
         {this.selectedCombatant.hasTalent(SPELLS.CLOUDBURST_TOTEM_TALENT.id) ? this.cloudburstTotem.subStatistic() : ''}
         {this.selectedCombatant.hasTalent(SPELLS.HIGH_TIDE_TALENT.id) ? this.highTide.subStatistic() : ''}
@@ -62,7 +62,6 @@ class TalentStatisticBox extends Analyzer {
       </StatisticsListBox>
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(1000);
 }
 
 export default TalentStatisticBox;

--- a/src/Parser/Shaman/Restoration/Modules/Talents/UnleashLife.js
+++ b/src/Parser/Shaman/Restoration/Modules/Talents/UnleashLife.js
@@ -6,6 +6,7 @@ import SPELLS from 'common/SPELLS';
 import { formatPercentage } from 'common/format';
 
 import StatisticsListBox, { STATISTIC_ORDER } from 'Interface/Others/StatisticsListBox';
+import STATISTIC_CATEGORY from 'Interface/Others/STATISTIC_CATEGORY';
 import StatisticListBoxItem from 'Interface/Others/StatisticListBoxItem';
 
 import Analyzer from 'Parser/Core/Analyzer';
@@ -300,16 +301,14 @@ class UnleashLife extends Analyzer {
 
   statistic() {
     return (
-      <div className="col-lg-3 col-md-4 col-sm-6 col-xs-12">
-        <div className="row">
-          <StatisticsListBox
-            title={<span><SpellLink id={SPELLS.UNLEASH_LIFE_TALENT.id} /> usage</span>}
-            containerProps={{ className: 'col-xs-12' }}
-          >
-            {this.unleashLifeCastRatioChart()}
-          </StatisticsListBox>
-        </div>
-      </div>
+      <StatisticsListBox
+        title={<span><SpellLink id={SPELLS.UNLEASH_LIFE_TALENT.id} /> usage</span>}
+        containerProps={{ className: 'col-lg-3 col-md-4 col-sm-6 col-xs-12' }}
+        category={STATISTIC_CATEGORY.TALENTS}
+        position={STATISTIC_ORDER.OPTIONAL(15)}
+      >
+        {this.unleashLifeCastRatioChart()}
+      </StatisticsListBox>
     );
   }
   statisticOrder = STATISTIC_ORDER.OPTIONAL(10);


### PR DESCRIPTION
Also moved the "total time saved" from the talent overview box to flash floods own module, since it was the only one that wasn't about how much healing it contributes.

Examples
![image](https://user-images.githubusercontent.com/2842471/46030186-c89c3100-c0f5-11e8-8fc6-e1b93fe7862a.png)
![image](https://user-images.githubusercontent.com/2842471/46030183-c33ee680-c0f5-11e8-89dc-ee4dc52e8552.png)
Log: https://wowanalyzer.com/report/Dg3G7BnMH2zxrCZd/21-Heroic+Zul+-+Wipe+19+(7:27)/12-%D0%90%D0%BD%D1%82%D1%82%D0%B0%D1%80%D0%B5%D1%81
