### PR TITLE
[Mage] Firestorm Support, Bug Fixes

### DIFF
--- a/src/common/SPELLS/shadowlands/legendaries/mage.ts
+++ b/src/common/SPELLS/shadowlands/legendaries/mage.ts
@@ -71,6 +71,11 @@ const legendaries: SpellList<LegendarySpell> = {
     icon: 'spell_fire_burnout',
     bonusID: 6932,
   },
+  FIRESTORM_BUFF: {
+    id: 333100,
+    name: 'Firestorm',
+    icon: 'spell_fire_burnout',
+  },
   SUN_KINGS_BLESSING: {
     id: 333313,
     name: 'Sun King\'s Blessing',

--- a/src/parser/mage/fire/CHANGELOG.tsx
+++ b/src/parser/mage/fire/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 12, 8), <>Added support for <SpellLink id={SPELLS.FIRESTORM.id} /> and adjusted <SpellLink id={SPELLS.HEATING_UP.id} /> to check for a Venthyr edge case.</>, Sharrq),
   change(date(2020, 11, 16), <>Cleaned up some older modules, resolved an issue in <SpellLink id={SPELLS.PYROCLASM_TALENT.id} />, and added support for <SpellLink id={SPELLS.SHIFTING_POWER.id} /> and <SpellLink id={SPELLS.MIRRORS_OF_TORMENT.id} />.</>, Sharrq),
   change(date(2020, 11, 16), <>Updated numbers for <SpellLink id={SPELLS.INFERNAL_CASCADE.id} /> and <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} /> to match latest tuning.</>, Sharrq),
   change(date(2020, 10, 20), 'Cleaned up variable types and constants.', Sharrq),

--- a/src/parser/mage/fire/CombatLogParser.ts
+++ b/src/parser/mage/fire/CombatLogParser.ts
@@ -38,6 +38,7 @@ import Kindling from './modules/talents/Kindling';
 
 //Legendaries
 import FeveredIncantation from './modules/items/FeveredIncantation';
+import Firestorm from './modules/items/Firestorm';
 
 //Covenants
 import ShiftingPower from '../shared/modules/features/ShiftingPower';
@@ -95,6 +96,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     //Legendaries
     feveredIncantation: FeveredIncantation,
+    firestorm: Firestorm,
 
     //Covenants
     shiftingPower: ShiftingPower,

--- a/src/parser/mage/fire/modules/items/FeveredIncantation.tsx
+++ b/src/parser/mage/fire/modules/items/FeveredIncantation.tsx
@@ -14,9 +14,8 @@ import HIT_TYPES from 'game/HIT_TYPES';
 
 const DAMAGE_BONUS_PER_STACK = 0.02;
 
-class ControlledDestruction extends Analyzer {
+class FeveredIncantation extends Analyzer {
 
-  conduitRank = 0;
   bonusDamage = 0;
 
   constructor(props: Options) {
@@ -54,4 +53,4 @@ class ControlledDestruction extends Analyzer {
   }
 }
 
-export default ControlledDestruction;
+export default FeveredIncantation;

--- a/src/parser/mage/fire/modules/items/Firestorm.tsx
+++ b/src/parser/mage/fire/modules/items/Firestorm.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import Events, { CastEvent, ApplyBuffEvent } from 'parser/core/Events';
+import Statistic from 'interface/statistics/Statistic';
+import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+import { SELECTED_PLAYER } from 'parser/core/EventFilter';
+import { formatNumber } from 'common/format';
+
+class Firestorm extends Analyzer {
+
+  castsDuringFirestorm = 0;
+  firestormProcs = 0;
+
+  constructor(props: Options) {
+    super(props);
+    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.FIRESTORM.bonusID);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell([SPELLS.PYROBLAST,SPELLS.FLAMESTRIKE]), this.onCast);
+    this.addEventListener(Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.FIRESTORM_BUFF), this.onFirestormApplied);
+  }
+
+  onCast(event: CastEvent) {
+    if (!this.selectedCombatant.hasBuff(SPELLS.FIRESTORM_BUFF.id)) {
+      return;
+    }
+    this.castsDuringFirestorm += 1;
+  }
+
+  onFirestormApplied(event: ApplyBuffEvent) {
+    this.firestormProcs += 1;
+  }
+
+  get castsPerProc() {
+    return this.castsDuringFirestorm / this.firestormProcs;
+  }
+
+  get buffUptime() {
+    return this.selectedCombatant.getBuffUptime(SPELLS.FEVERED_INCANTATION_BUFF.id) / this.owner.fightDuration;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        category={STATISTIC_CATEGORY.ITEMS}
+        size="flexible"
+      >
+        <BoringSpellValueText spell={SPELLS.FIRESTORM}>
+          {formatNumber(this.firestormProcs)} <small>Total Procs</small><br />
+          {formatNumber(this.castsPerProc)} <small>Avg. Casts per Proc</small><br />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default Firestorm;

--- a/src/parser/mage/frost/CHANGELOG.tsx
+++ b/src/parser/mage/frost/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 12, 8), <>Fixed a potential crash with <SpellLink id={SPELLS.ICY_PROPULSION.id} />.</>, Sharrq),
   change(date(2020, 11, 16), <>Added support for <SpellLink id={SPELLS.SHIFTING_POWER.id} />.</>, Sharrq),
   change(date(2020, 11, 16), <>Updated numbers for <SpellLink id={SPELLS.ICY_PROPULSION.id} /> and <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} /> to match latest tuning.</>, Sharrq),
   change(date(2020, 11, 8), <>Resolved an issue where <SpellLink id={SPELLS.ICE_LANCE.id} /> was miscounting Non Shattered casts. </>, Sharrq),

--- a/src/parser/mage/frost/modules/items/IcyPropulsion.tsx
+++ b/src/parser/mage/frost/modules/items/IcyPropulsion.tsx
@@ -36,7 +36,7 @@ class IcyPropulsion extends Analyzer {
   }
 
   onDamage(event: DamageEvent) {
-    if (!this.selectedCombatant.hasBuff(SPELLS.ICY_VEINS.id) || event.hitType !== HIT_TYPES.CRIT) {
+    if (!this.selectedCombatant.hasBuff(SPELLS.ICY_VEINS.id) || event.hitType !== HIT_TYPES.CRIT || !this.spellUsable.isOnCooldown(SPELLS.ICY_VEINS.id)) {
       return;
     }
 


### PR DESCRIPTION
- Added support for Firestorm (Towards #3721 )
- Fixed a naming issue in Fevered Incantation
- Added a check for casting Fire Blast during Mirrors of Torment in Heating Up
- Resolved a potential crash in Icy Propulsion for Frost Mage