### PR TITLE
[Death Knight] Bryndaor's Might & Superstrain legendaries

### DIFF
--- a/src/common/SPELLS/shadowlands/covenants/deathknight.ts
+++ b/src/common/SPELLS/shadowlands/covenants/deathknight.ts
@@ -34,6 +34,11 @@ const covenants: SpellList = {
     name: 'Swarming Mist',
     icon: 'ability_revendreth_deathknight'
   },
+  SWARMING_MIST_RUNIC_POWER_GAIN: {
+    id: 312546,
+    name: 'Swarming Mist',
+    icon: 'ability_revendreth_deathknight'
+  },
 
   //endregion
 };

--- a/src/common/SPELLS/shadowlands/legendaries/deathknight.ts
+++ b/src/common/SPELLS/shadowlands/legendaries/deathknight.ts
@@ -36,6 +36,12 @@ const legendaries: SpellList<LegendarySpell> = {
   //endregion
 
   //region Shared
+  SUPERSTRAIN: {
+    id: 334974,
+    name: 'Superstrain',
+    icon: 'spell_deathknight_explode_ghoul',
+    bonusID: 6953
+  }
 
   //endregion
 } as const;

--- a/src/common/SPELLS/shadowlands/legendaries/deathknight.ts
+++ b/src/common/SPELLS/shadowlands/legendaries/deathknight.ts
@@ -1,7 +1,18 @@
-import { SpellList } from "common/SPELLS/Spell";
+import { LegendarySpell, SpellList } from "common/SPELLS/Spell";
 
