### PR TITLE
[warrior][prot] Add tracker for Shield Blocka and Last Stand overlap while using Bolster

### DIFF
--- a/src/parser/warrior/protection/CombatLogParser.js
+++ b/src/parser/warrior/protection/CombatLogParser.js
@@ -19,6 +19,7 @@ import Avatar from './modules/features/Avatar';
 import AngerManagement from './modules/talents/AngerManagement';
 import BoomingVoice from './modules/talents/BoomingVoice';
 import HeavyRepercussions from './modules/talents/HeavyRepercussions';
+import Bolster from './modules/talents/Bolster';
 import IntoTheFray from './modules/talents/IntoTheFray';
 import Vengeance from './modules/talents/Vengeance';
 import Punish from './modules/talents/Punish';
@@ -49,6 +50,7 @@ class CombatLogParser extends CoreCombatLogParser {
     boomingVoice: BoomingVoice,
     heavyRepercussions: HeavyRepercussions,
     intoTheFray: IntoTheFray,
+    bolster: Bolster,
     vengeance: Vengeance,
     punish: Punish,
     dragonRoar: DragonRoar,

--- a/src/parser/warrior/protection/modules/talents/Bolster.js
+++ b/src/parser/warrior/protection/modules/talents/Bolster.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import Analyzer from 'parser/core/Analyzer';
+import SPELLS from 'common/SPELLS';
+
+import TalentStatisticBox from 'interface/others/TalentStatisticBox';
+import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
+
+import { formatDuration } from 'common/format';
+
+const debug = false;
+
+class Bolster extends Analyzer {
+  badBlocks = 0;
+  wastedBlockTime = 0;
+  buffStartTime = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.BOLSTER_TALENT.id);
+  }
+
+  on_byPlayer_applybuff(event) {
+    const spellId = event.ability.guid;
+    if (!(spellId === SPELLS.LAST_STAND.id || spellId === SPELLS.SHIELD_BLOCK_BUFF.id)) {
+      return;
+    }
+     
+    if (this.selectedCombatant.hasBuff(SPELLS.SHIELD_BLOCK_BUFF.id) && this.selectedCombatant.hasBuff(SPELLS.LAST_STAND.id)) {
+      this.badBlocks++;
+      this.buffStartTime += event.timestamp;
+    }
+  }
+
+  on_byPlayer_removebuff(event) {
+    const spellId = event.ability.guid;
+    if (!(spellId === SPELLS.LAST_STAND.id || spellId === SPELLS.SHIELD_BLOCK_BUFF.id)) {
+      return;
+    }
+
+    if (this.buffStartTime === 0) {
+      return;
+    }
+
+    this.wastedBlockTime += event.timestamp - this.buffStartTime;
+    this.buffStartTime = 0;
+    debug && console.log(`Wasted Block Time: ${this.wastedBlockTime}`);
+  }
+
+  on_fightend() {
+    if (debug) {
+      console.log(`Overlapped Casts ${this.badBlocks}`);
+      console.log(`Total wasted block time ${formatDuration(this.wastedBlockTime / 1000)}`);
+    }
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.badBlocks,
+      isGreaterThan: {
+        minor: 0,
+        average: 0,
+        major: 0,
+      },
+      style: 'number',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestionThresholds)
+        .addSuggestion((suggest, actual, recommended) => {
+          return suggest('You should never overlap Shield Block and Last stand when you take the Bolster talent.')
+            .icon(SPELLS.BOLSTER_TALENT.icon)
+            .actual(`You overlapped shield block and last stand ${this.badBlocks} times.`)
+            .recommended(`0 is recommended`);
+        });
+  }
+
+  statistic() {
+    return (
+      <TalentStatisticBox
+        talent={SPELLS.BOLSTER_TALENT.id}
+        position={STATISTIC_ORDER.OPTIONAL(3)}
+        value={`${ this.badBlocks }`}
+        label="Last Stand and Shield Block overlapped"
+        tooltip={`${formatDuration(this.wastedBlockTime / 1000)} wasted block time.`}
+      />
+    );
+  }
+}
+
+export default Bolster;


### PR DESCRIPTION
Bolster and Shield Block both provide 100% block coverage, this tells you the number of times that you cast one of them while the other was active, and gives you the total time wasted with overlaps. 