### PR TITLE
[Prot Pal] Fixed Judgment being reset too often with the CJ talent

### DIFF
--- a/src/parser/paladin/protection/CHANGELOG.js
+++ b/src/parser/paladin/protection/CHANGELOG.js
@@ -5,6 +5,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('17 May 2019'),
+    contributors: [emallson],
+    changes: <>Fixed an issue with <SpellLink id={SPELLS.JUDGMENT_CAST_PROTECTION.id} /> having its cooldown reset too often when using <SpellLink id={SPELLS.CRUSADERS_JUDGMENT_TALENT.id} />. Special thanks to Woliance for helping me work it out.</>,
+  },
+  {
     date: new Date('16 February 2019'),
     contributors: [emallson],
     changes: <><SpellLink id={SPELLS.HAND_OF_THE_PROTECTOR_TALENT.id} /> cast delay is now only tracked for self-targeted casts.</>,

--- a/src/parser/paladin/protection/modules/features/SpellUsable.js
+++ b/src/parser/paladin/protection/modules/features/SpellUsable.js
@@ -24,6 +24,7 @@ class SpellUsable extends CoreSpellUsable {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.HAMMER_OF_THE_RIGHTEOUS.id || spellId === SPELLS.BLESSED_HAMMER_TALENT.id) {
       this.lastPotentialTriggerForAvengersShield = event;
+      this.lastPotentialTriggerForJudgment = event;
     } else if (spellId === SPELLS.AVENGERS_SHIELD.id) {
       this.lastPotentialTriggerForAvengersShield = null;
     } else if (spellId === SPELLS.JUDGMENT_CAST_PROTECTION.id) {
@@ -46,11 +47,11 @@ class SpellUsable extends CoreSpellUsable {
     if (spellId === SPELLS.AVENGERS_SHIELD.id) {
       if (this.isOnCooldown(spellId)) {
         this.gc.triggerInferredReset(this.lastPotentialTriggerForAvengersShield);
-        this.endCooldown(spellId, undefined, this.lastPotentialTriggerForAvengersShield ? this.lastPotentialTriggerForAvengersShield.timestamp : undefined);
+        this.endCooldown(spellId, false, this.lastPotentialTriggerForAvengersShield ? this.lastPotentialTriggerForAvengersShield.timestamp : undefined);
       }
     } else if (this.hasCrusadersJudgment && spellId === SPELLS.JUDGMENT_CAST_PROTECTION.id) {
-      if (this.isOnCooldown(spellId)) {
-        this.endCooldown(spellId, undefined, this.lastPotentialTriggerForJudgment ? this.lastPotentialTriggerForJudgment.timestamp : undefined);
+      if (!this.chargesAvailable(spellId)) {
+        this.endCooldown(spellId, false, this.lastPotentialTriggerForJudgment ? this.lastPotentialTriggerForJudgment.timestamp : undefined);
       }
     }
 

--- a/src/parser/paladin/protection/modules/features/SpellUsable.js
+++ b/src/parser/paladin/protection/modules/features/SpellUsable.js
@@ -50,7 +50,7 @@ class SpellUsable extends CoreSpellUsable {
         this.endCooldown(spellId, false, this.lastPotentialTriggerForAvengersShield ? this.lastPotentialTriggerForAvengersShield.timestamp : undefined);
       }
     } else if (this.hasCrusadersJudgment && spellId === SPELLS.JUDGMENT_CAST_PROTECTION.id) {
-      if (!this.chargesAvailable(spellId)) {
+      if (!this.isAvailable(spellId)) {
         this.endCooldown(spellId, false, this.lastPotentialTriggerForJudgment ? this.lastPotentialTriggerForJudgment.timestamp : undefined);
       }
     }


### PR DESCRIPTION
Crusader's Judgment gives the Judgment ability a 2nd charge and causes it to be reset by Grand Crusader procs. When implementing support for this, I copied from the implementation for Avenger's Shield, which used `this.isOnCooldown` to check for when the cooldown should get reset (the proc doesn't normally appear in logs).

However, `this.isOnCooldown` returns `true` if only 1 of 2 charges is on cooldown. This PR changes it to use `this.isAvailable` instead, which only returns `false` if both charges are on CD. The result is a pretty substantial drop in missed judgment casts across all logs using CJ (which is by far the most common talent to use on every fight).