### PR TITLE
Updated timeline to show 'Combat Potion' instead of Int Pot

### DIFF
--- a/src/common/SPELLS/bfa/potions.js
+++ b/src/common/SPELLS/bfa/potions.js
@@ -54,4 +54,9 @@ export default {
     name: 'Steelskin Potion',
     icon: 'inv_alchemy_80_elixir01green',
   },
+  DUMMY_COMBAT_POTION: {
+    id: Number.MAX_VALUE,
+    name: 'Combat Potion',
+    icon: 'trade_alchemy',
+  },
 };

--- a/src/common/SpellLink.js
+++ b/src/common/SpellLink.js
@@ -40,6 +40,15 @@ class SpellLink extends React.PureComponent {
       tooltipDetails.ilvl = ilvl;
     }
 
+    if(id === Number.MAX_VALUE) {
+      return (
+        <span className="pseudolink">
+          {icon && <SpellIcon id={id} noLink style={iconStyle} alt="" />}{' '}
+          {children || (SPELLS[id] ? SPELLS[id].name : `Unknown spell: ${id}`)}
+        </span>
+      );
+    }
+
     return (
       <a
         href={TooltipProvider.spell(id, tooltipDetails)}

--- a/src/parser/shared/modules/items/CombatPotion.js
+++ b/src/parser/shared/modules/items/CombatPotion.js
@@ -7,6 +7,7 @@ import Potion from './Potion';
  */
 class CombatPotion extends Potion {
   static spells = [
+    SPELLS.DUMMY_COMBAT_POTION,
     SPELLS.BATTLE_POTION_OF_INTELLECT,
     SPELLS.BATTLE_POTION_OF_STRENGTH,
     SPELLS.BATTLE_POTION_OF_AGILITY,
@@ -21,6 +22,7 @@ class CombatPotion extends Potion {
   static recommendedEfficiency = 0;
   static extraAbilityInfo = {
     buffSpellId: [
+      SPELLS.DUMMY_COMBAT_POTION.id,
       SPELLS.BATTLE_POTION_OF_INTELLECT.id,
       SPELLS.BATTLE_POTION_OF_STRENGTH.id,
       SPELLS.BATTLE_POTION_OF_AGILITY.id,


### PR DESCRIPTION
Fix for #2678

Tried to use Spell Id of 0 for the dummy potion, but it made it appear at the top of the Timeframe.