### PR TITLE
[MW] Doughnut Update

### DIFF
--- a/src/parser/monk/mistweaver/CHANGELOG.js
+++ b/src/parser/monk/mistweaver/CHANGELOG.js
@@ -7,7 +7,7 @@ import SpellLink from 'common/SpellLink';
 export default [
   {
     date: new Date('2019-03-21'),
-    changes: 'Made mastery track more accurately and updated the donut chart to reflect that.',
+    changes: 'Updated mastery tracking to more accurately reflect the spell that triggered the <SpellLink id={SPELLS.GUST_OF_MIST.id} />. This includes updates to the statistic and healing efficiency sections.',
     contributors: [Abelito75],
   },
   {

--- a/src/parser/monk/mistweaver/CHANGELOG.js
+++ b/src/parser/monk/mistweaver/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2019-03-21'),
+    changes: 'Made mastery track more accurately and updated the donut chart to reflect that.',
+    contributors: [Abelito75],
+  },
+  {
     date: new Date('2019-03-15'),
     changes: <>Updated Mistweaver Spreadsheet tab to include  <SpellLink id={SPELLS.REFRESHING_JADE_WIND_TALENT.id} /> efficiency.</>,
     contributors: [Abelito75],

--- a/src/parser/monk/mistweaver/CONFIG.js
+++ b/src/parser/monk/mistweaver/CONFIG.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Anomoly } from 'CONTRIBUTORS';
+import { Anomoly, Abelito75 } from 'CONTRIBUTORS';
 import retryingPromise from 'common/retryingPromise';
 import SPECS from 'game/SPECS';
 
@@ -8,9 +8,9 @@ import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Anomoly],
+  contributors: [Anomoly, Abelito75],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '8.1',
+  patchCompatibility: '8.1.5',
   // If set to  false`, the spec will show up as unsupported.
   isSupported: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.

