### PR TITLE
Add Jaina's Frozen Solid to mitigation blacklist

### DIFF
--- a/src/parser/monk/brewmaster/modules/constants/AbilityBlacklist.js
+++ b/src/parser/monk/brewmaster/modules/constants/AbilityBlacklist.js
@@ -17,6 +17,7 @@ const SHARED = [
   285195, // Rastakhan, Deadly Withering
   285000, // Stormwall, Kelp-Wrapped
   287993, // Jaina, Chilling Touch
+  287490, // Jaina, Frozen Solid
   // ULDIR
   266948, // Vectis, Plague Bomb (intermission soak)
   // ANTORUS


### PR DESCRIPTION
Frozen Solid ticks (from being stuck in an ice block) skew otherwise useful info if the brewmaster gets frozen for long enough for mitigation to drop.