### PR TITLE
[Retribution Paladin] Indomitable Justice Icon Fix

### DIFF
--- a/src/common/SPELLS/bfa/azeritetraits/paladin.js
+++ b/src/common/SPELLS/bfa/azeritetraits/paladin.js
@@ -47,7 +47,7 @@ export default {
   INDOMITABLE_JUSTICE: {
     id: 275496,
     name: 'Indomitable Justice',
-    ïcon: 'spell_holy_righteousfury',
+    icon: 'spell_holy_righteousfury',
   },
   LIGHTS_DECREE: {
     id: 286229,


### PR DESCRIPTION
Changed from "ïcon" to "icon". Now properly shows on Indomitable Justice module and Character page.