### PR TITLE
[Demonology] Few fixes + Tier 15 talents

### DIFF
--- a/src/common/SPELLS/warlock.js
+++ b/src/common/SPELLS/warlock.js
@@ -359,12 +359,6 @@ export default {
     name: 'Felstorm',
     icon: 'ability_warrior_bladestorm',
   },
-  // TODO: check Wrathguard and Terrorguard glyphs
-  WRATHSTORM_BUFF: {
-    id: 115831,
-    name: 'Wrathstorm',
-    icon: 'ability_warrior_bladestorm',
-  },
   // also important for Dreadlash talent
   DREADBITE: {
     id: 271971,

--- a/src/parser/warlock/demonology/CHANGELOG.js
+++ b/src/parser/warlock/demonology/CHANGELOG.js
@@ -6,6 +6,11 @@ import SPELLS from 'common/SPELLS';
 
 export default [
   {
+    date: new Date('2018-11-15'),
+    changes: <>Fixed <SpellLink id={SPELLS.DEMONIC_CALLING_TALENT.id} /> and <SpellLink id={SPELLS.GRIMOIRE_FELGUARD_TALENT.id} /> modules.</>,
+    contributors: [Chizu],
+  },
+  {
     date: new Date('2018-11-12'),
     changes: 'Certain buffs or debuffs now show in timeline.',
     contributors: [Chizu],

--- a/src/parser/warlock/demonology/CHANGELOG.js
+++ b/src/parser/warlock/demonology/CHANGELOG.js
@@ -7,6 +7,11 @@ import SPELLS from 'common/SPELLS';
 export default [
   {
     date: new Date('2018-11-15'),
+    changes: <>Updated Checklist rules and added talent modules for the first row - <SpellLink id={SPELLS.DREADLASH_TALENT.id} />, <SpellLink id={SPELLS.DEMONIC_STRENGTH_TALENT.id} /> and <SpellLink id={SPELLS.BILESCOURGE_BOMBERS_TALENT.id} /></>,
+    contributors: [Chizu],
+  },
+  {
+    date: new Date('2018-11-15'),
     changes: <>Fixed <SpellLink id={SPELLS.DEMONIC_CALLING_TALENT.id} /> and <SpellLink id={SPELLS.GRIMOIRE_FELGUARD_TALENT.id} /> modules.</>,
     contributors: [Chizu],
   },

--- a/src/parser/warlock/demonology/CombatLogParser.js
+++ b/src/parser/warlock/demonology/CombatLogParser.js
@@ -21,6 +21,7 @@ import PowerSiphonNormalizer from './modules/talents/normalizers/PowerSiphonNorm
 
 import TalentStatisticBox from './modules/talents';
 import Dreadlash from './modules/talents/Dreadlash';
+import DemonicStrength from './modules/talents/DemonicStrength';
 import DemonicCalling from './modules/talents/DemonicCalling';
 import GrimoireFelguard from './modules/talents/GrimoireFelguard';
 
@@ -50,6 +51,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Talents
     talents: TalentStatisticBox,
     dreadlash: Dreadlash,
+    demonicStrength: DemonicStrength,
     demonicCalling: DemonicCalling,
     grimoireFelguard: GrimoireFelguard,
 

--- a/src/parser/warlock/demonology/CombatLogParser.js
+++ b/src/parser/warlock/demonology/CombatLogParser.js
@@ -22,6 +22,7 @@ import PowerSiphonNormalizer from './modules/talents/normalizers/PowerSiphonNorm
 import TalentStatisticBox from './modules/talents';
 import Dreadlash from './modules/talents/Dreadlash';
 import DemonicStrength from './modules/talents/DemonicStrength';
+import BilescourgeBombers from './modules/talents/BilescourgeBombers';
 import DemonicCalling from './modules/talents/DemonicCalling';
 import GrimoireFelguard from './modules/talents/GrimoireFelguard';
 
@@ -52,6 +53,7 @@ class CombatLogParser extends CoreCombatLogParser {
     talents: TalentStatisticBox,
     dreadlash: Dreadlash,
     demonicStrength: DemonicStrength,
+    bilescourgeBombers: BilescourgeBombers,
     demonicCalling: DemonicCalling,
     grimoireFelguard: GrimoireFelguard,
 

--- a/src/parser/warlock/demonology/CombatLogParser.js
+++ b/src/parser/warlock/demonology/CombatLogParser.js
@@ -20,6 +20,7 @@ import PrepullPetNormalizer from './modules/pets/normalizers/PrepullPetNormalize
 import PowerSiphonNormalizer from './modules/talents/normalizers/PowerSiphonNormalizer';
 
 import TalentStatisticBox from './modules/talents';
+import Dreadlash from './modules/talents/Dreadlash';
 import DemonicCalling from './modules/talents/DemonicCalling';
 import GrimoireFelguard from './modules/talents/GrimoireFelguard';
 
@@ -48,6 +49,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Talents
     talents: TalentStatisticBox,
+    dreadlash: Dreadlash,
     demonicCalling: DemonicCalling,
     grimoireFelguard: GrimoireFelguard,
 

--- a/src/parser/warlock/demonology/CombatLogParser.js
+++ b/src/parser/warlock/demonology/CombatLogParser.js
@@ -19,6 +19,7 @@ import PrepullPetNormalizer from './modules/pets/normalizers/PrepullPetNormalize
 
 import PowerSiphonNormalizer from './modules/talents/normalizers/PowerSiphonNormalizer';
 
+import TalentStatisticBox from './modules/talents';
 import DemonicCalling from './modules/talents/DemonicCalling';
 import GrimoireFelguard from './modules/talents/GrimoireFelguard';
 
@@ -46,6 +47,7 @@ class CombatLogParser extends CoreCombatLogParser {
     powerSiphonNormalizer: PowerSiphonNormalizer,
 
     // Talents
+    talents: TalentStatisticBox,
     demonicCalling: DemonicCalling,
     grimoireFelguard: GrimoireFelguard,
 

--- a/src/parser/warlock/demonology/modules/features/Abilities.js
+++ b/src/parser/warlock/demonology/modules/features/Abilities.js
@@ -92,7 +92,8 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         castEfficiency: {
-          suggestion: false,
+          suggestion: true,
+          recommendedEfficiency: 0.9,
         },
       },
       {

--- a/src/parser/warlock/demonology/modules/features/Checklist/Component.js
+++ b/src/parser/warlock/demonology/modules/features/Checklist/Component.js
@@ -44,9 +44,19 @@ class DemonologyWarlockChecklist extends React.PureComponent {
 
     return (
       <Checklist>
-        <Rule name="Use your core spells">
+        <Rule
+          name="Use your core spells"
+          description={<>Demonology has a lot of short cooldowns that make up majority of your rotation, such as <SpellLink id={SPELLS.CALL_DREADSTALKERS.id} /> or Felguard's <SpellLink id={SPELLS.FELSTORM_BUFF.id} />. Try to use them as much as possible.</>}
+        >
           <AbilityRequirement spell={SPELLS.CALL_DREADSTALKERS.id} />
+          <Requirement
+            name={(<SpellLink id={SPELLS.FELSTORM_BUFF.id} />)}
+            thresholds={thresholds.felstorm}
+          />
+          {combatant.hasTalent(SPELLS.BILESCOURGE_BOMBERS_TALENT.id) && <AbilityRequirement spell={SPELLS.BILESCOURGE_BOMBERS_TALENT.id} />}
+          {combatant.hasTalent(SPELLS.POWER_SIPHON_TALENT.id) && <AbilityRequirement spell={SPELLS.POWER_SIPHON_TALENT.id} />}
           {combatant.hasTalent(SPELLS.DOOM_TALENT.id) && <DotUptime id={SPELLS.DOOM_TALENT.id} thresholds={thresholds.doom} />}
+          {combatant.hasTalent(SPELLS.SOUL_STRIKE_TALENT.id) && <AbilityRequirement spell={SPELLS.SOUL_STRIKE_TALENT.id} />}
         </Rule>
         <Rule
           name="Don't cap your Soul Shards"
@@ -63,14 +73,10 @@ class DemonologyWarlockChecklist extends React.PureComponent {
           description="Be mindful of your cooldowns if you are specced into them and use them when it's appropriate. It's okay to hold a cooldown for a little bit when the encounter requires it (burn phases), but generally speaking you should use them as much as you can."
         >
           <AbilityRequirement spell={SPELLS.SUMMON_DEMONIC_TYRANT.id} />
-          {combatant.hasTalent(SPELLS.NETHER_PORTAL_TALENT.id) && <AbilityRequirement spell={SPELLS.NETHER_PORTAL_TALENT.id} />}
-          {combatant.hasTalent(SPELLS.POWER_SIPHON_TALENT.id) && <AbilityRequirement spell={SPELLS.POWER_SIPHON_TALENT.id} />}
-          {combatant.hasTalent(SPELLS.GRIMOIRE_FELGUARD_TALENT.id) && <AbilityRequirement spell={SPELLS.GRIMOIRE_FELGUARD_TALENT.id} />}
           {combatant.hasTalent(SPELLS.DEMONIC_STRENGTH_TALENT.id) && <AbilityRequirement spell={SPELLS.DEMONIC_STRENGTH_TALENT.id} />}
-          <Requirement
-            name={(<SpellLink id={SPELLS.FELSTORM_BUFF.id} icon />)}
-            thresholds={thresholds.felstorm}
-          />
+          {combatant.hasTalent(SPELLS.SUMMON_VILEFIEND_TALENT.id) && <AbilityRequirement spell={SPELLS.SUMMON_VILEFIEND_TALENT.id} />}
+          {combatant.hasTalent(SPELLS.GRIMOIRE_FELGUARD_TALENT.id) && <AbilityRequirement spell={SPELLS.GRIMOIRE_FELGUARD_TALENT.id} />}
+          {combatant.hasTalent(SPELLS.NETHER_PORTAL_TALENT.id) && <AbilityRequirement spell={SPELLS.NETHER_PORTAL_TALENT.id} />}
         </Rule>
         <Rule
           name="Use your utility and defensive spells"
@@ -89,7 +95,7 @@ class DemonologyWarlockChecklist extends React.PureComponent {
           name="Always be casting"
           description={(
             <>
-              You should try to avoid doing nothing during the fight. When you're out of Soul Shards, cast <SpellLink id={SPELLS.SHADOW_BOLT_AFFLI.id} icon />/<SpellLink id={SPELLS.DRAIN_SOUL_TALENT.id} icon />, refresh your DoTs etc. When you have to move, use your instant abilities or try to utilize <SpellLink id={SPELLS.DEMONIC_CIRCLE_TALENT.id} icon>Teleport</SpellLink> or <SpellLink id={SPELLS.DEMONIC_GATEWAY_CAST.id} icon>Gateway</SpellLink> to reduce the movement even further.
+              You should try to avoid doing nothing during the fight. When you're waiting for cooldowns, keep building Soul Shards to summon additional Wild Imps. When you have to move, use your instant abilities like <SpellLink id={SPELLS.DEMONBOLT.id} /> (with Demonic Core) or <SpellLink id={SPELLS.SOUL_STRIKE_TALENT.id} /> or try to utilize <SpellLink id={SPELLS.DEMONIC_CIRCLE_TALENT.id} icon>Teleport</SpellLink> or <SpellLink id={SPELLS.DEMONIC_GATEWAY_CAST.id} icon>Gateway</SpellLink> to reduce the movement even further.
             </>
           )}
         >

--- a/src/parser/warlock/demonology/modules/features/Felstorm.js
+++ b/src/parser/warlock/demonology/modules/features/Felstorm.js
@@ -1,54 +1,66 @@
 import React from 'react';
 
-import Analyzer from 'parser/core/Analyzer';
+import Analyzer, { SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
 import calculateMaxCasts from 'parser/core/calculateMaxCasts';
 
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
+import Events from 'parser/core/Events';
 
-const FELSTORM_COOLDOWN = 45;
+const FELSTORM_COOLDOWN = 30;
+const DEMONIC_STRENGTH_BUFFER = 100;
 
 class Felstorm extends Analyzer {
-  _felstormGuid = undefined;
+  _lastDemonicStrengthCast = null;
   mainPetFelstormCount = 0;
 
+  constructor(...args) {
+    super(...args);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.DEMONIC_STRENGTH_TALENT), this.demonicStrengthCast);
+    this.addEventListener(Events.applybuff.to(SELECTED_PLAYER_PET).spell(SPELLS.FELSTORM_BUFF), this.applyFelstormBuff);
+  }
+
+  demonicStrengthCast(event) {
+    this._lastDemonicStrengthCast = event.timestamp;
+  }
+
   // works with either direct /cast Felstorm or by using the Command Demon ability (if direct /cast Felstorm, then the player didn't cast it, but this buff gets applied either way)
-  // TODO: verify this still works
-  on_toPlayerPet_applybuff(event) {
-    if (event.ability.guid !== SPELLS.FELSTORM_BUFF.id && event.ability.guid !== SPELLS.WRATHSTORM_BUFF.id) {
+  applyFelstormBuff(event) {
+    if (this._lastDemonicStrengthCast && event.timestamp <= this._lastDemonicStrengthCast + DEMONIC_STRENGTH_BUFFER) {
+      // casting Demonic Strength triggers Felstorm as well, but we care about the pet ability itself, which is on separate cooldown
       return;
     }
     if (!event.sourceInstance) {
       // permanent Felguard doesn't have sourceInstance, while Grimoire: Felguard does (both use Felstorm in the exact same way)
       this.mainPetFelstormCount += 1;
-      if (!this._felstormGuid) {
-        this._felstormGuid = event.ability.guid;
-      }
     }
   }
 
+  get maxCasts() {
+    return Math.ceil(calculateMaxCasts(FELSTORM_COOLDOWN, this.owner.fightDuration));
+  }
+
   get suggestionThresholds(){
-    const maxCasts = Math.ceil(calculateMaxCasts(FELSTORM_COOLDOWN, this.owner.fightDuration));
+    const percentage = (this.mainPetFelstormCount / this.maxCasts) || 0;
     return {
-      actual: this.mainPetFelstormCount,
-      isLessThan: maxCasts,
-      style: 'number',
+      actual: percentage,
+      isLessThan: {
+        minor: 0.9,
+        average: 0.8,
+        major: 0.7,
+      },
+      style: 'percentage',
     };
   }
 
   suggestions(when) {
-    // TODO: this would be rather unpleasant to refactor (style issues, but still)
-    const maxCasts = Math.ceil(calculateMaxCasts(FELSTORM_COOLDOWN, this.owner.fightDuration));
-    const percentage = this.mainPetFelstormCount / maxCasts;
-    const petType = (!this._felstormGuid || this._felstormGuid === SPELLS.FELSTORM_BUFF.id) ? "Fel" : "Wrath";
-    when(percentage).isLessThan(0.9)
+    when(this.suggestionThresholds)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<>You should use your {petType}guard's <SpellLink id={this._felstormGuid || SPELLS.FELSTORM_BUFF.id} /> more often, preferably on cooldown.</>)
+        return suggest(<>You should use your Felguard's <SpellLink id={SPELLS.FELSTORM_BUFF.id} /> more often, preferably on cooldown.</>)
           .icon(SPELLS.FELSTORM_BUFF.icon)
-          .actual(`${this.mainPetFelstormCount} out of ${maxCasts} (${formatPercentage(actual)} %) ${petType}storm casts.`)
-          .recommended(`> ${formatPercentage(recommended)} % is recommended`)
-          .regular(recommended - 0.1).major(recommended - 0.2);
+          .actual(`${this.mainPetFelstormCount} out of ${this.maxCasts} (${formatPercentage(actual)} %) Felstorm casts.`)
+          .recommended(`> ${formatPercentage(recommended)} % is recommended`);
       });
   }
 }

--- a/src/parser/warlock/demonology/modules/talents/BilescourgeBombers.js
+++ b/src/parser/warlock/demonology/modules/talents/BilescourgeBombers.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import { formatThousands } from 'common/format';
+
+import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
+
+class BilescourgeBombers extends Analyzer {
+  damage = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.BILESCOURGE_BOMBERS_TALENT.id);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.BILESCOURGE_BOMBERS_DAMAGE), this.handleBilescourgeDamage);
+  }
+
+  handleBilescourgeDamage(event) {
+    this.damage += event.amount + (event.absorbed || 0);
+  }
+
+  subStatistic() {
+    return (
+      <StatisticListBoxItem
+        title={<><SpellLink id={SPELLS.BILESCOURGE_BOMBERS_TALENT.id} /> damage</>}
+        value={formatThousands(this.damage)}
+        valueTooltip={this.owner.formatItemDamageDone(this.damage)}
+      />
+    );
+  }
+}
+
+export default BilescourgeBombers;

--- a/src/parser/warlock/demonology/modules/talents/DemonicCalling.js
+++ b/src/parser/warlock/demonology/modules/talents/DemonicCalling.js
@@ -5,10 +5,10 @@ import Events from 'parser/core/Events';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 
-import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
+import { STATISTIC_ORDER } from 'interface/others/StatisticBox';
+import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
 
 const BUFF_DURATION = 20000;
 const debug = false;
@@ -44,7 +44,6 @@ class DemonicCalling extends Analyzer {
   }
 
   removeDemonicCallingBuff(event) {
-    // TODO same check as in refresh
     if (event.timestamp >= this._expectedBuffEnd) {
       // the buff fell off, another wasted instant
       this.wastedProcs += 1;
@@ -75,12 +74,11 @@ class DemonicCalling extends Analyzer {
       });
   }
 
-  statistic() {
+  subStatistic() {
     return (
-      <StatisticBox
-        icon={<SpellIcon id={SPELLS.DEMONIC_CALLING_TALENT.id} />}
+      <StatisticListBoxItem
+        title={<>Wasted <SpellLink id={SPELLS.DEMONIC_CALLING_TALENT.id} /> procs</>}
         value={this.wastedProcs}
-        label="Wasted cheaper Dreadstalkers"
       />
     );
   }

--- a/src/parser/warlock/demonology/modules/talents/DemonicStrength.js
+++ b/src/parser/warlock/demonology/modules/talents/DemonicStrength.js
@@ -1,0 +1,63 @@
+import React from 'react';
+
+import Analyzer, { SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import Pets from 'parser/shared/modules/Pets';
+
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import { formatThousands } from 'common/format';
+
+import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
+
+import PETS from '../pets/PETS';
+
+const BUFFER = 200;
+
+class DemonicStrength extends Analyzer {
+  static dependencies = {
+    pets: Pets,
+  };
+
+  _removedAt = null;
+  damage = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.DEMONIC_STRENGTH_TALENT.id);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER_PET).spell(SPELLS.FELSTORM_DAMAGE), this.handleFelstormDamage);
+    this.addEventListener(Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.DEMONIC_STRENGTH_TALENT), this.handleRemoveDemonicStrength);
+  }
+
+  handleFelstormDamage(event) {
+    // pet ability Felstorm and this "empowered" Felstorm can't be active at the same time, they're exclusive (the game doesn't let you cast it)
+    const petInfo = this.owner.playerPets.find(pet => pet.id === event.sourceID);
+    if (petInfo.guid === PETS.GRIMOIRE_FELGUARD.guid) {
+      // Grimoire: Felguard uses same spell IDs
+      return;
+    }
+    const pet = this.pets.getSourceEntity(event);
+    if (pet.hasBuff(SPELLS.DEMONIC_STRENGTH_TALENT.id) || event.timestamp <= this._removedAt + BUFFER) {
+      // the last empowered Felstorm usually happens in this order:
+      // Felstorm cast -> Demonic Strength removebuff -> Felstorm damages
+      // So in order to also count the last empowered damage events, we also count damage events within 200ms of the removebuff
+      this.damage += event.amount + (event.absorbed || 0);
+    }
+  }
+
+  handleRemoveDemonicStrength(event) {
+    this._removedAt = event.timestamp;
+  }
+
+  subStatistic() {
+    return (
+      <StatisticListBoxItem
+        title={<><SpellLink id={SPELLS.DEMONIC_STRENGTH_TALENT.id} /> Felstorm damage</>}
+        value={formatThousands(this.damage)}
+        valueTooltip={this.owner.formatItemDamageDone(this.damage)}
+      />
+    );
+  }
+}
+
+export default DemonicStrength;

--- a/src/parser/warlock/demonology/modules/talents/Dreadlash.js
+++ b/src/parser/warlock/demonology/modules/talents/Dreadlash.js
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import Analyzer, { SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
+
+import SPELLS from 'common/SPELLS';
+import Events from 'parser/core/Events';
+import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
+import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
+import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
+import SpellLink from 'common/SpellLink';
+import { formatThousands } from 'common/format';
+
+const DREADLASH_BONUS_DAMAGE = 0.25;
+const debug = false;
+
+class Dreadlash extends Analyzer {
+  _primaryTarget = null;
+  cleavedDamage = 0;
+  bonusDamage = 0; // only from primary target
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.DREADLASH_TALENT.id);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER_PET).spell(SPELLS.DREADBITE), this.handleDreadbite);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.CALL_DREADSTALKERS), this.handleDreadstalkerCast);
+  }
+
+  handleDreadbite(event) {
+    const target = encodeTargetString(event.targetID, event.targetInstance);
+    if (this._primaryTarget === target) {
+      debug && this.log(`Dreadbite damage on ${target}, primary`);
+      this.bonusDamage += calculateEffectiveDamage(event, DREADLASH_BONUS_DAMAGE);
+    }
+    else {
+      debug && this.log(`Dreadbite damage on ${target}, cleaved`);
+      this.cleavedDamage += event.amount + (event.absorbed || 0);
+    }
+  }
+
+  handleDreadstalkerCast(event) {
+    this._primaryTarget = encodeTargetString(event.targetID, event.targetInstance);
+    debug && this.log(`Dreadstalkers cast on ${this._primaryTarget}`);
+  }
+
+  subStatistic() {
+    const total = this.cleavedDamage + this.bonusDamage;
+    return (
+      <StatisticListBoxItem
+        title={<>Bonus <SpellLink id={SPELLS.DREADLASH_TALENT.id} /> damage</>}
+        value={formatThousands(total)}
+        valueTooltip={`${this.owner.formatItemDamageDone(total)}<br/>
+                      Bonus damage on primary target hits: ${formatThousands(this.bonusDamage)}<br/>
+                      Bonus cleaved damage: ${formatThousands(this.cleavedDamage)}`}
+      />
+    );
+  }
+}
+
+export default Dreadlash;

