### PR TITLE
[Affliction] Dreadful Calling trait

### DIFF
--- a/src/common/SPELLS/bfa/azeritetraits/warlock.js
+++ b/src/common/SPELLS/bfa/azeritetraits/warlock.js
@@ -15,4 +15,9 @@ export default {
     name: 'Wracking Brilliance',
     icon: 'spell_shadow_felmending',
   },
+  DREADFUL_CALLING:{
+    id: 278727,
+    name: 'Dreadful Calling',
+    icon: 'inv_beholderwarlock',
+  },
 };

--- a/src/parser/core/calculateBonusAzeriteDamage.js
+++ b/src/parser/core/calculateBonusAzeriteDamage.js
@@ -6,11 +6,12 @@
  * @returns {number} Bonus damage contributed by the trait
  */
 export default function calculateBonusAzeriteDamage(event, traitBonus, ...coefficients) {
-  // In order to be general and not weird to pass attack power into "intellect" field, it's in the coefficients array (which all get multiplied together to form the base damage)
-  const baseDamage = coefficients.reduce((total, current) => total * current, 1);
-  // gets what percentage trait bonus is in the modified base damage
-  const traitPortion = traitBonus / (baseDamage + traitBonus);
   const actualDamage = event.amount + (event.absorbed || 0);
-  // scales down the actual damage according to the percentage
-  return actualDamage * traitPortion;
+  // In order to generalize, instead of hardcoded fields for intellect, attack power, spell coefficients
+  // there's just one array that gets multiplied together to form the base damage
+  const baseDamage = coefficients.reduce((total, current) => total * current, 1);
+  // Get modifier from `actualDamage = (baseDamage + traitBonus) * modifier`
+  const modifier = actualDamage / (baseDamage + traitBonus);
+  // Scale the trait bonus by the same modifier
+  return traitBonus * modifier;
 }

--- a/src/parser/core/calculateBonusAzeriteDamage.js
+++ b/src/parser/core/calculateBonusAzeriteDamage.js
@@ -1,0 +1,16 @@
+/**
+ * Calculates the trait contribution to the real damage from event.
+ * @param {object} event Damage event itself
+ * @param {number} traitBonus Bonus to base damage from traits
+ * @param {...number} coefficients Coefficients that form the base damage (most likely SP coefficient, current intellect, current attack power etc.)
+ * @returns {number} Bonus damage contributed by the trait
+ */
+export default function calculateBonusAzeriteDamage(event, traitBonus, ...coefficients) {
+  // In order to be general and not weird to pass attack power into "intellect" field, it's in the coefficients array (which all get multiplied together to form the base damage)
+  const baseDamage = coefficients.reduce((total, current) => total * current, 1);
+  // gets what percentage trait bonus is in the modified base damage
+  const traitPortion = traitBonus / (baseDamage + traitBonus);
+  const actualDamage = event.amount + (event.absorbed || 0);
+  // scales down the actual damage according to the percentage
+  return actualDamage * traitPortion;
+}

--- a/src/parser/druid/feral/modules/azeritetraits/WildFleshrending.js
+++ b/src/parser/druid/feral/modules/azeritetraits/WildFleshrending.js
@@ -11,6 +11,7 @@ import Enemies from 'parser/shared/modules/Enemies';
 import StatTracker from 'parser/shared/modules/StatTracker';
 import TraitStatisticBox, { STATISTIC_ORDER } from 'interface/others/TraitStatisticBox';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
+import calculateBonusAzeriteDamage from 'parser/core/calculateBonusAzeriteDamage';
 
 import { FERAL_DRUID_DAMAGE_AURA, INCARNATION_SHRED_DAMAGE, SAVAGE_ROAR_DAMAGE_BONUS, TIGERS_FURY_DAMAGE_BONUS, BLOODTALONS_DAMAGE_BONUS, MOMENT_OF_CLARITY_DAMAGE_BONUS, SHRED_SWIPE_BONUS_ON_BLEEDING } from '../../constants.js';
 import Abilities from '../Abilities.js';
