### PR TITLE
[Assassination] Cooldown tab & dot uptime suggestions

### DIFF
--- a/src/common/SPELLS/rogue.js
+++ b/src/common/SPELLS/rogue.js
@@ -395,6 +395,22 @@ export default {
     name: 'Elaborate Planning',
     icon: 'inv_misc_map08',
   },
+  SUBTERFUGE_BUFF: {
+    id: 115192,
+    name: 'Subterfuge',
+    icon: 'rogue_subterfuge',
+  },
+  MASTER_ASSASIN_BUFF: {
+    id: 256735,
+    name: 'Master Assasin',
+    icon: 'ability_criticalstrike',
+  },
+  TOXIC_BLADE_DEBUFF: {
+    id: 245389,
+    name: 'Toxic Blade',
+    icon: 'inv_weapon_shortblade_62',
+  },
+  
 
   //Outlaw
 

--- a/src/parser/core/CASTS_THAT_ARENT_CASTS.js
+++ b/src/parser/core/CASTS_THAT_ARENT_CASTS.js
@@ -26,4 +26,5 @@ export default [
   SPELLS.CHAOS_BLADES_DAMAGE_MH.id, // Chaos Blades "casts" when you auto attack with the buff on. So the cast means nothing, just the buff application (SPELLS.CHAOS_BLADES_BUFF)
   255724, // proc from a Legion Antorus trinket
   SPELLS.GALECALLERS_BOON_CAST.id, //This can be used off GCD
+  SPELLS.MUTILATE_OFFHAND.id, // Mutilate off hand
 ];

--- a/src/parser/rogue/assassination/CHANGELOG.js
+++ b/src/parser/rogue/assassination/CHANGELOG.js
@@ -8,6 +8,16 @@ import { tsabo, Cloake, Zerotorescue, Gebuz } from 'CONTRIBUTORS';
 export default [
   {
     date: new Date('2018-11-04'),
+    changes: <>Added suggestions for <SpellLink id={SPELLS.GARROTE.id} /> and <SpellLink id={SPELLS.RUPTURE.id} /> uptime.</>,
+    contributors: [Gebuz],
+  },
+  {
+    date: new Date('2018-11-04'),
+    changes: 'Added cooldowns tab',
+    contributors: [Gebuz],
+  },
+  {
+    date: new Date('2018-11-04'),
     changes: 'Updated timeline with buffs & debuffs and added missing GCDs',
     contributors: [Gebuz],
   },

--- a/src/parser/rogue/assassination/CHANGELOG.js
+++ b/src/parser/rogue/assassination/CHANGELOG.js
@@ -3,9 +3,14 @@ import React from 'react';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 
-import { tsabo, Cloake, Zerotorescue } from 'CONTRIBUTORS';
+import { tsabo, Cloake, Zerotorescue, Gebuz } from 'CONTRIBUTORS';
 
 export default [
+  {
+    date: new Date('2018-11-04'),
+    changes: 'Updated timeline with buffs & debuffs and added missing GCDs',
+    contributors: [Gebuz],
+  },
   {
     date: new Date('2018-08-02'),
     changes: 'Added natural energy regen.',

--- a/src/parser/rogue/assassination/CONFIG.js
+++ b/src/parser/rogue/assassination/CONFIG.js
@@ -11,7 +11,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [tsabo, Cloake],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '7.3',
+  patchCompatibility: '8.0.1',
   // If set to  false`, the spec will show up as unsupported.
   isSupported: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.

--- a/src/parser/rogue/assassination/CombatLogParser.js
+++ b/src/parser/rogue/assassination/CombatLogParser.js
@@ -3,6 +3,7 @@ import CoreCombatLogParser from 'parser/core/CombatLogParser';
 import DamageDone from 'parser/shared/modules/DamageDone';
 import Abilities from './modules/Abilities';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
+import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
 
 import ComboPointDetails from '../shared/resources/ComboPointDetails';
 import ComboPointTracker from '../shared/resources/ComboPointTracker';
@@ -32,6 +33,7 @@ class CombatLogParser extends CoreCombatLogParser {
     damageDone: [DamageDone, { showStatistic: true }],
     abilities: Abilities,
     alwaysBeCasting: AlwaysBeCasting,
+    cooldownThroughputTracker: CooldownThroughputTracker,
 
     //Resource
     comboPointTracker: ComboPointTracker,

--- a/src/parser/rogue/assassination/modules/Abilities.js
+++ b/src/parser/rogue/assassination/modules/Abilities.js
@@ -12,15 +12,17 @@ class Abilities extends CoreAbilities {
         gcd: {
           static: 1000,
         },
+        buffSpellId: SPELLS.ENVENOM.id,
       },
       {
         spell: SPELLS.GARROTE,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         // During the Subterfuge buff (from the talent), the spell has no cd
-        cooldown: () => combatant.hasBuff(SPELLS.SUBTERFUGE_TALENT.id) ? 0 : 6,
+        cooldown: () => combatant.hasBuff(SPELLS.SUBTERFUGE_BUFF.id) ? 0 : 6,
         gcd: {
           static: 1000,
         },
+        buffSpellId: SPELLS.GARROTE.id,
       },
       {
         spell: SPELLS.MUTILATE,
@@ -42,6 +44,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           static: 1000,
         },
+        buffSpellId: SPELLS.RUPTURE.id,
       },
       {
         spell: SPELLS.BLINDSIDE_TALENT,
@@ -62,8 +65,11 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.CRIMSON_TEMPEST_TALENT,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        gcd: null,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
+        gcd: {
+          static: 1000,
+        },
+        buffSpellId: SPELLS.CRIMSON_TEMPEST_TALENT.id,
         enabled: combatant.hasTalent(SPELLS.CRIMSON_TEMPEST_TALENT.id),
       },
       // Rotational AOE
@@ -82,6 +88,10 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: true,
         },
+        gcd: {
+          base: 1000,
+        },
+        buffSpellId: SPELLS.VENDETTA.id,
       },
       {
         spell: SPELLS.VANISH,
@@ -90,6 +100,7 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: true,
         },
+        buffSpellId: combatant.hasTalent(SPELLS.SUBTERFUGE_TALENT.id) ? SPELLS.SUBTERFUGE_BUFF.id : SPELLS.MASTER_ASSASIN_BUFF.id,
       },
       {
         spell: SPELLS.TOXIC_BLADE_TALENT,
@@ -101,9 +112,8 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(SPELLS.TOXIC_BLADE_TALENT.id),
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: 0.90,
-          extraSuggestion: 'Use on cooldown, or delay for Vendetta if less then 10 seconds remain.',
         },
