### PR TITLE
[Outlaw] Abilities, Buffs, and Spells updates

### DIFF
--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -626,3 +626,13 @@ export const HolySchmidt = {
     link: 'https://worldofwarcraft.com/en-us/character/us/whisperwind/holyschmidt',
   }],
 };
+export const Coywolf = {
+  nickname: 'Coywolf',
+  github: 'Coywolf',
+  discord: 'Coywolf#3500',
+  mains: [{
+    name: 'Coywolf',
+    spec: SPECS.OUTLAW_ROGUE,
+    link: 'https://worldofwarcraft.com/en-us/character/us/arthas/coywolf',
+  }],
+};

--- a/src/common/SPELLS/bfa/azeritetraits/rogue.js
+++ b/src/common/SPELLS/bfa/azeritetraits/rogue.js
@@ -10,6 +10,11 @@ export default {
     name: 'Ace Up Your Sleeve',
     icon: 'inv_weapon_rifle_01',
   },
+  ACE_UP_YOUR_SLEEVE_BUFF: { // This appears to be what actually generates the combo points
+    id: 279714,
+    name: 'Ace Up Your Sleeve',
+    icon: 'inv_weapon_rifle_01',
+  },
   DEADSHOT: {
     id: 272935,
     name: 'Deadshot',

--- a/src/common/SPELLS/rogue.js
+++ b/src/common/SPELLS/rogue.js
@@ -497,6 +497,11 @@ export default {
     name: 'Broadside',
     icon: 'ability_rogue_rollthebones06',
   },
+  BLADE_RUSH_TALENT_BUFF: { // This is the energy gain buff
+    id: 271896, 
+    name: 'Blade Rush', 
+    icon: 'ability_arakkoa_spinning_blade',
+  },
 
 
   //Procs
@@ -514,5 +519,10 @@ export default {
     id: 86392,
     name: 'Main Gauche',
     icon: 'inv_weapon_shortblade_15',
+  },
+  OPPORTUNITY: {
+    id: 195627,
+    name: 'Opportunity',
+    icon: 'ability_rogue_pistolshot',
   },
 };

--- a/src/parser/rogue/outlaw/CONFIG.js
+++ b/src/parser/rogue/outlaw/CONFIG.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { tsabo } from 'CONTRIBUTORS';
+import { tsabo, Coywolf } from 'CONTRIBUTORS';
 import retryingPromise from 'common/retryingPromise';
 import SPECS from 'game/SPECS';
 import Warning from 'interface/common/Alert/Warning';
@@ -9,7 +9,7 @@ import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [tsabo],
+  contributors: [tsabo, Coywolf],
   // The WoW client patch this spec was last updated to be fully compatible with.
   patchCompatibility: '7.3',
   // If set to  false`, the spec will show up as unsupported.

--- a/src/parser/rogue/outlaw/CombatLogParser.js
+++ b/src/parser/rogue/outlaw/CombatLogParser.js
@@ -3,6 +3,7 @@ import ArcaneTorrent from 'parser/shared/modules/racials/bloodelf/ArcaneTorrent'
 
 import Abilities from './modules/Abilities';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
+import Buffs from './modules/Buffs';
 import SpellUsable from '../shared/SpellUsable';
 
 import ComboPointDetails from '../shared/resources/ComboPointDetails';
@@ -23,6 +24,7 @@ class CombatLogParser extends CoreCombatLogParser {
     //Feature
     abilities: Abilities,
     alwaysBeCasting: AlwaysBeCasting,
+    buffs: Buffs,
     spellUsable: SpellUsable,
 
     //Resource

--- a/src/parser/rogue/outlaw/modules/Abilities.js
+++ b/src/parser/rogue/outlaw/modules/Abilities.js
@@ -68,6 +68,21 @@ class Abilities extends CoreAbilities {
         },
         enabled: combatant.hasTalent(SPELLS.GHOSTLY_STRIKE_TALENT.id),
       },
