### PR TITLE
Added legplates of unbound anguish

### DIFF
--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -145,6 +145,7 @@ import CrestOfPaku from '../shared/modules/items/bfa/raids/bod/CrestOfPaku';
 import IncandescentSliver from '../shared/modules/items/bfa/raids/bod/IncandescentSliver';
 // Crucible of Storms
 import LeggingsOfTheAberrantTidesage from '../shared/modules/items/bfa/raids/crucibleofstorms/LeggingsOfTheAberrantTidesage';
+import LegplatesOfUnboundAnguish from '../shared/modules/items/bfa/raids/crucibleofstorms/LegplatesOfUnboundAnguish';
 import LurkersInsidiousGift from '../shared/modules/items/bfa/raids/crucibleofstorms/LurkersInsidiousGift';
 import StormglideSteps from '../shared/modules/items/bfa/raids/crucibleofstorms/StormglideSteps';
 import TridentOfDeepOcean from '../shared/modules/items/bfa/raids/crucibleofstorms/TridentOfDeepOcean';
@@ -304,6 +305,7 @@ class CombatLogParser {
     incandescentSliver: IncandescentSliver,
     // Crucible of Storms
     leggingsOfTheAberrantTidesage: LeggingsOfTheAberrantTidesage,
+    legplatesOfUnboundAnguish: LegplatesOfUnboundAnguish,
     lurkersInsidiousGift: LurkersInsidiousGift,
     stormglideSteps: StormglideSteps,
     tridentOfDeepOcean: TridentOfDeepOcean,

--- a/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/LegplatesOfUnboundAnguish.js
+++ b/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/LegplatesOfUnboundAnguish.js
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import ITEMS from 'common/ITEMS/index';
+import SPELLS from 'common/SPELLS/index';
+
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
+import ItemDamageTaken from 'interface/others/ItemDamageTaken';
+import ItemDamageDone from 'interface/others/ItemDamageDone';
+import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
+import { formatNumber } from 'common/format';
+import { TooltipElement } from 'common/Tooltip';
+
+// Example log: https://www.warcraftlogs.com/reports/dFc9GAjyvK2MCxJ1#fight=10&source=6
+
+class LegplatesOfUnboundAnguish extends Analyzer {
+
+  damage = 0;
+  damageTaken = 0;
+
+  constructor(...args){
+    super(...args);
+    this.active = this.selectedCombatant.hasLegs(ITEMS.LEGPLATES_OF_UNBOUND_ANGUISH.id);
+    if(!this.active){
+      return;
+    }
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.UNBOUND_ANGUISH_DAMAGE), this._damage);
+    this.addEventListener(Events.damage.to(SELECTED_PLAYER).spell(SPELLS.UNBOUND_ANGUISH_SACRIFICE), this._sacrifice);
+  }
+
+  _damage(event) {
+    this.damage += (event.amount || 0) + (event.absorbed || 0);
+  }
+
+  _sacrifice(event) {
+    this.damageTaken += (event.amount || 0) + (event.absorbed || 0);
+  }
+
+  statistic() {
+    return (
+      <ItemStatistic
+        size="flexible"
+      >
+        <BoringItemValueText item={ITEMS.LEGPLATES_OF_UNBOUND_ANGUISH}>
+          <TooltipElement content={`Damage done: ${formatNumber(this.damage)}`}>
+            <ItemDamageDone amount={this.damage} />
+            </TooltipElement><br />
+          <TooltipElement content={`Health sacrificed: ${formatNumber(this.damageTaken)}`}>
+            <ItemDamageTaken amount={this.damageTaken} />
+          </TooltipElement>
+        </BoringItemValueText>
+      </ItemStatistic>
+    );
+  }
+
+}
+
+export default LegplatesOfUnboundAnguish;


### PR DESCRIPTION
Adds the plate legs "legplates of unbound anguish"

Example log: https://www.warcraftlogs.com/reports/dFc9GAjyvK2MCxJ1#fight=10&source=6

![image](https://user-images.githubusercontent.com/5396409/58512391-4a6cbe80-819d-11e9-91c4-c9a5c601ab43.png)

![image](https://user-images.githubusercontent.com/5396409/58512403-4e98dc00-819d-11e9-91a6-9bb5875c45eb.png)

![image](https://user-images.githubusercontent.com/5396409/58512419-55275380-819d-11e9-8717-0af1d8aaee31.png)

