### PR TITLE
[Mage] Add a suggestion to talent into Rune of Power when playing Arcane or Fire

### DIFF
--- a/src/parser/mage/shared/modules/features/RuneOfPower.js
+++ b/src/parser/mage/shared/modules/features/RuneOfPower.js
@@ -15,7 +15,7 @@ import SUGGESTION_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
 /*
  * If Rune of Power is substantially better than the rest of the row, enable
  * ROP talent suggestion. At time of writing, it's a substantial increase over
- * incanters flow for fire and arcane in almost all situations.
+ * incanters flow for fire and arcane in all situations.
  */
 const SUGGEST_ROP = { [SPECS.FROST_MAGE.id]: false, [SPECS.ARCANE_MAGE.id]: true, [SPECS.FIRE_MAGE.id]: true };
 
@@ -87,6 +87,7 @@ class RuneOfPower extends Analyzer {
     };
   }
 
+  showSuggestion = true;
   suggestions(when) {
     if (!this.hasROP) {
       when(SUGGEST_ROP[this.selectedCombatant.specId]).isTrue()
@@ -99,6 +100,10 @@ class RuneOfPower extends Analyzer {
             .icon(SPELLS.RUNE_OF_POWER_TALENT.icon)
             .staticImportance(SUGGESTION_IMPORTANCE.REGULAR);
         });
+      return;
+    }
+
+    if(!this.showSuggestion) {
       return;
     }
 
@@ -122,8 +127,9 @@ class RuneOfPower extends Analyzer {
 
   }
 
