### PR TITLE
Various minor updates

### DIFF
--- a/src/Parser/Core/Modules/Items/BFA/Raids/Uldir/ConstructOvercharger.js
+++ b/src/Parser/Core/Modules/Items/BFA/Raids/Uldir/ConstructOvercharger.js
@@ -8,7 +8,7 @@ import Analyzer from 'Parser/Core/Analyzer';
 
 /**
  * Construct Overcharger -
- * Equip: Your attacks have a chance to increase your Haste by 21 for 10 sec, stacking up to 8 times.
+ * Equip: Your attacks have a chance to increase your Haste by X for 10 sec, stacking up to 8 times.
  */
 
 class ConstructOvercharger extends Analyzer{

--- a/src/Parser/Core/Modules/StatTracker.js
+++ b/src/Parser/Core/Modules/StatTracker.js
@@ -273,7 +273,7 @@ class StatTracker extends Analyzer {
     [SPELLS.DEADLY_NAVIGATION_BUFF_SMALL.id]: { crit: 50 },
     [SPELLS.DEADLY_NAVIGATION_BUFF_BIG.id]: { crit: 600 },
     [SPELLS.QUICK_NAVIGATION_BUFF_SMALL.id]: { haste: 50 },
-    [SPELLS.QUICK_NAVIGATION_BUFF_BIG.id]: { crit: 600 },
+    [SPELLS.QUICK_NAVIGATION_BUFF_BIG.id]: { haste: 600 },
     264878: { crit: 650 }, // Crow's Nest Scope
     //endregion
 
@@ -305,6 +305,10 @@ class StatTracker extends Analyzer {
     [SPELLS.GALECALLERS_BOON_BUFF.id]: {
       itemId: ITEMS.GALECALLERS_BOON.id,
       haste: (_, item) => calculateSecondaryStatDefault(310, 917, item.itemLevel),
+    },
+    [SPELLS.TITANIC_OVERCHARGE.id]: {
+      itemId: ITEMS.CONSTRUCT_OVERCHARGER.id,
+      haste: (_, item) => calculateSecondaryStatDefault(355, 35, item.itemLevel),
     },
     // region Quests
     // Mostly implemented for beta/PTR, don't expect to ever need those spells/trinkets elsewhere, so hard-coding the ids here

--- a/src/Parser/Hunter/BeastMastery/CombatLogParser.js
+++ b/src/Parser/Hunter/BeastMastery/CombatLogParser.js
@@ -1,6 +1,7 @@
 import CoreCombatLogParser from 'Parser/Core/CombatLogParser';
 import DamageDone from 'Parser/Core/Modules/DamageDone';
-import GlobalCooldown from 'Parser/Hunter/BeastMastery/Modules/Core/GlobalCooldown';
+import GlobalCooldown from './Modules/Core/GlobalCooldown';
+import SpellUsable from './Modules/Core/SpellUsable';
 
 //Features
 import Abilities from './Modules/Abilities';
@@ -45,6 +46,7 @@ class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     damageDone: [DamageDone, { showStatistic: true }],
     globalCooldown: GlobalCooldown,
+    spellUsable: SpellUsable,
 
     //Features
     alwaysBeCasting: AlwaysBeCasting,

--- a/src/Parser/Hunter/BeastMastery/Modules/Abilities.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Abilities.js
@@ -62,6 +62,8 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.BARBED_SHOT,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        cooldown: haste => 12 / (1 + haste),
+        charges: 2,
         gcd: {
           base: 1500,
         },

--- a/src/Parser/Hunter/BeastMastery/Modules/Core/SpellUsable.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Core/SpellUsable.js
@@ -1,0 +1,34 @@
+import SPELLS from 'common/SPELLS';
+import CoreSpellUsable from 'Parser/Core/Modules/SpellUsable';
+
+class SpellUsable extends CoreSpellUsable {
+  static dependencies = {
+    ...CoreSpellUsable.dependencies,
+  };
+
+  lastPotentialTriggerForBarbedShotReset = null;
+  on_byPlayer_cast(event) {
+    if (super.on_byPlayer_cast) {
+      super.on_byPlayer_cast(event);
+    }
+
+    const spellId = event.ability.guid;
+    if (spellId === SPELLS.AUTO_SHOT.id) {
+      this.lastPotentialTriggerForBarbedShotReset = event;
+    } else if (spellId === SPELLS.BARBED_SHOT.id) {
+      this.lastPotentialTriggerForBarbedShotReset = null;
+    }
+  }
+
+  beginCooldown(spellId, timestamp) {
+    if (spellId === SPELLS.BARBED_SHOT.id) {
+      if (this.isOnCooldown(spellId)) {
+        this.endCooldown(spellId, undefined, this.lastPotentialTriggerForBarbedShotReset ? this.lastPotentialTriggerForBarbedShotReset.timestamp : undefined);
+      }
+    }
+
+    super.beginCooldown(spellId, timestamp);
+  }
+}
+
+export default SpellUsable;

--- a/src/Parser/Hunter/BeastMastery/Modules/Spells/BarbedShot.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Spells/BarbedShot.js
@@ -128,15 +128,27 @@ class BarbedShot extends Analyzer {
   }
 
   get direFrenzy3StackThreshold() {
-    return {
-      actual: this.percentUptimeMaxStacks,
-      isLessThan: {
-        minor: 0.45,
-        average: 0.40,
-        major: 0.35,
-      },
-      style: 'percentage',
-    };
+    if (this.selectedCombatant.hasTrait(SPELLS.FEEDING_FRENZY.id)) {
+      return {
+        actual: this.percentUptimeMaxStacks,
+        isLessThan: {
+          minor: 0.60,
+          average: 0.55,
+          major: 0.50,
+        },
+        style: 'percentage',
+      };
+    } else {
+      return {
+        actual: this.percentUptimeMaxStacks,
+        isLessThan: {
+          minor: 0.45,
+          average: 0.40,
+          major: 0.35,
+        },
+        style: 'percentage',
+      };
+    }
   }
 
   suggestions(when) {

--- a/src/Parser/Hunter/BeastMastery/Modules/Spells/BarbedShot.js
+++ b/src/Parser/Hunter/BeastMastery/Modules/Spells/BarbedShot.js
@@ -30,7 +30,6 @@ class BarbedShot extends Analyzer {
   barbedShotStacks = [];
   lastBarbedShotStack = 0;
   lastBarbedShotUpdate = this.owner.fight.start_time;
-  buffStarters = 0;
 
   constructor(...args) {
     super(...args);
@@ -67,10 +66,6 @@ class BarbedShot extends Analyzer {
 
   on_byPlayer_damage(event) {
     const spellId = event.ability.guid;
-    if (this.selectedCombatant.hasBuff(SPELLS.BARBED_SHOT_BUFF.id) && this.buffStarters === 0) {
-      this.buffStarters = 1;
-      this.spellUsable.beginCooldown(SPELLS.BARBED_SHOT.id, this.owner.fight.start_time);
-    }
     if (spellId !== SPELLS.BARBED_SHOT.id) {
       return;
     }
@@ -90,7 +85,6 @@ class BarbedShot extends Analyzer {
     if (spellId !== SPELLS.BARBED_SHOT_PET_BUFF.id) {
       return;
     }
-    this.buffStarters += 1;
     this.handleStacks(event);
   }
 

--- a/src/Parser/Hunter/Survival/Modules/Abilities.js
+++ b/src/Parser/Hunter/Survival/Modules/Abilities.js
@@ -14,7 +14,7 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: .9,
+          recommendedEfficiency: combatant.hasTalent(SPELLS.ALPHA_PREDATOR_TALENT.id) ? 0.7 : .9,
         },
         timelineSortIndex: 3,
         charges: combatant.hasTalent(SPELLS.ALPHA_PREDATOR_TALENT.id) ? 2 : 1,

--- a/src/Parser/Hunter/Survival/Modules/Spells/KillCommand.js
+++ b/src/Parser/Hunter/Survival/Modules/Spells/KillCommand.js
@@ -38,7 +38,6 @@ class KillCommand extends Analyzer {
       return;
     }
     if (!this.spellUsable.isOnCooldown(SPELLS.KILL_COMMAND_SV.id)) {
-      this.resetWhileNotOnCD++;
       return;
     }
     this.resets++;
@@ -52,7 +51,6 @@ class KillCommand extends Analyzer {
         icon={<SpellIcon id={SPELLS.KILL_COMMAND_SV.id} />}
         value={`${this.resets}`}
         label="Kill Command resets"
-        tooltip={`You had ${this.resetWhileNotOnCD} resets whilst Kill Command was not on cooldown`}
       />
     );
   }

--- a/src/Parser/Hunter/Survival/Modules/Spells/SerpentSting.js
+++ b/src/Parser/Hunter/Survival/Modules/Spells/SerpentSting.js
@@ -175,7 +175,7 @@ class SerpentSting extends Analyzer {
 
   suggestions(when) {
     when(this.uptimeThreshold).addSuggestion((suggest, actual, recommended) => {
-      return suggest(<React.Fragment>Remember to maintain the <SpellLink id={SPELLS.SERPENT_STING_SV.id} /> on enemies, but don't refresh the debuff unless you have a <SpellLink id={SPELLS.VIPERS_VENOM_TALENT.id} /> buff, or the debuff has less than {formatPercentage(PANDEMIC)}% duration remaining.</React.Fragment>)
+      return suggest(<React.Fragment>Remember to maintain the <SpellLink id={SPELLS.SERPENT_STING_SV.id} /> on enemies, but don't refresh the debuff unless it has less than {formatPercentage(PANDEMIC)}% duration remaining {this.selectedCombatant.hasTalent(SPELLS.VIPERS_VENOM_TALENT.id) ? <React.Fragment>, or you have a <SpellLink id={SPELLS.VIPERS_VENOM_TALENT.id} /> buff</React.Fragment> : ''}.</React.Fragment>)
         .icon(SPELLS.SERPENT_STING_SV.icon)
         .actual(`${formatPercentage(actual)}% Serpent Sting uptime`)
         .recommended(`>${formatPercentage(recommended)}% is recommended`);

--- a/src/articles/2018-04-14-Battle-For-Azeroth/index.js
+++ b/src/articles/2018-04-14-Battle-For-Azeroth/index.js
@@ -7,6 +7,6 @@ import BackgroundImage from './Background.jpg';
 
 export default (
   <ImageArticle title="Battle for Azeroth" publishedAt="2018-04-14" publishedBy={Zerotorescue} image={BackgroundImage} style={{ paddingTop: 350 }}>
-    Work has started on support for <b>Battle for Azeroth</b>. We continue to need contributions to get all specs compatible with Battle for Azeroth. If you want to help out, join us on <a href="/discord">Discord</a> or see the <a href="https://github.com/WoWAnalyzer/WoWAnalyzer#contributing">instructions on GitHub</a>. Our progress can be followed at <a href="https://bfa.wowanalyzer.com">bfa.wowanalyzer.com</a>.
+    Work has started on support for <b>Battle for Azeroth</b>. We continue to need contributions to get all specs compatible with Battle for Azeroth. If you want to help out, join us on <a href="/discord">Discord</a> or see the <a href="https://github.com/WoWAnalyzer/WoWAnalyzer#contributing">instructions on GitHub</a>. Our progress can be followed at <a href="https://wowanalyzer.com">wowanalyzer.com</a>.
   </ImageArticle>
 );


### PR DESCRIPTION
Adds Construct Overcharger to stat-tracker
Adds some sort of cooldown resetting to Barbed Shot as seen in [Avengers Shield](https://github.com/WoWAnalyzer/WoWAnalyzer/blob/master/src/Parser/Paladin/Protection/Modules/Features/SpellUsable.js) and [Shield Slam](https://github.com/WoWAnalyzer/WoWAnalyzer/blob/master/src/Parser/Warrior/Protection/Modules/Features/SpellUsable.js).
Fixes Quick nav buff in stat tracker
Fixes a SV suggestion and removes part of kill command reset tooltip as it never could happen. 