### PR TITLE
[BrM] Hot Trub Damage Estimator

### DIFF
--- a/src/common/SPELLS/monk.js
+++ b/src/common/SPELLS/monk.js
@@ -443,6 +443,11 @@ export default {
     name: "Brew-Stache",
     icon: "inv_misc_archaeology_vrykuldrinkinghorn",
   },
+  HOT_TRUB: {
+    id: 202126,
+    name: "Hot Trub",
+    icon: "spell_brew_dark",
+  },
 
   // Windwalker Spells
   COMBO_STRIKES: {

--- a/src/parser/monk/brewmaster/CHANGELOG.js
+++ b/src/parser/monk/brewmaster/CHANGELOG.js
@@ -8,6 +8,11 @@ import SpellLink from 'common/SpellLink';
 
 export default [
   {
+    date: new Date('2019-06-28'),
+    changes: <>Added a <SpellLink id={SPELLS.HOT_TRUB.id} /> damage estimator. Nerf sucks :(</>,
+    contributors: [emallson],
+  },
+  {
     date: new Date('2019-04-11'),
     changes: <>Fixed a bug in the Mitigation Values tab that caused Mastery's base 8% to be counted towards contribution by Mastery Rating.</>,
     contributors: [emallson],

--- a/src/parser/monk/brewmaster/CombatLogParser.js
+++ b/src/parser/monk/brewmaster/CombatLogParser.js
@@ -38,6 +38,7 @@ import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import StaggerPoolGraph from './modules/features/StaggerPoolGraph';
 import MitigationCheck from './modules/features/MitigationCheck';
 import MitigationSheet from './modules/features/MitigationSheet';
+import HotTrubValue from './modules/features/HotTrubValue';
 
 // Items
 // normalizers
@@ -68,6 +69,7 @@ class CombatLogParser extends CoreCombatLogParser {
     abilities: Abilities,
     staggerPoolGraph: StaggerPoolGraph,
     sheet: MitigationSheet,
+    hotTrubValue: HotTrubValue,
 
     // Spells
     ironSkinBrew: IronSkinBrew,

--- a/src/parser/monk/brewmaster/CombatLogParser.js
+++ b/src/parser/monk/brewmaster/CombatLogParser.js
@@ -38,7 +38,7 @@ import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import StaggerPoolGraph from './modules/features/StaggerPoolGraph';
 import MitigationCheck from './modules/features/MitigationCheck';
 import MitigationSheet from './modules/features/MitigationSheet';
-import HotTrubValue from './modules/features/HotTrubValue';
+import HotTrubTimeMachine from './modules/features/HotTrubTimeMachine';
 
 // Items
 // normalizers
@@ -69,7 +69,7 @@ class CombatLogParser extends CoreCombatLogParser {
     abilities: Abilities,
     staggerPoolGraph: StaggerPoolGraph,
     sheet: MitigationSheet,
-    hotTrubValue: HotTrubValue,
+    hotTrubTimeMachine: HotTrubTimeMachine,
 
     // Spells
     ironSkinBrew: IronSkinBrew,

--- a/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
@@ -429,6 +429,83 @@ exports[`The Brewmaster Analyzer analyzers HighTolerance matches the statistic s
 
 exports[`The Brewmaster Analyzer analyzers HighTolerance matches the suggestions snapshot 1`] = `Array []`;
 
+exports[`The Brewmaster Analyzer analyzers HotTrubValue matches the statistic snapshot 1`] = `
+<div
+  className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
+>
+  <div
+    className="panel statistic standard statistic-box"
+    style={
+      Object {
+        "height": "auto",
+        "zIndex": 1,
+      }
+    }
+  >
+    <div
+      className="panel-body"
+    >
+      <div
+        className="pad"
+      >
+        <label>
+          <a
+            href="http://wowhead.com/spell=202126"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <img
+              alt="Hot Trub"
+              className="icon game "
+              src="//render-us.worldofwarcraft.com/icons/56/spell_brew_dark.jpg"
+            />
+          </a>
+           
+          Hot Trub Time Machine
+        </label>
+        <div
+          className="value"
+        >
+          <img
+            alt="Damage"
+            className="icon"
+            src="/img/sword.png"
+          />
+           
+          252
+           DPS 
+          <small>
+            4.52
+             % of total
+          </small>
+        </div>
+      </div>
+      <div
+        className="row"
+      >
+        <div
+          className="col-xs-12"
+        />
+      </div>
+      <div
+        className="statistic-expansion-button-holster"
+      >
+        <button
+          className="btn btn-primary"
+          onClick={[Function]}
+        >
+          <span
+            className="glyphicon glyphicon-chevron-down"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`The Brewmaster Analyzer analyzers HotTrubValue matches the suggestions snapshot 1`] = `Array []`;
+
 exports[`The Brewmaster Analyzer analyzers IronSkinBrew matches the statistic snapshot 1`] = `
 <div
   className="col-lg-3 col-md-4 col-sm-6 col-xs-12"

--- a/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
@@ -429,7 +429,7 @@ exports[`The Brewmaster Analyzer analyzers HighTolerance matches the statistic s
 
 exports[`The Brewmaster Analyzer analyzers HighTolerance matches the suggestions snapshot 1`] = `Array []`;
 
-exports[`The Brewmaster Analyzer analyzers HotTrubValue matches the statistic snapshot 1`] = `
+exports[`The Brewmaster Analyzer analyzers HotTrubTimeMachine matches the statistic snapshot 1`] = `
 <div
   className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
 >
@@ -504,7 +504,7 @@ exports[`The Brewmaster Analyzer analyzers HotTrubValue matches the statistic sn
 </div>
 `;
 
-exports[`The Brewmaster Analyzer analyzers HotTrubValue matches the suggestions snapshot 1`] = `Array []`;
+exports[`The Brewmaster Analyzer analyzers HotTrubTimeMachine matches the suggestions snapshot 1`] = `Array []`;
 
 exports[`The Brewmaster Analyzer analyzers IronSkinBrew matches the statistic snapshot 1`] = `
 <div

--- a/src/parser/monk/brewmaster/modules/features/AgilityValue.js
+++ b/src/parser/monk/brewmaster/modules/features/AgilityValue.js
@@ -59,12 +59,12 @@ export default class AgilityValue extends Analyzer {
     return this.gotox.agiBonusHealing;
   }
   _agiDamagePooled = 0;
-  _hasHT = false;
+  hasHT = false;
 
   constructor(...args) {
     super(...args);
 
-    this._hasHT = this.selectedCombatant.hasTalent(SPELLS.HIGH_TOLERANCE_TALENT.id);
+    this.hasHT = this.selectedCombatant.hasTalent(SPELLS.HIGH_TOLERANCE_TALENT.id);
 
     this.addEventListener(EVENT_STAGGER_POOL_ADDED, this._onStaggerGained);
     this.addEventListener(EVENT_STAGGER_POOL_REMOVED, this._onPurify);
@@ -101,8 +101,8 @@ export default class AgilityValue extends Analyzer {
   }
 
   _onStaggerGained(event) {
-    const baseStagger = staggerPct(BASE_AGI, this.K, this._hasIsb, this._hasHT);
-    const agiStagger = staggerPct(this.stats.currentAgilityRating, this.K, this._hasIsb, this._hasHT);
+    const baseStagger = staggerPct(BASE_AGI, this.K, this._hasIsb, this.hasHT);
+    const agiStagger = staggerPct(this.stats.currentAgilityRating, this.K, this._hasIsb, this.hasHT);
     const amountAgiStaggered = (1 - baseStagger / agiStagger) * event.amount;
 
     this.totalAgiStaggered += amountAgiStaggered;

--- a/src/parser/monk/brewmaster/modules/features/HotTrubTimeMachine.js
+++ b/src/parser/monk/brewmaster/modules/features/HotTrubTimeMachine.js
@@ -11,7 +11,7 @@ import { EVENT_STAGGER_POOL_ADDED, EVENT_STAGGER_POOL_REMOVED } from '../core/St
 import AgilityValue, { staggerPct } from './AgilityValue';
 import { lookupK } from '../constants/Mitigation';
 
-const debug = true;
+const debug = false;
 
 export function hotTrubDamage(amtPurified, maxHP) {
   return Math.min(uncappedHotTrubDamage(amtPurified), Math.floor(maxHP * 0.2));

--- a/src/parser/monk/brewmaster/modules/features/HotTrubTimeMachine.js
+++ b/src/parser/monk/brewmaster/modules/features/HotTrubTimeMachine.js
@@ -25,7 +25,7 @@ function pctLost(obj) {
   return obj.lost / (obj.lost + obj.damage);
 }
 
-export default class HotTrubValue extends Analyzer {
+export default class HotTrubTimeMachine extends Analyzer {
   static dependencies = {
     stats: StatTracker,
     agi: AgilityValue,

--- a/src/parser/monk/brewmaster/modules/features/HotTrubValue.js
+++ b/src/parser/monk/brewmaster/modules/features/HotTrubValue.js
@@ -142,7 +142,7 @@ export default class HotTrubValue extends Analyzer {
             <dt><b>Max Cast</b></dt> <dd>{formatNumber(this.actual.maxCast)}</dd>
             <dt><b>Damage Lost to HP Cap</b></dt> <dd>{formatNumber(this.actual.lost)} <em>({formatPercentage(pctLost(this.actual))}%)</em></dd>
           </dl>
-          <br/>
+          <br />
           <p>These numbers are all <em>hypothetical</em>. You don't need to have the Conflict &amp; Strife essence equipped to see this.</p>
           <h5>Degenerate Play</h5>
           <p>If you replaced every ISB cast with a PB cast, how much damage would you have done?</p>
@@ -158,4 +158,4 @@ export default class HotTrubValue extends Analyzer {
       </StatisticBox>
     );
   }
-};
+}

--- a/src/parser/monk/brewmaster/modules/features/HotTrubValue.js
+++ b/src/parser/monk/brewmaster/modules/features/HotTrubValue.js
@@ -1,0 +1,161 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import StatTracker from 'parser/shared/modules/StatTracker';
+import StatisticBox from 'interface/others/StatisticBox';
+import SpellIcon from 'common/SpellIcon';
+import ItemDamageDone from 'interface/others/ItemDamageDone';
+import { formatNumber, formatPercentage } from 'common/format';
+import { EVENT_STAGGER_POOL_ADDED, EVENT_STAGGER_POOL_REMOVED } from '../core/StaggerFabricator';
+import AgilityValue, { staggerPct } from './AgilityValue';
+import { lookupK } from '../constants/Mitigation';
+
+const debug = true;
+
+export function hotTrubDamage(amtPurified, maxHP) {
+  return Math.min(uncappedHotTrubDamage(amtPurified), Math.floor(maxHP * 0.2));
+}
+
+export function uncappedHotTrubDamage(amtPurified) {
+  return Math.floor(amtPurified * 0.3);
+}
+
+function pctLost(obj) {
+  return obj.lost / (obj.lost + obj.damage);
+}
+
+export default class HotTrubValue extends Analyzer {
+  static dependencies = {
+    stats: StatTracker,
+    agi: AgilityValue,
+  };
+
+  actual = null;
+
+  degenerate = null;
+
+  K = null;
+
+  constructor(...props) {
+    super(...props);
+
+    this.K = lookupK(this.owner.fight);
+
+    this.actual = {
+      damage: 0,
+      maxCast: 0,
+      lost: 0,
+    };
+
+    this.degenerate = {
+      damage: 0,
+      maxCast: 0,
+      lost: 0,
+      staggerPool: 0,
+      tickAmount: 0,
+    };
+
+    this.addEventListener(EVENT_STAGGER_POOL_REMOVED, this._calculatePurifyDamage);
+    
+    this.addEventListener(EVENT_STAGGER_POOL_ADDED, this._degenerateStaggerAdd);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell([SPELLS.PURIFYING_BREW, SPELLS.IRONSKIN_BREW]), this._degeneratePurifyDamage);
+    this.addEventListener(EVENT_STAGGER_POOL_REMOVED, this._degenerateRemoveStagger);
+  }
+
+  _calculatePurifyDamage(event) {
+    if(event._reason.ability.guid !== SPELLS.PURIFYING_BREW.id) {
+      return;
+    }
+
+    const dmg = hotTrubDamage(event.amount, event._reason.maxHitPoints);
+    this.actual.damage += dmg;
+    this.actual.lost += uncappedHotTrubDamage(event.amount) - dmg;
+
+    if(dmg > this.actual.maxCast) {
+      this.actual.maxCast = dmg;
+    }
+  }
+
+  _degenerateStaggerAdd(event) {
+    const actualPct = staggerPct(
+      this.stats.currentAgilityRating, this.K, 
+      this.selectedCombatant.hasBuff(SPELLS.IRONSKIN_BREW_BUFF.id),
+      this.agi.hasHT
+    );
+
+    const degenPct = staggerPct(
+      this.stats.currentAgilityRating, this.K, 
+      false,
+      this.agi.hasHT
+    );
+
+    const staggered = event.amount * degenPct / actualPct;
+    this.degenerate.staggerPool += staggered;
+
+    const numTicks = this.selectedCombatant.hasTalent(SPELLS.BOB_AND_WEAVE_TALENT.id) ? 26 : 20;
+    this.degenerate.tickAmount = Math.ceil(this.degenerate.staggerPool / numTicks);
+    debug && this.log("Degenerate staggered damage", staggered, "Total Stagger", this.degenerate.staggerPool);
+  }
+
+  _degeneratePurifyDamage(event) {
+    const amount = this.degenerate.staggerPool / 2;
+    this.degenerate.staggerPool -= amount;
+    this.degenerate.tickAmount /= 2;
+
+    const dmg = hotTrubDamage(amount, event.maxHitPoints);
+    this.degenerate.damage += dmg;
+    this.degenerate.lost += uncappedHotTrubDamage(amount) - dmg;
+
+    if(dmg > this.degenerate.maxCast) {
+      this.degenerate.maxCast = dmg;
+    }
+    debug && this.log("Degenerate purified", amount, "Damage dealt", dmg, "Remaining Stagger", this.degenerate.staggerPool);
+  }
+
+  _degenerateRemoveStagger(event) {
+    if(event._reason.ability.guid === SPELLS.PURIFYING_BREW.id) {
+      // handled in _degeneratePurifyDamage, everything else is flat
+      // reduction
+      return;
+    }
+
+    if(event._reason.ability.guid === SPELLS.STAGGER_TAKEN.id) {
+      // stagger dot, replace event amount with our own tick amount;
+      this.degenerate.staggerPool -= this.degenerate.tickAmount;
+      return;
+    }
+    
+    const amount = event.amount + event.overheal;
+    this.degenerate.staggerPool -= Math.min(this.degenerate.staggerPool, amount);
+  }
+  
+  statistic() {
+    return (
+      <StatisticBox
+        label="Hot Trub Time Machine"
+        icon={<SpellIcon id={SPELLS.HOT_TRUB.id} />}
+        value={<ItemDamageDone amount={this.actual.damage} />}
+      >
+        <div style={{padding: '2ex'}}>
+          <dl>
+            <dt><b>Max Cast</b></dt> <dd>{formatNumber(this.actual.maxCast)}</dd>
+            <dt><b>Damage Lost to HP Cap</b></dt> <dd>{formatNumber(this.actual.lost)} <em>({formatPercentage(pctLost(this.actual))}%)</em></dd>
+          </dl>
+          <br/>
+          <p>These numbers are all <em>hypothetical</em>. You don't need to have the Conflict &amp; Strife essence equipped to see this.</p>
+          <h5>Degenerate Play</h5>
+          <p>If you replaced every ISB cast with a PB cast, how much damage would you have done?</p>
+          <dl>
+            <dt><b>Total Damage</b></dt>
+            <dd><ItemDamageDone amount={this.degenerate.damage} /></dd>
+            <dt><b>Max Cast</b></dt>
+            <dd>{formatNumber(this.degenerate.maxCast)}</dd>
+            <dt><b>Damage Lost to HP Cap</b></dt>
+            <dd>{formatNumber(this.degenerate.lost)} <em>({formatPercentage(pctLost(this.degenerate))}%)</em></dd>
+          </dl>
+        </div>
+      </StatisticBox>
+    );
+  }
+};

--- a/src/parser/monk/brewmaster/modules/features/HotTrubValue.js
+++ b/src/parser/monk/brewmaster/modules/features/HotTrubValue.js
@@ -18,7 +18,7 @@ export function hotTrubDamage(amtPurified, maxHP) {
 }
 
 export function uncappedHotTrubDamage(amtPurified) {
-  return Math.floor(amtPurified * 0.3);
+  return Math.floor(amtPurified * 0.2);
 }
 
 function pctLost(obj) {


### PR DESCRIPTION
Shows an estimate of the damage the Hot Trub PvP talent would do if you'd used the Conflict & Strife essence. Hot Trub deals damage equal to 20% of purified damage, up to a maximum of 20% of your max HP per cast.

Hot Trub is not usable in PvE content *yet* so this lets us get an idea for how much damage it does in current content.

(screenshot looks mega large for some reason, not sure why)

![Screenshot from 2019-06-28 12-00-25](https://user-images.githubusercontent.com/4909458/60357249-26211f00-99a1-11e9-8623-77a2542429bd.png)
