### PR TITLE
ctrl on modifier to go to local host

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -8,6 +8,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/contributor/Button';
 
 export default [
+  change(date(2019, 12, 8), <>Reduced likely hood to accidnetly go to unintended page.</>, Abelito75),
   change(date(2019, 11, 14), "Added the ability to define different rotations for analysis (like no icelance for frost mages)", Zeboot),
   change(date(2019, 10, 25), <>Fixed a bug in the dispels module.</>, Khadaj),
   change(date(2019, 10, 25), <>Added missing spell information for resource refunds and gains from <SpellLink id={SPELLS.LUCID_DREAMS_MINOR.id} /> and <SpellLink id={SPELLS.VISION_OF_PERFECTION.id} />.</>, Juko8),

--- a/src/interface/Hotkeys.js
+++ b/src/interface/Hotkeys.js
@@ -17,8 +17,8 @@ class Hotkeys extends React.PureComponent {
     if (document.activeElement && document.activeElement !== document.body) {
       return;
     }
-
-    if (e.key === 'l') {
+    //Make it more unlikely that people go to localhost
+    if (e.ctrlKey && e.key === 'l') {
       console.log('Pressed "l". This is a shortcut for redirecting to localhost');
       window.location = `http://localhost:3000${window.location.pathname}`;
     }


### PR DESCRIPTION
Make it less likely that if someone accidentally starts typing in wowA they won't go to localhost
new combo is ctrl + l 
(this is a lower case L not a capital I)