-const legendaries: SpellList = {
+const legendaries: SpellList<LegendarySpell> = {
   //region Blood
+  BRYNDAORS_MIGHT: {
+    id: 334501,
+    name: 'Bryndaor\'s Might',
+    icon: 'ability_creature_cursed_04',
+    bonusID: 6940
+  },
+  BRYNDAORS_MIGHT_RUNIC_POWER_GAIN: {
+    id: 334502,
+    name: 'Bryndaor\'s Might',
+    icon: 'ability_creature_cursed_04'
+  },
 
   //endregion
 

--- a/src/localization/de/messages.json
+++ b/src/localization/de/messages.json
@@ -314,6 +314,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "",
   "deathknight.frost.suggestions.runicPower.wasted": "",
   "deathknight.shared.suggestions.runes.overcapped": "",
+  "deathknight.suggestions.brynadaorsMight.efficiency": "",
   "deathknight.suggestions.hysteria.efficiency": "",
   "deathknight.unholy.suggestions.alwaysBeCasting": "",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "",

--- a/src/localization/en/messages.json
+++ b/src/localization/en/messages.json
@@ -314,6 +314,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "{0}% of Rime procs were either refreshed and lost or expired without being used",
   "deathknight.frost.suggestions.runicPower.wasted": "{0}% wasted",
   "deathknight.shared.suggestions.runes.overcapped": "{0}% runes overcapped",
+  "deathknight.suggestions.brynadaorsMight.efficiency": "You wasted {0}% of RP from {1} by being RP capped.",
   "deathknight.suggestions.hysteria.efficiency": "You wasted {0}% of RP from {1} by being RP capped.",
   "deathknight.unholy.suggestions.alwaysBeCasting": "{0}% downtime",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "An average {actual} of Festering Wounds were popped by Apocalypse",

--- a/src/localization/es/messages.json
+++ b/src/localization/es/messages.json
@@ -314,6 +314,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "",
   "deathknight.frost.suggestions.runicPower.wasted": "",
   "deathknight.shared.suggestions.runes.overcapped": "",
+  "deathknight.suggestions.brynadaorsMight.efficiency": "",
   "deathknight.suggestions.hysteria.efficiency": "",
   "deathknight.unholy.suggestions.alwaysBeCasting": "",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "",

--- a/src/localization/fr/messages.json
+++ b/src/localization/fr/messages.json
@@ -314,6 +314,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "",
   "deathknight.frost.suggestions.runicPower.wasted": "",
   "deathknight.shared.suggestions.runes.overcapped": "",
+  "deathknight.suggestions.brynadaorsMight.efficiency": "",
   "deathknight.suggestions.hysteria.efficiency": "",
   "deathknight.unholy.suggestions.alwaysBeCasting": "",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "",

--- a/src/localization/it/messages.json
+++ b/src/localization/it/messages.json
@@ -314,6 +314,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "",
   "deathknight.frost.suggestions.runicPower.wasted": "",
   "deathknight.shared.suggestions.runes.overcapped": "",
+  "deathknight.suggestions.brynadaorsMight.efficiency": "",
   "deathknight.suggestions.hysteria.efficiency": "",
   "deathknight.unholy.suggestions.alwaysBeCasting": "",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "",

--- a/src/localization/ko/messages.json
+++ b/src/localization/ko/messages.json
@@ -314,6 +314,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "",
   "deathknight.frost.suggestions.runicPower.wasted": "",
   "deathknight.shared.suggestions.runes.overcapped": "",
+  "deathknight.suggestions.brynadaorsMight.efficiency": "",
   "deathknight.suggestions.hysteria.efficiency": "",
   "deathknight.unholy.suggestions.alwaysBeCasting": "",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "",

--- a/src/localization/pl/messages.json
+++ b/src/localization/pl/messages.json
@@ -314,6 +314,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "",
   "deathknight.frost.suggestions.runicPower.wasted": "",
   "deathknight.shared.suggestions.runes.overcapped": "",
+  "deathknight.suggestions.brynadaorsMight.efficiency": "",
   "deathknight.suggestions.hysteria.efficiency": "",
   "deathknight.unholy.suggestions.alwaysBeCasting": "",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "",

--- a/src/localization/pt/messages.json
+++ b/src/localization/pt/messages.json
@@ -314,6 +314,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "",
   "deathknight.frost.suggestions.runicPower.wasted": "",
   "deathknight.shared.suggestions.runes.overcapped": "",
+  "deathknight.suggestions.brynadaorsMight.efficiency": "",
   "deathknight.suggestions.hysteria.efficiency": "",
   "deathknight.unholy.suggestions.alwaysBeCasting": "",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "",

--- a/src/localization/ru/messages.json
+++ b/src/localization/ru/messages.json
@@ -314,6 +314,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "{0}% of Rime procs were either refreshed and lost or expired without being used",
   "deathknight.frost.suggestions.runicPower.wasted": "{0}% wasted",
   "deathknight.shared.suggestions.runes.overcapped": "{0}% runes overcapped",
+  "deathknight.suggestions.brynadaorsMight.efficiency": "",
   "deathknight.suggestions.hysteria.efficiency": "",
   "deathknight.unholy.suggestions.alwaysBeCasting": "{0}% downtime",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "An average {actual} of Festering Wounds were popped by Apocalypse",

--- a/src/localization/zh/messages.json
+++ b/src/localization/zh/messages.json
@@ -314,6 +314,7 @@
   "deathknight.frost.suggestions.rime.wastedProcs": "",
   "deathknight.frost.suggestions.runicPower.wasted": "",
   "deathknight.shared.suggestions.runes.overcapped": "",
+  "deathknight.suggestions.brynadaorsMight.efficiency": "",
   "deathknight.suggestions.hysteria.efficiency": "",
   "deathknight.unholy.suggestions.alwaysBeCasting": "",
   "deathknight.unholy.suggestions.apocalypse.efficiency": "",

--- a/src/parser/deathknight/blood/CHANGELOG.tsx
+++ b/src/parser/deathknight/blood/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 12, 12), <>Added <SpellLink id={SPELLS.BRYNDAORS_MIGHT.id} /> and <SpellLink id={SPELLS.SUPERSTRAIN.id} /> modules</>, joshinator),
   change(date(2020, 11, 6), 'Runeforge-suggestions', joshinator),
   change(date(2020, 10, 27), <>Created statistics for <SpellLink id={SPELLS.RUNE_OF_THE_FALLEN_CRUSADER.id} /> and <SpellLink id={SPELLS.RUNE_OF_HYSTERIA.id} /></>, joshinator),
   change(date(2020, 10, 26), <>Replaced deprecated StatisticBox modules for talents, disable Ossuary until SL and new <SpellLink id={SPELLS.RELISH_IN_BLOOD_TALENT.id} /> module</>, joshinator),

