### PR TITLE
[Sub Rogue] Instant Poison Analyzer

### DIFF
--- a/analysis/rogue/src/InstantPoison.tsx
+++ b/analysis/rogue/src/InstantPoison.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { DamageEvent } from 'parser/core/Events';
+import SPELLS from 'common/SPELLS';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import BoringValueText from 'parser/ui/BoringValueText';
+import { SpellIcon, SpellLink } from 'interface';
+import { formatPercentage } from 'common/format';
+import { NumberThreshold, ThresholdStyle, When } from 'parser/core/ParseResults';
+
+class InstantPoison extends Analyzer {
+  numPoisonHits: number = 0;
+  numMeleeHits: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.INSTANT_POISON), this.onInstantPoisonDamage);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.MELEE), this.onMeleeDamage);
+  }
+
+  onInstantPoisonDamage(event: DamageEvent) {
+    this.numPoisonHits += 1;
+  }
+
+  onMeleeDamage(event: DamageEvent) {
+    this.numMeleeHits += 1;
+  }
+
+  get procPercentage(): number {
+    return this.numPoisonHits / this.numMeleeHits;
+  }
+
+  get instantPoisonSuggestionThresholds(): NumberThreshold {
+    return {
+      actual: this.procPercentage,
+      isLessThan: {
+        minor: 0.27,
+        average: 0.25,
+        major: 0.2,
+      },
+      style: ThresholdStyle.PERCENTAGE,
+    }
+  }
+
+  statistic(): React.ReactNode {
+    return (
+      <Statistic
+        size="flexible"
+        category={STATISTIC_CATEGORY.GENERAL}
+      >
+        <BoringValueText label={<><SpellIcon id={SPELLS.INSTANT_POISON.id}/> Instant Poison Proc Percentage</>}>
+          {formatPercentage(this.procPercentage)} %
+        </BoringValueText>
+      </Statistic>
+    );
+  }
+
+  suggestions(when: When) {
+    when(this.instantPoisonSuggestionThresholds)
+      .addSuggestion((suggest, actual, recommended) => suggest(
+        <>
+          Ensure that your poisons are freshly applied before the fight starts so that they do not expire.
+        </>)
+        .icon(SPELLS.INSTANT_POISON.icon)
+        .actual(<>You procced <SpellLink id={SPELLS.INSTANT_POISON.id} /> on {formatPercentage(this.procPercentage)} % of your melee hits.</>)
+        .recommended(`Unless unlucky, you should have around a 30% proc chance over the fight.`)
+      );
+  }
+
+}
+
+export default InstantPoison;

--- a/analysis/rogue/src/InstantPoison.tsx
+++ b/analysis/rogue/src/InstantPoison.tsx
@@ -36,9 +36,9 @@ class InstantPoison extends Analyzer {
     return {
       actual: this.procPercentage,
       isLessThan: {
-        minor: 0.27,
-        average: 0.25,
-        major: 0.2,
+        minor: 0.2,
+        average: 0.15,
+        major: 0.1,
       },
       style: ThresholdStyle.PERCENTAGE,
     }
@@ -65,7 +65,7 @@ class InstantPoison extends Analyzer {
         </>)
         .icon(SPELLS.INSTANT_POISON.icon)
         .actual(<>You procced <SpellLink id={SPELLS.INSTANT_POISON.id} /> on {formatPercentage(this.procPercentage)} % of your melee hits.</>)
-        .recommended(`Unless unlucky, you should have around a 30% proc chance over the fight.`)
+        .recommended(`If your poisons are applied, you should have around a 30% proc chance over the fight.`)
       );
   }
 

--- a/analysis/rogue/src/index.ts
+++ b/analysis/rogue/src/index.ts
@@ -8,6 +8,7 @@ export { default as EssenceOfBloodfang } from './EssenceOfBloodfang';
 export { default as FilteredDamageTracker } from './FilteredDamageTracker';
 export { default as FinisherTracker } from './FinisherTracker';
 export { default as InvigoratingShadowdust } from './InvigoratingShadowdust';
+export { default as InstantPoison } from './InstantPoison';
 export * from './IsStealth';
 export { default as SpellEnergyCost } from './SpellEnergyCost';
 export { default as SpellUsable } from './SpellUsable';

