### PR TITLE
Dwarf: Track Stoneform damage reduced

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Mamtooth, Zerotorescue, Putro, joshinator, Gebuz, ackwell, emallson, blazyb, Dambroda, Nalhan } from 'CONTRIBUTORS';
+import { Mamtooth, Zerotorescue, Putro, joshinator, Gebuz, ackwell, emallson, blazyb, Dambroda, Nalhan, Satyric } from 'CONTRIBUTORS';
 import ItemLink from 'common/ItemLink';
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
@@ -8,6 +8,11 @@ import SpellLink from 'common/SpellLink';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  {
+    date: new Date('2018-10-06'),
+    changes: <React.Fragment> Added a damage reduction tracker for <SpellLink id={SPELLS.STONEFORM.id} /> </React.Fragment>,
+    contributors: [Satyric],
+  },
   {
     date: new Date('2018-10-02'),
     changes: 'Added a BFA-ready food and flasker checker to the well prepared checklist, with a lot of help from ArthurEnglebert',

--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -10,7 +10,7 @@ import Contributor from 'interface/contributor/Button';
 export default [
   {
     date: new Date('2018-10-06'),
-    changes: <React.Fragment> Added a damage reduction tracker for <SpellLink id={SPELLS.STONEFORM.id} /> </React.Fragment>,
+    changes: <React.Fragment> Added a damage reduction module for dwarf racial <SpellLink id={SPELLS.STONEFORM.id} /> </React.Fragment>,
     contributors: [Satyric],
   },
   {

--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -486,5 +486,15 @@ export const Nalhan = {
     name: 'Doughmaker',
     spec: SPECS.DISCIPLINE_PRIEST,
     link: 'http://us.battle.net/wow/character/arthas/Doughmaker',
+  }], 
+};
+export const Satyric = {
+  nickname: 'Satyric',
+  github: 'kujan',
+  discord: 'Satyric#9107',
+  mains: [{
+    name: 'Satyric',
+    spec: SPECS.HOLY_PALADIN,
+    link: 'https://worldofwarcraft.com/en-gb/character/ragnaros/Satyric',
   }],
 };

--- a/src/common/SPELLS/racials.js
+++ b/src/common/SPELLS/racials.js
@@ -85,6 +85,11 @@ export default {
     name: 'Stoneform',
     icon: 'spell_shadow_unholystrength',
   },
+  STONEFORM_BUFF: {
+    id: 65116,
+    name: 'Stoneform',
+    icon: 'spell_shadow_unholystrength',
+  },
   MIGHT_OF_THE_MOUNTAIN: {
     id: 59224,
     name: 'Might of the Mountain',

--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -61,6 +61,7 @@ import PreparationRuleAnalyzer from './modules/features/Checklist2/PreparationRu
 
 import ArcaneTorrent from './modules/racials/bloodelf/ArcaneTorrent';
 import MightOfTheMountain from './modules/racials/dwarf/MightOfTheMountain';
+import Stoneform from './modules/racials/dwarf/Stoneform';
 
 // Shared Buffs
 import VantusRune from './modules/spells/VantusRune';
@@ -173,7 +174,8 @@ class CombatLogParser {
     // Racials
     arcaneTorrent: ArcaneTorrent,
     mightOfTheMountain: MightOfTheMountain,
-
+    stoneform: Stoneform,
+    
     // Items:
     // BFA
     gildedLoaFigurine: GildedLoaFigurine,

--- a/src/parser/core/modules/racials/dwarf/Stoneform.js
+++ b/src/parser/core/modules/racials/dwarf/Stoneform.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import Analyzer from 'parser/core/Analyzer';
+
+import Combatants from 'parser/core/modules/Combatants';
+import { formatNumber } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import RACES from 'game/RACES';
+import StatisticBox from 'interface/others/StatisticBox';
+
+const STONEFORM_DAMAGE_REDUCTION = 0.1;
+const FALLING_DAMAGE_ABILITY_ID = 3;
+const PHYSICAL_EVENT_TYPE = 1;
+
+class Stoneform extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+  
+  damageReduced = 0;
+  physicalDamageTaken = 0;
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.race && this.selectedCombatant.race === RACES.Dwarf;
+  }
+
+  on_toPlayer_damage(event) {
+    const spellId = event.ability.guid;
+    if (spellId === FALLING_DAMAGE_ABILITY_ID) {
+      return;
+    }
+    
+    const damageTaken = event.amount + (event.absorbed || 0);
+    const isStoneformActive = this.selectedCombatant.hasBuff(SPELLS.STONEFORM_BUFF.id, event.timestamp, this.owner.playerId);
+    
+    if (isStoneformActive && event.ability.type === PHYSICAL_EVENT_TYPE) { 
+      //console.log(event);
+      console.log("Damage taken: " + damageTaken);
+      this.physicalDamageTaken += damageTaken;
+      this.damageReduced += damageTaken / (1 - STONEFORM_DAMAGE_REDUCTION) * STONEFORM_DAMAGE_REDUCTION;
+      console.log("Total reduction: " + this.damageReduced);
+    }
+  }
+
+  statistic() {
+    return(
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.STONEFORM_BUFF.id} />}
+        value={`${formatNumber(this.damageReduced)}`}
+        label="Stoneform Damage Reduced"
+        tooltip={`Over the course of the encounter you took ${formatNumber(this.physicalDamageTaken)} physical damage while Stoneform was active`}
+      />
+    );
+
+  }
+
+}
+
+export default Stoneform;

