### PR TITLE
Fix the URL to Holy Paladin StatValues file

### DIFF
--- a/src/parser/paladin/holy/modules/features/StatValues.js
+++ b/src/parser/paladin/holy/modules/features/StatValues.js
@@ -117,7 +117,7 @@ class StatValues extends BaseHealerStatValues {
     return baseHeal * healIncreaseFromOneMastery;
   }
 
-  moreInformationLink = 'https://github.com/WoWAnalyzer/WoWAnalyzer/blob/master/src/parser/Paladin/Holy/Modules/Features/StatValues.md';
+  moreInformationLink = 'https://github.com/WoWAnalyzer/WoWAnalyzer/blob/master/src/parser/paladin/holy/modules/features/StatValues.md';
   _prepareResults() {
     return [
       STAT.INTELLECT,


### PR DESCRIPTION
Currently, if you click the "More Info" link in the stats box on a Holy Paladin analysis, you'll end up in a GitHub 404. It turns out it's because GH URLs looks case sensitive, so quite easy to fix :)