### PR TITLE
Fixed crash on Balance Druid Analyzer when spells were precasted

### DIFF
--- a/analysis/druid/src/ConvokeSpirits.tsx
+++ b/analysis/druid/src/ConvokeSpirits.tsx
@@ -251,6 +251,10 @@ class ConvokeSpirits extends Analyzer {
 
   //just adds to spell to a tracker... yeah i know i could feed them all down to addemUp my default but i don't want something like (event: DamageEvent | ApplyBuffEvent | RefreshBuffEvent... ) deal with it
   addemUp(spellId: number, timestamp: number) {
+    // if Convoke hasn't been casted in this fight, there is nothing to analyzere here. This also fixes crashes resulting from precasting spells, as they don't have a cast Event associated with them
+    if(this.cast === 0) {
+      return;
+    }
 
     let fromConvokeButWeNoticeAfterwards = false;
     //since travel time is the stupidiest thing in the world we have a weird af check

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 // prettier-ignore
-import { Abelito75, acornellier, AdamKelly, Adoraci, Amani, Barry, Barter, ChagriAli, ChristopherKiss, Dambroda, emallson, flurreN, Guyius, Haelrail, HolySchmidt, Jafowler, jos3p, joshinator, Juko8, Keraldi, Khazak, Kruzershtern, Mae, Maldark, Moonrabbit, niseko, Putro, Sharrq, Ssabbar, Zeboot, Zerotorescue } from 'CONTRIBUTORS';
+import { Abelito75, acornellier, AdamKelly, Adoraci, Amani, Barry, Barter, ChagriAli, ChristopherKiss, Dambroda, emallson, flurreN, Guyius, Haelrail, HolySchmidt, Jafowler, jos3p, joshinator, Juko8, Kartarn, Keraldi, Khazak, Kruzershtern, Mae, Maldark, Moonrabbit, niseko, Putro, Sharrq, Ssabbar, Zeboot, Zerotorescue } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS';
 import ITEMS from 'common/ITEMS';
 import SpellLink from 'interface/SpellLink';
@@ -9,6 +9,7 @@ import { change, date } from 'common/changelog';
 
 // prettier-ignore
 export default [
+  change(date(2021, 2, 27), 'Fixed a crash resulting from precasting spells on druid specs.', Kartarn),
   change(date(2021, 2, 24), <>Fixed a crash triggered by <SpellLink id={SPELLS.CONVOKE_SPIRITS.id} /> casting 0 spells</>, acornellier),
   change(date(2021, 2, 14), <>Update <ItemLink id={ITEMS.VANTUS_RUNE_CASTLE_NATHRIA.id} /> versatility value.</>, Adoraci),
   change(date(2021, 1, 20), 'Rework spec support: automatically mark specs as unsupported when patch does not match the game and added a toggle to mark a spec with partial support.', Zerotorescue),


### PR DESCRIPTION
As of the recent commit fixing the crash that occured when Convoke did not cast any spells (https://github.com/WoWAnalyzer/WoWAnalyzer/pull/4413) most Balance druid analysis started crashing with this error:
![image](https://user-images.githubusercontent.com/36763177/109394401-21a3cb00-7927-11eb-8377-166df3f4c4b8.png). 
It turned out that this resulted from this line: https://github.com/WoWAnalyzer/WoWAnalyzer/blob/shadowlands/analysis/druid/src/ConvokeSpirits.tsx#L278 assuming that the beforehand checks in line https://github.com/WoWAnalyzer/WoWAnalyzer/blob/shadowlands/analysis/druid/src/ConvokeSpirits.tsx#L259 filtered out all events not belonging to Convoke by checking if the damage event has a corresponding cast event associated with it. 

This is also the case for spells which have been precast, as they have a damage event, but no cast event for them, which lead to an 'undefined' error, as no Convoke-Cast-Event initiated the variable.

The check fixes the crashes. As a side effect it also corrects a bug in which precasted spells used to be displayed as a seperate Convoke cast in the statistics.

<table>
<tr><th>Before</th><th>After</th></tr><tr><td>
<img src="https://user-images.githubusercontent.com/36763177/109394814-31bcaa00-7929-11eb-90f7-d33bd0c550f9.png" />
</td><td>
<img src="https://user-images.githubusercontent.com/36763177/109394839-5c0e6780-7929-11eb-9d37-159bf539b1a3.png" />
</td></tr></table>