### PR TITLE
[BrM] fixed bug with purifying brew module & staggering strikes

### DIFF
--- a/src/parser/monk/brewmaster/modules/core/StaggerFabricator.js
+++ b/src/parser/monk/brewmaster/modules/core/StaggerFabricator.js
@@ -61,7 +61,7 @@ class StaggerFabricator extends Analyzer {
     //
     // other sources of flat reduction may also hit this condition
     this._staggerPool = Math.max(this._staggerPool, 0);
-    const staggerEvent = this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount);
+    const staggerEvent = this._fab(EVENT_STAGGER_POOL_REMOVED, event, amount, overage);
     this.owner.fabricateEvent(staggerEvent, event);
     if(this.ht && this.ht.active) {
       this._updateHaste(event, staggerEvent);
@@ -115,11 +115,12 @@ class StaggerFabricator extends Analyzer {
     this.removeStagger(event, amount);
   }
 
-  _fab(type, reason, amount) {
+  _fab(type, reason, amount, overage = 0) {
     return {
       timestamp: reason.timestamp,
       type: type,
-      amount: amount,
+      amount: amount + overage,
+      overheal: -overage,
       newPooledDamage: this._staggerPool,
       _reason: reason,
     };

--- a/src/parser/monk/brewmaster/modules/spells/PurifyingBrew.js
+++ b/src/parser/monk/brewmaster/modules/spells/PurifyingBrew.js
@@ -98,6 +98,12 @@ class PurifyingBrew extends Analyzer {
   }
 
   on_removestagger(event) {
+    if(this._lastHit === null) {
+      if(event.amount > 0) {
+        console.warn('Stagger removed but player hasn\'t been hit yet', event);
+      }
+      return; // no hit yet
+    }
     // tracking gap from peak --- ideally you want to purify as close to
     // a peak as possible, but if no purify charges are available we
     // want to get the new pooled amount


### PR DESCRIPTION
There are only 3 sources of purification in the game right now: PB, Stagger ticks, and SS. PB & Stagger ticks can only happen after you get hit (the game won't let you purify with an empty pool), but SS is tied to BoS and can be used without having anything in the stagger pool. This fixes that edge case in the `PurifyingBrew` module.