### PR TITLE
[Feral] Changed wasted energy threshold

### DIFF
--- a/src/parser/druid/feral/CHANGELOG.js
+++ b/src/parser/druid/feral/CHANGELOG.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { Anatta336 } from 'CONTRIBUTORS';
+import { Anatta336, Abelito75 } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 3,27), <>Improved thresholds of wasted energy to be precentage based.</>, [Abelito75]),
   change(date(2019, 8, 10), <>Improved tracking of <SpellLink id={SPELLS.FEROCIOUS_BITE.id} /> energy use to account for <SpellLink id={SPELLS.BERSERK.id} />. Also highlights low energy bites on the timeline.</>, [Anatta336]),
   change(date(2019, 8, 9), <>Fixed tracking pre-pull use of <SpellLink id={SPELLS.BERSERK.id} /> and <SpellLink id={SPELLS.TIGERS_FURY.id} /> so they're properly counted when calculating cast efficiency.</>, [Anatta336]),
   change(date(2019, 6, 19), <>Improved how finisher combo point use is assessed, low-combo use of <SpellLink id={SPELLS.RIP.id} /> is recognised as correct in certain circumstances.</>, [Anatta336]),

--- a/src/parser/druid/feral/CONFIG.js
+++ b/src/parser/druid/feral/CONFIG.js
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { Anatta336 } from 'CONTRIBUTORS';
 import SPECS from 'game/SPECS';
-import Warning from 'interface/Alert/Warning';
 
 import CHANGELOG from './CHANGELOG';
 

--- a/src/parser/druid/feral/CONFIG.js
+++ b/src/parser/druid/feral/CONFIG.js
@@ -10,18 +10,13 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Anatta336],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '8.0.1',
+  patchCompatibility: '8.3',
   // If set to  false`, the spec will show up as unsupported.
   isSupported: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
-      <Warning>
-        This analyzer is in the process of being updated for Feral's changes in patch 8.1. Some analysis may be missing until that's complete.<br />
-        You can follow the <a href="https://github.com/WoWAnalyzer/WoWAnalyzer/issues/2843">update progress</a>.
-      </Warning><br />
-
       We hope this analyzer will help improve your Feral druid experience. As always it's best to focus on improving one aspect of your play at a time. Keeping good uptimes on your DoTs is key to good damage output, so is a great place to start. Unless you have very high haste you can expect to spend time waiting for energy during bos fights, use this to your advantage as it gives you time to plan what to do next rather than spamming buttons.<br /><br />
 
       Most of the mechanics are now covered in this analyzer but there's always things to improve. If you have suggestions or comments about the analyzer you can reach the WoWAnalyzer team on <a href="https://github.com/WoWAnalyzer/WoWAnalyzer/issues/new">GitHub</a>, on <a href="https://discord.gg/AxphPxU">Discord</a>, or message me (<a href="/contributor/Anatta336">Anatta</a>) directly on Discord. We're always interested in improving the analyzer, whether it's in-depth theorycraft or rewording some text to be easier to understand. The whole project is open source and welcomes contributions so you can directly improve it too!<br /><br />

--- a/src/parser/druid/feral/modules/features/EnergyCapTracker.js
+++ b/src/parser/druid/feral/modules/features/EnergyCapTracker.js
@@ -92,7 +92,7 @@ class EnergyCapTracker extends RegenResourceCapTracker {
     return (
       <StatisticBox
         icon={<Icon icon="spell_shadow_shadowworddominate" alt="Capped Energy" />}
-        value={this.missedRegenPerMinute.toFixed(1)}
+        value={(formatPercentage(this.percentCapped) + "%")}
         label="Wasted energy per minute from being capped"
         tooltip={(
           <>

--- a/src/parser/druid/feral/modules/features/EnergyCapTracker.js
+++ b/src/parser/druid/feral/modules/features/EnergyCapTracker.js
@@ -59,15 +59,19 @@ class EnergyCapTracker extends RegenResourceCapTracker {
     return Math.floor(max);
   }
 
+  get percentCapped(){
+    return (this.naturalRegen - this.missedRegen) / this.naturalRegen;
+  }
+
   get suggestionThresholds() {
     return {
-      actual: this.missedRegenPerMinute,
-      isGreaterThan: {
-        minor: 20,
-        average: 40,
-        major: 60,
+      actual: this.percentCapped,
+      isLessThan: {
+        minor: .8,
+        average: .70,
+        major: .65,
       },
-      style: 'number',
+      style: 'percentage',
     };
   }
 
@@ -79,8 +83,8 @@ class EnergyCapTracker extends RegenResourceCapTracker {
         </>,
       )
         .icon('spell_shadow_shadowworddominate')
-        .actual(`${actual.toFixed(1)} regenerated energy lost per minute due to being capped.`)
-        .recommended(`<${recommended} is recommended.`);
+        .actual(`${formatPercentage(actual)}% regenerated energy lost per minute due to being capped.`)
+        .recommended(`<${recommended}% is recommended.`);
     });
   }
 


### PR DESCRIPTION
Wasted energy thresholds were valid pre-essences and the crazy stats we have now but now its impossible to not cap on energy during berserk without wasting combo points. Switched to %