### PR TITLE
[Feral] Track Shadowmeld use

### DIFF
--- a/src/parser/druid/feral/CHANGELOG.js
+++ b/src/parser/druid/feral/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-10-05'),
+    changes: <React.Fragment>Added tracking for using <SpellLink id={SPELLS.SHADOWMELD.id} /> to buff <SpellLink id={SPELLS.RAKE.id} /> damage.</React.Fragment>,
+    contributors: [Anatta336],
+  },
+  {
     date: new Date('2018-08-11'),
     changes: <React.Fragment>Added tracking for wasted energy from <SpellLink id={SPELLS.TIGERS_FURY.id} /> and a breakdown of how energy is spent.</React.Fragment>,
     contributors: [Anatta336],

--- a/src/parser/druid/feral/CombatLogParser.js
+++ b/src/parser/druid/feral/CombatLogParser.js
@@ -36,6 +36,7 @@ import PredatorySwiftness from './modules/spells/PredatorySwiftness';
 import ThrashHitCount from './modules/spells/ThrashHitCount';
 import SwipeHitCount from './modules/spells/SwipeHitCount';
 import TigersFuryEnergy from './modules/spells/TigersFuryEnergy';
+import Shadowmeld from './modules/racials/Shadowmeld';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -70,6 +71,7 @@ class CombatLogParser extends CoreCombatLogParser {
     thrashHitCount: ThrashHitCount,
     swipeHitCount: SwipeHitCount,
     tigersFuryEnergy: TigersFuryEnergy,
+    shadowmeld: Shadowmeld,
 
     // talents
     savageRoarUptime: SavageRoarUptime,

--- a/src/parser/druid/feral/modules/features/checklist/Component.js
+++ b/src/parser/druid/feral/modules/features/checklist/Component.js
@@ -224,13 +224,9 @@ class FeralDruidChecklist extends React.PureComponent {
           <CastEfficiencyRequirement spell={SPELLS.TIGERS_FURY.id} />
           {combatant.race === RACES.NightElf && (
             <Requirement
-              name={(
-                <React.Fragment>
-                  <SpellLink id={SPELLS.SHADOWMELD.id} />
-                </React.Fragment>
-              )}
+              name={<SpellLink id={SPELLS.SHADOWMELD.id} />}
               thresholds={thresholds.shadowmeld}
-              tooltip={'This measures how many of the possible uses of Shadowmeld were used to provide the double damage bonus to Rake.'}
+              tooltip="This measures how many of the possible uses of Shadowmeld were used to provide the double damage bonus to Rake."
             />
           )}
         </Rule>

--- a/src/parser/druid/feral/modules/features/checklist/Component.js
+++ b/src/parser/druid/feral/modules/features/checklist/Component.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
+import RACES from 'game/RACES';
 import Checklist from 'parser/core/modules/features/Checklist2';
 import Rule from 'parser/core/modules/features/Checklist2/Rule';
 import Requirement from 'parser/core/modules/features/Checklist2/Requirement';
@@ -204,7 +205,7 @@ class FeralDruidChecklist extends React.PureComponent {
           🗵 Cast efficiency of Berserk or Incarnation (depending on talent)
           ☐ Make the most of Berserk/Incarnation by using as many abilities as possible during the buff (importance of this may be so low that it's not worth checking - run some simulations to find out)
           🗵 Cast efficiency of Tiger's Fury
-          ☐ Shadowmeld for Night Elves, both cast efficiency and correctly using it to buff Rake}
+          🗵 Shadowmeld for Night Elves: cast efficiency of correctly using it to buff Rake
         */}
         <Rule
           name="Use your cooldowns"
@@ -221,6 +222,17 @@ class FeralDruidChecklist extends React.PureComponent {
             <CastEfficiencyRequirement spell={SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id} />
           )}
           <CastEfficiencyRequirement spell={SPELLS.TIGERS_FURY.id} />
+          {combatant.race === RACES.NightElf && (
+            <Requirement
+              name={(
+                <React.Fragment>
+                  <SpellLink id={SPELLS.SHADOWMELD.id} />
+                </React.Fragment>
+              )}
+              thresholds={thresholds.shadowmeld}
+              tooltip={'This measures how many of the possible uses of Shadowmeld were used to provide the double damage bonus to Rake.'}
+            />
+          )}
         </Rule>
 
         {/*Manage Snapshots

--- a/src/parser/druid/feral/modules/features/checklist/Module.js
+++ b/src/parser/druid/feral/modules/features/checklist/Module.js
@@ -22,6 +22,7 @@ import Bloodtalons from '../../talents/Bloodtalons';
 import Predator from '../../talents/Predator';
 import BrutalSlashHitCount from '../../talents/BrutalSlashHitCount';
 import TigersFuryEnergy from '../../spells/TigersFuryEnergy';
+import Shadowmeld from '../../racials/Shadowmeld';
 
 class Checklist extends Analyzer {
   static dependencies = {
@@ -45,6 +46,7 @@ class Checklist extends Analyzer {
     predator: Predator,
     brutalSlashHitcount: BrutalSlashHitCount,
     tigersFuryEnergy: TigersFuryEnergy,
+    shadowmeld: Shadowmeld,
   };
 
   render() {
@@ -73,6 +75,9 @@ class Checklist extends Analyzer {
           energyCapped: this.energyCapTracker.suggestionThresholds,
           tigersFuryIgnoreEnergy: this.tigersFuryEnergy.shouldIgnoreEnergyWaste,
           tigersFuryEnergy: this.tigersFuryEnergy.suggestionThresholds,
+
+          // cooldowns
+          shadowmeld: this.shadowmeld.efficiencyThresholds,
 
           // snapshot
           rakeDowngrade: this.rakeSnapshot.downgradeSuggestionThresholds,

--- a/src/parser/druid/feral/modules/racials/Shadowmeld.js
+++ b/src/parser/druid/feral/modules/racials/Shadowmeld.js
@@ -1,0 +1,125 @@
+import React from 'react';
+import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import { formatPercentage } from 'common/format';
+import RACES from 'game/RACES';
+import Analyzer from 'parser/core/Analyzer';
+import Abilities from 'parser/core/modules/Abilities';
+
+const BUFF_WINDOW_TIME = 60;
+
+/**
+ * The Night Elf racial ability Shadowmeld can be used by as a DPS cooldown for Feral druids.
+ * The stealth provided by Shadowmeld doubles the damage of a Rake cast while it's active.
+ * This analyzer checks how often Shadowmeld is being to buff Rake's damage.
+ */
+class Shadowmeld extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+  }
+
+  wastedDuringStealth = 0;
+  correctUses = 0;
+  totalUses = 0;
+
+  constructor(...args) {
+    super(...args);
+    if (this.selectedCombatant.race !== RACES.NightElf) {
+      // only run if we know the active combatant has Shadowmeld
+      this.active = false;
+    }
+  }
+
+  on_byPlayer_cast(event) {
+    if (event.ability.guid === SPELLS.RAKE.id &&
+      this.selectedCombatant.hasBuff(SPELLS.SHADOWMELD.id, null, BUFF_WINDOW_TIME)) {
+      // using Rake when Shadowmeld is active means Shadowmeld was used correctly
+      this.correctUses += 1;
+      return;
+    }
+
+    if (event.ability.guid !== SPELLS.SHADOWMELD.id) {
+      return;
+    }
+    this.totalUses += 1;
+
+    if (this.selectedCombatant.hasBuff(SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id) ||
+        this.selectedCombatant.hasBuff(SPELLS.PROWL.id, null, BUFF_WINDOW_TIME) ||
+        this.selectedCombatant.hasBuff(SPELLS.PROWL_INCARNATION.id, null, BUFF_WINDOW_TIME)) {
+      // using Shadowmeld when the player already has a stealth (or stealth-like) effect active is almost always a mistake
+      this.wastedDuringStealth += 1;
+    }
+  }
+
+  get possibleUses() {
+    const cooldown = this.abilities.getAbility(SPELLS.SHADOWMELD.id).cooldown * 1000;
+    return Math.floor(this.owner.fightDuration / cooldown) + 1;
+  }
+
+  get efficiencyThresholds() {
+    return {
+      actual: this.correctUses / this.possibleUses,
+      isLessThan: {
+        minor: 0.90,
+        average: 0.80,
+        major: 0.70,
+      },
+      style: 'percentage',
+    };
+  }
+
+  get wastedDuringStealthThresholds() {
+    return {
+      actual: this.wastedDuringStealth / this.totalUses,
+      isGreaterThan: {
+        minor: 0.0,
+        average: 0.10,
+        major: 0.20,
+      },
+      style: 'percentage',
+    };
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.SHADOWMELD.id} />}
+        value={`${formatPercentage(this.correctUses / this.possibleUses)}%`}
+        label="Shadowmeld used to buff Rake"
+        tooltip={`You used Shadowmeld <b>${this.correctUses}</b> times to increase Rake's damage.<br />
+          <li>You could have used it <b>${this.possibleUses}</b> times.
+          <li>You used it <b>${this.totalUses}</b> times (<b>${this.totalUses - this.correctUses}</b> didn't buff Rake.)
+          <li>You used Shadowmeld while already benefiting from a stealth effect <b>${this.wastedDuringStealth}</b> times.`}
+        position={STATISTIC_ORDER.OPTIONAL()}
+      />
+    );
+  }
+
+  suggestions(when) {
+    when(this.efficiencyThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <React.Fragment>
+          You could be using <SpellLink id={SPELLS.SHADOWMELD.id} /> to increase your <SpellLink id={SPELLS.RAKE.id} /> damage more often. Activating <SpellLink id={SPELLS.SHADOWMELD.id} /> and immediately using <SpellLink id={SPELLS.RAKE.id} /> will cause it to deal double damage.
+        </React.Fragment>
+      )
+        .icon(SPELLS.SHADOWMELD.icon)
+        .actual(`${(actual * 100).toFixed(0)}% cast efficiency.`)
+        .recommended(`>${(recommended * 100).toFixed(0)}% is recommended`);
+    });
+
+    when(this.wastedDuringStealthThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <React.Fragment>
+          You are wasting <SpellLink id={SPELLS.SHADOWMELD.id} /> by using it when you already have a stealth effect active.
+        </React.Fragment>
+      )
+        .icon(SPELLS.SHADOWMELD.icon)
+        .actual(`${(actual * 100).toFixed(0)}% of casts were used when already stealthed.`)
+        .recommended('None is recommended');
+    });
+  }
+}
+
+export default Shadowmeld;

