### PR TITLE
[Shadowlands][Mage] Legendaries, Conduits, and Covenant Spell IDs

### DIFF
--- a/src/common/SPELLS/shadowlands/conduits/mage.js
+++ b/src/common/SPELLS/shadowlands/conduits/mage.js
@@ -1,17 +1,127 @@
 export default {
-  //region Kyrian
 
-  //endregion
+  //Arcane
+  ARCANE_PRODIGY: {
+    id: 336873,
+    name: 'Arcane Prodigy',
+    icon: 'spell_nature_moonglow'
+  },
+  ARTIFICE_OF_THE_ARCHMAGE: {
+    id: 337240,
+    name: 'Artifice of the Archmage',
+    icon: 'spell_druid_swarm',
+  },
+  MAGIS_BRAND: {
+    id: 337192,
+    name: 'Magi\'s Brand',
+    icon: 'spell_arcane_arcane01_nightborne',
+  },
+  NETHER_PRECISION: {
+    id: 336886,
+    name: 'Nether Precision',
+    icon: 'spell_arcane_blast_nightborne',
+  },
 
-  //region Necrolord
+  //Fire
+  CONTROLLED_DESTRUCTION: {
+    id: 341325,
+    name: 'Controlled Destruction',
+    icon: 'inv_misc_volatilefire',
+  },
+  FLAME_ACCRETION: {
+    id: 337224,
+    name: 'Flame Accretion',
+    icon: 'ability_mage_firestarter',
+  },
+  MASTER_FLAME: {
+    id: 336852,
+    name: 'Master Flame',
+    icon: 'inv_elemental_primal_fire',
+  },
+  INFERNAL_CASCADE: {
+    id: 336821,
+    name: 'Infernal Cascade',
+    icon: 'ability_rhyolith_immolation',
+  },
 
-  //endregion
+  //Frost
+  SHIVERING_CORE: {
+    id: 336472,
+    name: 'Shivering Core',
+    icon: 'spell_fire_blueflamestrike',
+  },
+  UNRELENTING_COLD: {
+    id: 336460,
+    name: 'Unrelenting Cold',
+    icon: 'spell_fire_blueflamering'
+  },
+  ICY_PROPULSION: {
+    id: 336522,
+    name: 'Icy Propulsion',
+    icon: 'spell_frost_coldhearted',
+  },
+  ICE_BITE: {
+    id: 336569,
+    name: 'Ice Bite',
+    icon: 'spell_frost_frostblast',
+  },
 
-  //region Night Fae
+  //Shared
+  CRYO_FREEZE: {
+    id: 337123,
+    name: 'Cryo-Freeze',
+    icon: 'spell_frost_icefloes',
+  },
+  DIVERTED_ENERGY: {
+    id: 337136,
+    name: 'Diverted Energy',
+    icon: 'inv_soulbarrier',
+  },
+  TEMPEST_BARRIER: {
+    id: 337293,
+    name: 'Tempest Barrier',
+    icon: 'inv_shield_1h_artifactstormfist_d_04',
+  },
+  FLOW_OF_TIME: {
+    id: 336636,
+    name: 'Flow of Time',
+    icon: 'spell_arcane_blink',
+  },
+  INCANTATION_OF_SWIFTNESS: {
+    id: 337275,
+    name: 'Incantation of Swiftness',
+    icon: 'rogue_burstofspeed',
+  },
+  WINTERS_PROTECTION: {
+    id: 336613,
+    name: 'Winter\'s Protection',
+    icon: 'spell_ice_rune',
+  },
+  GROUNDING_SURGE: {
+    id: 336777,
+    name: 'Grounding Surge',
+    icon: 'ability_priest_surgeofdarkness',
+  },
 
-  //endregion
-
-  //region Venthyr
-
-  //endregion
+  //Covenant
+  IRE_OF_THE_ASCENDED: {
+    id: 337058,
+    name: 'Ire of the Ascended',
+    icon: 'paladin_holy',
+  },
+  SIPHONED_MALICE: {
+    id: 337087,
+    name: 'Siphoned Malice',
+    icon: 'inv_articact_stolenpower',
+  },
+  GIFT_OF_THE_LICH: {
+    id: 336999,
+    name: 'Gift of the Lich',
+    icon: 'spell_holy_turnundead',
+  },
+  DISCIPLINE_OF_THE_GROVE: {
+    id: 336992,
+    name: 'Discipline of the Grove',
+    icon: 'achievement_big_wineos',
+  },
 };

