### PR TITLE
Dev/ignition mages fuse

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Yajinni, Mamtooth, Zerotorescue, Putro, joshinator, Gebuz, ackwell, emallson, blazyb, Dambroda, Nalhan, Satyric, niseko, Khadaj, Fyruna, Matardarix, jos3p, Aelexe, Chizu, Hartra344, Hordehobbs, Dorixius, Sharrq, Scotsoo } from 'CONTRIBUTORS';
+import { Yajinni, Mamtooth, Zerotorescue, Putro, joshinator, Gebuz, ackwell, emallson, blazyb, Dambroda, Nalhan, Satyric, niseko, Khadaj, Fyruna, Matardarix, jos3p, Aelexe, Chizu, Hartra344, Hordehobbs, Dorixius, Sharrq, Scotsoo, HolySchmidt } from 'CONTRIBUTORS';
 import ItemLink from 'common/ItemLink';
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
@@ -7,6 +7,11 @@ import SpellLink from 'common/SpellLink';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  {
+    date: new Date('2019-06-02'),
+    changes: <>Added a <SpellLink id={SPELLS.IGNITION_MAGES_FUSE_BUFF.id} /> module to track usage and average haste gained.</>,
+    contributors: [HolySchmidt],
+  },
   {
     date: new Date('2019-05-12'),
     changes: 'Added average heart of azeroth level to the player selection page',

--- a/src/common/SPELLS/bfa/dungeons/items.js
+++ b/src/common/SPELLS/bfa/dungeons/items.js
@@ -72,6 +72,13 @@ export default {
     icon: 'inv_misc_redsaberonfang',
   },
 
+  // Tol Dogar
+  IGNITION_MAGES_FUSE_BUFF: {
+    id: 271115,
+    name: 'Ignition Mage\'s Fuse',
+    icon: 'inv_misc_rope_01',
+  },
+
   // Shrine of the Storm
   CONCH_OF_DARK_WHISPERS_BUFF: {
     id: 271071,

--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -88,6 +88,8 @@ import RotcrustedVoodooDoll from '../shared/modules/items/bfa/dungeons/Rotcruste
 import AzerokksResonatingHeart from '../shared/modules/items/bfa/dungeons/AzerokksResonatingHeart';
 import VesselOfSkitteringShadows from '../shared/modules/items/bfa/dungeons/VesselOfSkitteringShadows';
 import LadyWaycrestsMusicBox from '../shared/modules/items/bfa/dungeons/LadyWaycrestsMusicBox';
+import IgnitionMagesFuse from '../shared/modules/items/bfa/dungeons/IgnitionMagesFuse';
+
 // PVP
 import DreadGladiatorsMedallion from '../shared/modules/items/bfa/pvp/DreadGladiatorsMedallion';
 import DreadGladiatorsInsignia from '../shared/modules/items/bfa/pvp/DreadGladiatorsInsignia';
@@ -247,6 +249,8 @@ class CombatLogParser {
     azerokksResonatingHeart: AzerokksResonatingHeart,
     vesselOfSkitteringShadows: VesselOfSkitteringShadows,
     ladyWaycrestsMusicBox: LadyWaycrestsMusicBox,
+    ingnitionMagesFuse: IgnitionMagesFuse,
+    
     // PVP
     dreadGladiatorsMedallion: DreadGladiatorsMedallion,
     dreadGladiatorsInsignia: DreadGladiatorsInsignia,

--- a/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
+import UptimeIcon from 'interface/icons/Uptime';
+import HasteIcon from 'interface/icons/Haste';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
+import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
+import Analyzer from 'parser/core/Analyzer';
+import { formatPercentage, formatNumber } from 'common/format';
+import { calculateSecondaryStatDefault } from 'common/stats';
+
+/**
+ * Ignition Mage's Fuse -
+ * Use: Ignite the fuse, gaining 312 Haste every 4 sec. Haste is removed after 20 sec.
+ */
+class IgnitionMagesFuse extends Analyzer {
+  statBuff = 0;
+  statBudget = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrinket(ITEMS.IGNITION_MAGES_FUSE.id);
+
+    if(this.active) {
+      this.statBuff = calculateSecondaryStatDefault(300, 84, this.selectedCombatant.getItem(ITEMS.IgnitionMagesFuse.id).itemLevel);
+      this.statBudget = calculateSecondaryStatDefault(340, 200, this.selectedCombatant.getItem(ITEMS.IgnitionMagesFuse.id).itemLevel);
+    }
+
+  }
+
+  get totalBuffUptime() {
+    return this.selectedCombatant.getBuffUptime(SPELLS.IgnitionMagesFuse_BUFF.id) / this.owner.fightDuration;
+  }
+
+  get averageStatGain(){
+    const averageStacks = this.selectedCombatant.getStackWeightedBuffUptime(SPELLS.IgnitionMagesFuse_BUFF.id) / this.owner.fightDuration;
+    return averageStacks * this.statBuff;
+  }
+
+  statistic() {
+    return (
+      <ItemStatistic
+        size="flexible"
+        tooltip={`The stat budget for a non-proc main hand would yield ${formatNumber(this.statBudget)} secondary stats`}
+      >
+        <BoringItemValueText item={ITEMS.IgnitionMagesFuse}>
+          <UptimeIcon /> {formatPercentage(this.totalBuffUptime)}% <small>uptime</small> <br />
+          <HasteIcon /> {formatNumber(this.averageStatGain)} <small>average Haste gained</small>
+        </BoringItemValueText>
+      </ItemStatistic>
+    );
+  }
+}
+
+export default IgnitionMagesFuse;

--- a/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
@@ -44,14 +44,16 @@ class IgnitionMagesFuse extends Analyzer {
 
     this.statBuff = calculateSecondaryStatDefault(340, 164, this.selectedCombatant.getItem(ITEMS.IGNITION_MAGES_FUSE.id).itemLevel);
     this.addEventListener(Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.IGNITION_MAGES_FUSE_BUFF), this.onUse);
-  
     this.abilities.add({
       spell: SPELLS.IGNITION_MAGES_FUSE_BUFF,
+      buffSpellId: SPELLS.IGNITION_MAGES_FUSE_BUFF.id,
       name: ITEMS.IGNITION_MAGES_FUSE.name,
       category: Abilities.SPELL_CATEGORIES.ITEMS,
       cooldown: ACTIVATION_COOLDOWN,
+      gcd: null,
       castEfficiency: {
         suggestion: true,
+        casts: () => this.uses,
       },
     });
   }

--- a/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
@@ -9,32 +9,46 @@ import BoringItemValueText from 'interface/statistics/components/BoringItemValue
 import Analyzer from 'parser/core/Analyzer';
 import { formatPercentage, formatNumber } from 'common/format';
 import { calculateSecondaryStatDefault } from 'common/stats';
-
+import StatTracker from 'parser/shared/modules/StatTracker';
 /**
- * Ignition Mage's Fuse -
- * Use: Ignite the fuse, gaining 312 Haste every 4 sec. Haste is removed after 20 sec.
+  Ignition Mage's Fuse
+  Item Level 340
+  Binds when picked up
+  Unique-Equipped
+  Trinket	
+  +205 Intellect
+  Use: Ignite the fuse, gaining 168 Haste every 4 sec. Haste is removed after 20 sec. (2 Min Cooldown)
  */
+
 class IgnitionMagesFuse extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+    statTracker: StatTracker,
+  };
+
   statBuff = 0;
