### PR TITLE
[Demonology] [Bug] Fixed Grimoire: Felguard cooldown

### DIFF
--- a/src/parser/warlock/demonology/CHANGELOG.js
+++ b/src/parser/warlock/demonology/CHANGELOG.js
@@ -6,6 +6,11 @@ import SPELLS from 'common/SPELLS';
 
 export default [
   {
+    date: new Date('2018-11-23'),
+    changes: <>Fixed <SpellLink id={SPELLS.GRIMOIRE_FELGUARD_TALENT.id} /> cooldown</>,
+    contributors: [Chizu],
+  },
+  {
     date: new Date('2018-11-19'),
     changes: 'Consolidated various talent boxes into one Talents statistic box.',
     contributors: [Chizu],

--- a/src/parser/warlock/demonology/modules/features/Abilities.js
+++ b/src/parser/warlock/demonology/modules/features/Abilities.js
@@ -147,7 +147,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.GRIMOIRE_FELGUARD_TALENT,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
-        cooldown: 90,
+        cooldown: 120,
         enabled: combatant.hasTalent(SPELLS.GRIMOIRE_FELGUARD_TALENT.id),
         gcd: {
           base: 1500,


### PR DESCRIPTION
Not sure how I've missed this, Grimoire: Felguard nowadays has 2 minutes instead of 1,5 minute CD.