### PR TITLE
Add module for void bolt efficiency

### DIFF
--- a/analysis/priestshadow/src/CHANGELOG.tsx
+++ b/analysis/priestshadow/src/CHANGELOG.tsx
@@ -8,6 +8,7 @@ import { ResourceLink } from 'interface';
 import React from 'react';
 
 export default [
+  change(date(2021, 4, 11), <>Added <SpellLink id={SPELLS.VOID_BOLT.id} /> cast efficiency module.</>, Adoraci),
   change(date(2021, 4, 1), <>Bump support to 9.0.5</>, Adoraci),
   change(date(2021, 1, 29), <>Added <SpellLink id={SPELLS.HAUNTING_APPARITIONS.id} /> conduit module.</>, Adoraci),
   change(date(2021, 1, 23), <>Added <SpellLink id={SPELLS.SEARING_NIGHTMARE_TALENT.id} /> talent module.</>, Adoraci),

--- a/analysis/priestshadow/src/CombatLogParser.tsx
+++ b/analysis/priestshadow/src/CombatLogParser.tsx
@@ -20,6 +20,7 @@ import CooldownThroughputTracker from './modules/features/CooldownThroughputTrac
 import DarkThoughts from './modules/features/DarkThoughts';
 import DotUptimes from './modules/features/DotUptimes';
 import SkippableCasts from './modules/features/SkippableCasts';
+import VoidBoltUsage from './modules/features/VoidBoltUsage';
 import InsanityTracker from './modules/resources/InsanityTracker';
 import InsanityUsage from './modules/resources/InsanityUsage';
 import DissonantEchoes from './modules/shadowlands/conduits/DissonantEchoes';
@@ -62,6 +63,7 @@ class CombatLogParser extends MainCombatLogParser {
     dotUptimes: DotUptimes,
     skippableCasts: SkippableCasts,
     darkThoughts: DarkThoughts,
+    voidBoltUsage: VoidBoltUsage,
 
     // spells:
     shadowfiend: Shadowfiend,

--- a/analysis/priestshadow/src/CombatLogParser.tsx
+++ b/analysis/priestshadow/src/CombatLogParser.tsx
@@ -1,4 +1,5 @@
 import MainCombatLogParser from 'parser/core/CombatLogParser';
+import ArcaneTorrent from 'parser/shared/modules/racials/bloodelf/ArcaneTorrent';
 
 import {
   BoonOfTheAscended,
@@ -101,6 +102,8 @@ class CombatLogParser extends MainCombatLogParser {
     eternalCallToTheVoid: EternalCallToTheVoid,
     talbadarsStratagem: TalbadarsStratagem,
     twinsOfTheSunPriestess: TwinsOfTheSunPriestess,
+
+    arcaneTorrent: [ArcaneTorrent, { active: false }] as const,
   };
 }
 

--- a/analysis/priestshadow/src/modules/features/Buffs.tsx
+++ b/analysis/priestshadow/src/modules/features/Buffs.tsx
@@ -37,6 +37,12 @@ class Buffs extends CoreBuffs {
         timelineHighlight: true,
       },
       {
+        spellId: SPELLS.DISSONANT_ECHOES_BUFF.id,
+        triggeredBySpellId: SPELLS.VOID_BOLT_DISSONANT_ECHOES.id,
+        enabled: combatant.hasConduitBySpellID(SPELLS.DISSONANT_ECHOES.id),
+        timelineHighlight: true,
+      },
+      {
         spellId: SPELLS.VAMPIRIC_EMBRACE.id,
         timelineHighlight: true,
       },

--- a/analysis/priestshadow/src/modules/features/VoidBoltUsage.tsx
+++ b/analysis/priestshadow/src/modules/features/VoidBoltUsage.tsx
@@ -1,0 +1,102 @@
+import { t } from '@lingui/macro';
+import SPELLS from 'common/SPELLS';
+import { SpellLink } from 'interface';
+import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
+import Events, { BeginCastEvent, CastEvent } from 'parser/core/Events';
+import { When, ThresholdStyle } from 'parser/core/ParseResults';
+import EventHistory from 'parser/shared/modules/EventHistory';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import React from 'react';
+
+import GlobalCooldown from '../core/GlobalCooldown';
+
+// Example log: /report/ZTdNYvhp9aqQD36A/9-Mythic+Huntsman+Altimor+-+Kill+(5:47)/Lampshadow/standard/timeline
+class VoidBoltUsage extends Analyzer {
+  static dependencies = {
+    eventHistory: EventHistory,
+    globalCooldown: GlobalCooldown,
+    spellUsable: SpellUsable,
+  };
+  protected eventHistory!: EventHistory;
+  protected globalCooldown!: GlobalCooldown;
+  protected spellUsable!: SpellUsable;
+
+  badGlobals: number = 0;
+  voidBoltOnCD: boolean = false;
+
+  constructor(options: Options) {
+    super(options);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onCast);
+    this.addEventListener(Events.begincast.by(SELECTED_PLAYER), this.onBeginCast);
+  }
+
+  onBeginCast(event: BeginCastEvent) {
+    if (
+      !this.selectedCombatant.hasBuff(SPELLS.VOIDFORM_BUFF.id) ||
+      !this.globalCooldown.isOnGlobalCooldown(event.ability.guid)
+    ) {
+      return;
+    }
+    this.voidBoltOnCD = this.spellUsable.isOnCooldown(SPELLS.VOID_BOLT.id); // if a cast has a cast time, then when they started casting vb might've been on cooldown
+  }
+
+  onCast(event: CastEvent) {
+    if (
+      !this.selectedCombatant.hasBuff(SPELLS.VOIDFORM_BUFF.id) ||
+      !this.globalCooldown.isOnGlobalCooldown(event.ability.guid) ||
+      event.ability.guid === SPELLS.VOID_BOLT.id ||
+      this.spellUsable.isOnCooldown(SPELLS.VOID_BOLT.id) ||
+      this.voidBoltOnCD === true
+    ) {
+      return;
+    }
+
+    if (event.meta === undefined) {
+      event.meta = {
+        isEnhancedCast: false,
+        isInefficientCast: false,
+      };
+    }
+
+    event.meta.isInefficientCast = true;
+    event.meta.inefficientCastReason = 'Casted while Void Bolt is off cooldown.';
+
+    this.badGlobals += 1;
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.badGlobals,
+      isGreaterThan: {
+        minor: 0,
+        average: 0,
+        major: 1,
+      },
+      style: ThresholdStyle.NUMBER,
+    };
+  }
+
+  suggestions(when: When) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
+      suggest(
+        <>
+          Your <SpellLink id={SPELLS.VOID_BOLT.id} /> usage can be improved. It's the highest
+          priority ability to use during <SpellLink id={SPELLS.VOIDFORM_BUFF.id} />. There should
+          only be 2 global cooldowns between each <SpellLink id={SPELLS.VOID_BOLT.id} /> unless you
+          have more than 135% haste in which case it becomes only 1 global cooldown between{' '}
+          <SpellLink id={SPELLS.VOID_BOLT.id} />.
+        </>,
+      )
+        .icon(SPELLS.VOID_BOLT.icon)
+        .actual(
+          t({
+            id: 'priest.shadow.suggestions.voidBolt.efficiency',
+            message: `You had ${this.badGlobals} cast(s) while Void Bolt was off cooldown during Voidform.`,
+          }),
+        )
+        .recommended(`${recommended} is recommended.`),
+    );
+  }
+}
+
+export default VoidBoltUsage;

