### PR TITLE
[Bug] [Restoration Druid] Wild Growth fix

### DIFF
--- a/src/parser/druid/restoration/modules/features/WildGrowth.js
+++ b/src/parser/druid/restoration/modules/features/WildGrowth.js
@@ -35,9 +35,6 @@ class WildGrowth extends Analyzer {
       return;
     }
 
-    console.info(event);
-    console.info(this.wgTracker);
-
     if(Object.getOwnPropertyNames(this.wgTracker).length > 0) {
       this.wgTracker.badPrecast = (this.wgTracker.firstTicksOverheal / this.wgTracker.firstTicksRaw) > PRECAST_THRESHOLD;
       this.wgHistory.push(this.wgTracker);
@@ -77,7 +74,6 @@ class WildGrowth extends Analyzer {
 
   on_finished() {
     this.wgHistory.push(this.wgTracker);
-    console.info(this.wgHistory);
   }
 
   get averageEffectiveHits() {

--- a/src/parser/druid/restoration/modules/features/WildGrowth.js
+++ b/src/parser/druid/restoration/modules/features/WildGrowth.js
@@ -22,7 +22,9 @@ class WildGrowth extends Analyzer {
   wgHistory = [];
   wgTracker = {
     wgBuffs: [],
+    startTimestamp: 0,
     heal: 0,
+    overheal: 0,
     firstTicksOverheal: 0,
     firstTicksRaw: 0,
   };
@@ -33,12 +35,20 @@ class WildGrowth extends Analyzer {
       return;
     }
 
+    console.info(event);
+    console.info(this.wgTracker);
+
     if(Object.getOwnPropertyNames(this.wgTracker).length > 0) {
       this.wgTracker.badPrecast = (this.wgTracker.firstTicksOverheal / this.wgTracker.firstTicksRaw) > PRECAST_THRESHOLD;
       this.wgHistory.push(this.wgTracker);
     }
-    
+    this.wgTracker = {};
+    this.wgTracker.wgBuffs = [];
     this.wgTracker.startTimestamp = event.timestamp;
+    this.wgTracker.heal = 0;
+    this.wgTracker.overheal = 0;
+    this.wgTracker.firstTicksOverheal = 0;
+    this.wgTracker.firstTicksRaw = 0;
   }
 
   on_byPlayer_heal(event) {
@@ -59,7 +69,7 @@ class WildGrowth extends Analyzer {
 
   on_byPlayer_applybuff(event) {
     const spellId = event.ability.guid;
-    if (spellId !== SPELLS.WILD_GROWTH.id) {
+    if (spellId !== SPELLS.WILD_GROWTH.id || !this.wgTracker.wgBuffs) {
       return;
     }
     this.wgTracker.wgBuffs.push(event.targetID);
@@ -67,6 +77,7 @@ class WildGrowth extends Analyzer {
 
   on_finished() {
     this.wgHistory.push(this.wgTracker);
+    console.info(this.wgHistory);
   }
 
   get averageEffectiveHits() {

--- a/src/parser/druid/restoration/modules/features/WildGrowth.js
+++ b/src/parser/druid/restoration/modules/features/WildGrowth.js
@@ -66,7 +66,7 @@ class WildGrowth extends Analyzer {
 
   on_byPlayer_applybuff(event) {
     const spellId = event.ability.guid;
-    if (spellId !== SPELLS.WILD_GROWTH.id || !this.wgTracker.wgBuffs) {
+    if (spellId !== SPELLS.WILD_GROWTH.id) {
       return;
     }
     this.wgTracker.wgBuffs.push(event.targetID);

--- a/src/parser/druid/restoration/modules/features/WildGrowth.js
+++ b/src/parser/druid/restoration/modules/features/WildGrowth.js
@@ -20,7 +20,12 @@ class WildGrowth extends Analyzer {
   };
 
   wgHistory = [];
-  wgTracker = {};
+  wgTracker = {
+    wgBuffs: [],
+    heal: 0,
+    firstTicksOverheal: 0,
+    firstTicksRaw: 0,
+  };
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
@@ -32,13 +37,8 @@ class WildGrowth extends Analyzer {
       this.wgTracker.badPrecast = (this.wgTracker.firstTicksOverheal / this.wgTracker.firstTicksRaw) > PRECAST_THRESHOLD;
       this.wgHistory.push(this.wgTracker);
     }
-    this.wgTracker = {};
-    this.wgTracker.wgBuffs = [];
+    
     this.wgTracker.startTimestamp = event.timestamp;
-    this.wgTracker.heal = 0;
-    this.wgTracker.overheal = 0;
-    this.wgTracker.firstTicksOverheal = 0;
-    this.wgTracker.firstTicksRaw = 0;
   }
 
   on_byPlayer_heal(event) {


### PR DESCRIPTION
`this.wgTracker.wgBuffs.push(event.targetID);` in `on_byPlayer_applybuff` would fail if an applyBuff event would appear before the first cast-event.
This is just initializing the object with the necessary props to avoid crashes, not sure why applyBuffs apear before the castEvent, but this fix shouldn't break the numbers except the `startTimestamp` of the first WG.

@buimichael should give this a closer look to see if everything is still working as intended