### PR TITLE
[Spriest] Making last voidform green on the checklist if you ended the fight in it.

### DIFF
--- a/src/parser/priest/shadow/modules/checklist/Component.js
+++ b/src/parser/priest/shadow/modules/checklist/Component.js
@@ -44,10 +44,16 @@ class ShadowPriestChecklist extends React.PureComponent {
       const requirements = [];
 
       for (let voidFormIndex = 0; voidFormIndex < props.voidform.voidforms.length; voidFormIndex++) {
+        const thresholds = props.voidform.suggestionStackThresholds(props.voidform.voidforms[voidFormIndex]);
+        // If you end the fight in voidform, we want to mark that voidform as green.
+        if (props.voidform.voidforms[voidFormIndex].excluded) {
+          thresholds.isLessThan = { minor: 0 };
+        }
+
         requirements.push(<Requirement
           key={voidFormIndex}
           name={`Voidform #${voidFormIndex + 1} stacks`}
-          thresholds={props.voidform.suggestionStackThresholds(props.voidform.voidforms[voidFormIndex])}
+          thresholds={thresholds}
         />);
 
       }


### PR DESCRIPTION
Currently, if you end a fight in voidform, you can be penalized in the checklist for the number of stacks you have. The stack average ignores ending voidforms, but the checklist still shows the last one as red. This fix makes it so the checklist will always show a fight ending voidform as green.

Before
![screen shot 2018-11-06 at 12 34 51 pm](https://user-images.githubusercontent.com/716498/48088981-9a177880-e1c0-11e8-8298-b37f5db9fd3e.png)

After: 
![screen shot 2018-11-06 at 12 34 09 pm](https://user-images.githubusercontent.com/716498/48088853-4c9b0b80-e1c0-11e8-9b9f-2d51e3d66f7d.png)
