### PR TITLE
[Hunter] Add Surging Shots Azerite Trait

### DIFF
--- a/src/common/SPELLS/bfa/azeritetraits/hunter.js
+++ b/src/common/SPELLS/bfa/azeritetraits/hunter.js
@@ -43,6 +43,11 @@ export default {
   },
 
   //Marksmanship
+  SURGING_SHOTS: {
+    id: 287707,
+    name: 'Surging Shots',
+    icon: 'ability_hunter_snipershot',
+  },
   STEADY_AIM: {
     id: 277651,
     name: 'Steady Aim',
@@ -73,7 +78,6 @@ export default {
     name: 'Unerring Vision',
     icon: 'ability_trueshot',
   },
-
 
   //Survival
   WILDERNESS_SURVIVAL: {

--- a/src/parser/hunter/marksmanship/CHANGELOG.js
+++ b/src/parser/hunter/marksmanship/CHANGELOG.js
@@ -6,6 +6,11 @@ import SPELLS from 'common/SPELLS';
 
 export default [
   {
+    date: new Date('2019-03-26'),
+    changes: <> Implemented a module for <SpellLink id={SPELLS.SURGING_SHOTS.id} />, <SpellLink id={SPELLS.FOCUSED_FIRE.id} /> and <SpellLink id={SPELLS.UNERRING_VISION.id} />.</>,
+    contributors: [Putro],
+  },
+  {
     date: new Date('2019-03-20'),
     changes: <> Implemented a module for <SpellLink id={SPELLS.IN_THE_RHYTHM.id} />.</>,
     contributors: [Putro],

--- a/src/parser/hunter/marksmanship/CombatLogParser.js
+++ b/src/parser/hunter/marksmanship/CombatLogParser.js
@@ -4,6 +4,7 @@ import ArcaneTorrent from 'parser/shared/modules/racials/bloodelf/ArcaneTorrent'
 import GlobalCooldown from './modules/core/GlobalCooldown';
 import Channeling from './modules/features/Channeling';
 import Abilities from './modules/Abilities';
+import SpellUsable from './modules/core/SpellUsable';
 
 //Features
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
@@ -42,6 +43,7 @@ import FocusTab from '../shared/modules/features/focuschart/FocusTab';
 
 //Azerite Traits
 import SteadyAim from './modules/spells/azeritetraits/SteadyAim';
+import SurgingShots from './modules/spells/azeritetraits/SurgingShots';
 import InTheRhythm from './modules/spells/azeritetraits/InTheRhythm';
 
 //Traits and Talents
@@ -53,6 +55,7 @@ class CombatLogParser extends CoreCombatLogParser {
     abilities: Abilities,
     channeling: Channeling,
     globalCooldown: GlobalCooldown,
+    spellUsable: SpellUsable,
 
     // Features
     alwaysBeCasting: AlwaysBeCasting,
@@ -91,6 +94,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     //Azerite Traits
     steadyAim: SteadyAim,
+    surgingShots: SurgingShots,
     inTheRhythm: InTheRhythm,
 
     //Spells and Talents

--- a/src/parser/hunter/marksmanship/modules/core/SpellUsable.js
+++ b/src/parser/hunter/marksmanship/modules/core/SpellUsable.js
@@ -1,0 +1,39 @@
+import SPELLS from 'common/SPELLS';
+import CoreSpellUsable from 'parser/shared/modules/SpellUsable';
+
+class SpellUsable extends CoreSpellUsable {
+  static dependencies = {
+    ...CoreSpellUsable.dependencies,
+  };
+
+  lastPotentialTriggerForRapidFireReset = null;
+  rapidFireResets = 0;
+
+  on_byPlayer_cast(event) {
+    if (super.on_byPlayer_cast) {
+      super.on_byPlayer_cast(event);
+    }
+
+    const spellId = event.ability.guid;
+    if (this.selectedCombatant.hasTrait(SPELLS.SURGING_SHOTS.id)) {
+      if (spellId === SPELLS.AIMED_SHOT.id) {
+        this.lastPotentialTriggerForRapidFireReset = event;
+      } else if (spellId === SPELLS.RAPID_FIRE.id) {
+        this.lastPotentialTriggerForRapidFireReset = null;
+      }
+    }
+  }
+
+  beginCooldown(spellId, cooldownTriggerEvent) {
+    if (spellId === SPELLS.RAPID_FIRE.id && this.selectedCombatant.hasTrait(SPELLS.SURGING_SHOTS.id)) {
+      if (this.isOnCooldown(spellId)) {
+        this.rapidFireResets += 1;
+        this.endCooldown(spellId, undefined, this.lastPotentialTriggerForRapidFireReset ? this.lastPotentialTriggerForRapidFireReset.timestamp : undefined);
+      }
+    }
+
+    super.beginCooldown(spellId, cooldownTriggerEvent);
+  }
+}
+
+export default SpellUsable;

--- a/src/parser/hunter/marksmanship/modules/spells/azeritetraits/SurgingShots.js
+++ b/src/parser/hunter/marksmanship/modules/spells/azeritetraits/SurgingShots.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import Analyzer from 'parser/core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import AzeritePowerStatistic from 'interface/statistics/AzeritePowerStatistic';
+import { calculateAzeriteEffects } from 'common/stats';
+import { formatNumber } from 'common/format';
+import SpellLink from 'common/SpellLink';
+import SpellUsable from 'parser/hunter/marksmanship/modules/core/SpellUsable';
+
+const surgingShotsStats = traits => Object.values(traits).reduce((obj, rank) => {
+  const [damage] = calculateAzeriteEffects(SPELLS.SURGING_SHOTS.id, rank);
+  obj.damage += damage;
+  return obj;
+}, {
+  damage: 0,
+});
+
+const BASELINE_RF_TICKS = 10;
+const INITIAL_DAMAGE_MOD = 0.5;
+const RAMP_UP_MOD = 0.2;
+const debug = false;
+
+/** Surging Shots
+ * Rapid Fire damage is increased by up to 465 per shot fired, this damage starts lower and increases per shot of Rapid Fire.
+ * Aimed Shot has a 15% chance to reset the cooldown of Rapid Fire.
+ *
+ * TODO: Running TODO - verify that the tooltip is still 'wrong', and that the spell values are still hardcoded.
+ * It actually starts at 50% of the tooltip value, and then scales by 20% per tick and it doesn't scale beyond normal ticks.
+ * Spell Data will say a 415 piece increases damage by 356, tooltip will say 534. 356 is the value at the 5th tick.
+ * See more here: https://github.com/simulationcraft/simc/blob/bfa-dev/engine/class_modules/sc_hunter.cpp#L2724
+ *
+ */
+class SurgingShots extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+  };
+
+  initialDamage = 0;
+  damage = 0;
+  damagePotential = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrait(SPELLS.SURGING_SHOTS.id);
+    if (!this.active) {
+      return;
+    }
+    const { damage } = surgingShotsStats(this.selectedCombatant.traitsBySpellId[SPELLS.SURGING_SHOTS.id]);
+    this.damage = damage;
+    this.initialDamage = damage * INITIAL_DAMAGE_MOD;
+
+    for (let ticks = 1; ticks <= BASELINE_RF_TICKS; ticks++) {
+      this.damagePotential += this.initialDamage * (1 + (RAMP_UP_MOD * ticks));
+      debug && console.log('Tick number: ', ticks, ' and added damage: ', this.initialDamage * (1 + (RAMP_UP_MOD * ticks)));
+    }
+    debug && console.log('SuS damage potential: ', this.damagePotential);
+  }
+
+  statistic() {
+    return (
+      <AzeritePowerStatistic
+        size="flexible"
+      >
+        <BoringSpellValueText spell={SPELLS.SURGING_SHOTS}>
+          {this.spellUsable.rapidFireResets}
+          <small> resets</small>
+          <br />
+          <small>Up to</small>
+          {formatNumber(this.damagePotential)}
+          <small> damage per <SpellLink id={SPELLS.RAPID_FIRE.id} /></small>
+        </BoringSpellValueText>
+      </AzeritePowerStatistic>
+    );
+  }
+
+}
+
+export default SurgingShots;


### PR DESCRIPTION
Relies on #3087 because of moving Spell IDs around. 

![image](https://user-images.githubusercontent.com/29204244/55032601-8b1b5080-5011-11e9-8574-b8391650b187.png)

Log: https://www.warcraftlogs.com/reports/y4HQqGk37WF1M2Dc#fight=18&type=summary&source=24

Source on the bugginess of this trait: https://github.com/simulationcraft/simc/blob/bfa-dev/engine/class_modules/sc_hunter.cpp#L2724