--- a/analysis/rogueassassination/src/CHANGELOG.js
+++ b/analysis/rogueassassination/src/CHANGELOG.js
@@ -6,7 +6,7 @@ import { SpellLink } from 'interface';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2021,1,25), <>Add analyzer and suggestion for <SpellLink id={SPELLS.INSTANT_POISON.id} /> application.</>, Hordehobbs),
+  change(date(2021,2,27), <>Add analyzer and suggestion for <SpellLink id={SPELLS.INSTANT_POISON.id} /> application.</>, Hordehobbs),
   change(date(2020, 12, 28), <> Fixed an issue where <SpellLink id={SPELLS.DUSKWALKERS_PATCH.id} /> module wouldn't load, as well as various crashes. </>, Putro),
   change(date(2020, 12, 18), <> Fixed an issue where the analyzer couldn't reduce the cooldown of <SpellLink id={SPELLS.SERRATED_BONE_SPIKE.id} />. </>, Putro),
   change(date(2020, 12, 15), 'Added warning for spec not being supported', Tyndi),

--- a/analysis/rogueassassination/src/CHANGELOG.js
+++ b/analysis/rogueassassination/src/CHANGELOG.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { Tyndi, Zeboot, Putro } from 'CONTRIBUTORS';
+import { Tyndi, Zeboot, Putro, Hordehobbs } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2021,1,25), <>Add analyzer and suggestion for <SpellLink id={SPELLS.INSTANT_POISON.id} /> application.</>, Hordehobbs),
   change(date(2020, 12, 28), <> Fixed an issue where <SpellLink id={SPELLS.DUSKWALKERS_PATCH.id} /> module wouldn't load, as well as various crashes. </>, Putro),
   change(date(2020, 12, 18), <> Fixed an issue where the analyzer couldn't reduce the cooldown of <SpellLink id={SPELLS.SERRATED_BONE_SPIKE.id} />. </>, Putro),
   change(date(2020, 12, 15), 'Added warning for spec not being supported', Tyndi),

--- a/analysis/rogueassassination/src/CombatLogParser.ts
+++ b/analysis/rogueassassination/src/CombatLogParser.ts
@@ -13,6 +13,7 @@ import {
   SerratedBoneSpike,
   SpellEnergyCost,
   SpellUsable,
+  InstantPoison,
 } from '@wowanalyzer/rogue';
 
 import CoreCombatLogParser from 'parser/core/CombatLogParser';
@@ -90,6 +91,7 @@ class CombatLogParser extends CoreCombatLogParser {
     garroteSnapshot: GarroteSnapshot,
     ruptureSnapshot: RuptureSnapshot,
     crimsonTempestSnapshot: CrimsonTempestSnapshot,
+    instantPoison: InstantPoison,
 
     //Casts
 

--- a/analysis/rogueoutlaw/src/CHANGELOG.js
+++ b/analysis/rogueoutlaw/src/CHANGELOG.js
@@ -6,7 +6,7 @@ import { SpellLink } from 'interface';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2021,1,25), <>Add analyzer and suggestion for <SpellLink id={SPELLS.INSTANT_POISON.id} /> application.</>, Hordehobbs),
+  change(date(2021,2,27), <>Add analyzer and suggestion for <SpellLink id={SPELLS.INSTANT_POISON.id} /> application.</>, Hordehobbs),
   change(date(2021, 1, 17), <>Suggestion added to cast <SpellLink id={SPELLS.BETWEEN_THE_EYES.id} /> more often</>, Canotsa),
   change(date(2020, 12, 21), 'Minor update to suggestions', Tyndi),
   change(date(2020, 12, 18), <> Fixed an issue where the analyzer couldn't reduce the cooldown of <SpellLink id={SPELLS.SERRATED_BONE_SPIKE.id} />. </>, Putro),

--- a/analysis/rogueoutlaw/src/CHANGELOG.js
+++ b/analysis/rogueoutlaw/src/CHANGELOG.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { Putro, Tyndi, Zeboot, Canotsa} from 'CONTRIBUTORS';
+import { Putro, Tyndi, Zeboot, Canotsa, Hordehobbs } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2021,1,25), <>Add analyzer and suggestion for <SpellLink id={SPELLS.INSTANT_POISON.id} /> application.</>, Hordehobbs),
   change(date(2021, 1, 17), <>Suggestion added to cast <SpellLink id={SPELLS.BETWEEN_THE_EYES.id} /> more often</>, Canotsa),
   change(date(2020, 12, 21), 'Minor update to suggestions', Tyndi),
   change(date(2020, 12, 18), <> Fixed an issue where the analyzer couldn't reduce the cooldown of <SpellLink id={SPELLS.SERRATED_BONE_SPIKE.id} />. </>, Putro),

--- a/analysis/rogueoutlaw/src/CombatLogParser.ts
+++ b/analysis/rogueoutlaw/src/CombatLogParser.ts
@@ -10,6 +10,7 @@ import {
   SerratedBoneSpike,
   SpellEnergyCost,
   SpellUsable,
+  InstantPoison,
 } from '@wowanalyzer/rogue';
 
 import CoreCombatLogParser from 'parser/core/CombatLogParser';
@@ -65,6 +66,7 @@ class CombatLogParser extends CoreCombatLogParser {
     //Core
     restlessBlades: RestlessBlades,
     rollTheBonesCastTracker: RollTheBonesCastTracker,
+    instantPoison: InstantPoison,
 
     //Items
     guileCharm: GuileCharm,

--- a/analysis/roguesubtlety/src/CHANGELOG.js
+++ b/analysis/roguesubtlety/src/CHANGELOG.js
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2021,1,25), <>Add analyzer and suggestion for <SpellLink id={SPELLS.INSTANT_POISON.id} /> application.</>, Hordehobbs),
   change(date(2021, 1, 23), "Add GeneratorFollowingVanish analyzer.", Hordehobbs),
   change(date(2021, 1, 23), "Update CastsInShadowDance analyzer for proper value of max possible casts.", Hordehobbs),
   change(date(2021, 1, 23), <>Remove <SpellLink id={SPELLS.VANISH.id} /> as an offensive CD from checklist. </>, Hordehobbs),

