### PR TITLE
[Core / Hunter] AverageTargetsHit and One With The Pack + Stomp 

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -9,6 +9,11 @@ import Contributor from 'interface/contributor/Button';
 
 export default [
   {
+    date: new Date('2018-11-09'),
+    changes: 'Added an AverageTargetsHit module for general usage.',
+    contributors: [Putro],
+  },
+  {
     date: new Date('2018-11-02'),
     changes: <>Added <SpellLink id={SPELLS.TRADEWINDS.id} /> module.</>,
     contributors: [Fyruna],

--- a/src/common/format.js
+++ b/src/common/format.js
@@ -69,11 +69,3 @@ export function formatMilliseconds(duration) {
 
   return response;
 }
-
-/**
- *
- */
-export function formatAverageTargetsHit(casts, hits, unique = 0) {
-
-  return 0;
-}

--- a/src/common/format.js
+++ b/src/common/format.js
@@ -69,3 +69,11 @@ export function formatMilliseconds(duration) {
 
   return response;
 }
+
+/**
+ *
+ */
+export function formatAverageTargetsHit(casts, hits, unique = 0) {
+
+  return 0;
+}

--- a/src/interface/others/AverageTargetsHit.js
+++ b/src/interface/others/AverageTargetsHit.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class AverageTargetsHit extends React.PureComponent {
+  static propTypes = {
+    casts: PropTypes.string.isRequired,
+    hits: PropTypes.string.isRequired,
+    approximate: PropTypes.bool,
+  };
+
+  render() {
+    const { casts, hits, approximate } = this.props;
+    const averageHits = (hits / casts).toFixed(1);
+    return (
+      <>
+        {approximate && '≈'}{averageHits}{' average '}{averageHits > 1 ? 'targets hit' : 'target hit'}
+      </>
+    );
+  }
+}
+
+export default AverageTargetsHit;

--- a/src/parser/hunter/beastmastery/CHANGELOG.js
+++ b/src/parser/hunter/beastmastery/CHANGELOG.js
@@ -6,6 +6,11 @@ import SPELLS from 'common/SPELLS';
 
 export default [
   {
+    date: new Date('2018-11-07'),
+    changes: <>Implemented talent statistic modules for <SpellLink id={SPELLS.ONE_WITH_THE_PACK_TALENT.id} />, <SpellLink id={SPELLS.BARRAGE_TALENT.id} /> and <SpellLink id={SPELLS.STOMP_TALENT.id} />.</>,
+    contributors: [Putro],
+  },
+  {
     date: new Date('2018-11-02'),
     changes: <>Implemented a talent statistic module and suggestions for <SpellLink id={SPELLS.VENOMOUS_BITE_TALENT.id} /> and <SpellLink id={SPELLS.THRILL_OF_THE_HUNT_TALENT.id} />.</>,
     contributors: [Putro],

--- a/src/parser/hunter/beastmastery/CHANGELOG.js
+++ b/src/parser/hunter/beastmastery/CHANGELOG.js
@@ -7,7 +7,7 @@ import SPELLS from 'common/SPELLS';
 export default [
   {
     date: new Date('2018-11-07'),
-    changes: <>Implemented talent statistic modules for <SpellLink id={SPELLS.ONE_WITH_THE_PACK_TALENT.id} />, <SpellLink id={SPELLS.BARRAGE_TALENT.id} /> and <SpellLink id={SPELLS.STOMP_TALENT.id} />.</>,
+    changes: <>Implemented talent statistic modules for <SpellLink id={SPELLS.ONE_WITH_THE_PACK_TALENT.id} /> and <SpellLink id={SPELLS.STOMP_TALENT.id} />.</>,
     contributors: [Putro],
   },
   {

--- a/src/parser/hunter/beastmastery/CombatLogParser.js
+++ b/src/parser/hunter/beastmastery/CombatLogParser.js
@@ -24,6 +24,7 @@ import Stomp from './modules/talents/Stomp';
 import AMurderOfCrows from '../shared/modules/talents/AMurderOfCrows';
 import ThrillOfTheHunt from './modules/talents/ThrillOfTheHunt';
 import VenomousBite from './modules/talents/VenomousBite';
+import OneWithThePack from './modules/talents/OneWithThePack';
 
 //Spells
 import BeastCleave from './modules/spells/BeastCleave';
@@ -85,6 +86,7 @@ class CombatLogParser extends CoreCombatLogParser {
     aMurderOfCrows: AMurderOfCrows,
     venomousBite: VenomousBite,
     thrillOfTheHunt: ThrillOfTheHunt,
+    oneWithThePack: OneWithThePack,
 
     //Traits and talents
     traitsAndTalents: TraitsAndTalents,

--- a/src/parser/hunter/beastmastery/modules/Abilities.js
+++ b/src/parser/hunter/beastmastery/modules/Abilities.js
@@ -215,17 +215,23 @@ class Abilities extends CoreAbilities {
         },
       },
       {
+        spell: SPELLS.ASPECT_OF_THE_CHEETAH,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: () => {
+          const bornToBeWildCDR = combatant.hasTalent(SPELLS.BORN_TO_BE_WILD_TALENT.id) ? 0.2 : 0;
+          return 180 * (1 - bornToBeWildCDR);
+        },
+        gcd: null,
+      },
+      {
         spell: SPELLS.ASPECT_OF_THE_TURTLE,
         buffSpellId: SPELLS.ASPECT_OF_THE_TURTLE.id,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         isDefensive: true,
-        cooldown: 180,
-        gcd: null,
-      },
-      {
-        spell: SPELLS.ASPECT_OF_THE_CHEETAH,
-        category: Abilities.SPELL_CATEGORIES.UTILITY,
-        cooldown: 180,
+        cooldown: () => {
+          const bornToBeWildCDR = combatant.hasTalent(SPELLS.BORN_TO_BE_WILD_TALENT.id) ? 0.2 : 0;
+          return 180 * (1 - bornToBeWildCDR);
+        },
         gcd: null,
       },
       {

--- a/src/parser/hunter/beastmastery/modules/features/SpellsAndTalents.js
+++ b/src/parser/hunter/beastmastery/modules/features/SpellsAndTalents.js
@@ -8,7 +8,6 @@ import Analyzer from 'parser/core/Analyzer';
 import Barrage from 'parser/hunter/shared/modules/talents/Barrage';
 import ChimaeraShot from 'parser/hunter/beastmastery/modules/talents/ChimaeraShot';
 import Stampede from 'parser/hunter/beastmastery/modules/talents/Stampede';
-import Stomp from 'parser/hunter/beastmastery/modules/talents/Stomp';
 import KillerInstinct from 'parser/hunter/beastmastery/modules/talents/KillerInstinct';
 import AspectOfTheBeast from 'parser/hunter/beastmastery/modules/talents/AspectOfTheBeast';
 import BarbedShot from '../spells/BarbedShot';
@@ -23,7 +22,6 @@ class SpellsAndTalents extends Analyzer {
     killerInstinct: KillerInstinct,
     chimaeraShot: ChimaeraShot,
     stampede: Stampede,
-    stomp: Stomp,
     aMurderOfCrows: AMurderOfCrows,
     aspectOfTheBeast: AspectOfTheBeast,
   };
@@ -49,7 +47,6 @@ class SpellsAndTalents extends Analyzer {
         {this.killerInstinct.active && this.killerInstinct.subStatistic()}
         {this.chimaeraShot.active && this.chimaeraShot.subStatistic()}
         {this.stampede.active && this.stampede.subStatistic()}
-        {this.stomp.active && this.stomp.subStatistic()}
         {this.aMurderOfCrows.active && this.aMurderOfCrows.subStatistic()}
         {this.aspectOfTheBeast.active && this.aspectOfTheBeast.subStatistic()}
       </StatisticsListBox>

--- a/src/parser/hunter/beastmastery/modules/talents/OneWithThePack.js
+++ b/src/parser/hunter/beastmastery/modules/talents/OneWithThePack.js
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import Analyzer from 'parser/core/Analyzer';
+import HIT_TYPES from 'game/HIT_TYPES';
+import TalentStatisticBox from 'interface/others/TalentStatisticBox';
+import SpellIcon from 'common/SpellIcon';
+
+/**
+ * Wild Call has a 20% increased chance to reset the cooldown of Barbed Shot.
+ *
+ * Example log: https://www.warcraftlogs.com/reports/PLyFT2hcmCv39X7R#fight=1&type=damage-done&source=6
+ *
+ * Wild Call: Your auto shot critical strikes have a 20% chance to reset the cooldown of Barbed Shot.
+ */
+
+const WILD_CALL_RESET_PERCENT = 0.2;
+
+class OneWithThePack extends Analyzer {
+
+  procChances = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.ONE_WITH_THE_PACK_TALENT.id);
+  }
+
+  on_byPlayer_damage(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.AUTO_SHOT.id) {
+      return;
+    }
+    if (event.hitType !== HIT_TYPES.CRIT) {
+      return;
+    }
+    this.procChances += 1;
+  }
+
+  statistic() {
+    return (
+      <TalentStatisticBox
+        icon={<SpellIcon id={SPELLS.ONE_WITH_THE_PACK_TALENT.id} />}
+        value={`≈${(this.procChances * WILD_CALL_RESET_PERCENT).toFixed(1)} resets`}
+        label="One With The Pack"
+        tooltip={`Since there is no way to track Wild Call resets, this is an approximation of how many resets One With The Pack granted you.`}
+      />
+    );
+  }
+}
+
+export default OneWithThePack;

--- a/src/parser/hunter/beastmastery/modules/talents/Stomp.js
+++ b/src/parser/hunter/beastmastery/modules/talents/Stomp.js
@@ -6,6 +6,7 @@ import ItemDamageDone from 'interface/others/ItemDamageDone';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import SpellIcon from 'common/SpellIcon';
+import AverageTargetsHit from 'interface/others/AverageTargetsHit';
 
 /**
  * When you cast Barbed Shot, your pet stomps the ground, dealing [((50% of Attack power)) * (1 + Versatility)] Physical damage to all nearby enemies.
@@ -17,6 +18,7 @@ class Stomp extends Analyzer {
 
   damage = 0;
   hits = 0;
+  casts = 0;
 
   constructor(...args) {
     super(...args);
@@ -24,7 +26,11 @@ class Stomp extends Analyzer {
   }
 
   on_byPlayer_cast(event) {
-
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.BARBED_SHOT.id && spellId !== SPELLS.DIRE_BEAST_TALENT.id) {
+      return;
+    }
+    this.casts += 1;
   }
 
   on_byPlayerPet_damage(event) {
@@ -43,7 +49,7 @@ class Stomp extends Analyzer {
         icon={<SpellIcon id={SPELLS.STOMP_TALENT.id} />}
         value={<>
           <ItemDamageDone amount={this.damage} /> <br />
-
+          <AverageTargetsHit casts={this.casts} hits={this.hits} />
         </>}
         label="Stomp"
       />

--- a/src/parser/hunter/beastmastery/modules/talents/Stomp.js
+++ b/src/parser/hunter/beastmastery/modules/talents/Stomp.js
@@ -1,10 +1,11 @@
 import React from 'react';
 
 import SPELLS from 'common/SPELLS';
-import SpellLink from 'common/SpellLink';
 import Analyzer from 'parser/core/Analyzer';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
-import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
+import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
+import TalentStatisticBox from 'interface/others/TalentStatisticBox';
+import SpellIcon from 'common/SpellIcon';
 
 /**
  * When you cast Barbed Shot, your pet stomps the ground, dealing [((50% of Attack power)) * (1 + Versatility)] Physical damage to all nearby enemies.
@@ -13,11 +14,17 @@ import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
  */
 
 class Stomp extends Analyzer {
+
   damage = 0;
+  hits = 0;
 
   constructor(...args) {
     super(...args);
     this.active = this.selectedCombatant.hasTalent(SPELLS.STOMP_TALENT.id);
+  }
+
+  on_byPlayer_cast(event) {
+
   }
 
   on_byPlayerPet_damage(event) {
@@ -25,14 +32,20 @@ class Stomp extends Analyzer {
     if (spellId !== SPELLS.STOMP_DAMAGE.id) {
       return;
     }
+    this.hits += 1;
     this.damage += event.amount + (event.absorbed || 0);
   }
 
-  subStatistic() {
+  statistic() {
     return (
-      <StatisticListBoxItem
-        title={<SpellLink id={SPELLS.STOMP_TALENT.id} />}
-        value={<ItemDamageDone amount={this.damage} />}
+      <TalentStatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
+        icon={<SpellIcon id={SPELLS.STOMP_TALENT.id} />}
+        value={<>
+          <ItemDamageDone amount={this.damage} /> <br />
+
+        </>}
+        label="Stomp"
       />
     );
   }

--- a/src/parser/hunter/marksmanship/modules/Abilities.js
+++ b/src/parser/hunter/marksmanship/modules/Abilities.js
@@ -209,17 +209,23 @@ class Abilities extends CoreAbilities {
 
       },
       {
+        spell: SPELLS.ASPECT_OF_THE_CHEETAH,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: () => {
+          const bornToBeWildCDR = combatant.hasTalent(SPELLS.BORN_TO_BE_WILD_TALENT.id) ? 0.2 : 0;
+          return 180 * (1 - bornToBeWildCDR);
+        },
+        gcd: null,
+      },
+      {
         spell: SPELLS.ASPECT_OF_THE_TURTLE,
         buffSpellId: SPELLS.ASPECT_OF_THE_TURTLE.id,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         isDefensive: true,
-        cooldown: 180,
-        gcd: null,
-      },
-      {
-        spell: SPELLS.ASPECT_OF_THE_CHEETAH,
-        category: Abilities.SPELL_CATEGORIES.UTILITY,
-        cooldown: 180,
+        cooldown: () => {
+          const bornToBeWildCDR = combatant.hasTalent(SPELLS.BORN_TO_BE_WILD_TALENT.id) ? 0.2 : 0;
+          return 180 * (1 - bornToBeWildCDR);
+        },
         gcd: null,
       },
       {

--- a/src/parser/hunter/shared/modules/talents/NaturalMending.js
+++ b/src/parser/hunter/shared/modules/talents/NaturalMending.js
@@ -60,8 +60,8 @@ class NaturalMending extends Analyzer {
       <TalentStatisticBox
         position={STATISTIC_ORDER.OPTIONAL()}
         icon={<SpellIcon id={SPELLS.NATURAL_MENDING_TALENT.id} />}
-        value={`${formatNumber(this.effectiveExhilReductionMs / 1000)}s`}
-        label="Exhilaration CDR"
+        value={`${formatNumber(this.effectiveExhilReductionMs / 1000)}s CDR`}
+        label="Natural Mending"
         tooltip={`You wasted ${formatNumber(this.wastedExhilReductionMs / 1000)} seconds of CDR by spending focus whilst Exhilaration wasn't on cooldown.`} />
     );
   }

--- a/src/parser/hunter/survival/modules/Abilities.js
+++ b/src/parser/hunter/survival/modules/Abilities.js
@@ -157,8 +157,8 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.ASPECT_OF_THE_EAGLE,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: () => {
-          const hasBornToBeWild = combatant.hasTalent(SPELLS.BORN_TO_BE_WILD_TALENT.id);
-          return 90 * (1 - (hasBornToBeWild ? 0.2 : 0));
+          const bornToBeWildCDR = combatant.hasTalent(SPELLS.BORN_TO_BE_WILD_TALENT.id) ? 0.2 : 0;
+          return 90 * (1 - bornToBeWildCDR);
         },
         gcd: null,
       },
@@ -166,8 +166,8 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.ASPECT_OF_THE_CHEETAH,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: () => {
-          const hasBornToBeWild = combatant.hasTalent(SPELLS.BORN_TO_BE_WILD_TALENT.id);
-          return 180 * (1 - (hasBornToBeWild ? 0.2 : 0));
+          const bornToBeWildCDR = combatant.hasTalent(SPELLS.BORN_TO_BE_WILD_TALENT.id) ? 0.2 : 0;
+          return 180 * (1 - bornToBeWildCDR);
         },
         gcd: null,
       },
@@ -177,8 +177,8 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         isDefensive: true,
         cooldown: () => {
-          const hasBornToBeWild = combatant.hasTalent(SPELLS.BORN_TO_BE_WILD_TALENT.id);
-          return 180 * hasBornToBeWild ? 0.8 : 1;
+          const bornToBeWildCDR = combatant.hasTalent(SPELLS.BORN_TO_BE_WILD_TALENT.id) ? 0.2 : 0;
+          return 180 * (1 - bornToBeWildCDR);
         },
         gcd: null,
       },

--- a/src/parser/hunter/survival/modules/spells/azeritetraits/WildernessSurvival.js
+++ b/src/parser/hunter/survival/modules/spells/azeritetraits/WildernessSurvival.js
@@ -38,7 +38,7 @@ class WildernessSurvival extends Analyzer {
   }
 
   get effectiveCDRInSeconds() {
-    return this.effectiveWSReductionMs / 1000;
+    return (this.effectiveWSReductionMs / 1000).toFixed(1);
   }
 
   get wastedCDRInSeconds() {


### PR DESCRIPTION
Fixes a bug with Born to be wild affecting CDR. 
Fixes formatting with a Survival Azerite trait

Adds a core average targets hit module (unique targets hit is WIP and will be in next PR) 
Implements an actual statistic for Stomp together with the newly added core average targets hit module.
Implements One With The Pack talent. 

/report/A89tf3NJMqCXhKFV/1-Normal+Taloc+-+Kill+(5:32)/15-Shadowmikey
![image](https://user-images.githubusercontent.com/29204244/48168558-fcbb6200-e2ef-11e8-8d07-d993c7ca07bc.png)
![image](https://user-images.githubusercontent.com/29204244/48168566-00e77f80-e2f0-11e8-8c2d-48f15439bd05.png)

/report/A89tf3NJMqCXhKFV/5-Normal+Vectis+-+Kill+(5:29)/15-Shadowmikey
![image](https://user-images.githubusercontent.com/29204244/48168571-0b097e00-e2f0-11e8-8f35-848e2e86c6ad.png)

