### PR TITLE
Centralized cast cooldowns and pet damage for CooldownThroughputTrackers

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -9,6 +9,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/ContributorButton';
 
 export default [
+  change(date(2020, 5, 14), 'Centralized cast cooldowns and pet damage for CooldownThroughputTrackers', Vetyst),
   change(date(2020, 5, 14), 'Replaced hardcoded event type strings with EventType equivalent', Vetyst),
   change(date(2020, 5, 13), 'Disallow use of ++ and -- to adhere to the style guide', Putro),
   change(date(2020, 5, 12), 'Tweak JetBrains codeStyles file to better adhere to code style, while allowing for auto-formatting all files in the repository.', Vetyst),

--- a/src/parser/deathknight/unholy/modules/features/CooldownThroughputTracker.js
+++ b/src/parser/deathknight/unholy/modules/features/CooldownThroughputTracker.js
@@ -1,50 +1,7 @@
 import CoreCooldownThroughputTracker from 'parser/shared/modules/CooldownThroughputTracker';
 
-
-const debug = false;
-
 class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
-  static cooldownSpells = [
-    ...CoreCooldownThroughputTracker.cooldownSpells,
-    // if im understanding correctly CooldownThroughputTracker tracks all abilities cast during the duration of some CD that buffs you in some way, (ex Battle Cry, Pillar of Frost)
-    // Unholy's CDs are all based around summons so nothing goes here
-  ];
-  static castCooldowns = [
-  ];
-
-  on_byPlayer_cast(event) {
-    const spellId = event.ability.guid;
-    const cooldownSpell = this.constructor.castCooldowns.find(cooldownSpell => cooldownSpell.spell.id === spellId);
-    if (cooldownSpell) {
-      // adding the fixed cooldown, now we need to remove it from activeCooldowns too
-      const cooldown = this._addFixedCooldown(cooldownSpell, event.timestamp);
-      this.activeCooldowns.push(cooldown);
-      debug && console.log(`%cCooldown started: ${cooldownSpell.spell.name}`, 'color: green', cooldown);
-    }
-    // super.on_byPlayer_cast(event) would call trackEvent anyway
-    super.on_byPlayer_cast && super.on_byPlayer_cast(event);
-  }
-
-  _addFixedCooldown(cooldownSpell, timestamp) {
-    const cooldown = {
-      ...cooldownSpell,
-      start: timestamp,
-      end: timestamp + cooldownSpell.duration * 1000,
-      events: [],
-    };
-    this.pastCooldowns.push(cooldown);
-    return cooldown;
-  }
-
-  // on_event() might be more accurate but it would be most likely called much more
-  trackEvent(event) {
-    this.activeCooldowns = this.activeCooldowns.filter(cooldown => !cooldown.end || event.timestamp < cooldown.end);
-    super.trackEvent(event);
-  }
-
-  on_byPlayerPet_damage(event) {
-    this.trackEvent(event);
-  }
+  static trackPlayerPetDamage = true;
 }
 
 export default CooldownThroughputTracker;

--- a/src/parser/druid/feral/modules/features/CooldownThroughputTracker.js
+++ b/src/parser/druid/feral/modules/features/CooldownThroughputTracker.js
@@ -29,14 +29,6 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
       ],
     },
   ];
-
-  trackEvent(event) {
-    this.activeCooldowns.forEach((cooldown) => {
-      if (event.ability.guid !== SPELLS.DOOM_VORTEX.id) {
-        cooldown.events.push(event);
-      }
-    });
-  }
 }
 
 export default CooldownThroughputTracker;

--- a/src/parser/mage/arcane/modules/features/CooldownThroughputTracker.js
+++ b/src/parser/mage/arcane/modules/features/CooldownThroughputTracker.js
@@ -1,8 +1,6 @@
 import SPELLS from 'common/SPELLS';
 import CoreCooldownThroughputTracker, { BUILT_IN_SUMMARY_TYPES } from 'parser/shared/modules/CooldownThroughputTracker';
 