--- a/analysis/roguesubtlety/src/CHANGELOG.js
+++ b/analysis/roguesubtlety/src/CHANGELOG.js
@@ -6,7 +6,7 @@ import { SpellLink } from 'interface';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2021,1,25), <>Add analyzer and suggestion for <SpellLink id={SPELLS.INSTANT_POISON.id} /> application.</>, Hordehobbs),
+  change(date(2021,2,27), <>Add analyzer and suggestion for <SpellLink id={SPELLS.INSTANT_POISON.id} /> application.</>, Hordehobbs),
   change(date(2021, 1, 23), "Add GeneratorFollowingVanish analyzer.", Hordehobbs),
   change(date(2021, 1, 23), "Update CastsInShadowDance analyzer for proper value of max possible casts.", Hordehobbs),
   change(date(2021, 1, 23), <>Remove <SpellLink id={SPELLS.VANISH.id} /> as an offensive CD from checklist. </>, Hordehobbs),

--- a/analysis/roguesubtlety/src/CombatLogParser.tsx
+++ b/analysis/roguesubtlety/src/CombatLogParser.tsx
@@ -14,6 +14,7 @@ import {
   SpellEnergyCost,
   SpellUsable,
   StealthDamageTracker,
+  InstantPoison,
 } from '@wowanalyzer/rogue';
 
 import CoreCombatLogParser from 'parser/core/CombatLogParser';
@@ -82,6 +83,7 @@ class CombatLogParser extends CoreCombatLogParser {
     castsInStealth: CastsInStealth,
     vanishFindWeakness: VanishFindWeakness,
     generatorFollowingVanish: GeneratorFollowingVanish,
+    instantPoison: InstantPoison,
 
     //Talents
     darkShadowContribution: DarkShadowContribution,

--- a/src/common/SPELLS/rogue.ts
+++ b/src/common/SPELLS/rogue.ts
@@ -281,6 +281,11 @@ const spells = {
     name: 'Crippling Poison',
     icon: 'ability_poisonsting',
   },
+  INSTANT_POISON: {
+    id: 315585,
+    name: "Instant Poison",
+    icon: "ability_creature_poison_03",
+  },
 
   //Builders
   MUTILATE: {


### PR DESCRIPTION
### Notes
- Adds `InstantPoison` analyzer, which provides a statistic on the percentage of melee hits that procced Instant Poison and a suggestion if this deviates from the expected proc percentage enough that the Instant Poison buff may not have been up for part of the fight.

### Testing
`yarn build && yarn lint && yarn test:integration`

### Screenshots
(Note that the threshold level had to be adjusted to get the suggestion to show up)
<img width="952" alt="2021-01-25 17_47_42-Heroic Shriekwing - Kill (3_22) by Mowglis in Castle Nathria - WoWAnalyzer" src="https://user-images.githubusercontent.com/6363390/105789992-47a90a80-5f38-11eb-850b-4d279dc449d3.png">

### Issues
- Resolves #4240 
- Resolves #4133 