### PR TITLE
[Feral] [Minor] Add SotF energy generator

### DIFF
--- a/src/common/SPELLS/druid.js
+++ b/src/common/SPELLS/druid.js
@@ -772,6 +772,12 @@ export default {
     name: 'Jungle Stalker',
     icon: 'ability_mount_siberiantigermount',
   },
+  // effect that shows up in the combat log for energy generated from feral's Soul of the Forest talent.
+  SOUL_OF_THE_FOREST_FERAL_ENERGY: {
+    id: 114113,
+    name: 'Soul of the Forest',
+    icon: 'ability_druid_manatree',
+  },
 
   // feral legion tier sets
   FERAL_DRUID_T19_2SET_BONUS_BUFF: {


### PR DESCRIPTION
The SpellId used to report energy gains from Feral's talent Soul of the Forest was missing from druid's `SPELLS`.

Before:
![sotf-before](https://user-images.githubusercontent.com/35700764/59566807-f1d26800-905c-11e9-8086-9c240912f13f.png)

After:
![sotf-after](https://user-images.githubusercontent.com/35700764/59566808-f3039500-905c-11e9-8327-1597a6faf428.png)
