### PR TITLE
[Retribution] Updating Divine Purpose module

### DIFF
--- a/src/parser/paladin/retribution/CHANGELOG.js
+++ b/src/parser/paladin/retribution/CHANGELOG.js
@@ -6,6 +6,11 @@ import { Juko8, Skeletor } from 'CONTRIBUTORS';
 
 export default [
   {
+    date: new Date('2019-03-11'),
+    changes: <> Updated <SpellLink id={SPELLS.DIVINE_PURPOSE_TALENT_RETRIBUTION.id} icon /> module with tooltip displaying what spells the procs were used for and longest chain of procs. </>,
+    contributors: [Juko8], 
+  },
+  {
     date: new Date('2019-03-08'),
     changes: <> Updated <SpellLink id={SPELLS.CONSECRATION_TALENT.id} icon /> module to display average targets hit.</>,
     contributors: [Skeletor],
@@ -32,7 +37,7 @@ export default [
   },
   {
     date: new Date('2018-10-04'),
-    changes: <React.Fragment> Added Divine Right.</React.Fragment>,
+    changes: 'Added Divine Right.',
     contributors: [Juko8],
   },
   {

--- a/src/parser/paladin/retribution/CONFIG.js
+++ b/src/parser/paladin/retribution/CONFIG.js
@@ -23,7 +23,7 @@ export default {
 
   		If you want to learn more about Retribution Paladins make sure to also check out the <a href="https://discordapp.com/invite/hammerofwrath" target="_blank" rel="noopener noreferrer">Hammer of Wrath Paladin Discord</a>. The <kbd>#ret-faq</kbd> channel has some useful guides and the <kbd>#ret-general</kbd> has lots of memes if you're into that.<br /><br />
 
-      In-depth guides are available at <a href="https://www.retpaladin.xyz/ret-paladin-8-1-0-pve-guide/">RetPaldin.XYZ</a>, <a href="https://www.wowhead.com/retribution-paladin-guide">Wowhead</a>, and <a href="http://www.icy-veins.com/wow/retribution-paladin-pve-dps-guide">Icy Veins</a>. These guides also feature encounter specific tips to help you improve. Look for them in the navigation bar/panels.<br /><br />
+      In-depth guides are available at <a href="https://www.retpaladin.xyz/ret-paladin-8-1-0-pve-guide/">RetPaladin.XYZ</a>, <a href="https://www.wowhead.com/retribution-paladin-guide">Wowhead</a>, and <a href="http://www.icy-veins.com/wow/retribution-paladin-pve-dps-guide">Icy Veins</a>. These guides also feature encounter specific tips to help you improve. Look for them in the navigation bar/panels.<br /><br />
 
   		Feel free to message us on discord or on GitHub with any bugs or ideas for things we could work on!
   	</>

--- a/src/parser/paladin/retribution/modules/talents/DivinePurpose.js
+++ b/src/parser/paladin/retribution/modules/talents/DivinePurpose.js
@@ -75,20 +75,23 @@ class DivinePurpose extends Analyzer {
   }
 
   statistic() {
-    const chainProcText = this.largestProcChain > 1 ? `<br>Your longest chain of procs was ${this.largestProcChain}` : ``;
-    const justicarsVengeanceText = this.selectedCombatant.hasTalent(SPELLS.JUSTICARS_VENGEANCE_TALENT.id) ? `<br>Justicars Vengeance: ${this.justicarsVengeanceConsumptions}` : ``; 
+    const chainProcText = this.largestProcChain > 1 ? `<br />Your longest chain of procs was ${this.largestProcChain}` : ``;
+    const justicarsVengeanceText = this.selectedCombatant.hasTalent(SPELLS.JUSTICARS_VENGEANCE_TALENT.id) ? `<br />Justicars Vengeance: ${this.justicarsVengeanceConsumptions}` : ``; 
     return (
       <StatisticBox
         position={STATISTIC_ORDER.OPTIONAL(1)}
         icon={<SpellIcon id={SPELLS.DIVINE_PURPOSE_TALENT_RETRIBUTION.id} />}
         value={`${formatNumber(this.divinePurposeProcs)}`}
         label="Divine Purpose procs"
-        tooltip={`
-          Your Divine Purpose procs were used on:<br>
-          Templars Verdict: ${this.templarsVerdictConsumptions}<br>
-          Divine Storm: ${this.divineStormConsumptions}
-          ${justicarsVengeanceText}
-          ${chainProcText}`}
+        tooltip={(
+          <>
+          Your Divine Purpose procs were used on:<br />
+          Templars Verdict: {this.templarsVerdictConsumptions}<br />
+          Divine Storm: {this.divineStormConsumptions}
+          {justicarsVengeanceText}
+          {chainProcText}
+          </>
+          )}
       />
     );
   }

--- a/src/parser/paladin/retribution/modules/talents/DivinePurpose.js
+++ b/src/parser/paladin/retribution/modules/talents/DivinePurpose.js
@@ -75,8 +75,7 @@ class DivinePurpose extends Analyzer {
   }
 
   statistic() {
-    const chainProcText = this.largestProcChain > 1 ? `<br />Your longest chain of procs was ${this.largestProcChain}` : ``;
-    const justicarsVengeanceText = this.selectedCombatant.hasTalent(SPELLS.JUSTICARS_VENGEANCE_TALENT.id) ? `<br />Justicars Vengeance: ${this.justicarsVengeanceConsumptions}` : ``; 
+    const hasJV = this.selectedCombatant.hasTalent(SPELLS.JUSTICARS_VENGEANCE_TALENT.id);
     return (
       <StatisticBox
         position={STATISTIC_ORDER.OPTIONAL(1)}
@@ -88,10 +87,10 @@ class DivinePurpose extends Analyzer {
           Your Divine Purpose procs were used on:<br />
           Templars Verdict: {this.templarsVerdictConsumptions}<br />
           Divine Storm: {this.divineStormConsumptions}
-          {justicarsVengeanceText}
-          {chainProcText}
+          {hasJV && <><br />Justicars Vengeance: {this.justicarsVengeanceConsumptions}</>}
+          {this.largestProcChain > 1 && <><br />Your longest chain of procs was {this.largestProcChain}</>}
           </>
-          )}
+        )}
       />
     );
   }


### PR DESCRIPTION
- Adds breakdown of what spells were used to consume the divine purpose proc similar to tooltip of judgment module.
- Adds a line in the tooltip displaying the largest chain of procs, if there were any
![billede](https://user-images.githubusercontent.com/30317641/54137330-c157ae00-441d-11e9-9d61-2aed7dd3b4da.png)

Kinda resolves #1508, though i think Zero intended it to be for Holy's Divine Purpose