### PR TITLE
Degraded experience toaster

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -8,6 +8,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  change(date(2019, 7, 31), 'Added \'degraded experience\' toaster in case of disabled modules.', Zeboot),
   change(date(2019, 7, 27), 'Added Unbridled Fury to the list of strong pre-potions.', emallson),
   change(date(2019, 7, 27), <>Added <SpellLink id={SPELLS.NULL_DYNAMO.id} /> essence.</>, emallson),
   change(date(2019, 7, 25), 'Fixed a crash in the Ever-Rising Tide Module', HawkCorrigan),

--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -8,8 +8,8 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  change(date(2019, 8, 2), 'Added \'degraded experience\' toaster in case of disabled modules.', Zeboot),
   change(date(2019, 8, 2), <>Fixed the Haste value of <SpellLink id={SPELLS.EVER_RISING_TIDE_MAJOR.id} /></>, niseko),
-  change(date(2019, 7, 31), 'Added \'degraded experience\' toaster in case of disabled modules.', Zeboot),
   change(date(2019, 7, 27), 'Added Unbridled Fury to the list of strong pre-potions.', emallson),
   change(date(2019, 7, 27), <>Added <SpellLink id={SPELLS.NULL_DYNAMO.id} /> essence.</>, emallson),
   change(date(2019, 7, 25), 'Fixed a crash in the Ever-Rising Tide Module', HawkCorrigan),

