### PR TITLE
[Frost Mage] Thermal Void rewrite

### DIFF
--- a/src/parser/mage/frost/CHANGELOG.js
+++ b/src/parser/mage/frost/CHANGELOG.js
@@ -11,7 +11,7 @@ export default [
     contributors: [Dambroda],
   },
   {
-    date: new Date('2018-11-27'),
+    date: new Date('2018-11-24'),
     changes: <>Added a statistics module for <SpellLink id={SPELLS.LONELY_WINTER_TALENT.id} />.</>,
     contributors: [Dambroda],
   },

--- a/src/parser/mage/frost/CHANGELOG.js
+++ b/src/parser/mage/frost/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-11-22'),
+    changes: <>Removed <SpellLink id={SPELLS.THERMAL_VOID_TALENT.id} /> from checklist and updated the module to better show what the talent provides.</>,
+    contributors: [Dambroda],
+  },
+  {
     date: new Date('2018-11-18'),
     changes: <>Removed <SpellLink id={SPELLS.BONE_CHILLING_TALENT.id} /> uptime from checklist and updated the module to calculate damage instead of uptime.</>,
     contributors: [Dambroda],

--- a/src/parser/mage/frost/modules/checklist/Component.js
+++ b/src/parser/mage/frost/modules/checklist/Component.js
@@ -65,7 +65,6 @@ class FrostMageChecklist extends React.PureComponent {
           description="Regardless of which talents you select, you should ensure that you are utilizing them properly. If you are having trouble effectively using a particular talent, you should consider taking a different talent that you can utilize properly or focus on effectively using the talents that you have selected."
         >
           {combatant.hasTalent(SPELLS.GLACIAL_SPIKE_TALENT.id) && <Requirement name="Glacial Spike utilization" thresholds={thresholds.glacialSpikeUtilization} />}
-          {combatant.hasTalent(SPELLS.THERMAL_VOID_TALENT.id) && <Requirement name="Thermal Void avg duration" thresholds={thresholds.thermalVoidDuration} tooltip="Thermal Void adds time to your Icy Veins every time you cast an Ice Lance that benefits from Shatter (this includes Fingers of Frost proc usage and Ice Lance's that land in Winter's Chill). Maximizing this uptime will increase your damage." />}
           {combatant.hasTalent(SPELLS.RUNE_OF_POWER_TALENT.id) && <Requirement name="Rune of Power uptime" thresholds={thresholds.runeOfPowerBuffUptime} tooltip="Using Rune of Power effectively means being able to stay within the range of it for it's entire duration. If you are unable to do so or if you frequently have to move out of the range of the buff, consider taking a different talent instead." />}
           {!combatant.hasTalent(SPELLS.LONELY_WINTER_TALENT.id) && <Requirement name="Water Elemental utilization" thresholds={thresholds.waterElementalUptime} />}
         </Rule>

--- a/src/parser/mage/frost/modules/checklist/Module.js
+++ b/src/parser/mage/frost/modules/checklist/Module.js
@@ -53,7 +53,6 @@ class Checklist extends BaseChecklist {
           glacialSpikeUtilization: this.glacialSpike.utilSuggestionThresholds,
           fingersOfFrostUtilization: this.iceLance.fingersUtilSuggestionThresholds,
           iceLanceNotShattered: this.iceLance.nonShatteredSuggestionThresholds,
-          thermalVoidDuration: this.thermalVoid.suggestionThresholds,
           wintersChillIceLance: this.wintersChill.iceLanceUtilSuggestionThresholds,
           wintersChillHardCasts: this.wintersChill.hardcastUtilSuggestionThresholds,
           wintersReachUtilization: this.wintersReach.procUtilizationThresholds,

--- a/src/parser/mage/frost/modules/features/ThermalVoid.js
+++ b/src/parser/mage/frost/modules/features/ThermalVoid.js
@@ -2,39 +2,48 @@ import React from 'react';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import SpellIcon from 'common/SpellIcon';
-import { formatNumber } from 'common/format';
+import { formatDuration, formatNumber } from 'common/format';
 import TalentStatisticBox, { STATISTIC_ORDER } from 'interface/others/TalentStatisticBox';
 import Analyzer from 'parser/core/Analyzer';
 import { SELECTED_PLAYER } from 'parser/core/EventFilter';
 import Events from 'parser/core/Events';
 import CombatLogParser from 'parser/core/CombatLogParser';
+import StatisticBox from 'interface/others/StatisticBox';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 
+const BASE_DUR = 20; // The standard duration of IV
+
+/*
+ * Icy Veins' duration is increased by 10 sec.
+ * Your Ice Lances against frozen targets extend your Icy Veins by an additional 1 sec.
+ */
 class ThermalVoid extends Analyzer {
-  casts = 0;
+  activeCast = null;
+  casts = [];
   buffApplied = 0;
   extraUptime = 0;
 
   constructor(...args) {
     super(...args);
     this.active = this.selectedCombatant.hasTalent(SPELLS.THERMAL_VOID_TALENT.id);
-    if (!this.active) {
-      return;
-    }
-    this.addEventListener(Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.ICY_VEINS), this.onApplyIcyVeins);
-    this.addEventListener(CombatLogParser.finish, this.onFinish);
-
   }
 
   onApplyIcyVeins(event) {
-    this.casts += 1;
+    // In the event that you get IV to refresh due to extended uptime. This maybe will only have ever happened in legion
+    if (this.activeCast !== null) {
+      this.activeCast.finish = event.timestamp;
+    }
+    this.activeCast = { start: event.timestamp, finish: null };
+    this.casts.push(this.activeCast);
+  }
+
+  onRemoveIcyVeins(event) {
+    this.casts.push({ start: event, finish: null });
     this.buffApplied = event.timestamp;
   }
 
   onFinish() {
-    if (this.selectedCombatant.hasBuff(SPELLS.ICY_VEINS.id)) {
-      this.casts -= 1;
-      this.extraUptime = this.owner.currentTimestamp - this.buffApplied;
-    }
+
   }
 
   get uptime() {
@@ -50,14 +59,49 @@ class ThermalVoid extends Analyzer {
   }
 
   statistic() {
+    const hist = this.selectedCombatant.getBuffHistory(SPELLS.ICY_VEINS.id);
+    let totalIncrease = 0;
+    const castRows = hist.map((buff, idx) => {
+      const end = buff.end || this.owner.currentTimestamp;
+      const castTime = (buff.start - this.owner.fight.start_time) / 1000;
+      const duration = (end - buff.start) / 1000;
+      const increase = duration - BASE_DUR;
+      totalIncrease += increase;
+      return (
+        <tr key={idx}>
+          <td>{formatDuration(castTime)}</td>
+          <td>{formatDuration(duration)}</td>
+          <td>{formatDuration(increase)}</td>
+        </tr>
+      );
+    });
+
     return (
-      <TalentStatisticBox
-        talent={SPELLS.THERMAL_VOID_TALENT.id}
-        position={STATISTIC_ORDER.CORE(100)}
-        value={`${formatNumber(this.averageDurationSeconds)}s`}
-        label="Avg Icy Veins Duration"
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.THERMAL_VOID_TALENT.id} />}
+        label={`<SpellLink id={SPELLS.THERMAL_VOID_TALENT.id} icon={false} /> average extension`}
+        value={`${formatDuration(totalIncrease / hist.length)}`}
         tooltip="Icy Veins Casts that do not complete before the fight ends are removed from this statistic"
-      />
+        category={STATISTIC_CATEGORY.TALENTS}
+      >
+        <table className="table table-condensed">
+          <thead>
+            <tr>
+              <th>Cast</th>
+              <th>Duration</th>
+              <th>Extension</th>
+            </tr>
+          </thead>
+          <tbody>
+            {castRows}
+            <tr key="total">
+              <th>Total</th>
+              <th>--</th>
+              <th>{formatDuration(totalIncrease)}</th>
+            </tr>
+          </tbody>
+        </table>
+      </StatisticBox>
     );
   }
 }


### PR DESCRIPTION
Thermal Void is currently in the checklist using flat extension values to determine if the player used it properly. As it is entirely RNG and fight-dependent how long you can extend TV, I think it's better to not have a checklist/suggestion item and instead only include a statistic. Suggestions would probably be tied into FoF/brain freeze efficiency upgrades instead.

### Before:
![image](https://user-images.githubusercontent.com/43309639/48920967-106ada80-ee51-11e8-9161-3f0a3ac6097f.png)
![image](https://user-images.githubusercontent.com/43309639/48920974-195bac00-ee51-11e8-80c3-0a141efbd783.png)
![image](https://user-images.githubusercontent.com/43309639/48921003-50ca5880-ee51-11e8-9286-0348e080e4b2.png)
(worth noting that in the sample provided, frozen orb was cast twice during Icy Veins; just goes to show that we really cannot use extension time as suggestion threshholds here)

### After:
**_No suggestion/checklist items_**

![image](https://user-images.githubusercontent.com/43309639/48920994-36907a80-ee51-11e8-815c-de670ea83466.png)


