### PR TITLE
[Mage] Moved Mage Conduit Statistics to ConduitSpellText

### DIFF
--- a/src/parser/mage/arcane/CHANGELOG.tsx
+++ b/src/parser/mage/arcane/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import { change, date } from 'common/changelog';
 
 // prettier-ignore
 export default [
+  change(date(2020, 12, 28), <>Updated conduit statistic boxes to use the new layout.</>, Sharrq),
   change(date(2020, 12, 24), <>Fixed an issue that was showing <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} /> as lasting the entire fight duration in the Cooldowns tab.</>, Sharrq),
   change(date(2020, 12, 19), <>Added module to check the active time during <SpellLink id={SPELLS.ARCANE_POWER.id} />.</>, Sharrq),
   change(date(2020, 12, 16), `Fixed an abe with suggestions showing {0} instead of the suggestion text in Arcane modules.`, Sharrq),

--- a/src/parser/mage/arcane/modules/items/ArcaneBombardment.tsx
+++ b/src/parser/mage/arcane/modules/items/ArcaneBombardment.tsx
@@ -21,8 +21,8 @@ class ArcaneBombardment extends Analyzer {
 
   bonusDamage = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.ARCANE_BOMBARDMENT.bonusID);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.ARCANE_BARRAGE), this.onBarrageDamage);
   }

--- a/src/parser/mage/arcane/modules/items/ArcaneHarmony.tsx
+++ b/src/parser/mage/arcane/modules/items/ArcaneHarmony.tsx
@@ -22,8 +22,8 @@ class ArcaneHarmony extends Analyzer {
   stacks = 0
   totalStacks = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.ARCANE_HARMONY.bonusID);
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.ARCANE_BARRAGE), this.onBarrageCast);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.ARCANE_BARRAGE), this.onBarrageDamage);

--- a/src/parser/mage/arcane/modules/items/ArcaneProdigy.tsx
+++ b/src/parser/mage/arcane/modules/items/ArcaneProdigy.tsx
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import Events, { CastEvent } from 'parser/core/Events';
 import Statistic from 'interface/statistics/Statistic';
-import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import ConduitSpellText from 'interface/statistics/components/ConduitSpellText';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import UptimeIcon from 'interface/icons/Uptime';
 import { SELECTED_PLAYER } from 'parser/core/EventFilter';
@@ -21,12 +21,9 @@ class ArcaneProdigy extends Analyzer {
   cooldownReduction = 0;
   wastedReduction = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasConduitBySpellID(SPELLS.ARCANE_PRODIGY.id);
-    if (!this.active) {
-      return;
-    }
     this.conduitRank = this.selectedCombatant.conduitRankBySpellID(SPELLS.ARCANE_PRODIGY.id);
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.ARCANE_MISSILES), this.onMissilesCast);
   }
@@ -50,14 +47,14 @@ class ArcaneProdigy extends Analyzer {
   statistic() {
     return (
       <Statistic
-        category={STATISTIC_CATEGORY.ITEMS}
+        category={STATISTIC_CATEGORY.COVENANTS}
         size="flexible"
         tooltip={<>You reduced the cooldown on Arcane Power by a total of {this.reductionSeconds}s. Additionally, by casting Arcane Missiles while Arcane Power was not on cooldown, you wasted {this.wastedReductionSeconds}s that could have reduced the cooldown on Arcane Power further. </>}
       >
-        <BoringSpellValueText spell={SPELLS.ARCANE_PRODIGY}>
+        <ConduitSpellText spell={SPELLS.ARCANE_PRODIGY} rank={this.conduitRank}>
           <UptimeIcon /> {this.reductionSeconds}s <small>Arcane Power CDR</small><br />
           {this.wastedReductionSeconds}s <small>Wasted CDR</small>
-        </BoringSpellValueText>
+        </ConduitSpellText>
       </Statistic>
     );
   }

--- a/src/parser/mage/arcane/modules/items/ArtificeOfTheArchmage.tsx
+++ b/src/parser/mage/arcane/modules/items/ArtificeOfTheArchmage.tsx
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import Events, { EnergizeEvent } from 'parser/core/Events';
 import Statistic from 'interface/statistics/Statistic';
-import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import ConduitSpellText from 'interface/statistics/components/ConduitSpellText';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import { SELECTED_PLAYER } from 'parser/core/EventFilter';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
@@ -14,11 +14,13 @@ class ArtificeOfTheArchmage extends Analyzer {
   }
   protected spellUsable!: SpellUsable;
 
+  conduitRank = 0;
   freeCharges = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasConduitBySpellID(SPELLS.ARTIFICE_OF_THE_ARCHMAGE.id);
+    this.conduitRank = this.selectedCombatant.conduitRankBySpellID(SPELLS.ARTIFICE_OF_THE_ARCHMAGE.id);
     this.addEventListener(Events.energize.by(SELECTED_PLAYER).spell(SPELLS.ARTIFICE_OF_THE_ARCHMAGE_ENERGIZE), this.onEnergize);
   }
 
