### PR TITLE
[Prot Pal] Added tracking for good SotR casts.

### DIFF
--- a/src/parser/paladin/protection/CHANGELOG.js
+++ b/src/parser/paladin/protection/CHANGELOG.js
@@ -5,8 +5,13 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('10 October 2018'),
+    contributors: [emallson],
+    changes: <>Added tracking for which <SpellLink id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id} /> casts are effective.</>,
+  },
+  {
     date: new Date('6 October 2018'),
     contributors: [emallson],
-    changes: <React.Fragment>Added support for <SpellLink id={SPELLS.INSPIRING_VANGUARD.id} />, including the ability to exactly detect <SpellLink id={SPELLS.GRAND_CRUSADER.id} /> resets when this trait is taken.</React.Fragment>,
+    changes: <>Added support for <SpellLink id={SPELLS.INSPIRING_VANGUARD.id} />, including the ability to exactly detect <SpellLink id={SPELLS.GRAND_CRUSADER.id} /> resets when this trait is taken.</>,
   },
 ];

--- a/src/parser/paladin/protection/CONFIG.js
+++ b/src/parser/paladin/protection/CONFIG.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-// import { Zerotorescue } from 'CONTRIBUTORS';
+import { emallson } from 'CONTRIBUTORS';
 import SPECS from 'game/SPECS';
 import Warning from 'interface/common/Alert/Warning';
 import SPELLS from 'common/SPELLS';
@@ -10,7 +10,7 @@ import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [],
+  contributors: [emallson],
   // The WoW client patch this spec was last updated to be fully compatible with.
   patchCompatibility: '8.0.1',
   // If set to  false`, the spec will show up as unsupported.

--- a/src/parser/paladin/protection/modules/features/Checklist/Component.js
+++ b/src/parser/paladin/protection/modules/features/Checklist/Component.js
@@ -51,13 +51,16 @@ class ProtectionPaladinChecklist extends React.PureComponent{
           description={(
             <>
               Maintain <SpellLink id={SPELLS.CONSECRATION_CAST.id} /> to reduce all incoming damage by a flat amount and use it as a rotational filler if necessary.<br />
-              Use <SpellLink id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id} /> to flat out your physical damage taken or weave them into your rotation when you're about to cap charges.
+              Use <SpellLink id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id} /> to smooth out your physical damage taken or weave them into your rotation when you're about to cap charges.
             </>
           )}
         >
+          <AbilityRequirement spell={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id}
+            name={(<><SpellLink id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id} /> cast efficiency</>)} 
+          />
           <Requirement
             name={(
-              <><SpellLink id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id} /> efficiency</>
+              <>Good <SpellLink id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id} /> casts</>
             )}
             thresholds={thresholds.shieldOfTheRighteous}
           />

--- a/src/parser/paladin/protection/modules/features/ShieldOfTheRighteous.js
+++ b/src/parser/paladin/protection/modules/features/ShieldOfTheRighteous.js
@@ -4,34 +4,149 @@ import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 import Analyzer from 'parser/core/Analyzer';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
 import SPELLS from 'common/SPELLS';
 import MAGIC_SCHOOLS from 'game/MAGIC_SCHOOLS';
+import {findByBossId} from 'raids/index';
 
+
+const SOTR_DURATION = 4500;
+
+const isGoodCast = cast => cast.melees >= 2 || cast.tankbusters >= 1 || cast.remainingCharges >= 1.35;
 
 class ShieldOfTheRighteous extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+  };
 
   physicalHitsWithShieldOfTheRighteous = 0;
   physicalDamageWithShieldOfTheRighteous = 0;
   physicalHitsWithoutShieldOfTheRighteous = 0;
   physicalDamageWithoutShieldOfTheRighteous = 0;
 
