### PR TITLE
[Core] Fix weighted buff uptime calculation when buff doesn't expire

### DIFF
--- a/src/parser/core/Entity.js
+++ b/src/parser/core/Entity.js
@@ -101,10 +101,16 @@ class Entity {
       .reduce((totalUptime, buff) => {
         let startTime;
         let startStacks;
-        const buffUptime = buff.stackHistory.reduce((stackUptime, stack) => {
-          const result = !startTime ? 0 : (stack.timestamp - startTime) * startStacks;
+        const buffUptime = buff.stackHistory.reduce((stackUptime, stack, idx, arr) => {
+          let result = !startTime ? 0 : (stack.timestamp - startTime) * startStacks;
           startTime = stack.timestamp;
           startStacks = stack.stacks;
+          if (buff.end === null && idx === arr.length - 1) {
+            // If the buff instance didn't end (usually because it was still active at the end of the fight) we need to manually account for it
+            const finalStackUptime = this.owner.currentTimestamp - startTime;
+            const weighted = finalStackUptime * startStacks;
+            result += weighted;
+          }
           return stackUptime + result;
         }, 0);
         return totalUptime + buffUptime;


### PR DESCRIPTION
Because there is no buff remove event at the end of the fight, getStackWeightedBuffUptime doesn't work properly because the last stack change event (the one that sets it to 0 when buffremove is called) is never actually added to the buffhistory. 

Another solution would be to fabricate the buffremove event at the end of the fight. This one seems simpler and less likely to cause bugs.

I discovered this while working on Bone Chilling, where frost mages would get the 10 stacks of the buff in the first 15 seconds of the fight and never lose them. Weighted uptime showed ~1% when it should have been close to 1000%, even though regular getBuffUptime was correct.