### PR TITLE
[Mage] Rune of Power Fix + Phoenix Flames Capped Charges

### DIFF
--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -598,7 +598,6 @@ export interface UpdateSpellUsableEvent extends Event<EventType.UpdateSpellUsabl
   isOnCooldown: boolean
   isAvailable: boolean
   chargesAvailable: number
-  chargesOnCooldown: number
   maxCharges: number
   timePassed?: number
   sourceID: number

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -598,6 +598,7 @@ export interface UpdateSpellUsableEvent extends Event<EventType.UpdateSpellUsabl
   isOnCooldown: boolean
   isAvailable: boolean
   chargesAvailable: number
+  chargesOnCooldown: number
   maxCharges: number
   timePassed?: number
   sourceID: number

--- a/src/parser/mage/arcane/CHANGELOG.tsx
+++ b/src/parser/mage/arcane/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import { change, date } from 'common/changelog';
 
 // prettier-ignore
 export default [
+  change(date(2020, 12, 24), <>Fixed an issue that was showing <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} /> as lasting the entire fight duration in the Cooldowns tab.</>, Sharrq),
   change(date(2020, 12, 19), <>Added module to check the active time during <SpellLink id={SPELLS.ARCANE_POWER.id} />.</>, Sharrq),
   change(date(2020, 12, 16), `Fixed an abe with suggestions showing {0} instead of the suggestion text in Arcane modules.`, Sharrq),
   change(date(2020, 12, 10), <>Updated <SpellLink id={SPELLS.ARCANE_POWER.id} /> to include <SpellLink id={SPELLS.TOUCH_OF_THE_MAGI.id} /> usage and added support for <SpellLink id={SPELLS.ARCANE_ECHO_TALENT.id} />.</>, Sharrq),

--- a/src/parser/mage/fire/CHANGELOG.tsx
+++ b/src/parser/mage/fire/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 12, 24), <>Added module to check for capping on <SpellLink id={SPELLS.PHOENIX_FLAMES.id} /> charges and fixed an issue that was showing <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} /> as lasting the entire fight duration in the Cooldowns tab.</>, Sharrq),
   change(date(2020, 12, 19), <>Added module to check the active time during <SpellLink id={SPELLS.COMBUSTION.id} /> and fixed a typo in <SpellLink id={SPELLS.FIRESTORM.id} />.</>, Sharrq),
   change(date(2020, 12, 19), <>Resolved an issue in <SpellLink id={SPELLS.COMBUSTION.id} /> that was marking <SpellLink id={SPELLS.FIREBALL.id} /> casts that started before Combustion and ended after Combustion as being cast during Combustion.</>, Sharrq),
   change(date(2020, 12, 16), `Fixed an abe with suggestions showing {0} instead of the suggestion text in Fire modules and an abe that was causing a crash in Pyroclasm.`, Sharrq),

--- a/src/parser/mage/fire/CombatLogParser.ts
+++ b/src/parser/mage/fire/CombatLogParser.ts
@@ -6,6 +6,7 @@ import CombustionNormalizer from './normalizers/Combustion';
 import ScorchNormalizer from './normalizers/Scorch';
 import PyroclasmBuffNormalizer from './normalizers/PyroclasmBuff';
 import ShiftingPowerNormalizer from '../shared/normalizers/ShiftingPower'
+import RuneOfPowerNormalizer from '../shared/normalizers/RuneOfPower';
 
 import Checklist from './modules/Checklist/Module';
 import Buffs from './modules/features/Buffs';
@@ -27,6 +28,7 @@ import CombustionFirestarter from './modules/features/CombustionFirestarter';
 import CombustionCharges from './modules/features/CombustionCharges';
 import CombustionSpellUsage from './modules/features/CombustionSpellUsage';
 import CombustionActiveTime from './modules/features/CombustionActiveTime';
+import PhoenixFlames from './modules/features/PhoenixFlames';
 import HeatingUp from './modules/features/HeatingUp';
 import Pyroclasm from './modules/features/Pyroclasm';
 
