### PR TITLE
[BrM] (finally) updated mitigation blacklist for ISB hit tracking

### DIFF
--- a/src/parser/monk/brewmaster/modules/constants/AbilityBlacklist.js
+++ b/src/parser/monk/brewmaster/modules/constants/AbilityBlacklist.js
@@ -5,6 +5,18 @@
  */
 
 const SHARED = [
+  // CRUCIBLE OF STORMS
+  282743, // Cabal, Storm of Annihilation (Crown effect)
+  295479, // Uu'nat, Touch of the End
+  // BOD
+  288806, // Mekkatorque, Gigavolt Blast
+  286646, // Mekkatorque, Gigavolt Charge
+  289648, // Mekkatorque (Spark Bot), Spark Shield -- RJW causes a bunch of events for this. not much you can do to avoid it
+  288939, // Mekkatorque, Gigavolt Radiation
+  284831, // Rastakhan, Scorching Detonation -- DoT
+  285195, // Rastakhan, Deadly Withering
+  285000, // Stormwall, Kelp-Wrapped
+  287993, // Jaina, Chilling Touch
   // ULDIR
   266948, // Vectis, Plague Bomb (intermission soak)
   // ANTORUS


### PR DESCRIPTION
Includes spells for BoD and CoS. In case anyone's forgotten: this is mostly used to blacklist dots that can't be effectively mitigated with Ironskin Brew but also produce a LOT of hits that skew hit tracking. The worst offender this tier is Jaina, with Chilling Touch frequently being 3-5x as many hits as Ice Shard.