### PR TITLE
[Priest] Add 2 shadow legendaries and 1 priest legendary

### DIFF
--- a/src/common/SPELLS/shadowlands/legendaries/priest.ts
+++ b/src/common/SPELLS/shadowlands/legendaries/priest.ts
@@ -21,7 +21,23 @@ const legendaries: SpellList<LegendarySpell> = {
     bonusID: 6973,
   },
   //endregion
-
+  // https://www.warcraftlogs.com/reports/NKcbdPzMXRJ1Drk6#fight=9&type=damage-done&source=11
+  ETERNAL_CALL_TO_THE_VOID: {
+    id: 336214,
+    name: 'Eternall Call to the Void',
+    icon: 'achievement_boss_yoggsaron_01',
+    bonusID: 6983,
+  },
+  ETERNAL_CALL_TO_THE_VOID_MIND_FLAY_DAMAGE: {
+    id: 193473,
+    name: 'Mind Flay',
+    icon: 'spell_shadow_siphonmana',
+  },
+  ETERNAL_CALL_TO_THE_VOID_MIND_SEAR_DAMAGE: {
+    id: 344752,
+    name: 'Mind Sear',
+    icon: 'spell_shadow_siphonmana',
+  },
   //region Shadow
 
   //endregion

--- a/src/common/SPELLS/shadowlands/legendaries/priest.ts
+++ b/src/common/SPELLS/shadowlands/legendaries/priest.ts
@@ -38,6 +38,13 @@ const legendaries: SpellList<LegendarySpell> = {
     name: 'Mind Sear',
     icon: 'spell_shadow_siphonmana',
   },
+  // https://www.warcraftlogs.com/reports/NKcbdPzMXRJ1Drk6#fight=9&type=damage-done&source=6
+  TALBADARS_STRATAGEM: {
+    id: 342415,
+    name: "Talbadar's Stratagem",
+    icon: 'spell_fire_twilightcano',
+    bonusID: 7162,
+  },
   //region Shadow
 
   //endregion

--- a/src/common/SPELLS/shadowlands/legendaries/priest.ts
+++ b/src/common/SPELLS/shadowlands/legendaries/priest.ts
@@ -50,7 +50,12 @@ const legendaries: SpellList<LegendarySpell> = {
   //endregion
 
   //region Shared
-
+  TWINS_OF_THE_SUN_PRIESTESS: {
+    id: 336897,
+    name: 'Twins of the Sun Priestess',
+    icon: 'spell_fire_felflamering_red',
+    bonusID: 7002,
+  },
   //endregion
 } as const;
 export default legendaries;

--- a/src/parser/priest/discipline/CHANGELOG.tsx
+++ b/src/parser/priest/discipline/CHANGELOG.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { Khadaj, Ogofo, Oratio, Reglitch, VMakaev, Zeboot } from 'CONTRIBUTORS';
+import { Adoraci, Khadaj, Ogofo, Oratio, Reglitch, VMakaev, Zeboot } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2021, 1, 23), <>Added <SpellLink id={SPELLS.TWINS_OF_THE_SUN_PRIESTESS.id} /> legendary.</>, Adoraci),
   change(date(2020, 12, 28), <>Fixing <SpellLink id={SPELLS.BOON_OF_THE_ASCENDED.id} /></>, Khadaj),
   change(date(2020, 12, 28), <>Adding support for <SpellLink id={SPELLS.FAE_GUARDIANS.id} /></>, Khadaj),
   change(date(2020, 12, 28), <>Adding support for <SpellLink id={SPELLS.UNHOLY_NOVA.id} /></>, Khadaj),

--- a/src/parser/priest/discipline/CombatLogParser.ts
+++ b/src/parser/priest/discipline/CombatLogParser.ts
@@ -46,6 +46,8 @@ import FaeGuardians from '../shared/modules/shadowlands/covenants/FaeGuardians';
 
 import ShiningRadiance from './modules/shadowlands/conduits/ShiningRadiance';
 
