### PR TITLE
[Prot Paladin] Add SOTR Overcap Analyzer

### DIFF
--- a/src/parser/paladin/protection/CHANGELOG.tsx
+++ b/src/parser/paladin/protection/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 11, 8), <>Add Overcap analyzer for <SpellLink id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id}/> </>, Hordehobbs),
   change(date(2020, 10, 27), <>Update analyzers for <SpellLink id={SPELLS.RIGHTEOUS_PROTECTOR_TALENT.id}/> and <SpellLink id={SPELLS.SERAPHIM_TALENT.id}/>.</>, Hordehobbs),
   change(date(2020, 10, 26), <>Create analyzers for <SpellLink id={SPELLS.FIRST_AVENGER_TALENT.id} /> and <SpellLink id={SPELLS.MOMENT_OF_GLORY_TALENT.id} />.</>, Hordehobbs),
   change(date(2020, 10, 25), <>Create analyzers for <SpellLink id={SPELLS.REDOUBT_TALENT.id} /> and <SpellLink id={SPELLS.BLESSED_HAMMER_TALENT.id}/>.</>, Hordehobbs),

--- a/src/parser/paladin/protection/CombatLogParser.ts
+++ b/src/parser/paladin/protection/CombatLogParser.ts
@@ -9,6 +9,7 @@ import Checklist from './modules/features/Checklist/Module';
 import MitigationCheck from './modules/features/MitigationCheck';
 import Haste from './modules/core/Haste';
 
+import OvercapShieldOfTheRighteous from './modules/features/OvercapShieldOfTheRighteous';
 
 //Spells
 import Consecration from './modules/spells/Consecration';