-  statBudget = 0;
+  casts = 0;
 
   constructor(...args) {
     super(...args);
     this.active = this.selectedCombatant.hasTrinket(ITEMS.IGNITION_MAGES_FUSE.id);
 
     if(this.active) {
-      this.statBuff = calculateSecondaryStatDefault(300, 84, this.selectedCombatant.getItem(ITEMS.IgnitionMagesFuse.id).itemLevel);
-      this.statBudget = calculateSecondaryStatDefault(340, 200, this.selectedCombatant.getItem(ITEMS.IgnitionMagesFuse.id).itemLevel);
+      this.statBuff = calculateSecondaryStatDefault(340, 164, this.selectedCombatant.getItem(ITEMS.IGNITION_MAGES_FUSE.id).itemLevel);
+      this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.IGNITION_MAGES_FUSE.id), this.onCast);
     }
+  }
 
+  onCast(event) {
+    this.casts += 1;
   }
 
   get totalBuffUptime() {
-    return this.selectedCombatant.getBuffUptime(SPELLS.IgnitionMagesFuse_BUFF.id) / this.owner.fightDuration;
+    return this.selectedCombatant.getBuffUptime(SPELLS.IGNITION_MAGES_FUSE.id) / this.owner.fightDuration;
   }
 
   get averageStatGain(){
-    const averageStacks = this.selectedCombatant.getStackWeightedBuffUptime(SPELLS.IgnitionMagesFuse_BUFF.id) / this.owner.fightDuration;
+    const averageStacks = this.selectedCombatant.getStackWeightedBuffUptime(SPELLS.IGNITION_MAGES_FUSE.id) / this.owner.fightDuration;
     return averageStacks * this.statBuff;
   }
 
