### PR TITLE
[Frost Mage] Fix typos and incorrect SpellLink in Splitting Ice / Thermal Void modules

### DIFF
--- a/src/parser/mage/frost/CHANGELOG.tsx
+++ b/src/parser/mage/frost/CHANGELOG.tsx
@@ -6,7 +6,8 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2020, 6, 1), <>Fixed <SpellLink id={SPELLS.ICY_VEINS.id} /> pre-pull detection</>, [Dambroda]),
+  change(date(2020, 6, 3), <>Fixed <SpellLink id={SPELLS.THERMAL_VOID_TALENT.id} /> statistic icon and <SpellLink id={SPELLS.SPLITTING_ICE_TALENT.id} /> typo.</>, [Dambroda]),
+  change(date(2020, 6, 1), <>Fixed <SpellLink id={SPELLS.ICY_VEINS.id} /> pre-pull detection.</>, [Dambroda]),
   change(date(2020, 5, 25), <>Updated Integration Tests and Example Logs.</>,[Sharrq]),
   change(date(2020, 5, 25), <>Updated remaining files to Typescript.</>,[Sharrq]),
   change(date(2020, 5, 12), <>Updated modules to Typescript and Event Listeners.</>,[Sharrq]),

--- a/src/parser/mage/frost/integrationTests/example.test.ts.snap
+++ b/src/parser/mage/frost/integrationTests/example.test.ts.snap
@@ -4150,9 +4150,8 @@ exports[`Frost Mage integration test: example log SplittingIce matches the stati
           className="value"
         >
           ≈
-          $
           2.25
-           %
+          %
         </div>
       </div>
     </div>

--- a/src/parser/mage/frost/modules/features/SplittingIce.tsx
+++ b/src/parser/mage/frost/modules/features/SplittingIce.tsx
@@ -102,7 +102,7 @@ class SplittingIce extends Analyzer {
       >
         <BoringSpellValueText spell={SPELLS.SPLITTING_ICE_TALENT}>
           <>
-            {this.hasGlacialSpike ? '≈' : ''}${formatPercentage(this.damagePercent)} %
+            {this.hasGlacialSpike ? '≈' : ''}{formatPercentage(this.damagePercent)}%
           </>
         </BoringSpellValueText>
       </Statistic>

--- a/src/parser/mage/frost/modules/features/ThermalVoid.tsx
+++ b/src/parser/mage/frost/modules/features/ThermalVoid.tsx
@@ -72,7 +72,7 @@ class ThermalVoid extends Analyzer {
         </>
       )}
       >
-        <BoringSpellValueText spell={SPELLS.SPLITTING_ICE_TALENT}>
+        <BoringSpellValueText spell={SPELLS.THERMAL_VOID_TALENT}>
           <><SpellIcon id={SPELLS.ICY_VEINS.id} /> +{formatNumber(totalIncrease)} seconds</>
         </BoringSpellValueText>
       </Statistic>


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/43309639/83708971-6554e880-a5d2-11ea-9ea0-2a0294714465.png)


After:
![image](https://user-images.githubusercontent.com/43309639/83708985-6dad2380-a5d2-11ea-8240-7edbe33825e1.png)
