### PR TITLE
[Death Recap] Add absorbed healing

### DIFF
--- a/src/interface/others/DeathRecap.js
+++ b/src/interface/others/DeathRecap.js
@@ -144,7 +144,7 @@ class DeathRecap extends React.PureComponent {
                           `You healed yourself for ${formatNumber(event.amount)}` :
                           `${sourceName} healed you for ${formatNumber(event.amount)}`
                           }
-                          ${event.absorbed > 0 ? ` and ${formatNumber(event.absorbed)} of that healing was absorbed<br/>` : ''}
+                          ${event.absorbed > 0 ? `, ${formatNumber(event.absorbed)} of that healing was absorbed` : ''}
                           ${event.overheal > 0 ? ` and overhealed for ${formatNumber(event.overheal)}<br/>` : ''}
                         `} style={(event.amount === 0 && event.absorbed > 0) ? {color: 'orange'} : {color: 'green'}}>
                           +{formatNumber(event.amount)} {event.absorbed > 0 ? `(A: ${formatNumber(event.absorbed)} )` : ''} {event.overheal > 0 ? `(O: ${formatNumber(event.overheal)} )` : ''}

--- a/src/interface/others/DeathRecap.js
+++ b/src/interface/others/DeathRecap.js
@@ -144,9 +144,10 @@ class DeathRecap extends React.PureComponent {
                           `You healed yourself for ${formatNumber(event.amount)}` :
                           `${sourceName} healed you for ${formatNumber(event.amount)}`
                           }
+                          ${event.absorbed > 0 ? ` and ${formatNumber(event.absorbed)} of that healing was absorbed<br/>` : ''}
                           ${event.overheal > 0 ? ` and overhealed for ${formatNumber(event.overheal)}<br/>` : ''}
-                        `} style={{ color: 'green' }}>
-                          +{formatNumber(event.amount)} {event.overheal > 0 ? `(O: ${formatNumber(event.overheal)} )` : ''}
+                        `} style={(event.amount === 0 && event.absorbed > 0) ? {color: 'orange'} : {color: 'green'}}>
+                          +{formatNumber(event.amount)} {event.absorbed > 0 ? `(A: ${formatNumber(event.absorbed)} )` : ''} {event.overheal > 0 ? `(O: ${formatNumber(event.overheal)} )` : ''}
                         </dfn>
                       );
                     } else if (event.type === 'damage') {


### PR DESCRIPTION
Colored yellow unless there was effective healing.
Before
![image](https://user-images.githubusercontent.com/2842471/47091130-8c577e80-d224-11e8-9c8c-3d560242aa11.png)
After
![image](https://user-images.githubusercontent.com/2842471/47091147-94afb980-d224-11e8-988f-1cb392ba3483.png)
https://wowanalyzer.com/report/RMN8HfkdyhFCJ4vT/28-Mythic+Vectis+-+Wipe+12+(4:28)/111-Tianchu/death-recap