### PR TITLE
Resto Druid - Clearcasting statistic text abundance fix

### DIFF
--- a/src/parser/druid/restoration/modules/features/Clearcasting.js
+++ b/src/parser/druid/restoration/modules/features/Clearcasting.js
@@ -26,7 +26,7 @@ class Clearcasting extends Analyzer {
   nonCCRegrowths = 0;
   totalRegrowths = 0;
   lowHealthRegrowthsNoCC = 0;
-  abundanceRegrowthNoCC = 0;
+  abundanceRegrowthsNoCC = 0;
 
   constructor(...args) {
     super(...args);
@@ -86,7 +86,7 @@ class Clearcasting extends Analyzer {
       this.nonCCRegrowths += 1;
       const abundance = this.selectedCombatant.getBuff(SPELLS.ABUNDANCE_BUFF.id);
       if (abundance) {
-        this.abundanceRegrowthNoCC += abundance.stacks >= ABUNDANCE_EXCEPTION_STACKS;
+        this.abundanceRegrowthsNoCC += abundance.stacks >= ABUNDANCE_EXCEPTION_STACKS;
       }
     }
   }
@@ -130,7 +130,7 @@ class Clearcasting extends Analyzer {
   }
 
   get nonCCRegrowthsPerMinute() {
-    return (this.nonCCRegrowths - (this.lowHealthRegrowthsNoCC + this.abundanceRegrowthNoCC)) / (this.owner.fightDuration / 60000);
+    return (this.nonCCRegrowths - (this.lowHealthRegrowthsNoCC + this.abundanceRegrowthsNoCC)) / (this.owner.fightDuration / 60000);
   }
 
   get nonCCRegrowthsSuggestionThresholds() {
@@ -176,7 +176,7 @@ class Clearcasting extends Analyzer {
             </ul>
             <b>${this.nonCCRegrowths} of your Regrowths were cast without a Clearcasting proc.</b>
             <b>${this.lowHealthRegrowthsNoCC}</b> of these were cast on targets with low health and
-            <b>${this.abundanceRegrowthNoCC}</b> of these were cast with more than ${ABUNDANCE_EXCEPTION_STACKS} stacks of abundance, so they have been disregarded as bad Regrowth(s).
+            <b>${this.abundanceRegrowthsNoCC}</b> of these were cast with more than ${ABUNDANCE_EXCEPTION_STACKS} stacks of abundance, so they have been disregarded as bad Regrowth(s).
             Using a clearcasting proc as soon as you get it should be one of your top priorities.
             Even if it overheals you still get that extra mastery stack on a target and the minor HoT.
             Spending your GCD on a free spell also helps with mana management in the long run.<br />

--- a/src/parser/druid/restoration/modules/features/Clearcasting.js
+++ b/src/parser/druid/restoration/modules/features/Clearcasting.js
@@ -26,6 +26,7 @@ class Clearcasting extends Analyzer {
   nonCCRegrowths = 0;
   totalRegrowths = 0;
   lowHealthRegrowthsNoCC = 0;
+  abundanceRegrowthNoCC = 0;
 
   constructor(...args) {
     super(...args);
@@ -82,11 +83,10 @@ class Clearcasting extends Analyzer {
       this.usedProcs += 1;
       debug && console.log(`Regrowth w/CC cast @${this.owner.formatTimestamp(event.timestamp)} - ${this.availableProcs} procs remaining`);
     } else {
-        const abundance = this.selectedCombatant.getBuff(SPELLS.ABUNDANCE_BUFF.id);
-        if (abundance) {
-          this.nonCCRegrowths += abundance.stacks < ABUNDANCE_EXCEPTION_STACKS;
-        } else {
-          this.nonCCRegrowths += 1;
+      this.nonCCRegrowths += 1;
+      const abundance = this.selectedCombatant.getBuff(SPELLS.ABUNDANCE_BUFF.id);
+      if (abundance) {
+        this.abundanceRegrowthNoCC += abundance.stacks >= ABUNDANCE_EXCEPTION_STACKS;
       }
     }
   }
@@ -130,7 +130,7 @@ class Clearcasting extends Analyzer {
   }
 
   get nonCCRegrowthsPerMinute() {
-    return (this.nonCCRegrowths - this.lowHealthRegrowthsNoCC) / (this.owner.fightDuration / 60000);
+    return (this.nonCCRegrowths - (this.lowHealthRegrowthsNoCC + this.abundanceRegrowthNoCC)) / (this.owner.fightDuration / 60000);
   }
 
   get nonCCRegrowthsSuggestionThresholds() {
@@ -175,7 +175,8 @@ class Clearcasting extends Analyzer {
               <li>Expired: <b>${this.expiredProcs}</b></li>
             </ul>
             <b>${this.nonCCRegrowths} of your Regrowths were cast without a Clearcasting proc.</b>
-            <b>${this.lowHealthRegrowthsNoCC}</b> of these were cast on targets with low health, so they have been disregarded as bad Regrowth(s).
+            <b>${this.lowHealthRegrowthsNoCC}</b> of these were cast on targets with low health and
+            <b>${this.abundanceRegrowthNoCC}</b> of these were cast with more than ${ABUNDANCE_EXCEPTION_STACKS} stacks of abundance, so they have been disregarded as bad Regrowth(s).
             Using a clearcasting proc as soon as you get it should be one of your top priorities.
             Even if it overheals you still get that extra mastery stack on a target and the minor HoT.
             Spending your GCD on a free spell also helps with mana management in the long run.<br />


### PR DESCRIPTION
Fixed an issue where the statistic for clearcasting was displaying incorrect regrowth information as a result of recent abundance change 