+        buffSpellId: SPELLS.TOXIC_BLADE_DEBUFF.id,
       },
       {
         spell: SPELLS.EXSANGUINATE_TALENT,
@@ -115,8 +125,6 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(SPELLS.EXSANGUINATE_TALENT.id),
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: 0.90,
-          extraSuggestion: 'Use on cooldown, or delay for Vendetta if less then 10 seconds remain.',
         },
       },
       // Defensive
@@ -125,6 +133,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         cooldown: 120,
         gcd: null,
+        buffSpellId: SPELLS.CLOAK_OF_SHADOWS.id,
       },
       {
         spell: SPELLS.CRIMSON_VIAL,
@@ -133,6 +142,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1000,
         },
+        buffSpellId: SPELLS.CRIMSON_VIAL.id,
       },
       {
         spell: SPELLS.EVASION,
@@ -169,12 +179,14 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 30,
         gcd: null,
+        buffSpellId: SPELLS.SHADOWSTEP.id,
       },
       {
         spell: SPELLS.SPRINT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 60,
         gcd: null,
+        buffSpellId: SPELLS.SPRINT.id,
       },
       {
         spell: SPELLS.TRICKS_OF_THE_TRADE,
@@ -187,6 +199,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 2,
         gcd: null,
+        buffSpellId: SPELLS.STEALTH.id,
       },
       {
         spell: SPELLS.BLIND,
@@ -195,6 +208,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           static: 1000,
         },
+        buffSpellId: SPELLS.BLIND.id,
       },
       {
         spell: SPELLS.CHEAP_SHOT,
@@ -202,6 +216,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           static: 1000,
         },
