### PR TITLE
[Prot] converted consecration to hit tracking

### DIFF
--- a/src/parser/paladin/protection/CHANGELOG.js
+++ b/src/parser/paladin/protection/CHANGELOG.js
@@ -5,6 +5,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('28 October 2018'),
+    contributors: [emallson],
+    changes: <>Converted <SpellLink id={SPELLS.CONSECRATION_CAST.id} /> from buff uptime to hit tracking.</>,
+  },
+  {
     date: new Date('10 October 2018'),
     contributors: [emallson],
     changes: <>Added tracking for which <SpellLink id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id} /> casts are effective.</>,

--- a/src/parser/paladin/protection/CombatLogParser.js
+++ b/src/parser/paladin/protection/CombatLogParser.js
@@ -12,9 +12,9 @@ import MitigationCheck from './modules/features/MitigationCheck';
 
 //Spells
 import Judgment from './modules/spells/Judgment';
+import Consecration from './modules/spells/Consecration';
 import LightOfTheProtectorTiming from './modules/features/LightOfTheProtectorTiming';
 import ShieldOfTheRighteous from './modules/features/ShieldOfTheRighteous';
-import Consecration from './modules/features/Consecration';
 import GrandCrusader from './modules/core/GrandCrusader';
 
 //Talents

--- a/src/parser/paladin/protection/modules/features/Checklist/Component.js
+++ b/src/parser/paladin/protection/modules/features/Checklist/Component.js
@@ -66,7 +66,7 @@ class ProtectionPaladinChecklist extends React.PureComponent{
           />
           <Requirement
             name={(
-              <><SpellLink id={SPELLS.CONSECRATION_CAST.id} /> uptime</>
+              <>Hits Mitigated with <SpellLink id={SPELLS.CONSECRATION_CAST.id} /></>
             )}
             thresholds={thresholds.consecration}
           />

--- a/src/parser/paladin/protection/modules/features/Checklist/Module.js
+++ b/src/parser/paladin/protection/modules/features/Checklist/Module.js
@@ -7,7 +7,7 @@ import Combatants from 'parser/shared/modules/Combatants';
 import PreparationRuleAnalyzer from 'parser/shared/modules/features/Checklist2/PreparationRuleAnalyzer';
 
 import ShieldOfTheRighteous from '../ShieldOfTheRighteous';
-import Consecration from '../Consecration';
+import Consecration from '../../spells/Consecration';
 
 import Component from './Component';
 

--- a/src/parser/paladin/protection/modules/spells/Consecration.js
+++ b/src/parser/paladin/protection/modules/spells/Consecration.js
@@ -6,13 +6,23 @@ import { formatPercentage } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 
 class Consecration extends Analyzer {
-  get uptime() {
-    return this.selectedCombatant.getBuffUptime(SPELLS.CONSECRATION_BUFF.id) / this.owner.fightDuration;
+  _hitsTaken = 0;
+  _hitsMitigated = 0;
+
+  on_toPlayer_damage(event) {
+    this._hitsTaken += 1;
+    if(this.selectedCombatant.hasBuff(SPELLS.CONSECRATION_BUFF.id)) {
+      this._hitsMitigated += 1;
+    }
+  }
+
+  get pctHitsMitigated() {
+    return this._hitsMitigated / this._hitsTaken;
   }
 
   get uptimeSuggestionThresholds() {
     return {
-      actual: this.uptime,
+      actual: this.pctHitsMitigated,
       isLessThan: {
         minor: 0.95,
         average: 0.9,
@@ -25,7 +35,7 @@ class Consecration extends Analyzer {
   suggestions(when) {
     when(this.uptimeSuggestionThresholds)
         .addSuggestion((suggest, actual, recommended) => {
-          return suggest('Your Consecration uptime can be improved. Maintain it to reduce all incoming damage by a flat amount and refresh it during rotational downtime.')
+          return suggest('Your Consecration usage can be improved. Maintain it to reduce all incoming damage and refresh it during rotational downtime.')
             .icon(SPELLS.CONSECRATION_CAST.icon)
             .actual(`${formatPercentage(actual)}% Consecration uptime`)
             .recommended(`>${formatPercentage(recommended)}% is recommended`);
@@ -36,8 +46,8 @@ class Consecration extends Analyzer {
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.CONSECRATION_CAST.id} />}
-        value={`${formatPercentage(this.uptime)} %`}
-        label="Consecration uptime"
+        value={`${formatPercentage(this.pctHitsMitigated)} %`}
+        label="Hits Mitigated w/ Consecration"
       />
     );
   }


### PR DESCRIPTION
Very simple change. Instead of caring about having Cons up all the time, only check how many hits were mitigated with it.

**Old**
![screenshot from 2018-10-28 15-51-56](https://user-images.githubusercontent.com/4909458/47621125-6dc97100-dac9-11e8-9871-dc7fc242d3e0.png)
**New**
![screenshot from 2018-10-28 15-52-03](https://user-images.githubusercontent.com/4909458/47621124-6d30da80-dac9-11e8-972e-6da8951f61f2.png)

