### PR TITLE
[Warrior] Missing Charge ability

### DIFF
--- a/src/parser/core/CASTS_THAT_ARENT_CASTS.js
+++ b/src/parser/core/CASTS_THAT_ARENT_CASTS.js
@@ -32,4 +32,5 @@ export default [
   SPELLS.DIRE_BEAST_SECONDARY_WITH_SCENT.id, //A secondary cast event from Dire Beast talent
   SPELLS.DIRE_BEAST_SECONDARY_WITHOUT_SCENT.id, //A secondary cast event from Dire Beast talent
   SPELLS.DIVINE_HYMN_HEAL.id, //The heal component of divine hymn
+  SPELLS.CHARGE_2.id, // The damage component of charge
 ];


### PR DESCRIPTION
Charge has a cast event for the damage event when you reach your target but was not classed as an ability. It's now been added to the Casts that aren't casts list