### PR TITLE
Fixed crest of paku display

### DIFF
--- a/src/parser/shared/modules/items/bfa/raids/bod/CrestOfPaku.js
+++ b/src/parser/shared/modules/items/bfa/raids/bod/CrestOfPaku.js
@@ -61,7 +61,7 @@ class CrestOfPaku extends Analyzer {
           <div className="value">
             <UptimeIcon /> {formatPercentage(this.uptime, 0)}% <small>uptime</small><br />
             <HasteIcon /> {formatNumber(this.averageHasteRating)} <small>average Haste gained</small><br />
-            <SpeedIcon /> {formatNumber(this.averageHasteRating)} <small>average Speed gained</small>
+            <SpeedIcon /> {formatNumber(this.averageSpeedRating)} <small>average Speed gained</small>
           </div>
         </div>
       </Statistic>


### PR DESCRIPTION
Crest of paku was displaying haste for both haste and speed, fixed the speed display to actually display speed.