### PR TITLE
Fix issue where fabricated events had wonky event order

### DIFF
--- a/src/parser/core/modules/EventEmitter.js
+++ b/src/parser/core/modules/EventEmitter.js
@@ -174,9 +174,17 @@ class EventEmitter extends Module {
     // Some modules need to have a primitive value to cause re-renders
     // TODO: This can probably be removed since we only render upon completion now
     this.owner.eventCount += 1;
+
+    if (this._finally) {
+      const currentBatch = this._finally;
+      this._finally = null;
+      currentBatch.forEach(item => item());
+    }
+
+    return event;
   }
   fabricateEvent(event, trigger = null) {
-    this.triggerEvent({
+    const fabricatedEvent = {
       // When no timestamp is provided in the event (you should always try to), the current timestamp will be used by default.
       timestamp: this.owner.currentTimestamp,
       // If this event was triggered you should pass it along
@@ -184,13 +192,23 @@ class EventEmitter extends Module {
       ...event,
       type: event.type instanceof EventFilter ? event.type.eventType : event.type,
       __fabricated: true,
+    };
+    this.finally(() => {
+      this.triggerEvent(fabricatedEvent);
     });
+    return fabricatedEvent;
   }
   _validateEvent(event) {
     if (!event.type) {
       console.log(event);
       throw new Error('Events should have a type. No type received. See the console for the event.');
     }
+  }
+
+  _finally = null;
+  finally(func) {
+    this._finally = this._finally || [];
+    this._finally.push(func);
   }
 }
 

--- a/src/parser/core/modules/EventEmitter.js
+++ b/src/parser/core/modules/EventEmitter.js
@@ -175,13 +175,22 @@ class EventEmitter extends Module {
     // TODO: This can probably be removed since we only render upon completion now
     this.owner.eventCount += 1;
 
+    this.runFinally();
+
+    return event;
+  }
+  _finally = null;
+  finally(func) {
+    this._finally = this._finally || [];
+    this._finally.push(func);
+  }
+  runFinally() {
     if (this._finally) {
       const currentBatch = this._finally;
+      // Reset before running so if an item calls another event, it doesn't do the same finally multiple times
       this._finally = null;
       currentBatch.forEach(item => item());
     }
-
-    return event;
   }
   fabricateEvent(event, trigger = null) {
     const fabricatedEvent = {
@@ -203,12 +212,6 @@ class EventEmitter extends Module {
       console.log(event);
       throw new Error('Events should have a type. No type received. See the console for the event.');
     }
-  }
-
-  _finally = null;
-  finally(func) {
-    this._finally = this._finally || [];
-    this._finally.push(func);
   }
 }
 

--- a/src/parser/core/modules/EventEmitter.test.js
+++ b/src/parser/core/modules/EventEmitter.test.js
@@ -3,7 +3,6 @@ import TestCombatLogParser from 'parser/core/tests/TestCombatLogParser';
 import EventEmitter from './EventEmitter';
 
 describe('Core/EventEmitter', () => {
-  const ACTIVE_MODULE = { active: true };
   let parser;
   let eventEmitter;
   beforeEach(() => {
@@ -15,16 +14,10 @@ describe('Core/EventEmitter', () => {
       const timestamp = 421098;
       parser.currentTimestamp = timestamp;
 
-      expect.assertions(1);
-      return new Promise((resolve, reject) => {
-        eventEmitter.addEventListener(EventEmitter.catchAll, event => {
-          expect(event.timestamp).toBe(timestamp);
-          resolve();
-        }, ACTIVE_MODULE);
-        eventEmitter.fabricateEvent({
-          type: 'test',
-        });
+      const fabricatedEvent = eventEmitter.fabricateEvent({
+        type: 'test',
       });
+      expect(fabricatedEvent.timestamp).toBe(timestamp);
     });
   });
 });


### PR DESCRIPTION
Old situation:
```
1. cast event handled 
  1.1 some module called early: ohh nice cast event! let me fabricate something
       -> fabricated event handled completely
  1.2 cast event called on the rest of the listeners
2. next event
```
New situation:
```
1. cast event handled 
  1.1 some module called early: ohh nice cast event! let me fabricate something
       -> fabricated event queued
  1.2 cast event called on the rest of the listeners
2. fabricated event
3. next event
```

It's beautiful in its own way.