### PR TITLE
[Havoc Demon Hunter] CD correction

### DIFF
--- a/src/parser/demonhunter/havoc/CHANGELOG.js
+++ b/src/parser/demonhunter/havoc/CHANGELOG.js
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 
 export default [
+  change(date(2020, 12, 26), <><SpellLink id={SPELLS.GLAIVE_TEMPEST_TALENT.id} /> have correct cd, and <SpellLink id={SPELLS.CYCLE_OF_HATRED_TALENT.id} /> is not reducing cooldown correctly on <SpellLink id={SPELLS.EYE_BEAM.id} /></>, flurreN),
   change(date(2020, 12, 26), <><SpellLink id={SPELLS.NETHERWALK_TALENT.id} /> and <SpellLink id={SPELLS.DARKNESS.id} /> now have a correct gcd.</>, flurreN),
   change(date(2020, 12, 24), 'Updated CDs and baselines for SL', [flurreN]),
   change(date(2020, 12, 23), 'Updated spells and talents for SL', [flurreN]),

--- a/src/parser/demonhunter/havoc/modules/Abilities.js
+++ b/src/parser/demonhunter/havoc/modules/Abilities.js
@@ -50,7 +50,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.FELBLADE_TALENT,
         enabled: combatant.hasTalent(SPELLS.FELBLADE_TALENT.id),
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        // Felblade cooldown can be reset by Shear or Demon Blades (when talented). But it's CD reset is not any event, so can't track if it resets or not.
+        // Felblade cooldown can be reset by Demon Bite (Demon Blade talent cant be used). But it's CD reset is not any event, so can't track if it resets or not.
         cooldown: haste => 15 / (1 + haste),
         gcd: {
           base: 1500,

--- a/src/parser/demonhunter/havoc/modules/Abilities.js
+++ b/src/parser/demonhunter/havoc/modules/Abilities.js
@@ -50,7 +50,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.FELBLADE_TALENT,
         enabled: combatant.hasTalent(SPELLS.FELBLADE_TALENT.id),
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        // Felblade cooldown can be reset by Demon Bite (Demon Blade talent cant be used). But it's CD reset is not any event, so can't track if it resets or not.
+        // Felblade cooldown can be reset by Demon Bite. But it's CD reset is not any event, so can't track if it resets or not.
         cooldown: haste => 15 / (1 + haste),
         gcd: {
           base: 1500,

--- a/src/parser/demonhunter/havoc/modules/Abilities.js
+++ b/src/parser/demonhunter/havoc/modules/Abilities.js
@@ -215,7 +215,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.GLAIVE_TEMPEST_TALENT,
         enabled: combatant.hasTalent(SPELLS.GLAIVE_TEMPEST_TALENT.id),
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
-        cooldown: 20,
+        cooldown: haste => 20 / (1 + haste),
         gcd: {
           base: 1500,
         },

--- a/src/parser/demonhunter/havoc/modules/talents/CycleOfHatred.js
+++ b/src/parser/demonhunter/havoc/modules/talents/CycleOfHatred.js
@@ -31,10 +31,10 @@ class CycleOfHatred extends Analyzer {
   }
 
   onEnergizeEvent(event) {
-    if (!this.spellUsable.isOnCooldown(SPELLS.METAMORPHOSIS_HAVOC.id)) {
+    if (!this.spellUsable.isOnCooldown(SPELLS.EYE_BEAM.id)) {
       return;
     }
-    const effectiveReduction = this.spellUsable.reduceCooldown(SPELLS.METAMORPHOSIS_HAVOC.id, COOLDOWN_REDUCTION_MS);
+    const effectiveReduction = this.spellUsable.reduceCooldown(SPELLS.EYE_BEAM.id, COOLDOWN_REDUCTION_MS);
     this.totalCooldownReduction += effectiveReduction;
   }
 
@@ -43,7 +43,7 @@ class CycleOfHatred extends Analyzer {
       <TalentStatisticBox
         talent={SPELLS.CYCLE_OF_HATRED_TALENT.id}
         position={STATISTIC_ORDER.OPTIONAL(7)}
-        value={<>{formatNumber(this.totalCooldownReduction / 1000)} sec <small>total <SpellIcon id={SPELLS.METAMORPHOSIS_HAVOC.id} />Meta cooldown reduction</small></>}
+        value={<>{formatNumber(this.totalCooldownReduction / 1000)} sec <small>total <SpellIcon id={SPELLS.EYE_BEAM.id} /> Eye Beam cooldown reduction</small></>}
       />
     );
   }

--- a/src/parser/demonhunter/havoc/modules/talents/Felblade.js
+++ b/src/parser/demonhunter/havoc/modules/talents/Felblade.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import SPELLS from 'common/SPELLS';
-import TalentStatisticBox from 'interface/others/TalentStatisticBox';
-import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
 import Events from 'parser/core/Events';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import { formatPercentage } from 'common/format';
 import SpellLink from 'common/SpellLink';
 import { t } from '@lingui/macro';
+import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import Statistic from 'interface/statistics/Statistic';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+
 
 /**
  * Example Report: https://www.warcraftlogs.com/reports/1HRhNZa2cCkgK9AV#fight=48&type=summary&source=10
@@ -60,10 +62,9 @@ class Felblade extends Analyzer {
   statistic() {
     const effectiveFuryGain = this.furyGain - this.furyWaste;
     return (
-      <TalentStatisticBox
-        talent={SPELLS.FELBLADE_TALENT.id}
-        position={STATISTIC_ORDER.OPTIONAL(6)}
-        value={<>{this.furyPerMin} <small>Fury per min </small></>}
+      <Statistic
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
         tooltip={(
           <>
             {effectiveFuryGain} Effective Fury gained<br />
@@ -71,9 +72,16 @@ class Felblade extends Analyzer {
             {this.furyWaste} Fury wasted
           </>
         )}
-      />
+      >
+        <BoringSpellValueText spell={SPELLS.FELBLADE_TALENT}>
+          <>
+            {this.furyPerMin} <small>Fury per min </small>
+          </>
+        </BoringSpellValueText>
+      </Statistic>
     );
   }
+
 }
 
 export default Felblade;


### PR DESCRIPTION
Another cd correction...
Added haste calculation https://www.wowhead.com/spell=342817/glaive-tempest
It reduced cd on wrong spell, probably from last expansion https://www.wowhead.com/spell=258887/cycle-of-hatred

Also updated depricated statistic code on Felblade