### PR TITLE
[Brewmaster] Update Abilities

### DIFF
--- a/src/parser/monk/brewmaster/CHANGELOG.js
+++ b/src/parser/monk/brewmaster/CHANGELOG.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { Abelito75, emallson, Zerotorescue } from 'CONTRIBUTORS';
+import { Abelito75, emallson, Zerotorescue, Dambroda } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 10, 17), 'Added some missing abilities and updated ability cooldowns.', Dambroda),
   change(date(2020, 10, 12), 'Updated checklist to reflect the Shadowlands changes.', emallson),
   change(date(2020, 10, 6), <>Added Fallen Order statistic.</>, Abelito75),
   change(date(2020, 9, 5), <>Updated Brewmaster spells for Shadowlands.</>, emallson),

--- a/src/parser/monk/brewmaster/integrationTests/example.test.ts.snap
+++ b/src/parser/monk/brewmaster/integrationTests/example.test.ts.snap
@@ -1523,7 +1523,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
               }
             >
               0
-              /10
+              /6
                
               casts
             </td>
@@ -1622,7 +1622,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
               }
             >
               0
-              
+              /62
                
               casts
             </td>
@@ -1633,7 +1633,19 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
                 }
               }
             >
-              
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
             </td>
             <td
               className="text-left"
@@ -1644,7 +1656,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
                 }
               }
             >
-              
+              0.00%
             </td>
             <td
               style={
@@ -2132,7 +2144,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
               }
             >
               2
-              
+              /17
                
               casts
             </td>
@@ -2143,7 +2155,19 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
                 }
               }
             >
-              
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "13.011515190943983%",
+                    }
+                  }
+                />
+              </div>
             </td>
             <td
               className="text-left"
@@ -2154,7 +2178,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
                 }
               }
             >
-              
+              13.01%
             </td>
             <td
               style={
@@ -2387,7 +2411,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
               }
             >
               0
-              
+              /7
                
               casts
             </td>
@@ -2398,7 +2422,19 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
                 }
               }
             >
-              
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
             </td>
             <td
               className="text-left"
@@ -2409,7 +2445,104 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
                 }
               }
             >
-              
+              0.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                href="http://wowhead.com/spell=119381"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/ability_monk_legsweep.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Leg Sweep
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.00
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              0
+              /6
+               
+              casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              0.00%
             </td>
             <td
               style={
@@ -2472,7 +2605,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
               }
             >
               7
-              
+              /39
                
               casts
             </td>
@@ -2483,7 +2616,19 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
                 }
               }
             >
-              
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "18.21612126732158%",
+                    }
+                  }
+                />
+              </div>
             </td>
             <td
               className="text-left"
@@ -2494,7 +2639,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
                 }
               }
             >
-              
+              18.22%
             </td>
             <td
               style={
@@ -2557,7 +2702,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
               }
             >
               0
-              
+              /21
                
               casts
             </td>
@@ -2568,7 +2713,19 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
                 }
               }
             >
-              
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
             </td>
             <td
               className="text-left"
@@ -2579,7 +2736,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
                 }
               }
             >
-              
+              0.00%
             </td>
             <td
               style={
@@ -2642,7 +2799,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
               }
             >
               0
-              
+              /39
                
               casts
             </td>
@@ -2653,7 +2810,19 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
                 }
               }
             >
-              
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
             </td>
             <td
               className="text-left"
@@ -2664,7 +2833,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
                 }
               }
             >
-              
+              0.00%
             </td>
             <td
               style={
@@ -2812,7 +2981,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
               }
             >
               0
-              
+              /11
                
               casts
             </td>
@@ -2823,7 +2992,19 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
                 }
               }
             >
-              
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
             </td>
             <td
               className="text-left"
@@ -2834,7 +3015,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
                 }
               }
             >
