### PR TITLE
[Fire Mage] Shifting Power Usage Fix

### DIFF
--- a/src/parser/mage/fire/CHANGELOG.tsx
+++ b/src/parser/mage/fire/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'common/SpellLink';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2021, 1, 23), <>Fixed a bug that was causing the suggestions and statistics to show the % of good <SpellLink id={SPELLS.SHIFTING_POWER.id} /> uses as opposed to the % of bad uses.</>, Sharrq),
   change(date(2021, 1, 15), <>Fixed an issue that was not adding the proper amount of additional CDR from <SpellLink id={SPELLS.DISCIPLINE_OF_THE_GROVE.id} />.</>, Sharrq),
   change(date(2021, 1, 14), <>Fixed an issue in <SpellLink id={SPELLS.KINDLING_TALENT.id} /> that was not counting crits from <SpellLink id={SPELLS.PHOENIX_FLAMES.id} /> when calculating cooldown reduction.</>, Sharrq),
   change(date(2021, 1, 14), <>Added a check to ignore pre-casts during <SpellLink id={SPELLS.FIRESTORM.id} />.</>, Sharrq),

--- a/src/parser/mage/fire/integrationTests/example.test.ts.snap
+++ b/src/parser/mage/fire/integrationTests/example.test.ts.snap
@@ -5131,7 +5131,7 @@ Array [
         message="{0}% utilization"
         values={
           Object {
-            "0": "25.00",
+            "0": "75.00",
           }
         }
       />
@@ -7163,7 +7163,7 @@ exports[`Fire Mage integration test: example log matches the checklist snapshot 
               style={
                 Object {
                   "backgroundColor": "#ffc84a",
-                  "width": "61.74622411007057%",
+                  "width": "64.34778661007057%",
                 }
               }
             />
@@ -7852,7 +7852,7 @@ exports[`Fire Mage integration test: example log matches the checklist snapshot 
                   }
                 >
                    
-                  25.00%
+                  75.00%
                    
                    
                 </div>
@@ -7874,7 +7874,7 @@ exports[`Fire Mage integration test: example log matches the checklist snapshot 
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "10.40625%",
+                        "width": "31.21875%",
                       }
                     }
                   />

--- a/src/parser/mage/fire/modules/features/ShiftingPowerUsage.tsx
+++ b/src/parser/mage/fire/modules/features/ShiftingPowerUsage.tsx
@@ -33,7 +33,7 @@ class ShiftingPowerUsage extends Analyzer {
   }
 
   get percentUsage() {
-    return this.badUses / this.abilityTracker.getAbility(SPELLS.SHIFTING_POWER.id).casts;
+    return 1 - (this.badUses / this.abilityTracker.getAbility(SPELLS.SHIFTING_POWER.id).casts);
   }
 
   get shiftingPowerUsageThresholds() {


### PR DESCRIPTION
This fixes a bug that was showing the % of good Shifting Power usage in the statistic and suggestion as opposed to the % of bad casts (which the suggestion thresholds is based on)