### PR TITLE
[Mage] Add guesstimated classResources to fabricated prepull cast events

### DIFF
--- a/src/parser/mage/shared/normalizers/PrePullCooldowns.js
+++ b/src/parser/mage/shared/normalizers/PrePullCooldowns.js
@@ -42,6 +42,7 @@ class PrePullCooldowns extends EventsNormalizer {
 
   normalize(events) {
     const prepullCasts = [];
+    let precastClassResources = null;
 
     const firstEventIndex = this.getFightStartIndex(events);
     const firstTimestamp = events[firstEventIndex].timestamp;
@@ -71,6 +72,21 @@ class PrePullCooldowns extends EventsNormalizer {
       }
 
       if (event.type === 'cast') {
+
+        if (precastClassResources === null && event.classResources) {
+          /* This will copy the first resource information to all precast events.
+           * It's not pretty or 100% accurate, but it prevents errors on analyzers
+           * that require resource information and usually wont be too far off.
+           *
+           * In the future, a better way to handle this would be to make sure any
+           * analyzers that need the resource information check for .prepull, or
+           * we gain access to spell data that lets us build the resource
+           * information more accurately.
+           */
+          debug && console.log("Setting prepull class resources to:", event.classResources);
+          precastClassResources = event.classResources;
+        }
+
         const spellId = event.ability.guid;
         PREPULL_DMG_CDS.forEach(cdInfo => {
           if (cdInfo.cast === spellId) {
@@ -109,6 +125,7 @@ class PrePullCooldowns extends EventsNormalizer {
       const gcd = (ability && ability.gcd && ability.gcd.base) || 1500;
       totalGCD += gcd;
       event.timestamp = firstTimestamp - totalGCD;
+      event.classResources = precastClassResources;
     }
     events.unshift(...prepullCasts);
     return events;


### PR DESCRIPTION
Fixes an issue with the ArcanePower module that was trying to grab the mana value from these events