### PR TITLE
[Core] Warning Message for Shadowlands Prepatch

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -10,6 +10,7 @@ import Contributor from 'interface/ContributorButton';
 
 // prettier-ignore
 export default [
+  change(date(2020, 9, 8), 'Added a warning message for Shadowlands Prepatch.', Sharrq),
   change(date(2020, 8, 5), 'Fix an issue where changelogs wouldn\'t count in pull requests.', Putro),
   change(date(2020, 8, 4), 'Fixed a bug causing the total fight duration field to be improperly calculated, leading to confusing downtime/death percentages', Dambroda),
   change(date(2020, 7, 27), 'Updated contributor details to TypeScript and fixed contributor description not appearing when viewing those details', Dambroda),

--- a/src/interface/report/Results/index.js
+++ b/src/interface/report/Results/index.js
@@ -379,6 +379,14 @@ class Results extends React.PureComponent {
         <ReportDurationWarning duration={reportDuration} />}
 
         {parser && parser.disabledModules && <DegradedExperience disabledModules={parser.disabledModules} />}
+        {
+          //Warning Message for Shadowlands Prepatch (Remove after Shadowlands Launch)
+          <div className="container">
+            <Warning style={{ marginBottom: 30}}>
+              In an effort to focus on Shadowlands and Castle Nathria development, we will be removing support for Azerite, Essences, Corruption, and other BFA specific items with the launch of Prepatch. As a result, analysis of Prepatch encounters may be inaccurate.
+            </Warning>
+          </div>
+        }
         {boss && boss.fight.resultsWarning && (
           <div className="container">
             <Warning style={{ marginBottom: 30 }}>


### PR DESCRIPTION
Added a warning message to notify users that we will be removing support for Azerite, Essences, Corruption, and all BFA items with the launch of Prepatch.