### PR TITLE
Initial Surge of Power talent support for Elemental Shamans

### DIFF
--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -736,3 +736,13 @@ export const Adoraci = {
     link: 'https://worldofwarcraft.com/en-us/character/us/zuljin/adoraci',
   }],
 };
+export const TheJigglr = {
+  nickname: 'TheJigglr',
+  github: 'myran2',
+  discord: 'Henry#4712',
+  mains: [{
+    name: 'Thejigglr',
+    spec: SPECS.ELEMENTAL_SHAMAN,
+    link: 'https://worldofwarcraft.com/en-us/character/us/bleeding-hollow/thejigglr',
+  }],
+};

--- a/src/common/SPELLS/shaman.js
+++ b/src/common/SPELLS/shaman.js
@@ -337,7 +337,7 @@ export default {
   },
   SURGE_OF_POWER: {
     id: 285514,
-    name: "Surge of Power Buff",
+    name: "Surge of Power",
     icon: "spell_nature_shamanrage",
   },
   UNLIMITED_POWER_BUFF: {

--- a/src/common/SPELLS/shaman.js
+++ b/src/common/SPELLS/shaman.js
@@ -335,7 +335,7 @@ export default {
     name: "Master Of The Elements Buff",
     icon: "spell_nature_elementalabsorption",
   },
-  SURGE_OF_POWER: {
+  SURGE_OF_POWER_BUFF: {
     id: 285514,
     name: "Surge of Power",
     icon: "spell_nature_shamanrage",

--- a/src/common/SPELLS/shaman.js
+++ b/src/common/SPELLS/shaman.js
@@ -335,7 +335,7 @@ export default {
     name: "Master Of The Elements Buff",
     icon: "spell_nature_elementalabsorption",
   },
-  SURGE_OF_POWER_BUFF: {
+  SURGE_OF_POWER: {
     id: 285514,
     name: "Surge of Power Buff",
     icon: "spell_nature_shamanrage",

--- a/src/common/SPELLS/shaman.js
+++ b/src/common/SPELLS/shaman.js
@@ -335,6 +335,11 @@ export default {
     name: "Master Of The Elements Buff",
     icon: "spell_nature_elementalabsorption",
   },
+  SURGE_OF_POWER_BUFF: {
+    id: 285514,
+    name: "Surge of Power Buff",
+    icon: "spell_nature_shamanrage",
+  },
   UNLIMITED_POWER_BUFF: {
     id: 272737,
     name: "Unlimited Power Buff",

--- a/src/parser/shaman/elemental/CHANGELOG.js
+++ b/src/parser/shaman/elemental/CHANGELOG.js
@@ -6,7 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2019, 8, 21), <>Added support for <SpellLink id={SPELLS.TALENT_SURGE_OF_POWER} /></>, [TheJigglr]),
+  change(date(2019, 8, 21), <>Added support for <SpellLink id={SPELLS.SURGE_OF_POWER_TALENT.id} /></>, [TheJigglr]),
   change(date(2019, 8, 14), <>Updated <SpellLink id={SPELLS.LAVA_BURST.id} /> to check for <SpellLink id={SPELLS.FLAME_SHOCK.id} /> on damage instead of on cast.</>, [Draenal]),
   change(date(2019, 5, 6), <>Added support for the damage part of <SpellLink id={SPELLS.IGNEOUS_POTENTIAL.id} />.</>, [niseko]),
   change(date(2019, 3, 20), <>Fixing <SpellLink id={SPELLS.MASTER_OF_THE_ELEMENTS_TALENT.id} />-Tracker and Damage Calculation.</>, [HawkCorrigan]),

--- a/src/parser/shaman/elemental/CHANGELOG.js
+++ b/src/parser/shaman/elemental/CHANGELOG.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { niseko, HawkCorrigan, Draenal } from 'CONTRIBUTORS';
+import { niseko, HawkCorrigan, Draenal, TheJigglr } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 8, 21), <>Added support for <SpellLink id={SPELLS.TALENT_SURGE_OF_POWER} /></>, [TheJigglr]),
   change(date(2019, 8, 14), <>Updated <SpellLink id={SPELLS.LAVA_BURST.id} /> to check for <SpellLink id={SPELLS.FLAME_SHOCK.id} /> on damage instead of on cast.</>, [Draenal]),
   change(date(2019, 5, 6), <>Added support for the damage part of <SpellLink id={SPELLS.IGNEOUS_POTENTIAL.id} />.</>, [niseko]),
   change(date(2019, 3, 20), <>Fixing <SpellLink id={SPELLS.MASTER_OF_THE_ELEMENTS_TALENT.id} />-Tracker and Damage Calculation.</>, [HawkCorrigan]),

--- a/src/parser/shaman/elemental/CombatLogParser.js
+++ b/src/parser/shaman/elemental/CombatLogParser.js
@@ -20,6 +20,7 @@ import Stormkeeper from './modules/talents/Stormkeeper';
 import TotemMastery from './modules/talents/TotemMastery';
 import UnlimitedPower from './modules/talents/UnlimitedPower';
 import UnlimitedPowerTimesByStacks from './modules/talents/UnlimitedPowerTimesByStacks';
+import SurgeOfPower from './modules/talents/SurgeOfPower';
 import Checklist from './modules/checklist/Module';
 import Buffs from './modules/Buffs';
 
@@ -58,6 +59,7 @@ class CombatLogParser extends CoreCombatLogParser {
     stormElemental: StormElemental,
     liquidMagmaTotem: LiquidMagmaTotem,
     masterOfTheElements: MasterOfTheElements,
+    surgeOfPower: SurgeOfPower,
     primalFireElemental: PrimalFireElemental,
     primalStormElemental: PrimalStormElemental,
     totemMastery: TotemMastery,

--- a/src/parser/shaman/elemental/modules/Buffs.js
+++ b/src/parser/shaman/elemental/modules/Buffs.js
@@ -23,6 +23,11 @@ class Buffs extends CoreBuffs {
         timelineHightlight: true,
       },
       {
+        spellId: SPELLS.SURGE_OF_POWER_BUFF.id,
+        enabled: combatant.hasTalent(SPELLS.SURGE_OF_POWER_TALENT.id),
+        timelineHightlight: true,
+      },
+      {
         spellId: SPELLS.STORMKEEPER_TALENT.id,
         timelineHightlight: true,
       },

--- a/src/parser/shaman/elemental/modules/talents/SurgeOfPower.js
+++ b/src/parser/shaman/elemental/modules/talents/SurgeOfPower.js
@@ -46,7 +46,7 @@ class SurgeOfPower extends Analyzer {
       this.skCasts += 1;
     }
 
-    if(!this.selectedCombatant.hasBuff(SPELLS.SURGE_OF_POWER.id)){
+    if(!this.selectedCombatant.hasBuff(SPELLS.SURGE_OF_POWER_BUFF.id)){
       return;
     }
 

--- a/src/parser/shaman/elemental/modules/talents/SurgeOfPower.js
+++ b/src/parser/shaman/elemental/modules/talents/SurgeOfPower.js
@@ -1,0 +1,135 @@
+import React from 'react';
+
+import Analyzer from 'parser/core/Analyzer';
+import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
+import SpellIcon from 'common/SpellIcon';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import { SELECTED_PLAYER } from 'parser/core/EventFilter';
+import Events from 'parser/core/Events';
+
+const SURGE_OF_POWER = {
+  INCREASE: 0.2,
+  DURATION: 15000,
+  WINDOW_DURATION: 500,
+  AFFECTED_CASTS: [
+    SPELLS.FLAME_SHOCK,
+    SPELLS.FROST_SHOCK,
+    SPELLS.LAVA_BURST,
+    SPELLS.LIGHTNING_BOLT,
+  ],
+  TALENTS: [
+    SPELLS.SURGE_OF_POWER_TALENT.id,
+  ],
+};
+
+class SurgeOfPower extends Analyzer {
+  sopBuffedAbilities = {};
+  sopActivationTimestamp = null;
+  sopConsumptionTimestamp = null;
+  // number of SoP empowered lava bursts
+  lvbCastCount = 0;
+  // % of SK lightning bolts empoered by SoP
+  sopSKCastsPercentage = 0.0;
+  // total SK + SoP lightning bolt casts
+  skSopCasts = 0;
+  // total SK lightning bolt casts
+  skCasts = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.SURGE_OF_POWER_TALENT.id);
+
+    for (const key in SURGE_OF_POWER.AFFECTED_CASTS) {
+      const spellid = SURGE_OF_POWER.AFFECTED_CASTS[key].id;
+      if((this.selectedCombatant.hasTalent(spellid)) || (!SURGE_OF_POWER.TALENTS.includes(spellid))) {
+        this.sopBuffedAbilities[spellid] = 0;
+      }
+    }
+
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SURGE_OF_POWER.AFFECTED_CASTS), this._onCast);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.EARTH_SHOCK), this._onESCast);
+  }
+
+  _onCast(event){
+    // cast lightning bolt with only SK buff active
+    if (this.selectedCombatant.hasBuff(SPELLS.STORMKEEPER_TALENT.id, event.timestamp) && event.ability.guid === SPELLS.LIGHTNING_BOLT.id) {
+      this.skCasts += 1;
+    }
+
+    if(this.sopActivationTimestamp===null){ //the buff is a clusterfuck so we just track it manually
+      return;
+    }
+
+    this.sopConsumptionTimestamp=event.timestamp;
+    this.sopActivationTimestamp=null;
+    event.meta = event.meta || {};
+    event.meta.isEnhancedCast = true;
+    this.sopBuffedAbilities[event.ability.guid]++;
+
+    // cast lightning bolt with SoP and SK buffs active
+    if (this.selectedCombatant.hasBuff(SPELLS.STORMKEEPER_TALENT.id, event.timestamp) && event.ability.guid === SPELLS.LIGHTNING_BOLT.id) {
+      this.skSopCasts += 1;
+    }
+  }
+
+  _onESCast(event){
+    this.sopActivationTimestamp = event.timestamp;
+  }
+
+  statistic() {
+    const value = `${this.sopBuffedAbilities[SPELLS.LAVA_BURST.id] * 6} Seconds`;
+    const label = `Elemental Cooldown Reduction from Surge of Power`;
+    return (
+      <StatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
+        icon={<SpellIcon id={SPELLS.SURGE_OF_POWER_TALENT.id} />}
+        value={value}
+        label={label}
+      >
+        <table className="table table-condensed">
+          <thead>
+            <tr>
+              <th>Ability</th>
+              <th>Number of Buffed Casts</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.keys(this.sopBuffedAbilities).map((e) => (
+              <tr key={e}>
+                <th>{<SpellLink id={Number(e)} />}</th>
+                <td>{this.sopBuffedAbilities[e]}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </StatisticBox>
+    );
+  }
+
+  get suggestionTresholds() {
+    //console.info(this.sopSKCastsPercentage);
+    return {
+      actual: this.skSopCasts / this.skCasts,
+      isLessThan: {
+        minor: 0.9,
+        average: 0.75,
+        major: 0.5,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when){
+    when(this.suggestionTresholds)
+      .addSuggestion((suggest, actual, recommended) => {
+        return suggest(<span>You should aim to empower all of your Stormkeeper lightning bolts with Surge of Power. You can accomplish this 
+        consistently by pooling to 95+ maelstrom right before Stormkeeper is available, then casting ES -> SK -> LB -> LvB -> ES -> LB.</span>)
+          .icon(SPELLS.SURGE_OF_POWER_TALENT.icon)
+          .actual(`${actual}% of Stormkeeper Lightning Bolts empowered with Surge`)
+          .recommended(`100% is recommended.`);
+      });
+  }
+}
+
+export default SurgeOfPower;

--- a/src/parser/shaman/elemental/modules/talents/SurgeOfPower.js
+++ b/src/parser/shaman/elemental/modules/talents/SurgeOfPower.js
@@ -9,8 +9,6 @@ import { SELECTED_PLAYER } from 'parser/core/EventFilter';
 import Events from 'parser/core/Events';
 
 const SURGE_OF_POWER = {
-  DURATION: 15000,
-  WINDOW_DURATION: 500,
   AFFECTED_CASTS: [
     SPELLS.FLAME_SHOCK,
     SPELLS.FROST_SHOCK,
@@ -21,8 +19,6 @@ const SURGE_OF_POWER = {
 
 class SurgeOfPower extends Analyzer {
   sopBuffedAbilities = {};
-  // % of SK lightning bolts empoered by SoP
-  sopSKCastsPercentage = 0.0;
   // total SK + SoP lightning bolt casts
   skSopCasts = 0;
   // total SK lightning bolt casts
@@ -91,7 +87,6 @@ class SurgeOfPower extends Analyzer {
   }
 
   get suggestionTresholds() {
-    //console.info(this.sopSKCastsPercentage);
     return {
       actual: this.skSopCasts / this.skCasts,
       isLessThan: {


### PR DESCRIPTION
This is kind of a rough implementation but it works locally with my character. There might be nicer ways of doing what I did. I used the Master of the Elements implementation as a guide.

This PR adds a Statistic object that shows the amount of cooldown reduction for fire ele by default. There is also a dropdown with a table that shows a breakdown of all SoP empowered casts.
https://i.imgur.com/xb6gC2N.png

It also adds an object to the Suggestions view that tracks the amount of SoP empowered stormkeepers.
https://i.imgur.com/chNK4kt.png