### PR TITLE
[Destruction] Temporarily disable Fire and Brimstone module

### DIFF
--- a/src/parser/warlock/destruction/CombatLogParser.js
+++ b/src/parser/warlock/destruction/CombatLogParser.js
@@ -13,7 +13,7 @@ import SoulShardDetails from './modules/soulshards/SoulShardDetails';
 import Backdraft from './modules/features/Backdraft';
 import Eradication from './modules/talents/Eradication';
 import ReverseEntropy from './modules/talents/ReverseEntropy';
-import FireAndBrimstone from './modules/talents/FireAndBrimstone';
+// import FireAndBrimstone from './modules/talents/FireAndBrimstone';
 import ChannelDemonfire from './modules/talents/ChannelDemonfire';
 import GrimoireOfSupremacy from './modules/talents/GrimoireOfSupremacy';
 import SoulConduit from './modules/talents/SoulConduit';
@@ -39,7 +39,7 @@ class CombatLogParser extends CoreCombatLogParser {
     backdraft: Backdraft,
     eradication: Eradication,
     reverseEntropy: ReverseEntropy,
-    fireAndBrimstone: FireAndBrimstone,
+    // fireAndBrimstone: FireAndBrimstone,
     channelDemonfire: ChannelDemonfire,
     grimoireOfSupremacy: GrimoireOfSupremacy,
     soulConduit: SoulConduit,

--- a/src/parser/warlock/destruction/modules/talents/index.js
+++ b/src/parser/warlock/destruction/modules/talents/index.js
@@ -6,14 +6,14 @@ import StatisticsListBox from 'interface/others/StatisticsListBox';
 
 import ReverseEntropy from './ReverseEntropy';
 import ChannelDemonfire from './ChannelDemonfire';
-import FireAndBrimstone from './FireAndBrimstone';
+// import FireAndBrimstone from './FireAndBrimstone';
 import SoulConduit from './SoulConduit';
 import GrimoireOfSupremacy from './GrimoireOfSupremacy';
 
 class TalentStatisticBox extends Analyzer {
   static dependencies = {
     reverseEntropy: ReverseEntropy,
-    fireAndBrimstone: FireAndBrimstone,
+    // fireAndBrimstone: FireAndBrimstone,
     channelDemonfire: ChannelDemonfire,
     soulConduit: SoulConduit,
     grimoireOfSupremacy: GrimoireOfSupremacy,


### PR DESCRIPTION
My module for Fire and Brimstone talent is currently broken (it was wired to my custom fragment tracking which was removed) and so it was showing 0 fragments gained (in cleave fights) which only confuses people. Because the logic isn't really flawed that much, it's just not updated to the ResourceTracker changes, I don't want to delete the whole module, just commented it out till I find the time to fix it.