### PR TITLE
[Core] Cancelled Casts Fix

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -9,6 +9,7 @@ import Contributor from 'interface/ContributorButton';
 
 // prettier-ignore
 export default [
+  change(date(2020, 12, 9), 'Fixed a bug in Cancelled Casts that was counting enchant procs and other effects as abilities that interrupted casts', Sharrq),
   change(date(2020, 12, 9), 'Updated Potions and Flask!', Abelito75),
   change(date(2020, 12, 8), 'Updated Stat Tracking to use squished stat values, and added shadowlands food, potions, and flasks.', Sharrq),
   change(date(2020, 12, 7), 'Added background and headshot graphics for Castle Nathria bosses', Sharrq),

--- a/src/common/SPELLS/shadowlands/enchants.ts
+++ b/src/common/SPELLS/shadowlands/enchants.ts
@@ -31,6 +31,11 @@ const enchants: SpellList = {
     name: 'Sinful Revelation',
     icon: 'trade_engraving',
   },
+  SINFUL_REVELATION_PROC: {
+    id: 324260,
+    name: 'Sinful Revelation',
+    icon: 'spell_shaman_measuredinsight',
+  },
   FORTIFIED_AVOIDANCE: {
     id: 309530,
     name: 'Fortified Avoidance',

--- a/src/interface/report/Results/index.js
+++ b/src/interface/report/Results/index.js
@@ -425,20 +425,6 @@ class Results extends React.PureComponent {
         {parser && parser.disabledModules && (
           <DegradedExperience disabledModules={parser.disabledModules} />
         )}
-        <div className="container">
-            <Warning style={{ marginBottom: 30 }}>
-              In an effort to focus on Shadowlands and Castle Nathria, we will be removing support
-              for Azerite, Essences, Corruption, and other BFA items with the launch of Prepatch. As
-              a result, analysis of Prepatch encounters may be inaccurate. If you would like to
-              follow your spec's Shadowlands development or provide suggestions/feedback,{' '}
-              <a
-                href="
-https://github.com/WoWAnalyzer/WoWAnalyzer/issues?q=is%3Aopen+is%3Aissue+label%3AShadowlands"
-              >
-                Click Here
-              </a>
-            </Warning>
-          </div>
         {boss && boss.fight.resultsWarning && (
           <div className="container">
             <Warning style={{ marginBottom: 30 }}>{boss.fight.resultsWarning}</Warning>

--- a/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
+++ b/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
@@ -38,6 +38,9 @@ const spells: number[] = [
   SPELLS.SHADOWCORE_OIL_BLAST.id,
   //endregion
 
+  //region Enchants
+  SPELLS.SINFUL_REVELATION_PROC.id,
+
   //region Death Knight
   SPELLS.BREATH_OF_SINDRAGOSA_TALENT_DAMAGE_TICK.id,
   SPELLS.RUNE_1.id,
@@ -49,6 +52,9 @@ const spells: number[] = [
   SPELLS.BARBED_SHOT_PET_BUFF.id, //The buff applied to BM Hunter pet when casting Barbed Shot
   SPELLS.DIRE_BEAST_SUMMON.id, //A secondary cast event from Dire Beast talent
   //endregion
+
+  //region Mage
+  SPELLS.RUNE_OF_POWER_BUFF.id,
 
   //region Covenants
   SPELLS.RESONATING_ARROW_DEBUFF.id, //The debuff applied to mobs inside Kyrian hunter ability resonating arrow area of effect

--- a/src/parser/shared/modules/CancelledCasts.tsx
+++ b/src/parser/shared/modules/CancelledCasts.tsx
@@ -11,6 +11,8 @@ import CrossIcon from 'interface/icons/Cross';
 import Statistic from 'interface/statistics/Statistic';
 import BoringValueText from 'interface/statistics/components/BoringValueText';
 import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
+import CASTS_THAT_ARENT_CASTS from 'parser/core/CASTS_THAT_ARENT_CASTS';
+import CASTABLE_WHILE_CASTING_SPELLS from 'parser/core/CASTABLE_WHILE_CASTING_SPELLS';
 
 import Events, { CastEvent, BeginCastEvent } from '../../core/Events';
 
@@ -39,7 +41,7 @@ class CancelledCasts extends Analyzer {
 
   onBeginCast(event: BeginCastEvent) {
     const spellId = event.ability.guid;
-    if (this.IGNORED_ABILITIES.includes(spellId)) {
+    if (this.IGNORED_ABILITIES.includes(spellId) || CASTS_THAT_ARENT_CASTS.includes(spellId) || CASTABLE_WHILE_CASTING_SPELLS.includes(spellId)) {
       return;
     }
     if (this.wasCastStarted && this.beginCastSpell !== undefined &&
@@ -56,7 +58,7 @@ class CancelledCasts extends Analyzer {
   onCast(event: CastEvent) {
     const spellId = event.ability.guid;
     const beginCastAbility = this.beginCastSpell && this.beginCastSpell.ability;
-    if (this.IGNORED_ABILITIES.includes(spellId) || !beginCastAbility) {
+    if (this.IGNORED_ABILITIES.includes(spellId) || CASTS_THAT_ARENT_CASTS.includes(spellId) || CASTABLE_WHILE_CASTING_SPELLS.includes(spellId) || !beginCastAbility) {
       return;
     }
     if (beginCastAbility.guid !== spellId && this.wasCastStarted) {


### PR DESCRIPTION
The Cancelled Casts module was counting spells as cancelled if a "Casts that arent casts" ability happened mid cast.

Additionally, the proc from Sinful Revelation was counting as interrupting the cast so i added it to Casts that arent casts.

Also removed the Prepatch warning.