### PR TITLE
{VDH} Fixed FTD talent tracking and cleaned up soul code

### DIFF
--- a/src/common/SPELLS/demonhunter.js
+++ b/src/common/SPELLS/demonhunter.js
@@ -221,6 +221,11 @@ export default {
     name: 'Feast of Souls Heal',
     icon: 'spell_shadow_soulleech',
   },
+  CONSUME_SOUL_VDH: {
+    id: 203794,
+    name: 'Consume Soul',
+    icon: 'ability_warlock_improvedsoulleech',
+  },
 
   // Havoc
   //T21 Bonus

--- a/src/parser/demonhunter/vengeance/CHANGELOG.js
+++ b/src/parser/demonhunter/vengeance/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-11-15'),
+    changes: <>Improved tracking of <SpellLink id={SPELLS.FEED_THE_DEMON_TALENT.id} /> talent.</>,
+    contributors: [Yajinni],
+  },
+  {
     date: new Date('2018-08-5'),
     changes: <>Added stat box for <SpellLink id={SPELLS.FEED_THE_DEMON_TALENT.id} /> showing amount of CD reduction it provides.</>,
     contributors: [Yajinni],

--- a/src/parser/demonhunter/vengeance/modules/Abilities.js
+++ b/src/parser/demonhunter/vengeance/modules/Abilities.js
@@ -71,11 +71,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.DEMON_SPIKES,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
-        /* Removing Demon Spikes cooldown as the Feed the Demon talent breaks it when selected
-         * Feed the Demon reduces the cooldown of Demon Spikes by 0.5s for each soul fragment consumed when on CD
-         * So, while I can't figure out a way to track this CD, I'm removing it from cast effiency to not break things or do wrong suggestions
-        */
-        cooldown: !combatant.hasTalent(SPELLS.FEED_THE_DEMON_TALENT.id) ? haste => 20 / (1 + haste) : null,
+        cooldown: haste => 20 / (1 + haste),
         charges: combatant.hasLegs(ITEMS.OBLIVIONS_EMBRACE.id) ? 3 : 2,
         isDefensive: true,
       },

--- a/src/parser/demonhunter/vengeance/modules/features/SoulFragmentsTracker.js
+++ b/src/parser/demonhunter/vengeance/modules/features/SoulFragmentsTracker.js
@@ -20,11 +20,6 @@ class SoulFragmentsTracker extends Analyzer {
       return;
     }
 