-              
+              0.00%
             </td>
             <td
               style={
@@ -3341,7 +3522,7 @@ Array [
         values={
           Object {
             "0": 0,
-            "1": 10,
+            "1": 6,
             "2": "0",
           }
         }

--- a/src/parser/monk/brewmaster/modules/Abilities.ts
+++ b/src/parser/monk/brewmaster/modules/Abilities.ts
@@ -1,8 +1,9 @@
 import SPELLS from 'common/SPELLS';
 import CoreAbilities from 'parser/core/modules/Abilities';
+import { SpellbookAbility } from 'parser/core/modules/Ability';
 
 class Abilities extends CoreAbilities {
-  spellbook() {
+  spellbook(): SpellbookAbility[] {
     const combatant = this.selectedCombatant;
     return [
       // Rotational Spells
@@ -93,7 +94,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.CELESTIAL_BREW,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
-        cooldown: haste => (combatant.hasTalent(SPELLS.LIGHT_BREWING_TALENT) ? 60 : 48) / (1 + haste),
+        cooldown: combatant.hasTalent(SPELLS.LIGHT_BREWING_TALENT) ? 60 : 48,
         gcd: {
           static: 1000,
         },
@@ -116,6 +117,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.EXPEL_HARM,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
+        cooldown: 5,
         gcd: {
           static: 500,
         },
@@ -163,6 +165,8 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.CHI_TORPEDO_TALENT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.CHI_TORPEDO_TALENT.id),
+        cooldown: 20,
+        charges: 2,
         // Both Roll and Chi Torpedo don't actually have a GCD but block all spells during its animation for about the same duration, so maybe time it in-game and mark it as channeling instead? The issue is you can follow up any ability on the GCD with chi torpedo/roll, so it can still cause overlap.
         gcd: null,
       },
@@ -170,6 +174,8 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.ROLL,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: !combatant.hasTalent(SPELLS.CHI_TORPEDO_TALENT.id),
+        cooldown: combatant.hasTalent(SPELLS.CELERITY_TALENT.id) ? 15 : 20,
+        charges: combatant.hasTalent(SPELLS.CELERITY_TALENT.id) ? 3 : 2,
         // Both Roll and Chi Torpedo don't actually have a GCD but block all spells during its animation for about the same duration, so maybe time it in-game and mark it as channeling instead? The issue is you can follow up any ability on the GCD with chi torpedo/roll, so it can still cause overlap.
         gcd: null,
       },
@@ -199,6 +205,15 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.PARALYSIS,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: 45,
+        gcd: {
+          static: 1000,
+        },
+      },
+      {
+        spell: SPELLS.LEG_SWEEP,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: combatant.hasTalent(SPELLS.TIGER_TAIL_SWEEP_TALENT.id) ? 50 : 60,
         gcd: {
           static: 1000,
         },
@@ -206,10 +221,12 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.PROVOKE,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: 8,
         gcd: null,
       },
       {
         spell: SPELLS.SPEAR_HAND_STRIKE,
+        cooldown: 15,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         gcd: null,
       },
@@ -217,6 +234,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.DETOX_ENERGY,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
+        cooldown: 8,
         gcd: {
           // This was tested in-game (in Legion): it does NOT have a static GCD but a base GCD of 1sec and scales with Haste
           base: 1500,
@@ -233,6 +251,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.TIGERS_LUST_TALENT,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         enabled: combatant.hasTalent(SPELLS.TIGERS_LUST_TALENT.id),
+        cooldown: 30,
         gcd: {
           static: 1000,
         },


### PR DESCRIPTION
Converted to TS
Celestial brew CD doesn't scale with haste

Added cds for:
 - Expel harm 5s
 - Chi torpedo 20s (2 charges)
 - Roll: 20 or 15s, 2 or 3 charges (celerity talent),
 - Paralysis: 45s
 - Added leg sweep ability (utility section, 60/50s cd Tiger Tail Sweep talent)
 - Provoke 8s
 - Spear hand strike 15s
 - Detox 8s
 - Tiger's lust 30s