--- a/src/parser/deathknight/blood/CONFIG.js
+++ b/src/parser/deathknight/blood/CONFIG.js
@@ -11,7 +11,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Yajinni, joshinator],
   // The WoW client patch this spec was last updated to be fully compatible with.
-  patchCompatibility: '8.2.5',
+  patchCompatibility: '9.0.2',
   // If set to  false`, the spec will show up as unsupported.
   isSupported: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.

--- a/src/parser/deathknight/blood/CombatLogParser.ts
+++ b/src/parser/deathknight/blood/CombatLogParser.ts
@@ -53,6 +53,9 @@ import RuneForgeChecker from './modules/core/RuneForgeChecker';
 import RuneOfTheFallenCrusader from '../shared/runeforges/RuneOfTheFallenCrusader';
 import RuneOfHysteria from '../shared/runeforges/RuneOfHysteria';
 
+// Legendaries
+import BrynadaorsMight from './modules/items/BrynadaorsMight';
+
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     // Core Statistics
@@ -111,7 +114,10 @@ class CombatLogParser extends CoreCombatLogParser {
     // Runes
     runeForgeChecker: RuneForgeChecker,
     runeOfTheFallenCrusader: RuneOfTheFallenCrusader,
-    runeOfHysteria: RuneOfHysteria
+    runeOfHysteria: RuneOfHysteria,
+
+    // Legendaries
+    brynadaorsMight: BrynadaorsMight
   };
 }
 

--- a/src/parser/deathknight/blood/CombatLogParser.ts
+++ b/src/parser/deathknight/blood/CombatLogParser.ts
@@ -49,6 +49,7 @@ import RuneOfHysteria from '../shared/runeforges/RuneOfHysteria';
 
 // Legendaries
 import BrynadaorsMight from './modules/items/BrynadaorsMight';
+import Superstrain from '../shared/items/Superstrain';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -105,7 +106,8 @@ class CombatLogParser extends CoreCombatLogParser {
     runeOfHysteria: RuneOfHysteria,
 
     // Legendaries
-    brynadaorsMight: BrynadaorsMight
+    brynadaorsMight: BrynadaorsMight,
+    superStrain: Superstrain
   };
 }
 

