### PR TITLE
[Core] Event History utility function and some TS conversions

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@lingui/core": "^2.9.0",
     "@lingui/loader": "^2.9.0",
     "@lingui/macro": "^2.9.0",
+    "@sentry/browser": "^5.19.1",
     "@types/jest": "^24.0.23",
     "@types/lingui__core": "^2.7.0",
     "@types/lingui__macro": "^2.7.3",

--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -10,6 +10,7 @@ import Contributor from 'interface/ContributorButton';
 
 // prettier-ignore
 export default [
+  change(date(2020, 7, 11), 'Added shared functionality to get an array of filtered events previous to the currently processing event.', Dambroda),
   change(date(2020, 7, 6), <> Added support for <ItemLink id={ITEMS.SUBROUTINE_RECALIBRATION.id} />. </>, Putro),
   change(date(2020, 6, 27), 'Initial page load performance enhancements.', Stui),
   change(date(2020, 6, 12), 'Move various probability helpers to a shared folder.', Putro),

--- a/src/interface/report/Results/DegradedExperience.js
+++ b/src/interface/report/Results/DegradedExperience.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Danger from 'interface/Alert/Danger';
-import MODULE_ERROR from 'parser/core/MODULE_ERROR';
+import ModuleError from 'parser/core/ModuleError';
 
 const toTitleCase = s => s.substr(0, 1).toUpperCase() + s.substr(1);
 
@@ -25,7 +25,7 @@ class DegradedExperience extends React.Component {
 
   get firstError() {
     const { disabledModules } = this.props;
-    const existingErrorTypes = Object.values(MODULE_ERROR).filter(state => disabledModules[state] && disabledModules[state].length !== 0);
+    const existingErrorTypes = Object.values(ModuleError).filter(state => disabledModules[state] && disabledModules[state].length !== 0);
     if (existingErrorTypes.length > 0) {
       return disabledModules[existingErrorTypes[0]][0].key;
     }
@@ -36,8 +36,8 @@ class DegradedExperience extends React.Component {
     const { disabledModules } = this.props;
     let amount = 0;
     if (disabledModules) {
-      amount = Object.values(MODULE_ERROR).reduce((total, cur) => {
-        if (cur === MODULE_ERROR.DEPENDENCY) { //dont count dependency errors for total
+      amount = Object.values(ModuleError).reduce((total, cur) => {
+        if (cur === ModuleError.DEPENDENCY) { //dont count dependency errors for total
           return total;
         }
         return total + (disabledModules[cur] ? disabledModules[cur].length : 0);
@@ -48,8 +48,8 @@ class DegradedExperience extends React.Component {
 
   get disabledDependencyCount() {
     const { disabledModules } = this.props;
-    if (disabledModules[MODULE_ERROR.DEPENDENCY]) {
-      return disabledModules[MODULE_ERROR.DEPENDENCY].length;
+    if (disabledModules[ModuleError.DEPENDENCY]) {
+      return disabledModules[ModuleError.DEPENDENCY].length;
     }
     return 0;
   }
@@ -74,7 +74,7 @@ class DegradedExperience extends React.Component {
 
           {this.state.expanded && (
             <>
-              <br /><br />{Object.values(MODULE_ERROR)
+              <br /><br />{Object.values(ModuleError)
               .filter(state => disabledModules[state] && disabledModules[state].length !== 0)
               .map(state => (
                 <div key={state}>

--- a/src/parser/core/Analyzer.ts
+++ b/src/parser/core/Analyzer.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import EventSubscriber from './EventSubscriber';
+import EventSubscriber, { EventListener } from './EventSubscriber';
 import EventFilter, {
   SELECTED_PLAYER,
   SELECTED_PLAYER_PET,
@@ -84,7 +84,7 @@ class Analyzer extends EventSubscriber {
   }
   addEventListener<T extends Event>(
     eventFilter: T['type'] | EventFilter<T['type']>,
-    listener: (event: T) => void,
+    listener: EventListener<T>,
   ) {
     if (this.hasLegacyEventListener) {
       throw new Error(

--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -201,6 +201,7 @@ import Ashjrakamas from '../shared/modules/items/bfa/Ashjrakamas';
 import ParseResults from './ParseResults';
 import EventsNormalizer from './EventsNormalizer';
 import EventEmitter from './modules/EventEmitter';
+import EventHistory from 'parser/shared/modules/EventHistory';
 // This prints to console anything that the DI has to do
 const debugDependencyInjection = false;
 const MAX_DI_ITERATIONS = 100;
@@ -240,6 +241,7 @@ class CombatLogParser {
     pets: Pets,
     spellManaCost: SpellManaCost,
     channeling: Channeling,
+    eventHistory: EventHistory,
     abilityTracker: AbilityTracker,
     haste: Haste,
     statTracker: StatTracker,

--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -30,6 +30,7 @@ import Buffs from './modules/Buffs';
 import AbilitiesMissing from '../shared/modules/AbilitiesMissing';
 import CastEfficiency from '../shared/modules/CastEfficiency';
 import SpellUsable from '../shared/modules/SpellUsable';
+import EventHistory from '../shared/modules/EventHistory';
 import SpellHistory from '../shared/modules/SpellHistory';
 import GlobalCooldown from '../shared/modules/GlobalCooldown';
 import Enemies from '../shared/modules/Enemies';
@@ -201,7 +202,6 @@ import Ashjrakamas from '../shared/modules/items/bfa/Ashjrakamas';
 import ParseResults from './ParseResults';
 import EventsNormalizer from './EventsNormalizer';
 import EventEmitter from './modules/EventEmitter';
-import EventHistory from 'parser/shared/modules/EventHistory';
 // This prints to console anything that the DI has to do
 const debugDependencyInjection = false;
 const MAX_DI_ITERATIONS = 100;

--- a/src/parser/core/CombatLogParser.js
+++ b/src/parser/core/CombatLogParser.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { findByBossId } from 'raids';
 import { formatDuration, formatNumber, formatPercentage } from 'common/format';
 import DeathRecapTracker from 'interface/others/DeathRecapTracker';
-import MODULE_ERROR from 'parser/core/MODULE_ERROR';
+import MODULE_ERROR from 'parser/core/ModuleError';
 // Normalizers
 import ApplyBuffNormalizer from '../shared/normalizers/ApplyBuff';
 import CancelledCastsNormalizer from '../shared/normalizers/CancelledCasts';

--- a/src/parser/core/EventFilter.ts
+++ b/src/parser/core/EventFilter.ts
@@ -2,6 +2,9 @@ export const SELECTED_PLAYER = 1;
 export const SELECTED_PLAYER_PET = 2;
 const VALID_BY_FLAGS = SELECTED_PLAYER | SELECTED_PLAYER_PET;
 
+export type SpellInfo = { id: number };
+export type SpellFilter = SpellInfo | Array<SpellInfo>;
+
 class EventFilter<T extends string> {
   eventType: T;
   constructor(eventType: T) {
@@ -30,8 +33,8 @@ class EventFilter<T extends string> {
   getTo() {
     return this._to;
   }
-  private _spell: object | undefined;
-  spell(value: object) {
+  private _spell: SpellFilter | undefined;
+  spell(value: SpellFilter) {
     // TODO: Use spell id instead
     if (typeof value !== 'object') {
       throw new Error(

--- a/src/parser/core/EventSubscriber.ts
+++ b/src/parser/core/EventSubscriber.ts
@@ -7,10 +7,12 @@ import { Event } from './Events';
 
 export { SELECTED_PLAYER, SELECTED_PLAYER_PET };
 
+export type EventListener<T extends Event> = (event: T) => void;
+
 class EventSubscriber extends Module {
   addEventListener<T extends Event>(
     eventFilter: T['type'] | EventFilter<T['type']>,
-    listener: (event: T) => void,
+    listener: EventListener<T>,
   ) {
     if (!this.active) {
       return;

--- a/src/parser/core/MODULE_ERROR.js
+++ b/src/parser/core/MODULE_ERROR.js
@@ -1,9 +1,0 @@
-//states modules can be disabled in due to errors alongside the description to show in the degraded experience toaster
-const MODULE_ERROR = {
-  INITIALIZATION: "initialization",
-  EVENTS: "event handling",
-  RESULTS: "result generation",
-  DEPENDENCY: "one or more dependencies",
-};
-
-export default MODULE_ERROR;

--- a/src/parser/core/Module.ts
+++ b/src/parser/core/Module.ts
@@ -17,6 +17,8 @@ class Module {
   active: boolean = true;
   /** This module's execution priority, this makes sure dependencies are executed before modules that depend on them. */
   priority: number = 0;
+  /** This module's given name by the parser, sometimes auto generated and sometimes requested. */
+  key!: string;
   get selectedCombatant(): Combatant {
     return this.owner.selectedCombatant;
   }

--- a/src/parser/core/ModuleError.ts
+++ b/src/parser/core/ModuleError.ts
@@ -1,0 +1,9 @@
+//states modules can be disabled in due to errors alongside the description to show in the degraded experience toaster
+enum ModuleError {
+  INITIALIZATION = "initialization",
+  EVENTS = "event handling",
+  RESULTS = "result generation",
+  DEPENDENCY = "one or more dependencies",
+}
+
+export default ModuleError;

--- a/src/parser/core/modules/EventEmitter.ts
+++ b/src/parser/core/modules/EventEmitter.ts
@@ -292,11 +292,11 @@ class EventEmitter extends Module {
     console.error('Disabling', name, 'and child dependencies because an error occured:', err);
     // Disable this module and all active modules that have this as a dependency
     this.owner.deepDisable(module, ModuleError.EVENTS, err);
-    Sentry && Sentry.withScope(scope => {
+    window.Sentry && window.Sentry.withScope(scope => {
       scope.setTag('type', 'module_error');
       scope.setTag('spec', `${this.selectedCombatant.spec.specName} ${this.selectedCombatant.spec.className}`);
       scope.setExtra('module', name);
-      Sentry.captureException(err);
+      window.Sentry && window.Sentry.captureException(err);
     });
   }
 }

--- a/src/parser/core/modules/EventEmitter.ts
+++ b/src/parser/core/modules/EventEmitter.ts
@@ -1,13 +1,19 @@
-import MODULE_ERROR from 'parser/core/MODULE_ERROR';
-import Events from '../Events';
-
+import ModuleError from 'parser/core/ModuleError';
+import Events, { Event } from '../Events';
 import Module from '../Module';
+import { EventListener } from '../EventSubscriber';
 import { SELECTED_PLAYER, SELECTED_PLAYER_PET } from '../Analyzer';
-import EventFilter from '../EventFilter';
+import EventFilter, { SpellFilter } from '../EventFilter';
 
 const CATCH_ALL_EVENT = 'event';
 
 const PROFILE = false;
+
+type BoundListener = {
+  eventFilter: EventFilter<string> | string;
+  module: Module;
+  listener: EventListener<Event>;
+}
 
 /**
  * This (core) module takes care of:
@@ -20,21 +26,22 @@ class EventEmitter extends Module {
     return new EventFilter(CATCH_ALL_EVENT);
   }
 
-  constructor(options) {
+  constructor(options: any) {
     super(options);
     if (PROFILE) {
+      this.timePerModule = new Map<Module, number>();
       this.addEventListener(Events.fightend, this.reportModuleTimes.bind(this), this);
     }
   }
 
-  _eventListenersByEventType = {};
+  _eventListenersByEventType: {[eventType: string]: BoundListener[]} = {};
   numEventListeners = 0;
   /**
    * @param {string|EventFilter} eventFilter
    * @param {function} listener
    * @param {Module} module
    */
-  addEventListener(eventFilter, listener, module) {
+  addEventListener(eventFilter: EventFilter<string>|string, listener: EventListener<Event>, module: Module) {
     const eventType = eventFilter instanceof EventFilter ? eventFilter.eventType : eventFilter;
     this._eventListenersByEventType[eventType] = this._eventListenersByEventType[eventType] || [];
     this._eventListenersByEventType[eventType].push({
@@ -44,7 +51,7 @@ class EventEmitter extends Module {
     });
     this.numEventListeners += 1;
   }
-  _compileListener(eventFilter, listener, module) {
+  _compileListener(eventFilter: EventFilter<any>|string, listener: EventListener<Event>, module: Module) {
     listener = this._prependCounter(listener);
     if (eventFilter instanceof EventFilter) {
       listener = this._prependFilters(eventFilter, listener);
@@ -54,20 +61,20 @@ class EventEmitter extends Module {
     return listener;
   }
   numActualExecutions = 0;
-  _prependCounter(listener) {
+  _prependCounter<T extends Event>(listener: EventListener<T>): EventListener<T> {
     return event => {
       this.numActualExecutions += 1;
       listener(event);
     };
   }
-  _prependActiveCheck(listener, module) {
-    return function (event) {
+  _prependActiveCheck<T extends Event>(listener: EventListener<T>, module: Module): EventListener<T> {
+    return function(event) {
       if (module.active) {
         listener(event);
       }
     };
   }
-  _prependFilters(eventFilter, listener) {
+  _prependFilters<T extends Event>(eventFilter: EventFilter<string>, listener: EventListener<T>): EventListener<T> {
     const by = eventFilter.getBy();
     if (by) {
       listener = this._prependByCheck(listener, by);
@@ -82,59 +89,73 @@ class EventEmitter extends Module {
     }
     return listener;
   }
-  _prependByCheck(listener, by) {
+
+  createByCheck<T extends Event>(by: number): ((event: Event) => boolean) | null {
     const requiresSelectedPlayer = by & SELECTED_PLAYER;
     const requiresSelectedPlayerPet = by & SELECTED_PLAYER_PET;
 
-    let check;
     if (requiresSelectedPlayer && requiresSelectedPlayerPet) {
-      check = event => this.owner.byPlayer(event) || this.owner.byPlayerPet(event);
+      return event => this.owner.byPlayer(event) || this.owner.byPlayerPet(event);
     } else if (requiresSelectedPlayer) {
-      check = event => this.owner.byPlayer(event);
+      return event => this.owner.byPlayer(event);
     } else if (requiresSelectedPlayerPet) {
-      check = event => this.owner.byPlayerPet(event);
+      return event => this.owner.byPlayerPet(event);
     } else {
+      return null;
+    }
+  }
+  _prependByCheck<T extends Event>(listener: EventListener<T>, by: number): EventListener<T> {
+    const check = this.createByCheck(by);
+    if (!check) {
       return listener;
     }
 
-    return function (event) {
+    return function(event) {
       if (check(event)) {
         listener(event);
       }
     };
   }
-  _prependToCheck(listener, to) {
+
+  createToCheck(to: number): ((event: Event) => boolean) | null {
     const requiresSelectedPlayer = to & SELECTED_PLAYER;
     const requiresSelectedPlayerPet = to & SELECTED_PLAYER_PET;
-
-    let check;
     if (requiresSelectedPlayer && requiresSelectedPlayerPet) {
-      check = event => this.owner.toPlayer(event) || this.owner.toPlayerPet(event);
+      return event => this.owner.toPlayer(event) || this.owner.toPlayerPet(event);
     } else if (requiresSelectedPlayer) {
-      check = event => this.owner.toPlayer(event);
+      return event => this.owner.toPlayer(event);
     } else if (requiresSelectedPlayerPet) {
-      check = event => this.owner.toPlayerPet(event);
+      return event => this.owner.toPlayerPet(event);
     } else {
+      return null;
+    }
+  }
+  _prependToCheck<T extends Event>(listener: EventListener<T>, to: number): EventListener<T> {
+    const check = this.createToCheck(to);
+    if (!check) {
       return listener;
     }
-
-    return function (event) {
+    return function(event: T) {
       if (check(event)) {
         listener(event);
       }
     };
   }
-  _prependSpellCheck(listener, spell) {
+
+  createSpellCheck(spell: SpellFilter): ((event: Event) => boolean) {
     if (spell instanceof Array) {
-      return function (event) {
-        if (event.ability && spell.some(s => s.id === event.ability.guid)) {
-          listener(event);
-        }
-      };
+      // @ts-ignore adding typechecking to <generic> event properties will be a lot of work
+      return event => event.ability && spell.some(s => s.id === event.ability.guid);
     }
     const spellId = spell.id;
-    return function (event) {
-      if (event.ability && event.ability.guid === spellId) {
+    // @ts-ignore adding typechecking to <generic> event properties will be a lot of work
+    return event => event.ability && event.ability.guid === spellId;
+  }
+
+  _prependSpellCheck<T extends Event>(listener: EventListener<T>, spell: SpellFilter): EventListener<T> {
+    const check = this.createSpellCheck(spell);
+    return function(event: T) {
+      if (check(event)) {
         listener(event);
       }
     };
@@ -143,7 +164,7 @@ class EventEmitter extends Module {
   numTriggeredEvents = 0;
   numListenersCalled = 0;
   _isHandlingEvent = false;
-  triggerEvent(event) {
+  triggerEvent(event: Event) {
     if (process.env.NODE_ENV === 'development') {
       this._validateEvent(event);
     }
@@ -157,7 +178,7 @@ class EventEmitter extends Module {
       this.owner._timestamp = event.timestamp;
     }
 
-    let run = options => {
+    let run = (options: BoundListener) => {
       try {
         this.numListenersCalled += 1;
         options.listener(event);
@@ -194,10 +215,10 @@ class EventEmitter extends Module {
 
     return event;
   }
-  /** @var {Map} */
-  timePerModule = PROFILE ? new Map() : undefined;
-  profile(run) {
-    return options => {
+
+  timePerModule!: Map<Module, number>;
+  profile(run: (options: BoundListener) => void) {
+    return (options: BoundListener) => {
       const start = performance.now();
       run(options);
       const duration = performance.now() - start;
@@ -206,7 +227,7 @@ class EventEmitter extends Module {
     };
   }
   reportModuleTimes() {
-    const table = [];
+    const table: Array<{module: Module, duration: number, ofTotal: string}> = [];
     const totalDuration = Array.from(this.timePerModule).reduce((sum, [, value]) => sum + value, 0);
     this.timePerModule.forEach((value, key) => {
       table.push({
@@ -220,8 +241,8 @@ class EventEmitter extends Module {
     console.log('Total module time:', totalDuration, 'ms');
     console.groupEnd();
   }
-  _finally = null;
-  finally(func) {
+  _finally: Function[]|null = null;
+  finally(func: Function) {
     this._finally = this._finally || [];
     this._finally.push(func);
   }
@@ -238,7 +259,7 @@ class EventEmitter extends Module {
    * @param {object|null} trigger
    * @returns {object} The event that was triggered.
    */
-  fabricateEvent(event, trigger = null) {
+  fabricateEvent(event: { type: EventFilter<any>|string }, trigger = null) {
     const fabricatedEvent = {
       // When no timestamp is provided in the event (you should always try to), the current timestamp will be used by default.
       timestamp: this.owner.currentTimestamp,
@@ -257,24 +278,26 @@ class EventEmitter extends Module {
       return this.triggerEvent(fabricatedEvent);
     }
   }
-  _validateEvent(event) {
+  _validateEvent(event: any) {
     if (!event.type) {
       console.log(event);
       throw new Error('Events should have a type. No type received. See the console for the event.');
     }
   }
-  _handleError(err, module) {
+  _handleError(err: Error, module: Module) {
     if (process.env.NODE_ENV !== 'production') {
       throw err;
     }
     const name = module.key;
     console.error('Disabling', name, 'and child dependencies because an error occured:', err);
     // Disable this module and all active modules that have this as a dependency
-    this.owner.deepDisable(module, MODULE_ERROR.EVENTS, err);
+    this.owner.deepDisable(module, ModuleError.EVENTS, err);
+    // @ts-ignore Sentry does not exist on window, need Sentry types
     window.Sentry && window.Sentry.withScope(scope => {
       scope.setTag('type', 'module_error');
       scope.setTag('spec', `${this.selectedCombatant.spec.specName} ${this.selectedCombatant.spec.className}`);
       scope.setExtra('module', name);
+      // @ts-ignore Sentry does not exist on window, need Sentry types
       window.Sentry.captureException(err);
     });
   }

--- a/src/parser/core/modules/EventEmitter.ts
+++ b/src/parser/core/modules/EventEmitter.ts
@@ -292,13 +292,11 @@ class EventEmitter extends Module {
     console.error('Disabling', name, 'and child dependencies because an error occured:', err);
     // Disable this module and all active modules that have this as a dependency
     this.owner.deepDisable(module, ModuleError.EVENTS, err);
-    // @ts-ignore Sentry does not exist on window, need Sentry types
-    window.Sentry && window.Sentry.withScope(scope => {
+    Sentry && Sentry.withScope(scope => {
       scope.setTag('type', 'module_error');
       scope.setTag('spec', `${this.selectedCombatant.spec.specName} ${this.selectedCombatant.spec.className}`);
       scope.setExtra('module', name);
-      // @ts-ignore Sentry does not exist on window, need Sentry types
-      window.Sentry.captureException(err);
+      Sentry.captureException(err);
     });
   }
 }

--- a/src/parser/mage/arcane/modules/features/CooldownThroughputTracker.js
+++ b/src/parser/mage/arcane/modules/features/CooldownThroughputTracker.js
@@ -8,7 +8,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     ...CoreCooldownThroughputTracker.cooldownSpells,
     {
       spell: SPELLS.ARCANE_POWER,
-      buffer: 4000,
+      startBufferMS: 4000,
       summary: [
         BUILT_IN_SUMMARY_TYPES.DAMAGE,
       ],
@@ -31,20 +31,9 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     },
   ];
 
-  previousCasts = [];
-
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
     const cooldownSpell = this.constructor.castCooldowns.find(cooldownSpell => cooldownSpell.spell.id === spellId);
-
-    //Keep 4 Seconds worth of events
-    this.previousCasts.forEach(cast => {
-      if (cast.timestamp < event.timestamp - 4000) {
-        this.previousCasts.shift();
-      }
-    });
-    this.previousCasts.push(event);
-
     if (cooldownSpell) {
       // adding the fixed cooldown, now we need to remove it from activeCooldowns too
       const cooldown = this._addFixedCooldown(cooldownSpell, event.timestamp);
@@ -53,19 +42,6 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     }
     // super.on_byPlayer_cast(event) would call trackEvent anyway
     super.on_byPlayer_cast && super.on_byPlayer_cast(event);
-  }
-
-  addCooldown(cooldownSpell, timestamp) {
-    const cooldown = {
-      ...cooldownSpell,
-      start: timestamp - (cooldownSpell.buffer || 0),
-      end: null,
-      events: [],
-    };
-    //this.cooldownPreSpells = this.previousCasts.reverse();
-    this.previousCasts.reverse().forEach(event => cooldown.events.unshift(event));
-    this.pastCooldowns.push(cooldown);
-    return cooldown;
   }
 
   _addFixedCooldown(cooldownSpell, timestamp) {

--- a/src/parser/mage/fire/modules/features/CooldownThroughputTracker.js
+++ b/src/parser/mage/fire/modules/features/CooldownThroughputTracker.js
@@ -9,7 +9,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     ...CoreCooldownThroughputTracker.cooldownSpells,
     {
       spell: SPELLS.COMBUSTION,
-      buffer: 4000,
+      startBufferMS: 4000,
       summary: [
         BUILT_IN_SUMMARY_TYPES.DAMAGE,
       ],
@@ -32,20 +32,9 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     },
   ];
 
-  previousCasts = [];
-
   on_byPlayer_cast(event) {
     const spellId = event.ability.guid;
     const cooldownSpell = this.constructor.castCooldowns.find(cooldownSpell => cooldownSpell.spell.id === spellId);
-
-    //Keep 4 Seconds worth of events
-    this.previousCasts.forEach(cast => {
-      if (cast.timestamp < event.timestamp - 4000) {
-        this.previousCasts.shift();
-      }
-    });
-    this.previousCasts.push(event);
-
     if (cooldownSpell) {
       // adding the fixed cooldown, now we need to remove it from activeCooldowns too
       const cooldown = this._addFixedCooldown(cooldownSpell, event.timestamp);
@@ -54,19 +43,6 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     }
     // super.on_byPlayer_cast(event) would call trackEvent anyway
     super.on_byPlayer_cast && super.on_byPlayer_cast(event);
-  }
-
-  addCooldown(cooldownSpell, timestamp) {
-    const cooldown = {
-      ...cooldownSpell,
-      start: timestamp - (cooldownSpell.buffer || 0),
-      end: null,
-      events: [],
-    };
-    //this.cooldownPreSpells = this.previousCasts.reverse();
-    this.previousCasts.reverse().forEach(event => cooldown.events.unshift(event));
-    this.pastCooldowns.push(cooldown);
-    return cooldown;
   }
 
   _addFixedCooldown(cooldownSpell, timestamp) {

--- a/src/parser/shared/modules/CooldownThroughputTracker.tsx
+++ b/src/parser/shared/modules/CooldownThroughputTracker.tsx
@@ -4,22 +4,46 @@ import SPELLS from 'common/SPELLS/index';
 import Panel from 'interface/others/Panel';
 import CooldownIcon from 'interface/icons/Cooldown';
 import CooldownOverview from 'interface/others/CooldownOverview';
-import Analyzer from 'parser/core/Analyzer';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import CASTS_THAT_ARENT_CASTS from 'parser/core/CASTS_THAT_ARENT_CASTS';
+import EventHistory from 'parser/shared/modules/EventHistory';
+import Events, { Event, AbsorbedEvent, ApplyBuffEvent, ApplyDebuffEvent, CastEvent, DamageEvent, HealEvent, RemoveBuffEvent, RemoveDebuffEvent } from 'parser/core/Events';
+import EventFilter from 'parser/core/EventFilter';
 
 const debug = false;
 
-export const BUILT_IN_SUMMARY_TYPES = {
-  HEALING: 'HEALING',
-  OVERHEALING: 'OVERHEALING',
-  ABSORBED: 'ABSORBED',
-  ABSORBS_APPLIED: 'ABSORBS_APPLIED',
-  MANA: 'MANA',
-  DAMAGE: 'DAMAGE',
+export enum BUILT_IN_SUMMARY_TYPES {
+  HEALING = 'HEALING',
+  OVERHEALING = 'OVERHEALING',
+  ABSORBED = 'ABSORBED',
+  ABSORBS_APPLIED = 'ABSORBS_APPLIED',
+  MANA = 'MANA',
+  DAMAGE = 'DAMAGE',
+}
+
+type TrackedEvent = CastEvent | HealEvent | AbsorbedEvent | DamageEvent | ApplyBuffEvent;
+
+export type CooldownSpell = {
+  spell: any,
+  summary: Array<BUILT_IN_SUMMARY_TYPES>,
+  startBufferFilter?: EventFilter<any>,
+  startBufferMS?: number,
+  startBufferEvents?: number,
+};
+
+type TrackedCooldown = CooldownSpell & {
+  start: number,
+  end: number | null,
+  events: Array<Event>,
 };
 
 class CooldownThroughputTracker extends Analyzer {
-  static cooldownSpells = [
+  static dependencies = {
+    eventHistory: EventHistory,
+  };
+  protected eventHistory!: EventHistory;
+
+  static cooldownSpells: Array<CooldownSpell> = [
     {
       spell: SPELLS.INNERVATE,
       summary: [
@@ -36,12 +60,13 @@ class CooldownThroughputTracker extends Analyzer {
     ...CASTS_THAT_ARENT_CASTS,
   ];
 
-  pastCooldowns = [];
-  activeCooldowns = [];
+  pastCooldowns: Array<TrackedCooldown> = [];
+  activeCooldowns: Array<TrackedCooldown> = [];
 
-  startCooldown(event) {
+  startCooldown(event: CastEvent | ApplyBuffEvent | ApplyDebuffEvent) {
     const spellId = event.ability.guid;
-    const cooldownSpell = this.constructor.cooldownSpells.find(cooldownSpell => cooldownSpell.spell.id === spellId);
+    const ctor = this.constructor as typeof CooldownThroughputTracker;
+    const cooldownSpell = ctor.cooldownSpells.find(cooldownSpell => cooldownSpell.spell.id === spellId);
     if (!cooldownSpell) {
       return;
     }
@@ -49,17 +74,34 @@ class CooldownThroughputTracker extends Analyzer {
     this.activeCooldowns.push(cooldown);
     debug && console.log(`%cCooldown started: ${cooldownSpell.spell.name}`, 'color: green', cooldown);
   }
-  addCooldown(cooldownSpell, timestamp) {
+
+  addCooldown(cooldownSpell: CooldownSpell, timestamp: number): TrackedCooldown {
+    let events: Array<Event> = [];
+    let start = timestamp;
+    const startBufferMS = cooldownSpell.startBufferMS;
+    if (startBufferMS || cooldownSpell.startBufferEvents) {
+      // Default to only including cast events by the player
+      const filter = cooldownSpell.startBufferFilter || Events.cast.by(SELECTED_PLAYER);
+      events = this.eventHistory.last(cooldownSpell.startBufferEvents, startBufferMS, filter);
+      if(startBufferMS) {
+        start = timestamp - startBufferMS;
+      } else {
+        // If filtering by only event count, set the start timestamp to the oldest event found
+        start = (events[0] && events[0].timestamp) || start;
+      }
+    }
     const cooldown = {
       ...cooldownSpell,
-      start: timestamp,
+      start: start,
       end: null,
-      events: [],
+      events: events,
     };
+
     this.pastCooldowns.push(cooldown);
     return cooldown;
   }
-  endCooldown(event) {
+
+  endCooldown(event: RemoveDebuffEvent | RemoveBuffEvent) {
     const spellId = event.ability.guid;
     const index = this.activeCooldowns.findIndex(cooldown => cooldown.spell.id === spellId);
     if (index === -1) {
@@ -71,6 +113,7 @@ class CooldownThroughputTracker extends Analyzer {
     this.activeCooldowns.splice(index, 1);
     debug && console.log(`%cCooldown ended: ${cooldown.spell.name}`, 'color: red', cooldown);
   }
+
   on_fightend() {
     this.activeCooldowns.forEach((cooldown) => {
       cooldown.end = this.owner.fight.end_time;
@@ -80,41 +123,52 @@ class CooldownThroughputTracker extends Analyzer {
   }
 
   // region Event tracking
-  trackEvent(event) {
+  trackEvent(event: TrackedEvent) {
     this.activeCooldowns.forEach((cooldown) => {
       cooldown.events.push(event);
     });
   }
-  on_byPlayer_cast(event) {
-    if (this.constructor.ignoredSpells.includes(event.ability.guid)) {
+
+  on_byPlayer_cast(event: CastEvent) {
+    const ctor = this.constructor as typeof CooldownThroughputTracker;
+    if (ctor.ignoredSpells.includes(event.ability.guid)) {
       return;
     }
     this.trackEvent(event);
   }
-  on_byPlayer_heal(event) {
+
+  on_byPlayer_heal(event: HealEvent) {
     this.trackEvent(event);
   }
-  on_byPlayer_absorbed(event) {
+
+  on_byPlayer_absorbed(event: AbsorbedEvent) {
     this.trackEvent(event);
   }
-  on_byPlayer_damage(event) {
+
+  on_byPlayer_damage(event: DamageEvent) {
     this.trackEvent(event);
   }
-  on_byPlayer_applybuff(event) {
+
+  on_byPlayer_applybuff(event: ApplyBuffEvent) {
     this.trackEvent(event);
   }
-  on_toPlayer_applybuff(event) {
+
+  on_toPlayer_applybuff(event: ApplyBuffEvent) {
     this.startCooldown(event);
   }
-  on_toPlayer_removebuff(event) {
+
+  on_toPlayer_removebuff(event: RemoveBuffEvent) {
     this.endCooldown(event);
   }
-  on_byPlayer_applydebuff(event) {
+
+  on_byPlayer_applydebuff(event: ApplyDebuffEvent) {
     this.startCooldown(event);
   }
-  on_byPlayer_removedebuff(event) {
+
+  on_byPlayer_removedebuff(event: RemoveDebuffEvent) {
     this.endCooldown(event);
   }
+
   // endregion
 
   tab() {

--- a/src/parser/shared/modules/EventHistory.ts
+++ b/src/parser/shared/modules/EventHistory.ts
@@ -11,7 +11,7 @@ class EventHistory extends Module {
    * @param filterDef an optional EventFilter to apply to all events
    * @returns the last `count` events that match the given filters, with the oldest events first
    */
-  public last(count: number | null = null, maxTime: number | null = null, filterDef: EventFilter<string> | null = null): Array<Event> {
+  public last(count?: number, maxTime?: number, filterDef?: EventFilter<string>): Array<Event> {
     let filter = (event: any) => {
       return true;
     };

--- a/src/parser/shared/modules/EventHistory.ts
+++ b/src/parser/shared/modules/EventHistory.ts
@@ -1,0 +1,88 @@
+import Module from 'parser/core/Module';
+import { Event } from 'parser/core/Events';
+import EventFilter from 'parser/core/EventFilter';
+import EventEmitter from 'parser/core/modules/EventEmitter';
+
+class EventHistory extends Module {
+
+  /**
+   * @param count the maximum number of events to return, or null for no limit
+   * @param maxTime the maximum number of milliseconds to look back, or null for no limit
+   * @param filterDef an optional EventFilter to apply to all events
+   * @returns the last `count` events that match the given filters, with the oldest events first
+   */
+  public last(count: number | null = null, maxTime: number | null = null, filterDef: EventFilter<string> | null = null): Array<Event> {
+    let filter = (event: any) => {
+      return true;
+    };
+
+    if (maxTime) {
+      const minTime = this.owner.currentTimestamp - maxTime;
+      const prevFilter = filter;
+      filter = (event: any) => {
+        if (!event.timestamp || event.timestamp < minTime) {
+          return false;
+        }
+        return prevFilter(event);
+      };
+    }
+
+    if (filterDef) {
+      const ee: EventEmitter = this.owner.getModule(EventEmitter);
+      const prevFilter = filter;
+      filter = event => {
+        if (event.type !== filterDef.eventType) {
+          return false;
+        }
+        return prevFilter(event);
+      };
+      const filterTo = filterDef.getTo();
+      if (filterTo) {
+        const prevFilter = filter;
+        const toFilter = ee.createToCheck(filterTo);
+        if (toFilter) {
+          filter = event => {
+            if (!toFilter(event)) {
+              return false;
+            }
+            return prevFilter(event);
+          };
+        }
+      }
+      const filterBy = filterDef.getBy();
+      if (filterBy) {
+        const prevFilter = filter;
+        const byFilter = ee.createByCheck(filterBy);
+        if (byFilter) {
+          filter = event => {
+            if (!byFilter(event)) {
+              return false;
+            }
+            return prevFilter(event);
+          };
+        }
+      }
+      const filterSpell = filterDef.getSpell();
+      if (filterSpell) {
+        const prevFilter = filter;
+        const spellFilter = ee.createSpellCheck(filterSpell);
+        filter = event => {
+          if (!spellFilter(event)) {
+            return false;
+          }
+          return prevFilter(event);
+        };
+      }
+    }
+
+    let history = this.owner.eventHistory.filter(event => filter(event));
+    if (count && count < history.length) {
+      history = history.slice(-count);
+    }
+    return history;
+  }
+
+}
+
+
+export default EventHistory;

--- a/types/sentry.d.ts
+++ b/types/sentry.d.ts
@@ -2,5 +2,5 @@ import * as SentryType from '@sentry/browser';
 
 declare global {
   // May be undefined when adblockers block Sentry (for privacy concerns)
-  const Sentry: typeof SentryType | undefined;
+  interface Window { Sentry: typeof SentryType | undefined }
 }

--- a/types/sentry.d.ts
+++ b/types/sentry.d.ts
@@ -1,0 +1,6 @@
+import * as SentryType from '@sentry/browser';
+
+declare global {
+  // May be undefined when adblockers block Sentry (for privacy concerns)
+  const Sentry: typeof SentryType | undefined;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1437,6 +1437,58 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@sentry/browser@^5.19.1":
+  version "5.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.19.1.tgz#b22f36fc71f36719ad352a54e6b31722622128c0"
+  integrity sha512-Aon5Nc2n8sIXKg6Xbr4RM3/Xs7vFpXksL56z3yIuGrmpCM8ToQ25/tQv8h+anYi72x5bn1npzaXB/NwU1Qwfhg==
+  dependencies:
+    "@sentry/core" "5.19.1"
+    "@sentry/types" "5.19.1"
+    "@sentry/utils" "5.19.1"
+    tslib "^1.9.3"
+
+"@sentry/core@5.19.1":
+  version "5.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.19.1.tgz#f5ff7feb1118035f75f1d0bc2a76e2b040d2aa8e"
+  integrity sha512-BGGxjeT95Og/hloBhQXAVcndVXPmIU6drtF3oKRT12cBpiG965xEDEUwiJVvyb5MAvojdVEZBK2LURUFY/d7Zw==
+  dependencies:
+    "@sentry/hub" "5.19.1"
+    "@sentry/minimal" "5.19.1"
+    "@sentry/types" "5.19.1"
+    "@sentry/utils" "5.19.1"
+    tslib "^1.9.3"
+
+"@sentry/hub@5.19.1":
+  version "5.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.19.1.tgz#f3bc8500680974ce43c1eedcd8e90696cc18b306"
+  integrity sha512-XjfbNGWVeDsP38alm5Cm08YPIw5Hu6HbPkw7a3y1piViTrg4HdtsE+ZJqq0YcURo2RTpg6Ks6coCS/zJxIPygQ==
+  dependencies:
+    "@sentry/types" "5.19.1"
+    "@sentry/utils" "5.19.1"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.19.1":
+  version "5.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.19.1.tgz#04043d93a7dc90cbed1a31d80f6bf59688ea3100"
+  integrity sha512-pgNfsaCroEsC8gv+NqmPTIkj4wyK6ZgYLV12IT4k2oJLkGyg45TSAKabyB7oEP5jsj8sRzm8tDomu8M4HpaCHg==
+  dependencies:
+    "@sentry/hub" "5.19.1"
+    "@sentry/types" "5.19.1"
+    tslib "^1.9.3"
+
+"@sentry/types@5.19.1":
+  version "5.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.19.1.tgz#8762f668d3fc2416fbde31d15d13009544caeb54"
+  integrity sha512-M5MhTLnjqYFwxMwcFPBpBgYQqI9hCvtVuj/A+NvcBHpe7VWOXdn/Sys+zD6C76DWGFYQdw3OWCsZimP24dL8mA==
+
+"@sentry/utils@5.19.1":
+  version "5.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.19.1.tgz#e1134db40e4bb9732251e515721cec7ee94d4d9c"
+  integrity sha512-neUiNBnZSHjWTZWy2QV02EHTx1C2L3DBPzRXlh0ca5xrI7LMBLmhkHlhebn1E5ky3PW1teqZTgmh0jZoL99TEA==
+  dependencies:
+    "@sentry/types" "5.19.1"
+    tslib "^1.9.3"
+
 "@svgr/babel-plugin-add-jsx-attribute@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz#dadcb6218503532d6884b210e7f3c502caaa44b1"
@@ -12128,6 +12180,11 @@ tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tslib@^1.9.3:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
What's in here?

**TS Conversion**
- Converted EventEmitter to TS
- Converted MODULE_ERROR to TS enum
- Converted CooldownThroughputTracker to TS
- Stictified some existing TS

**New functionality**
- New module EventHistory that can be imported as a dependency
  - Adds EventHistory.last(count, maxTime, filterDef)
   ```
  /**
   * @param count the maximum number of events to return, or null for no limit
   * @param maxTime the maximum number of milliseconds to look back, or null for no limit
   * @param filterDef an optional EventFilter to apply to all events
   * @returns the last `count` events that match the given filters, with the oldest events first
   */
- CooldownThroughputTracker (and children) cooldownSpells have new options (thanks Sharrq):
  - `startBufferMS`: If provided, the cooldown tracker will add X ms of events from before the cooldown started to the cooldown window
  - `startBufferEvents`: If provided, limits the number of events added to the cooldown window
  - `startBufferFilter`: An `EventFilter` to filter the events for, defaults to `Events.cast.by(SELECTED_PLAYER)`
  - NOTE: `startBufferEvents` and `startBufferMS` are and'ed, not or'ed. Providing both will filter by both.

EXAMPLES:

```javascript
    // Get the last three cast events by the selected player
    this.eventHistory.last(3, null, Events.cast.by(SELECTED_PLAYER));

    // Get the last three flurry casts by the selected player (will potentially go back to fight start!)
    this.eventHistory.last(3, null, Events.cast.by(SELECTED_PLAYER).spell(SPELLS.FLURRY)));

    // Get the last 5 seconds of cast events for the selected player
    this.eventHistory.last(null, 5000, Events.cast.by(SELECTED_PLAYER));

    // Get the last 10 seconds of cast events for the selected player, but give me a maximum of the latest 5
    this.eventHistory.last(5, 10000, Events.cast.by(SELECTED_PLAYER))
```

```javascript
    {
      spell: SPELLS.COMBUSTION,
      startBufferEvents: 10,
      summary: [
        BUILT_IN_SUMMARY_TYPES.DAMAGE,
      ],
    },
```

Note that the cooldown durations are different (because no timestamp filter was added), and 10 events before Combustion are included:

![image](https://user-images.githubusercontent.com/43309639/87234948-10ec1800-c38b-11ea-9c02-8ebeafbebbb2.png)
(also this is not what it's actually being changed to Sharrq, just an example! keeping your 4 second windows)

