### PR TITLE
Add item warnings to Core and update focuscaptracker for Hunter

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -9,6 +9,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/ContributorButton';
 
 export default [
+  change(date(2020, 2, 21), <>Added the possibility of adding item warnings, and added a warning for people using <ItemLink id={ITEMS.WHISPERING_ELDRITH_BOW.id} />.</>, Putro),
   change(date(2020, 2, 21), <>Added <SpellLink id={SPELLS.SYMBIOTIC_PRESENCE.id} />.</>, niseko),
   change(date(2020, 2, 17), <>Added <ItemLink id={ITEMS.FORBIDDEN_OBSIDIAN_CLAW.id} /> and <ItemLink id={ITEMS.HUMMING_BLACK_DRAGONSCALE.id} />.</>, niseko),
   change(date(2020, 2, 14), <>Updated <SpellLink id={SPELLS.VOID_RITUAL_BUFF.id} /> and <SpellLink id={SPELLS.SURGING_VITALITY_BUFF.id} /> with the hotfixed stat values.</>, niseko),

--- a/src/common/ITEMS/bfa/raids/nyalothathewakingcity/index.js
+++ b/src/common/ITEMS/bfa/raids/nyalothathewakingcity/index.js
@@ -3,6 +3,14 @@ import ITEM_QUALITIES from 'game/ITEM_QUALITIES';
 export default {
   // Group by boss (with comments)
 
+  //Skitra the Prophet
+  WHISPERING_ELDRITH_BOW: {
+    id: 172193,
+    name: 'Whispering Eldritch Bow',
+    icon: 'inv_bow_1h_nzothraid_d_01',
+    quality: ITEM_QUALITIES.PURPLE,
+  },
+
   // Ra-den the Despoiled
   VITA_CHARGED_TITANSHARD: { //Trinket
     id: 174500,
@@ -10,7 +18,6 @@ export default {
     icon: 'spell_nature_lightningoverload',
     quality: ITEM_QUALITIES.PURPLE,
   },
-
   VOID_TWISTED_TITANSHARD: { //Trinket
     id: 174528,
     name: 'Void-Twisted Titanshard',

--- a/src/interface/report/Results/ItemWarning.js
+++ b/src/interface/report/Results/ItemWarning.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import Warning from 'interface/Alert/Warning';
+import PropTypes from 'prop-types';
+import ITEMS from 'common/ITEMS';
+import ItemLink from 'common/ItemLink';
+
+const WARNING_ITEMS = [ITEMS.WHISPERING_ELDRITH_BOW.id];
+
+class ItemWarning extends React.Component {
+  static propTypes = {
+    gear: PropTypes.object.isRequired,
+  };
+
+  badItems = [];
+  checkItems() {
+    const { gear } = this.props;
+    if (gear) {
+      Object.values(gear).forEach(item => {
+        if (WARNING_ITEMS.includes(item.id) && !this.badItems.includes(item.id)) {
+          this.badItems.push(item.id);
+        }
+      }, 0);
+    }
+  }
+
+  render() {
+    this.checkItems();
+    if (this.badItems.length === 0) {
+      return null;
+    }
+    return (
+      <div className="container">
+        <Warning style={{ marginBottom: 30 }}>
+          This module can have some inaccuracies caused by effects from items that cannot be tracked in WoWAnalyzer, this may cause not all statistics to be accurate for this player. This is due to the following items: <br />
+          {this.badItems.map(item => (
+            <ItemLink id={item} />
+          ))}
+        </Warning>
+      </div>);
+  }
+
+}
+
+export default ItemWarning;

--- a/src/interface/report/Results/index.js
+++ b/src/interface/report/Results/index.js
@@ -36,6 +36,7 @@ import Statistics from './Statistics';
 import Character from './Character';
 import EncounterStats from './EncounterStats';
 import DegradedExperience from './DegradedExperience';
+import ItemWarning from './ItemWarning';
 import EVENT_PARSING_STATE from '../EVENT_PARSING_STATE';
 import BOSS_PHASES_STATE from '../BOSS_PHASES_STATE';
 import ScrollToTop from './ScrollToTop';
@@ -169,7 +170,6 @@ class Results extends React.PureComponent {
       || this.props.parsingState !== EVENT_PARSING_STATE.DONE;
   }
 
-
   renderContent(selectedTab, results) {
     const { parser, premium } = this.props;
 
@@ -214,7 +214,6 @@ class Results extends React.PureComponent {
           return this.renderLoadingIndicator();
         }
         const statTracker = parser.getModule(StatTracker);
-
         return (
           <div className="container">
             <Character
@@ -380,6 +379,7 @@ class Results extends React.PureComponent {
             </Warning>
           </div>
         )}
+        {parser && parser.selectedCombatant.gear && <ItemWarning gear={parser.selectedCombatant.gear} />}
         {timeFilter && (
           <div className="container">
             <Warning style={{ marginBottom: 30 }}>

--- a/src/parser/hunter/beastmastery/modules/core/BeastMasteryFocusCapTracker.tsx
+++ b/src/parser/hunter/beastmastery/modules/core/BeastMasteryFocusCapTracker.tsx
@@ -11,15 +11,9 @@ class BeastMasteryFocusCapTracker extends FocusCapTracker {
     return regenRate;
   }
 
-  naturalRegenRate() {
-    const regen = super.naturalRegenRate();
-    return regen;
-  }
-
   currentMaxResource() {
     const max = BASE_FOCUS_MAX;
-    // What should be x.5 becomes x in-game.
-    return Math.floor(max);
+    return max;
   }
 }
 

--- a/src/parser/hunter/shared/modules/resources/FocusCapTracker.js
+++ b/src/parser/hunter/shared/modules/resources/FocusCapTracker.js
@@ -32,15 +32,8 @@ class FocusCapTracker extends RegenResourceCapTracker {
   static baseRegenRate = BASE_FOCUS_REGEN;
   static isRegenHasted = true;
 
-  naturalRegenRate() {
-    const regen = super.naturalRegenRate();
-    return regen;
-  }
-
   currentMaxResource() {
-    const max = BASE_FOCUS_MAX;
-    // What should be x.5 becomes x in-game.
-    return Math.floor(max);
+    return BASE_FOCUS_MAX;
   }
 
   get wastedPercent() {
@@ -55,11 +48,13 @@ class FocusCapTracker extends RegenResourceCapTracker {
   }
 
   on_byPlayer_cast(event) {
+    super.on_byPlayer_cast(event);
     const secondsIntoFight = Math.floor((event.timestamp - this.owner.fight.start_time) / 1000);
     this.bySecond[secondsIntoFight] = (this.bySecond[secondsIntoFight] || this.current);
   }
 
   on_byPlayer_damage(event) {
+    super.on_byPlayer_damage(event);
     const secondsIntoFight = Math.floor((event.timestamp - this.owner.fight.start_time) / 1000);
     this.bySecond[secondsIntoFight] = (this.bySecond[secondsIntoFight] || this.current);
   }


### PR DESCRIPTION
With bad item: 
![image](https://user-images.githubusercontent.com/29204244/75053929-61dd9b80-54d2-11ea-9f93-0902598e9866.png)

Without:
![image](https://user-images.githubusercontent.com/29204244/75053948-699d4000-54d2-11ea-8670-1e72c8b17e01.png)


It has the possibility to add more items if a player is so unlucky to be using multiple items that causes errors - did that for futureproofing purposes. 