@@ -33,13 +35,13 @@ class ArtificeOfTheArchmage extends Analyzer {
   statistic() {
     return (
       <Statistic
-        category={STATISTIC_CATEGORY.ITEMS}
+        category={STATISTIC_CATEGORY.COVENANTS}
         size="flexible"
         tooltip={<>The number of Arcane Charges you received from the Artifice of the Archmage conduit. </>}
       >
-        <BoringSpellValueText spell={SPELLS.ARTIFICE_OF_THE_ARCHMAGE}>
+        <ConduitSpellText spell={SPELLS.ARTIFICE_OF_THE_ARCHMAGE} rank={this.conduitRank}>
           {this.freeCharges} <small>Free Arcane Charges</small>
-        </BoringSpellValueText>
+        </ConduitSpellText>
       </Statistic>
     );
   }

--- a/src/parser/mage/fire/CHANGELOG.tsx
+++ b/src/parser/mage/fire/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 12, 28), <>Updated conduit statistic boxes to use the new layout.</>, Sharrq),
   change(date(2020, 12, 24), <>Added module to check for capping on <SpellLink id={SPELLS.PHOENIX_FLAMES.id} /> charges and fixed an issue that was showing <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} /> as lasting the entire fight duration in the Cooldowns tab.</>, Sharrq),
   change(date(2020, 12, 19), <>Added module to check the active time during <SpellLink id={SPELLS.COMBUSTION.id} /> and fixed a typo in <SpellLink id={SPELLS.FIRESTORM.id} />.</>, Sharrq),
   change(date(2020, 12, 19), <>Resolved an issue in <SpellLink id={SPELLS.COMBUSTION.id} /> that was marking <SpellLink id={SPELLS.FIREBALL.id} /> casts that started before Combustion and ended after Combustion as being cast during Combustion.</>, Sharrq),

--- a/src/parser/mage/fire/integrationTests/example.test.ts.snap
+++ b/src/parser/mage/fire/integrationTests/example.test.ts.snap
@@ -4461,7 +4461,7 @@ exports[`Fire Mage integration test: example log InfernalCascade matches the sta
   className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
 >
   <div
-    category="ITEMS"
+    category="COVENANT"
     className="panel statistic flexible "
   >
     <div
@@ -4492,6 +4492,8 @@ exports[`Fire Mage integration test: example log InfernalCascade matches the sta
           >
             Infernal Cascade
           </a>
+           - Rank 
+          4
         </label>
         <div
           className="value"

--- a/src/parser/mage/fire/modules/items/ControlledDestruction.tsx
+++ b/src/parser/mage/fire/modules/items/ControlledDestruction.tsx
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import Events, { DamageEvent } from 'parser/core/Events';
 import Statistic from 'interface/statistics/Statistic';
-import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import ConduitSpellText from 'interface/statistics/components/ConduitSpellText';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import ItemDamageDone from 'interface/ItemDamageDone';
 import { SELECTED_PLAYER } from 'parser/core/EventFilter';
@@ -16,12 +16,9 @@ class ControlledDestruction extends Analyzer {
   conduitRank = 0;
   bonusDamage = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasConduitBySpellID(SPELLS.CONTROLLED_DESTRUCTION.id);
-    if (!this.active) {
-      return;
-    }
     this.conduitRank = this.selectedCombatant.conduitRankBySpellID(SPELLS.CONTROLLED_DESTRUCTION.id);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.PYROBLAST), this.onPyroDamage);
   }
