### PR TITLE
[Havoc DH] Level 100 talents

### DIFF
--- a/src/parser/demonhunter/havoc/CHANGELOG.js
+++ b/src/parser/demonhunter/havoc/CHANGELOG.js
@@ -1,15 +1,16 @@
 import React from 'react';
 
-import { Mamtooth } from 'CONTRIBUTORS';
+import { Mamtooth, Yajinni } from 'CONTRIBUTORS';
 import ITEMS from 'common/ITEMS';
 import ItemLink from 'common/ItemLink';
+import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 
 export default [
   {
     date: new Date('2019-02-06'),
-    changes: <>Added stats and suggestions for <SpellLink id={ITEMS.IMMOLATION_AURA.id} icon /> and <SpellLink id={ITEMS.DEMON_BLADES_TALENT.id} icon />.</>,
-    contributors: [Mamtooth],
+    changes: <>Added stats and suggestions for <SpellLink id={SPELLS.IMMOLATION_AURA_TALENT.id} /> and <SpellLink id={SPELLS.DEMON_BLADES_TALENT.id} />.</>,
+    contributors: [Yajinni],
   },
   {
     date: new Date('2018-08-05'),

--- a/src/parser/demonhunter/havoc/CHANGELOG.js
+++ b/src/parser/demonhunter/havoc/CHANGELOG.js
@@ -3,8 +3,14 @@ import React from 'react';
 import { Mamtooth } from 'CONTRIBUTORS';
 import ITEMS from 'common/ITEMS';
 import ItemLink from 'common/ItemLink';
+import SpellLink from 'common/SpellLink';
 
 export default [
+  {
+    date: new Date('2019-02-06'),
+    changes: <>Added stats and suggestions for <SpellLink id={ITEMS.IMMOLATION_AURA.id} icon /> and <SpellLink id={ITEMS.DEMON_BLADES_TALENT.id} icon />.</>,
+    contributors: [Mamtooth],
+  },
   {
     date: new Date('2018-08-05'),
     changes: <>Added <ItemLink id={ITEMS.SOUL_OF_THE_SLAYER.id} icon /> suggestions talents picks for BfA.</>,

--- a/src/parser/demonhunter/havoc/CONFIG.js
+++ b/src/parser/demonhunter/havoc/CONFIG.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Mamtooth } from 'CONTRIBUTORS';
+import { Mamtooth, Yajinni } from 'CONTRIBUTORS';
 import SPECS from 'game/SPECS';
 import retryingPromise from 'common/retryingPromise';
 import Warning from 'interface/common/Alert/Warning';
@@ -9,7 +9,7 @@ import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Mamtooth],
+  contributors: [Mamtooth, Yajinni],
   // The WoW client patch this spec was last updated to be fully compatible with.
   patchCompatibility: '8.0.1',
   // If set to  false`, the spec will show up as unsupported.

--- a/src/parser/demonhunter/havoc/CombatLogParser.js
+++ b/src/parser/demonhunter/havoc/CombatLogParser.js
@@ -17,6 +17,7 @@ import Nemesis from './modules/spells/Nemesis';
 import Felblade from './modules/talents/Felblade';
 import DemonicAppetite from './modules/talents/DemonicAppetite';
 import BlindFury from './modules/talents/BlindFury';
+import DemonBlades from './modules/talents/DemonBlades';
 
 
 //Resources
@@ -50,6 +51,7 @@ class CombatLogParser extends CoreCombatLogParser {
     felblade: Felblade,
     demonicAppetite: DemonicAppetite,
     blindFury: BlindFury,
+    demonBlades: DemonBlades,
 
     //Resources
     furyTracker: FuryTracker,

--- a/src/parser/demonhunter/havoc/CombatLogParser.js
+++ b/src/parser/demonhunter/havoc/CombatLogParser.js
@@ -18,7 +18,7 @@ import Felblade from './modules/talents/Felblade';
 import DemonicAppetite from './modules/talents/DemonicAppetite';
 import BlindFury from './modules/talents/BlindFury';
 import DemonBlades from './modules/talents/DemonBlades';
-
+import ImmolationAura from './modules/talents/ImmolationAura';
 
 //Resources
 import FuryDetails from './modules/resourcetracker/FuryDetails';
@@ -52,6 +52,7 @@ class CombatLogParser extends CoreCombatLogParser {
     demonicAppetite: DemonicAppetite,
     blindFury: BlindFury,
     demonBlades: DemonBlades,
+    immolationAura: ImmolationAura,
 
     //Resources
     furyTracker: FuryTracker,

--- a/src/parser/demonhunter/havoc/modules/talents/DemonBlades.js
+++ b/src/parser/demonhunter/havoc/modules/talents/DemonBlades.js
@@ -67,8 +67,10 @@ class DemonBlades extends Analyzer{
       <TalentStatisticBox
         talent={SPELLS.DEMON_BLADES_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(6)}
-        value={(<>{this.furyPerMin} fury per min <br />
-                {this.owner.formatItemDamageDone(this.damage)}</>)}
+        value={(<>
+                {this.furyPerMin} fury per min <br />
+                {this.owner.formatItemDamageDone(this.damage)}
+              </>)}
         tooltip={`
           ${formatThousands(this.damage)} Total damage<br />
           ${this.effectiveFuryGain} Effective fury gained<br />

--- a/src/parser/demonhunter/havoc/modules/talents/DemonBlades.js
+++ b/src/parser/demonhunter/havoc/modules/talents/DemonBlades.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import TalentStatisticBox from 'interface/others/TalentStatisticBox';
+import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
+import Events from 'parser/core/Events';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { formatThousands } from 'common/format';
+
+/**
+ * Example Report:
+ */
+class DemonBlades extends Analyzer{
+
+  effectiveFuryGain = 0;
+  furyGain = 0;
+  furyWaste = 0;
+  damage = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.DEMON_BLADES_TALENT.id);
+    if (!this.active) {
+      return;
+    }
+    this.addEventListener(Events.energize.by(SELECTED_PLAYER).spell(SPELLS.DEMON_BLADES_FURY), this.onEnergizeEvent);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.DEMON_BLADES_FURY), this.onDamageEvent);
+  }
+
+  onEnergizeEvent(event) {
+    this.furyGain += event.resourceChange;
+    this.furyWaste += event.waste;
+  }
+
+  onDamageEvent(event) {
+    this.damage += event.amount;
+  }
+
+  get furyPerMin() {
+    return ((this.furyGain - this.furyWaste) / (this.owner.fightDuration/60000)).toFixed(2);
+  }
+
+  statistic(){
+    this.effectiveFuryGain = this.furyGain - this.furyWaste;
+    return (
+      <TalentStatisticBox
+        talent={SPELLS.DEMON_BLADES_TALENT.id}
+        position={STATISTIC_ORDER.OPTIONAL(6)}
+        value={(<>{this.furyPerMin} fury per min <br />
+                {this.owner.formatItemDamageDone(this.damage)}</>)}
+        tooltip={`
+          ${formatThousands(this.damage)} Total damage<br />
+          ${this.effectiveFuryGain} Effective fury gained<br />
+          ${this.furyGain} Total fury gained<br />
+          ${this.furyWaste} Fury wasted
+        `}
+      />
+    );
+  }
+}
+export default DemonBlades;

--- a/src/parser/demonhunter/havoc/modules/talents/ImmolationAura.js
+++ b/src/parser/demonhunter/havoc/modules/talents/ImmolationAura.js
@@ -7,7 +7,7 @@ import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import { formatThousands, formatPercentage } from 'common/format';
 
 /**
- * Example Report:
+ * Example Report: https://www.warcraftlogs.com/reports/tYjD6fp9cJ7nbAkm/#fight=7&source=12
  */
 
 const IMMOLATION_AURA = [SPELLS.IMMOLATION_AURA_FIRST_STRIKE_DPS, SPELLS.IMMOLATION_AURA_BUFF_DPS];

--- a/src/parser/demonhunter/havoc/modules/talents/ImmolationAura.js
+++ b/src/parser/demonhunter/havoc/modules/talents/ImmolationAura.js
@@ -58,28 +58,6 @@ class ImmolationAura extends Analyzer{
     when(this.suggestionThresholds)
       .addSuggestion((suggest, actual, recommended) => {
         return suggest(<> Be mindful of your fury levels and spend it before capping.</>)
-          .icon(SPELLS.DEMON_BLADES_TALENT.icon)
-          .actual(`${formatPercentage(actual)}% fury wasted`)
-          .recommended(`0% is recommended.`);
-      });
-  }
-
-  get suggestionThresholds() {
-    return {
-      actual: this.furyWaste / this.furyGain,
-      isGreaterThan: {
-        minor: 0.03,
-        average: 0.07,
-        major: 0.1,
-      },
-      style: 'percentage',
-    };
-  }
-
-  suggestions(when) {
-    when(this.suggestionThresholds)
-      .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<> Be mindful of your fury levels and spend it before capping.</>)
           .icon(SPELLS.IMMOLATION_AURA_TALENT.icon)
           .actual(`${formatPercentage(actual)}% fury wasted`)
           .recommended(`0% is recommended.`);

--- a/src/parser/demonhunter/havoc/modules/talents/ImmolationAura.js
+++ b/src/parser/demonhunter/havoc/modules/talents/ImmolationAura.js
@@ -70,8 +70,10 @@ class ImmolationAura extends Analyzer{
       <TalentStatisticBox
         talent={SPELLS.IMMOLATION_AURA_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(6)}
-        value={(<>{this.furyPerMin} fury per min <br />
-                {this.owner.formatItemDamageDone(this.damage)}</>)}
+        value={(<>
+                {this.furyPerMin} fury per min <br />
+                {this.owner.formatItemDamageDone(this.damage)}
+              </>)}
         tooltip={`
           ${formatThousands(this.damage)} Total damage<br />
           ${this.effectiveFuryGain} Effective fury gained<br />


### PR DESCRIPTION
Created a log with the 3rd talent, but unfortunately due to its nature i have no way of calculating its fury generation.  

Talent in question:
**Insatiable Hunger:**  Demon's Bite generates up to 10 additional Fury.
As for **Demons Bite:** Quickly attack for (45.279% of Attack power) Physical damage. Generates 20 to 30 Fury.

Since they both generate variable amount of fury, and logs dont show the extra fury Insatiable hunger provides, i have no way of separating the 2 and calculating the extra it provides. A log if anyone wants to look into it:
https://www.warcraftlogs.com/reports/AZMDnzrG48KJLgP6/#fight=last&type=resources&view=events&spell=117


![image](https://user-images.githubusercontent.com/9600587/52332395-7d116200-29c8-11e9-920d-1c3ca9d14094.png)
![image](https://user-images.githubusercontent.com/9600587/52332415-8c90ab00-29c8-11e9-98e0-d9ffaccb79ac.png)

![image](https://user-images.githubusercontent.com/9600587/52332434-9c0ff400-29c8-11e9-85ec-aaad8aa5a632.png)
![image](https://user-images.githubusercontent.com/9600587/52332455-aaf6a680-29c8-11e9-9081-a88eb81daf05.png)
