### PR TITLE
[Warlock] More probability things

### DIFF
--- a/src/parser/warlock/affliction/modules/azerite/PandemicInvocation.js
+++ b/src/parser/warlock/affliction/modules/azerite/PandemicInvocation.js
@@ -1,21 +1,45 @@
 import React from 'react';
 
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
-import SoulShardTracker from 'parser/warlock/affliction/modules/soulshards/SoulShardTracker';
+import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
 import Events from 'parser/core/Events';
 
 import SPELLS from 'common/SPELLS';
-import { formatThousands } from 'common/format';
+import { formatPercentage, formatThousands } from 'common/format';
 
 import TraitStatisticBox from 'interface/others/TraitStatisticBox';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
+
+import { binomialPMF, findMax } from 'parser/warlock/shared/probability';
+import { getDotDurations } from '../../constants';
+import SoulShardTracker from '../soulshards/SoulShardTracker';
+
+const PROC_CHANCE = 0.0666;
+const PROC_WINDOW = 5000;
+const PANDEMIC_WINDOW = 0.3;
+const PANDEMIC_DOTS = [
+  SPELLS.AGONY,
+  SPELLS.CORRUPTION_DEBUFF,
+  SPELLS.SIPHON_LIFE_TALENT,
+];
 
 class PandemicInvocation extends Analyzer {
   static dependencies = {
     soulShardTracker: SoulShardTracker,
   };
-
+  _dotDurations = {};
+  _dots = {
+    /*
+    [target string]: {
+      [dot id]: {
+        start: number,
+        end: number,
+      },
+    },
+     */
+  };
   damage = 0;
+  opportunities = 0;
 
   constructor(...args) {
     super(...args);
@@ -24,7 +48,45 @@ class PandemicInvocation extends Analyzer {
       return;
     }
 
+    this._dotDurations = getDotDurations(this.selectedCombatant.hasTalent(SPELLS.CREEPING_DEATH_TALENT.id));
+    const hasAC = this.selectedCombatant.hasTalent(SPELLS.ABSOLUTE_CORRUPTION_TALENT.id);
+    if (hasAC) {
+      // remove Corruption from the array if player has Absolute Corruption
+      // this way it doesn't set up the listener (because with the talent, the debuff is permanent so it can't be refreshed with < 5 sec)
+      PANDEMIC_DOTS.splice(1, 1);
+    }
+
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(PANDEMIC_DOTS), this.onDotCast);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.PANDEMIC_INVOCATION_DAMAGE), this.onPandemicInvocationDamage);
+  }
+
+  onDotCast(event) {
+    const target = encodeTargetString(event.targetID, event.targetInstance);
+    const spellId = event.ability.guid;
+    this._dots[target] = this._dots[target] || {};
+    const dot = this._dots[target][spellId];
+
+    if (dot && event.timestamp < dot.end) {
+      // dot refresh, pandemic handling, proc handling
+      const remainingDuration = dot.end - event.timestamp;
+      if (remainingDuration < PROC_WINDOW) {
+        this.opportunities += 1;
+      }
+      const maxDuration = (1 + PANDEMIC_WINDOW) * this._dotDurations[spellId];
+      const newDuration = remainingDuration + this._dotDurations[spellId];
+      const resultDuration = Math.min(newDuration, maxDuration);
+
+      this._dots[target][spellId] = {
+        start: event.timestamp,
+        end: event.timestamp + resultDuration,
+      };
+    } else {
+      // new dot application
+      this._dots[target][spellId] = {
+        start: event.timestamp,
+        end: event.timestamp + this._dotDurations[spellId],
+      };
+    }
   }
 
   onPandemicInvocationDamage(event) {
@@ -34,12 +96,18 @@ class PandemicInvocation extends Analyzer {
   statistic() {
     const generated = this.soulShardTracker.getGeneratedBySpell(SPELLS.PANDEMIC_INVOCATION_ENERGIZE.id);
     const wasted = this.soulShardTracker.getWastedBySpell(SPELLS.PANDEMIC_INVOCATION_ENERGIZE.id);
+    const { max } = findMax(this.opportunities, (k, n) => binomialPMF(k, n, PROC_CHANCE));
     return (
       <TraitStatisticBox
         trait={SPELLS.PANDEMIC_INVOCATION.id}
         value={<ItemDamageDone amount={this.damage} />}
         tooltip={`Pandemic Invocation damage: ${formatThousands(this.damage)}<br />
-                  You gained ${generated} Soul Shards and wasted ${wasted} Soul Shards with this trait.`}
+                  You gained ${generated} Soul Shards and wasted ${wasted} Soul Shards with this trait
+                  ${max > 0 ?
+                      `, which is <strong>${formatPercentage(generated / max)}%</strong> of Shards you were most likely to get in this fight (${max} Shards).`
+                    :
+                      ', while you were most likely to not get any Shards.'
+                  }`}
       />
     );
   }

--- a/src/parser/warlock/affliction/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/affliction/modules/talents/SoulConduit.js
@@ -43,7 +43,7 @@ class SoulConduit extends Analyzer {
     const estimatedUAdamage = shardsGained * TICKS_PER_UA * avgDamage;
     const totalSpent = this.soulShardTracker.spent;
     // find number of Shards we were MOST LIKELY to get in the fight
-    const { max } = findMax(totalSpent, SC_PROC_CHANCE, binomialPMF);
+    const { max } = findMax(totalSpent, (k, n) => binomialPMF(k, n, SC_PROC_CHANCE));
     return (
       <StatisticListBoxItem
         title={<>Shards generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}

--- a/src/parser/warlock/affliction/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/affliction/modules/talents/SoulConduit.js
@@ -48,7 +48,12 @@ class SoulConduit extends Analyzer {
       <StatisticListBoxItem
         title={<>Shards generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}
         value={shardsGained}
-        valueTooltip={`You gained ${shardsGained} Shards from this talent, which is <strong>${formatPercentage(shardsGained / max)}%</strong> of Shards you were most likely to get in this fight (${max} Shards).<br />
+        valueTooltip={`You gained ${shardsGained} Shards from this talent
+                      ${max > 0 ?
+                          `, which is <strong>${formatPercentage(shardsGained / max)}%</strong> of Shards you were most likely to get in this fight (${max} Shards).`
+                        :
+                          ', while you were most likely to not get any Shards.'
+                      }<br />
                       Estimated damage: ${formatThousands(estimatedUAdamage)} (${this.owner.formatItemDamageDone(estimatedUAdamage)})<br /><br />
                       This result is estimated by multiplying number of Soul Shards gained from this talent by the average Unstable Affliction damage for the whole fight.`}
       />

--- a/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
+++ b/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
@@ -75,7 +75,12 @@ class DemonicMeteor extends Analyzer {
         trait={SPELLS.DEMONIC_METEOR.id}
         value={<ItemDamageDone amount={this.damage} approximate />}
         tooltip={`Estimated bonus Hand of Gul'dan damage: ${formatThousands(this.damage)}<br />
-                You gained ${shardsGained} Shards with this trait, which is <strong>${formatPercentage(shardsGained / max)} %</strong> of procs you were most likely to get in this fight (${max} procs).<br /><br />
+                You gained ${shardsGained} Shards with this trait
+                ${max > 0 ?
+                    `, which is <strong>${formatPercentage(shardsGained / max)} %</strong> of Shards you were most likely to get in this fight (${max} Shards).`
+                  :
+                    ', while you were most likely to not get any Shards.'
+                }<br /><br />
                 The damage is an approximation using current Intellect values at given time, but because we might miss some Intellect buffs (e.g. trinkets, traits), the value of current Intellect might be a little incorrect.`}
       />
     );

--- a/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
+++ b/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
@@ -69,7 +69,7 @@ class DemonicMeteor extends Analyzer {
   statistic() {
     const shardsGained = this.soulShardTracker.getGeneratedBySpell(SPELLS.DEMONIC_METEOR_SHARD_GEN.id);
     // we need to get the amount of shards we were most likely to get given certain probabilities
-    const { max } = findMax(this.probabilities.length, this.probabilities, poissonBinomialPMF);
+    const { max } = findMax(this.probabilities.length, (k, n) => poissonBinomialPMF(k, n, this.probabilities));
     return (
       <TraitStatisticBox
         trait={SPELLS.DEMONIC_METEOR.id}

--- a/src/parser/warlock/demonology/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/demonology/modules/talents/SoulConduit.js
@@ -29,7 +29,7 @@ class SoulConduit extends Analyzer {
     const extraHogs = Math.floor(generated / SHARDS_PER_HOG);
     const totalSpent = this.soulShardTracker.spent;
     // find number of Shards we were MOST LIKELY to get in the fight
-    const { max } = findMax(totalSpent, SC_PROC_CHANCE, binomialPMF);
+    const { max } = findMax(totalSpent, (k, n) => binomialPMF(k, n, SC_PROC_CHANCE));
     return (
       <StatisticListBoxItem
         title={<>Shards generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}

--- a/src/parser/warlock/demonology/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/demonology/modules/talents/SoulConduit.js
@@ -34,7 +34,13 @@ class SoulConduit extends Analyzer {
       <StatisticListBoxItem
         title={<>Shards generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}
         value={generated}
-        valueTooltip={`You gained ${generated} Shards from this talent, which is <strong>${formatPercentage(generated / max)}%</strong> of Shards you were most likely to get in this fight (${max} Shards)<br />
+        valueTooltip={`You gained ${generated} Shards from this talent
+                       ${max > 0 ?
+                          `, which is <strong>${formatPercentage(generated / max)}%</strong> of Shards you were most likely to get in this fight (${max} Shards).`
+                        :
+                          ', while you were most likely to not get any Shards.'
+                        }
+                      <br />
                       You would get ${extraHogs} extra 3 shard Hands of Gul'dan with shards from this talent.`}
       />
     );

--- a/src/parser/warlock/destruction/modules/azerite/ChaosShards.js
+++ b/src/parser/warlock/destruction/modules/azerite/ChaosShards.js
@@ -6,14 +6,16 @@ import calculateBonusAzeriteDamage from 'parser/core/calculateBonusAzeriteDamage
 import StatTracker from 'parser/shared/modules/StatTracker';
 
 import SPELLS from 'common/SPELLS';
-import { formatThousands } from 'common/format';
+import { formatPercentage, formatThousands } from 'common/format';
 import { calculateAzeriteEffects } from 'common/stats';
 
 import TraitStatisticBox from 'interface/others/TraitStatisticBox';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 
+import { binomialPMF, findMax } from 'parser/warlock/shared/probability';
 import SoulShardTracker from '../soulshards/SoulShardTracker';
 
+const PROC_CHANCE = 0.04;
 const INCINERATE_SP_COEFFICIENT = 0.641;
 const debug = false;
 
@@ -25,6 +27,7 @@ class ChaosShards extends Analyzer {
 
   bonus = 0;
   damage = 0;
+  opportunities = 0;
 
   constructor(...args) {
     super(...args);
@@ -41,6 +44,7 @@ class ChaosShards extends Analyzer {
       }, 0);
 
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.INCINERATE), this.onIncinerateDamage);
+    this.addEventListener(SoulShardTracker.fullshardgained, this.onFullShardGained);
   }
 
   onIncinerateDamage(event) {
@@ -48,15 +52,27 @@ class ChaosShards extends Analyzer {
     this.damage += damage;
   }
 
+  onFullShardGained() {
+    this.opportunities += 1;
+  }
+
   statistic() {
     const generated = this.soulShardTracker.getGeneratedBySpell(SPELLS.CHAOS_SHARDS_BUFF_ENERGIZE.id);
     const wasted = this.soulShardTracker.getWastedBySpell(SPELLS.CHAOS_SHARDS_BUFF_ENERGIZE.id);
+    const total = generated + wasted;
+    const { max } = findMax(this.opportunities, (k, n) => binomialPMF(k, n, PROC_CHANCE));
     return (
       <TraitStatisticBox
         trait={SPELLS.CHAOS_SHARDS.id}
         value={<ItemDamageDone amount={this.damage} approximate />}
         tooltip={`Estimated bonus Incinerate damage: ${formatThousands(this.damage)}<br />
-                  You gained ${generated} Soul Shard Fragments and wasted ${wasted} Soul Shard Fragments with this trait.<br /><br />
+                  You gained ${generated} Fragments and wasted ${wasted} Fragments with this trait
+                  ${max > 0 ?
+                    `, which is <strong>${formatPercentage(total / (max * 10))} %</strong> of Fragments you were most likely to get in this fight (${max * 10} Fragments).`
+                  :
+                    ', while you were most likely to not get any Fragments.'
+                  }
+                  <br /><br />
                   The damage is an approximation using current Intellect values at given time, but because we might miss some Intellect buffs (e.g. trinkets, traits), the value of current Intellect might be a little incorrect.`}
       />
     );

--- a/src/parser/warlock/destruction/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/destruction/modules/talents/SoulConduit.js
@@ -36,7 +36,7 @@ class SoulConduit extends Analyzer {
     const estimatedDamage = Math.floor(generatedShards / 2) * this.averageChaosBoltDamage; // Chaos Bolt costs 2 shards to cast
     const totalSpent = this.soulShardTracker.spent / FRAGMENTS_PER_SHARD; // Destruction Soul Shard Tracker tracks fragments (10 fragments per shard)
     // find number of Shards we were MOST LIKELY to get in the fight
-    const { max } = findMax(totalSpent, SC_PROC_CHANCE, binomialPMF);
+    const { max } = findMax(totalSpent, (k, n) => binomialPMF(k, n, SC_PROC_CHANCE));
     return (
       <StatisticListBoxItem
         title={<>Shards generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}

--- a/src/parser/warlock/destruction/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/destruction/modules/talents/SoulConduit.js
@@ -41,10 +41,16 @@ class SoulConduit extends Analyzer {
       <StatisticListBoxItem
         title={<>Shards generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}
         value={generatedShards}
-        valueTooltip={`You gained ${generatedShards} Shards from this talent, which is <strong>${formatPercentage(generatedShards / max)}%</strong> of Shards you were most likely to get in this fight (${max} Shards).<br />
-          Estimated damage: ${formatThousands(estimatedDamage)} (${this.owner.formatItemDamageDone(estimatedDamage)}).<br /><br />
+        valueTooltip={`You gained ${generatedShards} Shards from this talent
+                      ${max > 0 ?
+                          `, which is <strong>${formatPercentage(generatedShards / max)}%</strong> of Shards you were most likely to get in this fight (${max} Shards).`
+                        :
+                          ', while you were most likely to not get any Shards.'
+                      }
+                      <br />
+                      Estimated damage: ${formatThousands(estimatedDamage)} (${this.owner.formatItemDamageDone(estimatedDamage)}).<br /><br />
 
-          This result is estimated by multiplying average Chaos Bolt damage by potential casts you would get from these bonus Shards.`}
+                      This result is estimated by multiplying average Chaos Bolt damage by potential casts you would get from these bonus Shards.`}
       />
     );
   }

--- a/src/parser/warlock/shared/probability.js
+++ b/src/parser/warlock/shared/probability.js
@@ -116,24 +116,19 @@ export function binomialCDF(k, n, p) {
 }
 
 /**
- * Finds the maximum of PMF of given distribution. Meant to be used with `binomialPMF` or `poissonBinomialPMF` (because of the shape).
+ * Finds the maximum of PMF of given distribution.
  * @param n {Number} Maximum number of tries for given event
- * @param p {Number|[Number]} Probability or probability vector
- * @param pmf {Function} PMF function - meant to be `binomialPMF` or `poissonBinomialPMF`
- * @returns Maximum of given PMF function - argument and probability itself
+ * @param {Function} pmf Callback that returns probability of exactly K events happening in N tries. Parameters - K, N
+ * @returns {{ max: Number, p: Number }} Maximum of given PMF function - argument and probability itself
  */
-export function findMax(n, p, pmf) {
-  // Since Binomial and Poisson binomial distributions both have bell like shape, we can iterate upwards from k = 0
-  // When the probability starts to decrease, we've found the local (and global) maximum of the function and we can break and return
+export function findMax(n, pmf) {
   let max = -1;
   let maxP = 0;
   for (let i = 0; i <= n; i++) {
-    const probability = pmf(i, n, p);
+    const probability = pmf(i, n);
     if (probability > maxP) {
       max = i;
       maxP = probability;
-    } else if (probability < maxP) {
-      break;
     }
   }
   return {


### PR DESCRIPTION
Cleaned up the `findMax` function, now it doesn't depend on the function shape (and instead iterates through all possibilities, which is more computationally heavy but in our cases (relatively small N), it shouldn't be a problem), and the `pmf` has been changed to not provide the probabilities.

This allows for more generalized syntax that you can see in Demonic Meteor or Soul Conduit for example.

Implemented this probability things in Pandemic Invocation and Chaos Shards traits:
- for Pandemic Invocation, the additional code is tracking dots and handling Pandemic effect
- for Chaos Shards I modified Destro SoulShardTracker to emit `fullshardgained` event when .. generating a full Shard 😄 

Also rewrote texts a little so that it doesn't break when player was most likely to get *no* Shards from an effect.