### PR TITLE
[Feral] Remove Legion items and update from statisticOrder

### DIFF
--- a/src/parser/druid/feral/CONFIG.js
+++ b/src/parser/druid/feral/CONFIG.js
@@ -31,7 +31,7 @@ export default {
     </React.Fragment>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/Fypvm9C4tQ1VBzNq/34-Heroic+Vectis+-+Kill+(5:47)/32-Haramb%C3%A0e',
+  exampleReport: '/report/8fXGQwgy63F27HkJ/14-Heroic+Fetid+Devourer+-+Kill+(2:04)/15-%E4%BD%95%E4%BB%A5%E9%A3%98%E9%A3%98%E7%84%B6',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/parser/druid/feral/modules/bleeds/RakeSnapshot.js
+++ b/src/parser/druid/feral/modules/bleeds/RakeSnapshot.js
@@ -133,8 +133,7 @@ class RakeSnapshot extends Snapshot {
   }
 
   statistic() {
-    return super.generateStatistic(SPELLS.RAKE.name);
+    return super.generateStatistic(SPELLS.RAKE.name, STATISTIC_ORDER.CORE(10));
   }
-  statisticOrder = STATISTIC_ORDER.CORE(10);
 }
 export default RakeSnapshot;

--- a/src/parser/druid/feral/modules/bleeds/RakeUptime.js
+++ b/src/parser/druid/feral/modules/bleeds/RakeUptime.js
@@ -47,11 +47,10 @@ class RakeUptime extends Analyzer {
         icon={<SpellIcon id={SPELLS.RAKE.id} />}
         value={`${formatPercentage(this.uptime)}%`}
         label="Rake uptime"
+        position={STATISTIC_ORDER.CORE(3)}
       />
     );
   }
-
-  statisticOrder = STATISTIC_ORDER.CORE(3);
 }
 
 export default RakeUptime;

--- a/src/parser/druid/feral/modules/bleeds/RipSnapshot.js
+++ b/src/parser/druid/feral/modules/bleeds/RipSnapshot.js
@@ -233,8 +233,7 @@ class RipSnapshot extends Snapshot {
   }
 
   statistic() {
-    return super.generateStatistic(SPELLS.RIP.name);
+    return super.generateStatistic(SPELLS.RIP.name, STATISTIC_ORDER.CORE(11));
   }
-  statisticOrder = STATISTIC_ORDER.CORE(11);
 }
 export default RipSnapshot;

--- a/src/parser/druid/feral/modules/bleeds/RipUptime.js
+++ b/src/parser/druid/feral/modules/bleeds/RipUptime.js
@@ -47,11 +47,10 @@ class RipUptime extends Analyzer {
         icon={<SpellIcon id={SPELLS.RIP.id} />}
         value={`${formatPercentage(this.uptime)}%`}
         label="Rip uptime"
+        position={STATISTIC_ORDER.CORE(4)}
       />
     );
   }
-
-  statisticOrder = STATISTIC_ORDER.CORE(4);
 }
 
 export default RipUptime;