@@ -36,9 +33,9 @@ class ControlledDestruction extends Analyzer {
         category={STATISTIC_CATEGORY.ITEMS}
         size="flexible"
       >
-        <BoringSpellValueText spell={SPELLS.CONTROLLED_DESTRUCTION}>
-          <ItemDamageDone amount={this.bonusDamage} />
-        </BoringSpellValueText>
+        <ConduitSpellText spell={SPELLS.CONTROLLED_DESTRUCTION} rank={this.conduitRank}>
+         <ItemDamageDone amount={this.bonusDamage} />
+        </ConduitSpellText>
       </Statistic>
     );
   }

--- a/src/parser/mage/fire/modules/items/FeveredIncantation.tsx
+++ b/src/parser/mage/fire/modules/items/FeveredIncantation.tsx
@@ -18,8 +18,8 @@ class FeveredIncantation extends Analyzer {
 
   bonusDamage = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.FEVERED_INCANTATION.bonusID);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDamage);
   }

--- a/src/parser/mage/fire/modules/items/Firestorm.tsx
+++ b/src/parser/mage/fire/modules/items/Firestorm.tsx
@@ -13,8 +13,8 @@ class Firestorm extends Analyzer {
   castsDuringFirestorm = 0;
   firestormProcs = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.FIRESTORM.bonusID);
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell([SPELLS.PYROBLAST,SPELLS.FLAMESTRIKE]), this.onCast);
     this.addEventListener(Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.FIRESTORM_BUFF), this.onFirestormApplied);

--- a/src/parser/mage/fire/modules/items/InfernalCascade.tsx
+++ b/src/parser/mage/fire/modules/items/InfernalCascade.tsx
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import Events, { DamageEvent } from 'parser/core/Events';
 import Statistic from 'interface/statistics/Statistic';
-import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import ConduitSpellText from 'interface/statistics/components/ConduitSpellText';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import ItemDamageDone from 'interface/ItemDamageDone';
 import { SELECTED_PLAYER } from 'parser/core/EventFilter';
@@ -19,12 +19,9 @@ class InfernalCascade extends Analyzer {
   totalBuffs = 0;
   combustionCount = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasConduitBySpellID(SPELLS.INFERNAL_CASCADE.id);
-    if (!this.active) {
-      return;
-    }
     this.conduitRank = this.selectedCombatant.conduitRankBySpellID(SPELLS.INFERNAL_CASCADE.id);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDamage);
     this.addEventListener(Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.INFERNAL_CASCADE_BUFF), this.onBuffStack);
@@ -61,13 +58,13 @@ class InfernalCascade extends Analyzer {
   statistic() {
     return (
       <Statistic
-        category={STATISTIC_CATEGORY.ITEMS}
+        category={STATISTIC_CATEGORY.COVENANTS}
         size="flexible"
       >
-        <BoringSpellValueText spell={SPELLS.INFERNAL_CASCADE}>
+        <ConduitSpellText spell={SPELLS.INFERNAL_CASCADE} rank={this.conduitRank}>
           <ItemDamageDone amount={this.bonusDamage} /><br />
           {this.averageBuffStack} <small>Avg. stacks per Combustion</small>
-        </BoringSpellValueText>
+        </ConduitSpellText>
       </Statistic>
     );
   }

--- a/src/parser/mage/fire/modules/items/MasterFlame.tsx
+++ b/src/parser/mage/fire/modules/items/MasterFlame.tsx
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import Events, { DamageEvent } from 'parser/core/Events';
 import Statistic from 'interface/statistics/Statistic';
-import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import ConduitSpellText from 'interface/statistics/components/ConduitSpellText';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import ItemDamageDone from 'interface/ItemDamageDone';
 import { SELECTED_PLAYER } from 'parser/core/EventFilter';
@@ -16,12 +16,9 @@ class MasterFlame extends Analyzer {
   conduitRank = 0;
   bonusDamage = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasConduitBySpellID(SPELLS.MASTER_FLAME.id);
-    if (!this.active) {
-      return;
-    }
     this.conduitRank = this.selectedCombatant.conduitRankBySpellID(SPELLS.MASTER_FLAME.id);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.FLAMESTRIKE), this.onFlameStrikeDamage);
   }
