### PR TITLE
Fixes WoWAnalyzer#4445 : FoodChecker now checks druid conduit Born Anew

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 
 // prettier-ignore
 export default [
+  change(date(2021, 3, 20), <> Fixed food check warning when druid conduit's <SpellLink id={SPELLS.DRUID_BORN_ANEW.id} /> was present on fight start.</>, Kartarn),
   change(date(2021, 3, 16), 'Fixed issue with contributor icons.', emallson),
   change(date(2021, 3, 8), 'Converted most Report related components to TS', acornellier),
   change(date(2021, 3, 3), 'Converted dungeon files to TS and added Dungeon interface', Procyon),

--- a/src/common/SPELLS/shadowlands/others.ts
+++ b/src/common/SPELLS/shadowlands/others.ts
@@ -114,6 +114,11 @@ const spells = {
     name: 'Feast of Gluttonous Hedonism',
     icon: 'inv_tradeskill_cooking_shadowlandsfeast_large01',
   },
+  DRUID_BORN_ANEW: {
+    id: 341449,
+    name: 'Born Anew',
+    icon: 'spell_nature_reincarnation',
+  },
   VEILED_AUGMENT_RUNE: {
     id: 347901,
     name: 'Veiled Augment Rune',

--- a/src/parser/shared/modules/items/FoodChecker.ts
+++ b/src/parser/shared/modules/items/FoodChecker.ts
@@ -47,6 +47,9 @@ const HIGHER_FOOD_IDS = [
   SPELLS.TENEBROUS_CROWN_ROAST_ASPIC.id,
   SPELLS.IRIDESCENT_RAVIOLI_WITH_APPLE_SAUCE.id,
   SPELLS.STEAK_A_LA_MODE.id,
+
+  //30 Primary stat Druid Conduit 'Born Anew' Well Fed Buff
+  SPELLS.DRUID_BORN_ANEW.id,
 ];
 
 class FoodChecker extends Analyzer {


### PR DESCRIPTION
When a druid has the https://www.wowhead.com/spell=341280/born-anew conduit and Battle-revives someone, the revived player gets a special Well Fed buff, gaining 30 Primary Stat.