### PR TITLE
[Core] Time spent casting fix for Mana Efficiency module

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -8,6 +8,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  change(date(2019, 9, 5), 'Fixed a calculation error affecting time spent casting in some cases.', niseko),
   change(date(2019, 8, 27), <>Added check to remove <SpellLink id={SPELLS.WINDWALKING.id} /> from dispel infographic. </>, Abelito75),
   change(date(2019, 8, 27), <>Updated <SpellLink id={SPELLS.CONCENTRATED_FLAME.id} /> to take into account 2 charges at rank 3 and up.</>, Yajinni),
   change(date(2019, 8, 26), 'Normalized the location of visions of perfections reduced cd calculator.', Abelito75),

--- a/src/parser/shared/modules/CastEfficiency.js
+++ b/src/parser/shared/modules/CastEfficiency.js
@@ -106,7 +106,7 @@ class CastEfficiency extends Analyzer {
           beginCastTimestamp = null;
           return acc + castTime;
         } else if (event.type === 'beginchannel') {
-          beginChannelTimestamp = event.timestamp;
+          beginChannelTimestamp = beginCastTimestamp ? null : event.timestamp;
           return acc;
         } else if (event.type === 'endchannel') {
           //limit by start time in case of pre phase events


### PR DESCRIPTION
fix #3309 
Issue was caused by https://github.com/WoWAnalyzer/WoWAnalyzer/commit/6d2863ff363cbc9ec8e94c896c571d2ae326c5d5#diff-fee0b230fde9d0291b998680603642deR98 doubling the time calculation for every spell that has actual cast events. I looked at the Mistweaver module to make sure that this commit didn't break it again, but without knowing what spell this was implemented for its hard to fully verify.

Before the change
![grafik](https://user-images.githubusercontent.com/2842471/64320512-00c31980-cfbf-11e9-8f11-d30ebd8067ad.png)
After (increased are spells that have cast events, as the time spent casting is now correct)
![grafik](https://user-images.githubusercontent.com/2842471/64320528-0a4c8180-cfbf-11e9-9f6c-b9e73d01e66b.png)
