### PR TITLE
Bf/sea giants tidestone

### DIFF
--- a/src/parser/shared/modules/items/bfa/SeaGiantsTidestone.js
+++ b/src/parser/shared/modules/items/bfa/SeaGiantsTidestone.js
@@ -27,7 +27,7 @@ class SeaGiantsTidestone extends Analyzer {
   };
   
   casts = 0;
-  spellPower = 0;
+  haste = 0;
 
   constructor(...args) {
     super(...args);
@@ -35,7 +35,7 @@ class SeaGiantsTidestone extends Analyzer {
       ITEMS.SEA_GIANTS_TIDESTONE.id
     );
     if (this.active) {
-      this.spellPower = calculateSecondaryStatDefault(370, 985, this.selectedCombatant.getItem(ITEMS.SEA_GIANTS_TIDESTONE.id).itemLevel);
+      this.haste = calculateSecondaryStatDefault(370, 985, this.selectedCombatant.getItem(ITEMS.SEA_GIANTS_TIDESTONE.id).itemLevel);
 
       this.abilities.add({
         spell: SPELLS.FEROCITY_OF_THE_SKROG,
@@ -64,7 +64,7 @@ class SeaGiantsTidestone extends Analyzer {
     return {
       item: ITEMS.SEA_GIANTS_TIDESTONE,
       result: (
-        <dfn data-tip={`Average spell power gained ${formatNumber(this.spellPower * this.totalBuffUptime)}`}>
+        <dfn data-tip={`Average haste gained ${formatNumber(this.haste * this.totalBuffUptime)}`}>
           Used {this.casts} times / {formatPercentage(this.totalBuffUptime)}% uptime
         </dfn>
       ),

--- a/src/parser/shared/modules/items/bfa/SeaGiantsTidestone.js
+++ b/src/parser/shared/modules/items/bfa/SeaGiantsTidestone.js
@@ -48,11 +48,11 @@ class SeaGiantsTidestone extends Analyzer {
           suggestion: true,
         },
       });
-    }
 
-    this.statTracker.add(SPELLS.FEROCITY_OF_THE_SKROG.id, {
-      haste: this.haste,
-    });
+      this.statTracker.add(SPELLS.FEROCITY_OF_THE_SKROG.id, {
+        haste: this.haste,
+      });
+    }
   }
   
   on_byPlayer_cast(event) {

--- a/src/parser/shared/modules/items/bfa/SeaGiantsTidestone.js
+++ b/src/parser/shared/modules/items/bfa/SeaGiantsTidestone.js
@@ -4,6 +4,7 @@ import SPELLS from 'common/SPELLS/index';
 import ITEMS from 'common/ITEMS/index';
 import Analyzer from 'parser/core/Analyzer';
 import Abilities from 'parser/core/modules/Abilities';
+import StatTracker from 'parser/shared/modules/StatTracker';
 import { formatPercentage } from 'common/format';
 import { formatNumber } from 'common/format';
 import { calculateSecondaryStatDefault } from 'common/stats';
@@ -24,6 +25,7 @@ import { calculateSecondaryStatDefault } from 'common/stats';
 class SeaGiantsTidestone extends Analyzer {
   static dependencies = {
     abilities: Abilities,
+    statTracker: StatTracker,
   };
   
   casts = 0;
@@ -47,6 +49,10 @@ class SeaGiantsTidestone extends Analyzer {
         },
       });
     }
+
+    this.statTracker.add(SPELLS.FEROCITY_OF_THE_SKROG.id, {
+      haste: this.haste,
+    });
   }
   
   on_byPlayer_cast(event) {


### PR DESCRIPTION
Adjusted tooltip to show average haste.
Added to SPELLS.FEROCITY_OF_THE_SKROG to the stat tracker using example provided by @sMteX.
![tooltip](https://user-images.githubusercontent.com/3276248/50375445-5be8e380-05cb-11e9-929d-ecc19339f8d5.jpg)

#2833 #2861