### PR TITLE
Fixed garrote early refresh tracking.

### DIFF
--- a/src/parser/rogue/assassination/CHANGELOG.js
+++ b/src/parser/rogue/assassination/CHANGELOG.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { tsabo, Cloake, Zerotorescue, Gebuz, Aelexe } from 'CONTRIBUTORS';
+import { tsabo, Cloake, Zerotorescue, Gebuz, Aelexe, Vetyst } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 5, 26), <>Fixed garrote early refresh tracking.</>, [Vetyst]),
   change(date(2019, 4, 22), <>Early dot refresh tracking</>, [tsabo]),
   change(date(2018, 11, 20), <>Added Bleed snapshot tracking and support for <SpellLink id={SPELLS.NIGHTSTALKER_TALENT.id} />, <SpellLink id={SPELLS.SUBTERFUGE_TALENT.id} /> and <SpellLink id={SPELLS.MASTER_ASSASSIN_TALENT.id} />.</>, [Gebuz]),
   change(date(2018, 11, 15), <>Fixed <SpellLink id={SPELLS.ARCANE_TORRENT_ENERGY.id} /> GCD.</>, [Aelexe]),

--- a/src/parser/rogue/assassination/normalizers/GarroteNormalizer.js
+++ b/src/parser/rogue/assassination/normalizers/GarroteNormalizer.js
@@ -27,7 +27,7 @@ class GarroteNormalizer extends EventsNormalizer {
           }
           if (previousEvent.type === EventType.RemoveDebuff &&
               previousEvent.ability.guid === SPELLS.GARROTE.id) {
-            event.type = EventType.RefreshBuff;
+            event.type = EventType.RefreshDebuff;
             event.__modified = true;
             fixedEvents.splice(previousEventIndex, 1);
             eventsRemoved += 1;


### PR DESCRIPTION
Seems the convertion in #3580 was wrong for the GarroteNormalizer. I'll take the time to look through all the changes tomorrow afternoon (EU) in that PR again to make sure no other modules suffer from this.