### PR TITLE
Tooltip fixes

### DIFF
--- a/src/parser/core/healingEfficiency/HealingEfficiencyBreakdown.js
+++ b/src/parser/core/healingEfficiency/HealingEfficiencyBreakdown.js
@@ -73,9 +73,9 @@ class HealingEfficiencyBreakdown extends React.Component {
           <>
             <th colSpan={2} className="text-center">Healing per mana spent</th>
             <th colSpan={2} className="text-center">
-              <dfn data-tip="This includes time spent waiting on the GCD">
+              <TooltipElement content="This includes time spent waiting on the GCD">
                 Healing per second spent casting
-              </dfn>
+              </TooltipElement>
             </th>
           </>
         )}
@@ -127,7 +127,7 @@ class HealingEfficiencyBreakdown extends React.Component {
     return (
       <>
         <th>
-          <TooltipElement content={`Total Casts (Number of targets hit)`}>Casts</TooltipElement>
+          <TooltipElement content="Total Casts (Number of targets hit)">Casts</TooltipElement>
         </th>
         <th>Mana Spent</th>
         {this.state.showHealing && (

--- a/src/parser/deathknight/blood/modules/features/MarrowrendUsage.js
+++ b/src/parser/deathknight/blood/modules/features/MarrowrendUsage.js
@@ -189,12 +189,6 @@ class MarrowrendUsage extends Analyzer {
   }
 
   statistic() {
-
-    let botDText = '';
-    if (this.hasBonesOfTheDamned) {
-      botDText = `${ this.wastedbonesOfTheDamnedProcs } casts with ${REFRESH_AT_STACKS_WITHOUT_BONES_OF_THE_DAMNED} stacks of ${SPELLS.BONE_SHIELD.name}, wasting potential ${SPELLS.BONES_OF_THE_DAMNED.name} procs.<br/>`;
-    }
-
     return (
       <StatisticBox
         icon={<SpellIcon id={SPELLS.MARROWREND.id} />}
@@ -203,7 +197,7 @@ class MarrowrendUsage extends Analyzer {
         tooltip={(
           <>
             {this.refreshMRCasts} casts to refresh Bone Shield, those do not count towards bad casts.<br />
-            {botDText}
+            {this.hasBonesOfTheDamned && <>{this.wastedbonesOfTheDamnedProcs} casts with {REFRESH_AT_STACKS_WITHOUT_BONES_OF_THE_DAMNED} stacks of {SPELLS.BONE_SHIELD.name}, wasting potential {SPELLS.BONES_OF_THE_DAMNED.name} procs.<br /></>}
             {this.badMRCasts} casts with more than {REFRESH_AT_STACKS_WITHOUT_BONES_OF_THE_DAMNED} stacks of Bone Shield wasting {this.bsStacksWasted} stacks.<br /><br />
 
             Avoid casting Marrowrend unless you have {this.refreshAtStacks} or less stacks or if Bone Shield has less than 6sec of its duration left.

--- a/src/parser/deathknight/blood/modules/spells/azeritetraits/BloodyRuneblade.js
+++ b/src/parser/deathknight/blood/modules/spells/azeritetraits/BloodyRuneblade.js
@@ -77,10 +77,12 @@ class BloddyRuneblade extends Analyzer{
             {this.bloodyRunebladeRPGain} RP Gained
           </>
         )}
-        tooltip={`
-          ${formatPercentage(this.buffUptime)}% uptime<br />
-          ${this.bloodyRunebladeProcsCounter} Procs
-        `}
+        tooltip={(
+          <>
+            {formatPercentage(this.buffUptime)}% uptime<br />
+            {this.bloodyRunebladeProcsCounter} Procs
+          </>
+        )}
       />
     );
   }

--- a/src/parser/demonhunter/havoc/modules/spells/DemonBite.js
+++ b/src/parser/demonhunter/havoc/modules/spells/DemonBite.js
@@ -63,16 +63,22 @@ class DemonBite extends Analyzer{
         icon={<SpellIcon id={SPELLS.DEMONS_BITE.id} />}
         label="Demon Bite"
         position={STATISTIC_ORDER.OPTIONAL(6)}
-        value={(<><span style={{ fontSize: '75%' }}>
-                {this.furyPerMin} fury per min <br />
-                {this.owner.formatItemDamageDone(this.damage)}
-              </span></>)}
-        tooltip={`
-          ${formatThousands(this.damage)} Total damage<br />
-          ${effectiveFuryGain} Effective fury gained<br />
-          ${this.furyGain} Total fury gained<br />
-          ${this.furyWaste} Fury wasted
-        `}
+        value={(
+          <>
+            <span style={{ fontSize: '75%' }}>
+              {this.furyPerMin} fury per min <br />
+              {this.owner.formatItemDamageDone(this.damage)}
+            </span>
+          </>
+        )}
+        tooltip={(
+          <>
+            {formatThousands(this.damage)} Total damage<br />
+            {effectiveFuryGain} Effective fury gained<br />
+            {this.furyGain} Total fury gained<br />
+            {this.furyWaste} Fury wasted
+          </>
+        )}
       />
     );
   }

--- a/src/parser/demonhunter/havoc/modules/spells/azeritetraits/FuriousGaze.js
+++ b/src/parser/demonhunter/havoc/modules/spells/azeritetraits/FuriousGaze.js
@@ -66,10 +66,12 @@ class FuriousGaze extends Analyzer{
         position={STATISTIC_ORDER.OPTIONAL()}
         trait={SPELLS.FURIOUS_GAZE.id}
         value={`${formatNumber(this.averageHaste)} average Haste`}
-        tooltip={`
-          ${formatPercentage(this.buffUptime)}% uptime<br />
-          ${this.furiousGazeProcsCounter} Procs
-        `}
+        tooltip={(
+          <>
+            {formatPercentage(this.buffUptime)}% uptime<br />
+            {this.furiousGazeProcsCounter} Procs
+          </>
+        )}
       />
     );
   }

--- a/src/parser/demonhunter/havoc/modules/talents/BlindFury.js
+++ b/src/parser/demonhunter/havoc/modules/talents/BlindFury.js
@@ -65,11 +65,14 @@ class BlindFury extends Analyzer{
         talent={SPELLS.BLIND_FURY_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(6)}
         value={`${this.furyPerMin} fury per min`}
-        tooltip={`Since this will always max out your fury on cast, wasted and totals do not matter. Only the amount effectively gained. <br />
-                  A bad cast is when you cast Eye Beam with more than 50 fury. At that point you are wasting enough fury gained for it to be a dps loss. <br /><br />
-                  ${this.gained} Effective fury gained<br />
-                  ${this.badCast} Bad casts
-        `}
+        tooltip={(
+          <>
+            Since this will always max out your fury on cast, wasted and totals do not matter. Only the amount effectively gained. <br />
+            A bad cast is when you cast Eye Beam with more than 50 fury. At that point you are wasting enough fury gained for it to be a dps loss. <br /><br />
+            {this.gained} Effective fury gained<br />
+            {this.badCast} Bad casts
+          </>
+        )}
       />
     );
   }

--- a/src/parser/demonhunter/havoc/modules/talents/DarkSlash.js
+++ b/src/parser/demonhunter/havoc/modules/talents/DarkSlash.js
@@ -51,9 +51,7 @@ class DarkSlash extends Analyzer {
         talent={SPELLS.DARK_SLASH_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(6)}
         value={this.owner.formatItemDamageDone(this.extraDamage)}
-        tooltip={`
-          ${formatThousands(this.extraDamage)} total damage
-        `}
+        tooltip={`${formatThousands(this.extraDamage)} total damage`}
       />
     );
   }

--- a/src/parser/demonhunter/havoc/modules/talents/DemonBlades.js
+++ b/src/parser/demonhunter/havoc/modules/talents/DemonBlades.js
@@ -66,16 +66,20 @@ class DemonBlades extends Analyzer{
       <TalentStatisticBox
         talent={SPELLS.DEMON_BLADES_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(6)}
-        value={(<>
-                {this.furyPerMin} fury per min <br />
-                {this.owner.formatItemDamageDone(this.damage)}
-              </>)}
-        tooltip={`
-          ${formatThousands(this.damage)} Total damage<br />
-          ${effectiveFuryGain} Effective fury gained<br />
-          ${this.furyGain} Total fury gained<br />
-          ${this.furyWaste} Fury wasted
-        `}
+        value={(
+          <>
+            {this.furyPerMin} fury per min <br />
+            {this.owner.formatItemDamageDone(this.damage)}
+          </>
+        )}
+        tooltip={(
+          <>
+            {formatThousands(this.damage)} Total damage<br />
+            {effectiveFuryGain} Effective fury gained<br />
+            {this.furyGain} Total fury gained<br />
+            {this.furyWaste} Fury wasted
+          </>
+        )}
       />
     );
   }

--- a/src/parser/demonhunter/havoc/modules/talents/DemonicAppetite.js
+++ b/src/parser/demonhunter/havoc/modules/talents/DemonicAppetite.js
@@ -61,11 +61,13 @@ class DemonicAppetite extends Analyzer{
         talent={SPELLS.DEMONIC_APPETITE_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(6)}
         value={`${this.furyPerMin} fury per min`}
-        tooltip={`
-          ${effectiveFuryGain} Effective fury gained<br />
-          ${this.furyGain} Total fury gained<br />
-          ${this.furyWaste} Fury wasted
-        `}
+        tooltip={(
+          <>
+            {effectiveFuryGain} Effective fury gained<br />
+            {this.furyGain} Total fury gained<br />
+            {this.furyWaste} Fury wasted
+          </>
+        )}
       />
     );
   }

