### PR TITLE
[Feral] Separate out buffs

### DIFF
--- a/src/parser/druid/feral/CHANGELOG.js
+++ b/src/parser/druid/feral/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2019-06-16'),
+    changes: <>Changed which buffs are displayed on the timeline view, making rotation-relevant information clearer.</>,
+    contributors: [Anatta336],
+  },
+  {
     date: new Date('2019-03-06'),
     changes: <>Added tracking of <SpellLink id={SPELLS.GUSHING_LACERATIONS_TRAIT.id} />.</>,
     contributors: [Anatta336],

--- a/src/parser/druid/feral/CombatLogParser.js
+++ b/src/parser/druid/feral/CombatLogParser.js
@@ -4,6 +4,7 @@ import RakeBleed from './normalizers/RakeBleed';
 import ComboPointsFromAoE from './normalizers/ComboPointsFromAoE';
 
 import Abilities from './modules/Abilities';
+import Buffs from './modules/Buffs';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
 import SpellUsable from './modules/features/SpellUsable';
@@ -51,6 +52,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Features
     alwaysBeCasting: AlwaysBeCasting,
     abilities: Abilities,
+    buffs: Buffs,
     cooldownThroughputTracker: CooldownThroughputTracker,
     ferociousBiteEnergy: FerociousBiteEnergy,
     spellUsable: SpellUsable,

--- a/src/parser/druid/feral/modules/Abilities.js
+++ b/src/parser/druid/feral/modules/Abilities.js
@@ -43,7 +43,6 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.SAVAGE_ROAR_TALENT,
-        buffSpellId: SPELLS.SAVAGE_ROAR_TALENT.id,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         enabled: combatant.hasTalent(SPELLS.SAVAGE_ROAR_TALENT.id),
         gcd: {
@@ -70,6 +69,15 @@ class Abilities extends CoreAbilities {
         },
         timelineSortIndex: 10,
         primaryCoefficient: 0.055, // initial damage, not DoT damage
+      },
+      {
+        spell: SPELLS.PRIMAL_WRATH_TALENT,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
+        enabled: combatant.hasTalent(SPELLS.PRIMAL_WRATH_TALENT.id),
+        gcd: {
+          static: 1000,
+        },
+        timelineSortIndex: 5,
       },
       {
         spell: SPELLS.SWIPE_CAT,
@@ -109,7 +117,6 @@ class Abilities extends CoreAbilities {
 
       {
         spell: SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT,
-        buffSpellId: SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 180,
         enabled: combatant.hasTalent(SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id),
@@ -125,7 +132,6 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.BERSERK,
-        buffSpellId: SPELLS.BERSERK.id,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 180,
         enabled: !combatant.hasTalent(SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id),
@@ -140,7 +146,6 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.TIGERS_FURY,
-        buffSpellId: SPELLS.TIGERS_FURY.id,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 30,
         castEfficiency: {
@@ -192,7 +197,6 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.DASH,
-        buffSpellId: SPELLS.DASH.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: !combatant.hasTalent(SPELLS.TIGER_DASH_TALENT.id),
         cooldown: 120,
@@ -210,7 +214,6 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.TIGER_DASH_TALENT,
-        buffSpellId: SPELLS.TIGER_DASH_TALENT.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.TIGER_DASH_TALENT.id),
         cooldown: 45,
@@ -228,8 +231,6 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: [SPELLS.STAMPEDING_ROAR_HUMANOID, SPELLS.STAMPEDING_ROAR_CAT, SPELLS.STAMPEDING_ROAR_BEAR],
-        // buffSpellId should match the version that was cast
-        buffSpellId: SPELLS.STAMPEDING_ROAR_CAT.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 120,
         gcd: (combatant => {
@@ -258,23 +259,14 @@ class Abilities extends CoreAbilities {
         timelineSortIndex: 33,
       },
       {
-        spell: SPELLS.PROWL,
-        buffSpellId: SPELLS.PROWL.id,
+        spell: [SPELLS.PROWL, SPELLS.PROWL_INCARNATION],
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         // 6 second cooldown, but triggered by leaving stealth not by using Prowl.
         gcd: null,
         timelineSortIndex: 25,
       },
       {
-        spell: SPELLS.PROWL_INCARNATION,
-        buffSpellId: SPELLS.PROWL_INCARNATION.id,
-        category: Abilities.SPELL_CATEGORIES.UTILITY,
-        gcd: null,
-        timelineSortIndex: 26,
-      },
-      {
         spell: SPELLS.SHADOWMELD,
-        buffSpellId: SPELLS.SHADOWMELD.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 120,
         isUndetectable: true,
@@ -283,7 +275,6 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.SURVIVAL_INSTINCTS,
-        buffSpellId: SPELLS.SURVIVAL_INSTINCTS.id,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         cooldown: 120,
         charges: 2,
@@ -366,7 +357,6 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.BEAR_FORM,
-        buffSpellId: SPELLS.BEAR_FORM.id,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         gcd: {
           base: 1500,
@@ -376,7 +366,6 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.CAT_FORM,
-        buffSpellId: SPELLS.CAT_FORM.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         gcd: {
           base: 1500,
@@ -385,7 +374,6 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.MOONKIN_FORM_AFFINITY,
-        buffSpellId: SPELLS.MOONKIN_FORM_AFFINITY.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         // only has a cooldown for feral spec
         cooldown: 90,
@@ -397,7 +385,6 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.TRAVEL_FORM,
-        buffSpellId: SPELLS.TRAVEL_FORM.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         gcd: {
           base: 1500,
@@ -406,7 +393,6 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.STAG_FORM,
-        buffSpellId: SPELLS.STAG_FORM.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         gcd: {
           base: 1500,

--- a/src/parser/druid/feral/modules/Buffs.js
+++ b/src/parser/druid/feral/modules/Buffs.js
@@ -1,0 +1,119 @@
+import SPELLS from 'common/SPELLS';
+import CoreBuffs from 'parser/core/modules/Buffs';
+import BLOODLUST_BUFFS from 'game/BLOODLUST_BUFFS';
+
+class Buffs extends CoreBuffs {
+  buffs() {
+    const combatant = this.selectedCombatant;
+
+    // This should include ALL buffs that can be applied by your spec.
+    // This data can be used by various kinds of modules to improve their results, and modules added in the future may rely on buffs that aren't used today.
+    return [
+      // rotational
+      {
+        spellId: SPELLS.BLOODTALONS_BUFF.id,
+        enabled: combatant.hasTalent(SPELLS.BLOODTALONS_TALENT),
+        triggeredBySpellId: [SPELLS.REGROWTH.id, SPELLS.ENTANGLING_ROOTS.id],
+        timelineHightlight: true,
+      },
+      {
+        spellId: SPELLS.PREDATORY_SWIFTNESS.id,
+        // only important for rotation when using Bloodtalons, but always available
+        timelineHightlight: combatant.hasTalent(SPELLS.BLOODTALONS_TALENT),
+      },
+      {
+        spellId: SPELLS.SAVAGE_ROAR_TALENT.id,
+        enabled: combatant.hasTalent(SPELLS.SAVAGE_ROAR_TALENT),
+        timelineHightlight: true,
+      },
+
+      // defensive
+      {
+        spellId: SPELLS.SURVIVAL_INSTINCTS.id,
+        timelineHightlight: true,
+      },
+      {
+        spellId: SPELLS.BEAR_FORM.id,
+        timelineHightlight: true,
+      },
+
+      // stealth
+      {
+        spellId: [SPELLS.PROWL.id, SPELLS.PROWL_INCARNATION.id],
+        timelineHightlight: true,
+      },
+      {
+        spellId: SPELLS.SHADOWMELD.id,
+        timelineHightlight: true,
+      },
+
+      // cooldowns
+      {
+        spellId: SPELLS.TIGERS_FURY.id,
+        timelineHightlight: true,
+      },
+      {
+        spellId: SPELLS.BERSERK.id,
+        enabled: !combatant.hasTalent(SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT),
+        timelineHightlight: true,
+      },
+      {
+        spellId: SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id,
+        enabled: combatant.hasTalent(SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT),
+        timelineHightlight: true,
+      },
+      {
+        spellId: Object.keys(BLOODLUST_BUFFS).map(item => Number(item)),
+        timelineHightlight: true,
+      },
+
+      // utility
+      {
+        // it could be useful to see when the combatant is out of cat form, but filling the timeline with a nearly constant buff would add too much noise
+        spellId: SPELLS.CAT_FORM.id,
+      },
+      {
+        spellId: SPELLS.MOONKIN_FORM_AFFINITY.id,
+        enabled: combatant.hasTalent(SPELLS.BALANCE_AFFINITY_TALENT_SHARED),
+      },
+      {
+        spellId: SPELLS.TREANT_FORM.id,
+      },
+      {
+        spellId: SPELLS.TRAVEL_FORM.id,
+        timelineHightlight: true,
+      },
+      {
+        spellId: SPELLS.STAG_FORM.id,
+        timelineHightlight: true,
+      },
+      {
+        spellId: SPELLS.DASH.id,
+        enabled: !combatant.hasTalent(SPELLS.TIGER_DASH_TALENT),
+      },
+      {
+        spellId: SPELLS.TIGER_DASH_TALENT.id,
+        enabled: combatant.hasTalent(SPELLS.TIGER_DASH_TALENT),
+      },
+      {
+        spellId: SPELLS.STAMPEDING_ROAR_CAT.id,
+      },
+      {
+        spellId: SPELLS.STAMPEDING_ROAR_BEAR.id,
+      },
+      {
+        spellId: SPELLS.REGROWTH.id,
+      },
+      {
+        spellId: SPELLS.REJUVENATION.id,
+        enabled: combatant.hasTalent(SPELLS.RESTORATION_AFFINITY_TALENT),
+      },
+      {
+        spellId: SPELLS.WILD_GROWTH.id,
+        enabled: combatant.hasTalent(SPELLS.RESTORATION_AFFINITY_TALENT),
+      },
+    ];
+  }
+}
+
+export default Buffs;


### PR DESCRIPTION
Replaces the old `buffSpellId` properties within `Abilities.js`, instead creating a `Buffs.js` for the Feral spec. This also makes the timeline view for Feral show information that's more consequential to the spec.

Timeline before:
![timelineBefore](https://user-images.githubusercontent.com/35700764/59566494-feed5800-9058-11e9-9c5b-67571f5c8541.png)

Timeline after:
![timelineAfter](https://user-images.githubusercontent.com/35700764/59566495-001e8500-9059-11e9-90ac-f6e34ca6648e.png)

