### PR TITLE
[Destruction] Inferno and Roaring Blaze

### DIFF
--- a/src/parser/warlock/destruction/CHANGELOG.js
+++ b/src/parser/warlock/destruction/CHANGELOG.js
@@ -7,6 +7,11 @@ import SPELLS from 'common/SPELLS';
 
 export default [
   {
+    date: new Date('2018-11-04'),
+    changes: <>Added <SpellLink id={SPELLS.INFERNO_TALENT.id} /> and <SpellLink id={SPELLS.ROARING_BLAZE_TALENT.id} /> talent modules.</>,
+    contributors: [Chizu],
+  },
+  {
     date: new Date('2018-11-02'),
     changes: <><SpellLink id={SPELLS.FIRE_AND_BRIMSTONE_TALENT.id} /> should now correctly track bonus fragments and cleaved damage again.</>,
     contributors: [Chizu],

--- a/src/parser/warlock/destruction/CombatLogParser.js
+++ b/src/parser/warlock/destruction/CombatLogParser.js
@@ -14,6 +14,7 @@ import SoulShardDetails from './modules/soulshards/SoulShardDetails';
 import Backdraft from './modules/features/Backdraft';
 import Eradication from './modules/talents/Eradication';
 import ReverseEntropy from './modules/talents/ReverseEntropy';
+import Inferno from './modules/talents/Inferno';
 import FireAndBrimstone from './modules/talents/FireAndBrimstone';
 import ChannelDemonfire from './modules/talents/ChannelDemonfire';
 import GrimoireOfSupremacy from './modules/talents/GrimoireOfSupremacy';
@@ -40,6 +41,7 @@ class CombatLogParser extends CoreCombatLogParser {
     backdraft: Backdraft,
     eradication: Eradication,
     reverseEntropy: ReverseEntropy,
+    inferno: Inferno,
     fireAndBrimstone: FireAndBrimstone,
     channelDemonfire: ChannelDemonfire,
     grimoireOfSupremacy: GrimoireOfSupremacy,

--- a/src/parser/warlock/destruction/CombatLogParser.js
+++ b/src/parser/warlock/destruction/CombatLogParser.js
@@ -17,6 +17,7 @@ import ReverseEntropy from './modules/talents/ReverseEntropy';
 import Inferno from './modules/talents/Inferno';
 import FireAndBrimstone from './modules/talents/FireAndBrimstone';
 import ChannelDemonfire from './modules/talents/ChannelDemonfire';
+import RoaringBlaze from './modules/talents/RoaringBlaze';
 import GrimoireOfSupremacy from './modules/talents/GrimoireOfSupremacy';
 import SoulConduit from './modules/talents/SoulConduit';
 import Talents from './modules/talents';
@@ -44,6 +45,7 @@ class CombatLogParser extends CoreCombatLogParser {
     inferno: Inferno,
     fireAndBrimstone: FireAndBrimstone,
     channelDemonfire: ChannelDemonfire,
+    roaringBlaze: RoaringBlaze,
     grimoireOfSupremacy: GrimoireOfSupremacy,
     soulConduit: SoulConduit,
     talents: Talents,

--- a/src/parser/warlock/destruction/modules/talents/Inferno.js
+++ b/src/parser/warlock/destruction/modules/talents/Inferno.js
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import Analyzer from 'parser/core/Analyzer';
+import AbilityTracker from 'parser/shared/modules/AbilityTracker';
+
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import { formatThousands } from 'common/format';
+
+import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
+
+import SoulShardTracker from '../soulshards/SoulShardTracker';
+
+const FRAGMENTS_PER_CHAOS_BOLT = 20;
+const FRAGMENTS_PER_RAIN_OF_FIRE = 30;
+
+/*
+    Inferno (Tier 60 Destruction talent):
+      Rain of Fire damage has a 20% chance to generate a Soul Shard Fragment.
+ */
+class Inferno extends Analyzer {
+  static dependencies = {
+    soulShardTracker: SoulShardTracker,
+    abilityTracker: AbilityTracker,
+  };
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.INFERNO_TALENT.id);
+  }
+
+  get averageRainOfFireDamage() {
+    // Rain of Fire has different spellId for cast and damage but AbilityTracker picks up both of them
+    const rofDamage = this.abilityTracker.getAbility(SPELLS.RAIN_OF_FIRE_DAMAGE.id);
+    const rofCast = this.abilityTracker.getAbility(SPELLS.RAIN_OF_FIRE_CAST.id);
+    return ((rofDamage.damageEffective + rofDamage.damageAbsorbed) / rofCast.casts) || 0;
+  }
+
+  get averageChaosBoltDamage() {
+    const chaosBolt = this.abilityTracker.getAbility(SPELLS.CHAOS_BOLT.id);
+    return ((chaosBolt.damageEffective + chaosBolt.damageAbsorbed) / chaosBolt.casts) || 0;
+  }
+
+  subStatistic() {
+    // ESTIMATED fragments from Rain of Fire, see comments in SoulShardTracker._getRandomFragmentDistribution()
+    const fragments = this.soulShardTracker.getGeneratedBySpell(SPELLS.RAIN_OF_FIRE_DAMAGE.id);
+    const estimatedRofDamage = Math.floor(fragments / FRAGMENTS_PER_RAIN_OF_FIRE) * this.averageRainOfFireDamage;
+    const estimatedChaosBoltDamage = Math.floor(fragments / FRAGMENTS_PER_CHAOS_BOLT) * this.averageChaosBoltDamage;
+    return (
+      <StatisticListBoxItem
+        title={<><strong>Estimated</strong> bonus fragments from <SpellLink id={SPELLS.INFERNO_TALENT.id} /></>}
+        value={fragments}
+        valueTooltip={`While majority of sources of Soul Shard Fragments are certain, chance based sources (Inferno and Immolate crits) make tracking the fragments 100% correctly impossible (fragment generation is NOT in logs).<br /><br />
+            If you used all these bonus fragments on Chaos Bolts, they would do ${formatThousands(estimatedChaosBoltDamage)} damage (${this.owner.formatItemDamageDone(estimatedChaosBoltDamage)}).<br />
+            If you used them on Rain of Fires, they would do ${formatThousands(estimatedRofDamage)} damage (${this.owner.formatItemDamageDone(estimatedRofDamage)}).<br />
+            Both of these estimates are based on average damage of respective spells during the fight.`}
+      />
+    );
+  }
+}
+
+export default Inferno;

--- a/src/parser/warlock/destruction/modules/talents/RoaringBlaze.js
+++ b/src/parser/warlock/destruction/modules/talents/RoaringBlaze.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import Analyzer from 'parser/core/Analyzer';
+
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import { formatThousands } from 'common/format';
+
+import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
+
+/*
+  Roaring Blaze (Tier 90 Destruction talent):
+    Conflagrate burns the target for an additional (48% of Spell power) Fire damage over 6 sec.
+ */
+class RoaringBlaze extends Analyzer {
+  damage = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.ROARING_BLAZE_TALENT.id);
+  }
+
+  on_byPlayer_damage(event) {
+    if (event.ability.guid !== SPELLS.ROARING_BLAZE_DAMAGE.id) {
+      return;
+    }
+    this.damage += (event.amount || 0) + (event.absorbed || 0);
+  }
+
+  subStatistic() {
+    return (
+      <StatisticListBoxItem
+        title={<><SpellLink id={SPELLS.ROARING_BLAZE_TALENT.id} /> damage</>}
+        value={formatThousands(this.damage)}
+        valueTooltip={this.owner.formatItemDamageDone(this.damage)}
+      />
+    );
+  }
+}
+
+export default RoaringBlaze;

