### PR TITLE
[Feral] Gushing Lacerations azerite trait

### DIFF
--- a/src/common/SPELLS/bfa/azeritetraits/druid.js
+++ b/src/common/SPELLS/bfa/azeritetraits/druid.js
@@ -94,6 +94,16 @@ export default {
     name: 'Iron Jaws',
     icon: 'inv_misc_bone_09',
   },
+  GUSHING_LACERATIONS_TRAIT: {
+    id: 278509,
+    name: 'Gushing Lacerations',
+    icon: 'ability_ghoulfrenzy',
+  },
+  GUSHING_LACERATIONS_PROC: {
+    id: 279471,
+    name: 'Gushing Lacerations',
+    icon: 'ability_ghoulfrenzy',
+  },
   MASTERFUL_INSTINCTS: {
     id: 273344,
     name: 'Masterful Instincts',

--- a/src/parser/core/CASTS_THAT_ARENT_CASTS.js
+++ b/src/parser/core/CASTS_THAT_ARENT_CASTS.js
@@ -15,6 +15,7 @@ export default [
   SPELLS.DEFILED_AUGMENT_RUNE.id,
   SPELLS.UMBRAL_GLAIVE_STORM_TICK.id, // ticks of the Umbral Moonglaives trinket proc a cast event
   SPELLS.PRIMAL_FURY.id, // Feral Druid "extra CP on crit" proc causes a cast event
+  SPELLS.GUSHING_LACERATIONS_PROC.id, // Feral Druid azerite trait causes a cast event when it procs a combo point
   SPELLS.BARBED_SHOT_PET_BUFF.id, //The buff applied to BM Hunter pet when casting Barbed Shot
   SPELLS.BLOW_DARKMOON_WHISTLE.id, //Darkmoon Whistle active that some people macro into abilities
   SPELLS.DARKMOON_FIREWORK.id, //Darkmoon Firework toy

--- a/src/parser/druid/feral/CHANGELOG.js
+++ b/src/parser/druid/feral/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2019-03-06'),
+    changes: <>Added tracking of <SpellLink id={SPELLS.GUSHING_LACERATIONS_TRAIT.id} />.</>,
+    contributors: [Anatta336],
+  },
+  {
     date: new Date('2019-02-26'),
     changes: <>Added tracking of <SpellLink id={SPELLS.IRON_JAWS_TRAIT.id} />.</>,
     contributors: [Anatta336],

--- a/src/parser/druid/feral/CombatLogParser.js
+++ b/src/parser/druid/feral/CombatLogParser.js
@@ -42,6 +42,7 @@ import WildFleshrending from './modules/azeritetraits/WildFleshrending';
 import UntamedFerocity from './modules/azeritetraits/UntamedFerocity';
 import JungleFury from './modules/azeritetraits/JungleFury';
 import IronJaws from './modules/azeritetraits/IronJaws';
+import GushingLacerations from './modules/azeritetraits/GushingLacerations';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -95,6 +96,7 @@ class CombatLogParser extends CoreCombatLogParser {
     untamedFerocity: UntamedFerocity,
     jungleFury: JungleFury,
     ironJaws: IronJaws,
+    gushingLacerations: GushingLacerations,
   };
 }
 

--- a/src/parser/druid/feral/modules/Abilities.js
+++ b/src/parser/druid/feral/modules/Abilities.js
@@ -31,6 +31,7 @@ class Abilities extends CoreAbilities {
           static: 1000,
         },
         timelineSortIndex: 5,
+        primaryCoefficient: 0.125, // damage per tick
       },
       {
         spell: SPELLS.FEROCIOUS_BITE,

--- a/src/parser/druid/feral/modules/azeritetraits/GushingLacerations.js
+++ b/src/parser/druid/feral/modules/azeritetraits/GushingLacerations.js
@@ -1,0 +1,94 @@
+import React from 'react';
+
+import { formatNumber } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import { calculateAzeriteEffects } from 'common/stats';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import calculateBonusAzeriteDamage from 'parser/core/calculateBonusAzeriteDamage';
+import StatTracker from 'parser/shared/modules/StatTracker';
+import TraitStatisticBox, { STATISTIC_ORDER } from 'interface/others/TraitStatisticBox';
+import ItemDamageDone from 'interface/others/ItemDamageDone';
+
+import Abilities from '../Abilities';
+
+const debug = false;
+
+/**
+ * Gushing Lacerations
+ * Rip deals X additional periodic damage, and has a 6% chance to award a combo point each time it deals damage.
+ * The X additional damage is applied to every tick of the DoT. The 6% chance doesn't increase with multiple traits.
+ */
+class GushingLacerations extends Analyzer {
+  static dependencies = {
+    statTracker: StatTracker,
+    abilities: Abilities,
+  };
+
+  traitBonus = 0;
+  ripTickCoefficient = 0;
+  attackPower = 0;
+  totalDamage = 0;
+  comboProcs = 0;
+  wastedCombo = 0;
+
+  constructor(...args) {
+    super(...args);
+    if (!this.selectedCombatant.hasTrait(SPELLS.GUSHING_LACERATIONS_TRAIT.id)) {
+      this.active = false;
+      return;
+    }
+
+    this.traitBonus = this.selectedCombatant.traitsBySpellId[SPELLS.GUSHING_LACERATIONS_TRAIT.id]
+      .reduce((sum, rank) => sum + calculateAzeriteEffects(SPELLS.GUSHING_LACERATIONS_TRAIT.id, rank)[0], 0);
+    this.ripTickCoefficient = this.abilities.getAbility(SPELLS.RIP.id).primaryCoefficient;
+
+    debug && this.log(`trait bonus: ${this.traitBonus}`);
+    debug && this.log(`rip per tick coefficient: ${this.ripTickCoefficient}`);
+
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this._cast);
+    this.addEventListener(Events.energize.to(SELECTED_PLAYER).spell(SPELLS.GUSHING_LACERATIONS_PROC), this._comboProc);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.RIP), this._ripDamage);
+  }
+
+  _cast(event) {
+    if (!event.attackPower) {
+      return;
+    }
+    // listen for all cast events to get the most up to date possible measure of attackPower. StatTracker could in theory provide a more up to date value, but its accuracy is currently poorer than reading off attackPower from events.
+    this.attackPower = event.attackPower;
+  }
+
+  _comboProc(event) {
+    this.comboProcs += 1;
+    this.wastedCombo += event.waste || 0;
+    debug && this.log(`Gushing Lacerations gave a combo point, with waste: ${event.waste}`);
+  }
+
+  _ripDamage(event) {
+    const [ damageContribution ] = calculateBonusAzeriteDamage(event, [this.traitBonus], this.attackPower, this.ripTickCoefficient);
+    this.totalDamage += damageContribution;
+    debug && this.log(`Rip tick with extra ${damageContribution.toFixed(0)} damage`);
+  }
+
+  statistic() {
+    return (
+      <TraitStatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
+        trait={SPELLS.GUSHING_LACERATIONS_TRAIT.id}
+        value={(
+          <>
+            <ItemDamageDone amount={this.totalDamage} /><br />
+            {((this.comboProcs - this.wastedCombo) / (this.owner.fightDuration / 1000 / 60)).toFixed(1)} combo points per minute
+          </>
+        )}
+        tooltip={
+          `Provided a total of <b>${formatNumber(this.totalDamage)}</b> extra damage through your Rip.<br />
+          Triggered the generation an extra <b>${this.comboProcs}</b> combo point${this.comboProcs === 1 ? '' : 's'}, of which <b>${this.wastedCombo}</b> ${this.wastedCombo === 1 ? 'was' : 'were'} wasted.`
+        }
+      />
+    );
+  }
+}
+
+export default GushingLacerations;

