### PR TITLE
Add timefilter shortcut to Death Recap

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -8,6 +8,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  change(date(2019, 8, 16), 'Added event filter to death recap to view only pre-death events.', Zeboot),
   change(date(2019, 8, 14), 'Fixed potential crash of phase fabrication during mixed filter usage.', Zeboot),
   change(date(2019, 8, 12), 'Added more phase trigger types to improve our phase detection.', Zeboot),
   change(date(2019, 8, 12), <>Added <SpellLink id={SPELLS.LOYAL_TO_THE_END.id} /> azerite trait.</>, Khadaj),

--- a/src/interface/others/DeathRecap.js
+++ b/src/interface/others/DeathRecap.js
@@ -28,11 +28,18 @@ class DeathRecap extends React.PureComponent {
       amountThreshold: AMOUNT_THRESHOLD,
     };
     this.handleClick = this.handleClick.bind(this);
+    this.filterDeath = this.filterDeath.bind(this);
   }
 
   handleClick(event) {
     const clicked = event === this.state.detailedView ? -1 : event;
     this.setState({ detailedView: clicked });
+  }
+
+  filterDeath(event, i) {
+    const start = this.props.report.fight.offset_time + (i !== 0 && this.props.events[i-1].deathtime - this.props.report.fight.start_time);
+    const end = event.deathtime + this.props.report.fight.offset_time - this.props.report.fight.start_time;
+    this.props.report.applyTimeFilter(start, end);
   }
 
   render() {
@@ -66,7 +73,8 @@ class DeathRecap extends React.PureComponent {
     };
 
     const events = this.props.events;
-
+    /* eslint-disable no-script-url */
+    /* eslint-disable jsx-a11y/anchor-is-valid */
     return (
       <>
         <div className="pad" style={{ marginBottom: 15 }}>
@@ -102,9 +110,12 @@ class DeathRecap extends React.PureComponent {
         </div>
         {events.map((death, i) => (
           <React.Fragment key={i}>
-            {events.length > 1 && (
-              <h2 onClick={() => this.handleClick(i)} style={{ padding: '10px 20px', cursor: 'pointer' }}>Death #{i + 1}</h2>
-            )}
+            <div style={{display: 'block'}}>
+              <h2 onClick={() => this.handleClick(i)} style={{ padding: '10px 20px', cursor: 'pointer', display: 'inline-block' }}>Death #{i + 1}</h2>
+              <TooltipElement content="Filter events to the time between either the start of combat or your last death (whichever happened more recently) and this death.">
+                <a href="javascript:" onClick={() => this.filterDeath(death, i)}>Filter to prior events</a>
+              </TooltipElement>
+            </div>
             <table style={{ display: this.state.detailedView === i ? 'block' : 'none' }} className="data-table">
               <thead>
                 <tr>

--- a/src/interface/others/DeathRecapTracker.js
+++ b/src/interface/others/DeathRecapTracker.js
@@ -99,6 +99,9 @@ class DeathRecapTracker extends Analyzer {
     this.addEvent(event);
   }
   on_toPlayer_death(event) {
+    if(event.timestamp <= this.owner.fight.start_time){
+      return;
+    }
     this.addEvent(event);
     this.deaths.push(event.timestamp);
   }

--- a/src/interface/report/EventParser.js
+++ b/src/interface/report/EventParser.js
@@ -45,6 +45,8 @@ class EventParser extends React.PureComponent {
     combatants: PropTypes.arrayOf(PropTypes.shape({
       sourceID: PropTypes.number.isRequired,
     })),
+    applyTimeFilter: PropTypes.func.isRequired,
+    applyPhaseFilter: PropTypes.func.isRequired,
     parserClass: PropTypes.func.isRequired,
     characterProfile: PropTypes.object,
     events: PropTypes.array.isRequired,
@@ -86,6 +88,8 @@ class EventParser extends React.PureComponent {
   makeParser() {
     const { report, fight, combatants, player, characterProfile, parserClass } = this.props;
     const parser = new parserClass(report, player, fight, combatants, characterProfile);
+    parser.applyTimeFilter = this.props.applyTimeFilter;
+    parser.applyPhaseFilter = this.props.applyPhaseFilter;
     this.setState({
       parser,
     });

--- a/src/interface/report/index.js
+++ b/src/interface/report/index.js
@@ -203,6 +203,8 @@ class ResultsLoader extends React.PureComponent {
             fight={this.state.filteredFight}
             player={player}
             combatants={combatants}
+            applyTimeFilter={this.applyTimeFilter}
+            applyPhaseFilter={this.handlePhaseSelection}
             parserClass={this.state.parserClass}
             characterProfile={this.state.characterProfile}
             events={this.state.filteredEvents}

--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -356,6 +356,9 @@ class CombatLogParser {
   // Override this with spec specific modules when extending
   static specModules = {};
 
+  applyTimeFilter = (start, end) => null; //dummy function gets filled in by event parser
+  applyPhaseFilter = (phase, instance) => null; //dummy function gets filled in by event parser
+
   report = null;
   // Player info from WCL - required
   player = null;


### PR DESCRIPTION
idea by @abelito75 

Adds a button to the death recap that lets you filter the events to only include events prior to the death  to make suggestions / analysis more accurate using the existing time filtering functionality. In the case of multiple deaths it filters events to the time between the deaths.

Also attaches the filtering functionality (both time and phase based) to the combatlogparser object so other modules can make use of this functionality

Examples:
![image](https://user-images.githubusercontent.com/5396409/63144660-43af5400-bff4-11e9-964a-8d2c6d5638ba.png)

![image](https://user-images.githubusercontent.com/5396409/63144661-4611ae00-bff4-11e9-83a6-95d5a62cd553.png)
![image](https://user-images.githubusercontent.com/5396409/63144663-4ad66200-bff4-11e9-80a3-072fbbf39fe0.png)

![image](https://user-images.githubusercontent.com/5396409/63144691-54f86080-bff4-11e9-83b4-c62f7a4a9a05.png)
