### PR TITLE
[Prot Warrior] Block Checker Update

### DIFF
--- a/src/parser/warrior/protection/CHANGELOG.js
+++ b/src/parser/warrior/protection/CHANGELOG.js
@@ -8,6 +8,7 @@ import { Abelito75 } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [  
+  change(date(2019, 9, 18),<>Physical hits blocked now only checks blockable hits. </>,Abelito75),
   change(date(2019, 9, 4),<>Fixed a bug in <SpellLink id={SPELLS.BRACE_FOR_IMPACT.id} />. </>,Abelito75),
   change(date(2019, 9, 4),<>Changed timeformat for <SpellLink id={SPELLS.BRACE_FOR_IMPACT.id} />. </>,Abelito75),
   change(date(2019, 9, 4),<>Updated wording for <SpellLink id={SPELLS.AVATAR_TALENT.id} />.</>,Abelito75),

--- a/src/parser/warrior/protection/modules/features/BlockCheck.js
+++ b/src/parser/warrior/protection/modules/features/BlockCheck.js
@@ -6,14 +6,22 @@ import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 
+import ShieldBlock from '../spells/ShieldBlock';
+
 const debug = false;
 
 //Moved from another file as it was easier to keep track of with this name
 class BlockCheck extends Analyzer {
-  physicalHitsWithShieldBlock = 0;
-  physicalDamageWithShieldBlock = 0;
-  physicalHitsWithoutShieldBlock = 0;
-  physicalDamageWithoutShieldBlock = 0;
+  static dependencies = {
+    shieldBlock: ShieldBlock,
+  };
+
+  physicalHitsWithBlock = 0;
+  physicalDamageWithBlock = 0;
+  physicalHitsWithoutBlock = 0;
+  physicalDamageWithoutBlock = 0;
+
+  listOfEvents;
 
   bolster = this.selectedCombatant.hasTalent(SPELLS.BOLSTER_TALENT.id);
   heavyRepercussions = this.selectedCombatant.hasTalent(SPELLS.HEAVY_REPERCUSSIONS_TALENT.id);
@@ -43,6 +51,7 @@ class BlockCheck extends Analyzer {
 
   constructor(...args) {
     super(...args);
+    this.listOfEvents = [];
     if(this.bolster && this.heavyRepercussions){
       this.thresholdsToUse = this.blHRThresholds;
     }else if(this.bolster && !this.heavyRepercussions){
@@ -55,29 +64,48 @@ class BlockCheck extends Analyzer {
   on_toPlayer_damage(event) {
     // Physical
     if (event.ability.type === 1) {
-      if (this.selectedCombatant.hasBuff(SPELLS.SHIELD_BLOCK_BUFF.id) || (this.bolster && this.selectedCombatant.hasBuff(SPELLS.LAST_STAND.id))) {
-        this.physicalHitsWithShieldBlock += 1;
-        this.physicalDamageWithShieldBlock += event.amount + (event.absorbed || 0) + (event.overkill || 0);
-      } else {
-        this.physicalHitsWithoutShieldBlock += 1;
-        this.physicalDamageWithoutShieldBlock += event.amount + (event.absorbed || 0) + (event.overkill || 0);
-      }
+      event.prot = {
+        shieldBlock: this.selectedCombatant.hasBuff(SPELLS.SHIELD_BLOCK_BUFF.id),//ability to look what important buffs they had retro actively
+        bloster: (this.bolster && this.selectedCombatant.hasBuff(SPELLS.LAST_STAND.id)),
+      };
+      this.listOfEvents.push(event);
     }
   }
 
   on_fightend() {
+    let blockableSet = new Set();//this is master list of all BLOCKED events in the fight
+    blockableSet.add(1);//make it so if they never hit sb we still get data from the melees they take
+    this.shieldBlock.shieldBlocksDefensive.forEach(function(block){
+      block.eventName.forEach(function(blockedAbility){
+        blockableSet.add(blockedAbility);//just go through one set to another
+      });
+    });
+
+    const that = this;
+    this.listOfEvents.forEach(function(event){
+      if(blockableSet.has(event.ability.guid)){//if it ain't been blocked over the whole fight it prob aint blockable
+        if (event.prot.shieldBlock || event.prot.bloster) {//they got block up when it happened?
+          that.physicalHitsWithBlock += 1;
+          that.physicalDamageWithBlock += event.amount + (event.absorbed || 0) + (event.overkill || 0);
+        } else {
+          that.physicalHitsWithoutBlock += 1;
+          that.physicalDamageWithoutBlock += event.amount + (event.absorbed || 0) + (event.overkill || 0);
+        }
+      }
+    });
+
     if (debug) {
-      console.log(`Hits with block spell up ${this.physicalHitsWithShieldBlock}`);
-      console.log(`Damage with block spell up ${this.physicalDamageWithShieldBlock}`);
-      console.log(`Hits without block spell up ${this.physicalHitsWithoutShieldBlock}`);
-      console.log(`Damage without block spell up ${this.physicalDamageWithoutShieldBlock}`);
-      console.log(`Total physical ${this.physicalDamageWithoutShieldBlock}${this.physicalDamageWithShieldBlock}`);
+      console.log(`Hits with block spell up ${this.physicalHitsWithBlock}`);
+      console.log(`Damage with block spell up ${this.physicalDamageWithBlock}`);
+      console.log(`Hits without block spell up ${this.physicalHitsWithoutBlock}`);
+      console.log(`Damage without block spell up ${this.physicalDamageWithoutBlock}`);
+      console.log(`Total physical ${this.physicalDamageWithoutBlock}${this.physicalDamageWithBlock}`);
     }
   }
 
   get suggestionThresholds() {//was in here before but is/was never used and appears to be very high requirements that are unreasonable maybe lower and add laster?
     return {
-      actual: this.physicalDamageWithShieldBlock / (this.physicalDamageWithShieldBlock + this.physicalDamageWithoutShieldBlock),
+      actual: this.physicalDamageWithBlock / (this.physicalDamageWithBlock + this.physicalDamageWithoutBlock),
       isLessThan: this.thresholdsToUse,
       style: 'percentage',
     };
@@ -94,8 +122,8 @@ class BlockCheck extends Analyzer {
   }
 
   statistic() {
-    const physicalHitsMitigatedPercent = this.physicalHitsWithShieldBlock / (this.physicalHitsWithShieldBlock + this.physicalHitsWithoutShieldBlock);
-    const physicalDamageMitigatedPercent = this.physicalDamageWithShieldBlock / (this.physicalDamageWithShieldBlock + this.physicalDamageWithoutShieldBlock);
+    const physicalHitsMitigatedPercent = this.physicalHitsWithBlock / (this.physicalHitsWithBlock + this.physicalHitsWithoutBlock);
+    const physicalDamageMitigatedPercent = this.physicalDamageWithBlock / (this.physicalDamageWithBlock + this.physicalDamageWithoutBlock);
 
     return (
       <StatisticBox
@@ -106,10 +134,10 @@ class BlockCheck extends Analyzer {
           <>
             Shield Block usage breakdown:
             <ul>
-              <li>You were hit <strong>{this.physicalHitsWithShieldBlock}</strong> times with block up (<strong>{formatThousands(this.physicalDamageWithShieldBlock)}</strong> damage).</li>
-              <li>You were hit <strong>{this.physicalHitsWithoutShieldBlock}</strong> times <strong><em>without</em></strong> block up (<strong>{formatThousands(this.physicalDamageWithoutShieldBlock)}</strong> damage).</li>
+              <li>You were hit <strong>{this.physicalHitsWithBlock}</strong> times with block up (<strong>{formatThousands(this.physicalDamageWithBlock)}</strong> damage).</li>
+              <li>You were hit <strong>{this.physicalHitsWithoutBlock}</strong> times <strong><em>without</em></strong> block up (<strong>{formatThousands(this.physicalDamageWithoutBlock)}</strong> damage).</li>
             </ul>
-            <strong>{formatPercentage(physicalHitsMitigatedPercent)}%</strong> of physical attacks were mitigated with Shield Block (<strong>{formatPercentage(physicalDamageMitigatedPercent)}%</strong> of physical damage taken).
+            <strong>{formatPercentage(physicalHitsMitigatedPercent)}%</strong> of physical attacks were mitigated with Block (<strong>{formatPercentage(physicalDamageMitigatedPercent)}%</strong> of physical damage taken).
           </>
         )}
       />

--- a/src/parser/warrior/protection/modules/features/BlockCheck.js
+++ b/src/parser/warrior/protection/modules/features/BlockCheck.js
@@ -73,7 +73,7 @@ class BlockCheck extends Analyzer {
   }
 
   on_fightend() {
-    let blockableSet = new Set();//this is master list of all BLOCKED events in the fight
+    const blockableSet = new Set();//this is master list of all BLOCKED events in the fight
     blockableSet.add(1);//make it so if they never hit sb we still get data from the melees they take
     this.shieldBlock.shieldBlocksDefensive.forEach(function(block){
       block.eventName.forEach(function(blockedAbility){

--- a/src/parser/warrior/protection/modules/spells/ShieldBlock.js
+++ b/src/parser/warrior/protection/modules/spells/ShieldBlock.js
@@ -63,6 +63,7 @@ class ShieldBlock extends Analyzer {
     if(event.blocked > 0){
       this.shieldBlocksDefensive[this.shieldBlocksDefensive.length-1].blockAbleEvents += 1;
       this.shieldBlocksDefensive[this.shieldBlocksDefensive.length-1].eventName.add(event.ability.name);
+      this.shieldBlocksDefensive[this.shieldBlocksDefensive.length-1].eventSpellId.add(event.ability.guid);
     }
 
     this.shieldBlocksDefensive[this.shieldBlocksDefensive.length-1].blockedDamage += event.blocked || 0;
@@ -91,7 +92,8 @@ class ShieldBlock extends Analyzer {
       blockAbleEvents: 0,
       blockedDamage: 0,
       damageTaken: 0,
-      eventName: new Set(),
+      eventName: new Set(),//human readable
+      eventSpellId: new Set(),//data safe
       good: false,
     };
 


### PR DESCRIPTION
Now only checks blockable hits (retroactive)
Before:
![before](https://user-images.githubusercontent.com/25177817/65112797-dc980d00-d9ae-11e9-90b9-2da7b736c4ec.PNG)

After:
![after](https://user-images.githubusercontent.com/25177817/65112800-df92fd80-d9ae-11e9-98a3-3fd9003e369c.PNG)

This will drop the stat a little bit but make it more accurate because before it only checked if it was physical and you had a block spell up so things that were aoe that were not blockable but happened while you had Shield block up counted as a good thing even thought it didn't matter