### PR TITLE
Removed extra x-axis padding from several charts.

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -9,6 +9,7 @@ import Contributor from 'interface/ContributorButton';
 
 // prettier-ignore
 export default [
+  change(date(2020, 11, 1), 'Eliminated x-axis padding in several charts.', emallson),
   change(date(2020, 11, 1), 'Shifted all spells to use the same generic Spell type', Putro),
   change(date(2020, 10, 31), 'Added i18n of Premium page', jos3p),
   change(date(2020, 10, 29), 'Update game components to Typescript', jos3p),

--- a/src/interface/others/BaseChart.tsx
+++ b/src/interface/others/BaseChart.tsx
@@ -38,6 +38,11 @@ export default function BaseChart(props: Props) {
     config: defaultConfig,
     renderer: "canvas" as const,
     ...props,
+    spec: {
+      ...props.spec,
+      datasets: props.data,
+    },
+    data: undefined
   };
 
   return (

--- a/src/interface/others/FlushLineChart.tsx
+++ b/src/interface/others/FlushLineChart.tsx
@@ -20,6 +20,7 @@ export default function FlushLineChart(props: Props) {
 
   const x = props.x || 'time';
   const y = props.y || 'val';
+
   const spec = {
     mark: {
       type: 'area' as const,
@@ -39,7 +40,7 @@ export default function FlushLineChart(props: Props) {
         key: x,
         keyvals: {
           start: 0,
-          stop: props.duration || Math.max.apply(null, props.data.map((obj: any) => obj[x])),
+          stop: props.duration ? Math.ceil(props.duration) : Math.max.apply(null, props.data.map((obj: any) => obj[x])),
         },
         method: 'value' as const,
         value: 0,

--- a/src/interface/others/FlushLineChart.tsx
+++ b/src/interface/others/FlushLineChart.tsx
@@ -60,6 +60,9 @@ export default function FlushLineChart(props: Props) {
         field: x,
         type: 'quantitative' as const,
         axis: null,
+        scale: {
+          nice: false
+        },
       },
       y: {
         field: 'sum_val',

--- a/src/interface/others/charts/ManaLevelGraph.js
+++ b/src/interface/others/charts/ManaLevelGraph.js
@@ -47,7 +47,7 @@ class ManaLevelGraph extends React.PureComponent {
                 grid: false,
               },
               title: null,
-              scale: { zero: true },
+              scale: { zero: true, nice: false },
             },
             y: {
               field: 'y',

--- a/src/parser/monk/brewmaster/modules/features/StaggerPoolGraph.tsx
+++ b/src/parser/monk/brewmaster/modules/features/StaggerPoolGraph.tsx
@@ -98,7 +98,11 @@ class StaggerPoolGraph extends Analyzer {
       type: 'quantitative' as const,
       axis: {
         labelExpr: formatTime('datum.value'),
+        tickCount: 25,
         grid: false,
+      },
+      scale: {
+        nice: false,
       },
       title: null,
     };

--- a/src/parser/shaman/shared/maelstromchart/Maelstrom.js
+++ b/src/parser/shaman/shared/maelstromchart/Maelstrom.js
@@ -51,6 +51,9 @@ const Maelstrom = props => {
           labelExpr: formatTime('datum.value * 1000'),
           grid: false,
         },
+        scale: {
+          nice: false,
+        },
         title: 'Time',
       },
       y: {

--- a/src/parser/shared/modules/features/SelfHealTimingGraph.js
+++ b/src/parser/shared/modules/features/SelfHealTimingGraph.js
@@ -99,7 +99,7 @@ class SelfHealTimingGraph extends Analyzer {
           grid: false,
         },
         title: null,
-        scale: { zero: true },
+        scale: { zero: true, nice: false },
       },
       y: {
         field: 'y',

--- a/src/parser/shared/modules/resources/mana/ManaUsageGraph.js
+++ b/src/parser/shared/modules/resources/mana/ManaUsageGraph.js
@@ -46,7 +46,7 @@ class ManaUsageGraph extends React.Component {
             grid: false,
           },
           title: null,
-          scale: { zero: true },
+          scale: { zero: true, nice: false },
         },
         y: {
           field: 'y',


### PR DESCRIPTION
This is not a universal change, but I adjusted a few that I saw. The fix is just to set `scale: { nice: false }` on the x-axis encoding.

This improves the rendering of charts where we'd naturally expect the right-end to match with the fight length.

## Before
![image](https://user-images.githubusercontent.com/4909458/97817218-fc4ccc00-1c68-11eb-9adb-f96539a99dc5.png)

## After
![image](https://user-images.githubusercontent.com/4909458/97817213-eb9c5600-1c68-11eb-98fa-ae203ba8439e.png)
