### PR TITLE
[Sub Rogue] Shuriken Storm limit CP waste

### DIFF
--- a/src/parser/rogue/subtlety/CHANGELOG.js
+++ b/src/parser/rogue/subtlety/CHANGELOG.js
@@ -7,6 +7,11 @@ import { Zerotorescue, tsabo, Gebuz, Aelexe } from 'CONTRIBUTORS';
 
 export default [
   {
+    date: new Date('2019-01-19'),
+    changes: 'Fix Shuriken Storm CP waste. Any Shuriken Storm that generates at least 3CPs will not be considered waste, otherwise waste will be limited by the CP pool size.',
+    contributors: [tsabo],
+  },
+  {
     date: new Date('2018-12-28'),
     changes: 'Updates for 8.1, minor fixes.',
     contributors: [tsabo],

--- a/src/parser/rogue/subtlety/CONFIG.js
+++ b/src/parser/rogue/subtlety/CONFIG.js
@@ -20,12 +20,12 @@ export default {
     <>
       <Warning>
         The Subtlety Rogue analysis isn't complete yet.
-        All recomendations and analysis should be in line with <a href="http://www.ravenholdt.net/subtlety-guide/"> wEak's guide </a> and Simcraft APL.
+        All recommendations and analysis should be in line with <a href="http://www.ravenholdt.net/subtlety-guide/"> wEak's guide </a> and Simcraft APL.
         TODO:
         <ul>
          <li>Target values still need to be adjusted.</li>
          <li>More mistkes need highlighting.</li>
-         <li>Nightblade refresh analysis accuracy needs to be improved.</li>
+         <li>Nightblade usage analysis accuracy needs to be improved.</li>
         </ul>
         
         <br />

--- a/src/parser/rogue/subtlety/CombatLogParser.js
+++ b/src/parser/rogue/subtlety/CombatLogParser.js
@@ -7,6 +7,9 @@ import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import Checklist from './modules/features/checklist/Module';
 import SpellUsable from '../shared/SpellUsable';
 
+//Normalizers
+import ShurikenStormNormalizer from './normalizers/ShurikenStormNormalizer';
+
 import ComboPointDetails from '../shared/resources/ComboPointDetails';
 import ComboPointTracker from '../shared/resources/ComboPointTracker';
 import EnergyDetails from '../shared/resources/EnergyDetails';
@@ -40,6 +43,9 @@ class CombatLogParser extends CoreCombatLogParser {
     checklist: Checklist,
     alwaysBeCasting: AlwaysBeCasting,
     spellUsable: SpellUsable,
+    
+    //Normalizers
+    shurikenStormNormalizer: ShurikenStormNormalizer,
 
     //Resource
     comboPointTracker: ComboPointTracker,

--- a/src/parser/rogue/subtlety/normalizers/ShurikenStormNormalizer.js
+++ b/src/parser/rogue/subtlety/normalizers/ShurikenStormNormalizer.js
@@ -1,0 +1,58 @@
+import SPELLS from 'common/SPELLS';
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+
+/**
+ * Shuriken Storm Energize events reporting overcaping of CPs. 
+ * 
+ * @param {Array} events
+ * @returns {Array} Events possibly with some reordered.
+ */
+class ShurikenStormNormalizer extends EventsNormalizer {
+
+  /**
+   * Shuriken Storm should never provide less then 3CP.
+   * If less then 3 CPs were generated, it most likely was a mistake to cast this spell.
+   * We will remove all waste from casts that generated at least 3 CPs, because under normal circumstances you never finish with 3CP deficit.
+   * In some cases it may be better to use a different builder, but even if it is a damage or proc loss to Shuriken Storm in these situations, its still not a CP waste.
+   * 
+   * If less the 3CPs were generated, we can consider anything up to the Max CP cap as waste.
+   * Logic behind this: If finisher was used instead, next Shuriken Storm would generate CPs up to the max CP pool.
+   */
+  minCPs = 3;
+
+  normalize(events) {
+    const fixedEvents = [];
+
+    //Player CP Pool
+    let cpPool = 5;
+    if(this.selectedCombatant.hasTalent(SPELLS.DEEPER_STRATAGEM_TALENT.id)) {
+      cpPool += 1;
+    }
+
+    events.forEach((event, eventIndex) => {
+      fixedEvents.push(event);
+
+      // Find Shuriken Storm CP Events
+      if(event.type === 'energize' && event.ability.guid === SPELLS.SHURIKEN_STORM_CP.id) {
+        //Remove excess waste from Shuriken Storm.
+        if(event.waste > 0) {
+          if(event.resourceChange - event.waste >= this.minCPs) {
+            //Consider the event as having no waste
+            event.resourceChange = event.resourceChange - event.waste;
+            event.waste = 0;
+          }
+          else {
+            //Clear off extra waste that would go over the max CP
+            const newWaste = Math.min(event.waste, cpPool);
+            event.resourceChange = event.resourceChange - event.waste + newWaste;
+            event.waste = newWaste;
+          }
+        }
+      }
+    });
+    
+    return fixedEvents;
+  }
+}
+
+export default ShurikenStormNormalizer;


### PR DESCRIPTION
Fixes #2696

Normalizer to remove crazy CP waste when using Shuriken Storm in a situation with more then 6 targets.