### PR TITLE
[General] Fixing timeline and downtime for bugged channel events

### DIFF
--- a/src/parser/shared/modules/AlwaysBeCasting.js
+++ b/src/parser/shared/modules/AlwaysBeCasting.js
@@ -47,6 +47,10 @@ class AlwaysBeCasting extends Analyzer {
     return true;
   }
   on_endchannel(event) {
+    // If you don't have a beginchannel event, the event will have the start of the fight as the beginchannel. This messes up a number of other modules.
+    if (!event.beginChannel){
+      return false;
+    }
     // If the channel was shorter than the GCD then use the GCD as active time
     let amount = event.duration;
     if (this.globalCooldown.isOnGlobalCooldown(event.ability.guid)) {

--- a/src/parser/shared/modules/Channeling.js
+++ b/src/parser/shared/modules/Channeling.js
@@ -85,7 +85,10 @@ class Channeling extends Analyzer {
   // TODO: Move this to SpellTimeline, it's only used for that so it should track it itself
   history = [];
   on_endchannel(event) {
-    this.history.push(event);
+    // If you don't have a beginchannel event, the event will have the start of the fight as the beginchannel. This messes up a number of other modules.
+    if (event.beginChannel){
+      this.history.push(event);
+    }
   }
 
   // TODO: Re-implement below


### PR DESCRIPTION
There is an issue with channeling events where some channeled events have no beginChannel event. Currently any such events will use the fight start time as the begin channel time. This leads to some interesting side effects in the spell timeline and the downtime module:

![screen shot 2018-11-13 at 8 14 36 am](https://user-images.githubusercontent.com/716498/48422582-33dca980-e71c-11e8-93f4-db3786996eb0.png)

This fix removes channeled events that have no beginChannel from the channeling history and from the downtime calculations. I've only seen one log that has a channel event with no beginChannel, so please look at a few logs to see if this breaks anything big.

This is the example log that began this hunt: https://wowanalyzer.com/report/qtLF1aNfZr92kcdG/9-Mythic+Zek'voz+-+Kill+(7:44)/21-Yath

It should be noted that the following warning will appear whenever this "fix" would occur:

`05:17.609 (module: Channeling) [Spell Name] 'endChannel' was called while we weren't channeling, assuming it was a pre-combat channel.`
