### PR TITLE
[Destruction] Fixed Fire and Brimstone talent

### DIFF
--- a/src/parser/warlock/destruction/CHANGELOG.js
+++ b/src/parser/warlock/destruction/CHANGELOG.js
@@ -7,6 +7,11 @@ import SPELLS from 'common/SPELLS';
 
 export default [
   {
+    date: new Date('2018-11-02'),
+    changes: <><SpellLink id={SPELLS.FIRE_AND_BRIMSTONE_TALENT.id} /> should now correctly track bonus fragments and cleaved damage again.</>,
+    contributors: [Chizu],
+  },
+  {
     date: new Date('2018-10-02'),
     changes: <>Fixed <SpellLink id={SPELLS.ERADICATION_TALENT.id} /> to snapshot the debuff on cast instead of damage.</>,
     contributors: [Chizu],

--- a/src/parser/warlock/destruction/CombatLogParser.js
+++ b/src/parser/warlock/destruction/CombatLogParser.js
@@ -14,7 +14,7 @@ import SoulShardDetails from './modules/soulshards/SoulShardDetails';
 import Backdraft from './modules/features/Backdraft';
 import Eradication from './modules/talents/Eradication';
 import ReverseEntropy from './modules/talents/ReverseEntropy';
-// import FireAndBrimstone from './modules/talents/FireAndBrimstone';
+import FireAndBrimstone from './modules/talents/FireAndBrimstone';
 import ChannelDemonfire from './modules/talents/ChannelDemonfire';
 import GrimoireOfSupremacy from './modules/talents/GrimoireOfSupremacy';
 import SoulConduit from './modules/talents/SoulConduit';
@@ -40,7 +40,7 @@ class CombatLogParser extends CoreCombatLogParser {
     backdraft: Backdraft,
     eradication: Eradication,
     reverseEntropy: ReverseEntropy,
-    // fireAndBrimstone: FireAndBrimstone,
+    fireAndBrimstone: FireAndBrimstone,
     channelDemonfire: ChannelDemonfire,
     grimoireOfSupremacy: GrimoireOfSupremacy,
     soulConduit: SoulConduit,

--- a/src/parser/warlock/destruction/modules/talents/FireAndBrimstone.js
+++ b/src/parser/warlock/destruction/modules/talents/FireAndBrimstone.js
@@ -4,16 +4,18 @@ import Analyzer from 'parser/core/Analyzer';
 import ISSUE_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
 
 import SpellLink from 'common/SpellLink';
-import { formatNumber, formatPercentage } from 'common/format';
+import { formatThousands } from 'common/format';
 import SPELLS from 'common/SPELLS';
+
+import HIT_TYPES from 'game/HIT_TYPES';
 
 import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
 
-// TODO: Broken on BFA - try on for example /report/1A2cLdJDwfxWhHaZ/18-Normal+Zek'voz+-+Kill+(3:47)/11-Clibano
+const debug = false;
 class FireAndBrimstone extends Analyzer {
   _primaryTargets = [];
 
-  generatedCleaveFragments = 0;
+  bonusFragments = 0;
   bonusDmg = 0;
 
   constructor(...args) {
@@ -25,6 +27,7 @@ class FireAndBrimstone extends Analyzer {
     if (event.ability.guid !== SPELLS.INCINERATE.id) {
       return;
     }
+    debug && this.log(`Storing Incinerate cast on ${event.targetID}, ${event.targetInstance}`);
     this._primaryTargets.push({
       timestamp: event.timestamp,
       targetID: event.targetID,
@@ -32,28 +35,30 @@ class FireAndBrimstone extends Analyzer {
     });
   }
 
-  // TODO: verify how this works on BFA (if still on cast or damage or how)
-  on_soulshardfragment_gained(event) {
+  on_byPlayer_damage(event) {
     if (event.ability.guid !== SPELLS.INCINERATE.id) {
       return;
     }
     // should find FIRST (oldest) Incinerate cast, so even though you can fire multiple Incinerates before the first hits, this should pair the events correctly even if they have the same ID and instance
     const primaryTargetEventIndex = this._primaryTargets.findIndex(primary => primary.targetID === event.targetID && primary.targetInstance === event.targetInstance);
     if (primaryTargetEventIndex !== -1) {
+      debug && this.log(`Found Incinerate cast on ${event.targetID}, ${event.targetInstance}`);
       // it's a Incinerate damage on primary target, delete the event so it doesn't interfere with another casts
       this._primaryTargets.splice(primaryTargetEventIndex, 1);
       return;
     }
+    debug && this.log(`Incinerate CLEAVE on ${event.targetID}, ${event.targetInstance}`);
     // should be cleaved damage
-    this.generatedCleaveFragments += event.amount;
-    this.bonusDmg += event.damage;
+    this.bonusFragments += (event.hitType === HIT_TYPES.CRIT) ? 2 : 1;
+    this.bonusDmg += event.amount + (event.absorbed || 0);
+    debug && this.log(`Current bonus fragments: ${this.bonusFragments}`);
   }
 
   suggestions(when) {
     // this is incorrect in certain situations with pre-casted Incinerates, but there's very little I can do about it
     // example: pre-cast Incinerate -> *combat starts* -> hard cast Incinerate -> first Incinerate lands -> second Incinerate lands
     // but because the second Incinerate "technically" doesn't have a cast event to pair with, it's incorrectly recognized as cleaved
-    when(this.generatedCleaveFragments).isEqual(0)
+    when(this.bonusFragments).isEqual(0)
       .addSuggestion(suggest => {
         return suggest(<>Your <SpellLink id={SPELLS.FIRE_AND_BRIMSTONE_TALENT.id} icon /> talent didn't contribute any bonus fragments. When there are no adds to cleave onto, this talent is useless and you should switch to a different talent.</>)
           .icon(SPELLS.FIRE_AND_BRIMSTONE_TALENT.icon)
@@ -66,9 +71,9 @@ class FireAndBrimstone extends Analyzer {
   subStatistic() {
     return (
       <StatisticListBoxItem
-        title={<SpellLink id={SPELLS.FIRE_AND_BRIMSTONE_TALENT.id}>FnB Gain</SpellLink>}
-        value={`${this.generatedCleaveFragments} bonus Fragments`}
-        valueTooltip={`Your Fire and Brimstone talent also contributed ${formatNumber(this.bonusDmg)} bonus cleave damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.bonusDmg))}%).`}
+        title={<><SpellLink id={SPELLS.FIRE_AND_BRIMSTONE_TALENT.id} /> bonus fragments</>}
+        value={this.bonusFragments}
+        valueTooltip={`Your Fire and Brimstone talent also contributed ${formatThousands(this.bonusDmg)} bonus cleave damage (${this.owner.formatItemDamageDone(this.bonusDmg)}).`}
       />
     );
   }

--- a/src/parser/warlock/destruction/modules/talents/index.js
+++ b/src/parser/warlock/destruction/modules/talents/index.js
@@ -6,14 +6,14 @@ import StatisticsListBox from 'interface/others/StatisticsListBox';
 
 import ReverseEntropy from './ReverseEntropy';
 import ChannelDemonfire from './ChannelDemonfire';
-// import FireAndBrimstone from './FireAndBrimstone';
+import FireAndBrimstone from './FireAndBrimstone';
 import SoulConduit from './SoulConduit';
 import GrimoireOfSupremacy from './GrimoireOfSupremacy';
 
 class TalentStatisticBox extends Analyzer {
   static dependencies = {
     reverseEntropy: ReverseEntropy,
-    // fireAndBrimstone: FireAndBrimstone,
+    fireAndBrimstone: FireAndBrimstone,
     channelDemonfire: ChannelDemonfire,
     soulConduit: SoulConduit,
     grimoireOfSupremacy: GrimoireOfSupremacy,


### PR DESCRIPTION
Fire and Brimstone talent was disabled a little while ago because of it was wired to a system that got removed. This fixes it to work correctly again.

Example log - /report/M7rwPTjc2QK34JDa/25-LFR+Zul+-+Kill+(4:37)/19-Alucar/
![image](https://user-images.githubusercontent.com/5068584/47903642-3f121880-de84-11e8-8cc0-c784b653fa98.png)
