### PR TITLE
[Fire Mage] Hot Streak Redo

### DIFF
--- a/src/parser/mage/fire/CHANGELOG.js
+++ b/src/parser/mage/fire/CHANGELOG.js
@@ -4,6 +4,11 @@ import { Sharrq } from 'CONTRIBUTORS';
 
 export default [
   {
+    date: new Date('2018-11-14'),
+    changes: 'Updated the Hot Streak module to fix some incorrect suggestions and make things easier to understand.',
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2018-10-11'),
     changes: 'Fixed bug that caused Suggestions to crash',
     contributors: [Sharrq],

--- a/src/parser/mage/fire/CombatLogParser.js
+++ b/src/parser/mage/fire/CombatLogParser.js
@@ -19,6 +19,8 @@ import ArcaneIntellect from '../shared/modules/features/ArcaneIntellect';
 import RuneOfPower from '../shared/modules/features/RuneOfPower';
 import Kindling from './modules/features/Kindling';
 import HotStreak from './modules/features/HotStreak';
+import HotStreakPreCasts from './modules/features/HotStreakPreCasts';
+import HotStreakWastedCrits from './modules/features/HotStreakWastedCrits';
 import CombustionFirestarter from './modules/features/CombustionFirestarter';
 import CombustionCharges from './modules/features/CombustionCharges';
 import CombustionSpellUsage from './modules/features/CombustionSpellUsage';
@@ -45,6 +47,8 @@ class CombatLogParser extends CoreCombatLogParser {
     damageDone: [DamageDone, { showStatistic: true }],
     cancelledCasts: CancelledCasts,
     hotStreak: HotStreak,
+    hotStreakPreCasts: HotStreakPreCasts,
+    hotStreakWastedCrits: HotStreakWastedCrits,
     combustionFirestarter: CombustionFirestarter,
     combustionCharges: CombustionCharges,
     combustionSpellUsage: CombustionSpellUsage,

--- a/src/parser/mage/fire/modules/Checklist/Module.js
+++ b/src/parser/mage/fire/modules/Checklist/Module.js
@@ -11,6 +11,8 @@ import CombustionPyroclasm from '../features/CombustionPyroclasm';
 import CombustionSpellUsage from '../features/CombustionSpellUsage';
 import HeatingUp from '../features/HeatingUp';
 import HotStreak from '../features/HotStreak';
+import HotStreakWastedCrits from '../features/HotStreakWastedCrits';
+import HotStreakPreCasts from '../features/HotStreakPreCasts';
 import Pyroclasm from '../features/Pyroclasm';
 import SearingTouch from '../features/SearingTouch';
 import AlwaysBeCasting from '../features/AlwaysBeCasting';
@@ -29,6 +31,8 @@ class Checklist extends Analyzer {
     combustionSpellUsage: CombustionSpellUsage,
     heatingUp: HeatingUp,
     hotStreak: HotStreak,
+    hotStreakWastedCrits: HotStreakWastedCrits,
+    hotStreakPreCasts: HotStreakPreCasts,
     pyroclasm: Pyroclasm,
     searingTouch: SearingTouch,
     castEfficiency: CastEfficiency,
@@ -56,8 +60,8 @@ class Checklist extends Analyzer {
           fireBlastHeatingUpUsage: this.heatingUp.fireBlastUtilSuggestionThresholds,
           phoenixFlamesHeatingUpUsage: this.heatingUp.phoenixFlamesUtilSuggestionThresholds,
           hotStreakUtilization: this.hotStreak.hotStreakUtilizationThresholds,
-          hotStreakWastedCrits: this.hotStreak.wastedCritsThresholds,
-          hotStreakPreCasts: this.hotStreak.castBeforeHotStreakThresholds,
+          hotStreakWastedCrits: this.hotStreakWastedCrits.wastedCritsThresholds,
+          hotStreakPreCasts: this.hotStreakPreCasts.castBeforeHotStreakThresholds,
           pyroclasmUtilization: this.pyroclasm.procUtilizationThresholds,
           searingTouchUtilization: this.searingTouch.suggestionThreshold,
           arcaneIntellectUptime: this.arcaneIntellect.suggestionThresholds,

--- a/src/parser/mage/fire/modules/features/HeatingUp.js
+++ b/src/parser/mage/fire/modules/features/HeatingUp.js
@@ -191,6 +191,7 @@ class HeatingUp extends Analyzer {
     } else {
       return (
         <StatisticBox
+          position={STATISTIC_ORDER.CORE(14)}
           icon={<SpellIcon id={SPELLS.HEATING_UP.id} />}
           value={`${formatPercentage(this.fireBlastUtil, 0)} %`}
           label="Heating Up Utilization"

--- a/src/parser/mage/fire/modules/features/HotStreak.js
+++ b/src/parser/mage/fire/modules/features/HotStreak.js
@@ -19,15 +19,14 @@ class HotStreak extends Analyzer {
 
   constructor(...args) {
     super(...args);
-    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.PYROBLAST), this.onPyroblastCast);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell([SPELLS.PYROBLAST,SPELLS.FLAMESTRIKE]), this.onHotStreakSpenderCast);
     this.addEventListener(Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.HOT_STREAK), this.onHotStreakApplied);
-    this.addEventListener(Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.HOT_STREAK), this.onHotStreakRemoved);
     this.addEventListener(Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.HOT_STREAK), this.checkForExpiredProcs);
 
   }
 
   //When Pyroblast is cast, get the timestamp. This is used for determining if pyroblast was cast immediately before Hot Streak was removed.
-  onPyroblastCast(event) {
+  onHotStreakSpenderCast(event) {
     this.castTimestamp = event.timestamp;
   }
 
@@ -36,10 +35,7 @@ class HotStreak extends Analyzer {
     this.totalHotStreakProcs += 1;
   }
 
-  onHotStreakRemoved(event) {
-    this.hotStreakRemoved = event.timestamp;
-  }
-
+  //Checks to see if there was a Hot Streak spender cast immediately before Hot Streak was removed. If there was not, then it must have expired.
   checkForExpiredProcs(event) {
     if (!this.castTimestamp || this.castTimestamp + PROC_WINDOW_MS < event.timestamp) {
       debug && this.log("Hot Streak proc expired");

--- a/src/parser/mage/fire/modules/features/HotStreak.js
+++ b/src/parser/mage/fire/modules/features/HotStreak.js
@@ -1,139 +1,62 @@
 import React from 'react';
-import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import SpellIcon from 'common/SpellIcon';
-import { formatPercentage, formatNumber } from 'common/format';
+import { formatPercentage } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
-import Analyzer from 'parser/core/Analyzer';
-import HIT_TYPES from 'game/HIT_TYPES';
-import EnemyInstances, { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
 
 const debug = false;
 
 const PROC_WINDOW_MS = 200;
 
-const HOT_STREAK_CONTRIBUTORS = [
-  SPELLS.FIREBALL.id,
-  SPELLS.PYROBLAST.id,
-  SPELLS.FIRE_BLAST.id,
-  SPELLS.SCORCH.id,
-  SPELLS.PHOENIX_FLAMES_TALENT.id,
-];
-
 class HotStreak extends Analyzer {
-  static dependencies = {
-    enemies: EnemyInstances,
-  };
 
-  totalProcs = 0;
-  wastedCrits = 0;
+  totalHotStreakProcs = 0;
   expiredProcs = 0;
-  pyroWithoutProc = 0;
-  lastCastTimestamp = 0;
-  buffAppliedTimestamp = 0;
   hotStreakRemoved = 0;
-  bracerProcRemoved = 0;
-  pyroclasmProcRemoved = 0;
-  castsIntoHotStreak = 0;
-  castedBeforeHotStreak = 0;
-  noCastBeforeHotStreak = 0;
-  pyromaniacProc = false;
-  currentHealth = 0;
-  maxHealth = 0;
-  targetId = 0;
 
-  on_byPlayer_cast(event) {
-    const spellId = event.ability.guid;
-    if (!HOT_STREAK_CONTRIBUTORS.includes(spellId) && spellId !== SPELLS.FLAMESTRIKE.id) {
-      return;
-    }
-    if (spellId === SPELLS.FIREBALL.id || spellId === SPELLS.SCORCH.id) {
-      this.castTimestamp = event.timestamp;
-    }
-    this.targetId = encodeTargetString(event.targetID, event.targetInstance);
-    this.lastCastTimestamp = this.owner.currentTimestamp;
-    this.pyromaniacProc = false;
+  constructor(...args) {
+    super(...args);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.PYROBLAST), this.onPyroblastCast);
+    this.addEventListener(Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.HOT_STREAK), this.onHotStreakApplied);
+    this.addEventListener(Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.HOT_STREAK), this.onHotStreakRemoved);
+    this.addEventListener(Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.HOT_STREAK), this.checkForExpiredProcs);
+
   }
 
-  on_byPlayer_damage(event) {
-    const spellId = event.ability.guid;
-    const damageTarget = encodeTargetString(event.targetID, event.targetInstance);
-    //If the player has Firestarter, get the target's health
-    if (this.selectedCombatant.hasTalent(SPELLS.FIRESTARTER_TALENT.id) && HOT_STREAK_CONTRIBUTORS.includes(spellId)) {
-      this.currentHealth = event.hitPoints;
-      this.maxHealth = event.maxHitPoints;
-    }
-    if (!HOT_STREAK_CONTRIBUTORS.includes(spellId) || !this.selectedCombatant.hasBuff(SPELLS.HOT_STREAK.id) || event.hitType !== HIT_TYPES.CRIT || (spellId === SPELLS.PHOENIX_FLAMES_TALENT.id && this.targetId !== damageTarget)) {
-      return;
-    }
-    //If Pyromaniac caused the player to immediately get a new hot streak after spending one, then dont count the damage crits that were cast before Pyromaniac Proc's since the user cant do anything to prevent this.
-    if ((spellId === SPELLS.FIREBALL.id || spellId === SPELLS.SCORCH.id || spellId === SPELLS.PYROBLAST.id) && this.pyromaniacProc) {
-      debug && this.log("Wasted Crit Ignored");
-    } else if (HOT_STREAK_CONTRIBUTORS.includes(spellId) && this.selectedCombatant.hasBuff(SPELLS.HOT_STREAK.id,null,-50)) {
-      this.wastedCrits += 1;
-      debug && this.log("Hot Streak overwritten");
-    }
+  //When Pyroblast is cast, get the timestamp. This is used for determining if pyroblast was cast immediately before Hot Streak was removed.
+  onPyroblastCast(event) {
+    this.castTimestamp = event.timestamp;
   }
 
-  on_toPlayer_applybuff(event) {
-    const spellId = event.ability.guid;
-    if (spellId !== SPELLS.HOT_STREAK.id) {
-      return;
-    }
-    //If Hot Streak is removed and re-applied within 100ms of eachother then Pyromaniac Proc'd and granted a new hot streak
-    if (this.selectedCombatant.hasTalent(SPELLS.PYROMANIAC_TALENT.id) && this.buffAppliedTimestamp - this.hotStreakRemoved < PROC_WINDOW_MS) {
-      this.pyromaniacProc = true;
-    }
-    this.totalProcs += 1;
+  //Count the number of times Hot Streak was applied
+  onHotStreakApplied() {
+    this.totalHotStreakProcs += 1;
   }
 
-  on_toPlayer_removebuff(event) {
-    const spellId = event.ability.guid;
-    if (spellId !== SPELLS.HOT_STREAK.id && spellId !== SPELLS.KAELTHAS_ULTIMATE_ABILITY.id) {
-      return;
-    }
-    if (spellId === SPELLS.HOT_STREAK.id) {
-      this.hotStreakRemoved = event.timestamp;
-    } else if (spellId === SPELLS.KAELTHAS_ULTIMATE_ABILITY.id) {
-      this.bracerProcRemoved = event.timestamp;
-      return;
-    } else if (spellId === SPELLS.PYROCLASM_BUFF.id) {
-      this.pyroclasmProcRemoved = event.timestamp;
-      return;
-    }
-    //Check for Expired Procs, also if Fireball or Scorch was cast at the same time that Hot Streak was removed, then it was cast alongside Hot Streak (For the cast before hot streak check). Excluded Hot Streak procs during Combustion.
-    //Also checks to see if the bracer proc or pyroclasm proc was removed within 100ms of Hot Streak getting removed (i.e. they hard casted Pyroblast for the bracer/pyroclasm proc and used Hot Streak on the end of it.)
-    //Also checks to see if the player has Firestarter or Combustion and if they have Firestarter, checks to see if the boss is less than 90% health
-    if (!this.lastCastTimestamp || this.lastCastTimestamp + PROC_WINDOW_MS < this.owner.currentTimestamp) {
-      this.expiredProcs += 1;
+  onHotStreakRemoved(event) {
+    this.hotStreakRemoved = event.timestamp;
+  }
+
+  checkForExpiredProcs(event) {
+    if (!this.castTimestamp || this.castTimestamp + PROC_WINDOW_MS < event.timestamp) {
       debug && this.log("Hot Streak proc expired");
-    } else if (this.hotStreakRemoved - PROC_WINDOW_MS < this.castTimestamp || this.hotStreakRemoved - PROC_WINDOW_MS < this.bracerProcRemoved || this.hotStreakRemoved - PROC_WINDOW_MS < this.pyroclasmProcRemoved) {
-      this.castedBeforeHotStreak += 1;
-    } else if (!this.selectedCombatant.hasBuff(SPELLS.COMBUSTION.id) && (!this.selectedCombatant.hasTalent(SPELLS.FIRESTARTER_TALENT.id) || (this.currentHealth / this.maxHealth) < 0.90)) {
-      this.noCastBeforeHotStreak += 1;
-      debug && this.log("No hard cast before Hot Streak");
+      this.expiredProcs += 1;
     }
   }
 
   get usedProcs() {
-    return this.totalProcs - this.expiredProcs;
+    return this.totalHotStreakProcs - this.expiredProcs;
   }
 
   get expiredProcsPercent() {
-    return (this.expiredProcs / this.totalProcs) || 0;
+    return (this.expiredProcs / this.totalHotStreakProcs) || 0;
   }
 
   get hotStreakUtil() {
-    return 1 - (this.expiredProcs / this.totalProcs) || 0;
-  }
-
-  get castBeforeHotStreakUtil() {
-    return 1 - (this.noCastBeforeHotStreak / (this.castedBeforeHotStreak + this.noCastBeforeHotStreak));
-  }
-
-  get wastedCritsPerMinute() {
-    return this.wastedCrits / (this.owner.fightDuration / 60000);
+    return 1 - (this.expiredProcs / this.totalHotStreakProcs) || 0;
   }
 
   get hotStreakUtilizationThresholds() {
@@ -148,30 +71,6 @@ class HotStreak extends Analyzer {
     };
   }
 
-  get wastedCritsThresholds() {
-    return {
-      actual: this.wastedCritsPerMinute,
-      isGreaterThan: {
-        minor: 0,
-        average: 1,
-        major: 3,
-      },
-      style: 'number',
-    };
-  }
-
-  get castBeforeHotStreakThresholds() {
-    return {
-      actual: this.castBeforeHotStreakUtil,
-      isLessThan: {
-        minor: .90,
-        average: .80,
-        major:.70,
-      },
-      style: 'percentage',
-    };
-  }
-
   suggestions(when) {
     when(this.hotStreakUtilizationThresholds)
       .addSuggestion((suggest, actual, recommended) => {
@@ -180,50 +79,21 @@ class HotStreak extends Analyzer {
           .actual(`${formatPercentage(this.hotStreakUtil)}% expired`)
           .recommended(`<${formatPercentage(recommended)}% is recommended`);
       });
-      when(this.wastedCritsThresholds)
-        .addSuggestion((suggest, actual, recommended) => {
-          return suggest(<>You crit with {formatNumber(this.wastedCrits)} ({formatNumber(this.wastedCritsPerMinute)} Per Minute) direct damage abilities while <SpellLink id={SPELLS.HOT_STREAK.id} /> was active. This is a waste since those crits could have contibuted towards your next Hot Streak. Try to use your procs as soon as possible to avoid this.</>)
-            .icon(SPELLS.HOT_STREAK.icon)
-            .actual(`${formatNumber(this.wastedCrits)} crits wasted`)
-            .recommended(`${formatNumber(recommended)} is recommended`);
-      });
-      when(this.castBeforeHotStreakThresholds)
-        .addSuggestion((suggest, actual, recommended) => {
-          return suggest(<>While <SpellLink id={SPELLS.COMBUSTION.id} /> was not active, you failed to <SpellLink id={SPELLS.FIREBALL.id} /> or <SpellLink id={SPELLS.SCORCH.id} /> just before using your <SpellLink id={SPELLS.HOT_STREAK.id} /> {this.noCastBeforeHotStreak} times ({formatPercentage(this.castBeforeHotStreakUtil)}%). Make sure you hard cast Fireball{this.selectedCombatant.hasWrists(ITEMS.MARQUEE_BINDINGS_OF_THE_SUN_KING.id) ? `, a hard casted Pyroblast (if you have a bracer proc), ` : ` `}or Scorch just before each instant <SpellLink id={SPELLS.PYROBLAST.id} /> to increase the odds of getting a <SpellLink id={SPELLS.HEATING_UP.id} /> or <SpellLink id={SPELLS.HOT_STREAK.id} /> proc. Additionally, it is also acceptable to use your <SpellLink id={SPELLS.HOT_STREAK.id} /> procs if you need to move.</>)
-            .icon(SPELLS.HOT_STREAK.icon)
-            .actual(`${formatPercentage(this.castBeforeHotStreakUtil)}% Utilization`)
-            .recommended(`${formatPercentage(recommended)}% is recommended`);
-      });
   }
 
   statistic() {
     return (
       <StatisticBox
-        position={STATISTIC_ORDER.CORE(12)}
+        position={STATISTIC_ORDER.CORE(15)}
         icon={<SpellIcon id={SPELLS.HOT_STREAK.id} />}
-        value={(
-          <span>
-            <SpellIcon
-              id={SPELLS.HOT_STREAK.id}
-              style={{
-                height: '1.2em',
-                marginBottom: '.15em',
-              }}
-            />
-            {' '}{formatPercentage(this.hotStreakUtil, 0)}{' %'}
-            <br />
-            <SpellIcon
-              id={SPELLS.PYROBLAST.id}
-              style={{
-                height: '1.2em',
-                marginBottom: '.15em',
-              }}
-            />
-            {' '}{formatPercentage(this.castBeforeHotStreakUtil, 0)}{' %'}
-          </span>
-        )}
-        label="Hot Streak Utilization"
-        tooltip={`Every Hot Streak should be preceded by Fireball${this.selectedCombatant.hasWrists(ITEMS.MARQUEE_BINDINGS_OF_THE_SUN_KING.id) ? `, a hard casted Pyroblast (if you have a bracer proc), ` : ` `}or Scorch to increase the chances of gaining a Heating Up or Hot Streak buff. The only time you should not be doing this is during Combustion or when you need to move. Additionally, ensure that you are using all of your Hot Streak Procs and not letting them expire`}
+        value={`${formatPercentage(this.hotStreakUtil, 0)} %`}
+        label="Hot Streak utilization"
+        tooltip={`Hot Streak is a big part of your rotation and therefore it is important that you use all the procs that you get and avoid letting them expire.
+        <ul>
+          <li>Total procs - ${this.totalHotStreakProcs}</li>
+          <li>Used procs - ${this.usedProcs}</li>
+          <li>Expired procs - ${this.expiredProcs}</li>
+        </ul>`}
       />
     );
   }

--- a/src/parser/mage/fire/modules/features/HotStreakPreCasts.js
+++ b/src/parser/mage/fire/modules/features/HotStreakPreCasts.js
@@ -37,7 +37,7 @@ class HotStreakPreCasts extends Analyzer {
     this.hasFirestarter = this.selectedCombatant.hasTalent(SPELLS.FIRESTARTER_TALENT.id);
     this.hasSearingTouch = this.selectedCombatant.hasTalent(SPELLS.SEARING_TOUCH_TALENT.id);
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.FIREBALL), this.getCastTimestamp);
-    if (this.hasFirestarter || this.hasSearingTouch) {HOT_STREAK_CONTRIBUTORS.map(spell => this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(spell), this.checkHealthPercent));}
+    if (this.hasFirestarter || this.hasSearingTouch) {this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(HOT_STREAK_CONTRIBUTORS), this.checkHealthPercent);}
     this.addEventListener(Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.HOT_STREAK), this.onHotStreakRemoved);
     this.addEventListener(Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.PYROCLASM_BUFF), this.onPyroclasmRemoved);
     this.addEventListener(Events.removebuffstack.to(SELECTED_PLAYER).spell(SPELLS.PYROCLASM_BUFF), this.onPyroclasmRemoved);

--- a/src/parser/mage/fire/modules/features/HotStreakPreCasts.js
+++ b/src/parser/mage/fire/modules/features/HotStreakPreCasts.js
@@ -33,6 +33,7 @@ class HotStreakPreCasts extends Analyzer {
 
   constructor(...args) {
     super(...args);
+    this.hasPyroclasm = this.selectedCombatant.hasTalent(SPELLS.PYROCLASM_TALENT.id);
     this.hasFirestarter = this.selectedCombatant.hasTalent(SPELLS.FIRESTARTER_TALENT.id);
     this.hasSearingTouch = this.selectedCombatant.hasTalent(SPELLS.SEARING_TOUCH_TALENT.id);
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.FIREBALL), this.getCastTimestamp);

--- a/src/parser/mage/fire/modules/features/HotStreakPreCasts.js
+++ b/src/parser/mage/fire/modules/features/HotStreakPreCasts.js
@@ -1,0 +1,128 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import SpellIcon from 'common/SpellIcon';
+import { formatPercentage } from 'common/format';
+import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+
+const debug = true;
+
+const PROC_WINDOW_MS = 200;
+const FIRESTARTER_HEALTH_THRESHOLD = 0.90;
+const SEARING_TOUCH_HEALTH_THRESHOLD = 0.30;
+
+const HOT_STREAK_CONTRIBUTORS = [
+  SPELLS.FIREBALL,
+  SPELLS.PYROBLAST,
+  SPELLS.FIRE_BLAST,
+  SPELLS.SCORCH,
+  SPELLS.PHOENIX_FLAMES_TALENT,
+];
+
+class HotStreakPreCasts extends Analyzer {
+
+  lastCastTimestamp = 0;
+  hotStreakRemoved = 0;
+  pyroclasmProcRemoved = 0;
+  castedBeforeHotStreak = 0;
+  noCastBeforeHotStreak = 0;
+  currentHealth = 0;
+  maxHealth = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.hasFirestarter = this.selectedCombatant.hasTalent(SPELLS.FIRESTARTER_TALENT.id);
+    this.hasSearingTouch = this.selectedCombatant.hasTalent(SPELLS.SEARING_TOUCH_TALENT.id);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.FIREBALL), this.getCastTimestamp);
+    if (this.hasFirestarter || this.hasSearingTouch) {HOT_STREAK_CONTRIBUTORS.map(spell => this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(spell), this.checkHealthPercent));}
+    this.addEventListener(Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.HOT_STREAK), this.onHotStreakRemoved);
+    this.addEventListener(Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.PYROCLASM_BUFF), this.onPyroclasmRemoved);
+    this.addEventListener(Events.removebuffstack.to(SELECTED_PLAYER).spell(SPELLS.PYROCLASM_BUFF), this.onPyroclasmRemoved);
+    this.addEventListener(Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.HOT_STREAK), this.checkForHotStreakPreCasts);
+
+  }
+
+  //When the player casts Fireball, get the timestamp. This timestamp is used for determining if the spell was cast before using Hot Streak
+  getCastTimestamp(event) {
+    this.castTimestamp = event.timestamp;
+  }
+
+  //If the player has the Searing Touch or Firestarter talents, then we need to get the health percentage on damage events so we can know whether we are in the Firestarter or Searing Touch execute windows
+  checkHealthPercent(event) {
+    this.currentHealth = event.hitPoints;
+    this.maxHealth = event.maxHitPoints;
+  }
+
+  //Get the timestamp that Hot Streak was removed. This is used for comparing the cast Timestamp to see if there was a hard cast immediately before Hot Streak was removed (and therefore they pre-casted before Hot Streak)
+  onHotStreakRemoved(event) {
+    this.hotStreakRemoved = event.timestamp;
+  }
+
+  //Get the timestamp that Pyroclasm was removed. Because using Hot Streak involves casting Pyroblast, it isnt possible to tell if they hard casted Pyroblast immediately before using their Hot Streak Pyroblast.
+  //So this is to check to see if the Pyroclasm proc was removed right before Hot Streak was removed.
+  onPyroclasmRemoved(event) {
+    this.pyroclasmProcRemoved = event.timestamp;
+  }
+
+  //Compares timestamps to determine if an ability was hard casted immediately before using Hot Streak.
+  //If Combustion is active or they are in the Firestarter or Searing Touch execute windows, then this check is ignored.
+  checkForHotStreakPreCasts(event) {
+    if (this.selectedCombatant.hasBuff(SPELLS.COMBUSTION.id) || (this.hasFirestarter && this.currentHealth / this.maxHealth > FIRESTARTER_HEALTH_THRESHOLD) || (this.hasSearingTouch && this.currentHealth / this.maxHealth < SEARING_TOUCH_HEALTH_THRESHOLD)) {
+      debug && this.log("Pre Cast Ignored");
+      return;
+    }
+
+    if (this.hotStreakRemoved - PROC_WINDOW_MS < this.castTimestamp || this.hotStreakRemoved - PROC_WINDOW_MS < this.pyroclasmProcRemoved) {
+      this.castedBeforeHotStreak += 1;
+    } else {
+      this.noCastBeforeHotStreak += 1;
+      debug && this.log("No hard cast before Hot Streak");
+    }
+  }
+
+  get castBeforeHotStreakUtil() {
+    return 1 - (this.noCastBeforeHotStreak / (this.castedBeforeHotStreak + this.noCastBeforeHotStreak));
+  }
+
+  get castBeforeHotStreakThresholds() {
+    return {
+      actual: this.castBeforeHotStreakUtil,
+      isLessThan: {
+        minor: .95,
+        average: .85,
+        major:.75,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+      when(this.castBeforeHotStreakThresholds)
+        .addSuggestion((suggest, actual, recommended) => {
+          return suggest(<>In situations where you are not able to guarantee a crit (<SpellLink id={SPELLS.COMBUSTION.id} />, <SpellLink id={SPELLS.FIRESTARTER_TALENT.id} />, and <SpellLink id={SPELLS.SEARING_TOUCH_TALENT.id} />), you didn't pre-cast <SpellLink id={SPELLS.FIREBALL.id} /> {this.hasPyroclasm ? 'or use a Pyroclasm Proc' : ''} {this.noCastBeforeHotStreak} times. Pre-casting when you can't guarantee a crit helps you get more <SpellLink id={SPELLS.HEATING_UP.id} /> and <SpellLink id={SPELLS.HOT_STREAK.id} /> procs, so you should do this whenenver possible.</>)
+            .icon(SPELLS.HOT_STREAK.icon)
+            .actual(`${formatPercentage(this.castBeforeHotStreakUtil)}% Utilization`)
+            .recommended(`${formatPercentage(recommended)}% is recommended`);
+      });
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        position={STATISTIC_ORDER.CORE(15)}
+        icon={<SpellIcon id={SPELLS.HOT_STREAK.id} />}
+        value={`${formatPercentage(this.castBeforeHotStreakUtil, 0)} %`}
+        label="Hot Streak pre-casts"
+        tooltip={`By pre-casting Fireball (or hard casting Pyroblast to use a Pyroclasm proc), you are increasing the chances of getting another Heating Up or Hot Streak since if both the pre-cast and the instant Pyroblast crit, then you will instantly get a new Hot Streak, or if one of them procs then you will have a new Heating Up proc that you can convert to Hot Streak with a guaranteed crit ability like Fire Blast or Phoenix Flames. Therefore you should always do this, except in the below circumstances where you can guarantee a crit.        <ul>
+          <li>Combustion is active</li>
+          <li>You have Firestarter and the target is above 90% health</li>
+          <li>You have Searing Touch and the target is below 30% health</li>
+        </ul>`}
+      />
+    );
+  }
+}
+
+export default HotStreakPreCasts;