+import TwinsOfTheSunPriestess from '../shared/modules/shadowlands/legendaries/TwinsOfTheSunPriestess';
+
 import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from './constants';
 
 class CombatLogParser extends CoreCombatLogParser {
@@ -105,6 +107,9 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Conduits
     shiningRadiance: ShiningRadiance,
+
+    // Legendaries
+    twinsOfTheSunPriestess: TwinsOfTheSunPriestess,
   };
 }
 

--- a/src/parser/priest/holy/CHANGELOG.tsx
+++ b/src/parser/priest/holy/CHANGELOG.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { Khadaj, niseko, Zeboot } from 'CONTRIBUTORS';
+import { Adoraci, Khadaj, niseko, Zeboot } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import SPELLS from 'common/SPELLS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2021, 1, 23), <>Added <SpellLink id={SPELLS.TWINS_OF_THE_SUN_PRIESTESS.id} /> legendary.</>, Adoraci),
   change(date(2020, 12, 28), <>Adding support for <SpellLink id={SPELLS.BOON_OF_THE_ASCENDED.id} /></>, Khadaj),
   change(date(2020, 12, 28), <>Adding support for <SpellLink id={SPELLS.MINDGAMES.id} /></>, Khadaj),
   change(date(2020, 12, 28), <>Adding support for <SpellLink id={SPELLS.FAE_GUARDIANS.id} /></>, Khadaj),

--- a/src/parser/priest/holy/CombatLogParser.tsx
+++ b/src/parser/priest/holy/CombatLogParser.tsx
@@ -51,6 +51,8 @@ import ManaTracker from '../../core/healingEfficiency/ManaTracker';
 // Items
 import HarmoniousApparatus from './modules/shadowlands/items/HarmoniousApparatus';
 import DivineImage from './modules/shadowlands/items/DivineImage';
+import TwinsOfTheSunPriestess from '../shared/modules/shadowlands/legendaries/TwinsOfTheSunPriestess';
+
 
 // Conduits
 import ResonantWords from './modules/shadowlands/conduits/ResonantWords';
@@ -143,6 +145,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Items
     harmoniousApparatus: HarmoniousApparatus,
     divineImage: DivineImage,
+    twinsOfTheSunPriestess: TwinsOfTheSunPriestess,
 
     // Conduits
     resonantWords: ResonantWords,

