### PR TITLE
[Feral] FinisherUse null reference fix

### DIFF
--- a/src/parser/druid/feral/modules/combopoints/FinisherUse.js
+++ b/src/parser/druid/feral/modules/combopoints/FinisherUse.js
@@ -76,6 +76,12 @@ class FinisherUse extends Analyzer {
     // Rip has been used without full combo points, which is a good thing only in certain situations
     // RipSnapshot will have added the feralSnapshotState prop to the event, because this module has RipSnapshot as a dependency
     // we know that will have been done before this executes.
+    if (!event.feralSnapshotState) {
+      // ..but when it comes to null references it's worth checking.
+      // If for some reason the property doesn't exist just skip checking this cast
+      debug && this.warn('Rip cast event doesn\'t have the expected feralSnapshotState property.');
+      return;
+    }
     if (RipSnapshot.wasStateFreshlyApplied(event.feralSnapshotState)) {
       debug && this.log(`cast ${finisher.name} with ${combo} combo points but it was a fresh application, so is good`);
       this.freshRips += 1;

--- a/src/parser/druid/feral/modules/core/Snapshot.js
+++ b/src/parser/druid/feral/modules/core/Snapshot.js
@@ -30,7 +30,7 @@ const debug = false;
 const BUFF_WINDOW_TIME = 60;
 
 // leeway in ms between a cast event and debuff apply/refresh for them to be associated
-const CAST_WINDOW_TIME = 100;
+const CAST_WINDOW_TIME = 300;
 
 /**
  * Leeway in ms between when a debuff was expected to wear off and when damage events will no longer be counted
@@ -63,6 +63,9 @@ class Snapshot extends Analyzer {
   damageFromBloodtalons = 0;
 
   static wasStateFreshlyApplied(state) {
+    if (!state) {
+      return false;
+    }
     if (!state.prev) {
       // no previous state, so must be fresh
       return true;
@@ -76,6 +79,9 @@ class Snapshot extends Analyzer {
   }
 
   static wasStatePowerUpgrade(state) {
+    if (!state) {
+      return false;
+    }
     if (Snapshot.wasStateFreshlyApplied(state)) {
       // a fresh application isn't the same as an upgrade
       return false;

--- a/src/parser/druid/feral/normalizers/BleedDebuffEvents.js
+++ b/src/parser/druid/feral/normalizers/BleedDebuffEvents.js
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS/index';
 import EventsNormalizer from 'parser/core/EventsNormalizer';
 
-const CAST_WINDOW = 100;
+const CAST_WINDOW = 300;
 const CAST_DEBUFF_PAIRS = [
   { 
     cast: SPELLS.RIP,


### PR DESCRIPTION
Small fix for a possible null reference. As well as checking for the null reference also fixes the cause of the null object. It was due to a greater than 100ms timestamp difference between an ability's cast and debuff events.

Log which caused an error:
`report/1wWP8749VFN6Z2xA/3-Heroic+Conclave+of+the+Chosen+-+Kill+(6:10)/Cajotan`