@@ -33,12 +30,12 @@ class MasterFlame extends Analyzer {
   statistic() {
     return (
       <Statistic
-        category={STATISTIC_CATEGORY.ITEMS}
+        category={STATISTIC_CATEGORY.COVENANTS}
         size="flexible"
       >
-        <BoringSpellValueText spell={SPELLS.MASTER_FLAME}>
+        <ConduitSpellText spell={SPELLS.MASTER_FLAME} rank={this.conduitRank}>
           <ItemDamageDone amount={this.bonusDamage} />
-        </BoringSpellValueText>
+        </ConduitSpellText>
       </Statistic>
     );
   }

--- a/src/parser/mage/frost/CHANGELOG.tsx
+++ b/src/parser/mage/frost/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 12, 28), <>Updated conduit statistic boxes to use the new layout.</>, Sharrq),
   change(date(2020, 12, 24), <>Fixed an error in <SpellLink id={SPELLS.GLACIAL_FRAGMENTS.id} /> that was not properly counting absorbed damage.</>, Sharrq),
   change(date(2020, 12, 24), <>Fixed an issue that was showing <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} /> as lasting the entire fight duration in the Cooldowns tab.</>, Sharrq),
   change(date(2020, 12, 19), <>Added module to check the active time during <SpellLink id={SPELLS.ICY_VEINS.id} /> and added support for <SpellLink id={SPELLS.GLACIAL_FRAGMENTS.id} />.</>, Sharrq),

--- a/src/parser/mage/frost/integrationTests/example.test.ts.snap
+++ b/src/parser/mage/frost/integrationTests/example.test.ts.snap
@@ -3973,7 +3973,7 @@ exports[`Frost Mage integration test: example log IceBite matches the statistic 
   className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
 >
   <div
-    category="ITEMS"
+    category="COVENANT"
     className="panel statistic flexible "
   >
     <div
@@ -4004,6 +4004,8 @@ exports[`Frost Mage integration test: example log IceBite matches the statistic 
           >
             Ice Bite
           </a>
+           - Rank 
+          3
         </label>
         <div
           className="value"

--- a/src/parser/mage/frost/modules/items/ColdFront.tsx
+++ b/src/parser/mage/frost/modules/items/ColdFront.tsx
@@ -18,8 +18,8 @@ class ColdFront extends Analyzer {
 
   bonusFrozenOrbs = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.COLD_FRONT.bonusID);
     this.addEventListener(Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.COLD_FRONT_BUFF), this.onBuffApplied);
   }

--- a/src/parser/mage/frost/modules/items/GlacialFragments.tsx
+++ b/src/parser/mage/frost/modules/items/GlacialFragments.tsx
@@ -16,8 +16,8 @@ class GlacialFragments extends Analyzer {
   hasSplittingIce: boolean;
   fragmentDamage = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.GLACIAL_FRAGMENTS.bonusID);
     this.hasSplittingIce = this.selectedCombatant.hasTalent(SPELLS.SPLITTING_ICE_TALENT.id);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.GLACIAL_FRAGMENTS_DAMAGE), this.onFragmentDamage);

--- a/src/parser/mage/frost/modules/items/IceBite.tsx
+++ b/src/parser/mage/frost/modules/items/IceBite.tsx
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import Events, { DamageEvent } from 'parser/core/Events';
 import Statistic from 'interface/statistics/Statistic';
-import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import ConduitSpellText from 'interface/statistics/components/ConduitSpellText';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import ItemDamageDone from 'interface/ItemDamageDone';
 import { SELECTED_PLAYER } from 'parser/core/EventFilter';
@@ -23,12 +23,9 @@ class IceBite extends Analyzer {
   conduitRank = 0;
   bonusDamage = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasConduitBySpellID(SPELLS.ICE_BITE.id);
-    if (!this.active) {
-      return;
-    }
     this.conduitRank = this.selectedCombatant.conduitRankBySpellID(SPELLS.ICE_BITE.id);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.ICE_LANCE_DAMAGE), this.onIceLanceDamage);
   }
