### PR TITLE
[Prot warrior] AngerManagement + checklist clean up + visions minor for rage

### DIFF
--- a/src/common/SPELLS/bfa/essences/essences.js
+++ b/src/common/SPELLS/bfa/essences/essences.js
@@ -230,6 +230,11 @@ export default {
     name: 'Vision of Perfection',
     icon: 'spell_azerite_essence_18',
   },
+  VISION_OF_PERFECTION_RAGE: {
+    id: 302585,
+    name: 'Vision of Perfection',
+    icon: 'spell_azerite_essence_18',
+  },
   STRIVE_FOR_PERFECTION: {
     id: 296320,
     name: 'Strive for Perfection',

--- a/src/parser/warrior/protection/CHANGELOG.js
+++ b/src/parser/warrior/protection/CHANGELOG.js
@@ -1,10 +1,14 @@
 // eslint-disable-next-line no-unused-vars
 import React from 'react';
 
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+
 import { Zerotorescue, Abelito75 } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 8, 22),<>Updated cooldown tracking when <SpellLink id={SPELLS.ANGER_MANAGEMENT_TALENT.id} /> is talented. Also added visions of perfection so we have no more missing spell.  </>,Abelito75),
   change(date(2019, 8, 15),<>Buff tracking changed for timeline.</>,Abelito75),
   change(date(2019, 8, 15),<>Shield Slam module created for assuming possible casts.</>,Abelito75),
   change(date(2019, 8, 9),<>Big Overhaul to Checklist. We also have a working checklist again</>,Abelito75),

--- a/src/parser/warrior/protection/CombatLogParser.js
+++ b/src/parser/warrior/protection/CombatLogParser.js
@@ -23,6 +23,7 @@ import IntoTheFray from './modules/talents/IntoTheFray';
 import Vengeance from './modules/talents/Vengeance';
 import Punish from './modules/talents/Punish';
 import DragonRoar from './modules/talents/DragonRoar';
+import AngerCD from './modules/talents/AngerCD';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -46,6 +47,7 @@ class CombatLogParser extends CoreCombatLogParser {
     shieldSlam: ShieldSlam,
     //Talents
     angerManagement: AngerManagement,
+    angerCD: AngerCD,
     boomingVoice: BoomingVoice,
     heavyRepercussions: HeavyRepercussions,
     intoTheFray: IntoTheFray,

--- a/src/parser/warrior/protection/modules/Abilities.js
+++ b/src/parser/warrior/protection/modules/Abilities.js
@@ -32,11 +32,6 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         buffSpellId: SPELLS.PUNISH_DEBUFF.id,
         cooldown: haste => 9 / (1 + haste),
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: .9,
-          extraSuggestion: 'Casting Shield Slam regularly is very important for performing well.',
-        },
         timelineSortIndex: 1,
       },
       {
@@ -76,11 +71,6 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.DEMORALIZING_SHOUT,
         buffSpellId: SPELLS.DEMORALIZING_SHOUT.id,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
-        castEfficiency: {
-          suggestion: combatant.hasTalent(SPELLS.BOOMING_VOICE_TALENT.id),
-          recommendedEfficiency: combatant.hasTalent(SPELLS.ANGER_MANAGEMENT_TALENT.id) ? .95 : .80,
-          extraSuggestion: 'Cast Demoralizing Shout more liberally to maximize it\'s DPS boost unless you need it so survive a specific mechanic.',
-        },
         gcd: {
           base: 1500,
         },
@@ -161,10 +151,6 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.AVATAR_TALENT,
         buffSpellId: SPELLS.AVATAR_TALENT.id,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: .9,
-        },
         gcd: {
           base: 1500,
         },

--- a/src/parser/warrior/protection/modules/features/Checklist/Component.js
+++ b/src/parser/warrior/protection/modules/features/Checklist/Component.js
@@ -61,12 +61,23 @@ class ProtectionWarriorChecklist extends React.PureComponent {
             </>
           )}
         >
-          <AbilityRequirement spell={SPELLS.SHIELD_WALL.id} />
-          <AbilityRequirement spell={SPELLS.LAST_STAND.id} />
+          <Requirement
+            name={(<SpellLink id={SPELLS.SHIELD_WALL.id} /> )}
+            thresholds={thresholds.shieldWallCD}
+            />
+          <Requirement
+            name={(<SpellLink id={SPELLS.LAST_STAND.id} /> )}
+            thresholds={thresholds.lastStandCD}
+            />
           <AbilityRequirement spell={SPELLS.SPELL_REFLECTION.id} 
             tooltip={<>Take this with a grain of salt as some bosses it is not possible to use. </>}
           /> 
