### PR TITLE
fix wikilink

### DIFF
--- a/src/parser/shared/modules/features/TimelineTab/TabComponent/index.js
+++ b/src/parser/shared/modules/features/TimelineTab/TabComponent/index.js
@@ -25,7 +25,7 @@ class TimelineTab extends React.PureComponent {
         </div>
         {!isAbilityCooldownsAccurate && (
           <Danger style={{ marginTop: 10, marginBottom: 10 }}>
-            Spell cooldown durations could not be shown because this spec's spell cooldown durations have not been properly configured yet. See <a href="https://github.com/WoWAnalyzer/WoWAnalyzer/wiki/Abilities#how-to-configure-the-spell-cooldown-durations-properly">this page</a> if you're interested in contributing improvements.
+            Spell cooldown durations could not be shown because this spec's spell cooldown durations have not been properly configured yet. See <a href="https://github.com/WoWAnalyzer/WoWAnalyzer/wiki/Module:-Abilities#how-to-configure-the-spell-cooldown-durations-properly">this page</a> if you're interested in contributing improvements.
           </Danger>
         )}
         {!isGlobalCooldownAccurate && (


### PR DESCRIPTION
Clicking on the link leads to a "Create new page" if logged into github (or contributing if not), probably because the wikipage was renamed.

![link1](https://user-images.githubusercontent.com/3185600/47837066-e6228180-ddaa-11e8-9e27-b6aa7f744c82.jpg)

example from discord: https://wowanalyzer.com/report/hzw9FHMqGYP7Z3fd/1-Heroic+Taloc+-+Kill+(4:07)/16-Anikka/timeline