--- a/src/parser/druid/feral/modules/azeritetraits/GushingLacerations.js
+++ b/src/parser/druid/feral/modules/azeritetraits/GushingLacerations.js
@@ -34,8 +34,9 @@ class GushingLacerations extends Analyzer {
 
   constructor(...args) {
     super(...args);
-    if (!this.selectedCombatant.hasTrait(SPELLS.GUSHING_LACERATIONS_TRAIT.id)) {
-      this.active = false;
+
+    this.active = this.selectedCombatant.hasTrait(SPELLS.GUSHING_LACERATIONS_TRAIT.id);
+    if (!this.active) {
       return;
     }
 
@@ -71,6 +72,10 @@ class GushingLacerations extends Analyzer {
     debug && this.log(`Rip tick with extra ${damageContribution.toFixed(0)} damage`);
   }
 
+  get effectiveComboPointsPerMinute() {
+    return (this.comboProcs - this.wastedCombo) / (this.owner.fightDuration / 1000 / 60);
+  }
+
   statistic() {
     return (
       <TraitStatisticBox
@@ -79,7 +84,7 @@ class GushingLacerations extends Analyzer {
         value={(
           <>
             <ItemDamageDone amount={this.totalDamage} /><br />
-            {((this.comboProcs - this.wastedCombo) / (this.owner.fightDuration / 1000 / 60)).toFixed(1)} combo points per minute
+            {this.effectiveComboPointsPerMinute.toFixed(1)} combo points per minute
           </>
         )}
         tooltip={


### PR DESCRIPTION
Adds tracking for the [Gushing Lacerations](https://www.wowhead.com/spell=278509/gushing-lacerations) azerite trait. Provides a simple statistic with damage increase and combo points generated (and wasted) from the trait.

![gushinglacerations01](https://user-images.githubusercontent.com/35700764/54008146-495b6080-415d-11e9-9f14-3d1535d90dc0.png)
