### PR TITLE
[RDruid] patch update

### DIFF
--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -756,3 +756,32 @@ export const fluffels = {
     link: 'https://worldofwarcraft.com/en-gb/character/eu/draenor/micheladaw',
   }],
 };
+export const JeremyDwayne = {
+  nickname: 'JeremyDwayne',
+  github: 'jeremydwayne',
+  discord: 'jeremydwayne#3717',
+  mains: [
+    {
+      name: 'Jeremydwayne',
+      spec: SPECS.MISTWEAVER_MONK,
+      link: 'https://worldofwarcraft.com/en-us/character/us/stormrage/jeremydwayne',
+    }
+  ],
+  alts: [
+    {
+      name: 'Jeremypally',
+      spec: SPECS.HOLY_PALADIN,
+      link: 'https://worldofwarcraft.com/en-us/character/us/stormrage/jeremypally',
+    },
+    {
+      name: 'Morehots',
+      spec: SPECS.RESTORATION_DRUID,
+      link: 'https://worldofwarcraft.com/en-us/character/us/stormrage/morehots',
+    },
+    {
+      name: 'Dovesoap',
+      spec: SPECS.DISCIPLINE_PRIEST,
+      link: 'https://worldofwarcraft.com/en-us/character/us/stormrage/dovesoap',
+    }
+  ],
+};

--- a/src/CONTRIBUTORS.js
+++ b/src/CONTRIBUTORS.js
@@ -765,7 +765,7 @@ export const JeremyDwayne = {
       name: 'Jeremydwayne',
       spec: SPECS.MISTWEAVER_MONK,
       link: 'https://worldofwarcraft.com/en-us/character/us/stormrage/jeremydwayne',
-    }
+    },
   ],
   alts: [
     {
@@ -782,6 +782,6 @@ export const JeremyDwayne = {
       name: 'Dovesoap',
       spec: SPECS.DISCIPLINE_PRIEST,
       link: 'https://worldofwarcraft.com/en-us/character/us/stormrage/dovesoap',
-    }
+    },
   ],
 };

--- a/src/parser/druid/restoration/CHANGELOG.js
+++ b/src/parser/druid/restoration/CHANGELOG.js
@@ -1,10 +1,11 @@
 // eslint-disable-next-line no-unused-vars
 import React from 'react';
 
-import { Yajinni, blazyb, fel1ne, Qbz, Zerotorescue, Abelito75, Anatta336 } from 'CONTRIBUTORS';
+import { Yajinni, blazyb, fel1ne, Qbz, Zerotorescue, Abelito75, Anatta336, JeremyDwayne } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 10, 4), 'No spec changes have occurred, restoration druid module is compatible with patch 8.2.5', [JeremyDwayne]),
   change(date(2019, 8, 18), 'Corrected some global cooldown values related to catweaving.', [Anatta336]),
   change(date(2019, 8, 12), 'Added essence Lucid Dreams.', [blazyb]),
   change(date(2019, 6, 2), 'Enabled the QElive auto import link for stat values.', [Abelito75]),

--- a/src/parser/druid/restoration/CONFIG.js
+++ b/src/parser/druid/restoration/CONFIG.js
@@ -10,7 +10,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [blazyb],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '8.1.5',
+  patchCompatibility: '8.2.5',
   // If set to  false`, the spec will show up as unsupported.
   isSupported: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.


### PR DESCRIPTION
No spec changes have occurred, the restoration druid module is compatible with patch 8.2.5.