### PR TITLE
[Core] Simplify code for TraitStatisticBox and fix font size for talent boxes

### DIFF
--- a/src/interface/others/StatisticBox.js
+++ b/src/interface/others/StatisticBox.js
@@ -16,6 +16,7 @@ class StatisticBox extends React.PureComponent {
     footer: PropTypes.node,
     footerStyle: PropTypes.object,
     containerProps: PropTypes.object,
+    item: PropTypes.bool,
     alignIcon: PropTypes.string,
     warcraftLogs: PropTypes.string,
     category: PropTypes.string,
@@ -63,12 +64,12 @@ class StatisticBox extends React.PureComponent {
   }
 
   render() {
-    const { icon, value, tooltip, label, footer, footerStyle, containerProps, alignIcon, warcraftLogs, children, ...others } = this.props;
+    const { icon, value, tooltip, label, footer, footerStyle, containerProps, item, alignIcon, warcraftLogs, children, ...others } = this.props;
     delete others.category;
     delete others.position;
     return (
       <div className="col-lg-3 col-md-4 col-sm-6 col-xs-12" style={{ zIndex: this.state.expanded ? 2 : 1 }} {...containerProps}>
-        <div className="panel statistic-box expandable" {...others}>
+        <div className={`panel statistic-box expandable${item && ' item'}`} {...others}>
           <div className="panel-body">
             <div className="flex">
               <div className="flex-sub statistic-icon" style={{ display: 'flex', alignItems: alignIcon }}>

--- a/src/interface/others/TalentStatisticBox.js
+++ b/src/interface/others/TalentStatisticBox.js
@@ -14,7 +14,7 @@ const TalentStatisticBox = ({ talent, icon, label, ...others }) => {
   label = label || <SpellLink id={talent} icon={false} />;
 
   return (
-    <StatisticBox icon={icon} label={label} {...others} />
+    <StatisticBox icon={icon} label={label} item {...others} />
   );
 };
 

--- a/src/interface/others/TraitStatisticBox.js
+++ b/src/interface/others/TraitStatisticBox.js
@@ -4,53 +4,28 @@ import PropTypes from 'prop-types';
 import SpellLink from 'common/SpellLink';
 import SpellIcon from 'common/SpellIcon';
 
-import './StatisticBox.css';
 import STATISTIC_CATEGORY from './STATISTIC_CATEGORY';
+import StatisticBox from './StatisticBox';
 
 export { default as STATISTIC_ORDER } from './STATISTIC_ORDER';
 
-const TraitStatisticBox = ({ trait, icon, label, value, tooltip, containerProps, alignIcon, ...others }) => {
-  delete others.category;
-  delete others.position;
+const TraitStatisticBox = ({ trait, icon, label, ...others }) => {
+  icon = icon || <SpellIcon id={trait} />;
+  label = label || <SpellLink id={trait} icon={false} />;
+
   return (
-    <div className="col-lg-3 col-md-4 col-sm-6 col-xs-12" {...containerProps}>
-      <div className="panel statistic-box item" {...others}>
-        <div className="panel-body flex">
-          <div className="flex-sub statistic-icon" style={{ display: 'flex', alignItems: alignIcon }}>
-            {icon || <SpellIcon id={trait} />}
-          </div>
-          <div className="flex-main">
-            <div className="slabel">
-              {label || <SpellLink id={trait} icon={false} />}
-            </div>
-            <dfn data-tip={tooltip} className="value">
-              {value}
-            </dfn>
-          </div>
-        </div>
-      </div>
-    </div>
+    <StatisticBox icon={icon} label={label} item {...others} />
   );
 };
+
 TraitStatisticBox.propTypes = {
-  trait: PropTypes.number,
-  /**
-   * Override the trait's icon.
-   */
-  icon: PropTypes.node,
-  /**
-   * Override the trait's label.
-   */
-  label: PropTypes.node,
-  value: PropTypes.node.isRequired,
-  tooltip: PropTypes.string,
-  containerProps: PropTypes.object,
-  alignIcon: PropTypes.string,
-  category: PropTypes.string,
-  position: PropTypes.number,
+  ...StatisticBox.propTypes,
+  trait: PropTypes.number.isRequired,
+  icon: PropTypes.node, // Override the icon requirement
+  label: PropTypes.node, // Override the label requirement
 };
+
 TraitStatisticBox.defaultProps = {
-  alignIcon: 'center',
   category: STATISTIC_CATEGORY.AZERITE_POWERS,
 };
 


### PR DESCRIPTION
Simplified the core code for TraitStatisticBox (like I did for talents in #2735). As discussed, this lead to potential issues with font sizes being too large, so I added a prop into core statistic box that allows us to add the font smallifying css class (name is pretty bad, I just have it match the css class name but its very misleading I think).

Mainly creating this PR to hopefully actually get a discussion going on how to determine font size for statistic boxes. 