### PR TITLE
[Ele Shaman] Remove 'dot' category for flame shock

### DIFF
--- a/src/parser/shaman/elemental/modules/Abilities.js
+++ b/src/parser/shaman/elemental/modules/Abilities.js
@@ -3,10 +3,6 @@ import SPELLS from 'common/SPELLS';
 import CoreAbilities from 'parser/shared/modules/Abilities';
 
 class Abilities extends CoreAbilities {
-  static SPELL_CATEGORIES = {
-    ...CoreAbilities.SPELL_CATEGORIES,
-    DOTS: 'Dot',
-  };
   spellbook() {
     const combatant = this.selectedCombatant;
     return [
@@ -104,7 +100,7 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.FLAME_SHOCK,
-        category: Abilities.SPELL_CATEGORIES.DOTS,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         gcd: {
           base: 1500,
         },


### PR DESCRIPTION
This custom category didn't match with any existing abilities conventions, current contributor (HawkCorrigan) agrees that it can be removed