### PR TITLE
[Hunter] Extend DeathTracker to ignore Feign Death casts as deaths

### DIFF
--- a/src/parser/hunter/beastmastery/CHANGELOG.tsx
+++ b/src/parser/hunter/beastmastery/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SPELLS from 'common/SPELLS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 6, 4), <> Updated the death tracking module to not say that you died, when you used <SpellLink id={SPELLS.FEIGN_DEATH.id} />.</>, Putro),
   change(date(2020, 5,26), 'Converted all hunter modules to Typescript and cleaned up the entire hunter codebase in preparation for Shadowlands.', Putro),
   change(date(2020, 5, 24), <> Fixed an issue where <SpellLink id={SPELLS.DANCE_OF_DEATH.id} /> agility buff was being overvalued. </>, Putro),
   change(date(2020, 5, 13), <> Fixed part of <SpellLink id={SPELLS.ANIMAL_COMPANION_TALENT.id} /> module to properly show damage without it talented.</>, Putro),

--- a/src/parser/hunter/beastmastery/CombatLogParser.tsx
+++ b/src/parser/hunter/beastmastery/CombatLogParser.tsx
@@ -8,6 +8,8 @@ import Buffs from './modules/Buffs';
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import FocusUsage from '../shared/modules/resources/FocusUsage';
+//Death Tracker
+import DeathTracker from '../shared/modules/core/DeathTracker';
 //Talents
 import KillerInstinct from './modules/talents/KillerInstinct';
 import NaturalMending from '../shared/modules/talents/NaturalMending';
@@ -67,6 +69,9 @@ class CombatLogParser extends CoreCombatLogParser {
     spellFocusCost: SpellFocusCost,
     beastMasteryFocusCapTracker: BeastMasteryFocusCapTracker,
     focus: Focus,
+
+    //DeathTracker
+    deathTracker: DeathTracker,
 
     //Spells
     bestialWrath: BestialWrath,

--- a/src/parser/hunter/beastmastery/modules/spells/BarbedShot.tsx
+++ b/src/parser/hunter/beastmastery/modules/spells/BarbedShot.tsx
@@ -44,9 +44,12 @@ class BarbedShot extends Analyzer {
   }
 
   get percentUptimePet() {
-    //this removes the time spent without the pet having the frenzy buff
-    const petUptime = this.barbedShotStacks.slice(1).flat().reduce((totalUptime: number, stackUptime: number) => totalUptime + stackUptime, 0);
-    return petUptime / this.owner.fightDuration;
+    //This removes the time spent without the pet having the frenzy buff
+    const withoutNoBuff = this.barbedShotStacks.slice(1);
+    //Because .flat doesn't work in Microsoft Edge (non-chromium versions), we use this alternate option that is equivalent
+    const alternativeFlatten = withoutNoBuff.reduce((acc, val) => acc.concat(val), []);
+    //After flattening the array, we can reduce it normally. 
+    return alternativeFlatten.reduce((totalUptime: number, stackUptime: number) => totalUptime + stackUptime, 0) / this.owner.fightDuration;
   }
 
   get percentPlayerUptime() {
@@ -144,17 +147,17 @@ class BarbedShot extends Analyzer {
 
   suggestions(when: any) {
     when(this.frenzyUptimeThreshold).addSuggestion((suggest: any, actual: any, recommended: any) => {
-        return suggest(<>Your pet has a general low uptime of the buff from <SpellLink id={SPELLS.BARBED_SHOT.id} />, you should never be sitting on 2 stacks of this spell, if you've chosen this talent, it's your most important spell to continously be casting. </>)
-          .icon(SPELLS.BARBED_SHOT.icon)
-          .actual(`Your pet had the buff from Barbed Shot for ${formatPercentage(actual)}% of the fight`)
-          .recommended(`${formatPercentage(recommended)}% is recommended`);
-      });
+      return suggest(<>Your pet has a general low uptime of the buff from <SpellLink id={SPELLS.BARBED_SHOT.id} />, you should never be sitting on 2 stacks of this spell, if you've chosen this talent, it's your most important spell to continously be casting. </>)
+        .icon(SPELLS.BARBED_SHOT.icon)
+        .actual(`Your pet had the buff from Barbed Shot for ${formatPercentage(actual)}% of the fight`)
+        .recommended(`${formatPercentage(recommended)}% is recommended`);
+    });
     when(this.frenzy3StackThreshold).addSuggestion((suggest: any, actual: any, recommended: any) => {
-        return suggest(<>Your pet has a general low uptime of the 3 stacked buff from <SpellLink id={SPELLS.BARBED_SHOT.id} />. It's important to try and maintain the buff at 3 stacks for as long as possible, this is done by spacing out your casts, but at the same time never letting them cap on charges. </>)
-          .icon(SPELLS.BARBED_SHOT.icon)
-          .actual(`Your pet had 3 stacks of the buff from Barbed Shot for ${formatPercentage(actual)}% of the fight`)
-          .recommended(`${formatPercentage(recommended)}% is recommended`);
-      });
+      return suggest(<>Your pet has a general low uptime of the 3 stacked buff from <SpellLink id={SPELLS.BARBED_SHOT.id} />. It's important to try and maintain the buff at 3 stacks for as long as possible, this is done by spacing out your casts, but at the same time never letting them cap on charges. </>)
+        .icon(SPELLS.BARBED_SHOT.icon)
+        .actual(`Your pet had 3 stacks of the buff from Barbed Shot for ${formatPercentage(actual)}% of the fight`)
+        .recommended(`${formatPercentage(recommended)}% is recommended`);
+    });
   }
 
   statistic() {

--- a/src/parser/hunter/marksmanship/CHANGELOG.tsx
+++ b/src/parser/hunter/marksmanship/CHANGELOG.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
-import { Putro, LeoZhekov } from 'CONTRIBUTORS';
+import { LeoZhekov, Putro } from 'CONTRIBUTORS';
 import SpellLink from 'common/SpellLink';
 import SPELLS from 'common/SPELLS';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2020, 5,26), 'Converted all hunter modules to Typescript and cleaned up the entire hunter codebase in preparation for Shadowlands.', Putro),
