### PR TITLE
Stormglide steps [don't merge yet]

### DIFF
--- a/src/common/ITEMS/bfa/raids/crucibleofstorms/index.js
+++ b/src/common/ITEMS/bfa/raids/crucibleofstorms/index.js
@@ -13,6 +13,13 @@ export default {
   },
 
   // Uu'nat, Harbinger of the Void
+  STORMGLIDE_STEPS: {
+    id: 167834,
+    name: 'Stormglide Steps',
+    icon: 'inv_boot_leather_zuldazarraid_d_01',
+    quality: ITEM_QUALITIES.PURPLE,
+  },
+
   TRIDENT_OF_DEEP_OCEAN: {
     id: 167864,
     name: 'Trident of Deep Ocean',

--- a/src/common/SPELLS/bfa/raids/crucibleofstorms/items.js
+++ b/src/common/SPELLS/bfa/raids/crucibleofstorms/items.js
@@ -29,4 +29,9 @@ export default {
     icon: "shaman_pvp_ripplingwaters",
   },
 
+  UNTOUCHABLE: { //Stormglide Steps Crit Buff
+    id: 295278,
+    name: "Untouchable",
+    icon: "ability_monk_ridethewind",
+  },
 };

--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -145,6 +145,7 @@ import CrestOfPaku from '../shared/modules/items/bfa/raids/bod/CrestOfPaku';
 import IncandescentSliver from '../shared/modules/items/bfa/raids/bod/IncandescentSliver';
 // Crucible of Storms
 import LeggingsOfTheAberrantTidesage from '../shared/modules/items/bfa/raids/crucibleofstorms/LeggingsOfTheAberrantTidesage';
+import StormglideSteps from '../shared/modules/items/bfa/raids/crucibleofstorms/StormglideSteps';
 import TridentOfDeepOcean from '../shared/modules/items/bfa/raids/crucibleofstorms/TridentOfDeepOcean';
 
 import ParseResults from './ParseResults';
@@ -301,6 +302,7 @@ class CombatLogParser {
     incandescentSliver: IncandescentSliver,
     // Crucible of Storms
     leggingsOfTheAberrantTidesage: LeggingsOfTheAberrantTidesage,
+    stormglideSteps: StormglideSteps,
     tridentOfDeepOcean: TridentOfDeepOcean,
   };
   // Override this with spec specific modules when extending

--- a/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/StormglideSteps.js
+++ b/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/StormglideSteps.js
@@ -48,14 +48,6 @@ class StormglideSteps extends Analyzer {
     return this.critRating * this.averageStacks;
   }
 
-  _formatUptime(duration) {
-    const seconds = duration / 1000;
-    if(seconds < 60){
-      return <>{seconds.toFixed(0)}s</>;
-    }
-    return formatDuration(seconds);
-  }
-
   statistic() {
     const buffStacks = this.selectedCombatant.getStackBuffUptimes(SPELLS.UNTOUCHABLE.id);
     const maxStacks = Object.keys(buffStacks)
@@ -69,8 +61,8 @@ class StormglideSteps extends Analyzer {
         tooltip={(
           <>
           Average stacks: <b>{this.averageStacks.toFixed(1)}</b><br />
-          Time spent at <b>0</b> stacks: <b>{this._formatUptime(unbuffedDuration)}</b> ({formatPercentage(unbuffedDuration / this.owner.fightDuration)}%)<br />
-          {maxStacks !== 0 && <> Time spent at <b>{maxStacks}</b> stack{maxStacks !== '1' && `s`}: <b>{this._formatUptime(maxStackDuration)}</b> ({formatPercentage(maxStackDuration / this.owner.fightDuration)}%)</>}
+          Time spent at <b>0</b> stacks: <b>{formatDuration(unbuffedDuration / 1000)}</b> ({formatPercentage(unbuffedDuration / this.owner.fightDuration)}%)<br />
+          {maxStacks !== 0 && <> Time spent at <b>{maxStacks}</b> stack{maxStacks !== '1' && `s`}: <b>{formatDuration(maxStackDuration / 1000)}</b> ({formatPercentage(maxStackDuration / this.owner.fightDuration)}%)</>}
           </>
         )}
       >

--- a/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/StormglideSteps.js
+++ b/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/StormglideSteps.js
@@ -62,7 +62,7 @@ class StormglideSteps extends Analyzer {
           <>
           Average stacks: <b>{this.averageStacks.toFixed(1)}</b><br />
           Time spent at <b>0</b> stacks: <b>{formatDuration(unbuffedDuration / 1000)}</b> ({formatPercentage(unbuffedDuration / this.owner.fightDuration)}%)<br />
-          {maxStacks !== 0 && <> Time spent at <b>{maxStacks}</b> stack{maxStacks !== '1' && `s`}: <b>{formatDuration(maxStackDuration / 1000)}</b> ({formatPercentage(maxStackDuration / this.owner.fightDuration)}%)</>}
+          {maxStacks !== 0 && <> Time spent at <b>{maxStacks}</b> stack{maxStacks !== 1 && `s`}: <b>{formatDuration(maxStackDuration / 1000)}</b> ({formatPercentage(maxStackDuration / this.owner.fightDuration)}%)</>}
           </>
         )}
       >

--- a/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/StormglideSteps.js
+++ b/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/StormglideSteps.js
@@ -48,6 +48,14 @@ class StormglideSteps extends Analyzer {
     return this.critRating * this.averageStacks;
   }
 
+  _formatUptime(duration) {
+    const seconds = duration / 1000;
+    if(seconds < 60){
+      return <>{seconds.toFixed(0)}s</>;
+    }
+    return formatDuration(seconds);
+  }
+
   statistic() {
     const buffStacks = this.selectedCombatant.getStackBuffUptimes(SPELLS.UNTOUCHABLE.id);
     const maxStacks = Object.keys(buffStacks)
@@ -61,10 +69,8 @@ class StormglideSteps extends Analyzer {
         tooltip={(
           <>
           Average stacks: <b>{this.averageStacks.toFixed(1)}</b><br />
-          Time spent without buff: <b>{(unbuffedDuration / 1000).toFixed(0)}s</b> ({formatPercentage(unbuffedDuration / this.owner.fightDuration)}%)<br />
-          {maxStacks !== 0 && <>
-            Time at <b>{maxStacks}</b> stacks: <b>{(maxStackDuration / 1000).toFixed(0)}s </b>({formatPercentage(maxStackDuration / this.owner.fightDuration)}%)
-            </>}
+          Time spent at <b>0</b> stacks: <b>{this._formatUptime(unbuffedDuration)}</b> ({formatPercentage(unbuffedDuration / this.owner.fightDuration)}%)<br />
+          {maxStacks !== 0 && <> Time spent at <b>{maxStacks}</b> stack{maxStacks !== '1' && `s`}: <b>{this._formatUptime(maxStackDuration)}</b> ({formatPercentage(maxStackDuration / this.owner.fightDuration)}%)</>}
           </>
         )}
       >

--- a/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/StormglideSteps.js
+++ b/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/StormglideSteps.js
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import { calculateSecondaryStatDefault } from 'common/stats';
+
+import ITEMS from 'common/ITEMS/index';
+import SPELLS from 'common/SPELLS/index';
+
+import Analyzer from 'parser/core/Analyzer';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
+import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
+import StatTracker from 'parser/shared/modules/StatTracker';
+
+import { formatNumber, formatPercentage } from 'common/format';
+
+import CriticalStrikeIcon from 'interface/icons/CriticalStrike';
+import UptimeIcon from 'interface/icons/Uptime';
+
+// https://www.warcraftlogs.com/reports/RDHTGY68yPQ3WJ9r#fight=28source=14
+
+class StormglideSteps extends Analyzer {
+  static dependencies = {
+    statTracker: StatTracker,
+  };
+
+  constructor(...args){
+    super(...args);
+    this.active = this.selectedCombatant.hasFeet(ITEMS.STORMGLIDE_STEPS.id);
+    if(!this.active){
+      return;
+    }
+
+    const item = this.selectedCombatant.feet;
+    this.critRating = calculateSecondaryStatDefault(395, 20, item.itemLevel);
+    this.statTracker.add(SPELLS.UNTOUCHABLE.id, {
+      crit: this.critRating,
+    });
+  }
+
+  get buffUptime() {
+    return this.selectedCombatant.getBuffUptime(SPELLS.UNTOUCHABLE.id) / this.owner.fightDuration;
+  }
+
+  get averageStacks() {
+    return (this.selectedCombatant.getStackWeightedBuffUptime(SPELLS.UNTOUCHABLE.id) / this.owner.fightDuration);
+  }
+
+  get averageStat() {
+    return this.critRating * this.averageStacks;
+  }
+
+  statistic() {
+    return (
+      <ItemStatistic
+        size="flexible"
+        tooltip={(
+          <>
+          Average stacks: <b>{this.averageStacks.toFixed(2)}</b>
+          </>
+        )}
+      >
+        <BoringItemValueText item={ITEMS.STORMGLIDE_STEPS}>
+          <UptimeIcon /> {formatPercentage(this.buffUptime)}% <small>buff uptime</small><br />
+          <CriticalStrikeIcon /> {formatNumber(this.averageStat)} <small>average Critical Strike</small><br />
+        </BoringItemValueText>
+      </ItemStatistic>
+    );
+  }
+
+}
+
+export default StormglideSteps;

--- a/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/StormglideSteps.js
+++ b/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/StormglideSteps.js
@@ -10,7 +10,7 @@ import ItemStatistic from 'interface/statistics/ItemStatistic';
 import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
 import StatTracker from 'parser/shared/modules/StatTracker';
 
-import { formatNumber, formatPercentage } from 'common/format';
+import { formatNumber, formatPercentage, formatDuration } from 'common/format';
 
 import CriticalStrikeIcon from 'interface/icons/CriticalStrike';
 import UptimeIcon from 'interface/icons/Uptime';
@@ -49,12 +49,22 @@ class StormglideSteps extends Analyzer {
   }
 
   statistic() {
+    const buffStacks = this.selectedCombatant.getStackBuffUptimes(SPELLS.UNTOUCHABLE.id);
+    const maxStacks = Object.keys(buffStacks)
+    .map(stacks => parseInt(stacks,10) || 0) //convert keys to integers
+    .reduce((a,b) => a > b ? a : b, 0); //find the largest key (aka highest stack)
+    const maxStackDuration = buffStacks[maxStacks] || 0;
+    const unbuffedDuration = buffStacks[0] || 0;
     return (
       <ItemStatistic
         size="flexible"
         tooltip={(
           <>
-          Average stacks: <b>{this.averageStacks.toFixed(2)}</b>
+          Average stacks: <b>{this.averageStacks.toFixed(1)}</b><br />
+          Time spent without buff: <b>{(unbuffedDuration / 1000).toFixed(0)}s</b> ({formatPercentage(unbuffedDuration / this.owner.fightDuration)}%)<br />
+          {maxStacks !== 0 && <>
+            Time at <b>{maxStacks}</b> stacks: <b>{(maxStackDuration / 1000).toFixed(0)}s </b>({formatPercentage(maxStackDuration / this.owner.fightDuration)}%)
+            </>}
           </>
         )}
       >


### PR DESCRIPTION
Requires https://github.com/WoWAnalyzer/WoWAnalyzer/pull/3137 to be merged first as it utilizes its new stack uptime calculation, do not merge beforehand. I just created this PR already so its functionality can be reviewed.

Adds the leather boots "Stormglide Steps" from crucible of storms.
Example log: https://www.warcraftlogs.com/reports/RDHTGY68yPQ3WJ9r#fight=28source=14

Box:
![image](https://user-images.githubusercontent.com/5396409/57831135-8fafea00-77b4-11e9-865f-d22e7a8cd642.png)

Tooltip:
![image](https://user-images.githubusercontent.com/5396409/57832890-fe8f4200-77b8-11e9-890a-f6e54747f12a.png)

