### PR TITLE
[Core] run build & docker actions only on upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,7 @@ jobs:
     needs: [prepare]
     name: 'Build'
     runs-on: ubuntu-latest
+    if: github.repository == 'wowanalyzer/wowanalyzer'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -152,7 +153,7 @@ jobs:
       [typecheck, linting, test-interface, test-parser, test-integration, build]
     name: 'Publish Docker image'
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.repository == 'wowanalyzer/wowanalyzer'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1


### PR DESCRIPTION
This way the `Build` & `Publish Docker Image` jobs only run on upstream, since they fail on forks.
[Looks like this on forks](https://github.com/joshinat0r/WoWAnalyzer/actions/runs/346249621) compared to [previously](https://github.com/joshinat0r/WoWAnalyzer/actions/runs/328925972)