### PR TITLE
[Feral] Improve tracking of finisher combo use

### DIFF
--- a/src/parser/druid/feral/CHANGELOG.js
+++ b/src/parser/druid/feral/CHANGELOG.js
@@ -6,6 +6,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2019-06-19'),
+    changes: <>Improved how finisher combo point use is assessed, low-combo use of <SpellLink id={SPELLS.RIP.id} /> is recognised as correct in certain circumstances.</>,
+    contributors: [Anatta336],
+  },
+  {
     date: new Date('2019-06-16'),
     changes: <>Changed which buffs are displayed on the timeline view, making rotation-relevant information clearer.</>,
     contributors: [Anatta336],

--- a/src/parser/druid/feral/CombatLogParser.js
+++ b/src/parser/druid/feral/CombatLogParser.js
@@ -2,6 +2,7 @@ import CoreCombatLogParser from 'parser/core/CombatLogParser';
 
 import RakeBleed from './normalizers/RakeBleed';
 import ComboPointsFromAoE from './normalizers/ComboPointsFromAoE';
+import BleedDebuffEvents from './normalizers/BleedDebuffEvents';
 
 import Abilities from './modules/Abilities';
 import Buffs from './modules/Buffs';
@@ -22,6 +23,7 @@ import RipSnapshot from './modules/bleeds/RipSnapshot';
 
 import ComboPointTracker from './modules/combopoints/ComboPointTracker';
 import ComboPointDetails from './modules/combopoints/ComboPointDetails';
+import FinisherUse from './modules/combopoints/FinisherUse';
 
 import SavageRoarUptime from './modules/talents/SavageRoarUptime';
 import MoonfireUptime from './modules/talents/MoonfireUptime';
@@ -47,6 +49,7 @@ class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     // Normalizers
     rakeBleed: RakeBleed,
+    bleedDebuffEvents: BleedDebuffEvents,
     comboPointsFromAoE: ComboPointsFromAoE,
 
     // Features
@@ -87,6 +90,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // resources
     comboPointTracker: ComboPointTracker,
     comboPointDetails: ComboPointDetails,
+    finisherUse: FinisherUse,
 
     // azerite traits
     wildFleshrending: WildFleshrending,

--- a/src/parser/druid/feral/modules/bleeds/RakeSnapshot.js
+++ b/src/parser/druid/feral/modules/bleeds/RakeSnapshot.js
@@ -21,8 +21,8 @@ import Snapshot from '../core/Snapshot';
 const FORGIVE_PROWL_LOSS_TIME = 1000;
 
 class RakeSnapshot extends Snapshot {
-  static spellCastId = SPELLS.RAKE.id;
-  static debuffId = SPELLS.RAKE_BLEED.id;
+  static spell = SPELLS.RAKE;
+  static debuff = SPELLS.RAKE_BLEED;
   static durationOfFresh = RAKE_BASE_DURATION;
   static isProwlAffected = true;
   static isTigersFuryAffected = true;

--- a/src/parser/druid/feral/modules/combopoints/ComboPointDetails.js
+++ b/src/parser/druid/feral/modules/combopoints/ComboPointDetails.js
@@ -2,9 +2,6 @@ import React from 'react';
 import Analyzer from 'parser/core/Analyzer';
 import Panel from 'interface/others/Panel';
 import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
-import { formatPercentage } from 'common/format';
-import SPELLS from 'common/SPELLS';
-import SpellLink from 'common/SpellLink';
 
 import ResourceBreakdown from './ComboPointBreakdown';
 import WastedPointsIcon from '../images/feralComboPointIcon.png';
@@ -36,21 +33,6 @@ class ComboPointDetails extends Analyzer {
     };
   }
 
-  get finishersBelowMaxSuggestionThresholds() {
-    const maxComboPointCasts = Object.values(this.comboPointTracker.spendersObj).reduce((acc, spell) => acc + spell.spentByCast.filter(cps => cps === 5).length, 0);
-    const totalCasts = this.comboPointTracker.spendersCasts;
-    const maxComboPointPercent = maxComboPointCasts / totalCasts;
-    return {
-      actual: maxComboPointPercent,
-      isLessThan: {
-        minor: 0.95,
-        average: 0.90,
-        major: 0.85,
-      },
-      style: 'percentage',
-    };
-  }
-
   suggestions(when) {
     when(this.wastingSuggestionThresholds).addSuggestion((suggest, actual, recommended) => {
       return suggest(
@@ -61,17 +43,6 @@ class ComboPointDetails extends Analyzer {
         .icon('creatureportrait_bubble')
         .actual(`${actual.toFixed(1)} combo points wasted per minute`)
         .recommended('zero waste is recommended');
-    });
-
-    when(this.finishersBelowMaxSuggestionThresholds).addSuggestion((suggest, actual, recommended) => {
-      return suggest(
-        <>
-          You are casting too many finishers with less that 5 combo points. Apart from <SpellLink id={SPELLS.SAVAGE_ROAR_TALENT.id} /> during the opening of a fight you should always use finishers with a full 5 combo points.
-        </>
-      )
-        .icon('creatureportrait_bubble')
-        .actual(`${formatPercentage(actual)}% of finishers were cast with 5 combo points`)
-        .recommended(`>${formatPercentage(recommended)}% is recommended`);
     });
   }
 

--- a/src/parser/druid/feral/modules/combopoints/FinisherUse.js
+++ b/src/parser/druid/feral/modules/combopoints/FinisherUse.js
@@ -1,0 +1,153 @@
+import React from 'react';
+
+import SpellLink from 'common/SpellLink';
+import SPELLS from 'common/SPELLS';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import BoringResourceValue from 'interface/statistics/components/BoringResourceValue/index';
+import { STATISTIC_ORDER } from 'interface/others/StatisticBox';
+import Statistic from 'interface/statistics/Statistic';
+
+import RipSnapshot from '../bleeds/RipSnapshot';
+
+const debug = false;
+
+const FINISHERS = [
+  SPELLS.FEROCIOUS_BITE,
+  SPELLS.RIP,
+  SPELLS.MAIM,
+  SPELLS.PRIMAL_WRATH_TALENT,
+  SPELLS.SAVAGE_ROAR_TALENT,
+];
+const MAX_COMBO = 5;
+
+/**
+ * Although all finishers are most efficient at 5 combo points, in some situations use at fewer combo points
+ * will be a damage increase compared to waiting for the full 5.
+ * 
+ * Situations where <5 combo point use of an ability is fine:
+ *  Fresh Rip on a target which doesn't yet have it.
+ *  Rip on a target that already has Rip if it upgrades the snapshot, so long as player is using Sabertooth.
+ *  [NYI] Maim on a target where the stun is effective and useful.
+ * 
+ */
+class FinisherUse extends Analyzer {
+  static dependencies = {
+    ripSnapshot: RipSnapshot,
+  };
+
+  hasSabertooth = false;
+
+  totalFinishers = 0;
+  notFullComboFinishers = 0;
+  badFinishers = 0;
+  freshRips = 0;
+  upgradingRips = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.hasSabertooth = this.selectedCombatant.hasTalent(SPELLS.SABERTOOTH_TALENT.id);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this._castSpell);
+  }
+
+  _castSpell(event) {
+    const finisher = FINISHERS.find(element => element.id === event.ability.guid);
+    if (!finisher) {
+      return;
+    }
+    this.totalFinishers += 1;
+
+    const combo = this.getComboPoints(event);
+    if (!combo || combo === MAX_COMBO) {
+      // either full combo points (therefore not a problem) used or something went wrong and couldn't get combo information
+      return;
+    }
+    this.notFullComboFinishers += 1;
+
+    if (finisher !== SPELLS.RIP) {
+      this.badFinishers += 1;
+      debug && this.log(`cast ${finisher.name} with ${combo} combo points`);
+      return;
+    }
+
+    // Rip has been used without full combo points, which is a good thing only in certain situations
+    // RipSnapshot will have added the feralSnapshotState prop to the event, because this module has RipSnapshot as a dependency
+    // we know that will have been done before this executes.
+    if (RipSnapshot.wasStateFreshlyApplied(event.feralSnapshotState)) {
+      debug && this.log(`cast ${finisher.name} with ${combo} combo points but it was a fresh application, so is good`);
+      this.freshRips += 1;
+      return;
+    }
+    if (this.hasSabertooth && RipSnapshot.wasStatePowerUpgrade(event.feralSnapshotState)) {
+      debug && this.log(`cast ${finisher.name} with ${combo} combo points but it was upgrading ready to be extended with sabertooth, so is good`);
+      this.upgradingRips += 1;
+      return;
+    }
+    debug && this.log(`cast ${finisher.name} with ${combo} combo points`);
+    this.badFinishers += 1;
+  }
+
+  getComboPoints(castEvent) {
+    const resource = castEvent.classResources.find(item => item.type === RESOURCE_TYPES.COMBO_POINTS.id);
+    return resource.amount;
+  }
+
+  get fractionBadFinishers() {
+    if (this.totalFinishers === 0) {
+      return 0;
+    }
+    return this.badFinishers / this.totalFinishers;
+  }
+
+  get badFinishersThresholds() {
+    return {
+      actual: this.fractionBadFinishers,
+      isGreaterThan: {
+        minor: 0,
+        average: 0.05,
+        major: 0.10,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.badFinishersThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <>
+          You are unnecessarily using finishers at less than full combo points. Generally the only finisher you should use without full combo points is <SpellLink id={SPELLS.RIP.id} /> when applying it to a target that doesn't have it active yet.
+        </>
+      )
+        .icon('creatureportrait_bubble')
+        .actual(`${(actual * 100).toFixed(0)}% of finishers were incorrectly used without full combo points`)
+        .recommended(`${(recommended * 100).toFixed(0)}% is recommended`);
+    });
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE(6)}
+        size="small"
+        tooltip={(
+          <>
+            All finisher abilities are most efficient when used at full combo points, but there are situations where that rule doesn't apply. Of the <b>{this.totalFinishers}</b> finishers you used, <b>{this.notFullComboFinishers}</b> {this.notFullComboFinishers === 1 ? 'was' : 'were'} used without full combo points, and <b>{this.badFinishers}</b> appear not to have had a good reason for their low combo use.<br />
+            <ul>
+              <li><b>{this.freshRips}</b> {this.freshRips === 1 ? 'was a fresh Rip' : 'were fresh Rips'} applied to a target which didn't already have the DoT, where low combo point use is typically the right thing to do.</li>
+              <li><b>{this.upgradingRips}</b> {this.upgradingRips === 1 ? 'was an upgrading Rip' : 'were upgrading Rips'} where thanks to snapshotting the new DoT would do more damage than the existing. When combined with Sabertooth to extend the improved DoT this is a situation where low combo finisher use is of benefit.</li>
+            </ul>
+          </>
+        )}
+      >
+        <BoringResourceValue
+          resource={RESOURCE_TYPES.COMBO_POINTS}
+          value={`${(this.fractionBadFinishers * 100).toFixed(0)}%`}
+          label="Low Combo Finishers"
+        />
+      </Statistic>
+    );
+  }
+}
+
+export default FinisherUse;

