### PR TITLE
Extend the precast FireElemental checker for StormElemental

### DIFF
--- a/src/parser/shaman/elemental/CombatLogParser.js
+++ b/src/parser/shaman/elemental/CombatLogParser.js
@@ -5,7 +5,7 @@ import Abilities from './modules/Abilities';
 import Overload from './modules/features/Overload';
 
 import FlameShock from './modules/core/FlameShock';
-import FireElemental from './modules/features/FireElemental';
+import StormFireElemental from './modules/features/StormFireElemental';
 
 import Aftershock from './modules/talents/Aftershock';
 import Ascendance from './modules/talents/Ascendance';
@@ -38,7 +38,7 @@ class CombatLogParser extends CoreCombatLogParser {
     abilities: Abilities,
     flameShock: FlameShock,
     overload: Overload,
-    fireElemental: FireElemental,
+    stormfireElemental: StormFireElemental,
 
     // Talents
     aftershock: Aftershock,

--- a/src/parser/shaman/elemental/modules/features/StormFireElemental.js
+++ b/src/parser/shaman/elemental/modules/features/StormFireElemental.js
@@ -1,8 +1,9 @@
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from "common/SPELLS/shaman";
+import TALENTS from "common/SPELLS/talents/shaman";
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 
-class FireElemental extends Analyzer {
+class StormFireElemental extends Analyzer {
 
   static dependencies = {
     spellUsable:SpellUsable,
@@ -10,24 +11,22 @@ class FireElemental extends Analyzer {
 
   last_pet_summon_timeStamp=null;
 
+  summon_spell = this.selectedCombatant.hasTalent(TALENTS.STORM_ELEMENTAL_TALENT.id) ? 192249 : SPELLS.FIRE_ELEMENTAL.id;
 
-  on_byPlayerPet_damage(event) {
-      const spellId = event.ability.guid;
-      if (spellId !== SPELLS.FIRE_ELEMENTAL_FIRE_BLAST.id) {
-        return;
-      }
+
+  on_byPlayerPet_damage(event){
       if(this.last_pet_summon_timeStamp===null){
-        this.spellUsable.beginCooldown(SPELLS.FIRE_ELEMENTAL.id);
+        this.spellUsable.beginCooldown(this.summon_spell, event.timestamp);
         this.last_pet_summon_timeStamp=event.timestamp;
       }
   }
   on_byPlayer_summon(event) {
     const spellId = event.ability.guid;
-    if (spellId !== SPELLS.SUMMON_FIRE_ELEMENTAL.id) {
+    if (spellId !== this.summon_spell) {
       return;
     }
     this.last_pet_summon_timeStamp=event.timestamp;
   }
 }
 
-export default FireElemental;
+export default StormFireElemental;

--- a/src/parser/shaman/elemental/modules/features/StormFireElemental.js
+++ b/src/parser/shaman/elemental/modules/features/StormFireElemental.js
@@ -8,21 +8,44 @@ class StormFireElemental extends Analyzer {
   static dependencies = {
     spellUsable:SpellUsable,
   };
+  elementalData = {
+    FireElemental: {
+      summon: SPELLS.FIRE_ELEMENTAL.id,
+      damageSpells: [
+        SPELLS.FIRE_ELEMENTAL_FIRE_BLAST.id,
+        SPELLS.FIRE_ELEMENTAL_METEOR.id,
+        SPELLS.FIRE_ELEMENTAL_IMMOLATE.id,
+      ],
+    },
+    StormElemental: {
+      summon: TALENTS.STORM_ELEMENTAL_TALENT,
+      damageSpells: [
+        SPELLS.EYE_OF_THE_STORM.id,
+        SPELLS.WIND_GUST.id,
+        SPELLS.CALL_LIGHTNING.id,
+      ],
+    },
+  };
 
   last_pet_summon_timeStamp=null;
 
-  summon_spell = this.selectedCombatant.hasTalent(TALENTS.STORM_ELEMENTAL_TALENT.id) ? 192249 : SPELLS.FIRE_ELEMENTAL.id;
+  relevantData = this.selectedCombatant.hasTalent(TALENTS.STORM_ELEMENTAL_TALENT.id) ? this.data.StormElemental : this.data.FireElemental;
 
 
   on_byPlayerPet_damage(event){
-      if(this.last_pet_summon_timeStamp===null){
-        this.spellUsable.beginCooldown(this.summon_spell, event.timestamp);
-        this.last_pet_summon_timeStamp=event.timestamp;
+      if(this.last_pet_summon_timeStamp!==null) {
+        return;
       }
+      if(!this.relevant.damageSpells.includes(event.ability.guid)) {
+        return;
+      }
+      this.spellUsable.beginCooldown(this.summon_spell, event.timestamp);
+      this.last_pet_summon_timeStamp=event.timestamp;
+
   }
   on_byPlayer_summon(event) {
     const spellId = event.ability.guid;
-    if (spellId !== this.summon_spell) {
+    if (spellId !== this.relevant.summon) {
       return;
     }
     this.last_pet_summon_timeStamp=event.timestamp;

--- a/src/parser/shaman/elemental/modules/features/StormFireElemental.js
+++ b/src/parser/shaman/elemental/modules/features/StormFireElemental.js
@@ -36,7 +36,7 @@ class StormFireElemental extends Analyzer {
       if(this.last_pet_summon_timeStamp!==null) {
         return;
       }
-      if(!this.relevant.damageSpells.includes(event.ability.guid)) {
+      if(!this.relevantData.damageSpells.includes(event.ability.guid)) {
         return;
       }
       this.spellUsable.beginCooldown(this.summon_spell, event.timestamp);


### PR DESCRIPTION
title.

Depends on the fact that Fire and Storm Elementals count as the only pets so it should works as long as there are no trinkets, azerite traits or w/e that spawn "pets" in the sense of the "byPlayerPet_damage" check.

AFAIK and what I checked the only thing I can think of is Echo Of The Elementals Trait whit which the logic still works because the casts are interlinked.

TBF Storm Elemental should not be cast precombat anyway, because it is a .05% damage loss, so it shouldn't be relevant for anyone who plays a proper rotation ^^


Checked with **https://www.warcraftlogs.com/reports/gxWQvyP9dbDtkHpw/#fight=3&source=24**