### PR TITLE
[MW] Lifecycles Bug Fix - Vivify

### DIFF
--- a/src/parser/monk/mistweaver/CHANGELOG.js
+++ b/src/parser/monk/mistweaver/CHANGELOG.js
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 10, 1), <>Bugfix for Lifecycles adding the potential mana reduction from an empowered <SpellLink id={SPELLS.VIVIFY.id} /> </>,Anomoly),
   change(date(2019, 9, 27), <>Update to date for 8.2.5 </>,Abelito75),
   change(date(2019, 8, 17), <>Fixed bug where you could have NaN mana tea overhealing.</>, Abelito75),
   change(date(2019, 8, 14), <>Wotc infographic now checks for physical damage only.</>, Abelito75),

--- a/src/parser/monk/mistweaver/modules/talents/Lifecycles.js
+++ b/src/parser/monk/mistweaver/modules/talents/Lifecycles.js
@@ -31,8 +31,17 @@ class Lifecycles extends Analyzer {
 
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
+
+    
+
     // Checking to ensure player has cast Vivify and has the mana reduction buff.
     if (spellId === SPELLS.VIVIFY.id && this.selectedCombatant.hasBuff(SPELLS.LIFECYCLES_VIVIFY_BUFF.id)) {
+
+      // Checking for TFT->Viv and classify as non-reduced Viv
+      if (this.selectedCombatant.hasBuff(SPELLS.THUNDER_FOCUS_TEA.id)) {
+        this.castsNonRedViv += 1;
+        return;
+      }
       this.manaSaved += SPELLS.VIVIFY.manaCost * (SPELLS.LIFECYCLES_VIVIFY_BUFF.manaPercRed);
       this.manaSavedViv += SPELLS.VIVIFY.manaCost * (SPELLS.LIFECYCLES_VIVIFY_BUFF.manaPercRed);
       this.castsRedViv += 1;


### PR DESCRIPTION
Small bug fix to remove excess mana saved from the calculation when a TFT empowered Vivify is cast with the Lifecycles buff.