### PR TITLE
[Prot Pal] Fix GoAK + Glyph of the Queen

### DIFF
--- a/src/common/SPELLS/paladin.js
+++ b/src/common/SPELLS/paladin.js
@@ -394,6 +394,12 @@ export default {
     name: 'Guardian of Ancient Kings',
     icon: 'spell_holy_heroism',
   },
+  // GoAK has a different spell ID with Glyph of the Queen
+  GUARDIAN_OF_ANCIENT_KINGS_QUEEN: {
+    id: 212641,
+    name: 'Guardian of Ancient Kings',
+    icon: 'spell_holy_heroism',
+  },
   HAMMER_OF_THE_RIGHTEOUS: {
     id: 53595,
     name: 'Hammer of the Righteous',

--- a/src/parser/paladin/protection/modules/Abilities.js
+++ b/src/parser/paladin/protection/modules/Abilities.js
@@ -125,8 +125,8 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.GUARDIAN_OF_ANCIENT_KINGS,
-        buffSpellId: SPELLS.GUARDIAN_OF_ANCIENT_KINGS.id,
+        spell: [SPELLS.GUARDIAN_OF_ANCIENT_KINGS, SPELLS.GUARDIAN_OF_ANCIENT_KINGS_QUEEN],
+        buffSpellId: [SPELLS.GUARDIAN_OF_ANCIENT_KINGS.id, SPELLS.GUARDIAN_OF_ANCIENT_KINGS_QUEEN.id],
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         cooldown: 300,
         castEfficiency: {


### PR DESCRIPTION
Glyph of the Queen (https://www.wowhead.com/spell=212642/glyph-of-the-queen) changes the spell id of GoAK, similarly to the 200 different polymorph spells. This fixes the detection of the alternate spell.