### PR TITLE
TreacherousCovenant Fix

### DIFF
--- a/src/parser/shared/modules/spells/bfa/azeritetraits/TreacherousCovenant.js
+++ b/src/parser/shared/modules/spells/bfa/azeritetraits/TreacherousCovenant.js
@@ -70,28 +70,34 @@ class TreacherousCovenant extends Analyzer {
     this._buffUptime += event.timestamp - this._buffApplied;
   }
 
+  get buffUptime() {
+    // This is returning the wrong value which is greatly increasing the uptime. I'm not sure why, but I want to get a quick patch out as this is a very popular trait.
+    //return this.selectedCombatant.getBuffUptime(SPELLS.TREACHEROUS_COVENANT_BUFF.id) / this.owner.fightDuration;
+    return this._buffUptime / this.owner.fightDuration;
+  }
+
+  _debuffUptime = 0;
+  _debuffApplied = 0;
   _applyDebuff(event) {
     this.debuffActive = true;
+    this._debuffApplied = event.timestamp;
   }
 
   _removeDebuff(event) {
     this.debuffActive = false;
+    this._debuffUptime += event.timestamp - this._debuffApplied;
+  }
+
+  get debuffUptime() {
+    // This is returning the *correct* value, but I don't want to have two different ways of calculating these.
+    // return this.selectedCombatant.getBuffUptime(SPELLS.TREACHEROUS_COVENANT_DEBUFF.id) / this.owner.fightDuration;
+    return this._debuffUptime / this.owner.fightDuration;
   }
 
   _takeDamage(event) {
     if (this.debuffActive) {
       this.extraDamageTaken += (event.amount || 0) * DAMAGE_MODIFIER;
     }
-  }
-
-  get debuffUptime() {
-    return this.selectedCombatant.getBuffUptime(SPELLS.TREACHEROUS_COVENANT_DEBUFF.id) / this.owner.fightDuration;
-  }
-
-  get buffUptime() {
-    // This is returning the wrong value which is greatly increasing the uptime. I'm not sure why, but I want to get a quick patch out as this is a very popular trait.
-    //return this.selectedCombatant.getBuffUptime(SPELLS.TREACHEROUS_COVENANT_BUFF.id) / this.owner.fightDuration;
-    return this._buffUptime / this.owner.fightDuration;
   }
 
   get averageStatModifier() {

--- a/src/parser/shared/modules/spells/bfa/azeritetraits/TreacherousCovenant.js
+++ b/src/parser/shared/modules/spells/bfa/azeritetraits/TreacherousCovenant.js
@@ -46,6 +46,9 @@ class TreacherousCovenant extends Analyzer {
     const { stat } = treacherousCovenantStat(this.selectedCombatant.traitsBySpellId[SPELLS.TREACHEROUS_COVENANT.id]);
     this.statModifier = stat;
 
+    this.addEventListener(Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.TREACHEROUS_COVENANT_BUFF), this._applyBuff);
+    this.addEventListener(Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.TREACHEROUS_COVENANT_BUFF), this._removeBuff);
+
     this.addEventListener(Events.applydebuff.to(SELECTED_PLAYER).spell(SPELLS.TREACHEROUS_COVENANT_DEBUFF), this._applyDebuff);
     this.addEventListener(Events.removedebuff.to(SELECTED_PLAYER).spell(SPELLS.TREACHEROUS_COVENANT_DEBUFF), this._removeDebuff);
 
@@ -56,6 +59,15 @@ class TreacherousCovenant extends Analyzer {
       intellect: this.statModifier,
       agility: this.statModifier,
     });
+  }
+
+  _buffUptime = 0;
+  _buffApplied = 0;
+  _applyBuff(event) {
+    this._buffApplied = event.timestamp;
+  }
+  _removeBuff(event) {
+    this._buffUptime += event.timestamp - this._buffApplied;
   }
 
   _applyDebuff(event) {
@@ -77,10 +89,12 @@ class TreacherousCovenant extends Analyzer {
   }
 
   get buffUptime() {
-    return this.selectedCombatant.getBuffUptime(SPELLS.TREACHEROUS_COVENANT_BUFF.id) / this.owner.fightDuration;
+    // This is returning the wrong value which is greatly increasing the uptime. I'm not sure why, but I want to get a quick patch out as this is a very popular trait.
+    //return this.selectedCombatant.getBuffUptime(SPELLS.TREACHEROUS_COVENANT_BUFF.id) / this.owner.fightDuration;
+    return this._buffUptime / this.owner.fightDuration;
   }
 
-  get averageStatModifier(){
+  get averageStatModifier() {
     return this.buffUptime * this.statModifier;
   }
 


### PR DESCRIPTION
Treacherous Covenant is currently displaying > 100% buff uptime on some parses. I don't know why this is happening, but this fixes it for now.

Before:
![screen shot 2019-02-07 at 7 23 38 am](https://user-images.githubusercontent.com/716498/52417527-5545fb00-2aa9-11e9-9227-cab3dea72f02.png)

After:
![screen shot 2019-02-07 at 7 22 32 am](https://user-images.githubusercontent.com/716498/52417485-3d6e7700-2aa9-11e9-830d-520bd404c3cb.png)

give me a few minutes before you approve this please
