### PR TITLE
added lurker's insidious gift

### DIFF
--- a/src/common/SPELLS/bfa/raids/crucibleofstorms/items.js
+++ b/src/common/SPELLS/bfa/raids/crucibleofstorms/items.js
@@ -101,6 +101,12 @@ export default {
     icon: "inv_darkmoon_eye",
   },
 
+  INSIDIOUS_GIFT_CAST: { //Lurker's Insidious Gift Cast
+    id: 295501,
+    name: "Insidious Gift",
+    icon: "inv_enchant_voidsphere",
+  },
+
   OBLIVION_SPEAR_DAMAGE: { //Harbinger's Inscrutable Will Damage
     id: 295393,
     name: "Oblivion Spear",

--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -145,6 +145,7 @@ import CrestOfPaku from '../shared/modules/items/bfa/raids/bod/CrestOfPaku';
 import IncandescentSliver from '../shared/modules/items/bfa/raids/bod/IncandescentSliver';
 // Crucible of Storms
 import LeggingsOfTheAberrantTidesage from '../shared/modules/items/bfa/raids/crucibleofstorms/LeggingsOfTheAberrantTidesage';
+import LurkersInsidiousGift from '../shared/modules/items/bfa/raids/crucibleofstorms/LurkersInsidiousGift';
 import StormglideSteps from '../shared/modules/items/bfa/raids/crucibleofstorms/StormglideSteps';
 import TridentOfDeepOcean from '../shared/modules/items/bfa/raids/crucibleofstorms/TridentOfDeepOcean';
 
@@ -302,6 +303,7 @@ class CombatLogParser {
     incandescentSliver: IncandescentSliver,
     // Crucible of Storms
     leggingsOfTheAberrantTidesage: LeggingsOfTheAberrantTidesage,
+    lurkersInsidiousGift: LurkersInsidiousGift,
     stormglideSteps: StormglideSteps,
     tridentOfDeepOcean: TridentOfDeepOcean,
   };

--- a/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/LurkersInsidiousGift.js
+++ b/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/LurkersInsidiousGift.js
@@ -1,0 +1,145 @@
+import React from 'react';
+
+import { formatNumber, formatPercentage } from 'common/format';
+import { calculateSecondaryStatDefault } from 'common/stats';
+
+import SPELLS from 'common/SPELLS/index';
+import ITEMS from 'common/ITEMS/index';
+
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import Abilities from 'parser/core/modules/Abilities';
+import StatTracker from 'parser/shared/modules/StatTracker';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
+import ItemDamageTaken from 'interface/others/ItemDamageTaken';
+import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
+import MasteryIcon from 'interface/icons/Mastery';
+import { TooltipElement } from 'common/Tooltip';
+import ItemLink from 'common/ItemLink';
+
+//Example Log: https://www.warcraftlogs.com/reports/vZQfwra1xVK76M4L/#fight=13&source=17
+//Second Example Log: https://www.warcraftlogs.com/reports/vZQfwra1xVK76M4L/#fight=13&source=1
+
+class LurkersInsidiousGift extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+    statTracker: StatTracker,
+  };
+
+  static cooldown = 120; //seconds
+  static duration = 30; //seconds
+  static maxStacks = 30;
+
+  stacks = {};
+  uses = 0;
+  damageTaken = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrinket(ITEMS.LURKERS_INSIDIOUS_GIFT.id);
+    if(!this.active) {
+      return;
+    }
+    const item = this.selectedCombatant.getItem(ITEMS.LURKERS_INSIDIOUS_GIFT.id);
+    this.masteryRating = calculateSecondaryStatDefault(395, 881, item.itemLevel);
+    this.statTracker.add(SPELLS.INSIDIOUS_GIFT.id, {
+      mastery: this.masteryRating,
+    });
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.INSIDIOUS_GIFT_CAST), this._cast);
+    this.addEventListener(Events.applydebuffstack.to(SELECTED_PLAYER).spell(SPELLS.SUFFERING_DEBUFF), this._stack);
+    this.addEventListener(Events.damage.to(SELECTED_PLAYER).spell(SPELLS.SUFFERING_DAMAGE), this._takeDamage);
+    this.addEventListener(Events.fightend, this._end);
+
+    this.abilities.add({
+      spell: SPELLS.INSIDIOUS_GIFT_CAST,
+      name: ITEMS.LURKERS_INSIDIOUS_GIFT.name,
+      category: Abilities.SPELL_CATEGORIES.ITEMS,
+      cooldown: this.constructor.cooldown,
+      castEfficiency: {
+        suggestion: true,
+      },
+    });
+  }
+
+  _cast(event){
+    this.uses += 1;
+    this.stacks[this.uses] = 0;
+  }
+
+  _stack(event){
+    this.stacks[this.uses] += 1;
+  }
+
+  _takeDamage(event){
+    this.damageTaken += (event.amount || 0) + (event.absorbed || 0);
+  }
+
+  _end(event){
+    this.stacks[this.uses] = this.constructor.maxStacks; //if fight ends with debuff still running, pretend it ran for all 30 stacks
+  }
+
+  get possibleUseCount() {
+    return Math.ceil(this.owner.fightDuration / (this.constructor.cooldown * 1000));
+  }
+
+  get averageStat(){
+    return this.masteryRating * this.selectedCombatant.getBuffUptime(SPELLS.INSIDIOUS_GIFT.id) / this.owner.fightDuration;
+  }
+
+  get wastedStacks(){
+    const totalStacksGained = Object.values(this.stacks).reduce((total, cur) => {
+      return total + cur;
+    }, 0);
+    const totalStacksPossible = this.uses * this.constructor.maxStacks;
+    return (totalStacksPossible - totalStacksGained) / totalStacksPossible;
+  }
+
+
+  statistic() {
+    return (
+      <ItemStatistic
+        size="flexible"
+        tooltip={(
+          <>
+            Uses: <b>{this.uses}</b> out of <b>{this.possibleUseCount}</b> possible use{this.possibleUseCount !== 1 && <>s</>}<br />
+          </>
+        )}
+      >
+        <BoringItemValueText item={ITEMS.LURKERS_INSIDIOUS_GIFT}>
+          <MasteryIcon /> {formatNumber(this.averageStat)} <small>average Mastery</small><br />
+          <TooltipElement content={`Damage taken: ${formatNumber(this.damageTaken)}`}>
+            <ItemDamageTaken amount={this.damageTaken} />
+          </TooltipElement>
+        </BoringItemValueText>
+      </ItemStatistic>
+    );
+  }
+
+  get suggestedStacks() {
+    return {
+      actual: this.wastedStacks,
+      isGreaterThan: {
+        minor: 0.05,
+        average: 0.08,
+        major: 0.1,
+      },
+      style: 'number',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestedStacks).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <>
+          Your usage of <ItemLink id={ITEMS.LURKERS_INSIDIOUS_GIFT.id} /> can be improved. Try to use it when you will get the most duration out of the mastery buff without having to cancel it (and without losing uses).
+        </>
+      )
+        .icon(ITEMS.LURKERS_INSIDIOUS_GIFT.icon)
+        .actual(`${formatPercentage(actual)}% of stacks wasted.`)
+        .recommended(`<5.00% of stacks wasted is recommended`);
+    });
+  }
+
+}
+
+export default LurkersInsidiousGift;


### PR DESCRIPTION
Adds the Agi DPS trinket "Lurker's Insidious Gift" from Crucible of Storms, including a wasted stack suggestion.

Example logs: 
https://www.warcraftlogs.com/reports/vZQfwra1xVK76M4L/#fight=13&source=17
https://www.warcraftlogs.com/reports/vZQfwra1xVK76M4L/#fight=13&source=1

![image](https://user-images.githubusercontent.com/5396409/58136222-a54a6700-7c2d-11e9-80d0-b1209de221c8.png)

![image](https://user-images.githubusercontent.com/5396409/58136227-a8455780-7c2d-11e9-8f02-5b67cccdecf9.png)
![image](https://user-images.githubusercontent.com/5396409/58136238-aed3cf00-7c2d-11e9-9391-69b0a58ab670.png)

Suggestion:
![image](https://user-images.githubusercontent.com/5396409/58138299-cdd65f00-7c35-11e9-8363-6752ecf2c82f.png)
