### PR TITLE
[Fire Mage] Lucid Dreams Support & CLF Haste Buff

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -8,6 +8,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  change(date(2019, 8, 21), 'Added Spell IDs and the stacking haste buff from Condensed Life Force.', Sharrq),
   change(date(2019, 8, 20), 'Fixed potential crash of phase fabrication during mixed filter usage.', Zeboot),
   change(date(2019, 8, 16), 'Added event filter to death recap to view only pre-death events.', Zeboot),
   change(date(2019, 8, 14), 'Fixed potential crash of phase fabrication during mixed filter usage.', Zeboot),

--- a/src/common/SPELLS/bfa/essences/essences.js
+++ b/src/common/SPELLS/bfa/essences/essences.js
@@ -240,4 +240,31 @@ export default {
     name: 'Strive for Perfection',
     icon: 'inv_radientazeritematrix',
   },
+  //Condensed Life Force
+  GUARDIAN_OF_AZEROTH: {
+    id: 299358,
+    traitId: 14,
+    name: 'Guardian of Azeroth',
+    icon: 'spell_azerite_essence14',
+  },
+  GUARDIAN_OF_AZEROTH_MAJOR: {
+    id: 295840,
+    name: 'Guardian of Azeroth',
+    icon: 'spell_azerite_essence14',
+  },
+  GUARDIAN_OF_AZEROTH_HASTE_BUFF: {
+    id: 295855,
+    name: 'Guardian of Azeroth',
+    icon: 'spell_azerite_essence14',
+  },
+  AZERITE_SPIKE: {
+    id: 296856,
+    name: 'Azerite Spike',
+    icon: 'spell_azerite_essence14',
+  },
+  CONDENSED_LIFE_FORCE_DEBUFF: {
+    id: 295838,
+    name: 'Condensed Life Force',
+    icon: 'spell_azerite_essence14',
+  },
 };

--- a/src/parser/mage/fire/CHANGELOG.js
+++ b/src/parser/mage/fire/CHANGELOG.js
@@ -8,6 +8,9 @@ import ItemLink from 'common/ItemLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 8, 21), <>Add support for Fire Blast cooldown reduction from <SpellLink id={SPELLS.LUCID_DREAMS_MAJOR.id} />.</>, [Sharrq]),
+  change(date(2019, 8, 20), <>Minor code style fix</>, [Sharrq]),
+  change(date(2019, 8, 20), <>Fixed an issue that caused Boss Health calculations to be incorrect on Lady Ashvane, resulting in incorrect results for several statistics and suggestions.</>, [Sharrq]),
   change(date(2019, 8, 19), <>Removed <SpellLink id={SPELLS.PYROCLASM_TALENT.id} /> during <SpellLink id={SPELLS.COMBUSTION.id} /> suggestions to match Altered Time guide.</>, [Sharrq]),
   change(date(2019, 8, 19), <>Added support for <ItemLink id={ITEMS.HYPERTHREAD_WRISTWRAPS.id} />.</>, [Sharrq]),
   change(date(2019, 8, 16), <>Modified <SpellLink id={SPELLS.COMBUSTION.id} /> during <SpellLink id={SPELLS.FIRESTARTER_TALENT.id} /> to only check the first cast during Combustion and not every cast.</>, [Sharrq]),

--- a/src/parser/mage/fire/CombatLogParser.js
+++ b/src/parser/mage/fire/CombatLogParser.js
@@ -32,6 +32,8 @@ import Meteor from './modules/features/Meteor';
 
 import HyperthreadWristwraps from './modules/items/HyperthreadWristwraps';
 
+import LucidDreams from './modules/items/LucidDreams';
+
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     //Normalizers
@@ -70,6 +72,9 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Items
     hyperthreadWristwraps: HyperthreadWristwraps,
+
+    // Essences
+    lucidDreams: LucidDreams,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }],

