### PR TITLE
[General Azerite] Blessed Portents trait module

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -9,6 +9,11 @@ import Contributor from 'Interface/Contributor/Button';
 
 export default [
   {
+    date: new Date('2018-09-25'),
+    changes: <React.Fragment> Added <SpellLink id={SPELLS.BLESSED_PORTENTS.id} /> module.</React.Fragment>,
+    contributors: [Nalhan],
+  },
+  {
     date: new Date('2018-09-24'),
     changes: <React.Fragment> Added <SpellLink id={SPELLS.CONCENTRATED_MENDING.id} /> module. </React.Fragment>,
     contributors: [Nalhan],

--- a/src/Parser/Core/CombatLogParser.js
+++ b/src/Parser/Core/CombatLogParser.js
@@ -90,6 +90,7 @@ import OverWhelmingPower from './Modules/Spells/BFA/AzeriteTraits/OverwhelmingPo
 import ElementalWhirl from './Modules/Spells/BFA/AzeriteTraits/ElementalWhirl';
 import BloodRite from './Modules/Spells/BFA/AzeriteTraits/BloodRite';
 import ConcentratedMending from './Modules/Spells/BFA/AzeriteTraits/ConcentratedMending';
+import BlessedPortents from './Modules/Spells/BFA/AzeriteTraits/BlessedPortents';
 // Uldir
 import TwitchingTentacleofXalzaix from './Modules/Items/BFA/Raids/Uldir/TwitchingTentacleofXalzaix';
 import VigilantsBloodshaper from './Modules/Items/BFA/Raids/Uldir/VigilantsBloodshaper';
@@ -192,6 +193,7 @@ class CombatLogParser {
     elementalWhirl: ElementalWhirl,
     bloodRite: BloodRite,
     concentratedMending: ConcentratedMending,
+    blessedPortents: BlessedPortents,
 
     // Uldir
     twitchingTentacleofXalzaix: TwitchingTentacleofXalzaix,

--- a/src/Parser/Core/Modules/Features/SpellInfo.js
+++ b/src/Parser/Core/Modules/Features/SpellInfo.js
@@ -118,7 +118,7 @@ export default {
     vers: true,
   },
   // https://www.warcraftlogs.com/reports/axKCmGyfgXFw6QVL/#fight=28&source=156
-  [SPELLS.BLESSED_PORTENTS.id]: { // General Azerite Power
+  [SPELLS.BLESSED_PORTENTS_HEAL.id]: { // General Azerite Power
     int: false,
     crit: true,
     hasteHpct: true,

--- a/src/Parser/Core/Modules/Spells/BFA/AzeriteTraits/BlessedPortents.js
+++ b/src/Parser/Core/Modules/Spells/BFA/AzeriteTraits/BlessedPortents.js
@@ -15,8 +15,6 @@ class BlessedPortents extends Analyzer {
   expiredBuffs = 0;
   refreshedBuffs = 0;
   activeBuffs = 0;
-
-  buffed = {};
   
   constructor(...args) {
     super(...args);
@@ -30,8 +28,6 @@ class BlessedPortents extends Analyzer {
     }
 
     this.healing += event.amount + (event.absorbed || 0);
-
-    //const targetId = event.targetID;
 
     this.proccedBuffs++;
     this.expiredBuffs--;
@@ -69,7 +65,7 @@ class BlessedPortents extends Analyzer {
     return this.proccedBuffs + this.expiredBuffs + this.refreshedBuffs + this.activeBuffs;
   }
 
-   statistic() {
+  statistic() {
     const healingThroughputPercent = this.owner.getPercentageOfTotalHealingDone(this.healing);
     const hps = this.healing / this.owner.fightDuration * 1000;
     return (

--- a/src/Parser/Core/Modules/Spells/BFA/AzeriteTraits/BlessedPortents.js
+++ b/src/Parser/Core/Modules/Spells/BFA/AzeriteTraits/BlessedPortents.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import Analyzer from 'Parser/Core/Analyzer';
+import { formatNumber, formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import TraitStatisticBox, { STATISTIC_ORDER } from 'Interface/Others/TraitStatisticBox';
+
+ /**
+ * Your healing spells have a chance to apply Blessed Portents for 20 sec.
+ * When the ally falls below 50% health, Blessed Portents is consumed
+ * and instantly restores X health.
+ */
+class BlessedPortents extends Analyzer {
+  healing = 0;
+  proccedBuffs = 0;
+  expiredBuffs = 0;
+  refreshedBuffs = 0;
+  activeBuffs = 0;
+
+  buffed = {};
+  
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrait(SPELLS.BLESSED_PORTENTS.id);
+  }
+
+  on_byPlayer_heal(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.BLESSED_PORTENTS_HEAL.id) {
+      return;
+    }
+
+    this.healing += event.amount + (event.absorbed || 0);
+
+    //const targetId = event.targetID;
+
+    this.proccedBuffs++;
+    this.expiredBuffs--;
+  }
+
+  on_byPlayer_applybuff(event) {
+    const spellId = event.ability.guid;
+
+    if (spellId !== SPELLS.BLESSED_PORTENTS_BUFF.id) {
+      return;
+    }
+
+    this.activeBuffs++;
+  }
+
+  on_byPlayer_removebuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.BLESSED_PORTENTS_BUFF.id) {
+      return;
+    }
+
+    this.expiredBuffs++;
+    this.activeBuffs--;
+  }
+
+  on_byPlayer_refreshbuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.BLESSED_PORTENTS_BUFF.id) {
+      return;
+    }
+
+    this.refreshedBuffs++;
+  }
+  get totalBuffs() {
+    return this.proccedBuffs + this.expiredBuffs + this.refreshedBuffs + this.activeBuffs;
+  }
+
+   statistic() {
+    const healingThroughputPercent = this.owner.getPercentageOfTotalHealingDone(this.healing);
+    const hps = this.healing / this.owner.fightDuration * 1000;
+    return (
+      <TraitStatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
+        trait={SPELLS.BLESSED_PORTENTS.id}
+        value={`${formatPercentage(healingThroughputPercent)} % / ${formatNumber(hps)} HPS`}
+        tooltip={`Applied <b>${formatNumber(this.totalBuffs)}</b> buffs,
+                  <b>${formatNumber(this.refreshedBuffs)}</b> were refreshes.
+                  <ul>
+                    <li>Procced: <b>${formatNumber(this.proccedBuffs)}</b></li>
+                    <li>Expired: <b>${formatNumber(this.expiredBuffs)}</b></li>
+                    <li>Active at encounter end: <b>${formatNumber(this.activeBuffs)}</b></li>
+                  </ul>
+                `}
+      />
+    );
+  }
+}
+
+ export default BlessedPortents;

--- a/src/common/SPELLS/BFA/AzeriteTraits/General.js
+++ b/src/common/SPELLS/BFA/AzeriteTraits/General.js
@@ -72,6 +72,16 @@ export default {
     icon: 'achievement_zone_stormpeaks_01',
   },
   BLESSED_PORTENTS: {
+    id: 267889,
+    name: 'Blessed Portents',
+    icon: 'spell_holy_fanaticism',
+  },
+  BLESSED_PORTENTS_BUFF: {
+    id: 271843,
+    name: 'Blessed Portents',
+    icon: 'spell_holy_fanaticism',
+  },
+  BLESSED_PORTENTS_HEAL: {
     id: 280052,
     name: 'Blessed Portents',
     icon: 'spell_holy_fanaticism',


### PR DESCRIPTION
Issue #2242 
Back again with another azerite trait. Tracks Blessed Portents healing contribution and shows number of buffs applied, refreshed, procced, expired, and active at the end of the fight.
![chrome_2018-09-25_16-11-23](https://user-images.githubusercontent.com/586978/46048519-a6e37f80-c0de-11e8-8b07-c5d878420638.png)
