### PR TITLE
[Warlock] Probability playground

### DIFF
--- a/src/parser/warlock/affliction/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/affliction/modules/talents/SoulConduit.js
@@ -4,15 +4,17 @@ import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';
 
 import SPELLS from 'common/SPELLS';
-import { formatThousands } from 'common/format';
+import { formatPercentage, formatThousands } from 'common/format';
 import SpellLink from 'common/SpellLink';
 
 import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
 
 import { UNSTABLE_AFFLICTION_DEBUFFS } from '../../constants';
 import SoulShardTracker from '../soulshards/SoulShardTracker';
+import { binomialCDF } from 'parser/warlock/shared/probability';
 
 const TICKS_PER_UA = 4;
+const SC_PROC_CHANCE = 0.15;
 
 class SoulConduit extends Analyzer {
   static dependencies = {
@@ -39,11 +41,24 @@ class SoulConduit extends Analyzer {
     const avgDamage = this._totalUAdamage / (this._totalTicks > 0 ? this._totalTicks : 1);
     const shardsGained = this.soulShardTracker.getGeneratedBySpell(SPELLS.SOUL_CONDUIT_SHARD_GEN.id);
     const estimatedUAdamage = shardsGained * TICKS_PER_UA * avgDamage;
+    const totalSpent = this.soulShardTracker.spent;
+    // since we want to get the amount of shards we would MOST LIKELY get, we intentionally need to try higher values for k than usually possible
+    const { partial: probabilities } = binomialCDF(Math.round(totalSpent / 2), totalSpent, SC_PROC_CHANCE);
+    // with 15% chance per shard, it's very unlikely that we would get half of the shards refunded, so the maximum must be somewhere lower than that, and "partial" array of the return object contains those values
+    let maxP = 0;
+    let max = -1;
+    probabilities.forEach((p, k) => {
+      if (p > maxP) {
+        maxP = p;
+        max = k;
+      }
+    });
     return (
       <StatisticListBoxItem
         title={<>Shards generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}
         value={shardsGained}
         valueTooltip={`Estimated damage: ${formatThousands(estimatedUAdamage)} (${this.owner.formatItemDamageDone(estimatedUAdamage)})<br />
+                      You gained ${shardsGained} Soul Shards from this talent (<strong>${formatPercentage(shardsGained / max)}%</strong> of Shards you could expect in this fight.)<br />
                       This result is estimated by multiplying number of Soul Shards gained from this talent by the average Unstable Affliction damage for the whole fight.`}
       />
     );

--- a/src/parser/warlock/affliction/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/affliction/modules/talents/SoulConduit.js
@@ -9,9 +9,9 @@ import SpellLink from 'common/SpellLink';
 
 import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
 
+import { binomialCDF } from 'parser/warlock/shared/probability';
 import { UNSTABLE_AFFLICTION_DEBUFFS } from '../../constants';
 import SoulShardTracker from '../soulshards/SoulShardTracker';
-import { binomialCDF } from 'parser/warlock/shared/probability';
 
 const TICKS_PER_UA = 4;
 const SC_PROC_CHANCE = 0.15;

--- a/src/parser/warlock/affliction/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/affliction/modules/talents/SoulConduit.js
@@ -43,7 +43,7 @@ class SoulConduit extends Analyzer {
     const estimatedUAdamage = shardsGained * TICKS_PER_UA * avgDamage;
     const totalSpent = this.soulShardTracker.spent;
     // find number of Shards we were MOST LIKELY to get in the fight
-    const { k: max } = findMax(totalSpent, SC_PROC_CHANCE, binomialPMF);
+    const { max } = findMax(totalSpent, SC_PROC_CHANCE, binomialPMF);
     return (
       <StatisticListBoxItem
         title={<>Shards generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}

--- a/src/parser/warlock/affliction/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/affliction/modules/talents/SoulConduit.js
@@ -9,7 +9,7 @@ import SpellLink from 'common/SpellLink';
 
 import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
 
-import { binomialPMF } from 'parser/warlock/shared/probability';
+import { binomialPMF, findMax } from 'parser/warlock/shared/probability';
 import { UNSTABLE_AFFLICTION_DEBUFFS } from '../../constants';
 import SoulShardTracker from '../soulshards/SoulShardTracker';
 
@@ -42,20 +42,8 @@ class SoulConduit extends Analyzer {
     const shardsGained = this.soulShardTracker.getGeneratedBySpell(SPELLS.SOUL_CONDUIT_SHARD_GEN.id);
     const estimatedUAdamage = shardsGained * TICKS_PER_UA * avgDamage;
     const totalSpent = this.soulShardTracker.spent;
-    // similar to what we do in DemonicMeteor
-    // Binomial distribution follows a bell-shaped curve
-    // iterate upwards from k = 0, search for local (=global) maximum, when value starts to decrease, break
-    let max = -1;
-    let maxP = 0;
-    for (let i = 0; i <= totalSpent; i++) {
-      const p = binomialPMF(i, totalSpent, SC_PROC_CHANCE);
-      if (p > maxP) {
-        max = i;
-        maxP = p;
-      } else if (p < maxP) {
-        break;
-      }
-    }
+    // find number of Shards we were MOST LIKELY to get in the fight
+    const { k: max } = findMax(totalSpent, SC_PROC_CHANCE, binomialPMF);
     return (
       <StatisticListBoxItem
         title={<>Shards generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}

--- a/src/parser/warlock/affliction/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/affliction/modules/talents/SoulConduit.js
@@ -57,8 +57,8 @@ class SoulConduit extends Analyzer {
       <StatisticListBoxItem
         title={<>Shards generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}
         value={shardsGained}
-        valueTooltip={`Estimated damage: ${formatThousands(estimatedUAdamage)} (${this.owner.formatItemDamageDone(estimatedUAdamage)})<br />
-                      You gained ${shardsGained} Soul Shards from this talent (<strong>${formatPercentage(shardsGained / max)}%</strong> of Shards you could expect in this fight.)<br />
+        valueTooltip={`You gained ${shardsGained} Shards from this talent, which is <strong>${formatPercentage(shardsGained / max)}%</strong> of Shards you were most likely to get in this fight (${max} Shards).<br />
+                      Estimated damage: ${formatThousands(estimatedUAdamage)} (${this.owner.formatItemDamageDone(estimatedUAdamage)})<br /><br />
                       This result is estimated by multiplying number of Soul Shards gained from this talent by the average Unstable Affliction damage for the whole fight.`}
       />
     );

--- a/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
+++ b/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
@@ -13,7 +13,7 @@ import { formatPercentage, formatThousands } from 'common/format';
 import TraitStatisticBox from 'interface/others/TraitStatisticBox';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 
-import { poissonBinomialPMF } from 'parser/warlock/shared/probability';
+import { findMax, poissonBinomialPMF } from 'parser/warlock/shared/probability';
 import SoulShardTracker from '../soulshards/SoulShardTracker';
 
 const HOG_SP_COEFFICIENT = 0.16; // taken from Simcraft SpellDataDump
@@ -69,20 +69,7 @@ class DemonicMeteor extends Analyzer {
   statistic() {
     const shardsGained = this.soulShardTracker.getGeneratedBySpell(SPELLS.DEMONIC_METEOR_SHARD_GEN.id);
     // we need to get the amount of shards we were most likely to get given certain probabilities
-    // this corresponds to the highest PMF in the distribution
-    // since Poisson binomial distribution has a bell shape similar to regular binomial, we only need to find the maximum probability for given k
-    // once it starts to decrease, we can break the loop
-    let max = -1;
-    let maxP = 0;
-    for (let i = 0; i <= this.probabilities.length; i++) {
-      const p = poissonBinomialPMF(i, this.probabilities.length, this.probabilities);
-      if (p > maxP) {
-        max = i;
-        maxP = p;
-      } else if (p < maxP) {
-        break;
-      }
-    }
+    const { k: max } = findMax(this.probabilities.length, this.probabilities, poissonBinomialPMF);
     return (
       <TraitStatisticBox
         trait={SPELLS.DEMONIC_METEOR.id}

--- a/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
+++ b/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
@@ -12,6 +12,7 @@ import { formatThousands } from 'common/format';
 import TraitStatisticBox from 'interface/others/TraitStatisticBox';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 
+import { poissonBinomialCDF, poissonBinomialPMF } from 'parser/warlock/shared/probability';
 import SoulShardTracker from '../soulshards/SoulShardTracker';
 
 const HOG_SP_COEFFICIENT = 0.16; // taken from Simcraft SpellDataDump
@@ -51,6 +52,12 @@ class DemonicMeteor extends Analyzer {
 
   statistic() {
     const shardsGained = this.soulShardTracker.getGeneratedBySpell(SPELLS.DEMONIC_METEOR_SHARD_GEN.id);
+    this.log('Poisson PMF test');
+    const pmf = poissonBinomialPMF(2, 3, [0.15, 0.1, 0.15]);
+    this.log(`Result: ${pmf}`);
+    this.log('Poisson CDF test');
+    const { probability: cdf } = poissonBinomialCDF(2, 3, [0.15, 0.1, 0.15]);
+    this.log(`Result: ${cdf}`);
     return (
       <TraitStatisticBox
         trait={SPELLS.DEMONIC_METEOR.id}

--- a/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
+++ b/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
@@ -69,7 +69,7 @@ class DemonicMeteor extends Analyzer {
   statistic() {
     const shardsGained = this.soulShardTracker.getGeneratedBySpell(SPELLS.DEMONIC_METEOR_SHARD_GEN.id);
     // we need to get the amount of shards we were most likely to get given certain probabilities
-    const { k: max } = findMax(this.probabilities.length, this.probabilities, poissonBinomialPMF);
+    const { max } = findMax(this.probabilities.length, this.probabilities, poissonBinomialPMF);
     return (
       <TraitStatisticBox
         trait={SPELLS.DEMONIC_METEOR.id}

--- a/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
+++ b/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
@@ -88,7 +88,7 @@ class DemonicMeteor extends Analyzer {
         trait={SPELLS.DEMONIC_METEOR.id}
         value={<ItemDamageDone amount={this.damage} approximate />}
         tooltip={`Estimated bonus Hand of Gul'dan damage: ${formatThousands(this.damage)}<br />
-                Shards gained with this trait: ${shardsGained} (<strong>${formatPercentage(shardsGained / max)} %</strong> of procs you could expect in this fight.)<br /><br />
+                You gained ${shardsGained} Shards with this trait, which is <strong>${formatPercentage(shardsGained / max)} %</strong> of procs you were most likely to get in this fight (${max} procs).<br /><br />
                 The damage is an approximation using current Intellect values at given time, but because we might miss some Intellect buffs (e.g. trinkets, traits), the value of current Intellect might be a little incorrect.`}
       />
     );

--- a/src/parser/warlock/demonology/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/demonology/modules/talents/SoulConduit.js
@@ -43,7 +43,7 @@ class SoulConduit extends Analyzer {
       <StatisticListBoxItem
         title={<>Shards generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}
         value={generated}
-        valueTooltip={`You gained ${generated} Soul Shards from this talent (<strong>${formatPercentage(generated / max)}%</strong> of Shards you could expect in this fight.)<br />
+        valueTooltip={`You gained ${generated} Soul Shards from this talent, which is <strong>${formatPercentage(generated / max)}%</strong> of Shards you were most likely to get in this fight (${max} Shards)<br />
                       You would get ${extraHogs} extra 3 shard Hands of Gul'dan with shards from this talent.`}
       />
     );

--- a/src/parser/warlock/demonology/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/demonology/modules/talents/SoulConduit.js
@@ -29,7 +29,7 @@ class SoulConduit extends Analyzer {
     const extraHogs = Math.floor(generated / SHARDS_PER_HOG);
     const totalSpent = this.soulShardTracker.spent;
     // find number of Shards we were MOST LIKELY to get in the fight
-    const { k: max } = findMax(totalSpent, SC_PROC_CHANCE, binomialPMF);
+    const { max } = findMax(totalSpent, SC_PROC_CHANCE, binomialPMF);
     return (
       <StatisticListBoxItem
         title={<>Shards generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}

--- a/src/parser/warlock/demonology/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/demonology/modules/talents/SoulConduit.js
@@ -4,12 +4,15 @@ import Analyzer from 'parser/core/Analyzer';
 
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
+import { formatPercentage } from 'common/format';
 
 import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
 
+import { binomialCDF } from 'parser/warlock/shared/probability';
 import SoulShardTracker from '../soulshards/SoulShardTracker';
 
 const SHARDS_PER_HOG = 3;
+const SC_PROC_CHANCE = 0.15;
 
 class SoulConduit extends Analyzer {
   static dependencies = {
@@ -24,11 +27,24 @@ class SoulConduit extends Analyzer {
   subStatistic() {
     const generated = this.soulShardTracker.getGeneratedBySpell(SPELLS.SOUL_CONDUIT_SHARD_GEN.id);
     const extraHogs = Math.floor(generated / SHARDS_PER_HOG);
+    const totalSpent = this.soulShardTracker.spent;
+    // since we want to get the amount of shards we would MOST LIKELY get, we intentionally need to try higher values for k than usually possible
+    const { partial: probabilities } = binomialCDF(Math.round(totalSpent / 2), totalSpent, SC_PROC_CHANCE);
+    // with 15% chance per shard, it's very unlikely that we would get half of the shards refunded, so the maximum must be somewhere lower than that, and "partial" array of the return object contains those values
+    let maxP = 0;
+    let max = -1;
+    probabilities.forEach((p, k) => {
+      if (p > maxP) {
+        maxP = p;
+        max = k;
+      }
+    });
     return (
       <StatisticListBoxItem
         title={<>Shards generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}
         value={generated}
-        valueTooltip={`You would get ${extraHogs} extra 3 shard Hands of Gul'dan with shards from this talent.`}
+        valueTooltip={`You gained ${generated} Soul Shards from this talent (<strong>${formatPercentage(generated / max)}%</strong> of Shards you could expect in this fight.)<br />
+                      You would get ${extraHogs} extra 3 shard Hands of Gul'dan with shards from this talent.`}
       />
     );
   }

--- a/src/parser/warlock/demonology/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/demonology/modules/talents/SoulConduit.js
@@ -8,7 +8,7 @@ import { formatPercentage } from 'common/format';
 
 import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
 
-import { binomialCDF } from 'parser/warlock/shared/probability';
+import { binomialPMF } from 'parser/warlock/shared/probability';
 import SoulShardTracker from '../soulshards/SoulShardTracker';
 
 const SHARDS_PER_HOG = 3;
@@ -28,17 +28,19 @@ class SoulConduit extends Analyzer {
     const generated = this.soulShardTracker.getGeneratedBySpell(SPELLS.SOUL_CONDUIT_SHARD_GEN.id);
     const extraHogs = Math.floor(generated / SHARDS_PER_HOG);
     const totalSpent = this.soulShardTracker.spent;
-    // since we want to get the amount of shards we would MOST LIKELY get, we intentionally need to try higher values for k than usually possible
-    const { partial: probabilities } = binomialCDF(Math.round(totalSpent / 2), totalSpent, SC_PROC_CHANCE);
-    // with 15% chance per shard, it's very unlikely that we would get half of the shards refunded, so the maximum must be somewhere lower than that, and "partial" array of the return object contains those values
-    let maxP = 0;
+    // Binomial distribution follows a bell-shaped curve
+    // iterate upwards from k = 0, search for local (=global) maximum, when value starts to decrease, break
     let max = -1;
-    probabilities.forEach((p, k) => {
+    let maxP = 0;
+    for (let i = 0; i <= totalSpent; i++) {
+      const p = binomialPMF(i, totalSpent, SC_PROC_CHANCE);
       if (p > maxP) {
+        max = i;
         maxP = p;
-        max = k;
+      } else if (p < maxP) {
+        break;
       }
-    });
+    }
     return (
       <StatisticListBoxItem
         title={<>Shards generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}

--- a/src/parser/warlock/destruction/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/destruction/modules/talents/SoulConduit.js
@@ -9,10 +9,10 @@ import { formatPercentage, formatThousands } from 'common/format';
 
 import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
 
-import { binomialPMF } from 'parser/warlock/shared/probability';
+import { binomialPMF, findMax } from 'parser/warlock/shared/probability';
 import SoulShardTracker from '../soulshards/SoulShardTracker';
 
-const FRAGMENTS_PER_CHAOS_BOLT = 20;
+const FRAGMENTS_PER_SHARD = 10;
 const SC_PROC_CHANCE = 0.15;
 
 class SoulConduit extends Analyzer {
@@ -32,30 +32,19 @@ class SoulConduit extends Analyzer {
   }
 
   subStatistic() {
-    const generated = this.soulShardTracker.getGeneratedBySpell(SPELLS.SOUL_CONDUIT_SHARD_GEN.id);
-    const estimatedDamage = Math.floor(generated / FRAGMENTS_PER_CHAOS_BOLT) * this.averageChaosBoltDamage;
-    const totalSpent = this.soulShardTracker.spent / 10; // Destruction Soul Shard Tracker tracks fragments (10 fragments per shard)
-    // Binomial distribution follows a bell-shaped curve
-    // iterate upwards from k = 0, search for local (=global) maximum, when value starts to decrease, break
-    let max = -1;
-    let maxP = 0;
-    for (let i = 0; i <= totalSpent; i++) {
-      const p = binomialPMF(i, totalSpent, SC_PROC_CHANCE);
-      if (p > maxP) {
-        max = i;
-        maxP = p;
-      } else if (p < maxP) {
-        break;
-      }
-    }
+    const generatedShards = this.soulShardTracker.getGeneratedBySpell(SPELLS.SOUL_CONDUIT_SHARD_GEN.id) / FRAGMENTS_PER_SHARD;
+    const estimatedDamage = Math.floor(generatedShards / 2) * this.averageChaosBoltDamage; // Chaos Bolt costs 2 shards to cast
+    const totalSpent = this.soulShardTracker.spent / FRAGMENTS_PER_SHARD; // Destruction Soul Shard Tracker tracks fragments (10 fragments per shard)
+    // find number of Shards we were MOST LIKELY to get in the fight
+    const { k: max } = findMax(totalSpent, SC_PROC_CHANCE, binomialPMF);
     return (
       <StatisticListBoxItem
-        title={<>Fragments generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}
-        value={generated}
-        valueTooltip={`You gained ${generated} fragments from this talent, which is <strong>${formatPercentage(generated / max)}%</strong> of fragments you were most likely to get in this fight (${max} fragments).<br />
+        title={<>Shards generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}
+        value={generatedShards}
+        valueTooltip={`You gained ${generatedShards} Shards from this talent, which is <strong>${formatPercentage(generatedShards / max)}%</strong> of Shards you were most likely to get in this fight (${max} Shards).<br />
           Estimated damage: ${formatThousands(estimatedDamage)} (${this.owner.formatItemDamageDone(estimatedDamage)}).<br /><br />
 
-          This result is estimated by multiplying average Chaos Bolt damage by potential casts you would get from these bonus fragments.`}
+          This result is estimated by multiplying average Chaos Bolt damage by potential casts you would get from these bonus Shards.`}
       />
     );
   }

--- a/src/parser/warlock/destruction/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/destruction/modules/talents/SoulConduit.js
@@ -36,7 +36,7 @@ class SoulConduit extends Analyzer {
     const estimatedDamage = Math.floor(generatedShards / 2) * this.averageChaosBoltDamage; // Chaos Bolt costs 2 shards to cast
     const totalSpent = this.soulShardTracker.spent / FRAGMENTS_PER_SHARD; // Destruction Soul Shard Tracker tracks fragments (10 fragments per shard)
     // find number of Shards we were MOST LIKELY to get in the fight
-    const { k: max } = findMax(totalSpent, SC_PROC_CHANCE, binomialPMF);
+    const { max } = findMax(totalSpent, SC_PROC_CHANCE, binomialPMF);
     return (
       <StatisticListBoxItem
         title={<>Shards generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}

--- a/src/parser/warlock/destruction/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/destruction/modules/talents/SoulConduit.js
@@ -5,13 +5,15 @@ import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
-import { formatThousands } from 'common/format';
+import { formatPercentage, formatThousands } from 'common/format';
 
 import StatisticListBoxItem from 'interface/others/StatisticListBoxItem';
 
+import { binomialCDF } from 'parser/warlock/shared/probability';
 import SoulShardTracker from '../soulshards/SoulShardTracker';
 
 const FRAGMENTS_PER_CHAOS_BOLT = 20;
+const SC_PROC_CHANCE = 0.15;
 
 class SoulConduit extends Analyzer {
   static dependencies = {
@@ -32,12 +34,24 @@ class SoulConduit extends Analyzer {
   subStatistic() {
     const generated = this.soulShardTracker.getGeneratedBySpell(SPELLS.SOUL_CONDUIT_SHARD_GEN.id);
     const estimatedDamage = Math.floor(generated / FRAGMENTS_PER_CHAOS_BOLT) * this.averageChaosBoltDamage;
-
+    const totalSpent = this.soulShardTracker.spent / 10; // Destruction Soul Shard Tracker tracks fragments (10 fragments per shard)
+    // since we want to get the amount of shards we would MOST LIKELY get, we intentionally need to try higher values for k than usually possible
+    const { partial: probabilities } = binomialCDF(Math.round(totalSpent / 2), totalSpent, SC_PROC_CHANCE);
+    // with 15% chance per shard, it's very unlikely that we would get half of the shards refunded, so the maximum must be somewhere lower than that, and "partial" array of the return object contains those values
+    let maxP = 0;
+    let max = -1;
+    probabilities.forEach((p, k) => {
+      if (p > maxP) {
+        maxP = p;
+        max = k * 10; // k is again in whole Shards, here we're talking in fragments, hence the multiplication
+      }
+    });
     return (
       <StatisticListBoxItem
         title={<>Fragments generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}
         value={generated}
-        valueTooltip={`Estimated damage: ${formatThousands(estimatedDamage)} (${this.owner.formatItemDamageDone(estimatedDamage)}).
+        valueTooltip={`Estimated damage: ${formatThousands(estimatedDamage)} (${this.owner.formatItemDamageDone(estimatedDamage)}).<br />
+          You gained ${generated} fragments from this talent (<strong>${formatPercentage(generated / max)}%</strong> of fragments you could expect in this fight.)<br />
           This result is estimated by multiplying average Chaos Bolt damage by potential casts you would get from these bonus fragments.`}
       />
     );

--- a/src/parser/warlock/destruction/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/destruction/modules/talents/SoulConduit.js
@@ -50,8 +50,9 @@ class SoulConduit extends Analyzer {
       <StatisticListBoxItem
         title={<>Fragments generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}
         value={generated}
-        valueTooltip={`Estimated damage: ${formatThousands(estimatedDamage)} (${this.owner.formatItemDamageDone(estimatedDamage)}).<br />
-          You gained ${generated} fragments from this talent (<strong>${formatPercentage(generated / max)}%</strong> of fragments you could expect in this fight.)<br />
+        valueTooltip={`You gained ${generated} fragments from this talent, which is <strong>${formatPercentage(generated / max)}%</strong> of fragments you were most likely to get in this fight (${max} fragments).<br />
+          Estimated damage: ${formatThousands(estimatedDamage)} (${this.owner.formatItemDamageDone(estimatedDamage)}).<br /><br />
+
           This result is estimated by multiplying average Chaos Bolt damage by potential casts you would get from these bonus fragments.`}
       />
     );

--- a/src/parser/warlock/shared/probability.js
+++ b/src/parser/warlock/shared/probability.js
@@ -67,12 +67,7 @@ export function poissonBinomialCDF(k, n, p) {
   for (let i = 0; i <= k; i++) {
     probability += Ekj(i, n, p, lookup);
   }
-  // For practical reasons, return the lookup table as well, as there should exist PMF values for k <= k (as in argument of this function)
-  // this is practical for showing a chart like emallson has
-  return {
-    probability,
-    lookup,
-  };
+  return probability;
 }
 
 // Binomial Distribution
@@ -114,15 +109,8 @@ export function binomialPMF(k, n, p) {
  */
 export function binomialCDF(k, n, p) {
   let probability = 0;
-  const partial = [];
   for (let i = 0; i <= k; i++) {
-    const prob = binomialPMF(i, n, p);
-    probability += prob;
-    partial.push(prob);
+    probability += binomialPMF(i, n, p);
   }
-  // in the same nature like poissonBinomialCDF, return information for previously calculated PMF
-  return {
-    probability,
-    partial,
-  };
+  return probability;
 }

--- a/src/parser/warlock/shared/probability.js
+++ b/src/parser/warlock/shared/probability.js
@@ -114,3 +114,30 @@ export function binomialCDF(k, n, p) {
   }
   return probability;
 }
+
+/**
+ * Finds the maximum of PMF of given distribution. Meant to be used with `binomialPMF` or `poissonBinomialPMF` (because of the shape).
+ * @param n {Number} Maximum number of tries for given event
+ * @param p {Number|[Number]} Probability or probability vector
+ * @param pmf {Function} PMF function - meant to be `binomialPMF` or `poissonBinomialPMF`
+ * @returns Maximum of given PMF function - argument and probability itself
+ */
+export function findMax(n, p, pmf) {
+  // Since Binomial and Poisson binomial distributions both have bell like shape, we can iterate upwards from k = 0
+  // When the probability starts to decrease, we've found the local (and global) maximum of the function and we can break and return
+  let k = -1;
+  let max = 0;
+  for (let i = 0; i <= n; i++) {
+    const probability = pmf(i, n, p);
+    if (probability > max) {
+      k = i;
+      max = probability;
+    } else if (probability < max) {
+      break;
+    }
+  }
+  return {
+    k,
+    p: max,
+  };
+}

--- a/src/parser/warlock/shared/probability.js
+++ b/src/parser/warlock/shared/probability.js
@@ -27,7 +27,7 @@ function Ekj(k, j, p, lookup) {
 
 // Poisson's Binomial Distribution
 // Methods based on Wikipedia page and this research paper:
-// // https://www.researchgate.net/publication/257017356_On_computing_the_distribution_function_for_the_Poisson_binomial_distribution
+// https://www.researchgate.net/publication/257017356_On_computing_the_distribution_function_for_the_Poisson_binomial_distribution
 
 /**
  * Calculates the probability that out of n tries with p probabilities, we get exactly k positive outcomes
@@ -72,5 +72,57 @@ export function poissonBinomialCDF(k, n, p) {
   return {
     probability,
     lookup,
+  };
+}
+
+// Binomial Distribution
+
+function bin(n, k) {
+  // n! / (k! * (n - k)!)
+  // factorials are awful, let's simplify a bit
+  // we know k < n:
+  // numerator: n! = 1 * 2 * ... * (n - k) * (n - k + 1) * (n - k + 2 ) * ... * n
+  // denominator: k! * (n - k)! = k! * 1 * 2 * ... * (n - k)
+  // cancelling out 1 * 2 * ... * (n - k) from both we get:
+  // (n - k + 1) * (n - k + 2) * ... n / k!
+  let numerator = 1;
+  let denominator = 1;
+  for (let i = n - k + 1; i <= n; i++) {
+    numerator *= i;
+  }
+  for (let i = 1; i <= k; i++) {
+    denominator *= i;
+  }
+  return numerator / denominator;
+}
+
+/**
+ * Calculates the probability that out of n tries with probability p, we get exactly k positive outcomes
+ * @param k {Number} Number of desired positive outcomes
+ * @param n {Number} Number of tries
+ * @param p {Number} Probability of positive outcome
+ */
+export function binomialPMF(k, n, p) {
+  return bin(n, k) * Math.pow(p, k) * Math.pow(1 - p, n - k);
+}
+
+/**
+ * Calculates the probability that out of n tries with probability p, we get k or less positive outcomes
+ * @param k {Number} Number of desired positive outcomes
+ * @param n {Number} Number of tries
+ * @param p {Number} Probability of positive outcome
+ */
+export function binomialCDF(k, n, p) {
+  let probability = 0;
+  const partial = [];
+  for (let i = 0; i <= k; i++) {
+    const prob = binomialPMF(i, n, p);
+    probability += prob;
+    partial.push(prob);
+  }
+  // in the same nature like poissonBinomialCDF, return information for previously calculated PMF
+  return {
+    probability,
+    partial,
   };
 }

--- a/src/parser/warlock/shared/probability.js
+++ b/src/parser/warlock/shared/probability.js
@@ -1,0 +1,76 @@
+/**
+ * Recursive formula for calculating the PMF (probability mass function) of Poisson's Binomial Distribution
+ * @param k {Number} Number of desired positive outcomes
+ * @param j {Number} Number of total tries
+ * @param p {[Number]} Probability vector
+ * @param lookup {Array} Lookup table
+ * @returns {Number} Probability
+ */
+function Ekj(k, j, p, lookup) {
+  if (k === -1) {
+    return 0;
+  }
+  if (k === j+1) {
+    return 0;
+  }
+  if (k === 0 && j === 0) {
+    return 1;
+  }
+  if (lookup[k][j] !== null) {
+    return lookup[k][j];
+  }
+  // literature uses 1-based indices for probabilities, as we're using an array, we have to use 0 based
+  const value = (1 - p[j-1]) * Ekj(k, j-1, p, lookup) + p[j-1] * Ekj(k-1, j-1, p, lookup);
+  lookup[k][j] = value;
+  return value;
+}
+
+// Poisson's Binomial Distribution
+// Methods based on Wikipedia page and this research paper:
+// // https://www.researchgate.net/publication/257017356_On_computing_the_distribution_function_for_the_Poisson_binomial_distribution
+
+/**
+ * Calculates the probability that out of n tries with p probabilities, we get exactly k positive outcomes
+ * @param k {Number} Number of desired positive outcomes
+ * @param n {Number} Number of total tries
+ * @param p {[Number]} Probability vector
+ */
+export function poissonBinomialPMF(k, n, p) {
+  // denoted in the paper as ξk, I'll call it Ek for simplicity
+  // using the recursive formula in chapter 2.5
+  if (p.length !== n) {
+    throw new Error("You must supply a probability vector with the same length as the number of total tries into Poisson Binomial PMF");
+  }
+  // Using a lookup table to simplify recursion a little bit
+  // construct an (n+1) x (n+1) lookup table (because Ek,j uses indexes from 0 to n INCLUSIVE, with this we don't have to subtract indexes all the time)
+  // intentionally set tu nulls so we know which values are computed or not
+  const lookup = [...Array(n+1)].map(_ => Array(n + 1).fill(null));
+  return Ekj(k, n, p, lookup);
+}
+
+/**
+ * Calculates the probability that out of n tries with p probabilities, we get less than or equal k positive outcomes
+ * @param k {Number} Number of desired positive outcomes
+ * @param n {Number} Number of total tries
+ * @param p {[Number]} Probability vector
+ */
+export function poissonBinomialCDF(k, n, p) {
+  // While technically equal to summing Ei from i = 0 to k, since we use recursion, a better solution is a lookup table
+  if (p.length !== n) {
+    throw new Error("You must supply a probability vector with the same length as the number of total tries into Poisson Binomial CDF");
+  }
+  // see comments in poissonBinomialPMF
+  const lookup = [...Array(n+1)].map(_ => Array(n+1).fill(null));
+  let probability = 0;
+  // since Ekj uses the values from "previous row" (Ekj(k - 1, j - 1, ...)), it's better to iterate from 0
+  // this way, it produces the least necessary amount of calculations with the lookup table (only the Ekj(k, j - 1) parts)
+  for (let i = 0; i <= k; i++) {
+    probability += Ekj(i, n, p, lookup);
+  }
+  // For practical reasons, return the lookup table as well, as there should exist PMF values for k <= k (as in argument of this function)
+  // this is practical for showing a chart like emallson has
+  return {
+    probability,
+    lookup,
+  };
+}

--- a/src/parser/warlock/shared/probability.js
+++ b/src/parser/warlock/shared/probability.js
@@ -125,19 +125,19 @@ export function binomialCDF(k, n, p) {
 export function findMax(n, p, pmf) {
   // Since Binomial and Poisson binomial distributions both have bell like shape, we can iterate upwards from k = 0
   // When the probability starts to decrease, we've found the local (and global) maximum of the function and we can break and return
-  let k = -1;
-  let max = 0;
+  let max = -1;
+  let maxP = 0;
   for (let i = 0; i <= n; i++) {
     const probability = pmf(i, n, p);
-    if (probability > max) {
-      k = i;
-      max = probability;
-    } else if (probability < max) {
+    if (probability > maxP) {
+      max = i;
+      maxP = probability;
+    } else if (probability < maxP) {
       break;
     }
   }
   return {
-    k,
-    p: max,
+    max,
+    p: maxP,
   };
 }


### PR DESCRIPTION
I got inspired by emallson and Putro and tried to make usage of some probability distributions in my Warlocks. Specifically, I looked at classic [binomial distribution](https://en.wikipedia.org/wiki/Binomial_distribution) and its generalized neighbor, [Poisson binomial distribution](https://en.wikipedia.org/wiki/Poisson_binomial_distribution) (the difference is merely in the fact that binomial has fixed probability chance for all events whereas Poisson can have different probabilities for each event).

Originally I wanted to implement it in more places but I'd rather not inflate this PR any more than needed. Added both distributions, their [PMF](https://en.wikipedia.org/wiki/Probability_mass_function) and [CDF](https://en.wikipedia.org/wiki/Cumulative_distribution_function) functions and an example of implementing it.

With these functions you can show:
- what is the % chance of exactly K successful out of N events
- what is the % chance of getting <= K successful out of N events
- draw a distribution graph similar to emallson's Expected mitigation by Mastery
- get the number of events (k) you were *most likely* to get given the probabilities

I would personally show almost all of these but I've talked about it with the Warlock theorycrafter Motoko and we agreed that for majority of the people, it could be just confusing, so in the end I only used the last thing and shown the % of actual procs vs expected procs, to see if they were (un)lucky or if it's just normal.

(I might add an information what was the expected amount of procs in the tooltip, awaiting response from him)

![image](https://user-images.githubusercontent.com/5068584/50737952-cb1b2600-11ce-11e9-91cc-bd0679e25bc5.png)
