### PR TITLE
[Frost Death Knight] Finish FDK abilities for prepatch

### DIFF
--- a/src/common/SPELLS/deathknight.ts
+++ b/src/common/SPELLS/deathknight.ts
@@ -289,10 +289,10 @@ const spells: SpellList = {
     icon: 'inv_misc_rune_10',
   },
 
-  PESTILENT_PUSTULES: {
-    id: 220211,
-    name: 'Pestilent Pustules',
-    icon: 'spell_yorsahj_bloodboil_purpleoil',
+  OBLITERATION_RUNE_GAIN:{
+    id: 281327,
+    name: 'Obliteration',
+    icon: 'inv_axe_114',
   },
   
   // Unholy:
@@ -349,6 +349,12 @@ const spells: SpellList = {
     id: 51460,
     name: 'Runic Corruption',
     icon: 'spell_shadow_rune',
+  },
+
+  PESTILENT_PUSTULES: {
+    id: 220211,
+    name: 'Pestilent Pustules',
+    icon: 'spell_yorsahj_bloodboil_purpleoil',
   },
 
   // scourge strike has one cast event but two damage events, the cast and physical

--- a/src/common/SPELLS/shadowlands/covenants/deathknight.ts
+++ b/src/common/SPELLS/shadowlands/covenants/deathknight.ts
@@ -2,18 +2,38 @@ import { SpellList } from "common/SPELLS/Spell";
 
 const covenants: SpellList = {
   //region Kyrian
+  SHACKLE_THE_UNWORTHY: {
+    id: 312202,
+    name: 'Shackle the Unworthy',
+    icon: 'ability_bastion_deathknight',
+  },
 
   //endregion
 
   //region Necrolord
+  ABOMINATION_LIMB: {
+    id: 315443,
+    name: 'Abomination Limb',
+    icon: 'ability_maldraxxus_deathknight',
+  },
 
   //endregion
 
   //region Night Fae
+  DEATHS_DUE: {
+    id: 324128,
+    name: 'Death\'s Due',
+    icon: 'ability_ardenweald_deathknight',
+  },
 
   //endregion
 
   //region Venthyr
+  SWARMING_MIST: {
+    id: 311648,
+    name: 'Swarming Mist',
+    icon: 'ability_revendreth_deathknight'
+  },
 
   //endregion
 };

--- a/src/common/SPELLS/shadowlands/legendaries/deathknight.ts
+++ b/src/common/SPELLS/shadowlands/legendaries/deathknight.ts
@@ -6,6 +6,17 @@ const legendaries: SpellList = {
   //endregion
 
   //region Frost
+  RAGE_OF_THE_FROZEN_CHAMPION: {
+    id: 341725,
+    name: 'Rage of the Frozen Champion',
+    icon: 'spell_mage_frostbomb',
+  },
+
+  KOLTIRAS_FAVOR_RUNE_GAIN: {
+    id: 334584,
+    name: 'Koltira\'s Favor',
+    icon: 'spell_shadow_focusedpower',
+  },
 
   //endregion
 

--- a/src/parser/deathknight/frost/CHANGELOG.tsx
+++ b/src/parser/deathknight/frost/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+    change(date(2020, 10, 22), 'Tweaked spells for prepatch, fixed bug where abilities that only wasted Runic Power and generated none were not showing up in the resource tab', [Khazak]),
     change(date(2020, 10, 16), 'Updated Abilities with pre-patch spells', [Khazak]),
     change(date(2020, 8, 11), 'Converted Frost Death Knight modules to Typescript', [Khazak]),
     change(date(2020, 5, 11), <>Fixed issue where <SpellLink id={SPELLS.ICECAP_TALENT.id} /> was not properly counting the internal cooldown</>, [Khazak]),

--- a/src/parser/deathknight/frost/modules/Abilities.tsx
+++ b/src/parser/deathknight/frost/modules/Abilities.tsx
@@ -33,7 +33,7 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.80,
-          //extraSuggestion: <>You should use this with every <SpellLink id={SPELLS.BREATH_OF_SINDRAGOSA_TALENT.id} />, otherwise use it with <SpellLink id={SPELLS.PILLAR_OF_FROST} /> if Breath of Sindragosa is not talented.</>,
+          extraSuggestion: <>You should use this with every <SpellLink id={SPELLS.BREATH_OF_SINDRAGOSA_TALENT.id} /> if it is talented. Otherwise use it with <SpellLink id={SPELLS.PILLAR_OF_FROST.id} />.</>,
         },
         timelineSortIndex: 1,
       },

--- a/src/parser/deathknight/frost/modules/features/SpellUsable.ts
+++ b/src/parser/deathknight/frost/modules/features/SpellUsable.ts
@@ -6,9 +6,9 @@ import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 
 /**
  *
-Your Frost Strike, Frostscythe, and Obliterate critical strikes reduce the remaining cooldown of Pillar of Frost by 3 sec.
+Your Frost Strike, Frostscythe, and Obliterate critical strikes reduce the remaining cooldown of Pillar of Frost by 4 sec.
  */
-const ICECAP_COOLDOWN_REDUCTION_MS = 3000;
+const ICECAP_COOLDOWN_REDUCTION_MS = 4000;
 const ICECAP_INTERNAL_CD = 1000;
 
 const ICECAP_ABILITIES = [

--- a/src/parser/shared/modules/resources/resourcetracker/ResourceBreakdown.js
+++ b/src/parser/shared/modules/resources/resourcetracker/ResourceBreakdown.js
@@ -19,7 +19,7 @@ class ResourceBreakdown extends React.Component {
         wasted: buildersObj[abilityId].wasted,
       }))
       .sort((a, b) => b.generated - a.generated)
-      .filter(ability => ability.generated > 0);
+      .filter(ability => ability.generated > 0 || ability.wasted);
   }
   prepareSpent(spendersObj) {
     return Object.keys(spendersObj)


### PR DESCRIPTION
This is a small one.  Finished final spellbook adjustments and started in on adding shadowlands abilities and updating the resource tracking for the new talent that reduces runic power costs when I ran into the roadblock of Breath of Sindragosa.  There's nothing in logs showing RP spent on BoS so I'm gonna have to do something weird and manual to get that data into the resource tracker properly show I can then accurately report how much RP was saved with the new talent.  I'd rather PR this now with the resource tracker bugfix so I can take as much time as I need on implementing BoS RP spending