@@ -64,6 +66,7 @@ class CombatLogParser extends CoreCombatLogParser {
     pyroclasmBuffNormalizer: PyroclasmBuffNormalizer,
     combustionNormalizer: CombustionNormalizer,
     shiftingPowerNormalizer: ShiftingPowerNormalizer,
+    runeOfPowerNormalizer: RuneOfPowerNormalizer,
 
     //Checklist
     checklist: Checklist,
@@ -81,6 +84,7 @@ class CombatLogParser extends CoreCombatLogParser {
     combustionCharges: CombustionCharges,
     combustionSpellUsage: CombustionSpellUsage,
     combustionActiveTime: CombustionActiveTime,
+    phoenixFlames: PhoenixFlames,
     heatingUp: HeatingUp,
     mirrorImage: MirrorImage,
     elementalBarrier: ElementalBarrier,

--- a/src/parser/mage/fire/integrationTests/example.test.ts.snap
+++ b/src/parser/mage/fire/integrationTests/example.test.ts.snap
@@ -4643,6 +4643,49 @@ exports[`Fire Mage integration test: example log MirrorImage matches the statist
 </div>
 `;
 
+exports[`Fire Mage integration test: example log PhoenixFlames matches the suggestions snapshot 1`] = `
+Array [
+  Object {
+    "details": null,
+    "icon": "artifactability_firemage_phoenixbolt",
+    "importance": "major",
+    "issue": <React.Fragment>
+      You spent 
+      75
+      s (
+      20.10
+      % of the fight) capped on 
+      <ForwardRef
+        id={257541}
+      />
+       charges. While it is important to pool charges for your next 
+      <ForwardRef
+        id={190319}
+      />
+      , it is also important that you avoid capping on charges whenever possible. To avoid this, you should use a charge of 
+      <ForwardRef
+        id={257541}
+      />
+       if you are capped or are about to cap on charges.
+    </React.Fragment>,
+    "stat": <React.Fragment>
+      <Trans
+        id="mage.fire.suggestions.phoenixFlames.phoenixFlamesCappedCharges"
+        message="{0}% of fight capped on charges"
+        values={
+          Object {
+            "0": "20.10",
+          }
+        }
+      />
+       (
+      5.00% is recommended
+      )
+    </React.Fragment>,
+  },
+]
+`;
+
 exports[`Fire Mage integration test: example log RuneOfPower matches the statistic snapshot 1`] = `
 <div
   className="col-lg-3 col-md-4 col-sm-6 col-xs-12"

--- a/src/parser/mage/fire/modules/features/CooldownThroughputTracker.js
+++ b/src/parser/mage/fire/modules/features/CooldownThroughputTracker.js
@@ -13,7 +13,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
       ],
     },
     {
-      spell: SPELLS.RUNE_OF_POWER_TALENT,
+      spell: SPELLS.RUNE_OF_POWER_BUFF,
       summary: [
         BUILT_IN_SUMMARY_TYPES.DAMAGE,
       ],

--- a/src/parser/mage/fire/modules/features/PhoenixFlames.tsx
+++ b/src/parser/mage/fire/modules/features/PhoenixFlames.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
+import { formatNumber, formatPercentage } from 'common/format';
+import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
+import { When, ThresholdStyle } from 'parser/core/ParseResults';
+import Events, { UpdateSpellUsableEvent, CastEvent } from 'parser/core/Events';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import { Trans } from '@lingui/macro';
+
+class PhoenixFlames extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+  };
+  protected spellUsable!: SpellUsable;
+
+  chargesCapped = false;
+  cappedTimestamp = 0;
+  timeSpentCapped = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.addEventListener(Events.UpdateSpellUsable.by(SELECTED_PLAYER).spell(SPELLS.PHOENIX_FLAMES), this.onCooldownUpdate);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.PHOENIX_FLAMES), this.onPhoenixCast);
+  }
+
+  onCooldownUpdate(event: UpdateSpellUsableEvent) {
+    if (event.trigger !== "endcooldown") {
+      return;
+    }
+    this.chargesCapped = true;
+    this.cappedTimestamp = event.timestamp;
+  }
+
+  onPhoenixCast(event: CastEvent) {
+    if (!this.chargesCapped) {
+      return;
+    }
+    this.timeSpentCapped += event.timestamp - this.cappedTimestamp;
+    this.log(this.timeSpentCapped)
+    this.chargesCapped = false;
+    this.cappedTimestamp = 0;
+  }
+
+  get percentCapped() {
+    return this.timeSpentCapped / this.owner.fightDuration;
+  }
+
+  get cappedSeconds() {
+    return this.timeSpentCapped / 1000;
+  }
+
+  get phoenixCappedChargesThresholds() {
+    return {
+      actual: this.percentCapped,
+      isGreaterThan: {
+        minor: .05,
+        average: .1,
+        major: .2,
+      },
+      style: ThresholdStyle.PERCENTAGE,
+    };
+  }
+
+
+  suggestions(when: When) {
+    when(this.phoenixCappedChargesThresholds)
+    .addSuggestion((suggest, actual, recommended) => suggest(<>You spent {formatNumber(this.cappedSeconds)}s ({formatPercentage(this.percentCapped)}% of the fight) capped on <SpellLink id={SPELLS.PHOENIX_FLAMES.id} /> charges. While it is important to pool charges for your next <SpellLink id={SPELLS.COMBUSTION.id} />, it is also important that you avoid capping on charges whenever possible. To avoid this, you should use a charge of <SpellLink id={SPELLS.PHOENIX_FLAMES.id} /> if you are capped or are about to cap on charges.</>)
+        .icon(SPELLS.PHOENIX_FLAMES.icon)
+        .actual(<Trans id="mage.fire.suggestions.phoenixFlames.phoenixFlamesCappedCharges">{formatPercentage(actual)}% of fight capped on charges</Trans>)
+        .recommended(`${formatPercentage(recommended)}% is recommended`));
+  }
+}
+export default PhoenixFlames;

--- a/src/parser/mage/fire/modules/features/PhoenixFlames.tsx
+++ b/src/parser/mage/fire/modules/features/PhoenixFlames.tsx
@@ -38,7 +38,6 @@ class PhoenixFlames extends Analyzer {
       return;
     }
     this.timeSpentCapped += event.timestamp - this.cappedTimestamp;
-    this.log(this.timeSpentCapped)
     this.chargesCapped = false;
     this.cappedTimestamp = 0;
   }

--- a/src/parser/mage/frost/CHANGELOG.tsx
+++ b/src/parser/mage/frost/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 12, 24), <>Fixed an issue that was showing <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} /> as lasting the entire fight duration in the Cooldowns tab.</>, Sharrq),
   change(date(2020, 12, 19), <>Added module to check the active time during <SpellLink id={SPELLS.ICY_VEINS.id} /> and added support for <SpellLink id={SPELLS.GLACIAL_FRAGMENTS.id} />.</>, Sharrq),
   change(date(2020, 12, 17), <>Resolved an issue in <SpellLink id={SPELLS.WINTERS_CHILL.id} /> that was causing it to miscount shattered spells.</>, Sharrq),
   change(date(2020, 12, 16), `Fixed an abe with suggestions showing {0} instead of the suggestion text in Frost modules and fixed an abe that was causing a crash in Winter's Chill.`, Sharrq),

--- a/src/parser/mage/shared/normalizers/RuneOfPower.ts
+++ b/src/parser/mage/shared/normalizers/RuneOfPower.ts
@@ -1,0 +1,50 @@
+import SPELLS from 'common/SPELLS';
+
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+import { AnyEvent, EventType } from 'parser/core/Events';
+
+class RuneOfPower extends EventsNormalizer {
+  normalize(events: AnyEvent[]) {
+    const fixedEvents: AnyEvent[] = [];
+    events.forEach((event, eventIndex) => {
+      fixedEvents.push(event);
+
+      if (event.type === EventType.RemoveBuff && event.ability.guid === SPELLS.RUNE_OF_POWER_BUFF.id) {
+        const castTimestamp = event.timestamp;
+        for (let previousEventIndex = eventIndex; previousEventIndex >= 0; previousEventIndex -= 1) {
+          const previousEvent = fixedEvents[previousEventIndex];
+          if (previousEvent && (castTimestamp - previousEvent.timestamp) > 100) {
+            break;
+          }
+          if (previousEvent && (previousEvent.type === EventType.ApplyBuff || previousEvent.type === EventType.Cast) && previousEvent.ability.guid === SPELLS.RUNE_OF_POWER_BUFF.id) {
+            fixedEvents.splice(previousEventIndex, 1);
+            previousEvent.__modified = true;
+          }
+          if (previousEvent && previousEvent.type === EventType.RemoveBuff && previousEvent.timestamp !== castTimestamp && previousEvent.ability.guid === SPELLS.RUNE_OF_POWER_BUFF.id) {
+            fixedEvents.splice(previousEventIndex, 1);
+            previousEvent.__modified = true;
+          }
+        }
+      } else if (event.type === EventType.Cast && event.ability.guid === SPELLS.RUNE_OF_POWER_BUFF.id) {
+        const castTimestamp = event.timestamp;
+
+        for (let previousEventIndex = eventIndex; previousEventIndex >= 0; previousEventIndex -= 1) {
+          const previousEvent = fixedEvents[previousEventIndex];
+          if (previousEvent && (castTimestamp - previousEvent.timestamp) > 50) {
+            break;
+          }
+          if (previousEvent && previousEvent.type === EventType.ApplyBuff && previousEvent.ability.guid === SPELLS.RUNE_OF_POWER_BUFF.id && previousEvent.sourceID === event.sourceID) {
+            fixedEvents.splice(previousEventIndex, 1);
+            fixedEvents.push(previousEvent);
+            previousEvent.__modified = true;
+            break;
+          }
+        }
+      }
+    });
+
+    return fixedEvents;
+  }
+}
+
+export default RuneOfPower;

--- a/src/parser/mage/shared/normalizers/ShiftingPower.ts
+++ b/src/parser/mage/shared/normalizers/ShiftingPower.ts
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import EventsNormalizer from 'parser/core/EventsNormalizer';
 import { AnyEvent, EventType } from 'parser/core/Events';
 
-class Combustion extends EventsNormalizer {
+class ShiftingPower extends EventsNormalizer {
   normalize(events: AnyEvent[]) {
     const fixedEvents: AnyEvent[] = [];
     events.forEach((event, eventIndex) => {
@@ -31,4 +31,4 @@ class Combustion extends EventsNormalizer {
   }
 }
 
-export default Combustion;
+export default ShiftingPower;


### PR DESCRIPTION
- Fixed an issue that was causing Rune of Power to show that it lasted the entire fight duration in the Cooldowns tab
- Added a module to check how long the player was capped on Phoenix Flames charges.