### PR TITLE
[Prot Paladin] Grand Crusader + Inspiring Vanguard

### DIFF
--- a/src/common/SPELLS/bfa/azeritetraits/paladin.js
+++ b/src/common/SPELLS/bfa/azeritetraits/paladin.js
@@ -81,4 +81,16 @@ export default {
     name: 'Divine Right',
     icon: 'ability_paladin_divinestorm',
   },
+
+  // Protection
+  INSPIRING_VANGUARD: {
+    id: 278609,
+    name: 'Inspiring Vanguard',
+    icon: 'inv_helmet_74',
+  },
+  INSPIRING_VANGUARD_BUFF: {
+    id: 279397,
+    name: 'Inspiring Vanguard',
+    icon: 'inv_helmet_74',
+  },
 };

--- a/src/parser/paladin/protection/CHANGELOG.js
+++ b/src/parser/paladin/protection/CHANGELOG.js
@@ -1,8 +1,12 @@
-// import React from 'react';
-
-// import { Hewhosmites, Zerotorescue, joshinator } from 'CONTRIBUTORS';
-// import SPELLS from 'common/SPELLS';
-// import SpellLink from 'common/SpellLink';
+import React from 'react';
+import { emallson } from 'CONTRIBUTORS';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
 
 export default [
+  {
+    date: new Date('6 October 2018'),
+    contributors: [emallson],
+    changes: <React.Fragment>Added support for <SpellLink id={SPELLS.INSPIRING_VANGUARD.id} />, including the ability to exactly detect <SpellLink id={SPELLS.GRAND_CRUSADER.id} /> resets when this trait is taken.</React.Fragment>,
+  },
 ];

--- a/src/parser/paladin/protection/CombatLogParser.js
+++ b/src/parser/paladin/protection/CombatLogParser.js
@@ -15,10 +15,14 @@ import Judgment from './modules/spells/Judgment';
 import LightOfTheProtectorTiming from './modules/features/LightOfTheProtectorTiming';
 import ShieldOfTheRighteous from './modules/features/ShieldOfTheRighteous';
 import Consecration from './modules/features/Consecration';
+import GrandCrusader from './modules/core/GrandCrusader';
 
 //Talents
 import Seraphim from './modules/talents/Seraphim';
 import RighteousProtector from './modules/talents/RighteousProtector';
+
+//Azerite Traits
+import InspiringVanguard from './modules/spells/azeritetraits/InspiringVanguard';
 
 //import CooldownTracker from './Modules/Features/CooldownTracker';
 