--- a/src/parser/deathknight/blood/modules/items/BrynadaorsMight.tsx
+++ b/src/parser/deathknight/blood/modules/items/BrynadaorsMight.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+
+import Statistic from 'interface/statistics/Statistic';
+import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+import Events, { EnergizeEvent } from 'parser/core/Events';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import { formatPercentage } from 'common/format';
+import { i18n } from '@lingui/core';
+import { t } from '@lingui/macro';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
+
+class BrynadaorsMight extends Analyzer {
+
+  runicPowerGained: number = 0;
+  runicPowerWasted: number = 0;
+
+  brynadaorsTriggered: number = 0;
+  deathStriked: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    const active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.BRYNDAORS_MIGHT.bonusID)
+    this.active = active
+    if (!active) {
+      return;
+    }
+
+    this.addEventListener(Events.energize, this._onEnergize)
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.DEATH_STRIKE_HEAL), this._onHeal)
+  }
+
+  _onEnergize(event: EnergizeEvent) {
+    if (event.resourceChangeType !== RESOURCE_TYPES.RUNIC_POWER.id || event.ability.guid !== SPELLS.BRYNDAORS_MIGHT_RUNIC_POWER_GAIN.id) {
+      return;
+    }
+
+    this.runicPowerGained += event.resourceChange
+    this.runicPowerWasted += event.waste
+    this.brynadaorsTriggered += 1
+  }
+
+  _onHeal() {
+    this.deathStriked += 1
+  }
+
+  get brynadaorsNotTriggered() {
+    return this.deathStriked - this.brynadaorsTriggered
+  }
+
+  get brynadaorsPercentage() {
+    return this.brynadaorsNotTriggered / this.deathStriked
+  }
+
+  get rpWastePercentage() {
+    return this.runicPowerWasted / this.runicPowerGained
+  }
+
+  get efficiencySuggestionThresholds() {
+    return {
+      actual: this.rpWastePercentage,
+      isGreaterThan: {
+        minor: 0,
+        average: .2,
+        major: .4,
+      },
+      style: ThresholdStyle.PERCENTAGE,
+    };
+  }
+
+  suggestions(when: When) {
+    when(this.efficiencySuggestionThresholds)
+      .addSuggestion((suggest, actual, recommended) => suggest(<span>Avoid being Runic Power capped at all times, you wasted {this.runicPowerWasted} PR by being RP capped.</span>)
+          .icon(SPELLS.BRYNDAORS_MIGHT.icon)
+          .actual(i18n._(t('deathknight.suggestions.brynadaorsMight.efficiency')`You wasted ${(formatPercentage(actual))}% of RP from ${SPELLS.BRYNDAORS_MIGHT.name} by being RP capped.`))
+          .recommended(`${formatPercentage(recommended)}% is recommended`));
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        category={STATISTIC_CATEGORY.ITEMS}
+        size="flexible"
+        tooltip={(
+          <>
+            <strong>{this.brynadaorsTriggered}</strong> of your {SPELLS.DEATH_STRIKE.name}s triggered {SPELLS.BRYNDAORS_MIGHT.name} while <strong>{this.brynadaorsNotTriggered} ({formatPercentage(this.brynadaorsPercentage)}%) did not</strong>.<br />
+            <strong>RP wasted: </strong> {this.runicPowerWasted} ({formatPercentage(this.rpWastePercentage)} %)
+          </>
+        )}
+      >
+        <BoringSpellValueText spell={SPELLS.BRYNDAORS_MIGHT}>
+          <>
+            {this.runicPowerGained} <small>RP gained</small>
+          </>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+
+}
+
+export default BrynadaorsMight;

--- a/src/parser/deathknight/blood/modules/items/BrynadaorsMight.tsx
+++ b/src/parser/deathknight/blood/modules/items/BrynadaorsMight.tsx
@@ -10,8 +10,6 @@ import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import Events, { EnergizeEvent } from 'parser/core/Events';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { formatPercentage } from 'common/format';
-import { i18n } from '@lingui/core';
-import { t } from '@lingui/macro';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 
 class BrynadaorsMight extends Analyzer {
@@ -77,7 +75,7 @@ class BrynadaorsMight extends Analyzer {
     when(this.efficiencySuggestionThresholds)
       .addSuggestion((suggest, actual, recommended) => suggest(<span>Avoid being Runic Power capped at all times, you wasted {this.runicPowerWasted} PR by being RP capped.</span>)
           .icon(SPELLS.BRYNDAORS_MIGHT.icon)
-          .actual(i18n._(t('deathknight.suggestions.brynadaorsMight.efficiency')`You wasted ${(formatPercentage(actual))}% of RP from ${SPELLS.BRYNDAORS_MIGHT.name} by being RP capped.`))
+          .actual(`You wasted ${(formatPercentage(actual))}% of RP from ${SPELLS.BRYNDAORS_MIGHT.name} by being RP capped.`)
           .recommended(`${formatPercentage(recommended)}% is recommended`));
   }
 

--- a/src/parser/deathknight/frost/CHANGELOG.tsx
+++ b/src/parser/deathknight/frost/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+    change(date(2020, 12, 12), <>Added <SpellLink id={SPELLS.SUPERSTRAIN.id} /> module</>, joshinator),
     change(date(2020, 12, 7), 'Updated Abilities with covenant signature and class abilities', [Khazak]),
     change(date(2020, 11, 13), <>Added analyzer for <SpellLink id={SPELLS.HYPOTHERMIC_PRESENCE_TALENT.id} /></>, [Khazak]),
     change(date(2020, 11, 5), <>Added manual RP tracking for <SpellLink id={SPELLS.BREATH_OF_SINDRAGOSA_TALENT.id} /> and updated suggestion to target a 25+ second duration</>, [Khazak]),

--- a/src/parser/deathknight/frost/CombatLogParser.ts
+++ b/src/parser/deathknight/frost/CombatLogParser.ts
@@ -26,6 +26,9 @@ import Frostscythe from './modules/talents/Frostscythe';
 import RuneOfTheFallenCrusader from '../shared/runeforges/RuneOfTheFallenCrusader';
 import RuneOfHysteria from '../shared/runeforges/RuneOfHysteria';
 
+// Legendaries
+import Superstrain from '../shared/items/Superstrain';
+
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     // Core
@@ -56,6 +59,9 @@ class CombatLogParser extends CoreCombatLogParser {
     // Runes
     runeOfTheFallenCrusader: RuneOfTheFallenCrusader,
     runeOfHysteria: RuneOfHysteria,
+
+    // Legendaries
+    superStrain: Superstrain,
 
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: 0.5 }] as const,
   };

