### PR TITLE
[BrM] Updated Hit Mitigation Blacklist for Uldir

### DIFF
--- a/src/parser/monk/brewmaster/modules/constants/AbilityBlacklist.js
+++ b/src/parser/monk/brewmaster/modules/constants/AbilityBlacklist.js
@@ -5,6 +5,8 @@
  */
 
 const SHARED = [
+  // ULDIR
+  266948, // Vectis, Plague Bomb (intermission soak)
   // ANTORUS
   // Garothi Worldbreaker
   247159, // Luring Destruction, intermission pulse
@@ -28,6 +30,11 @@ const SHARED = [
 ];
 
 export const BOF = SHARED.concat([
+  // ULDIR
+  265178, // Vectis, Evolving Affliction
+  265143, // Vectis, Omega Vector (tank *shouldnt* get, but w/e)
+  274358, // Zul, Rupturing Blood (dot interaction with bof is unknown; assuming that it won't change individual ticks for now)
+  263334, // G'huun, Putrid Blood
   // ANTORUS
   // Kin'Garoth
   246779, // Empowered bombs (Kin'garoth)

--- a/src/parser/monk/brewmaster/modules/spells/BreathOfFire.js
+++ b/src/parser/monk/brewmaster/modules/spells/BreathOfFire.js
@@ -52,7 +52,7 @@ class BreathOfFire extends Analyzer {
     if (this.enemies.enemies[event.sourceID].hasBuff(SPELLS.BREATH_OF_FIRE_DEBUFF.id)) {
       this.hitsWithBoF += 1;
     } else {
-      if (DEBUG_ABILITIES) {
+      if (DEBUG_ABILITIES && event.ability.guid !== SPELLS.MELEE.id) {
         console.log('hit w/o bof', event);
       }
       this.hitsWithoutBoF += 1;


### PR DESCRIPTION
The hit mitigation blacklist is used to ignore abilities for the purpose of counting % of hits mitigated, as some kinds of effects (dots, background aoes) generate many hits but aren't of concern for mitigation. This adds spells for bosses in uldir.