+  showStatistic = false;
   statistic() {
-    if (!this.hasROP) return null;
+    if (!this.hasROP || !this.showStatistic) return null;
 
     return (
       <TalentStatisticBox

--- a/src/parser/mage/shared/modules/features/RuneOfPower.js
+++ b/src/parser/mage/shared/modules/features/RuneOfPower.js
@@ -127,7 +127,7 @@ class RuneOfPower extends Analyzer {
 
   }
 
-  showStatistic = false;
+  showStatistic = true;
   statistic() {
     if (!this.hasROP || !this.showStatistic) return null;
 

--- a/src/parser/mage/shared/modules/features/RuneOfPower.js
+++ b/src/parser/mage/shared/modules/features/RuneOfPower.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import SPELLS from 'common/SPELLS';
+import SPECS from 'game/SPECS';
 import SpellLink from 'common/SpellLink';
 import SpellIcon from 'common/SpellIcon';
 import { formatNumber, formatPercentage } from 'common/format';
@@ -7,6 +8,16 @@ import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStat
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import Analyzer from 'parser/core/Analyzer';
 import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
+import Events from 'parser/core/Events';
+import { SELECTED_PLAYER } from 'parser/core/EventFilter';
+import SUGGESTION_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
+
+/*
+ * If Rune of Power is substantially better than the rest of the row, enable
+ * ROP talent suggestion. At time of writing, it's a substantial increase over
+ * incanters flow for fire and arcane in almost all situations.
+ */
+const SUGGEST_ROP = { [SPECS.FROST_MAGE.id]: false, [SPECS.ARCANE_MAGE.id]: true, [SPECS.FIRE_MAGE.id]: true };
 
 const DAMAGE_BONUS = 0.4;
 const RUNE_DURATION = 10;
@@ -18,14 +29,19 @@ class RuneOfPower extends Analyzer {
     abilityTracker: AbilityTracker,
   };
 
+  hasROP = false;
   damage = 0;
 
   constructor(...args) {
     super(...args);
-    this.active = this.selectedCombatant.hasTalent(SPELLS.RUNE_OF_POWER_TALENT.id);
+
+    if (this.selectedCombatant.hasTalent(SPELLS.RUNE_OF_POWER_TALENT.id)) {
+      this.hasROP = true;
+      this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onPlayerDamage);
+    }
   }
 
-  on_byPlayer_damage(event) {
+  onPlayerDamage(event) {
     if (this.selectedCombatant.hasBuff(SPELLS.RUNE_OF_POWER_BUFF.id)) {
       this.damage += calculateEffectiveDamage(event, DAMAGE_BONUS);
     }
@@ -59,31 +75,41 @@ class RuneOfPower extends Analyzer {
     };
   }
 
-
   get roundedSecondsSuggestionThresholds() {
     return {
       actual: this.roundedSecondsPerCast,
       isLessThan: {
         minor: RUNE_DURATION,
         average: RUNE_DURATION - 1,
-        major: RUNE_DURATION - 3,
+        major: RUNE_DURATION - 2,
       },
       style: 'number',
     };
   }
 
-  showSuggestion = true;
-
   suggestions(when) {
-    if (this.showSuggestion) {
-      when(this.damageSuggestionThresholds)
-        .addSuggestion((suggest, actual, recommended) => {
-          return suggest(<>Your <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} /> damage boost is below the expected passive gain from <SpellLink id={SPELLS.INCANTERS_FLOW_TALENT.id} />. Either find ways to make better use of the talent, or switch to <SpellLink id={SPELLS.INCANTERS_FLOW_TALENT.id} />.</>)
+    if (!this.hasROP) {
+      when(SUGGEST_ROP[this.selectedCombatant.specId]).isTrue()
+        .addSuggestion((suggest) => {
+          return suggest(
+            <>
+            It is highly recommended to talent into <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} /> when playing this spec.
+            While it can take some practice to master, when played correctly it outputs substantially more DPS than <SpellLink id={SPELLS.INCANTERS_FLOW_TALENT.id} /> or <SpellLink id={SPELLS.MIRROR_IMAGE_TALENT.id} />.
+            </>)
             .icon(SPELLS.RUNE_OF_POWER_TALENT.icon)
-            .actual(`${formatPercentage(this.damageIncreasePercent)}% damage increase from Rune of Power`)
-            .recommended(`${formatPercentage(recommended)}% is the passive gain from Incanter's Flow`);
+            .staticImportance(SUGGESTION_IMPORTANCE.REGULAR);
         });
+      return;
     }
+
+    when(this.damageSuggestionThresholds)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<>Your <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} /> damage boost is below the expected passive gain from <SpellLink id={SPELLS.INCANTERS_FLOW_TALENT.id} />. Either find ways to make better use of the talent, or switch to <SpellLink id={SPELLS.INCANTERS_FLOW_TALENT.id} />.</>)
+          .icon(SPELLS.RUNE_OF_POWER_TALENT.icon)
+          .actual(`${formatPercentage(this.damageIncreasePercent)}% damage increase from Rune of Power`)
+          .recommended(`${formatPercentage(recommended)}% is the passive gain from Incanter's Flow`);
+      });
+
     if (this.abilityTracker.getAbility(SPELLS.RUNE_OF_POWER_TALENT.id).casts > 0) {
       when(this.roundedSecondsSuggestionThresholds)
         .addSuggestion((suggest, actual, recommended) => {
@@ -93,22 +119,23 @@ class RuneOfPower extends Analyzer {
             .recommended(`the full duration of ${formatNumber(RUNE_DURATION)}s is recommended`);
         });
     }
+
   }
 
-  showStatistic = true;
-
   statistic() {
-    if (!this.showStatistic) return null;
+    if (!this.hasROP) return null;
+
     return (
       <TalentStatisticBox
         position={STATISTIC_ORDER.CORE(100)}
         icon={<SpellIcon id={SPELLS.RUNE_OF_POWER_TALENT.id} />}
         value={`${formatPercentage(this.damagePercent)} %`}
         label="Rune of Power damage"
-        tooltip={`This is the portion of your total damage attributable to Rune of Power's boost. Expressed as an increase vs never using Rune of Power, this is a <b>${formatPercentage(this.damageIncreasePercent)}% damage increase</b>. Note that this number does <i>not</i> factor in the opportunity cost of casting Rune of Power instead of another damaging spell`}
+        tooltip={`This is the portion of your total damage attributable to Rune of Power's boost. Expressed as an increase vs never using Rune of Power, this is a <b>${formatPercentage(this.damageIncreasePercent)}% damage increase</b>. Note that this number does <i>not</i> factor in the opportunity cost of casting Rune of Power instead of another damaging spell.`}
       />
     );
   }
+
 }
 
 export default RuneOfPower;


### PR DESCRIPTION
According to sims and mage TCS, there are really no situations where Incanter's Flow or Mirror Image are good options. On average, looking at WCL, a well played RoP increases throughput by about 10% on average. Because it's a playstyle choice, I think it's better to not make it part of the checklist and to keep it as an _Average_ suggestion. I also added an easy way (the constant at the top of the module) to enable/disable the suggestion as talents are rebalanced.

Also, changed module to new eventlistener 😉 

![image](https://user-images.githubusercontent.com/43309639/48537091-529a8780-e865-11e8-95c0-643c56241a4e.png)
