### PR TITLE
[Core] Fix for Cancelled Casts (Statistic and Timeline)

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -8,6 +8,11 @@ import Contributor from 'interface/contributor/Button';
 
 export default [
   {
+    date: new Date('2019-05-10'),
+    changes: <>Fixed an issue where the timeline and the Cancelled Casts statistic would incorrectly mark a spell as cancelled in high latency situations.</>,
+    contributors: [Sharrq],
+  },
+  {
     date: new Date('2019-04-20'),
     changes: <>Fixed issue for mages where the timeline would show a cast as cancelled if they cast an ability that could be cast while casting (e.g. <SpellLink id={SPELLS.SHIMMER_TALENT.id} /> or <SpellLink id={SPELLS.FIRE_BLAST.id} />).</>,
     contributors: [Sharrq],

--- a/src/parser/mage/fire/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/mage/fire/__snapshots__/CombatLogParser.test.js.snap
@@ -293,7 +293,7 @@ exports[`The Fire Mage Analyzer analyzers CancelledCasts matches the statistic s
             </g>
           </svg>
            
-          11.98
+          6.96
           % 
           <small>
             Casts Cancelled
@@ -327,10 +327,10 @@ Array [
   Object {
     "details": null,
     "icon": "inv_misc_map_01",
-    "importance": "regular",
+    "importance": "minor",
     "issue": <React.Fragment>
       You cancelled 
-      11.98
+      6.96
       % of your spells. While it is expected that you will have to cancel a few casts to react to boss mechanics or move, you should try to ensure that you are cancelling as few casts as possible by utilizing movement abilities such as 
       <SpellLink
         icon={true}
@@ -344,7 +344,7 @@ Array [
       .
     </React.Fragment>,
     "stat": <React.Fragment>
-      11.98% casts cancelled
+      6.96% casts cancelled
        (
       &lt;5.00% is recommended
       )
@@ -2192,7 +2192,7 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
               style={
                 Object {
                   "backgroundColor": "#df7102",
-                  "width": "33.981651979135805%",
+                  "width": "47.43822743581738%",
                 }
               }
             />
@@ -2345,7 +2345,7 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  11.98%
+                  6.96%
                    
                    
                 </div>
@@ -2365,9 +2365,9 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#ffc84a",
+                        "backgroundColor": "#a6c34c",
                         "transition": "background-color 800ms",
-                        "width": "60.01976047904192%",
+                        "width": "86.93291139240506%",
                       }
                     }
                   />

--- a/src/parser/shared/modules/CancelledCasts.js
+++ b/src/parser/shared/modules/CancelledCasts.js
@@ -7,7 +7,8 @@ import Statistic from 'interface/statistics/Statistic';
 import BoringValueText from 'interface/statistics/components/BoringValueText';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 
-const debug = false;
+const debug = true;
+const MS_BUFFER = 100;
 
 class CancelledCasts extends Analyzer {
   castsCancelled = 0;
@@ -23,39 +24,41 @@ class CancelledCasts extends Analyzer {
     if (this.constructor.IGNORED_ABILITIES.includes(spellId)) {
       return;
     }
-    if (this.wasCastStarted) {
+    if (this.wasCastStarted && event.timestamp - this.beginCastSpell.timestamp > MS_BUFFER) {
       this.castsCancelled += 1;
       this.addToCancelledList(event);
     }
-    this.beginCastSpell = event.ability;
+    this.beginCastSpell = event;
     this.wasCastStarted = true;
   }
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
-    if (this.constructor.IGNORED_ABILITIES.includes(spellId)) {
+    const beginCastAbility = this.beginCastSpell.ability;
+    if (this.constructor.IGNORED_ABILITIES.includes(spellId) || !beginCastAbility) {
       return;
     }
-    if (this.beginCastSpell.guid !== spellId && this.wasCastStarted) {
+    if (beginCastAbility.guid !== spellId && this.wasCastStarted) {
       this.castsCancelled += 1;
       this.addToCancelledList(event);
     }
-    if (this.beginCastSpell.guid === spellId && this.wasCastStarted) {
+    if (beginCastAbility.guid === spellId && this.wasCastStarted) {
       this.castsFinished += 1;
     }
     this.wasCastStarted = false;
   }
 
   addToCancelledList(event) {
-    if (!this.cancelledSpellList[this.beginCastSpell.guid]) {
-      this.cancelledSpellList[this.beginCastSpell.guid] = {
-        'spellName': this.beginCastSpell.name,
+    const beginCastAbility = this.beginCastSpell.ability;
+    if (!this.cancelledSpellList[beginCastAbility.guid]) {
+      this.cancelledSpellList[beginCastAbility.guid] = {
+        'spellName': beginCastAbility.name,
         'amount': 1,
       };
     } else {
-      this.cancelledSpellList[this.beginCastSpell.guid].amount += 1;
+      this.cancelledSpellList[beginCastAbility.guid].amount += 1;
     }
-    debug && console.log("cast cancelled at: ", event.timestamp);
+    debug && this.log(beginCastAbility.name + " cast cancelled");
   }
   get totalCasts() {
     return this.castsCancelled + this.castsFinished;

--- a/src/parser/shared/modules/CancelledCasts.js
+++ b/src/parser/shared/modules/CancelledCasts.js
@@ -7,7 +7,7 @@ import Statistic from 'interface/statistics/Statistic';
 import BoringValueText from 'interface/statistics/components/BoringValueText';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 
-const debug = true;
+const debug = false;
 const MS_BUFFER = 100;
 
 class CancelledCasts extends Analyzer {

--- a/src/parser/shared/normalizers/CancelledCasts.js
+++ b/src/parser/shared/normalizers/CancelledCasts.js
@@ -2,6 +2,8 @@ import EventsNormalizer from 'parser/core/EventsNormalizer';
 import CASTS_THAT_ARENT_CASTS from 'parser/core/CASTS_THAT_ARENT_CASTS';
 import CASTABLE_WHILE_CASTING_SPELLS from 'parser/core/CASTABLE_WHILE_CASTING_SPELLS';
 
+const MS_BUFFER = 100;
+
 /**
  * During analysis there's no way to know at a `begincast` event if it will end up being canceled. This marks all `begincast` events by the player with an `isCancelled` property whether it was cancelled.
  */
@@ -22,7 +24,7 @@ class CancelledCasts extends EventsNormalizer {
   }
 
   handleBeginCast(event) {
-    if (this.isCasting) {
+    if (this.isCasting && event.timestamp - this.lastBeginCast.timestamp > MS_BUFFER) {
       this.markLastBeginCastCancelled();
     }
     this.lastBeginCast = event;


### PR DESCRIPTION
One of the contributors in the Mage Discord brought up an issue for Fire Mages where the Cancelled Casts stat box and the timeline would incorrectly mark a spell as cancelled.

Some background, Fire Mage has a proc called Hot Streak that makes your next Pyroblast instant cast. You get Hot Streak by getting two critical strikes in a row with a direct damage ability (Like Fireball, Fire Blast, Scorch, Pyroblast, etc). Additionally, abilities like Fire Blast and Phoenix Flames are guaranteed to crit, and with a talent Scorch is guaranteed to crit under 30% health. So you can predict when you will gain Hot Streak because you know that the Fire Blast will give you your second crit and give you Hot Streak.

So it is common for Fire Mages to be casting a spell, hit Fire Blast mid cast to get their Hot Streak proc, and then use their instant pyroblast at the end of that cast ... OR it is also common for Fire Mages using Searing Touch to cast Scorch under 30% health (when they know it will crit), and queue up their instant Pyro within milliseconds of receiving it because they know it is coming.

The result of that with latency is that the log shows two begincast events for that Pyroblast (like they started casting it, cancelled it, and then 20ms later cast it again), so it was marking those as cancelled. You could also barely see them in the timeline

![image](https://user-images.githubusercontent.com/1304554/57563880-186bf780-7369-11e9-8c7a-931c525eb4fb.png)

This change gives the stat box and the timeline a 100ms buffer where it will ignore the cancelled cast. Im pretty sure it is impossible for someone to cast something, cancel it, and recast it within 100ms ... so this should be pretty safe .... but if it is possible, 20-40ms lost is nothing and they deserve for the cast to not count against them. 
