### PR TITLE
[Frost Death Knight] Added breath of sindragosa module

### DIFF
--- a/src/parser/deathknight/frost/CHANGELOG.js
+++ b/src/parser/deathknight/frost/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
     {
+      date: new Date('2018-10-22'),
+      changes: <>Added module for <SpellLink id={SPELLS.BREATH_OF_SINDRAGOSA_TALENT.id} /></>,
+      contributors: [Khazak],
+    },
+    {
       date: new Date('2018-10-11'),
       changes: <>Fixed bugs in <SpellLink id={SPELLS.KILLING_MACHINE.id} /> module that caused it to give weird suggestions</>,
       contributors: [Khazak],

--- a/src/parser/deathknight/frost/CombatLogParser.js
+++ b/src/parser/deathknight/frost/CombatLogParser.js
@@ -10,7 +10,7 @@ import FrostFeverUptime from './modules/features/FrostFeverUptime';
 import RimeEfficiency from './modules/features/RimeEfficiency';
 import HardHowlingBlastCasts from './modules/features/HardHowlingBlastCasts';
 import KillingMachineEfficiency from './modules/features/KillingMachine';
-
+import BreathOfSindragosa from './modules/features/BreathOfSindragosa';
 
 import RuneTracker from './modules/features/RuneTracker';
 import RuneDetails from '../shared/RuneDetails';
@@ -35,6 +35,7 @@ class CombatLogParser extends CoreCombatLogParser {
     frostfeverUptime: FrostFeverUptime,
     rimeEfficiency: RimeEfficiency,
     killingMachineEfficiency: KillingMachineEfficiency,
+    breathofSindragoa: BreathOfSindragosa,
 
     //resource tracker
     runeTracker: RuneTracker,

--- a/src/parser/deathknight/frost/modules/features/BreathOfSindragosa.js
+++ b/src/parser/deathknight/frost/modules/features/BreathOfSindragosa.js
@@ -1,0 +1,99 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+
+import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
+
+import Analyzer from 'parser/core/Analyzer';
+
+class BreathOfSindragosa extends Analyzer{
+  static dependancies = {
+
+  }
+
+  beginTimestamp = 0;
+  casts = 0;
+  badCasts = 0;
+  totalDuration = 0;
+  breathActive = false;
+
+  on_byPlayer_applybuff(event){
+    const spellId = event.ability.guid;
+    if(spellId !== SPELLS.BREATH_OF_SINDRAGOSA_TALENT.id){
+      return;
+    }
+    this.casts += 1;
+    this.beginTimestamp = event.timestamp;
+    this.breathActive = true;
+  }
+
+  on_byPlayer_removebuff(event){
+    const spellId = event.ability.guid;
+    if(spellId !== SPELLS.BREATH_OF_SINDRAGOSA_TALENT.id){
+      return;
+    }
+    this.breathActive = false;
+    const duration = event.timestamp - this.beginTimestamp;
+    if(duration < 15000){
+      this.badCasts +=1;
+    }
+    this.totalDuration += duration;
+  }
+
+  on_finished(event){
+    if(this.breathActive){
+      this.endTimestamp = event.timestamp;
+      const duration = event.timestamp - this.beginTimestamp;
+      if(duration < 20000){
+        this.badCasts +=1;
+      }
+      this.totalDuration += duration;
+    }
+
+  }
+
+  suggestions(when){
+    when(this.suggestionThresholds)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<> You are not getting good uptime from your <SpellLink id={SPELLS.BREATH_OF_SINDRAGOSA_TALENT.id} /> casts. Your cast should last <b>at least</b> 15 seconds to take full advantage of the <SpellLink id={SPELLS.PILLAR_OF_FROST.id} /> buff.  A good cast is one that 20 seconds or more.  To ensure a good duration, make you sure have 3 Runes ready and 70 Runic Power pooled before you start the cast.  Also make sure to use <SpellLink id={SPELLS.EMPOWER_RUNE_WEAPON.id} /> before you cast Breath of Sindragosa.</>)
+          .icon(SPELLS.BREATH_OF_SINDRAGOSA_TALENT.icon)
+          .actual(`You averaged ${(this.averageDuration).toFixed(1)} seconds of uptime per cast`)
+          .recommended(`>${recommended} seconds is recommended`);
+      });
+  }
+
+  get averageDuration() {
+    return (this.totalDuration / this.casts) / 1000;
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.averageDuration,
+      isLessThan: {
+        minor: (20.0),
+        average: (17.5),
+        major: (15.0),
+      },
+      style: 'seconds',
+      suffix: 'Average',
+    };
+  }
+
+  statistic(){
+      return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.BREATH_OF_SINDRAGOSA_TALENT.id} />}
+        value={`${(this.averageDuration).toFixed(1)} seconds`}
+        label="Average Breath of Sindragosa Duration"
+        tooltip={`You cast Breath of Sindragosa ${this.casts} times for a combined total of ${this.totalDuration / 1000} seconds.  ${this.badCasts} casts were under 20 seconds`}
+        position={STATISTIC_ORDER.CORE(60)}
+
+      />
+      );
+  }
+
+}
+
+export default BreathOfSindragosa;


### PR DESCRIPTION
Tracks how long the user sustains breath and gives a suggestion if needed

![suggestion](https://user-images.githubusercontent.com/10967144/47398203-adbedb80-d6f8-11e8-9d7b-ae43b7909c36.png)

![image](https://user-images.githubusercontent.com/10967144/47398369-66851a80-d6f9-11e8-9b15-bba551fa913e.png)

Example log: https://www.warcraftlogs.com/reports/D4wCaZgKjAXLnMPV/#fight=16&source=13&type=auras&ability=152279