### PR TITLE
Add Totem Mastery Uptime Checklist item when talent is selected

### DIFF
--- a/src/parser/shaman/elemental/CHANGELOG.js
+++ b/src/parser/shaman/elemental/CHANGELOG.js
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 10, 26), <>Add a checklist item for <SpellLink id={SPELLS.TOTEM_MASTERY_TALENT_ELEMENTAL.id} /> uptime.</>, [Draenal]),
   change(date(2019, 10, 21), <>Add a checklist item for <SpellLink id={SPELLS.FLAME_SHOCK.id} /> uptime and early refreshes.</>, [Draenal]),
   change(date(2019, 10, 16), <>Count precast <SpellLink id={SPELLS.STORMKEEPER_TALENT.id} /> in total number of <SpellLink id={SPELLS.STORMKEEPER_TALENT.id} /> casts.</>, [TheJigglr]),
   change(date(2019, 10, 12), <>Add suggestion and checklist for Icefury efficiency.</>, [Draenal]),

--- a/src/parser/shaman/elemental/modules/checklist/Component.js
+++ b/src/parser/shaman/elemental/modules/checklist/Component.js
@@ -24,8 +24,8 @@ class ElementalShamanChecklist extends React.PureComponent {
         {this.useCoreAbilitiesRule()}
         {this.minimizeDowntimeRule()}
         {this.maintainFlameShockRule()}
-        {this.keepYourTotemsUp()}
-        {this.maximizeIcefuryRule()}
+        {this.props.combatant.hasTalent(SPELLS.TOTEM_MASTERY_TALENT_ELEMENTAL.id) ? this.keepYourTotemsUp() : ''}
+        {this.props.combatant.hasTalent(SPELLS.ICEFURY_TALENT.id) ? this.maximizeIcefuryRule() : ''}
         <PreparationRule thresholds={this.props.thresholds} />
       </Checklist>
     );
@@ -76,21 +76,6 @@ class ElementalShamanChecklist extends React.PureComponent {
     );
   }
 
