### PR TITLE
[Core] Cast Efficiency Fix

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -8,6 +8,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  change(date(2019, 10, 1), <>Fixed an issue in Cast Efficiency that caused spells to have a time on CD higher than 100%.</>, Sharrq),
   change(date(2019, 9, 30), <>Adjusted phase transitions for Orgozoa, Za'qul, and Queen Azshara to be more accurate.</>, Sharrq),
   change(date(2019, 9, 20), <>Added <ItemLink id={ITEMS.CYCLOTRONIC_BLAST.id} />.</>, Juko8),
   change(date(2019, 9, 20), 'Added 8.2 gems', Juko8),

--- a/src/parser/deathknight/blood/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/deathknight/blood/__snapshots__/CombatLogParser.test.js.snap
@@ -1114,7 +1114,7 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
   className="checklist"
 >
   <li
-    className="expandable  passed"
+    className="expandable expanded failed"
   >
     <div
       className="meta"
@@ -1138,8 +1138,8 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
               className="perf-bar"
               style={
                 Object {
-                  "backgroundColor": "#4ec04e",
-                  "width": "100%",
+                  "backgroundColor": "#ac1f39",
+                  "width": "-457.81291127245913%",
                 }
               }
             />
@@ -1244,7 +1244,7 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
                   }
                 >
                    
-                  96.69%
+                  -992.84%
                    
                    
                 </div>
@@ -1264,9 +1264,9 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#4ec04e",
+                        "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "100%",
+                        "width": "-472.30862019513313%",
                       }
                     }
                   />
@@ -1316,7 +1316,7 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
                   }
                 >
                    
-                  91.94%
+                  -998.46%
                    
                    
                 </div>
@@ -1336,9 +1336,9 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#4ec04e",
+                        "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "100%",
+                        "width": "-443.31720234978513%",
                       }
                     }
                   />
@@ -2284,8 +2284,8 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
               className="perf-bar"
               style={
                 Object {
-                  "backgroundColor": "#ffc84a",
-                  "width": "53.3536913241092%",
+                  "backgroundColor": "#ac1f39",
+                  "width": "-1009.9779694831233%",
                 }
               }
             />
@@ -2390,7 +2390,7 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
                   }
                 >
                    
-                  64.55%
+                  -1077.18%
                    
                    
                 </div>
@@ -2410,9 +2410,9 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#4ec04e",
+                        "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "100%",
+                        "width": "-1024.8625305993633%",
                       }
                     }
                   />
@@ -2534,7 +2534,7 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
                   }
                 >
                    
-                  43.04%
+                  -1061.54%
                    
                    
                 </div>
@@ -2554,9 +2554,9 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#ffc84a",
+                        "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "60.06107397232762%",
+                        "width": "-1009.9779694831233%",
                       }
                     }
                   />

--- a/src/parser/mage/arcane/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/mage/arcane/__snapshots__/CombatLogParser.test.js.snap
@@ -410,7 +410,7 @@ exports[`The Arcane Mage Analyzer should match the checklist snapshot 1`] = `
   className="checklist"
 >
   <li
-    className="expandable  passed"
+    className="expandable expanded failed"
   >
     <div
       className="meta"
@@ -434,8 +434,8 @@ exports[`The Arcane Mage Analyzer should match the checklist snapshot 1`] = `
               className="perf-bar"
               style={
                 Object {
-                  "backgroundColor": "#a6c34c",
-                  "width": "78.59150422960799%",
+                  "backgroundColor": "#ac1f39",
+                  "width": "-196.7702528519747%",
                 }
               }
             />
@@ -612,7 +612,7 @@ exports[`The Arcane Mage Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  68.81%
+                  -1116.36%
                    
                    
                 </div>
@@ -634,7 +634,7 @@ exports[`The Arcane Mage Analyzer should match the checklist snapshot 1`] = `
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "30.55234957947211%",
+                        "width": "-495.6627952636176%",
                       }
                     }
                   />
@@ -756,7 +756,7 @@ exports[`The Arcane Mage Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  87.58%
+                  -1106.80%
                    
                    
                 </div>
@@ -776,9 +776,9 @@ exports[`The Arcane Mage Analyzer should match the checklist snapshot 1`] = `
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#a6c34c",
+                        "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "83.81366733895986%",
+                        "width": "-491.41821614428113%",
                       }
                     }
                   />

--- a/src/parser/mage/fire/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/mage/fire/__snapshots__/CombatLogParser.test.js.snap
@@ -795,7 +795,7 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
   className="checklist"
 >
   <li
-    className="expandable  passed"
+    className="expandable expanded failed"
   >
     <div
       className="meta"
@@ -819,8 +819,8 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
               className="perf-bar"
               style={
                 Object {
-                  "backgroundColor": "#a6c34c",
-                  "width": "79.49747309696245%",
+                  "backgroundColor": "#ac1f39",
+                  "width": "-273.2502436596573%",
                 }
               }
             />
