### PR TITLE
[Prot] removed arcane torrent suggestion

### DIFF
--- a/src/parser/paladin/protection/CombatLogParser.js
+++ b/src/parser/paladin/protection/CombatLogParser.js
@@ -2,6 +2,7 @@ import CoreCombatLogParser from 'parser/core/CombatLogParser';
 import HealingDone from 'parser/shared/modules/HealingDone';
 import DamageDone from 'parser/shared/modules/DamageDone';
 import DamageTaken from 'parser/shared/modules/DamageTaken';
+import ArcaneTorrent from 'parser/shared/modules/racials/bloodelf/ArcaneTorrent';
 
 import Abilities from './modules/Abilities';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
@@ -54,6 +55,9 @@ class CombatLogParser extends CoreCombatLogParser {
     righteousProtector: RighteousProtector,
     judgment: Judgment,
     seraphim: Seraphim,
+
+    // There's no throughput benefit from casting Arcane Torrent on cooldown
+    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }],
   };
 }
 

--- a/src/parser/shared/modules/racials/bloodelf/ArcaneTorrent.js
+++ b/src/parser/shared/modules/racials/bloodelf/ArcaneTorrent.js
@@ -17,7 +17,7 @@ class ArcaneTorrent extends Analyzer {
     if (!this.active) {
       return;
     }
-    this.castEfficiency = options.castEfficiency || this.castEfficiency;
+    this.castEfficiency = (options.castEfficiency === undefined) ? this.castEfficiency : options.castEfficiency;
 
     this.abilities.add({
       spell: [SPELLS.ARCANE_TORRENT_MANA1, SPELLS.ARCANE_TORRENT_MANA2, SPELLS.ARCANE_TORRENT_MANA3, SPELLS.ARCANE_TORRENT_RAGE, SPELLS.ARCANE_TORRENT_ENERGY, SPELLS.ARCANE_TORRENT_RUNIC_POWER, SPELLS.ARCANE_TORRENT_MONK, SPELLS.ARCANE_TORRENT_FOCUS, SPELLS.ARCANE_TORRENT_FURY],


### PR DESCRIPTION
pretty much what it says in the title :man_shrugging: 

Prot pallies don't actually use mana for anything, so the mana returned by AT is mostly wasted.

Also fixes a bug in the AT module where you actually couldn't turn *off* the AT suggestion via options as was intended.