### PR TITLE
[Prot Paladin] fixed m+ crash with SotR module

### DIFF
--- a/src/parser/paladin/protection/modules/features/ShieldOfTheRighteous.js
+++ b/src/parser/paladin/protection/modules/features/ShieldOfTheRighteous.js
@@ -48,8 +48,11 @@ class ShieldOfTheRighteous extends Analyzer {
 
   constructor(...args) {
     super(...args);
-    const boss = findByBossId(this.owner.boss.id);
-    this._tankbusters = boss.fight.softMitigationChecks.physical;
+    // M+ doesn't have a boss prop
+    if(this.owner.boss) {
+      const boss = findByBossId(this.owner.boss.id);
+      this._tankbusters = boss.fight.softMitigationChecks.physical;
+    }
   }
 
   _partialCharge() {


### PR DESCRIPTION
[Crashing log](https://www.wowanalyzer.com/report/JMZXyh6qjgKWtV7w/1-+Atal'Dazar+-+Kill+(37:38)/4-Aurovin)

`this.owner` does not have a `boss` prop in M+ logs.