### PR TITLE
[DisciplinePriest] Fix Schism damage multiplier to 25%

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -1021,4 +1021,19 @@ export const Mae: Contributor = {
     spec: SPECS.RESTORATION_SHAMAN,
     link: 'https://worldofwarcraft.com/en-gb/character/eu/draenor/maerstrom'
   }]
-}
+};
+export const VMakaev: Contributor = {
+  nickname: 'VMakaev',
+  github: 'vladimirmakaev',
+  discord: 'Vladimir#5076',
+  mains: [{
+    name: 'Kaylleen',
+    spec: SPECS.DISCIPLINE_PRIEST,
+    link: 'https://worldofwarcraft.com/en-gb/character/eu/silvermoon/kaylleen'
+  }, {
+    name: 'Elastan',
+    spec: SPECS.PROTECTION_PALADIN,
+    link: 'https://worldofwarcraft.com/en-gb/character/eu/silvermoon/elastan'
+  }]
+};
+

--- a/src/parser/priest/discipline/CHANGELOG.tsx
+++ b/src/parser/priest/discipline/CHANGELOG.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Ogofo, Oratio, Reglitch, Zerotorescue, niseko, Khadaj, blazyb, Adoraci, Tiphess, Putro, Zeboot } from 'CONTRIBUTORS';
+import { Ogofo, Oratio, Reglitch, Zerotorescue, niseko, Khadaj, blazyb, Adoraci, Tiphess, Putro, Zeboot, VMakaev } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import ItemLink from 'common/ItemLink';
@@ -8,7 +8,8 @@ import ITEMS from 'common/ITEMS';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2020, 11, 13),  <>Implementation of <SpellLink id={SPELLS.SHINING_RADIANCE.id} />.</>, [Oratio]),
+  change(date(2020, 12, 2), <>Fixed damage bonus of <SpellLink id={SPELLS.SCHISM_TALENT.id} /> to 25% to match Shadowlands nerf.</>, [VMakaev]),
+  change(date(2020, 11, 13), <>Implementation of <SpellLink id={SPELLS.SHINING_RADIANCE.id} />.</>, [Oratio]),
   change(date(2020, 10, 18), 'Converted legacy listeners to new event filters', Zeboot),
   change(date(2020, 10, 10), <>Implementation of <SpellLink id={SPELLS.BOON_OF_THE_ASCENDED.id} />.</>, [Ogofo]),
   change(date(2020, 10, 3), <>Update <SpellLink id={SPELLS.POWER_WORD_SOLACE_TALENT.id} /> cooldown.</>, [Reglitch]),

--- a/src/parser/priest/discipline/modules/spells/Schism.tsx
+++ b/src/parser/priest/discipline/modules/spells/Schism.tsx
@@ -42,7 +42,7 @@ class Schism extends Analyzer {
   protected sins!: SinsOfTheMany;
 
   // Spell metadata
-  static bonus = 0.4;
+  static bonus = 0.25;
   static duration = 9000;
   static synergisticAbilities = [
     SPELLS.HALO_TALENT.id,


### PR DESCRIPTION
Noticed this when was looking through the code. It was changed from 40% to 25%