@@ -42,15 +56,14 @@ class IgnitionMagesFuse extends Analyzer {
     return (
       <ItemStatistic
         size="flexible"
-        tooltip={`The stat budget for a non-proc main hand would yield ${formatNumber(this.statBudget)} secondary stats`}
       >
-        <BoringItemValueText item={ITEMS.IgnitionMagesFuse}>
-          <UptimeIcon /> {formatPercentage(this.totalBuffUptime)}% <small>uptime</small> <br />
-          <HasteIcon /> {formatNumber(this.averageStatGain)} <small>average Haste gained</small>
+        <BoringItemValueText item={ITEMS.IGNITION_MAGES_FUSE}>
+          <HasteIcon /> {formatNumber(this.averageStatGain)} <small>average Haste gained</small> <br />
         </BoringItemValueText>
       </ItemStatistic>
     );
   }
 }
+
 
 export default IgnitionMagesFuse;

--- a/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
@@ -1,13 +1,15 @@
 import React from 'react';
+
+import { formatNumber, formatPercentage } from 'common/format';
+import { calculateSecondaryStatDefault } from 'common/stats';
+
 import SPELLS from 'common/SPELLS/index';
 import ITEMS from 'common/ITEMS/index';
 
 import Abilities from 'parser/core/modules/Abilities';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
-import { calculateSecondaryStatDefault } from 'common/stats';
 import Events from 'parser/core/Events';
-import { formatNumber, formatPercentage } from 'common/format';
 import HasteIcon from 'interface/icons/Haste';
 import ItemStatistic from 'interface/statistics/ItemStatistic';
 import StatTracker from 'parser/shared/modules/StatTracker';
@@ -26,6 +28,7 @@ const ACTIVATION_COOLDOWN = 120; // seconds
 
 class IgnitionMagesFuse extends Analyzer {
   static dependencies = {
+    abilities: Abilities,
     statTracker: StatTracker,
   };
 

--- a/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
@@ -54,6 +54,7 @@ class IgnitionMagesFuse extends Analyzer {
       castEfficiency: {
         suggestion: true,
         casts: () => this.uses,
+        maxCasts: () => this.possibleUseCount,
       },
     });
   }

--- a/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
@@ -69,7 +69,7 @@ class IgnitionMagesFuse extends Analyzer {
         size="flexible"
         tooltip={(
           <>
-            You activated your Ingntion Mage/'s Fuse <b>{this.uses}</b> of <b>{this.possibleUseCount}</b> possible time{this.uses === 1 ? '' : 's'}.<br/>
+            You activated your Ingntion Mage's Fuse <b>{this.uses}</b> of <b>{this.possibleUseCount}</b> possible time{this.uses === 1 ? '' : 's'}.<br />
             Buff uptime was {formatPercentage(this.uptime, 0)}%, utilization was {formatPercentage(this.utilization, 0)}%.
           </>
         )}

--- a/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
@@ -9,7 +9,6 @@ import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import ItemStatistic from 'interface/statistics/ItemStatistic';
 import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
 import Events from 'parser/core/Events';
-import ItemHealingDone from 'interface/others/ItemHealingDone';
 import StatTracker from 'parser/shared/modules/StatTracker';
 
 const ACTIVATION_COOLDOWN = 120; // seconds

--- a/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
@@ -40,13 +40,6 @@ class IgnitionMagesFuse extends Analyzer {
     }
 
     this.statBuff = calculateSecondaryStatDefault(340, 164, this.selectedCombatant.getItem(ITEMS.IGNITION_MAGES_FUSE.id).itemLevel);
-    
-    /*
-    this.statTracker.add(SPELLS.IGNITION_MAGES_FUSE.id, {
-      haste: this.statBuff,
-    });
-    */
-    
     this.addEventListener(Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.IGNITION_MAGES_FUSE_BUFF), this.onUse);
   }
 
@@ -54,10 +47,8 @@ class IgnitionMagesFuse extends Analyzer {
     this.uses += 1;
   }
 
