### PR TITLE
[Unholy Death Knight] Fix outdated suggestion for Soul Reaper

### DIFF
--- a/src/parser/deathknight/unholy/CHANGELOG.tsx
+++ b/src/parser/deathknight/unholy/CHANGELOG.tsx
@@ -7,7 +7,7 @@ import SPELLS from 'common/SPELLS'
 import SpellLink from 'common/SpellLink';
 
 export default [
-  change(date(2020, 12, 9), <>Removed no longer accurate checklist suggestion for <SpellLink id={SPELLS.SOUL_REAPER_TALENT.id}/></>, [Khazak]),
+  change(date(2020, 12, 9), <>Reworked <SpellLink id={SPELLS.SOUL_REAPER_TALENT.id}/> to use ExecuteHelper to provide cast efficiency and damage statistics</>, [Khazak]),
   change(date(2020, 12, 7), 'Updated Abilities with covenant signature and class abilities', [Khazak]),
   change(date(2020, 11, 25), <>Updated cooldown tracking to support <SpellLink id={SPELLS.DEATH_COIL.id} /> Rank 2 and <SpellLink id={SPELLS.ARMY_OF_THE_DAMNED_TALENT.id} /></>, [Khazak]),
   change(date(2020, 10, 27), <>Created statistics for <SpellLink id={SPELLS.RUNE_OF_THE_FALLEN_CRUSADER.id} /> and <SpellLink id={SPELLS.RUNE_OF_HYSTERIA.id} /></>, joshinator),

--- a/src/parser/deathknight/unholy/CHANGELOG.tsx
+++ b/src/parser/deathknight/unholy/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import SPELLS from 'common/SPELLS'
 import SpellLink from 'common/SpellLink';
 
 export default [
+  change(date(2020, 12, 9), <>Removed no longer accurate checklist suggestion for <SpellLink id={SPELLS.SOUL_REAPER_TALENT.id}/></>, [Khazak]),
   change(date(2020, 12, 7), 'Updated Abilities with covenant signature and class abilities', [Khazak]),
   change(date(2020, 11, 25), <>Updated cooldown tracking to support <SpellLink id={SPELLS.DEATH_COIL.id} /> Rank 2 and <SpellLink id={SPELLS.ARMY_OF_THE_DAMNED_TALENT.id} /></>, [Khazak]),
   change(date(2020, 10, 27), <>Created statistics for <SpellLink id={SPELLS.RUNE_OF_THE_FALLEN_CRUSADER.id} /> and <SpellLink id={SPELLS.RUNE_OF_HYSTERIA.id} /></>, joshinator),

--- a/src/parser/deathknight/unholy/CombatLogParser.ts
+++ b/src/parser/deathknight/unholy/CombatLogParser.ts
@@ -12,6 +12,8 @@ import VirulentPlagueEfficiency from './modules/features/VirulentPlagueEfficienc
 import WoundTracker from './modules/features/WoundTracker';
 import SpellUsable from './modules/features/SpellUsable'
 
+import SoulReaper from './modules/talents/SoulReaper';
+
 import RunicPowerDetails from './modules/runicpower/RunicPowerDetails';
 import RunicPowerTracker from './modules/runicpower/RunicPowerTracker';
 
@@ -35,6 +37,9 @@ class CombatLogParser extends CoreCombatLogParser {
     virulentPlagueEfficiency: VirulentPlagueEfficiency,
     woundTracker: WoundTracker,
     spellUsable: SpellUsable,
+
+    // Talents
+    soulReaper: SoulReaper,
 
     // RunicPower
     runicPowerTracker: RunicPowerTracker,

--- a/src/parser/deathknight/unholy/integrationTests/example.test.ts.snap
+++ b/src/parser/deathknight/unholy/integrationTests/example.test.ts.snap
@@ -1389,7 +1389,7 @@ exports[`Unholy Death Knight integration test: example log CastEfficiency matche
                   className="flex-sub performance-bar"
                   style={
                     Object {
-                      "backgroundColor": "#ff8000",
+                      "backgroundColor": "#70b570",
                       "width": "0%",
                     }
                   }
@@ -1414,9 +1414,7 @@ exports[`Unholy Death Knight integration test: example log CastEfficiency matche
                   "width": "25%",
                 }
               }
-            >
-              shared.castEfficiency.canBeImproved
-            </td>
+            />
           </tr>
           <tr>
             <td
@@ -3163,50 +3161,6 @@ Array [
       )
     </React.Fragment>,
   },
-  Object {
-    "details": null,
-    "icon": "spell_shadow_corpseexplode",
-    "importance": "major",
-    "issue": <React.Fragment>
-      <WithI18n
-        components={
-          Array [
-            <ForwardRef
-              id={327574}
-            />,
-          ]
-        }
-        defaults="Try to cast <0/> more often."
-        id="shared.modules.castEfficiency.suggest"
-      />
-       
-      
-    </React.Fragment>,
-    "stat": <React.Fragment>
-      <WithI18n
-        defaults="{0} out of {1} possible casts. You kept it on cooldown {2}% of the time."
-        id="shared.modules.castEfficiency.actual"
-        values={
-          Object {
-            "0": 0,
-            "1": 1,
-            "2": "0",
-          }
-        }
-      />
-       (
-      <WithI18n
-        defaults=">{0}% is recommended"
-        id="shared.modules.castEfficiency.recommended"
-        values={
-          Object {
-            "0": "90",
-          }
-        }
-      />
-      )
-    </React.Fragment>,
-  },
 ]
 `;
 
@@ -4438,23 +4392,7 @@ exports[`Unholy Death Knight integration test: example log matches the checklist
           <div
             className="col-md-12"
           >