@@ -56,6 +57,7 @@ class CombatLogParser extends CoreCombatLogParser {
     consecration: Consecration,
     mitigationcheck: MitigationCheck,
     noDamageSOTR: NoDamageShieldOfTheRighteous,
+    overcapSOTR: OvercapShieldOfTheRighteous,
     //cooldownTracker: CooldownTracker,
 
     // Talents

--- a/src/parser/paladin/protection/integrationTests/example.test.ts.snap
+++ b/src/parser/paladin/protection/integrationTests/example.test.ts.snap
@@ -4398,6 +4398,94 @@ exports[`Protection Paladin integration test: example log NullDynamo matches the
 </div>
 `;
 
+exports[`Protection Paladin integration test: example log OvercapShieldOfTheRighteous matches the statistic snapshot 1`] = `
+<div
+  className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
+>
+  <div
+    category="GENERAL"
+    className="panel statistic flexible "
+    position={100}
+    style={
+      Object {
+        "zIndex": 1,
+      }
+    }
+  >
+    <div
+      className="panel-body"
+    >
+      <div
+        className="flex boring-value "
+      >
+        <div
+          className="flex-sub icon"
+        >
+          <a
+            className="spell-link-text"
+            href="http://wowhead.com/spell=53600"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <img
+              alt="Shield of the Righteous"
+              className="icon game "
+              src="//render-us.worldofwarcraft.com/icons/56/ability_paladin_shieldofvengeance.jpg"
+            />
+          </a>
+        </div>
+        <div
+          className="flex-main value"
+        >
+          <div>
+            -2s
+          </div>
+          <small>
+            Uptime lost to overcapping
+          </small>
+        </div>
+      </div>
+      <div
+        className="row"
+      >
+        <div
+          className="col-xs-12"
+        />
+      </div>
+      <div
+        className="statistic-expansion-button-holster"
+      >
+        <button
+          className="btn btn-primary"
+          onClick={[Function]}
+        >
+          <span
+            className="glyphicon glyphicon-chevron-down"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      className="detail-corner"
+      data-place="top"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onTouchStart={[Function]}
+    >
+      <svg
+        className="icon"
+        viewBox="0 0 100 100"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M58.9,82.9h7v12.9H34.1V82.9h7.1V45.5h-0.6c-3.6,0-6.4-2.9-6.4-6.4c0-3.6,2.9-6.4,6.4-6.4h0.6h17.4h0.3V82.9z M49,25.8  c6,0,10.8-4.8,10.8-10.8C59.8,9,55,4.2,49,4.2S38.2,9,38.2,15C38.2,21,43,25.8,49,25.8z"
+        />
+      </svg>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Protection Paladin integration test: example log PotionChecker matches the suggestions snapshot 1`] = `
 Array [
   Object {

--- a/src/parser/paladin/protection/modules/features/OvercapShieldOfTheRighteous.tsx
+++ b/src/parser/paladin/protection/modules/features/OvercapShieldOfTheRighteous.tsx
@@ -1,0 +1,126 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent } from 'parser/core/Events';
+import SPELLS from 'common/SPELLS';
+import React from 'react';
+import Statistic from 'interface/statistics/Statistic';
+import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+import BoringSpellValue from 'interface/statistics/components/BoringSpellValue';
+import { formatNumber } from 'common/format';
+import SpellLink from 'common/SpellLink';
+import Abilities from 'parser/paladin/protection/modules/Abilities';
+import SpellUsable from 'parser/paladin/protection/modules/features/SpellUsable';
+import { TrackedBuffEvent } from 'parser/core/Entity';
+
+const ACTIVE_MITIGATION_CAP = 13.5 * 1000; // Active mitigation buffs cap out at 13.5 seconds.
+const SOTR_BUFF_LENGTH = 4.5 * 1000; // SOTR grants a 4.5s buff.
+const SOTR_SOFT_CAP = ACTIVE_MITIGATION_CAP - SOTR_BUFF_LENGTH;
+const SECOND = 1000;
+
+class OvercapShieldOfTheRighteous extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+  };
+
+  protected spellUsable!: SpellUsable;
+
+  goodSotrCasts: number = 0;
+  badSotrCasts: number = 0;
+  totalSotrOvercapping: number = 0;
+  lastSotrCastTimestamp: number = 0;
+  numSotrCasts: number = 0;
+  sotrCasts: CastEvent[] = [];
+  sotrCastToBuffTimeAtCast: Map<number, number> = new Map<number, number>();
+
+  hpGeneratingSpells = [
+    SPELLS.BLESSED_HAMMER_TALENT,
+    SPELLS.HAMMER_OF_THE_RIGHTEOUS,
+    SPELLS.HAMMER_OF_WRATH,
+    SPELLS.JUDGMENT_CAST_PROTECTION,
+  ];
+
+  constructor(options: Options) {
+    super(options);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.SHIELD_OF_THE_RIGHTEOUS), this.trackSotRCasts);
+  }
+
+  trackSotRCasts(event: CastEvent): void {
+    this.numSotrCasts += 1;
+    this.sotrCasts.push(event);
+    if (this.sotrCastToBuffTimeAtCast.size === 0) {
+      this.sotrCastToBuffTimeAtCast.set(event.timestamp, 0);
+    } else {
+      const diffBetweenSotRCasts = event.timestamp - this.lastSotrCastTimestamp;
+      const buffTimeAtLastCast = (this.sotrCastToBuffTimeAtCast.get(this.lastSotrCastTimestamp) || 0);
+      const currentBuffUptime = Math.max(Math.min(SOTR_BUFF_LENGTH - diffBetweenSotRCasts + buffTimeAtLastCast, ACTIVE_MITIGATION_CAP), 0);
+      console.log(`Calculated ${currentBuffUptime} as ${SOTR_BUFF_LENGTH} - ${diffBetweenSotRCasts} + ${buffTimeAtLastCast}.`);
+      this.sotrCastToBuffTimeAtCast.set(event.timestamp, currentBuffUptime);
+    }
+    this.lastSotrCastTimestamp = event.timestamp;
+  }
+
+  getSotrOvercapAmount(event: CastEvent): number {
+    if (!this.selectedCombatant.hasBuff(SPELLS.SHIELD_OF_THE_RIGHTEOUS_BUFF.id, event.timestamp)) {
+      return 0;
+    } else if (this.castIsForgivable(event)) {
+      return 0;
+    } else {
+      const currentBufftime = this.getCurrentSotrBuffTime(event);
+      console.log(`Found current SOTR buff time of ${currentBufftime} at timestamp ${event.timestamp}.`);
+      return Math.min(Math.max(0, currentBufftime + SOTR_BUFF_LENGTH - SOTR_SOFT_CAP), SOTR_BUFF_LENGTH);
+    }
+  }
+
+  /**
+   * Determine if a cast of SotR is "forgivable" despite buff overcapping.
+   * A cast is determined to be forgivable if using abilities other than SotR
+   * would result in Holy Power overcapping otherwise.
+   * @param event
+   */
+  castIsForgivable(event: CastEvent): boolean {
+    for (let i = 0; i < this.hpGeneratingSpells.length; i++) {
+      if (this.spellUsable.isAvailable(this.hpGeneratingSpells[i].id)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  getCurrentSotrBuffTime(event: CastEvent): number {
+    return (this.sotrCastToBuffTimeAtCast.get(event.timestamp) || 0);
+  }
+
+  statistic(): React.ReactNode {
+    const idealSotrUptime = this.numSotrCasts * SOTR_BUFF_LENGTH;
+    const actualSotrUptime = this.selectedCombatant.getBuffUptime(SPELLS.SHIELD_OF_THE_RIGHTEOUS_BUFF.id);
+    const lostUptimeDueToOvercap = idealSotrUptime - actualSotrUptime;
+    let overcapSum: number = 0;
+    this.sotrCasts.forEach((cast) => {
+      const overcapAmount = this.getSotrOvercapAmount(cast);
+      console.log(`Found overcap amount of ${overcapAmount} for SOTR cast at timestamp ${cast.timestamp}.`);
+      overcapSum += overcapAmount;
+    });
+    return (
+      <>
+        <Statistic
+          position={STATISTIC_ORDER.DEFAULT}
+          size="flexible"
+          category={STATISTIC_CATEGORY.GENERAL}
+          tooltip={(
+            <>
+              You lost {formatNumber(lostUptimeDueToOvercap/SECOND)} seconds due to overcapping <SpellLink id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id} />.<br />
+              Overcapping occurs when you cast <SpellLink id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id} /> with more than {formatNumber(SOTR_SOFT_CAP/SECOND)} seconds left on the buff.
+            </>
+          )}
+        >
+          <BoringSpellValue spell={SPELLS.SHIELD_OF_THE_RIGHTEOUS}
+            value={`${formatNumber(lostUptimeDueToOvercap/SECOND)}s`}
+            label="Uptime lost to overcapping"
+          />
+        </Statistic>
+      </>
+    );
+  }
+}
+
+export default OvercapShieldOfTheRighteous;


### PR DESCRIPTION
## Notes
- Resolves #3976 
- Adds OvercapShieldOfTheRighteous Analyzer to track total amount of SOTR buff overcapping and which SOTR casts resulted in buff overcapping.
- [Log used in testing. ](https://www.warcraftlogs.com/reports/xXW9f4KnmdF2MYV8/#fight=41&source=2)

## Screenshots
<img width="246" alt="2020-11-08 13_50_11-Mythic Wrathion - Kill (4_22) by Decix in Ny'alotha - WoWAnalyzer" src="https://user-images.githubusercontent.com/6363390/98485285-3159a100-21ca-11eb-921a-e24bcf0d5015.png">

## Testing
- `yarn lint`, `yarn build`, `yarn test:integration`
