### PR TITLE
Fix damage calculation for Streaking Stars.

### DIFF
--- a/src/common/SPELLS/bfa/azeritetraits/druid.js
+++ b/src/common/SPELLS/bfa/azeritetraits/druid.js
@@ -156,6 +156,11 @@ export default {
     name: 'Streaking Stars',
     icon: 'spell_nature_natureguardian',
   },
+  STREAKING_STAR: {
+    id: 272873,
+    name: 'Streaking Star',
+    icon: 'spell_nature_natureguardian',
+  },
   ARCANIC_PULSAR:{
     id: 287784,
     name: 'Arcanic Pulsar',

--- a/src/parser/druid/balance/CHANGELOG.js
+++ b/src/parser/druid/balance/CHANGELOG.js
@@ -6,7 +6,8 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2019, 8, 13), <>Added tracking for <SpellLink id={SPELLS.STREAKING_STARS.id} />.</>, Viridis),
+  change(date(2019, 8, 15), <>Fixed damage calculations for <SpellLink id={SPELLS.STREAKING_STARS.id} />.</>, [Viridis]),
+  change(date(2019, 8, 13), <>Added tracking for <SpellLink id={SPELLS.STREAKING_STARS.id} />.</>, [Viridis]),
   change(date(2019, 8, 12), 'Fixed an incorrect spell name on the suggestions for Balance Druids when using Stellar Flare.', Wing5wong),
   change(date(2019, 4, 30), 'Added High Noon and Power of the Moon azerite pieces to the statistics tab.', [Abelito75]),
   change(date(2019, 4, 27), 'Added DawningSun azerite piece to the statistics tab.', [Abelito75]),

--- a/src/parser/druid/balance/modules/talents/azeritetraits/StreakingStars.js
+++ b/src/parser/druid/balance/modules/talents/azeritetraits/StreakingStars.js
@@ -7,17 +7,8 @@ import DAMAGING_ABILITIES from 'parser/druid/balance/constants';
 import { formatNumber, formatPercentage } from 'common/format';
 import SpellLink from 'common/SpellLink';
 import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
-import { calculateAzeriteEffects } from 'common/stats';
 import AzeritePowerStatistic from 'interface/statistics/AzeritePowerStatistic';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
-
-const streakingStarsStats = traits => Object.values(traits).reduce((obj, rank) => {
-  const [damage] = calculateAzeriteEffects(SPELLS.STREAKING_STARS.id, rank);
-  obj.damage += damage;
-  return obj;
-}, {
-  damage: 0,
-});
 
 /**
  * Streaking Stars,  Azerite Power
@@ -54,9 +45,6 @@ class StreakingStars extends Analyzer {
     if (this.selectedCombatant.hasTalent(SPELLS.INCARNATION_CHOSEN_OF_ELUNE_TALENT.id)) {
       this.buffToTrack = SPELLS.INCARNATION_CHOSEN_OF_ELUNE_TALENT;
     }
-
-    const { damage } = streakingStarsStats(this.selectedCombatant.traitsBySpellId[SPELLS.STREAKING_STARS.id]);
-    this.damagePerStreakingStars = damage;
 
     this.addEventListener(Events.applybuff.by(SELECTED_PLAYER).spell(this.buffToTrack), this.onCelestialAlignmentApply);
     this.addEventListener(Events.removebuff.by(SELECTED_PLAYER).spell(this.buffToTrack), this.onCelestialAlignmentRemove);

--- a/src/parser/druid/balance/modules/talents/azeritetraits/StreakingStars.js
+++ b/src/parser/druid/balance/modules/talents/azeritetraits/StreakingStars.js
@@ -88,12 +88,12 @@ class StreakingStars extends Analyzer {
   }
 
   get damageDone() {
-    const spell = this.abilityTracker.getAbility(SPELLS.STREAKING_STARS.id);
+    const spell = this.abilityTracker.getAbility(SPELLS.STREAKING_STAR.id);
     return spell.damageEffective + spell.damageAbsorbed;
   }
 
   statistic() {
-    const totalDamage = this.damagePerStreakingStars * (this.totalCastsDuringCelestialAlignment - this.badCasts);
+    const totalDamage = this.damageDone;
     const damageThroughputPercent = this.owner.getPercentageOfTotalDamageDone(totalDamage);
     const dps = totalDamage / this.owner.fightDuration * 1000;
     return (

--- a/src/parser/druid/balance/modules/talents/azeritetraits/StreakingStars.js
+++ b/src/parser/druid/balance/modules/talents/azeritetraits/StreakingStars.js
@@ -105,7 +105,7 @@ class StreakingStars extends Analyzer {
             that you cast while <SpellLink id={this.buffToTrack.id} /> buff is active, providing<br />
             that it is not a duplicate of the previously cast skill.<br />
             <br />
-            {formatNumber(this.damagePerStreakingStars)} damage per proc of <SpellLink id={SPELLS.STREAKING_STARS.id} /><br />
+            {formatNumber(totalDamage / (this.totalCastsDuringCelestialAlignment - this.badCasts))} average damage per proc of <SpellLink id={SPELLS.STREAKING_STARS.id} /><br />
             {this.totalCastsDuringCelestialAlignment - this.badCasts} out of {this.totalCastsDuringCelestialAlignment} possible procs of <SpellLink id={SPELLS.STREAKING_STARS.id} /><br />
           </>
         )}


### PR DESCRIPTION
Damage calculations were naively done by multiplying occurences by amount of
damage the trait gives. This does not take into consideration absorb
shields, crits, damage boosts, ... etc. Now using the ability tracker to
get the correct values (which now also perfectly match the WCL logs
unlike before)

@Gebuz 