### PR TITLE
[Core] Font of Power fix

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -9,6 +9,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/ContributorButton';
 
 export default [
+  change(date(2020, 4, 14), <>Using <ItemLink id={ITEMS.AZSHARAS_FONT_OF_POWER.id} /> no longer shows as downtime during the channel.</>, Sharrq),
   change(date(2020, 3, 30), <>Added <SpellLink id={SPELLS.FLASH_OF_INSIGHT.id} />.</>, niseko),
   change(date(2020, 3, 30), <>Added <SpellLink id={SPELLS.SEVERE_T3.id} /> <SpellLink id={SPELLS.EXPEDIENT_T3.id} /> <SpellLink id={SPELLS.MASTERFUL_T3.id} /> <SpellLink id={SPELLS.VERSATILE_T3.id} />.</>, niseko),
   change(date(2020, 3, 30), <>Added <SpellLink id={SPELLS.ESSENCE_OF_THE_FOCUSING_IRIS_RANK_THREE_FOUR.id} /> and <SpellLink id={SPELLS.FOCUSED_ENERGY_BUFF.id} />.</>, Putro),

--- a/src/parser/shared/modules/items/bfa/raids/azsharaseternalpalace/AzsharasFontofPower.js
+++ b/src/parser/shared/modules/items/bfa/raids/azsharaseternalpalace/AzsharasFontofPower.js
@@ -1,11 +1,14 @@
 import React from 'react';
 
-import Analyzer from 'parser/core/Analyzer';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
 import ItemStatistic from 'interface/statistics/ItemStatistic';
 import BoringItemValueText from 'interface/statistics/components/BoringItemValueText';
 import Abilities from 'parser/core/modules/Abilities';
+import Buffs from 'parser/core/modules/Buffs';
+import Channeling from 'parser/shared/modules/Channeling';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import UptimeIcon from 'interface/icons/Uptime';
 import { formatPercentage, formatNumber } from 'common/format';
@@ -23,6 +26,8 @@ class AzsharasFontofPower extends Analyzer {
   static dependencies = {
     abilityTracker: AbilityTracker,
     abilities: Abilities,
+    buffs: Buffs,
+    channeling: Channeling,
   };
 
   constructor(...args) {
@@ -38,8 +43,23 @@ class AzsharasFontofPower extends Analyzer {
           suggestions: true,
         },
       });
+      this.buffs.add({
+        spellId: SPELLS.LATENT_ARCANA_BUFF.id,
+        timelineHightlight: true,
+      });
       this.statBuff = calculatePrimaryStat(400, 2203, this.selectedCombatant.getItem(ITEMS.AZSHARAS_FONT_OF_POWER.id).itemLevel);
     }
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.LATENT_ARCANA_CHANNEL), this.onChannelStart);
+    this.addEventListener(Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.LATENT_ARCANA_CHANNEL), this.onChannelEnd);
+  }
+
+  onChannelStart(event) {
+    this.channeling.beginChannel(event);
+    console.log(event);
+  }
+
+  onChannelEnd(event) {
+    this.channeling.endChannel(event);
   }
 
   get buffUptime() {

--- a/src/parser/shared/modules/items/bfa/raids/azsharaseternalpalace/AzsharasFontofPower.js
+++ b/src/parser/shared/modules/items/bfa/raids/azsharaseternalpalace/AzsharasFontofPower.js
@@ -55,7 +55,6 @@ class AzsharasFontofPower extends Analyzer {
 
   onChannelStart(event) {
     this.channeling.beginChannel(event);
-    console.log(event);
   }
 
   onChannelEnd(event) {


### PR DESCRIPTION
Fixes Font of Power so the channel no longer shows up as downtime in the timeline and in the Downtime % stat.

Also added the Latent Arcana Buff to the timeline buffs.