### PR TITLE
[Destruction] Checklist implementation

### DIFF
--- a/src/parser/warlock/affliction/CONFIG.js
+++ b/src/parser/warlock/affliction/CONFIG.js
@@ -18,10 +18,10 @@ export default {
   // TODO: once there is an estabilished "rule of thumb" rotation, put it in the description
   description: (
     <>
-      Hello fellow Netherlords! With some help from a theorycrafter from Warlock Discord, we've put together this tool to help you improve your gameplay. It should be fine for you generally, but it will be even more useful in an expert's hands. <br /> <br />
+      Hello fellow Netherlords! With some help from <strong>Motoko</strong> from Warlock Discord, we've put together this tool to help you improve your gameplay. It should be fine for you generally, but it will be even more useful in an expert's hands. <br /> <br />
 
-      If you have any questions about Warlocks, feel free to pay a visit to <a href="https://goo.gl/7PH6Bn" target="_blank" rel="noopener noreferrer">Council of the Black Harvest Discord</a>
-      or <a href="http://lockonestopshop.com" target="_blank" rel="noopener noreferrer">Lock One Stop Shop</a>, if you'd like to discuss anything about this analyzer, message me @Chizu on WoWAnalyzer Discord.
+      If you have any questions about Warlocks, feel free to pay a visit to <a href="https://goo.gl/7PH6Bn" target="_blank" rel="noopener noreferrer">Council of the Black Harvest Discord</a>&nbsp;
+      or <a href="http://lockonestopshop.com" target="_blank" rel="noopener noreferrer">Lock One Stop Shop</a>, if you'd like to discuss anything about this analyzer, message me @Chizu#2873 on WoWAnalyzer Discord.
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.

--- a/src/parser/warlock/affliction/CONFIG.js
+++ b/src/parser/warlock/affliction/CONFIG.js
@@ -20,7 +20,7 @@ export default {
     <>
       Hello fellow Netherlords! With some help from <strong>Motoko</strong> from Warlock Discord, we've put together this tool to help you improve your gameplay. It should be fine for you generally, but it will be even more useful in an expert's hands. <br /> <br />
 
-      If you have any questions about Warlocks, feel free to pay a visit to <a href="https://goo.gl/7PH6Bn" target="_blank" rel="noopener noreferrer">Council of the Black Harvest Discord</a>&nbsp;
+      If you have any questions about Warlocks, feel free to pay a visit to <a href="https://discord.gg/BlackHarvest" target="_blank" rel="noopener noreferrer">Council of the Black Harvest Discord</a>&nbsp;
       or <a href="http://lockonestopshop.com" target="_blank" rel="noopener noreferrer">Lock One Stop Shop</a>, if you'd like to discuss anything about this analyzer, message me @Chizu#2873 on WoWAnalyzer Discord.
     </>
   ),

--- a/src/parser/warlock/demonology/CONFIG.js
+++ b/src/parser/warlock/demonology/CONFIG.js
@@ -22,7 +22,7 @@ export default {
 
       I'm terribly sorry if you see your Downtime (time not spent doing anything) in negative numbers as that makes no sense but I currently have no clue as to why it happens. Any help with that from some savvy programmer would be appreciated. <br /> <br />
 
-      If you have any questions about Warlocks, feel free to pay a visit to <a href="https://goo.gl/7PH6Bn" target="_blank" rel="noopener noreferrer">Council of the Black Harvest Discord</a>, if you'd like to discuss anything about this analyzer, leave a message on the GitHub issue or message either @Chizu or @🥓Hordehobbs on WoWAnalyzer Discord.<br /><br />
+      If you have any questions about Warlocks, feel free to pay a visit to <a href="https://discord.gg/BlackHarvest" target="_blank" rel="noopener noreferrer">Council of the Black Harvest Discord</a>, if you'd like to discuss anything about this analyzer, leave a message on the GitHub issue or message either @Chizu or @🥓Hordehobbs on WoWAnalyzer Discord.<br /><br />
 
       <Warning>
         The Demonology Warlock analysis isn't complete yet. What we do show should be good to use, but it does not show the complete picture.<br />

--- a/src/parser/warlock/destruction/CHANGELOG.js
+++ b/src/parser/warlock/destruction/CHANGELOG.js
@@ -7,6 +7,11 @@ import SPELLS from 'common/SPELLS';
 
 export default [
   {
+    date: new Date('2018-11-03'),
+    changes: 'Implemented Checklist for Destruction Warlocks.',
+    contributors: [Chizu],
+  },
+  {
     date: new Date('2018-11-02'),
     changes: <><SpellLink id={SPELLS.FIRE_AND_BRIMSTONE_TALENT.id} /> should now correctly track bonus fragments and cleaved damage again.</>,
     contributors: [Chizu],

--- a/src/parser/warlock/destruction/CONFIG.js
+++ b/src/parser/warlock/destruction/CONFIG.js
@@ -1,11 +1,8 @@
 import React from 'react';
 
 import { Chizu } from 'CONTRIBUTORS';
-import SpellLink from 'common/SpellLink';
-import SPELLS from 'common/SPELLS';
 import retryingPromise from 'common/retryingPromise';
 import SPECS from 'game/SPECS';
-import Warning from 'interface/common/Alert/Warning';
 
 import CHANGELOG from './CHANGELOG';
 
@@ -20,16 +17,10 @@ export default {
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
-      Hello fellow Netherlords! While I gotta admit this tool feels more like a statistic than something that really helps you (just yet!), I hope it still is useful to you. Any suggestions as to what could be useful to see are welcome and I'll try to implement them in order for this tool to be more than just a glorified WCL log. <br /> <br />
+      Hello fellow Netherlords! With some help from <strong>Motoko</strong> from Warlock Discord, we've put together this tool to help you improve your gameplay. It should be fine for you generally, but it will be even more useful in an expert's hands. <br /> <br />
 
-      As for a general rule of thumb - keep your <SpellLink id={SPELLS.IMMOLATE_DEBUFF.id} /> up as much as you can, cast <SpellLink id={SPELLS.CONFLAGRATE.id} /> on CD. Dump shards into fat <SpellLink id={SPELLS.CHAOS_BOLT.id} /> and just overall don't forget to cast spells when you have them (<SpellLink id={SPELLS.CHANNEL_DEMONFIRE_TALENT.id} />, <SpellLink id={SPELLS.HAVOC.id} /> when there's something to cleave etc.). <br /> <br />
-
-      If you have any questions about Warlocks, feel free to pay a visit to <a href="https://goo.gl/7PH6Bn" target="_blank" rel="noopener noreferrer">Council of the Black Harvest Discord</a>, if you'd like to discuss anything about this analyzer, leave a message on the GitHub issue or message me @Chizu on WoWAnalyzer Discord.<br /><br />
-
-      <Warning>
-        The Destruction Warlock analysis isn't complete yet. What we do show should be good to use, but it does not show the complete picture.<br />
-        If there is something missing, incorrect, or inaccurate, please report it on <a href="https://github.com/WoWAnalyzer/WoWAnalyzer/issues/new">GitHub</a> or contact us on <a href="https://discord.gg/AxphPxU">Discord</a>.
-      </Warning>
+      If you have any questions about Warlocks, feel free to pay a visit to <a href="https://goo.gl/7PH6Bn" target="_blank" rel="noopener noreferrer">Council of the Black Harvest Discord</a>&nbsp;
+      or <a href="http://lockonestopshop.com" target="_blank" rel="noopener noreferrer">Lock One Stop Shop</a>, if you'd like to discuss anything about this analyzer, message me @Chizu#2873 on WoWAnalyzer Discord.
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.

--- a/src/parser/warlock/destruction/CONFIG.js
+++ b/src/parser/warlock/destruction/CONFIG.js
@@ -19,7 +19,7 @@ export default {
     <>
       Hello fellow Netherlords! With some help from <strong>Motoko</strong> from Warlock Discord, we've put together this tool to help you improve your gameplay. It should be fine for you generally, but it will be even more useful in an expert's hands. <br /> <br />
 
-      If you have any questions about Warlocks, feel free to pay a visit to <a href="https://goo.gl/7PH6Bn" target="_blank" rel="noopener noreferrer">Council of the Black Harvest Discord</a>&nbsp;
+      If you have any questions about Warlocks, feel free to pay a visit to <a href="https://discord.gg/BlackHarvest" target="_blank" rel="noopener noreferrer">Council of the Black Harvest Discord</a>&nbsp;
       or <a href="http://lockonestopshop.com" target="_blank" rel="noopener noreferrer">Lock One Stop Shop</a>, if you'd like to discuss anything about this analyzer, message me @Chizu#2873 on WoWAnalyzer Discord.
     </>
   ),

--- a/src/parser/warlock/destruction/CombatLogParser.js
+++ b/src/parser/warlock/destruction/CombatLogParser.js
@@ -7,6 +7,7 @@ import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
 import ImmolateUptime from './modules/features/ImmolateUptime';
 import Havoc from './modules/features/Havoc';
+import Checklist from './modules/features/Checklist/Module';
 
 import SoulShardTracker from './modules/soulshards/SoulShardTracker';
 import SoulShardDetails from './modules/soulshards/SoulShardDetails';
@@ -33,6 +34,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Core
     havoc: Havoc,
+    checklist: Checklist,
     soulShardTracker: SoulShardTracker,
     soulShardDetails: SoulShardDetails,
 

--- a/src/parser/warlock/destruction/modules/features/Checklist/Component.js
+++ b/src/parser/warlock/destruction/modules/features/Checklist/Component.js
@@ -1,0 +1,110 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import SpellLink from 'common/SpellLink';
+import SPELLS from 'common/SPELLS';
+
+import Checklist from 'parser/shared/modules/features/Checklist2';
+import Rule from 'parser/shared/modules/features/Checklist2/Rule';
+import Requirement from 'parser/shared/modules/features/Checklist2/Requirement';
+import PreparationRule from 'parser/shared/modules/features/Checklist2/PreparationRule';
+import GenericCastEfficiencyRequirement from 'parser/shared/modules/features/Checklist2/GenericCastEfficiencyRequirement';
+
+class DestructionWarlockChecklist extends React.PureComponent {
+  static propTypes = {
+    castEfficiency: PropTypes.object.isRequired,
+    combatant: PropTypes.shape({
+      hasTalent: PropTypes.func.isRequired,
+      hasTrinket: PropTypes.func.isRequired,
+    }).isRequired,
+    thresholds: PropTypes.object.isRequired,
+    shardTracker: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { combatant, castEfficiency, thresholds, shardTracker } = this.props;
+
+    const AbilityRequirement = props => (
+      <GenericCastEfficiencyRequirement
+        castEfficiency={castEfficiency.getCastEfficiencyForSpellId(props.spell)}
+        {...props}
+      />
+    );
+
+    return (
+      <Checklist>
+        <Rule
+          name="Use your core spells"
+          description={(
+            <>
+              Destruction Warlocks have a simple rotation core. Maintain your <SpellLink id={SPELLS.IMMOLATE.id} /> on all enemies if possible, don't waste your <SpellLink id={SPELLS.CONFLAGRATE.id} /> and <SpellLink id={SPELLS.BACKDRAFT.id} /> stacks. Use <SpellLink id={SPELLS.HAVOC.id} /> whenever there's something else to cleave.
+            </>
+          )}
+        >
+          <Requirement
+            name={<><SpellLink id={SPELLS.IMMOLATE.id} /> uptime</>}
+            thresholds={thresholds.immolate}
+          />
+          <AbilityRequirement spell={SPELLS.CONFLAGRATE.id} />
+          <Requirement
+            name={<>Wasted <SpellLink id={SPELLS.BACKDRAFT.id} /> stacks per minute</>}
+            thresholds={thresholds.wastedBackdraft}
+          />
+        </Rule>
+        <Rule
+          name="Don't cap your Soul Shard Fragments"
+          description="Soul Shards are your most important resource and since you are in control of their generation, it's very important to plan your rotation and not let them cap."
+        >
+          <Requirement
+            name="Wasted fragments per minute"
+            thresholds={thresholds.soulShards}
+            valueTooltip={`You wasted ${shardTracker.wasted} fragments.`}
+          />
+        </Rule>
+        <Rule
+          name="Use your cooldowns and talents"
+          description="Be mindful of your talent choices and use them when it's appropriate. It's okay to hold on a cooldown for a little bit when the encounter requires it (burn phases or priority targets), but generally speaking you should use them as much as you can."
+        >
+          {combatant.hasTalent(SPELLS.ERADICATION_TALENT.id) && (
+            <Requirement
+              name={<><SpellLink id={SPELLS.ERADICATION_TALENT.id} /> uptime</>}
+              thresholds={thresholds.eradication}
+            />
+          )}
+          {combatant.hasTalent(SPELLS.SHADOWBURN_TALENT.id) && <AbilityRequirement spell={SPELLS.SHADOWBURN_TALENT.id} />}
+          {combatant.hasTalent(SPELLS.CATACLYSM_TALENT.id) && <AbilityRequirement spell={SPELLS.CATACLYSM_TALENT.id} />}
+          {combatant.hasTalent(SPELLS.CHANNEL_DEMONFIRE_TALENT.id) && <AbilityRequirement spell={SPELLS.CHANNEL_DEMONFIRE_TALENT.id} />}
+          {combatant.hasTalent(SPELLS.SOUL_FIRE_TALENT.id) && <AbilityRequirement spell={SPELLS.SOUL_FIRE_TALENT.id} />}
+          <AbilityRequirement spell={SPELLS.SUMMON_INFERNAL.id} />
+          {combatant.hasTalent(SPELLS.DARK_SOUL_INSTABILITY_TALENT.id) && <AbilityRequirement spell={SPELLS.DARK_SOUL_INSTABILITY_TALENT.id} />}
+        </Rule>
+        <Rule
+          name="Use your utility and defensive spells"
+          description={(
+            <>
+              Use other spells in your toolkit to your advantage. For example, you can try to minimize necessary movement by using <SpellLink id={SPELLS.DEMONIC_GATEWAY_CAST.id} icon />, <SpellLink id={SPELLS.DEMONIC_CIRCLE_TALENT.id} icon />, <SpellLink id={SPELLS.BURNING_RUSH_TALENT.id} icon /> or mitigate incoming damage with <SpellLink id={SPELLS.UNENDING_RESOLVE.id} icon />/<SpellLink id={SPELLS.DARK_PACT_TALENT.id} icon />.<br />
+              While you shouldn't cast these defensives on cooldown, be aware of them and use them whenever effective. Not using them at all indicates you might not be aware of them or not using them optimally.
+            </>
+          )}
+        >
+          {combatant.hasTalent(SPELLS.DEMONIC_CIRCLE_TALENT.id) && <AbilityRequirement spell={SPELLS.DEMONIC_CIRCLE_TELEPORT.id} />}
+          {combatant.hasTalent(SPELLS.DARK_PACT_TALENT.id) && <AbilityRequirement spell={SPELLS.DARK_PACT_TALENT.id} />}
+          <AbilityRequirement spell={SPELLS.UNENDING_RESOLVE.id} />
+        </Rule>
+        <Rule
+          name="Always be casting"
+          description={(
+            <>
+              You should try to avoid doing nothing during the fight. When you have to move, try to save some <SpellLink id={SPELLS.CONFLAGRATE.id} /> charges or try to utilize <SpellLink id={SPELLS.DEMONIC_CIRCLE_TALENT.id} icon>Teleport</SpellLink> or <SpellLink id={SPELLS.DEMONIC_GATEWAY_CAST.id} icon>Gateway</SpellLink> to reduce the movement even further.
+            </>
+          )}
+        >
+          <Requirement name="Downtime" thresholds={thresholds.downtime} />
+        </Rule>
+        <PreparationRule thresholds={thresholds} />
+      </Checklist>
+    );
+  }
+}
+
+export default DestructionWarlockChecklist;

--- a/src/parser/warlock/destruction/modules/features/Checklist/Module.js
+++ b/src/parser/warlock/destruction/modules/features/Checklist/Module.js
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import Analyzer from 'parser/core/Analyzer';
+import CastEfficiency from 'parser/shared/modules/CastEfficiency';
+import Combatants from 'parser/shared/modules/Combatants';
+import PreparationRuleAnalyzer from 'parser/shared/modules/features/Checklist2/PreparationRuleAnalyzer';
+
+import AlwaysBeCasting from '../AlwaysBeCasting';
+import ImmolateUptime from '../ImmolateUptime';
+import Backdraft from '../Backdraft';
+import SoulShardDetails from '../../soulshards/SoulShardDetails';
+import SoulShardTracker from '../../soulshards/SoulShardTracker';
+import Eradication from '../../talents/Eradication';
+
+import Component from './Component';
+
+class Checklist extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    castEfficiency: CastEfficiency,
+    alwaysBeCasting: AlwaysBeCasting,
+    preparationRuleAnalyzer: PreparationRuleAnalyzer,
+
+    immolateUptime: ImmolateUptime,
+    backdraft: Backdraft,
+    soulShardDetails: SoulShardDetails,
+    soulShardTracker: SoulShardTracker,
+    eradication: Eradication,
+  };
+
+  render() {
+    return (
+      <Component
+        castEfficiency={this.castEfficiency}
+        combatant={this.combatants.selected}
+        thresholds={{
+          ...this.preparationRuleAnalyzer.thresholds,
+          immolate: this.immolateUptime.suggestionThresholds,
+          wastedBackdraft: this.backdraft.suggestionThresholds,
+          eradication: this.eradication.suggestionThresholds,
+          soulShards: this.soulShardDetails.suggestionThresholds,
+          downtime: this.alwaysBeCasting.suggestionThresholds,
+        }}
+        shardTracker={this.soulShardTracker}
+      />
+    );
+  }
+}
+
+export default Checklist;


### PR DESCRIPTION
Destro isn't a very complicated spec so this is pretty simple like "use your stuff, don't cap resources" etc. I also updated configs for both Destro and Affli and removed the Warning from Destro as I'm actively working on it right now. I still got some things to add but it's mostly talent related "statistic" stuff, `how much damage did talent X do` etc., so I don't think it's blocking players from using this.

Example log (from which the screen is): /report/7aKQwdf4M86BcGgx/46-Mythic+Zul+-+Kill+(3:23)/83-Strungol/

PS. Not a clue why the warning is shown on the timeline, all haste buffs should be implemented by now (Overwhelming Power, elemental Whirl, Reverse Entropy). Maybe only Reorigination Array and Backdraft but that's affecting cast time, not haste.

![image](https://user-images.githubusercontent.com/5068584/47956907-fd30c180-dfac-11e8-818b-3a8e0658aee5.png)