--- a/src/parser/mage/fire/modules/features/HotStreakWastedCrits.js
+++ b/src/parser/mage/fire/modules/features/HotStreakWastedCrits.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import { formatNumber } from 'common/format';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import HIT_TYPES from 'game/HIT_TYPES';
+import EnemyInstances, { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
+
+const debug = false;
+
+const PROC_WINDOW_MS = 200;
+
+const HOT_STREAK_CONTRIBUTORS = [
+  SPELLS.FIREBALL.id,
+  SPELLS.PYROBLAST.id,
+  SPELLS.FIRE_BLAST.id,
+  SPELLS.SCORCH.id,
+  SPELLS.PHOENIX_FLAMES_TALENT.id,
+];
+
+class HotStreakWastedCrits extends Analyzer {
+  static dependencies = {
+    enemies: EnemyInstances,
+  };
+
+  lastCastEvent = 0;
+  wastedCrits = 0;
+  hasPyromaniacProc = false;
+
+  constructor(...args) {
+    super(...args);
+    this.hasPyromaniac = this.selectedCombatant.hasTalent(SPELLS.PYROMANIAC_TALENT.id);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this._onCast);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER), this._onDamage);
+    this.addEventListener(Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.HOT_STREAK), this.checkForPyromaniacProc);
+
+  }
+
+  //When a spell that contributes towards Hot Streak is cast, get the event info to use for excluding the cleaves from Phoenix Flames on the damage event
+  _onCast(event) {
+    if (!HOT_STREAK_CONTRIBUTORS.includes(event.ability.guid) && event.ability.guid !== SPELLS.FLAMESTRIKE.id) {
+      return;
+    }
+    this.lastCastEvent = event;
+    this.pyromaniacProc = false;
+  }
+
+  //When a spell that contributes towards Hot Streak crits the target while Hot Streak is active, count it as a wasted crit.
+  //Excludes the cleave from Phoenix Flames (the cleave doesnt contribute towards Hot Streak) and excludes crits immediately after Pyromaniac procs, cause the player cant do anything to prevent that.
+  _onDamage(event) {
+    const spellId = event.ability.guid;
+    const castTarget = encodeTargetString(this.lastCastEvent.targetID, event.targetInstance);
+    const damageTarget = encodeTargetString(event.targetID, event.targetInstance);
+    if (!HOT_STREAK_CONTRIBUTORS.includes(spellId) || event.hitType !== HIT_TYPES.CRIT || !this.selectedCombatant.hasBuff(SPELLS.HOT_STREAK.id) || (spellId === SPELLS.PHOENIX_FLAMES_TALENT.id && castTarget !== damageTarget)) {
+      return;
+    }
+
+    if (this.hasPyromaniacProc) {
+      debug && this.log("Wasted Crit Ignored");
+    } else if (this.selectedCombatant.hasBuff(SPELLS.HOT_STREAK.id,null,-50)) {
+      this.wastedCrits += 1;
+      debug && this.log("Wasted Crit");
+    }
+  }
+
+  //Pyromaniac doesnt trigger an event, so we need to check to see if the player immediately got a new Hot Streak immediately after using a Hot Streak
+  checkForPyromaniacProc(event) {
+    if (this.hasPyromaniac && event.timestamp - this.hotStreakRemoved < PROC_WINDOW_MS) {
+      this.hasPyromaniacProc = true;
+    }
+  }
+
+  get wastedCritsPerMinute() {
+    return this.wastedCrits / (this.owner.fightDuration / 60000);
+  }
+
+  get wastedCritsThresholds() {
+    return {
+      actual: this.wastedCritsPerMinute,
+      isGreaterThan: {
+        minor: 0,
+        average: 1,
+        major: 3,
+      },
+      style: 'number',
+    };
+  }
+
+  suggestions(when) {
+      when(this.wastedCritsThresholds)
+        .addSuggestion((suggest, actual, recommended) => {
+          return suggest(<>You crit with {formatNumber(this.wastedCrits)} ({formatNumber(this.wastedCritsPerMinute)} Per Minute) direct damage abilities while <SpellLink id={SPELLS.HOT_STREAK.id} /> was active. This is a waste since those crits could have contibuted towards your next Hot Streak. Try to use your procs as soon as possible to avoid this.</>)
+            .icon(SPELLS.HOT_STREAK.icon)
+            .actual(`${formatNumber(this.wastedCrits)} crits wasted`)
+            .recommended(`${formatNumber(recommended)} is recommended`);
+      });
+  }
+}
+
+export default HotStreakWastedCrits;