@@ -29,7 +33,8 @@ class CombatLogParser extends CoreCombatLogParser {
     damageDone: [DamageDone, { showStatistic: true }],
     healingDone: [HealingDone, { showStatistic: true }],
 
-    // Paladin Core
+    // Core
+    grandCrusader: GrandCrusader,
 
     // Features
     abilities: Abilities,
@@ -41,6 +46,9 @@ class CombatLogParser extends CoreCombatLogParser {
     consecration: Consecration,
     mitigationcheck: MitigationCheck,
     //cooldownTracker: CooldownTracker,
+    
+    // Azerite Traits
+    inspiringVanguard: InspiringVanguard,
 
     // Talents
     righteousProtector: RighteousProtector,

--- a/src/parser/paladin/protection/modules/core/GrandCrusader.js
+++ b/src/parser/paladin/protection/modules/core/GrandCrusader.js
@@ -1,0 +1,174 @@
+import React from 'react';
+import { Line as LineChart } from 'react-chartjs-2';
+import Analyzer from 'parser/core/Analyzer';
+import ExpandableStatisticBox from 'interface/others/ExpandableStatisticBox';
+import SpellIcon from 'common/SpellIcon';
+import SPELLS from 'common/SPELLS';
+import HIT_TYPES from 'parser/core/HIT_TYPES';
+import { formatPercentage } from 'common/format';
+
+const BASE_PROC_CHANCE = 0.15;
+const FA_PROC_CHANCE = 0.1;
+const IV_PROC_CHANCE = 0.05;
+
+class GrandCrusader extends Analyzer {
+  _totalResets = 0;
+  _exactResets = 0;
+  _inferredResets = 0;
+  _resetChances = 0;
+
+  _hasIV = false;
+  _hasFA = false;
+
+  constructor(...args) {
+    super(...args);
+    this._hasIV = this.selectedCombatant.hasTrait(SPELLS.INSPIRING_VANGUARD.id);
+    this._hasFA = this.selectedCombatant.hasTalent(SPELLS.FIRST_AVENGER_TALENT.id);
+  }
+
+  get procChance() {
+    let chance = BASE_PROC_CHANCE;
+    if(this._hasIV) {
+      chance += IV_PROC_CHANCE;
+    }
+    if(this._hasFA) {
+      chance += FA_PROC_CHANCE;
+    }
+
+    return chance;
+  }
+
+  on_byPlayer_cast(event) {
+    if(![SPELLS.HAMMER_OF_THE_RIGHTEOUS.id, SPELLS.BLESSED_HAMMER_TALENT.id].includes(event.ability.guid)) {
+      return;
+    }
+    this._resetChances += 1;
+  }
+
+  on_toPlayer_damage(event) {
+    if (![HIT_TYPES.DODGE, HIT_TYPES.PARRY].includes(event.hitType)) {
+      return;
+    }
+    this._resetChances += 1;
+  }
+
+  triggerExactReset(event) {
+    this._totalResets += 1;
+    this._exactResets += 1;
+  }
+
+  triggerInferredReset(event) {
+    this._totalResets += 1;
+    if(this._hasIV) {
+      console.warn('Inferred reset with IV. This shouldn\'t happen.', event);
+    }
+    this._inferredResets += 1;
+  }
+
+  plot() {
+    // stolen from BrM code
+
+    // not the most efficient, but close enough and pretty safe
+    function binom(n, k) {
+      if(k > n) {
+        return null;
+      }
+      if(k === 0) {
+        return 1;
+      }
+
+      return n / k * binom(n-1, k-1);
+    }
+
+    // pmf of the binomial distribution with n = _resetChances and
+    // p = procChance
+    const reset_prob = (i) => binom(this._resetChances, i) * Math.pow(this.procChance, i) * Math.pow(1 - this.procChance, this._resetChances - i);
+
+    // probability of having exactly k resets of the n chances
+    const reset_probs = Array.from({length: this._resetChances}, (_x, i) => {
+      return { x: i, y: reset_prob(i) };
+    });
+
+    return (
+      <LineChart
+        data={{
+          labels: Array.from({length: this._resetChances}, (_x, i) => i),
+          datasets: [
+            {
+              label: 'Actual Resets',
+              data: [{ x: this._totalResets, y: reset_prob(this._totalResets) }],
+              backgroundColor: '#00ff96',
+              type: 'scatter',
+            },
+            {
+              label: 'Reset Probability',
+              data: reset_probs,
+              backgroundColor: 'rgba(255, 139, 45, 0.2)',
+              borderColor: 'rgb(255, 139, 45)',
+              borderWidth: 2,
+              radius: 0,
+            },
+          ],
+        }}
+        options={{
+          tooltips: {
+            callbacks: {
+              title: (tooltipItem, data) => data.datasets[tooltipItem[0].datasetIndex].label,
+              label: (tooltipItem, data) => `${formatPercentage(data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index].x / this._resetChances)}%`,
+            },
+          },
+          legend: {
+            display: false,
+          },
+          scales: {
+            xAxes: [{
+              stacked: true,
+              scaleLabel: { 
+                display: true,
+                labelString: 'Reset %',
+                lineHeight: 1,
+                padding: 0,
+                fontColor: '#ccc',
+              },
+              ticks: {
+                fontColor: '#ccc',
+                callback: (x) => `${formatPercentage(x / this._resetChances, 0)}%`,
+              },
+            }],
+            yAxes: [{
+              stacked: true,
+              scaleLabel: { 
+                display: true,
+                labelString: 'Likelihood',
+                fontColor: '#ccc',
+              },
+              ticks: {
+                fontColor: '#ccc',
+                callback: (y) => `${formatPercentage(y, 0)}%`,
+              },
+            }],
+          },
+        }}
+        />
+    );
+  }
+
+  statistic() {
+    return (
+      <ExpandableStatisticBox
+        icon={<SpellIcon id={SPELLS.GRAND_CRUSADER.id} />}
+        value={`${this._totalResets} Resets`}
+        label={"Grand Crusader"}
+        tooltip={`Grand Crusader reset the cooldown of Avenger's Shield at least ${this._totalResets} times. ${this._inferredResets} are inferred from using it before its cooldown normally be up.<br/>
+            You had ${this._resetChances} chances for Grand Crusader to trigger with a ${formatPercentage(this.procChance, 0)}% chance to trigger.`}
+      >
+        <div style={{padding: '8px'}}>
+          {this.plot()}
+          <p>Likelihood of having <em>exactly</em> as many resets as you did with your traits and talents.</p>
+        </div>
+      </ExpandableStatisticBox>
+    );
+  }
+}
+
+export default GrandCrusader;

--- a/src/parser/paladin/protection/modules/features/SpellUsable.js
+++ b/src/parser/paladin/protection/modules/features/SpellUsable.js
@@ -1,10 +1,12 @@
 import SPELLS from 'common/SPELLS';
 import CoreSpellUsable from 'parser/core/modules/SpellUsable';
 import HIT_TYPES from 'parser/core/HIT_TYPES';
+import GrandCrusader from '../core/GrandCrusader';
 
 class SpellUsable extends CoreSpellUsable {
   static dependencies = {
     ...CoreSpellUsable.dependencies,
+    gc: GrandCrusader,
   };
 
   constructor(...args) {
@@ -42,6 +44,7 @@ class SpellUsable extends CoreSpellUsable {
   beginCooldown(spellId, timestamp) {
     if (spellId === SPELLS.AVENGERS_SHIELD.id) {
       if (this.isOnCooldown(spellId)) {
+        this.gc.triggerInferredReset(this.lastPotentialTriggerForAvengersShield);
         this.endCooldown(spellId, undefined, this.lastPotentialTriggerForAvengersShield ? this.lastPotentialTriggerForAvengersShield.timestamp : undefined);
       }
     } else if (this.hasCrusadersJudgment && spellId === SPELLS.JUDGMENT_CAST_PROTECTION.id) {

--- a/src/parser/paladin/protection/modules/spells/azeritetraits/InspiringVanguard.js
+++ b/src/parser/paladin/protection/modules/spells/azeritetraits/InspiringVanguard.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import Analyzer from 'parser/core/Analyzer';
+import TraitStatisticBox from 'interface/others/TraitStatisticBox';
+import { calculateAzeriteEffects } from 'common/stats';
+import { formatNumber, formatPercentage } from 'common/format';
+import GrandCrusader from '../../core/GrandCrusader';
+import SpellUsable from '../../features/SpellUsable';
+
+function inspiringVanguardStrength(combatant) {
+  if(!combatant.hasTrait(SPELLS.INSPIRING_VANGUARD.id)) {
+    return 0;
+  }
+
+  const traits = combatant.traitsBySpellId[SPELLS.INSPIRING_VANGUARD.id];
+  return traits.reduce((sum, ilvl) => sum + calculateAzeriteEffects(SPELLS.INSPIRING_VANGUARD.id, ilvl)[0], 0);
+}
+
+// TODO: figure out how to get the stats to the stat tracker without
+// crashing the whole thing.
+//
+// something is causing a dependency look via SpellUsable
+export const INSPIRING_VANGUARD_STATS = {
+  strength: inspiringVanguardStrength,
+};
+
+class InspiringVanguard extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+    gc: GrandCrusader,
+  };
+  
+  _strength = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrait(SPELLS.INSPIRING_VANGUARD.id);
+
+    if(!this.active) {
+      return;
+    }
+
+    this._strength = inspiringVanguardStrength(this.selectedCombatant);
+  }
+
+  get avgStrength() {
+    return this._strength * this.buffUptimePct;
+  }
+
+  get buffUptimePct() {
+    return this.selectedCombatant.getBuffUptime(SPELLS.INSPIRING_VANGUARD_BUFF.id) / this.owner.fightDuration;
+  }
+
+  on_toPlayer_applybuff(event) {
+    this._handleBuff(event);
+  }
+
+  on_toPlayer_refreshbuff(event) {
+    this._handleBuff(event);
+  }
+
+  _handleBuff(event) {
+    if(event.ability.guid !== SPELLS.INSPIRING_VANGUARD_BUFF.id) {
+      return;
+    }
+
+    this.gc.triggerExactReset(event);
+
+    // reset AS cd
+    if(this.spellUsable.isOnCooldown(SPELLS.AVENGERS_SHIELD.id)) {
+      this.spellUsable.endCooldown(SPELLS.AVENGERS_SHIELD.id);
+    }
+
+    // reset Judgment CD if the CJ talent is selected
+    if(this.selectedCombatant.hasTalent(SPELLS.CRUSADERS_JUDGMENT_TALENT.id) && this.spellUsable.isOnCooldown(SPELLS.JUDGMENT_CAST_PROTECTION.id)) {
+      this.spellUsable.endCooldown(SPELLS.JUDGMENT_CAST_PROTECTION.id);
+    }
+  }
+
+  statistic() {
+    return ( 
+      <TraitStatisticBox
+        trait={SPELLS.INSPIRING_VANGUARD.id}
+        value={`${formatNumber(this.avgStrength)} Avg. Strength`}
+        tooltip={`Inspiring Vanguard was up for <b>${formatPercentage(this.buffUptimePct)}%</b> of the fight.`}
+        /> 
+    );
+  }
+}
+
+export default InspiringVanguard;


### PR DESCRIPTION
Starting my work on the prot paladin module. One of the hardest things with it is that a core mechanic (Grand Crusader) can't normally be detected. However, the trait Inspiring Vanguard can be used to detect it since it triggers `applybuff`/`refreshbuff` when GC triggers.

This PR implements support for IV and for using it to detect exact resets. It also shows a distribution for GC resets similar to what I did for BrM mastery.

![screenshot from 2018-10-06 05-13-09](https://user-images.githubusercontent.com/4909458/46569757-97a6d200-c927-11e8-94f8-3d75c9cf3995.png)
![screenshot from 2018-10-06 05-12-53](https://user-images.githubusercontent.com/4909458/46569758-97a6d200-c927-11e8-8cb0-b0e59d28acd9.png)

Log: https://www.warcraftlogs.com/reports/vmcGHZWhRVnQkXxK/#fight=7&source=13

P.S. sorry for PR size. This started as the GC PR and then woli pointed out the power of IV and I got carried away.