@@ -997,7 +997,7 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  88.07%
+                  -626.37%
                    
                    
                 </div>
@@ -1017,9 +1017,9 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#a6c34c",
+                        "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "87.04442950691704%",
+                        "width": "-278.10801211595424%",
                       }
                     }
                   />
@@ -1069,7 +1069,7 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  111.52%
+                  -604.49%
                    
                    
                 </div>
@@ -1089,9 +1089,9 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#4ec04e",
+                        "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "100%",
+                        "width": "-268.39247520336033%",
                       }
                     }
                   />
@@ -1141,7 +1141,7 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  69.70%
+                  -643.98%
                    
                    
                 </div>
@@ -1163,7 +1163,7 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "30.945462880932766%",
+                        "width": "-285.92865010872737%",
                       }
                     }
                   />

--- a/src/parser/mage/frost/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/mage/frost/__snapshots__/CombatLogParser.test.js.snap
@@ -1093,7 +1093,7 @@ exports[`The Frost Mage Analyzer should match the checklist snapshot 1`] = `
   className="checklist"
 >
   <li
-    className="expandable  passed"
+    className="expandable expanded failed"
   >
     <div
       className="meta"
@@ -1117,8 +1117,8 @@ exports[`The Frost Mage Analyzer should match the checklist snapshot 1`] = `
               className="perf-bar"
               style={
                 Object {
-                  "backgroundColor": "#a6c34c",
-                  "width": "87.48076480642287%",
+                  "backgroundColor": "#ac1f39",
+                  "width": "-181.11605555382616%",
                 }
               }
             />
@@ -1295,7 +1295,7 @@ exports[`The Frost Mage Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  83.75%
+                  -418.57%
                    
                    
                 </div>
@@ -1315,9 +1315,9 @@ exports[`The Frost Mage Analyzer should match the checklist snapshot 1`] = `
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#ffc84a",
+                        "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "62.44229441926863%",
+                        "width": "-185.84368615557028%",
                       }
                     }
                   />
@@ -1367,7 +1367,7 @@ exports[`The Frost Mage Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  93.39%
+                  -407.92%
                    
                    
                 </div>
@@ -1387,9 +1387,9 @@ exports[`The Frost Mage Analyzer should match the checklist snapshot 1`] = `
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#4ec04e",
+                        "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "100%",
+                        "width": "-181.11605555382616%",
                       }
                     }
                   />

--- a/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
@@ -2170,7 +2170,7 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  92.16%
+                  -255.33%
                    
                    
                 </div>
@@ -2190,9 +2190,9 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#4ec04e",
+                        "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "100%",
+                        "width": "-113.36526837437759%",
                       }
                     }
                   />
@@ -2475,7 +2475,7 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  62.65%
+                  -284.60%
                    
                    
                 </div>
@@ -2497,7 +2497,7 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "32.098471647407955%",
+                        "width": "-145.8051956072403%",
                       }
                     }
                   />
@@ -3117,7 +3117,7 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
               style={
                 Object {
                   "backgroundColor": "#ac1f39",
-                  "width": "25.418407290452055%",
+                  "width": "-145.8051956072403%",
                 }
               }
             />
@@ -3236,7 +3236,7 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  62.65%
+                  -284.60%
                    
                    
                 </div>
@@ -3258,7 +3258,7 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "32.098471647407955%",
+                        "width": "-145.8051956072403%",
                       }
                     }
                   />
@@ -3308,7 +3308,7 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  33.18%
+                  -313.93%
                    
                    
                 </div>
@@ -3330,7 +3330,7 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "16.99804326829244%",
+                        "width": "-160.8271530304319%",
                       }
                     }
                   />

--- a/src/parser/paladin/holy/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/paladin/holy/__snapshots__/CombatLogParser.test.js.snap
@@ -5048,7 +5048,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
               style={
                 Object {
                   "backgroundColor": "#ac1f39",
-                  "width": "20.621678817654804%",
+                  "width": "-348.405882342238%",
                 }
               }
             />
@@ -5226,7 +5226,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                   }
                 >
                    
-                  68.23%
+                  -680.07%
                    
                    
                 </div>
@@ -5246,9 +5246,9 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#df7102",
+                        "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "44.06406390122066%",
+                        "width": "-348.405882342238%",
                       }
                     }
                   />
@@ -5298,7 +5298,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                   }
                 >
                    
-                  42.50%
+                  -684.18%
                    
                    
                 </div>
@@ -5320,7 +5320,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "21.7728332870595%",
+                        "width": "-350.51146238300936%",
                       }
                     }
                   />
@@ -5370,7 +5370,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                   }
                 >
                    
-                  51.45%
+                  -697.89%
                    
                    
                 </div>
