### PR TITLE
[Restoration Shaman] Fix Chain Heal ordering

### DIFF
--- a/src/parser/shaman/restoration/modules/talents/HighTide.js
+++ b/src/parser/shaman/restoration/modules/talents/HighTide.js
@@ -16,6 +16,11 @@ const HEAL_WINDOW_MS = 150;
 const bounceReduction = 0.7;
 const bounceReductionHighTide = 0.85;
 
+/**
+ * High Tide:
+ * Chain Heal bounces to 1 additional target, and its falloff with each bounce is reduced by half.
+ */
+
 class HighTide extends Analyzer {
   static dependencies = {
     statTracker: StatTracker,
@@ -41,18 +46,40 @@ class HighTide extends Analyzer {
       return;
     }
 
-    // resets if its a new chain heal, can't use the cast event for this as its often somewhere in the middle of the healing events
+    // Detects new chain heal casts, can't use the cast event for this as its often somewhere in between its healing events
     if (!this.chainHealTimestamp || event.timestamp - this.chainHealTimestamp > HEAL_WINDOW_MS) {
       this.processBuffer();
       this.chainHealTimestamp = event.timestamp;
     }
 
-    const currentMastery = this.statTracker.currentMasteryPercentage;
+    /**
+     * Due to how Chain Heal interacts with the combatlog, we have to take a lot of extra steps here.
+     * Issues:
+     * 1. The healing events are backwards [5,4,3,2,1]
+     * 2. If the Shaman heals himself, his healing event is always first [3,5,4,2,1] (3 = Shaman)
+     * 3. If 2. happens, the heal on the shaman is also happening before the cast event, which the lines above already deal with.
+     * 
+     * Calculating out High Tide requires us to know the exact jump order, as High Tide affects each jump differently, you gain
+     * 0% heal on the initial hit but 100% healing on the last hit, compared to not having High Tide.
+     * https://ancestralguidance.com/hidden-spell-mechanics/
+     * The solution is to reorder the events into the correct hit order, which could be done since each consecutive heal is weaker
+     * than the one beforehand (by 15%), except, you have the Shaman mastery which will result in random healing numbers
+     * as each hit has a different mastery effectiveness - the higher the Shamans mastery, the more rapidly different the numbers end up.
+     * With traits like https://www.wowhead.com/spell=277942/ancestral-resonance existing, shamans mastery can randomly double or triple mid combat.
+     * 
+     * So we take 1 cast of chain heal at a time (5 hits maximum), calculate out crits and the mastery bonus, reorder them according to the new values
+     * (High healing to Low healing or [5,4,3,2,1] to [1,2,3,4,5]) and get the High Tide contribution by comparing the original heal valuesa gainst
+     * what a non-High Tide Chain Heal would have done each bounce (double the fall-off per hit and no 5th hit).
+     * 
+     * Things that are able to break the sorting: Deluge (Pls don't take it) as its undetectable, random player-based heal increases
+     * (possibly encounter mechanics) if not accounted for.
+     */
     let heal = event.amount + (event.absorb || 0) + (event.overheal || 0);
     if (event.hitType === HIT_TYPES.CRIT) {
       const critMult = this.critEffectBonus.getBonus(event);
       heal /= critMult;
     }
+    const currentMastery = this.statTracker.currentMasteryPercentage;
     const masteryEffectiveness = Math.max(0, 1 - (event.hitPoints - event.amount) / event.maxHitPoints);
     const baseHealingDone = heal / (1 + currentMastery * masteryEffectiveness);
 
@@ -60,13 +87,13 @@ class HighTide extends Analyzer {
       baseHealingDone: baseHealingDone,
       ...event,
     });
-
   }
 
   processBuffer() {
     this.buffer.sort((a, b) => parseFloat(b.baseHealingDone) - parseFloat(a.baseHealingDone));
 
     for (const [index, event] of Object.entries(this.buffer)) {
+      // 0%, 21%, 47%, 79%, (100%) increase per hit over not having High Tide, assuming no overheal thats a 46% total increase
       const FACTOR_CONTRIBUTED_BY_HT_HIT = (bounceReductionHighTide ** index) / (bounceReduction ** index) - 1;
 
       if (parseInt(index) === 4) {


### PR DESCRIPTION
Chain Heals combat log events are all over the place and mess up the High Tide analysis. Usually they're backwards (4 -> 3 -> 2 -> Initial) but if any of them hits the player it'll be the first entry. Can't do a normalizer for this as to order it correctly (even if it's only the player itself that's wrong), you'd need mastery effectiveness and current mastery rating - the normalizer happens before you get that information (current rating at least).
Example: 3rd Hit -> 4th Hit -> 2nd Hit -> 1st Hit
![image](https://user-images.githubusercontent.com/2842471/47002801-31dbf680-d12e-11e8-8a76-3a44d21b34d1.png)

I remove the variables affecting the heals (mastery, crits), buffer them and sort by their base + parse them when it has all events of a cast.