### PR TITLE
[MW] Updated Ancient Teachings of the Monastery

### DIFF
--- a/src/common/SPELLS/shadowlands/legendaries/monk.ts
+++ b/src/common/SPELLS/shadowlands/legendaries/monk.ts
@@ -74,8 +74,16 @@ const legendaries: SpellList<LegendarySpell> = {
     name: 'Ancient Teachings of the Monastery',
     icon: 'inv_jewelcrafting_jadeserpent',
   },
-
-
+  ANCIENT_TEACHINGS_OF_THE_MONASTERY_CRIT_HEAL:{
+    id: 347572,
+    name: 'Ancient Teachings of the Monastery',
+    icon: 'inv_jewelcrafting_jadeserpent',
+  },
+  ANCIENT_TEACHINGS_OF_THE_MONASTERY_BUFF:{
+    id: 347553,
+    name: 'Ancient Teachings of the Monastery',
+    icon: 'inv_misc_book_07',
+  },
   //endregion
 
   //region Windwalker

--- a/src/localization/de/messages.json
+++ b/src/localization/de/messages.json
@@ -321,6 +321,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "",
   "deathknight.frost.suggestions.runicPower.wasted": "",
   "deathknight.shared.suggestions.runes.overcapped": "",
+  "deathknight.suggestions.hysteria.efficiency": "",
   "deathknight.unholy.suggestions.alwaysBeCasting": "",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "",
   "deathknight.unholy.suggestions.festeringStrikes.efficiency": "",

--- a/src/localization/en/messages.json
+++ b/src/localization/en/messages.json
@@ -321,6 +321,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "{0}% of Rime procs were either refreshed and lost or expired without being used",
   "deathknight.frost.suggestions.runicPower.wasted": "{0}% wasted",
   "deathknight.shared.suggestions.runes.overcapped": "{0}% runes overcapped",
+  "deathknight.suggestions.hysteria.efficiency": "You wasted {0}% of RP from {1} by being RP capped.",
   "deathknight.unholy.suggestions.alwaysBeCasting": "{0}% downtime",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "An average {actual} of Festering Wounds were popped by Apocalypse",
   "deathknight.unholy.suggestions.festeringStrikes.efficiency": "{0}% of Festering Strikes did not risk overcapping Festering Wounds",

--- a/src/localization/es/messages.json
+++ b/src/localization/es/messages.json
@@ -321,6 +321,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "",
   "deathknight.frost.suggestions.runicPower.wasted": "",
   "deathknight.shared.suggestions.runes.overcapped": "",
+  "deathknight.suggestions.hysteria.efficiency": "",
   "deathknight.unholy.suggestions.alwaysBeCasting": "",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "",
   "deathknight.unholy.suggestions.festeringStrikes.efficiency": "",

--- a/src/localization/fr/messages.json
+++ b/src/localization/fr/messages.json
@@ -321,6 +321,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "",
   "deathknight.frost.suggestions.runicPower.wasted": "",
   "deathknight.shared.suggestions.runes.overcapped": "",
+  "deathknight.suggestions.hysteria.efficiency": "",
   "deathknight.unholy.suggestions.alwaysBeCasting": "",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "",
   "deathknight.unholy.suggestions.festeringStrikes.efficiency": "",

--- a/src/localization/it/messages.json
+++ b/src/localization/it/messages.json
@@ -321,6 +321,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "",
   "deathknight.frost.suggestions.runicPower.wasted": "",
   "deathknight.shared.suggestions.runes.overcapped": "",
+  "deathknight.suggestions.hysteria.efficiency": "",
   "deathknight.unholy.suggestions.alwaysBeCasting": "",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "",
   "deathknight.unholy.suggestions.festeringStrikes.efficiency": "",

--- a/src/localization/ko/messages.json
+++ b/src/localization/ko/messages.json
@@ -321,6 +321,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "",
   "deathknight.frost.suggestions.runicPower.wasted": "",
   "deathknight.shared.suggestions.runes.overcapped": "",
+  "deathknight.suggestions.hysteria.efficiency": "",
   "deathknight.unholy.suggestions.alwaysBeCasting": "",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "",
   "deathknight.unholy.suggestions.festeringStrikes.efficiency": "",

--- a/src/localization/pl/messages.json
+++ b/src/localization/pl/messages.json
@@ -321,6 +321,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "",
   "deathknight.frost.suggestions.runicPower.wasted": "",
   "deathknight.shared.suggestions.runes.overcapped": "",
+  "deathknight.suggestions.hysteria.efficiency": "",
   "deathknight.unholy.suggestions.alwaysBeCasting": "",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "",
   "deathknight.unholy.suggestions.festeringStrikes.efficiency": "",

