### PR TITLE
Add Icefury Efficiency checklist item and suggestion

### DIFF
--- a/src/parser/shaman/elemental/CHANGELOG.js
+++ b/src/parser/shaman/elemental/CHANGELOG.js
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 10, 12), <>Add suggestion and checklist for Icefury efficiency.</>, [Draenal]),
   change(date(2019, 10, 12), <>Added cancelled casts to downtime checklist. Add cancelled casts suggestion.</>, [Draenal]),
   change(date(2019, 8, 21), <>Added support for <SpellLink id={SPELLS.SURGE_OF_POWER_TALENT.id} /></>, [TheJigglr]),
   change(date(2019, 8, 14), <>Updated <SpellLink id={SPELLS.LAVA_BURST.id} /> to check for <SpellLink id={SPELLS.FLAME_SHOCK.id} /> on damage instead of on cast.</>, [Draenal]),

--- a/src/parser/shaman/elemental/CombatLogParser.js
+++ b/src/parser/shaman/elemental/CombatLogParser.js
@@ -23,12 +23,14 @@ import TotemMastery from './modules/talents/TotemMastery';
 import UnlimitedPower from './modules/talents/UnlimitedPower';
 import UnlimitedPowerTimesByStacks from './modules/talents/UnlimitedPowerTimesByStacks';
 import SurgeOfPower from './modules/talents/SurgeOfPower';
+import Icefury from './modules/talents/Icefury';
+
 import Checklist from './modules/checklist/Module';
 import Buffs from './modules/Buffs';
 
-import EchoOfTheElementals from './modules/azerite/EchoOfTheElementals';
 import LavaShock from './modules/azerite/LavaShock';
 import SynapseShock from '../shared/azerite/SynapseShock';
+import EchoOfTheElementals from './modules/azerite/EchoOfTheElementals';
 
 import SpiritWolf from '../shared/talents/SpiritWolf';
 import StaticCharge from '../shared/talents/StaticCharge';
