### PR TITLE
[Blood Death Knight][Bug] allow DRW cast event during DRW

### DIFF
--- a/src/parser/deathknight/blood/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/deathknight/blood/__snapshots__/CombatLogParser.test.js.snap
@@ -817,77 +817,7 @@ exports[`The Blood Deathknight Analyzer analyzers DamageTaken matches the sugges
 
 exports[`The Blood Deathknight Analyzer analyzers DancingRuneWeapon matches the statistic snapshot 1`] = `"module has no statistic method"`;
 
-exports[`The Blood Deathknight Analyzer analyzers DancingRuneWeapon matches the suggestions snapshot 1`] = `
-Array [
-  Object {
-    "details": null,
-    "icon": "inv_sword_07",
-    "importance": "regular",
-    "issue": <React.Fragment>
-      Avoid casting spells during 
-      <SpellLink
-        icon={true}
-        id={49028}
-      />
-       that don't benefit from the coppies such as 
-      <SpellLink
-        icon={true}
-        id={206931}
-      />
-       and 
-      <SpellLink
-        icon={true}
-        id={43265}
-      />
-      . Check the cooldown-tab below for more detailed breakdown.
-      <div>
-        Try and prioritize 
-        <React.Fragment>
-          <SpellLink
-            icon={true}
-            id={49998}
-          />
-          , 
-        </React.Fragment>
-        <React.Fragment>
-          <SpellLink
-            icon={true}
-            id={206930}
-          />
-          , 
-        </React.Fragment>
-        <React.Fragment>
-          <SpellLink
-            icon={true}
-            id={50842}
-          />
-          , 
-        </React.Fragment>
-        <React.Fragment>
-          <SpellLink
-            icon={true}
-            id={195182}
-          />
-           
-        </React.Fragment>
-        <React.Fragment>
-          and (if in AoE)
-          <SpellLink
-            icon={true}
-            id={274156}
-          />
-        </React.Fragment>
-      </div>
-    </React.Fragment>,
-    "stat": <React.Fragment>
-      13 out of 15 casts during DRW were good
-       (
-      15 recommended
-      )
-    </React.Fragment>,
-  },
-]
-`;
+exports[`The Blood Deathknight Analyzer analyzers DancingRuneWeapon matches the suggestions snapshot 1`] = `Array []`;
 
 exports[`The Blood Deathknight Analyzer analyzers DeathStrikeTiming matches the statistic snapshot 1`] = `"module has no statistic method"`;
 

--- a/src/parser/deathknight/blood/modules/features/DancingRuneWeapon.js
+++ b/src/parser/deathknight/blood/modules/features/DancingRuneWeapon.js
@@ -29,6 +29,7 @@ class DancingRuneWeapon extends Analyzer {
 
     //push all casts during DRW that were on the GCD in array
     if (event.ability.guid !== SPELLS.RAISE_ALLY.id && //probably usefull to rezz someone even if it's a personal DPS-loss
+      event.ability.guid !== SPELLS.DANCING_RUNE_WEAPON.id && //because you get the DRW buff before the cast event since BFA
       this.abilities.getAbility(event.ability.guid) !== undefined &&
       this.abilities.getAbility(event.ability.guid).gcd) {
       this.castsDuringDRW.push(event.ability.guid);

--- a/src/parser/deathknight/blood/modules/features/DancingRuneWeapon.js
+++ b/src/parser/deathknight/blood/modules/features/DancingRuneWeapon.js
@@ -29,7 +29,7 @@ class DancingRuneWeapon extends Analyzer {
 
     //push all casts during DRW that were on the GCD in array
     if (event.ability.guid !== SPELLS.RAISE_ALLY.id && //probably usefull to rezz someone even if it's a personal DPS-loss
-      // event.ability.guid !== SPELLS.DANCING_RUNE_WEAPON.id && //because you get the DRW buff before the cast event since BFA
+      event.ability.guid !== SPELLS.DANCING_RUNE_WEAPON.id && //because you get the DRW buff before the cast event since BFA
       this.abilities.getAbility(event.ability.guid) !== undefined &&
       this.abilities.getAbility(event.ability.guid).gcd) {
       this.castsDuringDRW.push(event.ability.guid);

--- a/src/parser/deathknight/blood/modules/features/DancingRuneWeapon.js
+++ b/src/parser/deathknight/blood/modules/features/DancingRuneWeapon.js
@@ -29,7 +29,7 @@ class DancingRuneWeapon extends Analyzer {
 
     //push all casts during DRW that were on the GCD in array
     if (event.ability.guid !== SPELLS.RAISE_ALLY.id && //probably usefull to rezz someone even if it's a personal DPS-loss
-      event.ability.guid !== SPELLS.DANCING_RUNE_WEAPON.id && //because you get the DRW buff before the cast event since BFA
+      // event.ability.guid !== SPELLS.DANCING_RUNE_WEAPON.id && //because you get the DRW buff before the cast event since BFA
       this.abilities.getAbility(event.ability.guid) !== undefined &&
       this.abilities.getAbility(event.ability.guid).gcd) {
       this.castsDuringDRW.push(event.ability.guid);


### PR DESCRIPTION
Whitelist DRW for DRW since the cast is since BfA on the GCD. The DRW cast event happens right after the buff apply and fails the check.