### PR TITLE
[Mage] Reverting to 9.0.2 and Ending Support for Mage

### DIFF
--- a/.env
+++ b/.env
@@ -6,7 +6,7 @@
 
 ## Game information.
 # The current version of the game. Used to check spec patch compatibility and as a caching key.
-REACT_APP_CURRENT_GAME_PATCH=9.0.2
+REACT_APP_CURRENT_GAME_PATCH=9.0.5
 
 ## Development settings.
 # The API key to use to fetch information from Warcraft Logs. You need to enter your own API key by creating a new file in the root repo called `.env.local` with the contents: `WCL_API_KEY=INSERT_YOUR_API_KEY_HERE`. After saving this file, you need to restart `yarn start`.

--- a/analysis/magearcane/src/CHANGELOG.tsx
+++ b/analysis/magearcane/src/CHANGELOG.tsx
@@ -7,6 +7,8 @@ import React from 'react';
 
 // prettier-ignore
 export default [
+  change(date(2021, 3, 11), 'Reverting support back to Patch 9.0.2 as Arcane Mage has not been fully tested/updated for 9.0.5.', Sharrq),
+  change(date(2021, 3, 11), 'Removed myself as a contributor/maintainer for Arcane Mage. Marked Arcane Mage as Unsupported/Unmaintained.', Sharrq),
   change(date(2021, 3, 6), 'Updated for Patch 9.0.5.', Sharrq),
   change(date(2021, 1, 15), <>Fixed an issue that was not adding the proper amount of additional CDR from <SpellLink id={SPELLS.DISCIPLINE_OF_THE_GROVE.id} />.</>, Sharrq),
   change(date(2020, 12, 28), <>Updated conduit statistic boxes to use the new layout.</>, Sharrq),

--- a/analysis/magearcane/src/CONFIG.tsx
+++ b/analysis/magearcane/src/CONFIG.tsx
@@ -13,8 +13,9 @@ export default {
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
-      As of March 11, 2021, Arcane Mage is no longer being maintained or supported. 
-      <br /><br />
+      As of March 11, 2021, Arcane Mage is no longer being maintained or supported 
+      <br />
+      <br />
       If you are looking for help improving your gameplay, refer to the resources below:
       <br />
       <a href="https://discord.gg/0gLMHikX2aZ23VdA" target="_blank" rel="noopener noreferrer">

--- a/analysis/magearcane/src/CONFIG.tsx
+++ b/analysis/magearcane/src/CONFIG.tsx
@@ -1,4 +1,3 @@
-import { Sharrq } from 'CONTRIBUTORS';
 import SPECS from 'game/SPECS';
 import React from 'react';
 
@@ -6,31 +5,15 @@ import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Sharrq],
+  contributors: [],
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.0.5',
+  patchCompatibility: '9.0.2',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
-      Hello Everyone! We are always looking to improve the Arcane Mage Analyzers and Modules; so if
-      you find any issues or if there is something missing that you would like to see added, please{' '}
-      <a
-        href="https://github.com/WoWAnalyzer/WoWAnalyzer/issues/new?labels=Mage"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        open an issue
-      </a>{' '}
-      on GitHub or send us a message on the{' '}
-      <a href="https://wowanalyzer.com/discord" target="_blank" rel="noopener noreferrer">
-        WoWAnalyzer Discord
-      </a>
-      .<br />
-      <br />
-      If you need additional assistance in improving your gameplay as an Arcane Mage or
-      interpretting the information provided, please refer to the following resources:
+      As of March 11, 2021, Arcane Mage is no longer being maintained or supported. If you are looking for help improving your gameplay, refer to the resources below:
       <br />
       <a href="https://discord.gg/0gLMHikX2aZ23VdA" target="_blank" rel="noopener noreferrer">
         Mage Class Discord

--- a/analysis/magearcane/src/CONFIG.tsx
+++ b/analysis/magearcane/src/CONFIG.tsx
@@ -13,7 +13,9 @@ export default {
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
-      As of March 11, 2021, Arcane Mage is no longer being maintained or supported. If you are looking for help improving your gameplay, refer to the resources below:
+      As of March 11, 2021, Arcane Mage is no longer being maintained or supported. 
+      <br /><br />
+      If you are looking for help improving your gameplay, refer to the resources below:
       <br />
       <a href="https://discord.gg/0gLMHikX2aZ23VdA" target="_blank" rel="noopener noreferrer">
         Mage Class Discord

--- a/analysis/magearcane/src/CONFIG.tsx
+++ b/analysis/magearcane/src/CONFIG.tsx
@@ -13,7 +13,7 @@ export default {
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
-      As of March 11, 2021, Arcane Mage is no longer being maintained or supported 
+      As of March 11, 2021, Arcane Mage is no longer being maintained or supported
       <br />
       <br />
       If you are looking for help improving your gameplay, refer to the resources below:

--- a/analysis/magefire/src/CHANGELOG.tsx
+++ b/analysis/magefire/src/CHANGELOG.tsx
@@ -6,6 +6,8 @@ import React from 'react';
 
 
 export default [
+  change(date(2021, 3, 11), 'Reverting support back to Patch 9.0.2 as Fire Mage has not been fully tested/updated for 9.0.5.', Sharrq),
+  change(date(2021, 3, 11), 'Removed myself as a contributor/maintainer for Fire Mage. Marked Fire Mage as Unsupported/Unmaintained.', Sharrq),
   change(date(2021, 3, 6), 'Updated for Patch 9.0.5.', Sharrq),
   change(date(2021, 3, 6), <>Adjusted <SpellLink id={SPELLS.COMBUSTION.id} /> Statistics to show a breakdown of the active time and pre-cast delay for each cast.</>, Sharrq),
   change(date(2021, 3, 6), <>Added the ability to check the delay between using <SpellLink id={SPELLS.COMBUSTION.id} /> and the end of pre-cast abilities.</>, Sharrq),

--- a/analysis/magefire/src/CONFIG.tsx
+++ b/analysis/magefire/src/CONFIG.tsx
@@ -13,7 +13,7 @@ export default {
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
-      As of March 11, 2021, Fire Mage is no longer being maintained or supported 
+      As of March 11, 2021, Fire Mage is no longer being maintained or supported
       <br />
       <br />
       If you are looking for help improving your gameplay, refer to the resources below:

--- a/analysis/magefire/src/CONFIG.tsx
+++ b/analysis/magefire/src/CONFIG.tsx
@@ -1,4 +1,3 @@
-import { Sharrq } from 'CONTRIBUTORS';
 import SPECS from 'game/SPECS';
 import React from 'react';
 
@@ -6,31 +5,15 @@ import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Sharrq],
+  contributors: [],
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.0.5',
+  patchCompatibility: '9.0.2',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
-      Hello Everyone! We are always looking to improve the Fire Mage Analyzers and Modules; so if
-      you find any issues or if there is something missing that you would like to see added, please{' '}
-      <a
-        href="https://github.com/WoWAnalyzer/WoWAnalyzer/issues/new?labels=Mage"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        open an issue
-      </a>{' '}
-      on GitHub or send us a message on the{' '}
-      <a href="https://wowanalyzer.com/discord" target="_blank" rel="noopener noreferrer">
-        WoWAnalyzer Discord
-      </a>
-      .<br />
-      <br />
-      If you need additional assistance in improving your gameplay as an Fire Mage or interpretting
-      the information provided, please refer to the following resources:
+      As of March 11, 2021, Fire Mage is no longer being maintained or supported. If you are looking for help improving your gameplay, refer to the resources below:
       <br />
       <a href="https://discord.gg/0gLMHikX2aZ23VdA" target="_blank" rel="noopener noreferrer">
         Mage Class Discord

--- a/analysis/magefire/src/CONFIG.tsx
+++ b/analysis/magefire/src/CONFIG.tsx
@@ -13,8 +13,9 @@ export default {
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
-      As of March 11, 2021, Fire Mage is no longer being maintained or supported. 
-      <br /><br />
+      As of March 11, 2021, Fire Mage is no longer being maintained or supported 
+      <br />
+      <br />
       If you are looking for help improving your gameplay, refer to the resources below:
       <br />
       <a href="https://discord.gg/0gLMHikX2aZ23VdA" target="_blank" rel="noopener noreferrer">

--- a/analysis/magefire/src/CONFIG.tsx
+++ b/analysis/magefire/src/CONFIG.tsx
@@ -13,7 +13,9 @@ export default {
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
-      As of March 11, 2021, Fire Mage is no longer being maintained or supported. If you are looking for help improving your gameplay, refer to the resources below:
+      As of March 11, 2021, Fire Mage is no longer being maintained or supported. 
+      <br /><br />
+      If you are looking for help improving your gameplay, refer to the resources below:
       <br />
       <a href="https://discord.gg/0gLMHikX2aZ23VdA" target="_blank" rel="noopener noreferrer">
         Mage Class Discord

--- a/analysis/magefrost/src/CHANGELOG.tsx
+++ b/analysis/magefrost/src/CHANGELOG.tsx
@@ -6,6 +6,8 @@ import React from 'react';
 
 
 export default [
+  change(date(2021, 3, 11), 'Reverting support back to Patch 9.0.2 as Frost Mage has not been fully tested/updated for 9.0.5.', Sharrq),
+  change(date(2021, 3, 11), 'Removed myself as a contributor/maintainer for Frost Mage. Marked Frost Mage as Unsupported/Unmaintained.', Sharrq),
   change(date(2021, 3, 6), 'Updated for Patch 9.0.5.', Sharrq),
   change(date(2021, 1, 15), <>Fixed an issue that was not adding the proper amount of additional CDR from <SpellLink id={SPELLS.DISCIPLINE_OF_THE_GROVE.id} />.</>, Sharrq),
   change(date(2020, 12, 28), <>Updated conduit statistic boxes to use the new layout.</>, Sharrq),

--- a/analysis/magefrost/src/CONFIG.tsx
+++ b/analysis/magefrost/src/CONFIG.tsx
@@ -1,4 +1,4 @@
-import { Sharrq, Dambroda } from 'CONTRIBUTORS';
+import { Dambroda } from 'CONTRIBUTORS';
 import SPECS from 'game/SPECS';
 import Config from 'parser/Config';
 import React from 'react';
@@ -7,30 +7,14 @@ import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Sharrq, Dambroda],
+  contributors: [Dambroda],
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.0.5',
+  patchCompatibility: '9.0.2',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more. If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
-      Hello Everyone! We are always looking to improve the Frost Mage Analyzers and Modules; so if
-      you find any issues or if there is something missing that you would like to see added, please{' '}
-      <a
-        href="https://github.com/WoWAnalyzer/WoWAnalyzer/issues/new?labels=Mage"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        open an issue
-      </a>{' '}
-      on GitHub or send us a message on the{' '}
-      <a href="https://wowanalyzer.com/discord" target="_blank" rel="noopener noreferrer">
-        WoWAnalyzer Discord
-      </a>
-      .<br />
-      <br />
-      If you need additional assistance in improving your gameplay as an Frost Mage or interpretting
-      the information provided, please refer to the following resources:
+      As of March 11, 2021, Frost Mage is no longer being maintained or supported. If you are looking for help improving your gameplay, refer to the resources below:
       <br />
       <a href="https://discord.gg/0gLMHikX2aZ23VdA" target="_blank" rel="noopener noreferrer">
         Mage Class Discord

--- a/analysis/magefrost/src/CONFIG.tsx
+++ b/analysis/magefrost/src/CONFIG.tsx
@@ -14,7 +14,9 @@ const config: Config = {
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more. If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
-      As of March 11, 2021, Frost Mage is no longer being maintained or supported. If you are looking for help improving your gameplay, refer to the resources below:
+      As of March 11, 2021, Frost Mage is no longer being maintained or supported. 
+      <br /><br />
+      If you are looking for help improving your gameplay, refer to the resources below:
       <br />
       <a href="https://discord.gg/0gLMHikX2aZ23VdA" target="_blank" rel="noopener noreferrer">
         Mage Class Discord

--- a/analysis/magefrost/src/CONFIG.tsx
+++ b/analysis/magefrost/src/CONFIG.tsx
@@ -14,8 +14,9 @@ const config: Config = {
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more. If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
-      As of March 11, 2021, Frost Mage is no longer being maintained or supported. 
-      <br /><br />
+      As of March 11, 2021, Frost Mage is no longer being maintained or supported 
+      <br />
+      <br />
       If you are looking for help improving your gameplay, refer to the resources below:
       <br />
       <a href="https://discord.gg/0gLMHikX2aZ23VdA" target="_blank" rel="noopener noreferrer">

--- a/analysis/magefrost/src/CONFIG.tsx
+++ b/analysis/magefrost/src/CONFIG.tsx
@@ -14,7 +14,7 @@ const config: Config = {
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more. If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
-      As of March 11, 2021, Frost Mage is no longer being maintained or supported 
+      As of March 11, 2021, Frost Mage is no longer being maintained or supported
       <br />
       <br />
       If you are looking for help improving your gameplay, refer to the resources below:

--- a/src/parser/Config.ts
+++ b/src/parser/Config.ts
@@ -39,6 +39,7 @@ interface Config {
     | '8.3'
     | '9.0.1'
     | '9.0.2'
+    | '9.0.5'
     | string;
   /**
    * Whether support for the spec is only partial and some important elements


### PR DESCRIPTION
I am reverting the mage specs back to 9.0.2 because while i made the changes that I know about to the specs (via the wow patch notes), I have not had a chance to go over any further changes needed for 9.0.5 support with the Mage Discord. I had bumped these up to 9.0.5 pre-emptively with the expectation that I was going to continue monitoring and testing with 9.0.5 logs to ensure everything was working properly, but now that I am withdrawing my support from WoWAnalyzer and as a result these mage specs, that is no longer the case. So i am reverting these back to 9.0.2 until someone can confirm everything.

Additionally, as mentioned above, I am removing myself as a maintainer as I no longer intend to contribute to the mage specs or WoWAnalyzer as a whole.