+      {
+        spell: SPELLS.BETWEEN_THE_EYES,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        cooldown: 30,
+        gcd: {
+          static: standardGcd,
+        },
+      },
+      {
+        spell: SPELLS.PISTOL_SHOT,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        gcd: {
+          static: standardGcd,
+        },
+      },
       // Rotational (AOE)
       {
         spell: SPELLS.BLADE_FLURRY,
@@ -88,15 +103,6 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
-        },
-      },
-      {
-        spell: SPELLS.VANISH,
-        category: Abilities.SPELL_CATEGORIES.UTILITY,
-        cooldown: 120,
-        gcd: null,
-        castEfficiency: {
-          suggestion: false,
         },
       },
       {
@@ -156,21 +162,24 @@ class Abilities extends CoreAbilities {
       },
       // Others
       {
-        spell: SPELLS.BETWEEN_THE_EYES,
+        spell: SPELLS.PICK_LOCK,
         category: Abilities.SPELL_CATEGORIES.OTHERS,
-        cooldown: 30,
-        gcd: {
-          static: standardGcd,
-        },
       },
       {
-        spell: SPELLS.PISTOL_SHOT,
+        spell: SPELLS.PICK_POCKET,
         category: Abilities.SPELL_CATEGORIES.OTHERS,
-        gcd: {
-          static: standardGcd,
-        },
+        // While this actually has a 0.5s CD, it shows up weird in the Abilities tab if we set that
       },
       // Utility
+      {
+        spell: SPELLS.VANISH,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: 120,
+        gcd: null,
+        castEfficiency: {
+          suggestion: false,
+        },
+      },
       {
         spell: SPELLS.GRAPPLING_HOOK,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
@@ -243,16 +252,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.SAP,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
-      },
-      {
-        spell: SPELLS.PICK_LOCK,
-        category: Abilities.SPELL_CATEGORIES.UTILITY,
-      },
-      {
-        spell: SPELLS.PICK_POCKET,
-        category: Abilities.SPELL_CATEGORIES.UTILITY,
-        // While this actually has a 0.5s CD, it shows up weird in the Abilities tab if we set that
-      },
+      },      
     ];
   }
 }

--- a/src/parser/rogue/outlaw/modules/Abilities.js
+++ b/src/parser/rogue/outlaw/modules/Abilities.js
@@ -1,12 +1,16 @@
+import React from 'react';
+
 import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
 import CoreAbilities from 'parser/core/modules/Abilities';
+import ISSUE_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
 
 class Abilities extends CoreAbilities {
   spellbook() {
     const combatant = this.selectedCombatant;
 
     const standardGcd = combatant => 1000 * (1 - (combatant.hasBuff(SPELLS.ADRENALINE_RUSH.id) ? 0.2 : 0));
-
+    
     return [
       // Rotational
       {
@@ -65,6 +69,8 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
+          recommendedEfficiency: 0.95,
+          extraSuggestion: 'The only time you should delay casting this is to avoid over-capping Combo Points.',
         },
         enabled: combatant.hasTalent(SPELLS.GHOSTLY_STRIKE_TALENT.id),
       },
@@ -74,7 +80,7 @@ class Abilities extends CoreAbilities {
         cooldown: 30,
         gcd: {
           static: standardGcd,
-        },
+        },        
       },
       {
         spell: SPELLS.PISTOL_SHOT,
@@ -103,6 +109,8 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
+          recommendedEfficiency: 0.9,
+          extraSuggestion: `Using Adrenaline Rush on cooldown is very important and should only be delayed when you know you won't be able to attack for the majority of it's duration.`,
         },
       },
       {
@@ -114,6 +122,7 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
+          extraSuggestion: <>In most cases this should be considered part of your rotation, only below <SpellLink id={SPELLS.ROLL_THE_BONES.id} icon /> on priority. However you should delay using it to line it up with <SpellLink id={SPELLS.BLADE_FLURRY.id} icon /> when there is more than one target.</>,
         },
         enabled: combatant.hasTalent(SPELLS.BLADE_RUSH_TALENT.id),
       },
@@ -126,6 +135,7 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
+          extraSuggestion: <>In most cases this should be considered part of your rotation, only below <SpellLink id={SPELLS.ROLL_THE_BONES.id} icon /> on priority. However you should delay using it to line it up with <SpellLink id={SPELLS.BLADE_FLURRY.id} icon /> when there is more than one target.</>,
         },
         enabled: combatant.hasTalent(SPELLS.KILLING_SPREE_TALENT.id),
       },
