### PR TITLE
[Ret] Judgment module fix and some other minor things

### DIFF
--- a/src/parser/paladin/retribution/CombatLogParser.js
+++ b/src/parser/paladin/retribution/CombatLogParser.js
@@ -1,6 +1,6 @@
 import CoreCombatLogParser from 'parser/core/CombatLogParser';
 import DamageDone from 'parser/shared/modules/DamageDone';
-
+import GlobalCooldown from './modules/core/GlobalCooldown';
 import Haste from './modules/core/Haste';
 
 import Abilities from './modules/Abilities';
@@ -29,6 +29,7 @@ class CombatLogParser extends CoreCombatLogParser {
     haste: Haste,
     // PaladinCore
     damageDone: [DamageDone, { showStatistic: true }],
+    globalCooldown: GlobalCooldown,
     artOfWar: ArtOfWar,
 
     // Features

--- a/src/parser/paladin/retribution/modules/core/ArtOfWar.js
+++ b/src/parser/paladin/retribution/modules/core/ArtOfWar.js
@@ -88,6 +88,7 @@ class AoWProcTracker extends Analyzer {
   statistic() {
     return (
       <StatisticBox
+        position={STATISTIC_ORDER.OPTIONAL(2)}
         icon={<SpellIcon id={SPELLS.ART_OF_WAR.id} />}
         value={`${formatPercentage(this.consumedProcsPercent)}%`}
         label="Art of War procs used"
@@ -95,7 +96,6 @@ class AoWProcTracker extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(2);
 }
 
 export default AoWProcTracker;

--- a/src/parser/paladin/retribution/modules/core/GlobalCooldown.js
+++ b/src/parser/paladin/retribution/modules/core/GlobalCooldown.js
@@ -1,0 +1,30 @@
+import CoreGlobalCooldown from 'parser/shared/modules/GlobalCooldown';
+import SPELLS from 'common/SPELLS';
+import Haste from './Haste';
+import Abilities from '../Abilities';
+
+const MIN_GCD= 750;
+
+/**
+ * The Global Cooldown from Wake of Ashes is currently double dipping haste
+ */ 
+
+class GlobalCooldown extends CoreGlobalCooldown {
+  static dependencies = {
+    abilities: Abilities,
+    haste: Haste,
+  };
+
+  getGlobalCooldownDuration(spellId) {
+    const gcd = super.getGlobalCooldownDuration(spellId);
+    if (!gcd) {
+      return 0;
+    }
+    if (spellId && spellId === SPELLS.WAKE_OF_ASHES_TALENT.id) {
+      return Math.max(gcd / (1 + this.haste.current));
+    }
+    return Math.max(MIN_GCD, gcd);
+  }
+}
+
+export default GlobalCooldown;

--- a/src/parser/paladin/retribution/modules/core/Judgment.js
+++ b/src/parser/paladin/retribution/modules/core/Judgment.js
@@ -84,6 +84,7 @@ class Judgment extends Analyzer {
     const justicarsVengeanceText = this.selectedCombatant.hasTalent(SPELLS.JUSTICARS_VENGEANCE_TALENT.id) ? `<br>Justicars Vengeance consumptions: ${this.justicarsVengeanceConsumptions}` : ``; 
     return (
       <StatisticBox
+        position={STATISTIC_ORDER.CORE(6)}
         icon={<SpellIcon id={SPELLS.JUDGMENT_DEBUFF.id} />}
         value={`${formatPercentage(this.percentageJudgmentsConsumed)}%`}
         label="Judgments Consumed"
@@ -95,7 +96,6 @@ class Judgment extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.CORE(6);
 }
 
 export default Judgment;

--- a/src/parser/paladin/retribution/modules/core/Judgment.js
+++ b/src/parser/paladin/retribution/modules/core/Judgment.js
@@ -9,6 +9,10 @@ import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 
+const JUDGMENT_DURATION = 15000;
+
+const HOLY_POWER_ATTACKS = [SPELLS.TEMPLARS_VERDICT_DAMAGE.id, SPELLS.DIVINE_STORM_DAMAGE.id, SPELLS.JUSTICARS_VENGEANCE_TALENT.id];
+
 class Judgment extends Analyzer {
   static dependencies = {
     enemies: Enemies,
@@ -17,38 +21,73 @@ class Judgment extends Analyzer {
   divineStormConsumptions = 0;
   justicarsVengeanceConsumptions = 0;
   judgmentsApplied = 0;
+  judgmentsOverwritten = 0;
+  judgmentTargets = [];
 
   on_byPlayer_applydebuff(event) {
     const spellId = event.ability.guid;
     if (spellId !== SPELLS.JUDGMENT_DEBUFF.id) {
       return;
     }
+    // The event doesn't specify instance on the first target of that type
+    let targetInstance = event.targetInstance;
+    if (targetInstance === undefined) {
+      targetInstance = 1;
+    }
     this.judgmentsApplied += 1;
+    const judgmentTarget = { targetID: event.targetID, targetInstance: targetInstance, timestamp: event.timestamp };
+    this.judgmentTargets.push(judgmentTarget);
+  }
+
+  on_byPlayer_refreshdebuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.JUDGMENT_DEBUFF.id) {
+      return;
+    }
+    let targetInstance = event.targetInstance;
+    if (targetInstance === undefined) {
+      targetInstance = 1;
+    }
+    this.judgmentsOverwritten += 1;
+    this.judgmentTargets.forEach((judgmentTarget, index) => {
+      if (judgmentTarget.targetID === event.targetID && judgmentTarget.targetInstance === targetInstance) {
+        judgmentTarget.timestamp = event.timestamp;
+      }
+    });
   }
 
   on_byPlayer_damage(event) {
-    const enemy = this.enemies.getEntity(event);
     const spellId = event.ability.guid;
-
-    if (!enemy) {
+    if (!HOLY_POWER_ATTACKS.includes(spellId)) {
       return;
     }
-    if (!enemy.hasBuff(SPELLS.JUDGMENT_DEBUFF.id, null, 250)) {
-      return;
+    let targetInstance = event.targetInstance;
+    if (targetInstance === undefined) {
+      targetInstance = 1;
     }
-    switch (spellId) {
-      case SPELLS.TEMPLARS_VERDICT_DAMAGE.id:
-        this.templarsVerdictConsumptions += 1;
-        break;
-      case SPELLS.DIVINE_STORM_DAMAGE.id:
-        this.divineStormConsumptions += 1;
-        break;
-      case SPELLS.JUSTICARS_VENGEANCE_TALENT.id:
-        this.justicarsVengeanceConsumptions += 1;
-        break;
-      default:
-        break;
-    }
+    this.judgmentTargets.forEach((judgmentTarget, index) => {
+      // remove expired judgments
+      const expirationTimestamp = judgmentTarget.timestamp + JUDGMENT_DURATION;
+      if (expirationTimestamp < event.timestamp) {
+        this.judgmentTargets.splice(index, 1);
+      }
+      if (judgmentTarget.targetID === event.targetID && judgmentTarget.targetInstance === targetInstance) {
+        switch (spellId) {
+          case SPELLS.TEMPLARS_VERDICT_DAMAGE.id:
+            this.templarsVerdictConsumptions += 1;
+            break;
+          case SPELLS.DIVINE_STORM_DAMAGE.id:
+            this.divineStormConsumptions += 1;
+            break;
+          case SPELLS.JUSTICARS_VENGEANCE_TALENT.id:
+            this.justicarsVengeanceConsumptions += 1;
+            break;
+          default:
+            break;
+        }
+        this.judgmentTargets.splice(index, 1);
+      }
+    });
   }
 
   get judgmentsConsumed() {
@@ -90,9 +129,10 @@ class Judgment extends Analyzer {
         label="Judgments Consumed"
         tooltip={`
           Judgments Applied: ${this.judgmentsApplied}<br>
-          Templars Verdicts consumptions: ${this.templarsVerdictConsumptions}<br>
-          Divine Storm consumptions: ${this.divineStormConsumptions}
-          ${justicarsVengeanceText}`}
+          Templars Verdicts Consumptions: ${this.templarsVerdictConsumptions}<br>
+          Divine Storm Consumptions: ${this.divineStormConsumptions}
+          ${justicarsVengeanceText}<br>
+          Judgments Overwritten: ${this.judgmentsOverwritten}`}
       />
     );
   }

--- a/src/parser/paladin/retribution/modules/core/Retribution.js
+++ b/src/parser/paladin/retribution/modules/core/Retribution.js
@@ -36,6 +36,7 @@ class Retribution extends Analyzer {
   statistic() {
     return (
       <StatisticBox
+        position={STATISTIC_ORDER.UNIMPORTANT()}
         icon={<SpellIcon id={SPELLS.RETRIBUTION_BUFF.id} />}
         value={`${formatNumber(this.bonusDmg / this.owner.fightDuration * 1000)} DPS`}
         label="Damage contributed"
@@ -43,7 +44,6 @@ class Retribution extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.UNIMPORTANT();
 }
 
 export default Retribution;

--- a/src/parser/paladin/retribution/modules/holypower/HolyPowerDetails.js
+++ b/src/parser/paladin/retribution/modules/holypower/HolyPowerDetails.js
@@ -44,6 +44,7 @@ class HolyPowerDetails extends Analyzer {
   statistic() {
     return (
       <StatisticBox
+        position={STATISTIC_ORDER.CORE(4)}
         icon={(
           <img
             src={WastedHPIcon}
@@ -72,7 +73,6 @@ class HolyPowerDetails extends Analyzer {
       ),
     };
   }
-  statisticOrder = STATISTIC_ORDER.CORE(4);
 }
 
 export default HolyPowerDetails;

--- a/src/parser/paladin/retribution/modules/talents/DivinePurpose.js
+++ b/src/parser/paladin/retribution/modules/talents/DivinePurpose.js
@@ -34,13 +34,13 @@ class DivinePurpose extends Analyzer {
   statistic() {
     return (
       <StatisticBox
+        position={STATISTIC_ORDER.OPTIONAL(1)}
         icon={<SpellIcon id={SPELLS.DIVINE_PURPOSE_TALENT_RETRIBUTION.id} />}
         value={`${formatNumber(this.divinePurposeProcs)}`}
         label="Divine Purpose procs"
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL(1);
 }
 
 export default DivinePurpose;

--- a/src/parser/paladin/retribution/modules/talents/Inquisition.js
+++ b/src/parser/paladin/retribution/modules/talents/Inquisition.js
@@ -64,6 +64,7 @@ class Inquisition extends Analyzer {
   statistic() {
     return (
       <StatisticBox
+        position={STATISTIC_ORDER.CORE(5)}
         icon={<SpellIcon id={SPELLS.INQUISITION_TALENT.id} />}
         value={`${formatPercentage(this.efficiency)}%`}
         label="Damage done while buffed"
@@ -71,7 +72,6 @@ class Inquisition extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.CORE(5);
 }
 
 export default Inquisition;

--- a/src/parser/paladin/retribution/modules/talents/RighteousVerdict.js
+++ b/src/parser/paladin/retribution/modules/talents/RighteousVerdict.js
@@ -64,6 +64,7 @@ class RighteousVerdict extends Analyzer {
   statistic() {
     return (
       <StatisticBox
+        position={STATISTIC_ORDER.CORE(7)}
         icon={<SpellIcon id={SPELLS.RIGHTEOUS_VERDICT_TALENT.id} />}
         value={formatNumber(this.damageDone)}
         label="Damage Done"
@@ -74,7 +75,6 @@ class RighteousVerdict extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.CORE(7);
 }
 
 export default RighteousVerdict;


### PR DESCRIPTION
- Added custom GCD for Wake of Ashes
- Updated use of position prop instead of deprecated statisticOrder
- Fixed judgment consumptions being counted for every tick when a divine storm consumed a judgment

old result: 
![billede](https://user-images.githubusercontent.com/30317641/46751475-fdde7c80-ccba-11e8-83d7-e5a58538fbeb.png)
new result:
![billede](https://user-images.githubusercontent.com/30317641/46751500-0fc01f80-ccbb-11e8-8080-38a056e5db89.png)

Planning to turn the judgment statistic into a donut so less info is hidden in the tooltip. 
