### PR TITLE
[Discipline] Power Word: Solace and Mind Games bugfix

### DIFF
--- a/src/parser/priest/discipline/CHANGELOG.js
+++ b/src/parser/priest/discipline/CHANGELOG.js
@@ -8,7 +8,7 @@ import ITEMS from 'common/ITEMS';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2020, 10, 3), <>Update <SpellLink id={SPELLS.POWER_WORD_SOLACE.id} /> cooldown.</>, [Reglitch]),
+  change(date(2020, 10, 3), <>Update <SpellLink id={SPELLS.POWER_WORD_SOLACE_TALENT.id} /> cooldown.</>, [Reglitch]),
   change(date(2020, 10, 2), <>Implementation of <SpellLink id={SPELLS.MINDGAMES.id} /></>, [Oratio]),
   change(date(2020, 9, 30), <>Shadowlands Clean up.</>, [Oratio]),
   change(date(2020, 7, 20), <>Fixed a bug where the <SpellLink id={SPELLS.ATONEMENT_BUFF.id} /> Applicator Breakdown chart would sometimes not load due to an error.</>, [Tiphess]),

--- a/src/parser/priest/discipline/CHANGELOG.js
+++ b/src/parser/priest/discipline/CHANGELOG.js
@@ -8,6 +8,7 @@ import ITEMS from 'common/ITEMS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 10, 3), <>Update <SpellLink id={SPELLS.POWER_WORD_SOLACE.id} /> cooldown.</>, [Reglitch]),
   change(date(2020, 10, 2), <>Implementation of <SpellLink id={SPELLS.MINDGAMES.id} /></>, [Oratio]),
   change(date(2020, 9, 30), <>Shadowlands Clean up.</>, [Oratio]),
   change(date(2020, 7, 20), <>Fixed a bug where the <SpellLink id={SPELLS.ATONEMENT_BUFF.id} /> Applicator Breakdown chart would sometimes not load due to an error.</>, [Tiphess]),

--- a/src/parser/priest/discipline/CombatLogParser.js
+++ b/src/parser/priest/discipline/CombatLogParser.js
@@ -40,7 +40,7 @@ import Schism from './modules/spells/Schism';
 
 import SinsOfTheMany from './modules/spells/SinsOfTheMany';
 
-import Mindgames from './modules/shadowlands/covenants/Mindgames';
+import MindGames from './modules/shadowlands/covenants/MindGames';
 
 import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from './constants';
 
@@ -97,7 +97,7 @@ class CombatLogParser extends CoreCombatLogParser {
     lucidDreams: LucidDreams,
 
     // Covenants
-    mindgames: Mindgames,
+    mindgames: MindGames,
   };
 }
 

--- a/src/parser/priest/discipline/CombatLogParser.js
+++ b/src/parser/priest/discipline/CombatLogParser.js
@@ -40,7 +40,7 @@ import Schism from './modules/spells/Schism';
 
 import SinsOfTheMany from './modules/spells/SinsOfTheMany';
 
-import MindGames from './modules/shadowlands/covenants/MindGames';
+import Mindgames from './modules/shadowlands/covenants/Mindgames';
 
 import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from './constants';
 
@@ -97,7 +97,7 @@ class CombatLogParser extends CoreCombatLogParser {
     lucidDreams: LucidDreams,
 
     // Covenants
-    mindgames: MindGames,
+    mindgames: Mindgames,
   };
 }
 

--- a/src/parser/priest/discipline/modules/Abilities.js
+++ b/src/parser/priest/discipline/modules/Abilities.js
@@ -60,7 +60,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.POWER_WORD_SOLACE_TALENT,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        cooldown: haste => 12 / (1 + haste),
+        cooldown: haste => 15 / (1 + haste),
         gcd: {
           base: 1500,
         },


### PR DESCRIPTION
# Description
Updates the cooldown of Power Word: Solace to be 15 seconds as described in [this issue](https://github.com/WoWAnalyzer/WoWAnalyzer/issues/3726).

Also fixes the casing of Mind Games import to be correct.