### PR TITLE
Add normalizer for buffs that are missing cast events

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Yajinni, Mamtooth, Zerotorescue, Putro, joshinator, Gebuz, ackwell, emallson, blazyb, Dambroda, Nalhan, Satyric, niseko, Khadaj, Fyruna, Matardarix, jos3p, Aelexe, Chizu, Hartra344, Hordehobbs, Dorixius, Sharrq, Scotsoo, HolySchmidt } from 'CONTRIBUTORS';
+import { Yajinni, Mamtooth, Zerotorescue, Putro, joshinator, Gebuz, ackwell, emallson, blazyb, Dambroda, Nalhan, Satyric, niseko, Khadaj, Fyruna, Matardarix, jos3p, Aelexe, Chizu, Hartra344, Hordehobbs, Dorixius, Sharrq, Scotsoo, HolySchmidt, Zeboot } from 'CONTRIBUTORS';
 import ItemLink from 'common/ItemLink';
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
@@ -7,6 +7,11 @@ import SpellLink from 'common/SpellLink';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  {
+    date: new Date('2019-06-10'),
+    changes: 'Fixed an issue with some items not providing relevant cast events.',
+    contributors: [Zeboot],
+  },
   {
     date: new Date('2019-06-02'),
     changes: <>Added a <SpellLink id={SPELLS.IGNITION_MAGES_FUSE_BUFF.id} /> module to track usage and average haste gained.</>,

--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -13,6 +13,7 @@ import CancelledCastsNormalizer from '../shared/normalizers/CancelledCasts';
 import PrePullCooldownsNormalizer from '../shared/normalizers/PrePullCooldowns';
 import FightEndNormalizer from '../shared/normalizers/FightEnd';
 import PhaseChangesNormalizer from '../shared/normalizers/PhaseChanges';
+import MissingCastsNormalizer from '../shared/normalizers/MissingCasts';
 
 // Core modules
 import HealingDone from '../shared/modules/throughput/HealingDone';
@@ -182,7 +183,8 @@ class CombatLogParser {
     cancelledCastsNormalizer: CancelledCastsNormalizer,
     prepullNormalizer: PrePullCooldownsNormalizer,
     phaseChangesNormalizer: PhaseChangesNormalizer,
-
+    missingCastsNormalize: MissingCastsNormalizer,
+    
     // Analyzers
     healingDone: HealingDone,
     damageDone: DamageDone,
@@ -256,7 +258,7 @@ class CombatLogParser {
     vesselOfSkitteringShadows: VesselOfSkitteringShadows,
     ladyWaycrestsMusicBox: LadyWaycrestsMusicBox,
     ingnitionMagesFuse: IgnitionMagesFuse,
-    
+
     // PVP
     dreadGladiatorsMedallion: DreadGladiatorsMedallion,
     dreadGladiatorsInsignia: DreadGladiatorsInsignia,

--- a/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/IgnitionMagesFuse.js
@@ -21,7 +21,7 @@ const ACTIVATION_COOLDOWN = 120; // seconds
   Item Level 340
   Binds when picked up
   Unique-Equipped
-  Trinket	
+  Trinket
   +205 Intellect
   Use: Ignite the fuse, gaining 168 Haste every 4 sec. Haste is removed after 20 sec. (2 Min Cooldown)
  */
@@ -43,18 +43,15 @@ class IgnitionMagesFuse extends Analyzer {
     }
 
     this.statBuff = calculateSecondaryStatDefault(340, 164, this.selectedCombatant.getItem(ITEMS.IGNITION_MAGES_FUSE.id).itemLevel);
-    this.addEventListener(Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.IGNITION_MAGES_FUSE_BUFF), this.onUse);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.IGNITION_MAGES_FUSE_BUFF), this.onUse);
+
     this.abilities.add({
       spell: SPELLS.IGNITION_MAGES_FUSE_BUFF,
-      buffSpellId: SPELLS.IGNITION_MAGES_FUSE_BUFF.id,
       name: ITEMS.IGNITION_MAGES_FUSE.name,
       category: Abilities.SPELL_CATEGORIES.ITEMS,
       cooldown: ACTIVATION_COOLDOWN,
-      gcd: null,
       castEfficiency: {
         suggestion: true,
-        casts: () => this.uses,
-        maxCasts: () => this.possibleUseCount,
       },
     });
   }

