### PR TITLE
[MW] RM updates + hot tracking

### DIFF
--- a/src/parser/monk/mistweaver/CHANGELOG.js
+++ b/src/parser/monk/mistweaver/CHANGELOG.js
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 11, 12), <>Big Rising Mist overhaul. Now includes extra Vivify cleaves, Enveloping Mist, and Gusts Of mist hits from Essence Font's Hot. </>,Abelito75),
   change(date(2019, 11, 9), <>Added upwelling statistic. </>,Abelito75),
   change(date(2019, 11, 9), <>Fixed Tier45 comparison if you didn't play in a way where mana would be returned/saved. </>,Abelito75),
   change(date(2019, 10, 14), <>Fixed small typos for rising mist statistic box. </>,Abelito75),

--- a/src/parser/monk/mistweaver/modules/core/HotTracker.js
+++ b/src/parser/monk/mistweaver/modules/core/HotTracker.js
@@ -7,6 +7,8 @@ import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
 const PANDEMIC_FACTOR = 1.3;
 const PANDEMIC_EXTRA = 0.3;
 
+const TFT_REM = 10000;//10 seconds for rem
+
 // tolerated difference between expected and actual HoT fall before a 'mismatch' is logged
 const EXPECTED_REMOVAL_THRESHOLD = 200;
 
@@ -74,9 +76,19 @@ class HotTracker extends Analyzer {
       return;
     }
 
+    if(this.hots[-1] && spellId === SPELLS.RENEWING_MIST_HEAL.id){
+      if (!this.hots[targetId]) {
+        this.hots[targetId] = {};
+      }
+      this.hots[targetId][spellId] = this.hots[-1][spellId];
+      delete this.hots[-1];
+      return;
+    }
+
     const newHot = {
       start: event.timestamp,
       end: event.timestamp + this.hotInfo[spellId].duration,
+      originalEnd: event.timestamp + this.hotInfo[spellId].duration,
       spellId, // stored extra here so I don't have to convert string to number like I would if I used its key in the object.
       name: event.ability.name, // stored for logging
       ticks: [], // listing of ticks w/ effective heal amount and timestamp, to be used as part of the HoT extension calculations
@@ -88,6 +100,10 @@ class HotTracker extends Analyzer {
       this.hots[targetId] = {};
     }
     this.hots[targetId][spellId] = newHot;
+
+    if(this.selectedCombatant.hasBuff(SPELLS.THUNDER_FOCUS_TEA.id) && spellId === SPELLS.RENEWING_MIST_HEAL.id){
+      this.hots[targetId][spellId].end += TFT_REM;
+    }
   }
 
   on_byPlayer_refreshbuff(event) {
@@ -106,6 +122,8 @@ class HotTracker extends Analyzer {
     const oldEnd = hot.end;
     const freshDuration = this.hotInfo[spellId].duration;
     hot.end += this._calculateExtension(freshDuration, hot, spellId, true, true);
+
+    hot.originalEnd = hot.end;//reframe our info
 
     // seperately calculating if refresh was in pandemic, because for display to the player I want to avoid factoring in tick clipping...
     const remaining = oldEnd - event.timestamp;
@@ -138,10 +156,15 @@ class HotTracker extends Analyzer {
       return;
     }
 
-    this._checkRemovalTime(this.hots[targetId][spellId], event.timestamp, targetId);
-    this._tallyExtensions(this.hots[targetId][spellId]);
-
-    delete this.hots[targetId][spellId];
+    if(spellId === SPELLS.RENEWING_MIST_HEAL.id && this.hots[targetId][spellId].end > event.timestamp){
+      this.hots[-1] = {};
+      this.hots[-1][spellId] = this.hots[targetId][spellId];
+    }else{
+      this._checkRemovalTime(this.hots[targetId][spellId], event.timestamp, targetId);
+      this._tallyExtensions(this.hots[targetId][spellId]);
+    }
+    delete this.hots[targetId][spellId];//we still delete in the end but we move first
+    
   }
 
   /*

--- a/src/parser/monk/mistweaver/modules/talents/RisingMist.js
+++ b/src/parser/monk/mistweaver/modules/talents/RisingMist.js
@@ -5,13 +5,21 @@ import TalentStatisticBox from 'interface/others/TalentStatisticBox';
 
 import SPELLS from 'common/SPELLS';
 
-import Analyzer from 'parser/core/Analyzer';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
+import Events from 'parser/core/Events';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import HotTracker from '../core/HotTracker';
 
 const debug = false;
 
 const RISING_MIST_EXTENSION = 2000;
+
+const UNAFFECTED_SPELLS = [
+  SPELLS.CRANE_HEAL.id,
+  SPELLS.ENVELOPING_MIST.id,
+];
+
 
 class RisingMist extends Analyzer {
   static dependencies = {
@@ -30,12 +38,91 @@ class RisingMist extends Analyzer {
 
   targetCount = 0;
 
+  extraVivCleaves = 0;
+  extraVivHealing = 0;
+  extraVivOverhealing = 0;
+  extraVivAbsorbed = 0;
+
+  extraEnvHits = 0;
+  extraEnvBonusHealing = 0;
+
+  extraMasteryHits = 0
+  extraMasteryhealing = 0;
+  extraMasteryOverhealing = 0;
+  extraMasteryAbsorbed = 0;
+
+  masteryTickTock = false;
+
+  extraEFhealing = 0;
+  extraEFOverhealing = 0;
+  extraEFAbsorbed = 0;
+
   constructor(...args) {
     super(...args);
     this.active = this.selectedCombatant.hasTalent(SPELLS.RISING_MIST_TALENT.id);
+    this.evmHealingIncrease = this.selectedCombatant.hasTalent(SPELLS.MIST_WRAP_TALENT.id) ? .4 : .3;
+    if(!this.active){
+      return;
+    }
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.RISING_SUN_KICK), this.extendHots);
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.VIVIFY), this.handleVivify);
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER), this.calculateEvn);//gotta just look at all heals tbh
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.GUSTS_OF_MISTS), this.handleMastery);
   }
 
-  on_byPlayer_cast(event) {
+  handleMastery(event){
+    const targetId = event.targetID;
+    if(!this.hotTracker.hots[targetId] || !this.hotTracker.hots[targetId][SPELLS.ESSENCE_FONT_BUFF.id]){
+      return;
+    }
+    
+    const object = this.hotTracker.hots[targetId][SPELLS.ESSENCE_FONT_BUFF.id];
+
+    if(object.originalEnd < event.timestamp){
+      if(!this.masteryTickTock){
+        this.extraMasteryHits += 1;
+        this.extraMasteryhealing += event.amount || 0;
+        this.extraMasteryOverhealing += event.overheal || 0;
+        this.extraMasteryAbsorbed += event.absorbed || 0;
+      }
+      this.masteryTickTock = !this.masteryTickTock;
+    }
+  }
+
+  calculateEvn(event){
+    const targetId = event.targetID;
+    const spellId = event.ability.guid;
+    if(!this.hotTracker.hots[targetId] || !this.hotTracker.hots[targetId][SPELLS.ENVELOPING_MIST.id]){
+      return;
+    }
+    const object = this.hotTracker.hots[targetId][SPELLS.ENVELOPING_MIST.id];
+
+    if (UNAFFECTED_SPELLS.includes(spellId)) {
+      return;
+    }
+
+    if(object.originalEnd < event.timestamp){
+      this.extraEnvHits += 1;
+      this.extraEnvBonusHealing += calculateEffectiveHealing(event, this.evmHealingIncrease);
+    }
+
+  }
+
+  handleVivify(event){
+    const targetId = event.targetID;
+    if(!this.hotTracker.hots[targetId] || !this.hotTracker.hots[targetId][SPELLS.RENEWING_MIST_HEAL.id]){
+      return;
+    }
+    const object = this.hotTracker.hots[targetId][SPELLS.RENEWING_MIST_HEAL.id];
+    if(object.originalEnd < event.timestamp){
+      this.extraVivCleaves += 1;
+      this.extraVivHealing += event.amount || 0;
+      this.extraVivOverhealing += event.overheal || 0;
+      this.extraVivAbsorbed += event.absorbed || 0;
+    }
+  }
+
+  extendHots(event) {
     const spellId = event.ability.guid;
     if (SPELLS.RISING_SUN_KICK.id !== spellId) {
       return;
@@ -95,7 +182,7 @@ class RisingMist extends Analyzer {
     return this.abilityTracker.getAbility(SPELLS.RISING_MIST_HEAL.id).healingEffective;
   }
   get totalHealing() {
-    return this.hotHealing + this.directHealing;
+    return this.hotHealing + this.directHealing + this.extraMasteryhealing + this.extraVivHealing + this.extraEnvBonusHealing;
   }
 
   get averageHealing() {
@@ -104,6 +191,18 @@ class RisingMist extends Analyzer {
 
   get averageTargetsPerRM() {
     return this.targetCount / this.risingMistCount || 0;
+  }
+
+  get calculateVivOverHealing(){
+    return formatPercentage(this.extraVivOverhealing / (this.extraVivHealing + this.extraVivOverhealing));
+  }
+
+  get calculateMasteryOverHealing(){
+    return formatPercentage(this.extraMasteryOverhealing / (this.extraMasteryhealing + this.extraMasteryOverhealing));
+  }
+
+  get calculateEFOverHealing(){
+    return formatPercentage(this.extraEFOverhealing / (this.extraEFhealing + this.extraEFOverhealing));
   }
 
   statistic() {
@@ -124,6 +223,21 @@ class RisingMist extends Analyzer {
                 <li>Essense Font HoTs Extended: {this.efCount}</li>
                 <li>Renewing Mist HoTs Extended: {this.remCount}</li>
                 <li>Enveloping Mist HoTs Extended: {this.evmCount}</li>
+              </ul>
+              Vivify
+              <ul>
+                <li>Extra Cleaves: {this.extraVivCleaves}</li>
+                <li>Extra Healing: {formatNumber(this.extraVivHealing)} ({this.calculateVivOverHealing}% Overhealing)</li>
+              </ul>
+              Enveloping Mist
+              <ul>
+                <li>Extra Hits: {this.extraEnvHits}</li>
+                <li>Extra Healing: {formatNumber(this.extraEnvBonusHealing)}</li>
+              </ul>
+              Mastery
+              <ul>
+                <li>Extra Hits: {this.extraMasteryHits}</li>
+                <li>Extra Healing: {formatNumber(this.extraMasteryhealing)} ({this.calculateMasteryOverHealing}% Overhealing)</li>
               </ul>
             </ul>
           </>


### PR DESCRIPTION
Updated RM to include the healing from extra vivify cleave, extra evn hits, and extra ef mastery procs. Also made it so hot tracker can actually track rem bounces.

**### BIG NOTE HERE** These changes will show very little this patch but next patch it will be more useful. They are adding these features in its just they are extending the duration you extend hots so this is just getting work done ahead of time

![new](https://user-images.githubusercontent.com/25177817/68649444-bc895380-04f0-11ea-9447-d600c4c5aa74.png)
