### PR TITLE
[Druid] Fix shadowlands guardian compiler errors

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -1065,6 +1065,7 @@ export const Xcessiv: Contributor = {
     link: 'https://worldofwarcraft.com/en-us/character/us/thrall/xcessiv',
   }],
 };
+
 export const Tora: Contributor = {
   nickname: "Tora",
   github: "RobinKa",
@@ -1077,4 +1078,19 @@ export const Tora: Contributor = {
   links: {
     "Website": "https://warlock.ai"
   },
+};
+
+export const Kettlepaw: Contributor = {
+  nickname: 'Kettlepaw',
+  github: 'abbottmg',
+  discord: 'abbott#2506',
+  mains: [{
+    name: 'Caeldrim',
+    spec: SPECS.GUARDIAN_DRUID,
+    link: 'https://worldofwarcraft.com/en-us/character/us/wyrmrest-accord/caeldrim',
+  }, {
+    name: 'Kettlepaw',
+    spec: SPECS.BREWMASTER_MONK,
+    link: 'https://worldofwarcraft.com/en-us/character/us/wyrmrest-accord/kettlepaw',
+  }],
 };

--- a/src/parser/core/modules/Abilities.ts
+++ b/src/parser/core/modules/Abilities.ts
@@ -81,7 +81,9 @@ class Abilities extends Module {
     this.loadSpellbook(this.spellbook());
   }
   loadSpellbook(spellbook: SpellbookAbility[]) {
-    this.abilities = spellbook.map(options => new Ability(this, options));
+    // Abilities subtypes may want to construct a particular subtype of Ability
+    const ability_class = (this.constructor as typeof Abilities).ABILITY_CLASS;
+    this.abilities = spellbook.map(options => new ability_class(this, options));
     this.activeAbilities = this.abilities.filter(ability => ability.enabled);
   }
 

--- a/src/parser/core/modules/Abilities.ts
+++ b/src/parser/core/modules/Abilities.ts
@@ -82,8 +82,8 @@ class Abilities extends Module {
   }
   loadSpellbook(spellbook: SpellbookAbility[]) {
     // Abilities subtypes may want to construct a particular subtype of Ability
-    const ability_class = (this.constructor as typeof Abilities).ABILITY_CLASS;
-    this.abilities = spellbook.map(options => new ability_class(this, options));
+    const abilityClass = (this.constructor as typeof Abilities).ABILITY_CLASS;
+    this.abilities = spellbook.map(options => new abilityClass(this, options));
     this.activeAbilities = this.abilities.filter(ability => ability.enabled);
   }
 

--- a/src/parser/core/modules/Ability.ts
+++ b/src/parser/core/modules/Ability.ts
@@ -150,6 +150,18 @@ export interface SpellbookAbility<TrackedAbilityType extends TrackedAbility = Tr
 }
 
 class Ability {
+   /**
+   * When extending this class with a new propTypes property you MUST include
+   * its parent's propTypes values in your new override value. Otherwise your
+   * class will treat inherited props as misplaced
+   * Example:
+   * import CoreAbility from 'parser/core/modules/Ability';
+   * class Ability extends CoreAbility {
+   *   static propTypes = {
+   *     ...CoreAbility.propTypes,
+   *     //...new property entries here...
+   * }
+   */
   static propTypes: { [key: string]: any } = {
     /**
      * REQUIRED The spell definition. If an array of spell definitions is
@@ -394,8 +406,6 @@ class Ability {
   shownSpell = null;
 
   /**
-   * When extending this class you MUST copy-paste this function into the new
-   * class. Otherwise your new props will not be set properly.
    * @param owner
    * @param options
    */

--- a/src/parser/druid/guardian/CHANGELOG.js
+++ b/src/parser/druid/guardian/CHANGELOG.js
@@ -2,6 +2,6 @@ import { Kettlepaw, Zeboot } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2020, 12, 18), 'Fixed compiler errors affecing FrenziedRegen and AntiFillerSpam', Kettlepaw),
+  change(date(2020, 12, 18), 'Fixed compiler errors affecting FrenziedRegen and AntiFillerSpam', Kettlepaw),
   change(date(2020, 10, 18), 'Converted legacy listeners to new event filters', Zeboot),
 ];

