### PR TITLE
Keep track of module names for errors in production

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -8,6 +8,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  change(date(2019, 8, 3), 'Keep track of disabled modules names during production.', Zeboot),
   change(date(2019, 8, 3), 'Made the error handler more resilient to errors in browser extensions.', Zerotorescue),
   change(date(2019, 8, 3), 'Changed polyfilling so we might accidentally support more old and/or shitty browsers.', Zerotorescue),
   change(date(2019, 8, 3), 'Updated to create-react-app 3 and made the development environment easier to update.', Zerotorescue),

--- a/src/interface/report/Results/DegradedExperience.js
+++ b/src/interface/report/Results/DegradedExperience.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import Danger from 'interface/common/Alert/Danger';
 import MODULE_ERROR from 'parser/core/MODULE_ERROR';
 
-const isMinified = process.env.NODE_ENV === 'production';
 const toTitleCase = s => s.substr(0, 1).toUpperCase() + s.substr(1);
 
 class DegradedExperience extends React.Component {

--- a/src/interface/report/Results/DegradedExperience.js
+++ b/src/interface/report/Results/DegradedExperience.js
@@ -5,6 +5,7 @@ import Danger from 'interface/common/Alert/Danger';
 import MODULE_ERROR from 'parser/core/MODULE_ERROR';
 
 const isMinified = process.env.NODE_ENV === 'production';
+const toTitleCase = s => s.substr(0, 1).toUpperCase() + s.substr(1);
 
 class DegradedExperience extends React.Component {
   static propTypes = {
@@ -27,7 +28,7 @@ class DegradedExperience extends React.Component {
     const { disabledModules } = this.props;
     const existingErrorTypes = Object.values(MODULE_ERROR).filter(state => disabledModules[state] && disabledModules[state].length !== 0);
     if (existingErrorTypes.length > 0) {
-      return disabledModules[existingErrorTypes[0]][0].module.name;
+      return disabledModules[existingErrorTypes[0]][0].key;
     }
     return '';
   }
@@ -67,7 +68,7 @@ class DegradedExperience extends React.Component {
       <div className="container">
         <Danger style={{ marginBottom: 30 }}>
           <h2>Degraded experience</h2>
-          {!isMinified ? <span style={{ color: 'white' }}>{this.firstError}</span> : (this.disabledModuleCount > 1 ? 'Several modules' : 'A module')} encountered an error and had to be disabled. {this.disabledModuleCount > 1 && <>As a consequence <span style={{ color: 'white' }}>{this.disabledModuleCount - 1}</span> other modules had to be disabled as they depend on these modules.</>} Results may be incomplete. Please report this issue to us on <a href="https://wowanalyzer.com/discord">Discord</a> so we can fix it!{' '}
+          <span style={{ color: 'white' }}>{toTitleCase(this.firstError)}</span> {this.disabledModuleCount > 1 && <>and {this.disabledModuleCount - 1} other module{this.disabledModuleCount > 2 && 's'} </>}encountered an error and had to be disabled. {this.disabledDependencyCount > 1 && <>As a consequence <span style={{ color: 'white' }}>{this.disabledDependencyCount}</span> other modules had to be disabled as they depend on these modules.</>} Results may be incomplete. Please report this issue to us on <a href="https://wowanalyzer.com/discord">Discord</a> so we can fix it!{' '}
           <a href="javascript:" onClick={this.toggleDetails}>
             {this.state.expanded ? 'Less information' : 'More information'}
           </a>
@@ -81,10 +82,10 @@ class DegradedExperience extends React.Component {
                   The following modules have been disabled due to errors during {state}:<br />
                   <div style={{ color: 'white' }}>
                     {disabledModules[state]
-                      .sort((a, b) => a.module.name.localeCompare(b.module.name))
+                      .sort((a, b) => a.key.localeCompare(b.key))
                       .map(m => (
-                        <React.Fragment key={m.module.name}>
-                          {m.module.name}<br />
+                        <React.Fragment key={m.key}>
+                          {toTitleCase(m.key)}<br />
                           {m.error && <pre>{m.error.stack ? m.error.stack : m.error.toString()}</pre>}
                         </React.Fragment>
                       ))}

--- a/src/parser/core/modules/EventEmitter.js
+++ b/src/parser/core/modules/EventEmitter.js
@@ -267,7 +267,7 @@ class EventEmitter extends Module {
     if (process.env.NODE_ENV !== 'production') {
       throw err;
     }
-    const name = module.constructor.name;
+    const name = module.key;
     console.error('Disabling', name, 'and child dependencies because an error occured:', err);
     // Disable this module and all active modules that have this as a dependency
     this.owner.deepDisable(module, MODULE_ERROR.EVENTS, err);


### PR DESCRIPTION
Keeps track of each module's "desired name" so in minified production code, error messages still appear correct.

![image](https://user-images.githubusercontent.com/5396409/62416622-58780900-b63e-11e9-9226-bac356503473.png)
