### PR TITLE
[gitignore] add webstorm 2018.3 encodings.xml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ temp
 /.idea/vcs.xml
 /.idea/workspace.xml
 /.idea/codeStyles/*
+/.idea/encodings.xml
 /.vscode
 
 .vs/ProjectSettings.json


### PR DESCRIPTION
With the new 2018.3 update to webstorm a new filetype was added to the .idea/ folder. 
This makes sure it doesn't get pushed to mess with anyone elses configuration. 