### PR TITLE
Disallow ++ and -- outside of for loops

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ node_modules
 /src/localization/_build/
 /src/localization/*/*.js
 /scripts/localization/*.js
+/scripts/azerite/extract.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -134,5 +134,8 @@ module.exports = {
 
     // // enforce spacing before and after comma
     // 'comma-spacing': ['warn', { before: false, after: true }],
+
+    // enforce not using ++ and -- except in for loops
+    'no-plusplus': [2, {allowForLoopAfterthoughts: true }],
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -136,6 +136,6 @@ module.exports = {
     // 'comma-spacing': ['warn', { before: false, after: true }],
 
     // enforce not using ++ and -- except in for loops
-    'no-plusplus': [2, {allowForLoopAfterthoughts: true }],
+    'no-plusplus': ['warn', {'allowForLoopAfterthoughts': true }],
   },
 };

--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -9,6 +9,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/ContributorButton';
 
 export default [
+  change(date(2020, 5, 12), 'Disallow use of ++ and -- to adhere to the style guide', Putro),
   change(date(2020, 5, 12), 'Reduced avatar and article image file sizes', Vetyst),
   change(date(2020, 4, 26), <>Added <SpellLink id={SPELLS.BLOOD_FURY_PHYSICAL.id} /> to the core parser. </>, Putro),
   change(date(2020, 4, 16), <>Fixed a bug where the haste value gained <SpellLink id={SPELLS.ESSENCE_OF_THE_FOCUSING_IRIS_RANK_THREE_FOUR.id} /> minor was extremely low if the buff never fell off.</>, Putro),

--- a/src/common/retryingPromise.test.js
+++ b/src/common/retryingPromise.test.js
@@ -39,8 +39,8 @@ describe('retryingPromise', () => {
     expect.assertions(1);
     const returnValue = {};
     let call = 0;
-    const result = await retryingPromise(() => call === 0 ? Promise.reject() : Promise.resolve(returnValue));
-    call += 1;
+    // eslint-disable-next-line no-plusplus
+    const result = await retryingPromise(() => call++ === 0 ? Promise.reject() : Promise.resolve(returnValue));
     expect(result).toBe(returnValue);
   });
   it('gives up and returns the last error if it can\'t be resolved', async () => {

--- a/src/common/retryingPromise.test.js
+++ b/src/common/retryingPromise.test.js
@@ -39,7 +39,8 @@ describe('retryingPromise', () => {
     expect.assertions(1);
     const returnValue = {};
     let call = 0;
-    const result = await retryingPromise(() => call++ === 0 ? Promise.reject() : Promise.resolve(returnValue));
+    const result = await retryingPromise(() => call === 0 ? Promise.reject() : Promise.resolve(returnValue));
+    call += 1;
     expect(result).toBe(returnValue);
   });
   it('gives up and returns the last error if it can\'t be resolved', async () => {

--- a/src/interface/report/PlayerLoader.js
+++ b/src/interface/report/PlayerLoader.js
@@ -147,7 +147,7 @@ class PlayerLoader extends React.PureComponent {
         // Gear may be null for broken combatants
         this.ilvl += player.gear ? getAverageItemLevel(player.gear) : 0;
         if (characterData && characterData.heartOfAzeroth) {
-          numberOfCombatantsWithLoadedHeart++;
+          numberOfCombatantsWithLoadedHeart += 1;
           this.heartLvl += characterData.heartOfAzeroth.azeriteItemLevel;
         }
       });

--- a/src/interface/report/Results/ScrollToTop/js/elevator.js
+++ b/src/interface/report/Results/ScrollToTop/js/elevator.js
@@ -45,7 +45,7 @@ var Elevator = function(options) {
   function easeInOutQuad(t, b, c, d) {
     t /= d / 2;
     if (t < 1) return c / 2 * t * t + b;
-    t--;
+    t -= 1;
     return -c / 2 * (t * (t - 2) - 1) + b;
   }
 

--- a/src/interface/statistics/components/RadarChart/SvgWrappingText.js
+++ b/src/interface/statistics/components/RadarChart/SvgWrappingText.js
@@ -40,7 +40,8 @@ class SvgWrappingText extends React.PureComponent {
         line.pop();
         tspan.text(line.join(' '));
         line = [word];
-        tspan = text.append('tspan').attr('x', x).attr('y', y).attr('dy', ++lineNumber * lineHeight + dy + 'em').text(word);
+        lineNumber += 1;
+        tspan = text.append('tspan').attr('x', x).attr('y', y).attr('dy', lineNumber * lineHeight + dy + 'em').text(word);
       }
     });
   }

--- a/src/parser/deathknight/blood/modules/talents/Hemostasis.js
+++ b/src/parser/deathknight/blood/modules/talents/Hemostasis.js
@@ -41,20 +41,20 @@ class Hemostasis extends Analyzer {
 
     if (spellID === SPELLS.DEATH_STRIKE.id) {
       if(this.buffStack > 0){
-        this.buffedDeathStrikes++;
+        this.buffedDeathStrikes += 1;
         this.damage += calculateEffectiveDamage(event, PERCENT_BUFF * this.buffStack);
         this.buffStack = 0;
         return;
       }
-      this.unbuffedDeathStrikes++;
+      this.unbuffedDeathStrikes += 1;
     }
 
     if (spellID === SPELLS.BLOOD_BOIL.id) {
       if (this.buffStack === MAX_BUFF_STACKS) {
-        this.wastedBuffs++;
+        this.wastedBuffs += 1;
       } else {
-        this.buffStack++;
-        this.gainedBuffs++;
+        this.buffStack += 1;
+        this.gainedBuffs += 1;
       }
     }
   }

--- a/src/parser/deathknight/frost/modules/talents/GatheringStorm.js
+++ b/src/parser/deathknight/frost/modules/talents/GatheringStorm.js
@@ -31,7 +31,7 @@ class GatheringStorm extends Analyzer {
     if (!this.active) {
       return;
     }
-    
+
     this.addEventListener(Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.GATHERING_STORM_TALENT_BUFF), this.onApplyBuff);
     this.addEventListener(Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.GATHERING_STORM_TALENT_BUFF), this.onApplyBuffStack);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.REMORSELESS_WINTER_DAMAGE), this.onDamage);
@@ -41,14 +41,14 @@ class GatheringStorm extends Analyzer {
 
   onApplyBuff(event) {
     this.currentStacks = 1;
-    this.totalCasts++;
-    this.totalStacks++;
+    this.totalCasts += 1;
+    this.totalStacks += 1;
     debug && console.log('applied buff');
   }
 
   onApplyBuffStack(event) {
-    this.currentStacks++;
-    this.totalStacks++;
+    this.currentStacks += 1;
+    this.totalStacks += 1;
     debug && console.log(`added buff stack, now at ${this.currentStacks}`);
   }
 

--- a/src/parser/deathknight/unholy/modules/features/ClawingShadowsEfficiency.js
+++ b/src/parser/deathknight/unholy/modules/features/ClawingShadowsEfficiency.js
@@ -48,14 +48,14 @@ class ClawingShadowsEfficiency extends Analyzer {
   on_byPlayer_cast(event){
     const spellId = event.ability.guid;
     if(spellId === SPELLS.CLAWING_SHADOWS_TALENT.id){
-		  this.totalClawingShadowsCasts++;
+		  this.totalClawingShadowsCasts += 1;
 		  if(this.targets.hasOwnProperty(encodeTargetString(event.targetID, event.targetInstance))){
 			  const currentTargetWounds = this.targets[encodeTargetString(event.targetID, event.targetInstance)];
 			  if(currentTargetWounds < 1){
-				  this.clawingShadowCastsZeroWounds++;
+				  this.clawingShadowCastsZeroWounds += 1;
 			  }
 		  } else {
-			this.clawingShadowCastsZeroWounds++;
+			this.clawingShadowCastsZeroWounds += 1;
       }
     }
   }

--- a/src/parser/deathknight/unholy/modules/features/FesteringStrike.js
+++ b/src/parser/deathknight/unholy/modules/features/FesteringStrike.js
@@ -48,11 +48,11 @@ class FesteringStrike extends Analyzer {
   on_byPlayer_cast(event){
     const spellId = event.ability.guid;
     if(spellId === SPELLS.FESTERING_STRIKE.id){
-      this.totalFesteringStrikeCasts++;
+      this.totalFesteringStrikeCasts += 1;
       if(this.targets.hasOwnProperty(event.targetID)){
         const currentTargetWounds = this.targets[event.targetID];
         if(currentTargetWounds > 3){
-          this.festeringStrikeCastsOverThreeStacks++;
+          this.festeringStrikeCastsOverThreeStacks += 1;
         }
       }
     }

--- a/src/parser/deathknight/unholy/modules/features/ScourgeStrikeEfficiency.js
+++ b/src/parser/deathknight/unholy/modules/features/ScourgeStrikeEfficiency.js
@@ -23,7 +23,7 @@ class ScourgeStrikeEfficiency extends Analyzer {
 
   totalScourgeStrikeCasts = 0;
   scourgeStrikeCastsZeroWounds = 0;
-  
+
   on_byPlayer_applydebuffstack(event){
     const spellId = event.ability.guid;
     if(spellId === SPELLS.FESTERING_WOUND.id){
@@ -48,14 +48,14 @@ class ScourgeStrikeEfficiency extends Analyzer {
   on_byPlayer_cast(event){
     const spellId = event.ability.guid;
     if(spellId === SPELLS.SCOURGE_STRIKE.id){
-		this.totalScourgeStrikeCasts++;
+		this.totalScourgeStrikeCasts += 1;
 		if(this.targets.hasOwnProperty(encodeTargetString(event.targetID, event.targetInstance))) {
 			const currentTargetWounds = this.targets[encodeTargetString(event.targetID, event.targetInstance)];
 			if(currentTargetWounds < 1){
-				this.scourgeStrikeCastsZeroWounds++;
+				this.scourgeStrikeCastsZeroWounds += 1;
 			}
 		} else {
-			this.scourgeStrikeCastsZeroWounds++;
+			this.scourgeStrikeCastsZeroWounds += 1;
 		}
 	}
   }

--- a/src/parser/druid/balance/modules/talents/TwinMoons.js
+++ b/src/parser/druid/balance/modules/talents/TwinMoons.js
@@ -21,13 +21,13 @@ class TwinMoons extends Analyzer {
     if (event.ability.guid !== SPELLS.MOONFIRE_BEAR.id || event.tick === true) {
       return;
     }
-      this.moonfireHits++;
+      this.moonfireHits += 1;
   }
   on_byPlayer_cast(event) {
     if (event.ability.guid !== SPELLS.MOONFIRE.id) {
       return;
     }
-      this.moonfireCasts++;
+      this.moonfireCasts += 1;
   }
 
   get percentTwoHits() {

--- a/src/parser/druid/restoration/modules/core/hottracking/RegrowthAttributor.js
+++ b/src/parser/druid/restoration/modules/core/hottracking/RegrowthAttributor.js
@@ -45,7 +45,7 @@ class RegrowthAttributor extends Analyzer {
       this.totalNonCCRegrowthOverhealing += event.overheal || 0;
       this.totalNonCCRegrowthAbsorbs += event.absorbed || 0;
       if(event.tick) {
-        this.totalNonCCRegrowthHealingTicks++;
+        this.totalNonCCRegrowthHealingTicks += 1;
       }
     }
   }

--- a/src/parser/druid/restoration/modules/features/Clearcasting.js
+++ b/src/parser/druid/restoration/modules/features/Clearcasting.js
@@ -75,7 +75,7 @@ class Clearcasting extends Analyzer {
     if (spellId !== SPELLS.REGROWTH.id) {
       return;
     }
-  
+
     if(this.selectedCombatant.hasBuff(SPELLS.INNERVATE.id)) {
       return;
     }
@@ -104,7 +104,7 @@ class Clearcasting extends Analyzer {
     const hitPointsBeforeHeal = event.hitPoints - effectiveHealing;
     const healthPercentage = hitPointsBeforeHeal / event.maxHitPoints;
     if(healthPercentage<LOW_HEALTH_HEALING_THRESHOLD && !this.selectedCombatant.hasBuff(SPELLS.CLEARCASTING_BUFF.id, event.timestamp, MS_BUFFER)) {
-      this.lowHealthRegrowthsNoCC++;
+      this.lowHealthRegrowthsNoCC += 1;
     }
   }
 

--- a/src/parser/druid/restoration/modules/features/Ironbark.js
+++ b/src/parser/druid/restoration/modules/features/Ironbark.js
@@ -15,7 +15,7 @@ class Ironbark extends Analyzer {
 
   on_byPlayer_cast(event) {
     if(event.ability.guid === SPELLS.IRONBARK.id) {
-      this.ironbarkCount  += 1;
+      this.ironbarkCount += 1;
     }
   }
 

--- a/src/parser/druid/restoration/modules/features/Ironbark.js
+++ b/src/parser/druid/restoration/modules/features/Ironbark.js
@@ -15,7 +15,7 @@ class Ironbark extends Analyzer {
 
   on_byPlayer_cast(event) {
     if(event.ability.guid === SPELLS.IRONBARK.id) {
-      this.ironbarkCount ++;
+      this.ironbarkCount  += 1;
     }
   }
 

--- a/src/parser/druid/restoration/modules/features/PrematureRejuvenations.js
+++ b/src/parser/druid/restoration/modules/features/PrematureRejuvenations.js
@@ -51,7 +51,7 @@ class PrematureRejuvenations extends Analyzer {
 
   on_byPlayer_cast(event) {
     if (event.ability.guid === SPELLS.REJUVENATION.id) {
-      this.totalRejuvsCasts++;
+      this.totalRejuvsCasts += 1;
 
       const oldRejuv = this.rejuvenations.find(e => e.targetId === event.targetID);
       if (oldRejuv == null) {
@@ -61,7 +61,7 @@ class PrematureRejuvenations extends Analyzer {
 
       const pandemicTimestamp = oldRejuv.timestamp + ((REJUV_DURATION * PANDEMIC_THRESHOLD) + MS_BUFFER);
       if (pandemicTimestamp > event.timestamp) {
-        this.earlyRefreshments++;
+        this.earlyRefreshments += 1;
         this.timeLost += pandemicTimestamp - event.timestamp;
       }
 

--- a/src/parser/druid/restoration/modules/items/azeritetraits/AutumnLeaves.js
+++ b/src/parser/druid/restoration/modules/items/azeritetraits/AutumnLeaves.js
@@ -71,7 +71,7 @@ class AutumnLeaves extends Analyzer {
     if (SPELLS.REJUVENATION.id !== spellId && SPELLS.REJUVENATION_GERMINATION.id !== spellId) {
       return;
     }
-    this.totalOneSecondValue++;
+    this.totalOneSecondValue += 1;
   }
 
   on_byPlayer_refreshbuff(event) {
@@ -79,7 +79,7 @@ class AutumnLeaves extends Analyzer {
     if (SPELLS.REJUVENATION.id !== spellId && SPELLS.REJUVENATION_GERMINATION.id !== spellId) {
       return;
     }
-    this.totalOneSecondValue++;
+    this.totalOneSecondValue += 1;
   }
 
   getSpellUptime(spellId) {

--- a/src/parser/druid/restoration/modules/items/azeritetraits/LivelySpirit.js
+++ b/src/parser/druid/restoration/modules/items/azeritetraits/LivelySpirit.js
@@ -68,7 +68,7 @@ class LivelySpirit extends Analyzer {
       && this.ABILITIES_BUFFING_LIVELY_SPIRIT.includes(spellId)
       && this.innervateTimestamp !== 0
       && (this.innervateTimestamp + INNERVATE_DURATION) >= event.timestamp) {
-      this.castsDuringInnervate++;
+      this.castsDuringInnervate += 1;
     }
   }
 

--- a/src/parser/druid/restoration/modules/items/azeritetraits/RampantGrowth.js
+++ b/src/parser/druid/restoration/modules/items/azeritetraits/RampantGrowth.js
@@ -65,7 +65,7 @@ class RampantGrowth extends Analyzer{
 
     // If regrowth was cast on the LB target, disregard regrowth base HoT/mastery healing on that target for 12 seconds.
     if(combatant.hasBuff(SPELLS.LIFEBLOOM_HOT_HEAL.id, event.timestamp, 200, null, this.owner.playerId)) {
-      this.directRegrowthCastsOnLB++;
+      this.directRegrowthCastsOnLB += 1;
       this.banPeriod = event.timestamp + REGROWTH_DURATION;
     } else {
       this.banPeriod = 0;

--- a/src/parser/druid/restoration/modules/talents/Abundance.js
+++ b/src/parser/druid/restoration/modules/talents/Abundance.js
@@ -39,7 +39,7 @@ class Abundance extends Analyzer {
 
     if (!this.selectedCombatant.hasBuff(SPELLS.CLEARCASTING_BUFF.id) && !this.selectedCombatant.hasBuff(SPELLS.INNERVATE.id)) {
       this.manaSavings.push(abundanceBuff.stacks * ABUNDANCE_MANA_REDUCTION > 1 ? 1 : abundanceBuff.stacks * ABUNDANCE_MANA_REDUCTION);
-      this.manaCasts++;
+      this.manaCasts += 1;
     }
 
     this.critGains.push((abundanceBuff.stacks * ABUNDANCE_INCREASED_CRIT) > 1 ? 1 : abundanceBuff.stacks * ABUNDANCE_INCREASED_CRIT);

--- a/src/parser/druid/restoration/modules/talents/Photosynthesis.js
+++ b/src/parser/druid/restoration/modules/talents/Photosynthesis.js
@@ -72,9 +72,9 @@ class Photosynthesis extends Analyzer {
     if(spellId === SPELLS.LIFEBLOOM_BLOOM_HEAL.id){
       if(this.lastRealBloomTimestamp === null || (event.timestamp - this.lastRealBloomTimestamp) > BLOOM_BUFFER_MS) {
         this.lifebloomIncrease += event.amount;
-        this.randomProccs++;
+        this.randomProccs += 1;
       } else {
-        this.naturalProccs++;
+        this.naturalProccs += 1;
       }
     }
 

--- a/src/parser/hunter/beastmastery/modules/spells/BeastCleave.tsx
+++ b/src/parser/hunter/beastmastery/modules/spells/BeastCleave.tsx
@@ -75,7 +75,7 @@ class BeastCleave extends Analyzer {
     }
     this.casts += 1;
     if (this.beastCleaveHits === 0) {
-      this.castsWithoutHits++;
+      this.castsWithoutHits += 1;
     }
     this.beastCleaveHits = 0;
     this.timestamp = event.timestamp;

--- a/src/parser/hunter/beastmastery/modules/spells/azeritetraits/FeedingFrenzy.tsx
+++ b/src/parser/hunter/beastmastery/modules/spells/azeritetraits/FeedingFrenzy.tsx
@@ -110,7 +110,7 @@ class FeedingFrenzy extends Analyzer {
     if (spellId !== SPELLS.BARBED_SHOT.id) {
       return;
     }
-    this.casts++;
+    this.casts += 1;
     if (!this.hasFrenzyUp ||
       event.timestamp <
       this.buffApplication +

--- a/src/parser/hunter/beastmastery/modules/spells/azeritetraits/PrimalInstincts.tsx
+++ b/src/parser/hunter/beastmastery/modules/spells/azeritetraits/PrimalInstincts.tsx
@@ -75,9 +75,9 @@ class PrimalInstincts extends Analyzer {
 
     const hasTwoBarbedCharges = this.spellUsable.chargesAvailable(SPELLS.BARBED_SHOT.id) === 2;
     if (hasTwoBarbedCharges) {
-      this.wastedBarbedShots++;
+      this.wastedBarbedShots += 1;
     } else {
-      this.chargesGained++;
+      this.chargesGained += 1;
     }
   }
 

--- a/src/parser/hunter/beastmastery/modules/talents/KillerInstinct.tsx
+++ b/src/parser/hunter/beastmastery/modules/talents/KillerInstinct.tsx
@@ -39,12 +39,12 @@ class KillerInstinct extends Analyzer {
     if (!event.hitPoints || !event.maxHitPoints) {
       return;
     }
-    this.casts++;
+    this.casts += 1;
     const enemyHealthPercent = (
       event.hitPoints / event.maxHitPoints
     );
     if (enemyHealthPercent <= KILLER_INSTINCT_TRESHOLD) {
-      this.castsWithExecute++;
+      this.castsWithExecute += 1;
 
       const traitDamage = calculateEffectiveDamage(
         event,

--- a/src/parser/hunter/beastmastery/modules/talents/Stampede.tsx
+++ b/src/parser/hunter/beastmastery/modules/talents/Stampede.tsx
@@ -71,11 +71,11 @@ class Stampede extends Analyzer {
         event.absorbed || 0
       );
 
-    this.hits++;
+    this.hits += 1;
     this.damage += damage;
 
     if (this.currentCast !== null) {
-      this.currentCast.hits++;
+      this.currentCast.hits += 1;
       this.currentCast.damage += damage;
     }
   }
@@ -86,7 +86,7 @@ class Stampede extends Analyzer {
       cast.averageHits = cast.hits / STAMPEDE_POTENTIAL_HITS;
 
       if (cast.averageHits < 1) {
-        this.inefficientCasts++;
+        this.inefficientCasts += 1;
       }
     });
   }

--- a/src/parser/hunter/marksmanship/modules/spells/Trueshot.js
+++ b/src/parser/hunter/marksmanship/modules/spells/Trueshot.js
@@ -42,7 +42,7 @@ class Trueshot extends Analyzer {
       this.accumulatedFocusAtTSCast += event.classResources[0].amount || 0;
     }
     if (spellId === SPELLS.AIMED_SHOT.id && this.selectedCombatant.hasBuff(SPELLS.TRUESHOT.id)) {
-      this.aimedShotsPrTS++;
+      this.aimedShotsPrTS += 1;
     }
   }
 

--- a/src/parser/hunter/marksmanship/modules/spells/azeritetraits/SteadyAim.js
+++ b/src/parser/hunter/marksmanship/modules/spells/azeritetraits/SteadyAim.js
@@ -63,7 +63,7 @@ class SteadyAim extends Analyzer {
       return;
     }
     if (spellId === SPELLS.STEADY_SHOT.id) {
-      this.maxPossible++;
+      this.maxPossible += 1;
       if (this._stacks === MAX_STACKS) {
         this.wasted += 1;
       }

--- a/src/parser/hunter/marksmanship/modules/talents/DoubleTap.js
+++ b/src/parser/hunter/marksmanship/modules/talents/DoubleTap.js
@@ -30,7 +30,7 @@ class DoubleTap extends Analyzer {
     if (spellId !== SPELLS.DOUBLE_TAP_TALENT.id) {
       return;
     }
-    this.activations++;
+    this.activations += 1;
   }
 
   on_byPlayer_cast(event) {
@@ -39,10 +39,10 @@ class DoubleTap extends Analyzer {
       return;
     }
     if (spellId === SPELLS.AIMED_SHOT.id) {
-      this.aimedUsage++;
+      this.aimedUsage += 1;
     }
     if (spellId === SPELLS.RAPID_FIRE.id) {
-      this.RFUsage++;
+      this.RFUsage += 1;
     }
   }
 

--- a/src/parser/hunter/marksmanship/modules/talents/HuntersMark.js
+++ b/src/parser/hunter/marksmanship/modules/talents/HuntersMark.js
@@ -54,7 +54,7 @@ class HuntersMark extends Analyzer {
     if (spellId !== SPELLS.HUNTERS_MARK_TALENT.id) {
       return;
     }
-    this.casts++;
+    this.casts += 1;
     this.timeOfCast = event.timestamp;
   }
 
@@ -92,7 +92,7 @@ class HuntersMark extends Analyzer {
       this.precastConfirmed = true;
     }
     if (!this.debuffRemoved) {
-      this.recasts++;
+      this.recasts += 1;
     }
     this.debuffRemoved = false;
     const enemyID = encodeTargetString(event.targetID, event.targetInstance);
@@ -125,7 +125,7 @@ class HuntersMark extends Analyzer {
     if (spellId !== SPELLS.HUNTERS_MARK_TALENT.id) {
       return;
     }
-    this.recasts++;
+    this.recasts += 1;
   }
 
   on_byPlayer_energize(event) {
@@ -133,7 +133,7 @@ class HuntersMark extends Analyzer {
     if (spellId !== SPELLS.HUNTERS_MARK_FOCUS.id) {
       return;
     }
-    this.refunds++;
+    this.refunds += 1;
   }
 
   on_byPlayer_damage(event) {

--- a/src/parser/hunter/marksmanship/modules/talents/LockAndLoad.js
+++ b/src/parser/hunter/marksmanship/modules/talents/LockAndLoad.js
@@ -102,7 +102,7 @@ class LockAndLoad extends Analyzer {
       term = 0.3989422804 * Math.pow(-1, k) * Math.pow(z, k) / (2 * k + 1) /
         Math.pow(2, k) * Math.pow(z, k + 1) / factK;
       sum += term;
-      k++;
+      k += 1;
       factK *= k;
     }
     sum += 0.5;

--- a/src/parser/hunter/marksmanship/modules/talents/Volley.js
+++ b/src/parser/hunter/marksmanship/modules/talents/Volley.js
@@ -40,7 +40,7 @@ class Volley extends Analyzer {
     if (spellId === SPELLS.VOLLEY_DAMAGE.id) {
       this.damage += event.amount + (event.absorbed || 0);
       if (event.timestamp > (this.lastVolleyHit + BUFFER_MS)) {
-        this.procs++;
+        this.procs += 1;
         this.lastVolleyHit = event.timestamp;
       }
     }
@@ -75,7 +75,7 @@ class Volley extends Analyzer {
       term = 0.3989422804 * Math.pow(-1, k) * Math.pow(z, k) / (2 * k + 1) /
         Math.pow(2, k) * Math.pow(z, k + 1) / factK;
       sum += term;
-      k++;
+      k += 1;
       factK *= k;
     }
     sum += 0.5;

--- a/src/parser/hunter/shared/modules/spells/azeritetraits/DireConsequences.tsx
+++ b/src/parser/hunter/shared/modules/spells/azeritetraits/DireConsequences.tsx
@@ -38,7 +38,7 @@ class DireConsequences extends Analyzer {
     if (spellId !== SPELLS.DIRE_BEAST_BUFF.id) {
       return;
     }
-    this.procs++;
+    this.procs += 1;
   }
 
   statistic() {

--- a/src/parser/hunter/shared/modules/talents/AMurderOfCrows.tsx
+++ b/src/parser/hunter/shared/modules/talents/AMurderOfCrows.tsx
@@ -104,7 +104,7 @@ class AMurderOfCrows extends Analyzer {
     if (spellId !== SPELLS.A_MURDER_OF_CROWS_TALENT.id) {
       return;
     }
-    this.casts++;
+    this.casts += 1;
     this.applicationTimestamp = 0;
     this.lastDamageTick = 0;
   }
@@ -136,7 +136,7 @@ class AMurderOfCrows extends Analyzer {
       return;
     }
     if (this.casts === 0) {
-      this.casts++;
+      this.casts += 1;
       this.spellUsable.beginCooldown(SPELLS.A_MURDER_OF_CROWS_TALENT.id, {
         timestamp: this.owner.fight.start_time,
       });

--- a/src/parser/hunter/survival/modules/spells/ButcheryCarve.js
+++ b/src/parser/hunter/survival/modules/spells/ButcheryCarve.js
@@ -55,7 +55,7 @@ class ButcheryCarve extends Analyzer {
     if (spellId !== SPELLS.BUTCHERY_TALENT.id && spellId !== SPELLS.CARVE.id) {
       return;
     }
-    this.casts++;
+    this.casts += 1;
     this.reductionAtCurrentCast = 0;
   }
 
@@ -64,12 +64,12 @@ class ButcheryCarve extends Analyzer {
     if (spellId !== SPELLS.BUTCHERY_TALENT.id && spellId !== SPELLS.CARVE.id) {
       return;
     }
-    this.targetsHit++;
+    this.targetsHit += 1;
     this.damage += event.amount + (event.absorbed || 0);
     if (this.reductionAtCurrentCast === MAX_TARGETS_HIT) {
       return;
     }
-    this.reductionAtCurrentCast++;
+    this.reductionAtCurrentCast += 1;
     if (this.spellUsable.isOnCooldown(this.bombSpellKnown)) {
       this.checkCooldown(this.bombSpellKnown);
     } else {

--- a/src/parser/hunter/survival/modules/spells/KillCommand.js
+++ b/src/parser/hunter/survival/modules/spells/KillCommand.js
@@ -33,7 +33,7 @@ class KillCommand extends Analyzer {
     if (spellId !== SPELLS.KILL_COMMAND_CAST_SV.id) {
       return;
     }
-    this.casts++;
+    this.casts += 1;
   }
 
   on_byPlayer_applybuff(event) {
@@ -44,7 +44,7 @@ class KillCommand extends Analyzer {
     if (!this.spellUsable.isOnCooldown(SPELLS.KILL_COMMAND_CAST_SV.id)) {
       return;
     }
-    this.resets++;
+    this.resets += 1;
     this.spellUsable.reduceCooldown(SPELLS.KILL_COMMAND_CAST_SV.id, this.abilities.getExpectedCooldownDuration(SPELLS.KILL_COMMAND_CAST_SV.id, this.spellUsable.cooldownTriggerEvent(SPELLS.KILL_COMMAND_CAST_SV.id)));
   }
 

--- a/src/parser/hunter/survival/modules/spells/SerpentSting.js
+++ b/src/parser/hunter/survival/modules/spells/SerpentSting.js
@@ -48,7 +48,7 @@ class SerpentSting extends Analyzer {
     if (spellId !== SPELLS.SERPENT_STING_SV.id) {
       return;
     }
-    this.casts++;
+    this.casts += 1;
 
     if (event.meta === undefined) {
       event.meta = {
@@ -117,7 +117,7 @@ class SerpentSting extends Analyzer {
     if (this.serpentStingTargets.length === 0) {
       return;
     }
-    this.timesRefreshed++;
+    this.timesRefreshed += 1;
     if (targetInstance === undefined) {
       targetInstance = 1;
     }
@@ -127,7 +127,7 @@ class SerpentSting extends Analyzer {
       if (this.serpentStingTargets[i].targetID === serpentStingTarget.targetID && this.serpentStingTargets[i].targetInstance === serpentStingTarget.targetInstance) {
         const timeRemaining = this.serpentStingTargets[i].serpentStingDuration - (event.timestamp - this.serpentStingTargets[i].timestamp);
         if (timeRemaining > (hastedSerpentStingDuration * SERPENT_STING_SV_PANDEMIC) && !this.hasVV) {
-          this.badRefresh++;
+          this.badRefresh += 1;
         }
         const pandemicSerpentStingDuration = Math.min(hastedSerpentStingDuration * SERPENT_STING_SV_PANDEMIC, timeRemaining) + hastedSerpentStingDuration;
         if (!this.hasVV) {

--- a/src/parser/hunter/survival/modules/spells/WildfireBomb.js
+++ b/src/parser/hunter/survival/modules/spells/WildfireBomb.js
@@ -67,13 +67,13 @@ class WildfireBomb extends Analyzer {
         timestamp: this.owner.fight.start_time,
       });
     }
-    this.targetsHit++;
+    this.targetsHit += 1;
     const enemy = this.enemies.getEntity(event);
     if (this.acceptedCastDueToCapping || !enemy) {
       return;
     }
     if (enemy.hasBuff(SPELLS.WILDFIRE_BOMB_DOT.id) && event.timestamp > this.lastRefresh + MS_BUFFER) {
-      this.badRefreshes++;
+      this.badRefreshes += 1;
       this.lastRefresh = event.timestamp;
     }
   }

--- a/src/parser/hunter/survival/modules/spells/azeritetraits/LatentPoison.js
+++ b/src/parser/hunter/survival/modules/spells/azeritetraits/LatentPoison.js
@@ -60,7 +60,7 @@ class LatentPoison extends Analyzer {
     if (spellId !== SPELLS.SERPENT_STING_SV.id) {
       return;
     }
-    this.maxPossible++;
+    this.maxPossible += 1;
     if (this._stacks === MAX_STACKS) {
       this.wasted += 1;
     }

--- a/src/parser/hunter/survival/modules/talents/Chakrams.js
+++ b/src/parser/hunter/survival/modules/talents/Chakrams.js
@@ -41,7 +41,7 @@ class Chakrams extends Analyzer {
       return;
     }
     this.uniqueTargets = [];
-    this.casts++;
+    this.casts += 1;
   }
 
   on_byPlayer_damage(event) {
@@ -50,14 +50,14 @@ class Chakrams extends Analyzer {
       return;
     }
     if (this.casts === 0) {
-      this.casts++;
+      this.casts += 1;
       this.spellUsable.beginCooldown(SPELLS.CHAKRAMS_TALENT.id, {
         timestamp: this.owner.fight.start_time,
       });
     }
     const damageTarget = encodeTargetString(event.targetID, event.targetInstance);
     if (!this.uniqueTargets.includes(damageTarget)) {
-      this.targetsHit++;
+      this.targetsHit += 1;
       this.uniqueTargets.push(damageTarget);
     }
   }

--- a/src/parser/hunter/survival/modules/talents/HydrasBite.js
+++ b/src/parser/hunter/survival/modules/talents/HydrasBite.js
@@ -36,7 +36,7 @@ class HydrasBite extends Analyzer {
     }
     const target = encodeTargetString(event.targetID, event.targetInstance);
     this.mainTargets.push(target);
-    this.casts++;
+    this.casts += 1;
   }
 
   on_byPlayer_damage(event) {

--- a/src/parser/hunter/survival/modules/talents/MongooseBite.js
+++ b/src/parser/hunter/survival/modules/talents/MongooseBite.js
@@ -52,7 +52,7 @@ class MongooseBite extends Analyzer {
       if (!this.mongooseBiteStacks[this.lastMongooseBiteStack]) {
         this.mongooseBiteStacks[this.lastMongooseBiteStack].push(this.lastMongooseBiteStack);
       } else {
-        this.mongooseBiteStacks[this.lastMongooseBiteStack]++;
+        this.mongooseBiteStacks[this.lastMongooseBiteStack] += 1;
       }
       if (this.aspectOfTheEagleFixed) {
         this.lastMongooseBiteStack += 1;

--- a/src/parser/hunter/survival/modules/talents/SteelTrap.js
+++ b/src/parser/hunter/survival/modules/talents/SteelTrap.js
@@ -36,7 +36,7 @@ class SteelTrap extends Analyzer {
     if (spellId !== SPELLS.STEEL_TRAP_TALENT.id) {
       return;
     }
-    this.casts++;
+    this.casts += 1;
   }
 
   on_byPlayer_damage(event) {

--- a/src/parser/hunter/survival/modules/talents/VipersVenom.js
+++ b/src/parser/hunter/survival/modules/talents/VipersVenom.js
@@ -55,7 +55,7 @@ class VipersVenom extends Analyzer {
       return;
     }
     if (RAPTOR_MONGOOSE_VARIANTS.includes(spellId)) {
-      this.badRaptorsOrMBs++;
+      this.badRaptorsOrMBs += 1;
     }
   }
 
@@ -73,7 +73,7 @@ class VipersVenom extends Analyzer {
     if (spellId !== SPELLS.VIPERS_VENOM_BUFF.id) {
       return;
     }
-    this.procs++;
+    this.procs += 1;
     this.lastProcTimestamp = event.timestamp;
   }
 
@@ -82,7 +82,7 @@ class VipersVenom extends Analyzer {
     if (spellId !== SPELLS.VIPERS_VENOM_BUFF.id) {
       return;
     }
-    this.wastedProcs++;
+    this.wastedProcs += 1;
   }
 
   get averageTimeBetweenBuffAndUsage() {

--- a/src/parser/monk/mistweaver/modules/talents/Upwelling.js
+++ b/src/parser/monk/mistweaver/modules/talents/Upwelling.js
@@ -33,7 +33,7 @@ class Upwelling extends Analyzer {
   totalOverhealing = 0;
   totalAbsorbs = 0;
 
-  castEF = 0;//casts of ef 
+  castEF = 0;//casts of ef
   extraHots = 0;//number of extra hots
   extraBolts = 0;//number of extra bolts
   efHotHeal = 0;//healing from hots
@@ -87,19 +87,19 @@ class Upwelling extends Analyzer {
   boltHeal(event){
     const targetID = event.targetID;//short hand
 
-    this.totalBolts++;//told number of bolts
+    this.totalBolts += 1;//told number of bolts
     if (this.boltCount > BASE_BOLTS){//only get bolts that are from upwelling
       this.totalHealing += event.amount || 0;
       this.totalOverhealing += event.overheal || 0;
       this.totalAbsorbs += event.absorbed || 0;
-      this.extraBolts++;
+      this.extraBolts += 1;
     }
     const holder = {
       fullCount: this.boltCount > BASE_BOLTS,//if its an extra bolt or not
       applicationTime: event.timestamp,//time when casted for nonextra damage
     };
     this.hotMap.set(targetID, holder);//overriding is okay and actually desired if it want to
-    this.boltCount++;//increase current bolt
+    this.boltCount += 1;//increase current bolt
   }
 
   efcast(event) {

--- a/src/parser/paladin/holy/modules/beacons/BeaconUptime.js
+++ b/src/parser/paladin/holy/modules/beacons/BeaconUptime.js
@@ -12,11 +12,11 @@ import BoringSpellValue from 'interface/statistics/components/BoringSpellValue';
 
 for DIVINE_PURPOSE testing (A):
 
-    A1: 100% uptime with precast: 
+    A1: 100% uptime with precast:
         https://www.warcraftlogs.com/reports/wgfFpV4zrckHdhYt#fight=4&type=auras&sourceclass=Any&target=1&ability=53563
         Results Expected: 100%, precasted BoL: true, precasted BoF: null
         Passed: true
-    A2: < 100% uptime with precast: 
+    A2: < 100% uptime with precast:
         https://www.warcraftlogs.com/reports/wgfFpV4zrckHdhYt#fight=6&type=auras&source=1&by=target&ability=53563
         Results Expected: 92%, precasted BoL: true, precasted BoF: null
         passed: true
@@ -24,15 +24,15 @@ for DIVINE_PURPOSE testing (A):
         https://www.warcraftlogs.com/reports/MPFA4THXv6gmG1VD#fight=30&type=auras&source=3&by=target&ability=53563
         Results Expected: 88%, precasted BoL: true, precasted BoF: null
         Passed: true
-    A4: 100% uptime with precast with BoL swap: 
+    A4: 100% uptime with precast with BoL swap:
         https://www.warcraftlogs.com/reports/MPFA4THXv6gmG1VD#fight=12&type=auras&source=3&by=target&ability=53563
         Results Expected: 100%, precasted BoL: true, precasted BoF: null
         Passed: true
-    A5: < 100% uptime with precast with BoL swap: 
+    A5: < 100% uptime with precast with BoL swap:
         https://www.warcraftlogs.com/reports/MPFA4THXv6gmG1VD#fight=12&type=auras&source=3&by=target&ability=53563
         Results Expected: 100%, precasted BoL: true, precasted BoF: null
         Passed: true
-    A6: < 100% without precast with BoL swap: 
+    A6: < 100% without precast with BoL swap:
 
         Results Expected: %, precasted BoL: , precasted BoF: null
         Passed:
@@ -44,44 +44,44 @@ for BEACON_OF_FAITH testing (B):
             https://www.warcraftlogs.com/reports/DPwyKpWBZ6F947mx/#fight=2&source=7&type=auras&by=target&ability=53563
             Results Expected: BoL uptime 100%, BoF uptime 100%, precasted BoL: true, precasted BoF: true
             Passed: true
-        B12: < 100% uptime with precast: 
+        B12: < 100% uptime with precast:
             https://www.warcraftlogs.com/reports/DPwyKpWBZ6F947mx/#fight=13&source=7&type=auras&by=target&ability=156910
             Results Expected: BoL uptime 95%, BoF uptime 94%, precasted BoL: true, precasted BoF: true
             Passed: true
-        B13: < 100% without precast: 
+        B13: < 100% without precast:
             https://www.warcraftlogs.com/reports/DPwyKpWBZ6F947mx/#fight=10&source=7&type=auras&by=target&ability=156910
             Results Expected: BoL uptime 46%, BoF uptime 74%, precasted BoL: false, precasted BoF: false
             Passed: true
-        B14: 100% uptime with precast with BoF swap: 
+        B14: 100% uptime with precast with BoF swap:
             https://www.warcraftlogs.com/reports/DPwyKpWBZ6F947mx/#fight=11&source=7&type=auras&by=target&ability=156910
             Results Expected: BoL uptime 100%, BoF uptime 100%, precasted BoL: true, precasted BoF: true
             Passed: true
-        B15: < 100% uptime with precast with BoF swap: 
+        B15: < 100% uptime with precast with BoF swap:
             https://www.warcraftlogs.com/reports/DPwyKpWBZ6F947mx/#fight=8&source=7&type=auras&by=target&ability=156910
             Results Expected: BoL uptime 100%, BoF uptime 82%, precasted BoL: true, precasted BoF: true
             Passed: true
-        B16: < 100% without precast with BoF swap: 
+        B16: < 100% without precast with BoF swap:
             https://www.warcraftlogs.com/reports/DPwyKpWBZ6F947mx/#fight=14&source=7&type=auras&by=target&ability=156910
             Results Expected: BoL uptime 73%, BoF uptime 99%, precasted BoL: false, precasted BoF: false
             Passed: true
     BoL uptime (B2*):
-        B21: 100% uptime with precast: 
+        B21: 100% uptime with precast:
             https://www.warcraftlogs.com/reports/DPwyKpWBZ6F947mx/#fight=2&source=7&type=auras&by=target&ability=53563
             Results Expected: BoL uptime 100%, BoF uptime 100%, precasted BoL: true, precasted BoF: true
             Passed: true
-        B22: < 100% uptime with precast: 
+        B22: < 100% uptime with precast:
             https://www.warcraftlogs.com/reports/DPwyKpWBZ6F947mx/#fight=9&source=7&type=auras&by=target&ability=53563
             Results Expected: BoL uptime 83%, BoF uptime 90%, precasted BoL: true, precasted BoF: true
             Passed: true
-        B23: < 100% without precast: 
+        B23: < 100% without precast:
             https://www.warcraftlogs.com/reports/DPwyKpWBZ6F947mx/#fight=14&source=7&type=auras&by=target&ability=53563
             Results Expected: BoL uptime 73%, BoF uptime 99%, precasted BoL: false, precasted BoF: false
             Passed: true
-        B24: 100% uptime with precast with BoL swap: 
+        B24: 100% uptime with precast with BoL swap:
             https://www.warcraftlogs.com/reports/DPwyKpWBZ6F947mx/#fight=8&source=7&type=auras&by=target&ability=53563
             Results Expected: BoL uptime 100%, BoF uptime 82%, precasted BoL: true, precasted BoF: true
             Passed: true
-        B25: < 100% uptime with precast with BoL swap: 
+        B25: < 100% uptime with precast with BoL swap:
             https://www.warcraftlogs.com/reports/DPwyKpWBZ6F947mx/#fight=19&source=7&type=auras&by=target&ability=53563
             Results Expected: BoL uptime 97%, BoF uptime 98%, precasted BoL: true, precasted BoF: true
             Passed: true
@@ -108,13 +108,13 @@ class BeaconUptime extends Analyzer {
 
         // Due to getBuffHistory for BoV, uptime is calculated at the end of the fight
         this.addEventListener(Events.fightend, this._endOfFight);
-        
+
         // this is really has divine purpose talent
         this.hasBoL = this.selectedCombatant.hasTalent(SPELLS.DIVINE_PURPOSE_TALENT_HOLY.id);
 
         this.hasBoF = this.selectedCombatant.hasTalent(SPELLS.BEACON_OF_FAITH_TALENT.id);
         this.hasBoV = this.selectedCombatant.hasTalent(SPELLS.BEACON_OF_VIRTUE_TALENT.id);
-        
+
         this.idBoL = SPELLS.BEACON_OF_LIGHT_CAST_AND_BUFF.id;
         this.idBoF = SPELLS.BEACON_OF_FAITH_TALENT.id;
         this.idBoV = SPELLS.BEACON_OF_VIRTUE_TALENT.id;
@@ -122,7 +122,7 @@ class BeaconUptime extends Analyzer {
         this.BuffEventType = Object.freeze({REMOVEBUFF: 0, PREPULL: 1, POSTPULL: 2, UPDATE: 3, ENDOFFIGHT: 4});
 
     }
-    
+
     missingBoLPrepull = true;
     missingBoFPrepull = true;
     missingBoL = true;
@@ -132,7 +132,7 @@ class BeaconUptime extends Analyzer {
     fightStart = this.owner.fight.start_time;
     fightEnd = this.owner.fight.end_time;
     fightLength = this.fightEnd - this.fightStart;
-    
+
     lastBoLtimestamp = null;
     lastBoFtimestamp = null;
     lastBoVtimestamp = null;
@@ -197,7 +197,7 @@ class BeaconUptime extends Analyzer {
         style: 'percentage',
       };
     }
-    
+
     _updateBoL(event,type) {
       const {REMOVEBUFF,PREPULL,POSTPULL,UPDATE, ENDOFFIGHT} = this.BuffEventType;
 
@@ -206,13 +206,13 @@ class BeaconUptime extends Analyzer {
         this.missingBoL = true;
         this.uptimeBoL += event.timestamp - this.lastBoLtimestamp;
         this.lastBoLtimestamp = event.timestamp;
-        this.countBoL--;
+        this.countBoL -= 1;
         return;
       }
       // checks for overlap of beacon application with beacon removal
       // should never be >2 but just in case
       if(type === REMOVEBUFF && this.countBoL >= 2) {
-        this.countBoL--;
+        this.countBoL -= 1;
         return;
       }
       //buff applied prepull
@@ -220,20 +220,20 @@ class BeaconUptime extends Analyzer {
         this.missingBoLPrepull = false;
         this.missingBoL = false;
         this.lastBoLtimestamp = this.fightStart;
-        this.countBoL++;
+        this.countBoL += 1;
         return;
       }
-      // buff applied post pull, if death occurs and reapply happens before old buff goes away 
+      // buff applied post pull, if death occurs and reapply happens before old buff goes away
       // wont override lastBoLtimestamp if countBoL > 0
       if(type === POSTPULL && this.countBoL === 0) {
         this.lastBoLtimestamp = event.timestamp;
         this.missingBoL = false;
-        this.countBoL++;
+        this.countBoL += 1;
         return;
       }
       // increases count without overriding lastBoLtimestamp to track double applications
       if(type === POSTPULL && this.countBoL > 0) {
-        this.countBoL++;
+        this.countBoL += 1;
         return;
       }
       //buff not changed but updated
@@ -246,18 +246,18 @@ class BeaconUptime extends Analyzer {
 
     _updateBoF(event,type) {
       const {REMOVEBUFF,PREPULL,POSTPULL,UPDATE, ENDOFFIGHT} = this.BuffEventType;
-      
+
       // buff removed
       if(type === REMOVEBUFF && this.countBoF < 2) {
         this.missingBoF = true;
         this.uptimeBoF += event.timestamp - this.lastBoFtimestamp;
         this.lastBoFtimestamp = event.timestamp;
-        this.countBoF--;
+        this.countBoF -= 1;
       }
       // checks for overlap of beacon application with beacon removal
       // should never be >2 but just in case
       if(type === REMOVEBUFF && this.countBoF >= 2) {
-        this.countBoF--;
+        this.countBoF -= 1;
         return;
       }
       // buff applied prepull
@@ -265,20 +265,20 @@ class BeaconUptime extends Analyzer {
         this.missingBoFPrepull = false;
         this.missingBoF = false;
         this.lastBoFtimestamp = this.fightStart;
-        this.countBoF++;
+        this.countBoF += 1;
         return;
       }
-      // buff applied post pull, if death occurs and reapply happens before old buff goes away 
+      // buff applied post pull, if death occurs and reapply happens before old buff goes away
       // wont override lastBoFtimestamp if countBoF > 0
       if(type === POSTPULL && this.countBoF === 0) {
         this.lastBoFtimestamp = event.timestamp;
         this.missingBoF = false;
-        this.countBoF++;
+        this.countBoF += 1;
         return;
       }
       // increases count without overriding lastBoFtimestamp to track double applications
       if(type === POSTPULL && this.countBoF > 0) {
-        this.countBoF++;
+        this.countBoF += 1;
         return;
       }
       //buff not changed but updated
@@ -374,12 +374,12 @@ class BeaconUptime extends Analyzer {
       }
     }
 
-    _offBuff(event) {   
-      
+    _offBuff(event) {
+
       const {REMOVEBUFF} = this.BuffEventType;
 
-      if(event.ability.guid !== this.idBoL && 
-        event.ability.guid !== this.idBoF && 
+      if(event.ability.guid !== this.idBoL &&
+        event.ability.guid !== this.idBoF &&
         event.ability.guid !== this.idBoV) {
         return;
       }
@@ -396,7 +396,7 @@ class BeaconUptime extends Analyzer {
 
     _onPrepull(event) {
       const {PREPULL} = this.BuffEventType;
-      
+
       // prepull check for BoL active
       if(this.hasBoL && event.ability.guid === this.idBoL) {
         this._updateBoL(event,PREPULL);
@@ -416,8 +416,8 @@ class BeaconUptime extends Analyzer {
 
     _onBuff(event) {
 
-      if(event.ability.guid !== this.idBoL && 
-        event.ability.guid !== this.idBoF && 
+      if(event.ability.guid !== this.idBoL &&
+        event.ability.guid !== this.idBoF &&
         event.ability.guid !== this.idBoV) {
         return;
       }
@@ -440,25 +440,25 @@ class BeaconUptime extends Analyzer {
         return;
       }
     }
-    
+
 
 statistic() {
 
   const boringSpellValueContainer = {display: "flex", flexDirection: "row" };
-  const missingPrepullContainer = ( 
+  const missingPrepullContainer = (
       <div style={{color: "red", margin: "auto", textAlign: "center"}}>
-      <Trans>Not<br />casted<br />prepull</Trans></div> 
+      <Trans>Not<br />casted<br />prepull</Trans></div>
     );
-    
+
   return (
     <Statistic
       position={STATISTIC_ORDER.CORE(60)}
       size={'flexible'}
       >
       <label style={{margin: "10px"}}><Trans>Beacon Uptime</Trans></label>
-      
+
       {/*  adds a section for BoL stats if BoV talent is not taken */}
