### PR TITLE
[Spriest] Fixing double firing of endChannel event

### DIFF
--- a/src/parser/priest/shadow/modules/core/Channeling.js
+++ b/src/parser/priest/shadow/modules/core/Channeling.js
@@ -24,7 +24,7 @@ class Channeling extends CoreChanneling {
   }
 
   cancelChannel(event, ability) {
-    if (this.isChannelingSpell(SPELLS.MIND_FLAY.id) || this.isChannelingSpell(SPELLS.VOID_TORRENT_TALENT.id)) {
+    if (this.isChannelingSpell(SPELLS.VOID_TORRENT_TALENT.id)) {
       // If a channeling spell is "canceled" it was actually just ended, so if it looks canceled then instead just mark it as ended
       this.log('Marking', this._currentChannel.ability.name, 'as ended since we started casting something else:', event.ability.name);
       this.endChannel(event);


### PR DESCRIPTION
Fixing issue that caused MindFlay to trigger the end channel event twice in a row under certain circumstances. Would cause the spell timeline to display a long mind flay channel time and would cause the downtime card to be funky:

![48422582-33dca980-e71c-11e8-93f4-db3786996eb0](https://user-images.githubusercontent.com/716498/48433838-634be000-e735-11e8-8e29-8753499f27bc.png)

Example broken log: https://wowanalyzer.com/report/qtLF1aNfZr92kcdG/9-Mythic+Zek'voz+-+Kill+(7:44)/21-Yath