### PR TITLE
[WW] Cleanup and updating use of position prop

### DIFF
--- a/src/parser/monk/windwalker/modules/chi/ChiDetails.js
+++ b/src/parser/monk/windwalker/modules/chi/ChiDetails.js
@@ -15,10 +15,17 @@ class ChiDetails extends Analyzer {
     chiTracker: ChiTracker,
   };
 
+  get chiWasted() {
+    return this.chiTracker.wasted;
+  }
+
+  get chiWastedPerMinute() {
+    return (this.chiWasted / this.owner.fightDuration) * 1000 * 60;
+  }
+
   get suggestionThresholds() {
-    const chiWastedPerMinute = (this.chiTracker.wasted / this.owner.fightDuration) * 1000 * 60;
     return {
-      actual: chiWastedPerMinute,
+      actual: this.chiWastedPerMinute,
       isGreaterThan: {
         minor: 0,
         average: 1,
@@ -29,18 +36,15 @@ class ChiDetails extends Analyzer {
   }
 
   suggestions(when) {
-    const chiWasted = this.chiTracker.wasted;
-    const chiWastedPerMinute = (chiWasted / this.owner.fightDuration) * 1000 * 60;
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
       return suggest('You are wasting Chi. Try to use it and not let it cap and go to waste')
         .icon('creatureportrait_bubble')
-        .actual(`${chiWasted} Chi wasted (${chiWastedPerMinute.toFixed(2)} per minute)`)
+        .actual(`${this.chiWasted} Chi wasted (${actual} per minute)`)
         .recommended(`${recommended.toFixed(2)} Chi wasted is recommended`);
     });
   }
 
   statistic() {
-    const chiWasted = this.chiTracker.wasted;
     return (
       <StatisticBox
         position={STATISTIC_ORDER.CORE(1)}
@@ -50,7 +54,7 @@ class ChiDetails extends Analyzer {
             alt="Wasted Chi"
           />
         )}
-        value={`${chiWasted}`}
+        value={`${this.chiWasted}`}
         label="Wasted Chi"
       />
     );

--- a/src/parser/monk/windwalker/modules/chi/ChiDetails.js
+++ b/src/parser/monk/windwalker/modules/chi/ChiDetails.js
@@ -43,6 +43,7 @@ class ChiDetails extends Analyzer {
     const chiWasted = this.chiTracker.wasted;
     return (
       <StatisticBox
+        position={STATISTIC_ORDER.CORE(1)}
         icon={(
           <img
             src={WastedChiIcon}
@@ -70,7 +71,6 @@ class ChiDetails extends Analyzer {
       ),
     };
   }
-  statisticOrder = STATISTIC_ORDER.CORE(1);
 }
 
 export default ChiDetails;

--- a/src/parser/monk/windwalker/modules/features/CooldownThroughputTracker.js
+++ b/src/parser/monk/windwalker/modules/features/CooldownThroughputTracker.js
@@ -29,13 +29,6 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
         BUILT_IN_SUMMARY_TYPES.DAMAGE,
       ],
     },
