### PR TITLE
[Warlock] Added buffSpellIds to Abilities

### DIFF
--- a/src/parser/warlock/affliction/CHANGELOG.js
+++ b/src/parser/warlock/affliction/CHANGELOG.js
@@ -6,6 +6,11 @@ import SPELLS from 'common/SPELLS';
 
 export default [
   {
+    date: new Date('2018-11-12'),
+    changes: 'Certain buffs or debuffs now show in timeline.',
+    contributors: [Chizu],
+  },
+  {
     date: new Date('2018-10-15'),
     changes: <>Added <SpellLink id={SPELLS.VILE_TAINT_TALENT.id} />, <SpellLink id={SPELLS.GRIMOIRE_OF_SACRIFICE_TALENT.id} /> and <SpellLink id={SPELLS.SHADOW_EMBRACE_TALENT.id} /> modules.</>,
     contributors: [Chizu],

--- a/src/parser/warlock/affliction/modules/features/Abilities.js
+++ b/src/parser/warlock/affliction/modules/features/Abilities.js
@@ -42,6 +42,7 @@ class Abilities extends CoreAbilities {
           // TODO: possibly implement Haunt resets via SpellUsable?
           extraSuggestion: 'This estimate may not be correct sometimes because of Haunt\'s resets. The real amount of possible Haunts will be higher if there were adds on this fight.',
         },
+        buffSpellId: SPELLS.HAUNT_TALENT.id,
       },
       {
         spell: SPELLS.AGONY,
@@ -49,6 +50,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        buffSpellId: SPELLS.AGONY.id,
       },
       {
         spell: SPELLS.CORRUPTION_CAST,
@@ -56,6 +58,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        buffSpellId: SPELLS.CORRUPTION_DEBUFF.id,
       },
       {
         spell: SPELLS.SIPHON_LIFE_TALENT,
@@ -64,6 +67,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        buffSpellId: SPELLS.SIPHON_LIFE_TALENT.id,
       },
       {
         spell: SPELLS.SHADOW_BOLT_AFFLI,
@@ -92,6 +96,7 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: false,
         },
+        buffSpellId: SPELLS.PHANTOM_SINGULARITY_TALENT.id,
       },
       {
         spell: SPELLS.SEED_OF_CORRUPTION_DEBUFF,
@@ -111,6 +116,7 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: false,
         },
+        buffSpellId: SPELLS.VILE_TAINT_TALENT.id,
       },
 
       // Cooldowns
@@ -138,6 +144,7 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: 0.9,
         },
+        buffSpellId: SPELLS.DARK_SOUL_MISERY_TALENT.id,
       },
 
       // Defensive
@@ -168,6 +175,7 @@ class Abilities extends CoreAbilities {
           averageIssueEfficiency: 0.20,
           majorIssueEfficiency: 0.10,
         },
+        buffSpellId: SPELLS.DARK_PACT_TALENT.id,
       },
 
       // Utility
@@ -178,6 +186,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        buffSpellId: SPELLS.BURNING_RUSH_TALENT.id,
       },
       {
         spell: SPELLS.DRAIN_LIFE,

--- a/src/parser/warlock/demonology/CHANGELOG.js
+++ b/src/parser/warlock/demonology/CHANGELOG.js
@@ -4,6 +4,11 @@ import { Chizu, Hordehobbs } from 'CONTRIBUTORS';
 
 export default [
   {
+    date: new Date('2018-11-12'),
+    changes: 'Certain buffs or debuffs now show in timeline.',
+    contributors: [Chizu],
+  },
+  {
     date: new Date('2018-09-21'),
     changes: 'Removed all legendaries and tier set modules.',
     contributors: [Chizu],

--- a/src/parser/warlock/demonology/modules/features/Abilities.js
+++ b/src/parser/warlock/demonology/modules/features/Abilities.js
@@ -67,6 +67,7 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         enabled: combatant.hasTalent(SPELLS.DOOM_TALENT.id),
+        buffSpellId: SPELLS.DOOM_TALENT.id,
       },
       {
         spell: SPELLS.SHADOW_BOLT_DEMO,
@@ -198,6 +199,7 @@ class Abilities extends CoreAbilities {
           averageIssueEfficiency: 0.20,
           majorIssueEfficiency: 0.10,
         },
+        buffSpellId: SPELLS.DARK_PACT_TALENT.id,
       },
 
       // Utility
@@ -208,6 +210,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        buffSpellId: SPELLS.BURNING_RUSH_TALENT.id,
       },
       {
         spell: SPELLS.DRAIN_LIFE,

--- a/src/parser/warlock/destruction/CHANGELOG.js
+++ b/src/parser/warlock/destruction/CHANGELOG.js
@@ -7,6 +7,11 @@ import SPELLS from 'common/SPELLS';
 
 export default [
   {
+    date: new Date('2018-11-12'),
+    changes: 'Certain buffs or debuffs now show in timeline.',
+    contributors: [Chizu],
+  },
+  {
     date: new Date('2018-11-04'),
     changes: <>Added <SpellLink id={SPELLS.GRIMOIRE_OF_SACRIFICE_TALENT.id} /> module, damage estimate to <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /> and moved <SpellLink id={SPELLS.ERADICATION_TALENT.id} /> to the rest of the talents.</>,
     contributors: [Chizu],

--- a/src/parser/warlock/destruction/modules/features/Abilities.js
+++ b/src/parser/warlock/destruction/modules/features/Abilities.js
@@ -64,6 +64,7 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: 0.9,
         },
+        buffSpellId: SPELLS.SHADOWBURN_TALENT.id,
       },
       {
         spell: SPELLS.IMMOLATE,
@@ -71,6 +72,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        buffSpellId: SPELLS.IMMOLATE_DEBUFF.id,
       },
       {
         spell: SPELLS.INCINERATE,
@@ -89,6 +91,7 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: false,
         },
+        buffSpellId: SPELLS.HAVOC.id,
       },
       {
         spell: SPELLS.RAIN_OF_FIRE_CAST,
@@ -128,6 +131,7 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: 0.9,
         },
+        buffSpellId: SPELLS.DARK_SOUL_INSTABILITY_TALENT.id,
       },
 
       // Defensive
@@ -158,6 +162,7 @@ class Abilities extends CoreAbilities {
           averageIssueEfficiency: 0.20,
           majorIssueEfficiency: 0.10,
         },
+        buffSpellId: SPELLS.DARK_PACT_TALENT.id,
       },
 
       // Utility
@@ -168,6 +173,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        buffSpellId: SPELLS.BURNING_RUSH_TALENT.id,
       },
       {
         spell: SPELLS.DRAIN_LIFE,


### PR DESCRIPTION
Demonology's Nether Portal is missing, but to avoid merge conflicts (it's missing the spell in SPELLS in this branch), I'll add it in #2644 