### PR TITLE
[Prot Paladin] Add Blessed Hammer and Redoubt Talent Analyzers

### DIFF
--- a/src/common/SPELLS/paladin.ts
+++ b/src/common/SPELLS/paladin.ts
@@ -516,6 +516,11 @@ const spells: SpellList = {
     name: 'Shining Light',
     icon: 'ability_paladin_lightoftheprotector',
   },
+  REDOUBT_BUFF: {
+    id: 280375,
+    name: 'Redoubt',
+    icon: 'ability_warrior_shieldguard',
+  },
   // the shining light buff does not have a proper tooltip. this one does. used in display
   SHINING_LIGHT_DESC: {
     id: 321136,

--- a/src/parser/paladin/protection/CHANGELOG.tsx
+++ b/src/parser/paladin/protection/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 10, 25), <>Create analyzers for <SpellLink id={SPELLS.REDOUBT_TALENT.id} /> and <SpellLink id={SPELLS.BLESSED_HAMMER_TALENT.id}/>.</>, Hordehobbs),
   change(date(2020, 10, 23), <>Aggregate Prot and Ret <SpellLink id={SPELLS.JUDGMENT_CAST.id} /> analyzers into single analyzer.</>, Hordehobbs),
   change(date(2020, 10, 21), 'Add Holy Shield spell blocks analyzer', Hordehobbs),
   change(date(2020, 10, 18), 'Converted legacy listeners to new event filters', Zeboot),

--- a/src/parser/paladin/protection/CombatLogParser.ts
+++ b/src/parser/paladin/protection/CombatLogParser.ts
@@ -25,6 +25,7 @@ import RighteousProtector from './modules/talents/RighteousProtector';
 import SanctifiedWrathProtJudgement from './modules/talents/SanctifiedWrathProtJudgement';
 import HolyShieldSpellBlock from './modules/talents/HolyShieldSpellBlock';
 import Redoubt from './modules/talents/Redoubt';
+import BlessedHammerDamageReduction from './modules/talents/BlessedHammerDamageReduction';
 
 //import CooldownTracker from './Modules/Features/CooldownTracker';
 import HolyPowerTracker from '../shared/holypower/HolyPowerTracker';