@@ -121,11 +122,9 @@ class WildFleshrending extends Analyzer {
      * Assumptions: There are no effects in play that adjust damage by a set number rather than by multiplying, apart from those that appear in the log as absorbed damage. Everything that modifies the ability's base damage also modifies the trait's bonus damage in the same way. I've yet to find anything that violates these assumptions.
      */
     
-    const coefficient = this.abilities.getAbility(event.ability.guid).primaryCoefficient;
     const traitBonus = isShred ? this.shredBonus : this.swipeBonus;
-    const damageDone = event.amount + event.absorbed;
-    const modifier = damageDone / (this.attackPower * coefficient + traitBonus);
-    const traitDamageContribution = traitBonus * modifier;
+    const coefficient = this.abilities.getAbility(event.ability.guid).primaryCoefficient;
+    const traitDamageContribution = calculateBonusAzeriteDamage(event, traitBonus, this.attackPower, coefficient);
     if (isShred) {
       this.shredDamage += traitDamageContribution;
       debug && console.log(`${this.owner.formatTimestamp(event.timestamp, 3)} Shred increased by ${traitDamageContribution.toFixed(0)}.`);

--- a/src/parser/hunter/beastmastery/modules/spells/azeritetraits/FeedingFrenzy.js
+++ b/src/parser/hunter/beastmastery/modules/spells/azeritetraits/FeedingFrenzy.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import StatTracker from 'parser/shared/modules/StatTracker';
+import calculateBonusAzeriteDamage from 'parser/core/calculateBonusAzeriteDamage';
 import { formatNumber, formatPercentage } from 'common/format';
 import TraitStatisticBox, { STATISTIC_ORDER } from 'interface/others/TraitStatisticBox';
 import SPELLS from 'common/SPELLS';
@@ -102,10 +103,7 @@ class FeedingFrenzy extends Analyzer {
       return;
     }
 
-    const damageDone = event.amount + event.absorbed;
-    const modifier = damageDone / (this.lastAttackPower * FEEDING_FRENZY_DAMAGE_COEFFICIENT + this.traitBonus);
-    const traitDamageContribution = this.traitBonus * modifier;
-
+    const traitDamageContribution = calculateBonusAzeriteDamage(event, this.traitBonus, this.lastAttackPower, FEEDING_FRENZY_DAMAGE_COEFFICIENT);
     this.traitDamageContribution += traitDamageContribution;
 
     if (debug) {
@@ -118,6 +116,7 @@ class FeedingFrenzy extends Analyzer {
         estimatedDamage *= critMultiplier;
       }
       estimatedDamage *= externalModifier;
+      const damageDone = event.amount + event.absorbed;
       console.log(`Damage: ${damageDone}, externalModifier: ${externalModifier.toFixed(3)}, estimatedDamage: ${estimatedDamage.toFixed(0)}, traitDamageContribution: ${traitDamageContribution.toFixed(0)}`);
 
       const variation = estimatedDamage / traitDamageContribution;

--- a/src/parser/warlock/affliction/CombatLogParser.js
+++ b/src/parser/warlock/affliction/CombatLogParser.js
@@ -35,6 +35,7 @@ import SoulConduit from './modules/talents/SoulConduit';
 import Checklist from './modules/features/Checklist/Module';
 
 import WrackingBrilliance from './modules/azerite/WrackingBrilliance';
+import DreadfulCalling from './modules/azerite/DreadfulCalling';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -77,6 +78,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Azerite Traits
     wrackingBrilliance: WrackingBrilliance,
+    dreadfulCalling: DreadfulCalling,
     // There's no throughput benefit from casting Arcane Torrent on cooldown
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }],
   };

--- a/src/parser/warlock/affliction/modules/azerite/DreadfulCalling.js
+++ b/src/parser/warlock/affliction/modules/azerite/DreadfulCalling.js
@@ -4,6 +4,7 @@ import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import StatTracker from 'parser/shared/modules/StatTracker';
+import calculateBonusAzeriteDamage from 'parser/core/calculateBonusAzeriteDamage';
 
 import SPELLS from 'common/SPELLS';
 import { calculateAzeriteEffects } from 'common/stats';
