### PR TITLE
[Trinket] Added 'Rotcrusted Voodoo Doll' Trinket

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Mamtooth, Zerotorescue, Putro, joshinator, Gebuz, ackwell, emallson, blazyb, Dambroda, Nalhan, Satyric, niseko, Khadaj, Fyruna, Matardarix } from 'CONTRIBUTORS';
+import { Mamtooth, Zerotorescue, Putro, joshinator, Gebuz, ackwell, emallson, blazyb, Dambroda, Nalhan, Satyric, niseko, Khadaj, Fyruna, Matardarix, jos3p } from 'CONTRIBUTORS';
 import ItemLink from 'common/ItemLink';
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
@@ -8,6 +8,11 @@ import SpellLink from 'common/SpellLink';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  {
+    date: new Date('2018-11-10'),
+    changes: <>Added <ItemLink id={ITEMS.ROTCRUSTED_VOODOO_DOLL.id} /> module.</>,
+    contributors: [jos3p],
+  },
   {
     date: new Date('2018-11-09'),
     changes: <>Added <ItemLink id={ITEMS.REZANS_GLEAMING_EYE.id} /> module.</>,

--- a/src/common/SPELLS/bfa/dungeons/items.js
+++ b/src/common/SPELLS/bfa/dungeons/items.js
@@ -27,6 +27,11 @@ export default {
     name: 'Rotcrusted Voodoo Doll',
     icon: 'inv_misc_primitive_toy05',
   },
+  ROTCRUSTED_VOODOO_DOLL_HIT: {
+    id: 271468,
+    name: 'Rotcrusted Voodoo Doll',
+    icon: 'inv_misc_primitive_toy05',
+  },
 
   // Atal'Dazar
   TOUCH_OF_THE_VOODOO: { // Revitalizing Voodoo Totem

--- a/src/common/SPELLS/bfa/dungeons/items.js
+++ b/src/common/SPELLS/bfa/dungeons/items.js
@@ -17,6 +17,16 @@ export default {
     name: 'Lingering Spore Pods',
     icon: 'spell_druid_wildmushroom_frenzy',
   },
+  ROTCRUSTED_VOODOO_DOLL_BUFF: {
+    id: 271462,
+    name: 'Rotcrusted Voodoo Doll',
+    icon: 'inv_misc_primitive_toy05',
+  },
+  ROTCRUSTED_VOODOO_DOLL_TICK: {
+    id: 271465,
+    name: 'Rotcrusted Voodoo Doll',
+    icon: 'inv_misc_primitive_toy05',
+  },
 
   // Atal'Dazar
   TOUCH_OF_THE_VOODOO: { // Revitalizing Voodoo Totem

--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -210,7 +210,7 @@ class CombatLogParser {
     harlansLoadedDice: HarlansLoadedDice,
     lustrousGoldenPlumage: LustrousGoldenPlumage,
     rezansGleamingEye: RezansGleamingEye,
-    rotcrustedvoodoodoll: RotcrustedVoodooDoll,
+    rotcrustedVoodooDoll: RotcrustedVoodooDoll,
     // PVP
     dreadGladiatorsMedallion: DreadGladiatorsMedallion,
     dreadGladiatorsBadge: DreadGladiatorsBadge,

--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -76,6 +76,7 @@ import GalecallersBoon from '../shared/modules/items/bfa/dungeons/GalecallersBoo
 import HarlansLoadedDice from '../shared/modules/items/bfa/dungeons/HarlansLoadedDice';
 import LustrousGoldenPlumage from '../shared/modules/items/bfa/dungeons/LustrousGoldenPlumage';
 import RezansGleamingEye from '../shared/modules/items/bfa/dungeons/RezansGleamingEye';
+import RotcrustedVoodooDoll from '../shared/modules/items/bfa/dungeons/RotcrustedVoodooDoll';
 // PVP
 import DreadGladiatorsMedallion from '../shared/modules/items/bfa/pvp/DreadGladiatorsMedallion';
 import DreadGladiatorsBadge from '../shared/modules/items/bfa/pvp/DreadGladiatorsBadge';
@@ -209,6 +210,7 @@ class CombatLogParser {
     harlansLoadedDice: HarlansLoadedDice,
     lustrousGoldenPlumage: LustrousGoldenPlumage,
     rezansGleamingEye: RezansGleamingEye,
+    rotcrustedvoodoodoll: RotcrustedVoodooDoll,
     // PVP
     dreadGladiatorsMedallion: DreadGladiatorsMedallion,
     dreadGladiatorsBadge: DreadGladiatorsBadge,

--- a/src/parser/shared/modules/items/bfa/dungeons/RotcrustedVoodooDoll.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/RotcrustedVoodooDoll.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS/index';
+import ITEMS from 'common/ITEMS/index';
+import Analyzer from 'parser/core/Analyzer';
+import { formatNumber } from 'common/format';
+import ItemDamageDone from 'interface/others/ItemDamageDone';
+import Abilities from 'parser/shared/modules/Abilities';
+
+/**
+ * Rotcrusted Voodoo Doll
+ * Use: Brandish the Voodoo Doll at your target, 
+ * dealing X Shadow damage over 6 sec, and an additional X Shadow damage after 6 sec. (2 Min Cooldown)
+ */
+class RotcrustedVoodooDoll extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+  };
+
+  damage = 0;
+  ticks = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrinket(ITEMS.ROTCRUSTED_VOODOO_DOLL.id);
+
+    if (this.active) {
+        this.abilities.add({
+          spell: SPELLS.ROTCRUSTED_VOODOO_DOLL_BUFF,
+          buffSpellId: SPELLS.ROTCRUSTED_VOODOO_DOLL_TICK.id,
+          name: ITEMS.ROTCRUSTED_VOODOO_DOLL.name,
+          category: Abilities.SPELL_CATEGORIES.ITEMS,
+          cooldown: 120,
+          castEfficiency: {
+            suggestion: true,
+          },
+        });
+      }
+  }
+
+  on_byPlayer_damage(event) {
+    if (event.ability.guid !== SPELLS.ROTCRUSTED_VOODOO_DOLL_TICK.id) {
+      return;
+    }
+
+    this.damage += event.amount + (event.absorbed || 0);
+    this.ticks += 1;
+  }
+
+  item(){
+    return{
+      item: ITEMS.ROTCRUSTED_VOODOO_DOLL,
+      result: (
+        <>
+          <dfn data-tip={`<b>${this.ticks}</b> ticks, causing <b>${formatNumber(this.damage)}</b> damage.`}>
+            <ItemDamageDone amount={this.damage} />
+          </dfn>
+        </>
+      ),
+    };
+  }
+}
+
+export default RotcrustedVoodooDoll;

--- a/src/parser/shared/modules/items/bfa/dungeons/RotcrustedVoodooDoll.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/RotcrustedVoodooDoll.js
@@ -6,6 +6,8 @@ import { formatNumber } from 'common/format';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 import Abilities from 'parser/shared/modules/Abilities';
 
+const ACTIVATION_COOLDOWN = 120; // seconds
+
 /**
  * Rotcrusted Voodoo Doll
  * Use: Brandish the Voodoo Doll at your target, 
@@ -29,7 +31,7 @@ class RotcrustedVoodooDoll extends Analyzer {
           buffSpellId: SPELLS.ROTCRUSTED_VOODOO_DOLL_TICK.id,
           name: ITEMS.ROTCRUSTED_VOODOO_DOLL.name,
           category: Abilities.SPELL_CATEGORIES.ITEMS,
-          cooldown: 120,
+          cooldown: ACTIVATION_COOLDOWN,
           castEfficiency: {
             suggestion: true,
           },

--- a/src/parser/shared/modules/items/bfa/dungeons/RotcrustedVoodooDoll.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/RotcrustedVoodooDoll.js
@@ -12,6 +12,8 @@ const ACTIVATION_COOLDOWN = 120; // seconds
  * Rotcrusted Voodoo Doll
  * Use: Brandish the Voodoo Doll at your target, 
  * dealing X Shadow damage over 6 sec, and an additional X Shadow damage after 6 sec. (2 Min Cooldown)
+ * 
+ * Example log: /report/hYkG1MtKyxB8cPRZ/3-Heroic+Taloc+-+Kill+(3:49)/9-Qt/abilities
  */
 class RotcrustedVoodooDoll extends Analyzer {
   static dependencies = {

--- a/src/parser/shared/modules/items/bfa/dungeons/RotcrustedVoodooDoll.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/RotcrustedVoodooDoll.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import SPELLS from 'common/SPELLS/index';
-import ITEMS from 'common/ITEMS/index';
+import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
 import Analyzer from 'parser/core/Analyzer';
 import { formatNumber } from 'common/format';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
@@ -52,11 +52,9 @@ class RotcrustedVoodooDoll extends Analyzer {
     return{
       item: ITEMS.ROTCRUSTED_VOODOO_DOLL,
       result: (
-        <>
           <dfn data-tip={`<b>${this.ticks}</b> ticks, causing <b>${formatNumber(this.damage)}</b> damage.`}>
             <ItemDamageDone amount={this.damage} />
           </dfn>
-        </>
       ),
     };
   }

--- a/src/parser/shared/modules/items/bfa/dungeons/RotcrustedVoodooDoll.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/RotcrustedVoodooDoll.js
@@ -48,8 +48,8 @@ class RotcrustedVoodooDoll extends Analyzer {
     this.ticks += 1;
   }
 
-  item(){
-    return{
+  item() {
+    return {
       item: ITEMS.ROTCRUSTED_VOODOO_DOLL,
       result: (
           <dfn data-tip={`<b>${this.ticks}</b> ticks, causing <b>${formatNumber(this.damage)}</b> damage.`}>

--- a/src/parser/shared/modules/items/bfa/dungeons/RotcrustedVoodooDoll.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/RotcrustedVoodooDoll.js
@@ -38,7 +38,7 @@ class RotcrustedVoodooDoll extends Analyzer {
   }
 
   on_byPlayer_damage(event) {
-    if (event.ability.guid !== SPELLS.ROTCRUSTED_VOODOO_DOLL_TICK.id) {
+    if ((event.ability.guid !== SPELLS.ROTCRUSTED_VOODOO_DOLL_TICK.id) && (event.ability.guid !== SPELLS.ROTCRUSTED_VOODOO_DOLL_HIT.id)) {
       return;
     }
 


### PR DESCRIPTION
Adds tracking of Rotcrusted Voodoo Doll to timeline, abilities tab & statistics icon

![doll](https://user-images.githubusercontent.com/3185600/48004800-346cb300-e112-11e8-948d-8f8b9c91cfe7.jpg)

fixes #1696 