### PR TITLE
[issue-2939] NEXT: Convert modules using `item()` into `statistic()`

### DIFF
--- a/src/parser/core/Analyzer.js
+++ b/src/parser/core/Analyzer.js
@@ -79,7 +79,6 @@ class Analyzer extends EventSubscriber {
   }
 
   // Override these with functions that return info about their rendering in the specific slots
-  item() { return undefined; }
   statistic() { return undefined; }
   /**
    * @deprecated Set the `position` property on the Statistic component instead.

--- a/src/parser/deathknight/blood/modules/items/ShacklesofBryndaor.js
+++ b/src/parser/deathknight/blood/modules/items/ShacklesofBryndaor.js
@@ -33,7 +33,7 @@ class ShacklesofBryndaor extends Analyzer {
     return this.runicPowerGained / this.owner.fightDuration * 1000 * 60;
   }
 
-  item() {
+  statistic() {
     const rpPercent=this.runicPowerGained / this.runicPowerTracker.generated;
     const extraDS=this.runicPowerGained / this.dsCost;
     return {

--- a/src/parser/deathknight/blood/modules/items/SkullflowersHaemostasis.js
+++ b/src/parser/deathknight/blood/modules/items/SkullflowersHaemostasis.js
@@ -65,7 +65,7 @@ class SkullflowersHaemostasis extends Analyzer {
     }
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.SKULLFLOWERS_HAEMOSTASIS,
       result:(

--- a/src/parser/deathknight/blood/modules/items/SoulflayersCorruption.js
+++ b/src/parser/deathknight/blood/modules/items/SoulflayersCorruption.js
@@ -49,7 +49,7 @@ class SoulflayersCorruption extends Analyzer {
     }
   }
 
-  item() {
+  statistic() {
     const perProc=this.absorb/this.umbilicusEternusCount;
     return {
       item: ITEMS.SOULFLAYERS_CORRUPTION,

--- a/src/parser/demonhunter/shared/modules/items/SoulOfTheSlayer.js
+++ b/src/parser/demonhunter/shared/modules/items/SoulOfTheSlayer.js
@@ -39,7 +39,7 @@ class SoulOfTheSlayer extends Analyzer {
     this.hasPickedOtherTalent = this.selectedCombatant.hasTalent(this.option1) || this.selectedCombatant.hasTalent(this.option2);
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.SOUL_OF_THE_SLAYER,
       result: <>This gave you <SpellLink id={this.talentGained} />.</>,

--- a/src/parser/mage/shared/modules/items/ShardOfTheExodar.js
+++ b/src/parser/mage/shared/modules/items/ShardOfTheExodar.js
@@ -49,7 +49,7 @@ class ShardOfTheExodar extends Analyzer {
     return this.teamCasts + this.personalCasts;
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.SHARD_OF_THE_EXODAR,
       result: `Gained Time Warp effect ${formatNumber(this.actualCasts)} Times. (${formatNumber(this.possibleCasts)} Possible)`,

--- a/src/parser/priest/shadow/modules/items/AnundsSearedShackles.js
+++ b/src/parser/priest/shadow/modules/items/AnundsSearedShackles.js
@@ -40,7 +40,7 @@ class AnundsSearedShackles extends Analyzer {
     }
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.ANUNDS_SEARED_SHACKLES,
       result: <ItemDamageDone amount={this.bonusDmg} />,

--- a/src/parser/priest/shadow/modules/items/HeartOfTheVoid.js
+++ b/src/parser/priest/shadow/modules/items/HeartOfTheVoid.js
@@ -32,7 +32,7 @@ class HeartOfTheVoid extends Analyzer {
     }
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.HEART_OF_THE_VOID,
       result: (

--- a/src/parser/priest/shadow/modules/items/TwinsPainfulTouch.js
+++ b/src/parser/priest/shadow/modules/items/TwinsPainfulTouch.js
@@ -47,7 +47,7 @@ class TwinsPainfulTouch extends Analyzer {
     }
   }
 
-  item() {
+  statistic() {
     const totalApplied = this.totalApplied || 0;
 
     return {

--- a/src/parser/priest/shadow/modules/items/ZenkaramIridisAnadem.js
+++ b/src/parser/priest/shadow/modules/items/ZenkaramIridisAnadem.js
@@ -35,7 +35,7 @@ class ZenkaramIridisAnadem extends Analyzer {
     }
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.ZENKARAM_IRIDIS_ANADEM,
       result: (

--- a/src/parser/shared/modules/items/bfa/AncientKnotOfWisdom.js
+++ b/src/parser/shared/modules/items/bfa/AncientKnotOfWisdom.js
@@ -73,7 +73,7 @@ class AncientKnotOfWisdom extends Analyzer {
     return (averageStacks * this.intellectPerStack).toFixed(0);
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.ANCIENT_KNOT_OF_WISDOM,
       result: (

--- a/src/parser/shared/modules/items/bfa/FirstMatesSpyglass.js
+++ b/src/parser/shared/modules/items/bfa/FirstMatesSpyglass.js
@@ -73,7 +73,7 @@ class FirstMatesSpyglass extends Analyzer {
       return this.selectedCombatant.getBuffUptime(SPELLS.SPYGLASS_SIGHT.id) / this.owner.fightDuration;
   }
   
-  item() {
+  statistic() {
     return {
       item: ITEMS.FIRST_MATES_SPYGLASS,
       result: (

--- a/src/parser/shared/modules/items/bfa/GildedLoaFigurine.js
+++ b/src/parser/shared/modules/items/bfa/GildedLoaFigurine.js
@@ -30,7 +30,7 @@ class GildedLoaFigurine extends Analyzer {
     return this.selectedCombatant.getBuffUptime(SPELLS.WILL_OF_THE_LOA.id) / this.owner.fightDuration;
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.GILDED_LOA_FIGURINE,
       result: (

--- a/src/parser/shared/modules/items/bfa/SeaGiantsTidestone.js
+++ b/src/parser/shared/modules/items/bfa/SeaGiantsTidestone.js
@@ -66,7 +66,7 @@ class SeaGiantsTidestone extends Analyzer {
     return this.selectedCombatant.getBuffUptime(SPELLS.FEROCITY_OF_THE_SKROG.id) / this.owner.fightDuration;
   }
   
-  item() {
+  statistic() {
     return {
       item: ITEMS.SEA_GIANTS_TIDESTONE,
       result: (

--- a/src/parser/shared/modules/items/bfa/crafted/DarkmoonDeckBlockades.js
+++ b/src/parser/shared/modules/items/bfa/crafted/DarkmoonDeckBlockades.js
@@ -142,7 +142,7 @@ class DarkmoonDeckBlockades extends Analyzer {
     };
   }
 
-  item() {
+  statistic() {
     const summary = this.staminaSummary;
     const totals = this._getSummaryTotals(summary);
     const tooltipData = (

--- a/src/parser/shared/modules/items/bfa/crafted/DarkmoonDeckFathoms.js
+++ b/src/parser/shared/modules/items/bfa/crafted/DarkmoonDeckFathoms.js
@@ -29,7 +29,7 @@ class DarkmoonDeckFathoms extends Analyzer {
     this.damage += event.amount + (event.absorbed || 0);
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.DARKMOON_DECK_FATHOMS,
       result: <ItemDamageDone amount={this.damage} />,

--- a/src/parser/shared/modules/items/bfa/crafted/DarkmoonDeckTides.js
+++ b/src/parser/shared/modules/items/bfa/crafted/DarkmoonDeckTides.js
@@ -51,7 +51,7 @@ class DarkmoonDeckTides extends Analyzer {
     this.manaGained += event.resourceChange;
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.DARKMOON_DECK_TIDES,
       result: (

--- a/src/parser/shared/modules/items/bfa/dungeons/AzerokksResonatingHeart.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/AzerokksResonatingHeart.js
@@ -58,7 +58,7 @@ class AzerokksResonatingHeart extends Analyzer {
     return (this.agilityBuff * this.uptime).toFixed(0);
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.AZEROKKS_RESONATING_HEART,
       result: (

--- a/src/parser/shared/modules/items/bfa/dungeons/BalefireBranch.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/BalefireBranch.js
@@ -163,7 +163,7 @@ class BalefireBranch extends Analyzer {
     return this.intellectPerStack * (this.sumStacks / (this.owner.fightDuration / 1000));
   }
 
-  item() {
+  statistic() {
     const expectedIntellectWithoutDamage = this.intellectPerStack * (this.expectedSumStacks / (this.owner.fightDuration / 1000));
     return {
       item: ITEMS.BALEFIRE_BRANCH,

--- a/src/parser/shared/modules/items/bfa/dungeons/ConchofDarkWhispers.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/ConchofDarkWhispers.js
@@ -26,7 +26,7 @@ class ConchofDarkWhispers extends Analyzer {
     return this.selectedCombatant.getBuffUptime(SPELLS.CONCH_OF_DARK_WHISPERS_BUFF.id) / this.owner.fightDuration;
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.CONCH_OF_DARK_WHISPERS,
       result: (

--- a/src/parser/shared/modules/items/bfa/dungeons/FangsOfIntertwinedEssence.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/FangsOfIntertwinedEssence.js
@@ -67,7 +67,7 @@ class FangsOfIntertwinedEssence extends Analyzer {
     return this.restoreCount / this.useCount;
   }
   
-  item() {
+  statistic() {
     return {
       item: ITEMS.FANGS_OF_INTERTWINED_ESSENCE,
       result: (

--- a/src/parser/shared/modules/items/bfa/dungeons/GalecallersBoon.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/GalecallersBoon.js
@@ -43,7 +43,7 @@ class GalecallersBoon extends Analyzer {
     return this.selectedCombatant.getBuffUptime(SPELLS.GALECALLERS_BOON_BUFF.id) / this.owner.fightDuration;
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.GALECALLERS_BOON,
       result: (

--- a/src/parser/shared/modules/items/bfa/dungeons/HarlansLoadedDice.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/HarlansLoadedDice.js
@@ -61,7 +61,7 @@ class HarlansLoadedDice extends Analyzer {
     return this.selectedCombatant.getBuffTriggerCount(SPELLS.LOADED_DIE_MASTERY_SMALL.id) + this.selectedCombatant.getBuffTriggerCount(SPELLS.LOADED_DIE_MASTERY_BIG.id);
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.HARLANS_LOADED_DICE,
       result: (

--- a/src/parser/shared/modules/items/bfa/dungeons/LadyWaycrestsMusicBox.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/LadyWaycrestsMusicBox.js
@@ -45,7 +45,7 @@ class LadyWaycrestsMusicBox extends Analyzer {
     this.active = this.selectedCombatant.hasTrinket(ITEMS.LADY_WAYCRESTS_MUSIC_BOX.id);
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.LADY_WAYCRESTS_MUSIC_BOX,
       result: (

--- a/src/parser/shared/modules/items/bfa/dungeons/LingeringSporepods.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/LingeringSporepods.js
@@ -53,7 +53,7 @@ class LingeringSporepods extends Analyzer {
     this.healing += (event.amount || 0) + (event.absorbed || 0);
   }
   
-  item() {
+  statistic() {
     return {
       item: ITEMS.LINGERING_SPOREPODS,
       result: (

--- a/src/parser/shared/modules/items/bfa/dungeons/LustrousGoldenPlumage.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/LustrousGoldenPlumage.js
@@ -41,7 +41,7 @@ class LustrousGoldenPlumage extends Analyzer {
     return this.selectedCombatant.getBuffUptime(SPELLS.GOLDEN_LUSTER.id) / this.owner.fightDuration;
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.LUSTROUS_GOLDEN_PLUMAGE,
       result: (

--- a/src/parser/shared/modules/items/bfa/dungeons/MydasTalisman.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/MydasTalisman.js
@@ -44,7 +44,7 @@ class MydasTalisman extends Analyzer {
     this.damage += event.amount + (event.absorbed || 0);
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.MYDAS_TALISMAN,
       result: <ItemDamageDone amount={this.damage} />,

--- a/src/parser/shared/modules/items/bfa/dungeons/RevitalizingVoodooTotem.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/RevitalizingVoodooTotem.js
@@ -45,7 +45,7 @@ class RevitalizingVoodooTotem extends Analyzer {
     this.healing += event.amount + (event.absorbed || 0);
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.REVITALIZING_VOODOO_TOTEM,
       result: <ItemHealingDone amount={this.healing} />,

--- a/src/parser/shared/modules/items/bfa/dungeons/RezansGleamingEye.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/RezansGleamingEye.js
@@ -28,7 +28,7 @@ class RezansGleamingEye extends Analyzer {
         return this.selectedCombatant.getBuffUptime(SPELLS.REZANS_GLEAMING_EYE_BUFF.id) / this.owner.fightDuration;
     }
 
-    item() {
+    statistic() {
         return {
         item: ITEMS.REZANS_GLEAMING_EYE,
         result: (

--- a/src/parser/shared/modules/items/bfa/dungeons/RotcrustedVoodooDoll.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/RotcrustedVoodooDoll.js
@@ -50,7 +50,7 @@ class RotcrustedVoodooDoll extends Analyzer {
     this.ticks += 1;
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.ROTCRUSTED_VOODOO_DOLL,
       result: (

--- a/src/parser/shared/modules/items/bfa/dungeons/Seabreeze.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/Seabreeze.js
@@ -34,7 +34,7 @@ class Seabreeze extends Analyzer {
     return averageStacks * this.statBuff;
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.SEABREEZE,
       result: (

--- a/src/parser/shared/modules/items/bfa/dungeons/VesselOfSkitteringShadows.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/VesselOfSkitteringShadows.js
@@ -29,7 +29,7 @@ class VesselOfSkitteringShadows extends Analyzer {
     this.damage += event.amount + (event.absorbed || 0);
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.VESSEL_OF_SKITTERING_SHADOWS,
       result: <ItemDamageDone amount={this.damage} />,

--- a/src/parser/shared/modules/items/bfa/enchants/CoastalSurge.js
+++ b/src/parser/shared/modules/items/bfa/enchants/CoastalSurge.js
@@ -28,7 +28,7 @@ class CostalSurge extends Analyzer {
   }
 
 
-  item() {
+  statistic() {
     return {
       id: SPELLS.COASTAL_SURGE.id,
       icon: <SpellIcon id={SPELLS.COASTAL_SURGE.id} />,

--- a/src/parser/shared/modules/items/bfa/enchants/Navigation.js
+++ b/src/parser/shared/modules/items/bfa/enchants/Navigation.js
@@ -126,7 +126,7 @@ class Navigation extends Analyzer {
 
     return ((smallBuffIncrease + bigBuffIncrease) / this.owner.fightDuration).toFixed(2);
   }
-  item() {
+  statistic() {
     const buffStacks = this.cleanStacks;
     const maxStackBuffDuration = this.maxStackBuffUptime();
     const tooltipData = (

--- a/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsBadge.js
+++ b/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsBadge.js
@@ -41,7 +41,7 @@ class DreadGladiatorsBadge extends Analyzer {
     return this.selectedCombatant.getBuffUptime(SPELLS.DIG_DEEP.id) / this.owner.fightDuration;
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.DREAD_GLADIATORS_BADGE,
       result: (

--- a/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsInsignia.js
+++ b/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsInsignia.js
@@ -58,7 +58,7 @@ class DreadGladiatorsInsignia extends Analyzer {
     return (this.primaryStatBuff * this.uptime).toFixed(0);
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.DREAD_GLADIATORS_INSIGNIA,
       result: (

--- a/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsMedallion.js
+++ b/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsMedallion.js
@@ -40,7 +40,7 @@ class DreadGladiatorsMedallion extends Analyzer {
     return this.selectedCombatant.getBuffUptime(SPELLS.RAPID_ADAPTATION.id) / this.owner.fightDuration;
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.DREAD_GLADIATORS_MEDALLION,
       result: (

--- a/src/parser/shared/modules/items/bfa/raids/uldir/ConstructOvercharger.js
+++ b/src/parser/shared/modules/items/bfa/raids/uldir/ConstructOvercharger.js
@@ -35,7 +35,7 @@ class ConstructOvercharger extends Analyzer {
     return this.selectedCombatant.getBuffTriggerCount(SPELLS.TITANIC_OVERCHARGE.id);
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.CONSTRUCT_OVERCHARGER,
       result: (

--- a/src/parser/shared/modules/items/bfa/raids/uldir/DiscOfSystematicRegression.js
+++ b/src/parser/shared/modules/items/bfa/raids/uldir/DiscOfSystematicRegression.js
@@ -30,7 +30,7 @@ class DiscOfSystematicRegression extends Analyzer {
         }
     }
 
-    item(){
+    statistic(){
         return {
         item: ITEMS.DISC_OF_SYSTEMATIC_REGRESSION,
         result: (

--- a/src/parser/shared/modules/items/bfa/raids/uldir/FreneticCorpuscle.js
+++ b/src/parser/shared/modules/items/bfa/raids/uldir/FreneticCorpuscle.js
@@ -28,7 +28,7 @@ class FreneticCorpuscle extends Analyzer {
     }
   }
 
-  item(){
+  statistic(){
     return {
       item: ITEMS.FRENETIC_CORPUSCLE,
       result: (

--- a/src/parser/shared/modules/items/bfa/raids/uldir/InoculatingExtract.js
+++ b/src/parser/shared/modules/items/bfa/raids/uldir/InoculatingExtract.js
@@ -61,7 +61,7 @@ class InoculatingExtract extends Analyzer{
   }
 
 
-  item(){
+  statistic(){
     return{
       item: ITEMS.INOCULATING_EXTRACT,
       result: (

--- a/src/parser/shared/modules/items/bfa/raids/uldir/SyringeOfBloodborneInfirmity.js
+++ b/src/parser/shared/modules/items/bfa/raids/uldir/SyringeOfBloodborneInfirmity.js
@@ -55,7 +55,7 @@ class SyringeOfBloodborneInfirmity extends Analyzer{
         return this.selectedCombatant.getBuffTriggerCount(SPELLS.CRITICAL_PROWESS.id);
     }
 
-    item() {
+    statistic() {
         return {
             item: ITEMS.SYRINGE_OF_BLOODBORNE_INFIRMITY,
             result: (

--- a/src/parser/shared/modules/items/bfa/raids/uldir/TwitchingTentacleofXalzaix.js
+++ b/src/parser/shared/modules/items/bfa/raids/uldir/TwitchingTentacleofXalzaix.js
@@ -27,7 +27,7 @@ class TwitchingTentacleofXalzaix extends Analyzer {
     return this.selectedCombatant.getBuffUptime(SPELLS.UNCONTAINED_POWER.id) / this.owner.fightDuration;
   }
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.TWITCHING_TENTACLE_OF_XALZAIX,
       result: (

--- a/src/parser/shared/modules/items/bfa/raids/uldir/VigilantsBloodshaper.js
+++ b/src/parser/shared/modules/items/bfa/raids/uldir/VigilantsBloodshaper.js
@@ -29,7 +29,7 @@ class VigilantsBloodshaper extends Analyzer{
     }
   }
 
-  item(){
+  statistic(){
     return{
       item: ITEMS.VIGILANTS_BLOODSHAPER,
       result: (

--- a/src/parser/warrior/protection/modules/items/ThundergodsVigor.js
+++ b/src/parser/warrior/protection/modules/items/ThundergodsVigor.js
@@ -40,7 +40,7 @@ class ThundergodsVigor extends Analyzer {
   }
 
 
-  item() {
+  statistic() {
     return {
       item: ITEMS.THUNDERGODS_VIGOR,
       result: (


### PR DESCRIPTION
- change `item()` deprecated usages left to `statistic()`
- remove `item()` from `Analyzer` completely

#2939 