### PR TITLE
lava burst check's for flame shock on damage instead of on cast

### DIFF
--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -717,11 +717,11 @@ export const Draenal = {
   mains: [{
     name: 'Draenal',
     spec: SPECS.ELEMENTAL_SHAMAN,
-    link: 'https://worldofwarcraft.com/en-us/character/us/malganis/draenal'
+    link: 'https://worldofwarcraft.com/en-us/character/us/malganis/draenal',
   },
   {
     name: 'MagicEraser',
     spec: SPECS.FROST_MAGE,
-    link: 'https://worldofwarcraft.com/en-us/character/us/malganis/magiceraser'
-  }]
-}
+    link: 'https://worldofwarcraft.com/en-us/character/us/malganis/magiceraser',
+  }],
+};

--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -711,3 +711,17 @@ export const Wing5wong = {
     link: 'https://worldofwarcraft.com/en-us/character/us/frostmourne/shrom',
   }],
 };
+export const Draenal = {
+  nickname: 'Draenal',
+  github: 'MikeCook9994',
+  mains: [{
+    name: 'Draenal',
+    spec: SPECS.ELEMENTAL_SHAMAN,
+    link: 'https://worldofwarcraft.com/en-us/character/us/malganis/draenal'
+  },
+  {
+    name: 'MagicEraser',
+    spec: SPECS.FROST_MAGE,
+    link: 'https://worldofwarcraft.com/en-us/character/us/malganis/magiceraser'
+  }]
+}

--- a/src/parser/shaman/elemental/CHANGELOG.js
+++ b/src/parser/shaman/elemental/CHANGELOG.js
@@ -15,4 +15,3 @@ export default [
   change(date(2018, 10, 17), <>Flagged the Elemental Shaman Analyzer as supported.</>, [HawkCorrigan]),
   change(date(2018, 10, 15), <>Added Checks for the correct usage of <SpellLink id={SPELLS.STORM_ELEMENTAL_TALENT.id} /> and <SpellLink id={SPELLS.FIRE_ELEMENTAL.id} /> when talented into <SpellLink id={SPELLS.PRIMAL_ELEMENTALIST_TALENT.id} />.</>, [HawkCorrigan]),
 ];
-7

--- a/src/parser/shaman/elemental/CHANGELOG.js
+++ b/src/parser/shaman/elemental/CHANGELOG.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { niseko, HawkCorrigan } from 'CONTRIBUTORS';
+import { niseko, HawkCorrigan, Draenal } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 8, 14), <>Updated <SpellLink id={SPELLS.LAVA_BURST.id} /> to check for flame shock on damage instead of on cast.</>, [Draenal]),
   change(date(2019, 5, 6), <>Added support for the damage part of <SpellLink id={SPELLS.IGNEOUS_POTENTIAL.id} />.</>, [niseko]),
   change(date(2019, 3, 20), <>Fixing <SpellLink id={SPELLS.MASTER_OF_THE_ELEMENTS_TALENT.id} />-Tracker and Damage Calculation.</>, [HawkCorrigan]),
   change(date(2018, 11, 13), <>Added a basic Checklist, with the cross-spec functionalities.</>, [HawkCorrigan]),

--- a/src/parser/shaman/elemental/CHANGELOG.js
+++ b/src/parser/shaman/elemental/CHANGELOG.js
@@ -6,7 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2019, 8, 14), <>Updated <SpellLink id={SPELLS.LAVA_BURST.id} /> to check for <SpellLink id={SPELLS.FLAME_SHOCK} /> on damage instead of on cast.</>, [Draenal]),
+  change(date(2019, 8, 14), <>Updated <SpellLink id={SPELLS.LAVA_BURST.id} /> to check for <SpellLink id={SPELLS.FLAME_SHOCK.id} /> on damage instead of on cast.</>, [Draenal]),
   change(date(2019, 5, 6), <>Added support for the damage part of <SpellLink id={SPELLS.IGNEOUS_POTENTIAL.id} />.</>, [niseko]),
   change(date(2019, 3, 20), <>Fixing <SpellLink id={SPELLS.MASTER_OF_THE_ELEMENTS_TALENT.id} />-Tracker and Damage Calculation.</>, [HawkCorrigan]),
   change(date(2018, 11, 13), <>Added a basic Checklist, with the cross-spec functionalities.</>, [HawkCorrigan]),
@@ -15,3 +15,4 @@ export default [
   change(date(2018, 10, 17), <>Flagged the Elemental Shaman Analyzer as supported.</>, [HawkCorrigan]),
   change(date(2018, 10, 15), <>Added Checks for the correct usage of <SpellLink id={SPELLS.STORM_ELEMENTAL_TALENT.id} /> and <SpellLink id={SPELLS.FIRE_ELEMENTAL.id} /> when talented into <SpellLink id={SPELLS.PRIMAL_ELEMENTALIST_TALENT.id} />.</>, [HawkCorrigan]),
 ];
+7

--- a/src/parser/shaman/elemental/CHANGELOG.js
+++ b/src/parser/shaman/elemental/CHANGELOG.js
@@ -6,7 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2019, 8, 14), <>Updated <SpellLink id={SPELLS.LAVA_BURST.id} /> to check for flame shock on damage instead of on cast.</>, [Draenal]),
+  change(date(2019, 8, 14), <>Updated <SpellLink id={SPELLS.LAVA_BURST.id} /> to check for <SpellLink id={SPELLS.FLAME_SHOCK} /> on damage instead of on cast.</>, [Draenal]),
   change(date(2019, 5, 6), <>Added support for the damage part of <SpellLink id={SPELLS.IGNEOUS_POTENTIAL.id} />.</>, [niseko]),
   change(date(2019, 3, 20), <>Fixing <SpellLink id={SPELLS.MASTER_OF_THE_ELEMENTS_TALENT.id} />-Tracker and Damage Calculation.</>, [HawkCorrigan]),
   change(date(2018, 11, 13), <>Added a basic Checklist, with the cross-spec functionalities.</>, [HawkCorrigan]),

--- a/src/parser/shaman/elemental/modules/core/FlameShock.js
+++ b/src/parser/shaman/elemental/modules/core/FlameShock.js
@@ -21,7 +21,7 @@ class FlameShock extends Analyzer {
     return this.enemies.getBuffUptime(SPELLS.FLAME_SHOCK.id) / this.owner.fightDuration;
   }
 
-  on_byPlayer_cast(event) {
+  on_byPlayer_damage(event) {
     if(event.ability.guid !== SPELLS.LAVA_BURST.id) {
       return;
     }


### PR DESCRIPTION
8.1 introduced an undocumented change so that lava burst checks if the target has flame shock on damage instead of cast to guarantee the crit.

@HawkCorrigan 