### PR TITLE
[Fire Mage] Fix Crash in Heating Up

### DIFF
--- a/src/parser/mage/fire/modules/features/HeatingUp.js
+++ b/src/parser/mage/fire/modules/features/HeatingUp.js
@@ -47,7 +47,7 @@ class HeatingUp extends Analyzer {
     const hasCombustion = this.selectedCombatant.hasBuff(SPELLS.COMBUSTION.id);
     const hasHotStreak = this.selectedCombatant.hasBuff(SPELLS.HOT_STREAK.id);
     const hasHeatingUp = this.selectedCombatant.hasBuff(SPELLS.HEATING_UP.id);
-    const castTarget = encodeTargetString(this.phoenixFlamesCastEvent.targetID, event.targetInstance);
+    const castTarget = this.phoenixFlamesCastEvent ? encodeTargetString(this.phoenixFlamesCastEvent.targetID, event.targetInstance) : null;
     const damageTarget = encodeTargetString(event.targetID, event.targetInstance);
     const healthPercent = event.hitPoints / event.maxHitPoints;
     if (castTarget !== damageTarget || hasHeatingUp) {


### PR DESCRIPTION
If the player casts Phoenix Flames before the pull then it crashed the module since there was no cast event in the log.