+  change(date(2020, 6, 4), <> Updated the death tracking module to not say that you died, when you used <SpellLink id={SPELLS.FEIGN_DEATH.id} />.</>, Putro),
+  change(date(2020, 5, 26), 'Converted all hunter modules to Typescript and cleaned up the entire hunter codebase in preparation for Shadowlands.', Putro),
   change(date(2020, 2, 21), 'Correct an issue that caused the analyzer to think you had wasted more natural focus regen than you actually had.', Putro),
   change(date(2020, 2, 15), <> Updated condition of determining an inefficient <SpellLink id={SPELLS.AIMED_SHOT.id} /> while under the effect of <SpellLink id={SPELLS.TRUESHOT.id} /></>, LeoZhekov),
   change(date(2020, 1, 31), <> Update the CancelledCast module to a new look, so that it is consistent with the rest of the codebase. </>, Putro),

--- a/src/parser/hunter/marksmanship/CombatLogParser.tsx
+++ b/src/parser/hunter/marksmanship/CombatLogParser.tsx
@@ -12,6 +12,9 @@ import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import CancelledCasts from '../shared/modules/features/CancelledCasts';
 import FocusUsage from '../shared/modules/resources/FocusUsage';
 
+//Death Tracker
+import DeathTracker from '../shared/modules/core/DeathTracker';
+
 //Focus
 import FocusTracker from '../shared/modules/resources/FocusTracker';
 import FocusDetails from '../shared/modules/resources/FocusDetails';
