### PR TITLE
[Azerite] Adding Synergistic Growth to other healing classes

### DIFF
--- a/src/common/SPELLS/bfa/azeritetraits/druid.js
+++ b/src/common/SPELLS/bfa/azeritetraits/druid.js
@@ -49,16 +49,6 @@ export default {
     name: 'Fungal Essence',
     icon: 'inv_misc_herb_talandrasrose',
   },
-  SYNERGISTIC_GROWTH: {
-    id: 267892,
-    name: 'Synergistic Growth',
-    icon: 'inv_misc_markoftheworldtree',
-  },
-  SYNERGISTIC_GROWTH_BUFF: {
-    id: 272090,
-    name: 'Synergistic Growth',
-    icon: 'inv_misc_markoftheworldtree',
-  },
   WILD_FLESHRENDING: {
     id: 279527,
     name: 'Wild Fleshrending',

--- a/src/common/SPELLS/bfa/azeritetraits/general.js
+++ b/src/common/SPELLS/bfa/azeritetraits/general.js
@@ -157,6 +157,11 @@ export default {
     icon: 'achievement_bg_killflagcarriers_grabflag_capit',
   },
   WOUNDBINDER: {
+    id: 267880,
+    name: 'Woundbinder',
+    icon: 'inv_misc_emberweavebandage',
+  },
+  WOUNDBINDER_BUFF: {
     id: 269085,
     name: 'Woundbinder',
     icon: 'inv_misc_emberweavebandage',

--- a/src/common/SPELLS/bfa/azeritetraits/general.js
+++ b/src/common/SPELLS/bfa/azeritetraits/general.js
@@ -91,6 +91,16 @@ export default {
     name: 'Blessed Portents',
     icon: 'spell_holy_fanaticism',
   },
+  SYNERGISTIC_GROWTH: {
+    id: 267892,
+    name: 'Synergistic Growth',
+    icon: 'inv_misc_markoftheworldtree',
+  },
+  SYNERGISTIC_GROWTH_BUFF: {
+    id: 272090,
+    name: 'Synergistic Growth',
+    icon: 'inv_misc_markoftheworldtree',
+  },
   AZERITE_FORTIFICATION: {
     id: 270659,
     name: 'Azerite Fortification',

--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -105,6 +105,7 @@ import TidalSurge from '../shared/modules/spells/bfa/azeritetraits/TidalSurge';
 import BlightborneInfusion from '../shared/modules/spells/bfa/azeritetraits/BlightborneInfusion';
 import ArchiveOfTheTitans from '../shared/modules/spells/bfa/azeritetraits/ArchiveOfTheTitans';
 import Savior from '../shared/modules/spells/bfa/azeritetraits/Savior';
+import WoundBinder from '../shared/modules/spells/bfa/azeritetraits/WoundBinder';
 // Uldir
 import TwitchingTentacleofXalzaix from '../shared/modules/items/bfa/raids/uldir/TwitchingTentacleofXalzaix';
 import VigilantsBloodshaper from '../shared/modules/items/bfa/raids/uldir/VigilantsBloodshaper';
@@ -225,6 +226,7 @@ class CombatLogParser {
     blightborneInfusion: BlightborneInfusion,
     archiveOfTheTitans: ArchiveOfTheTitans,
     savior: Savior,
+    woundBinder:WoundBinder,
 
     // Uldir
     twitchingTentacleofXalzaix: TwitchingTentacleofXalzaix,

--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -106,6 +106,7 @@ import BlightborneInfusion from '../shared/modules/spells/bfa/azeritetraits/Blig
 import ArchiveOfTheTitans from '../shared/modules/spells/bfa/azeritetraits/ArchiveOfTheTitans';
 import Savior from '../shared/modules/spells/bfa/azeritetraits/Savior';
 import WoundBinder from '../shared/modules/spells/bfa/azeritetraits/WoundBinder';
+import SynergisticGrowth from '../shared/modules/spells/bfa/azeritetraits/SynergisticGrowth';
 // Uldir
 import TwitchingTentacleofXalzaix from '../shared/modules/items/bfa/raids/uldir/TwitchingTentacleofXalzaix';
 import VigilantsBloodshaper from '../shared/modules/items/bfa/raids/uldir/VigilantsBloodshaper';
@@ -227,6 +228,7 @@ class CombatLogParser {
     archiveOfTheTitans: ArchiveOfTheTitans,
     savior: Savior,
     woundBinder:WoundBinder,
+    synergisticGrowth: SynergisticGrowth,
 
     // Uldir
     twitchingTentacleofXalzaix: TwitchingTentacleofXalzaix,

--- a/src/parser/druid/restoration/CombatLogParser.js
+++ b/src/parser/druid/restoration/CombatLogParser.js
@@ -45,7 +45,6 @@ import GroveTending from './modules/items/azeritetraits/GroveTending';
 import LaserMatrix from './modules/items/azeritetraits/LaserMatrixRestoDruid';
 import WakingDream from './modules/items/azeritetraits/WakingDream';
 import LivelySpirit from './modules/items/azeritetraits/LivelySpirit';
-import SynergisticGrowth from './modules/items/azeritetraits/SynergisticGrowth';
 
 import StatWeights from './modules/features/StatWeights';
 
@@ -110,7 +109,6 @@ class CombatLogParser extends CoreCombatLogParser {
     laserMatrix: LaserMatrix,
     wakingDream: WakingDream,
     livelySpirit: LivelySpirit,
-    synergisticGrowth: SynergisticGrowth,
 
     statWeights: StatWeights,
   };

--- a/src/parser/shared/modules/spells/bfa/azeritetraits/SynergisticGrowth.js
+++ b/src/parser/shared/modules/spells/bfa/azeritetraits/SynergisticGrowth.js
@@ -4,18 +4,14 @@ import {formatPercentage, formatNumber} from 'common/format';
 import { calculateAzeriteEffects } from 'common/stats';
 import SPELLS from 'common/SPELLS/index';
 import TraitStatisticBox, { STATISTIC_ORDER } from 'interface/others/TraitStatisticBox';
-import StatWeights from '../../../../../druid/restoration/modules/features/StatWeights';
 
 /**
  Casting Wild Growth grants you 165 Mastery for 10 sec sec. This cannot occur more than once every 30 sec.
  Example Log: /report/nfVcdAMXFGBgwvzp/2-Heroic+Taloc+-+Kill+(3:55)/21-Palamx
  */
 class SynergisticGrowth extends Analyzer{
-  static dependencies = {
-    statWeights: StatWeights,
-  };
-
   masteryBuff = 0;
+  procs = 0;
 
   constructor(...args){
     super(...args);
@@ -30,6 +26,10 @@ class SynergisticGrowth extends Analyzer{
     return this.selectedCombatant.getBuffUptime(SPELLS.SYNERGISTIC_GROWTH_BUFF.id) / this.owner.fightDuration;
   }
 
+  get totalBuffProcs() {
+    return this.selectedCombatant.getBuffTriggerCount(SPELLS.SYNERGISTIC_GROWTH_BUFF.id);
+  }
+
   get averageStatGain(){
     const averageStacks = this.selectedCombatant.getStackWeightedBuffUptime(SPELLS.SYNERGISTIC_GROWTH_BUFF.id) / this.owner.fightDuration;
     return averageStacks * this.masteryBuff;
@@ -40,12 +40,11 @@ class SynergisticGrowth extends Analyzer{
       <TraitStatisticBox
         position={STATISTIC_ORDER.OPTIONAL()}
         trait={SPELLS.SYNERGISTIC_GROWTH.id}
-        value={(
-          <>
-            {formatPercentage(this.totalBuffUptime)}% uptime<br />
-            {formatNumber(this.averageStatGain)} average mastery gained.
-          </>
-        )}
+        value={`${formatNumber(this.averageStatGain)} average Mastery`}
+        tooltip={`
+          ${formatPercentage(this.totalBuffUptime)}% Uptime<br />
+          ${this.totalBuffProcs} Total Procs
+        `}
       />
     );
   }

--- a/src/parser/shared/modules/spells/bfa/azeritetraits/SynergisticGrowth.js
+++ b/src/parser/shared/modules/spells/bfa/azeritetraits/SynergisticGrowth.js
@@ -2,9 +2,9 @@ import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import {formatPercentage, formatNumber} from 'common/format';
 import { calculateAzeriteEffects } from 'common/stats';
-import SPELLS from 'common/SPELLS';
+import SPELLS from 'common/SPELLS/index';
 import TraitStatisticBox, { STATISTIC_ORDER } from 'interface/others/TraitStatisticBox';
-import StatWeights from '../../features/StatWeights';
+import StatWeights from '../../../../../druid/restoration/modules/features/StatWeights';
 
 /**
  Casting Wild Growth grants you 165 Mastery for 10 sec sec. This cannot occur more than once every 30 sec.

--- a/src/parser/shared/modules/spells/bfa/azeritetraits/SynergisticGrowth.js
+++ b/src/parser/shared/modules/spells/bfa/azeritetraits/SynergisticGrowth.js
@@ -8,6 +8,7 @@ import StatWeights from '../../../../../druid/restoration/modules/features/StatW
 
 /**
  Casting Wild Growth grants you 165 Mastery for 10 sec sec. This cannot occur more than once every 30 sec.
+ Example Log: /report/nfVcdAMXFGBgwvzp/2-Heroic+Taloc+-+Kill+(3:55)/21-Palamx
  */
 class SynergisticGrowth extends Analyzer{
   static dependencies = {

--- a/src/parser/shared/modules/spells/bfa/azeritetraits/WoundBinder.js
+++ b/src/parser/shared/modules/spells/bfa/azeritetraits/WoundBinder.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import Analyzer from 'parser/core/Analyzer';
+import SPELLS from 'common/SPELLS/index';
+import TraitStatisticBox, { STATISTIC_ORDER } from 'interface/others/TraitStatisticBox';
+import { calculateAzeriteEffects } from 'common/stats';
+import { formatNumber } from 'common/format';
+
+const woundBinderStats = traits => Object.values(traits).reduce((obj, rank) => {
+  const [haste] = calculateAzeriteEffects(SPELLS.WOUNDBINDER.id, rank);
+  obj.haste += haste;
+  return obj;
+}, {
+  haste: 0,
+});
+
+const BASE_HASTE_AMOUNT = .34;
+
+/**
+ Your healing effects have a chance to increase your Haste by up to 435 for 6 sec. Healing lower health targets will grant you more Haste.
+
+ This trait scales linearly starting at with 34% of the haste at 0% health and 100% at 100% health.
+
+ Example Report: /report/yqwzpPZVhWJ6Qtj1/8-Normal+Taloc+-+Kill+(2:54)/22-Fearrful
+ */
+class WoundBinder extends Analyzer {
+  procs = [];
+  lastTargetHealedPercent = 1;
+  fullHasteValue = 0;
+
+  get uptime() {
+    return this.selectedCombatant.getBuffUptime(SPELLS.WOUNDBINDER_BUFF.id) / this.owner.fightDuration;
+  }
+
+  get averageHasteProcAmount() {
+    const sum = this.procs.reduce(function (a, b) {
+      return a + b;
+    });
+    const avg = sum / this.procs.length;
+    return avg;
+  }
+
+  get averageHaste() {
+    return this.averageHasteProcAmount * this.uptime;
+  }
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrait(SPELLS.WOUNDBINDER.id);
+
+    if (this.active){
+      const { haste } = woundBinderStats(this.selectedCombatant.traitsBySpellId[SPELLS.WOUNDBINDER.id]);
+      this.fullHasteValue = haste;
+    }
+  }
+
+  calculateHasteAmount(targetHealthPercent = 1) {
+    // The formula is HasteGained = .34 + percentMissingHealth * .66
+    return this.fullHasteValue * (BASE_HASTE_AMOUNT + ((1 - BASE_HASTE_AMOUNT) * (1 - targetHealthPercent)));
+  }
+
+  on_byPlayer_heal(event) {
+    // We track the last heal from the player to use for the haste calculation
+    this.lastTargetHealedPercent = (event.hitPoints / event.maxHitPoints);
+  }
+
+  on_byPlayer_applybuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.WOUNDBINDER_BUFF.id) {
+      return;
+    }
+
+    this.procs.push(this.calculateHasteAmount(this.lastTargetHealedPercent));
+  }
+
+  statistic() {
+    return (
+      <TraitStatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
+        trait={SPELLS.WOUNDBINDER.id}
+        value={`${formatNumber(this.averageHaste)} average Haste`}
+        tooltip={`${this.procs.length} total procs for [${this.procs.map((value) => Math.floor(value)).join(', ')}] haste.`}
+      />
+    );
+  }
+}
+
+export default WoundBinder;


### PR DESCRIPTION
Synergistic Growth was created for druids, but not for other classes. This PR moves the existing trait module and updates it to match some of the existing traits.

Old trait: 
![aknkgro](https://user-images.githubusercontent.com/716498/47580053-b3880d00-d902-11e8-9cd4-7b0223a19915.png)

New Trait: 
![yw6ceiz](https://user-images.githubusercontent.com/716498/47580067-bbe04800-d902-11e8-8e48-97e16ebd4e19.png)

I built this on top of #2512 and it should not be merged until that PR is.