### PR TITLE
[Death Knight] Venthy Covenant statistic & superstrain damage fix

### DIFF
--- a/src/common/SPELLS/shadowlands/covenants/deathknight.ts
+++ b/src/common/SPELLS/shadowlands/covenants/deathknight.ts
@@ -32,6 +32,11 @@ const covenants = {
     name: 'Swarming Mist',
     icon: 'ability_revendreth_deathknight'
   },
+  SWARMING_MIST_TICK: {
+    id: 311730,
+    name: 'Swarming Mist',
+    icon: 'ability_revendreth_deathknight'
+  },
   SWARMING_MIST_RUNIC_POWER_GAIN: {
     id: 312546,
     name: 'Swarming Mist',

--- a/src/parser/deathknight/blood/CHANGELOG.tsx
+++ b/src/parser/deathknight/blood/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 12, 20), <>Added module for <SpellLink id={SPELLS.SWARMING_MIST.id} /> and added RP gained from <SpellLink id={SPELLS.SUPERSTRAIN.id} /> to statistic damage</>, joshinator),
   change(date(2020, 12, 12), <>Added <SpellLink id={SPELLS.BRYNDAORS_MIGHT.id} /> and <SpellLink id={SPELLS.SUPERSTRAIN.id} /> modules</>, joshinator),
   change(date(2020, 11, 6), 'Runeforge-suggestions', joshinator),
   change(date(2020, 10, 27), <>Created statistics for <SpellLink id={SPELLS.RUNE_OF_THE_FALLEN_CRUSADER.id} /> and <SpellLink id={SPELLS.RUNE_OF_HYSTERIA.id} /></>, joshinator),

--- a/src/parser/deathknight/blood/CombatLogParser.ts
+++ b/src/parser/deathknight/blood/CombatLogParser.ts
@@ -19,7 +19,7 @@ import DeathStrikeTiming from './modules/features/DeathStrikeTiming';
 import BoneShieldTimesByStacks from './modules/features/BoneShieldTimesByStacks';
 import DeathsCaress from './modules/core/DeathsCaress';
 import MitigationCheck from './modules/features/MitigationCheck';
-// import Ossuary from './modules/features/Ossuary';
+import Ossuary from './modules/features/Ossuary';
 
 // Resources
 import RunicPowerDetails from './modules/runicpower/RunicPowerDetails';
@@ -50,6 +50,9 @@ import RuneOfHysteria from '../shared/runeforges/RuneOfHysteria';
 // Legendaries
 import BrynadaorsMight from './modules/items/BrynadaorsMight';
 import Superstrain from '../shared/items/Superstrain';
+
+// Covenants
+import SwarmingMist from '../shared/covenants/SwarmingMist';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -96,7 +99,7 @@ class CombatLogParser extends CoreCombatLogParser {
     voracious: Voracious,
     rapidDecomposition: RapidDecomposition,
     willOfTheNecropolis: WillOfTheNecropolis,
-    // ossuary: Ossuary,
+    ossuary: Ossuary,
     consumption: Consumption,
     relishInBlood: RelishInBlood,
 
@@ -107,7 +110,10 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Legendaries
     brynadaorsMight: BrynadaorsMight,
-    superStrain: Superstrain
+    superStrain: Superstrain,
+
+    // Covenants
+    swarmingMist: SwarmingMist
   };
 }
 

