### PR TITLE
[Prot Paladin] Add First Avenger and Moment of Glory analyzers, minor cleanup

### DIFF
--- a/src/common/SPELLS/talents/paladin.js
+++ b/src/common/SPELLS/talents/paladin.js
@@ -41,6 +41,7 @@ export default {
   AEGIS_OF_LIGHT_TALENT: { id: 204150, name: 'Aegis of Light', icon: 'spell_holy_greaterblessingoflight' },
   LAST_DEFENDER_TALENT: { id: 203791, name: 'Last Defender', icon: 'spell_holy_divinepurpose' },
   RIGHTEOUS_PROTECTOR_TALENT: { id: 204074, name: 'Righteous Protector', icon: 'ability_paladin_shieldofthetemplar' },
+  MOMENT_OF_GLORY_TALENT: { id: 327193, name: 'Moment of Glory', icon: 'ability_paladin_veneration' },
 
   // Holy
   //15 crusader's might, bestow faith, light's hammer

--- a/src/common/SPELLS/talents/paladin.js
+++ b/src/common/SPELLS/talents/paladin.js
@@ -36,7 +36,7 @@ export default {
   RETRIBUTION_AURA_TALENT: { id: 203797, name: 'Retribution Aura', icon: 'spell_holy_auraoflight' },
   BLESSING_OF_SPELLWARDING_TALENT: { id: 204018, name: 'Blessing of Spellwarding', icon: 'spell_holy_blessingofprotection', manaCost: 3000 },
   FINAL_STAND_TALENT: { id: 204077, name: 'Final Stand', icon: 'spell_holy_crusade' },
-  HAND_OF_THE_PROTECTOR_TALENT: { id: 213652, name: 'Hand of the Protector', icon: 'ability_paladin_blessedhands' },
+  HAND_OF_THE_PROTECTOR_TALENT: { id: 315924, name: 'Hand of the Protector', icon: 'ability_paladin_blessedhands' },
   CONSECRATED_GROUND_TALENT: { id: 204054, name: 'Consecrated Ground', icon: 'ability_paladin_righteousvengeance' },
   AEGIS_OF_LIGHT_TALENT: { id: 204150, name: 'Aegis of Light', icon: 'spell_holy_greaterblessingoflight' },
   LAST_DEFENDER_TALENT: { id: 203791, name: 'Last Defender', icon: 'spell_holy_divinepurpose' },

--- a/src/parser/paladin/protection/CHANGELOG.tsx
+++ b/src/parser/paladin/protection/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 10, 26), <>Create analyzers for <SpellLink id={SPELLS.FIRST_AVENGER_TALENT.id} /> and <SpellLink id={SPELLS.MOMENT_OF_GLORY_TALENT.id} />.</>, Hordehobbs),
   change(date(2020, 10, 25), <>Create analyzers for <SpellLink id={SPELLS.REDOUBT_TALENT.id} /> and <SpellLink id={SPELLS.BLESSED_HAMMER_TALENT.id}/>.</>, Hordehobbs),
   change(date(2020, 10, 23), <>Aggregate Prot and Ret <SpellLink id={SPELLS.JUDGMENT_CAST.id} /> analyzers into single analyzer.</>, Hordehobbs),
   change(date(2020, 10, 21), 'Add Holy Shield spell blocks analyzer', Hordehobbs),

--- a/src/parser/paladin/protection/CombatLogParser.ts
+++ b/src/parser/paladin/protection/CombatLogParser.ts
@@ -26,6 +26,7 @@ import SanctifiedWrathProtJudgement from './modules/talents/SanctifiedWrathProtJ
 import HolyShieldSpellBlock from './modules/talents/HolyShieldSpellBlock';
 import Redoubt from './modules/talents/Redoubt';
 import BlessedHammerDamageReduction from './modules/talents/BlessedHammerDamageReduction';
+import FirstAvenger from './modules/talents/FirstAvenger';
 
 //import CooldownTracker from './Modules/Features/CooldownTracker';
 import HolyPowerTracker from '../shared/holypower/HolyPowerTracker';
