### PR TITLE
[Destruction] Added Bursting Flare trait

### DIFF
--- a/src/common/SPELLS/bfa/azeritetraits/warlock.js
+++ b/src/common/SPELLS/bfa/azeritetraits/warlock.js
@@ -63,4 +63,15 @@ export default {
     name: 'Supreme Commander',
     icon: 'inv_summondemonictyrant',
   },
+
+  BURSTING_FLARE: {
+    id: 279909,
+    name: 'Bursting Flare',
+    icon: 'spell_fire_fireball',
+  },
+  BURSTING_FLARE_BUFF: {
+    id: 279913,
+    name: 'Bursting Flare',
+    icon: 'spell_fire_fireball',
+  },
 };

--- a/src/parser/shared/modules/StatTracker.js
+++ b/src/parser/shared/modules/StatTracker.js
@@ -30,6 +30,7 @@ import { STAT_TRACKER as CASCADING_CALAMITY_STATS } from 'parser/warlock/afflict
 import { STAT_TRACKER as WRACKING_BRILLIANCE_STATS } from 'parser/warlock/affliction/modules/azerite/WrackingBrilliance';
 import { STAT_TRACKER as EXPLOSIVE_POTENTIAL_STATS } from 'parser/warlock/demonology/modules/azerite/ExplosivePotential';
 import { STAT_TRACKER as SUPREME_COMMANDER_STATS } from 'parser/warlock/demonology/modules/azerite/SupremeCommander';
+import { STAT_TRACKER as BURSTING_FLARE_STATS } from 'parser/warlock/destruction/modules/azerite/BurstingFlare';
 
 const debug = false;
 
@@ -296,6 +297,7 @@ class StatTracker extends Analyzer {
     [SPELLS.CASCADING_CALAMITY_BUFF.id]: CASCADING_CALAMITY_STATS,
     [SPELLS.WRACKING_BRILLIANCE_BUFF.id]: WRACKING_BRILLIANCE_STATS,
     [SPELLS.SUPREME_COMMANDER_BUFF.id]: SUPREME_COMMANDER_STATS,
+    [SPELLS.BURSTING_FLARE_BUFF.id]: BURSTING_FLARE_STATS,
     // endregion
     //region Death Knight
     [SPELLS.BONES_OF_THE_DAMNED_BUFF.id]: BOFD_ARMOR, // Armor when Bones of the Damend trait is up

--- a/src/parser/warlock/destruction/CombatLogParser.js
+++ b/src/parser/warlock/destruction/CombatLogParser.js
@@ -34,6 +34,8 @@ import SoulConduit from './modules/talents/SoulConduit';
 import ChannelDemonfire from './modules/talents/ChannelDemonfire';
 import Talents from './modules/talents';
 
+import BurstingFlare from './modules/azerite/BurstingFlare';
+
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     // Features
@@ -72,6 +74,9 @@ class CombatLogParser extends CoreCombatLogParser {
     soulConduit: SoulConduit,
     channelDemonfire: ChannelDemonfire,
     talents: Talents,
+
+    // Azerite traits
+    burstingFlare: BurstingFlare,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }],

