### PR TITLE
[Prot] Shield of the Righteous CDR stat

### DIFF
--- a/src/parser/paladin/protection/CHANGELOG.js
+++ b/src/parser/paladin/protection/CHANGELOG.js
@@ -5,6 +5,12 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('28 October 2018'),
+    contributors: [emallson],
+    changes: <>Added <SpellLink id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id} /> cooldown reduction statistic.</>,
+  },
+
+  {
     date: new Date('10 October 2018'),
     contributors: [emallson],
     changes: <>Added tracking for which <SpellLink id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id} /> casts are effective.</>,

--- a/src/parser/paladin/protection/modules/features/SpellUsable.js
+++ b/src/parser/paladin/protection/modules/features/SpellUsable.js
@@ -30,6 +30,7 @@ class SpellUsable extends CoreSpellUsable {
       this.lastPotentialTriggerForJudgment = null;
     }
   }
+
   on_toPlayer_damage(event) {
     if (super.on_toPlayer_damage) {
       super.on_toPlayer_damage(event);

--- a/src/parser/paladin/protection/modules/spells/Judgment.js
+++ b/src/parser/paladin/protection/modules/spells/Judgment.js
@@ -69,7 +69,7 @@ class Judgment extends Analyzer {
 
   statistic() {
     const cjTooltip = this.selectedCombatant.hasTalent(SPELLS.CRUSADERS_JUDGMENT_TALENT.id) ?
-      `<br/>Without the Crusader's Judgment talent, this would have been roughly <b>${formatPercentage(this.baseCdrPercentage)}%</b> (or ${formatNumber(this.baseCdr / 1000)}s).` : '';
+      `<br/>Without the Crusader's Judgment talent, your effective SotR CDR would have been roughly <b>${formatPercentage(this.baseCdrPercentage)}%</b> (or ${formatNumber(this.baseCdr / 1000)}s).` : '';
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id} />}

--- a/src/parser/paladin/protection/modules/spells/Judgment.js
+++ b/src/parser/paladin/protection/modules/spells/Judgment.js
@@ -1,9 +1,13 @@
+import React from 'react';
 import SPELLS from 'common/SPELLS';
 
+import StatisticBox from 'interface/others/StatisticBox';
+import SpellIcon from 'common/SpellIcon';
 import Analyzer from 'parser/core/Analyzer';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import HIT_TYPES from 'game/HIT_TYPES';
+import { formatNumber, formatPercentage } from 'common/format';
 
 const REDUCTION_TIME_REGULAR = 2000; // ms
 const REDUCTION_TIME_CRIT = 4000; // ms
@@ -13,6 +17,12 @@ const REDUCTION_TIME_CRIT = 4000; // ms
  * Judges the target dealing (250% of Spell power) Holy damage, and reducing the remaining cooldown on Shield of the Righteous by 2 sec, or 4 sec on a critical strike.
  */
 class Judgment extends Analyzer {
+  _totalCdr = 0;
+  _wastedCdr = 0;
+
+  _casts = 0;
+  _crits = 0;
+
   static dependencies = {
     abilityTracker: AbilityTracker,
     spellUsable: SpellUsable,
@@ -24,13 +34,35 @@ class Judgment extends Analyzer {
       return;
     }
 
+    this._casts += 1;
+
+    const isCrit = event.hitType === HIT_TYPES.CRIT || event.hitType === HIT_TYPES.BLOCKED_CRIT;
+    this._crits += isCrit ? 1 : 0;
+
     if (this.spellUsable.isOnCooldown(SPELLS.SHIELD_OF_THE_RIGHTEOUS.id)) {
       // Nope, I did not verify if blocked crits count as crits for this trait, I just assumed it. Please do test if you can and report back or fix this comment.
       // Confirmed: Blocked crits count as crits.
-      const isCrit = event.hitType === HIT_TYPES.CRIT || event.hitType === HIT_TYPES.BLOCKED_CRIT;
       const reduction = isCrit ? REDUCTION_TIME_CRIT : REDUCTION_TIME_REGULAR;
-      this.spellUsable.reduceCooldown(SPELLS.SHIELD_OF_THE_RIGHTEOUS.id, reduction);
+      const actualReduction = this.spellUsable.reduceCooldown(SPELLS.SHIELD_OF_THE_RIGHTEOUS.id, reduction);
+      this._totalCdr += actualReduction;
+      this._wastedCdr += reduction - actualReduction;
     }
+  }
+
+  get cdrPercentage() {
+    return this._totalCdr / (this.owner.fightDuration + this._totalCdr);
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id} />}
+        label="Effective SotR CDR"
+        value={`${formatPercentage(this.cdrPercentage)}%`}
+        tooltip={`Your Judgment casts reduced the cooldown of Shield of the Righteous by <b>${formatNumber(this._totalCdr / 1000)}s</b> over ${formatNumber(this._casts)} casts, ${formatNumber(this._crits)} of which were critical strikes.<br/>
+            You wasted <b>${formatNumber(this._wastedCdr / 1000)}s</b> of cooldown reduction.`}
+          />
+    );
   }
 }
 

--- a/src/parser/paladin/protection/modules/talents/RighteousProtector.js
+++ b/src/parser/paladin/protection/modules/talents/RighteousProtector.js
@@ -59,7 +59,7 @@ class RighteousProtector extends Analyzer {
       <StatisticBox
         icon={<SpellIcon id={SPELLS.RIGHTEOUS_PROTECTOR_TALENT.id} />}
         value={`${ this.avengingWrathReduced / 1000 } sec`}
-        label="cooldown reduction"
+        label="Righteous Protector CDR"
         tooltip={`
           Avenging Wrath reduction: ${ this.avengingWrathReduced / 1000 }s (${ this.avengingWrathReductionWasted / 1000 }s wasted)<br/>
           ${ lotpName } reduction: ${ (this.lightOfTheProtectorReduced / 1000).toFixed(0) }s (${ (this.lightOfTheProtectorReductionWasted / 1000).toFixed(0) }s wasted)


### PR DESCRIPTION
![screenshot from 2018-10-28 16-13-20](https://user-images.githubusercontent.com/4909458/47621450-9011bd80-dace-11e8-83bd-6f50b6b8efaf.png)

also changed the label of the Righteous Protector cooldown reduction stat to differentiate it.

also also trying something with the changelog. apparently padding (aka blank lines) in json lists can help prevent merge conflicts. merge #2523 first to test this.