--- a/src/parser/warlock/demonology/modules/talents/GrimoireFelguard.js
+++ b/src/parser/warlock/demonology/modules/talents/GrimoireFelguard.js
@@ -4,10 +4,11 @@ import Analyzer from 'parser/core/Analyzer';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 
 import SPELLS from 'common/SPELLS';
-import { formatNumber, formatThousands } from 'common/format';
-import SpellIcon from 'common/SpellIcon';
+import { formatThousands } from 'common/format';
+import SpellLink from 'common/SpellLink';
 
-import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
+import { STATISTIC_ORDER } from 'interface/others/StatisticBox';
+import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
 
 import DemoPets from '../pets/DemoPets';
 import PETS from '../pets/PETS';
@@ -23,14 +24,13 @@ class GrimoireFelguard extends Analyzer {
     this.active = this.selectedCombatant.hasTalent(SPELLS.GRIMOIRE_FELGUARD_TALENT.id);
   }
 
-  statistic() {
+  subStatistic() {
     const damage = this.demoPets.getPetDamage(PETS.GRIMOIRE_FELGUARD.guid);
     return (
-      <StatisticBox
-        icon={<SpellIcon id={SPELLS.GRIMOIRE_FELGUARD_TALENT.id} />}
-        value={`${formatNumber(damage / this.owner.fightDuration * 1000)} DPS`}
-        label="Grimoire: Felguard damage"
-        tooltip={`Your Grimoire: Felguard did ${formatThousands(damage)} damage (${this.owner.formatItemDamageDone(damage)}).`}
+      <StatisticListBoxItem
+        title={<><SpellLink id={SPELLS.GRIMOIRE_FELGUARD_TALENT.id} /> damage</>}
+        value={formatThousands(damage)}
+        valueTooltip={this.owner.formatItemDamageDone(damage)}
       />
     );
   }

--- a/src/parser/warlock/demonology/modules/talents/index.js
+++ b/src/parser/warlock/demonology/modules/talents/index.js
@@ -5,12 +5,14 @@ import Analyzer from 'parser/core/Analyzer';
 import StatisticsListBox, { STATISTIC_ORDER } from 'interface/others/StatisticsListBox';
 
 import Dreadlash from './Dreadlash';
+import DemonicStrength from './DemonicStrength';
 import DemonicCalling from './DemonicCalling';
 import GrimoireFelguard from './GrimoireFelguard';
 
 class TalentStatisticBox extends Analyzer {
   static dependencies = {
     dreadlash: Dreadlash,
+    demonicStrength: DemonicStrength,
     demonicCalling: DemonicCalling,
     grimoireFelguard: GrimoireFelguard,
   };

--- a/src/parser/warlock/demonology/modules/talents/index.js
+++ b/src/parser/warlock/demonology/modules/talents/index.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import Analyzer from 'parser/core/Analyzer';
+
+import StatisticsListBox, { STATISTIC_ORDER } from 'interface/others/StatisticsListBox';
+
+import DemonicCalling from './DemonicCalling';
+import GrimoireFelguard from './GrimoireFelguard';
+
+class TalentStatisticBox extends Analyzer {
+  static dependencies = {
+    demonicCalling: DemonicCalling,
+    grimoireFelguard: GrimoireFelguard,
+  };
+
+  constructor(...args) {
+    super(...args);
+    // active if at least one module is active and has subStatistic()
+    this.active = Object.keys(this.constructor.dependencies)
+      .filter(name => this[name].subStatistic)
+      .map(name => this[name].active)
+      .includes(true);
+  }
+
+  statistic() {
+    return (
+      <StatisticsListBox
+        position={STATISTIC_ORDER.CORE(4)}
+        title="Talents">
+        {
+          Object.keys(this.constructor.dependencies)
+            .map(name => this[name])
+            .filter(module => module.active && module.subStatistic)
+            .map(module => module.subStatistic())
+        }
+      </StatisticsListBox>
+    );
+  }
+}
+
+export default TalentStatisticBox;

--- a/src/parser/warlock/demonology/modules/talents/index.js
+++ b/src/parser/warlock/demonology/modules/talents/index.js
@@ -4,11 +4,13 @@ import Analyzer from 'parser/core/Analyzer';
 
 import StatisticsListBox, { STATISTIC_ORDER } from 'interface/others/StatisticsListBox';
 
+import Dreadlash from './Dreadlash';
 import DemonicCalling from './DemonicCalling';
 import GrimoireFelguard from './GrimoireFelguard';
 
 class TalentStatisticBox extends Analyzer {
   static dependencies = {
+    dreadlash: Dreadlash,
     demonicCalling: DemonicCalling,
     grimoireFelguard: GrimoireFelguard,
   };

--- a/src/parser/warlock/demonology/modules/talents/index.js
+++ b/src/parser/warlock/demonology/modules/talents/index.js
@@ -6,6 +6,7 @@ import StatisticsListBox, { STATISTIC_ORDER } from 'interface/others/StatisticsL
 
 import Dreadlash from './Dreadlash';
 import DemonicStrength from './DemonicStrength';
+import BilescourgeBombers from './BilescourgeBombers';
 import DemonicCalling from './DemonicCalling';
 import GrimoireFelguard from './GrimoireFelguard';
 
@@ -13,6 +14,7 @@ class TalentStatisticBox extends Analyzer {
   static dependencies = {
     dreadlash: Dreadlash,
     demonicStrength: DemonicStrength,
+    bilescourgeBombers: BilescourgeBombers,
     demonicCalling: DemonicCalling,
     grimoireFelguard: GrimoireFelguard,
   };


### PR DESCRIPTION
Overall simple changes:
- added cast efficiency for Bilescourge Bombers talent
- tweaked Checklist a little
  - moved shorter CD abilities to core spells instead of cooldowns

![image](https://user-images.githubusercontent.com/5068584/48569241-76131000-e901-11e8-855f-c525e1bf9ca6.png)

  - added few more CDs

![image](https://user-images.githubusercontent.com/5068584/48569266-80cda500-e901-11e8-84c6-5f181f824bea.png)

  - added description to the first rule
  - fixed the description in ABC rule (was copied from Affli)

![image](https://user-images.githubusercontent.com/5068584/48569289-8b883a00-e901-11e8-8ab5-8a4533c6590b.png)

- cleaned up and fixed Felstorm module (was picking up casts from Demonic Strength as well)
- fixed Demonic Calling module (was counting proc refreshes while the ability was on CD as wasted)
- updated Demonic Calling and Felstorm to the new event listening method
- added T15 talent modules 