### PR TITLE
[Destruction] Wasted Conflagrate 

### DIFF
--- a/src/parser/warlock/destruction/CHANGELOG.js
+++ b/src/parser/warlock/destruction/CHANGELOG.js
@@ -8,6 +8,11 @@ import SPELLS from 'common/SPELLS';
 export default [
   {
     date: new Date('2018-10-02'),
+    changes: <React.Fragment>Added a statistic box showing wasted <SpellLink id={SPELLS.CONFLAGRATE.id} /> casts.</React.Fragment>,
+    contributors: [Chizu],
+  },
+  {
+    date: new Date('2018-10-02'),
     changes: <React.Fragment>Added <SpellLink id={SPELLS.GRIMOIRE_OF_SUPREMACY_TALENT.id} /> stack tracker.</React.Fragment>,
     contributors: [Chizu],
   },

--- a/src/parser/warlock/destruction/CombatLogParser.js
+++ b/src/parser/warlock/destruction/CombatLogParser.js
@@ -5,6 +5,7 @@ import Abilities from './modules/features/Abilities';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
 import ImmolateUptime from './modules/features/ImmolateUptime';
+import Conflagrate from './modules/features/Conflagrate';
 import Havoc from './modules/features/Havoc';
 
 import SoulShardTracker from './modules/soulshards/SoulShardTracker';
@@ -31,6 +32,7 @@ class CombatLogParser extends CoreCombatLogParser {
     immolateUptime: ImmolateUptime,
 
     // Core
+    conflagrate: Conflagrate,
     havoc: Havoc,
     soulShardTracker: SoulShardTracker,
     soulShardDetails: SoulShardDetails,

--- a/src/parser/warlock/destruction/modules/features/Conflagrate.js
+++ b/src/parser/warlock/destruction/modules/features/Conflagrate.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import Analyzer from 'parser/core/Analyzer';
+import CastEfficiency from 'parser/core/modules/CastEfficiency';
+
+import SPELLS from 'common/SPELLS';
+import StatisticBox from 'interface/others/StatisticBox';
+import SpellIcon from 'common/SpellIcon';
+
+class Conflagrate extends Analyzer {
+  static dependencies = {
+    castEfficiency: CastEfficiency,
+  };
+
+  statistic() {
+    const { casts, maxCasts } = this.castEfficiency.getCastEfficiencyForSpellId(SPELLS.CONFLAGRATE.id);
+    const missed = maxCasts - casts;
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.CONFLAGRATE.id} />}
+        label="Missed Conflagrate casts"
+        value={missed}
+        tooltip={`${casts} out of ${maxCasts} possible casts.`}
+      />
+    );
+  }
+}
+
+export default Conflagrate;


### PR DESCRIPTION
Although I'm not exactly a fan of this, as it's duplicated from what is shown in the Abilities tab, apparently people are lazy to look for that, and from the viewpoint of analyzing logs, it's important to make it more visible, so here it is.

Example: https://www.warcraftlogs.com/reports/PdLX2rva3q8fN1Zw/#fight=29&source=23

![image](https://user-images.githubusercontent.com/5068584/46368948-d61b6300-c681-11e8-9391-29e9a28bdb84.png)
