### PR TITLE
[Blood Death Knight] Relish in Blood & general SL stuff

### DIFF
--- a/src/common/SPELLS/deathknight.ts
+++ b/src/common/SPELLS/deathknight.ts
@@ -135,6 +135,11 @@ const spells: SpellList = {
     name: 'Voracious',
     icon: 'ability_ironmaidens_whirlofblood',
   },
+  RELISH_IN_BLOOD: {
+    id: 317614,
+    name: 'Relish in Blood',
+    icon: 'ability_deathknight_roilingblood',
+  },
 
   // CC
   GOREFIENDS_GRASP: {

--- a/src/parser/deathknight/blood/CHANGELOG.js
+++ b/src/parser/deathknight/blood/CHANGELOG.js
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 10, 26), <>Replaced deprecated StatisticBox modules for talents, disable Ossuary until SL and new <SpellLink id={SPELLS.RELISH_IN_BLOOD_TALENT.id} /> module</>, joshinator),
   change(date(2020, 10, 20), 'Replaced the deprecated StatisticBox modules', LeoZhekov),
   change(date(2020, 10, 18), 'Converted legacy listeners to new event filters', Zeboot),
   change(date(2020, 9, 10), <>Changed <SpellLink id={SPELLS.OSSUARY.id} /> from a talent to baseline. Changed <SpellLink id={SPELLS.BLOOD_TAP_TALENT.id} /> to talent.</>, [Yajinni]),

--- a/src/parser/deathknight/blood/CombatLogParser.js
+++ b/src/parser/deathknight/blood/CombatLogParser.js
@@ -19,7 +19,7 @@ import DeathStrikeTiming from './modules/features/DeathStrikeTiming';
 import BoneShieldTimesByStacks from './modules/features/BoneShieldTimesByStacks';
 import DeathsCaress from './modules/core/DeathsCaress';
 import MitigationCheck from './modules/features/MitigationCheck';
-import Ossuary from './modules/features/Ossuary';
+// import Ossuary from './modules/features/Ossuary';
 
 // Resources
 import RunicPowerDetails from './modules/runicpower/RunicPowerDetails';
@@ -40,6 +40,7 @@ import Voracious from './modules/talents/Voracious';
 import RapidDecomposition from './modules/talents/RapidDecomposition';
 import WillOfTheNecropolis from './modules/talents/WillOfTheNecropolis';
 import Consumption from './modules/talents/Consumption';
+import RelishInBlood from './modules/talents/RelishInBlood';
 
 // Azerite Traits
 import BonesOfTheDamned from './modules/spells/azeritetraits/BonesOfTheDamned';
