### PR TITLE
[Blood Death Knight] Marrowrend-usage update

### DIFF
--- a/src/parser/deathknight/blood/CHANGELOG.js
+++ b/src/parser/deathknight/blood/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2019-02-14'),
+    changes: <>Updated <SpellLink id={SPELLS.BONE_SHIELD.id} />-suggestion to account for different types of bad <SpellLink id={SPELLS.MARROWREND.id} />s</>,
+    contributors: [joshinator],
+  },
+  {
     date: new Date('2019-02-03'),
     changes: <>Added <SpellLink id={SPELLS.BLOODY_RUNEBLADE.id} /> azerite trait and marked patch 8.1 compatible.</>,
     contributors: [Yajinni],

--- a/src/parser/deathknight/blood/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/deathknight/blood/__snapshots__/CombatLogParser.test.js.snap
@@ -1110,10 +1110,11 @@ exports[`The Blood Deathknight Analyzer analyzers MarrowrendUsage matches the st
           >
             <dfn
               data-tip="
-          3 casts to refresh Bone Shield<br>
-          0 casts with more than 7 stacks of Bone Shield wasting at least 0 stacks<br>
+          3 casts to refresh Bone Shield, those do not count towards bad casts.<br>
+          
+          0 casts with more than 7 stacks of Bone Shield wasting 0 stacks.<br>
           <br>
-          Avoid casting Marrowrend unless you have 7 or less stacks or if Bone Shield has less than 6sec duration left.
+          Avoid casting Marrowrend unless you have 7 or less stacks or if Bone Shield has less than 6sec of its duration left.
         "
             >
               0 / 10

--- a/src/parser/deathknight/blood/modules/features/MarrowrendUsage.js
+++ b/src/parser/deathknight/blood/modules/features/MarrowrendUsage.js
@@ -11,6 +11,7 @@ import Analyzer from 'parser/core/Analyzer';
 
 const REFRESH_AT_STACKS_WITH_BONES_OF_THE_DAMNED = 6;
 const REFRESH_AT_STACKS_WITHOUT_BONES_OF_THE_DAMNED = 7;
+
 const REFRESH_AT_SECONDS = 6;
 const BS_DURATION = 30;
 const MR_GAIN = 3;
@@ -31,12 +32,15 @@ class MarrowrendUsage extends Analyzer {
   lastMarrowrendCast = 0;
 
   bsStacksWasted = 0;
-  badMRCasts = 0;
+  botdStacksWasted = 0;
+
   refreshMRCasts = 0;
   totalMRCasts = 0;
 
+  badMRCasts = 0;
+
   hasBonesOfTheDamned = false;
-  refreshAtStacks = REFRESH_AT_STACKS_WITHOUT_BONES_OF_THE_DAMNED;
+  refreshAtStacks = REFRESH_AT_STACKS_WITHOUT_BONES_OF_THE_DAMNED; // contains number for the tooltip for proper MR-usage, not used for calculations
 
   bonesOfTheDamnedProc = 0;
   totalStacksGenerated = 0;
@@ -88,16 +92,26 @@ class MarrowrendUsage extends Analyzer {
       this.refreshMRCasts += 1;
     } else {
       const boneShieldStacks = this.currentBoneShieldStacks - this.currentBoneShieldBuffer;
-      if (boneShieldStacks > this.refreshAtStacks) {
-        this.badMRCasts += 1;
-        const wasted = MR_GAIN - this.currentBoneShieldBuffer;
-        if (wasted > 0) {
-          this.bsStacksWasted += wasted;
+      let badCast = '';
 
-          event.meta = event.meta || {};
-          event.meta.isInefficientCast = true;
-          event.meta.inefficientCastReason = `You made this cast with ${boneShieldStacks} stacks of Bone Shield while it had ${(durationLeft).toFixed(1)} seconds left.`;
-        }
+      if (boneShieldStacks > REFRESH_AT_STACKS_WITHOUT_BONES_OF_THE_DAMNED) {
+        // this was a wasted charge for sure
+        const wasted = MR_GAIN - this.currentBoneShieldBuffer;
+        this.badMRCasts += 1;
+        this.bsStacksWasted += wasted;
+        badCast = badCast + `You made this cast with ${boneShieldStacks} stacks of Bone Shield while it had ${(durationLeft).toFixed(1)} seconds left, wasting ${wasted} charges.<br />`;
+      }
+
+      if (this.hasBonesOfTheDamned && boneShieldStacks >= REFRESH_AT_STACKS_WITHOUT_BONES_OF_THE_DAMNED) {
+        // this was a potentially proc of BotD
+        this.botdStacksWasted += 1;
+        badCast = badCast + `This cast couldn't proc ${SPELLS.BONES_OF_THE_DAMNED.name} because you had already ${boneShieldStacks} stacks.`;
+      }
+
+      if (badCast !== '') {
+        event.meta = event.meta || {};
+        event.meta.isInefficientCast = true;
+        event.meta.inefficientCastReason = badCast;
       }
     }
 