--- a/src/localization/pt/messages.json
+++ b/src/localization/pt/messages.json
@@ -321,6 +321,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "",
   "deathknight.frost.suggestions.runicPower.wasted": "",
   "deathknight.shared.suggestions.runes.overcapped": "",
+  "deathknight.suggestions.hysteria.efficiency": "",
   "deathknight.unholy.suggestions.alwaysBeCasting": "",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "",
   "deathknight.unholy.suggestions.festeringStrikes.efficiency": "",

--- a/src/localization/ru/messages.json
+++ b/src/localization/ru/messages.json
@@ -321,6 +321,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "{0}% of Rime procs were either refreshed and lost or expired without being used",
   "deathknight.frost.suggestions.runicPower.wasted": "{0}% wasted",
   "deathknight.shared.suggestions.runes.overcapped": "{0}% runes overcapped",
+  "deathknight.suggestions.hysteria.efficiency": "",
   "deathknight.unholy.suggestions.alwaysBeCasting": "{0}% downtime",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "An average {actual} of Festering Wounds were popped by Apocalypse",
   "deathknight.unholy.suggestions.festeringStrikes.efficiency": "{0}% of Festering Strikes did not risk overcapping Festering Wounds",

--- a/src/localization/zh/messages.json
+++ b/src/localization/zh/messages.json
@@ -321,6 +321,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "",
   "deathknight.frost.suggestions.runicPower.wasted": "",
   "deathknight.shared.suggestions.runes.overcapped": "",
+  "deathknight.suggestions.hysteria.efficiency": "",
   "deathknight.unholy.suggestions.alwaysBeCasting": "",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "",
   "deathknight.unholy.suggestions.festeringStrikes.efficiency": "",

--- a/src/parser/monk/mistweaver/CHANGELOG.tsx
+++ b/src/parser/monk/mistweaver/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import { change, date } from 'common/changelog';
 
 
 export default [
+  change(date(2020, 10, 31), <>Updates to Ancient Teachings of the Monastery.</>, Vohrr),
   change(date(2020, 10, 19), <>Fixed talent detection for hot tracker. </>, Abelito75),
   change(date(2020, 10, 25), <>Added average Enveloping Breath targets to checklist and suggestions.</>, Vohrr),
   change(date(2020, 10, 21), <>Updates to Lifecyles module to account for innervate and Chi-Ji stacks and updated suggestion threshhold for Shadowlands. </>, Vohrr),

--- a/src/parser/monk/mistweaver/modules/shadowlands/legendaries/AncientTeachingsoftheMonastery.tsx
+++ b/src/parser/monk/mistweaver/modules/shadowlands/legendaries/AncientTeachingsoftheMonastery.tsx
@@ -20,7 +20,7 @@ class AncientTeachingsoftheMonastery extends Analyzer {
   lastDamageSpellID: number = 0;
 
   /**
-   * Tiger Palm, Blackout Kick, and Rising Sun Kick heal an injured ally within 20 yards for 120% of the damage done.
+   * After you cast Essence Font, Tiger Palm, Blackout Kick, and Rising Sun Kick heal an injured ally within 20 yards for 250% of the damage done. Lasts 15s.
    */
   constructor(options: Options){
     super(options);
@@ -32,9 +32,13 @@ class AncientTeachingsoftheMonastery extends Analyzer {
 
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell([SPELLS.RISING_SUN_KICK_SECOND, SPELLS.BLACKOUT_KICK, SPELLS.BLACKOUT_KICK_TOTM, SPELLS.TIGER_PALM]), this.lastDamageEvent);
     this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.ANCIENT_TEACHINGS_OF_THE_MONASTERY_HEAL), this.calculateEffectiveHealing);
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.ANCIENT_TEACHINGS_OF_THE_MONASTERY_CRIT_HEAL), this.calculateEffectiveHealing);
   }
 
   lastDamageEvent(event: DamageEvent) {
+    if(!this.selectedCombatant.hasBuff(SPELLS.ANCIENT_TEACHINGS_OF_THE_MONASTERY_BUFF)) {
+      return;
+    }
     this.lastDamageSpellID = event.ability.guid;
     if(!this.damageSpellToHealing.has(this.lastDamageSpellID)){
       this.damageSpellToHealing.set(this.lastDamageSpellID, 0);


### PR DESCRIPTION
Added in spells for the  buff and "crit" heal and updated the event handlers for the new mechanics of the legendary

Even though the 'crit heal' isn't an actual crit the crit damage events still go to the separate id so this will work whether blizzard fixes it or not