### PR TITLE
[Bug] [Protection Paladin] LotP fix

### DIFF
--- a/src/parser/paladin/protection/modules/spells/LightOfTheProtector.js
+++ b/src/parser/paladin/protection/modules/spells/LightOfTheProtector.js
@@ -72,7 +72,7 @@ export default class LightOfTheProtector extends Analyzer {
   }
 
   _countDelay(event) {
-    const delay = event.timestamp - this._lastHit.timestamp - this._msTilHeal;
+    const delay = event.timestamp - (this._lastHit ? this._lastHit.timestamp : 0) - this._msTilHeal;
     if(delay < 0) {
       console.error("LotP/HotP delay came out negative", delay);
     }


### PR DESCRIPTION
`this._lastHit` is initially null, so trying to get the timestamp of the _lastHit is erroing.
This fixes the error, but not sure how much it screws with the displayed data.
@emallson should have a look at it when he has some time.