### PR TITLE
[Fire Mage] Blaster Master Trait

### DIFF
--- a/src/common/SPELLS/mage.js
+++ b/src/common/SPELLS/mage.js
@@ -554,6 +554,16 @@ export default {
     name: 'Galvanizing Spark',
     icon: 'spell_arcane_arcane03',
   },
+  BLASTER_MASTER: {
+    id: 274596,
+    name: 'Blaster Master',
+    icon: 'spell_fire_fireball',
+  },
+  BLASTER_MASTER_BUFF: {
+    id: 274598,
+    name: 'Blaster Master',
+    icon: 'spell_fire_fireball',
+  },
 
   //Tier Sets
   FIRE_MAGE_T20_2SET_BONUS_BUFF: {

--- a/src/parser/mage/fire/CHANGELOG.js
+++ b/src/parser/mage/fire/CHANGELOG.js
@@ -1,8 +1,20 @@
-// import React from 'react';
+import React from 'react';
 
 import { Sharrq } from 'CONTRIBUTORS';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
 
 export default [
+  {
+    date: new Date('2018-11-15'),
+    changes: <>Added support for <SpellLink id={SPELLS.BLASTER_MASTER.id} />.</>,
+    contributors: [Sharrq],
+  },
+  {
+    date: new Date('2018-11-14'),
+    changes: <>Updated the <SpellLink id={SPELLS.HOT_STREAK.id} /> module to fix some incorrect suggestions and make things easier to understand.</>,
+    contributors: [Sharrq],
+  },
   {
     date: new Date('2018-10-11'),
     changes: 'Fixed bug that caused Suggestions to crash',

--- a/src/parser/mage/fire/CHANGELOG.js
+++ b/src/parser/mage/fire/CHANGELOG.js
@@ -16,11 +16,6 @@ export default [
     contributors: [Sharrq],
   },
   {
-    date: new Date('2018-11-14'),
-    changes: 'Updated the Hot Streak module to fix some incorrect suggestions and make things easier to understand.',
-    contributors: [Sharrq],
-  },
-  {
     date: new Date('2018-10-11'),
     changes: 'Fixed bug that caused Suggestions to crash',
     contributors: [Sharrq],

--- a/src/parser/mage/fire/CombatLogParser.js
+++ b/src/parser/mage/fire/CombatLogParser.js
@@ -14,6 +14,8 @@ import Abilities from './modules/features/Abilities';
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
 import CancelledCasts from '../shared/modules/features/CancelledCasts';
 
+import BlasterMaster from './modules/traits/BlasterMaster';
+
 import MirrorImage from '../shared/modules/features/MirrorImage';
 import ArcaneIntellect from '../shared/modules/features/ArcaneIntellect';
 import RuneOfPower from '../shared/modules/features/RuneOfPower';
@@ -52,6 +54,9 @@ class CombatLogParser extends CoreCombatLogParser {
     heatingUp: HeatingUp,
     pyroclasm: Pyroclasm,
     searingTouch: SearingTouch,
+
+    //Traits
+    blasterMaster: BlasterMaster,
 
     // Talents
     mirrorImage: MirrorImage,

--- a/src/parser/mage/fire/modules/traits/BlasterMaster.js
+++ b/src/parser/mage/fire/modules/traits/BlasterMaster.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import AbilityTracker from 'parser/shared/modules/AbilityTracker';
+import { formatNumber } from 'common/format';
+import TraitStatisticBox, { STATISTIC_ORDER } from 'interface/others/TraitStatisticBox';
+import Analyzer from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import { SELECTED_PLAYER } from 'parser/core/EventFilter';
+
+const debug = false;
+
+const TRAIT_STACK_THRESHOLD = 4;
+
+class BlasterMaster extends Analyzer {
+  static dependencies = {
+    abilityTracker: AbilityTracker,
+  };
+
+  lastCombustion = null;
+  stackCount = 0;
+  totalStacks = 0;
+  badCombustion = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrait(SPELLS.BLASTER_MASTER.id);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.COMBUSTION), this.onCombustionCast);
+    this.addEventListener(Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.COMBUSTION), this.onCombustionStart);
+    this.addEventListener(Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.COMBUSTION), this.onCombustionEnd);
+    this.addEventListener(Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.BLASTER_MASTER_BUFF), this.onTraitStack);
+    this.addEventListener(Events.applybuffstack.to(SELECTED_PLAYER).spell(SPELLS.BLASTER_MASTER_BUFF), this.onTraitStack);
+  }
+
+  onCombustionCast(event) {
+    this.lastCombustion = event;
+  }
+
+  onCombustionStart(event) {
+    const buff = this.selectedCombatant.getBuff(SPELLS.BLASTER_MASTER_BUFF.id);
+    if (buff) {
+      this.stackCount = buff.stacks;
+    }
+  }
+
+  onCombustionEnd(event) {
+    if (this.stackCount < TRAIT_STACK_THRESHOLD) {
+      this.badCombustion += 1;
+      this.lastCombustion.meta = this.lastCombustion.meta || {};
+      this.lastCombustion.meta.isInefficientCast = true;
+      this.lastCombustion.meta.inefficientCastReason = `You only got ${this.stackCount} Blaster Master stacks during this Combustion. In order to get the most out of Blaster Master, you should aim to get to 4 stacks of the trait during each Combustion.`;
+    }
+    this.totalStacks += this.stackCount;
+    debug && this.log("Combustion Ended: " + this.stackCount + " stacks");
+  }
+
+  onTraitStack(event) {
+    const buff = this.selectedCombatant.getBuff(SPELLS.BLASTER_MASTER_BUFF.id);
+    if (buff && buff.stacks > this.stackCount) {
+      this.stackCount = buff.stacks;
+      debug && this.log("Gained Blaster Master Stack. " + this.stackCount + " Stacks Total");
+    }
+  }
+
+  get averageStacksPerCombustion() {
+    return this.totalStacks / this.abilityTracker.getAbility(SPELLS.COMBUSTION.id).casts;
+  }
+
+  get averageStackThresholds() {
+    return {
+      actual: this.averageStacksPerCombustion,
+      isLessThan: {
+        minor: 4,
+        average: 3.5,
+        major: 3,
+      },
+      style: 'number',
+    };
+  }
+
+  suggestions(when) {
+    when(this.averageStackThresholds)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<>On average, you got {this.averageStacksPerCombustion.toFixed(2)} stacks of <SpellLink id={SPELLS.BLASTER_MASTER.id} /> per <SpellLink id={SPELLS.COMBUSTION.id} /> cast. In order to maximize the use of the trait, you should aim for getting to 4 stacks each time you use Combustion. For more information on how to adjust your Combustion rotation to make this happen, refer to <a href="https://cdn.discordapp.com/attachments/431912396349636609/511996656829595659/BlasterMaster_Rotation.png" target="_blank" rel="noopener noreferrer">this graphic</a></>)
+          .icon(SPELLS.BLASTER_MASTER.icon)
+          .actual(`${this.averageStacksPerCombustion.toFixed(2)} stacks per Combustion`)
+          .recommended(`<${formatNumber(recommended)}% is recommended`);
+      });
+  }
+
+  statistic() {
+    return (
+      <TraitStatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
+        trait={SPELLS.BLASTER_MASTER.id}
+        value={(<>{this.averageStacksPerCombustion.toFixed(2)} stacks per Combustion<br /></>)}
+        tooltip={
+          `Blaster Master is a somewhat complicated trait to get the full effect from and may involve adjusting your rotation during Combustion. In order to get the most out of this trait, you shoud aim to get to 4 stacks of the Blaster Master during Combustion. For additional information on how to adjust your rotation to accomplish this, refer to the Mage Discord or the link in the Suggestion.`
+        }
+      />
+    );
+  }
+}
+
+export default BlasterMaster;