@@ -177,7 +187,9 @@ class Abilities extends CoreAbilities {
         cooldown: 120,
         gcd: null,
         castEfficiency: {
-          suggestion: false,
+          suggestion: true,
+          extraSuggestion: <>In most fights this can be used on cooldown for an <SpellLink id={SPELLS.AMBUSH.id} icon />, but it's perfectly fine to save this for a <SpellLink id={SPELLS.CHEAP_SHOT.id} icon /> on adds, especially when talented for <SpellLink id={SPELLS.PREY_ON_THE_WEAK_TALENT.id} icon />.</>,
+          importance: ISSUE_IMPORTANCE.MINOR,
         },
       },
       {

--- a/src/parser/rogue/outlaw/modules/Abilities.js
+++ b/src/parser/rogue/outlaw/modules/Abilities.js
@@ -70,7 +70,6 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.95,
-          extraSuggestion: 'The only time you should delay casting this is to avoid over-capping Combo Points.',
         },
         enabled: combatant.hasTalent(SPELLS.GHOSTLY_STRIKE_TALENT.id),
       },
@@ -122,7 +121,7 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
-          extraSuggestion: <>In most cases this should be considered part of your rotation, only below <SpellLink id={SPELLS.ROLL_THE_BONES.id} icon /> on priority. However you should delay using it to line it up with <SpellLink id={SPELLS.BLADE_FLURRY.id} icon /> when there is more than one target.</>,
+          extraSuggestion: <>You should delay using it to line it up with <SpellLink id={SPELLS.BLADE_FLURRY.id} icon /> in AoE scenarios.</>,
         },
         enabled: combatant.hasTalent(SPELLS.BLADE_RUSH_TALENT.id),
       },
@@ -135,7 +134,7 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
-          extraSuggestion: <>In most cases this should be considered part of your rotation, only below <SpellLink id={SPELLS.ROLL_THE_BONES.id} icon /> on priority. However you should delay using it to line it up with <SpellLink id={SPELLS.BLADE_FLURRY.id} icon /> when there is more than one target.</>,
+          extraSuggestion: <>You should delay using it to line it up with <SpellLink id={SPELLS.BLADE_FLURRY.id} icon /> in AoE scenarios.</>,
         },
         enabled: combatant.hasTalent(SPELLS.KILLING_SPREE_TALENT.id),
       },

