### PR TITLE
[Rogue] Fix Marked for Death cooldown tracking

### DIFF
--- a/src/parser/rogue/assassination/CHANGELOG.js
+++ b/src/parser/rogue/assassination/CHANGELOG.js
@@ -7,6 +7,11 @@ import { tsabo, Cloake, Zerotorescue, Gebuz, Aelexe } from 'CONTRIBUTORS';
 
 export default [
   {
+    date: new Date('2018-11-13'),
+    changes: <>Fixed cooldown tracking for <SpellLink id={SPELLS.MARKED_FOR_DEATH_TALENT.id} /> when targets die with the debuff.</>,
+    contributors: [Aelexe],
+  },
+  {
     date: new Date('2018-11-09'),
     changes: <>Added <SpellLink id={SPELLS.POISON_BOMB_TALENT.id} /> module and updated <SpellLink id={SPELLS.ELABORATE_PLANNING_TALENT.id} /> and <SpellLink id={SPELLS.BLINDSIDE_TALENT.id} /> modules.</>,
     contributors: [Gebuz],

--- a/src/parser/rogue/assassination/CombatLogParser.js
+++ b/src/parser/rogue/assassination/CombatLogParser.js
@@ -5,6 +5,7 @@ import Abilities from './modules/Abilities';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
 import Checklist from './modules/features/Checklist/Module';
+import SpellUsable from '../shared/SpellUsable';
 
 import ComboPointDetails from '../shared/resources/ComboPointDetails';
 import ComboPointTracker from '../shared/resources/ComboPointTracker';
@@ -39,6 +40,7 @@ class CombatLogParser extends CoreCombatLogParser {
     alwaysBeCasting: AlwaysBeCasting,
     cooldownThroughputTracker: CooldownThroughputTracker,
     checklist: Checklist,
+    spellUsable: SpellUsable,
 
     //Resource
     comboPointTracker: ComboPointTracker,

--- a/src/parser/rogue/outlaw/CHANGELOG.js
+++ b/src/parser/rogue/outlaw/CHANGELOG.js
@@ -1,6 +1,16 @@
-import { tsabo, Zerotorescue, Gebuz } from 'CONTRIBUTORS';
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+
+import { tsabo, Zerotorescue, Gebuz, Aelexe } from 'CONTRIBUTORS';
 
 export default [
+  {
+    date: new Date('2018-11-13'),
+    changes: <>Fixed cooldown tracking for <SpellLink id={SPELLS.MARKED_FOR_DEATH_TALENT.id} /> when targets die with the debuff.</>,
+    contributors: [Aelexe],
+  },
   {
     date: new Date('2018-11-05'),
     changes: 'Updated resource tracking to display percent instead of per minute, and added spenders to the energy tab.',

--- a/src/parser/rogue/outlaw/CombatLogParser.js
+++ b/src/parser/rogue/outlaw/CombatLogParser.js
@@ -4,6 +4,7 @@ import ArcaneTorrent from 'parser/shared/modules/racials/bloodelf/ArcaneTorrent'
 
 import Abilities from './modules/Abilities';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
+import SpellUsable from '../shared/SpellUsable';
 
 import ComboPointDetails from '../shared/resources/ComboPointDetails';
 import ComboPointTracker from '../shared/resources/ComboPointTracker';
@@ -23,6 +24,7 @@ class CombatLogParser extends CoreCombatLogParser {
     damageDone: [DamageDone, { showStatistic: true }],
     abilities: Abilities,
     alwaysBeCasting: AlwaysBeCasting,
+    spellUsable: SpellUsable,
 
     //Resource
     comboPointTracker: ComboPointTracker,

--- a/src/parser/rogue/shared/SpellUsable.js
+++ b/src/parser/rogue/shared/SpellUsable.js
@@ -1,0 +1,46 @@
+import SPELLS from 'common/SPELLS';
+
+import CoreSpellUsable from 'parser/shared/modules/SpellUsable';
+import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
+
+const MARK_FOR_DEATH_DURATION = 60 * 1000;
+
+class SpellUsable extends CoreSpellUsable {
+
+  /**
+	 * A map of target strings to the timestamp of when Marked for Death was cast on them.
+	 */
+	markMap = {};
+
+  on_byPlayer_cast(event) {
+    if (super.on_byPlayer_cast) {
+      super.on_byPlayer_cast(event);
+    }
+
+		if (!event.ability.guid === SPELLS.MARKED_FOR_DEATH_TALENT.id) {
+			return;
+		}
+
+		const targetString = encodeTargetString(event.targetID, event.targetInstance);
+		this.markMap[targetString] = event.timestamp;
+	}
+
+  on_byPlayer_removedebuff(event) {
+    if (super.on_byPlayer_removedebuff) {
+      super.on_byPlayer_removedebuff(event);
+    }
+
+    if (event.ability.guid !== SPELLS.MARKED_FOR_DEATH_TALENT.id || !this.isOnCooldown(SPELLS.MARKED_FOR_DEATH_TALENT.id)) {
+			return;
+		}
+
+		const targetString = encodeTargetString(event.targetID, event.targetInstance);
+
+		// Only refresh cooldown if the target died, which is not the case if the debuff is removed at the end of its duration.
+		if(event.timestamp - this.markMap[targetString] < MARK_FOR_DEATH_DURATION) {
+			this.endCooldown(SPELLS.MARKED_FOR_DEATH_TALENT.id);
+		}
+	}
+}
+
+export default SpellUsable;

--- a/src/parser/rogue/subtlety/CHANGELOG.js
+++ b/src/parser/rogue/subtlety/CHANGELOG.js
@@ -7,6 +7,11 @@ import { Zerotorescue, tsabo, Gebuz, Aelexe } from 'CONTRIBUTORS';
 
 export default [
   {
+    date: new Date('2018-11-13'),
+    changes: <>Fixed cooldown tracking for <SpellLink id={SPELLS.MARKED_FOR_DEATH_TALENT.id} /> when targets die with the debuff.</>,
+    contributors: [Aelexe],
+  },
+  {
     date: new Date('2018-11-11'),
     changes: <>Added suggestion for <SpellLink id={SPELLS.SHARPENED_BLADES.id} /> stack wastage.</>,
     contributors: [Aelexe],

--- a/src/parser/rogue/subtlety/CombatLogParser.js
+++ b/src/parser/rogue/subtlety/CombatLogParser.js
@@ -4,6 +4,7 @@ import DamageDone from 'parser/shared/modules/DamageDone';
 import Abilities from './modules/Abilities';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import Checklist from './modules/features/checklist/Module';
+import SpellUsable from '../shared/SpellUsable';
 
 import ComboPointDetails from '../shared/resources/ComboPointDetails';
 import ComboPointTracker from '../shared/resources/ComboPointTracker';
@@ -39,6 +40,7 @@ class CombatLogParser extends CoreCombatLogParser {
     abilities: Abilities,
     checklist: Checklist,
     alwaysBeCasting: AlwaysBeCasting,
+    spellUsable: SpellUsable,
 
     //Resource
     comboPointTracker: ComboPointTracker,


### PR DESCRIPTION
Adds Marked for Death's cooldown reset on target death by tracking when the debuff expires before its full duration. This could cause a false positive in rare situations where a mob despawns without triggering a death event, but I'm not aware of any such cases in Uldir.

![image](https://user-images.githubusercontent.com/2950145/48388905-18938d80-e760-11e8-9b5d-3b1a55378b70.png)