--- a/src/parser/druid/feral/modules/combopoints/ComboPointDetails.js
+++ b/src/parser/druid/feral/modules/combopoints/ComboPointDetails.js
@@ -87,10 +87,10 @@ class ComboPointDetails extends Analyzer {
         value={`${this.pointsWastedPerMinute.toFixed(2)}`}
         label="Wasted Combo Points per minute"
         tooltip={`You wasted a total of <b>${this.pointsWasted}</b> combo points. This number does NOT include Primal Fury procs that happened on a point builder used at 4 CPs, because this waste can't be controlled.`}
+        position={STATISTIC_ORDER.CORE(6)}
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.CORE(6);
 
   tab() {
     return {

--- a/src/parser/druid/feral/modules/combopoints/ComboPointTracker.js
+++ b/src/parser/druid/feral/modules/combopoints/ComboPointTracker.js
@@ -22,18 +22,6 @@ class ComboPointTracker extends ResourceTracker {
     this.maxResource = 5;
   }
 
-  on_byPlayer_cast(event) {
-    const spellId = event.ability.guid;
-
-    // T21 4pc set bonus can proc "free Ferocious Bite that counts as if it spent the full 5 CPs"
-    // the energy cost is properly missing from the cast, but the CP cost shows very strangely. (amount: x, max: 5, cost: 5) where x is the amount of CPs you had on cast.
-    // Returning before this CP cost can be processed to avoid messing up the results
-    if ((spellId === SPELLS.FEROCIOUS_BITE.id) && event.classResources && !event.classResources.find(resource => resource.type === RESOURCE_TYPES.ENERGY.id)) {
-      return;
-    }
-    super.on_byPlayer_cast(event);
-  }
-
   _applyBuilder(spellId, resource, gain, waste) {
     const isMaxBefore = (this.current === this.maxResource);
     super._applyBuilder(spellId, resource, gain, waste);

--- a/src/parser/druid/feral/modules/core/HitCountAoE.js
+++ b/src/parser/druid/feral/modules/core/HitCountAoE.js
@@ -80,7 +80,7 @@ class HitCountAoE extends Analyzer {
     return (this.castsWithOneHit / this.owner.fightDuration) * (1000 * 60);
   }
 
-  statistic() {
+  generateStatistic(statisticPosition) {
     if (this.casts === 0) {
       // Only show statistic if the ability is used.
       return null;
@@ -93,6 +93,7 @@ class HitCountAoE extends Analyzer {
         tooltip={`You used ${this.constructor.spell.name} <b>${this.casts}</b> time${(this.casts === 1) ? '' : 's'}.<br />
           <li><b>${this.castsWithOneHit}</b> hit just 1 target.
           <li><b>${this.castsWithZeroHits}</b> hit nothing at all.`}
+        position={statisticPosition}
       />
     );
   }

--- a/src/parser/druid/feral/modules/core/Snapshot.js
+++ b/src/parser/druid/feral/modules/core/Snapshot.js
@@ -233,7 +233,7 @@ class Snapshot extends Analyzer {
     return info;
   }
 
-  generateStatistic(spellName) {
+  generateStatistic(spellName, statisticPosition) {
     const subStats = [];
     const buffNames = [];
     if (this.constructor.isProwlAffected) {
@@ -266,6 +266,7 @@ class Snapshot extends Analyzer {
           </React.Fragment>
         )}
         tooltip={`${spellName} maintains the damage bonus from ${buffsComment} if ${isPlural ? 'they were' : 'it was'} present when the DoT was applied. This lists how many of your ${spellName} ticks benefited from ${isPlural ? 'each' : 'the'} buff. ${isPlural ? 'As a tick can benefit from multiple buffs at once these percentages can add up to more than 100%.' : ''}`}
+        position={statisticPosition}
       >
         {subStats}
       </StatisticsListBox>

--- a/src/parser/druid/feral/modules/features/AlwaysBeCasting.js
+++ b/src/parser/druid/feral/modules/features/AlwaysBeCasting.js
@@ -6,7 +6,7 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
     // override the suggestions from CoreAlwaysBeCasting so there's never any generated, but we still get the statistic.
     return null;
   }
-  statisticOrder = STATISTIC_ORDER.CORE(1);
+  position = STATISTIC_ORDER.CORE(1);
 }
 
 export default AlwaysBeCasting;

--- a/src/parser/druid/feral/modules/features/EnergyCapTracker.js
+++ b/src/parser/druid/feral/modules/features/EnergyCapTracker.js
@@ -1,26 +1,16 @@
 import React from 'react';
 import Icon from 'common/Icon';
-import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { formatDuration, formatPercentage } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 import RegenResourceCapTracker from 'parser/core/modules/RegenResourceCapTracker';
 
-/**
- * The analyzer is set up for BfA-prepatch where legendaries and other special 110 items are still
- * active. You can disable the efects when checking accuracy on logs with players above 115.
- */
-const debugIsPlayerAbove115 = false;
 
 const BASE_ENERGY_REGEN = 11;
-const CHATOYANT_SIGNET_REGEN_MULTIPLIER = 1.05;
-
 const BASE_ENERGY_MAX = 100;
-const CHATOYANT_SIGNET_MAX_ADDITION = 100;
 const MOMENT_OF_CLARITY_MAX_ADDITION = 30;
 const BERSERK_MAX_ADDITION = 50;
-const STABILIZED_ENERGY_PENDANT_MAX_MULTIPLIER = 1.05;
 
 const RESOURCE_REFUND_ON_MISS = 0.8;
 
@@ -32,7 +22,6 @@ const RESOURCE_REFUND_ON_MISS = 0.8;
  *
  * No need to override getReducedDrain:
  * Reduced drain cost from Berserk/Incarnation on Ferocious Bite is already applied in the log.
- * Free bites from T21_4pc don't generate a drain event in the log.
  */
 class EnergyCapTracker extends RegenResourceCapTracker {
   static resourceType = RESOURCE_TYPES.ENERGY;
@@ -50,32 +39,14 @@ class EnergyCapTracker extends RegenResourceCapTracker {
     SPELLS.BRUTAL_SLASH_TALENT.id,
   ];
 
-  naturalRegenRate() {
-    let regen = super.naturalRegenRate();
-    if (!debugIsPlayerAbove115 && this.selectedCombatant.getItem(ITEMS.CHATOYANT_SIGNET.id)) {
-      // BFA: Chatoyant's effect will stop working after level 115.
-      regen *= CHATOYANT_SIGNET_REGEN_MULTIPLIER;
-    }
-    return regen;
-  }
-
   currentMaxResource() {
     let max = BASE_ENERGY_MAX;
-    if (!debugIsPlayerAbove115 && this.selectedCombatant.getItem(ITEMS.CHATOYANT_SIGNET.id)) {
-      // BFA: Chatoyant's effect will stop working after level 115.
-      max += CHATOYANT_SIGNET_MAX_ADDITION;
-    }
     if (this.selectedCombatant.hasTalent(SPELLS.MOMENT_OF_CLARITY_TALENT.id)) {
       max += MOMENT_OF_CLARITY_MAX_ADDITION;
     }
     if (this.combatantHasBuffActive(SPELLS.BERSERK.id) || this.combatantHasBuffActive(SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id)) {
       // combatantHasBuffActive is used so that if the buff faded at this timestamp it will not count.
       max += BERSERK_MAX_ADDITION;
-    }
-    if (!debugIsPlayerAbove115 && this.selectedCombatant.getItem(ITEMS.STABILIZED_ENERGY_PENDANT.id)) {
-      // BFA: Pendant's effect will stop working after level 115.
-      // multiplier is applied after the additions
-      max *= STABILIZED_ENERGY_PENDANT_MAX_MULTIPLIER;
     }
     // What should be x.5 becomes x in-game.
     return Math.floor(max);

--- a/src/parser/druid/feral/modules/features/EnergyCapTracker.js
+++ b/src/parser/druid/feral/modules/features/EnergyCapTracker.js
@@ -104,9 +104,9 @@ class EnergyCapTracker extends RegenResourceCapTracker {
           </div>
         )}
         footerStyle={{ overflow: 'hidden' }}
+        position={STATISTIC_ORDER.CORE(1)}
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.CORE(1);
 }
 export default EnergyCapTracker;

--- a/src/parser/druid/feral/modules/features/SpellEnergyCost.js
+++ b/src/parser/druid/feral/modules/features/SpellEnergyCost.js
@@ -14,7 +14,6 @@ class SpellEnergyCost extends SpellResourceCost {
     const cost = super.getResourceCost(event);
     
     // no need to check for Clearcasting as the zero cost is already applied in the log
-    // no need to check for T21_4pc as the free bite already shows as free in the log
     
     if (this.selectedCombatant.hasBuff(SPELLS.BERSERK.id) ||
         this.selectedCombatant.hasBuff(SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id)) {

--- a/src/parser/druid/feral/modules/spells/FerociousBiteEnergy.js
+++ b/src/parser/druid/feral/modules/spells/FerociousBiteEnergy.js
@@ -18,8 +18,6 @@ const debug = false;
 /**
  * Although Ferocious Bite costs 25 energy, it does up to double damage if the character has more.
  * It's recommended that feral druids use Bite when at 50 energy or higher.
- * An exception to this is when the bonus from 4-piece T21 is active, which makes Bite cost no
- * energy and ignore the current energy level.
  */
 class FerociousBiteEnergy extends Analyzer {
   biteCount = 0;
@@ -51,7 +49,7 @@ class FerociousBiteEnergy extends Analyzer {
     }
     
     if (this.lastBiteCast.energy === 0) {
-      this.freeBiteCount++;
+      this.freeBiteCount += 1;
     }
     else if (this.lastBiteCast.energy < ENERGY_FOR_FULL_DAMAGE_BITE) {
       this.lowEnergyBiteCount++;
@@ -63,7 +61,7 @@ class FerociousBiteEnergy extends Analyzer {
     else {
       this.energySpentOnBiteTotal += this.lastBiteCast.energy;
     }
-    this.biteCount++;
+    this.biteCount += 1;
     this.lastBiteCast.isPaired = true;
   }
 

--- a/src/parser/druid/feral/modules/spells/FerociousBiteEnergy.js
+++ b/src/parser/druid/feral/modules/spells/FerociousBiteEnergy.js
@@ -52,7 +52,7 @@ class FerociousBiteEnergy extends Analyzer {
       this.freeBiteCount += 1;
     }
     else if (this.lastBiteCast.energy < ENERGY_FOR_FULL_DAMAGE_BITE) {
-      this.lowEnergyBiteCount++;
+      this.lowEnergyBiteCount += 1;
       this.energySpentOnBiteTotal += this.lastBiteCast.energy;
       const actualDamage = event.amount + event.absorbed;
       const lostDamage = this.calcPotentialBiteDamage(actualDamage, this.lastBiteCast.energy) - actualDamage;

--- a/src/parser/druid/feral/modules/spells/PredatorySwiftness.js
+++ b/src/parser/druid/feral/modules/spells/PredatorySwiftness.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 import SPELLS from 'common/SPELLS';
-import ITEMS from 'common/ITEMS';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
@@ -22,11 +21,6 @@ const POTENTIAL_SPENDERS = [
  * which makes the next Regrowth or Entangling Roots instant cast and usable in cat form. Normally
  * this provides occasional extra utility. But with the Bloodtalons talent it becomes an important
  * part of the damage rotation.
- * 
- * The Feral legendary Ailuro Pouncers breaks this Analyzer. The Pouncers allow Predatory Swiftness
- * to have up to 3 stacks, but the combat log still only shows an event for gaining or losing the buff
- * overall, not the change in stacks. We cannot reliably predict when the stacks will change because
- * there can be randomness as to whether a stack is generated.
  */
 class PredatorySwiftness extends Analyzer {
   hasSwiftness = false;
@@ -38,18 +32,10 @@ class PredatorySwiftness extends Analyzer {
   overwritten = 0;
 
   /**
-   * The combat log reports the player gaining Predatory Swiftness twice when they use a free
-   * Ferocious Bite from the T21 4pc set bonus. Avoid this by tracking time of last gain event.
+   * The combat log sometimes reports the player gaining Predatory Swiftness twice from a single finisher.
+   * Avoid this by tracking time of last gain event.
    */
   timeLastGain = null;
-
-  constructor(...args) {
-    super(...args);
-    if (this.selectedCombatant.hasFeet(ITEMS.AILURO_POUNCERS.id)) {
-      // disable entirely as the legendary breaks our ability to track Predatory Swiftness
-      this.isActive = false;
-    }
-  }
 
   on_finished() {
     if (this.hasSwiftness) {

--- a/src/parser/druid/feral/modules/spells/PredatorySwiftness.js
+++ b/src/parser/druid/feral/modules/spells/PredatorySwiftness.js
@@ -147,11 +147,10 @@ class PredatorySwiftness extends Analyzer {
           <li>The buff was allowed to expire <b>${this.expired}</b> time${this.expired !== 1 ? 's' : ''}.
           <li>You used another finisher while the buff was still active and overwrote it <b>${this.overwritten}</b> time${this.overwritten !== 1 ? 's' : ''}.
           <li>You had <b>${this.remainAfterFight}</b> remaining unused at the end of the fight.`}
+        position={STATISTIC_ORDER.OPTIONAL(5)}
       />
     );
   }
-
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(5);
 }
 
 export default PredatorySwiftness;

--- a/src/parser/druid/feral/modules/spells/SwipeHitCount.js
+++ b/src/parser/druid/feral/modules/spells/SwipeHitCount.js
@@ -12,6 +12,10 @@ import HitCountAoE from '../core/HitCountAoE';
 class SwipeHitCount extends HitCountAoE {
   static spell = SPELLS.SWIPE_CAT;
 
+  statistic() {
+    return this.generateStatistic(STATISTIC_ORDER.OPTIONAL(10));
+  }
+
   get hitNoneThresholds() {
     return {
       actual: this.hitZeroPerMinute,
@@ -59,8 +63,6 @@ class SwipeHitCount extends HitCountAoE {
         .recommended(`${recommended} is recommended`);
     });
   }
-
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(10);
 }
 
 export default SwipeHitCount;

--- a/src/parser/druid/feral/modules/spells/ThrashHitCount.js
+++ b/src/parser/druid/feral/modules/spells/ThrashHitCount.js
@@ -13,6 +13,10 @@ import HitCountAoE from '../core/HitCountAoE';
 class ThrashHitCount extends HitCountAoE {
   static spell = SPELLS.THRASH_FERAL;
   
+  statistic() {
+    return this.generateStatistic(STATISTIC_ORDER.OPTIONAL(11));
+  }
+
   get hitNoneThresholds() {
     return {
       actual: this.hitZeroPerMinute,
@@ -49,8 +53,6 @@ class ThrashHitCount extends HitCountAoE {
         .recommended(`${recommended} is recommended`);
     });
   }
-
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(11);
 }
 
 export default ThrashHitCount;

--- a/src/parser/druid/feral/modules/talents/Bloodtalons.js
+++ b/src/parser/druid/feral/modules/talents/Bloodtalons.js
@@ -329,13 +329,13 @@ class Bloodtalons extends Analyzer {
         <React.Fragment>
           <SpellLink id={SPELLS.BLOODTALONS_TALENT.id} /> usage
         </React.Fragment>
-      )}>
+      )}
+        position={STATISTIC_ORDER.OPTIONAL(4)}
+      >
         {this.combinedChart()}
       </StatisticsListBox>
     );
   }
-
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(4);
 }
 
 export default Bloodtalons;

--- a/src/parser/druid/feral/modules/talents/BrutalSlashHitCount.js
+++ b/src/parser/druid/feral/modules/talents/BrutalSlashHitCount.js
@@ -18,6 +18,10 @@ class BrutalSlashHitCount extends HitCountAoE {
     this.active = this.selectedCombatant.hasTalent(SPELLS.BRUTAL_SLASH_TALENT.id);
   }
 
+  statistic() {
+    return this.generateStatistic(STATISTIC_ORDER.OPTIONAL(10));
+  }
+
   get wrongTalentThresholds() {
     return {
       // Interested in how many targets are available so exclude any "zero hit" casts.
@@ -65,8 +69,6 @@ class BrutalSlashHitCount extends HitCountAoE {
         .recommended(`${recommended} is recommended`);
     });
   }
-
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(10);
 }
 
 export default BrutalSlashHitCount;

--- a/src/parser/druid/feral/modules/talents/MoonfireSnapshot.js
+++ b/src/parser/druid/feral/modules/talents/MoonfireSnapshot.js
@@ -88,8 +88,7 @@ class MoonfireSnapshot extends Snapshot {
   }
 
   statistic() {
-    return super.generateStatistic(SPELLS.MOONFIRE_FERAL.name);
+    return super.generateStatistic(SPELLS.MOONFIRE_FERAL.name, STATISTIC_ORDER.OPTIONAL(10));
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(10)
 }
 export default MoonfireSnapshot;

--- a/src/parser/druid/feral/modules/talents/MoonfireUptime.js
+++ b/src/parser/druid/feral/modules/talents/MoonfireUptime.js
@@ -53,11 +53,10 @@ class MoonfireUptime extends Analyzer {
         icon={<SpellIcon id={SPELLS.MOONFIRE_BEAR.id} />}
         value={`${formatPercentage(moonfireUptime)} %`}
         label="Moonfire uptime"
+        position={STATISTIC_ORDER.OPTIONAL(2)}
       />
     );
   }
-
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(2);
 }
 
 export default MoonfireUptime;

--- a/src/parser/druid/feral/modules/talents/Predator.js
+++ b/src/parser/druid/feral/modules/talents/Predator.js
@@ -79,11 +79,10 @@ class Predator extends Analyzer {
         value={this.extraCastsPerMinute.toFixed(2)}
         label="Extra Tiger's Fury casts per minute"
         tooltip={this.extraCasts > 0 ? hadExtraCasts : noExtraCasts}
+        positon={STATISTIC_ORDER.OPTIONAL(3)}
       />
     );
   }
-
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(3);
 }
 
 export default Predator;

--- a/src/parser/druid/feral/modules/talents/SavageRoarDmg.js
+++ b/src/parser/druid/feral/modules/talents/SavageRoarDmg.js
@@ -65,11 +65,10 @@ class SavageRoar extends Analyzer {
         value={`${formatNumber(this.bonusDmg / this.owner.fightDuration * 1000)} DPS`}
         label="Damage contributed"
         tooltip={`Your Savage Roar talent contributed <b>${formatNumber(this.bonusDmg)}</b> total damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.bonusDmg))}%).`}
+        position={STATISTIC_ORDER.OPTIONAL(1)}
       />
     );
   }
-
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(1);
 }
 
 export default SavageRoar;

--- a/src/parser/druid/feral/modules/talents/SavageRoarUptime.js
+++ b/src/parser/druid/feral/modules/talents/SavageRoarUptime.js
@@ -47,11 +47,10 @@ class SavageRoarUptime extends Analyzer {
         icon={<SpellIcon id={SPELLS.SAVAGE_ROAR_TALENT.id} />}
         value={`${formatPercentage(this.uptime)}%`}
         label="Savage Roar uptime"
+        position={STATISTIC_ORDER.OPTIONAL(0)}
       />
     );
   }
-
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(0);
 }
 
 export default SavageRoarUptime;

--- a/src/parser/druid/feral/normalizers/ComboPointsFromAoE.js
+++ b/src/parser/druid/feral/normalizers/ComboPointsFromAoE.js
@@ -68,8 +68,7 @@ class ComboPointsFromAoE extends EventsNormalizer {
         combo = Math.min(MAX_COMBO, combo + (event.resourceChange - event.waste));
       }
       if ((event.type === 'cast') && (event.sourceID === this.playerId) &&
-          eventComboResource && eventComboResource.cost &&
-          (event.ability.guid !== SPELLS.FEROCIOUS_BITE.id || !this.isBiteFree(event))) {
+          eventComboResource && eventComboResource.cost) {
         // Spent combo points, which always puts a Feral druid back to 0
         combo = 0;
       }
@@ -136,11 +135,6 @@ class ComboPointsFromAoE extends EventsNormalizer {
       return null;
     }
     return event.classResources.find(resource => (resource.type === type));
-  }
-
-  isBiteFree(event) {
-    // Unlike normal Bites, one made free by the T21 4pc proc doesn't provide an energy entry on its classResources
-    return !this.getResource(event, RESOURCE_TYPES.ENERGY.id);
   }
 }
 


### PR DESCRIPTION
This is some general housekeeping, with no user-visible changes.
Removed special handling for the old Legion tier sets, legendaries, and a few items with unusual effects (just like legendaries they stopped functioning at level 116.)
Replaced all uses of `statisticOrder` with the `position` property on the StatisticBox (or equivalent) itself.
Also updated the spec's example log to be from the live version of the game instead of the beta.