### PR TITLE
Absorbed damage now included in damage calculations for cooldown tabs

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -8,6 +8,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  change(date(2019, 8, 22), 'Updated cooldown tab so it includes absorbed damage for dps.', Abelito75),
   change(date(2019, 8, 22), 'Added Spell IDs and the stacking haste buff from Condensed Life Force.', Sharrq),
   change(date(2019, 8, 22), <><SpellLink id={SPELLS.LUCID_DREAMS.id} /> minor for rage refund added. Shouldn't show up as missing id in rage-useage now.</>, Abelito75),
   change(date(2019, 8, 20), 'Fixed potential crash of phase fabrication during mixed filter usage.', Zeboot),

--- a/src/interface/others/Cooldown.js
+++ b/src/interface/others/Cooldown.js
@@ -101,7 +101,7 @@ class Cooldown extends React.Component {
   }
 
   calculateDamageStatistics(cooldown) {
-    const damageDone = cooldown.events.reduce((acc, event) => event.type === 'damage' ? acc + event.amount : acc, 0);
+    const damageDone = cooldown.events.reduce((acc, event) => event.type === 'damage' ? acc + ((event.amount || 0) + (event.absorbed || 0)) : acc, 0);
 
     return { damageDone };
   }


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/25177817/63644058-0874eb00-c6ae-11e9-962e-eb03bc470240.PNG)
After:
![after](https://user-images.githubusercontent.com/25177817/63644060-0f9bf900-c6ae-11e9-9bb2-01afa8eb12f2.PNG)
