### PR TITLE
Fix prepull normalizer for demonology warlock

### DIFF
--- a/src/common/SPELLS/warlock.js
+++ b/src/common/SPELLS/warlock.js
@@ -370,6 +370,11 @@ export default {
     name: 'Dreadbite',
     icon: 'spell_warlock_calldreadstalkers',
   },
+  SHARPENED_DREADFANGS: {
+    id: 215111,
+    name: 'Sharpened Dreadfangs',
+    icon: 'inv_feldreadravenmount',
+  },
   FEL_FIREBOLT: {
     id: 104318,
     name: 'Fel Firebolt',
@@ -380,6 +385,7 @@ export default {
     name: 'Demonfire',
     icon: 'ability_vehicle_demolisherflamecatapult',
   },
+
   VILEFIEND_BILE_SPIT: {
     id: 267997,
     name: 'Bile Spit',
@@ -466,6 +472,11 @@ export default {
   DEMONIC_CONSUMPTION_BUFF: {
     id: 267972,
     name: 'Demonic Consumption',
+    icon: 'spell_warlock_soulburn',
+  },
+  DEMONIC_CONSUMPTION_CAST: {
+    id: 267971,
+    name: 'Demonic Consumption(cast)',
     icon: 'spell_warlock_soulburn',
   },
 

--- a/src/parser/warlock/demonology/CombatLogParser.js
+++ b/src/parser/warlock/demonology/CombatLogParser.js
@@ -21,6 +21,7 @@ import DemonicTyrantHandler from './modules/pets/DemoPets/DemonicTyrantHandler';
 import ImplosionHandler from './modules/pets/DemoPets/ImplosionHandler';
 import PetTimelineTab from './modules/pets/PetTimelineTab';
 import PrepullPetNormalizer from './modules/pets/normalizers/PrepullPetNormalizer';
+import SummonOrderNormalizer from './modules/pets/normalizers/SummonOrderNormalizer';
 
 import PowerSiphonNormalizer from './modules/talents/normalizers/PowerSiphonNormalizer';
 
@@ -72,6 +73,7 @@ class CombatLogParser extends CoreCombatLogParser {
     demonicTyrantHandler: DemonicTyrantHandler,
     implosionHandler: ImplosionHandler,
     petTimelineTab: PetTimelineTab,
+    summonOrderNormalizer: SummonOrderNormalizer,
     prepullPetNormalizer: PrepullPetNormalizer,
 
     // Normalizers

--- a/src/parser/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.js
+++ b/src/parser/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.js
@@ -34,7 +34,7 @@ class PrepullPetNormalizer extends EventsNormalizer {
       }
       debug && console.log(`(${this.owner.formatTimestamp(event.timestamp, 3)}) Event`, event);
       if (event.type === 'summon' && event.ability && PET_SUMMON_ABILITY_IDS.includes(event.ability.guid)) {
-        this.checkForPetsWhichSummonWasLaterThanItsFirstCast(event, fabricatedEvents)
+        this.checkForPetsWhichSummonWasLaterThanItsFirstCast(event, fabricatedEvents);
         summonedPets.push(encodeTargetString(event.targetID, event.targetInstance));
         debug && console.log(`(${this.owner.formatTimestamp(event.timestamp, 3)}) Pet summon, added to array. Current array: `, JSON.parse(JSON.stringify(summonedPets)));
       }

--- a/src/parser/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.js
+++ b/src/parser/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.js
@@ -18,6 +18,9 @@ class PrepullPetNormalizer extends EventsNormalizer {
   // This normalizer looks at first 30 seconds (because that's hypothetically the longest any temporary pet can live, given a 15 second duration and 15 second extension via Demonic Tyrant, realistically lower because of GCD and cast time of DT)
   // And if it finds begincast, cast or damage events from a pet that isn't summoned yet, fabricates a summon event for them
 
+  // Sometimes pet's first cast happens before it's summon event(for example demonic consumption), both the event and the summon happens at the same time
+  // checkForPetsWhichSummonWasLaterThanItsFirstCast will check if they both have the same time, then it deletes the fabricated event
+
   normalize(events) {
     debug && console.log('playerPets', this.owner.playerPets.sort((pet1, pet2) => pet1.id - pet2.id));
     const maxTimestamp = this.owner.fight.start_time + MAX_TEMPORARY_PET_DURATION;
@@ -31,6 +34,7 @@ class PrepullPetNormalizer extends EventsNormalizer {
       }
       debug && console.log(`(${this.owner.formatTimestamp(event.timestamp, 3)}) Event`, event);
       if (event.type === 'summon' && event.ability && PET_SUMMON_ABILITY_IDS.includes(event.ability.guid)) {
+        this.checkForPetsWhichSummonWasLaterThanItsFirstCast(event, fabricatedEvents)
         summonedPets.push(encodeTargetString(event.targetID, event.targetInstance));
         debug && console.log(`(${this.owner.formatTimestamp(event.timestamp, 3)}) Pet summon, added to array. Current array: `, JSON.parse(JSON.stringify(summonedPets)));
       }
@@ -72,6 +76,7 @@ class PrepullPetNormalizer extends EventsNormalizer {
               abilityIcon: spell.icon,
             },
             __fabricated: true,
+            __originalTimeStamp: event.timestamp
           };
 
           summonedPets.push(petString);
@@ -85,6 +90,15 @@ class PrepullPetNormalizer extends EventsNormalizer {
     }
     events.unshift(...fabricatedEvents);
     return events;
+  }
+  checkForPetsWhichSummonWasLaterThanItsFirstCast(event, fabricatedEvents) {
+    // delete fabricated event, the pet immediately started casting something and events were pushed before the summon
+    for (var k = 0; k < fabricatedEvents.length; k++) {
+      if (fabricatedEvents[k].__originalTimeStamp == event.timestamp) {
+        debug && console.log(`(${this.owner.formatTimestamp(event.timestamp, 3)}) Deleting fabricated summon of pet`);
+        fabricatedEvents.splice(k, 1)
+      }
+    }
   }
 
   _getPetGuid(id) {

--- a/src/parser/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.js
+++ b/src/parser/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.js
@@ -76,7 +76,7 @@ class PrepullPetNormalizer extends EventsNormalizer {
               abilityIcon: spell.icon,
             },
             __fabricated: true,
-            __originalTimeStamp: event.timestamp,
+            __originalTimestamp: event.timestamp,
           };
 
           summonedPets.push(petString);

--- a/src/parser/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.js
+++ b/src/parser/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.js
@@ -76,7 +76,7 @@ class PrepullPetNormalizer extends EventsNormalizer {
               abilityIcon: spell.icon,
             },
             __fabricated: true,
-            __originalTimeStamp: event.timestamp
+            __originalTimeStamp: event.timestamp,
           };
 
           summonedPets.push(petString);
@@ -93,10 +93,10 @@ class PrepullPetNormalizer extends EventsNormalizer {
   }
   checkForPetsWhichSummonWasLaterThanItsFirstCast(event, fabricatedEvents) {
     // delete fabricated event, the pet immediately started casting something and events were pushed before the summon
-    for (var k = 0; k < fabricatedEvents.length; k++) {
-      if (fabricatedEvents[k].__originalTimeStamp == event.timestamp) {
+    for (let k = 0; k < fabricatedEvents.length; k++) {
+      if (fabricatedEvents[k].__originalTimeStamp === event.timestamp) {
         debug && console.log(`(${this.owner.formatTimestamp(event.timestamp, 3)}) Deleting fabricated summon of pet`);
-        fabricatedEvents.splice(k, 1)
+        fabricatedEvents.splice(k, 1);
       }
     }
   }

--- a/src/parser/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.js
+++ b/src/parser/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.js
@@ -34,7 +34,7 @@ class PrepullPetNormalizer extends EventsNormalizer {
       }
       debug && console.log(`(${this.owner.formatTimestamp(event.timestamp, 3)}) Event`, event);
       if (event.type === 'summon' && event.ability && PET_SUMMON_ABILITY_IDS.includes(event.ability.guid)) {
-        this.checkForPetsWhichSummonWasLaterThanItsFirstCast(event, fabricatedEvents);
+        this.preSummonCheck(event, fabricatedEvents);
         summonedPets.push(encodeTargetString(event.targetID, event.targetInstance));
         debug && console.log(`(${this.owner.formatTimestamp(event.timestamp, 3)}) Pet summon, added to array. Current array: `, JSON.parse(JSON.stringify(summonedPets)));
       }
@@ -91,7 +91,7 @@ class PrepullPetNormalizer extends EventsNormalizer {
     events.unshift(...fabricatedEvents);
     return events;
   }
-  checkForPetsWhichSummonWasLaterThanItsFirstCast(event, fabricatedEvents) {
+  preSummonCheck(event, fabricatedEvents) {
     // delete fabricated event, the pet immediately started casting something and events were pushed before the summon
     for (let k = 0; k < fabricatedEvents.length; k++) {
       if (fabricatedEvents[k].__originalTimeStamp === event.timestamp) {

--- a/src/parser/warlock/demonology/modules/pets/normalizers/SummonOrderNormalizer.js
+++ b/src/parser/warlock/demonology/modules/pets/normalizers/SummonOrderNormalizer.js
@@ -1,0 +1,68 @@
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+import SPELLS from 'common/SPELLS';
+
+const MS_BUFFER = 100;
+
+class SummonOrderNormalizer extends EventsNormalizer {
+
+  normalize(events) {
+    const _events = [];
+
+    events.forEach((event, idx) => {
+      _events.push(event);
+
+      // swap both dogs sharpened-dreadfangs cast and their summon
+      if (this.isDogSummon(event)) {
+        const castTimestamp = event.timestamp;
+
+        for (let previousEventIndex = idx; previousEventIndex >= 0; previousEventIndex -= 1) {
+          const previousEvent = _events[previousEventIndex];
+          if ((castTimestamp - previousEvent.timestamp) > MS_BUFFER) {
+            break;
+          }
+          if (previousEvent.type === 'cast' && previousEvent.ability.guid === SPELLS.SHARPENED_DREADFANGS.id && previousEvent.sourceInstance === event.targetInstance) {
+            this.swapEvents(_events, previousEventIndex, previousEvent);
+            break;
+          }
+        }
+      }
+
+      // swap demonic tyrant and its demonic consumption & begin_cast event with its summon
+      if (event.type === 'summon' && event.ability.guid === SPELLS.SUMMON_DEMONIC_TYRANT.id) {
+        const castTimestamp = event.timestamp;
+
+        for (let previousEventIndex = idx; previousEventIndex >= 0; previousEventIndex -= 1) {
+          const previousEvent = _events[previousEventIndex];
+          if ((castTimestamp - previousEvent.timestamp) > MS_BUFFER) {
+            break;
+          }
+          if (this.isDemonicConsumption(previousEvent, event) || this.isDemonFire(previousEvent, event)) {
+            this.swapEvents(_events, previousEventIndex, previousEvent);
+          }
+        }
+      }
+    });
+    return _events;
+  }
+
+  // helper
+  isDogSummon(event) {
+    return event.type === 'summon' && (event.ability.guid === SPELLS.DREADSTALKER_SUMMON_1.id || event.ability.guid === SPELLS.DREADSTALKER_SUMMON_2.id);
+  }
+
+  swapEvents(_events, previousEventIndex, previousEvent) {
+    _events.splice(previousEventIndex, 1);
+    _events.push(previousEvent);
+    _events.__modified = true;
+  }
+
+  isDemonFire(previousEvent, event) {
+    return previousEvent.type === 'begincast' && previousEvent.ability.guid === SPELLS.DEMONIC_TYRANT_DAMAGE.id && previousEvent.sourceInstance === event.targetInstance;
+  }
+
+  isDemonicConsumption(previousEvent, event) {
+    return previousEvent.type === 'cast' && previousEvent.ability.guid === SPELLS.DEMONIC_CONSUMPTION_CAST.id && previousEvent.sourceInstance === event.targetInstance;
+  }
+}
+
+export default SummonOrderNormalizer;


### PR DESCRIPTION
Some pet summons instantly trigger a cast(demonic consumption for example), these events are pushed before the actual summon, so the normalizer created fabricated summons, as they were already present when the boss was pulled.
My change will remove that extra summons.

Here is how it looks currently: https://www.wowanalyzer.com/report/XnMK8R3wq1NTQd7Y/22-Heroic+Mekkatorque+-+Kill+(5:23)/Gwelican/pet-timeline