@@ -59,6 +60,7 @@ class CombatLogParser extends CoreCombatLogParser {
     sanctifiedWrathProtJudgement: SanctifiedWrathProtJudgement,
     holyShieldSpellBlock: HolyShieldSpellBlock,
     redoubt: Redoubt,
+    blessedHammerDamageReduction: BlessedHammerDamageReduction,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,

--- a/src/parser/paladin/protection/CombatLogParser.ts
+++ b/src/parser/paladin/protection/CombatLogParser.ts
@@ -24,6 +24,7 @@ import Seraphim from './modules/talents/Seraphim';
 import RighteousProtector from './modules/talents/RighteousProtector';
 import SanctifiedWrathProtJudgement from './modules/talents/SanctifiedWrathProtJudgement';
 import HolyShieldSpellBlock from './modules/talents/HolyShieldSpellBlock';
+import Redoubt from './modules/talents/Redoubt';
 
 //import CooldownTracker from './Modules/Features/CooldownTracker';
 import HolyPowerTracker from '../shared/holypower/HolyPowerTracker';
@@ -57,6 +58,7 @@ class CombatLogParser extends CoreCombatLogParser {
     seraphim: Seraphim,
     sanctifiedWrathProtJudgement: SanctifiedWrathProtJudgement,
     holyShieldSpellBlock: HolyShieldSpellBlock,
+    redoubt: Redoubt,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,

--- a/src/parser/paladin/protection/integrationTests/example.test.ts.snap
+++ b/src/parser/paladin/protection/integrationTests/example.test.ts.snap
@@ -29,6 +29,69 @@ Array [
 ]
 `;
 
+exports[`Protection Paladin integration test: example log BlessedHammerDamageReduction matches the statistic snapshot 1`] = `
+<div
+  className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
+>
+  <div
+    category="TALENTS"
+    className="panel statistic flexible "
+    position={100}
+  >
+    <div
+      className="panel-body"
+    >
+      <div
+        className="flex boring-value "
+      >
+        <div
+          className="flex-sub icon"
+        >
+          <a
+            href="http://wowhead.com/spell=204019"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <img
+              alt="Blessed Hammer"
+              className="icon game "
+              src="//render-us.worldofwarcraft.com/icons/56/paladin_retribution.jpg"
+            />
+          </a>
+        </div>
+        <div
+          className="flex-main value"
+        >
+          <div>
+            6,284
+          </div>
+          <small>
+            Reduced damage from 20 hits.
+          </small>
+        </div>
+      </div>
+    </div>
+    <div
+      className="detail-corner"
+      data-place="top"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onTouchStart={[Function]}
+    >
+      <svg
+        className="icon"
+        viewBox="0 0 100 100"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M58.9,82.9h7v12.9H34.1V82.9h7.1V45.5h-0.6c-3.6,0-6.4-2.9-6.4-6.4c0-3.6,2.9-6.4,6.4-6.4h0.6h17.4h0.3V82.9z M49,25.8  c6,0,10.8-4.8,10.8-10.8C59.8,9,55,4.2,49,4.2S38.2,9,38.2,15C38.2,21,43,25.8,49,25.8z"
+        />
+      </svg>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Protection Paladin integration test: example log CastEfficiency matches the statistic snapshot 1`] = `
 <div
   className="panel "

--- a/src/parser/paladin/protection/modules/talents/BlessedHammerDamageReduction.tsx
+++ b/src/parser/paladin/protection/modules/talents/BlessedHammerDamageReduction.tsx
@@ -1,0 +1,90 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import Events, { DamageEvent } from 'parser/core/Events';
+import Enemies from 'parser/shared/modules/Enemies';
+import React from 'react';
+import Statistic from 'interface/statistics/Statistic';
+import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+import { formatNumber } from 'common/format';
+import SpellLink from 'common/SpellLink';
+import BoringSpellValue from 'interface/statistics/components/BoringSpellValue';
+
+class BlessedHammerDamageReduction extends Analyzer {
+  static dependencies = {
+    enemies: Enemies,
+  };
+
+  protected enemies!: Enemies;
+
+  totalMeleeHits: number = 0;
+  reducedDamageHits: number = 0;
+  totalReducedDamage: number = 0;
+  currentAttackPower: number | null = null;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.BLESSED_HAMMER_TALENT.id);
+    if (!this.active) {
+      return;
+    }
+    this.addEventListener(Events.damage.to(SELECTED_PLAYER), this.trackHitsToPlayer);
+    this.addEventListener(Events.damage.to(SELECTED_PLAYER), this.trackCurrentAttackPower);
+  }
+
+  trackHitsToPlayer(event: DamageEvent): void {
+    this.totalMeleeHits += 1;
+    if (!event.sourceID || !this.enemies.enemies[event.sourceID]) {
+      return;
+    }
+    console.dir(this.enemies.enemies[event.sourceID]);
+    const sourceIsDebuffed = this.enemies.enemies[event.sourceID].hasBuff(SPELLS.BLESSED_HAMMER_DEBUFF.id, event.timestamp, undefined, undefined, this.owner.playerId);
+    console.log(`Enemy has debuff ${SPELLS.BLESSED_HAMMER_DEBUFF.id}? ${sourceIsDebuffed}`);
+    if (sourceIsDebuffed) {
+      this.reducedDamageHits += 1;
+      this.totalReducedDamage += this.blessedHammerDamageReduction;
+    }
+  }
+
+  trackCurrentAttackPower(event: DamageEvent) {
+    console.dir(event);
+    if ('attackPower' in event && event.attackPower) {
+      console.log(`Setting attack power to ${event.attackPower}`);
+      this.currentAttackPower = event.attackPower;
+    }
+  }
+
+  get blessedHammerDamageReduction(): number {
+    if (!this.currentAttackPower) {
+      return 0;
+    }
+    return this.currentAttackPower * 30 / 100;
+  }
+
+  get averageHitReduction(): number {
+    return this.totalReducedDamage / this.reducedDamageHits;
+  }
+
+  statistic(): React.ReactNode {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.DEFAULT}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={(
+          <>
+            Average <b>{formatNumber(this.averageHitReduction)}</b> damage reduced per hit affected by <SpellLink id={SPELLS.BLESSED_HAMMER_TALENT.id} />.
+          </>
+        )}
+      >
+        <BoringSpellValue
+          spell={SPELLS.BLESSED_HAMMER_TALENT}
+          value={formatNumber(this.totalReducedDamage)}
+          label={`Reduced damage from ${this.reducedDamageHits} hits.`}
+        />
+      </Statistic>
+    );
+  }
+}
+
+export default BlessedHammerDamageReduction;

