### PR TITLE
Atonement Applicator Breakdown bugfix

### DIFF
--- a/src/parser/priest/discipline/CHANGELOG.js
+++ b/src/parser/priest/discipline/CHANGELOG.js
@@ -8,6 +8,7 @@ import ITEMS from 'common/ITEMS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 7, 20), <>Fixed a bug where the <SpellLink id={SPELLS.ATONEMENT_BUFF.id} /> Applicator Breakdown chart would sometimes not load due to an error.</>, [Tiphess]),
   change(date(2020, 6, 20), <>Updated spell calculation tests to reflect <SpellLink id={SPELLS.ATONEMENT_BUFF.id} /> coefficent adjustment for 8.3.</>, Putro),
   change(date(2020, 6, 3), <>Added an <SpellLink id={SPELLS.ATONEMENT_BUFF.id} /> applicator breakdown chart.</>, [Tiphess]),
   change(date(2020, 5, 26), <>Added a <SpellLink id={SPELLS.ENDURING_LUMINESCENCE.id} /> analyzer and fixed the <SpellLink id={SPELLS.ATONEMENT_BUFF.id} /> coefficient to 50% to match the 8.3 nerf.</>, [Tiphess]),

--- a/src/parser/priest/discipline/modules/features/AtonementApplicatorBreakdown.js
+++ b/src/parser/priest/discipline/modules/features/AtonementApplicatorBreakdown.js
@@ -81,7 +81,7 @@ class AtonementApplicatorBreakdown extends Analyzer{
                 this.setWasRefreshedProperty(event, true);
             }
 
-            //Putting a custom event object for Radiances since there it's only 1 cast for 5 buffs
+            //Putting a custom event object for Radiances since there is only 1 cast for 5 buffs
             this._castsApplyBuffsMap.set({
                 "event": {
                     "timestamp": this._lastRadianceCastTimestamp,
@@ -169,8 +169,11 @@ class AtonementApplicatorBreakdown extends Analyzer{
     }
     
     handleEvangelismCasts(event){
-
         this._castsApplyBuffsMap.forEach((atonement, cast) => {
+            if(atonement === null){
+                return;
+            }
+            
             if(cast.applicatorId === SPELLS.POWER_WORD_RADIANCE.id){
                 if(event.timestamp > atonement.applyBuff.timestamp 
                 && event.timestamp < atonement.applyBuff.timestamp + SPELLS.POWER_WORD_RADIANCE.atonementDuration + (this._hasEL ? ENDURING_LUMINESCENCE_BONUS_MS : 0)){


### PR DESCRIPTION
Fixes this problem: https://discordapp.com/channels/316864121536512000/360770373454659585/734730843112734732

The atonement argument in the foreach of the `handleEvangelismCasts` method is sometimes null, I simply forgot to initially add the same null check done inside `handleAtonementsHits`