+  _tankbusters = [];
+
+  _sotrCasts = [    
+    /*
+    {
+        castTime: <timestamp>,
+        buffStartTime: <timestamp>, // if extending, when the "new" buff starts
+        melees: <number>, // melees received while during buff
+        tankbusters: <number>, // tankbusters mitigated by buff
+     }
+     */
+  ];
+
+  // this setup is used to track which melee attacks are mitigated by
+  // which casts.
+  _futureCasts = [];
+  _activeCast = null;
+
+  _buffExpiration = 0;
+
+  constructor(...args) {
+    super(...args);
+    const boss = findByBossId(this.owner.boss.id);
+    this._tankbusters = Object.values(boss.fight.softMitigationChecks);
+  }
+
+  _partialCharge() {
+    const cd = this.spellUsable._currentCooldowns[SPELLS.SHIELD_OF_THE_RIGHTEOUS.id];
+
+    return 1 - this.spellUsable.cooldownRemaining(SPELLS.SHIELD_OF_THE_RIGHTEOUS.id) / cd.expectedDuration;
+  }
+
+  on_byPlayer_cast(event) {
+    if(event.ability.guid !== SPELLS.SHIELD_OF_THE_RIGHTEOUS.id) {
+      return;
+    }
+    const cast = {
+      castTime: event.timestamp,
+      buffStartTime: Math.max(this._buffExpiration, event.timestamp),
+      melees: 0,
+      tankbusters: 0,
+      remainingCharges: this.spellUsable.chargesAvailable(SPELLS.SHIELD_OF_THE_RIGHTEOUS.id) + this._partialCharge(),
+      _event: event,
+    };
+
+    this._buffExpiration = Math.min(Math.max(this._buffExpiration, event.timestamp) + SOTR_DURATION, SOTR_DURATION * 3);
+    
+    if(cast.buffStartTime > cast.castTime) {
+      this._futureCasts.push(cast);
+    } else {
+      this._activeCast = cast;
+    }
+    this._sotrCasts.push(cast);
+  }
+
   on_toPlayer_damage(event) {
-    if (event.ability.type === MAGIC_SCHOOLS.ids.PHYSICAL && this.selectedCombatant.hasBuff(SPELLS.SHIELD_OF_THE_RIGHTEOUS_BUFF.id)) {
+    if(event.ability.type !== MAGIC_SCHOOLS.ids.PHYSICAL) {
+      return;
+    }
+
+    if (this.selectedCombatant.hasBuff(SPELLS.SHIELD_OF_THE_RIGHTEOUS_BUFF.id)) {
       this.physicalHitsWithShieldOfTheRighteous += 1;
       this.physicalDamageWithShieldOfTheRighteous += event.amount + (event.absorbed || 0) + (event.overkill || 0);
-    } else if (event.ability.type === MAGIC_SCHOOLS.ids.PHYSICAL && !this.selectedCombatant.hasBuff(SPELLS.SHIELD_OF_THE_RIGHTEOUS_BUFF.id)) {
+
+      if(this._tankbusters.includes(event.ability.guid)) {
+        this._processTankbuster(event);
+      } else {
+        this._processPhysicalHit(event);
+      }
+    } else {
       this.physicalHitsWithoutShieldOfTheRighteous += 1;
       this.physicalDamageWithoutShieldOfTheRighteous += event.amount + (event.absorbed || 0) + (event.overkill || 0);
     }
   }
 
+  _processPhysicalHit(event) {
+    this._updateActiveCast(event);
+    if(!this._activeCast) {
+      return;
+    }
+
+    this._activeCast.melees += 1;
+  }
+
+  _processTankbuster(event) {
+    this._updateActiveCast(event);
+    if(!this._activeCast) {
+      return;
+    }
+
+    this._activeCast.tankbusters += 1;
+  }
+
+  // if the buff associated with the current active cast is no longer
+  // active, move to the next.
+  _updateActiveCast(event) {
+    while(this._activeCast && (this._activeCast.buffStartTime + SOTR_DURATION) < event.timestamp) {
+      this._markupActiveCast();
+      this._activeCast = this._futureCasts.shift();
+    }
+  }
+
+  _markupActiveCast() {
+    if(isGoodCast(this._activeCast)) {
+      return;
+    }
+    const meta = this._activeCast._event.meta || {};
+    meta.isInefficientCast = true;
+    meta.inefficientCastReason = 'This cast did not block many melee attacks, or block a tankbuster, or prevent you from capping SotR charges.';
+    this._activeCast._event.meta = meta;
+  }
+
+  get goodCasts() {
+    return this._sotrCasts.filter(isGoodCast);
+  }
+
   get suggestionThresholds() {
     return {
-      actual: this.physicalDamageWithShieldOfTheRighteous / (this.physicalDamageWithShieldOfTheRighteous + this.physicalDamageWithoutShieldOfTheRighteous),
+      actual: this.goodCasts.length / this._sotrCasts.length,
       isLessThan: {
-        minor: 0.5,
-        average: 0.35,
-        major: 0.2,
+        minor: 0.9,
+        average: 0.75,
+        major: 0.6,
       },
       style: 'percentage',
     };
@@ -40,9 +155,9 @@ class ShieldOfTheRighteous extends Analyzer {
   suggestions(when) {
     when(this.suggestionThresholds)
         .addSuggestion((suggest, actual, recommended) => {
-          return suggest(<>You only had the <SpellLink id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id} /> buff for {formatPercentage(actual)}% of physical damage taken. You should have Shield of the Righteous up to mitigate as much physical damage as possible.</>)
+          return suggest(<>{formatPercentage(actual)}% of your <SpellLink id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id} /> casts were <em>good</em> (they mitigated at least 2 auto-attacks or 1 tankbuster, or prevented capping charges). You should have Shield of the Righteous up to mitigate as much physical damage as possible.</>)
             .icon(SPELLS.SHIELD_OF_THE_RIGHTEOUS.icon)
-            .actual(`${formatPercentage(actual)}% was mitigated by Shield of the Righteous`)
+            .actual(`${formatPercentage(actual)}% good Shield of the Righteous casts`)
             .recommended(`${Math.round(formatPercentage(recommended))}% or more is recommended`);
         });
   }
@@ -61,7 +176,8 @@ class ShieldOfTheRighteous extends Analyzer {
                 <li>You were hit <b>${this.physicalHitsWithShieldOfTheRighteous}</b> times with your Shield of the Righteous buff (<b>${formatThousands(this.physicalDamageWithShieldOfTheRighteous)}</b> damage).</li>
                 <li>You were hit <b>${this.physicalHitsWithoutShieldOfTheRighteous}</b> times <b><i>without</i></b> your Shield of the Righteous buff (<b>${formatThousands(this.physicalDamageWithoutShieldOfTheRighteous)}</b> damage).</li>
             </ul>
-            <b>${formatPercentage(physicalHitsMitigatedPercent)}%</b> of physical attacks were mitigated with Shield of the Righteous (<b>${formatPercentage(physicalDamageMitigatedPercent)}%</b> of physical damage taken).`}
+            <b>${formatPercentage(physicalHitsMitigatedPercent)}%</b> of physical attacks were mitigated with Shield of the Righteous (<b>${formatPercentage(physicalDamageMitigatedPercent)}%</b> of physical damage taken).<br/>
+            <b>${this.goodCasts.length}</b> of your ${this._sotrCasts.length} casts were <em>good</em> (blocked at least 2 melees or a tankbuster, or prevented capping charges).`}
       />
     );
   }


### PR DESCRIPTION
![screenshot from 2018-10-10 20-34-05](https://user-images.githubusercontent.com/4909458/46773532-d8a63a00-cccb-11e8-8015-83821a58e0c7.png)
![screenshot from 2018-10-10 20-28-13](https://user-images.githubusercontent.com/4909458/46773533-d8a63a00-cccb-11e8-8c93-c69c58abd825.png)

A *good* SotR cast (based on feedback from protadin vets) satisfies one of:

- mitigates 2+ melees
- mitigates a tankbuster
- prevents capping charges

The SotR module now tries to assign every melee and (physical) tankbuster to exactly one SotR cast. Then these casts are processed to count the amount of casts that were good.

This also is a first step in updating the prot paladin checklist.