### PR TITLE
[Arcane Mage] Arcane Power Update & Arcane Echo

### DIFF
--- a/src/common/SPELLS/mage.ts
+++ b/src/common/SPELLS/mage.ts
@@ -459,7 +459,7 @@ const spells = {
     icon: 'spell_mage_icenova',
   },
   TOUCH_OF_THE_MAGI_DEBUFF: {
-    id: 210725,
+    id: 210824,
     name: 'Touch of the Magi',
     icon: 'spell_mage_icenova',
   },

--- a/src/common/SPELLS/mage.ts
+++ b/src/common/SPELLS/mage.ts
@@ -454,6 +454,11 @@ const spells = {
     icon: 'spell_nature_wispsplode',
   },
   TOUCH_OF_THE_MAGI: {
+    id: 321507,
+    name: 'Touch of the Magi',
+    icon: 'spell_mage_icenova',
+  },
+  TOUCH_OF_THE_MAGI_DEBUFF: {
     id: 210725,
     name: 'Touch of the Magi',
     icon: 'spell_mage_icenova',

--- a/src/parser/mage/arcane/CHANGELOG.tsx
+++ b/src/parser/mage/arcane/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import { change, date } from 'common/changelog';
 
 // prettier-ignore
 export default [
+  change(date(2020, 12, 10), <>Updated <SpellLink id={SPELLS.ARCANE_POWER.id} /> to include <SpellLink id={SPELLS.TOUCH_OF_THE_MAGI.id} /> usage and added support for <SpellLink id={SPELLS.ARCANE_ECHO_TALENT.id} />.</>, Sharrq),
   change(date(2020, 12, 10), <>Removed checks for <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} /> from <SpellLink id={SPELLS.ARCANE_POWER.id} /> module, as per Shadowlands it is now baked into the spell. </>, Putro),
   change(date(2020, 11, 16), <>Added support for <SpellLink id={SPELLS.SHIFTING_POWER.id} />.</>, Sharrq),
   change(date(2020, 11, 16), <>Updated numbers for <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} /> to match latest tuning.</>, Sharrq),

--- a/src/parser/mage/arcane/CombatLogParser.ts
+++ b/src/parser/mage/arcane/CombatLogParser.ts
@@ -29,6 +29,7 @@ import RuleOfThrees from './modules/talents/RuleOfThrees';
 import TimeAnomaly from './modules/talents/TimeAnomaly';
 import ArcaneFamiliar from './modules/talents/ArcaneFamiliar';
 import MasterOfTime from './modules/talents/MasterOfTime';
+import ArcaneEcho from './modules/talents/ArcaneEcho';
 
 //Legendaries
 import ArcaneHarmony from './modules/items/ArcaneHarmony';
