### PR TITLE
[Sub Rogue] Multiple Updates

### DIFF
--- a/src/parser/rogue/subtlety/CHANGELOG.js
+++ b/src/parser/rogue/subtlety/CHANGELOG.js
@@ -6,6 +6,10 @@ import { SpellLink } from 'interface';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2021, 1, 23), "Add GeneratorFollowingVanish analyzer.", Hordehobbs),
+  change(date(2021, 1, 23), "Update CastsInShadowDance analyzer for proper value of max possible casts.", Hordehobbs),
+  change(date(2021, 1, 23), <>Remove <SpellLink id={SPELLS.VANISH.id} /> as an offensive CD from checklist. </>, Hordehobbs),
+  change(date(2021, 1, 23), "Update DeepeningShadows analyzer for new CDR values.", Hordehobbs),
   change(date(2020, 12, 27), <>Added analyzer for tracking <SpellLink id={SPELLS.VANISH.id} /> usage in conjunction with refreshing <SpellLink id={SPELLS.FIND_WEAKNESS.id} />. </>, Hordehobbs),
   change(date(2020, 12, 21), 'Minor update to suggestions', Tyndi),
   change(date(2020, 12, 18), <> Fixed an issue where the analyzer couldn't reduce the cooldown of <SpellLink id={SPELLS.SERRATED_BONE_SPIKE.id} />. </>, Putro),

--- a/src/parser/rogue/subtlety/CombatLogParser.tsx
+++ b/src/parser/rogue/subtlety/CombatLogParser.tsx
@@ -2,6 +2,8 @@ import CoreCombatLogParser from 'parser/core/CombatLogParser';
 
 import ArcaneTorrent from 'parser/shared/modules/racials/bloodelf/ArcaneTorrent';
 
+import GeneratorFollowingVanish from 'parser/rogue/subtlety/modules/core/GeneratorFollowingVanish';
+
 import Abilities from './modules/Abilities';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import Checklist from './modules/features/checklist/Module';
@@ -78,6 +80,7 @@ class CombatLogParser extends CoreCombatLogParser {
     castsInShadowDance: CastsInShadowDance,
     castsInStealth: CastsInStealth,
     vanishFindWeakness: VanishFindWeakness,
+    generatorFollowingVanish: GeneratorFollowingVanish,
 
     //Talents
     darkShadowContribution: DarkShadowContribution,

--- a/src/parser/rogue/subtlety/modules/core/CastsInShadowDance.tsx
+++ b/src/parser/rogue/subtlety/modules/core/CastsInShadowDance.tsx
@@ -15,6 +15,9 @@ import CastsInStealthBase from './CastsInStealthBase';
 import DanceDamageTracker from './DanceDamageTracker';
 
 class CastsInShadowDance extends CastsInStealthBase {
+  BASE_MAX_CASTS: number = 8;
+  BONUS_SUBTERFUGE_CASTS: number = 1;
+
   static dependencies = {
     damageTracker: DamageTracker,
     danceDamageTracker: DanceDamageTracker,
@@ -26,7 +29,7 @@ class CastsInShadowDance extends CastsInStealthBase {
   constructor(options: Options & { danceDamageTracker: DanceDamageTracker }) {
     super(options);
 
-    this.maxCastsPerStealth = 5 + (this.selectedCombatant.hasTalent(SPELLS.SUBTERFUGE_TALENT.id) ? 1 : 0);
+    this.maxCastsPerStealth = this.BASE_MAX_CASTS + (this.selectedCombatant.hasTalent(SPELLS.SUBTERFUGE_TALENT.id) ? this.BONUS_SUBTERFUGE_CASTS : 0);
 
     this.stealthCondition = 'Shadow Dance';
 

--- a/src/parser/rogue/subtlety/modules/core/DeepeningShadows.ts
+++ b/src/parser/rogue/subtlety/modules/core/DeepeningShadows.ts
@@ -9,6 +9,9 @@ import Events, { SpendResourceEvent } from 'parser/core/Events';
  * Your finishing moves reduce the remaining cooldown on Shadow Dance by 1.5 sec per combo point spent.
  */
 class DeepeningShadows extends Analyzer {
+  BASE_CDR: number = 1000;
+  ENVELOPING_SHADOWS_EXTRA_CDR: number = 500;
+
   static dependencies = {
     spellUsable: SpellUsable,
   };
@@ -17,7 +20,7 @@ class DeepeningShadows extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.cdrPerComboPoint = 1500 + (this.selectedCombatant.hasTalent(SPELLS.ENVELOPING_SHADOWS_TALENT.id) ? 1000 : 0);
+    this.cdrPerComboPoint = this.BASE_CDR + (this.selectedCombatant.hasTalent(SPELLS.ENVELOPING_SHADOWS_TALENT.id) ? this.ENVELOPING_SHADOWS_EXTRA_CDR : 0);
     this.addEventListener(Events.SpendResource.by(SELECTED_PLAYER), this.onSpendResource);
   }
 

--- a/src/parser/rogue/subtlety/modules/core/GeneratorFollowingVanish.tsx
+++ b/src/parser/rogue/subtlety/modules/core/GeneratorFollowingVanish.tsx
@@ -1,0 +1,111 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import Events, { CastEvent } from 'parser/core/Events';
+import { NumberThreshold, ThresholdStyle, When } from 'parser/core/ParseResults';
+import React from 'react';
+import SpellLink from 'common/SpellLink';
+import SpellIcon from 'common/SpellIcon';
+import Statistic from 'interface/statistics/Statistic';
+import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+import { formatNumber } from 'common/format';
+import BoringSpellValue from 'interface/statistics/components/BoringSpellValue';
+
+class GeneratorFollowingVanish extends Analyzer {
+  generatorSpells = [
+    SPELLS.BACKSTAB.id,
+    SPELLS.SHADOWSTRIKE.id,
+    SPELLS.SHURIKEN_STORM.id,
+    SPELLS.SHURIKEN_TOSS.id,
+  ];
+
+  lastCastPtr: CastEvent | null = null;
+  badFollowingVanishCasts: Array<[CastEvent, CastEvent]> = [];
+  goodFollowingVanishCasts: Array<[CastEvent, CastEvent]> = [];
+
+  constructor(options: Options) {
+    super(options);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.trackAllCasts);
+  }
+
+  trackAllCasts(event: CastEvent) {
+    if (this.lastCastPtr !== null && this.lastCastPtr.ability.guid === SPELLS.VANISH.id) {
+      if (this.generatorSpells.includes(event.ability.guid)) {
+        this.goodFollowingVanishCasts.push([this.lastCastPtr, event]);
+      } else {
+        this.badFollowingVanishCasts.push([this.lastCastPtr, event]);
+      }
+    }
+    this.lastCastPtr = event;
+  }
+
+  get suggestionsThreshold(): NumberThreshold {
+    return {
+      actual: this.badFollowingVanishCasts.length,
+      isGreaterThan: {
+        minor: 1,
+        average: 2,
+        major: 3,
+      },
+      style: ThresholdStyle.NUMBER,
+    };
+  }
+
+  suggestions(when: When) {
+    when(this.suggestionsThreshold)
+      .addSuggestion((suggest, actual, recommended) => suggest(
+        <>
+          Try to avoid casting non-generator spells as the cast following <SpellLink id={SPELLS.VANISH.id} />.
+        </>)
+        .icon(SPELLS.SHADOWSTRIKE.icon)
+        .actual(`You cast ${this.badFollowingVanishCasts.length} non-generators following a Vanish.`)
+        .recommended(`Try to only cast generators following a Vanish.`)
+      );
+  }
+
+  statistic(): React.ReactNode {
+    const tableEntries: React.ReactNode[] = this.badFollowingVanishCasts.map((castPair, idx) => (
+        <>
+          <tr key={idx}>
+            <td>{this.owner.formatTimestamp(castPair[0].timestamp)}</td>
+            <td><SpellIcon id={castPair[1].ability.guid}/></td>
+            <td>{this.owner.formatTimestamp(castPair[1].timestamp)}</td>
+          </tr>
+        </>
+      ));
+   return (
+     <>
+       <Statistic
+         position={STATISTIC_ORDER.DEFAULT}
+         size="flexible"
+         category={STATISTIC_CATEGORY.GENERAL}
+         tooltip={(
+           <>
+             You cast non-generators following <SpellLink id={SPELLS.VANISH.id} /> {formatNumber(this.badFollowingVanishCasts.length)} times and generators {formatNumber(this.goodFollowingVanishCasts.length)} times.
+           </>
+         )}
+         dropdown={(
+           <>
+             <table className="table table-condensed">
+               <thead>
+                 <tr>
+                   <th>Vanish Timestamp</th>
+                   <th>Bad Spell Cast</th>
+                   <th>Bad Cast Timestamp</th>
+                 </tr>
+               </thead>
+               <tbody>
+                 {tableEntries}
+               </tbody>
+             </table>
+           </>
+         )}
+         >
+         <BoringSpellValue spell={SPELLS.VANISH} value={`${this.badFollowingVanishCasts.length} non-generators cast`} label="Non-generators Cast After Vanish" />
+       </Statistic>
+     </>
+   );
+  }
+}
+
+export default GeneratorFollowingVanish;

--- a/src/parser/rogue/subtlety/modules/core/GeneratorFollowingVanish.tsx
+++ b/src/parser/rogue/subtlety/modules/core/GeneratorFollowingVanish.tsx
@@ -3,13 +3,13 @@ import SPELLS from 'common/SPELLS';
 import Events, { CastEvent } from 'parser/core/Events';
 import { NumberThreshold, ThresholdStyle, When } from 'parser/core/ParseResults';
 import React from 'react';
-import SpellLink from 'common/SpellLink';
-import SpellIcon from 'common/SpellIcon';
-import Statistic from 'interface/statistics/Statistic';
-import STATISTIC_ORDER from 'interface/others/STATISTIC_ORDER';
-import STATISTIC_CATEGORY from 'interface/others/STATISTIC_CATEGORY';
+import SpellLink from 'interface/SpellLink';
+import SpellIcon from 'interface/SpellIcon';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import { formatNumber } from 'common/format';
-import BoringSpellValue from 'interface/statistics/components/BoringSpellValue';
+import BoringSpellValue from 'parser/ui/BoringSpellValue';
 
 class GeneratorFollowingVanish extends Analyzer {
   generatorSpells = [

--- a/src/parser/rogue/subtlety/modules/features/checklist/Component.tsx
+++ b/src/parser/rogue/subtlety/modules/features/checklist/Component.tsx
@@ -32,7 +32,6 @@ const SubRogueChecklist = ({ combatant, castEfficiency, thresholds }: ChecklistP
       >
         <AbilityRequirement spell={SPELLS.SHADOW_DANCE.id} />
         <AbilityRequirement spell={SPELLS.SYMBOLS_OF_DEATH.id} />
-        <AbilityRequirement spell={SPELLS.VANISH.id} />
         <AbilityRequirement spell={SPELLS.SHADOW_BLADES.id} />
         {combatant.hasTalent(SPELLS.SECRET_TECHNIQUE_TALENT.id) && (
           <AbilityRequirement spell={SPELLS.SECRET_TECHNIQUE_TALENT.id} />


### PR DESCRIPTION
## Updates
### Deepening Shadows Analyzer
- Update to new cooldown reduction values. Previous values were incorrect (Had 1.5s CDR base with 1s increase from Enveloping Shadows talent rather than the correct [1s base](https://www.wowhead.com/spell=185314/deepening-shadows) with [0.5s from Enveloping Shadows](https://www.wowhead.com/spell=238104/enveloping-shadows).

### Checklist
- Remove Vanish as an offensive CD given that it should not be cast on CD but rather in conjunction with refreshing Find Weakness on the target.

### Casts In Shadow Dance Analyzer
- Update for the correct number of maximum possible casts in Shadow Dance. Previous value failed to take into account GCD changes for Rogue.
- Resolves #4224 
- Screenshot:
![image](https://user-images.githubusercontent.com/6363390/105599712-71e8a580-5d49-11eb-83f5-7f8281140197.png)


### GeneratorFollowingVanish Analyzer
- Adds analyzer to ensure that a combo-point generating ability is cast following Vanish rather than a finisher.
- Resolves #4228 
- Screenshot:
![image](https://user-images.githubusercontent.com/6363390/105599490-5f6e6c00-5d49-11eb-93f7-87b55f28078e.png)

## Testing
`yarn lint`
`yarn test:integration`
`yarn build`
Log used in testing: https://www.warcraftlogs.com/reports/jCwvTdy2kmtMrz7L/#fight=3&source=7