### PR TITLE
[Core] Add basic dispel tracker

### DIFF
--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -183,6 +183,24 @@ export const Fyruna = {
   nickname: 'Fyruna',
   github: 'Fyruna',
   avatar: require('./interface/images/avatars/Fyruna_avatar.jpg'),
+  mains: [{
+    name: 'Aevaa',
+    spec: SPECS.ASSASSINATION_ROGUE,
+    link: 'https://worldofwarcraft.com/en-gb/character/magtheridon/aevaa',
+  }],
+  alts: [{
+    name: 'Aeri',
+    spec: SPECS.BREWMASTER_MONK,
+    link: 'https://worldofwarcraft.com/en-gb/character/magtheridon/aeri',
+  }, {
+    name: 'Avynn',
+    spec: SPECS.DISCIPLINE_PRIEST,
+    link: 'https://worldofwarcraft.com/en-gb/character/magtheridon/avynn',
+  }, {
+    name: 'Seiralia',
+    spec: SPECS.RESTORATION_DRUID,
+    link: 'https://worldofwarcraft.com/en-gb/character/sporeggar/seiralia',
+  }],
 };
 export const Anomoly = {
   nickname: 'Anomoly',

--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -42,6 +42,7 @@ import Channeling from '../shared/modules/Channeling';
 import DeathDowntime from '../shared/modules/downtime/DeathDowntime';
 import TotalDowntime from '../shared/modules/downtime/TotalDowntime';
 import DistanceMoved from '../shared/modules/others/DistanceMoved';
+import DispelTracker from '../shared/modules/DispelTracker';
 
 // Tabs
 import RaidHealthTab from '../shared/modules/features/RaidHealthTab';
@@ -197,6 +198,7 @@ class CombatLogParser {
     vantusRune: VantusRune,
     distanceMoved: DistanceMoved,
     deathRecapTracker: DeathRecapTracker,
+    dispels: DispelTracker,
 
     critEffectBonus: CritEffectBonus,
 

--- a/src/parser/shared/modules/DispelTracker.js
+++ b/src/parser/shared/modules/DispelTracker.js
@@ -1,0 +1,58 @@
+import React from "react";
+import Analyzer from "parser/core/Analyzer";
+import Statistic from "interface/statistics/Statistic";
+import STATISTIC_ORDER from "interface/others/STATISTIC_ORDER";
+import SpellLink from "common/SpellLink";
+
+const debug = false;
+
+class DispelTracker extends Analyzer {
+  dispelEvents = {};
+  dispelCount = 0;
+  on_dispel(event) {
+    if (!this.owner.byPlayer(event)) {
+      return;
+    }
+
+    const spellDispelled = event.extraAbility.guid;
+    if (!this.dispelEvents[spellDispelled]) {
+      this.dispelEvents[spellDispelled] = 1;
+    } else {
+      this.dispelEvents[spellDispelled]++;
+    }
+
+    this.dispelCount++;
+  }
+
+  statistic() {
+    if (!this.dispelCount) {
+      debug && console.log("DispelTracker: This player did not dispel anything during this fight; this can have multiple reasons.");
+      return null;
+    }
+
+    debug && console.log("DispelTracker: All events", this.dispelEvents);
+    return (
+      <Statistic position={STATISTIC_ORDER.OPTIONAL(1)}>
+        <div className="pad">
+          <label>
+            Dispells
+          </label>
+          {Object.keys(this.dispelEvents).map(key => {
+            return (
+            <div className="flex">
+              <div className="flex-sub" style={{flex: 3}}><SpellLink id={key} /></div>
+              <div className="flex-sub" style={{flex: 1, textAlign: "right"}}>{this.dispelEvents[key]}</div>
+            </div>
+            );
+          })}
+          <div className="flex">
+            <div className="flex-sub value" style={{ flex: 3 }}>Total</div>
+            <div className="flex-sub value" style={{ flex: 1, textAlign: "right" }}>{this.dispelCount}</div>
+          </div>
+        </div>
+      </Statistic>
+    );
+  }
+}
+
+export default DispelTracker;


### PR DESCRIPTION
Resolves #3064 

![image](https://user-images.githubusercontent.com/5927637/57728477-53856800-7694-11e9-83ec-298b8d3f8e19.png)

> Yes, dispel is with one l, dispells is with 2. #dictionary

Used this log for testing: https://www.warcraftlogs.com/reports/YTmBqXd694N3gDJF

