### PR TITLE
[Core] Cast Efficiency Fix (Attempt 2)

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -8,6 +8,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  change(date(2019, 10, 2), <>Fixed an issue in Cast Efficiency that caused spells to have a time on CD higher than 100%.</>, Sharrq),
   change(date(2019, 9, 30), <>Adjusted phase transitions for Orgozoa, Za'qul, and Queen Azshara to be more accurate.</>, Sharrq),
   change(date(2019, 9, 20), <>Added <ItemLink id={ITEMS.CYCLOTRONIC_BLAST.id} />.</>, Juko8),
   change(date(2019, 9, 20), 'Added 8.2 gems', Juko8),

--- a/src/parser/deathknight/blood/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/deathknight/blood/__snapshots__/CombatLogParser.test.js.snap
@@ -1138,8 +1138,8 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
               className="perf-bar"
               style={
                 Object {
-                  "backgroundColor": "#4ec04e",
-                  "width": "100%",
+                  "backgroundColor": "#a6c34c",
+                  "width": "93.54088992016754%",
                 }
               }
             />
@@ -1244,7 +1244,7 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
                   }
                 >
                    
-                  96.69%
+                  93.70%
                    
                    
                 </div>
@@ -1316,7 +1316,7 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
                   }
                 >
                    
-                  91.94%
+                  88.08%
                    
                    
                 </div>
@@ -1336,9 +1336,9 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#4ec04e",
+                        "backgroundColor": "#a6c34c",
                         "transition": "background-color 800ms",
-                        "width": "100%",
+                        "width": "87.08177984033509%",
                       }
                     }
                   />
@@ -2284,8 +2284,8 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
               className="perf-bar"
               style={
                 Object {
-                  "backgroundColor": "#ffc84a",
-                  "width": "53.3536913241092%",
+                  "backgroundColor": "#ac1f39",
+                  "width": "8.900300127367128%",
                 }
               }
             />
@@ -2390,7 +2390,7 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
                   }
                 >
                    
-                  64.55%
+                  9.35%
                    
                    
                 </div>
@@ -2410,9 +2410,9 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#4ec04e",
+                        "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "100%",
+                        "width": "8.900300127367128%",
                       }
                     }
                   />
@@ -2534,7 +2534,7 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
                   }
                 >
                    
-                  43.04%
+                  25.00%
                    
                    
                 </div>
@@ -2554,9 +2554,9 @@ exports[`The Blood Deathknight Analyzer should match the checklist snapshot 1`] 
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#ffc84a",
+                        "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "60.06107397232762%",
+                        "width": "23.784861243607313%",
                       }
                     }
                   />

--- a/src/parser/mage/arcane/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/mage/arcane/__snapshots__/CombatLogParser.test.js.snap
@@ -380,7 +380,7 @@ exports[`The Arcane Mage Analyzer should match the checklist snapshot 1`] = `
               style={
                 Object {
                   "backgroundColor": "#a6c34c",
-                  "width": "78.59150422960799%",
+                  "width": "72.07486774111928%",
                 }
               }
             />
@@ -701,7 +701,7 @@ exports[`The Arcane Mage Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  87.58%
+                  82.34%
                    
                    
                 </div>
@@ -721,9 +721,9 @@ exports[`The Arcane Mage Analyzer should match the checklist snapshot 1`] = `
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#a6c34c",
+                        "backgroundColor": "#ffc84a",
                         "transition": "background-color 800ms",
-                        "width": "83.81366733895986%",
+                        "width": "57.747121385005016%",
                       }
                     }
                   />

--- a/src/parser/mage/fire/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/mage/fire/__snapshots__/CombatLogParser.test.js.snap
@@ -848,7 +848,7 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
               style={
                 Object {
                   "backgroundColor": "#a6c34c",
-                  "width": "79.49747309696245%",
+                  "width": "76.9403110420353%",
                 }
               }
             />
@@ -1025,7 +1025,7 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  88.07%
+                  86.58%
                    
                    
                 </div>
@@ -1047,7 +1047,7 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
                       Object {
                         "backgroundColor": "#a6c34c",
                         "transition": "background-color 800ms",
-                        "width": "87.04442950691704%",
+                        "width": "77.13926452585714%",
                       }
                     }
                   />
@@ -1097,7 +1097,7 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  111.52%
+                  108.46%
                    
                    
                 </div>
@@ -1169,7 +1169,7 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  69.70%
+                  68.97%
                    
                    
                 </div>
@@ -1191,7 +1191,7 @@ exports[`The Fire Mage Analyzer should match the checklist snapshot 1`] = `
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "30.945462880932766%",
+                        "width": "30.621979642284074%",
                       }
                     }
                   />