@@ -119,23 +133,31 @@ class MarrowrendUsage extends Analyzer {
     return this.bonesOfTheDamnedProc;
   }
 
+  get wastedbonesOfTheDamnedProcs() {
+    return this.botdStacksWasted;
+  }
+
   get totalBoneShieldStacksGenerated() {
     return this.totalStacksGenerated;
   }
 
-  get badCastsPercent() {
-    return this.badMRCasts / this.totalMRCasts;
+  get wastedBoneShieldStacksPercent() {
+    return this.bsStacksWasted / (this.totalStacksGenerated + this.bsStacksWasted);
   }
 
   get marrowrendCasts() {
     return this.totalMRCasts;
   }
 
+  get refreshWithStacks() {
+    return this.refreshAtStacks;
+  }
+
   get suggestionThresholds() {
     return {
-      actual: this.badCastsPercent,
+      actual: this.wastedBoneShieldStacksPercent,
       isGreaterThan: {
-        minor: 0.05,
+        minor: 0,
         average: 0.1,
         major: .2,
       },
@@ -145,9 +167,9 @@ class MarrowrendUsage extends Analyzer {
 
   get suggestionThresholdsEfficiency() {
     return {
-      actual: 1 - this.badCastsPercent,
+      actual: 1 - this.wastedBoneShieldStacksPercent,
       isLessThan: {
-        minor: 0.95,
+        minor: 1,
         average: 0.9,
         major: .8,
       },
@@ -158,14 +180,20 @@ class MarrowrendUsage extends Analyzer {
   suggestions(when) {
     when(this.suggestionThresholds)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<>You casted {this.badMRCasts} Marrowrends with more than {this.refreshAtStacks} stacks of <SpellLink id={SPELLS.BONE_SHIELD.id} /> that were not about to expire. Try to cast <SpellLink id={SPELLS.HEART_STRIKE.id} /> instead under those conditions.</>)
+        const botDDisclaimer = this.hasBonesOfTheDamned ? ` (not counting possible ${SPELLS.BONES_OF_THE_DAMNED.name} procs)` : '';
+        return suggest(<>You casted {this.badMRCasts} Marrowrends with more than {REFRESH_AT_STACKS_WITHOUT_BONES_OF_THE_DAMNED} stacks of <SpellLink id={SPELLS.BONE_SHIELD.id} /> that were not about to expire, wasting {this.bsStacksWasted} stacks{botDDisclaimer}.<br />Cast <SpellLink id={SPELLS.HEART_STRIKE.id} /> instead if you are at {this.refreshAtStacks} stacks or above.</>)
           .icon(SPELLS.MARROWREND.icon)
-          .actual(`${formatPercentage(actual)}% bad Marrowrend casts`)
-          .recommended(`<${formatPercentage(recommended)}% is recommended`);
+          .actual(`${formatPercentage(actual)}% wasted ${SPELLS.BONE_SHIELD.name} stacks`)
+          .recommended(`${this.bsStacksWasted} stacks wasted, ${this.totalStacksGenerated} stacks generated`);
       });
   }
 
   statistic() {
+
+    let botDText = '';
+    if (this.hasBonesOfTheDamned) {
+      botDText = `${ this.wastedbonesOfTheDamnedProcs } casts with ${REFRESH_AT_STACKS_WITHOUT_BONES_OF_THE_DAMNED} stacks of ${SPELLS.BONE_SHIELD.name}, wasting potential ${SPELLS.BONES_OF_THE_DAMNED.name} procs.<br/>`;
+    }
 
     return (
       <StatisticBox
@@ -173,10 +201,11 @@ class MarrowrendUsage extends Analyzer {
         value={`${ this.badMRCasts } / ${ this.totalMRCasts }`}
         label="Bad Marrowrend casts"
         tooltip={`
-          ${ this.refreshMRCasts } casts to refresh Bone Shield<br>
-          ${ this.badMRCasts } casts with more than ${this.refreshAtStacks} stacks of Bone Shield wasting at least ${ this.bsStacksWasted } stacks<br>
+          ${ this.refreshMRCasts } casts to refresh Bone Shield, those do not count towards bad casts.<br>
+          ${ botDText }
+          ${ this.badMRCasts } casts with more than ${ REFRESH_AT_STACKS_WITHOUT_BONES_OF_THE_DAMNED } stacks of Bone Shield wasting ${ this.bsStacksWasted } stacks.<br>
           <br>
-          Avoid casting Marrowrend unless you have ${this.refreshAtStacks} or less stacks or if Bone Shield has less than 6sec duration left.
+          Avoid casting Marrowrend unless you have ${ this.refreshAtStacks } or less stacks or if Bone Shield has less than 6sec of its duration left.
         `}
       />
 

--- a/src/parser/deathknight/blood/modules/spells/azeritetraits/BonesOfTheDamned.js
+++ b/src/parser/deathknight/blood/modules/spells/azeritetraits/BonesOfTheDamned.js
@@ -6,6 +6,7 @@ import { calculateAzeriteEffects } from 'common/stats';
 import Analyzer from 'parser/core/Analyzer';
 import TraitStatisticBox, { STATISTIC_ORDER } from 'interface/others/TraitStatisticBox';
 import StatTracker from 'parser/shared/modules/StatTracker';
+import SpellLink from 'common/SpellLink';
 
 import MarrowrendUsage from '../../features/MarrowrendUsage';
 import BoneShieldTimesByStacks from '../../features/BoneShieldTimesByStacks';
@@ -50,6 +51,26 @@ class BonesOfTheDamned extends Analyzer{
     });
   }
 
+  get suggestionThresholds() {
+    // suggestion based on wasted possible procs in relation to total MR casts
+    return {
+      actual: this.marrowrendUsage.wastedbonesOfTheDamnedProcs / this.marrowrendUsage.marrowrendCasts,
+      isGreaterThan: {
+        minor: 0,
+        average: 0.3,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestionThresholds)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<>{formatPercentage(actual)}% <SpellLink id={SPELLS.MARROWREND.id} /> casts locked you out of possible <SpellLink id={SPELLS.BONES_OF_THE_DAMNED.id} /> procs. Only cast <SpellLink id={SPELLS.MARROWREND.id} /> at {this.marrowrendUsage.refreshWithStacks} stacks or below to maximize the benefit of this trait.</>)
+          .icon(SPELLS.BONES_OF_THE_DAMNED.icon);
+      });
+  }
+
   get bonesOfTheDamnedProcPercentage() {
     return this.marrowrendUsage.bonesOfTheDamnedProcs / (this.marrowrendUsage.totalBoneShieldStacksGenerated - this.marrowrendUsage.bonesOfTheDamnedProcs);
   }
@@ -75,7 +96,8 @@ class BonesOfTheDamned extends Analyzer{
         )}
         tooltip={`
           ${formatPercentage(this.bonesOfTheDamnedProcPercentage)}% of your gained ${SPELLS.BONE_SHIELD.name} stacks are from ${SPELLS.BONES_OF_THE_DAMNED.name}.<br/>
-          ${formatPercentage(this.bonesOfTheDamnedMarrowrendProcPercentage)}% of your ${SPELLS.MARROWREND.name} casts procced ${SPELLS.BONES_OF_THE_DAMNED.name}.
+          ${formatPercentage(this.bonesOfTheDamnedMarrowrendProcPercentage)}% of your ${SPELLS.MARROWREND.name} casts procced ${SPELLS.BONES_OF_THE_DAMNED.name}.<br/>
+          ${formatNumber(this.marrowrendUsage.wastedbonesOfTheDamnedProcs)} of your ${SPELLS.MARROWREND.name} casts locked you out of an potential ${SPELLS.BONES_OF_THE_DAMNED.name} proc
         `}
       />
     );

--- a/src/parser/deathknight/blood/modules/spells/azeritetraits/EternalRuneWeapon.js
+++ b/src/parser/deathknight/blood/modules/spells/azeritetraits/EternalRuneWeapon.js
@@ -80,6 +80,10 @@ class EternalRuneWeapon extends Analyzer {
           return;
         }
 
+        if (this.bonusDurations.length === 0) {
+          this.bonusDurations.push([]);
+        }
+        
         this.bonusDurations[this.bonusDurations.length - 1].push(DANCING_RUNE_WEAPON_BONUS_DURATION_PER_TRAIT * this.traits * runeCost);
       });
   }

