### PR TITLE
[MW] Clean up

### DIFF
--- a/src/common/SPELLS/monk.js
+++ b/src/common/SPELLS/monk.js
@@ -63,6 +63,12 @@ export default {
     name: 'Trancendance: Transfer',
     icon: 'spell_shaman_spectraltransformation',
   },
+  LEG_SWEEP: {
+    id: 119381,
+    name: 'Leg Sweep',
+    icon: 'ability_monk_legsweep',
+  },
+
   // Mistweaver Monk Spells
   RISING_MIST_HEAL: {
     id: 274912,
@@ -214,170 +220,7 @@ export default {
     icon: 'ability_monk_fortifyingelixir',
   },
 
-  // Traits:
-  // Mistweaver Monk
-  DANCING_MISTS: {
-    id: 199573,
-    name: 'Dancing Mists',
-    icon: 'ability_monk_souldance',
-  },
-  TENDRILS_OF_REVIVAL: {
-    id: 238058,
-    name: 'Tendrils of Revival',
-    icon: 'spell_monk_revival',
-  },
-  WHISPERS_OF_SHAOHAO: {
-    id: 242400,
-    name: 'Whispers of Shaohao',
-    icon: 'inv_cloudserpent_egg_green',
-  },
-  WHISPERS_OF_SHAOHAO_TRAIT: {
-    id: 238130,
-    name: 'Whispers of Shaohao',
-    icon: 'inv_cloudserpent_egg_green',
-  },
-  MISTS_OF_SHEILUN: {
-    id: 199894,
-    name: 'The Mists of Sheilun',
-    icon: 'ability_monk_chiexplosion',
-  },
-  MISTS_OF_SHEILUN_TRAIT: {
-    id: 199887,
-    name: 'The Mists of Sheilun',
-    icon: 'ability_monk_chibrew',
-  },
-  MISTS_OF_SHEILUN_BUFF: {
-    id: 199888,
-    name: 'The Mists of Sheilun',
-    icon: 'ability_monk_chibrew',
-  },
-  CELESTIAL_BREATH: {
-    id: 199656,
-    name: 'Celestial Breath',
-    icon: 'ability_monk_chiexplosion',
-  },
-  CELESTIAL_BREATH_BUFF: {
-    id: 199641,
-    name: 'Celestial Breath',
-    icon: 'ability_monk_chiexplosion',
-  },
-  CELESTIAL_BREATH_TRAIT: {
-    id: 199640,
-    name: 'Celestial Breath',
-    icon: 'ability_monk_dragonkick',
-  },
-  BLESSINGS_OF_YULON: {
-    id: 199668,
-    name: 'Blessings of Yu\'lon',
-    icon: 'ability_monk_summonserpentstatue',
-  },
-  EFFUSIVE_MISTS: {
-    id: 238094,
-    name: 'Effusive Mists',
-    icon: 'ability_monk_effuse',
-  },
-  SPIRIT_TETHER: {
-    id: 199387,
-    name: 'Spirit Tether',
-    icon: 'monk_ability_transcendence',
-  },
-  COALESCING_MISTS: {
-    id: 199364,
-    name: 'Coalescing Mists',
-    icon: 'ability_monk_effuse',
-  },
-  SOOTHING_REMEDIES: {
-    id: 199377,
-    name: 'Soothing Remedies',
-    icon: 'ability_monk_soothingmists',
-  },
-  ESSENCE_OF_THE_MIST: {
-    id: 199485,
-    name: 'Essence of the Mist',
-    icon: 'ability_monk_essencefont',
-  },
-  WAY_OF_THE_MISTWEAVER: {
-    id: 199366,
-    name: 'Way of the Mistweaver',
-    icon: 'spell_monk_envelopingmist',
-  },
-  INFUSION_OF_LIFE: {
-    id: 199380,
-    name: 'Infusion of Life',
-    icon: 'ability_monk_vivify',
-  },
-  EXTENDED_HEALING: {
-    id: 199372,
-    name: 'Extended Healing',
-    icon: 'ability_monk_renewingmists',
-  },
-  PROTECTION_OF_SHAOHAO: {
-    id: 199367,
-    name: 'Protection of Shaohao',
-    icon: 'ability_monk_chicocoon',
-  },
-
-  // Legendary Effects
-  SHELTER_OF_RIN_HEAL: {
-    id: 235750,
-    name: 'Shelter of Rin',
-    icon: 'ability_monk_chiwave',
-  },
-  DOORWAY_TO_NOWHERE_SUMMON: {
-    id: 248293,
-    name: 'Doorway to Nowhere',
-    icon: 'inv_pet_cranegod',
-  },
-  OVYDS_WINTER_WRAP_BUFF: {
-    id: 217642,
-    name: 'Ovyd\'s Winter Wrap',
-    icon: 'ability_monk_souldance',
-  },
-
-  // Tier Set Bonus's
-  XUENS_BATTLEGEAR_4_PIECE_BUFF: {
-    id: 242258,
-    name: 'Monk T20 Mistweaver 4P Bonus',
-    icon: 'spell_monk_mistweaver_spec',
-  },
-  DANCE_OF_MISTS: {
-    id: 247891,
-    name: 'Dance of Mists',
-    icon: 'ability_monk_effuse',
-  },
-  XUENS_BATTLEGEAR_2_PIECE_BUFF: {
-    id: 242257,
-    name: 'Monk T20 Mistweaver 2P Bonus',
-    icon: 'spell_monk_mistweaver_spec',
-  },
-  SURGE_OF_MISTS: {
-    id: 246328,
-    name: 'Surge of Mists',
-    icon: 'spell_monk_mistweaver_spec',
-  },
-  CHIJIS_BATTLEGEAR_2_PIECE_BUFF: {
-    id: 251825,
-    name: 'Monk T21 Mistweaver 2P Bonus',
-    icon: 'ability_monk_surgingmist',
-  },
-  CHIJIS_BATTLEGEAR_4_PIECE_BUFF: {
-    id: 251826,
-    name: 'Monk T21 Mistweaver 4P Bonus',
-    icon: 'ability_monk_effuse',
-  },
-  CHI_BOLT: {
-    id: 253581,
-    name: 'Chi Bolt',
-    icon: 'ability_monk_effuse',
-  },
-  TRANQUIL_MIST: {
-    id: 253448,
-    name: 'Tranquil Mist',
-    icon: 'ability_monk_surgingmist',
-  },
-
   // Mistweaver Azerite Traits
-
   OVERFLOWING_MISTS_HEAL: {
     id: 273354,
     name: 'Overflowing Mists',

--- a/src/parser/monk/mistweaver/CHANGELOG.js
+++ b/src/parser/monk/mistweaver/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2019-03-15'),
+    changes: <>Added SI to buffs to buffs module to track  <SpellLink id={SPELLS.SECRET_INFUSION.id} />.</>,
+    contributors: [Abelito75],
+  },
+  {
     date: new Date('2019-03-11'),
     changes: 'Added new Buffs module to track and highlight Mistweaver specific buffs on the timeline',
     contributors: [Anomoly],

--- a/src/parser/monk/mistweaver/modules/features/Abilities.js
+++ b/src/parser/monk/mistweaver/modules/features/Abilities.js
@@ -100,7 +100,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.REVIVAL,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
-        cooldown: 180 - (combatant.traitsBySpellId[SPELLS.TENDRILS_OF_REVIVAL.id] || 0) * 10,
+        cooldown: 180,
         gcd: {
           base: 1500,
         },
@@ -194,7 +194,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.PARALYSIS,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-        cooldown: 15,
+        cooldown: 45,
         gcd: {
           base: 1500,
         },
@@ -204,6 +204,15 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 45,
         enabled: combatant.hasTalent(SPELLS.RING_OF_PEACE_TALENT.id),
+        gcd: {
+          base: 1500,
+        },
+      },
+
+      {
+        spell:SPELLS.LEG_SWEEP,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: combatant.hasTalent(SPELLS.TIGER_TAIL_SWEEP_TALENT.id) ? 50 : 60,
         gcd: {
           base: 1500,
         },

--- a/src/parser/monk/mistweaver/modules/features/Buffs.js
+++ b/src/parser/monk/mistweaver/modules/features/Buffs.js
@@ -51,6 +51,28 @@ class Buffs extends CoreBuffs {
         spellId: Object.keys(BLOODLUST_BUFFS).map(item => Number(item)),
         timelineHightlight: true,
       },
+
+      //SI buffs
+      {
+        spellId: SPELLS.SECRET_INFUSION_MASTERY.id,
+        timelineHightlight: true,
+        //TODO: check for azerite
+      },
+      {
+        spellId: SPELLS.SECRET_INFUSION_HASTE.id,
+        timelineHightlight: true,
+        //TODO: check for azerite
+      },
+      {
+        spellId: SPELLS.SECRET_INFUSION_CRIT.id,
+        timelineHightlight: true,
+        //TODO: check for azerite
+      },
+      {
+        spellId: SPELLS.SECRET_INFUSION_VERSATILITY.id,
+        timelineHightlight: true,
+        //TODO: check for azerite
+      },
     ];
   }
 }

