### PR TITLE
[Arcane Mage] Cooldown Pre Spells

### DIFF
--- a/src/parser/mage/arcane/CHANGELOG.tsx
+++ b/src/parser/mage/arcane/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 7, 7), <>Adjusted the Cooldowns page to show the 4 seconds before <SpellLink id={SPELLS.ARCANE_POWER.id} />.</>, [Sharrq]),
   change(date(2020, 6, 19), 'Updated integration tests', [Sharrq]),
   change(date(2020, 6, 19), 'Updated Arcane for TypeScript, Event Listeners, Statistic Boxes, and Constants', [Sharrq]),
   change(date(2020, 6, 1), <>Fixed <SpellLink id={SPELLS.ARCANE_POWER.id} /> pre-pull detection</>, [Dambroda]),

--- a/src/parser/mage/arcane/modules/features/CooldownThroughputTracker.js
+++ b/src/parser/mage/arcane/modules/features/CooldownThroughputTracker.js
@@ -8,6 +8,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     ...CoreCooldownThroughputTracker.cooldownSpells,
     {
       spell: SPELLS.ARCANE_POWER,
+      buffer: 4000,
       summary: [
         BUILT_IN_SUMMARY_TYPES.DAMAGE,
       ],
@@ -30,9 +31,20 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     },
   ];
 
+  previousCasts = [];
+
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
     const cooldownSpell = this.constructor.castCooldowns.find(cooldownSpell => cooldownSpell.spell.id === spellId);
+
+    //Keep 4 Seconds worth of events
+    this.previousCasts.forEach(cast => {
+      if (cast.timestamp < event.timestamp - 4000) {
+        this.previousCasts.shift();
+      }
+    });
+    this.previousCasts.push(event);
+
     if (cooldownSpell) {
       // adding the fixed cooldown, now we need to remove it from activeCooldowns too
       const cooldown = this._addFixedCooldown(cooldownSpell, event.timestamp);
@@ -41,6 +53,19 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     }
     // super.on_byPlayer_cast(event) would call trackEvent anyway
     super.on_byPlayer_cast && super.on_byPlayer_cast(event);
+  }
+
+  addCooldown(cooldownSpell, timestamp) {
+    const cooldown = {
+      ...cooldownSpell,
+      start: timestamp - (cooldownSpell.buffer || 0),
+      end: null,
+      events: [],
+    };
+    //this.cooldownPreSpells = this.previousCasts.reverse();
+    this.previousCasts.reverse().forEach(event => cooldown.events.unshift(event));
+    this.pastCooldowns.push(cooldown);
+    return cooldown;
   }
 
   _addFixedCooldown(cooldownSpell, timestamp) {


### PR DESCRIPTION
Same as the change for Fire, adds the 4 seconds of spells before Arcane Power to the Cooldowns page.

Before
![image](https://user-images.githubusercontent.com/1304554/86841599-c48e9880-c069-11ea-8242-371d7df6fd1f.png)


After
![image](https://user-images.githubusercontent.com/1304554/86841554-b6d91300-c069-11ea-83d9-a6383ea3ba0d.png)
