### PR TITLE
[Ret Pally] Fix another case of deps not being properly expanded

### DIFF
--- a/src/parser/paladin/retribution/modules/core/GlobalCooldown.js
+++ b/src/parser/paladin/retribution/modules/core/GlobalCooldown.js
@@ -1,20 +1,12 @@
 import CoreGlobalCooldown from 'parser/shared/modules/GlobalCooldown';
 import SPELLS from 'common/SPELLS';
-import Haste from './Haste';
-import Abilities from '../Abilities';
 
-const MIN_GCD= 750;
+const MIN_GCD = 750;
 
 /**
  * The Global Cooldown from Wake of Ashes is currently double dipping haste
- */ 
-
+ */
 class GlobalCooldown extends CoreGlobalCooldown {
-  static dependencies = {
-    abilities: Abilities,
-    haste: Haste,
-  };
-
   getGlobalCooldownDuration(spellId) {
     const gcd = super.getGlobalCooldownDuration(spellId);
     if (!gcd) {


### PR DESCRIPTION
> [7:17 PM] Skeletor: https://wowanalyzer.com/report/yTY6Gp3nWKmZLPz9/21-Mythic+Taloc+-+Kill+(5:13)/7-Alfajhor
> happening to me on multiple logs for ret
> "A connection error occured.
> Something went wrong talking to our servers, please try again.
> t.module is undefined"

I have no idea what happened that caused this to break all of a sudden, it was fine up until a few hours ago. It looks like it should have been broken before, but maybe it's just specific logs. 

Anyway, this module didn't need to override deps so I just removed that.