### PR TITLE
[Fire Mage] Bug Fixes

### DIFF
--- a/src/parser/mage/fire/CHANGELOG.js
+++ b/src/parser/mage/fire/CHANGELOG.js
@@ -6,6 +6,8 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 8, 16), <>Modified <SpellLink id={SPELLS.COMBUSTION.id} /> during <SpellLink id={SPELLS.FIRESTARTER_TALENT.id} /> to only check the first cast during Combustion and not every cast.</>, [Sharrq]),
+  change(date(2019, 8, 16), <>Fixed a bug that was causing the <SpellLink id={SPELLS.PYROCLASM_TALENT.id} /> checklist item to show up without Pyroclasm talented.</>, [Sharrq]),
   change(date(2019, 8, 6), <>Added statistics and suggestions for <SpellLink id={SPELLS.METEOR_TALENT.id} /></>, [Sharrq]),
   change(date(2019, 8, 6), 'Reworded Hot Streak pre cast suggestion to make it clearer.', [Sharrq]),
   change(date(2019, 8, 6), 'Updated spec compatibility to 8.2.', [Sharrq]),

--- a/src/parser/mage/fire/modules/Checklist/Component.js
+++ b/src/parser/mage/fire/modules/Checklist/Component.js
@@ -74,7 +74,7 @@ class FireMageChecklist extends React.PureComponent {
               tooltip="If you are talented into Firestarter, you should ensure that you do not cast Combustion while the boss is above 90% Health. This would be a waste considering every spell is guaranteed to crit while the boss is above 90% Health, which defeats the purpose of using Combustion. Instead, you should use Combustion when the boss gets to 89% so you can continue the streak of guaranteed crits once Firestarter finishes."
             />
           )}
-          {combatant.hasTalent(SPELLS.FIRESTARTER_TALENT.id) && (
+          {combatant.hasTalent(SPELLS.PYROCLASM_TALENT.id) && (
             <Requirement
               name="Pyroclasm Usage"
               thresholds={thresholds.pyroclasmCombustionUsage}

--- a/src/parser/mage/fire/modules/features/CombustionFirestarter.js
+++ b/src/parser/mage/fire/modules/features/CombustionFirestarter.js
@@ -43,6 +43,7 @@ class CombustionFirestarter extends Analyzer {
       return;
     }
 
+    this.combustionCast = false;
     const healthPercent = event.hitPoints / event.maxHitPoints;
     if (healthPercent > FIRESTARTER_HEALTH_THRESHOLD) {
       this.combustionDuringFirestarter = true;


### PR DESCRIPTION
Fixed a couple bugs

1. The Pyroclasm checklist item was showing up without Pyroclasm talented
2. Combustion during Firestarter was checking every cast during Combustion instead of just the first one, which meant if the target switched targets during Combustion, it would mark them as casting Combustion during Firestarter