### PR TITLE
Removed GCD from Innervate and Natures Swiftness

### DIFF
--- a/src/parser/druid/balance/modules/Abilities.js
+++ b/src/parser/druid/balance/modules/Abilities.js
@@ -171,9 +171,6 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.INNERVATE,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 180,
-        gcd: {
-          base: 1500,
-        },
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.70,

--- a/src/parser/druid/restoration/modules/Abilities.js
+++ b/src/parser/druid/restoration/modules/Abilities.js
@@ -27,9 +27,6 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.NATURES_SWIFTNESS,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 60,//TODO include conduit reduction
-        gcd: {
-          base: 1500,
-        },
         castEfficiency: {
           suggestion: true,
         },
@@ -38,9 +35,6 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.INNERVATE,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 180,
-        gcd: {
-          base: 1500,
-        },
         castEfficiency: {
           suggestion: true,
         },


### PR DESCRIPTION
Both spells are no longer on the GCD since SL