### PR TITLE
[Mage] Pre-pull cooldown normalizer

### DIFF
--- a/src/common/format.js
+++ b/src/common/format.js
@@ -36,12 +36,14 @@ export function formatPercentage(percentage, precision = 2) {
  * Ex: 317.3 => 5:17
  */
 export function formatDuration(duration, precision = 0) {
+  const neg = duration < 0 ? '-' : '';
+  duration = Math.abs(duration);
   const minutes = Math.floor(duration / 60);
   const mult = Math.pow(10, precision);
   const rest = (Math.floor(duration % 60 * mult) / mult).toFixed(precision);
   const seconds = rest < 10 ? `0${rest}` : rest;
 
-  return `${minutes}:${seconds}`;
+  return `${neg}${minutes}:${seconds}`;
 }
 
 /**

--- a/src/parser/mage/arcane/CombatLogParser.js
+++ b/src/parser/mage/arcane/CombatLogParser.js
@@ -11,6 +11,7 @@ import Mana from './modules/ManaChart/Mana';
 import ManaValues from './modules/ManaChart/ManaValues';
 
 import ArcaneCharges from './normalizers/ArcaneCharges';
+import PrePullCooldowns from '../shared/normalizers/PrePullCooldowns';
 
 import ArcaneChargeTracker from './modules/features/ArcaneChargeTracker';
 import ArcanePower from './modules/features/ArcanePower';
@@ -32,7 +33,8 @@ class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     //Normalizers
     arcaneCharges: ArcaneCharges,
-    
+    prePullCooldowns: PrePullCooldowns,
+
     // Features
     checklist: Checklist,
     alwaysBeCasting: AlwaysBeCasting,

--- a/src/parser/mage/fire/CombatLogParser.js
+++ b/src/parser/mage/fire/CombatLogParser.js
@@ -4,6 +4,7 @@ import DamageDone from 'parser/core/modules/DamageDone';
 import FlamestrikeNormalizer from './normalizers/Flamestrike';
 import Scorch from './normalizers/Scorch';
 import PyroclasmBuff from './normalizers/PyroclasmBuff';
+import PrePullCooldowns from '../shared/normalizers/PrePullCooldowns';
 
 import Checklist from './modules/Checklist/Module';
 
@@ -31,6 +32,7 @@ class CombatLogParser extends CoreCombatLogParser {
     FlameStrikeNormalizer: FlamestrikeNormalizer,
     scorch: Scorch,
     pyroclasmBuff: PyroclasmBuff,
+    prePullCooldowns: PrePullCooldowns,
 
     //Checklist
     checklist: Checklist,

--- a/src/parser/mage/frost/CombatLogParser.js
+++ b/src/parser/mage/frost/CombatLogParser.js
@@ -3,6 +3,8 @@ import DamageDone from 'parser/core/modules/DamageDone';
 
 import Checklist from './modules/checklist/Module';
 
+import PrePullCooldowns from '../shared/normalizers/PrePullCooldowns';
+
 import Abilities from './modules/features/Abilities';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
@@ -22,9 +24,13 @@ import Whiteout from './modules/traits/Whiteout';
 import FrozenOrb from './modules/cooldowns/FrozenOrb';
 import ColdSnap from './modules/cooldowns/ColdSnap';
 
+
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     checklist: Checklist,
+
+    // Normalizers
+    prePullCooldowns: PrePullCooldowns,
 
     // Features
     abilities: Abilities,

--- a/src/parser/mage/shared/normalizers/PrePullCooldowns.js
+++ b/src/parser/mage/shared/normalizers/PrePullCooldowns.js
@@ -1,0 +1,141 @@
+import Abilities from 'parser/core/modules/Abilities';
+import SPELLS from 'common/SPELLS';
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+
+const debug = false;
+
+// If a prepull spell applies a buff and has a CD that we may care about tracking efficiency for, it should be here
+const PREPULL_BUFF_CDS = [
+  SPELLS.ICY_VEINS.id,
+  SPELLS.ARCANE_POWER.id,
+  SPELLS.COMBUSTION.id,
+
+  // Debatable whether these types of spells should be included. They can be cast long before pull.
+  //SPELLS.PRISMATIC_BARRIER.id,
+  //SPELLS.ICE_BARRIER.id,
+  //SPELLS.BLAZING_BARRIER.id,
+];
+
+// If a prepull spell does damage and has a CD that we may care about tracking efficiency for, it should be here
+const PREPULL_DMG_CDS = [
+  {cast: SPELLS.METEOR_TALENT.id, damage: SPELLS.METEOR_DAMAGE.id},
+  {cast: SPELLS.PHOENIX_FLAMES_TALENT.id, damage: SPELLS.PHOENIX_FLAMES_TALENT.id},
+  {cast: SPELLS.ARCANE_ORB_TALENT.id, damage: SPELLS.ARCANE_ORB_DAMAGE.id},
+  {cast: SPELLS.EBONBOLT_TALENT.id, damage: SPELLS.EBONBOLT_DAMAGE.id},
+  {cast: SPELLS.COMET_STORM_TALENT.id,damage: SPELLS.COMET_STORM_DAMAGE.id},
+  {cast: SPELLS.FROZEN_ORB.id, damage: SPELLS.FROZEN_ORB_DAMAGE.id},
+];
+
+// TODO maybe update the Timeline tab to show these prepull casts?
+/*
+ * This normalizer attempts to track all potentially relevant casts that happened
+ * before the pull. It then fabricates cast events in order to help other
+ * modules (like cast efficiency) be more accurate. You should avoid using this to
+ * track spells that require accurate cast event data in analyzers, as all of it is
+ * fabricated.
+ */
+class PrePullCooldowns extends EventsNormalizer {
+
+  static dependencies = {
+    abilities: Abilities,
+  };
+
+  normalize(events) {
+    const prepullCasts = [];
+
+    const firstEventIndex = this.getFightStartIndex(events);
+    const firstTimestamp = events[firstEventIndex].timestamp;
+    const playerId = this.owner.playerId;
+
+    for (let i = 0; i < events.length; i += 1) {
+      const event = events[i];
+      const targetId = event.targetID;
+      const sourceId = event.sourceID;
+
+      if (sourceId !== playerId) {
+        continue;
+      }
+
+      if (event.type === 'applybuff') {
+        // Some specs may have cooldowns that apply to other people, but for now this only checks self-applied buffs
+        if (targetId !== playerId) {
+          continue;
+        }
+
+        const spellId = event.ability.guid;
+        if (PREPULL_BUFF_CDS.includes(spellId) && event.prepull) {
+          debug && console.log(`Detected a precast CD: ${event.ability.name} fight start: ${this.owner.fight.start_time}`);
+          prepullCasts.push(this.constructor._fabricateCastEvent(event));
+        }
+        continue;
+      }
+
+      if (event.type === 'cast') {
+        const spellId = event.ability.guid;
+        PREPULL_DMG_CDS.forEach(cdInfo => {
+          if (cdInfo.cast === spellId) {
+            cdInfo.wasCast = true;
+          }
+        });
+      }
+
+      if (event.type === 'damage') {
+        const spellId = event.ability.guid;
+        PREPULL_DMG_CDS.forEach(cdInfo => {
+          if (cdInfo.damage === spellId) {
+            if (!cdInfo.wasCast) {
+              cdInfo.wasCast = true;
+              debug && console.log(`Detected a precast damage cooldown: ${event.ability.name}`);
+              prepullCasts.push(this.constructor._fabricateCastEvent(event, cdInfo.cast));
+            }
+          }
+        });
+      }
+    }
+
+    /*
+     * Potential issue: If players cast buffs long before the pull that have a
+     * long duration, this normalizer doesn't know that and assumes they
+     * cast it optimized right before the pull. This means that the next time
+     * it gets cast we may get an error saying it was still on cooldown. To
+     * resolve this, we could also listen for buffremove events and use that
+     * to deduce the cast time. This would require ability info about durations.
+     */
+    // Working backwards, assume worst-case GCD timestamps
+    let totalGCD = 0;
+    for (let i = prepullCasts.length - 1; i >= 0; i -= 1) {
+      const event = prepullCasts[i];
+      const ability = this.abilities.getAbility(event.ability.guid);
+      const gcd = (ability && ability.gcd && ability.gcd.base) || 1500;
+      totalGCD += gcd;
+      event.timestamp = firstTimestamp - totalGCD;
+    }
+    events.unshift(...prepullCasts);
+    return events;
+  }
+
+  static _fabricateCastEvent(event, abilityId = null) {
+    const ability = {
+      abilityIcon: event.ability.abilityIcon,
+      guid: abilityId || event.ability.guid,
+      name: event.ability.name,
+      type: event.ability.type,
+    };
+
+    return {
+      type: 'cast',
+      ability: ability,
+      sourceID: event.sourceID,
+      sourceIsFriendly: event.sourceIsFriendly,
+      targetID: event.targetID,
+      targetIsFriendly: event.targetIsFriendly,
+
+      // Custom properties:
+      prepull: true,
+      __fabricated: true,
+    };
+  }
+
+}
+
+export default PrePullCooldowns;


### PR DESCRIPTION
This normalizer attempts to solve a problem throughout the WoWAnalyzer castefficiency module. While the castefficiency module can (with the ApplyBuff normalizer checking for event.prepull) properly deduce cooldown percentages, it does not accurately count the actual casts.

For example, the analyzer can tell I have _had_ the Icy Veins buff 3 times, but it can't tell that I have _cast the spell_ 3 times:
![image](https://user-images.githubusercontent.com/43309639/46444794-788e2180-c728-11e8-9fe3-770d4eaa1f77.png)
![image](https://user-images.githubusercontent.com/43309639/46444799-7c21a880-c728-11e8-9ca3-dc788d880969.png)

With this PR, cast events are fabricated pre-pull (with pre-pull timestamps, to avoid the "you cast spell X while still on the GCD from Y!" error) which will be accounted for castefficiency percentages AND counts.
Example:
![image](https://user-images.githubusercontent.com/43309639/46445073-cb1c0d80-c729-11e8-867f-4e8810b36c87.png)

![image](https://user-images.githubusercontent.com/43309639/46445091-f1da4400-c729-11e8-8b1b-f7d3df115a0e.png)


The goal of this pull request is to test the concept for mages first, and then if it works and gets optimized it can be made global and all specs can remove their prepull buff checks because this will handle it automatically.