### PR TITLE
[Core] Convert GenericCastEfficiencyRequirement to Typescript

### DIFF
--- a/src/parser/priest/discipline/modules/features/Checklist/Component.tsx
+++ b/src/parser/priest/discipline/modules/features/Checklist/Component.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import SPELLS from 'common/SPELLS';
 // import ITEMS from 'common/ITEMS';
@@ -10,113 +9,136 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { TooltipElement } from 'common/Tooltip';
 import Checklist from 'parser/shared/modules/features/Checklist';
 import Rule from 'parser/shared/modules/features/Checklist/Rule';
+import AbilityRequirement from 'parser/shared/modules/features/Checklist/AbilityRequirement';
 import Requirement from 'parser/shared/modules/features/Checklist/Requirement';
 import PreparationRule from 'parser/shared/modules/features/Checklist/PreparationRule';
-import GenericCastEfficiencyRequirement from 'parser/shared/modules/features/Checklist/GenericCastEfficiencyRequirement';
 import Combatant from 'parser/core/Combatant';
 import CastEfficiency from 'parser/shared/modules/CastEfficiency';
 
-const DisciplinePriestChecklist = ({ combatant, castEfficiency, thresholds }: { combatant: Combatant, castEfficiency: CastEfficiency, thresholds: any }) => {
-  const AbilityRequirement = (props: { spell: number }) => (
-    <GenericCastEfficiencyRequirement
-      castEfficiency={castEfficiency.getCastEfficiencyForSpellId(props.spell)}
-      {...props}
-    />
-  );
-  AbilityRequirement.propTypes = {
-    spell: PropTypes.number.isRequired,
-  };
-
-  return (
-    <Checklist>
-      <Rule
-        name="Use core abilities as often as possible"
-        description={(
-          <>
-            Using your core abilities as often as possible will typically result in better performance, remember to <SpellLink id={SPELLS.SMITE.id} /> as often as you can!
-          </>
-        )}
-      >
-        <AbilityRequirement spell={SPELLS.PENANCE_CAST.id} />
-        {combatant.hasTalent(SPELLS.SCHISM_TALENT.id) && (
-          <AbilityRequirement spell={SPELLS.SCHISM_TALENT.id} />
-        )}
-        {combatant.hasTalent(SPELLS.POWER_WORD_SOLACE_TALENT.id) && (
-          <AbilityRequirement spell={SPELLS.POWER_WORD_SOLACE_TALENT.id} />
-        )}
-        {combatant.hasTalent(SPELLS.DIVINE_STAR_TALENT.id) && (
-          <AbilityRequirement spell={SPELLS.DIVINE_STAR_TALENT.id} />
-        )}
-        {combatant.hasTalent(SPELLS.SHADOW_COVENANT_TALENT.id) && (
-          <AbilityRequirement spell={SPELLS.SHADOW_COVENANT_TALENT.id} />
-        )}
-      </Rule>
-
-      <Rule
-        name="Use cooldowns effectively"
-        description={(
-          <>
-            Cooldowns are an important part of healing, try to use them to counter fight mechanics. For example if a boss has burst damage every 1.5 minutes, <SpellLink id={SPELLS.RAPTURE.id} /> should be used to counter it.
-          </>
-        )}
-      >
-        {!combatant.hasTalent(SPELLS.SPIRIT_SHELL_TALENT.id) && <AbilityRequirement spell={SPELLS.RAPTURE.id} />}
-        {!combatant.hasTalent(SPELLS.MINDBENDER_TALENT_SHARED.id) && (
-          <AbilityRequirement spell={SPELLS.SHADOWFIEND.id} />
-        )}
-        {combatant.hasTalent(SPELLS.MINDBENDER_TALENT_SHARED.id) && (
-          <AbilityRequirement spell={SPELLS.MINDBENDER_TALENT_SHARED.id} />
-        )}
-        {combatant.hasTalent(SPELLS.HALO_TALENT.id) && (
-          <AbilityRequirement spell={SPELLS.HALO_TALENT.id} />
-        )}
-        {combatant.hasTalent(SPELLS.EVANGELISM_TALENT.id) && (
-          <AbilityRequirement spell={SPELLS.EVANGELISM_TALENT.id} />
-        )}
-        {/* We can't detect race, so disable this when it has never been cast. */}
-        {castEfficiency.getCastEfficiencyForSpellId(SPELLS.ARCANE_TORRENT_MANA1.id) && (
-          <AbilityRequirement spell={SPELLS.ARCANE_TORRENT_MANA1.id} />
-        )}
-      </Rule>
-
-      <Rule
-        name="Use your supportive abilities"
-        description="While you shouldn't aim to cast defensives and externals on cooldown, be aware of them and try to use them whenever effective. Not using them at all indicates you might not be aware of them enough or not utilizing them optimally."
-      >
-        <AbilityRequirement spell={SPELLS.PAIN_SUPPRESSION.id} />
-        <AbilityRequirement spell={SPELLS.LEAP_OF_FAITH.id} />
-        <AbilityRequirement spell={SPELLS.DESPERATE_PRAYER.id} />
-      </Rule>
-
-      <Rule
-        name="Try to avoid being inactive for a large portion of the fight"
-        description={(
-          <>
-            High downtime is inexcusable, while it may be tempting to not cast and save mana, Discipline's damage fillers such as <SpellLink id={SPELLS.SMITE.id} /> are extremely cheap. You can reduce your downtime by reducing the delay between casting spells, anticipating movement, moving during the GCD, and <TooltipElement content="You can ignore this while learning Discipline, but contributing DPS whilst healing is a major part of becoming a better than average player.">when you're not healing try to contribute some damage.*</TooltipElement>.
-          </>
-        )}
-      >
-        <Requirement name="Non healing time" thresholds={thresholds.nonHealingTimeSuggestionThresholds} />
-        <Requirement name="Downtime" thresholds={thresholds.downtimeSuggestionThresholds} />
-      </Rule>
-
-      <Rule
-        name={<>Use all of your <ResourceLink id={RESOURCE_TYPES.MANA.id} /> effectively</>}
-        description="If you have a large amount of mana left at the end of the fight that's mana you could have turned into healing. Try to use all your mana during a fight. A good rule of thumb is to try to match your mana level with the boss's health."
-      >
-        <Requirement name="Mana left" thresholds={thresholds.manaLeft} />
-      </Rule>
-      <PreparationRule thresholds={thresholds} />
-    </Checklist>
-  );
+type Props = {
+  combatant: Combatant;
+  castEfficiency: CastEfficiency;
+  thresholds: any;
+  // Should be the following when fully converted to TS
+  // thresholds: {
+  //   downtimeSuggestionThresholds: RequirementThresholds;
+  //   manaLeft: RequirementThresholds;
+  //   nonHealingTimeSuggestionThresholds: RequirementThresholds;
+  // };
 };
 
-DisciplinePriestChecklist.propTypes = {
-  castEfficiency: PropTypes.object.isRequired,
-  combatant: PropTypes.shape({
-    hasTalent: PropTypes.func.isRequired,
-  }).isRequired,
-  thresholds: PropTypes.object.isRequired,
-};
+const DisciplinePriestChecklist = ({ combatant, castEfficiency, thresholds }: Props) => (
+  <Checklist>
+    <Rule
+      name="Use core abilities as often as possible"
+      description={
+        <>
+          Using your core abilities as often as possible will typically result in better
+          performance, remember to <SpellLink id={SPELLS.SMITE.id} /> as often as you can!
+        </>
+      }
+    >
+      <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.PENANCE_CAST.id} />
+      {combatant.hasTalent(SPELLS.SCHISM_TALENT.id) && (
+        <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.SCHISM_TALENT.id} />
+      )}
+      {combatant.hasTalent(SPELLS.POWER_WORD_SOLACE_TALENT.id) && (
+        <AbilityRequirement
+          castEfficiency={castEfficiency}
+          spell={SPELLS.POWER_WORD_SOLACE_TALENT.id}
+        />
+      )}
+      {combatant.hasTalent(SPELLS.DIVINE_STAR_TALENT.id) && (
+        <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.DIVINE_STAR_TALENT.id} />
+      )}
+      {combatant.hasTalent(SPELLS.SHADOW_COVENANT_TALENT.id) && (
+        <AbilityRequirement
+          castEfficiency={castEfficiency}
+          spell={SPELLS.SHADOW_COVENANT_TALENT.id}
+        />
+      )}
+    </Rule>
+
+    <Rule
+      name="Use cooldowns effectively"
+      description={
+        <>
+          Cooldowns are an important part of healing, try to use them to counter fight mechanics.
+          For example if a boss has burst damage every 1.5 minutes,{' '}
+          <SpellLink id={SPELLS.RAPTURE.id} /> should be used to counter it.
+        </>
+      }
+    >
+      {!combatant.hasTalent(SPELLS.SPIRIT_SHELL_TALENT.id) && (
+        <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.RAPTURE.id} />
+      )}
+      {!combatant.hasTalent(SPELLS.MINDBENDER_TALENT_SHARED.id) && (
+        <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.SHADOWFIEND.id} />
+      )}
+      {combatant.hasTalent(SPELLS.MINDBENDER_TALENT_SHARED.id) && (
+        <AbilityRequirement
+          castEfficiency={castEfficiency}
+          spell={SPELLS.MINDBENDER_TALENT_SHARED.id}
+        />
+      )}
+      {combatant.hasTalent(SPELLS.HALO_TALENT.id) && (
+        <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.HALO_TALENT.id} />
+      )}
+      {combatant.hasTalent(SPELLS.EVANGELISM_TALENT.id) && (
+        <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.EVANGELISM_TALENT.id} />
+      )}
+      {/* We can't detect race, so disable this when it has never been cast. */}
+      {castEfficiency.getCastEfficiencyForSpellId(SPELLS.ARCANE_TORRENT_MANA1.id) && (
+        <AbilityRequirement
+          castEfficiency={castEfficiency}
+          spell={SPELLS.ARCANE_TORRENT_MANA1.id}
+        />
+      )}
+    </Rule>
+
+    <Rule
+      name="Use your supportive abilities"
+      description="While you shouldn't aim to cast defensives and externals on cooldown, be aware of them and try to use them whenever effective. Not using them at all indicates you might not be aware of them enough or not utilizing them optimally."
+    >
+      <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.PAIN_SUPPRESSION.id} />
+      <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.LEAP_OF_FAITH.id} />
+      <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.DESPERATE_PRAYER.id} />
+    </Rule>
+
+    <Rule
+      name="Try to avoid being inactive for a large portion of the fight"
+      description={
+        <>
+          High downtime is inexcusable, while it may be tempting to not cast and save mana,
+          Discipline's damage fillers such as <SpellLink id={SPELLS.SMITE.id} /> are extremely
+          cheap. You can reduce your downtime by reducing the delay between casting spells,
+          anticipating movement, moving during the GCD, and{' '}
+          <TooltipElement content="You can ignore this while learning Discipline, but contributing DPS whilst healing is a major part of becoming a better than average player.">
+            when you're not healing try to contribute some damage.*
+          </TooltipElement>
+          .
+        </>
+      }
+    >
+      <Requirement
+        name="Non healing time"
+        thresholds={thresholds.nonHealingTimeSuggestionThresholds}
+      />
+      <Requirement name="Downtime" thresholds={thresholds.downtimeSuggestionThresholds} />
+    </Rule>
+
+    <Rule
+      name={
+        <>
+          Use all of your <ResourceLink id={RESOURCE_TYPES.MANA.id} /> effectively
+        </>
+      }
+      description="If you have a large amount of mana left at the end of the fight that's mana you could have turned into healing. Try to use all your mana during a fight. A good rule of thumb is to try to match your mana level with the boss's health."
+    >
+      <Requirement name="Mana left" thresholds={thresholds.manaLeft} />
+    </Rule>
+    <PreparationRule thresholds={thresholds} />
+  </Checklist>
+);
 
 export default DisciplinePriestChecklist;