-const debug = false;
-
 class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
   static cooldownSpells = [
     ...CoreCooldownThroughputTracker.cooldownSpells,
@@ -21,6 +19,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
   ];
 
   static castCooldowns = [
+    ...CoreCooldownThroughputTracker.castCooldowns,
     {
       spell: SPELLS.MIRROR_IMAGE_TALENT,
       duration: 40,
@@ -30,39 +29,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     },
   ];
 
-  on_byPlayer_cast(event) {
-    const spellId = event.ability.guid;
-    const cooldownSpell = this.constructor.castCooldowns.find(cooldownSpell => cooldownSpell.spell.id === spellId);
-    if (cooldownSpell) {
-      // adding the fixed cooldown, now we need to remove it from activeCooldowns too
-      const cooldown = this._addFixedCooldown(cooldownSpell, event.timestamp);
-      this.activeCooldowns.push(cooldown);
-      debug && console.log(`%cCooldown started: ${cooldownSpell.spell.name}`, 'color: green', cooldown);
-    }
-    // super.on_byPlayer_cast(event) would call trackEvent anyway
-    super.on_byPlayer_cast && super.on_byPlayer_cast(event);
-  }
-
-  _addFixedCooldown(cooldownSpell, timestamp) {
-    const cooldown = {
-      ...cooldownSpell,
-      start: timestamp,
-      end: timestamp + cooldownSpell.duration * 1000,
-      events: [],
-    };
-    this.pastCooldowns.push(cooldown);
-    return cooldown;
-  }
-
-  // on_event() might be more accurate but it would be most likely called much more
-  trackEvent(event) {
-    this.activeCooldowns = this.activeCooldowns.filter(cooldown => !cooldown.end || event.timestamp < cooldown.end);
-    super.trackEvent(event);
-  }
-
-  on_byPlayerPet_damage(event) {
-    this.trackEvent(event);
-  }
+  static trackPlayerPetDamage = true;
 }
 
 export default CooldownThroughputTracker;

--- a/src/parser/mage/fire/modules/features/CooldownThroughputTracker.js
+++ b/src/parser/mage/fire/modules/features/CooldownThroughputTracker.js
@@ -1,8 +1,5 @@
-import CoreCooldownThroughputTracker, { BUILT_IN_SUMMARY_TYPES } from 'parser/shared/modules/CooldownThroughputTracker';
-
 import SPELLS from 'common/SPELLS';
-
-const debug = false;
+import CoreCooldownThroughputTracker, { BUILT_IN_SUMMARY_TYPES } from 'parser/shared/modules/CooldownThroughputTracker';
 
 class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
   static cooldownSpells = [
@@ -22,6 +19,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
   ];
 
   static castCooldowns = [
+    ...CoreCooldownThroughputTracker.castCooldowns,
     {
       spell: SPELLS.MIRROR_IMAGE_TALENT,
       duration: 40,
@@ -31,39 +29,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     },
   ];
 
-  on_byPlayer_cast(event) {
-    const spellId = event.ability.guid;
-    const cooldownSpell = this.constructor.castCooldowns.find(cooldownSpell => cooldownSpell.spell.id === spellId);
-    if (cooldownSpell) {
-      // adding the fixed cooldown, now we need to remove it from activeCooldowns too
-      const cooldown = this._addFixedCooldown(cooldownSpell, event.timestamp);
-      this.activeCooldowns.push(cooldown);
-      debug && console.log(`%cCooldown started: ${cooldownSpell.spell.name}`, 'color: green', cooldown);
-    }
-    // super.on_byPlayer_cast(event) would call trackEvent anyway
-    super.on_byPlayer_cast && super.on_byPlayer_cast(event);
-  }
-
-  _addFixedCooldown(cooldownSpell, timestamp) {
-    const cooldown = {
-      ...cooldownSpell,
-      start: timestamp,
-      end: timestamp + cooldownSpell.duration * 1000,
-      events: [],
-    };
-    this.pastCooldowns.push(cooldown);
-    return cooldown;
-  }
-
-  // on_event() might be more accurate but it would be most likely called much more
-  trackEvent(event) {
-    this.activeCooldowns = this.activeCooldowns.filter(cooldown => !cooldown.end || event.timestamp < cooldown.end);
-    super.trackEvent(event);
-  }
-
-  on_byPlayerPet_damage(event) {
-    this.trackEvent(event);
-  }
+  static trackPlayerPetDamage = true;
 }
 
 export default CooldownThroughputTracker;