@@ -78,6 +79,7 @@ class CombatLogParser extends CoreCombatLogParser {
     ruleOfThrees: RuleOfThrees,
     timeAnomaly: TimeAnomaly,
     masterOfTime: MasterOfTime,
+    arcaneEcho: ArcaneEcho,
 
     //Legendaries
     arcaneHarmony: ArcaneHarmony,

--- a/src/parser/mage/arcane/integrationTests/example.test.ts.snap
+++ b/src/parser/mage/arcane/integrationTests/example.test.ts.snap
@@ -18,9 +18,155 @@ Array [
        casts instant.
     </span>,
     "stat": <React.Fragment>
-      37.56% downtime
+      37.22% downtime
        (
       &lt;20.00% is recommended
+      )
+    </React.Fragment>,
+  },
+]
+`;
+
+exports[`Arcane Mage integration test: example log ArcaneEcho matches the statistic snapshot 1`] = `
+<div
+  className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
+>
+  <div
+    category="TALENTS"
+    className="panel statistic flexible "
+  >
+    <div
+      className="panel-body"
+    >
+      <div
+        className="pad boring-text "
+      >
+        <label>
+          <a
+            className="spell-link-text"
+            href="http://wowhead.com/spell=342231"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <img
+              alt="Arcane Echo"
+              className="icon game "
+              src="//render-us.worldofwarcraft.com/icons/56/ability_socererking_arcanewrath.jpg"
+            />
+          </a>
+           
+          <a
+            className="spell-link-text"
+            href="http://wowhead.com/spell=342231"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Arcane Echo
+          </a>
+        </label>
+        <div
+          className="value"
+        >
+          <a
+            className="spell-link-text"
+            href="http://wowhead.com/spell=5143"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <img
+              alt="Arcane Missiles"
+              className="icon game "
+              src="//render-us.worldofwarcraft.com/icons/56/spell_nature_starfall.jpg"
+            />
+          </a>
+           
+          1
+           
+          <small>
+            Average casts per Touch of the Magi
+          </small>
+          <br />
+          <a
+            className="spell-link-text"
+            href="http://wowhead.com/spell=321507"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <img
+              alt="Touch of the Magi"
+              className="icon game "
+              src="//render-us.worldofwarcraft.com/icons/56/spell_mage_icenova.jpg"
+            />
+          </a>
+           
+          1
+           
+          <small>
+            Touch of the Magi Utilization
+          </small>
+        </div>
+      </div>
+    </div>
+    <div
+      className="detail-corner"
+      data-place="top"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onTouchStart={[Function]}
+    >
+      <svg
+        className="icon"
+        viewBox="0 0 100 100"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M58.9,82.9h7v12.9H34.1V82.9h7.1V45.5h-0.6c-3.6,0-6.4-2.9-6.4-6.4c0-3.6,2.9-6.4,6.4-6.4h0.6h17.4h0.3V82.9z M49,25.8  c6,0,10.8-4.8,10.8-10.8C59.8,9,55,4.2,49,4.2S38.2,9,38.2,15C38.2,21,43,25.8,49,25.8z"
+        />
+      </svg>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Arcane Mage integration test: example log ArcaneEcho matches the suggestions snapshot 1`] = `
+Array [
+  Object {
+    "details": null,
+    "icon": "spell_nature_starfall",
+    "importance": "major",
+    "issue": <React.Fragment>
+      You failed to cast enough 
+      <ForwardRef
+        id={5143}
+      />
+       into 
+      <ForwardRef
+        id={321507}
+      />
+       
+      5
+       times. When using 
+      <ForwardRef
+        id={342231}
+      />
+       you should be casting 
+      <ForwardRef
+        id={5143}
+      />
+       non-stop (Whether you have 
+      <ForwardRef
+        id={263725}
+      />
+       procs or not) until the 
+      <ForwardRef
+        id={321507}
+      />
+       debuff is removed from the target.
+    </React.Fragment>,
+    "stat": <React.Fragment>
+      5 Bad Touch of the Magi Uses
+       (
+      0 is recommended
       )
     </React.Fragment>,
   },
@@ -62,16 +208,28 @@ Array [
       <ForwardRef
         id={5143}
       />
-       without 
+       improperly 
+      2
+       times. In order to get the most out of 
+      <ForwardRef
+        id={5143}
+      />
+       you should only cast it if you have 
       <ForwardRef
         id={263725}
       />
-       
-      5
-       times. Arcane Missiles is a very expensive spell (more expensive than a 4 Charge Arcane Blast) and therefore it should only be cast when you have the Clearcasting buff which makes the spell free.
+       or if you are using 
+      <ForwardRef
+        id={342231}
+      />
+       and the target has 
+      <ForwardRef
+        id={321507}
+      />
+      .
     </React.Fragment>,
     "stat": <React.Fragment>
-      73.68% Uptime
+      89.47% Uptime
        (
       100.00% is recommended
       )
@@ -1003,6 +1161,104 @@ exports[`Arcane Mage integration test: example log CastEfficiency matches the st
               }
             >
               
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
+                href="http://wowhead.com/spell=321507"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/spell_mage_icenova.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Touch of the Magi
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              1.04
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              5
+              /7
+               
+              casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "75.83063845354741%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              75.83%
             </td>
             <td
               style={
@@ -5278,7 +5534,7 @@ exports[`Arcane Mage integration test: example log matches the checklist snapsho
               style={
                 Object {
                   "backgroundColor": "#ac1f39",
-                  "width": "28.662975000000014%",
+                  "width": "6.660000000000001%",
                 }
               }
             />
@@ -5440,6 +5696,96 @@ exports[`Arcane Mage integration test: example log matches the checklist snapsho
               <div
                 className="flex-main"
               >
+                Bad Touch of the Magi Uses
+              </div>
+              <div
+                className="flex-sub"
+                style={
+                  Object {
+                    "marginLeft": 10,
+                  }
+                }
+              >
+                <div
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onTouchStart={[Function]}
+                >
+                  <svg
+                    className="icon"
+                    viewBox="0 0 100 100"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M53.1,73h-7.2c-1.1,0-1.9-0.9-1.9-1.9V44h11v27.1C55,72.1,54.1,73,53.1,73z"
+                    />
+                    <path
+                      d="M55,39H44v-9.1c0-1.1,0.9-1.9,1.9-1.9h7.2c1.1,0,1.9,0.9,1.9,1.9V39z"
+                    />
+                    <path
+                      d="M50,96C24.6,96,4,75.4,4,50S24.6,4,50,4s46,20.6,46,46S75.4,96,50,96z M50,12c-21,0-38,17-38,38s17,38,38,38s38-17,38-38   S71,12,50,12z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div
+                className="flex-sub content-middle text-muted"
+                style={
+                  Object {
+                    "marginLeft": 5,
+                    "marginRight": 10,
+                    "minWidth": 55,
+                  }
+                }
+              >
+                <div
+                  className="text-right"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                >
+                   
+                  5
+                   
+                   
+                </div>
+              </div>
+              <div
+                className="flex-sub content-middle"
+                style={
+                  Object {
+                    "width": 50,
+                  }
+                }
+              >
+                <div
+                  className="performance-bar-container"
+                >
+                  <div
+                    className="performance-bar small"
+                    style={
+                      Object {
+                        "backgroundColor": "#ac1f39",
+                        "transition": "background-color 800ms",
+                        "width": "6.660000000000001%",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="col-md-6"
+          >
+            <div
+              className="flex"
+            >
+              <div
+                className="flex-main"
+              >
                 Rune of Power Uptime
               </div>
               <div
@@ -5551,7 +5897,7 @@ exports[`Arcane Mage integration test: example log matches the checklist snapsho
               style={
                 Object {
                   "backgroundColor": "#df7102",
-                  "width": "43.3618032273797%",
+                  "width": "43.38598192987392%",
                 }
               }
             />
@@ -5644,7 +5990,7 @@ exports[`Arcane Mage integration test: example log matches the checklist snapsho
                   }
                 >
                    
-                  37.56%
+                  37.22%
                    
                    
                 </div>
@@ -5666,7 +6012,7 @@ exports[`Arcane Mage integration test: example log matches the checklist snapsho
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "5.319710350863295%",
+                        "width": "5.368067755851726%",
                       }
                     }
                   />
@@ -5947,7 +6293,7 @@ exports[`Arcane Mage integration test: example log matches the checklist snapsho
               style={
                 Object {
                   "backgroundColor": "#ac1f39",
-                  "width": "27.263157894736846%",
+                  "width": "33.10526315789474%",
                 }
               }
             />
@@ -6175,7 +6521,7 @@ exports[`Arcane Mage integration test: example log matches the checklist snapsho
                   }
                 >
                    
-                  73.68%
+                  89.47%
                    
                    
                 </div>
@@ -6197,7 +6543,7 @@ exports[`Arcane Mage integration test: example log matches the checklist snapsho
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "27.263157894736846%",
+                        "width": "33.10526315789474%",
                       }
                     }
                   />

--- a/src/parser/mage/arcane/modules/Checklist/Component.tsx
+++ b/src/parser/mage/arcane/modules/Checklist/Component.tsx
@@ -66,6 +66,13 @@ const ArcaneMageChecklist = ({ combatant, castEfficiency, thresholds }: any) => 
             thresholds={thresholds.arcaneOrbMissedOrbs}
           />
         )}
+        {combatant.hasTalent(SPELLS.ARCANE_ECHO_TALENT.id) && (
+          <Requirement
+            name="Bad Touch of the Magi Uses"
+            tooltip="Arcane Echo causes direct damage abilities, like Arcane Missiles, to pulse damage to up to 8 nearby targets. Because of this, you should be non-stop casting Arcane Missiles (whether you have Clearcasting procs or not), into any target with the Touch of the Magi debuff until that debuff is removed."
+            thresholds={thresholds.arcaneEchoLowUsage}
+          />
+        )}
         {combatant.hasTalent(SPELLS.RULE_OF_THREES_TALENT.id) && (
           <Requirement
             name="Rule of Threes Buff Usage"

--- a/src/parser/mage/arcane/modules/Checklist/Module.tsx
+++ b/src/parser/mage/arcane/modules/Checklist/Module.tsx
@@ -7,6 +7,7 @@ import PreparationRuleAnalyzer from 'parser/shared/modules/features/Checklist/Pr
 
 import ArcaneFamiliar from '../talents/ArcaneFamiliar';
 import ArcaneOrb from '../talents/ArcaneOrb';
+import ArcaneEcho from '../talents/ArcaneEcho';
 import ArcanePower from '../features/ArcanePower';
 import RuleOfThrees from '../talents/RuleOfThrees';
 import TimeAnomaly from '../talents/TimeAnomaly';
@@ -26,6 +27,7 @@ class Checklist extends BaseChecklist {
     castEfficiency: CastEfficiency,
     arcaneFamiliar: ArcaneFamiliar,
     arcaneOrb: ArcaneOrb,
+    arcaneEcho: ArcaneEcho,
     arcanePower: ArcanePower,
     ruleOfThrees: RuleOfThrees,
     timeAnomaly: TimeAnomaly,
@@ -42,6 +44,7 @@ class Checklist extends BaseChecklist {
   protected castEfficiency!: CastEfficiency;
   protected arcaneFamiliar!: ArcaneFamiliar;
   protected arcaneOrb!: ArcaneOrb;
+  protected arcaneEcho!: ArcaneEcho;
   protected arcanePower!: ArcanePower;
   protected ruleOfThrees!: RuleOfThrees;
   protected timeAnomaly!: TimeAnomaly;
@@ -65,6 +68,7 @@ class Checklist extends BaseChecklist {
           downtimeSuggestionThresholds: this.alwaysBeCasting.downtimeSuggestionThresholds,
           arcaneFamiliarUptime: this.arcaneFamiliar.arcaneFamiliarUptimeThresholds,
           arcaneOrbMissedOrbs: this.arcaneOrb.missedOrbsThresholds,
+          arcaneEchoLowUsage: this.arcaneEcho.badTouchUsageThreshold,
           arcanePowerCooldown: this.arcanePower.arcanePowerCooldownThresholds,
           arcanePowerManaUtilization: this.arcanePower.arcanePowerManaUtilization,
           arcanePowerCasts: this.arcanePower.arcanePowerCastThresholds,

--- a/src/parser/mage/arcane/modules/features/Abilities.tsx
+++ b/src/parser/mage/arcane/modules/features/Abilities.tsx
@@ -51,6 +51,18 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.90,
+        },
+      },
+      {
+        spell: SPELLS.TOUCH_OF_THE_MAGI,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        cooldown: 45,
+        gcd: {
+          base: 1500,
+        },
       },
       {
         spell: SPELLS.SUPERNOVA_TALENT,

--- a/src/parser/mage/arcane/modules/features/ArcaneMissiles.tsx
+++ b/src/parser/mage/arcane/modules/features/ArcaneMissiles.tsx
@@ -8,24 +8,34 @@ import Events, { CastEvent } from 'parser/core/Events';
 import { When, ThresholdStyle } from 'parser/core/ParseResults';
 import { i18n } from '@lingui/core';
 import { t } from '@lingui/macro';
+import Enemies from 'parser/shared/modules/Enemies';
 
 const debug = false;
 
 class ArcaneMissiles extends Analyzer {
 	static dependencies = {
 		abilityTracker: AbilityTracker,
+		enemies: Enemies,
 	};
 	protected abilityTracker!: AbilityTracker;
+	protected enemies!: Enemies;
 
+	hasArcaneEcho: boolean;
 	castWithoutClearcasting = 0;
 
 	constructor(options: Options) {
-    super(options);
-			this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell([SPELLS.ARCANE_MISSILES, SPELLS.ARCANE_BARRAGE]), this.onCast);
+		super(options);
+		this.hasArcaneEcho = this.selectedCombatant.hasTalent(SPELLS.ARCANE_ECHO_TALENT.id);
+		this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell([SPELLS.ARCANE_MISSILES, SPELLS.ARCANE_BARRAGE]), this.onCast);
   }
 
 	onCast(event: CastEvent) {
 		const spellId = event.ability.guid;
+		const enemy = this.enemies.getEntity(event);
+		if (this.hasArcaneEcho && enemy && enemy.hasBuff(SPELLS.TOUCH_OF_THE_MAGI_DEBUFF.id)) {
+			return;
+		}
+
 		if (spellId === SPELLS.ARCANE_MISSILES.id && !this.selectedCombatant.hasBuff(SPELLS.CLEARCASTING_ARCANE.id)) {
 			debug && this.log('Arcane Missiles cast without Clearcasting');
 			this.castWithoutClearcasting += 1;
@@ -50,7 +60,7 @@ class ArcaneMissiles extends Analyzer {
 
 	suggestions(when: When) {
 		when(this.arcaneMissileUsageThresholds)
-			.addSuggestion((suggest, actual, recommended) => suggest(<>You cast <SpellLink id={SPELLS.ARCANE_MISSILES.id} /> without <SpellLink id={SPELLS.CLEARCASTING_ARCANE.id} /> {this.castWithoutClearcasting} times. Arcane Missiles is a very expensive spell (more expensive than a 4 Charge Arcane Blast) and therefore it should only be cast when you have the Clearcasting buff which makes the spell free.</>)
+			.addSuggestion((suggest, actual, recommended) => suggest(<>You cast <SpellLink id={SPELLS.ARCANE_MISSILES.id} /> improperly {this.castWithoutClearcasting} times. In order to get the most out of <SpellLink id={SPELLS.ARCANE_MISSILES.id} /> you should only cast it if you have <SpellLink id={SPELLS.CLEARCASTING_ARCANE.id} /> or if you are using <SpellLink id={SPELLS.ARCANE_ECHO_TALENT.id} /> and the target has <SpellLink id={SPELLS.TOUCH_OF_THE_MAGI.id} />.</>)
 					.icon(SPELLS.ARCANE_MISSILES.icon)
 					.actual(i18n._(t('mage.arcane.suggestions.arcaneMissiles.clearCasting.uptime')`${formatPercentage(this.missilesUtilization)}% Uptime`))
 					.recommended(`${formatPercentage(recommended)}% is recommended`));

--- a/src/parser/mage/arcane/modules/features/ArcanePower.tsx
+++ b/src/parser/mage/arcane/modules/features/ArcanePower.tsx
@@ -8,10 +8,13 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import Statistic from 'interface/statistics/Statistic';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import { TooltipElement } from 'common/Tooltip';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import DeathTracker from 'parser/shared/modules/DeathTracker';
 import SpellManaCost from 'parser/shared/modules/SpellManaCost';
+import Enemies from 'parser/shared/modules/Enemies';
+import EventHistory from 'parser/shared/modules/EventHistory';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import Events, { ApplyBuffEvent, CastEvent, RemoveBuffEvent } from 'parser/core/Events';
@@ -31,6 +34,9 @@ const ARCANE_POWER_SPELL_BLACKLIST = [
   SPELLS.ARCANE_ORB_TALENT,
   SPELLS.RUNE_OF_POWER_TALENT,
 ];
+const ARCANE_EXPLOSION_COST = 5000;
+const ARCANE_BLAST_BASE_COST = 1375;
+const OVERPOWERED_COST_REDUCTION = 0.5;
 
 const debug = false;
 
@@ -42,66 +48,70 @@ class ArcanePower extends Analyzer {
     deathTracker: DeathTracker,
     // Needed for the `resourceCost` prop of events
     spellManaCost: SpellManaCost,
+    enemies: Enemies,
+    eventHistory: EventHistory,
   };
   protected abilityTracker!: AbilityTracker;
   protected arcaneChargeTracker!: ArcaneChargeTracker;
   protected spellUsable!: SpellUsable;
   protected deathTracker!: DeathTracker;
   protected spellManaCost!: SpellManaCost;
+  protected enemies!: Enemies;
+  protected eventHistory!: EventHistory;
 
   protected hasOverpowered: boolean;
 
   badUses = 0;
   totalCastsDuringAP = 0;
   badCastsDuringAP = 0;
-  runeTimestamp = 0;
   outOfMana = 0;
   buffEndTimestamp = 0;
   arcanePowerCasted = false;
   lowManaCast = 0;
   lowChargesCast = 0;
+  missingTouchOfTheMagi = 0;
 
   constructor(options: Options) {
     super(options);
     this.hasOverpowered = this.selectedCombatant.hasTalent(SPELLS.OVERPOWERED_TALENT.id);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.ARCANE_POWER), this.onArcanePowerCast);
     this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onCast);
     this.addEventListener(Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.ARCANE_POWER), this.onApplyBuff);
     this.addEventListener(Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.ARCANE_POWER), this.onRemoveBuff);
   }
 
+  onArcanePowerCast(event: CastEvent) {
+    const manaResource: any = event.classResources && event.classResources.find(classResource => classResource.type === RESOURCE_TYPES.MANA.id);
+    const currentManaPercent = manaResource.amount / manaResource.max;
+    const touchOfTheMagiCast = this.eventHistory.last(1, 1000, Events.cast.by(SELECTED_PLAYER).spell(SPELLS.TOUCH_OF_THE_MAGI));
+    this.arcanePowerCasted = true;
+
+    if (this.arcaneChargeTracker.charges < 4 || (!this.hasOverpowered && currentManaPercent < MANA_THRESHOLD) || touchOfTheMagiCast.length === 0) {
+      this.badUses += 1;
+    }
+
+    if (this.arcaneChargeTracker.charges < 4) {
+      debug && this.log('Arcane Power Cast with Low Charges');
+      this.lowChargesCast += 1;
+    }
+
+    if (!this.hasOverpowered && currentManaPercent < MANA_THRESHOLD) {
+      debug && this.log('Arcane Power Cast with low mana');
+      this.lowManaCast += 1;
+    }
+
+    if (touchOfTheMagiCast.length === 0) {
+      debug && this.log('Arcane Power cast without Touch of the Magi');
+      this.missingTouchOfTheMagi += 1;
+    }
+  }
+
   onCast(event: CastEvent) {
     const spellId = event.ability.guid;
-    if (spellId === SPELLS.ARCANE_POWER.id) {
-      const manaResource: any = event.classResources && event.classResources.find(classResource => classResource.type === RESOURCE_TYPES.MANA.id);
-      const currentManaPercent = manaResource.amount / manaResource.max;
-      this.arcanePowerCasted = true;
-
-      if (this.arcaneChargeTracker.charges < 4 || (!this.hasOverpowered && currentManaPercent < MANA_THRESHOLD)) {
-        this.badUses += 1;
-      }
-
-      if (this.selectedCombatant.hasBuff(SPELLS.ARCANE_POWER.id)) {
-        this.buffEndTimestamp = event.timestamp + 10000;
-        debug && this.log('Arcane Power Cast During Arcane Power Proc');
-        debug && this.log('Arcane Power End Time adjusted to');
-      }
-
-      if (this.arcaneChargeTracker.charges < 4) {
-        debug && this.log('Arcane Power Cast with Low Charges');
-        debug && this.log('Arcane Charges: ' + this.arcaneChargeTracker.charges);
-        this.lowChargesCast += 1;
-      }
-
-      if (!this.hasOverpowered && currentManaPercent < MANA_THRESHOLD) {
-        debug && this.log('Arcane Power Cast with low mana');
-        debug && !this.hasOverpowered && this.log('Mana Percent: ' + currentManaPercent);
-        this.lowManaCast += 1;
-      }
-      return;
-    }
     if (!this.selectedCombatant.hasBuff(SPELLS.ARCANE_POWER.id)) {
       return;
     }
+
     // Any spell except arcane power or rune of power that was cast during Arcane Power
     this.totalCastsDuringAP += 1;
     if (ARCANE_POWER_SPELL_BLACKLIST.includes(event.ability)) {
@@ -118,25 +128,17 @@ class ArcanePower extends Analyzer {
         const buffTimeRemaining = this.buffEndTimestamp - event.timestamp;
         if (manaRemaining < this.estimatedManaCost(spellId) && buffTimeRemaining > 1000) {
           debug && this.log('Ran Out of Mana during Arcane Power');
-          debug && this.log('Mana Remaining: ' + manaRemaining);
-          debug && this.log('Estimated Mana Cost: ' + this.estimatedManaCost(spellId));
-          debug && this.log('Time left on Arcane Power: ' + buffTimeRemaining);
           this.outOfMana += 1;
         }
       });
-
     }
   }
 
   onApplyBuff(event: ApplyBuffEvent) {
     if (this.arcanePowerCasted) {
-      debug && this.log('Arcane Power Cast');
       this.buffEndTimestamp = event.timestamp + 10000;
-      debug && this.log('Arcane Power Ends');
     } else {
-      debug && this.log('Arcane Power Proc');
       this.buffEndTimestamp = event.timestamp + 8000;
-      debug && this.log('Arcane Power Ends');
     }
   }
 
@@ -146,31 +148,26 @@ class ArcanePower extends Analyzer {
 
   estimatedManaCost(spellId: number) {
     if (spellId === SPELLS.ARCANE_EXPLOSION.id) {
-      if (this.hasOverpowered) {
-        return 2000 * 0.4;
-      } else {
-        return 2000;
-      }
-    } else if (spellId === SPELLS.ARCANE_BLAST.id) {
-      if (this.hasOverpowered) {
-        return (550 + (550 * this.arcaneChargeTracker.charges)) * 0.4;
-      } else if (this.selectedCombatant.hasBuff(SPELLS.RULE_OF_THREES_BUFF.id)) {
+      if (this.selectedCombatant.hasBuff(SPELLS.CLEARCASTING_ARCANE.id)) {
         return 0;
       } else {
-        return 550 + (550 * this.arcaneChargeTracker.charges);
+        return this.hasOverpowered ? ARCANE_EXPLOSION_COST * OVERPOWERED_COST_REDUCTION : ARCANE_EXPLOSION_COST;
+      }
+    }
+
+    const arcaneCharges = this.arcaneChargeTracker.charges < 4 ? this.arcaneChargeTracker.charges + 1 : 4;
+    if (spellId === SPELLS.ARCANE_BLAST.id) {
+      if (this.selectedCombatant.hasBuff(SPELLS.RULE_OF_THREES_BUFF.id)) {
+        return 0
+      } else {
+        return this.hasOverpowered ? (ARCANE_BLAST_BASE_COST * arcaneCharges ) * OVERPOWERED_COST_REDUCTION : ARCANE_BLAST_BASE_COST * arcaneCharges;
       }
     }
     return 0;
   }
 
   get requiredChecks() {
-    let checks = 1;
-    if (!this.hasOverpowered) {
-      //Also checks mana level if you dont have Overpowered talented
-      checks += 1;
-    }
-    return checks;
-
+    return this.hasOverpowered ? 2 : 3;
   }
 
   get failedChecks() {
@@ -183,6 +180,10 @@ class ArcanePower extends Analyzer {
 
   get castUtilization() {
     return 1 - (this.badCastsDuringAP / this.totalCastsDuringAP);
+  }
+  
+  get totalArcanePowerCasts() {
+    return this.abilityTracker.getAbility(SPELLS.ARCANE_POWER.id).casts;
   }
 
   get arcanePowerCooldownThresholds() {
@@ -225,8 +226,9 @@ class ArcanePower extends Analyzer {
     when(this.arcanePowerCooldownThresholds)
       .addSuggestion((suggest, actual, recommended) => suggest(<>You cast <SpellLink id={SPELLS.ARCANE_POWER.id} /> without proper setup {this.badUses} times. Arcane Power has a short duration so you should get the most out of it by meeting all requirements before casting it.
         <ul>
-          <li>You have 4 <SpellLink id={SPELLS.ARCANE_CHARGE.id} /> - You had this {this.abilityTracker.getAbility(SPELLS.ARCANE_POWER.id).casts - this.lowChargesCast} out of {this.abilityTracker.getAbility(SPELLS.ARCANE_POWER.id).casts} casts.</li>
-          {!this.hasOverpowered ? <li>You have more than 40% mana - You had this {this.abilityTracker.getAbility(SPELLS.ARCANE_POWER.id).casts - this.lowManaCast} out of {this.abilityTracker.getAbility(SPELLS.ARCANE_POWER.id).casts} casts.</li> : ''}
+          <li>You have 4 <SpellLink id={SPELLS.ARCANE_CHARGE.id} /> - You failed this {this.lowChargesCast} times out of {this.totalArcanePowerCasts} casts.</li>
+          <li><>You cast <SpellLink id={SPELLS.TOUCH_OF_THE_MAGI.id} /> <TooltipElement content="Arcane Power should be cast right on the end of the Rune of Power cast. There should not be any casts or any delay in between Rune of Power and Arcane Power to ensure that Rune of Power is up for the entire duration of Arcane Power.">immediately</TooltipElement> before Arcane Power - You failed this {this.missingTouchOfTheMagi} times out of {this.totalArcanePowerCasts} casts</> </li>
+          {!this.hasOverpowered ? <li>You have more than 40% mana - You failed this {this.lowManaCast} times out of {this.totalArcanePowerCasts} casts.</li> : ''}
         </ul>
       </>)
         .icon(SPELLS.ARCANE_POWER.icon)
@@ -254,9 +256,10 @@ class ArcanePower extends Analyzer {
             Before casting Arcane Power, you should ensure that you meet all of the following requirements. If Arcane Power frequently comes off cooldown and these requirements are not already met, then consider modifying your rotation to ensure that they are met before Arcane Power comes off cooldown
             <ul>
               <li>You have 4 Arcane Charges - Missed {this.lowChargesCast} times</li>
+              <li>You cast Touch of the Magi immediately before AP - Missed {this.missingTouchOfTheMagi} times</li>
               {!this.hasOverpowered && <li>You have more than 40% mana - Missed {this.lowManaCast} times</li>}
             </ul>
-            Additionally, you should only be casting Arcane Blast and Arcane Missiles (If you have a Clearcasting Proc) during Arcane Power to maximize the short cooldown duration.
+            Additionally, you should only be casting Arcane Blast (Single Target), Arcane Explosion (AOE), and Arcane Missiles (If you have a Clearcasting Proc) during Arcane Power to maximize the short cooldown duration.
           </>
         )}
       >

--- a/src/parser/mage/arcane/modules/talents/ArcaneEcho.tsx
+++ b/src/parser/mage/arcane/modules/talents/ArcaneEcho.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import { formatNumber } from 'common/format';
+import Statistic from 'interface/statistics/Statistic';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import AbilityTracker from 'parser/shared/modules/AbilityTracker';
+import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
+import Events, { CastEvent, DamageEvent, FightEndEvent } from 'parser/core/Events';
+import { When, ThresholdStyle } from 'parser/core/ParseResults';
+import { i18n } from '@lingui/core';
+import { t } from '@lingui/macro';
+
+class ArcaneOrb extends Analyzer {
+	static dependencies = {
+		abilityTracker: AbilityTracker,
+	};
+	protected abilityTracker!: AbilityTracker;
+
+	totalHits = 0;
+	badCasts = 0;
+	orbCast = false;
+
+	constructor(options: Options) {
+    super(options);
+	   this.active = this.selectedCombatant.hasTalent(SPELLS.ARCANE_ORB_TALENT.id);
+		 this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.ARCANE_ORB_TALENT), this.onOrbCast);
+		 this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.ARCANE_ORB_DAMAGE), this.onOrbDamage);
+		 this.addEventListener(Events.fightend, this.onFightEnd);
+  }
+
+	onOrbDamage(event: DamageEvent) {
+		this.totalHits += 1;
+		this.orbCast = false;
+	}
+
+	onOrbCast(event: CastEvent) {
+		if (this.orbCast) {
+			this.badCasts += 1;
+		}
+		this.orbCast = true;
+	}
+
+	onFightEnd(event: FightEndEvent) {
+		if (this.orbCast) {
+			this.badCasts += 1;
+		}
+	}
+
+	get averageHitsPerCast() {
+		return this.totalHits / this.abilityTracker.getAbility(SPELLS.ARCANE_ORB_TALENT.id).casts;
+	}
+
+	get missedOrbsThresholds() {
+    return {
+      actual: this.badCasts,
+      isGreaterThan: {
+				average: 0,
+        major: 0,
+      },
+      style: ThresholdStyle.NUMBER,
+    };
+	}
+
+	suggestions(when: When) {
+		when(this.missedOrbsThresholds)
+			.addSuggestion((suggest, actual, recommended) => 
+				suggest(<>You cast <SpellLink id={SPELLS.ARCANE_ORB_TALENT.id} /> {this.badCasts} times without hitting anything. While it is acceptable to use this ability on Single Target encounters, you need to ensure you are aiming the ability so that it will at least hit one target.</>)
+					.icon(SPELLS.ARCANE_ORB_TALENT.icon)
+					.actual(i18n._(t('mage.arcane.suggestions.arcaneOrb.badCasts')`${formatNumber(this.badCasts)} Missed Orbs`))
+					.recommended(`${formatNumber(recommended)} is recommended`));
+	}
+
+	statistic() {
+    return (
+      <Statistic
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={`You averaged ${formatNumber(this.averageHitsPerCast)} hits per cast of Arcane Orb. ${this.badCasts > 0 ? `Additionally, you cast Arcane Orb ${this.badCasts} times without hitting anything.` : '' } Casting Arcane Orb when it will only hit one target is still beneficial and acceptable, but if you can aim it so that it hits multiple enemies then you should.`}
+      >
+        <BoringSpellValueText spell={SPELLS.ARCANE_ORB_TALENT}>
+          <>
+            {formatNumber(this.averageHitsPerCast)} <small>Average hits per cast</small>
+          </>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default ArcaneOrb;


### PR DESCRIPTION
- Updated Arcane Power to check for Touch of the Magi pre-AP
- Cleaned up Arcane Power a bit
- Added Arcane Echo to check for number of Missile casts per Touch of the Magi
- Updated Arcane Missiles to not complain about Missiles cast without Clearcasting if the target has touch of the Magi and the player has Arcane Echo.

Towards #3657