@@ -5392,7 +5392,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "24.475520625438733%",
+                        "width": "-331.99538856692874%",
                       }
                     }
                   />
@@ -5442,7 +5442,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                   }
                 >
                    
-                  11.86%
+                  -733.63%
                    
                    
                 </div>
@@ -5464,7 +5464,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "7.179639899555116%",
+                        "width": "-444.1784439666702%",
                       }
                     }
                   />
@@ -5573,7 +5573,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
     </div>
   </li>
   <li
-    className="expandable  passed"
+    className="expandable expanded failed"
   >
     <div
       className="meta"
@@ -5597,8 +5597,8 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
               className="perf-bar"
               style={
                 Object {
-                  "backgroundColor": "#4ec04e",
-                  "width": "100%",
+                  "backgroundColor": "#ac1f39",
+                  "width": "-422.14835942626524%",
                 }
               }
             />
@@ -5710,7 +5710,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                   }
                 >
                    
-                  88.94%
+                  -675.10%
                    
                    
                 </div>
@@ -5730,9 +5730,9 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#4ec04e",
+                        "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "100%",
+                        "width": "-345.8564511522185%",
                       }
                     }
                   />
@@ -5782,7 +5782,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                   }
                 >
                    
-                  88.94%
+                  -673.57%
                    
                    
                 </div>
@@ -5802,9 +5802,9 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#4ec04e",
+                        "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "100%",
+                        "width": "-498.44026770031206%",
                       }
                     }
                   />
@@ -7864,7 +7864,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
               style={
                 Object {
                   "backgroundColor": "#ac1f39",
-                  "width": "5.695387420320162%",
+                  "width": "-156.995177981332%",
                 }
               }
             />
@@ -8041,7 +8041,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                   }
                 >
                    
-                  11.12%
+                  -674.26%
                    
                    
                 </div>
@@ -8063,7 +8063,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "5.695387420320162%",
+                        "width": "-345.4267658123966%",
                       }
                     }
                   />
@@ -8113,7 +8113,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                   }
                 >
                    
-                  29.65%
+                  -729.12%
                    
                    
                 </div>
@@ -8135,7 +8135,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "21.93778858197396%",
+                        "width": "-539.5491240942633%",
                       }
                     }
                   />

--- a/src/parser/paladin/protection/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/paladin/protection/__snapshots__/CombatLogParser.test.js.snap
@@ -556,7 +556,7 @@ exports[`The Protection Paladin Analyzer should match the checklist snapshot 1`]
               style={
                 Object {
                   "backgroundColor": "#df7102",
-                  "width": "46.72776467824141%",
+                  "width": "42.44084499331257%",
                 }
               }
             />
@@ -733,7 +733,7 @@ exports[`The Protection Paladin Analyzer should match the checklist snapshot 1`]
                   }
                 >
                    
-                  81.92%
+                  79.93%
                    
                    
                 </div>
@@ -753,9 +753,9 @@ exports[`The Protection Paladin Analyzer should match the checklist snapshot 1`]
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#ffc84a",
+                        "backgroundColor": "#df7102",
                         "transition": "background-color 800ms",
-                        "width": "56.34944865788687%",
+                        "width": "49.70891510844192%",
                       }
                     }
                   />
@@ -805,7 +805,7 @@ exports[`The Protection Paladin Analyzer should match the checklist snapshot 1`]
                   }
                 >
                    
-                  66.14%
+                  65.56%
                    
                    
                 </div>
@@ -827,7 +827,7 @@ exports[`The Protection Paladin Analyzer should match the checklist snapshot 1`]
                       Object {
                         "backgroundColor": "#df7102",
                         "transition": "background-color 800ms",
-                        "width": "37.106080698595946%",
+                        "width": "35.17277487818321%",
                       }
                     }
                   />
@@ -1454,7 +1454,7 @@ exports[`The Protection Paladin Analyzer should match the checklist snapshot 1`]
               style={
                 Object {
                   "backgroundColor": "#ffc84a",
-                  "width": "64.79189793087662%",
+                  "width": "64.6652930857104%",
                 }
               }
             />
@@ -1574,7 +1574,7 @@ exports[`The Protection Paladin Analyzer should match the checklist snapshot 1`]
                   }
                 >
                    
-                  13.01%
+                  12.50%
                    
                    
                 </div>
@@ -1596,7 +1596,7 @@ exports[`The Protection Paladin Analyzer should match the checklist snapshot 1`]
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "9.627093792629852%",
+                        "width": "9.247279257131217%",
                       }
                     }
                   />

