### PR TITLE
[(Frost) Mage] Moved Arcane Intellect rules & change how Bone Chilling is analyzed

### DIFF
--- a/src/common/SPELLS/mage.js
+++ b/src/common/SPELLS/mage.js
@@ -115,32 +115,32 @@ export default {
     id: 28271,
     name: 'Polymorph',
     icon: 'ability_hunter_pet_turtle',
-  }, 
+  },
   POLYMORPH_TURKEY: {
     id: 61780,
     name: 'Polymorph',
     icon: 'achievement_worldevent_thanksgiving',
-  }, 
+  },
   POLYMORPH_PENGUIN: {
     id: 161355,
     name: 'Polymorph',
     icon: 'inv_misc_penguinpet',
-  }, 
+  },
   POLYMORPH_BUMBLEBEE: {
     id: 277792,
     name: 'Polymorph',
     icon: 'inv_bee_default',
-  }, 
+  },
   POLYMORPH_PEACOCK: {
     id: 161372,
     name: 'Polymorph',
     icon: 'inv_pet_peacock_gold',
-  }, 
+  },
   POLYMORPH_DIREHORN: {
     id: 277787,
     name: 'Polymorph',
     icon: 'inv_pet_direhorn',
-  }, 
+  },
 
 
   //Frost
@@ -526,6 +526,11 @@ export default {
   //Azerite Traits
   GLACIAL_ASSAULT: {
     id: 279855,
+    name: 'Glacial Assault',
+    icon: 'spell_mage_cometstorm2',
+  },
+  GLACIAL_ASSAULT_DAMAGE: {
+    id: 279856,
     name: 'Glacial Assault',
     icon: 'spell_mage_cometstorm2',
   },

--- a/src/parser/mage/fire/modules/Checklist/Component.js
+++ b/src/parser/mage/fire/modules/Checklist/Component.js
@@ -95,18 +95,10 @@ class FireMageChecklist extends React.PureComponent {
           <Requirement name="Downtime" thresholds={thresholds.downtimeSuggestionThresholds} />
           <Requirement name="Cancelled Casts" thresholds={thresholds.cancelledCasts} />
         </Rule>
-        <Rule
-          name="Maintain your buffs"
-          description={(
-            <>
-              You should ensure that you maintain <SpellLink id={SPELLS.ARCANE_INTELLECT.id} /> for the entire fight and recast it whenever you are ressurected and likewise, if you have the appropriate classes/specs in your group you should also ensure that you maintain their buffs as possible.
-            </>
-          )}
-        >
-          <Requirement name="Arcane Intellect Uptime" thresholds={thresholds.arcaneIntellectUptime} />
-        </Rule>
-        
-        <PreparationRule thresholds={thresholds} />
+
+        <PreparationRule thresholds={thresholds}>
+          <Requirement name="Arcane Intellect active" thresholds={thresholds.arcaneIntellectUptime} />
+        </PreparationRule>
       </Checklist>
     );
   }

--- a/src/parser/mage/fire/modules/features/Pyroclasm.js
+++ b/src/parser/mage/fire/modules/features/Pyroclasm.js
@@ -6,7 +6,7 @@ import SpellIcon from 'common/SpellIcon';
 import Analyzer from 'parser/core/Analyzer';
 import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 import { formatNumber, formatPercentage } from 'common/format';
-import getDamageBonus from 'parser/mage/shared/modules/GetDamageBonus';
+import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
 
 const BONUS_DAMAGE = 2.25;
 const CAST_BUFFER = 250;
@@ -126,7 +126,7 @@ class Pyroclasm extends Analyzer {
       return;
     }
       if (this.isBuffed === true) {
-        this.damage += getDamageBonus(event, BONUS_DAMAGE);
+        this.damage += calculateEffectiveDamage(event, BONUS_DAMAGE);
         this.isBuffed = false;
         debug && this.log("Pyroblast Damage");
       } else {

--- a/src/parser/mage/frost/modules/checklist/Component.js
+++ b/src/parser/mage/frost/modules/checklist/Component.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SPELLS from 'common/SPELLS';
-import SpellLink from 'common/SpellLink';
 import Checklist from 'parser/shared/modules/features/Checklist2';
 import Rule from 'parser/shared/modules/features/Checklist2/Rule';
 import Requirement from 'parser/shared/modules/features/Checklist2/Requirement';
@@ -81,19 +80,9 @@ class FrostMageChecklist extends React.PureComponent {
           <Requirement name="Downtime" thresholds={thresholds.downtimeSuggestionThresholds} />
           <Requirement name="Cancelled casts" thresholds={thresholds.cancelledCasts} />
         </Rule>
-        <Rule
-          name="Maintain your buffs"
-          description={(
-            <>
-              You should ensure that you maintain <SpellLink id={SPELLS.ARCANE_INTELLECT.id} /> for the entire fight and recast it whenever you are ressurected and likewise, if you have the appropriate classes/specs in your group you should also ensure that you maintain their buffs as possible. Additionally, you should also ensure that you are maximizing your uptime of <SpellLink id={SPELLS.BONE_CHILLING_TALENT.id} /> if you are talented into it.
-            </>
-          )}
-        >
-          <Requirement name="Arcane Intellect uptime" thresholds={thresholds.arcaneIntellectUptime} />
-          {combatant.hasTalent(SPELLS.BONE_CHILLING_TALENT.id) && <Requirement name="Bone Chilling uptime" thresholds={thresholds.boneChillingUptime} />}
-        </Rule>
-
-        <PreparationRule thresholds={thresholds} />
+        <PreparationRule thresholds={thresholds}>
+          <Requirement name="Arcane Intellect active" thresholds={thresholds.arcaneIntellectUptime} />
+        </PreparationRule>
       </Checklist>
     );
   }

