### PR TITLE
Added Protection Paladin Abilities

### DIFF
--- a/src/common/SPELLS/talents/paladin.ts
+++ b/src/common/SPELLS/talents/paladin.ts
@@ -54,6 +54,7 @@ const talents: SpellList = {
   CONSECRATED_GROUND_TALENT: { id: 204054, name: 'Consecrated Ground', icon: 'ability_paladin_righteousvengeance' },
   RIGHTEOUS_PROTECTOR_TALENT: { id: 204074, name: 'Righteous Protector', icon: 'ability_paladin_shieldofthetemplar' },
   FINAL_STAND_TALENT: { id: 204077, name: 'Final Stand', icon: 'spell_holy_crusade' },
+  FINAL_STAND_CAST: {id: 204079, name: 'Final Stand', icon: 'spell_holy_crusade'},
   SANCTIFIED_WRATH_TALENT_PROTECTION: { id: 171648, name: 'Sanctified Wrath', icon: 'ability_paladin_judgementsofthejust' },
 
   //Retribution

--- a/src/parser/paladin/protection/CHANGELOG.tsx
+++ b/src/parser/paladin/protection/CHANGELOG.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { emallson, Hordehobbs, Zeboot } from 'CONTRIBUTORS';
+import { emallson, Hordehobbs, Zeboot, HolySchmidt } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2021, 1, 3), <>Added ability tracking for <SpellLink id={SPELLS.FINAL_STAND_TALENT.id}/> and <SpellLink id={SPELLS.DIVINE_TOLL.id}/> for protection paladin.</>, HolySchmidt),
   change(date(2020, 11, 8), <>Add Overcap analyzer for <SpellLink id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id}/> </>, Hordehobbs),
   change(date(2020, 10, 27), <>Update analyzers for <SpellLink id={SPELLS.RIGHTEOUS_PROTECTOR_TALENT.id}/> and <SpellLink id={SPELLS.SERAPHIM_TALENT.id}/>.</>, Hordehobbs),
   change(date(2020, 10, 26), <>Create analyzers for <SpellLink id={SPELLS.FIRST_AVENGER_TALENT.id} /> and <SpellLink id={SPELLS.MOMENT_OF_GLORY_TALENT.id} />.</>, Hordehobbs),

--- a/src/parser/paladin/protection/CombatLogParser.ts
+++ b/src/parser/paladin/protection/CombatLogParser.ts
@@ -35,6 +35,9 @@ import MomentOfGlory from './modules/talents/MomentOfGlory';
 import HolyPowerTracker from '../shared/holypower/HolyPowerTracker';
 import HolyPowerDetails from '../shared/holypower/HolyPowerDetails';
 
+// Covenant Abilities
+import DivineToll from '../shared/shadowlands/covenants/DivineToll';
+
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     // Core
@@ -76,6 +79,9 @@ class CombatLogParser extends CoreCombatLogParser {
     // HolyPower
     holyPowerTracker: HolyPowerTracker,
     holyPowerDetails: HolyPowerDetails,
+
+    // Covenant Abilities 
+    devineToll: DivineToll,
   };
 }
 