-    const old = event.oldStacks;
-    const neww = event.newStacks;
-    console.log("New stacks", neww);
-    console.log("Old stacks", old);
-
     this.currentSouls = event.newStacks;
 
     if (event.oldStacks > MAX_SOUL_FRAGMENTS) {

--- a/src/parser/demonhunter/vengeance/modules/features/SoulFragmentsTracker.js
+++ b/src/parser/demonhunter/vengeance/modules/features/SoulFragmentsTracker.js
@@ -9,18 +9,21 @@ class SoulFragmentsTracker extends Analyzer {
   soulsGenerated = 0;
 
   // souls generated above the maximum 5 that can be held
-  soulsWasted = 0;
+  overcap = 0;
 
   soulsSpent = 0;
   currentSouls = 0;
-
-  soulsConsumedBySpell = [];
 
   on_byPlayer_changebuffstack(event) {
     const spellId = event.ability.guid;
     if (spellId !== SPELLS.SOUL_FRAGMENT_STACK.id) {
       return;
     }
+
+    const old = event.oldStacks;
+    const neww = event.newStacks;
+    console.log("New stacks", neww);
+    console.log("Old stacks", old);
 
     this.currentSouls = event.newStacks;
 
@@ -35,14 +38,14 @@ class SoulFragmentsTracker extends Analyzer {
       this.soulsSpent += spent;
       return;
     }
-    
+
     // souls are being generated
     const gained = event.newStacks - event.oldStacks;
     this.soulsGenerated += gained;
-    
+
     if (event.newStacks > MAX_SOUL_FRAGMENTS) {
       // generating souls above the max
-      this.soulsWasted += (event.newStacks - MAX_SOUL_FRAGMENTS);
+      this.overcap += (event.newStacks - MAX_SOUL_FRAGMENTS);
     }
   }
 }

--- a/src/parser/demonhunter/vengeance/modules/statistics/SoulFragmentsConsume.js
+++ b/src/parser/demonhunter/vengeance/modules/statistics/SoulFragmentsConsume.js
@@ -17,7 +17,7 @@ class SoulFragmentsConsume extends Analyzer {
   };
 
   castTimestamp = undefined;
-  totalSoulsConsumed = 0;
+  totalSoulsConsumedBySpells = 0;
 
   soulsConsumedBySpell = {};
 
@@ -46,7 +46,7 @@ class SoulFragmentsConsume extends Analyzer {
     if (this.castTimestamp !== undefined && (event.timestamp - this.castTimestamp) < REMOVE_STACK_BUFFER) {
       const consumed = event.oldStacks - event.newStacks;
       this.soulsConsumedBySpell[this.trackedSpell].souls += consumed;
-      this.totalSoulsConsumed += consumed;
+      this.totalSoulsConsumedBySpells += consumed;
     }
   }
 
@@ -58,13 +58,12 @@ class SoulFragmentsConsume extends Analyzer {
   }
 
   statistic() {
-    const overcap= this.soulFragmentsTracker.soulsWasted;
-    const soulsByTouch =this.soulFragmentsTracker.soulsGenerated - this.soulFragmentsTracker.currentSouls - this.soulFragmentsTracker.soulsWasted - this.totalSoulsConsumed;
+    const soulsByTouch = this.soulFragmentsTracker.soulsGenerated - this.totalSoulsConsumedBySpells;
     return (
       <StatisticBox
         position={STATISTIC_ORDER.CORE(6)}
         icon={<SpellIcon id={SPELLS.SOUL_FRAGMENT_STACK.id} />}
-        value={`${this.soulFragmentsTracker.soulsGenerated - this.soulFragmentsTracker.currentSouls} Souls`}
+        value={`${this.soulFragmentsTracker.soulsSpent} Souls`}
         label="Consumed"
       >
         <table className="table table-condensed">
@@ -83,7 +82,7 @@ class SoulFragmentsConsume extends Analyzer {
             ))}
             <tr>
               <th>Overcapped</th>
-              <td>{overcap}</td>
+              <td>{this.soulFragmentsTracker.overcap}</td>
             </tr>
             <tr>
               <th>By Touch</th>

--- a/src/parser/demonhunter/vengeance/modules/talents/FeedTheDemon.js
+++ b/src/parser/demonhunter/vengeance/modules/talents/FeedTheDemon.js
@@ -27,9 +27,9 @@ class FeedTheDemon extends Analyzer {
     this.active = this.selectedCombatant.hasTalent(SPELLS.FEED_THE_DEMON_TALENT.id);
   }
 
-  on_byPlayer_removebuffstack(event) {
+  on_byPlayer_heal(event) {
     const spellId = event.ability.guid;
-    if (spellId !== SPELLS.SOUL_FRAGMENT_STACK.id) {
+    if (spellId !== SPELLS.CONSUME_SOUL_VDH.id) {
       return;
     }
     if (!this.selectedCombatant.hasTalent(SPELLS.FEED_THE_DEMON_TALENT.id)){


### PR DESCRIPTION
Improved Feed The Demon soul talent tracking. There is a delay in changing of buff stacks and actually consuming a soul. When consuming a soul thats when the actual reduction for the talent happens. Changed the code to track that so its more accurate. 

Now that i track that and reduce the CD of demon spikes i also updated it int he abilities file.

Also updated some code and values in the soul tracking to make it more clear what its doing.