### PR TITLE
fix crash if no player targetted with void stone

### DIFF
--- a/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/VoidStone.js
+++ b/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/VoidStone.js
@@ -91,7 +91,7 @@ class VoidStone extends Analyzer {
                   return (
                     <tr key={use}>
                       <th>{formatDuration(this.absorbedByUse[use].time / 1000)}</th>
-                      <td>{target.name || <>Unknown</>}</td>
+                      <td>{(target && target.name) || <>Unknown</>}</td>
                       <td>{formatNumber(this.absorbedByUse[use].amount)}</td>
                     </tr>
                   );


### PR DESCRIPTION
fixes https://wowanalyzer.com/report/7c8zdHXYtRrDVvpA/3-Mythic+Conclave+of+the+Chosen+-+Kill+(5:39)/Gospi

crash caused by player casting void stone on a totem instead of a player