--- a/src/parser/mage/fire/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/mage/fire/__snapshots__/CombatLogParser.test.js.snap
@@ -633,6 +633,10 @@ exports[`The Fire Mage Analyzer analyzers Kindling matches the statistic snapsho
 
 exports[`The Fire Mage Analyzer analyzers Kindling matches the suggestions snapshot 1`] = `"module inactive"`;
 
+exports[`The Fire Mage Analyzer analyzers LucidDreams matches the statistic snapshot 1`] = `"module inactive"`;
+
+exports[`The Fire Mage Analyzer analyzers LucidDreams matches the suggestions snapshot 1`] = `"module inactive"`;
+
 exports[`The Fire Mage Analyzer analyzers Meteor matches the statistic snapshot 1`] = `
 <div
   className="col-lg-3 col-md-4 col-sm-6 col-xs-12"

--- a/src/parser/mage/fire/modules/features/Abilities.js
+++ b/src/parser/mage/fire/modules/features/Abilities.js
@@ -1,5 +1,4 @@
 import SPELLS from 'common/SPELLS';
-import ITEMS from 'common/ITEMS';
 
 import CoreAbilities from 'parser/core/modules/Abilities';
 

--- a/src/parser/mage/fire/modules/features/Abilities.js
+++ b/src/parser/mage/fire/modules/features/Abilities.js
@@ -1,5 +1,4 @@
 import SPELLS from 'common/SPELLS';
-import ITEMS from 'common/ITEMS';
 
 import CoreAbilities from 'parser/core/modules/Abilities';
 
@@ -49,8 +48,11 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.FIRE_BLAST,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         gcd: null,
-        cooldown: haste => combatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) || combatant.hasFinger(ITEMS.SOUL_OF_THE_ARCHMAGE.id) ? 10 / (1 + haste) : 12 / (1 + haste),
-        charges: combatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) || combatant.hasFinger(ITEMS.SOUL_OF_THE_ARCHMAGE.id) ? 3 : 2,
+        cooldown: haste => {
+          const cdr = combatant.hasBuff(SPELLS.LUCID_DREAMS_MINOR_STAT_BUFF.id) ? 1 : 0;
+          return (combatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) ? 10 : 12) / (1 + haste) / (1 + cdr);
+        },
+        charges: combatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) ? 3 : 2,
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.90,

--- a/src/parser/mage/fire/modules/features/Abilities.js
+++ b/src/parser/mage/fire/modules/features/Abilities.js
@@ -1,4 +1,5 @@
 import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
 
 import CoreAbilities from 'parser/core/modules/Abilities';
 
@@ -48,10 +49,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.FIRE_BLAST,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         gcd: null,
-        cooldown: haste => {
-          const cdr = combatant.hasBuff(SPELLS.LUCID_DREAMS_MAJOR.id) ? 1 : 0;
-          return (combatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) ? 10 : 12) / (1 + haste) / (1 + cdr);
-        },
+        cooldown: haste => (combatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) ? 10 : 12) / (1 + haste),
         charges: combatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) ? 3 : 2,
         castEfficiency: {
           suggestion: true,

--- a/src/parser/mage/fire/modules/features/Abilities.js
+++ b/src/parser/mage/fire/modules/features/Abilities.js
@@ -49,7 +49,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         gcd: null,
         cooldown: haste => {
-          const cdr = combatant.hasBuff(SPELLS.LUCID_DREAMS_MINOR_STAT_BUFF.id) ? 1 : 0;
+          const cdr = combatant.hasBuff(SPELLS.LUCID_DREAMS_MAJOR.id) ? 1 : 0;
           return (combatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) ? 10 : 12) / (1 + haste) / (1 + cdr);
         },
         charges: combatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) ? 3 : 2,