--- a/src/parser/demonhunter/havoc/modules/talents/FelBarrage.js
+++ b/src/parser/demonhunter/havoc/modules/talents/FelBarrage.js
@@ -33,9 +33,7 @@ class FelBarrage extends Analyzer{
         talent={SPELLS.FEL_BARRAGE_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(6)}
         value={this.owner.formatItemDamageDone(this.damage)}
-        tooltip={`
-          ${formatThousands(this.damage)} Total damage
-        `}
+        tooltip={`${formatThousands(this.damage)} Total damage`}
       />
     );
   }

--- a/src/parser/demonhunter/havoc/modules/talents/FelMastery.js
+++ b/src/parser/demonhunter/havoc/modules/talents/FelMastery.js
@@ -34,9 +34,7 @@ class FelMastery extends Analyzer{
         talent={SPELLS.FEL_MASTERY_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(6)}
         value={`Extra damage done by Fel Rush ${this.owner.formatItemDamageDone(this.damage)}`}
-        tooltip={`
-          ${formatThousands(this.damage)} Total damage
-        `}
+        tooltip={`${formatThousands(this.damage)} Total damage`}
       />
     );
   }

--- a/src/parser/demonhunter/havoc/modules/talents/Felblade.js
+++ b/src/parser/demonhunter/havoc/modules/talents/Felblade.js
@@ -62,11 +62,13 @@ class Felblade extends Analyzer{
         talent={SPELLS.FELBLADE_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(6)}
         value={`${this.furyPerMin} fury per min`}
-        tooltip={`
-          ${effectiveFuryGain} Effective fury gained<br />
-          ${this.furyGain} Total fury gained<br />
-          ${this.furyWaste} Fury wasted
-        `}
+        tooltip={(
+          <>
+            {effectiveFuryGain} Effective fury gained<br />
+            {this.furyGain} Total fury gained<br />
+            {this.furyWaste} Fury wasted
+          </>
+        )}
       />
     );
   }

--- a/src/parser/demonhunter/havoc/modules/talents/ImmolationAura.js
+++ b/src/parser/demonhunter/havoc/modules/talents/ImmolationAura.js
@@ -69,16 +69,20 @@ class ImmolationAura extends Analyzer{
       <TalentStatisticBox
         talent={SPELLS.IMMOLATION_AURA_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(6)}
-        value={(<>
-                {this.furyPerMin} fury per min <br />
-                {this.owner.formatItemDamageDone(this.damage)}
-              </>)}
-        tooltip={`
-          ${formatThousands(this.damage)} Total damage<br />
-          ${effectiveFuryGain} Effective fury gained<br />
-          ${this.furyGain} Total fury gained<br />
-          ${this.furyWaste} Fury wasted
-        `}
+        value={(
+          <>
+            {this.furyPerMin} fury per min <br />
+            {this.owner.formatItemDamageDone(this.damage)}
+          </>
+        )}
+        tooltip={(
+          <>
+            {formatThousands(this.damage)} Total damage<br />
+            {effectiveFuryGain} Effective fury gained<br />
+            {this.furyGain} Total fury gained<br />
+            {this.furyWaste} Fury wasted
+          </>
+        )}
       />
     );
   }

--- a/src/parser/demonhunter/havoc/modules/talents/Nemesis.js
+++ b/src/parser/demonhunter/havoc/modules/talents/Nemesis.js
@@ -72,7 +72,7 @@ class Nemesis extends Analyzer {
         tooltip={(
           <>
             Nemesis Contributed {formatNumber(this.bonusDmg / this.owner.fightDuration * 1000)} DPS / {formatNumber(this.bonusDmg)} total damage.<br />
-            You had ${formatPercentage(this.nemesisUptimePercent)}% uptime.
+            You had {formatPercentage(this.nemesisUptimePercent)}% uptime.
             {this.everHadNemesisBuff && <><br /><br /> Due to technical limitations it is not currently possible to tell if your Nemesis buff type is the same as the boss type. This limitation may cause the damage contributed by Nemesis to appear higher than it otherwise would.</>}
           </>
         )}

--- a/src/parser/demonhunter/havoc/modules/talents/TrailofRuin.js
+++ b/src/parser/demonhunter/havoc/modules/talents/TrailofRuin.js
@@ -33,9 +33,7 @@ class TrailofRuin extends Analyzer{
         talent={SPELLS.TRAIL_OF_RUIN_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(6)}
         value={this.owner.formatItemDamageDone(this.damage)}
-        tooltip={`
-          ${formatThousands(this.damage)} Total damage
-        `}
+        tooltip={`${formatThousands(this.damage)} Total damage`}
       />
     );
   }

--- a/src/parser/demonhunter/vengeance/modules/talents/SpiritBombFrailtyDebuff.js
+++ b/src/parser/demonhunter/vengeance/modules/talents/SpiritBombFrailtyDebuff.js
@@ -56,7 +56,7 @@ class SpiritBombFrailtyDebuff extends Analyzer {
         position={STATISTIC_ORDER.CORE(5)}
         value={`${formatPercentage(this.uptime)}%`}
         label="Spirit Bomb debuff uptime"
-        tooltip={<>Total damage was ${formatThousands(spiritBombDamage)}.<br />Total uptime was ${formatDuration(spiritBombUptime / 1000)}.</>}
+        tooltip={<>Total damage was {formatThousands(spiritBombDamage)}.<br />Total uptime was {formatDuration(spiritBombUptime / 1000)}.</>}
       />
     );
   }

--- a/src/parser/druid/feral/modules/azeritetraits/GushingLacerations.js
+++ b/src/parser/druid/feral/modules/azeritetraits/GushingLacerations.js
@@ -87,10 +87,12 @@ class GushingLacerations extends Analyzer {
             {this.effectiveComboPointsPerMinute.toFixed(1)} combo points per minute
           </>
         )}
-        tooltip={
-          `Provided a total of <b>${formatNumber(this.totalDamage)}</b> extra damage through your Rip.<br />
-          Triggered the generation an extra <b>${this.comboProcs}</b> combo point${this.comboProcs === 1 ? '' : 's'}, of which <b>${this.wastedCombo}</b> ${this.wastedCombo === 1 ? 'was' : 'were'} wasted.`
-        }
+        tooltip={(
+          <>
+            Provided a total of <b>{formatNumber(this.totalDamage)}</b> extra damage through your Rip.<br />
+            Triggered the generation an extra <b>{this.comboProcs}</b> combo point{this.comboProcs === 1 ? '' : 's'}, of which <b>{this.wastedCombo}</b> {this.wastedCombo === 1 ? 'was' : 'were'} wasted.
+          </>
+        )}
       />
     );
   }

--- a/src/parser/druid/feral/modules/azeritetraits/IronJaws.js
+++ b/src/parser/druid/feral/modules/azeritetraits/IronJaws.js
@@ -19,9 +19,9 @@ const PROC_CHANCE_PER_COMBO = 0.08;
 /**
  * Iron Jaws
  * Ferocious Bite has a 8% chance per combo point to increase the damage of your next Maim by X per combo point.
- * 
+ *
  * Example log: /report/7ZjPwhdHXFb8r6ky/6-Normal+Grong+the+Revenant+-+Kill+(3:30)/17-Ashurabisha
- * 
+ *
  * Using Ferocious Bite has a chance to give the player the Iron Jaws buff, which lasts 30 seconds or until they next use Maim.
  * When Maim is used with the buff active the removebuff event appears before the cast event for Maim in the log.
  */
@@ -30,10 +30,10 @@ class IronJaws extends Analyzer {
     abilities: Abilities,
   };
 
-  traitBonus = 0; // trait bonus damage is per combo point on 
+  traitBonus = 0; // trait bonus damage is per combo point on
   coefficient = 0; // per combo point spent on Maim
   damage = 0;
-  
+
   // updated when Maim is cast, used when Maim damage is detected
   attackPower = 0;
   comboPoints = 0;
@@ -50,7 +50,7 @@ class IronJaws extends Analyzer {
       this.active = false;
       return;
     }
-    
+
     this.traitBonus = this.selectedCombatant.traitsBySpellId[SPELLS.IRON_JAWS_TRAIT.id]
       .reduce((sum, rank) => sum + calculateAzeriteEffects(SPELLS.IRON_JAWS_TRAIT.id, rank)[0], 0);
     this.coefficient = this.abilities.getAbility(SPELLS.MAIM.id).primaryCoefficient;
@@ -87,7 +87,7 @@ class IronJaws extends Analyzer {
     }
     this.buffedMaimCount += 1;
     debug && this.log('Buffed Maim');
-    
+
     this.comboPoints = this.getComboPoints(event);
     debug && this.log(`Maim used with ${this.comboPoints} combo points.`);
     if (this.comboPoints && this.comboPoints < 5) {
@@ -121,10 +121,14 @@ class IronJaws extends Analyzer {
         value={(
           <ItemDamageDone amount={this.damage} />
         )}
-        tooltip={`Increased your Maim damage by a total of <b>${formatNumber(this.damage)}</b>.<br />
-        From your use of Ferocious Bite you would expect on average to get <b>${this.expectedProcCount.toFixed(1)}</b> Iron Jaws procs. You actually got <b>${this.ironJawsProcCount}</b>.<br />
-        Of those <b>${this.ironJawsProcCount}</b> procs you made use of <b>${this.buffedMaimCount}</b> to buff Maim's damage.<br />
-        You cast Maim <b>${this.unbuffedMaimCount}</b> time${this.unbuffedMaimCount === 1 ? '' : 's'} without the Iron Jaws buff.`}
+        tooltip={(
+          <>
+            Increased your Maim damage by a total of <b>{formatNumber(this.damage)}</b>.<br />
+            From your use of Ferocious Bite you would expect on average to get <b>{this.expectedProcCount.toFixed(1)}</b> Iron Jaws procs. You actually got <b>{this.ironJawsProcCount}</b>.<br />
+            Of those <b>{this.ironJawsProcCount}</b> procs you made use of <b>{this.buffedMaimCount}</b> to buff Maim's damage.<br />
+            You cast Maim <b>{this.unbuffedMaimCount}</b> time{this.unbuffedMaimCount === 1 ? '' : 's'} without the Iron Jaws buff.
+          </>
+        )}
       />
     );
   }

