### PR TITLE
[BrM] Clarify purify usage in stagger plot

### DIFF
--- a/src/Parser/Monk/Brewmaster/CHANGELOG.js
+++ b/src/Parser/Monk/Brewmaster/CHANGELOG.js
@@ -8,6 +8,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-09-27'),
+    changes: 'Updated Stagger plot to show very quick purifies more accurately.',
+    contributors: [emallson],
+  },
+  {
     date: new Date('2018-09-22'),
     changes: <React.Fragment>Updated <SpellLink id={SPELLS.IRONSKIN_BREW.id} /> and <SpellLink id={SPELLS.BREATH_OF_FIRE.id} /> suggestions to use hits mitigated instead of uptime.</React.Fragment>,
     contributors: [emallson],

--- a/src/Parser/Monk/Brewmaster/Modules/Features/StaggerPoolGraph.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/StaggerPoolGraph.js
@@ -255,7 +255,7 @@ class StaggerPoolGraph extends Analyzer {
                 ticks: {
                   fontColor: '#ccc',
                   callback: function (x) {
-                    const label = formatDuration(x, 1); // formatDuration got changed -- need precision=1 or it blows up, but that adds a .0 to it
+                    const label = formatDuration(Math.floor(x/2), 1); // formatDuration got changed -- need precision=1 or it blows up, but that adds a .0 to it
                     return label.substring(0, label.length - 2);
                   },
                 },

--- a/src/Parser/Monk/Brewmaster/Modules/Features/StaggerPoolGraph.js
+++ b/src/Parser/Monk/Brewmaster/Modules/Features/StaggerPoolGraph.js
@@ -59,7 +59,7 @@ class StaggerPoolGraph extends Analyzer {
 
   plot() {
     // x indices
-    const labels = Array.from({ length: Math.ceil(this.owner.fightDuration / 1000) }, (x, i) => i);
+    const labels = Array.from({ length: Math.ceil(this.owner.fightDuration / 500) }, (x, i) => i);
 
     // somethingBySeconds are all objects mapping from seconds ->
     // something, where if a value is unknown for that timestamp it is
@@ -70,25 +70,28 @@ class StaggerPoolGraph extends Analyzer {
     }, {});
     const hpBySeconds = Object.assign({}, poolBySeconds);
 
-    const purifies = this._purifyTimestamps.map(timestamp => Math.floor((timestamp - this.owner.fight.start_time) / 1000));
+    const purifies = this._purifyTimestamps.map(timestamp => Math.floor((timestamp - this.owner.fight.start_time) / 500));
     const deaths = this._deathEvents.map(({ timestamp, killingAbility }) => {
       return {
-        seconds: Math.floor((timestamp - this.owner.fight.start_time) / 1000),
+        seconds: Math.floor((timestamp - this.owner.fight.start_time) / 500),
         ability: killingAbility,
       };
     });
 
     this._staggerEvents.forEach(({ timestamp, newPooledDamage }) => {
-      const seconds = Math.floor((timestamp - this.owner.fight.start_time) / 1000);
+      const seconds = Math.floor((timestamp - this.owner.fight.start_time) / 500);
       // show the peak rather than left or right edge of the bin. this
       // can cause display issues if there is a rapid sequence of
       // hit->purify->hit but has the upside of making purifies after
-      // big hits (aka good purifies) very visible
+      // big hits (aka good purifies) very visible.
+      //
+      // note for future me: upping resolution from 1s -> 500ms
+      // eliminated the issue mentioned above
       poolBySeconds[seconds] = (poolBySeconds[seconds] > newPooledDamage) ? poolBySeconds[seconds] : newPooledDamage;
     });
 
     this._hpEvents.forEach(({ timestamp, hitPoints, maxHitPoints }) => {
-      const seconds = Math.floor((timestamp - this.owner.fight.start_time) / 1000);
+      const seconds = Math.floor((timestamp - this.owner.fight.start_time) / 500);
       // we fill in the blanks later if hitPoints is not defined
       if (!!hitPoints) {
         hpBySeconds[seconds] = { hitPoints, maxHitPoints };


### PR DESCRIPTION
Currently, the stagger plot uses the *right edge* of a bin for determining the y value. This can make purifies look bad when a player purifies very quickly after a hit, since the previous bin was small and we sometimes get an extra stagger tick within the current bin. This PR changes that by doing two things:

1. Bins are now plotted using the *max* value within the bin instead of the rightmost value.
2. (1) introduced an issue where if a hit occurred right after a purify, it would look like the purify did literally nothing. I fixed this by upping the resolution of the plot from 1s bins to 0.5s bins.

I also cleaned up how purifies are positioned. It should now always place them in the correct bin instead of occasionally putting them back an extra bin.

**M Fetid, before & after**
![screenshot from 2018-09-25 14-33-42](https://user-images.githubusercontent.com/4909458/46035533-3da93f80-c0d1-11e8-8eef-16319371e79a.png)
![screenshot from 2018-09-25 14-39-26](https://user-images.githubusercontent.com/4909458/46035464-15214580-c0d1-11e8-823b-ac89bbb7d13a.png)

**M Vectis, before & after**
![screenshot from 2018-09-25 14-34-09](https://user-images.githubusercontent.com/4909458/46035544-46017a80-c0d1-11e8-84de-9cd1ce22cb8d.png)
![screenshot from 2018-09-25 14-39-08](https://user-images.githubusercontent.com/4909458/46035466-15214580-c0d1-11e8-807d-c8e98df7cb3d.png)
