### PR TITLE
added item and spell IDs for most crucible items

### DIFF
--- a/src/common/ITEMS/bfa/raids/crucibleofstorms/index.js
+++ b/src/common/ITEMS/bfa/raids/crucibleofstorms/index.js
@@ -4,19 +4,138 @@ import ITEM_QUALITIES from 'game/ITEM_QUALITIES';
 export default {
   // Group by boss (with comments)
 
-  // The Restless Cabal
-  LEGGINGS_OF_THE_ABERRANT_TIDESAGE: {
+  /*
+   * The Restless Cabal
+   */
+
+  ABYSSAL_SPEAKERS_GAUNTLETS: { //plate hands
+    id: 167841,
+    name: 'Abyssal Speaker\'s Gauntlets',
+    icon: 'inv_plate_zuldazarraid_d_01_glove',
+    quality: ITEM_QUALITIES.PURPLE,
+  },
+
+  FATHUULS_FLOODGUARDS: { //mail legs
+    id: 167842,
+    name: 'Fa\'thuul\'s Floodguards',
+    icon: 'inv_pants_mail_zuldazarraid_d_01',
+    quality: ITEM_QUALITIES.PURPLE,
+  },
+
+  FATHOM_DREDGERS: { //cloth hands
+    id: 167833,
+    name: 'Fathom Dredgers',
+    icon: 'inv_glove_cloth_zuldazarraid_d_01',
+    quality: ITEM_QUALITIES.PURPLE,
+  },
+
+  GLOVES_OF_THE_UNDYING_PACT: { //leather hands
+    id: 167219,
+    name: 'Gloves of the Undying Pact',
+    icon: 'inv_glove_leather_zuldazarraid_d_01',
+    quality: ITEM_QUALITIES.PURPLE,
+  },
+
+  INSURGENTS_SCOURING_CHAIN: { //mail belt
+    id: 167837,
+    name: 'Insurgent\'s Scouring Chain',
+    icon: 'inv_belt_mail_zuldazarraid_d_01',
+    quality: ITEM_QUALITIES.PURPLE,
+  },
+
+  LEGGINGS_OF_THE_ABERRANT_TIDESAGE: { //leather pants
     id: 167838,
     name: 'Leggings of the Aberrant Tidesage',
     icon: 'inv_pants_leather_zuldazarraid_d_01',
     quality: ITEM_QUALITIES.PURPLE,
   },
 
-  // Uu'nat, Harbinger of the Void
-  TRIDENT_OF_DEEP_OCEAN: {
+  MINDTHIEFS_ELDRITCH_CLASP: { //plate belt
+    id: 167840,
+    name: 'Mindthief\'s Eldritch Clasp',
+    icon: 'inv_plate_zuldazarraid_d_01_belt',
+    quality: ITEM_QUALITIES.PURPLE,
+  },
+
+  PILLAR_OF_THE_DROWNED_CABAL: { //healer staff
+    id: 167863,
+    name: 'Pillar of the Drowned Cabal',
+    icon: 'inv_staff_2h_shrineraid_d_01',
+    quality: ITEM_QUALITIES.PURPLE,
+  },
+
+  ZAXASJS_DEEPSTRIDERS: { //cloth feet
+    id: 167218,
+    name: 'Zaxasj\'s Deepstriders',
+    icon: 'inv_boot_cloth_zuldazarraid_d_01',
+    quality: ITEM_QUALITIES.PURPLE,
+  },
+
+  /*
+   * Uu'nat, Harbinger of the Void
+   */
+
+  GRIPS_OF_FORSAKEN_SANITY: { //mail hands
+    id: 167839,
+    name: 'Grips of Forsaken Sanity',
+    icon: 'inv_glove_mail_zuldazarraid_d_01',
+    quality: ITEM_QUALITIES.PURPLE,
+  },
+
+  HARBINGERS_INSCRUTABLE_WILL: { //int dps trinket
+    id: 167867,
+    name: 'Harbinger\'s Inscrutable Will',
+    icon: 'inv_60pvp_trinket3d',
+    quality: ITEM_QUALITIES.PURPLE,
+  },
+
+  IDOL_OF_INDISCRIMINATE_CONSUMPTION: { //tank trinket
+    id: 167868,
+    name: 'Idol of Indiscriminate Consumption',
+    icon: 'inv_7_0raid_trinket_09d',
+    quality: ITEM_QUALITIES.PURPLE,
+  },
+
+  LEGPLATES_OF_UNBOUND_ANGUISH: { //plate legs
+    id: 167217,
+    name: 'Legplates of Unbound Anguish',
+    icon: 'inv_plate_zuldazarraid_d_01_pants',
+    quality: ITEM_QUALITIES.PURPLE,
+  },
+
+  LURKERS_INSIDIOUS_GIFT: { //agi/str dps trinket
+    id: 167866,
+    name: 'Luker\'s Insidious Gift',
+    icon: 'inv_enchant_voidsphere',
+    quality: ITEM_QUALITIES.PURPLE,
+  },
+
+  MALFORMED_HERALDS_LEGWRAPS: { //cloth legs
+    id: 167835,
+    name: 'Malformed Herald\'s Legwraps',
+    icon: 'inv_pant_cloth_zuldazarraidmythic_d_01',
+    quality: ITEM_QUALITIES.PURPLE,
+  },
+
+  STORMGLIDE_STEPS: { //leather boots
+    id: 167834,
+    name: 'Stormglide Steps',
+    icon: 'inv_boot_leather_zuldazarraid_d_01',
+    quality: ITEM_QUALITIES.PURPLE,
+  },
+
+  TRIDENT_OF_DEEP_OCEAN: { //tank polearm
     id: 167864,
     name: 'Trident of Deep Ocean',
     icon: 'inv_polearm_2h_kthirrelic_d_01',
     quality: ITEM_QUALITIES.PURPLE,
   },
+
+  VOID_STONE: { //healer trinket
+    id: 167865,
+    name: 'Void Stone',
+    icon: 'inv_enchanting_wod_crystal2',
+    quality: ITEM_QUALITIES.PURPLE,
+  },
+
 };

--- a/src/common/SPELLS/bfa/raids/crucibleofstorms/index.js
+++ b/src/common/SPELLS/bfa/raids/crucibleofstorms/index.js
@@ -1,4 +1,5 @@
 import safeMerge from 'common/safeMerge';
 import ITEMS from './items';
+import MECHANICS from './mechanics';
 
-export default safeMerge(ITEMS);
+export default safeMerge(ITEMS, MECHANICS);

--- a/src/common/SPELLS/bfa/raids/crucibleofstorms/items.js
+++ b/src/common/SPELLS/bfa/raids/crucibleofstorms/items.js
@@ -3,7 +3,46 @@
 export default {
   // Group by boss (with comments)
 
-  // The Restless Cabal
+  /*
+   * The Restless Cabal
+   */
+
+  DEEPSTRIDER: { //Zaxasj's Deepstriders
+    id: 295167,
+    name: "Deepstrider",
+    icon: "spell_nature_giftofthewaterspirit",
+  },
+
+  DREDGED_VITALITY: { //Fathom Dredgers
+    id: 295134,
+    name: "Dredged Vitality",
+    icon: "ability_shawaterelemental_swirl",
+  },
+
+  DROWNING_TIDE_DAMAGE: { //Fa'thuul's Floodguards Damage
+    id: 295257,
+    name: "Drowning Tide",
+    icon: "spell_fire_blueflamestrike",
+  },
+
+  DROWNING_TIDE_HEAL: { //Fa'thuul's Floodguards Heal
+    id: 295279,
+    name: "Drowning Tide",
+    icon: "spell_fire_blueflamestrike",
+  },
+
+  EPHEMERAL_VIGOR: { //Abyssal Speaker's Gauntlets
+    id: 295431,
+    name: "Ephemeral Vigor",
+    icon: "spell_priest_shadoworbs",
+  },
+
+  MARINERS_WARD: { //Pillar of the Drowned Cabal
+    id: 295411, // NOT CONFIRMED, NO EXAMPLE LOG FOUND, probably two spells with different IDs? (one for ward, one for healing?)
+    name: "Mariner's Ward",
+    icon: "ability_shaman_watershield",
+  },
+
   NIMBUS_BOLT: { // Leggings of the Aberrant Tidesage Damage
     id: 295811,
     name: "Nimbus Bolt",
@@ -16,7 +55,28 @@ export default {
     icon: "inv_elemental_mote_water01",
   },
 
-  // Uu'nat, Harbinger of the Void
+  PHANTOM_PAIN: { // Mindthief's Eldritch Clasp
+    id: 295446, // NOT CONFIRMED, NO EXAMPLE LOG FOUND, probably two spells with different IDs? (one for damage taken, one for healing?)
+    name: "Phantom Pain",
+    icon: "inv_misc_volatileshadow",
+  },
+
+  SCOURING_WAKE: { //Insurgent's Scouring Chain
+    id: 295141, // NOT CONFIRMED, NO EXAMPLE LOG FOUND
+    name: "Scouring Wake",
+    icon: "spell_frost_summonwaterelemental",
+  },
+
+  UNDYING_PACT: { //Gloves of the Undying Pact
+    id: 295193, // NOT CONFIRMED, NO EXAMPLE LOG FOUND
+    name: "Undying Pact",
+    icon: "inv_misc_volatilewater",
+  },
+
+  /*
+   * Uu'nat, Harbinger of the Void
+   */
+
   CUSTODY_OF_THE_DEEP_SHIELD: { //Trident of Deep Ocean Absorb
     id: 292675,
     name: "Custody of the Deep",
@@ -29,4 +89,75 @@ export default {
     icon: "shaman_pvp_ripplingwaters",
   },
 
+  INDISCRIMINATE_CONSUMPTION: { //Idol of Indiscriminate Consumption
+    id: 295962, // NOT CONFIRMED, NO EXAMPLE LOG FOUND
+    name: "Indiscriminate Consumption",
+    icon: "ability_druid_primaltenacity",
+  },
+
+  INSIDIOUS_GIFT: { //Lurker's Insidious Gift Mastery Buff
+    id: 295408,
+    name: "Insidious Gift",
+    icon: "inv_darkmoon_eye",
+  },
+
+  OBLIVION_SPEAR_DAMAGE: { //Harbinger's Inscrutable Will Damage
+    id: 295393,
+    name: "Oblivion Spear",
+    icon: "spell_fire_twilightpyroblast",
+  },
+
+  OBLIVION_SPEAR_SILENCE: { //Harbinger's Inscrutable Will Silence
+    id: 295395,
+    name: "Oblivion Spear",
+    icon: "spell_fire_twilightpyroblast",
+  },
+
+  SPITEFUL_BINDING: { //Grips of Forsaken Insanity
+    id: 295178,
+    name: "Spiteful Binding",
+    icon: "ability_creature_disease_05",
+  },
+
+  SUFFERING_DAMAGE: { //Lurker's Insidious Gift Damage
+    id: 295410,
+    name: "Suffering",
+    icon: "spell_shadow_painandsuffering",
+  },
+
+  SUFFERING_DEBUFF: { //Lurker's Insidious Gift Debuff
+    id: 295413,
+    name: "Suffering",
+    icon: "spell_shadow_painandsuffering",
+  },
+
+  UMBRAL_SHELL: { //Void Stone
+    id: 295271,
+    name: "Umbral Shell",
+    icon: "spell_warlock_demonsoul",
+  },
+
+  UNBOUND_ANGUISH_DAMAGE: { //Legplates of Unbound Anguish additional Damage Done
+    id: 295428,
+    name: "Unbound Anguish",
+    icon: "ability_warlock_soulswap",
+  },
+
+  UNBOUND_ANGUISH_SACRIFICE: { //Legplates of Unbound Anguish HP sacrificed
+    id: 295866,
+    name: "Unbound Anguish",
+    icon: "ability_warlock_soulswap",
+  },
+
+  VOID_EMBRACE: { //Malformed Herald's Legwraps Haste Buff
+    id: 295174,
+    name: "Void Embrace",
+    icon: "ability_priest_voidentropy",
+  },
+
+  VOID_BACKLASH: { //Malformed Herald's Legwraps Damage Taken
+    id: 295176,
+    name: "Void Backlash",
+    icon: "spell_priest_voidtendrils",
+  },
 };

--- a/src/common/SPELLS/bfa/raids/crucibleofstorms/mechanics.js
+++ b/src/common/SPELLS/bfa/raids/crucibleofstorms/mechanics.js
@@ -1,0 +1,12 @@
+// Mechanics such as Haste buffs or debuffs triggered only in this instance
+
+export default {
+  /*
+   * The Restless Cabal
+   */
+   PROMISES_OF_POWER: {
+     id: 282566,
+     name: "Promises of Power",
+     icon: "spell_priest_void-flay",
+   },
+};


### PR DESCRIPTION
Added the IDs for the on use / equip items from crucible of storms as well as all the spell IDs I could find with the use of public logs. I haven't found logs for every single item so those spell IDs might be incorrect, it is noted where appropriate. This pull request is meant as a baseline for adding statistics boxes for these items in future PRs, which I've been slowly working on one item at a time

Example logs the IDs are extracted from (where I could find logs), I'll update these (as well as relevant spell IDs) as I find more logs:

Abyssal Speaker's Gauntlets: https://www.warcraftlogs.com/reports/7bfnQGY8cKpT94RA#fight=11&source=18&translate=true

Fathom Dredgers: https://www.warcraftlogs.com/reports/vZQfwra1xVK76M4L/#fight=13&source=6

Fathuuls Floodguards: https://www.warcraftlogs.com/reports/Px9pcQwt3rFXjDn7#fight=24&source=186

Gloves of the Undying Pact: none found yet

Grips of Forsaken Sanity: https://www.warcraftlogs.com/reports/K8ZDQLNhJGwBqWjC#fight=17&source=10

Harbinger's Inscrutable Will: https://www.warcraftlogs.com/reports/KkB8jL1HpwxV7NtT#fight=4&source=136

Idol of Indiscriminate Consumption: none found yet

Insurgents Scouring Chain: none found yet

Legplates of Unbound Anguish: https://www.warcraftlogs.com/reports/dFc9GAjyvK2MCxJ1#fight=10&source=6

Lurker's Insidious Gift: https://www.warcraftlogs.com/reports/vZQfwra1xVK76M4L/#fight=13&source=17

Malformed Herald's Legwraps: https://www.warcraftlogs.com/reports/GD6xT8JwbzHqYF3j#fight=22&source=33

Mindthief's Eldritch Clasp: none found yet

Pillar of the Drowned Cabal: none found yet

Void Stone: https://www.warcraftlogs.com/reports/vZQfwra1xVK76M4L/#fight=13&source=6

Zaxasj's Deepstriders: https://www.warcraftlogs.com/reports/xPLfZ4FnqWzA2GKM#fight=9&translate=true&source=10