### PR TITLE
[Blood Death Knight] update HB and MR-modules

### DIFF
--- a/src/parser/deathknight/blood/CHANGELOG.js
+++ b/src/parser/deathknight/blood/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-09-28'),
+    changes: <React.Fragment>Updated the <SpellLink id={SPELLS.MARROWREND.id} />-usage module to account for <SpellLink id={SPELLS.BONES_OF_THE_DAMNED.id} /> and updated <SpellLink id={SPELLS.HEARTBREAKER_TALENT.id} />-Module.</React.Fragment>,
+    contributors: [joshinator],
+  },
+  {
     date: new Date('2018-08-03'),
     changes: <React.Fragment>Added <SpellLink id={SPELLS.BONE_SPIKE_GRAVEYARD.id} />-Module.</React.Fragment>,
     contributors: [joshinator],

--- a/src/parser/deathknight/blood/modules/features/MarrowrendUsage.js
+++ b/src/parser/deathknight/blood/modules/features/MarrowrendUsage.js
@@ -9,7 +9,8 @@ import AbilityTracker from 'parser/core/modules/AbilityTracker';
 import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 import Analyzer from 'parser/core/Analyzer';
 
-const REFRESH_AT_STACKS = 6;
+const REFRESH_AT_STACKS_WITH_BONES_OF_THE_DAMNED = 6;
+const REFRESH_AT_STACKS_WITHOUT_BONES_OF_THE_DAMNED = 7;
 const REFRESH_AT_SECONDS = 6;
 const BS_DURATION = 30;
 const MR_GAIN = 3;
@@ -35,6 +36,7 @@ class MarrowrendUsage extends Analyzer {
   totalMRCasts = 0;
 
   hasBonesOfTheDamned = false;
+  refreshAtStacks = REFRESH_AT_STACKS_WITHOUT_BONES_OF_THE_DAMNED;
 
   bonesOfTheDamnedProc = 0;
   totalStacksGenerated = 0;
@@ -85,7 +87,7 @@ class MarrowrendUsage extends Analyzer {
       this.refreshMRCasts += 1;
     } else {
       const boneShieldStacks = this.currentBoneShieldStacks - this.currentBoneShieldBuffer;
-      if (boneShieldStacks > REFRESH_AT_STACKS) {
+      if (boneShieldStacks > this.refreshAtStacks) {
         this.badMRCasts += 1;
         const wasted = MR_GAIN - this.currentBoneShieldBuffer;
         if (wasted > 0) {
@@ -155,7 +157,7 @@ class MarrowrendUsage extends Analyzer {
   suggestions(when) {
     when(this.suggestionThresholds)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<React.Fragment>You casted {this.badMRCasts} Marrowrends with more than 6 stacks of <SpellLink id={SPELLS.BONE_SHIELD.id} /> that were not about to expire. Try to cast <SpellLink id={SPELLS.HEART_STRIKE.id} /> instead under those conditions.</React.Fragment>)
+        return suggest(<React.Fragment>You casted {this.badMRCasts} Marrowrends with more than {this.refreshAtStacks} stacks of <SpellLink id={SPELLS.BONE_SHIELD.id} /> that were not about to expire. Try to cast <SpellLink id={SPELLS.HEART_STRIKE.id} /> instead under those conditions.</React.Fragment>)
           .icon(SPELLS.MARROWREND.icon)
           .actual(`${formatPercentage(actual)}% bad Marrowrend casts`)
           .recommended(`<${formatPercentage(recommended)}% is recommended`);
@@ -169,10 +171,12 @@ class MarrowrendUsage extends Analyzer {
         icon={<SpellIcon id={SPELLS.MARROWREND.id} />}
         value={`${ this.badMRCasts } / ${ this.totalMRCasts }`}
         label="Bad Marrowrend casts"
-        tooltip={`${ this.refreshMRCasts } casts to refresh Bone Shield<br>
-        ${ this.badMRCasts } casts with more than 6 stacks of Bone Shield wasting at least ${ this.bsStacksWasted } stacks<br>
-        <br>
-        Avoid casting Marrowrend unless you have 6 or less stacks or if Bone Shield has less than 6sec duration left.`}
+        tooltip={`
+          ${ this.refreshMRCasts } casts to refresh Bone Shield<br>
+          ${ this.badMRCasts } casts with more than ${this.refreshAtStacks} stacks of Bone Shield wasting at least ${ this.bsStacksWasted } stacks<br>
+          <br>
+          Avoid casting Marrowrend unless you have ${this.refreshAtStacks} or less stacks or if Bone Shield has less than 6sec duration left.
+        `}
       />
 
     );

--- a/src/parser/deathknight/blood/modules/features/MarrowrendUsage.js
+++ b/src/parser/deathknight/blood/modules/features/MarrowrendUsage.js
@@ -46,6 +46,7 @@ class MarrowrendUsage extends Analyzer {
 
     if(this.selectedCombatant.hasTrait(SPELLS.BONES_OF_THE_DAMNED.id)) {
       this.hasBonesOfTheDamned = true;
+      this.refreshAtStacks = REFRESH_AT_STACKS_WITH_BONES_OF_THE_DAMNED;
     }
   }
 

--- a/src/parser/deathknight/blood/modules/talents/Heartbreaker.js
+++ b/src/parser/deathknight/blood/modules/talents/Heartbreaker.js
@@ -2,7 +2,6 @@ import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS/index';
 import SpellIcon from 'common/SpellIcon';
-import SpellLink from 'common/SpellLink';
 import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
@@ -39,28 +38,6 @@ class Heartbreaker extends Analyzer {
 
   get averageHearStrikeHits() {
     return (this.rpGains.length / this.hsCasts).toFixed(2);
-  }
-
-  get averageHitSuggestionThresholds() {
-    return {
-      actual: this.averageHearStrikeHits,
-      isLessThan: {
-        minor: 4,
-        average: 2.5,
-        major: 2,
-      },
-      style: 'number',
-    };
-  }
-
-  suggestions(when) {
-    when(this.averageHitSuggestionThresholds)
-        .addSuggestion((suggest, actual, recommended) => {
-          return suggest(<React.Fragment><SpellLink id={SPELLS.HEARTBREAKER_TALENT.id} /> relies heavily on the amount of targets you can hit with <SpellLink id={SPELLS.HEART_STRIKE.id} /> to perform on par with <SpellLink id={SPELLS.BLOODDRINKER_TALENT.id} />. Consider picking <SpellLink id={SPELLS.BLOODDRINKER_TALENT.id} /> if you can't hit reliable multiple (4+) targets.</React.Fragment>)
-            .icon(SPELLS.HEARTBREAKER_TALENT.icon)
-            .actual(`on average ${actual} targets hit with Heart Strike`)
-            .recommended(`>${recommended} is recommended`);
-        });
   }
 
   statistic() {


### PR DESCRIPTION
Updates the Marrowrend usage module to default to a 7 stack refresh and only use 6 stacks when running Bones of the Damned.

Also removes the suggestion for running Hearth Breaker since it's now a more or less viable choice for pure defensive purpose (primarily due to the relative damage/healing loss on BD going into BfA).