### PR TITLE
Fix for phase filter crashing if multiple casts get listed

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -8,6 +8,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  change(date(2019, 8, 14), 'Fixed potential crash of phase fabrication during mixed filter usage.', Zeboot),
   change(date(2019, 8, 12), 'Added more phase trigger types to improve our phase detection.', Zeboot),
   change(date(2019, 8, 12), <>Added <SpellLink id={SPELLS.LOYAL_TO_THE_END.id} /> azerite trait.</>, Khadaj),
   change(date(2019, 8, 7), <>Updated <SpellLink id={SPELLS.CONCENTRATED_FLAME.id} /> healing calculation.</>, Yajinni),

--- a/src/common/fabricateBossPhaseEvents.js
+++ b/src/common/fabricateBossPhaseEvents.js
@@ -70,7 +70,12 @@ export function fabricateBossPhaseEvents(events, report, fight) {
             case 'interrupt':
             case 'dispel':
             case 'cast': {
-              let bossEvents = events.filter(e => e.type === phase.filter.type && (e.ability.guid === phase.filter.ability.id || e.extraAbility.guid === phase.filter.ability.id));
+              let bossEvents = events.filter(e => e.type === phase.filter.type &&
+                (
+                  (e.ability && e.ability.guid === phase.filter.ability.id) ||
+                  (e.extraAbility && e.extraAbility.guid === phase.filter.ability.id)
+                )
+              );
               if (phase.filter.eventInstance !== undefined && phase.filter.eventInstance >= 0 && !phase.multiple) {
                 if (bossEvents.length >= (phase.filter.eventInstance + 1)) {
                   // If the instance exists, only that specific instance is relevant
@@ -176,7 +181,7 @@ export function fabricateBossPhaseEvents(events, report, fight) {
       });
     }
   }
-  
+
   phaseEvents.sort((a, b) => a.start - b.start);
   phaseEvents.filter((event, index, array) => {
     return index === 0 || event.key !== array[index - 1].key; //only keep events that arent preceded by another start event of the same phase


### PR DESCRIPTION
the extraAbility check used in interrupts crashes the filter if no extraAbility exists, meaning if 2 different phases use regular cast events, this crashes. Fix checks for extraAbility to be present before comparing guid