### PR TITLE
[Enhancement Shaman] Disabling the Flametongue Refresh module if Searing Assault talent is taken

### DIFF
--- a/src/parser/shaman/enhancement/modules/core/FlametongueRefresh.js
+++ b/src/parser/shaman/enhancement/modules/core/FlametongueRefresh.js
@@ -10,7 +10,11 @@ class FlametongueRefresh extends Analyzer {
   flametongueCasts = 0;
   earlyRefresh = 0;
   refreshPercentageCast = 0;
-  hasSearingAssaultTalent = this.selectedCombatant.hasTalent(SPELLS.SEARING_ASSAULT_TALENT.id);
+
+  constructor(...args) {
+    super(...args);
+    this.active = !this.selectedCombatant.hasTalent(SPELLS.SEARING_ASSAULT_TALENT.id);
+  }
 
   on_byPlayer_cast(event) {
     if(event.ability.guid === SPELLS.FLAMETONGUE.id) {
@@ -27,7 +31,7 @@ class FlametongueRefresh extends Analyzer {
   }
 
   on_byPlayer_refreshbuff(event) {
-    if(!this.hasSearingAssaultTalent && event.ability.guid === SPELLS.FLAMETONGUE_BUFF.id) {
+    if(event.ability.guid === SPELLS.FLAMETONGUE_BUFF.id) {
       if(this.flametongueTimestamp !== 0) {
         if(event.timestamp - this.flametongueTimestamp < PANDEMIC_THRESHOLD) {
           this.earlyRefresh += 1;

--- a/src/parser/shaman/enhancement/modules/core/FlametongueRefresh.test.js
+++ b/src/parser/shaman/enhancement/modules/core/FlametongueRefresh.test.js
@@ -1,0 +1,30 @@
+import FlametongueRefresh from './FlametongueRefresh';
+import SPELLS from 'common/SPELLS';
+
+describe('Flametongue Refresh module', () => {
+    it('should be disabled when Searing assault is taken', () => {
+        const ownerWithSearingAssault = {
+            selectedCombatant: {
+                hasTalent: jest.fn(() => true),
+            },
+            addEventListener: jest.fn(),
+        };
+
+        const module = new FlametongueRefresh({owner: ownerWithSearingAssault});
+        expect(module.active).toBe(false);
+        expect(ownerWithSearingAssault.selectedCombatant.hasTalent).toHaveBeenCalledWith(SPELLS.SEARING_ASSAULT_TALENT.id);
+    });
+
+    it('should be enabled when Searing assault is not taken', () => {
+        const ownerWithSearingAssault = {
+            selectedCombatant: {
+                hasTalent: jest.fn(() => false),
+            },
+            addEventListener: jest.fn(),
+        };
+
+        const module = new FlametongueRefresh({owner: ownerWithSearingAssault});
+        expect(module.active).toBe(true);
+        expect(ownerWithSearingAssault.selectedCombatant.hasTalent).toHaveBeenCalledWith(SPELLS.SEARING_ASSAULT_TALENT.id);
+    });
+});


### PR DESCRIPTION
Changes as suggested in the comments of #2437

Changing the disabling of the Flametongue Refresh module from a bool check in an `if` statement to just disabling the module if Searing Assault is taken.

Also added a test for just the enabling/disabling part of the module.