--- a/src/parser/shared/modules/CastEfficiency.js
+++ b/src/parser/shared/modules/CastEfficiency.js
@@ -258,6 +258,7 @@ class CastEfficiency extends Analyzer {
     } else {
       // Cast efficiency calculated as the percent of fight time spell was unavailable
       // The spell is considered unavailable if it is on cooldown, the time since it came off cooldown is less than the cast time or the cooldown was reset through a proc during a GCD
+      // Time Offset reduces the Unavailable time to account for the portion of the CD that extended beyond the end of the fight
       if (cooldown && availableFightDuration) {
         const timeOnCd = cdInfo.completedRechargeTime + cdInfo.endingRechargeTime;
         const lastCastTimestamp = cdInfo.castTimes && cdInfo.castTimes[(cdInfo.castTimes).length - 1];

--- a/src/parser/shared/modules/CastEfficiency.js
+++ b/src/parser/shared/modules/CastEfficiency.js
@@ -77,11 +77,15 @@ class CastEfficiency extends Analyzer {
 
     const casts = history.filter(event => event.type === 'cast').length;
 
+    const castEvents = history.filter(event => event.type === 'cast');
+    const castTimes = castEvents.map(event => event.timestamp);
+
     return {
       completedRechargeTime,
       endingRechargeTime,
       recharges,
       casts,
+      castTimes,
     };
   }
 
@@ -256,7 +260,9 @@ class CastEfficiency extends Analyzer {
       // The spell is considered unavailable if it is on cooldown, the time since it came off cooldown is less than the cast time or the cooldown was reset through a proc during a GCD
       if (cooldown && availableFightDuration) {
         const timeOnCd = cdInfo.completedRechargeTime + cdInfo.endingRechargeTime;
-        const timeUnavailable = timeOnCd + timeSpentCasting + timeWaitingOnGCD;
+        const lastCastTimestamp = cdInfo.castTimes && cdInfo.castTimes[(cdInfo.castTimes).length - 1];
+        const timeOffset = lastCastTimestamp + (cooldown * 1000) > availableFightDuration ? (cooldown * 1000) - (availableFightDuration - lastCastTimestamp) : 0;
+        const timeUnavailable = timeOnCd + timeSpentCasting + timeWaitingOnGCD - timeOffset;
         efficiency = timeUnavailable / availableFightDuration;
       } else if (includeNoCooldownEfficiency) {
         efficiency = casts / rawMaxCasts;

--- a/src/parser/shared/modules/CastEfficiency.js
+++ b/src/parser/shared/modules/CastEfficiency.js
@@ -44,6 +44,7 @@ class CastEfficiency extends Analyzer {
         endingRechargeTime: 0,
         recharges: 0,
         casts: 0,
+        castTimestamps: [],
       };
     }
 
@@ -78,14 +79,14 @@ class CastEfficiency extends Analyzer {
     const casts = history.filter(event => event.type === 'cast').length;
 
     const castEvents = history.filter(event => event.type === 'cast');
-    const castTimes = castEvents.map(event => event.timestamp);
+    const castTimestamps = castEvents.map(event => event.timestamp);
 
     return {
       completedRechargeTime,
       endingRechargeTime,
       recharges,
       casts,
-      castTimes,
+      castTimestamps,
     };
   }
 
@@ -261,7 +262,7 @@ class CastEfficiency extends Analyzer {
       // Time Offset reduces the Unavailable time to account for the portion of the CD that extended beyond the end of the fight
       if (cooldown && availableFightDuration) {
         const timeOnCd = cdInfo.completedRechargeTime + cdInfo.endingRechargeTime;
-        const lastCastTimestamp = cdInfo.castTimes && cdInfo.castTimes[(cdInfo.castTimes).length - 1];
+        const lastCastTimestamp = cdInfo.castTimestamps[(cdInfo.castTimestamps).length - 1];
         const timeOffset = lastCastTimestamp + (cooldown * 1000) > availableFightDuration ? (cooldown * 1000) - (availableFightDuration - lastCastTimestamp) : 0;
         const timeUnavailable = timeOnCd + timeSpentCasting + timeWaitingOnGCD - timeOffset;
         efficiency = timeUnavailable / availableFightDuration;


### PR DESCRIPTION
Cast Efficiency was showing > 100% for the Time on Cooldown for a lot of spells.
This was because when calculating the Time on CD, it was essentially doing (SpellCooldown * SpellCasts / FightDuration).

So the remaining cooldown of the spell beyond the end of the fight was counting towards the time on cooldown.

![image](https://user-images.githubusercontent.com/1304554/65982025-f53d0400-e43f-11e9-8d8a-cd1b03cf0a5a.png)

In the above example, Combustion was cast 3 times (120 second cooldown each) and the fight was 299 seconds long. 
So it was doing 360/299= 120%

Instead it should have been 2 casts for 120s each and a third for 33s to total 273/299

![image](https://user-images.githubusercontent.com/1304554/65981142-1c92d180-e43e-11e9-9710-55b409c3db0c.png)


I am not sure if this is the best way to fix it or not, but its the only way i could make it work.