### PR TITLE
[BRM] Fix the Light Brewing talent ID

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,0 @@
-# Copy this file and rename it to `.env.local` to configure your own WCL API key. You can get your own API key from the bottom of the Warcraft Logs settings: https://www.warcraftlogs.com/profile
-# You should also enter the application name "WoWAnalyzer (development)" on that page, just above the key.
-REACT_APP_WCL_API_KEY=INSERT_YOUR_OWN_API_KEY_HERE

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,3 @@
+# Copy this file and rename it to `.env.local` to configure your own WCL API key. You can get your own API key from the bottom of the Warcraft Logs settings: https://www.warcraftlogs.com/profile
+# You should also enter the application name "WoWAnalyzer (development)" on that page, just above the key.
+REACT_APP_WCL_API_KEY=INSERT_YOUR_OWN_API_KEY_HERE

--- a/src/common/SPELLS/talents/monk.js
+++ b/src/common/SPELLS/talents/monk.js
@@ -25,7 +25,7 @@ export default {
   UPWELLING_TALENT: { id: 274963, name: 'Upwelling', icon: 'ability_monk_surgingmist' },
   RISING_MIST_TALENT: { id: 274909, name: 'Rising Mist', icon: 'ability_monk_effuse' },
   // Brewmaster
-  LIGHT_BREWING_TALENT: { id: 196721, name: 'Light Brewing', icon: 'spell_brew_wheat' },
+  LIGHT_BREWING_TALENT: { id: 325093, name: 'Light Brewing', icon: 'spell_brew_wheat' },
   SPITFIRE_TALENT: { id: 242580, name: 'Spitfire', icon: 'ability_monk_breathoffire' },
   BLACK_OX_BREW_TALENT: { id: 115399, name: 'Black Ox Brew', icon: 'ability_monk_chibrew' },
   BOB_AND_WEAVE_TALENT: { id: 280515, name: 'Bob and Weave', icon: 'ability_creature_cursed_04' },

--- a/src/parser/monk/brewmaster/CHANGELOG.js
+++ b/src/parser/monk/brewmaster/CHANGELOG.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { Abelito75, emallson, Dambroda, Zeboot, LeoZhekov } from 'CONTRIBUTORS';
+import { Abelito75, emallson, Dambroda, Zeboot, LeoZhekov, Matardarix } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 12, 15), <>Fix <SpellLink id={SPELLS.LIGHT_BREWING_TALENT.id} /> ID</>, Matardarix),
   change(date(2020, 11, 26), <>Replaced the deprecated StatisticBoxes from the modules with the new Statistic</>, LeoZhekov),
   change(date(2020, 10, 24), <>Added checklist item and timeline annotations for bad <SpellLink id={SPELLS.TIGER_PALM.id} /> casts.</>, emallson),
   change(date(2020, 10, 18), 'Converted legacy listeners to new event filters', Zeboot),

--- a/src/parser/monk/brewmaster/integrationTests/example.test.ts.snap
+++ b/src/parser/monk/brewmaster/integrationTests/example.test.ts.snap
@@ -170,7 +170,7 @@ exports[`Brewmaster Monk integration test: example log BrewCDR matches the stati
         <div
           className="value"
         >
-          26.30
+          27.33
            %
         </div>
       </div>
@@ -1381,7 +1381,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
               }
             >
               22
-              /36
+              /32
                
               casts
             </td>
@@ -1400,7 +1400,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
                   style={
                     Object {
                       "backgroundColor": "#ff8000",
-                      "width": "59.94014475498823%",
+                      "width": "66.28541987946811%",
                     }
                   }
                 />
@@ -1415,7 +1415,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
                 }
               }
             >
-              59.94%
+              66.29%
             </td>
             <td
               style={
@@ -1484,7 +1484,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
               }
             >
               4
-              /8
+              /7
                
               casts
             </td>
@@ -1503,7 +1503,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
                   style={
                     Object {
                       "backgroundColor": "#ff8000",
-                      "width": "40.990321734867976%",
+                      "width": "48.55737991465495%",
                     }
                   }
                 />
@@ -1518,7 +1518,7 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
                 }
               }
             >
-              40.99%
+              48.56%
             </td>
             <td
               style={
@@ -3195,8 +3195,8 @@ Array [
         values={
           Object {
             "0": 22,
-            "1": 36,
-            "2": "60",
+            "1": 32,
+            "2": "66",
           }
         }
       />
@@ -3239,8 +3239,8 @@ Array [
         values={
           Object {
             "0": 4,
-            "1": 8,
-            "2": "41",
+            "1": 7,
+            "2": "49",
           }
         }
       />
@@ -4253,7 +4253,7 @@ exports[`Brewmaster Monk integration test: example log matches the checklist sna
               style={
                 Object {
                   "backgroundColor": "#ffc84a",
-                  "width": "59.09985142514069%",
+                  "width": "60.7797383410534%",
                 }
               }
             />
@@ -4389,7 +4389,7 @@ exports[`Brewmaster Monk integration test: example log matches the checklist sna
                   }
                 >
                    
-                  40.99%
+                  48.56%
                    
                    
                 </div>
@@ -4411,7 +4411,7 @@ exports[`Brewmaster Monk integration test: example log matches the checklist sna
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "18.199702850281383%",
+                        "width": "21.5594766821068%",
                       }
                     }
                   />
@@ -4568,8 +4568,8 @@ exports[`Brewmaster Monk integration test: example log matches the checklist sna
               className="perf-bar"
               style={
                 Object {
-                  "backgroundColor": "#df7102",
-                  "width": "49.93340268317666%",
+                  "backgroundColor": "#ffc84a",
+                  "width": "53.339686051939125%",
                 }
               }
             />
@@ -4818,7 +4818,7 @@ exports[`Brewmaster Monk integration test: example log matches the checklist sna
                   }
                 >
                    
-                  59.94%
+                  66.29%
                    
                    
                 </div>
@@ -4840,7 +4840,7 @@ exports[`Brewmaster Monk integration test: example log matches the checklist sna
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "24.950085254263854%",
+                        "width": "27.591306024828604%",
                       }
                     }
                   />
@@ -5013,7 +5013,7 @@ exports[`Brewmaster Monk integration test: example log matches the checklist sna
                   }
                 >
                    
-                  0.15s
+                  -1.96s
                    
                    
                 </div>

--- a/src/parser/monk/brewmaster/modules/core/BrewCDR.test.js.snap
+++ b/src/parser/monk/brewmaster/modules/core/BrewCDR.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BrewCDR should match the cdr snapshot 1`] = `0.2630088802883363`;
+exports[`BrewCDR should match the cdr snapshot 1`] = `0.27334653181026225`;


### PR DESCRIPTION
Fix the ID of the light brewing talent, that wasn't up to date. 
Note that this will also fix the CD calculation of Purifying and Celestial Brew.
Live:
![image](https://user-images.githubusercontent.com/48837283/102208942-fda82000-3ec7-11eb-9aa7-d674d7bf89fd.png)
Fixed:
![image](https://user-images.githubusercontent.com/48837283/102208991-0e589600-3ec8-11eb-8574-fc480a92c8de.png)