--- a/src/parser/mage/frost/modules/features/CooldownThroughputTracker.js
+++ b/src/parser/mage/frost/modules/features/CooldownThroughputTracker.js
@@ -1,8 +1,6 @@
 import SPELLS from 'common/SPELLS';
 import CoreCooldownThroughputTracker, { BUILT_IN_SUMMARY_TYPES } from 'parser/shared/modules/CooldownThroughputTracker';
 
-const debug = false;
-
 class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
   static cooldownSpells = [
     ...CoreCooldownThroughputTracker.cooldownSpells,
@@ -22,7 +20,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
   ];
 
   static castCooldowns = [
-
+    ...CoreCooldownThroughputTracker.castCooldowns,
     {
       spell: SPELLS.MIRROR_IMAGE_TALENT,
       duration: 40,
@@ -32,39 +30,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     },
   ];
 
-  on_byPlayer_cast(event) {
-    const spellId = event.ability.guid;
-    const cooldownSpell = this.constructor.castCooldowns.find(cooldownSpell => cooldownSpell.spell.id === spellId);
-    if (cooldownSpell) {
-      // adding the fixed cooldown, now we need to remove it from activeCooldowns too
-      const cooldown = this._addFixedCooldown(cooldownSpell, event.timestamp);
-      this.activeCooldowns.push(cooldown);
-      debug && console.log(`%cCooldown started: ${cooldownSpell.spell.name}`, 'color: green', cooldown);
-    }
-    // super.on_byPlayer_cast(event) would call trackEvent anyway
-    super.on_byPlayer_cast && super.on_byPlayer_cast(event);
-  }
-
-  _addFixedCooldown(cooldownSpell, timestamp) {
-    const cooldown = {
-      ...cooldownSpell,
-      start: timestamp,
-      end: timestamp + cooldownSpell.duration * 1000,
-      events: [],
-    };
-    this.pastCooldowns.push(cooldown);
-    return cooldown;
-  }
-
-  // on_event() might be more accurate but it would be most likely called much more
-  trackEvent(event) {
-    this.activeCooldowns = this.activeCooldowns.filter(cooldown => !cooldown.end || event.timestamp < cooldown.end);
-    super.trackEvent(event);
-  }
-
-  on_byPlayerPet_damage(event) {
-    this.trackEvent(event);
-  }
+  static trackPlayerPetDamage = true;
 }
 
 export default CooldownThroughputTracker;

--- a/src/parser/monk/windwalker/modules/features/CooldownThroughputTracker.js
+++ b/src/parser/monk/windwalker/modules/features/CooldownThroughputTracker.js
@@ -2,8 +2,6 @@ import SPELLS from 'common/SPELLS';
 
 import CoreCooldownThroughputTracker, { BUILT_IN_SUMMARY_TYPES } from 'parser/shared/modules/CooldownThroughputTracker';
 
-const debug = false;
-
 class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
   static cooldownSpells = [
     ...CoreCooldownThroughputTracker.cooldownSpells,
@@ -16,6 +14,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
   ];
 
   static castCooldowns = [
+    ...CoreCooldownThroughputTracker.castCooldowns,
     {
       spell: SPELLS.TOUCH_OF_DEATH,
       duration: 8,
@@ -31,39 +30,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     },
   ];
 
