### PR TITLE
[Core] Try to better guess GCD's for prepull cast events

### DIFF
--- a/src/parser/shared/normalizers/PrePullCooldowns.js
+++ b/src/parser/shared/normalizers/PrePullCooldowns.js
@@ -151,7 +151,7 @@ class PrePullCooldowns extends EventsNormalizer {
   _resolveAbilityGcd(id) {
     const ability = this.abilities.getAbility(id);
     const gcdProp = ability.gcd;
-    if (gcdProp === null) {
+    if (!gcdProp) {
       return 0;
     }
     if (typeof gcdProp.static === 'number') {


### PR DESCRIPTION
I was just setting 1500ms for everything. While it's true I cant use the standard gcd resolutions (normalizer: I can't call the functions because haste, etc, will be wrong), I can check for regular numbers and use those instead of the worst-case 1500 _if_ they are set.