-      {!this.hasBoV && 
+      {!this.hasBoV &&
       (
         <div style={boringSpellValueContainer}>
         <BoringSpellValue
@@ -466,24 +466,24 @@ statistic() {
           value={`${this.uptimeBoLPerc}%`}
           label={<Trans>BoL Uptime</Trans>} />
         {this.missingBoLPrepull && missingPrepullContainer}
-        </div> 
+        </div>
       )}
-        
+
       {/* adds a section for BoF stats if BoF talent taken */}
-      {this.hasBoF && 
+      {this.hasBoF &&
       (
         <div style={boringSpellValueContainer}>
         <BoringSpellValue
           spell={SPELLS.BEACON_OF_FAITH_TALENT}
           value={`${this.uptimeBoFPerc}%`}
           label={<Trans>BoF Uptime</Trans>} />
-        
+
         {this.missingBoFPrepull && missingPrepullContainer}
         </div>
       )}
 
       {/* adds a section for BoV stats if BoV talent taken */}
-      {this.hasBoV && 
+      {this.hasBoV &&
       (
         <div style={boringSpellValueContainer}>
         <BoringSpellValue

--- a/src/parser/paladin/protection/modules/items/LucidDreams.tsx
+++ b/src/parser/paladin/protection/modules/items/LucidDreams.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import SPELLS from 'common/SPELLS';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { ApplyBuffEvent, RemoveBuffEvent, HealEvent, CastEvent } from 'parser/core/Events';
+import Events, { HealEvent, CastEvent } from 'parser/core/Events';
 import Abilities from 'parser/core/modules/Abilities';
 import ItemStatistic from 'interface/statistics/ItemStatistic';
 import SpellLink from 'common/SpellLink';

--- a/src/parser/paladin/retribution/modules/talents/Crusade.js
+++ b/src/parser/paladin/retribution/modules/talents/Crusade.js
@@ -44,7 +44,7 @@ class Crusade extends Analyzer {
 
   onCrusadeBuffStack(event) {
     if (this.crusadeCastTimestamp && event.timestamp > (this.crusadeCastTimestamp + CAST_BUFFER + this.gcdBuffer)) {
-      this.badFirstGlobal++;
+      this.badFirstGlobal += 1;
     }
     this.crusadeCastTimestamp = null;
   }

--- a/src/parser/paladin/retribution/modules/talents/DivinePurpose.js
+++ b/src/parser/paladin/retribution/modules/talents/DivinePurpose.js
@@ -24,7 +24,7 @@ class DivinePurpose extends Analyzer {
   constructor(...args) {
     super(...args);
     this.active = this.selectedCombatant.hasTalent(SPELLS.DIVINE_PURPOSE_TALENT_RETRIBUTION.id);
-  
+
     // event listeners
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(HOLY_POWER_SPENDERS), this.onCast);
     this.addEventListener(Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.DIVINE_PURPOSE_BUFF), this.onApplyDivinePurpose);
@@ -34,7 +34,7 @@ class DivinePurpose extends Analyzer {
     const spellId = event.ability.guid;
     if (!this.selectedCombatant.hasBuff(SPELLS.DIVINE_PURPOSE_BUFF.id)) {
       return;
-    }  
+    }
     switch (spellId) {
       case SPELLS.TEMPLARS_VERDICT.id:
         this.templarsVerdictConsumptions += 1;
@@ -56,7 +56,7 @@ class DivinePurpose extends Analyzer {
   }
 
   onApplyDivinePurpose(event){
-    this.divinePurposeProcs++;
+    this.divinePurposeProcs += 1;
     const timeSinceLastDPconsumption = event.timestamp - this.lastDivinePurposeConsumption;
     if (timeSinceLastDPconsumption < CHAIN_PROC_BUFFER) {
       if (this.currentProcChain === 0) {

--- a/src/parser/paladin/retribution/modules/talents/RighteousVerdict.js
+++ b/src/parser/paladin/retribution/modules/talents/RighteousVerdict.js
@@ -25,7 +25,7 @@ class RighteousVerdict extends Analyzer {
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.TEMPLARS_VERDICT.id) {
-      this.totalSpenders++;
+      this.totalSpenders += 1;
     }
   }
 
@@ -35,7 +35,7 @@ class RighteousVerdict extends Analyzer {
       return;
     }
     if (spellId === SPELLS.TEMPLARS_VERDICT_DAMAGE.id) {
-      this.spendersInsideBuff++;
+      this.spendersInsideBuff += 1;
       this.damageDone += calculateEffectiveDamage(event, RIGHTEOUS_VERDICT_MODIFIER);
     }
   }

--- a/src/parser/priest/discipline/modules/features/PurgeTheWicked.js
+++ b/src/parser/priest/discipline/modules/features/PurgeTheWicked.js
@@ -56,12 +56,12 @@ class PurgeTheWicked extends Analyzer {
   }
 
   onDotCast(event) {
-    this.ptwCasts++;
+    this.ptwCasts += 1;
     this.lastCastTarget = event.targetID;
   }
 
   onDotApply(event) {
-    this.ptwApplications++;
+    this.ptwApplications += 1;
 
     if (event.targetID !== this.lastCastTarget) {
       this.ptwCleaveTracker[event.targetID] = 1;

--- a/src/parser/priest/holy/modules/spells/PrayerOfMending.js
+++ b/src/parser/priest/holy/modules/spells/PrayerOfMending.js
@@ -38,11 +38,11 @@ class PrayerOfMending extends Analyzer {
     const spellId = event.ability.guid;
 
     if (spellId === SPELLS.PRAYER_OF_MENDING_CAST.id) {
-      this.pomCasts++;
+      this.pomCasts += 1;
     }
     if (spellId === SPELLS.HOLY_WORD_SALVATION_TALENT.id) {
       this.lastSalvCastTime = event.timestamp;
-      this.salvCasts++;
+      this.salvCasts += 1;
     }
   }
 
@@ -50,7 +50,7 @@ class PrayerOfMending extends Analyzer {
     const spellId = event.ability.guid;
 
     if (spellId === SPELLS.PRAYER_OF_MENDING_HEAL.id) {
-      this.pomHealTicks++;
+      this.pomHealTicks += 1;
       this.totalPoMHealing += event.amount || 0;
       this.totalPoMOverhealing += event.overheal || 0;
       this.totalPoMAbsorption += event.absorbed || 0;
@@ -64,8 +64,8 @@ class PrayerOfMending extends Analyzer {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.PRAYER_OF_MENDING_BUFF.id) {
       if (event.prepull) {
-        this.prepullPomBuffs++;
-        this.pomCasts++;
+        this.prepullPomBuffs += 1;
+        this.pomCasts += 1;
       }
     }
   }
@@ -74,9 +74,9 @@ class PrayerOfMending extends Analyzer {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.PRAYER_OF_MENDING_BUFF.id) {
       if (event.stacksGained > 0) {
-        this.pomBuffCount++;
+        this.pomBuffCount += 1;
       } else {
-        this.pomRemovalCount++;
+        this.pomRemovalCount += 1;
       }
     }
   }

--- a/src/parser/priest/holy/modules/spells/Renew.js
+++ b/src/parser/priest/holy/modules/spells/Renew.js
@@ -109,7 +109,7 @@ class Renew extends Analyzer {
       this.validateRenew(event);
     }
     if (spellId === SPELLS.RENEW.id) {
-      this.renewsCast++;
+      this.renewsCast += 1;
       this.lastCast = event;
     } else if (spellId === SPELLS.HOLY_WORD_SALVATION_TALENT.id) {
       this.lastSalvationCast = event.timestamp;
@@ -133,14 +133,14 @@ class Renew extends Analyzer {
       return;
     }
 
-    this.totalRenewApplications++;
+    this.totalRenewApplications += 1;
 
     if (this.salvationActive && event.timestamp - this.lastSalvationCast < MS_BUFFER) {
-      this.renewsFromSalvation++;
+      this.renewsFromSalvation += 1;
     } else if (this.enduringRenewalActive && event.timestamp - this.lastEnduringRenewalSpellCast < MS_BUFFER) {
-      this.renewsFromEnduringRenewal++;
+      this.renewsFromEnduringRenewal += 1;
     } else {
-      this.renewsFromBenedictionAndRenew++;
+      this.renewsFromBenedictionAndRenew += 1;
     }
   }
 

--- a/src/parser/priest/holy/modules/spells/azeritetraits/BlessedSanctuary.js
+++ b/src/parser/priest/holy/modules/spells/azeritetraits/BlessedSanctuary.js
@@ -51,7 +51,7 @@ class BlessedSanctuary extends Analyzer {
     const spellId = event.ability.guid;
 
     if (spellId === SPELLS.HOLY_WORD_SANCTIFY.id) {
-      this.blessedSanctuaryProcCount++;
+      this.blessedSanctuaryProcCount += 1;
     }
   }
 

--- a/src/parser/priest/holy/modules/spells/azeritetraits/EverlastingLight.js
+++ b/src/parser/priest/holy/modules/spells/azeritetraits/EverlastingLight.js
@@ -39,7 +39,7 @@ class EverlastingLight extends Analyzer {
       this.currentMana = event.classResources[0].amount;
     }
     if (spellId === SPELLS.GREATER_HEAL.id) {
-      this.totalHealsCast++;
+      this.totalHealsCast += 1;
     }
   }
 

--- a/src/parser/priest/holy/modules/spells/azeritetraits/PermeatingGlow.js
+++ b/src/parser/priest/holy/modules/spells/azeritetraits/PermeatingGlow.js
@@ -28,7 +28,7 @@ class PermeatingGlow extends Analyzer {
 
     if (spellId === SPELLS.FLASH_HEAL.id) {
       if (this.permiatingGlowBuffs[event.targetID.toString()]) {
-        this.permiatingGlowProcCount++;
+        this.permiatingGlowProcCount += 1;
         let eventHealing = this.permiatingGlowProcAmount;
         let eventOverhealing = 0;
 

--- a/src/parser/priest/holy/modules/spells/azeritetraits/PrayerfulLitany.js
+++ b/src/parser/priest/holy/modules/spells/azeritetraits/PrayerfulLitany.js
@@ -65,7 +65,7 @@ class PrayerfulLitany extends Analyzer {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.PRAYER_OF_HEALING.id) {
       this.lastPoHCast = event.timestamp;
-      this.prayerOfHealingCasts++;
+      this.prayerOfHealingCasts += 1;
 
       // If you hit yourself with prayer of healing, the heal event will fire before the cast event. This compensates for that.
       if (this.numberOfHeals > 1) {

--- a/src/parser/priest/holy/modules/spells/holyword/HolyWordBase.js
+++ b/src/parser/priest/holy/modules/spells/holyword/HolyWordBase.js
@@ -120,12 +120,12 @@ class HolyWordBase extends Analyzer {
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
     if (spellId === this.spellId) {
-      this.holyWordCasts++;
+      this.holyWordCasts += 1;
       this.remainingCooldown = this.baseCooldown;
 
       if (this.apotheosisActive) {
         this.apotheosisManaReduction += this.manaCost;
-        this.holyWordApotheosisCasts++;
+        this.holyWordApotheosisCasts += 1;
       }
 
     } else if (this.serendipityProccers[spellId] != null) {
@@ -182,7 +182,7 @@ class HolyWordBase extends Analyzer {
   on_byPlayer_applybuff(event) {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.APOTHEOSIS_TALENT.id) {
-      this.apotheosisCasts++;
+      this.apotheosisCasts += 1;
       this.apotheosisActive = true;
     }
   }

--- a/src/parser/priest/holy/modules/talents/100/Apotheosis.js
+++ b/src/parser/priest/holy/modules/talents/100/Apotheosis.js
@@ -27,7 +27,7 @@ class Apotheosis extends Analyzer {
   on_byPlayer_applybuff(event) {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.APOTHEOSIS_TALENT.id) {
-      this.apotheosisCasts++;
+      this.apotheosisCasts += 1;
       this.apotheosisActive = true;
     }
   }

--- a/src/parser/priest/holy/modules/talents/15/TrailOfLight.js
+++ b/src/parser/priest/holy/modules/talents/15/TrailOfLight.js
@@ -19,7 +19,7 @@ class TrailOfLight extends Analyzer {
   on_byPlayer_heal(event) {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.TRAIL_OF_LIGHT_HEAL.id) {
-      this.totalToLProcs++;
+      this.totalToLProcs += 1;
       this.totalToLHealing += event.overheal || 0;
       this.totalToLOverhealing += (event.amount || 0);
     }

--- a/src/parser/priest/holy/modules/talents/30/AngelicFeather.js
+++ b/src/parser/priest/holy/modules/talents/30/AngelicFeather.js
@@ -17,7 +17,7 @@ class AngelicFeather extends Analyzer {
     const spellId = event.ability.guid;
 
     if (spellId === SPELLS.ANGELIC_FEATHER_TALENT.id) {
-      this.angelicFeatherCasts++;
+      this.angelicFeatherCasts += 1;
     }
   }
 
@@ -25,7 +25,7 @@ class AngelicFeather extends Analyzer {
     const spellId = event.ability.guid;
 
     if (spellId === SPELLS.ANGELIC_FEATHER_TALENT.id) {
-      this.angelicFeatherEffects++;
+      this.angelicFeatherEffects += 1;
     }
   }
 

--- a/src/parser/priest/holy/modules/talents/30/AngelsMercy.js
+++ b/src/parser/priest/holy/modules/talents/30/AngelsMercy.js
@@ -26,7 +26,7 @@ class AngelsMercy extends Analyzer {
           this.desperatePrayerTimeReduced += DESPERATE_PRAYER_BASE_COOLDOWN - timeSinceLastDP;
         }
       }
-      this.desperatePrayersCast++;
+      this.desperatePrayersCast += 1;
       this.lastDesperatePrayerTimestamp = event.timestamp;
     }
   }

--- a/src/parser/priest/holy/modules/talents/45/Afterlife.js
+++ b/src/parser/priest/holy/modules/talents/45/Afterlife.js
@@ -32,7 +32,7 @@ class Afterlife extends Analyzer {
     if (spellId === SPELLS.SPIRIT_OF_REDEMPTION_BUFF.id) {
       this.inSpiritOfRedemption = true;
       this.spiritOfRedemptionStartTime = event.timestamp;
-      this.sorCount++;
+      this.sorCount += 1;
     }
   }
 

--- a/src/parser/priest/holy/modules/talents/45/CosmicRipple.js
+++ b/src/parser/priest/holy/modules/talents/45/CosmicRipple.js
@@ -26,10 +26,10 @@ class CosmicRipple extends Analyzer {
     }
     this.overhealing += event.overheal || 0;
     this.totalHealing += (event.amount || 0) + (event.absorbed || 0);
-    this.totalHits++;
+    this.totalHits += 1;
 
     if (event.timestamp - this.lastRippleTimeStamp > 1000) {
-      this.totalRipples++;
+      this.totalRipples += 1;
       this.lastRippleTimeStamp = event.timestamp;
     }
   }

--- a/src/parser/priest/holy/modules/talents/60/Censure.js
+++ b/src/parser/priest/holy/modules/talents/60/Censure.js
@@ -18,7 +18,7 @@ class Censure extends Analyzer {
     const spellId = event.ability.guid;
 
     if (spellId === SPELLS.HOLY_WORD_CHASTISE.id) {
-      this.chastiseCasts++;
+      this.chastiseCasts += 1;
     }
   }
 
@@ -26,10 +26,10 @@ class Censure extends Analyzer {
     const spellId = event.ability.guid;
 
     if (spellId === SPELLS.HOLY_WORD_CHASTISE_CENSURE_INCAPACITATE.id) {
-      this.censureIncomp++;
+      this.censureIncomp += 1;
     }
     if (spellId === SPELLS.HOLY_WORD_CHASTISE_CENSURE_STUN.id) {
-      this.censureStuns++;
+      this.censureStuns += 1;
     }
   }
 

--- a/src/parser/priest/holy/modules/talents/60/PsychicVoice.js
+++ b/src/parser/priest/holy/modules/talents/60/PsychicVoice.js
@@ -16,14 +16,14 @@ class PsychicVoice extends Analyzer {
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.PSYCHIC_SCREAM.id) {
-      this.psychicScreamCasts++;
+      this.psychicScreamCasts += 1;
     }
   }
 
   on_byPlayer_applydebuff(event) {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.PSYCHIC_SCREAM.id) {
-      this.psychicScreamHits++;
+      this.psychicScreamHits += 1;
     }
   }
 

--- a/src/parser/priest/holy/modules/talents/60/ShiningForce.js
+++ b/src/parser/priest/holy/modules/talents/60/ShiningForce.js
@@ -16,14 +16,14 @@ class ShiningForce extends Analyzer {
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.SHINING_FORCE_TALENT.id) {
-      this.shiningForceCasts++;
+      this.shiningForceCasts += 1;
     }
   }
 
   on_byPlayer_applydebuff(event) {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.SHINING_FORCE_TALENT.id) {
-      this.shiningForceHits++;
+      this.shiningForceHits += 1;
     }
   }
 

--- a/src/parser/priest/holy/modules/talents/75/BindingHeal.js
+++ b/src/parser/priest/holy/modules/talents/75/BindingHeal.js
@@ -36,7 +36,7 @@ class BindingHeal extends Analyzer {
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.BINDING_HEAL_TALENT.id) {
-      this.bindingHealCasts++;
+      this.bindingHealCasts += 1;
     }
   }
 

--- a/src/parser/priest/holy/modules/talents/75/CircleOfHealing.js
+++ b/src/parser/priest/holy/modules/talents/75/CircleOfHealing.js
@@ -32,14 +32,14 @@ class CircleOfHealing extends Analyzer {
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.CIRCLE_OF_HEALING_TALENT.id) {
-      this.circleOfHealingCasts++;
+      this.circleOfHealingCasts += 1;
     }
   }
 
   on_byPlayer_heal(event) {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.CIRCLE_OF_HEALING_TALENT.id) {
-      this.circleOfHealingTargetsHit++;
+      this.circleOfHealingTargetsHit += 1;
       this.circleOfHealingHealing += event.amount || 0;
       this.circleOfHealingOverhealing += event.overheal || 0;
     }

--- a/src/parser/priest/holy/modules/talents/75/SurgeOfLight.js
+++ b/src/parser/priest/holy/modules/talents/75/SurgeOfLight.js
@@ -42,7 +42,7 @@ class SurgeOfLight extends Analyzer {
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
     if (spellId === SPELLS.FLASH_HEAL.id && this.freeFlashHealPending) {
-      this.solFlashHeals++;
+      this.solFlashHeals += 1;
     }
   }
 

--- a/src/parser/priest/shared/modules/features/DesperatePrayer.js
+++ b/src/parser/priest/shared/modules/features/DesperatePrayer.js
@@ -47,7 +47,7 @@ class DesperatePrayer extends Analyzer {
 
   on_toPlayer_death(event) {
     if(!this.spellUsable.isOnCooldown(SPELLS.DESPERATE_PRAYER.id)){
-      this.deathsWithDPReady++;
+      this.deathsWithDPReady += 1;
     }
   }
 

--- a/src/parser/priest/shared/modules/spells/azeritetraits/Sanctum.js
+++ b/src/parser/priest/shared/modules/spells/azeritetraits/Sanctum.js
@@ -32,7 +32,7 @@ class Sanctum extends Analyzer {
     const spellId = event.ability.guid;
 
     if (spellId === SPELLS.FADE.id) {
-      this.fadeCount++;
+      this.fadeCount += 1;
     }
   }
 

--- a/src/parser/priest/shared/modules/spells/azeritetraits/TwistMagic.js
+++ b/src/parser/priest/shared/modules/spells/azeritetraits/TwistMagic.js
@@ -30,7 +30,7 @@ class TwistMagic extends Analyzer {
 
     const spellId = event.ability.guid;
     if (spellId === SPELLS.PURIFY.id || spellId === SPELLS.DISPEL_MAGIC.id || spellId === SPELLS.MASS_DISPEL.id) {
-      this.totalDispels++;
+      this.totalDispels += 1;
     }
   }
 

--- a/src/parser/rogue/subtlety/modules/talents/FindWeakness.js
+++ b/src/parser/rogue/subtlety/modules/talents/FindWeakness.js
@@ -16,7 +16,7 @@ class FindWeakness extends Analyzer {
   static dependencies = {
     enemies: Enemies,
   };
-   
+
   constructor(...args) {
     super(...args);
     this.active = this.selectedCombatant.hasTalent(SPELLS.FIND_WEAKNESS_TALENT.id);
@@ -47,7 +47,7 @@ class FindWeakness extends Analyzer {
 
     //For now does not support target switching, just makes sure that enough time has passed since the last application
     if(Math.max(...hasDebuff, this.latestTs) > event.timestamp - 8000) {
-      this.badVanishCasts++;
+      this.badVanishCasts += 1;
       event.meta = event.meta || {};
       event.meta.isInefficientCast = true;
       event.meta.inefficientCastReason = `Use Vanish only when Find Weakness is not up or is about to run out.`;
@@ -85,7 +85,7 @@ class FindWeakness extends Analyzer {
         value={`${formatPercentage(uptime)} %`}
         label={`${SPELLS.FIND_WEAKNESS_TALENT.name} uptime`}
       />
-    );  
+    );
   }
 }
 

--- a/src/parser/shaman/elemental/modules/core/FlameShock.js
+++ b/src/parser/shaman/elemental/modules/core/FlameShock.js
@@ -64,7 +64,7 @@ class FlameShock extends EarlyDotRefreshesAnalyzer {
 
     const target = this.enemies.getEntity(event);
     if(target && !target.hasBuff(SPELLS.FLAME_SHOCK.id)){
-      this.badLavaBursts++;
+      this.badLavaBursts += 1;
     }
   }
 

--- a/src/parser/shaman/elemental/modules/talents/CallTheThunder.js
+++ b/src/parser/shaman/elemental/modules/talents/CallTheThunder.js
@@ -35,7 +35,7 @@ class CallTheThunder extends Analyzer {
 
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.EARTH_SHOCK), this.onEarthShockCast);
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.EARTHQUAKE), this.onEarthquakeCast);
-    
+
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.EARTH_SHOCK), this.onEarthShockDamage);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.EARTHQUAKE_DAMAGE), this.onEarthquakeDamage);
   }
@@ -78,11 +78,11 @@ class CallTheThunder extends Analyzer {
   }
 
   onEarthShockCast() {
-    this.earthShockCasts++;
+    this.earthShockCasts += 1;
   }
 
   onEarthquakeCast() {
-    this.earthquakeCasts++;
+    this.earthquakeCasts += 1;
   }
 
   statistic() {

--- a/src/parser/shaman/elemental/modules/talents/ElementalBlast.js
+++ b/src/parser/shaman/elemental/modules/talents/ElementalBlast.js
@@ -23,7 +23,7 @@ class ElementalBlast extends Analyzer {
 
   on_toPlayer_removebuff(event) {
     if (ELEMENTAL_BLAST_IDS.includes(event.ability.guid)){
-      this.currentBuffAmount--;
+      this.currentBuffAmount -= 1;
       if (this.currentBuffAmount===0) {
         this.resultDuration += event.timestamp - this.lastFreshApply;
       }
@@ -35,7 +35,7 @@ class ElementalBlast extends Analyzer {
       if (this.currentBuffAmount===0) {
         this.lastFreshApply = event.timestamp;
       }
-      this.currentBuffAmount++;
+      this.currentBuffAmount += 1;
     }
   }
 

--- a/src/parser/shaman/elemental/modules/talents/Icefury.js
+++ b/src/parser/shaman/elemental/modules/talents/Icefury.js
@@ -11,26 +11,26 @@ class Icefury extends Analyzer {
   static dependencies = {
     abilityTracker: AbilityTracker,
   };
-  
+
   empoweredFrostShockCasts = 0;
-  
+
   constructor(...args) {
     super(...args);
     this.active = this.selectedCombatant.hasTalent(SPELLS.ICEFURY_TALENT.id);
-    
+
     if (!this.active) {
       return;
     }
 
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.FROST_SHOCK), this.onFrostShockCast);
   }
-  
+
   onFrostShockCast(event) {
     if (this.selectedCombatant.hasBuff(SPELLS.ICEFURY_TALENT.id)) {
-      this.empoweredFrostShockCasts++;
+      this.empoweredFrostShockCasts += 1;
     }
   }
-  
+
   get suggestionThresholds() {
     return {
       actual: this.empoweredFrostShockCasts / this.abilityTracker.getAbility(SPELLS.ICEFURY_TALENT.id).casts,
@@ -42,7 +42,7 @@ class Icefury extends Analyzer {
       style: 'decimal',
     };
   }
-  
+
   suggestions(when) {
     when(this.suggestionThresholds).addSuggestion((suggest, actual) => {
       return suggest(<>You should fully utilize your <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> casts by casting 4 <SpellLink id={SPELLS.FROST_SHOCK.id} />s before the <SpellLink id={SPELLS.ICEFURY_TALENT.id} /> buff expires. Pay attention to the remaining duration of the buff to ensure you have time to use all of the stacks.</>)

--- a/src/parser/shaman/elemental/modules/talents/MasterOfTheElements.js
+++ b/src/parser/shaman/elemental/modules/talents/MasterOfTheElements.js
@@ -73,7 +73,7 @@ class MasterOfTheElements extends Analyzer {
     this.moteActivationTimestamp=null;
     event.meta = event.meta || {};
     event.meta.isEnhancedCast = true;
-    this.moteBuffedAbilities[event.ability.guid]++;
+    this.moteBuffedAbilities[event.ability.guid] += 1;
 
   }
 

--- a/src/parser/shaman/elemental/modules/talents/PrimalFireElemental.js
+++ b/src/parser/shaman/elemental/modules/talents/PrimalFireElemental.js
@@ -48,7 +48,7 @@ class PrimalFireElemental extends Analyzer {
   on_cast(event) {
     switch(event.ability.guid) {
       case SPELLS.FIRE_ELEMENTAL.id:
-        this.PFEcasts++;
+        this.PFEcasts += 1;
         break;
       case SPELLS.FIRE_ELEMENTAL_FIRE_BLAST.id:
         this.usedCasts['Fire Blast']=true;
@@ -58,7 +58,7 @@ class PrimalFireElemental extends Analyzer {
         break;
       case SPELLS.FIRE_ELEMENTAL_METEOR.id:
         this.usedCasts.Meteor=true;
-        this.meteorCasts++;
+        this.meteorCasts += 1;
         break;
       default:
         break;

--- a/src/parser/shaman/elemental/modules/talents/SurgeOfPower.js
+++ b/src/parser/shaman/elemental/modules/talents/SurgeOfPower.js
@@ -49,7 +49,7 @@ class SurgeOfPower extends Analyzer {
 
     event.meta = event.meta || {};
     event.meta.isEnhancedCast = true;
-    this.sopBuffedAbilities[event.ability.guid]++;
+    this.sopBuffedAbilities[event.ability.guid] += 1;
 
     // cast lightning bolt with SoP and SK buffs active
     if (this.selectedCombatant.hasBuff(SPELLS.STORMKEEPER_TALENT.id, event.timestamp) && event.ability.guid === SPELLS.LIGHTNING_BOLT.id) {

--- a/src/parser/shaman/restoration/modules/spells/ChainHeal.js
+++ b/src/parser/shaman/restoration/modules/spells/ChainHeal.js
@@ -53,7 +53,7 @@ class ChainHeal extends Analyzer {
     if (this.buffer.length === 0) {
       return;
     }
-    this.castIndex++;
+    this.castIndex += 1;
     this.chainHealHistory[this.castIndex] = {};
     const currentCast = this.buffer.find(event => event.type === "cast");
     if (!currentCast) {

--- a/src/parser/shaman/restoration/modules/talents/HighTide.js
+++ b/src/parser/shaman/restoration/modules/talents/HighTide.js
@@ -68,11 +68,11 @@ class HighTide extends Analyzer {
     this.currentHighTideBuff = 0;
   }
 
-  // on a chain heal cast and buff counter is greater than 0, adds one to used counter 
+  // on a chain heal cast and buff counter is greater than 0, adds one to used counter
   // and reduces buff counter by one.
   onChainHealCast(event) {
     if (this.currentHighTideBuff > 0) {
-      this.usedHighTides++;
+      this.usedHighTides += 1;
       this.currentHighTideBuff -= 1;
     }
   }
@@ -95,18 +95,18 @@ class HighTide extends Analyzer {
      * 1. The healing events are backwards [4,3,2,1]
      * 2. If the Shaman heals himself, his healing event is always first [3,4,2,1] (3 = Shaman)
      * 3. If 2. happens, the heal on the shaman is also happening before the cast event, which the lines above already deal with.
-     * 
+     *
      * Calculating out High Tide requires us to know the exact jump order, as High Tide affects each jump differently.
      * https://ancestralguidance.com/hidden-spell-mechanics/
      * The solution is to reorder the events into the correct hit order, which could be done since each consecutive heal is weaker
      * than the one beforehand (by 30%), except, you have the Shaman mastery which will result in random healing numbers
      * as each hit has a different mastery effectiveness - the higher the Shamans mastery, the more rapidly different the numbers end up.
      * With traits like https://www.wowhead.com/spell=277942/ancestral-resonance existing, shamans mastery can randomly double or triple mid combat.
-     * 
+     *
      * So we take 1 cast of chain heal at a time (4 hits maximum), calculate out crits and the mastery bonus, reorder them according to the new values
      * (High healing to Low healing or [4,3,2,1] to [1,2,3,4]) and get the High Tide contribution by comparing the original heal values against
      * what a non-High Tide Chain Heal would have done each bounce.
-     * 
+     *
      * Things that are able to break the sorting: Deluge (Pls don't take it) as its undetectable, random player-based heal increases
      * (possibly encounter mechanics) if not accounted for.
      */

--- a/src/parser/shared/modules/DispelTracker.js
+++ b/src/parser/shared/modules/DispelTracker.js
@@ -29,7 +29,7 @@ class DispelTracker extends Analyzer {
     if (!this.dispelEvents[abilityDispelled.guid]) {
       this.dispelEvents[abilityDispelled.guid] = 1;
     } else {
-      this.dispelEvents[abilityDispelled.guid]++;
+      this.dispelEvents[abilityDispelled.guid] += 1;
     }
 
     if (!SPELLS[abilityDispelled.guid]) {
@@ -41,7 +41,7 @@ class DispelTracker extends Analyzer {
       };
     }
 
-    this.dispelCount++;
+    this.dispelCount += 1;
   }
 
   statistic() {

--- a/src/parser/shared/modules/items/bfa/dungeons/AzerokksResonatingHeart.js
+++ b/src/parser/shared/modules/items/bfa/dungeons/AzerokksResonatingHeart.js
@@ -17,7 +17,7 @@ const BASE_AGILITY_BUFF = 593;
 /**
  * Azerokk's Resonating Heart
  * Equip: Your attacks have a chance to harmonize with the shard, granting you X Agility for 15 sec.
- * 
+ *
  * Test log: http://wowanalyzer.com/report/PcaGB6n41NDMrbmA/1-Mythic+Champion+of+the+Light+-+Kill+(1:37)/Baboune/statistics
  */
 class AzerokksResonatingHeart extends Analyzer {
@@ -52,7 +52,7 @@ class AzerokksResonatingHeart extends Analyzer {
       return;
     }
 
-    this.procs++;
+    this.procs += 1;
   }
 
   get uptime() {

--- a/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsInsignia.js
+++ b/src/parser/shared/modules/items/bfa/pvp/DreadGladiatorsInsignia.js
@@ -51,7 +51,7 @@ class DreadGladiatorsInsignia extends Analyzer {
       return;
     }
 
-    this.procs++;
+    this.procs += 1;
   }
 
   get uptime() {

--- a/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/TridentOfDeepOcean.js
+++ b/src/parser/shared/modules/items/bfa/raids/crucibleofstorms/TridentOfDeepOcean.js
@@ -49,7 +49,7 @@ class TridentOfDeepOcean extends Analyzer {
   }
 
   _applyShield(event){
-    this.shieldCount++;
+    this.shieldCount += 1;
   }
 
   _absorbDamage(event){

--- a/src/parser/shared/modules/spells/bfa/azeritetraits/BlessedPortents.js
+++ b/src/parser/shared/modules/spells/bfa/azeritetraits/BlessedPortents.js
@@ -29,8 +29,8 @@ class BlessedPortents extends Analyzer {
 
     this.healing += event.amount + (event.absorbed || 0);
 
-    this.proccedBuffs++;
-    this.expiredBuffs--;
+    this.proccedBuffs += 1;
+    this.expiredBuffs -= 1;
   }
 
   on_byPlayer_applybuff(event) {
@@ -40,7 +40,7 @@ class BlessedPortents extends Analyzer {
       return;
     }
 
-    this.activeBuffs++;
+    this.activeBuffs += 1;
   }
 
   on_byPlayer_removebuff(event) {
@@ -49,8 +49,8 @@ class BlessedPortents extends Analyzer {
       return;
     }
 
-    this.expiredBuffs++;
-    this.activeBuffs--;
+    this.expiredBuffs += 1;
+    this.activeBuffs -= 1;
   }
 
   on_byPlayer_refreshbuff(event) {
@@ -59,7 +59,7 @@ class BlessedPortents extends Analyzer {
       return;
     }
 
-    this.refreshedBuffs++;
+    this.refreshedBuffs += 1;
   }
   get totalBuffs() {
     return this.proccedBuffs + this.expiredBuffs + this.refreshedBuffs + this.activeBuffs;

--- a/src/parser/shared/modules/spells/bfa/azeritetraits/Tradewinds.js
+++ b/src/parser/shared/modules/spells/bfa/azeritetraits/Tradewinds.js
@@ -60,7 +60,7 @@ class Tradewinds extends Analyzer {
 
   handleBuff(event) {
     if (event.ability.guid === SPELLS.TRADEWINDS_BUFF.id) {
-      this.procs++;
+      this.procs += 1;
     }
   }
 

--- a/src/parser/warrior/fury/modules/talents/MeatCleaver.js
+++ b/src/parser/warrior/fury/modules/talents/MeatCleaver.js
@@ -49,7 +49,7 @@ class MeatCleaver extends Analyzer {
     // Whirlwind triggers damage 3 times. We only need to count the number of targets hit on the first set of MH damage
     if (this.whirlwindEvents[this.lastWhirlwindCast].isFirstRoundOfDamage) {
       if (event.ability.guid === SPELLS.WHIRLWIND_FURY_DAMAGE_MH.id) {
-        this.whirlwindEvents[this.lastWhirlwindCast].targetsHit++;
+        this.whirlwindEvents[this.lastWhirlwindCast].targetsHit += 1;
       } else {
         this.whirlwindEvents[this.lastWhirlwindCast].isFirstRoundOfDamage = false;
       }

--- a/src/parser/warrior/protection/modules/spells/ShieldBlock.js
+++ b/src/parser/warrior/protection/modules/spells/ShieldBlock.js
@@ -95,7 +95,7 @@ class ShieldBlock extends Analyzer {
     };
 
     this.shieldBlocksOffensive.push(offensive);
-    
+
     const defensive = {
       shieldBlock: this.shieldBlocksDefensive.length + 1,
       blockAbleEvents: 0,
@@ -111,7 +111,7 @@ class ShieldBlock extends Analyzer {
   }
 
   shieldSlamCast(event){
-    this.shieldBlocksOffensive[this.shieldBlocksOffensive.length-1].shieldSlamCasts++;
+    this.shieldBlocksOffensive[this.shieldBlocksOffensive.length-1].shieldSlamCasts += 1;
 
     if(this.shieldBlocksOffensive[this.shieldBlocksOffensive.length-1].shieldSlamCasts > this.ssNeeded){
       this.shieldBlocksOffensive[this.shieldBlocksOffensive.length-1].good = true;
@@ -122,7 +122,7 @@ class ShieldBlock extends Analyzer {
     const bonusDamage = Math.round(eventDamage - eventDamage / 1.3);
 
     this.shieldBlocksOffensive[this.shieldBlocksOffensive.length-1].bonusDamage = beforeDamage + bonusDamage;
-    
+
   }
 
 
@@ -209,7 +209,7 @@ class ShieldBlock extends Analyzer {
           <br /><br />
             Some casts may be good both offensively and defensively.
           <br /><br />
-            Try to maximize the efficiency of your <SpellLink id={SPELLS.SHIELD_BLOCK.id} /> casts by ensuring that you take advantage of the offensive or defensive effects each time. 
+            Try to maximize the efficiency of your <SpellLink id={SPELLS.SHIELD_BLOCK.id} /> casts by ensuring that you take advantage of the offensive or defensive effects each time.
           </>
         )}
       >

--- a/src/parser/warrior/protection/modules/talents/Bolster.js
+++ b/src/parser/warrior/protection/modules/talents/Bolster.js
@@ -24,9 +24,9 @@ class Bolster extends Analyzer {
     if (!(spellId === SPELLS.LAST_STAND.id || spellId === SPELLS.SHIELD_BLOCK_BUFF.id)) {
       return;
     }
-     
+
     if (this.selectedCombatant.hasBuff(SPELLS.SHIELD_BLOCK_BUFF.id) && this.selectedCombatant.hasBuff(SPELLS.LAST_STAND.id)) {
-      this.badBlocks++;
+      this.badBlocks += 1;
       this.buffStartTime += event.timestamp;
     }
   }


### PR DESCRIPTION
Enforces the style-guide more accurately: https://github.com/WoWAnalyzer/WoWAnalyzer/wiki/Meta:-Style-guide

The only commit I am a bit worried about is the last one, I couldn't get no-plusplus to allow the lines where we had something like the below codesnippet, which only happened in our azerite extract tool which is going to be gone in SL, so I think it's okay to add it to eslintignore for now. 
```
for (i = 0, j = l; i < l; i++, j--) {
    doSomething(i, j);
}
```

It's just weird because eslint says that what I added should allow for it.. 