-    {
-      spell: SPELLS.INVOKE_XUEN_THE_WHITE_TIGER_TALENT,
-      duration: 20,
-      summary: [
-        BUILT_IN_SUMMARY_TYPES.DAMAGE,
-      ],
-    },
   ];
 
   on_byPlayer_cast(event) {

--- a/src/parser/monk/windwalker/modules/features/checklist/Component.js
+++ b/src/parser/monk/windwalker/modules/features/checklist/Component.js
@@ -116,7 +116,7 @@ class WindwalkerMonkChecklist extends React.PureComponent {
           <Requirement
             name={(
               <>
-                Bad <SpellLink id={SPELLS.SPINNING_CRANE_KICK.id} /> casts
+                Bad <SpellLink id={SPELLS.SPINNING_CRANE_KICK.id} /> casts per minute
               </>
             )}
             thresholds={thresholds.spinningCraneKick}

--- a/src/parser/monk/windwalker/modules/spells/BlackoutKick.js
+++ b/src/parser/monk/windwalker/modules/spells/BlackoutKick.js
@@ -90,6 +90,7 @@ class BlackoutKick extends Analyzer {
   statistic() {
     return (
       <StatisticBox
+        position={STATISTIC_ORDER.CORE(5)}
         icon={<SpellIcon id={SPELLS.BLACKOUT_KICK.id} />}
         value={(
           <span style={{ fontsize: '75%' }}>
@@ -116,7 +117,6 @@ class BlackoutKick extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.CORE(5);
 }
 
 export default BlackoutKick;

--- a/src/parser/monk/windwalker/modules/spells/ComboBreaker.js
+++ b/src/parser/monk/windwalker/modules/spells/ComboBreaker.js
@@ -54,10 +54,14 @@ class ComboBreaker extends Analyzer {
       }
     }
   }
+
+  get usedCBProcs() {
+    return this.consumedCBProc / this.CBProcsTotal;
+  }
+
   get suggestionThresholds() {
-    const usedCBprocs = this.consumedCBProc / this.CBProcsTotal;
     return {
-      actual: usedCBprocs,
+      actual: this.usedCBProcs,
       isLessThan: {
         minor: 0.9,
         average: 0.8,
@@ -68,28 +72,26 @@ class ComboBreaker extends Analyzer {
   }
 
   suggestions(when) {
-    const unusedCBprocs = 1 - (this.consumedCBProc / this.CBProcsTotal);
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>Your <SpellLink id={SPELLS.COMBO_BREAKER_BUFF.id} /> procs should be used before you tiger palm again so they are not overwritten. While some will be overwritten due to higher priority of getting Chi for spenders, wasting <SpellLink id={SPELLS.COMBO_BREAKER_BUFF.id} /> procs is not optimal.</span>)
           .icon(SPELLS.COMBO_BREAKER_BUFF.icon)
-          .actual(`${formatPercentage(unusedCBprocs)}% used Combo Breaker procs`)
+          .actual(`${formatPercentage(actual)}% used Combo Breaker procs`)
           .recommended(`>${formatPercentage(recommended)}% used Combo Breaker Procs is recommended`);
     });
   }
   
   statistic() {
-    const usedCBProcs = this.consumedCBProc / this.CBProcsTotal;
     const averageCBProcs = this.abilityTracker.getAbility(SPELLS.TIGER_PALM.id).casts * (this.selectedCombatant.hasTrait(SPELLS.PRESSURE_POINT.id) ? 0.1 : 0.08);
     return (
       <StatisticBox
+        position={STATISTIC_ORDER.CORE(6)}
         icon={<SpellIcon id={SPELLS.COMBO_BREAKER_BUFF.id} />}
-        value={`${formatPercentage(usedCBProcs)}%`}
+        value={`${formatPercentage(this.usedCBProcs)}%`}
         label="Combo Breaker Procs Used"
         tooltip={`You got a total of <b>${this.CBProcsTotal} Combo Breaker procs</b> and <b>used ${this.consumedCBProc}</b> of them. Average number of procs from your Tiger Palms this fight is <b>${averageCBProcs.toFixed(2)}</b>, and you got <b>${this.CBProcsTotal}</b>.`}
       />
    );
   }
-  statisticOrder = STATISTIC_ORDER.CORE(4);
 }
 
 export default ComboBreaker;

--- a/src/parser/monk/windwalker/modules/spells/ComboStrikes.js
+++ b/src/parser/monk/windwalker/modules/spells/ComboStrikes.js
@@ -60,7 +60,7 @@ class ComboStrikes extends Analyzer {
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>You ignored your <SpellLink id={SPELLS.COMBO_STRIKES.id} /> buff by casting the same spell twice in a row. This directly lowers your overall damage, and if you have <SpellLink id={SPELLS.HIT_COMBO_TALENT.id} /> talented, you will also drop all stacks of this damage buff.</span>)
           .icon(SPELLS.COMBO_STRIKES.icon)
-          .actual(`${this.masteryDropSpellSequence.length} instances where mastery dropped.`)
+          .actual(`${actual} instances where mastery dropped.`)
           .recommended(`${recommended} times mastery should be dropped`);
       });
   }

