### PR TITLE
[Mage] Update all specs to 8.1

### DIFF
--- a/src/parser/mage/arcane/CHANGELOG.js
+++ b/src/parser/mage/arcane/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-12-16'),
+    changes: 'Updated for Patch 8.1.',
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2018-10-11'),
     changes: <>Fixed <SpellLink id={SPELLS.ARCANE_CHARGE.id} /> Normalizer to not put energize events after <SpellLink id={SPELLS.ARCANE_BARRAGE.id} /> and added Normalizer to sort the <SpellLink id={SPELLS.ARCANE_POWER.id} /> cast before the buff application</>,
     contributors: [Sharrq],

--- a/src/parser/mage/arcane/CONFIG.js
+++ b/src/parser/mage/arcane/CONFIG.js
@@ -10,7 +10,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Sharrq],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '8.0.1',
+  patchCompatibility: '8.1',
   // If set to  false`, the spec will show up as unsupported.
   isSupported: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.

--- a/src/parser/mage/fire/CHANGELOG.js
+++ b/src/parser/mage/fire/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-12-16'),
+    changes: 'Updated for Patch 8.1.',
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2018-11-17'),
     changes: <>Updated the <SpellLink id={SPELLS.HEATING_UP.id} /> module to fix some incorrect values and to properly handle <SpellLink id={SPELLS.SEARING_TOUCH_TALENT.id} />.</>,
     contributors: [Sharrq],

--- a/src/parser/mage/fire/CONFIG.js
+++ b/src/parser/mage/fire/CONFIG.js
@@ -10,7 +10,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Sharrq],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '8.0.1',
+  patchCompatibility: '8.1',
   // If set to  false`, the spec will show up as unsupported.
   isSupported: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.

--- a/src/parser/mage/fire/modules/traits/BlasterMaster.js
+++ b/src/parser/mage/fire/modules/traits/BlasterMaster.js
@@ -48,7 +48,7 @@ class BlasterMaster extends Analyzer {
       this.badCombustion += 1;
       this.lastCombustion.meta = this.lastCombustion.meta || {};
       this.lastCombustion.meta.isInefficientCast = true;
-      this.lastCombustion.meta.inefficientCastReason = `You only got ${this.stackCount} Blaster Master stacks during this Combustion. In order to get the most out of Blaster Master, you should aim to get to 4 stacks of the trait during each Combustion.`;
+      this.lastCombustion.meta.inefficientCastReason = `You only got ${this.stackCount} Blaster Master stacks during this Combustion. In order to get the most out of Blaster Master, you should aim to get to ${TRAIT_STACK_THRESHOLD} stacks of the trait during each Combustion.`;
     }
     this.totalStacks += this.stackCount;
     debug && this.log("Combustion Ended: " + this.stackCount + " stacks");
@@ -70,8 +70,8 @@ class BlasterMaster extends Analyzer {
     return {
       actual: this.averageStacksPerCombustion,
       isLessThan: {
-        minor: 4,
-        average: 3,
+        minor: 3,
+        average: 2.5,
         major: 2,
       },
       style: 'number',
@@ -81,7 +81,7 @@ class BlasterMaster extends Analyzer {
   suggestions(when) {
     when(this.averageStackThresholds)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<>On average, you got {this.averageStacksPerCombustion.toFixed(2)} stacks of <SpellLink id={SPELLS.BLASTER_MASTER.id} /> per <SpellLink id={SPELLS.COMBUSTION.id} /> cast. In order to maximize the use of the trait, you should aim for getting to 4 stacks each time you use Combustion. For more information on how to adjust your Combustion rotation to make this happen, refer to <a href="https://cdn.discordapp.com/attachments/431912396349636609/511996656829595659/BlasterMaster_Rotation.png" target="_blank" rel="noopener noreferrer">this graphic</a></>)
+        return suggest(<>On average, you got {this.averageStacksPerCombustion.toFixed(2)} stacks of <SpellLink id={SPELLS.BLASTER_MASTER.id} /> per <SpellLink id={SPELLS.COMBUSTION.id} /> cast. In order to maximize the use of the trait, you should aim for getting to {TRAIT_STACK_THRESHOLD} stacks each time you use Combustion. For more information on how to adjust your Combustion rotation to make this happen, refer to <a href="https://cdn.discordapp.com/attachments/431912396349636609/511996656829595659/BlasterMaster_Rotation.png" target="_blank" rel="noopener noreferrer">this graphic</a></>)
           .icon(SPELLS.BLASTER_MASTER.icon)
           .actual(`${this.averageStacksPerCombustion.toFixed(2)} stacks per Combustion`)
           .recommended(`${formatNumber(recommended)} is recommended`);
@@ -95,7 +95,7 @@ class BlasterMaster extends Analyzer {
         trait={SPELLS.BLASTER_MASTER.id}
         value={`${this.averageStacksPerCombustion.toFixed(2)} stacks per Combustion`}
         tooltip={
-          `Blaster Master is a somewhat complicated trait to get the full effect from and may involve adjusting your rotation during Combustion. In order to get the most out of this trait, you should aim to get to 4 stacks of the Blaster Master during Combustion. For additional information on how to accomplish this, refer to the Mage Discord or the link in the Suggestion.`
+          `Blaster Master is a somewhat complicated trait to get the full effect from and may involve adjusting your rotation during Combustion. In order to get the most out of this trait, you should aim to get to ${TRAIT_STACK_THRESHOLD} stacks of the Blaster Master during Combustion. For additional information on how to accomplish this, refer to the Mage Discord or the link in the Suggestion.`
         }
       />
     );

--- a/src/parser/mage/fire/modules/traits/BlasterMaster.js
+++ b/src/parser/mage/fire/modules/traits/BlasterMaster.js
@@ -10,7 +10,7 @@ import { SELECTED_PLAYER } from 'parser/core/EventFilter';
 
 const debug = false;
 
-const TRAIT_STACK_THRESHOLD = 4;
+const TRAIT_STACK_THRESHOLD = 3;
 
 class BlasterMaster extends Analyzer {
   static dependencies = {

--- a/src/parser/mage/frost/CHANGELOG.js
+++ b/src/parser/mage/frost/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-12-16'),
+    changes: 'Updated for Patch 8.1.',
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2018-11-27'),
     changes: <>Removed <SpellLink id={SPELLS.THERMAL_VOID_TALENT.id} /> from checklist and updated the module to better show what the talent provides.</>,
     contributors: [Dambroda],

--- a/src/parser/mage/frost/CONFIG.js
+++ b/src/parser/mage/frost/CONFIG.js
@@ -12,7 +12,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Sharrq, Dambroda],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '8.0.1',
+  patchCompatibility: '8.1',
   // If set to  false`, the spec will show up as unsupported.
   isSupported: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more. If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/parser/mage/frost/modules/traits/Whiteout.js
+++ b/src/parser/mage/frost/modules/traits/Whiteout.js
@@ -21,7 +21,7 @@ const FO_REDUCTION_SEC = 0.5;
  * To update, see https://www.wowhead.com/spell=137020/frost-mage
  * AURA = 1 + (Damage modifier)
  */
-const FROST_MAGE_AURA = 1 + (-0.24);
+const FROST_MAGE_AURA = 1 + (-0.22);
 
 /**
  * Ice Lance deals an additional X1 (stacks and scales) damage and reduces the cooldown of Frozen Orb by 0.5 (does not stack or scale) sec.


### PR DESCRIPTION
Update all Mage specs to 8.1. Mage didnt get very many changes overall, so this is pretty short.

- No changes for Arcane
- Blaster Master caps at 3 stacks now
- Frost's damage aura was updated