### PR TITLE
[Core] Hide empty rules in the checklist

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Yajinni, Mamtooth, Zerotorescue, Putro, joshinator, Gebuz, ackwell, emallson, blazyb, Dambroda, Nalhan, Satyric, niseko, Khadaj, Fyruna, Matardarix, jos3p, Aelexe, Chizu, Hartra344, Hordehobbs, Dorixius } from 'CONTRIBUTORS';
+import { Yajinni, Mamtooth, Zerotorescue, Putro, joshinator, Gebuz, ackwell, emallson, blazyb, Dambroda, Nalhan, Satyric, niseko, Khadaj, Fyruna, Matardarix, jos3p, Aelexe, Chizu, Hartra344, Hordehobbs, Dorixius, Sharrq } from 'CONTRIBUTORS';
 import ItemLink from 'common/ItemLink';
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
@@ -7,6 +7,11 @@ import SpellLink from 'common/SpellLink';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  {
+    date: new Date('2019-03-2'),
+    changes: <>Hide checklist rules if all of the requirements beneath them are hidden/disabled.</>,
+    contributors: [Sharrq],
+  },
   {
     date: new Date('2019-02-24'),
     changes: <>Added composition details to raid composition screen showing role counts and avarage ilvl.</>,

--- a/src/parser/shared/modules/features/Checklist/Rule.js
+++ b/src/parser/shared/modules/features/Checklist/Rule.js
@@ -102,8 +102,11 @@ class Rule extends React.PureComponent {
 
     const performance = this.performance;
     const passed = this.passed;
+    const requirements = this.props.children;
+    console.log(this.props);
+    console.log(requirements);
 
-    if (!this.props.children || !this.props.children.some(this.checkEmptyRule)) {
+    if (!requirements || (Array.isArray(requirements) && !requirements.some(this.checkEmptyRule))) {
       return null;
     }
 

--- a/src/parser/shared/modules/features/Checklist/Rule.js
+++ b/src/parser/shared/modules/features/Checklist/Rule.js
@@ -103,8 +103,6 @@ class Rule extends React.PureComponent {
     const performance = this.performance;
     const passed = this.passed;
     const requirements = this.props.children;
-    console.log(this.props);
-    console.log(requirements);
 
     if (!requirements || (Array.isArray(requirements) && !requirements.some(this.checkEmptyRule))) {
       return null;

--- a/src/parser/shared/modules/features/Checklist/Rule.js
+++ b/src/parser/shared/modules/features/Checklist/Rule.js
@@ -70,6 +70,14 @@ class Rule extends React.PureComponent {
     }
   }
 
+  checkEmptyRule(child) {
+    if (child.props) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   setRequirementPerformance(performance) {
     // We don't have to worry about adding the same Requirement's performance multiple times here because it's only called in the Requirement's constructor, which is only called once.
     this.setState(state => ({
@@ -94,6 +102,10 @@ class Rule extends React.PureComponent {
 
     const performance = this.performance;
     const passed = this.passed;
+
+    if (!this.props.children || !this.props.children.some(this.checkEmptyRule)) {
+      return null;
+    }
 
     return (
       <RuleContext.Provider value={this.setRequirementPerformance}>


### PR DESCRIPTION
The old checklist would hide a rule if all of the requirements underneath it were hidden, but it doesnt look like the new checklist does that. This should fix that.

Before (Use GS and Use talents are empty)
![image](https://user-images.githubusercontent.com/1304554/53690330-eec19f00-3d2d-11e9-8f55-064043130bf7.png)

After
![image](https://user-images.githubusercontent.com/1304554/53690333-07ca5000-3d2e-11e9-8811-7b87384c400d.png)
