### PR TITLE
[Core] Dispel Tracker BlackList added

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -8,6 +8,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  change(date(2019, 8, 27), <>Added check to remove <SpellLink id={SPELLS.WINDWALKING.id} /> from dispel infographic. </>, Abelito75),
   change(date(2019, 8, 27), <>Updated <SpellLink id={SPELLS.CONCENTRATED_FLAME.id} /> to take into account 2 charges at rank 3 and up.</>, Yajinni),
   change(date(2019, 8, 26), 'Normalized the location of visions of perfections reduced cd calculator.', Abelito75),
   change(date(2019, 8, 22), 'Updated cooldown tab so it includes absorbed damage for dps.', Abelito75),

--- a/src/common/SPELLS/monk.js
+++ b/src/common/SPELLS/monk.js
@@ -575,4 +575,9 @@ export default {
     name: 'Reverse Harm',
     icon: 'ability_monk_expelharm',
   },
+  WINDWALKING: {
+    id: 166646,
+    name: 'Windwalking',
+    icon: 'monk_stance_whitetiger',
+  },
 };

--- a/src/parser/shared/modules/DispelTracker.js
+++ b/src/parser/shared/modules/DispelTracker.js
@@ -10,8 +10,18 @@ const debug = false;
 class DispelTracker extends Analyzer {
   dispelEvents = {};
   dispelCount = 0;
+
+  blackList = [
+    SPELLS.WINDWALKING.id,
+  ];
+
   on_dispel(event) {
     if (!this.owner.byPlayer(event)) {
+      return;
+    }
+    const spellId = event.extraAbility.guid;
+
+    if(this.blackList.includes(spellId)){
       return;
     }
 


### PR DESCRIPTION
Added a blacklist to Dispel Tracker so we can easily add spells we don't want listed
This currently only has Windwalking which is a friendly aura that ww give off no matter what. 
It can be `Dispelled` by warrior but instantly given it again. This is pointless and should be caught as it provides 0 useful data