--- a/src/parser/shared/normalizers/MissingCasts.js
+++ b/src/parser/shared/normalizers/MissingCasts.js
@@ -13,10 +13,12 @@ class MissingCasts extends EventsNormalizer {
   ];
 
   normalize(events) {
-    const missingCastEvents = events.filter(event => event.type === 'applybuff' && this.constructor.missingCastBuffs.includes(event.ability.guid));
+    const missingCastEvents = events
+    .filter(event => event.type === 'applybuff' && this.constructor.missingCastBuffs.includes(event.ability.guid))
+    .map(this.constructor._fabricateCastEvent);
     missingCastEvents.forEach(event => {
       const index = events.findIndex(e => e.timestamp >= event.timestamp);
-      events.splice(index, 0, this.constructor._fabricateCastEvent(event)); //sort into event list just before cast event
+      events.splice(index, 0, event); //sort into event list just before cast event
     });
     return events;
   }

--- a/src/parser/shared/normalizers/MissingCasts.js
+++ b/src/parser/shared/normalizers/MissingCasts.js
@@ -1,8 +1,9 @@
 import EventsNormalizer from 'parser/core/EventsNormalizer';
 import SPELLS from 'common/SPELLS';
 
-/**
- * During analysis there's no way to know at a `begincast` event if it will end up being canceled. This marks all `begincast` events by the player with an `isCancelled` property whether it was cancelled.
+/*
+ * Some on use items (e.g. trinkets) provide a buff when used but do not trigger a cast event, making it more annoying to check for automatically using e.g. usage suggestions.
+ * This normalizer adds cast events at the same timestamp as the applybuff event occured
  */
 class MissingCasts extends EventsNormalizer {
   /*

--- a/src/parser/shared/normalizers/MissingCasts.js
+++ b/src/parser/shared/normalizers/MissingCasts.js
@@ -1,0 +1,40 @@
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+import SPELLS from 'common/SPELLS';
+
+/**
+ * During analysis there's no way to know at a `begincast` event if it will end up being canceled. This marks all `begincast` events by the player with an `isCancelled` property whether it was cancelled.
+ */
+class MissingCasts extends EventsNormalizer {
+  /*
+   * List of buffs that do not have an associated cast event
+   */
+  static missingCastBuffs = [
+    SPELLS.IGNITION_MAGES_FUSE_BUFF.id,
+  ];
+
+  normalize(events) {
+    const missingCastEvents = events.filter(event => event.type === 'applybuff' && this.constructor.missingCastBuffs.includes(event.ability.guid));
+    missingCastEvents.forEach(event => {
+      const index = events.findIndex(e => e.timestamp >= event.timestamp);
+      events.splice(index, 0, this.constructor._fabricateCastEvent(event)); //sort into event list just before cast event
+    });
+    return events;
+  }
+
+  static _fabricateCastEvent(event) {
+    return {
+      type: 'cast',
+      ability: event.ability,
+      sourceID: event.sourceID,
+      sourceIsFriendly: event.sourceIsFriendly,
+      targetID: event.targetID,
+      targetIsFriendly: event.targetIsFriendly,
+      timestamp: event.timestamp,
+
+      // Custom properties:
+      __fabricated: true,
+    };
+  }
+}
+
+export default MissingCasts;


### PR DESCRIPTION
Some items that provide buffs do not produce associated cast events for using the item (see Ignition Mage's Fuse for example), leading to them having to manually track uses for e.g. the usage statistic.

This PR adds a normalizer that fabricates cast events when the buffs given are applied.
Currently only contains the Ignition Mage's fuse (as this is where the cast being missing was noticed), but obviously provides an easy way to add further items to it.