### PR TITLE
Add Natural Harmony statistic for elemental/enhancement shaman

### DIFF
--- a/src/common/SPELLS/bfa/azeritetraits/shaman.js
+++ b/src/common/SPELLS/bfa/azeritetraits/shaman.js
@@ -57,6 +57,26 @@ export default {
     name: 'Igneous Potential',
     icon: 'spell_shaman_lavasurge',
   },
+  NATURAL_HARMONY_TRAIT: {
+    id: 278697, 
+    name: 'Natural Harmony',
+    icon: 'spell_nature_elementalprecision_1',
+  },
+  NATURAL_HARMONY_FIRE_BUFF: {
+    id: 279028, 
+    name: 'Natural Harmony: Fire',
+    icon: 'spell_nature_elementalprecision_1',
+  },
+  NATURAL_HARMONY_FROST_BUFF: {
+    id: 279029, 
+    name: 'Natural Harmony: Frost',
+    icon: 'spell_nature_elementalprecision_1',
+  },
+  NATURAL_HARMONY_NATURE_BUFF: {
+    id: 279033, 
+    name: 'Natural Harmony: Nature',
+    icon: 'spell_nature_elementalprecision_1',
+  },
   // Restoration
   OVERFLOWING_SHORES_TRAIT: {
     id: 277658,

--- a/src/parser/shaman/elemental/CHANGELOG.js
+++ b/src/parser/shaman/elemental/CHANGELOG.js
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 11, 28), <>Added a statistic for <SpellLink id={SPELLS.NATURAL_HARMONY_TRAIT.id} /> to track avg crit, haste, mastery and uptime for each</>, [Draenal]),
   change(date(2019, 10, 31), <>Add a checklist item for <SpellLink id={SPELLS.ASCENDANCE_TALENT_ELEMENTAL.id} /></>, [HawkCorrigan] ),
   change(date(2019, 10, 31), <>Fixed formatting for SoP suggestion</>, [HawkCorrigan]),
   change(date(2019, 10, 26), <>Add a checklist item for <SpellLink id={SPELLS.TOTEM_MASTERY_TALENT_ELEMENTAL.id} /> uptime.</>, [Draenal]),

--- a/src/parser/shaman/elemental/CombatLogParser.js
+++ b/src/parser/shaman/elemental/CombatLogParser.js
@@ -28,6 +28,7 @@ import Icefury from './modules/talents/Icefury';
 import Checklist from './modules/checklist/Module';
 import Buffs from './modules/Buffs';
 
+import NaturalHarmony from '../shared/azerite/NaturalHarmony';
 import LavaShock from './modules/azerite/LavaShock';
 import SynapseShock from '../shared/azerite/SynapseShock';
 import EchoOfTheElementals from './modules/azerite/EchoOfTheElementals';
@@ -75,6 +76,7 @@ class CombatLogParser extends CoreCombatLogParser {
     icefury: Icefury,
 
     // Azerite
+    naturalHarmony: NaturalHarmony,
     lavaShock: LavaShock,
     synapseShock: SynapseShock,
     echoOfTheElementals: EchoOfTheElementals,

--- a/src/parser/shaman/enhancement/CHANGELOG.js
+++ b/src/parser/shaman/enhancement/CHANGELOG.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { HawkCorrigan, niseko, mtblanton } from 'CONTRIBUTORS';
+import { HawkCorrigan, niseko, mtblanton, Draenal } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 11, 28), <>Added a statistic for <SpellLink id={SPELLS.NATURAL_HARMONY_TRAIT.id} /> to track avg crit, haste, mastery and uptime for each</>, [Draenal]),
   change(date(2019, 10, 31), <>Add a suggestion for Totem Mastery</>, [HawkCorrigan]),
   change(date(2018, 11, 18), 'Small updates to various Enhancement spells', [mtblanton]),
   change(date(2018, 11, 4), <>Added support for <SpellLink id={SPELLS.PACK_SPIRIT_TRAIT.id} /> and <SpellLink id={SPELLS.SERENE_SPIRIT_TRAIT.id} /> azerite traits.</>, [niseko]),

--- a/src/parser/shaman/enhancement/CombatLogParser.js
+++ b/src/parser/shaman/enhancement/CombatLogParser.js
@@ -26,6 +26,7 @@ import AnkhNormalizer from '../shared/normalizers/AnkhNormalizer';
 import AstralShift from '../shared/spells/AstralShift';
 import PackSpirit from '../shared/azerite/PackSpirit';
 import SereneSpirit from '../shared/azerite/SereneSpirit';
+import NaturalHarmony from '../shared/azerite/NaturalHarmony';
 
 //Resources
 import MaelstromDetails from '../shared/maelstromchart/MaelstromDetails';
