### PR TITLE
[Core] Allow array in new event spell filter

### DIFF
--- a/src/parser/core/modules/EventEmitter.js
+++ b/src/parser/core/modules/EventEmitter.js
@@ -113,6 +113,13 @@ class EventEmitter extends Module {
     };
   }
   _prependSpellCheck(listener, spell) {
+    if(spell instanceof Array) {
+      return function(event) {
+        if (event.ability && spell.some(s => s.id === event.ability.guid)) {
+          listener(event);
+        }
+      };
+    }
     const spellId = spell.id;
     return function (event) {
       if (event.ability && event.ability.guid === spellId) {


### PR DESCRIPTION
Not sure if it was intentionally left out. Also was considering adding a way to send either numbers/numbers array instead of only spell objects, but I don't want to mess with the design too much.