-  on_byPlayer_cast(event) {
-    const spellId = event.ability.guid;
-    const cooldownSpell = this.constructor.castCooldowns.find(cooldownSpell => cooldownSpell.spell.id === spellId);
-    if (cooldownSpell) {
-      // adding the fixed cooldown, now we need to remove it from activeCooldowns too
-      const cooldown = this._addFixedCooldown(cooldownSpell, event.timestamp);
-      this.activeCooldowns.push(cooldown);
-      debug && console.log(`%cCooldown started: ${cooldownSpell.spell.name}`, 'color: green', cooldown);
-    }
-    // super.on_byPlayer_cast(event) would call trackEvent anyway
-    super.on_byPlayer_cast && super.on_byPlayer_cast(event);
-  }
-
-  _addFixedCooldown(cooldownSpell, timestamp) {
-    const cooldown = {
-      ...cooldownSpell,
-      start: timestamp,
-      end: timestamp + cooldownSpell.duration * 1000,
-      events: [],
-    };
-    this.pastCooldowns.push(cooldown);
-    return cooldown;
-  }
-
-  // on_event() might be more accurate but it would be most likely called much more
-  trackEvent(event) {
-    this.activeCooldowns = this.activeCooldowns.filter(cooldown => !cooldown.end || event.timestamp < cooldown.end);
-    super.trackEvent(event);
-  }
-
-  on_byPlayerPet_damage(event) {
-    this.trackEvent(event);
-  }
+  static trackPlayerPetDamage = true;
 }
 
 export default CooldownThroughputTracker;

--- a/src/parser/shaman/enhancement/modules/features/CooldownThroughputTracker.js
+++ b/src/parser/shaman/enhancement/modules/features/CooldownThroughputTracker.js
@@ -18,13 +18,11 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     },
   ];
 
-  trackEvent(event) {
-    this.activeCooldowns.forEach((cooldown) => {
-      if (event.ability.guid !== SPELLS.DOOM_VORTEX.id) {
-        cooldown.events.push(event);
-      }
-    });
-  }
+  static ignoredSpells = [
+    ...CoreCooldownThroughputTracker.ignoredSpells,
+
+    SPELLS.DOOM_VORTEX.id, // Should we even support legon spells anymore?
+  ];
 }
 
 export default CooldownThroughputTracker;

--- a/src/parser/warlock/affliction/modules/features/CooldownThroughputTracker.js
+++ b/src/parser/warlock/affliction/modules/features/CooldownThroughputTracker.js
@@ -2,8 +2,6 @@ import CoreCooldownThroughputTracker, { BUILT_IN_SUMMARY_TYPES } from 'parser/sh
 
 import SPELLS from 'common/SPELLS';
 
-const debug = false;
-
 class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
   static cooldownSpells = [
     ...CoreCooldownThroughputTracker.cooldownSpells,
@@ -16,6 +14,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
   ];
 
   static castCooldowns = [
+    ...CoreCooldownThroughputTracker.castCooldowns,
     {
       spell: SPELLS.SUMMON_DARKGLARE,
       duration: 20,
@@ -25,39 +24,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     },
   ];
 