--- a/src/parser/shared/modules/features/Checklist/AbilityRequirement.tsx
+++ b/src/parser/shared/modules/features/Checklist/AbilityRequirement.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import CastEfficiency from '../../CastEfficiency';
+import GenericCastEfficiencyRequirement from './GenericCastEfficiencyRequirement';
+
+type Props = {
+  castEfficiency: CastEfficiency;
+  spell: number;
+};
+
+const AbilityRequirement = ({ castEfficiency, spell, ...others }: Props) => {
+  const abilityCastEfficiency = castEfficiency.getCastEfficiencyForSpellId(spell);
+  return (
+    abilityCastEfficiency && (
+      <GenericCastEfficiencyRequirement
+        castEfficiency={abilityCastEfficiency}
+        spell={spell}
+        {...others}
+      />
+    )
+  );
+};
+
+export default AbilityRequirement;

--- a/src/parser/shared/modules/features/Checklist/DotUptime.tsx
+++ b/src/parser/shared/modules/features/Checklist/DotUptime.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import SpellLink from 'common/SpellLink';
+import Requirement, {
+  RequirementThresholds,
+} from 'parser/shared/modules/features/Checklist/Requirement';
+
+type Props = {
+  id: number;
+  thresholds: RequirementThresholds;
+};
+
+const DotUptime = ({ id, thresholds }: Props) => (
+  <Requirement
+    name={
+      <>
+        <SpellLink id={id} icon /> uptime
+      </>
+    }
+    thresholds={thresholds}
+  />
+);
+
+export default DotUptime;

