### PR TITLE
[Havok DH] Removed fel eruption suggestion

### DIFF
--- a/src/parser/demonhunter/havoc/modules/Abilities.js
+++ b/src/parser/demonhunter/havoc/modules/Abilities.js
@@ -41,6 +41,15 @@ class Abilities extends CoreAbilities {
         },
       },
       {
+        spell: SPELLS.FEL_ERUPTION_TALENT,
+        enabled: combatant.hasTalent(SPELLS.FEL_ERUPTION_TALENT.id),
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: 30,
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
         spell: SPELLS.FEL_BARRAGE_TALENT,
         enabled: combatant.hasTalent(SPELLS.FEL_BARRAGE_TALENT.id),
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,

--- a/src/parser/demonhunter/havoc/modules/Abilities.js
+++ b/src/parser/demonhunter/havoc/modules/Abilities.js
@@ -41,20 +41,6 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.FEL_ERUPTION_TALENT,
-        enabled: combatant.hasTalent(SPELLS.FEL_ERUPTION_TALENT.id),
-        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
-        cooldown: 30,
-        gcd: {
-          base: 1500,
-        },
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: 0.95,
-          extraSuggestion: 'This is a great Chaos burst damage spell and it does a huge single target DPS increase by just 10 Fury per cast. Should definitively be used as soon as it gets available.',
-        },
-      },
-      {
         spell: SPELLS.FEL_BARRAGE_TALENT,
         enabled: combatant.hasTalent(SPELLS.FEL_BARRAGE_TALENT.id),
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,


### PR DESCRIPTION
The damage increase to it was removed in BFA so no longer worth using on CD
![image](https://user-images.githubusercontent.com/9600587/46270382-39d44d80-c515-11e8-8c11-8cdabc6a9243.png)
