### PR TITLE
#2963 Fetch Heart of Azeroth item level from Blizzard API and display the value on Raid Composition page

### DIFF
--- a/server/constants/index.js
+++ b/server/constants/index.js
@@ -1,0 +1,3 @@
+export const HEART_OF_AZEROTH = {
+  id: 158075,
+};

--- a/server/controllers/api/character.js
+++ b/server/controllers/api/character.js
@@ -54,7 +54,7 @@ async function getCharacterFromBlizzardApi(region, realm, name) {
   }
   // This is the only field that we need and isn't always otherwise obtainable (e.g. when this is fetched by character id)
   // eslint-disable-next-line prefer-const
-  const {talents, thumbnail, items, ...other} = data;
+  const { talents, thumbnail, items, ...other } = data;
   delete other.calcClass;
   delete other.totalHonorableKills;
   delete other.level;
@@ -81,6 +81,7 @@ async function getCharacterFromBlizzardApi(region, realm, name) {
       quality: heartOfAzerothItem.quality,
       itemLevel: heartOfAzerothItem.itemLevel,
       timewalkerLevel: heartOfAzerothItem.tooltipParams && heartOfAzerothItem.tooltipParams.timewalkerLevel,
+      azeriteItemLevel: heartOfAzerothItem.azeriteItem && heartOfAzerothItem.azeriteItem.azeriteLevel,
     };
   }
   delete json.items;

--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -551,3 +551,13 @@ export const Korebian = {
   nickname: 'Korebian',
   github: 'Asamsig',
 };
+export const _4Ply = {
+  nickname: '4Ply',
+  github: '4Ply',
+  discord: '4Ply#9270',
+  mains: [{
+    name: 'Uzdrowiciela',
+    spec: SPECS.RESTORATION_DRUID,
+    link: 'https://worldofwarcraft.com/en-gb/character/sylvanas/Uzdrowiciela',
+  }],
+};

--- a/src/interface/report/PlayerSelection/PlayerTile.js
+++ b/src/interface/report/PlayerSelection/PlayerTile.js
@@ -100,7 +100,7 @@ class PlayerTile extends React.PureComponent {
               {
                 heartOfAzeroth
                 && <div className="flex-main text-right">
-                  <Icon icon={heartOfAzeroth.icon}/> {heartOfAzeroth.itemLevel}
+                  <Icon icon={heartOfAzeroth.icon}/> {heartOfAzeroth.azeriteItemLevel}
                 </div>
               }
             </div>

--- a/src/interface/report/PlayerSelection/PlayerTile.js
+++ b/src/interface/report/PlayerSelection/PlayerTile.js
@@ -49,6 +49,7 @@ class PlayerTile extends React.PureComponent {
     const avatar = characterInfo && characterInfo.thumbnail ? `https://render-${characterInfo.region}.worldofwarcraft.com/character/${characterInfo.thumbnail.replace('avatar', 'inset')}` : '/img/fallback-character.jpg';
     const spec = SPECS[player.combatant.specID];
     const analysisUrl = makeUrl(player.id);
+    const heartOfAzeroth = characterInfo && characterInfo.heartOfAzeroth;
 
     player.parsable = !player.combatant.error && spec;
     if (!player.parsable) {
@@ -95,7 +96,13 @@ class PlayerTile extends React.PureComponent {
               <div className="flex-main">
                 <Icon icon="inv_helmet_03" /> {Math.round(getAverageItemLevel(player.combatant.gear))}
               </div>
-              <div className="flex-main text-right" />
+
+              {
+                heartOfAzeroth
+                && <div className="flex-main text-right">
+                  <Icon icon={heartOfAzeroth.icon}/> {heartOfAzeroth.itemLevel}
+                </div>
+              }
             </div>
           </div>
         </div>


### PR DESCRIPTION
Resolves #2963 
The result looks like this:

![](https://i.imgur.com/M5iXNvt.jpg)


Please note that this is my first contribution to this project, and so please forgive me if I have done something in the wrong place. If so - I'll happily fix it!