+        buffSpellId: SPELLS.CHEAP_SHOT.id,
       },
       {
         spell: SPELLS.DISTRACT,
@@ -224,6 +239,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           static: 1000,
         },
+        buffSpellId: SPELLS.KIDNEY_SHOT.id,
       },
       {
         spell: SPELLS.SHROUD_OF_CONCEALMENT,
@@ -232,10 +248,12 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1000,
         },
+        buffSpellId: SPELLS.SHROUD_OF_CONCEALMENT.id,
       },
       {
         spell: SPELLS.SAP,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
+        buffSpellId: SPELLS.SAP.id,
       },
       {
         spell: SPELLS.PICK_LOCK,

--- a/src/parser/rogue/assassination/modules/features/CooldownThroughputTracker.js
+++ b/src/parser/rogue/assassination/modules/features/CooldownThroughputTracker.js
@@ -1,0 +1,29 @@
+import SPELLS from 'common/SPELLS';
+
+import CoreCooldownThroughputTracker, { BUILT_IN_SUMMARY_TYPES } from 'parser/shared/modules/CooldownThroughputTracker';
+
+class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
+  static cooldownSpells = [
+    ...CooldownThroughputTracker.cooldownSpells,
+    {
+      spell: SPELLS.VENDETTA,
+      summary: [
+        BUILT_IN_SUMMARY_TYPES.DAMAGE,
+      ],
+    },
+    {
+      spell: SPELLS.SUBTERFUGE_BUFF,
+      summary: [
+        BUILT_IN_SUMMARY_TYPES.DAMAGE,
+      ],
+    },
+    {
+      spell: SPELLS.MASTER_ASSASIN_BUFF,
+      summary: [
+        BUILT_IN_SUMMARY_TYPES.DAMAGE,
+      ],
+    },
+  ];
+}
+
+export default CooldownThroughputTracker;

--- a/src/parser/rogue/assassination/modules/spells/GarroteUptime.js
+++ b/src/parser/rogue/assassination/modules/spells/GarroteUptime.js
@@ -1,12 +1,13 @@
 import React from 'react';
 
 import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import SpellIcon from 'common/SpellIcon';
+import { formatPercentage } from 'common/format';
 
 import Analyzer from 'parser/core/Analyzer';
 import Enemies from 'parser/shared/modules/Enemies';
 import StatisticBox from 'interface/others/StatisticBox';
-import SpellIcon from 'common/SpellIcon';
-import { formatPercentage } from 'common/format';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 
 class GarroteUptime extends Analyzer {
@@ -18,11 +19,32 @@ class GarroteUptime extends Analyzer {
     return this.enemies.getBuffUptime(SPELLS.GARROTE.id) / this.owner.fightDuration;
   }
 
+  get suggestionThresholds() {
+    return {
+      actual: this.percentUptime,
+      isLessThan: {
+        minor: 0.95,
+        average: 0.9,
+        major: 0.8,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(<>Your <SpellLink id={SPELLS.GARROTE.id} /> uptime can be improved. Try to pay more attention to your <SpellLink id={SPELLS.GARROTE.id} /> on the boss.</>)
+        .icon(SPELLS.GARROTE.icon)
+        .actual(`${formatPercentage(actual)}% Garrote uptime`)
+        .recommended(`>${formatPercentage(recommended)}% is recommended`);
+    });
+  }
+
   statistic() {
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.GARROTE.id} />}
-        value={`${formatPercentage(this.percentUptime)}%`}
+        value={`${formatPercentage(this.percentUptime)} %`}
         label="Garrote Uptime"
       />
     );

--- a/src/parser/rogue/assassination/modules/spells/RuptureUptime.js
+++ b/src/parser/rogue/assassination/modules/spells/RuptureUptime.js
@@ -1,12 +1,13 @@
 import React from 'react';
 
 import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import SpellIcon from 'common/SpellIcon';
+import { formatPercentage } from 'common/format';
 
 import Analyzer from 'parser/core/Analyzer';
 import Enemies from 'parser/shared/modules/Enemies';
 import StatisticBox from 'interface/others/StatisticBox';
