### PR TITLE
[MW] Nourishing chi now tracks all hots

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -889,3 +889,7 @@ export const MusicMeister: Contributor = {
     link: 'https://worldofwarcraft.com/en-us/character/us/illidan/leviisa',
   }],
 };
+export const Moonrabbit: Contributor = {
+  nickname: 'Moonrabbit',
+  github: 'alliepet',
+};

--- a/src/parser/monk/mistweaver/CHANGELOG.js
+++ b/src/parser/monk/mistweaver/CHANGELOG.js
@@ -6,7 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2020, 10, 1), <>Corrected Nourshing Chi to track all hots. </>, Moonrabbit),
+  change(date(2020, 10, 2), <>Corrected Nourshing Chi to track all hots. </>, Moonrabbit),
   change(date(2020, 10, 1), <>Updated spell data so stat weights will be accurate. </>, Abelito75),
   change(date(2020, 10, 1), <>Added Statistics for Tear of Morning and Ancient Teachings of the Monastery. </>, Abelito75),
   change(date(2020, 9, 30), <>Integration Tests have been added for Mistweaver. </>, Anomoly),

--- a/src/parser/monk/mistweaver/CHANGELOG.js
+++ b/src/parser/monk/mistweaver/CHANGELOG.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { Anomoly, Gao, Zerotorescue, Abelito75, niseko, blazyb, JeremyDwayne, FraunchToost, Tyndi } from 'CONTRIBUTORS';
+import { Anomoly, Gao, Zerotorescue, Abelito75, niseko, blazyb, JeremyDwayne, FraunchToost, Tyndi, Moonrabbit } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 10, 1), <>Corrected Nourshing Chi to track all hots. </>, Moonrabbit),
   change(date(2020, 10, 1), <>Updated spell data so stat weights will be accurate. </>, Abelito75),
   change(date(2020, 10, 1), <>Added Statistics for Tear of Morning and Ancient Teachings of the Monastery. </>, Abelito75),
   change(date(2020, 9, 30), <>Integration Tests have been added for Mistweaver. </>, Anomoly),

--- a/src/parser/monk/mistweaver/modules/shadowlands/conduits/NourishingChi.js
+++ b/src/parser/monk/mistweaver/modules/shadowlands/conduits/NourishingChi.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import SPELLS from 'common/SPELLS';
 import Events from 'parser/core/Events';
-import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Analyzer from 'parser/core/Analyzer';
 import Combatants from 'parser/shared/modules/Combatants';
 
 import ItemHealingDone from 'interface/ItemHealingDone';
@@ -36,7 +36,7 @@ class NourishingChi extends Analyzer {
     if (!this.active) {
       return;
     }
-    this.addEventListener(Events.heal.by(SELECTED_PLAYER), this.heal);
+    this.addEventListener(Events.heal, this.heal);
   }
 
   heal(event) {


### PR DESCRIPTION
Was only tracking selected players hots when it should be all hots