### PR TITLE
[Frost Mage] Non Shatter Ice Lance Fix

### DIFF
--- a/src/parser/mage/frost/CHANGELOG.tsx
+++ b/src/parser/mage/frost/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 11, 8), <>Resolved an issue where <SpellLink id={SPELLS.ICE_LANCE.id} /> was miscounting Non Shattered casts. </>, Sharrq),
   change(date(2020, 10, 29), <>Updated <SpellLink id={SPELLS.BRAIN_FREEZE.id} /> module to check for overlapping <SpellLink id={SPELLS.FLURRY.id} /> (Using a Brain Freeze while Winters Chill is still on the target). </>, Sharrq),
   change(date(2020, 10, 20), 'Cleaned up variable types and constants.', Sharrq),
   change(date(2020, 10, 20), <>Added Covenant Abilities to Spellbook and removed the GCD on <SpellLink id={SPELLS.ICY_VEINS.id} />. </>, Sharrq),

--- a/src/parser/mage/frost/integrationTests/example.test.ts.snap
+++ b/src/parser/mage/frost/integrationTests/example.test.ts.snap
@@ -4975,7 +4975,7 @@ exports[`Frost Mage integration test: example log IceLance matches the statistic
         <div
           className="value"
         >
-          44%
+          50%
            
           <small>
             Casts shattered
@@ -5016,9 +5016,9 @@ Array [
         id={30455}
       />
        
-      10
+      9
        times (
-      55.56
+      50.00
       %) without 
       <ForwardRef
         id={12982}
@@ -5034,7 +5034,7 @@ Array [
        proc, or if you are moving and you cant cast anything else.
     </React.Fragment>,
     "stat": <React.Fragment>
-      55.56% missed
+      50.00% missed
        (
       &lt;5.00% is recommended
       )

--- a/src/parser/mage/frost/modules/features/BrainFreeze.tsx
+++ b/src/parser/mage/frost/modules/features/BrainFreeze.tsx
@@ -64,7 +64,6 @@ class BrainFreeze extends Analyzer {
 
   onFlurryCast(event: CastEvent) {
     const enemy = this.enemies.getEntity(event);
-    this.log(enemy.hasBuff(SPELLS.WINTERS_CHILL.id))
     if (!this.selectedCombatant.hasBuff(SPELLS.BRAIN_FREEZE.id)) {
       this.flurryHardCast += 1;
     } else if (enemy && enemy.hasBuff(SPELLS.WINTERS_CHILL.id)) {

--- a/src/parser/mage/frost/modules/features/IceLance.tsx
+++ b/src/parser/mage/frost/modules/features/IceLance.tsx
@@ -55,7 +55,7 @@ class IceLance extends Analyzer {
       return;
     }
     const enemy = this.enemies.getEntity(event);
-    if (enemy && !SHATTER_DEBUFFS.some(effect => enemy.hasBuff(effect, event.timestamp)) && !this.hadFingersProc) {
+    if (enemy && !SHATTER_DEBUFFS.some(effect => enemy.hasBuff(effect.id, event.timestamp)) && !this.hadFingersProc) {
       this.nonShatteredCasts += 1;
     }
   }


### PR DESCRIPTION
This resolves an issue where Ice Lance was miscounting the number of Non Shattered casts. Also removes a leftover console log from Brain Freeze