### PR TITLE
Fixed issue in resto druid suggestions for extending wild growth and cenarion ward with flourish

### DIFF
--- a/src/parser/druid/restoration/modules/talents/Flourish.js
+++ b/src/parser/druid/restoration/modules/talents/Flourish.js
@@ -230,7 +230,7 @@ class Flourish extends Analyzer {
         .addSuggestion((suggest, actual, recommended) => {
           return suggest(<>Your <SpellLink id={SPELLS.FLOURISH_TALENT.id} /> should always aim to extend a <SpellLink id={SPELLS.CENARION_WARD_HEAL.id} /></>)
             .icon(SPELLS.FLOURISH_TALENT.icon)
-            .actual(`${this.cenarionWard}/${this.flourishCount} CWs extended.`)
+            .actual(`${this.cwsExtended}/${this.flourishCount} CWs extended.`)
             .recommended(`${formatPercentage(recommended)}% is recommended`);
         });
     }

--- a/src/parser/druid/restoration/modules/talents/Flourish.js
+++ b/src/parser/druid/restoration/modules/talents/Flourish.js
@@ -221,7 +221,7 @@ class Flourish extends Analyzer {
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<>Your <SpellLink id={SPELLS.FLOURISH_TALENT.id} /> should always aim to extend a <SpellLink id={SPELLS.WILD_GROWTH.id} /></>)
           .icon(SPELLS.FLOURISH_TALENT.icon)
-          .actual(`${formatPercentage(this.wildGrowthCasts / this.flourishCount, 0)}% WGs extended.`)
+          .actual(`${formatPercentage(this.wgsExtended / this.flourishCount, 0)}% WGs extended.`)
           .recommended(`${formatPercentage(recommended)}% is recommended`);
       });
 


### PR DESCRIPTION
Fixes an issue in the suggestions tab for resto druid that was incorrectly displaying the percentage of wild growths extended by flourish. 