--- a/analysis/priestshadow/src/modules/features/VoidBoltUsage.tsx
+++ b/analysis/priestshadow/src/modules/features/VoidBoltUsage.tsx
@@ -4,7 +4,6 @@ import { SpellLink } from 'interface';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
 import Events, { BeginCastEvent, CastEvent } from 'parser/core/Events';
 import { When, ThresholdStyle } from 'parser/core/ParseResults';
-import EventHistory from 'parser/shared/modules/EventHistory';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import React from 'react';
 
@@ -13,11 +12,9 @@ import GlobalCooldown from '../core/GlobalCooldown';
 // Example log: /report/ZTdNYvhp9aqQD36A/9-Mythic+Huntsman+Altimor+-+Kill+(5:47)/Lampshadow/standard/timeline
 class VoidBoltUsage extends Analyzer {
   static dependencies = {
-    eventHistory: EventHistory,
     globalCooldown: GlobalCooldown,
     spellUsable: SpellUsable,
   };
-  protected eventHistory!: EventHistory;
   protected globalCooldown!: GlobalCooldown;
   protected spellUsable!: SpellUsable;
 

--- a/src/parser/shared/modules/racials/bloodelf/ArcaneTorrent.ts
+++ b/src/parser/shared/modules/racials/bloodelf/ArcaneTorrent.ts
@@ -14,13 +14,16 @@ class ArcaneTorrent extends Analyzer {
 
   constructor(
     options: Options & {
+      active?: boolean;
       gcd?: number;
       castEfficiency?: number;
       abilities: Abilities;
     },
   ) {
     super(options);
-    this.active = this.selectedCombatant.race === RACES.BloodElf;
+    this.active =
+      this.selectedCombatant.race === RACES.BloodElf &&
+      (options.active === undefined || options.active === true);
     if (!this.active) {
       return;
     }


### PR DESCRIPTION
Void Bolt is usable only during Voidform or with a Dissonant Echoes (conduit) proc. Void bolt should be used on CD which is always 2 GCDs unless you have >135% haste then it's 1 GCD.

* Highlight timeline casts where VB is off CD and another ability is used
* Suggests if they have bad casts that they use VB on CD

This pretty much one of the core concepts of shadow priest is 2 gcds between each VB.

![image](https://user-images.githubusercontent.com/5396389/114319789-fd6c0a00-9ae0-11eb-85ac-894a44e1deb6.png)
