### PR TITLE
Remove instant poison from assassination rogues

### DIFF
--- a/analysis/rogueassassination/src/CHANGELOG.js
+++ b/analysis/rogueassassination/src/CHANGELOG.js
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2021,3,4), <>Removed analyzer and suggestion for <SpellLink id={SPELLS.INSTANT_POISON.id} /> application.</>, tuxedobob),
   change(date(2021,2,27), <>Add analyzer and suggestion for <SpellLink id={SPELLS.INSTANT_POISON.id} /> application.</>, Hordehobbs),
   change(date(2020, 12, 28), <> Fixed an issue where <SpellLink id={SPELLS.DUSKWALKERS_PATCH.id} /> module wouldn't load, as well as various crashes. </>, Putro),
   change(date(2020, 12, 18), <> Fixed an issue where the analyzer couldn't reduce the cooldown of <SpellLink id={SPELLS.SERRATED_BONE_SPIKE.id} />. </>, Putro),

--- a/analysis/rogueassassination/src/CHANGELOG.js
+++ b/analysis/rogueassassination/src/CHANGELOG.js
@@ -6,7 +6,7 @@ import { SpellLink } from 'interface';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2021,3,4), <>Removed analyzer and suggestion for <SpellLink id={SPELLS.INSTANT_POISON.id} /> application.</>, tuxedobob),
+  change(date(2021,3,4), <>Removed analyzer and suggestion for <SpellLink id={SPELLS.INSTANT_POISON.id} /> application.</>, Hordehobbs),
   change(date(2021,2,27), <>Add analyzer and suggestion for <SpellLink id={SPELLS.INSTANT_POISON.id} /> application.</>, Hordehobbs),
   change(date(2020, 12, 28), <> Fixed an issue where <SpellLink id={SPELLS.DUSKWALKERS_PATCH.id} /> module wouldn't load, as well as various crashes. </>, Putro),
   change(date(2020, 12, 18), <> Fixed an issue where the analyzer couldn't reduce the cooldown of <SpellLink id={SPELLS.SERRATED_BONE_SPIKE.id} />. </>, Putro),

--- a/analysis/rogueassassination/src/CombatLogParser.ts
+++ b/analysis/rogueassassination/src/CombatLogParser.ts
@@ -13,7 +13,6 @@ import {
   SerratedBoneSpike,
   SpellEnergyCost,
   SpellUsable,
-  InstantPoison,
 } from '@wowanalyzer/rogue';
 
 import CoreCombatLogParser from 'parser/core/CombatLogParser';

--- a/analysis/rogueassassination/src/CombatLogParser.ts
+++ b/analysis/rogueassassination/src/CombatLogParser.ts
@@ -90,7 +90,6 @@ class CombatLogParser extends CoreCombatLogParser {
     garroteSnapshot: GarroteSnapshot,
     ruptureSnapshot: RuptureSnapshot,
     crimsonTempestSnapshot: CrimsonTempestSnapshot,
-    instantPoison: InstantPoison,
 
     //Casts
 


### PR DESCRIPTION
Assassination rogues use Deadly Poison.