### PR TITLE
[Enhancement] Calculate Hailstorm stack statistics

### DIFF
--- a/src/parser/shaman/enhancement/CHANGELOG.tsx
+++ b/src/parser/shaman/enhancement/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 11, 5), <>Added stack statictics for <SpellLink id={SPELLS.HAILSTORM_TALENT.id}/></>, [Mae]),
   change(date(2020, 11, 5), <>Added <SpellLink id={SPELLS.FLAME_SHOCK.id} /> statistics</>, [Mae]),
   change(date(2020, 11, 3), <>Added <SpellLink id={SPELLS.SUNDERING_TALENT.id} /> to offensive cooldowns checklist.</>, [Mae]),
   change(date(2020, 10, 12), <>Added Maelstrom Weapon stats for <SpellLink id={SPELLS.FERAL_SPIRIT.id} />.</>, [Vonn]),

--- a/src/parser/shaman/enhancement/modules/talents/Hailstorm.tsx
+++ b/src/parser/shaman/enhancement/modules/talents/Hailstorm.tsx
@@ -5,15 +5,21 @@ import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Statistic from 'interface/statistics/Statistic';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
-import Events, { DamageEvent } from 'parser/core/Events';
+import Events, { ApplyBuffStackEvent, DamageEvent, RemoveBuffStackEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
 import ItemDamageDone from 'interface/ItemDamageDone';
 import AverageTargetsHit from 'interface/others/AverageTargetsHit';
 import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
+import { formatNumber, formatPercentage } from 'common/format';
+import Spell from 'common/SPELLS/Spell';
 
 const HAILSTORM = {
   INCREASE_PER_STACK: .35,
 };
+
+const MAX_STACKS = 5;
+const STACKS_CONSUMED_PER_FROST_SHOCK_CAST = 5;
+const MAX_MAELSTROM_WEAPON_STACKS_CONSUMED_PER_CAST = 5;
 
 /**
  * Each stack of Maelstrom Weapon consumed increases the damage of your next
@@ -26,6 +32,13 @@ class Hailstorm extends Analyzer {
   protected casts: number = 0;
   protected hits: number = 0;
   protected damage: number = 0;
+  protected currentStacks: number = 0;
+  protected lostStacks: number = 0;
+  protected totalStacksGained: number = 0;
+  protected overcappedStacks: number = 0;
+  protected currentMaelstromWeaponStacks: number = 0;
+
+  protected timestamp: number = 0;
 
   constructor(options: Options) {
     super(options);
@@ -33,22 +46,74 @@ class Hailstorm extends Analyzer {
     this.active = this.selectedCombatant.hasTalent(SPELLS.HAILSTORM_TALENT.id);
 
     this.addEventListener(
+      Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.MAELSTROM_WEAPON_BUFF),
+      this.onMaelstromWeaponStackApply,
+    )
+
+    const SPELLS_WITH_CAST_TIME: Spell[] = [
+      SPELLS.CHAIN_HEAL,
+      SPELLS.CHAIN_LIGHTNING,
+      SPELLS.HEALING_SURGE,
+      SPELLS.LIGHTNING_BOLT,
+    ]
+
+    SPELLS_WITH_CAST_TIME.forEach(spell => {
+      this.addEventListener(
+        Events.cast.by(SELECTED_PLAYER).spell(spell),
+        this.onSpellWithCastTimeCast
+      )
+    })
+    
+    this.addEventListener(
       Events.cast.by(SELECTED_PLAYER)
-        .spell(SPELLS.FROST_SHOCK),
+      .spell(SPELLS.FROST_SHOCK),
       this.onFrostShockCast,
+    );
+      
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER)
+      .spell(SPELLS.FROST_SHOCK),
+      this.onFrostShockDamage,
     );
 
     this.addEventListener(
-      Events.damage.by(SELECTED_PLAYER)
-        .spell(SPELLS.FROST_SHOCK),
-      this.onFrostShockDamage,
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.HAILSTORM_BUFF),
+      this.onHailstormRemove,
+    )
+
+    this.addEventListener(
+      Events.removebuffstack.by(SELECTED_PLAYER).spell(SPELLS.HAILSTORM_BUFF),
+        this.onHailstormStackRemove
+    )
+  }
+
+  onMaelstromWeaponStackApply(event: ApplyBuffStackEvent) {
+    this.currentMaelstromWeaponStacks = event.stack;
+  }
+
+  onSpellWithCastTimeCast() {
+    const maelstromWeaponStacksConsumed = Math.min(
+      MAX_MAELSTROM_WEAPON_STACKS_CONSUMED_PER_CAST,
+      this.currentMaelstromWeaponStacks
+    )
+    this.currentMaelstromWeaponStacks -= maelstromWeaponStacksConsumed;
+
+    const hailstormStacksGained = Math.min(
+      maelstromWeaponStacksConsumed,
+      MAX_STACKS - this.currentStacks
     );
+    this.currentStacks += hailstormStacksGained;
+    this.totalStacksGained += hailstormStacksGained;
+    this.overcappedStacks += maelstromWeaponStacksConsumed - hailstormStacksGained;
   }
 
   onFrostShockCast() {
     if (!this.selectedCombatant.hasBuff(SPELLS.HAILSTORM_BUFF.id)) {
       return;
     }
+
+    this.currentStacks -= STACKS_CONSUMED_PER_FROST_SHOCK_CAST;
+    this.currentStacks = this.currentStacks < 0 ? 0 : this.currentStacks;
 
     this.casts += 1;
   }
@@ -60,7 +125,27 @@ class Hailstorm extends Analyzer {
 
     this.hits += 1;
     // TODO: hailstorm buff stacks are buggy right now, so assume that they're correctly using 5 stacks
-    this.damage += calculateEffectiveDamage(event, HAILSTORM.INCREASE_PER_STACK * 5);
+    this.damage += calculateEffectiveDamage(event, HAILSTORM.INCREASE_PER_STACK * STACKS_CONSUMED_PER_FROST_SHOCK_CAST);
+  }
+
+  onHailstormStackRemove(event: RemoveBuffStackEvent) {
+    // if hailstorm removal is due to consumption by frost shock, they are not considered as lost
+    if (this.currentStacks === 0) {
+      return;
+    }
+
+    this.lostStacks += (this.currentStacks - event.stack);
+    this.currentStacks = event.stack;
+  }
+
+  onHailstormRemove() {
+    // if hailstorm removal is due to consumption by frost shock, they are not considered as lost
+    if (this.currentStacks === 0) {
+      return;
+    }
+
+    this.lostStacks += this.currentStacks;
+    this.currentStacks = 0;
   }
 
   statistic() {
@@ -69,11 +154,28 @@ class Hailstorm extends Analyzer {
         position={STATISTIC_ORDER.OPTIONAL()}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={(
+          <ul>
+            <li>Stacks gained: usable stacks that you gained, not counting overcap.</li>
+            <li>Overcapped stacks: stacks that you could have potentially gained, but didn't because you can't have more then {MAX_STACKS} stacks.</li>
+            <li>Timed out stacks: stacks that you didn't consume with Frost Shock and that ended up timing out.</li>
+          </ul>
+        )}
       >
         <BoringSpellValueText spell={SPELLS.HAILSTORM_TALENT}>
           <>
             <ItemDamageDone amount={this.damage} approximate /><br />
-            <AverageTargetsHit casts={this.casts} hits={this.hits} />
+            <AverageTargetsHit casts={this.casts} hits={this.hits} /><br/>
+            {formatNumber(this.totalStacksGained)} <small>stacks gained</small><br/>
+            { formatNumber(this.overcappedStacks)} <small>stacks overcapped</small><br/>
+            { this.lostStacks !== 0
+              ? <p style={{whiteSpace: 'nowrap'}}>
+                  {formatNumber(this.lostStacks)}{` `}
+                  ({formatPercentage(this.lostStacks / this.totalStacksGained )}%){` `}
+                  <small>stacks timed out</small>
+                </p> 
+              : <>{formatNumber(this.lostStacks)}{` `}<small>stacks lost due to buff timeout</small></>
+            }
           </>
         </BoringSpellValueText>
       </Statistic>

--- a/src/parser/shaman/enhancement/modules/talents/Hailstorm.tsx
+++ b/src/parser/shaman/enhancement/modules/talents/Hailstorm.tsx
@@ -156,9 +156,8 @@ class Hailstorm extends Analyzer {
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={(
           <ul>
-            <li>Stacks gained: usable stacks that you gained, not counting overcap.</li>
-            <li>Overcapped stacks: stacks that you could have potentially gained, but didn't because you can't have more then {MAX_STACKS} stacks.</li>
-            <li>Timed out stacks: stacks that you didn't consume with Frost Shock and that ended up timing out.</li>
+            <li>{`${formatNumber(this.totalStacksGained)} / ${formatNumber(this.totalStacksGained + this.overcappedStacks)} stacks gained: you overcapped ${this.overcappedStacks} stacks.`}</li>
+            <li>{`${formatNumber(this.totalStacksGained - this.lostStacks)} / ${formatNumber(this.totalStacksGained)} stacks used: ${this.lostStacks} stacks lost due to timeout.`}</li>
           </ul>
         )}
       >
@@ -166,16 +165,10 @@ class Hailstorm extends Analyzer {
           <>
             <ItemDamageDone amount={this.damage} approximate /><br />
             <AverageTargetsHit casts={this.casts} hits={this.hits} /><br/>
-            {formatNumber(this.totalStacksGained)} <small>stacks gained</small><br/>
-            { formatNumber(this.overcappedStacks)} <small>stacks overcapped</small><br/>
-            { this.lostStacks !== 0
-              ? <p style={{whiteSpace: 'nowrap'}}>
-                  {formatNumber(this.lostStacks)}{` `}
-                  ({formatPercentage(this.lostStacks / this.totalStacksGained )}%){` `}
-                  <small>stacks timed out</small>
-                </p> 
-              : <>{formatNumber(this.lostStacks)}{` `}<small>stacks lost due to buff timeout</small></>
-            }
+            <>
+                  {formatPercentage((this.totalStacksGained - this.lostStacks)/(this.totalStacksGained + this.overcappedStacks))}{'% '}
+                  <small>stacks used</small>
+            </>
           </>
         </BoringSpellValueText>
       </Statistic>


### PR DESCRIPTION
Related issue: https://github.com/WoWAnalyzer/WoWAnalyzer/issues/3222

Ideas behind this analyzer:

- Hailstorm stacks are gained when player uses Maelstrom Weapon stacks, but not when Maelstrom Weapon stacks expire by themselves
- `onMaelstromWeaponStackApply` method helps track current number of Maelstrom Weapon stacks
- `onSpellWithCastTimeCast` method is used to detect when Maelstrom Weapon stacks are spent and determine the number of Hailstorm stacks gained


Used [this logs](https://www.warcraftlogs.com/reports/WYf4JAB7vPaVKrgD) to test.

<img width="322" alt="Screenshot 2020-11-08 at 15 37 47" src="https://user-images.githubusercontent.com/10657271/98467936-666cf000-21d8-11eb-8a82-de2e3b7f46fb.png">

<img width="480" alt="Screenshot 2020-11-08 at 15 37 52" src="https://user-images.githubusercontent.com/10657271/98467932-640a9600-21d8-11eb-999c-419918b280d4.png">
