### PR TITLE
[Core] [Bug] StatTracker fix

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Mamtooth, Zerotorescue, Putro, joshinator, Gebuz, ackwell, emallson, blazyb, Dambroda, Nalhan, Satyric, niseko, Khadaj, Fyruna, Matardarix, jos3p, Aelexe } from 'CONTRIBUTORS';
+import { Mamtooth, Zerotorescue, Putro, joshinator, Gebuz, ackwell, emallson, blazyb, Dambroda, Nalhan, Satyric, niseko, Khadaj, Fyruna, Matardarix, jos3p, Aelexe, Chizu } from 'CONTRIBUTORS';
 import ItemLink from 'common/ItemLink';
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
@@ -8,6 +8,11 @@ import SpellLink from 'common/SpellLink';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  {
+    date: new Date('2018-12-09'),
+    changes: 'Fixed crashes when switching players that can get the same buff.',
+    contributors: [Chizu],
+  },
   {
     date: new Date('2018-11-15'),
     changes: <>Added <ItemLink id={ITEMS.DREAD_GLADIATORS_INSIGNIA.id} /> module.</>,


### PR DESCRIPTION
Example log: `/report/8Cy3KTwHzD4PgRtN/52-LFR+Zul+-+Kill+(5:27)/1210-Ishbale` - both the ele shaman Ishbale and arcane mage Andrømedâ share at least Archive of the Titans which is added with the `add()` method. Doesn't crash now.