### PR TITLE
[Blood Death Knight][All tanks] Deaths Caress update + softmit-check

### DIFF
--- a/src/parser/deathknight/blood/CHANGELOG.js
+++ b/src/parser/deathknight/blood/CHANGELOG.js
@@ -6,7 +6,7 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
-    date: new Date('2018-09-28'),
+    date: new Date('2018-11-06'),
     changes: <>Updated the <SpellLink id={SPELLS.DEATHS_CARESS.id} />-usage module to check more accurately if a cast was bad or not (by checking available ranged spells and the distance between the player and the enemy).</>,
     contributors: [joshinator],
   },

--- a/src/parser/deathknight/blood/CHANGELOG.js
+++ b/src/parser/deathknight/blood/CHANGELOG.js
@@ -7,6 +7,11 @@ import SpellLink from 'common/SpellLink';
 export default [
   {
     date: new Date('2018-09-28'),
+    changes: <>Updated the <SpellLink id={SPELLS.DEATHS_CARESS.id} />-usage module to check more accurately if a cast was bad or not (by checking available ranged spells and the distance between the player and the enemy).</>,
+    contributors: [joshinator],
+  },
+  {
+    date: new Date('2018-09-28'),
     changes: <>Updated the <SpellLink id={SPELLS.MARROWREND.id} />-usage module to account for <SpellLink id={SPELLS.BONES_OF_THE_DAMNED.id} /> and updated <SpellLink id={SPELLS.HEARTBREAKER_TALENT.id} />-Module.</>,
     contributors: [joshinator],
   },

--- a/src/parser/deathknight/blood/modules/core/DeathsCaress.js
+++ b/src/parser/deathknight/blood/modules/core/DeathsCaress.js
@@ -3,26 +3,87 @@ import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS/index';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
 
-import RuneTracker from '../../../shared/RuneTracker';
+const RANGE_WHERE_YOU_SHOULDNT_DC = 12; // yrd
 
 class DeathsCaress extends Analyzer {
   static dependencies = {
-    tracker: RuneTracker,
+    spellUsable: SpellUsable,
   };
 
   dcCasts = 0;
+  cast = [];
+
+  spellsThatShouldBeUsedFirst = [
+    SPELLS.DEATH_AND_DECAY.id,
+  ];
+
+  constructor(...args) {
+    super(...args);
+    if(this.selectedCombatant.hasTalent(SPELLS.BLOODDRINKER_TALENT.id)) {
+      this.spellsThatShouldBeUsedFirst.push(SPELLS.BLOODDRINKER_TALENT.id);
+    }
+  }
 
   on_byPlayer_cast(event) {
     if (event.ability.guid !== SPELLS.DEATHS_CARESS.id) {
       return;
     }
+
+    const hadAnotherRangedSpell = this.spellsThatShouldBeUsedFirst.some(e => this.spellUsable.isAvailable(e));
     this.dcCasts += 1;
+
+    this.cast.push({
+      timestamp: event.timestamp,
+      hadAnotherRangedSpell: hadAnotherRangedSpell,
+      playerPosition: {
+        x: event.x,
+        y: event.y,
+      },
+      enemyPosition: {
+        x: 0,
+        y: 0,
+      },
+    });
+  }
+
+  on_byPlayer_damage(event) {
+    if (event.ability.guid !== SPELLS.DEATHS_CARESS.id || this.cast.length === 0) {
+      return;
+    }
+
+    this.cast[this.cast.length - 1].enemyPosition = {
+      x: event.x,
+      y: event.y,
+    };
+  }
+
+  calculateDistance(x1, y1, x2, y2) {
+    return Math.sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2)) / 100;
+  }
+
+  get badDcCasts() {
+    let badCasts = 0;
+
+    this.cast.forEach(e => {
+      //only happens when the target died before the damage event occurs
+      if (e.enemyPosition.x === 0 && e.enemyPosition.y === 0) {
+        return;
+      }
+
+      const distance = this.calculateDistance(e.enemyPosition.x, e.enemyPosition.y, e.playerPosition.x, e.playerPosition.y);
+      if (distance <= RANGE_WHERE_YOU_SHOULDNT_DC || e.hadAnotherRangedSpell) { // close to melee-range => bad || when another ranged spell was available
+        badCasts += 1;
+      }
+    });
+
+    return badCasts;
   }
 
   get averageCastSuggestionThresholds() {
     return {
-      actual: 1 - (this.dcCasts / (this.tracker.runesMaxCasts - this.tracker.runesWasted)),
+      actual: 1 - (this.badDcCasts / this.dcCasts),
       isLessThan: {
         minor: 1,
         average: .95,
@@ -37,7 +98,7 @@ class DeathsCaress extends Analyzer {
         .addSuggestion((suggest, actual, recommended) => {
           return suggest(<>Avoid casting <SpellLink id={SPELLS.DEATHS_CARESS.id} /> unless you're out of melee range and about to cap your runes while <SpellLink id={SPELLS.DEATH_AND_DECAY.id} /> and <SpellLink id={SPELLS.BLOODDRINKER_TALENT.id} /> are on cooldown. Dump runes primarily with <SpellLink id={SPELLS.HEART_STRIKE.id} />.</>)
             .icon(SPELLS.DEATHS_CARESS.icon)
-            .actual(`${formatPercentage(this.dcCasts / (this.tracker.runesMaxCasts - this.tracker.runesWasted))}% runes spend with Death's Caress`)
+            .actual(`${formatPercentage(this.badDcCasts / this.dcCasts)}% bad ${SPELLS.DEATHS_CARESS.name} casts`)
             .recommended(`0% are recommended`);
         });
   }

--- a/src/parser/deathknight/blood/modules/features/Checklist.js
+++ b/src/parser/deathknight/blood/modules/features/Checklist.js
@@ -96,15 +96,16 @@ class Checklist extends CoreChecklist {
             check: () => this.runeTracker.suggestionThresholdsEfficiency,
           }),
           new Requirement({
-            name: <><SpellLink id={SPELLS.MARROWREND.id} /> efficiency</>,
+            name: <><SpellLink id={SPELLS.MARROWREND.id} /> Efficiency</>,
             check: () => this.marrowrendUsage.suggestionThresholdsEfficiency,
           }),
           new Requirement({
-            name: <><SpellLink id={SPELLS.RUNE_STRIKE_TALENT.id} /> efficiency</>,
+            name: <><SpellLink id={SPELLS.RUNE_STRIKE_TALENT.id} /> Efficiency</>,
             check: () => this.runeStrike.cooldownReductionThresholds,
+            when: this.selectedCombatant.hasTalent(SPELLS.RUNE_STRIKE_TALENT.id),
           }),
           new Requirement({
-            name: <>Avoid casting <SpellLink id={SPELLS.DEATHS_CARESS.id} /></>,
+            name: <><SpellLink id={SPELLS.DEATHS_CARESS.id} /> Efficiency</>,
             check: () => this.deathsCaress.averageCastSuggestionThresholds,
           }),
         ];

--- a/src/parser/shared/modules/MitigationCheck.js
+++ b/src/parser/shared/modules/MitigationCheck.js
@@ -10,6 +10,7 @@ import Enemies from 'parser/shared/modules/Enemies';
 
 import { findByBossId } from 'raids/index';
 import StatisticBox from 'interface/others/StatisticBox';
+import HIT_TYPES from 'game/HIT_TYPES';
 
 const debug = false;
 
@@ -52,7 +53,8 @@ class MitigationCheck extends Analyzer {
     if (this.checks.includes(spell) && !event.tick) {
       debug && console.log(this.buffCheck);
       debug && console.log(this.debuffCheck);
-      if (this.buffCheck.some((e) => this.selectedCombatant.hasBuff(e))) {
+      if (this.buffCheck.some((e) => this.selectedCombatant.hasBuff(e)) || event.hitType === HIT_TYPES.MISS || event.hitType === HIT_TYPES.DODGE || event.hitType === HIT_TYPES.PARRY || event.hitType === HIT_TYPES.IMMUNE) {
+        // pass checked if buff was up or the damage missed
         this.checksPassedMap.set(spell, this.checksPassedMap.get(spell) + 1);
       } else {
         const enemy = this.enemies.getEntities()[event.sourceID];

--- a/src/parser/shared/modules/MitigationCheck.js
+++ b/src/parser/shared/modules/MitigationCheck.js
@@ -53,7 +53,7 @@ class MitigationCheck extends Analyzer {
     if (this.checks.includes(spell) && !event.tick) {
       debug && console.log(this.buffCheck);
       debug && console.log(this.debuffCheck);
-      if (this.buffCheck.some((e) => this.selectedCombatant.hasBuff(e)) || event.hitType === HIT_TYPES.MISS || event.hitType === HIT_TYPES.DODGE || event.hitType === HIT_TYPES.PARRY || event.hitType === HIT_TYPES.IMMUNE) {
+      if (this.buffCheck.some((e) => this.selectedCombatant.hasBuff(e)) || event.hitType === HIT_TYPES.IMMUNE) {
         // pass checked if buff was up or the damage missed
         this.checksPassedMap.set(spell, this.checksPassedMap.get(spell) + 1);
       } else {


### PR DESCRIPTION
**Blood Death Knight**
Updates the Death's Caress-module to account for distance between the player and the target and checks if other ranged spells where available (DnD or BD, since those to more than DC).

The 12 yrd limit right now is kind of arbitrary. I had some distances that were bigger than 30yrds (up to 37yrd), which should be due to travel-time of the spell and the target's hitbox. But I think 12yrd should be a good place to start since it's still in the 8yrd range (+- boss hitbox) for BB.
Will adjust that number according to feedback. But it's for sure more accurate than the current implementation that just flags every single cast as bad.


**Soft Mitigation Check**
Now flags checks that were parried, dodged, missed or immuned as passed.