### PR TITLE
[General] Updating the wording on the EncounterStats

### DIFF
--- a/src/interface/report/Results/EncounterStats.js
+++ b/src/interface/report/Results/EncounterStats.js
@@ -256,7 +256,7 @@ class EncounterStats extends React.PureComponent {
             </div>
           </div>
           <div className="col-md-6">
-            {formatThousands(log.total)} DPS
+            {formatThousands(log.total)} {this.metric}
           </div>
         </div>
       </div>

--- a/src/interface/report/Results/EncounterStats.js
+++ b/src/interface/report/Results/EncounterStats.js
@@ -266,7 +266,7 @@ class EncounterStats extends React.PureComponent {
   similiarLogs() {
     return (
       <div className="col-md-12 flex-main" style={{ textAlign: 'left', margin: '5px auto' }}>
-        {this.state.similiarKillTimes.length > 1 ? 'These are' : 'This is'} the {this.state.similiarKillTimes.length} top {this.amountOfParses} {this.state.similiarKillTimes.length > 1 ? 'logs' : 'log'} that {this.state.similiarKillTimes.length > 1 ? 'are' : 'is'} closest to your kill-time within {formatPercentage(this.durationVariancePercentage, 0)}% variance.
+        {this.state.similiarKillTimes.length > 1 ? 'These are' : 'This is'} {this.state.similiarKillTimes.length} of the top {this.amountOfParses} {this.state.similiarKillTimes.length > 1 ? 'logs' : 'log'} that {this.state.similiarKillTimes.length > 1 ? 'are' : 'is'} closest to your kill-time within {formatPercentage(this.durationVariancePercentage, 0)}% variance.
         {this.state.similiarKillTimes.map(log => this.singleLog(log.rank))}
       </div>
     );
@@ -275,7 +275,7 @@ class EncounterStats extends React.PureComponent {
   closestLogs() {
     return (
       <div className="col-md-12 flex-main" style={{ textAlign: 'left', margin: '5px auto' }}>
-        {this.state.closestKillTimes.length > 1 ? 'These are' : 'This is'} the {this.state.closestKillTimes.length} top {this.amountOfParses} {this.state.closestKillTimes.length > 1 ? 'logs' : 'log'} that {this.state.closestKillTimes.length > 1 ? 'are' : 'is'} closest to your kill-time. Large differences won't be good for comparing.
+        {this.state.closestKillTimes.length > 1 ? 'These are' : 'This is'} {this.state.closestKillTimes.length} of the top {this.amountOfParses} {this.state.closestKillTimes.length > 1 ? 'logs' : 'log'} that {this.state.closestKillTimes.length > 1 ? 'are' : 'is'} closest to your kill-time. Large differences won't be good for comparing.
         {this.state.closestKillTimes.map(log => this.singleLog(log.rank))}
       </div>
     );


### PR DESCRIPTION
Healers currently show "dps done" in the similar fights pane. This fixes that.

I felt that the wording for the similar kill times was a bit off.

`These are the 9 top 9 logs that are closest to your kill-time within 20% variance.`

will now be

`These are 9 of the top 9 logs that are closest to your kill-time within 20% variance.`

This is an examples of a *healers* log:

Before: ![screen shot 2019-01-31 at 8 05 26 am](https://user-images.githubusercontent.com/716498/52063071-10f9ae80-252f-11e9-91d8-6c90678b4d5b.png)

After: ![screen shot 2019-01-31 at 8 05 46 am](https://user-images.githubusercontent.com/716498/52063081-13f49f00-252f-11e9-9c01-1651cc6bf131.png)
