### PR TITLE
[MW] REM During MT Updates

### DIFF
--- a/src/parser/monk/mistweaver/CHANGELOG.js
+++ b/src/parser/monk/mistweaver/CHANGELOG.js
@@ -8,6 +8,11 @@ import ItemLink from 'common/ItemLink';
 
 export default [
   {
+    date: new Date('2019-02-7'),
+    changes: <>Added statistics, suggestions, and checklist item for tracking the number of <SpellLink id={SPELLS.RENEWING_MIST.id} /> during <SpellLink id={SPELLS.MANA_TEA_TALENT.id} />. Also, adding some additional tooltips to the Healing Efficiency page.</>,
+    contributors: [Anomoly],
+  },
+  {
     date: new Date('2019-01-21'),
     changes: <>Ignore cooldown errors caused by <SpellLink id={SPELLS.FONT_OF_LIFE.id} /> (it is not detectable in logs so we can't make it 100% accurate).</>,
     contributors: [Zerotorescue],

--- a/src/parser/monk/mistweaver/CONFIG.js
+++ b/src/parser/monk/mistweaver/CONFIG.js
@@ -10,7 +10,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Anomoly],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '8.0',
+  patchCompatibility: '8.1',
   // If set to  false`, the spec will show up as unsupported.
   isSupported: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.

--- a/src/parser/monk/mistweaver/CombatLogParser.js
+++ b/src/parser/monk/mistweaver/CombatLogParser.js
@@ -54,6 +54,7 @@ import RefreshingJadeWind from './modules/talents/RefreshingJadeWind';
 import Lifecycles from './modules/talents/Lifecycles';
 import SpiritOfTheCrane from './modules/talents/SpiritOfTheCrane';
 import RisingMist from './modules/talents/RisingMist';
+import RenewingMistDuringManaTea from './modules/talents/RenewingMistDuringManaTea';
 
 // Azerite Traits
 import FontOfLife from './modules/spells/azeritetraits/FontOfLife';
@@ -112,6 +113,7 @@ class CombatLogParser extends CoreCombatLogParser {
     spiritOfTheCrane: SpiritOfTheCrane,
     risingMist: RisingMist,
     jadeSerpentStatue: JadeSerpentStatue,
+    renewingMistDuringManaTea: RenewingMistDuringManaTea,
 
     // Azerite Traits
     fontOfLife: FontOfLife,

--- a/src/parser/monk/mistweaver/modules/features/Checklist/Component.js
+++ b/src/parser/monk/mistweaver/modules/features/Checklist/Component.js
@@ -55,6 +55,7 @@ class MistweaverMonkChecklist extends React.PureComponent {
         >
           <AbilityRequirement spell={SPELLS.THUNDER_FOCUS_TEA.id} />
           {combatant.hasTalent(SPELLS.MANA_TEA_TALENT.id) && <AbilityRequirement spell={SPELLS.MANA_TEA_TALENT.id} />}
+          {combatant.hasTalent(SPELLS.MANA_TEA_TALENT.id) && <Requirement name={(<><SpellLink id={SPELLS.RENEWING_MIST.id} /> active during MT</>)} thresholds={thresholds.renewingMistDuringManaTea} />}
           {combatant.hasTalent(SPELLS.CHI_BURST_TALENT.id) && <AbilityRequirement spell={SPELLS.CHI_BURST_TALENT.id} />}
           {combatant.hasTalent(SPELLS.CHI_WAVE_TALENT.id) && <AbilityRequirement spell={SPELLS.CHI_WAVE_TALENT.id} />}
           {combatant.hasTalent(SPELLS.INVOKE_CHIJI_THE_RED_CRANE_TALENT.id) && <AbilityRequirement spell={SPELLS.INVOKE_CHIJI_THE_RED_CRANE_TALENT.id} />}

--- a/src/parser/monk/mistweaver/modules/features/Checklist/Module.js
+++ b/src/parser/monk/mistweaver/modules/features/Checklist/Module.js
@@ -15,6 +15,7 @@ import ManaTea from '../../talents/ManaTea';
 import Lifecycles from '../../talents/Lifecycles';
 import ThunderFocusTea from '../../spells/ThunderFocusTea';
 import EssenceFontMastery from '../EssenceFontMastery';
+import RenewingMistDuringManaTea from '../../talents/RenewingMistDuringManaTea';
 
 import Component from './Component';
 
@@ -33,6 +34,7 @@ class Checklist extends BaseChecklist {
     lifecycles: Lifecycles,
     thunderFocusTea: ThunderFocusTea,
     essenceFontMastery: EssenceFontMastery,
+    renewingMistDuringManaTea: RenewingMistDuringManaTea,
   };
 
   render() {
@@ -54,6 +56,7 @@ class Checklist extends BaseChecklist {
           lifecycles: this.lifecycles.suggestionThresholds,
           thunderFocusTea: this.thunderFocusTea.suggestionThresholds,
           essenceFontMastery: this.essenceFontMastery.suggestionThresholds,
+          renewingMistDuringManaTea: this.renewingMistDuringManaTea.suggestionThresholds,
 
         }}
       />

--- a/src/parser/monk/mistweaver/modules/features/MistweaverHealingEfficiencyDetails.js
+++ b/src/parser/monk/mistweaver/modules/features/MistweaverHealingEfficiencyDetails.js
@@ -24,7 +24,7 @@ class MistweaverHealingEfficiencyDetails extends HealingEfficiencyDetails {
           /> 
         </Tab>), 
         <Tab style={{ padding: '15px 22px 15px 15px' }} className="flex" key={"healingEfficiencyTrackerTextInfo"}>
-            <SpellLink id={SPELLS.GUSTS_OF_MISTS.id} /> healing is added to the appropriate spell that caused the gust. Essence font is given the healing from duplicated gusts, since without EF the second gust would not have happened. Renewing mist is given the splash healing of vivify's heal since without ReM, vivify wouldn't have splashed.
+            <SpellLink id={SPELLS.GUSTS_OF_MISTS.id} /> healing is added to the appropriate spell that caused the gust. <SpellLink id={SPELLS.ESSENCE_FONT.id} /> is given the healing from duplicated gusts, since without <SpellLink id={SPELLS.ESSENCE_FONT.id} /> the second gust would not have happened. <SpellLink id={SPELLS.RENEWING_MIST.id} /> is given the splash healing of <SpellLink id={SPELLS.VIVIFY.id} />'s heal since without <SpellLink id={SPELLS.RENEWING_MIST.id} />, <SpellLink id={SPELLS.VIVIFY.id} /> wouldn't have splashed.
         </Tab>];
       },
     };

--- a/src/parser/monk/mistweaver/modules/features/StatValuesSpellInfo.js
+++ b/src/parser/monk/mistweaver/modules/features/StatValuesSpellInfo.js
@@ -174,4 +174,12 @@ export default {
     mastery: false,
     vers: true,
   },
+  [SPELLS.SOOTHING_MIST_STATUE.id]: {
+    int: true,
+    crit: true,
+    hasteHpm: false,
+    hasteHpct: true,
+    mastery: false,
+    vers: true,
+  },
 };

