### PR TITLE
[Feral] Fix typo in Treant Form ability

### DIFF
--- a/src/parser/druid/feral/modules/Abilities.js
+++ b/src/parser/druid/feral/modules/Abilities.js
@@ -533,7 +533,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.TREANT_FORM,
         category: Abilities.SPELL_CATEGORIES.OTHERS,
         gcd: {
-          fixed: 1500,
+          static: 1500,
         },
       },
       {


### PR DESCRIPTION
Fixes a timeline-disabling error in Feral logs where the druid uses Treant form.

Example log which caused the error: report/qr2JtNvkXFby7GVA/4-Heroic+MOTHER+-+Kill+(4:59)/5-Lederbärbel/timeline