### PR TITLE
[Shadowlands][Mage] Focus Magic Module

### DIFF
--- a/src/common/SPELLS/mage.js
+++ b/src/common/SPELLS/mage.js
@@ -71,6 +71,16 @@ export default {
     name: 'Arcane Intellect',
     icon: 'spell_holy_magicalsentry',
   },
+  FOCUS_MAGIC_CRIT_BUFF: {
+    id: 321363,
+    name: 'Focus Magic',
+    icon: 'spell_arcane_studentofmagic',
+  },
+  FOCUS_MAGIC_INT_BUFF: {
+    id: 334180,
+    name: 'Focus Magic',
+    icon: 'spell_arcane_studentofmagic',
+  },
   ALTER_TIME: {
     id: 109878,
     name: 'Alter Time',

--- a/src/parser/mage/arcane/CHANGELOG.tsx
+++ b/src/parser/mage/arcane/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 9, 19), <>Added module for <SpellLink id={SPELLS.FOCUS_MAGIC_TALENT.id} /> buff uptime. </>, Sharrq),
   change(date(2020, 9, 8), <>Added Spell IDs for the Shadowlands Mage Conduits, Legendaries, and Covenant Abilities. </>, Sharrq),
   change(date(2020, 9, 8), <>Removed Azerite, Essences, and BFA Items in prep for Shadowlands. </>, Sharrq),
   change(date(2020, 8, 23), <>General Cleanup for Mage Spells</>, Sharrq),

--- a/src/parser/mage/fire/CHANGELOG.tsx
+++ b/src/parser/mage/fire/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 9, 19), <>Added module for <SpellLink id={SPELLS.FOCUS_MAGIC_TALENT.id} /> buff uptime. </>, Sharrq),
   change(date(2020, 9, 8), <>Added Spell IDs for the Shadowlands Mage Conduits, Legendaries, and Covenant Abilities. </>, Sharrq),
   change(date(2020, 9, 8), <>Removed Azerite, Essences, and BFA Items in prep for Shadowlands. </>, Sharrq),
   change(date(2020, 8, 23), <>General Cleanup for Mage Spells</>, Sharrq),

--- a/src/parser/mage/frost/CHANGELOG.tsx
+++ b/src/parser/mage/frost/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 9, 19), <>Added module for <SpellLink id={SPELLS.FOCUS_MAGIC_TALENT.id} /> buff uptime. </>, Sharrq),
   change(date(2020, 9, 19), <>Updated the<SpellLink id={SPELLS.WINTERS_CHILL.id} /> module for Shadowlands. </>, Sharrq),
   change(date(2020, 9, 13), <>Updated modules for <SpellLink id={SPELLS.GLACIAL_SPIKE_TALENT.id} /> and <SpellLink id={SPELLS.BRAIN_FREEZE.id} /> for Shadowlands. </>, Sharrq),
   change(date(2020, 9, 8), <>Added Spell IDs for the Shadowlands Mage Conduits, Legendaries, and Covenant Abilities. </>, Sharrq),

--- a/src/parser/mage/frost/CombatLogParser.ts
+++ b/src/parser/mage/frost/CombatLogParser.ts
@@ -14,6 +14,7 @@ import ThermalVoid from './modules/talents/ThermalVoid';
 import GlacialSpike from './modules/talents/GlacialSpike';
 import BoneChilling from './modules/talents/BoneChilling';
 import RuneOfPower from '../shared/modules/features/RuneOfPower';
+import FocusMagic from '../shared/modules/features/FocusMagic';
 import MirrorImage from '../shared/modules/features/MirrorImage';
 import ArcaneIntellect from '../shared/modules/features/ArcaneIntellect';
 import SplittingIce from './modules/talents/SplittingIce';
@@ -46,6 +47,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // T45 TODO - Incanters Flow
     mirrorImage: MirrorImage,
+    focusMagic: FocusMagic,
     runeOfPower: RuneOfPower,
 
     // T60 TODO - Frozen Touch, Chain Reaction, Ebonbolt