--- a/src/parser/mage/fire/modules/features/HotStreakWastedCrits.js
+++ b/src/parser/mage/fire/modules/features/HotStreakWastedCrits.js
@@ -60,6 +60,9 @@ class HotStreakWastedCrits extends Analyzer {
       debug && this.log("Wasted Crit Ignored");
     } else if (this.selectedCombatant.hasBuff(SPELLS.HOT_STREAK.id,null,-50)) {
       this.wastedCrits += 1;
+      this.lastCastEvent.meta = this.lastCastEvent.meta || {};
+      this.lastCastEvent.meta.isInefficientCast = true;
+      this.lastCastEvent.meta.inefficientCastReason = "This cast crit while you already had Hot Streak and could have contributed towards your next Heating Up or Hot Streak.";
       debug && this.log("Wasted Crit");
     }
   }


### PR DESCRIPTION
I redid Hot Streak to be easier to work with, updated it to the new event listeners, and fixed some bugs.

- Split Hot Streak into 3 separate modules (HotStreak, HotStreakWastedCrits, and HotStreakPreCasts)
- Split the double Stat Box into two separate boxes (which should be easier to understand)
- Rewrote the PreCasts suggestion to not include precasting Scorch cause that leads to munched procs.
- Changed the analysis on PreCasts to ignore anything during Combustion, the Firestarter execute, or the Searing Touch execute
- removed some variables that werent used
- Updated the Checklist to look at the new files
- Added comments throughout the code
- Added a position to Heating Up's stat box (Cause it was ordered weird)
- Added timeline highlights for wasted crits
- Changelog stuff


Stat Boxes Before
![image](https://user-images.githubusercontent.com/1304554/48529947-20842800-e85b-11e8-8137-6ecbd4c8801b.png)

Stat Boxes After
![image](https://user-images.githubusercontent.com/1304554/48529967-37c31580-e85b-11e8-8959-20715d890582.png)
![image](https://user-images.githubusercontent.com/1304554/48529978-4b6e7c00-e85b-11e8-8d86-83661d549250.png)
![image](https://user-images.githubusercontent.com/1304554/48529991-575a3e00-e85b-11e8-847c-c3262b11dc2c.png)

PreCasts suggestion before
![image](https://user-images.githubusercontent.com/1304554/48530006-6b9e3b00-e85b-11e8-892b-b1945f3450e1.png)

PreCasts suggestion after
![image](https://user-images.githubusercontent.com/1304554/48530028-853f8280-e85b-11e8-8d07-cbbef02faaf9.png)

Wasted Crits Timeline Highlight
![image](https://user-images.githubusercontent.com/1304554/48531368-a0ad8c00-e861-11e8-94dc-4eae5eb02d1e.png)