--- a/src/parser/mage/fire/modules/items/HyperthreadWristwraps.js
+++ b/src/parser/mage/fire/modules/items/HyperthreadWristwraps.js
@@ -42,6 +42,7 @@ class HyperthreadWristwraps extends Analyzer {
   }
 
   onWristUse(event) {
+    const bracerReduction = this.selectedCombatant.hasBuff(SPELLS.LUCID_DREAMS_MAJOR.id) ? 10000 : 5000;
     debug && console.log(this.lastThreeSpells);
     this.lastThreeSpells.forEach(spell => {
       if (spell === SPELLS.FIRE_BLAST.id) {
@@ -49,7 +50,7 @@ class HyperthreadWristwraps extends Analyzer {
       }
       if (this.spellUsable.isOnCooldown(spell)) {
         debug && this.log('Reduced ' + spell + ' by 5 seconds.');
-        this.spellUsable.reduceCooldown(spell,5000);
+        this.spellUsable.reduceCooldown(spell, bracerReduction, event.timestamp);
       }
     });
     if (this.fireBlastReductions !== 2) {

--- a/src/parser/mage/fire/modules/items/LucidDreams.js
+++ b/src/parser/mage/fire/modules/items/LucidDreams.js
@@ -45,12 +45,10 @@ class LucidDreams extends Analyzer {
   }
 
   onEvent(event) {
-    if (!this.selectedCombatant.hasBuff(SPELLS.LUCID_DREAMS_MAJOR.id) || event.timestamp <= this.lastTimestamp) {
+    if (!this.selectedCombatant.hasBuff(SPELLS.LUCID_DREAMS_MAJOR.id) || event.timestamp <= this.lastTimestamp || this.lastTimestamp === 0 || !this.spellUsable.isOnCooldown(SPELLS.FIRE_BLAST.id)) {
       return;
     }
-    if (this.lastTimestamp !== 0) {
-      this.spellUsable.reduceCooldown(SPELLS.FIRE_BLAST.id, event.timestamp - this.lastTimestamp, event.timestamp);
-    }
+    this.spellUsable.reduceCooldown(SPELLS.FIRE_BLAST.id, event.timestamp - this.lastTimestamp, event.timestamp);
     this.lastTimestamp = event.timestamp;
   }
 

--- a/src/parser/mage/fire/modules/items/LucidDreams.js
+++ b/src/parser/mage/fire/modules/items/LucidDreams.js
@@ -1,0 +1,85 @@
+import SPELLS from 'common/SPELLS';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import Abilities from 'parser/core/modules/Abilities';
+import EnemyInstances from 'parser/shared/modules/EnemyInstances';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import StatTracker from 'parser/shared/modules/StatTracker';
+
+const debug = false;
+
+class LucidDreams extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+    spellUsable: SpellUsable,
+    enemies: EnemyInstances,
+    statTracker: StatTracker,
+  };
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasEssence(SPELLS.LUCID_DREAMS.traitId);
+    if (!this.active) {
+      return;
+    }
+    this.hasMajor = this.selectedCombatant.hasMajor(SPELLS.LUCID_DREAMS.traitId);
+    if(this.hasMajor) {
+      this.abilities.add({
+        spell: SPELLS.LUCID_DREAMS_MAJOR,
+        category: Abilities.SPELL_CATEGORIES.ITEMS,
+        cooldown: 120,
+        gcd: {
+          base: 1500,
+        },
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.95,
+          },
+      });
+    }
+    this.addEventListener(Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.LUCID_DREAMS_MAJOR), this.onLucidApplied);
+    this.addEventListener(Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.LUCID_DREAMS_MAJOR), this.onLucidRemoved);
+    this.addEventListener(Events.energize.by(SELECTED_PLAYER).spell(SPELLS.LUCID_DREAMS_MINOR_RESOURCE_REFUND), this.onLucidEnergize);
+  }
+
+  onLucidApplied(event) {
+    if (!this.spellUsable.isOnCooldown(SPELLS.FIRE_BLAST.id)) {
+      return;
+    }
+    const cdrRemaining = this.spellUsable.cooldownRemaining(SPELLS.FIRE_BLAST.id);
+    const rechargeTime = ((this.selectedCombatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) ? 10 : 12) / (1 + this.statTracker.currentHastePercentage)) * 1000;
+    const chargesOnCooldown = (this.selectedCombatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) ? 3 : 2) - this.spellUsable.chargesAvailable(SPELLS.FIRE_BLAST.id);
+    const reduction = (rechargeTime * (chargesOnCooldown - 1)) / 2;
+    debug && this.log("Fire Blast Charges on Cooldown: " + chargesOnCooldown);
+    debug && this.log("Fire Blast Remaining Cooldown: " + cdrRemaining);
+
+    if (chargesOnCooldown > 1) {
+      this.spellUsable.reduceCooldown(SPELLS.FIRE_BLAST.id, reduction + (cdrRemaining / 2), event.timestamp);
+    } else {
+      this.spellUsable.reduceCooldown(SPELLS.FIRE_BLAST.id, cdrRemaining / 2, event.timestamp);
+    }
+  }
+
+  onLucidRemoved(event) {
+    const chargesOnCooldown = (this.selectedCombatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) ? 3 : 2) - this.spellUsable.chargesAvailable(SPELLS.FIRE_BLAST.id);
+    const rechargeTime = ((this.selectedCombatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) ? 10 : 12) / (1 + this.statTracker.currentHastePercentage)) * 1000;
+    const extension = (rechargeTime * (chargesOnCooldown - 1)) / 2;
+    debug && this.log("Fire Blast Charges on Cooldown: " + chargesOnCooldown);
+    debug && this.log("Fire Blast Cooldown Extension: " + extension);
+
+    if (chargesOnCooldown > 1) {
+      this.spellUsable.extendCooldown(SPELLS.FIRE_BLAST.id, extension, event.timestamp);
+    }
+  }
+
+  onLucidEnergize(event) {
+    const rechargeTime = ((this.selectedCombatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) ? 10 : 12) / (1 + this.statTracker.currentHastePercentage)) * 1000;
+    const refund = rechargeTime / 2;
+    if (this.spellUsable.isOnCooldown(SPELLS.FIRE_BLAST.id)) {
+      debug && this.log("Fire Blast Cooldown Refund: " + refund);
+      this.spellUsable.reduceCooldown(SPELLS.FIRE_BLAST.id, refund, event.timestamp);
+    }
+  }
+}
+
+export default LucidDreams;

