### PR TITLE
Fix earthwarden

### DIFF
--- a/src/parser/druid/guardian/CHANGELOG.js
+++ b/src/parser/druid/guardian/CHANGELOG.js
@@ -2,6 +2,7 @@ import { Kettlepaw, Zeboot } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 12, 21), 'Update event listener for Earthwarden absorp events', Kettlepaw),
   change(date(2020, 12, 18), 'Fixed compiler errors affecting FrenziedRegen and AntiFillerSpam', Kettlepaw),
   change(date(2020, 10, 18), 'Converted legacy listeners to new event filters', Zeboot),
 ];

--- a/src/parser/druid/guardian/modules/talents/Earthwarden.js
+++ b/src/parser/druid/guardian/modules/talents/Earthwarden.js
@@ -54,7 +54,7 @@ class Earthwarden extends Analyzer {
     super(...args);
     this.active = this.selectedCombatant.lv45Talent === SPELLS.EARTHWARDEN_TALENT.id;
     this.addEventListener(Events.damage.to(SELECTED_PLAYER).spell(ABILITIES_THAT_CONSUME_EW), this.onDamage);
-    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.EARTHWARDEN_BUFF), this.onAbsorbed);
+    this.addEventListener(Events.absorbed.by(SELECTED_PLAYER).spell(SPELLS.EARTHWARDEN_BUFF), this.onAbsorbed);
   }
 
   onDamage(event) {


### PR DESCRIPTION
Earthwarden currently looks for damage events when searching for earthwarden absorption. I assume this is a case of the event sources being spread out more over time. Either way, the module currently finds 0 examples of the talent mitigating damage, rendering it nonfunctional. Correcting the event listener to search the `Events.absorbed` source appears to find a reasonable number of events.

I'm marking this as draft for now so I can write up a small test case.