### PR TITLE
[Core] Add My'das Talisman stat block and event tracking

### DIFF
--- a/server/helpers/fetchFromWarcraftLogsApi.js
+++ b/server/helpers/fetchFromWarcraftLogsApi.js
@@ -1,5 +1,4 @@
 import querystring from 'querystring';
-import { RequestError } from 'request-promise-native/errors';
 
 import { warcraftLogsApiResponseLatencyHistogram } from 'helpers/metrics';
 import RequestTimeoutError from 'helpers/request/RequestTimeoutError';

--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Mamtooth, Zerotorescue, Putro, joshinator, Gebuz, ackwell, emallson, blazyb, Dambroda, Nalhan, Satyric, niseko, Khadaj, Fyruna, Matardarix, jos3p } from 'CONTRIBUTORS';
+import { Mamtooth, Zerotorescue, Putro, joshinator, Gebuz, ackwell, emallson, blazyb, Dambroda, Nalhan, Satyric, niseko, Khadaj, Fyruna, Matardarix, jos3p, Aelexe } from 'CONTRIBUTORS';
 import ItemLink from 'common/ItemLink';
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
@@ -8,6 +8,11 @@ import SpellLink from 'common/SpellLink';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  {
+    date: new Date('2018-11-11'),
+    changes: <>Added <ItemLink id={ITEMS.MYDAS_TALISMAN.id} /> module.</>,
+    contributors: [Aelexe],
+  },
   {
     date: new Date('2018-11-10'),
     changes: <>Added <ItemLink id={ITEMS.ROTCRUSTED_VOODOO_DOLL.id} /> module.</>,

--- a/src/common/ITEMS/bfa/dungeons/index.js
+++ b/src/common/ITEMS/bfa/dungeons/index.js
@@ -39,6 +39,12 @@ export default {
   },
 
   // Atal'Dazar
+  MYDAS_TALISMAN: {
+    id: 158319,
+    name: 'My\'das Talisman',
+    icon: 'inv_offhand_draenei_a_02',
+    quality: ITEM_QUALITIES.BLUE,
+  },
   REVITALIZING_VOODOO_TOTEM: {
     id: 158320,
     name: 'Revitalizing Voodoo Totem',

--- a/src/common/SPELLS/bfa/dungeons/items.js
+++ b/src/common/SPELLS/bfa/dungeons/items.js
@@ -34,6 +34,16 @@ export default {
   },
 
   // Atal'Dazar
+  TOUCH_OF_GOLD: { // My'das Talisman
+    id: 265954,
+    name: 'Touch of Gold',
+    icon: 'inv_gauntlets_60',
+  },
+  TOUCH_OF_GOLD_DAMAGE: { // My'das Talisman
+    id: 265953,
+    name: 'Touch of Gold',
+    icon: 'inv_gauntlets_60',
+  },
   TOUCH_OF_THE_VOODOO: { // Revitalizing Voodoo Totem
     id: 266018,
     name: 'Touch of the Voodoo',

--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -66,6 +66,7 @@ import VantusRune from '../shared/modules/spells/VantusRune';
 import GildedLoaFigurine from '../shared/modules/items/bfa/GildedLoaFigurine';
 import FirstMatesSpyglass from '../shared/modules/items/bfa/FirstMatesSpyglass';
 // Dungeons
+import MydasTalisman from '../shared/modules/items/bfa/dungeons/MydasTalisman';
 import RevitalizingVoodooTotem from '../shared/modules/items/bfa/dungeons/RevitalizingVoodooTotem';
 import LingeringSporepods from '../shared/modules/items/bfa/dungeons/LingeringSporepods';
 import FangsOfIntertwinedEssence from '../shared/modules/items/bfa/dungeons/FangsOfIntertwinedEssence';
@@ -201,6 +202,7 @@ class CombatLogParser {
     firstMatesSpyglass: FirstMatesSpyglass,
     revitalizingVoodooTotem: RevitalizingVoodooTotem,
     // Dungeons
+    mydasTalisman: MydasTalisman,
     lingeringSporepods: LingeringSporepods,
     fangsOfIntertwinedEssence: FangsOfIntertwinedEssence,
     balefireBranch: BalefireBranch,

--- a/src/parser/shared/modules/items/bfa/dungeons/MydasTalisman.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/MydasTalisman.js
@@ -1,0 +1,55 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS/index';
+import ITEMS from 'common/ITEMS/index';
+import Analyzer from 'parser/core/Analyzer';
+import Abilities from 'parser/shared/modules/Abilities';
+
+import ItemDamageDone from 'interface/others/ItemDamageDone';
+
+/**
+ * My'das Talisman
+ * Use: Turn your hands to gold, causing your next 5 auto-attacks to deal X extra damage. (1 Min, 30 Sec Cooldown)
+ */
+class MydasTalisman extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+  };
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrinket(ITEMS.MYDAS_TALISMAN.id);
+
+    if (this.active) {
+      this.damage = 0;
+
+      this.abilities.add({
+        spell: SPELLS.TOUCH_OF_GOLD,
+        buffSpellId: SPELLS.TOUCH_OF_GOLD.id,
+        name: ITEMS.MYDAS_TALISMAN.name,
+        category: Abilities.SPELL_CATEGORIES.ITEMS,
+        cooldown: 90,
+        castEfficiency: {
+          suggestion: true,
+        },
+      });
+    }
+  }
+
+  on_byPlayer_damage(event) {
+    if (event.ability.guid !== SPELLS.TOUCH_OF_GOLD_DAMAGE.id) {
+      return;
+    }
+
+    this.damage += event.amount + (event.absorbed || 0);
+  }
+
+  item() {
+    return {
+      item: ITEMS.MYDAS_TALISMAN,
+      result: <ItemDamageDone amount={this.damage} />,
+    };
+  }
+}
+
+export default MydasTalisman;


### PR DESCRIPTION
Added My'Das Talisman stat block and added the spell to abilities for tracking. I also flagged it for cast efficiency suggestions, but I couldn't test if it works because all the logs I could find used it on cooldown.

![image](https://user-images.githubusercontent.com/2950145/48308941-6dee6400-e5d3-11e8-9b3a-83bf6a6f221f.png)

![image](https://user-images.githubusercontent.com/2950145/48308946-7d6dad00-e5d3-11e8-851d-11e52bfad9ed.png)