--- a/src/parser/druid/guardian/CHANGELOG.js
+++ b/src/parser/druid/guardian/CHANGELOG.js
@@ -1,6 +1,7 @@
-import { Zeboot } from 'CONTRIBUTORS';
+import { Kettlepaw, Zeboot } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 12, 18), 'Fixed compiler errors affecing FrenziedRegen and AntiFillerSpam', Kettlepaw),
   change(date(2020, 10, 18), 'Converted legacy listeners to new event filters', Zeboot),
 ];

--- a/src/parser/druid/guardian/modules/Ability.js
+++ b/src/parser/druid/guardian/modules/Ability.js
@@ -18,17 +18,6 @@ class Ability extends CoreAbility {
   };
 
   antiFillerSpam = null;
-
-  /**
-   * When extending this class you MUST copy-paste this function into the new class. Otherwise your new props will not be set properly.
-   * @param owner
-   * @param options
-   */
-  constructor(owner, options) {
-    super(owner, options);
-    this._owner = owner;
-    this._setProps(options);
-  }
 }
 
 export default Ability;

--- a/src/parser/druid/guardian/modules/spells/FrenziedRegeneration.js
+++ b/src/parser/druid/guardian/modules/spells/FrenziedRegeneration.js
@@ -8,7 +8,6 @@ import StatTracker from 'parser/shared/modules/StatTracker';
 import Events from 'parser/core/Events';
 import { t } from '@lingui/macro';
 
-const WILDFLESH_MODIFIER_PER_RANK = 0.05;
 const FR_WINDOW_MS = 5000;
 const FR_MINIMUM_HP_HEAL = 0.05;
 
@@ -39,11 +38,8 @@ class FrenziedRegeneration extends Analyzer {
 
   constructor(...args) {
     super(...args);
-    const player = this.selectedCombatant;
-    const wildfleshRank = player.traitsBySpellId[SPELLS.WILDFLESH_TRAIT.id];
     const versModifier = this.statTracker.currentVersatilityPercentage;
 
-    this._healModifier += (wildfleshRank * WILDFLESH_MODIFIER_PER_RANK);
     this._healModifier += versModifier; // TODO: Account for Haste buffs by asking the actual value on each event instead of in here
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.FRENZIED_REGENERATION), this.onCast);
     this.addEventListener(Events.cast.to(SELECTED_PLAYER), this.onDamage);


### PR DESCRIPTION
This corrects two compiler errors affecting the druid/guardian module hierarchy:

1. The Frenzied Regeneration spell module was attempting to read a Combatant's trait information, which was recently removed
2. The `Abilities` loader module was not finding the guardian-specific `Ability` subtype, which adds properties necessary for the Anti-Filler Spam feature module to operate. I believe this compiler error only occurs in development mode.

The first error required simply removing the calculation of a defunct Legion trait's effect on healing, which removed the need to reference the missing trait accessor.

The second error required modifying the core `Abilities` `loadSpellbook` method to dynamically discover the `Ability` subtype to construct using the class's static `ABILITY_CLASS` property, rather than statically calling the `Ability` constructor. This `ABILITY_CLASS` property is overridden by the guardian `Abilities` object to point at [guardian-specific Ability](src/parser/druid/guardian/modules/Ability.js).

The comments noting a special requirement for copy-pasting the `Ability` constructor let me on a small wild goose chase (the duplicated constructor was never getting called because `loadSpellbook` wasn't looking for it). Once I did find the root issue, I noticed that the duplicate constructor was actually redundant, at least based on the current implementation of `propTypes` and `Ability._setProps`. As such, I removed the redundant override as well as the comments, and replaced the latter with a comment explaining how to override `propTypes` to ensure `_setProps` has the information it needs within a single call.

All that said, I am not particularly familiar with this codebase so I understand if you know of a reason why the copy-paste constructor pattern should remain.