### PR TITLE
[Resto Druid] Correct catweaving GCDs

### DIFF
--- a/src/parser/druid/restoration/CHANGELOG.js
+++ b/src/parser/druid/restoration/CHANGELOG.js
@@ -1,10 +1,11 @@
 // eslint-disable-next-line no-unused-vars
 import React from 'react';
 
-import { Yajinni, blazyb, fel1ne, Qbz, Zerotorescue, Abelito75 } from 'CONTRIBUTORS';
+import { Yajinni, blazyb, fel1ne, Qbz, Zerotorescue, Abelito75, Anatta336 } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 8, 18), 'Corrected some global cooldown values related to catweaving.', [Anatta336]),
   change(date(2019, 8, 12), 'Added essence Lucid Dreams.', [blazyb]),
   change(date(2019, 6, 2), 'Enabled the QElive auto import link for stat values.', [Abelito75]),
   change(date(2019, 5, 26), 'Fixed a bug where Lively Spirit increased int gain on tab switch.', [Qbz]),

--- a/src/parser/druid/restoration/modules/Abilities.js
+++ b/src/parser/druid/restoration/modules/Abilities.js
@@ -240,7 +240,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.SHRED,
         category: Abilities.SPELL_CATEGORIES.OTHERS,
         gcd: {
-          base: 1000,
+          static: 1000,
         },
       },
       //Forms
@@ -263,14 +263,14 @@ class Abilities extends CoreAbilities {
         buffSpellId: SPELLS.BEAR_FORM.id,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         gcd: {
-          base: 1000,
+          base: 1500,
         },
       },
       {
         spell: SPELLS.CAT_FORM,
         category: Abilities.SPELL_CATEGORIES.OTHERS,
         gcd: {
-          base: 1000,
+          base: 1500,
         },
       },
       {
@@ -296,7 +296,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.OTHERS,
         enabled: combatant.hasTalent(SPELLS.GUARDIAN_AFFINITY_TALENT_SHARED.id),
         gcd: {
-          base: 1000,
+          static: 1000,
         },
       },
       {
@@ -321,7 +321,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.OTHERS,
         enabled: combatant.hasTalent(SPELLS.FERAL_AFFINITY_TALENT_RESTORATION.id),
         gcd: {
-          base: 1500,
+          static: 1000,
         },
       },
       {
@@ -337,7 +337,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.OTHERS,
         enabled: combatant.hasTalent(SPELLS.FERAL_AFFINITY_TALENT_RESTORATION.id),
         gcd: {
-          base: 1000,
+          static: 1000,
         },
       },
       {
@@ -345,7 +345,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.OTHERS,
         enabled: combatant.hasTalent(SPELLS.FERAL_AFFINITY_TALENT_RESTORATION.id),
         gcd: {
-          base: 1000,
+          static: 1000,
         },
       },
       {
@@ -353,7 +353,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.OTHERS,
         enabled: combatant.hasTalent(SPELLS.FERAL_AFFINITY_TALENT_RESTORATION.id),
         gcd: {
-          base: 1000,
+          static: 1000,
         },
       },
 
@@ -409,18 +409,30 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.DASH,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 120,
-        gcd: {
-          base: 1500,
-        },
+        gcd: (combatant => {
+          if (combatant.hasBuff(SPELLS.CAT_FORM.id)) {
+            // off the GCD if player is already in cat form
+            return null;
+          }
+          return {
+            static: 1500,
+          };
+        }),
       },
       {
         spell: SPELLS.TIGER_DASH_TALENT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.TIGER_DASH_TALENT.id),
         cooldown: 45,
-        gcd: {
-          base: 1500,
-        },
+        gcd: (combatant => {
+          if (combatant.hasBuff(SPELLS.CAT_FORM.id)) {
+            // off the GCD if player is already in cat form
+            return null;
+          }
+          return {
+            static: 1500,
+          };
+        }),
       },
 
       //CC


### PR DESCRIPTION
A few abilities associated with a druid's animal forms had their GCD incorrectly set. The main correction is that the cat abilities always have a 1.00 second GCD regardless of haste (just like Feral or Rogue abilities.) Dash/Tiger Dash also have an unusual effect where they only trigger the GCD (which for some reason also isn't affected by haste) if used when outside of cat form.

Top line is before, bottom is after these changes.
![restoGCD](https://user-images.githubusercontent.com/35700764/63230996-fb1eb300-c20c-11e9-9733-39ca8e82c30c.png)
