### PR TITLE
[Hunter] A Murder of Crows fixing

### DIFF
--- a/src/parser/hunter/beastmastery/modules/Abilities.js
+++ b/src/parser/hunter/beastmastery/modules/Abilities.js
@@ -78,19 +78,6 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.A_MURDER_OF_CROWS_TALENT,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        cooldown: 60,
-        enabled: combatant.hasTalent(SPELLS.A_MURDER_OF_CROWS_TALENT.id),
-        gcd: {
-          base: 1500,
-        },
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: 0.9,
-        },
-      },
-      {
         spell: SPELLS.ASPECT_OF_THE_WILD,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         buffSpellId: SPELLS.ASPECT_OF_THE_WILD.id,

--- a/src/parser/hunter/marksmanship/modules/Abilities.js
+++ b/src/parser/hunter/marksmanship/modules/Abilities.js
@@ -70,19 +70,6 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(SPELLS.EXPLOSIVE_SHOT_TALENT.id),
       },
       {
-        spell: SPELLS.A_MURDER_OF_CROWS_TALENT,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        cooldown: 60,
-        enabled: combatant.hasTalent(SPELLS.A_MURDER_OF_CROWS_TALENT.id),
-        gcd: {
-          base: 1500,
-        },
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: 0.8,
-        },
-      },
-      {
         spell: SPELLS.HUNTERS_MARK_TALENT,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         enabled: combatant.hasTalent(SPELLS.HUNTERS_MARK_TALENT.id),

--- a/src/parser/hunter/shared/modules/talents/AMurderOfCrows.js
+++ b/src/parser/hunter/shared/modules/talents/AMurderOfCrows.js
@@ -7,6 +7,7 @@ import SpellUsable from 'parser/shared/modules/SpellUsable';
 import SpellLink from 'common/SpellLink';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
+import Abilities from 'parser/shared/modules/Abilities';
 
 /**
  * Summons a flock of crows to attack your target over the next 15 sec. If the target dies while under attack, A Murder of Crows' cooldown is reset.
@@ -17,11 +18,13 @@ import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
 const CROWS_TICK_RATE = 1000;
 const MS_BUFFER = 100;
 const CROWS_DURATION = 15000;
+const debug = false;
 
 class AMurderOfCrows extends Analyzer {
 
   static dependencies = {
     spellUsable: SpellUsable,
+    abilities: Abilities,
   };
 
   bonusDamage = 0;
@@ -29,10 +32,42 @@ class AMurderOfCrows extends Analyzer {
   applicationTimestamp = null;
   lastDamageTick = null;
   crowsEndingTimestamp = null;
+  maxCasts = 0;
 
   constructor(...args) {
     super(...args);
     this.active = this.selectedCombatant.hasTalent(SPELLS.A_MURDER_OF_CROWS_TALENT.id);
+    if (!this.active) {
+      return;
+    }
+    this.abilities.add({
+      spell: SPELLS.A_MURDER_OF_CROWS_TALENT,
+      category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+      cooldown: 60,
+      gcd: {
+        base: 1500,
+      },
+      castEfficiency: {
+        suggestion: true,
+        recommendedEfficiency: 0.85,
+        maxCasts: () => this.maxCasts,
+      },
+      ...this.constructor.extraAbilityInfo,
+    });
+  }
+
+  checkForReset(event) {
+    // Checks if we've had atleast 1 damage tick of the currently applied crows, and checks that crows is in fact on cooldown.
+    if (this.lastDamageTick && this.spellUsable.isOnCooldown(SPELLS.A_MURDER_OF_CROWS_TALENT.id)
+      // Checks whether the current damage event happened while the time passed since crows application is less than the crows duration
+      && this.applicationTimestamp && event.timestamp < this.crowsEndingTimestamp
+      // Checks to see if more than 1 second has passed since last tick
+      && event.timestamp > this.lastDamageTick + CROWS_TICK_RATE + MS_BUFFER) {
+      // If more than 1 second has passed and less than the duration has elapsed, we can assume that crows has been reset, and thus we reset the CD.
+      this.spellUsable.endCooldown(SPELLS.A_MURDER_OF_CROWS_TALENT.id, event.timestamp);
+      this.maxCasts += 1;
+      debug && console.log("Crows was reset at: ", event.timestamp);
+    }
   }
 
   on_byPlayer_cast(event) {
@@ -45,17 +80,25 @@ class AMurderOfCrows extends Analyzer {
     this.lastDamageTick = null;
   }
 
+  on_byPlayer_applybuff(event) {
+    this.checkForReset(event);
+  }
+
+  on_byPlayer_removebuff(event) {
+    this.checkForReset(event);
+  }
+
+  on_byPlayer_applybuffstack(event) {
+    this.checkForReset(event);
+  }
+
+  on_byPlayerPet_damage(event) {
+    this.checkForReset(event);
+  }
+
   on_byPlayer_damage(event) {
     const spellId = event.ability.guid;
-    // Checks if we've had atleast 1 damage tick of the currently applied crows, and checks that crows is in fact on cooldown.
-    if (this.lastDamageTick && this.spellUsable.isOnCooldown(SPELLS.A_MURDER_OF_CROWS_TALENT.id)
-      // Checks whether the current damage event happened while the time passed since crows application is less than the crows duration
-      && this.applicationTimestamp && event.timestamp < this.crowsEndingTimestamp
-      // Checks to see if more than 1 second has passed since last tick
-      && event.timestamp > this.lastDamageTick + CROWS_TICK_RATE + MS_BUFFER) {
-      // If more than 1 second has passed and less than the duration has elapsed, we can assume that crows has been reset, and thus we reset the CD.
-      this.spellUsable.endCooldown(SPELLS.A_MURDER_OF_CROWS_TALENT.id, event.timestamp);
-    }
+    this.checkForReset(event);
     if (spellId !== SPELLS.A_MURDER_OF_CROWS_DEBUFF.id) {
       return;
     }
@@ -71,6 +114,10 @@ class AMurderOfCrows extends Analyzer {
     }
     this.lastDamageTick = event.timestamp;
     this.bonusDamage += event.amount + (event.absorbed || 0);
+  }
+
+  on_finished() {
+    this.maxCasts += Math.ceil(this.owner.fightDuration / 60000);
   }
 
   subStatistic() {

--- a/src/parser/hunter/shared/modules/talents/AMurderOfCrows.js
+++ b/src/parser/hunter/shared/modules/talents/AMurderOfCrows.js
@@ -72,6 +72,7 @@ class AMurderOfCrows extends Analyzer {
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
+    this.checkForReset(event);
     if (spellId !== SPELLS.A_MURDER_OF_CROWS_TALENT.id) {
       return;
     }
@@ -80,6 +81,10 @@ class AMurderOfCrows extends Analyzer {
     this.lastDamageTick = null;
   }
 
+  on_byPlayer_energize(event) {
+    this.checkForReset(event);
+  }
+  
   on_byPlayer_applybuff(event) {
     this.checkForReset(event);
   }

--- a/src/parser/hunter/survival/modules/Abilities.js
+++ b/src/parser/hunter/survival/modules/Abilities.js
@@ -86,19 +86,6 @@ class Abilities extends CoreAbilities {
         timelineSortIndex: 6,
       },
       {
-        spell: SPELLS.A_MURDER_OF_CROWS_TALENT,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        cooldown: 60,
-        enabled: combatant.hasTalent(SPELLS.A_MURDER_OF_CROWS_TALENT.id),
-        gcd: {
-          base: 1500,
-        },
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: .85,
-        },
-      },
-      {
         spell: SPELLS.STEEL_TRAP_TALENT,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         cooldown: 30,


### PR DESCRIPTION
Old (without associated bugfix in this PR which would push it to 26): 
![image](https://user-images.githubusercontent.com/29204244/47982687-f4391080-e0d0-11e8-8ff5-cd3549fc4e7a.png)

New: 
![image](https://user-images.githubusercontent.com/29204244/47982681-edaa9900-e0d0-11e8-8e2a-e8099465e312.png)

Log: https://wowanalyzer.com/report/GrzhBC6MPVZ8cbQp/28-Mythic+Fetid+Devourer+-+Kill+(4:41)/19-Raicha/abilities

Fixes a bug where a player wouldn't be doing any damage in the timespan where crows could reset, so it was never registered as a reset.

Moves Crows into its own module and ensure the maxCasts prop is accurate. 
