### PR TITLE
[Priest] Fae Guardians 9.0.5 changes and DR correction

### DIFF
--- a/analysis/priest/src/FaeGuardians.tsx
+++ b/analysis/priest/src/FaeGuardians.tsx
@@ -4,6 +4,7 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import COVENANTS from 'game/shadowlands/COVENANTS';
 import SPECS from 'game/SPECS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import calculateEffectiveDamageReduction from 'parser/core/calculateEffectiveDamageReduction';
 import Events, {
   ApplyBuffEvent,
   DamageEvent,
@@ -20,7 +21,7 @@ import React from 'react';
 
 import ItemInsanityGained from '@wowanalyzer/priest-shadow/src/interface/ItemInsanityGained';
 
-const GUARDIAN_DAMAGE_REDUCTION = 0.1;
+const GUARDIAN_DAMAGE_REDUCTION = 0.2;
 
 // Holy: https://www.warcraftlogs.com/reports/2frFV7hnRg4ZxXcA#fight=5
 // Shadow: https://www.warcraftlogs.com/reports/WqcaKR9nNkChXyfm#fight=5
@@ -108,7 +109,7 @@ class FaeGuardians extends Analyzer {
     if (event.targetID !== this.currentShieldedTargetId) {
       return;
     }
-    this.damageReduced += (event.amount || 0) / (1 - GUARDIAN_DAMAGE_REDUCTION);
+    this.damageReduced += calculateEffectiveDamageReduction(event, GUARDIAN_DAMAGE_REDUCTION);
   }
 
   onEnergize(event: EnergizeEvent) {

--- a/analysis/priestdiscipline/src/CHANGELOG.tsx
+++ b/analysis/priestdiscipline/src/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 
 
 export default [
+  change(date(2021, 4, 11), <>Updated <SpellLink id={SPELLS.GUARDIAN_FAERIE.id} /> damage reduction to 20% and corrected DR calculation.</>, Adoraci),
   change(date(2021, 4, 9), <>Support for <SpellLink id={SPELLS.CLARITY_OF_MIND.id} /></>, Reglitch),
   change(date(2021, 4, 8), <>Support for <SpellLink id={SPELLS.SHATTERED_PERCEPTIONS.id} /></>, Reglitch),
   change(date(2021, 4, 6), <>9.0.5 support! <SpellLink id={SPELLS.SPIRIT_SHELL_TALENT.id} /> support for everyone!</>, Reglitch),

--- a/analysis/priestholy/src/CHANGELOG.tsx
+++ b/analysis/priestholy/src/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 
 
 export default [
+  change(date(2021, 4, 11), <>Updated <SpellLink id={SPELLS.GUARDIAN_FAERIE.id} /> damage reduction to 20% and corrected DR calculation.</>, Adoraci),
   change(date(2021, 3, 10), <>Updated <SpellLink id={SPELLS.DIVINE_HYMN_HEAL.id} /> appproxmiation</>, Khadaj),
   change(date(2021, 3, 3), <>Removed spreadsheet tab</>, acornellier),
   change(date(2021, 2, 26), <>Updating base mana value for <SpellLink id={SPELLS.ENLIGHTENMENT_TALENT.id} />.</>, Khadaj),

--- a/analysis/priestshadow/src/CHANGELOG.tsx
+++ b/analysis/priestshadow/src/CHANGELOG.tsx
@@ -8,6 +8,8 @@ import { ResourceLink } from 'interface';
 import React from 'react';
 
 export default [
+  change(date(2021, 4, 11), <>Updated <SpellLink id={SPELLS.GUARDIAN_FAERIE.id} /> damage reduction to 20% and corrected DR calculation.</>, Adoraci),
+  change(date(2021, 4, 11), <>Removed <SpellLink id={SPELLS.ARCANE_TORRENT_MANA3.id} /> suggestion.</>, Adoraci),
   change(date(2021, 4, 11), <>Added <SpellLink id={SPELLS.VOID_BOLT.id} /> cast efficiency module.</>, Adoraci),
   change(date(2021, 4, 1), <>Bump support to 9.0.5</>, Adoraci),
   change(date(2021, 1, 29), <>Added <SpellLink id={SPELLS.HAUNTING_APPARITIONS.id} /> conduit module.</>, Adoraci),

--- a/src/parser/core/calculateEffectiveDamageReduction.ts
+++ b/src/parser/core/calculateEffectiveDamageReduction.ts
@@ -1,0 +1,6 @@
+import { DamageEvent } from './Events';
+
+export default function calculateEffectiveDamageReduction(event: DamageEvent, reduction: number) {
+  const raw = (event.amount || 0) + (event.absorbed || 0);
+  return (raw / (1 - reduction)) * reduction;
+}


### PR DESCRIPTION
The DR calculation was not calculating properly, this fixes it and updates to the new 20% DR from fae guardians changed in 9.0.5. Calculations below.

OLD - 10% DR calculation used:
https://www.warcraftlogs.com/reports/Q8MBTt6WVAXwLZNx#fight=last&type=auras&source=7&ability=327694
![image](https://user-images.githubusercontent.com/5396389/114325774-d53fd380-9aff-11eb-83fb-d910c8b42861.png)

Now if we use a wclogs filter to damage taken to the player when he had faerie guardians up: [Link](https://www.warcraftlogs.com/reports/Q8MBTt6WVAXwLZNx#fight=last&type=damage-taken&source=7&pins=2%24Separate%24%23244F4B%24damage%241%240.0.0.Any%240.0.0.Any%24true%240.0.0.Any%24true%240%24and%24auras-gained%240%240.0.0.Any%240.0.0.Any%24true%240.0.0.Any%24true%24327694%24true%24false%2463)

The total damage is 264.4k. Using the previous calculation there is no way that 10% DR would be 204k.

NEW - 20% DR w/ new calculation used, half it to get the old value of what it should be:
![image](https://user-images.githubusercontent.com/5396389/114325969-9fe7b580-9b00-11eb-8a69-1c660d982a30.png)
