### PR TITLE
[Shadowlands][Enhancement] Removed Earth Elemental suggestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,3 @@ temp
 .vs/slnx.sqlite-journal
 .vs/VSWorkspaceState.json
 .vs/WoWAnalyzer/v15/.suo
-/.vs/WoWAnalyzer Repo/v16/.suo

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ temp
 .vs/slnx.sqlite-journal
 .vs/VSWorkspaceState.json
 .vs/WoWAnalyzer/v15/.suo
+/.vs/WoWAnalyzer Repo/v16/.suo

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -873,3 +873,13 @@ export const Tiphess: Contributor = {
     link: 'https://worldofwarcraft.com/en-us/character/us/zuljin/tjphess',
   }],
 };
+export const MusicMeister: Contributor = {
+  nickname: 'MusicMeister',
+  github: 'TheMusicMeister',
+  discord: 'The Music Meister#8236',
+  mains: [{
+    name: 'Leviisa',
+    spec: SPECS.ENHANCEMENT_SHAMAN,
+    link: 'https://worldofwarcraft.com/en-us/character/us/illidan/leviisa',
+  }],
+};

--- a/src/parser/shaman/enhancement/CHANGELOG.tsx
+++ b/src/parser/shaman/enhancement/CHANGELOG.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { HawkCorrigan, niseko, mtblanton, Draenal, Vetyst } from 'CONTRIBUTORS';
+import { HawkCorrigan, niseko, mtblanton, Draenal, Vetyst, MusicMeister } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 9, 23), <>Removed <SpellLink id={SPELLS.EARTH_ELEMENTAL.id} /> from recommended offensive spells.</>, [MusicMeister]),
   change(date(2020, 8, 28), <>First go at removing obsolete Spells and Azerite.</>, [HawkCorrigan]),
   change(date(2020, 6, 1), <>Added <strong>Maintain your buffs</strong> checklist rule.</>, [Vetyst]),
   change(date(2020, 5, 27), <>Corrected damage gains of <SpellLink id={SPELLS.ROILING_STORM.id} /> and <SpellLink id={SPELLS.THUNDERAANS_FURY.id} />, they now scale with stats.</>, [Vetyst]),

--- a/src/parser/shaman/enhancement/modules/Abilities.tsx
+++ b/src/parser/shaman/enhancement/modules/Abilities.tsx
@@ -1,9 +1,7 @@
-import React from 'react';
 
 import SPELLS from 'common/SPELLS';
 import CoreAbilities from 'parser/core/modules/Abilities';
 import { SpellbookAbility } from 'parser/core/modules/Ability';
-import SpellLink from 'common/SpellLink';
 import { STORMSTRIKE_CAST_SPELLS } from '../constants';
 
 class Abilities extends CoreAbilities {

--- a/src/parser/shaman/enhancement/modules/Abilities.tsx
+++ b/src/parser/shaman/enhancement/modules/Abilities.tsx
@@ -47,15 +47,6 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: 0.8,
-          extraSuggestion: (
-            <>
-              The total damage that it deals is equal to 2-3 GCDs. Additionally their attacks have a chance to trigger <SpellLink id={SPELLS.STORMBRINGER_BUFF.id} />, weapon enchantments, azerite traits and essence effects. (Corruption effects have not been confirmed.)
-            </>
-          ),
-        },
       },
       {
         spell: SPELLS.EARTHEN_SPIKE_TALENT,

--- a/src/parser/shaman/enhancement/modules/Abilities.tsx
+++ b/src/parser/shaman/enhancement/modules/Abilities.tsx
@@ -47,6 +47,9 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        castEfficiency: {
+          suggestion: false,
+        },
       },
       {
         spell: SPELLS.EARTHEN_SPIKE_TALENT,


### PR DESCRIPTION
Based on comments from Enhancement Shaman discord, Earth Elemental is no longer a valid offensive GCD.