### PR TITLE
Crusaders Might Additional Info

### DIFF
--- a/src/parser/paladin/holy/CHANGELOG.js
+++ b/src/parser/paladin/holy/CHANGELOG.js
@@ -6,7 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2019, 11, 6), <>Added suggestion in the timeline and a tooltip to prioritize <SpellLink id={SPELLS.HOLY_SHOCK_CAST.id} /> over <SpellLink id={SPELLS.CRUSADER_STRIKE.id} /> when using <SpellLink id={SPELLS.CRUSADERS_MIGHT_TALENT.id} /> talent.</>, [HolySchmidt]),
+  change(date(2019, 11, 9), <>Added suggestion in the timeline and a tooltip to prioritize <SpellLink id={SPELLS.HOLY_SHOCK_CAST.id} /> over <SpellLink id={SPELLS.CRUSADER_STRIKE.id} /> when using <SpellLink id={SPELLS.CRUSADERS_MIGHT_TALENT.id} /> talent.</>, [HolySchmidt]),
   change(date(2019, 10, 21), <>Fixed a typo in <SpellLink id={SPELLS.RULE_OF_LAW_TALENT.id} />'s suggestion. </>, [Abelito75]),
   change(date(2019, 8, 12), 'Added essence Lucid Dreams.', [blazyb]),
   change(date(2019, 6, 13), <><SpellLink id={SPELLS.GLIMMER_OF_LIGHT.id} /> statistic added showing healing, damage, beacon healing, <SpellLink id={SPELLS.HOLY_SHOCK_CAST.id} />s/min and refresh utilization.</>, [HolySchmidt]),

--- a/src/parser/paladin/holy/CHANGELOG.js
+++ b/src/parser/paladin/holy/CHANGELOG.js
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 11, 6), <>Added suggestion in the timeline and a tooltip to prioritize <SpellLink id={SPELLS.HOLY_SHOCK_CAST.id} /> over <SpellLink id={SPELLS.CRUSADER_STRIKE.id} /> when using <SpellLink id={SPELLS.CRUSADERS_MIGHT_TALENT.id} /> talent.</>, [HolySchmidt]),
   change(date(2019, 10, 21), <>Fixed a typo in <SpellLink id={SPELLS.RULE_OF_LAW_TALENT.id} />'s suggestion. </>, [Abelito75]),
   change(date(2019, 8, 12), 'Added essence Lucid Dreams.', [blazyb]),
   change(date(2019, 6, 13), <><SpellLink id={SPELLS.GLIMMER_OF_LIGHT.id} /> statistic added showing healing, damage, beacon healing, <SpellLink id={SPELLS.HOLY_SHOCK_CAST.id} />s/min and refresh utilization.</>, [HolySchmidt]),

--- a/src/parser/paladin/holy/modules/talents/CrusadersMight.js
+++ b/src/parser/paladin/holy/modules/talents/CrusadersMight.js
@@ -108,10 +108,10 @@ class CrusadersMight extends Analyzer {
           <>
             You cast Crusader Strike <b>{this.wastedHolyShockReductionCount}</b> time{(this.wastedHolyShockReductionCount > 1)?'s':''} when Holy Shock was off cooldown.<br />
             This wasted <b>{(this.wastedHolyShockReductionMs/1000).toFixed(1)}</b> seconds of Holy Shock cooldown reduction,<br />
-            preventing you from casting <b>{Math.floor(this.holyShocksCastsLost)}</b> additional Holy Shock cast{(this.holyShocksLost >= 2) ? 's':''}.<br /><br />
+            preventing you from <b>{Math.floor(this.holyShocksCastsLost)}</b> additional Holy Shock cast{(this.holyShocksLost >= 2) ? 's':''}.<br /><br />
             You cast Crusader Strike <b>{this.wastedLightOfDawnReductionCount}</b> time{(this.wastedLightOfDawnReductionCount > 1)?'s':''} when Light of Dawn was off cooldown.<br />
             This wated <b>{(this.wastedLightOfDawnReductionMs/1000).toFixed(1)}</b> seconds of Light of Dawn cooldown reduction,<br />
-            preventing you from casting <b>{Math.floor(this.lightOfDawnCastsLost)}</b> additional Light of Dawn cast{(this.lightOfDawnCastsLost > 2?'s':'')}.
+            preventing you from <b>{Math.floor(this.lightOfDawnCastsLost)}</b> additional Light of Dawn cast{(this.lightOfDawnCastsLost > 2?'s':'')}.
           </>
         )}
       />

--- a/src/parser/paladin/holy/modules/talents/CrusadersMight.js
+++ b/src/parser/paladin/holy/modules/talents/CrusadersMight.js
@@ -4,8 +4,10 @@ import { Trans } from '@lingui/macro';
 import SPELLS from 'common/SPELLS';
 import SpellIcon from 'common/SpellIcon';
 
-import Analyzer from 'parser/core/Analyzer';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import StatTracker from 'parser/shared/modules/StatTracker';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
+import Events from 'parser/core/Events';
 
 import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 