--- a/src/parser/deathknight/blood/integrationTests/example.test.ts.snap
+++ b/src/parser/deathknight/blood/integrationTests/example.test.ts.snap
@@ -4242,6 +4242,94 @@ exports[`Blood Death Knight integration test: example log MarrowrendUsage matche
 </div>
 `;
 
+exports[`Blood Death Knight integration test: example log Ossuary matches the statistic snapshot 1`] = `
+<div
+  className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
+>
+  <div
+    className="panel statistic flexible "
+    position={3}
+  >
+    <div
+      className="panel-body"
+    >
+      <div
+        className="pad boring-text "
+      >
+        <label>
+          <a
+            className="spell-link-text"
+            href="http://wowhead.com/spell=219788"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <img
+              alt="Ossuary"
+              className="icon game "
+              src="//render-us.worldofwarcraft.com/icons/56/ability_deathknight_brittlebones.jpg"
+            />
+          </a>
+           
+          <a
+            className="spell-link-text"
+            href="http://wowhead.com/spell=219788"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Ossuary
+          </a>
+        </label>
+        <div
+          className="value"
+        >
+          3
+           / 
+          20
+           
+          <small>
+            Death Strikes without Ossuary
+          </small>
+        </div>
+      </div>
+    </div>
+    <div
+      className="detail-corner"
+      data-place="top"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onTouchStart={[Function]}
+    >
+      <svg
+        className="icon"
+        viewBox="0 0 100 100"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M58.9,82.9h7v12.9H34.1V82.9h7.1V45.5h-0.6c-3.6,0-6.4-2.9-6.4-6.4c0-3.6,2.9-6.4,6.4-6.4h0.6h17.4h0.3V82.9z M49,25.8  c6,0,10.8-4.8,10.8-10.8C59.8,9,55,4.2,49,4.2S38.2,9,38.2,15C38.2,21,43,25.8,49,25.8z"
+        />
+      </svg>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Blood Death Knight integration test: example log Ossuary matches the suggestions snapshot 1`] = `
+Array [
+  Object {
+    "details": null,
+    "icon": "ability_deathknight_brittlebones",
+    "importance": "regular",
+    "issue": "Your Ossuary usage can be improved. Avoid casting Death Strike while not having Ossuary up as you lose Runic Power by doing so.",
+    "stat": <React.Fragment>
+      {"id":"deathknight.blood.suggestions.ossuary.efficiency","message":"{0}% Ossuary efficiency","values":{"0":"85.00"}}
+       (
+      100.00% is recommended
+      )
+    </React.Fragment>,
+  },
+]
+`;
+
 exports[`Blood Death Knight integration test: example log PotionChecker matches the suggestions snapshot 1`] = `
 Array [
   Object {
@@ -5784,8 +5872,8 @@ exports[`Blood Death Knight integration test: example log matches the checklist 
               className="perf-bar"
               style={
                 Object {
-                  "backgroundColor": "#4ec04e",
-                  "width": "100%",
+                  "backgroundColor": "#a6c34c",
+                  "width": "77.76666666666668%",
                 }
               }
             />
