### PR TITLE
Add Battle of Dazar'alor item spells

### DIFF
--- a/src/common/SPELLS/bfa/raids/battleofdazaralor/index.js
+++ b/src/common/SPELLS/bfa/raids/battleofdazaralor/index.js
@@ -1,0 +1,5 @@
+import safeMerge from 'common/safeMerge';
+import ITEMS from './items';
+import MECHANICS from './mechanics';
+
+export default safeMerge(ITEMS, MECHANICS);

--- a/src/common/SPELLS/bfa/raids/battleofdazaralor/items.js
+++ b/src/common/SPELLS/bfa/raids/battleofdazaralor/items.js
@@ -1,0 +1,126 @@
+// Spells such as on use casts or buffs triggered by items from this instance
+
+export default {
+  //Champion of the Light
+  ENVELOPING_PROTECTION: { //Ward of Envelopment
+    id: 287568,
+    name: "Enveloping Protection",
+    icon: "misc_legionfall_paladin",
+  },
+
+  //Grong
+  PRIMAL_RAGE_GRONG_TRINKET: { //Grong's Primal Rage
+    id: 288267,
+    name: "Primal Rage",
+    icon: "sha_inv_elemental_primal_shadow_nightmare",
+  },
+
+  //Jadefire Masters
+  INVOCATION_OF_YULON: {
+    id: 289521,
+    name: "Invocation of Yu'lon",
+    icon: "ability_monk_jadeserpentbreath",
+  },
+
+  //Opulence
+  INCANDESCENT_LUSTER: { //Incandescent Sliver
+    id: 289522,
+    name: "Incandescent Luster",
+    icon: "ability_priest_casecade",
+  },
+  DIAMOND_BARRIER: { //Diamond-laced Refracting Prism
+    id: 288034,
+    name: "Diamond Barrier",
+    icon: "hunter_pvp_diamondice",
+  },
+  GILDED_PATH: { //Boots of the Gilded Path
+    id: 290243,
+    name: "Gilded Path",
+    icon: "inv_misc_coin_01",
+  },
+
+  //Conclave of the Chosen
+  GIFT_OF_WIND: { //Crest of Pa'ku
+    id: 288304,
+    name: "Gift of Wind",
+    icon: "ability_skyreach_wind",
+  },
+  KIMBULS_RAZOR_CLAWS: {
+    id: 288328,
+    name: "Kimbul's Razor Claws",
+    icon: "ability_druid_mangle2",
+  },
+  GIFT_OF_THE_LOA: { //Gift of the Loa 2-set bonus
+    id: 290263,
+    name: "Gift of the Loa",
+    icon: "inv_archaeology_80_zandalari_zandalariidol",
+  },
+
+  //Rastakhan
+  BWONSAMDIS_BARGAIN: {
+    id: 288186,
+    name: "Bwonsamdi's Bargain",
+    icon: "ability_argus_deathfog",
+  },
+  MIRROR_OF_ENTWINED_FATE_BUFF: {
+    id: 287999,
+    name: "Mirror of Entwined Fate",
+    icon: "archaeology_5_0_carvedbronzemirror",
+  },
+  MIRROR_OF_ENTWINED_FATE_DEBUFF: {
+    id: 291170,
+    name: "Mirror of Entwined Fate",
+    icon: "archaeology_5_0_carvedbronzemirror",
+  },
+
+  //High Tinker Mekkatorque
+  R_A_G_E: { //Ramping Amplitude Gigavolt Engine
+    id: 288156,
+    name: "R.A.G.E",
+    icon: "inv_eng_gizmo3",
+  },
+  V_I_G_O_R_ENGAGED: { //Variable Intensity Gigavolt Oscillating Reactor
+    id: 287915,
+    name: "V.I.G.O.R Engaged",
+    icon: "inv_potiond_4",
+  },
+  BUSTER_SHOT: { //Twin-pipe Buster Cannon
+    id: 289386,
+    name: "Buster Shot",
+    icon: "spell_mage_flameorb_blue",
+  },
+  HIGH_TINKERS_EXPERTISE: { //High Tinker's Cape
+    id: 291240,
+    name: "High Tinker's Expertise",
+    icon: "inv_faction_zandalariempire",
+  },
+  MECH_JOCKEY: { //Mech-jockey Grips
+    id: 290255,
+    name: "Mech-Jockey",
+    icon: "inv_engineering_gravitationalreductionslippers",
+  },
+
+  //Stormwall Blockade
+
+  //Jaina Proudmoore
+  EVERCHILL: { //Everchill Anchor
+    id: 289525,
+    name: "Everchill",
+    icon: "inv_staff_15",
+  },
+  SURGING_WATERS: { //Tidestorm Codex
+    id: 289885,
+    name: "Surging Waters",
+    icon: "spell_frost_summonwaterelemental_2",
+  },
+  LIGHT_OF_THE_SEA: { //Fogbreaker, Light of the Sea
+    id: 290249,
+    name: "Light of the Sea",
+    icon: "inv_offhand_1h_zuldazarraid_d_01",
+  },
+  KEEPSAKES_OF_THE_RESOLUTE_COMMANDANT: {
+    id: 290362,
+    name: "Keepsakes of the Resolute Commandant",
+    icon: "spell_fire_blueflamebolt",
+  },
+};

--- a/src/common/SPELLS/bfa/raids/battleofdazaralor/mechanics.js
+++ b/src/common/SPELLS/bfa/raids/battleofdazaralor/mechanics.js
@@ -1,0 +1,5 @@
+// Mechanics such as Haste buffs or debuffs triggered only in this instance
+
+export default {
+
+};

--- a/src/common/SPELLS/bfa/raids/index.js
+++ b/src/common/SPELLS/bfa/raids/index.js
@@ -1,4 +1,5 @@
 import safeMerge from 'common/safeMerge';
 import Uldir from './uldir';
+import BattleOfDazaralor from './battleofdazaralor';
 
-export default safeMerge(Uldir);
+export default safeMerge(Uldir, BattleOfDazaralor);


### PR DESCRIPTION
Adds spell info for Battle of Dazar'alor items, a prerequisite for making analyzers for the raid's trinkets.