### PR TITLE
[Beast Mastery] Implement a Killer Instinct module

### DIFF
--- a/src/parser/hunter/beastmastery/CHANGELOG.js
+++ b/src/parser/hunter/beastmastery/CHANGELOG.js
@@ -6,6 +6,11 @@ import SPELLS from 'common/SPELLS';
 
 export default [
   {
+    date: new Date('2018-10-31'),
+    changes: <>Implement statistics for the talent <SpellLink id={SPELLS.KILLER_INSTINCT_TALENT.id} />.</>,
+    contributors: [Streammz],
+  },
+  {
     date: new Date('2018-10-29'),
     changes: <>Implement a suggestion that checks for <SpellLink id={SPELLS.MULTISHOT_BM.id} /> usage in single target situations, warning you about multi-shot uses where no paired <SpellLink id={SPELLS.BEAST_CLEAVE_PET_BUFF.id} /> damage has been dealt.</>,
     contributors: [Streammz],

--- a/src/parser/hunter/beastmastery/CombatLogParser.js
+++ b/src/parser/hunter/beastmastery/CombatLogParser.js
@@ -12,6 +12,7 @@ import FocusUsage from '../shared/modules/features/FocusUsage';
 import TimeFocusCapped from '../shared/modules/features/TimeFocusCapped';
 
 //Talents
+import KillerInstinct from './modules/talents/KillerInstinct';
 import NaturalMending from '../shared/modules/talents/NaturalMending';
 import Trailblazer from '../shared/modules/talents/Trailblazer';
 import Barrage from '../shared/modules/talents/Barrage';
@@ -70,6 +71,7 @@ class CombatLogParser extends CoreCombatLogParser {
     aspectOfTheWild: AspectOfTheWild,
 
     //Talents
+    killerInstinct: KillerInstinct,
     chimaeraShot: ChimaeraShot,
     direBeast: DireBeast,
     naturalMending: NaturalMending,

--- a/src/parser/hunter/beastmastery/modules/features/TraitsAndTalents.js
+++ b/src/parser/hunter/beastmastery/modules/features/TraitsAndTalents.js
@@ -9,6 +9,7 @@ import Barrage from 'parser/hunter/shared/modules/talents/Barrage';
 import ChimaeraShot from 'parser/hunter/beastmastery/modules/talents/ChimaeraShot';
 import Stampede from 'parser/hunter/beastmastery/modules/talents/Stampede';
 import Stomp from 'parser/hunter/beastmastery/modules/talents/Stomp';
+import KillerInstinct from 'parser/hunter/beastmastery/modules/talents/KillerInstinct';
 import BarbedShot from '../spells/BarbedShot';
 import BeastCleave from '../spells/BeastCleave';
 import AMurderOfCrows from '../../../shared/modules/talents/AMurderOfCrows';
@@ -18,6 +19,7 @@ class TraitsAndTalents extends Analyzer {
     beastCleave: BeastCleave,
     barrage: Barrage,
     barbedShot: BarbedShot,
+    killerInstinct: KillerInstinct,
     chimaeraShot: ChimaeraShot,
     stampede: Stampede,
     stomp: Stomp,
@@ -42,6 +44,7 @@ class TraitsAndTalents extends Analyzer {
         {this.barbedShot.active && this.barbedShot.subStatistic()}
         {this.barrage.active && this.barrage.subStatistic()}
         {this.beastCleave.active && this.beastCleave.subStatistic()}
+        {this.killerInstinct.active && this.killerInstinct.subStatistic()}
         {this.chimaeraShot.active && this.chimaeraShot.subStatistic()}
         {this.stampede.active && this.stampede.subStatistic()}
         {this.stomp.active && this.stomp.subStatistic()}

--- a/src/parser/hunter/beastmastery/modules/talents/KillerInstinct.js
+++ b/src/parser/hunter/beastmastery/modules/talents/KillerInstinct.js
@@ -1,11 +1,14 @@
 import React from 'react';
+import SpellLink from 'common/SpellLink';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
+import ItemDamageDone from 'interface/others/ItemDamageDone';
+import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
 import SpellIcon from 'common/SpellIcon';
 
 import SPELLS from 'common/SPELLS';
 import Analyzer from 'parser/core/Analyzer';
-import { formatNumber, formatPercentage } from 'common/format';
+import { formatNumber } from 'common/format';
 
 
 const KILLER_INSTINCT_TRESHOLD = 0.35;
@@ -41,17 +44,23 @@ class KillerInstinct extends Analyzer {
   }
 
   statistic() {
-    const damageThroughputPercent = this.owner.getPercentageOfTotalDamageDone(this.damage);
-    const dps = this.damage / this.owner.fightDuration * 1000;
-
     return (
       <TalentStatisticBox
         position={STATISTIC_ORDER.OPTIONAL()}
         icon={<SpellIcon id={SPELLS.KILLER_INSTINCT_TALENT.id} />}
-        value={<>{formatNumber(this.castsWithExecute)} casts at &lt;35% health<br />{formatPercentage(damageThroughputPercent)} % / {formatNumber(dps)} DPS</>}
+        value={<>{formatNumber(this.castsWithExecute)} casts at &lt;35% health</>}
         label="Killer Instinct"
         tooltip={`You've casted a total of ${this.casts} Kill Commands, of which ${this.castsWithExecute} were on enemies with less than 35% of their health remaining.
                   These ${this.castsWithExecute} casts have provided you a total of ${formatNumber(this.damage)} extra damage throughout the fight.`}
+      />
+    );
+  }
+
+  subStatistic() {
+    return (
+      <StatisticListBoxItem
+        title={<SpellLink id={SPELLS.KILLER_INSTINCT_TALENT.id} />}
+        value={<ItemDamageDone amount={this.damage} />}
       />
     );
   }

--- a/src/parser/hunter/beastmastery/modules/talents/KillerInstinct.js
+++ b/src/parser/hunter/beastmastery/modules/talents/KillerInstinct.js
@@ -4,16 +4,21 @@ import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
+import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
 import SpellIcon from 'common/SpellIcon';
 
 import SPELLS from 'common/SPELLS';
 import Analyzer from 'parser/core/Analyzer';
 import { formatNumber } from 'common/format';
 
-
 const KILLER_INSTINCT_TRESHOLD = 0.35;
 const KILLER_INSTINCT_CONTRIBUTION = 0.5;
 
+/**
+ * Kill Command deals 50% increased damage against enemies below 35% health.
+ *
+ * Example log: https://www.warcraftlogs.com/reports/CznQpdmRFBJkjg4w/#fight=40&source=16&type=damage-done
+ */
 class KillerInstinct extends Analyzer {
   casts = 0;
   castsWithExecute = 0;
@@ -35,10 +40,7 @@ class KillerInstinct extends Analyzer {
     if (enemyHealthPercent <= KILLER_INSTINCT_TRESHOLD) {
       this.castsWithExecute++;
 
-      const totalDamage = (event.amount + event.absorbed);
-      const baseDamage = totalDamage / (1 + KILLER_INSTINCT_CONTRIBUTION);
-      const traitDamage = totalDamage - baseDamage;
-
+      const traitDamage = calculateEffectiveDamage(event, KILLER_INSTINCT_CONTRIBUTION);
       this.damage += traitDamage;
     }
   }
@@ -50,8 +52,8 @@ class KillerInstinct extends Analyzer {
         icon={<SpellIcon id={SPELLS.KILLER_INSTINCT_TALENT.id} />}
         value={<>{formatNumber(this.castsWithExecute)} casts at &lt;35% health</>}
         label="Killer Instinct"
-        tooltip={`You've casted a total of ${this.casts} Kill Commands, of which ${this.castsWithExecute} were on enemies with less than 35% of their health remaining.
-                  These ${this.castsWithExecute} casts have provided you a total of ${formatNumber(this.damage)} extra damage throughout the fight.`}
+        tooltip={`You cast a total of ${this.casts} Kill Commands, of which ${this.castsWithExecute} were on enemies with less than 35% of their health remaining.
+                  These ${this.castsWithExecute} casts provided you a total of ${formatNumber(this.damage)} extra damage throughout the fight.`}
       />
     );
   }

--- a/src/parser/hunter/beastmastery/modules/talents/KillerInstinct.js
+++ b/src/parser/hunter/beastmastery/modules/talents/KillerInstinct.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
+import TalentStatisticBox from 'interface/others/TalentStatisticBox';
+import SpellIcon from 'common/SpellIcon';
+
+import SPELLS from 'common/SPELLS';
+import Analyzer from 'parser/core/Analyzer';
+import { formatNumber, formatPercentage } from 'common/format';
+
+
+const KILLER_INSTINCT_TRESHOLD = 0.35;
+const KILLER_INSTINCT_CONTRIBUTION = 0.5;
+
+class KillerInstinct extends Analyzer {
+  casts = 0;
+  castsWithExecute = 0;
+  damage = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.KILLER_INSTINCT_TALENT.id);
+  }
+
+  on_byPlayerPet_damage(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.KILL_COMMAND_PET.id) {
+      return;
+    }
+
+    this.casts++;
+    const enemyHealthPercent = (event.hitPoints / event.maxHitPoints);
+    if (enemyHealthPercent <= KILLER_INSTINCT_TRESHOLD) {
+      this.castsWithExecute++;
+
+      const totalDamage = (event.amount + event.absorbed);
+      const baseDamage = totalDamage / (1 + KILLER_INSTINCT_CONTRIBUTION);
+      const traitDamage = totalDamage - baseDamage;
+
+      this.damage += traitDamage;
+    }
+  }
+
+  statistic() {
+    const damageThroughputPercent = this.owner.getPercentageOfTotalDamageDone(this.damage);
+    const dps = this.damage / this.owner.fightDuration * 1000;
+
+    return (
+      <TalentStatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
+        icon={<SpellIcon id={SPELLS.KILLER_INSTINCT_TALENT.id} />}
+        value={<>{formatNumber(this.castsWithExecute)} casts at &lt;35% health<br />{formatPercentage(damageThroughputPercent)} % / {formatNumber(dps)} DPS</>}
+        label="Killer Instinct"
+        tooltip={`You've casted a total of ${this.casts} Kill Commands, of which ${this.castsWithExecute} were on enemies with less than 35% of their health remaining.
+                  These ${this.castsWithExecute} casts have provided you a total of ${formatNumber(this.damage)} extra damage throughout the fight.`}
+      />
+    );
+  }
+}
+
+export default KillerInstinct;


### PR DESCRIPTION
Implement a module for the Level 15 Beast Mastery talent _Killer Instinct_, as requested by #2529 

![2018-1031_11-45-44](https://user-images.githubusercontent.com/626948/47783322-b0c25900-dd02-11e8-914b-18beb5c5973e.png)
![2018-1031_11-46-46](https://user-images.githubusercontent.com/626948/47783324-b1f38600-dd02-11e8-859f-19b5992f6b38.png)

It currently only adds a statistic in the Talents section, mentioning how many casts have been done when the enemy had less than 35% of it's health left, and another substatistic in the _Spells, Traits and Talents_ section showing how much damage has been contributed by this talent.