### PR TITLE
[DPriest] Bug: Fixing PW:Radiance Evangelism overlap

### DIFF
--- a/src/parser/priest/discipline/CHANGELOG.js
+++ b/src/parser/priest/discipline/CHANGELOG.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { Oratio, Reglitch, Zerotorescue, niseko } from 'CONTRIBUTORS';
+import { Oratio, Reglitch, Zerotorescue, niseko, Khadaj } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 7, 26), <>The Evangelism module now correctly shows buff count when casting <SpellLink id={SPELLS.EVANGELISM_TALENT.id} /> right after <SpellLink id={SPELLS.POWER_WORD_RADIANCE.id} />.</>, [Khadaj]),
   change(date(2018, 10, 17), `The Atonement sources tab should no longer display spells that do not cause atonement healing.`, [niseko]),
   change(date(2018, 9, 14), <>Fixed the <SpellLink id={SPELLS.TWIST_OF_FATE_TALENT_DISCIPLINE.id} /> analyzer.</>, [Zerotorescue]),
   change(date(2018, 7, 31), <>Rework of the <SpellLink id={SPELLS.GRACE.id} /> module.</>, [Oratio]),

--- a/src/parser/priest/discipline/normalizers/PowerWordRadianceNormalizer.js
+++ b/src/parser/priest/discipline/normalizers/PowerWordRadianceNormalizer.js
@@ -35,6 +35,7 @@ class PowerWordRadianceNormalizer extends EventsNormalizer {
       if (event.type === "applybuff" || event.type === "refreshbuff" || event.type === "applybuffstack") {
         const spellId = event.ability.guid;
         if ((event.timestamp - lastRadianceTimestamp) < MAX_TIME_SINCE_CAST && BUFFS_TO_MOVE.includes(spellId)) {
+          event.timestamp = lastRadianceTimestamp;
           event.__modified = true;
           fixedEvents.splice(lastRadianceIndex + 1, 0, event);
           fixedEvents.splice(-1, 1);


### PR DESCRIPTION
There used to be a problem where if you cast evangelism immediately after PW:R, the evangelism module wouldn't pick up on those last 5 atonements that PW:R applied, so the atonement count & healing contribution would be way off. It was fixed at one point back during legion, but seems to be broken again. This PR reorders the events correctly and resolves the issue.

Before:
![Screen+Shot+2019-07-26+at+2 33 53+PM](https://user-images.githubusercontent.com/716498/61982702-73011100-afb2-11e9-97ea-e0b13fb889d5.png)

After:
![Screen+Shot+2019-07-26+at+2 33 08+PM](https://user-images.githubusercontent.com/716498/61982711-798f8880-afb2-11e9-951e-65cdc2c5d871.png)

Example Log: https://wowanalyzer.com/report/W1THLf49pP2m3jtx/3-Mythic+Abyssal+Commander+Sivara+-+Kill+(5:32)/Xaph/statistics