### PR TITLE
Include precast Stormkeeper in total number of Stormkeeper casts.

### DIFF
--- a/src/parser/shaman/elemental/CHANGELOG.js
+++ b/src/parser/shaman/elemental/CHANGELOG.js
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 10, 16), <>Count precast <SpellLink id={SPELLS.STORMKEEPER_TALENT.id} /> in total number of <SpellLink id={SPELLS.STORMKEEPER_TALENT.id} /> casts.</>, [TheJigglr]),
   change(date(2019, 10, 12), <>Added cancelled casts to downtime checklist. Add cancelled casts suggestion.</>, [Draenal]),
   change(date(2019, 8, 21), <>Added support for <SpellLink id={SPELLS.SURGE_OF_POWER_TALENT.id} /></>, [TheJigglr]),
   change(date(2019, 8, 14), <>Updated <SpellLink id={SPELLS.LAVA_BURST.id} /> to check for <SpellLink id={SPELLS.FLAME_SHOCK.id} /> on damage instead of on cast.</>, [Draenal]),

--- a/src/parser/shaman/elemental/modules/Buffs.js
+++ b/src/parser/shaman/elemental/modules/Buffs.js
@@ -29,6 +29,7 @@ class Buffs extends CoreBuffs {
       },
       {
         spellId: SPELLS.STORMKEEPER_TALENT.id,
+        triggeredBySpellId: SPELLS.STORMKEEPER_TALENT.id,
         timelineHightlight: true,
       },
       {

--- a/src/parser/shaman/elemental/modules/talents/Stormkeeper.js
+++ b/src/parser/shaman/elemental/modules/talents/Stormkeeper.js
@@ -58,7 +58,6 @@ class Stormkeeper extends Analyzer {
     const stormKeeperAbility = this.abilities.abilities.find(function(element) {
       return element.spell === SPELLS.STORMKEEPER_TALENT;
     });
-    console.log(stormKeeperAbility);
     stormKeeperAbility.castEfficiency.casts = ()=>{
       return this.stormkeeperCasts;
     };

--- a/src/parser/shaman/elemental/modules/talents/Stormkeeper.js
+++ b/src/parser/shaman/elemental/modules/talents/Stormkeeper.js
@@ -6,8 +6,6 @@ import { formatNumber, formatPercentage } from 'common/format';
 
 import Analyzer from 'parser/core/Analyzer';
 
-import Abilities from 'parser/core/modules/Abilities';
-
 import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 
 const AFFECTED_ABILITIES = [SPELLS.LIGHTNING_BOLT_OVERLOAD.id,
@@ -17,11 +15,6 @@ const AFFECTED_ABILITIES = [SPELLS.LIGHTNING_BOLT_OVERLOAD.id,
 
 class Stormkeeper extends Analyzer {
   damageDoneByBuffedCasts = 0;
-  stormkeeperCasts = 0;
-
-  static dependencies = {
-    abilities: Abilities,
-  };
 
   constructor(...args) {
     super(...args);
@@ -45,22 +38,6 @@ class Stormkeeper extends Analyzer {
 
   get damagePerSecond() {
     return this.damageDoneByBuffedCasts / (this.owner.fightDuration / 1000);
-  }
-
-  on_byPlayer_applybuff(event){
-    const spellId = event.ability.guid;
-    if (spellId === SPELLS.STORMKEEPER_TALENT.id) {
-      this.stormkeeperCasts += 1;
-    }
-  }
-
-  on_fightend(event){
-    const stormKeeperAbility = this.abilities.abilities.find(function(element) {
-      return element.spell === SPELLS.STORMKEEPER_TALENT;
-    });
-    stormKeeperAbility.castEfficiency.casts = ()=>{
-      return this.stormkeeperCasts;
-    };
   }
 
   statistic() {

--- a/src/parser/shaman/elemental/modules/talents/Stormkeeper.js
+++ b/src/parser/shaman/elemental/modules/talents/Stormkeeper.js
@@ -55,7 +55,6 @@ class Stormkeeper extends Analyzer {
   }
 
   on_fightend(event){
-    console.log(this.abilities.abilities[9]);
     this.abilities.abilities[9].castEfficiency.casts = (a, b) =>{
       return this.stormkeeperCasts;
     };

--- a/src/parser/shaman/elemental/modules/talents/Stormkeeper.js
+++ b/src/parser/shaman/elemental/modules/talents/Stormkeeper.js
@@ -55,7 +55,11 @@ class Stormkeeper extends Analyzer {
   }
 
   on_fightend(event){
-    this.abilities.abilities[9].castEfficiency.casts = (a, b) =>{
+    const stormKeeperAbility = this.abilities.abilities.find(function(element) {
+      return element.spell === SPELLS.STORMKEEPER_TALENT;
+    });
+    console.log(stormKeeperAbility);
+    stormKeeperAbility.castEfficiency.casts = ()=>{
       return this.stormkeeperCasts;
     };
   }

--- a/src/parser/shaman/elemental/modules/talents/Stormkeeper.js
+++ b/src/parser/shaman/elemental/modules/talents/Stormkeeper.js
@@ -6,6 +6,8 @@ import { formatNumber, formatPercentage } from 'common/format';
 
 import Analyzer from 'parser/core/Analyzer';
 
+import Abilities from 'parser/core/modules/Abilities';
+
 import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 
 const AFFECTED_ABILITIES = [SPELLS.LIGHTNING_BOLT_OVERLOAD.id,
@@ -15,6 +17,11 @@ const AFFECTED_ABILITIES = [SPELLS.LIGHTNING_BOLT_OVERLOAD.id,
 
 class Stormkeeper extends Analyzer {
   damageDoneByBuffedCasts = 0;
+  stormkeeperCasts = 0;
+
+  static dependencies = {
+    abilities: Abilities,
+  };
 
   constructor(...args) {
     super(...args);
@@ -38,6 +45,20 @@ class Stormkeeper extends Analyzer {
 
   get damagePerSecond() {
     return this.damageDoneByBuffedCasts / (this.owner.fightDuration / 1000);
+  }
+
+  on_byPlayer_applybuff(event){
+    const spellId = event.ability.guid;
+    if (spellId === SPELLS.STORMKEEPER_TALENT.id) {
+      this.stormkeeperCasts += 1;
+    }
+  }
+
+  on_fightend(event){
+    console.log(this.abilities.abilities[9]);
+    this.abilities.abilities[9].castEfficiency.casts = (a, b) =>{
+      return this.stormkeeperCasts;
+    };
   }
 
   statistic() {


### PR DESCRIPTION
Currently, the Stormkeeper cast ~5 seconds before pull is not included in the cast efficiency calculation. This results in suggestions that say you missed a cast of Stormkeeper when you really did not.

Here is an example WA report that demonstrates the issue: 
https://wowanalyzer.com/report/rJXM1TmkpKPgN2n7/4-Mythic+Abyssal+Commander+Sivara+-+Kill+(2:50)/Thejigglr/overview
The report says that I only used 2/3 possible Stormkeeper casts.

If you check the actual log (https://www.warcraftlogs.com/reports/rJXM1TmkpKPgN2n7/#fight=4&source=7&type=auras&ability=191634), you can see that I had the Stormkeeper buff 3 times during the fight, so a cast was not recorded.

This change manually tracks Stormkeeper casts, which results in the correct total number of casts being recorded.