### PR TITLE
[Druid] Fix GCD of Wild Charge

### DIFF
--- a/src/parser/druid/balance/modules/Abilities.js
+++ b/src/parser/druid/balance/modules/Abilities.js
@@ -218,9 +218,7 @@ class Abilities extends CoreAbilities {
         spell: [SPELLS.WILD_CHARGE_TALENT, SPELLS.WILD_CHARGE_MOONKIN, SPELLS.WILD_CHARGE_CAT, SPELLS.WILD_CHARGE_BEAR, SPELLS.WILD_CHARGE_TRAVEL],
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 15,
-        gcd: {
-          static: 500,
-        },
+        gcd: null,
         enabled: combatant.hasTalent(SPELLS.WILD_CHARGE_TALENT.id),
         timelineSortIndex: 14,
       },

--- a/src/parser/druid/feral/modules/Abilities.js
+++ b/src/parser/druid/feral/modules/Abilities.js
@@ -356,9 +356,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 15,
         enabled: combatant.hasTalent(SPELLS.WILD_CHARGE_TALENT.id),
-        gcd: {
-          static: 500,
-        },
+        gcd: null,
         timelineSortIndex: 42,
       },
       {

--- a/src/parser/druid/guardian/modules/Abilities.js
+++ b/src/parser/druid/guardian/modules/Abilities.js
@@ -321,9 +321,7 @@ class Abilities extends CoreAbilities {
         spell: [SPELLS.WILD_CHARGE_TALENT, SPELLS.WILD_CHARGE_MOONKIN, SPELLS.WILD_CHARGE_CAT, SPELLS.WILD_CHARGE_BEAR, SPELLS.WILD_CHARGE_TRAVEL],
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 15,
-        gcd: {
-          static: 500,
-        },
+        gcd: null,
         enabled: combatant.hasTalent(SPELLS.WILD_CHARGE_TALENT.id),
       },
       {

--- a/src/parser/druid/restoration/modules/Abilities.js
+++ b/src/parser/druid/restoration/modules/Abilities.js
@@ -391,36 +391,28 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.WILD_CHARGE_TALENT.id),
         cooldown: 15,
-        gcd: {
-          base: 500,
-        },
+        gcd: null,
       },
       {
         spell: SPELLS.WILD_CHARGE_BEAR,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.WILD_CHARGE_TALENT.id),
         cooldown: 15,
-        gcd: {
-          base: 500,
-        },
+        gcd: null,
       },
       {
         spell: SPELLS.WILD_CHARGE_CAT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.WILD_CHARGE_TALENT.id),
         cooldown: 15,
-        gcd: {
-          base: 500,
-        },
+        gcd: null,
       },
       {
         spell: SPELLS.WILD_CHARGE_MOONKIN,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.WILD_CHARGE_TALENT.id),
         cooldown: 15,
-        gcd: {
-          base: 500,
-        },
+        gcd: null,
       },
       {
         spell: SPELLS.DASH,


### PR DESCRIPTION
Patch 8.1 removed the GCD from all forms of the Wild Charge talent for all druid specs. Double checked in-game that they really are off the GCD now.
Official forum post: https://us.forums.blizzard.com/en/wow/t/which-spells-are-being-removed-from-gcd-in-8-1/37795/7