### PR TITLE
[Mage] Updated Spec Compat to 8.1.5

### DIFF
--- a/src/parser/mage/arcane/CHANGELOG.js
+++ b/src/parser/mage/arcane/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2019-3-14'),
+    changes: 'Updated spec compatibility to 8.1.5.',
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2019-3-2'),
     changes: 'Added spec buffs to the timeline.',
     contributors: [Sharrq],

--- a/src/parser/mage/arcane/CONFIG.js
+++ b/src/parser/mage/arcane/CONFIG.js
@@ -10,7 +10,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Sharrq],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '8.1',
+  patchCompatibility: '8.1.5',
   // If set to  false`, the spec will show up as unsupported.
   isSupported: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.

--- a/src/parser/mage/fire/CHANGELOG.js
+++ b/src/parser/mage/fire/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2019-3-14'),
+    changes: 'Updated spec compatibility to 8.1.5.',
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2019-3-2'),
     changes: 'Added spec buffs to the timeline.',
     contributors: [Sharrq],

--- a/src/parser/mage/fire/CONFIG.js
+++ b/src/parser/mage/fire/CONFIG.js
@@ -10,7 +10,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Sharrq],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '8.1',
+  patchCompatibility: '8.1.5',
   // If set to  false`, the spec will show up as unsupported.
   isSupported: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.

--- a/src/parser/mage/frost/CHANGELOG.js
+++ b/src/parser/mage/frost/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2019-3-14'),
+    changes: 'Updated spec compatibility to 8.1.5.',
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2019-3-2'),
     changes: 'Added spec buffs to the timeline.',
     contributors: [Sharrq],

--- a/src/parser/mage/frost/CONFIG.js
+++ b/src/parser/mage/frost/CONFIG.js
@@ -12,7 +12,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Sharrq, Dambroda],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '8.1',
+  patchCompatibility: '8.1.5',
   // If set to  false`, the spec will show up as unsupported.
   isSupported: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more. If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.


### PR DESCRIPTION
There were no changes to anything for mages in 8.1.5, so updating compat to 8.1.5