--- a/src/parser/druid/feral/modules/azeritetraits/JungleFury.js
+++ b/src/parser/druid/feral/modules/azeritetraits/JungleFury.js
@@ -59,7 +59,6 @@ class JungleFury extends Analyzer {
   }
 
   statistic() {
-    const timeComment = this.hasPredator ? '' : `<br />The trait provided you with an extra <b>${(this.buffCount * DURATION_INCREASE / 1000).toFixed(0)}</b> seconds of Tiger's Fury over the course of this fight.`;
     return (
       <TraitStatisticBox
         position={STATISTIC_ORDER.OPTIONAL()}
@@ -70,7 +69,16 @@ class JungleFury extends Analyzer {
             {formatNumber(this.averageCritRating)} average Crit
           </>
         )}
-        tooltip={`Jungle Fury grants <b>${this.critRating}</b> critical strike rating while Tiger's Fury is active.${timeComment}`}
+        tooltip={(
+          <>
+            Jungle Fury grants <b>{this.critRating}</b> critical strike rating while Tiger's Fury is active.
+            {this.hasPredator && (
+              <>
+                <br />The trait provided you with an extra <b>{(this.buffCount * DURATION_INCREASE / 1000).toFixed(0)}</b> seconds of Tiger's Fury over the course of this fight.
+              </>
+            )}
+          </>
+        )}
       />
     );
   }

--- a/src/parser/druid/feral/modules/azeritetraits/UntamedFerocity.js
+++ b/src/parser/druid/feral/modules/azeritetraits/UntamedFerocity.js
@@ -99,7 +99,7 @@ class UntamedFerocity extends Analyzer {
       // only interested in direct damage from whitelisted spells which hit the target
       return;
     }
-    
+
     if (this.hasWildFleshrending && isAffectedByWildFleshrending(event, this.owner, this.enemies)) {
       // if the ability was given bonus damage from both Wild Fleshrending and Untamed Ferocity need to account for that to accurately attribute damage to each.
       const fleshrendingBonus = (event.ability.guid === SPELLS.SHRED.id) ? this.shredBonus : this.swipeBonus;
@@ -126,7 +126,7 @@ class UntamedFerocity extends Analyzer {
     const basePossibleCasts = Math.floor(this.owner.fightDuration / cooldownDuration) + 1;
     const improvedPossibleCasts = Math.floor((this.owner.fightDuration + this.cooldownReduction) / cooldownDuration) + 1;
     const extraCastsPossible = improvedPossibleCasts - basePossibleCasts;
-    const extraCastsComment = (improvedPossibleCasts === basePossibleCasts) ? `This wasn't enough to allow any extra casts during the fight, but may have given you more freedom in timing those casts.` : `This gave you the opportunity over the duration of the fight to use ${cooldownName} <b>${extraCastsPossible}</b> extra time${extraCastsPossible === 1 ? '' : 's'}.`;
+    const extraCastsComment = (improvedPossibleCasts === basePossibleCasts) ? `This wasn't enough to allow any extra casts during the fight, but may have given you more freedom in timing those casts.` : <>This gave you the opportunity over the duration of the fight to use {cooldownName} <b>{extraCastsPossible}</b> extra time{extraCastsPossible === 1 ? '' : 's'}.</>;
 
     return (
       <TraitStatisticBox
@@ -138,9 +138,13 @@ class UntamedFerocity extends Analyzer {
           {(this.cooldownReduction / 1000).toFixed(1)} seconds cooldown reduction
           </>
         )}
-        tooltip={`Increased the damage of your combo point generators by a total of <b>${formatNumber(this.untamedDamage)}</b><br />
-          The cooldown on your ${cooldownName} was reduced by a total of <b>${(this.cooldownReduction / 1000).toFixed(1)}</b> seconds.<br />
-          ${extraCastsComment}`}
+        tooltip={(
+          <>
+            Increased the damage of your combo point generators by a total of <b>{formatNumber(this.untamedDamage)}</b><br />
+            The cooldown on your {cooldownName} was reduced by a total of <b>{(this.cooldownReduction / 1000).toFixed(1)}</b> seconds.<br />
+            {extraCastsComment}
+          </>
+        )}
       />
     );
   }

--- a/src/parser/hunter/marksmanship/modules/talents/DoubleTap.js
+++ b/src/parser/hunter/marksmanship/modules/talents/DoubleTap.js
@@ -77,8 +77,8 @@ class DoubleTap extends Analyzer {
           <>
             You used Double Tap a total of {this.activations} times, and utilised {this.totalUsage} of them.
             <ul>
-              {this.aimedUsage > 0 && <li>Out of the total activations, you used ${this.aimedUsage} of them on Aimed Shots.</li>}
-              {this.RFUsage > 0 && <li>Out of the total activations, you used ${this.RFUsage} of them on Rapid Fires.</li>}
+              {this.aimedUsage > 0 && <li>Out of the total activations, you used {this.aimedUsage} of them on Aimed Shots.</li>}
+              {this.RFUsage > 0 && <li>Out of the total activations, you used {this.RFUsage} of them on Rapid Fires.</li>}
             </ul>
           </>
         )}

--- a/src/parser/hunter/survival/modules/talents/VipersVenom.js
+++ b/src/parser/hunter/survival/modules/talents/VipersVenom.js
@@ -126,17 +126,27 @@ class VipersVenom extends Analyzer {
   }
 
   statistic() {
-    let tooltip = `<ul><li>Average time between gaining Viper's Venom buff and using it was <b>${this.averageTimeBetweenBuffAndUsage}</b> seconds. <ul><li>Note: This accounts for the GCD after the ${this.spellKnown.name} proccing Viper's Venom. </li>`;
-    tooltip += this.wastedProcs > 0 ? `<li>You wasted ${this.wastedProcs} procs by gaining a new proc, whilst your current proc was still active.</li>` : ``;
-    tooltip += `</ul></li></ul>`;
     return (
       <TalentStatisticBox
         talent={SPELLS.VIPERS_VENOM_TALENT.id}
-        value={<>
-          {this.procs} / {this.wastedProcs + this.procs} procs used<br />
-          <ItemDamageDone amount={this.bonusDamage} />
-        </>}
-        tooltip={tooltip}
+        value={(
+          <>
+            {this.procs} / {this.wastedProcs + this.procs} procs used<br />
+            <ItemDamageDone amount={this.bonusDamage} />
+          </>
+        )}
+        tooltip={(
+          <>
+            <ul>
+              <li>Average time between gaining Viper's Venom buff and using it was <b>{this.averageTimeBetweenBuffAndUsage}</b> seconds.
+                <ul>
+                  <li>Note: This accounts for the GCD after the {this.spellKnown.name} proccing Viper's Venom. </li>
+                  {this.wastedProcs > 0 && <li>You wasted {this.wastedProcs} procs by gaining a new proc, whilst your current proc was still active.</li>}
+                </ul>
+              </li>
+            </ul>
+          </>
+        )}
       />
     );
   }

--- a/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
@@ -636,24 +636,24 @@ exports[`The Brewmaster Analyzer analyzers MitigationSheet matches the statistic
           <th
             className="text-right"
           >
-            <dfn
-              data-tip="The <em>average</em> stat value throughout a fight, including buffs and debuffs, is used here. The value is normalized so that Armor is always 1, and other stats are relative to this."
+            <b
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onTouchStart={[Function]}
             >
-              <b>
-                Per Rating (Normalized)
-              </b>
-            </dfn>
+              Per Rating (Normalized)
+            </b>
           </th>
           <th
             className="text-right"
           >
-            <dfn
-              data-tip="Amount of rating gained from the last 5 average ilvls of your gear. For secondary stats, this assumes the relative amounts of each stat don't change (as if you upgraded each piece by 5 ilvls without actually changing any of them)."
+            <b
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onTouchStart={[Function]}
             >
-              <b>
-                Rating — Last 5 ilvls
-              </b>
-            </dfn>
+              Rating — Last 5 ilvls
+            </b>
           </th>
           <th
             className="text-right"
@@ -944,7 +944,11 @@ exports[`The Brewmaster Analyzer analyzers MitigationSheet matches the statistic
             }
           >
             <dfn
-              data-tip="The amount of damage avoided by dodging may be reduced by purification. This is reflected in the range of values."
+              className=""
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onTouchStart={[Function]}
+              style={Object {}}
             >
               Dodge
             </dfn>
