### PR TITLE
[Core] Fix for Development Tab

### DIFF
--- a/src/interface/others/DevelopmentTab.js
+++ b/src/interface/others/DevelopmentTab.js
@@ -297,12 +297,11 @@ class DevelopmentTab extends React.Component {
             Modules:
             <ul className="list">
               {Object.values(parser._modules)
-                .map((moduleClass, index) => {
-                  const module = parser.getModule(moduleClass);
+                .map((module, index) => {
                   return (
                     <li key={index} className="flex">
                       <div className="flex-main">
-                        <Code dump={module}>{module.name}</Code>
+                        <Code dump={module}>{module.constructor.name}</Code>
                       </div>
                       <div className="flex-main" style={{ color: module.active ? 'green' : 'red' }}>
                         {module.active ? 'Active' : 'Inactive'}


### PR DESCRIPTION
`parser._modules` was returning already the instances of the classes (`typeof === object`), whereas `getModule()` wants the class (`typeof === function`) causing it to crash in dev. 