### PR TITLE
[BrM] corrected HT thresholds in stagger fabricator

### DIFF
--- a/src/parser/monk/brewmaster/modules/core/StaggerFabricator.js
+++ b/src/parser/monk/brewmaster/modules/core/StaggerFabricator.js
@@ -10,9 +10,9 @@ const T20_4PC_PURIFY = 0.05;
 export const EVENT_STAGGER_POOL_ADDED = 'addstagger';
 export const EVENT_STAGGER_POOL_REMOVED = 'removestagger';
 
-const STAGGER_THRESHOLDS = {
-  HEAVY: 0.6,
-  MODERATE: 0.3,
+const HT_STAGGER_THRESHOLDS = {
+  HEAVY: 0.7,
+  MODERATE: 0.4,
   LIGHT: 0.0,
 };
 
@@ -131,9 +131,9 @@ class StaggerFabricator extends Analyzer {
     const staggerRatio = staggerEvent.newPooledDamage / (sourceEvent.maxHitPoints || this._lastKnownMaxHp);
     if(staggerRatio === 0) {
       currentBuff = null;
-    } else if(staggerRatio < STAGGER_THRESHOLDS.MODERATE) {
+    } else if(staggerRatio < HT_STAGGER_THRESHOLDS.MODERATE) {
       currentBuff = SPELLS.LIGHT_STAGGER_DEBUFF.id;
-    } else if(staggerRatio < STAGGER_THRESHOLDS.HEAVY) {
+    } else if(staggerRatio < HT_STAGGER_THRESHOLDS.HEAVY) {
       currentBuff = SPELLS.MODERATE_STAGGER_DEBUFF.id;
     } else {
       currentBuff = SPELLS.HEAVY_STAGGER_DEBUFF.id;


### PR DESCRIPTION
High Tolerance changes the moderate/heavy stagger thresholds from 30% and 60% to 40% and 70%, respectively. I accidentally used the non-HT numbers to calculate haste gained from HT.