### PR TITLE
[Feral Druid] Update RipSnapshot for 8.1

### DIFF
--- a/src/parser/druid/feral/CHANGELOG.js
+++ b/src/parser/druid/feral/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2018-12-20'),
+    changes: <>Updated tracking of <SpellLink id={SPELLS.RIP.id} /> snapshots, and interaction with <SpellLink id={SPELLS.SABERTOOTH_TALENT.id} /> for patch 8.1.</>,
+    contributors: [Anatta336],
+  },
+  {
     date: new Date('2018-10-10'),
     changes: <>Added tracking to Feral for the <SpellLink id={SPELLS.WILD_FLESHRENDING.id} /> Azerite trait.</>,
     contributors: [Anatta336],

--- a/src/parser/druid/feral/CONFIG.js
+++ b/src/parser/druid/feral/CONFIG.js
@@ -21,6 +21,9 @@ export default {
   description: (
     <>
       <Warning>
+        This analyzer is in the process of being updated for Feral's changes in patch 8.1. Some results may be misleading until that's complete.
+      </Warning><br />
+      <Warning>
       AoE encounters are not currently well covered. You'll get the most useful feedback on fights which are primarily against a single target.
       </Warning><br />
 

--- a/src/parser/druid/feral/constants.js
+++ b/src/parser/druid/feral/constants.js
@@ -1,15 +1,17 @@
 export const RAKE_BASE_DURATION = 15000;
-export const RIP_BASE_DURATION = 24000;
+export const RIP_DURATION_1_CP = 8000;
+export const RIP_DURATION_PER_CP = 4000;
+export const RIP_MAXIMUM_EXTENDED_DURATION = 31200;
+export const SABERTOOTH_EXTEND_PER_CP = 4000;
 // cat moonfire lasts for 14 seconds, unlike caster and bear moonfire with a base of 16 seconds.
 export const MOONFIRE_FERAL_BASE_DURATION = 14000;
 export const THRASH_FERAL_BASE_DURATION = 15000;
 
-export const BITE_EXECUTE_RANGE = 0.25;
 export const SAVAGE_ROAR_DAMAGE_BONUS = 0.15;
 export const TIGERS_FURY_DAMAGE_BONUS = 0.15;
 export const BLOODTALONS_DAMAGE_BONUS = 0.25;
 export const MOMENT_OF_CLARITY_DAMAGE_BONUS = 0.15;
-export const JAGGED_WOUNDS_MODIFIER = 0.80;
+export const PROWL_RAKE_DAMAGE_BONUS = 1.00;
 export const PANDEMIC_FRACTION = 0.3;
 
 export const SHRED_COEFFICIENT = 0.380562;

--- a/src/parser/druid/feral/modules/bleeds/RakeSnapshot.js
+++ b/src/parser/druid/feral/modules/bleeds/RakeSnapshot.js
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { formatPercentage } from 'common/format';
 import { STATISTIC_ORDER } from 'interface/others/StatisticsListBox';
-import { RAKE_BASE_DURATION, JAGGED_WOUNDS_MODIFIER, PANDEMIC_FRACTION } from '../../constants';
+import { RAKE_BASE_DURATION, PANDEMIC_FRACTION } from '../../constants';
 import Snapshot from '../core/Snapshot';
 
 /**
@@ -35,13 +35,6 @@ class RakeSnapshot extends Snapshot {
 
   // rake DoTs refreshed with weaker snapshot before pandemic
   downgradeCastCount = 0;
-
-  constructor(...args) {
-    super(...args);
-    if (this.selectedCombatant.hasTalent(SPELLS.JAGGED_WOUNDS_TALENT.id)) {
-      this.constructor.durationOfFresh = RAKE_BASE_DURATION * JAGGED_WOUNDS_MODIFIER;
-    }
-  }
 
   checkRefreshRule(stateNew) {
     const stateOld = stateNew.prev;

--- a/src/parser/druid/feral/modules/bleeds/RipUptime.js
+++ b/src/parser/druid/feral/modules/bleeds/RipUptime.js
@@ -32,7 +32,10 @@ class RipUptime extends Analyzer {
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
       return suggest(
         <>
-          Your <SpellLink id={SPELLS.RIP.id} /> uptime can be improved. You can refresh the DoT once it has reached its <dfn data-tip={`The last 30% of the DoT's duration. When you refresh during this time you don't lose any duration in the process.`}>pandemic window</dfn>, don't wait for it to wear off. Avoid spending combo points on <SpellLink id={SPELLS.FEROCIOUS_BITE.id} /> if <SpellLink id={SPELLS.RIP.id} /> will need refreshing soon.
+          Your <SpellLink id={SPELLS.RIP.id} /> uptime can be improved. You can refresh the DoT once it has reached its <dfn data-tip={`The last 30% of the DoT's duration. When you refresh during this time you don't lose any duration in the process.`}>pandemic window</dfn>, don't wait for it to wear off.
+          {!this.selectedCombatant.hasTalent(SPELLS.SABERTOOTH_TALENT.id) ?
+            <> Avoid spending combo points on <SpellLink id={SPELLS.FEROCIOUS_BITE.id} /> if <SpellLink id={SPELLS.RIP.id} /> will need refreshing soon.</> : <></>
+          }
         </>
       )
         .icon(SPELLS.RIP.icon)

--- a/src/parser/druid/feral/modules/features/checklist/Component.js
+++ b/src/parser/druid/feral/modules/features/checklist/Component.js
@@ -60,7 +60,6 @@ class FeralDruidChecklist extends React.PureComponent {
           🗵 Cast efficiency of Feral Frenzy (if talented)
           🗵 Only use Swipe if it hits multiple enemies
           🗵 Don't waste combo points by generating more when full
-          Would be nice to advise against using single target abilities when there's many enemies present, but difficult to consistently detect that situation from the logs.
         */}
         <Rule
           name="Generate combo points"
@@ -105,6 +104,7 @@ class FeralDruidChecklist extends React.PureComponent {
           🗵 Uptime for Savage Roar buff (if talented)
           🗵 Ferocious Bite only at energy >= 50
           🗵 Don't cast Rip when Ferocious Bite could have refreshed it, unless you're upgrading the snapshot
+          🗵 Don't reduce duration of Rip by refreshing early and with low combo points
           🗵 Don't use finishers at less than 5 combo points
         */}
         <Rule
@@ -136,6 +136,14 @@ class FeralDruidChecklist extends React.PureComponent {
               </>
             )}
             thresholds={thresholds.ripShouldBeBite}
+          />
+          <Requirement
+            name={(
+              <>
+                <SpellLink id={SPELLS.RIP.id} /> which reduced duration by refreshing early with low combo points
+              </>
+            )}
+            thresholds={thresholds.ripDurationReduction}
           />
           <Requirement
             name={(

--- a/src/parser/druid/feral/modules/features/checklist/Module.js
+++ b/src/parser/druid/feral/modules/features/checklist/Module.js
@@ -67,6 +67,7 @@ class Checklist extends BaseChecklist {
           savageRoarUptime: this.savageRoarUptime.suggestionThresholds,
           ferociousBiteEnergy: this.ferociousBiteEnergy.suggestionThresholds,
           ripShouldBeBite: this.ripSnapshot.shouldBeBiteSuggestionThresholds,
+          ripDurationReduction: this.ripSnapshot.durationReductionThresholds,
           finishersBelowFull: this.comboPointDetails.finishersBelowMaxSuggestionThresholds,
           
           // energy

--- a/src/parser/druid/feral/modules/talents/MoonfireSnapshot.js
+++ b/src/parser/druid/feral/modules/talents/MoonfireSnapshot.js
@@ -17,7 +17,6 @@ class MoonfireSnapshot extends Snapshot {
   static spellCastId = SPELLS.MOONFIRE_FERAL.id;
   static debuffId = SPELLS.MOONFIRE_FERAL.id;
 
-  // unlike bleeds, Moonfire's duration is not affected by the Jagged Wounds talent
   static durationOfFresh = MOONFIRE_FERAL_BASE_DURATION;
   static isProwlAffected = false;
   static isTigersFuryAffected = true;


### PR DESCRIPTION
The mechanics of Rip were changed in 8.1, which is now reflected in the logic of RipSnapshot. Previously Rip had a set duration like the other Feral DoTs but now it depends on the combo points used. In addition the Sabertooth talent works differently, extending the duration by a set amount rather than resetting it.

Reworked `RipSnapshot` to work with the new mechanics of Rip.
Removed reference to the removed Jagged Wounds talent.
Removed anything to do with the removed mechanic of Ferocious Bite refreshing Rip when target is in execute range.
Improved `RipUptime`'s suggestion to only advise against using Bite if the player doesn't have Sabertooth.
Moved some constants from `Snapshot` out to `constants`
Prevented false information coming from the Predator analysis in `SpellUsable` 
Added check for reducing duration of Rip's DoT by refreshing early with low combo points. Both as a suggestion and checkpoint item.
Added a warning that the spec isn't fully updated for 8.1 yet.