### PR TITLE
fixed a crashing bug in the light of the protector module

### DIFF
--- a/src/parser/paladin/protection/modules/spells/LightOfTheProtector.js
+++ b/src/parser/paladin/protection/modules/spells/LightOfTheProtector.js
@@ -60,6 +60,9 @@ export default class LightOfTheProtector extends Analyzer {
   // update the delay based on SotR cast with the RP talent, which
   // reduces LotP/HotP CD by 3s
   _updateDelayRP(event) {
+    if(!this._lastHit || this._msTilHeal === 0) {
+      return;
+    }
     const delayFromHit = event.timestamp - this._lastHit.timestamp;
     this._msTilHeal -= RP_REDUCTION_TIME;
     // we couldn't cast the heal before the current event happened


### PR DESCRIPTION
This bug is triggered by casting SotR before being hit the first time in an encounter, something that apparently didn't happen in my test logs.