--- a/src/parser/deathknight/blood/modules/talents/Bonestorm.js
+++ b/src/parser/deathknight/blood/modules/talents/Bonestorm.js
@@ -33,6 +33,13 @@ class Bonestorm extends Analyzer {
       return;
     }
 
+    if (this.bsCasts.length === 0) {
+      // to account for prepull-cheese, assuming 100RP because I dont know how much RP was spend prepull
+      this.bsCasts.push({
+        cost: 100,
+        hits: [],
+      });
+    }
     this.bsCasts[this.bsCasts.length - 1].hits.push(event.amount + event.absorbed);
     this.totalBonestormDamage += event.amount + event.absorbed;
   }


### PR DESCRIPTION
Updates the calculation for bad Marrowrends by counting the wasted charges.
The module is currently punishing all types of bad Marrowrends equally, but there is a difference between wasting a potential BotD-proc and capping 3 stacks.
I've made an extra suggestion for possible BotD-procs to keep the number for the core-suggestion accurate.

Also fixed two issues with Bonestorm and ERW that caused errors when used prepull.

![image](https://user-images.githubusercontent.com/29842841/52810504-00027e80-3093-11e9-8812-f0cd9dffb5ee.png)
![image](https://user-images.githubusercontent.com/29842841/52810518-098be680-3093-11e9-8dbc-8167b0e72858.png)
![image](https://user-images.githubusercontent.com/29842841/52810689-6be4e700-3093-11e9-86af-9606afaf6f82.png)
![image](https://user-images.githubusercontent.com/29842841/52810698-72735e80-3093-11e9-84c0-8f632dd940ba.png)
