### PR TITLE
More BrM Sheet cleanup

### DIFF
--- a/src/parser/monk/brewmaster/CombatLogParser.js
+++ b/src/parser/monk/brewmaster/CombatLogParser.js
@@ -12,6 +12,7 @@ import Channeling from './modules/core/Channeling';
 import MasteryValue from './modules/core/MasteryValue';
 import AgilityValue from './modules/features/AgilityValue';
 import VersatilityValue from './modules/features/VersatilityValue';
+import CritValue from './modules/features/CritValue';
 import SpellUsable from './modules/core/SpellUsable';
 // Spells
 import IronSkinBrew from './modules/spells/IronSkinBrew';
@@ -61,6 +62,7 @@ class CombatLogParser extends CoreCombatLogParser {
     agilityValue: AgilityValue,
     masteryValue: MasteryValue,
     versValue: VersatilityValue,
+    critValue: CritValue,
     mitigationCheck: MitigationCheck,
     spellUsable: SpellUsable,
 

--- a/src/parser/monk/brewmaster/CombatLogParser.js
+++ b/src/parser/monk/brewmaster/CombatLogParser.js
@@ -11,6 +11,7 @@ import GlobalCooldown from './modules/core/GlobalCooldown';
 import Channeling from './modules/core/Channeling';
 import MasteryValue from './modules/core/MasteryValue';
 import AgilityValue from './modules/features/AgilityValue';
+import VersatilityValue from './modules/features/VersatilityValue';
 import SpellUsable from './modules/core/SpellUsable';
 // Spells
 import IronSkinBrew from './modules/spells/IronSkinBrew';
@@ -59,6 +60,7 @@ class CombatLogParser extends CoreCombatLogParser {
     globalCooldown: GlobalCooldown,
     agilityValue: AgilityValue,
     masteryValue: MasteryValue,
+    versValue: VersatilityValue,
     mitigationCheck: MitigationCheck,
     spellUsable: SpellUsable,
 

--- a/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
@@ -1776,6 +1776,10 @@ exports[`The Brewmaster Analyzer analyzers TrainingOfNiuzao matches the statisti
 
 exports[`The Brewmaster Analyzer analyzers TrainingOfNiuzao matches the suggestions snapshot 1`] = `"module inactive"`;
 
+exports[`The Brewmaster Analyzer analyzers VersatilityValue matches the statistic snapshot 1`] = `"module has no statistic method"`;
+
+exports[`The Brewmaster Analyzer analyzers VersatilityValue matches the suggestions snapshot 1`] = `Array []`;
+
 exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
 <ul
   className="checklist"

--- a/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
@@ -273,6 +273,10 @@ exports[`The Brewmaster Analyzer analyzers Checklist matches the statistic snaps
 
 exports[`The Brewmaster Analyzer analyzers Checklist matches the suggestions snapshot 1`] = `"module has no suggestions"`;
 
+exports[`The Brewmaster Analyzer analyzers CritValue matches the statistic snapshot 1`] = `"module has no statistic method"`;
+
+exports[`The Brewmaster Analyzer analyzers CritValue matches the suggestions snapshot 1`] = `Array []`;
+
 exports[`The Brewmaster Analyzer analyzers DamageTaken matches the statistic snapshot 1`] = `"module has no statistic method"`;
 
 exports[`The Brewmaster Analyzer analyzers DamageTaken matches the suggestions snapshot 1`] = `Array []`;

--- a/src/parser/monk/brewmaster/modules/features/CritValue.js
+++ b/src/parser/monk/brewmaster/modules/features/CritValue.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import StatTracker from 'parser/shared/modules/StatTracker';
+import Events from 'parser/core/Events';
+import SPELLS from 'common/SPELLS';
+import HIT_TYPES from 'game/HIT_TYPES';
+import SpellLink from 'common/SpellLink';
+import STAT, { getClassNameColor, getName } from 'parser/shared/modules/features/STAT';
+import { calculateSecondaryStatDefault } from 'common/stats';
+import CelestialFortune from '../spells/CelestialFortune';
+
+import MitigationSheet, { makeIcon } from '../features/MitigationSheet';
+
+export default class CritValue extends Analyzer {
+  static dependencies = {
+    stats: StatTracker,
+    sheet: MitigationSheet,
+    cf: CelestialFortune,
+  };
+
+  critBonusHealing = 0; // crit bonus healing from non-CF sources
+
+  constructor(...args) {
+    super(...args);
+
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER), this._handleHeal);
+    this.sheet.registerStat(STAT.CRITICAL_STRIKE, this.statValue());
+  }
+
+  get bonusCritRatio() {
+    return this.cf.bonusCritRatio;
+  }
+
+  _handleHeal(event) {
+    if(event.hitType !== HIT_TYPES.CRIT) {
+      return;
+    }
+
+    // counting absorbed healing because we live in a Vectis world
+    const totalHeal = event.amount + (event.overheal || 0) + (event.absorbed || 0);
+    this.critBonusHealing += Math.max(totalHeal / 2 - (event.overheal || 0), 0) * this.bonusCritRatio; // remove overhealing from the bonus healing
+  }
+
+  statValue() {
+    const module = this;
+    return {
+      priority: 4,
+      icon: makeIcon(STAT.CRITICAL_STRIKE),
+      name: getName(STAT.CRITICAL_STRIKE),
+      className: getClassNameColor(STAT.CRITICAL_STRIKE),
+      statName: 'crit', // consistently inconsistent
+      get gain() {
+        return [
+          { name: <><SpellLink id={SPELLS.CELESTIAL_FORTUNE_HEAL.id} /> Healing</>, amount: module.cf.critBonusHealing },
+          { name: 'Critical Heals', amount: module.critBonusHealing },
+        ];
+      },
+      increment: this.sheet.increment(calculateSecondaryStatDefault, module.stats.startingCritRating),
+    };
+  }
+}

--- a/src/parser/monk/brewmaster/modules/features/VersatilityValue.js
+++ b/src/parser/monk/brewmaster/modules/features/VersatilityValue.js
@@ -1,15 +1,12 @@
-import React from 'react';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import STAT, { getClassNameColor, getName } from 'parser/shared/modules/features/STAT';
 import Events from 'parser/core/Events';
 import StatTracker from 'parser/shared/modules/StatTracker';
 import SPELLS from 'common/SPELLS';
 import HIT_TYPES from 'game/HIT_TYPES';
-import MAGIC_SCHOOLS from 'game/MAGIC_SCHOOLS';
 import { calculateSecondaryStatDefault } from 'common/stats';
 
 import MitigationSheet, { makeIcon } from './MitigationSheet';
-import { diminish, lookupK } from '../constants/Mitigation';
 
 export default class VersatilityValue extends Analyzer {
   static dependencies = {

--- a/src/parser/monk/brewmaster/modules/features/VersatilityValue.js
+++ b/src/parser/monk/brewmaster/modules/features/VersatilityValue.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import STAT, { getClassNameColor, getName } from 'parser/shared/modules/features/STAT';
+import Events from 'parser/core/Events';
+import StatTracker from 'parser/shared/modules/StatTracker';
+import SPELLS from 'common/SPELLS';
+import HIT_TYPES from 'game/HIT_TYPES';
+import MAGIC_SCHOOLS from 'game/MAGIC_SCHOOLS';
+import { calculateSecondaryStatDefault } from 'common/stats';
+
+import MitigationSheet, { makeIcon } from './MitigationSheet';
+import { diminish, lookupK } from '../constants/Mitigation';
+
+export default class VersatilityValue extends Analyzer {
+  static dependencies = {
+    stats: StatTracker,
+    sheet: MitigationSheet,
+  };
+
+  damageMitigated = 0;
+  healing = 0;
+
+  constructor(...args) {
+    super(...args);
+
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER), this._onHealVers);
+    this.addEventListener(Events.damage.to(SELECTED_PLAYER), this._onDamageTaken);
+
+    this.sheet.registerStat(STAT.VERSATILITY, this.statValue());
+  }
+
+  _onHealVers(event) {
+    if(event.ability.guid === SPELLS.CELESTIAL_FORTUNE_HEAL.id) {
+      return; // CF is unaffected by vers
+    }
+
+    const totalHeal = event.amount + (event.overheal || 0) + (event.absorbed || 0);
+    const originalHeal = totalHeal / (1 + this.stats.currentVersatilityPercentage);
+    this.healing += Math.max(totalHeal - originalHeal - (event.overheal || 0), 0);
+  }
+
+  _onDamageTaken(event) {
+    if(event.hitType === HIT_TYPES.DODGE) {
+      return; // no damage taken, can't do anything
+    }
+    if(event.unmitigatedAmount === undefined) {
+      this.log('Missing unmitigated amount', event);
+      return;
+    }
+    const alreadyMitigated = event._mitigated || 0;
+    // vers mitigation is half the damage/heal %
+    const versMitigated = this.sheet._mitigate(event, this.stats.currentVersatilityPercentage / 2, alreadyMitigated);
+
+    this.damageMitigated += versMitigated;
+  }
+
+  statValue() {
+    const vers = this;
+    return {
+      priority: 3,
+      icon: makeIcon(STAT.VERSATILITY),
+      name: getName(STAT.VERSATILITY),
+      className: getClassNameColor(STAT.VERSATILITY),
+      statName: STAT.VERSATILITY,
+      get gain() {
+        return [
+          { name: 'Damage Mitigated', amount: vers.damageMitigated },
+          { name: 'Additional Healing', amount: vers.healing },
+        ];
+      },
+      increment: this.sheet.increment(calculateSecondaryStatDefault, this.stats.startingVersatilityRating),
+    };
+  }
+}

--- a/src/parser/monk/brewmaster/modules/spells/CelestialFortune.js
+++ b/src/parser/monk/brewmaster/modules/spells/CelestialFortune.js
@@ -5,17 +5,12 @@ import Combatants from 'parser/shared/modules/Combatants';
 import StatisticBox from 'interface/others/StatisticBox';
 import SPELLS from 'common/SPELLS';
 import SPECS from 'game/SPECS';
-import HIT_TYPES from 'game/HIT_TYPES';
 import SpellIcon from 'common/SpellIcon';
 import SpecIcon from 'common/SpecIcon';
 import SpellLink from 'common/SpellLink';
 import Icon from 'common/Icon';
 import Panel from 'interface/others/Panel';
 import {formatNumber} from 'common/format';
-import STAT, { getClassNameColor, getName } from 'parser/shared/modules/features/STAT';
-import { calculateSecondaryStatDefault } from 'common/stats';
-
-import MitigationSheet, { makeIcon } from '../features/MitigationSheet';
 
 /**
  * Celestial Fortune
@@ -34,11 +29,9 @@ class CelestialFortune extends Analyzer {
   static dependencies = {
     stats: StatTracker,
     combatants: Combatants,
-    sheet: MitigationSheet,
   };
 
   critBonusHealing = 0;
-  _otherCritBonusHealing = 0; // crit bonus healing from non-CF sources
   _totalHealing = 0;
   _overhealing = 0;
   _healingByEntityBySpell = {
@@ -49,12 +42,6 @@ class CelestialFortune extends Analyzer {
      * },
      */
   };