-  on_byPlayer_cast(event) {
-    const spellId = event.ability.guid;
-    const cooldownSpell = this.constructor.castCooldowns.find(cooldownSpell => cooldownSpell.spell.id === spellId);
-    if (cooldownSpell) {
-      // adding the fixed cooldown, now we need to remove it from activeCooldowns too
-      const cooldown = this._addFixedCooldown(cooldownSpell, event.timestamp);
-      this.activeCooldowns.push(cooldown);
-      debug && console.log(`%cCooldown started: ${cooldownSpell.spell.name}`, 'color: green', cooldown);
-    }
-    // super.on_byPlayer_cast(event) would call trackEvent anyway
-    super.on_byPlayer_cast && super.on_byPlayer_cast(event);
-  }
-
-  _addFixedCooldown(cooldownSpell, timestamp) {
-    const cooldown = {
-      ...cooldownSpell,
-      start: timestamp,
-      end: timestamp + cooldownSpell.duration * 1000,
-      events: [],
-    };
-    this.pastCooldowns.push(cooldown);
-    return cooldown;
-  }
-
-  // on_event() might be more accurate but it would be most likely called much more
-  trackEvent(event) {
-    this.activeCooldowns = this.activeCooldowns.filter(cooldown => !cooldown.end || event.timestamp < cooldown.end);
-    super.trackEvent(event);
-  }
-
-  on_byPlayerPet_damage(event) {
-    this.trackEvent(event);
-  }
+  static trackPlayerPetDamage = true;
 }
 
 export default CooldownThroughputTracker;

--- a/src/parser/warlock/demonology/modules/features/CooldownThroughputTracker.js
+++ b/src/parser/warlock/demonology/modules/features/CooldownThroughputTracker.js
@@ -2,11 +2,9 @@ import CoreCooldownThroughputTracker, { BUILT_IN_SUMMARY_TYPES } from 'parser/sh
 
 import SPELLS from 'common/SPELLS';
 
-const debug = false;
-
 class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
-  // nether portal, grimoire, demonic tyrant,
   static castCooldowns = [
+    ...CoreCooldownThroughputTracker.castCooldowns,
     {
       spell: SPELLS.NETHER_PORTAL_TALENT,
       duration: 20,
@@ -30,43 +28,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     },
   ];
 
-  on_byPlayer_cast(event) {
-    const spellId = event.ability.guid;
-    const cooldownSpell = this.constructor.castCooldowns.find(cooldownSpell => cooldownSpell.spell.id === spellId);
-    if (cooldownSpell) {
-      // adding the fixed cooldown, now we need to remove it from activeCooldowns too
-      const cooldown = this.addFixedCooldown(cooldownSpell, event.timestamp);
-      this.activeCooldowns.push(cooldown);
-      debug && console.log(`%cCooldown started: ${cooldownSpell.spell.name}`, 'color: green', cooldown);
-    }
-    // super.on_byPlayer_cast(event) would call trackEvent anyway
-    this.trackEvent(event);
-  }
-
-  addFixedCooldown(cooldownSpell, timestamp) {
-    const cooldown = {
-      ...cooldownSpell,
-      start: timestamp,
-      end: timestamp + cooldownSpell.duration * 1000,
-      events: [],
-    };
-    this.pastCooldowns.push(cooldown);
-    return cooldown;
-  }
-
-  // on_event() might be more accurate but it would be most likely called much more
-  trackEvent(event) {
-    const finishedCooldowns = this.activeCooldowns.filter(cooldown => cooldown.end && cooldown.end < event.timestamp).map((_, index) => index);
-    finishedCooldowns.forEach((index) => {
-      debug && console.log(`%cCooldown ended: ${this.activeCooldowns[index].spell.name}`, 'color: red', this.activeCooldowns[index]);
-      this.activeCooldowns.splice(index, 1);
-    });
-    super.trackEvent(event);
-  }
-
-  on_byPlayerPet_damage(event) {
-    this.trackEvent(event);
-  }
+  static trackPlayerPetDamage = true;
 }
 
 export default CooldownThroughputTracker;

--- a/src/parser/warlock/destruction/modules/features/CooldownThroughputTracker.js
+++ b/src/parser/warlock/destruction/modules/features/CooldownThroughputTracker.js
@@ -1,8 +1,5 @@
-import CoreCooldownThroughputTracker, { BUILT_IN_SUMMARY_TYPES } from 'parser/shared/modules/CooldownThroughputTracker';
-
 import SPELLS from 'common/SPELLS';
