### PR TITLE
[Feral] Add Untamed Ferocity azerite trait

### DIFF
--- a/src/common/SPELLS/bfa/azeritetraits/druid.js
+++ b/src/common/SPELLS/bfa/azeritetraits/druid.js
@@ -69,6 +69,11 @@ export default {
     name: 'Wild Fleshrending',
     icon: 'ability_warrior_bloodnova',
   },
+  UNTAMED_FEROCITY: {
+    id: 273338,
+    name: 'Untamed Ferocity',
+    icon: 'ability_druid_disembowel',
+  },
   MASTERFUL_INSTINCTS: {
     id: 273344,
     name: 'Masterful Instincts',

--- a/src/parser/druid/feral/CHANGELOG.js
+++ b/src/parser/druid/feral/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2019-02-08'),
+    changes: <>Added tracking of <SpellLink id={SPELLS.UNTAMED_FEROCITY.id} /> and updated <SpellLink id={SPELLS.WILD_FLESHRENDING.id} />.</>,
+    contributors: [Anatta336],
+  },
+  {
     date: new Date('2018-12-20'),
     changes: <>Updated tracking of <SpellLink id={SPELLS.RIP.id} /> snapshots, and interaction with <SpellLink id={SPELLS.SABERTOOTH_TALENT.id} /> for patch 8.1.</>,
     contributors: [Anatta336],

--- a/src/parser/druid/feral/CombatLogParser.js
+++ b/src/parser/druid/feral/CombatLogParser.js
@@ -39,6 +39,7 @@ import TigersFuryEnergy from './modules/spells/TigersFuryEnergy';
 import Shadowmeld from './modules/racials/Shadowmeld';
 
 import WildFleshrending from './modules/azeritetraits/WildFleshrending';
+import UntamedFerocity from './modules/azeritetraits/UntamedFerocity';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -89,6 +90,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // azerite traits
     wildFleshrending: WildFleshrending,
+    untamedFerocity: UntamedFerocity,
   };
 }
 

--- a/src/parser/druid/feral/modules/Abilities.js
+++ b/src/parser/druid/feral/modules/Abilities.js
@@ -22,6 +22,7 @@ class Abilities extends CoreAbilities {
           static: 1000,
         },
         timelineSortIndex: 2,
