### PR TITLE
[BUG] Fix for duplicate Rogue trait

### DIFF
--- a/src/common/SPELLS/rogue.js
+++ b/src/common/SPELLS/rogue.js
@@ -228,7 +228,7 @@ export default {
     id: 248210,
     name: 'The First of the Dead',
     icon: 'inv_glove_cloth_raidwarlockmythic_q_01',
-  }, 
+  },
   FIND_WEAKNESS_BUFF: {
     id: 91021,
     name: 'Find Weakness',
@@ -410,7 +410,7 @@ export default {
     name: 'Toxic Blade',
     icon: 'inv_weapon_shortblade_62',
   },
-  
+
 
   //Outlaw
 
@@ -525,12 +525,5 @@ export default {
     id: 86392,
     name: 'Main Gauche',
     icon: 'inv_weapon_shortblade_15',
-  },
-
-  //Traits
-  ACE_UP_YOUR_SLEEVE: {
-    id: 279714,
-    name: 'Ace Up Your Sleeve',
-    icon: 'inv_weapon_rifle_01',
   },
 };


### PR DESCRIPTION
Recent Rogue PR introduced a duplicate SPELL object with Rogue Azerite trait Ace Up Your Sleeve which I didn't thought to check while reviewing and which is failing the site in development. This removes it (and leaves it in `azeritetraits/rogue.js` where it's supposed to be)