### PR TITLE
[Restoration Shaman] Disable Ancestral Vigor when there are multiple players with that talent

### DIFF
--- a/src/parser/shaman/restoration/modules/talents/AncestralVigor.js
+++ b/src/parser/shaman/restoration/modules/talents/AncestralVigor.js
@@ -8,6 +8,7 @@ import Icon from 'common/Icon';
 import { formatDuration, formatPercentage } from 'common/format';
 import SPECS from 'game/SPECS';
 
+import StatisticBox from 'interface/others/StatisticBox';
 import LazyLoadStatisticBox, { STATISTIC_ORDER } from 'interface/others/LazyLoadStatisticBox';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 
@@ -23,9 +24,18 @@ class AncestralVigor extends Analyzer {
   };
   loaded = false;
   lifeSavingEvents = [];
+  disableStatistics = false;
   constructor(...args) {
     super(...args);
     this.active = !!this.selectedCombatant.hasTalent(SPELLS.ANCESTRAL_VIGOR_TALENT.id);
+    if (!this.active) {
+      return;
+    }
+
+    const restoShamans = Object.values(this.combatants.players).filter(combatant => (combatant._combatantInfo.specID === SPECS.RESTORATION_SHAMAN.id) && (combatant !== this.selectedCombatant));
+    if (restoShamans && restoShamans.some(shaman => shaman.hasTalent(SPELLS.ANCESTRAL_VIGOR_TALENT.id))) {
+      this.disableStatistics = true;
+    }
   }
 
   // recursively fetch events until no nextPageTimestamp is returned
@@ -71,55 +81,68 @@ class AncestralVigor extends Analyzer {
     const tooltip = this.loaded
       ? 'The amount of players that would have died without your Ancestral Vigor buff.'
       : 'Click to analyze how many lives were saved by the ancestral vigor buff.';
-    return (
-      <LazyLoadStatisticBox
-        loader={this.load.bind(this)}
-        icon={<SpellIcon id={SPELLS.ANCESTRAL_VIGOR.id} />}
-        value={`≈${this.lifeSavingEvents.length}`}
-        label="Lives saved"
-        tooltip={tooltip}
-        category={STATISTIC_CATEGORY.TALENTS}
-        position={STATISTIC_ORDER.OPTIONAL(60)}
-      >
-        <table className="table table-condensed" style={{ fontWeight: 'bold' }}>
-          <thead>
-            <tr>
-              <th>Time</th>
-              <th>Player</th>
-              <th style={{ textAlign: 'center' }}>Ability</th>
-              <th>Health</th>
-            </tr>
-          </thead>
-          <tbody>
-            {
-              this.lifeSavingEvents
-                .map((event, index) => {
-                  const combatant = this.combatants.players[event.targetID];
-                  if (!combatant) {
-                    return null; // pet or something
+    if (this.disableStatistics) {
+      return (
+        <StatisticBox
+          icon={<SpellIcon id={SPELLS.ANCESTRAL_VIGOR.id} />}
+          label="Lives saved"
+          value="Module disabled"
+          tooltip="There were multiple Restoration Shamans with Ancestral Vigor in your raid group, this causes major issues with buff tracking. As the results from this module would be very inaccurate, it was disabled."
+          category={STATISTIC_CATEGORY.TALENTS}
+          position={STATISTIC_ORDER.OPTIONAL(60)}
+        />
+      );
+    } else {
+      return (
+        <LazyLoadStatisticBox
+          loader={this.load.bind(this)}
+          icon={<SpellIcon id={SPELLS.ANCESTRAL_VIGOR.id} />}
+          value={`≈${this.lifeSavingEvents.length}`}
+          label="Lives saved"
+          tooltip={tooltip}
+          category={STATISTIC_CATEGORY.TALENTS}
+          position={STATISTIC_ORDER.OPTIONAL(60)}
+        >
+          <table className="table table-condensed" style={{ fontWeight: 'bold' }}>
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Player</th>
+                <th style={{ textAlign: 'center' }}>Ability</th>
+                <th>Health</th>
+              </tr>
+            </thead>
+            <tbody>
+              {
+                this.lifeSavingEvents
+                  .map((event, index) => {
+                    const combatant = this.combatants.players[event.targetID];
+                    if (!combatant) {
+                      return null; // pet or something
+                    }
+
+                    const spec = SPECS[combatant.specId];
+                    const specClassName = spec.className.replace(' ', '');
+
+                    return (
+                      <tr key={index}>
+                        <th scope="row">{formatDuration((event.timestamp - this.owner.fight.start_time) / 1000, 0)}</th>
+                        <td className={specClassName}>{combatant.name}</td>
+                        <td style={{ textAlign: 'center' }}>
+                          <SpellLink id={event.ability.guid} icon={false}>
+                            <Icon icon={event.ability.abilityIcon} />
+                          </SpellLink></td>
+                        <td>{formatPercentage(event.hitPoints / event.maxHitPoints)}%</td>
+                      </tr>
+                    );
                   }
-
-                  const spec = SPECS[combatant.specId];
-                  const specClassName = spec.className.replace(' ', '');
-
-                  return (
-                    <tr key={index}>
-                      <th scope="row">{formatDuration((event.timestamp - this.owner.fight.start_time) / 1000, 0)}</th>
-                      <td className={specClassName}>{combatant.name}</td>
-                      <td style={{ textAlign: 'center' }}>
-                        <SpellLink id={event.ability.guid} icon={false}>
-                          <Icon icon={event.ability.abilityIcon} />
-                        </SpellLink></td>
-                      <td>{formatPercentage(event.hitPoints / event.maxHitPoints)}%</td>
-                    </tr>
-                  );
-                }
-                )
-            }
-          </tbody>
-        </table>
-      </LazyLoadStatisticBox>
-    );
+                  )
+              }
+            </tbody>
+          </table>
+        </LazyLoadStatisticBox>
+      );
+    }
   }
 }
 


