### PR TITLE
soul infusion module fix

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 
 // prettier-ignore
 export default [
+  change(date(2021, 3, 11), <>Fixed <SpellLink id={SPELLS.SOUL_INFUSION.id}/> calculator causing errors on Sun King</>, acornellier),
   change(date(2021, 3, 8), 'Converted most Report related components to TS', acornellier),
   change(date(2021, 3, 3), 'Converted dungeon files to TS and added Dungeon interface', Procyon),
   change(date(2021, 3, 3), 'Converted various components to functional components in TypeScript.', acornellier),

--- a/src/parser/shared/modules/Channeling.js
+++ b/src/parser/shared/modules/Channeling.js
@@ -13,10 +13,12 @@ class Channeling extends Analyzer {
   };
   _currentChannel = null;
 
-  constructor(options) {
+  constructor(options, addEventListeners = true) {
     super(options);
-    this.addEventListener(Events.begincast.by(SELECTED_PLAYER), this.onBegincast);
-    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onCast);
+    if (addEventListeners) {
+      this.addEventListener(Events.begincast.by(SELECTED_PLAYER), this.onBegincast);
+      this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onCast);
+    }
   }
 
   beginChannel(event, ability = event.ability) {

--- a/src/parser/shared/modules/spells/SoulInfusion.tsx
+++ b/src/parser/shared/modules/spells/SoulInfusion.tsx
@@ -9,7 +9,7 @@ import CoreChanneling from 'parser/shared/modules/Channeling';
 
 class SoulInfusion extends CoreChanneling {
   constructor(options: Options) {
-    super(options);
+    super(options, false);
 
     const boss = this.owner.boss;
     this.active = boss === bosses.bosses['SunKingsSalvation'];


### PR DESCRIPTION
The event listeners were being created twice - once for the regular `Channeling` and once for the `SoulInfusion`. I can't think of a cleaner way to fix this so I just added an optional flag to the constructor. Probably best to just delete the module completely, unless there's a better way.