### PR TITLE
[Restoration Shaman] Update azerite to use event listeners

### DIFF
--- a/src/interface/others/RestorationShamanSpreadsheet.js
+++ b/src/interface/others/RestorationShamanSpreadsheet.js
@@ -58,8 +58,8 @@ class RestorationShamanSpreadsheet extends React.Component {
               <tr><td>{parser.selectedCombatant.hasTalent(SPELLS.CLOUDBURST_TOTEM_TALENT.id) ? cpm(SPELLS.CLOUDBURST_TOTEM_TALENT.id) : cpm(SPELLS.HEALING_STREAM_TOTEM_CAST.id)}</td></tr>
               <tr><td>{cpm(SPELLS.CHAIN_HEAL.id)}</td></tr>
               <tr><td>{parser.getModule(SurgingTides).surgingTideProcsPerMinute}</td></tr>
-              <tr><td>{(parser.getModule(SpoutingSpirits).spoutingSpiritsHits / casts(SPELLS.SPIRIT_LINK_TOTEM.id) || getAbility(SPELLS.SPOUTING_SPIRITS_HEAL.id).healingHits / casts(SPELLS.SPIRIT_LINK_TOTEM.id) || 0).toFixed(2)}</td></tr>
-              <tr><td>{(parser.getModule(OverflowingShores).overflowingShoresHits / casts(SPELLS.HEALING_RAIN_CAST.id) || 0).toFixed(2)}</td></tr>
+              <tr><td>{((parser.getModule(SpoutingSpirits).spoutingSpiritsHits || getAbility(SPELLS.SPOUTING_SPIRITS_HEAL.id).healingHits) / casts(SPELLS.SPIRIT_LINK_TOTEM.id) || 0).toFixed(2)}</td></tr>
+              <tr><td>{((parser.getModule(OverflowingShores).overflowingShoresHits || getAbility(SPELLS.OVERFLOWING_SHORES_HEAL.id).healingHits) / casts(SPELLS.HEALING_RAIN_CAST.id) || 0).toFixed(2)}</td></tr>
               <tr><td>{parser.getModule(EbbAndFlow).ebbAndFlowEffectiveness.toFixed(2)}</td></tr>
               <tr><td>{parser.getModule(Combatants).playerCount}</td></tr>
               <tr><td>{cpm(SPELLS.ASTRAL_SHIFT.id)}</td></tr>

--- a/src/parser/shaman/restoration/modules/azerite/OverflowingShores.js
+++ b/src/parser/shaman/restoration/modules/azerite/OverflowingShores.js
@@ -20,7 +20,6 @@ class OverflowingShores extends BaseHealerAzerite {
 
     this.addEventListener(Events.begincast.by(SELECTED_PLAYER).spell(SPELLS.HEALING_RAIN_CAST), this._onRainBegincast);
     this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.HEALING_RAIN_HEAL), this._onRainHeal);
-    this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(this.constructor.HEAL), this._onOverflowingShoresHeal);
   }
 
   _onRainBegincast(event) {
@@ -38,10 +37,6 @@ class OverflowingShores extends BaseHealerAzerite {
       }
       this.potentialHits += 1;
     }
-  }
-
-  _onOverflowingShoresHeal() {
-    this.potentialHits += 1;
   }
 
   get overflowingShoresHits() {

--- a/src/parser/shaman/restoration/modules/azerite/SpoutingSpirits.js
+++ b/src/parser/shaman/restoration/modules/azerite/SpoutingSpirits.js
@@ -1,4 +1,4 @@
-import { SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
+import { SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';
 
 import SPELLS from 'common/SPELLS';
@@ -18,7 +18,7 @@ class SpoutingSpirits extends BaseHealerAzerite {
     super(...args);
     this.disableStatistic = !this.hasTrait;
 
-    this.addEventListener(Events.cast.by(SELECTED_PLAYER_PET).spell(SPELLS.SPIRIT_LINK_TOTEM), this._onSpiritLinkCast);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.SPIRIT_LINK_TOTEM), this._onSpiritLinkCast);
     this.addEventListener(Events.heal.by(SELECTED_PLAYER_PET).spell(SPELLS.SPIRIT_LINK_TOTEM_REDISTRIBUTE), this._onSpiritLinkRedistribution);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER_PET).spell(SPELLS.SPIRIT_LINK_TOTEM_REDISTRIBUTE), this._onSpiritLinkRedistribution);
   }

--- a/src/parser/shaman/restoration/modules/azerite/SwellingStream.js
+++ b/src/parser/shaman/restoration/modules/azerite/SwellingStream.js
@@ -1,3 +1,6 @@
+import { SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+
 import SPELLS from 'common/SPELLS';
 import BaseHealerAzerite from './BaseHealerAzerite';
 
@@ -8,8 +11,8 @@ import BaseHealerAzerite from './BaseHealerAzerite';
  */
 
 class SwellingStream extends BaseHealerAzerite {
-  static TRAIT = SPELLS.SWELLING_STREAM.id;
-  static HEAL = SPELLS.SWELLING_STREAM_HEAL.id;
+  static TRAIT = SPELLS.SWELLING_STREAM;
+  static HEAL = SPELLS.SWELLING_STREAM_HEAL;
 
   constructor(...args) {
     super(...args);
@@ -17,10 +20,7 @@ class SwellingStream extends BaseHealerAzerite {
     if (!this.active) {
       return;
     }
-  }
-
-  on_byPlayerPet_heal(event) {
-    this.on_byPlayer_heal(event);
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER_PET).spell(this.constructor.HEAL), this._processHealing);
   }
 }
 


### PR DESCRIPTION
So I don't have to do that in 8.1 when i add the new traits.

Also adds the possibility to add mouseover details of the trait
![image](https://user-images.githubusercontent.com/2842471/48933237-db699100-eeff-11e8-88cb-443b92147cea.png)
