### PR TITLE
[Fury Warrior] Fixed SpellUseable issue for Fury

### DIFF
--- a/src/parser/warrior/fury/CombatLogParser.js
+++ b/src/parser/warrior/fury/CombatLogParser.js
@@ -8,6 +8,8 @@ import Checklist from './modules/features/checklist/Module';
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
 import SpellUsable from './modules/features/SpellUsable';
 
+import EnrageNormalizer from './modules/normalizers/Enrage';
+
 import Enrage from './modules/buffdebuff/Enrage';
 
 import MissedRampage from './modules/spells/MissedRampage';
@@ -44,6 +46,8 @@ class CombatLogParser extends CoreCombatLogParser {
     checklist: Checklist,
     cooldownThroughputTracker: CooldownThroughputTracker,
     spellUsable: SpellUsable,
+
+    enrageNormalizer: EnrageNormalizer,
 
     enrageUptime: Enrage,
 

--- a/src/parser/warrior/fury/modules/normalizers/Enrage.js
+++ b/src/parser/warrior/fury/modules/normalizers/Enrage.js
@@ -1,0 +1,40 @@
+import SPELLS from 'common/SPELLS';
+
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+
+class Enrage extends EventsNormalizer {
+  /**
+  * The applybuff from enrage is logged after the cast of Bloodthirst if it procs 
+  * This ensures the enrage buff comes before the cast of Bloodthirst so the haste effect of Enrage updates the GCD correctly
+  * @param {Array} events
+  * @returns {Array}
+  **/
+
+  normalize(events) {
+    const fixedEvents = [];
+    events.forEach((event, eventIndex) => {
+      fixedEvents.push(event);
+
+      if(event.type === 'applybuff' && event.ability.guid === SPELLS.ENRAGE.id) {
+        const castTimestamp = event.timestamp;
+
+        for (let previousEventIndex = eventIndex; previousEventIndex >= 0; previousEventIndex -= 1) {
+          const previousEvent = fixedEvents[previousEventIndex];
+          if ((castTimestamp - previousEvent.timestamp) > 50) {
+            break;
+          }
+          if (previousEvent.type === 'cast' && previousEvent.ability.guid === SPELLS.BLOODTHIRST.id && previousEvent.sourceID === event.sourceID) {
+            fixedEvents.splice(previousEventIndex, 1);
+            fixedEvents.push(previousEvent);
+            previousEvent.__modified = true;
+            break;
+          }
+        }
+      }
+    });
+
+    return fixedEvents;
+  }
+}
+
+export default Enrage;


### PR DESCRIPTION
When Bloodthirst triggered Enrage, the enrage event appeared after the cast and so the haste didn't effect it's GCD.