--- a/src/parser/mage/fire/modules/items/LucidDreams.js
+++ b/src/parser/mage/fire/modules/items/LucidDreams.js
@@ -1,8 +1,8 @@
 import SPELLS from 'common/SPELLS';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';
+import EventEmitter from 'parser/core/modules/EventEmitter';
 import Abilities from 'parser/core/modules/Abilities';
-import EnemyInstances from 'parser/shared/modules/EnemyInstances';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import StatTracker from 'parser/shared/modules/StatTracker';
 
@@ -12,9 +12,10 @@ class LucidDreams extends Analyzer {
   static dependencies = {
     abilities: Abilities,
     spellUsable: SpellUsable,
-    enemies: EnemyInstances,
     statTracker: StatTracker,
   };
+
+  lastTimestamp = 0;
 
   constructor(...args) {
     super(...args);
@@ -37,39 +38,29 @@ class LucidDreams extends Analyzer {
           },
       });
     }
+    this.addEventListener(EventEmitter.catchAll, this.onEvent);
     this.addEventListener(Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.LUCID_DREAMS_MAJOR), this.onLucidApplied);
     this.addEventListener(Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.LUCID_DREAMS_MAJOR), this.onLucidRemoved);
     this.addEventListener(Events.energize.by(SELECTED_PLAYER).spell(SPELLS.LUCID_DREAMS_MINOR_RESOURCE_REFUND), this.onLucidEnergize);
   }
 