@@ -14,20 +16,31 @@ const COOLDOWN_REDUCTION_MS = 1500;
 class CrusadersMight extends Analyzer {
   static dependencies = {
     spellUsable: SpellUsable,
+    statTracker: StatTracker,
   };
 
   effectiveHolyShockReductionMs = 0;
   wastedHolyShockReductionMs = 0;
+  wastedHolyShockReductionCount = 0;
+  holyShocksCastsLost = 0;
+
   effectiveLightOfDawnReductionMs = 0;
   wastedLightOfDawnReductionMs = 0;
+  wastedLightOfDawnReductionCount = 0;
+  lightOfDawnCastsLost = 0;
 
   constructor(...args) {
     super(...args);
     this.active = this.selectedCombatant.hasTalent(SPELLS.CRUSADERS_MIGHT_TALENT.id);
+    if (!this.active) {
+      return;
+    }
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.CRUSADER_STRIKE), this.onCast);    
   }
 
-  on_byPlayer_cast(event) {
+  onCast(event) {
     const spellId = event.ability.guid;
+
     if (spellId !== SPELLS.CRUSADER_STRIKE.id) {
       return;
     }
@@ -38,20 +51,32 @@ class CrusadersMight extends Analyzer {
       this.effectiveHolyShockReductionMs += reductionMs;
       this.wastedHolyShockReductionMs += COOLDOWN_REDUCTION_MS - reductionMs;
     } else {
+      const holyShockCooldown = 9000 / (1 + this.statTracker.hastePercentage(this.statTracker.currentHasteRating));
       this.wastedHolyShockReductionMs += COOLDOWN_REDUCTION_MS;
+      this.wastedHolyShockReductionCount += 1;
+      this.holyShocksCastsLost += (COOLDOWN_REDUCTION_MS / holyShockCooldown);
+      
+      // mark the event on the timeline //
+      event.meta = event.meta || {};
+      event.meta.isInefficientCast = true;
+      event.meta.inefficientCastReason = <Trans>Holy Shock was off cooldown when you cast Crusader Strike.  You should cast Holy Shock before Crusader Strike for maximum healing or damage.</Trans>;
     }
+
     const lightOfDawnisOnCooldown = this.spellUsable.isOnCooldown(SPELLS.LIGHT_OF_DAWN_CAST.id);
     if (lightOfDawnisOnCooldown) {
       const reductionMs = this.spellUsable.reduceCooldown(SPELLS.LIGHT_OF_DAWN_CAST.id, COOLDOWN_REDUCTION_MS);
       this.effectiveLightOfDawnReductionMs += reductionMs;
       this.wastedLightOfDawnReductionMs += COOLDOWN_REDUCTION_MS - reductionMs;
     } else {
+      const lightOfDawnCooldown = 15000 / (1 + this.statTracker.hastePercentage(this.statTracker.currentHasteRating));
       this.wastedLightOfDawnReductionMs += COOLDOWN_REDUCTION_MS;
+      this.wastedLightOfDawnReductionCount += 1;
+      this.lightOfDawnCastsLost += (COOLDOWN_REDUCTION_MS / lightOfDawnCooldown);
     }
   }
 
   statistic() {
-    const formatSeconds = seconds => <Trans>{seconds}s</Trans>;
+    const formatSeconds = (seconds) => <Trans>{seconds}s</Trans>;
 
     return (
       <StatisticBox
@@ -79,6 +104,16 @@ class CrusadersMight extends Analyzer {
           </>
         )}
         label={<Trans>Cooldown reduction</Trans>}
+        tooltip={(
+          <>
+            You cast Crusader Strike <b>{this.wastedHolyShockReductionCount}</b> time{(this.wastedHolyShockReductionCount > 1)?'s':''} when Holy Shock was off cooldown.<br />
+            This wasted <b>{(this.wastedHolyShockReductionMs/1000).toFixed(1)}</b> seconds of Holy Shock cooldown reduction,<br />
+            preventing you from casting <b>{Math.floor(this.holyShocksCastsLost)}</b> additional Holy Shock cast{(this.holyShocksLost >= 2) ? 's':''}.<br /><br />
+            You cast Crusader Strike <b>{this.wastedLightOfDawnReductionCount}</b> time{(this.wastedLightOfDawnReductionCount > 1)?'s':''} when Light of Dawn was off cooldown.<br />
+            This wated <b>{(this.wastedLightOfDawnReductionMs/1000).toFixed(1)}</b> seconds of Light of Dawn cooldown reduction,<br />
+            preventing you from casting <b>{Math.floor(this.lightOfDawnCastsLost)}</b> additional Light of Dawn cast{(this.lightOfDawnCastsLost > 2?'s':'')}.
+          </>
+        )}
       />
     );
   }


### PR DESCRIPTION
Most Holy Paladin builds for raiding and M+ are taking the Crusader's Might talent in the first tier.  
![image](https://user-images.githubusercontent.com/3276248/68357297-d8e95280-00e2-11ea-84e5-4efb4ea98871.png)

The goal of these builds is to reduce the cooldown of Holy Shock to cast as many as possible.  Holy Shock will always do more damage or healing (depending on who it is cast on) than Crusader Strike.  Therefore Holy Shock should always be cast before Crusader Strike.  There are situations where it will not be beneficial to cast Light of Dawn, so I did not push those events to the timeline.
![image](https://user-images.githubusercontent.com/3276248/68357795-742ef780-00e4-11ea-8c2c-9cacc8fd2369.png)


The previous trait statistic was showing the total cooldown reduction for HS and LoD.  I added a tooltip that shows how much cooldown reduction was left "on the table" for each spell and how many extra casts it equates to.
![image](https://user-images.githubusercontent.com/3276248/68357692-20bca980-00e4-11ea-98aa-20ce1f9845af.png)

I also converted the module to use an event instead of an onCast method.