### PR TITLE
Add a workflow that deletes old artifacts using a CRON script

### DIFF
--- a/.github/workflows/deleteOldArtifacts.yml
+++ b/.github/workflows/deleteOldArtifacts.yml
@@ -1,0 +1,14 @@
+name: 'Delete old artifacts'
+
+on:
+  schedule:
+    - cron: '*/5 * * * *' # every 5 minutes - Should be set to something like 0 0 */14 * * for every 14 days, or maybe every 7 days?
+
+jobs:
+  delete-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kolpav/purge-artifacts-action@v1
+        with:
+          token: ${{ secrets.TOKEN_GITHUB }}
+          expire-in: 0 # Setting this to 0 will delete all artifacts - https://github.com/jkroso/parse-duration for information on usage

--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -9,6 +9,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/ContributorButton';
 
 export default [
+  change(date(2020,5,29), 'Added a cron job to delete old artifacts', Putro),
   change(date(2020, 5, 27), <>Fixed a bug where <ItemLink id={ITEMS.VOID_TWISTED_TITANSHARD.id} /> showed as having done 0 healing </>, Putro),
   change(date(2020, 5, 25), 'Replaced hard-coded statistic categories with STATISTIC_CATEGORY.', Vetyst),
   change(date(2020, 5, 18), 'Replaced duplicate FIGHT_DIFFICULTIES with DIFFICULTIES', Vetyst),


### PR DESCRIPTION
This cron job should purge all existing artifacts we have lying around. 
After it has run, it should be adjusted to run much more rarely so we don't run cron jobs all the time. 

I hope this fixes the issue plagueing hunter now, as everything works locally for them, but not on production so I have no way of verifying if this is actually what is causing the issue or not. 

Here it is completing its run on my local branch: https://github.com/Pewtro/WoWAnalyzer/actions/runs/119061952