### PR TITLE
[Core] Add a warning if there are filtered results on a fight

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -9,6 +9,7 @@ import { change, date } from 'common/changelog';
 
 // prettier-ignore
 export default [
+  change(date(2021, 1, 21), 'Added a warning on fights where damage is filtered on WarcraftLogs but not WoWAnalyzer.', Adoraci),
   change(date(2021, 1, 20), 'Rework spec support: automatically mark specs as unsupported when patch does not match the game and added a toggle to mark a spec with partial support.', Zerotorescue),
   change(date(2021, 1, 20), 'Change homepage header to be consistent with report page.', Zerotorescue),
   change(date(2021, 1, 20), 'Updated the Missing Encounters warning to show always and prompt users to click Refresh if encounters are missing.', Sharrq),

--- a/src/interface/report/Results/index.js
+++ b/src/interface/report/Results/index.js
@@ -436,7 +436,7 @@ class Results extends React.PureComponent {
             <AlertWarning style={{ marginBottom: 30 }}>
               <Trans id="interface.report.results.warning.filteredByWclogs">
                 This fight has results that are filtered in WarcraftLogs which are not filtered here.
-                Bonus damage or boss healing may result in WoWAnalyzer displaying higher numbers than
+                Bonus damage or bosses full-healing may result in WoWAnalyzer displaying higher numbers than
                 what you see on WarcraftLogs. To see exactly what is being filtered out, check the table
                 on the WarcraftLogs site.
               </Trans>

--- a/src/interface/report/Results/index.js
+++ b/src/interface/report/Results/index.js
@@ -66,6 +66,7 @@ class Results extends React.PureComponent {
       boss: PropTypes.shape({
         fight: PropTypes.shape({
           resultsWarning: PropTypes.any,
+          filteredResults: PropTypes.bool,
         }),
       }),
       getOptionalModule: PropTypes.func.isRequired,
@@ -428,6 +429,18 @@ class Results extends React.PureComponent {
         {boss && boss.fight.resultsWarning && (
           <div className="container">
             <AlertWarning style={{ marginBottom: 30 }}>{boss.fight.resultsWarning}</AlertWarning>
+          </div>
+        )}
+        {boss && boss.fight.filteredResults && (
+          <div className="container">
+            <AlertWarning style={{ marginBottom: 30 }}>
+              <Trans id="interface.report.results.warning.filteredByWclogs">
+                This fight has results that are filtered in WarcraftLogs which are not filtered here.
+                Bonus damage or boss healing may result in WoWAnalyzer displaying higher numbers than
+                what you see on WarcraftLogs. To see exactly what is being filtered out, check the table
+                on the WarcraftLogs site.
+              </Trans>
+            </AlertWarning>
           </div>
         )}
         {parser && parser.selectedCombatant.gear && (

--- a/src/raids/castlenathria/HuntsmanAltimor.ts
+++ b/src/raids/castlenathria/HuntsmanAltimor.ts
@@ -14,6 +14,7 @@ const HuntsmanAltimor: Boss = {
   icon: 'achievement_raid_revendrethraid_altimor',
   fight: {
     vantusRuneBuffId: 334132,
+    filteredResults: true,
     softMitigationChecks: {
       physical: [],
       magical: [],

--- a/src/raids/castlenathria/TheCouncilOfBlood.ts
+++ b/src/raids/castlenathria/TheCouncilOfBlood.ts
@@ -14,6 +14,7 @@ const TheCouncilOfBlood: Boss = {
   icon: 'achievement_raid_revendrethraid_nobilitycouncil',
   fight: {
     vantusRuneBuffId: 311450,
+    filteredResults: true,
     softMitigationChecks: {
       physical: [],
       magical: [],

--- a/src/raids/index.ts
+++ b/src/raids/index.ts
@@ -20,6 +20,7 @@ type EncounterConfig = {
     magical: [],
   },
   resultsWarning?: string;
+  filteredResults?: boolean;
   phases?: { [key: string]: PhaseConfig },
   raceTranslation?: (race: Race, spec: Spec) => Race,
   disableDeathSuggestion?: boolean,


### PR DESCRIPTION
* Adds a `filteredResults` option to encounters
* Displays a warning that results on WarcraftLogs are filtered but the filtered numbers are not reflected in WoWAnalyzer

There have been multiple occasions where someone will ask in Discord why their dps is wrong on certain fights and it's due to the filtering difference. I looked into getting the filtered values from wclogs but the filtering is done on the table and raw events are never touched, so it is not an easy task at this time.

In Nathria, there is filtered damage in Huntsman and Council. In the past with Nya'lotha for example, there was filtered damage in Hivemind, Carapace, and N'zoth.

![image](https://user-images.githubusercontent.com/5396389/105620520-f4b24480-5dcb-11eb-9a75-f36310e32b28.png)
