### PR TITLE
Fix crash when character profile 404s

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -10,7 +10,7 @@ import Contributor from 'interface/ContributorButton';
 
 // prettier-ignore
 export default [
-  change(date(2020, 7, 23), 'Converted core log parser to TypeScript and added strict event typechecking to event listeners.', Dambroda),
+  change(date(2020, 7, 23), 'Converted core log parser to TypeScript and added strict event type checking to event listeners.', Dambroda),
   change(date(2020, 7, 11), 'Added shared functionality to get an array of filtered events previous to the currently processing event.', Dambroda),
   change(date(2020, 7, 6), <> Added support for <ItemLink id={ITEMS.SUBROUTINE_RECALIBRATION.id} />. </>, Putro),
   change(date(2020, 6, 27), 'Initial page load performance enhancements.', Stui),

--- a/src/parser/core/Combatant.ts
+++ b/src/parser/core/Combatant.ts
@@ -80,7 +80,8 @@ class Combatant extends Entity {
     const raceId = this.owner.characterProfile.race;
     let race = Object.values(RACES).find(race => race.id === raceId);
     if(race === undefined) {
-      throw new Error(`Unknown race id ${raceId}`);
+      return null;
+      // throw new Error(`Unknown race id ${raceId}`);
     }
     if (!this.owner.boss) {
       return race;


### PR DESCRIPTION
I misinterpreted the logic of how this worked before converting to TS -- fixed a crash caused by throwing an error when race was not found even if the characterprofile object was sent (as an error)