-
-  constructor(...args) {
-    super(...args);
-
-    this.sheet.registerStat(STAT.CRITICAL_STRIKE, this.statValue());
-  }
 
   _lastMaxHp = 0;
 
@@ -84,16 +71,6 @@ class CelestialFortune extends Analyzer {
       // only adds if a CF heal is queued
       this._addHealing(event);
     }
-  }
-
-  on_byPlayer_heal(event) {
-    if(event.hitType !== HIT_TYPES.CRIT) {
-      return;
-    }
-
-    // counting absorbed healing because we live in a Vectis world
-    const totalHeal = event.amount + (event.overheal || 0) + (event.absorbed || 0);
-    this._otherCritBonusHealing += Math.max(totalHeal / 2 - (event.overheal || 0), 0) * this.bonusCritRatio; // remove overhealing from the bonus healing
   }
 
   on_toPlayer_applybuff(event) {
@@ -261,24 +238,6 @@ class CelestialFortune extends Analyzer {
           </div>
         </Panel>
       ),
-    };
-  }
-
-  statValue() {
-    const cf = this;
-    return {
-      priority: 4,
-      icon: makeIcon(STAT.CRITICAL_STRIKE),
-      name: getName(STAT.CRITICAL_STRIKE),
-      className: getClassNameColor(STAT.CRITICAL_STRIKE),
-      statName: 'crit', // consistently inconsistent
-      get gain() {
-        return [
-          { name: <><SpellLink id={SPELLS.CELESTIAL_FORTUNE_HEAL.id} /> Healing</>, amount: cf.critBonusHealing },
-          { name: 'Critical Heals', amount: cf._otherCritBonusHealing },
-        ];
-      },
-      increment: this.sheet.increment(calculateSecondaryStatDefault, this.stats.startingCritRating),
     };
   }
 }