@@ -70,11 +72,12 @@ class CombatLogParser extends CoreCombatLogParser {
     stormkeeper: Stormkeeper,
     unlimitedPowerTimesByStacks: UnlimitedPowerTimesByStacks,
     unlimitedPower: UnlimitedPower,
-    echoOfTheElementals: EchoOfTheElementals,
+    icefury: Icefury,
 
     // Azerite
     lavaShock: LavaShock,
     synapseShock: SynapseShock,
+    echoOfTheElementals: EchoOfTheElementals,
 
     spiritWolf: SpiritWolf,
     staticCharge: StaticCharge,

--- a/src/parser/shaman/elemental/modules/checklist/Component.js
+++ b/src/parser/shaman/elemental/modules/checklist/Component.js
@@ -61,7 +61,10 @@ class ElementalShamanChecklist extends React.PureComponent {
         <Rule
           name={<>Utilize all Icefury Stacks</>}
           description={(
-            <><SpellLink id={SPELLS.ICEFURY_TALENT.id} />'s damage component itself is not a strong spell so it's important to fully utilize the talent by consuming all 4 <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> buff stacks with <SpellLink id={SPELLS.FROST_SHOCK.id} /> casts during the buff's duration. While you should try to buff as many <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> empowered <SpellLink id={SPELLS.FROST_SHOCK.id} /> as you can with <SpellLink id={SPELLS.MASTER_OF_THE_ELEMENTS_TALENT.id} />, it is far more important to actually use all 4 charges before the buff expires.</>
+            <>
+              <SpellLink id={SPELLS.ICEFURY_TALENT.id} />'s damage component itself is not a strong spell so it's important to fully utilize the talent by consuming all 4 <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> buff stacks with <SpellLink id={SPELLS.FROST_SHOCK.id} /> casts during the buff's duration. 
+              {combatant.hasTalent(SPELLS.MASTER_OF_THE_ELEMENTS_TALENT.id) && <> While you should try to buff as many <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> empowered <SpellLink id={SPELLS.FROST_SHOCK.id} /> as you can with <SpellLink id={SPELLS.MASTER_OF_THE_ELEMENTS_TALENT.id} />, it is far more important to actually use all 4 charges before the buff expires.</>}
+            </>
           )}>
           <Requirement name={<>Average <SpellLink id={SPELLS.FROST_SHOCK.id} /> Casts within <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> Duration</>} thresholds={thresholds.icefuryEfficiency} />
         </Rule>

--- a/src/parser/shaman/elemental/modules/checklist/Component.js
+++ b/src/parser/shaman/elemental/modules/checklist/Component.js
@@ -59,11 +59,11 @@ class ElementalShamanChecklist extends React.PureComponent {
         </Rule>
         {combatant.hasTalent(SPELLS.ICEFURY_TALENT.id) && (
         <Rule
-          name="Utilize all Icefury Stacks"
+          name={<>Utilize all Icefury Stacks</>}
           description={(
             <><SpellLink id={SPELLS.ICEFURY_TALENT.id} />'s damage component itself is not a strong spell so it's important to fully utilize the talent by consuming all 4 <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> buff stacks with <SpellLink id={SPELLS.FROST_SHOCK.id} /> casts during the buff's duration. While you should try to buff as many <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> empowered <SpellLink id={SPELLS.FROST_SHOCK.id} /> as you can with <SpellLink id={SPELLS.MASTER_OF_THE_ELEMENTS_TALENT.id} />, it is far more important to actually use all 4 charges before the buff expires.</>
           )}>
-          <Requirement name="Average Frost Shock Casts within Icefury Duration" thresholds={thresholds.icefuryEfficiency} />
+          <Requirement name={<>Average <SpellLink id={SPELLS.FROST_SHOCK.id} /> Casts within <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> Duration</>} thresholds={thresholds.icefuryEfficiency} />
         </Rule>
         )}
         <PreparationRule thresholds={thresholds} />

--- a/src/parser/shaman/elemental/modules/checklist/Component.js
+++ b/src/parser/shaman/elemental/modules/checklist/Component.js
@@ -57,6 +57,13 @@ class ElementalShamanChecklist extends React.PureComponent {
           <Requirement name="Downtime" thresholds={thresholds.downtime} />
           <Requirement name="Cancelled casts" thresholds={thresholds.cancelledCasts} />
         </Rule>
+        <Rule
+          name="Utilize all Icefury Stacks"
+          description={(
+            <><SpellLink id={SPELLS.ICEFURY_TALENT.id} /> damage component itself is not a strong spell so it's important to fully utilize the talent by consuming all 4 <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> buff stacks with <SpellLink id={SPELLS.FROST_SHOCK.id} /> casts during the buff's duration. While you should try and buff as many <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> empowered <SpellLink id={SPELLS.FROST_SHOCK.id} /> as you can with <SpellLink id={SPELLS.MASTER_OF_THE_ELEMENTS_TALENT.id} />, it is far more important to actually use all 4 charges before the buff expires.</>
+          )}>
+          <Requirement name="Average Frost Shocks Casts within Icefury duration" thresholds={thresholds.icefuryEfficiency} />
+        </Rule>
         <PreparationRule thresholds={thresholds} />
       </Checklist>
     );

--- a/src/parser/shaman/elemental/modules/checklist/Component.js
+++ b/src/parser/shaman/elemental/modules/checklist/Component.js
@@ -60,9 +60,9 @@ class ElementalShamanChecklist extends React.PureComponent {
         <Rule
           name="Utilize all Icefury Stacks"
           description={(
-            <><SpellLink id={SPELLS.ICEFURY_TALENT.id} /> damage component itself is not a strong spell so it's important to fully utilize the talent by consuming all 4 <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> buff stacks with <SpellLink id={SPELLS.FROST_SHOCK.id} /> casts during the buff's duration. While you should try and buff as many <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> empowered <SpellLink id={SPELLS.FROST_SHOCK.id} /> as you can with <SpellLink id={SPELLS.MASTER_OF_THE_ELEMENTS_TALENT.id} />, it is far more important to actually use all 4 charges before the buff expires.</>
+            <><SpellLink id={SPELLS.ICEFURY_TALENT.id} />'s damage component itself is not a strong spell so it's important to fully utilize the talent by consuming all 4 <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> buff stacks with <SpellLink id={SPELLS.FROST_SHOCK.id} /> casts during the buff's duration. While you should try to buff as many <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> empowered <SpellLink id={SPELLS.FROST_SHOCK.id} /> as you can with <SpellLink id={SPELLS.MASTER_OF_THE_ELEMENTS_TALENT.id} />, it is far more important to actually use all 4 charges before the buff expires.</>
           )}>
-          <Requirement name="Average Frost Shocks Casts within Icefury duration" thresholds={thresholds.icefuryEfficiency} />
+          <Requirement name="Average Frost Shock Casts within Icefury Duration" thresholds={thresholds.icefuryEfficiency} />
         </Rule>
         <PreparationRule thresholds={thresholds} />
       </Checklist>

--- a/src/parser/shaman/elemental/modules/checklist/Component.js
+++ b/src/parser/shaman/elemental/modules/checklist/Component.js
@@ -57,6 +57,7 @@ class ElementalShamanChecklist extends React.PureComponent {
           <Requirement name="Downtime" thresholds={thresholds.downtime} />
           <Requirement name="Cancelled casts" thresholds={thresholds.cancelledCasts} />
         </Rule>
+        {combatant.hasTalent(SPELLS.ICEFURY_TALENT.id) && (
         <Rule
           name="Utilize all Icefury Stacks"
           description={(
@@ -64,6 +65,7 @@ class ElementalShamanChecklist extends React.PureComponent {
           )}>
           <Requirement name="Average Frost Shock Casts within Icefury Duration" thresholds={thresholds.icefuryEfficiency} />
         </Rule>
+        )}
         <PreparationRule thresholds={thresholds} />
       </Checklist>
     );

--- a/src/parser/shaman/elemental/modules/checklist/Module.js
+++ b/src/parser/shaman/elemental/modules/checklist/Module.js
@@ -5,6 +5,7 @@ import CastEfficiency from 'parser/shared/modules/CastEfficiency';
 import Combatants from 'parser/shared/modules/Combatants';
 import PreparationRuleAnalyzer from 'parser/shared/modules/features/Checklist/PreparationRuleAnalyzer';
 
+import Icefury from 'parser/shaman/elemental/modules/talents/Icefury';
 import CancelledCasts from 'parser/shaman/elemental/modules/features/CancelledCasts';
 import AlwaysBeCasting from 'parser/shaman/elemental/modules/features/AlwaysBeCasting';
 
@@ -17,6 +18,7 @@ class Checklist extends BaseChecklist {
     preparationRuleAnalyzer: PreparationRuleAnalyzer,
     cancelledCasts: CancelledCasts,
     alwaysBeCasting: AlwaysBeCasting,
+    icefury: Icefury,
   };
 
   render() {
@@ -28,6 +30,7 @@ class Checklist extends BaseChecklist {
           ...this.preparationRuleAnalyzer.thresholds,
           cancelledCasts: this.cancelledCasts.cancelledCastSuggestionThresholds,
           downtime: this.alwaysBeCasting.downtimeSuggestionThresholds,
+          icefuryEfficiency: this.icefury.suggestionThresholds,
         }}
       />
     );

--- a/src/parser/shaman/elemental/modules/talents/Icefury.js
+++ b/src/parser/shaman/elemental/modules/talents/Icefury.js
@@ -3,9 +3,9 @@ import React from 'react';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 
+import Events from 'parser/core/Events';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
-
-import Analyzer from 'parser/core/Analyzer';
 
 class Icefury extends Analyzer {
   static dependencies = {
@@ -17,13 +17,17 @@ class Icefury extends Analyzer {
   constructor(...args) {
     super(...args);
     this.active = this.selectedCombatant.hasTalent(SPELLS.ICEFURY_TALENT.id);
+    
+    if (!this.active) {
+      return;
+    }
+
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.FROST_SHOCK), this.onFrostShockCast);
   }
   
-  on_byPlayer_cast(event) {
+  onFrostShockCast(event) {
     if (this.selectedCombatant.hasBuff(SPELLS.ICEFURY_TALENT.id)) {
-      if (event.ability.guid === SPELLS.FROST_SHOCK.id) {
-        this.empoweredFrostShockCasts++;
-      }
+      this.empoweredFrostShockCasts++;
     }
   }
   

--- a/src/parser/shaman/elemental/modules/talents/Icefury.js
+++ b/src/parser/shaman/elemental/modules/talents/Icefury.js
@@ -1,0 +1,30 @@
+import SPELLS from 'common/SPELLS';
+
+import AbilityTracker from 'parser/shared/modules/AbilityTracker';
+
+import Analyzer from 'parser/core/Analyzer';
+
+class Icefury extends Analyzer {
+    static dependencies = {
+        abilityTracker: AbilityTracker,
+    };
+
+  icefuryCasts = 0;
+  empoweredFrostShockCasts = 0;
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.ICEFURY.id);
+    this.icefuryCasts = this.abilityTracker.getAbility(SPELLS.ICEFURY.id).casts;
+  }
+
+  on_cast(event) {
+      if (event.ability.guid === SPELLS.FROST_SHOCK.id) {
+          if (this.selectedCombatant.hasBuff(SPELLS.FROST_SHOCK.id)) {
+              this.empoweredFrostShockCasts++;
+          }
+      }
+  }
+}
+
+export default Icefury;

--- a/src/parser/shaman/elemental/modules/talents/Icefury.js
+++ b/src/parser/shaman/elemental/modules/talents/Icefury.js
@@ -1,29 +1,51 @@
+import React from 'react';
+
 import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
 
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 
 import Analyzer from 'parser/core/Analyzer';
 
 class Icefury extends Analyzer {
-    static dependencies = {
-        abilityTracker: AbilityTracker,
-    };
-
-  icefuryCasts = 0;
+  static dependencies = {
+    abilityTracker: AbilityTracker,
+  };
+  
   empoweredFrostShockCasts = 0;
-
+  
   constructor(...args) {
     super(...args);
-    this.active = this.selectedCombatant.hasTalent(SPELLS.ICEFURY.id);
-    this.icefuryCasts = this.abilityTracker.getAbility(SPELLS.ICEFURY.id).casts;
+    this.active = this.selectedCombatant.hasTalent(SPELLS.ICEFURY_TALENT.id);
   }
-
-  on_cast(event) {
+  
+  on_byPlayer_cast(event) {
+    if (this.selectedCombatant.hasBuff(SPELLS.ICEFURY_TALENT.id)) {
       if (event.ability.guid === SPELLS.FROST_SHOCK.id) {
-          if (this.selectedCombatant.hasBuff(SPELLS.FROST_SHOCK.id)) {
-              this.empoweredFrostShockCasts++;
-          }
+        this.empoweredFrostShockCasts++;
       }
+    }
+  }
+  
+  get suggestionThresholds() {
+    return {
+      actual: this.empoweredFrostShockCasts / this.abilityTracker.getAbility(SPELLS.ICEFURY_TALENT.id).casts,
+      isLessThan: {
+        minor: 4,
+        average: 3.5,
+        major: 3,
+      },
+      style: 'decimal',
+    };
+  }
+  
+  suggestions(when) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual) => {
+      return suggest(<>You should fully utilize your <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> casts by casting 4 <SpellLink id={SPELLS.FROST_SHOCK.id} />s before the <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> buff expires. Pay attention to the remaining duration of the buff to ensure you have time to use all of the stacks.</>)
+      .icon(SPELLS.ICEFURY_TALENT.icon)
+      .actual(<>On average, only {actual.toFixed(2)} <SpellLink id={SPELLS.ICEFURY_TALENT.id} />(s) stacks were consumed with  <SpellLink id={SPELLS.FROST_SHOCK.id} /> casts before <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> buff expired.</>)
+      .recommended(<>It's recommended to always consume all 4 stacks.</>);
+    });
   }
 }
 


### PR DESCRIPTION
Icefury is currently one of the most popular ele shaman talents at the moment and a lot of players will struggle to actually fully utilize it by using all of the charges before it expires because of how tight it can be to use them all especially when it sync with Stormkeeper (which is often). Many players will try to over optimize with Master of the Elements and ultimately cost themselves DPS.

![af2c518361ed7219f9877af705373be5](https://user-images.githubusercontent.com/6856899/66899361-a8b10700-efaf-11e9-9aca-469645a683f1.png)