@@ -61,6 +62,7 @@ class CombatLogParser extends CoreCombatLogParser {
     holyShieldSpellBlock: HolyShieldSpellBlock,
     redoubt: Redoubt,
     blessedHammerDamageReduction: BlessedHammerDamageReduction,
+    firstAvenger: FirstAvenger,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,

--- a/src/parser/paladin/protection/CombatLogParser.ts
+++ b/src/parser/paladin/protection/CombatLogParser.ts
@@ -27,6 +27,7 @@ import HolyShieldSpellBlock from './modules/talents/HolyShieldSpellBlock';
 import Redoubt from './modules/talents/Redoubt';
 import BlessedHammerDamageReduction from './modules/talents/BlessedHammerDamageReduction';
 import FirstAvenger from './modules/talents/FirstAvenger';
+import MomentOfGlory from './modules/talents/MomentOfGlory';
 
 //import CooldownTracker from './Modules/Features/CooldownTracker';
 import HolyPowerTracker from '../shared/holypower/HolyPowerTracker';
@@ -63,6 +64,7 @@ class CombatLogParser extends CoreCombatLogParser {
     redoubt: Redoubt,
     blessedHammerDamageReduction: BlessedHammerDamageReduction,
     firstAvenger: FirstAvenger,
+    momentOfGlory: MomentOfGlory,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,

--- a/src/parser/paladin/protection/integrationTests/example.test.ts.snap
+++ b/src/parser/paladin/protection/integrationTests/example.test.ts.snap
@@ -5870,7 +5870,7 @@ exports[`Protection Paladin integration test: example log matches the checklist 
             </a>
              to heal yourself (or others, with 
             <a
-              href="http://wowhead.com/spell=213652"
+              href="http://wowhead.com/spell=315924"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/src/parser/paladin/protection/modules/talents/BlessedHammerDamageReduction.tsx
+++ b/src/parser/paladin/protection/modules/talents/BlessedHammerDamageReduction.tsx
@@ -37,9 +37,7 @@ class BlessedHammerDamageReduction extends Analyzer {
     if (!event.sourceID || !this.enemies.enemies[event.sourceID]) {
       return;
     }
-    console.dir(this.enemies.enemies[event.sourceID]);
     const sourceIsDebuffed = this.enemies.enemies[event.sourceID].hasBuff(SPELLS.BLESSED_HAMMER_DEBUFF.id, event.timestamp, undefined, undefined, this.owner.playerId);
-    console.log(`Enemy has debuff ${SPELLS.BLESSED_HAMMER_DEBUFF.id}? ${sourceIsDebuffed}`);
     if (sourceIsDebuffed) {
       this.reducedDamageHits += 1;
       this.totalReducedDamage += this.blessedHammerDamageReduction;
@@ -47,9 +45,7 @@ class BlessedHammerDamageReduction extends Analyzer {
   }
 
   trackCurrentAttackPower(event: DamageEvent) {
-    console.dir(event);
     if ('attackPower' in event && event.attackPower) {
-      console.log(`Setting attack power to ${event.attackPower}`);
       this.currentAttackPower = event.attackPower;
     }
   }

--- a/src/parser/paladin/protection/modules/talents/FirstAvenger.tsx
+++ b/src/parser/paladin/protection/modules/talents/FirstAvenger.tsx
@@ -97,7 +97,6 @@ class FirstAvenger extends Analyzer {
             </>
           )}
         />
-
       </Statistic>
     );
   }

--- a/src/parser/paladin/protection/modules/talents/FirstAvenger.tsx
+++ b/src/parser/paladin/protection/modules/talents/FirstAvenger.tsx
@@ -1,0 +1,106 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
+import SPELLS from 'common/SPELLS';
+import React from 'react';
+import Statistic from 'interface/statistics/Statistic';
+import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+import { formatNumber } from 'common/format';
+import SpellLink from 'common/SpellLink';
+import BoringSpellValue from 'interface/statistics/components/BoringSpellValue';
+
+// One second bounce buffer for AS to bounce around and hit targets.
+const AVENGERS_SHIELD_BOUNCE_BUFFER: number = 1000;
+const TALENTLESS_NUM_OF_BOUNCES = 3;
+
+class FirstAvenger extends Analyzer {
+  lastAvengersShieldCastTimestamp: number = 0;
+  totalNumHits: number = 0;
+  totalNumCasts: number = 0;
+  castToHitsMap: Map<number, DamageEvent[]> = new Map<number, DamageEvent[]>();
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.FIRST_AVENGER_TALENT.id);
+    if (!this.active) {
+      return;
+    }
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.AVENGERS_SHIELD), this.trackAvengersShieldCasts);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.AVENGERS_SHIELD), this.trackAvengersShieldHits);
+  }
+
+  trackAvengersShieldCasts(event: CastEvent): void {
+    this.lastAvengersShieldCastTimestamp = event.timestamp;
+    this.totalNumCasts += 1;
+  }
+
+  trackAvengersShieldHits(event: DamageEvent): void {
+    if (event.timestamp - this.lastAvengersShieldCastTimestamp < AVENGERS_SHIELD_BOUNCE_BUFFER) {
+      if (!this.castToHitsMap.has(this.lastAvengersShieldCastTimestamp)) {
+        this.castToHitsMap.set(this.lastAvengersShieldCastTimestamp, []);
+      }
+      this.totalNumHits += 1;
+      const hits: DamageEvent[] | undefined = this.castToHitsMap.get(this.lastAvengersShieldCastTimestamp);
+      if (hits !== undefined) {
+        hits.push(event);
+      }
+    }
+  }
+
+  getExtraDamageForCast(castTimestamp: number): number {
+    if (!this.castToHitsMap.has(castTimestamp)) {
+      return 0;
+    }
+    const hits: DamageEvent[] | undefined = this.castToHitsMap.get(castTimestamp);
+    if (hits === undefined) {
+      return 0;
+    }
+    const numExtraHits = hits.length > TALENTLESS_NUM_OF_BOUNCES ? hits.length - TALENTLESS_NUM_OF_BOUNCES : 0;
+    return (hits.map((damageEvent) => damageEvent.amount + (damageEvent.absorbed || 0))
+                .reduce((prev, current) => prev + current, 0) / hits.length)
+            * numExtraHits;
+  }
+
+  get averageHitsPerCast(): number {
+    return this.totalNumHits / this.totalNumCasts;
+  }
+
+  get totalExtraDamage(): number {
+    return Array.from(this.castToHitsMap.keys())
+                  .map((castTimestamp) => this.getExtraDamageForCast(castTimestamp))
+                  .reduce((prev, current) => prev + current, 0);
+  }
+
+  get averageExtraDamage(): number {
+    return this.totalExtraDamage / this.totalNumCasts;
+  }
+
+  statistic(): React.ReactNode {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.DEFAULT}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={(
+          <>
+              You hit on average <b>{formatNumber(this.averageHitsPerCast)}</b> enemies per cast of <SpellLink id={SPELLS.AVENGERS_SHIELD.id} /><br />
+              The extra hits from taking First Avenger contributed <b>{formatNumber(this.totalExtraDamage)}</b> total extra damage.
+          </>
+        )}
+      >
+        <BoringSpellValue
+          spell={SPELLS.FIRST_AVENGER_TALENT}
+          value={formatNumber(this.averageExtraDamage)}
+          label={(
+            <>
+              Average extra damage per cast of <SpellLink id={SPELLS.AVENGERS_SHIELD.id} />.
+            </>
+          )}
+        />
+
+      </Statistic>
+    );
+  }
+}
+
+export default FirstAvenger;

--- a/src/parser/paladin/protection/modules/talents/MomentOfGlory.tsx
+++ b/src/parser/paladin/protection/modules/talents/MomentOfGlory.tsx
@@ -1,0 +1,63 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import Events, { DamageEvent } from 'parser/core/Events';
+import React from 'react';
+import Statistic from 'interface/statistics/Statistic';
+import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
+import { formatNumber } from 'common/format';
+import SpellLink from 'common/SpellLink';
+import BoringSpellValue from 'interface/statistics/components/BoringSpellValue';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+
+const DAMAGE_MODIFIER = 0.2;
+
+class MomentOfGlory extends Analyzer {
+  damageBoostedHits: number = 0;
+  totalExtraDamage: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.MOMENT_OF_GLORY_TALENT.id);
+    if (!this.active) {
+      return;
+    }
+
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.AVENGERS_SHIELD), this.trackASDamage);
+  }
+
+  trackASDamage(event: DamageEvent): void {
+    if (!this.selectedCombatant.hasBuff(SPELLS.MOMENT_OF_GLORY_TALENT.id, event.timestamp, undefined, undefined, this.owner.playerId)) {
+      return;
+    }
+    this.damageBoostedHits += 1;
+    this.totalExtraDamage += this.getBonusDamageFromMoG(event);
+  }
+
+  getBonusDamageFromMoG(event: DamageEvent): number {
+    const baseDamageDone = event.amount + (event.absorbed || 0);
+    return baseDamageDone - (baseDamageDone * (1 / (1 + DAMAGE_MODIFIER)));
+  }
+
+  statistic(): React.ReactNode {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.DEFAULT}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={(
+          <>
+            You hit <b>{formatNumber(this.damageBoostedHits)}</b> targets with a <SpellLink id={SPELLS.AVENGERS_SHIELD.id} /> boosted with <SpellLink id={SPELLS.MOMENT_OF_GLORY_TALENT.id} />.
+          </>
+        )}
+      >
+       <BoringSpellValue
+         spell={SPELLS.MOMENT_OF_GLORY_TALENT}
+         value={formatNumber(this.totalExtraDamage)}
+         label="Extra Damage"
+       />
+      </Statistic>
+    );
+  }
+}
+
+export default MomentOfGlory;

--- a/src/parser/paladin/protection/modules/talents/MomentOfGlory.tsx
+++ b/src/parser/paladin/protection/modules/talents/MomentOfGlory.tsx
@@ -50,11 +50,11 @@ class MomentOfGlory extends Analyzer {
           </>
         )}
       >
-       <BoringSpellValue
-         spell={SPELLS.MOMENT_OF_GLORY_TALENT}
-         value={formatNumber(this.totalExtraDamage)}
-         label="Extra Damage"
-       />
+        <BoringSpellValue
+          spell={SPELLS.MOMENT_OF_GLORY_TALENT}
+          value={formatNumber(this.totalExtraDamage)}
+          label="Extra Damage"
+        />
       </Statistic>
     );
   }


### PR DESCRIPTION
# Notes
- Fix some broken spell IDs for protection paladin.
- Remove some leftover console.log calls from a previous PR. Whoops.
- Add analyzers to track bonus damage dealt by taking First Avenger and Moment of Glory talents.
- [Log used for First Avenger](https://www.warcraftlogs.com/reports/KzFbPaBqAgr9h4Rw#fight=11&type=summary&source=8)
- [Log used for Moment of Glory](https://www.warcraftlogs.com/reports/N4gKnBz6XpGdZjax#fight=7&type=summary&source=87)

# Screenshots
<img width="258" alt="2020-10-26 11_28_26-Mythic The Hivemind - Kill (4_13) by Ashincka in Battle of Dazar'alor - WoWAnaly" src="https://user-images.githubusercontent.com/6363390/97213200-8d5e0780-177e-11eb-9a83-c401496c80ca.png">
<img width="446" alt="2020-10-26 11_28_50-Mythic The Hivemind - Kill (4_13) by Ashincka in Battle of Dazar'alor - WoWAnaly" src="https://user-images.githubusercontent.com/6363390/97213203-8df69e00-177e-11eb-9ea3-cb36aaa12a66.png">
<img width="250" alt="2020-10-26 11_29_21-Mythic The Hivemind - Kill (3_51) by Fatpala in Mythic - WoWAnalyzer" src="https://user-images.githubusercontent.com/6363390/97213204-8df69e00-177e-11eb-9436-8c71af20cbd6.png">
<img width="439" alt="2020-10-26 11_29_31-Mythic The Hivemind - Kill (3_51) by Fatpala in Mythic - WoWAnalyzer" src="https://user-images.githubusercontent.com/6363390/97213209-8df69e00-177e-11eb-8a9e-94464c59f9c3.png">
