### PR TITLE
Tweak BW cooldown efficiency

### DIFF
--- a/src/parser/hunter/beastmastery/CHANGELOG.tsx
+++ b/src/parser/hunter/beastmastery/CHANGELOG.tsx
@@ -6,7 +6,7 @@ import SPELLS from 'common/SPELLS';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2020, 2, 15), <>Added an inefficient cast detection of <SpellLink id={SPELLS.ASPECT_OF_THE_WILD.id} /> when you have two stacks of <SpellLink id={SPELLS.BARBED_SHOT.id} /> up. Also included the number of wasted <SpellLink id={SPELLS.BARBED_SHOT.id} /> stacks in the <SpellLink id={SPELLS.PRIMAL_INSTINCTS.id} /> statistics. </>, LeoZhekov),
+  change(date(2020, 2, 15), <> Added an inefficient cast detection of <SpellLink id={SPELLS.ASPECT_OF_THE_WILD.id} /> when you have two stacks of <SpellLink id={SPELLS.BARBED_SHOT.id} /> up. Also included the number of wasted <SpellLink id={SPELLS.BARBED_SHOT.id} /> stacks in the <SpellLink id={SPELLS.PRIMAL_INSTINCTS.id} /> statistics. </>, LeoZhekov),
   change(date(2020, 2, 14), <>Added a <SpellLink id={SPELLS.RAPID_RELOAD.id} /> azerite trait module. </>, Putro),
   change(date(2020, 2, 14), <>Fix a bug that would indicate you hadn't hit enemies with <SpellLink id={SPELLS.BEAST_CLEAVE_BUFF.id} /> despite having done so whilst using <SpellLink id={SPELLS.ANIMAL_COMPANION_TALENT.id} />.</>, Putro),
   change(date(2020, 2, 13), 'Add focus checks from natural regeneration and from generators, as well as additional cobra shot and multi shot checks to the BM checklist.', Putro),

--- a/src/parser/hunter/beastmastery/modules/Abilities.tsx
+++ b/src/parser/hunter/beastmastery/modules/Abilities.tsx
@@ -19,7 +19,7 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: 0.9,
+          recommendedEfficiency: 0.85,
           extraSuggestion: (
             <>
               <SpellLink id={SPELLS.BESTIAL_WRATH.id} /> should be cast on cooldown as its cooldown is quickly reset again through <SpellLink id={SPELLS.BARBED_SHOT.id} />. You want to start each <SpellLink id={SPELLS.BESTIAL_WRATH.id} /> window with as much focus as possible.


### PR DESCRIPTION
The spell is so short CD with all the reductions in 8.3 that it isn't uncommon for WoWA to tell you that you've used it too few times even if only a GCD is in between it coming off CD and it being cast. This tries to account for that by simply lowering the cast efficiency. It will still trigger if people aren't casting it enough, but won't trigger if there are simply a GCD between it coming off CD and it being cast.