### PR TITLE
[Core] Fix for Cancelled Casts in Timeline

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -8,6 +8,11 @@ import Contributor from 'interface/contributor/Button';
 
 export default [
   {
+    date: new Date('2019-04-20'),
+    changes: <>Fixed issue for mages where the timeline would show a cast as cancelled if they cast an ability that could be cast while casting (e.g. <SpellLink id={SPELLS.SHIMMER_TALENT.id} /> or <SpellLink id={SPELLS.FIRE_BLAST.id} />).</>,
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2019-03-30'),
     changes: 'Fixed issue where the character parses page didn\'t return any results when region wasn\'t capitalized.',
     contributors: [Zerotorescue],

--- a/src/parser/core/CASTABLE_WHILE_CASTING_SPELLS.js
+++ b/src/parser/core/CASTABLE_WHILE_CASTING_SPELLS.js
@@ -1,0 +1,13 @@
+import SPELLS from 'common/SPELLS';
+
+export default [
+  /**
+   * This consists of spells that are able to be cast while casting. This is
+   * primarily used to ignore the below spells when determining whether a 
+   * spell cast was cancelled since these do not interrupt casting.
+   */
+  SPELLS.FIRE_BLAST.id,
+  SPELLS.SHIMMER_TALENT.id,
+  SPELLS.ICE_FLOES_TALENT.id,
+  SPELLS.COMBUSTION.id,
+];

--- a/src/parser/shared/normalizers/CancelledCasts.js
+++ b/src/parser/shared/normalizers/CancelledCasts.js
@@ -1,5 +1,6 @@
 import EventsNormalizer from 'parser/core/EventsNormalizer';
 import CASTS_THAT_ARENT_CASTS from 'parser/core/CASTS_THAT_ARENT_CASTS';
+import CASTABLE_WHILE_CASTING_SPELLS from 'parser/core/CASTABLE_WHILE_CASTING_SPELLS';
 
 /**
  * During analysis there's no way to know at a `begincast` event if it will end up being canceled. This marks all `begincast` events by the player with an `isCancelled` property whether it was cancelled.
@@ -30,7 +31,7 @@ class CancelledCasts extends EventsNormalizer {
     if (!this.isCasting) {
       return;
     }
-    if (CASTS_THAT_ARENT_CASTS.includes(event.ability.guid)) {
+    if (CASTS_THAT_ARENT_CASTS.includes(event.ability.guid) || CASTABLE_WHILE_CASTING_SPELLS.includes(event.ability.guid)) {
       return;
     }
 


### PR DESCRIPTION
There was a bug with the timeline where it would show a spell as cancelled if the player cast an ability that is castable while casting (Such as Shimmer, Fire Blast, Ice Floes, or Combustion). These spells do not interrupt spell casting and should not trigger marking an ability as cancelled.

Maybe there is a better way to resolve this, but i saw the CASTS_THAT_ARE_NOT_CASTS thing and just decided to replicate that since it was the easiest way to fix it.