### PR TITLE
[Restoration Shaman] EWT crash fix

### DIFF
--- a/src/parser/shaman/restoration/modules/talents/EarthenWallTotem.js
+++ b/src/parser/shaman/restoration/modules/talents/EarthenWallTotem.js
@@ -54,7 +54,7 @@ class EarthenWallTotem extends Analyzer {
     if (this.prePullCast) {
       this.earthenWallTotems[this.castNumber] = {
         potentialHealing: event.maxHitPoints, // this is taking the totems max HP, which is the same result as the players unless Mag'har Orc
-        effectiveHealing: 0,
+        effectiveHealing: this.earthenWallTotems[this.castNumber].effectiveHealing || 0,
         timestamp: this.owner.fight.start_time,
       };
       this.prePullCast = false;
@@ -73,6 +73,12 @@ class EarthenWallTotem extends Analyzer {
     const combatant = this.combatants.players[event.targetID];
     if (!combatant) {
       return;
+    }
+    // Prepull EWT casts will have absorb events first, but those don't have any health information
+    if(!this.earthenWallTotems[this.castNumber]) {
+      this.earthenWallTotems[this.castNumber] = {
+        effectiveHealing: 0,
+      };
     }
     this.earthenWallTotems[this.castNumber].effectiveHealing += event.amount;
   }


### PR DESCRIPTION
Casting a EWT pre-pull was causing it to crash, since I didn't account for it starting with absorb events, not damage taken events (absorb events don't have max-health information). This fix creates an array if there is none, until the damage taken events come in and fully initializes it.

Failing log: https://wowanalyzer.com/report/RXWCm7BZMjPb4K6c/7-Mythic+G'huun+-+Kill+(8:48)/3-Maeveycakes