### PR TITLE
Removed duplicate entry of Guardian Spirit in defensive buffs.

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -9,6 +9,7 @@ import { change, date } from 'common/changelog';
 import Contributor from 'interface/ContributorButton';
 
 export default [
+  change(date(2020, 6, 3), <>Removed duplicate entry of <SpellLink id={SPELLS.GUARDIAN_SPIRIT.id} /> in defensive buffs.</>, Vetyst),
   change(date(2020, 5, 29), 'Add a warning when the log exceeds our supported duration.', Vetyst),
   change(date(2020, 5, 27), <>Fixed a bug where <ItemLink id={ITEMS.VOID_TWISTED_TITANSHARD.id} /> showed as having done 0 healing </>, Putro),
   change(date(2020, 5, 25), 'Replaced hard-coded statistic categories with STATISTIC_CATEGORY.', Vetyst),

--- a/src/common/DEFENSIVE_BUFFS.js
+++ b/src/common/DEFENSIVE_BUFFS.js
@@ -19,9 +19,6 @@ const DEFENSIVE_BUFFS = [
     spell: SPELLS.GUARDIAN_SPIRIT,
   },
   {
-    spell: SPELLS.GUARDIAN_SPIRIT,
-  },
-  {
     spell: SPELLS.PAIN_SUPPRESSION,
   },
   {


### PR DESCRIPTION
This caused a massive amount of errors (local development) to be generated when viewing death recaps (where guardian spirit was active on the player that died).
Aditionally, Guardian Spirit was shown as twice on the character that died eventhough that is not the case.

Before PR:
![before-pr](https://user-images.githubusercontent.com/3527340/83632065-e3979780-a59e-11ea-8d9f-19655a8dabae.jpg)
![before-pr](https://user-images.githubusercontent.com/3527340/83632313-5739a480-a59f-11ea-8117-f425f4651cef.jpg)

After PR:
![after-pr](https://user-images.githubusercontent.com/3527340/83632072-e6928800-a59e-11ea-83ca-30259f4f00b7.jpg)
![after-pr](https://user-images.githubusercontent.com/3527340/83632311-5739a480-a59f-11ea-81e3-586e73068234.jpg)

[See Report](https://wowanalyzer.com/report/dfcJYaAg8Z7Q6KvW/8-Mythic+Maut+-+Kill+(5:26)/Part%C3%ADcle/standard/death-recap)