### PR TITLE
Fix #support Player Selection breaking

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -9,6 +9,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/ContributorButton';
 
 export default [
+  change(date(2020, 2, 12), 'Fixed a bug that breaks the player selection when there is incomplete information from warcraftlogs.', niseko),
   change(date(2020, 2, 9), 'Added statistics for the 8.3 Alchemist Stones.', niseko),
   change(date(2020, 2, 5), <> Implemented <ItemLink id={ITEMS.VOID_TWISTED_TITANSHARD.id} />, <ItemLink id={ITEMS.VITA_CHARGED_TITANSHARD.id} /> and <SpellLink id={SPELLS.TITANIC_EMPOWERMENT.id} />. </>, Putro),
   change(date(2020, 2, 5), <>Added <SpellLink id={SPELLS.HONED_MIND_BUFF.id} />, <SpellLink id={SPELLS.SURGING_VITALITY_BUFF.id} />, <SpellLink id={SPELLS.RACING_PULSE_BUFF.id} /> and <SpellLink id={SPELLS.DEADLY_MOMENTUM_BUFF.id} />.</>, niseko),

--- a/src/interface/ReportRaidBuffList/ReportRaidBuffList.tsx
+++ b/src/interface/ReportRaidBuffList/ReportRaidBuffList.tsx
@@ -45,6 +45,9 @@ const getCompositionBreakdown = (combatants: CombatantInfoEvent[]) => {
 
   return combatants.reduce((map, combatant) => {
     const spec = SPECS[combatant.specID];
+    if (!spec) {
+      return map;
+    }
     const className = spec.className;
 
     AVAILABLE_RAID_BUFFS.forEach((providedBy, spellId) => {


### PR DESCRIPTION
https://discordapp.com/channels/316864121536512000/360770373454659585/676947886126268437

Warcraftlogs gave us incomplete information on one of the players and caused the player selection to break through the raid buffs module.
https://wowanalyzer.com/report/G32tBkRD4x8PVQCJ/7-Normal+N%27Zoth+the+Corruptor+-+Kill+(11:20)
![image](https://user-images.githubusercontent.com/2842471/74338524-a9fa1100-4da2-11ea-8b27-7caf187cd845.png)

The player causing that issue still won't be select able, as there is a lot of information missing, but the rest works fine.