### PR TITLE
Buff Uptime Bugfix

### DIFF
--- a/src/parser/core/Entity.js
+++ b/src/parser/core/Entity.js
@@ -114,7 +114,7 @@ class Entity {
           if (buff.end === null && idx === arr.length - 1) {
             // If the buff instance didn't end (usually because it was still active at the end of the fight) we need to manually account for it
             const finalStackUptime = this.owner.currentTimestamp - startTime;
-            stackUptimes[startStacks] += finalStackUptime;
+            stackUptimes[startStacks] = (stackUptimes[startStacks] || 0) + finalStackUptime;
             stackUptimes[0] -= finalStackUptime; //reduce time spent at no stacks by time spent at current stack
           }
         });


### PR DESCRIPTION
#3123 

Fixed an issue with the buff uptime returning "NaN" for a stack the the fight "ends on" if that stack has never been seen before