### PR TITLE
[BrM] Updated ISB Hit Tracking for 8.3

### DIFF
--- a/src/parser/monk/brewmaster/CHANGELOG.js
+++ b/src/parser/monk/brewmaster/CHANGELOG.js
@@ -8,6 +8,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020,  3, 10), <>Updated hit tracking for Ny'alotha and bumped compatability to 8.3.</>, emallson),
   change(date(2019, 12, 22), <>Warning threshold for <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} /> / <SpellLink id={SPELLS.PURIFYING_BREW.id} /> is now calculated based on time spent in red stagger.</>, emallson),
   change(date(2019, 10, 28), <>Added support for items in the <SpellLink id={SPELLS.CELESTIAL_FORTUNE_HEAL.id} /> tab.</>, Abelito75),
   change(date(2019, 10, 16), <>Removed <SpellLink id={SPELLS.ARCANE_TORRENT_ENERGY.id} /> from Brewmaster suggestions.</>, emallson),

--- a/src/parser/monk/brewmaster/CHANGELOG.js
+++ b/src/parser/monk/brewmaster/CHANGELOG.js
@@ -8,7 +8,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2020,  3, 10), <>Updated hit tracking for Ny'alotha and bumped compatability to 8.3.</>, emallson),
+  change(date(2020, 3, 10), <>Updated hit tracking for Ny'alotha and bumped compatability to 8.3.</>, emallson),
   change(date(2019, 12, 22), <>Warning threshold for <SpellLink id={SPELLS.HEAVY_STAGGER_DEBUFF.id} /> / <SpellLink id={SPELLS.PURIFYING_BREW.id} /> is now calculated based on time spent in red stagger.</>, emallson),
   change(date(2019, 10, 28), <>Added support for items in the <SpellLink id={SPELLS.CELESTIAL_FORTUNE_HEAL.id} /> tab.</>, Abelito75),
   change(date(2019, 10, 16), <>Removed <SpellLink id={SPELLS.ARCANE_TORRENT_ENERGY.id} /> from Brewmaster suggestions.</>, emallson),

--- a/src/parser/monk/brewmaster/CONFIG.js
+++ b/src/parser/monk/brewmaster/CONFIG.js
@@ -9,7 +9,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [emallson],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '8.2.5',
+  patchCompatibility: '8.3',
   // If set to  false`, the spec will show up as unsupported.
   isSupported: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.

--- a/src/parser/monk/brewmaster/modules/constants/AbilityBlacklist.js
+++ b/src/parser/monk/brewmaster/modules/constants/AbilityBlacklist.js
@@ -5,6 +5,37 @@
  */
 
 const SHARED = [
+  // Ny'Alotha
+  // Wrathion
+  306015, // Searing Armor (DoT)
+  311362, // Rising Heat (DoT)
+  // Maut
+  310455, // Shadow Wounds (DoT)
+  306070, // Obsidian Skin
+  308168, // Consuming Shadows (Raid Dmg)
+  // Skitra
+  309652, // Illusionary Bolt (Raid Dmg)
+  312741, // Psychic Reverb (Raid Dmg)
+  // Drest'agath
+  310277, // Volatile Seed (DoT -- impact still counts)
+  308947, // Throes of Agony (Raid Dmg)
+  310499, // Void Miasma (DoT around Tentacles)
+  // Xanesh
+  305792, // Anguish (Raid Dmg)
+  313228, // Void-Touched (DoT)
+  // Vexiona
+  313283, // Void Corruption (DoT)
+  // Hivemind
+  310403, // Devouring Frenzy (Raid Dmg)
+  // Ra'den
+  309854, // Ruin (Raid Dmg)
+  // Il'gynoth
+  311143, // Hemorrhage (Raid Dmg)
+  // Carapace
+  307061, // Mycelial Growth (Slow in P2)
+  // N'zoth
+  319346, // Infinity's Toll (Raid Dmg)
+  315715, // Contempt (Raid Dmg in 2nd Psychus)
   // ETERNAL PALACE
   // Sivara
   302588, // Frost Mark
@@ -45,26 +76,6 @@ const SHARED = [
   287490, // Jaina, Frozen Solid
   // ULDIR
   266948, // Vectis, Plague Bomb (intermission soak)
-  // ANTORUS
-  // Garothi Worldbreaker
-  247159, // Luring Destruction, intermission pulse
-  // Felhounds of Sargeras
-  // Antoran High Command
-  // Eonar (SKIP)
-  // Portal Keeper
-  // Imonar
-  248424, // Gathering Power (Imonar bridge phase)
-  // Kin'Garoth
-  246646, // Flames of the Forge (Kin'garoth intermission pulsing aoe)
-  // Varimathras
-  // Coven of Shivarra
-  258018, // Sense of Dread, pulsing aoe from inactive shivarra
-  // Aggramar
-  244912, // Blazing Eruption, the pulse of Embers on Aggramar
-  254329, // Unleashed Flame, Embers on Aggramar
-  245632, // Unchecked Flame, Flames on Aggramar (there are two that can't be stack, can't bof both)
-  // Argus
-  256396, // Reorigination pulse, aoe hit from orbs. generally don't get bof on these
 ];
 
 export const BOF = SHARED.concat([


### PR DESCRIPTION
Just blacklisted a bunch of dots / raid dmg effects that skew hit counts. Removed Legion blacklist.

Also bumped patch compatibility.