@@ -5989,6 +6077,80 @@ exports[`Blood Death Knight integration test: example log matches the checklist 
                         "backgroundColor": "#4ec04e",
                         "transition": "background-color 800ms",
                         "width": "100%",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="col-md-6"
+          >
+            <div
+              className="flex"
+            >
+              <div
+                className="flex-main"
+              >
+                <a
+                  className="spell-link-text"
+                  href="http://wowhead.com/spell=219788"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <img
+                    alt=""
+                    className="icon game "
+                    src="//render-us.worldofwarcraft.com/icons/56/ability_deathknight_brittlebones.jpg"
+                  />
+                   
+                  Ossuary
+                </a>
+                 Efficiency
+              </div>
+              <div
+                className="flex-sub content-middle text-muted"
+                style={
+                  Object {
+                    "marginLeft": 5,
+                    "marginRight": 10,
+                    "minWidth": 55,
+                  }
+                }
+              >
+                <div
+                  className="text-right"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                >
+                   
+                  85.00%
+                   
+                   
+                </div>
+              </div>
+              <div
+                className="flex-sub content-middle"
+                style={
+                  Object {
+                    "width": 50,
+                  }
+                }
+              >
+                <div
+                  className="performance-bar-container"
+                >
+                  <div
+                    className="performance-bar small"
+                    style={
+                      Object {
+                        "backgroundColor": "#ac1f39",
+                        "transition": "background-color 800ms",
+                        "width": "33.300000000000004%",
                       }
                     }
                   />

--- a/src/parser/deathknight/blood/modules/Abilities.js
+++ b/src/parser/deathknight/blood/modules/Abilities.js
@@ -2,6 +2,8 @@ import SPELLS from 'common/SPELLS';
 import ISSUE_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
 import CoreAbilities from 'parser/core/modules/Abilities';
 
+import COVENANTS from 'game/shadowlands/COVENANTS';
+
 class Abilities extends CoreAbilities {
   spellbook() {
     const combatant = this.selectedCombatant;
@@ -318,6 +320,84 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.HIDDEN,
         cooldown: haste => 10 / (1 + haste),
         charges: 2,
+      },
+
+      // covenants
+      {
+        spell: SPELLS.SWARMING_MIST,
+        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,     
+        cooldown: 60,
+        gcd: {
+          base: 1500,
+        },
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.90,
+        },
+        enabled: combatant.hasCovenant(COVENANTS.VENTHYR.id),
+      },
+      {
+        spell: SPELLS.DOOR_OF_SHADOWS,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,     
+        cooldown: 60,
+        gcd: {
+          base: 1500,
+        },
+        enabled: combatant.hasCovenant(COVENANTS.VENTHYR.id),
+      },
+      {
+        spell: SPELLS.ABOMINATION_LIMB,
+        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,     
+        cooldown: 120,
+        gcd: {
+          base: 1500,
+        },
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.90,
+        },
+        enabled: combatant.hasCovenant(COVENANTS.NECROLORD.id),
+      },
+      {
+        spell: SPELLS.FLESHCRAFT,
+        category: Abilities.SPELL_CATEGORIES.DEFENSIVE,     
+        cooldown: 120,
+        enabled: combatant.hasCovenant(COVENANTS.NECROLORD.id),
+      },
+      {
+        spell: SPELLS.SHACKLE_THE_UNWORTHY,
+        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,     
+        cooldown: 60,
+        gcd: {
+          base: 1500,
+        },
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.90,
+        },
+        enabled: combatant.hasCovenant(COVENANTS.KYRIAN.id),
+      },
+      {
+        spell: SPELLS.DEATHS_DUE,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,     
+        cooldown: 15,
+        gcd: {
+          base: 1500,
+        },
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.90,
+        },
+        enabled: combatant.hasCovenant(COVENANTS.NIGHT_FAE.id),
+      },
+      {
+        spell: SPELLS.SOULSHAPE,
+        category: Abilities.SPELL_CATEGORIES.UTILITY,     
+        cooldown: 30,
+        gcd: {
+          base: 1500,
+        },
+        enabled: combatant.hasCovenant(COVENANTS.NIGHT_FAE.id),
       },
     ];
   }

--- a/src/parser/deathknight/blood/modules/features/checklist/Component.js
+++ b/src/parser/deathknight/blood/modules/features/checklist/Component.js
@@ -94,10 +94,10 @@ const BloodDeathKnightChecklist = ({ combatant, castEfficiency, thresholds }) =>
           name={<><SpellLink id={SPELLS.BONE_SHIELD.id} /> Uptime</>}
           thresholds={thresholds.boneShield}
         />
-        {/* <Requirement
-          name={<><SpellLink id={SPELLS.OSSUARY.id} /> Uptime</>}
+        <Requirement
+          name={<><SpellLink id={SPELLS.OSSUARY.id} /> Efficiency</>}
           thresholds={thresholds.ossuary}
-        /> */}
+        />
       </Rule>
       <Rule
         name="Use your defensive cooldowns"

--- a/src/parser/deathknight/blood/modules/features/checklist/Module.js
+++ b/src/parser/deathknight/blood/modules/features/checklist/Module.js
@@ -15,7 +15,7 @@ import MarrowrendUsage from "../MarrowrendUsage";
 import DeathsCaress from '../../core/DeathsCaress';
 import BoneStorm from '../../talents/Bonestorm';
 import MarkOfBloodUptime from '../../talents/MarkOfBlood';
-// import Ossuary from '../Ossuary';
+import Ossuary from '../Ossuary';
 import Consumption from '../../talents/Consumption';
 import RunicPowerDetails from '../../runicpower/RunicPowerDetails';
 import RuneTracker from '../../../../shared/RuneTracker';
@@ -29,7 +29,7 @@ class Checklist extends BaseChecklist {
 
     bloodplagueUptime: BloodPlagueUptime,
     boneShield: BoneShield,
-    // ossuary: Ossuary,
+    ossuary: Ossuary,
     deathsCaress: DeathsCaress,
     bonestorm: BoneStorm,
     consumption: Consumption,
@@ -57,7 +57,7 @@ class Checklist extends BaseChecklist {
           bloodPlague: this.bloodplagueUptime.uptimeSuggestionThresholds,
           markOfBlood: this.markOfBloodUptime.uptimeSuggestionThresholds,
           boneShield: this.boneShield.uptimeSuggestionThresholds,
-          // ossuary: this.ossuary.uptimeSuggestionThresholds,
+          ossuary: this.ossuary.efficiencySuggestionThresholds,
         }}
       />
     );

--- a/src/parser/deathknight/frost/CHANGELOG.tsx
+++ b/src/parser/deathknight/frost/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+    change(date(2020, 12, 20), <>Added module for <SpellLink id={SPELLS.SWARMING_MIST.id} /> and added RP gained from <SpellLink id={SPELLS.SUPERSTRAIN.id} /> to statistic damage</>, joshinator),
     change(date(2020, 12, 12), <>Added <SpellLink id={SPELLS.SUPERSTRAIN.id} /> module</>, joshinator),
     change(date(2020, 12, 7), 'Updated Abilities with covenant signature and class abilities', [Khazak]),
     change(date(2020, 11, 13), <>Added analyzer for <SpellLink id={SPELLS.HYPOTHERMIC_PRESENCE_TALENT.id} /></>, [Khazak]),

--- a/src/parser/deathknight/frost/CombatLogParser.ts
+++ b/src/parser/deathknight/frost/CombatLogParser.ts
@@ -29,6 +29,9 @@ import RuneOfHysteria from '../shared/runeforges/RuneOfHysteria';
 // Legendaries
 import Superstrain from '../shared/items/Superstrain';
 
+// Covenants
+import SwarmingMist from '../shared/covenants/SwarmingMist';
+
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     // Core
@@ -62,6 +65,9 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Legendaries
     superStrain: Superstrain,
+
+    // Covenants
+    swarmingMist: SwarmingMist,
 
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: 0.5 }] as const,
   };

--- a/src/parser/deathknight/shared/covenants/SwarmingMist.tsx
+++ b/src/parser/deathknight/shared/covenants/SwarmingMist.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+
+import Statistic from 'interface/statistics/Statistic';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+import Events, { DamageEvent, EnergizeEvent } from 'parser/core/Events';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import SPECS from 'game/SPECS';
+import ItemDamageDone from 'interface/ItemDamageDone';
+import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import { formatNumber, formatPercentage } from 'common/format';
+import COVENANTS from 'game/shadowlands/COVENANTS';
+import { t } from '@lingui/macro';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
+
+const DEATH_STRIKE_RP = 40;
+const DEATH_COIL_RP = 40;
+const FROST_STRIKE_RP = 25;
+
+class Superstrain extends Analyzer {
+
+  rpGained: number = 0;
+  rpWasted: number = 0;
+
+  rpDamage: number = 0;
+  rpSpenderUsed: number = 0;
+
+  swarmingMistDamage: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    const active = this.selectedCombatant.hasCovenant(COVENANTS.VENTHYR.id)
+    this.active = active
+    if (!active) {
+      return;
+    }
+
+    this.addEventListener(Events.energize, this._onSwarmingMistEnergize);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.SWARMING_MIST_TICK), this._onSwarmingMistDamage);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell([SPELLS.DEATH_STRIKE, SPELLS.DEATH_COIL, SPELLS.FROST_STRIKE_MAIN_HAND_DAMAGE, SPELLS.FROST_STRIKE_OFF_HAND_DAMAGE]), this._rpSpender);
+  }
+
+  _onSwarmingMistDamage(event: DamageEvent) {
+    this.swarmingMistDamage += event.amount + (event.absorb || 0);
+  }
+
+  _onSwarmingMistEnergize(event: EnergizeEvent) {
+    if (event.resourceChangeType !== RESOURCE_TYPES.RUNIC_POWER.id || event.ability.guid !== SPELLS.SWARMING_MIST_RUNIC_POWER_GAIN.id) {
+      return;
+    }
+
+    this.rpGained += event.resourceChange;
+    this.rpWasted += event.waste;
+  }
+
+  _rpSpender(event: DamageEvent) {
+    this.rpDamage += event.amount + (event.absorb || 0);
+    this.rpSpenderUsed += 1;
+  }
+
+  get rpSpenderAverageDamage() {
+    return this.rpDamage / this.rpSpenderUsed;
+  }
+
+  get rpBonusDamage() {
+    return this.rpSpenderAverageDamage * Math.floor(this.rpGained / this.rpSpenderCost);
+  }
+
+  get totalDamage() {
+    return this.swarmingMistDamage + this.rpBonusDamage;
+  }
+
+  get rpSpenderCost() {
+    if (this.selectedCombatant.spec === SPECS.BLOOD_DEATH_KNIGHT) {
+      return DEATH_STRIKE_RP;
+    }
+
+    if (this.selectedCombatant.spec === SPECS.UNHOLY_DEATH_KNIGHT) {
+      return DEATH_COIL_RP;
+    }
+
+    return FROST_STRIKE_RP;
+  }
+
+  get rpSpenderName() {
+    if (this.selectedCombatant.spec === SPECS.BLOOD_DEATH_KNIGHT) {
+      return SPELLS.DEATH_STRIKE.name
+    }
+
+    if (this.selectedCombatant.spec === SPECS.UNHOLY_DEATH_KNIGHT) {
+      return SPELLS.DEATH_COIL.name
+    }
+
+    return SPELLS.FROST_STRIKE.name
+  }
+
+  get rpWastePercentage() {
+    return this.rpWasted / this.rpGained
+  }
+
+  get efficiencySuggestionThresholds() {
+    return {
+      actual: this.rpWastePercentage,
+      isGreaterThan: {
+        minor: 0,
+        average: .2,
+        major: .4,
+      },
+      style: ThresholdStyle.PERCENTAGE,
+    };
+  }
+
+  suggestions(when: When) {
+    when(this.efficiencySuggestionThresholds)
+      .addSuggestion((suggest, actual, recommended) => suggest(<span>Avoid being Runic Power capped at all times, you wasted {this.rpWasted} PR by being RP capped.</span>)
+          .icon(SPELLS.SWARMING_MIST_TICK.icon)
+          .actual(t({
+      id: "deathknight.suggestions.swarmingmist.efficiency",
+      message: `You wasted ${(formatPercentage(actual))}% of RP from ${SPELLS.SWARMING_MIST.name} by being RP capped.`
+    }))
+          .recommended(`${formatPercentage(recommended)}% is recommended`));
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        category={STATISTIC_CATEGORY.COVENANTS}
+        size="flexible"
+        tooltip={(
+          <>
+            <strong>Runic Power:</strong> {this.rpGained} RP gained ({this.rpWasted} wasted)<br />
+            <strong>Runic Power Damage:</strong> {formatNumber(this.rpBonusDamage)} damage ({this.rpSpenderName} does an average of {formatNumber(this.rpSpenderAverageDamage)} damage)<br />
+            <strong>Swarming Mist Damage:</strong> {formatNumber(this.swarmingMistDamage)} damage
+          </>
+        )}
+      >
+        <BoringSpellValueText spell={SPELLS.SWARMING_MIST}>
+          <>
+            <ItemDamageDone amount={this.totalDamage} />
+          </>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+
+}
+
+export default Superstrain;

--- a/src/parser/deathknight/shared/items/Superstrain.tsx
+++ b/src/parser/deathknight/shared/items/Superstrain.tsx
@@ -13,13 +13,20 @@ import ItemDamageDone from 'interface/ItemDamageDone';
 import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
 import { formatNumber } from 'common/format';
 
+const DEATH_STRIKE_RP = 40;
+const DEATH_COIL_RP = 40;
+
 class Superstrain extends Analyzer {
 
-  frostFeverRPGained: number = 0
-  frostFeverRPWasted: number = 0
-  frostFeverDamage: number = 0
-  bloodPlagueDamage: number = 0
-  virulentPlagueDamage: number = 0
+  frostFeverRPGained: number = 0;
+  frostFeverRPWasted: number = 0;
+
+  rpDamage: number = 0;
+  rpSpenderUsed: number = 0;
+
+  frostFeverDamage: number = 0;
+  bloodPlagueDamage: number = 0;
+  virulentPlagueDamage: number = 0;
 
   constructor(options: Options) {
     super(options);
@@ -31,36 +38,38 @@ class Superstrain extends Analyzer {
     }
 
     if ([SPECS.BLOOD_DEATH_KNIGHT, SPECS.UNHOLY_DEATH_KNIGHT].includes(this.selectedCombatant.spec)) {
-      this.addEventListener(Events.energize, this._onFrostFeverEnergize)
+      this.addEventListener(Events.energize, this._onFrostFeverEnergize);
     }
 
 
     if (this.selectedCombatant.spec === SPECS.BLOOD_DEATH_KNIGHT) {
-      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.FROST_FEVER), this._onFrostFeverDamage)
-      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.VIRULENT_PLAGUE), this._onVirulentPlagueDamage)
+      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.FROST_FEVER), this._onFrostFeverDamage);
+      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.VIRULENT_PLAGUE), this._onVirulentPlagueDamage);
+      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.DEATH_STRIKE), this._rpSpender);
     }
 
     if (this.selectedCombatant.spec === SPECS.UNHOLY_DEATH_KNIGHT) {
-      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.FROST_FEVER), this._onFrostFeverDamage)
-      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.BLOOD_PLAGUE), this._onBloodPlagueDamage)
+      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.FROST_FEVER), this._onFrostFeverDamage);
+      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.BLOOD_PLAGUE), this._onBloodPlagueDamage);
+      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.DEATH_COIL), this._rpSpender);
     }
 
     if (this.selectedCombatant.spec === SPECS.FROST_DEATH_KNIGH) {
-      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.VIRULENT_PLAGUE), this._onVirulentPlagueDamage)
-      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.BLOOD_PLAGUE), this._onBloodPlagueDamage)
+      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.VIRULENT_PLAGUE), this._onVirulentPlagueDamage);
+      this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.BLOOD_PLAGUE), this._onBloodPlagueDamage);
     }
   }
 
   _onFrostFeverDamage(event: DamageEvent) {
-    this.frostFeverDamage += event.amount + (event.absorb || 0)
+    this.frostFeverDamage += event.amount + (event.absorb || 0);
   }
 
   _onBloodPlagueDamage(event: DamageEvent) {
-    this.bloodPlagueDamage += event.amount + (event.absorb || 0)
+    this.bloodPlagueDamage += event.amount + (event.absorb || 0);
   }
 
   _onVirulentPlagueDamage(event: DamageEvent) {
-    this.virulentPlagueDamage += event.amount + (event.absorb || 0)
+    this.virulentPlagueDamage += event.amount + (event.absorb || 0);
   }
 
   _onFrostFeverEnergize(event: EnergizeEvent) {
@@ -68,16 +77,34 @@ class Superstrain extends Analyzer {
       return;
     }
 
-    this.frostFeverRPGained += event.resourceChange
-    this.frostFeverRPWasted += event.waste
+    this.frostFeverRPGained += event.resourceChange;
+    this.frostFeverRPWasted += event.waste;
+  }
+
+  _rpSpender(event: DamageEvent) {
+    this.rpDamage += event.amount + (event.absorb || 0);
+    this.rpSpenderUsed += 1;
+  }
+
+  get rpSpenderAverageDamage() {
+    return this.rpDamage / this.rpSpenderUsed;
+  }
+
+  get rpBonusDamage() {
+    const rpSpenderCost = this.selectedCombatant.spec === SPECS.BLOOD_DEATH_KNIGHT ? DEATH_STRIKE_RP : DEATH_COIL_RP;
+    return this.rpSpenderAverageDamage * Math.floor(this.frostFeverRPGained / rpSpenderCost);
   }
 
   get frostFeverTotalRP() {
-    return this.frostFeverRPGained + this.frostFeverRPWasted
+    return this.frostFeverRPGained + this.frostFeverRPWasted;
   }
 
   get superStrainDamage() {
-    return this.frostFeverDamage + this.bloodPlagueDamage + this.virulentPlagueDamage
+    return this.frostFeverDamage + this.bloodPlagueDamage + this.virulentPlagueDamage + this.rpBonusDamage;
+  }
+
+  get rpSpenderName() {
+    return this.selectedCombatant.spec === SPECS.BLOOD_DEATH_KNIGHT ? SPELLS.DEATH_STRIKE.name : SPELLS.DEATH_COIL.name;
   }
 
   statistic() {
@@ -88,6 +115,7 @@ class Superstrain extends Analyzer {
         tooltip={(
           <>
             {this.frostFeverTotalRP > 0 && <><strong>Runic Power:</strong> {this.frostFeverRPGained} RP gained ({this.frostFeverRPWasted} wasted)<br /></>}
+            {this.frostFeverTotalRP > 0 && <><strong>Runic Power Damage:</strong> {formatNumber(this.rpBonusDamage)} damage ({this.rpSpenderName} does an average of {formatNumber(this.rpSpenderAverageDamage)} damage)<br /></>}
             {this.frostFeverDamage > 0 && <><strong>Frost Fever:</strong> {formatNumber(this.frostFeverDamage)} damage<br /></>}
             {this.bloodPlagueDamage > 0 && <><strong>Blood Plague:</strong> {formatNumber(this.bloodPlagueDamage)} damage<br /></>}
             {this.virulentPlagueDamage > 0 && <><strong>Virulent Plague:</strong> {formatNumber(this.virulentPlagueDamage)} damage<br /></>}

--- a/src/parser/deathknight/unholy/CHANGELOG.tsx
+++ b/src/parser/deathknight/unholy/CHANGELOG.tsx
@@ -7,7 +7,8 @@ import SPELLS from 'common/SPELLS'
 import SpellLink from 'common/SpellLink';
 
 export default [
-  change(date (2020, 12, 17), <>Fix <SpellLink id={SPELLS.SOUL_REAPER_TALENT.id} /> module from showing when it shouldn't and lower suggestion threshold for <SpellLink id={SPELLS.VIRULENT_PLAGUE.id} /></>, [Khazak]),
+  change(date(2020, 12, 20), <>Added module for <SpellLink id={SPELLS.SWARMING_MIST.id} /> and added RP gained from <SpellLink id={SPELLS.SUPERSTRAIN.id} /> to statistic damage</>, joshinator),
+  change(date(2020, 12, 17), <>Fix <SpellLink id={SPELLS.SOUL_REAPER_TALENT.id} /> module from showing when it shouldn't and lower suggestion threshold for <SpellLink id={SPELLS.VIRULENT_PLAGUE.id} /></>, [Khazak]),
   change(date(2020, 12, 12), <>Added <SpellLink id={SPELLS.SUPERSTRAIN.id} /> module</>, joshinator),
   change(date(2020, 12, 9), <>Reworked <SpellLink id={SPELLS.SOUL_REAPER_TALENT.id}/> to use ExecuteHelper to provide cast efficiency and damage statistics</>, [Khazak]),
   change(date(2020, 12, 7), 'Updated Abilities with covenant signature and class abilities', [Khazak]),

--- a/src/parser/deathknight/unholy/CombatLogParser.ts
+++ b/src/parser/deathknight/unholy/CombatLogParser.ts
@@ -27,6 +27,9 @@ import RuneOfHysteria from '../shared/runeforges/RuneOfHysteria';
 // Legendaries
 import Superstrain from '../shared/items/Superstrain';
 
+// Covenants
+import SwarmingMist from '../shared/covenants/SwarmingMist';
+
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     // Features
@@ -58,6 +61,9 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Legendaries
     superStrain: Superstrain,
+
+    // Covenants
+    swarmingMist: SwarmingMist,
 
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: 0.5 }] as const,
   };


### PR DESCRIPTION
- Adds a statistic for the Venthyr covenant ability
![image](https://user-images.githubusercontent.com/29842841/102722776-b2e13a80-4303-11eb-8a9c-672b623f20b0.png)
![image](https://user-images.githubusercontent.com/29842841/102722783-c096c000-4303-11eb-9ad4-ec77913e535e.png)


- Adds damage gained by Superstrains RP part (by taking the average cost of DS/DC/FS)
- [Blood] Reactivated Ossuary and made the checklist use its efficiency instead of uptime
- [Blood] Added covenant abilities to the spellbook