--- a/src/parser/monk/brewmaster/modules/spells/CelestialFortune.js
+++ b/src/parser/monk/brewmaster/modules/spells/CelestialFortune.js
@@ -83,14 +83,17 @@ class CelestialFortune extends Analyzer {
     } else {
       // only adds if a CF heal is queued
       this._addHealing(event);
-      if(event.hitType !== HIT_TYPES.CRIT) {
-        return;
-      }
-
-      // counting absorbed healing because we live in a Vectis world
-      const totalHeal = event.amount + (event.overheal || 0) + (event.absorbed || 0);
-      this._otherCritBonusHealing += Math.max(totalHeal / 2 - (event.overheal || 0), 0) * this.bonusCritRatio; // remove overhealing from the bonus healing
     }
+  }
+
+  on_byPlayer_heal(event) {
+    if(event.hitType !== HIT_TYPES.CRIT) {
+      return;
+    }
+
+    // counting absorbed healing because we live in a Vectis world
+    const totalHeal = event.amount + (event.overheal || 0) + (event.absorbed || 0);
+    this._otherCritBonusHealing += Math.max(totalHeal / 2 - (event.overheal || 0), 0) * this.bonusCritRatio; // remove overhealing from the bonus healing
   }
 
   on_toPlayer_applybuff(event) {
@@ -264,7 +267,7 @@ class CelestialFortune extends Analyzer {
   statValue() {
     const cf = this;
     return {
-      priority: 3,
+      priority: 4,
       icon: makeIcon(STAT.CRITICAL_STRIKE),
       name: getName(STAT.CRITICAL_STRIKE),
       className: getClassNameColor(STAT.CRITICAL_STRIKE),


### PR DESCRIPTION
Follow-up from #3121, covering Versatility and Critical Strike.

Currently some minor code-smell with Armor's mitigation being added to events as the field `_mitigated`. Since mitigation is multiplicative, you have to track mitigation across sources, which means either doing it all in one place or tracking what has already been mitigated.