### PR TITLE
[Core] More Warning Messages

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -8,6 +8,7 @@ import { change, date } from 'common/changelog';
 
 // prettier-ignore
 export default [
+  change(date(2020, 12, 19), 'Add warnings for logs with Advanced Combat Logging disabled and when no encounters are found.', Sharrq),
   change(date(2020, 12, 19), <> Fix issues with <ItemLink id={ITEMS.INSCRUTABLE_QUANTUM_DEVICE.id} /> not accounting for the correct stat given. </>, Putro),
   change(date(2020, 12, 19), 'Adjust our weak Potion suggestion to only show if a weak potion was actually used', Putro),
   change(date(2020, 12, 17), 'Added phase information for Castle Nathria bosses', Sharrq),

--- a/src/interface/report/AdvancedLoggingWarning.tsx
+++ b/src/interface/report/AdvancedLoggingWarning.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Trans } from '@lingui/macro';
+
+import Warning from 'interface/Alert/Warning';
+
+const AdvancedLoggingWarning = () => (
+    <div className="container">
+      <Warning style={{ marginBottom: 30 }}>
+        <h2><Trans id="interface.report.advancedLoggingWarning.advancedLoggingWarning">Advanced Combat Logging not Enabled</Trans></h2>
+        <Trans id="interface.report.advancedLoggingWarning.advancedLoggingWarningDetails">
+          Without Advanced Combat Logging, we are unable to get critical information about players including specs, talents, and gear. Without this information we are unable to provide analysis for this encounter. Please ensure that Advanced Combat Logging is enabled in game (Can be found in the game settings under System/Network).
+        </Trans>
+      </Warning>
+    </div>
+  );
+
+export default AdvancedLoggingWarning;

--- a/src/interface/report/EncountersNotFoundWarning.tsx
+++ b/src/interface/report/EncountersNotFoundWarning.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Trans } from '@lingui/macro';
+
+import Warning from 'interface/Alert/Warning';
+
+const EncountersNotFoundWarning = () => (
+    <div className="container">
+      <Warning style={{ marginBottom: 30 }}>
+        <h2><Trans id="interface.report.encountersNotFoundWarning.noEncountersFound">No Encounters Found</Trans></h2>
+        <Trans id="interface.report.encountersNotFoundWarning.noEncountersFoundDetails">
+          We were unable to find any encounters in this report. If Warcraft Logs shows a dungeon or boss encounter on this report, then try refreshing this page (Press F5) to re-pull the report from Warcraft Logs. Additionally, please note that due to the way combat logs work, we are unable to evaluate Target Dummy logs.
+        </Trans>
+      </Warning>
+    </div>
+  );
+
+export default EncountersNotFoundWarning;

--- a/src/interface/report/FightSelection.js
+++ b/src/interface/report/FightSelection.js
@@ -13,6 +13,7 @@ import { getFightFromReport } from 'interface/selectors/fight';
 import DocumentTitle from 'interface/DocumentTitle';
 import ReportDurationWarning, { MAX_REPORT_DURATION } from 'interface/report/ReportDurationWarning';
 import ClassicLogWarning from 'interface/report/ClassicLogWarning';
+import EncountersNotFoundWarning from 'interface/report/EncountersNotFoundWarning';
 
 import FightSelectionPanel from './FightSelectionPanel';
 
@@ -98,6 +99,8 @@ class FightSelection extends React.PureComponent {
         {reportDuration > MAX_REPORT_DURATION && (
           <ReportDurationWarning duration={reportDuration} />
         )}
+
+        {!report.fights.find(fight => fight.boss > 0) && <EncountersNotFoundWarning />}
 
         {report.gameVersion === 1 && (
           <FightSelectionPanel

--- a/src/interface/report/PlayerLoader.js
+++ b/src/interface/report/PlayerLoader.js
@@ -13,6 +13,7 @@ import Tooltip from 'common/Tooltip';
 import PlayerSelection from 'interface/report/PlayerSelection';
 import RaidCompositionDetails from 'interface/report/RaidCompositionDetails';
 import ReportDurationWarning, { MAX_REPORT_DURATION } from 'interface/report/ReportDurationWarning';
+import AdvancedLoggingWarning from 'interface/report/AdvancedLoggingWarning';
 import ReportRaidBuffList from 'interface/ReportRaidBuffList';
 import { fetchCharacter } from 'interface/actions/characters';
 import { generateFakeCombatantInfo } from 'interface/report/CombatantInfoFaker';
@@ -108,7 +109,7 @@ class PlayerLoader extends React.PureComponent {
       return;
     }
     try {
-      const combatants = await fetchCombatants(report.code, fight.start_time, fight.end_time);
+      const combatants = await fetchCombatants(report.code, fight.start_time, fight.end_time); 
       combatants.forEach(player => {
         if (process.env.NODE_ENV === 'development' && FAKE_PLAYER_IF_DEV_ENV) {
           console.error('This player (sourceID: ' + player.sourceID + ') has an error. Because you\'re in development environment, we have faked the missing information, see CombatantInfoFaker.ts for more information.');
@@ -282,6 +283,8 @@ class PlayerLoader extends React.PureComponent {
 
           {fight.end_time > MAX_REPORT_DURATION &&
           <ReportDurationWarning duration={reportDuration} />}
+
+          {combatants.length === 0 && <AdvancedLoggingWarning />}
 
           <PlayerSelection
             players={report.friendlies.map(friendly => {


### PR DESCRIPTION
Added warning messages for when Advanced Combat Logging is not enabled and if there are no dungeon/boss encounters in the log.

Advanced Combat Logging
![image](https://user-images.githubusercontent.com/1304554/102705789-e4e59480-4250-11eb-900c-34abc378a823.png)


No Encounters Found
![image](https://user-images.githubusercontent.com/1304554/102705782-cf706a80-4250-11eb-86c0-975e41d20230.png)
