### PR TITLE
remove all - in icon names rather than one

### DIFF
--- a/src/common/Icon.js
+++ b/src/common/Icon.js
@@ -7,7 +7,7 @@ const Icon = ({ icon, alt, ...others }) => {
   if (!icon) {
     return null;
   }
-  icon = icon.replace('.jpg', '').replace('-', '');
+  icon = icon.replace('.jpg', '').replace(/-/g, '');
   if (icon === 'petbattle_healthdown') {
     // Blizzard seems to have forgotten to remove the dash for this one... or something
     icon = 'petbattle_health-down';


### PR DESCRIPTION
achievement_guildperk_quick-and-dead got replaced with achievement_guildperk_quickand-dead and not as supposed like achievement_guildperk_quickanddead