### PR TITLE
Fixing Lifebloom Fix?

### DIFF
--- a/src/parser/shared/modules/Entities.js
+++ b/src/parser/shared/modules/Entities.js
@@ -97,7 +97,7 @@ class Entities extends Analyzer {
 
     debug && this.log(`Apply buff stack ${event.ability.name} to ${entity.name}`);
 
-    const existingBuff = entity.buffs.find(item => item.ability.guid === event.ability.guid && item.end === null);
+    const existingBuff = entity.buffs.find(item => item.ability.guid === event.ability.guid && item.end === null && event.sourceID === item.sourceID);
     if (existingBuff) {
       const oldStacks = existingBuff.stacks || 1; // the original spell counts as 1 stack
       existingBuff.stacks = event.stack;
@@ -120,8 +120,8 @@ class Entities extends Analyzer {
     }
 
     debug && this.log(`Remove buff ${event.ability.name} from ${entity.name}`);
-
-    const existingBuff = entity.buffs.find(item => item.ability.guid === event.ability.guid && item.end === null);
+    
+    const existingBuff = entity.buffs.find(item => item.ability.guid === event.ability.guid && item.end === null && event.sourceID === item.sourceID);
     if (existingBuff) {
       existingBuff.end = event.timestamp;
       existingBuff.stackHistory.push({ stacks: 0, timestamp: event.timestamp });


### PR DESCRIPTION
This is still not a nice fix but it at least fixes the changebuffstack events.

I would like to completely get rid of the one rogue buff event in the buff history but for that I need more time to understand why it even exists.

Live:
![grafik](https://user-images.githubusercontent.com/2129161/53105583-b225c480-3531-11e9-94bd-7e927c7079f6.png)

Fixed:
![grafik](https://user-images.githubusercontent.com/2129161/53105606-bc47c300-3531-11e9-8470-f31faf6ce41d.png)

Report:
http://localhost:3000/report/naqbT14ywgHpWh7D/25-Mythic+Conclave+of+the+Chosen+-+Wipe+11+(4:51)/94-Syqu/events
