### PR TITLE
[Shadow Priest] Add Spiteful Apparitions azerite trait

### DIFF
--- a/src/common/SPELLS/bfa/azeritetraits/priest.js
+++ b/src/common/SPELLS/bfa/azeritetraits/priest.js
@@ -104,6 +104,11 @@ export default {
     name: 'Whispers of the Damned',
     icon: 'inv_misc_eye_03',
   },
+  SPITEFUL_APPARITIONS: {
+    id: 277682,
+    name: 'Spiteful Apparitions',
+    icon: 'ability_priest_shadowyapparition',
+  },
   DEATH_DENIED: {
     id: 287717,
     name: 'Death Denied',

--- a/src/parser/priest/shadow/CHANGELOG.js
+++ b/src/parser/priest/shadow/CHANGELOG.js
@@ -6,7 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2019, 8, 18), <>Added <SpellLink id={SPELLS.SPITEFUL_APPARITIONS.id} /> module.</>, [Adoraci]),
+  change(date(2019, 8, 22), <>Added <SpellLink id={SPELLS.SPITEFUL_APPARITIONS.id} /> module.</>, [Adoraci]),
   change(date(2019, 8, 17), <>Added <SpellLink id={SPELLS.WHISPERS_OF_THE_DAMNED.id} /> module.</>, [Adoraci]),
   change(date(2018, 11, 19), <>Added <SpellLink id={SPELLS.DEATH_THROES.id} /> module.</>, [Khadaj]),
   change(date(2018, 11, 19), <>Added <SpellLink id={SPELLS.VAMPIRIC_EMBRACE.id} /> module.</>, [Khadaj]),

--- a/src/parser/priest/shadow/CHANGELOG.js
+++ b/src/parser/priest/shadow/CHANGELOG.js
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 8, 18), <>Added <SpellLink id={SPELLS.SPITEFUL_APPARITIONS.id} /> module.</>, [Adoraci]),
   change(date(2019, 8, 17), <>Added <SpellLink id={SPELLS.WHISPERS_OF_THE_DAMNED.id} /> module.</>, [Adoraci]),
   change(date(2018, 11, 19), <>Added <SpellLink id={SPELLS.DEATH_THROES.id} /> module.</>, [Khadaj]),
   change(date(2018, 11, 19), <>Added <SpellLink id={SPELLS.VAMPIRIC_EMBRACE.id} /> module.</>, [Khadaj]),

--- a/src/parser/priest/shadow/CombatLogParser.js
+++ b/src/parser/priest/shadow/CombatLogParser.js
@@ -24,6 +24,7 @@ import VampiricEmbrace from './modules/spells/VampiricEmbrace';
 import ChorusOfInsanity from './modules/spells/azeritetraits/ChorusOfInsanity';
 import DeathThroes from './modules/spells/azeritetraits/DeathThroes';
 import WhispersOfTheDamned from './modules/spells/azeritetraits/WhispersOfTheDamned';
+import SpitefulApparitions from './modules/spells/azeritetraits/SpitefulApparitions';
 // talents
 import TwistOfFate from './modules/talents/TwistOfFate';
 import VoidTorrent from './modules/talents/VoidTorrent';
