### PR TITLE
[Arcane Mage] Remove AP Check on Fight End

### DIFF
--- a/src/parser/mage/arcane/CHANGELOG.js
+++ b/src/parser/mage/arcane/CHANGELOG.js
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 10, 1), <>Removed the check to see if <SpellLink id={SPELLS.ARCANE_POWER.id} /> was available when the fight ended.</>,[Sharrq]),
   change(date(2019, 9, 30), 'Updated Spec Compatibility to 8.2.5.',[Sharrq]),
   change(date(2019, 9, 16), 'Fix a bug where arcane mage mana graph would not show time labels correctly.', fluffels),
   change(date(2019, 8, 6), 'Updated spec compatibility to 8.2.', [Sharrq]),

--- a/src/parser/mage/arcane/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/mage/arcane/__snapshots__/CombatLogParser.test.js.snap
@@ -123,7 +123,7 @@ exports[`The Arcane Mage Analyzer analyzers ArcanePower matches the statistic sn
             />
           </a>
            
-          98
+          0
            %
         </div>
       </div>
@@ -149,62 +149,7 @@ exports[`The Arcane Mage Analyzer analyzers ArcanePower matches the statistic sn
 </div>
 `;
 
-exports[`The Arcane Mage Analyzer analyzers ArcanePower matches the suggestions snapshot 1`] = `
-Array [
-  Object {
-    "details": null,
-    "icon": "spell_nature_lightning",
-    "importance": "minor",
-    "issue": <React.Fragment>
-      You cast spells other than 
-      <SpellLink
-        icon={true}
-        id={30451}
-      />
-      ,
-      <SpellLink
-        icon={true}
-        id={5143}
-      />
-      , 
-      <SpellLink
-        icon={true}
-        id={1449}
-      />
-      , and 
-      <SpellLink
-        icon={true}
-        id={205025}
-      />
-       during 
-      <SpellLink
-        icon={true}
-        id={12042}
-      />
-      . Arcane Power is a short duration, so you should ensure that you are getting the most use out of it. Buff spells like Rune of Power should be cast immediately before casting Arcane Power. Other spells such as Charged Up, Blink/Shimmer, etc are acceptable during Arcane Power, but should be avoided if possible.
-    </React.Fragment>,
-    "stat": <React.Fragment>
-      98.00% Utilization
-       (
-      100.00% is recommended
-      )
-    </React.Fragment>,
-  },
-  Object {
-    "details": null,
-    "icon": "spell_nature_lightning",
-    "importance": "regular",
-    "issue": <React.Fragment>
-      <SpellLink
-        icon={true}
-        id={12042}
-      />
-       was available to be cast when the boss died. You should ensure that you are casting Arcane Power on cooldown, especially at the end of the fight to get a little bit of last minute damage into the boss.
-    </React.Fragment>,
-    "stat": null,
-  },
-]
-`;
+exports[`The Arcane Mage Analyzer analyzers ArcanePower matches the suggestions snapshot 1`] = `Array []`;
 
 exports[`The Arcane Mage Analyzer analyzers Buffs matches the statistic snapshot 1`] = `"module has no statistic method"`;
 
@@ -791,7 +736,7 @@ exports[`The Arcane Mage Analyzer should match the checklist snapshot 1`] = `
     </div>
   </li>
   <li
-    className="expandable expanded failed"
+    className="expandable  passed"
   >
     <div
       className="meta"
@@ -815,8 +760,8 @@ exports[`The Arcane Mage Analyzer should match the checklist snapshot 1`] = `
               className="perf-bar"
               style={
                 Object {
-                  "backgroundColor": "#ffc84a",
-                  "width": "62.193333333333335%",
+                  "backgroundColor": "#4ec04e",
+                  "width": "100%",
                 }
               }
             />
@@ -953,7 +898,7 @@ exports[`The Arcane Mage Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  98.00%
+                  0.00%
                    
                    
                 </div>
@@ -973,9 +918,9 @@ exports[`The Arcane Mage Analyzer should match the checklist snapshot 1`] = `
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#a6c34c",
+                        "backgroundColor": "#4ec04e",
                         "transition": "background-color 800ms",
-                        "width": "86.58%",
+                        "width": "100%",
                       }
                     }
                   />
@@ -1066,96 +1011,6 @@ exports[`The Arcane Mage Analyzer should match the checklist snapshot 1`] = `
                         "backgroundColor": "#4ec04e",
                         "transition": "background-color 800ms",
                         "width": "100%",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="col-md-6"
-          >
-            <div
-              className="flex"
-            >
-              <div
-                className="flex-main"
-              >
-                Arcane Power Available on Kill
-              </div>
-              <div
-                className="flex-sub"
-                style={
-                  Object {
-                    "marginLeft": 10,
-                  }
-                }
-              >
-                <div
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onTouchStart={[Function]}
-                >
-                  <svg
-                    className="icon"
-                    viewBox="0 0 100 100"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M53.1,73h-7.2c-1.1,0-1.9-0.9-1.9-1.9V44h11v27.1C55,72.1,54.1,73,53.1,73z"
-                    />
-                    <path
-                      d="M55,39H44v-9.1c0-1.1,0.9-1.9,1.9-1.9h7.2c1.1,0,1.9,0.9,1.9,1.9V39z"
-                    />
-                    <path
-                      d="M50,96C24.6,96,4,75.4,4,50S24.6,4,50,4s46,20.6,46,46S75.4,96,50,96z M50,12c-21,0-38,17-38,38s17,38,38,38s38-17,38-38   S71,12,50,12z"
-                    />
-                  </svg>
-                </div>
-              </div>
-              <div
-                className="flex-sub content-middle text-muted"
-                style={
-                  Object {
-                    "marginLeft": 5,
-                    "marginRight": 10,
-                    "minWidth": 55,
-                  }
-                }
-              >
-                <div
-                  className="text-right"
-                  style={
-                    Object {
-                      "width": "100%",
-                    }
-                  }
-                >
-                   
-                  Yes
-                   
-                   
-                </div>
-              </div>
-              <div
-                className="flex-sub content-middle"
-                style={
-                  Object {
-                    "width": 50,
-                  }
-                }
-              >
-                <div
-                  className="performance-bar-container"
-                >
-                  <div
-                    className="performance-bar small"
-                    style={
-                      Object {
-                        "backgroundColor": "#ac1f39",
-                        "transition": "background-color 800ms",
-                        "width": "0%",
                       }
                     }
                   />

--- a/src/parser/mage/arcane/modules/Checklist/Component.js
+++ b/src/parser/mage/arcane/modules/Checklist/Component.js
@@ -66,11 +66,6 @@ class ArcaneMageChecklist extends React.PureComponent {
             tooltip="In order to effectively utilize Arcane Power, there are certain things you need to ensure are setup before you cast Arcane Power. Making sure you have 4 Arcane Charges, You have more than 40% Mana (Unless you have the Overpowered Talent), and ensuring you cast Rune of Power immediately before Arcane Power (if you have Rune of Power talented) will all help make the most out of your burn phase."
             thresholds={thresholds.arcanePowerCooldown}
           />
-          <Requirement
-            name="Arcane Power Available on Kill"
-            tooltip="Seeing as the boss is about to die, you should always ensure that Arcane Power is on cooldown when the boss dies. Even if you will only get half the duration out of it you should still cast it to get a boost in damage at the end."
-            thresholds={thresholds.arcanePowerOnKill}
-          />
 
         </Rule>
         <Rule

--- a/src/parser/mage/arcane/modules/Checklist/Module.js
+++ b/src/parser/mage/arcane/modules/Checklist/Module.js
@@ -53,7 +53,6 @@ class Checklist extends BaseChecklist {
           arcanePowerCooldown: this.arcanePower.cooldownSuggestionThresholds,
           arcanePowerManaUtilization: this.arcanePower.manaUtilizationThresholds,
           arcanePowerCasts: this.arcanePower.castSuggestionThresholds,
-          arcanePowerOnKill: this.arcanePower.arcanePowerOnKillSuggestionThresholds,
           ruleOfThreesUsage: this.ruleOfThrees.suggestionThresholds,
           timeAnomalyManaUtilization: this.timeAnomaly.manaUtilizationThresholds,
           arcaneMissilesUtilization: this.arcaneMissiles.missilesSuggestionThresholds,

--- a/src/parser/mage/arcane/modules/features/ArcanePower.js
+++ b/src/parser/mage/arcane/modules/features/ArcanePower.js
@@ -8,7 +8,6 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 import { TooltipElement } from 'common/Tooltip';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
-import SpellHistory from 'parser/shared/modules/SpellHistory';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import DeathTracker from 'parser/shared/modules/DeathTracker';
 import SpellManaCost from 'parser/shared/modules/SpellManaCost';
@@ -39,7 +38,6 @@ class ArcanePower extends Analyzer {
     deathTracker: DeathTracker,
     // Needed for the `resourceCost` prop of events
     spellManaCost: SpellManaCost,
-    spellHistory: SpellHistory,
   };
 
   badUses = 0;


### PR DESCRIPTION
SpellUsable is reporting that Arcane Power is off CD and available to be cast at the end of the fight when it 100% is not. Removing the check until i figure out why it thinks it is off CD.