### PR TITLE
[Demonology] Fixed crash with pet trinkets

### DIFF
--- a/src/parser/warlock/demonology/CHANGELOG.js
+++ b/src/parser/warlock/demonology/CHANGELOG.js
@@ -6,6 +6,11 @@ import SPELLS from 'common/SPELLS';
 
 export default [
   {
+    date: new Date('2018-12-29'),
+    changes: 'Fixed a bug that caused a crash when player was wearing trinket that summons pets (like Vanquished Tendril of G\'huun).',
+    contributors: [Chizu],
+  },
+  {
     date: new Date('2018-12-23'),
     changes: <>Added support for <SpellLink id={SPELLS.BALEFUL_INVOCATION.id} /> trait. Also fixed <SpellLink id={SPELLS.DEMONBOLT.id} /> icon in Soul Shard tab. </>,
     contributors: [Chizu],

--- a/src/parser/warlock/demonology/modules/pets/Timeline.js
+++ b/src/parser/warlock/demonology/modules/pets/Timeline.js
@@ -1,8 +1,7 @@
 import SPELLS from 'common/SPELLS';
 
 import { DESPAWN_REASONS } from './TimelinePet';
-import { isPermanentPet } from './helpers';
-import PETS from './PETS';
+import { isPermanentPet, isWarlockPet } from './helpers';
 
 const debug = false;
 
@@ -33,7 +32,7 @@ class Timeline {
 
   getPetsAtTimestamp(timestamp) {
     // Warlock pet check so this doesn't pick up things like Vanquished Tendrils of G'huun (trinket, spawns a pet that timeline picks up)
-    return this.timeline.filter(pet => this._isWarlockPet(pet.guid) &&
+    return this.timeline.filter(pet => isWarlockPet(pet.guid) &&
       pet.spawn <= timestamp && timestamp <= (pet.realDespawn || pet.expectedDespawn));
   }
 
@@ -46,10 +45,6 @@ class Timeline {
       obj[key].pets.push(pet);
       return obj;
     }, {});
-  }
-
-  _isWarlockPet(guid) {
-    return isPermanentPet(guid) || !!PETS[guid];
   }
 }
 

--- a/src/parser/warlock/demonology/modules/pets/helpers.js
+++ b/src/parser/warlock/demonology/modules/pets/helpers.js
@@ -2,4 +2,5 @@ import PETS from './PETS';
 
 export const isPermanentPet = guid => guid.toString().length > 6;
 export const isWildImp = guid => guid === PETS.WILD_IMP_HOG.guid || guid === PETS.WILD_IMP_INNER_DEMONS.guid;
-export const isRandomPet = guid => !isPermanentPet(guid) && PETS[guid].isRandom;
+export const isRandomPet = guid => isWarlockPet(guid) && !isPermanentPet(guid) && PETS[guid].isRandom;
+export const isWarlockPet = guid => isPermanentPet(guid) || !!PETS[guid];


### PR DESCRIPTION
Fixes a crash in Demonology Warlock when player has trinket or anything, that summons pets (like Vanquished Tendril of G'huun)