### PR TITLE
[Restoration Shaman] Earthen Wall Totem cast details

### DIFF
--- a/src/parser/shaman/restoration/CHANGELOG.js
+++ b/src/parser/shaman/restoration/CHANGELOG.js
@@ -7,7 +7,7 @@ import SpellLink from 'common/SpellLink';
 export default [
   {
     date: new Date('2018-11-12'),
-    changes: <>The <SpellLink id={SPELLS.EARTHEN_WALL_TOTEM_TALENT.id} /> module now provides efficiency details on individual casts.</>,
+    changes: <>The <SpellLink id={SPELLS.EARTHEN_WALL_TOTEM_TALENT.id} /> module now provides efficiency details on individual casts, and filters out healing on pets.</>,
     contributors: [niseko],
   },
   {

--- a/src/parser/shaman/restoration/CHANGELOG.js
+++ b/src/parser/shaman/restoration/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-11-12'),
+    changes: <>The <SpellLink id={SPELLS.EARTHEN_WALL_TOTEM_TALENT.id} /> module now provides efficiency details on individual casts.</>,
+    contributors: [niseko],
+  },
+  {
     date: new Date('2018-11-04'),
     changes: 'New Tab added: "Mana Efficiency".',
     contributors: [niseko],

--- a/src/parser/shaman/restoration/CHANGELOG.js
+++ b/src/parser/shaman/restoration/CHANGELOG.js
@@ -6,7 +6,7 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
-    date: new Date('2018-11-12'),
+    date: new Date('2018-11-15'),
     changes: <>The <SpellLink id={SPELLS.EARTHEN_WALL_TOTEM_TALENT.id} /> module now provides efficiency details on individual casts, and filters out healing on pets.</>,
     contributors: [niseko],
   },

--- a/src/parser/shaman/restoration/modules/talents/EarthenWallTotem.js
+++ b/src/parser/shaman/restoration/modules/talents/EarthenWallTotem.js
@@ -3,9 +3,10 @@ import React from 'react';
 import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import SPELLS from 'common/SPELLS';
-import { formatNumber, formatPercentage } from 'common/format';
+import { formatNumber, formatPercentage, formatDuration } from 'common/format';
 
-import Analyzer from 'parser/core/Analyzer';
+import Analyzer, { SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
 
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 
@@ -13,93 +14,120 @@ import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
 
+const RECOMMENDED_EFFICIENCY = 0.75;
+
 class EarthenWallTotem extends Analyzer {
   static dependencies = {
     abilityTracker: AbilityTracker,
   };
 
+  earthenWallTotems = [];
+  castNumber = 0;
   prePullCast = true;
-  prePullCastHealth = 0; // Used to be boolean, but i need the number in case the player is Mag'har Orc
-  potentialHealing = 0;
-  healing = 0;
+  isMaghar = false;
 
-  constructor(...args) {
-    super(...args);
+  constructor(props) {
+    super(props);
     this.active = this.selectedCombatant.hasTalent(SPELLS.EARTHEN_WALL_TOTEM_TALENT.id);
+    this.isMaghar = this.selectedCombatant.race && this.selectedCombatant.race.name === "Mag'har Orc";
+
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.EARTHEN_WALL_TOTEM_TALENT), this._onCast);
+    this.addEventListener(Events.damage.to(SELECTED_PLAYER_PET).spell(SPELLS.EARTHEN_WALL_TOTEM_SELF_DAMAGE), this._onTotemDamageTaken);
   }
 
-  on_toPlayerPet_damage(event) {
-    const spellId = event.ability.guid;
-
-    if (spellId !== SPELLS.EARTHEN_WALL_TOTEM_SELF_DAMAGE.id) {
-      return;
-    }
-
-    if (this.prePullCast) {
-      this.potentialHealing += event.maxHitPoints; // this is taking the totems max HP, which is the same result as the players unless Mag'har Orc
-      this.prePullCast = false;
-      this.prePullCastHealth = event.maxHitPoints;
-    }
-
-    this.healing += (event.amount || 0);
-  }
-
-  on_byPlayer_cast(event) {
-    const spellId = event.ability.guid;
-
-    if (spellId !== SPELLS.EARTHEN_WALL_TOTEM_TALENT.id) {
-      return;
-    }
-
+  _onCast(event) {
     if (this.prePullCast) {
       this.prePullCast = false;
     }
 
-    this.potentialHealing += event.maxHitPoints; 
+    this.castNumber += 1;
+    this.earthenWallTotems[this.castNumber] = {
+      potentialHealing: this.isMaghar ? Math.floor(event.maxHitPoints * 1.1) : event.maxHitPoints,
+      effectiveHealing: 0,
+      timestamp: event.timestamp,
+    };
   }
 
-  get earthenShieldEfficiency() {
-    return this.healing / this.potentialHealing;
-  }
-
-  // If Mag'har Orc, +10% totem health (FeelsBadMan, no player race data)
-  on_finished() {
-    if (this.abilityTracker.getAbility(SPELLS.ANCESTRAL_CALL.id).casts || 0) {
-      // if this.prePullCastHealth has a value, it already got increased by 10% because it takes the totems health instead of the players
-      if (this.prePullCastHealth > 0) {
-        this.potentialHealing = (this.potentialHealing - this.prePullCastHealth) * 1.1 + this.prePullCastHealth;
-      } else {
-        this.potentialHealing *= 1.1;
-      }
+  _onTotemDamageTaken(event) {
+    if (this.prePullCast) {
+      this.earthenWallTotems[this.castNumber] = {
+        potentialHealing: event.maxHitPoints, // this is taking the totems max HP, which is the same result as the players unless Mag'har Orc
+        effectiveHealing: 0,
+        timestamp: this.owner.fight.start_time,
+      };
+      this.prePullCast = false;
     }
+
+    // If for some reason something goes wrong with the race detection
+    // The reason this isn't always using the totems health, is that I need to account for totems that never had damage taken events
+    if (event.maxHitPoints && this.earthenWallTotems[this.castNumber].potentialHealing !== event.maxHitPoints) {
+      this.isMaghar = true; // likely
+      this.earthenWallTotems[this.castNumber].potentialHealing = event.maxHitPoints;
+    }
+
+    this.earthenWallTotems[this.castNumber].effectiveHealing += event.amount + (event.absorbed || 0);
+  }
+
+  get totalEffectiveHealing() {
+    return Object.values(this.earthenWallTotems).reduce((sum, cast) => sum + cast.effectiveHealing, 0);
+  }
+
+  get totalPotentialHealing() {
+    return Object.values(this.earthenWallTotems).reduce((sum, cast) => sum + cast.potentialHealing, 0);
+  }
+
+  get earthenWallEfficiency() {
+    return this.totalEffectiveHealing / this.totalPotentialHealing;
   }
 
   suggestions(when) {
-    when(this.earthenShieldEfficiency).isLessThan(0.75)
+    when(this.earthenWallEfficiency).isLessThan(RECOMMENDED_EFFICIENCY)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>Try to cast <SpellLink id={SPELLS.EARTHEN_WALL_TOTEM_TALENT.id} /> at times - and positions where there will be as many people taking damage possible inside of it to maximize the amount it absorbs.</span>)
           .icon(SPELLS.EARTHEN_WALL_TOTEM_TALENT.icon)
-          .actual(`${this.earthenShieldEfficiency.toFixed(2)}%`)
+          .actual(`${this.earthenWallEfficiency.toFixed(2)}%`)
           .recommended(`${recommended}%`)
           .regular(recommended - .15).major(recommended - .3);
       });
   }
 
   statistic() {
-    const casts = this.abilityTracker.getAbility(SPELLS.EARTHEN_WALL_TOTEM_TALENT.id).casts + (this.prePullCastHealth > 0 ? 1 : 0);
+    const casts = this.earthenWallTotems.filter((cast => cast.timestamp > 0)).length;
+    const nth = (number) => ["st", "nd", "rd"][((number + 90) % 100 - 10) % 10 - 1] || "th";
 
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.EARTHEN_WALL_TOTEM_TALENT.id} />}
-        value={`${formatPercentage(this.earthenShieldEfficiency)} %`}
+        value={`${formatPercentage(this.earthenWallEfficiency)} %`}
         category={STATISTIC_CATEGORY.TALENTS}
         position={STATISTIC_ORDER.OPTIONAL(60)}
-        label={(
-          <dfn data-tip={`The percentage of the potential absorb of Earthen Wall Totem that was actually used. You cast a total of ${casts} Earthen Wall Totems with a combined health of ${formatNumber(this.potentialHealing)}, which absorbed a total of ${formatNumber(this.healing)} damage.`}>
-            Earthen Wall Totem efficiency
-          </dfn>
-        )}
-      />
+        label={"Earthen Wall Totem efficiency"}
+        tooltip={`The percentage of the potential absorb of Earthen Wall Totem that was actually used. You cast a total of ${casts} Earthen Wall Totems with a combined health of ${formatNumber(this.totalPotentialHealing)}, which absorbed a total of ${formatNumber(this.totalEffectiveHealing)} damage.`}
+      >
+        <table className="table table-condensed">
+          <thead>
+            <tr>
+              <th>Cast</th>
+              <th>Time</th>
+              <th>Efficiency</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              this.earthenWallTotems.filter((cast => cast.timestamp > 0)).map((cast, index) => {
+                const castEfficiency = cast.effectiveHealing / cast.potentialHealing;
+                return (
+                  <tr key={index}>
+                    <th scope="row">{index + 1}{nth(index + 1)}</th>
+                    <td>{formatDuration((cast.timestamp - this.owner.fight.start_time) / 1000) || 0}</td>
+                    <td style={castEfficiency < RECOMMENDED_EFFICIENCY ? { color: 'red', fontWeight: 'bold' } : { fontWeight: 'bold' }}>{formatPercentage(castEfficiency)} %</td>
+                  </tr>
+                );
+              })
+            }
+          </tbody>
+        </table>
+      </StatisticBox>
     );
   }
 