--- a/src/interface/report/Results/DegradedExperience.js
+++ b/src/interface/report/Results/DegradedExperience.js
@@ -27,6 +27,7 @@ class DegradedExperience extends React.PureComponent {
         <Danger style={{ marginBottom: 30 }}>
         <h2> Degraded Experience </h2>
           One or more modules have encountered an error and have been disabled along with modules depending on them. Results may be inaccurate and / or incomplete. <br />
+          Please report this issue to us on <a href="https://wowanalyzer.com/discord">Discord</a> or <a href="https://github.com/WoWAnalyzer/WoWAnalyzer">GitHub</a> so we can fix it! <br />
           {this.state.expanded && (
             <><br />The following modules have been disabled due to errors: <br />
               <div style={{color: "white"}}>

--- a/src/interface/report/Results/DegradedExperience.js
+++ b/src/interface/report/Results/DegradedExperience.js
@@ -38,7 +38,7 @@ class DegradedExperience extends React.PureComponent {
               <div key={state}>
                 <br />The following modules have been disabled due to errors during {state}: <br />
                 <div style={{color: "white"}}>
-                  {disabledModules[state].sort((a,b) => a.name.localeCompare(b.name)).map((m, i) => <span key={i}>{m.name}<br /></span>)}
+                  {disabledModules[state].sort((a,b) => a.name.localeCompare(b.name)).map((m, i) => <React.Fragment key={i}>{m.name}<br /></React.Fragment>)}
                 </div>
               </div>
             );

--- a/src/interface/report/Results/DegradedExperience.js
+++ b/src/interface/report/Results/DegradedExperience.js
@@ -6,7 +6,7 @@ import { DISABLED_STATE } from 'parser/core/CombatLogParser';
 
 class DegradedExperience extends React.PureComponent {
   static propTypes = {
-    disabledModules: PropTypes.array.isRequired,
+    disabledModules: PropTypes.object.isRequired,
   };
 
   constructor(...args){
@@ -15,6 +15,10 @@ class DegradedExperience extends React.PureComponent {
       expanded: false,
     };
     this.toggleDetails = this.toggleDetails.bind(this);
+  }
+
+  componentWillReceiveProps(nextProps){
+    this.forceUpdate();
   }
 
   toggleDetails() {
@@ -31,14 +35,15 @@ class DegradedExperience extends React.PureComponent {
           Please report this issue to us on <a href="https://wowanalyzer.com/discord">Discord</a> or <a href="https://github.com/WoWAnalyzer/WoWAnalyzer">GitHub</a> so we can fix it! <br />
           {this.state.expanded && Object.values(DISABLED_STATE).filter(state => disabledModules[state] && disabledModules[state].length !== 0).map(state => {
             return (
-              <>
+              <div key={state}>
                 <br />The following modules have been disabled due to errors during {state}: <br />
                 <div style={{color: "white"}}>
-                  {disabledModules[state].sort((a,b) => a.name.localeCompare(b.name)).map(m => <>{m.name}<br /></>)}<br />
+                  {disabledModules[state].sort((a,b) => a.name.localeCompare(b.name)).map((m, i) => <span key={i}>{m.name}<br /></span>)}
                 </div>
-              </>
+              </div>
             );
           })}
+          <br />
           <span style={{ color: styles.primaryColor, cursor: "pointer" }} onClick={this.toggleDetails}>{this.state.expanded ? <>Show Less</> : <>Show More</>}</span>
         </Danger>
       </div>

--- a/src/interface/report/Results/DegradedExperience.js
+++ b/src/interface/report/Results/DegradedExperience.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styles from 'interface/layout/Theme.scss';
 import Danger from 'interface/common/Alert/Danger';
-import { DISABLED_STATE } from 'parser/core/CombatLogParser';
+import MODULE_ERROR from 'parser/core/MODULE_ERROR';
 
 class DegradedExperience extends React.PureComponent {
   static propTypes = {
@@ -33,7 +33,7 @@ class DegradedExperience extends React.PureComponent {
         <h2> Degraded Experience </h2>
           One or more modules have encountered an error and have been disabled along with modules depending on them. Results may be inaccurate and / or incomplete. <br />
           Please report this issue to us on <a href="https://wowanalyzer.com/discord">Discord</a> or <a href="https://github.com/WoWAnalyzer/WoWAnalyzer">GitHub</a> so we can fix it! <br />
-          {this.state.expanded && Object.values(DISABLED_STATE).filter(state => disabledModules[state] && disabledModules[state].length !== 0).map(state => {
+          {this.state.expanded && Object.values(MODULE_ERROR).filter(state => disabledModules[state] && disabledModules[state].length !== 0).map(state => {
             return (
               <div key={state}>
                 <br />The following modules have been disabled due to errors during {state}: <br />

--- a/src/interface/report/Results/DegradedExperience.js
+++ b/src/interface/report/Results/DegradedExperience.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import styles from 'interface/layout/Theme.scss';
 import Danger from 'interface/common/Alert/Danger';
 
 class DegradedExperience extends React.PureComponent {
@@ -34,7 +34,7 @@ class DegradedExperience extends React.PureComponent {
               </div>
             </>
           )}
-          <span onClick={this.toggleDetails}>{this.state.expanded ? <>Show Less</> : <>Show More</>}</span>
+          <span style={{ color: styles.primaryColor, cursor: "pointer" }} onClick={this.toggleDetails}>{this.state.expanded ? <>Show Less</> : <>Show More</>}</span>
         </Danger>
       </div>
     );

--- a/src/interface/report/Results/DegradedExperience.js
+++ b/src/interface/report/Results/DegradedExperience.js
@@ -21,13 +21,36 @@ class DegradedExperience extends React.Component {
     this.setState({expanded: !this.state.expanded});
   }
 
+  get firstError() {
+    const { disabledModules } = this.props;
+    const existingErrorTypes = Object.values(MODULE_ERROR).filter(state => disabledModules[state] && disabledModules[state].length !== 0);
+    if(existingErrorTypes.length > 0){
+      return disabledModules[existingErrorTypes[0]][0].name;
+    }
+    return "";
+  }
+
+  get disabledModuleCount(){
+    const { disabledModules } = this.props;
+    let amount = 0;
+    if(disabledModules){
+      amount = Object.values(MODULE_ERROR).reduce((total, cur) => {
+        return total + (disabledModules[cur] ? disabledModules[cur].length : 0);
+      }, 0);
+    }
+    return amount;
+  }
+
   render() {
     const { disabledModules } = this.props;
-    return (
+    return this.disabledModuleCount > 0 && (
       <div className="container">
         <Danger style={{ marginBottom: 30 }}>
         <h2> Degraded Experience </h2>
-          One or more modules have encountered an error and have been disabled along with modules depending on them. Results may be inaccurate and / or incomplete. <br />
+          <span style={{color: "white"}}>{this.firstError} </span>
+          {this.disabledModuleCount > 1 && <>and <span style={{color: "white"}}>{this.disabledModuleCount - 1}</span> other modules have encountered an error and have been disabled along with modules depending on them. </>}
+          {this.disabledModuleCount === 1 && <>has encountered an error and has been disabled. </>}
+          Results may be inaccurate and / or incomplete. <br />
           Please report this issue to us on <a href="https://wowanalyzer.com/discord">Discord</a> or <a href="https://github.com/WoWAnalyzer/WoWAnalyzer">GitHub</a> so we can fix it! <br />
           {this.state.expanded && Object.values(MODULE_ERROR).filter(state => disabledModules[state] && disabledModules[state].length !== 0).map(state => {
             return (

--- a/src/interface/report/Results/DegradedExperience.js
+++ b/src/interface/report/Results/DegradedExperience.js
@@ -48,7 +48,7 @@ class DegradedExperience extends React.Component {
         <Danger style={{ marginBottom: 30 }}>
         <h2> Degraded Experience </h2>
           <span style={{color: "white"}}>{this.firstError} </span>
-          {this.disabledModuleCount > 1 && <>and <span style={{color: "white"}}>{this.disabledModuleCount - 1}</span> other modules have encountered an error and have been disabled along with modules depending on them. </>}
+          {this.disabledModuleCount > 1 && <>and <span style={{color: "white"}}>{this.disabledModuleCount - 1}</span> other modules have encountered an error directly or inside a dependency and have been disabled. </>}
           {this.disabledModuleCount === 1 && <>has encountered an error and has been disabled. </>}
           Results may be inaccurate and / or incomplete. <br />
           Please report this issue to us on <a href="https://wowanalyzer.com/discord">Discord</a> or <a href="https://github.com/WoWAnalyzer/WoWAnalyzer">GitHub</a> so we can fix it! <br />

--- a/src/interface/report/Results/DegradedExperience.js
+++ b/src/interface/report/Results/DegradedExperience.js
@@ -4,7 +4,7 @@ import styles from 'interface/layout/Theme.scss';
 import Danger from 'interface/common/Alert/Danger';
 import MODULE_ERROR from 'parser/core/MODULE_ERROR';
 
-class DegradedExperience extends React.PureComponent {
+class DegradedExperience extends React.Component {
   static propTypes = {
     disabledModules: PropTypes.object.isRequired,
   };
@@ -15,10 +15,6 @@ class DegradedExperience extends React.PureComponent {
       expanded: false,
     };
     this.toggleDetails = this.toggleDetails.bind(this);
-  }
-
-  componentWillReceiveProps(nextProps){
-    this.forceUpdate();
   }
 
   toggleDetails() {

--- a/src/interface/report/Results/DegradedExperience.js
+++ b/src/interface/report/Results/DegradedExperience.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Danger from 'interface/common/Alert/Danger';
+
+class DegradedExperience extends React.PureComponent {
+  static propTypes = {
+    disabledModules: PropTypes.array.isRequired,
+  };
+
+  constructor(...args){
+    super(...args);
+    this.state = {
+      expanded: false,
+    };
+    this.toggleDetails = this.toggleDetails.bind(this);
+  }
+
+  toggleDetails() {
+    this.setState({expanded: !this.state.expanded});
+  }
+
+  render() {
+    const { disabledModules } = this.props;
+    return (
+      <div className="container">
+        <Danger style={{ marginBottom: 30 }}>
+        <h2> Degraded Experience </h2>
+          One or more modules have encountered an error and have been disabled along with modules depending on them. Results may be inaccurate and / or incomplete. <br />
+          {this.state.expanded && (
+            <><br />The following modules have been disabled due to errors: <br />
+              <div style={{color: "white"}}>
+                {disabledModules.sort((a,b) => a.name.localeCompare(b.name)).map(m => <>{m.name}<br /></>)}<br />
+              </div>
+            </>
+          )}
+          <span onClick={this.toggleDetails}>{this.state.expanded ? <>Show Less</> : <>Show More</>}</span>
+        </Danger>
+      </div>
+    );
+  }
+}
+
+export default DegradedExperience;

--- a/src/interface/report/Results/DegradedExperience.js
+++ b/src/interface/report/Results/DegradedExperience.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styles from 'interface/layout/Theme.scss';
 import Danger from 'interface/common/Alert/Danger';
+import { DISABLED_STATE } from 'parser/core/CombatLogParser';
 
 class DegradedExperience extends React.PureComponent {
   static propTypes = {
@@ -28,13 +29,16 @@ class DegradedExperience extends React.PureComponent {
         <h2> Degraded Experience </h2>
           One or more modules have encountered an error and have been disabled along with modules depending on them. Results may be inaccurate and / or incomplete. <br />
           Please report this issue to us on <a href="https://wowanalyzer.com/discord">Discord</a> or <a href="https://github.com/WoWAnalyzer/WoWAnalyzer">GitHub</a> so we can fix it! <br />
-          {this.state.expanded && (
-            <><br />The following modules have been disabled due to errors: <br />
-              <div style={{color: "white"}}>
-                {disabledModules.sort((a,b) => a.name.localeCompare(b.name)).map(m => <>{m.name}<br /></>)}<br />
-              </div>
-            </>
-          )}
+          {this.state.expanded && Object.values(DISABLED_STATE).filter(state => disabledModules[state] && disabledModules[state].length !== 0).map(state => {
+            return (
+              <>
+                <br />The following modules have been disabled due to errors during {state}: <br />
+                <div style={{color: "white"}}>
+                  {disabledModules[state].sort((a,b) => a.name.localeCompare(b.name)).map(m => <>{m.name}<br /></>)}<br />
+                </div>
+              </>
+            );
+          })}
           <span style={{ color: styles.primaryColor, cursor: "pointer" }} onClick={this.toggleDetails}>{this.state.expanded ? <>Show Less</> : <>Show More</>}</span>
         </Danger>
       </div>

--- a/src/interface/report/Results/DegradedExperience.js
+++ b/src/interface/report/Results/DegradedExperience.js
@@ -25,20 +25,31 @@ class DegradedExperience extends React.Component {
     const { disabledModules } = this.props;
     const existingErrorTypes = Object.values(MODULE_ERROR).filter(state => disabledModules[state] && disabledModules[state].length !== 0);
     if(existingErrorTypes.length > 0){
-      return disabledModules[existingErrorTypes[0]][0].name;
+      return disabledModules[existingErrorTypes[0]][0].module.name;
     }
     return "";
   }
 
-  get disabledModuleCount(){
+  get disabledModuleCount() {
     const { disabledModules } = this.props;
     let amount = 0;
     if(disabledModules){
       amount = Object.values(MODULE_ERROR).reduce((total, cur) => {
+        if(cur === MODULE_ERROR.DEPENDENCY){ //dont count dependency errors for total
+          return total;
+        }
         return total + (disabledModules[cur] ? disabledModules[cur].length : 0);
       }, 0);
     }
     return amount;
+  }
+
+  get disabledDependencyCount() {
+    const { disabledModules } = this.props;
+    if(disabledModules[MODULE_ERROR.DEPENDENCY]){
+      return disabledModules[MODULE_ERROR.DEPENDENCY].length;
+    }
+    return 0;
   }
 
   render() {
@@ -48,16 +59,18 @@ class DegradedExperience extends React.Component {
         <Danger style={{ marginBottom: 30 }}>
         <h2> Degraded Experience </h2>
           <span style={{color: "white"}}>{this.firstError} </span>
-          {this.disabledModuleCount > 1 && <>and <span style={{color: "white"}}>{this.disabledModuleCount - 1}</span> other modules have encountered an error directly or inside a dependency and have been disabled. </>}
+          {this.disabledModuleCount > 1 && <>and <span style={{color: "white"}}>{this.disabledModuleCount - 1}</span> other modules have encountered an error have been disabled. </>}
           {this.disabledModuleCount === 1 && <>has encountered an error and has been disabled. </>}
-          Results may be inaccurate and / or incomplete. <br />
+          <br />
+          <span style={{color: "white"}}>{this.disabledDependencyCount}</span> module{this.disabledDependencyCount === 1 ? <> has</> : <>s have</>} been disabled as they depend on these modules. <br /><br />
+          Results may be incomplete. <br />
           Please report this issue to us on <a href="https://wowanalyzer.com/discord">Discord</a> or <a href="https://github.com/WoWAnalyzer/WoWAnalyzer">GitHub</a> so we can fix it! <br />
           {this.state.expanded && Object.values(MODULE_ERROR).filter(state => disabledModules[state] && disabledModules[state].length !== 0).map(state => {
             return (
               <div key={state}>
                 <br />The following modules have been disabled due to errors during {state}: <br />
                 <div style={{color: "white"}}>
-                  {disabledModules[state].sort((a,b) => a.name.localeCompare(b.name)).map((m, i) => <React.Fragment key={i}>{m.name}<br /></React.Fragment>)}
+                  {disabledModules[state].sort((a,b) => a.module.name.localeCompare(b.module.name)).map((m, i) => <ModuleError module={m.module.name} error={m.error} key={i} />)}
                 </div>
               </div>
             );
@@ -70,4 +83,32 @@ class DegradedExperience extends React.Component {
   }
 }
 
+class ModuleError extends React.Component {
+  static propTypes = {
+    module: PropTypes.string.isRequired,
+    error: PropTypes.object,
+  };
+
+  constructor(...args){
+    super(...args);
+    this.state = {
+      expanded: false,
+    };
+    this.toggleError = this.toggleError.bind(this);
+  }
+
+  toggleError() {
+    this.setState({expanded: !this.state.expanded});
+  }
+
+  render() {
+    const {module, error} = this.props;
+    return (
+      <>
+        {module}  {error && <span style={{ color: styles.primaryColor, cursor: "pointer" }} onClick={this.toggleError}>{this.state.expanded ? <>Hide Error</> : <>Show Error</>}</span>}<br />
+        {this.state.expanded && error && <pre>{error.stack}</pre>}
+      </>
+    );
+  }
+}
 export default DegradedExperience;

--- a/src/interface/report/Results/index.js
+++ b/src/interface/report/Results/index.js
@@ -151,16 +151,6 @@ class Results extends React.PureComponent {
       || this.props.parsingState !== EVENT_PARSING_STATE.DONE;
   }
 
-  get disabledModules(){
-    const parser = this.props.parser;
-    let amount = 0;
-    if(parser.disabledModules){
-      amount = Object.values(MODULE_ERROR).reduce((total, cur) => {
-        return total + (parser.disabledModules[cur] ? parser.disabledModules[cur].length : 0);
-      }, 0);
-    }
-    return amount;
-  }
 
   renderContent(selectedTab, results) {
     const { parser, premium } = this.props;
@@ -362,7 +352,7 @@ class Results extends React.PureComponent {
           applyFilter={applyFilter}
           isLoading={this.isLoading}
         />
-        {parser && this.disabledModules > 0 && <DegradedExperience disabledModules={parser.disabledModules} />}
+        {parser && parser.disabledModules && <DegradedExperience disabledModules={parser.disabledModules} />}
         {boss && boss.fight.resultsWarning && (
           <div className="container">
             <Warning style={{ marginBottom: 30 }}>

--- a/src/interface/report/Results/index.js
+++ b/src/interface/report/Results/index.js
@@ -35,6 +35,7 @@ import Overview from './Overview';
 import Statistics from './Statistics';
 import Character from './Character';
 import EncounterStats from './EncounterStats';
+import DegradedExperience from './DegradedExperience';
 import EVENT_PARSING_STATE from '../EVENT_PARSING_STATE';
 import BOSS_PHASES_STATE from '../BOSS_PHASES_STATE';
 import ScrollToTop from './ScrollToTop';
@@ -349,7 +350,7 @@ class Results extends React.PureComponent {
           applyFilter={applyFilter}
           isLoading={this.isLoading}
         />
-
+        {parser && parser.disabledModules && parser.disabledModules.length !== 0 && <DegradedExperience disabledModules={parser.disabledModules} />}
         {boss && boss.fight.resultsWarning && (
           <div className="container">
             <Warning style={{ marginBottom: 30 }}>

--- a/src/interface/report/Results/index.js
+++ b/src/interface/report/Results/index.js
@@ -152,12 +152,14 @@ class Results extends React.PureComponent {
   }
 
   get disabledModules(){
-    if(this.props.parser.disabledModules){
-      return Object.values(DISABLED_STATE).reduce((total, cur) => {
-        return total + (this.props.parser.disabledModules[cur] ? this.props.parser.disabledModules[cur].length : 0);
+    const parser = this.props.parser;
+    let amount = 0;
+    if(parser.disabledModules){
+      amount = Object.values(DISABLED_STATE).reduce((total, cur) => {
+        return total + (parser.disabledModules[cur] ? parser.disabledModules[cur].length : 0);
       }, 0);
     }
-    return 0;
+    return amount;
   }
 
   renderContent(selectedTab, results) {
@@ -360,7 +362,7 @@ class Results extends React.PureComponent {
           applyFilter={applyFilter}
           isLoading={this.isLoading}
         />
-        {parser && this.disabledModules !== 0 && <DegradedExperience disabledModules={parser.disabledModules} />}
+        {parser && this.disabledModules > 0 && <DegradedExperience disabledModules={parser.disabledModules} />}
         {boss && boss.fight.resultsWarning && (
           <div className="container">
             <Warning style={{ marginBottom: 30 }}>

--- a/src/interface/report/Results/index.js
+++ b/src/interface/report/Results/index.js
@@ -27,6 +27,7 @@ import ChangelogTab from 'interface/others/ChangelogTab';
 import ErrorBoundary from 'interface/common/ErrorBoundary';
 import Checklist from 'parser/shared/modules/features/Checklist/Module';
 import StatTracker from 'parser/shared/modules/StatTracker';
+import { DISABLED_STATE } from 'parser/core/CombatLogParser';
 
 import './Results.scss';
 import Header from './Header';
@@ -148,6 +149,15 @@ class Results extends React.PureComponent {
       || this.props.isLoadingPhases
       || this.props.isFilteringEvents
       || this.props.parsingState !== EVENT_PARSING_STATE.DONE;
+  }
+
+  get disabledModules(){
+    if(this.props.parser.disabledModules){
+      return Object.values(DISABLED_STATE).reduce((total, cur) => {
+        return total + (this.props.parser.disabledModules[cur] ? this.props.parser.disabledModules[cur].length : 0);
+      }, 0);
+    }
+    return 0;
   }
 
   renderContent(selectedTab, results) {
@@ -350,7 +360,7 @@ class Results extends React.PureComponent {
           applyFilter={applyFilter}
           isLoading={this.isLoading}
         />
-        {parser && parser.disabledModules && parser.disabledModules.length !== 0 && <DegradedExperience disabledModules={parser.disabledModules} />}
+        {parser && this.disabledModules !== 0 && <DegradedExperience disabledModules={parser.disabledModules} />}
         {boss && boss.fight.resultsWarning && (
           <div className="container">
             <Warning style={{ marginBottom: 30 }}>

--- a/src/interface/report/Results/index.js
+++ b/src/interface/report/Results/index.js
@@ -27,7 +27,7 @@ import ChangelogTab from 'interface/others/ChangelogTab';
 import ErrorBoundary from 'interface/common/ErrorBoundary';
 import Checklist from 'parser/shared/modules/features/Checklist/Module';
 import StatTracker from 'parser/shared/modules/StatTracker';
-import { DISABLED_STATE } from 'parser/core/CombatLogParser';
+import MODULE_ERROR from 'parser/core/MODULE_ERROR';
 
 import './Results.scss';
 import Header from './Header';
@@ -155,7 +155,7 @@ class Results extends React.PureComponent {
     const parser = this.props.parser;
     let amount = 0;
     if(parser.disabledModules){
-      amount = Object.values(DISABLED_STATE).reduce((total, cur) => {
+      amount = Object.values(MODULE_ERROR).reduce((total, cur) => {
         return total + (parser.disabledModules[cur] ? parser.disabledModules[cur].length : 0);
       }, 0);
     }

--- a/src/interface/report/Results/index.js
+++ b/src/interface/report/Results/index.js
@@ -27,7 +27,6 @@ import ChangelogTab from 'interface/others/ChangelogTab';
 import ErrorBoundary from 'interface/common/ErrorBoundary';
 import Checklist from 'parser/shared/modules/features/Checklist/Module';
 import StatTracker from 'parser/shared/modules/StatTracker';
-import MODULE_ERROR from 'parser/core/MODULE_ERROR';
 
 import './Results.scss';
 import Header from './Header';

--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -176,6 +176,12 @@ import EventEmitter from './modules/EventEmitter';
 // This prints to console anything that the DI has to do
 const debugDependencyInjection = false;
 
+//states modules can be disabled in due to errors alongside the description to show in the degraded experience toaster
+export const DISABLED_STATE = {
+  INITIALIZATION: "initialization",
+  RESULTS: "result generation",
+};
+
 class CombatLogParser {
   static abilitiesAffectedByHealingIncreases = [];
   static abilitiesAffectedByDamageIncreases = [];
@@ -360,7 +366,7 @@ class CombatLogParser {
   characterProfile = null;
 
   //Disabled Modules
-  disabledModules = [];
+  disabledModules = null;
 
   adjustForDowntime = true;
   get hasDowntime() {
@@ -407,7 +413,11 @@ class CombatLogParser {
     this.characterProfile = characterProfile;
     this._timestamp = selectedFight.start_time;
     this.boss = findByBossId(selectedFight.boss);
-    this.disabledModules = [];
+    this.disabledModules = {};
+    //initialize disabled modules for each state
+    Object.values(DISABLED_STATE).forEach(key => {
+      this.disabledModules[key] = [];
+    });
     this.initializeModules({
       ...this.constructor.internalModules,
       ...this.constructor.defaultModules,
@@ -507,14 +517,14 @@ class CombatLogParser {
             priority,
           }, desiredModuleName);
         }catch(e){
-          this.disabledModules.push(moduleClass);
+          this.disabledModules[DISABLED_STATE.INITIALIZATION].push(moduleClass);
           debugDependencyInjection && console.warn(moduleClass.name, 'disabled due to error during initialization: ', e);
         }
 
       } else {
-        const disabledDependencies = missingDependencies.map(d => d.name).filter(x => this.disabledModules.map(d => d.name).includes(x)); //see if a dependency was previously disabled due to an error
+        const disabledDependencies = missingDependencies.map(d => d.name).filter(x => this.disabledModules[DISABLED_STATE.INITIALIZATION].map(d => d.name).includes(x)); //see if a dependency was previously disabled due to an error
         if(disabledDependencies.length !== 0){ //if a dependency was already marked as disabled due to an error, mark this module as disabled
-          this.disabledModules.push(moduleClass);
+          this.disabledModules[DISABLED_STATE.INITIALIZATION].push(moduleClass);
           debugDependencyInjection && console.warn(moduleClass.name, 'disabled due to error during initialization of a dependency.');
         }else{
           debugDependencyInjection && console.warn(moduleClass.name, 'could not be loaded, missing dependencies:', missingDependencies.map(d => d.name));
@@ -577,13 +587,16 @@ class CombatLogParser {
     this.getModule(EventEmitter).addEventListener(...args);
   }
 
-  deepDisable(module) {
+  deepDisable(module, state = DISABLED_STATE.RESULTS) {
     console.error('Disabling', module.constructor.name);
+    if(module.active){ //prevent duplicate entries
+      this.disabledModules[state].push(module.constructor);
+    }
     module.active = false;
     this.activeModules.forEach(active => {
         const deps = active.constructor.dependencies;
         if (deps && Object.values(deps).find(depClass => module instanceof depClass)) {
-          this.deepDisable(active);
+          this.deepDisable(active, state);
         }
       }
     );
@@ -647,61 +660,69 @@ class CombatLogParser {
       .sort((a, b) => this._modules[b].priority - this._modules[a].priority)
       .forEach((key, index) => {
         const module = this._modules[key];
+        if(!module.active){
+          return; //check if module is active in case a module gets disabled due to an error
+        }
 
-        if (module.statistic) {
-          let basePosition = index;
-          if (module.statisticOrder !== undefined) {
-            basePosition = module.statisticOrder;
-            console.warn('DEPRECATED', 'Setting the position of a statistic via a module\'s `statisticOrder` prop is deprecated. Set the `position` prop on the `StatisticBox` instead. Example commit: https://github.com/WoWAnalyzer/WoWAnalyzer/commit/ece1bbeca0d3721ede078d256a30576faacb803d', module);
-          }
+        try{
+          if (module.statistic) {
+            let basePosition = index;
+            if (module.statisticOrder !== undefined) {
+              basePosition = module.statisticOrder;
+              console.warn('DEPRECATED', 'Setting the position of a statistic via a module\'s `statisticOrder` prop is deprecated. Set the `position` prop on the `StatisticBox` instead. Example commit: https://github.com/WoWAnalyzer/WoWAnalyzer/commit/ece1bbeca0d3721ede078d256a30576faacb803d', module);
+            }
 
-          const statistic = module.statistic({ i18n });
-          if (statistic) {
-            if (Array.isArray(statistic)) {
-              statistic.forEach((statistic, statisticIndex) => {
-                addStatistic(statistic, basePosition, `${key}-statistic-${statisticIndex}`);
-              });
-            } else {
-              addStatistic(statistic, basePosition, `${key}-statistic`);
+            const statistic = module.statistic({ i18n });
+            if (statistic) {
+              if (Array.isArray(statistic)) {
+                statistic.forEach((statistic, statisticIndex) => {
+                  addStatistic(statistic, basePosition, `${key}-statistic-${statisticIndex}`);
+                });
+              } else {
+                addStatistic(statistic, basePosition, `${key}-statistic`);
+              }
             }
           }
-        }
-        if (module.item) {
-          const item = module.item({ i18n });
-          if (item) {
-            if (React.isValidElement(item)) {
-              results.statistics.push(React.cloneElement(item, {
-                key: `${key}-item`,
-                position: index,
-              }));
-            } else {
-              const id = item.id || item.item.id;
-              const itemDetails = id && this.selectedCombatant.getItem(id);
-              const icon = item.icon || <ItemIcon id={item.item.id} details={itemDetails} />;
-              const title = item.title || <ItemLink id={item.item.id} details={itemDetails} icon={false} />;
+          if (module.item) {
+            const item = module.item({ i18n });
+            if (item) {
+              if (React.isValidElement(item)) {
+                results.statistics.push(React.cloneElement(item, {
+                  key: `${key}-item`,
+                  position: index,
+                }));
+              } else {
+                const id = item.id || item.item.id;
+                const itemDetails = id && this.selectedCombatant.getItem(id);
+                const icon = item.icon || <ItemIcon id={item.item.id} details={itemDetails} />;
+                const title = item.title || <ItemLink id={item.item.id} details={itemDetails} icon={false} />;
 
-              results.statistics.push(
-                <ItemStatisticBox
-                  key={`${key}-item`}
-                  position={index}
-                  icon={icon}
-                  label={title}
-                  value={item.result}
-                  tooltip={item.tooltip}
-                />
-              );
+                results.statistics.push(
+                  <ItemStatisticBox
+                    key={`${key}-item`}
+                    position={index}
+                    icon={icon}
+                    label={title}
+                    value={item.result}
+                    tooltip={item.tooltip}
+                  />
+                );
+              }
             }
           }
-        }
-        if (module.tab) {
-          const tab = module.tab({ i18n });
-          if (tab) {
-            results.tabs.push(tab);
+          if (module.tab) {
+            const tab = module.tab({ i18n });
+            if (tab) {
+              results.tabs.push(tab);
+            }
           }
+          if (module.suggestions) {
+            module.suggestions(results.suggestions.when, { i18n });
+          }
+        }catch(e){ //error occured during results generation of module, disable module and all modules depending on it
+          this.deepDisable(module);
         }
-        if (module.suggestions) {
-          module.suggestions(results.suggestions.when, { i18n });
-        }
+
       });
 
     return results;

--- a/src/parser/core/MODULE_ERROR.js
+++ b/src/parser/core/MODULE_ERROR.js
@@ -3,6 +3,7 @@ const MODULE_ERROR = {
   INITIALIZATION: "initialization",
   EVENTS: "event handling",
   RESULTS: "result generation",
+  DEPENDENCY: "one or more dependencies",
 };
 
 export default MODULE_ERROR;

--- a/src/parser/core/MODULE_ERROR.js
+++ b/src/parser/core/MODULE_ERROR.js
@@ -1,0 +1,8 @@
+//states modules can be disabled in due to errors alongside the description to show in the degraded experience toaster
+const MODULE_ERROR = {
+  INITIALIZATION: "initialization",
+  EVENTS: "event handling",
+  RESULTS: "result generation",
+};
+
+export default MODULE_ERROR;

--- a/src/parser/core/modules/EventEmitter.js
+++ b/src/parser/core/modules/EventEmitter.js
@@ -270,7 +270,7 @@ class EventEmitter extends Module {
     const name = module.constructor.name;
     console.error('Disabling', name, 'and child dependencies because an error occured:', err);
     // Disable this module and all active modules that have this as a dependency
-    this.owner.deepDisable(module, MODULE_ERROR.EVENTS);
+    this.owner.deepDisable(module, MODULE_ERROR.EVENTS, err);
     window.Sentry && window.Sentry.withScope(scope => {
       scope.setTag('type', 'module_error');
       scope.setTag('spec', `${this.selectedCombatant.spec.specName} ${this.selectedCombatant.spec.className}`);

--- a/src/parser/core/modules/EventEmitter.js
+++ b/src/parser/core/modules/EventEmitter.js
@@ -1,3 +1,4 @@
+import MODULE_ERROR from 'parser/core/MODULE_ERROR';
 import Events from '../Events';
 
 import Module from '../Module';
@@ -269,7 +270,7 @@ class EventEmitter extends Module {
     const name = module.constructor.name;
     console.error('Disabling', name, 'and child dependencies because an error occured:', err);
     // Disable this module and all active modules that have this as a dependency
-    this.owner.deepDisable(module);
+    this.owner.deepDisable(module, MODULE_ERROR.EVENTS);
     window.Sentry && window.Sentry.withScope(scope => {
       scope.setTag('type', 'module_error');
       scope.setTag('spec', `${this.selectedCombatant.spec.specName} ${this.selectedCombatant.spec.className}`);


### PR DESCRIPTION
#2174 

Adds a warning about a degraded experience if a module is disabled during loading. Also disables any modules depending on this module. Catches errors during initialization of modules (during constructor), event handling, as well as result generation (and new types can be added easily). Outside of production these errors don't get suppressed / modules stay enabled and throw their errors to allow debugging during development.

![image](https://user-images.githubusercontent.com/5396409/62266663-69036600-b429-11e9-862d-884c82ab03ac.png)

![image](https://user-images.githubusercontent.com/5396409/62266680-7ddff980-b429-11e9-8456-1af2e60b2a32.png)

