### PR TITLE
[BrM] Added extra CDR to SSLK stat tooltip

### DIFF
--- a/src/parser/monk/brewmaster/CHANGELOG.js
+++ b/src/parser/monk/brewmaster/CHANGELOG.js
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2021, 1, 23), <>Add wasted cooldown avoided to <SpellLink id={SPELLS.STORMSTOUTS_LAST_KEG.id} /> statistic tooltip.</>, emallson),
   change(date(2021, 1, 18), <>Add support for <SpellLink id={SPELLS.STORMSTOUTS_LAST_KEG.id} />.</>, Matardarix),
   change(date(2021, 1, 16), <>Added <SpellLink id={SPELLS.WALK_WITH_THE_OX.id} /> cooldown reduction.</>, emallson),
   change(date(2021, 1, 16), <>Added <SpellLink id={SPELLS.WEAPONS_OF_ORDER_CAST.id} />, <SpellLink id={SPELLS.BONEDUST_BREW_CAST.id} /> and <SpellLink id={SPELLS.FAELINE_STOMP_CAST.id} /> to Brewmaster ability list.</>, emallson),

--- a/src/parser/monk/brewmaster/modules/shadowlands/legendaries/StormstoutsLastKeg.tsx
+++ b/src/parser/monk/brewmaster/modules/shadowlands/legendaries/StormstoutsLastKeg.tsx
@@ -46,6 +46,22 @@ class StormstoutsLastKeg extends Analyzer {
     this.damage += calculateEffectiveDamage(event, STORMSTOUTS_LK_MODIFIER);
   }
 
+  // The idea here is that we can look at the remaining cooldown after a cast
+  // to determine how much time the spell would have spent off cooldown without
+  // the legendary. For example: if you cast Keg Smash 400ms after the first
+  // charge comes off cooldown, then after the cast (when this event fires)
+  // `expectedDuration - remaining = 400`, which is the amount of time it would
+  // have wasted if not for this legendary.
+  //
+  // There is a special case for getting an entire extra cast off, because in
+  // that scenario the remaining CD is equal to the expected total CD of the
+  // cast.
+  //
+  // TODO: There is a pathological case that I havent figured out how to solve
+  // yet: if the player casts Keg Smash exactly at the 2nd charge every time,
+  // then they waste exactly 1 cast. The current implementation will report
+  // them "preventing" n wasted casts. As long as players are trying to keep it
+  // at 0 charges, this doesn't occur.
   trackExtraCD(_event: CastEvent) {
     const { expectedDuration, chargesOnCooldown } = this.spellUsable._currentCooldowns[SPELLS.KEG_SMASH.id];
     const remaining = this.spellUsable.cooldownRemaining(SPELLS.KEG_SMASH.id);

--- a/src/parser/monk/brewmaster/modules/shadowlands/legendaries/StormstoutsLastKeg.tsx
+++ b/src/parser/monk/brewmaster/modules/shadowlands/legendaries/StormstoutsLastKeg.tsx
@@ -9,13 +9,29 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
-import Events, { DamageEvent } from 'parser/core/Events';
+import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import { formatDuration } from 'common/format';
+
+import BrewCDR from '../../core/BrewCDR';
+import Abilities from '../../Abilities';
 
 /**
  * Keg Smash deals 30% additional damage, and has 1 additional charge.
  */
 class StormstoutsLastKeg extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+    brewCdr: BrewCDR,
+    spellUsable: SpellUsable,
+  };
+
+  protected spellUsable!: SpellUsable;
+  protected brewCdr!: BrewCDR;
+  protected abilities!: Abilities;
+
   damage = 0;
+  extraCD = 0;
 
   constructor(options: Options) {
     super(options);
@@ -23,10 +39,27 @@ class StormstoutsLastKeg extends Analyzer {
     this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.STORMSTOUTS_LAST_KEG.bonusID);
 
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.KEG_SMASH), this.onDamage);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.KEG_SMASH), this.trackExtraCD);
   }
 
   onDamage(event: DamageEvent) {
     this.damage += calculateEffectiveDamage(event, STORMSTOUTS_LK_MODIFIER);
+  }
+
+  trackExtraCD(_event: CastEvent) {
+    const { expectedDuration, chargesOnCooldown } = this.spellUsable._currentCooldowns[SPELLS.KEG_SMASH.id];
+    const remaining = this.spellUsable.cooldownRemaining(SPELLS.KEG_SMASH.id);
+    // if we ever get a 3rd charge this will need revisiting
+    if (chargesOnCooldown === 1) {
+      this.extraCD += remaining;
+    } else {
+      this.extraCD += expectedDuration - remaining;
+    }
+  }
+
+  avgCooldown() {
+    const ability = this.abilities.getAbility(SPELLS.KEG_SMASH.id)!;
+    return ability.getCooldown(this.brewCdr.meanHaste);
   }
 
   statistic() {
@@ -36,7 +69,8 @@ class StormstoutsLastKeg extends Analyzer {
         size="flexible"
         tooltip={(
           <>
-            This statistic shows the damage gained from the increased Keg Smash damage. It does not reflect the potential damage gain from having 2 charges of Keg Smashs.
+          <p>This statistic shows the damage gained from the increased Keg Smash damage. It does not reflect the potential damage gain from having 2 charges of Keg Smashs.</p>
+            <p>This legendary prevented {formatDuration(this.extraCD / 1000)} of wasted cooldown time, equal to about {(this.extraCD / 1000 / this.avgCooldown()).toFixed(1)} extra casts of Keg Smash. This includes the initial extra cast.</p>
           </>
         )}
         category={STATISTIC_CATEGORY.ITEMS}


### PR DESCRIPTION
See the (extensive) doc comment for the methodology. It is implemented this way to track actual benefit due to fight downtime and rotational errors.