### PR TITLE
[Core] Fix negative formatDuration; [Mage] Fix Time Warp GCD info

### DIFF
--- a/src/common/format.js
+++ b/src/common/format.js
@@ -36,12 +36,14 @@ export function formatPercentage(percentage, precision = 2) {
  * Ex: 317.3 => 5:17
  */
 export function formatDuration(duration, precision = 0) {
+  const neg = duration < 0 ? '-' : '';
+  duration = Math.abs(duration);
   const minutes = Math.floor(duration / 60);
   const mult = Math.pow(10, precision);
   const rest = (Math.floor(duration % 60 * mult) / mult).toFixed(precision);
   const seconds = rest < 10 ? `0${rest}` : rest;
 
-  return `${minutes}:${seconds}`;
+  return `${neg}${minutes}:${seconds}`;
 }
 
 /**

--- a/src/parser/mage/arcane/modules/features/Abilities.js
+++ b/src/parser/mage/arcane/modules/features/Abilities.js
@@ -87,9 +87,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.TIME_WARP,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
-        gcd: {
-          base: 1500,
-        },
+        gcd: null,
         cooldown: 300,
         castEfficiency: {
           disabled: true,

--- a/src/parser/mage/fire/modules/features/Abilities.js
+++ b/src/parser/mage/fire/modules/features/Abilities.js
@@ -110,6 +110,15 @@ class Abilities extends CoreAbilities {
 
       // Cooldowns
       {
+        spell: SPELLS.TIME_WARP,
+        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
+        gcd: null,
+        cooldown: 300,
+        castEfficiency: {
+          disabled: true,
+        },
+      },
+      {
         spell: SPELLS.COMBUSTION,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         gcd: null,

--- a/src/parser/mage/frost/modules/features/Abilities.js
+++ b/src/parser/mage/frost/modules/features/Abilities.js
@@ -21,7 +21,7 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(SPELLS.EBONBOLT_TALENT.id),
         castEfficiency: {
           //If using Glacial Spike, it is recommended to hold Ebonbolt as an emergency proc if GS is available and you dont have a Brain Freeze Proc. Therefore, with good luck, it is possible to go the entire fight without casting Ebonbolt.
-          disabled: combatant.hasTalent(SPELLS.GLACIAL_SPIKE_TALENT.id) ? true : false,
+          disabled: combatant.hasTalent(SPELLS.GLACIAL_SPIKE_TALENT.id),
           suggestion: true,
           recommendedEfficiency: 0.90,
         },
@@ -114,9 +114,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.TIME_WARP,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
-        gcd: {
-          base: 1500,
-        },
+        gcd: null,
         cooldown: 300,
         castEfficiency: {
           disabled: true,


### PR DESCRIPTION
formatDuration now will properly handle negative durations. This has no effect on how positive durations on displayed. Added to support potentially adding pre-pull features later on.

Also fixing time warp GCDs