### PR TITLE
[Arcane Mage] Bug Fixes & Updates

### DIFF
--- a/src/parser/mage/arcane/CHANGELOG.js
+++ b/src/parser/mage/arcane/CHANGELOG.js
@@ -6,6 +6,21 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-10-11'),
+    changes: <>Fixed <SpellLink id={SPELLS.ARCANE_CHARGE.id} /> Normalizer to not put energize events after <SpellLink id={SPELLS.ARCANE_BARRAGE.id} /> and added Normalizer to sort the <SpellLink id={SPELLS.ARCANE_POWER.id} /> cast before the buff application</>,
+    contributors: [Sharrq],
+  },
+  {
+    date: new Date('2018-10-11'),
+    changes: <>Redid <SpellLink id={SPELLS.ARCANE_POWER.id} /> Utilization to count each pre-req separately. Also updated tooltip and suggestion to show which checks were failed.</>,
+    contributors: [Sharrq],
+  },
+  {
+    date: new Date('2018-10-11'),
+    changes: <>Fixed <SpellLink id={SPELLS.RULE_OF_THREES_TALENT.id} /> bug</>,
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2018-08-28'),
     changes: <>Added support for <SpellLink id={SPELLS.GALVANIZING_SPARK.id} /> and <SpellLink id={SPELLS.ANOMALOUS_IMPACT.id} /></>,
     contributors: [Sharrq],

--- a/src/parser/mage/arcane/CombatLogParser.js
+++ b/src/parser/mage/arcane/CombatLogParser.js
@@ -11,6 +11,7 @@ import Mana from './modules/ManaChart/Mana';
 import ManaValues from './modules/ManaChart/ManaValues';
 
 import ArcaneCharges from './normalizers/ArcaneCharges';
+import ArcanePowerNormalizer from './normalizers/ArcanePower';
 import PrePullCooldowns from '../shared/normalizers/PrePullCooldowns';
 
 import ArcaneChargeTracker from './modules/features/ArcaneChargeTracker';
@@ -33,6 +34,7 @@ class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     //Normalizers
     arcaneCharges: ArcaneCharges,
+    arcanePowerNormalizer: ArcanePowerNormalizer,
     prePullCooldowns: PrePullCooldowns,
 
     // Features

--- a/src/parser/mage/arcane/modules/features/ArcanePower.js
+++ b/src/parser/mage/arcane/modules/features/ArcanePower.js
@@ -171,15 +171,17 @@ class ArcanePower extends Analyzer {
   }
 
   get requiredChecks() {
-    if (this.hasOverpowered && !this.hasRuneOfPower) {
-      return 1;
-    } else if (!this.hasOverpowered && !this.hasRuneOfPower) {
-      return 2;
-    } else if (this.hasOverpowered && this.hasRuneOfPower) {
-      return 3;
-    } else {
-      return 4;
+    let checks = 1;
+    if (!this.hasOverpowered) {
+      //Also checks mana level if you dont have Overpowered talented
+      checks += 1;
     }
+    if (this.hasRuneOfPower) {
+      //Also checks to see if RoP was delayed or missing if RoP is talented
+      checks += 1;
+    }
+    return checks;
+
   }
 
   get failedChecks() {

--- a/src/parser/mage/arcane/modules/features/ArcanePower.js
+++ b/src/parser/mage/arcane/modules/features/ArcanePower.js
@@ -251,10 +251,10 @@ class ArcanePower extends Analyzer {
   suggestions(when) {
     when(this.cooldownSuggestionThresholds)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<>You cast <SpellLink id={SPELLS.ARCANE_POWER.id} /> without meeting all of the pre-requisites {this.badUses} times. Arcane Power has a short duration so it is important that you meet all of the following pre-requisites before casting Arcane Power to ensure you get the most out of it. If the necessary abilities are not available or you dont have enough resources, consider modifying your rotation to ensure that these requirements are met before Arcane Power comes off cooldown.
+        return suggest(<>You cast <SpellLink id={SPELLS.ARCANE_POWER.id} /> without properly setting up for it {this.badUses} times. Arcane Power has a short duration so it is important that you get the most out of it by ensuring you meet all of the below requirements before casting Arcane Power.
         <ul>
-          <li>You have 4 Arcane Charges - Failed {this.lowChargesCast} of {this.abilityTracker.getAbility(SPELLS.ARCANE_POWER.id).casts} casts.</li>
-          {this.hasRuneOfPower ? <li>You cast Rune of Power <dfn data-tip={`Arcane Power should be cast right on the end of the Rune of Power cast. There should not be any casts or any delay in between Rune of Power and Arcane Power to ensure that Rune of Power is up for the entire duration of Arcane Power.`}>immediately</dfn> before Arcane Power - Failed {this.delayedRuneCast + this.noRuneCast} of {this.abilityTracker.getAbility(SPELLS.ARCANE_POWER.id).casts} casts.</li> : ''}
+          <li>You have 4 <SpellLink id={SPELLS.ARCANE_CHARGE.id} /> - Failed {this.lowChargesCast} of {this.abilityTracker.getAbility(SPELLS.ARCANE_POWER.id).casts} casts.</li>
+          {this.hasRuneOfPower ? <li>You cast <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} /> <dfn data-tip={`Arcane Power should be cast right on the end of the Rune of Power cast. There should not be any casts or any delay in between Rune of Power and Arcane Power to ensure that Rune of Power is up for the entire duration of Arcane Power.`}>immediately</dfn> before Arcane Power - Failed {this.delayedRuneCast + this.noRuneCast} of {this.abilityTracker.getAbility(SPELLS.ARCANE_POWER.id).casts} casts.</li> : ''}
           {!this.hasOverpowered ? <li>You have more than 40% mana - Failed {this.lowManaCast} of {this.abilityTracker.getAbility(SPELLS.ARCANE_POWER.id).casts} casts.</li> : ''}  
         </ul>
         </>)

--- a/src/parser/mage/arcane/modules/features/ArcanePower.js
+++ b/src/parser/mage/arcane/modules/features/ArcanePower.js
@@ -251,16 +251,16 @@ class ArcanePower extends Analyzer {
   suggestions(when) {
     when(this.cooldownSuggestionThresholds)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<>You cast <SpellLink id={SPELLS.ARCANE_POWER.id} /> without properly setting up for it {this.badUses} times. Arcane Power has a short duration so it is important that you get the most out of it by ensuring you meet all of the below requirements before casting Arcane Power.
+        return suggest(<>You cast <SpellLink id={SPELLS.ARCANE_POWER.id} /> without proper setup {this.badUses} times. Arcane Power has a short duration so you should get the most out of it by meeting all requirements before casting it.
         <ul>
-          <li>You have 4 <SpellLink id={SPELLS.ARCANE_CHARGE.id} /> - Failed {this.lowChargesCast} of {this.abilityTracker.getAbility(SPELLS.ARCANE_POWER.id).casts} casts.</li>
-          {this.hasRuneOfPower ? <li>You cast <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} /> <dfn data-tip={`Arcane Power should be cast right on the end of the Rune of Power cast. There should not be any casts or any delay in between Rune of Power and Arcane Power to ensure that Rune of Power is up for the entire duration of Arcane Power.`}>immediately</dfn> before Arcane Power - Failed {this.delayedRuneCast + this.noRuneCast} of {this.abilityTracker.getAbility(SPELLS.ARCANE_POWER.id).casts} casts.</li> : ''}
-          {!this.hasOverpowered ? <li>You have more than 40% mana - Failed {this.lowManaCast} of {this.abilityTracker.getAbility(SPELLS.ARCANE_POWER.id).casts} casts.</li> : ''}  
+          <li>You have 4 <SpellLink id={SPELLS.ARCANE_CHARGE.id} /> - You had this {this.abilityTracker.getAbility(SPELLS.ARCANE_POWER.id).casts - this.lowChargesCast} out of {this.abilityTracker.getAbility(SPELLS.ARCANE_POWER.id).casts} casts.</li>
+          {this.hasRuneOfPower ? <li>You cast <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} /> <dfn data-tip={`Arcane Power should be cast right on the end of the Rune of Power cast. There should not be any casts or any delay in between Rune of Power and Arcane Power to ensure that Rune of Power is up for the entire duration of Arcane Power.`}>immediately</dfn> before Arcane Power - You did this {this.abilityTracker.getAbility(SPELLS.ARCANE_POWER.id).casts - (this.delayedRuneCast + this.noRuneCast)} out of {this.abilityTracker.getAbility(SPELLS.ARCANE_POWER.id).casts} casts.</li> : ''}
+          {!this.hasOverpowered ? <li>You have more than 40% mana - You had this {this.abilityTracker.getAbility(SPELLS.ARCANE_POWER.id).casts - this.lowManaCast} out of {this.abilityTracker.getAbility(SPELLS.ARCANE_POWER.id).casts} casts.</li> : ''}  
         </ul>
         </>)
           .icon(SPELLS.ARCANE_POWER.icon)
-          .actual(`${formatPercentage(this.cooldownUtilization)}% Utilization`)
-          .recommended(`${formatPercentage(recommended)}% is recommended`);
+          .actual(`${this.badUses} Bad Casts`)
+          .recommended(`0 is recommended`);
       });
     when(this.castSuggestionThresholds)
       .addSuggestion((suggest, actual, recommended) => {

--- a/src/parser/mage/arcane/modules/features/RuleOfThrees.js
+++ b/src/parser/mage/arcane/modules/features/RuleOfThrees.js
@@ -24,7 +24,7 @@ class RuleOfThrees extends Analyzer {
 		if (spellId !== SPELLS.ARCANE_BARRAGE.id) {
 			return;
 		}
-		if (this.selectedCombatant.hasBuff(SPELLS.RULE_OF_THREES_BUFF.id)) {
+		if (this.selectedCombatant.hasBuff(SPELLS.RULE_OF_THREES_BUFF.id,event.timestamp + 1)) {
 			debug && this.log("Arcane Barrage with Rule of Threes Buff");
 			this.barrageWithRuleOfThrees += 1;
 		}

--- a/src/parser/mage/arcane/normalizers/ArcaneCharges.js
+++ b/src/parser/mage/arcane/normalizers/ArcaneCharges.js
@@ -4,15 +4,11 @@ import SPELLS from 'common/SPELLS';
 
 const ARCANE_CHARGE_SPELLS = [
   SPELLS.ARCANE_BLAST.id,
+  SPELLS.ARCANE_EXPLOSION.id,
   SPELLS.CHARGED_UP_TALENT.id,
-  SPELLS.GALVANIZING_SPARK.id,
 ];
 
 class ArcaneCharges extends EventsNormalizer {
-  /**
-   * @param {Array} events
-   * @returns {Array}
-   */
 
     /** Ensures that the Energize events to give the player Arcane Charges is always after the Cast event if they happen at the same time. 
     * This is primarily because when the cast completes it calculates damage based on the charges the player had when the spell completed,

--- a/src/parser/mage/arcane/normalizers/ArcaneCharges.js
+++ b/src/parser/mage/arcane/normalizers/ArcaneCharges.js
@@ -1,5 +1,12 @@
 
 import EventsNormalizer from 'parser/core/EventsNormalizer';
+import SPELLS from 'common/SPELLS';
+
+const ARCANE_CHARGE_SPELLS = [
+  SPELLS.ARCANE_BLAST.id,
+  SPELLS.CHARGED_UP_TALENT.id,
+  SPELLS.GALVANIZING_SPARK.id,
+];
 
 class ArcaneCharges extends EventsNormalizer {
   /**
@@ -18,7 +25,7 @@ class ArcaneCharges extends EventsNormalizer {
     events.forEach((event, eventIndex) => {
       fixedEvents.push(event);
 
-      if (event.type === 'cast') {
+      if (event.type === 'cast' && ARCANE_CHARGE_SPELLS.includes(event.ability.guid)) {
         const castTimestamp = event.timestamp;
 
         for (let previousEventIndex = eventIndex; previousEventIndex >= 0; previousEventIndex -= 1) {

--- a/src/parser/mage/arcane/normalizers/ArcanePower.js
+++ b/src/parser/mage/arcane/normalizers/ArcanePower.js
@@ -1,0 +1,37 @@
+import SPELLS from 'common/SPELLS';
+
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+
+class ArcanePowerNormalizer extends EventsNormalizer {
+  /**
+   * @param {Array} events
+   * @returns {Array}
+   */
+  normalize(events) {
+    const fixedEvents = [];
+    events.forEach((event, eventIndex) => {
+      fixedEvents.push(event);
+
+      if (event.type === 'cast' && event.ability.guid === SPELLS.ARCANE_POWER.id) {
+        const castTimestamp = event.timestamp;
+
+        for (let previousEventIndex = eventIndex; previousEventIndex >= 0; previousEventIndex -= 1) {
+          const previousEvent = fixedEvents[previousEventIndex];
+          if ((castTimestamp - previousEvent.timestamp) > 50) {
+            break;
+          }
+          if (previousEvent.type === 'applybuff' && previousEvent.ability.guid === SPELLS.ARCANE_POWER.id && previousEvent.sourceID === event.sourceID) {
+            fixedEvents.splice(previousEventIndex, 1);
+            fixedEvents.push(previousEvent);
+            previousEvent.__modified = true;
+            break;
+          }
+        }
+      }
+    });
+
+    return fixedEvents;
+  }
+}
+
+export default ArcanePowerNormalizer;

--- a/src/parser/mage/arcane/normalizers/ArcanePower.js
+++ b/src/parser/mage/arcane/normalizers/ArcanePower.js
@@ -3,10 +3,9 @@ import SPELLS from 'common/SPELLS';
 import EventsNormalizer from 'parser/core/EventsNormalizer';
 
 class ArcanePowerNormalizer extends EventsNormalizer {
-  /**
-   * @param {Array} events
-   * @returns {Array}
-   */
+
+  //Ensures that the apply buff event for Arcane Power is sorted after the Arcane Power cast.
+
   normalize(events) {
     const fixedEvents = [];
     events.forEach((event, eventIndex) => {


### PR DESCRIPTION
- Fixed Arcane Charge Normalizer so that it will put the energize events after the cast that generated them, but before the Arcane Barrage cast if they were cast on the same time stamp.
- Fixed bug in Rule of Threes where it would count Arcane Barrage as being cast with the Rule of Threes active if Rule of Threes was removed on the same timestamp as the Arcane Barrage cast (even if the Remove Buff event happened first)
- Modified Arcane Power module to count each pre-req separately and use only failed checks for determining utilization instead of failed casts.
- Updated Arcane Power tooltip and suggestion to show which checks were failed

For the AP Change, the difference here is that before these changes, if you cast Arcane Power twice and you missed one check on one of the casts, your utilization is 50%. After the changes, if it checks 3 things per cast and you miss one check on one cast, your utilization is 83% (5/6). Additionally, the players in mage discord were complaining that there is no way to tell which checks you failed aside from pouring over events and timelines. Im not completely sold on this way of displaying it, but it works until i can come up with a better solution.

Fixes #2425 