--- a/src/parser/druid/feral/modules/features/checklist/Component.js
+++ b/src/parser/druid/feral/modules/features/checklist/Component.js
@@ -109,7 +109,7 @@ class FeralDruidChecklist extends React.PureComponent {
           🗵 Ferocious Bite only at energy >= 50
           🗵 Don't cast Rip when Ferocious Bite could have refreshed it, unless you're upgrading the snapshot
           🗵 Don't reduce duration of Rip by refreshing early and with low combo points
-          🗵 Don't use finishers at less than 5 combo points
+          🗵 Don't use finishers at less than 5 combo points (except for certain exceptions)
         */}
         <Rule
           name="Spend combo points"
@@ -157,10 +157,11 @@ class FeralDruidChecklist extends React.PureComponent {
           <Requirement
             name={(
               <>
-                Finishers used with full combo points
+                Needless low combo point finishers
               </>
             )}
-            thresholds={thresholds.finishersBelowFull}
+            thresholds={thresholds.badLowComboFinishers}
+            tooltip="Your finishers are most efficient when used with full combo points. However it is still worth using a low combo point Rip if it's not yet up on a target (this exception is detected and taken into account when calculating this metric.)"
           />
         </Rule>
 

--- a/src/parser/druid/feral/modules/features/checklist/Module.js
+++ b/src/parser/druid/feral/modules/features/checklist/Module.js
@@ -22,6 +22,7 @@ import Bloodtalons from '../../talents/Bloodtalons';
 import Predator from '../../talents/Predator';
 import TigersFuryEnergy from '../../spells/TigersFuryEnergy';
 import Shadowmeld from '../../racials/Shadowmeld';
+import FinisherUse from '../../combopoints/FinisherUse';
 
 class Checklist extends BaseChecklist {
   static dependencies = {
@@ -45,6 +46,7 @@ class Checklist extends BaseChecklist {
     predator: Predator,
     tigersFuryEnergy: TigersFuryEnergy,
     shadowmeld: Shadowmeld,
+    finisherUse: FinisherUse,
   };
 
   render() {
@@ -68,7 +70,7 @@ class Checklist extends BaseChecklist {
           ferociousBiteEnergy: this.ferociousBiteEnergy.suggestionThresholds,
           ripShouldBeBite: this.ripSnapshot.shouldBeBiteSuggestionThresholds,
           ripDurationReduction: this.ripSnapshot.durationReductionThresholds,
-          finishersBelowFull: this.comboPointDetails.finishersBelowMaxSuggestionThresholds,
+          badLowComboFinishers: this.finisherUse.badFinishersThresholds,
 
           // energy
           energyCapped: this.energyCapTracker.suggestionThresholds,

--- a/src/parser/druid/feral/modules/spells/TigersFuryEnergy.js
+++ b/src/parser/druid/feral/modules/spells/TigersFuryEnergy.js
@@ -26,7 +26,7 @@ class TigersFuryEnergy extends Analyzer {
       isGreaterThan: {
         minor: 0,
         average: 0.10,
-        major: 0.15,
+        major: 0.25,
       },
       style: 'percentage',
     };

--- a/src/parser/druid/feral/modules/talents/MoonfireSnapshot.js
+++ b/src/parser/druid/feral/modules/talents/MoonfireSnapshot.js
@@ -15,8 +15,8 @@ import { MOONFIRE_FERAL_BASE_DURATION, PANDEMIC_FRACTION } from '../../constants
  */
 
 class MoonfireSnapshot extends Snapshot {
-  static spellCastId = SPELLS.MOONFIRE_FERAL.id;
-  static debuffId = SPELLS.MOONFIRE_FERAL.id;
+  static spell = SPELLS.MOONFIRE_FERAL;
+  static debuff = SPELLS.MOONFIRE_FERAL;
 
   static durationOfFresh = MOONFIRE_FERAL_BASE_DURATION;
   static isProwlAffected = false;

--- a/src/parser/druid/feral/normalizers/BleedDebuffEvents.js
+++ b/src/parser/druid/feral/normalizers/BleedDebuffEvents.js
@@ -1,0 +1,87 @@
+import SPELLS from 'common/SPELLS/index';
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+
+const CAST_WINDOW = 100;
+const CAST_DEBUFF_PAIRS = [
+  { 
+    cast: SPELLS.RIP,
+    debuff: SPELLS.RIP,
+  },
+  {
+    cast: SPELLS.RAKE,
+    debuff: SPELLS.RAKE_BLEED,
+  },
+  {
+    cast: SPELLS.MOONFIRE_FERAL,
+    debuff: SPELLS.MOONFIRE_BEAR,
+  },
+  {
+    cast: SPELLS.THRASH_FERAL,
+    debuff: SPELLS.THRASH_FERAL,
+    multipleDebuffs: true,
+  },
+  {
+    cast: SPELLS.PRIMAL_WRATH_TALENT,
+    debuff: SPELLS.RIP,
+    multipleDebuffs: true,
+  },
+];
+
+class BleedDebuffEvents extends EventsNormalizer {
+  /**
+   * When analyzing the effect of a cast event it's often necessary to know about what debuff application that cast
+   * caused. Typically this is handled by listening for both the cast and applydebuff or refreshdebuff
+   * events, and combining the information from them to form an analysis. That delays full analysis of a cast event
+   * until after the associated debuff event has been processed.
+   * Normally this isn't a problem but if another module relies on the result of that cast event analysis it will
+   * also have to wait for future events before it can trust the result from the module it relies on. This can lead
+   * to some messy coupling between modules.
+   * 
+   * This normalizer attempts to link specified cast events with appropriate debuff apply/refresh events. This way
+   * a module that needs to know about the debuff event caused by a cast event can directly access that event through
+   * the cast event. It's important that the module design is aware that when doing so the debuff event will have not
+   * yet been processed by anything else. e.g. an entity.hasDebuff query will not yet see the debuff.
+   * 
+   * @param {Array} events
+   * @returns {Array} Events with some cast events having gained a .debuffEvents property, which is an array of applydebuff and/or refreshdebuff events.
+   */
+  normalize(events) {
+    const fixedEvents = [];
+    for (let castEventIndex = 0; castEventIndex < events.length; castEventIndex += 1) {
+      const castEvent = events[castEventIndex];
+      fixedEvents.push(castEvent);
+      if (castEvent.type !== 'cast') {
+        continue;
+      }
+      const pair = CAST_DEBUFF_PAIRS.find(item => item.cast.id === castEvent.ability.guid);
+      if (!pair) {
+        continue;
+      }
+      castEvent.__modified = true;
+      castEvent.debuffEvents = [];
+      // found a suitable cast event so now look forward for debuff events
+      // note: debuff events usually appear after associated cast events - make sure this normalizer runs after any that enforce that.
+      for (let debuffEventIndex = castEventIndex; debuffEventIndex < events.length; debuffEventIndex += 1) {
+        const debuffEvent = events[debuffEventIndex];
+        if (debuffEvent.timestamp > castEvent.timestamp + CAST_WINDOW) {
+          // if this event is past the time limit then can assume any future events will also be past the time limit, so stop looking.
+          break;
+        }
+        if (debuffEvent.type !== 'applydebuff' && debuffEvent.type !== 'refreshdebuff') {
+          continue;
+        }
+        if (debuffEvent.ability.guid !== pair.debuff.id) {
+          continue;
+        }
+        castEvent.debuffEvents.push(debuffEvent);
+        if (!pair.multipleDebuffs) {
+          // the cast is only expected to produce one debuff event, so stop searching for more
+          break;
+        }
+      }
+    }
+    return fixedEvents;
+  }
+}
+
+export default BleedDebuffEvents;

--- a/src/parser/druid/feral/normalizers/BleedDebuffEvents.test.js
+++ b/src/parser/druid/feral/normalizers/BleedDebuffEvents.test.js
@@ -1,0 +1,131 @@
+import SPELLS from 'common/SPELLS';
+
+import BleedDebuffEvents from './BleedDebuffEvents';
+
+describe('Druid/Feral/Normalizers/BleedDebuffEvents', () => {
+  /**
+   * The expected result is listing what testid should be in each event's debuffEvents property.
+   * null means the event shouldn't have a debuffEvents property at all, if the event should be
+   * given an empty debuffEvents that's shown as empty array [] 
+   */
+  const scenarios = [
+    {
+      it: 'creates debuffEvents array with one matched applydebuff',
+      events: [
+        { testid: 1, timestamp: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+        { testid: 2, timestamp: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+      ],
+      result: [
+        [2],
+        null,
+      ],
+    },
+    {
+      it: 'creates debuffEvents array with one matched refreshdebuff',
+      events: [
+        { testid: 1, timestamp: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+        { testid: 2, timestamp: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'refreshdebuff' },
+      ],
+      result: [
+        [2],
+        null,
+      ],
+    },
+    {
+      it: 'skips over mismatched applydebuff events',
+      events: [
+        { testid: 1, timestamp: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+        { testid: 2, timestamp: 1, ability: { guid: SPELLS.RIP.id }, type: 'applydebuff' },
+        { testid: 3, timestamp: 1, ability: { guid: SPELLS.MOONFIRE_BEAR.id }, type: 'applydebuff' },
+        { testid: 4, timestamp: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+      ],
+      result: [
+        [4],
+        null,
+        null,
+        null,
+      ],
+    },
+    {
+      it: 'skips over damage events',
+      events: [
+        { testid: 1, timestamp: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+        { testid: 2, timestamp: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'damage' },
+        { testid: 3, timestamp: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+      ],
+      result: [
+        [3],
+        null,
+        null,
+      ],
+    },
+    {
+      it: 'copes when there\'s no matching debuff events',
+      events: [
+        { testid: 1, timestamp: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+        { testid: 2, timestamp: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'damage' },
+        { testid: 3, timestamp: 1, ability: { guid: SPELLS.RIP.id }, type: 'applydebuff' },
+      ],
+      result: [
+        [],
+        null,
+        null,
+      ],
+    },
+    
+    {
+      it: 'ignores debuff events too far in the future',
+      events: [
+        { testid: 1, timestamp: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+        { testid: 2, timestamp: 10000, ability: { guid: SPELLS.RIP.id }, type: 'applydebuff' },
+      ],
+      result: [
+        [],
+        null,
+      ],
+    },
+    {
+      it: 'handles abilities which create multiple debuffs',
+      events: [
+        { testid: 1, timestamp: 1, ability: { guid: SPELLS.THRASH_FERAL.id }, type: 'cast' },
+        { testid: 2, timestamp: 1, ability: { guid: SPELLS.THRASH_FERAL.id }, type: 'applydebuff' },
+        { testid: 3, timestamp: 1, ability: { guid: SPELLS.THRASH_FERAL.id }, type: 'applydebuff' },
+        { testid: 4, timestamp: 1, ability: { guid: SPELLS.THRASH_FERAL.id }, type: 'applydebuff' },
+      ],
+      result: [
+        [2, 3, 4],
+        null,
+        null,
+        null,
+      ],
+    },
+    {
+      it: 'ignores multiple debuffs on abilities meant to only create one',
+      events: [
+        { testid: 1, timestamp: 1, ability: { guid: SPELLS.RAKE.id }, type: 'cast' },
+        { testid: 2, timestamp: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+        { testid: 3, timestamp: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+        { testid: 4, timestamp: 1, ability: { guid: SPELLS.RAKE_BLEED.id }, type: 'applydebuff' },
+      ],
+      result: [
+        [2],
+        null,
+        null,
+        null,
+      ],
+    },
+  ];
+
+  scenarios.forEach(scenario => {
+    it(scenario.it, () => {
+      const parser = new BleedDebuffEvents({});
+      expect(parser.normalize(scenario.events).map(event => (
+        event.debuffEvents ? 
+          event.debuffEvents.map(linkedEvent => (
+            linkedEvent.testid
+          ))
+         : null
+      ))).toEqual(scenario.result);
+    });
+  });
+});


### PR DESCRIPTION
Previously combo use was analysed by just counting how many casts were at full and not-full combo points. That would incorrectly consider the standard (and highest DPS) opener as including a mistake when the player uses Rip without full combo points.

Now each time a finisher is used the `FinisherUse` module will determine if it was a good use or not. Most finishers should still always be used at full combo points but the exceptions for Rip are handled. If Rip is applied to a target that doesn't yet have the debuff, that's correct play even with very low combo points. Just getting the DoT ticking is a damage increase over waiting for full combo points. Similarly upgrading the snapshot damage of an existing Rip depends only on the buffs active and not on combo points, so a low combo point cast is fine in that case too - so long as the player is using the Sabretooth talent.

To handle that second exception `FinisherUse` uses information from `RipSnapshot`. To make that information available this PR makes some changes to `Snapshot`, along with some general updates such as using the event listener system. To make the task of `Snapshot` easier there's now also a `BleedDebuffEvents` normalizer (along with a test for it) which adds a helper property to specific Feral-relevant cast events.

![combo-suggest](https://user-images.githubusercontent.com/35700764/59766486-35fd7c80-9298-11e9-9fce-7314c26d56cd.png)
![combo-checklist](https://user-images.githubusercontent.com/35700764/59766492-37c74000-9298-11e9-9b70-bcf90050aa89.png)
![combo-statistic](https://user-images.githubusercontent.com/35700764/59766494-38f86d00-9298-11e9-9d05-66cd3ba1012f.png)