--- a/src/parser/shared/modules/features/Checklist/GenericCastEfficiencyRequirement.tsx
+++ b/src/parser/shared/modules/features/Checklist/GenericCastEfficiencyRequirement.tsx
@@ -1,43 +1,38 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import SpellLink from 'common/SpellLink';
 import { captureException } from 'common/errorLogger';
 
 import Requirement from './Requirement';
+import { AbilityCastEfficiency } from '../../CastEfficiency';
+import { ThresholdStyle } from 'parser/core/ParseResults';
+
+type Props = {
+  castEfficiency: AbilityCastEfficiency;
+  isMaxCasts?: boolean;
+  name?: React.ReactNode;
+  spell: number;
+};
 
 /**
  * This is a common requirement for all checklists that uses settings for CastEfficiency to create a Requirement. It shows the spell and your efficiency as performance depending on the configured cast efficiency efficiency thresholds.
  *
  * This requirement is automatically disabled if the ability's CastEfficiency suggestion is disabled (i.e. if the ability's castEfficiency: { suggestion } is unset or false), or the ability is disabled completely. If you set `onlyWithSuggestion` to `false` in the object when creating this requirement you can change this behavior to always show if the ability is enabled, regardless of the CastEfficiency suggestion property being set.
  */
-class GenericCastEfficiencyRequirement extends React.PureComponent {
-  static propTypes = {
-    spell: PropTypes.number.isRequired,
-    name: PropTypes.node,
-    castEfficiency: PropTypes.shape({
-      efficiency: PropTypes.number.isRequired,
-      gotMaxCasts: PropTypes.bool.isRequired,
-      recommendedEfficiency: PropTypes.number.isRequired,
-      averageIssueEfficiency: PropTypes.number.isRequired,
-      majorIssueEfficiency: PropTypes.number.isRequired,
-      casts: PropTypes.any,
-      maxCasts: PropTypes.any,
-    }).isRequired,
-    isMaxCasts: PropTypes.bool,
-  };
-
+class GenericCastEfficiencyRequirement extends React.PureComponent<Props> {
   get thresholds() {
     if (!this.props.castEfficiency) {
-      captureException(new Error(`GenericCastEfficiencyRequirement requires that you pass the castEfficiency object yourself. Spell: ${this.props.spell}`));
+      // Remove exception when everything is in Typescript
+      captureException(
+        new Error(
+          `GenericCastEfficiencyRequirement requires that you pass the castEfficiency object yourself. Spell: ${this.props.spell}`,
+        ),
+      );
       return null;
     }
 
-    if(this.props.isMaxCasts) {
-      const {
-        casts,
-        maxCasts,
-      } = this.props.castEfficiency;
+    if (this.props.isMaxCasts) {
+      const { casts, maxCasts } = this.props.castEfficiency;
 
       return {
         actual: casts,
@@ -47,7 +42,7 @@ class GenericCastEfficiencyRequirement extends React.PureComponent {
           average: maxCasts - 1,
           major: maxCasts - 2,
         },
-        style: 'number',
+        style: ThresholdStyle.NUMBER,
       };
     } else {
       const {
@@ -59,13 +54,13 @@ class GenericCastEfficiencyRequirement extends React.PureComponent {
       } = this.props.castEfficiency;
 
       return {
-        actual: gotMaxCasts ? 1 : efficiency,
+        actual: gotMaxCasts ? 1 : efficiency || 0,
         isLessThan: {
           minor,
           average,
           major,
         },
-        style: 'percentage',
+        style: ThresholdStyle.PERCENTAGE,
       };
     }
   }
@@ -79,11 +74,7 @@ class GenericCastEfficiencyRequirement extends React.PureComponent {
     }
 
     return (
-      <Requirement
-        name={name || <SpellLink id={spell} />}
-        thresholds={thresholds}
-        {...others}
-      />
+      <Requirement name={name || <SpellLink id={spell} />} thresholds={thresholds} {...others} />
     );
   }
 }

--- a/src/parser/warrior/protection/modules/features/Checklist/Component.tsx
+++ b/src/parser/warrior/protection/modules/features/Checklist/Component.tsx
@@ -6,110 +6,131 @@ import ResourceLink from 'common/ResourceLink';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import Checklist from 'parser/shared/modules/features/Checklist';
 import Rule from 'parser/shared/modules/features/Checklist/Rule';
-import Requirement, { RequirementThresholds } from 'parser/shared/modules/features/Checklist/Requirement';
+import AbilityRequirement from 'parser/shared/modules/features/Checklist/AbilityRequirement';
+import Requirement, {
+  RequirementThresholds,
+} from 'parser/shared/modules/features/Checklist/Requirement';
 import PreparationRule from 'parser/shared/modules/features/Checklist/PreparationRule';
-import GenericCastEfficiencyRequirement from 'parser/shared/modules/features/Checklist/GenericCastEfficiencyRequirement';
 import Combatant from 'parser/core/Combatant';
 import CastEfficiency from 'parser/shared/modules/CastEfficiency';
 
 type Props = {
-  castEfficiency: CastEfficiency,
-  combatant: Combatant,
-  thresholds: { [name: string]: RequirementThresholds },
+  castEfficiency: CastEfficiency;
+  combatant: Combatant;
+  thresholds: { [name: string]: RequirementThresholds };
 };
 
-const ProtectionWarriorChecklist = ({ combatant, castEfficiency, thresholds }: Props) => {
-  const AbilityRequirement = (props: { spell: number }) => (
-    <GenericCastEfficiencyRequirement
-      castEfficiency={castEfficiency.getCastEfficiencyForSpellId(props.spell)}
-      {...props}
-    />
-  );
-
-  return (
-    <Checklist>
-      <Rule
-        name="Rotational Spells"
-        description={(
+const ProtectionWarriorChecklist = ({ combatant, castEfficiency, thresholds }: Props) => (
+  <Checklist>
+    <Rule
+      name="Rotational Spells"
+      description={
+        <>
+          Be sure to use <SpellLink id={SPELLS.SHIELD_SLAM.id} /> and{' '}
+          <SpellLink id={SPELLS.THUNDER_CLAP.id} /> on cooldown to maximise your{' '}
+          <ResourceLink id={RESOURCE_TYPES.RAGE.id} /> generation and damage output.
+          <br /> <SpellLink id={SPELLS.REVENGE.id} /> can be used to avoid rage capping and{' '}
+          <SpellLink id={SPELLS.DEVASTATE.id} /> should only be used when every other spell
+          mentioned here is on cooldown.
+        </>
+      }
+    >
+      <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.THUNDER_CLAP.id} />
+      <Requirement
+        name={<SpellLink id={SPELLS.SHIELD_SLAM.id} />}
+        thresholds={thresholds.shieldSlam}
+      />
+      <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.SHIELD_BLOCK.id} />
+      <Requirement
+        name={
           <>
-            Be sure to use <SpellLink id={SPELLS.SHIELD_SLAM.id} /> and <SpellLink id={SPELLS.THUNDER_CLAP.id} /> on cooldown to maximise your <ResourceLink id={RESOURCE_TYPES.RAGE.id} /> generation and damage output.<br /> <SpellLink id={SPELLS.REVENGE.id} /> can be used to avoid rage capping and <SpellLink id={SPELLS.DEVASTATE.id} /> should only be used when every other spell mentioned here is on cooldown.
+            Effective <SpellLink id={SPELLS.SHIELD_BLOCK.id} /> Casts{' '}
           </>
-        )}
-      >
-        <AbilityRequirement spell={SPELLS.THUNDER_CLAP.id} />
-        <Requirement
-          name={(<SpellLink id={SPELLS.SHIELD_SLAM.id} />)}
-          thresholds={thresholds.shieldSlam}
+        }
+        thresholds={thresholds.shieldBlock}
+      />
+      {combatant.hasTalent(SPELLS.BOOMING_VOICE_TALENT.id) && (
+        <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.DEMORALIZING_SHOUT.id} />
+      )}
+      {combatant.hasTalent(SPELLS.DRAGON_ROAR_TALENT.id) && (
+        <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.DRAGON_ROAR_TALENT.id} />
+      )}
+    </Rule>
+
+    <Rule
+      name="Defensive Cooldowns"
+      description={
+        <>
+          Protection warriors have a multitude of defensive spells on a fairly short cooldown. Be
+          sure to use these to further mitigate incoming damage.
+        </>
+      }
+    >
+      <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.SHIELD_WALL.id} />
+      <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.LAST_STAND.id} />
+      <Requirement
+        name={
+          <>
+            Magic damage with <SpellLink id={SPELLS.SPELL_REFLECTION.id} />
+          </>
+        }
+        thresholds={thresholds.spellReflect}
+      />
+      {!combatant.hasTalent(SPELLS.BOOMING_VOICE_TALENT.id) && (
+        <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.DEMORALIZING_SHOUT.id} />
+      )}
+    </Rule>
+
+    <Rule
+      name="Offensive Cooldowns"
+      description={
+        <>
+          Using <SpellLink id={SPELLS.AVATAR_TALENT.id} /> as often as possible is very important
+          because it will increase your overall damage a lot and provides 20{' '}
+          <ResourceLink id={RESOURCE_TYPES.RAGE.id} />.<br /> If you are also using{' '}
+          <SpellLink id={SPELLS.UNSTOPPABLE_FORCE_TALENT.id} /> remember that{' '}
+          <SpellLink id={SPELLS.THUNDER_CLAP.id} /> will have a reduced cooldown so you can use it
+          every other GCD.
+        </>
+      }
+    >
+      <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.AVATAR_TALENT.id} />
+      <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.DEMORALIZING_SHOUT.id} />
+      {combatant.hasTalent(SPELLS.RAVAGER_TALENT_PROTECTION.id) && (
+        <AbilityRequirement
+          castEfficiency={castEfficiency}
+          spell={SPELLS.RAVAGER_TALENT_PROTECTION.id}
         />
-        <AbilityRequirement spell={SPELLS.SHIELD_BLOCK.id} />
-        <Requirement
-          name={(<>Effective <SpellLink id={SPELLS.SHIELD_BLOCK.id} /> Casts </>)}
-          thresholds={thresholds.shieldBlock}
-        />
-        {combatant.hasTalent(SPELLS.BOOMING_VOICE_TALENT.id) && (<AbilityRequirement spell={SPELLS.DEMORALIZING_SHOUT.id} />)}
-        {combatant.hasTalent(SPELLS.DRAGON_ROAR_TALENT.id) && <AbilityRequirement spell={SPELLS.DRAGON_ROAR_TALENT.id} />}
+      )}
+    </Rule>
 
