### PR TITLE
[Havoc Demon Hunter] Updated CDs and baselines

### DIFF
--- a/src/parser/demonhunter/havoc/CHANGELOG.js
+++ b/src/parser/demonhunter/havoc/CHANGELOG.js
@@ -2,6 +2,7 @@ import { LeoZhekov, flurreN } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 12, 24), 'Updated spells and talents for SL', [flurreN]),
   change(date(2020, 12, 23), 'Updated spells and talents for SL', [flurreN]),
   change(date(2020, 10, 30), 'Updated the deprecated StatisticBox elements with the new Statistic ones.', [LeoZhekov]),
 ];

--- a/src/parser/demonhunter/havoc/CHANGELOG.js
+++ b/src/parser/demonhunter/havoc/CHANGELOG.js
@@ -2,7 +2,7 @@ import { LeoZhekov, flurreN } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2020, 12, 24), 'Updated spells and talents for SL', [flurreN]),
+  change(date(2020, 12, 24), 'Updated CDs and baselines for SL', [flurreN]),
   change(date(2020, 12, 23), 'Updated spells and talents for SL', [flurreN]),
   change(date(2020, 10, 30), 'Updated the deprecated StatisticBox elements with the new Statistic ones.', [LeoZhekov]),
 ];

--- a/src/parser/demonhunter/havoc/modules/Abilities.js
+++ b/src/parser/demonhunter/havoc/modules/Abilities.js
@@ -34,7 +34,7 @@ class Abilities extends CoreAbilities {
       {
         spell: [SPELLS.BLADE_DANCE, SPELLS.DEATH_SWEEP],
         category: combatant.hasTalent(SPELLS.FIRST_BLOOD_TALENT.id) ? Abilities.SPELL_CATEGORIES.ROTATIONAL : Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
-        cooldown: haste => 9 / (1 + haste),
+        cooldown: haste => 15 / (1 + haste),
         gcd: {
           base: 1500,
         },

--- a/src/parser/demonhunter/havoc/modules/Abilities.js
+++ b/src/parser/demonhunter/havoc/modules/Abilities.js
@@ -63,7 +63,6 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.IMMOLATION_AURA,
         // IMMOLATION_AURA is the ID for cast and the buff. But damage is done from IMMOLATION_AURA_INITIAL_HIT_DAMAGE and IMMOLATION_AURA_BUFF_DAMAGE
         buffSpellId: SPELLS.IMMOLATION_AURA.id,
-        enabled: combatant.hasTalent(SPELLS.IMMOLATION_AURA.id),
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         cooldown: haste => 30 / (1 + haste),
         gcd: {
@@ -92,7 +91,6 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.THROW_GLAIVE_HAVOC,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        charges: combatant.hasTalent(SPELLS.MASTER_OF_THE_GLAIVE_TALENT.id) ? 2 : 1,
         cooldown: haste => 10 / (1 + haste),
         gcd: {
           base: 1500,

--- a/src/parser/demonhunter/havoc/modules/Abilities.js
+++ b/src/parser/demonhunter/havoc/modules/Abilities.js
@@ -256,7 +256,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.NETHERWALK_TALENT,
         enabled: combatant.hasTalent(SPELLS.NETHERWALK_TALENT.id),
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
-        cooldown: 120,
+        cooldown: 180,
       },
     ];
   }

--- a/src/parser/demonhunter/havoc/modules/Abilities.js
+++ b/src/parser/demonhunter/havoc/modules/Abilities.js
@@ -231,11 +231,11 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.METAMORPHOSIS_HAVOC,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         buffSpellId: SPELLS.METAMORPHOSIS_HAVOC_BUFF.id,
-        cooldown: 240,
+        cooldown: 300,
         gcd: null, // Logs track the "landing" spell which is not on GCD
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: 0.80, //4 minute cd. You want some leeway in when to burn it.
+          recommendedEfficiency: 0.80, //5 minute cd. You want some leeway in when to burn it.
         },
       },
 