-  onLucidApplied(event) {
-    if (!this.spellUsable.isOnCooldown(SPELLS.FIRE_BLAST.id)) {
+  onEvent(event) {
+    if (!this.selectedCombatant.hasBuff(SPELLS.LUCID_DREAMS_MAJOR.id) || event.timestamp <= this.lastTimestamp) {
       return;
     }
-    const cdrRemaining = this.spellUsable.cooldownRemaining(SPELLS.FIRE_BLAST.id);
-    const rechargeTime = ((this.selectedCombatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) ? 10 : 12) / (1 + this.statTracker.currentHastePercentage)) * 1000;
-    const chargesOnCooldown = (this.selectedCombatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) ? 3 : 2) - this.spellUsable.chargesAvailable(SPELLS.FIRE_BLAST.id);
-    const reduction = (rechargeTime * (chargesOnCooldown - 1)) / 2;
-    debug && this.log("Fire Blast Charges on Cooldown: " + chargesOnCooldown);
-    debug && this.log("Fire Blast Remaining Cooldown: " + cdrRemaining);
-
-    if (chargesOnCooldown > 1) {
-      this.spellUsable.reduceCooldown(SPELLS.FIRE_BLAST.id, reduction + (cdrRemaining / 2), event.timestamp);
-    } else {
-      this.spellUsable.reduceCooldown(SPELLS.FIRE_BLAST.id, cdrRemaining / 2, event.timestamp);
+    if (this.lastTimestamp !== 0) {
+      this.spellUsable.reduceCooldown(SPELLS.FIRE_BLAST.id, event.timestamp - this.lastTimestamp, event.timestamp);
     }
+    this.lastTimestamp = event.timestamp;
+  }
+
+  onLucidApplied(event) {
+    this.lastTimestamp = event.timestamp;
   }
 
   onLucidRemoved(event) {
-    const chargesOnCooldown = (this.selectedCombatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) ? 3 : 2) - this.spellUsable.chargesAvailable(SPELLS.FIRE_BLAST.id);
-    const rechargeTime = ((this.selectedCombatant.hasTalent(SPELLS.FLAME_ON_TALENT.id) ? 10 : 12) / (1 + this.statTracker.currentHastePercentage)) * 1000;
-    const extension = (rechargeTime * (chargesOnCooldown - 1)) / 2;
-    debug && this.log("Fire Blast Charges on Cooldown: " + chargesOnCooldown);
-    debug && this.log("Fire Blast Cooldown Extension: " + extension);
-
-    if (chargesOnCooldown > 1) {
-      this.spellUsable.extendCooldown(SPELLS.FIRE_BLAST.id, extension, event.timestamp);
-    }
+    this.spellUsable.reduceCooldown(SPELLS.FIRE_BLAST.id, event.timestamp - this.lastTimestamp, event.timestamp);
+    this.lastTimestamp = 0;
   }
 
   onLucidEnergize(event) {

--- a/src/parser/shared/modules/Haste.js
+++ b/src/parser/shared/modules/Haste.js
@@ -35,7 +35,9 @@ class Haste extends Analyzer {
     [SPELLS.QUICK_THINKER_BUFF.id]: 0.15,
     [SPELLS.EMPOWER_RUNE_WEAPON.id]: 0.15, // Frost DK
     [SPELLS.EVER_RISING_TIDE_CHARGING_BUFF.id]: 0.1, // Essence
-    [SPELLS.GUARDIAN_OF_AZEROTH_HASTE_BUFF.id]: 0.02, // Essence
+    [SPELLS.GUARDIAN_OF_AZEROTH_HASTE_BUFF.id]: {
+      hastePerStack: 0.02,
+    },
 
     // Boss abilities:
     [SPELLS.OPULENCE_AMETHYST_OF_THE_SHADOW_KING.id]: 0.5, // Amethyst of the Shadow King by Opulence (BoD - BFA)

--- a/src/parser/shared/modules/Haste.js
+++ b/src/parser/shared/modules/Haste.js
@@ -35,6 +35,7 @@ class Haste extends Analyzer {
     [SPELLS.QUICK_THINKER_BUFF.id]: 0.15,
     [SPELLS.EMPOWER_RUNE_WEAPON.id]: 0.15, // Frost DK
     [SPELLS.EVER_RISING_TIDE_CHARGING_BUFF.id]: 0.1, // Essence
+    [SPELLS.GUARDIAN_OF_AZEROTH_HASTE_BUFF.id]: 0.02, // Essence
 
     // Boss abilities:
     [SPELLS.OPULENCE_AMETHYST_OF_THE_SHADOW_KING.id]: 0.5, // Amethyst of the Shadow King by Opulence (BoD - BFA)


### PR DESCRIPTION
Adds Fire Mage support for Lucid Dreams Major and Minor
Adds Spell IDs for Condensed Life Force
Adds the stacking Haste buff from Condensed Life Force
Adjusted Hyperthread Wristwraps to give double the reduction during Lucid Dreams to compensate for the doubled cool down regen from Lucid.