### PR TITLE
Keep stdin open in dev service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile.dev
     container_name: wowanalyzer-dev
+    stdin_open: true
     ports:
       - 3000:3000
       - 35729:35729


### PR DESCRIPTION
Some piece of the developer server's stack assumes it is running in
a TTY and treats a closed STDIN as signal to terminate the server.
This was causing a newly cloned repo to fail to launch and
immediately exit the docker service via e.g. `docker-compose up dev`.
Directing docker-compose to open STDIN to the service process keeps
the server alive and happy so it can respond to requests.

I opened a PR because the patch seemed to help another dev with the same problem in discord. If this would present a problem for the main site, I can look into other ways to accomplish this fix for dev machines.