@@ -43,12 +40,12 @@ class IceBite extends Analyzer {
   statistic() {
     return (
       <Statistic
-        category={STATISTIC_CATEGORY.ITEMS}
+        category={STATISTIC_CATEGORY.COVENANTS}
         size="flexible"
       >
-        <BoringSpellValueText spell={SPELLS.ICE_BITE}>
+        <ConduitSpellText spell={SPELLS.ICE_BITE} rank={this.conduitRank}>
           <ItemDamageDone amount={this.bonusDamage} />
-        </BoringSpellValueText>
+        </ConduitSpellText>
       </Statistic>
     );
   }

--- a/src/parser/mage/frost/modules/items/IcyPropulsion.tsx
+++ b/src/parser/mage/frost/modules/items/IcyPropulsion.tsx
@@ -6,7 +6,7 @@ import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import Events, { DamageEvent } from 'parser/core/Events';
 import Statistic from 'interface/statistics/Statistic';
 import UptimeIcon from 'interface/icons/Uptime';
-import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import ConduitSpellText from 'interface/statistics/components/ConduitSpellText';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import HIT_TYPES from 'game/HIT_TYPES';
 import { SELECTED_PLAYER } from 'parser/core/EventFilter';
@@ -25,12 +25,9 @@ class IcyPropulsion extends Analyzer {
   conduitRank = 0;
   cooldownReduction = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasConduitBySpellID(SPELLS.ICY_PROPULSION.id);
-    if (!this.active) {
-      return;
-    }
     this.conduitRank = this.selectedCombatant.conduitRankBySpellID(SPELLS.ICY_PROPULSION.id);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDamage);
   }
@@ -55,13 +52,13 @@ class IcyPropulsion extends Analyzer {
   statistic() {
     return (
       <Statistic
-        category={STATISTIC_CATEGORY.ITEMS}
+        category={STATISTIC_CATEGORY.COVENANTS}
         size="flexible"
         tooltip={<>Icy Propulsion reduced the cooldown on Icy Veins by a total of {this.reductionSeconds} ({this.reductionPerIcyVeins} Per Icy Veins on average).</>}
       >
-        <BoringSpellValueText spell={SPELLS.ICY_PROPULSION}>
+        <ConduitSpellText spell={SPELLS.ICY_PROPULSION} rank={this.conduitRank}>
           <UptimeIcon /> {`${formatNumber(this.reductionSeconds)}s`} <small>Icy Veins CDR</small>
-        </BoringSpellValueText>
+        </ConduitSpellText>
       </Statistic>
     );
   }

--- a/src/parser/mage/frost/modules/items/ShiveringCore.tsx
+++ b/src/parser/mage/frost/modules/items/ShiveringCore.tsx
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import Events, { DamageEvent } from 'parser/core/Events';
 import Statistic from 'interface/statistics/Statistic';
-import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import ConduitSpellText from 'interface/statistics/components/ConduitSpellText';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import ItemDamageDone from 'interface/ItemDamageDone';
 import { SELECTED_PLAYER } from 'parser/core/EventFilter';
@@ -16,12 +16,9 @@ class ShiveringCore extends Analyzer {
   conduitRank = 0;
   bonusDamage = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasConduitBySpellID(SPELLS.SHIVERING_CORE.id);
-    if (!this.active) {
-      return;
-    }
     this.conduitRank = this.selectedCombatant.conduitRankBySpellID(SPELLS.SHIVERING_CORE.id);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.BLIZZARD_DAMAGE), this.onBlizzardDamage);
   }
@@ -33,12 +30,12 @@ class ShiveringCore extends Analyzer {
   statistic() {
     return (
       <Statistic
-        category={STATISTIC_CATEGORY.ITEMS}
+        category={STATISTIC_CATEGORY.COVENANTS}
         size="flexible"
       >
-        <BoringSpellValueText spell={SPELLS.SHIVERING_CORE}>
+        <ConduitSpellText spell={SPELLS.SHIVERING_CORE} rank={this.conduitRank}>
           <ItemDamageDone amount={this.bonusDamage} />
-        </BoringSpellValueText>
+        </ConduitSpellText>
       </Statistic>
     );
   }

--- a/src/parser/mage/frost/modules/items/UnrelentingCold.tsx
+++ b/src/parser/mage/frost/modules/items/UnrelentingCold.tsx
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import Events, { DamageEvent } from 'parser/core/Events';
 import Statistic from 'interface/statistics/Statistic';
-import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import ConduitSpellText from 'interface/statistics/components/ConduitSpellText';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import ItemDamageDone from 'interface/ItemDamageDone';
 import { SELECTED_PLAYER } from 'parser/core/EventFilter';
@@ -16,12 +16,9 @@ class UnrelentingCold extends Analyzer {
   conduitRank = 0;
   bonusDamage = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasConduitBySpellID(SPELLS.UNRELENTING_COLD.id);
-    if (!this.active) {
-      return;
-    }
     this.conduitRank = this.selectedCombatant.conduitRankBySpellID(SPELLS.UNRELENTING_COLD.id);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.FROZEN_ORB_DAMAGE), this.onFrozenOrbDamage);
   }
