### PR TITLE
[Shadow Priest] Add Searing Nightmare talent module

### DIFF
--- a/src/parser/priest/shadow/CHANGELOG.tsx
+++ b/src/parser/priest/shadow/CHANGELOG.tsx
@@ -9,6 +9,7 @@ import { ResourceLink } from 'interface';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 export default [
+  change(date(2021, 1, 23), <>Added <SpellLink id={SPELLS.SEARING_NIGHTMARE_TALENT.id} /> talent module.</>, Adoraci),
   change(date(2021, 1, 23), <>Changed DOT uptime tracker into better looking StatisticBar.</>, Adoraci),
   change(date(2021, 1, 23), <>Added <SpellLink id={SPELLS.ETERNAL_CALL_TO_THE_VOID.id} /> legendary.</>, Adoraci),
   change(date(2021, 1, 23), <>Added <SpellLink id={SPELLS.TALBADARS_STRATAGEM.id} /> legendary.</>, Adoraci),

--- a/src/parser/priest/shadow/CombatLogParser.tsx
+++ b/src/parser/priest/shadow/CombatLogParser.tsx
@@ -31,6 +31,7 @@ import TwistOfFate from './modules/talents/TwistOfFate';
 import VoidTorrent from './modules/talents/VoidTorrent';
 import ShadowCrash from './modules/talents/ShadowCrash';
 import AuspiciousSpirits from './modules/talents/AuspiciousSpirits';
+import SearingNightmare from './modules/talents/SearingNightmare';
 // normalizers
 import ShadowfiendNormalizer from '../shared/normalizers/ShadowfiendNormalizer';
 import Buffs from './modules/features/Buffs';
@@ -87,6 +88,7 @@ class CombatLogParser extends MainCombatLogParser {
     voidTorrent: VoidTorrent,
     shadowCrash: ShadowCrash,
     auspiciousSpirits: AuspiciousSpirits,
+    searingNightmare: SearingNightmare,
 
     // normalizers:
     shadowfiendNormalizer: ShadowfiendNormalizer,

--- a/src/parser/priest/shadow/modules/core/Channeling.tsx
+++ b/src/parser/priest/shadow/modules/core/Channeling.tsx
@@ -54,6 +54,11 @@ class Channeling extends CoreChanneling {
         return;
       }
 
+      if (event.ability.guid === SPELLS.SEARING_NIGHTMARE_TALENT.id && this.isChannelingSpell(SPELLS.MIND_SEAR.id)) {
+        // Searing nightmare used during mind sear
+        return;
+      }
+
       // If a channeling spell is "canceled" it was actually just ended, so if it looks canceled then instead just mark it as ended
       this.endChannel(event);
     } else {

--- a/src/parser/priest/shadow/modules/talents/SearingNightmare.tsx
+++ b/src/parser/priest/shadow/modules/talents/SearingNightmare.tsx
@@ -54,7 +54,7 @@ class SearingNightmare extends Analyzer {
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
       suggest(
         <>
-          You hit an average of {formatNumber(actual)} targets with <SpellLink id={SPELLS.SEARING_NIGHTMARE_TALENT.id} />. Using <SpellLink id={SPELLS.SEARING_NIGHTMARE_TALENT.id} /> below {formatNumber(recommended)} targets is not worth it and you will get more damage value from your insanity with <SpellLink id={SPELLS.DEVOURING_PLAGUE.id} />.
+          You hit an average of {formatNumber(actual)} targets with <SpellLink id={SPELLS.SEARING_NIGHTMARE_TALENT.id} />. Using <SpellLink id={SPELLS.SEARING_NIGHTMARE_TALENT.id} /> below {formatNumber(recommended)} targets is not worth it and you will get more damage value from your insanity with <SpellLink id={SPELLS.DEVOURING_PLAGUE.id} />. If you are not getting enough hits or casts from this talent, you will likely benefit more from a different one.
         </>
       )
         .icon(SPELLS.SEARING_NIGHTMARE_TALENT.icon)

--- a/src/parser/priest/shadow/modules/talents/SearingNightmare.tsx
+++ b/src/parser/priest/shadow/modules/talents/SearingNightmare.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { DamageEvent } from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import { formatNumber } from 'common/format';
+import AbilityTracker from 'parser/priest/shadow/modules/core/AbilityTracker';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import { SpellLink } from 'interface';
+import { t } from '@lingui/macro';
+
+class SearingNightmare extends Analyzer {
+  static dependencies = {
+    abilityTracker: AbilityTracker,
+  };
+  protected abilityTracker!: AbilityTracker;
+
+  damage = 0;
+  totalTargetsHit = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.SEARING_NIGHTMARE_TALENT.id);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.SEARING_NIGHTMARE_TALENT), this.onDamage);
+  }
+
+  get averageTargetsHit() {
+    return this.totalTargetsHit / this.abilityTracker.getAbility(SPELLS.SEARING_NIGHTMARE_TALENT.id).casts || 0;
+  }
+
+  onDamage(event: DamageEvent) {
+    this.totalTargetsHit += 1;
+    this.damage += event.amount + (event.absorbed || 0);
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.averageTargetsHit,
+      isLessThan: {
+        minor: 4,
+        average: 3.5,
+        major: 3,
+      },
+      style: ThresholdStyle.NUMBER,
+    };
+  }
+
+  suggestions(when: When) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
+      suggest(
+        <>
+          You hit an average of {formatNumber(actual)} targets with <SpellLink id={SPELLS.SEARING_NIGHTMARE_TALENT.id} />. Using <SpellLink id={SPELLS.SEARING_NIGHTMARE_TALENT.id} /> below {formatNumber(recommended)} targets is not worth it and you will get more damage value from your insanity with <SpellLink id={SPELLS.DEVOURING_PLAGUE.id} />.
+        </>
+      )
+        .icon(SPELLS.SEARING_NIGHTMARE_TALENT.icon)
+        .actual(
+          t({
+            id: 'priest.shadow.suggestions.searingNightmare.efficiency',
+            message: `Hit an average of ${formatNumber(actual)} targets with Searing Nightmare.`,
+          }),
+        )
+        .recommended(`>=${recommended} is recommended.`),
+    );
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
+        tooltip={`Average targets hit: ${formatNumber(this.averageTargetsHit)}`}
+      >
+        <BoringSpellValueText spell={SPELLS.SEARING_NIGHTMARE_TALENT}>
+          <>
+            <ItemDamageDone amount={this.damage} />
+          </>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default SearingNightmare;


### PR DESCRIPTION
## Searing Nightmare
* Adds timeline support for using searing nightmare during mind sear channel
* Adds statistic that shows amount of dps done and average targets hit
* Adds suggestion if the number of average targets hit is less than 4
  * Shadow Priest TC accepted values are devouring plague up to 3 targets. 4+ targets is Searing Nightmare
  * Also doubles as a check if the person forgot to switch talents since if they don't cast it at all, it will be 0 average targets hit

![image](https://user-images.githubusercontent.com/5396389/105619815-35a65b00-5dc4-11eb-8418-449f86ecbba5.png)
