### PR TITLE
[Hpriest] Adding renew cast suggestion

### DIFF
--- a/src/parser/priest/holy/CHANGELOG.js
+++ b/src/parser/priest/holy/CHANGELOG.js
@@ -4,6 +4,16 @@ import { niseko, Yajinni, Khadaj } from 'CONTRIBUTORS';
 
 export default [
   {
+    date: new Date('2018-11-05'),
+    changes: 'Adding Renew suggestion.',
+    contributors: [Khadaj],
+  },
+  {
+    date: new Date('2018-10-22'),
+    changes: 'Adding mana efficiency tab.',
+    contributors: [Khadaj],
+  },
+  {
     date: new Date('2018-09-13'),
     changes: 'Adding Holy Priest Azerite traits.',
     contributors: [Khadaj],

--- a/src/parser/priest/holy/modules/spells/Renew.js
+++ b/src/parser/priest/holy/modules/spells/Renew.js
@@ -198,7 +198,7 @@ class Renew extends Analyzer {
             .actual(<>
               You used Renew {this.badRenews} times when another spell would have been more productive.
               Renew is one of the least efficient spells Holy Priests have, and should only be cast when moving with no other instants available.</>)
-            .recommended(`Two per minute is recommended, except for movement heavy fights.`);
+            .recommended(`Two or less per minute is recommended, except for movement heavy fights.`);
         }
       );
   }

--- a/src/parser/priest/holy/modules/spells/Renew.js
+++ b/src/parser/priest/holy/modules/spells/Renew.js
@@ -1,17 +1,30 @@
+import React from 'react';
+
 import SPELLS from 'common/SPELLS';
 import Analyzer from 'parser/core/Analyzer';
