### PR TITLE
[Trinket] Add missing Dread Gladiator's Medallion on use ability

### DIFF
--- a/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsMedallion.js
+++ b/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsMedallion.js
@@ -5,12 +5,16 @@ import ITEMS from 'common/ITEMS/index';
 import Analyzer from 'parser/core/Analyzer';
 import { formatPercentage, formatNumber } from 'common/format';
 import { calculateSecondaryStatDefault } from 'common/stats';
+import Abilities from 'parser/shared/modules/Abilities';
 
 /**
  * Dread Gladiator's Medallion -
  * Use: Increases Versatility by 429 for 20 sec. (2 Min Cooldown)
  */
 class DreadGladiatorsMedallion extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+  };
   statBuff = 0;
 
   constructor(...args) {
@@ -19,6 +23,16 @@ class DreadGladiatorsMedallion extends Analyzer {
 
     if(this.active) {
       this.statBuff = calculateSecondaryStatDefault(300, 576, this.selectedCombatant.getItem(ITEMS.DREAD_GLADIATORS_MEDALLION.id).itemLevel);
+      this.abilities.add({
+        spell: SPELLS.RAPID_ADAPTATION,
+        buffSpellId: SPELLS.RAPID_ADAPTATION.id,
+        name: ITEMS.DREAD_GLADIATORS_MEDALLION.name,
+        category: Abilities.SPELL_CATEGORIES.ITEMS,
+        cooldown: 120,
+        castEfficiency: {
+          suggestion: true,
+        },
+      });
     }
   }
 


### PR DESCRIPTION
Noticed that it is missing from the module

![image](https://user-images.githubusercontent.com/2842471/48625008-466e1180-e9ae-11e8-9a8b-ce5a5eefea33.png)
https://www.warcraftlogs.com/reports/RH8mJB7NgwDzth2k#fight=46&type=summary&source=3