### PR TITLE
[druid] fix convoke crash

### DIFF
--- a/analysis/druid/src/ConvokeSpirits.tsx
+++ b/analysis/druid/src/ConvokeSpirits.tsx
@@ -144,6 +144,7 @@ class ConvokeSpirits extends Analyzer {
   startTracking(event: ApplyBuffEvent) {
     this.tracking = true;
     this.cast += 1;
+    this.whatHappendIneachConvoke[this.cast] = {spellIdToCasts: []};
   }
 
   newRejuv(event: ApplyBuffEvent | RefreshBuffEvent) {
@@ -268,11 +269,6 @@ class ConvokeSpirits extends Analyzer {
       return;
     }
 
-    //make sure we got this object if not make a new one (cry a little too)
-    if(!this.whatHappendIneachConvoke[this.cast]) {
-      this.whatHappendIneachConvoke[this.cast] = {spellIdToCasts: []};
-    }
-
     //we know it exists
     const oneCast = this.whatHappendIneachConvoke[this.cast];
     if(!oneCast.spellIdToCasts[spellId]) {
@@ -299,7 +295,7 @@ class ConvokeSpirits extends Analyzer {
       return;
     }
 
-    const howManyDidWeCount = this.whatHappendIneachConvoke[this.cast].spellIdToCasts.reduce((previousValue: number, currentValue: number) => previousValue + currentValue);
+    const howManyDidWeCount = this.whatHappendIneachConvoke[this.cast].spellIdToCasts.reduce((previousValue: number, currentValue: number) => previousValue + currentValue, 0);
 
     //this can happen due to a resto druid lego that just randomly adds rejuvs (with no cast event)
     //so lets remove those if possible. if not then ??? sorry fam

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -9,7 +9,7 @@ import { change, date } from 'common/changelog';
 
 // prettier-ignore
 export default [
-  change(date(2021, 2, 24), 'Fixed a crash triggered by convoke casting 0 spells', acornellier),
+  change(date(2021, 2, 24), <>Fixed a crash triggered by <SpellLink id={SPELLS.CONVOKE_SPIRITS.id} /> casting 0 spells</>, acornellier),
   change(date(2021, 2, 14), <>Update <ItemLink id={ITEMS.VANTUS_RUNE_CASTLE_NATHRIA.id} /> versatility value.</>, Adoraci),
   change(date(2021, 1, 20), 'Rework spec support: automatically mark specs as unsupported when patch does not match the game and added a toggle to mark a spec with partial support.', Zerotorescue),
   change(date(2021, 1, 20), 'Change homepage header to be consistent with report page.', Zerotorescue),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 // prettier-ignore
-import { Abelito75, AdamKelly, Adoraci, Amani, Barry, Barter, ChagriAli, ChristopherKiss, Dambroda, emallson, flurreN, Guyius, Haelrail, HolySchmidt, Jafowler, jos3p, joshinator, Juko8, Keraldi, Khazak, Kruzershtern, Mae, Maldark, Moonrabbit, niseko, Putro, Sharrq, Ssabbar, Zeboot, Zerotorescue } from 'CONTRIBUTORS';
+import { Abelito75, acornellier, AdamKelly, Adoraci, Amani, Barry, Barter, ChagriAli, ChristopherKiss, Dambroda, emallson, flurreN, Guyius, Haelrail, HolySchmidt, Jafowler, jos3p, joshinator, Juko8, Keraldi, Khazak, Kruzershtern, Mae, Maldark, Moonrabbit, niseko, Putro, Sharrq, Ssabbar, Zeboot, Zerotorescue } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
 import SpellLink from 'interface/SpellLink';
@@ -9,6 +9,7 @@ import { change, date } from 'common/changelog';
 
 // prettier-ignore
 export default [
+  change(date(2021, 2, 24), 'Fixed a crash triggered by convoke casting 0 spells', acornellier),
   change(date(2021, 2, 14), <>Update <ItemLink id={ITEMS.VANTUS_RUNE_CASTLE_NATHRIA.id} /> versatility value.</>, Adoraci),
   change(date(2021, 1, 20), 'Rework spec support: automatically mark specs as unsupported when patch does not match the game and added a toggle to mark a spec with partial support.', Zerotorescue),
   change(date(2021, 1, 20), 'Change homepage header to be consistent with report page.', Zerotorescue),

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -1305,3 +1305,14 @@ export const Pendragon: Contributor = {
     link: 'https://worldofwarcraft.com/en-us/character/us/stormrage/larison',
   }],
 };
+
+export const acornellier: Contributor = {
+  nickname: 'acornellier',
+  github: 'acornellier',
+  discord: 'Ortemis#3934',
+  mains: [{
+    name: 'Ortemis',
+    spec: SPECS.HOLY_PALADIN,
+    link: 'https://worldofwarcraft.com/en-us/character/us/sargeras/ortemis',
+  }],
+};


### PR DESCRIPTION
Fixes this bug reported in Discord: https://wowanalyzer.com/report/rfVHDZPQKAJc29bv/1-Mythic++Profondeurs+Sanguines+-+Kill+(34:44)/Natshsram/standard/overview

The druid starting casting convoke and immediately died, causing `startTracking` to be called, incrementing `this.cast`, then `stopTracking` to be called, but `this.whatHappendIneachConvoke[this.cast]` hadn't been initialized yet. I moved the initialization to `startTracking` to avoid any future issues like this.