### PR TITLE
[Havoc Demon Hunter] Added correct gcd

### DIFF
--- a/src/parser/demonhunter/havoc/CHANGELOG.js
+++ b/src/parser/demonhunter/havoc/CHANGELOG.js
@@ -1,7 +1,11 @@
+import React from 'react';
 import { LeoZhekov, flurreN } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'common/SpellLink';
 
 export default [
+  change(date(2020, 12, 26), <><SpellLink id={SPELLS.NETHERWALK_TALENT.id} /> and <SpellLink id={SPELLS.DARKNESS.id} /> now have a correct gcd.</>, flurreN),
   change(date(2020, 12, 24), 'Updated CDs and baselines for SL', [flurreN]),
   change(date(2020, 12, 23), 'Updated spells and talents for SL', [flurreN]),
   change(date(2020, 10, 30), 'Updated the deprecated StatisticBox elements with the new Statistic ones.', [LeoZhekov]),

--- a/src/parser/demonhunter/havoc/modules/Abilities.js
+++ b/src/parser/demonhunter/havoc/modules/Abilities.js
@@ -260,6 +260,9 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(SPELLS.NETHERWALK_TALENT.id),
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         cooldown: 180,
+        gcd: {
+          base: 1500,
+        },
       },
     ];
   }

--- a/src/parser/demonhunter/havoc/modules/Abilities.js
+++ b/src/parser/demonhunter/havoc/modules/Abilities.js
@@ -251,6 +251,9 @@ class Abilities extends CoreAbilities {
         buffSpellId: SPELLS.DARKNESS.id,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         cooldown: 180,
+        gcd: {
+          base: 1500,
+        },
       },
       {
         spell: SPELLS.NETHERWALK_TALENT,


### PR DESCRIPTION
https://www.wowhead.com/spell=196555/netherwalk
https://www.wowhead.com/spell=196718/darkness

Both spells have an gcd of 1.5sec