### PR TITLE
[Prot Pal] HotP delay now only looks at self-targeted casts

### DIFF
--- a/src/parser/paladin/protection/CHANGELOG.js
+++ b/src/parser/paladin/protection/CHANGELOG.js
@@ -5,6 +5,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('16 February 2019'),
+    contributors: [emallson],
+    changes: <><SpellLink id={SPELLS.HAND_OF_THE_PROTECTOR_TALENT.id} /> cast delay is now only tracked for self-targeted casts.</>,
+  },
+  {
     date: new Date('29 December 2018'),
     contributors: [emallson],
     changes: <>Added support for <SpellLink id={SPELLS.AVENGERS_VALOR_BUFF.id} /> to the Good <SpellLink id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id} /> casts check.</>,

--- a/src/parser/paladin/protection/modules/features/Checklist/Component.js
+++ b/src/parser/paladin/protection/modules/features/Checklist/Component.js
@@ -88,7 +88,10 @@ class ProtectionPaladinChecklist extends React.PureComponent{
         >
           <AbilityRequirement name={<><SpellLink id={this.props.extras.lotpAbility.id} /> Cast Efficiency</>} 
             spell={this.props.extras.lotpAbility.id} />
-          <Requirement name="Avg. Cast Delay" thresholds={thresholds.lotpDelay} />
+          <Requirement name="Avg. Cast Delay"
+            tooltip={this.props.extras.lotpAbility.id === SPELLS.HAND_OF_THE_PROTECTOR_TALENT.id ? 
+                "Only self-casts are counted for delay tracking." : null}
+            thresholds={thresholds.lotpDelay} />
           <Requirement name="Overhealing" thresholds={thresholds.lotpOverheal} />
         </Rule>
         <PreparationRule thresholds={thresholds} />

--- a/src/parser/paladin/protection/modules/spells/LightOfTheProtector.js
+++ b/src/parser/paladin/protection/modules/spells/LightOfTheProtector.js
@@ -41,10 +41,14 @@ export default class LightOfTheProtector extends Analyzer {
     super(props);
     if(this.selectedCombatant.hasTalent(SPELLS.HAND_OF_THE_PROTECTOR_TALENT.id)) {
       this.activeSpell = SPELLS.HAND_OF_THE_PROTECTOR_TALENT;
+      this.addEventListener(Events.cast.by(SELECTED_PLAYER).to(SELECTED_PLAYER).spell(this.activeSpell), this._countDelay);
+    } else {
+      // LotP has no target, so .to(SELECTED_PLAYER) filters out ALL
+      // casts
+      this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(this.activeSpell), this._countDelay);
     }
 
     this.addEventListener(Events.damage.to(SELECTED_PLAYER), this._startDelayTimer);
-    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(this.activeSpell), this._countDelay);
     this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(this.activeSpell), this._countHeal);
 
     if(this.selectedCombatant.hasTalent(SPELLS.RIGHTEOUS_PROTECTOR_TALENT.id)) {


### PR DESCRIPTION
Pretty self-explanatory. Don't want to track delay since last time the Paladin was hit when they HotP another target.