### PR TITLE
[Core] Fix bug with fabricate event filter property

### DIFF
--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -459,8 +459,8 @@ class CombatLogParser {
       timestamp: this.currentTimestamp,
       // If this event was triggered you should pass it along
       trigger: trigger ? trigger : undefined,
-      type: event.type instanceof EventFilter ? event.type.eventType : event.type,
       ...event,
+      type: event.type instanceof EventFilter ? event.type.eventType : event.type,
       __fabricated: true,
     });
   }


### PR DESCRIPTION
https://cdn.discordapp.com/attachments/392514374532726795/510315859969835008/unknown.png

[9:15 PM] niseko: found the cause, on_finished never gets called
[9:30 PM] Dambroda: found another bug, or tell me if its just my end
[9:30 PM] Dambroda: if i go to the events tab and scroll all the way to the bottom, it crashes
[9:30 PM] Dambroda: only if i have fabricated turned on
[9:31 PM] niseko: that is one impressive error message