+        primaryCoefficient: 0.1822, // initial damage, not DoT damage
       },
       {
         spell: SPELLS.RIP,
@@ -57,6 +58,7 @@ class Abilities extends CoreAbilities {
           base: 1000,
         },
         timelineSortIndex: 3,
+        primaryCoefficient: 0.15, // initial damage, not DoT damage
       },
 
       {
@@ -66,6 +68,7 @@ class Abilities extends CoreAbilities {
           static: 1000,
         },
         timelineSortIndex: 10,
+        primaryCoefficient: 0.055, // initial damage, not DoT damage
       },
       {
         spell: SPELLS.SWIPE_CAT,

--- a/src/parser/druid/feral/modules/azeritetraits/UntamedFerocity.js
+++ b/src/parser/druid/feral/modules/azeritetraits/UntamedFerocity.js
@@ -1,0 +1,149 @@
+import React from 'react';
+
+import { formatNumber } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import { calculateAzeriteEffects } from 'common/stats';
+import HIT_TYPES from 'game/HIT_TYPES';
+import Analyzer from 'parser/core/Analyzer';
+import Enemies from 'parser/shared/modules/Enemies';
+import StatTracker from 'parser/shared/modules/StatTracker';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import calculateBonusAzeriteDamage from 'parser/core/calculateBonusAzeriteDamage';
+import TraitStatisticBox, { STATISTIC_ORDER } from 'interface/others/TraitStatisticBox';
+import ItemDamageDone from 'interface/others/ItemDamageDone';
+
+import { calcShredBonus, calcSwipeBonus, isAffectedByWildFleshrending } from '../azeritetraits/WildFleshrending';
+import Abilities from '../Abilities.js';
+
+const debug = false;
+export const AFFECTED_SPELLS = [
+  SPELLS.RAKE.id,
+  SPELLS.SHRED.id,
+  SPELLS.MOONFIRE_FERAL.id,
+  SPELLS.THRASH_FERAL.id,
+  SPELLS.SWIPE_CAT.id,
+  SPELLS.BRUTAL_SLASH_TALENT.id,
+];
+const HIT_TYPES_TO_IGNORE = [
+  HIT_TYPES.MISS,
+  HIT_TYPES.DODGE,
+  HIT_TYPES.PARRY,
+];
+
+const COOLDOWN_REDUCTION_BERSERK = 300;
+const COOLDOWN_REDUCTION_INCARNATION = 200;
+
+export function calcBonus(combatant) {
+  if (!combatant.hasTrait(SPELLS.UNTAMED_FEROCITY.id)) {
+    return 0;
+  }
+  return combatant.traitsBySpellId[SPELLS.UNTAMED_FEROCITY.id]
+    .reduce((sum, rank) => sum + calculateAzeriteEffects(SPELLS.UNTAMED_FEROCITY.id, rank)[0], 0);
+}
+
+/**
+ * Untamed Ferocity
+ * Combo-point generating abilities deal X additional instant damage and reduce the cooldown of
+ * Berserk by 0.3 sec [or Incarnation: King of the Jungle by 0.2 sec]
+ */
+class UntamedFerocity extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+    enemies: Enemies,
+    statTracker: StatTracker,
+    spellUsable: SpellUsable,
+  };
+
+  hasWildFleshrending = false;
+  shredBonus = 0;
+  swipeBonus = 0;
+  untamedBonus = 0;
+  untamedDamage = 0;
+
+  hasIncarnation = false;
+  cooldownId = 0;
+  cooldownReduction = 0;
+
+  // Only cast events (not damage events) give attack power values, so have to temporarily store it. As we're dealing with instant damage abilites there's no problem with that.
+  attackPower = 0;
+
+  constructor(...args) {
+    super(...args);
+    if(!this.selectedCombatant.hasTrait(SPELLS.UNTAMED_FEROCITY.id)) {
+      this.active = false;
+      return;
+    }
+    this.untamedBonus = calcBonus(this.selectedCombatant);
+
+    this.hasWildFleshrending = this.selectedCombatant.hasTrait(SPELLS.WILD_FLESHRENDING.id);
+    if (this.hasWildFleshrending) {
+      this.shredBonus = calcShredBonus(this.selectedCombatant);
+      this.swipeBonus = calcSwipeBonus(this.selectedCombatant);
+    }
+    debug && this.log(`untamedBonus: ${this.untamedBonus}, shredBonus: ${this.shredBonus}, swipeBonus: ${this.swipeBonus}`);
+
+    this.hasIncarnation = this.selectedCombatant.hasTalent(SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id);
+    this.cooldownId = this.hasIncarnation ? SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id : SPELLS.BERSERK.id;
+    this.cooldownReductionPerHit = this.hasIncarnation ? COOLDOWN_REDUCTION_INCARNATION : COOLDOWN_REDUCTION_BERSERK;
+  }
+
+  on_byPlayer_cast(event) {
+    if (!AFFECTED_SPELLS.includes(event.ability.guid)) {
+      return;
+    }
+    this.attackPower = event.attackPower;
+  }
+
+  on_byPlayer_damage(event) {
+    if (!AFFECTED_SPELLS.includes(event.ability.guid) || event.tick || HIT_TYPES_TO_IGNORE.includes(event.hitType)) {
+      // only interested in direct damage from whitelisted spells which hit the target
+      return;
+    }
+    
+    if (this.hasWildFleshrending && isAffectedByWildFleshrending(event, this.owner, this.enemies)) {
+      // if the ability was given bonus damage from both Wild Fleshrending and Untamed Ferocity need to account for that to accurately attribute damage to each.
+      const fleshrendingBonus = (event.ability.guid === SPELLS.SHRED.id) ? this.shredBonus : this.swipeBonus;
+      const coefficient = this.abilities.getAbility(event.ability.guid).primaryCoefficient;
+      const [traitDamageContribution] = calculateBonusAzeriteDamage(event, [this.untamedBonus, fleshrendingBonus], this.attackPower, coefficient);
+      this.untamedDamage += traitDamageContribution;
+      debug && this.log(`Affected ability including Wild Fleshrending, damage from Untamed Ferocity: ${traitDamageContribution}`);
+    } else {
+      const coefficient = this.abilities.getAbility(event.ability.guid).primaryCoefficient;
+      const [traitDamageContribution] = calculateBonusAzeriteDamage(event, [this.untamedBonus], this.attackPower, coefficient);
+      this.untamedDamage += traitDamageContribution;
+      debug && this.log(`Affected ability damage from Untamed Ferocity: ${traitDamageContribution}`);
+    }
+
+    if (this.spellUsable.isOnCooldown(this.cooldownId)) {
+      this.cooldownReduction += this.cooldownReductionPerHit;
+      this.spellUsable.reduceCooldown(this.cooldownId, this.cooldownReductionPerHit);
+    }
+  }
+
+  statistic() {
+    const cooldownName = this.hasIncarnation ? 'Incarnation' : 'Berserk';
+    const cooldownDuration = this.abilities.getExpectedCooldownDuration(this.cooldownId);
+    const basePossibleCasts = Math.floor(this.owner.fightDuration / cooldownDuration) + 1;
+    const improvedPossibleCasts = Math.floor((this.owner.fightDuration + this.cooldownReduction) / cooldownDuration) + 1;
+    const extraCastsPossible = improvedPossibleCasts - basePossibleCasts;
+    const extraCastsComment = (improvedPossibleCasts === basePossibleCasts) ? `This wasn't enough to allow any extra casts during the fight, but may have given you more freedom in timing those casts.` : `This gave you the opportunity over the duration of the fight to use ${cooldownName} <b>${extraCastsPossible}</b> extra time${extraCastsPossible === 1 ? '' : 's'}.`;
+
+    return (
+      <TraitStatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
+        trait={SPELLS.UNTAMED_FEROCITY.id}
+        value={(
+          <>
+          <ItemDamageDone amount={this.untamedDamage} /><br />
+          {(this.cooldownReduction / 1000).toFixed(1)} seconds cooldown reduction
+          </>
+        )}
+        tooltip={`Increased the damage of your combo point generators by a total of <b>${formatNumber(this.untamedDamage)}</b><br />
+          The cooldown on your ${cooldownName} was reduced by a total of <b>${(this.cooldownReduction / 1000).toFixed(1)}</b> seconds.<br />
+          ${extraCastsComment}`}
+      />
+    );
+  }
+}
+
+export default UntamedFerocity;


