### PR TITLE
[Prot Pal] Fixed bug in SotR module

### DIFF
--- a/src/parser/paladin/protection/modules/features/ShieldOfTheRighteous.js
+++ b/src/parser/paladin/protection/modules/features/ShieldOfTheRighteous.js
@@ -114,7 +114,9 @@ class ShieldOfTheRighteous extends Analyzer {
   }
 
   on_finished(event) {
-    this._markupCast(this._activeCast);
+    if(this._activeCast) {
+      this._markupCast(this._activeCast);
+    }
     this._futureCasts.forEach(this._markupCast.bind(this));
   }
 


### PR DESCRIPTION
Fixed a bug revealed by [this log](https://wowanalyzer.com/report/a3zyYvVfBDgPFrTc/6-Heroic+Zul+-+Kill+(3:32)/10-%D0%A4%D0%B8%D1%80%D1%81%D0%B1%D1%80%D1%83%D1%82). `this._markupCast` was being called on an undefined `_activeCast`.