### PR TITLE
[MW] Updated Lifecycles module for shadowlands and fixed a small bug

### DIFF
--- a/src/parser/monk/mistweaver/CHANGELOG.tsx
+++ b/src/parser/monk/mistweaver/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import { change, date } from 'common/changelog';
 
 
 export default [
+  change(date(2020, 10, 21), <>Updates to Lifecyles module to account for innervate and Chi-Ji stacks and updated suggestion threshhold for Shadowlands. </>, Vohrr),
   change(date(2020, 10, 20), <>Fixed Mana Tea duration in T45Comparison and updated Mana Tea suggestion.</>, Vohrr),
   change(date(2020, 10, 19), <>Fixed Refreshing Jade Wind. </>, Abelito75),
   change(date(2020, 10, 19), <>Added Enveloping Breath module. </>, Vohrr),

--- a/src/parser/monk/mistweaver/modules/talents/Lifecycles.tsx
+++ b/src/parser/monk/mistweaver/modules/talents/Lifecycles.tsx
@@ -83,7 +83,7 @@ class Lifecycles extends Analyzer {
     this.manaSaved += (manaCost * SPELLS.LIFECYCLES_ENVELOPING_MIST_BUFF.manaPercRed);
     this.manaSavedEnm += (manaCost * SPELLS.LIFECYCLES_ENVELOPING_MIST_BUFF.manaPercRed);
     this.castsRedEnm += 1;
-    debug && console.log('Viv Reduced');
+    debug && console.log('Env Reduced');
   }
 
   get suggestionThresholds() {


### PR DESCRIPTION
accounted for innervate buffs in both vivify and enveloping mist events
accounted for chiji stacks overlapping with LC Env buff
updated mana savings threshold for suggestions
reworded part of the tooltip for clarity
small visual change to the stat box
![image](https://user-images.githubusercontent.com/26779541/96759591-42bb4480-13a6-11eb-9514-b1de442eed78.png)



