### PR TITLE
[Holy paladin] Fixed error with stat weights

### DIFF
--- a/src/parser/paladin/holy/CHANGELOG.js
+++ b/src/parser/paladin/holy/CHANGELOG.js
@@ -4,6 +4,7 @@ import { Abelito75, Putro, Zeboot } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [  
+  change(date(2020, 12, 21), <>Fixed stat weights for logs with first events being absorb healing.</>, Abelito75),
   change(date(2020, 12, 21), <>Removed glimmer build as its default now.</>, Abelito75),
   change(date(2020, 12, 21), <>Small tweek to stat weights.</>, Abelito75),
   change(date(2020, 12, 17), <>Updated spell cooldowns!</>, Abelito75),

--- a/src/parser/paladin/holy/modules/features/MasteryEffectiveness.js
+++ b/src/parser/paladin/holy/modules/features/MasteryEffectiveness.js
@@ -138,6 +138,14 @@ class MasteryEffectiveness extends Analyzer {
       distance = this.distanceSum / this.distanceCount;
     }
 
+    if(!distance){// still undefined? we just die now (should only happen with weird first event absorb logs)
+      console.error(
+        "Received a heal before we know the player location. Can't process since player location is still unknown.",
+        event,
+      );
+      return;
+    }
+
     this.distanceSum += distance;
     this.distanceCount += 1;
 


### PR DESCRIPTION
If the first event was an absorb event then mastery would NaN out. We can't actually find the value of that so we just abort now