### PR TITLE
[MW] Bugfix SCK

### DIFF
--- a/src/parser/monk/mistweaver/CHANGELOG.js
+++ b/src/parser/monk/mistweaver/CHANGELOG.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { Anomoly, Gao, Zerotorescue, Abelito75, niseko, blazyb } from 'CONTRIBUTORS';
+import { Anomoly, Gao, Zerotorescue, Abelito75, niseko, blazyb, JeremyDwayne } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 10, 4), <>Added missing array declaration for enemiesHitSCK <SpellLink id={SPELLS.SPINNING_CRANE_KICK.id}/>.</>, JeremyDwayne),
   change(date(2019, 10, 1), <>Bugfix for Lifecycles adding the potential mana reduction from an empowered <SpellLink id={SPELLS.VIVIFY.id} /> </>,Anomoly),
   change(date(2019, 9, 27), <>Update to date for 8.2.5 </>,Abelito75),
   change(date(2019, 8, 17), <>Fixed bug where you could have NaN mana tea overhealing.</>, Abelito75),

--- a/src/parser/monk/mistweaver/CHANGELOG.js
+++ b/src/parser/monk/mistweaver/CHANGELOG.js
@@ -6,7 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2019, 10, 4), <>Added missing array declaration for enemiesHitSCK <SpellLink id={SPELLS.SPINNING_CRANE_KICK.id}/>.</>, JeremyDwayne),
+  change(date(2019, 10, 4), <>Added missing array declaration for enemiesHitSCK <SpellLink id={SPELLS.SPINNING_CRANE_KICK.id} />.</>, JeremyDwayne),
   change(date(2019, 10, 1), <>Bugfix for Lifecycles adding the potential mana reduction from an empowered <SpellLink id={SPELLS.VIVIFY.id} /> </>,Anomoly),
   change(date(2019, 9, 27), <>Update to date for 8.2.5 </>,Abelito75),
   change(date(2019, 8, 17), <>Fixed bug where you could have NaN mana tea overhealing.</>, Abelito75),

--- a/src/parser/monk/mistweaver/modules/spells/SpinningCraneKick.js
+++ b/src/parser/monk/mistweaver/modules/spells/SpinningCraneKick.js
@@ -15,7 +15,7 @@ class SpinningCraneKick extends Analyzer{
     badSCKcount = 0;
     badSCKTimeList = [];
     canceledSCKcount = 0;//figure out if this is possible
-    enemiesHitSCK;
+    enemiesHitSCK = [];
     currentTime = 0;
 
     on_byPlayer_cast(event){


### PR DESCRIPTION
The enemiesHitSCK array needs to be initialized to avoid checking if an enemy exists on an undefined variable when it expects an array. 

`TypeError: Cannot read property 'includes' of undefined`

An example of this error can be seen in this log: https://wowanalyzer.com/report/dtPChJZjHQwpYxrn/35-Mythic+Za%27qul+-+Wipe+6+(7:01)/15-Monclear