-
-const debug = false;
+import CoreCooldownThroughputTracker, { BUILT_IN_SUMMARY_TYPES } from 'parser/shared/modules/CooldownThroughputTracker';
 
 class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
   static cooldownSpells = [
@@ -16,6 +13,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
   ];
 
   static castCooldowns = [
+    ...CoreCooldownThroughputTracker.castCooldowns,
     {
       spell: SPELLS.HAVOC,
       duration: 10,
@@ -32,39 +30,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     },
   ];
 
-  on_byPlayer_cast(event) {
-    const spellId = event.ability.guid;
-    const cooldownSpell = this.constructor.castCooldowns.find(cooldownSpell => cooldownSpell.spell.id === spellId);
-    if (cooldownSpell) {
-      // adding the fixed cooldown, now we need to remove it from activeCooldowns too
-      const cooldown = this._addFixedCooldown(cooldownSpell, event.timestamp);
-      this.activeCooldowns.push(cooldown);
-      debug && console.log(`%cCooldown started: ${cooldownSpell.spell.name}`, 'color: green', cooldown);
-    }
-    // super.on_byPlayer_cast(event) would call trackEvent anyway
-    super.on_byPlayer_cast && super.on_byPlayer_cast(event);
-  }
-
-  _addFixedCooldown(cooldownSpell, timestamp) {
-    const cooldown = {
-      ...cooldownSpell,
-      start: timestamp,
-      end: timestamp + cooldownSpell.duration * 1000,
-      events: [],
-    };
-    this.pastCooldowns.push(cooldown);
-    return cooldown;
-  }
-
-  // on_event() might be more accurate but it would be most likely called much more
-  trackEvent(event) {
-    this.activeCooldowns = this.activeCooldowns.filter(cooldown => !cooldown.end || event.timestamp < cooldown.end);
-    super.trackEvent(event);
-  }
-
-  on_byPlayerPet_damage(event) {
-    this.trackEvent(event);
-  }
+  static trackPlayerPetDamage = true;
 }
 
 export default CooldownThroughputTracker;

--- a/src/parser/warrior/arms/modules/features/CooldownThroughputTracker.js
+++ b/src/parser/warrior/arms/modules/features/CooldownThroughputTracker.js
@@ -25,6 +25,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
   ];
 
   static castCooldowns = [
+    ...CoreCooldownThroughputTracker.castCooldowns,
     {
       spell: SPELLS.WARBREAKER_TALENT,
       duration: 10,
@@ -40,32 +41,6 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
       ],
     },
   ];
-
-  on_byPlayer_cast(event) {
-    const spellId = event.ability.guid;
-    const cooldownSpell = this.constructor.castCooldowns.find(cooldownSpell => cooldownSpell.spell.id === spellId);
-    if (cooldownSpell) {
-      const cooldown = this._addFixedCooldown(cooldownSpell, event.timestamp);
-      this.activeCooldowns.push(cooldown);
-    }
-    super.on_byPlayer_cast && super.on_byPlayer_cast(event);
-  }
-
-  _addFixedCooldown(cooldownSpell, timestamp) {
-    const cooldown = {
-      ...cooldownSpell,
-      start: timestamp,
-      end: timestamp + cooldownSpell.duration * 1000,
-      events: [],
-    };
-    this.pastCooldowns.push(cooldown);
-    return cooldown;
-  }
-
-  trackEvent(event) {
-    this.activeCooldowns = this.activeCooldowns.filter(cooldown => !cooldown.end || event.timestamp < cooldown.end);
-    super.trackEvent(event);
-  }
 }
 
 export default CooldownThroughputTracker;


### PR DESCRIPTION
I read issue #733 and decided to walk through the CooldownThroughputTrackers. 
There was still some duplicated code for classes that handeled pet damage and had cast cooldowns that could not be tracked by buffs/debuffs.

In this PR that code has been merged into the Core CooldownThroughputTrackers.