@@ -33,12 +30,12 @@ class UnrelentingCold extends Analyzer {
   statistic() {
     return (
       <Statistic
-        category={STATISTIC_CATEGORY.ITEMS}
+        category={STATISTIC_CATEGORY.COVENANTS}
         size="flexible"
       >
-        <BoringSpellValueText spell={SPELLS.UNRELENTING_COLD}>
+        <ConduitSpellText spell={SPELLS.UNRELENTING_COLD} rank={this.conduitRank}>
           <ItemDamageDone amount={this.bonusDamage} />
-        </BoringSpellValueText>
+        </ConduitSpellText>
       </Statistic>
     );
   }

--- a/src/parser/mage/shared/modules/items/DivertedEnergy.tsx
+++ b/src/parser/mage/shared/modules/items/DivertedEnergy.tsx
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import Events, { HealEvent } from 'parser/core/Events';
 import Statistic from 'interface/statistics/Statistic';
-import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import ConduitSpellText from 'interface/statistics/components/ConduitSpellText';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import ItemHealingDone from 'interface/ItemHealingDone';
 import { SELECTED_PLAYER } from 'parser/core/EventFilter';
@@ -11,12 +11,14 @@ import { formatNumber } from 'common/format';
 
 class DivertedEnergy extends Analyzer {
 
+  conduitRank = 0;
   healingDone = 0;
   overhealing = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasConduitBySpellID(SPELLS.DIVERTED_ENERGY.id);
+    this.conduitRank = this.selectedCombatant.conduitRankBySpellID(SPELLS.DIVERTED_ENERGY.id);
     this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.DIVERTED_ENERGY_HEAL), this.onDivertedEnergyHeal);
   }
 
