### PR TITLE
[BrM] Purifying Brew / Heavy Stagger threshold calculation change

### DIFF
--- a/src/parser/monk/brewmaster/CHANGELOG.js
+++ b/src/parser/monk/brewmaster/CHANGELOG.js
@@ -8,6 +8,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2019, 12, 22), <>Warning threshold for <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} /> / <SpellLink id={SPELLS.PURIFYING_BREW.id} /> is now calculated based on time spent in red stagger.</>, emallson),
   change(date(2019, 10, 28), <>Added support for items in the <SpellLink id={SPELLS.CELESTIAL_FORTUNE_HEAL.id} /> tab.</>, Abelito75),
   change(date(2019, 10, 16), <>Removed <SpellLink id={SPELLS.ARCANE_TORRENT_ENERGY.id} /> from Brewmaster suggestions.</>, emallson),
   change(date(2019, 9, 27), <>Update to date for 8.2.5 </>,Abelito75),

--- a/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
@@ -4954,32 +4954,6 @@ Array [
   Object {
     "details": null,
     "icon": "inv_misc_beer_06",
-    "importance": "major",
-    "issue": <React.Fragment>
-      You should 
-      <em>
-        almost never
-      </em>
-       cast 
-      <ForwardRef
-        id={119582}
-      />
-       without being in at least 
-      <ForwardRef
-        id={124273}
-      />
-      . Notable exceptions are when you otherwise can't be healed (such as on Zek'voz).
-    </React.Fragment>,
-    "stat": <React.Fragment>
-      33.33% of your purifies were less than Heavy Stagger
-       (
-      &lt; 10.00% is recommended
-      )
-    </React.Fragment>,
-  },
-  Object {
-    "details": null,
-    "icon": "inv_misc_beer_06",
     "importance": "minor",
     "issue": <React.Fragment>
       You should spend brews not needed to maintain 
@@ -6633,8 +6607,8 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
               className="perf-bar"
               style={
                 Object {
-                  "backgroundColor": "#ac1f39",
-                  "width": "32.801003785663%",
+                  "backgroundColor": "#ffc84a",
+                  "width": "58.35376377018014%",
                 }
               }
             />
@@ -6754,7 +6728,21 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
                    
                   Heavy Stagger
                 </a>
-                 is not dangerous in itself. You should almost never purify lower than this unless you cannot be healed.
+                 is not dangerous in itself. While not every fight will put you into 
+                <a
+                  href="http://wowhead.com/spell=124273"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <img
+                    alt=""
+                    className="icon game "
+                    src="//render-us.worldofwarcraft.com/icons/56/priest_icon_chakra_red.jpg"
+                  />
+                   
+                  Heavy Stagger
+                </a>
+                 consistently, you should often aim to save your purifies for these parts of the fight.
               </li>
               <li>
                 If you are going to purify a hit, do so as soon as possible after it lands. Every half-second delayed after the hit causes you to take 5% of the hit's damage from 
@@ -6825,6 +6813,36 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
                 </a>
               </div>
               <div
+                className="flex-sub"
+                style={
+                  Object {
+                    "marginLeft": 10,
+                  }
+                }
+              >
+                <div
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onTouchStart={[Function]}
+                >
+                  <svg
+                    className="icon"
+                    viewBox="0 0 100 100"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M53.1,73h-7.2c-1.1,0-1.9-0.9-1.9-1.9V44h11v27.1C55,72.1,54.1,73,53.1,73z"
+                    />
+                    <path
+                      d="M55,39H44v-9.1c0-1.1,0.9-1.9,1.9-1.9h7.2c1.1,0,1.9,0.9,1.9,1.9V39z"
+                    />
+                    <path
+                      d="M50,96C24.6,96,4,75.4,4,50S24.6,4,50,4s46,20.6,46,46S75.4,96,50,96z M50,12c-21,0-38,17-38,38s17,38,38,38s38-17,38-38   S71,12,50,12z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div
                 className="flex-sub content-middle text-muted"
                 style={
                   Object {
@@ -6863,9 +6881,9 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#ac1f39",
+                        "backgroundColor": "#4ec04e",
                         "transition": "background-color 800ms",
-                        "width": "19.980000000000004%",
+                        "width": "100%",
                       }
                     }
                   />

--- a/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
+++ b/src/parser/monk/brewmaster/__snapshots__/CombatLogParser.test.js.snap
@@ -6742,7 +6742,7 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
                    
                   Heavy Stagger
                 </a>
-                 consistently, you should often aim to save your purifies for these parts of the fight.
+                 consistently, this remains a good rule of thumb.
               </li>
               <li>
                 If you are going to purify a hit, do so as soon as possible after it lands. Every half-second delayed after the hit causes you to take 5% of the hit's damage from 
@@ -6797,20 +6797,21 @@ exports[`The Brewmaster Analyzer should match the checklist snapshot 1`] = `
               <div
                 className="flex-main"
               >
-                Purifies with less than 
+                Inefficient 
                 <a
-                  href="http://wowhead.com/spell=124273"
+                  href="http://wowhead.com/spell=119582"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
                   <img
                     alt=""
                     className="icon game "
-                    src="//render-us.worldofwarcraft.com/icons/56/priest_icon_chakra_red.jpg"
+                    src="//render-us.worldofwarcraft.com/icons/56/inv_misc_beer_06.jpg"
                   />
                    
-                  Heavy Stagger
+                  Purifying Brew
                 </a>
+                 casts.
               </div>
               <div
                 className="flex-sub"

--- a/src/parser/monk/brewmaster/modules/features/checklist/Component.js
+++ b/src/parser/monk/brewmaster/modules/features/checklist/Component.js
@@ -68,15 +68,15 @@ const BrewmasterMonkChecklist = ({ combatant, castEfficiency, thresholds }) => {
 <>
           Effective use of <SpellLink id={SPELLS.PURIFYING_BREW.id} /> is fundamental to playing Brewmaster successfully. While we cannot <em>automatically</em> tell whether a purify is effective or not, there are some simple guidelines that naturally lead to more effective purifies:
           <ul>
-            <li>Avoid casting <SpellLink id={SPELLS.PURIFYING_BREW.id} /> at less than <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} />. In a raid environment, <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} /> is not dangerous in itself. While not every fight will put you into <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} /> consistently, you should often aim to save your purifies for these parts of the fight.</li>
+            <li>Avoid casting <SpellLink id={SPELLS.PURIFYING_BREW.id} /> at less than <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} />. In a raid environment, <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} /> is not dangerous in itself. While not every fight will put you into <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} /> consistently, this remains a good rule of thumb.</li>
             <li>If you are going to purify a hit, do so as soon as possible after it lands. Every half-second delayed after the hit causes you to take 5% of the hit's damage from <SpellLink id={SPELLS.STAGGER.id} />.</li>
           </ul>
           For more information on effective use of <SpellLink id={SPELLS.PURIFYING_BREW.id} />, see the <a href="https://www.peakofserenity.com/bfa/brewmaster/purifying/">Peak of Serenity guide</a>.
         </>
 )}
     >
-      <Requirement name={<>Purifies with less than <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} /></>} thresholds={thresholds.purifyHeavy}
-        tooltip="Not every fight puts you in Heavy Stagger consistently. The warning threshold here is calculated based on how much time you spent in Heavy Stagger." />
+      <Requirement name={<>Inefficient <SpellLink id={SPELLS.PURIFYING_BREW.id} /> casts.</>} thresholds={thresholds.purifyHeavy}
+        tooltip="A purify is 'inefficient' if it occurs with (relatively) low stagger. The warning threshold is calculated based on how much time you spent in Heavy Stagger." />
       <Requirement name={'Average Purification Delay'} thresholds={thresholds.purifyDelay}
         tooltip="The delay is tracked from the most recent time you were able to purify after a hit. If the hit occurred when no charges were available, you are not penalized." />
       <Requirement name={<>Available <SpellLink id={SPELLS.PURIFYING_BREW.id} /> charges used</>} thresholds={thresholds.purifyCasts}

--- a/src/parser/monk/brewmaster/modules/features/checklist/Component.js
+++ b/src/parser/monk/brewmaster/modules/features/checklist/Component.js
@@ -68,14 +68,15 @@ const BrewmasterMonkChecklist = ({ combatant, castEfficiency, thresholds }) => {
 <>
           Effective use of <SpellLink id={SPELLS.PURIFYING_BREW.id} /> is fundamental to playing Brewmaster successfully. While we cannot <em>automatically</em> tell whether a purify is effective or not, there are some simple guidelines that naturally lead to more effective purifies:
           <ul>
-            <li>Avoid casting <SpellLink id={SPELLS.PURIFYING_BREW.id} /> at less than <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} />. In a raid environment, <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} /> is not dangerous in itself. You should almost never purify lower than this unless you cannot be healed.</li>
+            <li>Avoid casting <SpellLink id={SPELLS.PURIFYING_BREW.id} /> at less than <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} />. In a raid environment, <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} /> is not dangerous in itself. While not every fight will put you into <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} /> consistently, you should often aim to save your purifies for these parts of the fight.</li>
             <li>If you are going to purify a hit, do so as soon as possible after it lands. Every half-second delayed after the hit causes you to take 5% of the hit's damage from <SpellLink id={SPELLS.STAGGER.id} />.</li>
           </ul>
           For more information on effective use of <SpellLink id={SPELLS.PURIFYING_BREW.id} />, see the <a href="https://www.peakofserenity.com/bfa/brewmaster/purifying/">Peak of Serenity guide</a>.
         </>
 )}
     >
-      <Requirement name={<>Purifies with less than <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} /></>} thresholds={thresholds.purifyHeavy} />
+      <Requirement name={<>Purifies with less than <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} /></>} thresholds={thresholds.purifyHeavy}
+        tooltip="Not every fight puts you in Heavy Stagger consistently. The warning threshold here is calculated based on how much time you spent in Heavy Stagger." />
       <Requirement name={'Average Purification Delay'} thresholds={thresholds.purifyDelay}
         tooltip="The delay is tracked from the most recent time you were able to purify after a hit. If the hit occurred when no charges were available, you are not penalized." />
       <Requirement name={<>Available <SpellLink id={SPELLS.PURIFYING_BREW.id} /> charges used</>} thresholds={thresholds.purifyCasts}

--- a/src/parser/monk/brewmaster/modules/spells/PurifyingBrew.js
+++ b/src/parser/monk/brewmaster/modules/spells/PurifyingBrew.js
@@ -203,7 +203,7 @@ class PurifyingBrew extends Analyzer {
     });
 
     when(this.purifyHeavySuggestion).addSuggestion((suggest, actual, recommended) => {
-      return suggest(<>You should <em>almost never</em> cast <SpellLink id={SPELLS.PURIFYING_BREW.id} /> without being in at least <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} />. Notable exceptions are when you otherwise can't be healed (such as on Zek'voz).</>)
+      return suggest(<>You should avoid casting <SpellLink id={SPELLS.PURIFYING_BREW.id} /> without being in at least <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} />. While not every fight will put you into <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} /> consistently, you should often aim to save your purifies for these parts of the fight.</>)
         .icon(SPELLS.PURIFYING_BREW.icon)
         .actual(`${formatPercentage(actual)}% of your purifies were less than Heavy Stagger`)
         .recommended(`< ${formatPercentage(recommended)}% is recommended`);

--- a/src/parser/monk/brewmaster/modules/spells/PurifyingBrew.js
+++ b/src/parser/monk/brewmaster/modules/spells/PurifyingBrew.js
@@ -90,7 +90,7 @@ class PurifyingBrew extends Analyzer {
     return this.purifyAmounts.reduce((prev, cur) => prev + cur, 0);
   }
 
-  get badPurifies() {
+  get belowHeavyPurifies() {
     return this.totalPurifies - this.heavyPurifies;
   }
 
@@ -166,12 +166,15 @@ class PurifyingBrew extends Analyzer {
   }
 
   get purifyHeavySuggestion() {
+    const heavyUptime = this.selectedCombatant.getBuffUptime(SPELLS.HEAVY_STAGGER_DEBUFF.id) / this.owner.fightDuration;
+    const threshold = Math.max(1 - 2 * heavyUptime, 0) + 0.1;
+    console.log(`Purify threshold: ${threshold}`);
     return {
-      actual: this.badPurifies / this.totalPurifies,
+      actual: this.belowHeavyPurifies / this.totalPurifies,
       isGreaterThan: {
-        minor: 0.1,
-        average: 0.15,
-        major: 0.2,
+        minor: threshold,
+        average: 1.5 * threshold,
+        major: 2 * threshold,
       },
       style: 'percentage',
     };
@@ -224,7 +227,7 @@ class PurifyingBrew extends Analyzer {
           <>
             Purifying Brew removed <strong>{formatNumber(this.totalPurified)}</strong> damage in total over {this.totalPurifies} casts.<br />
             The smallest purify removed <strong>{formatNumber(this.minPurify)}</strong> and the largest purify removed <strong>{formatNumber(this.maxPurify)}</strong>.<br />
-            You purified <strong>{this.badPurifies}</strong> ({formatPercentage(this.badPurifies / this.totalPurifies)}%) times without reaching Heavy Stagger.<br />
+            You purified <strong>{this.belowHeavyPurifies}</strong> ({formatPercentage(this.belowHeavyPurifies / this.totalPurifies)}%) times without reaching Heavy Stagger.<br />
             Your purifies were delayed from the nearest peak by <strong>{(this.avgPurifyDelay / 1000).toFixed(2)}s</strong> on average.
           </>
         )}


### PR DESCRIPTION
**tl;dr** - The old threshold was set in Legion. Half the fights this tier didn't consistently put you in heavy stagger (i have 0.96% time in Heavy Stagger on radiance), which made the threshold wrong. This changes it to adjust based on actual time in Heavy Stagger.

The new function is `threshold(x) = max(1 - 2 x, 0) + 0.1` (y = threshold, x = fraction of time in heavy stagger):
![Screenshot from 2019-12-22 12-43-27](https://user-images.githubusercontent.com/4909458/71325454-249d6300-24bb-11ea-960f-5f35ea82349c.png)

If you spend at least 50% of the fight in heavy stagger, the threshold is unchanged. Otherwise, it is increased. The only fight that will likely be unchanged this tier is Za'qul, where 40-60% heavy stagger is pretty common. This will still ding people for purifying too often during medium/light stagger, but not on fights where you don't have other options. At some point, I should *probably* make all light stagger purifies actual errors, but thats a problem for future me.
