### PR TITLE
[Assasination] Update timeline with buffs & debuffs and missing GCDs

### DIFF
--- a/src/common/SPELLS/rogue.js
+++ b/src/common/SPELLS/rogue.js
@@ -395,6 +395,22 @@ export default {
     name: 'Elaborate Planning',
     icon: 'inv_misc_map08',
   },
+  SUBTERFUGE_BUFF: {
+    id: 115192,
+    name: 'Subterfuge',
+    icon: 'rogue_subterfuge',
+  },
+  MASTER_ASSASIN_BUFF: {
+    id: 256735,
+    name: 'Master Assasin',
+    icon: 'ability_criticalstrike',
+  },
+  TOXIC_BLADE_DEBUFF: {
+    id: 245389,
+    name: 'Toxic Blade',
+    icon: 'inv_weapon_shortblade_62',
+  },
+  
 
   //Outlaw
 

--- a/src/parser/core/CASTS_THAT_ARENT_CASTS.js
+++ b/src/parser/core/CASTS_THAT_ARENT_CASTS.js
@@ -26,4 +26,5 @@ export default [
   SPELLS.CHAOS_BLADES_DAMAGE_MH.id, // Chaos Blades "casts" when you auto attack with the buff on. So the cast means nothing, just the buff application (SPELLS.CHAOS_BLADES_BUFF)
   255724, // proc from a Legion Antorus trinket
   SPELLS.GALECALLERS_BOON_CAST.id, //This can be used off GCD
+  SPELLS.MUTILATE_OFFHAND.id, // Mutilate off hand
 ];

--- a/src/parser/rogue/assassination/CHANGELOG.js
+++ b/src/parser/rogue/assassination/CHANGELOG.js
@@ -3,9 +3,14 @@ import React from 'react';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 
-import { tsabo, Cloake, Zerotorescue } from 'CONTRIBUTORS';
+import { tsabo, Cloake, Zerotorescue, Gebuz } from 'CONTRIBUTORS';
 
 export default [
+  {
+    date: new Date('2018-11-04'),
+    changes: 'Updated timeline with buffs & debuffs and added missing GCDs',
+    contributors: [Gebuz],
+  },
   {
     date: new Date('2018-08-02'),
     changes: 'Added natural energy regen.',

--- a/src/parser/rogue/assassination/CONFIG.js
+++ b/src/parser/rogue/assassination/CONFIG.js
@@ -11,7 +11,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [tsabo, Cloake],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '7.3',
+  patchCompatibility: '8.0.1',
   // If set to  false`, the spec will show up as unsupported.
   isSupported: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.

--- a/src/parser/rogue/assassination/modules/Abilities.js
+++ b/src/parser/rogue/assassination/modules/Abilities.js
@@ -12,15 +12,17 @@ class Abilities extends CoreAbilities {
         gcd: {
           static: 1000,
         },
+        buffSpellId: SPELLS.ENVENOM.id,
       },
       {
         spell: SPELLS.GARROTE,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         // During the Subterfuge buff (from the talent), the spell has no cd
-        cooldown: () => combatant.hasBuff(SPELLS.SUBTERFUGE_TALENT.id) ? 0 : 6,
+        cooldown: () => combatant.hasBuff(SPELLS.SUBTERFUGE_BUFF.id) ? 0 : 6,
         gcd: {
           static: 1000,
         },
+        buffSpellId: SPELLS.GARROTE.id,
       },
       {
         spell: SPELLS.MUTILATE,
@@ -42,6 +44,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           static: 1000,
         },
+        buffSpellId: SPELLS.RUPTURE.id,
       },
       {
         spell: SPELLS.BLINDSIDE_TALENT,
@@ -62,8 +65,11 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.CRIMSON_TEMPEST_TALENT,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        gcd: null,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
+        gcd: {
+          static: 1000,
+        },
+        buffSpellId: SPELLS.CRIMSON_TEMPEST_TALENT.id,
         enabled: combatant.hasTalent(SPELLS.CRIMSON_TEMPEST_TALENT.id),
       },
       // Rotational AOE
@@ -82,6 +88,10 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: true,
         },
+        gcd: {
+          base: 1000,
+        },
+        buffSpellId: SPELLS.VENDETTA.id,
       },
       {
         spell: SPELLS.VANISH,
@@ -90,6 +100,7 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: true,
         },