-  keepYourTotemsUp() {
-    const description = (
-      <>
-        Totems provide a significant buff at the cost of a GCD. Make sure you keep them up and are within range of them. 
-        They last for 2 minutes so you should should only need to refresh them a couple times a fight.
-      </>
-    );
-
-    return (
-      <Rule name="Demonstrate Mastery of Totems" description={description}>
-        <Requirement name="Totem Uptime" thresholds={this.props.thresholds.totemMasteryUptime} />
-      </Rule>
-    );
-  }
-
   maintainFlameShockRule() {
     const description = (
       <>
@@ -108,6 +93,21 @@ class ElementalShamanChecklist extends React.PureComponent {
     );
   }
 
+  keepYourTotemsUp() {
+    const description = (
+      <>
+        <SpellLink id={SPELLS.TOTEM_MASTERY_TALENT_ELEMENTAL.id} /> provides a significant buff at the cost of a GCD. Make sure you keep them up and are within range of them. 
+        They last for 2 minutes so you should should only need to refresh them a couple times a fight.
+      </>
+    );
+
+    return (
+      <Rule name="Demonstrate Mastery of Totems" description={description}>
+        <Requirement name="Totem Uptime" thresholds={this.props.thresholds.totemMasteryUptime} />
+      </Rule>
+    );
+  }
+
   maximizeIcefuryRule() {
 
     const description = (
@@ -117,11 +117,11 @@ class ElementalShamanChecklist extends React.PureComponent {
       </>
     );
 
-    return this.props.combatant.hasTalent(SPELLS.ICEFURY_TALENT.id) ? (
+    return (
       <Rule name="Utilize all Icefury Stacks" description={description}>
         <Requirement name={<>Average <SpellLink id={SPELLS.FROST_SHOCK.id} /> Casts within <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> Duration</>} thresholds={this.props.thresholds.icefuryEfficiency} />
       </Rule>
-    ) : '';
+    );
   }
 }
 

--- a/src/parser/shaman/elemental/modules/checklist/Component.js
+++ b/src/parser/shaman/elemental/modules/checklist/Component.js
@@ -24,6 +24,7 @@ class ElementalShamanChecklist extends React.PureComponent {
         {this.useCoreAbilitiesRule()}
         {this.minimizeDowntimeRule()}
         {this.maintainFlameShockRule()}
+        {this.keepYourTotemsUp()}
         {this.maximizeIcefuryRule()}
         <PreparationRule thresholds={this.props.thresholds} />
       </Checklist>
@@ -75,6 +76,21 @@ class ElementalShamanChecklist extends React.PureComponent {
     );
   }
 
+  keepYourTotemsUp() {
+    const description = (
+      <>
+        Totems provide a significant buff at the cost of a GCD. Make sure you keep them up and are within range of them. 
+        They last for 2 minutes so you should should only need to refresh them a couple times a fight.
+      </>
+    );
+
+    return (
+      <Rule name="Demonstrate Mastery of Totems" description={description}>
+        <Requirement name="Totem Uptime" thresholds={this.props.thresholds.totemMasteryUptime} />
+      </Rule>
+    );
+  }
+
   maintainFlameShockRule() {
     const description = (
       <>
@@ -85,7 +101,7 @@ class ElementalShamanChecklist extends React.PureComponent {
     );
 
     return (
-      <Rule name="Maintain your flame shock." description={description}>
+      <Rule name="Maintain your flame shock" description={description}>
         <Requirement name={(<><SpellLink id={SPELLS.FLAME_SHOCK.id} /> uptime</> )} thresholds={this.props.thresholds.flameShockUptime} />
         <Requirement name={( <> Bad <SpellLink id={SPELLS.FLAME_SHOCK.id} /> refreshes </> )} thresholds={this.props.thresholds.flameShockRefreshes} />
       </Rule>

--- a/src/parser/shaman/elemental/modules/checklist/Module.js
+++ b/src/parser/shaman/elemental/modules/checklist/Module.js
@@ -9,6 +9,7 @@ import Icefury from 'parser/shaman/elemental/modules/talents/Icefury';
 import CancelledCasts from 'parser/shaman/elemental/modules/features/CancelledCasts';
 import AlwaysBeCasting from 'parser/shaman/elemental/modules/features/AlwaysBeCasting';
 import FlameShock from 'parser/shaman/elemental/modules/core/FlameShock';
+import TotemMastery from 'parser/shaman/elemental/modules/talents/TotemMastery';
 
 import Component from './Component';
 
@@ -21,6 +22,7 @@ class Checklist extends BaseChecklist {
     alwaysBeCasting: AlwaysBeCasting,
     icefury: Icefury,
     flameshock: FlameShock,
+    totemMastery: TotemMastery,
   };
 
   render() {
@@ -35,6 +37,7 @@ class Checklist extends BaseChecklist {
           icefuryEfficiency: this.icefury.suggestionThresholds,
           flameShockUptime: this.flameshock.uptimeThreshold,
           flameShockRefreshes: this.flameshock.refreshThreshold,
+          totemMasteryUptime: this.totemMastery.uptimeSuggestionThresholds,
         }}
       />
     );

--- a/src/parser/shaman/elemental/modules/core/FlameShock.js
+++ b/src/parser/shaman/elemental/modules/core/FlameShock.js
@@ -68,11 +68,6 @@ class FlameShock extends EarlyDotRefreshesAnalyzer {
     }
   }
 
-  couldCastWhileMoving(castEvent, endEvent) {
-    // You would rather always cast Frost shock over flame shock as filler unless you're within pandemic range
-    return false;
-  }
-
   suggestions(when) {
     when(this.uptimeThreshold).addSuggestion((suggest, actual, recommended) => {
       return suggest(<span>Your <SpellLink id={SPELLS.FLAME_SHOCK.id} /> uptime can be improved.</span>)

--- a/src/parser/shaman/elemental/modules/talents/TotemMastery.js
+++ b/src/parser/shaman/elemental/modules/talents/TotemMastery.js
@@ -21,6 +21,18 @@ class TotemMastery extends Analyzer {
     this.active = this.selectedCombatant.hasTalent(SPELLS.TOTEM_MASTERY_TALENT_ELEMENTAL.id);
   }
 
+  get uptimeSuggestionThresholds() {
+    return {
+      actual: this.minUptime,
+      isLessThan: {
+        minor: 0.99,
+        average: 0.94,
+        major: 0.85,
+      },
+      style: 'percentage',
+    };
+  }
+
   get minUptime() {
     return Math.min(
       this.selectedCombatant.getBuffUptime(BUFF_TOTEM_RESONANCE_SPELL_ID),
@@ -36,14 +48,12 @@ class TotemMastery extends Analyzer {
   }
 
   suggestions(when) {
-    when(this.minUptime).isLessThan(0.99)
-      .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span>Your <SpellLink id={SPELLS.TOTEM_MASTERY_TALENT_ELEMENTAL.id} /> uptime can be improved. Try to place the totems better.</span>)
-          .icon(SPELLS.TOTEM_MASTERY_TALENT_ELEMENTAL.icon)
-          .actual(`${formatPercentage(actual)}% uptime`)
-          .recommended(`>${formatPercentage(recommended)}% is recommended`)
-          .regular(recommended - 0.05).major(recommended - 0.15);
-      });
+    when(this.uptimeSuggestionThresholds).addSuggestion((suggest, actual, recommended) => {
+      return suggest(<span>Your <SpellLink id={SPELLS.TOTEM_MASTERY_TALENT_ELEMENTAL.id} /> uptime can be improved. Try to place the totems better.</span>)
+        .icon(SPELLS.TOTEM_MASTERY_TALENT_ELEMENTAL.icon)
+        .actual(`${formatPercentage(actual)}% uptime`)
+        .recommended(`>${formatPercentage(recommended)}% is recommended`);
+    });
   }
 
   statistic() {


### PR DESCRIPTION
Pretty basic but important item. This is is more or less the last distinct thing I plan to add to the checklist, maybe something for storm elemental in the future.