### PR TITLE
[BRM] Conduit - Add Celestial Effervescence statistic module

### DIFF
--- a/analysis/monkbrewmaster/src/CHANGELOG.tsx
+++ b/analysis/monkbrewmaster/src/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2021, 2, 23), <>Added <SpellLink id={SPELLS.CELESTIAL_EFFERVESCENCE.id} /> statistic module.</>, Matardarix),
   change(date(2021, 1, 28), <>Added <SpellLink id={SPELLS.WALK_WITH_THE_OX.id} /> statistic module.</>, Matardarix),
   change(date(2021, 1, 25), <>Add support for <SpellLink id={SPELLS.FORTIFYING_INGREDIENTS.id} />, <SpellLink id={SPELLS.GROUNDING_BREATH.id} /> and <SpellLink id={SPELLS.HARM_DENIAL.id} />.</>, Matardarix),
   change(date(2021, 1, 23), <>Add wasted cooldown avoided to <SpellLink id={SPELLS.STORMSTOUTS_LAST_KEG.id} /> statistic tooltip.</>, emallson),

--- a/analysis/monkbrewmaster/src/CombatLogParser.ts
+++ b/analysis/monkbrewmaster/src/CombatLogParser.ts
@@ -46,6 +46,7 @@ import WeaponsOfOrder from './modules/spells/shadowlands/WeaponsOfOrder';
 import ScaldingBrew from './modules/shadowlands/conduits/ScaldingBrew';
 import EvasiveStride from './modules/shadowlands/conduits/EvasiveStride';
 import WalkWithTheOx from './modules/shadowlands/conduits/WalkWithTheOx';
+import CelestialEffervescence from './modules/shadowlands/conduits/CelestialEffervescence';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -102,6 +103,7 @@ class CombatLogParser extends CoreCombatLogParser {
     fortifyingIngredients: FortifyingIngredients,
     groundingBreath: GroundingBreath,
     evasiveStride: EvasiveStride,
+    celestialEffervescence: CelestialEffervescence,
     /// Potency
     scaldingBrew: ScaldingBrew,
     walkWithTheOx: WalkWithTheOx,

--- a/analysis/monkbrewmaster/src/constants.tsx
+++ b/analysis/monkbrewmaster/src/constants.tsx
@@ -30,6 +30,7 @@ export const BASE_AGI = 1468;
 
 // Conduits
 export const WALK_WITH_THE_OX_DAMAGE_INCREASE = [0, 0.25, 0.275, 0.3, 0.325, 0.35, 0.375, 0.4, 0.425, 0.45, 0.475, 0.5, 0.525, 0.55, 0.575, 0.6];
+export const CELESTIAL_EFFERVESCENCE_HEALING_INCREASE = [0, 0.188, 0.206, 0.225, 0.244, 0.263, 0.281, 0.3, 0.319, 0.338, 0.356, 0.375, 0.394, 0.413, 0.431, 0.45];
 
 // Legendaries
 export const STORMSTOUTS_LK_MODIFIER = 0.3;

--- a/analysis/monkbrewmaster/src/modules/shadowlands/conduits/CelestialEffervescence.tsx
+++ b/analysis/monkbrewmaster/src/modules/shadowlands/conduits/CelestialEffervescence.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
+import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';import SPELLS from 'common/SPELLS';
+import Events, { HealEvent } from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import ConduitSpellText from 'parser/ui/ConduitSpellText';
+import STATISTIC_ORDER  from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+
+import { CELESTIAL_EFFERVESCENCE_HEALING_INCREASE } from '../../../constants';
+
+/**
+ * While under the effects of Celestial Brew, your effects that heal you are increased by x%
+ */
+export default class CelestialEffervescence extends Analyzer {
+
+  healingIncrease = 0;
+  rank: number;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.rank = this.selectedCombatant.conduitRankBySpellID(SPELLS.CELESTIAL_EFFERVESCENCE.id);
+    if(!this.rank) {
+      this.active = false;
+      return;
+    }
+
+    this.addEventListener(Events.heal.to(SELECTED_PLAYER), this.onHeal);
+  }
+
+  private onHeal(event: HealEvent) {
+    if(this.selectedCombatant.hasBuff(SPELLS.CELESTIAL_BREW.id)){
+      this.healingIncrease += calculateEffectiveHealing(event, CELESTIAL_EFFERVESCENCE_HEALING_INCREASE[this.rank]);
+    }
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(13)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.COVENANTS}>
+        <ConduitSpellText spell={SPELLS.CELESTIAL_EFFERVESCENCE} rank={this.rank}>
+          <ItemHealingDone amount={this.healingIncrease} />
+        </ConduitSpellText>
+      </Statistic>
+    );
+  }
+}


### PR DESCRIPTION
Add Celestial Effervescence statistic module
![image](https://user-images.githubusercontent.com/48837283/108873247-e20d7400-75f2-11eb-8a4c-ec1d9bacd9cd.png)

Example log: https://www.warcraftlogs.com/reports/LPQzVc9yRFG327wX#fight=14&type=damage-done&source=22