--- a/src/parser/deathknight/shared/items/Superstrain.tsx
+++ b/src/parser/deathknight/shared/items/Superstrain.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+
+import Statistic from 'interface/statistics/Statistic';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+import Events, { DamageEvent, EnergizeEvent } from 'parser/core/Events';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import SPECS from 'game/SPECS';
+import ItemDamageDone from 'interface/ItemDamageDone';
+import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import { formatNumber } from 'common/format';
+
+class Superstrain extends Analyzer {
+
+  frostFeverRPGained: number = 0
+  frostFeverRPWasted: number = 0
+  frostFeverDamage: number = 0
+  bloodPlagueDamage: number = 0
+  virulentPlagueDamage: number = 0
+
+  constructor(options: Options) {
+    super(options);
+
+    const active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.SUPERSTRAIN.bonusID)
+    this.active = active
+    if (!active) {
+      return;
+    }
+
+    if ([SPECS.BLOOD_DEATH_KNIGHT, SPECS.UNHOLY_DEATH_KNIGHT].includes(this.selectedCombatant.spec)) {
+      this.addEventListener(Events.energize, this._onFrostFeverEnergize)
+    }
+
+
+    if (this.selectedCombatant.spec === SPECS.BLOOD_DEATH_KNIGHT) {
+      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.FROST_FEVER), this._onFrostFeverDamage)
+      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.VIRULENT_PLAGUE), this._onVirulentPlagueDamage)
+    }
+
+    if (this.selectedCombatant.spec === SPECS.UNHOLY_DEATH_KNIGHT) {
+      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.FROST_FEVER), this._onFrostFeverDamage)
+      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.BLOOD_PLAGUE), this._onBloodPlagueDamage)
+    }
+
+    if (this.selectedCombatant.spec === SPECS.FROST_DEATH_KNIGH) {
+      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.VIRULENT_PLAGUE), this._onVirulentPlagueDamage)
+      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.BLOOD_PLAGUE), this._onBloodPlagueDamage)
+    }
+  }
+
+  _onFrostFeverDamage(event: DamageEvent) {
+    this.frostFeverDamage += event.amount + (event.absorb || 0)
+  }
+
+  _onBloodPlagueDamage(event: DamageEvent) {
+    this.bloodPlagueDamage += event.amount + (event.absorb || 0)
+  }
+
+  _onVirulentPlagueDamage(event: DamageEvent) {
+    this.virulentPlagueDamage += event.amount + (event.absorb || 0)
+  }
+
+  _onFrostFeverEnergize(event: EnergizeEvent) {
+    if (event.resourceChangeType !== RESOURCE_TYPES.RUNIC_POWER.id || event.ability.guid !== SPELLS.FROST_FEVER_RP_GAIN.id) {
+      return;
+    }
+
+    this.frostFeverRPGained += event.resourceChange
+    this.frostFeverRPWasted += event.waste
+  }
+
+  get frostFeverTotalRP() {
+    return this.frostFeverRPGained + this.frostFeverRPWasted
+  }
+
+  get superStrainDamage() {
+    return this.frostFeverDamage + this.bloodPlagueDamage + this.virulentPlagueDamage
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        category={STATISTIC_CATEGORY.ITEMS}
+        size="flexible"
+        tooltip={(
+          <>
+            {this.frostFeverTotalRP > 0 && <><strong>Runic Power:</strong> {this.frostFeverRPGained} RP gained ({this.frostFeverRPWasted} wasted)<br /></>}
+            {this.frostFeverDamage > 0 && <><strong>Frost Fever:</strong> {formatNumber(this.frostFeverDamage)} damage<br /></>}
+            {this.bloodPlagueDamage > 0 && <><strong>Blood Plague:</strong> {formatNumber(this.bloodPlagueDamage)} damage<br /></>}
+            {this.virulentPlagueDamage > 0 && <><strong>Virulent Plague:</strong> {formatNumber(this.virulentPlagueDamage)} damage<br /></>}
+          </>
+        )}
+      >
+        <BoringSpellValueText spell={SPELLS.SUPERSTRAIN}>
+          <>
+            <ItemDamageDone amount={this.superStrainDamage} />
+          </>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+
+}
+
+export default Superstrain;

