### PR TITLE
[Restoration Shaman] Removal of Tidal Wave checklist rule

### DIFF
--- a/src/parser/shaman/restoration/CHANGELOG.js
+++ b/src/parser/shaman/restoration/CHANGELOG.js
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 11, 1), <>Removed <SpellLink id={SPELLS.TIDAL_WAVES_BUFF.id} /> checklist rule as it doesn't line up with current shaman gameplay anymore.</>, niseko),
   change(date(2019, 9, 26), <>Updated for patch 8.2.5: <SpellLink id={SPELLS.DELUGE_TALENT.id} /> now includes <SpellLink id={SPELLS.HEALING_WAVE.id} /> and <SpellLink id={SPELLS.HEALING_SURGE_RESTORATION.id} />.</>, niseko),
   change(date(2019, 9, 5), 'Updated for patch 8.2.', niseko),
   change(date(2019, 8, 12), 'Added essence Lucid Dreams.', [blazyb]),

--- a/src/parser/shaman/restoration/modules/features/TidalWaves.js
+++ b/src/parser/shaman/restoration/modules/features/TidalWaves.js
@@ -17,7 +17,7 @@ class TidalWaves extends Analyzer {
     const suggestedThresholds = this.suggestionThresholds;
     when(suggestedThresholds.actual).isGreaterThan(suggestedThresholds.isGreaterThan.minor)
       .addSuggestion((suggest, actual, recommended) => {
-        return suggest(<span><SpellLink id={SPELLS.TIDAL_WAVES_BUFF.id} /> buffed <SpellLink id={SPELLS.HEALING_WAVE.id} /> can make for some very efficient healing, consider casting more of them ({formatPercentage(suggestedThresholds.actual)}% unused Tidal Waves).</span>)
+        return suggest(<span><SpellLink id={SPELLS.TIDAL_WAVES_BUFF.id} /> buffed <SpellLink id={SPELLS.HEALING_WAVE.id} /> can make for some very efficient healing, consider casting more of them if you are running into mana issues ({formatPercentage(suggestedThresholds.actual)}% unused Tidal Waves).</span>)
           .icon(SPELLS.TIDAL_WAVES_BUFF.icon)
           .actual(`${formatPercentage(suggestedThresholds.actual)}% unused Tidal waves`)
           .recommended(`Less than ${formatPercentage(suggestedThresholds.isGreaterThan.minor, 0)}% unused Tidal Waves`)
@@ -44,9 +44,9 @@ class TidalWaves extends Analyzer {
     return {
       actual: unusedTwRate,
       isGreaterThan: {
-        minor: 0.1,
-        average: 0.35,
-        major: 0.6,
+        minor: 0.5,
+        average: 0.8,
+        major: 0.9,
       },
       style: 'percentage',
     };

--- a/src/parser/shaman/restoration/modules/features/checklist/Component.js
+++ b/src/parser/shaman/restoration/modules/features/checklist/Component.js
@@ -72,20 +72,6 @@ class RestoShamanChecklist extends React.PureComponent {
           )}
         </Rule>
         <Rule
-          name={(<>Maximize <SpellLink id={SPELLS.TIDAL_WAVES_BUFF.id} /> usage</>
-          )}
-          description={(
-            <>
-              <SpellLink id={SPELLS.TIDAL_WAVES_BUFF.id} /> buffed <SpellLink id={SPELLS.HEALING_WAVE.id} /> can make for some very efficient healing.
-              You should try to use as many of the generated tidal waves as you can. You should also avoid using <SpellLink id={SPELLS.HEALING_WAVE.id} /> or <SpellLink id={SPELLS.HEALING_SURGE_RESTORATION.id} /> without a tidal wave.
-            </>
-          )}
-        >
-          <Requirement name={(<>Unused <SpellLink id={SPELLS.TIDAL_WAVES_BUFF.id} /></>)} thresholds={thresholds.unusedTidalWavesThresholds} />
-          <Requirement name={(<>Unbuffed <SpellLink id={SPELLS.HEALING_SURGE_RESTORATION.id} /></>)} thresholds={thresholds.unbuffedHealingSurgesThresholds} />
-          <Requirement name={(<>Unbuffed <SpellLink id={SPELLS.HEALING_WAVE.id} /></>)} thresholds={thresholds.unbuffedHealingWavesThresholds} />
-        </Rule>
-        <Rule
           name="Target AOE spells effectively"
           description="As a resto shaman our core AOE spells rely on not just who we target but where they are on the ground to maximize healing potential. You should plan you AOE spells ahead of time in preparation for where you expect raid members to be for the spells duration."
         >

--- a/src/parser/shaman/restoration/modules/features/checklist/Module.js
+++ b/src/parser/shaman/restoration/modules/features/checklist/Module.js
@@ -7,13 +7,10 @@ import ManaValues from 'parser/shared/modules/ManaValues';
 import PreparationRuleAnalyzer from 'parser/shared/modules/features/Checklist/PreparationRuleAnalyzer';
 
 import AlwaysBeCasting from '../AlwaysBeCasting';
-import TidalWaves from '../TidalWaves';
 import ChainHeal from '../../spells/ChainHeal';
 import HealingRain from '../../spells/HealingRain';
 import Wellspring from '../../talents/Wellspring';
 import EarthenWallTotem from '../../talents/EarthenWallTotem';
-import HealingSurge from '../../spells/HealingSurge';
-import HealingWave from '../../spells/HealingWave';
 
 import Component from './Component';
 
@@ -24,13 +21,10 @@ class Checklist extends BaseChecklist {
     alwaysBeCasting: AlwaysBeCasting,
     manaValues: ManaValues,
     preparationRuleAnalyzer: PreparationRuleAnalyzer,
-    tidalWaves: TidalWaves,
     chainHeal: ChainHeal,
     healingRain: HealingRain,
     wellspring: Wellspring,
     earthenWallTotem: EarthenWallTotem,
-    healingSurge: HealingSurge,
-    healingWave: HealingWave,
   };
 
   render() {
@@ -43,9 +37,6 @@ class Checklist extends BaseChecklist {
 
           nonHealingTimeSuggestionThresholds: this.alwaysBeCasting.nonHealingTimeSuggestionThresholds,
           downtimeSuggestionThresholds: this.alwaysBeCasting.downtimeSuggestionThresholds,
-          unusedTidalWavesThresholds: this.tidalWaves.suggestionThresholds,
-          unbuffedHealingSurgesThresholds: this.healingSurge.suggestedThreshold,
-          unbuffedHealingWavesThresholds: this.healingWave.suggestedThreshold,
           chainHealTargetThresholds: this.chainHeal.suggestionThreshold,
           healingRainTargetThreshold: this.healingRain.suggestionThreshold,
           wellspringTargetThreshold: this.wellspring.suggestionThreshold,


### PR DESCRIPTION
Tidal Waves aren't what they used to be, and this makes this checklist item more misleading for people trying to learn, than anything else. I'll see if I can figure out a new format for it in the future. Alternatively if TW get to be an important part of the gameplay again in the future I'll add it again.