### PR TITLE
Arms warrior improvements

### DIFF
--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -547,3 +547,7 @@ export const Eylwen = {
   github: 'Alastair-Scott',
   discord: 'Eylwen#0287',
 };
+export const Korebian = {
+  nickname: 'Korebian',
+  github: 'Asamsig',
+};

--- a/src/parser/warrior/arms/CHANGELOG.js
+++ b/src/parser/warrior/arms/CHANGELOG.js
@@ -1,9 +1,14 @@
 import React from 'react';
-import { Aelexe, Zerotorescue, Sharrq, Matardarix } from 'CONTRIBUTORS';
+import { Aelexe, Zerotorescue, Sharrq, Matardarix, Korebian } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 
 export default [
+  {
+    date: new Date('2019-02-02'),
+    changes: <>Added more information to the <SpellLink id={SPELLS.CRUSHING_ASSAULT_TRAIT.id} /> module. Added <SpellLink id={SPELLS.LORD_OF_WAR.id} /> module.</>,
+    contributors: [Korebian],
+  },
   {
     date: new Date('2018-12-12'),
     changes: <>Updated for patch 8.1, <SpellLink id={SPELLS.CHARGE.id} /> is no longer on the GCD and <SpellLink id={SPELLS.EXECUTIONERS_PRECISION_TRAIT.id} /> have been replaced by <SpellLink id={SPELLS.STRIKING_THE_ANVIL.id} />.</>,

--- a/src/parser/warrior/arms/CombatLogParser.js
+++ b/src/parser/warrior/arms/CombatLogParser.js
@@ -45,6 +45,7 @@ import SeismicWave from './modules/spells/azeritetraits/SeismicWave';
 import TestOfMight from './modules/spells/azeritetraits/TestOfMight';
 import CrushingAssault from './modules/spells/azeritetraits/CrushingAssault';
 import StrikingTheAnvil from './modules/spells/azeritetraits/StrikingTheAnvil';
+import LordOfWar from './modules/spells/azeritetraits/LordOfWar';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -103,6 +104,7 @@ class CombatLogParser extends CoreCombatLogParser {
     testOfMight: TestOfMight,
     crushingAssault: CrushingAssault,
     strikingTheAnvil: StrikingTheAnvil,
+    lordOfWar: LordOfWar,
   };
 }
 

--- a/src/parser/warrior/arms/modules/core/Execute/MortalStrike.js
+++ b/src/parser/warrior/arms/modules/core/Execute/MortalStrike.js
@@ -70,7 +70,7 @@ class MortalStrikeAnalyzer extends Analyzer {
     when(this.badMortalStrikeThresholds).addSuggestion((suggest, actual, recommended) => {
       return suggest(<>Try to avoid using <SpellLink id={SPELLS.MORTAL_STRIKE.id} icon /> on a target in <SpellLink id={SPELLS.EXECUTE.id} icon /> range, as <SpellLink id={SPELLS.MORTAL_STRIKE.id} /> is less rage efficient than <SpellLink id={SPELLS.EXECUTE.id} />.</>)
         .icon(SPELLS.MORTAL_STRIKE.icon)
-        .actual(`Mortal Strike was used ${formatPercentage(actual)}% of the time on a target in execute range.`)
+        .actual(`Mortal Strike was cast ${this.mortalStrikesInExecuteRange} times accounting for ${formatPercentage(actual)}% of the total possible casts of Mortal Strike during a time a target was in execute range.`)
         .recommended(`${formatPercentage(recommended)}% is recommended`);
     });
     when(this.goodMortalStrikeThresholds).addSuggestion((suggest, actual, recommended) => {

--- a/src/parser/warrior/arms/modules/core/Overpower.js
+++ b/src/parser/warrior/arms/modules/core/Overpower.js
@@ -31,7 +31,7 @@ class OverpowerAnalyzer extends Analyzer {
       return;
     }
 
-    if (!this.executeRange.isTargetInExecuteRange(event) && !this.hasEP) {
+    if (!this.executeRange.isTargetInExecuteRange(event)) {
       this.wastedProc += 1;
 
       event.meta = event.meta || {};

--- a/src/parser/warrior/arms/modules/spells/azeritetraits/CrushingAssault.js
+++ b/src/parser/warrior/arms/modules/spells/azeritetraits/CrushingAssault.js
@@ -4,7 +4,8 @@ import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import TraitStatisticBox, { STATISTIC_ORDER } from 'interface/others/TraitStatisticBox';
 import React from 'react';
 import Events from 'parser/core/Events';
-import { formatNumber } from 'common/format';
+import { formatNumber, formatPercentage } from 'common/format';
+import HIT_TYPES from 'game/HIT_TYPES';
 
 const crushingAssaultDamage = traits => Object.values(traits).reduce((obj, rank) => {
   const [damage] = calculateAzeriteEffects(SPELLS.CRUSHING_ASSAULT_TRAIT.id, rank);
@@ -26,6 +27,8 @@ class CrushingAssault extends Analyzer {
   traits = 0;
 
   crushingAssaultDamage = 0;
+  totalProcs = 0;
+  crits = 0;
 
   constructor(...args) {
     super(...args);
@@ -39,22 +42,31 @@ class CrushingAssault extends Analyzer {
     this.traits = traits;
 
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.SLAM), this._onSlamDamage);
+    this.addEventListener(Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.CRUSHING_ASSAULT_BUFF), this._countCrushingAssaultProc);
+    this.addEventListener(Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.CRUSHING_ASSAULT_BUFF), this._countCrushingAssaultProc);
   }
 
-  _onSlamDamage() {
+  _onSlamDamage(event) {
     if (!this.selectedCombatant.hasBuff(SPELLS.CRUSHING_ASSAULT_BUFF.id)) {
       return;
     }
     this.crushingAssaultDamage += this.damage;
+    this.crits += event.hitType === HIT_TYPES.CRIT ? 1 : 0;
+  }
+
+  _countCrushingAssaultProc() {
+    this.totalProcs += 1;
   }
 
   statistic() {
+    const critPercent = (this.crits === 0 || this.totalProcs === 0) ? 'none' : `${formatPercentage((this.crits / this.totalProcs), 0)}%`;
     return (
       <TraitStatisticBox
         position={STATISTIC_ORDER.OPTIONAL()}
         trait={SPELLS.CRUSHING_ASSAULT_TRAIT.id}
         value={`${this.owner.formatItemDamageDone(this.crushingAssaultDamage)}`}
-        tooltip={`Damage done: ${formatNumber(this.crushingAssaultDamage)}`}
+        tooltip={`Damage done: <b>${formatNumber(this.crushingAssaultDamage)}</b><br />
+        Crushing Assault procced a total of <b>${this.totalProcs}</b> times, <b>${critPercent}</b> of which were critital hits.`}
       />
     );
   }

--- a/src/parser/warrior/arms/modules/spells/azeritetraits/LordOfWar.js
+++ b/src/parser/warrior/arms/modules/spells/azeritetraits/LordOfWar.js
@@ -1,0 +1,59 @@
+import { calculateAzeriteEffects } from 'common/stats';
+import SPELLS from 'common/SPELLS';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import TraitStatisticBox, { STATISTIC_ORDER } from 'interface/others/TraitStatisticBox';
+import React from 'react';
+import Events from 'parser/core/Events';
+import { formatNumber } from 'common/format';
+
+const lordOfWarDamage = traits => Object.values(traits).reduce((obj, rank) => {
+  const [damage] = calculateAzeriteEffects(SPELLS.LORD_OF_WAR.id, rank);
+  obj.damage += damage;
+  obj.traits += 1;
+  return obj;
+}, {
+  damage: 0,
+  traits: 0,
+});
+
+/**
+ * Example report: /report/YXFby87mzNrLtwj1/7-Normal+Conclave+of+the+Chosen+-+Kill+(4:17)/30-Korebian/timeline
+ */
+
+class LordOfWar extends Analyzer {
+
+  damage = 0;
+  traits = 0;
+
+  lordOfWarDamage = 0;
+
+  constructor(...args) {
+    super(...args);
+    
+    this.active = this.selectedCombatant.hasTrait(SPELLS.LORD_OF_WAR.id);
+
+    const { damage, traits } = lordOfWarDamage(this.selectedCombatant.traitsBySpellId[SPELLS.LORD_OF_WAR.id]);
+    this.damage = damage;
+    this.traits = traits;
+
+    const spell = this.selectedCombatant.hasTalent(SPELLS.WARBREAKER_TALENT.id) ? SPELLS.WARBREAKER_TALENT : SPELLS.COLOSSUS_SMASH;
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(spell), this._onColossusSmashDamage);
+  }
+
+  _onColossusSmashDamage() {
+    this.lordOfWarDamage += this.damage;
+  }
+
+  statistic() {
+    return (
+      <TraitStatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
+        trait={SPELLS.LORD_OF_WAR.id}
+        value={`${this.owner.formatItemDamageDone(this.lordOfWarDamage)}`}
+        tooltip={`Damage done: <b>${formatNumber(this.lordOfWarDamage)}</b>`}
+      />
+    );
+  }
+}
+
+export default LordOfWar;

--- a/src/parser/warrior/arms/modules/spells/azeritetraits/StrikingTheAnvil.js
+++ b/src/parser/warrior/arms/modules/spells/azeritetraits/StrikingTheAnvil.js
@@ -5,6 +5,8 @@ import SPELLS from 'common/SPELLS/index';
 import TraitStatisticBox from 'interface/others/TraitStatisticBox';
 import Events from 'parser/core/Events';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
+import Enemies from 'parser/shared/modules/Enemies';
+import ExecuteRange from 'parser/warrior/arms/modules/core/Execute/ExecuteRange';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 
 /**
@@ -29,6 +31,8 @@ const CDR_PER_PROC = 1500; // ms
 
 class StrikingTheAnvil extends Analyzer {
   static dependencies = {
+    executeRange: ExecuteRange,
+    enemies: Enemies,
     spellUsable: SpellUsable,
   };
 
@@ -41,12 +45,14 @@ class StrikingTheAnvil extends Analyzer {
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.OVERPOWER), this._onOverpowerCast);
   }
 
-  _onOverpowerCast() {
+  _onOverpowerCast(event) {
     if (!this.selectedCombatant.hasBuff(SPELLS.STRIKING_THE_ANVIL_BUFF.id)) {
       return;
     }
     if (!this.spellUsable.isOnCooldown(SPELLS.MORTAL_STRIKE.id)) {
-      this.wastedReduction += CDR_PER_PROC;
+      if (!this.executeRange.isTargetInExecuteRange(event)) {
+        this.wastedReduction += CDR_PER_PROC;
+      }
     } else {
       const effectiveReduction = this.spellUsable.reduceCooldown(SPELLS.MORTAL_STRIKE.id, CDR_PER_PROC);
       this.effectiveReduction += effectiveReduction;


### PR DESCRIPTION
Slam with crushing assault is not a bad cast over mortal strike during execution phase.
Added Lord of War tracking.
Added more info to the tooltip on Crushing assault.
Added more information to overusing Mortal Strike/Slam.
Excluded Striking the Anvil "waste" when in execute range.