### PR TITLE
[Demonology] Legion Strike module

### DIFF
--- a/src/parser/warlock/demonology/CombatLogParser.js
+++ b/src/parser/warlock/demonology/CombatLogParser.js
@@ -8,7 +8,7 @@ import CooldownThroughputTracker from './modules/features/CooldownThroughputTrac
 import Felstorm from './modules/features/Felstorm';
 import Checklist from './modules/features/Checklist/Module';
 import SummonDemonicTyrant from './modules/features/SummonDemonicTyrant';
-
+import LegionStrike from './modules/features/LegionStrike';
 
 import SoulShardTracker from './modules/soulshards/SoulShardTracker';
 import SoulShardDetails from './modules/soulshards/SoulShardDetails';
@@ -59,6 +59,7 @@ class CombatLogParser extends CoreCombatLogParser {
     felstorm: Felstorm,
     checklist: Checklist,
     summonDemonicTyrant: SummonDemonicTyrant,
+    legionStrike: LegionStrike,
 
     // Core
     soulShardTracker: SoulShardTracker,
@@ -103,7 +104,7 @@ class CombatLogParser extends CoreCombatLogParser {
     supremeCommander: SupremeCommander,
     shadowsBite: ShadowsBite,
     balefulInvocation: BalefulInvocation,
-    
+
     // There's no throughput benefit from casting Arcane Torrent on cooldown
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }],
   };

--- a/src/parser/warlock/demonology/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/warlock/demonology/__snapshots__/CombatLogParser.test.js.snap
@@ -339,6 +339,78 @@ exports[`The Demonology Warlock Analyzer analyzers InnerDemons matches the stati
 
 exports[`The Demonology Warlock Analyzer analyzers InnerDemons matches the suggestions snapshot 1`] = `"module inactive"`;
 
+exports[`The Demonology Warlock Analyzer analyzers LegionStrike matches the statistic snapshot 1`] = `
+<div
+  className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
+  style={
+    Object {
+      "zIndex": 1,
+    }
+  }
+>
+  <div
+    className="panel statistic-box expandable "
+  >
+    <div
+      className="panel-body"
+    >
+      <div
+        className="flex"
+      >
+        <div
+          className="flex-sub statistic-icon"
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+        >
+          <a
+            href="http://wowhead.com/spell=30213"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+             
+            <img
+              alt=""
+              className="icon"
+              src="//render-us.worldofwarcraft.com/icons/56/inv_axe_09.jpg"
+            />
+          </a>
+        </div>
+        <div
+          className="flex-main"
+          style={
+            Object {
+              "paddingLeft": 16,
+              "position": "relative",
+            }
+          }
+        >
+          <div
+            className="slabel"
+          >
+            Legion Strike damage
+          </div>
+          <div
+            className="value"
+          >
+            <dfn
+              data-tip="987,365 damage"
+            >
+              17.09 % / 3,918 DPS
+            </dfn>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`The Demonology Warlock Analyzer analyzers LegionStrike matches the suggestions snapshot 1`] = `Array []`;
+
 exports[`The Demonology Warlock Analyzer analyzers NetherPortal matches the statistic snapshot 1`] = `"module has no statistic method"`;
 
 exports[`The Demonology Warlock Analyzer analyzers NetherPortal matches the suggestions snapshot 1`] = `Array []`;