--- a/src/parser/monk/mistweaver/modules/spells/Vivify.js
+++ b/src/parser/monk/mistweaver/modules/spells/Vivify.js
@@ -25,6 +25,7 @@ class Vivify extends Analyzer {
   remVivifyHealing = 0;
   gustsHealing = 0;
   lastCastTarget = null;
+  remDuringManaTea = 0;
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
@@ -44,6 +45,9 @@ class Vivify extends Analyzer {
     if ((spellId === SPELLS.VIVIFY.id) && (this.lastCastTarget !== event.targetID)) {
       this.remVivifyHealCount += 1;
       this.remVivifyHealing += (event.amount || 0 ) + (event.absorbed || 0);
+      if (this.selectedCombatant.hasBuff(SPELLS.MANA_TEA_TALENT.id)) {
+        this.remDuringManaTea += 1;
+      }
     }
   }
 

--- a/src/parser/monk/mistweaver/modules/talents/RenewingMistDuringManaTea.js
+++ b/src/parser/monk/mistweaver/modules/talents/RenewingMistDuringManaTea.js
@@ -1,0 +1,78 @@
+// Modified from Original Code by Blazyb and his Innervate module.
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import SpellIcon from 'common/SpellIcon';
+
+import AbilityTracker from 'parser/shared/modules/AbilityTracker';
+
+import Analyzer from 'parser/core/Analyzer';
+
+import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
+
+import Vivify from '../spells/Vivify';
+import ManaTea from './ManaTea';
+
+class RenewingMistDuringManaTea extends Analyzer {
+  static dependencies = {
+    abilityTracker: AbilityTracker,
+    vivify: Vivify,
+    manaTea: ManaTea,
+  };
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.MANA_TEA_TALENT.id);
+  }
+
+  get avgRemDuringMT() {
+    return this.vivify.remDuringManaTea / this.manaTea.vivCasts || 0;
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.avgRemDuringMT,
+      isLessThan: {
+        minor: 2,
+        average: 1.5,
+        major: 1,
+      },
+      style: 'number',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <>
+          During <SpellLink id={SPELLS.MANA_TEA_TALENT.id} /> you should have a minimum of two <SpellLink id={SPELLS.RENEWING_MIST.id} /> out to maximize your healing during the buff.
+        </>
+      )
+        .icon(SPELLS.MANA_TEA_TALENT.icon)
+        .actual(`${this.avgRemDuringMT.toFixed(2)} average Renewing Mists during Mana Tea`)
+        .recommended(`${recommended} average Renewing Mists recommended`);
+    });
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        position={STATISTIC_ORDER.CORE(25)}
+        icon={<SpellIcon id={SPELLS.MANA_TEA_TALENT.id} />}
+        value={`${this.avgRemDuringMT.toFixed(2)}`}
+        label={(
+          <dfn
+            data-tip={`
+              This is the average number of Renewing Mists active during Mana Tea
+            `}
+          >
+            Average Renewing Mists
+          </dfn>
+        )}
+      />
+    );
+  }
+}
+
+export default RenewingMistDuringManaTea;


### PR DESCRIPTION
Added a new statistic and checklist item to track the number of Renewing Mists active during Mana Tea.