@@ -63,6 +64,7 @@ class CombatLogParser extends CoreCombatLogParser {
     astralShift: AstralShift,
     packSpirit: PackSpirit,
     sereneSpirit: SereneSpirit,
+    naturalHarmony: NaturalHarmony,
 
     maelstromTracker: MaelstromTracker,
     maelstromDetails: MaelstromDetails,

--- a/src/parser/shaman/shared/azerite/NaturalHarmony.js
+++ b/src/parser/shaman/shared/azerite/NaturalHarmony.js
@@ -1,0 +1,114 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import { TooltipElement } from 'common/Tooltip';
+import { formatPercentage } from 'common/format';
+import { calculateAzeriteEffects } from 'common/stats';
+
+import Analyzer from 'parser/core/Analyzer';
+import StatTracker from 'parser/shared/modules/StatTracker';
+
+import HasteIcon from 'interface/icons/Haste';
+import UptimeIcon from 'interface/icons/Uptime';
+import CriticalStrikeIcon from 'interface/icons/CriticalStrike';
+import MasteryIcon from 'interface/icons/Mastery';
+import AzeritePowerStatistic from 'interface/statistics/AzeritePowerStatistic';
+import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText/index';
+
+const NaturalHarmonyStats = traits => Object.values(traits).reduce((total, ilvl) => {
+  const statForPiece = calculateAzeriteEffects(SPELLS.NATURAL_HARMONY_TRAIT.id, ilvl)[0]; 
+  return statForPiece + total;
+}, 0);
+
+class NaturalHarmony extends Analyzer {
+  naturalHarmonyStatValue = 0;
+
+  static dependencies = {
+    statTracker: StatTracker,
+  };
+
+  constructor(...args) {
+    super(...args);
+    this.active = this.selectedCombatant.hasTrait(SPELLS.NATURAL_HARMONY_TRAIT.id);
+    if (!this.active) {
+      return;
+    }
+
+    this.naturalHarmonyStatValue = NaturalHarmonyStats(this.selectedCombatant.traitsBySpellId[SPELLS.NATURAL_HARMONY_TRAIT.id]);
+
+    this.statTracker.add(SPELLS.NATURAL_HARMONY_FIRE_BUFF.id, {
+      crit: this.naturalHarmonyStatValue,
+    });
+
+    this.statTracker.add(SPELLS.NATURAL_HARMONY_NATURE_BUFF.id, {
+      haste: this.naturalHarmonyStatValue,
+    });
+
+    this.statTracker.add(SPELLS.NATURAL_HARMONY_FROST_BUFF.id, {
+      mastery: this.naturalHarmonyStatValue,
+    });
+  }
+
+  get critBuffUptime() {
+    return this.selectedCombatant.getBuffUptime(SPELLS.NATURAL_HARMONY_FIRE_BUFF.id) / this.owner.fightDuration;
+  }
+
+  get hasteBuffUptime() {
+    return this.selectedCombatant.getBuffUptime(SPELLS.NATURAL_HARMONY_NATURE_BUFF.id) / this.owner.fightDuration;
+  }
+
+  get masteryBuffUptime() {
+    return this.selectedCombatant.getBuffUptime(SPELLS.NATURAL_HARMONY_FROST_BUFF.id) / this.owner.fightDuration;
+  }
+
+  get averageCrit() {
+    return (this.naturalHarmonyStatValue * this.critBuffUptime).toFixed(0);    
+  }
+
+  get averageHaste() {
+    return (this.naturalHarmonyStatValue * this.hasteBuffUptime).toFixed(0);
+  }
+
+  get averageMastery() {
+    return (this.naturalHarmonyStatValue * this.masteryBuffUptime).toFixed(0);
+  }
+  
+  statistic() {
+    return (
+      <AzeritePowerStatistic
+        size="flexible"
+        tooltip={(
+          <div>
+            Grants {this.naturalHarmonyStatValue} critical strike via <SpellLink id={SPELLS.NATURAL_HARMONY_FIRE_BUFF.id} /> for 12 seconds after casting a fire spell.<br />
+            Grants {this.naturalHarmonyStatValue} haste via <SpellLink id={SPELLS.NATURAL_HARMONY_NATURE_BUFF.id} /> for 12 seconds after casting a nature spell.<br />
+            Grants {this.naturalHarmonyStatValue} mastery via <SpellLink id={SPELLS.NATURAL_HARMONY_FROST_BUFF.id} /> for 12 seconds after casting a frost spell.
+          </div>
+        )}
+      >
+        <BoringSpellValueText spell={SPELLS.NATURAL_HARMONY_TRAIT}>
+          <CriticalStrikeIcon /> <TooltipElement content={(
+            <div>
+              <UptimeIcon /> {formatPercentage(this.critBuffUptime, 2)} uptime
+            </div>
+          )}
+          > {this.averageCrit} <small>average Crit gained</small></TooltipElement><br />
+          <HasteIcon /> <TooltipElement content={(
+            <div>
+              <UptimeIcon /> {formatPercentage(this.hasteBuffUptime, 2)} uptime 
+            </div>
+          )}
+          >{this.averageHaste} <small>average Haste gained</small></TooltipElement><br />
+          <MasteryIcon /> <TooltipElement content={(
+            <div>
+              <UptimeIcon /> {formatPercentage(this.masteryBuffUptime, 2)} uptime 
+            </div>
+          )} 
+          >{this.averageMastery} <small>average Mastery gained</small></TooltipElement>
+        </BoringSpellValueText>
+      </AzeritePowerStatistic>
+    );
+  }
+}
+
+export default NaturalHarmony;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6856899/69844632-aab6e880-1232-11ea-9bd4-6b2bb1fa548d.png)

Hovering avg stat gained lines gives uptime for each buff.

The tooltip on the stat reads:
```
Grants x critical strike via Natural Harmony: Fire for 12 seconds after casting a fire spell.
Grants x haste via Natural Harmony: Nature for 12 seconds after casting a nature spell.
Grants x mastery via Natural Harmony: Frost for 12 seconds after casting a frost spell.
```