-          {!combatant.hasTalent(SPELLS.BOOMING_VOICE_TALENT.id) && <AbilityRequirement spell={SPELLS.DEMORALIZING_SHOUT.id} />}
+          {!combatant.hasTalent(SPELLS.BOOMING_VOICE_TALENT.id) && (
+              <Requirement
+                name={(<SpellLink id={SPELLS.DEMORALIZING_SHOUT.id} /> )}
+                thresholds={thresholds.demoShoutCD}
+            />
+            )}
         </Rule>
 
         <Rule
@@ -78,8 +89,16 @@ class ProtectionWarriorChecklist extends React.PureComponent {
             </>
           )}
           >
-            <AbilityRequirement spell={SPELLS.AVATAR_TALENT.id} />
-            {combatant.hasTalent(SPELLS.BOOMING_VOICE_TALENT.id) && <AbilityRequirement spell={SPELLS.DEMORALIZING_SHOUT.id} />}
+            <Requirement
+              name={(<SpellLink id={SPELLS.AVATAR_TALENT.id} /> )}
+              thresholds={thresholds.avatarCD}
+            />
+            {combatant.hasTalent(SPELLS.BOOMING_VOICE_TALENT.id) && (
+              <Requirement
+                name={(<SpellLink id={SPELLS.DEMORALIZING_SHOUT.id} /> )}
+                thresholds={thresholds.demoShoutCD}
+            />
+            )}
             {combatant.hasTalent(SPELLS.RAVAGER_TALENT_PROTECTION.id) && <AbilityRequirement spell={SPELLS.RAVAGER_TALENT_PROTECTION.id} />}
             
           </Rule>

