### PR TITLE
Update the RtB Tracker for Outlaw Rogue.

### DIFF
--- a/analysis/rogueoutlaw/src/CHANGELOG.js
+++ b/analysis/rogueoutlaw/src/CHANGELOG.js
@@ -1,11 +1,12 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
-import { Putro, Tyndi, Zeboot, Canotsa, Hordehobbs, Akai } from 'CONTRIBUTORS';
+import { Putro, Tyndi, Zeboot, Canotsa, Hordehobbs, Akai, ab } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import React from 'react';
 
 
 export default [
+  change(date(2021, 4, 7), <>Updated <SpellLink id={SPELLS.ROLL_THE_BONES.id} /> to use the new combat buff priority list</>, ab),
   change(date(2021, 3, 4), <>Fixed error where <SpellLink id={SPELLS.DREADBLADES_TALENT.id} /> was being suggested even when not talented</>, Akai),
   change(date(2021, 2, 27), <>Add analyzer and suggestion for <SpellLink id={SPELLS.INSTANT_POISON.id} /> application.</>, Hordehobbs),
   change(date(2021, 1, 17), <>Suggestion added to cast <SpellLink id={SPELLS.BETWEEN_THE_EYES.id} /> more often</>, Canotsa),

--- a/analysis/rogueoutlaw/src/modules/features/RollTheBonesCastTracker.js
+++ b/analysis/rogueoutlaw/src/modules/features/RollTheBonesCastTracker.js
@@ -9,9 +9,23 @@ import { ROLL_THE_BONES_BUFFS, ROLL_THE_BONES_DURATION } from '../../constants';
 
 export const ROLL_THE_BONES_CATEGORIES = {
   LOW_VALUE: 'low',
-  MID_VALUE: 'mid',
   HIGH_VALUE: 'high',
 };
+
+let BROADSIDE_VALUE = { sleight_of_hand: 2, base: 3 };
+let TRUE_BEARING_VALUE = { sleight_of_hand: 2, base: 3 };
+let RUTHLESS_PRECISION_VALUE = { sleight_of_hand: 2, base: 2 };
+let SKULL_AND_CROSSBONES_VALUE = { sleight_of_hand: 2, base: 2 };
+let BURIED_TREASURE_VALUE = { sleight_of_hand: 1, base: 1 };
+let GRAND_MELEE_VALUE = { sleight_of_hand: 1, base: 1 };
+
+var BUFF_VALUE_BY_ID = {};
+BUFF_VALUE_BY_ID[SPELLS.BROADSIDE.id] = BROADSIDE_VALUE;
+BUFF_VALUE_BY_ID[SPELLS.TRUE_BEARING.id] = TRUE_BEARING_VALUE;
+BUFF_VALUE_BY_ID[SPELLS.RUTHLESS_PRECISION.id] = RUTHLESS_PRECISION_VALUE;
+BUFF_VALUE_BY_ID[SPELLS.SKULL_AND_CROSSBONES.id] = SKULL_AND_CROSSBONES_VALUE;
+BUFF_VALUE_BY_ID[SPELLS.BURIED_TREASURE.id] = BURIED_TREASURE_VALUE;
+BUFF_VALUE_BY_ID[SPELLS.GRAND_MELEE.id] = GRAND_MELEE_VALUE;
 
 // e.g. 1 combo point is 12 seconds, 3 combo points is 24 seconds
 const PANDEMIC_WINDOW = 0.3;
@@ -53,14 +67,18 @@ class RollTheBonesCastTracker extends Analyzer {
   }
 
   categorizeCast(cast) {
-    if (
-      cast.appliedBuffs.some(
-        (buff) => buff.id === SPELLS.RUTHLESS_PRECISION.id || buff.id === SPELLS.GRAND_MELEE.id,
-      )
-    ) {
+    var combat_buffs_value = 0;
+    if (this.selectedCombatant.hasConduitBySpellID(SPELLS.SLEIGHT_OF_HAND)) {
+      // Players should aim to roll for at least 2 buffs if they're using the Sleight of Hand conduit,
+      // as such we use a lower value for the combat buffs to make sure no single buff outweighs a 2x roll.
+      cast.appliedBuffs.forEach(
+        (buff) => (combat_buffs_value += BUFF_VALUE_BY_ID[buff.id].sleight_of_hand),
+      );
+    } else {
+      cast.appliedBuffs.forEach((buff) => (combat_buffs_value += BUFF_VALUE_BY_ID[buff.id].base));
+    }
+    if (combat_buffs_value > 2) {
       return ROLL_THE_BONES_CATEGORIES.HIGH_VALUE;
-    } else if (cast.appliedBuffs.length > 1) {
-      return ROLL_THE_BONES_CATEGORIES.MID_VALUE;
     }
 
     return ROLL_THE_BONES_CATEGORIES.LOW_VALUE;

--- a/analysis/rogueoutlaw/src/modules/features/RollTheBonesCastTracker.js
+++ b/analysis/rogueoutlaw/src/modules/features/RollTheBonesCastTracker.js
@@ -12,14 +12,14 @@ export const ROLL_THE_BONES_CATEGORIES = {
   HIGH_VALUE: 'high',
 };
 
-let BROADSIDE_VALUE = { sleight_of_hand: 2, base: 3 };
-let TRUE_BEARING_VALUE = { sleight_of_hand: 2, base: 3 };
-let RUTHLESS_PRECISION_VALUE = { sleight_of_hand: 2, base: 2 };
-let SKULL_AND_CROSSBONES_VALUE = { sleight_of_hand: 2, base: 2 };
-let BURIED_TREASURE_VALUE = { sleight_of_hand: 1, base: 1 };
-let GRAND_MELEE_VALUE = { sleight_of_hand: 1, base: 1 };
+const BROADSIDE_VALUE = { sleight_of_hand: 2, base: 3 };
+const TRUE_BEARING_VALUE = { sleight_of_hand: 2, base: 3 };
+const RUTHLESS_PRECISION_VALUE = { sleight_of_hand: 2, base: 2 };
+const SKULL_AND_CROSSBONES_VALUE = { sleight_of_hand: 2, base: 2 };
+const BURIED_TREASURE_VALUE = { sleight_of_hand: 1, base: 1 };
+const GRAND_MELEE_VALUE = { sleight_of_hand: 1, base: 1 };
 
-var BUFF_VALUE_BY_ID = {};
+let BUFF_VALUE_BY_ID = {};
 BUFF_VALUE_BY_ID[SPELLS.BROADSIDE.id] = BROADSIDE_VALUE;
 BUFF_VALUE_BY_ID[SPELLS.TRUE_BEARING.id] = TRUE_BEARING_VALUE;
 BUFF_VALUE_BY_ID[SPELLS.RUTHLESS_PRECISION.id] = RUTHLESS_PRECISION_VALUE;
@@ -67,7 +67,7 @@ class RollTheBonesCastTracker extends Analyzer {
   }
 
   categorizeCast(cast) {
-    var combat_buffs_value = 0;
+    let combat_buffs_value = 0;
     if (this.selectedCombatant.hasConduitBySpellID(SPELLS.SLEIGHT_OF_HAND)) {
       // Players should aim to roll for at least 2 buffs if they're using the Sleight of Hand conduit,
       // as such we use a lower value for the combat buffs to make sure no single buff outweighs a 2x roll.

--- a/analysis/rogueoutlaw/src/modules/spells/RollTheBonesEfficiency.js
+++ b/analysis/rogueoutlaw/src/modules/spells/RollTheBonesEfficiency.js
@@ -53,7 +53,9 @@ class RollTheBonesEfficiency extends Analyzer {
         extraSuggestion: (
           <>
             If you roll a single buff and it's not one of the two highest value, try to reroll it as
-            soon as you can.
+            soon as you can. If you roll a single buff and use{' '}
+            <SpellLink id={SPELLS.SLEIGHT_OF_HAND.id} /> reroll any single roll, regardless of the
+            buff.
           </>
         ),
         suggestionThresholds: this.rollSuggestionThreshold(
@@ -68,9 +70,9 @@ class RollTheBonesEfficiency extends Analyzer {
         total: rtbCastValues[ROLL_THE_BONES_CATEGORIES.HIGH_VALUE].length,
         extraSuggestion: (
           <>
-            If you ever roll one of the two highest value buffs (especially with a 5 buff roll!),
-            try to leave the buff active as long as possible, refreshing with less than 3 seconds
-            remaining.
+            If you ever roll a high value buff or multiple bufss, try to leave keep them as long as
+            possible, refreshing with less than 3 seconds remaining. If you're using
+            <SpellLink id={SPELLS.SLEIGHT_OF_HAND.id} /> no single buff is considered high value.
           </>
         ),
         suggestionThresholds: this.rollSuggestionThreshold(

--- a/analysis/rogueoutlaw/src/modules/spells/RollTheBonesEfficiency.js
+++ b/analysis/rogueoutlaw/src/modules/spells/RollTheBonesEfficiency.js
@@ -10,7 +10,6 @@ import RollTheBonesCastTracker, {
   ROLL_THE_BONES_CATEGORIES,
 } from '../features/RollTheBonesCastTracker';
 
-const MID_TIER_REFRESH_TIME = 11000;
 const HIGH_TIER_REFRESH_TIME = 3000;
 
 /**
@@ -32,17 +31,6 @@ class RollTheBonesEfficiency extends Analyzer {
     ].length;
 
     return totalRolls - delayedRolls;
-  }
-
-  get goodMidValueRolls() {
-    // todo get the actual pandemic window. it's tricky because it's based on the next cast, and it's not really important that the player is exact anyway
-    return this.rollTheBonesCastTracker.rolltheBonesCastValues[
-      ROLL_THE_BONES_CATEGORIES.MID_VALUE
-    ].filter(
-      (cast) =>
-        this.rollTheBonesCastTracker.castRemainingDuration(cast) > HIGH_TIER_REFRESH_TIME &&
-        this.rollTheBonesCastTracker.castRemainingDuration(cast) < MID_TIER_REFRESH_TIME,
-    ).length;
   }
 
   get goodHighValueRolls() {
@@ -71,22 +59,6 @@ class RollTheBonesEfficiency extends Analyzer {
         suggestionThresholds: this.rollSuggestionThreshold(
           this.goodLowValueRolls,
           rtbCastValues[ROLL_THE_BONES_CATEGORIES.LOW_VALUE].length,
-        ),
-      },
-      // Percentage of mid rolls that were rerolled at or below pandemic, but above 3 seconds
-      {
-        label: 'mid value',
-        pass: this.goodMidValueRolls,
-        total: rtbCastValues[ROLL_THE_BONES_CATEGORIES.MID_VALUE].length,
-        extraSuggestion: (
-          <>
-            If you roll two buffs and neither is one of the two highest value, try to reroll them
-            once you reach the pandemic window, at about 9-10 seconds remaining.
-          </>
-        ),
-        suggestionThresholds: this.rollSuggestionThreshold(
-          this.goodMidValueRolls,
-          rtbCastValues[ROLL_THE_BONES_CATEGORIES.MID_VALUE].length,
         ),
       },
       // Percentage of good rolls that were rerolled below 3 seconds
@@ -158,9 +130,8 @@ class RollTheBonesEfficiency extends Analyzer {
         suggest(
           <>
             Your efficiency with refreshing <SpellLink id={SPELLS.ROLL_THE_BONES.id} /> after a{' '}
-            {suggestion.label} roll could be improved.{' '}
-            <SpellLink id={SPELLS.RUTHLESS_PRECISION.id} /> and{' '}
-            <SpellLink id={SPELLS.GRAND_MELEE.id} /> are your highest value buffs from{' '}
+            {suggestion.label} roll could be improved. <SpellLink id={SPELLS.BROADSIDE.id} /> and{' '}
+            <SpellLink id={SPELLS.TRUE_BEARING.id} /> are your highest value buffs from{' '}
             <SpellLink id={SPELLS.ROLL_THE_BONES.id} />. {suggestion.extraSuggestion || ''}
           </>,
         )

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -94,6 +94,10 @@ export const Zerotorescue: Contributor = {
     },
   ],
 };
+export const ab: Contributor = {
+  nickname: 'ab',
+  github: 'alex-bau',
+};
 export const blazyb: Contributor = {
   nickname: 'blazyb',
   github: 'buimichael',

--- a/src/common/SPELLS/shadowlands/conduits/rogue.ts
+++ b/src/common/SPELLS/shadowlands/conduits/rogue.ts
@@ -26,6 +26,11 @@ const conduits = {
     name: 'Deeper Daggers',
     icon: 'ability_rogue_focusedattacks',
   },
+  SLEIGHT_OF_HAND: {
+    id: 341543,
+    name: 'Sleight of Hand',
+    icon: 'inv_misc_dice_02',
+  },
   //endregion
 } as const;
 export default conduits;


### PR DESCRIPTION
* Update High Value buffs to Broadside and True Bearing. The buff prio
  changed with SLs, but this isn't reflected in the analyzer.

* Use values and a sum to track if a roll is low or high values (as
  opposed to ifing for high value rolls).

* Incorporate Sleight of Hand into the sims by punishing people who hold
  onto single value rolls (even if they _should_ be high value rolls).

* Punish holding onto GM+BT (the two worst buffs for OLW) if rolled
  together.