### PR DESCRIPTION
Untamed Ferocity increases the direct damage of all combo generating abilities by X, and reduces the remaining cooldown of Berserk/Incarnation whenever they're used. This adds a tracker for how much damage that provides and how much the cooldown is reduced.

Because Wild Fleshrending also increases direct damage of some combo generating abilities that module was updated to take the Untamed Ferocity damage into account. I've tried to keep the logic for each trait in their own file, exporting and importing as needed between the two.

I also removed a chunk of dead code from the Wild Fleshrending module. It was debug-only code that used an alternative method to calculate damage contribution and is no longer needed.

![untamedferocity01](https://user-images.githubusercontent.com/35700764/52456660-b0c9c480-2b4d-11e9-9ff1-190e484cb58b.png)
![untamedferocity02](https://user-images.githubusercontent.com/35700764/52456661-b0c9c480-2b4d-11e9-9112-b51972e42eac.png)
![untamedferocity03](https://user-images.githubusercontent.com/35700764/52456662-b1625b00-2b4d-11e9-98ab-2ada7aebbaf1.png)

**Example logs:**
Using only Untamed Ferocity
/report/VdgMp8kZnRhJNGvr/7-Normal+Grong+-+Kill+(3:35)/5-Anatta

Using both Untamed Ferocity and Wild Fleshrending. Wild Fleshrending's damage is now reported slightly lower than before this change, as it was incorrectly getting credit for damage from Untamed Ferocity.
/report/x6HhmQKMdpLN4PZ2/58-Heroic+Grong+the+Revenant+-+Kill+(3:14)/20-Adriael

Only using Wild Fleshrending. Gives same results as before.
/report/Zjn8m1b6aJpPRHXq/10-Heroic+Grong+-+Kill+(3:21)/6-Rapîdus