--- a/src/parser/rogue/outlaw/modules/Buffs.js
+++ b/src/parser/rogue/outlaw/modules/Buffs.js
@@ -1,0 +1,91 @@
+import SPELLS from 'common/SPELLS';
+import CoreBuffs from 'parser/core/modules/Buffs';
+import BLOODLUST_BUFFS from 'game/BLOODLUST_BUFFS';
+
+class Buffs extends CoreBuffs {
+  buffs() {
+    const combatant = this.selectedCombatant;
+
+    // This should include ALL buffs that can be applied by your spec.
+    // This data can be used by various kinds of modules to improve their results, and modules added in the future may rely on buffs that aren't used today.
+    return [
+      // Core
+      {
+        spellId: SPELLS.ADRENALINE_RUSH.id,
+        timelineHightlight: true,
+      },
+      {
+        spellId: SPELLS.BLADE_RUSH_TALENT.id,
+        enabled: combatant.hasTalent(SPELLS.BLADE_RUSH_TALENT.id),
+      },
+      {
+        spellId: SPELLS.SLICE_AND_DICE_TALENT.id,
+        enabled: combatant.hasTalent(SPELLS.SLICE_AND_DICE_TALENT.id),
+        timelineHightlight: true,
+      },
+      {
+        spellId: SPELLS.OPPORTUNITY.id,
+        timelineHightlight: true,
+      },
+
+      // Roll the Bones
+      {
+        spellId: SPELLS.ROLL_THE_BONES.id,
+        enabled: !combatant.hasTalent(SPELLS.SLICE_AND_DICE_TALENT.id),
+        timelineHightlight: true,
+      },
+      {
+        spellId: SPELLS.RUTHLESS_PRECISION.id,
+        enabled: !combatant.hasTalent(SPELLS.SLICE_AND_DICE_TALENT.id),
+      },
+      {
+        spellId: SPELLS.GRAND_MELEE.id,
+        enabled: !combatant.hasTalent(SPELLS.SLICE_AND_DICE_TALENT.id),
+      },
+      {
+        spellId: SPELLS.BROADSIDE.id,
+        enabled: !combatant.hasTalent(SPELLS.SLICE_AND_DICE_TALENT.id),
+      },
+      {
+        spellId: SPELLS.SKULL_AND_CROSSBONES.id,
+        enabled: !combatant.hasTalent(SPELLS.SLICE_AND_DICE_TALENT.id),
+      },
+      {
+        spellId: SPELLS.BURIED_TREASURE.id,
+        enabled: !combatant.hasTalent(SPELLS.SLICE_AND_DICE_TALENT.id),
+      },
+      {
+        spellId: SPELLS.TRUE_BEARING.id,
+        enabled: !combatant.hasTalent(SPELLS.SLICE_AND_DICE_TALENT.id),
+      },
+
+      // Misc
+      {
+        spellId: SPELLS.CLOAK_OF_SHADOWS.id,
+      },
+      {
+        spellId: SPELLS.CRIMSON_VIAL.id,
+      },
+      {
+        spellId: SPELLS.FEINT.id,
+      },
+      {
+        spellId: SPELLS.RIPOSTE.id,
+      },
+      {
+        spellId: SPELLS.SPRINT.id,
+      },
+      {
+        spellId: SPELLS.SHROUD_OF_CONCEALMENT.id,
+      },
+
+      // Bloodlust Buffs
+      {
+        spellId: Object.keys(BLOODLUST_BUFFS).map(item => Number(item)),
+        timelineHightlight: true,
+      },
+    ];
+  }
+}
+
+export default Buffs;

--- a/src/parser/rogue/outlaw/modules/core/ComboPoints.js
+++ b/src/parser/rogue/outlaw/modules/core/ComboPoints.js
@@ -39,10 +39,10 @@ class ComboPoints extends Analyzer {
       extraSuggestion: this.makeExtraSuggestion(SPELLS.AMBUSH),
     });
     resourceSuggest(when, this.comboPointTracker, {
-      spell: SPELLS.PISTOL_SHOT, // 1 CP
+      spell: SPELLS.PISTOL_SHOT, // 1 CP, 2 with proc and Quick Draw
       minor: 0,
-      avg: 0.1,
-      major: 0.2,
+      avg: 0.05,
+      major: 0.1,
       // TODO: Beta logs incorrectly add bonus CP from an extra Sinister Strike to Pistol shot. 
       // Want to see if its fixed in PrePatch or can be fixed on WCL side before creating workaround.
       extraSuggestion: this.makeExtraSuggestion(SPELLS.PISTOL_SHOT),

--- a/src/parser/rogue/outlaw/modules/core/ComboPoints.js
+++ b/src/parser/rogue/outlaw/modules/core/ComboPoints.js
@@ -43,8 +43,6 @@ class ComboPoints extends Analyzer {
       minor: 0,
       avg: 0.05,
       major: 0.1,
-      // TODO: Beta logs incorrectly add bonus CP from an extra Sinister Strike to Pistol shot. 
-      // Want to see if its fixed in PrePatch or can be fixed on WCL side before creating workaround.
       extraSuggestion: this.makeExtraSuggestion(SPELLS.PISTOL_SHOT),
     });
     resourceSuggest(when, this.comboPointTracker, {


### PR DESCRIPTION
This is a few general changes to the spec. I added a couple of missing spells that were causing the Combo Point Usage and Energy Usage tabs to error. Did a pass on the abilities module to tweak/add some basic recommendations, and added a buffs module, basing it on other specs. Added a contributors entry for myself.

(Split 1 of 5 from my original: https://github.com/WoWAnalyzer/WoWAnalyzer/pull/3113)