@@ -107,11 +135,10 @@ class EarthenWallTotem extends Analyzer {
     return (
       <StatisticListBoxItem
         title={<SpellLink id={SPELLS.EARTHEN_WALL_TOTEM_TALENT.id} />}
-        value={`${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing))} %`}
+        value={`${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.totalEffectiveHealing))} %`}
       />
     );
   }
 }
 
 export default EarthenWallTotem;
-

--- a/src/parser/shaman/restoration/modules/talents/EarthenWallTotem.js
+++ b/src/parser/shaman/restoration/modules/talents/EarthenWallTotem.js
@@ -15,6 +15,7 @@ import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
 
 const RECOMMENDED_EFFICIENCY = 0.75;
+const MAGHAR_ORC_PET_HEALTH_INCREASE = 0.1;
 
 class EarthenWallTotem extends Analyzer {
   static dependencies = {
@@ -43,7 +44,7 @@ class EarthenWallTotem extends Analyzer {
 
     this.castNumber += 1;
     this.earthenWallTotems[this.castNumber] = {
-      potentialHealing: this.isMaghar ? Math.floor(event.maxHitPoints * 1.1) : event.maxHitPoints,
+      potentialHealing: this.isMaghar ? Math.floor(event.maxHitPoints * (1+MAGHAR_ORC_PET_HEALTH_INCREASE)) : event.maxHitPoints,
       effectiveHealing: 0,
       timestamp: event.timestamp,
     };
@@ -59,8 +60,8 @@ class EarthenWallTotem extends Analyzer {
       this.prePullCast = false;
     }
 
-    // If for some reason something goes wrong with the race detection
-    // The reason this isn't always using the totems health, is that I need to account for totems that never had damage taken events
+    // If for some reason something goes wrong with the race detection, this should be the only reason for differences in health
+    // The reason this isn't always using the totems health, is that you need to account for totems that never had damage taken events (0% efficiency)
     if (event.maxHitPoints && this.earthenWallTotems[this.castNumber].potentialHealing !== event.maxHitPoints) {
       this.isMaghar = true; // likely
       this.earthenWallTotems[this.castNumber].potentialHealing = event.maxHitPoints;

--- a/src/parser/shaman/restoration/modules/talents/EarthenWallTotem.js
+++ b/src/parser/shaman/restoration/modules/talents/EarthenWallTotem.js
@@ -8,7 +8,7 @@ import { formatNumber, formatPercentage, formatDuration } from 'common/format';
 import Analyzer, { SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';
 
-import AbilityTracker from 'parser/shared/modules/AbilityTracker';
+import Combatants from 'parser/shared/modules/Combatants';
 
 import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
@@ -19,7 +19,7 @@ const MAGHAR_ORC_PET_HEALTH_INCREASE = 0.1;
 
 class EarthenWallTotem extends Analyzer {
   static dependencies = {
-    abilityTracker: AbilityTracker,
+    combatants: Combatants,
   };
 
   earthenWallTotems = [];
@@ -69,6 +69,11 @@ class EarthenWallTotem extends Analyzer {
   }
 
   _onAbsorbed(event) {
+    // Filtering out pets as healing on them is pointless, sadly
+    const combatant = this.combatants.players[event.targetID];
+    if (!combatant) {
+      return;
+    }
     this.earthenWallTotems[this.castNumber].effectiveHealing += event.amount;
   }
 
@@ -107,7 +112,8 @@ class EarthenWallTotem extends Analyzer {
         position={STATISTIC_ORDER.OPTIONAL(60)}
         label={"Earthen Wall Totem efficiency"}
         tooltip={`The percentage of the potential absorb of Earthen Wall Totem that was actually used. You cast a total of ${casts} Earthen Wall Totems with a combined health of ${formatNumber(this.totalPotentialHealing)}, which absorbed a total of ${formatNumber(this.totalEffectiveHealing)} damage.<br/><br/>
-        This can be higher than 100% because it sometimes absorbs a few more damage hits before the totem realizes it is supposed to be dead already.`}
+        This can be higher than 100% because it sometimes absorbs a few more damage hits before the totem realizes it is supposed to be dead already.<br/><br/>
+        <b>Pet healing is filtered out.</b>`}
       >
         <table className="table table-condensed">
           <thead>
@@ -141,6 +147,7 @@ class EarthenWallTotem extends Analyzer {
       <StatisticListBoxItem
         title={<SpellLink id={SPELLS.EARTHEN_WALL_TOTEM_TALENT.id} />}
         value={`${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.totalEffectiveHealing))} %`}
+        valueTooltip="Pet healing is filtered out"
       />
     );
   }


### PR DESCRIPTION
Enables the module to show efficiency on a cast-by-cast basis.

Before:
![image](https://user-images.githubusercontent.com/2842471/48326571-526a7400-e63a-11e8-81ea-811e4204f520.png)
After:
![image](https://user-images.githubusercontent.com/2842471/48327376-a11a0d00-e63e-11e8-9b0b-23897b834016.png)


Update: Changed it to use absorbed damage instead of damage taken as effective healing, as they can differ. The totem processes damage events in batches, so you can actually get more healing out of it than what should be possible. Earthen Wall applies shields to everyone around it, that are replenished / reapplied instantaneously - every time a shield absorbs any damage, the totem damages itself for the same amount. The combination of raid-wide damage, the raid being stacked near the totem and the totem batching events together, you can get what's shown below:

![image](https://user-images.githubusercontent.com/2842471/48327968-015e7e00-e642-11e8-917c-a0dd6d8f7e47.png)
![image](https://user-images.githubusercontent.com/2842471/48328510-96fb0d00-e644-11e8-8eb8-d2d2c40373a2.png)
(it dies midway through processing the damage events, following are just a bunch of buff removals until the next cast)
