### PR TITLE
[Blood][Bug] fixed MR stack counting & blood version bump

### DIFF
--- a/src/parser/deathknight/blood/CHANGELOG.js
+++ b/src/parser/deathknight/blood/CHANGELOG.js
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 12, 4), <>Fixed an issue for some logs where <SpellLink id={SPELLS.BONE_SHIELD.id} /> wouldn't be counted properly, resulting in wrong bad <SpellLink id={SPELLS.MARROWREND.id} />-metrics</>, [joshinator]),
   change(date(2019, 2, 14), <>Updated <SpellLink id={SPELLS.BONE_SHIELD.id} />-suggestion to account for different types of bad <SpellLink id={SPELLS.MARROWREND.id} />s</>, [joshinator]),
   change(date(2019, 2, 3), <>Added <SpellLink id={SPELLS.BLOODY_RUNEBLADE.id} /> azerite trait and marked patch 8.1 compatible.</>, [Yajinni]),
   change(date(2018, 11, 30), <>Readd the checklist, make <SpellLink id={SPELLS.OSSUARY_TALENT.id} />-suggestion based on <SpellLink id={SPELLS.DEATH_STRIKE.id} /> casts without <SpellLink id={SPELLS.OSSUARY_TALENT.id} />.</>, [joshinator]),

--- a/src/parser/deathknight/blood/CONFIG.js
+++ b/src/parser/deathknight/blood/CONFIG.js
@@ -12,7 +12,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Yajinni, joshinator],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '8.1',
+  patchCompatibility: '8.2.5',
   // If set to  false`, the spec will show up as unsupported.
   isSupported: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.

--- a/src/parser/deathknight/blood/modules/features/MarrowrendUsage.js
+++ b/src/parser/deathknight/blood/modules/features/MarrowrendUsage.js
@@ -58,14 +58,14 @@ class MarrowrendUsage extends Analyzer {
   on_toPlayer_applybuff(event) {
     if (event.ability.guid === SPELLS.BONE_SHIELD.id){
       this.currentBoneShieldBuffer += 1;
-      this.currentBoneShieldStacks += 1;
+      this.currentBoneShieldStacks = event.stack;
     }
   }
 
   on_toPlayer_applybuffstack(event) {
     if (event.ability.guid === SPELLS.BONE_SHIELD.id){
       this.currentBoneShieldBuffer += 1;
-      this.currentBoneShieldStacks += 1;
+      this.currentBoneShieldStacks = event.stack;
     }
   }
 
@@ -79,7 +79,7 @@ class MarrowrendUsage extends Analyzer {
   on_toPlayer_removebuffstack(event) {
     if (event.ability.guid === SPELLS.BONE_SHIELD.id){
       this.currentBoneShieldBuffer = 0;
-      this.currentBoneShieldStacks -= 1;
+      this.currentBoneShieldStacks = event.stack;
     }
   }
 
@@ -99,7 +99,7 @@ class MarrowrendUsage extends Analyzer {
         const wasted = MR_GAIN - this.currentBoneShieldBuffer;
         this.badMRCasts += 1;
         this.bsStacksWasted += wasted;
-        badCast = badCast + `You made this cast with ${boneShieldStacks} stacks of Bone Shield while it had ${(durationLeft).toFixed(1)} seconds left, wasting ${wasted} charges.<br />`;
+        badCast = badCast + `You made this cast with ${boneShieldStacks} stacks of Bone Shield while it had ${(durationLeft).toFixed(1)} seconds left, wasting ${wasted} charges.`;
       }
 
       if (this.hasBonesOfTheDamned && boneShieldStacks >= REFRESH_AT_STACKS_WITHOUT_BONES_OF_THE_DAMNED) {


### PR DESCRIPTION
- Bumped version from 8.1 to 8.2.5 (had no gameplay impacting changes)
- Removed the `<br>` from the tooltip as it's not working anymore
- Fixed an issue where the BS-tracker wouldn't count the stacks gained/lost properly, resulting in wrong metrics for bad marrowrend usage, wasted BS stacks and BotD procs.
The change does not impact other logs. The module now essentially just copies the correct amount of stacks from the last event, making it somewhat self-correcting instead of continuing with wrong numbers.

**bugged example**
report/btLn3zCJWP1ARNVY/10-Mythic+Queen+Azshara+-+Kill+(10:32)/Scorned/standard/timeline
live
![image](https://user-images.githubusercontent.com/29842841/70130993-d5190380-1681-11ea-92ba-6b6d60f4d01e.png)

updated
![image](https://user-images.githubusercontent.com/29842841/70131029-e7933d00-1681-11ea-9d18-c0f1ca5dca48.png)