### PR TITLE
Show cancelled casts on the timeline

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -9,6 +9,11 @@ import Contributor from 'interface/contributor/Button';
 
 export default [
   {
+    date: new Date('2018-11-16'),
+    changes: 'Added cancelled casts to the timeline.',
+    contributors: [niseko],
+  },
+  {
     date: new Date('2018-11-14'),
     changes: <>Added <SpellLink id={SPELLS.GIFT_OF_THE_NAARU_MAGE.id} /> to ability list.</>,
     contributors: [Dambroda],

--- a/src/parser/shared/modules/features/TimelineTab/TabComponent/SpellRow.js
+++ b/src/parser/shared/modules/features/TimelineTab/TabComponent/SpellRow.js
@@ -95,6 +95,28 @@ class SpellRow extends React.PureComponent {
               </div>
             );
           }
+          if (event.type === 'begincast' && event.isCancelled) {
+            const top = buffEvents ? 1 : -1;
+            const height = 22; // only used if buffEvents
+            const offset = 6 * secondWidth; // moving the cast slightly so it doesn't get fully covered up
+            return (
+              <div
+                key={index}
+                style={{
+                  left: (event.timestamp + offset - start) / 1000 * secondWidth,
+                  top, // without this, icon vertical positioning slightly off...
+                  zIndex: 8,
+                }}
+              >
+                <SpellIcon
+                  id={event.ability.guid}
+                  className={'cancelled'}
+                  data-tip={`This ${event.ability.name} cast was cancelled`}
+                  style={buffEvents ? { height } : {}}
+                />
+              </div>
+            );
+          }
           if (showCooldowns && event.type === 'updatespellusable' && (event.trigger === 'endcooldown' || event.trigger === 'restorecharge')) {
             const left = (event.start - start) / 1000 * secondWidth;
             const maxWidth = totalWidth - left; // don't expand beyond the container width

--- a/src/parser/shared/modules/features/TimelineTab/TabComponent/SpellTimeline.css
+++ b/src/parser/shared/modules/features/TimelineTab/TabComponent/SpellTimeline.css
@@ -98,7 +98,11 @@
   box-shadow: 0 0 11px red;
   border-radius: 2px;
 }
-
+.spell-timeline .events .cancelled {
+  box-sizing: content-box;
+  filter: grayscale(100%);
+  box-shadow: 0 0 11px grey;
+}
 .spell-timeline .events .enhanced {
   border: 2px solid rgb(226, 226, 226);
   box-sizing: content-box;


### PR DESCRIPTION
Seeing cancelled casts can explain a lot of gaps in the timeline without having to dig deeper. I'm offsetting it slightly because a cast finish into a failed cast would fully cover up the icon otherwise.

![image](https://user-images.githubusercontent.com/2842471/48624330-67cdfe00-e9ac-11e8-8fbc-a19d2499fad8.png)
![image](https://user-images.githubusercontent.com/2842471/48624446-b4b1d480-e9ac-11e8-8198-cadf65a9ff69.png)
![image](https://user-images.githubusercontent.com/2842471/48624532-eaef5400-e9ac-11e8-8e76-517fcae231e4.png)
https://www.warcraftlogs.com/reports/RXWCm7BZMjPb4K6c/#fight=7