### PR TITLE
[BrM] fixed purify timeline inefficient cast tooltip

### DIFF
--- a/src/parser/monk/brewmaster/modules/spells/PurifyingBrew.js
+++ b/src/parser/monk/brewmaster/modules/spells/PurifyingBrew.js
@@ -19,10 +19,10 @@ const PURIFY_DELAY_THRESHOLD = 1250; // 1.25s, gives a bit of flexibility in cas
 function markupPurify(event, delay, hasHeavyStagger) {
   const msgs = [];
   if(delay > PURIFY_DELAY_THRESHOLD) {
-    msgs.push(`<li>You delayed casting it for <b>${(delay / 1000).toFixed(2)}s</b> after being hit, allowing Stagger to tick down.</li>`);
+    msgs.push(<li>You delayed casting it for <b>{(delay / 1000).toFixed(2)}s</b> after being hit, allowing Stagger to tick down.</li>);
   }
   if(!hasHeavyStagger) {
-    msgs.push(`<li>You cast without reaching at least Heavy Stagger, which is <em>almost always</em> inefficient.</li>`);
+    msgs.push(<li>You cast without reaching at least Heavy Stagger, which is <em>almost always</em> inefficient.</li>);
   }
 
   if(msgs.length === 0) {
@@ -30,7 +30,10 @@ function markupPurify(event, delay, hasHeavyStagger) {
   }
   const meta = event.meta || {};
   meta.isInefficientCast = true;
-  meta.inefficientCastReason = `This Purifying Brew cast was inefficient because:<ul>${msgs.join('')}</ul>`;
+  meta.inefficientCastReason = <>
+    This Purifying Brew cast was inefficient because:
+    <ul>{msgs}</ul>
+  </>;
   event.meta = meta;
 }
 


### PR DESCRIPTION
Now looks like this
![Screenshot from 2019-05-27 21-44-18](https://user-images.githubusercontent.com/4909458/58445024-e082e500-80c8-11e9-9afd-866cd8fa90ee.png)

Previously had the HTML tags printed in the tooltip