-import SpellIcon from 'common/SpellIcon';
-import { formatPercentage } from 'common/format';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 
 class RuptureUptime extends Analyzer {
@@ -18,11 +19,32 @@ class RuptureUptime extends Analyzer {
     return this.enemies.getBuffUptime(SPELLS.RUPTURE.id) / this.owner.fightDuration;
   }
 
+  get suggestionThresholds() {
+    return {
+      actual: this.percentUptime,
+      isLessThan: {
+        minor: 0.95,
+        average: 0.9,
+        major: 0.8,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(<>Your <SpellLink id={SPELLS.RUPTURE.id} /> uptime can be improved. Try to pay more attention to your <SpellLink id={SPELLS.RUPTURE.id} /> on the boss.</>)
+        .icon(SPELLS.RUPTURE.icon)
+        .actual(`${formatPercentage(actual)}% Rupture uptime`)
+        .recommended(`>${formatPercentage(recommended)}% is recommended`);
+    });
+  }
+
   statistic() {
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.RUPTURE.id} />}
-        value={`${formatPercentage(this.percentUptime)}%`}
+        value={`${formatPercentage(this.percentUptime)} %`}
         label="Rupture Uptime"
       />
     );

--- a/src/parser/shared/modules/CooldownThroughputTracker.js
+++ b/src/parser/shared/modules/CooldownThroughputTracker.js
@@ -40,7 +40,7 @@ class CooldownThroughputTracker extends Analyzer {
   pastCooldowns = [];
   activeCooldowns = [];
 
-  on_toPlayer_applybuff(event) {
+  startCooldown(event) {
     const spellId = event.ability.guid;
     const cooldownSpell = this.constructor.cooldownSpells.find(cooldownSpell => cooldownSpell.spell.id === spellId);
     if (!cooldownSpell) {
@@ -60,7 +60,7 @@ class CooldownThroughputTracker extends Analyzer {
     this.pastCooldowns.push(cooldown);
     return cooldown;
   }
-  on_toPlayer_removebuff(event) {
+  endCooldown(event) {
     const spellId = event.ability.guid;
     const index = this.activeCooldowns.findIndex(cooldown => cooldown.spell.id === spellId);
     if (index === -1) {
@@ -103,6 +103,18 @@ class CooldownThroughputTracker extends Analyzer {
   }
   on_byPlayer_applybuff(event) {
     this.trackEvent(event);
+  }
+  on_toPlayer_applybuff(event) {
+    this.startCooldown(event);
+  }
+  on_toPlayer_removebuff(event) {
+    this.endCooldown(event);
+  }
+  on_byPlayer_applydebuff(event) {
+    this.startCooldown(event);
+  }
+  on_byPlayer_removedebuff(event) {
+    this.endCooldown(event);
   }
   // endregion
 

--- a/src/parser/shared/modules/GlobalCooldown.js
+++ b/src/parser/shared/modules/GlobalCooldown.js
@@ -7,6 +7,7 @@ import Haste from './Haste';
 import Channeling from './Channeling';
 
 const INVALID_GCD_CONFIG_LAG_MARGIN = 150; // not sure what this is based around, but <150 seems to catch most false positives
+const MIN_GCD = 750; // Minimum GCD for most abilities is 750ms.
 
 /**
  * This triggers a fabricated `globalcooldown` event when appropriate.
@@ -121,8 +122,7 @@ class GlobalCooldown extends Analyzer {
     }
     if (gcd.base) {
       const baseGCD = this._resolveAbilityGcdField(gcd.base);
-      // The minimum GCD duration is pretty much always with 100% Haste: 50% of the base duration. There is no known case of it ever being 0.
-      const minimumGCD = this._resolveAbilityGcdField(gcd.minimum) || (baseGCD / 2);
+      const minimumGCD = this._resolveAbilityGcdField(gcd.minimum) || MIN_GCD;
       return this.constructor.calculateGlobalCooldown(this.haste.current, baseGCD, minimumGCD);
     }
     throw new Error(`Ability ${ability.name} (spellId: ${spellId}) defines a GCD property but provides neither a base nor static value.`);


### PR DESCRIPTION
Depends on #2588

Also changed CooldownThroughputTracker to support debuffs (Vendetta).

![image](https://user-images.githubusercontent.com/6773230/47969544-6bdb5100-e079-11e8-930d-62bd7109ae0d.png)
