### PR TITLE
[Beast Mastery] Make the Global Cooldown during AOTW use proper haste values.

### DIFF
--- a/src/parser/hunter/beastmastery/modules/core/GlobalCooldown.js
+++ b/src/parser/hunter/beastmastery/modules/core/GlobalCooldown.js
@@ -1,5 +1,4 @@
 import CoreGlobalCooldown from 'parser/shared/modules/GlobalCooldown';
-import StatTracker from 'parser/shared/modules/StatTracker';
 import Channeling from 'parser/shared/modules/Channeling';
 import SPELLS from 'common/SPELLS';
 import Haste from 'parser/shared/modules/Haste';
@@ -32,7 +31,6 @@ class GlobalCooldown extends CoreGlobalCooldown {
   static dependencies = {
     abilities: Abilities,
     haste: Haste,
-    statTracker: StatTracker,
     channeling: Channeling,
   };
 

--- a/src/parser/hunter/beastmastery/modules/core/GlobalCooldown.js
+++ b/src/parser/hunter/beastmastery/modules/core/GlobalCooldown.js
@@ -43,7 +43,7 @@ class GlobalCooldown extends CoreGlobalCooldown {
     }
     if (spellId && ASPECT_AFFECTED_ABILTIES.includes(spellId) && this.selectedCombatant.hasBuff(SPELLS.ASPECT_OF_THE_WILD.id)) {
       let unhastedAspectGCD = MAX_GCD - ASPECT_GCD_REDUCTION;
-      const hastepercent = 1 + this.statTracker.currentHastePercentage;
+      const hastepercent = 1 + this.haste.current;
       if (spellId === SPELLS.ASPECT_OF_THE_WILD.id) {
         // Aspect of the wild has a GCD of 1.3s in the spelldata - this is to account for the GCD reduction of the buff it gives
         // The issue is that the buff applies before the cast event making Aspect of the Wild double dip from the GCD reduction it provides


### PR DESCRIPTION
Currently BM is showing an error on the Timeline for users that the Global Cooldown has not been configured properly, and after investigating, I found that the haste values used during our cooldown AOTW use the wrong numbers with certain buffs up, such as time-warp and bloodlust.

The reason this happens, is because currently it is using the StatTracker to calculate the current haste, but buffs like Time Warp is a percentage based buff, and thus not representable using a stat tracker. Arguably this may even be a different issue itself.

To ensure the `GlobalCooldown.js` module for Beast Mastery is consistent with the shared `CoreGlobalCooldown` module, I've changed it to instead use `this.haste.current` instead, which the shared module also uses.