### PR TITLE
[Demonology] Shadow's Bite and Forbidden Knowledge traits

### DIFF
--- a/src/common/SPELLS/bfa/azeritetraits/__UNUSED.js
+++ b/src/common/SPELLS/bfa/azeritetraits/__UNUSED.js
@@ -789,11 +789,6 @@ export default {
     name: 'Serrated Jaws',
     icon: 'ability_hunter_killcommand',
   },
-  SHADOWS_BITE: {
-    id: 272944,
-    name: 'Shadow\'s Bite',
-    icon: 'spell_shadow_shadowbolt',
-  },
   SHELLSHOCK: {
     id: 274357,
     name: 'Shellshock',

--- a/src/common/SPELLS/bfa/azeritetraits/warlock.js
+++ b/src/common/SPELLS/bfa/azeritetraits/warlock.js
@@ -25,4 +25,25 @@ export default {
     name: 'Dreadful Calling',
     icon: 'inv_beholderwarlock',
   },
+
+  SHADOWS_BITE: {
+    id: 272944,
+    name: 'Shadow\'s Bite',
+    icon: 'spell_shadow_painspike',
+  },
+  SHADOWS_BITE_BUFF: {
+    id: 272945,
+    name: 'Shadow\'s Bite',
+    icon: 'spell_shadow_painspike',
+  },
+  FORBIDDEN_KNOWLEDGE: {
+    id: 278738,
+    name: 'Forbidden Knowledge',
+    icon: 'inv_offhand_hyjal_d_01',
+  },
+  FORBIDDEN_KNOWLEDGE_BUFF: {
+    id: 279666,
+    name: 'Forbidden Knowledge',
+    icon: 'inv_offhand_hyjal_d_01',
+  },
 };

--- a/src/parser/core/calculateBonusAzeriteDamage.js
+++ b/src/parser/core/calculateBonusAzeriteDamage.js
@@ -1,24 +1,17 @@
 /**
  * Calculates the trait contribution to the real damage from event.
  * @param {object} event Damage event itself
- * @param {number|number[]} traitBonus Bonus to base damage from traits - either one single trait (number) or multiple traits that need to be accounted for (number[])
+ * @param {number[]} traitBonuses Array of additive bonuses to base damage from traits
  * @param {...number} coefficients Coefficients that form the base damage (most likely SP coefficient, current intellect, current attack power etc.)
  * @returns {number[]} Bonus damage contributed by the trait/s
  */
