### PR TITLE
[Feral Druid] Update Brutal Slash for 8.1

### DIFF
--- a/src/parser/druid/feral/modules/Abilities.js
+++ b/src/parser/druid/feral/modules/Abilities.js
@@ -90,7 +90,7 @@ class Abilities extends CoreAbilities {
           static: 1000,
         },
         timelineSortIndex: 11,
-        primaryCoefficient: 0.60,
+        primaryCoefficient: 0.69,
       },
       {
         spell: SPELLS.SWIPE_BEAR,

--- a/src/parser/druid/feral/modules/features/checklist/Component.js
+++ b/src/parser/druid/feral/modules/features/checklist/Component.js
@@ -296,14 +296,13 @@ class FeralDruidChecklist extends React.PureComponent {
 
         {/*Pick the right talents (if player is using talents that may be unsuitable)
           🗵 Only use Predator if it's allowing you to reset Tiger's Fury by killing adds
-          🗵 Only use Brutal Slash if on average it hits more than n targets (exact value of n needs simulation to find and is likely to change with gear and other talents, but when hitting just 1 target it's definitely the wrong talent.)
         */}
-        {(combatant.hasTalent(SPELLS.PREDATOR_TALENT.id) || combatant.hasTalent(SPELLS.BRUTAL_SLASH_TALENT.id)) && (
+        {(combatant.hasTalent(SPELLS.PREDATOR_TALENT.id)) && (
             <Rule
               name="Pick the most suitable Talents"
               description={(
                 <>
-                  The <SpellLink id={SPELLS.PREDATOR_TALENT.id} /> and <SpellLink id={SPELLS.BRUTAL_SLASH_TALENT.id} /> talents are only effective on fights with multiple enemies and should be swapped out for single target encounters.
+                  The <SpellLink id={SPELLS.PREDATOR_TALENT.id} /> talent is generally only effective on fights with multiple enemies and should be swapped out for single target encounters.
                 </>
               )}
             >
@@ -315,16 +314,6 @@ class FeralDruidChecklist extends React.PureComponent {
                   </>
                 )}
                 thresholds={thresholds.predatorWrongTalent}
-              />
-            )}
-            {combatant.hasTalent(SPELLS.BRUTAL_SLASH_TALENT.id) && (
-              <Requirement
-                name={(
-                  <>
-                    Average targets hit by <SpellLink id={SPELLS.BRUTAL_SLASH_TALENT.id} />
-                  </>
-                )}
-                thresholds={thresholds.brutalSlashWrongTalent}
               />
             )}
             

--- a/src/parser/druid/feral/modules/features/checklist/Module.js
+++ b/src/parser/druid/feral/modules/features/checklist/Module.js
@@ -20,7 +20,6 @@ import MoonfireSnapshot from '../../talents/MoonfireSnapshot';
 import PredatorySwiftness from '../../spells/PredatorySwiftness';
 import Bloodtalons from '../../talents/Bloodtalons';
 import Predator from '../../talents/Predator';
-import BrutalSlashHitCount from '../../talents/BrutalSlashHitCount';
 import TigersFuryEnergy from '../../spells/TigersFuryEnergy';
 import Shadowmeld from '../../racials/Shadowmeld';
 
@@ -44,7 +43,6 @@ class Checklist extends BaseChecklist {
     predatorySwiftness: PredatorySwiftness,
     bloodtalons: Bloodtalons,
     predator: Predator,
-    brutalSlashHitcount: BrutalSlashHitCount,
     tigersFuryEnergy: TigersFuryEnergy,
     shadowmeld: Shadowmeld,
   };
@@ -91,7 +89,6 @@ class Checklist extends BaseChecklist {
 
           // talent selection
           predatorWrongTalent: this.predator.suggestionThresholds,
-          brutalSlashWrongTalent: this.brutalSlashHitcount.wrongTalentThresholds,
         }}
       />
     );

--- a/src/parser/druid/feral/modules/talents/BrutalSlashHitCount.js
+++ b/src/parser/druid/feral/modules/talents/BrutalSlashHitCount.js
@@ -6,9 +6,8 @@ import { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 import HitCountAoE from '../core/HitCountAoE';
 
 /**
- * If the player has taken the Brutal Slash talent it should be used even if there's only one
- * target available to hit. However if it's mostly only hitting a single target then the player
- * would do more damage if they had chosen a different talent.
+ * Despite being an AoE ability Brutal Slash is usually the best talent on its row for single target fights.
+ * It can be useful to count how many targets it hits, but hitting just one is not a mistake.
  */
 class BrutalSlashHitCount extends HitCountAoE {
   static spell = SPELLS.BRUTAL_SLASH_TALENT;
@@ -20,19 +19,6 @@ class BrutalSlashHitCount extends HitCountAoE {
 
   statistic() {
     return this.generateStatistic(STATISTIC_ORDER.OPTIONAL(10));
-  }
-
-  get wrongTalentThresholds() {
-    return {
-      // Interested in how many targets are available so exclude any "zero hit" casts.
-      actual: this.averageTargetsHitNotIncludingZeroCasts,
-      isLessThan: {
-        minor: 2,
-        average: 1.5,
-        major: 1.2,
-      },
-      style: 'number',
-    };
   }
 
   get hitNoneThresholds() {
@@ -48,16 +34,6 @@ class BrutalSlashHitCount extends HitCountAoE {
   }
 
   suggestions(when) {
-    when(this.wrongTalentThresholds).addSuggestion((suggest, actual, recommended) => {
-      return suggest(
-        <>
-          Your <SpellLink id={SPELLS.BRUTAL_SLASH_TALENT.id} /> is mostly hitting just one target. On a single target fight switching talents to <SpellLink id={SPELLS.SABERTOOTH_TALENT.id} /> or <SpellLink id={SPELLS.SAVAGE_ROAR_TALENT.id} /> is likely to improve your damage.
-        </>
-      )
-        .icon(SPELLS.BRUTAL_SLASH_TALENT.icon)
-        .actual(`${actual.toFixed(1)} average targets hit.`)
-        .recommended(`>${recommended} is recommended`);
-    });
     when(this.hitNoneThresholds).addSuggestion((suggest, actual, recommended) => {
       return suggest(
         <>


### PR DESCRIPTION
Brutal Slash itself didn't change much (just increased coefficient, which is used for calculating Azerite trait damage.) But the talent tree was rearranged so it's now the best choice in its row for single target damage rather than the worst. This removes a suggestion and checklist item around that fact.