### PR TITLE
[Druid] Fix Earthwarden reporting

### DIFF
--- a/analysis/druidguardian/src/CHANGELOG.tsx
+++ b/analysis/druidguardian/src/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { change, date } from 'common/changelog';
 import { Kettlepaw, Zeboot, g3neral, Tiboonn, Buudha } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2021, 4, 7), 'Correct reporting for Earthwarden absorb events', Kettlepaw),
   change(date(2021, 3, 25), 'Added basic checklist section to be expanded on, and upgraded touched files to Typescript', Buudha),
   change(date(2021, 2, 20), 'Updated the Stats page to use the new Statistics modules', Buudha),
   change(date(2021, 2, 20), 'Added spell info for conduits, Venthyr soulbind\'s and some Kyrain SB\'s as well as legendary data', Buudha),

--- a/analysis/druidguardian/src/CONFIG.tsx
+++ b/analysis/druidguardian/src/CONFIG.tsx
@@ -1,5 +1,5 @@
 import SPELLS from 'common/SPELLS';
-import { Buudha } from 'CONTRIBUTORS';
+import { Buudha, Kettlepaw } from 'CONTRIBUTORS';
 import SPECS from 'game/SPECS';
 import { SpellLink } from 'interface';
 import React from 'react';
@@ -8,7 +8,7 @@ import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Buudha],
+  contributors: [Buudha, Kettlepaw],
   // The WoW client patch this spec was last updated.
   patchCompatibility: '9.0.5',
   isPartial: true,

--- a/analysis/druidguardian/src/modules/talents/Earthwarden.js
+++ b/analysis/druidguardian/src/modules/talents/Earthwarden.js
@@ -59,7 +59,7 @@ class Earthwarden extends Analyzer {
       this.onDamage,
     );
     this.addEventListener(
-      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.EARTHWARDEN_BUFF),
+      Events.absorbed.by(SELECTED_PLAYER).spell(SPELLS.EARTHWARDEN_BUFF),
       this.onAbsorbed,
     );
   }


### PR DESCRIPTION
Earthwarden's stats box was always reporting 0% mitigation. This was because the event listener was looking for damage-by-player events instead of absorption-by-player events.