### PR TITLE
[Demonology] Demonic Meteor trait

### DIFF
--- a/src/common/SPELLS/bfa/azeritetraits/warlock.js
+++ b/src/common/SPELLS/bfa/azeritetraits/warlock.js
@@ -5,11 +5,7 @@
  */
 
 export default {
-  EXPLOSIVE_POTENTIAL: { // buff
-    id: 275398,
-    name: 'Explosive Potential',
-    icon: 'inv__implosion',
-  },
+  // Affliction Azerite traits and effects
   CASCADING_CALAMITY: {
     id: 275372,
     name: 'Cascading Calamity',
@@ -20,9 +16,16 @@ export default {
     name: 'Wracking Brilliance',
     icon: 'spell_shadow_felmending',
   },
-  DREADFUL_CALLING:{
+  DREADFUL_CALLING: {
     id: 278727,
     name: 'Dreadful Calling',
     icon: 'inv_beholderwarlock',
+  },
+
+  // Demonology Azerite traits and effects
+  DEMONIC_METEOR: {
+    id: 278737,
+    name: 'Demonic Meteor',
+    icon: 'ability_warlock_handofguldan',
   },
 };

--- a/src/parser/shared/modules/StatTracker.js
+++ b/src/parser/shared/modules/StatTracker.js
@@ -290,7 +290,6 @@ class StatTracker extends Analyzer {
     [SPELLS.BLUR_OF_TALONS_BUFF.id]: BLUR_OF_TALON_STATS,
     // endregion
     // region Warlock
-    [SPELLS.EXPLOSIVE_POTENTIAL.id]: { haste: 841 },
     [SPELLS.CASCADING_CALAMITY_BUFF.id]: CASCADING_CALAMITY_STATS,
     [SPELLS.WRACKING_BRILLIANCE_BUFF.id]: WRACKING_BRILLIANCE_STATS,
     // endregion

--- a/src/parser/warlock/demonology/CombatLogParser.js
+++ b/src/parser/warlock/demonology/CombatLogParser.js
@@ -35,6 +35,8 @@ import SacrificedSouls from './modules/talents/SacrificedSouls';
 import DemonicConsumption from './modules/talents/DemonicConsumption';
 import NetherPortal from './modules/talents/NetherPortal';
 
+import DemonicMeteor from './modules/azerite/DemonicMeteor';
+
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     // Features
@@ -72,6 +74,9 @@ class CombatLogParser extends CoreCombatLogParser {
     sacrificedSouls: SacrificedSouls,
     demonicConsumption: DemonicConsumption,
     netherPortal: NetherPortal,
+
+    // Azerite traits
+    demonicMeteor: DemonicMeteor,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }],

--- a/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
+++ b/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import StatTracker from 'parser/shared/modules/StatTracker';
+import calculateBonusAzeriteDamage from 'parser/core/calculateBonusAzeriteDamage';
+
+import SPELLS from 'common/SPELLS';
+import { calculateAzeriteEffects } from 'common/stats';
+import { formatThousands } from 'common/format';
+
+import TraitStatisticBox from 'interface/others/TraitStatisticBox';
+import ItemDamageDone from 'interface/others/ItemDamageDone';
+
+import SoulShardTracker from '../soulshards/SoulShardTracker';
+
+const HOG_SP_COEFFICIENT = 0.16; // taken from Simcraft SpellDataDump
+
+/*
+    Demonic Meteor
+      Hand of Gul'dan deals X additional damage and has a 5% chance per Soul Shard spent of refunding a Soul Shard.
+ */
+class DemonicMeteor extends Analyzer {
+  static dependencies = {
+    soulShardTracker: SoulShardTracker,
+    statTracker: StatTracker,
+  };
+
+  traitBonus = 0;
+  damage = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrait(SPELLS.DEMONIC_METEOR.id);
+    if (!this.active) {
+      return;
+    }
+
+    this.traitBonus = this.selectedCombatant.traitsBySpellId[SPELLS.DEMONIC_METEOR.id].reduce((total, rank) => {
+      const [ damage ] = calculateAzeriteEffects(SPELLS.DEMONIC_METEOR.id, rank);
+      return total + damage;
+    }, 0);
+
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.HAND_OF_GULDAN_DAMAGE), this.onHogDamage);
+  }
+
+  onHogDamage(event) {
+    this.damage += calculateBonusAzeriteDamage(event, this.traitBonus, HOG_SP_COEFFICIENT, this.statTracker.currentIntellectRating);
+  }
+
+  statistic() {
+    const shardsGained = this.soulShardTracker.getGeneratedBySpell(SPELLS.DEMONIC_METEOR_SHARD_GEN.id);
+    return (
+      <TraitStatisticBox
+        trait={SPELLS.DEMONIC_METEOR.id}
+        value={<ItemDamageDone amount={this.damage} approximate />}
+        tooltip={`Estimated bonus Hand of Gul'dan damage: ${formatThousands(this.damage)}<br />
+                Shards gained with this trait: ${shardsGained}<br /><br />
+                The damage is an approximation using current Intellect values at given time, but because we might miss some Intellect buffs (e.g. trinkets, traits), the value of current Intellect might be a little incorrect.`}
+      />
+    );
+  }
+}
+export default DemonicMeteor;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5068584/48960328-f5d95400-ef6b-11e8-9f64-3a7ddda91135.png)
![image](https://user-images.githubusercontent.com/5068584/48960336-ff62bc00-ef6b-11e8-8599-b6601d441ee9.png)

Part of #2724. Although Hand of Gul'dan damage scales with shards used, it's also as a multiplicative bonus, same as versatility for example, so it's not included. 