### PR TITLE
[Destruction] Rain of Fire bugfix

### DIFF
--- a/src/parser/warlock/destruction/modules/features/RainOfFire.js
+++ b/src/parser/warlock/destruction/modules/features/RainOfFire.js
@@ -11,6 +11,7 @@ import SpellIcon from 'common/SpellIcon';
 
 const BUFFER = 100;
 const BASE_ROF_DURATION = 8000;
+const debug = false;
 
 // Tries to estimate "effectiveness" of Rain of Fires - counting average targets hit by each RoF (unique targets hit)
 class RainOfFire extends Analyzer {
@@ -50,7 +51,10 @@ class RainOfFire extends Analyzer {
     // filter ROF that should be still active
     const filtered = this.casts.filter(cast => event.timestamp <= cast.expectedEnd + BUFFER);
     const target = encodeTargetString(event.targetID, event.targetInstance);
-    if (filtered.length === 1) {
+    if (filtered.length === 0) {
+      debug && this.log('Something weird happened, ROF damage without any ongoing casts', event);
+    }
+    else if (filtered.length === 1) {
       // single active ROF, attribute the targets hit to it
       const cast = filtered[0];
       const timeSinceLastTick = event.timestamp - (cast.lastTickTimestamp || cast.timestamp);
@@ -64,7 +68,6 @@ class RainOfFire extends Analyzer {
         cast.targetsHit.push(target);
       }
     }
-    // TODO: filtered.length === 0? precast ROF?
     else {
       // multiple ROFs active
       // if any cast's last tick is within 100ms of current timestamp, it's probably still the same tick


### PR DESCRIPTION
I have no clue how this could happen. Fixes (ignores) damage events when there should be no Rain of Fires active. 

Log that caused this: `/report/48F3art1K9qCfXc6/1-Heroic+Taloc+-+Kill+(5:36)/9-Sharwem` - 2 damage events without any cast event before it (also how could there be just 2 of them and not more??)

![image](https://user-images.githubusercontent.com/5068584/48899874-195bac00-ee51-11e8-85f9-8fac58a0093b.png)