### PR DESCRIPTION
As I already, extensively complained about a few weeks ago in the discord, multiple Resto Shamans with the https://www.wowhead.com/spell=207401/ancestral-vigor talent cause interesting issues. The buff is shared between all of them, everyone can extend each others buffs and this confuses both warcraftlogs and wowanalyzer. 
Queries to warcraftlogs will return seemingly random results of people who didn't even have the buff active at all, and wowanalyzer seeing random refreshbuffs without it ever being applied, assumes that those buffs were active before the pull even started (or: someone else refreshes your buff and you never get an removebuff event, so it assumes the buff ran until the end of combat).

Example of that behavior: 
![image](https://user-images.githubusercontent.com/2842471/48333132-99666280-e656-11e8-8db1-89d763cc432a.png)
https://www.warcraftlogs.com/reports/4gVcahLRzQXtnCAZ/#fight=49&source=11

From the view of the druid:
![image](https://user-images.githubusercontent.com/2842471/48333548-26f68200-e658-11e8-8034-ada64e9ea94d.png)
In that image, at `5:11.100` player A applies his buff (it is supposed to last 10 seconds).
At `5:17.158` player O applies it as well, creating a removebuff and applybuff as you can only have one active at a time.
But at `5:26.663` player A applies the buff again aaand... creates a refreshbuff. Even though player O removed player A's buff and applied his own, and the 10 second buff duration would be long over, the combatlogs still believe that the currently active buff belongs to player A.

The only realistic way I'm currently thinking of that would fix this, is manually tracking the buff and querying warcraftlogs for timestamps instead of the current query. I might look into that more, but for now I'm simply disabling the module as accuracy cannot be guaranteed with multiple Resto Shamans.
![image](https://user-images.githubusercontent.com/2842471/48333674-953b4480-e658-11e8-9d1f-f13ba299f0c0.png)

fixes #2630 