--- a/src/parser/priest/shadow/CHANGELOG.tsx
+++ b/src/parser/priest/shadow/CHANGELOG.tsx
@@ -9,6 +9,9 @@ import { ResourceLink } from 'interface';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 export default [
+  change(date(2021, 1, 23), <>Added <SpellLink id={SPELLS.ETERNAL_CALL_TO_THE_VOID.id} /> legendary.</>, Adoraci),
+  change(date(2021, 1, 23), <>Added <SpellLink id={SPELLS.TALBADARS_STRATAGEM.id} /> legendary.</>, Adoraci),
+  change(date(2021, 1, 23), <>Added <SpellLink id={SPELLS.TWINS_OF_THE_SUN_PRIESTESS.id} /> legendary.</>, Adoraci),
   change(date(2021, 1, 23), <>Updated checklist to include <SpellLink id={SPELLS.POWER_INFUSION.id} />.</>, Adoraci),
   change(date(2021, 1, 23), <>Added support for <SpellLink id={SPELLS.SHADOW_WORD_DEATH.id} />.</>, Adoraci),
   change(date(2021, 1, 23), <>Added <ResourceLink id={RESOURCE_TYPES.INSANITY.id} /> tracker and suggestions.</>, Adoraci),

--- a/src/parser/priest/shadow/CombatLogParser.tsx
+++ b/src/parser/priest/shadow/CombatLogParser.tsx
@@ -46,6 +46,8 @@ import DissonantEchoes from './modules/shadowlands/conduits/DissonantEchoes';
 // legendaries
 import EternalCallToTheVoid from './modules/shadowlands/legendaries/EternalCallToTheVoid';
 import TalbadarsStratagem from './modules/shadowlands/legendaries/TalbadarsStratagem';
+import TwinsOfTheSunPriestess from '../shared/modules/shadowlands/legendaries/TwinsOfTheSunPriestess';
+
 class CombatLogParser extends MainCombatLogParser {
   static specModules = {
     // core
@@ -99,6 +101,7 @@ class CombatLogParser extends MainCombatLogParser {
     // legendaries:
     eternalCallToTheVoid: EternalCallToTheVoid,
     talbadarsStratagem: TalbadarsStratagem,
+    twinsOfTheSunPriestess: TwinsOfTheSunPriestess,
   };
 }
 

--- a/src/parser/priest/shadow/CombatLogParser.tsx
+++ b/src/parser/priest/shadow/CombatLogParser.tsx
@@ -33,8 +33,6 @@ import AuspiciousSpirits from './modules/talents/AuspiciousSpirits';
 // normalizers
 import ShadowfiendNormalizer from '../shared/normalizers/ShadowfiendNormalizer';
 import Buffs from './modules/features/Buffs';
-// conduits
-import DissonantEchoes from './modules/shadowlands/conduits/DissonantEchoes';
 
 // Covenants
 import UnholyNova from '../shared/modules/shadowlands/covenants/UnholyNova';
@@ -42,6 +40,11 @@ import Mindgames from '../shared/modules/shadowlands/covenants/Mindgames';
 import BoonOfTheAscended from '../shared/modules/shadowlands/covenants/BoonOfTheAscended';
 import FaeGuardians from '../shared/modules/shadowlands/covenants/FaeGuardians';
 
+// conduits
+import DissonantEchoes from './modules/shadowlands/conduits/DissonantEchoes';
+
+// legendaries
+import EternalCallToTheVoid from './modules/shadowlands/legendaries/EternalCallToTheVoid';
 class CombatLogParser extends MainCombatLogParser {
   static specModules = {
     // core
@@ -91,6 +94,9 @@ class CombatLogParser extends MainCombatLogParser {
 
     // conduits:
     dissonantEchoes: DissonantEchoes,
+
+    // legendaries:
+    eternalCallToTheVoid: EternalCallToTheVoid,
   };
 }
 

--- a/src/parser/priest/shadow/CombatLogParser.tsx
+++ b/src/parser/priest/shadow/CombatLogParser.tsx
@@ -45,6 +45,7 @@ import DissonantEchoes from './modules/shadowlands/conduits/DissonantEchoes';
 
 // legendaries
 import EternalCallToTheVoid from './modules/shadowlands/legendaries/EternalCallToTheVoid';
+import TalbadarsStratagem from './modules/shadowlands/legendaries/TalbadarsStratagem';
 class CombatLogParser extends MainCombatLogParser {
   static specModules = {
     // core
@@ -97,6 +98,7 @@ class CombatLogParser extends MainCombatLogParser {
 
     // legendaries:
     eternalCallToTheVoid: EternalCallToTheVoid,
+    talbadarsStratagem: TalbadarsStratagem,
   };
 }
 

--- a/src/parser/priest/shadow/integrationTests/example.test.ts.snap
+++ b/src/parser/priest/shadow/integrationTests/example.test.ts.snap
@@ -4381,6 +4381,66 @@ exports[`Shadow Priest integration test: example log DistanceMoved matches the s
 </div>
 `;
 
+exports[`Shadow Priest integration test: example log EternalCallToTheVoid matches the statistic snapshot 1`] = `
+<div
+  className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
+>
+  <div
+    category="ITEMS"
+    className="panel statistic flexible "
+  >
+    <div
+      className="panel-body"
+    >
+      <div
+        className="pad boring-text "
+      >
+        <label>
+          <a
+            className="spell-link-text"
+            href="http://wowhead.com/spell=336214"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <img
+              alt="Eternall Call to the Void"
+              className="icon game "
+              src="//render-us.worldofwarcraft.com/icons/56/achievement_boss_yoggsaron_01.jpg"
+            />
+          </a>
+           
+          <a
+            className="spell-link-text"
+            href="http://wowhead.com/spell=336214"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Eternall Call to the Void
+          </a>
+        </label>
+        <div
+          className="value"
+        >
+          <img
+            alt="Damage"
+            className="icon"
+            src="/img/sword.png"
+          />
+           
+          86
+           DPS
+           
+          <small>
+            1.93
+             % of total
+          </small>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Shadow Priest integration test: example log FortressOfTheMind matches the statistic snapshot 1`] = `
 <div
   className="col-lg-3 col-md-4 col-sm-6 col-xs-12"

--- a/src/parser/priest/shadow/modules/shadowlands/legendaries/EternalCallToTheVoid.tsx
+++ b/src/parser/priest/shadow/modules/shadowlands/legendaries/EternalCallToTheVoid.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import Events, { DamageEvent } from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import { SELECTED_PLAYER_PET } from 'parser/core/EventFilter';
+
+class EternalCallToTheVoid extends Analyzer {
+
+  damage = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.ETERNAL_CALL_TO_THE_VOID.bonusID);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER_PET).spell(SPELLS.ETERNAL_CALL_TO_THE_VOID_MIND_FLAY_DAMAGE), this.onDamage);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER_PET).spell(SPELLS.ETERNAL_CALL_TO_THE_VOID_MIND_SEAR_DAMAGE), this.onDamage);
+  }
+
+  onDamage(event: DamageEvent) {
+    this.damage += event.amount + (event.absorbed || 0);
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        category={STATISTIC_CATEGORY.ITEMS}
+        size="flexible"
+      >
+        <BoringSpellValueText spell={SPELLS.ETERNAL_CALL_TO_THE_VOID}>
+          <ItemDamageDone amount={this.damage} />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default EternalCallToTheVoid;

--- a/src/parser/priest/shadow/modules/shadowlands/legendaries/TalbadarsStratagem.tsx
+++ b/src/parser/priest/shadow/modules/shadowlands/legendaries/TalbadarsStratagem.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import Events, { DamageEvent } from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import { SELECTED_PLAYER } from 'parser/core/EventFilter';
+import EnemyInstances from 'parser/shared/modules/EnemyInstances';
+import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
+
+const TALBADARS_STRATAGEM_INCREASE = 0.6;
+
+class TalbadarsStratagem extends Analyzer {
+  static dependencies = {
+    enemies: EnemyInstances,
+  };
+  protected enemies!: EnemyInstances;
+
+  bonusDamage = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.TALBADARS_STRATAGEM.bonusID);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.MIND_BLAST), this.onDamage);
+  }
+
+  onDamage(event: DamageEvent) {
+    const enemy = this.enemies.getEntity(event);
+    if (!enemy || !enemy.hasBuff(SPELLS.SHADOW_WORD_PAIN.id) || !enemy.hasBuff(SPELLS.SHADOW_WORD_PAIN.id) || !enemy.hasBuff(SPELLS.DEVOURING_PLAGUE.id)) {
+      return;
+    }
+    this.bonusDamage += calculateEffectiveDamage(event, TALBADARS_STRATAGEM_INCREASE);
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        category={STATISTIC_CATEGORY.ITEMS}
+        size="flexible"
+      >
+        <BoringSpellValueText spell={SPELLS.TALBADARS_STRATAGEM}>
+          <ItemDamageDone amount={this.bonusDamage} />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default TalbadarsStratagem;

--- a/src/parser/priest/shared/modules/shadowlands/legendaries/TwinsOfTheSunPriestess.tsx
+++ b/src/parser/priest/shared/modules/shadowlands/legendaries/TwinsOfTheSunPriestess.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import Events, { CastEvent } from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import { SELECTED_PLAYER } from 'parser/core/EventFilter';
+import { formatNumber } from 'common/format';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import { SpellLink } from 'interface';
+import { t } from '@lingui/macro';
+
+class TwinsOfTheSunPriestess extends Analyzer {
+
+  // More could probably be done with this to analyze what the person you used it on did.
+  // this is at least a base of making sure they're using PI on other players and not wasting it on themself.
+
+  goodCasts = 0;
+  badCasts = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.TWINS_OF_THE_SUN_PRIESTESS.bonusID);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.POWER_INFUSION), this.onCast);
+  }
+
+  get totalCasts() {
+    return this.badCasts + this.goodCasts;
+  }
+
+  onCast(event: CastEvent) {
+    if (event.targetID === event.sourceID) {
+      this.badCasts += 1;
+    } else {
+      this.goodCasts += 1;
+    }
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.badCasts,
+      isGreaterThan: {
+        minor: 0,
+        average: 0,
+        major: 1,
+      },
+      style: ThresholdStyle.NUMBER,
+    };
+  }
+
+  suggestions(when: When) {
+    const castsPlural = this.badCasts === 1 ? 'cast' : 'casts';
+    when(this.suggestionThresholds)
+      .addSuggestion((suggest, actual, recommended) => suggest(<>You had {this.badCasts} bad {castsPlural} of <SpellLink id={SPELLS.POWER_INFUSION.id} /> by using it on yourself. When taking this legendary, make sure to always use it on an ally. By using it on yourself, you lose out on a free <SpellLink id={SPELLS.POWER_INFUSION.id} /> for a raid member.</>)
+      .icon(SPELLS.TWINS_OF_THE_SUN_PRIESTESS.icon)
+      .actual(
+        t({
+          id:'priest.shared.legendaries.twinsOfTheSunPriestess.efficiency',
+          message: `You had ${this.badCasts} ${castsPlural} of Power Infusion on yourself.`
+        })
+      )
+      .recommended(`No casts on yourself is recommended.`));
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        category={STATISTIC_CATEGORY.ITEMS}
+        size="flexible"
+      >
+        <BoringSpellValueText spell={SPELLS.TWINS_OF_THE_SUN_PRIESTESS}>
+          {formatNumber(this.goodCasts)}/{formatNumber(this.totalCasts)} Uses
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default TwinsOfTheSunPriestess;

--- a/src/parser/shared/modules/CooldownThroughputTracker.tsx
+++ b/src/parser/shared/modules/CooldownThroughputTracker.tsx
@@ -61,6 +61,13 @@ class CooldownThroughputTracker extends Analyzer {
         BUILT_IN_SUMMARY_TYPES.MANA,
       ],
     },
+    {
+      spell: SPELLS.POWER_INFUSION,
+      summary: [
+        BUILT_IN_SUMMARY_TYPES.DAMAGE,
+        BUILT_IN_SUMMARY_TYPES.HEALING,
+      ],
+    }
   ];
 
   static ignoredSpells: number[] = [


### PR DESCRIPTION
## General Changes
* Added Power Infusion to the global cooldown throughput tracker as it can be cast on any player for huge damage or healing boosts

## Legendaries
### Twins of the Sun Priestess (All Specs)
* Calculates number of bad casts
  * A bad cast is a cast on themself with the legendary. Since using PI on an ally gives both of them PI, there is no case where they should ever cast it on themself. Even giving the worst dps the PI is still a net gain.
* Suggests they use on ally if they have any bad casts

![image](https://user-images.githubusercontent.com/5396389/105616176-ff0c1880-5da2-11eb-872d-2d8bfaf7ca5f.png)
![image](https://user-images.githubusercontent.com/5396389/105616182-0df2cb00-5da3-11eb-917f-54b0b7a6d22b.png)

### Eternal Call to the Void (Shadow)
* Legendary gives random proc when using mind flay or mind sear. No other interaction is required.
* Gives DPS gain statistic from using the legendary

![image](https://user-images.githubusercontent.com/5396389/105616194-31b61100-5da3-11eb-9319-186ba294ab0f.png)

### Talbadar's Stratagem
* Legendary gives bonus damage if the target has Vampiric Touch, Shadow Word: Pain, and Devouring Plague
* Gives DPS gain statistic from using the legendary

![image](https://user-images.githubusercontent.com/5396389/105616209-4db9b280-5da3-11eb-8f79-afd6a7bba6a2.png)
