### PR TITLE
[Beast Mastery] Implement talent statistics and suggestions for the Stampede module

### DIFF
--- a/src/parser/hunter/beastmastery/modules/talents/Stampede.js
+++ b/src/parser/hunter/beastmastery/modules/talents/Stampede.js
@@ -2,22 +2,55 @@ import React from 'react';
 
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
+import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import Analyzer from 'parser/core/Analyzer';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
+import StatisticBox from 'interface/others/StatisticBox';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+import SpellIcon from 'common/SpellIcon';
+import { formatNumber, formatMilliseconds } from 'common/format';
+
+// The potential amount of hits per target per stampede cast.
+// By checking through various Zek'voz logs, it seems to consistently hit the boss 18 times, except if the boss was moved.
+// By using this number, we can calculate the average amount of targets hit per cast.
+const STAMPEDE_POTENTIAL_HITS = 18;
 
 /**
  * Summon a herd of stampeding animals from the wilds around you that deal damage to your enemies for 12 sec.
  *
  * Example log: https://www.warcraftlogs.com/reports/KQjC6mh74wDBV2Zp#fight=17&type=damage-done&source=21&translate=true
+ * Example log with suggestion triggered: https://www.warcraftlogs.com/reports/z3TH89XagA1hcP7G/#fight=20&source=238
  */
-
 class Stampede extends Analyzer {
+
+  casts = [];
   damage = 0;
+  hits = 0;
+  averageHits = 0;
+  inefficientCasts = 0;
+
 
   constructor(...args) {
     super(...args);
     this.active = this.selectedCombatant.hasTalent(SPELLS.STAMPEDE_TALENT.id);
+  }
+
+  get currentCast() {
+    if (this.casts.length === 0) {
+      return null;
+    }
+
+    return this.casts[this.casts.length - 1];
+  }
+
+  on_byPlayer_applybuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.STAMPEDE_TALENT.id) {
+      return;
+    }
+
+    this.casts.push({ timestamp: event.timestamp, damage: 0, hits: 0, averageHits: 0 });
   }
 
   on_byPlayer_damage(event) {
@@ -25,7 +58,87 @@ class Stampede extends Analyzer {
     if (spellId !== SPELLS.STAMPEDE_DAMAGE.id) {
       return;
     }
-    this.damage += event.amount + (event.absorbed || 0);
+    const damage = event.amount + (event.absorbed || 0);
+
+    this.hits++;
+    this.damage += damage;
+
+    if (this.currentCast !== null) {
+      this.currentCast.hits++;
+      this.currentCast.damage += damage;
+    }
+  }
+
+  on_finished() {
+    this.averageHits = this.hits / this.casts.length / STAMPEDE_POTENTIAL_HITS;
+    this.casts.forEach((cast) => {
+      cast.averageHits = cast.hits / STAMPEDE_POTENTIAL_HITS;
+
+      if (cast.averageHits < 1) {
+        this.inefficientCasts++;
+      }
+    });
+  }
+
+  get stampedeInefficientCastsTreshold() {
+    return {
+      actual: this.inefficientCasts,
+      isGreaterThan: {
+        minor: 0,
+        average: 0,
+        major: 1
+      },
+      style: 'number',
+    };
+  }
+
+  suggestions(when) {
+    when(this.stampedeInefficientCastsTreshold)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<>You cast <SpellLink id={SPELLS.STAMPEDE_TALENT.id} /> inefficiently {actual} {actual > 1 ? "times" : "time"} throughout the fight. This means you've placed <SpellLink id={SPELLS.STAMPEDE_TALENT.id} /> at a place where it was impossible for it to deal it's full damage, or the enemy moved out of it. Avoid using <SpellLink id={SPELLS.STAMPEDE_TALENT.id} /> on moments where it's likely the enemy will be moving out of it.</>)
+          .icon(SPELLS.STAMPEDE_TALENT.icon)
+          .actual(`${actual} inefficient ${actual > 1 ? "casts" : "cast"}`)
+          .recommended(`${recommended} is recommended`);
+      });
+  }
+
+  statistic() {
+    if (this.casts.length > 0) {
+      const averageHit = this.damage / this.hits;
+      const stampedePlural = this.casts.length === 1 ? `1 Stampede` : `a total of ${this.casts.length} Stampedes`;
+      return (
+        <StatisticBox
+          position={STATISTIC_ORDER.OPTIONAL()}
+          icon={<SpellIcon id={SPELLS.STAMPEDE_TALENT.id} />}
+          value={<>{this.casts.length} casts / {this.hits} hits</>}
+          label="Stampede"
+          category={STATISTIC_CATEGORY.TALENTS}
+          tooltip={`You cast ${stampedePlural} in the fight, which hit enemies ${this.hits} times for an average of ${formatNumber(averageHit)} damage per hit.`}
+        >
+          <table className="table table-condensed">
+            <thead>
+              <tr>
+                <th>Cast at</th>
+                <th>Damage</th>
+                <th>Hits</th>
+                <th>Avg hit</th>
+              </tr>
+            </thead>
+            <tbody>
+              {this.casts.map((cast, idx) => (
+                <tr key={idx}>
+                  <td>{formatMilliseconds(cast.timestamp - this.owner.fight.start_time)}</td>
+                  <td>{formatNumber(cast.damage)}</td>
+                  <td>{cast.hits}</td>
+                  <td>{formatNumber(cast.damage / cast.hits)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </StatisticBox>
+      );
+    }
+    return null;
   }
 
   subStatistic() {

--- a/src/parser/hunter/beastmastery/modules/talents/Stampede.js
+++ b/src/parser/hunter/beastmastery/modules/talents/Stampede.js
@@ -86,7 +86,7 @@ class Stampede extends Analyzer {
       isGreaterThan: {
         minor: 0,
         average: 0,
-        major: 1
+        major: 1,
       },
       style: 'number',
     };
@@ -110,7 +110,7 @@ class Stampede extends Analyzer {
         <StatisticBox
           position={STATISTIC_ORDER.OPTIONAL()}
           icon={<SpellIcon id={SPELLS.STAMPEDE_TALENT.id} />}
-          value={<>{this.casts.length} casts / {this.hits} hits</>}
+          value={<>{this.casts.length} {this.casts.length > 1 ? "casts" : "cast"} / {this.hits} hits</>}
           label="Stampede"
           category={STATISTIC_CATEGORY.TALENTS}
           tooltip={`You cast ${stampedePlural} in the fight, which hit enemies ${this.hits} times for an average of ${formatNumber(averageHit)} damage per hit.`}


### PR DESCRIPTION
In regards to #2529, this adds more statistics and suggestions for the _Stampede_ level 90 talent.

First it adds an extra expandable statistics sheet in the _Talents_ section:
![image](https://user-images.githubusercontent.com/626948/47857789-d460ce80-ddea-11e8-984e-4c7aca989d8a.png)
![image](https://user-images.githubusercontent.com/626948/47857747-bc894a80-ddea-11e8-8655-b22acff72bb3.png)

Second, it adds a suggestion regarding inefficient Stampede usage, where not all potential stampede hits actually hit the target:
![image](https://user-images.githubusercontent.com/626948/47857699-9cf22200-ddea-11e8-9dc6-b9db1e20d177.png)

The already existing damage contribution is untouched.