--- a/src/parser/paladin/protection/modules/talents/Redoubt.tsx
+++ b/src/parser/paladin/protection/modules/talents/Redoubt.tsx
@@ -1,0 +1,70 @@
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import StatTracker from 'parser/shared/modules/StatTracker';
+import React from 'react';
+import Statistic from 'interface/statistics/Statistic';
+import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+import { formatNumber } from 'common/format';
+import BoringSpellValue from 'interface/statistics/components/BoringSpellValue';
+
+const STAT_MODIFIER = 0.02;
+
+class Redoubt extends Analyzer {
+  static dependencies = {
+    statTracker: StatTracker,
+  };
+
+
+  protected statTracker!: StatTracker;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.REDOUBT_TALENT.id);
+    if (!this.active) {
+      return;
+    }
+    const localStatTracker: StatTracker = options.statTracker as StatTracker;
+    localStatTracker.add(SPELLS.REDOUBT_BUFF.id, {
+      stamina: this.bonusStaminaGain(localStatTracker),
+      strength: this.bonusStrenghGain(localStatTracker)
+    });
+  }
+
+  bonusStaminaGain(statTracker: StatTracker) {
+    return statTracker.startingStaminaRating * STAT_MODIFIER;
+  }
+
+  bonusStrenghGain(statTracker: StatTracker) {
+    return statTracker.startingStrengthRating * STAT_MODIFIER;
+  }
+
+  get averageStacks() {
+    return this.selectedCombatant.getStackWeightedBuffUptime(SPELLS.REDOUBT_BUFF.id) / this.owner.fightDuration;
+  }
+
+  statistic(): React.ReactNode {
+    const averageStamGain = this.bonusStaminaGain(this.statTracker) * this.averageStacks;
+    const averageStrengthGain = this.bonusStrenghGain(this.statTracker) * this.averageStacks;
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.DEFAULT}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={(
+          <>
+            Taking the Redoubt talent gave you on average {formatNumber(averageStamGain)} Stamina and {formatNumber(averageStrengthGain)} Strength.
+          </>
+        )}
+      >
+        <BoringSpellValue
+          spell={SPELLS.REDOUBT_TALENT}
+          value={formatNumber(this.averageStacks)}
+          label="Average Stacks"
+        />
+      </Statistic>
+    );
+  }
+}
+
+export default Redoubt;


### PR DESCRIPTION
# Notes
- Add analyzers for the remaining two row-1 talents: Redoubt and Blessed Hammer.
- Towards issue #3877 
- [Blessed Hammer log](https://www.warcraftlogs.com/reports/LfzdHcRX16ptjvy8#fight=7&type=summary&source=14).
- [Redoubt log](https://www.warcraftlogs.com/reports/wMmrB7NA6qTx1Rtp#fight=15&type=summary&source=27).

# Screenshots
## Blessed Hammer
<img width="278" alt="2020-10-25 12_57_07-Mythic Maut - Kill (3_06) by Exality in Hpala PepeHands - WoWAnalyzer" src="https://user-images.githubusercontent.com/6363390/97118205-f7ff3c80-16c5-11eb-9721-354303a3dcec.png">
<img width="458" alt="2020-10-25 12_57_14-Mythic Maut - Kill (3_06) by Exality in Hpala PepeHands - WoWAnalyzer" src="https://user-images.githubusercontent.com/6363390/97118206-f897d300-16c5-11eb-977e-e04015508a15.png">

## Redoubt
<img width="291" alt="2020-10-25 12_58_45-Mythic The Hivemind - Kill (2_25) by Djurarn in No lag today_!_!_! - WoWAnalyzer" src="https://user-images.githubusercontent.com/6363390/97118219-fe8db400-16c5-11eb-8ab1-6bc8572ae523.png">
<img width="444" alt="2020-10-25 12_58_53-Mythic The Hivemind - Kill (2_25) by Djurarn in No lag today_!_!_! - WoWAnalyzer" src="https://user-images.githubusercontent.com/6363390/97118220-ff264a80-16c5-11eb-9326-7af9254c0c77.png">