--- a/src/common/SPELLS/shadowlands/conduits/mage.js
+++ b/src/common/SPELLS/shadowlands/conduits/mage.js
@@ -4,7 +4,7 @@ export default {
   ARCANE_PRODIGY: {
     id: 336873,
     name: 'Arcane Prodigy',
-    icon: 'spell_nature_moonglow'
+    icon: 'spell_nature_moonglow',
   },
   ARTIFICE_OF_THE_ARCHMAGE: {
     id: 337240,
@@ -53,7 +53,7 @@ export default {
   UNRELENTING_COLD: {
     id: 336460,
     name: 'Unrelenting Cold',
-    icon: 'spell_fire_blueflamering'
+    icon: 'spell_fire_blueflamering',
   },
   ICY_PROPULSION: {
     id: 336522,

--- a/src/common/SPELLS/shadowlands/covenants/mage.js
+++ b/src/common/SPELLS/shadowlands/covenants/mage.js
@@ -1,17 +1,31 @@
 export default {
-  //region Kyrian
 
-  //endregion
+  //Kyrian
+  RADIANT_SPARK: {
+    id: 307443,
+    name: 'Radiant Spark',
+    icon: 'ability_bastion_mage',
+  },
 
-  //region Necrolord
+  //Venthyr
+  MIRRORS_OF_TORMENT: {
+    id: 314793,
+    name: 'Mirrors of Torment',
+    icon: 'ability_revendreth_mage',
+  },
 
-  //endregion
+  //Necrolord
+  DEATHBORNE: {
+    id: 324220,
+    name: 'Deathborne',
+    icon: 'ability_maldraxxus_mage',
+  },
 
-  //region Night Fae
+  //Night Fae
+  SHIFTING_POWER: {
+    id: 314791,
+    name: 'Shifting Power',
+    icon: 'ability_ardenweald_mage',
+  },
 
-  //endregion
-
-  //region Venthyr
-
-  //endregion
 };

--- a/src/common/SPELLS/shadowlands/legendaries/mage.js
+++ b/src/common/SPELLS/shadowlands/legendaries/mage.js
@@ -1,17 +1,91 @@
 export default {
-  //region Arcane
+  
+  //Arcane
+  ARCANE_BOMBARDMENT: {
+    id: 332892,
+    name: 'Arcane Bombardment',
+    icon: 'ability_mage_arcanebarrage',
+  },
+  ARCANE_HARMONY: {
+    id: 332769,
+    name: 'Arcane Harmony',
+    icon: 'ability_creature_cursed_04',
+  },
+  SIPHON_STORM: {
+    id: 332928,
+    name: 'Siphon Storm',
+    icon: 'ability_monk_forcesphere_arcane',
+  },
+  TEMPORAL_WARP: {
+    id: 327351,
+    name: 'Temporal Warp',
+    icon: 'ability_bossmagistric_timewarp2',
+  },
 
-  //endregion
+  //Fire
+  FEVERED_INCANTATION: {
+    id: 333030,
+    name: 'Fevered Incantation',
+    icon: 'inv_misc_enchantedpearld',
+  },
+  FIRESTORM: {
+    id: 333097,
+    name: 'Firestorm',
+    icon: 'spell_fire_burnout',
+  },
+  MOLTEN_SKYFALL: {
+    id: 333167,
+    name: 'Molten Skyfall',
+    icon: 'spell_mage_meteor',
+  },
+  SUN_KINGS_BLESSING: {
+    id: 333313,
+    name: 'Sun King\'s Blessing',
+    icon: 'ability_mage_firestarter',
+  },
 
-  //region Fire
+  //Frost
+  COLD_FRONT: {
+    id: 327284,
+    name: 'Cold Front',
+    icon: 'ability_mage_coldasice',
+  },
+  FREEZING_WINDS: {
+    id: 327364,
+    name: 'Freezing Winds',
+    icon: 'spell_shadow_soulleech_2',
+  },
+  GLACIAL_FRAGMENTS: {
+    id: 327492,
+    name: 'Glacial Fragments',
+    icon: 'artifactability_frostmage_blackicicles',
+  },
+  SLICK_ICE: {
+    id: 327508,
+    name: 'Slick Ice',
+    icon: 'inv_enchant_shardshadowfrostlarge',
+  },
 
-  //endregion
+  //Shared
+  DISCIPLINARY_COMMAND: {
+    id: 327365,
+    name: 'Disciplinary Command',
+    icon: 'spell_fire_masterofelements',
+  },
+  EXPANDED_POTENTIAL: {
+    id: 327489,
+    name: 'Expanded Potential',
+    icon: 'ability_mage_potentspirit',
+  },
+  GRISLY_ICICLE: {
+    id: 333393,
+    name: 'Grisly Icicle',
+    icon: 'inv_weapon_shortblade_84',
+  },
+  TRIUNE_WARD: {
+    id: 333373,
+    name: 'Triune Ward',
+    icon: 'inv_jewelry_amulet_01',
+  },
 
-  //region Frost
-
-  //endregion
-
-  //region Shared
-
-  //endregion
 };

--- a/src/parser/mage/arcane/CHANGELOG.tsx
+++ b/src/parser/mage/arcane/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 9, 8), <>Added Spell IDs for the Shadowlands Mage Conduits, Legendaries, and Covenant Abilities. </>, Sharrq),
   change(date(2020, 9, 8), <>Removed Azerite, Essences, and BFA Items in prep for Shadowlands. </>, Sharrq),
   change(date(2020, 8, 23), <>General Cleanup for Mage Spells</>, Sharrq),
   change(date(2020, 8, 22), <>Arcane class changes for Shadowlands (Baseline <SpellLink id={SPELLS.TOUCH_OF_THE_MAGI.id} />, <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} /> cooldown and charge changes (All Specs), New Talents, <SpellLink id={SPELLS.FROSTBOLT.id} />/<SpellLink id={SPELLS.FIRE_BLAST.id} /> Spellbook entries)</>, Sharrq),

--- a/src/parser/mage/fire/CHANGELOG.tsx
+++ b/src/parser/mage/fire/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 9, 8), <>Added Spell IDs for the Shadowlands Mage Conduits, Legendaries, and Covenant Abilities. </>, Sharrq),
   change(date(2020, 9, 8), <>Removed Azerite, Essences, and BFA Items in prep for Shadowlands. </>, Sharrq),
   change(date(2020, 8, 23), <>General Cleanup for Mage Spells</>, Sharrq),
   change(date(2020, 8, 4), <>Fire class changes for Shadowlands (Baseline <SpellLink id={SPELLS.PHOENIX_FLAMES.id} />, <SpellLink id={SPELLS.KINDLING_TALENT.id} /> reduction increase, <SpellLink id={SPELLS.DRAGONS_BREATH.id} /> CD, <SpellLink id={SPELLS.PYROCLASM_TALENT.id} /> Damage Bonus, <SpellLink id={SPELLS.FROSTBOLT.id} />/<SpellLink id={SPELLS.ARCANE_EXPLOSION.id} /> Spellbook entries)</>, Sharrq),

--- a/src/parser/mage/frost/CHANGELOG.tsx
+++ b/src/parser/mage/frost/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 9, 8), <>Added Spell IDs for the Shadowlands Mage Conduits, Legendaries, and Covenant Abilities. </>, Sharrq),
   change(date(2020, 9, 8), <>Removed Azerite, Essences, and BFA Items in prep for Shadowlands. </>, Sharrq),
   change(date(2020, 8, 23), <>Shadowlands base changes (Added <SpellLink id={SPELLS.FIRE_BLAST.id} /> and <SpellLink id={SPELLS.ARCANE_EXPLOSION.id} /></>, Sharrq),
   change(date(2020, 8, 23), <>General Cleanup for Mage Spells</>, Sharrq),


### PR DESCRIPTION
Added Spell IDs for all of the Mage Legendaries, Conduits, and Covenant Spells

Towards #3657 and #3675