### PR TITLE
[Elemental] Fix statistics box with Flame Shock

### DIFF
--- a/src/parser/shaman/elemental/CHANGELOG.tsx
+++ b/src/parser/shaman/elemental/CHANGELOG.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { niseko, HawkCorrigan, Draenal, TheJigglr, Zeboot } from 'CONTRIBUTORS';
+import { niseko, HawkCorrigan, Draenal, TheJigglr, Zeboot, Mae } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 11, 4), <>Fix duration and statictic display for <SpellLink id={SPELLS.FLAME_SHOCK.id} /></>, Mae),
   change(date(2020, 10, 31), <>Add a suggestion for usage of Echoing Shock</>, HawkCorrigan),
   change(date(2020, 10, 25), <>Convert to Typescript</>, HawkCorrigan),
   change(date(2020, 10, 18), 'Converted legacy listeners to new event filters', Zeboot),

--- a/src/parser/shaman/elemental/modules/core/FlameShock.tsx
+++ b/src/parser/shaman/elemental/modules/core/FlameShock.tsx
@@ -9,15 +9,15 @@ import Enemies from 'parser/shared/modules/Enemies';
 import EarlyDotRefreshesAnalyzer from 'parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes';
 import badRefreshSuggestion from 'parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesSuggestionByCount';
 
-import { STATISTIC_ORDER } from 'interface/others/StatisticBox';
+import StatisticBox, { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import { DamageEvent } from 'parser/core/Events';
-import Statistic from 'interface/statistics/Statistic';
 import Events from 'parser/core/Events';
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 
 import { i18n } from '@lingui/core';
 import { t } from '@lingui/macro';
+import Icon from 'common/Icon';
 
 class FlameShock extends EarlyDotRefreshesAnalyzer {
   static dependencies = {
@@ -98,17 +98,13 @@ class FlameShock extends EarlyDotRefreshesAnalyzer {
 
   statistic() {
     return (
-      <Statistic
+      <StatisticBox
         position={STATISTIC_ORDER.CORE()}
         size="flexible"
-        >
-        <>
-          <UptimeIcon /> {formatPercentage(this.uptime)}% uptime on Flame Shock
-        </>
         value={`${formatPercentage(this.uptime)} %`}
-        label="Uptime"
-        tooltip="Flame Shock Uptime"
-      </Statistic>
+        icon={<Icon icon={SPELLS.FLAME_SHOCK.icon}/>}
+        label="Flame Shock uptime"
+        />
     );
   }
 }

--- a/src/parser/shaman/elemental/modules/core/FlameShock.tsx
+++ b/src/parser/shaman/elemental/modules/core/FlameShock.tsx
@@ -28,7 +28,7 @@ class FlameShock extends EarlyDotRefreshesAnalyzer {
   protected enemies!: Enemies;
 
   static dots = [{
-    name: "Flame Shock",
+    name: SPELLS.FLAME_SHOCK.name,
     debuffId: SPELLS.FLAME_SHOCK.id,
     castId: SPELLS.FLAME_SHOCK.id,
     duration: 18000,
@@ -103,7 +103,7 @@ class FlameShock extends EarlyDotRefreshesAnalyzer {
         size="flexible"
         value={`${formatPercentage(this.uptime)} %`}
         icon={<Icon icon={SPELLS.FLAME_SHOCK.icon}/>}
-        label="Flame Shock uptime"
+        label={`${SPELLS.FLAME_SHOCK.name} uptime`}
         />
     );
   }

--- a/src/parser/shaman/elemental/modules/core/FlameShock.tsx
+++ b/src/parser/shaman/elemental/modules/core/FlameShock.tsx
@@ -31,7 +31,7 @@ class FlameShock extends EarlyDotRefreshesAnalyzer {
     name: "Flame Shock",
     debuffId: SPELLS.FLAME_SHOCK.id,
     castId: SPELLS.FLAME_SHOCK.id,
-    duration: 24000,
+    duration: 18000,
     movementFiller: true,
   }]
 

--- a/src/parser/shaman/enhancement/modules/resourceTracker/MaelstromWeaponTracker.ts
+++ b/src/parser/shaman/enhancement/modules/resourceTracker/MaelstromWeaponTracker.ts
@@ -1,0 +1,5 @@
+import ResourceTracker from 'parser/shared/modules/resources/resourcetracker/ResourceTracker';
+
+class MaelstromWeaponTracker extends ResourceTracker {
+
+}


### PR DESCRIPTION
Related issue: https://github.com/WoWAnalyzer/WoWAnalyzer/issues/4050

After fix:

<img width="326" alt="Screenshot 2020-11-04 at 21 04 12" src="https://user-images.githubusercontent.com/10657271/98162212-4fc94f00-1ee1-11eb-8234-e08dcd94e0e7.png">

Proof for duration fix: https://www.wowhead.com/spell=188389/flame-shock