### PR TITLE
fixed 2 minor formatting issues

### DIFF
--- a/src/parser/monk/brewmaster/modules/spells/GiftOfTheOx.js
+++ b/src/parser/monk/brewmaster/modules/spells/GiftOfTheOx.js
@@ -103,7 +103,7 @@ export default class GiftOfTheOx extends Analyzer {
         value={`${formatNumber(this.totalHealing / (this.owner.fightDuration / 1000))} HPS`}
         tooltip={(
           <>
-            You generated {formatNumber(this.orbsGenerated)} healing spheres and consumed {formatNumber(this.orbsConsumed)} of them, healing for <b>{formatNumber(this.totalHealing)}</b>.
+            You generated {formatNumber(this.orbsGenerated)} healing spheres and consumed {formatNumber(this.orbsConsumed)} of them, healing for <b>{formatNumber(this.totalHealing)}</b>.<br />
             {formatNumber(this.expelHarmOrbsConsumed)} of these were consumed with Expel Harm over {formatNumber(this.expelHarmCasts)} casts.
           </>
         )}

--- a/src/parser/shared/modules/throughput/HealingDone.js
+++ b/src/parser/shared/modules/throughput/HealingDone.js
@@ -100,7 +100,7 @@ class HealingDone extends Analyzer {
               alt="Healing"
             />
           </div>
-          <Tooltip content={<>Total healing done: <strong>${formatThousands(this.total.effective)}</strong></>}>
+          <Tooltip content={<>Total healing done: <strong>{formatThousands(this.total.effective)}</strong></>}>
             <div
               className="flex-sub value"
               style={{ width: 190 }}


### PR DESCRIPTION
Fixed 2 slight formatting issues I happened to notice while analyzing a log last night.

First issue: "$" being displayed here
 ![image](https://user-images.githubusercontent.com/5396409/59556193-d1ec6700-8fbe-11e9-9d5d-aa9e0b8449ee.png)

Second issue: no space or newline after first sentence
![image](https://user-images.githubusercontent.com/5396409/59556196-d9ac0b80-8fbe-11e9-9fb4-f2e7c60af80b.png)