--- a/src/parser/core/modules/racials/dwarf/Stoneform.js
+++ b/src/parser/core/modules/racials/dwarf/Stoneform.js
@@ -3,10 +3,16 @@ import Analyzer from 'parser/core/Analyzer';
 
 import Combatants from 'parser/core/modules/Combatants';
 import { formatNumber } from 'common/format';
-import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import RACES from 'game/RACES';
+import SpellIcon from 'common/SpellIcon';
+import SPELLS from 'common/SPELLS';
 import StatisticBox from 'interface/others/StatisticBox';
+
+/**
+ * Removes all poison, disease, curse, magic, and bleed effects and reduces all physical damage taken by 10% for 8 sec.
+ *
+ * Example log: https://www.warcraftlogs.com/reports/gYCR2kZaJHVbjfxP/#fight=52&source=16&type=damage-taken
+ */
 
 const STONEFORM_DAMAGE_REDUCTION = 0.1;
 const FALLING_DAMAGE_ABILITY_ID = 3;
@@ -19,6 +25,7 @@ class Stoneform extends Analyzer {
   
   damageReduced = 0;
   physicalDamageTaken = 0;
+
   constructor(...args) {
     super(...args);
     this.active = this.selectedCombatant.race && this.selectedCombatant.race === RACES.Dwarf;
@@ -26,7 +33,7 @@ class Stoneform extends Analyzer {
 
   on_toPlayer_damage(event) {
     const spellId = event.ability.guid;
-    if (spellId === FALLING_DAMAGE_ABILITY_ID) {
+    if (spellId === FALLING_DAMAGE_ABILITY_ID) { // Falling damage is the same type as physical but ignores DRs.
       return;
     }
     
@@ -43,7 +50,7 @@ class Stoneform extends Analyzer {
     return(
       <StatisticBox
         icon={<SpellIcon id={SPELLS.STONEFORM_BUFF.id} />}
-        value={`${formatNumber(this.damageReduced)}`}
+        value={`≈${formatNumber(this.damageReduced)}`}
         label="Stoneform Damage Reduced"
         tooltip={`Over the course of the encounter you took ${formatNumber(this.physicalDamageTaken)} physical damage while Stoneform was active`}
       />

--- a/src/parser/core/modules/racials/dwarf/Stoneform.js
+++ b/src/parser/core/modules/racials/dwarf/Stoneform.js
@@ -34,11 +34,8 @@ class Stoneform extends Analyzer {
     const isStoneformActive = this.selectedCombatant.hasBuff(SPELLS.STONEFORM_BUFF.id, event.timestamp, this.owner.playerId);
     
     if (isStoneformActive && event.ability.type === PHYSICAL_EVENT_TYPE) { 
-      //console.log(event);
-      console.log("Damage taken: " + damageTaken);
       this.physicalDamageTaken += damageTaken;
       this.damageReduced += damageTaken / (1 - STONEFORM_DAMAGE_REDUCTION) * STONEFORM_DAMAGE_REDUCTION;
-      console.log("Total reduction: " + this.damageReduced);
     }
   }
 

--- a/src/parser/core/modules/racials/dwarf/Stoneform.js
+++ b/src/parser/core/modules/racials/dwarf/Stoneform.js
@@ -37,12 +37,15 @@ class Stoneform extends Analyzer {
 
   on_toPlayer_damage(event) {
     const spellId = event.ability.guid;
+
+    if (event.ability.type !== MAGIC_SCHOOLS.ids.PHYSICAL) {
+      return;
+    }
+
     if (spellId === FALLING_DAMAGE_ABILITY_ID) { // Falling damage is the same type as physical but ignores DRs.
       return;
     }
-    if (event.ability.type === MAGIC_SCHOOLS.ids.PHYSICAL) {
-      return;
-    }
+
     const damageTaken = event.amount + (event.absorbed || 0);
     const isStoneformActive = this.selectedCombatant.hasBuff(SPELLS.STONEFORM_BUFF.id, event.timestamp, this.owner.playerId);
     


### PR DESCRIPTION
Stoneform reduces physical damage taken by 10% when active, this adds a statistic for the approximate damage reduction provided by Stoneform. Fixes #2063.

![image](https://user-images.githubusercontent.com/5457828/46562146-146f8700-c8fb-11e8-913b-55ff2fcfb398.png)
