### PR TITLE
Add bin/setup script for easy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Now you need to pull a copy of the codebase onto your computer. Make a fork of t
 
 When cloning finishes, open a command window to the source and run the command `npm install`. This will take a minute or two the first time. While it's running, copy the `.env.local.example` file in the project root, and name it `.env.local`. Now you need to fill the WCL API key. To get your key, login to Warcraft Logs and go to [your profile](https://www.warcraftlogs.com/profile). Scroll to the bottom, enter an **Application Name** (this is required) and copy the **public key**, then replace `INSERT_YOUR_OWN_API_KEY_HERE` in `.env.local` with this key.
 
+Optionally if you're on a bash compatible machine, you can run `bin/setup` for an interactive setup of this application.
+
 Once all that's done you're ready to fire up the development server! Just run the command `npm start` in the project root. The first start will take another minute.
 
 <table align="center">

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "== Installing Dependencies =="
+npm install
+
+echo "== Copying .env.local if needed =="
+if [ ! -f .env.local ]; then
+  read -sp "Please enter your Warcraft Logs Public Api Key: " api_key
+  cp .env.local.example .env.local
+  sed -i s/INSERT_YOUR_OWN_API_KEY_HERE/$api_key/ .env.local
+fi


### PR DESCRIPTION
A bin/setup goes through the initial setup of this application
interactively

If this doesn't get accepted, I totally understand. This slightly reduces the friction for onboarding, and is something I personally love to see in projects. Every project has it's own setup and it's convenient to be able to run a script and have the setup steps be automated.