--- a/src/parser/demonhunter/havoc/modules/Abilities.js
+++ b/src/parser/demonhunter/havoc/modules/Abilities.js
@@ -32,7 +32,20 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: [SPELLS.BLADE_DANCE, SPELLS.DEATH_SWEEP],
+        spell: [SPELLS.BLADE_DANCE],
+        category: combatant.hasTalent(SPELLS.FIRST_BLOOD_TALENT.id) ? Abilities.SPELL_CATEGORIES.ROTATIONAL : Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
+        cooldown: haste => 15 / (1 + haste),
+        gcd: {
+          base: 1500,
+        },
+        castEfficiency: {
+          suggestion: combatant.hasTalent(SPELLS.FIRST_BLOOD_TALENT.id),
+          recommendedEfficiency: 0.95,
+          extraSuggestion: <>This should be part of your single target rotation due to the <SpellLink id={SPELLS.FIRST_BLOOD_TALENT.id} /> talent. This includes the <SpellLink id={SPELLS.DEATH_SWEEP.id} /> casts since they are the same ability and share their cooldowns.</>,
+        },
+      },
+      {
+        spell: [SPELLS.DEATH_SWEEP],
         category: combatant.hasTalent(SPELLS.FIRST_BLOOD_TALENT.id) ? Abilities.SPELL_CATEGORIES.ROTATIONAL : Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
         cooldown: haste => 9 / (1 + haste),
         gcd: {

--- a/src/parser/demonhunter/havoc/modules/Abilities.js
+++ b/src/parser/demonhunter/havoc/modules/Abilities.js
@@ -34,7 +34,7 @@ class Abilities extends CoreAbilities {
       {
         spell: [SPELLS.BLADE_DANCE, SPELLS.DEATH_SWEEP],
         category: combatant.hasTalent(SPELLS.FIRST_BLOOD_TALENT.id) ? Abilities.SPELL_CATEGORIES.ROTATIONAL : Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
-        cooldown: haste => 15 / (1 + haste),
+        cooldown: haste => 9 / (1 + haste),
         gcd: {
           base: 1500,
         },

--- a/src/parser/demonhunter/havoc/modules/Abilities.js
+++ b/src/parser/demonhunter/havoc/modules/Abilities.js
@@ -97,7 +97,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.THROW_GLAIVE_HAVOC,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        cooldown: haste => 10 / (1 + haste),
+        cooldown: haste => 9 / (1 + haste),
         gcd: {
           base: 1500,
         },

--- a/src/parser/demonhunter/havoc/modules/Abilities.js
+++ b/src/parser/demonhunter/havoc/modules/Abilities.js
@@ -32,22 +32,15 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: [SPELLS.BLADE_DANCE],
+        spell: [SPELLS.BLADE_DANCE, SPELLS.DEATH_SWEEP],
         category: combatant.hasTalent(SPELLS.FIRST_BLOOD_TALENT.id) ? Abilities.SPELL_CATEGORIES.ROTATIONAL : Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
-        cooldown: haste => 15 / (1 + haste),
-        gcd: {
-          base: 1500,
+        cooldown: haste => {
+          if(combatant.hasBuff(SPELLS.METAMORPHOSIS_HAVOC_BUFF.id)) {
+            return 9 / (1 + haste); //Death Sweep CD
+          } else {
+            return 15 / (1 + haste); //Blade Dance CD
+          }
         },
-        castEfficiency: {
-          suggestion: combatant.hasTalent(SPELLS.FIRST_BLOOD_TALENT.id),
-          recommendedEfficiency: 0.95,
-          extraSuggestion: <>This should be part of your single target rotation due to the <SpellLink id={SPELLS.FIRST_BLOOD_TALENT.id} /> talent. This includes the <SpellLink id={SPELLS.DEATH_SWEEP.id} /> casts since they are the same ability and share their cooldowns.</>,
-        },
-      },
-      {
-        spell: [SPELLS.DEATH_SWEEP],
-        category: combatant.hasTalent(SPELLS.FIRST_BLOOD_TALENT.id) ? Abilities.SPELL_CATEGORIES.ROTATIONAL : Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
-        cooldown: haste => 9 / (1 + haste),
         gcd: {
           base: 1500,
         },

--- a/src/parser/demonhunter/havoc/modules/Abilities.js
+++ b/src/parser/demonhunter/havoc/modules/Abilities.js
@@ -34,13 +34,9 @@ class Abilities extends CoreAbilities {
       {
         spell: [SPELLS.BLADE_DANCE, SPELLS.DEATH_SWEEP],
         category: combatant.hasTalent(SPELLS.FIRST_BLOOD_TALENT.id) ? Abilities.SPELL_CATEGORIES.ROTATIONAL : Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
-        cooldown: haste => {
-          if(combatant.hasBuff(SPELLS.METAMORPHOSIS_HAVOC_BUFF.id)) {
-            return 9 / (1 + haste); //Death Sweep CD
-          } else {
-            return 15 / (1 + haste); //Blade Dance CD
-          }
-        },
+        cooldown: haste => combatant.hasBuff(SPELLS.METAMORPHOSIS_HAVOC_BUFF.id) ? 9 / (1 + haste) : 15 / (1 + haste),
+        //Blade dance = 15s cd
+        //Death Sweep = 9s cd
         gcd: {
           base: 1500,
         },


### PR DESCRIPTION
Havoc now has the correct CD timers and baselines for shadowlands in the spells added in Abilites.js