### PR TITLE
[BrM] another purifying brew fix

### DIFF
--- a/src/parser/monk/brewmaster/modules/spells/PurifyingBrew.js
+++ b/src/parser/monk/brewmaster/modules/spells/PurifyingBrew.js
@@ -108,7 +108,7 @@ class PurifyingBrew extends Analyzer {
     // a peak as possible, but if no purify charges are available we
     // want to get the new pooled amount
     const gap = event.timestamp - this._lastHit.timestamp;
-    if(event.trigger.ability.guid === SPELLS.STAGGER.id && this._msTilPurify - gap > 0) {
+    if(event.trigger.ability && event.trigger.ability.guid === SPELLS.STAGGER.id && this._msTilPurify - gap > 0) {
       this._msTilPurify = Math.max(0, this._msTilPurify - gap);
       this._lastHit = event;
     }


### PR DESCRIPTION
missed an important check that the `event.trigger` object has `.ability` before trying to access `.ability.guid`

side note: turns out death events don't have an `ability` associated with them

fixes errors with:
https://wowanalyzer.com/report/K2kVtAM4HNnDc9Pr/11-Mythic+Mythrax+-+Kill+(8:23)/4-Rngbrew
https://wowanalyzer.com/report/1qVA8G6P9rgabHJ4/2-Heroic+Taloc+-+Kill+(6:25)/3-T%C3%ADdes
and several more