### PR TITLE
Checking on cast instead of on summon so the ability guids match

### DIFF
--- a/src/parser/shaman/elemental/modules/features/StormFireElemental.js
+++ b/src/parser/shaman/elemental/modules/features/StormFireElemental.js
@@ -43,7 +43,7 @@ class StormFireElemental extends Analyzer {
       this.last_pet_summon_timeStamp=event.timestamp;
 
   }
-  on_byPlayer_summon(event) {
+  on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
     if (spellId !== this.relevantData.summon) {
       return;


### PR DESCRIPTION
Got a report that the cooldown percentages were wrong if the Elemental was not being used pre-pull, because I was comparing the summon events with the cast spellids.
Changed it to actually check on cast now instead of on summon.

http://localhost:3000/report/6M3Z8pQvxC4Ttc7n/3-Mythic+MOTHER+-+Kill+(4:10)/9-Nellor/events