### PR TITLE
[Demonology] Tier 90 talents + minor fixes

### DIFF
--- a/src/common/SPELLS/others.js
+++ b/src/common/SPELLS/others.js
@@ -629,6 +629,11 @@ export default {
     name: 'Rising Tides',
     icon: 'inv_7_0raid_trinket_04a',
   },
+  VANQUISHED_TENDRIL_OF_GHUUN_SUMMON: {
+    id: 278163,
+    name: 'Vanquished Tendril of G\'huun',
+    icon: 'achievement_nazmir_boss_ghuun',
+  },
   // Engine of Eradication buff
   DEMONIC_VIGOR: {
     id: 242612,

--- a/src/parser/warlock/demonology/CHANGELOG.js
+++ b/src/parser/warlock/demonology/CHANGELOG.js
@@ -6,6 +6,11 @@ import SPELLS from 'common/SPELLS';
 
 export default [
   {
+    date: new Date('2018-11-16'),
+    changes: <>Added <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /> and <SpellLink id={SPELLS.INNER_DEMONS_TALENT.id} /> modules. Fixed the Pet Timeline if it encounters an unknown pet.</>,
+    contributors: [Chizu],
+  },
+  {
     date: new Date('2018-11-12'),
     changes: 'Certain buffs or debuffs now show in timeline.',
     contributors: [Chizu],

--- a/src/parser/warlock/demonology/CombatLogParser.js
+++ b/src/parser/warlock/demonology/CombatLogParser.js
@@ -20,6 +20,7 @@ import PrepullPetNormalizer from './modules/pets/normalizers/PrepullPetNormalize
 import PowerSiphonNormalizer from './modules/talents/normalizers/PowerSiphonNormalizer';
 
 import DemonicCalling from './modules/talents/DemonicCalling';
+import SoulConduit from './modules/talents/SoulConduit';
 import GrimoireFelguard from './modules/talents/GrimoireFelguard';
 
 class CombatLogParser extends CoreCombatLogParser {
@@ -47,6 +48,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Talents
     demonicCalling: DemonicCalling,
+    soulConduit: SoulConduit,
     grimoireFelguard: GrimoireFelguard,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown

--- a/src/parser/warlock/demonology/CombatLogParser.js
+++ b/src/parser/warlock/demonology/CombatLogParser.js
@@ -21,6 +21,7 @@ import PowerSiphonNormalizer from './modules/talents/normalizers/PowerSiphonNorm
 
 import DemonicCalling from './modules/talents/DemonicCalling';
 import SoulConduit from './modules/talents/SoulConduit';
+import InnerDemons from './modules/talents/InnerDemons';
 import GrimoireFelguard from './modules/talents/GrimoireFelguard';
 
 class CombatLogParser extends CoreCombatLogParser {
@@ -49,6 +50,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Talents
     demonicCalling: DemonicCalling,
     soulConduit: SoulConduit,
+    innerDemons: InnerDemons,
     grimoireFelguard: GrimoireFelguard,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown

--- a/src/parser/warlock/demonology/modules/pets/CONSTANTS.js
+++ b/src/parser/warlock/demonology/modules/pets/CONSTANTS.js
@@ -109,3 +109,17 @@ export const PERMANENT_PET_ABILITIES_TO_SUMMON_MAP = {
   [SPELLS.FELGUARD_LEGION_STRIKE.id]: SPELLS.SUMMON_FELGUARD.id,
   [SPELLS.FELSTORM_BUFF.id]: SPELLS.SUMMON_FELGUARD.id,
 };
+
+// random pets that can be summoned from Inner Demons/Nether Portal. Does NOT include Wild Imps summoned by Inner Demons, those are not random
+export const RANDOM_PET_GUIDS = [
+  PETS.BILESCOURGE.guid,
+  PETS.VICIOUS_HELLHOUND.guid,
+  PETS.SHIVARRA.guid,
+  PETS.DARKHOUND.guid,
+  PETS.ILLIDARI_SATYR.guid,
+  PETS.VOID_TERROR.guid,
+  PETS.URZUL.guid,
+  PETS.WRATHGUARD.guid,
+  PETS.EYE_OF_GULDAN.guid,
+  PETS.PRINCE_MALCHEZAAR.guid,
+];

--- a/src/parser/warlock/demonology/modules/pets/DemoPets.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets.js
@@ -233,15 +233,16 @@ class DemoPets extends Analyzer {
     return this._getPets();
   }
 
-  getPetDamage(id, isGuid = true) {
+  getPetDamage(id, instance = null, isGuid = true) {
+    // if instance = null, returns total damage from all instances, otherwise from a specific instance
     // isGuid = true, because it's more convenient to call this with getPetDamage(PETS.SOME_PET.guid)
     // because you know what you're looking for (pet IDs change, GUIDs don't)
     const guid = isGuid ? id : this._toGuid(id);
-    if (!this.damage.hasEntry(guid)) {
+    if (!this.damage.hasEntry(guid, instance)) {
       debug && this.error(`this.getPetDamage() called with nonexistant ${isGuid ? 'gu' : ''}id ${id}`);
       return 0;
     }
-    return this.damage.getDamageForGuid(guid);
+    return this.damage.getDamageForGuid(guid, instance);
   }
 
   get permanentPetDamage() {

--- a/src/parser/warlock/demonology/modules/pets/PetDamage.js
+++ b/src/parser/warlock/demonology/modules/pets/PetDamage.js
@@ -19,14 +19,17 @@ class PetDamage {
     this.pets[petInfo.guid].total += amount;
   }
 
-  getDamageForGuid(guid) {
-    return Object.values(this.pets[guid].instances).reduce((total, current) => total + current, 0);
+  getDamageForGuid(guid, instance) {
+    if (instance === null) {
+      return this.pets[guid].total;
+    }
+    return this.pets[guid].instances[instance];
   }
 
   get permanentPetDamage() {
     return Object.keys(this.pets)
       .filter(guid => isPermanentPet(guid))
-      .map(guid => this.getDamageForGuid(guid))
+      .map(guid => this.getDamageForGuid(guid, null))
       .reduce((total, current) => total + current, 0);
   }
 
@@ -35,8 +38,11 @@ class PetDamage {
     this.pets[guid].instances[instance] = this.pets[guid].instances[instance] || 0;
   }
 
-  hasEntry(guid) {
-    return !!this.pets[guid];
+  hasEntry(guid, instance) {
+    if (instance === null) {
+      return !!this.pets[guid];
+    }
+    return this.pets[guid] && this.pets[guid].instances[instance] !== undefined;
   }
 }
 

--- a/src/parser/warlock/demonology/modules/pets/PetTimelineTab/TabComponent/PetRow.js
+++ b/src/parser/warlock/demonology/modules/pets/PetTimelineTab/TabComponent/PetRow.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
+import Icon from 'common/Icon';
 
 class PetRow extends React.PureComponent {
   static propTypes = {
@@ -21,6 +23,7 @@ class PetRow extends React.PureComponent {
           const barLeft = (pet.spawn - start) / 1000 * secondWidth;
           const maxWidth = totalWidth - barLeft; // don't expand beyond the container width
           const width = Math.min(maxWidth, ((pet.realDespawn || pet.expectedDespawn) - pet.spawn) / 1000 * secondWidth);
+          const isSummonAbilityKnown = !!SPELLS[pet.summonAbility];
           return (
             <>
               <div
@@ -31,11 +34,19 @@ class PetRow extends React.PureComponent {
                   zIndex: 10,
                 }}
               >
-                <SpellIcon
-                  id={pet.summonAbility}
-                  className={pet.meta.iconClass}
-                  data-tip={pet.meta.tooltip}
-                />
+                {isSummonAbilityKnown && (
+                  <SpellIcon
+                    id={pet.summonAbility}
+                    className={pet.meta.iconClass}
+                    data-tip={pet.meta.tooltip}
+                  />
+                )}
+                {!isSummonAbilityKnown && (
+                  <Icon
+                    icon="inv_misc_questionmark"
+                    data-tip={pet.name}
+                  />
+                )}
               </div>
               <div
                 key={`${index}-duration`}

--- a/src/parser/warlock/demonology/modules/pets/PetTimelineTab/TabComponent/PetTimeline.js
+++ b/src/parser/warlock/demonology/modules/pets/PetTimelineTab/TabComponent/PetTimeline.js
@@ -10,6 +10,7 @@ import DeathEvents from 'parser/shared/modules/features/TimelineTab/TabComponent
 import { formatDuration } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
+import Icon from 'common/Icon';
 
 import PetRow from './PetRow';
 import KeyCastsRow from './KeyCastsRow';
@@ -206,7 +207,12 @@ class PetTimeline extends React.PureComponent {
           </div>
           {Object.keys(pets).map(spellId => (
             <div className="lane" key={spellId}>
-              <SpellLink id={Number(spellId)} />
+              {spellId !== 'unknown' && <SpellLink id={Number(spellId)} />}
+              {spellId === 'unknown' && (
+                <>
+                  <Icon icon="inv_misc_questionmark" /> Unknown pet
+                </>
+              )}
             </div>
           ))}
         </div>

--- a/src/parser/warlock/demonology/modules/pets/Timeline.js
+++ b/src/parser/warlock/demonology/modules/pets/Timeline.js
@@ -17,6 +17,11 @@ class Timeline {
     return this.timeline.find(filter);
   }
 
+  filter(predicate) {
+    // forward
+    return this.timeline.filter(predicate);
+  }
+
   tryDespawnLastPermanentPet(timestamp) {
     const permanentPets = this.timeline.filter(pet => isPermanentPet(pet.guid));
     if (permanentPets.length > 0) {

--- a/src/parser/warlock/demonology/modules/pets/Timeline.js
+++ b/src/parser/warlock/demonology/modules/pets/Timeline.js
@@ -36,8 +36,9 @@ class Timeline {
 
   groupPetsBySummonAbility() {
     return this.timeline.reduce((obj, pet) => {
-      const key = pet.summonedBy || 'unknown';
-      const spellName = pet.summonedBy ? SPELLS[pet.summonedBy].name : 'unknown';
+      // if pet is summoned by unknown spell, it gets summonedBy = -1
+      const key = pet.summonedBy !== -1 ? pet.summonedBy : 'unknown';
+      const spellName = (SPELLS[pet.summonedBy] && SPELLS[pet.summonedBy].name) || 'unknown';
       obj[key] = obj[key] || { spellName, pets: [] };
       obj[key].pets.push(pet);
       return obj;

--- a/src/parser/warlock/demonology/modules/pets/Timeline.js
+++ b/src/parser/warlock/demonology/modules/pets/Timeline.js
@@ -2,6 +2,7 @@ import SPELLS from 'common/SPELLS';
 
 import { DESPAWN_REASONS } from './TimelinePet';
 import { isPermanentPet } from './helpers';
+import PETS from './PETS';
 
 const debug = false;
 
@@ -31,7 +32,9 @@ class Timeline {
   }
 
   getPetsAtTimestamp(timestamp) {
-    return this.timeline.filter(pet => pet.spawn <= timestamp && timestamp <= (pet.realDespawn || pet.expectedDespawn));
+    // Warlock pet check so this doesn't pick up things like Vanquished Tendrils of G'huun (trinket, spawns a pet that timeline picks up)
+    return this.timeline.filter(pet => this._isWarlockPet(pet.guid) &&
+      pet.spawn <= timestamp && timestamp <= (pet.realDespawn || pet.expectedDespawn));
   }
 
   groupPetsBySummonAbility() {
@@ -43,6 +46,10 @@ class Timeline {
       obj[key].pets.push(pet);
       return obj;
     }, {});
+  }
+
+  _isWarlockPet(guid) {
+    return isPermanentPet(guid) || !!PETS[guid];
   }
 }
 

--- a/src/parser/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.js
+++ b/src/parser/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.js
@@ -44,13 +44,17 @@ class PrepullPetNormalizer extends EventsNormalizer {
           let spell;
           if (this._verifyPermanentPet(petId)) {
             if (!PERMANENT_PET_ABILITIES_TO_SUMMON_MAP[event.ability.guid]) {
-              debug && console.log(`(${this.owner.formatTimestamp(event.timestamp, 3)}) ERROR - unknown ability`, event);
+              debug && console.error(`(${this.owner.formatTimestamp(event.timestamp, 3)}) ERROR - unknown ability`, event);
               continue;
             }
             spell = SPELLS[PERMANENT_PET_ABILITIES_TO_SUMMON_MAP[event.ability.guid]];
           }
           else {
             const guid = this._getPetGuid(petId);
+            if (!PET_GUID_TO_SUMMON_ABILITY_MAP[guid]) {
+              debug && console.error(`(${this.owner.formatTimestamp(event.timestamp, 3)}) ERROR - unknown pet`, event);
+              continue;
+            }
             spell = SPELLS[PET_GUID_TO_SUMMON_ABILITY_MAP[guid]];
           }
           const fabricatedEvent = {

--- a/src/parser/warlock/demonology/modules/talents/InnerDemons.js
+++ b/src/parser/warlock/demonology/modules/talents/InnerDemons.js
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import Analyzer from 'parser/core/Analyzer';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import { formatThousands } from 'common/format';
+
+import StatisticBox from 'interface/others/StatisticBox';
+
+import DemoPets from '../pets/DemoPets';
+import PETS from '../pets/PETS';
+import { RANDOM_PET_GUIDS } from '../pets/CONSTANTS';
+
+class InnerDemons extends Analyzer {
+  static dependencies = {
+    demoPets: DemoPets,
+  };
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.INNER_DEMONS_TALENT.id);
+  }
+
+  get damage() {
+    const wildImps = this.demoPets.getPetDamage(PETS.WILD_IMP_INNER_DEMONS.guid);
+    const otherPetsSummonedByID = this.demoPets.timeline.filter(pet => RANDOM_PET_GUIDS.includes(pet.guid) && pet.summonedBy === SPELLS.INNER_DEMONS_TALENT.id);
+    const other = otherPetsSummonedByID
+      .map(pet => this.demoPets.getPetDamage(pet.guid, pet.instance))
+      .reduce((total, current) => total + current, 0);
+    return wildImps + other;
+  }
+
+  // count Imposion damage? not technically Inner Demon damage though..
+  statistic() {
+    const damage = this.damage;
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.INNER_DEMONS_TALENT.id} />}
+        value={formatThousands(damage)}
+        label="Damage from Inner Demons pets"
+        tooltip={`${this.owner.formatItemDamageDone(damage)}<br />
+                  Note that this only counts the direct damage from them, not Implosion damage (if used) from Wild Imps`}
+      />
+    );
+  }
+}
+
+export default InnerDemons;

--- a/src/parser/warlock/demonology/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/demonology/modules/talents/SoulConduit.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import Analyzer from 'parser/core/Analyzer';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+
+import StatisticBox from 'interface/others/StatisticBox';
+
+import SoulShardTracker from '../soulshards/SoulShardTracker';
+
+class SoulConduit extends Analyzer {
+  static dependencies = {
+    soulShardTracker: SoulShardTracker,
+  };
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.SOUL_CONDUIT_TALENT.id);
+  }
+
+  // TODO: damage estimate using average damage from HOG + their imps, Dreadstalkers and Vilefiend or Grimoire?
+  statistic() {
+    const generated = this.soulShardTracker.getGeneratedBySpell(SPELLS.SOUL_CONDUIT_SHARD_GEN.id);
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.SOUL_CONDUIT_TALENT.id} />}
+        value={generated}
+        label="Shards generated with Soul Conduit"
+      />
+    );
+  }
+}
+
+export default SoulConduit;


### PR DESCRIPTION
Adds Soul Conduit and Inner Demons talent modules. I'm aware of few comments that shouldn't really be there but after all these PRs get merged, I still have to rework them into StatisticListBoxItems anyway, so then I can remove or implement them.

This PR should also fix situations when PetTimeline (and DemoPets) encounters an unknown pet. Should render like this:

![image](https://user-images.githubusercontent.com/5068584/48628646-fdbb5600-e9b7-11e8-90ad-758300b4a9e3.png)

Tooltip loads because I added the ability from `summon` event to SPELLS. If it doesn't exist in SPELLS, it shows the name (which is found in `parser.playerPets`, so regardless of our actions) in tooltip and shows same "?" icon.