@@ -30,13 +32,13 @@ class DivertedEnergy extends Analyzer {
   statistic() {
     return (
       <Statistic
-        category={STATISTIC_CATEGORY.ITEMS}
+        category={STATISTIC_CATEGORY.COVENANTS}
         size="flexible"
       >
-        <BoringSpellValueText spell={SPELLS.DIVERTED_ENERGY}>
+        <ConduitSpellText spell={SPELLS.DIVERTED_ENERGY} rank={this.conduitRank}>
           <ItemHealingDone amount={this.healingDone} /><br />
           {formatNumber(this.overhealing)} <small>Overhealing</small>
-        </BoringSpellValueText>
+        </ConduitSpellText>
       </Statistic>
     );
   }

--- a/src/parser/mage/shared/modules/items/GroundingSurge.tsx
+++ b/src/parser/mage/shared/modules/items/GroundingSurge.tsx
@@ -15,8 +15,8 @@ class GroundingSurge extends Analyzer {
   conduitRank = 0;
   bonusDamage = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasConduitBySpellID(SPELLS.GROUNDING_SURGE.id);
     if (!this.active) {
       return;

--- a/src/parser/mage/shared/modules/items/IreOfTheAscended.tsx
+++ b/src/parser/mage/shared/modules/items/IreOfTheAscended.tsx
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import Events, { DamageEvent } from 'parser/core/Events';
 import Statistic from 'interface/statistics/Statistic';
-import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import ConduitSpellText from 'interface/statistics/components/ConduitSpellText';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import ItemDamageDone from 'interface/ItemDamageDone';
 import { SELECTED_PLAYER } from 'parser/core/EventFilter';
@@ -16,12 +16,9 @@ class IreOfTheAscended extends Analyzer {
   conduitRank = 0;
   bonusDamage = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasConduitBySpellID(SPELLS.IRE_OF_THE_ASCENDED.id);
-    if (!this.active) {
-      return;
-    }
     this.conduitRank = this.selectedCombatant.conduitRankBySpellID(SPELLS.IRE_OF_THE_ASCENDED.id);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDamage);
   }
@@ -36,12 +33,12 @@ class IreOfTheAscended extends Analyzer {
   statistic() {
     return (
       <Statistic
-        category={STATISTIC_CATEGORY.ITEMS}
+        category={STATISTIC_CATEGORY.COVENANTS}
         size="flexible"
       >
-        <BoringSpellValueText spell={SPELLS.IRE_OF_THE_ASCENDED}>
+        <ConduitSpellText spell={SPELLS.IRE_OF_THE_ASCENDED} rank={this.conduitRank}>
           <ItemDamageDone amount={this.bonusDamage} />
-        </BoringSpellValueText>
+        </ConduitSpellText>
       </Statistic>
     );
   }

--- a/src/parser/mage/shared/modules/items/SiphonedMalice.tsx
+++ b/src/parser/mage/shared/modules/items/SiphonedMalice.tsx
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import Events, { DamageEvent } from 'parser/core/Events';
 import Statistic from 'interface/statistics/Statistic';
-import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import ConduitSpellText from 'interface/statistics/components/ConduitSpellText';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import ItemDamageDone from 'interface/ItemDamageDone';
 import { SELECTED_PLAYER } from 'parser/core/EventFilter';
@@ -16,12 +16,9 @@ class SiphonedMalice extends Analyzer {
   conduitRank = 0;
   bonusDamage = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasConduitBySpellID(SPELLS.SIPHONED_MALICE.id);
-    if (!this.active) {
-      return;
-    }
     this.conduitRank = this.selectedCombatant.conduitRankBySpellID(SPELLS.SIPHONED_MALICE.id);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDamage);
   }
@@ -37,12 +34,12 @@ class SiphonedMalice extends Analyzer {
   statistic() {
     return (
       <Statistic
-        category={STATISTIC_CATEGORY.ITEMS}
+        category={STATISTIC_CATEGORY.COVENANTS}
         size="flexible"
       >
-        <BoringSpellValueText spell={SPELLS.SIPHONED_MALICE}>
+        <ConduitSpellText spell={SPELLS.SIPHONED_MALICE} rank={this.conduitRank}>
           <ItemDamageDone amount={this.bonusDamage} />
-        </BoringSpellValueText>
+        </ConduitSpellText>
       </Statistic>
     );
   }

--- a/src/parser/mage/shared/modules/items/TempestBarrier.tsx
+++ b/src/parser/mage/shared/modules/items/TempestBarrier.tsx
@@ -3,18 +3,20 @@ import SPELLS from 'common/SPELLS';
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import Events, { AbsorbedEvent } from 'parser/core/Events';
 import Statistic from 'interface/statistics/Statistic';
-import BoringSpellValueText from 'interface/statistics/components/BoringSpellValueText';
+import ConduitSpellText from 'interface/statistics/components/ConduitSpellText';
 import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
 import { SELECTED_PLAYER } from 'parser/core/EventFilter';
 import { formatNumber } from 'common/format';
 
 class TempestBarrier extends Analyzer {
 
+  conduitRank = 0;
   damageAbsorbed = 0;
 
-  constructor(props: Options) {
-    super(props);
+  constructor(options: Options) {
+    super(options);
     this.active = this.selectedCombatant.hasConduitBySpellID(SPELLS.TEMPEST_BARRIER.id);
+    this.conduitRank = this.selectedCombatant.conduitRankBySpellID(SPELLS.TEMPEST_BARRIER.id);
     this.addEventListener(Events.absorbed.by(SELECTED_PLAYER).spell(SPELLS.TEMPEST_BARRIER_ABSORB), this.onAbsorb);
   }
 
@@ -25,12 +27,12 @@ class TempestBarrier extends Analyzer {
   statistic() {
     return (
       <Statistic
-        category={STATISTIC_CATEGORY.ITEMS}
+        category={STATISTIC_CATEGORY.COVENANTS}
         size="flexible"
       >
-        <BoringSpellValueText spell={SPELLS.TEMPEST_BARRIER}>
+        <ConduitSpellText spell={SPELLS.TEMPEST_BARRIER} rank={this.conduitRank}>
           {formatNumber(this.damageAbsorbed)} <small>Damage absorbed</small>
-        </BoringSpellValueText>
+        </ConduitSpellText>
       </Statistic>
     );
   }


### PR DESCRIPTION
Updated the mage conduit stat boxes to be in the COVENANTS category and use ConduitSpellText.