### PR TITLE
[Server] Remove bad dependency from event-stream and update version

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2329,8 +2329,8 @@
       }
     },
     "event-stream": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
       "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
       "dev": true,
       "requires": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2331,7 +2331,7 @@
     "event-stream": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
-      "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
       "dev": true,
       "requires": {
         "duplexer": "^0.1.1",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2335,7 +2335,6 @@
       "dev": true,
       "requires": {
         "duplexer": "^0.1.1",
-        "flatmap-stream": "^0.1.0",
         "from": "^0.1.7",
         "map-stream": "0.0.7",
         "pause-stream": "^0.0.11",


### PR DESCRIPTION
Just testing if this resolves Travis errors.  Travis is bugging out now that flatmap has been removed from npm (see below). New version of event-stream has flatmap removed. I just manually updated the version number and removed the dep to match the npm description, but I assume there's a command I should have run instead that also updates the crc? 

Cause: https://github.com/dominictarr/event-stream/issues/115



