### PR TITLE
[Fire Mage] Bug Fix for Meteor

### DIFF
--- a/src/parser/mage/fire/CHANGELOG.js
+++ b/src/parser/mage/fire/CHANGELOG.js
@@ -8,6 +8,7 @@ import ItemLink from 'common/ItemLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 9, 19), <>Fixed a bug in <SpellLink id={SPELLS.METEOR_TALENT.id} /> that was looking for the wrong Spell ID for <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} />.</>, [Sharrq]),
   change(date(2019, 9, 3), <>Fixed bug in <SpellLink id={SPELLS.LUCID_DREAMS_MAJOR.id} />.</>, [Sharrq]),
   change(date(2019, 8, 27), <>Update <SpellLink id={SPELLS.BLASTER_MASTER.id} /> explanation graphic to new version.</>, [Sharrq]),
   change(date(2019, 8, 21), <>Add support for Fire Blast cooldown reduction from <SpellLink id={SPELLS.LUCID_DREAMS_MAJOR.id} />.</>, [Sharrq]),

--- a/src/parser/mage/fire/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/mage/fire/__snapshots__/CombatLogParser.test.js.snap
@@ -674,7 +674,7 @@ exports[`The Fire Mage Analyzer analyzers Meteor matches the statistic snapshot 
         <div
           className="value"
         >
-          100 %
+          20 %
         </div>
       </div>
     </div>
@@ -699,7 +699,46 @@ exports[`The Fire Mage Analyzer analyzers Meteor matches the statistic snapshot 
 </div>
 `;
 
-exports[`The Fire Mage Analyzer analyzers Meteor matches the suggestions snapshot 1`] = `Array []`;
+exports[`The Fire Mage Analyzer analyzers Meteor matches the suggestions snapshot 1`] = `
+Array [
+  Object {
+    "details": null,
+    "icon": "spell_mage_meteor",
+    "importance": "major",
+    "issue": <React.Fragment>
+      You cast 
+      <SpellLink
+        icon={true}
+        id={153561}
+      />
+       without 
+      <SpellLink
+        icon={true}
+        id={116011}
+      />
+       
+      4
+       times. In order to get the most out of 
+      <SpellLink
+        icon={true}
+        id={153561}
+      />
+       you should always cast it while being buffed by 
+      <SpellLink
+        icon={true}
+        id={116011}
+      />
+      .
+    </React.Fragment>,
+    "stat": <React.Fragment>
+      20.00% Utilization
+       (
+      &lt;95.00% is recommended
+      )
+    </React.Fragment>,
+  },
+]
+`;
 
 exports[`The Fire Mage Analyzer analyzers MirrorImage matches the statistic snapshot 1`] = `"module inactive"`;
 
@@ -1967,7 +2006,7 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
     </div>
   </li>
   <li
-    className="expandable  passed"
+    className="expandable expanded failed"
   >
     <div
       className="meta"
@@ -1991,8 +2030,8 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
               className="perf-bar"
               style={
                 Object {
-                  "backgroundColor": "#a6c34c",
-                  "width": "89.06298850574713%",
+                  "backgroundColor": "#ffc84a",
+                  "width": "58.34141987829614%",
                 }
               }
             />
@@ -2295,7 +2334,7 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  100.00%
+                  20.00%
                    
                    
                 </div>
@@ -2315,9 +2354,9 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#4ec04e",
+                        "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "100%",
+                        "width": "7.8352941176470585%",
                       }
                     }
                   />

--- a/src/parser/mage/fire/modules/features/Meteor.js
+++ b/src/parser/mage/fire/modules/features/Meteor.js
@@ -31,7 +31,7 @@ class Meteor extends Analyzer {
   }
 
   onMeteor(event) {
-    if (this.selectedCombatant.hasBuff(SPELLS.RUNE_OF_POWER_TALENT.id)) {
+    if (this.selectedCombatant.hasBuff(SPELLS.RUNE_OF_POWER_BUFF.id)) {
       this.badMeteor += 1;
     }
   }


### PR DESCRIPTION
Meteor was using the wrong Spell ID when looking for the Rune of Power Buff so it was always saying that they cast Meteor during Rune of Power when they really didnt.