### PR TITLE
Update raden trinket values to match in-game behaviour

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -14,7 +14,7 @@ export default [
   change(date(2020, 2, 12), 'Implemented a corruption overview on the character page.', Putro),
   change(date(2020, 2, 12), 'Fixed a bug that breaks the player selection when there is incomplete information from warcraftlogs.', niseko),
   change(date(2020, 2, 9), 'Added statistics for the 8.3 Alchemist Stones.', niseko),
-  change(date(2020, 2, 5), <> Implemented <ItemLink id={ITEMS.VOID_TWISTED_TITANSHARD.id} />, <ItemLink id={ITEMS.VITA_CHARGED_TITANSHARD.id} /> and <SpellLink id={SPELLS.TITANIC_EMPOWERMENT.id} />. </>, Putro),
+  change(date(2020, 2, 5), <> Implemented <ItemLink id={ITEMS.VOID_TWISTED_TITANSHARD.id} />, <ItemLink id={ITEMS.VITA_CHARGED_TITANSHARD.id} /> as well as an individual statistic for the set bonus <SpellLink id={SPELLS.TITANIC_EMPOWERMENT.id} />. </>, Putro),
   change(date(2020, 2, 5), <>Added <SpellLink id={SPELLS.HONED_MIND_BUFF.id} />, <SpellLink id={SPELLS.SURGING_VITALITY_BUFF.id} />, <SpellLink id={SPELLS.RACING_PULSE_BUFF.id} /> and <SpellLink id={SPELLS.DEADLY_MOMENTUM_BUFF.id} />.</>, niseko),
   change(date(2020, 2, 5), <>Added <SpellLink id={SPELLS.VOID_RITUAL_BUFF.id} />.</>, niseko),
   change(date(2020, 2, 5), <>Added <SpellLink id={SPELLS.SIPHONER_T3.id} /> and fixed leech stat values in parses using this corruption.</>, niseko),

--- a/src/parser/shared/modules/items/bfa/raids/nyalothathewakingcity/VitaChargedTitanshard.js
+++ b/src/parser/shared/modules/items/bfa/raids/nyalothathewakingcity/VitaChargedTitanshard.js
@@ -25,7 +25,7 @@ class VitaChargedTitanshard extends Analyzer {
     this.active = !!this._item;
 
     if (this.active) {
-      this.hasteRating = calculateSecondaryStatDefault(445, 611, this._item.itemLevel);
+      this.hasteRating = calculateSecondaryStatDefault(445, 1525, this._item.itemLevel);
       this.statTracker.add(SPELLS.VITA_CHARGED_BUFF.id, {
         haste: this.hasteRating,
       });

--- a/src/parser/shared/modules/items/bfa/raids/nyalothathewakingcity/VoidTwistedTitanshard.js
+++ b/src/parser/shared/modules/items/bfa/raids/nyalothathewakingcity/VoidTwistedTitanshard.js
@@ -30,7 +30,7 @@ class VoidTwistedTitanshard extends Analyzer {
     this.active = !!this._item;
 
     if (this.active) {
-      this.critRating = calculateSecondaryStatDefault(460, 1573, this._item.itemLevel);
+      this.critRating = calculateSecondaryStatDefault(460, 1543, this._item.itemLevel);
       this.statTracker.add(SPELLS.VOID_SHROUD.id, {
         crit: this.critRating,
       });

--- a/src/parser/shared/modules/items/bfa/raids/nyalothathewakingcity/VoidTwistedTitanshard.js
+++ b/src/parser/shared/modules/items/bfa/raids/nyalothathewakingcity/VoidTwistedTitanshard.js
@@ -30,7 +30,7 @@ class VoidTwistedTitanshard extends Analyzer {
     this.active = !!this._item;
 
     if (this.active) {
-      this.critRating = calculateSecondaryStatDefault(445, 589, this._item.itemLevel);
+      this.critRating = calculateSecondaryStatDefault(460, 1573, this._item.itemLevel);
       this.statTracker.add(SPELLS.VOID_SHROUD.id, {
         crit: this.critRating,
       });


### PR DESCRIPTION
~~SimulationCraft seems to be 30 critrating off when calculating the voidshroud buff, going with in-game numbers (30 crit rating at ilvl460)~~ Scamaz'd by human race