### PR TITLE
[BrM] Added Purifying Brew checklist item

### DIFF
--- a/src/parser/monk/brewmaster/CHANGELOG.js
+++ b/src/parser/monk/brewmaster/CHANGELOG.js
@@ -8,8 +8,13 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-10-15'),
+    changes: <>Added <SpellLink id={SPELLS.PURIFYING_BREW.id} /> checklist item.</>,
+    contributors: [emallson],
+  },
+  {
     date: new Date('2018-10-02'),
-    changes: <React.Fragment>Re-enabled the <SpellLink id={SPELLS.MASTERY_ELUSIVE_BRAWLER.id} /> module and added additional distribution information to it.</React.Fragment>,
+    changes: <>Re-enabled the <SpellLink id={SPELLS.MASTERY_ELUSIVE_BRAWLER.id} /> module and added additional distribution information to it.</>,
     contributors: [emallson],
   },
   {

--- a/src/parser/monk/brewmaster/CONFIG.js
+++ b/src/parser/monk/brewmaster/CONFIG.js
@@ -19,7 +19,7 @@ export default {
     <>
       Hello, and welcome to the Brewmaster Analyzer! This analyzer is maintained by <a href="//raider.io/characters/us/arthas/Eisenpelz"><code>emallson</code></a>, and there are currently no known issues.<br />
 
-      If you have questions about the output, please ask in the <code>#brew_questions</code> channel of the <a href="http://discord.gg/peakofserenity">Peak of Serenity</a>. If you have theorycrafting questions or want to contribute, come say hi in <code>#craft-brewing</code>.
+      If you have questions about the output, please ask in the <code>#brew-questions</code> channel of the <a href="http://discord.gg/peakofserenity">Peak of Serenity</a>. If you have theorycrafting questions or want to contribute, come say hi in <code>#craft-brewing</code>.
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.

--- a/src/parser/monk/brewmaster/modules/features/StaggerPoolGraph.js
+++ b/src/parser/monk/brewmaster/modules/features/StaggerPoolGraph.js
@@ -128,14 +128,6 @@ class StaggerPoolGraph extends Analyzer {
       }
     }
 
-    const purifiesByLabels = Object.keys(poolByLabels).map(label => {
-      if (purifies.includes(Number(label))) {
-        return poolByLabels[label];
-      } else {
-        return undefined;
-      }
-    });
-
     const deathsByLabels = Object.keys(hpByLabels).map(label => {
       const deathEvent = deaths.find(event => event.label === Number(label));
       if (!!deathEvent) {
@@ -144,6 +136,8 @@ class StaggerPoolGraph extends Analyzer {
         return undefined;
       }
     });
+
+    const labelIndices = Object.keys(poolByLabels).reduce ((obj, label, index) => { obj[label] = index; return obj; }, {});
 
     // some labels are referred to later for drawing tooltips
     const DEATH_LABEL = 'Player Death';
@@ -179,11 +173,11 @@ class StaggerPoolGraph extends Analyzer {
         },
         {
           label: PURIFY_LABEL,
-          pointBackgroundColor: '#00ff96',
           backgroundColor: '#00ff96',
-          data: purifiesByLabels,
-          fillOpacity: 0,
+          data: purifies.map(label => { return { x: labelIndices[String(label)], y: poolByLabels[String(label)] }; }),
+          type: 'scatter',
           pointRadius: 4,
+          showLine: false,
         },
         {
           label: STAGGER_LABEL,
@@ -227,7 +221,7 @@ class StaggerPoolGraph extends Analyzer {
           options={{
             tooltips: {
               callbacks: {
-                label: labelItem,
+                label: labelItem.bind(this),
               },
             },
             legend: {

--- a/src/parser/monk/brewmaster/modules/features/checklist/Component.js
+++ b/src/parser/monk/brewmaster/modules/features/checklist/Component.js
@@ -78,6 +78,22 @@ class BrewmasterMonkChecklist extends React.PureComponent {
           )}
           thresholds={thresholds.isbClipping} />
       </Rule>
+      <Rule name={<>Use <SpellLink id={SPELLS.PURIFYING_BREW.id} /> effectively</>}
+        description={
+          <>
+            Effective use of <SpellLink id={SPELLS.PURIFYING_BREW.id} /> is fundamental to playing Brewmaster successfully. While we cannot <em>automatically</em> tell whether a purify is effective or not, there are some simple guidelines that naturally lead to more effective purifies:
+            <ul>
+              <li>Avoid casting <SpellLink id={SPELLS.PURIFYING_BREW.id} /> at less than <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} />. In a raid environment, <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} /> is not dangerous in itself. You should almost never purify lower than this unless you cannot be healed.</li>
+              <li>If you are going to purify a hit, do so as soon as possible after it lands. Every half-second delayed after the hit causes you to take 5% of the hit's damage from <SpellLink id={SPELLS.STAGGER.id} />.</li>
+            </ul>
+            For more information on effective use of <SpellLink id={SPELLS.PURIFYING_BREW.id} />, see the <a href="https://www.peakofserenity.com/bfa/brewmaster/purifying/">Peak of Serenity guide</a>.
+          </>
+        }
+      >
+        <Requirement name={<>Purifies with less than <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} /></>} thresholds={thresholds.purifyHeavy} />
+        <Requirement name={'Average Purification Delay'} thresholds={thresholds.purifyDelay} 
+          tooltip="The delay is tracked from the most recent time you were able to purify after a hit. If the hit occurred when no charges were available, you are not penalized." />
+      </Rule>
       <Rule
         name={'Top the DPS Charts'}
         description={

--- a/src/parser/monk/brewmaster/modules/features/checklist/Module.js
+++ b/src/parser/monk/brewmaster/modules/features/checklist/Module.js
@@ -5,6 +5,7 @@ import CastEfficiency from 'parser/shared/modules/CastEfficiency';
 import PreparationRuleAnalyzer from 'parser/shared/modules/features/Checklist2/PreparationRuleAnalyzer';
 
 import IronSkinBrew from '../../spells/IronSkinBrew';
+import PurifyingBrew from '../../spells/PurifyingBrew';
 import BrewCDR from '../../core/BrewCDR';
 import BreathOfFire from '../../spells/BreathOfFire';
 import TigerPalm from '../../spells/TigerPalm';
@@ -20,6 +21,7 @@ class Checklist extends Analyzer {
 
     bof: BreathOfFire,
     isb: IronSkinBrew,
+    pb: PurifyingBrew,
     brewcdr: BrewCDR,
     tp: TigerPalm,
     rjw: RushingJadeWind,
@@ -35,6 +37,8 @@ class Checklist extends Analyzer {
           ...this.preparationRuleAnalyzer.thresholds,
 
           isb: this.isb.uptimeSuggestionThreshold,
+          purifyHeavy: this.pb.purifyHeavySuggestion,
+          purifyDelay: this.pb.purifyDelaySuggestion,
           totalCDR: this.brewcdr.suggestionThreshold,
           isbClipping: this.isb.clipSuggestionThreshold,
           bof: this.bof.suggestionThreshold,

--- a/src/parser/monk/brewmaster/modules/spells/PurifyingBrew.js
+++ b/src/parser/monk/brewmaster/modules/spells/PurifyingBrew.js
@@ -4,20 +4,48 @@ import { formatNumber, formatPercentage } from 'common/format';
 import SpellIcon from 'common/SpellIcon';
 import SPELLS from 'common/SPELLS';
 import Analyzer from 'parser/core/Analyzer';
-import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import StatisticBox from 'interface/others/StatisticBox';
 
 import SharedBrews from '../core/SharedBrews';
+
+const PURIFY_DELAY_THRESHOLD = 1250; // 1.25s, gives a bit of flexibility in case the brew-GCD is rolling right when a hit comes in
+
+function markupPurify(event, delay, hasHeavyStagger) {
+  const msgs = [];
+  if(delay > PURIFY_DELAY_THRESHOLD) {
+    msgs.push(`<li>You delayed casting it for <b>${(delay / 1000).toFixed(2)}s</b>, allowing Stagger to tick down.</li>`);
+  }
+  if(!hasHeavyStagger) {
+    msgs.push(`<li>You cast without reaching at least Heavy Stagger, which is <em>almost always</em> inefficient.</li>`);
+  }
+
+  if(msgs.length === 0) {
+    return;
+  }
+  const meta = event.meta || {};
+  meta.isInefficientCast = true;
+  meta.inefficientCastReason = `This Purifying Brew cast was inefficient because:<ul>${msgs.join('')}</ul>`;
+  event.meta = meta;
+}
 
 class PurifyingBrew extends Analyzer {
   static dependencies = {
     brews: SharedBrews,
+    spells: SpellUsable,
   };
 
   purifyAmounts = [];
+  purifyDelays = [];
 
   heavyPurifies = 0;
 
+  // used to track heavy stagger for when the debuff drops just before the
+  // cast event happens
   _heavyStaggerDropped = false;
+
+  _lastHit = null;
+  _msTilPurify = 0;
 
   on_byPlayer_removedebuff(event) {
     if (event.ability.guid === SPELLS.HEAVY_STAGGER_DEBUFF.id) {
@@ -57,14 +85,40 @@ class PurifyingBrew extends Analyzer {
     return this.purifyAmounts.length;
   }
 
+  get avgPurifyDelay() {
+    if(this.purifyDelays.length === 0) {
+      return 0;
+    }
+    return this.purifyDelays.reduce((delay, total) => total + delay) / this.purifyDelays.length;
+  }
+
+  on_addstagger(event) {
+    this._lastHit = event;
+    this._msTilPurify = this.spells.isAvailable(SPELLS.PURIFYING_BREW.id) ? 0 : this.spells.cooldownRemaining(SPELLS.PURIFYING_BREW.id);
+  }
+
   on_removestagger(event) {
+    // tracking gap from peak --- ideally you want to purify as close to
+    // a peak as possible, but if no purify charges are available we
+    // want to get the new pooled amount
+    const gap = event.timestamp - this._lastHit.timestamp;
+    if(event.trigger.ability.guid === SPELLS.STAGGER.id && this._msTilPurify - gap > 0) {
+      this._msTilPurify = Math.max(0, this._msTilPurify - gap);
+      this._lastHit = event;
+    }
+
+    // tracking purification
     if (!event.trigger.ability || event.trigger.ability.guid !== SPELLS.PURIFYING_BREW.id) {
-      // reset this, death or another ability took us out of heavy stagger
+      // reset this, if we lost heavy stagger then death or another ability took us out of heavy stagger
       this._heavyStaggerDropped = false;
       return;
     }
     this.purifyAmounts.push(event.amount);
-    if (this.selectedCombatant.hasBuff(SPELLS.HEAVY_STAGGER_DEBUFF.id) || this._heavyStaggerDropped) {
+    const delay = event.timestamp - this._lastHit.timestamp - this._msTilPurify;
+    this.purifyDelays.push(delay);
+    const hasHeavyStagger = this.selectedCombatant.hasBuff(SPELLS.HEAVY_STAGGER_DEBUFF.id) || this._heavyStaggerDropped;
+    markupPurify(event.trigger, delay, hasHeavyStagger);
+    if (hasHeavyStagger) {
       this.heavyPurifies += 1;
     }
     this._heavyStaggerDropped = false;
@@ -78,11 +132,11 @@ class PurifyingBrew extends Analyzer {
         label="Avg. Mitigation per Purifying Brew"
         tooltip={`Purifying Brew removed <b>${formatNumber(this.totalPurified)}</b> damage in total over ${this.totalPurifies} casts.<br/>
                   The smallest purify removed <b>${formatNumber(this.minPurify)}</b> and the largest purify removed <b>${formatNumber(this.maxPurify)}</b>.<br/>
-                  You purified <b>${this.badPurifies}</b> (${formatPercentage(this.badPurifies / this.totalPurifies)}%) times without reaching Heavy Stagger.`}
+                  You purified <b>${this.badPurifies}</b> (${formatPercentage(this.badPurifies / this.totalPurifies)}%) times without reaching Heavy Stagger.<br/>
+                  Your purifies were delayed from the nearest peak by <b>${(this.avgPurifyDelay / 1000).toFixed(2)}s</b> on average.`}
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL();
 }
 
 export default PurifyingBrew;

--- a/src/parser/monk/brewmaster/modules/spells/PurifyingBrew.js
+++ b/src/parser/monk/brewmaster/modules/spells/PurifyingBrew.js
@@ -14,7 +14,7 @@ const PURIFY_DELAY_THRESHOLD = 1250; // 1.25s, gives a bit of flexibility in cas
 function markupPurify(event, delay, hasHeavyStagger) {
   const msgs = [];
   if(delay > PURIFY_DELAY_THRESHOLD) {
-    msgs.push(`<li>You delayed casting it for <b>${(delay / 1000).toFixed(2)}s</b>, allowing Stagger to tick down.</li>`);
+    msgs.push(`<li>You delayed casting it for <b>${(delay / 1000).toFixed(2)}s</b> after being hit, allowing Stagger to tick down.</li>`);
   }
   if(!hasHeavyStagger) {
     msgs.push(`<li>You cast without reaching at least Heavy Stagger, which is <em>almost always</em> inefficient.</li>`);
@@ -89,7 +89,7 @@ class PurifyingBrew extends Analyzer {
     if(this.purifyDelays.length === 0) {
       return 0;
     }
-    return this.purifyDelays.reduce((delay, total) => total + delay) / this.purifyDelays.length;
+    return this.purifyDelays.reduce((total, delay) => total + delay) / this.purifyDelays.length;
   }
 
   on_addstagger(event) {
@@ -122,6 +122,30 @@ class PurifyingBrew extends Analyzer {
       this.heavyPurifies += 1;
     }
     this._heavyStaggerDropped = false;
+  }
+
+  get purifyDelaySuggestion() {
+    return {
+      actual: this.avgPurifyDelay / 1000,
+      isGreaterThan: {
+        minor: 1,
+        average: PURIFY_DELAY_THRESHOLD / 1000,
+        major: PURIFY_DELAY_THRESHOLD / 1000 + 1,
+      },
+      style: 'seconds',
+    };
+  }
+
+  get purifyHeavySuggestion() {
+    return {
+      actual: this.badPurifies / this.totalPurifies,
+      isGreaterThan: {
+        minor: 0.1,
+        average: 0.15,
+        major: 0.2,
+      },
+      style: 'percentage',
+    };
   }
 
   statistic() {


### PR DESCRIPTION
This has been a *long* time coming. I had been putting off doing this until I nailed down more than just "don't use it unless in heavy stagger". Recently, we had a discussion about *delays* after a peak in stagger which made me realize that its actually pretty easy to measure that. So, at long last, we have a reasonable checklist item for PB.

I'm too lazy to manually do a screenshot that has the delay tooltip, but the delay is only counted from the most recently available charge if no charges were available when you were hit. This means that, for example, if you take a big hit with 1s left on PB, then purify 1.5s after the hit, it counts as a .5s delay.

![screenshot from 2018-10-15 21-45-01](https://user-images.githubusercontent.com/4909458/46987828-d6751e80-d0c3-11e8-99ae-e063f6e36d67.png)
![screenshot from 2018-10-15 21-44-47](https://user-images.githubusercontent.com/4909458/46987829-d6751e80-d0c3-11e8-9890-75695d7ac7ff.png)
![screenshot from 2018-10-15 21-35-08](https://user-images.githubusercontent.com/4909458/46987830-d70db500-d0c3-11e8-804f-703d0796cfa8.png)
