### PR TITLE
[Hunter] fix crows cast efficiency

### DIFF
--- a/src/parser/hunter/beastmastery/CombatLogParser.js
+++ b/src/parser/hunter/beastmastery/CombatLogParser.js
@@ -19,6 +19,7 @@ import DireBeast from './modules/talents/DireBeast';
 import KillerCobra from './modules/talents/KillerCobra';
 import Stampede from './modules/talents/Stampede';
 import Stomp from './modules/talents/Stomp';
+import AMurderOfCrows from '../shared/modules/talents/AMurderOfCrows';
 
 //Spells
 import BestialWrathAverageFocus from "./modules/spells/bestialwrath/BestialWrathAverageFocus";
@@ -77,6 +78,7 @@ class CombatLogParser extends CoreCombatLogParser {
     killerCobra: KillerCobra,
     stampede: Stampede,
     stomp: Stomp,
+    aMurderOfCrows: AMurderOfCrows,
 
     //Traits and talents
     traitsAndTalents: TraitsAndTalents,

--- a/src/parser/hunter/shared/modules/talents/AMurderOfCrows.js
+++ b/src/parser/hunter/shared/modules/talents/AMurderOfCrows.js
@@ -7,6 +7,7 @@ import SpellUsable from 'parser/core/modules/SpellUsable';
 import SpellLink from 'common/SpellLink';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
+import { encodeTargetString } from 'parser/core/modules/EnemyInstances';
 
 /**
  * Summons a flock of crows to attack your target over the next 15 sec. If the target dies while under attack, A Murder of Crows' cooldown
@@ -14,6 +15,11 @@ import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
  *
  * Example log: https://www.warcraftlogs.com/reports/8jJqDcrGK1xM3Wn6#fight=2&type=damage-done
  */
+
+const CROWS_TICK_RATE = 1000;
+const MS_BUFFER = 100;
+const CROWS_DURATION = 15000;
+
 class AMurderOfCrows extends Analyzer {
 
   static dependencies = {
@@ -22,6 +28,9 @@ class AMurderOfCrows extends Analyzer {
 
   bonusDamage = 0;
   casts = 0;
+  enemyID = null;
+  applicationTimestamp = null;
+  lastDamageTick = null;
 
   constructor(...args) {
     super(...args);
@@ -34,17 +43,30 @@ class AMurderOfCrows extends Analyzer {
       return;
     }
     this.casts++;
+    this.enemyID = encodeTargetString(event.targetID, event.targetInstance);
+    this.applicationTimestamp = event.timestamp;
+    this.lastDamageTick = null;
   }
 
   on_byPlayer_damage(event) {
     const spellId = event.ability.guid;
+    if (this.lastDamageTick && event.timestamp + MS_BUFFER < this.applicationTimestamp + CROWS_DURATION && event.timestamp > this.lastDamageTick + CROWS_TICK_RATE + MS_BUFFER && this.spellUsable.isOnCooldown(SPELLS.A_MURDER_OF_CROWS_TALENT.id)) {
+      this.spellUsable.endCooldown(SPELLS.A_MURDER_OF_CROWS_TALENT.id, event.timestamp);
+      this.lastDamageTick = null;
+      this.enemyID = null;
+    }
     if (spellId !== SPELLS.A_MURDER_OF_CROWS_DEBUFF.id) {
       return;
+    }
+    if (!this.enemyID) {
+      this.enemyID = encodeTargetString(event.targetID, event.targetInstance);
     }
     if (this.casts === 0) {
       this.casts++;
       this.spellUsable.beginCooldown(SPELLS.A_MURDER_OF_CROWS_TALENT.id, this.owner.fight.start_time);
+      this.applicationTimestamp = this.owner.fight.start_time;
     }
+    this.lastDamageTick = event.timestamp;
     this.bonusDamage += event.amount + (event.absorbed || 0);
   }
 


### PR DESCRIPTION
Fixes the issue on this log: https://www.wowanalyzer.com/report/YvHhpD3LnZWRBAQg/16-Heroic+Fetid+Devourer+-+Kill+(2:09)/7-Claypenguin

Where crows was wildly off the mark in terms of cast efficiency. 