@@ -12,7 +13,6 @@ import { formatThousands } from 'common/format';
 import TraitStatisticBox from 'interface/others/TraitStatisticBox';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 
-import { calculateBonusAzeriteDamage } from 'parser/warlock/shared/helpers';
 import { UNSTABLE_AFFLICTION_DEBUFFS } from '../../constants';
 
 const CDR_PER_CAST = 1000;
@@ -67,9 +67,9 @@ class DreadfulCalling extends Analyzer {
       <TraitStatisticBox
         trait={SPELLS.DREADFUL_CALLING.id}
         value={<ItemDamageDone amount={this.damage} approximate />}
-        tooltip={`Estimated bonus Unstable Affliction damage: ${formatThousands(this.damage)}<br />
-                The damage is an approximation using current Intellect values at given time.<br /><br />
-                You also reduced your Summon Darkglare cooldown by ${this.effectiveCDRseconds} seconds`}
+        tooltip={`Estimated bonus Unstable Affliction damage: ${formatThousands(this.damage)}<br />You also reduced your Summon Darkglare cooldown by ${this.effectiveCDRseconds} seconds<br /><br />
+                The damage is an approximation using current Intellect values at given time. Note that this estimate does NOT take into account lowered cooldown of Darkglare.
+                Also, because we might miss some Intellect buffs (e.g. trinkets, traits), the value of current Intellect might be also little incorrect.`}
       />
     );
   }

--- a/src/parser/warlock/affliction/modules/azerite/DreadfulCalling.js
+++ b/src/parser/warlock/affliction/modules/azerite/DreadfulCalling.js
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import StatTracker from 'parser/shared/modules/StatTracker';
+
+import SPELLS from 'common/SPELLS';
+import { calculateAzeriteEffects } from 'common/stats';
+import { formatThousands } from 'common/format';
+
+import TraitStatisticBox from 'interface/others/TraitStatisticBox';
+import ItemDamageDone from 'interface/others/ItemDamageDone';
+
+import { calculateBonusAzeriteDamage } from 'parser/warlock/shared/helpers';
+import { UNSTABLE_AFFLICTION_DEBUFFS } from '../../constants';
+
+const CDR_PER_CAST = 1000;
+const UNSTABLE_AFFLICTION_SP_COEFFICIENT = 0.16;
+
+/*
+    Dreadful Calling
+      Unstable Affliction deals X additional damage, and casting Unstable Affliction reduce the cooldown of Summon Darkglare by 1 sec.
+ */
+class DreadfulCalling extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+    statTracker: StatTracker,
+  };
+
+  damageFromTraits = 0;
+  effectiveReduction = 0;
+  damage = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrait(SPELLS.DREADFUL_CALLING.id);
+    if (!this.active) {
+      return;
+    }
+    // the tooltip here is misleading - in the tooltip it's 4 * bonus damage for all ticks combined, calculateAzeriteEffects() correctly returns bonus per tick
+    this.damageFromTraits = this.selectedCombatant.traitsBySpellId[SPELLS.DREADFUL_CALLING.id].reduce((total, rank) => {
+      const [ damage ] = calculateAzeriteEffects(SPELLS.DREADFUL_CALLING.id, rank);
+      return total + damage;
+    }, 0);
+
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.UNSTABLE_AFFLICTION_CAST), this.onUAcast);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(UNSTABLE_AFFLICTION_DEBUFFS), this.onUAdamage);
+  }
+
+  onUAdamage(event) {
+    this.damage += calculateBonusAzeriteDamage(event, this.damageFromTraits, UNSTABLE_AFFLICTION_SP_COEFFICIENT, this.statTracker.currentIntellectRating);
+  }
+
+  onUAcast() {
+    if (this.spellUsable.isOnCooldown(SPELLS.SUMMON_DARKGLARE.id)) {
+      this.effectiveReduction += this.spellUsable.reduceCooldown(SPELLS.SUMMON_DARKGLARE.id, CDR_PER_CAST);
+    }
+  }
+
+  get effectiveCDRseconds() {
+    return (this.effectiveReduction / 1000).toFixed(1);
+  }
+
+  statistic() {
+    return (
+      <TraitStatisticBox
+        trait={SPELLS.DREADFUL_CALLING.id}
+        value={<ItemDamageDone amount={this.damage} approximate />}
+        tooltip={`Estimated bonus Unstable Affliction damage: ${formatThousands(this.damage)}<br />
+                The damage is an approximation using current Intellect values at given time.<br /><br />
+                You also reduced your Summon Darkglare cooldown by ${this.effectiveCDRseconds} seconds`}
+      />
+    );
+  }
+}
+
+export default DreadfulCalling;

