### PR TITLE
[Fire Mage] Health Calculation Fixes

### DIFF
--- a/src/parser/mage/fire/CHANGELOG.js
+++ b/src/parser/mage/fire/CHANGELOG.js
@@ -8,6 +8,7 @@ import ItemLink from 'common/ItemLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 8, 20), <>Fixed an issue that caused Boss Health calculations to be incorrect on Lady Ashvane, resulting in incorrect results for several statistics and suggestions.</>, [Sharrq]),
   change(date(2019, 8, 19), <>Removed <SpellLink id={SPELLS.PYROCLASM_TALENT.id} /> during <SpellLink id={SPELLS.COMBUSTION.id} /> suggestions to match Altered Time guide.</>, [Sharrq]),
   change(date(2019, 8, 19), <>Added support for <ItemLink id={ITEMS.HYPERTHREAD_WRISTWRAPS.id} />.</>, [Sharrq]),
   change(date(2019, 8, 16), <>Modified <SpellLink id={SPELLS.COMBUSTION.id} /> during <SpellLink id={SPELLS.FIRESTARTER_TALENT.id} /> to only check the first cast during Combustion and not every cast.</>, [Sharrq]),

--- a/src/parser/mage/fire/modules/features/CombustionFirestarter.js
+++ b/src/parser/mage/fire/modules/features/CombustionFirestarter.js
@@ -22,6 +22,7 @@ class CombustionFirestarter extends Analyzer {
   combustionCast = false;
   combustionCastEvent = null;
   combustionDuringFirestarter = false;
+  healthPercent = 1;
 
   constructor(...args) {
     super(...args);
@@ -44,8 +45,8 @@ class CombustionFirestarter extends Analyzer {
     }
 
     this.combustionCast = false;
-    const healthPercent = event.hitPoints / event.maxHitPoints;
-    if (healthPercent > FIRESTARTER_HEALTH_THRESHOLD) {
+    if (event.hitPoints > 0) {this.healthPercent = event.hitPoints / event.maxHitPoints;}
+    if (this.healthPercent > FIRESTARTER_HEALTH_THRESHOLD) {
       this.combustionDuringFirestarter = true;
       this.combustionCastEvent.meta = this.combustionCastEvent.meta || {};
       this.combustionCastEvent.meta.isInefficientCast = true;

--- a/src/parser/mage/fire/modules/features/HeatingUp.js
+++ b/src/parser/mage/fire/modules/features/HeatingUp.js
@@ -25,6 +25,7 @@ class HeatingUp extends Analyzer {
   phoenixFlamesWithoutHeatingUp = 0;
   fireBlastWithHotStreak = 0;
   phoenixFlamesWithHotStreak = 0;
+  healthPercent = 1;
 
   constructor(...args) {
     super(...args);
@@ -49,14 +50,14 @@ class HeatingUp extends Analyzer {
     const hasHeatingUp = this.selectedCombatant.hasBuff(SPELLS.HEATING_UP.id);
     const castTarget = this.phoenixFlamesCastEvent ? encodeTargetString(this.phoenixFlamesCastEvent.targetID, event.targetInstance) : null;
     const damageTarget = encodeTargetString(event.targetID, event.targetInstance);
-    const healthPercent = event.hitPoints / event.maxHitPoints;
+    if (event.hitPoints > 0) {this.healthPercent = event.hitPoints / event.maxHitPoints;}
     if (castTarget !== damageTarget || hasHeatingUp) {
       return;
     }
 
     //If Combustion is active, the player is within the Firestarter execute window, or the player is in the Searing Touch execute window, then ignore the event
     //If the player had Hot Streak though, then its a mistake regardless
-    if (!hasHotStreak && (hasCombustion || (this.hasFirestarter && healthPercent > FIRESTARTER_HEALTH_THRESHOLD) || (this.hasSearingTouch && healthPercent < SEARING_TOUCH_HEALTH_THRESHOLD))) {
+    if (!hasHotStreak && (hasCombustion || (this.hasFirestarter && this.healthPercent > FIRESTARTER_HEALTH_THRESHOLD) || (this.hasSearingTouch && this.healthPercent < SEARING_TOUCH_HEALTH_THRESHOLD))) {
       debug && this.log("Event Ignored");
       return;
     }
@@ -75,14 +76,14 @@ class HeatingUp extends Analyzer {
     const hasCombustion = this.selectedCombatant.hasBuff(SPELLS.COMBUSTION.id);
     const hasHotStreak = this.selectedCombatant.hasBuff(SPELLS.HOT_STREAK.id);
     const hasHeatingUp = this.selectedCombatant.hasBuff(SPELLS.HEATING_UP.id);
-    const healthPercent = event.hitPoints / event.maxHitPoints;
+    if (event.hitPoints > 0) {this.healthPercent = event.hitPoints / event.maxHitPoints;}
     if (hasHeatingUp) {
       return;
     }
 
     //If Combustion is active, the player is within the Firestarter execute window, or the player is in the Searing Touch execute window, then ignore the event
     //If the player had Hot Streak though, then its a mistake regardless
-    if (!hasHotStreak && (hasCombustion || (this.hasFirestarter && healthPercent > FIRESTARTER_HEALTH_THRESHOLD) || (this.hasSearingTouch && healthPercent < SEARING_TOUCH_HEALTH_THRESHOLD))) {
+    if (!hasHotStreak && (hasCombustion || (this.hasFirestarter && this.healthPercent > FIRESTARTER_HEALTH_THRESHOLD) || (this.hasSearingTouch && this.healthPercent < SEARING_TOUCH_HEALTH_THRESHOLD))) {
       debug && this.log("Event Ignored");
       return;
     }

--- a/src/parser/mage/fire/modules/features/HotStreakPreCasts.js
+++ b/src/parser/mage/fire/modules/features/HotStreakPreCasts.js
@@ -7,7 +7,7 @@ import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';
 
-const debug = false;
+const debug = true;
 
 const PROC_WINDOW_MS = 200;
 const FIRESTARTER_HEALTH_THRESHOLD = 0.90;
@@ -27,8 +27,7 @@ class HotStreakPreCasts extends Analyzer {
   pyroclasmProcRemoved = 0;
   castedBeforeHotStreak = 0;
   noCastBeforeHotStreak = 0;
-  currentHealth = 0;
-  maxHealth = 0;
+  healthPercent = 1;
 
   constructor(...args) {
     super(...args);
@@ -51,8 +50,7 @@ class HotStreakPreCasts extends Analyzer {
 
   //If the player has the Searing Touch or Firestarter talents, then we need to get the health percentage on damage events so we can know whether we are in the Firestarter or Searing Touch execute windows
   checkHealthPercent(event) {
-    this.currentHealth = event.hitPoints;
-    this.maxHealth = event.maxHitPoints;
+    if (event.hitPoints > 0) {this.healthPercent = event.hitPoints / event.maxHitPoints;}
   }
 
   //Get the timestamp that Hot Streak was removed. This is used for comparing the cast Timestamp to see if there was a hard cast immediately before Hot Streak was removed (and therefore they pre-casted before Hot Streak)
@@ -69,8 +67,8 @@ class HotStreakPreCasts extends Analyzer {
   //Compares timestamps to determine if an ability was hard casted immediately before using Hot Streak.
   //If Combustion is active or they are in the Firestarter or Searing Touch execute windows, then this check is ignored.
   checkForHotStreakPreCasts(event) {
-    if (this.selectedCombatant.hasBuff(SPELLS.COMBUSTION.id) || (this.hasFirestarter && this.currentHealth / this.maxHealth > FIRESTARTER_HEALTH_THRESHOLD) || (this.hasSearingTouch && this.currentHealth / this.maxHealth < SEARING_TOUCH_HEALTH_THRESHOLD)) {
-      debug && this.log("Pre Cast Ignored");
+    if (this.selectedCombatant.hasBuff(SPELLS.COMBUSTION.id) || (this.hasFirestarter && this.healthPercent > FIRESTARTER_HEALTH_THRESHOLD) || (this.hasSearingTouch && this.healthPercent < SEARING_TOUCH_HEALTH_THRESHOLD)) {
+      debug && this.log('Pre Cast Ignored');
       return;
     }
 

--- a/src/parser/mage/fire/modules/features/HotStreakPreCasts.js
+++ b/src/parser/mage/fire/modules/features/HotStreakPreCasts.js
@@ -7,7 +7,7 @@ import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';
 
-const debug = true;
+const debug = false;
 
 const PROC_WINDOW_MS = 200;
 const FIRESTARTER_HEALTH_THRESHOLD = 0.90;

--- a/src/parser/mage/fire/modules/features/SearingTouch.js
+++ b/src/parser/mage/fire/modules/features/SearingTouch.js
@@ -17,6 +17,7 @@ class SearingTouch extends Analyzer {
 
   badCasts = 0;
   totalCasts = 0;
+  healthPercent = 1;
 
   constructor(...args) {
     super(...args);
@@ -26,8 +27,8 @@ class SearingTouch extends Analyzer {
 
   //When the target is under 30% health, check to see if the player cast Fireball. If they do, count it as a mistake.
   onDamage(event) {
-    const healthPercent = event.hitPoints / event.maxHitPoints;
-    if (healthPercent > SEARING_TOUCH_HEALTH_THRESHOLD) {
+    if (event.hitPoints > 0) {this.healthPercent = event.hitPoints / event.maxHitPoints;}
+    if (this.healthPercent > SEARING_TOUCH_HEALTH_THRESHOLD) {
       return;
     }
     this.totalCasts += 1;


### PR DESCRIPTION
Fixes a bug for Lady Ashvane where the boss health was not being calculated correctly because the hitPoints and maxHitPoints values were missing on damage events when Ashvane has the Carapace up.