--- a/src/parser/warrior/protection/modules/features/Checklist/Component.js
+++ b/src/parser/warrior/protection/modules/features/Checklist/Component.js
@@ -48,7 +48,12 @@ class ProtectionWarriorChecklist extends React.PureComponent {
           />
           <AbilityRequirement spell={SPELLS.SHIELD_BLOCK.id} />
           {combatant.hasTalent(SPELLS.STORM_BOLT_TALENT.id) && <AbilityRequirement spell={SPELLS.STORM_BOLT_TALENT.id} />}
-          {combatant.hasTalent(SPELLS.BOOMING_VOICE_TALENT.id) && <AbilityRequirement spell={SPELLS.DEMORALIZING_SHOUT.id} />}
+          {combatant.hasTalent(SPELLS.BOOMING_VOICE_TALENT.id) && (
+            <Requirement
+              name={(<SpellLink id={SPELLS.DEMORALIZING_SHOUT.id} /> )}
+              thresholds={thresholds.demoShoutCD}
+            />
+          )}
           {combatant.hasTalent(SPELLS.DRAGON_ROAR_TALENT.id) && <AbilityRequirement spell={SPELLS.DRAGON_ROAR_TALENT.id} />}
           
         </Rule>

--- a/src/parser/warrior/protection/modules/features/Checklist/Module.js
+++ b/src/parser/warrior/protection/modules/features/Checklist/Module.js
@@ -10,6 +10,7 @@ import Component from './Component';
 import RageDetails from '../../core/RageDetails';
 import RageTracker from '../../core/RageTracker';
 import ShieldSlam from '../../spells/ShieldSlam';
+import AngerCD from '../../talents/AngerCD';
 
 
 class Checklist extends BaseChecklist {
@@ -22,6 +23,7 @@ class Checklist extends BaseChecklist {
     rageDetails: RageDetails,
     rageTracker: RageTracker,
     shieldSlam: ShieldSlam,
+    angerCD: AngerCD,
   };
 
   render() {
@@ -34,6 +36,10 @@ class Checklist extends BaseChecklist {
           downtimeSuggestionThresholds: this.alwaysBeCasting.downtimeSuggestionThresholds,
           rageDetails: this.rageDetails.suggestionThresholds,
           shieldSlam: this.shieldSlam.suggestionThresholds,
+          demoShoutCD: this.angerCD.suggestionThresholdsDemoShout,
+          avatarCD: this.angerCD.suggestionThresholdsAvatar,
+          lastStandCD: this.angerCD.suggestionThresholdsLastStand,
+          shieldWallCD: this.angerCD.suggestionThresholdsShieldWall,
         }}
       />
     );

--- a/src/parser/warrior/protection/modules/talents/AngerCD.js
+++ b/src/parser/warrior/protection/modules/talents/AngerCD.js
@@ -1,0 +1,141 @@
+import React from 'react';
+import Analyzer from 'parser/core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import { formatPercentage } from 'common/format';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import AbilityTracker from 'parser/shared/modules/AbilityTracker';
+import AngerManagement from './AngerManagement';
+
+class AngerCD extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+    abilityTracker: AbilityTracker,
+    angerManagement: AngerManagement,
+  };
+
+  actualFightTime = 0;
+  DEMOSHOUTCD = 45000;
+  AVATARCD = 90000;
+  LASTSTANDCD = this.selectedCombatant.hasTalent(SPELLS.BOLSTER_TALENT.id) ? 180000 - 60000 : 180000;
+  SHIELDWALLCD = 240000;
+
+  hasAM = false;
+
+  constructor(...args) {
+    super(...args);
+    this.hasAM = this.selectedCombatant.hasTalent(SPELLS.ANGER_MANAGEMENT_TALENT.id);
+  }
+
+  on_fightend(){
+    if(this.hasAM){
+      this.actualFightTime = (this.owner.fight.end_time - this.owner.fight.start_time) + this.angerManagement.effectiveReduction[SPELLS.DEMORALIZING_SHOUT.id] + this.angerManagement.wastedReduction[SPELLS.DEMORALIZING_SHOUT.id];
+    }else{
+      this.actualFightTime = (this.owner.fight.end_time - this.owner.fight.start_time);
+    }
+  }
+
+  ratio(spellCD, spellid){
+    const possibleCasts = Math.ceil(this.actualFightTime/spellCD) || 1;
+    const actualCasts = this.abilityTracker.getAbility(spellid).casts || 0;
+    return actualCasts / possibleCasts;
+  }
+
+  //KLUDGE
+  get suggestionThresholdsDemoShout(){
+    return {
+      actual: this.ratio(this.DEMOSHOUTCD, SPELLS.DEMORALIZING_SHOUT.id),
+      isLessThan: {
+        minor: .90,
+        average: .80,
+        major: .70,
+      },
+      style: 'percentage',
+    };
+  }
+  
+  get suggestionThresholdsAvatar(){
+    return {
+      actual: this.ratio(this.AVATARCD, SPELLS.AVATAR_TALENT.id),
+      isLessThan: {
+        minor: .90,
+        average: .80,
+        major: .70,
+      },
+      style: 'percentage',
+    };
+  }
+
+  get suggestionThresholdsLastStand(){
+    return {
+      actual: this.ratio(this.LASTSTANDCD, SPELLS.LAST_STAND.id),
+      isLessThan: {
+        minor: .80,
+        average: .70,
+        major: .60,
+      },
+      style: 'percentage',
+    };
+  }
+
+  get suggestionThresholdsShieldWall(){
+    return {
+      actual: this.ratio(this.SHIELDWALLCD, SPELLS.SHIELD_WALL.id),
+      isLessThan: {
+        minor: .80,
+        average: .70,
+        major: .60,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+
+    when(this.suggestionThresholdsDemoShout).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <>
+          Try to cast <SpellLink id={SPELLS.DEMORALIZING_SHOUT.id} /> more often. Cast <SpellLink id={SPELLS.DEMORALIZING_SHOUT.id} /> more liberally to maximize it's DPS boost unless you need it so survive a specific mechanic.
+        </>
+      )
+        .icon(SPELLS.DEMORALIZING_SHOUT.icon)
+        .actual(`${formatPercentage(actual)}% Demoralizing Shout`)
+        .recommended(`${formatPercentage(recommended)}% casts recommended`);
+    });
+
+    when(this.suggestionThresholdsAvatar).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <>
+          Try to cast <SpellLink id={SPELLS.AVATAR_TALENT.id} /> more often.
+        </>
+      )
+        .icon(SPELLS.AVATAR_TALENT.icon)
+        .actual(`${formatPercentage(actual)}% Avatar casts`)
+        .recommended(`${formatPercentage(recommended)}% casts recommended`);
+    });
+
+    when(this.suggestionThresholdsLastStand).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <>
+          Try to cast <SpellLink id={SPELLS.LAST_STAND.id} /> more often.
+        </>
+      )
+        .icon(SPELLS.LAST_STAND.icon)
+        .actual(`${formatPercentage(actual)}% Last Stand casts`)
+        .recommended(`${formatPercentage(recommended)}% casts recommended`);
+    });
+
+    when(this.suggestionThresholdsShieldWall).addSuggestion((suggest, actual, recommended) => {
+      return suggest(
+        <>
+          Try to cast <SpellLink id={SPELLS.SHIELD_WALL.id} /> more often.
+        </>
+      )
+        .icon(SPELLS.SHIELD_WALL.icon)
+        .actual(`${formatPercentage(actual)}% Shield Wall casts`)
+        .recommended(`${formatPercentage(recommended)}% casts recommended`);
+    });
+  }
+}
+
+export default AngerCD;


### PR DESCRIPTION
Added custom cd calculators so angermanagement doesn't show crazy things like 150% cast rate of avatar

Checklist clean up is for anger management and deleting the generic cast efficient suggestions so we don't double post.

Visions minor for rage shows up and Unknown spell. now it doesn't
example log
https://wowanalyzer.com/report/YTkJCPQ9cVKHMvaq/24-Normal+Orgozoa+-+Kill+(6:30)/Istenn/rage-usage