### PR TITLE
[Beast Mastery] add a suggestion if people use Multishot on ST bosses

### DIFF
--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -507,3 +507,8 @@ export const jos3p = {
   github: 'jos3p',
   discord: 'jos3p#9746',
 };
+export const Streammz = {
+  nickname: 'Streammz',
+  github: 'Streammz',
+  discord: 'Streammz#9999',
+};

--- a/src/parser/hunter/beastmastery/CHANGELOG.js
+++ b/src/parser/hunter/beastmastery/CHANGELOG.js
@@ -1,10 +1,15 @@
 import React from 'react';
 
-import { Putro } from 'CONTRIBUTORS';
+import { Putro, Streammz } from 'CONTRIBUTORS';
 import SpellLink from 'common/SpellLink';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  {
+    date: new Date('2018-10-29'),
+    changes: <>Implement a suggestion that checks for <SpellLink id={SPELLS.MULTISHOT_BM.id} /> usage in single target situations, warning you about multi-shot uses where no paired <SpellLink id={SPELLS.BEAST_CLEAVE_PET_BUFF.id} /> damage has been dealt.</>,
+    contributors: [Streammz],
+  },
   {
     date: new Date('2018-10-25'),
     changes: <>Implemented the new checklist for Beast Mastery, added a <SpellLink id={SPELLS.COBRA_SHOT.id} /> statistic and associated suggestions, and updated <SpellLink id={SPELLS.KILLER_COBRA_TALENT.id} /> suggestions.</>,

--- a/src/parser/hunter/beastmastery/CombatLogParser.js
+++ b/src/parser/hunter/beastmastery/CombatLogParser.js
@@ -24,6 +24,7 @@ import AMurderOfCrows from '../shared/modules/talents/AMurderOfCrows';
 
 //Spells
 import BeastCleave from './modules/spells/BeastCleave';
+import MultiShotSingleTarget from "./modules/spells/MultiShotSingleTarget";
 import CobraShot from './modules/spells/CobraShot';
 import BarbedShot from './modules/spells/BarbedShot';
 import AspectOfTheWild from './modules/spells/AspectOfTheWild';
@@ -63,6 +64,7 @@ class CombatLogParser extends CoreCombatLogParser {
     //Spells
     bestialWrath: BestialWrath,
     beastCleave: BeastCleave,
+    multiShotSingleTarget: MultiShotSingleTarget,
     cobraShot: CobraShot,
     barbedShot: BarbedShot,
     aspectOfTheWild: AspectOfTheWild,

--- a/src/parser/hunter/beastmastery/modules/spells/MultiShotSingleTarget.js
+++ b/src/parser/hunter/beastmastery/modules/spells/MultiShotSingleTarget.js
@@ -62,7 +62,7 @@ class MultiShotSingleTarget extends Analyzer {
 
   get castsWithoutHitsTreshold() {
     return {
-      actual: this.castsWithoutHits + 5,
+      actual: this.castsWithoutHits,
       isGreaterThan: {
         minor: 0,
         average: 0,

--- a/src/parser/hunter/beastmastery/modules/spells/MultiShotSingleTarget.js
+++ b/src/parser/hunter/beastmastery/modules/spells/MultiShotSingleTarget.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import Analyzer from 'parser/core/Analyzer';
+import TraitStatisticBox, { STATISTIC_ORDER } from 'interface/others/TraitStatisticBox';
+import SpellLink from 'common/SpellLink';
+import SPELLS from 'common/SPELLS';
+
+/**
+ * Tracks the amount of multi-shot casts that did not trigger any beast cleave damage
+ *
+ * Example log: https://www.warcraftlogs.com/reports/zjgLyKdZnhMkPJDq#fight=67&type=damage-done&source=915
+ */
+class MultiShotSingleTarget extends Analyzer {
+
+  cleaveUp = false;
+  beastCleaveHits = 0;
+  casts = 0;
+  castsWithoutHits = 0;
+
+  constructor(...args) {
+    super(...args);
+  }
+
+  on_toPlayerPet_applybuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.BEAST_CLEAVE_PET_BUFF.id) {
+      return;
+    }
+
+    // Refreshes? Not sure if this is needed, or if removebuff is called before this.
+    if (this.cleaveUp && this.beastCleaveHits == 0) {
+      this.castsWithoutHits++;
+    }
+
+    this.cleaveUp = true;
+    this.beastCleaveHits = 0;
+  }
+
+  on_toPlayerPet_removebuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.BEAST_CLEAVE_PET_BUFF.id) {
+      return;
+    }
+
+    if (this.beastCleaveHits === 0) {
+      this.castsWithoutHits++;
+    }
+    this.cleaveUp = false;
+  }
+
+  on_byPlayerPet_damage(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.BEAST_CLEAVE_DAMAGE.id) {
+      return;
+    }
+    this.beastCleaveHits++;
+  }
+
+  suggestions(when) {
+    when({
+      actual: this.castsWithoutHits,
+      isGreaterThan: {
+        minor: 0,
+        average: 0,
+        major: 3
+      },
+      style: 'number'
+    }).addSuggestion((suggest, actual, recommended) => {
+      return suggest(<>You've casted <SpellLink id={SPELLS.MULTISHOT_BM.id} /> {actual} time{actual == 1 ? '' : 's'} without your pets doing any <SpellLink id={SPELLS.BEAST_CLEAVE_PET_BUFF.id} /> damage onto additional targets. On single-target situations, avoid using multi-shot.</>)
+        .icon(SPELLS.BEAST_CLEAVE_PET_BUFF.icon)
+        .actual(`${actual} cast${actual == 1 ? '' : 's'} without any Beast Cleave damage`)
+        .recommended(`0 is recommended`);
+    })
+  }
+}
+
+export default MultiShotSingleTarget;


### PR DESCRIPTION
Implementation for the following issue: https://github.com/WoWAnalyzer/WoWAnalyzer/issues/1145

This is how it looks like: https://i.imgur.com/t3p8ngF.png

Currently, it checks for cases where multishot has been used (and thus beast cleave has been applied), and no beast cleave damage has been done within that 4 second Beast Cleave window. 

It adds an _avarage_ suggestion for 1-3 multi-shot casts, and a _major_ suggestion for any more than that. These are just numbers I came up with, so if you feel these numbers should be altered, feel free to do so/recommend better ones!

This is my first contribution to WoWAnalyzer. If there's anything important I should know or something I may have forgotten, please let me know 🙂 