### PR TITLE
[Subtlety Rogue] Add Inevitability module

### DIFF
--- a/src/common/SPELLS/bfa/azeritetraits/rogue.js
+++ b/src/common/SPELLS/bfa/azeritetraits/rogue.js
@@ -1,14 +1,17 @@
 export default {
-  SHARPENED_BLADES: {
+  // Shared
+  SHARPENED_BLADES: { // Assassination and Subtlety
     id: 272911,
     name: 'Sharpened Blades',
     icon: 'inv_throwingknife_07',
   },
-  SHARPENED_BLADES_BUFF: {
+  SHARPENED_BLADES_BUFF: { // Assassination and Subtlety
     id: 272916,
     name: 'Sharpened Blades',
     icon: 'inv_throwingknife_07',
   },
+
+  // Assassination
   SHROUDED_SUFFOCATION: {
     id: 279703,
     name: 'Shrouded Suffocation',
@@ -18,5 +21,14 @@ export default {
     id: 273009,
     name: 'Double Dose',
     icon: 'ability_rogue_shadowstrikes',
+  },
+
+  // Outlaw
+
+  // Subtlety
+  INEVITABILITY: {
+    id: 278683,
+    name: 'Inevitability',
+    icon: 'spell_shadow_rune',
   },
 };

--- a/src/parser/rogue/subtlety/CHANGELOG.js
+++ b/src/parser/rogue/subtlety/CHANGELOG.js
@@ -7,6 +7,11 @@ import { Zerotorescue, tsabo, Gebuz, Aelexe } from 'CONTRIBUTORS';
 
 export default [
   {
+    date: new Date('2018-11-13'),
+    changes: <>Added <SpellLink id={SPELLS.INEVITABILITY.id} /> module.</>,
+    contributors: [Aelexe],
+  },
+  {
     date: new Date('2018-11-11'),
     changes: <>Added suggestion for <SpellLink id={SPELLS.SHARPENED_BLADES.id} /> stack wastage.</>,
     contributors: [Aelexe],

--- a/src/parser/rogue/subtlety/CombatLogParser.js
+++ b/src/parser/rogue/subtlety/CombatLogParser.js
@@ -30,6 +30,7 @@ import FindWeakness from "./modules/talents/FindWeakness";
 
 import DarkShadowSpecterOfBetrayal from './modules/talents/DarkShadow/DarkShadowSpecterOfBetrayal';
 
+import Inevitability from './modules/azeritetraits/Inevitability';
 import SharpenedBlades from '../shared/azeritetraits/SharpenedBlades';
 
 class CombatLogParser extends CoreCombatLogParser {
@@ -75,7 +76,8 @@ class CombatLogParser extends CoreCombatLogParser {
     findWeakness: FindWeakness,
 
     // Traits
-    SharpenedBlades: SharpenedBlades,
+    inevitability: Inevitability,
+    sharpenedBlades: SharpenedBlades,
   };
 }
 

--- a/src/parser/rogue/subtlety/modules/azeritetraits/Inevitability.js
+++ b/src/parser/rogue/subtlety/modules/azeritetraits/Inevitability.js
@@ -1,0 +1,119 @@
+import React from 'react';
+import TraitStatisticBox, { STATISTIC_ORDER } from 'interface/others/TraitStatisticBox';
+
+import { formatNumber, formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS/index';
+
+import Analyzer from 'parser/core/Analyzer';
+
+const SYMBOLS_BASE_DURATION = 10 * 1000;
+const INEVITABILITY_DURATION_INCREASE = 0.5 * 1000;
+
+/**
+ * Backstab and Shadowstrike deal an additional X damage and extend the duration of your Symbols of Death by 0.5 sec.
+ */
+class Inevitability extends Analyzer {
+
+	/**
+	 * Timestamp of the most recent Symbols of Death cast.
+	 */
+	lastSymbolsCastTime = 0;
+
+	/**
+	 * The duration by which the most recent Symbols of Death was extended in milliseconds.
+	 */
+	lastSymbolsExtension = 0;
+
+	/**
+	 * The duration by which Symbols of Death was extended in milliseconds.
+	 */
+	symbolsExtendedDuration = 0;
+
+	/**
+	 * The damage dealt during Symbols of Death's extended duration.
+	 */
+	symbolsExtendedDamage = 0;
+
+  constructor(...args) {
+    super(...args);
+		this.active = this.selectedCombatant.hasTrait(SPELLS.INEVITABILITY.id);
+  }
+
+  on_byPlayer_cast(event) {
+		const spellId = event.ability.guid;
+		
+		if (spellId === SPELLS.SYMBOLS_OF_DEATH.id) {
+			this.lastSymbolsCastTime = event.timestamp;
+			this.lastSymbolsExtension = 0;
+		} else if ((spellId === SPELLS.BACKSTAB.id || spellId === SPELLS.SHADOWSTRIKE.id) && this.selectedCombatant.hasBuff(SPELLS.SYMBOLS_OF_DEATH.id)) {
+			this.symbolsExtendedDuration += INEVITABILITY_DURATION_INCREASE;
+			this.lastSymbolsExtension += INEVITABILITY_DURATION_INCREASE;
+		}
+	}
+
+	on_byPlayer_damage(event) {
+		// Total damage during Symbols of Death, after the base duration has passed.
+		if (!this.selectedCombatant.hasBuff(SPELLS.SYMBOLS_OF_DEATH.id) || event.timestamp <= this.lastSymbolsCastTime + SYMBOLS_BASE_DURATION) {
+			return;
+		}
+
+		this.symbolsExtendedDamage += event.amount + event.absorbed;
+	}
+
+	on_finished(event) {
+		// If Symbols of Death is active at the end of the fight, reduce the extended duration by the amount extended past the end of the fight.
+		const lastSymbolsEndTimestamp = this.lastSymbolsCastTime + SYMBOLS_BASE_DURATION + this.lastSymbolsExtension;
+		if(lastSymbolsEndTimestamp > event.timestamp) {
+			// Limit the adjustment to the extended amount.
+			const extensionAdjustment = Math.min(lastSymbolsEndTimestamp - event.timestamp, this.lastSymbolsExtension);
+			this.symbolsExtendedDuration -= extensionAdjustment;
+		}
+	}
+
+	/**
+	 * Returns Symbols of Death uptime in milliseconds.
+	 * @returns {number}
+	 */
+	get symbolsUptime() {
+		return this.selectedCombatant.getBuffUptime(SPELLS.SYMBOLS_OF_DEATH.id) / this.owner.fightDuration;
+	}
+
+	/**
+	 * Returns the extended duration of Symbols of Death as a percentage of the base duration.
+	 * @returns {number}
+	 */
+	get symbolsExtendedPercent() {
+		const symbolsBaseDuration = this.selectedCombatant.getBuffUptime(SPELLS.SYMBOLS_OF_DEATH.id) - this.symbolsExtendedDuration;
+
+		return this.symbolsExtendedDuration / symbolsBaseDuration;
+	}
+
+	/**
+	 * Returns the damage dealt during the extended Symbols of Death as a percentage of total damage dealt.
+	 * @returns {number}
+	 */
+	get symbolsExtendedDamagePercent() {
+		return this.owner.getPercentageOfTotalDamageDone(this.symbolsExtendedDamage);
+	}
+	
+	/**
+	 * Returns the damage dealt during the extended Symbols of Death divided by the fight duration.
+	 * @returns {number}
+	 */
+	get symbolsExtendedDps() {
+		return this.symbolsExtendedDamage / this.owner.fightDuration * 1000;
+	}
+
+	statistic() {
+    return (
+      <TraitStatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
+        trait={SPELLS.INEVITABILITY.id}
+        value={`${formatPercentage(this.symbolsExtendedDamagePercent)} % / ${formatNumber(this.symbolsExtendedDps)} DPS`}
+        tooltip={`Symbols of Death was extended by <b>${(this.symbolsExtendedDuration / 1000).toFixed(1)} seconds</b>, increasing Symbols of Death's uptime by <b>${formatPercentage(this.symbolsExtendedPercent)}%</b>.`}
+      />
+    );
+  }
+}
+
+export default Inevitability;


### PR DESCRIPTION
Adds a stat block for Inevitability, displaying the damage and duration contributed.

The damage is calculated specifically for the extended duration instead of as a percentage of the whole duration, as damage is weighted towards the start of the duration, meaning not doing so would inflate the value of this trait.

The module does not currently take into account the flat damage added to Backstab and Shadowstrike, but that contributes a fairly minor part to the overall value of this trait.

![image](https://user-images.githubusercontent.com/2950145/48380444-a3fb2780-e73c-11e8-887b-f06fa9c6c037.png)