-  get onCooldown(){
-    // make sure it is not possible to have the item constantly on cooldown //
-    const actualCooldown = this.uses * ACTIVATION_COOLDOWN * 1000 / this.owner.fightDuration;
-    return (actualCooldown > 1) ? 1 : actualCooldown;
+  get utilization(){
+    return this.uses / this.possibleUseCount;
   }
 
   get getAverageHaste(){
@@ -80,7 +71,7 @@ class IgnitionMagesFuse extends Analyzer {
         tooltip={(
           <>
             You activated your Ingntion Mage/'s Fuse <b>{this.uses}</b> of <b>{this.possibleUseCount}</b> possible time{this.uses === 1 ? '' : 's'}.<br/>
-            Buff uptime was {formatPercentage(this.uptime, 0)}%, time on cooldown was {formatPercentage(this.onCooldown, 0)}%.
+            Buff uptime was {formatPercentage(this.uptime, 0)}%, utilization was {formatPercentage(this.utilization, 0)}%.
           </>
         )}
       >
@@ -93,7 +84,7 @@ class IgnitionMagesFuse extends Analyzer {
 
   get suggestedUsage() {
     return {
-      actual: this.onCooldown,
+      actual: this.utilization,
       isLessThan: {
         minor: .8,
         average: .7,

--- a/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import SPELLS from 'common/SPELLS/index';
 import ITEMS from 'common/ITEMS/index';
-import ItemLink from 'common/ItemLink';
-import { formatNumber, formatPercentage } from 'common/format';
-import { calculateSecondaryStatDefault } from 'common/stats';
-import HasteIcon from 'interface/icons/Haste';
+
+import Abilities from 'parser/core/modules/Abilities';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
-import ItemStatistic from 'interface/statistics/ItemStatistic';
 import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
+import { calculateSecondaryStatDefault } from 'common/stats';
 import Events from 'parser/core/Events';
+import { formatNumber, formatPercentage } from 'common/format';
+import HasteIcon from 'interface/icons/Haste';
+import ItemStatistic from 'interface/statistics/ItemStatistic';
 import StatTracker from 'parser/shared/modules/StatTracker';
 
 const ACTIVATION_COOLDOWN = 120; // seconds
@@ -40,6 +41,16 @@ class IgnitionMagesFuse extends Analyzer {
 
     this.statBuff = calculateSecondaryStatDefault(340, 164, this.selectedCombatant.getItem(ITEMS.IGNITION_MAGES_FUSE.id).itemLevel);
     this.addEventListener(Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.IGNITION_MAGES_FUSE_BUFF), this.onUse);
+  
+    this.abilities.add({
+      spell: SPELLS.IGNITION_MAGES_FUSE_BUFF,
+      name: ITEMS.IGNITION_MAGES_FUSE.name,
+      category: Abilities.SPELL_CATEGORIES.ITEMS,
+      cooldown: ACTIVATION_COOLDOWN,
+      castEfficiency: {
+        suggestion: true,
+      },
+    });
   }
 
   onUse(event) {
@@ -79,30 +90,6 @@ class IgnitionMagesFuse extends Analyzer {
         </BoringItemValueText>
       </ItemStatistic>
     );
-  }
-
-  get suggestedUsage() {
-    return {
-      actual: this.utilization,
-      isLessThan: {
-        minor: .8,
-        average: .7,
-        major: .6,
-      },
-      style: 'number',
-    };
-  }
-  suggestions(when) {
-    when(this.suggestedUsage).addSuggestion((suggest, actual, recommended) => {
-      return suggest(
-        <>
-          Your usage of <ItemLink id={ITEMS.IGNITION_MAGES_FUSE.id} /> can be improved, try keeping it on cooldown more often or consider changing to a passive trinket.
-        </>
-      )
-        .icon(ITEMS.IGNITION_MAGES_FUSE.icon)
-        .actual(`Used trinket ${this.uses} time(s) out of ${this.possibleUseCount} possible uses.`)
-        .recommended(`> 80% is recommended`);
-    });
   }
 }
 


### PR DESCRIPTION
Created an item statistic for Ignition Mage's Fuse, showing average haste gained with tooltip to display utilization and buff up-time.  A suggestion will be shown if the utilization is less than %80 of potential uses.

![image](https://user-images.githubusercontent.com/3276248/58764801-82775700-8539-11e9-8392-27c7f7a89a2b.png)

Example Log:
https://www.warcraftlogs.com/reports/2aC7VhbnRdJ8H4TX#fight=last&source=13