### PR TITLE
[Havoc DH] Remove redundant dependencies from Abilities.js

### DIFF
--- a/src/parser/demonhunter/havoc/modules/Abilities.js
+++ b/src/parser/demonhunter/havoc/modules/Abilities.js
@@ -2,18 +2,9 @@ import React from 'react';
 
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
-import AbilityTracker from 'parser/shared/modules/AbilityTracker';
-import Haste from 'parser/shared/modules/Haste';
-
 import CoreAbilities from 'parser/shared/modules/Abilities';
 
-
 class Abilities extends CoreAbilities {
-  static dependencies = {
-    abilityTracker: AbilityTracker,
-    haste: Haste,
-  };
-
   spellbook() {
     const combatant = this.selectedCombatant;
     return [

--- a/src/parser/shaman/elemental/modules/Abilities.js
+++ b/src/parser/shaman/elemental/modules/Abilities.js
@@ -3,10 +3,6 @@ import SPELLS from 'common/SPELLS';
 import CoreAbilities from 'parser/shared/modules/Abilities';
 
 class Abilities extends CoreAbilities {
-  static SPELL_CATEGORIES = {
-    ...CoreAbilities.SPELL_CATEGORIES,
-    DOTS: 'Dot',
-  };
   spellbook() {
     const combatant = this.selectedCombatant;
     return [
@@ -104,7 +100,7 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.FLAME_SHOCK,
-        category: Abilities.SPELL_CATEGORIES.DOTS,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         gcd: {
           base: 1500,
         },


### PR DESCRIPTION
These deps are declared in CoreAbilities and not needed inside the extension