### PR TITLE
[Core] Added race translation tables for BoD faction swaps

### DIFF
--- a/src/parser/core/Combatant.js
+++ b/src/parser/core/Combatant.js
@@ -49,7 +49,16 @@ class Combatant extends Entity {
     return SPECS[this.specId];
   }
   get race() {
-    return this.owner.characterProfile ? Object.values(RACES).find(race => race.id === this.owner.characterProfile.race) : null;
+    if(!this.owner.characterProfile) {
+      return null;
+    }
+    const raceId = this.owner.characterProfile.race;
+    let race = Object.values(RACES).find(race => race.id === raceId);
+    const raceTranslation = this.owner.fight.boss.fight.raceTranslation;
+    if(raceTranslation) {
+      race = raceTranslation(race, this.spec);
+    }
+    return race;
   }
 
   _combatantInfo = null;

--- a/src/parser/core/Combatant.js
+++ b/src/parser/core/Combatant.js
@@ -2,7 +2,7 @@ import SPECS from 'game/SPECS';
 import RACES from 'game/RACES';
 import traitIdMap from 'common/TraitIdMap';
 import SPELLS from 'common/SPELLS';
-
+import { findByBossId } from 'raids/index';
 import Entity from './Entity';
 
 export const TALENT_ROWS = {
@@ -54,9 +54,9 @@ class Combatant extends Entity {
     }
     const raceId = this.owner.characterProfile.race;
     let race = Object.values(RACES).find(race => race.id === raceId);
-    const raceTranslation = this.owner.fight.boss.fight.raceTranslation;
-    if(raceTranslation) {
-      race = raceTranslation(race, this.spec);
+    const boss = findByBossId(this.owner.boss.id);
+    if(boss && boss.fight.raceTranslation) {
+      race = boss.fight.raceTranslation(race, this.spec);
     }
     return race;
   }

--- a/src/raids/battleofdazaralor/ConclaveOfTheChosen.js
+++ b/src/raids/battleofdazaralor/ConclaveOfTheChosen.js
@@ -1,5 +1,6 @@
 // import Background from './images/backgrounds/FridaIronbellows.jpg';
 import Headshot from './images/headshots/ConclaveOfTheChosen.jpg';
+import { BOD_HORDE_TO_ALLIANCE } from './RaceTranslation';
 
 export default {
   id: 2268,
@@ -15,5 +16,6 @@ export default {
         282411, // Thundering Storm
       ],
     },
+    raceTranslation: BOD_HORDE_TO_ALLIANCE,
   },
 };

--- a/src/raids/battleofdazaralor/HighTinkerMekkatorque.js
+++ b/src/raids/battleofdazaralor/HighTinkerMekkatorque.js
@@ -1,5 +1,6 @@
 // import Background from './images/backgrounds/FridaIronbellows.jpg';
 import Headshot from './images/headshots/HighTinkerMekkatorque.jpg';
+import { BOD_ALLIANCE_TO_HORDE } from './RaceTranslation';
 
 export default {
   id: 2276,
@@ -13,5 +14,6 @@ export default {
       physical: [],
       magical: [],
     },
+    raceTranslation: BOD_ALLIANCE_TO_HORDE,
   },
 };

--- a/src/raids/battleofdazaralor/JainaProudmoore.js
+++ b/src/raids/battleofdazaralor/JainaProudmoore.js
@@ -1,6 +1,6 @@
 // import Background from './images/backgrounds/FridaIronbellows.jpg';
 import Headshot from './images/headshots/JainaProudmoore.jpg';
-import BOD_HORDE_TO_ALLIANCE from 'RaceTranslation';
+import { BOD_ALLIANCE_TO_HORDE } from './RaceTranslation';
 
 export default {
   id: 2281,
@@ -16,6 +16,6 @@ export default {
         287565, // Avalanche
       ],
     },
-    raceTranslation: BOD_HORDE_TO_ALLIANCE,
+    raceTranslation: BOD_ALLIANCE_TO_HORDE,
   },
 };

--- a/src/raids/battleofdazaralor/JainaProudmoore.js
+++ b/src/raids/battleofdazaralor/JainaProudmoore.js
@@ -1,5 +1,6 @@
 // import Background from './images/backgrounds/FridaIronbellows.jpg';
 import Headshot from './images/headshots/JainaProudmoore.jpg';
+import BOD_HORDE_TO_ALLIANCE from 'RaceTranslation';
 
 export default {
   id: 2281,
@@ -15,5 +16,6 @@ export default {
         287565, // Avalanche
       ],
     },
+    raceTranslation: BOD_HORDE_TO_ALLIANCE,
   },
 };

--- a/src/raids/battleofdazaralor/KingRastakhan.js
+++ b/src/raids/battleofdazaralor/KingRastakhan.js
@@ -1,5 +1,6 @@
 import Background from './images/backgrounds/KingRastakhan.jpg';
 import Headshot from './images/headshots/KingRastakhan.png';
+import { BOD_HORDE_TO_ALLIANCE } from './RaceTranslation';
 
 export default {
   id: 2272,
@@ -13,5 +14,6 @@ export default {
       physical: [],
       magical: [],
     },
+    raceTranslation: BOD_HORDE_TO_ALLIANCE,
   },
 };

--- a/src/raids/battleofdazaralor/OpulenceTreasureGuardian.js
+++ b/src/raids/battleofdazaralor/OpulenceTreasureGuardian.js
@@ -1,5 +1,6 @@
 import Background from './images/backgrounds/OpulenceTreasureGuardian.jpg';
 import Headshot from './images/headshots/OpulenceTreasureGuardian.png';
