### PR TITLE
[Brewmaster, Bug Fix] Add fix for ScaldingBrew analyzer when Keg Smash hits non-enemy targets

### DIFF
--- a/src/parser/monk/brewmaster/CHANGELOG.js
+++ b/src/parser/monk/brewmaster/CHANGELOG.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { Abelito75, emallson, Dambroda, Zeboot, LeoZhekov, Matardarix } from 'CONTRIBUTORS';
+import { Abelito75, emallson, Dambroda, Zeboot, LeoZhekov, Matardarix, Hordehobbs } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 12, 28), <>Add fix for non-enemy targets hit by <SpellLink id={SPELLS.SCALDING_BREW.id} />. </>, Hordehobbs),
   change(date(2020, 12, 10), <>Added stats for <SpellLink id={SPELLS.SCALDING_BREW.id} /> and <SpellLink id={SPELLS.EVASIVE_STRIDE.id} />.</>, emallson),
   change(date(2020, 12, 15), <>Fix <SpellLink id={SPELLS.LIGHT_BREWING_TALENT.id} /> ID</>, Matardarix),
   change(date(2020, 11, 26), <>Replaced the deprecated StatisticBoxes from the modules with the new Statistic</>, LeoZhekov),

--- a/src/parser/monk/brewmaster/modules/shadowlands/conduits/ScaldingBrew.tsx
+++ b/src/parser/monk/brewmaster/modules/shadowlands/conduits/ScaldingBrew.tsx
@@ -11,6 +11,8 @@ import SpellLink from 'common/SpellLink';
 import ItemDamageDone from 'interface/ItemDamageDone'
 import STATISTIC_ORDER  from 'interface/others/STATISTIC_ORDER';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+import Combatants from 'parser/shared/modules/Combatants';
+import Entity from 'parser/core/Entity';
 
 const DAMAGE_AMP_PER_RANK = 0.0075;
 const BASE_DAMAGE_AMP = 0.075;
@@ -18,9 +20,11 @@ const BASE_DAMAGE_AMP = 0.075;
 export default class ScaldingBrew extends Analyzer {
   static dependencies = {
     enemies: Enemies,
+    combatants: Combatants,
   };
 
   protected enemies!: Enemies;
+  protected combatants!: Combatants;
 
   bonusDamage = 0;
   // hits that did not trigger scalding brew
@@ -52,10 +56,13 @@ export default class ScaldingBrew extends Analyzer {
   }
 
   private damage(event: DamageEvent) {
-    const enemy = this.enemies.enemies[event.targetID];
-    if(enemy && enemy.hasBuff(SPELLS.BREATH_OF_FIRE_DEBUFF.id)) {
+    const target: Entity = this.enemies.enemies[event.targetID] || this.combatants.players[event.targetID];
+    if (!target) {
+      return;
+    }
+    if(target.hasBuff(SPELLS.BREATH_OF_FIRE_DEBUFF.id)) {
       this.bonusDamage += calculateEffectiveDamage(event, this.mult);
-    } else if(enemy.hasBuff(SPELLS.KEG_SMASH.id, event.timestamp - 100)) {
+    } else if(target.hasBuff(SPELLS.KEG_SMASH.id, event.timestamp - 100)) {
       this.missedHits += 1;
 
       if(this.lastCast) {


### PR DESCRIPTION
### Notes
- Add fix for ScaldingBrew analyzer when Keg Smash hits a non-enemy target.
  - Analyzer now takes into account players hit by Keg Smash in case of friendly-fire scenario and returns early if the Entity hit by Keg Smash cannot be found.
  - Log where problem was found: https://www.warcraftlogs.com/reports/Zm1AXdQTMrvq6WBa/#fight=5&source=3

### Testing
`yarn lint`, `yarn build`, `yarn test:integration`