### PR TITLE
[Druid] Restore anti-filler reporting

### DIFF
--- a/analysis/druidguardian/src/CHANGELOG.tsx
+++ b/analysis/druidguardian/src/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { change, date } from 'common/changelog';
 import { Kettlepaw, Zeboot, g3neral, Tiboonn, Buudha } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2020, 4, 7), 'Updated class syntax to re-enable AntiFillerSpam info', Kettlepaw),
   change(date(2021, 4, 7), 'Correct reporting for Earthwarden absorb events', Kettlepaw),
   change(date(2021, 3, 25), 'Added basic checklist section to be expanded on, and upgraded touched files to Typescript', Buudha),
   change(date(2021, 2, 20), 'Updated the Stats page to use the new Statistics modules', Buudha),

--- a/analysis/druidguardian/src/CHANGELOG.tsx
+++ b/analysis/druidguardian/src/CHANGELOG.tsx
@@ -2,7 +2,7 @@ import { change, date } from 'common/changelog';
 import { Kettlepaw, Zeboot, g3neral, Tiboonn, Buudha } from 'CONTRIBUTORS';
 
 export default [
-  change(date(2020, 4, 7), 'Updated class syntax to re-enable AntiFillerSpam info', Kettlepaw),
+  change(date(2021, 4, 10), 'Updated class syntax to re-enable AntiFillerSpam info', Kettlepaw),
   change(date(2021, 4, 7), 'Correct reporting for Earthwarden absorb events', Kettlepaw),
   change(date(2021, 3, 25), 'Added basic checklist section to be expanded on, and upgraded touched files to Typescript', Buudha),
   change(date(2021, 2, 20), 'Updated the Stats page to use the new Statistics modules', Buudha),

--- a/analysis/druidguardian/src/modules/Ability.js
+++ b/analysis/druidguardian/src/modules/Ability.js
@@ -10,7 +10,7 @@ class Ability extends CoreAbility {
     }),
   };
 
-  antiFillerSpam = null;
+  antiFillerSpam;
 }
 
 export default Ability;


### PR DESCRIPTION
Remove null default for antiFillerSpam prop which was being set *after*
the superclass's constructor was called, probably in part because this class
is not Typescript.

As indicated in previous discussion, it's probably best to stop jumping
through hoops to get this additional data into SpellbookAbility child objects
and just provide it as a parallel type created within guardiandruid, but
that is a bigger change and I am still learning the architecture of this
project, so I thought it worthwhile to stabilize this feature in the
meantime.