### PR TITLE
[Paladin] Final Stand Cast Bug

### DIFF
--- a/analysis/paladinprotection/src/CHANGELOG.tsx
+++ b/analysis/paladinprotection/src/CHANGELOG.tsx
@@ -6,6 +6,8 @@ import { SpellLink } from 'interface';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2021, 2, 20), <>Fixed overlapping GCDs caused by <SpellLink id={SPELLS.FINAL_STAND_TALENT.id} />.  Added GCD tracking for <SpellLink id={SPELLS.DIVINE_PROTECTION.id} /> and removed GDC tracking from <SpellLink id={SPELLS.FINAL_STAND_TALENT.id} /> taunt cast.</>, HolySchmidt),
+  change(date(2021, 2, 20), <>Removed <SpellLink id={SPELLS.AVENGING_WRATH.id} /> from the GCD.</>, HolySchmidt),
   change(date(2021, 2, 13), <>Removed <SpellLink id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id} /> from the GCD.</>, emallson),
   change(date(2021, 1, 3), <>Added ability tracking for <SpellLink id={SPELLS.FINAL_STAND_TALENT.id}/> and <SpellLink id={SPELLS.DIVINE_TOLL.id}/> for protection paladin.</>, HolySchmidt),
   change(date(2020, 11, 8), <>Add Overcap analyzer for <SpellLink id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id}/> </>, Hordehobbs),

--- a/analysis/paladinprotection/src/integrationTests/example.test.ts.snap
+++ b/analysis/paladinprotection/src/integrationTests/example.test.ts.snap
@@ -1304,7 +1304,7 @@ exports[`Protection Paladin integration test: example log CastEfficiency matches
             >
               <a
                 className="spell-link-text"
-                href="http://wowhead.com/spell=204079"
+                href="http://wowhead.com/spell=642"
                 rel="noopener noreferrer"
                 style={
                   Object {
@@ -1316,7 +1316,7 @@ exports[`Protection Paladin integration test: example log CastEfficiency matches
                 <img
                   alt=""
                   className="icon game "
-                  src="//render-us.worldofwarcraft.com/icons/56/spell_holy_crusade.jpg"
+                  src="//render-us.worldofwarcraft.com/icons/56/spell_holy_divineshield.jpg"
                   style={
                     Object {
                       "height": undefined,
@@ -1325,7 +1325,7 @@ exports[`Protection Paladin integration test: example log CastEfficiency matches
                   }
                 />
                  
-                Final Stand
+                Divine Shield
               </a>
             </td>
             <td
@@ -2980,14 +2980,14 @@ Array [
   },
   Object {
     "details": null,
-    "icon": "spell_holy_crusade",
+    "icon": "spell_holy_divineshield",
     "importance": "major",
     "issue": <React.Fragment>
       <Trans
         components={
           Object {
             "0": <ForwardRef
-              id={204079}
+              id={642}
             />,
           }
         }

--- a/analysis/paladinprotection/src/integrationTests/example.test.ts.snap
+++ b/analysis/paladinprotection/src/integrationTests/example.test.ts.snap
@@ -20,7 +20,7 @@ Array [
       .
     </React.Fragment>,
     "stat": <React.Fragment>
-      {"id":"paladin.protection.alwaysBeCasting.downtime","message":"{0}% downtime","values":{"0":"26.71"}}
+      {"id":"paladin.protection.alwaysBeCasting.downtime","message":"{0}% downtime","values":{"0":"27.52"}}
        (
       &lt;20.00% is recommended
       )

--- a/analysis/paladinprotection/src/modules/Abilities.js
+++ b/analysis/paladinprotection/src/modules/Abilities.js
@@ -240,7 +240,8 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(SPELLS.REPENTANCE_TALENT.id),
       },
       {
-        spell: SPELLS.FINAL_STAND_CAST,
+        spell: SPELLS.DIVINE_SHIELD,
+        buffSpellId: SPELLS.DIVINE_SHIELD.id,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         cooldown: 300 * (combatant.hasTalent(SPELLS.UNBREAKABLE_SPIRIT_TALENT.id) ? 0.7 : 1),
         castEfficiency: {

--- a/analysis/paladinprotection/src/modules/Abilities.js
+++ b/analysis/paladinprotection/src/modules/Abilities.js
@@ -120,9 +120,6 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.AVENGING_WRATH,
         buffSpellId: SPELLS.AVENGING_WRATH.id,
         category: Abilities.SPELL_CATEGORIES.SEMI_DEFENSIVE,
-        gcd: {
-          base: 1500,
-        },
         cooldown: 120,
         // castEfficiency: {
         //   suggestion: true,


### PR DESCRIPTION
#4406 
Minor fixes to Final Stand and Wings for protection paladin.
- Removed GCD from wings.
- Fixed issue where the taunt cast was being tracked instead of the initial bubble cast.
- Timeline corrected to remove GCD overlap when enemies are taunted from Final Stand.

![image](https://user-images.githubusercontent.com/3276248/108606393-dcf8bc80-7387-11eb-844e-a52a374f9163.png)
