### PR TITLE
remove legacy listener support

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -10,6 +10,7 @@ import Contributor from 'interface/ContributorButton';
 
 // prettier-ignore
 export default [
+  change(date(2020, 10, 19), 'Removed legacy event listener support', Zeboot),
   change(date(2020, 10, 18), 'Added drain event', Zeboot),
   change(date(2020, 10, 18), 'Converted components in interface/common to functional components in TypeScript.', Barter),
   change(date(2020, 10, 18), 'Refactored Contributor and added typing to some ContributorDetails', Dambroda),

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -432,14 +432,18 @@ export const Zeboot: Contributor = {
       spec: SPECS.BREWMASTER_MONK,
       link: 'https://worldofwarcraft.com/en-us/character/us/whisperwind/zebeer',
     }, {
+      name: 'Zeaccent',
+      spec: SPECS.PROTECTION_PALADIN,
+      link: 'https://worldofwarcraft.com/en-us/character/us/whisperwind/Zeaccent',
+    }, ],
+    alts: [{
+      name: 'Zebot',
+      spec: SPECS.PROTECTION_WARRIOR,
+      link: 'https://worldofwarcraft.com/en-us/character/us/area-52/Zebot',
+    }, {
       name: 'Zeboot',
       spec: SPECS.GUARDIAN_DRUID,
       link: 'https://worldofwarcraft.com/en-us/character/us/whisperwind/zeboot',
-    }],
-    alts: [{
-      name: 'Zelightsneak',
-      spec: SPECS.ASSASSINATION_ROGUE,
-      link: 'https://worldofwarcraft.com/en-us/character/us/whisperwind/zelightsneak',
     }],
 };
 export const HawkCorrigan: Contributor = {

--- a/src/parser/core/Analyzer.ts
+++ b/src/parser/core/Analyzer.ts
@@ -11,68 +11,7 @@ import { EventType, MappedEvent } from './Events';
 export { SELECTED_PLAYER, SELECTED_PLAYER_PET };
 export type Options = _Options
 
-const EVENT_LISTENER_REGEX = /on_((by|to)Player(Pet)?_)?(.+)/;
-
-/**
- * Get a list of all methods of all classes in the prototype chain until this
- * class. Orginal source: https://stackoverflow.com/a/40577337/684353
- * @param {object} obj A class instance
- * @returns {Set<any>}
- */
-function getAllChildMethods(obj: object) {
-  // Set is required here to avoid duplicate methods (if a class extends another it might override the same method)
-  const methods = new Set<string>();
-  // eslint-disable-next-line no-cond-assign
-  while ((obj = Object.getPrototypeOf(obj)) && obj !== Analyzer.prototype) {
-    const keys = Object.getOwnPropertyNames(obj).concat(
-      (Object.getOwnPropertySymbols(obj) as unknown) as string[],
-    );
-    keys.forEach(k => methods.add(k));
-  }
-  return methods;
-}
-function addLegacyEventListenerSupport(object: Analyzer) {
-  const methods = getAllChildMethods(object);
-  let hasLegacyEventListener = false;
-  // Check for any methods that match the old magic method names and connect them to the new event listeners
-  // Based on https://github.com/xivanalysis/xivanalysis/blob/a24b9c0ed8b341cbb8bd8144a772e95a08541f8d/src/parser/core/Module.js#L51
-  methods.forEach(name => {
-    const match = EVENT_LISTENER_REGEX.exec(name);
-    if (!match) {
-      return;
-    }
-    const [listener, , playerFilter, pet, eventType] = match;
-    const filter = new EventFilter(eventType as EventType);
-
-    // This only shows available filters used by the legacy method.
-    // For a full list of supported properties see the core CombatLogParser
-    let by = 0;
-    if (playerFilter === 'by' && !pet) {
-      by = by | SELECTED_PLAYER;
-    }
-    if (playerFilter === 'by' && pet) {
-      by = by | SELECTED_PLAYER_PET;
-    }
-    filter.by(by);
-    let to = 0;
-    if (playerFilter === 'to' && !pet) {
-      to = to | SELECTED_PLAYER;
-    }
-    if (playerFilter === 'to' && pet) {
-      to = to | SELECTED_PLAYER_PET;
-    }
-    filter.to(to);
-
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    object.addEventListener(filter, object[listener]);
-    hasLegacyEventListener = true;
-  });
-  object.hasLegacyEventListener = hasLegacyEventListener;
-}
-
 class Analyzer extends EventSubscriber {
-  hasLegacyEventListener = false;
 
   /**
    * Called when the parser finished initializing; after all required
@@ -80,19 +19,14 @@ class Analyzer extends EventSubscriber {
    * initialized. Use this method to toggle the module on/off based on having
    * items equipped, talents selected, etc.
    */
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
   constructor(options: Options) {
     super(options);
-    addLegacyEventListenerSupport(this);
   }
   addEventListener<ET extends EventType, E extends MappedEvent<ET>>(
     eventFilter: ET | EventFilter<ET>,
     listener: EventListener<ET, E>,
   ) {
-    if (this.hasLegacyEventListener) {
-      throw new Error(
-        'You can not combine legacy event listeners with manual event listeners, use only one method.',
-      );
-    }
     super.addEventListener(eventFilter, listener);
   }
 


### PR DESCRIPTION
now that all event listeners are converted to the new type, removes support of legacy listeners.
All that's missing to reenable the camelcase rule are a bunch of API objects like fight, gonna be looking at those next