-            You should aim to use your cooldowns as often as you can to maximize your damage output. In the case of 
-            <a
-              className="spell-link-text"
-              href="http://wowhead.com/spell=343294"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              <img
-                alt=""
-                className="icon game "
-                src="//render-us.worldofwarcraft.com/icons/56/ability_deathknight_soulreaper.jpg"
-              />
-               
-              Soul Reaper
-            </a>
-            , you want to use it when you're at less than 2 runes. However, you also want to make sure you don't waste possible casts by holding on to it for too long.
-             
+            You should aim to use your cooldowns as often as you can to maximize your damage output.
             <a
               href="https://www.wowhead.com/unholy-death-knight-rotation-guide#cooldown-usage"
               rel="noopener noreferrer"

--- a/src/parser/deathknight/unholy/integrationTests/example.test.ts.snap
+++ b/src/parser/deathknight/unholy/integrationTests/example.test.ts.snap
@@ -691,6 +691,106 @@ exports[`Unholy Death Knight integration test: example log CastEfficiency matche
               }
             />
           </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
+                href="http://wowhead.com/spell=343294"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/ability_deathknight_soulreaper.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Soul Reaper
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.00
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              0
+              /9
+               
+              casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#ff8000",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              0.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            >
+              shared.castEfficiency.canBeImproved
+            </td>
+          </tr>
         </tbody>
         <tbody>
           <tr>
@@ -3161,6 +3261,50 @@ Array [
       )
     </React.Fragment>,
   },
+  Object {
+    "details": null,
+    "icon": "ability_deathknight_soulreaper",
+    "importance": "major",
+    "issue": <React.Fragment>
+      <WithI18n
+        components={
+          Array [
+            <ForwardRef
+              id={343294}
+            />,
+          ]
+        }
+        defaults="Try to cast <0/> more often."
+        id="shared.modules.castEfficiency.suggest"
+      />
+       
+      
+    </React.Fragment>,
+    "stat": <React.Fragment>
+      <WithI18n
+        defaults="{0} out of {1} possible casts. You kept it on cooldown {2}% of the time."
+        id="shared.modules.castEfficiency.actual"
+        values={
+          Object {
+            "0": 0,
+            "1": 9,
+            "2": "0",
+          }
+        }
+      />
+       (
+      <WithI18n
+        defaults=">{0}% is recommended"
+        id="shared.modules.castEfficiency.recommended"
+        values={
+          Object {
+            "0": "85",
+          }
+        }
+      />
+      )
+    </React.Fragment>,
+  },
 ]
 `;
 
@@ -3878,6 +4022,67 @@ exports[`Unholy Death Knight integration test: example log ScourgeStrikeEfficien
           d="M58.9,82.9h7v12.9H34.1V82.9h7.1V45.5h-0.6c-3.6,0-6.4-2.9-6.4-6.4c0-3.6,2.9-6.4,6.4-6.4h0.6h17.4h0.3V82.9z M49,25.8  c6,0,10.8-4.8,10.8-10.8C59.8,9,55,4.2,49,4.2S38.2,9,38.2,15C38.2,21,43,25.8,49,25.8z"
         />
       </svg>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Unholy Death Knight integration test: example log SoulReaper matches the statistic snapshot 1`] = `
+<div
+  className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
+>
+  <div
+    category="TALENTS"
+    className="panel statistic flexible "
+    position={1030}
+  >
+    <div
+      className="panel-body"
+    >
+      <div
+        className="pad boring-text "
+      >
+        <label>
+          <a
+            className="spell-link-text"
+            href="http://wowhead.com/spell=343294"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <img
+              alt="Soul Reaper"
+              className="icon game "
+              src="//render-us.worldofwarcraft.com/icons/56/ability_deathknight_soulreaper.jpg"
+            />
+          </a>
+           
+          <a
+            className="spell-link-text"
+            href="http://wowhead.com/spell=343294"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Soul Reaper
+          </a>
+        </label>
+        <div
+          className="value"
+        >
+          <img
+            alt="Damage"
+            className="icon"
+            src="/img/sword.png"
+          />
+           
+          0
+           DPS
+           
+          <small>
+            0.00
+             % of total
+          </small>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/parser/deathknight/unholy/modules/features/Abilities.tsx
+++ b/src/parser/deathknight/unholy/modules/features/Abilities.tsx
@@ -132,7 +132,7 @@ class Abilities extends CoreAbilities {
           recommendedEfficiency: 0.90,
         },
       },
-      
+
       // defensives
       {
         spell: SPELLS.SACRIFICIAL_PACT,
@@ -140,10 +140,6 @@ class Abilities extends CoreAbilities {
         cooldown: 120,
         gcd: {
           base: 1500,
-        },
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: 0.90,
         },
       },
       {
@@ -195,7 +191,6 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.SOUL_REAPER_TALENT,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        cooldown: 6,
         gcd: {
           base: 1500,
         },

--- a/src/parser/deathknight/unholy/modules/features/Abilities.tsx
+++ b/src/parser/deathknight/unholy/modules/features/Abilities.tsx
@@ -189,14 +189,6 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.SOUL_REAPER_TALENT,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        gcd: {
-          base: 1500,
-        },
-        enabled: combatant.hasTalent(SPELLS.SOUL_REAPER_TALENT.id),
-      },
-      {
         spell: SPELLS.UNHOLY_BLIGHT_TALENT,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         enabled: combatant.hasTalent(SPELLS.UNHOLY_BLIGHT_TALENT.id),

--- a/src/parser/deathknight/unholy/modules/features/checklist/Component.js
+++ b/src/parser/deathknight/unholy/modules/features/checklist/Component.js
@@ -27,7 +27,7 @@ const UnholyDeathKnightChecklist = ({ combatant, castEfficiency, thresholds }) =
         name="Use cooldowns as often as possible"
         description={(
           <>
-            You should aim to use your cooldowns as often as you can to maximize your damage output. In the case of <SpellLink id={SPELLS.SOUL_REAPER_TALENT.id} />, you want to use it when you're at less than 2 runes. However, you also want to make sure you don't waste possible casts by holding on to it for too long.{' '}
+            You should aim to use your cooldowns as often as you can to maximize your damage output.
             <a href="https://www.wowhead.com/unholy-death-knight-rotation-guide#cooldown-usage" target="_blank" rel="noopener noreferrer">More info.</a>
           </>
         )}

--- a/src/parser/deathknight/unholy/modules/talents/SoulReaper.tsx
+++ b/src/parser/deathknight/unholy/modules/talents/SoulReaper.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Abilities from 'parser/core/modules/Abilities';
+import SPELLS from 'common/SPELLS';
+import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
+import Events, { FightEndEvent } from 'parser/core/Events';
+import Statistic from 'interface/statistics/Statistic';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import ItemDamageDone from 'interface/ItemDamageDone';
+import ExecuteHelper from 'parser/shared/ExecuteHelper';
+
+const SOUL_REAPER_EXECUTE_RANGE = .35
+
+class SoulReaper extends ExecuteHelper {
+  static executeSources = SELECTED_PLAYER;
+  static lowerThreshold = SOUL_REAPER_EXECUTE_RANGE;
+  static executeOutsideRangeEnablers = [SPELLS.FLAYERS_MARK];
+  static modifiesDamage = false;
+
+  static dependencies = {
+    ...ExecuteHelper.dependencies,
+    abilities: Abilities,
+  };
+
+  maxCasts: number = 0;
+
+  protected abilities!: Abilities;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.addEventListener(Events.fightend, this.adjustMaxCasts);
+    const ctor = this.constructor as typeof ExecuteHelper;
+    ctor.executeSpells.push(SPELLS.SOUL_REAPER_TALENT);
+
+    (options.abilities as Abilities).add({
+      spell: SPELLS.SOUL_REAPER_TALENT,
+      category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+      cooldown: 6,
+      gcd: {
+        base: 1500,
+      },
+      castEfficiency: {
+        suggestion: true,
+        recommendedEfficiency: 0.85,
+        maxCasts: () => this.maxCasts,
+      },
+    });
+  }
+
+  adjustMaxCasts(event: FightEndEvent) {
+    super.onFightEnd(event)
+    this.maxCasts += Math.ceil(this.totalExecuteDuration / 6000);
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(30)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+      >
+        <BoringSpellValueText spell={SPELLS.SOUL_REAPER_TALENT}>
+          <>
+            <ItemDamageDone amount={this.damage} />
+          </>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default SoulReaper;

--- a/src/parser/deathknight/unholy/modules/talents/SoulReaper.tsx
+++ b/src/parser/deathknight/unholy/modules/talents/SoulReaper.tsx
@@ -16,8 +16,6 @@ const SOUL_REAPER_EXECUTE_RANGE = .35
 class SoulReaper extends ExecuteHelper {
   static executeSources = SELECTED_PLAYER;
   static lowerThreshold = SOUL_REAPER_EXECUTE_RANGE;
-  static executeOutsideRangeEnablers = [SPELLS.FLAYERS_MARK];
-  static modifiesDamage = false;
 
   static dependencies = {
     ...ExecuteHelper.dependencies,


### PR DESCRIPTION
Soul reaper is an execute only ability now and won't be used off CD.  Also moved the pet sac to defensive because unholy wont ever use it offensively