### PR TITLE
[Core] TalentStatisticBox rewrite

### DIFF
--- a/src/interface/others/StatisticBox.js
+++ b/src/interface/others/StatisticBox.js
@@ -68,7 +68,7 @@ class StatisticBox extends React.PureComponent {
     delete others.position;
     return (
       <div className="col-lg-3 col-md-4 col-sm-6 col-xs-12" style={{ zIndex: this.state.expanded ? 2 : 1 }} {...containerProps}>
-        <div className="panel statistic-box item expandable" {...others}>
+        <div className="panel statistic-box expandable" {...others}>
           <div className="panel-body">
             <div className="flex">
               <div className="flex-sub statistic-icon" style={{ display: 'flex', alignItems: alignIcon }}>

--- a/src/interface/others/StatisticBox.js
+++ b/src/interface/others/StatisticBox.js
@@ -68,7 +68,7 @@ class StatisticBox extends React.PureComponent {
     delete others.position;
     return (
       <div className="col-lg-3 col-md-4 col-sm-6 col-xs-12" style={{ zIndex: this.state.expanded ? 2 : 1 }} {...containerProps}>
-        <div className="panel statistic-box expandable" {...others}>
+        <div className="panel statistic-box item expandable" {...others}>
           <div className="panel-body">
             <div className="flex">
               <div className="flex-sub statistic-icon" style={{ display: 'flex', alignItems: alignIcon }}>

--- a/src/interface/others/TalentStatisticBox.js
+++ b/src/interface/others/TalentStatisticBox.js
@@ -4,47 +4,28 @@ import PropTypes from 'prop-types';
 import SpellLink from 'common/SpellLink';
 import SpellIcon from 'common/SpellIcon';
 
-import './StatisticBox.css';
 import STATISTIC_CATEGORY from './STATISTIC_CATEGORY';
+import StatisticBox from './StatisticBox';
 
 export { default as STATISTIC_ORDER } from './STATISTIC_ORDER';
 
-const TalentStatisticBox = ({ talent, icon, label, value, tooltip, containerProps, alignIcon, ...others }) => {
-  delete others.category;
-  delete others.position;
+const TalentStatisticBox = ({ talent, icon, label, ...others }) => {
+  icon = icon || <SpellIcon id={talent} />;
+  label = label || <SpellLink id={talent} icon={false} />;
+
   return (
-    <div className="col-lg-3 col-md-4 col-sm-6 col-xs-12" {...containerProps}>
-      <div className="panel statistic-box item" {...others}>
-        <div className="panel-body flex">
-          <div className="flex-sub statistic-icon" style={{ display: 'flex', alignItems: alignIcon }}>
-            {icon || <SpellIcon id={talent} />}
-          </div>
-          <div className="flex-main">
-            <div className="slabel">
-              {label || <SpellLink id={talent} icon={false} />}
-            </div>
-            <dfn data-tip={tooltip} className="value">
-              {value}
-            </dfn>
-          </div>
-        </div>
-      </div>
-    </div>
+    <StatisticBox icon={icon} label={label} {...others} />
   );
 };
+
 TalentStatisticBox.propTypes = {
-  talent: PropTypes.number,
-  icon: PropTypes.node, // Override the talent icon.
-  label: PropTypes.node, // Override the talent label.
-  value: PropTypes.node.isRequired,
-  tooltip: PropTypes.string,
-  containerProps: PropTypes.object,
-  alignIcon: PropTypes.string,
-  category: PropTypes.string,
-  position: PropTypes.number,
+  ...StatisticBox.propTypes,
+  talent: PropTypes.number.isRequired,
+  icon: PropTypes.node, // Override the icon requirement
+  label: PropTypes.node, // Override the label requirement
 };
+
 TalentStatisticBox.defaultProps = {
-  alignIcon: 'center',
   category: STATISTIC_CATEGORY.TALENTS,
 };
 

--- a/src/parser/deathknight/blood/modules/talents/Bloodworms.js
+++ b/src/parser/deathknight/blood/modules/talents/Bloodworms.js
@@ -4,7 +4,6 @@ import SPELLS from 'common/SPELLS/index';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
-import SpellIcon from 'common/SpellIcon';
 import { formatThousands } from 'common/format';
 
 //Worms last 15 sec. But sometimes lag and such makes them expire a little bit early.

--- a/src/parser/deathknight/blood/modules/talents/Bloodworms.js
+++ b/src/parser/deathknight/blood/modules/talents/Bloodworms.js
@@ -79,8 +79,8 @@ class Bloodworms extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.BLOODWORMS_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(6)}
-        icon={<SpellIcon id={SPELLS.BLOODWORMS_TALENT.id} />}
         value={this.owner.formatItemHealingDone(this.totalHealing)}
         label="Bloodworm Stats"
         tooltip={`<strong>Damage:</strong> ${formatThousands(this.totalDamage)} / ${this.owner.formatItemDamageDone(this.totalDamage)}<br>

--- a/src/parser/deathknight/blood/modules/talents/Bonestorm.js
+++ b/src/parser/deathknight/blood/modules/talents/Bonestorm.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage, formatNumber } from 'common/format';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
@@ -39,7 +38,7 @@ class Bonestorm extends Analyzer {
   }
 
   get goodBonestormCasts() {
-    const goodCasts = this.bsCasts.filter((val, index) => {
+    const goodCasts = this.bsCasts.filter((val) => {
       return val.hits.length / (val.cost / 100) >= SUGGESTED_MIN_TARGETS_FOR_BONESTORM;
     });
     return goodCasts.length;

--- a/src/parser/deathknight/blood/modules/talents/Bonestorm.js
+++ b/src/parser/deathknight/blood/modules/talents/Bonestorm.js
@@ -88,8 +88,8 @@ class Bonestorm extends Analyzer {
 
     return (
       <TalentStatisticBox
+        talent={SPELLS.BONESTORM_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(7)}
-        icon={<SpellIcon id={SPELLS.BONESTORM_TALENT.id} />}
         value={`${ formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.totalBonestormDamage)) } %`}
         label="of your total damage"
         tooltip={`${ this.BonestormTooltip }`}

--- a/src/parser/deathknight/blood/modules/talents/FoulBulwark.js
+++ b/src/parser/deathknight/blood/modules/talents/FoulBulwark.js
@@ -30,8 +30,8 @@ class FoulBulwark extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.FOUL_BULWARK_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(3)}
-        icon={<SpellIcon id={SPELLS.FOUL_BULWARK_TALENT.id} />}
         value={`${this.averageFoulBullwark}%`}
         label="average Foul Bulwark buff"
       >

--- a/src/parser/deathknight/blood/modules/talents/FoulBulwark.js
+++ b/src/parser/deathknight/blood/modules/talents/FoulBulwark.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import { formatDuration, formatPercentage } from 'common/format';

--- a/src/parser/deathknight/blood/modules/talents/Heartbreaker.js
+++ b/src/parser/deathknight/blood/modules/talents/Heartbreaker.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS/index';
-import SpellIcon from 'common/SpellIcon';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';

--- a/src/parser/deathknight/blood/modules/talents/Heartbreaker.js
+++ b/src/parser/deathknight/blood/modules/talents/Heartbreaker.js
@@ -44,8 +44,8 @@ class Heartbreaker extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.HEARTBREAKER_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(1)}
-        icon={<SpellIcon id={SPELLS.HEARTBREAKER_TALENT.id} />}
         value={`${this.totalRPGained}`}
         label="Runic Power gained"
         tooltip={`

--- a/src/parser/deathknight/blood/modules/talents/Hemostasis.js
+++ b/src/parser/deathknight/blood/modules/talents/Hemostasis.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import { formatNumber } from 'common/format';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';

--- a/src/parser/deathknight/blood/modules/talents/Hemostasis.js
+++ b/src/parser/deathknight/blood/modules/talents/Hemostasis.js
@@ -64,8 +64,8 @@ class Hemostasis extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.HEMOSTASIS_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(2)}
-        icon={<SpellIcon id={SPELLS.HEMOSTASIS_TALENT.id} />}
         value={`${this.buffedDeathStrikes} / ${this.buffedDeathStrikes + this.unbuffedDeathStrikes}`}
         label="Death Strikes with Hemostasis"
         tooltip={`

--- a/src/parser/deathknight/blood/modules/talents/MarkOfBlood.js
+++ b/src/parser/deathknight/blood/modules/talents/MarkOfBlood.js
@@ -3,7 +3,6 @@ import Analyzer from 'parser/core/Analyzer';
 import Enemies from 'parser/shared/modules/Enemies';
 import SPELLS from 'common/SPELLS/index';
 import SpellLink from 'common/SpellLink';
-import SpellIcon from 'common/SpellIcon';
 import { formatPercentage } from 'common/format';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';

--- a/src/parser/deathknight/blood/modules/talents/MarkOfBlood.js
+++ b/src/parser/deathknight/blood/modules/talents/MarkOfBlood.js
@@ -47,8 +47,8 @@ class MarkOfBlood extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.MARK_OF_BLOOD_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(6)}
-        icon={<SpellIcon id={SPELLS.MARK_OF_BLOOD_TALENT.id} />}
         value={`${formatPercentage(this.uptime)} %`}
         label="Mark Of Blood Uptime"
       />

--- a/src/parser/deathknight/blood/modules/talents/Ossuary.js
+++ b/src/parser/deathknight/blood/modules/talents/Ossuary.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import { formatPercentage } from 'common/format';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';

--- a/src/parser/deathknight/blood/modules/talents/Ossuary.js
+++ b/src/parser/deathknight/blood/modules/talents/Ossuary.js
@@ -57,8 +57,8 @@ class Ossuary extends Analyzer {
 
     return (
       <TalentStatisticBox
+        talent={SPELLS.OSSUARY_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(3)}
-        icon={<SpellIcon id={SPELLS.OSSUARY_TALENT.id} />}
         value={`${ this.dsWithoutOS } / ${ this.dsWithOS + this.dsWithoutOS }`}
         label="Death Strikes without Ossuary"
         tooltip={`

--- a/src/parser/deathknight/blood/modules/talents/RapidDecomposition.js
+++ b/src/parser/deathknight/blood/modules/talents/RapidDecomposition.js
@@ -33,10 +33,9 @@ class RapidDecomposition extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.RAPID_DECOMPOSITION_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(2)}
-        icon={<SpellIcon id={SPELLS.RAPID_DECOMPOSITION_TALENT.id} />}
         value={`${this.owner.formatItemDamageDone(this.totalDamage)}`}
-        label="Rapid Decomposition"
         tooltip={`<strong>Blood Plague:</strong> ${this.owner.formatItemDamageDone(this.bpDamage)}</br>
                   <strong>Death And Decay:</strong> ${this.owner.formatItemDamageDone(this.dndDamage)}`}
       />

--- a/src/parser/deathknight/blood/modules/talents/RapidDecomposition.js
+++ b/src/parser/deathknight/blood/modules/talents/RapidDecomposition.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS/index';
-import SpellIcon from 'common/SpellIcon';
 import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';

--- a/src/parser/deathknight/blood/modules/talents/RedThirst.js
+++ b/src/parser/deathknight/blood/modules/talents/RedThirst.js
@@ -45,8 +45,8 @@ class RedThirst extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.RED_THIRST_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(7)}
-        icon={<SpellIcon id={SPELLS.RED_THIRST_TALENT.id} />}
         value={`${formatNumber(this.averageReduction)} sec`}
         label="Red Thirst average reduction"
         tooltip={`${formatNumber(this.reduction)} sec total effective reduction and ${formatNumber(this.wastedReduction)} sec (${formatPercentage(this.wastedPercent)}%) wasted reduction.`}

--- a/src/parser/deathknight/blood/modules/talents/RedThirst.js
+++ b/src/parser/deathknight/blood/modules/talents/RedThirst.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import { formatPercentage, formatNumber } from 'common/format';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';

--- a/src/parser/deathknight/blood/modules/talents/RuneStrike.js
+++ b/src/parser/deathknight/blood/modules/talents/RuneStrike.js
@@ -54,7 +54,7 @@ class RuneStrike extends Analyzer {
         if (runeCost <= 0) {
           return;
         }
-        for (let i = 0; i < runeCost; i++) { 
+        for (let i = 0; i < runeCost; i++) {
           if (!this.spellUsable.isOnCooldown(SPELLS.RUNE_STRIKE_TALENT.id)) {
             this.wastedReduction += MS_REDUCTION_PER_RUNE;
           } else {
@@ -99,8 +99,8 @@ class RuneStrike extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.RUNE_STRIKE_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(1)}
-        icon={<SpellIcon id={SPELLS.RUNE_STRIKE_TALENT.id} />}
         value={`${formatPercentage(this.goodCastEfficiency)}%`}
         label="good casts"
         tooltip={`

--- a/src/parser/deathknight/blood/modules/talents/RuneStrike.js
+++ b/src/parser/deathknight/blood/modules/talents/RuneStrike.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS/index';
-import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';

--- a/src/parser/deathknight/blood/modules/talents/Tombstone.js
+++ b/src/parser/deathknight/blood/modules/talents/Tombstone.js
@@ -2,10 +2,9 @@ import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS/index';
 import SpellLink from 'common/SpellLink';
-import SpellIcon from 'common/SpellIcon';
 import { formatNumber, formatPercentage } from 'common/format';
 import DamageTracker from 'parser/shared/modules/AbilityTracker';
-import TalentStatisticBox from 'interface/others/StatisticBox';
+import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 
 const RPPERCHARGE = 6;

--- a/src/parser/deathknight/blood/modules/talents/Tombstone.js
+++ b/src/parser/deathknight/blood/modules/talents/Tombstone.js
@@ -95,8 +95,8 @@ class Tombstone extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.TOMBSTONE_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(3)}
-        icon={<SpellIcon id={SPELLS.TOMBSTONE_TALENT.id} />}
         value={`${this.wastedCasts}`}
         label="Bad Casts"
         tooltip={`Any cast without 5 charges is considered a wasted cast.`}

--- a/src/parser/deathknight/blood/modules/talents/Voracious.js
+++ b/src/parser/deathknight/blood/modules/talents/Voracious.js
@@ -31,9 +31,10 @@ class Voracious extends Analyzer {
 
   statistic() {
     return (
+
       <TalentStatisticBox
+        talent={SPELLS.VORACIOUS_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(6)}
-        icon={<SpellIcon id={SPELLS.VORACIOUS_TALENT.id} />}
         value={`${formatPercentage(this.uptime)} %`}
         label="Voracious uptime"
       />

--- a/src/parser/deathknight/blood/modules/talents/Voracious.js
+++ b/src/parser/deathknight/blood/modules/talents/Voracious.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import { formatPercentage } from 'common/format';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';

--- a/src/parser/deathknight/blood/modules/talents/WillOfTheNecropolis.js
+++ b/src/parser/deathknight/blood/modules/talents/WillOfTheNecropolis.js
@@ -51,10 +51,9 @@ class WillOfTheNecropolis extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.WILL_OF_THE_NECROPOLIS_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(4)}
-        icon={<SpellIcon id={SPELLS.WILL_OF_THE_NECROPOLIS_TALENT.id} />}
         value={`${this.owner.formatItemHealingDone(this.totalWotnAbsorbed)}`}
-        label="Will Of The Necropolis"
         tooltip={`<strong>Total Damage Absorbed: </strong> ${formatNumber(this.totalWotnAbsorbed)} </br>
                   <strong>Activated: </strong> ${this.activated}</br>
                   <strong>Absorbed 5% Max Health or more count: </strong> ${this.goodAbsorbCount}  `}

--- a/src/parser/deathknight/blood/modules/talents/WillOfTheNecropolis.js
+++ b/src/parser/deathknight/blood/modules/talents/WillOfTheNecropolis.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS/index';
-import SpellIcon from 'common/SpellIcon';
 import { formatNumber } from "common/format";
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';

--- a/src/parser/demonhunter/vengeance/modules/talents/AgonizingFlames.js
+++ b/src/parser/demonhunter/vengeance/modules/talents/AgonizingFlames.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS/index';
-import SpellIcon from 'common/SpellIcon';
 import { formatNumber } from 'common/format';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
@@ -33,10 +32,9 @@ class AgonizingFlames extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.AGONIZING_FLAMES_TALENT.id}
         position={STATISTIC_ORDER.CORE(9)}
-        icon={<SpellIcon id={SPELLS.AGONIZING_FLAMES_TALENT.id} />}
         value={`${this.owner.formatItemDamageDone(this.damage)}`}
-        label="Agonizing Flames"
         tooltip={`This shows the extra dps that the talent provides.<br/>
                   <b>Total extra damage:</b> ${formatNumber(this.damage)}`}
       />

--- a/src/parser/demonhunter/vengeance/modules/talents/BurningAlive.js
+++ b/src/parser/demonhunter/vengeance/modules/talents/BurningAlive.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS/index';
-import SpellIcon from 'common/SpellIcon';
 import { formatNumber } from 'common/format';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
@@ -29,10 +28,9 @@ class BurningAlive extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.BURNING_ALIVE_TALENT.id}
         position={STATISTIC_ORDER.CORE(10)}
-        icon={<SpellIcon id={SPELLS.BURNING_ALIVE_TALENT.id} />}
         value={`${this.owner.formatItemDamageDone(this.damage)}`}
-        label="Burning Alive"
         tooltip={`This shows the extra dps that the talent provides.<br/>
                   <b>Total extra damage:</b> ${formatNumber(this.damage)}`}
       />

--- a/src/parser/demonhunter/vengeance/modules/talents/FeastOfSouls.js
+++ b/src/parser/demonhunter/vengeance/modules/talents/FeastOfSouls.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS/index';
-import SpellIcon from 'common/SpellIcon';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import { formatNumber, formatPercentage } from 'common/format';
@@ -30,10 +29,9 @@ class FeastOfSouls extends Analyzer {
     const overHealPercent = this.overHeal/(this.overHeal + this.heal);
     return (
       <TalentStatisticBox
+        talent={SPELLS.FEAST_OF_SOULS_TALENT.id}
         position={STATISTIC_ORDER.CORE(8)}
-        icon={<SpellIcon id={SPELLS.FEAST_OF_SOULS_TALENT.id} />}
         value={`${this.owner.formatItemHealingDone(this.heal)}`}
-        label="Feast of Souls"
         tooltip={`This shows the extra hps that the talent provides.<br/>
                   <b>Effective healing:</b> ${formatNumber(this.heal)}<br/>
                   <b>Overhealing:</b> ${formatNumber(this.overHeal)} | ${formatPercentage(overHealPercent)}%`}

--- a/src/parser/demonhunter/vengeance/modules/talents/FeedTheDemon.js
+++ b/src/parser/demonhunter/vengeance/modules/talents/FeedTheDemon.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import { formatPercentage, formatNumber } from 'common/format';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
@@ -72,8 +71,8 @@ class FeedTheDemon extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.FEED_THE_DEMON_TALENT.id}
         position={STATISTIC_ORDER.CORE(6)}
-        icon={<SpellIcon id={SPELLS.FEED_THE_DEMON_TALENT.id} />}
         value={`${formatNumber(this.averageReduction)} sec`}
         label="Feed the Demon average reduction"
         tooltip={`${formatNumber(this.reduction)} sec total effective reduction.</br>

--- a/src/parser/demonhunter/vengeance/modules/talents/Gluttony.js
+++ b/src/parser/demonhunter/vengeance/modules/talents/Gluttony.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 
@@ -41,8 +40,8 @@ class Gluttony extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.GLUTTONY_TALENT.id}
         position={STATISTIC_ORDER.CORE(7)}
-        icon={<SpellIcon id={SPELLS.GLUTTONY_TALENT.id} />}
         value={`${this.gluttonyProcs}`}
         label="Gluttony procs"
       />

--- a/src/parser/demonhunter/vengeance/modules/talents/RazorSpikes.js
+++ b/src/parser/demonhunter/vengeance/modules/talents/RazorSpikes.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
-import SpellIcon from 'common/SpellIcon';
 
 import SPELLS from 'common/SPELLS/index';
 import Analyzer from 'parser/core/Analyzer';
@@ -34,10 +33,9 @@ class RazorSpikes extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.RAZOR_SPIKES_TALENT.id}
         position={STATISTIC_ORDER.CORE(5)}
-        icon={<SpellIcon id={SPELLS.RAZOR_SPIKES_TALENT.id} />}
         value={`${this.owner.formatItemDamageDone(this.damage)}`}
-        label="Razor Spikes"
         tooltip={`This shows the extra dps that the talent provides.<br/>
                   <b>Total extra damage:</b> ${formatNumber(this.damage)}`}
       />

--- a/src/parser/demonhunter/vengeance/modules/talents/SoulBarrier.js
+++ b/src/parser/demonhunter/vengeance/modules/talents/SoulBarrier.js
@@ -6,7 +6,6 @@ import DamageTracker from 'parser/shared/modules/AbilityTracker';
 
 import SPELLS from 'common/SPELLS/index';
 import SpellLink from 'common/SpellLink';
-import SpellIcon from 'common/SpellIcon';
 import { formatPercentage, formatNumber } from 'common/format';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
@@ -85,8 +84,8 @@ class SoulBarrier extends Analyzer {
     const avgBuffLength = (this.totalBuffLength / this.casts) / 1000;
     return (
       <TalentStatisticBox
+        talent={SPELLS.SOUL_BARRIER_TALENT.id}
         position={STATISTIC_ORDER.CORE(7)}
-        icon={<SpellIcon id={SPELLS.SOUL_BARRIER_TALENT.id} />}
         value={`${formatPercentage(this.uptime)} %`}
         label="Soul Barrier uptime"
         tooltip={`Average Buff Length: <strong>${formatNumber(avgBuffLength)} seconds</strong></br>

--- a/src/parser/demonhunter/vengeance/modules/talents/SpiritBombFrailtyDebuff.js
+++ b/src/parser/demonhunter/vengeance/modules/talents/SpiritBombFrailtyDebuff.js
@@ -6,7 +6,6 @@ import Enemies from 'parser/shared/modules/Enemies';
 
 import SPELLS from 'common/SPELLS/index';
 import SpellLink from 'common/SpellLink';
-import SpellIcon from 'common/SpellIcon';
 import { formatPercentage, formatThousands, formatDuration } from 'common/format';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
@@ -53,8 +52,8 @@ class SpiritBombFrailtyDebuff extends Analyzer {
 
     return (
       <TalentStatisticBox
+        talent={SPELLS.SPIRIT_BOMB_TALENT.id}
         position={STATISTIC_ORDER.CORE(5)}
-        icon={<SpellIcon id={SPELLS.SPIRIT_BOMB_TALENT.id} />}
         value={`${formatPercentage(this.uptime)}%`}
         label="Spirit Bomb debuff uptime"
         tooltip={`Total damage was ${formatThousands(spiritBombDamage)}.<br/>

--- a/src/parser/demonhunter/vengeance/modules/talents/SpiritBombSoulsConsume.js
+++ b/src/parser/demonhunter/vengeance/modules/talents/SpiritBombSoulsConsume.js
@@ -4,7 +4,6 @@ import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 
 import SPELLS from 'common/SPELLS/index';
-import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 
 import { formatPercentage } from 'common/format';
@@ -104,8 +103,8 @@ class SpiritBombSoulsConsume extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.SPIRIT_BOMB_TALENT.id}
         position={STATISTIC_ORDER.CORE(6)}
-        icon={<SpellIcon id={SPELLS.SPIRIT_BOMB_TALENT.id} />}
         value={`${formatPercentage(this.percentGoodCasts)} %`}
         label="Good Spirit Bomb casts"
       >

--- a/src/parser/demonhunter/vengeance/modules/talents/VoidReaverDebuff.js
+++ b/src/parser/demonhunter/vengeance/modules/talents/VoidReaverDebuff.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
-import SpellIcon from 'common/SpellIcon';
 import Enemies from 'parser/shared/modules/Enemies';
 
 import SPELLS from 'common/SPELLS';
@@ -49,8 +48,8 @@ class VoidReaverDebuff extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.VOID_REAVER_TALENT.id}
         position={STATISTIC_ORDER.CORE(5)}
-        icon={<SpellIcon id={SPELLS.VOID_REAVER_TALENT.id} />}
         value={`${formatPercentage(this.uptime)} %`}
         label="Void Reaver uptime"
       />

--- a/src/parser/hunter/beastmastery/modules/talents/ChimaeraShot.js
+++ b/src/parser/hunter/beastmastery/modules/talents/ChimaeraShot.js
@@ -44,11 +44,10 @@ class ChimaeraShot extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
-        icon={<SpellIcon id={SPELLS.CHIMAERA_SHOT_TALENT.id} />}
+        talent={SPELLS.CHIMAERA_SHOT_TALENT.id}
         value={<>
           <AverageTargetsHit casts={this.casts} hits={this.hits} />
         </>}
-        label="Chimaera Shot"
       />
     );
   }

--- a/src/parser/hunter/beastmastery/modules/talents/ChimaeraShot.js
+++ b/src/parser/hunter/beastmastery/modules/talents/ChimaeraShot.js
@@ -5,7 +5,6 @@ import SpellLink from 'common/SpellLink';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
-import SpellIcon from 'common/SpellIcon';
 import AverageTargetsHit from 'interface/others/AverageTargetsHit';
 
 /**

--- a/src/parser/hunter/beastmastery/modules/talents/DireBeast.js
+++ b/src/parser/hunter/beastmastery/modules/talents/DireBeast.js
@@ -78,14 +78,13 @@ class DireBeast extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
-        icon={<SpellIcon id={SPELLS.DIRE_BEAST_TALENT.id} />}
+        talent={SPELLS.DIRE_BEAST_TALENT.id}
         value={
           <>
             <ItemDamageDone amount={this.damage} /> <br />
             gained {formatPercentage(HASTE_PERCENT / this.owner.fightDuration * this.uptime)}% haste <br />
             gained {this.focusGained} focus <ResourceIcon id={RESOURCE_TYPES.FOCUS.id} />
           </>}
-        label="Dire Beast"
         tooltip={`
             You had ${formatPercentage(this.uptime / this.owner.fightDuration)}% uptime on the Dire Beast haste buff. <br />
             You wasted ${this.focusWasted} focus by being too close to focus cap when Dire Beast gave you focus.`}

--- a/src/parser/hunter/beastmastery/modules/talents/DireBeast.js
+++ b/src/parser/hunter/beastmastery/modules/talents/DireBeast.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import { formatPercentage } from 'common/format';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import ResourceIcon from 'common/ResourceIcon';

--- a/src/parser/hunter/beastmastery/modules/talents/KillerCobra.js
+++ b/src/parser/hunter/beastmastery/modules/talents/KillerCobra.js
@@ -5,7 +5,6 @@ import Analyzer from 'parser/core/Analyzer';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import { formatNumber } from 'common/format';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
-import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import StatTracker from 'parser/shared/modules/StatTracker';
 import GlobalCooldown from 'parser/hunter/beastmastery/modules/core/GlobalCooldown';

--- a/src/parser/hunter/beastmastery/modules/talents/KillerCobra.js
+++ b/src/parser/hunter/beastmastery/modules/talents/KillerCobra.js
@@ -53,7 +53,7 @@ class KillerCobra extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
-        icon={<SpellIcon id={SPELLS.KILLER_COBRA_TALENT.id} />}
+        talent={SPELLS.KILLER_COBRA_TALENT.id}
         value={this.effectiveKillCommandResets}
         label="Kill Command Resets"
         tooltip={`You wasted ${formatNumber(this.wastedKillerCobraCobraShots)} Cobra Shots in Bestial Wrath by using them while Kill Command wasn't on cooldown. </br> `}

--- a/src/parser/hunter/beastmastery/modules/talents/KillerInstinct.js
+++ b/src/parser/hunter/beastmastery/modules/talents/KillerInstinct.js
@@ -4,7 +4,6 @@ import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
 import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
-import SpellIcon from 'common/SpellIcon';
 
 import SPELLS from 'common/SPELLS';
 import Analyzer from 'parser/core/Analyzer';

--- a/src/parser/hunter/beastmastery/modules/talents/KillerInstinct.js
+++ b/src/parser/hunter/beastmastery/modules/talents/KillerInstinct.js
@@ -47,9 +47,8 @@ class KillerInstinct extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
-        icon={<SpellIcon id={SPELLS.KILLER_INSTINCT_TALENT.id} />}
+        talent={SPELLS.KILLER_INSTINCT_TALENT.id}
         value={<>{formatNumber(this.castsWithExecute)} casts at &lt;35% health</>}
-        label="Killer Instinct"
         tooltip={`You cast a total of ${this.casts} Kill Commands, of which ${this.castsWithExecute} were on enemies with less than 35% of their health remaining.
                   These ${this.castsWithExecute} casts provided you a total of ${formatNumber(this.damage)} extra damage throughout the fight.`}
       />

--- a/src/parser/hunter/beastmastery/modules/talents/OneWithThePack.js
+++ b/src/parser/hunter/beastmastery/modules/talents/OneWithThePack.js
@@ -4,7 +4,6 @@ import SPELLS from 'common/SPELLS';
 import Analyzer from 'parser/core/Analyzer';
 import HIT_TYPES from 'game/HIT_TYPES';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
-import SpellIcon from 'common/SpellIcon';
 
 /**
  * Wild Call has a 20% increased chance to reset the cooldown of Barbed Shot.
@@ -13,7 +12,6 @@ import SpellIcon from 'common/SpellIcon';
  *
  * Wild Call: Your auto shot critical strikes have a 20% chance to reset the cooldown of Barbed Shot.
  */
-
 const WILD_CALL_RESET_PERCENT = 0.2;
 
 class OneWithThePack extends Analyzer {

--- a/src/parser/hunter/beastmastery/modules/talents/OneWithThePack.js
+++ b/src/parser/hunter/beastmastery/modules/talents/OneWithThePack.js
@@ -39,9 +39,8 @@ class OneWithThePack extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
-        icon={<SpellIcon id={SPELLS.ONE_WITH_THE_PACK_TALENT.id} />}
+        talent={SPELLS.ONE_WITH_THE_PACK_TALENT.id}
         value={`≈${(this.procChances * WILD_CALL_RESET_PERCENT).toFixed(1)} resets`}
-        label="One With The Pack"
         tooltip={`Since there is no way to track Wild Call resets, this is an approximation of how many resets One With The Pack granted you.`}
       />
     );

--- a/src/parser/hunter/beastmastery/modules/talents/ScentOfBlood.js
+++ b/src/parser/hunter/beastmastery/modules/talents/ScentOfBlood.js
@@ -63,13 +63,12 @@ class ScentOfBlood extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
-        icon={<SpellIcon id={SPELLS.SCENT_OF_BLOOD_TALENT.id} />}
+        talent={SPELLS.SCENT_OF_BLOOD_TALENT.id}
         value={
           <>
             gained {this.focusGained} focus <ResourceIcon id={RESOURCE_TYPES.FOCUS.id} />
           </>
         }
-        label="Scent of Blood"
         tooltip={`
             <ul>
             <li>You wasted ${this.focusWastedFromBS} focus by being too close to focus cap when Barbed Shot gave you focus.</li>

--- a/src/parser/hunter/beastmastery/modules/talents/ScentOfBlood.js
+++ b/src/parser/hunter/beastmastery/modules/talents/ScentOfBlood.js
@@ -2,7 +2,6 @@ import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
-import SpellIcon from 'common/SpellIcon';
 import ResourceIcon from 'common/ResourceIcon';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 

--- a/src/parser/hunter/beastmastery/modules/talents/SpittingCobra.js
+++ b/src/parser/hunter/beastmastery/modules/talents/SpittingCobra.js
@@ -2,7 +2,6 @@ import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
-import SpellIcon from 'common/SpellIcon';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 import ResourceIcon from 'common/ResourceIcon';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';

--- a/src/parser/hunter/beastmastery/modules/talents/SpittingCobra.js
+++ b/src/parser/hunter/beastmastery/modules/talents/SpittingCobra.js
@@ -46,14 +46,13 @@ class SpittingCobra extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
-        icon={<SpellIcon id={SPELLS.SPITTING_COBRA_TALENT.id} />}
+        talent={SPELLS.SPITTING_COBRA_TALENT.id}
         value={
           <>
             <ItemDamageDone amount={this.damage} /> <br />
             gained {this.focusGained} focus <ResourceIcon id={RESOURCE_TYPES.FOCUS.id} />
           </>
         }
-        label="Spitting Cobra"
         tooltip={`You wasted ${this.focusWasted} focus by being too close to focus cap when Spitting Cobra gave you focus.`}
       />
     );

--- a/src/parser/hunter/beastmastery/modules/talents/Stomp.js
+++ b/src/parser/hunter/beastmastery/modules/talents/Stomp.js
@@ -4,7 +4,6 @@ import SPELLS from 'common/SPELLS';
 import Analyzer from 'parser/core/Analyzer';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
-import SpellIcon from 'common/SpellIcon';
 import AverageTargetsHit from 'interface/others/AverageTargetsHit';
 
 /**

--- a/src/parser/hunter/beastmastery/modules/talents/Stomp.js
+++ b/src/parser/hunter/beastmastery/modules/talents/Stomp.js
@@ -44,12 +44,11 @@ class Stomp extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
-        icon={<SpellIcon id={SPELLS.STOMP_TALENT.id} />}
+        talent={SPELLS.STOMP_TALENT.id}
         value={<>
           <ItemDamageDone amount={this.damage} /> <br />
           <AverageTargetsHit casts={this.casts} hits={this.hits} />
         </>}
-        label="Stomp"
       />
     );
   }

--- a/src/parser/hunter/beastmastery/modules/talents/VenomousBite.js
+++ b/src/parser/hunter/beastmastery/modules/talents/VenomousBite.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import { formatNumber, formatPercentage } from 'common/format';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import SpellUsable from 'parser/shared/modules/SpellUsable';

--- a/src/parser/hunter/beastmastery/modules/talents/VenomousBite.js
+++ b/src/parser/hunter/beastmastery/modules/talents/VenomousBite.js
@@ -104,7 +104,7 @@ class VenomousBite extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
-        icon={<SpellIcon id={SPELLS.VENOMOUS_BITE_TALENT.id} />}
+        talent={SPELLS.VENOMOUS_BITE_TALENT.id}
         value={(
           <>
             {formatNumber(this.effectiveBWReductionMs / 1000)}s / {this.totalPossibleCDR / 1000}s

--- a/src/parser/hunter/marksmanship/modules/talents/CallingTheShots.js
+++ b/src/parser/hunter/marksmanship/modules/talents/CallingTheShots.js
@@ -3,7 +3,6 @@ import React from 'react';
 import SPELLS from 'common/SPELLS';
 import Analyzer from 'parser/core/Analyzer';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
-import SpellIcon from 'common/SpellIcon';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import { formatNumber } from 'common/format';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';

--- a/src/parser/hunter/marksmanship/modules/talents/CallingTheShots.js
+++ b/src/parser/hunter/marksmanship/modules/talents/CallingTheShots.js
@@ -52,8 +52,8 @@ class CallingTheShots extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.CALLING_THE_SHOTS_TALENT.id}
         position={STATISTIC_ORDER.CORE(15)}
-        icon={<SpellIcon id={SPELLS.CALLING_THE_SHOTS_TALENT.id} />}
         value={`${formatNumber(this.effectiveTrueshotReductionMs / 1000)}s`}
         label="Trueshot CDR"
         tooltip={`You wasted ${formatNumber(this.wastedTrueshotReductionMs / 1000)} seconds of CDR by using Arcane Shot or Multi Shot when Trueshot wasn't on cooldown or had less than 3 seconds remaning on CD.`} />

--- a/src/parser/hunter/marksmanship/modules/talents/DoubleTap.js
+++ b/src/parser/hunter/marksmanship/modules/talents/DoubleTap.js
@@ -57,8 +57,8 @@ class DoubleTap extends Analyzer {
 
     return (
       <TalentStatisticBox
+        talent={SPELLS.DOUBLE_TAP_TALENT.id}
         position={STATISTIC_ORDER.CORE(18)}
-        icon={<SpellIcon id={SPELLS.DOUBLE_TAP_TALENT.id} />}
         value={(
           <>
             {this.aimedUsage}{'  '}
@@ -80,7 +80,6 @@ class DoubleTap extends Analyzer {
             />
           </>
         )}
-        label="Double Tap"
         tooltip={tooltipText}
       />
     );

--- a/src/parser/hunter/marksmanship/modules/talents/HuntersMark.js
+++ b/src/parser/hunter/marksmanship/modules/talents/HuntersMark.js
@@ -8,7 +8,6 @@ import ItemDamageDone from 'interface/others/ItemDamageDone';
 import Enemies from 'parser/shared/modules/Enemies';
 import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
-import SpellIcon from 'common/SpellIcon';
 import { formatPercentage } from 'common/format';
 import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';

--- a/src/parser/hunter/marksmanship/modules/talents/HuntersMark.js
+++ b/src/parser/hunter/marksmanship/modules/talents/HuntersMark.js
@@ -154,8 +154,8 @@ class HuntersMark extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.HUNTERS_MARK_TALENT.id}
         position={STATISTIC_ORDER.CORE(19)}
-        icon={<SpellIcon id={SPELLS.HUNTERS_MARK_TALENT.id} />}
         value={`${formatPercentage(this.uptimePercentage)}%`}
         label="Hunters Mark uptime"
         tooltip={`<ul><li>You had a total of ${this.casts} casts of Hunter's Mark.</li><li>You cast Hunter's Mark ${this.recasts} times, whilst it was active on the target or another target.</li><li>You received up to ${this.refunds * FOCUS_PER_REFUND} focus from a total of ${this.refunds} refunds from targets with Hunter's Mark active dying.</li>${this.potentialPrecastConfirmation}</ul>`}

--- a/src/parser/hunter/marksmanship/modules/talents/LethalShots.js
+++ b/src/parser/hunter/marksmanship/modules/talents/LethalShots.js
@@ -4,7 +4,6 @@ import Analyzer from 'parser/core/Analyzer';
 
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
-import SpellIcon from 'common/SpellIcon';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 
 /**

--- a/src/parser/hunter/marksmanship/modules/talents/LethalShots.js
+++ b/src/parser/hunter/marksmanship/modules/talents/LethalShots.js
@@ -74,8 +74,8 @@ class LethalShots extends Analyzer {
     tooltipText += `</ul>`;
     return (
       <TalentStatisticBox
+        talent={SPELLS.LETHAL_SHOTS_TALENT.id}
         position={STATISTIC_ORDER.CORE(20)}
-        icon={<SpellIcon id={SPELLS.LETHAL_SHOTS_TALENT.id} />}
         value={`${this.totalUsage}/${this.totalProcs}`}
         label="utilised LS procs"
         tooltip={tooltipText} />

--- a/src/parser/hunter/marksmanship/modules/talents/LockAndLoad.js
+++ b/src/parser/hunter/marksmanship/modules/talents/LockAndLoad.js
@@ -145,8 +145,8 @@ class LockAndLoad extends Analyzer {
 
     return (
       <TalentStatisticBox
+        talent={SPELLS.LOCK_AND_LOAD_TALENT.id}
         position={STATISTIC_ORDER.CORE(24)}
-        icon={<SpellIcon id={SPELLS.LOCK_AND_LOAD_TALENT.id} />}
         value={`${this.wastedInstants} (${formatPercentage(this.wastedInstants / (this.totalProcs))}%)`}
         label="lost LnL stacks"
         tooltip={tooltipText}

--- a/src/parser/hunter/marksmanship/modules/talents/LockAndLoad.js
+++ b/src/parser/hunter/marksmanship/modules/talents/LockAndLoad.js
@@ -3,7 +3,6 @@ import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import { formatPercentage } from 'common/format';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import Abilities from 'parser/core/modules/Abilities';

--- a/src/parser/hunter/marksmanship/modules/talents/MasterMarksman.js
+++ b/src/parser/hunter/marksmanship/modules/talents/MasterMarksman.js
@@ -60,8 +60,8 @@ class MasterMarksman extends Analyzer {
     tooltipText += `</ul>`;
     return (
       <TalentStatisticBox
+        talent={SPELLS.MASTER_MARKSMAN_TALENT.id}
         position={STATISTIC_ORDER.CORE(21)}
-        icon={<SpellIcon id={SPELLS.MASTER_MARKSMAN_TALENT.id} />}
         value={`${this.usedProcs}/${this.totalProcs}`}
         label="utilised MM buffs"
         tooltip={tooltipText} />

--- a/src/parser/hunter/marksmanship/modules/talents/MasterMarksman.js
+++ b/src/parser/hunter/marksmanship/modules/talents/MasterMarksman.js
@@ -4,7 +4,6 @@ import Analyzer from 'parser/core/Analyzer';
 
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
-import SpellIcon from 'common/SpellIcon';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 
 /**

--- a/src/parser/hunter/marksmanship/modules/talents/SerpentSting.js
+++ b/src/parser/hunter/marksmanship/modules/talents/SerpentSting.js
@@ -7,7 +7,6 @@ import SpellLink from "common/SpellLink";
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 import { formatPercentage } from 'common/format';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
-import SpellIcon from 'common/SpellIcon';
 import Enemies from 'parser/shared/modules/Enemies';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';

--- a/src/parser/hunter/marksmanship/modules/talents/SerpentSting.js
+++ b/src/parser/hunter/marksmanship/modules/talents/SerpentSting.js
@@ -43,8 +43,8 @@ class SerpentSting extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.SERPENT_STING_TALENT.id}
         position={STATISTIC_ORDER.CORE(22)}
-        icon={<SpellIcon id={SPELLS.SERPENT_STING_TALENT.id} />}
         value={`${formatPercentage(this.uptimePercentage)}%`}
         label="Serpent Sting Uptime"
       />

--- a/src/parser/hunter/marksmanship/modules/talents/Volley.js
+++ b/src/parser/hunter/marksmanship/modules/talents/Volley.js
@@ -116,10 +116,9 @@ class Volley extends Analyzer {
 
     return (
       <TalentStatisticBox
+        talent={SPELLS.VOLLEY_TALENT.id}
         position={STATISTIC_ORDER.CORE(23)}
-        icon={<SpellIcon id={SPELLS.VOLLEY_TALENT.id} />}
-        value={`${this.procs}`}
-        label="Volley procs"
+        value={`${this.procs} procs`}
         tooltip={tooltipText}
       />
     );

--- a/src/parser/hunter/marksmanship/modules/talents/Volley.js
+++ b/src/parser/hunter/marksmanship/modules/talents/Volley.js
@@ -7,7 +7,6 @@ import SpellLink from "common/SpellLink";
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 import { formatPercentage } from 'common/format';
 import { STATISTIC_ORDER } from 'interface/others/StatisticBox';
-import SpellIcon from 'common/SpellIcon';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
 

--- a/src/parser/hunter/shared/modules/talents/Barrage.js
+++ b/src/parser/hunter/shared/modules/talents/Barrage.js
@@ -102,12 +102,11 @@ class Barrage extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
-        icon={<SpellIcon id={SPELLS.BARRAGE_TALENT.id} />}
+        talent={SPELLS.BARRAGE_TALENT.id}
         value={<>
           <AverageTargetsHit casts={this.casts.length} hits={this.hits} /> <br />
           <AverageTargetsHit casts={this.casts.length} hits={this.uniqueTargetsHit} unique approximate />
         </>}
-        label="Barrage"
       />
     );
   }

--- a/src/parser/hunter/shared/modules/talents/Barrage.js
+++ b/src/parser/hunter/shared/modules/talents/Barrage.js
@@ -5,7 +5,6 @@ import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
-import SpellIcon from 'common/SpellIcon';
 import AverageTargetsHit from 'interface/others/AverageTargetsHit';
 import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
 import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';

--- a/src/parser/hunter/shared/modules/talents/BindingShot.js
+++ b/src/parser/hunter/shared/modules/talents/BindingShot.js
@@ -34,9 +34,9 @@ class BindingShot extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
-        icon={<SpellIcon id={SPELLS.BINDING_SHOT_TALENT.id} />}
+        talent={SPELLS.BINDING_SHOT_TALENT.id}
         value={`${this._roots} roots / ${this._applications} possible`}
-        label="Binding Shot" />
+      />
     );
   }
 }

--- a/src/parser/hunter/shared/modules/talents/BindingShot.js
+++ b/src/parser/hunter/shared/modules/talents/BindingShot.js
@@ -1,7 +1,6 @@
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
-import SpellIcon from 'common/SpellIcon';
 import React from 'react';
 
 /**

--- a/src/parser/hunter/shared/modules/talents/BornToBeWild.js
+++ b/src/parser/hunter/shared/modules/talents/BornToBeWild.js
@@ -69,9 +69,8 @@ class BornToBeWild extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
-        icon={<SpellIcon id={SPELLS.BORN_TO_BE_WILD_TALENT.id} />}
+        talent={SPELLS.BORN_TO_BE_WILD_TALENT.id}
         value={`${formatNumber(this.effectiveTotalCDR / 1000)}s total effective CDR`}
-        label="Born To Be Wild"
         tooltip={`Effective CDR constitutes the time that was left of the original CD (before reduction from Born To Be Wild) when you cast it again as that is the effective cooldown reduction it provided for you.
                 <ul>
                   ${this.hasEagle ? `<li>Aspect of the Eagle: ${formatNumber(this._spells[SPELLS.ASPECT_OF_THE_EAGLE.id].effectiveCDR / 1000)}s</li>` : ``}

--- a/src/parser/hunter/shared/modules/talents/BornToBeWild.js
+++ b/src/parser/hunter/shared/modules/talents/BornToBeWild.js
@@ -1,7 +1,6 @@
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
-import SpellIcon from 'common/SpellIcon';
 import React from 'react';
 import SPECS from 'game/SPECS';
 import { formatNumber } from 'common/format';

--- a/src/parser/hunter/shared/modules/talents/NaturalMending.js
+++ b/src/parser/hunter/shared/modules/talents/NaturalMending.js
@@ -3,7 +3,6 @@ import React from 'react';
 import SPELLS from 'common/SPELLS/index';
 import Analyzer from 'parser/core/Analyzer';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
-import SpellIcon from 'common/SpellIcon';
 import { formatNumber } from 'common/format';
 import SPECS from 'game/SPECS';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';

--- a/src/parser/hunter/shared/modules/talents/NaturalMending.js
+++ b/src/parser/hunter/shared/modules/talents/NaturalMending.js
@@ -57,9 +57,8 @@ class NaturalMending extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
-        icon={<SpellIcon id={SPELLS.NATURAL_MENDING_TALENT.id} />}
+        talent={SPELLS.NATURAL_MENDING_TALENT.id}
         value={`${formatNumber(this.effectiveExhilReductionMs / 1000)}s/${formatNumber((this.wastedExhilReductionMs + this.effectiveExhilReductionMs) / 1000)}s`}
-        label="Natural Mending"
         tooltip={`You wasted ${formatNumber(this.wastedExhilReductionMs / 1000)} seconds of CDR by spending focus whilst Exhilaration wasn't on cooldown.`} />
     );
   }

--- a/src/parser/hunter/shared/modules/talents/Trailblazer.js
+++ b/src/parser/hunter/shared/modules/talents/Trailblazer.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS/index';
-import SpellIcon from 'common/SpellIcon';
 import { formatPercentage } from 'common/format';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 

--- a/src/parser/hunter/shared/modules/talents/Trailblazer.js
+++ b/src/parser/hunter/shared/modules/talents/Trailblazer.js
@@ -24,7 +24,7 @@ class Trailblazer extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
-        icon={<SpellIcon id={SPELLS.TRAILBLAZER_TALENT.id} />}
+        talent={SPELLS.TRAILBLAZER_TALENT.id}
         value={`${formatPercentage(this.percentUptime)}%`}
         label="Trailblazer uptime"
       />

--- a/src/parser/hunter/survival/modules/talents/BirdOfPrey.js
+++ b/src/parser/hunter/survival/modules/talents/BirdOfPrey.js
@@ -105,10 +105,9 @@ class BirdOfPrey extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.BIRDS_OF_PREY_TALENT.id}
         position={STATISTIC_ORDER.CORE(17)}
-        icon={<SpellIcon id={SPELLS.BIRDS_OF_PREY_TALENT.id} />}
         value={`extended CA by ${this.timeExtendedInSeconds}s`}
-        label="Bird of Prey"
         tooltip={`<ul><li>You extended Coordinated Assault by ${this.timeExtendedInSeconds} seconds.</li><li>You lost out on ${this.extensionTimeLostInSeconds} seconds of Coordinated Assault by attacking a different target than your pet.</li></ul>`}
       />
     );

--- a/src/parser/hunter/survival/modules/talents/BirdOfPrey.js
+++ b/src/parser/hunter/survival/modules/talents/BirdOfPrey.js
@@ -6,7 +6,6 @@ import Analyzer from 'parser/core/Analyzer';
 import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
 import SpellLink from 'common/SpellLink';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
-import SpellIcon from 'common/SpellIcon';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 
 const EXTENSION_PER_CAST = 1500;

--- a/src/parser/hunter/survival/modules/talents/Chakrams.js
+++ b/src/parser/hunter/survival/modules/talents/Chakrams.js
@@ -3,7 +3,6 @@ import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';

--- a/src/parser/hunter/survival/modules/talents/Chakrams.js
+++ b/src/parser/hunter/survival/modules/talents/Chakrams.js
@@ -66,8 +66,8 @@ class Chakrams extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.CHAKRAMS_TALENT.id}
         position={STATISTIC_ORDER.CORE(21)}
-        icon={<SpellIcon id={SPELLS.CHAKRAMS_TALENT.id} />}
         value={`${this.averageTargetsHit}`}
         label="Average targets hit"
       />

--- a/src/parser/hunter/survival/modules/talents/VipersVenom.js
+++ b/src/parser/hunter/survival/modules/talents/VipersVenom.js
@@ -140,8 +140,8 @@ class VipersVenom extends Analyzer {
     tooltip += `</ul></li></ul>`;
     return (
       <TalentStatisticBox
+        talent={SPELLS.VIPERS_VENOM_TALENT.id}
         position={STATISTIC_ORDER.CORE(22)}
-        icon={<SpellIcon id={SPELLS.VIPERS_VENOM_TALENT.id} />}
         value={`${this.procs}`}
         label="Viper's Venom procs"
         tooltip={tooltip}

--- a/src/parser/hunter/survival/modules/talents/VipersVenom.js
+++ b/src/parser/hunter/survival/modules/talents/VipersVenom.js
@@ -4,7 +4,6 @@ import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
-import SpellIcon from 'common/SpellIcon';
 import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
 import StatTracker from 'parser/shared/modules/StatTracker';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';

--- a/src/parser/mage/frost/modules/features/GlacialSpike.js
+++ b/src/parser/mage/frost/modules/features/GlacialSpike.js
@@ -126,8 +126,8 @@ class GlacialSpike extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.GLACIAL_SPIKE_TALENT.id}
         position={STATISTIC_ORDER.CORE(90)}
-        icon={<SpellIcon id={SPELLS.GLACIAL_SPIKE_TALENT.id} />}
         value={`${formatPercentage(this.utilPercentage, 0)} %`}
         label="Glacial Spike efficiency"
         tooltip={`You cast Glacial Spike ${this.totalCasts} times, ${this.goodCasts} casts of which met at least one of the requirements:

--- a/src/parser/mage/frost/modules/features/GlacialSpike.js
+++ b/src/parser/mage/frost/modules/features/GlacialSpike.js
@@ -2,7 +2,6 @@ import React from 'react';
 
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';

--- a/src/parser/mage/frost/modules/features/SplittingIce.js
+++ b/src/parser/mage/frost/modules/features/SplittingIce.js
@@ -75,8 +75,8 @@ class SplittingIce extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.SPLITTING_ICE_TALENT.id}
         position={STATISTIC_ORDER.CORE(100)}
-        icon={<SpellIcon id={SPELLS.SPLITTING_ICE_TALENT.id} />}
         value={`${this.hasGlacialSpike ? '≈' : ''}${formatPercentage(this.damagePercent)} %`}
         label="Splitting Ice damage"
         tooltip={`This is all the secondary target damage summed with the portion of primary target damage attributable to Splitting Ice.${this.hasGlacialSpike ? ' Because only the icicles inside each Glacial Spike are boosted, the damage bonus to Glacial Spike is estimated.' : ''}

--- a/src/parser/mage/frost/modules/features/SplittingIce.js
+++ b/src/parser/mage/frost/modules/features/SplittingIce.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import { formatPercentage } from 'common/format';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
 import Analyzer from 'parser/core/Analyzer';

--- a/src/parser/mage/frost/modules/features/ThermalVoid.js
+++ b/src/parser/mage/frost/modules/features/ThermalVoid.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
-import SpellIcon from 'common/SpellIcon';
 import { formatNumber } from 'common/format';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
 import Analyzer from 'parser/core/Analyzer';
@@ -68,8 +67,8 @@ class ThermalVoid extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.ICY_VEINS.id}
         position={STATISTIC_ORDER.CORE(100)}
-        icon={<SpellIcon id={SPELLS.ICY_VEINS.id} />}
         value={`${formatNumber(this.averageDurationSeconds)}s`}
         label="Avg Icy Veins Duration"
         tooltip="Icy Veins Casts that do not complete before the fight ends are removed from this statistic"

--- a/src/parser/mage/shared/modules/features/MirrorImage.js
+++ b/src/parser/mage/shared/modules/features/MirrorImage.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
-import SpellIcon from 'common/SpellIcon';
 import { formatPercentage } from 'common/format';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
 import Analyzer from 'parser/core/Analyzer';
@@ -64,8 +63,8 @@ class MirrorImage extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.MIRROR_IMAGE_TALENT.id}
         position={STATISTIC_ORDER.CORE(100)}
-        icon={<SpellIcon id={SPELLS.MIRROR_IMAGE_TALENT.id} />}
         value={`${formatPercentage(this.damagePercent)} %`}
         label="Mirror Image damage"
         tooltip={`This is the portion of your total damage attributable to Mirror Image. Expressed as an increase vs never using Mirror Image, this is a <b>${formatPercentage(this.damageIncreasePercent)}% damage increase</b>.`}

--- a/src/parser/mage/shared/modules/features/RuneOfPower.js
+++ b/src/parser/mage/shared/modules/features/RuneOfPower.js
@@ -2,7 +2,6 @@ import React from 'react';
 import SPELLS from 'common/SPELLS';
 import SPECS from 'game/SPECS';
 import SpellLink from 'common/SpellLink';
-import SpellIcon from 'common/SpellIcon';
 import { formatNumber, formatPercentage } from 'common/format';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';

--- a/src/parser/mage/shared/modules/features/RuneOfPower.js
+++ b/src/parser/mage/shared/modules/features/RuneOfPower.js
@@ -133,8 +133,8 @@ class RuneOfPower extends Analyzer {
 
     return (
       <TalentStatisticBox
+        talent={SPELLS.RUNE_OF_POWER_TALENT.id}
         position={STATISTIC_ORDER.CORE(100)}
-        icon={<SpellIcon id={SPELLS.RUNE_OF_POWER_TALENT.id} />}
         value={`${formatPercentage(this.damagePercent)} %`}
         label="Rune of Power damage"
         tooltip={`This is the portion of your total damage attributable to Rune of Power's boost. Expressed as an increase vs never using Rune of Power, this is a <b>${formatPercentage(this.damageIncreasePercent)}% damage increase</b>. Note that this number does <i>not</i> factor in the opportunity cost of casting Rune of Power instead of another damaging spell.`}

--- a/src/parser/priest/holy/modules/talents/100/Apotheosis.js
+++ b/src/parser/priest/holy/modules/talents/100/Apotheosis.js
@@ -1,8 +1,6 @@
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
-import SpellIcon from 'common/SpellIcon';
 import React from 'react';
 import HolyWordSanctify from 'parser/priest/holy/modules/spells/holyword/HolyWordSanctify';
 import HolyWordSerenity from 'parser/priest/holy/modules/spells/holyword/HolyWordSerenity';

--- a/src/parser/priest/holy/modules/talents/100/Apotheosis.js
+++ b/src/parser/priest/holy/modules/talents/100/Apotheosis.js
@@ -45,15 +45,13 @@ class Apotheosis extends Analyzer {
     return (
 
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.APOTHEOSIS_TALENT.id} />}
+        talent={SPELLS.APOTHEOSIS_TALENT.id}
         value={(
           <>
             <ItemManaGained amount={this.sanctify.apotheosisManaReduction + this.serenity.apotheosisManaReduction + this.chastise.apotheosisManaReduction} /><br />
             {formatNumber((this.sanctify.apotheosisCooldownReduction + this.serenity.apotheosisCooldownReduction + this.chastise.apotheosisCooldownReduction) / 1000)}s Cooldown Reduction
           </>
         )}
-        label="Apotheosis"
         tooltip={`
           Serenity: ${this.sanctify.apotheosisCooldownReduction / 1000}s CDR | ${this.sanctify.apotheosisManaReduction} Mana saved <br />
           Sanctify: ${this.serenity.apotheosisCooldownReduction / 1000}s CDR | ${this.serenity.apotheosisManaReduction} Mana saved <br />

--- a/src/parser/priest/holy/modules/talents/100/HolyWordSalvation.js
+++ b/src/parser/priest/holy/modules/talents/100/HolyWordSalvation.js
@@ -1,8 +1,6 @@
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
-import SpellIcon from 'common/SpellIcon';
 import React from 'react';
 import Renew from 'parser/priest/holy/modules/spells/Renew';
 import PrayerOfMending from 'parser/priest/holy/modules/spells/PrayerOfMending';

--- a/src/parser/priest/holy/modules/talents/100/HolyWordSalvation.js
+++ b/src/parser/priest/holy/modules/talents/100/HolyWordSalvation.js
@@ -83,14 +83,11 @@ class HolyWordSalvation extends Analyzer {
 
   statistic() {
     return (
-
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.HOLY_WORD_SALVATION_TALENT.id} />}
+        talent={SPELLS.HOLY_WORD_SALVATION_TALENT.id}
         value={(
           <ItemHealingDone amount={this.totalHealing} />
         )}
-        label="Holy Word: Salvation"
         tooltip={`
           Healing from Salv: ${formatThousands(this.healingFromSalv + this.absorptionFromSalv)}<br />
           Healing from Renews: ${formatThousands(this.healingFromRenew + this.absorptionFromRenew)}<br />
@@ -98,7 +95,6 @@ class HolyWordSalvation extends Analyzer {
         `}
         position={STATISTIC_ORDER.CORE(7)}
       />
-
     );
   }
 }

--- a/src/parser/priest/holy/modules/talents/100/LightOfTheNaaru.js
+++ b/src/parser/priest/holy/modules/talents/100/LightOfTheNaaru.js
@@ -1,8 +1,6 @@
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
-import SpellIcon from 'common/SpellIcon';
 import React from 'react';
 import HolyWordSanctify from 'parser/priest/holy/modules/spells/holyword/HolyWordSanctify';
 import HolyWordChastise from 'parser/priest/holy/modules/spells/holyword/HolyWordChastise';
@@ -25,10 +23,8 @@ class LightOfTheNaaru extends Analyzer {
     return (
 
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.LIGHT_OF_THE_NAARU_TALENT.id} />}
+        talent={SPELLS.LIGHT_OF_THE_NAARU_TALENT.id}
         value={`${Math.ceil((this.sanctify.lightOfTheNaaruCooldownReduction + this.serenity.lightOfTheNaaruCooldownReduction + this.chastise.lightOfTheNaaruCooldownReduction) / 1000)}s Cooldown Reduction`}
-        label="Light of the Naaru"
         tooltip={`
           Serenity: ${Math.ceil(this.serenity.lightOfTheNaaruCooldownReduction / 1000)}s CDR<br />
           Sanctify: ${Math.ceil(this.sanctify.lightOfTheNaaruCooldownReduction / 1000)}s CDR<br />

--- a/src/parser/priest/holy/modules/talents/15/EnduringRenewal.js
+++ b/src/parser/priest/holy/modules/talents/15/EnduringRenewal.js
@@ -78,14 +78,12 @@ class EnduringRenewal extends Analyzer {
     return (
 
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.ENDURING_RENEWAL_TALENT.id} />}
+        talent={SPELLS.ENDURING_RENEWAL_TALENT.id}
         value={(
           <>
             <ItemHealingDone amount={this.healing} />
           </>
         )}
-        label="Enduring Renewal"
         tooltip={`Refreshed Renews: ${this.refreshedRenews}`}
         position={STATISTIC_ORDER.CORE(1)}
       />

--- a/src/parser/priest/holy/modules/talents/15/EnduringRenewal.js
+++ b/src/parser/priest/holy/modules/talents/15/EnduringRenewal.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import SpellIcon from 'common/SpellIcon';
 
 import SPELLS from 'common/SPELLS/index';
 import Analyzer from 'parser/core/Analyzer';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import ItemHealingDone from 'interface/others/ItemHealingDone';
 
 import { ABILITIES_THAT_TRIGGER_ENDURING_RENEWAL } from '../../../constants';

--- a/src/parser/priest/holy/modules/talents/15/Enlightenment.js
+++ b/src/parser/priest/holy/modules/talents/15/Enlightenment.js
@@ -1,8 +1,6 @@
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
-import SpellIcon from 'common/SpellIcon';
 import React from 'react';
 import SpiritOfRedemption from 'parser/priest/holy/modules/spells/SpiritOfRedemption';
 import ItemManaGained from 'interface/others/ItemManaGained';

--- a/src/parser/priest/holy/modules/talents/15/Enlightenment.js
+++ b/src/parser/priest/holy/modules/talents/15/Enlightenment.js
@@ -32,14 +32,11 @@ class Enlightenment extends Analyzer {
 
   statistic() {
     return (
-
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.ENLIGHTENMENT_TALENT.id} />}
+        talent={SPELLS.ENLIGHTENMENT_TALENT.id}
         value={(
           <ItemManaGained amount={this.enlightenmentMana} />
         )}
-        label="Enlightment"
         position={STATISTIC_ORDER.CORE(1)}
       />
 

--- a/src/parser/priest/holy/modules/talents/15/TrailOfLight.js
+++ b/src/parser/priest/holy/modules/talents/15/TrailOfLight.js
@@ -3,8 +3,6 @@ import React from 'react';
 import SPELLS from 'common/SPELLS/index';
 import Analyzer from 'parser/core/Analyzer';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
-import SpellIcon from 'common/SpellIcon';
 import ItemHealingDone from 'interface/others/ItemHealingDone';
 
 // Example Log: /report/hRd3mpK1yTQ2tDJM/1-Mythic+MOTHER+-+Kill+(2:24)/14-丶寶寶小喵
@@ -29,18 +27,14 @@ class TrailOfLight extends Analyzer {
 
   statistic() {
     return (
-
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.TRAIL_OF_LIGHT_TALENT.id} />}
+        talent={SPELLS.TRAIL_OF_LIGHT_TALENT.id}
         value={(
           <ItemHealingDone amount={this.totalToLHealing} />
         )}
-        label="Trail of Light"
         tooltip={`Trail of Light Procs: ${this.totalToLProcs}`}
         position={STATISTIC_ORDER.CORE(1)}
       />
-
     );
   }
 }

--- a/src/parser/priest/holy/modules/talents/30/AngelicFeather.js
+++ b/src/parser/priest/holy/modules/talents/30/AngelicFeather.js
@@ -34,10 +34,8 @@ class AngelicFeather extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.ANGELIC_FEATHER_TALENT.id} />}
+        talent={SPELLS.ANGELIC_FEATHER_TALENT.id}
         value={`${this.angelicFeatherCasts} Feather(s) cast`}
-        label="Angelic Feather"
         position={STATISTIC_ORDER.CORE(2)}
       />
     );

--- a/src/parser/priest/holy/modules/talents/30/AngelicFeather.js
+++ b/src/parser/priest/holy/modules/talents/30/AngelicFeather.js
@@ -1,8 +1,6 @@
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
-import SpellIcon from 'common/SpellIcon';
 import React from 'react';
 
 // Example Log: /report/PNYB4zgrnR86h7Lc/6-Normal+Zek'voz,+Herald+of+N'zoth/Khadaj

--- a/src/parser/priest/holy/modules/talents/30/AngelsMercy.js
+++ b/src/parser/priest/holy/modules/talents/30/AngelsMercy.js
@@ -1,8 +1,6 @@
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
-import SpellIcon from 'common/SpellIcon';
 import React from 'react';
 
 const DESPERATE_PRAYER_BASE_COOLDOWN = 90000;

--- a/src/parser/priest/holy/modules/talents/30/AngelsMercy.js
+++ b/src/parser/priest/holy/modules/talents/30/AngelsMercy.js
@@ -37,10 +37,8 @@ class AngelsMercy extends Analyzer {
     return (
 
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.ANGELS_MERCY_TALENT.id} />}
+        talent={SPELLS.ANGELS_MERCY_TALENT.id}
         value={`${Math.floor(this.desperatePrayerTimeReduced / 1000)}s Cooldown Reduction Used`}
-        label="Angels Mercy"
         tooltip={`
           Desperate Prayers cast: ${this.desperatePrayersCast}<br />
         `}

--- a/src/parser/priest/holy/modules/talents/30/Perseverance.js
+++ b/src/parser/priest/holy/modules/talents/30/Perseverance.js
@@ -3,8 +3,6 @@ import React from 'react';
 import SPELLS from 'common/SPELLS/index';
 import Analyzer from 'parser/core/Analyzer';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
-import SpellIcon from 'common/SpellIcon';
 import ItemHealingDone from 'interface/others/ItemHealingDone';
 import { formatPercentage, formatThousands } from 'common/format';
 
@@ -44,21 +42,15 @@ class Perseverance extends Analyzer {
 
   statistic() {
     return (
-
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.PERSEVERANCE_TALENT.id} />}
-        value={(
-          <ItemHealingDone amount={this.totalDamageReduced} />
-        )}
-        label="Perseverance"
+        talent={SPELLS.PERSEVERANCE_TALENT.id}
+        value={<ItemHealingDone amount={this.totalDamageReduced} />}
         tooltip={`
           Perseverance Uptime: ${formatPercentage(this.uptime)}%<br />
           Damage Reduced: ${formatThousands(this.totalDamageReduced)}
           `}
         position={STATISTIC_ORDER.CORE(2)}
       />
-
     );
   }
 }

--- a/src/parser/priest/holy/modules/talents/45/Afterlife.js
+++ b/src/parser/priest/holy/modules/talents/45/Afterlife.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import SpellIcon from 'common/SpellIcon';
 
 import SPELLS from 'common/SPELLS/index';
 import Analyzer from 'parser/core/Analyzer';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import ItemHealingDone from 'interface/others/ItemHealingDone';
 
 const SPIRIT_OF_REDEMPTION_DURATION = 15000;

--- a/src/parser/priest/holy/modules/talents/45/Afterlife.js
+++ b/src/parser/priest/holy/modules/talents/45/Afterlife.js
@@ -61,12 +61,10 @@ class Afterlife extends Analyzer {
     return (
 
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.AFTERLIFE_TALENT.id} />}
+        talent={SPELLS.AFTERLIFE_TALENT.id}
         value={(
           <ItemHealingDone amount={this.healingInAfterlife} />
         )}
-        label="Afterlife"
         tooltip={`Extra Spirit of Redemption time: ${Math.floor(this.spiritOfRedemptionBonusTime / 1000)}s`}
         position={STATISTIC_ORDER.CORE(3)}
       />

--- a/src/parser/priest/holy/modules/talents/45/CosmicRipple.js
+++ b/src/parser/priest/holy/modules/talents/45/CosmicRipple.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import SpellIcon from 'common/SpellIcon';
 
 import SPELLS from 'common/SPELLS/index';
 import Analyzer from 'parser/core/Analyzer';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import ItemHealingDone from 'interface/others/ItemHealingDone';
 
 // Example Log: /report/C2NGDav6KHgc8ZWd/28-Mythic+Taloc+-+Kill+(7:07)/13-Ariemah

--- a/src/parser/priest/holy/modules/talents/45/CosmicRipple.js
+++ b/src/parser/priest/holy/modules/talents/45/CosmicRipple.js
@@ -40,12 +40,10 @@ class CosmicRipple extends Analyzer {
     return (
 
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.COSMIC_RIPPLE_HEAL.id} />}
+        talent={SPELLS.COSMIC_RIPPLE_HEAL.id}
         value={(
           <ItemHealingDone amount={this.totalHealing} />
         )}
-        label="Cosmic Ripple"
         position={STATISTIC_ORDER.CORE(3)}
       />
 

--- a/src/parser/priest/holy/modules/talents/45/GuardianAngel.js
+++ b/src/parser/priest/holy/modules/talents/45/GuardianAngel.js
@@ -69,12 +69,10 @@ class GuardianAngel extends Analyzer {
     return (
 
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.GUARDIAN_ANGEL_TALENT.id} />}
+        talent={SPELLS.GUARDIAN_ANGEL_TALENT.id}
         value={(
           <ItemHealingDone amount={this.guardianSpiritSelfHealing} />
         )}
-        label="Guardian Angel"
         tooltip={`
           Total Guardian Spirits Cast: ${this.guardianSpiritCasts}<br />
           Total Guardian Spirit Resets: ${this.guardianSpiritRefreshes}

--- a/src/parser/priest/holy/modules/talents/45/GuardianAngel.js
+++ b/src/parser/priest/holy/modules/talents/45/GuardianAngel.js
@@ -1,8 +1,6 @@
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
-import SpellIcon from 'common/SpellIcon';
 import React from 'react';
 import ItemHealingDone from 'interface/others/ItemHealingDone';
 

--- a/src/parser/priest/holy/modules/talents/60/Censure.js
+++ b/src/parser/priest/holy/modules/talents/60/Censure.js
@@ -1,8 +1,6 @@
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
-import SpellIcon from 'common/SpellIcon';
 import React from 'react';
 
 // Example Log: /report/PNYB4zgrnR86h7Lc/6-Normal+Zek'voz,+Herald+of+N'zoth/Khadaj

--- a/src/parser/priest/holy/modules/talents/60/Censure.js
+++ b/src/parser/priest/holy/modules/talents/60/Censure.js
@@ -39,12 +39,10 @@ class Censure extends Analyzer {
     return (
 
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.CENSURE_TALENT.id} />}
+        talent={SPELLS.CENSURE_TALENT.id}
         value={
           `${this.censureStuns + this.censureIncomp} Censure CC(s)`
         }
-        label="Censure"
         tooltip={`
           ${this.chastiseCasts} Chastise Casts<br />
           ${this.censureStuns} Chastise Stuns<br />

--- a/src/parser/priest/holy/modules/talents/60/PsychicVoice.js
+++ b/src/parser/priest/holy/modules/talents/60/PsychicVoice.js
@@ -1,8 +1,6 @@
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
-import SpellIcon from 'common/SpellIcon';
 import React from 'react';
 
 // Example Log: /report/nWVBjGLrDQvahH7M/15-Mythic+Taloc+-+Kill+(6:50)/3-Claver
@@ -31,15 +29,11 @@ class PsychicVoice extends Analyzer {
 
   statistic() {
     return (
-
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.PSYCHIC_VOICE_TALENT.id} />}
+        talent={SPELLS.PSYCHIC_VOICE_TALENT.id}
         value={`${this.psychicScreamHits} Targets Feared`}
-        label="Psychic Voice"
         position={STATISTIC_ORDER.CORE(4)}
       />
-
     );
   }
 }

--- a/src/parser/priest/holy/modules/talents/60/ShiningForce.js
+++ b/src/parser/priest/holy/modules/talents/60/ShiningForce.js
@@ -1,8 +1,6 @@
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
-import SpellIcon from 'common/SpellIcon';
 import React from 'react';
 
 // Example Log: /report/NcKyHD94nrj31tG2/10-Mythic+Zek'voz+-+Kill+(9:35)/3-旧时印月
@@ -33,10 +31,8 @@ class ShiningForce extends Analyzer {
     return (
 
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.SHINING_FORCE_TALENT.id} />}
+        talent={SPELLS.SHINING_FORCE_TALENT.id}
         value={`${this.shiningForceHits} Knock Back(s)`}
-        label="Shining Force"
         position={STATISTIC_ORDER.CORE(4)}
       />
 

--- a/src/parser/priest/holy/modules/talents/75/BindingHeal.js
+++ b/src/parser/priest/holy/modules/talents/75/BindingHeal.js
@@ -1,8 +1,6 @@
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
-import SpellIcon from 'common/SpellIcon';
 import React from 'react';
 import ItemHealingDone from 'interface/others/ItemHealingDone';
 import { formatPercentage, formatThousands } from 'common/format';

--- a/src/parser/priest/holy/modules/talents/75/BindingHeal.js
+++ b/src/parser/priest/holy/modules/talents/75/BindingHeal.js
@@ -66,12 +66,10 @@ class BindingHeal extends Analyzer {
     return (
 
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.BINDING_HEAL_TALENT.id} />}
+        talent={SPELLS.BINDING_HEAL_TALENT.id}
         value={(
           <ItemHealingDone amount={this.bindingHealHealing} />
         )}
-        label="Binding Heal"
         tooltip={`
           Casts:&#9;${this.bindingHealCasts}<br />
           Self Healing:&#9;${formatThousands(this.bindingHealSelfHealing)} (${formatPercentage(this.getOverhealPercent(this.bindingHealSelfHealing, this.bindingHealSelfOverhealing))}% OH)<br />

--- a/src/parser/priest/holy/modules/talents/75/CircleOfHealing.js
+++ b/src/parser/priest/holy/modules/talents/75/CircleOfHealing.js
@@ -1,8 +1,6 @@
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
-import SpellIcon from 'common/SpellIcon';
 import React from 'react';
 import ItemHealingDone from 'interface/others/ItemHealingDone';
 import { formatPercentage, formatThousands } from 'common/format';

--- a/src/parser/priest/holy/modules/talents/75/CircleOfHealing.js
+++ b/src/parser/priest/holy/modules/talents/75/CircleOfHealing.js
@@ -51,12 +51,11 @@ class CircleOfHealing extends Analyzer {
     return (
 
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.CIRCLE_OF_HEALING_TALENT.id} />}
+        talent={SPELLS.CIRCLE_OF_HEALING_TALENT.id}
+
         value={(
           <ItemHealingDone amount={this.circleOfHealingHealing} />
         )}
-        label="Circle of Healing"
         tooltip={`
           Coh Casts: ${this.circleOfHealingCasts}<br />
           Total Healing: ${formatThousands(this.circleOfHealingHealing)} (${formatPercentage(this.overHealPercent)}% OH)<br />

--- a/src/parser/priest/holy/modules/talents/75/SurgeOfLight.js
+++ b/src/parser/priest/holy/modules/talents/75/SurgeOfLight.js
@@ -1,8 +1,6 @@
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
-import SpellIcon from 'common/SpellIcon';
 import React from 'react';
 import ItemHealingDone from 'interface/others/ItemHealingDone';
 
@@ -56,18 +54,12 @@ class SurgeOfLight extends Analyzer {
 
   statistic() {
     return (
-
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.SURGE_OF_LIGHT_TALENT.id} />}
-        value={(
-          <ItemHealingDone amount={this.solHealing} />
-        )}
+        talent={SPELLS.SURGE_OF_LIGHT_TALENT.id}
+        value={<ItemHealingDone amount={this.solHealing} />}
         tooltip={`${this.solFlashHeals} free Flash Heals`}
-        label="Surge of Light"
         position={STATISTIC_ORDER.CORE(5)}
       />
-
     );
   }
 }

--- a/src/parser/priest/holy/modules/talents/90/Benediction.js
+++ b/src/parser/priest/holy/modules/talents/90/Benediction.js
@@ -1,8 +1,6 @@
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
-import SpellIcon from 'common/SpellIcon';
 import React from 'react';
 import ItemHealingDone from 'interface/others/ItemHealingDone';
 import Renew from 'parser/priest/holy/modules/spells/Renew';

--- a/src/parser/priest/holy/modules/talents/90/Benediction.js
+++ b/src/parser/priest/holy/modules/talents/90/Benediction.js
@@ -31,12 +31,10 @@ class Benediction extends Analyzer {
     return (
 
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.BENEDICTION_TALENT.id} />}
+        talent={SPELLS.BENEDICTION_TALENT.id}
         value={(
           <ItemHealingDone amount={this.healingFromBenedictionRenews} />
         )}
-        label="Benediction"
         tooltip={`${this.renewsFromBenediction} total Renews from Benediction`}
         position={STATISTIC_ORDER.CORE(6)}
       />

--- a/src/parser/priest/holy/modules/talents/90/DivineStar.js
+++ b/src/parser/priest/holy/modules/talents/90/DivineStar.js
@@ -47,15 +47,13 @@ class DivineStar extends Analyzer {
     return (
 
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.DIVINE_STAR_TALENT.id} />}
+        talent={SPELLS.DIVINE_STAR_TALENT.id}
         value={(
           <>
             <ItemHealingDone amount={this.divineStarHealing} /><br />
             <ItemDamageDone amount={this.divineStarDamage} />
           </>
         )}
-        label="Divine Star"
         tooltip={`Divine Stars Cast: ${this.divineStarCasts}`}
         position={STATISTIC_ORDER.CORE(6)}
       />

--- a/src/parser/priest/holy/modules/talents/90/DivineStar.js
+++ b/src/parser/priest/holy/modules/talents/90/DivineStar.js
@@ -1,8 +1,6 @@
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
-import SpellIcon from 'common/SpellIcon';
 import React from 'react';
 import ItemHealingDone from 'interface/others/ItemHealingDone';
 import ItemDamageDone from 'interface/others/ItemDamageDone';

--- a/src/parser/priest/holy/modules/talents/90/Halo.js
+++ b/src/parser/priest/holy/modules/talents/90/Halo.js
@@ -47,15 +47,13 @@ class Halo extends Analyzer {
     return (
 
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.HALO_TALENT.id} />}
+        talent={SPELLS.HALO_TALENT.id}
         value={(
           <>
             <ItemHealingDone amount={this.haloHealing} /><br />
             <ItemDamageDone amount={this.haloDamage} />
           </>
         )}
-        label="Halo"
         tooltip={`Halos Cast: ${this.haloCasts}`}
         position={STATISTIC_ORDER.CORE(6)}
       />

--- a/src/parser/priest/holy/modules/talents/90/Halo.js
+++ b/src/parser/priest/holy/modules/talents/90/Halo.js
@@ -1,8 +1,6 @@
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
-import SpellIcon from 'common/SpellIcon';
 import React from 'react';
 import ItemHealingDone from 'interface/others/ItemHealingDone';
 import ItemDamageDone from 'interface/others/ItemDamageDone';

--- a/src/parser/priest/shadow/modules/talents/AuspiciousSpirits.js
+++ b/src/parser/priest/shadow/modules/talents/AuspiciousSpirits.js
@@ -35,10 +35,8 @@ class AuspiciousSpirits extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.AUSPICIOUS_SPIRITS_TALENT.id} />}
+        talent={SPELLS.AUSPICIOUS_SPIRITS_TALENT.id}
         value={<ItemDamageDone amount={this.damage / SPIRIT_DAMAGE_MULTIPLIER} />}
-        label={SPELLS.AUSPICIOUS_SPIRITS_TALENT.name}
         tooltip={`
         ${formatNumber(this.insanity)} Insanity generated.<br /><br />
         The damage displayed is the additional damage you gained from taking this talent. The Spirits are doing roughly twice as much overall damage.

--- a/src/parser/priest/shadow/modules/talents/AuspiciousSpirits.js
+++ b/src/parser/priest/shadow/modules/talents/AuspiciousSpirits.js
@@ -3,10 +3,8 @@ import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 
 import SPELLS from 'common/SPELLS/index';
-import SpellIcon from 'common/SpellIcon';
 import { formatNumber } from 'common/format';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 
 const SPIRIT_DAMAGE_MULTIPLIER = 2;

--- a/src/parser/priest/shadow/modules/talents/DarkVoid.js
+++ b/src/parser/priest/shadow/modules/talents/DarkVoid.js
@@ -57,10 +57,8 @@ class DarkVoid extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.DARK_VOID_TALENT.id} />}
+        talent={SPELLS.DARK_VOID_TALENT.id}
         value={<ItemDamageDone amount={this.totalDamage} />}
-        label={`${SPELLS.DARK_VOID_TALENT.name}`}
         tooltip={`
           Damage from ${SPELLS.DARK_VOID_TALENT.name}: ${formatNumber(this.dvDamage)}<br />
           Damage from ${SPELLS.SHADOW_WORD_PAIN.name}: ${formatNumber(this.swpDamage)}

--- a/src/parser/priest/shadow/modules/talents/DarkVoid.js
+++ b/src/parser/priest/shadow/modules/talents/DarkVoid.js
@@ -1,11 +1,9 @@
 import React from 'react';
 
 import SPELLS from 'common/SPELLS/index';
-import SpellIcon from 'common/SpellIcon';
 import Analyzer from 'parser/core/Analyzer';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
 
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 import { formatNumber } from 'common/format';
 import AbilityTracker from 'parser/priest/shadow/modules/core/AbilityTracker';

--- a/src/parser/priest/shadow/modules/talents/ShadowCrash.js
+++ b/src/parser/priest/shadow/modules/talents/ShadowCrash.js
@@ -1,11 +1,9 @@
 import React from 'react';
 
 import SPELLS from 'common/SPELLS/index';
-import SpellIcon from 'common/SpellIcon';
 import Analyzer from 'parser/core/Analyzer';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
 
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 import { formatNumber } from 'common/format';
 import AbilityTracker from 'parser/priest/shadow/modules/core/AbilityTracker';
@@ -38,13 +36,10 @@ class ShadowCrash extends Analyzer {
   }
 
   statistic() {
-
     return (
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.SHADOW_CRASH_TALENT.id} />}
+        talent={SPELLS.SHADOW_CRASH_TALENT.id}
         value={<ItemDamageDone amount={this.damage} />}
-        label={`${SPELLS.SHADOW_CRASH_TALENT.name}`}
         tooltip={`Average targets hit: ${formatNumber(this.averageTargetsHit)}`}
         position={STATISTIC_ORDER.CORE(5)}
       />

--- a/src/parser/priest/shadow/modules/talents/TwistOfFate.js
+++ b/src/parser/priest/shadow/modules/talents/TwistOfFate.js
@@ -3,10 +3,8 @@ import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 
 import SPELLS from 'common/SPELLS/index';
-import SpellIcon from 'common/SpellIcon';
 import { formatPercentage } from 'common/format';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 
 const TWIST_OF_FATE_INCREASE = 1.1;
@@ -33,10 +31,8 @@ class TwistOfFate extends Analyzer {
     const uptime = this.selectedCombatant.getBuffUptime(SPELLS.TWIST_OF_FATE_BUFF.id) / this.owner.fightDuration;
     return (
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
-        icon={<SpellIcon id={SPELLS.TWIST_OF_FATE_TALENT_SHADOW.id} />}
+        talent={SPELLS.TWIST_OF_FATE_TALENT_SHADOW.id}
         value={<ItemDamageDone amount={this.damage} />}
-        label={SPELLS.TWIST_OF_FATE_TALENT_SHADOW.name}
         tooltip={`${formatPercentage(uptime)}% uptime`}
         position={STATISTIC_ORDER.CORE(1)}
       />

--- a/src/parser/priest/shadow/modules/talents/VoidTorrent.js
+++ b/src/parser/priest/shadow/modules/talents/VoidTorrent.js
@@ -2,10 +2,8 @@ import React from 'react';
 
 import SPELLS from 'common/SPELLS/index';
 import SpellLink from 'common/SpellLink';
-import SpellIcon from 'common/SpellIcon';
 import Analyzer from 'parser/core/Analyzer';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 
 import Voidform from '../spells/Voidform';

--- a/src/parser/priest/shadow/modules/talents/VoidTorrent.js
+++ b/src/parser/priest/shadow/modules/talents/VoidTorrent.js
@@ -117,12 +117,10 @@ class VoidTorrent extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
-        category={STATISTIC_CATEGORY.TALENTS}
+        talent={SPELLS.VOID_TORRENT_TALENT.id}
         position={STATISTIC_ORDER.CORE(6)}
-        icon={<SpellIcon id={SPELLS.VOID_TORRENT_TALENT.id} />}
         value={<ItemDamageDone amount={this.damage} />}
         tooltip={`${formatSeconds(this.totalWasted)} seconds wasted`}
-        label="Void Torrent"
       />
     );
   }

--- a/src/parser/rogue/assassination/modules/talents/Blindside.js
+++ b/src/parser/rogue/assassination/modules/talents/Blindside.js
@@ -14,7 +14,7 @@ const MS_BUFFER = 100;
 
 /**
  * Exploits the vulnerability of foes with less than 30% health.
- * 
+ *
  * Mutilate has a 25% chance to make your next Blindside free and usable on any target, regardless of their health.
  */
 class Blindside extends Analyzer {
@@ -42,11 +42,11 @@ class Blindside extends Analyzer {
     if (spellId !== SPELLS.MUTILATE.id) {
       return;
     }
-    
-    //Sometimes buff event is before the cast. 
+
+    //Sometimes buff event is before the cast.
     if(this.selectedCombatant.hasBuff(SPELLS.BLINDSIDE_BUFF.id, event.timestamp - MS_BUFFER)) {
       this.registerBadMutilate(event, "you had a Blindside Proc");
-    }    
+    }
     const target = this.enemies.getEntity(event);
     if(target && target.hpPercent < BLINDSIDE_EXECUTE) {
       this.registerBadMutilate(event, `health of your target was < ${BLINDSIDE_EXECUTE}% `);
@@ -85,8 +85,8 @@ class Blindside extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.BLINDSIDE_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(1)}
-        icon={<SpellIcon id={SPELLS.BLINDSIDE_TALENT.id} />}
         value={`${formatPercentage(this.efficiency)} %.`}
         label="Blindside efficiency"
         tooltip={`The efficiency is the number of Blindside casts divided by the number of Blindside casts plus the number of Mutilate casts while Blindside was available.`}

--- a/src/parser/rogue/assassination/modules/talents/Blindside.js
+++ b/src/parser/rogue/assassination/modules/talents/Blindside.js
@@ -3,7 +3,6 @@ import React from 'react';
 import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
 import EnemyInstances from 'parser/shared/modules/EnemyInstances';
@@ -27,8 +26,8 @@ class Blindside extends Analyzer {
     this.active = this.selectedCombatant.hasTalent(SPELLS.BLINDSIDE_TALENT.id);
   }
 
-  casts = 0
-  badMutilates = 0
+  casts = 0;
+  badMutilates = 0;
 
   get efficiency() {
     return (this.casts / this.casts + this.badMutilates) || 1;

--- a/src/parser/rogue/assassination/modules/talents/ElaboratePlanning.js
+++ b/src/parser/rogue/assassination/modules/talents/ElaboratePlanning.js
@@ -41,10 +41,9 @@ class ElaboratePlanning extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.ELABORATE_PLANNING_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(1)}
-        icon={<SpellIcon id={SPELLS.ELABORATE_PLANNING_TALENT.id} />}
         value={<ItemDamageDone amount={this.bonusDmg} />}
-        label="Elaborate Planning"
         tooltip={`${formatPercentage(this.percentUptime)} % uptime.`}
       />
     );

--- a/src/parser/rogue/assassination/modules/talents/ElaboratePlanning.js
+++ b/src/parser/rogue/assassination/modules/talents/ElaboratePlanning.js
@@ -4,7 +4,6 @@ import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import { formatPercentage } from 'common/format';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';

--- a/src/parser/rogue/assassination/modules/talents/MasterAssassin.js
+++ b/src/parser/rogue/assassination/modules/talents/MasterAssassin.js
@@ -4,7 +4,6 @@ import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';
 import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';

--- a/src/parser/rogue/assassination/modules/talents/MasterAssassin.js
+++ b/src/parser/rogue/assassination/modules/talents/MasterAssassin.js
@@ -43,10 +43,9 @@ class MasterAssassin extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.MASTER_ASSASSIN_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(2)}
-        icon={<SpellIcon id={SPELLS.MASTER_ASSASSIN_TALENT.id} />}
         value={<ItemDamageDone amount={this.bonusDamage} />}
-        label="Master Assassin"
       />
     );
   }

--- a/src/parser/rogue/assassination/modules/talents/MasterPoisoner.js
+++ b/src/parser/rogue/assassination/modules/talents/MasterPoisoner.js
@@ -33,10 +33,9 @@ class MasterPoisoner extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.MASTER_POISONER_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(1)}
-        icon={<SpellIcon id={SPELLS.MASTER_POISONER_TALENT.id} />}
         value={<ItemDamageDone amount={this.bonusDmg} />}