--- a/src/parser/druid/feral/modules/racials/Shadowmeld.js
+++ b/src/parser/druid/feral/modules/racials/Shadowmeld.js
@@ -18,7 +18,7 @@ const BUFF_WINDOW_TIME = 60;
 class Shadowmeld extends Analyzer {
   static dependencies = {
     abilities: Abilities,
-  }
+  };
 
   wastedDuringStealth = 0;
   correctUses = 0;
@@ -26,10 +26,7 @@ class Shadowmeld extends Analyzer {
 
   constructor(...args) {
     super(...args);
-    if (this.selectedCombatant.race !== RACES.NightElf) {
-      // only run if we know the active combatant has Shadowmeld
-      this.active = false;
-    }
+    this.active = this.selectedCombatant.race === RACES.NightElf;
   }
 
   on_byPlayer_cast(event) {
@@ -116,8 +113,8 @@ class Shadowmeld extends Analyzer {
         </React.Fragment>
       )
         .icon(SPELLS.SHADOWMELD.icon)
-        .actual(`${(actual * 100).toFixed(0)}% of casts were used when already stealthed.`)
-        .recommended('None is recommended');
+        .actual(`${this.wastedDuringStealth} cast${this.wastedDuringStealth === 1 ? '' : 's'} when already stealthed.`)
+        .recommended('0 is recommended');
     });
   }
 }


### PR DESCRIPTION
The Night Elf racial ability Shadowmeld provides a stealth effect which for a Feral druid is best used to buff the damage of Rake.

This adds tracking of Shadowmeld use for Night Elf Feral players. It provides a statistic showing how Shadowmeld was used, suggestions for failure to use it to buff Rake or wasting it by using when the player already had an effect that provides the damage buff, and adds it to the checklist.

All of these features are disabled and hidden if the player is not a Night Elf.

![shadowmeld01](https://user-images.githubusercontent.com/35700764/46536543-bc0e9a00-c8a6-11e8-9795-21ed07ba3368.png)
![shadowmeld02](https://user-images.githubusercontent.com/35700764/46536544-bc0e9a00-c8a6-11e8-83b3-1c2a2a809ba3.png)
![shadowmeld03](https://user-images.githubusercontent.com/35700764/46536545-bc0e9a00-c8a6-11e8-82df-36010b84b76d.png)
![shadowmeld04](https://user-images.githubusercontent.com/35700764/46536546-bca73080-c8a6-11e8-986a-5400e94e2856.png)
