### PR TITLE
[BrM] Checklist updates, now featuring Anti-Fetid Log Meme technology

### DIFF
--- a/src/parser/monk/brewmaster/modules/Abilities.js
+++ b/src/parser/monk/brewmaster/modules/Abilities.js
@@ -75,6 +75,9 @@ class Abilities extends CoreAbilities {
         cooldown: haste => brew_cooldown / (1 + haste),
         charges: combatant.hasTalent(SPELLS.LIGHT_BREWING_TALENT.id) ? 4 : 3,
         gcd: null,
+        castEfficiency: {
+          recommendedEfficiency: 0.9,
+        },
       },
       {
         spell: SPELLS.BLACK_OX_BREW_TALENT,

--- a/src/parser/monk/brewmaster/modules/features/checklist/Component.js
+++ b/src/parser/monk/brewmaster/modules/features/checklist/Component.js
@@ -39,9 +39,12 @@ class BrewmasterMonkChecklist extends React.PureComponent {
             </>
           }
         >
-      <Requirement
-        name={<>Hits mitigated with <SpellLink id={SPELLS.IRONSKIN_BREW.id} /></>}
-        thresholds={thresholds.isb} />
+        <Requirement
+          name={<>Hits mitigated with <SpellLink id={SPELLS.IRONSKIN_BREW.id} /></>}
+          thresholds={thresholds.isb} />
+        <AbilityRequirement spell={SPELLS.IRONSKIN_BREW.id}
+          name={<><SpellLink id={SPELLS.IRONSKIN_BREW.id} /> Cast Efficiency</>} 
+          tooltip="A low cast efficiency indicates that brews are being wasted to capping charges.<br/>The cast efficiency of Ironskin Brew is shared with Purifying Brew." />
       </Rule>
       <Rule
         name={<>Mitigate damage with <SpellLink id={SPELLS.BREATH_OF_FIRE.id} />.</>}
@@ -70,12 +73,9 @@ class BrewmasterMonkChecklist extends React.PureComponent {
           <AbilityRequirement spell={SPELLS.BLACK_OX_BREW_TALENT.id}
             name={<><SpellLink id={SPELLS.BLACK_OX_BREW_TALENT.id} /> Cast Efficiency</>} />
         )}
-        <Requirement name={(
-            <dfn data-tip="Ironskin Brew has a <em>cap</em> on total buff duration of three times the base duration. Casting Ironskin Brew with more time remaining than twice the base duration (normally 16 seconds) wastes part of the brew.">
-              <SpellLink id={SPELLS.IRONSKIN_BREW.id} /> duration lost to clipping
-            </dfn>
-          )}
-          thresholds={thresholds.isbClipping} />
+        <Requirement name={<><SpellLink id={SPELLS.IRONSKIN_BREW.id} /> duration clipped</>}
+          thresholds={thresholds.isbClipping}
+          tooltip="Ironskin Brew has a <em>cap</em> on total buff duration of three times the base duration. Casting Ironskin Brew with more time remaining than twice the base duration (normally 14 seconds) wastes part of the brew." />
       </Rule>
       <Rule name={<>Use <SpellLink id={SPELLS.PURIFYING_BREW.id} /> effectively</>}
         description={
@@ -92,6 +92,9 @@ class BrewmasterMonkChecklist extends React.PureComponent {
         <Requirement name={<>Purifies with less than <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} /></>} thresholds={thresholds.purifyHeavy} />
         <Requirement name={'Average Purification Delay'} thresholds={thresholds.purifyDelay} 
           tooltip="The delay is tracked from the most recent time you were able to purify after a hit. If the hit occurred when no charges were available, you are not penalized." />
+        <AbilityRequirement spell={SPELLS.PURIFYING_BREW.id}
+          name={<><SpellLink id={SPELLS.PURIFYING_BREW.id} /> Cast Efficiency</>}
+          tooltip="A low cast efficiency indicates that brews are being wasted to capping charges.<br/>The cast efficiency of Purifying Brew is shared with Ironskin Brew." />
       </Rule>
       <Rule
         name={'Top the DPS Charts'}


### PR DESCRIPTION
show cast efficiency for ISB/PB in the relevant checklist sections (and fix an outdated way of doing a tooltip).

This has historically not been a huge issue because you'd fail one of the other metrics if you weren't actually using your brews, but in some scenarios we can get brew-flooded now.

Also this gives a direct way of identifying the people who keep posting logs with 0 brews used on fetid. *(Please stop)*