### PR TITLE
[Hunter] Unerring Vision

### DIFF
--- a/src/parser/hunter/marksmanship/CombatLogParser.js
+++ b/src/parser/hunter/marksmanship/CombatLogParser.js
@@ -43,6 +43,7 @@ import FocusTab from '../shared/modules/features/focuschart/FocusTab';
 //Azerite Traits
 import SteadyAim from './modules/spells/azeritetraits/SteadyAim';
 import InTheRhythm from './modules/spells/azeritetraits/InTheRhythm';
+import UnerringVision from './modules/spells/azeritetraits/UnerringVision';
 
 //Traits and Talents
 import SpellsAndTalents from './modules/features/SpellsAndTalents';
@@ -92,6 +93,7 @@ class CombatLogParser extends CoreCombatLogParser {
     //Azerite Traits
     steadyAim: SteadyAim,
     inTheRhythm: InTheRhythm,
+    unerringVision: UnerringVision,
 
     //Spells and Talents
     spellsAndTalents: SpellsAndTalents,

--- a/src/parser/hunter/marksmanship/modules/spells/Trueshot.js
+++ b/src/parser/hunter/marksmanship/modules/spells/Trueshot.js
@@ -12,8 +12,10 @@ import Abilities from 'parser/core/modules/Abilities';
 import SpellLink from 'common/SpellLink';
 
 /**
- * Immediately gain 1 charge of Aimed Shot, and gain 30% Haste for 15 sec.
+ * Reduces the cooldown of your Aimed Shot and Rapid Fire by 60%, and causes Aimed Shot to cast 50% faster for 15 sec.
  * Lasts 15 sec.
+ *
+ * TODO: Verify if this is still bugged so that it reduces the cooldown of Aimed Shot by equivalent to 325% haste and Rapid Fire by the equivalent to 340% haste.
  *
  * Example log: https://www.warcraftlogs.com/reports/v6nrtTxNKGDmYJXy#fight=16&type=auras&source=6
  */
@@ -26,7 +28,6 @@ class Trueshot extends Analyzer {
   trueshotCasts = 0;
   accumulatedFocusAtTSCast = 0;
   aimedShotsPrTS = 0;
-  wastedAimedShotCharges = 0;
   startFocusForCombatant = 0;
 
   on_byPlayer_cast(event) {
@@ -76,7 +77,6 @@ class Trueshot extends Analyzer {
             <ul>
               <li>You started your Trueshot windows with an average of {this.averageFocus} Focus.</li>
               <li>You hit an average of {this.averageAimedShots} Aimed Shots inside each Trueshot window. </li>
-              <li>You gained {this.trueshotCasts - this.wastedAimedShotCharges} charges of Aimed Shot and lost out on {this.wastedAimedShotCharges} charges by activating Trueshot whilst Aimed Shot wasn't on cooldown.</li>
             </ul>
           </>
         )}

--- a/src/parser/hunter/marksmanship/modules/spells/azeritetraits/InTheRhythm.js
+++ b/src/parser/hunter/marksmanship/modules/spells/azeritetraits/InTheRhythm.js
@@ -19,6 +19,12 @@ const inTheRhythmStats = traits => Object.values(traits).reduce((obj, rank) => {
 
 const DURATION = 8000;
 
+/** Rapid Fire
+ * When Rapid Fire finishes fully channeling, your Haste is increased by 623 for 8 sec.
+ *
+ * Example log: https://www.warcraftlogs.com/reports/47LJvZ9BgdhR8TXf#fight=43&type=summary&source=16
+ */
+
 class InTheRhythm extends Analyzer {
   static dependencies = {
     statTracker: StatTracker,

--- a/src/parser/hunter/marksmanship/modules/spells/azeritetraits/UnerringVision.js
+++ b/src/parser/hunter/marksmanship/modules/spells/azeritetraits/UnerringVision.js
@@ -20,6 +20,8 @@ const MAX_STACKS = 10;
 
 /** Unerring Vision
  * While Trueshot is active you gain 158 Critical Strike rating every sec, stacking up to 10 times.
+ *
+ * Example log: https://www.warcraftlogs.com/reports/47LJvZ9BgdhR8TXf#fight=43&type=summary&source=16
  */
 class UnerringVision extends Analyzer {
   static dependencies = {

--- a/src/parser/hunter/marksmanship/modules/spells/azeritetraits/UnerringVision.js
+++ b/src/parser/hunter/marksmanship/modules/spells/azeritetraits/UnerringVision.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import Analyzer from 'parser/core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import CriticalStrike from 'interface/icons/CriticalStrike';
+import AzeritePowerStatistic from 'interface/statistics/AzeritePowerStatistic';
+import { calculateAzeriteEffects } from 'common/stats';
+import StatTracker from 'parser/shared/modules/StatTracker';
+import { formatPercentage, formatNumber } from 'common/format';
+
+const unerringVisionStats = traits => Object.values(traits).reduce((obj, rank) => {
+  const [crit] = calculateAzeriteEffects(SPELLS.UNERRING_VISION.id, rank);
+  obj.crit += crit;
+  return obj;
+}, {
+  crit: 0,
+});
+
+const MAX_STACKS = 10;
+
+/** Unerring Vision
+ * While Trueshot is active you gain 158 Critical Strike rating every sec, stacking up to 10 times.
+ */
+class UnerringVision extends Analyzer {
+  static dependencies = {
+    statTracker: StatTracker,
+  };
+  crit = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrait(SPELLS.UNERRING_VISION.id);
+    if (!this.active) {
+      return;
+    }
+    const { crit } = unerringVisionStats(this.selectedCombatant.traitsBySpellId[SPELLS.UNERRING_VISION.id]);
+    this.crit = crit;
+
+    this.statTracker.add(SPELLS.UNERRING_VISION_BUFF.id, {
+      crit,
+    });
+  }
+
+  get uptime() {
+    return this.selectedCombatant.getStackWeightedBuffUptime(SPELLS.UNERRING_VISION_BUFF.id) / this.owner.fightDuration;
+  }
+
+  get avgCrit() {
+    return this.uptime * this.crit;
+  }
+
+  statistic() {
+    return (
+      <AzeritePowerStatistic
+        size="flexible"
+        tooltip={(
+          <>
+            Unerring Vision granted <strong>{this.crit}</strong> Crit for <strong>{formatPercentage(this.uptime)}%</strong> of the fight. <br />
+          </>
+        )}
+      >
+        <BoringSpellValueText spell={SPELLS.UNERRING_VISION}>
+          <CriticalStrike /> {formatNumber(this.avgCrit)}
+          <small> average Crit gained</small>
+          <br />
+          <CriticalStrike />
+          <small> up to</small>
+          {formatNumber(this.crit * MAX_STACKS)}
+          <small> Crit gained</small>
+        </BoringSpellValueText>
+      </AzeritePowerStatistic>
+    );
+  }
+
+}
+
+export default UnerringVision;

--- a/src/parser/hunter/marksmanship/modules/spells/azeritetraits/UnerringVision.js
+++ b/src/parser/hunter/marksmanship/modules/spells/azeritetraits/UnerringVision.js
@@ -6,7 +6,7 @@ import CriticalStrike from 'interface/icons/CriticalStrike';
 import AzeritePowerStatistic from 'interface/statistics/AzeritePowerStatistic';
 import { calculateAzeriteEffects } from 'common/stats';
 import StatTracker from 'parser/shared/modules/StatTracker';
-import { formatPercentage, formatNumber } from 'common/format';
+import { formatNumber } from 'common/format';
 
 const unerringVisionStats = traits => Object.values(traits).reduce((obj, rank) => {
   const [crit] = calculateAzeriteEffects(SPELLS.UNERRING_VISION.id, rank);
@@ -53,11 +53,6 @@ class UnerringVision extends Analyzer {
     return (
       <AzeritePowerStatistic
         size="flexible"
-        tooltip={(
-          <>
-            Unerring Vision granted <strong>{this.crit}</strong> Crit for <strong>{formatPercentage(this.uptime)}%</strong> of the fight. <br />
-          </>
-        )}
       >
         <BoringSpellValueText spell={SPELLS.UNERRING_VISION}>
           <CriticalStrike /> {formatNumber(this.avgCrit)}


### PR DESCRIPTION
Removes some old information from Trueshot and adds a continous TODO to it until Blizzard a) updates tooltip or b) fixes the buggy Trueshot cooldown reduction. 

Adds the Unerring Vision Azerite Trait: 
![image](https://user-images.githubusercontent.com/29204244/55028086-278c2580-5007-11e9-9d19-a4d225eec6a6.png)
Log: https://www.warcraftlogs.com/reports/47LJvZ9BgdhR8TXf#fight=43&type=summary&source=16