### PR TITLE
Fa'thuul's floodguards

### DIFF
--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -144,6 +144,7 @@ import WardOfEnvelopment from '../shared/modules/items/bfa/raids/bod/WardOfEnvel
 import CrestOfPaku from '../shared/modules/items/bfa/raids/bod/CrestOfPaku';
 import IncandescentSliver from '../shared/modules/items/bfa/raids/bod/IncandescentSliver';
 // Crucible of Storms
+import FathuulsFloodguards from '../shared/modules/items/bfa/raids/crucibleofstorms/FathuulsFloodguards';
 import LeggingsOfTheAberrantTidesage from '../shared/modules/items/bfa/raids/crucibleofstorms/LeggingsOfTheAberrantTidesage';
 import LurkersInsidiousGift from '../shared/modules/items/bfa/raids/crucibleofstorms/LurkersInsidiousGift';
 import StormglideSteps from '../shared/modules/items/bfa/raids/crucibleofstorms/StormglideSteps';
@@ -303,6 +304,7 @@ class CombatLogParser {
     crestOfPaku: CrestOfPaku,
     incandescentSliver: IncandescentSliver,
     // Crucible of Storms
+    fathuulsFloodguards: FathuulsFloodguards,
     leggingsOfTheAberrantTidesage: LeggingsOfTheAberrantTidesage,
     lurkersInsidiousGift: LurkersInsidiousGift,
     stormglideSteps: StormglideSteps,

--- a/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/FathuulsFloodguards.js
+++ b/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/FathuulsFloodguards.js
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import ITEMS from 'common/ITEMS/index';
+import SPELLS from 'common/SPELLS/index';
+
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
+import ItemHealingDone from 'interface/others/ItemHealingDone';
+import ItemDamageDone from 'interface/others/ItemDamageDone';
+import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
+import { formatNumber, formatPercentage } from 'common/format';
+import { TooltipElement } from 'common/Tooltip';
+
+// Example log: https://www.warcraftlogs.com/reports/Px9pcQwt3rFXjDn7#fight=24&source=186
+
+class FathuulsFloodguards extends Analyzer {
+  damage = 0;
+  healing = 0;
+  overHealing = 0;
+
+  constructor(...args){
+    super(...args);
+    this.active = this.selectedCombatant.hasLegs(ITEMS.FATHUULS_FLOODGUARDS.id);
+    if(!this.active){
+      return;
+    }
+
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.DROWNING_TIDE_DAMAGE), this._damage);
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.DROWNING_TIDE_HEAL), this._heal);
+  }
+
+  _damage(event){
+    this.damage += (event.amount || 0) + (event.absorbed || 0);
+  }
+
+  _heal(event){
+    this.healing += (event.amount || 0) + (event.absorbed || 0);
+    this.overHealing += event.overheal || 0;
+  }
+
+  get overhealPercent() {
+    return this.overHealing / (this.healing + this.overHealing);
+  }
+
+  statistic() {
+    return (
+      <ItemStatistic
+        size="flexible"
+      >
+        <BoringItemValueText item={ITEMS.FATHUULS_FLOODGUARDS}>
+          <TooltipElement content={`Damage done: ${formatNumber(this.damage)}`}>
+            <ItemDamageDone amount={this.damage} />
+            </TooltipElement><br />
+          <TooltipElement content={`Healing done: ${formatNumber(this.healing)} (${formatPercentage(this.overhealPercent)}% OH)`}>
+            <ItemHealingDone amount={this.healing} />
+          </TooltipElement>
+        </BoringItemValueText>
+      </ItemStatistic>
+    );
+  }
+
+}
+
+export default FathuulsFloodguards;


### PR DESCRIPTION
Adds mail legs Fa'thuul's Floodguards from crucible of storms
Example log: https://www.warcraftlogs.com/reports/Px9pcQwt3rFXjDn7#fight=24&source=186

![image](https://user-images.githubusercontent.com/5396409/58531360-4f079600-81e2-11e9-94a8-1b66c04b4cb7.png)

![image](https://user-images.githubusercontent.com/5396409/58531368-52028680-81e2-11e9-920e-ffdbeeae3bc3.png)

![image](https://user-images.githubusercontent.com/5396409/58531370-54fd7700-81e2-11e9-90de-025791404fff.png)
