### PR TITLE
Implemented suggestions in timeline for unempowered Wrath and Starfire

### DIFF
--- a/analysis/druidbalance/src/CHANGELOG.tsx
+++ b/analysis/druidbalance/src/CHANGELOG.tsx
@@ -1,7 +1,11 @@
 import { Zeboot, LeoZhekov, Sharrq, Tiboonn, Kartarn, Ciuffi } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
+import { SpellLink } from 'interface';
+import SPELLS from 'common/SPELLS';
+import React from 'react';
 
 export default [
+  change(date(2021, 3, 7), <> Implemented correct wrong-cast suggestions in timeline for casting <SpellLink id={SPELLS.STARFIRE.id} /> and <SpellLink id={SPELLS.WRATH_MOONKIN.id} /> while not in the correct eclipse.</>, Kartarn),
   change(date(2021, 2, 21), 'Add modules for Starfire and Wrath to track unempowered casts', Tiboonn),
   change(date(2021, 2, 12), 'Added convoke tracking to the statistics page', Ciuffi),
   change(date(2021, 2, 13), 'Added Analyzer for utilizing Balance of All things legendary.', Kartarn),

--- a/analysis/druidbalance/src/integrationTests/example.test.ts.snap
+++ b/analysis/druidbalance/src/integrationTests/example.test.ts.snap
@@ -4426,38 +4426,6 @@ exports[`Balance Druid integration test: example log ThroughputStatisticGroup ma
 </div>
 `;
 
-exports[`Balance Druid integration test: example log UnempoweredStarfire matches the suggestions snapshot 1`] = `
-Array [
-  Object {
-    "details": null,
-    "icon": "spell_arcane_starfire",
-    "importance": "minor",
-    "issue": <React.Fragment>
-      You casted 
-      17
-       unempowered and non instant cast 
-      <ForwardRef
-        id={194153}
-      />
-       that hit less than 
-      5
-       targets, outside the 
-      2
-       needed to get to 
-      <ForwardRef
-        id={48518}
-      />
-    </React.Fragment>,
-    "stat": <React.Fragment>
-      {"id":"druid.balance.suggestions.starfire.efficiency","message":"{0} Unempowered Starfires per minute","values":{"0":"0.2"}}
-       (
-      0 is recommended
-      )
-    </React.Fragment>,
-  },
-]
-`;
-
 exports[`Balance Druid integration test: example log matches the checklist snapshot 1`] = `
 <ul
   className="checklist"

--- a/analysis/druidbalance/src/modules/features/UnempoweredStarfire.tsx
+++ b/analysis/druidbalance/src/modules/features/UnempoweredStarfire.tsx
@@ -29,6 +29,7 @@ class UnempoweredStarfire extends Analyzer {
   badCasts = 0;
   lastCast?: CastEvent;
   lastCastBuffed = false;
+  lastCastSolarEclipse = false;
   hits = 0;
   eclipseCount = 0;
 
@@ -41,7 +42,12 @@ class UnempoweredStarfire extends Analyzer {
   }
 
   checkCast() {
+    // we check the last cast instead of the current one, because we can't analyze how much targets were hit in the current cast
     if (this.lastCastBuffed || this.hits >= TARGETS_FOR_GOOD_CAST || !this.lastCast) {
+      return;
+    }
+    // if the player was in neither Eclipse, he used the spell to get into an eclipse, thus this cast is not considered bad
+    if (!this.lastCastBuffed && !this.lastCastSolarEclipse) {
       return;
     }
     this.badCasts += 1;
@@ -60,6 +66,7 @@ class UnempoweredStarfire extends Analyzer {
     this.lastCastBuffed = this.selectedCombatant.hasBuff(SPELLS.ECLIPSE_LUNAR.id)
       || this.selectedCombatant.hasBuff(SPELLS.OWLKIN_FRENZY.id)
       || this.selectedCombatant.hasBuff(SPELLS.WARRIOR_OF_ELUNE_TALENT.id);
+    this.lastCastSolarEclipse = this.selectedCombatant.hasBuff(SPELLS.ECLIPSE_SOLAR.id);
     this.hits = 0;
   }
 

--- a/analysis/druidbalance/src/modules/features/UnempoweredWrath.tsx
+++ b/analysis/druidbalance/src/modules/features/UnempoweredWrath.tsx
@@ -4,7 +4,7 @@ import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import { t } from '@lingui/macro';
-import Events, { CastEvent, DamageEvent, ApplyBuffEvent } from 'parser/core/Events';
+import Events, { CastEvent, ApplyBuffEvent } from 'parser/core/Events';
 
 const UNEMPOWERED_CASTS_NEEDED_FOR_EMPOWERMENT = 2;
 

--- a/analysis/druidbalance/src/modules/features/UnempoweredWrath.tsx
+++ b/analysis/druidbalance/src/modules/features/UnempoweredWrath.tsx
@@ -28,19 +28,21 @@ class UnempoweredWrath extends Analyzer {
   badCasts = 0;
   lastCast?: CastEvent;
   lastCastBuffed = false;
-  hits = 0;
   eclipseCount = 0;
 
   constructor(options: Options) {
     super(options);
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.WRATH_MOONKIN), this.onCast);
-    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.WRATH_MOONKIN), this.onDamage);
     this.addEventListener(Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.ECLIPSE_SOLAR), this.onApplyBuff);
     this.addEventListener(Events.fightend, this.onFightend);
   }
 
   checkCast() {
     if (this.lastCastBuffed || !this.lastCast) {
+      return;
+    }
+    // if the player was in neither Eclipse, he used the spell to get into an eclipse, thus this cast is not considered bad
+    if(!this.selectedCombatant.hasBuff(SPELLS.ECLIPSE_LUNAR) && !this.selectedCombatant.hasBuff(SPELLS.ECLIPSE_SOLAR)) {
       return;
     }
     this.badCasts += 1;
@@ -54,14 +56,9 @@ class UnempoweredWrath extends Analyzer {
   }
 
   onCast(event: CastEvent) {
-    this.checkCast();
     this.lastCast = event;
     this.lastCastBuffed = this.selectedCombatant.hasBuff(SPELLS.ECLIPSE_SOLAR.id);
-    this.hits = 0;
-  }
-
-  onDamage(event: DamageEvent) {
-    this.hits += 1;
+    this.checkCast();
   }
 
   onFightend() {


### PR DESCRIPTION
To get into an Eclipse you need to cast either two unempowered Starfire or Wrath, depending. Currently those two cast get marked as wrong in the timeline.

Old:
![image](https://user-images.githubusercontent.com/36763177/110243848-6ef1ef00-7f5c-11eb-9fb5-46e6428d8f88.png)

New:
![image](https://user-images.githubusercontent.com/36763177/110243854-7addb100-7f5c-11eb-99d5-f96614788512.png)