@@ -63,6 +64,7 @@ class CombatLogParser extends MainCombatLogParser {
     chorusOfInsanity: ChorusOfInsanity,
     deathThroes: DeathThroes,
     whispersOfTheDamned: WhispersOfTheDamned,
+    spitefulApparitions: SpitefulApparitions,
 
     // talents:
     twistOfFate: TwistOfFate,

--- a/src/parser/priest/shadow/modules/spells/azeritetraits/SpitefulApparitions.js
+++ b/src/parser/priest/shadow/modules/spells/azeritetraits/SpitefulApparitions.js
@@ -30,7 +30,6 @@ class SpitefulApparitions extends Analyzer {
 
   damageValue = 0;
   damageDone = 0;
-  wastedApparitions = 0;
 
   constructor(...args) {
     super(...args);

--- a/src/parser/priest/shadow/modules/spells/azeritetraits/SpitefulApparitions.js
+++ b/src/parser/priest/shadow/modules/spells/azeritetraits/SpitefulApparitions.js
@@ -62,7 +62,7 @@ class SpitefulApparitions extends Analyzer {
         value={<ItemDamageDone amount={this.damageDone} />}
         tooltip={(
           <>
-            {formatNumber(this.damageDone)} additional damage dealt by {SPELLS.SHADOWY_APPARITION.name} to targets affected by {SPELLS.VAMPIRIC_TOUCH.name}.<br/>
+            {formatNumber(this.damageDone)} additional damage dealt by {SPELLS.SHADOWY_APPARITION.name} to targets affected by {SPELLS.VAMPIRIC_TOUCH.name}.
           </>
         )}
       />

--- a/src/parser/priest/shadow/modules/spells/azeritetraits/SpitefulApparitions.js
+++ b/src/parser/priest/shadow/modules/spells/azeritetraits/SpitefulApparitions.js
@@ -1,0 +1,74 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS/index';
+import { calculateAzeriteEffects } from 'common/stats';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Enemies from 'parser/shared/modules/Enemies';
+import TraitStatisticBox, { STATISTIC_ORDER } from 'interface/others/TraitStatisticBox';
+import ItemDamageDone from 'interface/others/ItemDamageDone';
+import Events from 'parser/core/Events';
+import { formatNumber } from 'common/format';
+
+const spitefulApparitionsStats = traits => Object.values(traits).reduce((obj, rank) => {
+  const [damage] = calculateAzeriteEffects(SPELLS.SPITEFUL_APPARITIONS.id, rank);
+  obj.damage += damage;
+  return obj;
+}, {
+  damage: 0,
+});
+
+/**
+ * Spiteful Apparitions
+ * Shadowy Apparitions deal an additional 2544 damage to enemies suffering from your Vampiric Touch.
+ *
+ * Example log: /report/JQNwLbpdtmrzYAGC/5-Mythic+Blackwater+Behemoth+-+Kill+(5:09)/Adoraci
+ */
+class SpitefulApparitions extends Analyzer {
+  static dependencies = {
+    enemies: Enemies,
+  };
+
+  damageValue = 0;
+  damageDone = 0;
+  wastedApparitions = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrait(SPELLS.SPITEFUL_APPARITIONS.id);
+    if (!this.active) {
+      return;
+    }
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.SHADOWY_APPARITION_DAMAGE), this.onDamageEvent);
+
+    const { damage } = spitefulApparitionsStats(this.selectedCombatant.traitsBySpellId[SPELLS.SPITEFUL_APPARITIONS.id]);
+    this.damageValue = damage;
+  }
+
+  onDamageEvent(event) {
+    const enemy = this.enemies.getEntity(event);
+    if (!enemy) {
+      return;
+    }
+    if (!enemy.hasBuff(SPELLS.VAMPIRIC_TOUCH.id, event.timestamp)) {
+      return;
+    }
+    this.damageDone += this.damageValue;
+  }
+
+  statistic() {
+    return (
+      <TraitStatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
+        trait={SPELLS.SPITEFUL_APPARITIONS.id}
+        value={<ItemDamageDone amount={this.damageDone} />}
+        tooltip={(
+          <>
+            {formatNumber(this.damageDone)} additional damage dealt by {SPELLS.SHADOWY_APPARITION.name} to targets affected by {SPELLS.VAMPIRIC_TOUCH.name}.<br/>
+          </>
+        )}
+      />
+    );
+  }
+}
+
+export default SpitefulApparitions;


### PR DESCRIPTION
- Tracks additional damage from Spiteful Apparitions done by Shadowy Apparitions to targets with Vampiric Touch
Completes part of #2612 

![2019-08-18_06-35-28](https://user-images.githubusercontent.com/5396389/63223379-6a9b9080-c182-11e9-9c88-3a6f67f0b5b4.png)
![2019-08-18_06-35-35](https://user-images.githubusercontent.com/5396389/63223380-6e2f1780-c182-11e9-80ca-333e9f9bd054.png)