--- a/src/parser/deathknight/unholy/CHANGELOG.tsx
+++ b/src/parser/deathknight/unholy/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import SPELLS from 'common/SPELLS'
 import SpellLink from 'common/SpellLink';
 
 export default [
+  change(date(2020, 12, 12), <>Added <SpellLink id={SPELLS.SUPERSTRAIN.id} /> module</>, joshinator),
   change(date(2020, 12, 9), <>Reworked <SpellLink id={SPELLS.SOUL_REAPER_TALENT.id}/> to use ExecuteHelper to provide cast efficiency and damage statistics</>, [Khazak]),
   change(date(2020, 12, 7), 'Updated Abilities with covenant signature and class abilities', [Khazak]),
   change(date(2020, 11, 25), <>Updated cooldown tracking to support <SpellLink id={SPELLS.DEATH_COIL.id} /> Rank 2 and <SpellLink id={SPELLS.ARMY_OF_THE_DAMNED_TALENT.id} /></>, [Khazak]),

--- a/src/parser/deathknight/unholy/CombatLogParser.ts
+++ b/src/parser/deathknight/unholy/CombatLogParser.ts
@@ -24,6 +24,9 @@ import RuneDetails from '../shared/RuneDetails';
 import RuneOfTheFallenCrusader from '../shared/runeforges/RuneOfTheFallenCrusader';
 import RuneOfHysteria from '../shared/runeforges/RuneOfHysteria';
 
+// Legendaries
+import Superstrain from '../shared/items/Superstrain';
+
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     // Features
@@ -52,6 +55,9 @@ class CombatLogParser extends CoreCombatLogParser {
     // Runes
     runeOfTheFallenCrusader: RuneOfTheFallenCrusader,
     runeOfHysteria: RuneOfHysteria,
+
+    // Legendaries
+    superStrain: Superstrain,
 
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: 0.5 }] as const,
   };


### PR DESCRIPTION
- Superstrain
![image](https://user-images.githubusercontent.com/29842841/101990806-dc1d1d80-3ca8-11eb-8af5-f18eb350083e.png)
Damage and RP are counted appropriately per spec (eg blood wont show BP and frost wont see RP gained by FF)

- Bryndaor's Might
![image](https://user-images.githubusercontent.com/29842841/101990855-26060380-3ca9-11eb-944a-4d3fa7bffc80.png)
The amount of procs is currently only displayed, might eventually add a suggestion for a different legendary as people have multiple legendaries but for now its just a FYI stat.

- Bumped blood to 9.0.2