### PR TITLE
[Demonology] Pet tracking refactor and cleanup

### DIFF
--- a/src/parser/warlock/demonology/CombatLogParser.js
+++ b/src/parser/warlock/demonology/CombatLogParser.js
@@ -18,6 +18,7 @@ import PetSummonHandler from './modules/pets/DemoPets/PetSummonHandler';
 import WildImpEnergyHandler from './modules/pets/DemoPets/WildImpEnergyHandler';
 import PowerSiphonHandler from './modules/pets/DemoPets/PowerSiphonHandler';
 import DemonicTyrantHandler from './modules/pets/DemoPets/DemonicTyrantHandler';
+import ImplosionHandler from './modules/pets/DemoPets/ImplosionHandler';
 import PetTimelineTab from './modules/pets/PetTimelineTab';
 import PrepullPetNormalizer from './modules/pets/normalizers/PrepullPetNormalizer';
 
@@ -61,6 +62,7 @@ class CombatLogParser extends CoreCombatLogParser {
     wildImpEnergyHandler: WildImpEnergyHandler,
     powerSiphonHandler: PowerSiphonHandler,
     demonicTyrantHandler: DemonicTyrantHandler,
+    implosionHandler: ImplosionHandler,
     petTimelineTab: PetTimelineTab,
     prepullPetNormalizer: PrepullPetNormalizer,
 

--- a/src/parser/warlock/demonology/CombatLogParser.js
+++ b/src/parser/warlock/demonology/CombatLogParser.js
@@ -15,6 +15,7 @@ import SoulShardDetails from './modules/soulshards/SoulShardDetails';
 import DemoPets from './modules/pets/DemoPets';
 import PetDamageHandler from './modules/pets/DemoPets/PetDamageHandler';
 import PetSummonHandler from './modules/pets/DemoPets/PetSummonHandler';
+import WildImpEnergyHandler from './modules/pets/DemoPets/WildImpEnergyHandler';
 import PetTimelineTab from './modules/pets/PetTimelineTab';
 import PrepullPetNormalizer from './modules/pets/normalizers/PrepullPetNormalizer';
 
@@ -55,6 +56,7 @@ class CombatLogParser extends CoreCombatLogParser {
     demoPets: DemoPets,
     petDamageHandler: PetDamageHandler,
     petSummonHandler: PetSummonHandler,
+    wildImpEnergyHandler: WildImpEnergyHandler,
     petTimelineTab: PetTimelineTab,
     prepullPetNormalizer: PrepullPetNormalizer,
 

--- a/src/parser/warlock/demonology/CombatLogParser.js
+++ b/src/parser/warlock/demonology/CombatLogParser.js
@@ -16,6 +16,7 @@ import DemoPets from './modules/pets/DemoPets';
 import PetDamageHandler from './modules/pets/DemoPets/PetDamageHandler';
 import PetSummonHandler from './modules/pets/DemoPets/PetSummonHandler';
 import WildImpEnergyHandler from './modules/pets/DemoPets/WildImpEnergyHandler';
+import PowerSiphonHandler from './modules/pets/DemoPets/PowerSiphonHandler';
 import PetTimelineTab from './modules/pets/PetTimelineTab';
 import PrepullPetNormalizer from './modules/pets/normalizers/PrepullPetNormalizer';
 
@@ -57,6 +58,7 @@ class CombatLogParser extends CoreCombatLogParser {
     petDamageHandler: PetDamageHandler,
     petSummonHandler: PetSummonHandler,
     wildImpEnergyHandler: WildImpEnergyHandler,
+    powerSiphonHandler: PowerSiphonHandler,
     petTimelineTab: PetTimelineTab,
     prepullPetNormalizer: PrepullPetNormalizer,
 

--- a/src/parser/warlock/demonology/CombatLogParser.js
+++ b/src/parser/warlock/demonology/CombatLogParser.js
@@ -13,6 +13,8 @@ import SoulShardTracker from './modules/soulshards/SoulShardTracker';
 import SoulShardDetails from './modules/soulshards/SoulShardDetails';
 
 import DemoPets from './modules/pets/DemoPets';
+import PetDamageHandler from './modules/pets/DemoPets/PetDamageHandler';
+import PetSummonHandler from './modules/pets/DemoPets/PetSummonHandler';
 import PetTimelineTab from './modules/pets/PetTimelineTab';
 import PrepullPetNormalizer from './modules/pets/normalizers/PrepullPetNormalizer';
 
@@ -48,7 +50,11 @@ class CombatLogParser extends CoreCombatLogParser {
     // Core
     soulShardTracker: SoulShardTracker,
     soulShardDetails: SoulShardDetails,
+
+    // Pets
     demoPets: DemoPets,
+    petDamageHandler: PetDamageHandler,
+    petSummonHandler: PetSummonHandler,
     petTimelineTab: PetTimelineTab,
     prepullPetNormalizer: PrepullPetNormalizer,
 

--- a/src/parser/warlock/demonology/CombatLogParser.js
+++ b/src/parser/warlock/demonology/CombatLogParser.js
@@ -17,6 +17,7 @@ import PetDamageHandler from './modules/pets/DemoPets/PetDamageHandler';
 import PetSummonHandler from './modules/pets/DemoPets/PetSummonHandler';
 import WildImpEnergyHandler from './modules/pets/DemoPets/WildImpEnergyHandler';
 import PowerSiphonHandler from './modules/pets/DemoPets/PowerSiphonHandler';
+import DemonicTyrantHandler from './modules/pets/DemoPets/DemonicTyrantHandler';
 import PetTimelineTab from './modules/pets/PetTimelineTab';
 import PrepullPetNormalizer from './modules/pets/normalizers/PrepullPetNormalizer';
 
@@ -59,6 +60,7 @@ class CombatLogParser extends CoreCombatLogParser {
     petSummonHandler: PetSummonHandler,
     wildImpEnergyHandler: WildImpEnergyHandler,
     powerSiphonHandler: PowerSiphonHandler,
+    demonicTyrantHandler: DemonicTyrantHandler,
     petTimelineTab: PetTimelineTab,
     prepullPetNormalizer: PrepullPetNormalizer,
 

--- a/src/parser/warlock/demonology/modules/pets/CONSTANTS.js
+++ b/src/parser/warlock/demonology/modules/pets/CONSTANTS.js
@@ -62,18 +62,6 @@ export const PET_GUID_TO_SUMMON_ABILITY_MAP = {
   [PETS.PRINCE_MALCHEZAAR.guid]: SPELLS.PRINCE_MALCHEZAAR_SUMMON.id,
 };
 
-export const WILD_IMP_GUIDS = [
-  PETS.WILD_IMP_HOG.guid,
-  PETS.WILD_IMP_INNER_DEMONS.guid,
-];
-
-export const PETS_AFFECTED_BY_DEMONIC_TYRANT_GUIDS = [
-  ...WILD_IMP_GUIDS,
-  PETS.DREADSTALKER.guid,
-  PETS.VILEFIEND.guid,
-  PETS.GRIMOIRE_FELGUARD.guid,
-];
-
 // used to map summon ability id to summon spell ID (either spell that player casts or a talent)
 export const SUMMON_TO_SPELL_MAP = {
   [SPELLS.SUMMON_IMP.id]: SPELLS.SUMMON_IMP.id,

--- a/src/parser/warlock/demonology/modules/pets/CONSTANTS.js
+++ b/src/parser/warlock/demonology/modules/pets/CONSTANTS.js
@@ -109,17 +109,3 @@ export const PERMANENT_PET_ABILITIES_TO_SUMMON_MAP = {
   [SPELLS.FELGUARD_LEGION_STRIKE.id]: SPELLS.SUMMON_FELGUARD.id,
   [SPELLS.FELSTORM_BUFF.id]: SPELLS.SUMMON_FELGUARD.id,
 };
-
-// random pets that can be summoned from Inner Demons/Nether Portal. Does NOT include Wild Imps summoned by Inner Demons, those are not random
-export const RANDOM_PET_GUIDS = [
-  PETS.BILESCOURGE.guid,
-  PETS.VICIOUS_HELLHOUND.guid,
-  PETS.SHIVARRA.guid,
-  PETS.DARKHOUND.guid,
-  PETS.ILLIDARI_SATYR.guid,
-  PETS.VOID_TERROR.guid,
-  PETS.URZUL.guid,
-  PETS.WRATHGUARD.guid,
-  PETS.EYE_OF_GULDAN.guid,
-  PETS.PRINCE_MALCHEZAAR.guid,
-];

--- a/src/parser/warlock/demonology/modules/pets/CONSTANTS.js
+++ b/src/parser/warlock/demonology/modules/pets/CONSTANTS.js
@@ -1,5 +1,4 @@
 import SPELLS from 'common/SPELLS';
-import PETS from './PETS';
 
 // ability guids from 'summon' events - sometimes different from 'cast' ids
 export const PERMANENT_PET_SUMMON_ABILITY_IDS = [
@@ -41,26 +40,6 @@ export const PET_SUMMON_ABILITY_IDS = [
   ...PERMANENT_PET_SUMMON_ABILITY_IDS,
   ...TEMPORARY_PET_SUMMON_ABILITY_IDS,
 ];
-
-// used to map begincast, cast and damage from pre-pull summoned pets to their summon event abilities
-export const PET_GUID_TO_SUMMON_ABILITY_MAP = {
-  [PETS.WILD_IMP_HOG.guid]: SPELLS.WILD_IMP_HOG_SUMMON.id,
-  [PETS.DREADSTALKER.guid]: SPELLS.DREADSTALKER_SUMMON_1.id, // technically there are 2 summon abilities but they get mapped to same spell anyway
-  [PETS.VILEFIEND.guid]: SPELLS.SUMMON_VILEFIEND_TALENT.id,
-  [PETS.GRIMOIRE_FELGUARD.guid]: SPELLS.GRIMOIRE_FELGUARD_TALENT.id,
-  [PETS.DEMONIC_TYRANT.guid]: SPELLS.SUMMON_DEMONIC_TYRANT.id,
-  [PETS.WILD_IMP_INNER_DEMONS.guid]: SPELLS.WILD_IMP_ID_SUMMON.id,
-  [PETS.BILESCOURGE.guid]: SPELLS.BILESCOURGE_SUMMON.id,
-  [PETS.VICIOUS_HELLHOUND.guid]: SPELLS.VICIOUS_HELLHOUND_SUMMON.id,
-  [PETS.SHIVARRA.guid]: SPELLS.SHIVARRA_SUMMON.id,
-  [PETS.DARKHOUND.guid]: SPELLS.DARKHOUND_SUMMON.id,
-  [PETS.ILLIDARI_SATYR.guid]: SPELLS.ILLIDARI_SATYR_SUMMON.id,
-  [PETS.VOID_TERROR.guid]: SPELLS.VOID_TERROR_SUMMON.id,
-  [PETS.URZUL.guid]: SPELLS.URZUL_SUMMON.id,
-  [PETS.WRATHGUARD.guid]: SPELLS.WRATHGUARD_SUMMON.id,
-  [PETS.EYE_OF_GULDAN.guid]: SPELLS.EYE_OF_GULDAN_SUMMON.id,
-  [PETS.PRINCE_MALCHEZAAR.guid]: SPELLS.PRINCE_MALCHEZAAR_SUMMON.id,
-};
 
 // used to map summon ability id to summon spell ID (either spell that player casts or a talent)
 export const SUMMON_TO_SPELL_MAP = {

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/DemonicTyrantHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/DemonicTyrantHandler.js
@@ -12,7 +12,7 @@ class DemonicTyrantHandler extends Analyzer {
     demoPets: DemoPets,
   };
 
-  _lastDemonicTyrantCast = null;
+  _lastCast = null;
   _hasDemonicConsumption = false;
   _petsAffectedByDemonicTyrant = [];
 
@@ -27,7 +27,7 @@ class DemonicTyrantHandler extends Analyzer {
       return;
     }
     // extend current pets (not random ones from ID/NP) by 15 seconds
-    this._lastDemonicTyrantCast = event.timestamp;
+    this._lastCast = event.timestamp;
     const affectedPets = this.demoPets.currentPets.filter(pet => this._petsAffectedByDemonicTyrant.includes(pet.id));
     test && this.log('Demonic Tyrant cast, affected pets: ', JSON.parse(JSON.stringify(affectedPets)));
     affectedPets.forEach(pet => {
@@ -49,7 +49,7 @@ class DemonicTyrantHandler extends Analyzer {
       return;
     }
     // Demonic Tyrant effect faded, update imps' expected despawn
-    const actualBuffTime = event.timestamp - this._lastDemonicTyrantCast;
+    const actualBuffTime = event.timestamp - this._lastCast;
     this.demoPets.currentPets
       .filter(pet => this.demoPets.wildImpIds.includes(pet.id))
       .forEach(imp => {

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/DemonicTyrantHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/DemonicTyrantHandler.js
@@ -34,7 +34,7 @@ class DemonicTyrantHandler extends Analyzer {
       pet.extend();
       pet.pushHistory(event.timestamp, 'Extended with Demonic Tyrant', event);
       // if player has Demonic Consumption talent, kill all imps
-      if (this._hasDemonicConsumption && this.demoPets._wildImpIds.includes(pet.id)) {
+      if (this._hasDemonicConsumption && this.demoPets.wildImpIds.includes(pet.id)) {
         test && this.log('Wild Imp killed because Demonic Consumption', pet);
         pet.despawn(event.timestamp, DESPAWN_REASONS.DEMONIC_CONSUMPTION);
         pet.setMeta(META_CLASSES.DESTROYED, META_TOOLTIPS.DEMONIC_CONSUMPTION);
@@ -51,7 +51,7 @@ class DemonicTyrantHandler extends Analyzer {
     // Demonic Tyrant effect faded, update imps' expected despawn
     const actualBuffTime = event.timestamp - this._lastDemonicTyrantCast;
     this.demoPets.currentPets
-      .filter(pet => this.demoPets._wildImpIds.includes(pet.id))
+      .filter(pet => this.demoPets.wildImpIds.includes(pet.id))
       .forEach(imp => {
         // original duration = spawn + 15
         // extended duration on DT cast = (spawn + 15) + 15
@@ -74,7 +74,7 @@ class DemonicTyrantHandler extends Analyzer {
     }
 
     this._petsAffectedByDemonicTyrant = [
-      ...this.demoPets._wildImpIds,
+      ...this.demoPets.wildImpIds,
       ...usedPetGuids.map(guid => this.demoPets._toId(guid)),
     ];
   }

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/DemonicTyrantHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/DemonicTyrantHandler.js
@@ -1,0 +1,83 @@
+import Analyzer from 'parser/core/Analyzer';
+
+import SPELLS from 'common/SPELLS';
+import DemoPets from './index';
+import { DESPAWN_REASONS, META_CLASSES, META_TOOLTIPS } from '../TimelinePet';
+import PETS from '../PETS';
+
+const test = false;
+
+class DemonicTyrantHandler extends Analyzer {
+  static dependencies = {
+    demoPets: DemoPets,
+  };
+
+  _lastDemonicTyrantCast = null;
+  _hasDemonicConsumption = false;
+  _petsAffectedByDemonicTyrant = [];
+
+  constructor(...args) {
+    super(...args);
+    this._initializeDemonicTyrantPets();
+    this._hasDemonicConsumption = this.selectedCombatant.hasTalent(SPELLS.DEMONIC_CONSUMPTION_TALENT.id);
+  }
+
+  on_byPlayer_cast(event) {
+    if (event.ability.guid !== SPELLS.SUMMON_DEMONIC_TYRANT.id) {
+      return;
+    }
+    // extend current pets (not random ones from ID/NP) by 15 seconds
+    this._lastDemonicTyrantCast = event.timestamp;
+    const affectedPets = this.demoPets.currentPets.filter(pet => this._petsAffectedByDemonicTyrant.includes(pet.id));
+    test && this.log('Demonic Tyrant cast, affected pets: ', JSON.parse(JSON.stringify(affectedPets)));
+    affectedPets.forEach(pet => {
+      pet.extend();
+      pet.pushHistory(event.timestamp, 'Extended with Demonic Tyrant', event);
+      // if player has Demonic Consumption talent, kill all imps
+      if (this._hasDemonicConsumption && this.demoPets._wildImpIds.includes(pet.id)) {
+        test && this.log('Wild Imp killed because Demonic Consumption', pet);
+        pet.despawn(event.timestamp, DESPAWN_REASONS.DEMONIC_CONSUMPTION);
+        pet.setMeta(META_CLASSES.DESTROYED, META_TOOLTIPS.DEMONIC_CONSUMPTION);
+        pet.pushHistory(event.timestamp, 'Killed by Demonic Consumption', event);
+      }
+    });
+    test && this.log('Pets after Demonic Tyrant cast', JSON.parse(JSON.stringify(this.demoPets.currentPets)));
+  }
+
+  on_toPlayer_removebuff(event) {
+    if (event.ability.guid !== SPELLS.DEMONIC_POWER.id) {
+      return;
+    }
+    // Demonic Tyrant effect faded, update imps' expected despawn
+    const actualBuffTime = event.timestamp - this._lastDemonicTyrantCast;
+    this.demoPets.currentPets
+      .filter(pet => this.demoPets._wildImpIds.includes(pet.id))
+      .forEach(imp => {
+        // original duration = spawn + 15
+        // extended duration on DT cast = (spawn + 15) + 15
+        // real duration = (spawn + 15) + actualBuffTime
+        const old = imp.expectedDespawn;
+        imp.expectedDespawn = imp.spawn + PETS.WILD_IMP_HOG.duration + actualBuffTime;
+        imp.pushHistory(event.timestamp, 'Updated expected despawn from', old, 'to', imp.expectedDespawn);
+      });
+  }
+
+  _initializeDemonicTyrantPets() {
+    const usedPetGuids = [
+      PETS.DREADSTALKER.guid,
+    ];
+    if (this.selectedCombatant.hasTalent(SPELLS.SUMMON_VILEFIEND_TALENT.id)) {
+      usedPetGuids.push(PETS.VILEFIEND.guid);
+    }
+    if (this.selectedCombatant.hasTalent(SPELLS.GRIMOIRE_FELGUARD_TALENT.id)) {
+      usedPetGuids.push(PETS.GRIMOIRE_FELGUARD.guid);
+    }
+
+    this._petsAffectedByDemonicTyrant = [
+      ...this.demoPets._wildImpIds,
+      ...usedPetGuids.map(guid => this.demoPets._toId(guid)),
+    ];
+  }
+}
+
+export default DemonicTyrantHandler;

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/ImplosionHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/ImplosionHandler.js
@@ -1,5 +1,6 @@
-import Analyzer from 'parser/core/Analyzer';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
+import Events from 'parser/core/Events';
 
 import SPELLS from 'common/SPELLS';
 
@@ -17,10 +18,13 @@ class ImplosionHandler extends Analyzer {
   _lastCast = null;
   _targetsHit = [];
 
-  on_byPlayer_cast(event) {
-    if (event.ability.guid !== SPELLS.IMPLOSION_CAST.id) {
-      return;
-    }
+  constructor(...args) {
+    super(...args);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.IMPLOSION_CAST), this.onImplosionCast);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.IMPLOSION_DAMAGE), this.onImplosionDamage);
+  }
+
+  onImplosionCast(event) {
     // Mark current Wild Imps as "implodable"
     const imps = this.demoPets.currentPets.filter(pet => this.demoPets.wildImpIds.includes(pet.id));
     test && this.log('Implosion cast, current imps', JSON.parse(JSON.stringify(imps)));
@@ -36,10 +40,7 @@ class ImplosionHandler extends Analyzer {
     this._targetsHit = [];
   }
 
-  on_byPlayer_damage(event) {
-    if (event.ability.guid !== SPELLS.IMPLOSION_DAMAGE.id) {
-      return;
-    }
+  onImplosionDamage(event) {
     if (!event.x || !event.y) {
       debug && this.error('Implosion damage event doesn\'t have a target position', event);
       return;

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/ImplosionHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/ImplosionHandler.js
@@ -1,0 +1,97 @@
+import Analyzer from 'parser/core/Analyzer';
+import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
+
+import SPELLS from 'common/SPELLS';
+
+import DemoPets from './index';
+import { DESPAWN_REASONS, META_CLASSES, META_TOOLTIPS } from '../TimelinePet';
+
+const test = false;
+const debug = false;
+
+class ImplosionHandler extends Analyzer {
+  static dependencies = {
+    demoPets: DemoPets,
+  };
+
+  _lastImplosionCast = null;
+  _implosionTargetsHit = [];
+
+  on_byPlayer_cast(event) {
+    if (event.ability.guid !== SPELLS.IMPLOSION_CAST.id) {
+      return;
+    }
+    // Mark current Wild Imps as "implodable"
+    const imps = this.demoPets.currentPets.filter(pet => this.demoPets._wildImpIds.includes(pet.id));
+    test && this.log('Implosion cast, current imps', JSON.parse(JSON.stringify(imps)));
+    if (imps.some(imp => imp.x === null || imp.y === null)) {
+      debug && this.error('Implosion cast, some imps don\'t have coordinates', imps);
+      return;
+    }
+    imps.forEach(imp => {
+      imp.shouldImplode = true;
+      imp.pushHistory(event.timestamp, 'Marked for implosion', event);
+    });
+    this._lastImplosionCast = event.timestamp;
+    this._implosionTargetsHit = [];
+  }
+
+  on_byPlayer_damage(event) {
+    if (event.ability.guid !== SPELLS.IMPLOSION_DAMAGE.id) {
+      return;
+    }
+    if (!event.x || !event.y) {
+      debug && this.error('Implosion damage event doesn\'t have a target position', event);
+      return;
+    }
+    // Pairing damage events with Imploded Wild Imps
+    // First target hit kills an imp and marks the target
+    // Consequent target hits just mark the target (part of the same AOE explosion)
+    // Next hit on already marked target means new imp explosion
+    const target = encodeTargetString(event.targetID, event.targetInstance);
+    if (this._implosionTargetsHit.length === 0) {
+      test && this.log(`First Implosion damage after cast on ${target}`);
+    }
+    else if (this._implosionTargetsHit.includes(target)) {
+      test && this.log(`Implosion damage on ${target}, already marked => new imp exploded, reset array, marked`);
+    }
+    else if (this._implosionTargetsHit.length > 0 && !this._implosionTargetsHit.includes(target)) {
+      this._implosionTargetsHit.push(target);
+      test && this.log(`Implosion damage on ${target}, not hit yet, marked, skipped`);
+      return;
+    }
+    this._implosionTargetsHit = [target];
+
+    // handle Implosion
+    // Implosion pulls all Wild Imps towards target, exploding them and dealing AoE damage
+    // there's no connection of each damage event to individual Wild Imp, so take Imps that were present at the Implosion cast, order them by the distance from the target and kill them in this order (they should be travelling with the same speed)
+    const imps = this.demoPets._getPets(this._lastImplosionCast) // there's a delay between cast and damage events, might be possible to generate another imps, those shouldn't count, that's why I use Implosion cast timestamp instead of current pets
+      .filter(pet => this.demoPets._wildImpIds.includes(pet.id) && pet.shouldImplode && !pet.realDespawn)
+      .sort((imp1, imp2) => {
+        const distance1 = this._getDistance(imp1.x, imp1.y, event.x, event.y);
+        const distance2 = this._getDistance(imp2.x, imp2.y, event.x, event.y);
+        return distance1 - distance2;
+      });
+    test && this.log('Implosion damage, Imps to be imploded: ', JSON.parse(JSON.stringify(imps)));
+    if (imps.length === 0) {
+      debug && this.error('Error during calculating Implosion distance for imps');
+      if (!this.demoPets._getPets(this._lastImplosionCast).some(pet => this.demoPets._wildImpIds.includes(pet.id))) {
+        debug && this.error('No imps');
+        return;
+      }
+      if (!this.demoPets._getPets(this._lastImplosionCast).some(pet => this.demoPets._wildImpIds.includes(pet.id) && pet.shouldImplode)) {
+        debug && this.error('No implodable imps');
+      }
+      return;
+    }
+    imps[0].despawn(event.timestamp, DESPAWN_REASONS.IMPLOSION);
+    imps[0].setMeta(META_CLASSES.DESTROYED, META_TOOLTIPS.IMPLODED);
+    imps[0].pushHistory(event.timestamp, 'Killed by Implosion', event);
+  }
+
+  _getDistance(x1, y1, x2, y2) {
+    return Math.sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
+  }
+}
+
+export default ImplosionHandler;

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/ImplosionHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/ImplosionHandler.js
@@ -22,7 +22,7 @@ class ImplosionHandler extends Analyzer {
       return;
     }
     // Mark current Wild Imps as "implodable"
-    const imps = this.demoPets.currentPets.filter(pet => this.demoPets._wildImpIds.includes(pet.id));
+    const imps = this.demoPets.currentPets.filter(pet => this.demoPets.wildImpIds.includes(pet.id));
     test && this.log('Implosion cast, current imps', JSON.parse(JSON.stringify(imps)));
     if (imps.some(imp => imp.x === null || imp.y === null)) {
       debug && this.error('Implosion cast, some imps don\'t have coordinates', imps);
@@ -66,7 +66,7 @@ class ImplosionHandler extends Analyzer {
     // Implosion pulls all Wild Imps towards target, exploding them and dealing AoE damage
     // there's no connection of each damage event to individual Wild Imp, so take Imps that were present at the Implosion cast, order them by the distance from the target and kill them in this order (they should be travelling with the same speed)
     const imps = this.demoPets._getPets(this._lastImplosionCast) // there's a delay between cast and damage events, might be possible to generate another imps, those shouldn't count, that's why I use Implosion cast timestamp instead of current pets
-      .filter(pet => this.demoPets._wildImpIds.includes(pet.id) && pet.shouldImplode && !pet.realDespawn)
+      .filter(pet => this.demoPets.wildImpIds.includes(pet.id) && pet.shouldImplode && !pet.realDespawn)
       .sort((imp1, imp2) => {
         const distance1 = this._getDistance(imp1.x, imp1.y, event.x, event.y);
         const distance2 = this._getDistance(imp2.x, imp2.y, event.x, event.y);
@@ -75,11 +75,11 @@ class ImplosionHandler extends Analyzer {
     test && this.log('Implosion damage, Imps to be imploded: ', JSON.parse(JSON.stringify(imps)));
     if (imps.length === 0) {
       debug && this.error('Error during calculating Implosion distance for imps');
-      if (!this.demoPets._getPets(this._lastImplosionCast).some(pet => this.demoPets._wildImpIds.includes(pet.id))) {
+      if (!this.demoPets._getPets(this._lastImplosionCast).some(pet => this.demoPets.wildImpIds.includes(pet.id))) {
         debug && this.error('No imps');
         return;
       }
-      if (!this.demoPets._getPets(this._lastImplosionCast).some(pet => this.demoPets._wildImpIds.includes(pet.id) && pet.shouldImplode)) {
+      if (!this.demoPets._getPets(this._lastImplosionCast).some(pet => this.demoPets.wildImpIds.includes(pet.id) && pet.shouldImplode)) {
         debug && this.error('No implodable imps');
       }
       return;

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/ImplosionHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/ImplosionHandler.js
@@ -6,6 +6,7 @@ import SPELLS from 'common/SPELLS';
 
 import DemoPets from './index';
 import { DESPAWN_REASONS, META_CLASSES, META_TOOLTIPS } from '../TimelinePet';
+import { isWildImp } from '../helpers';
 
 const test = false;
 const debug = false;
@@ -26,7 +27,7 @@ class ImplosionHandler extends Analyzer {
 
   onImplosionCast(event) {
     // Mark current Wild Imps as "implodable"
-    const imps = this.demoPets.currentPets.filter(pet => this.demoPets.wildImpIds.includes(pet.id));
+    const imps = this.demoPets.currentPets.filter(pet => isWildImp(pet.guid));
     test && this.log('Implosion cast, current imps', JSON.parse(JSON.stringify(imps)));
     if (imps.some(imp => imp.x === null || imp.y === null)) {
       debug && this.error('Implosion cast, some imps don\'t have coordinates', imps);
@@ -67,7 +68,7 @@ class ImplosionHandler extends Analyzer {
     // Implosion pulls all Wild Imps towards target, exploding them and dealing AoE damage
     // there's no connection of each damage event to individual Wild Imp, so take Imps that were present at the Implosion cast, order them by the distance from the target and kill them in this order (they should be travelling with the same speed)
     const imps = this.demoPets._getPets(this._lastCast) // there's a delay between cast and damage events, might be possible to generate another imps, those shouldn't count, that's why I use Implosion cast timestamp instead of current pets
-      .filter(pet => this.demoPets.wildImpIds.includes(pet.id) && pet.shouldImplode && !pet.realDespawn)
+      .filter(pet => isWildImp(pet.guid) && pet.shouldImplode && !pet.realDespawn)
       .sort((imp1, imp2) => {
         const distance1 = this._getDistance(imp1.x, imp1.y, event.x, event.y);
         const distance2 = this._getDistance(imp2.x, imp2.y, event.x, event.y);
@@ -76,11 +77,11 @@ class ImplosionHandler extends Analyzer {
     test && this.log('Implosion damage, Imps to be imploded: ', JSON.parse(JSON.stringify(imps)));
     if (imps.length === 0) {
       debug && this.error('Error during calculating Implosion distance for imps');
-      if (!this.demoPets._getPets(this._lastCast).some(pet => this.demoPets.wildImpIds.includes(pet.id))) {
+      if (!this.demoPets._getPets(this._lastCast).some(pet => isWildImp(pet.guid))) {
         debug && this.error('No imps');
         return;
       }
-      if (!this.demoPets._getPets(this._lastCast).some(pet => this.demoPets.wildImpIds.includes(pet.id) && pet.shouldImplode)) {
+      if (!this.demoPets._getPets(this._lastCast).some(pet => isWildImp(pet.guid) && pet.shouldImplode)) {
         debug && this.error('No implodable imps');
       }
       return;

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/PetDamageHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/PetDamageHandler.js
@@ -10,7 +10,7 @@ class PetDamageHandler extends Analyzer {
   };
 
   on_byPlayerPet_damage(event) {
-    const petInfo = this._getPetInfo(event.sourceID);
+    const petInfo = this.demoPets._getPetInfo(event.sourceID);
     if (!petInfo) {
       debug && this.error(`Pet damage event with nonexistant pet id ${event.sourceID}`);
       return;
@@ -19,20 +19,6 @@ class PetDamageHandler extends Analyzer {
     this.demoPets.damage.addDamage(petInfo, event.sourceInstance, damage);
   }
 
-  _getPetInfo(id, isGuid = false) {
-    let pet;
-    if (isGuid) {
-      pet = this.owner.playerPets.find(pet => pet.guid === id);
-    }
-    else {
-      pet = this.owner.playerPets.find(pet => pet.id === id);
-    }
-    if (!pet) {
-      debug && this.error(`NewPets._getPetInfo() called with nonexistant pet ${isGuid ? 'gu' : ''}id ${id}`);
-      return null;
-    }
-    return pet;
-  }
 }
 
 export default PetDamageHandler;

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/PetDamageHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/PetDamageHandler.js
@@ -1,0 +1,38 @@
+import Analyzer from 'parser/core/Analyzer';
+
+import DemoPets from './index';
+
+const debug = false;
+
+class PetDamageHandler extends Analyzer {
+  static dependencies = {
+    demoPets: DemoPets,
+  };
+
+  on_byPlayerPet_damage(event) {
+    const petInfo = this._getPetInfo(event.sourceID);
+    if (!petInfo) {
+      debug && this.error(`Pet damage event with nonexistant pet id ${event.sourceID}`);
+      return;
+    }
+    const damage = event.amount + (event.absorbed || 0);
+    this.demoPets.damage.addDamage(petInfo, event.sourceInstance, damage);
+  }
+
+  _getPetInfo(id, isGuid = false) {
+    let pet;
+    if (isGuid) {
+      pet = this.owner.playerPets.find(pet => pet.guid === id);
+    }
+    else {
+      pet = this.owner.playerPets.find(pet => pet.id === id);
+    }
+    if (!pet) {
+      debug && this.error(`NewPets._getPetInfo() called with nonexistant pet ${isGuid ? 'gu' : ''}id ${id}`);
+      return null;
+    }
+    return pet;
+  }
+}
+
+export default PetDamageHandler;

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/PetDamageHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/PetDamageHandler.js
@@ -1,4 +1,5 @@
-import Analyzer from 'parser/core/Analyzer';
+import Analyzer, { SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
 
 import DemoPets from './index';
 
@@ -9,7 +10,12 @@ class PetDamageHandler extends Analyzer {
     demoPets: DemoPets,
   };
 
-  on_byPlayerPet_damage(event) {
+  constructor(...args) {
+    super(...args);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER_PET), this.onPetDamage);
+  }
+
+  onPetDamage(event) {
     const petInfo = this.demoPets._getPetInfo(event.sourceID);
     if (!petInfo) {
       debug && this.error(`Pet damage event with nonexistant pet id ${event.sourceID}`);

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/PetDamageHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/PetDamageHandler.js
@@ -18,7 +18,6 @@ class PetDamageHandler extends Analyzer {
     const damage = event.amount + (event.absorbed || 0);
     this.demoPets.damage.addDamage(petInfo, event.sourceInstance, damage);
   }
-
 }
 
 export default PetDamageHandler;

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/PetSummonHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/PetSummonHandler.js
@@ -3,7 +3,7 @@ import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 
 import DemoPets from './index';
-import { isPermanentPet } from '../helpers';
+import { isPermanentPet, isWildImp } from '../helpers';
 import { TimelinePet } from '../TimelinePet';
 import PETS from '../PETS';
 import { SUMMON_TO_SPELL_MAP } from '../CONSTANTS';
@@ -43,7 +43,7 @@ class PetSummonHandler extends Analyzer {
       this._getPetDuration(event.targetID),
       this._getSummonSpell(event),
       event.ability.guid);
-    if (this.demoPets.wildImpIds.includes(pet.id)) {
+    if (isWildImp(pet.guid)) {
       // Wild Imps need few additional properties
       pet.setWildImpProperties(this._lastPlayerPosition);
     }
@@ -103,7 +103,7 @@ class PetSummonHandler extends Analyzer {
     }
     // for imps, take Demonic Tyrant in consideration
     // if player doesn't have the buff, it's 15 seconds
-    if (this.demoPets.wildImpIds.includes(pet.id) && this.selectedCombatant.hasBuff(SPELLS.DEMONIC_POWER.id)) {
+    if (isWildImp(pet.guid) && this.selectedCombatant.hasBuff(SPELLS.DEMONIC_POWER.id)) {
       // if player has the buff, it takes the remaining buff time + 15 seconds
       const remainingBuffTime = (this._lastDemonicTyrantCast + DEMONIC_POWER_DURATION) - this.owner.currentTimestamp;
       return PETS[pet.guid].duration + remainingBuffTime;

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/PetSummonHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/PetSummonHandler.js
@@ -41,7 +41,7 @@ class PetSummonHandler extends Analyzer {
       event.targetInstance,
       event.timestamp,
       this._getPetDuration(event.targetID),
-      this._getSummonSpell(event), // needs SUMMON_TO_SPELL_MAP, _lastIDtick, BUFFER, _lastSpendResource
+      this._getSummonSpell(event),
       event.ability.guid);
     if (this.demoPets.wildImpIds.includes(pet.id)) {
       // Wild Imps need few additional properties

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/PetSummonHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/PetSummonHandler.js
@@ -1,9 +1,137 @@
 import Analyzer from 'parser/core/Analyzer';
 
+import SPELLS from 'common/SPELLS';
+
 import DemoPets from './index';
+import { isPermanentPet } from '../helpers';
+import { TimelinePet } from '../TimelinePet';
+import PETS from '../PETS';
+import { SUMMON_TO_SPELL_MAP } from '../CONSTANTS';
+
+const debug = false;
+const test = false;
+const DEMONIC_POWER_DURATION = 15000;
+const BUFFER = 150;
 
 class PetSummonHandler extends Analyzer {
+  static dependencies = {
+    demoPets: DemoPets,
+  };
 
+  _lastDemonicTyrantCast = null;
+  _lastIDtick = null;
+  _lastSpendResource = null;
+  _lastPlayerPosition = {
+    x: 0,
+    y: 0,
+  };
+
+  on_byPlayer_summon(event) {
+    const petInfo = this.demoPets._getPetInfo(event.targetID);
+    if (!petInfo) {
+      debug && this.error('Summoned unknown pet', event);
+      return;
+    }
+    if (isPermanentPet(petInfo.guid)) {
+      test && this.log('Permanent pet summon');
+      this.demoPets.timeline.tryDespawnLastPermanentPet(event.timestamp);
+    }
+    const pet = new TimelinePet(petInfo,
+      event.targetID,
+      event.targetInstance,
+      event.timestamp,
+      this._getPetDuration(event.targetID),
+      this._getSummonSpell(event), // needs SUMMON_TO_SPELL_MAP, _lastIDtick, BUFFER, _lastSpendResource
+      event.ability.guid);
+    if (this.demoPets._wildImpIds.includes(pet.id)) {
+      // Wild Imps need few additional properties
+      pet.setWildImpProperties(this._lastPlayerPosition);
+    }
+    test && this.log('Pet summoned', pet);
+    this.demoPets.timeline.addPet(pet);
+    pet.pushHistory(event.timestamp, 'Summoned', event);
+    if (pet.summonedBy === SPELLS.INNER_DEMONS_TALENT.id) {
+      this._lastIDtick = event.timestamp;
+    }
+  }
+
+  on_byPlayer_cast(event) {
+    this._updatePlayerPosition(event);
+    if (event.ability.guid !== SPELLS.SUMMON_DEMONIC_TYRANT.id) {
+      return;
+    }
+    this._lastDemonicTyrantCast = event.timestamp;
+  }
+
+  on_byPlayer_spendresource(event) {
+    this._lastSpendResource = event.timestamp;
+  }
+
+  // to update player position more accurately (based on DistanceMoved)
+  // important, since Wild Imp summons uses player position as default (not entirely accurate, as they're spawned around player, not exactly on top of it, but that's as close as I'm gonna get)
+  // needed for Implosion - there's a possibility that Wild Imps don't cast anything between their 'summon' and Implosion, therefore I wouldn't get their position
+
+  on_toPlayer_damage(event) {
+    this._updatePlayerPosition(event);
+  }
+
+  on_toPlayer_energize(event) {
+    this._updatePlayerPosition(event);
+  }
+
+  on_toPlayer_heal(event) {
+    this._updatePlayerPosition(event);
+  }
+
+  on_toPlayer_absorbed(event) {
+    this._updatePlayerPosition(event);
+  }
+
+  _getPetDuration(id, isGuid = false) {
+    const pet = this.demoPets._getPetInfo(id, isGuid);
+    if (!pet) {
+      debug && this.error(`NewPets._getPetDuration() called with nonexistant pet ${isGuid ? 'gu' : ''}id ${id}`);
+      return -1;
+    }
+    if (isPermanentPet(pet.guid)) {
+      debug && this.log('Called _getPetDuration() for permanent pet guid', pet);
+      return Infinity;
+    }
+    if (!PETS[pet.guid]) {
+      debug && this.error('Encountered pet unknown to PET_INFO.js', pet);
+      return -1;
+    }
+    // for imps, take Demonic Tyrant in consideration
+    // if player doesn't have the buff, it's 15 seconds
+    if (this.demoPets._wildImpIds.includes(pet.id) && this.selectedCombatant.hasBuff(SPELLS.DEMONIC_POWER.id)) {
+      // if player has the buff, it takes the remaining buff time + 15 seconds
+      const remainingBuffTime = (this._lastDemonicTyrantCast + DEMONIC_POWER_DURATION) - this.owner.currentTimestamp;
+      return PETS[pet.guid].duration + remainingBuffTime;
+    }
+    return PETS[pet.guid].duration;
+  }
+
+  _getSummonSpell(event) {
+    if (!SUMMON_TO_SPELL_MAP[event.ability.guid]) {
+      if (event.timestamp <= this._lastIDtick + BUFFER) {
+        return SPELLS.INNER_DEMONS_TALENT.id;
+      }
+      if (this.selectedCombatant.hasBuff(SPELLS.NETHER_PORTAL_BUFF.id) && event.timestamp <= this._lastSpendResource + BUFFER) {
+        return SPELLS.NETHER_PORTAL_TALENT.id;
+      }
+      debug && this.error('Unknown source of summon event', event);
+      return -1;
+    }
+    return SUMMON_TO_SPELL_MAP[event.ability.guid];
+  }
+
+  _updatePlayerPosition(event) {
+    if (!event.x || !event.y) {
+      return;
+    }
+    this._lastPlayerPosition.x = event.x;
+    this._lastPlayerPosition.y = event.y;
+  }
 }
 
 export default PetSummonHandler;

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/PetSummonHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/PetSummonHandler.js
@@ -43,7 +43,7 @@ class PetSummonHandler extends Analyzer {
       this._getPetDuration(event.targetID),
       this._getSummonSpell(event), // needs SUMMON_TO_SPELL_MAP, _lastIDtick, BUFFER, _lastSpendResource
       event.ability.guid);
-    if (this.demoPets._wildImpIds.includes(pet.id)) {
+    if (this.demoPets.wildImpIds.includes(pet.id)) {
       // Wild Imps need few additional properties
       pet.setWildImpProperties(this._lastPlayerPosition);
     }
@@ -103,7 +103,7 @@ class PetSummonHandler extends Analyzer {
     }
     // for imps, take Demonic Tyrant in consideration
     // if player doesn't have the buff, it's 15 seconds
-    if (this.demoPets._wildImpIds.includes(pet.id) && this.selectedCombatant.hasBuff(SPELLS.DEMONIC_POWER.id)) {
+    if (this.demoPets.wildImpIds.includes(pet.id) && this.selectedCombatant.hasBuff(SPELLS.DEMONIC_POWER.id)) {
       // if player has the buff, it takes the remaining buff time + 15 seconds
       const remainingBuffTime = (this._lastDemonicTyrantCast + DEMONIC_POWER_DURATION) - this.owner.currentTimestamp;
       return PETS[pet.guid].duration + remainingBuffTime;

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/PetSummonHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/PetSummonHandler.js
@@ -1,0 +1,9 @@
+import Analyzer from 'parser/core/Analyzer';
+
+import DemoPets from './index';
+
+class PetSummonHandler extends Analyzer {
+
+}
+
+export default PetSummonHandler;

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/PowerSiphonHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/PowerSiphonHandler.js
@@ -29,7 +29,7 @@ class PowerSiphonHandler extends Analyzer {
     // gets current imps that aren't "scheduled for implosion"
     // filters out only those that aren't active after the cast (they can't be killed because they're casting in the future)
     const currentImps = this.demoPets.currentPets
-      .filter(pet => this.demoPets._wildImpIds.includes(pet.id) && !pet.shouldImplode)
+      .filter(pet => this.demoPets.wildImpIds.includes(pet.id) && !pet.shouldImplode)
       .sort((imp1, imp2) => (imp1.currentEnergy - imp2.currentEnergy) || (imp1.spawn - imp2.spawn));
     const filtered = currentImps
       .filter(imp => !event.activeImpsAfterCast.includes(encodeTargetString(imp.id, imp.instance)));

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/PowerSiphonHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/PowerSiphonHandler.js
@@ -1,0 +1,54 @@
+import Analyzer from 'parser/core/Analyzer';
+import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
+
+import SPELLS from 'common/SPELLS';
+
+import DemoPets from './index';
+import { DESPAWN_REASONS, META_CLASSES, META_TOOLTIPS } from '../TimelinePet';
+
+const debug = false;
+const test = false;
+
+class PowerSiphonHandler extends Analyzer {
+  static dependencies = {
+    demoPets: DemoPets,
+  };
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.POWER_SIPHON_TALENT.id);
+  }
+
+  on_byPlayer_cast(event) {
+    if (event.ability.guid !== SPELLS.POWER_SIPHON_TALENT.id) {
+      return;
+    }
+    if (!event.activeImpsAfterCast || event.activeImpsAfterCast.length === 0) {
+      debug && this.error('Power Siphon cast didn\'t have any active imps after cast', event);
+    }
+    // gets current imps that aren't "scheduled for implosion"
+    // filters out only those that aren't active after the cast (they can't be killed because they're casting in the future)
+    const currentImps = this.demoPets.currentPets
+      .filter(pet => this.demoPets._wildImpIds.includes(pet.id) && !pet.shouldImplode)
+      .sort((imp1, imp2) => (imp1.currentEnergy - imp2.currentEnergy) || (imp1.spawn - imp2.spawn));
+    const filtered = currentImps
+      .filter(imp => !event.activeImpsAfterCast.includes(encodeTargetString(imp.id, imp.instance)));
+    test && this.log('POWER SIPHON cast', event.timestamp, ', current imps, sorted', JSON.parse(JSON.stringify(currentImps)));
+    test && this.log('Imps that AREN\'T active after PS cast, sorted', JSON.parse(JSON.stringify(filtered)));
+    // doesn't really make sense - sometimes you have loads of imps to sacrifice, but it doesn't pick them (because they're active after the cast)
+    if (filtered.length === 0) {
+      // game won't let you cast Power Siphon without available Wild Imps, if cast went through and we don't have Imps, we've done something wrong
+      debug && this.error('Something wrong, no Imps found on Power Siphon cast');
+      return;
+    }
+    // kill up to 2 imps
+    filtered.slice(0, 2).forEach(imp => {
+      imp.despawn(event.timestamp, DESPAWN_REASONS.POWER_SIPHON);
+      imp.setMeta(META_CLASSES.DESTROYED, META_TOOLTIPS.POWER_SIPHON);
+      imp.pushHistory(event.timestamp, 'Killed by Power Siphon', event);
+      test && this.log(`Despawning imp`, imp);
+    });
+  }
+}
+
+export default PowerSiphonHandler;

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/PowerSiphonHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/PowerSiphonHandler.js
@@ -1,5 +1,6 @@
-import Analyzer from 'parser/core/Analyzer';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
+import Events from 'parser/core/Events';
 
 import SPELLS from 'common/SPELLS';
 
@@ -17,12 +18,10 @@ class PowerSiphonHandler extends Analyzer {
   constructor(...args) {
     super(...args);
     this.active = this.selectedCombatant.hasTalent(SPELLS.POWER_SIPHON_TALENT.id);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.POWER_SIPHON_TALENT), this.onPowerSiphonCast);
   }
 
-  on_byPlayer_cast(event) {
-    if (event.ability.guid !== SPELLS.POWER_SIPHON_TALENT.id) {
-      return;
-    }
+  onPowerSiphonCast(event) {
     if (!event.activeImpsAfterCast || event.activeImpsAfterCast.length === 0) {
       debug && this.error('Power Siphon cast didn\'t have any active imps after cast', event);
     }

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/PowerSiphonHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/PowerSiphonHandler.js
@@ -6,6 +6,7 @@ import SPELLS from 'common/SPELLS';
 
 import DemoPets from './index';
 import { DESPAWN_REASONS, META_CLASSES, META_TOOLTIPS } from '../TimelinePet';
+import { isWildImp } from '../helpers';
 
 const debug = false;
 const test = false;
@@ -28,7 +29,7 @@ class PowerSiphonHandler extends Analyzer {
     // gets current imps that aren't "scheduled for implosion"
     // filters out only those that aren't active after the cast (they can't be killed because they're casting in the future)
     const currentImps = this.demoPets.currentPets
-      .filter(pet => this.demoPets.wildImpIds.includes(pet.id) && !pet.shouldImplode)
+      .filter(pet => isWildImp(pet.guid) && !pet.shouldImplode)
       .sort((imp1, imp2) => (imp1.currentEnergy - imp2.currentEnergy) || (imp1.spawn - imp2.spawn));
     const filtered = currentImps
       .filter(imp => !event.activeImpsAfterCast.includes(encodeTargetString(imp.id, imp.instance)));

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/WildImpEnergyHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/WildImpEnergyHandler.js
@@ -1,4 +1,5 @@
-import Analyzer from 'parser/core/Analyzer';
+import Analyzer, { SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
 
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
@@ -13,7 +14,12 @@ class WildImpEnergyHandler extends Analyzer {
     demoPets: DemoPets,
   };
 
-  on_byPlayerPet_cast(event) {
+  constructor(...args) {
+    super(...args);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER_PET), this.onPetCast);
+  }
+
+  onPetCast(event) {
     // handle Wild Imp energy - they should despawn when their energy reaches 0
     if (!this.demoPets.wildImpIds.includes(event.sourceID)) {
       return;

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/WildImpEnergyHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/WildImpEnergyHandler.js
@@ -15,7 +15,7 @@ class WildImpEnergyHandler extends Analyzer {
 
   on_byPlayerPet_cast(event) {
     // handle Wild Imp energy - they should despawn when their energy reaches 0
-    if (!this.demoPets._wildImpIds.includes(event.sourceID)) {
+    if (!this.demoPets.wildImpIds.includes(event.sourceID)) {
       return;
     }
     const pet = this.demoPets._getPetFromTimeline(event.sourceID, event.sourceInstance);

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/WildImpEnergyHandler.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/WildImpEnergyHandler.js
@@ -1,0 +1,53 @@
+import Analyzer from 'parser/core/Analyzer';
+
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+
+import DemoPets from './index';
+import { DESPAWN_REASONS, META_CLASSES, META_TOOLTIPS } from '../TimelinePet';
+
+const debug = false;
+const test = false;
+
+class WildImpEnergyHandler extends Analyzer {
+  static dependencies = {
+    demoPets: DemoPets,
+  };
+
+  on_byPlayerPet_cast(event) {
+    // handle Wild Imp energy - they should despawn when their energy reaches 0
+    if (!this.demoPets._wildImpIds.includes(event.sourceID)) {
+      return;
+    }
+    const pet = this.demoPets._getPetFromTimeline(event.sourceID, event.sourceInstance);
+    if (!pet) {
+      debug && this.error('Wild Imp from cast event not in timeline!', event);
+      return;
+    }
+    if (pet.realDespawn && event.timestamp >= pet.realDespawn) {
+      debug && this.error('Wild Imp casted something after despawn', pet, event);
+      return;
+    }
+    const energyResource = event.classResources && event.classResources.find(resource => resource.type === RESOURCE_TYPES.ENERGY.id);
+    if (!energyResource) {
+      debug && this.error('Wild Imp doesn\'t have energy class resource field', event);
+      return;
+    }
+    pet.updatePosition(event);
+    const oldEnergy = pet.currentEnergy;
+    const newEnergy = energyResource.amount - (energyResource.cost || 0); // if Wild Imp is extended by Demonic Tyrant, their casts are essentially free, and the 'cost' field is not present in the event
+    pet.currentEnergy = newEnergy;
+    if (oldEnergy === pet.currentEnergy) {
+      // Imp was empowered at least once, mark as empowered
+      pet.setMeta(META_CLASSES.EMPOWERED, META_TOOLTIPS.EMPOWERED);
+    }
+    pet.pushHistory(event.timestamp, 'Cast', event, 'old energy', oldEnergy, 'new energy', pet.currentEnergy);
+
+    if (pet.currentEnergy === 0) {
+      pet.despawn(event.timestamp, DESPAWN_REASONS.ZERO_ENERGY);
+      pet.pushHistory(event.timestamp, 'Killed by 0 energy', event);
+      test && this.log('Despawning Wild Imp', pet);
+    }
+  }
+}
+
+export default WildImpEnergyHandler;

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/index.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/index.js
@@ -1,22 +1,13 @@
 import Analyzer from 'parser/core/Analyzer';
-import SPELLS from 'common/SPELLS';
 
 import Timeline from '../Timeline';
 import PetDamage from '../PetDamage';
-import PETS from '../PETS';
 
 const debug = false;
 
 class DemoPets extends Analyzer {
   damage = new PetDamage();
   timeline = new Timeline();
-
-  wildImpIds = []; // important for different handling of duration, these IDs change from log to log
-
-  constructor(...args) {
-    super(...args);
-    this.initializeWildImps();
-  }
 
   // API
 
@@ -71,21 +62,6 @@ class DemoPets extends Analyzer {
       return null;
     }
     return pet;
-  }
-
-  initializeWildImps() {
-    // there's very little possibility these statements wouldn't return an object, Hand of Guldan is a key part of rotation
-    this.wildImpIds.push(this._toId(PETS.WILD_IMP_HOG.guid));
-    if (this.selectedCombatant.hasTalent(SPELLS.INNER_DEMONS_TALENT.id)) {
-      // and Inner Demons passively summons these Wild Imps
-      this.wildImpIds.push(this._toId(PETS.WILD_IMP_INNER_DEMONS.guid));
-    }
-    // basically player would have to be dead from the beginning to end to not have these recorded
-    // (and even then it's probably fine, because it takes the info from parser.playerPets, which is cross-fight)
-  }
-
-  _toId(guid) {
-    return this._getPetInfo(guid, true).id;
   }
 
   _toGuid(id) {

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/index.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/index.js
@@ -70,9 +70,6 @@ class DemoPets extends Analyzer {
     else if (event.ability.guid === SPELLS.SUMMON_DEMONIC_TYRANT.id) {
       this._handleDemonicTyrantCast(event);
     }
-    else if (event.ability.guid === SPELLS.POWER_SIPHON_TALENT.id) {
-      this._handlePowerSiphonCast(event);
-    }
   }
 
   on_byPlayer_damage(event) {
@@ -212,34 +209,6 @@ class DemoPets extends Analyzer {
       }
     });
     test && this.log('Pets after Demonic Tyrant cast', JSON.parse(JSON.stringify(this.currentPets)));
-  }
-
-  _handlePowerSiphonCast(event) {
-    if (!event.activeImpsAfterCast || event.activeImpsAfterCast.length === 0) {
-      debug && this.error('Power Siphon cast didn\'t have any active imps after cast', event);
-    }
-    // gets current imps that aren't "scheduled for implosion"
-    // filters out only those that aren't active after the cast (they can't be killed because they're casting in the future)
-    const currentImps = this.currentPets
-      .filter(pet => this._wildImpIds.includes(pet.id) && !pet.shouldImplode)
-      .sort((imp1, imp2) => (imp1.currentEnergy - imp2.currentEnergy) || (imp1.spawn - imp2.spawn));
-    const filtered = currentImps
-      .filter(imp => !event.activeImpsAfterCast.includes(encodeTargetString(imp.id, imp.instance)));
-    test && this.log('POWER SIPHON cast', event.timestamp, ', current imps, sorted', JSON.parse(JSON.stringify(currentImps)));
-    test && this.log('Imps that AREN\'T active after PS cast, sorted', JSON.parse(JSON.stringify(filtered)));
-    // doesn't really make sense - sometimes you have loads of imps to sacrifice, but it doesn't pick them (because they're active after the cast)
-    if (filtered.length === 0) {
-      // game won't let you cast Power Siphon without available Wild Imps, if cast went through and we don't have Imps, we've done something wrong
-      debug && this.error('Something wrong, no Imps found on Power Siphon cast');
-      return;
-    }
-    // kill up to 2 imps
-    filtered.slice(0, 2).forEach(imp => {
-      imp.despawn(event.timestamp, DESPAWN_REASONS.POWER_SIPHON);
-      imp.setMeta(META_CLASSES.DESTROYED, META_TOOLTIPS.POWER_SIPHON);
-      imp.pushHistory(event.timestamp, 'Killed by Power Siphon', event);
-      test && this.log(`Despawning imp`, imp);
-    });
   }
 
   _getPets(timestamp = this.owner.currentTimestamp) {

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/index.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/index.js
@@ -7,38 +7,6 @@ import PETS from '../PETS';
 
 const debug = false;
 
-  /*
-    TEST LOG - http://localhost:3000/report/3WQ2BFC4AJPqDLra/13-LFR+Mythrax+-+Kill+(4:22)/260-Grogar
-
-    BEFORE REFACTOR - data that should remain the same!
-    ​	_hasDemonicConsumption: false
-    ​	_implosionTargetsHit: [ "33.0" ]
-    ​	_lastDemonicTyrantCast: 54135785
-    ​	_lastIDtick: 54169689
-    ​	_lastImplosionCast: 54151999
-    ​	_lastPlayerPosition: { x: 24331, y: 23459 }
-    ​	_lastSpendResource: 54168237
-    ​	_petsAffectedByDemonicTyrant: [ 287, 264, 276, 285 ]
-    ​	wildImpIds: [ 287, 264 ]
-      timeline.length = 148
-      // guid, name and total
-      damage.pets = {
-        55659 - Wild Imp, 199027
-        98035 - Dreadstalker, 364343
-        135002 - Demonic Tyrant, 114633
-        135816 - Vilefiend, 187418
-        136398 - Illidari Satyr, 4139
-        136402 - Urzul, 19825
-        136403 - Void Terror, 35451
-        136404 - Bilescourge, 13010
-        136406 - Shivarra, 9502
-        136407 - Wrathguard, 20836
-        136408 - Darkhound, 18047
-        143622 - Wild Imp, 51730
-        36961778 - Flaatom, 343638
-
-      }
- */
 class DemoPets extends Analyzer {
   damage = new PetDamage();
   timeline = new Timeline();

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/index.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/index.js
@@ -1,14 +1,11 @@
 import Analyzer from 'parser/core/Analyzer';
-import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
 import SPELLS from 'common/SPELLS';
 
 import Timeline from '../Timeline';
-import { DESPAWN_REASONS, META_CLASSES, META_TOOLTIPS } from '../TimelinePet';
 import PetDamage from '../PetDamage';
 import PETS from '../PETS';
 
 const debug = false;
-const test = false;
 
   /*
     TEST LOG - http://localhost:3000/report/3WQ2BFC4AJPqDLra/13-LFR+Mythrax+-+Kill+(4:22)/260-Grogar
@@ -46,76 +43,12 @@ class DemoPets extends Analyzer {
   damage = new PetDamage();
   timeline = new Timeline();
 
-  _lastImplosionCast = null;
-  _implosionTargetsHit = [];
   _wildImpIds = []; // important for different handling of duration, these IDs change from log to log
 
   constructor(...args) {
     super(...args);
     this._initializeWildImps();
   }
-
-  // Pet timeline
-
-  on_byPlayer_cast(event) {
-    if (event.ability.guid === SPELLS.IMPLOSION_CAST.id) {
-      this._handleImplosionCast(event);
-    }
-  }
-
-  on_byPlayer_damage(event) {
-    if (event.ability.guid !== SPELLS.IMPLOSION_DAMAGE.id) {
-      return;
-    }
-    if (!event.x || !event.y) {
-      debug && this.error('Implosion damage event doesn\'t have a target position', event);
-      return;
-    }
-    // Pairing damage events with Imploded Wild Imps
-    // First target hit kills an imp and marks the target
-    // Consequent target hits just mark the target (part of the same AOE explosion)
-    // Next hit on already marked target means new imp explosion
-    const target = encodeTargetString(event.targetID, event.targetInstance);
-    if (this._implosionTargetsHit.length === 0) {
-      test && this.log(`First Implosion damage after cast on ${target}`);
-    }
-    else if (this._implosionTargetsHit.includes(target)) {
-      test && this.log(`Implosion damage on ${target}, already marked => new imp exploded, reset array, marked`);
-    }
-    else if (this._implosionTargetsHit.length > 0 && !this._implosionTargetsHit.includes(target)) {
-      this._implosionTargetsHit.push(target);
-      test && this.log(`Implosion damage on ${target}, not hit yet, marked, skipped`);
-      return;
-    }
-    this._implosionTargetsHit = [target];
-
-    // handle Implosion
-    // Implosion pulls all Wild Imps towards target, exploding them and dealing AoE damage
-    // there's no connection of each damage event to individual Wild Imp, so take Imps that were present at the Implosion cast, order them by the distance from the target and kill them in this order (they should be travelling with the same speed)
-    const imps = this._getPets(this._lastImplosionCast) // there's a delay between cast and damage events, might be possible to generate another imps, those shouldn't count, that's why I use Implosion cast timestamp instead of current pets
-      .filter(pet => this._wildImpIds.includes(pet.id) && pet.shouldImplode && !pet.realDespawn)
-      .sort((imp1, imp2) => {
-        const distance1 = this._getDistance(imp1.x, imp1.y, event.x, event.y);
-        const distance2 = this._getDistance(imp2.x, imp2.y, event.x, event.y);
-        return distance1 - distance2;
-      });
-    test && this.log('Implosion damage, Imps to be imploded: ', JSON.parse(JSON.stringify(imps)));
-    if (imps.length === 0) {
-      debug && this.error('Error during calculating Implosion distance for imps');
-      if (!this._getPets(this._lastImplosionCast).some(pet => this._wildImpIds.includes(pet.id))) {
-        debug && this.error('No imps');
-        return;
-      }
-      if (!this._getPets(this._lastImplosionCast).some(pet => this._wildImpIds.includes(pet.id) && pet.shouldImplode)) {
-        debug && this.error('No implodable imps');
-      }
-      return;
-    }
-    imps[0].despawn(event.timestamp, DESPAWN_REASONS.IMPLOSION);
-    imps[0].setMeta(META_CLASSES.DESTROYED, META_TOOLTIPS.IMPLODED);
-    imps[0].pushHistory(event.timestamp, 'Killed by Implosion', event);
-  }
-
 
   // API
 
@@ -148,22 +81,6 @@ class DemoPets extends Analyzer {
   }
 
   // HELPER METHODS
-
-  _handleImplosionCast(event) {
-    // Mark current Wild Imps as "implodable"
-    const imps = this.currentPets.filter(pet => this._wildImpIds.includes(pet.id));
-    test && this.log('Implosion cast, current imps', JSON.parse(JSON.stringify(imps)));
-    if (imps.some(imp => imp.x === null || imp.y === null)) {
-      debug && this.error('Implosion cast, some imps don\'t have coordinates', imps);
-      return;
-    }
-    imps.forEach(imp => {
-      imp.shouldImplode = true;
-      imp.pushHistory(event.timestamp, 'Marked for implosion', event);
-    });
-    this._lastImplosionCast = event.timestamp;
-    this._implosionTargetsHit = [];
-  }
 
   _getPets(timestamp = this.owner.currentTimestamp) {
     return this.timeline.getPetsAtTimestamp(timestamp);
@@ -205,10 +122,6 @@ class DemoPets extends Analyzer {
 
   _toGuid(id) {
     return this._getPetInfo(id).guid;
-  }
-
-  _getDistance(x1, y1, x2, y2) {
-    return Math.sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
   }
 }
 

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/index.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/index.js
@@ -1,7 +1,6 @@
 import Analyzer from 'parser/core/Analyzer';
 import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
 import SPELLS from 'common/SPELLS';
-import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 import Timeline from '../Timeline';
 import { DESPAWN_REASONS, META_CLASSES, META_TOOLTIPS } from '../TimelinePet';
@@ -127,42 +126,6 @@ class DemoPets extends Analyzer {
     imps[0].despawn(event.timestamp, DESPAWN_REASONS.IMPLOSION);
     imps[0].setMeta(META_CLASSES.DESTROYED, META_TOOLTIPS.IMPLODED);
     imps[0].pushHistory(event.timestamp, 'Killed by Implosion', event);
-  }
-
-  on_byPlayerPet_cast(event) {
-    // handle Wild Imp energy - they should despawn when their energy reaches 0
-    if (!this._wildImpIds.includes(event.sourceID)) {
-      return;
-    }
-    const pet = this._getPetFromTimeline(event.sourceID, event.sourceInstance);
-    if (!pet) {
-      debug && this.error('Wild Imp from cast event not in timeline!', event);
-      return;
-    }
-    if (pet.realDespawn && event.timestamp >= pet.realDespawn) {
-      debug && this.error('Wild Imp casted something after despawn', pet, event);
-      return;
-    }
-    const energyResource = event.classResources && event.classResources.find(resource => resource.type === RESOURCE_TYPES.ENERGY.id);
-    if (!energyResource) {
-      debug && this.error('Wild Imp doesn\'t have energy class resource field', event);
-      return;
-    }
-    pet.updatePosition(event);
-    const oldEnergy = pet.currentEnergy;
-    const newEnergy = energyResource.amount - (energyResource.cost || 0); // if Wild Imp is extended by Demonic Tyrant, their casts are essentially free, and the 'cost' field is not present in the event
-    pet.currentEnergy = newEnergy;
-    if (oldEnergy === pet.currentEnergy) {
-      // Imp was empowered at least once, mark as empowered
-      pet.setMeta(META_CLASSES.EMPOWERED, META_TOOLTIPS.EMPOWERED);
-    }
-    pet.pushHistory(event.timestamp, 'Cast', event, 'old energy', oldEnergy, 'new energy', pet.currentEnergy);
-
-    if (pet.currentEnergy === 0) {
-      pet.despawn(event.timestamp, DESPAWN_REASONS.ZERO_ENERGY);
-      pet.pushHistory(event.timestamp, 'Killed by 0 energy', event);
-      test && this.log('Despawning Wild Imp', pet);
-    }
   }
 
   on_toPlayer_removebuff(event) {

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/index.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/index.js
@@ -19,7 +19,7 @@ const debug = false;
     ​	_lastPlayerPosition: { x: 24331, y: 23459 }
     ​	_lastSpendResource: 54168237
     ​	_petsAffectedByDemonicTyrant: [ 287, 264, 276, 285 ]
-    ​	_wildImpIds: [ 287, 264 ]
+    ​	wildImpIds: [ 287, 264 ]
       timeline.length = 148
       // guid, name and total
       damage.pets = {
@@ -43,11 +43,11 @@ class DemoPets extends Analyzer {
   damage = new PetDamage();
   timeline = new Timeline();
 
-  _wildImpIds = []; // important for different handling of duration, these IDs change from log to log
+  wildImpIds = []; // important for different handling of duration, these IDs change from log to log
 
   constructor(...args) {
     super(...args);
-    this._initializeWildImps();
+    this.initializeWildImps();
   }
 
   // API
@@ -105,12 +105,12 @@ class DemoPets extends Analyzer {
     return pet;
   }
 
-  _initializeWildImps() {
+  initializeWildImps() {
     // there's very little possibility these statements wouldn't return an object, Hand of Guldan is a key part of rotation
-    this._wildImpIds.push(this._toId(PETS.WILD_IMP_HOG.guid));
+    this.wildImpIds.push(this._toId(PETS.WILD_IMP_HOG.guid));
     if (this.selectedCombatant.hasTalent(SPELLS.INNER_DEMONS_TALENT.id)) {
       // and Inner Demons passively summons these Wild Imps
-      this._wildImpIds.push(this._toId(PETS.WILD_IMP_INNER_DEMONS.guid));
+      this.wildImpIds.push(this._toId(PETS.WILD_IMP_INNER_DEMONS.guid));
     }
     // basically player would have to be dead from the beginning to end to not have these recorded
     // (and even then it's probably fine, because it takes the info from parser.playerPets, which is cross-fight)

--- a/src/parser/warlock/demonology/modules/pets/DemoPets/index.js
+++ b/src/parser/warlock/demonology/modules/pets/DemoPets/index.js
@@ -3,18 +3,51 @@ import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
 import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
-import Timeline from './Timeline';
-import { TimelinePet, DESPAWN_REASONS, META_CLASSES, META_TOOLTIPS } from './TimelinePet';
-import PetDamage from './PetDamage';
-import { isPermanentPet } from './helpers';
-import PETS from './PETS';
-import { SUMMON_TO_SPELL_MAP } from './CONSTANTS';
+import Timeline from '../Timeline';
+import { TimelinePet, DESPAWN_REASONS, META_CLASSES, META_TOOLTIPS } from '../TimelinePet';
+import PetDamage from '../PetDamage';
+import { isPermanentPet } from '../helpers';
+import PETS from '../PETS';
+import { SUMMON_TO_SPELL_MAP } from '../CONSTANTS';
 
 const BUFFER = 150;
 const DEMONIC_POWER_DURATION = 15000;
 const debug = false;
 const test = false;
 
+  /*
+    TEST LOG - http://localhost:3000/report/3WQ2BFC4AJPqDLra/13-LFR+Mythrax+-+Kill+(4:22)/260-Grogar
+
+    BEFORE REFACTOR - data that should remain the same!
+      _demonicTyrantBuffEnd: 54150759
+    ​	_hasDemonicConsumption: false
+    ​	_implosionTargetsHit: [ "33.0" ]
+    ​	_lastDemonicTyrantCast: 54135785
+    ​	_lastIDtick: 54169689
+    ​	_lastImplosionCast: 54151999
+    ​	_lastPlayerPosition: { x: 24331, y: 23459 }
+    ​	_lastSpendResource: 54168237
+    ​	_petsAffectedByDemonicTyrant: [ 287, 264, 276, 285 ]
+    ​	_wildImpIds: [ 287, 264 ]
+      timeline.length = 148
+      // guid, name and total
+      damage.pets = {
+        55659 - Wild Imp, 199027
+        98035 - Dreadstalker, 364343
+        135002 - Demonic Tyrant, 114633
+        135816 - Vilefiend, 187418
+        136398 - Illidari Satyr, 4139
+        136402 - Urzul, 19825
+        136403 - Void Terror, 35451
+        136404 - Bilescourge, 13010
+        136406 - Shivarra, 9502
+        136407 - Wrathguard, 20836
+        136408 - Darkhound, 18047
+        143622 - Wild Imp, 51730
+        36961778 - Flaatom, 343638
+
+      }
+ */
 class DemoPets extends Analyzer {
   damage = new PetDamage();
   timeline = new Timeline();
@@ -37,18 +70,6 @@ class DemoPets extends Analyzer {
     this._initializeWildImps();
     this._initializeDemonicTyrantPets();
     this._hasDemonicConsumption = this.selectedCombatant.hasTalent(SPELLS.DEMONIC_CONSUMPTION_TALENT.id);
-  }
-
-  // Pet damage
-
-  on_byPlayerPet_damage(event) {
-    const petInfo = this._getPetInfo(event.sourceID);
-    if (!petInfo) {
-      debug && this.error(`Pet damage event with nonexistant pet id ${event.sourceID}`);
-      return;
-    }
-    const damage = event.amount + (event.absorbed || 0);
-    this.damage.addDamage(petInfo, event.sourceInstance, damage);
   }
 
   // Pet timeline

--- a/src/parser/warlock/demonology/modules/pets/PETS.js
+++ b/src/parser/warlock/demonology/modules/pets/PETS.js
@@ -1,3 +1,5 @@
+import SPELLS from 'common/SPELLS';
+
 const INNER_DEMON_NETHER_PORTAL_DURATION = 15000;
 
 const indexByGuid = obj => {
@@ -12,67 +14,106 @@ const PETS = {
   WILD_IMP_HOG: {
     guid: 55659,
     duration: 15000, // maximum duration, realistically is handled differently
+    summonAbility: SPELLS.WILD_IMP_HOG_SUMMON.id,
+    isWildImp: true,
+    isAffectedByDemonicTyrant: true,
+    summonSpell: SPELLS.HAND_OF_GULDAN_CAST.id,
   },
   DREADSTALKER: {
     guid: 98035,
     duration: 12000,
+    summonAbility: [SPELLS.DREADSTALKER_SUMMON_1.id, SPELLS.DREADSTALKER_SUMMON_2.id],
+    isAffectedByDemonicTyrant: true,
+    summonSpell: SPELLS.CALL_DREADSTALKERS.id,
   },
   VILEFIEND: {
     guid: 135816,
     duration: 15000,
+    summonAbility: SPELLS.SUMMON_VILEFIEND_TALENT.id,
+    isAffectedByDemonicTyrant: true,
+    summonSpell: SPELLS.SUMMON_VILEFIEND_TALENT.id,
   },
   GRIMOIRE_FELGUARD: {
     guid: 17252,
     duration: 15000,
+    summonAbility: SPELLS.GRIMOIRE_FELGUARD_TALENT.id,
+    isAffectedByDemonicTyrant: true,
+    summonSpell: SPELLS.GRIMOIRE_FELGUARD_TALENT.id,
   },
   DEMONIC_TYRANT: {
     guid: 135002,
     duration: 15000,
+    summonAbility: SPELLS.SUMMON_DEMONIC_TYRANT.id,
+    summonSpell: SPELLS.SUMMON_DEMONIC_TYRANT.id,
   },
   // Inner Demons and Nether Portal demons
   WILD_IMP_INNER_DEMONS: {
     guid: 143622,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
+    summonAbility: SPELLS.WILD_IMP_ID_SUMMON.id,
+    isWildImp: true,
+    isAffectedByDemonicTyrant: true,
+    summonSpell: SPELLS.INNER_DEMONS_TALENT.id,
   },
   BILESCOURGE: {
     guid: 136404,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
+    summonAbility: SPELLS.BILESCOURGE_SUMMON.id,
+    isRandom: true,
   },
   VICIOUS_HELLHOUND: {
     guid: 136399,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
+    summonAbility: SPELLS.VICIOUS_HELLHOUND_SUMMON.id,
+    isRandom: true,
   },
   SHIVARRA: {
     guid: 136406,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
+    summonAbility: SPELLS.SHIVARRA_SUMMON.id,
+    isRandom: true,
   },
   DARKHOUND: {
     guid: 136408,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
+    summonAbility: SPELLS.DARKHOUND_SUMMON.id,
+    isRandom: true,
   },
   ILLIDARI_SATYR: {
     guid: 136398,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
+    summonAbility: SPELLS.ILLIDARI_SATYR_SUMMON.id,
+    isRandom: true,
   },
   VOID_TERROR: {
     guid: 136403,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
+    summonAbility: SPELLS.VOID_TERROR_SUMMON.id,
+    isRandom: true,
   },
   URZUL: {
     guid: 136402,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
+    summonAbility: SPELLS.URZUL_SUMMON.id,
+    isRandom: true,
   },
   WRATHGUARD: {
     guid: 136407,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
+    summonAbility: SPELLS.WRATHGUARD_SUMMON.id,
+    isRandom: true,
   },
   EYE_OF_GULDAN: {
     guid: 136401,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
+    summonAbility: SPELLS.EYE_OF_GULDAN_SUMMON.id,
+    isRandom: true,
   },
   PRINCE_MALCHEZAAR: {
     guid: 136397,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
+    summonAbility: SPELLS.PRINCE_MALCHEZAAR_SUMMON.id,
+    isRandom: true,
   },
 };
 

--- a/src/parser/warlock/demonology/modules/pets/PETS.js
+++ b/src/parser/warlock/demonology/modules/pets/PETS.js
@@ -15,43 +15,32 @@ const PETS = {
     guid: 55659,
     duration: 15000, // maximum duration, realistically is handled differently
     summonAbility: SPELLS.WILD_IMP_HOG_SUMMON.id,
-    isAffectedByDemonicTyrant: true,
-    summonSpell: SPELLS.HAND_OF_GULDAN_CAST.id,
   },
   DREADSTALKER: {
     guid: 98035,
     duration: 12000,
-    summonAbility: [SPELLS.DREADSTALKER_SUMMON_1.id, SPELLS.DREADSTALKER_SUMMON_2.id],
-    isAffectedByDemonicTyrant: true,
-    summonSpell: SPELLS.CALL_DREADSTALKERS.id,
+    summonAbility: SPELLS.DREADSTALKER_SUMMON_1.id,
   },
   VILEFIEND: {
     guid: 135816,
     duration: 15000,
     summonAbility: SPELLS.SUMMON_VILEFIEND_TALENT.id,
-    isAffectedByDemonicTyrant: true,
-    summonSpell: SPELLS.SUMMON_VILEFIEND_TALENT.id,
   },
   GRIMOIRE_FELGUARD: {
     guid: 17252,
     duration: 15000,
     summonAbility: SPELLS.GRIMOIRE_FELGUARD_TALENT.id,
-    isAffectedByDemonicTyrant: true,
-    summonSpell: SPELLS.GRIMOIRE_FELGUARD_TALENT.id,
   },
   DEMONIC_TYRANT: {
     guid: 135002,
     duration: 15000,
     summonAbility: SPELLS.SUMMON_DEMONIC_TYRANT.id,
-    summonSpell: SPELLS.SUMMON_DEMONIC_TYRANT.id,
   },
   // Inner Demons and Nether Portal demons
   WILD_IMP_INNER_DEMONS: {
     guid: 143622,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
     summonAbility: SPELLS.WILD_IMP_ID_SUMMON.id,
-    isAffectedByDemonicTyrant: true,
-    summonSpell: SPELLS.INNER_DEMONS_TALENT.id,
   },
   BILESCOURGE: {
     guid: 136404,

--- a/src/parser/warlock/demonology/modules/pets/PETS.js
+++ b/src/parser/warlock/demonology/modules/pets/PETS.js
@@ -15,7 +15,6 @@ const PETS = {
     guid: 55659,
     duration: 15000, // maximum duration, realistically is handled differently
     summonAbility: SPELLS.WILD_IMP_HOG_SUMMON.id,
-    isWildImp: true,
     isAffectedByDemonicTyrant: true,
     summonSpell: SPELLS.HAND_OF_GULDAN_CAST.id,
   },
@@ -51,7 +50,6 @@ const PETS = {
     guid: 143622,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
     summonAbility: SPELLS.WILD_IMP_ID_SUMMON.id,
-    isWildImp: true,
     isAffectedByDemonicTyrant: true,
     summonSpell: SPELLS.INNER_DEMONS_TALENT.id,
   },

--- a/src/parser/warlock/demonology/modules/pets/PetTimelineTab/TabComponent/PetTimeline.js
+++ b/src/parser/warlock/demonology/modules/pets/PetTimelineTab/TabComponent/PetTimeline.js
@@ -15,7 +15,7 @@ import Icon from 'common/Icon';
 import PetRow from './PetRow';
 import KeyCastsRow from './KeyCastsRow';
 import './PetTimeline.css';
-import { WILD_IMP_GUIDS } from '../../CONSTANTS';
+import { isWildImp } from '../../helpers';
 
 const NETHER_PORTAL_DURATION = 20000;
 const NEARBY_CASTS_BUFFER = 250;
@@ -149,7 +149,7 @@ class PetTimeline extends React.PureComponent {
     const { petTimeline } = this.props;
     events.filter(event => event.type === 'cast' && event.abilityId === SPELLS.IMPLOSION_CAST.id)
       .forEach(cast => {
-        const impCount = petTimeline.getPetsAtTimestamp(cast.timestamp).filter(pet => WILD_IMP_GUIDS.includes(pet.guid)).length;
+        const impCount = petTimeline.getPetsAtTimestamp(cast.timestamp).filter(pet => isWildImp(pet.guid)).length;
         cast.extraInfo = `Imploded ${impCount} Wild Imp${impCount > 1 ? 's' : ''}`;
       });
     return events;

--- a/src/parser/warlock/demonology/modules/pets/helpers.js
+++ b/src/parser/warlock/demonology/modules/pets/helpers.js
@@ -2,3 +2,4 @@ import PETS from './PETS';
 
 export const isPermanentPet = guid => guid.toString().length > 6;
 export const isWildImp = guid => guid === PETS.WILD_IMP_HOG.guid || guid === PETS.WILD_IMP_INNER_DEMONS.guid;
+export const isRandomPet = guid => !isPermanentPet(guid) && PETS[guid].isRandom;

--- a/src/parser/warlock/demonology/modules/pets/helpers.js
+++ b/src/parser/warlock/demonology/modules/pets/helpers.js
@@ -1,1 +1,4 @@
+import PETS from './PETS';
+
 export const isPermanentPet = guid => guid.toString().length > 6;
+export const isWildImp = guid => guid === PETS.WILD_IMP_HOG.guid || guid === PETS.WILD_IMP_INNER_DEMONS.guid;

--- a/src/parser/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.js
+++ b/src/parser/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.js
@@ -3,7 +3,7 @@ import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
 import SPELLS from 'common/SPELLS';
 import { PERMANENT_PET_ABILITIES_TO_SUMMON_MAP, PET_SUMMON_ABILITY_IDS } from '../CONSTANTS';
 import { isPermanentPet } from '../helpers';
-import PETS from 'parser/warlock/demonology/modules/pets/PETS';
+import PETS from '../PETS';
 
 const MAX_TEMPORARY_PET_DURATION = 30000;
 const CHECKED_EVENT_TYPES = ['begincast', 'cast', 'damage'];

--- a/src/parser/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.js
+++ b/src/parser/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.js
@@ -1,8 +1,9 @@
 import EventsNormalizer from 'parser/core/EventsNormalizer';
 import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
 import SPELLS from 'common/SPELLS';
-import { PERMANENT_PET_ABILITIES_TO_SUMMON_MAP, PET_GUID_TO_SUMMON_ABILITY_MAP, PET_SUMMON_ABILITY_IDS } from '../CONSTANTS';
+import { PERMANENT_PET_ABILITIES_TO_SUMMON_MAP, PET_SUMMON_ABILITY_IDS } from '../CONSTANTS';
 import { isPermanentPet } from '../helpers';
+import PETS from 'parser/warlock/demonology/modules/pets/PETS';
 
 const MAX_TEMPORARY_PET_DURATION = 30000;
 const CHECKED_EVENT_TYPES = ['begincast', 'cast', 'damage'];
@@ -51,11 +52,11 @@ class PrepullPetNormalizer extends EventsNormalizer {
           }
           else {
             const guid = this._getPetGuid(petId);
-            if (!PET_GUID_TO_SUMMON_ABILITY_MAP[guid]) {
+            if (!PETS[guid]) {
               debug && console.error(`(${this.owner.formatTimestamp(event.timestamp, 3)}) ERROR - unknown pet`, event);
               continue;
             }
-            spell = SPELLS[PET_GUID_TO_SUMMON_ABILITY_MAP[guid]];
+            spell = SPELLS[PETS[guid].summonAbility];
           }
           const fabricatedEvent = {
             timestamp: this.owner.fight.start_time,

--- a/src/parser/warlock/demonology/modules/talents/DemonicConsumption.js
+++ b/src/parser/warlock/demonology/modules/talents/DemonicConsumption.js
@@ -11,7 +11,7 @@ import SpellIcon from 'common/SpellIcon';
 import StatisticBox from 'interface/others/StatisticBox';
 
 import DemoPets from '../pets/DemoPets';
-import { WILD_IMP_GUIDS } from '../pets/CONSTANTS';
+import { isWildImp } from '../pets/helpers';
 
 const DAMAGE_BONUS_PER_ENERGY = 0.0025; // 0.25% per point of energy
 const debug = false;
@@ -32,7 +32,7 @@ class DemonicConsumption extends Analyzer {
   }
 
   handleCast() {
-    const imps = this.demoPets.currentPets.filter(pet => WILD_IMP_GUIDS.includes(pet.guid) && !pet.shouldImplode);
+    const imps = this.demoPets.currentPets.filter(pet => isWildImp(pet.guid) && !pet.shouldImplode);
     debug && this.log('Imps on Tyrant cast', JSON.parse(JSON.stringify(imps)));
     this._currentBonus = imps.map(imp => imp.currentEnergy).reduce((total, current) => total + current, 0) * DAMAGE_BONUS_PER_ENERGY;
     debug && this.log('Current bonus: ', this._currentBonus);

--- a/src/parser/warlock/demonology/modules/talents/InnerDemons.js
+++ b/src/parser/warlock/demonology/modules/talents/InnerDemons.js
@@ -10,7 +10,9 @@ import StatisticBox from 'interface/others/StatisticBox';
 
 import DemoPets from '../pets/DemoPets';
 import PETS from '../pets/PETS';
-import { RANDOM_PET_GUIDS } from '../pets/CONSTANTS';
+
+// random pets that can be summoned from Inner Demons/Nether Portal. Does NOT include Wild Imps summoned by Inner Demons, those are not random
+const RANDOM_PET_GUIDS = Object.values(PETS).filter(pet => pet.isRandom).map(pet => pet.guid);
 
 class InnerDemons extends Analyzer {
   static dependencies = {

--- a/src/parser/warlock/demonology/modules/talents/InnerDemons.js
+++ b/src/parser/warlock/demonology/modules/talents/InnerDemons.js
@@ -10,9 +10,7 @@ import StatisticBox from 'interface/others/StatisticBox';
 
 import DemoPets from '../pets/DemoPets';
 import PETS from '../pets/PETS';
-
-// random pets that can be summoned from Inner Demons/Nether Portal. Does NOT include Wild Imps summoned by Inner Demons, those are not random
-const RANDOM_PET_GUIDS = Object.values(PETS).filter(pet => pet.isRandom).map(pet => pet.guid);
+import { isRandomPet } from '../pets/helpers';
 
 class InnerDemons extends Analyzer {
   static dependencies = {
@@ -26,7 +24,7 @@ class InnerDemons extends Analyzer {
 
   get damage() {
     const wildImps = this.demoPets.getPetDamage(PETS.WILD_IMP_INNER_DEMONS.guid);
-    const otherPetsSummonedByID = this.demoPets.timeline.filter(pet => RANDOM_PET_GUIDS.includes(pet.guid) && pet.summonedBy === SPELLS.INNER_DEMONS_TALENT.id);
+    const otherPetsSummonedByID = this.demoPets.timeline.filter(pet => isRandomPet(pet.guid) && pet.summonedBy === SPELLS.INNER_DEMONS_TALENT.id);
     const other = otherPetsSummonedByID
       .map(pet => this.demoPets.getPetDamage(pet.guid, pet.instance))
       .reduce((total, current) => total + current, 0);

--- a/src/parser/warlock/demonology/modules/talents/normalizers/PowerSiphonNormalizer.js
+++ b/src/parser/warlock/demonology/modules/talents/normalizers/PowerSiphonNormalizer.js
@@ -1,7 +1,9 @@
 import EventsNormalizer from 'parser/core/EventsNormalizer';
 import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
+
 import SPELLS from 'common/SPELLS';
-import { WILD_IMP_GUIDS } from '../../pets/CONSTANTS';
+
+import { isWildImp } from '../../pets/helpers';
 
 const debug = false;
 const CHECKED_EVENT_TYPES = ['begincast', 'cast'];
@@ -61,7 +63,7 @@ class PowerSiphonNormalizer extends EventsNormalizer {
     if (!info) {
       return false;
     }
-    return WILD_IMP_GUIDS.includes(info.guid);
+    return isWildImp(info.guid);
   }
 }
 


### PR DESCRIPTION
The diff on this is ugly but the point is here:
- DemoPets.js was an unmaintainable mess, 440+ lines of glued up spaghetti code that somehow worked
- I broke it down into 6 smaller pieces, each of which takes care of **single** thing - Pet summoning, Wild Imp despawns due to energy, Demonic Tyrant extensions etc.
- these modules have been also updated to the new event listening system (apart from PetSummonHandler, which wasn't updated due to it listening to "spendresource" event)
- old `/pets/DemoPets.js` was moved to `/pets/DemoPets/index.js` so the imports are same
- new DemoPets.js now contains only `PetDamage` and `PetTimeline` objects, API methods and some common helper methods that I didn't want to duplicate across modules
- I also removed some helper arrays in `/pets/CONSTANTS.js`, instead I added props to the pets in `pets/PETS.js` and used those
