### PR TITLE
[Core] Update Timeline to allow specifying which spell you want shown

### DIFF
--- a/src/parser/core/modules/Ability.js
+++ b/src/parser/core/modules/Ability.js
@@ -122,7 +122,7 @@ class Ability {
      */
     damageSpellIds: PropTypes.arrayOf(PropTypes.number),
     /**
-     * A
+     * The spell that'll forcibly shown on the timeline if set.
      */
     shownSpell: PropTypes.shape({
       id: PropTypes.number.isRequired,

--- a/src/parser/core/modules/Ability.js
+++ b/src/parser/core/modules/Ability.js
@@ -121,6 +121,14 @@ class Ability {
      * An array of damage spell ids that this spell cast causes.
      */
     damageSpellIds: PropTypes.arrayOf(PropTypes.number),
+    /**
+     * A
+     */
+    shownSpell: PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      name: PropTypes.string.isRequired,
+      icon: PropTypes.string.isRequired,
+    }),
   };
 
   _owner = null;
@@ -202,6 +210,7 @@ class Ability {
   };
   charges = 1;
   enabled = true;
+  shownSpell = null;
 
   /**
    * When extending this class you MUST copy-paste this function into the new class. Otherwise your new props will not be set properly.

--- a/src/parser/hunter/survival/modules/Abilities.js
+++ b/src/parser/hunter/survival/modules/Abilities.js
@@ -216,9 +216,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.HARPOON,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        gcd: {
-          base: 500,
-        },
+        gcd: null,
         cooldown: 20,
       },
       {
@@ -293,6 +291,12 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+      },
+      {
+        spell: SPELLS.MISDIRECTION,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: 30,
+        gcd: null,
       },
 
       /**

--- a/src/parser/hunter/survival/modules/Abilities.js
+++ b/src/parser/hunter/survival/modules/Abilities.js
@@ -113,6 +113,7 @@ class Abilities extends CoreAbilities {
       },
       { //WFI talent here first so that's the icon shown in the timeline - it has no other effect.
         spell: [SPELLS.WILDFIRE_INFUSION_TALENT, SPELLS.VOLATILE_BOMB_WFI, SPELLS.PHEROMONE_BOMB_WFI, SPELLS.SHRAPNEL_BOMB_WFI],
+        shownSpell: SPELLS.WILDFIRE_INFUSION_TALENT,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         gcd: {
           base: 1500,

--- a/src/parser/shared/modules/features/TimelineTab/TabComponent/SpellTimeline.js
+++ b/src/parser/shared/modules/features/TimelineTab/TabComponent/SpellTimeline.js
@@ -125,9 +125,7 @@ class SpellTimeline extends React.PureComponent {
           )}
           {this.spells.map(spellId => (
             <div className="lane" key={spellId}>
-              <SpellLink id={spellId}>
-                {abilities.getAbility(spellId).name}
-              </SpellLink>
+              <SpellLink id={abilities.getAbility(spellId).shownSpell ? abilities.getAbility(spellId).shownSpell.id : spellId} />
             </div>
           ))}
         </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29204244/49706673-9778ca80-fc27-11e8-93f5-5c084f1343e3.png)
![image](https://user-images.githubusercontent.com/29204244/49706676-9c3d7e80-fc27-11e8-862d-b58e426e1074.png)

This allows you to set which spell you want linked in the timeline on the left, if nothing is defined as shownSpell, it'll just default to what it used to. 

Also deleted the redundant 
```JS
                {abilities.getAbility(spellId).name}
```

but if it was used somewhere let me know, I just couldn't find anywhere that would do anything different than regular spelllink. 

With the prepot update (I think), my prior hack to this broke - this fixes it permanently. 