### PR TITLE
[Frost Mage] Move Frozen Orb CD reduction into whiteout module [SRP]

### DIFF
--- a/src/parser/mage/frost/modules/cooldowns/FrozenOrb.js
+++ b/src/parser/mage/frost/modules/cooldowns/FrozenOrb.js
@@ -5,32 +5,21 @@ import SpellUsable from 'parser/core/modules/SpellUsable';
 const REDUCTION_MS = 500;
 
 class FrozenOrb extends Analyzer {
-	static dependencies = {
-		spellUsable: SpellUsable,
-	}
+  static dependencies = {
+    spellUsable: SpellUsable,
+  };
 
-	baseCooldown = 60;
-	cooldownReduction = 0;
+  on_byPlayer_damage(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.BLIZZARD_DAMAGE.id) {
+      return;
+    }
 
-	constructor(...args) {
-		super(...args);
-		this.hasWhiteoutTrait = this.selectedCombatant.hasTrait(SPELLS.WHITEOUT.id);
-	  }
-
-  	on_byPlayer_damage(event) {
-		const spellId = event.ability.guid;
-		if(spellId !== SPELLS.BLIZZARD_DAMAGE.id && spellId !== SPELLS.ICE_LANCE_DAMAGE.id) {
-			return;
-		}
-		if (this.spellUsable.isOnCooldown(SPELLS.FROZEN_ORB.id)) {
-			if (spellId === SPELLS.BLIZZARD_DAMAGE.id) {
-				this.cooldownReduction += this.spellUsable.reduceCooldown(SPELLS.FROZEN_ORB.id, REDUCTION_MS);
-			} else if (spellId === SPELLS.ICE_LANCE_DAMAGE.id && this.hasWhiteoutTrait) {
-				this.cooldownReduction += this.spellUsable.reduceCooldown(SPELLS.FROZEN_ORB.id, REDUCTION_MS);
-			}
-		}
-		
+    if (this.spellUsable.isOnCooldown(SPELLS.FROZEN_ORB.id)) {
+      this.spellUsable.reduceCooldown(SPELLS.FROZEN_ORB.id, REDUCTION_MS);
+    }
   }
+
 }
 
 export default FrozenOrb;

--- a/src/parser/mage/frost/modules/traits/Whiteout.js
+++ b/src/parser/mage/frost/modules/traits/Whiteout.js
@@ -26,7 +26,7 @@ const FO_REDUCTION_SEC = 0.5;
 
 /**
  * See known issue below, this is a temporary fix
- * To update, see https://ptr.wowhead.com/spell=137020/frost-mage
+ * To update, see https://www.wowhead.com/spell=137020/frost-mage
  * AURA = 1 + (Damage modifier)
  */
 const FROST_MAGE_AURA = 1 + (-0.24);
@@ -70,6 +70,7 @@ class Whiteout extends Analyzer {
       return;
     }
     if (this.spellUsable.isOnCooldown(SPELLS.FROZEN_ORB.id)) {
+      this.spellUsable.reduceCooldown(SPELLS.FROZEN_ORB.id, FO_REDUCTION_SEC * 1000);
       this.frozenOrbReductions += 1;
     }
 
@@ -122,6 +123,7 @@ class Whiteout extends Analyzer {
       />
     );
   }
+
 }
 
 export default Whiteout;


### PR DESCRIPTION
Because a separate Whiteout trait module was created, the FO CD reduction should probably be moved into that module for SRP to remove duplicate logic checking