@@ -72,6 +75,9 @@ class CombatLogParser extends CoreCombatLogParser {
     spellFocusCost: SpellFocusCost,
     focusCapTracker: FocusCapTracker,
     focus: Focus,
+
+    //DeathTracker
+    deathTracker: DeathTracker,
 
     //Spells
     trueshot: Trueshot,

--- a/src/parser/hunter/shared/modules/core/DeathTracker.tsx
+++ b/src/parser/hunter/shared/modules/core/DeathTracker.tsx
@@ -1,0 +1,31 @@
+import CoreDeathTracker from 'parser/shared/modules/DeathTracker';
+
+
+/**
+ * Due to combatlog restrictions it is not possible to know whether the hunter cast Feign Death or the hunter actually died.
+ * For this module we assume any single death lasting less than 0.2% of an encounter (1.2 seconds on a 10 minute fight) was due to Feign Death, and thus we remove it as it is improbable anyone is that fast to ress anyone.
+ */
+const TIME_SPENT_DEAD_THRESHOLD = 0.002; //0.2%
+class DeathTracker extends CoreDeathTracker {
+  static dependencies = {
+    ...CoreDeathTracker.dependencies,
+  };
+
+  deathPercentageOfEncounter(deathTimestamp: number, ressTimestamp: number) {
+    return (ressTimestamp - deathTimestamp) / this.owner.fightDuration;
+  }
+
+  resurrect(event: any) {
+    this.lastResurrectionTimestamp = this.owner.currentTimestamp;
+    const percentSpentDead = this.deathPercentageOfEncounter(this.lastDeathTimestamp, this.lastResurrectionTimestamp);
+    if (percentSpentDead > TIME_SPENT_DEAD_THRESHOLD) {
+      super.resurrect(event);
+    } else {
+      this.isAlive = true;
+      this.deaths.pop();
+    }
+  }
+}
+
+
+export default DeathTracker;

--- a/src/parser/hunter/survival/CHANGELOG.tsx
+++ b/src/parser/hunter/survival/CHANGELOG.tsx
@@ -6,7 +6,9 @@ import SPELLS from 'common/SPELLS';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2020, 5,26), 'Converted all hunter modules to Typescript and cleaned up the entire hunter codebase in preparation for Shadowlands', Putro),
+  change(date(2020, 6, 4), <> Updated the death tracking module to not say that you died, when you used <SpellLink id={SPELLS.FEIGN_DEATH.id} />.</>, Putro),
+  change(date(2020, 6, 3), <> Updated <SpellLink id={SPELLS.SERPENT_STING_SV.id} /> and <SpellLink id={SPELLS.VIPERS_VENOM_TALENT.id} /> to only allow refreshes in pandemic window regardless, and to require <SpellLink id={SPELLS.VIPERS_VENOM_BUFF.id} /> buff to be active for it to be worth casting in <SpellLink id={SPELLS.COORDINATED_ASSAULT.id} /> if you are talented into <SpellLink id={SPELLS.BIRDS_OF_PREY_TALENT.id} />. </>, Putro),
+  change(date(2020, 5, 26), 'Converted all hunter modules to Typescript and cleaned up the entire hunter codebase in preparation for Shadowlands', Putro),
   change(date(2020, 2, 15), <> Added a <SpellLink id={SPELLS.WILDFIRE_CLUSTER.id} /> module </>, Putro),
   change(date(2020, 1, 28), <> Completely reworked the Focus modules for Hunter. A new tab, chart and statistic has been added for Focus metrics. </>, Putro),
   change(date(2020, 1, 27), <> Updated the shared hunter talent modules for 8.3. </>, Putro),

--- a/src/parser/hunter/survival/CombatLogParser.tsx
+++ b/src/parser/hunter/survival/CombatLogParser.tsx
@@ -2,14 +2,14 @@ import CoreCombatLogParser from 'parser/core/CombatLogParser';
 import ArcaneTorrent from 'parser/shared/modules/racials/bloodelf/ArcaneTorrent';
 import Abilities from './modules/Abilities';
 import Checklist from './modules/checklist/Module';
-
 //Features
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import FocusUsage from '../shared/modules/resources/FocusUsage';
 //Normalizer
 import TipOfTheSpearNormalizer from './normalizers/TipOfTheSpear';