--- a/src/parser/warlock/demonology/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/warlock/demonology/__snapshots__/CombatLogParser.test.js.snap
@@ -397,9 +397,9 @@ exports[`The Demonology Warlock Analyzer analyzers LegionStrike matches the stat
             className="value"
           >
             <dfn
-              data-tip="987,365 damage"
+              data-tip="758,292 damage"
             >
-              17.09 % / 3,918 DPS
+              13.12 % / 3,009 DPS
             </dfn>
           </div>
         </div>

--- a/src/parser/warlock/demonology/modules/features/LegionStrike.js
+++ b/src/parser/warlock/demonology/modules/features/LegionStrike.js
@@ -10,6 +10,8 @@ import { formatThousands } from 'common/format';
 
 import StatisticBox from 'interface/others/StatisticBox';
 
+import { isPermanentPet } from '../pets/helpers';
+
 class LegionStrike extends Analyzer {
   casts = 0;
   damage = 0;
@@ -20,12 +22,26 @@ class LegionStrike extends Analyzer {
     this.addEventListener(Events.damage.by(SELECTED_PLAYER_PET).spell(SPELLS.FELGUARD_LEGION_STRIKE), this.legionStrikeDamage);
   }
 
-  legionStrikeCast() {
-    this.casts += 1;
+  legionStrikeCast(event) {
+    // Grimoire: Felguard casts Legion Strike with the same spell ID, only count LS casts from the permanent pet
+    if (this._isPermanentPet(event.sourceID)) {
+      this.casts += 1;
+    }
   }
 
   legionStrikeDamage(event) {
-    this.damage += event.amount + (event.absorbed || 0);
+    if (this._isPermanentPet(event.sourceID)) {
+      this.damage += event.amount + (event.absorbed || 0);
+    }
+  }
+
+  _getPetGuid(id) {
+    return this.owner.playerPets.find(pet => pet.id === id).guid;
+  }
+
+  _isPermanentPet(id) {
+    const guid = this._getPetGuid(id);
+    return isPermanentPet(guid);
   }
 
   get suggestionThresholds() {

--- a/src/parser/warlock/demonology/modules/features/LegionStrike.js
+++ b/src/parser/warlock/demonology/modules/features/LegionStrike.js
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import Analyzer, { SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+
+import SPELLS from 'common/SPELLS';
+import SpellIcon from 'common/SpellIcon';
+import SpellLink from 'common/SpellLink';
+import { formatThousands } from 'common/format';
+
+import StatisticBox from 'interface/others/StatisticBox';
+
+class LegionStrike extends Analyzer {
+  casts = 0;
+  damage = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER_PET).spell(SPELLS.FELGUARD_LEGION_STRIKE), this.legionStrikeCast);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER_PET).spell(SPELLS.FELGUARD_LEGION_STRIKE), this.legionStrikeDamage);
+  }
+
+  legionStrikeCast() {
+    this.casts += 1;
+  }
+
+  legionStrikeDamage(event) {
+    this.damage += event.amount + (event.absorbed || 0);
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.casts,
+      isLessThan: {
+        minor: 1,
+        average: 0,
+        major: 0,
+      },
+      style: 'number',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestionThresholds)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<>Your Felguard didn't cast <SpellLink id={SPELLS.FELGUARD_LEGION_STRIKE.id} /> at all. Remember to turn on the auto-cast for this ability as it's a great portion of your total damage.</>)
+          .icon(SPELLS.FELGUARD_LEGION_STRIKE.icon)
+          .actual(`${actual} Legion Strike casts`)
+          .recommended(`> ${recommended} casts are recommended`);
+      });
+  }
+
+  statistic() {
+    return (
+      <StatisticBox
+        icon={<SpellIcon id={SPELLS.FELGUARD_LEGION_STRIKE.id} />}
+        value={this.owner.formatItemDamageDone(this.damage)}
+        label="Legion Strike damage"
+        tooltip={`${formatThousands(this.damage)} damage`}
+      />
+    );
+  }
+}
+
+export default LegionStrike;


### PR DESCRIPTION
It was brought upon my attention that some players have Felguard's Legion Strike auto-cast turned off, smh. This module warns them if the Felguard didn't cast any Legion Strike and also shows the damage done by it (only by the permanent pet, since you have control over that one, Grimoire: Felguard (from talent) casts it too, but it does it automatically and it's already counted as total damage done by the talent elsewhere).
![image](https://user-images.githubusercontent.com/5068584/53448325-6c786880-3a17-11e9-9249-bf2748be4e0c.png)
