### PR TITLE
Grips of forsaken sanity

### DIFF
--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -144,6 +144,7 @@ import WardOfEnvelopment from '../shared/modules/items/bfa/raids/bod/WardOfEnvel
 import CrestOfPaku from '../shared/modules/items/bfa/raids/bod/CrestOfPaku';
 import IncandescentSliver from '../shared/modules/items/bfa/raids/bod/IncandescentSliver';
 // Crucible of Storms
+import GripsOfForsakenSanity from '../shared/modules/items/bfa/raids/crucibleofstorms/GripsOfForsakenSanity';
 import LeggingsOfTheAberrantTidesage from '../shared/modules/items/bfa/raids/crucibleofstorms/LeggingsOfTheAberrantTidesage';
 import LurkersInsidiousGift from '../shared/modules/items/bfa/raids/crucibleofstorms/LurkersInsidiousGift';
 import StormglideSteps from '../shared/modules/items/bfa/raids/crucibleofstorms/StormglideSteps';
@@ -303,6 +304,7 @@ class CombatLogParser {
     crestOfPaku: CrestOfPaku,
     incandescentSliver: IncandescentSliver,
     // Crucible of Storms
+    gripsOfForsakenSanity: GripsOfForsakenSanity,
     leggingsOfTheAberrantTidesage: LeggingsOfTheAberrantTidesage,
     lurkersInsidiousGift: LurkersInsidiousGift,
     stormglideSteps: StormglideSteps,

--- a/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/GripsOfForsakenSanity.js
+++ b/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/GripsOfForsakenSanity.js
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import ITEMS from 'common/ITEMS/index';
+import SPELLS from 'common/SPELLS/index';
+
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
+import ItemDamageTaken from 'interface/others/ItemDamageTaken';
+import ItemDamageDone from 'interface/others/ItemDamageDone';
+import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
+import { formatNumber } from 'common/format';
+import { TooltipElement } from 'common/Tooltip';
+
+// Example log: https://www.warcraftlogs.com/reports/K8ZDQLNhJGwBqWjC#fight=17&source=10
+
+class GripsOfForsakenSanity extends Analyzer {
+  damage = 0;
+  damageTaken = 0;
+
+  constructor(...args){
+    super(...args);
+    this.active = this.selectedCombatant.hasHands(ITEMS.GRIPS_OF_FORSAKEN_SANITY.id);
+    if(!this.active){
+      return;
+    }
+
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.SPITEFUL_BINDING), this._damage);
+  }
+
+  _damage(event){
+    const amount = (event.amount || 0) + (event.absorbed || 0);
+    if(event.targetID === event.sourceID){
+      this.damageTaken += amount;
+    }else{
+      this.damage += amount;
+    }
+  }
+
+  statistic() {
+    return (
+      <ItemStatistic
+        size="flexible"
+      >
+        <BoringItemValueText item={ITEMS.GRIPS_OF_FORSAKEN_SANITY}>
+          <TooltipElement content={`Damage done: ${formatNumber(this.damage)}`}>
+            <ItemDamageDone amount={this.damage} />
+            </TooltipElement><br />
+          <TooltipElement content={`Damage taken: ${formatNumber(this.damageTaken)}`}>
+            <ItemDamageTaken amount={this.damageTaken} />
+          </TooltipElement>
+        </BoringItemValueText>
+      </ItemStatistic>
+    );
+  }
+
+}
+
+export default GripsOfForsakenSanity;


### PR DESCRIPTION
Adds the mail hands "grips of forsaken sanity" from crucible of storms
Example log: https://www.warcraftlogs.com/reports/K8ZDQLNhJGwBqWjC#fight=17&source=10

![image](https://user-images.githubusercontent.com/5396409/58532647-82e4ba80-81e6-11e9-93d9-0dfa4029c1db.png)

![image](https://user-images.githubusercontent.com/5396409/58532654-86784180-81e6-11e9-9a6a-2eccf74d9a89.png)

![image](https://user-images.githubusercontent.com/5396409/58532658-88da9b80-81e6-11e9-81a0-26a050539778.png)

