### PR TITLE
[Feral] Jungle Fury azerite trait

### DIFF
--- a/src/common/SPELLS/bfa/azeritetraits/druid.js
+++ b/src/common/SPELLS/bfa/azeritetraits/druid.js
@@ -74,6 +74,16 @@ export default {
     name: 'Untamed Ferocity',
     icon: 'ability_druid_disembowel',
   },
+  JUNGLE_FURY_TRAIT: {
+    id: 274424,
+    name: 'Jungle Fury',
+    icon: 'ability_mount_jungletiger',
+  },
+  JUNGLE_FURY_BUFF: {
+    id: 274426,
+    name: 'Jungle Fury',
+    icon: 'ability_mount_jungletiger',
+  },
   MASTERFUL_INSTINCTS: {
     id: 273344,
     name: 'Masterful Instincts',

--- a/src/parser/druid/feral/CHANGELOG.js
+++ b/src/parser/druid/feral/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2019-02-23'),
+    changes: <>Added tracking of <SpellLink id={SPELLS.JUNGLE_FURY_TRAIT.id} />.</>,
+    contributors: [Anatta336],
+  },
+  {
     date: new Date('2019-02-08'),
     changes: <>Added tracking of <SpellLink id={SPELLS.UNTAMED_FEROCITY.id} /> and updated <SpellLink id={SPELLS.WILD_FLESHRENDING.id} />.</>,
     contributors: [Anatta336],

--- a/src/parser/druid/feral/CombatLogParser.js
+++ b/src/parser/druid/feral/CombatLogParser.js
@@ -40,6 +40,7 @@ import Shadowmeld from './modules/racials/Shadowmeld';
 
 import WildFleshrending from './modules/azeritetraits/WildFleshrending';
 import UntamedFerocity from './modules/azeritetraits/UntamedFerocity';
+import JungleFury from './modules/azeritetraits/JungleFury';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -91,6 +92,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // azerite traits
     wildFleshrending: WildFleshrending,
     untamedFerocity: UntamedFerocity,
+    jungleFury: JungleFury,
   };
 }
 

--- a/src/parser/druid/feral/modules/azeritetraits/JungleFury.js
+++ b/src/parser/druid/feral/modules/azeritetraits/JungleFury.js
@@ -1,0 +1,79 @@
+import React from 'react';
+
+import { formatNumber, formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import { calculateAzeriteEffects } from 'common/stats';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import StatTracker from 'parser/shared/modules/StatTracker';
+import TraitStatisticBox, { STATISTIC_ORDER } from 'interface/others/TraitStatisticBox';
+
+const DURATION_INCREASE = 2000;
+
+/**
+ * Jungle Fury
+ * Tiger's Fury increases your critical strike by X and lasts 12 sec. (An increase from the standard 10 seconds)
+ */
+class JungleFury extends Analyzer {
+  static dependencies = {
+    statTracker: StatTracker,
+  };
+
+  critRating = 0;
+  hasPredator = false;
+  buffCount = 0;
+
+  constructor(...args) {
+    super(...args);
+    if (!this.selectedCombatant.hasTrait(SPELLS.JUNGLE_FURY_TRAIT.id)) {
+      this.active = false;
+      return;
+    }
+    this.hasPredator = this.selectedCombatant.hasTalent(SPELLS.PREDATOR_TALENT.id);
+
+    this.critRating = this.selectedCombatant.traitsBySpellId[SPELLS.JUNGLE_FURY_TRAIT.id]
+      .reduce((sum, rank) => sum + calculateAzeriteEffects(SPELLS.JUNGLE_FURY_TRAIT.id, rank)[0], 0);
+
+    this.addEventListener(Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.TIGERS_FURY), this._loseTigersFury);
+
+    this.statTracker.add(SPELLS.JUNGLE_FURY_BUFF.id, {
+      crit: this.critRating,
+    });
+  }
+
+  _loseTigersFury(event) {
+    // Count how often the player benefits from the increased duration by looking for the buff dropping. Makes sure pre-combat casts are included and avoids cases where the extra time would have been after the fight ended.
+    if (this.hasPredator) {
+      // The Predator talent complicates calculating how much extra uptime was provided by this trait. It is possible to do, but as the talent is currently rarely taken I'll skip the work for now.
+      return;
+    }
+    this.buffCount += 1;
+  }
+
+  get buffUptime() {
+    return this.selectedCombatant.getBuffUptime(SPELLS.JUNGLE_FURY_BUFF.id) / this.owner.fightDuration;
+  }
+
+  get averageCritRating(){
+    return this.buffUptime * this.critRating;
+  }
+
+  statistic() {
+    const timeComment = this.hasPredator ? '' : `<br />The trait provided you with an extra <b>${(this.buffCount * DURATION_INCREASE / 1000).toFixed(0)}</b> seconds of Tiger's Fury over the course of this fight.`;
+    return (
+      <TraitStatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
+        trait={SPELLS.JUNGLE_FURY_TRAIT.id}
+        value={(
+          <>
+            {formatPercentage(this.buffUptime)}% uptime <br />
+            {formatNumber(this.averageCritRating)} average Crit
+          </>
+        )}
+        tooltip={`Jungle Fury grants <b>${this.critRating}</b> critical strike rating while Tiger's Fury is active.${timeComment}`}
+      />
+    );
+  }
+}
+
+export default JungleFury;


### PR DESCRIPTION
Adds simple analysis of the [Jungle Fury](https://www.wowhead.com/spell=274424/jungle-fury) azerite trait. Provides a statistic showing what critical strike rating it gave over the fight and how much extra duration on the Tiger's Fury buff was added by the trait.

![junglefury01](https://user-images.githubusercontent.com/35700764/53288904-6e77c880-3786-11e9-8099-e1be4a8df6ce.png)

Example log: report/tQRnCGHaTgKrA2JV/9-Heroic+Grong+the+Revenant+-+Kill+(3:18)/555-Hoofhartd