### PR TITLE
Resto Druid - Fixed ordering of WG/Flourish events

### DIFF
--- a/src/parser/druid/restoration/CHANGELOG.js
+++ b/src/parser/druid/restoration/CHANGELOG.js
@@ -4,7 +4,12 @@ import { Yajinni, blazyb, fel1ne, Qbz } from 'CONTRIBUTORS';
 
 export default [
   {
-    date: new Date('2018-10-19'), 
+    date: new Date('2018-11-06'),
+    changes: 'Fixed a minor bug with Flourish module and ordering of event being skewed.',
+    contributors: [blazyb],
+  },
+  {
+    date: new Date('2018-10-19'),
     changes: 'Updated bad Regrowth usage suggestions - using a regrowth with sufficent abundance stacks is not considered bad',
     contributors: [Qbz],
   },

--- a/src/parser/druid/restoration/normalizers/WildGrowth.js
+++ b/src/parser/druid/restoration/normalizers/WildGrowth.js
@@ -66,6 +66,30 @@ class WildGrowth extends EventsNormalizer {
           _newEvents = [];
         }
       }
+      // for WG apply buff events we look backwards through the events and any events of flourish we push forward
+      if (event.type === 'applybuff' && event.ability.guid === SPELLS.WILD_GROWTH.id) {
+        for (let _idx = idx - 1; _idx >= 0; _idx -= 1) {
+          const _event = _events[_idx];
+
+          if (_event.timestamp !== event.timestamp) {
+            _newEvents.reverse();
+            _events = _events.concat(_newEvents);
+            _newEvents = [];
+            break;
+          }
+
+          if ((_event.type === 'applybuff' || _event.type === 'cast') && _event.ability.guid === SPELLS.FLOURISH_TALENT.id) {
+            _events.splice(_idx, 1);
+            _newEvents.push(_event);
+          }
+        }
+
+        if (_newEvents.length) {
+          _newEvents.reverse();
+          _events = _events.concat(_newEvents);
+          _newEvents = [];
+        }
+      }
     });
 
     return _events;

--- a/src/parser/druid/restoration/normalizers/WildGrowth.test.js
+++ b/src/parser/druid/restoration/normalizers/WildGrowth.test.js
@@ -104,6 +104,48 @@ describe('RestoDruid/Modules/Normalizers/WildGrowth', () => {
       ],
       result: [2, 1, 4, 3, 6, 5],
     },
+    {
+      // 10: test that WG and Flourish buffs are reordering correctly
+      playerId: 1,
+      events: [
+        { testid: 1, timestamp: 1, targetID: null, ability: { guid: SPELLS.WILD_GROWTH.id }, type: 'cast' },
+        { testid: 2, timestamp: 1, targetID: null, ability: { guid: SPELLS.FLOURISH_TALENT.id }, type: 'cast' },
+        { testid: 3, timestamp: 1, targetID: 1, ability: { guid: SPELLS.FLOURISH_TALENT.id }, type: 'applybuff' },
+        { testid: 4, timestamp: 1, targetID: 2, ability: { guid: SPELLS.WILD_GROWTH.id }, type: 'applybuff' },
+        { testid: 5, timestamp: 1, targetID: 3, ability: { guid: SPELLS.WILD_GROWTH.id }, type: 'applybuff' },
+        { testid: 6, timestamp: 1, targetID: 4, ability: { guid: SPELLS.WILD_GROWTH.id }, type: 'applybuff' },
+        { testid: 7, timestamp: 1, targetID: 5, ability: { guid: SPELLS.WILD_GROWTH.id }, type: 'applybuff' },
+      ],
+      result: [1, 4, 5, 6, 7,  2, 3],
+    },
+    {
+      // 11: test that WG and Flourish buffs are reordering correctly #2
+      playerId: 1,
+      events: [
+        { testid: 1, timestamp: 1, targetID: null, ability: { guid: SPELLS.WILD_GROWTH.id }, type: 'cast' },
+        { testid: 3, timestamp: 1, targetID: 1, ability: { guid: SPELLS.FLOURISH_TALENT.id }, type: 'applybuff' },
+        { testid: 2, timestamp: 1, targetID: null, ability: { guid: SPELLS.FLOURISH_TALENT.id }, type: 'cast' },
+        { testid: 4, timestamp: 1, targetID: 2, ability: { guid: SPELLS.WILD_GROWTH.id }, type: 'applybuff' },
+        { testid: 5, timestamp: 1, targetID: 3, ability: { guid: SPELLS.WILD_GROWTH.id }, type: 'applybuff' },
+        { testid: 6, timestamp: 1, targetID: 4, ability: { guid: SPELLS.WILD_GROWTH.id }, type: 'applybuff' },
+        { testid: 7, timestamp: 1, targetID: 5, ability: { guid: SPELLS.WILD_GROWTH.id }, type: 'applybuff' },
+      ],
+      result: [1, 4, 5, 6, 7,  3, 2],
+    },
+    {
+      // 12: test that WG and Flourish buffs are in order and no orderings are made
+      playerId: 1,
+      events: [
+        { testid: 1, timestamp: 1, targetID: null, ability: { guid: SPELLS.WILD_GROWTH.id }, type: 'cast' },
+        { testid: 4, timestamp: 1, targetID: 2, ability: { guid: SPELLS.WILD_GROWTH.id }, type: 'applybuff' },
+        { testid: 5, timestamp: 1, targetID: 3, ability: { guid: SPELLS.WILD_GROWTH.id }, type: 'applybuff' },
+        { testid: 6, timestamp: 1, targetID: 4, ability: { guid: SPELLS.WILD_GROWTH.id }, type: 'applybuff' },
+        { testid: 7, timestamp: 1, targetID: 5, ability: { guid: SPELLS.WILD_GROWTH.id }, type: 'applybuff' },
+        { testid: 3, timestamp: 1, targetID: 1, ability: { guid: SPELLS.FLOURISH_TALENT.id }, type: 'applybuff' },
+        { testid: 2, timestamp: 1, targetID: null, ability: { guid: SPELLS.FLOURISH_TALENT.id }, type: 'cast' },
+      ],
+      result: [1, 4, 5, 6, 7,  3, 2],
+    },
   ];
 
   reorderScenarios.forEach((scenario, idx) => {


### PR DESCRIPTION
A bug was found by a user where a Flourish and WG cast happening at the exact same timestamp did not register in the flourish module.
Log: https://www.warcraftlogs.com/reports/YF9QbHPdWB8V4rKn#fight=last&type=summary&start=11672525&end=11690572&source=5&view=events

This is the events from WCL:
![img](https://i.gyazo.com/fe56bcec37dbec874763c6e4e943a5d5.png)

The issue here is that the applybuff events from WG comes after the cast and applybuff of flourish, making it seem as the player did not extend Wild Growh with Flourish. Below are two images, the image above shows current live version, the log and image above is referencing the 4th cast, this shows 4 HoTs available, but looking at the event logs it should be at least 6 (cause WG was extended).

The image below is the result of these changes.
[![Screenshot from Gyazo](https://gyazo.com/b45b038f05da1b716e7dc359bbb90424/raw)](https://gyazo.com/b45b038f05da1b716e7dc359bbb90424)

Live version suggests that 4/6 WGs were extended by Flourish, looking closely in the WCL cast events we can see clearly that all 6 Flourishes were extending WG.

I've extended the WildGrowth.js normalizer to move flourish event forwards and tests that should cover these scenarios.
