### PR TITLE
[Core] update timeline to double decimal

### DIFF
--- a/src/parser/shared/modules/features/TimelineTab/TabComponent/SpellTimeline.js
+++ b/src/parser/shared/modules/features/TimelineTab/TabComponent/SpellTimeline.js
@@ -167,7 +167,7 @@ class SpellTimeline extends React.PureComponent {
                       left,
                       width: Math.min(maxWidth, event.duration / 1000 * secondWidth),
                     }}
-                    data-tip={`${formatDuration(fightDuration, 3)}: ${(event.duration / 1000).toFixed(1)}s Global Cooldown by ${event.ability.name}`}
+                    data-tip={`${formatDuration(fightDuration, 3)}: ${(event.duration / 1000).toFixed(2)}s Global Cooldown by ${event.ability.name}`}
                   />
                 );
               })}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29204244/47584599-4359a580-d95b-11e8-9acd-27889139bbeb.png)


Provides better accuracy and shows more precisely whenever we hit the GCD cap at 0.75s (instead of showing 0.8s