+import DistanceMoved from 'parser/shared/modules/others/DistanceMoved';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import SpellLink from 'common/SpellLink';
 
 import { ABILITIES_THAT_TRIGGER_ENDURING_RENEWAL } from '../../constants';
 
 const MS_BUFFER = 100;
 
 class Renew extends Analyzer {
+  static dependencies = {
+    distanceMoved: DistanceMoved,
+    spellUsable: SpellUsable,
+  };
+
   totalRenewHealing = 0;
   totalRenewOverhealing = 0;
   totalRenewAbsorbs = 0;
   totalRenewTicks = 0;
 
   renewsCast = 0;
+  goodRenews = 0;
+  // A list of the reasons that a renew is listed as "bad". I may expand upon this later in a card.
+  badRenewReason = {};
   totalRenewApplications = 0;
 
   salvationActive = false;
@@ -24,6 +37,9 @@ class Renew extends Analyzer {
 
   benedictionActive = false;
   renewsFromBenedictionAndRenew = 0;
+
+  lastGCD = null;
+  lastCast = null;
 
   constructor(...args) {
     super(...args);
@@ -41,6 +57,22 @@ class Renew extends Analyzer {
 
   get renewsFromBenediction() {
     return this.renewsFromBenedictionAndRenew - this.renewsCast;
+  }
+
+  get badRenews() {
+    return this.renewsCast - this.goodRenews;
+  }
+
+  get badRenewThreshold() {
+    return {
+      actual: this.badRenews,
+      isGreaterThan: {
+        minor: 2 * this.owner.fightDuration / 1000 / 60,
+        average: 3 * this.owner.fightDuration / 1000 / 60,
+        major: 4 * this.owner.fightDuration / 1000 / 60,
+      },
+      style: 'number',
+    };
   }
 
   healingFromRenew(applicationCount) {
@@ -72,8 +104,13 @@ class Renew extends Analyzer {
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
 
+    if (this.lastCast) {
+      // If our last cast was a renew cast, validate that it was used well.
+      this.validateRenew(event);
+    }
     if (spellId === SPELLS.RENEW.id) {
       this.renewsCast++;
+      this.lastCast = event;
     }
     else if (spellId === SPELLS.HOLY_WORD_SALVATION_TALENT.id) {
       this.lastSalvationCast = event.timestamp;
@@ -109,6 +146,61 @@ class Renew extends Analyzer {
     else {
       this.renewsFromBenedictionAndRenew++;
     }
+  }
+
+  on_byPlayer_globalcooldown(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.RENEW.id) {
+      return;
+    }
+    this.lastGCD = event;
+  }
+
+  // This function validates if a renew should have been cast at all.
+  validateRenew(event) {
+    this.lastRenewCast = event.timestamp;
+    if (this.lastGCD && this.movedSinceCast(event)) {
+      // We are moving, but do we have any other instant cast spells?
+      const sanctifyOnCooldown = this.spellUsable.isOnCooldown(SPELLS.HOLY_WORD_SANCTIFY.id);
+      const serenityOnCooldown = this.spellUsable.isOnCooldown(SPELLS.HOLY_WORD_SERENITY.id);
+      let cohOnCooldown = true;
+      if (this.selectedCombatant.hasTalent(SPELLS.CIRCLE_OF_HEALING_TALENT.id)) {
+        cohOnCooldown = this.spellUsable.isOnCooldown(SPELLS.CIRCLE_OF_HEALING_TALENT.id);
+      }
+      if (sanctifyOnCooldown && serenityOnCooldown && cohOnCooldown) {
+        this.goodRenews += 1;
+      } else {
+        this.badRenewReason.betterspell = (this.badRenewReason.betterspell | 0) + 1;
+      }
+    }
+    this.badRenewReason.stationary = (this.badRenewReason.stationary | 0) + 1;
+
+    // Reset the cast history
+    this.lastGCD = null;
+    this.lastCast = null;
+  }
+
+  movedSinceCast(event) {
+    const timeSinceCast = event.timestamp - this.lastGCD.timestamp;
+    const timeSinceLastMovement = this.distanceMoved.timeSinceLastMovement();
+
+    if (timeSinceLastMovement < timeSinceCast) {
+      return true;
+    }
+    return false;
+  }
+
+  suggestions(when) {
+    when(this.badRenewThreshold)
+      .addSuggestion((suggest, actual, recommended) => {
+          return suggest(<>You should cast <SpellLink id={SPELLS.RENEW.id} /> less.</>)
+            .icon(SPELLS.RENEW.icon)
+            .actual(<>
+              You used Renew {this.badRenews} times when another spell would have been more productive.
+              Renew is one of the least efficient spells Holy Priests have, and should only be cast when moving with no other instants available.</>)
+            .recommended(`Two per minute is recommended, except for movement heavy fights.`);
+        }
+      );
   }
 }
 

--- a/src/parser/priest/holy/modules/spells/Renew.js
+++ b/src/parser/priest/holy/modules/spells/Renew.js
@@ -170,10 +170,10 @@ class Renew extends Analyzer {
       if (sanctifyOnCooldown && serenityOnCooldown && cohOnCooldown) {
         this.goodRenews += 1;
       } else {
-        this.badRenewReason.betterspell = (this.badRenewReason.betterspell | 0) + 1;
+        this.badRenewReason.betterspell = (this.badRenewReason.betterspell || 0) + 1;
       }
     }
-    this.badRenewReason.stationary = (this.badRenewReason.stationary | 0) + 1;
+    this.badRenewReason.stationary = (this.badRenewReason.stationary || 0) + 1;
 
     // Reset the cast history
     this.lastGCD = null;


### PR DESCRIPTION
Renew is a pretty bad spell for priests. One of the most common improvements you can make as a player is to limit the number of renews that you cast. Renew should only be cast when moving, and when you have no other instant cast spells. This update tries to validate if you are casting renew well. This is a bit hard to do as it's hard to tell if a player is moving.

![screen shot 2018-11-05 at 10 33 02 am](https://user-images.githubusercontent.com/716498/48015748-1473ca00-e0e7-11e8-8c6b-a2479aa6247c.png)
