### PR TITLE
Migrage PlayerSection to TS, Update dps range roles to num 3 to sort …

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -10,6 +10,7 @@ import Contributor from 'interface/ContributorButton';
 
 // prettier-ignore
 export default [
+  change(date(2020, 10, 24), 'Update PlayerSection to Typescript', Guyius),
   change(date(2020, 10, 23), 'Added initial Russian localization', Amani),
   change(date(2020, 10, 23), 'Healing Efficiency Tracker TypeScript conversion', niseko),
   change(date(2020, 10, 22), 'Update Footer to Typescript', Ssabbar),

--- a/src/interface/report/PlayerSelection/index.tsx
+++ b/src/interface/report/PlayerSelection/index.tsx
@@ -10,9 +10,10 @@ import './PlayerSelection.scss';
 const ROLE_SORT_KEY: {[key: string]: number} = {
   [ROLES.TANK]: 0,
   [ROLES.HEALER]: 1,
+  //Different sort for range/melee was tested and felt intuitive.
+  //Because of this all DPS are treated the same for sorting purposes.
   [ROLES.DPS.MELEE]: 2,
-  //I'm not sure if this is a bug or intended behaviour, But if this is 2 then there is no sort based or range/melle only on dps.
-  [ROLES.DPS.RANGED]: 3,
+  [ROLES.DPS.RANGED]: 2,
 };
 
 function sortPlayers(a: Player, b: Player) {  

--- a/src/interface/report/PlayerSelection/index.tsx
+++ b/src/interface/report/PlayerSelection/index.tsx
@@ -1,22 +1,23 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import SPECS from 'game/SPECS';
 import ROLES from 'game/ROLES';
+import { CombatantInfoEvent } from 'parser/core/Events';
 
 import PlayerTile from './PlayerTile';
 import './PlayerSelection.scss';
 
-const ROLE_SORT_KEY = {
+const ROLE_SORT_KEY: {[key: string]: number} = {
   [ROLES.TANK]: 0,
   [ROLES.HEALER]: 1,
   [ROLES.DPS.MELEE]: 2,
-  [ROLES.DPS.RANGED]: 2,
+  //I'm not sure if this is a bug or intended behaviour, But if this is 2 then there is no sort based or range/melle only on dps.
+  [ROLES.DPS.RANGED]: 3,
 };
-function sortPlayers(a, b) {
+
+function sortPlayers(a: Player, b: Player) {  
   const aSpec = SPECS[a.combatant.specID];
   const bSpec = SPECS[b.combatant.specID];
-
   const aRoleSortKey = aSpec ? ROLE_SORT_KEY[aSpec.role] : -1;
   const bRoleSortKey = bSpec ? ROLE_SORT_KEY[bSpec.role] : -1;
 
@@ -33,17 +34,33 @@ function sortPlayers(a, b) {
   return a.name.localeCompare(b.name);
 }
 
-const PlayerSelection = ({ players, makeUrl }) => (
+interface Fight {
+  id: number;
+}
+
+interface Player { 
+  combatant: CombatantInfoEvent;
+  fights: Fight[];
+  guid: number;
+  icon: string;
+  id: number;
+  name: string;
+  region: string;
+  server: string;
+  type: string;
+}
+
+interface Props {
+  players: Player[];
+  makeUrl: (playerId: string) => void;
+}
+
+const PlayerSelection = ({ players, makeUrl }: Props) => (
   <div className="player-selection">
     {players.sort(sortPlayers).map(player => (
       <PlayerTile key={player.guid} player={player} makeUrl={makeUrl} />
     ))}
   </div>
 );
-
-PlayerSelection.propTypes = {
-  players: PropTypes.arrayOf(PropTypes.object).isRequired,
-  makeUrl: PropTypes.func.isRequired,
-};
 
 export default PlayerSelection;


### PR DESCRIPTION
Migrate PlayerSection to TS.

I'm not sure if having both melees and ranged DPS as 2 was intended or not, I've updated range to 3 so the sort function will first return melee and then range. If this is intended let me know and I'll change back.
In addition not sure if I should put the Player interface in a more general place, hard to understand if there is any pattern for interfaces, for now, I'll leave it here, and once we start using it in more places we can move it as well.