### PR TITLE
Added Idol of Indiscriminate Consumption

### DIFF
--- a/src/common/SPELLS/bfa/raids/crucibleofstorms/items.js
+++ b/src/common/SPELLS/bfa/raids/crucibleofstorms/items.js
@@ -89,8 +89,14 @@ export default {
     icon: "shaman_pvp_ripplingwaters",
   },
 
-  INDISCRIMINATE_CONSUMPTION: { //Idol of Indiscriminate Consumption
-    id: 295962, // NOT CONFIRMED, NO EXAMPLE LOG FOUND
+  INDISCRIMINATE_CONSUMPTION: { //Idol of Indiscriminate Consumption Damage / Cast
+    id: 295962,
+    name: "Indiscriminate Consumption",
+    icon: "ability_druid_primaltenacity",
+  },
+
+  INDISCRIMINATE_CONSUMPTION_HEAL: { //Idol of Indiscriminate Consumption Heal
+    id: 297668,
     name: "Indiscriminate Consumption",
     icon: "ability_druid_primaltenacity",
   },
@@ -154,13 +160,13 @@ export default {
     name: "Unbound Anguish",
     icon: "ability_warlock_soulswap",
   },
-  
+
   UNTOUCHABLE: { //Stormglide Steps Crit Buff
     id: 295278,
     name: "Untouchable",
     icon: "ability_monk_ridethewind",
   },
-  
+
   VOID_EMBRACE: { //Malformed Herald's Legwraps Haste Buff
     id: 295174,
     name: "Void Embrace",

--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -144,6 +144,7 @@ import WardOfEnvelopment from '../shared/modules/items/bfa/raids/bod/WardOfEnvel
 import CrestOfPaku from '../shared/modules/items/bfa/raids/bod/CrestOfPaku';
 import IncandescentSliver from '../shared/modules/items/bfa/raids/bod/IncandescentSliver';
 // Crucible of Storms
+import IdolOfIndiscriminateConsumption from '../shared/modules/items/bfa/raids/crucibleofstorms/IdolOfIndiscriminateConsumption';
 import LeggingsOfTheAberrantTidesage from '../shared/modules/items/bfa/raids/crucibleofstorms/LeggingsOfTheAberrantTidesage';
 import LurkersInsidiousGift from '../shared/modules/items/bfa/raids/crucibleofstorms/LurkersInsidiousGift';
 import StormglideSteps from '../shared/modules/items/bfa/raids/crucibleofstorms/StormglideSteps';
@@ -303,6 +304,7 @@ class CombatLogParser {
     crestOfPaku: CrestOfPaku,
     incandescentSliver: IncandescentSliver,
     // Crucible of Storms
+    idolOfIndiscriminateConsumption: IdolOfIndiscriminateConsumption,
     leggingsOfTheAberrantTidesage: LeggingsOfTheAberrantTidesage,
     lurkersInsidiousGift: LurkersInsidiousGift,
     stormglideSteps: StormglideSteps,

--- a/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/IdolOfIndiscriminateConsumption.js
+++ b/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/IdolOfIndiscriminateConsumption.js
@@ -1,0 +1,219 @@
+import React from 'react';
+
+import ITEMS from 'common/ITEMS/index';
+import SPELLS from 'common/SPELLS/index';
+
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import Abilities from 'parser/core/modules/Abilities';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
+import ItemHealingDone from 'interface/others/ItemHealingDone';
+import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
+import { formatNumber, formatPercentage, formatDuration } from 'common/format';
+import { TooltipElement } from 'common/Tooltip';
+import ItemLink from 'common/ItemLink';
+
+// Example log: https://www.warcraftlogs.com/reports/D4LF8KhaAmBJ6T7x#fight=13&source=5
+
+class IdolOfIndiscriminateConsumption extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+  };
+
+  static cooldown = 60; //seconds
+  static maxTargets = 7;
+  casts = 0;
+  byCast = {};
+
+  constructor(...args){
+    super(...args);
+    this.active = this.selectedCombatant.hasTrinket(ITEMS.IDOL_OF_INDISCRIMINATE_CONSUMPTION.id);
+    if(!this.active){
+      return;
+    }
+
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.INDISCRIMINATE_CONSUMPTION), this._damage);
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.INDISCRIMINATE_CONSUMPTION_HEAL), this._heal);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.INDISCRIMINATE_CONSUMPTION), this._cast);
+
+    this.abilities.add({
+      spell: SPELLS.INDISCRIMINATE_CONSUMPTION,
+      name: ITEMS.IDOL_OF_INDISCRIMINATE_CONSUMPTION.name,
+      category: Abilities.SPELL_CATEGORIES.ITEMS,
+      cooldown: this.constructor.cooldown,
+      castEfficiency: {
+        suggestion: false,
+      },
+    });
+  }
+
+  _cast(event){
+    this.casts += 1;
+    this.byCast[this.casts] = {
+      time: event.timestamp - this.owner.fight.start_time,
+      healing: 0,
+      overHealing: 0,
+      damage: 0,
+      friendlyDamage: 0,
+      targets: 0,
+      missingHP: event.maxHitPoints - event.hitPoints,
+    };
+  }
+
+  _damage(event){
+    const amount = (event.amount || 0) + (event.absorbed || 0);
+    if(event.targetIsFriendly){
+      this.byCast[this.casts].friendlyDamage += amount;
+    }else{
+      this.byCast[this.casts].damage += amount;
+    }
+    this.byCast[this.casts].targets += 1;
+  }
+
+  _heal(event){
+    this.byCast[this.casts].healing += (event.amount || 0) + (event.absorbed || 0);
+    this.byCast[this.casts].overHealing += event.overheal || 0;
+  }
+
+  get overhealPercent() {
+    return this.overHealing / this.totalHealing;
+  }
+
+  get damage(){
+    return Object.values(this.byCast).reduce((total, cur) => total + cur.damage, 0);
+  }
+
+  get healing(){
+    return Object.values(this.byCast).reduce((total, cur) => total + cur.healing, 0);
+  }
+
+  get overHealing(){
+    return Object.values(this.byCast).reduce((total, cur) => total + cur.overHealing, 0);
+  }
+
+  get friendlyDamage(){
+    return Object.values(this.byCast).reduce((total, cur) => total + cur.friendlyDamage, 0);
+  }
+
+  get totalHealing(){
+    return Object.values(this.byCast).reduce((total, cur) => total + cur.healing + cur.overHealing, 0);
+  }
+
+  get totalDamage(){
+    return Object.values(this.byCast).reduce((total, cur) => total + cur.friendlyDamage + cur.damage, 0);
+  }
+
+  statistic() {
+    return (
+      <ItemStatistic
+        size="flexible"
+        tooltip={(
+          <>
+          Uses: {this.casts}<br />
+          Damage to allies: {formatNumber(this.friendlyDamage)}<br />
+          Damage to enemies: {formatNumber(this.damage)}
+          </>
+        )}
+        dropdown={(
+          <table className="table table-condensed">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Healing</th>
+                <th>OH</th>
+                <th>Enemy Damage</th>
+                <th>Ally Damage</th>
+              </tr>
+            </thead>
+            <tbody>
+              {
+                Object.keys(this.byCast).map(cast => {
+                  return (
+                    <tr key={cast}>
+                      <th>{formatDuration(this.byCast[cast].time / 1000)}</th>
+                      <td>{formatNumber(this.byCast[cast].healing)}</td>
+                      <td>{formatNumber(this.byCast[cast].overHealing)}</td>
+                      <td>{formatNumber(this.byCast[cast].damage)}</td>
+                      <td>{formatNumber(this.byCast[cast].friendlyDamage)}</td>
+                    </tr>
+                  );
+                })
+              }
+            </tbody>
+          </table>
+        )}
+      >
+        <BoringItemValueText item={ITEMS.IDOL_OF_INDISCRIMINATE_CONSUMPTION}>
+          <TooltipElement content={`Healing done: ${formatNumber(this.healing)} (${formatPercentage(this.overhealPercent)}% OH)`}>
+            <ItemHealingDone amount={this.healing} />
+          </TooltipElement>
+        </BoringItemValueText>
+      </ItemStatistic>
+    );
+  }
+
+  get suggestedOverheal() {
+    return {
+      actual: this.overhealPercent,
+      isGreaterThan: {
+        minor: 0.20,
+        average: 0.30,
+        major: 0.40,
+      },
+      style: 'number',
+    };
+  }
+
+  get ineffectiveCasts(){
+    const ineffective = Object.keys(this.byCast).reduce((total, cast) => {
+      if(this.byCast[cast].overHealing > 0 || this.byCast[cast].targets === this.constructor.maxTargets){
+        return total;
+      }
+      const healPerTarget = this.byCast[cast].healing / this.byCast[cast].targets;
+      if(this.byCast[cast].missingHP >= (healPerTarget*0.9)){//if missing health could be at least partially filled with another target at 10% overheal, consider cast ineffective
+        return total + 1;
+      }
+      return total;
+    }, 0);
+    return ineffective / this.casts;
+  }
+
+  get suggestedHitCount() {
+    return {
+      actual: this.ineffectiveCasts,
+      isGreaterThan: {
+        minor: 0.10,
+        average: 0.25,
+        major: 0.50,
+      },
+      style: 'number',
+    };
+  }
+
+  suggestions(when) {
+    console.log(this.byCast);
+    when(this.suggestedOverheal).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <>
+          Your usage of <ItemLink id={ITEMS.IDOL_OF_INDISCRIMINATE_CONSUMPTION.id} /> can be improved. Try to use it when you will get the least overhealing out of it.
+        </>
+      )
+        .icon(ITEMS.IDOL_OF_INDISCRIMINATE_CONSUMPTION.icon)
+        .actual(`${formatPercentage(actual)}% average overheal.`)
+        .recommended(`<20% is recommended`);
+    });
+    when(this.suggestedHitCount).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <>
+          Your usage of <ItemLink id={ITEMS.IDOL_OF_INDISCRIMINATE_CONSUMPTION.id} /> can be improved. Try to hit enough targets to heal to full.
+        </>
+      )
+        .icon(ITEMS.IDOL_OF_INDISCRIMINATE_CONSUMPTION.icon)
+        .actual(`${formatPercentage(actual)}% of casts could've hit additional targets without causing overhealing.`)
+        .recommended(`<10% is recommended`);
+    });
+  }
+
+}
+
+export default IdolOfIndiscriminateConsumption;

--- a/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/IdolOfIndiscriminateConsumption.js
+++ b/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/IdolOfIndiscriminateConsumption.js
@@ -191,7 +191,6 @@ class IdolOfIndiscriminateConsumption extends Analyzer {
   }
 
   suggestions(when) {
-    console.log(this.byCast);
     when(this.suggestedOverheal).addSuggestion((suggest, actual, recommended) => {
       return suggest(
         <>


### PR DESCRIPTION
Added the tank trinket "idol of indiscriminate consumption" from crucible of storms

Example log: https://www.warcraftlogs.com/reports/D4LF8KhaAmBJ6T7x#fight=13&source=5

![image](https://user-images.githubusercontent.com/5396409/58508934-9ae01e00-8195-11e9-9ded-cfebfd8f4951.png)

![image](https://user-images.githubusercontent.com/5396409/58508940-9ddb0e80-8195-11e9-9896-81c47e690509.png)

![image](https://user-images.githubusercontent.com/5396409/58508954-a6cbe000-8195-11e9-9c91-b8ca02540847.png)

![image](https://user-images.githubusercontent.com/5396409/58609764-167ebf80-82a9-11e9-83b2-f9304d8a44fd.png)