-      </Rule>
+    <Rule
+      name="Don't get too angry"
+      description={
+        <>
+          Minimizing your wasted <ResourceLink id={RESOURCE_TYPES.RAGE.id} /> should be top priority
+          as a protection warrior so be sure to use <SpellLink id={SPELLS.IGNORE_PAIN.id} /> and{' '}
+          <SpellLink id={SPELLS.REVENGE.id} /> to avoid this.
+        </>
+      }
+    >
+      <Requirement name="Lost Rage" thresholds={thresholds.rageDetails} />
+    </Rule>
 
-      <Rule
-        name="Defensive Cooldowns"
-        description={(
-          <>
-            Protection warriors have a multitude of defensive spells on a fairly short cooldown. Be sure to use these to further mitigate incoming damage.
-          </>
-        )}
-      >
-        <AbilityRequirement spell={SPELLS.SHIELD_WALL.id} />
-        <AbilityRequirement spell={SPELLS.LAST_STAND.id} />
-        <Requirement
-          name={(<>Magic damage with <SpellLink id={SPELLS.SPELL_REFLECTION.id} /></>)}
-          thresholds={thresholds.spellReflect}
-        />
-        {!combatant.hasTalent(SPELLS.BOOMING_VOICE_TALENT.id) && (
-          <AbilityRequirement spell={SPELLS.DEMORALIZING_SHOUT.id} />
-        )}
-      </Rule>
+    <Rule
+      name="Utility"
+      description={
+        <>
+          Warriors main raid utility comes from <SpellLink id={SPELLS.RALLYING_CRY.id} /> - it
+          should be used on high damage spikes to help people survive.
+        </>
+      }
+    >
+      <AbilityRequirement castEfficiency={castEfficiency} spell={SPELLS.RALLYING_CRY.id} />
+    </Rule>
 