--- a/src/parser/mage/frost/modules/talents/FocusMagic.tsx
+++ b/src/parser/mage/frost/modules/talents/FocusMagic.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import Analyzer from 'parser/core/Analyzer';
+import EnemyInstances from 'parser/shared/modules/EnemyInstances';
+import SPELLS from 'common/SPELLS';
+import UptimeIcon from 'interface/icons/Uptime';
+import SpellLink from 'common/SpellLink';
+import { formatPercentage } from 'common/format';
+import Statistic from 'interface/statistics/Statistic';
+import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+
+class FocusMagic extends Analyzer {
+  static dependencies = {
+    enemies: EnemyInstances,
+  };
+  protected enemies!: EnemyInstances;
+
+  constructor(options: any) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.FOCUS_MAGIC_TALENT.id);
+  }
+  get buffUptime() {
+    return this.selectedCombatant.getBuffUptime(SPELLS.FOCUS_MAGIC_CRIT_BUFF.id) / this.owner.fightDuration;
+  }
+
+  get focusMagicBuffUptimeThresholds() {
+    return {
+      actual: this.buffUptime,
+      isLessThan: {
+        minor: 0.95,
+        average: 0.85,
+        major: 0.75,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when: any) {
+    when(this.focusMagicBuffUptimeThresholds)
+      .addSuggestion((suggest: any, actual: any, recommended: any) => {
+        return suggest(<>You had low uptime on <SpellLink id={SPELLS.FOCUS_MAGIC_TALENT.id} />. In order to get benefit from this talent, ensure that you are putting <SpellLink id={SPELLS.FOCUS_MAGIC_TALENT.id} /> on another player or trading the buff with another mage before the pull. If you buffed a player for the entire fight but still had low uptime, consider giving the buff to a player that will crit more often so the buff can trigger as many times as possible.</>)
+          .icon(SPELLS.ICE_LANCE.icon)
+          .actual(`${formatPercentage(this.buffUptime)}% Focus Magic Uptime`)
+          .recommended(`<${formatPercentage(recommended)}% is recommended`);
+      });
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
+        tooltip={(<>In order for Focus Magic to compete with the other talents on that row, you need to ensure you are getting as much uptime out of the buff as possible. Therefore, if you forget to put the buff on another player or if they player you gave it to is not getting crits very often, then you might need to consider giving the buff to someone else. Ideally, you should aim to trade buffs with another mage who has also taken Focus Magic so you both get the full benefit.</>)}
+      >
+        <BoringSpellValueText spell={SPELLS.FOCUS_MAGIC_TALENT}>
+          <UptimeIcon /> {formatPercentage(this.buffUptime, 0)}% <small>Buff Uptime</small>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default FocusMagic;

--- a/src/parser/mage/shared/modules/features/FocusMagic.tsx
+++ b/src/parser/mage/shared/modules/features/FocusMagic.tsx
@@ -38,9 +38,10 @@ class FocusMagic extends Analyzer {
 
   onBuffRemoved(event: RemoveBuffEvent) {
     this.buffStack = 0;
-
+    
     if (this.highStackTimestamp !== 0) {
       this.intUptime += event.timestamp - this.highStackTimestamp;
+      this.highStackTimestamp = 0;
     }
   }
 

--- a/src/parser/mage/shared/modules/features/FocusMagic.tsx
+++ b/src/parser/mage/shared/modules/features/FocusMagic.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { ApplyBuffEvent, RefreshBuffEvent, RemoveBuffEvent } from 'parser/core/Events';
+import SPELLS from 'common/SPELLS';
+import UptimeIcon from 'interface/icons/Uptime';
+import SpellLink from 'common/SpellLink';
+import { formatPercentage } from 'common/format';
+import Statistic from 'interface/statistics/Statistic';
+import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+
+class FocusMagic extends Analyzer {
+
+  buffStack = 0;
+  highStackTimestamp = 0;
+  intUptime = 0;
+
+  constructor(options: any) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.FOCUS_MAGIC_TALENT.id);
+    this.addEventListener(Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.FOCUS_MAGIC_CRIT_BUFF), this.onBuffApplied);
+    this.addEventListener(Events.refreshbuff.to(SELECTED_PLAYER).spell(SPELLS.FOCUS_MAGIC_CRIT_BUFF), this.onBuffRefreshed);
+    this.addEventListener(Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.FOCUS_MAGIC_CRIT_BUFF), this.onBuffRemoved);
+  }
+
+  onBuffApplied(event: ApplyBuffEvent) {
+    this.buffStack = 1;
+  }
+
+  onBuffRefreshed(event: RefreshBuffEvent) {
+    this.buffStack += 1;
+
+    if (this.buffStack >= 8 && this.highStackTimestamp === 0) {
+      this.highStackTimestamp = event.timestamp;
+    }
+  }
+
+  onBuffRemoved(event: RemoveBuffEvent) {
+    this.buffStack = 0;
+
+    if (this.highStackTimestamp !== 0) {
+      this.intUptime += event.timestamp - this.highStackTimestamp;
+    }
+  }
+
+  get intBuffUptime() {
+    return this.intUptime / this.owner.fightDuration;
+  }
+
+  get critBuffUptime() {
+    return this.selectedCombatant.getBuffUptime(SPELLS.FOCUS_MAGIC_CRIT_BUFF.id) / this.owner.fightDuration;
+  }
+
+  get focusMagicBuffUptimeThresholds() {
+    return {
+      actual: this.critBuffUptime,
+      isLessThan: {
+        minor: 1,
+        average: 0.90,
+        major: 0.80,
+      },
+      style: 'percentage',
+    };
+  }
+
+  suggestions(when: any) {
+    when(this.focusMagicBuffUptimeThresholds)
+      .addSuggestion((suggest: any, actual: any, recommended: any) => {
+        return suggest(<>You had low uptime on <SpellLink id={SPELLS.FOCUS_MAGIC_TALENT.id} />. In order to get benefit from this talent, ensure that you are putting <SpellLink id={SPELLS.FOCUS_MAGIC_TALENT.id} /> on another player or trading the buff with another mage before the pull. If you buffed a player for the entire fight but still had low uptime, consider giving the buff to a player that will crit with direct damage (Non DoT) abilities more often so the buff can trigger as many times as possible.</>)
+          .icon(SPELLS.FOCUS_MAGIC_TALENT.icon)
+          .actual(`${formatPercentage(this.critBuffUptime)}% Focus Magic Uptime`)
+          .recommended(`<${formatPercentage(recommended)}% is recommended`);
+      });
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
+        tooltip={(
+          <>
+            In order for Focus Magic to compete with the other talents on that row, you need to ensure you are getting as much uptime out of the buff as possible. Therefore, if you forget to put the buff on another player or if the player you gave it to is not getting direct damage crits very often (DoT crits do not count), then you might need to consider giving the buff to someone else. Ideally, you should aim to trade buffs with another mage who has also taken Focus Magic so you both can benefit.<br /><br />
+          
+            In addition to giving you crit for 10 seconds when your partner crits, the buff also applies a stacking Intellect buff to you every time the crit buff is refreshed. So making sure that your partner is getting as many crits as possible so you can spend as much time at 8 stacks of the Intellect buff as possible should be your priority with this talent.
+          </>
+        )}
+      >
+        <BoringSpellValueText spell={SPELLS.FOCUS_MAGIC_TALENT}>
+          <UptimeIcon /> {formatPercentage(this.critBuffUptime, 0)}% <small>Crit Buff Uptime</small><br />
+          <UptimeIcon /> {formatPercentage(this.intBuffUptime, 0)}% <small>Int Buff Uptime (At 8 Stacks)</small>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default FocusMagic;


### PR DESCRIPTION
Added a module to track the Focus Magic buff for all mage specs

- Tracks the Int and Crit buffs for Focus Magic (Had to manually count the int one because it is a hidden buff)
- Added statistic for the crit buff uptime and the uptime at 8 stacks of the Intellect buff
- Suggestion is based on the crit uptime, as if they raise that, the int one will raise alongside it (in theory)

Towards #3657