### PR TITLE
Character cache storage - persist heartOfAzeroth field in Sequelize cache

### DIFF
--- a/server/migrations/20190223014101-character.js
+++ b/server/migrations/20190223014101-character.js
@@ -1,0 +1,15 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return Promise.all([
+      queryInterface.addColumn('Character', 'heartOfAzeroth', Sequelize.JSON, {
+        allowNull: true,
+      }),
+    ]);
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return Promise.all([
+      queryInterface.removeColumn('Character', 'heartOfAzeroth'),
+    ]);
+  },
+};

--- a/server/models/Character.js
+++ b/server/models/Character.js
@@ -56,6 +56,10 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: true,
     },
+    heartOfAzeroth: {
+      type: DataTypes.JSON,
+      allowNull: true,
+    },
     createdAt: {
       type: DataTypes.DATE, // this is actually DATETIME
       defaultValue: DataTypes.NOW,


### PR DESCRIPTION
This resolves the issue where the updated Character data fetched the Blizzard API is not defined in the Character model, and thus does not display when the character is fetched from the cache.

Definition:
https://github.com/WoWAnalyzer/WoWAnalyzer/blob/next/server/controllers/api/character.js#L77

Resolves #2963