### PR TITLE
QELive button

### DIFF
--- a/src/parser/druid/restoration/CHANGELOG.js
+++ b/src/parser/druid/restoration/CHANGELOG.js
@@ -1,8 +1,13 @@
 // import React from 'react';
 
-import { Yajinni, blazyb, fel1ne, Qbz, Zerotorescue } from 'CONTRIBUTORS';
+import { Yajinni, blazyb, fel1ne, Qbz, Zerotorescue, Abelito75 } from 'CONTRIBUTORS';
 
 export default [
+  {
+    date: new Date('2019-06-02'),
+    changes: 'Enabled the QElive auto import link for stat values.', 
+    contributors: [Abelito75],
+  },
   {
     date: new Date('2019-05-26'),
     changes: 'Fixed a bug where Lively Spirit increased int gain on tab switch.',

--- a/src/parser/druid/restoration/modules/features/StatWeights.js
+++ b/src/parser/druid/restoration/modules/features/StatWeights.js
@@ -96,6 +96,8 @@ class StatWeights extends BaseHealerStatValues {
   };
 
   spellInfo = DRUID_HEAL_INFO;
+  qeLive = true;
+
 
   _getCritChance(event) {
     const spellId = event.ability.guid;

--- a/src/parser/paladin/holy/CHANGELOG.js
+++ b/src/parser/paladin/holy/CHANGELOG.js
@@ -1,10 +1,15 @@
 import React from 'react';
 
-import { Zerotorescue, HolySchmidt } from 'CONTRIBUTORS';
+import { Zerotorescue, HolySchmidt, Abelito75 } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 
 export default [
+  {
+    date: new Date('2019-06-02'),
+    changes: <>Enabled the QElive auto import link for stat values.</>, 
+    contributors: [Abelito75],
+  },
   {
     date: new Date('2019-05-19'),
     changes: <><SpellLink id={SPELLS.AVENGING_CRUSADER_TALENT.id} /> statistic added showing total healing, healing transfered to beacons and tracks triggers as healing abilities.</>, 

--- a/src/parser/paladin/holy/modules/StatValues.js
+++ b/src/parser/paladin/holy/modules/StatValues.js
@@ -33,6 +33,7 @@ class StatValues extends BaseHealerStatValues {
   };
 
   spellInfo = SPELL_INFO;
+  qeLive = true;
 
   on_heal(event) {
     if (event.ability.guid === SPELLS.BEACON_OF_LIGHT_HEAL.id) {

--- a/src/parser/shared/modules/features/BaseHealerStatValues.js
+++ b/src/parser/shared/modules/features/BaseHealerStatValues.js
@@ -34,7 +34,11 @@ class BaseHealerStatValues extends Analyzer {
     statTracker: StatTracker,
   };
 
-  // QE Live Link Setter
+  /**
+   * QE Live Link Setter
+   * As of right now this is only enabled for MW, Resto Druid, and Holy Pally
+   * Unless you talk to Voulk, the creator of QElive, Do not flip the switch for other healers 
+   */
   qeLive = false;
 
   // region Spell info


### PR DESCRIPTION
As of Voulk's request I have enabled the QElive auto import stat Value link for resto druid and holy pally. He is planning to enable it for the last 3 healers (holy priest, resto shamie, and disc priest) but as of right now they are not 100% ready.