--- a/src/parser/warlock/destruction/modules/talents/index.js
+++ b/src/parser/warlock/destruction/modules/talents/index.js
@@ -6,6 +6,7 @@ import StatisticsListBox from 'interface/others/StatisticsListBox';
 
 import ReverseEntropy from './ReverseEntropy';
 import ChannelDemonfire from './ChannelDemonfire';
+import Inferno from './Inferno';
 import FireAndBrimstone from './FireAndBrimstone';
 import SoulConduit from './SoulConduit';
 import GrimoireOfSupremacy from './GrimoireOfSupremacy';
@@ -13,6 +14,7 @@ import GrimoireOfSupremacy from './GrimoireOfSupremacy';
 class TalentStatisticBox extends Analyzer {
   static dependencies = {
     reverseEntropy: ReverseEntropy,
+    inferno: Inferno,
     fireAndBrimstone: FireAndBrimstone,
     channelDemonfire: ChannelDemonfire,
     soulConduit: SoulConduit,

--- a/src/parser/warlock/destruction/modules/talents/index.js
+++ b/src/parser/warlock/destruction/modules/talents/index.js
@@ -9,6 +9,7 @@ import ChannelDemonfire from './ChannelDemonfire';
 import Inferno from './Inferno';
 import FireAndBrimstone from './FireAndBrimstone';
 import SoulConduit from './SoulConduit';
+import RoaringBlaze from './RoaringBlaze';
 import GrimoireOfSupremacy from './GrimoireOfSupremacy';
 
 class TalentStatisticBox extends Analyzer {
@@ -18,6 +19,7 @@ class TalentStatisticBox extends Analyzer {
     fireAndBrimstone: FireAndBrimstone,
     channelDemonfire: ChannelDemonfire,
     soulConduit: SoulConduit,
+    roaringBlaze: RoaringBlaze,
     grimoireOfSupremacy: GrimoireOfSupremacy,
   };
 


### PR DESCRIPTION
Part 3 out of 4 talent related PRs. This time Inferno and Roaring Blaze. To explain the Inferno tooltip - Soul Shard Fragments aren't in logs as `energize` events (with exception of I think only Soul Conduit, which gives whole shards), so I have to track them manually. Which is fine (majority of them are deterministic, e.g. Incinerate gives 2 fragments, +1 on crit, Conflagrate gives 5 fragments etc.), but Immolate crits *can* (50% chance) give 1 fragment, and Inferno talent makes Rain of Fire damage events have 20% chance to add a fragment too.

More information is in here https://github.com/WoWAnalyzer/WoWAnalyzer/blob/9edc1a4cf32ccde46c949063114e0befe3a1a6ce/src/parser/warlock/destruction/modules/soulshards/SoulShardTracker.js#L157, but the point is, I can assign fragments to known sources and those that are "left out", are then redistributed between Immolate and Rain of Fire, but it's only an **estimate**.

As with other modules, I tried to put a damage estimate on the fragments to give them some kind of "graspable value". If you think it's wrong or misleading, let me know.

Example log for Inferno: `/report/6hdzJbt4CNHrZV7A/10-LFR+Zul+-+Kill+(5:33)/88-Snorelord`
Example log for Roaring Blaze: `/report/wgWk38LzcDxmBpKq/21-LFR+Taloc+-+Kill+(4:35)/103-Avarita`

![image](https://user-images.githubusercontent.com/5068584/47968293-3da14580-e068-11e8-9a71-c33dc4f980dd.png)

![image](https://user-images.githubusercontent.com/5068584/47968297-4eea5200-e068-11e8-808a-44ad5828c5fc.png)

