### PR TITLE
[Fury Warrior] Missing Spell ID for Execute

### DIFF
--- a/src/common/SPELLS/warrior.js
+++ b/src/common/SPELLS/warrior.js
@@ -202,6 +202,11 @@ export default {
     name: 'Execute',
     icon: 'inv_sword_48',
   },
+  EXECUTE_FURY_MASSACRE: {
+    id: 280735,
+    name: 'Execute',
+    icon: 'inv_sword_48',
+  },
   EXECUTE_DAMAGE_FURY: {
     id: 280849,
     name: 'Execute',

--- a/src/parser/warrior/fury/modules/Abilities.js
+++ b/src/parser/warrior/fury/modules/Abilities.js
@@ -41,7 +41,7 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.EXECUTE_FURY,
+        spell: [SPELLS.EXECUTE_FURY, SPELLS.EXECUTE_FURY_MASSACRE],
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         cooldown: haste => 6 / (1 + haste),
         gcd: {

--- a/src/parser/warrior/fury/modules/features/SpellUsable.js
+++ b/src/parser/warrior/fury/modules/features/SpellUsable.js
@@ -1,6 +1,8 @@
 import SPELLS from 'common/SPELLS';
 import CoreSpellUsable from 'parser/shared/modules/SpellUsable';
 
+const FURY_EXECUTES = [SPELLS.EXECUTE_FURY.id, SPELLS.EXECUTE_FURY_MASSACRE.id];
+
 class SpellUsable extends CoreSpellUsable {
   static dependencies = {
     ...CoreSpellUsable.dependencies,
@@ -27,7 +29,7 @@ class SpellUsable extends CoreSpellUsable {
       this.lastPotentialTriggerForRagingBlow = event;
     }
 
-    if (spellId === SPELLS.EXECUTE_FURY.id) {
+    if (FURY_EXECUTES.includes(spellId)) {
       this.lastExecute = event.timestamp;
     }
   }
@@ -39,7 +41,7 @@ class SpellUsable extends CoreSpellUsable {
         this.endCooldown(spellId, undefined, this.lastPotentialTriggerForRagingBlow ? this.lastPotentialTriggerForRagingBlow.timestamp : undefined);
       }
     }
-    if (this.hasSuddenDeath && spellId === SPELLS.EXECUTE_FURY.id) {
+    if (this.hasSuddenDeath && FURY_EXECUTES.includes(spellId)) {
       if (this.isOnCooldown(spellId)) {
         this.executeCdrEvents[this.lastExecute] = this.cooldownRemaining(spellId);
         this.endCooldown(spellId);

--- a/src/parser/warrior/fury/modules/talents/SuddenDeath.js
+++ b/src/parser/warrior/fury/modules/talents/SuddenDeath.js
@@ -35,7 +35,7 @@ class SuddenDeath extends Analyzer {
       return;
     }
 
-    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.EXECUTE_FURY), this.onExecuteCast);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell([SPELLS.EXECUTE_FURY, SPELLS.EXECUTE_FURY_MASSACRE]), this.onExecuteCast);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell([SPELLS.EXECUTE_DAMAGE_FURY, SPELLS.EXECUTE_DAMAGE_OH_FURY]), this.onExecuteDamage);
     this.addEventListener(Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.SUDDEN_DEATH_TALENT_FURY_BUFF), this.onSuddenDeathProc);
     this.addEventListener(Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.SUDDEN_DEATH_TALENT_FURY_BUFF), this.onSuddenDeathProc);


### PR DESCRIPTION
When talented into Massacre, Execute has a different spell id and this was missing in a few places