### PR TITLE
Convert ReportDurationWarning from React class component to functional component

### DIFF
--- a/src/interface/report/ReportDurationWarning.tsx
+++ b/src/interface/report/ReportDurationWarning.tsx
@@ -18,16 +18,16 @@ const ReportDurationWarning = ({ duration }: Props) => {
   };
 
   return (
-      <div className="container">
-        <Warning style={{ marginBottom: 30 }}>
-          <h2><Trans>Report exceeds supported duration</Trans></h2>
-          <Trans>
-            The current report contains data collected over <strong>{formatNumber(durationInDays())} {durationInDays() > 1 ? 'days' : 'day'}</strong>.
+    <div className="container">
+      <Warning style={{ marginBottom: 30 }}>
+        <h2><Trans>Report exceeds supported duration</Trans></h2>
+        <Trans>
+          The current report contains data collected over <strong>{formatNumber(durationInDays())} {durationInDays() > 1 ? 'days' : 'day'}</strong>.
             This could lead to parsing issues with fights later in the report.
             We recommend that you split your logs before uploading them to warcraftlogs.com.
           </Trans>
-        </Warning>
-      </div>
+      </Warning>
+    </div>
   );
 };
 

--- a/src/interface/report/ReportDurationWarning.tsx
+++ b/src/interface/report/ReportDurationWarning.tsx
@@ -11,26 +11,24 @@ interface Props {
 const DAYS_IN_MS = 86400000;
 export const MAX_REPORT_DURATION = DAYS_IN_MS * 7;
 
-class ReportDurationWarning extends React.PureComponent<Props> {
+const ReportDurationWarning = ({ duration }: Props) => {
 
-  get durationInDays() {
-    return this.props.duration / DAYS_IN_MS;
-  }
+  const durationInDays = () => {
+    return duration / DAYS_IN_MS;
+  };
 
-  render() {
-    return (
+  return (
       <div className="container">
         <Warning style={{ marginBottom: 30 }}>
           <h2><Trans>Report exceeds supported duration</Trans></h2>
           <Trans>
-            The current report contains data collected over <strong>{formatNumber(this.durationInDays)} {this.durationInDays > 1 ? 'days' : 'day'}</strong>.
+            The current report contains data collected over <strong>{formatNumber(durationInDays())} {durationInDays() > 1 ? 'days' : 'day'}</strong>.
             This could lead to parsing issues with fights later in the report.
             We recommend that you split your logs before uploading them to warcraftlogs.com.
           </Trans>
         </Warning>
       </div>
-    );
-  }
-}
+  );
+};
 
 export default ReportDurationWarning;


### PR DESCRIPTION
fixes #3800 
Converted a smaller component (no state/hooks). Converted getter to generic function. Nothing else altered.

Let me know if this needs any further modifications!