### PR TITLE
[Fire Mage] Fixes Suggestions Crash

### DIFF
--- a/src/parser/mage/fire/CHANGELOG.js
+++ b/src/parser/mage/fire/CHANGELOG.js
@@ -4,6 +4,11 @@ import { Sharrq } from 'CONTRIBUTORS';
 
 export default [
   {
+    date: new Date('2018-10-11'),
+    changes: 'Fixed bug that caused Suggestions to crash',
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2018-9-14'),
     changes: 'Updated Checklist',
     contributors: [Sharrq],

--- a/src/parser/mage/fire/modules/features/CombustionPyroclasm.js
+++ b/src/parser/mage/fire/modules/features/CombustionPyroclasm.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
-import ItemLink from 'common/ItemLink';
 import { formatPercentage } from 'common/format';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import Analyzer from 'parser/core/Analyzer';
@@ -100,7 +99,7 @@ class CombustionPyroclasm extends Analyzer {
     if (this.expectedPyroblastCasts > 0) {
       when(this.pyrloclasmUtilThresholds)
         .addSuggestion((suggest, actual, recommended) => {
-          return suggest(<>During <SpellLink id={SPELLS.COMBUSTION.id} /> you had enough time to use {this.expectedPyroblastCasts} procs from your <ItemLink id={SPELLS.PYROCLASM_TALENT.id} />, but you only used {this.actualPyroblastCasts} of them. If there is more than 5 seconds of Combustion left, you should use your proc so that your hard casted <SpellLink id={SPELLS.PYROBLAST.id} /> will do 225% damage and be guaranteed to crit.</>)
+          return suggest(<>During <SpellLink id={SPELLS.COMBUSTION.id} /> you had enough time to use {this.expectedPyroblastCasts} procs from your <SpellLink id={SPELLS.PYROCLASM_TALENT.id} />, but you only used {this.actualPyroblastCasts} of them. If there is more than 5 seconds of Combustion left, you should use your proc so that your hard casted <SpellLink id={SPELLS.PYROBLAST.id} /> will do 225% damage and be guaranteed to crit.</>)
             .icon(SPELLS.PYROCLASM_TALENT.icon)
             .actual(`${formatPercentage(this.pyroclasmBuffUtil)}% Utilization`)
             .recommended(`${formatPercentage(recommended)} is recommended`);


### PR DESCRIPTION
Fixes a crash in suggestions  caused by a leftover ItemLink that didnt get updated when the module was renamed from the Fire Legendary Bracers to Pyroclasm