### PR TITLE
[Windwalker] Update Fists of Fury and ABC

### DIFF
--- a/src/parser/monk/windwalker/CHANGELOG.js
+++ b/src/parser/monk/windwalker/CHANGELOG.js
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 10, 1), <>Updated <SpellLink id={SPELLS.FISTS_OF_FURY_CAST.id} /> to lower expected average ticks when the player uses Cyclotronic Blast</>, Juko8),
   change(date(2019, 10, 1), <>Further updated analysis of <SpellLink id={SPELLS.SPINNING_CRANE_KICK.id} />. Calculations have been made more accurate and statistic now shows average enemies hit instead of average hits per cast.</>, Juko8),
   change(date(2019, 9, 12), <>Updated analysis of <SpellLink id={SPELLS.SPINNING_CRANE_KICK.id} />. Suggestions regarding bad casts were inaccurate and misleading, and have therefore been removed.</>, Juko8),
   change(date(2019, 8, 28), <>Added more support for <SpellLink id={SPELLS.REVERSE_HARM.id} /> including statistic and cast efficiency suggestion </>, Juko8),

--- a/src/parser/monk/windwalker/modules/features/AlwaysBeCasting.js
+++ b/src/parser/monk/windwalker/modules/features/AlwaysBeCasting.js
@@ -6,16 +6,28 @@ import { formatPercentage } from 'common/format';
 import { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 
 class AlwaysBeCasting extends CoreAlwaysBeCasting {
-  suggestions(when) {
-    const deadTimePercentage = this.totalTimeWasted / this.owner.fightDuration;
+  get downtimePercentage() {
+    return this.totalTimeWasted / this.owner.fightDuration;
+  }
 
-    when(deadTimePercentage).isGreaterThan(0.2)
-      .addSuggestion((suggest, actual, recommended) => {
+  get suggestionThresholds() {
+    return {
+      actual: this.downtimePercentage,
+      isGreaterThan: {
+        minor: 0.2,
+        average: 0.3,
+        major: 0.4,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => {
         return suggest(<span>Your downtime can be improved. Try to Always Be Casting (ABC), try to reduce the delay between casting spells.</span>)
           .icon('spell_mage_altertime')
           .actual(`${formatPercentage(actual)}% downtime`)
-          .recommended(`<${formatPercentage(recommended)}% is recommended`)
-          .regular(recommended + 0.15).major(recommended + 0.2);
+          .recommended(`<${formatPercentage(recommended)}% is recommended`);
       });
   }
 


### PR DESCRIPTION
Always Be Casting is mostly the same, just updated to use suggestions the new way.

Fists of Fury now has lower suggestion thresholds when using Cyclotronic since it's common to cancel Fists of Fury for bigger burst when using it. 
