### PR TITLE
Shadow priest/vamp embrace

### DIFF
--- a/src/parser/priest/shadow/CHANGELOG.js
+++ b/src/parser/priest/shadow/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-11-19'),
+    changes: <>Added <SpellLink id={SPELLS.VAMPIRIC_EMBRACE.id} /> module.</>,
+    contributors: [Khadaj],
+  },
+  {
     date: new Date('2018-11-08'),
     changes: <>Added <SpellLink id={SPELLS.DARK_VOID_TALENT.id} />.</>,
     contributors: [Khadaj],

--- a/src/parser/priest/shadow/CombatLogParser.js
+++ b/src/parser/priest/shadow/CombatLogParser.js
@@ -20,6 +20,7 @@ import Voidform from './modules/spells/Voidform';
 import VoidformAverageStacks from './modules/spells/VoidformAverageStacks';
 import Dispersion from './modules/spells/Dispersion';
 import CallToTheVoid from './modules/spells/CallToTheVoid';
+import VampiricEmbrace from './modules/spells/VampiricEmbrace';
 // azerite
 import ChorusOfInsanity from './modules/spells/azeritetraits/ChorusOfInsanity';
 // talents
@@ -59,6 +60,7 @@ class CombatLogParser extends MainCombatLogParser {
     voidformAverageStacks: VoidformAverageStacks,
     dispersion: Dispersion,
     callToTheVoid: CallToTheVoid,
+    vampiricEmbrace: VampiricEmbrace,
 
     // azerite
     chorusOfInsanity: ChorusOfInsanity,

--- a/src/parser/priest/shadow/modules/spells/VampiricEmbrace.js
+++ b/src/parser/priest/shadow/modules/spells/VampiricEmbrace.js
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import Analyzer from 'parser/core/Analyzer';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
+import ItemHealingDone from 'interface/others/ItemHealingDone';
+import DamageTracker from 'parser/shared/modules/AbilityTracker';
+import { formatNumber } from 'common/format';
+
+class VampiricEmbrace extends Analyzer {
+  static dependencies = {
+    abilityTracker: DamageTracker,
+  };
+
+  get casts() {
+    return this.abilityTracker.getAbility(SPELLS.VAMPIRIC_EMBRACE.id).casts;
+  }
+
+  get healingDone() {
+    return this.abilityTracker.getAbility(SPELLS.VAMPIRIC_EMBRACE_HEAL.id).healingEffective;
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        position={STATISTIC_ORDER.CORE(3)}
+        icon={<SpellIcon id={SPELLS.VAMPIRIC_EMBRACE.id} />}
+        value={<ItemHealingDone amount={this.healingDone} />}
+        label="Vampiric Embrace healing"
+        tooltip={`${formatNumber(this.healingDone)} healing done in ${this.casts} cast(s).`}
+      />
+    );
+  }
+}
+
+export default VampiricEmbrace;

--- a/src/parser/priest/shadow/modules/spells/VampiricEmbrace.js
+++ b/src/parser/priest/shadow/modules/spells/VampiricEmbrace.js
@@ -9,6 +9,7 @@ import ItemHealingDone from 'interface/others/ItemHealingDone';
 import DamageTracker from 'parser/shared/modules/AbilityTracker';
 import { formatNumber } from 'common/format';
 
+// Example log: /report/TzhG7rkfJAWP8MQp/32-Mythic+G'huun+-+Wipe+11+(8:21)/16-Constiince/changelog
 class VampiricEmbrace extends Analyzer {
   static dependencies = {
     abilityTracker: DamageTracker,


### PR DESCRIPTION
Vamp Embrace is optional for Shadowpriests, but represents a handy healing cooldown for the overall raid. It shouldn't be recommended, but it should be represented.

![screen shot 2018-11-19 at 9 34 36 am](https://user-images.githubusercontent.com/716498/48721289-d1355300-ebde-11e8-944a-b37358b3ab0b.png)
