### PR TITLE
[Hpriest] Suggestion threshold updates

### DIFF
--- a/src/parser/priest/holy/modules/Abilities.js
+++ b/src/parser/priest/holy/modules/Abilities.js
@@ -24,6 +24,9 @@ class Abilities extends CoreAbilities {
         cooldown: 90, // todo: Account for Angel's Mercy if possible
         castEfficiency: {
           suggestion: true,
+          recommendedEfficiency: 0.35,
+          averageIssueEfficiency: 0.20,
+          majorIssueEfficiency: 0,
         },
       },
       {
@@ -36,6 +39,9 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
+          recommendedEfficiency: .45,
+          averageIssueEfficiency: 0.25,
+          majorIssueEfficiency: 0,
         },
       },
       {
@@ -48,6 +54,9 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
+          recommendedEfficiency: 0.45,
+          averageIssueEfficiency: 0.25,
+          majorIssueEfficiency: 0,
         },
       },
       {
@@ -59,6 +68,8 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
+          recommendedEfficiency: 0.01, // This spell should be cast at least one per encounter
+          majorIssueEfficiency: 0,
         },
       },
       {
@@ -71,6 +82,9 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
+          recommendedEfficiency: 0.45,
+          averageIssueEfficiency: 0.25,
+          majorIssueEfficiency: 0,
         },
       },
       {
@@ -235,6 +249,11 @@ class Abilities extends CoreAbilities {
         buffSpellId: SPELLS.GUARDIAN_SPIRIT.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 180, // guardian angel talent can reduce this
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.01, // This spell should be cast at least one per encounter
+          majorIssueEfficiency: 0,
+        },
       },
       {
         spell: SPELLS.LEAP_OF_FAITH,

--- a/src/parser/priest/holy/modules/Abilities.js
+++ b/src/parser/priest/holy/modules/Abilities.js
@@ -39,8 +39,8 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: .45,
-          averageIssueEfficiency: 0.25,
+          recommendedEfficiency: 0.30,
+          averageIssueEfficiency: 0.10,
           majorIssueEfficiency: 0,
         },
       },
@@ -54,8 +54,8 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: 0.45,
-          averageIssueEfficiency: 0.25,
+          recommendedEfficiency: 0.30,
+          averageIssueEfficiency: 0.10,
           majorIssueEfficiency: 0,
         },
       },
@@ -82,8 +82,8 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: 0.45,
-          averageIssueEfficiency: 0.25,
+          recommendedEfficiency: 0.30,
+          averageIssueEfficiency: 0.10,
           majorIssueEfficiency: 0,
         },
       },


### PR DESCRIPTION
These numbers were theory-crafted by the Holy Priest discord. The 1% suggestions are for abilities that just need to be cast one or more times during a fight.