### PR TITLE
[Core] Fix the changelog dropdown displaying [object Object]

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Abelito75, AdamKelly, Amani, Barter, ChagriAli, ChristopherKiss, Dambroda, emallson, Guyius, Haelrail, HolySchmidt, Jafowler, jos3p, joshinator, Juko8, Keraldi, Khazak, Kruzershtern, Mae, Moonrabbit, niseko, Putro, Sharrq, Ssabbar, Zeboot, Zerotorescue } from 'CONTRIBUTORS';
+import { Abelito75, AdamKelly, Adoraci, Amani, Barter, ChagriAli, ChristopherKiss, Dambroda, emallson, Guyius, Haelrail, HolySchmidt, Jafowler, jos3p, joshinator, Juko8, Keraldi, Khazak, Kruzershtern, Mae, Moonrabbit, niseko, Putro, Sharrq, Ssabbar, Zeboot, Zerotorescue } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
 import SpellLink from 'common/SpellLink';
@@ -8,6 +8,7 @@ import { change, date } from 'common/changelog';
 
 // prettier-ignore
 export default [
+  change(date(2020, 12, 28), <>Fixed the Changelog dropdown selector displaying incorrectly.</>, Adoraci),
   change(date(2020, 12, 22), <>Re-enabled the QElive button for healers that have it supported.</>, Abelito75),
   change(date(2020, 12, 22), <>Added support for <ItemLink id={ITEMS.DARKMOON_DECK_VORACITY.id} /> and corrected downtime issues in fights where you had <SpellLink id={SPELLS.POWER_INFUSION.id} />.</>, Putro),
   change(date(2020, 12, 22), 'Resolved an issue in FilteredActiveTime that was not counting properly, resulting in > 100% active time.', Sharrq),

--- a/src/interface/ChangelogPanel/ChangelogPanel.tsx
+++ b/src/interface/ChangelogPanel/ChangelogPanel.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import CORE_CHANGELOG from 'CHANGELOG';
 import AVAILABLE_CONFIGS from 'parser';
 import { Trans } from '@lingui/macro';
+import { i18n } from '@lingui/core';
 
 import Changelog from '../Changelog';
 
@@ -26,7 +27,7 @@ const ChangelogPanel = () => {
           onChange={(e) => setChangelogType(Number(e.target.value))}
         >
           <option value={0}>
-            <Trans id="interface.changelogPanel.option.core">Core</Trans>
+            {i18n._('interface.changelogPanel.option.core')}
           </option>
           {AVAILABLE_CONFIGS.map((config) => (
             <option value={config.spec.id} key={config.spec.id}>

--- a/src/interface/ChangelogPanel/ChangelogPanel.tsx
+++ b/src/interface/ChangelogPanel/ChangelogPanel.tsx
@@ -2,8 +2,7 @@ import React, { useState } from 'react';
 
 import CORE_CHANGELOG from 'CHANGELOG';
 import AVAILABLE_CONFIGS from 'parser';
-import { Trans } from '@lingui/macro';
-import { i18n } from '@lingui/core';
+import { t, Trans } from '@lingui/macro';
 
 import Changelog from '../Changelog';
 
@@ -27,7 +26,7 @@ const ChangelogPanel = () => {
           onChange={(e) => setChangelogType(Number(e.target.value))}
         >
           <option value={0}>
-            {i18n._('interface.changelogPanel.option.core')}
+            {t({ id:'interface.changelogPanel.option.core', message: 'Core'})}
           </option>
           {AVAILABLE_CONFIGS.map((config) => (
             <option value={config.spec.id} key={config.spec.id}>


### PR DESCRIPTION
The `<select>` tag does not allow rendering of React components, so can't use the `<Trans>` component in here. Looking at other people having the same issue, using the direct `i18n._` call to translate works as it renders the text alone. [Reference thread](https://github.com/lingui/js-lingui/issues/655)

The issue is occurring under https://wowanalyzer.com/about

## Before
![image](https://user-images.githubusercontent.com/5396389/103195229-daaa4280-48af-11eb-968a-1358a6ad2244.png)

## After
![image](https://user-images.githubusercontent.com/5396389/103195247-e39b1400-48af-11eb-948e-01ebb322d332.png)