+        buffSpellId: combatant.hasTalent(SPELLS.SUBTERFUGE_TALENT.id) ? SPELLS.SUBTERFUGE_BUFF.id : SPELLS.MASTER_ASSASIN_BUFF.id,
       },
       {
         spell: SPELLS.TOXIC_BLADE_TALENT,
@@ -101,9 +112,8 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(SPELLS.TOXIC_BLADE_TALENT.id),
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: 0.90,
-          extraSuggestion: 'Use on cooldown, or delay for Vendetta if less then 10 seconds remain.',
         },
+        buffSpellId: SPELLS.TOXIC_BLADE_DEBUFF.id,
       },
       {
         spell: SPELLS.EXSANGUINATE_TALENT,
@@ -115,8 +125,6 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(SPELLS.EXSANGUINATE_TALENT.id),
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: 0.90,
-          extraSuggestion: 'Use on cooldown, or delay for Vendetta if less then 10 seconds remain.',
         },
       },
       // Defensive
@@ -125,6 +133,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         cooldown: 120,
         gcd: null,
+        buffSpellId: SPELLS.CLOAK_OF_SHADOWS.id,
       },
       {
         spell: SPELLS.CRIMSON_VIAL,
@@ -133,6 +142,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1000,
         },
+        buffSpellId: SPELLS.CRIMSON_VIAL.id,
       },
       {
         spell: SPELLS.EVASION,
@@ -169,12 +179,14 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 30,
         gcd: null,
+        buffSpellId: SPELLS.SHADOWSTEP.id,
       },
       {
         spell: SPELLS.SPRINT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 60,
         gcd: null,
+        buffSpellId: SPELLS.SPRINT.id,
       },
       {
         spell: SPELLS.TRICKS_OF_THE_TRADE,
@@ -187,6 +199,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 2,
         gcd: null,
+        buffSpellId: SPELLS.STEALTH.id,
       },
       {
         spell: SPELLS.BLIND,
@@ -195,6 +208,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           static: 1000,
         },
+        buffSpellId: SPELLS.BLIND.id,
       },
       {
         spell: SPELLS.CHEAP_SHOT,
@@ -202,6 +216,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           static: 1000,
         },
+        buffSpellId: SPELLS.CHEAP_SHOT.id,
       },
       {
         spell: SPELLS.DISTRACT,
@@ -224,6 +239,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           static: 1000,
         },
+        buffSpellId: SPELLS.KIDNEY_SHOT.id,
       },
       {
         spell: SPELLS.SHROUD_OF_CONCEALMENT,
@@ -232,10 +248,12 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1000,
         },
+        buffSpellId: SPELLS.SHROUD_OF_CONCEALMENT.id,
       },
       {
         spell: SPELLS.SAP,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
+        buffSpellId: SPELLS.SAP.id,
       },
       {
         spell: SPELLS.PICK_LOCK,

--- a/src/parser/shared/modules/GlobalCooldown.js
+++ b/src/parser/shared/modules/GlobalCooldown.js
@@ -7,6 +7,7 @@ import Haste from './Haste';
 import Channeling from './Channeling';
 
 const INVALID_GCD_CONFIG_LAG_MARGIN = 150; // not sure what this is based around, but <150 seems to catch most false positives
+const MIN_GCD = 750; // Minimum GCD for most abilities is 750ms.
 
 /**
  * This triggers a fabricated `globalcooldown` event when appropriate.
@@ -121,8 +122,7 @@ class GlobalCooldown extends Analyzer {
     }
     if (gcd.base) {
       const baseGCD = this._resolveAbilityGcdField(gcd.base);
-      // The minimum GCD duration is pretty much always with 100% Haste: 50% of the base duration. There is no known case of it ever being 0.
-      const minimumGCD = this._resolveAbilityGcdField(gcd.minimum) || (baseGCD / 2);
+      const minimumGCD = this._resolveAbilityGcdField(gcd.minimum) || MIN_GCD;
       return this.constructor.calculateGlobalCooldown(this.haste.current, baseGCD, minimumGCD);
     }
     throw new Error(`Ability ${ability.name} (spellId: ${spellId}) defines a GCD property but provides neither a base nor static value.`);


### PR DESCRIPTION
also adjusted the GCD module to set minimum GCD to 750 MS instead of base/2 (since some abilities have 1000 MS base).
Before:
![image](https://user-images.githubusercontent.com/6773230/47969084-c91fd400-e072-11e8-9912-53c71cf200ab.png)


After:
![image](https://user-images.githubusercontent.com/6773230/47969076-b907f480-e072-11e8-9f9a-4b6405bf557e.png)
