### PR TITLE
[Core] Fix crash on About tab of unsupported specs

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -9,6 +9,7 @@ import { change, date } from 'common/changelog';
 
 // prettier-ignore
 export default [
+  change(date(2021, 1, 23), 'Fix crash when viewing About page on unsupported specs.', Adoraci),
   change(date(2021, 1, 20), 'Rework spec support: automatically mark specs as unsupported when patch does not match the game and added a toggle to mark a spec with partial support.', Zerotorescue),
   change(date(2021, 1, 20), 'Change homepage header to be consistent with report page.', Zerotorescue),
   change(date(2021, 1, 20), 'Updated the Missing Encounters warning to show always and prompt users to click Refresh if encounters are missing.', Sharrq),

--- a/src/common/parseVersionString.ts
+++ b/src/common/parseVersionString.ts
@@ -1,4 +1,5 @@
 export default function parseVersionString(string: string) {
+  string = string || '0.0.0';
   const [major, minor, patch] = string.split('.');
 
   return {


### PR DESCRIPTION
Page was crashing on some unsupported specs when their patch was set to null:
https://wowanalyzer.com/report/MyhaxNdgVTJt6qrp/16-Mythic+Huntsman+Altimor+-+Kill+(6:06)/Artillocrani/standard/about

![image](https://user-images.githubusercontent.com/5396389/105616703-e3a30c80-5da6-11eb-9426-254d12af6632.png)
