### PR TITLE
fixed parseLog parameters & integrationTest can test spec builds

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -46,6 +46,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/ContributorButton';
 
 export default [
+  change(date(2019, 12, 17), "Fixed integration testing code with new build support.", [emallson]),
   change(date(2019, 12, 16), "Updated internal test tools to use new API URL.", [emallson]),
   change(date(2019, 12, 15), "Fix spell icons in cooldowns tab.", [Zerotorescue]),
   change(date(2019, 12, 15), "Added an available raid buffs panel to the player selection page.", [axelkic, Zerotorescue]),

--- a/src/parser/core/tests/integrationTest.js
+++ b/src/parser/core/tests/integrationTest.js
@@ -60,15 +60,16 @@ function checklist(parser) {
  *
  * @param {object} parserClass - (uninstantiated) CombatLogParser subclass to test.
  * @param {string} filename - which log from `test-logs` to load
+ * @param {string} build - which build to use when parsing the log. undefined means "no build"
  * @param {boolean} suppressWarn - Suppress `console.warn`
  * @param {boolean} suppressLog - Suppress `console.log`
  */
-export default function integrationTest(parserClass, filename, suppressLog = true, suppressWarn = true) {
+export default function integrationTest(parserClass, filename, build = undefined, suppressLog = true, suppressWarn = true) {
   return () => {
     let parser;
     beforeAll(async () => {
       const log = await loadLog(filename);
-      parser = parseLog(parserClass, log, suppressLog, suppressWarn);
+      parser = parseLog(parserClass, log, build, suppressLog, suppressWarn);
       window.fetch = jest.fn(url => {
         throw new Error(`Attempt to fetch "${url}". These tests shouldn't do AJAX calls.`);
       });

--- a/src/parser/core/tests/log-tools.js
+++ b/src/parser/core/tests/log-tools.js
@@ -50,7 +50,7 @@ export function suppressLogging(log, warn, error, cb) {
   return res;
 }
 
-export function parseLog(parserClass, log, build = undefined) {
+export function parseLog(parserClass, log, build = undefined, suppressLog = true, suppressWarn = true) {
   const friendlies = log.report.friendlies.find(({id}) => id === log.meta.player.id);
   const fight = {...log.report.fights.find(({id}) => id === log.meta.fight.id), offset_time: 0};
   const builds = ConfigLoader.getConfig(log.meta.player.specID).builds;
@@ -67,7 +67,7 @@ export function parseLog(parserClass, log, build = undefined) {
     build,
     builds,
   );
-  return suppressLogging(true, true, false, () => {
+  return suppressLogging(suppressLog, suppressWarn, false, () => {
     parser.normalize(JSON.parse(JSON.stringify(log.events))).forEach(event => parser.getModule(EventEmitter).triggerEvent(event));
     parser.finish();
     return parser;

--- a/src/parser/mage/frost/CombatLogParser.test.js
+++ b/src/parser/mage/frost/CombatLogParser.test.js
@@ -4,4 +4,5 @@ import CombatLogParser from './CombatLogParser';
 describe('The Frost Mage Analyzer', integrationTest(
   CombatLogParser,
   'frost-mage-example',
+  "NO_IL"
 ));

--- a/src/parser/mage/frost/CombatLogParser.test.js
+++ b/src/parser/mage/frost/CombatLogParser.test.js
@@ -4,5 +4,5 @@ import CombatLogParser from './CombatLogParser';
 describe('The Frost Mage Analyzer', integrationTest(
   CombatLogParser,
   'frost-mage-example',
-  "NO_IL"
+  "NO_IL",
 ));


### PR DESCRIPTION
The Frost Mage integration test was using `NO_IL`, so those tests again pass.