--- a/src/parser/mage/fire/modules/traits/BlasterMaster.js
+++ b/src/parser/mage/fire/modules/traits/BlasterMaster.js
@@ -93,9 +93,9 @@ class BlasterMaster extends Analyzer {
       <TraitStatisticBox
         position={STATISTIC_ORDER.OPTIONAL()}
         trait={SPELLS.BLASTER_MASTER.id}
-        value={(<>{this.averageStacksPerCombustion.toFixed(2)} stacks per Combustion<br /></>)}
+        value={`${this.averageStacksPerCombustion.toFixed(2)} stacks per Combustion`}
         tooltip={
-          `Blaster Master is a somewhat complicated trait to get the full effect from and may involve adjusting your rotation during Combustion. In order to get the most out of this trait, you shoud aim to get to 4 stacks of the Blaster Master during Combustion. For additional information on how to adjust your rotation to accomplish this, refer to the Mage Discord or the link in the Suggestion.`
+          `Blaster Master is a somewhat complicated trait to get the full effect from and may involve adjusting your rotation during Combustion. In order to get the most out of this trait, you should aim to get to 4 stacks of the Blaster Master during Combustion. For additional information on how to accomplish this, refer to the Mage Discord or the link in the Suggestion.`
         }
       />
     );

--- a/src/parser/mage/fire/modules/traits/BlasterMaster.js
+++ b/src/parser/mage/fire/modules/traits/BlasterMaster.js
@@ -71,8 +71,8 @@ class BlasterMaster extends Analyzer {
       actual: this.averageStacksPerCombustion,
       isLessThan: {
         minor: 4,
-        average: 3.5,
-        major: 3,
+        average: 3,
+        major: 2,
       },
       style: 'number',
     };
@@ -84,7 +84,7 @@ class BlasterMaster extends Analyzer {
         return suggest(<>On average, you got {this.averageStacksPerCombustion.toFixed(2)} stacks of <SpellLink id={SPELLS.BLASTER_MASTER.id} /> per <SpellLink id={SPELLS.COMBUSTION.id} /> cast. In order to maximize the use of the trait, you should aim for getting to 4 stacks each time you use Combustion. For more information on how to adjust your Combustion rotation to make this happen, refer to <a href="https://cdn.discordapp.com/attachments/431912396349636609/511996656829595659/BlasterMaster_Rotation.png" target="_blank" rel="noopener noreferrer">this graphic</a></>)
           .icon(SPELLS.BLASTER_MASTER.icon)
           .actual(`${this.averageStacksPerCombustion.toFixed(2)} stacks per Combustion`)
-          .recommended(`<${formatNumber(recommended)}% is recommended`);
+          .recommended(`${formatNumber(recommended)} is recommended`);
       });
   }
 


### PR DESCRIPTION
Added support for the Blaster Master Trait. Keeps track of the max number of stacks you got to during Combustion.

Suggestion
![image](https://user-images.githubusercontent.com/1304554/48599110-e767b880-e92b-11e8-88ec-870c61afd890.png)

Timeline
![image](https://user-images.githubusercontent.com/1304554/48599122-f8182e80-e92b-11e8-9eb5-24286171c6c2.png)

Stat Box
![image](https://user-images.githubusercontent.com/1304554/48599143-0f571c00-e92c-11e8-8f28-502dec6468eb.png)