--- a/src/parser/warlock/shared/helpers.js
+++ b/src/parser/warlock/shared/helpers.js
@@ -2,9 +2,3 @@ import SPELLS from 'common/SPELLS';
 
 export const mapSpellsToIds = spells => spells.map(spell => spell.id);
 export const mapIdsToSpells = ids => ids.map(id => SPELLS[id]);
-export const calculateBonusAzeriteDamage = (event, traitBonus, spellPowerCoefficient, intellect) => {
-  const baseDamage = spellPowerCoefficient * intellect;
-  const traitPortion = traitBonus / (baseDamage + traitBonus);
-  const actualDamage = event.amount + (event.absorbed || 0);
-  return actualDamage * traitPortion;
-};

--- a/src/parser/warlock/shared/helpers.js
+++ b/src/parser/warlock/shared/helpers.js
@@ -2,3 +2,9 @@ import SPELLS from 'common/SPELLS';
 
 export const mapSpellsToIds = spells => spells.map(spell => spell.id);
 export const mapIdsToSpells = ids => ids.map(id => SPELLS[id]);
+export const calculateBonusAzeriteDamage = (event, traitBonus, spellPowerCoefficient, intellect) => {
+  const baseDamage = spellPowerCoefficient * intellect;
+  const traitPortion = traitBonus / (baseDamage + traitBonus);
+  const actualDamage = event.amount + (event.absorbed || 0);
+  return actualDamage * traitPortion;
+};


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5068584/48925769-c4a74800-eec7-11e8-8876-fdbcd632512b.png)

Part of #2724. Added a helper function that should *estimate* the bonus part of Azerite traits that affect damage of spells (related issue: #2088). 

Assuming following:
- Azerite traits of this type affect *base* damage of spells
- For casters, this damage is determined by Intellect (and thus Spell Power) and the spell's SP coefficient
- so if `damage = (base + trait bonus) * coefficients`, that means both base and the trait bonus is scaled by same coefficients (like mastery, versatility etc.)
- and even if both damage parts gets scaled by the coefficients, their ratio stays the same regardless of it

We should be able to at least estimate the damage bonus with the following:
```
trait bonus = value that affects the damage
base damage = SP coefficient * current intellect
portion = trait bonus / (base damage + trait bonus)
bonus damage = real damage * portion
```
Example for Unstable Affliction and Dreadful Calling trait (assuming 100 bonus damage from trait, 6000 intellect, 0.16 SP coefficient and 4000 damage from event):
```
traitBonus = 100
intellect = 6000
SPcoeff = 0.16
actualDamage = 4000

baseDamage = 0.16 * 6000 = 960
portion = 100 / (960 + 100) = 0.094339
bonusDamage = 0.094339 * 4000 = 377.356
```

My source from which I got the idea for this, thinks this should be applicable to all Azerite traits (at least the Warlock ones), so I'd like to merge this before updating #2738 in order to not duplicate code in it as well. If others think this should apply to other specs/classes, it might be good idea to move it somewhere else into `common` probably.