--- a/src/parser/warlock/destruction/modules/azerite/BurstingFlare.js
+++ b/src/parser/warlock/destruction/modules/azerite/BurstingFlare.js
@@ -24,8 +24,6 @@ const debug = false;
   Casting Conflagrate on a target affected by your Immolate increases your Mastery by X for 20 sec, stacking up to 5 times.
  */
 class BurstingFlare extends Analyzer {
-  _lastChangeTimestamp = null;
-  _currentStacks = 0;
   totalMastery = 0;
   mastery = 0;
 

--- a/src/parser/warlock/destruction/modules/azerite/BurstingFlare.js
+++ b/src/parser/warlock/destruction/modules/azerite/BurstingFlare.js
@@ -24,7 +24,6 @@ const debug = false;
   Casting Conflagrate on a target affected by your Immolate increases your Mastery by X for 20 sec, stacking up to 5 times.
  */
 class BurstingFlare extends Analyzer {
-  totalMastery = 0;
   mastery = 0;
 
   constructor(...args) {

--- a/src/parser/warlock/destruction/modules/azerite/BurstingFlare.js
+++ b/src/parser/warlock/destruction/modules/azerite/BurstingFlare.js
@@ -1,0 +1,84 @@
+import React from 'react';
+
+import Analyzer from 'parser/core/Analyzer';
+
+import SPELLS from 'common/SPELLS';
+import { calculateAzeriteEffects } from 'common/stats';
+import { formatPercentage } from 'common/format';
+
+import TraitStatisticBox from 'interface/others/TraitStatisticBox';
+
+const burstingFlareStats = traits => traits.reduce((total, rank) => {
+  const [ mastery ] = calculateAzeriteEffects(SPELLS.BURSTING_FLARE.id, rank);
+  return total + mastery;
+}, 0);
+
+export const STAT_TRACKER = {
+  mastery: combatant => burstingFlareStats(combatant.traitsBySpellId[SPELLS.BURSTING_FLARE.id]),
+};
+
+const debug = true;
+
+/*
+  Bursting Flare:
+  Casting Conflagrate on a target affected by your Immolate increases your Mastery by X for 20 sec, stacking up to 5 times.
+ */
+class BurstingFlare extends Analyzer {
+  _lastChangeTimestamp = null;
+  _currentStacks = 0;
+  totalMastery = 0;
+  mastery = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrait(SPELLS.BURSTING_FLARE.id);
+    if (!this.active) {
+      return;
+    }
+    this.mastery = burstingFlareStats(this.selectedCombatant.traitsBySpellId[SPELLS.BURSTING_FLARE.id]);
+    debug && this.log(`Total bonus from BF: ${this.mastery}`);
+  }
+
+  on_byPlayer_changebuffstack(event) {
+    if (event.ability.guid !== SPELLS.BURSTING_FLARE_BUFF.id) {
+      return;
+    }
+    debug && this.log(`BF change buffstack, last timestamp ${this._lastChangeTimestamp}, old stacks ${event.oldStacks}, new stacks ${event.newStacks}`);
+    if (this._lastChangeTimestamp && event.oldStacks !== 0) {
+      const uptimeOnStack = event.timestamp - this._lastChangeTimestamp;
+      debug && this.log(`Uptime on old stack: ${uptimeOnStack}`);
+      this.totalMastery += event.oldStacks * this.mastery * uptimeOnStack;
+      debug && this.log(`Total mastery increased to ${this.totalMastery}`);
+    }
+    this._currentStacks = event.newStacks;
+    this._lastChangeTimestamp = event.timestamp;
+  }
+
+  on_finished(event) {
+    if (this._currentStacks !== 0) {
+      const uptimeOnStack = event.timestamp - this._lastChangeTimestamp;
+      debug && this.log(`Fight ended, adding rest of BF uptime on ${this._currentStacks} stacks: ${uptimeOnStack}`);
+      this.totalMastery += this._currentStacks * this.mastery * uptimeOnStack;
+    }
+  }
+
+  get uptime() {
+    return this.selectedCombatant.getBuffUptime(SPELLS.BURSTING_FLARE_BUFF.id) / this.owner.fightDuration;
+  }
+
+  get averageMastery() {
+    return (this.totalMastery / this.owner.fightDuration).toFixed(0);
+  }
+
+  statistic() {
+    return (
+      <TraitStatisticBox
+        trait={SPELLS.BURSTING_FLARE.id}
+        value={`${this.averageMastery} average Mastery`}
+        tooltip={`Bursting Flare grants ${this.mastery} Mastery per stack (${5 * this.mastery} Mastery at 5 stacks) while active. You had ${formatPercentage(this.uptime)} % uptime on the buff.`}
+      />
+    );
+  }
+}
+
+export default BurstingFlare;

--- a/src/parser/warlock/destruction/modules/azerite/BurstingFlare.js
+++ b/src/parser/warlock/destruction/modules/azerite/BurstingFlare.js
@@ -17,7 +17,7 @@ export const STAT_TRACKER = {
   mastery: combatant => burstingFlareStats(combatant.traitsBySpellId[SPELLS.BURSTING_FLARE.id]),
 };
 
-const debug = true;
+const debug = false;
 
 /*
   Bursting Flare:

--- a/src/parser/warlock/destruction/modules/azerite/BurstingFlare.js
+++ b/src/parser/warlock/destruction/modules/azerite/BurstingFlare.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
-import EventFilter from 'parser/core/EventFilter';
+import Analyzer from 'parser/core/Analyzer';
 
 import SPELLS from 'common/SPELLS';
 import { calculateAzeriteEffects } from 'common/stats';
@@ -38,31 +37,6 @@ class BurstingFlare extends Analyzer {
     }
     this.mastery = burstingFlareStats(this.selectedCombatant.traitsBySpellId[SPELLS.BURSTING_FLARE.id]);
     debug && this.log(`Total bonus from BF: ${this.mastery}`);
-
-    // by no chance I was able to get it working with CombatLogParser.finished and possibly Entities.changebuffstack
-    // not a clue why not but it just doesn't work (supposedly circular dependencies but the same code (at least with finished) works elsewhere, not here), this does
-    this.addEventListener(new EventFilter('changebuffstack').by(SELECTED_PLAYER).spell(SPELLS.BURSTING_FLARE_BUFF), this.onBurstingFlareChangeBuffStack);
-    this.addEventListener(new EventFilter('finished'), this.onFinished);
-  }
-
-  onBurstingFlareChangeBuffStack(event) {
-    debug && this.log(`BF change buffstack, last timestamp ${this._lastChangeTimestamp}, old stacks ${event.oldStacks}, new stacks ${event.newStacks}`);
-    if (this._lastChangeTimestamp && event.oldStacks !== 0) {
-      const uptimeOnStack = event.timestamp - this._lastChangeTimestamp;
-      debug && this.log(`Uptime on old stack: ${uptimeOnStack}`);
-      this.totalMastery += event.oldStacks * this.mastery * uptimeOnStack;
-      debug && this.log(`Total mastery increased to ${this.totalMastery}`);
-    }
-    this._currentStacks = event.newStacks;
-    this._lastChangeTimestamp = event.timestamp;
-  }
-
-  onFinished(event) {
-    if (this._currentStacks !== 0) {
-      const uptimeOnStack = event.timestamp - this._lastChangeTimestamp;
-      debug && this.log(`Fight ended, adding rest of BF uptime on ${this._currentStacks} stacks: ${uptimeOnStack}`);
-      this.totalMastery += this._currentStacks * this.mastery * uptimeOnStack;
-    }
   }
 
   get uptime() {
@@ -70,7 +44,8 @@ class BurstingFlare extends Analyzer {
   }
 
   get averageMastery() {
-    return (this.totalMastery / this.owner.fightDuration).toFixed(0);
+    const averageStacks = this.selectedCombatant.getStackWeightedBuffUptime(SPELLS.BURSTING_FLARE_BUFF.id) / this.owner.fightDuration;
+    return (averageStacks * this.mastery).toFixed(0);
   }
 
   statistic() {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5068584/48994746-232d2a00-f145-11e8-91d3-a6a10d9a5bf8.png)

Part of #2724. As for the event listeners - I know and you can read my rants about it on Discord - basically if I tried to do this properly, I got stuck somewhere in circular dependencies or circular imports, which would cause `characterTab` and `statTracker` to go `undefined` in `CombatLogParser` for no apparent reason => crashing the app. A solution proposed on Discord would be to have the event handlers in Events together with all other handlers. If that would be ok, I'll update the PR.