### PR TITLE
Fixed suggestion for wasted regenerated focus

### DIFF
--- a/analysis/hunter/src/FocusCapTracker.tsx
+++ b/analysis/hunter/src/FocusCapTracker.tsx
@@ -79,7 +79,7 @@ class FocusCapTracker extends RegenResourceCapTracker {
       id: "hunter.marksmanship.suggestions.focusCapTracker.focusLost",
       message: `${formatPercentage(1 - actual)}% regenerated focus lost due to being capped.`
     }))
-      .recommended(`<${formatPercentage(recommended, 0)}% is recommended.`));
+      .recommended(`<${formatPercentage(1 - recommended, 0)}% is recommended.`));
   }
 
   statistic() {

--- a/analysis/hunterbeastmastery/src/CHANGELOG.tsx
+++ b/analysis/hunterbeastmastery/src/CHANGELOG.tsx
@@ -1,10 +1,11 @@
-import { Putro } from 'CONTRIBUTORS';
+import { Putro, Kartarn } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 import { SpellLink } from 'interface';
 import SPELLS from 'common/SPELLS';
 import React from 'react';
 
 export default [
+  change(date(2021, 3, 6), 'Fixed suggestion for wasted regenerated focus.', Kartarn),
   change(date(2021, 1, 16), 'Due to the paywalling of the timeline feature, and fundamental differences of opinion - I will no longer be updating this module beyond todays date. All the modules should be accurate for Castle Nathria, but will not be accurate going forward.', Putro),
   change(date(2021, 1, 16), <> Added support for <SpellLink id={SPELLS.REVERSAL_OF_FORTUNE_CONDUIT.id} />, <SpellLink id={SPELLS.REJUVENATING_WIND_CONDUIT.id} /> and <SpellLink id={SPELLS.HARMONY_OF_THE_TORTOLLAN_CONDUIT.id} />. </>, Putro),
   change(date(2021, 1, 10), <> Adjusted <SpellLink id={SPELLS.WILD_SPIRITS.id}/> global cooldown to correctly be reduced by haste twice in the analyzer, to reflect behaviour in-game. </>, Putro),

--- a/analysis/hunterbeastmastery/src/integrationTests/beastMasteryIntegrationTests.test.ts.snap
+++ b/analysis/hunterbeastmastery/src/integrationTests/beastMasteryIntegrationTests.test.ts.snap
@@ -771,7 +771,7 @@ Array [
     "stat": <React.Fragment>
       {"id":"hunter.marksmanship.suggestions.focusCapTracker.focusLost","message":"{0}% regenerated focus lost due to being capped.","values":{"0":"23.98"}}
        (
-      &lt;90% is recommended.
+      &lt;10% is recommended.
       )
     </React.Fragment>,
   },

--- a/analysis/huntermarksmanship/src/CHANGELOG.tsx
+++ b/analysis/huntermarksmanship/src/CHANGELOG.tsx
@@ -1,10 +1,11 @@
-import { Putro, Zeboot } from 'CONTRIBUTORS';
+import { Putro, Zeboot, Kartarn } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 import React from 'react';
 import { SpellLink } from 'interface';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2021, 3, 6), 'Fixed suggestion for wasted regenerated focus.', Kartarn),
   change(date(2021, 1, 16), 'Due to the paywalling of the timeline feature, and fundamental differences of opinion - I will no longer be updating this module beyond todays date. All the modules should be accurate for Castle Nathria, but will not be accurate going forward.', Putro),
   change(date(2021, 1, 16), <> Added support for <SpellLink id={SPELLS.REVERSAL_OF_FORTUNE_CONDUIT.id} />, <SpellLink id={SPELLS.REJUVENATING_WIND_CONDUIT.id} /> and <SpellLink id={SPELLS.HARMONY_OF_THE_TORTOLLAN_CONDUIT.id} />. </>, Putro),
   change(date(2021, 1, 10), <> Create a hacky solution to handle precasting <SpellLink id={SPELLS.AIMED_SHOT.id} /> to properly handle downtime - this leads to showing extremely short casttime for any precast Aimed Shot that finishes cast inside combat.</>, Putro),

--- a/analysis/huntermarksmanship/src/integrationTests/marksmanshipIntegrationTests.test.ts.snap
+++ b/analysis/huntermarksmanship/src/integrationTests/marksmanshipIntegrationTests.test.ts.snap
@@ -13061,7 +13061,7 @@ Array [
     "stat": <React.Fragment>
       {"id":"hunter.marksmanship.suggestions.focusCapTracker.focusLost","message":"{0}% regenerated focus lost due to being capped.","values":{"0":"10.11"}}
        (
-      &lt;90% is recommended.
+      &lt;10% is recommended.
       )
     </React.Fragment>,
   },

--- a/analysis/huntersurvival/src/CHANGELOG.tsx
+++ b/analysis/huntersurvival/src/CHANGELOG.tsx
@@ -1,10 +1,11 @@
-import { Putro } from 'CONTRIBUTORS';
+import { Putro, Kartarn } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 import { SpellLink } from 'interface';
 import SPELLS from 'common/SPELLS';
 import React from 'react';
 
 export default [
+  change(date(2021, 3, 6), 'Fixed suggestion for wasted regenerated focus.', Kartarn),
   change(date(2021, 1, 16), 'Due to the paywalling of the timeline feature, and fundamental differences of opinion - I will no longer be updating this module beyond todays date. All the modules should be accurate for Castle Nathria, but will not be accurate going forward.', Putro),
   change(date(2021, 1, 16), <> Added support for <SpellLink id={SPELLS.LATENT_POISON_INJECTORS_EFFECT.id} />, <SpellLink id={SPELLS.RYLAKSTALKERS_CONFOUNDING_STRIKES_EFFECT.id} /> and <SpellLink id={SPELLS.BUTCHERS_BONE_FRAGMENTS_EFFECT.id} />. </>, Putro),
   change(date(2021, 1, 16), <> Added support for <SpellLink id={SPELLS.REVERSAL_OF_FORTUNE_CONDUIT.id} />, <SpellLink id={SPELLS.REJUVENATING_WIND_CONDUIT.id} /> and <SpellLink id={SPELLS.HARMONY_OF_THE_TORTOLLAN_CONDUIT.id} />. </>, Putro),


### PR DESCRIPTION
The message used the current % of efficiency in generating focus (so a value of 80% means you wasted 20% focus).
Thus changed it to be `1 - recommended%` instead of `recommended%`

Refering to this support question on the Discord server: https://discord.com/channels/316864121536512000/360770373454659585/816926809236701184