### PR TITLE
[Restoration Shaman] Ebb and Flow & Soothing Waters

### DIFF
--- a/src/common/SPELLS/bfa/azeritetraits/__UNUSED.js
+++ b/src/common/SPELLS/bfa/azeritetraits/__UNUSED.js
@@ -824,11 +824,6 @@ export default {
     name: 'Solitary Rejuvenation',
     icon: 'spell_nature_rejuvenation',
   },
-  SOOTHING_WATERS: {
-    id: 272989,
-    name: 'Soothing Waters',
-    icon: 'spell_nature_healingwavegreater',
-  },
   SOUL_FROM_THROS: {
     id: 273825,
     name: 'Soul From Thros',

--- a/src/common/SPELLS/bfa/azeritetraits/shaman.js
+++ b/src/common/SPELLS/bfa/azeritetraits/shaman.js
@@ -27,7 +27,7 @@ export default {
     icon: 'inv_spear_04',
   },
   SURGING_TIDES: {
-    id: 279181,
+    id: 278713,
     name: 'Surging Tides',
     icon: 'spell_nature_riptide',
   },
@@ -50,6 +50,11 @@ export default {
     id: 273597,
     name: 'Ebb and Flow',
     icon: 'ability_shaman_healingtide',
+  },
+  SOOTHING_WATERS_TRAIT: {
+    id: 272989,
+    name: 'Soothing Waters',
+    icon: 'spell_nature_healingwavegreater',
   },
   SERENE_SPIRIT_TRAIT: {
     id: 274412,

--- a/src/common/SPELLS/shaman.js
+++ b/src/common/SPELLS/shaman.js
@@ -607,6 +607,7 @@ export default {
     icon: 'spell_nature_healingwavegreater',
     manaCost: 5000,
     color: '#203755',
+    coefficient: 1.05,
   },
   HEALING_WAVE: {
     id: 77472,
@@ -614,6 +615,7 @@ export default {
     icon: 'spell_nature_healingwavelesser',
     manaCost: 1800,
     color: '#146585',
+    coefficient: 1.55,
   },
   HEALING_SURGE_RESTORATION: {
     id: 8004,
@@ -621,6 +623,7 @@ export default {
     icon: 'spell_nature_healingway',
     manaCost: 3800,
     color: '#40b3bf',
+    coefficient: 1.43,
   },
   RIPTIDE: {
     id: 61295,
@@ -666,6 +669,7 @@ export default {
     id: 114942,
     name: 'Healing Tide Totem',
     icon: 'ability_shaman_healingtide',
+    coefficient: 0.24,
   },
   ASCENDANCE_HEAL: {
     id: 114083,

--- a/src/interface/others/RestorationShamanSpreadsheet.js
+++ b/src/interface/others/RestorationShamanSpreadsheet.js
@@ -51,7 +51,7 @@ class RestorationShamanSpreadsheet extends React.Component {
               <tr><td>{parser._modules.spreadsheet.surgingTideProcsPerMinute}</td></tr>
               <tr><td>{(parser._modules.spreadsheet.spoutingSpiritsHits / casts(SPELLS.SPIRIT_LINK_TOTEM.id) || 0).toFixed(2)}</td></tr>
               <tr><td>{(parser._modules.spreadsheet.overflowingShoresHits / casts(SPELLS.HEALING_RAIN_CAST.id) || 0).toFixed(2)}</td></tr>
-              <tr><td>{parser._modules.spreadsheet.ebbAndFlowEffectiveness.toFixed(2)}</td></tr>
+              <tr><td>{parser._modules.ebbAndFlow.ebbAndFlowEffectiveness.toFixed(2)}</td></tr>
               <tr><td>{parser._modules.combatants.playerCount}</td></tr>
               <tr><td>{cpm(SPELLS.ASTRAL_SHIFT.id)}</td></tr>
               <tr><td>{(parser.selectedCombatant.getBuffUptime(SPELLS.GHOST_WOLF.id) / 1000).toFixed(2)}</td></tr>

--- a/src/parser/shaman/restoration/CombatLogParser.js
+++ b/src/parser/shaman/restoration/CombatLogParser.js
@@ -48,6 +48,8 @@ import Resurgence from './modules/spells/Resurgence';
 //Azerite
 import BaseHealerAzerite from './modules/azerite/BaseHealerAzerite';
 import SwellingStream from './modules/azerite/SwellingStream';
+import EbbAndFlow from './modules/azerite/EbbAndFlow';
+import SoothingWaters from './modules/azerite/SoothingWaters';
 // Shared
 import SpiritWolf from '../shared/talents/SpiritWolf';
 import StaticCharge from '../shared/talents/StaticCharge';
@@ -106,6 +108,8 @@ class CombatLogParser extends CoreCombatLogParser {
     // Azerite
     baseHealerAzerite: BaseHealerAzerite,
     swellingStream: SwellingStream,
+    ebbAndFlow: EbbAndFlow,
+    soothingWaters: SoothingWaters,
 
     // Shared:
     spiritWolf: SpiritWolf,

--- a/src/parser/shaman/restoration/modules/azerite/EbbAndFlow.js
+++ b/src/parser/shaman/restoration/modules/azerite/EbbAndFlow.js
@@ -2,9 +2,9 @@ import SPELLS from 'common/SPELLS';
 import StatTracker from 'parser/shared/modules/StatTracker';
 import BaseHealerAzerite from './BaseHealerAzerite';
 
-const totemSpawnDistance = 200; // 2 yards
-const ebbAndFlowMinDistance = 8;
-const ebbAndFlowMaxDistance = 40;
+const TOTEM_SPAWN_DISTANCE = 200; // 2 yards
+const EBB_AND_FLOW_MINUMUM_DISTANCE = 8;
+const EBB_AND_FLOW_MAXIMUM_DISTANCE = 40;
 
 /**
  * Ebb and Flow:
@@ -31,15 +31,14 @@ class EbbAndFlow extends BaseHealerAzerite {
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
-
     if (spellId !== SPELLS.HEALING_TIDE_TOTEM_CAST.id) {
       return;
     }
     // totem spawns 2 yards behind and to the right of your position on cast
     // everything gets calculated off of the totems position so this information is important to be precise
     const radians = event.facing / 100;
-    const xDistance = totemSpawnDistance * Math.cos(radians);
-    const yDistance = totemSpawnDistance * Math.sin(radians);
+    const xDistance = TOTEM_SPAWN_DISTANCE * Math.cos(radians);
+    const yDistance = TOTEM_SPAWN_DISTANCE * Math.sin(radians);
 
     this.healingTidePosition = {x: event.x + xDistance, y: event.y + yDistance};
   }
@@ -72,7 +71,7 @@ class EbbAndFlow extends BaseHealerAzerite {
   }
 
   effectiveness(distanceToPlayer) {
-    return Math.min(1 - ((distanceToPlayer - ebbAndFlowMinDistance) / (ebbAndFlowMaxDistance - ebbAndFlowMinDistance)), 1);
+    return Math.min(1 - ((distanceToPlayer - EBB_AND_FLOW_MINUMUM_DISTANCE) / (EBB_AND_FLOW_MAXIMUM_DISTANCE - EBB_AND_FLOW_MINUMUM_DISTANCE)), 1);
   }
 
   get ebbAndFlowEffectiveness() {

--- a/src/parser/shaman/restoration/modules/azerite/SoothingWaters.js
+++ b/src/parser/shaman/restoration/modules/azerite/SoothingWaters.js
@@ -1,10 +1,14 @@
-import HIT_TYPES from 'game/HIT_TYPES';
 import SPELLS from 'common/SPELLS';
 import StatTracker from 'parser/shared/modules/StatTracker';
 import CritEffectBonus from 'parser/shared/modules/helpers/CritEffectBonus';
 import BaseHealerAzerite from './BaseHealerAzerite';
 
-const HEAL_WINDOW_MS = 150;
+const HEAL_WINDOW_MS = 100;
+
+/**
+ * Soothing Waters:
+ * Your Chain Heal heals its primary target for an additional 756 healing.
+ */
 
 class SoothingWaters extends BaseHealerAzerite {
   static dependencies = {
@@ -14,13 +18,14 @@ class SoothingWaters extends BaseHealerAzerite {
   static TRAIT = SPELLS.SOOTHING_WATERS_TRAIT.id;
   static HEAL = SPELLS.SOOTHING_WATERS_TRAIT.id;
 
-  buffer = [];
   traitRawHealing = 0;
-  intellectOnHeal = 0;
+
+  chainHealEvent;
+  chainHealTarget;
 
   constructor(...args) {
     super(...args);
-    this.active = this.selectedCombatant.hasTrait(this.constructor.TRAIT);
+    this.active = this.hasTrait;
     if (!this.active) {
       return;
     }
@@ -28,9 +33,28 @@ class SoothingWaters extends BaseHealerAzerite {
     this.traitRawHealing = this.azerite.reduce((total, trait) => total + trait.rawHealing, 0);
   }
 
-  // Similar to the High Tide module, we can't use the actual chain heal events as they're in the wrong order.
-  // We're buffering the events, calculate the base healing and find out which is the initial one by finding the biggest healing event.
-  // more information on the "why" here: https://github.com/WoWAnalyzer/WoWAnalyzer/blob/master/src/parser/shaman/restoration/modules/talents/HighTide.js#L55
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+
+    if (spellId !== SPELLS.CHAIN_HEAL.id) {
+      return;
+    }
+
+    // filtering out healing events if they're not from the current cast
+    if (this.chainHealEvent && event.timestamp - this.chainHealEvent.timestamp >= HEAL_WINDOW_MS) {
+      this.chainHealEvent = undefined;
+    }
+
+    // sometimes you have heal events before the cast happens, so check here as well
+    // comparing the target ID guarantees no false positives as each cast can only heal the same target once
+    if (this.chainHealEvent && this.chainHealEvent.targetID === event.targetID) {
+      this.processTrait(this.chainHealEvent);
+      this.chainHealEvent = undefined;
+    } else {
+      this.chainHealTarget = event.targetID;
+    }
+  }
+
   on_byPlayer_heal(event) {
     const spellId = event.ability.guid;
 
@@ -38,44 +62,23 @@ class SoothingWaters extends BaseHealerAzerite {
       return;
     }
 
-    // Detects new chain heal casts, can't use the cast event for this as its often somewhere in between its healing events
-    if (!this.chainHealTimestamp || event.timestamp - this.chainHealTimestamp > HEAL_WINDOW_MS) {
-      this.processBuffer();
-      this.chainHealTimestamp = event.timestamp;
+    // we only want the initial heal - as that is the heal on the person you target on the cast,
+    // you only have to compare the heal and target ID.
+    if (this.chainHealTarget && this.chainHealTarget === event.targetID) {
+      this.processTrait(event);
+      this.chainHealTarget = undefined;
+    } else {
+      this.chainHealEvent = event;
     }
-
-    let heal = event.amount + (event.absorb || 0) + (event.overheal || 0);
-    if (event.hitType === HIT_TYPES.CRIT) {
-      const critMult = this.critEffectBonus.getBonus(event);
-      heal /= critMult;
-    }
-    const currentMastery = this.statTracker.currentMasteryPercentage;
-    const masteryEffectiveness = Math.max(0, 1 - (event.hitPoints - event.amount) / event.maxHitPoints);
-    const baseHealingDone = heal / (1 + currentMastery * masteryEffectiveness);
-    this.intellectOnHeal = this.statTracker.currentIntellectRating;
-
-    this.buffer.push({
-      baseHealingDone: baseHealingDone,
-      ...event,
-    });
   }
 
-  processBuffer() {
-    if (!this.buffer[0]) {
-      return;
-    }
-    // we only need the event with the highest healing done, which is the initial
-    const initialHitEvent = this.buffer.reduce((prev, curr) => prev.baseHealingDone > curr.baseHealingDone ? prev : curr);
-
-    const initialHitHealing = SPELLS.CHAIN_HEAL.coefficient * this.intellectOnHeal;
+  processTrait(initialHitEvent) {
+    this.healingtotal += initialHitEvent.amount + (initialHitEvent.absorbed || 0);
+    const currentIntellect = this.statTracker.currentIntellectRating;
+    const initialHitHealing = SPELLS.CHAIN_HEAL.coefficient * currentIntellect;
     const traitComponent = this.traitRawHealing / (initialHitHealing + this.traitRawHealing);
 
     this.processHealing(initialHitEvent, traitComponent);
-    this.buffer = [];
-  }
-
-  on_finished() {
-    this.processBuffer();
   }
 }
 

--- a/src/parser/shaman/restoration/modules/azerite/SoothingWaters.js
+++ b/src/parser/shaman/restoration/modules/azerite/SoothingWaters.js
@@ -35,21 +35,20 @@ class SoothingWaters extends BaseHealerAzerite {
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
-
     if (spellId !== SPELLS.CHAIN_HEAL.id) {
       return;
     }
 
     // filtering out healing events if they're not from the current cast
     if (this.chainHealEvent && event.timestamp - this.chainHealEvent.timestamp >= HEAL_WINDOW_MS) {
-      this.chainHealEvent = undefined;
+      this.chainHealEvent = null;
     }
 
     // sometimes you have heal events before the cast happens, so check here as well
     // comparing the target ID guarantees no false positives as each cast can only heal the same target once
     if (this.chainHealEvent && this.chainHealEvent.targetID === event.targetID) {
       this.processTrait(this.chainHealEvent);
-      this.chainHealEvent = undefined;
+      this.chainHealEvent = null;
     } else {
       this.chainHealTarget = event.targetID;
     }
@@ -57,7 +56,6 @@ class SoothingWaters extends BaseHealerAzerite {
 
   on_byPlayer_heal(event) {
     const spellId = event.ability.guid;
-
     if (spellId !== SPELLS.CHAIN_HEAL.id) {
       return;
     }
@@ -66,7 +64,7 @@ class SoothingWaters extends BaseHealerAzerite {
     // you only have to compare the heal and target ID.
     if (this.chainHealTarget && this.chainHealTarget === event.targetID) {
       this.processTrait(event);
-      this.chainHealTarget = undefined;
+      this.chainHealTarget = null;
     } else {
       this.chainHealEvent = event;
     }

--- a/src/parser/shaman/restoration/modules/azerite/SoothingWaters.js
+++ b/src/parser/shaman/restoration/modules/azerite/SoothingWaters.js
@@ -1,0 +1,82 @@
+import HIT_TYPES from 'game/HIT_TYPES';
+import SPELLS from 'common/SPELLS';
+import StatTracker from 'parser/shared/modules/StatTracker';
+import CritEffectBonus from 'parser/shared/modules/helpers/CritEffectBonus';
+import BaseHealerAzerite from './BaseHealerAzerite';
+
+const HEAL_WINDOW_MS = 150;
+
+class SoothingWaters extends BaseHealerAzerite {
+  static dependencies = {
+    statTracker: StatTracker,
+    critEffectBonus: CritEffectBonus,
+  };
+  static TRAIT = SPELLS.SOOTHING_WATERS_TRAIT.id;
+  static HEAL = SPELLS.SOOTHING_WATERS_TRAIT.id;
+
+  buffer = [];
+  traitRawHealing = 0;
+  intellectOnHeal = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrait(this.constructor.TRAIT);
+    if (!this.active) {
+      return;
+    }
+
+    this.traitRawHealing = this.azerite.reduce((total, trait) => total + trait.rawHealing, 0);
+  }
+
+  // Similar to the High Tide module, we can't use the actual chain heal events as they're in the wrong order.
+  // We're buffering the events, calculate the base healing and find out which is the initial one by finding the biggest healing event.
+  // more information on the "why" here: https://github.com/WoWAnalyzer/WoWAnalyzer/blob/master/src/parser/shaman/restoration/modules/talents/HighTide.js#L55
+  on_byPlayer_heal(event) {
+    const spellId = event.ability.guid;
+
+    if (spellId !== SPELLS.CHAIN_HEAL.id) {
+      return;
+    }
+
+    // Detects new chain heal casts, can't use the cast event for this as its often somewhere in between its healing events
+    if (!this.chainHealTimestamp || event.timestamp - this.chainHealTimestamp > HEAL_WINDOW_MS) {
+      this.processBuffer();
+      this.chainHealTimestamp = event.timestamp;
+    }
+
+    let heal = event.amount + (event.absorb || 0) + (event.overheal || 0);
+    if (event.hitType === HIT_TYPES.CRIT) {
+      const critMult = this.critEffectBonus.getBonus(event);
+      heal /= critMult;
+    }
+    const currentMastery = this.statTracker.currentMasteryPercentage;
+    const masteryEffectiveness = Math.max(0, 1 - (event.hitPoints - event.amount) / event.maxHitPoints);
+    const baseHealingDone = heal / (1 + currentMastery * masteryEffectiveness);
+    this.intellectOnHeal = this.statTracker.currentIntellectRating;
+
+    this.buffer.push({
+      baseHealingDone: baseHealingDone,
+      ...event,
+    });
+  }
+
+  processBuffer() {
+    if (!this.buffer[0]) {
+      return;
+    }
+    // we only need the event with the highest healing done, which is the initial
+    const initialHitEvent = this.buffer.reduce((prev, curr) => prev.baseHealingDone > curr.baseHealingDone ? prev : curr);
+
+    const initialHitHealing = SPELLS.CHAIN_HEAL.coefficient * this.intellectOnHeal;
+    const traitComponent = this.traitRawHealing / (initialHitHealing + this.traitRawHealing);
+
+    this.processHealing(initialHitEvent, traitComponent);
+    this.buffer = [];
+  }
+
+  on_finished() {
+    this.processBuffer();
+  }
+}
+
+export default SoothingWaters;

--- a/src/parser/shaman/restoration/modules/azerite/SoothingWaters.js
+++ b/src/parser/shaman/restoration/modules/azerite/SoothingWaters.js
@@ -73,7 +73,6 @@ class SoothingWaters extends BaseHealerAzerite {
   }
 
   processTrait(initialHitEvent) {
-    this.healingtotal += initialHitEvent.amount + (initialHitEvent.absorbed || 0);
     const currentIntellect = this.statTracker.currentIntellectRating;
     const initialHitHealing = SPELLS.CHAIN_HEAL.coefficient * currentIntellect;
     const traitComponent = this.traitRawHealing / (initialHitHealing + this.traitRawHealing);

--- a/src/parser/shaman/restoration/modules/azerite/SwellingStream.js
+++ b/src/parser/shaman/restoration/modules/azerite/SwellingStream.js
@@ -1,6 +1,12 @@
 import SPELLS from 'common/SPELLS';
 import BaseHealerAzerite from './BaseHealerAzerite';
 
+/**
+ * Swelling Stream:
+ * Every 3 sec your Healing Stream Totem releases a lesser chain heal,
+ * restoring 637 health to up to 3 injured allies. Healing is reduced by 30% after each jump.
+ */
+
 class SwellingStream extends BaseHealerAzerite {
   static TRAIT = SPELLS.SWELLING_STREAM.id;
   static HEAL = SPELLS.SWELLING_STREAM_HEAL.id;


### PR DESCRIPTION
The 2 azerite traits that require splitting healing off of other spells.
Relevant issue: #2009 
- https://www.wowhead.com/spell=273597/ebb-and-flow
	- Requires finding out the range of the totem to the target to know how much the trait actually contributed.
	- Healing contributed towards Healing Tide Totem
	- https://www.warcraftlogs.com/reports/fBnXhkHWJQT1yb32/#fight=26&source=8
![image](https://user-images.githubusercontent.com/2842471/47264691-de95e980-d51b-11e8-899a-4559484e6725.png)
	- Also moves the spreadsheet export from the dedicated file to this module, as there is no reason to do the same math twice.

- https://www.wowhead.com/spell=272989/soothing-waters
	- Requires finding out the initial heal of Chain Heal as no other heals are affected.
	- Healing contributed towards Chain Heal
	- https://www.warcraftlogs.com/reports/BZk41mDxqQyjw7TJ/#fight=9&source=11
![image](https://user-images.githubusercontent.com/2842471/47264697-f9685e00-d51b-11e8-9a5f-5d29dc3483ce.png) 
over 20% overheal even though his CH was only 6% overhealed, what a great trait :)