-      <Rule
-        name="Offensive Cooldowns"
-        description={(
-          <>
-            Using <SpellLink id={SPELLS.AVATAR_TALENT.id} /> as often as possible is very important because it will increase your overall damage a lot and provides 20 <ResourceLink id={RESOURCE_TYPES.RAGE.id} />.<br /> If you are also using <SpellLink id={SPELLS.UNSTOPPABLE_FORCE_TALENT.id} /> remember that <SpellLink id={SPELLS.THUNDER_CLAP.id} /> will have a reduced cooldown so you can use it every other GCD.
-
-          </>
-        )}
-      >
-        <AbilityRequirement spell={SPELLS.AVATAR_TALENT.id} />
-        <AbilityRequirement spell={SPELLS.DEMORALIZING_SHOUT.id} />
-        {combatant.hasTalent(SPELLS.RAVAGER_TALENT_PROTECTION.id) && <AbilityRequirement spell={SPELLS.RAVAGER_TALENT_PROTECTION.id} />}
-
-      </Rule>
-
-      <Rule
-        name="Don't get too angry"
-        description={(
-          <>
-            Minimizing your wasted <ResourceLink id={RESOURCE_TYPES.RAGE.id} /> should be top priority as a protection warrior so be sure to use <SpellLink id={SPELLS.IGNORE_PAIN.id} /> and <SpellLink id={SPELLS.REVENGE.id} /> to avoid this.
-          </>
-        )}
-      >
-        <Requirement name="Lost Rage" thresholds={thresholds.rageDetails} />
-      </Rule>
-
-      <Rule
-        name="Utility"
-        description={(
-          <>
-            Warriors main raid utility comes from <SpellLink id={SPELLS.RALLYING_CRY.id} /> - it should be used on high damage spikes to help people survive.
-          </>
-        )}
-      >
-        <AbilityRequirement spell={SPELLS.RALLYING_CRY.id} />
-      </Rule>
-
-      <PreparationRule thresholds={thresholds} />
-    </Checklist>
-  );
-};
+    <PreparationRule thresholds={thresholds} />
+  </Checklist>
+);
 
 export default ProtectionWarriorChecklist;


### PR DESCRIPTION
When working on the warlock module I did this and decided to split it into another PR.

- Extract AbilityRequirement and DotUptime components (that are copy-pasted across all spec modules)
- Convert GenericCastEfficiencyRequirement to TypeScript.

I am opening this early to get feedback before spreading the changes to all class modules :)