### PR TITLE
[Core] Fix StatisticBox icon size

### DIFF
--- a/src/interface/others/ItemStatisticBox.js
+++ b/src/interface/others/ItemStatisticBox.js
@@ -13,7 +13,7 @@ const ItemStatisticBox = ({ icon, value, tooltip, label, containerProps, alignIc
     <div className="col-lg-3 col-md-4 col-sm-6 col-xs-12" {...containerProps}>
       <div className="panel statistic-box item" {...others}>
         <div className="panel-body flex">
-          <div className="flex-sub" style={{ display: 'flex', alignItems: alignIcon }}>
+          <div className="flex-sub statistic-icon" style={{ display: 'flex', alignItems: alignIcon }}>
             {icon}
           </div>
           <div className="flex-main">

--- a/src/interface/others/TalentStatisticBox.js
+++ b/src/interface/others/TalentStatisticBox.js
@@ -16,7 +16,7 @@ const TalentStatisticBox = ({ talent, icon, label, value, tooltip, containerProp
     <div className="col-lg-3 col-md-4 col-sm-6 col-xs-12" {...containerProps}>
       <div className="panel statistic-box item" {...others}>
         <div className="panel-body flex">
-          <div className="flex-sub" style={{ display: 'flex', alignItems: alignIcon }}>
+          <div className="flex-sub statistic-icon" style={{ display: 'flex', alignItems: alignIcon }}>
             {icon || <SpellIcon id={talent} />}
           </div>
           <div className="flex-main">

--- a/src/interface/others/TraitStatisticBox.js
+++ b/src/interface/others/TraitStatisticBox.js
@@ -16,7 +16,7 @@ const TraitStatisticBox = ({ trait, icon, label, value, tooltip, containerProps,
     <div className="col-lg-3 col-md-4 col-sm-6 col-xs-12" {...containerProps}>
       <div className="panel statistic-box item" {...others}>
         <div className="panel-body flex">
-          <div className="flex-sub" style={{ display: 'flex', alignItems: alignIcon }}>
+          <div className="flex-sub statistic-icon" style={{ display: 'flex', alignItems: alignIcon }}>
             {icon || <SpellIcon id={trait} />}
           </div>
           <div className="flex-main">


### PR DESCRIPTION
This commit https://github.com/WoWAnalyzer/WoWAnalyzer/commit/770c2209a0dbf5bd23acd5cdb1d735c622fca782 changed a bit of CSS but didn't fix all of the affected statistic boxes.

Before
![image](https://user-images.githubusercontent.com/2842471/48306876-975eaf80-e541-11e8-9524-0e6cf87d8c87.png)
After
![image](https://user-images.githubusercontent.com/2842471/48306877-9b8acd00-e541-11e8-8d1b-b014eea93896.png)
