### PR TITLE
[Restoration Shaman] Spreadsheet export

### DIFF
--- a/src/interface/others/RestorationShamanSpreadsheet.js
+++ b/src/interface/others/RestorationShamanSpreadsheet.js
@@ -45,8 +45,8 @@ class RestorationShamanSpreadsheet extends React.Component {
               <tr><td>{parser.selectedCombatant.hasTalent(SPELLS.CLOUDBURST_TOTEM_TALENT.id) ? cpm(SPELLS.CLOUDBURST_TOTEM_TALENT.id) : cpm(SPELLS.HEALING_STREAM_TOTEM_CAST.id)}</td></tr>
               <tr><td>{cpm(SPELLS.CHAIN_HEAL.id)}</td></tr>
               <tr><td>{parser._modules.spreadsheet.surgingTideProcsPerMinute}</td></tr>
-              <tr><td>{(parser._modules.spreadsheet.spoutingSpiritsHits / casts(SPELLS.SPIRIT_LINK_TOTEM.id)).toFixed(2)}</td></tr>
-              <tr><td>{(parser._modules.spreadsheet.overflowingShoresHits / casts(SPELLS.HEALING_RAIN_CAST.id)).toFixed(2)}</td></tr>
+              <tr><td>{(parser._modules.spreadsheet.spoutingSpiritsHits / casts(SPELLS.SPIRIT_LINK_TOTEM.id) || 0).toFixed(2)}</td></tr>
+              <tr><td>{(parser._modules.spreadsheet.overflowingShoresHits / casts(SPELLS.HEALING_RAIN_CAST.id) || 0).toFixed(2)}</td></tr>
               <tr><td>{parser._modules.spreadsheet.ebbAndFlowEffectiveness.toFixed(2)}</td></tr>
               <tr><td>{parser._modules.combatants.playerCount}</td></tr>
               <tr><td>{cpm(SPELLS.ASTRAL_SHIFT.id)}</td></tr>

--- a/src/interface/others/RestorationShamanSpreadsheet.js
+++ b/src/interface/others/RestorationShamanSpreadsheet.js
@@ -51,6 +51,7 @@ class RestorationShamanSpreadsheet extends React.Component {
               <tr><td>{parser._modules.combatants.playerCount}</td></tr>
               <tr><td>{cpm(SPELLS.ASTRAL_SHIFT.id)}</td></tr>
               <tr><td>{(parser.selectedCombatant.getBuffUptime(SPELLS.GHOST_WOLF.id) / 1000).toFixed(2)}</td></tr>
+              <tr><td>{parser._modules.masteryEffectiveness.masteryEffectivenessPercent.toFixed(2)}</td></tr>
               <tr><td>{parser.selectedCombatant.race ? parser.selectedCombatant.race.name : 'Unknown'}</td></tr>
             </tbody>
           </table>

--- a/src/interface/others/RestorationShamanSpreadsheet.js
+++ b/src/interface/others/RestorationShamanSpreadsheet.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import SPELLS from 'common/SPELLS';
+
+const PRE_INTELLECT_POTION_BUFF = 900;
+
+class RestorationShamanSpreadsheet extends React.Component {
+  static propTypes = {
+    parser: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { parser } = this.props;
+
+    const styles = {
+      table: { borderBottom: '1px solid #dddddd', borderTop: '1px solid #dddddd', align: 'right', padding: '20px', float: 'left', margin: '5px', borderCollapse: 'separate', borderSpacing: '10px 0' },
+    };
+
+    const getAbility = spellId => parser._modules.abilityTracker.getAbility(spellId);
+    const casts = spellId => getAbility(spellId).casts;
+    const cpm = spellId => casts(spellId) / (parser.fightDuration / 1000 / 60) >= 0 ? (casts(spellId) / (parser.fightDuration / 1000 / 60)).toFixed(2) : '0';
+    const prePotion = parser._modules.prePotion.usedPrePotion ? PRE_INTELLECT_POTION_BUFF : 0;
+
+    return (
+      <div>
+        <div style={{ padding: '0px 22px 15px 0px' }}>Please use the below table to populate the Restoration Shaman Spreadsheet. <a href="https://ancestralguidance.com/spreadsheet/">Link to the sheet</a><br /></div>
+          <table style={styles.table} >
+            <tbody>
+              <tr><td>{parser.selectedCombatant._combatantInfo.intellect - prePotion}</td></tr>
+              <tr><td>{parser.selectedCombatant._combatantInfo.critSpell}</td></tr>
+              <tr><td>{parser.selectedCombatant._combatantInfo.hasteSpell}</td></tr>
+              <tr><td>{parser.selectedCombatant._combatantInfo.mastery}</td></tr>
+              <tr><td>{parser.selectedCombatant._combatantInfo.versatilityHealingDone}</td></tr>
+              <tr><td>{Math.floor(parser.fightDuration / 1000)}</td></tr>
+              <tr><td>{parser._modules.statValues.hpsPerIntellect.toFixed(2)}</td></tr>
+              <tr><td>{parser._modules.statValues.hpsPerCriticalStrike.toFixed(2)}</td></tr>
+              <tr><td>{parser._modules.statValues.hpsPerHaste.toFixed(2)}</td></tr>
+              <tr><td>{parser._modules.statValues.hpsPerMastery.toFixed(2)}</td></tr>
+              <tr><td>{parser._modules.statValues.hpsPerVersatility.toFixed(2)}</td></tr>
+              <tr><td>{cpm(SPELLS.RIPTIDE.id)}</td></tr>
+              <tr><td>{cpm(SPELLS.HEALING_RAIN_CAST.id)}</td></tr>
+              <tr><td>{cpm(SPELLS.HEALING_TIDE_TOTEM_CAST.id)}</td></tr>
+              <tr><td>{cpm(SPELLS.SPIRIT_LINK_TOTEM.id)}</td></tr>
+              <tr><td>{cpm(SPELLS.HEALING_STREAM_TOTEM_CAST.id)}</td></tr>
+              <tr><td>{cpm(SPELLS.CHAIN_HEAL.id)}</td></tr>
+              <tr><td>{parser._modules.spreadsheet.surgingTideProcsPerMinute}</td></tr>
+              <tr><td>{(parser._modules.spreadsheet.spoutingSpiritsHits / casts(SPELLS.SPIRIT_LINK_TOTEM.id)).toFixed(2)}</td></tr>
+              <tr><td>{(parser._modules.spreadsheet.overflowingShoresHits / casts(SPELLS.HEALING_RAIN_CAST.id)).toFixed(2)}</td></tr>
+              <tr><td>{parser._modules.spreadsheet.ebbAndFlowEffectiveness.toFixed(2)}</td></tr>
+              <tr><td>{parser._modules.combatants.playerCount}</td></tr>
+              <tr><td>{cpm(SPELLS.ASTRAL_SHIFT.id)}</td></tr>
+              <tr><td>{(parser.selectedCombatant.getBuffUptime(SPELLS.GHOST_WOLF.id) / 1000).toFixed(2)}</td></tr>
+              <tr><td>{parser.selectedCombatant.race ? parser.selectedCombatant.race.name : 'Unknown'}</td></tr>
+            </tbody>
+          </table>
+      </div>
+    );
+  }
+}
+
+export default RestorationShamanSpreadsheet;

--- a/src/interface/others/RestorationShamanSpreadsheet.js
+++ b/src/interface/others/RestorationShamanSpreadsheet.js
@@ -42,7 +42,7 @@ class RestorationShamanSpreadsheet extends React.Component {
               <tr><td>{cpm(SPELLS.HEALING_RAIN_CAST.id)}</td></tr>
               <tr><td>{cpm(SPELLS.HEALING_TIDE_TOTEM_CAST.id)}</td></tr>
               <tr><td>{cpm(SPELLS.SPIRIT_LINK_TOTEM.id)}</td></tr>
-              <tr><td>{cpm(SPELLS.HEALING_STREAM_TOTEM_CAST.id)}</td></tr>
+              <tr><td>{parser.selectedCombatant.hasTalent(SPELLS.CLOUDBURST_TOTEM_TALENT.id) ? cpm(SPELLS.CLOUDBURST_TOTEM_TALENT.id) : cpm(SPELLS.HEALING_STREAM_TOTEM_CAST.id)}</td></tr>
               <tr><td>{cpm(SPELLS.CHAIN_HEAL.id)}</td></tr>
               <tr><td>{parser._modules.spreadsheet.surgingTideProcsPerMinute}</td></tr>
               <tr><td>{(parser._modules.spreadsheet.spoutingSpiritsHits / casts(SPELLS.SPIRIT_LINK_TOTEM.id)).toFixed(2)}</td></tr>

--- a/src/parser/shaman/restoration/CHANGELOG.js
+++ b/src/parser/shaman/restoration/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-10-10'),
+    changes: 'New Tab added: "Player Log Data" with exports for the Restoration Shaman Spreadsheet.',
+    contributors: [niseko],
+  },
+  {
     date: new Date('2018-09-09'),
     changes: <>Added a spell breakdown for your <SpellLink id={SPELLS.FLASH_FLOOD_TALENT.id} /> buff usage.</>,
     contributors: [niseko],

--- a/src/parser/shaman/restoration/CombatLogParser.js
+++ b/src/parser/shaman/restoration/CombatLogParser.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import Tab from 'interface/others/Tab';
+import RestorationShamanSpreadsheet from 'interface/others/RestorationShamanSpreadsheet';
 import Feeding from 'interface/others/Feeding';
 
 import CoreCombatLogParser from 'parser/core/CombatLogParser';
@@ -10,6 +11,7 @@ import Abilities from './modules/Abilities';
 import HealingDone from './modules/core/HealingDone';
 import ShamanAbilityTracker from './modules/core/ShamanAbilityTracker';
 import HealingRainLocation from './modules/core/HealingRainLocation';
+import Spreadsheet from './modules/core/Spreadsheet';
 
 import MasteryEffectiveness from './modules/features/MasteryEffectiveness';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
@@ -60,6 +62,7 @@ class CombatLogParser extends CoreCombatLogParser {
     healingDone: [HealingDone, { showStatistic: true }],
     abilities: Abilities,
     healingRainLocation: HealingRainLocation,
+    spreadsheet: Spreadsheet,
 
     // Features
     alwaysBeCasting: AlwaysBeCasting,
@@ -108,6 +111,15 @@ class CombatLogParser extends CoreCombatLogParser {
 
     results.tabs = [
       ...results.tabs,
+      {
+        title: 'Player Log Data',
+        url: 'player-log-data',
+        render: () => (
+          <Tab style={{ padding: '15px 22px 15px 15px' }}>
+            <RestorationShamanSpreadsheet parser={this} />
+          </Tab>
+        ),
+      },
       {
         title: 'Feeding',
         url: 'feeding',

--- a/src/parser/shaman/restoration/modules/core/Spreadsheet.js
+++ b/src/parser/shaman/restoration/modules/core/Spreadsheet.js
@@ -1,0 +1,114 @@
+import Analyzer from 'parser/core/Analyzer';
+import Combatants from 'parser/shared/modules/Combatants';
+
+import SPELLS from 'common/SPELLS';
+
+const halfHP = 0.5;
+const rainBuffer = 2000;
+const linkBufferStart = 500;
+const linkBufferEnd = 1500;
+const totemSpawnDistance = 200; // 2 yards
+const ebbAndFlowMinDistance = 8;
+const ebbAndFlowMaxDistance = 40;
+
+class Spreadsheet extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  potentialSurgingTideProcs = 0;
+  potentialOverflowingShoresTargets = 0;
+  potentialSpoutingSpiritsTargets = 0;
+  healingTideTicks = [];
+
+  spiritLinkCastTimestamp = 0;
+  healingRainCastTimestamp = 0;
+  healingTidePosition = {};
+
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+
+    if (spellId === SPELLS.SPIRIT_LINK_TOTEM.id) {
+      this.spiritLinkCastTimestamp = event.timestamp;
+    } else if (spellId === SPELLS.HEALING_TIDE_TOTEM_CAST.id) {
+      // totem spawns 2 yards behind and to the right of your position on cast
+      const radians = event.facing / 100;
+      const xDistance = totemSpawnDistance * Math.cos(radians);
+      const yDistance = totemSpawnDistance * Math.sin(radians);
+
+      this.healingTidePosition = {x: event.x + xDistance, y: event.y + yDistance};
+    }
+  }
+
+  on_byPlayer_begincast(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.HEALING_RAIN_CAST.id || event.isCancelled) {
+      return;
+    }
+    this.healingRainCastTimestamp = event.timestamp;
+  }
+
+  on_byPlayer_heal(event) {
+    const spellId = event.ability.guid;
+
+    if (spellId === SPELLS.RIPTIDE.id && !event.tick) {
+      const currentHealth = Math.max(0, (event.hitPoints - event.amount) / event.maxHitPoints);
+      if (currentHealth >= halfHP) {
+        return;
+      }
+      this.potentialSurgingTideProcs += 1;
+
+      // checking how many people the initial of healing rain hits, while filtering out overheal events
+    } else if (this.healingRainCastTimestamp && spellId === SPELLS.HEALING_RAIN_HEAL.id && this.healingRainCastTimestamp <= event.timestamp && this.healingRainCastTimestamp >= event.timestamp - rainBuffer) {
+      if (event.overheal) {
+        return;
+      }
+      this.potentialOverflowingShoresTargets += 1;
+    }
+  }
+  
+  on_byPlayerPet_heal(event) {
+    const spellId = event.ability.guid;
+    // checking for a 1 second timespan shortly after SLT cast to find out how many people are inside the link when spouting spirits would heal
+    if (spellId === SPELLS.SPIRIT_LINK_TOTEM_REDISTRIBUTE.id && this.spiritLinkCastTimestamp <= event.timestamp - linkBufferStart && this.spiritLinkCastTimestamp >= event.timestamp - linkBufferEnd) {
+      this.potentialSpoutingSpiritsTargets += 1;
+    } else if (spellId === SPELLS.HEALING_TIDE_TOTEM_HEAL.id) {
+      // noone cares about pets
+      const combatant = this.combatants.players[event.targetID];
+      if (!combatant) {
+        return;
+      }
+
+      const a = this.healingTidePosition.x - event.x;
+      const b = this.healingTidePosition.y - event.y;
+      const distanceToPlayer = Math.sqrt(a*a + b*b);
+
+      this.healingTideTicks.push(distanceToPlayer);
+    }
+  }
+
+  on_byPlayerPet_damage(event) {
+    const spellId = event.ability.guid;
+    // checking for a 1 second timespan shortly after SLT cast to find out how many people are inside the link when spouting spirits would heal
+    if (spellId === SPELLS.SPIRIT_LINK_TOTEM_REDISTRIBUTE.id && this.spiritLinkCastTimestamp <= event.timestamp - linkBufferStart && this.spiritLinkCastTimestamp >= event.timestamp - linkBufferEnd) {
+      this.potentialSpoutingSpiritsTargets += 1;
+    }
+  }
+
+  get surgingTideProcsPerMinute() {
+    return (this.potentialSurgingTideProcs / (this.owner.fightDuration / 1000 / 60)).toFixed(2);
+  }
+  get spoutingSpiritsHits() {
+    return this.potentialSpoutingSpiritsTargets;
+  }
+  get overflowingShoresHits() {
+    return this.potentialOverflowingShoresTargets;
+  }
+  get ebbAndFlowEffectiveness() {
+    const averageDistance = this.healingTideTicks.reduce((total, tick) => total + tick, 0) / this.healingTideTicks.length / 100;
+    // 8 - 40 yards linear falloff
+    return Math.min(1 - ((averageDistance - ebbAndFlowMinDistance) / (ebbAndFlowMaxDistance - ebbAndFlowMinDistance)), 1);
+  }
+}
+
+export default Spreadsheet;

--- a/src/parser/shaman/restoration/modules/features/MasteryEffectiveness.js
+++ b/src/parser/shaman/restoration/modules/features/MasteryEffectiveness.js
@@ -65,15 +65,18 @@ class MasteryEffectiveness extends Analyzer {
     this.on_byPlayer_heal(event);
   }
 
+  get masteryEffectivenessPercent() {
+    return this.totalMasteryHealing / this.totalMaxPotentialMasteryHealing;
+  }
+
   statistic() {
-    const masteryEffectivenessPercent = this.totalMasteryHealing / this.totalMaxPotentialMasteryHealing;
     const masteryPercent = this.statTracker.currentMasteryPercentage;
-    const avgEffectiveMasteryPercent = masteryEffectivenessPercent * masteryPercent;
+    const avgEffectiveMasteryPercent = this.masteryEffectivenessPercent * masteryPercent;
 
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.DEEP_HEALING.id} />}
-        value={`${formatPercentage(masteryEffectivenessPercent)} %`}
+        value={`${formatPercentage(this.masteryEffectivenessPercent)} %`}
         label={(
           <dfn data-tip={`The percent of your mastery that you benefited from on average (so always between 0% and 100%). Since you have ${formatPercentage(masteryPercent)}% mastery, this means that on average your heals were increased by ${formatPercentage(avgEffectiveMasteryPercent)}% by your mastery.`}>
             Mastery benefit


### PR DESCRIPTION
Since i was asked to export some data to make life easier. Based on the Mistweaver / Hpriest player log data, i chose to omit the text descriptions to make copy / pasting easier.
The Spreadsheet.js file is a temporary collection of azerite information, and a bit of a mess, that will be moved into their respective azerite modules once i implement them. The link given is dead right now but will be active within the next few days.