### PR TITLE
[WIP] Rework prepull buff normalizers

### DIFF
--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -494,9 +494,7 @@ class CombatLogParser {
       .filter(module => module instanceof EventsNormalizer)
       .sort((a, b) => a.priority - b.priority) // lowest should go first, as `priority = 0` will have highest prio
       .forEach(module => {
-        if (module.normalize) {
-          events = module.normalize(events);
-        }
+        events = module.normalize(events);
       });
     return events;
   }

--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -9,6 +9,7 @@ import ChangelogTabTitle from 'interface/others/ChangelogTabTitle';
 import DeathRecapTracker from 'interface/others/DeathRecapTracker';
 import ItemStatisticBox from 'interface/others/ItemStatisticBox';
 
+import CombatantInfoAurasNormalizer from 'parser/shared/normalizers/CombatantInfoAuras';
 import ApplyBuffNormalizer from 'parser/shared/normalizers/ApplyBuff';
 import CancelledCastsNormalizer from 'parser/shared/normalizers/CancelledCasts';
 import PrePullCooldownsNormalizer from 'parser/shared/normalizers/PrePullCooldowns';
@@ -157,6 +158,7 @@ class CombatLogParser {
   static abilitiesAffectedByDamageIncreases = [];
 
   static internalModules = {
+    combatantInfoAurasNormalizer: CombatantInfoAurasNormalizer,
     fightEndNormalizer: FightEndNormalizer,
     eventEmitter: EventEmitter,
     combatants: Combatants,

--- a/src/parser/core/Combatant.js
+++ b/src/parser/core/Combatant.js
@@ -261,18 +261,18 @@ class Combatant extends Entity {
   }
   // endregion
 
-  _parsePrepullBuffs(buffs) {
-    // TODO: We only apply prepull buffs in the `auras` prop of combatantinfo, but not all prepull buffs are in there and ApplyBuff finds more. We should update ApplyBuff to add the other buffs to the auras prop of the combatantinfo too (or better yet, make a new normalizer for that).
+  _parsePrepullBuffs(auras) {
     const timestamp = this.owner.fight.start_time;
-    buffs.forEach(buff => {
-      const spell = SPELLS[buff.ability];
+    auras.forEach(aura => {
+      const extra = aura.__extra;
+      const spell = SPELLS[aura.ability];
       this.applyBuff({
-        ability: {
-          abilityIcon: buff.icon.replace('.jpg', ''),
-          guid: buff.ability,
+        ability: extra ? extra.ability : {
+          abilityIcon: aura.icon,
+          guid: aura.ability,
           name: spell ? spell.name : undefined,
         },
-        sourceID: buff.source,
+        sourceID: aura.source,
         start: timestamp,
       });
     });

--- a/src/parser/core/tests/TestCombatLogParser.js
+++ b/src/parser/core/tests/TestCombatLogParser.js
@@ -29,6 +29,7 @@ class TestCombatLogParser extends CombatLogParser {
 
   constructor(
     report = {
+      friendlies: [],
       friendlyPets: [],
     },
     selectedPlayer = {

--- a/src/parser/shared/modules/Entities.js
+++ b/src/parser/shared/modules/Entities.js
@@ -77,7 +77,7 @@ class Entities extends Analyzer {
 
     this._triggerChangeBuffStack(buff, event.timestamp, 0, 1);
 
-    if (event.prepull && event.__fromCombatantinfo) {
+    if (event.prepull) {
       // Prepull buffs were already applied in the Combatant constructor
       return;
     }

--- a/src/parser/shared/normalizers/ApplyBuff.js
+++ b/src/parser/shared/normalizers/ApplyBuff.js
@@ -21,7 +21,7 @@ class ApplyBuff extends EventsNormalizer {
         const sourceId = aura.source;
         const extra = aura.__extra;
 
-        debug && console.warn('Found a buff on', ((playersById[targetId] && playersById[targetId].name) || '???'), 'in the combatantinfo that was applied before the pull:', (SPELLS[spellId] && SPELLS[spellId].name) || '???', spellId, '! Fabricating an `applybuff` event so you don\'t have to do anything special to take this into account.');
+        debug && this.log('Found a buff on', ((playersById[targetId] && playersById[targetId].name) || '???'), 'in the combatantinfo that was applied before the pull:', (SPELLS[spellId] && SPELLS[spellId].name) || '???', spellId, '! Fabricating an `applybuff` event so you don\'t have to do anything special to take this into account.');
         const applybuff = {
           // These are all the properties a normal `applybuff` event would have.
           timestamp: firstStartTimestamp,

--- a/src/parser/shared/normalizers/ApplyBuff.js
+++ b/src/parser/shared/normalizers/ApplyBuff.js
@@ -4,125 +4,44 @@ import EventsNormalizer from 'parser/core/EventsNormalizer';
 
 const debug = false;
 
+/**
+ * Some buffs like Bloodlust and Holy Avenger when they are applied pre-combat it doesn't show up as an `applybuff` event, but the CombatantInfoAuras normalizer puts it in the `combatantinfo` buffs array. This uses that to detect prepull buffs and then fabricates an `applybuff` event at the start of the log.
+ * Unless Blizzard introduces some bug in the future, we can be sure that none of the buffs in the `combatantinfo.auras` prop have an `applybuff` event. So we don't have to check for that.
+ */
 class ApplyBuff extends EventsNormalizer {
-  // We need to track `combatantinfo` events this way since they aren't included in the `events` passed to `normalize` due to technical reasons (it's a different API call). We still need `combatantinfo` for all players, so cache it manually.
-  _combatantInfoEvents = [];
-  constructor(...args) {
-    super(...args);
-    this._combatantInfoEvents = this.owner.combatantInfoEvents;
-  }
-
-  _buffsAppliedByPlayerId = {};
-
-  /**
-   * Some buffs like Bloodlust and Holy Avenger when they are applied pre-combat it doesn't show up as an `applybuff` event nor in the `combatantinfo` buffs array. It can still be detected by looking for a `removebuff` event, this uses that to detect it and then fabricates an `applybuff` event at the start of the log.
-   * @param {Array} events
-   * @returns {Array}
-   */
   normalize(events) {
     const firstEventIndex = this.getFightStartIndex(events);
     const firstStartTimestamp = this.owner.fight.start_time;
     const playersById = this.owner.playersById;
-    const playerId = this.owner.playerId;
 
-    // region Buff event based detection
-    // This catches most relevant buffs and is most accurate. If a player is good at juggling certain buffs they can achieve 100% uptime, if that happens `removebuff` is never called, so we also check for other indicators that are just as reliable, such as `applybuffstack`, `removebuffstack` and `refreshbuff`.
-    for (let i = 0; i < events.length; i += 1) {
-      const event = events[i];
-      const targetId = event.targetID;
-      const sourceId = event.sourceID;
-
-      // A player can have the same buff twice given that the buff was applied by someone else. Because we only want to fabricate buffs once, we use `_buffsAppliedByPlayerId` to ensure we don't do it twice, but because it doesn't track a source we can't track other people's buffs. And that's fine too since we only care about stuff by/to the player.
-      if (![targetId, sourceId].includes(playerId)) {
-        continue;
-      }
-
-      this._buffsAppliedByPlayerId[targetId] = this._buffsAppliedByPlayerId[targetId] || [];
-
-      if (event.type === 'applybuff') {
-        const spellId = event.ability.guid;
-        this._buffsAppliedByPlayerId[targetId].push(spellId);
-      }
-      if (['removebuff', 'applybuffstack', 'removebuffstack', 'refreshbuff'].includes(event.type)) {
-        const spellId = event.ability.guid;
-        if (this._buffsAppliedByPlayerId[targetId].includes(spellId)) {
-          // This buff has an `applybuff` event and so isn't broken :D
-          continue;
-        }
-
-        debug && this.warn('Found a buff on', ((playersById[targetId] && playersById[targetId].name) || '???'), 'that was applied before the pull:', event.ability.name, spellId, '! Fabricating an `applybuff` event so you don\'t have to do anything special to take this into account.');
-        const targetInfo = this._combatantInfoEvents.find(combatantInfoEvent => combatantInfoEvent.sourceID === targetId);
-        const applybuff = {
-          // These are all the properties a normal `applybuff` event would have.
-          timestamp: firstStartTimestamp,
-          type: 'applybuff',
-          ability: event.ability,
-          sourceID: sourceId,
-          sourceIsFriendly: event.sourceIsFriendly,
-          targetID: targetId,
-          targetIsFriendly: event.targetIsFriendly,
-          // Custom properties:
-          prepull: true,
-          __fabricated: true,
-          // If we see a prepull buff from both its removebuff and in combatantinfo, we populate fabricated applybuff from the removebuff because this requires us to make up fewer fields. We still need to mark it as in the combatantinfo.
-          __fromCombatantinfo: targetInfo && targetInfo.auras && targetInfo.auras.some(aura => aura.ability === spellId),
-        };
-
-        events.splice(firstEventIndex, 0, applybuff);
-        // It shouldn't happen twice, but better be safe than sorry.
-        this._buffsAppliedByPlayerId[targetId].push(spellId);
-      }
-    }
-    // endregion
-
-    // region `combatantinfo` based detection
-    // This catches buffs that never drop, such as Flasks and more importantly Atonements, Beacons and Vantus runes.
-    this._combatantInfoEvents.forEach(event => {
+    this.owner.combatantInfoEvents.forEach(event => {
       const targetId = event.sourceID;
-      // event.auras can be undefined if combatantinfo for any player in the fight errored
-      event.auras && event.auras.forEach(aura => {
+      event.auras.forEach(aura => {
         const spellId = aura.ability;
         const sourceId = aura.source;
+        const extra = aura.__extra;
 
-        // A player can have the same buff twice given that the buff was applied by someone else. Because we only want to fabricate buffs once, we use `_buffsAppliedByPlayerId` to ensure we don't do it twice, but because it doesn't track a source we can't track other people's buffs. And that's fine too since we only care about stuff by/to the player.
-        if (![targetId, sourceId].includes(playerId)) {
-          return;
-        }
-
-        this._buffsAppliedByPlayerId[targetId] = this._buffsAppliedByPlayerId[targetId] || [];
-
-        if (this._buffsAppliedByPlayerId[targetId].includes(spellId)) {
-          // This buff has an `applybuff` event and so isn't broken :D
-          return;
-        }
-
-        debug && console.warn('Found a buff on', ((playersById[targetId] && playersById[targetId].name) || '???'), 'in the combatantinfo that was applied before the pull and never dropped:', (SPELLS[spellId] && SPELLS[spellId].name) || '???', spellId, '! Fabricating an `applybuff` event so you don\'t have to do anything special to take this into account.');
+        debug && console.warn('Found a buff on', ((playersById[targetId] && playersById[targetId].name) || '???'), 'in the combatantinfo that was applied before the pull:', (SPELLS[spellId] && SPELLS[spellId].name) || '???', spellId, '! Fabricating an `applybuff` event so you don\'t have to do anything special to take this into account.');
         const applybuff = {
           // These are all the properties a normal `applybuff` event would have.
           timestamp: firstStartTimestamp,
           type: 'applybuff',
-          ability: {
+          ability: extra ? extra.ability : {
             guid: spellId,
             name: SPELLS[spellId] ? SPELLS[spellId].name : 'Unknown',
             abilityIcon: aura.icon,
           },
           sourceID: sourceId,
-          sourceIsFriendly: true,
+          sourceIsFriendly: extra ? extra.sourceIsFriendly : true,
           targetID: targetId,
-          targetIsFriendly: true,
+          targetIsFriendly: extra ? extra.targetIsFriendly : true,
           // Custom properties:
           prepull: true,
           __fabricated: true,
-          __fromCombatantinfo: true,
         };
         events.splice(firstEventIndex, 0, applybuff);
-        // It shouldn't happen twice, but better be safe than sorry.
-        this._buffsAppliedByPlayerId[targetId].push(spellId);
       });
     });
-    // We don't need it anymore, this might introduce a crash if this method is ever called twice, but we're under the presumption that never happens so if it does crash we might have to verify if everything works properly with this behavior.
-    this._combatantInfoEvents = undefined;
-    // endregion
 
     return events;
   }

--- a/src/parser/shared/normalizers/CombatantInfoAuras.js
+++ b/src/parser/shared/normalizers/CombatantInfoAuras.js
@@ -29,7 +29,7 @@ class CombatantInfoAuras extends EventsNormalizer {
       completeBuffs[targetId] = completeBuffs[targetId] || {};
       completeBuffs[targetId][sourceId] = completeBuffs[targetId][sourceId] || [];
       completeBuffs[targetId][sourceId].push(Number(spellId));
-      debug && this.log(`Marked ${spellId} as complete`);
+      debug && this.log(`Marked ${spellId} on ${targetId} by ${sourceId} as complete`);
     };
     const isComplete = (sourceId, targetId, spellId) => {
       if (!completeBuffs[targetId] || !completeBuffs[targetId][sourceId]) {
@@ -77,7 +77,7 @@ class CombatantInfoAuras extends EventsNormalizer {
             combatant.auras = [];
           }
 
-          debug && this.log('Found a buff on', ((playersById[targetId] && playersById[targetId].name) || '???'), 'that was applied before the pull:', event.ability.name, spellId, '! Fabricating an entry in `auras` of the `combatantinfo` so you don\'t have to do anything special to take this into account.');
+          debug && this.log('Found', spellId, event.ability.name, 'on', targetId, ((playersById[targetId] && playersById[targetId].name) || '???'), 'by', sourceId, ((playersById[sourceId] && playersById[sourceId].name) || '???'), 'that was applied before the pull! Fabricating an entry in `auras` of the `combatantinfo` so you don\'t have to do anything special to take this into account.');
           combatant.auras.push({
             source: event.sourceID,
             ability: spellId,

--- a/src/parser/shared/normalizers/CombatantInfoAuras.js
+++ b/src/parser/shared/normalizers/CombatantInfoAuras.js
@@ -1,0 +1,103 @@
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+
+const debug = false;
+
+/**
+ * The `combatantinfo` event is a event that's fired at the start of the fight. It has a lot of information about the players, including an `auras` prop that's an array with a few of the buffs applied on the pull. Unfortunately this array is incomplete and based on a whitelist.
+ *
+ * **This normalizer will make sure the `auras` prop is complete.** It looks for events such as `refreshbuff` and `removebuff` to detect if a buff has been active since before the pull, and if so it will add it to the `auras` array.
+ *
+ * Note: each entry of the `auras` prop has the following format:
+ * {
+ *   source: (int)sourceId,
+ *   ability: (int)spellId,
+ *   icon: (string)icon,
+ * }
+ * This deviates from pretty much any other data structure in every single way. `source` is normally called `sourceID`, and `ability` and `icon` are usually in an object with the spell name, guid and icon.
+ */
+class CombatantInfoAuras extends EventsNormalizer {
+  normalize(events) {
+    const combatantInfoEvents = this.owner.combatantInfoEvents;
+    const playersById = this.owner.playersById;
+    const combatantInfoById = combatantInfoEvents.reduce((obj, combatantinfo) => {
+      obj[combatantinfo.sourceID] = combatantinfo;
+      return obj;
+    }, {});
+    // This tracks which buffs are completed already. A buff can only be applied once to someone per target/source/spellid.
+    const completeBuffs = {};
+    const markComplete = (sourceId, targetId, spellId) => {
+      completeBuffs[targetId] = completeBuffs[targetId] || {};
+      completeBuffs[targetId][sourceId] = completeBuffs[targetId][sourceId] || [];
+      completeBuffs[targetId][sourceId].push(Number(spellId));
+      debug && this.log(`Marked ${spellId} as complete`);
+    };
+    const isComplete = (sourceId, targetId, spellId) => {
+      if (!completeBuffs[targetId] || !completeBuffs[targetId][sourceId]) {
+        return false;
+      }
+      return completeBuffs[targetId][sourceId].includes(Number(spellId));
+    };
+
+    // Mark everything already in the `auras` prop as complete to avoid doubling them.
+    combatantInfoEvents.forEach(combatantinfo => {
+      // event.auras can be undefined if combatantinfo for any player in the fight errored
+      combatantinfo.auras && combatantinfo.auras.forEach(aura => {
+        markComplete(aura.source, combatantinfo.sourceID, aura.ability);
+      });
+    });
+
+    const length = events.length;
+    for (let i = 0; i < length; i += 1) {
+      const event = events[i];
+      const sourceId = event.sourceID;
+      const targetId = event.targetID;
+      if (!event.ability) {
+        continue;
+      }
+      const spellId = event.ability.guid;
+      if (isComplete(sourceId, targetId, spellId)) {
+        continue;
+      }
+
+      switch (event.type) {
+        case 'applybuff':
+          markComplete(sourceId, targetId, spellId);
+          break;
+        case 'removebuff':
+        case 'applybuffstack':
+        case 'removebuffstack':
+        case 'refreshbuff': {
+          const combatant = combatantInfoById[event.targetID];
+          if (!combatant) {
+            // Probably a pet
+            continue;
+          }
+          if (!combatant.auras) {
+            // event.auras can be undefined if combatantinfo for any player in the fight errored
+            combatant.auras = [];
+          }
+
+          debug && this.log('Found a buff on', ((playersById[targetId] && playersById[targetId].name) || '???'), 'that was applied before the pull:', event.ability.name, spellId, '! Fabricating an entry in `auras` of the `combatantinfo` so you don\'t have to do anything special to take this into account.');
+          combatant.auras.push({
+            source: event.sourceID,
+            ability: spellId,
+            icon: event.ability.abilityIcon,
+            __fabricated: true,
+            __extra: {
+              ability: event.ability,
+              sourceIsFriendly: event.sourceIsFriendly,
+              targetIsFriendly: event.targetIsFriendly,
+            },
+          });
+          markComplete(sourceId, targetId, spellId);
+          break;
+        }
+        default: break;
+      }
+    }
+
+    return events;
+  }
+}
+
+export default CombatantInfoAuras;


### PR DESCRIPTION
This adds a `CombatantInfoAuras` normalizer to add all prepull buffs to the `combatantinfo.auras` prop and rework `ApplyBuff` to just use that instead, greatly simplifying it.

This also fixes one of the rare bugs where if the same buff was applied to a target by two different sources, it would only fabricate 1 applybuff.