### PR TITLE
[Fury Warrior] Fix Warpaint not calculating

### DIFF
--- a/src/parser/warrior/fury/CHANGELOG.tsx
+++ b/src/parser/warrior/fury/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 10, 15), <>Fix <SpellLink id={SPELLS.WARPAINT_TALENT.id} /> not calculating properly.</>, Adoraci),
   change(date(2020, 10, 12), <>Updated specialization to TypeScript</>, Adoraci),
   change(date(2020, 3, 27), <>Removed Frothing Berserker suggestion.</>, Abelito75),
   change(date(2020, 3, 27), <>Changed Bloodthirst's threshold based on how many Cold Steel Hot Bloods you have.</>, Abelito75),

--- a/src/parser/warrior/fury/modules/talents/Warpaint.tsx
+++ b/src/parser/warrior/fury/modules/talents/Warpaint.tsx
@@ -28,12 +28,13 @@ class Warpaint extends Analyzer {
   }
 
   onPlayerDamageTaken(event: DamageEvent) {
+    const eventDamageTaken = ((event.amount || 0) + (event.absorbed || 0));
     if (this.selectedCombatant.hasBuff(SPELLS.ENRAGE.id)) {
-      const preMitigatedDamage = (event.amount + (event.absorbed || 0)) / (1 - REDUCTION_BONUS);
+      const preMitigatedDamage = eventDamageTaken / (1 - REDUCTION_BONUS);
       this.damageMitigated += preMitigatedDamage * REDUCTION_BONUS;
     }
 
-    this.damageTaken += event.amount + (event.absorbed || 0);
+    this.damageTaken += eventDamageTaken;
   }
 
   get damageMitigatedPercent() {

--- a/src/parser/warrior/fury/modules/talents/Warpaint.tsx
+++ b/src/parser/warrior/fury/modules/talents/Warpaint.tsx
@@ -29,11 +29,11 @@ class Warpaint extends Analyzer {
 
   onPlayerDamageTaken(event: DamageEvent) {
     if (this.selectedCombatant.hasBuff(SPELLS.ENRAGE.id)) {
-      const preMitigatedDamage = (event.amount + event.absorbed) / (1 - REDUCTION_BONUS);
+      const preMitigatedDamage = (event.amount + (event.absorbed || 0)) / (1 - REDUCTION_BONUS);
       this.damageMitigated += preMitigatedDamage * REDUCTION_BONUS;
     }
 
-    this.damageTaken += event.amount + event.absorbed;
+    this.damageTaken += event.amount + (event.absorbed || 0);
   }
 
   get damageMitigatedPercent() {
@@ -53,7 +53,7 @@ class Warpaint extends Analyzer {
       >
         <BoringSpellValueText spell={SPELLS.WARPAINT_TALENT}>
           <>
-            {formatPercentage(this.damageMitigatedPercent)}% damage mitigated
+            {formatPercentage(this.damageMitigatedPercent)}% <small>damage mitigated</small>
           </>
         </BoringSpellValueText>
       </Statistic>


### PR DESCRIPTION
This PR fixes Warpaint module not calculating properly.

Before: `event.absorbed` was returning undefined and calculating NaN when added together.
![image](https://user-images.githubusercontent.com/5396389/96075829-e8882400-0e79-11eb-8332-a9427e2eaeda.png)

After: If `event.absorbed` is undefined, default it to 0 to prevent calculation error.
![image](https://user-images.githubusercontent.com/5396389/96075855-f9d13080-0e79-11eb-8d39-36ee1b931dff.png)
