### PR TITLE
Updated Balance Druid About page

### DIFF
--- a/analysis/druidbalance/src/CHANGELOG.tsx
+++ b/analysis/druidbalance/src/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import { SpellLink } from 'interface';
 import React from 'react';
 
 export default [
-
+  change(date(2021, 4, 2), 'Updated \'About\' page for Shadowlands and current state of the spec\'s analyzer.', Kartarn),
   change(date(2021, 3, 20), <> Astral Power usage efficiency now takes into consideration if <SpellLink id={SPELLS.BALANCE_OF_ALL_THINGS_SOLAR.id} /> legendary is used. </>, Kartarn),
   change(date(2021, 3, 10), 'Updated Starlord, Stellar Drift and Twin Moons talents for Shadowlands.', Kartarn),
   change(date(2021, 3, 10), <> Implemented correct wrong-cast suggestions in timeline for casting <SpellLink id={SPELLS.STARFIRE.id} /> and <SpellLink id={SPELLS.WRATH_MOONKIN.id} /> while not in the correct eclipse.</>, Kartarn),

--- a/analysis/druidbalance/src/CONFIG.tsx
+++ b/analysis/druidbalance/src/CONFIG.tsx
@@ -1,25 +1,38 @@
+import SPELLS from 'common/SPELLS';
+import { Kartarn } from 'CONTRIBUTORS';
 import SPECS from 'game/SPECS';
+import { SpellLink } from 'interface';
 import React from 'react';
 
 import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [],
+  contributors: [Kartarn],
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.0.2',
+  patchCompatibility: '9.0.5',
   isPartial: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
       Hello Moonkins! This tool is intended to show major statistics and potential issues in your
-      rotation. Please mind that it can always be improved upon, so if you see anything that you
-      disagree with or think is missing please let us know!
+      rotation. The Balance Druid analyzer is not yet fully updated for Shadowlands but the most
+      important informations like DoT uptime, Eclipse usage and usage of the (most popular) Balance
+      of All Things legendary should give you a quick overview about your performance.
       <br />
       <br />
-      As a rule of thumb: Never overcap Astral Power, don't overcap empowerments and keep your dots
-      up on the target(s) at all times. Remember to pool Astral Power prior to movement.
+      If you have any idea on what is missing, we would be happy if you let us know directly on
+      Discord.
+      <br />
+      <br />
+      As a rule of thumb: Use the filler appropriate for your active eclipse (
+      <SpellLink id={SPELLS.WRATH_MOONKIN.id} /> for Solar Eclipse and{' '}
+      <SpellLink id={SPELLS.STARFIRE.id} /> for Lunar Eclipse), keep up your DoT's, maximize the
+      time you are in an eclipse and try to overcap as little Astral Power as possible. If you are
+      using the <SpellLink id={SPELLS.BALANCE_OF_ALL_THINGS_SOLAR.id} />, always make sure to have
+      atleast 90 Astral Power when entering an Eclipse, so you make most out of it's crit buff by
+      instantly casting three consecutive <SpellLink id={SPELLS.STARSURGE_MOONKIN.id} />.
       <br />
       <br />
       If you want to learn more about how to play Moonkin, visit{' '}
@@ -31,8 +44,12 @@ export default {
         DreamGrove, the Druid's Discord
       </a>{' '}
       or{' '}
-      <a href="https://dreamgrove.gg/" target="_blank" rel="noopener noreferrer">
-        DreamGrove.gg
+      <a
+        href="https://www.dreamgrove.gg/balance/2020-12-08-9.0_faq/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        DreamGrove.gg | 9.0.5 FAQ
       </a>
       .
     </>


### PR DESCRIPTION
Additionally I added myself as a regular contributor and bumped the supported version to 9.0.5.

These changes aim to ensure that people know that Balance Druid is not completely abandoned.