### PR TITLE
Fix for heroic leap

### DIFF
--- a/src/parser/warrior/fury/modules/Abilities.js
+++ b/src/parser/warrior/fury/modules/Abilities.js
@@ -173,7 +173,7 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.HEROIC_LEAP_FURY,
+        spell: SPELLS.HEROIC_LEAP,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         buffSpellId: SPELLS.BOUNDING_STRIDE_BUFF.id,
         cooldown: (haste, combatant) => 45 - (combatant.hasTalent(SPELLS.BOUNDING_STRIDE_TALENT.id) ? 15 : 0),


### PR DESCRIPTION
https://wowanalyzer.com/report/v2BRda7cVT6nfktw/29-Normal+Mythrax+-+Kill+(7:23)/16-Deadlywarior
Log was causing a redering error due to ID
Based on the log i updated the heroic leap to match the id
Seems no need for separate fury spell

![image](https://user-images.githubusercontent.com/9600587/46971657-9e9db500-d08a-11e8-92c1-28ced9f40f23.png)
