### PR TITLE
[Marksmanship] Precise Shots & Lone Wolf update

### DIFF
--- a/src/parser/hunter/marksmanship/CHANGELOG.js
+++ b/src/parser/hunter/marksmanship/CHANGELOG.js
@@ -6,6 +6,11 @@ import SPELLS from 'common/SPELLS';
 
 export default [
   {
+    date: new Date('2018-11-20'),
+    changes: <> Added a simple <SpellLink id={SPELLS.PRECISE_SHOTS.id} /> module. </>,
+    contributors: [Putro],
+  },
+  {
     date: new Date('2018-11-14'),
     changes: <> Created a module for <SpellLink id={SPELLS.BORN_TO_BE_WILD_TALENT.id} /> and <SpellLink id={SPELLS.BINDING_SHOT_TALENT.id} />. </>,
     contributors: [Putro],

--- a/src/parser/hunter/marksmanship/CombatLogParser.js
+++ b/src/parser/hunter/marksmanship/CombatLogParser.js
@@ -98,8 +98,8 @@ class CombatLogParser extends CoreCombatLogParser {
     //Azerite Traits
     steadyAim: SteadyAim,
 
-    //Traits and talents
-    traitsAndTalents: SpellsAndTalents,
+    //Spells and Talents
+    spellsAndTalents: SpellsAndTalents,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }],

--- a/src/parser/hunter/marksmanship/CombatLogParser.js
+++ b/src/parser/hunter/marksmanship/CombatLogParser.js
@@ -18,6 +18,7 @@ import RapidFireNormalizer from './normalizers/RapidFire';
 //Spells
 import Trueshot from './modules/spells/Trueshot';
 import LoneWolf from './modules/spells/LoneWolf';
+import PreciseShots from './modules/spells/PreciseShots';
 
 //Talents
 import AMurderOfCrows from '../shared/modules/talents/AMurderOfCrows';
@@ -46,7 +47,7 @@ import FocusTab from '../shared/modules/features/focuschart/FocusTab';
 import SteadyAim from './modules/spells/azeritetraits/SteadyAim';
 
 //Traits and Talents
-import TraitsAndTalents from './modules/features/TraitsAndTalents';
+import SpellsAndTalents from './modules/features/SpellsAndTalents';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -73,6 +74,7 @@ class CombatLogParser extends CoreCombatLogParser {
     //Spells
     trueshot: Trueshot,
     loneWolf: LoneWolf,
+    preciseShots: PreciseShots,
 
     //Talents
     volley: Volley,
@@ -97,7 +99,7 @@ class CombatLogParser extends CoreCombatLogParser {
     steadyAim: SteadyAim,
 
     //Traits and talents
-    traitsAndTalents: TraitsAndTalents,
+    traitsAndTalents: SpellsAndTalents,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }],

--- a/src/parser/hunter/marksmanship/modules/features/SpellsAndTalents.js
+++ b/src/parser/hunter/marksmanship/modules/features/SpellsAndTalents.js
@@ -5,18 +5,20 @@ import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 
 import Analyzer from 'parser/core/Analyzer';
 
-import AMurderOfCrows from 'parser/hunter/shared/modules/talents/AMurderOfCrows';
-import Barrage from 'parser/hunter/shared/modules/talents/Barrage';
+import AMurderOfCrows from '../../../shared/modules/talents/AMurderOfCrows';
+import Barrage from '../../../shared/modules/talents/Barrage';
 import LoneWolf from '../spells/LoneWolf';
 import Volley from '../talents/Volley';
 import ExplosiveShot from '../talents/ExplosiveShot';
 import PiercingShot from '../talents/PiercingShot';
 import HuntersMark from '../talents/HuntersMark';
 import SerpentSting from '../talents/SerpentSting';
+import PreciseShots from '../spells/PreciseShots';
 
-class TraitsAndTalents extends Analyzer {
+class SpellsAndTalents extends Analyzer {
   static dependencies = {
     loneWolf: LoneWolf,
+    preciseShots: PreciseShots,
     volley: Volley,
     explosiveShot: ExplosiveShot,
     aMurderOfCrows: AMurderOfCrows,
@@ -38,10 +40,11 @@ class TraitsAndTalents extends Analyzer {
     return (
       <StatisticsListBox
         position={STATISTIC_ORDER.CORE(12)}
-        title="Spells, Traits and Talents"
-        tooltip="This provides an overview of the damage contributions of various talents and traits. This isn't meant as a way to 1:1 evaluate talents, as some talents bring other strengths to the table than pure damage."
+        title="Spells and Talents"
+        tooltip="This provides an overview of the damage contributions of various spells and talents. This isn't meant as a way to 1:1 evaluate talents, as some talents bring other strengths to the table than pure damage."
       >
         {this.loneWolf.active && this.loneWolf.subStatistic()}
+        {this.preciseShots.active && this.preciseShots.subStatistic()}
         {this.volley.active && this.volley.subStatistic()}
         {this.explosiveShot.active && this.explosiveShot.subStatistic()}
         {this.aMurderOfCrows.active && this.aMurderOfCrows.subStatistic()}
@@ -49,11 +52,10 @@ class TraitsAndTalents extends Analyzer {
         {this.barrage.active && this.barrage.subStatistic()}
         {this.huntersMark.active && this.huntersMark.subStatistic()}
         {this.serpentSting.active && this.serpentSting.subStatistic()}
-        {}
       </StatisticsListBox>
 
     );
   }
 }
 
-export default TraitsAndTalents;
+export default SpellsAndTalents;

--- a/src/parser/hunter/marksmanship/modules/spells/LoneWolf.js
+++ b/src/parser/hunter/marksmanship/modules/spells/LoneWolf.js
@@ -41,17 +41,20 @@ class LoneWolf extends Analyzer {
   damage = 0;
   lwApplicationTimestamp = 0;
   loneWolfModifier = 0;
+  lwAppliedOrRemoved = false;
 
   constructor(...args) {
     super(...args);
     this.active = true;
   }
+
   on_byPlayer_applybuff(event) {
     const spellId = event.ability.guid;
     if (spellId !== SPELLS.LONE_WOLF_BUFF.id) {
       return;
     }
     this.lwApplicationTimestamp = event.timestamp;
+    this.lwAppliedOrRemoved = true;
   }
 
   on_byPlayer_removebuff(event) {
@@ -60,10 +63,11 @@ class LoneWolf extends Analyzer {
       return;
     }
     this.loneWolfModifier = 0;
+    this.lwAppliedOrRemoved = true;
   }
 
   on_byPlayer_damage(event) {
-    if (!this.selectedCombatant.hasBuff(SPELLS.LONE_WOLF_BUFF.id)) {
+    if (this.lwAppliedOrRemoved && !this.selectedCombatant.hasBuff(SPELLS.LONE_WOLF_BUFF.id)) {
       return;
     }
     if (!AFFECTED_SPELLS.includes(event.ability.guid)) {
@@ -77,7 +81,7 @@ class LoneWolf extends Analyzer {
     this.damage += calculateEffectiveDamage(event, this.loneWolfModifier);
   }
 
-  on_finished() { //TODO: WCL is currently having issues with blizzard not reporting LW uptime if it was up through the fight. Possibly check for pet damage, and if none - assume LW was up for the entirety of the fight.
+  on_finished() {
     if (this.damage === 0) {
       this.active = false;
     }

--- a/src/parser/hunter/marksmanship/modules/spells/PreciseShots.js
+++ b/src/parser/hunter/marksmanship/modules/spells/PreciseShots.js
@@ -95,7 +95,7 @@ class PreciseShots extends Analyzer {
         icon={<SpellIcon id={SPELLS.PRECISE_SHOTS.id} />}
         value={`${this.buffsGained} buffs used`}
         label={`Precise Shots`}
-        tooltip={`You wasted atleast ${this.minOverwrittenProcs} and up to ${this.maxOverwrittenProcs} procs by casting Aimed Shot when you already had Precise Shots active`}
+        tooltip={`You wasted between ${this.minOverwrittenProcs} and ${this.maxOverwrittenProcs} Precise Shots procs by casting Aimed Shot when you already had Precise Shots active`}
       />
     );
   }

--- a/src/parser/hunter/marksmanship/modules/spells/PreciseShots.js
+++ b/src/parser/hunter/marksmanship/modules/spells/PreciseShots.js
@@ -1,0 +1,113 @@
+import React from 'react';
+
+import Analyzer from 'parser/core/Analyzer';
+import SPELLS from 'common/SPELLS/hunter';
+import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
+import SpellIcon from 'common/SpellIcon';
+import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
+import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
+import SpellLink from 'common/SpellLink';
+import ItemDamageDone from 'interface/others/ItemDamageDone';
+
+/**
+ * Aimed Shot causes your next 1-2 Arcane Shots or Multi-Shots to deal 100% more damage.
+ */
+
+//TODO: Add a suggestion for Aimed Shotting when Precise Shots is active + some conditionals, but wait for 8.1 for Marksmanship minor rework before doing so.
+
+const ASSUMED_PROCS = 2; //Logs give no indication whether we gain 1 or 2 stacks - we assume 2 and work from there.
+const PRECISE_SHOTS_MODIFIER = 1;
+const MAX_TRAVEL_TIME = 500;
+
+class PreciseShots extends Analyzer {
+
+  damage = 0;
+  buffsActive = 0;
+  buffsGained = 0;
+  minOverwrittenProcs = 0;
+  maxOverwrittenProcs = 0;
+  buffedShotInFlight = null;
+
+  on_byPlayer_applybuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.PRECISE_SHOTS.id) {
+      return;
+    }
+    this.buffsActive = ASSUMED_PROCS;
+  }
+
+  on_byPlayer_removebuff(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.PRECISE_SHOTS.id) {
+      return;
+    }
+    this.buffsGained += 1;
+    this.buffsActive = 0;
+  }
+
+  on_byPlayer_applybuffstack(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.PRECISE_SHOTS.id) {
+      return;
+    }
+    this.minOverwrittenProcs += 1;
+    this.maxOverwrittenProcs += 2;
+    this.buffsActive = ASSUMED_PROCS;
+  }
+
+  on_byPlayer_removebuffstack(event) {
+    const spellId = event.ability.guid;
+    if (spellId !== SPELLS.PRECISE_SHOTS.id) {
+      return;
+    }
+    this.buffsGained += 1;
+    this.buffsActive -= 1;
+  }
+
+  on_byPlayer_cast(event) {
+    const spellId = event.ability.guid;
+    if (!this.selectedCombatant.hasBuff(SPELLS.PRECISE_SHOTS.id) || (spellId !== SPELLS.ARCANE_SHOT.id && spellId !== SPELLS.MULTISHOT_MM.id)) {
+      return;
+    }
+    this.buffedShotInFlight = event.timestamp;
+  }
+
+  on_byPlayer_damage(event) {
+    const spellId = event.ability.guid;
+    if (this.buffedShotInFlight && this.buffedShotInFlight > event.timestamp + MAX_TRAVEL_TIME) {
+      this.buffedShotInFlight = null;
+    }
+    if (spellId !== SPELLS.ARCANE_SHOT.id && spellId !== SPELLS.MULTISHOT_MM.id) {
+      return;
+    }
+    if (this.buffedShotInFlight && this.buffedShotInFlight < event.timestamp + MAX_TRAVEL_TIME) {
+      this.damage += calculateEffectiveDamage(event, PRECISE_SHOTS_MODIFIER);
+    }
+    if (spellId === SPELLS.ARCANE_SHOT.id) {
+      this.buffedShotInFlight = null;
+    }
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        position={STATISTIC_ORDER.CORE(17)}
+        icon={<SpellIcon id={SPELLS.PRECISE_SHOTS.id} />}
+        value={`${this.buffsGained} buffs used`}
+        label={`Precise Shots`}
+        tooltip={`You wasted atleast ${this.minOverwrittenProcs} and up to ${this.maxOverwrittenProcs} procs by casting Aimed Shot when you already had Precise Shots active`}
+      />
+    );
+  }
+
+  subStatistic() {
+    return (
+      <StatisticListBoxItem
+        title={<SpellLink id={SPELLS.PRECISE_SHOTS.id} />}
+        value={<ItemDamageDone amount={this.damage} />}
+      />
+    );
+  }
+}
+
+export default PreciseShots;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29204244/48740837-4c3b4f80-ec59-11e8-9459-878a56cf2ad1.png)
Creates a simple Precise Shots module and updates Lone Wolf module to be active despite WCL not showing LW buff uptime if it was at 100% throughout the fight. 

Renames the Spell and Talents list in preparation for talents to be potentially being moved out of it and traits 100% not being apart of it. 