--- a/src/parser/mage/frost/modules/checklist/Module.js
+++ b/src/parser/mage/frost/modules/checklist/Module.js
@@ -5,7 +5,6 @@ import CastEfficiency from 'parser/shared/modules/CastEfficiency';
 import Combatants from 'parser/shared/modules/Combatants';
 import PreparationRuleAnalyzer from 'parser/shared/modules/features/Checklist2/PreparationRuleAnalyzer';
 
-import BoneChilling from '../features/BoneChilling';
 import BrainFreeze from '../features/BrainFreeze';
 import GlacialSpike from '../features/GlacialSpike';
 import IceLance from '../features/IceLance';
@@ -24,7 +23,6 @@ class Checklist extends BaseChecklist {
   static dependencies = {
     combatants: Combatants,
     castEfficiency: CastEfficiency,
-    boneChilling: BoneChilling,
     brainFreeze: BrainFreeze,
     glacialSpike: GlacialSpike,
     iceLance: IceLance,
@@ -48,7 +46,6 @@ class Checklist extends BaseChecklist {
           ...this.preparationRuleAnalyzer.thresholds,
 
           downtimeSuggestionThresholds: this.alwaysBeCasting.downtimeSuggestionThresholds,
-          boneChillingUptime: this.boneChilling.suggestionThresholds,
           brainFreezeUtilization: this.brainFreeze.utilSuggestionThresholds,
           brainFreezeOverwrites: this.brainFreeze.overwriteSuggestionThresholds,
           brainFreezeExpired: this.brainFreeze.expiredSuggestionThresholds,

--- a/src/parser/mage/frost/modules/features/BoneChilling.js
+++ b/src/parser/mage/frost/modules/features/BoneChilling.js
@@ -1,55 +1,64 @@
 import React from 'react';
 import SPELLS from 'common/SPELLS';
-import SpellLink from 'common/SpellLink';
-import SpellIcon from 'common/SpellIcon';
-import { formatPercentage } from 'common/format';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
 import Analyzer from 'parser/core/Analyzer';
+import { SELECTED_PLAYER } from 'parser/core/EventFilter';
+import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
 
+import Events from 'parser/core/Events';
+import { formatNumber } from 'common/format';
+
+const WHITELIST = [
+  SPELLS.ICICLE_DAMAGE,
+  SPELLS.ICE_LANCE_DAMAGE,
+  SPELLS.BLIZZARD_DAMAGE,
+  SPELLS.FLURRY_DAMAGE,
+  SPELLS.FROSTBOLT_DAMAGE,
+  SPELLS.FROZEN_ORB_DAMAGE,
+  SPELLS.COMET_STORM_DAMAGE,
+  SPELLS.GLACIAL_SPIKE_DAMAGE,
+  SPELLS.FROST_NOVA,
+  SPELLS.EBONBOLT_DAMAGE,
+  SPELLS.GLACIAL_ASSAULT_DAMAGE,
+  SPELLS.CONE_OF_COLD,
+  SPELLS.RAY_OF_FROST_TALENT,
+  SPELLS.ICE_NOVA_TALENT,
+];
+
+const MOD_PER_STACK = 0.005;
 class BoneChilling extends Analyzer {
+
+  totalDamage = 0;
 
   constructor(...args) {
     super(...args);
-	   this.active = this.selectedCombatant.hasTalent(SPELLS.BONE_CHILLING_TALENT.id);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.BONE_CHILLING_TALENT.id);
+    if (this.active) {
+      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(WHITELIST), this.onAffectedDamage);
+    }
   }
 
-  get uptime() {
-		return this.selectedCombatant.getBuffUptime(SPELLS.BONE_CHILLING_BUFF.id) / this.owner.fightDuration;
-	}
-
-  get suggestionThresholds() {
-    return {
-      actual: this.uptime,
-      isLessThan: {
-        minor: 1,
-        average: 0.95,
-        major: 0.85,
-      },
-      style: 'percentage',
-    };
+  onAffectedDamage(event) {
+    const buffInfo = this.selectedCombatant.getBuff(SPELLS.BONE_CHILLING_BUFF.id);
+    if (!buffInfo) {
+      return;
+    }
+    const mod = buffInfo.stacks * MOD_PER_STACK;
+    const increase = calculateEffectiveDamage(event, mod);
+    this.totalDamage += increase;
   }
 
-  suggestions(when) {
-		when(this.suggestionThresholds)
-			.addSuggestion((suggest, actual, recommended) => {
-				return suggest(<>Your <SpellLink id={SPELLS.BONE_CHILLING_BUFF.id} /> was up for {formatPercentage(this.uptime)}% of the fight. Bone Chilling is a stacking buff that increases your damage by up to 5%, so it is important that you have the buff up for as much of the fight as possible. If you are unable to maintain this buff, then consider taking a different talent.</>)
-					.icon(SPELLS.BONE_CHILLING_TALENT.icon)
-					.actual(`${formatPercentage(this.uptime)}% Uptime`)
-					.recommended(`${formatPercentage(recommended)}% is recommended`);
-			});
-	}
-
-	statistic() {
+  statistic() {
     return (
-			<TalentStatisticBox
-  position={STATISTIC_ORDER.CORE(100)}
-  icon={<SpellIcon id={SPELLS.BONE_CHILLING_TALENT.id} />}
-  value={`${formatPercentage(this.uptime, 0)} %`}
-  label="Bone Chilling Uptime"
-  tooltip={`Bone Chilling was up for ${formatPercentage(this.uptime)}% of the fight. Bone Chilling is a stacking buff that increases your damage by up to 5%, so it is important that you have the buff up for as much of the fight as possible. If you are unable to maintain this buff, then consider taking a different talent.`}
-			/>
-		);
-	}
+      <TalentStatisticBox
+        talent={SPELLS.BONE_CHILLING_TALENT.id}
+        position={STATISTIC_ORDER.UNIMPORTANT()}
+        value={this.owner.formatItemDamageDone(this.totalDamage)}
+        tooltip={`Total damage increase: ${formatNumber(this.totalDamage)}`}
+      />
+    );
+  }
+
 }
 
 export default BoneChilling;

--- a/src/parser/mage/shared/modules/GetDamageBonus.js
+++ b/src/parser/mage/shared/modules/GetDamageBonus.js
@@ -1,4 +1,0 @@
-export default function getDamageBonus(event, increase) {
-  const raw = (event.amount || 0) + (event.absorbed || 0);
-  return raw - (raw / (1 + increase));
-}


### PR DESCRIPTION
Currently, there is a checklist rule (Maintain Your Buffs) for all three mage specs that checks for Arcane Intellect uptime. In most cases, it is the only item in that section. The exceptions are Frost (if talented into Bone Chilling) and Arcane (if talented into Arcane Familiar). Because Bone Chilling is a completely passive talent that requires no interaction from the player, it doesn't seem right to make it a checklist item; its uptime basically mirrors the player's uptime. So, removing that item, now there is only the Arcane Familiar uptime (a rarely taken talent) that would ever make this checklist rule contain more than one item. 

Taking that into account, I thought it might be better to put Arcane Intellect into the Be Prepared section, as it's a pre-combat buff and the idea of a single item in a rule section doesn't seem right.

**Before:**
![image](https://user-images.githubusercontent.com/43309639/48694413-13d03e80-eb91-11e8-8ab3-ec2413743ad2.png)

**After:**
![image](https://user-images.githubusercontent.com/43309639/48694515-58f47080-eb91-11e8-9dbc-245615a4fc41.png)
(These changes also were given to Fire. However I didn't look at Arcane Familiar yet so the Arcane spec does not have the rule moved)


Having thought about Bone Chilling, I also decided to completely change how it is displayed. As mentioned the current statistic is pretty useless, because incidentally as you play the BC uptime mirrors your own uptime. Instead I decided to give it a DPS statistic to better display what the talent is doing for you.

**Before:**
![image](https://user-images.githubusercontent.com/43309639/48694689-e9cb4c00-eb91-11e8-8df7-35ac7d4350bb.png)

**After:**
![image](https://user-images.githubusercontent.com/43309639/48694688-e8018880-eb91-11e8-81a4-17a65bf0ea22.png)


You'll also see a file removed, it duplicated the calculateEffectiveDamage helper function. As such I removed it and any references.
