### PR TITLE
[Fire Mage] Updated Blaster Master Graphic

### DIFF
--- a/src/parser/mage/fire/CHANGELOG.js
+++ b/src/parser/mage/fire/CHANGELOG.js
@@ -8,6 +8,7 @@ import ItemLink from 'common/ItemLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 8, 27), <>Update <SpellLink id={SPELLS.BLASTER_MASTER.id} /> explanation graphic to new version.</>, [Sharrq]),
   change(date(2019, 8, 21), <>Add support for Fire Blast cooldown reduction from <SpellLink id={SPELLS.LUCID_DREAMS_MAJOR.id} />.</>, [Sharrq]),
   change(date(2019, 8, 20), <>Minor code style fix</>, [Sharrq]),
   change(date(2019, 8, 20), <>Fixed an issue that caused Boss Health calculations to be incorrect on Lady Ashvane, resulting in incorrect results for several statistics and suggestions.</>, [Sharrq]),

--- a/src/parser/mage/fire/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/mage/fire/__snapshots__/CombatLogParser.test.js.snap
@@ -222,7 +222,7 @@ Array [
       3
        stacks each time you use Combustion. For more information on how to adjust your Combustion rotation to make this happen, refer to 
       <a
-        href="https://cdn.discordapp.com/attachments/431912396349636609/511996656829595659/BlasterMaster_Rotation.png"
+        href="https://cdn.discordapp.com/attachments/524387813060247553/606533890080899083/bm_combustion.png"
         rel="noopener noreferrer"
         target="_blank"
       >

--- a/src/parser/mage/fire/modules/traits/BlasterMaster.js
+++ b/src/parser/mage/fire/modules/traits/BlasterMaster.js
@@ -73,7 +73,7 @@ class BlasterMaster extends Analyzer {
   suggestions(when) {
     when(this.averageStackThresholds)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<>On average, you got {this.averageStacksPerCombustion.toFixed(2)} stacks of <SpellLink id={SPELLS.BLASTER_MASTER.id} /> per <SpellLink id={SPELLS.COMBUSTION.id} /> cast. In order to maximize the use of the trait, you should aim for getting to {TRAIT_STACK_THRESHOLD} stacks each time you use Combustion. For more information on how to adjust your Combustion rotation to make this happen, refer to <a href="https://cdn.discordapp.com/attachments/431912396349636609/511996656829595659/BlasterMaster_Rotation.png" target="_blank" rel="noopener noreferrer">this graphic</a></>)
+        return suggest(<>On average, you got {this.averageStacksPerCombustion.toFixed(2)} stacks of <SpellLink id={SPELLS.BLASTER_MASTER.id} /> per <SpellLink id={SPELLS.COMBUSTION.id} /> cast. In order to maximize the use of the trait, you should aim for getting to {TRAIT_STACK_THRESHOLD} stacks each time you use Combustion. For more information on how to adjust your Combustion rotation to make this happen, refer to <a href="https://cdn.discordapp.com/attachments/524387813060247553/606533890080899083/bm_combustion.png" target="_blank" rel="noopener noreferrer">this graphic</a></>)
           .icon(SPELLS.BLASTER_MASTER.icon)
           .actual(`${this.averageStacksPerCombustion.toFixed(2)} stacks per Combustion`)
           .recommended(`${formatNumber(recommended)} is recommended`);


### PR DESCRIPTION
The BM Rotation graphic was updated in the mage discord to include the Hyperthread Wristwraps, so i am pointing to the new graphic now.