### PR TITLE
[Core] Add missing IDs for Vision of Perfection and Lucid Dreams

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -9,7 +9,6 @@ import Contributor from 'interface/contributor/Button';
 
 export default [
   change(date(2019, 10, 25), <>Added missing spell information for resource refunds and gains from <SpellLink id={SPELLS.LUCID_DREAMS_MINOR.id} /> and <SpellLink id={SPELLS.VISION_OF_PERFECTION.id} />.</>, Juko8),
-  change(date(2019, 10, 13), <>Added extra information and cleaned up Vantus Rune infographic. />.</>, Abelito75),
   change(date(2019, 10, 24), <>Replaced the activity time statistic icons that had outgrown their space with smaller ones. <small>I only fixed it for <a href="https://hacktoberfest.digitalocean.com/">the shirt</a>.</small></>, Zerotorescue),
   change(date(2019, 10, 24), 'Updated nodejs for docker.', JeremyDwayne),
   change(date(2019, 10, 19), <>Fixed an issue in the character tab caused it to break for logs without essences.</>, Draenal),

--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -8,6 +8,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  change(date(2019, 10, 25), <>Added missing spell information for resource refunds and gains from <SpellLink id={SPELLS.LUCID_DREAMS_MINOR.id} /> and <SpellLink id={SPELLS.VISION_OF_PERFECTION.id} />.</>, Juko8),
   change(date(2019, 10, 13), <>Added extra information and cleaned up Vantus Rune infographic. />.</>, Abelito75),
   change(date(2019, 10, 13), <>Added <ItemLink id={ITEMS.RAZOR_CORAL.id} />.</>, Zeboot),
   change(date(2019, 10, 13), 'Added event filter to cooldown to view only events during a selected cooldown.', Zeboot),

--- a/src/common/SPELLS/bfa/azeritetraits/druid.js
+++ b/src/common/SPELLS/bfa/azeritetraits/druid.js
@@ -171,5 +171,10 @@ export default {
     name: 'Arcanic Pulsar',
     icon: 'spell_arcane_arcane03',
   },
+  ARCANIC_PULSAR_ENERGIZE:{
+    id: 305179,
+    name: 'Arcanic Pulsar',
+    icon: 'spell_arcane_arcane03',
+  },
   //end of balance
 };

--- a/src/common/SPELLS/bfa/essences/essences.js
+++ b/src/common/SPELLS/bfa/essences/essences.js
@@ -59,7 +59,7 @@ export default {
     id: 296065,
     name: 'The Ever-Rising Tide',
     icon: 'inv_elemental_mote_mana',
-  },  
+  },
   WELL_OF_EXISTENCE: {
     id: 299936,
     traitId: 19,
@@ -172,6 +172,7 @@ export default {
     icon: 'spell_azerite_essence_16',
   },
   // Memory of Lucid Dreams
+  // Each unique resource has its own refund spell. Icicles and Fire blast and Shield of the Righteous charges don't.
   LUCID_DREAMS: {
     id: 299374,
     traitId: 27,
@@ -203,8 +204,63 @@ export default {
     name: 'Lucid Dreams',
     icon: 'inv_radientazeritematrix',
   },
-   LUCID_DREAMS_MINOR_RESOURCE_REFUND_RAGE : {
-    id: 298321,
+  LUCID_DREAMS_MINOR_RESOURCE_REFUND_RAGE : {
+   id: 298321,
+   name: 'Lucid Dreams',
+   icon: 'inv_radientazeritematrix',
+  },
+  LUCID_DREAMS_MINOR_RESOURCE_REFUND_ENERGY: {
+    id: 298325,
+    name: 'Lucid Dreams',
+    icon: 'inv_radientazeritematrix',
+  },
+  LUCID_DREAMS_MINOR_RESOURCE_REFUND_PAIN: {
+    id: 298331,
+    name: 'Lucid Dreams',
+    icon: 'inv_radientazeritematrix',
+  },
+  LUCID_DREAMS_MINOR_RESOURCE_REFUND_FURY: {
+    id: 298330,
+    name: 'Lucid Dreams',
+    icon: 'inv_radientazeritematrix',
+  },
+  LUCID_DREAMS_MINOR_RESOURCE_REFUND_SOUL_SHARD: {
+    id: 298328,
+    name: 'Lucid Dreams',
+    icon: 'inv_radientazeritematrix',
+  },
+  LUCID_DREAMS_MINOR_RESOURCE_REFUND_HOLY_POWER: {
+    id: 298333,
+    name: 'Lucid Dreams',
+    icon: 'inv_radientazeritematrix',
+  },
+  LUCID_DREAMS_MINOR_RESOURCE_REFUND_ASTRAL_POWER: {
+    id: 298327,
+    name: 'Lucid Dreams',
+    icon: 'inv_radientazeritematrix',
+  },
+  LUCID_DREAMS_MINOR_RESOURCE_REFUND_RUNE: {
+    id: 304632,
+    name: 'Lucid Dreams',
+    icon: 'inv_radientazeritematrix',
+  },
+  LUCID_DREAMS_MINOR_RESOURCE_REFUND_RUNIC_POWER: {
+    id: 298334,
+    name: 'Lucid Dreams',
+    icon: 'inv_radientazeritematrix',
+  },
+  LUCID_DREAMS_MINOR_RESOURCE_REFUND_FOCUS: {
+    id: 299058,
+    name: 'Lucid Dreams',
+    icon: 'inv_radientazeritematrix',
+  },
+  LUCID_DREAMS_MINOR_RESOURCE_REFUND_MAELSTROM: {
+    id: 298332,
+    name: 'Lucid Dreams',
+    icon: 'inv_radientazeritematrix',
+  },
+  LUCID_DREAMS_MINOR_RESOURCE_REFUND_INSANITY: {
+    id: 298329,
     name: 'Lucid Dreams',
     icon: 'inv_radientazeritematrix',
   },
@@ -232,6 +288,16 @@ export default {
   },
   VISION_OF_PERFECTION_RAGE: {
     id: 302585,
+    name: 'Vision of Perfection',
+    icon: 'spell_azerite_essence_18',
+  },
+  VISION_OF_PERFECTION_ASTRAL_POWER: {
+    id: 302657,
+    name: 'Vision of Perfection',
+    icon: 'spell_azerite_essence_18',
+  },
+  VISION_OF_PERFECTION_RUNES_RUNIC_POWER: {
+    id: 302656,
     name: 'Vision of Perfection',
     icon: 'spell_azerite_essence_18',
   },


### PR DESCRIPTION
Also squeezed in a small spellId for balance druid because it was crashing on me while i was testing. 