### PR TITLE
fix character tab for old logs without essences

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Yajinni, Mamtooth, Zerotorescue, Putro, joshinator, Gebuz, ackwell, emallson, blazyb, Dambroda, Nalhan, Satyric, niseko, Khadaj, Fyruna, Matardarix, jos3p, Aelexe, Chizu, Hartra344, Hordehobbs, Dorixius, Sharrq, Scotsoo, HolySchmidt, Zeboot, Abelito75, Anatta336, HawkCorrigan, Amrux, Qbz, Viridis, Juko8 } from 'CONTRIBUTORS';
+import { Yajinni, Mamtooth, Zerotorescue, Putro, joshinator, Gebuz, ackwell, emallson, blazyb, Dambroda, Nalhan, Satyric, niseko, Khadaj, Fyruna, Matardarix, jos3p, Aelexe, Chizu, Hartra344, Hordehobbs, Dorixius, Sharrq, Scotsoo, HolySchmidt, Zeboot, Abelito75, Anatta336, HawkCorrigan, Amrux, Qbz, Viridis, Juko8, Draenal } from 'CONTRIBUTORS';
 import ItemLink from 'common/ItemLink';
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
@@ -8,7 +8,8 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/contributor/Button';
 
 export default [
-  change(date(2019, 10, 13), <>Added extra information and cleaned up Vantus Rune infographic. />.</>, Abelito75),
+  change(date(2019, 10, 19), <>Fixed an issue in the character tab caused it to break for logs without essences.</>, Draenal),
+  change(date(2019, 10, 13), <>Added extra information and cleaned up Vantus Rune infographic.</>, Abelito75),
   change(date(2019, 10, 13), <>Added <ItemLink id={ITEMS.RAZOR_CORAL.id} />.</>, Zeboot),
   change(date(2019, 10, 13), 'Added event filter to cooldown to view only events during a selected cooldown.', Zeboot),
   change(date(2019, 10, 13), <>Added <ItemLink id={ITEMS.BLOODTHIRSTY_URCHIN.id} />.</>, Zeboot),

--- a/src/interface/report/Results/Character/PlayerInfo/Essence.js
+++ b/src/interface/report/Results/Character/PlayerInfo/Essence.js
@@ -13,6 +13,8 @@ class Essence extends React.PureComponent {
     essences: PropTypes.object.isRequired,
   };
 
+  essences = this.props.essences || {}
+
   state = {
     essences: Object.values(ESSENCES),
   };
@@ -26,8 +28,6 @@ class Essence extends React.PureComponent {
   }
 
   render() {
-    const essences = this.props.essences;
-
     return (
       <>
         <h3>
@@ -35,7 +35,7 @@ class Essence extends React.PureComponent {
         </h3>
         <div className="essences">
           <div className="essence-row">
-            {Object.values(essences).map((essence, index) => {
+            {Object.values(this.essences).map((essence, index) => {
               const spell = this.state.essences.find(e => e.id === essence.spellID);
               const quality = this.convertRankIntoQuality(essence.rank);
               const height = index === 0 ? '60px' : '45px';
@@ -61,7 +61,7 @@ class Essence extends React.PureComponent {
   loadMissingIcons() {
     // load missing essence-icons and add them to the components state after it got fetched
     const missingIcons = [];
-    const essences = Object.values(this.props.essences);
+    const essences = Object.values(this.essences || {});
     essences.forEach(essence => {
       const foundEssence = this.state.essences.find(e => e.id === parseInt(essence.spellID, 10));
 

--- a/src/interface/report/Results/Character/PlayerInfo/Essence.js
+++ b/src/interface/report/Results/Character/PlayerInfo/Essence.js
@@ -61,7 +61,7 @@ class Essence extends React.PureComponent {
   loadMissingIcons() {
     // load missing essence-icons and add them to the components state after it got fetched
     const missingIcons = [];
-    const essences = Object.values(this.essences || {});
+    const essences = Object.values(this.essences);
     essences.forEach(essence => {
       const foundEssence = this.state.essences.find(e => e.id === parseInt(essence.spellID, 10));
 


### PR DESCRIPTION
Fixes #3366

There was a problem with the character tab logs pre 8.2. Low priority fix.