-
+//Death Tracker
+import DeathTracker from '../shared/modules/core/DeathTracker';
 //Spells
 import KillCommand from './modules/spells/KillCommand';
 import ButcheryCarve from './modules/spells/ButcheryCarve';
@@ -17,14 +17,12 @@ import SerpentSting from './modules/spells/SerpentSting';
 import CoordinatedAssault from './modules/spells/CoordinatedAssault';
 import WildfireBomb from './modules/spells/WildfireBomb';
 import RaptorStrike from './modules/spells/RaptorStrike';
-
 //Focus
 import FocusTracker from '../shared/modules/resources/FocusTracker';
 import FocusDetails from '../shared/modules/resources/FocusDetails';
 import SpellFocusCost from '../shared/modules/resources/SpellFocusCost';
 import SurvivalFocusCapTracker from './modules/core/SurvivalFocusCapTracker';
 import Focus from './modules/core/Focus';
-
 //Talents
 import Trailblazer from '../shared/modules/talents/Trailblazer';
 import NaturalMending from '../shared/modules/talents/NaturalMending';
@@ -73,6 +71,9 @@ class CombatLogParser extends CoreCombatLogParser {
 
     //Normalizers
     tipOfTheSpearNormalizer: TipOfTheSpearNormalizer,
+
+    //DeathTracker
+    deathTracker: DeathTracker,
 
     //Spells
     killCommand: KillCommand,

--- a/src/parser/hunter/survival/modules/talents/MongooseBite.tsx
+++ b/src/parser/hunter/survival/modules/talents/MongooseBite.tsx
@@ -80,7 +80,7 @@ class MongooseBite extends Analyzer {
   }
 
   get totalMongooseBites() {
-    return this.mongooseBiteStacks.flat().reduce((totalHits: number, stackHits: number) => totalHits + stackHits, 0);
+    return this.mongooseBiteStacks.reduce((totalHits: number, stackHits: number) => totalHits + stackHits, 0);
   }
 
   get fiveStackMongooseBites() {

--- a/src/parser/shared/modules/DeathTracker.tsx
+++ b/src/parser/shared/modules/DeathTracker.tsx
@@ -38,7 +38,6 @@ class DeathTracker extends Analyzer {
     this.die(event);
   }
   on_toPlayer_resurrect(event: any) {
-    console.log(event);
     this.resurrect(event);
   }
   on_byPlayer_cast(event: CastEvent) {

--- a/src/parser/shared/modules/DeathTracker.tsx
+++ b/src/parser/shared/modules/DeathTracker.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import {Link} from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { formatNumber, formatPercentage } from 'common/format';
 import Analyzer from 'parser/core/Analyzer';
 import makeAnalyzerUrl from 'interface/common/makeAnalyzerUrl';
+import { BeginCastEvent, CastEvent, DamageEvent, DeathEvent, HealEvent } from '../../core/Events';
 
 const WIPE_MAX_DEAD_TIME = 15 * 1000; // 15sec
 
@@ -10,53 +11,54 @@ const debug = false;
 
 // Log where someone died: https://wowanalyzer.com/report/RjH6AnYdP8GWzX4h/2-Heroic+Aggramar+-+Kill+(6:23)/Kantasai
 class DeathTracker extends Analyzer {
-  deaths = [];
-  resurrections = [];
+  deaths: DeathEvent[] = [];
+  resurrections: (CastEvent | BeginCastEvent | HealEvent | DamageEvent)[] = [];
 
-  lastDeathTimestamp = 0;
-  lastResurrectionTimestamp = 0;
-  _timeDead = 0;
-  _didCast = false;
-  isAlive = true;
+  lastDeathTimestamp: number = 0;
+  lastResurrectionTimestamp: number = 0;
+  _timeDead: number = 0
+  _didCast: boolean = false;
+  isAlive: boolean = true;
 
-  die(event) {
+  die(event: DeathEvent) {
     this.lastDeathTimestamp = this.owner.currentTimestamp;
-    debug && this.log("Player Died");
+    debug && this.log('Player Died');
     this.isAlive = false;
     this.deaths.push(event);
   }
-  resurrect(event) {
+  resurrect(event: CastEvent | BeginCastEvent | HealEvent | DamageEvent) {
     this.lastResurrectionTimestamp = this.owner.currentTimestamp;
     this._timeDead += this.lastResurrectionTimestamp - this.lastDeathTimestamp;
-    debug && this.log("Player was Resurrected");
+    debug && this.log('Player was Resurrected');
     this.isAlive = true;
     this.resurrections.push(event);
   }
 
-  on_toPlayer_death(event) {
+  on_toPlayer_death(event: DeathEvent) {
     this.die(event);
   }
-  on_toPlayer_resurrect(event) {
+  on_toPlayer_resurrect(event: any) {
+    console.log(event);
     this.resurrect(event);
   }
-  on_byPlayer_cast(event) {
+  on_byPlayer_cast(event: CastEvent) {
     this._didCast = true;
 
     if (!this.isAlive) {
       this.resurrect(event);
     }
   }
-  on_byPlayer_begincast(event) {
+  on_byPlayer_begincast(event: BeginCastEvent) {
     if (!this.isAlive) {
       this.resurrect(event);
     }
   }
-  on_toPlayer_heal(event) {
+  on_toPlayer_heal(event: HealEvent) {
     if (!this.isAlive) {
       this.resurrect(event);
     }
   }
-  on_toPlayer_damage(event) {
+  on_toPlayer_damage(event: DamageEvent) {
     if (!this.isAlive) {
       this.resurrect(event);
     }
@@ -79,7 +81,7 @@ class DeathTracker extends Analyzer {
     };
   }
 
-  suggestions(when) {
+  suggestions(when: any) {
     const boss = this.owner.boss;
     const fight = this.owner.fight;
     const player = this.owner.player;
@@ -90,7 +92,7 @@ class DeathTracker extends Analyzer {
 
     if (!disableDeathSuggestion && !isWipeDeath) {
       when(this.timeDeadPercent).isGreaterThan(0)
-        .addSuggestion((suggest, actual, recommended) => {
+        .addSuggestion((suggest: any, actual: any) => {
           return suggest(<>
             You died during this fight and were dead for {formatPercentage(actual)}% of the fight duration ({formatNumber(this.totalTimeDead / 1000)} seconds). Dying has a significant performance cost. View the <Link to={makeAnalyzerUrl(report, fight.id, player.id, 'death-recap')}>Death Recap</Link> to see the damage taken and what defensives and potions were still available.
           </>)
@@ -101,7 +103,7 @@ class DeathTracker extends Analyzer {
         });
     }
     when(this._didCast).isFalse()
-      .addSuggestion((suggest, actual, recommended) => {
+      .addSuggestion((suggest: any) => {
         return suggest('You did not cast a single spell this fight. You were either dead for the entire fight, or were AFK.')
           .icon('ability_fiegndead')
           .major(this.deathSuggestionThresholds.isGreaterThan.major);


### PR DESCRIPTION
Blocked by #3611 
Fixes #2670 

Due to combatlog restrictions, Feign Death is not shown as a cast event to other players (to make it more believable, otherwise it is cheesable with WA/AddOns easier than already). 
This change ignores extremely short deaths for hunters. 

Log: 
Before: 
![image](https://user-images.githubusercontent.com/29204244/83698126-f04cd780-a600-11ea-98fd-6d6e0c00ce93.png)
After:
No suggestion

Log: 
Before:
![image](https://user-images.githubusercontent.com/29204244/83698151-fd69c680-a600-11ea-815b-fe490715dcd1.png)

After:
![image](https://user-images.githubusercontent.com/29204244/83698166-078bc500-a601-11ea-8a30-5d0cecdc9cdf.png)
