### PR TITLE
[BrM] Removed bof from brm's soft mit checks

### DIFF
--- a/src/parser/monk/brewmaster/modules/features/MitigationCheck.js
+++ b/src/parser/monk/brewmaster/modules/features/MitigationCheck.js
@@ -9,7 +9,7 @@ class MitigationCheck extends CoreMitigationCheck {
                       SPELLS.FORTIFYING_BREW_BRM_BUFF.id,
                       SPELLS.ZEN_MEDITATION.id,
                       SPELLS.DAMPEN_HARM_TALENT.id];
-    this.debuffCheck = [SPELLS.BREATH_OF_FIRE_DEBUFF.id];
+    this.debuffCheck = [];
   }
 }
 

--- a/src/parser/monk/brewmaster/modules/features/checklist/Component.js
+++ b/src/parser/monk/brewmaster/modules/features/checklist/Component.js
@@ -32,6 +32,7 @@ class BrewmasterMonkChecklist extends React.PureComponent {
     return (
       <Checklist>
         <Rule
+          performanceMethod={PERFORMANCE_METHOD.FIRST}
           name={<>Mitigate damage with <SpellLink id={SPELLS.IRONSKIN_BREW.id} />.</>}
           description={
             <>


### PR DESCRIPTION
Breath of Fire is only a 5% damage reduction, and shouldn't count as a means to deal with a soft mitigation check.

**Before**
![screenshot from 2018-10-26 13-30-05](https://user-images.githubusercontent.com/4909458/47582742-48026780-d923-11e8-94bb-e00661cd696e.png)
**After**
![screenshot from 2018-10-26 13-30-13](https://user-images.githubusercontent.com/4909458/47582741-48026780-d923-11e8-9d64-b080e4fc6ecc.png)

I also changed the ISB checklist rule to use hits mitigated only instead of averaging with cast efficiency. Cast efficiency is mostly informative and not evaluative for this checklist item.

