### PR TITLE
[Mistweaver] Trait calculation fix

### DIFF
--- a/src/parser/monk/mistweaver/CHANGELOG.js
+++ b/src/parser/monk/mistweaver/CHANGELOG.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { Anomoly, Gao, Zerotorescue, Abelito75 } from 'CONTRIBUTORS';
+import { Anomoly, Gao, Zerotorescue, Abelito75, niseko } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 8, 1), <>Fixed trait calculations being unaffected by healing increases or decreases.</>, niseko),
   change(date(2019, 7, 23), <>Fixed strange bug with mana tea where if you didn't have it selected it crashed the Overview tab</>, Abelito75),
   change(date(2019, 7, 18), <>Made <SpellLink id={SPELLS.WAY_OF_THE_CRANE.id} /> infographic.</>, Abelito75),
   change(date(2019, 7, 2), <><SpellLink id={SPELLS.MANA_TEA_TALENT.id} /> rewrite. Includes all spells</>, Abelito75),

--- a/src/parser/monk/mistweaver/CHANGELOG.js
+++ b/src/parser/monk/mistweaver/CHANGELOG.js
@@ -6,7 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2019, 8, 1), <>Fixed trait calculations being unaffected by healing increases or decreases.</>, niseko),
+  change(date(2019, 8, 2), <>Fixed trait calculations being unaffected by healing increases or decreases.</>, niseko),
   change(date(2019, 7, 23), <>Fixed strange bug with mana tea where if you didn't have it selected it crashed the Overview tab</>, Abelito75),
   change(date(2019, 7, 18), <>Made <SpellLink id={SPELLS.WAY_OF_THE_CRANE.id} /> infographic.</>, Abelito75),
   change(date(2019, 7, 2), <><SpellLink id={SPELLS.MANA_TEA_TALENT.id} /> rewrite. Includes all spells</>, Abelito75),

--- a/src/parser/monk/mistweaver/modules/spells/azeritetraits/FontOfLife.js
+++ b/src/parser/monk/mistweaver/modules/spells/azeritetraits/FontOfLife.js
@@ -1,17 +1,18 @@
 import React from 'react';
 
+import { calculateAzeriteEffects } from 'common/stats';
 import { formatNumber, formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
-import HIT_TYPES from 'game/HIT_TYPES';
 import SpellLink from 'common/SpellLink';
 
 import StatTracker from 'parser/shared/modules/StatTracker';
 import Analyzer from 'parser/core/Analyzer';
 import Combatants from 'parser/shared/modules/Combatants';
 import AzeritePowerStatistic from 'interface/statistics/AzeritePowerStatistic';
+import { calculateTraitHealing } from 'parser/shared/modules/helpers/CalculateTraitHealing';
 
-import { MISTWEAVER_HEALING_AURA, ESSENCE_FONT_SPELLPOWER_COEFFICIENT } from '../../../constants';
+import { ESSENCE_FONT_SPELLPOWER_COEFFICIENT } from '../../../constants';
 
 class FontOfLife extends Analyzer {
   static dependencies = {
@@ -27,31 +28,25 @@ class FontOfLife extends Analyzer {
   constructor(...args) {
     super(...args);
     this.active = this.selectedCombatant.hasTrait(SPELLS.FONT_OF_LIFE.id);
+    if (!this.active) {
+      return;
+    }
+    const ranks = this.selectedCombatant.traitRanks(SPELLS.UPLIFTED_SPIRITS.id) || [];
+    this.traitRawHealing = ranks.reduce((total, rank) => total + calculateAzeriteEffects(SPELLS.UPLIFTED_SPIRITS.id, rank)[0], 0);
   }
 
   healing = 0;
   baseHeal = 0
+  traitRawHealing = 0;
 
   on_byPlayer_heal(event) {
     const spellId = event.ability.guid;
 
-    if (event.overheal > 0) { // Exit as spell has overhealed and no need for adding in the additional healing from the trait
+    if (spellId !== SPELLS.ESSENCE_FONT_BUFF.id || event.tick === true) {
       return;
     }
 
-    if (spellId === SPELLS.ESSENCE_FONT_BUFF.id && event.tick !== true) {
-      const versPerc = this.statTracker.currentVersatilityPercentage;
-      const mwAura = MISTWEAVER_HEALING_AURA;
-      const intRating = this.statTracker.currentIntellectRating;
-      const healAmount = event.amount + (event.absorbed || 0);
-
-      this.baseHeal = (intRating * ESSENCE_FONT_SPELLPOWER_COEFFICIENT) * mwAura * (1 + versPerc);
-
-      if (event.hitType === HIT_TYPES.CRIT) {
-        this.baseHeal = this.baseHeal * 2;
-      }
-      this.healing += (healAmount - this.baseHeal);
-    }
+    this.healing += calculateTraitHealing(this.statTracker.currentIntellectRating, ESSENCE_FONT_SPELLPOWER_COEFFICIENT, this.traitRawHealing, event).healing;
   }
 
   statistic() {

--- a/src/parser/monk/mistweaver/modules/spells/azeritetraits/FontOfLife.js
+++ b/src/parser/monk/mistweaver/modules/spells/azeritetraits/FontOfLife.js
@@ -31,8 +31,8 @@ class FontOfLife extends Analyzer {
     if (!this.active) {
       return;
     }
-    const ranks = this.selectedCombatant.traitRanks(SPELLS.UPLIFTED_SPIRITS.id) || [];
-    this.traitRawHealing = ranks.reduce((total, rank) => total + calculateAzeriteEffects(SPELLS.UPLIFTED_SPIRITS.id, rank)[0], 0);
+    const ranks = this.selectedCombatant.traitRanks(SPELLS.FONT_OF_LIFE.id) || [];
+    this.traitRawHealing = ranks.reduce((total, rank) => total + calculateAzeriteEffects(SPELLS.FONT_OF_LIFE.id, rank)[0], 0);
   }
 
   healing = 0;
@@ -42,7 +42,7 @@ class FontOfLife extends Analyzer {
   on_byPlayer_heal(event) {
     const spellId = event.ability.guid;
 
-    if (spellId !== SPELLS.ESSENCE_FONT_BUFF.id || event.tick === true) {
+    if (spellId !== SPELLS.ESSENCE_FONT_BUFF.id || event.tick) {
       return;
     }
 

--- a/src/parser/shared/modules/helpers/CalculateTraitHealing.js
+++ b/src/parser/shared/modules/helpers/CalculateTraitHealing.js
@@ -1,0 +1,13 @@
+export function calculateTraitHealing(IntellectRating, BaseSpellCoefficient, RawTraitHeal, event) {
+  const spellheal = IntellectRating * BaseSpellCoefficient;
+  const traitComponent = RawTraitHeal / (spellheal + RawTraitHeal);
+
+  const healAmount = event.amount + (event.absorbed || 0);
+  const overhealAmount = (event.overheal || 0);
+  const raw = healAmount + overhealAmount;
+  const relativeHealingFactor = 1 + traitComponent;
+  const relativeHealing = raw - raw / relativeHealingFactor;
+  const relativeOverHealing = Math.max(0, relativeHealing - overhealAmount);
+
+  return { healing: Math.max(0, relativeHealing - overhealAmount), overhealing: relativeOverHealing };
+}

--- a/src/parser/shared/modules/helpers/CalculateTraitHealing.js
+++ b/src/parser/shared/modules/helpers/CalculateTraitHealing.js
@@ -1,3 +1,5 @@
+// Function to calculate the contribution of a class-spell based azerite trait (as in, it directly affects an existing spell, increasing its healing) by figuring out how much % of the spell the trait will do.
+// As those traits scale exactly the same as the base spell (barring Intellect), any scalings and healing buffs or debuffs can be ignored
 export function calculateTraitHealing(IntellectRating, BaseSpellCoefficient, RawTraitHeal, event) {
   const spellheal = IntellectRating * BaseSpellCoefficient;
   const traitComponent = RawTraitHeal / (spellheal + RawTraitHeal);

--- a/src/parser/shared/modules/helpers/CalculateTraitHealing.js
+++ b/src/parser/shared/modules/helpers/CalculateTraitHealing.js
@@ -9,7 +9,8 @@ export function calculateTraitHealing(IntellectRating, BaseSpellCoefficient, Raw
   const raw = healAmount + overhealAmount;
   const relativeHealingFactor = 1 + traitComponent;
   const relativeHealing = raw - raw / relativeHealingFactor;
-  const relativeOverHealing = Math.max(0, relativeHealing - overhealAmount);
+  const heal = Math.max(0, relativeHealing - overhealAmount);
+  const overheal = Math.max(0, relativeHealing - heal);
 
-  return { healing: Math.max(0, relativeHealing - overhealAmount), overhealing: relativeOverHealing };
+  return { healing: heal, overhealing: overheal };
 }


### PR DESCRIPTION
Fights with healing increases or decreases break the mistweaver azerite calculations, as those effects are not accounted for. Since its not realistic to account for all those effects, I changed the calculation around based on my [Resto Shaman azerite](https://github.com/WoWAnalyzer/WoWAnalyzer/blob/master/src/parser/shaman/restoration/modules/azerite/BaseHealerAzerite.js#L63) approach which is unaffected by any outside factors.

Example of a log with lots of healing decreases: https://www.warcraftlogs.com/reports/yFpzQTVCZ9Ht27ba#fight=1&type=healing
![image](https://user-images.githubusercontent.com/2842471/62285822-b5b16600-b456-11e9-85bc-310cda86c91c.png)
fixed 
![image](https://user-images.githubusercontent.com/2842471/62351222-362ea000-b505-11e9-8fb4-0e02ec39e74b.png)
