### PR TITLE
[Warlock] Visual changes to damage values

### DIFF
--- a/src/parser/warlock/affliction/CHANGELOG.js
+++ b/src/parser/warlock/affliction/CHANGELOG.js
@@ -6,6 +6,11 @@ import SPELLS from 'common/SPELLS';
 
 export default [
   {
+    date: new Date('2018-12-23'),
+    changes: 'Changed display of damage in various places. Now shows % of total damage done and DPS with raw values in tooltip.',
+    contributors: [Chizu],
+  },
+  {
     date: new Date('2018-12-10'),
     changes: <>Updated for patch 8.1 - <SpellLink id={SPELLS.UNSTABLE_AFFLICTION_CAST.id} /> nerf.</>,
     contributors: [Chizu],

--- a/src/parser/warlock/affliction/modules/features/Darkglare.js
+++ b/src/parser/warlock/affliction/modules/features/Darkglare.js
@@ -219,9 +219,9 @@ class Darkglare extends Analyzer {
     return (
       <StatisticsListBox title={<SpellLink id={SPELLS.SUMMON_DARKGLARE.id} />}>
         <StatisticListBoxItem
-          title="Bonus damage from extended dots"
-          value={formatThousands(this.bonusDotDamage)}
-          valueTooltip="This only counts the damage that happened after the dot <u>should have fallen off</u> (but instead was extended with Darkglare)"
+          title="Bonus damage from dots"
+          value={this.owner.formatItemDamageDone(this.bonusDotDamage)}
+          valueTooltip={`${formatThousands(this.bonusDotDamage)} damage<br />This only counts the damage that happened after the dot <u>should have fallen off</u> (but instead was extended with Darkglare)`}
         />
         <StatisticListBoxItem
           title="Average dots extended per cast"
@@ -230,8 +230,10 @@ class Darkglare extends Analyzer {
         <StatisticListBoxItem
           title="Total damage"
           titleTooltip="Combined damage from extended dots and the pet itself"
-          value={formatThousands(totalDamage)}
-          valueTooltip={`Extended dot damage: ${formatThousands(this.bonusDotDamage)}<br />Pet damage: ${formatThousands(this.darkglareDamage)}<br />Percentage of total damage done: ${this.owner.formatItemDamageDone(totalDamage)}`}
+          value={this.owner.formatItemDamageDone(totalDamage)}
+          valueTooltip={`Damage from extended dots: ${formatThousands(this.bonusDotDamage)} (${this.owner.formatItemDamageDone(this.bonusDotDamage)})<br />
+                        Pet damage: ${formatThousands(this.darkglareDamage)} (${this.owner.formatItemDamageDone(this.darkglareDamage)})<br />
+                        Combined damage: ${formatThousands(totalDamage)}`}
         />
       </StatisticsListBox>
     );

--- a/src/parser/warlock/affliction/modules/features/DotUptimes/UnstableAfflictionUptime.js
+++ b/src/parser/warlock/affliction/modules/features/DotUptimes/UnstableAfflictionUptime.js
@@ -93,7 +93,7 @@ class UnstableAfflictionUptime extends Analyzer {
       <StatisticListBoxItem
         title={<><SpellLink id={SPELLS.UNSTABLE_AFFLICTION_CAST.id} /> uptime</>}
         value={`${formatPercentage(this.uptime)} %`}
-        valueTooltip={`Bonus damage from internal Contagion effect: ${formatThousands(this.damage)}`}
+        valueTooltip={`Bonus damage from internal Contagion effect: ${formatThousands(this.damage)} (${this.owner.formatItemDamageDone(this.damage)})`}
       />
     );
   }

--- a/src/parser/warlock/affliction/modules/talents/AbsoluteCorruption.js
+++ b/src/parser/warlock/affliction/modules/talents/AbsoluteCorruption.js
@@ -33,8 +33,9 @@ class AbsoluteCorruption extends Analyzer {
     return (
       <StatisticListBoxItem
         title={<><SpellLink id={SPELLS.ABSOLUTE_CORRUPTION_TALENT.id} /> bonus damage</>}
-        value={formatThousands(this.bonusDmg)}
-        valueTooltip={`${this.owner.formatItemDamageDone(this.bonusDmg)}<br /><br />Note: This only accounts for the passive 15% increased damage of Corruption. Actual bonus damage should be higher due to saved GCDs.`}
+        value={this.owner.formatItemDamageDone(this.bonusDmg)}
+        valueTooltip={`${formatThousands(this.bonusDmg)} bonus damage<br /><br />
+                      Note: This only accounts for the passive 15% increased damage of Corruption. Actual bonus damage should be higher due to saved GCDs.`}
       />
     );
   }

--- a/src/parser/warlock/affliction/modules/talents/Deathbolt.js
+++ b/src/parser/warlock/affliction/modules/talents/Deathbolt.js
@@ -27,7 +27,7 @@ class Deathbolt extends Analyzer {
       <StatisticListBoxItem
         title={<>Average <SpellLink id={SPELLS.DEATHBOLT_TALENT.id} /> damage</>}
         value={formatThousands(avg)}
-        valueTooltip={`${this.owner.formatItemDamageDone(total)}<br />Total damage done with Deathbolt: ${formatThousands(total)}`}
+        valueTooltip={`Total damage done with Deathbolt: ${formatThousands(total)} (${this.owner.formatItemDamageDone(total)})`}
       />
     );
   }

--- a/src/parser/warlock/affliction/modules/talents/DrainSoul.js
+++ b/src/parser/warlock/affliction/modules/talents/DrainSoul.js
@@ -106,8 +106,8 @@ class DrainSoul extends Analyzer {
       <>
         <StatisticListBoxItem
           title={<><SpellLink id={SPELLS.DRAIN_SOUL_TALENT.id} /> damage</>}
-          value={formatThousands(damage)}
-          valueTooltip={this.owner.formatItemDamageDone(damage)}
+          value={this.owner.formatItemDamageDone(damage)}
+          valueTooltip={`${formatThousands(damage)} damage`}
         />
         <StatisticListBoxItem
           title={<>Shards sniped with <SpellLink id={SPELLS.DRAIN_SOUL_TALENT.id} /></>}

--- a/src/parser/warlock/affliction/modules/talents/Haunt.js
+++ b/src/parser/warlock/affliction/modules/talents/Haunt.js
@@ -89,8 +89,8 @@ class Haunt extends Analyzer {
         />
         <StatisticListBoxItem
           title={<><SpellLink id={SPELLS.HAUNT_TALENT.id} /> bonus damage</>}
-          value={formatThousands(this.bonusDmg)}
-          valueTooltip={`${this.owner.formatItemDamageDone(this.bonusDmg)}<br />You buffed ${formatPercentage(buffedTicksPercentage)} % of your Unstable Affliction ticks with Haunt.`}
+          value={this.owner.formatItemDamageDone(this.bonusDmg)}
+          valueTooltip={`${formatThousands(this.bonusDmg)} bonus damage<br />You buffed ${formatPercentage(buffedTicksPercentage)} % of your Unstable Affliction ticks with Haunt.`}
         />
       </>
     );

--- a/src/parser/warlock/affliction/modules/talents/PhantomSingularity.js
+++ b/src/parser/warlock/affliction/modules/talents/PhantomSingularity.js
@@ -25,8 +25,8 @@ class PhantomSingularity extends Analyzer {
     return (
       <StatisticListBoxItem
         title={<><SpellLink id={SPELLS.PHANTOM_SINGULARITY_TALENT.id} /> damage</>}
-        value={formatThousands(damage)}
-        valueTooltip={this.owner.formatItemDamageDone(damage)}
+        value={this.owner.formatItemDamageDone(damage)}
+        valueTooltip={`${formatThousands(damage)} damage`}
       />
     );
   }

--- a/src/parser/warlock/affliction/modules/talents/ShadowEmbrace.js
+++ b/src/parser/warlock/affliction/modules/talents/ShadowEmbrace.js
@@ -125,8 +125,8 @@ class ShadowEmbrace extends Analyzer {
         />
         <StatisticListBoxItem
           title={<><SpellLink id={SPELLS.SHADOW_EMBRACE_TALENT.id} /> bonus damage</>}
-          value={formatThousands(this.damage)}
-          valueTooltip={this.owner.formatItemDamageDone(this.damage)}
+          value={this.owner.formatItemDamageDone(this.damage)}
+          valueTooltip={`${formatThousands(this.damage)} bonus damage`}
         />
       </>
     );

--- a/src/parser/warlock/affliction/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/affliction/modules/talents/SoulConduit.js
@@ -43,7 +43,8 @@ class SoulConduit extends Analyzer {
       <StatisticListBoxItem
         title={<>Shards generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}
         value={shardsGained}
-        valueTooltip={`Estimated damage: ${formatThousands(estimatedUAdamage)} - ${this.owner.formatItemDamageDone(estimatedUAdamage)} <br />This result is estimated by multiplying number of Soul Shards gained from this talent by the average Unstable Affliction damage for the whole fight.`}
+        valueTooltip={`Estimated damage: ${formatThousands(estimatedUAdamage)} (${this.owner.formatItemDamageDone(estimatedUAdamage)})<br />
+                      This result is estimated by multiplying number of Soul Shards gained from this talent by the average Unstable Affliction damage for the whole fight.`}
       />
     );
   }

--- a/src/parser/warlock/affliction/modules/talents/VileTaint.js
+++ b/src/parser/warlock/affliction/modules/talents/VileTaint.js
@@ -62,8 +62,8 @@ class VileTaint extends Analyzer {
     return (
       <StatisticListBoxItem
         title={<><SpellLink id={SPELLS.VILE_TAINT_TALENT.id} /> damage</>}
-        value={formatThousands(damage)}
-        valueTooltip={`${this.owner.formatItemDamageDone(damage)}<br />
+        value={this.owner.formatItemDamageDone(damage)}
+        valueTooltip={`${formatThousands(damage)} damage<br />
           Average targets hit: ${averageTargetsHit.toFixed(2)}`}
       />
     );

--- a/src/parser/warlock/demonology/CHANGELOG.js
+++ b/src/parser/warlock/demonology/CHANGELOG.js
@@ -6,6 +6,11 @@ import SPELLS from 'common/SPELLS';
 
 export default [
   {
+    date: new Date('2018-12-23'),
+    changes: 'Changed display of damage in various places. Now shows % of total damage done and DPS with raw values in tooltip.',
+    contributors: [Chizu],
+  },
+  {
     date: new Date('2018-12-10'),
     changes: 'Updated for patch 8.1 changes.',
     contributors: [Chizu],

--- a/src/parser/warlock/demonology/modules/azerite/UmbralBlaze.js
+++ b/src/parser/warlock/demonology/modules/azerite/UmbralBlaze.js
@@ -32,7 +32,7 @@ class UmbralBlaze extends Analyzer {
       <TraitStatisticBox
         trait={SPELLS.UMBRAL_BLAZE.id}
         value={<ItemDamageDone amount={this.damage} />}
-        tooltip={`Umbral Blaze damage: ${formatThousands(this.damage)}`}
+        tooltip={`${formatThousands(this.damage)} damage`}
       />
     );
   }

--- a/src/parser/warlock/demonology/modules/talents/BilescourgeBombers.js
+++ b/src/parser/warlock/demonology/modules/talents/BilescourgeBombers.js
@@ -25,9 +25,9 @@ class BilescourgeBombers extends Analyzer {
   subStatistic() {
     return (
       <StatisticListBoxItem
-        title={<><SpellLink id={SPELLS.BILESCOURGE_BOMBERS_TALENT.id} /> damage</>}
-        value={formatThousands(this.damage)}
-        valueTooltip={this.owner.formatItemDamageDone(this.damage)}
+        title={<><SpellLink id={SPELLS.BILESCOURGE_BOMBERS_TALENT.id} /> dmg</>}
+        value={this.owner.formatItemDamageDone(this.damage)}
+        valueTooltip={`${formatThousands(this.damage)} damage`}
       />
     );
   }

--- a/src/parser/warlock/demonology/modules/talents/DemonicConsumption.js
+++ b/src/parser/warlock/demonology/modules/talents/DemonicConsumption.js
@@ -45,9 +45,9 @@ class DemonicConsumption extends Analyzer {
   subStatistic() {
     return (
       <StatisticListBoxItem
-        title={<>Bonus <SpellLink id={SPELLS.DEMONIC_CONSUMPTION_TALENT.id} /> damage</>}
-        value={formatThousands(this.damage)}
-        valueTooltip={this.owner.formatItemDamageDone(this.damage)}
+        title={<>Bonus <SpellLink id={SPELLS.DEMONIC_CONSUMPTION_TALENT.id} /> dmg</>}
+        value={this.owner.formatItemDamageDone(this.damage)}
+        valueTooltip={`${formatThousands(this.damage)} damage`}
       />
     );
   }

--- a/src/parser/warlock/demonology/modules/talents/DemonicStrength.js
+++ b/src/parser/warlock/demonology/modules/talents/DemonicStrength.js
@@ -52,9 +52,9 @@ class DemonicStrength extends Analyzer {
   subStatistic() {
     return (
       <StatisticListBoxItem
-        title={<><SpellLink id={SPELLS.DEMONIC_STRENGTH_TALENT.id} /> Felstorm damage</>}
-        value={formatThousands(this.damage)}
-        valueTooltip={this.owner.formatItemDamageDone(this.damage)}
+        title={<><SpellLink id={SPELLS.DEMONIC_STRENGTH_TALENT.id} /> Felstorm dmg</>}
+        value={this.owner.formatItemDamageDone(this.damage)}
+        valueTooltip={`${formatThousands(this.damage)} damage`}
       />
     );
   }

--- a/src/parser/warlock/demonology/modules/talents/Doom.js
+++ b/src/parser/warlock/demonology/modules/talents/Doom.js
@@ -58,9 +58,9 @@ class Doom extends Analyzer {
     return (
       <>
         <StatisticListBoxItem
-          title={<><SpellLink id={SPELLS.DOOM_TALENT.id} /> damage</>}
-          value={formatThousands(this.damage)}
-          valueTooltip={this.owner.formatItemDamageDone(this.damage)}
+          title={<><SpellLink id={SPELLS.DOOM_TALENT.id} /> dmg</>}
+          value={this.owner.formatItemDamageDone(this.damage)}
+          valueTooltip={`${formatThousands(this.damage)} damage`}
         />
         <StatisticListBoxItem
           title={<><SpellLink id={SPELLS.DOOM_TALENT.id} /> uptime</>}

--- a/src/parser/warlock/demonology/modules/talents/Dreadlash.js
+++ b/src/parser/warlock/demonology/modules/talents/Dreadlash.js
@@ -46,11 +46,11 @@ class Dreadlash extends Analyzer {
     const total = this.cleavedDamage + this.bonusDamage;
     return (
       <StatisticListBoxItem
-        title={<>Bonus <SpellLink id={SPELLS.DREADLASH_TALENT.id} /> damage</>}
-        value={formatThousands(total)}
-        valueTooltip={`${this.owner.formatItemDamageDone(total)}<br/>
-                      Bonus damage on primary target hits: ${formatThousands(this.bonusDamage)}<br/>
-                      Bonus cleaved damage: ${formatThousands(this.cleavedDamage)}`}
+        title={<><SpellLink id={SPELLS.DREADLASH_TALENT.id} /> bonus dmg</>}
+        value={this.owner.formatItemDamageDone(total)}
+        valueTooltip={`${formatThousands(total)} bonus damage<br/>
+                      Bonus damage on primary target hits: ${formatThousands(this.bonusDamage)} (${this.owner.formatItemDamageDone(this.bonusDamage)})<br/>
+                      Bonus cleaved damage: ${formatThousands(this.cleavedDamage)} (${this.owner.formatItemDamageDone(this.cleavedDamage)})`}
       />
     );
   }

--- a/src/parser/warlock/demonology/modules/talents/FromTheShadows.js
+++ b/src/parser/warlock/demonology/modules/talents/FromTheShadows.js
@@ -40,9 +40,9 @@ class FromTheShadows extends Analyzer {
   subStatistic() {
     return (
       <StatisticListBoxItem
-        title={<><SpellLink id={SPELLS.FROM_THE_SHADOWS_TALENT.id} /> bonus damage</>}
-        value={formatThousands(this.damage)}
-        valueTooltip={this.owner.formatItemDamageDone(this.damage)}
+        title={<><SpellLink id={SPELLS.FROM_THE_SHADOWS_TALENT.id} /> bonus dmg</>}
+        value={this.owner.formatItemDamageDone(this.damage)}
+        valueTooltip={`${formatThousands(this.damage)} bonus damage`}
       />
     );
   }

--- a/src/parser/warlock/demonology/modules/talents/GrimoireFelguard.js
+++ b/src/parser/warlock/demonology/modules/talents/GrimoireFelguard.js
@@ -28,9 +28,9 @@ class GrimoireFelguard extends Analyzer {
     const damage = this.demoPets.getPetDamage(PETS.GRIMOIRE_FELGUARD.guid);
     return (
       <StatisticListBoxItem
-        title={<><SpellLink id={SPELLS.GRIMOIRE_FELGUARD_TALENT.id} /> damage</>}
-        value={formatThousands(damage)}
-        valueTooltip={this.owner.formatItemDamageDone(damage)}
+        title={<><SpellLink id={SPELLS.GRIMOIRE_FELGUARD_TALENT.id} /> dmg</>}
+        value={this.owner.formatItemDamageDone(damage)}
+        valueTooltip={`${formatThousands(damage)} damage`}
       />
     );
   }

--- a/src/parser/warlock/demonology/modules/talents/InnerDemons.js
+++ b/src/parser/warlock/demonology/modules/talents/InnerDemons.js
@@ -35,9 +35,9 @@ class InnerDemons extends Analyzer {
     const damage = this.damage;
     return (
       <StatisticListBoxItem
-        title={<><SpellLink id={SPELLS.INNER_DEMONS_TALENT.id} /> damage</>}
-        value={formatThousands(damage)}
-        valueTooltip={`${this.owner.formatItemDamageDone(damage)}<br />
+        title={<><SpellLink id={SPELLS.INNER_DEMONS_TALENT.id} /> dmg</>}
+        value={this.owner.formatItemDamageDone(damage)}
+        valueTooltip={`${formatThousands(damage)} damage<br />
                   Note that this only counts the direct damage from them, not Implosion damage (if used) from Wild Imps`}
       />
     );

--- a/src/parser/warlock/demonology/modules/talents/NetherPortal.js
+++ b/src/parser/warlock/demonology/modules/talents/NetherPortal.js
@@ -31,9 +31,9 @@ class NetherPortal extends Analyzer {
     const damage = this.damage;
     return (
       <StatisticListBoxItem
-        title={<><SpellLink id={SPELLS.NETHER_PORTAL_TALENT.id} /> damage</>}
-        value={formatThousands(damage)}
-        valueTooltip={this.owner.formatItemDamageDone(damage)}
+        title={<><SpellLink id={SPELLS.NETHER_PORTAL_TALENT.id} /> dmg</>}
+        value={this.owner.formatItemDamageDone(damage)}
+        valueTooltip={`${formatThousands(damage)} damage`}
       />
     );
   }

--- a/src/parser/warlock/demonology/modules/talents/SacrificedSouls.js
+++ b/src/parser/warlock/demonology/modules/talents/SacrificedSouls.js
@@ -82,11 +82,11 @@ class SacrificedSouls extends Analyzer {
     }
     return (
       <StatisticListBoxItem
-        title={<><SpellLink id={SPELLS.SACRIFICED_SOULS_TALENT.id} /> bonus damage</>}
-        value={`${formatThousands(this.totalBonusDamage)}${hasPS ? '*' : ''}`}
-        valueTooltip={`${this.owner.formatItemDamageDone(this.totalBonusDamage)}<br />
-                  Bonus Shadow Bolt damage: ${formatThousands(this._shadowBoltDamage)}<br />
-                  Bonus Demonbolt damage: ${formatThousands(this._demonboltDamage)}
+        title={<><SpellLink id={SPELLS.SACRIFICED_SOULS_TALENT.id} /> bonus dmg</>}
+        value={`${this.owner.formatItemDamageDone(this.totalBonusDamage)}${hasPS ? '*' : ''}`}
+        valueTooltip={`${formatThousands(this.totalBonusDamage)} bonus damage<br />
+                  Bonus Shadow Bolt damage: ${formatThousands(this._shadowBoltDamage)} (${this.owner.formatItemDamageDone(this._shadowBoltDamage)})<br />
+                  Bonus Demonbolt damage: ${formatThousands(this._demonboltDamage)} (${this.owner.formatItemDamageDone(this._demonboltDamage)})
                   ${powerSiphonTooltip}`}
       />
     );

--- a/src/parser/warlock/demonology/modules/talents/SoulStrike.js
+++ b/src/parser/warlock/demonology/modules/talents/SoulStrike.js
@@ -33,9 +33,9 @@ class SoulStrike extends Analyzer {
     return (
       <>
         <StatisticListBoxItem
-          title={<><SpellLink id={SPELLS.SOUL_STRIKE_TALENT.id} /> damage</>}
-          value={formatThousands(this.damage)}
-          valueTooltip={this.owner.formatItemDamageDone(this.damage)}
+          title={<><SpellLink id={SPELLS.SOUL_STRIKE_TALENT.id} /> dmg</>}
+          value={this.owner.formatItemDamageDone(this.damage)}
+          valueTooltip={`${formatThousands(this.damage)} damage`}
         />
         <StatisticListBoxItem
           title={<>Shards generated with <SpellLink id={SPELLS.SOUL_STRIKE_TALENT.id} /></>}

--- a/src/parser/warlock/demonology/modules/talents/SummonVilefiend.js
+++ b/src/parser/warlock/demonology/modules/talents/SummonVilefiend.js
@@ -27,9 +27,9 @@ class SummonVilefiend extends Analyzer {
     const damage = this.demoPets.getPetDamage(PETS.VILEFIEND.guid);
     return (
       <StatisticListBoxItem
-        title={<><SpellLink id={SPELLS.SUMMON_VILEFIEND_TALENT.id} /> damage</>}
-        value={formatThousands(damage)}
-        valueTooltip={this.owner.formatItemDamageDone(damage)}
+        title={<><SpellLink id={SPELLS.SUMMON_VILEFIEND_TALENT.id} /> dmg</>}
+        value={this.owner.formatItemDamageDone(damage)}
+        valueTooltip={`${formatThousands(damage)} damage`}
       />
     );
   }

--- a/src/parser/warlock/destruction/CHANGELOG.js
+++ b/src/parser/warlock/destruction/CHANGELOG.js
@@ -7,6 +7,11 @@ import SPELLS from 'common/SPELLS';
 
 export default [
   {
+    date: new Date('2018-12-23'),
+    changes: 'Changed display of damage in various places. Now shows % of total damage done and DPS with raw values in tooltip.',
+    contributors: [Chizu],
+  },
+  {
     date: new Date('2018-11-12'),
     changes: 'Certain buffs or debuffs now show in timeline.',
     contributors: [Chizu],

--- a/src/parser/warlock/destruction/modules/features/Havoc.js
+++ b/src/parser/warlock/destruction/modules/features/Havoc.js
@@ -6,7 +6,7 @@ import Events from 'parser/core/Events';
 
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
-import { formatNumber, formatPercentage } from 'common/format';
+import { formatThousands } from 'common/format';
 
 import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 
@@ -40,9 +40,10 @@ class Havoc extends Analyzer {
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.HAVOC.id} />}
-        value={`${formatNumber(this.damage / this.owner.fightDuration * 1000)} DPS`}
+        value={this.owner.formatItemDamageDone(this.damage)}
         label="Damage cleaved"
-        tooltip={`You cleaved ${formatNumber(this.damage)} damage (${formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.damage))} %) to targets afflicted by your Havoc.<br /><br />Note: This number might be higher than it should be, as it also counts the damage you did directly to the Havoc target (not just the cleaved damage).`}
+        tooltip={`You cleaved ${formatThousands(this.damage)} damage to targets afflicted by your Havoc.<br /><br />
+                Note: This number is probably higher than it should be, as it also counts the damage you did directly to the Havoc target (not just the cleaved damage).`}
       />
     );
   }

--- a/src/parser/warlock/destruction/modules/talents/Cataclysm.js
+++ b/src/parser/warlock/destruction/modules/talents/Cataclysm.js
@@ -61,8 +61,8 @@ class Cataclysm extends Analyzer {
     return (
       <StatisticListBoxItem
         title={<><SpellLink id={SPELLS.CATACLYSM_TALENT.id} /> damage</>}
-        value={formatThousands(damage)}
-        valueTooltip={`${this.owner.formatItemDamageDone(damage)}<br />
+        value={this.owner.formatItemDamageDone(damage)}
+        valueTooltip={`${formatThousands(damage)} damage<br />
           Average targets hit: ${averageTargetsHit.toFixed(2)}`}
       />
     );

--- a/src/parser/warlock/destruction/modules/talents/ChannelDemonfire.js
+++ b/src/parser/warlock/destruction/modules/talents/ChannelDemonfire.js
@@ -31,8 +31,8 @@ class ChannelDemonfire extends Analyzer {
     return (
       <StatisticListBoxItem
         title={<><SpellLink id={SPELLS.CHANNEL_DEMONFIRE_TALENT.id} /> damage</>}
-        value={formatThousands(this.damage)}
-        valueTooltip={this.owner.formatItemDamageDone(this.damage)}
+        value={this.owner.formatItemDamageDone(this.damage)}
+        valueTooltip={`${formatThousands(this.damage)} damage`}
       />
     );
   }

--- a/src/parser/warlock/destruction/modules/talents/Flashover.js
+++ b/src/parser/warlock/destruction/modules/talents/Flashover.js
@@ -64,8 +64,8 @@ class Flashover extends Analyzer {
       <>
         <StatisticListBoxItem
           title={<><SpellLink id={SPELLS.FLASHOVER_TALENT.id} /> bonus damage</>}
-          value={formatThousands(this.damage)}
-          valueTooltip={this.owner.formatItemDamageDone(this.damage)}
+          value={this.owner.formatItemDamageDone(this.damage)}
+          valueTooltip={`${formatThousands(this.damage)} bonus damage`}
         />
         <StatisticListBoxItem
           title={<>Bonus <SpellLink id={SPELLS.BACKDRAFT.id} /> stacks from <SpellLink id={SPELLS.FLASHOVER_TALENT.id} /></>}

--- a/src/parser/warlock/destruction/modules/talents/InternalCombustion.js
+++ b/src/parser/warlock/destruction/modules/talents/InternalCombustion.js
@@ -30,8 +30,8 @@ class InternalCombustion extends Analyzer {
     return (
       <StatisticListBoxItem
         title={<><SpellLink id={SPELLS.INTERNAL_COMBUSTION_TALENT.id} /> damage</>}
-        value={formatThousands(this.damage)}
-        valueTooltip={this.owner.formatItemDamageDone(this.damage)}
+        value={this.owner.formatItemDamageDone(this.damage)}
+        valueTooltip={`${formatThousands(this.damage)} damage`}
       />
     );
   }

--- a/src/parser/warlock/destruction/modules/talents/RoaringBlaze.js
+++ b/src/parser/warlock/destruction/modules/talents/RoaringBlaze.js
@@ -30,8 +30,8 @@ class RoaringBlaze extends Analyzer {
     return (
       <StatisticListBoxItem
         title={<><SpellLink id={SPELLS.ROARING_BLAZE_TALENT.id} /> damage</>}
-        value={formatThousands(this.damage)}
-        valueTooltip={this.owner.formatItemDamageDone(this.damage)}
+        value={this.owner.formatItemDamageDone(this.damage)}
+        valueTooltip={`${formatThousands(this.damage)} damage`}
       />
     );
   }

--- a/src/parser/warlock/destruction/modules/talents/Shadowburn.js
+++ b/src/parser/warlock/destruction/modules/talents/Shadowburn.js
@@ -45,8 +45,8 @@ class Shadowburn extends Analyzer {
     return (
       <StatisticListBoxItem
         title={<><SpellLink id={SPELLS.SHADOWBURN_TALENT.id} /> damage</>}
-        value={formatThousands(this.damage)}
-        valueTooltip={`${this.owner.formatItemDamageDone(this.damage)}<br /><br />
+        value={this.owner.formatItemDamageDone(this.damage)}
+        valueTooltip={`${formatThousands(this.damage)} damage<br /><br />
           Shadowburn also gave you ${fragments} fragments, and if they were used on Chaos Bolts, they would deal an estimated ${formatThousands(estimatedDamage)} damage (${this.owner.formatItemDamageDone(estimatedDamage)}). This is estimated using average Chaos Bolt damage over the fight.`}
       />
     );

--- a/src/parser/warlock/destruction/modules/talents/SoulFire.js
+++ b/src/parser/warlock/destruction/modules/talents/SoulFire.js
@@ -24,8 +24,8 @@ class SoulFire extends Analyzer {
     return (
       <StatisticListBoxItem
         title={<><SpellLink id={SPELLS.SOUL_FIRE_TALENT.id} /> damage</>}
-        value={formatThousands(damage)}
-        valueTooltip={this.owner.formatItemDamageDone(damage)}
+        value={this.owner.formatItemDamageDone(damage)}
+        valueTooltip={`${formatThousands(damage)} damage`}
       />
     );
   }


### PR DESCRIPTION
I figured showing raw damage in all places doesn't really put it into perspective as much, so instead of showing that + percentage and DPS in tooltips, I switched it. Now it shows percentage and DPS and raw damage values in tooltip. This makes it easier to judge how good a talent or spell was. The diff is a little ugly but nothing besides text should be changed. 

### Affliction
Before:
![image](https://user-images.githubusercontent.com/5068584/50383308-346c4680-06b1-11e9-8267-5e85f0db08aa.png)

After:
![image](https://user-images.githubusercontent.com/5068584/50383304-1d2d5900-06b1-11e9-98e2-3bc383406922.png)

### Demonology
Before:
![image](https://user-images.githubusercontent.com/5068584/50383310-536ad880-06b1-11e9-9172-df180ead42ca.png)

After:
![image](https://user-images.githubusercontent.com/5068584/50383327-89a85800-06b1-11e9-9b32-7d13c64ae38b.png)

### Destruction
Before: 
![image](https://user-images.githubusercontent.com/5068584/50383316-67aed580-06b1-11e9-8f23-be7ae5b2a234.png)

After:
![image](https://user-images.githubusercontent.com/5068584/50383322-7b5a3c00-06b1-11e9-8d27-94ccfd51ab55.png)
