### PR TITLE
Disc Priest: Removed error causing code

### DIFF
--- a/src/Parser/Priest/Discipline/Modules/Abilities.js
+++ b/src/Parser/Priest/Discipline/Modules/Abilities.js
@@ -23,7 +23,6 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
-          casts: castCount => castCount.casts,
         },
       },
       {
@@ -36,7 +35,6 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(SPELLS.EVANGELISM_TALENT.id),
         castEfficiency: {
           suggestion: true,
-          casts: castCount => castCount.casts,
         },
       },
       {


### PR DESCRIPTION
Undefined error:
![image](https://user-images.githubusercontent.com/9600587/46057391-6eb26000-c123-11e8-9f16-e97395310e8a.png)

log: https://www.wowanalyzer.com/report/64aM8HdAC2fLpD1q/2-Normal+Taloc+-+Kill+(4:25)/3-Amu

Not sure why this casts code exists but its causing the undefined. Removing it didnt seem to break anything.

          casts: castCount => castCount.casts,

Was reported to me by a friend.

