### PR TITLE
Fix spell ids and suggestion for Primal Storm/Fire Elemental

### DIFF
--- a/src/parser/shaman/elemental/CHANGELOG.tsx
+++ b/src/parser/shaman/elemental/CHANGELOG.tsx
@@ -4,7 +4,8 @@ import { HawkCorrigan, Zeboot } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2020, 11, 8), <>Adding a module Static </>, HawkCorrigan),
+  change(date(2020, 12, 24), <>Fix the cast checker for Primal Elementals</>, HawkCorrigan),
+  change(date(2020, 11, 8), <>Adding a module for Static Discharge</>, HawkCorrigan),
   change(date(2020, 11, 4), <>Fix Flame Shock</>, HawkCorrigan),
   change(date(2020, 10, 31), <>Add a suggestion for usage of Echoing Shock</>, HawkCorrigan),
   change(date(2020, 10, 25), <>Convert to Typescript</>, HawkCorrigan),

--- a/src/parser/shaman/elemental/CONFIG.tsx
+++ b/src/parser/shaman/elemental/CONFIG.tsx
@@ -3,10 +3,11 @@ import React from 'react';
 import SPECS from 'game/SPECS';
 
 import CHANGELOG from 'parser/shaman/elemental/CHANGELOG';
+import { HawkCorrigan } from 'CONTRIBUTORS';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [],
+  contributors: [HawkCorrigan],
   // The WoW client patch this spec was last updated to be fully compatible with.
   patchCompatibility: '8.2.5',
   // If set to  false`, the spec will show up as unsupported.

