### PR TITLE
[Restoration Shaman] Checklist improvements

### DIFF
--- a/src/parser/shaman/restoration/modules/features/checklist/Component.js
+++ b/src/parser/shaman/restoration/modules/features/checklist/Component.js
@@ -88,10 +88,17 @@ class RestoShamanChecklist extends React.PureComponent {
           name="Target AOE spells effectively"
           description="As a resto shaman our core AOE spells rely on not just who we target but where they are on the ground to maximize healing potential. You should plan you AOE spells ahead of time in preparation for where you expect raid members to be for the spells duration."
         >
-          <Requirement name={(<>Average <SpellLink id={SPELLS.CHAIN_HEAL.id} /> targets</>)} thresholds={thresholds.chainHealTargetThresholds} />
-          <Requirement name={(<>Average <SpellLink id={SPELLS.HEALING_RAIN_HEAL.id} /> targets</>)} thresholds={thresholds.healingRainTargetThreshold} />
+          {thresholds.chainHealTargetThresholds.actual > 0 && (
+            <Requirement name={(<>Average <SpellLink id={SPELLS.CHAIN_HEAL.id} /> targets</>)} thresholds={thresholds.chainHealTargetThresholds} />
+          )}
+          {thresholds.healingRainTargetThreshold.actual > 0 && (
+            <Requirement name={(<>Average <SpellLink id={SPELLS.HEALING_RAIN_HEAL.id} /> targets</>)} thresholds={thresholds.healingRainTargetThreshold} />
+          )}
           {combatant.hasTalent(SPELLS.WELLSPRING_TALENT.id) && (
             <Requirement name={(<>Average <SpellLink id={SPELLS.WELLSPRING_TALENT.id} /> efficiency</>)} thresholds={thresholds.wellspringTargetThreshold} />
+          )}
+          {combatant.hasTalent(SPELLS.EARTHEN_WALL_TOTEM_TALENT.id) && (
+            <Requirement name={(<>Average <SpellLink id={SPELLS.EARTHEN_WALL_TOTEM_TALENT.id} /> efficiency</>)} thresholds={thresholds.ewtTargetThreshold} />
           )}
         </Rule>
         <Rule

--- a/src/parser/shaman/restoration/modules/features/checklist/Module.js
+++ b/src/parser/shaman/restoration/modules/features/checklist/Module.js
@@ -11,6 +11,7 @@ import TidalWaves from '../TidalWaves';
 import ChainHeal from '../../spells/ChainHeal';
 import HealingRain from '../../spells/HealingRain';
 import Wellspring from '../../talents/Wellspring';
+import EarthenWallTotem from '../../talents/EarthenWallTotem';
 import HealingSurge from '../../spells/HealingSurge';
 import HealingWave from '../../spells/HealingWave';
 
@@ -27,6 +28,7 @@ class Checklist extends BaseChecklist {
     chainHeal: ChainHeal,
     healingRain: HealingRain,
     wellspring: Wellspring,
+    earthenWallTotem: EarthenWallTotem,
     healingSurge: HealingSurge,
     healingWave: HealingWave,
   };
@@ -47,6 +49,7 @@ class Checklist extends BaseChecklist {
           chainHealTargetThresholds: this.chainHeal.suggestionThreshold,
           healingRainTargetThreshold: this.healingRain.suggestionThreshold,
           wellspringTargetThreshold: this.wellspring.suggestionThreshold,
+          ewtTargetThreshold: this.earthenWallTotem.suggestionThreshold,
           manaLeft: this.manaValues.suggestionThresholds,
         }}
       />

--- a/src/parser/shaman/restoration/modules/talents/EarthenWallTotem.js
+++ b/src/parser/shaman/restoration/modules/talents/EarthenWallTotem.js
@@ -106,6 +106,18 @@ class EarthenWallTotem extends Analyzer {
       });
   }
 
+  get suggestionThreshold() {
+    return {
+      actual: this.earthenWallEfficiency,
+      isLessThan: {
+        minor: 0.75,
+        average: 0.6,
+        major: 0.5,
+      },
+      style: 'percentage',
+    };
+  }
+
   statistic() {
     const casts = this.earthenWallTotems.filter((cast => cast.timestamp > 0)).length;
     const nth = (number) => ["st", "nd", "rd"][((number + 90) % 100 - 10) % 10 - 1] || "th";


### PR DESCRIPTION
Hides base AoE spells that aren't casted for the target thresholds and adds Earthen Wall Totem to it.

Before
![image](https://user-images.githubusercontent.com/2842471/48689963-f91bbb00-ebcc-11e8-903c-690941068390.png)
After
![image](https://user-images.githubusercontent.com/2842471/48689973-fe790580-ebcc-11e8-9d77-c8643e3d9c66.png)
https://www.warcraftlogs.com/reports/RH8mJB7NgwDzth2k/#fight=26&source=3