### PR TITLE
Added Polymorph to spellbook

### DIFF
--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -498,3 +498,8 @@ export const Satyric = {
     link: 'https://worldofwarcraft.com/en-gb/character/ragnaros/Satyric',
   }],
 };
+export const jos3p = {
+  nickname: 'jos3p',
+  github: 'jos3p',
+  discord: 'jos3p#9746',
+};

--- a/src/common/SPELLS/mage.js
+++ b/src/common/SPELLS/mage.js
@@ -71,6 +71,72 @@ export default {
     name: 'Remove Curse',
     icon: 'spell_nature_removecurse',
   },
+  POLYMORPH_SHEEP: {
+    id: 118,
+    name: 'Polymorph',
+    icon: 'spell_nature_polymorph',
+  },
+  POLYMORPH_PIG: {
+    id: 28272,
+    name: 'Polymorph',
+    icon: 'spell_magic_polymorphpig',
+  },
+  POLYMORPH_BLACK_CAT: {
+    id: 61305,
+    name: 'Polymorph',
+    icon: 'achievement_halloween_cat_01',
+  },
+  POLYMORPH_MONKEY: {
+    id: 161354,
+    name: 'Polymorph',
+    icon: 'ability_hunter_aspectofthemonkey',
+  },
+  POLYMORPH_RABBIT: {
+    id: 61721,
+    name: 'Polymorph',
+    icon: 'spell_magic_polymorphrabbit',
+  },
+  POLYMORPH_POLAR_BEAR_CUB: {
+    id: 161353,
+    name: 'Polymorph',
+    icon: 'inv_pet_babyblizzardbear',
+  },
+  POLYMORPH_PORCUPINE: {
+    id: 126819,
+    name: 'Polymorph',
+    icon: 'inv_pet_porcupine',
+  },
+  POLYMORPH_TURTLE: {
+    id: 28271,
+    name: 'Polymorph',
+    icon: 'ability_hunter_pet_turtle',
+  }, 
+  POLYMORPH_TURKEY: {
+    id: 61780,
+    name: 'Polymorph',
+    icon: 'achievement_worldevent_thanksgiving',
+  }, 
+  POLYMORPH_PENGUIN: {
+    id: 161355,
+    name: 'Polymorph',
+    icon: 'inv_misc_penguinpet',
+  }, 
+  POLYMORPH_BUMBLEBEE: {
+    id: 277792,
+    name: 'Polymorph',
+    icon: 'inv_bee_default',
+  }, 
+  POLYMORPH_PEACOCK: {
+    id: 161372,
+    name: 'Polymorph',
+    icon: 'inv_pet_peacock_gold',
+  }, 
+  POLYMORPH_DIREHORN: {
+    id: 277787,
+    name: 'Polymorph',
+    icon: 'inv_pet_direhorn',
+  }, 
+
 
   //Frost
   MASTERY_ICICLES: {

--- a/src/parser/mage/arcane/modules/features/Abilities.js
+++ b/src/parser/mage/arcane/modules/features/Abilities.js
@@ -264,6 +264,19 @@ class Abilities extends CoreAbilities {
         },
         cooldown: 120,
       },
+      {
+        spell: [SPELLS.POLYMORPH_SHEEP, SPELLS.POLYMORPH_PIG, 
+          SPELLS.POLYMORPH_BLACK_CAT, SPELLS.POLYMORPH_MONKEY,
+          SPELLS.POLYMORPH_RABBIT, SPELLS.POLYMORPH_POLAR_BEAR_CUB,
+          SPELLS.POLYMORPH_PORCUPINE, SPELLS.POLYMORPH_TURTLE,
+          SPELLS.POLYMORPH_TURKEY, SPELLS.POLYMORPH_PENGUIN,
+          SPELLS.POLYMORPH_BUMBLEBEE, SPELLS.POLYMORPH_PEACOCK,
+          SPELLS.POLYMORPH_DIREHORN],
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        gcd: {
+          base: 1500,
+        },
+      },
     ];
   }
 }

--- a/src/parser/mage/fire/modules/features/Abilities.js
+++ b/src/parser/mage/fire/modules/features/Abilities.js
@@ -240,6 +240,19 @@ class Abilities extends CoreAbilities {
         },
         cooldown: 300,
       },
+      {
+        spell: [SPELLS.POLYMORPH_SHEEP, SPELLS.POLYMORPH_PIG, 
+          SPELLS.POLYMORPH_BLACK_CAT, SPELLS.POLYMORPH_MONKEY,
+          SPELLS.POLYMORPH_RABBIT, SPELLS.POLYMORPH_POLAR_BEAR_CUB,
+          SPELLS.POLYMORPH_PORCUPINE, SPELLS.POLYMORPH_TURTLE,
+          SPELLS.POLYMORPH_TURKEY, SPELLS.POLYMORPH_PENGUIN,
+          SPELLS.POLYMORPH_BUMBLEBEE, SPELLS.POLYMORPH_PEACOCK,
+          SPELLS.POLYMORPH_DIREHORN],
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        gcd: {
+          base: 1500,
+        },
+      },
     ];
   }
 }

--- a/src/parser/mage/frost/modules/features/Abilities.js
+++ b/src/parser/mage/frost/modules/features/Abilities.js
@@ -263,6 +263,19 @@ class Abilities extends CoreAbilities {
         enabled: !combatant.hasTalent(SPELLS.LONELY_WINTER_TALENT.id),
         cooldown: 30,
       },
+      {
+        spell: [SPELLS.POLYMORPH_SHEEP, SPELLS.POLYMORPH_PIG, 
+          SPELLS.POLYMORPH_BLACK_CAT, SPELLS.POLYMORPH_MONKEY,
+          SPELLS.POLYMORPH_RABBIT, SPELLS.POLYMORPH_POLAR_BEAR_CUB,
+          SPELLS.POLYMORPH_PORCUPINE, SPELLS.POLYMORPH_TURTLE,
+          SPELLS.POLYMORPH_TURKEY, SPELLS.POLYMORPH_PENGUIN,
+          SPELLS.POLYMORPH_BUMBLEBEE, SPELLS.POLYMORPH_PEACOCK,
+          SPELLS.POLYMORPH_DIREHORN],
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        gcd: {
+          base: 1500,
+        },
+      },
     ];
   }
 }


### PR DESCRIPTION
Added Polymorph to the spellbook and all mage specs.
It will always show up as Polymorph (Sheep) in the Abilities tab even if other variant was used..

Happy Hacktoberfest!