--- a/src/parser/monk/mistweaver/modules/features/CooldownThroughputTracker.js
+++ b/src/parser/monk/mistweaver/modules/features/CooldownThroughputTracker.js
@@ -19,7 +19,6 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     ...CoreCooldownThroughputTracker.ignoredSpells,
     SPELLS.CHI_BURST_HEAL.id,
     SPELLS.REFRESHING_JADE_WIND_HEAL.id,
-    SPELLS.SPIRIT_TETHER.id,
     SPELLS.TRANSCENDENCE.id,
   ];
 }

--- a/src/parser/monk/mistweaver/modules/features/EvmVivCastRatio.js
+++ b/src/parser/monk/mistweaver/modules/features/EvmVivCastRatio.js
@@ -21,8 +21,8 @@ class CastRatio extends Analyzer {
   statistic() {
     const getAbility = spellId => this.abilityTracker.getAbility(spellId);
 
-    const evmCasts = getAbility(SPELLS.ENVELOPING_MIST.id).casts;
-    const vivCasts = getAbility(SPELLS.VIVIFY.id).casts;
+    const evmCasts = getAbility(SPELLS.ENVELOPING_MIST.id).casts || 0;
+    const vivCasts = getAbility(SPELLS.VIVIFY.id).casts || 0;
 
     return (
       <StatisticBox

--- a/src/parser/monk/mistweaver/modules/features/StatValuesSpellInfo.js
+++ b/src/parser/monk/mistweaver/modules/features/StatValuesSpellInfo.js
@@ -78,22 +78,6 @@ export default {
     mastery: true, // Procs Gusts
     vers: false,
   },
-  [SPELLS.WHISPERS_OF_SHAOHAO.id]: {
-    int: true,
-    crit: true,
-    hasteHpm: false,
-    hasteHpct: false,
-    mastery: false,
-    vers: true,
-  },
-  [SPELLS.CELESTIAL_BREATH.id]: {
-    int: true,
-    crit: true,
-    hasteHpm: false,
-    hasteHpct: false,
-    mastery: false,
-    vers: true,
-  },
   [SPELLS.SOOTHING_MIST.id]: {
     int: true,
     crit: true,
@@ -118,14 +102,6 @@ export default {
     mastery: false,
     vers: true,
   },
-  [SPELLS.BLESSINGS_OF_YULON.id]: {
-    int: true,
-    crit: true,
-    hasteHpm: false,
-    hasteHpct: false,
-    mastery: false,
-    vers: true,
-  },
   [SPELLS.LIFE_COCOON.id]: {
     int: true,
     crit: false,
@@ -142,15 +118,7 @@ export default {
     mastery: false,
     vers: true,
   },
-  [SPELLS.TRANQUIL_MIST.id]: { // T21 2P HoT
-    int: true,
-    crit: true,
-    hasteHpm: true,
-    hasteHpct: false,
-    mastery: false,
-    vers: true,
-  },
-  [SPELLS.CHI_BOLT.id]: { // T21 2P HoT
+  [SPELLS.RISING_MIST_HEAL.id]: { // t100 trait
     int: true,
     crit: true,
     hasteHpm: false,
@@ -158,15 +126,7 @@ export default {
     mastery: false,
     vers: true,
   },
-  [SPELLS.RISING_MIST_HEAL.id]: { // T21 2P HoT
-    int: true,
-    crit: true,
-    hasteHpm: false,
-    hasteHpct: false,
-    mastery: false,
-    vers: true,
-  },
-  [SPELLS.HEALING_ELIXIR_TALENT.id]: { // T21 2P HoT
+  [SPELLS.HEALING_ELIXIR_TALENT.id]: { // t75 trait
     int: true,
     crit: true,
     hasteHpm: false,

--- a/src/parser/monk/mistweaver/modules/spells/RenewingMist.js
+++ b/src/parser/monk/mistweaver/modules/spells/RenewingMist.js
@@ -18,7 +18,7 @@ class RenewingMist extends Analyzer {
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
-    if (SPELLS.VIVIFY.id !== spellId) {
+    if (SPELLS.RENEWING_MIST.id !== spellId) {
       return;
     }
     this.lastCastTarget = event.targetID;
@@ -41,7 +41,7 @@ class RenewingMist extends Analyzer {
 
   on_fightend() {
     if (debug) {
-      //if needed
+      console.log("gusts rem healing: ", this.gustsHealing);
     }
   }
 }

--- a/src/parser/monk/mistweaver/modules/spells/SoothingMist.js
+++ b/src/parser/monk/mistweaver/modules/spells/SoothingMist.js
@@ -38,6 +38,7 @@ class SoothingMist extends Analyzer {
       console.log(`SooM Ticks: ${this.soomTicks}`);
       console.log('SooM Perc Uptime: ', (this.soomTicks * 2 / this.owner.fightDuration * 1000));
       console.log('SooM Buff Update: ', this.selectedCombatant.getBuffUptime(SPELLS.SOOTHING_MIST.id), ' Percent: ', this.selectedCombatant.getBuffUptime(SPELLS.SOOTHING_MIST.id) / this.owner.fightDuration);
+      console.log('soom gusts', this.gustsHealing);
     }
   }
 


### PR DESCRIPTION
This was to look over all the mw related constants/code to find and **destroy** any legion cobwebs which more or less happened but I also added SI to the buff timeline. It adds an event every ~30 seconds for people with SI but seeing what you cast in it is completely worth it imo (i double checked with voulk and a few others on this and the general idea was that it was fine). This clean up has also uncovered a big bug with how we track gusts of mist as we are on counting too much (i have seen as high as 200k healing more) which I have an idea but thought it would be idea to pus this clean up up first. Change log only denotes the SI change due to those being the only ones that effect end user; I can updated that to include cleaning out cobwebs if you wish.