+import { BOD_HORDE_TO_ALLIANCE } from './RaceTranslation';
 
 export default {
   id: 2271,
@@ -15,5 +16,6 @@ export default {
       ],
       magical: [],
     },
+    raceTranslation: BOD_HORDE_TO_ALLIANCE,
   },
 };

--- a/src/raids/battleofdazaralor/RaceTranslation.js
+++ b/src/raids/battleofdazaralor/RaceTranslation.js
@@ -1,15 +1,19 @@
-import SPECS from 'game/SPECS';
 import RACES from 'game/RACES';
 
-// Taken from https://www.wowhead.com/news=288178/battle-for-dazaralor-flashback-bosses-change-your-race-and-racials
+/*
+ * Taken from https://www.wowhead.com/news=288178/battle-for-dazaralor-flashback-bosses-change-your-race-and-racials
+ *
+ * Not happy using the class name strings as a comparator -
+ * another option would be to use ids, but would require setting up a
+ * constants class for Classes as well, not just Specs
+ */
 export function BOD_HORDE_TO_ALLIANCE(race, spec) {
   const className = spec.className;
   switch (race) {
     case RACES.Orc:
       return RACES.Dwarf;
-
     case RACES.Troll:
-      switch (clazz) {
+      switch (className) {
         case 'Shaman':
           return RACES.Draenei;
         case 'Warlock':
@@ -17,28 +21,51 @@ export function BOD_HORDE_TO_ALLIANCE(race, spec) {
         default:
           return RACES.NightElf;
       }
-
     case RACES.Undead:
       return RACES.Human;
-
     case RACES.Tauren:
-      return clazz === 'Druid' ? RACES.NightElf : RACES.Draenei;
-
+      return className === 'Druid' ? RACES.NightElf : RACES.Draenei;
     case RACES.BloodElf:
-      return clazz === 'DemonHunter' ? RACES.NightElf : RACES.Human;
-
+      return className === 'Demon Hunter' ? RACES.NightElf : RACES.Human;
     case RACES.Goblin:
-      switch (clazz) {
+      switch (className) {
         case 'Hunter':
         case 'Shaman':
           return RACES.Dwarf;
         default:
           return RACES.Gnome;
       }
-
     case RACES.PandarenHorde:
       return RACES.PandarenAlliance;
+    default:
+      return race;
+  }
+}
 
+export function BOD_ALLIANCE_TO_HORDE(race, spec) {
+  const className = spec.className;
+  switch (race) {
+    case RACES.Human:
+      return className === 'Paladin' ? RACES.BloodElf : RACES.Undead;
+    case RACES.NightElf:
+      return className === 'Demon Hunter' ? RACES.BloodElf : RACES.Troll;
+    case RACES.Dwarf:
+      switch (className) {
+        case 'Paladin':
+          return RACES.Tauren;
+        case 'Priest':
+          return RACES.Undead;
+        default:
+          return RACES.Orc;
+      }
+    case RACES.Draenei:
+      return className === 'Mage' ? RACES.Orc : RACES.Tauren;
+    case RACES.Gnome:
+      return className === 'Monk' ? RACES.BloodElf : RACES.Goblin;
+    case RACES.Worgen:
+      return RACES.Troll;
+    case RACES.PandarenAlliance:
+      return RACES.PandarenHorde;
     default:
       return race;
   }

--- a/src/raids/battleofdazaralor/RaceTranslation.js
+++ b/src/raids/battleofdazaralor/RaceTranslation.js
@@ -1,0 +1,45 @@
+import SPECS from 'game/SPECS';
+import RACES from 'game/RACES';
+
+// Taken from https://www.wowhead.com/news=288178/battle-for-dazaralor-flashback-bosses-change-your-race-and-racials
+export function BOD_HORDE_TO_ALLIANCE(race, spec) {
+  const className = spec.className;
+  switch (race) {
+    case RACES.Orc:
+      return RACES.Dwarf;
+
+    case RACES.Troll:
+      switch (clazz) {
+        case 'Shaman':
+          return RACES.Draenei;
+        case 'Warlock':
+          return RACES.Human;
+        default:
+          return RACES.NightElf;
+      }
+
+    case RACES.Undead:
+      return RACES.Human;
+
+    case RACES.Tauren:
+      return clazz === 'Druid' ? RACES.NightElf : RACES.Draenei;
+
+    case RACES.BloodElf:
+      return clazz === 'DemonHunter' ? RACES.NightElf : RACES.Human;
+
+    case RACES.Goblin:
+      switch (clazz) {
+        case 'Hunter':
+        case 'Shaman':
+          return RACES.Dwarf;
+        default:
+          return RACES.Gnome;
+      }
+
+    case RACES.PandarenHorde:
+      return RACES.PandarenAlliance;
+
+    default:
+      return race;
+  }
+}

--- a/src/raids/battleofdazaralor/StormwallBlockade.js
+++ b/src/raids/battleofdazaralor/StormwallBlockade.js
@@ -1,5 +1,6 @@
 // import Background from './images/backgrounds/FridaIronbellows.jpg';
 import Headshot from './images/headshots/StormwallBlockade.jpg';
+import { BOD_ALLIANCE_TO_HORDE } from './RaceTranslation';
 
 export default {
   id: 2280,
@@ -13,5 +14,6 @@ export default {
       physical: [],
       magical: [],
     },
+    raceTranslation: BOD_ALLIANCE_TO_HORDE,
   },
 };


### PR DESCRIPTION
Resolves #3014

As the comment indicates, there are better ways to compare the players class, but our way of handling it is pretty poor at the moment and it's either this or doing something like

`return spec.ranking.id === SPECS.GuardianDruid.ranking.id ? RACES.NightElf : RACES.Draenei;`

Which seems pretty arbitrary and confusing