### PR TITLE
[Core] Fix armory link for realms with spaces or apostrophes

### DIFF
--- a/src/CHANGELOG.js
+++ b/src/CHANGELOG.js
@@ -10,6 +10,7 @@ import Contributor from 'interface/ContributorButton';
 
 // prettier-ignore
 export default [
+  change(date(2020, 9, 21), 'Fix Armory link for characters on realms that contain spaces or apostrophes', Sharrq),
   change(date(2020, 9, 20), 'Update Shadowlands warning with github link for feedback/suggestions', Sharrq),
   change(date(2020, 9, 8), 'Added a warning message for Shadowlands Prepatch.', Sharrq),
   change(date(2020, 8, 5), 'Fix an issue where changelogs wouldn\'t count in pull requests.', Putro),

--- a/src/interface/common/makeAnalyzerUrl.js
+++ b/src/interface/common/makeAnalyzerUrl.js
@@ -58,9 +58,9 @@ export function makeArmoryUrl(player) {
   if (!profile) {
     return '#';
   }
-  let battleNetUrl = `https://worldofwarcraft.com/en-us/character/${profile.region}/${profile.realm}/${player.name}`;
+  let battleNetUrl = `https://worldofwarcraft.com/en-us/character/${profile.region}/${profile.realm.replace(/'/g, "").replace(/\s/g, "-").toLowerCase()}/${player.name}`;
   if (profile.region === 'CN') {
-    battleNetUrl = `https://www.wowchina.com/zh-cn/character/${profile.realm}/${player.name}`;
+    battleNetUrl = `https://www.wowchina.com/zh-cn/character/${profile.realm.replace(/'/g, "").replace(/\s/g, "-").toLowerCase()}/${player.name}`;
   }
   return battleNetUrl;
 }


### PR DESCRIPTION
Fixes #3487