### PR TITLE
[Core] Convert CombatLogParser to TypeScript and getting strict with EventListener

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -10,7 +10,7 @@ import Contributor from 'interface/ContributorButton';
 
 // prettier-ignore
 export default [
-  change(date(2020, 7, 23), 'Converted core combat log parser to TypeScript and added strict event typechecking to event listeners.', Dambroda),
+  change(date(2020, 7, 23), 'Converted core log parser to TypeScript and added strict event typechecking to event listeners.', Dambroda),
   change(date(2020, 7, 11), 'Added shared functionality to get an array of filtered events previous to the currently processing event.', Dambroda),
   change(date(2020, 7, 6), <> Added support for <ItemLink id={ITEMS.SUBROUTINE_RECALIBRATION.id} />. </>, Putro),
   change(date(2020, 6, 27), 'Initial page load performance enhancements.', Stui),

--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -10,6 +10,7 @@ import Contributor from 'interface/ContributorButton';
 
 // prettier-ignore
 export default [
+  change(date(2020, 7, 23), 'Converted core combat log parser to TypeScript and added strict event typechecking to event listeners.', Dambroda),
   change(date(2020, 7, 11), 'Added shared functionality to get an array of filtered events previous to the currently processing event.', Dambroda),
   change(date(2020, 7, 6), <> Added support for <ItemLink id={ITEMS.SUBROUTINE_RECALIBRATION.id} />. </>, Putro),
   change(date(2020, 6, 27), 'Initial page load performance enhancements.', Stui),

--- a/src/interface/report/PhaseParser.ts
+++ b/src/interface/report/PhaseParser.ts
@@ -2,25 +2,10 @@ import React, { ReactNode } from 'react';
 
 import { EventType, PhaseEvent } from 'parser/core/Events';
 import { findByBossId, Phase } from 'raids';
+import Fight from 'parser/core/Fight';
 
 export const SELECTION_ALL_PHASES = "ALL";
 export const SELECTION_CUSTOM_PHASE = "CUSTOM";
-
-//todo: move this
-export interface Fight {
-  filtered?: boolean;
-  phase?: string;
-  instance?: number;
-  // eslint-disable-next-line camelcase
-  offset_time: number;
-  // eslint-disable-next-line camelcase
-  original_end_time: number;
-  // eslint-disable-next-line camelcase
-  start_time: number,
-  // eslint-disable-next-line camelcase
-  end_time: number,
-  boss: number,
-}
 
 interface Props {
   fight: Fight,

--- a/src/interface/report/Results/PhaseSelector.tsx
+++ b/src/interface/report/Results/PhaseSelector.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { SELECTION_ALL_PHASES, SELECTION_CUSTOM_PHASE, Fight } from 'interface/report/PhaseParser';
+import { SELECTION_ALL_PHASES, SELECTION_CUSTOM_PHASE } from 'interface/report/PhaseParser';
+import Fight from 'parser/core/Fight';
 import { Phase } from 'raids';
 
 import './PhaseSelector.scss';

--- a/src/interface/report/Results/TimeFilter.tsx
+++ b/src/interface/report/Results/TimeFilter.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-
+import Fight from 'parser/core/Fight';
 import TimeInput from './TimeInput';
-import { Fight } from '../PhaseParser';
 
 interface Props {
   fight: Fight,
@@ -71,7 +70,7 @@ class TimeFilter extends React.PureComponent<Props, State> {
     return (
       <form onSubmit={this.handleSubmit}>
         <TimeInput name="start" min={0} max={this.state.max} time={this.state.start} onChange={this.selectStart} />
-         to 
+         to
         <TimeInput name="end" min={0} max={this.state.max} time={this.state.end} onChange={this.selectEnd} />
         <div className="buttons">
           <button type="submit" name="filter" className="btn btn-primary filter animated-button" disabled={isLoading || this.invalidTimes()}>

--- a/src/interface/report/Results/index.js
+++ b/src/interface/report/Results/index.js
@@ -181,7 +181,7 @@ class Results extends React.PureComponent {
         if (this.isLoading) {
           return this.renderLoadingIndicator();
         }
-        const checklist = parser.getModule(Checklist, true);
+        const checklist = parser.getOptionalModule(Checklist);
         return (
           <Overview
             checklist={checklist && checklist.render()}

--- a/src/interface/report/Results/index.js
+++ b/src/interface/report/Results/index.js
@@ -54,6 +54,7 @@ class Results extends React.PureComponent {
           resultsWarning: PropTypes.any,
         }),
       }),
+      getOptionalModule: PropTypes.func.isRequired,
       getModule: PropTypes.func.isRequired,
       selectedCombatant: PropTypes.any,
       fight: PropTypes.shape({

--- a/src/interface/report/TimeEventFilter.ts
+++ b/src/interface/report/TimeEventFilter.ts
@@ -2,10 +2,11 @@ import React from 'react';
 
 import { captureException } from 'common/errorLogger';
 import { SECOND_POTIONS } from 'parser/shared/modules/items/PrePotion';
+import Fight from 'parser/core/Fight';
 import { EventType, Event, PhaseEvent, CastEvent, ApplyBuffStackEvent, ApplyDebuffStackEvent, RemoveBuffStackEvent, RemoveDebuffStackEvent, ApplyBuffEvent, RemoveBuffEvent, ApplyDebuffEvent, RemoveDebuffEvent, FilterCooldownInfoEvent } from 'parser/core/Events';
 
 import { EventsParseError } from './EventParser';
-import { SELECTION_ALL_PHASES, Fight } from './PhaseParser';
+import { SELECTION_ALL_PHASES } from './PhaseParser';
 
 const TIME_AVAILABLE = console.time && console.timeEnd;
 const bench = (id: string) => TIME_AVAILABLE && console.time(id);
@@ -24,13 +25,13 @@ interface Props {
   phase: string,
   phaseinstance: number,
   bossPhaseEvents: PhaseEvent[],
-  events: Event[],
-  children: (isLoading: boolean, events?: Event[], fight?: any) => any,
+  events: Event<any>[],
+  children: (isLoading: boolean, events?: Event<any>[], fight?: any) => any,
 }
 
 interface State {
   isLoading: boolean,
-  events?: Event[],
+  events?: Event<any>[],
   fight?: Fight,
 }
 
@@ -119,21 +120,21 @@ class TimeEventFilter extends React.PureComponent<Props, State> {
 
 }
 
-function findRelevantPostFilterEvents(events: Event[]) {
-  return events.filter((e: Event) => e.type === EventType.Cast && SECOND_POTIONS.includes((e as CastEvent).ability.guid)).map(e => ({ ...e, type: EventType.FilterCooldownInfo, trigger: e.type }));
+function findRelevantPostFilterEvents(events: Event<any>[]) {
+  return events.filter((e: Event<any>) => e.type === EventType.Cast && SECOND_POTIONS.includes((e as CastEvent).ability.guid)).map(e => ({ ...e, type: EventType.FilterCooldownInfo, trigger: e.type }));
 }
 
 //filter prephase events to just the events outside the time period that "matter" to make statistics more accurate (e.g. buffs and cooldowns)
 type StackEvent = ApplyBuffStackEvent | ApplyDebuffStackEvent | RemoveBuffStackEvent | RemoveDebuffStackEvent;
 type BuffEvent = ApplyBuffEvent | ApplyDebuffEvent | RemoveBuffEvent | RemoveDebuffEvent;
 type CastRelevantEvent = CastEvent | FilterCooldownInfoEvent;
-function findRelevantPreFilterEvents(events: Event[]) {
+function findRelevantPreFilterEvents(events: Event<any>[]) {
   const buffEvents: BuffEvent[] = []; //(de)buff apply events for (de)buffs that stay active going into the time period
   const stackEvents: StackEvent[] = []; //stack events related to the above buff events that happen after the buff is applied
   const castEvents: CastRelevantEvent[] = []; //latest cast event of each cast by player for cooldown tracking
 
   const buffIsMarkedActive = (e: BuffEvent) => buffEvents.find(e2 => e.ability.guid === e2.ability.guid && e.targetID === e2.targetID && e.sourceID === e2.targetID) !== undefined;
-  const buffIsRemoved = (e: BuffEvent, buffRelevantEvents: Event[]) => buffRelevantEvents.find(e2 => e2.type === e.type.replace("apply", "remove") && eventFollows(e, e2 as BuffEvent)) !== undefined;
+  const buffIsRemoved = (e: BuffEvent, buffRelevantEvents: Event<any>[]) => buffRelevantEvents.find(e2 => e2.type === e.type.replace("apply", "remove") && eventFollows(e, e2 as BuffEvent)) !== undefined;
   const castHappenedLater = (e: CastEvent) => castEvents.find(e2 => e.ability.guid === e2.ability.guid && e.sourceID === e2.sourceID) !== undefined;
 
   events.forEach((e, index) => {
@@ -148,7 +149,7 @@ function findRelevantPreFilterEvents(events: Event[]) {
           if (!buffIsRemoved(e as BuffEvent, buffRelevantEvents)) {
             buffEvents.push(e as BuffEvent);
             //find relevant stack information for active buff / debuff
-            stackEvents.push(...buffRelevantEvents.reverse().reduce((arr: StackEvent[], e2: Event) => {
+            stackEvents.push(...buffRelevantEvents.reverse().reduce((arr: StackEvent[], e2: Event<any>) => {
               //traverse through all following stack events in chronological order
               if (eventFollows(e as BuffEvent, e2 as StackEvent)) {
                 //if stack is added, add the event to the end of the array
@@ -204,7 +205,7 @@ function findRelevantPreFilterEvents(events: Event[]) {
  * @return {Array}
  *  List of filtered events
  */
-export function filterEvents(events: Event[], start: number, end: number) {
+export function filterEvents(events: Event<any>[], start: number, end: number) {
   const phaseEvents = events.filter(event =>
     event.timestamp >= start
     && event.timestamp <= end,

--- a/src/parser/Config.ts
+++ b/src/parser/Config.ts
@@ -15,6 +15,20 @@ export interface Contributor {
   alts?: Array<{ name: string; spec: any; link: string }>;
 }
 
+export type Build = {
+  url: string;
+  name: string;
+  icon: ReactNode;
+  /**
+   * Whether the build should be visible. Using `false` can allow you to
+   * incrementally add support to modules, without having to bundle
+   * everything in a single giant PR or release it incomplete.
+   */
+  visible: boolean;
+  active?: boolean;
+}
+export type Builds = { [name: string]: Build };
+
 interface Config {
   /**
    * The people that have contributed to this spec recently. People don't have
@@ -52,19 +66,7 @@ interface Config {
    * on the homepage.
    */
   exampleReport: string;
-  builds?: {
-    [id: string]: {
-      url: string;
-      name: string;
-      icon: ReactNode;
-      /**
-       * Whether the build should be visible. Using `false` can allow you to
-       * incrementally add support to modules, without having to bundle
-       * everything in a single giant PR or release it incomplete.
-       */
-      visible: boolean;
-    };
-  };
+  builds?: Builds;
   // Don't change values for props below this line;
   /**
    * The spec this config is for . This is the only place (in code) that

--- a/src/parser/core/Analyzer.ts
+++ b/src/parser/core/Analyzer.ts
@@ -82,9 +82,9 @@ class Analyzer extends EventSubscriber {
     super(options);
     addLegacyEventListenerSupport(this);
   }
-  addEventListener<T extends Event>(
-    eventFilter: T['type'] | EventFilter<T['type']>,
-    listener: EventListener<T>,
+  addEventListener<ET extends string, E extends Event<ET>>(
+    eventFilter: ET | EventFilter<ET>,
+    listener: EventListener<ET, E>,
   ) {
     if (this.hasLegacyEventListener) {
       throw new Error(
@@ -101,7 +101,7 @@ class Analyzer extends EventSubscriber {
   /**
    * @deprecated Set the `position` property on the Statistic component instead.
    */
-  statisticOrder = undefined;
+  statisticOrder?: number = undefined;
   suggestions(when: (actual: object | any) => SuggestionAssertion) {}
   /**
    * @deprecated Return a `Panel` from the statistic method instead.

--- a/src/parser/core/CombatLogParser.test.js
+++ b/src/parser/core/CombatLogParser.test.js
@@ -93,7 +93,7 @@ describe('Core/CombatLogParser', () => {
         };
       }
       const parser = new MyCombatLogParser(fakeReport, fakePlayer, fakeFight, fakeCombatants);
-      expect(parser.getModule(MyModule, true)).toBe(undefined);
+      expect(parser.getOptionalModule(MyModule)).toBe(undefined);
       expect(Object.keys(parser._modules).length).toBe(0);
     });
   });

--- a/src/parser/core/CombatLogParser.ts
+++ b/src/parser/core/CombatLogParser.ts
@@ -3,7 +3,7 @@ import React from 'react';
 import { findByBossId } from 'raids';
 import { formatDuration, formatNumber, formatPercentage } from 'common/format';
 import DeathRecapTracker from 'interface/others/DeathRecapTracker';
-import MODULE_ERROR from 'parser/core/ModuleError';
+import ModuleError from 'parser/core/ModuleError';
 // Normalizers
 import ApplyBuffNormalizer from '../shared/normalizers/ApplyBuff';
 import CancelledCastsNormalizer from '../shared/normalizers/CancelledCasts';
@@ -488,7 +488,7 @@ class CombatLogParser {
     this.boss = findByBossId(selectedFight.boss);
     this.disabledModules = {};
     //initialize disabled modules for each state
-    Object.values(MODULE_ERROR).forEach(key => {
+    Object.values(ModuleError).forEach(key => {
       this.disabledModules[key] = [];
     });
     this.initializeModules({
@@ -594,7 +594,7 @@ class CombatLogParser {
           if (process.env.NODE_ENV !== 'production') {
             throw e;
           }
-          this.disabledModules[MODULE_ERROR.INITIALIZATION].push({ key: isMinified ? desiredModuleName : moduleClass.name, module: moduleClass, error: e });
+          this.disabledModules[ModuleError.INITIALIZATION].push({ key: isMinified ? desiredModuleName : moduleClass.name, module: moduleClass, error: e });
           debugDependencyInjection && console.warn(moduleClass.name, 'disabled due to error during initialization: ', e);
         }
 
@@ -602,13 +602,13 @@ class CombatLogParser {
         const disabledDependencies = missingDependencies
           .map(d => d.name)
           .filter(x =>
-            this.disabledModules[MODULE_ERROR.INITIALIZATION]
+            this.disabledModules[ModuleError.INITIALIZATION]
               .map(d => d.module.name)
               .includes(x),
           ); // see if a dependency was previously disabled due to an error
         if (disabledDependencies.length !== 0) {
           // if a dependency was already marked as disabled due to an error, mark this module as disabled
-          this.disabledModules[MODULE_ERROR.DEPENDENCY].push({ key: isMinified ? desiredModuleName : moduleClass.name, module: moduleClass });
+          this.disabledModules[ModuleError.DEPENDENCY].push({ key: isMinified ? desiredModuleName : moduleClass.name, module: moduleClass });
           debugDependencyInjection && console.warn(moduleClass.name, 'disabled due to error during initialization of a dependency.');
         } else {
           debugDependencyInjection && console.warn(moduleClass.name, 'could not be loaded, missing dependencies:', missingDependencies.map(d => d.name));
@@ -683,7 +683,7 @@ class CombatLogParser {
     this.activeModules.forEach(active => {
         const deps = active.constructor.dependencies;
         if (deps && Object.values(deps).find(depClass => module instanceof depClass)) {
-          this.deepDisable(active, MODULE_ERROR.DEPENDENCY);
+          this.deepDisable(active, ModuleError.DEPENDENCY);
         }
       },
     );
@@ -779,7 +779,7 @@ class CombatLogParser {
             if (process.env.NODE_ENV !== 'production') {
               throw e;
             }
-            this.deepDisable(module, MODULE_ERROR.RESULTS, e);
+            this.deepDisable(module, ModuleError.RESULTS, e);
             //break loop and start again with inaccurate modules now disabled (in case of modules being rendered before their dependencies' errors are encountered)
             return false;
           }

--- a/src/parser/core/EventSubscriber.ts
+++ b/src/parser/core/EventSubscriber.ts
@@ -7,12 +7,12 @@ import { Event } from './Events';
 
 export { SELECTED_PLAYER, SELECTED_PLAYER_PET };
 
-export type EventListener<T extends Event> = (event: T) => void;
+export type EventListener<ET extends string, E extends Event<ET>> = (event: E) => void;
 
 class EventSubscriber extends Module {
-  addEventListener<T extends Event>(
-    eventFilter: T['type'] | EventFilter<T['type']>,
-    listener: EventListener<T>,
+  addEventListener<ET extends string, E extends Event<ET>>(
+    eventFilter: ET | EventFilter<ET>,
+    listener: EventListener<ET, E>,
   ) {
     if (!this.active) {
       return;

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -87,13 +87,25 @@ export enum Class {
   Warlock = 'Warlock',
 }
 
-export interface Event {
-  type: EventType;
+export type AbilityEvent<T extends string> = Event<T> & { ability: Ability };
+export type SourcedEvent<T extends string> = Event<T> & { sourceID: number };
+export type TargettedEvent<T extends string> = Event<T> & { targetID: number };
+export function HasAbility<T extends string>(event: Event<T>): event is AbilityEvent<T> {
+  return (event as AbilityEvent<T>).ability !== undefined;
+}
+export function HasSource<T extends string>(event: Event<T>): event is SourcedEvent<T> {
+  return (event as SourcedEvent<T>).sourceID !== undefined;
+}
+export function HasTarget<T extends string>(event: Event<T>): event is TargettedEvent<T> {
+  return (event as TargettedEvent<T>).targetID !== undefined;
+}
+
+// TODO Eventually convert this back from string to EventType (once the edge cases of raw string filters are removed)
+export interface Event<T extends string> {
+  type: T;
   timestamp: number;
 }
-export interface BeginCastEvent extends Event {
-  type: EventType.BeginCast;
-
+export interface BeginCastEvent extends Event<EventType.BeginCast> {
   ability: Ability;
   castEvent: CastEvent;
   channel: {
@@ -109,31 +121,24 @@ export interface BeginCastEvent extends Event {
   target: { name: 'Environment'; id: -1; guid: 0; type: 'NPC'; icon: 'NPC' };
   targetIsFriendly: boolean;
 }
-export interface BeginChannelEvent extends Event {
-  type: EventType.BeginChannel;
+export interface BeginChannelEvent extends Event<EventType.BeginChannel> {
   ability: Ability;
   sourceID: number;
   isCancelled: boolean;
 }
-export interface EndChannelEvent extends Event {
-  type: EventType.EndChannel;
+export interface EndChannelEvent extends Event<EventType.EndChannel> {
   ability: Ability;
   sourceID: number;
   start: number;
   duration: number;
   beginChannel: BeginChannelEvent;
 }
-export interface CastEvent extends Event {
-  type: EventType.Cast | EventType.FilterCooldownInfo;
+export interface ICastEvent<T extends string> extends Event<T> {
   ability: Ability;
   absorb?: number;
   armor?: number;
   attackPower?: number;
-  classResources?: Array<
-    ClassResources & {
-      cost: number;
-    }
-  >;
+  classResources?: Array<ClassResources & {cost: number}>;
   facing?: number;
   hitPoints?: number;
   itemLevel?: number;
@@ -167,14 +172,12 @@ export interface CastEvent extends Event {
     enhancedCastReason?: React.ReactNode;
   };
 }
-export interface FilterCooldownInfoEvent extends CastEvent{
-  type: EventType.FilterCooldownInfo;
-
+export interface CastEvent extends ICastEvent<EventType.Cast> {}
+export interface FilterCooldownInfoEvent extends ICastEvent<EventType.FilterCooldownInfo> {
   trigger: EventType;
 }
-export interface HealEvent extends Event {
-  type: EventType.Heal;
 
+export interface HealEvent extends Event<EventType.Heal> {
   sourceID: number;
   sourceIsFriendly: boolean;
   targetID: number;
@@ -206,9 +209,7 @@ export interface BeaconHealEvent extends Omit<HealEvent, 'type'> {
   type: EventType.BeaconTransfer,
   originalHeal: HealEvent,
 }
-export interface AbsorbedEvent extends Event {
-  type: EventType.Absorbed;
-
+export interface AbsorbedEvent extends Event<EventType.Absorbed> {
   sourceID: number;
   sourceIsFriendly: boolean;
   targetID: number;
@@ -226,9 +227,7 @@ export interface AbsorbedEvent extends Event {
   amount: number;
   extraAbility: Ability;
 }
-export interface DamageEvent extends Event {
-  type: EventType.Damage;
-
+export interface DamageEvent extends Event<EventType.Damage> {
   source?: { name: 'Environment'; id: -1; guid: 0; type: 'NPC'; icon: 'NPC' };
   sourceID?: number;
   sourceIsFriendly: true;
@@ -257,9 +256,8 @@ export interface DamageEvent extends Event {
   tick?: boolean;
   overkill?: number;
 }
-export interface BuffEvent extends Event {}
-export interface ApplyBuffEvent extends BuffEvent {
-  type: EventType.ApplyBuff;
+export interface BuffEvent<T extends string> extends Event<T> {}
+export interface ApplyBuffEvent extends BuffEvent<EventType.ApplyBuff> {
   ability: Ability;
   sourceID: number;
   sourceIsFriendly: boolean;
@@ -268,8 +266,7 @@ export interface ApplyBuffEvent extends BuffEvent {
   targetInstance?: number;
   absorb?: number;
 }
-export interface ApplyDebuffEvent extends BuffEvent {
-  type: EventType.ApplyDebuff;
+export interface ApplyDebuffEvent extends BuffEvent<EventType.ApplyDebuff> {
   ability: Ability;
   source?: { name: 'Environment'; id: -1; guid: 0; type: 'NPC'; icon: 'NPC' };
   sourceID?: number;
@@ -279,8 +276,7 @@ export interface ApplyDebuffEvent extends BuffEvent {
   targetInstance?: number;
   absorb?: number;
 }
-export interface RemoveBuffEvent extends BuffEvent {
-  type: EventType.RemoveBuff;
+export interface RemoveBuffEvent extends BuffEvent<EventType.RemoveBuff> {
   ability: Ability;
   sourceID: number;
   sourceIsFriendly: boolean;
@@ -289,8 +285,7 @@ export interface RemoveBuffEvent extends BuffEvent {
   targetInstance?: number;
   absorb?: number;
 }
-export interface RemoveDebuffEvent extends BuffEvent {
-  type: EventType.RemoveDebuff;
+export interface RemoveDebuffEvent extends BuffEvent<EventType.RemoveDebuff> {
   ability: Ability;
   source?: { name: 'Environment'; id: -1; guid: 0; type: 'NPC'; icon: 'NPC' };
   sourceID?: number;
@@ -300,9 +295,7 @@ export interface RemoveDebuffEvent extends BuffEvent {
   targetIsFriendly: boolean;
   absorb?: number;
 }
-export interface ApplyBuffStackEvent extends BuffEvent {
-  type: EventType.ApplyBuffStack;
-
+export interface ApplyBuffStackEvent extends BuffEvent<EventType.ApplyBuffStack> {
   sourceID: number;
   sourceIsFriendly: boolean;
   targetID: number;
@@ -310,9 +303,7 @@ export interface ApplyBuffStackEvent extends BuffEvent {
   ability: Ability;
   stack: number;
 }
-export interface ApplyDebuffStackEvent extends BuffEvent {
-  type: EventType.ApplyDebuffStack;
-
+export interface ApplyDebuffStackEvent extends BuffEvent<EventType.ApplyDebuffStack> {
   sourceID: number;
   sourceIsFriendly: boolean;
   targetID: number;
@@ -320,9 +311,7 @@ export interface ApplyDebuffStackEvent extends BuffEvent {
   ability: Ability;
   stack: number;
 }
-export interface RemoveBuffStackEvent extends BuffEvent {
-  type: EventType.RemoveBuffStack;
-
+export interface RemoveBuffStackEvent extends BuffEvent<EventType.RemoveBuffStack> {
   sourceID: number;
   sourceIsFriendly: boolean;
   targetID: number;
@@ -330,9 +319,7 @@ export interface RemoveBuffStackEvent extends BuffEvent {
   ability: Ability;
   stack: number;
 }
-export interface ChangeBuffStackEvent extends BuffEvent {
-  type: EventType.ChangeBuffStack;
-
+export interface ChangeBuffStackEvent extends BuffEvent<EventType.ChangeBuffStack> {
   ability: Ability;
   end?: number;
   isDebuff?: boolean;
@@ -364,9 +351,7 @@ export interface ChangeBuffStackEvent extends BuffEvent {
     type: string;
   };
 }
-export interface RemoveDebuffStackEvent extends BuffEvent {
-  type: EventType.RemoveBuffStack;
-
+export interface RemoveDebuffStackEvent extends BuffEvent<EventType.RemoveDebuffStack> {
   sourceID: number;
   sourceIsFriendly: boolean;
   targetID: number;
@@ -374,9 +359,7 @@ export interface RemoveDebuffStackEvent extends BuffEvent {
   ability: Ability;
   stack: number;
 }
-export interface RefreshBuffEvent extends BuffEvent {
-  type: EventType.RefreshBuff;
-
+export interface RefreshBuffEvent extends BuffEvent<EventType.RefreshBuff> {
   source?: { name: 'Environment'; id: -1; guid: 0; type: 'NPC'; icon: 'NPC' };
   sourceID?: number;
   sourceIsFriendly: boolean;
@@ -384,9 +367,7 @@ export interface RefreshBuffEvent extends BuffEvent {
   targetIsFriendly: boolean;
   ability: Ability;
 }
-export interface RefreshDebuffEvent extends BuffEvent {
-  type: EventType.RefreshDebuff;
-
+export interface RefreshDebuffEvent extends BuffEvent<EventType.RefreshDebuff> {
   source?: { name: 'Environment'; id: -1; guid: 0; type: 'NPC'; icon: 'NPC' };
   sourceID?: number;
   sourceIsFriendly: boolean;
@@ -395,8 +376,7 @@ export interface RefreshDebuffEvent extends BuffEvent {
   targetIsFriendly: boolean;
   ability: Ability;
 }
-export interface EnergizeEvent extends Event {
-  type: EventType.Energize;
+export interface EnergizeEvent extends Event<EventType.Energize> {
   ability: Ability;
   sourceID: number;
   sourceIsFriendly: boolean;
@@ -419,16 +399,14 @@ export interface EnergizeEvent extends Event {
   mapID: number;
   itemLevel: number;
 }
-export interface DeathEvent extends Event {
-  type: EventType.Death;
+export interface DeathEvent extends Event<EventType.Death> {
   source: { name: 'Environment'; id: -1; guid: 0; type: 'NPC'; icon: 'NPC' };
   sourceIsFriendly: boolean;
   targetID: number;
   targetIsFriendly: boolean;
   ability: Ability;
 }
-export interface SummonEvent extends Event {
-  type: EventType.Summon;
+export interface SummonEvent extends Event<EventType.Summon> {
   sourceID: number;
   sourceIsFriendly: boolean;
   target: {
@@ -445,8 +423,7 @@ export interface SummonEvent extends Event {
   ability: Ability;
 }
 
-export interface GlobalCooldownEvent extends Event {
-  type: EventType.GlobalCooldown;
+export interface GlobalCooldownEvent extends Event<EventType.GlobalCooldown> {
   ability: Ability;
   duration: number;
   sourceID: number;
@@ -455,13 +432,11 @@ export interface GlobalCooldownEvent extends Event {
   trigger: CastEvent;
   __fabricated: true;
 }
-export interface FightEndEvent extends Event {
-  type: EventType.FightEnd;
+export interface FightEndEvent extends Event<EventType.FightEnd> {
   timestamp: number;
   __fabricated: true;
 }
-export interface UpdateSpellUsableEvent extends Event {
-  type: EventType.UpdateSpellUsable;
+export interface UpdateSpellUsableEvent extends Event<EventType.UpdateSpellUsable> {
   ability: Ability;
   name: string
   trigger: EventType.BeginCooldown | EventType.EndCooldown | EventType.RefreshCooldown | EventType.AddCooldownCharge | EventType.RestoreCharge;
@@ -499,7 +474,8 @@ export interface Stats {
   versatility: number
 }
 
-export interface ChangeStatsEvent extends Event {
+// TODO `type` was not set here before? confirm that it should be set
+export interface ChangeStatsEvent extends Event<EventType.ChangeStats> {
   targetID: number
   trigger: any
   after: Stats
@@ -507,18 +483,13 @@ export interface ChangeStatsEvent extends Event {
   delta: Stats
 }
 
-export interface PhaseEvent extends Event {
+export interface IPhaseEvent<T extends string> extends Event<T> {
   phase: PhaseConfig;
   __fabricated: true;
 }
-
-export interface PhaseStartEvent extends PhaseEvent {
-  type: EventType.PhaseStart;
-}
-
-export interface PhaseEndEvent extends PhaseEvent {
-  type: EventType.PhaseEnd;
-}
+export interface PhaseEvent extends IPhaseEvent<EventType.PhaseStart | EventType.PhaseEnd> {}
+export interface PhaseStartEvent extends IPhaseEvent<EventType.PhaseStart> {}
+export interface PhaseEndEvent extends IPhaseEvent<EventType.PhaseEnd> {}
 
 export interface Item {
   id: number;
@@ -553,8 +524,7 @@ export interface Trait {
   isMajor: boolean;
 }
 
-export interface CombatantInfoEvent extends Event {
-  type: EventType.CombatantInfo;
+export interface CombatantInfoEvent extends Event<EventType.CombatantInfo> {
   pin: string;
   sourceID: number;
   gear: Array<Item>;

--- a/src/parser/core/EventsNormalizer.ts
+++ b/src/parser/core/EventsNormalizer.ts
@@ -1,20 +1,19 @@
-import { EventType } from 'parser/core/Events';
-
+import { Event, EventType } from 'parser/core/Events';
 import Module from './Module';
 
 class EventsNormalizer extends Module {
   /**
-   * The combatlog has a lot of issues that make it harder to analyzer things. You can use this to normalize the log, for example by changing the order of events to match reality (e.g. a heal should never be logged before the cast event that triggers it, but Blizzard don't care about no logic).
+   * The combatlog has a lot of issues that make it harder to analyze things. You can use this to normalize the log, for example by changing the order of events to match reality (e.g. a heal should never be logged before the cast event that triggers it, but Blizzard don't care about no logic).
    * Caution: advanced usage, this should only be used as an exception.
    * @param {Array} events
    * @returns {Array}
    */
-  normalize(events) {
+  normalize(events: Array<Event<any>>): Array<Event<any>> {
     return events;
   }
 
   // Convenience methods
-  getFightStartIndex(events) {
+  getFightStartIndex(events: Array<Event<any>>): number {
     for (let i = 0; i < events.length; i += 1) {
       const event = events[i];
       if (event.type !== EventType.CombatantInfo) {

--- a/src/parser/core/Fight.ts
+++ b/src/parser/core/Fight.ts
@@ -1,0 +1,23 @@
+export interface Fight {
+  filtered?: boolean;
+  phase?: string;
+  instance?: number;
+  // eslint-disable-next-line camelcase
+  offset_time: number;
+  // eslint-disable-next-line camelcase
+  original_end_time: number;
+
+  // Below are WCL properties, above are generated or applied properties
+  id: number,
+  // eslint-disable-next-line camelcase
+  start_time: number,
+  // eslint-disable-next-line camelcase
+  end_time: number,
+  boss: number,
+  name: string,
+  size?: number,
+  difficulty?: number,
+  kill?: boolean,
+}
+
+export default Fight;

--- a/src/parser/core/modules/Abilities.ts
+++ b/src/parser/core/modules/Abilities.ts
@@ -1,5 +1,6 @@
 import Module from 'parser/core/Module';
 
+import { Event } from '../Events';
 import Ability, { SpellbookAbility } from './Ability';
 import AbilityTracker from '../../shared/modules/AbilityTracker';
 import Haste from '../../shared/modules/Haste';
@@ -83,7 +84,7 @@ class Abilities extends Module {
   /**
    * Returns the expected cooldown (in seconds) of the given spellId at the current timestamp (or undefined if there is no such spellInfo)
    */
-  getExpectedCooldownDuration(spellId: number, cooldownTriggerEvent: Event | undefined) {
+  getExpectedCooldownDuration(spellId: number, cooldownTriggerEvent: Event<any> | undefined) {
     const ability = this.getAbility(spellId);
     return ability ? Math.round(ability.getCooldown(this.haste.current, cooldownTriggerEvent) * 1000) : undefined;
   }

--- a/src/parser/core/modules/Abilities.ts
+++ b/src/parser/core/modules/Abilities.ts
@@ -1,6 +1,6 @@
 import Module from 'parser/core/Module';
 
-import Ability from './Ability';
+import Ability, { SpellbookAbility } from './Ability';
 import AbilityTracker from '../../shared/modules/AbilityTracker';
 import Haste from '../../shared/modules/Haste';
 
@@ -9,10 +9,10 @@ class Abilities extends Module {
     abilityTracker: AbilityTracker,
     haste: Haste,
   };
-  /** @property {AbilityTracker} */
-  abilityTracker;
-  /** @property {Haste} */
-  haste;
+  abilityTracker!: AbilityTracker;
+  haste!: Haste;
+
+  // TODO - Enum?
   static SPELL_CATEGORIES = {
     ROTATIONAL: 'Rotational Spell',
     ROTATIONAL_AOE: 'Spell (AOE)',
@@ -32,20 +32,20 @@ class Abilities extends Module {
    * This will be called *once* during initialization. See the Ability class for the available properties. This should contain ALL spells available to a player of your spec, including utility such as interrupts, dispells, etc
    * @returns {object[]}
    */
-  spellbook() {
+  spellbook(): Array<SpellbookAbility> {
     // This list will NOT be recomputed during the fight. If a cooldown changes based on something like Haste or a Buff you need to put it in a function.
     // While you can put checks for talents/traits outside of the cooldown prop, you generally should aim to keep everything about a single spell together. In general only move a prop up if you're regularly checking for the same talent/trait in multiple spells.
     return [];
   }
 
-  abilities = [];
-  activeAbilities = [];
-  constructor(...args) {
-    super(...args);
+  abilities: Array<Ability> = [];
+  activeAbilities: Array<Ability> = [];
+  constructor(args: any) {
+    super(args);
     this.loadSpellbook(this.spellbook());
   }
-  loadSpellbook(spellbook) {
-    this.abilities = spellbook.map(options => new this.constructor.ABILITY_CLASS(this, options));
+  loadSpellbook(spellbook: Array<SpellbookAbility>) {
+    this.abilities = spellbook.map(options => new Ability(this, options));
     this.activeAbilities = this.abilities.filter(ability => ability.enabled);
   }
 
@@ -53,8 +53,8 @@ class Abilities extends Module {
    * Add an ability to the list of active abilities.
    * @param {object} options An object with all the properties and their values that gets passed to the Ability class.
    */
-  add(options) {
-    const ability = new this.constructor.ABILITY_CLASS(this, options);
+  add(options: SpellbookAbility) {
+    const ability = new Ability(this, options);
     this.abilities.push(ability);
     this.activeAbilities.push(ability);
   }
@@ -64,7 +64,7 @@ class Abilities extends Module {
    *
    * @return {Ability}
    */
-  getAbility(spellId) {
+  getAbility(spellId: number) {
     const ability = this.activeAbilities.find(ability => {
       if (ability.spell instanceof Array) {
         return ability.spell.some(spell => spell.id === spellId);
@@ -83,7 +83,7 @@ class Abilities extends Module {
   /**
    * Returns the expected cooldown (in seconds) of the given spellId at the current timestamp (or undefined if there is no such spellInfo)
    */
-  getExpectedCooldownDuration(spellId, cooldownTriggerEvent) {
+  getExpectedCooldownDuration(spellId: number, cooldownTriggerEvent: Event | undefined) {
     const ability = this.getAbility(spellId);
     return ability ? Math.round(ability.getCooldown(this.haste.current, cooldownTriggerEvent) * 1000) : undefined;
   }
@@ -91,7 +91,7 @@ class Abilities extends Module {
   /**
    * Returns the max charges of the given spellId, or 1 if the spell doesn't have charges (or undefined if there is no such spellInfo)
    */
-  getMaxCharges(spellId) {
+  getMaxCharges(spellId: number) {
     const ability = this.getAbility(spellId);
     return ability ? (ability.charges || 1) : undefined;
   }
@@ -99,7 +99,7 @@ class Abilities extends Module {
   /**
    * Returns the timeline sort index, or null if none is set. (or undefined if there is no such spellInfo)
    */
-  getTimelineSortIndex(spellId) {
+  getTimelineSortIndex(spellId: number) {
     const ability = this.getAbility(spellId);
     return ability ? ability.timelineSortIndex : undefined;
   }

--- a/src/parser/core/modules/Ability.ts
+++ b/src/parser/core/modules/Ability.ts
@@ -415,7 +415,7 @@ class Ability {
   };
   charges = 1;
   enabled = true;
-  timelineSortIndex = null;
+  timelineSortIndex: number | null = null;
   /** @deprecated Use the Buffs module to define your buffs instead. If your spec has no Buffs module, this prop will be used to prefill it. */
   buffSpellId = null;
   shownSpell = null;

--- a/src/parser/core/modules/Ability.ts
+++ b/src/parser/core/modules/Ability.ts
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import CombatLogParser from 'parser/core/CombatLogParser';
 import Combatant from 'parser/core/Combatant';
-
+import { Event } from '../Events';
 import Abilities from './Abilities';
 
 export interface AbilityTrackerAbility {
@@ -61,7 +61,7 @@ export interface SpellbookAbility {
    * for more complicated calls or even to check for buffs. Parameters
    * provided: `hastePercentage`, `selectedCombatant`
    */
-  cooldown?: ((haste: number, trigger?: Event) => number) | number;
+  cooldown?: ((haste: number, trigger?: Event<any>) => number) | number;
   /**
    * NYI, do not use
    */
@@ -367,7 +367,7 @@ class Ability {
   get cooldown() {
     return this.getCooldown(this.owner.haste.current);
   }
-  getCooldown(haste: number, cooldownTriggerEvent?: Event) {
+  getCooldown(haste: number, cooldownTriggerEvent?: Event<any>) {
     if (this._cooldown === undefined) {
       // Most abilities will always be active and don't provide this prop at all
       return 0;

--- a/src/parser/core/modules/Ability.ts
+++ b/src/parser/core/modules/Ability.ts
@@ -83,7 +83,8 @@ export interface SpellbookAbility {
         base?: number | ((combatant: Combatant) => number);
         minimum?: number | ((combatant: Combatant) => number);
       }
-    | ((combatant: Combatant) => number);
+    | ((combatant: Combatant) => number)
+    | null;
   castEfficiency?: {
     name?: string;
     /**

--- a/src/parser/core/modules/EventEmitter.ts
+++ b/src/parser/core/modules/EventEmitter.ts
@@ -292,11 +292,11 @@ class EventEmitter extends Module {
     console.error('Disabling', name, 'and child dependencies because an error occured:', err);
     // Disable this module and all active modules that have this as a dependency
     this.owner.deepDisable(module, ModuleError.EVENTS, err);
-    Sentry && Sentry.withScope(scope => {
+    window.Sentry && window.Sentry.withScope(scope => {
       scope.setTag('type', 'module_error');
       scope.setTag('spec', `${this.selectedCombatant.spec.specName} ${this.selectedCombatant.spec.className}`);
       scope.setExtra('module', name);
-      Sentry.captureException(err);
+      window.Sentry && window.Sentry.captureException(err);
     });
   }
 }

--- a/src/parser/core/modules/EventEmitter.ts
+++ b/src/parser/core/modules/EventEmitter.ts
@@ -292,13 +292,11 @@ class EventEmitter extends Module {
     console.error('Disabling', name, 'and child dependencies because an error occured:', err);
     // Disable this module and all active modules that have this as a dependency
     this.owner.deepDisable(module, ModuleError.EVENTS, err);
-    // @ts-ignore Sentry does not exist on window, need Sentry types
-    window.Sentry && window.Sentry.withScope(scope => {
+    Sentry && Sentry.withScope(scope => {
       scope.setTag('type', 'module_error');
       scope.setTag('spec', `${this.selectedCombatant.spec.specName} ${this.selectedCombatant.spec.className}`);
       scope.setExtra('module', name);
-      // @ts-ignore Sentry does not exist on window, need Sentry types
-      window.Sentry.captureException(err);
+      Sentry.captureException(err);
     });
   }
 }

--- a/src/parser/core/tests/integrationTest.ts
+++ b/src/parser/core/tests/integrationTest.ts
@@ -3,11 +3,12 @@ import renderer from 'react-test-renderer';
 import ParseResults from 'parser/core/ParseResults';
 import BaseChecklist from 'parser/shared/modules/features/Checklist/Module';
 
-import CombatLogParser from '../CombatLogParser';
+import CombatLogParser, { DependenciesDefinition } from '../CombatLogParser';
 import Module from '../Module';
 import Analyzer from '../Analyzer';
 import { loadLog, parseLog } from './log-tools';
 import { statistic } from './snapshotTest';
+import { ReactElement } from 'react';
 
 function integrationStatistic(analyzer: Analyzer, parser: CombatLogParser) {
   if (!analyzer.active) {
@@ -33,19 +34,23 @@ function integrationSuggestions(analyzer: Analyzer) {
 }
 
 function checklist(parser: CombatLogParser) {
-  const checklistModule = Object.values(
-    (parser.constructor as typeof CombatLogParser).specModules,
-  ).find(m => m.prototype instanceof BaseChecklist);
+  const checklistModule = Object.values((parser.constructor as typeof CombatLogParser).specModules)
+    .map(dep => {
+      if (dep instanceof Array) {
+        return dep[0] as typeof Module;
+      } else {
+        return dep as typeof Module;
+      }
+    })
+    .find(m => {
+      return m.prototype instanceof BaseChecklist;
+    });
   if (checklistModule === undefined) {
     return 'no checklist';
   }
-  const result = parser.getModule(checklistModule).render();
-  return renderer.create(result).toJSON();
+  const result = (parser.getModule(checklistModule) as BaseChecklist).render();
+  return renderer.create(result as unknown as ReactElement).toJSON();
 }
-
-type ModuleConfig = {
-  [key: string]: typeof Module | Array<typeof Module>;
-};
 
 /**
  * Generates an integration test for a spec's CombatLogParser instance.
@@ -96,7 +101,7 @@ export default function integrationTest(
 
     // TODO: Test Abilities, Buffs and other classes extending Module
 
-    const getAnalyzers = (moduleConfig: ModuleConfig) =>
+    const getAnalyzers = (moduleConfig: DependenciesDefinition) =>
       Object.values(moduleConfig)
         .map(moduleClass => {
           if (moduleClass instanceof Array) {
@@ -109,7 +114,7 @@ export default function integrationTest(
         // Normalizers have no output, their effects are irrelevant so long as the
         // results of analyzers stay the same
         .filter(moduleClass => moduleClass.prototype instanceof Analyzer);
-    const testAnalyzers = (moduleConfig: ModuleConfig) =>
+    const testAnalyzers = (moduleConfig: DependenciesDefinition) =>
       getAnalyzers(moduleConfig).forEach(moduleClass => {
         describe(moduleClass.name, () => {
           // We skip anything without output so that adding a new analyzer will

--- a/src/parser/core/tests/integrationTest.ts
+++ b/src/parser/core/tests/integrationTest.ts
@@ -1,4 +1,5 @@
 import renderer from 'react-test-renderer';
+import { ReactElement } from 'react';
 
 import ParseResults from 'parser/core/ParseResults';
 import BaseChecklist from 'parser/shared/modules/features/Checklist/Module';
@@ -8,7 +9,6 @@ import Module from '../Module';
 import Analyzer from '../Analyzer';
 import { loadLog, parseLog } from './log-tools';
 import { statistic } from './snapshotTest';
-import { ReactElement } from 'react';
 
 function integrationStatistic(analyzer: Analyzer, parser: CombatLogParser) {
   if (!analyzer.active) {

--- a/src/parser/demonhunter/havoc/CombatLogParser.ts
+++ b/src/parser/demonhunter/havoc/CombatLogParser.ts
@@ -94,7 +94,7 @@ class CombatLogParser extends CoreCombatLogParser {
     furyDetails: FuryDetails,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
-    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }],
+    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,
   };
 }
 

--- a/src/parser/hunter/beastmastery/modules/spells/BarbedShot.tsx
+++ b/src/parser/hunter/beastmastery/modules/spells/BarbedShot.tsx
@@ -96,7 +96,7 @@ class BarbedShot extends Analyzer {
     }
   }
 
-  handleStacks(event: RemoveBuffEvent | ApplyBuffEvent | ApplyBuffStackEvent | FightEndEvent) {
+  handleStacks(event: RemoveBuffEvent & ApplyBuffEvent & ApplyBuffStackEvent & FightEndEvent) {
     this.barbedShotStacks[this.lastBarbedShotStack].push(event.timestamp - this.lastBarbedShotUpdate);
     if (event.type === EventType.FightEnd) {
       return;

--- a/src/parser/hunter/beastmastery/modules/talents/ThrillOfTheHunt.tsx
+++ b/src/parser/hunter/beastmastery/modules/talents/ThrillOfTheHunt.tsx
@@ -55,7 +55,7 @@ class ThrillOfTheHunt extends Analyzer {
     return formatPercentage(averageCrit);
   }
 
-  handleStacks(event: RemoveBuffEvent | ApplyBuffEvent | ApplyBuffStackEvent | FightEndEvent) {
+  handleStacks(event: RemoveBuffEvent & ApplyBuffEvent & ApplyBuffStackEvent & FightEndEvent) {
     this.thrillStacks[this.lastThrillStack].push(event.timestamp - this.lastThrillUpdate);
     if (event.type === EventType.FightEnd) {
       return;

--- a/src/parser/hunter/marksmanship/CombatLogParser.tsx
+++ b/src/parser/hunter/marksmanship/CombatLogParser.tsx
@@ -115,7 +115,7 @@ class CombatLogParser extends CoreCombatLogParser {
     rapidReload: RapidReload,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
-    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }],
+    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,
   };
 }
 

--- a/src/parser/hunter/marksmanship/modules/spells/azeritetraits/InTheRhythm.tsx
+++ b/src/parser/hunter/marksmanship/modules/spells/azeritetraits/InTheRhythm.tsx
@@ -62,7 +62,7 @@ class InTheRhythm extends Analyzer {
     this.possibleApplications += 1;
   }
 
-  itrApplication(event: ApplyBuffEvent | RefreshBuffEvent) {
+  itrApplication(event: ApplyBuffEvent & RefreshBuffEvent) {
     this.applications += 1;
     if(event.type === EventType.RefreshBuff) {
       this.wastedUptime += DURATION - (event.timestamp - this.lastApplicationTimestamp);

--- a/src/parser/hunter/marksmanship/modules/spells/azeritetraits/SteadyAim.tsx
+++ b/src/parser/hunter/marksmanship/modules/spells/azeritetraits/SteadyAim.tsx
@@ -53,7 +53,7 @@ class SteadyAim extends Analyzer {
     }
   }
 
-  onDebuffChange(event: ApplyDebuffEvent | ApplyDebuffStackEvent | RemoveDebuffEvent) {
+  onDebuffChange(event: ApplyDebuffEvent & ApplyDebuffStackEvent & RemoveDebuffEvent) {
     if (event.type === EventType.RemoveDebuff) {
       this.removeDebuffTimestamp = event.timestamp;
       this.aimedShotStacks = this._stacks;

--- a/src/parser/hunter/survival/CombatLogParser.ts
+++ b/src/parser/hunter/survival/CombatLogParser.ts
@@ -124,7 +124,7 @@ class CombatLogParser extends CoreCombatLogParser {
     memoryOfLucidDreams: MemoryOfLucidDreams,
 
     // Survival's throughput benefit isn't as big as for other classes
-    arcaneTorrent: [ArcaneTorrent, { castEfficiency: 0.5 }],
+    arcaneTorrent: [ArcaneTorrent, { castEfficiency: 0.5 }] as const,
   };
 }
 

--- a/src/parser/hunter/survival/modules/spells/azeritetraits/BlurOfTalons.tsx
+++ b/src/parser/hunter/survival/modules/spells/azeritetraits/BlurOfTalons.tsx
@@ -74,7 +74,7 @@ class BlurOfTalons extends Analyzer {
     return avgAgi;
   }
 
-  handleStacks(event: RemoveBuffEvent | ApplyBuffEvent | ApplyBuffStackEvent | FightEndEvent) {
+  handleStacks(event: RemoveBuffEvent & ApplyBuffEvent & ApplyBuffStackEvent & FightEndEvent) {
     this.blurOfTalonStacks[this.lastBlurStack].push(event.timestamp - this.lastBlurUpdate);
     if (event.type === EventType.FightEnd) {
       return;

--- a/src/parser/hunter/survival/modules/spells/azeritetraits/LatentPoison.tsx
+++ b/src/parser/hunter/survival/modules/spells/azeritetraits/LatentPoison.tsx
@@ -43,7 +43,7 @@ class LatentPoison extends Analyzer {
     return this.utilised / this.casts;
   }
 
-  handleStacks(event: ApplyDebuffEvent | ApplyDebuffStackEvent | RemoveDebuffEvent) {
+  handleStacks(event: ApplyDebuffEvent & ApplyDebuffStackEvent & RemoveDebuffEvent) {
     if (event.type !== EventType.RemoveDebuff) {
       this.applications += 1;
     }

--- a/src/parser/hunter/survival/modules/spells/azeritetraits/PrimevalIntuition.tsx
+++ b/src/parser/hunter/survival/modules/spells/azeritetraits/PrimevalIntuition.tsx
@@ -73,7 +73,7 @@ class PrimevalIntuition extends Analyzer {
     return avgCrit;
   }
 
-  handleStacks(event: RemoveBuffEvent | ApplyBuffEvent | ApplyBuffStackEvent | FightEndEvent) {
+  handleStacks(event: RemoveBuffEvent & ApplyBuffEvent & ApplyBuffStackEvent & FightEndEvent) {
     this.intuitionStacks[this.lastIntuitionStack].push(event.timestamp - this.lastIntuitionUpdate);
     if (event.type === EventType.FightEnd) {
       return;

--- a/src/parser/hunter/survival/modules/talents/HydrasBite.tsx
+++ b/src/parser/hunter/survival/modules/talents/HydrasBite.tsx
@@ -51,7 +51,7 @@ class HydrasBite extends Analyzer {
     }
   }
 
-  onDebuffApplication(event: ApplyDebuffEvent | RefreshDebuffEvent) {
+  onDebuffApplication(event: ApplyDebuffEvent & RefreshDebuffEvent) {
     const target = encodeTargetString(event.targetID, event.targetInstance);
     if (this.mainTargets.includes(target)) {
       return;

--- a/src/parser/hunter/survival/modules/talents/MongooseBite.tsx
+++ b/src/parser/hunter/survival/modules/talents/MongooseBite.tsx
@@ -67,7 +67,7 @@ class MongooseBite extends Analyzer {
     this.damage += event.amount + (event.absorbed || 0);
   }
 
-  handleStacks(event: DamageEvent | ApplyBuffEvent | ApplyBuffStackEvent | RemoveBuffEvent) {
+  handleStacks(event: DamageEvent & ApplyBuffEvent & ApplyBuffStackEvent & RemoveBuffEvent) {
     this.lastMongooseBiteStack = currentStacks(event);
     if (this.lastMongooseBiteStack === MAX_STACKS) {
       this.fiveBiteWindows += 1;

--- a/src/parser/hunter/survival/modules/talents/WildfireInfusion/ShrapnelBomb.tsx
+++ b/src/parser/hunter/survival/modules/talents/WildfireInfusion/ShrapnelBomb.tsx
@@ -48,7 +48,7 @@ class ShrapnelBomb extends Analyzer {
     this.damage += event.amount + (event.absorbed || 0);
   }
 
-  onDebuffApplication(event: ApplyDebuffEvent | ApplyDebuffStackEvent) {
+  onDebuffApplication(event: ApplyDebuffEvent & ApplyDebuffStackEvent) {
     if (event.type === EventType.ApplyDebuff) {
       this.applications += 1;
     }

--- a/src/parser/hunter/survival/modules/talents/WildfireInfusion/VolatileBomb.tsx
+++ b/src/parser/hunter/survival/modules/talents/WildfireInfusion/VolatileBomb.tsx
@@ -66,7 +66,7 @@ class VolatileBomb extends Analyzer {
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell([SPELLS.VOLATILE_BOMB_WFI_DOT, SPELLS.VOLATILE_BOMB_WFI_IMPACT]), this.onBombDamage);
   }
 
-  _serpentApplication(event: ApplyDebuffEvent | RefreshDebuffEvent) {
+  _serpentApplication(event: ApplyDebuffEvent & RefreshDebuffEvent) {
     const enemy = this.enemies.getEntity(event);
     if (!enemy) {
       return;

--- a/src/parser/mage/fire/CombatLogParser.ts
+++ b/src/parser/mage/fire/CombatLogParser.ts
@@ -68,7 +68,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Talents
     mirrorImage: MirrorImage,
     arcaneIntellect: ArcaneIntellect,
-    runeOfPower: [RuneOfPower, { showStatistic: false, showSuggestion: false }],
+    runeOfPower: [RuneOfPower, { showStatistic: false, showSuggestion: false }] as const,
     kindling: Kindling,
     meteor: Meteor,
     meteorRune: MeteorRune,
@@ -81,7 +81,7 @@ class CombatLogParser extends CoreCombatLogParser {
     lucidDreams: LucidDreams,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
-    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }],
+    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,
   };
 }
 

--- a/src/parser/mage/fire/modules/features/CombustionSpellUsage.tsx
+++ b/src/parser/mage/fire/modules/features/CombustionSpellUsage.tsx
@@ -36,7 +36,7 @@ class CombustionSpellUsage extends Analyzer {
   }
 
   //Because Fireball has a longer cast time than Scorch, the player should never cast Fireball during Combustion.
-  fireballCasts(event: CastEvent | BeginCastEvent) {
+  fireballCasts(event: CastEvent & BeginCastEvent) {
     const hasCombustion = this.selectedCombatant.hasBuff(SPELLS.COMBUSTION.id);
 
     if (!hasCombustion) {
@@ -55,7 +55,7 @@ class CombustionSpellUsage extends Analyzer {
     }
   }
 
-  scorchCasts(event: CastEvent | BeginCastEvent) {
+  scorchCasts(event: CastEvent & BeginCastEvent) {
     const hasCombustion = this.selectedCombatant.hasBuff(SPELLS.COMBUSTION.id);
     const fireBlastCharges = this.spellUsable.chargesAvailable(SPELLS.FIRE_BLAST.id);
     const phoenixFlamesCharges = (this.spellUsable.chargesAvailable(SPELLS.PHOENIX_FLAMES_TALENT.id) || 0);

--- a/src/parser/mage/fire/modules/features/HotStreakPreCasts.tsx
+++ b/src/parser/mage/fire/modules/features/HotStreakPreCasts.tsx
@@ -60,7 +60,7 @@ class HotStreakPreCasts extends Analyzer {
 
   //Get the timestamp that Pyroclasm was removed. Because using Hot Streak involves casting Pyroblast, it isnt possible to tell if they hard casted Pyroblast immediately before using their Hot Streak Pyroblast.
   //So this is to check to see if the Pyroclasm proc was removed right before Hot Streak was removed.
-  onPyroclasmRemoved(event: RemoveBuffEvent | RemoveBuffStackEvent) {
+  onPyroclasmRemoved(event: RemoveBuffEvent & RemoveBuffStackEvent) {
     this.pyroclasmProcRemoved = event.timestamp;
   }
 

--- a/src/parser/mage/fire/modules/features/Pyroclasm.tsx
+++ b/src/parser/mage/fire/modules/features/Pyroclasm.tsx
@@ -47,14 +47,14 @@ class Pyroclasm extends Analyzer {
   }
 
   //Counts the number of times Pyroclasm was applied
-  onPyroclasmApplied(event: ApplyBuffEvent | ApplyBuffStackEvent) {
+  onPyroclasmApplied(event: ApplyBuffEvent & ApplyBuffStackEvent) {
     this.totalProcs += 1;
     this.buffAppliedEvent = event;
     debug && this.log("Buff Applied");
   }
 
   //Checks to see if Pyroclasm was removed because it was used (there was a non instant pyroblast within 250ms) or because it expired.
-  onPyroclasmRemoved(event: RemoveBuffEvent | RemoveBuffStackEvent) {
+  onPyroclasmRemoved(event: RemoveBuffEvent & RemoveBuffStackEvent) {
     if (!this.castEvent || !this.beginCastEvent) {
       return;
     }

--- a/src/parser/mage/fire/modules/traits/BlasterMaster.tsx
+++ b/src/parser/mage/fire/modules/traits/BlasterMaster.tsx
@@ -49,7 +49,7 @@ class BlasterMaster extends Analyzer {
     debug && this.log("Combustion Ended: " + this.stackCount + " stacks");
   }
 
-  onTraitStack(event: ApplyBuffEvent | ApplyBuffStackEvent) {
+  onTraitStack(event: ApplyBuffEvent & ApplyBuffStackEvent) {
     const buff: any = this.selectedCombatant.getBuff(SPELLS.BLASTER_MASTER_BUFF.id);
     if (buff && buff.stacks > this.stackCount) {
       this.stackCount = buff.stacks;

--- a/src/parser/mage/frost/CONFIG.tsx
+++ b/src/parser/mage/frost/CONFIG.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Sharrq, Dambroda } from 'CONTRIBUTORS';
+import Config from 'parser/Config';
 
 import SPECS from 'game/SPECS';
 import SPELLS from 'common/SPELLS';
@@ -9,7 +10,7 @@ import SpellLink from 'common/SpellLink';
 import NoIceLance from './icons/noicelance.jpg';
 import CHANGELOG from './CHANGELOG';
 
-export default {
+const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Sharrq, Dambroda],
   // The WoW client patch this spec was last updated to be fully compatible with.
@@ -49,3 +50,4 @@ export default {
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };
+export default config;

--- a/src/parser/mage/frost/CombatLogParser.ts
+++ b/src/parser/mage/frost/CombatLogParser.ts
@@ -30,7 +30,7 @@ import WaterElemental from './modules/features/WaterElemental';
 import LonelyWinter from './modules/talents/LonelyWinter';
 
 class CombatLogParser extends CoreCombatLogParser {
-  static specModules = {
+   static specModules = {
     checklist: Checklist,
     buffs: Buffs,
 
@@ -79,7 +79,7 @@ class CombatLogParser extends CoreCombatLogParser {
     coldSnap: ColdSnap,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
-    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }],
+    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,
   };
 }
 

--- a/src/parser/mage/frost/modules/features/BrainFreezeNoIL.tsx
+++ b/src/parser/mage/frost/modules/features/BrainFreezeNoIL.tsx
@@ -28,7 +28,7 @@ class BrainFreezeNoIL extends Analyzer {
 
   constructor(options: any) {
     super(options);
-    this.active = this.owner.builds.NO_IL.active;
+    this.active = !!this.owner.builds.NO_IL.active;
     this.hasGlacialSpike = this.selectedCombatant.hasTalent(SPELLS.GLACIAL_SPIKE_TALENT.id);
     this.hasEbonbolt = this.selectedCombatant.hasTalent(SPELLS.EBONBOLT_TALENT.id);
 

--- a/src/parser/mage/frost/modules/features/GlacialSpikeNoIL.tsx
+++ b/src/parser/mage/frost/modules/features/GlacialSpikeNoIL.tsx
@@ -28,7 +28,7 @@ class GlacialSpikeNoIL extends Analyzer {
 
   constructor(options: any) {
     super(options);
-    this.active = this.selectedCombatant.hasTalent(SPELLS.GLACIAL_SPIKE_TALENT.id) && this.owner.builds.NO_IL.active;
+    this.active = this.selectedCombatant.hasTalent(SPELLS.GLACIAL_SPIKE_TALENT.id) && !!this.owner.builds.NO_IL.active;
     this.hasIncantersFlow = this.selectedCombatant.hasTalent(SPELLS.INCANTERS_FLOW_TALENT.id);
     this.hasSplittingIce = this.selectedCombatant.hasTalent(SPELLS.SPLITTING_ICE_TALENT.id);
 

--- a/src/parser/mage/frost/modules/features/IceLanceNoIL.tsx
+++ b/src/parser/mage/frost/modules/features/IceLanceNoIL.tsx
@@ -27,7 +27,7 @@ class IceLanceNoIL extends Analyzer {
 
   constructor(options: any) {
     super(options);
-    this.active = this.owner.builds.NO_IL.active;
+    this.active = !!this.owner.builds.NO_IL.active;
     this.hasSplittingIce = this.selectedCombatant.hasTalent(SPELLS.SPLITTING_ICE_TALENT.id);
 
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.ICE_LANCE), this.onIceLanceCast);
@@ -47,7 +47,7 @@ class IceLanceNoIL extends Analyzer {
 
   onIceLanceDamage(event: DamageEvent) {
     const damageTarget = encodeTargetString(event.targetID, event.targetInstance);
-    
+
     if (this.hasSplittingIce && this.hadFingersFrostProc && this.iceLanceCastTarget !== damageTarget) {
       this.goodIceLance += 1;
     }

--- a/src/parser/mage/frost/modules/features/WintersChillNoIL.tsx
+++ b/src/parser/mage/frost/modules/features/WintersChillNoIL.tsx
@@ -27,7 +27,7 @@ class WintersChillNoIL extends Analyzer {
 
   constructor(options: any) {
     super(options);
-    this.active = this.owner.builds.NO_IL.active;
+    this.active = !!this.owner.builds.NO_IL.active;
 
     if (!this.active) {
       return;

--- a/src/parser/monk/brewmaster/CombatLogParser.ts
+++ b/src/parser/monk/brewmaster/CombatLogParser.ts
@@ -68,7 +68,7 @@ class CombatLogParser extends CoreCombatLogParser {
     mitigationCheck: MitigationCheck,
     spellUsable: SpellUsable,
     // There's no throughput benefit from casting Arcane Torrent on cooldown
-    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }],
+    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,
 
     // Features
     checklist: Checklist,

--- a/src/parser/paladin/protection/CombatLogParser.ts
+++ b/src/parser/paladin/protection/CombatLogParser.ts
@@ -46,7 +46,7 @@ class CombatLogParser extends CoreCombatLogParser {
     consecration: Consecration,
     mitigationcheck: MitigationCheck,
     //cooldownTracker: CooldownTracker,
-    
+
     // Azerite Traits
     inspiringVanguard: InspiringVanguard,
     lucidDreams: LucidDreams,
@@ -57,7 +57,7 @@ class CombatLogParser extends CoreCombatLogParser {
     seraphim: Seraphim,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
-    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }],
+    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,
   };
 }
 

--- a/src/parser/rogue/assassination/CombatLogParser.ts
+++ b/src/parser/rogue/assassination/CombatLogParser.ts
@@ -9,7 +9,7 @@ import SpellUsable from '../shared/SpellUsable';
 
 //Normalizers
 import GarroteNormalizer from './normalizers/GarroteNormalizer';
-import GarroteOpenerNormalizer from './normalizers/GarroteOpenerNormalizer'; 
+import GarroteOpenerNormalizer from './normalizers/GarroteOpenerNormalizer';
 
 import ComboPointDetails from '../shared/resources/ComboPointDetails';
 import ComboPointTracker from '../shared/resources/ComboPointTracker';
@@ -90,9 +90,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Traits
 
     // Racials
-    arcaneTorrent: [ArcaneTorrent, {
-      gcd: 1000,
-    }],
+    arcaneTorrent: [ArcaneTorrent, { gcd: 1000 }] as const,
   };
 }
 

--- a/src/parser/rogue/outlaw/CombatLogParser.ts
+++ b/src/parser/rogue/outlaw/CombatLogParser.ts
@@ -49,9 +49,9 @@ class CombatLogParser extends CoreCombatLogParser {
     spellEnergyCost: SpellEnergyCost,
 
     //Core
-    restlessBlades: RestlessBlades,    
+    restlessBlades: RestlessBlades,
     rollTheBonesCastTracker: RollTheBonesCastTracker,
-    
+
     //Items
 
     //Casts
@@ -73,7 +73,7 @@ class CombatLogParser extends CoreCombatLogParser {
       gcd: 1000,
       castEfficiency: 0.5,
       extraSuggestion: 'You should be using Arcane Torrent whenever you have a free GCD for it.',
-    }],
+    }] as const,
   };
 }
 

--- a/src/parser/rogue/subtlety/CombatLogParser.ts
+++ b/src/parser/rogue/subtlety/CombatLogParser.ts
@@ -42,7 +42,7 @@ class CombatLogParser extends CoreCombatLogParser {
     checklist: Checklist,
     alwaysBeCasting: AlwaysBeCasting,
     spellUsable: SpellUsable,
-    
+
     //Normalizers
     shurikenStormNormalizer: ShurikenStormNormalizer,
 
@@ -82,9 +82,7 @@ class CombatLogParser extends CoreCombatLogParser {
     perforate: Perforate,
 
     // Racials
-    arcaneTorrent: [ArcaneTorrent, {
-      gcd: 1000,
-    }],
+    arcaneTorrent: [ArcaneTorrent, { gcd: 1000 }] as const,
   };
 }
 

--- a/src/parser/shaman/enhancement/modules/talents/HotHand.tsx
+++ b/src/parser/shaman/enhancement/modules/talents/HotHand.tsx
@@ -6,7 +6,7 @@ import Statistic from 'interface/statistics/Statistic';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
-import Events, { BuffEvent, DamageEvent } from 'parser/core/Events';
+import Events, { ApplyBuffEvent, DamageEvent, RefreshBuffEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
 import ItemDamageDone from 'interface/ItemDamageDone';
 import ResourceGenerated from 'interface/others/ResourceGenerated';
@@ -55,7 +55,7 @@ class HotHand extends Analyzer {
     );
   }
 
-  onHotHandBuff(event: BuffEvent) {
+  onHotHandBuff(event: RefreshBuffEvent & ApplyBuffEvent) {
     this.hotHandCount += 1;
   }
 

--- a/src/parser/shaman/enhancement/modules/talents/Landslide.tsx
+++ b/src/parser/shaman/enhancement/modules/talents/Landslide.tsx
@@ -4,7 +4,7 @@ import SPELLS from 'common/SPELLS/index';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 
 import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
-import Events, { BuffEvent, DamageEvent } from 'parser/core/Events';
+import Events, { ApplyBuffEvent, DamageEvent, RefreshBuffEvent } from 'parser/core/Events';
 import Statistic from 'interface/statistics/Statistic';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
@@ -53,7 +53,7 @@ class Landslide extends Analyzer {
     );
   }
 
-  onLandslideBuff(event: BuffEvent) {
+  onLandslideBuff(event: ApplyBuffEvent & RefreshBuffEvent) {
     this.landslideCount += 1;
   }
 

--- a/src/parser/shared/modules/CastEfficiency.tsx
+++ b/src/parser/shared/modules/CastEfficiency.tsx
@@ -180,7 +180,7 @@ class CastEfficiency extends Analyzer {
   }
 
   private getTimeSpentOnGcd(spellId: number) {
-    const ability: Ability = this.abilities.getAbility(spellId);
+    const ability = this.abilities.getAbility(spellId);
 
     if (ability && ability.gcd) {
       const cdInfo = this.getCooldownInfo(ability);

--- a/src/parser/shared/modules/CooldownThroughputTracker.tsx
+++ b/src/parser/shared/modules/CooldownThroughputTracker.tsx
@@ -34,7 +34,7 @@ export type CooldownSpell = {
 type TrackedCooldown = CooldownSpell & {
   start: number,
   end: number | null,
-  events: Array<Event>,
+  events: Array<Event<any>>,
 };
 
 class CooldownThroughputTracker extends Analyzer {
@@ -76,7 +76,7 @@ class CooldownThroughputTracker extends Analyzer {
   }
 
   addCooldown(cooldownSpell: CooldownSpell, timestamp: number): TrackedCooldown {
-    let events: Array<Event> = [];
+    let events: Array<Event<any>> = [];
     let start = timestamp;
     const startBufferMS = cooldownSpell.startBufferMS;
     if (startBufferMS || cooldownSpell.startBufferEvents) {

--- a/src/parser/shared/modules/EventHistory.ts
+++ b/src/parser/shared/modules/EventHistory.ts
@@ -11,8 +11,8 @@ class EventHistory extends Module {
    * @param filterDef an optional EventFilter to apply to all events
    * @returns the last `count` events that match the given filters, with the oldest events first
    */
-  public last(count?: number, maxTime?: number, filterDef?: EventFilter<string>): Array<Event> {
-    let filter = (event: any) => {
+  public last<ET extends string, E extends Event<ET>>(count?: number, maxTime?: number, filterDef?: EventFilter<ET>): Array<E> {
+    let filter = (event: Event<any>) => {
       return true;
     };
 
@@ -79,10 +79,9 @@ class EventHistory extends Module {
     if (count && count < history.length) {
       history = history.slice(-count);
     }
-    return history;
+    return history as Array<E>;
   }
 
 }
-
 
 export default EventHistory;

--- a/src/parser/shared/modules/SpellHistory.ts
+++ b/src/parser/shared/modules/SpellHistory.ts
@@ -1,4 +1,5 @@
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Abilities from 'parser/core/modules/Abilities';
 import Channeling from 'parser/shared/modules/Channeling';
 import Events, {
   ApplyBuffEvent,
@@ -11,7 +12,6 @@ import Events, {
 } from 'parser/core/Events';
 
 import SpellUsable from './SpellUsable';
-import Abilities from '../../core/modules/Abilities';
 
 class SpellHistory extends Analyzer {
   static dependencies = {

--- a/src/parser/shared/modules/SpellHistory.ts
+++ b/src/parser/shared/modules/SpellHistory.ts
@@ -74,13 +74,13 @@ class SpellHistory extends Analyzer {
 
   private append(
     event:
-      | BeginCastEvent
-      | CastEvent
-      | BeginChannelEvent
-      | EndChannelEvent
-      | ApplyBuffEvent
-      | RemoveBuffEvent
-      | UpdateSpellUsableEvent,
+      & BeginCastEvent
+      & CastEvent
+      & BeginChannelEvent
+      & EndChannelEvent
+      & ApplyBuffEvent
+      & RemoveBuffEvent
+      & UpdateSpellUsableEvent,
   ) {
     const spellId = event.ability.guid;
     const history = this.getAbility(spellId);

--- a/src/parser/shared/modules/spells/bfa/corruptions/FlashOfInsight.tsx
+++ b/src/parser/shared/modules/spells/bfa/corruptions/FlashOfInsight.tsx
@@ -40,7 +40,7 @@ class FlashOfInsight extends Analyzer {
     this.timestamp = this.owner.fight.start_time;
   }
 
-  stackChange(event: ApplyBuffStackEvent | RemoveBuffStackEvent) {
+  stackChange(event: ApplyBuffStackEvent & RemoveBuffStackEvent) {
     if (this.stack === 0) {
       this.statTracker.addStatMultiplier({ intellect: (1 + event.stack / 100) }, false);
       this.stack = event.stack;

--- a/src/parser/warlock/affliction/CombatLogParser.ts
+++ b/src/parser/warlock/affliction/CombatLogParser.ts
@@ -85,7 +85,7 @@ class CombatLogParser extends CoreCombatLogParser {
     pandemicInvocation: PandemicInvocation,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
-    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }],
+    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,
   };
 }
 

--- a/src/parser/warlock/demonology/CombatLogParser.ts
+++ b/src/parser/warlock/demonology/CombatLogParser.ts
@@ -106,7 +106,7 @@ class CombatLogParser extends CoreCombatLogParser {
     balefulInvocation: BalefulInvocation,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
-    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }],
+    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,
   };
 }
 

--- a/src/parser/warlock/destruction/CombatLogParser.ts
+++ b/src/parser/warlock/destruction/CombatLogParser.ts
@@ -87,7 +87,7 @@ class CombatLogParser extends CoreCombatLogParser {
     chaosShards: ChaosShards,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
-    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }],
+    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,
   };
 }
 

--- a/src/parser/warrior/protection/CombatLogParser.ts
+++ b/src/parser/warrior/protection/CombatLogParser.ts
@@ -79,7 +79,7 @@ class CombatLogParser extends CoreCombatLogParser {
     lucidDreamsRage: LucidDreamsRage,
 
     // Doesn't generate enough rage to be a valid cast
-    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }],
+    arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,
   };
 }
 

--- a/src/raids/index.ts
+++ b/src/raids/index.ts
@@ -1,13 +1,27 @@
+import { Race } from 'parser/core/Combatant';
+
 interface Raid {
   bosses: Array<Boss>,
 }
-
-type Boss = {
+export type Boss = {
   id: number,
-  fight: any,
-
+  name: string,
+  background?: string,
+  headshot?: string,
+  icon?: string,
+  fight: EncounterConfig,
 }
-
+type EncounterConfig = {
+  vantusRuneBuffId?: number,
+  softMitigationChecks?: {
+    physical: [],
+    magical: [],
+  },
+  phases?: { [key: string]: PhaseConfig },
+  raceTranslation?: (race: Race, spec: any) => Race,
+  disableDeathSuggestion?: boolean,
+  disableDowntimeSuggestion?: boolean,
+}
 export interface PhaseConfig {
   name: string,
   key: string,
@@ -16,7 +30,6 @@ export interface PhaseConfig {
   multiple?: boolean,
   instance?: number,
 }
-
 export interface Phase extends PhaseConfig {
   start: number[],
   end: number[],
@@ -33,11 +46,15 @@ const raids = {
 };
 export default raids;
 
-export function findByBossId(id:number) : Boss|null {
-  let boss = null;
+export function findByBossId(id: number): Boss | null {
+  let boss: Boss | null = null;
   Object.values(raids).some((raid: Raid) => {
-    boss = Object.values(raid.bosses).find(boss => boss.id === id);
-    return !!boss; // this breaks the loop early once we find a boss
+    const match = Object.values(raid.bosses).find(boss => boss.id === id);
+    if (match) {
+      boss = match;
+      return true;
+    }
+    return false;
   });
   return boss;
 }

--- a/types/sentry.d.ts
+++ b/types/sentry.d.ts
@@ -2,5 +2,5 @@ import * as SentryType from '@sentry/browser';
 
 declare global {
   // May be undefined when adblockers block Sentry (for privacy concerns)
-  const Sentry: typeof SentryType | undefined;
+  interface Window { Sentry: typeof SentryType | undefined }
 }

--- a/types/sentry.d.ts
+++ b/types/sentry.d.ts
@@ -1,0 +1,6 @@
+import * as SentryType from '@sentry/browser';
+
+declare global {
+  // May be undefined when adblockers block Sentry (for privacy concerns)
+  const Sentry: typeof SentryType | undefined;
+}


### PR DESCRIPTION
Details:

- Initial conversion of CombatLogParser to TypeScript. I put in a lot of types, but some I left for later. 
- addEventListener is *very* strict; see below:

Event Listener Changes
---

```javascript
addEventListener<ET extends string, E extends Event<ET>>(eventFilter: ET | EventFilter<ET>, listener: EventListener<ET, E>, module: Module) {
```
"what the fuck?" Right you would be, stuff is a bit weird on the back end for this. For maintainers, you should see basically no differences in how you write your code. Differences below.

**Your event listeners are now type-checked against the filter you provide** (if you're writing your module in TypeScript, of course).
```javascript
{ 
  addEventListener(Events.damage, this.onDamage);
}

// Works, you're allowed to ignore the event parameter completely
onDamage() {}

// Works, just as before
onDamage(event: DamageEvent) {}

// ERROR: TypeScript will yell at you for providing an EventListener that takes a different event type as a parameter
onDamage(event: CastEvent) {}

```

**When using a single event listener for multiple event types, you need to be more strict with your parameter union type** (if you're writing your module in TypeScript, of course).
```javascript
{ 
  addEventListener(Events.damage, this.trackEvent);
  addEventListener(Events.cast, this.trackEvent);
  addEventListener(Events.applybuff, this.trackEvent);
}

// Works, you're allowed to ignore the event parameter completely
onDamage() {}

// ERROR: the second two calls to addEventListener will be highlighted because the event listener provided doesn't have a signature that they will accept
onDamage(event: DamageEvent) {}

// ERROR: this was the previous way, but isn't strict enough to match.. but it's easy to change (below)
onDamage(event: DamageEvent | CastEvent | ApplyBuffEvent) {}

// Works! This ensures that any properties of the event that you use in your event listener exist on all of the provided event types
onDamage(event: DamageEvent & CastEvent & ApplyBuffEvent) {}

// If you want a property that's specific to one event type of the ones provided, you can still do things like this:
onDamage(event: DamageEvent & CastEvent & ApplyBuffEvent) {
  if(event.type === EventType.Damage) {
    const damage = (event as DamageEvent).amount;
  }
}
// Of course, you should still consider just creating a separate event listener for that event type if it wouldn't lead to a lot of duplicated code
```