### PR TITLE
[SPriest] 8.1 & Adding Shadowfiend normalizer to shadow

### DIFF
--- a/src/common/SPELLS/priest.js
+++ b/src/common/SPELLS/priest.js
@@ -150,6 +150,11 @@ export default {
     name: 'Shadowfiend',
     icon: 'spell_shadow_shadowfiend',
   },
+  VOIDLING: {
+    id: 254232,
+    name: 'Voidling',
+    icon: 'spell_shadow_shadowfiend',
+  },
   LIGHTSPAWN: {
     id: 254224,
     name: 'Shadowfiend',

--- a/src/parser/priest/discipline/CombatLogParser.js
+++ b/src/parser/priest/discipline/CombatLogParser.js
@@ -4,7 +4,7 @@ import HealingDone from 'parser/shared/modules/HealingDone';
 
 import AtonementSuccessiveDamageNormalizer from './normalizers/AtonementSuccessiveDamage';
 import EstelNormalizer from './normalizers/EstelNormalizer';
-import ShadowfiendNormalizer from './normalizers/ShadowfiendNormalizer';
+import ShadowfiendNormalizer from '../shared/normalizers/ShadowfiendNormalizer';
 import PowerWordRadianceNormalizer from './normalizers/PowerWordRadianceNormalizer';
 
 import Abilities from './modules/Abilities';

--- a/src/parser/priest/shadow/CONFIG.js
+++ b/src/parser/priest/shadow/CONFIG.js
@@ -10,7 +10,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Khadaj],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '8.0.1',
+  patchCompatibility: '8.1.0',
   // If set to  false`, the spec will show up as unsupported.
   isSupported: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.

--- a/src/parser/priest/shadow/CombatLogParser.js
+++ b/src/parser/priest/shadow/CombatLogParser.js
@@ -35,6 +35,8 @@ import TwinsPainfulTouch from './modules/items/TwinsPainfulTouch';
 import AnundsSearedShackles from './modules/items/AnundsSearedShackles';
 import HeartOfTheVoid from './modules/items/HeartOfTheVoid';
 import ZenkaramIridisAnadem from './modules/items/ZenkaramIridisAnadem';
+// normalizers
+import ShadowfiendNormalizer from '../shared/normalizers/ShadowfiendNormalizer';
 
 class CombatLogParser extends MainCombatLogParser {
   static specModules = {
@@ -79,6 +81,8 @@ class CombatLogParser extends MainCombatLogParser {
     anundsSearedShackles: AnundsSearedShackles,
     heartOfTheVoid: HeartOfTheVoid,
     zenkaramIridisAnadem: ZenkaramIridisAnadem,
+
+    shadowfiendNormalizer: ShadowfiendNormalizer,
   };
 }
 

--- a/src/parser/priest/shadow/modules/Abilities.js
+++ b/src/parser/priest/shadow/modules/Abilities.js
@@ -136,7 +136,7 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: [SPELLS.SHADOWFIEND, SPELLS.SHADOWFIEND_WITH_GLYPH_OF_THE_SHA],
+        spell: [SPELLS.SHADOWFIEND, SPELLS.SHADOWFIEND_WITH_GLYPH_OF_THE_SHA, SPELLS.VOIDLING],
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 180,
         gcd: {

--- a/src/parser/priest/shadow/modules/spells/VampiricEmbrace.js
+++ b/src/parser/priest/shadow/modules/spells/VampiricEmbrace.js
@@ -20,7 +20,7 @@ class VampiricEmbrace extends Analyzer {
   }
 
   get healingDone() {
-    return this.abilityTracker.getAbility(SPELLS.VAMPIRIC_EMBRACE_HEAL.id).healingEffective;
+    return this.abilityTracker.getAbility(SPELLS.VAMPIRIC_EMBRACE_HEAL.id).healingEffective || 0;
   }
 
   statistic() {

--- a/src/parser/priest/shared/normalizers/ShadowfiendNormalizer.js
+++ b/src/parser/priest/shared/normalizers/ShadowfiendNormalizer.js
@@ -8,7 +8,7 @@ class ShadowfiendNormalizer extends EventsNormalizer {
     events.forEach((event, eventIndex) => {
       if (event.type === "cast") {
         const spellId = event.ability.guid;
-        if (spellId === SPELLS.SHADOWFIEND_WITH_GLYPH_OF_THE_SHA.id || spellId === SPELLS.LIGHTSPAWN.id) {
+        if (spellId === SPELLS.SHADOWFIEND_WITH_GLYPH_OF_THE_SHA.id || spellId === SPELLS.LIGHTSPAWN.id || spellId === SPELLS.VOIDLING.id) {
           event.ability.oldGuid = event.ability.guid;
           event.ability.guid = SPELLS.SHADOWFIEND.id;
           event.__modified = true;


### PR DESCRIPTION
Bumping Shadow Priest version as there were no large changes in 8.1.

Bug Fixes:

Glyphed Shadow Fiends don't currently work correctly in Shadow. I've moved the Disc shadowfiend normalizer into a shared directory and added an additional check to fix this.

Example log: /report/cajpvgQdbX2BRCWk/9-Heroic+Taloc+-+Kill+(4:19)/135-Ellipsìs

Fixed problem with Vamp Embrace