### PR TITLE
[Restoration Shaman] Unleash Life

### DIFF
--- a/src/parser/shaman/restoration/modules/talents/UnleashLife.js
+++ b/src/parser/shaman/restoration/modules/talents/UnleashLife.js
@@ -16,13 +16,14 @@ import CooldownThroughputTracker from '../features/CooldownThroughputTracker';
 
 const UNLEASH_LIFE_HEALING_INCREASE = 0.45;
 const BUFFER_MS = 200;
-const riptideDuration = 18000;
-const unleashLifeBuffDuration = 10000;
+const UNLEASH_LIFE_DURATION = 10000;
+const debug = true;
 
 const CHART_SIZE = 75;
 
 /**
- * This is slightly inaccurate, since if you use UL on 2 Riptides in a row it will lose a few seconds of the first one.
+ * Unleash Life:
+ * Unleashes elemental forces of Life, healing a friendly target and increasing the effect of the Shaman's next direct heal.
  */
 
 class UnleashLife extends Analyzer {
@@ -30,22 +31,32 @@ class UnleashLife extends Analyzer {
     cooldownThroughputTracker: CooldownThroughputTracker,
   };
   healing = 0;
+  healingBuff = {
+    [SPELLS.RIPTIDE.id]: {
+      healing: 0,
+      castAmount: 0,
+      playersActive: [],
+    },
+    [SPELLS.CHAIN_HEAL.id]: {
+      healing: 0,
+      castAmount: 0,
+    },
+    [SPELLS.HEALING_WAVE.id]: {
+      healing: 0,
+      castAmount: 0,
+    },
+    [SPELLS.HEALING_SURGE_RESTORATION.id]: {
+      healing: 0,
+      castAmount: 0,
+    },
+  };
 
   unleashLifeCasts = 0;
   unleashLifeRemaining = 0;
   unleashLifeHealRemaining = 0;
-  unleashLifeFeedRemaining = 0;
 
-  buffedChainHeals = 0;
-  buffedHealingWaves = 0;
-  buffedHealingSurges = 0;
-  buffedRiptides = 0;
-
-  buffedRiptideTimestamp = null;
-  buffedRiptideTarget = null;
   buffedChainHealTimestamp = null;
   lastUnleashLifeTimestamp = null;
-  lastUnleashLifeFeedTimestamp = null;
 
   constructor(...args) {
     super(...args);
@@ -55,35 +66,46 @@ class UnleashLife extends Analyzer {
   on_byPlayer_heal(event) {
     const spellId = event.ability.guid;
 
-    if (event.timestamp > (this.buffedRiptideTimestamp + riptideDuration)) {
-      this.buffedRiptideTimestamp = null;
-      this.buffedRiptideTarget = null;
-    }
-
     if(spellId === SPELLS.UNLEASH_LIFE_TALENT.id) {
-      this.unleashLifeHealRemaining += 1;
-    }
-
-    if((this.lastUnleashLifeTimestamp + unleashLifeBuffDuration) <= event.timestamp) {
-      this.unleashLifeHealRemaining = 0;
-    }
-
-    if (
-      (spellId === SPELLS.HEALING_WAVE.id && this.unleashLifeHealRemaining > 0) || 
-      (spellId === SPELLS.HEALING_SURGE_RESTORATION.id && this.unleashLifeHealRemaining> 0) ||
-      (spellId === SPELLS.CHAIN_HEAL.id) ||
-      (spellId === SPELLS.RIPTIDE.id && !event.tick && this.unleashLifeHealRemaining> 0)
-    ) {
-      const hasUnleashLife = this.selectedCombatant.hasBuff(SPELLS.UNLEASH_LIFE_TALENT.id, event.timestamp, BUFFER_MS, BUFFER_MS);
-
-      if (hasUnleashLife) {
-        this.healing += calculateEffectiveHealing(event, UNLEASH_LIFE_HEALING_INCREASE);
-        this.unleashLifeHealRemaining - 1 < 0 ? this.unleashLifeHealRemaining = 0 : this.unleashLifeHealRemaining -= 1;
-      }
-    } else if (SPELLS.RIPTIDE.id === spellId && event.tick && this.buffedRiptideTarget === event.targetID) {
-      this.healing += calculateEffectiveHealing(event, UNLEASH_LIFE_HEALING_INCREASE);
-    } else if (spellId === SPELLS.UNLEASH_LIFE_TALENT.id) {
+      this.unleashLifeHealRemaining = 1;
+      this.lastUnleashLifeTimestamp = event.timestamp;
       this.healing += event.amount + (event.absorbed || 0);
+    }
+
+    if(this.unleashLifeHealRemaining > 0 && (this.lastUnleashLifeTimestamp + UNLEASH_LIFE_DURATION) <= event.timestamp) {
+      debug && console.log("Heal Timed out", event.timestamp);
+      this.unleashLifeHealRemaining = 0;
+      return;
+    }
+
+    // Thse 3 heals only have 1 event and are handled easily
+    if (this.unleashLifeHealRemaining > 0 && ((spellId === SPELLS.HEALING_WAVE.id) || (spellId === SPELLS.HEALING_SURGE_RESTORATION.id) || (spellId === SPELLS.RIPTIDE.id && !event.tick))) {
+      this.healingBuff[spellId].healing += calculateEffectiveHealing(event, UNLEASH_LIFE_HEALING_INCREASE);
+      this.unleashLifeHealRemaining = 0;
+      debug && console.log("Heal:",spellId);
+
+      // I had to move the HoT application to the heal event as the buffapply event had too many false positives
+      if (spellId === SPELLS.RIPTIDE.id) {
+        this.healingBuff[spellId].playersActive.push(event.targetID);
+        debug && console.log("HoT Applied:",spellId);
+      }
+
+    // Chain heal has up to 4 events so there is something more going on, setting the variable to -1 to indicate that there might be more events coming
+    } else if (spellId === SPELLS.CHAIN_HEAL.id && (this.unleashLifeHealRemaining > 0 || (this.unleashLifeHealRemaining < 0 && this.buffedChainHealTimestamp + BUFFER_MS > event.timestamp))) {
+      this.healingBuff[spellId].healing += calculateEffectiveHealing(event, UNLEASH_LIFE_HEALING_INCREASE);
+      this.unleashLifeHealRemaining = -1;
+      this.buffedChainHealTimestamp = event.timestamp;
+      debug && console.log("Heal:",spellId);
+
+    // Riptide HoT handling
+    } else if (spellId === SPELLS.RIPTIDE.id && this.healingBuff[spellId].playersActive.includes(event.targetID)) {
+      // Ticks on whoever its active
+      if (event.tick) {
+        this.healingBuff[spellId].healing += calculateEffectiveHealing(event, UNLEASH_LIFE_HEALING_INCREASE);
+      // Casting a Riptide without UnL on a target with a buffed Riptide will straight up remove the buff, not even the pandemic part gets anything from the increased healing
+      } else {
+        this.healingBuff[spellId].playersActive.splice(this.healingBuff[spellId].playersActive.indexOf(event.targetID),1);
+      }
     }
   }
 
@@ -92,91 +114,54 @@ class UnleashLife extends Analyzer {
 
     if(spellId === SPELLS.UNLEASH_LIFE_TALENT.id) {
       this.unleashLifeCasts += 1;
-      this.unleashLifeRemaining += 1;
+      this.unleashLifeRemaining = true;
       this.lastUnleashLifeTimestamp = event.timestamp;
+      debug && console.log("New Unleash", event.timestamp);
+    }
+
+    if(this.unleashLifeRemaining && (this.lastUnleashLifeTimestamp + UNLEASH_LIFE_DURATION) <= event.timestamp) {
+      this.unleashLifeRemaining = false;
+      debug && console.log("Cast Timed out", event.timestamp);
+      return;
     }
 
     const hasUnleashLife = this.selectedCombatant.hasBuff(SPELLS.UNLEASH_LIFE_TALENT.id, event.timestamp, BUFFER_MS, BUFFER_MS);
-
     if(!hasUnleashLife) {
       return;
     }
 
     if (this.unleashLifeRemaining) {
-      if((this.lastUnleashLifeTimestamp + unleashLifeBuffDuration) <= event.timestamp) {
-        this.unleashLifeRemaining = 0;
-        return;
-      }
-
-      switch(spellId) {
-        case SPELLS.CHAIN_HEAL.id:
-            this.buffedChainHeals += 1;
-            this.unleashLifeRemaining -= 1;
-          break;
-        case SPELLS.HEALING_WAVE.id:
-            this.buffedHealingWaves += 1;
-            this.unleashLifeRemaining -= 1;
-          break;
-        case SPELLS.HEALING_SURGE_RESTORATION.id:
-            this.buffedHealingSurges += 1;
-            this.unleashLifeRemaining -= 1;
-          break;
-        case SPELLS.RIPTIDE.id:
-            this.buffedRiptides += 1;
-            this.unleashLifeRemaining -= 1;
-          break;
-        default:
-          return;
+      if(this.healingBuff[spellId]) {
+        this.healingBuff[spellId].castAmount += 1;
+        this.unleashLifeRemaining = false;
+        debug && console.log("Cast:",spellId);
       }
     }
   }
 
-  on_byPlayer_applybuff(event) {
+  on_byPlayer_removebuff(event) {
     const spellId = event.ability.guid;
-
     if (spellId !== SPELLS.RIPTIDE.id) {
       return;
     }
 
-    const hasUnleashLife = this.selectedCombatant.hasBuff(SPELLS.UNLEASH_LIFE_TALENT.id, event.timestamp, 0, BUFFER_MS);
-
-    // Saving the buffed riptide target to track the healing done on.
-    if (hasUnleashLife) {
-      this.buffedRiptideTimestamp = event.timestamp;
-      this.buffedRiptideTarget = event.targetID;
-    } else if (event.targetID === this.buffedRiptideTarget) { // if you overwrite the buffed riptide, all value of Unleash Life is lost
-      this.buffedRiptideTimestamp = null;
-      this.buffedRiptideTarget = null;
+    if (!this.healingBuff[spellId].playersActive.includes(event.targetID)) {
+      return;
     }
+
+    this.healingBuff[spellId].playersActive.splice(this.healingBuff[spellId].playersActive.indexOf(event.targetID),1);
   }
 
   on_feed_heal(event) {
-    const spellId = event.ability.guid;
+    // rework
+  }
 
-    if(spellId === SPELLS.UNLEASH_LIFE_TALENT.id) {
-      this.unleashLifeFeedRemaining += 1;
-      this.lastUnleashLifeFeedTimestamp = event.timestamp;
-    }
+  get totalBuffedHealing() {
+    return Object.values(this.healingBuff).reduce((sum, spell) => sum + spell.healing, 0);
+  }
 
-    if((this.lastUnleashLifeFeedTimestamp + unleashLifeBuffDuration) <= event.timestamp) {
-      this.unleashLifeFeedRemaining = 0;
-    }
-
-    if (
-      (spellId === SPELLS.HEALING_WAVE.id && this.unleashLifeFeedRemaining > 0) || 
-      (spellId === SPELLS.HEALING_SURGE_RESTORATION.id && this.unleashLifeFeedRemaining> 0) ||
-      (spellId === SPELLS.CHAIN_HEAL.id) ||
-      (spellId === SPELLS.RIPTIDE.id && !event.tick && this.unleashLifeFeedRemaining> 0)
-    ) {
-      const hasUnleashLife = this.selectedCombatant.hasBuff(SPELLS.UNLEASH_LIFE_TALENT.id, event.timestamp, BUFFER_MS, BUFFER_MS);
-
-      if (hasUnleashLife) {
-        this.healing += event.feed * UNLEASH_LIFE_HEALING_INCREASE;
-        this.unleashLifeFeedRemaining - 1 < 0 ? this.unleashLifeFeedRemaining = 0 : this.unleashLifeFeedRemaining -= 1;
-      }
-    } else if (SPELLS.RIPTIDE.id === spellId && event.tick && this.buffedRiptideTarget === event.targetID) {
-      this.healing += event.feed * UNLEASH_LIFE_HEALING_INCREASE;
-    }
+  get totalUses() {
+    return Object.values(this.healingBuff).reduce((sum, spell) => sum + spell.castAmount, 0);
   }
 
   legend(items, total) {
@@ -251,38 +236,37 @@ class UnleashLife extends Analyzer {
   }
 
   unleashLifeCastRatioChart() {
-    const totalUses = this.buffedChainHeals + this.buffedHealingWaves + this.buffedHealingSurges + this.buffedRiptides;
-    const unusedUL = this.unleashLifeCasts - totalUses;
+    const unusedUL = this.unleashLifeCasts - this.totalUses;
 
     const items = [
       {
         color: SPELLS.CHAIN_HEAL.color,
         label: 'Chain Heal',
         spellId: SPELLS.CHAIN_HEAL.id,
-        value: this.buffedChainHeals,
+        value: this.healingBuff[SPELLS.CHAIN_HEAL.id].castAmount,
       },
       {
         color: SPELLS.HEALING_WAVE.color,
         label: 'Healing Wave',
         spellId: SPELLS.HEALING_WAVE.id,
-        value: this.buffedHealingWaves,
+        value: this.healingBuff[SPELLS.HEALING_WAVE.id].castAmount,
       },
       {
         color: SPELLS.HEALING_SURGE_RESTORATION.color,
         label: 'Healing Surge',
         spellId: SPELLS.HEALING_SURGE_RESTORATION.id,
-        value: this.buffedHealingSurges,
+        value: this.healingBuff[SPELLS.HEALING_SURGE_RESTORATION.id].castAmount,
       },
       {
         color: SPELLS.RIPTIDE.color,
         label: 'Riptide',
         spellId: SPELLS.RIPTIDE.id,
-        value: this.buffedRiptides,
+        value: this.healingBuff[SPELLS.RIPTIDE.id].castAmount,
       },
       {
         color: '#CC3D20',
         label: 'Unused Buffs',
-        tooltip: `The amount of Unleash Life buffs you did not use out of the total available. You cast ${this.unleashLifeCasts} Unleash Lifes, of which you used ${totalUses}.`,
+        tooltip: `The amount of Unleash Life buffs you did not use out of the total available. You cast ${this.unleashLifeCasts} Unleash Lifes, of which you used ${this.totalUses}.`,
         value: unusedUL,
       },
     ];
@@ -293,7 +277,7 @@ class UnleashLife extends Analyzer {
           {this.chart(items)}
         </div>
         <div className="flex-main" style={{ fontSize: '80%', paddingTop: 3 }}>
-          {this.legend(items, totalUses)}
+          {this.legend(items, this.totalUses)}
         </div>
       </div>
     );
@@ -317,7 +301,8 @@ class UnleashLife extends Analyzer {
     return (
       <StatisticListBoxItem
         title={<SpellLink id={SPELLS.UNLEASH_LIFE_TALENT.id} />}
-        value={`${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing + feeding))} %`}
+        value={`${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing + this.totalBuffedHealing + feeding))} %`}
+        valueTooltip={`${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing + feeding))}% from Unleash Life and ${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.totalBuffedHealing))}% from the healing buff.`}
       />
     );
   }

--- a/src/parser/shaman/restoration/modules/talents/UnleashLife.js
+++ b/src/parser/shaman/restoration/modules/talents/UnleashLife.js
@@ -127,11 +127,6 @@ class UnleashLife extends Analyzer {
       return;
     }
 
-    const hasUnleashLife = this.selectedCombatant.hasBuff(SPELLS.UNLEASH_LIFE_TALENT.id, event.timestamp, BUFFER_MS, BUFFER_MS);
-    if (!hasUnleashLife) {
-      return;
-    }
-
     if (this.unleashLifeRemaining) {
       if (this.healingBuff[spellId]) {
         this.healingBuff[spellId].castAmount += 1;


### PR DESCRIPTION
Reworks Unleash Life a bit. Motivation comes from needing to find out the healing distribution between the spells for a future module, and also to improve accuracy, as that wasn't quite there (riptide mostly).

The player_heal function is definitely a bit overloaded, but with how UnL works it does make other solutions hard (unless I'm missing something).
Casts & Heals essentially go through the same logic, as the combat log order for that is unreliable. Either standalone work fine.

I ran into issues using applybuff events for Riptide, with situations like this where Riptide isn't affected by Unleash Life (already consumed by Surge), but the `hasBuff(UnleashLife)` function will always return true here: 
![image](https://user-images.githubusercontent.com/2842471/47688810-5ed8e080-dbe7-11e8-82bf-c104922e345b.png)

Added a tooltip for more detail on the breakdown: 
![image](https://user-images.githubusercontent.com/2842471/47688897-abbcb700-dbe7-11e8-9cc3-399cce13984b.png)
https://www.warcraftlogs.com/reports/pCTvHnmtLR1wjDQa/#fight=50&source=12