### PR TITLE
[BrM] Implementing methods to calculate Agility's dodge/stagger mitigation

### DIFF
--- a/src/parser/monk/brewmaster/CombatLogParser.js
+++ b/src/parser/monk/brewmaster/CombatLogParser.js
@@ -11,6 +11,7 @@ import StaggerFabricator from './modules/core/StaggerFabricator';
 import GlobalCooldown from './modules/core/GlobalCooldown';
 import Channeling from './modules/core/Channeling';
 import MasteryValue from './modules/core/MasteryValue';
+import AgilityValue from './modules/features/AgilityValue';
 // Spells
 import IronSkinBrew from './modules/spells/IronSkinBrew';
 import PurifyingBrew from './modules/spells/PurifyingBrew';
@@ -53,6 +54,7 @@ class CombatLogParser extends CoreCombatLogParser {
     brews: SharedBrews,
     channeling: Channeling,
     globalCooldown: GlobalCooldown,
+    agilityValue: AgilityValue,
     masteryValue: MasteryValue,
     mitigationCheck: MitigationCheck,
 

--- a/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
@@ -4,6 +4,10 @@ exports[`The Brewmaster Analyzer analyzers Abilities matches the statistic snaps
 
 exports[`The Brewmaster Analyzer analyzers Abilities matches the suggestions snapshot 1`] = `"module has no suggestions"`;
 
+exports[`The Brewmaster Analyzer analyzers AgilityValue matches the statistic snapshot 1`] = `"module has no statistic method"`;
+
+exports[`The Brewmaster Analyzer analyzers AgilityValue matches the suggestions snapshot 1`] = `Array []`;
+
 exports[`The Brewmaster Analyzer analyzers AlwaysBeCasting matches the statistic snapshot 1`] = `
 <div
   className="col-lg-3 col-md-4 col-sm-6 col-xs-12"

--- a/src/parser/monk/brewmaster/modules/constants/Mitigation.js
+++ b/src/parser/monk/brewmaster/modules/constants/Mitigation.js
@@ -1,0 +1,16 @@
+// K is a constant that attenuates the diminishing return formula,
+// giving lower damage reduction on higher difficulties.
+export const ULDIR_K = [
+  null, // unknown difficulty
+  6300, // LFR --- using world K
+  null, // unknown
+  7736.4, // Normal
+  8467.2, // Heroic
+  9311.4, // Mythic
+];
+
+export const MPLUS_K = 7100.1;
+
+export function diminish(stat, K) {
+  return stat / (stat + K);
+}

--- a/src/parser/monk/brewmaster/modules/features/AgilityValue.js
+++ b/src/parser/monk/brewmaster/modules/features/AgilityValue.js
@@ -1,0 +1,90 @@
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import StatTracker from 'parser/shared/modules/StatTracker';
+import SPELLS from 'common/SPELLS';
+
+import { diminish, ULDIR_K, MPLUS_K } from '../constants/Mitigation';
+import { EVENT_STAGGER_POOL_ADDED, EVENT_STAGGER_POOL_REMOVED } from '../core/StaggerFabricator';
+
+export const BASE_AGI = 1450; // based on my panda monk, TODO get actual base value
+
+const STAGGER_COEFFS = {
+  base: 1.05,
+  isb: 3.7,
+  ht: 1.4,
+};
+
+export function staggerPct(agi, K, hasIsb, hasHT) {
+  const rating = agi * STAGGER_COEFFS.base * (hasIsb ? STAGGER_COEFFS.isb : 1) * (hasHT ? STAGGER_COEFFS.ht : 1);
+  return diminish(rating, K);
+}
+
+/**
+ * Calculates the amount of damage staggered & purified due to agility.
+ */
+export default class AgilityValue extends Analyzer {
+  static dependencies = {
+    stats: StatTracker,
+  };
+
+  K = 0;
+
+  totalAgiStaggered = 0;
+  totalAgiPurified = 0;
+
+  _agiDamagePooled = 0;
+  _hasHT = false;
+
+  constructor(...args) {
+    super(...args);
+
+    this._hasHT = this.selectedCombatant.hasTalent(SPELLS.HIGH_TOLERANCE_TALENT.id);
+
+    const fight = this.owner.fight;
+    if(fight.size === 5) {
+      this.K = MPLUS_K;
+    } else {
+      this.K = ULDIR_K[fight.difficulty];
+    };
+
+    this.addEventListener(EVENT_STAGGER_POOL_ADDED, this._onStaggerGained);
+    this.addEventListener(EVENT_STAGGER_POOL_REMOVED, this._onPurify);
+    this.addEventListener(EVENT_STAGGER_POOL_REMOVED, this._onStaggerTick);
+    this.addEventListener(Events.death.by(SELECTED_PLAYER), this._onDeath);
+  }
+
+  get _hasIsb() {
+    return this.selectedCombatant.hasBuff(SPELLS.IRONSKIN_BREW_BUFF.id);
+  }
+
+  _onDeath(event) {
+    this._agiDamagePooled = 0;
+  }
+
+  _onPurify(event) {
+    if(event.trigger.type !== 'death' && event.trigger.ability.guid === SPELLS.STAGGER_TAKEN.id) {
+      return;
+    }
+
+    const amount = Math.min(this._agiDamagePooled, event.amount);
+    this._agiDamagePooled -= amount;
+    this.totalAgiPurified += amount;
+  }
+
+  _onStaggerTick(event) {
+    if(event.trigger.type !== 'death' && event.trigger.ability.guid !== SPELLS.STAGGER_TAKEN.id) {
+      return;
+    }
+
+    this._agiDamagePooled = Math.max(this._agiDamagePooled - event.amount, 0);
+  }
+
+  _onStaggerGained(event) {
+    const baseStagger = staggerPct(BASE_AGI, this.K, this._hasIsb, this._hasHT);
+    const agiStagger = staggerPct(this.stats.currentAgilityRating, this.K, this._hasIsb, this._hasHT);
+    const amountAgiStaggered = (1 - baseStagger / agiStagger) * event.amount;
+
+    this.totalAgiStaggered += amountAgiStaggered;
+    this._agiDamagePooled += amountAgiStaggered;
+  }
+}


### PR DESCRIPTION
This is part of my ongoing stat-sheet project (see #2880 for more info). This contains code to evaluate mitigation attributable to agility from added purification and added dodge.

The method for calculating added dodge value is very straightforward: calculate expected amount dodged with base agi and subtract it from total expected amount dodged. This gives the amount that you dodged (approx.) due to agility gear and buffs.

The method for calculating added purification value is a bit more complex, but not too much:

1. When damage is staggered, calculate the amount of it that was staggered due to bonus agility. Add this to an "agility damage pool".
2. When the stagger DoT ticks, subtract it from the agility pool if non-empty.
3. When a purify occurs, remove damage from the agility pool equal to the amount purified (up to the total amount present). Damage removed this way is "purified due to agility."