--- a/src/parser/mage/frost/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/mage/frost/__snapshots__/CombatLogParser.test.js.snap
@@ -1118,7 +1118,7 @@ exports[`The Frost Mage Analyzer should match the checklist snapshot 1`] = `
               style={
                 Object {
                   "backgroundColor": "#a6c34c",
-                  "width": "87.48076480642287%",
+                  "width": "83.82960165374769%",
                 }
               }
             />
@@ -1295,7 +1295,7 @@ exports[`The Frost Mage Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  83.75%
+                  80.46%
                    
                    
                 </div>
@@ -1317,7 +1317,7 @@ exports[`The Frost Mage Analyzer should match the checklist snapshot 1`] = `
                       Object {
                         "backgroundColor": "#ffc84a",
                         "transition": "background-color 800ms",
-                        "width": "62.44229441926863%",
+                        "width": "51.488804961243076%",
                       }
                     }
                   />
@@ -1367,7 +1367,7 @@ exports[`The Frost Mage Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  93.39%
+                  91.11%
                    
                    
                 </div>

--- a/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
@@ -2170,7 +2170,7 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  92.16%
+                  90.95%
                    
                    
                 </div>
@@ -2475,7 +2475,7 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  62.65%
+                  61.68%
                    
                    
                 </div>
@@ -2497,7 +2497,7 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "32.098471647407955%",
+                        "width": "31.596716084606978%",
                       }
                     }
                   />
@@ -3117,7 +3117,7 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
               style={
                 Object {
                   "backgroundColor": "#ac1f39",
-                  "width": "25.418407290452055%",
+                  "width": "25.11006056722603%",
                 }
               }
             />
@@ -3236,7 +3236,7 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  62.65%
+                  61.68%
                    
                    
                 </div>
@@ -3258,7 +3258,7 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "32.098471647407955%",
+                        "width": "31.596716084606978%",
                       }
                     }
                   />
@@ -3308,7 +3308,7 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
                   }
                 >
                    
-                  33.18%
+                  32.35%
                    
                    
                 </div>
@@ -3330,7 +3330,7 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "16.99804326829244%",
+                        "width": "16.574758661415352%",
                       }
                     }
                   />

--- a/src/parser/paladin/holy/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/paladin/holy/__snapshots__/CombatLogParser.test.js.snap
@@ -5048,7 +5048,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
               style={
                 Object {
                   "backgroundColor": "#ac1f39",
-                  "width": "20.621678817654804%",
+                  "width": "20.55351845746216%",
                 }
               }
             />
@@ -5370,7 +5370,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                   }
                 >
                    
-                  51.45%
+                  50.73%
                    
                    
                 </div>
@@ -5392,7 +5392,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "24.475520625438733%",
+                        "width": "24.13471882447553%",
                       }
                     }
                   />
@@ -5597,8 +5597,8 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
               className="perf-bar"
               style={
                 Object {
-                  "backgroundColor": "#4ec04e",
-                  "width": "100%",
+                  "backgroundColor": "#a6c34c",
+                  "width": "80.84690962520474%",
                 }
               }
             />
@@ -5710,7 +5710,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                   }
                 >
                    
-                  88.94%
+                  73.53%
                    
                    
                 </div>