-        label="Master Poisoner"
       />
     );
   }

--- a/src/parser/rogue/assassination/modules/talents/MasterPoisoner.js
+++ b/src/parser/rogue/assassination/modules/talents/MasterPoisoner.js
@@ -4,7 +4,6 @@ import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';
 import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';

--- a/src/parser/rogue/assassination/modules/talents/Nightstalker.js
+++ b/src/parser/rogue/assassination/modules/talents/Nightstalker.js
@@ -4,7 +4,6 @@ import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';

--- a/src/parser/rogue/assassination/modules/talents/Nightstalker.js
+++ b/src/parser/rogue/assassination/modules/talents/Nightstalker.js
@@ -47,10 +47,9 @@ class Nightstalker extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.NIGHTSTALKER_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(2)}
-        icon={<SpellIcon id={SPELLS.NIGHTSTALKER_TALENT.id} />}
         value={<ItemDamageDone amount={this.bonusDamageTotal} />}
-        label="Nightstalker"
       />
     );
   }

--- a/src/parser/rogue/assassination/modules/talents/Subterfuge.js
+++ b/src/parser/rogue/assassination/modules/talents/Subterfuge.js
@@ -26,10 +26,9 @@ class Subterfuge extends Analyzer {
   statistic() {
     return (
       <TalentStatisticBox
+        talent={SPELLS.SUBTERFUGE_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(2)}
-        icon={<SpellIcon id={SPELLS.SUBTERFUGE_TALENT.id} />}
         value={<ItemDamageDone amount={this.bonusDamage} />}
-        label="Subterfuge"
       />
     );
   }

--- a/src/parser/rogue/assassination/modules/talents/Subterfuge.js
+++ b/src/parser/rogue/assassination/modules/talents/Subterfuge.js
@@ -4,7 +4,6 @@ import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 import SPELLS from 'common/SPELLS';
-import SpellIcon from 'common/SpellIcon';
 import Analyzer from 'parser/core/Analyzer';
 import GarroteSnapshot from '../features/GarroteSnapshot';
 


### PR DESCRIPTION
~~DO NOT MERGE -- Still resolving the warnings about the prop being required across all specs. (DH and DK done)~~  **All should be fixed**

For you, the reviewer:
I know this: 
![image](https://user-images.githubusercontent.com/43309639/48874287-5a978180-eda7-11e8-808a-918786c6ab1a.png)
is scary. But fear not, it turns out that of the 86 changed files, only 1 contains any real changes. 
https://github.com/WoWAnalyzer/WoWAnalyzer/pull/2735/files#diff-16fcfff135d17bd0d48cc3ebef9045c6

The other 85 are just fixing the lint errors that would have occured had I made the changes and then let it sit. 

TL;DR TalentStatisticBox: Removed duplicate code and instead made it a simple interpreter for StatisticBox that sets the category to TALENT and the icon and label of the box to the given talent's information.

TL;DR other 85 files: All instances of TalentStatisticBox use the default talent prop instead of the icon and label props. I left label as-is if it was not just a copy of the talent name. 

### Description
TalentStatisticBox was basically a duplicate of StatisticBox with less flexibility and the ability to set a 'talent' prop to automatically set the icon and label of the box. I've kept the talent prop and made it a requirement, which sets the icon and label of the box. You can still choose to override those props (probably only label usually).

It didn't allow child nodes, which meant people using tables, etc., in their talent boxes were forced to use StatisticBox instead. By simplifying the logic, talentbox IS a statistic box, just with auto resolution for icons and labels.

Also, the talentstatistic box had the "item" class which made its text smaller. It was inconsistent and this makes all talent boxes have the default font size.

BEFORE:
![image](https://user-images.githubusercontent.com/43309639/48870532-1354c500-ed96-11e8-959e-0d6767d4db18.png)

AFTER: _note that the table now actually appears and the font is larger_
![image](https://user-images.githubusercontent.com/43309639/48870525-0fc13e00-ed96-11e8-92f4-43d338779df3.png)