-export default function calculateBonusAzeriteDamage(event, traitBonus, ...coefficients) {
-  let bonuses;
-  if (traitBonus instanceof Array) {
-    bonuses = traitBonus;
-  }
-  else {
-    bonuses = [traitBonus];
-  }
+export default function calculateBonusAzeriteDamage(event, traitBonuses, ...coefficients) {
   const actualDamage = event.amount + (event.absorbed || 0);
   // In order to generalize, instead of hardcoded fields for intellect, attack power, spell coefficients
   // there's just one array that gets multiplied together to form the base damage
-  const baseDamage = coefficients.reduce((total, current) => total * current, 1) + bonuses.reduce((total, current) => total + current, 0);
+  const baseDamage = coefficients.reduce((total, current) => total * current, 1) + traitBonuses.reduce((total, current) => total + current, 0);
   // Get modifier from `actualDamage = baseDamage * modifier` (where baseDamage already has the additive bonuses added)
   const modifier = actualDamage / baseDamage;
   // Scale the trait bonus/es by the same modifier
-  return bonuses.map(bonus => bonus * modifier);
+  return traitBonuses.map(bonus => bonus * modifier);
 }

--- a/src/parser/core/calculateBonusAzeriteDamage.js
+++ b/src/parser/core/calculateBonusAzeriteDamage.js
@@ -1,18 +1,24 @@
 /**
  * Calculates the trait contribution to the real damage from event.
  * @param {object} event Damage event itself
- * @param {number} traitBonus Bonus to base damage from traits
- * @param {Array} coefficients Coefficients that form the base damage (most likely SP coefficient, current intellect, current attack power etc.)
- * @param {Array} knownOtherEffects Other constants to ADD to the base damage (e.g. effect from other traits that needs to be accounted for)
- * @returns {number} Bonus damage contributed by the trait
+ * @param {number|number[]} traitBonus Bonus to base damage from traits - either one single trait (number) or multiple traits that need to be accounted for (number[])
+ * @param {...number} coefficients Coefficients that form the base damage (most likely SP coefficient, current intellect, current attack power etc.)
+ * @returns {number[]} Bonus damage contributed by the trait/s
  */
-export default function calculateBonusAzeriteDamage(event, traitBonus, coefficients, knownOtherEffects = []) {
+export default function calculateBonusAzeriteDamage(event, traitBonus, ...coefficients) {
+  let bonuses;
+  if (traitBonus instanceof Array) {
+    bonuses = traitBonus;
+  }
+  else {
+    bonuses = [traitBonus];
+  }
   const actualDamage = event.amount + (event.absorbed || 0);
   // In order to generalize, instead of hardcoded fields for intellect, attack power, spell coefficients
   // there's just one array that gets multiplied together to form the base damage
-  const baseDamage = coefficients.reduce((total, current) => total * current, 1) + knownOtherEffects.reduce((total, current) => total + current, 0);
-  // Get modifier from `actualDamage = (baseDamage + traitBonus) * modifier`
-  const modifier = actualDamage / (baseDamage + traitBonus);
-  // Scale the trait bonus by the same modifier
-  return traitBonus * modifier;
+  const baseDamage = coefficients.reduce((total, current) => total * current, 1) + bonuses.reduce((total, current) => total + current, 0);
+  // Get modifier from `actualDamage = baseDamage * modifier` (where baseDamage already has the additive bonuses added)
+  const modifier = actualDamage / baseDamage;
+  // Scale the trait bonus/es by the same modifier
+  return bonuses.map(bonus => bonus * modifier);
 }

--- a/src/parser/core/calculateBonusAzeriteDamage.js
+++ b/src/parser/core/calculateBonusAzeriteDamage.js
@@ -2,14 +2,15 @@
  * Calculates the trait contribution to the real damage from event.
  * @param {object} event Damage event itself
  * @param {number} traitBonus Bonus to base damage from traits
- * @param {...number} coefficients Coefficients that form the base damage (most likely SP coefficient, current intellect, current attack power etc.)
+ * @param {Array} coefficients Coefficients that form the base damage (most likely SP coefficient, current intellect, current attack power etc.)
+ * @param {Array} knownOtherEffects Other constants to ADD to the base damage (e.g. effect from other traits that needs to be accounted for)
  * @returns {number} Bonus damage contributed by the trait
  */
-export default function calculateBonusAzeriteDamage(event, traitBonus, ...coefficients) {
+export default function calculateBonusAzeriteDamage(event, traitBonus, coefficients, knownOtherEffects = []) {
   const actualDamage = event.amount + (event.absorbed || 0);
   // In order to generalize, instead of hardcoded fields for intellect, attack power, spell coefficients
   // there's just one array that gets multiplied together to form the base damage
-  const baseDamage = coefficients.reduce((total, current) => total * current, 1);
+  const baseDamage = coefficients.reduce((total, current) => total * current, 1) + knownOtherEffects.reduce((total, current) => total + current, 0);
   // Get modifier from `actualDamage = (baseDamage + traitBonus) * modifier`
   const modifier = actualDamage / (baseDamage + traitBonus);
   // Scale the trait bonus by the same modifier

--- a/src/parser/druid/feral/modules/azeritetraits/WildFleshrending.js
+++ b/src/parser/druid/feral/modules/azeritetraits/WildFleshrending.js
@@ -124,7 +124,7 @@ class WildFleshrending extends Analyzer {
     
     const traitBonus = isShred ? this.shredBonus : this.swipeBonus;
     const coefficient = this.abilities.getAbility(event.ability.guid).primaryCoefficient;
-    const traitDamageContribution = calculateBonusAzeriteDamage(event, traitBonus, [this.attackPower, coefficient]);
+    const [ traitDamageContribution ] = calculateBonusAzeriteDamage(event, traitBonus, this.attackPower, coefficient);
     if (isShred) {
       this.shredDamage += traitDamageContribution;
       debug && console.log(`${this.owner.formatTimestamp(event.timestamp, 3)} Shred increased by ${traitDamageContribution.toFixed(0)}.`);

--- a/src/parser/druid/feral/modules/azeritetraits/WildFleshrending.js
+++ b/src/parser/druid/feral/modules/azeritetraits/WildFleshrending.js
@@ -124,7 +124,7 @@ class WildFleshrending extends Analyzer {
     
     const traitBonus = isShred ? this.shredBonus : this.swipeBonus;
     const coefficient = this.abilities.getAbility(event.ability.guid).primaryCoefficient;
-    const [ traitDamageContribution ] = calculateBonusAzeriteDamage(event, traitBonus, this.attackPower, coefficient);
+    const [ traitDamageContribution ] = calculateBonusAzeriteDamage(event, [traitBonus], this.attackPower, coefficient);
     if (isShred) {
       this.shredDamage += traitDamageContribution;
       debug && console.log(`${this.owner.formatTimestamp(event.timestamp, 3)} Shred increased by ${traitDamageContribution.toFixed(0)}.`);

--- a/src/parser/druid/feral/modules/azeritetraits/WildFleshrending.js
+++ b/src/parser/druid/feral/modules/azeritetraits/WildFleshrending.js
@@ -124,7 +124,7 @@ class WildFleshrending extends Analyzer {
     
     const traitBonus = isShred ? this.shredBonus : this.swipeBonus;
     const coefficient = this.abilities.getAbility(event.ability.guid).primaryCoefficient;
-    const traitDamageContribution = calculateBonusAzeriteDamage(event, traitBonus, this.attackPower, coefficient);
+    const traitDamageContribution = calculateBonusAzeriteDamage(event, traitBonus, [this.attackPower, coefficient]);
     if (isShred) {
       this.shredDamage += traitDamageContribution;
       debug && console.log(`${this.owner.formatTimestamp(event.timestamp, 3)} Shred increased by ${traitDamageContribution.toFixed(0)}.`);

--- a/src/parser/hunter/beastmastery/modules/spells/azeritetraits/FeedingFrenzy.js
+++ b/src/parser/hunter/beastmastery/modules/spells/azeritetraits/FeedingFrenzy.js
@@ -103,7 +103,7 @@ class FeedingFrenzy extends Analyzer {
       return;
     }
 
-    const traitDamageContribution = calculateBonusAzeriteDamage(event, this.traitBonus, [this.lastAttackPower, FEEDING_FRENZY_DAMAGE_COEFFICIENT]);
+    const [ traitDamageContribution ] = calculateBonusAzeriteDamage(event, this.traitBonus, this.lastAttackPower, FEEDING_FRENZY_DAMAGE_COEFFICIENT);
     this.traitDamageContribution += traitDamageContribution;
 
     if (debug) {

--- a/src/parser/hunter/beastmastery/modules/spells/azeritetraits/FeedingFrenzy.js
+++ b/src/parser/hunter/beastmastery/modules/spells/azeritetraits/FeedingFrenzy.js
@@ -103,7 +103,7 @@ class FeedingFrenzy extends Analyzer {
       return;
     }
 
-    const traitDamageContribution = calculateBonusAzeriteDamage(event, this.traitBonus, this.lastAttackPower, FEEDING_FRENZY_DAMAGE_COEFFICIENT);
+    const traitDamageContribution = calculateBonusAzeriteDamage(event, this.traitBonus, [this.lastAttackPower, FEEDING_FRENZY_DAMAGE_COEFFICIENT]);
     this.traitDamageContribution += traitDamageContribution;
 
     if (debug) {

--- a/src/parser/hunter/beastmastery/modules/spells/azeritetraits/FeedingFrenzy.js
+++ b/src/parser/hunter/beastmastery/modules/spells/azeritetraits/FeedingFrenzy.js
@@ -103,7 +103,7 @@ class FeedingFrenzy extends Analyzer {
       return;
     }
 
-    const [ traitDamageContribution ] = calculateBonusAzeriteDamage(event, this.traitBonus, this.lastAttackPower, FEEDING_FRENZY_DAMAGE_COEFFICIENT);
+    const [ traitDamageContribution ] = calculateBonusAzeriteDamage(event, [this.traitBonus], this.lastAttackPower, FEEDING_FRENZY_DAMAGE_COEFFICIENT);
     this.traitDamageContribution += traitDamageContribution;
 
     if (debug) {

--- a/src/parser/warlock/affliction/modules/azerite/DreadfulCalling.js
+++ b/src/parser/warlock/affliction/modules/azerite/DreadfulCalling.js
@@ -49,7 +49,7 @@ class DreadfulCalling extends Analyzer {
   }
 
   onUAdamage(event) {
-    this.damage += calculateBonusAzeriteDamage(event, this.damageFromTraits, UNSTABLE_AFFLICTION_SP_COEFFICIENT, this.statTracker.currentIntellectRating);
+    this.damage += calculateBonusAzeriteDamage(event, this.damageFromTraits, [UNSTABLE_AFFLICTION_SP_COEFFICIENT, this.statTracker.currentIntellectRating]);
   }
 
   onUAcast() {

--- a/src/parser/warlock/affliction/modules/azerite/DreadfulCalling.js
+++ b/src/parser/warlock/affliction/modules/azerite/DreadfulCalling.js
@@ -49,7 +49,7 @@ class DreadfulCalling extends Analyzer {
   }
 
   onUAdamage(event) {
-    const [ bonusDamage ] = calculateBonusAzeriteDamage(event, this.damageFromTraits, UNSTABLE_AFFLICTION_SP_COEFFICIENT, this.statTracker.currentIntellectRating);
+    const [ bonusDamage ] = calculateBonusAzeriteDamage(event, [this.damageFromTraits], UNSTABLE_AFFLICTION_SP_COEFFICIENT, this.statTracker.currentIntellectRating);
     this.damage += bonusDamage;
   }
 

--- a/src/parser/warlock/affliction/modules/azerite/DreadfulCalling.js
+++ b/src/parser/warlock/affliction/modules/azerite/DreadfulCalling.js
@@ -49,7 +49,8 @@ class DreadfulCalling extends Analyzer {
   }
 
   onUAdamage(event) {
-    this.damage += calculateBonusAzeriteDamage(event, this.damageFromTraits, [UNSTABLE_AFFLICTION_SP_COEFFICIENT, this.statTracker.currentIntellectRating]);
+    const [ bonusDamage ] = calculateBonusAzeriteDamage(event, this.damageFromTraits, UNSTABLE_AFFLICTION_SP_COEFFICIENT, this.statTracker.currentIntellectRating);
+    this.damage += bonusDamage;
   }
 
   onUAcast() {

--- a/src/parser/warlock/affliction/modules/azerite/InevitableDemise.js
+++ b/src/parser/warlock/affliction/modules/azerite/InevitableDemise.js
@@ -50,7 +50,7 @@ class InevitableDemise extends Analyzer {
     const buff = this.selectedCombatant.getBuff(SPELLS.INEVITABLE_DEMISE_BUFF.id);
     const currentStacks = buff ? buff.stacks : 0;
     const totalDamage = event.amount + (event.absorbed || 0);
-    const bonusDamage = calculateBonusAzeriteDamage(event, currentStacks * this.damagePerStack, DRAIN_LIFE_SP_COEFFICIENT, this.statTracker.currentIntellectRating);
+    const bonusDamage = calculateBonusAzeriteDamage(event, currentStacks * this.damagePerStack, [DRAIN_LIFE_SP_COEFFICIENT, this.statTracker.currentIntellectRating]);
     debug && this.log(`Drain Life damage, current stacks: ${currentStacks}, current bonus base damage: ${currentStacks * this.damagePerStack}, total damage: ${totalDamage}, Drain damage: ${totalDamage - bonusDamage}, bonus damage: ${bonusDamage}`);
     this.damage += bonusDamage;
   }

--- a/src/parser/warlock/affliction/modules/azerite/InevitableDemise.js
+++ b/src/parser/warlock/affliction/modules/azerite/InevitableDemise.js
@@ -50,7 +50,7 @@ class InevitableDemise extends Analyzer {
     const buff = this.selectedCombatant.getBuff(SPELLS.INEVITABLE_DEMISE_BUFF.id);
     const currentStacks = buff ? buff.stacks : 0;
     const totalDamage = event.amount + (event.absorbed || 0);
-    const bonusDamage = calculateBonusAzeriteDamage(event, currentStacks * this.damagePerStack, [DRAIN_LIFE_SP_COEFFICIENT, this.statTracker.currentIntellectRating]);
+    const [ bonusDamage ] = calculateBonusAzeriteDamage(event, currentStacks * this.damagePerStack, DRAIN_LIFE_SP_COEFFICIENT, this.statTracker.currentIntellectRating);
     debug && this.log(`Drain Life damage, current stacks: ${currentStacks}, current bonus base damage: ${currentStacks * this.damagePerStack}, total damage: ${totalDamage}, Drain damage: ${totalDamage - bonusDamage}, bonus damage: ${bonusDamage}`);
     this.damage += bonusDamage;
   }

--- a/src/parser/warlock/affliction/modules/azerite/InevitableDemise.js
+++ b/src/parser/warlock/affliction/modules/azerite/InevitableDemise.js
@@ -50,7 +50,7 @@ class InevitableDemise extends Analyzer {
     const buff = this.selectedCombatant.getBuff(SPELLS.INEVITABLE_DEMISE_BUFF.id);
     const currentStacks = buff ? buff.stacks : 0;
     const totalDamage = event.amount + (event.absorbed || 0);
-    const [ bonusDamage ] = calculateBonusAzeriteDamage(event, currentStacks * this.damagePerStack, DRAIN_LIFE_SP_COEFFICIENT, this.statTracker.currentIntellectRating);
+    const [ bonusDamage ] = calculateBonusAzeriteDamage(event, [currentStacks * this.damagePerStack], DRAIN_LIFE_SP_COEFFICIENT, this.statTracker.currentIntellectRating);
     debug && this.log(`Drain Life damage, current stacks: ${currentStacks}, current bonus base damage: ${currentStacks * this.damagePerStack}, total damage: ${totalDamage}, Drain damage: ${totalDamage - bonusDamage}, bonus damage: ${bonusDamage}`);
     this.damage += bonusDamage;
   }

--- a/src/parser/warlock/affliction/modules/azerite/SuddenOnset.js
+++ b/src/parser/warlock/affliction/modules/azerite/SuddenOnset.js
@@ -41,7 +41,7 @@ class SuddenOnset extends Analyzer {
   }
 
   onAgonyDamage(event) {
-    const [ bonusDamage ] = calculateBonusAzeriteDamage(event, this.traitBonus, AGONY_SP_COEFFICIENT, this.statTracker.currentIntellectRating);
+    const [ bonusDamage ] = calculateBonusAzeriteDamage(event, [this.traitBonus], AGONY_SP_COEFFICIENT, this.statTracker.currentIntellectRating);
     this.damage += bonusDamage;
   }
 

--- a/src/parser/warlock/affliction/modules/azerite/SuddenOnset.js
+++ b/src/parser/warlock/affliction/modules/azerite/SuddenOnset.js
@@ -41,7 +41,8 @@ class SuddenOnset extends Analyzer {
   }
 
   onAgonyDamage(event) {
-    this.damage += calculateBonusAzeriteDamage(event, this.traitBonus, [AGONY_SP_COEFFICIENT, this.statTracker.currentIntellectRating]);
+    const [ bonusDamage ] = calculateBonusAzeriteDamage(event, this.traitBonus, AGONY_SP_COEFFICIENT, this.statTracker.currentIntellectRating);
+    this.damage += bonusDamage;
   }
 
   statistic() {

--- a/src/parser/warlock/affliction/modules/azerite/SuddenOnset.js
+++ b/src/parser/warlock/affliction/modules/azerite/SuddenOnset.js
@@ -41,7 +41,7 @@ class SuddenOnset extends Analyzer {
   }
 
   onAgonyDamage(event) {
-    this.damage += calculateBonusAzeriteDamage(event, this.traitBonus, AGONY_SP_COEFFICIENT, this.statTracker.currentIntellectRating);
+    this.damage += calculateBonusAzeriteDamage(event, this.traitBonus, [AGONY_SP_COEFFICIENT, this.statTracker.currentIntellectRating]);
   }
 
   statistic() {

--- a/src/parser/warlock/demonology/CombatLogParser.js
+++ b/src/parser/warlock/demonology/CombatLogParser.js
@@ -82,7 +82,6 @@ class CombatLogParser extends CoreCombatLogParser {
     shadowsBiteForbiddenKnowledgeCore: ShadowsBiteForbiddenKnowledgeCore,
     shadowsBite: ShadowsBite,
     forbiddenKnowledge: ForbiddenKnowledge,
-    supremeCommander: SupremeCommander,
     umbralBlaze: UmbralBlaze,
     supremeCommander: SupremeCommander,
     

--- a/src/parser/warlock/demonology/CombatLogParser.js
+++ b/src/parser/warlock/demonology/CombatLogParser.js
@@ -35,6 +35,10 @@ import SacrificedSouls from './modules/talents/SacrificedSouls';
 import DemonicConsumption from './modules/talents/DemonicConsumption';
 import NetherPortal from './modules/talents/NetherPortal';
 
+import ShadowsBiteForbiddenKnowledgeCore from './modules/azerite/ShadowsBiteForbiddenKnowledgeCore';
+import ShadowsBite from './modules/azerite/ShadowsBite';
+import ForbiddenKnowledge from './modules/azerite/ForbiddenKnowledge';
+
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     // Features
@@ -72,6 +76,10 @@ class CombatLogParser extends CoreCombatLogParser {
     sacrificedSouls: SacrificedSouls,
     demonicConsumption: DemonicConsumption,
     netherPortal: NetherPortal,
+
+    shadowsBiteForbiddenKnowledgeCore: ShadowsBiteForbiddenKnowledgeCore,
+    shadowsBite: ShadowsBite,
+    forbiddenKnowledge: ForbiddenKnowledge,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }],

--- a/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
+++ b/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
@@ -45,7 +45,7 @@ class DemonicMeteor extends Analyzer {
   }
 
   onHogDamage(event) {
-    this.damage += calculateBonusAzeriteDamage(event, this.traitBonus, HOG_SP_COEFFICIENT, this.statTracker.currentIntellectRating);
+    this.damage += calculateBonusAzeriteDamage(event, this.traitBonus, [HOG_SP_COEFFICIENT, this.statTracker.currentIntellectRating]);
   }
 
   statistic() {

--- a/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
+++ b/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
@@ -45,7 +45,7 @@ class DemonicMeteor extends Analyzer {
   }
 
   onHogDamage(event) {
-    const [ bonusDamage ] = calculateBonusAzeriteDamage(event, this.traitBonus, HOG_SP_COEFFICIENT, this.statTracker.currentIntellectRating);
+    const [ bonusDamage ] = calculateBonusAzeriteDamage(event, [this.traitBonus], HOG_SP_COEFFICIENT, this.statTracker.currentIntellectRating);
     this.damage += bonusDamage;
   }
 

--- a/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
+++ b/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
@@ -45,7 +45,8 @@ class DemonicMeteor extends Analyzer {
   }
 
   onHogDamage(event) {
-    this.damage += calculateBonusAzeriteDamage(event, this.traitBonus, [HOG_SP_COEFFICIENT, this.statTracker.currentIntellectRating]);
+    const [ bonusDamage ] = calculateBonusAzeriteDamage(event, this.traitBonus, HOG_SP_COEFFICIENT, this.statTracker.currentIntellectRating);
+    this.damage += bonusDamage;
   }
 
   statistic() {

--- a/src/parser/warlock/demonology/modules/azerite/ForbiddenKnowledge.js
+++ b/src/parser/warlock/demonology/modules/azerite/ForbiddenKnowledge.js
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+
+import SPELLS from 'common/SPELLS';
+import { formatThousands } from 'common/format';
+
+import TraitStatisticBox from 'interface/others/TraitStatisticBox';
+import ItemDamageDone from 'interface/others/ItemDamageDone';
+
+import ShadowsBiteForbiddenKnowledgeCore from './ShadowsBiteForbiddenKnowledgeCore';
+
+const BUFF_DURATION = 15000;
+
+class ForbiddenKnowledge extends Analyzer {
+  static dependencies = {
+    core: ShadowsBiteForbiddenKnowledgeCore,
+  };
+
+  _lastBuffApply = null;
+  usedProcs = 0;
+  allProcs = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrait(SPELLS.FORBIDDEN_KNOWLEDGE.id);
+
+    this.addEventListener(Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.FORBIDDEN_KNOWLEDGE_BUFF), this.onFKBuffApply);
+    this.addEventListener(Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.FORBIDDEN_KNOWLEDGE_BUFF), this.onFKBuffRemove);
+  }
+
+  onFKBuffApply(event) {
+    this._lastBuffApply = event.timestamp;
+  }
+
+  onFKBuffRemove(event) {
+    if (event.timestamp < this._lastBuffApply + BUFF_DURATION) {
+      this.usedProcs += 1;
+    }
+    this.allProcs += 1;
+  }
+
+  statistic() {
+    return (
+      <TraitStatisticBox
+        trait={SPELLS.FORBIDDEN_KNOWLEDGE.id}
+        value={<ItemDamageDone amount={this.core.forbiddenKnowledgeDamage} approximate />}
+        tooltip={`Estimated bonus Demonbolt damage: ${formatThousands(this.core.forbiddenKnowledgeDamage)}<br />
+                You utilized ${this.usedProcs} out of ${this.allProcs} Forbidden Knowledge procs<br /><br />
+                The damage is an approximation using current Intellect values at given time, but because we might miss some Intellect buffs (e.g. trinkets, traits), the value of current Intellect might be a little incorrect.`}
+      />
+    );
+  }
+}
+
+export default ForbiddenKnowledge;

--- a/src/parser/warlock/demonology/modules/azerite/ShadowsBite.js
+++ b/src/parser/warlock/demonology/modules/azerite/ShadowsBite.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import Analyzer from 'parser/core/Analyzer';
+
+import SPELLS from 'common/SPELLS';
+import { formatThousands } from 'common/format';
+
+import TraitStatisticBox from 'interface/others/TraitStatisticBox';
+import ItemDamageDone from 'interface/others/ItemDamageDone';
+
+import ShadowsBiteForbiddenKnowledgeCore from './ShadowsBiteForbiddenKnowledgeCore';
+
+class ShadowsBite extends Analyzer {
+  static dependencies = {
+    core: ShadowsBiteForbiddenKnowledgeCore,
+  };
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrait(SPELLS.SHADOWS_BITE.id);
+  }
+
+  statistic() {
+    return (
+      <TraitStatisticBox
+        trait={SPELLS.SHADOWS_BITE.id}
+        value={<ItemDamageDone amount={this.core.shadowsBiteDamage} approximate />}
+        tooltip={`Estimated bonus Demonbolt damage: ${formatThousands(this.core.shadowsBiteDamage)}<br /><br />
+                The damage is an approximation using current Intellect values at given time, but because we might miss some Intellect buffs (e.g. trinkets, traits), the value of current Intellect might be a little incorrect.`}
+      />
+    );
+  }
+}
+
+export default ShadowsBite;

--- a/src/parser/warlock/demonology/modules/azerite/ShadowsBiteForbiddenKnowledgeCore.js
+++ b/src/parser/warlock/demonology/modules/azerite/ShadowsBiteForbiddenKnowledgeCore.js
@@ -1,0 +1,132 @@
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import StatTracker from 'parser/shared/modules/StatTracker';
+import calculateBonusAzeriteDamage from 'parser/core/calculateBonusAzeriteDamage';
+import Events from 'parser/core/Events';
+
+import SPELLS from 'common/SPELLS';
+import { calculateAzeriteEffects } from 'common/stats';
+
+const DEMONBOLT_SP_COEFFICIENT = 0.667;
+const MAX_TRAVEL_TIME = 2000;
+const FORBIDDEN_KNOWLEDGE_BUFF_DURATION = 15000;
+const INSTANT_CAST_BUFFER = 100;
+const debug = false;
+
+// Shadow's Bite and Forbidden Knowledge would share the same logic, so I extracted it into common core
+class ShadowsBiteForbiddenKnowledgeCore extends Analyzer {
+  static dependencies = {
+    statTracker: StatTracker,
+  };
+  forbiddenKnowledgeBonus = 0;
+  shadowsBiteBonus = 0;
+
+  forbiddenKnowledgeDamage = 0;
+  shadowsBiteDamage = 0;
+
+  _lastBeginCast = null;
+  _lastFKapply = null;
+  _queue = [
+    /*
+      {
+        timestamp: number
+        targetID: number,
+        targetInstance: number,
+        applyFK: boolean
+        applySB: boolean
+        intellect: number
+      }
+     */
+  ];
+
+  constructor(...args) {
+    super(...args);
+    const hasFK = this.selectedCombatant.hasTrait(SPELLS.FORBIDDEN_KNOWLEDGE.id);
+    const hasSB = this.selectedCombatant.hasTrait(SPELLS.SHADOWS_BITE.id);
+    this.active = hasFK || hasSB;
+    if (!this.active) {
+      return;
+    }
+
+    debug && this.log(`SB: ${hasSB}, FK: ${hasFK}`);
+    if (hasFK) {
+      this.forbiddenKnowledgeBonus = this.selectedCombatant.traitsBySpellId[SPELLS.FORBIDDEN_KNOWLEDGE.id]
+        .reduce((total, rank) => {
+          const [ damage ] = calculateAzeriteEffects(SPELLS.FORBIDDEN_KNOWLEDGE.id, rank);
+          debug && this.log(`FK, rank ${rank}, damage ${damage}`);
+          return total + damage;
+        }, 0);
+    }
+    if (hasSB) {
+      this.shadowsBiteBonus = this.selectedCombatant.traitsBySpellId[SPELLS.SHADOWS_BITE.id]
+        .reduce((total, rank) => {
+          const [ damage ] = calculateAzeriteEffects(SPELLS.SHADOWS_BITE.id, rank);
+          debug && this.log(`SB, rank ${rank}, damage ${damage}`);
+          return total + damage;
+        }, 0);
+    }
+
+    this.addEventListener(Events.begincast.by(SELECTED_PLAYER).spell(SPELLS.DEMONBOLT), this.onDemonboltBeginCast);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.DEMONBOLT), this.onDemonboltCast);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.DEMONBOLT), this.onDemonboltDamage);
+    this.addEventListener(Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.FORBIDDEN_KNOWLEDGE_BUFF), this.onForbiddenKnowledgeBuffApply);
+  }
+
+  onForbiddenKnowledgeBuffApply(event) {
+    this._lastFKapply = event.timestamp;
+  }
+
+  onDemonboltBeginCast(event) {
+    this._lastBeginCast = event.timestamp;
+  }
+
+  onDemonboltCast(event) {
+    // Both traits snapshot the "eligibility" for their respective bonus damage on cast, instead of damage
+    const isInstant = this._lastBeginCast && event.timestamp < this._lastBeginCast + INSTANT_CAST_BUFFER; // if DB was precasted (_lastBeginCast = null), this should evaluate to false
+    const buffedByFK = this._lastFKapply && event.timestamp < this._lastFKapply + FORBIDDEN_KNOWLEDGE_BUFF_DURATION; // if FK buff is consumed, it's removed BEFORE Demonbolt cast, that's why we can't use hasBuff()
+    this._lastBeginCast = null;
+    this._queue.push({
+      timestamp: event.timestamp,
+      targetID: event.targetID,
+      targetInstance: event.targetInstance,
+      applyFK: buffedByFK && !isInstant,
+      applySB: this.selectedCombatant.hasBuff(SPELLS.SHADOWS_BITE_BUFF.id),
+      intellect: this.statTracker.currentIntellectRating,
+    });
+    debug && this.log('Pushed cast into queue, current queue: ', JSON.parse(JSON.stringify(this._queue)));
+  }
+
+  onDemonboltDamage(event) {
+    // first filter out old casts
+    this._queue = this._queue.filter(cast => event.timestamp < (cast.timestamp + MAX_TRAVEL_TIME));
+    // try pairing damage event with casts in queue
+    const castIndex = this._queue
+      .findIndex(queuedCast => queuedCast.targetID === event.targetID
+                            && queuedCast.targetInstance === event.targetInstance);
+    if (castIndex === -1) {
+      debug && this.error('Encountered damage event with no buffed cast associated, queue:', JSON.parse(JSON.stringify(this._queue)), 'event', event);
+      return;
+    }
+
+    // Both trait bonuses can be active at the same time, and even if we only want one part of it, we need to account for the other part
+    // that's why there's another parameter in calculateBonusAzeriteDamage()
+
+    const pairedCast = this._queue[castIndex];
+    debug && this.log('Paired damage event with queued cast', pairedCast);
+
+    if (pairedCast.applyFK) {
+      const sbBonus = (pairedCast.applySB && this.shadowsBiteBonus) || 0;
+      debug && this.log(`Applying FK bonus ${this.forbiddenKnowledgeBonus}, with SB bonus ${sbBonus}`);
+      this.forbiddenKnowledgeDamage += calculateBonusAzeriteDamage(event, this.forbiddenKnowledgeBonus, [DEMONBOLT_SP_COEFFICIENT, pairedCast.intellect], [sbBonus]);
+    }
+
+    if (pairedCast.applySB) {
+      const fkBonus = (pairedCast.applyFK && this.forbiddenKnowledgeBonus) || 0;
+      debug && this.log(`Applying SB bonus ${this.shadowsBiteBonus}, with FK bonus ${fkBonus}`);
+      this.shadowsBiteDamage += calculateBonusAzeriteDamage(event, this.shadowsBiteBonus, [DEMONBOLT_SP_COEFFICIENT, pairedCast.intellect], [fkBonus]);
+    }
+
+    this._queue.splice(castIndex, 1);
+  }
+}
+
+export default ShadowsBiteForbiddenKnowledgeCore;

--- a/src/parser/warlock/demonology/modules/azerite/ShadowsBiteForbiddenKnowledgeCore.js
+++ b/src/parser/warlock/demonology/modules/azerite/ShadowsBiteForbiddenKnowledgeCore.js
@@ -113,17 +113,17 @@ class ShadowsBiteForbiddenKnowledgeCore extends Analyzer {
     const pairedCast = this._queue[castIndex];
     debug && this.log('Paired damage event with queued cast', pairedCast);
 
-    if (pairedCast.applyFK) {
-      const sbBonus = (pairedCast.applySB && this.shadowsBiteBonus) || 0;
-      debug && this.log(`Applying FK bonus ${this.forbiddenKnowledgeBonus}, with SB bonus ${sbBonus}`);
-      this.forbiddenKnowledgeDamage += calculateBonusAzeriteDamage(event, this.forbiddenKnowledgeBonus, [DEMONBOLT_SP_COEFFICIENT, pairedCast.intellect], [sbBonus]);
-    }
+    const fkBonus = (pairedCast.applyFK && this.forbiddenKnowledgeBonus) || 0;
+    const sbBonus = (pairedCast.applySB && this.shadowsBiteBonus) || 0;
 
-    if (pairedCast.applySB) {
-      const fkBonus = (pairedCast.applyFK && this.forbiddenKnowledgeBonus) || 0;
-      debug && this.log(`Applying SB bonus ${this.shadowsBiteBonus}, with FK bonus ${fkBonus}`);
-      this.shadowsBiteDamage += calculateBonusAzeriteDamage(event, this.shadowsBiteBonus, [DEMONBOLT_SP_COEFFICIENT, pairedCast.intellect], [fkBonus]);
-    }
+    debug && this.log(`FK bonus: ${fkBonus}, SB bonus: ${sbBonus}`);
+
+    const [ fkDamage, sbDamage ] = calculateBonusAzeriteDamage(event, [fkBonus, sbBonus], DEMONBOLT_SP_COEFFICIENT, pairedCast.intellect);
+
+    debug && this.log(`FK bonus damage: ${fkDamage}, SB bonus damage: ${sbDamage}`);
+
+    this.forbiddenKnowledgeDamage += fkDamage;
+    this.shadowsBiteDamage += sbDamage;
 
     this._queue.splice(castIndex, 1);
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5068584/48969422-937d6380-effe-11e8-8c22-a9f68b9302bc.png)
![image](https://user-images.githubusercontent.com/5068584/48969428-9c6e3500-effe-11e8-8a40-02c7fd114e80.png)

Part of #2724. This one was a little complicated, because both of these traits can affect Demonbolt at the same time (there's a very small window, around 3 seconds where this can happen, but I've tested it and it works) + they snapshot the effects on cast, so spell queue was also necessary. 

Because of this, I also had to change the signature of `calculateBonusAzeriteDamage` (and change all existing occurences):
- `coefficients` has to be an explicitly stated array
- there's an optional array parameter `knownOtherEffects` that contains ADDITIVE other trait bonuses
- resulting base damage is then multiplication of all coefficients (like Spell Power, SP coefficients etc.) + sum of all known effects

I'm aware that some of my other opened PRs use the old signature - I'll change them as soon as this PR is merged.

Tested thoroughly on this log: `/report/pbHAc1R3tN94VCQ7/22-LFR+Taloc+-+Kill+(4:44)/249-Velerius`