--- a/src/parser/shaman/elemental/modules/talents/PrimalFireElemental.tsx
+++ b/src/parser/shaman/elemental/modules/talents/PrimalFireElemental.tsx
@@ -30,8 +30,8 @@ class PrimalFireElemental extends Analyzer {
     super(options);
     this.usedCasts = {
       [SPELLS.FIRE_ELEMENTAL_METEOR.id]: false,
-      [SPELLS.IMMOLATE.id]: false,
-      [SPELLS.FIRE_BLAST.id]: false,
+      [SPELLS.FIRE_ELEMENTAL_IMMOLATE.id]: false,
+      [SPELLS.FIRE_ELEMENTAL_FIRE_BLAST.id]: false,
     };
     this.active = this.selectedCombatant.hasTalent(SPELLS.PRIMAL_ELEMENTALIST_TALENT.id)
       && (!this.selectedCombatant.hasTalent(SPELLS.STORM_ELEMENTAL_TALENT.id));
@@ -73,7 +73,7 @@ class PrimalFireElemental extends Analyzer {
   get missedMeteorSuggestionTresholds() {
     return {
       actual: this.unusedSpells.length,
-      isGreaterThan: {
+      isGreaterThanOrEqual: {
         major: 1,
       },
       style: ThresholdStyle.NUMBER,

--- a/src/parser/shaman/elemental/modules/talents/PrimalFireElemental.tsx
+++ b/src/parser/shaman/elemental/modules/talents/PrimalFireElemental.tsx
@@ -8,7 +8,7 @@ import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/
 
 import { STATISTIC_ORDER } from 'interface/others/StatisticBox';
 import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
-import { When } from 'parser/core/ParseResults';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import ItemDamageDone from 'interface/ItemDamageDone';
 import Statistic from 'interface/statistics/Statistic';
 import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
@@ -56,24 +56,47 @@ class PrimalFireElemental extends Analyzer {
     this.usedCasts[event.ability.guid] = true;
   }
 
+  get unusedSpells() {
+    return Object.keys(this.usedCasts).filter(key => !this.usedCasts[Number(key)]);
+  }
+
+  get unusedSpellsSuggestionTresholds() {
+    return {
+      actual: this.unusedSpells.length,
+      isGreaterThan: {
+        major: 1,
+      },
+      style: ThresholdStyle.NUMBER,
+    };
+  }
+
+  get missedMeteorSuggestionTresholds() {
+    return {
+      actual: this.unusedSpells.length,
+      isGreaterThan: {
+        major: 1,
+      },
+      style: ThresholdStyle.NUMBER,
+    };
+  }
+
   suggestions(when: When) {
-    const unusedSpells = Object.keys(this.usedCasts).filter(key => !this.usedCasts[Number(key)]);
-    const unusedSpellsString = unusedSpells.join(', ');
-    const unusedSpellsCount = unusedSpells.length;
-    when(unusedSpellsCount).isGreaterThan(0)
+    const unusedSpellsString = this.unusedSpells.map(x=>(SPELLS[x].name)).join(', ');
+    when(this.unusedSpellsSuggestionTresholds)
       .addSuggestion((suggest, actual, recommended) => suggest(<span> Your Fire Elemental is not using all of it's spells. Check if immolate and Fire Blast are set to autocast and you are using Meteor.</span>)
         .icon(SPELLS.FIRE_ELEMENTAL.icon)
         .actual(t({
-      id: "shaman.elemental.suggestions.primalElemental.unusedSpells",
-      message: `${formatNumber(unusedSpellsCount)} spells not used by your Fire Elemental (${unusedSpellsString})`
+      id: "shaman.elemental.suggestions.primalFireElemental.unusedSpells",
+      message: `${formatNumber(this.unusedSpells.length)} spells not used by your Fire Elemental (${unusedSpellsString})`
     }))
         .recommended(`You should be using all spells of your Fire Elemental.`)
         .major(recommended + 1));
-    when(this.missedMeteorCasts).isGreaterThan(0)
+
+    when(this.missedMeteorSuggestionTresholds)
       .addSuggestion((suggest, actual, recommended) => suggest(<span>You are not using <SpellLink id={SPELLS.FIRE_ELEMENTAL_METEOR.id} /> every time you cast <SpellLink id={SPELLS.FIRE_ELEMENTAL.id} /> if you are using <SpellLink id={SPELLS.PRIMAL_ELEMENTALIST_TALENT.id} />. Only wait with casting meteor if you wait for adds to spawn.</span>)
         .icon(SPELLS.FIRE_ELEMENTAL.icon)
         .actual(t({
-      id: "shaman.elemental.suggestions.primalElemental.meteorCastsMissed",
+      id: "shaman.elemental.suggestions.primalFireElemental.meteorCastsMissed",
       message: `${formatNumber(this.missedMeteorCasts)} missed Meteor Casts.`
     }))
         .recommended(`You should cast Meteor every time you summon your Fire Elemental `)

--- a/src/parser/shaman/elemental/modules/talents/PrimalFireElemental.tsx
+++ b/src/parser/shaman/elemental/modules/talents/PrimalFireElemental.tsx
@@ -63,7 +63,7 @@ class PrimalFireElemental extends Analyzer {
   get unusedSpellsSuggestionTresholds() {
     return {
       actual: this.unusedSpells.length,
-      isGreaterThan: {
+      isGreaterThanOrEqual: {
         major: 1,
       },
       style: ThresholdStyle.NUMBER,
@@ -87,7 +87,7 @@ class PrimalFireElemental extends Analyzer {
         .icon(SPELLS.FIRE_ELEMENTAL.icon)
         .actual(t({
       id: "shaman.elemental.suggestions.primalFireElemental.unusedSpells",
-      message: `${formatNumber(this.unusedSpells.length)} spells not used by your Fire Elemental (${unusedSpellsString})`
+      message: `${formatNumber(this.unusedSpells.length)} spell/-s not used by your Fire Elemental (${unusedSpellsString})`
     }))
         .recommended(`You should be using all spells of your Fire Elemental.`)
         .major(recommended + 1));

--- a/src/parser/shaman/elemental/modules/talents/PrimalStormElemental.tsx
+++ b/src/parser/shaman/elemental/modules/talents/PrimalStormElemental.tsx
@@ -86,7 +86,7 @@ class PrimalStormElemental extends Analyzer {
   }
 
   suggestions(when: When) {
-    const unusedSpellsString = this.unusedSpells.join(', ');
+    const unusedSpellsString = this.unusedSpells.map(x=>(SPELLS[x].name)).join(', ');
 
     when(this.unusedSpellsSuggestionTresholds)
       .addSuggestion((suggest, actual, recommended) => suggest(<span> Your Storm Elemental is not using all of it's spells. Check if Wind Gust and Call Lightning are set to autocast and you are using Eye Of The Storm.</span>)

--- a/src/parser/shaman/elemental/modules/talents/PrimalStormElemental.tsx
+++ b/src/parser/shaman/elemental/modules/talents/PrimalStormElemental.tsx
@@ -48,7 +48,7 @@ class PrimalStormElemental extends Analyzer {
   get unusedSpellsSuggestionTresholds() {
     return {
       actual: this.unusedSpells.length,
-      isGreaterThan: {
+      isGreaterThanOrEqual: {
         minor: 1,
         major: 1,
       },
@@ -59,7 +59,7 @@ class PrimalStormElemental extends Analyzer {
   get badCastsSuggestionTresholds() {
     return {
       actual: this.unusedSpells.length,
-      isGreaterThan: {
+      isGreaterThanOrEqual: {
         minor: 1,
         major: 5,
       },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2129161/103138936-83517a00-46d7-11eb-9118-6d518d9f3af8.png)

The cast checker was checking for mage spells again and only showed spell ids in the suggestion.