### PR TITLE
[Core] adjust Zul, Mythrax and Zek'vos names

### DIFF
--- a/src/game/ZONES.js
+++ b/src/game/ZONES.js
@@ -27,7 +27,7 @@ const ZONES = [
       },
       {
         "id": 2136,
-        "name": "Zek'voz, Herald of N'zoth",
+        "name": "Zek'voz",
         "npcID": 134445
       },
       {
@@ -37,12 +37,12 @@ const ZONES = [
       },
       {
         "id": 2145,
-        "name": "Zul, Reborn",
+        "name": "Zul",
         "npcID": 138967
       },
       {
         "id": 2135,
-        "name": "Mythrax the Unraveler",
+        "name": "Mythrax",
         "npcID": 134546
       },
       {


### PR DESCRIPTION
Because Warcraftlogs doesn't include these 3 bosses titles, our raid filter can't find them. 

Example:
![image](https://user-images.githubusercontent.com/29204244/48440474-49d48380-e789-11e8-946b-c02f34e9adc2.png)


Fix:
![image](https://user-images.githubusercontent.com/29204244/48440497-53f68200-e789-11e8-9f63-59364b797ece.png)
