### PR TITLE
[Holy Paladin] Correctly calculate extended duration provided by Light's Decree

### DIFF
--- a/src/parser/paladin/holy/CHANGELOG.js
+++ b/src/parser/paladin/holy/CHANGELOG.js
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 11, 24), <><SpellLink id={SPELLS.LIGHTS_DECREE.id} /> statistic now only shows extended duration from actual Avenging Wrath casts, since procs from Vision Of Perfection are not extended.</>, [Taleria]),
   change(date(2019, 11, 23), <><SpellLink id={SPELLS.LIGHTS_DECREE.id} /> statistic added showing healing, beacon healing and added duration.</>, [Taleria]),
   change(date(2019, 11, 9), <>Added suggestion in the timeline and a tooltip to prioritize <SpellLink id={SPELLS.HOLY_SHOCK_CAST.id} /> over <SpellLink id={SPELLS.CRUSADER_STRIKE.id} /> when using <SpellLink id={SPELLS.CRUSADERS_MIGHT_TALENT.id} /> talent.</>, [HolySchmidt]),
   change(date(2019, 10, 21), <>Fixed a typo in <SpellLink id={SPELLS.RULE_OF_LAW_TALENT.id} />'s suggestion. </>, [Abelito75]),

--- a/src/parser/paladin/holy/modules/azeritetraits/LightsDecree.js
+++ b/src/parser/paladin/holy/modules/azeritetraits/LightsDecree.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Trans } from '@lingui/macro';
-import Analyzer from 'parser/core/Analyzer';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import SPELLS from 'common/SPELLS';
 import AzeritePowerStatistic from 'interface/statistics/AzeritePowerStatistic';
@@ -10,6 +10,7 @@ import SpellIcon from 'common/SpellIcon';
 import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText/index';
 
 import BeaconHealSource from '../beacons/BeaconHealSource';
+import Events from 'parser/core/Events';
 
 const AW_BASE_DURATION = 20;
 const LIGHTS_DECREE_DURATION = 5;
@@ -37,6 +38,9 @@ class LightsDecree extends Analyzer {
     if (!this.active) {
       return;
     }
+
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER), this.onHeal);
+    this.addEventListener(this.beaconHealSource.beacontransfer.by(SELECTED_PLAYER), this.onBeaconTransfer);
   }
 
   hasAvengingWrathBuffThroughLightsDecree(event) {
@@ -52,7 +56,7 @@ class LightsDecree extends Analyzer {
     return remainingDuration <= LIGHTS_DECREE_DURATION;
   }
 
-  on_byPlayer_heal(event) {
+  onHeal(event) {
     if (!this.hasAvengingWrathBuffThroughLightsDecree(event)) {
       return;
     }
@@ -68,7 +72,7 @@ class LightsDecree extends Analyzer {
     this.healingFromGlimmer += healingDone;
   }
 
-  on_beacontransfer(event) {
+  onBeaconTransfer(event) {
     if (!this.hasAvengingWrathBuffThroughLightsDecree(event)) {
       return;
     }

--- a/src/parser/paladin/holy/modules/azeritetraits/LightsDecree.js
+++ b/src/parser/paladin/holy/modules/azeritetraits/LightsDecree.js
@@ -29,6 +29,7 @@ class LightsDecree extends Analyzer {
   regularHealing = 0;
   healingTransfered = 0;
   healingFromGlimmer = 0;
+  avengingWrathCasts = 0;
 
   constructor(...args) {
     super(...args);
@@ -41,6 +42,7 @@ class LightsDecree extends Analyzer {
 
     this.addEventListener(Events.heal.by(SELECTED_PLAYER), this.onHeal);
     this.addEventListener(this.beaconHealSource.beacontransfer.by(SELECTED_PLAYER), this.onBeaconTransfer);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.AVENGING_WRATH), this.onCastAvengingWrath);
   }
 
   hasAvengingWrathBuffThroughLightsDecree(event) {
@@ -54,6 +56,10 @@ class LightsDecree extends Analyzer {
     const remainingDuration = (end - buff.start) / 1000;
 
     return remainingDuration <= LIGHTS_DECREE_DURATION;
+  }
+
+  onCastAvengingWrath() {
+    this.avengingWrathCasts++;
   }
 
   onHeal(event) {
@@ -93,19 +99,7 @@ class LightsDecree extends Analyzer {
   }
 
   get totalDurationIncrease() {
-    const buffId = SPELLS.AVENGING_WRATH.id;
-    const hist = this.selectedCombatant.getBuffHistory(buffId);
-    if (!hist || hist.length === 0) {
-      return null;
-    }
-    let totalIncrease = 0;
-    hist.forEach((buff) => {
-      const end = buff.end || this.owner.currentTimestamp;
-      const duration = (end - buff.start) / 1000;
-      const increase = Math.max(0, duration - this.baseDuration);
-      totalIncrease += increase;
-    });
-    return totalIncrease;
+    return this.avengingWrathCasts * LIGHTS_DECREE_DURATION;
   }
 
   statistic() {

--- a/src/parser/paladin/holy/modules/azeritetraits/LightsDecree.js
+++ b/src/parser/paladin/holy/modules/azeritetraits/LightsDecree.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Trans } from '@lingui/macro';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import SPELLS from 'common/SPELLS';
@@ -107,13 +106,13 @@ class LightsDecree extends Analyzer {
       <AzeritePowerStatistic
         size="flexible"
         tooltip={(
-          <Trans>
+          <>
             The amount of healing done during the additional {LIGHTS_DECREE_DURATION} seconds given by the azerite trait. <br />
 
             Healing done: <b>{formatNumber(this.totalHealing)}</b> <br />
             Beacon healing transfered: <b>{formatNumber(this.healingTransfered)}</b> <br />
             Glimmer healing done: <b>{formatNumber(this.healingFromGlimmer)}</b> <br />
-          </Trans>
+          </>
         )}
       >
         <BoringSpellValueText spell={SPELLS.LIGHTS_DECREE}>

--- a/src/parser/paladin/holy/modules/azeritetraits/LightsDecree.js
+++ b/src/parser/paladin/holy/modules/azeritetraits/LightsDecree.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
+import Events from 'parser/core/Events';
 import SPELLS from 'common/SPELLS';
 import AzeritePowerStatistic from 'interface/statistics/AzeritePowerStatistic';
 import ItemHealingDone from 'interface/others/ItemHealingDone';
@@ -9,7 +10,6 @@ import SpellIcon from 'common/SpellIcon';
 import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText/index';
 
 import BeaconHealSource from '../beacons/BeaconHealSource';
-import Events from 'parser/core/Events';
 
 const AW_BASE_DURATION = 20;
 const LIGHTS_DECREE_DURATION = 5;


### PR DESCRIPTION
### Fixed

- Light's Decree statistic now only shows extended duration from actual Avenging Wrath casts, since procs from Vision Of Perfection are not extended.