### PR TITLE
[Mage] 9.0.5 Update

### DIFF
--- a/analysis/mage/src/MirrorsOfTorment.tsx
+++ b/analysis/mage/src/MirrorsOfTorment.tsx
@@ -4,7 +4,7 @@ import SpellUsable from 'parser/shared/modules/SpellUsable';
 import SPELLS from 'common/SPELLS';
 import COVENANTS from 'game/shadowlands/COVENANTS';
 
-const FIRE_BLAST_REDUCTION_MS = 4000;
+const FIRE_BLAST_REDUCTION_MS = 6000;
 
 class MirrorsOfTorment extends Analyzer {
   static dependencies = {

--- a/analysis/magearcane/src/CHANGELOG.tsx
+++ b/analysis/magearcane/src/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import { change, date } from 'common/changelog';
 
 // prettier-ignore
 export default [
+  change(date(2021, 3, 6), 'Updated for Patch 9.0.5.', Sharrq),
   change(date(2021, 1, 15), <>Fixed an issue that was not adding the proper amount of additional CDR from <SpellLink id={SPELLS.DISCIPLINE_OF_THE_GROVE.id} />.</>, Sharrq),
   change(date(2020, 12, 28), <>Updated conduit statistic boxes to use the new layout.</>, Sharrq),
   change(date(2020, 12, 24), <>Fixed an issue that was showing <SpellLink id={SPELLS.RUNE_OF_POWER_TALENT.id} /> as lasting the entire fight duration in the Cooldowns tab.</>, Sharrq),

--- a/analysis/magearcane/src/CONFIG.tsx
+++ b/analysis/magearcane/src/CONFIG.tsx
@@ -9,7 +9,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Sharrq],
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.0.2',
+  patchCompatibility: '9.0.5',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/magearcane/src/modules/items/ArcaneHarmony.tsx
+++ b/analysis/magearcane/src/modules/items/ArcaneHarmony.tsx
@@ -10,7 +10,7 @@ import { SELECTED_PLAYER } from 'parser/core/EventFilter';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
 
-const DAMAGE_BONUS_PER_STACK = .06;
+const DAMAGE_BONUS_PER_STACK = .08;
 
 class ArcaneHarmony extends Analyzer {
   static dependencies = {

--- a/analysis/magefire/src/CHANGELOG.tsx
+++ b/analysis/magefire/src/CHANGELOG.tsx
@@ -6,6 +6,10 @@ import { SpellLink } from 'interface';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2021, 3, 6), 'Updated for Patch 9.0.5.', Sharrq),
+  change(date(2021, 3, 6), <>Adjusted <SpellLink id={SPELLS.COMBUSTION.id} /> Statistics to show a breakdown of the active time and pre-cast delay for each cast.</>, Sharrq),
+  change(date(2021, 3, 6), <>Added the ability to check the delay between using <SpellLink id={SPELLS.COMBUSTION.id} /> and the end of pre-cast abilities.</>, Sharrq),
+  change(date(2021, 3, 6), <>Added support for <SpellLink id={SPELLS.DISCIPLINARY_COMMAND.id} />.</>, Sharrq),
   change(date(2021, 2, 21), <>Resolved an issue where <SpellLink id={SPELLS.FEVERED_INCANTATION.id} /> was using the wrong damage modifier value to determine it's damage contribution.</>, Sharrq),
   change(date(2021, 1, 23), <>Fixed a bug that was causing the suggestions and statistics to show the % of good <SpellLink id={SPELLS.SHIFTING_POWER.id} /> uses as opposed to the % of bad uses.</>, Sharrq),
   change(date(2021, 1, 15), <>Fixed an issue that was not adding the proper amount of additional CDR from <SpellLink id={SPELLS.DISCIPLINE_OF_THE_GROVE.id} />.</>, Sharrq),

--- a/analysis/magefire/src/CONFIG.tsx
+++ b/analysis/magefire/src/CONFIG.tsx
@@ -9,7 +9,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Sharrq],
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.0.2',
+  patchCompatibility: '9.0.5',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/magefire/src/CombatLogParser.ts
+++ b/analysis/magefire/src/CombatLogParser.ts
@@ -36,6 +36,7 @@ import CombustionFirestarter from './modules/features/CombustionFirestarter';
 import CombustionCharges from './modules/features/CombustionCharges';
 import CombustionSpellUsage from './modules/features/CombustionSpellUsage';
 import CombustionActiveTime from './modules/features/CombustionActiveTime';
+import CombustionPreCastDelay from './modules/features/CombustionPreCastDelay';
 import PhoenixFlames from './modules/features/PhoenixFlames';
 import HeatingUp from './modules/features/HeatingUp';
 import Pyroclasm from './modules/features/Pyroclasm';
@@ -50,6 +51,7 @@ import Kindling from './modules/talents/Kindling';
 //Legendaries
 import FeveredIncantation from './modules/items/FeveredIncantation';
 import Firestorm from './modules/items/Firestorm';
+import DisciplinaryCommand from './modules/items/DisciplinaryCommand';
 
 //Covenants
 import ShiftingPowerUsage from './modules/features/ShiftingPowerUsage';
@@ -85,6 +87,7 @@ class CombatLogParser extends CoreCombatLogParser {
     combustionCharges: CombustionCharges,
     combustionSpellUsage: CombustionSpellUsage,
     combustionActiveTime: CombustionActiveTime,
+    combustionPreCastDelay: CombustionPreCastDelay,
     phoenixFlames: PhoenixFlames,
     heatingUp: HeatingUp,
     mirrorImage: MirrorImage,
@@ -104,6 +107,7 @@ class CombatLogParser extends CoreCombatLogParser {
     //Legendaries
     feveredIncantation: FeveredIncantation,
     firestorm: Firestorm,
+    disciplinaryCommand: DisciplinaryCommand,
 
     //Covenants
     shiftingPower: ShiftingPower,

--- a/analysis/magefire/src/integrationTests/example.test.ts.snap
+++ b/analysis/magefire/src/integrationTests/example.test.ts.snap
@@ -3596,6 +3596,11 @@ exports[`Fire Mage integration test: example log CombustionActiveTime matches th
   <div
     className="panel statistic flexible "
     position={30}
+    style={
+      Object {
+        "zIndex": 1,
+      }
+    }
   >
     <div
       className="panel-body"
@@ -3634,7 +3639,32 @@ exports[`Fire Mage integration test: example log CombustionActiveTime matches th
           <small>
             Combustion Active Time
           </small>
+          <br />
+          0.51
+          s 
+          <small>
+            Avg. Pre-Cast Delay
+          </small>
         </div>
+      </div>
+      <div
+        className="row"
+      >
+        <div
+          className="col-xs-12"
+        />
+      </div>
+      <div
+        className="statistic-expansion-button-holster"
+      >
+        <button
+          className="btn btn-primary"
+          onClick={[Function]}
+        >
+          <span
+            className="glyphicon glyphicon-chevron-down"
+          />
+        </button>
       </div>
     </div>
     <div
@@ -5718,7 +5748,7 @@ exports[`Fire Mage integration test: example log matches the checklist snapshot 
               style={
                 Object {
                   "backgroundColor": "#a6c34c",
-                  "width": "76.07353041613764%",
+                  "width": "79.06433911412044%",
                 }
               }
             />
@@ -6403,6 +6433,96 @@ exports[`Fire Mage integration test: example log matches the checklist snapshot 
                         "backgroundColor": "#ffc84a",
                         "transition": "background-color 800ms",
                         "width": "62.92717946814746%",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="col-md-6"
+          >
+            <div
+              className="flex"
+            >
+              <div
+                className="flex-main"
+              >
+                Avg. Combustion Pre-Cast Delay (seconds)
+              </div>
+              <div
+                className="flex-sub"
+                style={
+                  Object {
+                    "marginLeft": 10,
+                  }
+                }
+              >
+                <div
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onTouchStart={[Function]}
+                >
+                  <svg
+                    className="icon"
+                    viewBox="0 0 100 100"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M53.1,73h-7.2c-1.1,0-1.9-0.9-1.9-1.9V44h11v27.1C55,72.1,54.1,73,53.1,73z"
+                    />
+                    <path
+                      d="M55,39H44v-9.1c0-1.1,0.9-1.9,1.9-1.9h7.2c1.1,0,1.9,0.9,1.9,1.9V39z"
+                    />
+                    <path
+                      d="M50,96C24.6,96,4,75.4,4,50S24.6,4,50,4s46,20.6,46,46S75.4,96,50,96z M50,12c-21,0-38,17-38,38s17,38,38,38s38-17,38-38   S71,12,50,12z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div
+                className="flex-sub content-middle text-muted"
+                style={
+                  Object {
+                    "marginLeft": 5,
+                    "marginRight": 10,
+                    "minWidth": 55,
+                  }
+                }
+              >
+                <div
+                  className="text-right"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                >
+                   
+                  0.51
+                   
+                   
+                </div>
+              </div>
+              <div
+                className="flex-sub content-middle"
+                style={
+                  Object {
+                    "width": 50,
+                  }
+                }
+              >
+                <div
+                  className="performance-bar-container"
+                >
+                  <div
+                    className="performance-bar small"
+                    style={
+                      Object {
+                        "backgroundColor": "#4ec04e",
+                        "transition": "background-color 800ms",
+                        "width": "100%",
                       }
                     }
                   />

--- a/analysis/magefire/src/modules/Checklist/Component.tsx
+++ b/analysis/magefire/src/modules/Checklist/Component.tsx
@@ -73,6 +73,11 @@ const FireMageChecklist = ({ combatant, castEfficiency, thresholds }: ChecklistP
           tooltip="In order to get the most out of Combustion, which is a large contributor to your damage, you should ensure that you are using every second of the cooldown to cast spells and get damage out. Any time spent not casting anything during Combustion is a major loss of damage."
           thresholds={thresholds.combustionActiveTime}
         />
+        <Requirement
+          name="Avg. Combustion Pre-Cast Delay (seconds)"
+          tooltip="In order to get a head start on your Combustion cooldown, it is recommended to pre-cast an ability (like Fireball) and activate Combustion during that pre-cast. In order to minimize the delay after you activate Combustion, and to prevent losing a GCD during Combustion, it is recommended that you activate Combustion within the last 0.7 seconds of that pre-cast ability. If you do not want to adjust your gameplay or if you cannot accomplish this due to latency, you can tell RaidBots to use a different delay value by entering apl_variable.combustion_cast_remains=value (where value is the delay in seconds ... i.e. 1.1 or 0.9) in the Custom APL section."
+          thresholds={thresholds.combustionPreCastDelay}
+        />
         {combatant.hasTalent(SPELLS.METEOR_TALENT.id) && (
           <Requirement
             name="Meteor Utilization During Combustion"

--- a/analysis/magefire/src/modules/Checklist/Module.tsx
+++ b/analysis/magefire/src/modules/Checklist/Module.tsx
@@ -11,6 +11,7 @@ import CombustionCharges from '../features/CombustionCharges';
 import CombustionFirestarter from '../features/CombustionFirestarter';
 import CombustionSpellUsage from '../features/CombustionSpellUsage';
 import CombustionActiveTime from '../features/CombustionActiveTime';
+import CombustionPreCastDelay from '../features/CombustionPreCastDelay';
 import HeatingUp from '../features/HeatingUp';
 import HotStreak from '../features/HotStreak';
 import HotStreakWastedCrits from '../features/HotStreakWastedCrits';
@@ -33,6 +34,7 @@ class Checklist extends BaseChecklist {
     combustionFirestarter: CombustionFirestarter,
     combustionSpellUsage: CombustionSpellUsage,
     combustionActiveTime: CombustionActiveTime,
+    combustionPreCastDelay: CombustionPreCastDelay,
     heatingUp: HeatingUp,
     hotStreak: HotStreak,
     hotStreakWastedCrits: HotStreakWastedCrits,
@@ -56,6 +58,7 @@ class Checklist extends BaseChecklist {
   protected combustionFirestarter!: CombustionFirestarter;
   protected combustionSpellUsage!: CombustionSpellUsage;
   protected combustionActiveTime!: CombustionActiveTime;
+  protected combustionPreCastDelay!: CombustionPreCastDelay;
   protected heatingUp!: HeatingUp;
   protected hotStreak!: HotStreak;
   protected hotStreakWastedCrits!: HotStreakWastedCrits;
@@ -86,11 +89,10 @@ class Checklist extends BaseChecklist {
           phoenixFlamesCombustionCharges: this.combustionCharges.phoenixFlamesThresholds,
           fireBlastCombustionCharges: this.combustionCharges.fireBlastThresholds,
           firestarterCombustionUsage: this.combustionFirestarter.SuggestionThresholds,
-          scorchSpellUsageDuringCombustion: this.combustionSpellUsage
-            .scorchDuringCombustionThresholds,
-          fireballSpellUsageDuringCombustion: this.combustionSpellUsage
-            .fireballDuringCombustionThresholds,
+          scorchSpellUsageDuringCombustion: this.combustionSpellUsage.scorchDuringCombustionThresholds,
+          fireballSpellUsageDuringCombustion: this.combustionSpellUsage.fireballDuringCombustionThresholds,
           combustionActiveTime: this.combustionActiveTime.combustionActiveTimeThresholds,
+          combustionPreCastDelay: this.combustionPreCastDelay.combustionCastDelayThresholds,
           fireBlastHeatingUpUsage: this.heatingUp.fireBlastUtilSuggestionThresholds,
           phoenixFlamesHeatingUpUsage: this.heatingUp.phoenixFlamesUtilSuggestionThresholds,
           hotStreakUtilization: this.hotStreak.hotStreakUtilizationThresholds,

--- a/analysis/magefire/src/modules/features/Buffs.tsx
+++ b/analysis/magefire/src/modules/features/Buffs.tsx
@@ -46,6 +46,10 @@ class Buffs extends CoreBuffs {
         timelineHighlight: true,
       },
       {
+        spellId: SPELLS.DISCIPLINARY_COMMAND_BUFF.id,
+        timelineHighlight: true,
+      },
+      {
         spellId: SPELLS.MIRROR_IMAGE.id,
         triggeredBySpellId: SPELLS.MIRROR_IMAGE.id,
         timelineHighlight: true,

--- a/analysis/magefire/src/modules/features/CombustionActiveTime.tsx
+++ b/analysis/magefire/src/modules/features/CombustionActiveTime.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options } from 'parser/core/Analyzer';
-import Events, { RemoveBuffEvent } from 'parser/core/Events';
+import Events, { RemoveBuffEvent, FightEndEvent } from 'parser/core/Events';
 import Statistic from 'parser/ui/Statistic';
 import { SpellLink } from 'interface';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
-import { formatNumber, formatPercentage } from 'common/format';
+import { formatNumber, formatPercentage, formatDuration } from 'common/format';
 import EventHistory from 'parser/shared/modules/EventHistory';
 import FilteredActiveTime from 'parser/shared/modules/FilteredActiveTime';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
@@ -14,28 +14,44 @@ import { When, ThresholdStyle } from 'parser/core/ParseResults';
 import { SELECTED_PLAYER } from 'parser/core/EventFilter';
 import { Trans } from '@lingui/macro';
 
+import CombustionPreCastDelay from './CombustionPreCastDelay';
+
 
 class CombustionActiveTime extends Analyzer {
   static dependencies = {
     eventHistory: EventHistory,
     filteredActiveTime: FilteredActiveTime,
     abilityTracker: AbilityTracker,
+    combustionPreCastDelay: CombustionPreCastDelay,
   };
   protected eventHistory!: EventHistory;
   protected filteredActiveTime!: FilteredActiveTime;
   protected abilityTracker!: AbilityTracker;
+  protected combustionPreCastDelay!: CombustionPreCastDelay;
 
   activeTime = 0;
+  combustionCasts: number[] = [];
 
   constructor(options: Options) {
     super(options);
     this.addEventListener(Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.COMBUSTION), this.onCombustionRemoved);
+    this.addEventListener(Events.fightend, this.onFinished);
   }
 
   onCombustionRemoved(event: RemoveBuffEvent) {
     const buffApplied = this.eventHistory.last(1, undefined, Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.COMBUSTION))[0].timestamp;
     const uptime = this.filteredActiveTime.getActiveTime(buffApplied, event.timestamp)
+    this.combustionCasts[buffApplied] = uptime / (event.timestamp - buffApplied);
     this.activeTime += uptime;
+  }
+
+  onFinished(event: FightEndEvent) {
+    if (this.selectedCombatant.hasBuff(SPELLS.COMBUSTION.id)) {
+      const buffApplied = this.eventHistory.last(1, undefined, Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.COMBUSTION))[0].timestamp;
+      const uptime = this.filteredActiveTime.getActiveTime(buffApplied, event.timestamp)
+      this.combustionCasts[buffApplied] = uptime / (event.timestamp - buffApplied);
+      this.activeTime += uptime;
+    }
   }
 
   get buffUptime() {
@@ -81,12 +97,35 @@ class CombustionActiveTime extends Analyzer {
         size="flexible"
         tooltip={(
           <>
-            When using Combustion, you should ensure you are getting the most out of it by using every second of the cooldown as any time spent not casting anything is lost damage. While sometimes this will be out of your control due to boss mechanics, you should try to minimize that risk by using your cooldowns when you are least likely to get interrupted or the boss is vulnerable.
+            When using Combustion, you should ensure you are getting the most out of it by using every second of the cooldown as any time spent not casting anything is lost damage. While sometimes this will be out of your control due to boss mechanics, you should try to minimize that risk by using your cooldowns when you are least likely to get interrupted or the boss is vulnerable. <br /><br />Additionally, it is recommended that you minimize the delay from the time you activate Combustion until your pre-cast (the spell you were casting when you activated Combustion) finishes, to ensure you do not miss out on a GCD during Combustion while waiting for that pre-cast to finish. The recommendation (and the value that SimC/RaidBots uses) is to activate Combustion with 0.7 seconds or less remaining in your pre-cast, but if you do not want to adjust your gameplay or cannot accomplish this due to latency/ping issues then you can use the values below to tell RaidBots to adjust the delay that it uses to provide more accurate sims. To do this, enter "apl_variable.combustion_cast_remains=value" in the Custom APL section in Raid Bots (where "value" is the delay in seconds ... i.e. 1.1 or 0.9).
           </>
         )}
+        dropdown={(
+          <>
+            <table className="table table-condensed">
+            <thead>
+              <tr>
+                <th style={{ textAlign: 'left' }}>Timestamp</th>
+                <th style={{ textAlign: 'left' }}>Active Time</th>
+                <th style={{ textAlign: 'left' }}>Delay</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.keys(this.combustionPreCastDelay.combustionCasts).map((cast) => (
+                <tr key={cast}>
+                  <th style={{ textAlign: 'left' }}>{formatDuration((Number(cast) - this.owner.fight.start_time) / 1000)}</th>
+                  <th style={{ textAlign: 'left' }}>{formatPercentage(this.combustionCasts[Number(cast)])}</th>
+                  <td style={{ textAlign: 'left' }}>{(this.combustionPreCastDelay.combustionCasts[Number(cast)] / 1000).toFixed(2)}s</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
       >
         <BoringSpellValueText spell={SPELLS.COMBUSTION}>
-          {formatPercentage(this.percentActiveTime)}% <small>Combustion Active Time</small>
+          {formatPercentage(this.percentActiveTime)}% <small>Combustion Active Time</small><br />
+          {this.combustionPreCastDelay.averageCastDelay.toFixed(2)}s <small>Avg. Pre-Cast Delay</small>
         </BoringSpellValueText>
       </Statistic>
     );

--- a/analysis/magefire/src/modules/features/CombustionPreCastDelay.tsx
+++ b/analysis/magefire/src/modules/features/CombustionPreCastDelay.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import { SpellLink } from 'interface';
+import AbilityTracker from 'parser/shared/modules/AbilityTracker';
+import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
+import { When, ThresholdStyle } from 'parser/core/ParseResults';
+import Events, { ApplyBuffEvent, BeginCastEvent, CastEvent } from 'parser/core/Events';
+import { Trans } from '@lingui/macro';
+
+const COMBUSTION_PRE_CASTS = [
+  SPELLS.FIREBALL,
+  SPELLS.PYROBLAST,
+  SPELLS.SCORCH,
+  SPELLS.PHOENIX_FLAMES,
+  SPELLS.FLAMESTRIKE,
+];
+
+class CombustionPreCastDelay extends Analyzer {
+  static dependencies = {
+    abilityTracker: AbilityTracker,
+  };
+  protected abilityTracker!: AbilityTracker;
+
+  castStartedTimestamp = 0;
+  combustionTimestamp = 0;
+  totalCastDelay = 0;
+  combustionCasts: number[] = [];
+
+  constructor(options: Options) {
+    super(options);
+    this.addEventListener(Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.COMBUSTION), this.onCombustion);
+    this.addEventListener(Events.begincast.by(SELECTED_PLAYER).spell(COMBUSTION_PRE_CASTS), this.onPreCastStarted);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(COMBUSTION_PRE_CASTS), this.onPreCastFinished);
+  }
+
+  onCombustion(event: ApplyBuffEvent) {
+    this.combustionTimestamp = event.timestamp;
+  }
+
+  onPreCastStarted(event: BeginCastEvent) {
+    this.castStartedTimestamp = event.timestamp;
+    if (this.combustionTimestamp !== 0) {
+      const castDelay = event.timestamp - this.combustionTimestamp;
+      this.totalCastDelay += castDelay;
+      this.combustionCasts[this.combustionTimestamp] = castDelay;
+      this.castStartedTimestamp = 0;
+      this.combustionTimestamp = 0;
+    }
+  }
+
+  onPreCastFinished(event: CastEvent) {
+    if (this.combustionTimestamp === 0) {
+      this.castStartedTimestamp = 0;
+      return;
+    }
+    const castDelay = event.timestamp - this.combustionTimestamp;
+    this.totalCastDelay += castDelay;
+    this.combustionCasts[this.combustionTimestamp] = castDelay;
+    this.castStartedTimestamp = 0;
+    this.combustionTimestamp = 0;
+  }
+
+  get averageCastDelay() {
+    return this.totalCastDelay / this.abilityTracker.getAbility(SPELLS.COMBUSTION.id).casts / 1000;
+  }
+
+  get combustionCastDelayThresholds() {
+    return {
+      actual: this.averageCastDelay,
+      isGreaterThan: {
+        minor: 0.7,
+        average: 1,
+        major: 1.5,
+      },
+      style: ThresholdStyle.DECIMAL,
+    };
+  }
+
+  suggestions(when: When) {
+    when(this.combustionCastDelayThresholds)
+      .addSuggestion((suggest, actual, recommended) => suggest(<>On average, you used <SpellLink id={SPELLS.COMBUSTION.id} /> with {this.averageCastDelay} seconds left on your pre-cast ability (The spell you were casting when you used <SpellLink id={SPELLS.COMBUSTION.id} />). In order to maximize the number of casts you can get in during <SpellLink id={SPELLS.COMBUSTION.id} />, it is recommended that you are activating <SpellLink id={SPELLS.COMBUSTION.id} /> closer to the end of your pre-cast (preferably within {recommended} seconds of the cast completing).</>)
+          .icon(SPELLS.COMBUSTION.icon)
+          .actual(<Trans id="mage.fire.suggestions.combustion.castDelay">{actual}s Avg. Pre-Cast Delay</Trans>)
+          .recommended(`${recommended} is recommended`));
+  }
+}
+export default CombustionPreCastDelay;

--- a/analysis/magefire/src/modules/items/DisciplinaryCommand.tsx
+++ b/analysis/magefire/src/modules/items/DisciplinaryCommand.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import { SpellLink } from 'interface';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import Events, { ApplyBuffEvent, RemoveBuffEvent, FightEndEvent } from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import { When, ThresholdStyle } from 'parser/core/ParseResults';
+import { SELECTED_PLAYER } from 'parser/core/EventFilter';
+import { formatPercentage } from 'common/format';
+import { Trans } from '@lingui/macro';
+
+class DisciplinaryCommand extends Analyzer {
+
+  combustionStartTimestamp = 0;
+  disciplinaryCommandStartTimestamp = 0;
+  disciplinaryCommandEndTimestamp = 0;
+  disciplinaryCommandUptime = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.DISCIPLINARY_COMMAND.bonusID);
+    this.addEventListener(Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.COMBUSTION), this.onCombustionStart);
+    this.addEventListener(Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.COMBUSTION), this.onCombustionEnd)
+    this.addEventListener(Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.DISCIPLINARY_COMMAND_BUFF), this.onBuffApplied);
+    this.addEventListener(Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.DISCIPLINARY_COMMAND_BUFF), this.onBuffRemoved);
+    this.addEventListener(Events.fightend, this.onFinished);
+  }
+
+  onCombustionStart(event: ApplyBuffEvent) {
+    this.combustionStartTimestamp = event.timestamp;
+    if (this.selectedCombatant.hasBuff(SPELLS.DISCIPLINARY_COMMAND_BUFF.id)) {
+      this.disciplinaryCommandStartTimestamp = event.timestamp;
+    }
+  }
+
+  onCombustionEnd(event: RemoveBuffEvent) {
+    if (this.disciplinaryCommandStartTimestamp === 0 && this.combustionStartTimestamp !== 0) {
+      return;
+    }
+
+    const buffApplied = this.selectedCombatant.hasBuff(SPELLS.DISCIPLINARY_COMMAND_BUFF.id);
+    this.disciplinaryCommandUptime += buffApplied ? event.timestamp - (this.disciplinaryCommandStartTimestamp || 0) : this.disciplinaryCommandEndTimestamp - this.combustionStartTimestamp;
+
+    this.combustionStartTimestamp = 0;
+    this.disciplinaryCommandStartTimestamp = 0;
+    this.disciplinaryCommandEndTimestamp = 0;
+  }
+
+  onBuffApplied(event: ApplyBuffEvent) {
+    this.disciplinaryCommandStartTimestamp = event.timestamp;
+  }
+
+  onBuffRemoved(event: RemoveBuffEvent) {
+    if (this.selectedCombatant.hasBuff(SPELLS.COMBUSTION.id)) {
+      this.disciplinaryCommandEndTimestamp = event.timestamp;
+    } else {
+      this.disciplinaryCommandStartTimestamp = 0;
+      this.disciplinaryCommandEndTimestamp = 0;
+    }
+  }
+
+  onFinished(event: FightEndEvent) {
+    if (!this.selectedCombatant.hasBuff(SPELLS.COMBUSTION.id)) {
+      return;
+    }
+    const buffApplied = this.selectedCombatant.hasBuff(SPELLS.DISCIPLINARY_COMMAND_BUFF.id);
+    this.disciplinaryCommandUptime += buffApplied ? event.timestamp - this.disciplinaryCommandStartTimestamp : this.combustionStartTimestamp - this.disciplinaryCommandEndTimestamp;
+  }
+
+  get percentUptimeDuringCombustion() {
+    return this.disciplinaryCommandUptime / this.selectedCombatant.getBuffUptime(SPELLS.COMBUSTION.id);
+  }
+
+  get disciplinaryCommandUptimeThresholds() {
+    return {
+      actual: this.percentUptimeDuringCombustion,
+      isLessThan: {
+        average: 1,
+        major: .9,
+      },
+      style: ThresholdStyle.PERCENTAGE,
+    };
+  }
+
+  suggestions(when: When) {
+    when(this.disciplinaryCommandUptimeThresholds)
+      .addSuggestion((suggest, actual, recommended) => suggest(<>You had the buff from <SpellLink id={SPELLS.DISCIPLINARY_COMMAND_BUFF.id} /> up for {formatPercentage(this.percentUptimeDuringCombustion,0)}% of your <SpellLink id={SPELLS.COMBUSTION.id} />. In order to get the most out of <SpellLink id={SPELLS.DISCIPLINARY_COMMAND_BUFF.id} /> you should ensure that you are triggering it with your <SpellLink id={SPELLS.COMBUSTION.id} /> cast, or within a couple seconds before, so that it is up for the entire duration of <SpellLink id={SPELLS.COMBUSTION.id} />.</>)
+          .icon(SPELLS.DISCIPLINARY_COMMAND_BUFF.icon)
+          .actual(<Trans id="mage.fire.suggestions.disciplinaryCommand.uptime">{formatPercentage(actual,0)}% Buff Uptime During Combustion</Trans>)
+          .recommended(`${formatPercentage(recommended)}% is recommended`));
+  }
+  
+
+  statistic() {
+    return (
+      <Statistic
+        category={STATISTIC_CATEGORY.ITEMS}
+        size="flexible"
+      >
+        <BoringSpellValueText spell={SPELLS.DISCIPLINARY_COMMAND}>
+          {formatPercentage(this.percentUptimeDuringCombustion,0)}% <small>Uptime during Combustion</small>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default DisciplinaryCommand;

--- a/analysis/magefrost/src/CHANGELOG.tsx
+++ b/analysis/magefrost/src/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2021, 3, 6), 'Updated for Patch 9.0.5.', Sharrq),
   change(date(2021, 1, 15), <>Fixed an issue that was not adding the proper amount of additional CDR from <SpellLink id={SPELLS.DISCIPLINE_OF_THE_GROVE.id} />.</>, Sharrq),
   change(date(2020, 12, 28), <>Updated conduit statistic boxes to use the new layout.</>, Sharrq),
   change(date(2020, 12, 24), <>Fixed an error in <SpellLink id={SPELLS.GLACIAL_FRAGMENTS.id} /> that was not properly counting absorbed damage.</>, Sharrq),

--- a/analysis/magefrost/src/CONFIG.tsx
+++ b/analysis/magefrost/src/CONFIG.tsx
@@ -11,7 +11,7 @@ const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Sharrq, Dambroda],
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.0.2',
+  patchCompatibility: '9.0.5',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more. If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (

--- a/src/common/SPELLS/shadowlands/legendaries/mage.ts
+++ b/src/common/SPELLS/shadowlands/legendaries/mage.ts
@@ -5,6 +5,11 @@ const legendaries = {
     icon: 'spell_fire_masterofelements',
     bonusID: 6832,
   },
+  DISCIPLINARY_COMMAND_BUFF: {
+    id: 327371,
+    name: 'Disciplinary Command',
+    icon: 'spell_fire_masterofelements',
+  },
   EXPANDED_POTENTIAL: {
     id: 327489,
     name: 'Expanded Potential',

--- a/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
+++ b/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
@@ -55,6 +55,7 @@ const spells: number[] = [
 
   //region Mage
   SPELLS.RUNE_OF_POWER_BUFF.id,
+  SPELLS.DISCIPLINARY_COMMAND_BUFF.id,
 
   //region Covenants
   SPELLS.COMBAT_MEDITATION_TRIGGER.id, //The Spell ID when Combat Meditation from Kyrian Soulbind triggers, so that there is now a soul ready to pick up


### PR DESCRIPTION
Added/Changed the following to support 9.0.5

- Added support for Disciplinary Command and a check to ensure the buff covers 100% of Combustion (Requested by Mage Discord)
- Added a check for the amount of delay between using Combustion and letting your pre-cast finish (Requested by Mage Discord)
- Adjusted the Combustion Stat Box to show the Active Time and Pre-Cast Delay as well as a breakdown for each cast
- Added Disciplinary Command to the timeline buffs and Casts that arent casts (it was causing cancelled casts)
- Updated Arcane Harmony and Mirrors of Torment based on 9.0.5 changes.