### PR TITLE
[MW] Mastery correction, small bugs

### DIFF
--- a/src/parser/monk/mistweaver/modules/features/Checklist/Component.js
+++ b/src/parser/monk/mistweaver/modules/features/Checklist/Component.js
@@ -94,7 +94,8 @@ class MistweaverMonkChecklist extends React.PureComponent {
 
           {combatant.hasTalent(SPELLS.MANA_TEA_TALENT.id) &&
           <Requirement name={(<><SpellLink id={SPELLS.MANA_TEA_TALENT.id} /> mana saved</>)} thresholds={thresholds.manaTea} />}
-          <Requirement name={(<><SpellLink id={SPELLS.MANA_TEA_TALENT.id} /> % overhealing</>)} thresholds={thresholds.manaTeaOverhealing} />
+          {combatant.hasTalent(SPELLS.MANA_TEA_TALENT.id) &&
+          <Requirement name={(<><SpellLink id={SPELLS.MANA_TEA_TALENT.id} /> % overhealing</>)} thresholds={thresholds.manaTeaOverhealing} />}
 
           {combatant.hasTalent(SPELLS.LIFECYCLES_TALENT.id) &&
           <Requirement name={(<><SpellLink id={SPELLS.LIFECYCLES_TALENT.id} /> mana saved</>)} thresholds={thresholds.lifecycles} />}

--- a/src/parser/monk/mistweaver/modules/spells/EnvelopingMists.js
+++ b/src/parser/monk/mistweaver/modules/spells/EnvelopingMists.js
@@ -25,16 +25,13 @@ class EnvelopingMists extends Analyzer {
 
   constructor(...args) {
     super(...args);
-    if (this.selectedCombatant.hasTalent(SPELLS.MIST_WRAP_TALENT.id)) {
-      this.EVM_HEALING_INCREASE=.4;
-    }
+    this.evmHealingIncrease = this.selectedCombatant.hasTalent(SPELLS.MIST_WRAP_TALENT.id) ? .4 : .3;
   }
 
-  EVM_HEALING_INCREASE = 0.3;//check for mistwrap
+  evmHealingIncrease = 0.3;//check for mistwrap
   healingIncrease = 0;
   gustsHealing = 0;
   lastCastTarget = null;
-  countForGusts = false;
   numberToCount = 0;
 
   on_byPlayer_cast(event) {
@@ -45,10 +42,10 @@ class EnvelopingMists extends Analyzer {
     }
     if (this.combatants.players[event.targetID]) {
       if (this.combatants.players[event.targetID].hasBuff(SPELLS.ESSENCE_FONT_BUFF.id, event.timestamp, 0, 0) === true) {
-        this.numberToCount++;
+        this.numberToCount += 1;
       }
     }
-    this.numberToCount++;
+    this.numberToCount += 1;
     this.lastCastTarget = event.targetID;
   }
 
@@ -64,12 +61,12 @@ class EnvelopingMists extends Analyzer {
     if ((spellId === SPELLS.GUSTS_OF_MISTS.id) && (this.lastCastTarget === event.targetID) && this.numberToCount >0) {
       this.gustProc += 1;
       this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
-      this.numberToCount--;
+      this.numberToCount -= 1;
     }
 
     if (this.combatants.players[targetId]) {
       if (this.combatants.players[targetId].hasBuff(SPELLS.ENVELOPING_MIST.id, event.timestamp, 0, 0) === true) {
-        this.healingIncrease += calculateEffectiveHealing(event, this.EVM_HEALING_INCREASE);
+        this.healingIncrease += calculateEffectiveHealing(event, this.evmHealingIncrease);
         debug && console.log('Event Details for Healing Increase: ' + event.ability.name);
       }
     }
@@ -78,7 +75,7 @@ class EnvelopingMists extends Analyzer {
   on_fightend() {
     if (debug) {
       console.log(`EvM Healing Contribution: ${this.healingIncrease}`);
-      console.log(`EnM Boost`, this.EVM_HEALING_INCREASE);
+      console.log(`EnM Boost`, this.evmHealingIncrease);
       console.log("gusts env healing: ", this.gustsHealing);
     }
   }

--- a/src/parser/monk/mistweaver/modules/spells/EnvelopingMists.js
+++ b/src/parser/monk/mistweaver/modules/spells/EnvelopingMists.js
@@ -23,16 +23,15 @@ class EnvelopingMists extends Analyzer {
     combatants: Combatants,
   };
 
-  constructor(...args) {
-    super(...args);
-    this.evmHealingIncrease = this.selectedCombatant.hasTalent(SPELLS.MIST_WRAP_TALENT.id) ? .4 : .3;
-  }
-
-  evmHealingIncrease = 0.3;//check for mistwrap
   healingIncrease = 0;
   gustsHealing = 0;
   lastCastTarget = null;
   numberToCount = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.evmHealingIncrease = this.selectedCombatant.hasTalent(SPELLS.MIST_WRAP_TALENT.id) ? .4 : .3;
+  }
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;

--- a/src/parser/monk/mistweaver/modules/spells/RenewingMist.js
+++ b/src/parser/monk/mistweaver/modules/spells/RenewingMist.js
@@ -29,11 +29,11 @@ class RenewingMist extends Analyzer {
     } 
     if (this.combatants.players[event.targetID]) {
       if (this.combatants.players[event.targetID].hasBuff(SPELLS.ESSENCE_FONT_BUFF.id, event.timestamp, 0, 0) === true) {
-        this.numberToCount++;
+        this.numberToCount += 1;
       }
     }
 
-    this.numberToCount++;
+    this.numberToCount += 1;
     this.lastCastTarget = event.targetID;
   }
 
@@ -42,7 +42,7 @@ class RenewingMist extends Analyzer {
 
     if ((spellId === SPELLS.GUSTS_OF_MISTS.id) && (this.lastCastTarget === event.targetID) && this.numberToCount>0) {
       this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
-      this.numberToCount--;
+      this.numberToCount -= 1;
     }
 
     if (spellId === SPELLS.RENEWING_MIST_HEAL.id) {

--- a/src/parser/monk/mistweaver/modules/spells/RenewingMist.js
+++ b/src/parser/monk/mistweaver/modules/spells/RenewingMist.js
@@ -2,11 +2,14 @@
 import SPELLS from 'common/SPELLS';
 
 import Analyzer from 'parser/core/Analyzer';
+import Combatants from 'parser/shared/modules/Combatants';
+
 
 const debug = false;
 
 class RenewingMist extends Analyzer {
   static dependencies = {
+    combatants: Combatants,
   };
 
   totalHealing = 0;
@@ -15,20 +18,31 @@ class RenewingMist extends Analyzer {
   gustsHealing = 0;
   lastCastTarget = null;
   healingHits = 0;
+  numberToCount = 0;
+
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
+
     if (SPELLS.RENEWING_MIST.id !== spellId) {
       return;
+    } 
+    if (this.combatants.players[event.targetID]) {
+      if (this.combatants.players[event.targetID].hasBuff(SPELLS.ESSENCE_FONT_BUFF.id, event.timestamp, 0, 0) === true) {
+        this.numberToCount++;
+      }
     }
+
+    this.numberToCount++;
     this.lastCastTarget = event.targetID;
   }
 
   on_byPlayer_heal(event) {
     const spellId = event.ability.guid;
 
-    if ((spellId === SPELLS.GUSTS_OF_MISTS.id) && (this.lastCastTarget === event.targetID)) {
+    if ((spellId === SPELLS.GUSTS_OF_MISTS.id) && (this.lastCastTarget === event.targetID) && this.numberToCount>0) {
       this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
+      this.numberToCount--;
     }
 
     if (spellId === SPELLS.RENEWING_MIST_HEAL.id) {

--- a/src/parser/monk/mistweaver/modules/spells/SoothingMist.js
+++ b/src/parser/monk/mistweaver/modules/spells/SoothingMist.js
@@ -27,7 +27,7 @@ class SoothingMist extends Analyzer {
       this.lastSoomTickTimestamp = event.timestamp;
     }
 
-    if (spellId === SPELLS.GUSTS_OF_MISTS.id && this.lastSoomTickTimestamp === event.timestamp) {
+    if (spellId === SPELLS.GUSTS_OF_MISTS.id && this.lastSoomTickTimestamp === event.timestamp && this.gustProc < Math.ceil(this.soomTicks/8)) {
       this.gustProc += 1;
       this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
     }

--- a/src/parser/monk/mistweaver/modules/spells/Vivify.js
+++ b/src/parser/monk/mistweaver/modules/spells/Vivify.js
@@ -97,8 +97,8 @@ class Vivify extends Analyzer {
           </>
         )
           .icon(SPELLS.VIVIFY.icon)
-          .actual(`${this.averageRemPerVivify} Unused Uplifting Trance procs`)
-          .recommended(`${recommended} wasted UT Buffs is recommended`);
+          .actual(`${this.averageRemPerVivify.toFixed(2)} Renewing Mists per Vivify`)
+          .recommended(`${recommended} Renewing Mists are recommended per Vivify`);
       });
   }
 

--- a/src/parser/monk/mistweaver/modules/spells/Vivify.js
+++ b/src/parser/monk/mistweaver/modules/spells/Vivify.js
@@ -27,20 +27,32 @@ class Vivify extends Analyzer {
   gustsHealing = 0;
   lastCastTarget = null;
   remDuringManaTea = 0;
+  countForGusts = false;
+  numberToCount = 0;
+
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
+
     if (SPELLS.VIVIFY.id !== spellId) {
       return;
     }
+    if (this.combatants.players[event.targetID]) {
+      if (this.combatants.players[event.targetID].hasBuff(SPELLS.ESSENCE_FONT_BUFF.id, event.timestamp, 0, 0) === true) {
+        this.numberToCount++;
+      }
+    }
+
+    this.numberToCount++;
     this.lastCastTarget = event.targetID;
   }
 
   on_byPlayer_heal(event) {
     const spellId = event.ability.guid;
 
-    if ((spellId === SPELLS.GUSTS_OF_MISTS.id) && (this.lastCastTarget === event.targetID)) {
+    if ((spellId === SPELLS.GUSTS_OF_MISTS.id) && (this.lastCastTarget === event.targetID) && this.numberToCount > 0) {
       this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
+      this.numberToCount--;
     }
 
     if ((spellId === SPELLS.VIVIFY.id) && (this.lastCastTarget !== event.targetID)) {

--- a/src/parser/monk/mistweaver/modules/spells/Vivify.js
+++ b/src/parser/monk/mistweaver/modules/spells/Vivify.js
@@ -27,7 +27,6 @@ class Vivify extends Analyzer {
   gustsHealing = 0;
   lastCastTarget = null;
   remDuringManaTea = 0;
-  countForGusts = false;
   numberToCount = 0;
 
 
@@ -39,11 +38,11 @@ class Vivify extends Analyzer {
     }
     if (this.combatants.players[event.targetID]) {
       if (this.combatants.players[event.targetID].hasBuff(SPELLS.ESSENCE_FONT_BUFF.id, event.timestamp, 0, 0) === true) {
-        this.numberToCount++;
+        this.numberToCount += 1;
       }
     }
 
-    this.numberToCount++;
+    this.numberToCount += 1;
     this.lastCastTarget = event.targetID;
   }
 
@@ -52,7 +51,7 @@ class Vivify extends Analyzer {
 
     if ((spellId === SPELLS.GUSTS_OF_MISTS.id) && (this.lastCastTarget === event.targetID) && this.numberToCount > 0) {
       this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
-      this.numberToCount--;
+      this.numberToCount -= 1;
     }
 
     if ((spellId === SPELLS.VIVIFY.id) && (this.lastCastTarget !== event.targetID)) {
@@ -74,9 +73,9 @@ class Vivify extends Analyzer {
     return {
       actual: this.averageRemPerVivify,
       isLessThan: {
-        minor: 1.5,
-        average: 1,
-        major: 0.5,
+        minor: 1.75,
+        average: 1.25,
+        major: 0.75,
       },
       style: 'number',
     };

--- a/src/parser/monk/mistweaver/modules/talents/JadeSerpentStatue.js
+++ b/src/parser/monk/mistweaver/modules/talents/JadeSerpentStatue.js
@@ -113,7 +113,7 @@ class JadeSerpentStatue extends Analyzer {
           You selected <SpellLink id={SPELLS.SUMMON_JADE_SERPENT_STATUE_TALENT.id} /> as your talent. To gain the most value out of this talent you should have it casting on someone as often as possible. The priority should be tanks or any raid member taking heavy damage, such as from a specific DOT or boss mechanic.
         </>
       )
-        .icon(SPELLS.MANA_TEA_TALENT.icon)
+        .icon(SPELLS.SUMMON_JADE_SERPENT_STATUE_TALENT.icon)
         .actual(`${formatPercentage(actual)}% uptime`)
         .recommended(`${formatPercentage(recommended)}% uptime is recommended`);
     });

--- a/src/parser/monk/mistweaver/modules/talents/ManaTea.js
+++ b/src/parser/monk/mistweaver/modules/talents/ManaTea.js
@@ -36,7 +36,6 @@ class ManaTea extends Analyzer {
   nonManaCasts = 0;
   castsUnderManaTea = 0;
 
-  hasLifeCycles = false;
   casted = false;
 
   effectiveHealing = 0;
@@ -45,9 +44,6 @@ class ManaTea extends Analyzer {
   constructor(...args) {
     super(...args);
     this.active = this.selectedCombatant.hasTalent(SPELLS.MANA_TEA_TALENT.id);
-    if (this.selectedCombatant.hasTalent(SPELLS.LIFECYCLES_TALENT.id)) {
-      this.hasLifeCycles = true;
-    }
   }
 
   on_toPlayer_applybuff(event) {


### PR DESCRIPTION
Should have broken up this into more pull requests most likely but shrug. Fixed mastery within 2ish% some fights its lower some its higher. Its a dirty fix but it works. The issue is that we can miss some casts and count some twice but we are always count the right number now. aka no more 2 env -> 8 gusts hit from env. It will always be 2 env -> 2-4 gusts procs depending on ef buff. This is a quick fix that works and could be slightly improved if you have a big brain idea. 

Most of the other things in here are removing old dead code/icon changes/tooltip changes

Didn't put anything in the change log as imo we don't want people to see we had issues before