### PR TITLE
[Feral] Fix prepull cooldowns

### DIFF
--- a/src/parser/druid/feral/CHANGELOG.js
+++ b/src/parser/druid/feral/CHANGELOG.js
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 8, 19), <>Fixed tracking pre-pull use of <SpellLink id={SPELLS.BERSERK.id} /> and <SpellLink id={SPELLS.TIGERS_FURY.id} /> so they're properly counted when calculating cast efficiency.</>, [Anatta336]),
   change(date(2019, 6, 19), <>Improved how finisher combo point use is assessed, low-combo use of <SpellLink id={SPELLS.RIP.id} /> is recognised as correct in certain circumstances.</>, [Anatta336]),
   change(date(2019, 6, 16), <>Changed which buffs are displayed on the timeline view, making rotation-relevant information clearer.</>, [Anatta336]),
   change(date(2019, 3, 6), <>Added tracking of <SpellLink id={SPELLS.GUSHING_LACERATIONS_TRAIT.id} />.</>, [Anatta336]),
@@ -15,7 +16,7 @@ export default [
   change(date(2019, 2, 8), <>Added tracking of <SpellLink id={SPELLS.UNTAMED_FEROCITY.id} /> and updated <SpellLink id={SPELLS.WILD_FLESHRENDING.id} />.</>, [Anatta336]),
   change(date(2018, 12, 20), <>Updated tracking of <SpellLink id={SPELLS.RIP.id} /> snapshots, and interaction with <SpellLink id={SPELLS.SABERTOOTH_TALENT.id} /> for patch 8.1.</>, [Anatta336]),
   change(date(2018, 10, 10), <>Added tracking to Feral for the <SpellLink id={SPELLS.WILD_FLESHRENDING.id} /> Azerite trait.</>, [Anatta336]),
-  change(date(2018, 10, 5), <React.Fragment>Added tracking for using <SpellLink id={SPELLS.SHADOWMELD.id} /> to buff <SpellLink id={SPELLS.RAKE.id} /> damage.</React.Fragment>, [Anatta336]),
+  change(date(2018, 10, 5), <>Added tracking for using <SpellLink id={SPELLS.SHADOWMELD.id} /> to buff <SpellLink id={SPELLS.RAKE.id} /> damage.</>, [Anatta336]),
   change(date(2018, 8, 11), <>Added tracking for wasted energy from <SpellLink id={SPELLS.TIGERS_FURY.id} /> and a breakdown of how energy is spent.</>, [Anatta336]),
   change(date(2018, 8, 5), <>Added a checklist for Feral.</>, [Anatta336]),
   change(date(2018, 7, 22), <>Corrected <SpellLink id={SPELLS.SAVAGE_ROAR_TALENT.id} /> to only claim credit for damage from abilities it affects in 8.0.1</>, [Anatta336]),

--- a/src/parser/druid/feral/modules/Buffs.js
+++ b/src/parser/druid/feral/modules/Buffs.js
@@ -23,6 +23,7 @@ class Buffs extends CoreBuffs {
       },
       {
         spellId: SPELLS.SAVAGE_ROAR_TALENT.id,
+        triggeredBySpellId: SPELLS.SAVAGE_ROAR_TALENT.id,
         enabled: combatant.hasTalent(SPELLS.SAVAGE_ROAR_TALENT),
         timelineHightlight: true,
       },
@@ -30,10 +31,12 @@ class Buffs extends CoreBuffs {
       // defensive
       {
         spellId: SPELLS.SURVIVAL_INSTINCTS.id,
+        triggeredBySpellId: SPELLS.SURVIVAL_INSTINCTS.id,
         timelineHightlight: true,
       },
       {
         spellId: SPELLS.BEAR_FORM.id,
+        triggeredBySpellId: SPELLS.BEAR_FORM.id,
         timelineHightlight: true,
       },
 
@@ -44,21 +47,25 @@ class Buffs extends CoreBuffs {
       },
       {
         spellId: SPELLS.SHADOWMELD.id,
+        triggeredBySpellId: SPELLS.SHADOWMELD.id,
         timelineHightlight: true,
       },
 
       // cooldowns
       {
         spellId: SPELLS.TIGERS_FURY.id,
+        triggeredBySpellId: SPELLS.TIGERS_FURY.id,
         timelineHightlight: true,
       },
       {
         spellId: SPELLS.BERSERK.id,
+        triggeredBySpellId: SPELLS.BERSERK.id,
         enabled: !combatant.hasTalent(SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT),
         timelineHightlight: true,
       },
       {
         spellId: SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id,
+        triggeredBySpellId: SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id,
         enabled: combatant.hasTalent(SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT),
         timelineHightlight: true,
       },
@@ -71,6 +78,7 @@ class Buffs extends CoreBuffs {
       {
         // it could be useful to see when the combatant is out of cat form, but filling the timeline with a nearly constant buff would add too much noise
         spellId: SPELLS.CAT_FORM.id,
+        triggeredBySpellId: SPELLS.CAT_FORM.id,
       },
       {
         spellId: SPELLS.MOONKIN_FORM_AFFINITY.id,
@@ -81,35 +89,45 @@ class Buffs extends CoreBuffs {
       },
       {
         spellId: SPELLS.TRAVEL_FORM.id,
+        triggeredBySpellId: SPELLS.TRAVEL_FORM.id,
         timelineHightlight: true,
       },
       {
         spellId: SPELLS.STAG_FORM.id,
+        triggeredBySpellId: SPELLS.STAG_FORM.id,
         timelineHightlight: true,
       },
       {
         spellId: SPELLS.DASH.id,
+        triggeredBySpellId: SPELLS.DASH.id,
         enabled: !combatant.hasTalent(SPELLS.TIGER_DASH_TALENT),
       },
       {
         spellId: SPELLS.TIGER_DASH_TALENT.id,
+        triggeredBySpellId: SPELLS.TIGER_DASH_TALENT.id,
         enabled: combatant.hasTalent(SPELLS.TIGER_DASH_TALENT),
       },
       {
         spellId: SPELLS.STAMPEDING_ROAR_CAT.id,
+        triggeredBySpellId: SPELLS.STAMPEDING_ROAR_CAT.id,
       },
       {
         spellId: SPELLS.STAMPEDING_ROAR_BEAR.id,
+        triggeredBySpellId: SPELLS.STAMPEDING_ROAR_BEAR.id,
       },
       {
         spellId: SPELLS.REGROWTH.id,
+        //triggeredBySpellId: SPELLS.REGROWTH.id
+        // disabled triggeredBySpellId for Regrowth as it causes the PrePullCooldowns normalizer to generate excessive Regrowth casts events before the pull: one for Regrowth and one for the Bloodtalons buff, but in reality a single cast produces both effects.
       },
       {
         spellId: SPELLS.REJUVENATION.id,
+        triggeredBySpellId: SPELLS.REJUVENATION.id,
         enabled: combatant.hasTalent(SPELLS.RESTORATION_AFFINITY_TALENT),
       },
       {
         spellId: SPELLS.WILD_GROWTH.id,
+        triggeredBySpellId: SPELLS.WILD_GROWTH.id,
         enabled: combatant.hasTalent(SPELLS.RESTORATION_AFFINITY_TALENT),
       },
     ];


### PR DESCRIPTION
Feral's `Buffs` was missing the `triggeredBySpellId` properties needed by the `PrePullCooldowns` normalizer, so cast efficiency wasn't accounting for pre-pull uses of Berserk and Tiger's Fury.

Example log with pre-pull cooldown use:
`report/T4LvfdbKAFPkVQ7Z/1-Mythic+Abyssal+Commander+Sivara+-+Kill+(4:14)/Sxqkitty/`