### PR TITLE
[Assa Rogue] Check for early refresh of dots.

### DIFF
--- a/src/parser/druid/balance/modules/features/EarlyDotRefreshes.js
+++ b/src/parser/druid/balance/modules/features/EarlyDotRefreshes.js
@@ -25,11 +25,11 @@ class EarlyDotRefreshes extends EarlyDotRefreshesCore {
   }
 
   get suggestionThresholdsStellarFlareEfficiency() {
-    return this.makeEfficiencyThresholds(SPELLS.STELLAR_FLARE_TALENT,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
+    return this.makeSuggestionThresholds(SPELLS.STELLAR_FLARE_TALENT,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
   }
 
   suggestions(when) {
-    suggest(when, this.makeSuggestionThresholds(SPELLS.STELLAR_FLARE_TALENT,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD));
+    suggest(when, this.suggestionThresholdsStellarFlareEfficiency);
   }
 }
 

--- a/src/parser/druid/balance/modules/features/EarlyDotRefreshes.js
+++ b/src/parser/druid/balance/modules/features/EarlyDotRefreshes.js
@@ -24,35 +24,12 @@ class EarlyDotRefreshes extends EarlyDotRefreshesCore {
     this.active = this.selectedCombatant.hasTalent(SPELLS.STELLAR_FLARE_TALENT.id);
   }
 
-  get suggestionThresholdsStellarFlare() {
-    return {
-      spell: SPELLS.STELLAR_FLARE_TALENT,
-      count: this.badCasts[DOTS[0].castId],
-      actual: this.badCastsPercent(DOTS[0].castId),
-      isGreaterThan: {
-        minor: 1 - MINOR_THRESHOLD,
-        average: 1 - AVERAGE_THRESHOLD,
-        major: 1 - MAJOR_THRESHOLD,
-      },
-      style: 'percentage',
-    };
-  }
-
   get suggestionThresholdsStellarFlareEfficiency() {
-    return {
-      spell: SPELLS.STELLAR_FLARE_TALENT,
-      actual: 1 - this.badCastsPercent(DOTS[0].castId),
-      isLessThan: {
-        minor: MINOR_THRESHOLD,
-        average: AVERAGE_THRESHOLD,
-        major: MAJOR_THRESHOLD,
-      },
-      style: 'percentage',
-    };
+    return this.makeEfficiencyThresholds(SPELLS.STELLAR_FLARE_TALENT,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
   }
 
   suggestions(when) {
-    suggest(when, this.suggestionThresholdsStellarFlare);
+    suggest(when, this.makeSuggestionThresholds(SPELLS.STELLAR_FLARE_TALENT,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD));
   }
 }
 

--- a/src/parser/druid/balance/modules/features/EarlyDotRefreshes.js
+++ b/src/parser/druid/balance/modules/features/EarlyDotRefreshes.js
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS';
 
 import EarlyDotRefreshesCore from 'parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes';
-import suggest from 'parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesSuggestion';
+import suggest from 'parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesSuggestionByCount';
 
 const DOTS = [
   {

--- a/src/parser/druid/balance/modules/features/EarlyDotRefreshes.js
+++ b/src/parser/druid/balance/modules/features/EarlyDotRefreshes.js
@@ -24,12 +24,35 @@ class EarlyDotRefreshes extends EarlyDotRefreshesCore {
     this.active = this.selectedCombatant.hasTalent(SPELLS.STELLAR_FLARE_TALENT.id);
   }
 
+  get suggestionThresholdsStellarFlare() {
+    return {
+      spell: SPELLS.STELLAR_FLARE_TALENT,
+      count: this.casts[DOTS[0].castId].badCasts,
+      actual: this.badCastsPercent(DOTS[0].castId),
+      isGreaterThan: {
+        minor: 1 - MINOR_THRESHOLD,
+        average: 1 - AVERAGE_THRESHOLD,
+        major: 1 - MAJOR_THRESHOLD,
+      },
+      style: 'percentage',
+    };
+  }
+
   get suggestionThresholdsStellarFlareEfficiency() {
-    return this.makeSuggestionThresholds(SPELLS.STELLAR_FLARE_TALENT,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
+    return {
+      spell: SPELLS.STELLAR_FLARE_TALENT,
+      actual: 1 - this.badCastsPercent(DOTS[0].castId),
+      isLessThan: {
+        minor: MINOR_THRESHOLD,
+        average: AVERAGE_THRESHOLD,
+        major: MAJOR_THRESHOLD,
+      },
+      style: 'percentage',
+    };
   }
 
   suggestions(when) {
-    suggest(when, this.suggestionThresholdsStellarFlareEfficiency);
+    suggest(when, this.suggestionThresholdsStellarFlare);
   }
 }
 

--- a/src/parser/druid/balance/modules/features/EarlyDotRefreshesInstants.js
+++ b/src/parser/druid/balance/modules/features/EarlyDotRefreshesInstants.js
@@ -46,12 +46,12 @@ class EarlyDotRefreshesInstants extends CoreEarlyDotRefreshesInstants {
   }
 
   get suggestionThresholdsSunfireEfficiency() {
-    return this.makeEfficiencyThresholds(SPELLS.SUNFIRE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
+    return this.makeEfficiencyThresholds(SPELLS.SUNFIRE_CAST,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
   }
 
   suggestions(when) {
     suggest(when, this.makeSuggestionThresholds(SPELLS.MOONFIRE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD));
-    suggest(when, this.makeSuggestionThresholds(SPELLS.SUNFIRE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD));
+    suggest(when, this.makeSuggestionThresholds(SPELLS.SUNFIRE_CAST,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD));
   }
 }
 

--- a/src/parser/druid/balance/modules/features/EarlyDotRefreshesInstants.js
+++ b/src/parser/druid/balance/modules/features/EarlyDotRefreshesInstants.js
@@ -41,63 +41,17 @@ class EarlyDotRefreshesInstants extends CoreEarlyDotRefreshesInstants {
     return false;
   }
 
-  get suggestionThresholdsMoonfire() {
-    return {
-      spell: SPELLS.MOONFIRE_BEAR,
-      count: this.badCasts[DOTS[0].castId],
-      actual: this.badCastsPercent(DOTS[0].castId),
-      isGreaterThan: {
-        minor: 1 - MINOR_THRESHOLD,
-        average: 1 - AVERAGE_THRESHOLD,
-        major: 1 - MAJOR_THRESHOLD,
-      },
-      style: 'percentage',
-    };
-  }
-
-  get suggestionThresholdsSunfire() {
-    return {
-      spell: SPELLS.SUNFIRE,
-      count: this.badCasts[DOTS[1].castId],
-      actual: this.badCastsPercent(DOTS[1].castId),
-      isGreaterThan: {
-        minor: 1 - MINOR_THRESHOLD,
-        average: 1 - AVERAGE_THRESHOLD,
-        major: 1 - MAJOR_THRESHOLD,
-      },
-      style: 'percentage',
-    };
-  }
-
   get suggestionThresholdsMoonfireEfficiency() {
-    return {
-      spell: SPELLS.MOONFIRE_BEAR,
-      actual: 1 - this.badCastsPercent(DOTS[0].castId),
-      isLessThan: {
-        minor: MINOR_THRESHOLD,
-        average: AVERAGE_THRESHOLD,
-        major: MAJOR_THRESHOLD,
-      },
-      style: 'percentage',
-    };
+    return this.makeEfficiencyThresholds(SPELLS.MOONFIRE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
   }
 
   get suggestionThresholdsSunfireEfficiency() {
-    return {
-      spell: SPELLS.SUNFIRE,
-      actual: 1 - this.badCastsPercent(DOTS[1].castId),
-      isLessThan: {
-        minor: MINOR_THRESHOLD,
-        average: AVERAGE_THRESHOLD,
-        major: MAJOR_THRESHOLD,
-      },
-      style: 'percentage',
-    };
+    return this.makeEfficiencyThresholds(SPELLS.SUNFIRE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
   }
 
   suggestions(when) {
-    suggest(when, this.suggestionThresholdsMoonfire);
-    suggest(when, this.suggestionThresholdsSunfire);
+    suggest(when, this.makeSuggestionThresholds(SPELLS.MOONFIRE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD));
+    suggest(when, this.makeSuggestionThresholds(SPELLS.SUNFIRE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD));
   }
 }
 

--- a/src/parser/druid/balance/modules/features/EarlyDotRefreshesInstants.js
+++ b/src/parser/druid/balance/modules/features/EarlyDotRefreshesInstants.js
@@ -41,17 +41,63 @@ class EarlyDotRefreshesInstants extends CoreEarlyDotRefreshesInstants {
     return false;
   }
 
+  get suggestionThresholdsMoonfire() {
+    return {
+      spell: SPELLS.MOONFIRE_BEAR,
+      count: this.casts[DOTS[0].castId].badCasts,
+      actual: this.badCastsPercent(DOTS[0].castId),
+      isGreaterThan: {
+        minor: 1 - MINOR_THRESHOLD,
+        average: 1 - AVERAGE_THRESHOLD,
+        major: 1 - MAJOR_THRESHOLD,
+      },
+      style: 'percentage',
+    };
+  }
+
+  get suggestionThresholdsSunfire() {
+    return {
+      spell: SPELLS.SUNFIRE,
+      count: this.casts[DOTS[1].castId].badCasts,
+      actual: this.badCastsPercent(DOTS[1].castId),
+      isGreaterThan: {
+        minor: 1 - MINOR_THRESHOLD,
+        average: 1 - AVERAGE_THRESHOLD,
+        major: 1 - MAJOR_THRESHOLD,
+      },
+      style: 'percentage',
+    };
+  }
+
   get suggestionThresholdsMoonfireEfficiency() {
-    return this.makeSuggestionThresholds(SPELLS.MOONFIRE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
+    return {
+      spell: SPELLS.MOONFIRE_BEAR,
+      actual: 1 - this.badCastsPercent(DOTS[0].castId),
+      isLessThan: {
+        minor: MINOR_THRESHOLD,
+        average: AVERAGE_THRESHOLD,
+        major: MAJOR_THRESHOLD,
+      },
+      style: 'percentage',
+    };
   }
 
   get suggestionThresholdsSunfireEfficiency() {
-    return this.makeSuggestionThresholds(SPELLS.SUNFIRE_CAST,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
+    return {
+      spell: SPELLS.SUNFIRE,
+      actual: 1 - this.badCastsPercent(DOTS[1].castId),
+      isLessThan: {
+        minor: MINOR_THRESHOLD,
+        average: AVERAGE_THRESHOLD,
+        major: MAJOR_THRESHOLD,
+      },
+      style: 'percentage',
+    };
   }
 
   suggestions(when) {
-    suggest(when, this.suggestionThresholdsMoonfireEfficiency);
-    suggest(when, this.suggestionThresholdsSunfireEfficiency);
+    suggest(when, this.suggestionThresholdsMoonfire);
+    suggest(when, this.suggestionThresholdsSunfire);
   }
 }
 

--- a/src/parser/druid/balance/modules/features/EarlyDotRefreshesInstants.js
+++ b/src/parser/druid/balance/modules/features/EarlyDotRefreshesInstants.js
@@ -42,16 +42,16 @@ class EarlyDotRefreshesInstants extends CoreEarlyDotRefreshesInstants {
   }
 
   get suggestionThresholdsMoonfireEfficiency() {
-    return this.makeEfficiencyThresholds(SPELLS.MOONFIRE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
+    return this.makeSuggestionThresholds(SPELLS.MOONFIRE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
   }
 
   get suggestionThresholdsSunfireEfficiency() {
-    return this.makeEfficiencyThresholds(SPELLS.SUNFIRE_CAST,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
+    return this.makeSuggestionThresholds(SPELLS.SUNFIRE_CAST,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
   }
 
   suggestions(when) {
-    suggest(when, this.makeSuggestionThresholds(SPELLS.MOONFIRE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD));
-    suggest(when, this.makeSuggestionThresholds(SPELLS.SUNFIRE_CAST,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD));
+    suggest(when, this.suggestionThresholdsMoonfireEfficiency);
+    suggest(when, this.suggestionThresholdsSunfireEfficiency);
   }
 }
 

--- a/src/parser/rogue/assassination/CHANGELOG.js
+++ b/src/parser/rogue/assassination/CHANGELOG.js
@@ -7,6 +7,11 @@ import { tsabo, Cloake, Zerotorescue, Gebuz, Aelexe } from 'CONTRIBUTORS';
 
 export default [
   {
+    date: new Date('2019-04-22'),
+    changes: <>Early dot refresh tracking</>,
+    contributors: [tsabo],
+  },
+  {
     date: new Date('2018-11-20'),
     changes: <>Added Bleed snapshot tracking and support for <SpellLink id={SPELLS.NIGHTSTALKER_TALENT.id} />, <SpellLink id={SPELLS.SUBTERFUGE_TALENT.id} /> and <SpellLink id={SPELLS.MASTER_ASSASSIN_TALENT.id} />.</>,
     contributors: [Gebuz],

--- a/src/parser/rogue/assassination/CombatLogParser.js
+++ b/src/parser/rogue/assassination/CombatLogParser.js
@@ -25,6 +25,7 @@ import SpellEnergyCost from '../shared/resources/SpellEnergyCost';
 import EnvenomUptime from './modules/spells/EnvenomUptime';
 import GarroteUptime from './modules/spells/GarroteUptime';
 import RuptureUptime from './modules/spells/RuptureUptime';
+import EarlyDotRefresh from './modules/spells/EarlyDotRefresh';
 
 import GarroteSnapshot from './modules/features/GarroteSnapshot';
 import RuptureSnapshot from './modules/features/RuptureSnapshot';
@@ -70,6 +71,7 @@ class CombatLogParser extends CoreCombatLogParser {
     envenomUptime: EnvenomUptime,
     garroteUptime: GarroteUptime,
     ruptureUptime: RuptureUptime,
+    earlyDotRefresh: EarlyDotRefresh,
 
     garroteSnapshot: GarroteSnapshot,
     ruptureSnapshot: RuptureSnapshot,

--- a/src/parser/rogue/assassination/modules/features/Checklist/Component.js
+++ b/src/parser/rogue/assassination/modules/features/Checklist/Component.js
@@ -54,7 +54,7 @@ class AssassinationRogueChecklist extends React.PureComponent {
           <Requirement
             name={(
               <>
-                <SpellLink id={SPELLS.GARROTE.id} /> refreshed early
+                <SpellLink id={SPELLS.GARROTE.id} /> effective refresh duration
               </>
             )}
             thresholds={thresholds.garroteEfficiency}
@@ -62,7 +62,7 @@ class AssassinationRogueChecklist extends React.PureComponent {
           <Requirement
             name={(
               <>
-                <SpellLink id={SPELLS.RUPTURE.id} /> refreshed early
+                <SpellLink id={SPELLS.RUPTURE.id} /> effective refresh duration
               </>
             )}
             thresholds={thresholds.ruptureEfficiency}

--- a/src/parser/rogue/assassination/modules/features/Checklist/Component.js
+++ b/src/parser/rogue/assassination/modules/features/Checklist/Component.js
@@ -33,7 +33,7 @@ class AssassinationRogueChecklist extends React.PureComponent {
       <Checklist>
         <Rule
           name="Maintain your DoTs on the boss"
-          description="DoTs are a big part of your damage. You should try to keep as high uptime on them as possible."
+          description="DoTs are a big part of your damage. You should try to keep as high uptime on them as possible, but do not refresh them too early"
         >
           <Requirement
             name={(

--- a/src/parser/rogue/assassination/modules/features/Checklist/Component.js
+++ b/src/parser/rogue/assassination/modules/features/Checklist/Component.js
@@ -51,6 +51,22 @@ class AssassinationRogueChecklist extends React.PureComponent {
             )}
             thresholds={thresholds.ruptureUptime}
           />
+          <Requirement
+            name={(
+              <>
+                <SpellLink id={SPELLS.GARROTE.id} /> refreshed early
+              </>
+            )}
+            thresholds={thresholds.garroteEfficiency}
+          />
+          <Requirement
+            name={(
+              <>
+                <SpellLink id={SPELLS.RUPTURE.id} /> refreshed early
+              </>
+            )}
+            thresholds={thresholds.ruptureEfficiency}
+          />
         </Rule>
         <Rule
           name="Do not overcap your resources"

--- a/src/parser/rogue/assassination/modules/features/Checklist/Module.js
+++ b/src/parser/rogue/assassination/modules/features/Checklist/Module.js
@@ -7,6 +7,8 @@ import PreparationRuleAnalyzer from 'parser/shared/modules/features/Checklist/Pr
 
 import GarroteUptime from '../../spells/GarroteUptime';
 import RuptureUptime from '../../spells/RuptureUptime';
+import EarlyDotRefresh from '../../spells/EarlyDotRefresh';
+
 
 import Blindside from '../../talents/Blindside';
 
@@ -30,6 +32,7 @@ class Checklist extends BaseChecklist {
 
     garroteUptime: GarroteUptime,
     ruptureUptime: RuptureUptime,
+    earlyDotRefresh: EarlyDotRefresh,
 
     blindside: Blindside,
 
@@ -54,6 +57,8 @@ class Checklist extends BaseChecklist {
 
           garroteUptime: this.garroteUptime.suggestionThresholds,
           ruptureUptime: this.ruptureUptime.suggestionThresholds,
+          garroteEfficiency: this.earlyDotRefresh.suggestionThresholdsGarroteEfficiency,
+          ruptureEfficiency: this.earlyDotRefresh.suggestionThresholdsRuptureEfficiency,
 
           blindsideEfficiency: this.blindside.suggestionThresholds,
 

--- a/src/parser/rogue/assassination/modules/spells/EarlyDotRefresh.js
+++ b/src/parser/rogue/assassination/modules/spells/EarlyDotRefresh.js
@@ -34,6 +34,14 @@ class EarlyDotRefresh extends EarlyDotRefreshesCore {
     //Update duration.
     this.getDot(SPELLS.RUPTURE.id).duration = (comboPointsSpent * 4 + 4) * 1000;
   }
+  
+  // Checks the status of the last cast and marks it accordingly.
+  getLastBadCastText(event, dot) {    
+    if (dot.castId === SPELLS.RUPTURE.id) {
+      return super.getLastBadCastText(event,dot) + " *Based on the amount of CPs spent.";
+    }
+    return super.getLastBadCastText(event,dot);
+  }
 
   get suggestionThresholdsRuptureEfficiency() {
     return this.makeSuggestionThresholds(SPELLS.RUPTURE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);

--- a/src/parser/rogue/assassination/modules/spells/EarlyDotRefresh.js
+++ b/src/parser/rogue/assassination/modules/spells/EarlyDotRefresh.js
@@ -5,9 +5,9 @@ import EarlyDotRefreshesCore from 'parser/shared/modules/earlydotrefreshes/Early
 import suggest from 'parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesSuggestion';
 
 
-const MINOR_THRESHOLD = 0.95;
-const AVERAGE_THRESHOLD = 0.9;
-const MAJOR_THRESHOLD = 0.85;
+const MINOR_THRESHOLD = 0.975;
+const AVERAGE_THRESHOLD = 0.95;
+const MAJOR_THRESHOLD = 0.9;
 
 class EarlyDotRefresh extends EarlyDotRefreshesCore {
   static dots = [

--- a/src/parser/rogue/assassination/modules/spells/EarlyDotRefresh.js
+++ b/src/parser/rogue/assassination/modules/spells/EarlyDotRefresh.js
@@ -7,7 +7,7 @@ import suggest from 'parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesSu
 
 const MINOR_THRESHOLD = 0.95;
 const AVERAGE_THRESHOLD = 0.9;
-const MAJOR_THRESHOLD = 0.7;
+const MAJOR_THRESHOLD = 0.85;
 
 class EarlyDotRefresh extends EarlyDotRefreshesCore {
   static dots = [

--- a/src/parser/rogue/assassination/modules/spells/EarlyDotRefresh.js
+++ b/src/parser/rogue/assassination/modules/spells/EarlyDotRefresh.js
@@ -1,0 +1,51 @@
+import SPELLS from 'common/SPELLS';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+
+import EarlyDotRefreshesCore from 'parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes';
+import suggest from 'parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesSuggestion';
+
+
+const MINOR_THRESHOLD = 0.95;
+const AVERAGE_THRESHOLD = 0.9;
+const MAJOR_THRESHOLD = 0.7;
+
+class EarlyDotRefresh extends EarlyDotRefreshesCore {
+  static dots = [
+    {
+      name: 'Rupture',
+      debuffId: SPELLS.RUPTURE.id,
+      castId: SPELLS.RUPTURE.id,
+      duration: 20000,
+    },
+    {
+      name: 'Garrote',
+      debuffId: SPELLS.GARROTE.id,
+      castId: SPELLS.GARROTE.id,
+      duration: 18000,
+    },
+  ];
+
+  on_byPlayer_spendresource(event) {
+    const comboPointsSpent = event.resourceChange;
+    if (event.resourceChangeType !== RESOURCE_TYPES.COMBO_POINTS.id) {
+      return;
+    }
+
+    //Update duration.
+    this.getDot(SPELLS.RUPTURE.id).duration = (comboPointsSpent * 4 + 4) * 1000;
+  }
+
+  get suggestionThresholdsRuptureEfficiency() {
+    return this.makeEfficiencyThresholds(SPELLS.RUPTURE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
+  }
+  get suggestionThresholdsGarroteEfficiency() {
+    return this.makeEfficiencyThresholds(SPELLS.GARROTE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
+  }
+
+  suggestions(when) {
+    suggest(when, this.makeSuggestionThresholds(SPELLS.RUPTURE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD));
+    suggest(when, this.makeSuggestionThresholds(SPELLS.GARROTE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD));
+  }
+}
+
+export default EarlyDotRefresh;

--- a/src/parser/rogue/assassination/modules/spells/EarlyDotRefresh.js
+++ b/src/parser/rogue/assassination/modules/spells/EarlyDotRefresh.js
@@ -36,15 +36,15 @@ class EarlyDotRefresh extends EarlyDotRefreshesCore {
   }
 
   get suggestionThresholdsRuptureEfficiency() {
-    return this.makeEfficiencyThresholds(SPELLS.RUPTURE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
+    return this.makeSuggestionThresholds(SPELLS.RUPTURE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
   }
   get suggestionThresholdsGarroteEfficiency() {
-    return this.makeEfficiencyThresholds(SPELLS.GARROTE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
+    return this.makeSuggestionThresholds(SPELLS.GARROTE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
   }
 
   suggestions(when) {
-    suggest(when, this.makeSuggestionThresholds(SPELLS.RUPTURE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD));
-    suggest(when, this.makeSuggestionThresholds(SPELLS.GARROTE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD));
+    suggest(when, this.suggestionThresholdsRuptureEfficiency);
+    suggest(when, this.suggestionThresholdsGarroteEfficiency);
   }
 }
 

--- a/src/parser/rogue/subtlety/modules/core/NightbladeEarlyRefresh.js
+++ b/src/parser/rogue/subtlety/modules/core/NightbladeEarlyRefresh.js
@@ -71,11 +71,11 @@ class NightbladeEarlyRefresh extends EarlyDotRefreshesCore {
   }
 
   get suggestionThresholdsNightbladeEfficiency() {
-    return this.makeEfficiencyThresholds(SPELLS.NIGHTBLADE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
+    return this.makeSuggestionThresholds(SPELLS.NIGHTBLADE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
   }
 
   suggestions(when) {
-    suggest(when, this.makeSuggestionThresholds(SPELLS.NIGHTBLADE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD));
+    suggest(when, this.suggestionThresholdsNightbladeEfficiency);
   }
 }
 

--- a/src/parser/rogue/subtlety/modules/core/NightbladeEarlyRefresh.js
+++ b/src/parser/rogue/subtlety/modules/core/NightbladeEarlyRefresh.js
@@ -54,7 +54,7 @@ class NightbladeEarlyRefresh extends EarlyDotRefreshesCore {
       return '';
     }
     return super.getLastBadCastText(event,dot);
-    }
+  }
 
   on_byPlayer_spendresource(event) {
     const comboPointsSpent = event.resourceChange;
@@ -70,35 +70,12 @@ class NightbladeEarlyRefresh extends EarlyDotRefreshesCore {
     return this.nextDuration;
   }
 
-  get suggestionThresholdsNightblade() {
-    return {
-      spell: SPELLS.NIGHTBLADE,
-      count: this.badCasts[SPELLS.NIGHTBLADE.id],
-      actual: this.badCastsPercent(SPELLS.NIGHTBLADE.id),
-      isGreaterThan: {
-        minor: 1 - MINOR_THRESHOLD,
-        average: 1 - AVERAGE_THRESHOLD,
-        major: 1 - MAJOR_THRESHOLD,
-      },
-      style: 'percentage',
-    };
-  }
-
   get suggestionThresholdsNightbladeEfficiency() {
-    return {
-      spell: SPELLS.NIGHTBLADE,
-      actual: 1 - this.badCastsPercent(SPELLS.NIGHTBLADE.id),
-      isLessThan: {
-        minor: MINOR_THRESHOLD,
-        average: AVERAGE_THRESHOLD,
-        major: MAJOR_THRESHOLD,
-      },
-      style: 'percentage',
-    };
+    return this.makeEfficiencyThresholds(SPELLS.NIGHTBLADE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD);
   }
 
   suggestions(when) {
-    suggest(when, this.suggestionThresholdsNightblade);
+    suggest(when, this.makeSuggestionThresholds(SPELLS.NIGHTBLADE,MINOR_THRESHOLD,AVERAGE_THRESHOLD,MAJOR_THRESHOLD));
   }
 }
 

--- a/src/parser/rogue/subtlety/modules/core/NightbladeEarlyRefresh.js
+++ b/src/parser/rogue/subtlety/modules/core/NightbladeEarlyRefresh.js
@@ -7,9 +7,9 @@ import SpellUsable from 'parser/shared/modules/SpellUsable';
 
 
 const MAX_SYMBOLS_COOLDOWN = 5000;
-const MINOR_THRESHOLD = 0.95;
-const AVERAGE_THRESHOLD = 0.9;
-const MAJOR_THRESHOLD = 0.85;
+const MINOR_THRESHOLD = 0.975;
+const AVERAGE_THRESHOLD = 0.95;
+const MAJOR_THRESHOLD = 0.9;
 
 class NightbladeEarlyRefresh extends EarlyDotRefreshesCore {
   static dependencies = {

--- a/src/parser/rogue/subtlety/modules/core/NightbladeEarlyRefresh.js
+++ b/src/parser/rogue/subtlety/modules/core/NightbladeEarlyRefresh.js
@@ -9,7 +9,7 @@ import SpellUsable from 'parser/shared/modules/SpellUsable';
 const MAX_SYMBOLS_COOLDOWN = 5000;
 const MINOR_THRESHOLD = 0.95;
 const AVERAGE_THRESHOLD = 0.9;
-const MAJOR_THRESHOLD = 0.7;
+const MAJOR_THRESHOLD = 0.85;
 
 class NightbladeEarlyRefresh extends EarlyDotRefreshesCore {
   static dependencies = {

--- a/src/parser/rogue/subtlety/modules/features/checklist/Component.js
+++ b/src/parser/rogue/subtlety/modules/features/checklist/Component.js
@@ -108,7 +108,7 @@ class SubRogueChecklist extends React.PureComponent {
           <Requirement
             name={(
               <>
-                <SpellLink id={SPELLS.NIGHTBLADE.id} /> refreshed early
+                <SpellLink id={SPELLS.NIGHTBLADE.id} /> effective refresh duration
               </>
             )}
             thresholds={thresholds.nightbladeEarlyRefresh}

--- a/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes.js
+++ b/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes.js
@@ -120,7 +120,7 @@ class EarlyDotRefreshes extends Analyzer {
   }
   
   get lastCastBuffer() {
-    return this.lastGCD.duration * 2 - BUFFER_MS
+    return this.lastGCD.duration * 2 - BUFFER_MS;
   } 
 
   // Checks the status of the last cast and marks it accordingly.

--- a/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes.js
+++ b/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes.js
@@ -150,6 +150,33 @@ class EarlyDotRefreshes extends Analyzer {
     const ability = this.abilityTracker.getAbility(spellId);
     return this.badCasts[spellId] / ability.casts || 0;
   }
+
+  makeSuggestionThresholds(spell, minor, avg, major) {
+    return {
+      spell: spell,
+      count: this.badCasts[spell.id],
+      actual: this.badCastsPercent(spell.id),
+      isGreaterThan: {
+        minor: 1 - minor,
+        average: 1 - avg,
+        major: 1 - major,
+      },
+      style: 'percentage',
+    };
+  }
+
+  makeEfficiencyThresholds(spell, minor, avg, major) {
+    return {
+      spell: spell,
+      actual: 1 - this.badCastsPercent(spell.id),
+      isLessThan: {
+        minor: minor,
+        average: avg,
+        major: major,
+      },
+      style: 'percentage',
+    };
+  }
 }
 
 export default EarlyDotRefreshes;

--- a/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes.js
+++ b/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes.js
@@ -137,7 +137,7 @@ class EarlyDotRefreshes extends Analyzer {
 
   // Get the suggestion for last bad cast. If empty, cast will be considered good.
   getLastBadCastText(event, dot) {
-    return `${dot.name} was refreshed ${formatDuration(this.lastCastMinWaste/1000)} seconds before the pandemic window.`;
+    return `${dot.name} was refreshed ${formatDuration(this.lastCastMinWaste/1000)} seconds before the pandemic window. It should be refreshed with at most ${formatDuration(PANDEMIC_WINDOW * dot.duration/1000)} left or part of the dot will be wasted.`;
   }
 
   //Returns the dot object
@@ -166,7 +166,7 @@ class EarlyDotRefreshes extends Analyzer {
     const newDuration = remainingDuration + extension;
     const maxDuration = (1 + PANDEMIC_WINDOW) * dot.duration;
     const lostDuration = maxDuration - newDuration;
-    if (lostDuration < 0) { //full extension
+    if (lostDuration <= 0) { //full extension
       this.targets[dot.debuffId][targetID] = timestamp + newDuration;
       return {wasted: 0, effective: extension};
     } // Else not full extension

--- a/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes.js
+++ b/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes.js
@@ -137,7 +137,7 @@ class EarlyDotRefreshes extends Analyzer {
 
   // Get the suggestion for last bad cast. If empty, cast will be considered good.
   getLastBadCastText(event, dot) {
-    return `${dot.name} was refreshed ${formatDuration(this.lastCastMinWaste/1000)} seconds early.`;
+    return `${dot.name} was refreshed ${formatDuration(this.lastCastMinWaste/1000)} seconds before the pandemic window.`;
   }
 
   //Returns the dot object

--- a/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes.js
+++ b/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes.js
@@ -174,6 +174,11 @@ class EarlyDotRefreshes extends Analyzer {
     return {wasted: lostDuration, effective: extension - lostDuration};
   }
 
+  badCastsPercent(spellId) {
+    const ability = this.abilityTracker.getAbility(spellId);
+    return this.casts[spellId].badCasts / ability.casts || 0;
+  }
+
   badCastsEffectivePercent(spellId) {
     if(!this.casts[spellId].addedDuration) return 1;
     return this.casts[spellId].addedDuration / (this.casts[spellId].addedDuration+this.casts[spellId].wastedDuration);

--- a/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesInstants.js
+++ b/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesInstants.js
@@ -21,21 +21,10 @@ class EarlyDotRefreshesInstants extends EarlyDotRefreshes {
     ...EarlyDotRefreshes.dependencies,
     distanceMoved: DistanceMoved,
   };
-
-  // Determines whether the last cast should be checked or not.
-  checkLastCast(event) {
-    if (!this.lastGCD || !this.lastCast) {
-      return;
-    }
-    // Since we don't have events for end of GCDs, we check on the first event after roughly a gcd has pasted.
-    const timeSinceCast = event.timestamp - this.lastGCD.timestamp;
-    if (timeSinceCast < this.lastGCD.duration - BUFFER_MS) {
-      return;
-    }
-    this.isLastCastBad(event);
-    this.lastGCD = null;
-    this.lastCast = null;
-  }
+  
+  get lastCastBuffer() {
+    return this.lastGCD.duration - BUFFER_MS;
+  } 
 
   // Checks the status of the last cast and marks it accordingly.
   getLastBadCastText(event, dot) {

--- a/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesInstantsSuggestion.js
+++ b/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesInstantsSuggestion.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { formatPercentage } from 'common/format';
+import { formatPercentage, formatDuration } from 'common/format';
 import SpellLink from 'common/SpellLink';
 
   function suggest(when, suggestion) {
     when(suggestion).addSuggestion((suggest, actual, recommended) => {
-      return suggest(<>You refreshed <SpellLink id={suggestion.spell.id} /> early {suggestion.count} times when you had better spells to cast. See the highlighted casts on the timeline for more information.</>)
+      return suggest(<>You refreshed <SpellLink id={suggestion.spell.id} /> early {suggestion.count} times when you had better spells to cast, resulting in {formatDuration(suggestion.wastedDuration)} seconds lost. See the highlighted casts on the timeline for more information.</>)
         .icon(suggestion.spell.icon)
-        .actual(`${formatPercentage(actual)}% bad Dot refreshes`)
+        .actual(`${formatPercentage(actual)}% effective duration`)
         .recommended(`<${formatPercentage(recommended)}% is recommended`);
     });
   }

--- a/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesSuggestion.js
+++ b/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesSuggestion.js
@@ -6,7 +6,7 @@ import SpellLink from 'common/SpellLink';
     when(suggestion).addSuggestion((suggest, actual, recommended) => {
       return suggest(<>You refreshed <SpellLink id={suggestion.spell.id} /> early {suggestion.count} times, resulting in {formatDuration(suggestion.wastedDuration)} seconds lost. The individual casts are highlighted on the timeline.</>)
         .icon(suggestion.spell.icon)
-        .actual(`${formatPercentage(actual)}% effective duration`)
+        .actual(`${formatPercentage(actual)}% effective refresh duration`)
         .recommended(`<${formatPercentage(recommended)}% is recommended`);
     });
   }

--- a/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesSuggestion.js
+++ b/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesSuggestion.js
@@ -4,10 +4,10 @@ import SpellLink from 'common/SpellLink';
 
   function suggest(when, suggestion) {
     when(suggestion).addSuggestion((suggest, actual, recommended) => {
-      return suggest(<>You refreshed <SpellLink id={suggestion.spell.id} /> early {suggestion.count} times, resulting in {formatDuration(suggestion.wastedDuration)} seconds lost. The individual casts are highlighted on the timeline.</>)
+      return suggest(<>You refreshed <SpellLink id={suggestion.spell.id} /> early {suggestion.count} times, resulting in {formatDuration(suggestion.wastedDuration/1000)} seconds lost. The individual casts are highlighted on the timeline.</>)
         .icon(suggestion.spell.icon)
         .actual(`${formatPercentage(actual)}% effective refresh duration`)
-        .recommended(`<${formatPercentage(recommended)}% is recommended`);
+        .recommended(`>${formatPercentage(recommended)}% is recommended`);
     });
   }
 

--- a/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesSuggestion.js
+++ b/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesSuggestion.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { formatPercentage } from 'common/format';
+import { formatPercentage, formatDuration } from 'common/format';
 import SpellLink from 'common/SpellLink';
 
   function suggest(when, suggestion) {
     when(suggestion).addSuggestion((suggest, actual, recommended) => {
-      return suggest(<>You refreshed <SpellLink id={suggestion.spell.id} /> early {suggestion.count} times. The individual casts are highlighted on the timeline.</>)
+      return suggest(<>You refreshed <SpellLink id={suggestion.spell.id} /> early {suggestion.count} times, resulting in {formatDuration(suggestion.wastedDuration)} seconds lost. The individual casts are highlighted on the timeline.</>)
         .icon(suggestion.spell.icon)
-        .actual(`${formatPercentage(actual)}% early refreshes`)
+        .actual(`${formatPercentage(actual)}% effective duration`)
         .recommended(`<${formatPercentage(recommended)}% is recommended`);
     });
   }

--- a/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesSuggestionByCount.js
+++ b/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesSuggestionByCount.js
@@ -4,9 +4,9 @@ import SpellLink from 'common/SpellLink';
 
   function suggest(when, suggestion) {
     when(suggestion).addSuggestion((suggest, actual, recommended) => {
-      return suggest(<>You refreshed <SpellLink id={suggestion.spell.id} /> early {suggestion.count} times when you had better spells to cast. See the highlighted casts on the timeline for more information.</>)
+      return suggest(<>You refreshed <SpellLink id={suggestion.spell.id} /> early {suggestion.count} times. The individual casts are highlighted on the timeline.</>)
         .icon(suggestion.spell.icon)
-        .actual(`${formatPercentage(actual)}% bad Dot refreshes`)
+        .actual(`${formatPercentage(actual)}% effective duration`)
         .recommended(`<${formatPercentage(recommended)}% is recommended`);
     });
   }


### PR DESCRIPTION
Adds early refresh logic for assassination, and fixes a bug in balance druid dots. 

Did not update Balance druid all the way to use effective refresh calculation, because I don't really know if calculating by effective duration instead of share of bad casts would be correct.
I think it is applicable in full to Stellar Flare, but maybe not to the instant casts. At least they might need a more advanced logic to calculate the effective duration.


Timeline (only for the default message):
![image](https://user-images.githubusercontent.com/9116609/56513858-051cf780-6534-11e9-8dc0-517790f43b7a.png)

Assa checklist:
![image](https://user-images.githubusercontent.com/9116609/56513891-1c5be500-6534-11e9-8f40-2de65de5b9b4.png)

Assa suggestion:
![image](https://user-images.githubusercontent.com/9116609/56514818-9ee5a400-6536-11e9-9fcb-3edb8f7a426f.png)