--- a/src/parser/monk/mistweaver/modules/features/EssenceFontMastery.js
+++ b/src/parser/monk/mistweaver/modules/features/EssenceFontMastery.js
@@ -75,7 +75,7 @@ class EssenceFontMastery extends Analyzer {
   }
 
   get suggestionThresholds() {
-    if(this.hasUpwelling){
+    if (this.hasUpwelling) {
       return {
         actual: this.avgMasteryCastsPerEF,
         isLessThan: {
@@ -85,7 +85,7 @@ class EssenceFontMastery extends Analyzer {
         },
         style: 'decimal',
       };
-    }else{
+    } else {
      return {
         actual: this.avgMasteryCastsPerEF,
         isLessThan: {

--- a/src/parser/monk/mistweaver/modules/features/EssenceFontMastery.js
+++ b/src/parser/monk/mistweaver/modules/features/EssenceFontMastery.js
@@ -36,13 +36,10 @@ class EssenceFontMastery extends Analyzer {
       if (this.combatants.players[targetId].hasBuff(SPELLS.ESSENCE_FONT_BUFF.id, event.timestamp, 0, 0) === true && !this.gustHeal) {
         debug && console.log(`First Gust Heal: Player ID: ${event.targetID}  Timestamp: ${event.timestamp}`);
         this.healEF += 1;
-        this.healing += (event.amount || 0) + (event.absorbed || 0);
         this.gustHeal = true;
       } else if (this.combatants.players[targetId].hasBuff(SPELLS.ESSENCE_FONT_BUFF.id, event.timestamp, 0, 0) === true && this.gustHeal) {
         this.healEF += 1;
         this.healing += (event.amount || 0) + (event.absorbed || 0);
-        this.secondGustHealing += (event.amount || 0) + (event.absorbed || 0) + (event.overheal || 0);
-        this.secondGustOverheal += (event.overheal || 0);
         this.gustHeal = false;
       }
     }

--- a/src/parser/monk/mistweaver/modules/features/EssenceFontMastery.js
+++ b/src/parser/monk/mistweaver/modules/features/EssenceFontMastery.js
@@ -18,6 +18,11 @@ class EssenceFontMastery extends Analyzer {
     combatants: Combatants,
   };
 
+  constructor(...args) {
+    super(...args);
+    this.hasUpwelling = this.selectedCombatant.hasTalent(SPELLS.UPWELLING_TALENT.id);
+  }
+
   healEF = 0;
   healing = 0;
   castEF = 0;
@@ -70,15 +75,27 @@ class EssenceFontMastery extends Analyzer {
   }
 
   get suggestionThresholds() {
-    return {
-      actual: this.avgMasteryCastsPerEF,
-      isLessThan: {
-        minor: 1.5,
-        average: 1,
-        major: .5,
-      },
-      style: 'decimal',
-    };
+    if(this.hasUpwelling){
+      return {
+        actual: this.avgMasteryCastsPerEF,
+        isLessThan: {
+          minor: 4,
+          average: 3.5,
+          major: 3,
+        },
+        style: 'decimal',
+      };
+    }else{
+     return {
+        actual: this.avgMasteryCastsPerEF,
+        isLessThan: {
+          minor: 3,
+          average: 2.5,
+          major: 2,
+       },
+       style: 'decimal',
+      };
+   }
   }
 
   suggestions(when) {

--- a/src/parser/monk/mistweaver/modules/features/MasteryStats.js
+++ b/src/parser/monk/mistweaver/modules/features/MasteryStats.js
@@ -19,7 +19,6 @@ const debug = false;
 
 class MasteryStats extends Analyzer {
   static dependencies = {
-    //essenceFontMastery: EssenceFontMastery,
     envelopingMists: EnvelopingMists,
     soothingMist: SoothingMist,
     renewingMist: RenewingMist,

--- a/src/parser/monk/mistweaver/modules/features/MasteryStats.js
+++ b/src/parser/monk/mistweaver/modules/features/MasteryStats.js
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { formatThousands } from 'common/format';
 
 import Analyzer from 'parser/core/Analyzer';
+import EssenceFontMastery from 'parser/monk/mistweaver/modules/features/EssenceFontMastery';
 import EnvelopingMists from 'parser/monk/mistweaver/modules/spells/EnvelopingMists';
 import SoothingMist from 'parser/monk/mistweaver/modules/spells/SoothingMist';
 import RenewingMist from 'parser/monk/mistweaver/modules/spells/RenewingMist';
@@ -19,6 +20,7 @@ const debug = false;
 
 class MasteryStats extends Analyzer {
   static dependencies = {
+    essenceFontMastery: EssenceFontMastery,
     envelopingMists: EnvelopingMists,
     soothingMist: SoothingMist,
     renewingMist: RenewingMist,
@@ -29,15 +31,11 @@ class MasteryStats extends Analyzer {
     return (this.vivify.gustsHealing || 0)
             + (this.renewingMist.gustsHealing || 0)
             + (this.envelopingMists.gustsHealing || 0)
-            + (this.soothingMist.gustsHealing || 0);
+            + (this.soothingMist.gustsHealing || 0)
+            + (this.essenceFontMastery.healing || 0);
   }
 
   renderMasterySourceChart() {
-    const efMasteryBonus = (this.vivify.efGusts || 0)
-    + (this.renewingMist.efGusts || 0)
-    + (this.envelopingMists.efGusts || 0)
-    + (this.soothingMist.efGusts || 0);
-
     const items = [
       {
         color: '#00b159',
@@ -71,8 +69,8 @@ class MasteryStats extends Analyzer {
         color: '#00bbcc',
         label: 'Essence font',
         spellId: SPELLS.ESSENCE_FONT.id,
-        value: efMasteryBonus,
-        valueTooltip: formatThousands(efMasteryBonus),
+        value: this.essenceFontMastery.healing,
+        valueTooltip: formatThousands(this.essenceFontMastery.healing),
       },
     ];
 

--- a/src/parser/monk/mistweaver/modules/features/MasteryStats.js
+++ b/src/parser/monk/mistweaver/modules/features/MasteryStats.js
@@ -6,7 +6,6 @@ import SpellLink from 'common/SpellLink';
 import { formatThousands } from 'common/format';
 
 import Analyzer from 'parser/core/Analyzer';
-import EssenceFontMastery from 'parser/monk/mistweaver/modules/features/EssenceFontMastery';
 import EnvelopingMists from 'parser/monk/mistweaver/modules/spells/EnvelopingMists';
 import SoothingMist from 'parser/monk/mistweaver/modules/spells/SoothingMist';
 import RenewingMist from 'parser/monk/mistweaver/modules/spells/RenewingMist';
@@ -20,7 +19,7 @@ const debug = false;
 
 class MasteryStats extends Analyzer {
   static dependencies = {
-    essenceFontMastery: EssenceFontMastery,
+    //essenceFontMastery: EssenceFontMastery,
     envelopingMists: EnvelopingMists,
     soothingMist: SoothingMist,
     renewingMist: RenewingMist,
@@ -31,11 +30,15 @@ class MasteryStats extends Analyzer {
     return (this.vivify.gustsHealing || 0)
             + (this.renewingMist.gustsHealing || 0)
             + (this.envelopingMists.gustsHealing || 0)
-            + (this.soothingMist.gustsHealing || 0)
-            + (this.essenceFontMastery.healing || 0);
+            + (this.soothingMist.gustsHealing || 0);
   }
 
   renderMasterySourceChart() {
+    const efMasteryBonus = (this.vivify.efGusts || 0)
+    + (this.renewingMist.efGusts || 0)
+    + (this.envelopingMists.efGusts || 0)
+    + (this.soothingMist.efGusts || 0);
+
     const items = [
       {
         color: '#00b159',
@@ -69,8 +72,8 @@ class MasteryStats extends Analyzer {
         color: '#00bbcc',
         label: 'Essence font',
         spellId: SPELLS.ESSENCE_FONT.id,
-        value: this.essenceFontMastery.healing,
-        valueTooltip: formatThousands(this.essenceFontMastery.healing),
+        value: efMasteryBonus,
+        valueTooltip: formatThousands(efMasteryBonus),
       },
     ];
 

--- a/src/parser/monk/mistweaver/modules/spells/EnvelopingMists.js
+++ b/src/parser/monk/mistweaver/modules/spells/EnvelopingMists.js
@@ -27,6 +27,7 @@ class EnvelopingMists extends Analyzer {
   gustsHealing = 0;
   lastCastTarget = null;
   numberToCount = 0;
+  efGusts = 0;
 
   constructor(...args) {
     super(...args);
@@ -59,7 +60,11 @@ class EnvelopingMists extends Analyzer {
 
     if ((spellId === SPELLS.GUSTS_OF_MISTS.id) && (this.lastCastTarget === event.targetID) && this.numberToCount >0) {
       this.gustProc += 1;
-      this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
+      if(this.numberToCount >1){
+        this.efGusts += (event.amount || 0) + (event.absorbed || 0);
+      }else{
+        this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
+      }
       this.numberToCount -= 1;
     }
 

--- a/src/parser/monk/mistweaver/modules/spells/EnvelopingMists.js
+++ b/src/parser/monk/mistweaver/modules/spells/EnvelopingMists.js
@@ -27,7 +27,6 @@ class EnvelopingMists extends Analyzer {
   gustsHealing = 0;
   lastCastTarget = null;
   numberToCount = 0;
-  efGusts = 0;
 
   constructor(...args) {
     super(...args);
@@ -39,11 +38,6 @@ class EnvelopingMists extends Analyzer {
 
     if (SPELLS.ENVELOPING_MIST.id !== spellId) {//bail early if not the right spell
       return;
-    }
-    if (this.combatants.players[event.targetID]) {
-      if (this.combatants.players[event.targetID].hasBuff(SPELLS.ESSENCE_FONT_BUFF.id, event.timestamp, 0, 0) === true) {
-        this.numberToCount += 1;
-      }
     }
     this.numberToCount += 1;
     this.lastCastTarget = event.targetID;
@@ -60,11 +54,7 @@ class EnvelopingMists extends Analyzer {
 
     if ((spellId === SPELLS.GUSTS_OF_MISTS.id) && (this.lastCastTarget === event.targetID) && this.numberToCount >0) {
       this.gustProc += 1;
-      if(this.numberToCount >1){
-        this.efGusts += (event.amount || 0) + (event.absorbed || 0);
-      }else{
-        this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
-      }
+      this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
       this.numberToCount -= 1;
     }
 

--- a/src/parser/monk/mistweaver/modules/spells/RenewingMist.js
+++ b/src/parser/monk/mistweaver/modules/spells/RenewingMist.js
@@ -19,7 +19,7 @@ class RenewingMist extends Analyzer {
   lastCastTarget = null;
   healingHits = 0;
   numberToCount = 0;
-
+  efGusts = 0;
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
@@ -41,7 +41,11 @@ class RenewingMist extends Analyzer {
     const spellId = event.ability.guid;
 
     if ((spellId === SPELLS.GUSTS_OF_MISTS.id) && (this.lastCastTarget === event.targetID) && this.numberToCount>0) {
-      this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
+      if(this.numberToCount >1){
+        this.efGusts += (event.amount || 0) + (event.absorbed || 0);
+      }else{
+        this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
+      }
       this.numberToCount -= 1;
     }
 

--- a/src/parser/monk/mistweaver/modules/spells/RenewingMist.js
+++ b/src/parser/monk/mistweaver/modules/spells/RenewingMist.js
@@ -19,7 +19,6 @@ class RenewingMist extends Analyzer {
   lastCastTarget = null;
   healingHits = 0;
   numberToCount = 0;
-  efGusts = 0;
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
@@ -27,11 +26,6 @@ class RenewingMist extends Analyzer {
     if (SPELLS.RENEWING_MIST.id !== spellId) {
       return;
     } 
-    if (this.combatants.players[event.targetID]) {
-      if (this.combatants.players[event.targetID].hasBuff(SPELLS.ESSENCE_FONT_BUFF.id, event.timestamp, 0, 0) === true) {
-        this.numberToCount += 1;
-      }
-    }
 
     this.numberToCount += 1;
     this.lastCastTarget = event.targetID;
@@ -41,11 +35,7 @@ class RenewingMist extends Analyzer {
     const spellId = event.ability.guid;
 
     if ((spellId === SPELLS.GUSTS_OF_MISTS.id) && (this.lastCastTarget === event.targetID) && this.numberToCount>0) {
-      if(this.numberToCount >1){
-        this.efGusts += (event.amount || 0) + (event.absorbed || 0);
-      }else{
-        this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
-      }
+      this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
       this.numberToCount -= 1;
     }
 

--- a/src/parser/monk/mistweaver/modules/spells/Vivify.js
+++ b/src/parser/monk/mistweaver/modules/spells/Vivify.js
@@ -28,7 +28,7 @@ class Vivify extends Analyzer {
   lastCastTarget = null;
   remDuringManaTea = 0;
   numberToCount = 0;
-
+  efGusts = 0;
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
@@ -50,7 +50,11 @@ class Vivify extends Analyzer {
     const spellId = event.ability.guid;
 
     if ((spellId === SPELLS.GUSTS_OF_MISTS.id) && (this.lastCastTarget === event.targetID) && this.numberToCount > 0) {
-      this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
+      if(this.numberToCount >1){
+        this.efGusts += (event.amount || 0) + (event.absorbed || 0);
+      }else{
+        this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
+      }
       this.numberToCount -= 1;
     }
 

--- a/src/parser/monk/mistweaver/modules/spells/Vivify.js
+++ b/src/parser/monk/mistweaver/modules/spells/Vivify.js
@@ -28,18 +28,12 @@ class Vivify extends Analyzer {
   lastCastTarget = null;
   remDuringManaTea = 0;
   numberToCount = 0;
-  efGusts = 0;
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
 
     if (SPELLS.VIVIFY.id !== spellId) {
       return;
-    }
-    if (this.combatants.players[event.targetID]) {
-      if (this.combatants.players[event.targetID].hasBuff(SPELLS.ESSENCE_FONT_BUFF.id, event.timestamp, 0, 0) === true) {
-        this.numberToCount += 1;
-      }
     }
 
     this.numberToCount += 1;
@@ -50,11 +44,7 @@ class Vivify extends Analyzer {
     const spellId = event.ability.guid;
 
     if ((spellId === SPELLS.GUSTS_OF_MISTS.id) && (this.lastCastTarget === event.targetID) && this.numberToCount > 0) {
-      if(this.numberToCount >1){
-        this.efGusts += (event.amount || 0) + (event.absorbed || 0);
-      }else{
-        this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
-      }
+      this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
       this.numberToCount -= 1;
     }
 


### PR DESCRIPTION
Updated the other files to track their ef double splash healing and modified the donut chart to count it. From the logs I have tested we are nearly perfect. 

There appears to be some bad logic in EssenceFontMastery as it is counting the first and second gusts that procs off of it as its own healing. As well it seems we have set the suggestion thresh holds a bit too low depending if they take upwelling or not since upwelling doubles the amount of time they have and getting 2 casts off in 8 seconds seems like a given.