@@ -92,8 +93,9 @@ class CombatLogParser extends CoreCombatLogParser {
     voracious: Voracious,
     rapidDecomposition: RapidDecomposition,
     willOfTheNecropolis: WillOfTheNecropolis,
-    ossuary: Ossuary,
+    // ossuary: Ossuary,
     consumption: Consumption,
+    relishInBlood: RelishInBlood,
 
     // Azerite Traits
     bonesOfTheDamned: BonesOfTheDamned,

--- a/src/parser/deathknight/blood/integrationTests/example.test.ts.snap
+++ b/src/parser/deathknight/blood/integrationTests/example.test.ts.snap
@@ -336,19 +336,15 @@ exports[`Blood Death Knight integration test: example log Bloodworms matches the
   className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
 >
   <div
-    className="panel statistic standard statistic-box"
-    style={
-      Object {
-        "height": "auto",
-        "zIndex": 1,
-      }
-    }
+    category="TALENTS"
+    className="panel statistic flexible "
+    position={1002}
   >
     <div
       className="panel-body"
     >
       <div
-        className="pad"
+        className="pad boring-text "
       >
         <label>
           <a
@@ -363,12 +359,30 @@ exports[`Blood Death Knight integration test: example log Bloodworms matches the
             />
           </a>
            
-          Bloodworm Stats
+          <a
+            href="http://wowhead.com/spell=195679"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Bloodworms
+          </a>
         </label>
         <div
           className="value"
         >
-          14.01 % / 1,123 HPS
+          <img
+            alt="Healing"
+            className="icon"
+            src="/img/healing.png"
+          />
+           
+          1,123
+           HPS
+           
+          <small>
+            14.01
+            % of total
+          </small>
         </div>
       </div>
     </div>
@@ -1415,6 +1429,152 @@ exports[`Blood Death Knight integration test: example log CastEfficiency matches
           <tr>
             <th>
               <b>
+                Cooldown
+              </b>
+            </th>
+            <th
+              className="text-center"
+            >
+              <dfn
+                className=""
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onTouchStart={[Function]}
+                style={Object {}}
+              >
+                shared.castEfficiency.cpm
+              </dfn>
+            </th>
+            <th
+              className="text-right"
+            >
+              <dfn
+                className=""
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onTouchStart={[Function]}
+                style={Object {}}
+              >
+                shared.castEfficiency.casts
+              </dfn>
+            </th>
+            <th
+              className="text-center"
+            >
+              <dfn
+                className=""
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onTouchStart={[Function]}
+                style={Object {}}
+              >
+                shared.castEfficiency.timeOnCooldown
+              </dfn>
+            </th>
+            <th />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                href="http://wowhead.com/spell=46585"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/inv_pet_ghoul.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Raise Dead
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.00
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              0
+              /2
+               
+              casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              0.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+        </tbody>
+        <tbody>
+          <tr>
+            <th>
+              <b>
                 Defensive Cooldown
               </b>
             </th>
@@ -1755,6 +1915,103 @@ exports[`Blood Death Knight integration test: example log CastEfficiency matches
             >
               shared.castEfficiency.canBeImproved
             </td>
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                href="http://wowhead.com/spell=51052"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/spell_deathknight_antimagiczone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Anti-Magic Zone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.00
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              0
+              /2
+               
+              casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              0.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
           </tr>
           <tr>
             <td
@@ -4078,19 +4335,15 @@ exports[`Blood Death Knight integration test: example log Hemostasis matches the
   className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
 >
   <div
-    className="panel statistic standard statistic-box"
-    style={
-      Object {
-        "height": "auto",
-        "zIndex": 1,
-      }
-    }
+    category="TALENTS"
+    className="panel statistic flexible "
+    position={1002}
   >
     <div
       className="panel-body"
     >
       <div
-        className="pad"
+        className="pad boring-text "
       >
         <label>
           <a
@@ -4105,12 +4358,22 @@ exports[`Blood Death Knight integration test: example log Hemostasis matches the
             />
           </a>
            
-          Death Strikes with Hemostasis
+          <a
+            href="http://wowhead.com/spell=273946"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Hemostasis
+          </a>
         </label>
         <div
           className="value"
         >
-          19 / 20
+          11.20
+           % 
+          <small>
+            average DS increase
+          </small>
         </div>
       </div>
     </div>
@@ -4370,92 +4633,6 @@ exports[`Blood Death Knight integration test: example log MitigationCheck matche
     </div>
   </div>
 </div>
-`;
-
-exports[`Blood Death Knight integration test: example log Ossuary matches the statistic snapshot 1`] = `
-<div
-  className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
->
-  <div
-    className="panel statistic flexible "
-    position={3}
-  >
-    <div
-      className="panel-body"
-    >
-      <div
-        className="pad boring-text "
-      >
-        <label>
-          <a
-            href="http://wowhead.com/spell=219788"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            <img
-              alt="Ossuary"
-              className="icon game "
-              src="//render-us.worldofwarcraft.com/icons/56/ability_deathknight_brittlebones.jpg"
-            />
-          </a>
-           
-          <a
-            href="http://wowhead.com/spell=219788"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Ossuary
-          </a>
-        </label>
-        <div
-          className="value"
-        >
-          3
-           / 
-          20
-           
-          <small>
-            Death Strikes without Ossuary
-          </small>
-        </div>
-      </div>
-    </div>
-    <div
-      className="detail-corner"
-      data-place="top"
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onTouchStart={[Function]}
-    >
-      <svg
-        className="icon"
-        viewBox="0 0 100 100"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M58.9,82.9h7v12.9H34.1V82.9h7.1V45.5h-0.6c-3.6,0-6.4-2.9-6.4-6.4c0-3.6,2.9-6.4,6.4-6.4h0.6h17.4h0.3V82.9z M49,25.8  c6,0,10.8-4.8,10.8-10.8C59.8,9,55,4.2,49,4.2S38.2,9,38.2,15C38.2,21,43,25.8,49,25.8z"
-        />
-      </svg>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Blood Death Knight integration test: example log Ossuary matches the suggestions snapshot 1`] = `
-Array [
-  Object {
-    "details": null,
-    "icon": "ability_deathknight_brittlebones",
-    "importance": "regular",
-    "issue": "Your Ossuary usage can be improved. Avoid casting Death Strike while not having Ossuary up as you lose Runic Power by doing so.",
-    "stat": <React.Fragment>
-      85.00% Ossuary efficiency
-       (
-      100.00% is recommended
-      )
-    </React.Fragment>,
-  },
-]
 `;
 
 exports[`Blood Death Knight integration test: example log PrePotion matches the suggestions snapshot 1`] = `
@@ -5065,19 +5242,15 @@ exports[`Blood Death Knight integration test: example log WillOfTheNecropolis ma
   className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
 >
   <div
-    className="panel statistic standard statistic-box"
-    style={
-      Object {
-        "height": "auto",
-        "zIndex": 1,
-      }
-    }
+    category="TALENTS"
+    className="panel statistic flexible "
+    position={1002}
   >
     <div
       className="panel-body"
     >
       <div
-        className="pad"
+        className="pad boring-text "
       >
         <label>
           <a
@@ -5103,7 +5276,19 @@ exports[`Blood Death Knight integration test: example log WillOfTheNecropolis ma
         <div
           className="value"
         >
-          1.32 % / 106 HPS
+          <img
+            alt="Healing"
+            className="icon"
+            src="/img/healing.png"
+          />
+           
+          106
+           HPS
+           
+          <small>
+            1.32
+            % of total
+          </small>
         </div>
       </div>
     </div>
@@ -5991,8 +6176,8 @@ exports[`Blood Death Knight integration test: example log matches the checklist 
               className="perf-bar"
               style={
                 Object {
-                  "backgroundColor": "#a6c34c",
-                  "width": "86.21994998218773%",
+                  "backgroundColor": "#4ec04e",
+                  "width": "100%",
                 }
               }
             />
@@ -6194,79 +6379,6 @@ exports[`Blood Death Knight integration test: example log matches the checklist 
                         "backgroundColor": "#4ec04e",
                         "transition": "background-color 800ms",
                         "width": "100%",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="col-md-6"
-          >
-            <div
-              className="flex"
-            >
-              <div
-                className="flex-main"
-              >
-                <a
-                  href="http://wowhead.com/spell=219788"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  <img
-                    alt=""
-                    className="icon game "
-                    src="//render-us.worldofwarcraft.com/icons/56/ability_deathknight_brittlebones.jpg"
-                  />
-                   
-                  Ossuary
-                </a>
-                 Uptime
-              </div>
-              <div
-                className="flex-sub content-middle text-muted"
-                style={
-                  Object {
-                    "marginLeft": 5,
-                    "marginRight": 10,
-                    "minWidth": 55,
-                  }
-                }
-              >
-                <div
-                  className="text-right"
-                  style={
-                    Object {
-                      "width": "100%",
-                    }
-                  }
-                >
-                   
-                  87.62%
-                   
-                   
-                </div>
-              </div>
-              <div
-                className="flex-sub content-middle"
-                style={
-                  Object {
-                    "width": 50,
-                  }
-                }
-              >
-                <div
-                  className="performance-bar-container"
-                >
-                  <div
-                    className="performance-bar small"
-                    style={
-                      Object {
-                        "backgroundColor": "#ffc84a",
-                        "transition": "background-color 800ms",
-                        "width": "58.65984994656319%",
                       }
                     }
                   />

--- a/src/parser/deathknight/blood/modules/Abilities.js
+++ b/src/parser/deathknight/blood/modules/Abilities.js
@@ -225,6 +225,19 @@ class Abilities extends CoreAbilities {
         },
       },
       {
+        spell: SPELLS.RAISE_DEAD_BLOOD_FROST,
+        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
+        cooldown: 120,
+      },
+      {
+        spell: SPELLS.ANTI_MAGIC_ZONE,
+        category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
+        cooldown: 120,
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
         spell: SPELLS.MARK_OF_BLOOD_TALENT,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         enabled: combatant.hasTalent(SPELLS.MARK_OF_BLOOD_TALENT),

--- a/src/parser/deathknight/blood/modules/features/AlwaysBeCasting.js
+++ b/src/parser/deathknight/blood/modules/features/AlwaysBeCasting.js
@@ -4,7 +4,6 @@ import CoreAlwaysBeCasting from 'parser/shared/modules/AlwaysBeCasting';
 
 import SPELLS from 'common/SPELLS';
 import { formatPercentage } from 'common/format';
-import { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 import SpellLink from 'common/SpellLink';
 import { i18n } from '@lingui/core';
 import { t } from '@lingui/macro';
@@ -32,8 +31,6 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
           .recommended(`<${formatPercentage(recommended)}% is recommended`));
     }
   }
-
-  statisticOrder = STATISTIC_ORDER.CORE(1);
 }
 
 export default AlwaysBeCasting;

--- a/src/parser/deathknight/blood/modules/features/checklist/Component.js
+++ b/src/parser/deathknight/blood/modules/features/checklist/Component.js
@@ -94,10 +94,10 @@ const BloodDeathKnightChecklist = ({ combatant, castEfficiency, thresholds }) =>
           name={<><SpellLink id={SPELLS.BONE_SHIELD.id} /> Uptime</>}
           thresholds={thresholds.boneShield}
         />
-        <Requirement
+        {/* <Requirement
           name={<><SpellLink id={SPELLS.OSSUARY.id} /> Uptime</>}
           thresholds={thresholds.ossuary}
-        />
+        /> */}
       </Rule>
       <Rule
         name="Use your defensive cooldowns"

--- a/src/parser/deathknight/blood/modules/features/checklist/Module.js
+++ b/src/parser/deathknight/blood/modules/features/checklist/Module.js
@@ -15,7 +15,7 @@ import MarrowrendUsage from "../MarrowrendUsage";
 import DeathsCaress from '../../core/DeathsCaress';
 import BoneStorm from '../../talents/Bonestorm';
 import MarkOfBloodUptime from '../../talents/MarkOfBlood';
-import Ossuary from '../Ossuary';
+// import Ossuary from '../Ossuary';
 import Consumption from '../../talents/Consumption';
 import RunicPowerDetails from '../../runicpower/RunicPowerDetails';
 import RuneTracker from '../../../../shared/RuneTracker';
@@ -29,7 +29,7 @@ class Checklist extends BaseChecklist {
 
     bloodplagueUptime: BloodPlagueUptime,
     boneShield: BoneShield,
-    ossuary: Ossuary,
+    // ossuary: Ossuary,
     deathsCaress: DeathsCaress,
     bonestorm: BoneStorm,
     consumption: Consumption,
@@ -57,7 +57,7 @@ class Checklist extends BaseChecklist {
           bloodPlague: this.bloodplagueUptime.uptimeSuggestionThresholds,
           markOfBlood: this.markOfBloodUptime.uptimeSuggestionThresholds,
           boneShield: this.boneShield.uptimeSuggestionThresholds,
-          ossuary: this.ossuary.uptimeSuggestionThresholds,
+          // ossuary: this.ossuary.uptimeSuggestionThresholds,
         }}
       />
     );

--- a/src/parser/deathknight/blood/modules/talents/Bloodworms.js
+++ b/src/parser/deathknight/blood/modules/talents/Bloodworms.js
@@ -2,7 +2,10 @@ import React from 'react';
 import Analyzer, { SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS/index';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
-import TalentStatisticBox from 'interface/others/TalentStatisticBox';
+import Statistic from 'interface/statistics/Statistic';
+import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+import ItemHealingDone from 'interface/ItemHealingDone';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import { formatThousands } from 'common/format';
 import Events from 'parser/core/Events';
@@ -73,11 +76,10 @@ class Bloodworms extends Analyzer {
 
   statistic() {
     return (
-      <TalentStatisticBox
-        talent={SPELLS.BLOODWORMS_TALENT.id}
-        position={STATISTIC_ORDER.OPTIONAL(6)}
-        value={this.owner.formatItemHealingDone(this.totalHealing)}
-        label="Bloodworm Stats"
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(2)}
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
         tooltip={(
           <>
             <strong>Damage:</strong> {formatThousands(this.totalDamage)} / {this.owner.formatItemDamageDone(this.totalDamage)}<br />
@@ -85,7 +87,13 @@ class Bloodworms extends Analyzer {
             <strong>Number of worms popped early:</strong> {this.poppedWorms(this.bloodworm)}
           </>
         )}
-      />
+      >
+        <BoringSpellValueText spell={SPELLS.BLOODWORMS_TALENT}>
+          <>
+            <ItemHealingDone amount={this.totalHealing} />
+          </>
+        </BoringSpellValueText>
+      </Statistic>
     );
   }
 }

--- a/src/parser/deathknight/blood/modules/talents/Hemostasis.js
+++ b/src/parser/deathknight/blood/modules/talents/Hemostasis.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
-import { formatNumber } from 'common/format';
-import TalentStatisticBox from 'interface/others/TalentStatisticBox';
+import { formatNumber, formatPercentage } from 'common/format';
+import Statistic from 'interface/statistics/Statistic';
+import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
 import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
@@ -15,10 +17,11 @@ class Hemostasis extends Analyzer {
   buffedDeathStrikes = 0;
   unbuffedDeathStrikes = 0;
   buffStack = 0;
+  usedBuffs = 0;
   wastedBuffs = 0;
   gainedBuffs = 0;
-  damage=0;
-  heal=0;
+  damage = 0;
+  heal = 0;
 
   constructor(...args) {
     super(...args);
@@ -38,6 +41,7 @@ class Hemostasis extends Analyzer {
     if (spellID === SPELLS.DEATH_STRIKE.id) {
       if(this.buffStack > 0){
         this.buffedDeathStrikes += 1;
+        this.usedBuffs += this.buffStack
         this.damage += calculateEffectiveDamage(event, PERCENT_BUFF * this.buffStack);
         this.buffStack = 0;
         return;
@@ -55,21 +59,29 @@ class Hemostasis extends Analyzer {
     }
   }
 
+  get averageIncrease() {
+    return this.usedBuffs / (this.buffedDeathStrikes + this.unbuffedDeathStrikes) * PERCENT_BUFF
+  }
 
   statistic() {
     return (
-      <TalentStatisticBox
-        talent={SPELLS.HEMOSTASIS_TALENT.id}
+      <Statistic
         position={STATISTIC_ORDER.OPTIONAL(2)}
-        value={`${this.buffedDeathStrikes} / ${this.buffedDeathStrikes + this.unbuffedDeathStrikes}`}
-        label="Death Strikes with Hemostasis"
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
         tooltip={(
           <>
             Resulting in {formatNumber(this.damage)} additional damage and {formatNumber(this.heal)} additional healing.<br />
             You gained {this.gainedBuffs} and wasted {this.wastedBuffs} stacks.
           </>
         )}
-      />
+      >
+        <BoringSpellValueText spell={SPELLS.HEMOSTASIS_TALENT}>
+          <>
+            {formatPercentage(this.averageIncrease)} % <small>average DS increase</small>
+          </>
+        </BoringSpellValueText>
+      </Statistic>
     );
   }
 }

--- a/src/parser/deathknight/blood/modules/talents/RedThirst.js
+++ b/src/parser/deathknight/blood/modules/talents/RedThirst.js
@@ -2,7 +2,10 @@ import React from 'react';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import { formatPercentage, formatNumber } from 'common/format';
-import TalentStatisticBox from 'interface/others/TalentStatisticBox';
+import Statistic from 'interface/statistics/Statistic';
+import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import UptimeIcon from 'interface/icons/Uptime';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import Events from 'parser/core/Events';
 
@@ -43,13 +46,22 @@ class RedThirst extends Analyzer {
 
   statistic() {
     return (
-      <TalentStatisticBox
-        talent={SPELLS.RED_THIRST_TALENT.id}
-        position={STATISTIC_ORDER.OPTIONAL(7)}
-        value={`${formatNumber(this.averageReduction)} sec`}
-        label="Red Thirst average reduction"
-        tooltip={`${formatNumber(this.reduction)} sec total effective reduction and ${formatNumber(this.wastedReduction)} sec (${formatPercentage(this.wastedPercent)}%) wasted reduction.`}
-      />
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(2)}
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
+        tooltip={(
+          <>
+            {formatNumber(this.reduction)} sec total effective reduction and {formatNumber(this.wastedReduction)} sec ({formatPercentage(this.wastedPercent)}%) wasted reduction.
+          </>
+        )}
+      >
+        <BoringSpellValueText spell={SPELLS.RED_THIRST_TALENT}>
+          <>
+            <UptimeIcon /> {formatNumber(this.averageReduction)} sec <small>average reduction</small>
+          </>
+        </BoringSpellValueText>
+      </Statistic>
     );
   }
 }

--- a/src/parser/deathknight/blood/modules/talents/RelishInBlood.tsx
+++ b/src/parser/deathknight/blood/modules/talents/RelishInBlood.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { EnergizeEvent, HealEvent } from 'parser/core/Events';
+
+import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
+import Statistic from 'interface/statistics/Statistic';
+import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+import { formatNumber, formatPercentage } from 'common/format';
+
+const RELISH_IN_BLOOD_RP = 10;
+
+class RelishInBlood extends Analyzer {
+
+  runicPowerGained = 0;
+  runicPowerWasted = 0;
+  healing = 0;
+  overhealing = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.RELISH_IN_BLOOD_TALENT.id);
+
+    this.addEventListener(Events.energize.spell(SPELLS.RELISH_IN_BLOOD), this._relishBuffed)
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.RELISH_IN_BLOOD), this._onHeal);
+  }
+
+  _relishBuffed(event: EnergizeEvent) {
+    const rpGain = event.resourceChange;
+
+    this.runicPowerGained += rpGain
+    this.runicPowerWasted += RELISH_IN_BLOOD_RP - rpGain
+  }
+
+  _onHeal(event: HealEvent) {
+    if (event.overheal) {
+      this.overhealing += event.overheal
+    }
+    this.healing += event.amount + event.absorb
+  }
+
+  get overhealPercentage() {
+    return this.overhealing / this.healing
+  }
+
+  get rpWastePercentage() {
+    return this.runicPowerWasted / this.runicPowerGained
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(2)}
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
+        tooltip={(
+          <>
+            <strong>RP wasted: </strong> {this.runicPowerWasted} ({formatPercentage(this.rpWastePercentage)} %)<br />
+            <strong>Healing: </strong> {formatNumber(this.healing)} <br />
+            <strong>Overhealing: </strong> {formatNumber(this.overhealing)} ({formatPercentage(this.overhealPercentage)} %) <br />
+          </>
+        )}
+      >
+        <BoringSpellValueText spell={SPELLS.RELISH_IN_BLOOD_TALENT}>
+          <>
+            {this.runicPowerGained} <small>RP gained</small>
+          </>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+
+}
+
+export default RelishInBlood;

--- a/src/parser/deathknight/blood/modules/talents/WillOfTheNecropolis.js
+++ b/src/parser/deathknight/blood/modules/talents/WillOfTheNecropolis.js
@@ -2,7 +2,10 @@ import React from 'react';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS/index';
 import { formatNumber } from "common/format";
-import TalentStatisticBox from 'interface/others/TalentStatisticBox';
+import Statistic from 'interface/statistics/Statistic';
+import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+import ItemHealingDone from 'interface/ItemHealingDone';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import Events from 'parser/core/Events';
 
@@ -48,10 +51,10 @@ class WillOfTheNecropolis extends Analyzer {
 
   statistic() {
     return (
-      <TalentStatisticBox
-        talent={SPELLS.WILL_OF_THE_NECROPOLIS_TALENT.id}
-        position={STATISTIC_ORDER.OPTIONAL(4)}
-        value={this.owner.formatItemHealingDone(this.totalWotnAbsorbed)}
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(2)}
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
         tooltip={(
           <>
             <strong>Total Damage Absorbed: </strong> {formatNumber(this.totalWotnAbsorbed)} <br />
@@ -59,7 +62,13 @@ class WillOfTheNecropolis extends Analyzer {
             <strong>Absorbed 5% Max Health or more count: </strong> {this.goodAbsorbCount}
           </>
         )}
-      />
+      >
+        <BoringSpellValueText spell={SPELLS.WILL_OF_THE_NECROPOLIS_TALENT}>
+          <>
+            <ItemHealingDone amount={this.totalWotnAbsorbed} />
+          </>
+        </BoringSpellValueText>
+      </Statistic>
     );
   }
 }


### PR DESCRIPTION
- replaced some of the old `TalentStatisticBox`es for talents
- added Raise Undead and AMZ to the spellbook
- created a Relish in Blood module to keep track of the RP and healing gained/wasted
- Hemostasis is now showing the average increase instead of amount of buffed death strikes (as average increase provides more information on how Hemostasis worked on this fight)
- disabled Ossuary, we dont have access to it right now (we get it during SL leveling)

Old:
![image](https://user-images.githubusercontent.com/29842841/97164034-d6638b00-1781-11eb-8123-da539691bf29.png)

New:
![image](https://user-images.githubusercontent.com/29842841/97164061-debbc600-1781-11eb-9cdf-b8ac7e86c293.png)