@@ -5730,9 +5730,9 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#4ec04e",
+                        "backgroundColor": "#ffc84a",
                         "transition": "background-color 800ms",
-                        "width": "100%",
+                        "width": "61.69381925040949%",
                       }
                     }
                   />
@@ -5782,7 +5782,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                   }
                 >
                    
-                  88.94%
+                  75.05%
                    
                    
                 </div>
@@ -8113,7 +8113,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                   }
                 >
                    
-                  29.65%
+                  19.50%
                    
                    
                 </div>
@@ -8135,7 +8135,7 @@ exports[`Holy Paladin integration test should match the checklist snapshot 1`] =
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "21.93778858197396%",
+                        "width": "14.431042959032172%",
                       }
                     }
                   />

--- a/src/parser/paladin/protection/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/paladin/protection/__snapshots__/CombatLogParser.test.js.snap
@@ -556,7 +556,7 @@ exports[`The Protection Paladin Analyzer should match the checklist snapshot 1`]
               style={
                 Object {
                   "backgroundColor": "#df7102",
-                  "width": "46.72776467824141%",
+                  "width": "42.44084499331257%",
                 }
               }
             />
@@ -733,7 +733,7 @@ exports[`The Protection Paladin Analyzer should match the checklist snapshot 1`]
                   }
                 >
                    
-                  81.92%
+                  79.93%
                    
                    
                 </div>
@@ -753,9 +753,9 @@ exports[`The Protection Paladin Analyzer should match the checklist snapshot 1`]
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#ffc84a",
+                        "backgroundColor": "#df7102",
                         "transition": "background-color 800ms",
-                        "width": "56.34944865788687%",
+                        "width": "49.70891510844192%",
                       }
                     }
                   />
@@ -805,7 +805,7 @@ exports[`The Protection Paladin Analyzer should match the checklist snapshot 1`]
                   }
                 >
                    
-                  66.14%
+                  65.56%
                    
                    
                 </div>
@@ -827,7 +827,7 @@ exports[`The Protection Paladin Analyzer should match the checklist snapshot 1`]
                       Object {
                         "backgroundColor": "#df7102",
                         "transition": "background-color 800ms",
-                        "width": "37.106080698595946%",
+                        "width": "35.17277487818321%",
                       }
                     }
                   />
@@ -1454,7 +1454,7 @@ exports[`The Protection Paladin Analyzer should match the checklist snapshot 1`]
               style={
                 Object {
                   "backgroundColor": "#ffc84a",
-                  "width": "64.79189793087662%",
+                  "width": "64.6652930857104%",
                 }
               }
             />
@@ -1574,7 +1574,7 @@ exports[`The Protection Paladin Analyzer should match the checklist snapshot 1`]
                   }
                 >
                    
-                  13.01%
+                  12.50%
                    
                    
                 </div>
@@ -1596,7 +1596,7 @@ exports[`The Protection Paladin Analyzer should match the checklist snapshot 1`]
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "9.627093792629852%",
+                        "width": "9.247279257131217%",
                       }
                     }
                   />


### PR DESCRIPTION
Cast Efficiency was showing > 100% for the Time on Cooldown for a lot of spells.
This was because when calculating the Time on CD, it was essentially doing (SpellCooldown * SpellCasts / FightDuration).

So the remaining cooldown of the spell beyond the end of the fight was counting towards the time on cooldown.

![image](https://user-images.githubusercontent.com/1304554/65982025-f53d0400-e43f-11e9-8d8a-cd1b03cf0a5a.png)

In the above example, Combustion was cast 3 times (120 second cooldown each) and the fight was 299 seconds long. 
So it was doing 360/299= 120%

Instead it should have been 2 casts for 120s each and a third for 33s to total 273/299

![image](https://user-images.githubusercontent.com/1304554/65981142-1c92d180-e43e-11e9-9710-55b409c3db0c.png)


I am not sure if this is the best way to fix it or not, but its the only way i could make it work.