### PR TITLE
[Mage] Update Spec Combatability to 8.2.5

### DIFF
--- a/src/parser/mage/arcane/CHANGELOG.js
+++ b/src/parser/mage/arcane/CHANGELOG.js
@@ -6,7 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2019, 9, 30), 'Updated Spec Compatability to 8.2.5.',[Sharrq]),
+  change(date(2019, 9, 30), 'Updated Spec Compatibility to 8.2.5.',[Sharrq]),
   change(date(2019, 9, 16), 'Fix a bug where arcane mage mana graph would not show time labels correctly.', fluffels),
   change(date(2019, 8, 6), 'Updated spec compatibility to 8.2.', [Sharrq]),
   change(date(2019, 3, 14), 'Updated spec compatibility to 8.1.5.', [Sharrq]),

--- a/src/parser/mage/arcane/CHANGELOG.js
+++ b/src/parser/mage/arcane/CHANGELOG.js
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 9, 30), 'Updated Spec Compatability to 8.2.5.',[Sharrq]),
   change(date(2019, 9, 16), 'Fix a bug where arcane mage mana graph would not show time labels correctly.', fluffels),
   change(date(2019, 8, 6), 'Updated spec compatibility to 8.2.', [Sharrq]),
   change(date(2019, 3, 14), 'Updated spec compatibility to 8.1.5.', [Sharrq]),

--- a/src/parser/mage/arcane/CONFIG.js
+++ b/src/parser/mage/arcane/CONFIG.js
@@ -10,7 +10,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Sharrq],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '8.2',
+  patchCompatibility: '8.2.5',
   // If set to  false`, the spec will show up as unsupported.
   isSupported: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.

--- a/src/parser/mage/fire/CHANGELOG.js
+++ b/src/parser/mage/fire/CHANGELOG.js
@@ -8,7 +8,7 @@ import ItemLink from 'common/ItemLink';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2019, 9, 30), 'Updated Spec Compatability to 8.2.5.',[Sharrq]),
+  change(date(2019, 9, 30), 'Updated Spec Compatibility to 8.2.5.',[Sharrq]),
   change(date(2019, 9, 25), <>Fixed a bug in <SpellLink id={SPELLS.METEOR_TALENT.id} /> that was incorrectly marking casts as bad if they were cast while empowered by <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} />.</>, Juko8),
   change(date(2019, 9, 19), <>Fixed a bug in <SpellLink id={SPELLS.METEOR_TALENT.id} /> that was looking for the wrong Spell ID for <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} />.</>, [Sharrq]),
   change(date(2019, 9, 3), <>Fixed bug in <SpellLink id={SPELLS.LUCID_DREAMS_MAJOR.id} />.</>, [Sharrq]),

--- a/src/parser/mage/fire/CHANGELOG.js
+++ b/src/parser/mage/fire/CHANGELOG.js
@@ -8,6 +8,7 @@ import ItemLink from 'common/ItemLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 9, 30), 'Updated Spec Compatability to 8.2.5.',[Sharrq]),
   change(date(2019, 9, 25), <>Fixed a bug in <SpellLink id={SPELLS.METEOR_TALENT.id} /> that was incorrectly marking casts as bad if they were cast while empowered by <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} />.</>, Juko8),
   change(date(2019, 9, 19), <>Fixed a bug in <SpellLink id={SPELLS.METEOR_TALENT.id} /> that was looking for the wrong Spell ID for <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} />.</>, [Sharrq]),
   change(date(2019, 9, 3), <>Fixed bug in <SpellLink id={SPELLS.LUCID_DREAMS_MAJOR.id} />.</>, [Sharrq]),

--- a/src/parser/mage/fire/CONFIG.js
+++ b/src/parser/mage/fire/CONFIG.js
@@ -10,7 +10,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Sharrq],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '8.2',
+  patchCompatibility: '8.2.5',
   // If set to  false`, the spec will show up as unsupported.
   isSupported: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.

--- a/src/parser/mage/frost/CHANGELOG.js
+++ b/src/parser/mage/frost/CHANGELOG.js
@@ -6,7 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2019, 9, 30), 'Updated Spec Compatability to 8.2.5.',[Sharrq]),
+  change(date(2019, 9, 30), 'Updated Spec Compatibility to 8.2.5.',[Sharrq]),
   change(date(2019, 8, 6), 'Updated spec compatibility to 8.2.', [Sharrq]),
   change(date(2019, 3, 18), 'Updated statistic boxes to new layout.', [Sharrq]),
   change(date(2019, 3, 14), 'Updated spec compatibility to 8.1.5.', [Sharrq]),

--- a/src/parser/mage/frost/CHANGELOG.js
+++ b/src/parser/mage/frost/CHANGELOG.js
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 9, 30), 'Updated Spec Compatability to 8.2.5.',[Sharrq]),
   change(date(2019, 8, 6), 'Updated spec compatibility to 8.2.', [Sharrq]),
   change(date(2019, 3, 18), 'Updated statistic boxes to new layout.', [Sharrq]),
   change(date(2019, 3, 14), 'Updated spec compatibility to 8.1.5.', [Sharrq]),

--- a/src/parser/mage/frost/CONFIG.js
+++ b/src/parser/mage/frost/CONFIG.js
@@ -12,7 +12,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Sharrq, Dambroda],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '8.2',
+  patchCompatibility: '8.2.5',
   // If set to  false`, the spec will show up as unsupported.
   isSupported: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more. If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.


### PR DESCRIPTION
No changes for mages in 8.2.5, updating compatability to 8.2.5