@@ -953,7 +957,11 @@ exports[`The Brewmaster Analyzer analyzers MitigationSheet matches the statistic
             className="text-right"
           >
             <dfn
-              data-tip="Not Yet Loaded"
+              className=""
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onTouchStart={[Function]}
+              style={Object {}}
             >
               NYL
             </dfn>
@@ -962,7 +970,11 @@ exports[`The Brewmaster Analyzer analyzers MitigationSheet matches the statistic
             className="text-right"
           >
             <dfn
-              data-tip="Not Yet Loaded"
+              className=""
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onTouchStart={[Function]}
+              style={Object {}}
             >
               NYL
             </dfn>
@@ -972,7 +984,11 @@ exports[`The Brewmaster Analyzer analyzers MitigationSheet matches the statistic
             className="text-right"
           >
             <dfn
-              data-tip="Not Yet Loaded"
+              className=""
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onTouchStart={[Function]}
+              style={Object {}}
             >
               NYL
             </dfn>
@@ -1123,7 +1139,11 @@ exports[`The Brewmaster Analyzer analyzers MitigationSheet matches the statistic
             }
           >
             <dfn
-              data-tip="The amount of damage avoided by dodging may be reduced by purification. This is reflected in the range of values."
+              className=""
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onTouchStart={[Function]}
+              style={Object {}}
             >
               Dodge
             </dfn>
@@ -1132,7 +1152,11 @@ exports[`The Brewmaster Analyzer analyzers MitigationSheet matches the statistic
             className="text-right"
           >
             <dfn
-              data-tip="Not Yet Loaded"
+              className=""
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onTouchStart={[Function]}
+              style={Object {}}
             >
               NYL
             </dfn>
@@ -1141,7 +1165,11 @@ exports[`The Brewmaster Analyzer analyzers MitigationSheet matches the statistic
             className="text-right"
           >
             <dfn
-              data-tip="Not Yet Loaded"
+              className=""
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onTouchStart={[Function]}
+              style={Object {}}
             >
               NYL
             </dfn>
@@ -1151,7 +1179,11 @@ exports[`The Brewmaster Analyzer analyzers MitigationSheet matches the statistic
             className="text-right"
           >
             <dfn
-              data-tip="Not Yet Loaded"
+              className=""
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onTouchStart={[Function]}
+              style={Object {}}
             >
               NYL
             </dfn>

--- a/src/parser/monk/brewmaster/modules/core/MasteryValue.js
+++ b/src/parser/monk/brewmaster/modules/core/MasteryValue.js
@@ -402,16 +402,18 @@ class MasteryValue extends Analyzer {
         icon={<SpellIcon id={SPELLS.MASTERY_ELUSIVE_BRAWLER.id} />}
         value={`${formatNumber(this.expectedMitigationPerSecond - this.noMasteryExpectedMitigationPerSecond)} DTPS`}
         label="Expected Mitigation by Mastery"
-        tooltip={this._loaded ? (<>
-          On average, you would dodge about <strong>{formatNumber(this.expectedMitigation)}</strong> damage on this fight. This value was increased by about <strong>{formatNumber(this.expectedMitigation - this.noMasteryExpectedMitigation)}</strong> due to Mastery.
-          You had an average expected dodge chance of <strong>{formatPercentage(this.expectedMeanDodge)}%</strong> and actually dodged about <strong>{formatNumber(this.estimatedActualMitigation)}</strong> damage with an overall rate of <strong>{formatPercentage(this.actualDodgeRate)}%</strong>.
-          This amounts to an expected reduction of <strong>{formatNumber((this.expectedMitigationPerSecond - this.noMasteryExpectedMitigationPerSecond) / this.averageMasteryRating)} DTPS per 1 Mastery</strong> <em>on this fight</em>.<br /><br />
+        tooltip={this._loaded ? (
+          <>
+            On average, you would dodge about <strong>{formatNumber(this.expectedMitigation)}</strong> damage on this fight. This value was increased by about <strong>{formatNumber(this.expectedMitigation - this.noMasteryExpectedMitigation)}</strong> due to Mastery.
+            You had an average expected dodge chance of <strong>{formatPercentage(this.expectedMeanDodge)}%</strong> and actually dodged about <strong>{formatNumber(this.estimatedActualMitigation)}</strong> damage with an overall rate of <strong>{formatPercentage(this.actualDodgeRate)}%</strong>.
+            This amounts to an expected reduction of <strong>{formatNumber((this.expectedMitigationPerSecond - this.noMasteryExpectedMitigationPerSecond) / this.averageMasteryRating)} DTPS per 1 Mastery</strong> <em>on this fight</em>.<br /><br />
 
-          <em>Technical Information:</em><br />
-          <strong>Estimated Actual Damage</strong> is calculated by calculating the average damage per hit of an ability, then multiplying that by the number of times you dodged each ability.<br />
-          <strong>Expected</strong> values are calculated by computing the expected number of mastery stacks each time you <em>could</em> dodge an ability.<br />
-          An ability is considered <strong>dodgeable</strong> if you dodged it at least once.
-          </>) : null}
+            <em>Technical Information:</em><br />
+            <strong>Estimated Actual Damage</strong> is calculated by calculating the average damage per hit of an ability, then multiplying that by the number of times you dodged each ability.<br />
+            <strong>Expected</strong> values are calculated by computing the expected number of mastery stacks each time you <em>could</em> dodge an ability.<br />
+            An ability is considered <strong>dodgeable</strong> if you dodged it at least once.
+          </>
+        ) : null}
         >
         <div style={{padding: '8px'}}>
           {this._loaded ? this.plot : null}

--- a/src/parser/monk/brewmaster/modules/features/MitigationSheet.js
+++ b/src/parser/monk/brewmaster/modules/features/MitigationSheet.js
@@ -18,6 +18,8 @@ import MasteryValue from '../core/MasteryValue';
 import Stagger from '../core/Stagger';
 import AgilityValue from './AgilityValue';
 import { diminish, lookupK } from '../constants/Mitigation';
+import { TooltipElement } from 'common/Tooltip';
+import Tooltip from 'common/Tooltip';
 
 function formatGain(gain) {
   if(typeof gain === 'number') {
@@ -278,7 +280,7 @@ export default class MitigationSheet extends Analyzer {
         gain: [
           { name: <><SpellLink id={SPELLS.GIFT_OF_THE_OX_1.id} /> Healing</>, amount: this.agiHealing },
           {
-            name: <dfn data-tip="The amount of damage avoided by dodging may be reduced by purification. This is reflected in the range of values.">Dodge</dfn>,
+            name: <TooltipElement content="The amount of damage avoided by dodging may be reduced by purification. This is reflected in the range of values.">Dodge</TooltipElement>,
             amount: {
               low: this.agiDamageDodged * (1 - this.stagger.pctPurified),
               high: this.agiDamageDodged,
@@ -297,7 +299,7 @@ export default class MitigationSheet extends Analyzer {
         gain: [
           { name: <><SpellLink id={SPELLS.GIFT_OF_THE_OX_1.id} /> Healing</>, amount: this.masteryHealing },
           {
-            name: <dfn data-tip="The amount of damage avoided by dodging may be reduced by purification. This is reflected in the range of values.">Dodge</dfn>,
+            name: <TooltipElement content="The amount of damage avoided by dodging may be reduced by purification. This is reflected in the range of values.">Dodge</TooltipElement>,
             amount:{
               low: this.masteryDamageMitigated * (1 - this.stagger.pctPurified),
               high: this.masteryDamageMitigated,
@@ -343,21 +345,21 @@ export default class MitigationSheet extends Analyzer {
         if(isLoaded !== false) {
           gainEl = formatGain(gain);
         } else {
-          gainEl = <dfn data-tip="Not Yet Loaded">NYL</dfn>;
+          gainEl = <TooltipElement content="Not Yet Loaded">NYL</TooltipElement>;
         }
 
         let perPointEl;
         if(isLoaded !== false) {
           perPointEl = formatWeight(gain, avg, this.normalizer, 1);
         } else {
-          perPointEl = <dfn data-tip="Not Yet Loaded">NYL</dfn>;
+          perPointEl = <TooltipElement content="Not Yet Loaded">NYL</TooltipElement>;
         }
 
         let valueEl;
         if(isLoaded !== false) {
           valueEl = formatWeight(gain, avg, this.normalizer, increment);
         } else {
-          valueEl = <dfn data-tip="Not Yet Loaded">NYL</dfn>;
+          valueEl = <TooltipElement content="Not Yet Loaded">NYL</TooltipElement>;
         }
 
         return (
@@ -384,7 +386,7 @@ export default class MitigationSheet extends Analyzer {
         <tr key={stat}>
           <td className={className}>
               {icon}{' '}
-              {tooltip ? <dfn data-tip={tooltip}>{name}</dfn> : name}
+              {tooltip ? <TooltipElement content={tooltip}>{name}</TooltipElement> : name}
           </td>
           <td className="text-right">
             <b>{formatGain(totalGain)}</b>
@@ -417,10 +419,10 @@ export default class MitigationSheet extends Analyzer {
             <b>Total</b>
           </th>
           <th className="text-right">
-            <dfn data-tip="The <em>average</em> stat value throughout a fight, including buffs and debuffs, is used here. The value is normalized so that Armor is always 1, and other stats are relative to this."><b>Per Rating (Normalized)</b></dfn>
+            <Tooltip content={<>The <em>average</em> stat value throughout a fight, including buffs and debuffs, is used here. The value is normalized so that Armor is always 1, and other stats are relative to this.</>}><b>Per Rating (Normalized)</b></Tooltip>
           </th>
           <th className="text-right">
-            <dfn data-tip="Amount of rating gained from the last 5 average ilvls of your gear. For secondary stats, this assumes the relative amounts of each stat don't change (as if you upgraded each piece by 5 ilvls without actually changing any of them)."><b>Rating &mdash; Last 5 ilvls</b></dfn>
+            <Tooltip content="Amount of rating gained from the last 5 average ilvls of your gear. For secondary stats, this assumes the relative amounts of each stat don't change (as if you upgraded each piece by 5 ilvls without actually changing any of them)."><b>Rating &mdash; Last 5 ilvls</b></Tooltip>
           </th>
           <th className="text-right">
             <b>Value &mdash; Last 5 ilvls</b>

--- a/src/parser/monk/brewmaster/modules/features/MitigationSheet.js
+++ b/src/parser/monk/brewmaster/modules/features/MitigationSheet.js
@@ -9,6 +9,7 @@ import STAT, { getClassNameColor, getIcon, getName } from 'parser/shared/modules
 import { formatNumber } from 'common/format';
 import Panel from 'interface/statistics/Panel';
 import SpellLink from 'common/SpellLink';
+import Tooltip, { TooltipElement } from 'common/Tooltip';
 import { calculatePrimaryStat, calculateSecondaryStatDefault } from 'common/stats';
 
 import { BASE_AGI } from '../../constants';
@@ -18,8 +19,6 @@ import MasteryValue from '../core/MasteryValue';
 import Stagger from '../core/Stagger';
 import AgilityValue from './AgilityValue';
 import { diminish, lookupK } from '../constants/Mitigation';
-import { TooltipElement } from 'common/Tooltip';
-import Tooltip from 'common/Tooltip';
 
 function formatGain(gain) {
   if(typeof gain === 'number') {

--- a/src/parser/monk/brewmaster/modules/spells/GiftOfTheOx.js
+++ b/src/parser/monk/brewmaster/modules/spells/GiftOfTheOx.js
@@ -101,7 +101,12 @@ export default class GiftOfTheOx extends Analyzer {
         icon={<SpellIcon id={GIFT_OF_THE_OX_SPELLS[0].id} />}
         label={"Gift of the Ox Healing"}
         value={`${formatNumber(this.totalHealing / (this.owner.fightDuration / 1000))} HPS`}
-        tooltip={`You generated ${formatNumber(this.orbsGenerated)} healing spheres and consumed ${formatNumber(this.orbsConsumed)} of them, healing for <b>${formatNumber(this.totalHealing)}</b>. ${formatNumber(this.expelHarmOrbsConsumed)} of these were consumed with Expel Harm over ${formatNumber(this.expelHarmCasts)} casts.`}
+        tooltip={(
+          <>
+            You generated {formatNumber(this.orbsGenerated)} healing spheres and consumed {formatNumber(this.orbsConsumed)} of them, healing for <b>{formatNumber(this.totalHealing)}</b>.
+            {formatNumber(this.expelHarmOrbsConsumed)} of these were consumed with Expel Harm over {formatNumber(this.expelHarmCasts)} casts.
+          </>
+        )}
       />
     );
   }

--- a/src/parser/monk/brewmaster/modules/spells/azeritetraits/StraightNoChaser.js
+++ b/src/parser/monk/brewmaster/modules/spells/azeritetraits/StraightNoChaser.js
@@ -122,7 +122,12 @@ export default class StraightNoChaser extends Analyzer {
           {formatNumber(this.avgArmor)} Armor Gained
           </>
         )}
-        tooltip={`There are no logged events for SNC's generated brew charges, so this is an <em>estimate</em> based on casts that occurred while your brews are on cooldown. <b>If you have low cast efficiency, this will be <em>underestimated!</em></b><br/><br/>Straight, No Chaser gave <b>${this.armor}</b> armor, and was up for ${formatPercentage(this.uptimePct)}% of the fight.`}
+        tooltip={(
+          <>
+            There are no logged events for SNC's generated brew charges, so this is an <em>estimate</em> based on casts that occurred while your brews are on cooldown. <b>If you have low cast efficiency, this will be <em>underestimated!</em></b><br /><br />
+            Straight, No Chaser gave <b>{this.armor}</b> armor, and was up for {formatPercentage(this.uptimePct)}% of the fight.
+          </>
+        )}
       >
         <div style={{padding: '8px'}}>
           {this.plot}

--- a/src/parser/monk/mistweaver/modules/spells/azeritetraits/SecretInfusion.js
+++ b/src/parser/monk/mistweaver/modules/spells/azeritetraits/SecretInfusion.js
@@ -73,7 +73,7 @@ class SecretInfusion extends Analyzer {
     this.healingMasteryBuff += this.selectedCombatant.hasBuff(SPELLS.SECRET_INFUSION_VERSATILITY.id) ? effectiveHealing : 0;
     this.healingVersatilityBuff += this.selectedCombatant.hasBuff(SPELLS.SECRET_INFUSION_MASTERY.id) ? effectiveHealing : 0;
   }
-  
+
   get buffUptimeCrit() {
     return this.selectedCombatant.getBuffUptime(SPELLS.SECRET_INFUSION_CRIT.id) / this.owner.fightDuration;
   }
@@ -86,7 +86,7 @@ class SecretInfusion extends Analyzer {
   get buffUptimeVersatility() {
     return this.selectedCombatant.getBuffUptime(SPELLS.SECRET_INFUSION_VERSATILITY.id) / this.owner.fightDuration;
   }
-  
+
   averageStatModifier(buffUptime) {
     return buffUptime * this.statModifier;
   }
@@ -107,10 +107,12 @@ class SecretInfusion extends Analyzer {
             {formatNumber(this.averageStatModifier(this.buffUptimeVersatility))} Average Versatility Rating<br />
           </>
         )}
-        tooltip={`
-          Grants <b>${this.statModifier}</b> additional stats when Thunder Focus Tea is used.<br/>
-          Buff Uptime: ${formatPercentage(this.totalBuffUptime)}%
-        `}
+        tooltip={(
+          <>
+            Grants <b>{this.statModifier}</b> additional stats when Thunder Focus Tea is used.<br />
+            Buff Uptime: {formatPercentage(this.totalBuffUptime)}%
+          </>
+        )}
       />
     );
   }

--- a/src/parser/monk/windwalker/modules/resources/EnergyCapTracker.js
+++ b/src/parser/monk/windwalker/modules/resources/EnergyCapTracker.js
@@ -52,8 +52,12 @@ class EnergyCapTracker extends RegenResourceCapTracker {
         icon={<Icon icon="spell_shadow_shadowworddominate" alt="Capped Energy" />}
         value={`${formatPercentage(this.cappedProportion)}%`}
         label="Time with capped energy"
-        tooltip={`Although it can be beneficial to wait and let your energy pool ready to be used at the right time, you should still avoid letting it reach the cap.<br/>
-        You spent <b>${formatPercentage(this.cappedProportion)}%</b> of the fight at capped energy, causing you to miss out on <b>${this.missedRegenPerMinute.toFixed(1)}</b> energy per minute from regeneration.`}
+        tooltip={(
+          <>
+            Although it can be beneficial to wait and let your energy pool ready to be used at the right time, you should still avoid letting it reach the cap.<br />
+            You spent <b>{formatPercentage(this.cappedProportion)}%</b> of the fight at capped energy, causing you to miss out on <b>{this.missedRegenPerMinute.toFixed(1)}</b> energy per minute from regeneration.
+          </>
+        )}
         footer={(
           <div className="statistic-box-bar">
             <Tooltip content={`Not at capped energy for ${formatDuration((this.owner.fightDuration - this.atCap) / 1000)}`}>

--- a/src/parser/monk/windwalker/modules/resources/EnergyCapTracker.js
+++ b/src/parser/monk/windwalker/modules/resources/EnergyCapTracker.js
@@ -5,6 +5,7 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { formatDuration, formatPercentage } from 'common/format';
 import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 import RegenResourceCapTracker from 'parser/shared/modules/RegenResourceCapTracker';
+import Tooltip from 'common/Tooltip';
 
 const BASE_ENERGY_REGEN = 10;
 const ASCENSION_REGEN_MULTIPLIER = 1.1;
@@ -55,20 +56,20 @@ class EnergyCapTracker extends RegenResourceCapTracker {
         You spent <b>${formatPercentage(this.cappedProportion)}%</b> of the fight at capped energy, causing you to miss out on <b>${this.missedRegenPerMinute.toFixed(1)}</b> energy per minute from regeneration.`}
         footer={(
           <div className="statistic-box-bar">
-            <div
-              className="stat-healing-bg"
-              style={{ width: `${(1 - this.cappedProportion) * 100}%` }}
-              data-tip={`Not at capped energy for ${formatDuration((this.owner.fightDuration - this.atCap) / 1000)}`}
-            >
-              <img src="/img/sword.png" alt="Uncapped Energy" />
-            </div>
+            <Tooltip content={`Not at capped energy for ${formatDuration((this.owner.fightDuration - this.atCap) / 1000)}`}>
+              <div
+                className="stat-healing-bg"
+                style={{ width: `${(1 - this.cappedProportion) * 100}%` }}
+              >
+                <img src="/img/sword.png" alt="Uncapped Energy" />
+              </div>
+            </Tooltip>
 
-            <div
-              className="remainder DeathKnight-bg"
-              data-tip={`At capped energy for ${formatDuration(this.atCap / 1000)}`}
-            >
-              <img src="/img/overhealing.png" alt="Capped Energy" />
-            </div>
+            <Tooltip content={`At capped energy for ${formatDuration(this.atCap / 1000)}`}>
+              <div className="remainder DeathKnight-bg" >
+                <img src="/img/overhealing.png" alt="Capped Energy" />
+              </div>
+            </Tooltip>
           </div>
         )}
         footerStyle={{ overflow: 'hidden' }}

--- a/src/parser/monk/windwalker/modules/spells/azeritetraits/FuryOfXuen.js
+++ b/src/parser/monk/windwalker/modules/spells/azeritetraits/FuryOfXuen.js
@@ -18,7 +18,7 @@ const furyOfXuenStats = traits => Object.values(traits).reduce((obj, rank) => {
 
 /**
  * Your Combo Strikes grant a stacking 2% chance for your next Fists of Fury to grant 768 Haste and invoke Xuen, The White Tiger for 8 sec.
- * 
+ *
  * The tooltip is rounded up and it actually gives 1.5% per stack
  */
 class FuryOfXuen extends Analyzer {
@@ -38,7 +38,7 @@ class FuryOfXuen extends Analyzer {
     }
     const {haste} = furyOfXuenStats(this.selectedCombatant.traitsBySpellId[SPELLS.FURY_OF_XUEN.id]);
     this.haste = haste;
-    
+
     this.statTracker.add(SPELLS.FURY_OF_XUEN_SUMMON.id, {
       haste,
     });
@@ -46,7 +46,7 @@ class FuryOfXuen extends Analyzer {
     this.addEventListener(Events.damage.by(SELECTED_PLAYER_PET), this.onPetDamage);
     this.addEventListener(Events.summon.by(SELECTED_PLAYER).spell(SPELLS.FURY_OF_XUEN_SUMMON), this.onPlayerSummon);
   }
-  
+
   onPlayerSummon(event) {
     const furyXuen = {targetID: event.targetID, targetInstance: event.targetInstance};
     this.furyXuens.push(furyXuen);
@@ -83,7 +83,7 @@ class FuryOfXuen extends Analyzer {
             {formatNumber(this.avgHaste)} Average Haste
           </>
         )}
-        tooltip={`You procced Fury of Xuen <b>${this.furyXuens.length}</b> times and had <b>${this.haste}</b> extra haste for <b>${formatPercentage(this.uptime)}%</b> of the fight`}
+        tooltip={<>You procced Fury of Xuen <b>{this.furyXuens.length}</b> times and had <b>{this.haste}</b> extra haste for <b>{formatPercentage(this.uptime)}%</b> of the fight</>}
       />
     );
   }

--- a/src/parser/paladin/holy/modules/talents/AuraOfSacrificeDamageReduction.js
+++ b/src/parser/paladin/holy/modules/talents/AuraOfSacrificeDamageReduction.js
@@ -162,21 +162,23 @@ class AuraOfSacrificeDamageReduction extends Analyzer {
     const totalDamageTransferred = passiveDamageTransferred + activeDamageTransferred;
     const totalDamageReduced = passiveDamageReduced + activeDamageReduced;
 
-    const tooltip = this.loaded ? (<>
-      <strong>Passive:</strong><br />
-      Damage transferred: {formatThousands(passiveDamageTransferred)} damage ({formatThousands(this.perSecond(passiveDamageTransferred))} DTPS)<br />
-      Effectively damage reduction: {formatThousands(passiveDamageReduced)} ({formatThousands(this.passiveDrps)} DRPS)<br />
-      <strong>Active (Aura Mastery):</strong><br />
-      Damage transferred: {formatThousands(activeDamageTransferred)} damage ({formatThousands(this.perSecond(activeDamageTransferred))} DTPS)<br />
-      Effective damage reduction: {formatThousands(activeDamageReduced)} ({formatThousands(this.activeDrps)} DRPS)<br />
-      <strong>Total:</strong><br />
-      Damage transferred: {formatThousands(totalDamageTransferred)} damage ({formatThousands(this.perSecond(totalDamageTransferred))} DTPS)<br />
-      Effective damage reduction: {formatThousands(totalDamageReduced)} damage ({formatThousands(this.perSecond(totalDamageReduced))} DRPS / {formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.totalDamageReduced))}% of total healing)<br /><br />
+    const tooltip = this.loaded ? (
+      <>
+        <strong>Passive:</strong><br />
+        Damage transferred: {formatThousands(passiveDamageTransferred)} damage ({formatThousands(this.perSecond(passiveDamageTransferred))} DTPS)<br />
+        Effectively damage reduction: {formatThousands(passiveDamageReduced)} ({formatThousands(this.passiveDrps)} DRPS)<br />
+        <strong>Active (Aura Mastery):</strong><br />
+        Damage transferred: {formatThousands(activeDamageTransferred)} damage ({formatThousands(this.perSecond(activeDamageTransferred))} DTPS)<br />
+        Effective damage reduction: {formatThousands(activeDamageReduced)} ({formatThousands(this.activeDrps)} DRPS)<br />
+        <strong>Total:</strong><br />
+        Damage transferred: {formatThousands(totalDamageTransferred)} damage ({formatThousands(this.perSecond(totalDamageTransferred))} DTPS)<br />
+        Effective damage reduction: {formatThousands(totalDamageReduced)} damage ({formatThousands(this.perSecond(totalDamageReduced))} DRPS / {formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.totalDamageReduced))}% of total healing)<br /><br />
 
-      This is an estimation. There are several ways to calculate the effective damage reduction of buffs, this uses the lowest method. At the same time the log's health tracking (and thus AM activity) isn't perfect, so there might be a few false positives when there's a lot of damage at the exact same moment.<br /><br />
+        This is an estimation. There are several ways to calculate the effective damage reduction of buffs, this uses the lowest method. At the same time the log's health tracking (and thus AM activity) isn't perfect, so there might be a few false positives when there's a lot of damage at the exact same moment.<br /><br />
 
-      Any damage transferred by the <strong>passive</strong> while immune (if applicable) is <em>not</em> included.
-    </>) : 'Click to load the required data.';
+        Any damage transferred by the <strong>passive</strong> while immune (if applicable) is <em>not</em> included.
+      </>
+    ) : 'Click to load the required data.';
     const footer = this.loaded && (
       <div className="statistic-box-bar">
         <Tooltip content={`You effectively reduced damage taken by a total of ${formatThousands(totalDamageReduced)} damage (${formatThousands(this.perSecond(totalDamageReduced))} DRPS).`}>

--- a/src/parser/paladin/retribution/modules/core/Judgment.js
+++ b/src/parser/paladin/retribution/modules/core/Judgment.js
@@ -114,18 +114,21 @@ class Judgment extends Analyzer {
   }
 
   statistic() {
-    const justicarsVengeanceText = this.selectedCombatant.hasTalent(SPELLS.JUSTICARS_VENGEANCE_TALENT.id) ? `<br>Justicars Vengeance consumptions: ${this.justicarsVengeanceConsumptions}` : ``;
+    const hasJV = this.selectedCombatant.hasTalent(SPELLS.JUSTICARS_VENGEANCE_TALENT.id);
     return (
       <StatisticBox
         position={STATISTIC_ORDER.CORE(6)}
         icon={<SpellIcon id={SPELLS.JUDGMENT_DEBUFF.id} />}
         value={`${formatPercentage(this.percentageJudgmentsConsumed)}%`}
         label="Judgments Consumed"
-        tooltip={`
-          Judgments Applied: ${this.judgmentsApplied}<br>
-          Templars Verdicts consumptions: ${this.templarsVerdictConsumptions}<br>
-          Divine Storm consumptions: ${this.divineStormConsumptions}
-          ${justicarsVengeanceText}`}
+        tooltip={(
+          <>
+            Judgments Applied: {this.judgmentsApplied}<br />
+            Templars Verdicts consumptions: {this.templarsVerdictConsumptions}<br />
+            Divine Storm consumptions: {this.divineStormConsumptions}
+            {hasJV && <><br />Justicars Vengeance consumptions: {this.justicarsVengeanceConsumptions}</>}
+          </>
+        )}
       />
     );
   }

--- a/src/parser/priest/holy/modules/core/EchoOfLight_Mastery.js
+++ b/src/parser/priest/holy/modules/core/EchoOfLight_Mastery.js
@@ -9,9 +9,8 @@ import HealingDone from 'parser/shared/modules/throughput/HealingDone';
 import Combatants from 'parser/shared/modules/Combatants';
 import ItemHealingDone from 'interface/others/ItemHealingDone';
 import { formatNumber, formatPercentage } from 'common/format';
-import { TooltipElement } from 'common/Tooltip';
+import Tooltip, { TooltipElement } from 'common/Tooltip';
 import { ABILITIES_THAT_TRIGGER_MASTERY } from '../../constants';
-import Tooltip from 'common/Tooltip';
 
 const DEBUG = false;
 const CUTOFF_PERCENT = .01;

--- a/src/parser/priest/holy/modules/core/EchoOfLight_Mastery.js
+++ b/src/parser/priest/holy/modules/core/EchoOfLight_Mastery.js
@@ -11,6 +11,7 @@ import ItemHealingDone from 'interface/others/ItemHealingDone';
 import { formatNumber, formatPercentage } from 'common/format';
 import { TooltipElement } from 'common/Tooltip';
 import { ABILITIES_THAT_TRIGGER_MASTERY } from '../../constants';
+import Tooltip from 'common/Tooltip';
 
 const DEBUG = false;
 const CUTOFF_PERCENT = .01;
@@ -241,11 +242,9 @@ class EchoOfLight_Mastery extends Analyzer {
         position={STATISTIC_ORDER.CORE(2)}
         icon={<SpellIcon id={SPELLS.ECHO_OF_LIGHT_MASTERY.id} />}
         value={(
-          <dfn
-            data-tip={`Total Healing: ${formatNumber(this.effectiveHealing)} (${formatPercentage(this.overHealingPercent)}% OH)`}
-          >
+          <Tooltip content={`Total Healing: ${formatNumber(this.effectiveHealing)} (${formatPercentage(this.overHealingPercent)}% OH)`}>
             <ItemHealingDone amount={this.effectiveHealing} />
-          </dfn>
+          </Tooltip>
         )}
         label={(
           <TooltipElement

--- a/src/parser/priest/holy/modules/spells/GuardianSpirit.js
+++ b/src/parser/priest/holy/modules/spells/GuardianSpirit.js
@@ -52,10 +52,12 @@ class GuardianSpirit extends Analyzer {
           <ItemHealingDone amount={this.totalHealingFromGSBuff} />
         )}
         label="Guardian Spirit Buff Contribution"
-        tooltip={
-          `You casted Guardian Spirit ${this.totalGSCasts} times, and it contributed ${formatNumber(this.totalHealingFromGSBuff)} healing. This includes healing from other healers.<br/>
-          NOTE: This metric uses an approximation to calculate contribution from the buff due to technical limitations.`
-        }
+        tooltip={(
+          <>
+            You casted Guardian Spirit {this.totalGSCasts} times, and it contributed {formatNumber(this.totalHealingFromGSBuff)} healing. This includes healing from other healers.<br />
+            NOTE: This metric uses an approximation to calculate contribution from the buff due to technical limitations.
+          </>
+        )}
       />
     );
   }

--- a/src/parser/rogue/subtlety/modules/core/NightbladeUptime.js
+++ b/src/parser/rogue/subtlety/modules/core/NightbladeUptime.js
@@ -31,7 +31,7 @@ class NightbladeUptime extends Analyzer {
 
   constructor(...args) {
     super(...args);
-    
+
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(ABILITIES_AFFECTED_BY_NIGHTBLADE), this.handleDamage);
   }
 
@@ -39,7 +39,7 @@ class NightbladeUptime extends Analyzer {
   totalDamage = 0;
   damageBonus = 0;
 
-  handleDamage(event) {    
+  handleDamage(event) {
     const target = this.enemies.getEntity(event);
     if (!target) {
       return;
@@ -62,7 +62,7 @@ class NightbladeUptime extends Analyzer {
   get uptimeThresholds() {
     return {
       actual: this.percentUptime,
-      isLessThan: { 
+      isLessThan: {
         minor: 0.98,
         average: 0.95,
         major: 0.9,
@@ -90,7 +90,7 @@ class NightbladeUptime extends Analyzer {
         icon={<SpellIcon id={SPELLS.NIGHTBLADE.id} />}
         value={`${formatPercentage(this.buffedPercent)}%`}
         label={`Damage Buffed by Nightblade`}
-        tooltip={`You buffed <b> ${formatPercentage(this.buffedPercent)}% </b> of your damage by Nightblade. <br/>The total increase was <b>${formatNumber(this.damageBonus/this.owner.fightDuration * 1000)} DPS </b>`}
+        tooltip={<>You buffed <b> {formatPercentage(this.buffedPercent)}% </b> of your damage by Nightblade. <br />The total increase was <b>{formatNumber(this.damageBonus/this.owner.fightDuration * 1000)} DPS </b></>}
       />
     );
   }

--- a/src/parser/shared/modules/items/bfa/raids/bod/IncandescentSliver.js
+++ b/src/parser/shared/modules/items/bfa/raids/bod/IncandescentSliver.js
@@ -75,9 +75,7 @@ class IncandescentSliver extends Analyzer {
           </>
         )}
         label="Incandescent Sliver"
-        tooltip={`The following players also had this trinket equipped: ${playersWithTrinket.map(player => {
-          return ` ${player._combatantInfo.name} (${player.spec.className})`;
-        })}.`}
+        tooltip={`The following players also had this trinket equipped: ${playersWithTrinket.map(player => ` ${player._combatantInfo.name} (${player.spec.className})`)}.`}
         category={STATISTIC_CATEGORY.ITEMS} />
     );
   }

--- a/src/parser/shared/modules/items/bfa/raids/bod/WardOfEnvelopment.js
+++ b/src/parser/shared/modules/items/bfa/raids/bod/WardOfEnvelopment.js
@@ -116,12 +116,12 @@ class WardOfEnvelopment extends Analyzer {
       item: ITEMS.WARD_OF_ENVELOPMENT,
       result: (
         <Tooltip content={(
-            <>
-              You activated your Ward of Envelopment <b>{this.uses}</b> of <b>{this.possibleUseCount}</b> possible time{this.uses === 1 ? '' : 's'} with an average of <b>{formatNumber(this.averageAbsorbPerCast)}</b> absorption per use.
-              It absorbed <b>{formatNumber(this.absorbUsed)}</b> out of <b>{formatNumber(this.totalAbsorb)}</b> damage and <b>{formatNumber(this.absorbWasted)} ({formatPercentage(this.wastedPercentage)}%)</b> was unused. <br />
-              On average you hit <b>{this.averageTargetsHit.toFixed(2)}</b> out of <b>5</b> allies and gained <b>{formatPercentage(this.gainedShieldValue)}%</b> extra absorption value per cast. <br />
-            </>
-          )}>
+          <>
+            You activated your Ward of Envelopment <b>{this.uses}</b> of <b>{this.possibleUseCount}</b> possible time{this.uses === 1 ? '' : 's'} with an average of <b>{formatNumber(this.averageAbsorbPerCast)}</b> absorption per use.
+            It absorbed <b>{formatNumber(this.absorbUsed)}</b> out of <b>{formatNumber(this.totalAbsorb)}</b> damage and <b>{formatNumber(this.absorbWasted)} ({formatPercentage(this.wastedPercentage)}%)</b> was unused. <br />
+            On average you hit <b>{this.averageTargetsHit.toFixed(2)}</b> out of <b>5</b> allies and gained <b>{formatPercentage(this.gainedShieldValue)}%</b> extra absorption value per cast. <br />
+          </>
+        )}>
           <ItemHealingDone amount={this.absorbUsed} />
         </Tooltip>
       ),

--- a/src/parser/shared/modules/items/bfa/raids/bod/WardOfEnvelopment.js
+++ b/src/parser/shared/modules/items/bfa/raids/bod/WardOfEnvelopment.js
@@ -8,13 +8,14 @@ import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';
 import ItemHealingDone from 'interface/others/ItemHealingDone';
 import Abilities from 'parser/core/modules/Abilities';
+import Tooltip from 'common/Tooltip';
 
 const MAX_ALLIES_HIT = 5;
 const ACTIVATION_COOLDOWN = 120; // seconds
 
 /**
  * Use: Envelop up to 5 allies in the targeted area in shared shields for 10 sec, preventing up to [x] damage taken by any of them. Damage prevented is increased when affecting multiple allies. (2 Min Cooldown)
- * 
+ *
  * Allies affected have the Enveloping Protection buff, lasts 10 seconds or until all damage is absorbed.
  * Hitting 1 ally gives the base value, each additional ally hit adds 7.5% of the base value. Maximum of 5 people hit for 30% extra on top of the base value.
  *
@@ -62,7 +63,7 @@ class WardOfEnvelopment extends Analyzer {
      * In order to accurately calculate the average players buffed you need this.
      */
     if (this.shieldsActive) {
-      this.shieldedNoOne += 1; 
+      this.shieldedNoOne += 1;
     }
     this.shieldsActive = true;
   }
@@ -114,13 +115,15 @@ class WardOfEnvelopment extends Analyzer {
     return {
       item: ITEMS.WARD_OF_ENVELOPMENT,
       result: (
-        <dfn data-tip={`
-          You activated your Ward of Envelopment <b>${this.uses}</b> of <b>${this.possibleUseCount}</b> possible time${this.uses === 1 ? '' : 's'} with an average of <b>${formatNumber(this.averageAbsorbPerCast)}</b> absorption per use.
-          It absorbed <b>${formatNumber(this.absorbUsed)}</b> out of <b>${formatNumber(this.totalAbsorb)}</b> damage and <b>${formatNumber(this.absorbWasted)} (${formatPercentage(this.wastedPercentage)}%)</b> was unused. <br />
-          On average you hit <b>${this.averageTargetsHit.toFixed(2)}</b> out of <b>5</b> allies and gained <b>${formatPercentage(this.gainedShieldValue)}%</b> extra absorption value per cast. <br />
-          `}>
+        <Tooltip content={(
+            <>
+              You activated your Ward of Envelopment <b>{this.uses}</b> of <b>{this.possibleUseCount}</b> possible time{this.uses === 1 ? '' : 's'} with an average of <b>{formatNumber(this.averageAbsorbPerCast)}</b> absorption per use.
+              It absorbed <b>{formatNumber(this.absorbUsed)}</b> out of <b>{formatNumber(this.totalAbsorb)}</b> damage and <b>{formatNumber(this.absorbWasted)} ({formatPercentage(this.wastedPercentage)}%)</b> was unused. <br />
+              On average you hit <b>{this.averageTargetsHit.toFixed(2)}</b> out of <b>5</b> allies and gained <b>{formatPercentage(this.gainedShieldValue)}%</b> extra absorption value per cast. <br />
+            </>
+          )}>
           <ItemHealingDone amount={this.absorbUsed} />
-        </dfn>
+        </Tooltip>
       ),
     };
   }
@@ -140,7 +143,7 @@ class WardOfEnvelopment extends Analyzer {
     when(this.suggestedShieldValue).addSuggestion((suggest, actual, recommended) => {
       return suggest(
         <>
-          Your usage of <ItemLink id={ITEMS.WARD_OF_ENVELOPMENT.id} /> can be improved. Try to place the it in an area with more allies to increase the overall abosorption it provides. 
+          Your usage of <ItemLink id={ITEMS.WARD_OF_ENVELOPMENT.id} /> can be improved. Try to place the it in an area with more allies to increase the overall abosorption it provides.
         </>
       )
         .icon(ITEMS.WARD_OF_ENVELOPMENT.icon)

--- a/src/parser/warlock/affliction/modules/azerite/PandemicInvocation.js
+++ b/src/parser/warlock/affliction/modules/azerite/PandemicInvocation.js
@@ -104,7 +104,7 @@ class PandemicInvocation extends Analyzer {
         tooltip={(
           <>
             Pandemic Invocation damage: {formatThousands(this.damage)}<br />
-            You gained {generated} Soul Shards and wasted ${wasted} Soul Shards with this trait, {max > 0 ? <>which is <strong>{formatPercentage(generated / max)}%</strong> of Shards you were most likely to get in this fight ({max} Shards).</> : 'while you were most likely to not get any Shards.'}
+            You gained {generated} Soul Shards and wasted {wasted} Soul Shards with this trait, {max > 0 ? <>which is <strong>{formatPercentage(generated / max)}%</strong> of Shards you were most likely to get in this fight ({max} Shards).</> : 'while you were most likely to not get any Shards.'}
           </>
         )}
       />

--- a/src/parser/warlock/affliction/modules/talents/Deathbolt.js
+++ b/src/parser/warlock/affliction/modules/talents/Deathbolt.js
@@ -135,13 +135,9 @@ class Deathbolt extends Analyzer {
     const avg = total / (deathbolt.casts || 1);
 
     const avgDotLengths = this.averageRemainingDotLengths;
-    let tooltip = 'Average remaining DoT durations on Deathbolt cast:<br /><br />';
-    Object.entries(avgDotLengths).forEach(([key, value]) => {
-      if (key === 'total') {
-        return;
-      }
-      tooltip += `${SPELLS[key].name}: ${(value / 1000).toFixed(2)} seconds<br />`;
-    });
+    const dotDurationsTooltip = Object.entries(avgDotLengths)
+      .filter(([key]) => key !== 'total')
+      .map(([key, value]) => <>{SPELLS[key].name}: {(value / 1000).toFixed(2)} seconds<br /></>);
 
     return (
       <>
@@ -157,7 +153,12 @@ class Deathbolt extends Analyzer {
         <StatisticListBoxItem
           title={<>Average DoT length on <SpellLink id={SPELLS.DEATHBOLT_TALENT.id} /> cast</>}
           value={`${(avgDotLengths.total / 1000).toFixed(2)} s`}
-          valueTooltip={tooltip}
+          valueTooltip={(
+            <>
+              Average remaining DoT durations on Deathbolt cast:<br /><br />
+              {dotDurationsTooltip}
+            </>
+          )}
         />
       </>
     );

--- a/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
+++ b/src/parser/warlock/demonology/modules/azerite/DemonicMeteor.js
@@ -77,7 +77,7 @@ class DemonicMeteor extends Analyzer {
         tooltip={(
           <>
             Estimated bonus Hand of Gul'dan damage: {formatThousands(this.damage)}<br />
-            You gained ${shardsGained} Shards with this trait, {max > 0 ? <>which is <strong>{formatPercentage(shardsGained / max)} %</strong> of Shards you were most likely to get in this fight ({max} Shards).</> : 'while you were most likely to not get any Shards.'}<br /><br />
+            You gained {shardsGained} Shards with this trait, {max > 0 ? <>which is <strong>{formatPercentage(shardsGained / max)} %</strong> of Shards you were most likely to get in this fight ({max} Shards).</> : 'while you were most likely to not get any Shards.'}<br /><br />
 
             The damage is an approximation using current Intellect values at given time, but because we might miss some Intellect buffs (e.g. trinkets, traits), the value of current Intellect might be a little incorrect.
           </>

--- a/src/parser/warlock/demonology/modules/talents/SoulConduit.js
+++ b/src/parser/warlock/demonology/modules/talents/SoulConduit.js
@@ -34,14 +34,14 @@ class SoulConduit extends Analyzer {
       <StatisticListBoxItem
         title={<>Shards generated with <SpellLink id={SPELLS.SOUL_CONDUIT_TALENT.id} /></>}
         value={generated}
-        valueTooltip={`You gained ${generated} Shards from this talent
-                       ${max > 0 ?
-                          `, which is <strong>${formatPercentage(generated / max)}%</strong> of Shards you were most likely to get in this fight (${max} Shards).`
-                        :
-                          ', while you were most likely to not get any Shards.'
-                        }
-                      <br />
-                      You would get ${extraHogs} extra 3 shard Hands of Gul'dan with shards from this talent.`}
+        valueTooltip={(
+          <>
+            You gained {generated} Shards from this talent
+            {max > 0 ? <>, which is <strong>{formatPercentage(generated / max)}%</strong> of Shards you were most likely to get in this fight ({max} Shards).</> : ', while you were most likely to not get any Shards.' }
+            <br />
+            You would get {extraHogs} extra 3 shard Hands of Gul'dan with shards from this talent.
+          </>
+        )}
       />
     );
   }

--- a/src/parser/warlock/destruction/modules/azerite/ChaosShards.js
+++ b/src/parser/warlock/destruction/modules/azerite/ChaosShards.js
@@ -68,7 +68,7 @@ class ChaosShards extends Analyzer {
         tooltip={(
           <>
             Estimated bonus Incinerate damage: {formatThousands(this.damage)}<br />
-            You gained {generated} Fragments and wasted ${wasted} Fragments with this trait, {max > 0 ? <>which is <strong>{formatPercentage(total / (max * 10))} %</strong> of Fragments you were most likely to get in this fight ({max * 10} Fragments).</> : 'while you were most likely to not get any Fragments.'}<br /><br />
+            You gained {generated} Fragments and wasted {wasted} Fragments with this trait, {max > 0 ? <>which is <strong>{formatPercentage(total / (max * 10))} %</strong> of Fragments you were most likely to get in this fight ({max * 10} Fragments).</> : 'while you were most likely to not get any Fragments.'}<br /><br />
 
             The damage is an approximation using current Intellect values at given time, but because we might miss some Intellect buffs (e.g. trinkets, traits), the value of current Intellect might be a little incorrect.
           </>

--- a/src/parser/warrior/arms/modules/spells/azeritetraits/LordOfWar.js
+++ b/src/parser/warrior/arms/modules/spells/azeritetraits/LordOfWar.js
@@ -50,7 +50,7 @@ class LordOfWar extends Analyzer {
         position={STATISTIC_ORDER.OPTIONAL()}
         trait={SPELLS.LORD_OF_WAR.id}
         value={`${this.owner.formatItemDamageDone(this.lordOfWarDamage)}`}
-        tooltip={`Damage done: <b>${formatNumber(this.lordOfWarDamage)}</b>`}
+        tooltip={<>Damage done: <b>{formatNumber(this.lordOfWarDamage)}</b></>}
       />
     );
   }

--- a/src/parser/warrior/fury/modules/azerite/ColdSteelHotBlood.js
+++ b/src/parser/warrior/fury/modules/azerite/ColdSteelHotBlood.js
@@ -16,7 +16,7 @@ class ColdSteelHotBlood extends Analyzer {
     super(...args);
 
     this.active = this.selectedCombatant.hasTrait(SPELLS.COLD_STEEL_HOT_BLOOD.id);
-    
+
     if(!this.active) {
       return;
     }
@@ -48,7 +48,7 @@ class ColdSteelHotBlood extends Analyzer {
       <TraitStatisticBox
         trait={SPELLS.COLD_STEEL_HOT_BLOOD.id}
         value={`${formatNumber(this.rageGained)} rage gained`}
-        tooltip={`Cold Steel, Hot Blood did <b>${formatThousands(this.totalDamage)} (${formatPercentage(this.damagePercentage)}%)</b> damage and <b>${formatThousands(this.totalHealing)}</b> healing (<b>${formatThousands(this.totalOverhealing)}</b> overhealing).`}
+        tooltip={<>Cold Steel, Hot Blood did <b>{formatThousands(this.totalDamage)} ({formatPercentage(this.damagePercentage)}%)</b> damage and <b>{formatThousands(this.totalHealing)}</b> healing (<b>{formatThousands(this.totalOverhealing)}</b> overhealing).</>}
       />
     );
   }

--- a/src/parser/warrior/fury/modules/azerite/UnbridledFerocity.js
+++ b/src/parser/warrior/fury/modules/azerite/UnbridledFerocity.js
@@ -26,7 +26,7 @@ class UnbridledFerocity extends Analyzer {
     super(...args);
 
     this.active = this.selectedCombatant.hasTrait(SPELLS.UNBRIDLED_FEROCITY.id);
-    
+
     if(!this.active) {
       return;
     }
@@ -80,7 +80,7 @@ class UnbridledFerocity extends Analyzer {
     if (this.recklessnessEvents.length === 0) {
       return;
     }
-    
+
     const lastIndex = this.recklessnessEvents.length - 1;
 
     if(!this.recklessnessEvents[lastIndex].end) {
@@ -114,7 +114,7 @@ class UnbridledFerocity extends Analyzer {
       <TraitStatisticBox
         trait={SPELLS.UNBRIDLED_FEROCITY.id}
         value={`${formatNumber(this.increasedRecklessnessDuration / 1000)}s Recklessness`}
-        tooltip={`Unbridled Ferocity did <b>${formatThousands(this.totalDamage)} (${formatPercentage(this.damagePercentage)}%)</b> damage.`}
+        tooltip={<>Unbridled Ferocity did <b>{formatThousands(this.totalDamage)} ({formatPercentage(this.damagePercentage)}%)</b> damage.</>}
       />
     );
   }


### PR DESCRIPTION
This PR should fix almost all tooltips that were left out unfixed with the onset of WoWA 3.0 due to change in tooltip library. It's a lot of files but simple changes mostly so it shouldn't be a big PITA to review

-------
EDIT: I figured I might explain a little what's happening so it could make it easier to review:

It's mainly replacing all (hopefully, but I'm almost sure I missed something) previous tooltips that would be broken/not displaying correctly with new tooltip library (`@wowanalyzer/react-tooltip-lite`). That includes:
1. Replacing elements (mostly `dfn`) with `data-tip` attributes with `<TooltipElement>` or `<Tooltip>`:
```javascript
<dfn data-tip="This includes time spent waiting on the GCD">
   Healing per second spent casting
</dfn>
```
into
```javascript
<TooltipElement content="This includes time spent waiting on the GCD">
   Healing per second spent casting
</TooltipElement>
```
2. Replacing interpolated strings that contained HTML markup into React Fragments:
```javascript
tooltip={`
  ${formatPercentage(this.buffUptime)}% uptime<br />
  ${this.bloodyRunebladeProcsCounter} Procs
`}
```
into
```javascript
tooltip={(
  <>
    {formatPercentage(this.buffUptime)}% uptime<br />
    {this.bloodyRunebladeProcsCounter} Procs
  </>
)}
```
3. Occasionally inlining tooltips that were extracted into variables:
```javascript
let tooltip = '';
if (condition) {
   tooltip = 'something';
}
//...
tooltip={(
  <>
    {tooltip}
  </>
)}
```
into
```javascript
tooltip={(
  <>
    {condition && <>something</>}
  </>
)}
```
4. Fixing forgotten $s in existing JSX tooltips:
```javascript
tooltip={<>Something: ${value}</>}
```
into
```javascript
tooltip={<>Something: {value}</>}
```