### PR TITLE
Updated patch list

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -9,6 +9,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/ContributorButton';
 
 export default [
+  change(date(2020, 5, 18), 'Updated patchlist', Vetyst),
   change(date(2020, 5, 14), 'Replaced hardcoded event type strings with EventType equivalent', Vetyst),
   change(date(2020, 5, 13), 'Disallow use of ++ and -- to adhere to the style guide', Putro),
   change(date(2020, 5, 12), 'Tweak JetBrains codeStyles file to better adhere to code style, while allowing for auto-formatting all files in the repository.', Vetyst),

--- a/src/common/PATCHES.js
+++ b/src/common/PATCHES.js
@@ -16,6 +16,30 @@ const PATCHES = [
     name: '8.1',
     timestamp: 1544565600000, // GMT: Tuesday, 11 December 2018 22:00:00, PST: Tuesday, 11 December 2018 14:00:00
     urlPrefix: '',
+    isCurrent: false,
+  },
+  {
+    name: '8.1.5',
+    timestamp: 1552428000000, // GMT: Tuesday, 12 March 2019 22:00:00
+    urlPrefix: '',
+    isCurrent: false,
+  },
+  {
+    name: '8.2',
+    timestamp: 1561500000000, // GMT: Tuesday, 25 June 2019 22:00:00
+    urlPrefix: '',
+    isCurrent: false,
+  },
+  {
+    name: '8.2.5',
+    timestamp: 1569362400000, // GMT: Tuesday, 24 September 2019 22:00:00
+    urlPrefix: '',
+    isCurrent: false,
+  },
+  {
+    name: '8.3',
+    timestamp: 1579039200000, // GMT: Tuesday, 14 January 2020 22:00:00
+    urlPrefix: '',
     isCurrent: true,
   },
 ];


### PR DESCRIPTION
The patches were behind, preventing warnings from appearing when viewing classes in which wowanalyzer is not up-to-date for.

In my opinion, this should trigger both maintainers and people from the community that use wowanalyzer to update the modules for the respective class/spec.