### PR TITLE
[Core] Replace item() with statistic() (Part 2)

### DIFF
--- a/src/parser/shared/modules/items/bfa/FirstMatesSpyglass.js
+++ b/src/parser/shared/modules/items/bfa/FirstMatesSpyglass.js
@@ -5,12 +5,17 @@ import ITEMS from 'common/ITEMS/index';
 import Analyzer from 'parser/core/Analyzer';
 import HIT_TYPES from 'game/HIT_TYPES';
 import Abilities from 'parser/core/modules/Abilities';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
+import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
+import UptimeIcon from 'interface/icons/Uptime';
+import CritIcon from 'interface/icons/CriticalStrike';
 import { formatPercentage } from 'common/format';
-import { TooltipElement } from 'common/Tooltip';
 
 /**
  * First Mate's Spyglass -
  * Use: Increase your Critical Strike by 768 for 15 sec. (2 Min Cooldown)
+ * 
+ * Test Log: https://www.warcraftlogs.com/reports/Q273n64m9JGNLqBh#fight=4&type=damage-done&source=17
  */
 class FirstMatesSpyglass extends Analyzer {
   static dependencies = {
@@ -74,15 +79,22 @@ class FirstMatesSpyglass extends Analyzer {
       return this.selectedCombatant.getBuffUptime(SPELLS.SPYGLASS_SIGHT.id) / this.owner.fightDuration;
   }
 
-  item() {
-    return {
-      item: ITEMS.FIRST_MATES_SPYGLASS,
-      result: (
-        <TooltipElement content={`You critically hit ${formatPercentage(this.timesCrit / this.timesHit)}% of the time with this buff up`}>
-          Used {this.casts} times / {formatPercentage(this.totalBuffUptime)}% uptime
-        </TooltipElement>
-      ),
-    };
+  get critPercentage() {
+    return this.timesCrit / this.timesHit;
+  }
+
+  statistic() {
+    return (
+      <ItemStatistic
+        size="flexible"
+        tooltip={`Used ${this.casts} times`}
+      >
+        <BoringItemValueText item={ITEMS.FIRST_MATES_SPYGLASS}>
+          <UptimeIcon /> {formatPercentage(this.totalBuffUptime)}% <small>uptime</small><br />
+          <CritIcon /> {formatPercentage(this.critPercentage,0)}% <small>critical hits during buff</small>
+        </BoringItemValueText>
+      </ItemStatistic>
+    );
   }
 }
 

--- a/src/parser/shared/modules/items/bfa/GildedLoaFigurine.js
+++ b/src/parser/shared/modules/items/bfa/GildedLoaFigurine.js
@@ -4,9 +4,7 @@ import SPELLS from 'common/SPELLS/index';
 import ITEMS from 'common/ITEMS/index';
 import Analyzer from 'parser/core/Analyzer';
 import UptimeIcon from 'interface/icons/Uptime';
-import IntellectIcon from 'interface/icons/Intellect';
-import AgilityIcon from 'interface/icons/Agility';
-import StrengthIcon from 'interface/icons/Strength';
+import PrimaryStatIcon from 'interface/icons/PrimaryStat';
 import ItemStatistic from 'interface/statistics/ItemStatistic';
 import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
 import { formatPercentage, formatNumber } from 'common/format';
@@ -41,7 +39,6 @@ class GildedLoaFigurine extends Analyzer {
   }
 
   statistic() {
-    console.log(this.selectedCombatant.spec.primaryStat);
     return (
       <ItemStatistic
         size="flexible"
@@ -49,9 +46,7 @@ class GildedLoaFigurine extends Analyzer {
       >
         <BoringItemValueText item={ITEMS.GILDED_LOA_FIGURINE}>
           <UptimeIcon /> {formatPercentage(this.totalBuffUptime)}% uptime<br />
-          {this.selectedCombatant.spec.primaryStat === "Intellect" ? <><IntellectIcon /> {formatNumber(this.totalBuffUptime * this.statBuff)} <small>average intellect</small></> : ''}
-          {this.selectedCombatant.spec.primaryStat === "Agility" ? <><AgilityIcon /> {formatNumber(this.totalBuffUptime * this.statBuff)} <small>average agility</small></> : ''}
-          {this.selectedCombatant.spec.primaryStat === "Strength" ? <><StrengthIcon /> {formatNumber(this.totalBuffUptime * this.statBuff)} <small>average strength</small></> : ''}
+          <PrimaryStatIcon stat={this.selectedCombatant.spec.primaryStat} /> {formatNumber(this.totalBuffUptime * this.statBuff)} <small>average {this.selectedCombatant.spec.primaryStat} gained</small>
         </BoringItemValueText>
       </ItemStatistic>
     );

--- a/src/parser/shared/modules/items/bfa/GildedLoaFigurine.js
+++ b/src/parser/shared/modules/items/bfa/GildedLoaFigurine.js
@@ -3,13 +3,22 @@ import React from 'react';
 import SPELLS from 'common/SPELLS/index';
 import ITEMS from 'common/ITEMS/index';
 import Analyzer from 'parser/core/Analyzer';
+import UptimeIcon from 'interface/icons/Uptime';
+import IntellectIcon from 'interface/icons/Intellect';
+import AgilityIcon from 'interface/icons/Agility';
+import StrengthIcon from 'interface/icons/Strength';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
+import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
 import { formatPercentage, formatNumber } from 'common/format';
 import { calculatePrimaryStat } from 'common/stats';
-import { TooltipElement } from 'common/Tooltip';
 
 /**
  * Gilded Loa Figurine -
  * Equip: Your spells and abilities have a chance to increase your primary stat by 814 for 10 sec.
+ * 
+ * Test Log(int): https://www.warcraftlogs.com/reports/7Bzx2VWX9TPtYGdK#fight=48&type=damage-done&source=6
+ * Test Log(agi): https://www.warcraftlogs.com/reports/JRYakMh4PyVtBxFq#fight=8&type=damage-done&source=270
+ * Test log(str): https://www.warcraftlogs.com/reports/rw2H3AKDfN1ghv4B#fight=3&type=damage-done&source=24
  */
 class GildedLoaFigurine extends Analyzer {
   statBuff = 0;
@@ -31,16 +40,21 @@ class GildedLoaFigurine extends Analyzer {
     return this.selectedCombatant.getBuffUptime(SPELLS.WILL_OF_THE_LOA.id) / this.owner.fightDuration;
   }
 
-  item() {
-    return {
-      item: ITEMS.GILDED_LOA_FIGURINE,
-      result: (
-        <TooltipElement content={`Procced ${this.buffTriggerCount} times`}>
-          {formatPercentage(this.totalBuffUptime)}% uptime<br />
-          {formatNumber(this.totalBuffUptime * this.statBuff)} average {this.selectedCombatant.spec.primaryStat}
-        </TooltipElement>
-      ),
-    };
+  statistic() {
+    console.log(this.selectedCombatant.spec.primaryStat);
+    return (
+      <ItemStatistic
+        size="flexible"
+        tooltip={`Procced ${this.buffTriggerCount} times`}
+      >
+        <BoringItemValueText item={ITEMS.GILDED_LOA_FIGURINE}>
+          <UptimeIcon /> {formatPercentage(this.totalBuffUptime)}% uptime<br />
+          {this.selectedCombatant.spec.primaryStat === "Intellect" ? <><IntellectIcon /> {formatNumber(this.totalBuffUptime * this.statBuff)} <small>average intellect</small></> : ''}
+          {this.selectedCombatant.spec.primaryStat === "Agility" ? <><AgilityIcon /> {formatNumber(this.totalBuffUptime * this.statBuff)} <small>average agility</small></> : ''}
+          {this.selectedCombatant.spec.primaryStat === "Strength" ? <><StrengthIcon /> {formatNumber(this.totalBuffUptime * this.statBuff)} <small>average strength</small></> : ''}
+        </BoringItemValueText>
+      </ItemStatistic>
+    );
   }
 }
 

--- a/src/parser/shared/modules/items/bfa/crafted/DarkmoonDeckBlockades.js
+++ b/src/parser/shared/modules/items/bfa/crafted/DarkmoonDeckBlockades.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import ITEMS from 'common/ITEMS/index';
+import ItemLink from 'common/ItemLink';
 import Analyzer from 'parser/core/Analyzer';
 import { calculatePrimaryStat } from 'common/stats';
 import StatisticBox from 'interface/others/StatisticBox';
@@ -142,14 +143,16 @@ class DarkmoonDeckBlockades extends Analyzer {
     };
   }
 
-  item() {
+
+
+  statistic() {
     const summary = this.staminaSummary;
     const totals = this._getSummaryTotals(summary);
     const tooltipData = (
       <StatisticBox
         icon={<ItemIcon id={ITEMS.DARKMOON_DECK_BLOCKADES.id} />}
         value={this.owner.formatItemHealingDone(this.healing)}
-        label="Darkmoon Deck: Blockades"
+        label={<ItemLink id={ITEMS.DARKMOON_DECK_BLOCKADES.id} icon={false} />}
         category={STATISTIC_CATEGORY.ITEMS}
       >
         <table className="table table-condensed">

--- a/src/parser/shared/modules/items/bfa/crafted/DarkmoonDeckTides.js
+++ b/src/parser/shared/modules/items/bfa/crafted/DarkmoonDeckTides.js
@@ -3,6 +3,8 @@ import React from 'react';
 import SPELLS from 'common/SPELLS/index';
 import ITEMS from 'common/ITEMS/index';
 import Analyzer from 'parser/core/Analyzer';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
+import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
 import ItemHealingDone from 'interface/others/ItemHealingDone';
 import ItemManaGained from 'interface/others/ItemManaGained';
 
@@ -22,6 +24,8 @@ const DARKMOON_DECK_TIDES_CARDS = [
  * Equip: Restores a moderate amount of mana when the deck is shuffled. Chance to throw a card to a random party member,
  * healing them and bouncing to other party members. Amount of mana restored and number of bounces depends on the topmost card in the deck.
  * Equip: Periodically shuffle the deck while in combat.
+ * 
+ * Test Log: https://www.warcraftlogs.com/reports/CadGJw7KZpq9Xgnb#fight=4&type=damage-done&source=60
  */
 
 class DarkmoonDeckTides extends Analyzer {
@@ -51,16 +55,17 @@ class DarkmoonDeckTides extends Analyzer {
     this.manaGained += event.resourceChange;
   }
 
-  item() {
-    return {
-      item: ITEMS.DARKMOON_DECK_TIDES,
-      result: (
-        <>
+  statistic() {
+    return (
+      <ItemStatistic
+        size="flexible"
+      >
+        <BoringItemValueText item={ITEMS.DARKMOON_DECK_TIDES}>
           <ItemHealingDone amount={this.healing} /><br />
           <ItemManaGained amount={this.manaGained} />
-        </>
-      ),
-    };
+        </BoringItemValueText>
+      </ItemStatistic>
+    );
   }
 }
 

--- a/src/parser/shared/modules/items/bfa/dungeons/AzerokksResonatingHeart.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/AzerokksResonatingHeart.js
@@ -6,6 +6,7 @@ import { formatPercentage } from 'common/format';
 import { calculatePrimaryStat } from 'common/stats';
 import ItemStatistic from 'interface/statistics/ItemStatistic';
 import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
+import AgilityIcon from 'interface/icons/Agility';
 
 import Analyzer from 'parser/core/Analyzer';
 import Abilities from 'parser/core/modules/Abilities';
@@ -69,7 +70,7 @@ class AzerokksResonatingHeart extends Analyzer {
         tooltip={<>You procced <strong>{SPELLS.BENEFICIAL_VIBRATIONS.name}</strong> {this.procs} times with an uptime of {formatPercentage(this.uptime)}%.</>}
       >
         <BoringItemValueText item={ITEMS.AZEROKKS_RESONATING_HEART}>
-          {this.averageAgility} <small>Avg. agility gained</small>
+          <AgilityIcon /> {this.averageAgility} <small>Avg. agility gained</small>
         </BoringItemValueText>
       </ItemStatistic>
     );

--- a/src/parser/shared/modules/items/bfa/dungeons/AzerokksResonatingHeart.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/AzerokksResonatingHeart.js
@@ -70,7 +70,7 @@ class AzerokksResonatingHeart extends Analyzer {
         tooltip={<>You procced <strong>{SPELLS.BENEFICIAL_VIBRATIONS.name}</strong> {this.procs} times with an uptime of {formatPercentage(this.uptime)}%.</>}
       >
         <BoringItemValueText item={ITEMS.AZEROKKS_RESONATING_HEART}>
-          <AgilityIcon /> {this.averageAgility} <small>Avg. agility gained</small>
+          <AgilityIcon /> {this.averageAgility} <small>average Agility gained</small>
         </BoringItemValueText>
       </ItemStatistic>
     );

--- a/src/parser/shared/modules/items/bfa/dungeons/MydasTalisman.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/MydasTalisman.js
@@ -3,6 +3,8 @@ import React from 'react';
 import SPELLS from 'common/SPELLS/index';
 import ITEMS from 'common/ITEMS/index';
 import Analyzer from 'parser/core/Analyzer';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
+import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
 import Abilities from 'parser/core/modules/Abilities';
 
 import ItemDamageDone from 'interface/others/ItemDamageDone';
@@ -10,6 +12,8 @@ import ItemDamageDone from 'interface/others/ItemDamageDone';
 /**
  * My'das Talisman
  * Use: Turn your hands to gold, causing your next 5 auto-attacks to deal X extra damage. (1 Min, 30 Sec Cooldown)
+ * 
+ * Test Log: https://www.warcraftlogs.com/reports/c3JjQfWgV4XptKkP#fight=3&type=damage-done&source=8
  */
 class MydasTalisman extends Analyzer {
   static dependencies = {
@@ -44,11 +48,16 @@ class MydasTalisman extends Analyzer {
     this.damage += event.amount + (event.absorbed || 0);
   }
 
-  item() {
-    return {
-      item: ITEMS.MYDAS_TALISMAN,
-      result: <ItemDamageDone amount={this.damage} />,
-    };
+  statistic() {
+    return (
+      <ItemStatistic
+        size="flexible"
+      >
+        <BoringItemValueText item={ITEMS.MYDAS_TALISMAN}>
+          <ItemDamageDone amount={this.damage} />
+        </BoringItemValueText>
+      </ItemStatistic>
+    );
   }
 }
 

--- a/src/parser/shared/modules/items/bfa/dungeons/RevitalizingVoodooTotem.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/RevitalizingVoodooTotem.js
@@ -3,6 +3,8 @@ import React from 'react';
 import SPELLS from 'common/SPELLS/index';
 import ITEMS from 'common/ITEMS/index';
 import Analyzer from 'parser/core/Analyzer';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
+import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
 import Abilities from 'parser/core/modules/Abilities';
 
 import ItemHealingDone from 'interface/others/ItemHealingDone';
@@ -10,6 +12,8 @@ import ItemHealingDone from 'interface/others/ItemHealingDone';
 /**
  * Revitalizing Voodoo Totem -
  * Use: Heals the target for 0 every 0.5 sec, stacking up to 12 times. Healing starts low and increases over the duration. (1 Min, 30 Sec Cooldown)
+ * 
+ * Test Log: https://www.warcraftlogs.com/reports/2fZTqh6VbNC1xXPL#fight=6&type=damage-done&source=17
  */
 class RevitalizingVoodooTotem extends Analyzer {
   static dependencies = {
@@ -45,11 +49,16 @@ class RevitalizingVoodooTotem extends Analyzer {
     this.healing += event.amount + (event.absorbed || 0);
   }
 
-  item() {
-    return {
-      item: ITEMS.REVITALIZING_VOODOO_TOTEM,
-      result: <ItemHealingDone amount={this.healing} />,
-    };
+  statistic() {
+    return (
+      <ItemStatistic
+        size="flexible"
+      >
+        <BoringItemValueText item={ITEMS.REVITALIZING_VOODOO_TOTEM}>
+          <ItemHealingDone amount={this.healing} />
+        </BoringItemValueText>
+      </ItemStatistic>
+    );
   }
 }
 

--- a/src/parser/shared/modules/items/bfa/dungeons/RezansGleamingEye.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/RezansGleamingEye.js
@@ -3,6 +3,10 @@ import React from 'react';
 import SPELLS from 'common/SPELLS/index';
 import ITEMS from 'common/ITEMS/index';
 import Analyzer from 'parser/core/Analyzer';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
+import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
+import UptimeIcon from 'interface/icons/Uptime';
+import HasteIcon from 'interface/icons/Haste';
 import { formatPercentage, formatNumber } from 'common/format';
 import { calculateSecondaryStatDefault } from 'common/stats';
 
@@ -28,16 +32,17 @@ class RezansGleamingEye extends Analyzer {
         return this.selectedCombatant.getBuffUptime(SPELLS.REZANS_GLEAMING_EYE_BUFF.id) / this.owner.fightDuration;
     }
 
-    item() {
-        return {
-        item: ITEMS.REZANS_GLEAMING_EYE,
-        result: (
-            <>
-            {formatPercentage(this.totalBuffUptime)}% uptime<br />
-            {formatNumber(this.totalBuffUptime * this.statBuff)} average Haste
-            </>
-        ),
-        };
+    statistic() {
+        return (
+          <ItemStatistic
+            size="flexible"
+          >
+            <BoringItemValueText item={ITEMS.REZANS_GLEAMING_EYE}>
+                <UptimeIcon /> {formatPercentage(this.totalBuffUptime)}% <small>uptime</small><br />
+                <HasteIcon /> {formatNumber(this.totalBuffUptime * this.statBuff)} <small>average Haste</small>
+            </BoringItemValueText>
+          </ItemStatistic>
+        );
     }
 }
 

--- a/src/parser/shared/modules/items/bfa/dungeons/RezansGleamingEye.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/RezansGleamingEye.js
@@ -39,7 +39,7 @@ class RezansGleamingEye extends Analyzer {
           >
             <BoringItemValueText item={ITEMS.REZANS_GLEAMING_EYE}>
                 <UptimeIcon /> {formatPercentage(this.totalBuffUptime)}% <small>uptime</small><br />
-                <HasteIcon /> {formatNumber(this.totalBuffUptime * this.statBuff)} <small>average Haste</small>
+                <HasteIcon /> {formatNumber(this.totalBuffUptime * this.statBuff)} <small>average Haste gained</small>
             </BoringItemValueText>
           </ItemStatistic>
         );

--- a/src/parser/shared/modules/items/bfa/dungeons/RotcrustedVoodooDoll.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/RotcrustedVoodooDoll.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
-import { TooltipElement } from 'common/Tooltip';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
+import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
 import Analyzer from 'parser/core/Analyzer';
 import { formatNumber } from 'common/format';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
@@ -51,15 +52,17 @@ class RotcrustedVoodooDoll extends Analyzer {
     this.ticks += 1;
   }
 
-  item() {
-    return {
-      item: ITEMS.ROTCRUSTED_VOODOO_DOLL,
-      result: (
-        <TooltipElement content={<><strong>{this.ticks}</strong> ticks, causing <strong>{formatNumber(this.damage)}</strong> damage.</>}>
+  statistic() {
+    return (
+      <ItemStatistic
+        size="flexible"
+        tooltip={<><strong>{this.ticks}</strong> ticks, causing <strong>{formatNumber(this.damage)}</strong> damage.</>}
+      >
+        <BoringItemValueText item={ITEMS.ROTCRUSTED_VOODOO_DOLL}>
           <ItemDamageDone amount={this.damage} />
-        </TooltipElement>
-      ),
-    };
+        </BoringItemValueText>
+      </ItemStatistic>
+    );
   }
 }
 

--- a/src/parser/shared/modules/items/bfa/dungeons/Seabreeze.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/Seabreeze.js
@@ -2,7 +2,10 @@ import React from 'react';
 
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
-import { TooltipElement } from 'common/Tooltip';
+import UptimeIcon from 'interface/icons/Uptime';
+import HasteIcon from 'interface/icons/Haste';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
+import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
 import Analyzer from 'parser/core/Analyzer';
 import { formatPercentage, formatNumber } from 'common/format';
 import { calculateSecondaryStatDefault } from 'common/stats';
@@ -35,18 +38,18 @@ class Seabreeze extends Analyzer {
     return averageStacks * this.statBuff;
   }
 
-  item() {
-    return {
-      item: ITEMS.SEABREEZE,
-      result: (
-        <>
-          {formatPercentage(this.totalBuffUptime)}% uptime<br />
-          <TooltipElement content={`The stat budget for a non-proc main hand would yield ${formatNumber(this.statBudget)} secondary stats`}>
-            {formatNumber(this.averageStatGain)} average Haste gained.
-          </TooltipElement>
-        </>
-      ),
-    };
+  statistic() {
+    return (
+      <ItemStatistic
+        size="flexible"
+        tooltip={`The stat budget for a non-proc main hand would yield ${formatNumber(this.statBudget)} secondary stats`}
+      >
+        <BoringItemValueText item={ITEMS.SEABREEZE}>
+          <UptimeIcon /> {formatPercentage(this.totalBuffUptime)}% <small>uptime</small> <br />
+          <HasteIcon /> {formatNumber(this.averageStatGain)} <small>average Haste gained</small>
+        </BoringItemValueText>
+      </ItemStatistic>
+    );
   }
 }
 

--- a/src/parser/shared/modules/items/bfa/dungeons/VesselOfSkitteringShadows.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/VesselOfSkitteringShadows.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import ITEMS from 'common/ITEMS';
 import Analyzer from 'parser/core/Analyzer';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
+import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
 import SPELLS from 'common/SPELLS/';
 import ItemDamageDone from 'interface/others/ItemDamageDone';
 
@@ -29,11 +31,16 @@ class VesselOfSkitteringShadows extends Analyzer {
     this.damage += event.amount + (event.absorbed || 0);
   }
 
-  item() {
-    return {
-      item: ITEMS.VESSEL_OF_SKITTERING_SHADOWS,
-      result: <ItemDamageDone amount={this.damage} />,
-    };
+  statistic() {
+    return (
+      <ItemStatistic
+        size="flexible"
+      >
+        <BoringItemValueText item={ITEMS.VESSEL_OF_SKITTERING_SHADOWS}>
+          <ItemDamageDone amount={this.damage} />
+        </BoringItemValueText>
+      </ItemStatistic>
+    );
   }
 }
 

--- a/src/parser/shared/modules/items/bfa/enchants/CoastalSurge.js
+++ b/src/parser/shared/modules/items/bfa/enchants/CoastalSurge.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
-import SpellIcon from 'common/SpellIcon';
-import SpellLink from 'common/SpellLink';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
+import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
 import SPELLS from 'common/SPELLS';
 import ItemHealingDone from 'interface/others/ItemHealingDone';
 
@@ -9,6 +9,8 @@ const COASTAL_SURGE_ENCHANT_ID = 5946;
 /**
  * Costal Surge:
  * Permanently enchant a weapon to sometimes cause the wielder's helpful spells to put a short heal over time effect on the target for 10 sec.
+ * 
+ * Test Log: /report/2fZTqh6VbNC1xXPL/6-Normal+Champion+of+the+Light+-+Kill+(1:31)/Akkame/statistics
  */
 class CostalSurge extends Analyzer {
   healing = 0;
@@ -27,14 +29,16 @@ class CostalSurge extends Analyzer {
     this.healing += event.amount + (event.absorbed || 0);
   }
 
-
-  item() {
-    return {
-      id: SPELLS.COASTAL_SURGE.id,
-      icon: <SpellIcon id={SPELLS.COASTAL_SURGE.id} />,
-      title: <SpellLink id={SPELLS.COASTAL_SURGE.id} icon={false} />,
-      result: <ItemHealingDone amount={this.healing} />,
-    };
+  statistic() {
+    return (
+      <ItemStatistic
+        size="flexible"
+      >
+        <BoringSpellValueText spell={SPELLS.COASTAL_SURGE}>
+          <ItemHealingDone amount={this.healing} />
+        </BoringSpellValueText>
+      </ItemStatistic>
+    );
   }
 
 }

--- a/src/parser/shared/modules/items/bfa/enchants/Navigation.js
+++ b/src/parser/shared/modules/items/bfa/enchants/Navigation.js
@@ -130,7 +130,7 @@ class Navigation extends Analyzer {
 
     return ((smallBuffIncrease + bigBuffIncrease) / this.owner.fightDuration).toFixed(0);
   }
-  item() {
+  statistic() {
     const buffStacks = this.cleanStacks;
     const maxStackBuffDuration = this.maxStackBuffUptime;
     return (

--- a/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsBadge.js
+++ b/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsBadge.js
@@ -60,11 +60,4 @@ class DreadGladiatorsBadge extends Analyzer {
   }
 }
 
-
-        </BoringItemValueText>
-      </ItemStatistic>
-    );
-  }
-}
-
 export default DreadGladiatorsBadge;

--- a/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsBadge.js
+++ b/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsBadge.js
@@ -4,9 +4,7 @@ import SPELLS from 'common/SPELLS/index';
 import ITEMS from 'common/ITEMS/index';
 import Analyzer from 'parser/core/Analyzer';
 import UptimeIcon from 'interface/icons/Uptime';
-import IntellectIcon from 'interface/icons/Intellect';
-import AgilityIcon from 'interface/icons/Agility';
-import StrengthIcon from 'interface/icons/Strength';
+import PrimaryStatIcon from 'interface/icons/PrimaryStat';
 import ItemStatistic from 'interface/statistics/ItemStatistic';
 import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
 import { formatPercentage, formatNumber } from 'common/format';
@@ -55,9 +53,14 @@ class DreadGladiatorsBadge extends Analyzer {
       >
         <BoringItemValueText item={ITEMS.DREAD_GLADIATORS_BADGE}>
           <UptimeIcon /> {formatPercentage(this.totalBuffUptime)}% uptime<br />
-          {this.selectedCombatant.spec.primaryStat === "Intellect" ? <><IntellectIcon /> {formatNumber(this.totalBuffUptime * this.statBuff)} <small>average intellect</small></> : ''}
-          {this.selectedCombatant.spec.primaryStat === "Agility" ? <><AgilityIcon /> {formatNumber(this.totalBuffUptime * this.statBuff)} <small>average agility</small></> : ''}
-          {this.selectedCombatant.spec.primaryStat === "Strength" ? <><StrengthIcon /> {formatNumber(this.totalBuffUptime * this.statBuff)} <small>average strength</small></> : ''}
+          <PrimaryStatIcon stat={this.selectedCombatant.spec.primaryStat} /> {formatNumber(this.totalBuffUptime * this.statBuff)} <small>average {this.selectedCombatant.spec.primaryStat} gained</small>
+        </BoringItemValueText>
+      </ItemStatistic>
+    );
+  }
+}
+
+
         </BoringItemValueText>
       </ItemStatistic>
     );

--- a/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsBadge.js
+++ b/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsBadge.js
@@ -3,6 +3,12 @@ import React from 'react';
 import SPELLS from 'common/SPELLS/index';
 import ITEMS from 'common/ITEMS/index';
 import Analyzer from 'parser/core/Analyzer';
+import UptimeIcon from 'interface/icons/Uptime';
+import IntellectIcon from 'interface/icons/Intellect';
+import AgilityIcon from 'interface/icons/Agility';
+import StrengthIcon from 'interface/icons/Strength';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
+import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
 import { formatPercentage, formatNumber } from 'common/format';
 import { calculatePrimaryStat } from 'common/stats';
 import Abilities from 'parser/core/modules/Abilities';
@@ -41,16 +47,20 @@ class DreadGladiatorsBadge extends Analyzer {
     return this.selectedCombatant.getBuffUptime(SPELLS.DIG_DEEP.id) / this.owner.fightDuration;
   }
 
-  item() {
-    return {
-      item: ITEMS.DREAD_GLADIATORS_BADGE,
-      result: (
-        <>
-          {formatPercentage(this.totalBuffUptime)}% uptime<br />
-          {formatNumber(this.totalBuffUptime * this.statBuff)} average Primary Stat
-        </>
-      ),
-    };
+  statistic() {
+    console.log(this.selectedCombatant.spec.primaryStat);
+    return (
+      <ItemStatistic
+        size="flexible"
+      >
+        <BoringItemValueText item={ITEMS.DREAD_GLADIATORS_BADGE}>
+          <UptimeIcon /> {formatPercentage(this.totalBuffUptime)}% uptime<br />
+          {this.selectedCombatant.spec.primaryStat === "Intellect" ? <><IntellectIcon /> {formatNumber(this.totalBuffUptime * this.statBuff)} <small>average intellect</small></> : ''}
+          {this.selectedCombatant.spec.primaryStat === "Agility" ? <><AgilityIcon /> {formatNumber(this.totalBuffUptime * this.statBuff)} <small>average agility</small></> : ''}
+          {this.selectedCombatant.spec.primaryStat === "Strength" ? <><StrengthIcon /> {formatNumber(this.totalBuffUptime * this.statBuff)} <small>average strength</small></> : ''}
+        </BoringItemValueText>
+      </ItemStatistic>
+    );
   }
 }
 

--- a/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsInsignia.js
+++ b/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsInsignia.js
@@ -71,7 +71,7 @@ class DreadGladiatorsInsignia extends Analyzer {
       >
         <BoringItemValueText item={ITEMS.DREAD_GLADIATORS_BADGE}>
           <UptimeIcon /> {formatPercentage(this.uptime)}% uptime<br />
-          <PrimaryStatIcon stat={this.selectedCombatant.spec.primaryStat} /> {formatNumber(this.totalBuffUptime * this.statBuff)} <small>average {this.selectedCombatant.spec.primaryStat} gained</small>
+          <PrimaryStatIcon stat={this.selectedCombatant.spec.primaryStat} /> {this.averagePrimaryStat} <small>average {this.selectedCombatant.spec.primaryStat} gained</small>
         </BoringItemValueText>
       </ItemStatistic>
     );

--- a/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsInsignia.js
+++ b/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsInsignia.js
@@ -4,7 +4,12 @@ import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
 import { formatPercentage } from 'common/format';
 import { calculatePrimaryStat } from 'common/stats';
-import { TooltipElement } from 'common/Tooltip';
+import UptimeIcon from 'interface/icons/Uptime';
+import IntellectIcon from 'interface/icons/Intellect';
+import AgilityIcon from 'interface/icons/Agility';
+import StrengthIcon from 'interface/icons/Strength';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
+import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
 
 import Analyzer from 'parser/core/Analyzer';
 import Abilities from 'parser/core/modules/Abilities';
@@ -59,15 +64,21 @@ class DreadGladiatorsInsignia extends Analyzer {
     return (this.primaryStatBuff * this.uptime).toFixed(0);
   }
 
-  item() {
-    return {
-      item: ITEMS.DREAD_GLADIATORS_INSIGNIA,
-      result: (
-        <TooltipElement content={<>You procced <strong>{SPELLS.TASTE_OF_VICTORY.name}</strong> {this.procs} times with an uptime of {formatPercentage(this.uptime)}%.</>}>
-          {this.averagePrimaryStat} average Primary Stat
-        </TooltipElement>
-      ),
-    };
+  statistic() {
+    console.log(this.selectedCombatant.spec.primaryStat);
+    return (
+      <ItemStatistic
+        size="flexible"
+        tooltip={<>You procced <strong>{SPELLS.TASTE_OF_VICTORY.name}</strong> {this.procs} times</>}
+      >
+        <BoringItemValueText item={ITEMS.DREAD_GLADIATORS_BADGE}>
+          <UptimeIcon /> {formatPercentage(this.uptime)}% uptime<br />
+          {this.selectedCombatant.spec.primaryStat === "Intellect" ? <><IntellectIcon /> {this.averagePrimaryStat} <small>average intellect</small></> : ''}
+          {this.selectedCombatant.spec.primaryStat === "Agility" ? <><AgilityIcon /> {this.averagePrimaryStat} <small>average agility</small></> : ''}
+          {this.selectedCombatant.spec.primaryStat === "Strength" ? <><StrengthIcon /> {this.averagePrimaryStat} <small>average strength</small></> : ''}
+        </BoringItemValueText>
+      </ItemStatistic>
+    );
   }
 }
 

--- a/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsInsignia.js
+++ b/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsInsignia.js
@@ -5,9 +5,7 @@ import ITEMS from 'common/ITEMS';
 import { formatPercentage } from 'common/format';
 import { calculatePrimaryStat } from 'common/stats';
 import UptimeIcon from 'interface/icons/Uptime';
-import IntellectIcon from 'interface/icons/Intellect';
-import AgilityIcon from 'interface/icons/Agility';
-import StrengthIcon from 'interface/icons/Strength';
+import PrimaryStatIcon from 'interface/icons/PrimaryStat';
 import ItemStatistic from 'interface/statistics/ItemStatistic';
 import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
 
@@ -73,9 +71,14 @@ class DreadGladiatorsInsignia extends Analyzer {
       >
         <BoringItemValueText item={ITEMS.DREAD_GLADIATORS_BADGE}>
           <UptimeIcon /> {formatPercentage(this.uptime)}% uptime<br />
-          {this.selectedCombatant.spec.primaryStat === "Intellect" ? <><IntellectIcon /> {this.averagePrimaryStat} <small>average intellect</small></> : ''}
-          {this.selectedCombatant.spec.primaryStat === "Agility" ? <><AgilityIcon /> {this.averagePrimaryStat} <small>average agility</small></> : ''}
-          {this.selectedCombatant.spec.primaryStat === "Strength" ? <><StrengthIcon /> {this.averagePrimaryStat} <small>average strength</small></> : ''}
+          <PrimaryStatIcon stat={this.selectedCombatant.spec.primaryStat} /> {formatNumber(this.totalBuffUptime * this.statBuff)} <small>average {this.selectedCombatant.spec.primaryStat} gained</small>
+        </BoringItemValueText>
+      </ItemStatistic>
+    );
+  }
+}
+
+
         </BoringItemValueText>
       </ItemStatistic>
     );

--- a/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsInsignia.js
+++ b/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsInsignia.js
@@ -78,11 +78,4 @@ class DreadGladiatorsInsignia extends Analyzer {
   }
 }
 
-
-        </BoringItemValueText>
-      </ItemStatistic>
-    );
-  }
-}
-
 export default DreadGladiatorsInsignia;


### PR DESCRIPTION
Ran into a little bit of an issue with DMD Blockades and Navigation as I couldnt really figure out how to make the dropdown in the new <Statistic> stuff. But changing item to statistic without changing the StatisticBox worked and everything still works fine, so i think its still ok to use StatisticBox??

Towards #2939

There is about 12-13 left after this