### PR TITLE
[BrM] fixed mastery's value in the mit sheet

### DIFF
--- a/src/parser/monk/brewmaster/CHANGELOG.js
+++ b/src/parser/monk/brewmaster/CHANGELOG.js
@@ -8,6 +8,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2019-04-11'),
+    changes: <>Fixed a bug in the Mitigation Values tab that caused Mastery's base 8% to be counted towards contribution by Mastery Rating.</>,
+    contributors: [emallson],
+  },
+  {
     date: new Date('2019-03-10'),
     changes: <>Fixed a bug in the <SpellLink id={SPELLS.IRONSKIN_BREW.id} /> normalizer that led to a crash in the new timeline.</>,
     contributors: [Zerotorescue],

--- a/src/parser/monk/brewmaster/modules/features/MitigationSheet.js
+++ b/src/parser/monk/brewmaster/modules/features/MitigationSheet.js
@@ -99,7 +99,7 @@ export default class MitigationSheet extends Analyzer {
   _avgStats = {};
 
   get masteryDamageMitigated() {
-    return this.masteryValue.expectedMitigation;
+    return this.masteryValue.expectedMitigation - this.masteryValue.noMasteryExpectedMitigation;
   }
 
   get masteryHealing() {


### PR DESCRIPTION
I forgot to subtract off the value of the base 8% mastery provided by the passive itself. Since the value of mastery is not linear (it has slight DR since more mastery -> you get fewer stacks), this has a relatively large impact on the valuation.

Still better than everything else, but not quite as insane.

**Before**
![Screenshot from 2019-04-11 23-17-38](https://user-images.githubusercontent.com/4909458/56010041-0175af00-5cb0-11e9-8ad3-ce2fad989ff2.png)

**After**
![Screenshot from 2019-04-11 23-09-39](https://user-images.githubusercontent.com/4909458/56010023-f4f15680-5caf-11e9-851d-b241b4475cb8.png)