--- a/src/parser/monk/windwalker/modules/spells/ComboStrikes.js
+++ b/src/parser/monk/windwalker/modules/spells/ComboStrikes.js
@@ -70,6 +70,7 @@ class ComboStrikes extends Analyzer {
 
     return (
       <ExpandableStatisticBox
+        position={STATISTIC_ORDER.CORE(2)}
         icon={<SpellIcon id={SPELLS.COMBO_STRIKES.id} />}
         value={`${formatNumber(masteryDropEvents)}`}
         label={(
@@ -110,8 +111,6 @@ class ComboStrikes extends Analyzer {
       </ExpandableStatisticBox>
     );
   }
-  statisticOrder = STATISTIC_ORDER.CORE(2);
-
 }
 
 export default ComboStrikes;

--- a/src/parser/monk/windwalker/modules/spells/FistsofFury.js
+++ b/src/parser/monk/windwalker/modules/spells/FistsofFury.js
@@ -16,7 +16,6 @@ class FistsofFury extends Analyzer {
   previousTickTimestamp = null;
   fistsTickNumber = 0;
   fistsCastNumber = 0;
-  averageTicks = 0;
 
   isNewFistsTick(timestamp) {
     return !this.previousTickTimestamp || (timestamp - this.previousTickTimestamp) > FISTS_OF_FURY_MINIMUM_TICK_TIME;
@@ -28,8 +27,6 @@ class FistsofFury extends Analyzer {
       return;
     }
     this.fistsCastNumber += 1;
-    // average ticks is calculated here in case you don't hit any ticks during a cast'
-    this.averageTicks = this.fistsTickNumber / this.fistsCastNumber;
   }
 
   on_byPlayer_damage(event) {
@@ -39,8 +36,12 @@ class FistsofFury extends Analyzer {
     }
     this.fistsTickNumber += 1;
     this.previousTickTimestamp = event.timestamp;
-    this.averageTicks = this.fistsTickNumber / this.fistsCastNumber;
   }
+
+  get averageTicks() {
+    return this.fistsTickNumber / this.fistsCastNumber;
+  }
+
   get suggestionThresholds() {
     return {
       actual: this.averageTicks,

--- a/src/parser/monk/windwalker/modules/spells/FistsofFury.js
+++ b/src/parser/monk/windwalker/modules/spells/FistsofFury.js
@@ -64,15 +64,14 @@ class FistsofFury extends Analyzer {
   statistic() {
     return (
       <StatisticBox
+        position={STATISTIC_ORDER.CORE(4)}
         icon={<SpellIcon id={SPELLS.FISTS_OF_FURY_CAST.id} />}
         value={this.averageTicks.toFixed(2)}
-        label={(
-          <>You had an average of {this.averageTicks.toFixed(2)} ticks in each Fists of Fury cast.</>
-        )}
+        label="Average Fists of Fury Ticks"
+        tooltip="Fists of Fury ticks 5 times over the duration of the channel"
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.CORE(6);
 }
 
 export default FistsofFury;

--- a/src/parser/monk/windwalker/modules/spells/SpinningCraneKick.js
+++ b/src/parser/monk/windwalker/modules/spells/SpinningCraneKick.js
@@ -95,12 +95,13 @@ class SpinningCraneKick extends Analyzer {
   }
 
   get suggestionThresholds() {
+    const badCastsPerMinute = (this.badCasts / this.owner.fightDuration) * 1000 * 60;
     return {
-      actual: this.badCasts,
+      actual: badCastsPerMinute,
       isGreaterThan: {
         minor: 0,
-        average: 2,
-        major: 4,
+        average: 1,
+        major: 2,
       },
       style: 'number',
     };
@@ -115,8 +116,8 @@ class SpinningCraneKick extends Analyzer {
           </>
         )
           .icon(SPELLS.SPINNING_CRANE_KICK.icon)
-          .actual(`${this.badCasts} Bad Casts`)
-          .recommended('0 Bad Casts are recommended');
+          .actual(`${actual} Bad Casts Per Minute`)
+          .recommended(`${recommended} Bad Casts are recommended`);
       });
   }
 

--- a/src/parser/monk/windwalker/modules/spells/TouchOfDeath.js
+++ b/src/parser/monk/windwalker/modules/spells/TouchOfDeath.js
@@ -95,6 +95,7 @@ class TouchOfDeath extends Analyzer {
     const averageGaleBurst = this.totalGaleBurst / this.abilityTracker.getAbility(SPELLS.TOUCH_OF_DEATH.id).casts;
     return (
       <StatisticBox
+        position={STATISTIC_ORDER.CORE(8)}
         icon={<SpellIcon id={SPELLS.TOUCH_OF_DEATH.id} />}
         value={`${(averageGaleBurst).toFixed(2)}`}
         label={`Average Gale Burst`}
@@ -102,7 +103,6 @@ class TouchOfDeath extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.CORE(12);
 }
 
 export default TouchOfDeath;

--- a/src/parser/monk/windwalker/modules/spells/TouchOfKarma.js
+++ b/src/parser/monk/windwalker/modules/spells/TouchOfKarma.js
@@ -48,14 +48,14 @@ class TouchOfKarma extends Analyzer {
     const absorbUsed = this.healingDone.byAbility(SPELLS.TOUCH_OF_KARMA_CAST.id).effective / this.totalPossibleAbsorb;
     return (
       <StatisticBox
+        position={STATISTIC_ORDER.OPTIONAL(2)}
         icon={<SpellIcon id={SPELLS.TOUCH_OF_KARMA_CAST.id} />}
         value={`${formatPercentage(absorbUsed)}%`}
         label="Touch of Karma Absorb used"
         tooltip="This does not account for possible absorbs from missed Touch of Karma casts"
-        />
+      />
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(2);
 }
 
 export default TouchOfKarma;

--- a/src/parser/monk/windwalker/modules/spells/TouchOfKarma.js
+++ b/src/parser/monk/windwalker/modules/spells/TouchOfKarma.js
@@ -21,10 +21,13 @@ class TouchOfKarma extends Analyzer {
     this.totalPossibleAbsorb += event.maxHitPoints * (this.selectedCombatant.hasTalent(SPELLS.GOOD_KARMA_TALENT.id) ? 1 : 0.5);
   }
 
+  get absorbUsed() {
+    return this.healingDone.byAbility(SPELLS.TOUCH_OF_KARMA_CAST.id).effective / this.totalPossibleAbsorb;
+  }
+
   get suggestionThresholds() {
-    const absorbUsed = this.healingDone.byAbility(SPELLS.TOUCH_OF_KARMA_CAST.id).effective / this.totalPossibleAbsorb;
     return {
-      actual: absorbUsed,
+      actual: this.absorbUsed,
       isLessThan: {
         minor: 0.8,
         average: 0.65,
@@ -35,22 +38,20 @@ class TouchOfKarma extends Analyzer {
   }
 
   suggestions(when) {
-    const absorbUsed = this.healingDone.byAbility(SPELLS.TOUCH_OF_KARMA_CAST.id).effective / this.totalPossibleAbsorb;
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
       return suggest(<> You consumed a low amount of your total <SpellLink id={SPELLS.TOUCH_OF_KARMA_CAST.id} /> absorb. It's best used when you can take enough damage to consume most of the absorb. Getting full absorb usage shouldn't be expected on lower difficulty encounters </>)
         .icon(SPELLS.TOUCH_OF_KARMA_CAST.icon)
-        .actual(`${formatPercentage(absorbUsed)}% Touch of Karma absorb used`)
+        .actual(`${formatPercentage(actual)}% Touch of Karma absorb used`)
         .recommended(`>${formatPercentage(recommended)}% is recommended`);
     });
   }
 
   statistic() {
-    const absorbUsed = this.healingDone.byAbility(SPELLS.TOUCH_OF_KARMA_CAST.id).effective / this.totalPossibleAbsorb;
     return (
       <StatisticBox
         position={STATISTIC_ORDER.OPTIONAL(2)}
         icon={<SpellIcon id={SPELLS.TOUCH_OF_KARMA_CAST.id} />}
-        value={`${formatPercentage(absorbUsed)}%`}
+        value={`${formatPercentage(this.absorbUsed)}%`}
         label="Touch of Karma Absorb used"
         tooltip="This does not account for possible absorbs from missed Touch of Karma casts"
       />

--- a/src/parser/monk/windwalker/modules/talents/EnergizingElixir.js
+++ b/src/parser/monk/windwalker/modules/talents/EnergizingElixir.js
@@ -3,15 +3,13 @@ import React from 'react';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
-import StatisticBox from 'interface/others/StatisticBox';
+import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 
 import Analyzer from 'parser/core/Analyzer';
 
 class EnergizingElixir extends Analyzer {
-  chiGained = 0;
   energyGained = 0;
   energyWasted = 0;
-  chiSaved = 0;
   eeCasts = 0;
 
   constructor(...args) {
@@ -28,33 +26,30 @@ class EnergizingElixir extends Analyzer {
   }
 
   /**
-   * Calculate the amount of Energy and Chi gained and wasted
+   * Calculate the amount of Energy gained and wasted
    * for each cast event of Energizing Elixir.
    */
   on_toPlayer_energize(event) {
     const spellId = event.ability.guid;
-    if (spellId === SPELLS.ENERGIZING_ELIXIR_TALENT.id) {
-      if (event.resourceChangeType === RESOURCE_TYPES.ENERGY.id) {
-        this.energyWasted += event.waste;
-        this.energyGained += event.resourceChange - event.waste;
-      }
-      if (event.resourceChangeType === RESOURCE_TYPES.CHI.id) {
-        this.chiWasted += event.waste;
-        this.chiGained += event.resourceChange - event.waste;
-      }
+    if (spellId !== SPELLS.ENERGIZING_ELIXIR_TALENT.id) {
+      return;
+    }
+    if (event.resourceChangeType === RESOURCE_TYPES.ENERGY.id) {
+      this.energyWasted += event.waste;
+      this.energyGained += event.resourceChange - event.waste;
     }
   }
 
   statistic() {
-    return (<StatisticBox icon={<SpellIcon id={SPELLS.ENERGIZING_ELIXIR_TALENT.id} />}
-      value={this.energyGained}
-      label={(
-        <dfn data-tip={`from ${this.eeCasts} Energizing Elixir Casts`}>
-          Energy gained
-        </dfn>
-        )}
-        />
-      );
-    }
+    return (
+      <StatisticBox
+        position={STATISTIC_ORDER.CORE(7)}
+        icon={<SpellIcon id={SPELLS.ENERGIZING_ELIXIR_TALENT.id} />}
+        value={this.energyGained}
+        label="Energy gained"
+        tooltip={`from ${this.eeCasts} Energizing Elixir Casts`}
+      />
+    );
   }
+}
   export default EnergizingElixir;

--- a/src/parser/monk/windwalker/modules/talents/HitCombo.js
+++ b/src/parser/monk/windwalker/modules/talents/HitCombo.js
@@ -19,10 +19,13 @@ class HitCombo extends Analyzer {
     this.active = this.selectedCombatant.hasTalent(SPELLS.HIT_COMBO_TALENT.id);
   }
 
+  get uptime() {
+    return this.selectedCombatant.getBuffUptime(SPELLS.HIT_COMBO_BUFF.id) / this.owner.fightDuration;
+  }
+
   get suggestionThresholds() {
-    const hitComboUptime = this.selectedCombatant.getBuffUptime(SPELLS.HIT_COMBO_BUFF.id) / this.owner.fightDuration;
     return {
-      actual: hitComboUptime,
+      actual: this.uptime,
       isLessThan: {
         minor: 0.98,
         average: 0.95,
@@ -33,24 +36,21 @@ class HitCombo extends Analyzer {
   }
 
   suggestions(when) {
-    const hitComboUptime = this.selectedCombatant.getBuffUptime(SPELLS.HIT_COMBO_BUFF.id) / this.owner.fightDuration;
-
     when(this.suggestionThresholds).isLessThan(0.95)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>You let your <SpellLink id={SPELLS.HIT_COMBO_TALENT.id} /> buff drop by casting a spell twice in a row. Dropping this buff is a large DPS decrease so be mindful of the spells being cast.</span>)
           .icon(SPELLS.HIT_COMBO_TALENT.icon)
-          .actual(`${formatPercentage(hitComboUptime)} % uptime`)
+          .actual(`${formatPercentage(actual)} % uptime`)
           .recommended(`>${formatPercentage(recommended)} % is recommended`);
       });
   }
 
   statistic() {
-    const hitComboUptime = this.selectedCombatant.getBuffUptime(SPELLS.HIT_COMBO_BUFF.id) / this.owner.fightDuration;
     return (
       <StatisticBox
         position={STATISTIC_ORDER.CORE(3)}
         icon={<SpellIcon id={SPELLS.HIT_COMBO_TALENT.id} />}
-        value={`${formatPercentage(hitComboUptime)} %`}
+        value={`${formatPercentage(this.uptime)} %`}
         tooltip="Hit Combo Uptime"
       />
     );

--- a/src/parser/monk/windwalker/modules/talents/HitCombo.js
+++ b/src/parser/monk/windwalker/modules/talents/HitCombo.js
@@ -44,23 +44,17 @@ class HitCombo extends Analyzer {
       });
   }
 
-
   statistic() {
     const hitComboUptime = this.selectedCombatant.getBuffUptime(SPELLS.HIT_COMBO_BUFF.id) / this.owner.fightDuration;
-
     return (
       <StatisticBox
+        position={STATISTIC_ORDER.CORE(3)}
         icon={<SpellIcon id={SPELLS.HIT_COMBO_TALENT.id} />}
         value={`${formatPercentage(hitComboUptime)} %`}
-        label={(
-          <dfn>
-            Hit Combo Uptime
-          </dfn>
-        )}
+        tooltip="Hit Combo Uptime"
       />
-      );
-    }
-  statisticOrder = STATISTIC_ORDER.CORE(3);
+    );
+  }
 }
 
 export default HitCombo;


### PR DESCRIPTION
- Reducing some duplicate code
- Small edits for consistency in the code layout
- Using position prop instead of deprecated statisticOrder
- Removed Xuen from CooldownThroughputTracker, it's not relevant to track what happens during it since there's no interaction with other abilities. 