--- a/src/parser/paladin/protection/integrationTests/example.test.ts.snap
+++ b/src/parser/paladin/protection/integrationTests/example.test.ts.snap
@@ -1253,6 +1253,109 @@ exports[`Protection Paladin integration test: example log CastEfficiency matches
               />
             </td>
           </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
+                href="http://wowhead.com/spell=204079"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/spell_holy_crusade.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Final Stand
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.00
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              0
+              /1
+               
+              casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#ff8000",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              0.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            >
+              <trans
+                id="shared.castEfficiency.canBeImproved"
+                message="Can be improved."
+              />
+            </td>
+          </tr>
         </tbody>
         <tbody>
           <tr>
@@ -2828,6 +2931,50 @@ Array [
         values={
           Object {
             "0": "10",
+          }
+        }
+      />
+      )
+    </React.Fragment>,
+  },
+  Object {
+    "details": null,
+    "icon": "spell_holy_crusade",
+    "importance": "major",
+    "issue": <React.Fragment>
+      <Trans
+        components={
+          Object {
+            "0": <ForwardRef
+              id={204079}
+            />,
+          }
+        }
+        id="shared.modules.castEfficiency.suggest"
+        message="Try to cast <0/> more often."
+      />
+       
+      
+    </React.Fragment>,
+    "stat": <React.Fragment>
+      <Trans
+        id="shared.modules.castEfficiency.actual"
+        message="{0} out of {1} possible casts. You kept it on cooldown {2}% of the time."
+        values={
+          Object {
+            "0": 0,
+            "1": 1,
+            "2": "0",
+          }
+        }
+      />
+       (
+      <Trans
+        id="shared.modules.castEfficiency.recommended"
+        message=">{0}% is recommended"
+        values={
+          Object {
+            "0": "60",
           }
         }
       />

--- a/src/parser/paladin/protection/modules/Abilities.js
+++ b/src/parser/paladin/protection/modules/Abilities.js
@@ -1,7 +1,6 @@
 import SPELLS from 'common/SPELLS';
 
 import CoreAbilities from 'parser/core/modules/Abilities';
-import COVENANTS from 'game/shadowlands/COVENANTS';
 //import SpellLink from 'common/SpellLink';
 
 class Abilities extends CoreAbilities {
@@ -241,18 +240,6 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         enabled: combatant.hasTalent(SPELLS.REPENTANCE_TALENT.id),
-      },
-      {
-        spell: SPELLS.DIVINE_TOLL,
-        category: Abilities.SPELL_CATEGORIES.SEMI_DEFENSIVE,
-        cooldown: 180,
-        castEfficiency: {
-          suggestion: true,
-        },
-        gcd: {
-          base: 1500,
-        },
-        enabled: combatant.hasCovenant(COVENANTS.KYRIAN.id),
       },
       {
         spell: SPELLS.FINAL_STAND_CAST,

--- a/src/parser/paladin/protection/modules/Abilities.js
+++ b/src/parser/paladin/protection/modules/Abilities.js
@@ -244,7 +244,7 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.DIVINE_TOLL,
-        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
+        category: Abilities.SPELL_CATEGORIES.SEMI_DEFENSIVE,
         cooldown: 180,
         castEfficiency: {
           suggestion: true,
@@ -253,6 +253,19 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         enabled: combatant.hasCovenant(COVENANTS.KYRIAN.id),
+      },
+      {
+        spell: SPELLS.FINAL_STAND_CAST,
+        category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
+        cooldown: 300 * (combatant.hasTalent(SPELLS.UNBREAKABLE_SPIRIT_TALENT.id) ? 0.7 : 1),
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.6,
+        },
+        gcd: {
+          base: 1500,
+        },
+        enabled: combatant.hasTalent(SPELLS.FINAL_STAND_TALENT.id),
       },
     ];
   }

--- a/src/parser/paladin/protection/modules/Abilities.js
+++ b/src/parser/paladin/protection/modules/Abilities.js
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS';
 
 import CoreAbilities from 'parser/core/modules/Abilities';
-
+import COVENANTS from 'game/shadowlands/COVENANTS';
 //import SpellLink from 'common/SpellLink';
 
 class Abilities extends CoreAbilities {
@@ -241,6 +241,18 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         enabled: combatant.hasTalent(SPELLS.REPENTANCE_TALENT.id),
+      },
+      {
+        spell: SPELLS.DIVINE_TOLL,
+        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
+        cooldown: 180,
+        castEfficiency: {
+          suggestion: true,
+        },
+        gcd: {
+          base: 1500,
+        },
+        enabled: combatant.hasCovenant(COVENANTS.KYRIAN.id),
       },
     ];
   }


### PR DESCRIPTION
Added ability tracking for Divine Toll and Final Stand for protection paladin.

![image](https://user-images.githubusercontent.com/3276248/103487950-eed1d080-4dd6-11eb-9525-ade048cd4299.png)

I believe this are cooldowns that are not effected by haste and that is how I coded them, however I am seeing errors for them being cast early.  I did add the 30% CD reduction from Unbreakable Spirit, but maybe I am missing something here.
> 17:55.359 (module: SpellUsable) Final Stand 204079 was cast while already marked as on cooldown. time passed: 800 cooldown remaining: 209200 expectedDuration: 210000

Here is my [test log](https://www.warcraftlogs.com/reports/wBxNPJ3Tg2v4FVKH#fight=last&type=casts&source=3)