### PR TITLE
[Core] Fix crash when no weapon is equipped

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -8,6 +8,7 @@ import { change, date } from 'common/changelog';
 
 // prettier-ignore
 export default [
+  change(date(2020, 12, 28), <>Resolved a crash that would occur if the player did not have a weapon equipped.</>, Sharrq),
   change(date(2020, 12, 28), <>Fixed the Changelog dropdown selector displaying incorrectly.</>, Adoraci),
   change(date(2020, 12, 22), <>Re-enabled the QElive button for healers that have it supported.</>, Abelito75),
   change(date(2020, 12, 22), <>Added support for <ItemLink id={ITEMS.DARKMOON_DECK_VORACITY.id} /> and corrected downtime issues in fights where you had <SpellLink id={SPELLS.POWER_INFUSION.id} />.</>, Putro),

--- a/src/parser/shared/modules/items/WeaponEnhancementChecker.tsx
+++ b/src/parser/shared/modules/items/WeaponEnhancementChecker.tsx
@@ -43,14 +43,14 @@ class WeaponEnhancementChecker extends Analyzer {
     }, {});
   }
   get numWeapons() {
-    return Object.keys(this.enhanceableWeapons).length;
+    return Object.keys(this.enhanceableWeapons).length || 1;
   }
   get weaponsMissingEnhancement() {
     const gear = this.enhanceableWeapons;
-    return Object.keys(gear).filter(slot => !this.hasEnhancement(gear[Number(slot)]));
+    return Object.keys(gear).length > 0 ? Object.keys(gear).filter(slot => !this.hasEnhancement(gear[Number(slot)])) : null;
   }
   get numWeaponsMissingEnhancement() {
-    return this.weaponsMissingEnhancement.length;
+    return this.weaponsMissingEnhancement ? this.weaponsMissingEnhancement.length : 1;
   }
   get weaponsMissingMaxEnhancement() {
     const gear = this.enhanceableWeapons;


### PR DESCRIPTION
The checks for Weapon Enhancements (Oils/Stones) was crashing if the player did not have a weapon equipped.

Fixes #4220