### PR TITLE
[Feral] Iron Jaws azerite trait

### DIFF
--- a/src/common/SPELLS/bfa/azeritetraits/__UNUSED.js
+++ b/src/common/SPELLS/bfa/azeritetraits/__UNUSED.js
@@ -404,11 +404,6 @@ export default {
     name: 'Invigorating Brew',
     icon: 'ability_monk_vivify',
   },
-  IRON_JAWS: {
-    id: 276021,
-    name: 'Iron Jaws',
-    icon: 'ability_druid_mangle-tga',
-  },
   ITEM__PROC_MASTERY: {
     id: 92322,
     name: 'Item - Proc Mastery',

--- a/src/common/SPELLS/bfa/azeritetraits/druid.js
+++ b/src/common/SPELLS/bfa/azeritetraits/druid.js
@@ -84,6 +84,16 @@ export default {
     name: 'Jungle Fury',
     icon: 'ability_mount_jungletiger',
   },
+  IRON_JAWS_TRAIT: {
+    id: 276021,
+    name: 'Iron Jaws',
+    icon: 'ability_druid_mangle',
+  },
+  IRON_JAWS_BUFF: {
+    id: 276026,
+    name: 'Iron Jaws',
+    icon: 'inv_misc_bone_09',
+  },
   MASTERFUL_INSTINCTS: {
     id: 273344,
     name: 'Masterful Instincts',

--- a/src/common/SPELLS/druid.js
+++ b/src/common/SPELLS/druid.js
@@ -693,12 +693,12 @@ export default {
   MAIM: {
     id: 22570,
     name: 'Maim',
-    icon: 'ability_druid_mangle-tga',
+    icon: 'ability_druid_mangle',
   },
-  MAIM_DEBUFF: {
+  MAIM_DEBUFF: { // the stun caused by Maim, which shows in the log as a 0 damage event
     id: 203123,
     name: 'Maim',
-    icon: 'ability_druid_mangle-tga',
+    icon: 'ability_druid_mangle',
   },
   RAKE_BLEED: {
     id: 155722,

--- a/src/parser/druid/feral/CHANGELOG.js
+++ b/src/parser/druid/feral/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2019-02-26'),
+    changes: <>Added tracking of <SpellLink id={SPELLS.IRON_JAWS_TRAIT.id} />.</>,
+    contributors: [Anatta336],
+  },
+  {
     date: new Date('2019-02-25'),
     changes: <>Updated explanatory text to reflect changes from patch 8.1.</>,
     contributors: [Anatta336],

--- a/src/parser/druid/feral/CombatLogParser.js
+++ b/src/parser/druid/feral/CombatLogParser.js
@@ -41,6 +41,7 @@ import Shadowmeld from './modules/racials/Shadowmeld';
 import WildFleshrending from './modules/azeritetraits/WildFleshrending';
 import UntamedFerocity from './modules/azeritetraits/UntamedFerocity';
 import JungleFury from './modules/azeritetraits/JungleFury';
+import IronJaws from './modules/azeritetraits/IronJaws';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -93,6 +94,7 @@ class CombatLogParser extends CoreCombatLogParser {
     wildFleshrending: WildFleshrending,
     untamedFerocity: UntamedFerocity,
     jungleFury: JungleFury,
+    ironJaws: IronJaws,
   };
 }
 

--- a/src/parser/druid/feral/modules/Abilities.js
+++ b/src/parser/druid/feral/modules/Abilities.js
@@ -187,6 +187,7 @@ class Abilities extends CoreAbilities {
           static: 1000,
         },
         timelineSortIndex: 32,
+        primaryCoefficient: 0.092, // damage per combo point
       },
       {
         spell: SPELLS.DASH,

--- a/src/parser/druid/feral/modules/azeritetraits/IronJaws.js
+++ b/src/parser/druid/feral/modules/azeritetraits/IronJaws.js
@@ -1,0 +1,227 @@
+import React from 'react';
+
+import { formatNumber } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import { calculateAzeriteEffects } from 'common/stats';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import calculateBonusAzeriteDamage from 'parser/core/calculateBonusAzeriteDamage';
+import TraitStatisticBox, { STATISTIC_ORDER } from 'interface/others/TraitStatisticBox';
+import ItemDamageDone from 'interface/others/ItemDamageDone';
+
+import Abilities from '../Abilities';
+
+const debug = false;
+const BUFFER_TIME = 100;
+const PROC_CHANCE_PER_COMBO = 0.08;
+/**
+ * Iron Jaws
+ * Ferocious Bite has a 8% chance per combo point to increase the damage of your next Maim by X per combo point.
+ * 
+ * Example log: /report/7ZjPwhdHXFb8r6ky/6-Normal+Grong+the+Revenant+-+Kill+(3:30)/17-Ashurabisha
+ * 
+ * Using Ferocious Bite has a chance to give the player the Iron Jaws buff, which lasts 30 seconds or until they next use Maim.
+ * When Maim is used with the buff active the removebuff event appears before the cast event for Maim in the log.
+ */
+class IronJaws extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+  };
+
+  traitBonus = 0; // trait bonus damage is per combo point on 
+  coefficient = 0; // per combo point spent on Maim
+  damage = 0;
+  
+  // updated when Maim is cast, used when Maim damage is detected
+  attackPower = 0;
+  comboPoints = 0;
+
+  ironJawsProcCount = 0;
+  expectedProcCount = 0;
+  unbuffedMaimCount = 0;
+  buffedMaimCount = 0;
+  missingComboMaimCount = 0;
+
+  constructor(...args) {
+    super(...args);
+    if (!this.selectedCombatant.hasTrait(SPELLS.IRON_JAWS_TRAIT.id)) {
+      this.active = false;
+      return;
+    }
+    
+    this.traitBonus = this.selectedCombatant.traitsBySpellId[SPELLS.IRON_JAWS_TRAIT.id]
+      .reduce((sum, rank) => sum + calculateAzeriteEffects(SPELLS.IRON_JAWS_TRAIT.id, rank)[0], 0);
+    this.coefficient = this.abilities.getAbility(SPELLS.MAIM.id).primaryCoefficient;
+
+    debug && this.log(`Iron Jaws bonus: ${this.traitBonus} from ${this.selectedCombatant.traitsBySpellId[SPELLS.IRON_JAWS_TRAIT.id].length} traits.`);
+    debug && this.log(`Maim's coefficient: ${this.coefficient}`);
+
+    this.addEventListener(Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.IRON_JAWS_BUFF), this._gainIronJaws);
+    this.addEventListener(Events.refreshbuff.to(SELECTED_PLAYER).spell(SPELLS.IRON_JAWS_BUFF), this._gainIronJaws);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.MAIM), this._castMaim);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.MAIM), this._damageMaim);
+    // there is also a damage event in the log from SPELLS.MAIM_DEBUFF but that's the stun attempting to be applied and never causes damage.
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.FEROCIOUS_BITE), this._castBite);
+  }
+
+  getComboPoints(event) {
+    const resource = event.classResources.find(item => item.type === RESOURCE_TYPES.COMBO_POINTS.id);
+    if (!resource) {
+      debug && this.log('Unable to find combo points.');
+      return null;
+    }
+    return resource.amount;
+  }
+
+  _gainIronJaws(event) {
+    this.ironJawsProcCount += 1;
+  }
+
+  _castMaim(event) {
+    if (!this.selectedCombatant.hasBuff(SPELLS.IRON_JAWS_BUFF.id, null, BUFFER_TIME)) {
+      this.unbuffedMaimCount += 1;
+      debug && this.log('Unbuffed Maim');
+      return;
+    }
+    this.buffedMaimCount += 1;
+    debug && this.log('Buffed Maim');
+    
+    this.comboPoints = this.getComboPoints(event);
+    debug && this.log(`Maim used with ${this.comboPoints} combo points.`);
+    if (this.comboPoints && this.comboPoints < 5) {
+      this.missingComboMaimCount += 1;
+    }
+    this.attackPower = event.attackPower;
+  }
+
+  _damageMaim(event) {
+    if (!this.comboPoints || !this.attackPower) {
+      debug && this.warn(`Unable to find attackPower (${this.attackPower}) or combo points (${this.comboPoints}) of Maim cast.`);
+      return;
+    }
+    const [ traitDamageContribution ] = calculateBonusAzeriteDamage(event, [this.traitBonus * this.comboPoints], this.attackPower, this.coefficient * this.comboPoints);
+    this.damage += traitDamageContribution;
+    debug && this.log(`Iron Jaws contributed ${traitDamageContribution.toFixed(0)} bonus damage of Maim's total ${event.amount + event.absorbed}`);
+  }
+
+  _castBite(event) {
+    // whenever the player casts Ferocious Bite there's a chance it'll activate Iron Jaws. Keep track of that chance and see how it matches up with reality.
+    const comboPoints = this.getComboPoints(event);
+    if (!comboPoints) return;
+    this.expectedProcCount += PROC_CHANCE_PER_COMBO * comboPoints;
+  }
+
+  statistic() {
+    return (
+      <TraitStatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
+        trait={SPELLS.IRON_JAWS_TRAIT.id}
+        value={(
+          <ItemDamageDone amount={this.damage} />
+        )}
+        tooltip={`Increased your Maim damage by a total of <b>${formatNumber(this.damage)}</b>.<br />
+        From your use of Ferocious Bite you would expect on average to get <b>${this.expectedProcCount.toFixed(1)}</b> Iron Jaws procs. You actually got <b>${this.ironJawsProcCount}</b>.<br />
+        Of those <b>${this.ironJawsProcCount}</b> procs you made use of <b>${this.buffedMaimCount}</b> to buff Maim's damage.<br />
+        You cast Maim <b>${this.unbuffedMaimCount}</b> time${this.unbuffedMaimCount === 1 ? '' : 's'} without the Iron Jaws buff.`}
+      />
+    );
+  }
+
+  get traitCountThreshold() {
+    return { // 1 trait is basically worthless, 2+ is fine
+      actual: this.selectedCombatant.traitsBySpellId[SPELLS.IRON_JAWS_TRAIT.id].length,
+      isLessThan: {
+        minor: 2,
+        average: 2,
+        major: 2,
+      },
+      style: 'number',
+    };
+  }
+
+  get wastedProcsThreshold() {
+    return { // percentage of procs that were not used
+      actual: (this.ironJawsProcCount - this.buffedMaimCount) / this.ironJawsProcCount,
+      isGreaterThan: {
+        minor: 0.10,
+        average: 0.15,
+        major: 0.25,
+      },
+      style: 'percentage',
+    };
+  }
+
+  get unbuffedMaimThreshold() {
+    return { // unbuffed Maims per minute
+      actual: this.unbuffedMaimCount / (this.owner.fightDuration / (60000)),
+      isGreaterThan: {
+        minor: 0.3,
+        average: 0.9,
+        major: 1.2,
+      },
+      style: 'number',
+    };
+  }
+
+  get missingComboMaimThreshold() {
+    return { // percentage of Maim casts made without full combo points
+      actual: this.missingComboMaimCount / (this.unbuffedMaimCount + this.buffedMaimCount),
+      isGreaterThan: {
+        minor: 0.0,
+        average: 0.0,
+        major: 0.2,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.traitCountThreshold).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <>
+          Using just 1 <SpellLink id={SPELLS.IRON_JAWS_TRAIT.id} /> Azerite trait is usually a waste. The reduction in your damage output from using <SpellLink id={SPELLS.MAIM.id} /> is only just made up for by the trait's bonus damage, so you would be better off with almost any other Feral trait.
+        </>
+      )
+        .icon(SPELLS.IRON_JAWS_TRAIT.icon)
+        .actual(`${actual} Iron Jaws traits.`)
+        .recommended(`2, 3 or none is recommended.`);
+    });
+
+    when(this.wastedProcsThreshold).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <>
+          You're not making full use of your <SpellLink id={SPELLS.IRON_JAWS_TRAIT.id} /> Azerite trait. When <SpellLink id={SPELLS.IRON_JAWS_TRAIT.id} /> procs you should replace your next finisher with <SpellLink id={SPELLS.MAIM.id} /> to make use of the significant bonus damage.
+        </>
+      )
+        .icon(SPELLS.IRON_JAWS_TRAIT.icon)
+        .actual(`${(actual * 100).toFixed(0)}% of Iron Jaws procs wasted.`)
+        .recommended(`<${(recommended * 100).toFixed(0)}% recommended.`);
+    });
+
+    when(this.unbuffedMaimThreshold).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <>
+          You're using <SpellLink id={SPELLS.MAIM.id} /> when it's not buffed by your <SpellLink id={SPELLS.IRON_JAWS_TRAIT.id} /> Azerite trait. Because of the cooldown on <SpellLink id={SPELLS.MAIM.id} /> this risks the ability not being available when <SpellLink id={SPELLS.IRON_JAWS_TRAIT.id} /> is active. If a fight requires you to regularly use <SpellLink id={SPELLS.MAIM.id} /> outside of your damage rotation, switching to different Azerite traits is likely to be beneficial.
+        </>
+      )
+        .icon(SPELLS.IRON_JAWS_TRAIT.icon)
+        .actual(`${actual.toFixed(1)} unbuffed Maims per minute.`)
+        .recommended(`<${recommended.toFixed(1)} recommended.`);
+    });
+
+    when(this.missingComboMaimThreshold).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <>
+          You're using <SpellLink id={SPELLS.MAIM.id} /> without full combo points. With your <SpellLink id={SPELLS.IRON_JAWS_TRAIT.id} /> Azerite trait <SpellLink id={SPELLS.MAIM.id} /> becomes an important damage source, and using it without full combo points significantly reduces its damage.
+        </>
+      )
+        .icon(SPELLS.IRON_JAWS_TRAIT.icon)
+        .actual(`${(actual * 100).toFixed(0)}% of Maims used without full combo points.`)
+        .recommended(`${(recommended * 100).toFixed(0)}% recommended.`);
+    });
+  }
+}
+
+export default IronJaws;


### PR DESCRIPTION
Adds support for the [Iron Jaws](https://www.wowhead.com/spell=276021/iron-jaws) azerite trait.

Using Iron Jaws requires a change in the player's ability priorities, so there's suggestions generated if they don't make the required changes.

Unusually the Iron Jaws trait is extremely weak if just one trait is active. It requires a change in rotation which is a damage loss without the trait, and having one trait barely makes up for that loss. So a suggestion is also generated if just one trait is detected.

![ironjaws01](https://user-images.githubusercontent.com/35700764/53386046-844cdf80-3978-11e9-95b5-3137d8b63b5a.png)
![ironjaws02](https://user-images.githubusercontent.com/35700764/53385407-33d48280-3976-11e9-93f5-6c31136eaa93.png)
![ironjaws03](https://user-images.githubusercontent.com/35700764/53385408-33d48280-3976-11e9-89df-719514ec3b4f.png)

Example log that uses Iron Jaws successfully:
`report/vWqBGXyhCr7LT931/13-Heroic+Grong+-+Kill+(3:17)/1-Berendain`
Example log that needs improvement with Iron Jaws:
`report/ZHwzYdhp6J1m9vWC/13-Normal+Grong+-+Kill+(4:02)/33-Lunardin`
