### PR TITLE
Ever Rising Tide haste

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -8,6 +8,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  change(date(2019, 8, 2), <>Fixed the Haste value of <SpellLink id={SPELLS.EVER_RISING_TIDE_MAJOR.id} /></>, niseko),
   change(date(2019, 7, 27), 'Added Unbridled Fury to the list of strong pre-potions.', emallson),
   change(date(2019, 7, 27), <>Added <SpellLink id={SPELLS.NULL_DYNAMO.id} /> essence.</>, emallson),
   change(date(2019, 7, 25), 'Fixed a crash in the Ever-Rising Tide Module', HawkCorrigan),

--- a/src/parser/shared/modules/spells/bfa/essences/TheEverRisingTide.js
+++ b/src/parser/shared/modules/spells/bfa/essences/TheEverRisingTide.js
@@ -149,12 +149,12 @@ class TheEverRisingTide extends Analyzer {
     let averageHaste = 0;
     const hasteBuffsCopy = this.hasteBuffs.slice(0); // don't destroy the original
     while (hasteBuffsCopy.length > 0) {
-      if (hasteBuffsCopy.findIndex(p => (p.trigger.ability && p.trigger.ability.guid === SPELLS.EVER_RISING_TIDE_CHARGING_BUFF.id)) === 0) {
+      const startIndex = hasteBuffsCopy.findIndex(p => (p.trigger.ability && p.trigger.ability.guid === SPELLS.EVER_RISING_TIDE_CHARGING_BUFF.id && p.trigger.type === "applybuff"));
+      const spliceCount = hasteBuffsCopy.findIndex(p => (p.trigger.ability && p.trigger.ability.guid === SPELLS.EVER_RISING_TIDE_CHARGING_BUFF.id && p.trigger.type === "removebuff")) + 1;
+      if (startIndex < 0 || spliceCount <= 0) {
         break;
       }
-      const ramp = hasteBuffsCopy.splice(
-        hasteBuffsCopy.findIndex(p => (p.trigger.ability && p.trigger.ability.guid === SPELLS.EVER_RISING_TIDE_CHARGING_BUFF.id && p.trigger.type === "applybuff")) || 0,
-        hasteBuffsCopy.findIndex(p => (p.trigger.ability && p.trigger.ability.guid === SPELLS.EVER_RISING_TIDE_CHARGING_BUFF.id && p.trigger.type === "removebuff")) + 1) || 1;
+      const ramp = hasteBuffsCopy.splice(startIndex, spliceCount);
       averageHaste = averageHaste === 0 ? this.average(ramp) : (averageHaste + this.average(ramp)) / 2;
     }
     return averageHaste * this.statTracker.hasteRatingPerPercent * this.selectedCombatant.getBuffUptime(SPELLS.EVER_RISING_TIDE_CHARGING_BUFF.id) / this.owner.fightDuration;


### PR DESCRIPTION
Fixed ERT haste calculation, error was that I expected `array.findIndex` to return `null` if it doesn't find an Index while its actually returning `-1`.

https://www.warcraftlogs.com/reports/vNQyRq6Zbpmgjh4A/#fight=14&source=7
![image](https://user-images.githubusercontent.com/2842471/62358291-aee92880-b514-11e9-9c6a-f7ebb4f3c7c4.png)