### PR TITLE
[Rogue] Add CD efficiency and follow-up ability tracking for Sepsis

### DIFF
--- a/analysis/rogue/src/covenants/nightfae/Sepsis.tsx
+++ b/analysis/rogue/src/covenants/nightfae/Sepsis.tsx
@@ -36,17 +36,16 @@ class Sepsis extends Analyzer {
       Events.damage.by(SELECTED_PLAYER).spell(SPELLS.SEPSIS_POISON),
       this.onPoisonDamage,
     );
-    this.addEventListener(Events.removedebuff.spell(SPELLS.SEPSIS), this.onDebuffFade);
+    this.addEventListener(
+      Events.removedebuff.by(SELECTED_PLAYER).spell(SPELLS.SEPSIS),
+      this.onDebuffFade,
+    );
   }
 
   onDebuffFade(event: RemoveDebuffEvent) {
     if (this.lastSepsisCast == null) {
       // This should never happen and indicates a bug if it does.
       debug && console.warn('Sepsis debuff faded before cast recorded.');
-      return;
-    }
-    if (event.sourceID !== this.selectedCombatant.id) {
-      // Debuff faded from Sepsis cast by another Rogue.
       return;
     }
     const lastCastTimestamp = this.lastSepsisCast.timestamp;

--- a/analysis/rogue/src/covenants/nightfae/Sepsis.tsx
+++ b/analysis/rogue/src/covenants/nightfae/Sepsis.tsx
@@ -2,30 +2,66 @@ import { formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import COVENANTS from 'game/shadowlands/COVENANTS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { DamageEvent } from 'parser/core/Events';
+import Events, { CastEvent, DamageEvent, RemoveDebuffEvent } from 'parser/core/Events';
 import Abilities from 'parser/core/modules/Abilities';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import React from 'react';
 
+const COOLDOWN_REDUCTION_MS = 30_000;
+const DOT_END_BUFFER_MS = 300;
+const BASE_DOT_LENGTH_MS = 10_000;
+const debug = false;
+
 class Sepsis extends Analyzer {
   static dependencies = {
     abilities: Abilities,
+    spellUsable: SpellUsable,
   };
   damage: number = 0;
   poisonDamage: number = 0;
+  lastSepsisCast: CastEvent | null = null;
   protected abilities!: Abilities;
+  protected spellUsable!: SpellUsable;
 
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasCovenant(COVENANTS.NIGHT_FAE.id);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.SEPSIS), this.onDamage);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.SEPSIS), this.onSepsisCast);
     this.addEventListener(
       Events.damage.by(SELECTED_PLAYER).spell(SPELLS.SEPSIS_POISON),
       this.onPoisonDamage,
     );
+    this.addEventListener(Events.removedebuff.spell(SPELLS.SEPSIS), this.onDebuffFade);
+  }
+
+  onDebuffFade(event: RemoveDebuffEvent) {
+    if (this.lastSepsisCast == null) {
+      // This should never happen and indicates a bug if it does.
+      debug && console.warn('Sepsis debuff faded before cast recorded.');
+      return;
+    }
+    if (event.sourceID !== this.selectedCombatant.id) {
+      // Debuff faded from Sepsis cast by another Rogue.
+      return;
+    }
+    const lastCastTimestamp = this.lastSepsisCast.timestamp;
+    const dotEndTimestamp = event.timestamp;
+    const timestampDiff = dotEndTimestamp - lastCastTimestamp;
+
+    // If the Sepsis DoT does not reach its full duration, the CD
+    // of Sepsis is reduced by 30 seconds.
+    if (timestampDiff < BASE_DOT_LENGTH_MS + DOT_END_BUFFER_MS) {
+      this.spellUsable.reduceCooldown(SPELLS.SEPSIS.id, COOLDOWN_REDUCTION_MS);
+    }
+  }
+
+  onSepsisCast(event: CastEvent) {
+    this.lastSepsisCast = event;
   }
 
   onDamage(event: DamageEvent) {

--- a/analysis/rogue/src/covenants/nightfae/StealthAbilityFollowingSepsis.tsx
+++ b/analysis/rogue/src/covenants/nightfae/StealthAbilityFollowingSepsis.tsx
@@ -19,7 +19,7 @@ const STEALTH_ABILITIES: Spell[] = [
   SPELLS.SHADOWSTRIKE,
 ];
 
-const debug = true;
+const debug = false;
 
 /**
  * Analyzer to track the usage of the correct stealth abilities following

--- a/analysis/rogue/src/covenants/nightfae/StealthAbilityFollowingSepsis.tsx
+++ b/analysis/rogue/src/covenants/nightfae/StealthAbilityFollowingSepsis.tsx
@@ -72,6 +72,41 @@ class StealthAbilityFollowingSepsis extends Analyzer {
         </>,
       );
     });
+    let tooltip: React.ReactElement | null;
+    if (this.badCasts.length === 0) {
+      tooltip = (
+        <>
+          You used <SpellLink id={this.properStealthAbility.id} />
+          following the completion of <SpellLink id={SPELLS.SEPSIS_POISON.id} />
+          every time! Great job!
+        </>
+      );
+    } else {
+      tooltip = (
+        <>
+          You used the incorrect stealth ability instead of{' '}
+          <SpellLink id={this.properStealthAbility.id} />
+          following the completion of <SpellLink id={SPELLS.SEPSIS_POISON.id} />
+        </>
+      );
+    }
+
+    let dropdown: React.ReactElement | null = null;
+    if (this.badCasts.length !== 0) {
+      dropdown = (
+        <>
+          <table className="table table-condensed">
+            <thead>
+              <tr>
+                <th>Cast Timestamp</th>
+                <th>Bad Ability</th>
+              </tr>
+            </thead>
+            <tbody>{tableEntries}</tbody>
+          </table>
+        </>
+      );
+    }
 
     return (
       <>
@@ -79,26 +114,8 @@ class StealthAbilityFollowingSepsis extends Analyzer {
           position={STATISTIC_ORDER.DEFAULT}
           size="flexible"
           category={STATISTIC_CATEGORY.COVENANTS}
-          tooltip={
-            <>
-              You used the incorrect stealth ability instead of{' '}
-              <SpellLink id={this.properStealthAbility.id} />
-              following the completion of <SpellLink id={SPELLS.SEPSIS_POISON.id} />
-            </>
-          }
-          dropdown={
-            <>
-              <table className="table table-condensed">
-                <thead>
-                  <tr>
-                    <th>Cast Timestamp</th>
-                    <th>Bad Ability</th>
-                  </tr>
-                </thead>
-                <tbody>{tableEntries}</tbody>
-              </table>
-            </>
-          }
+          tooltip={tooltip}
+          dropdown={dropdown}
         >
           <BoringSpellValue
             spell={SPELLS.SEPSIS}

--- a/analysis/rogue/src/covenants/nightfae/StealthAbilityFollowingSepsis.tsx
+++ b/analysis/rogue/src/covenants/nightfae/StealthAbilityFollowingSepsis.tsx
@@ -1,0 +1,114 @@
+import SPELLS from 'common/SPELLS';
+import Spell from 'common/SPELLS/Spell';
+import COVENANTS from 'game/shadowlands/COVENANTS';
+import SPECS from 'game/SPECS';
+import { SpellLink } from 'interface';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent } from 'parser/core/Events';
+import BoringSpellValue from 'parser/ui/BoringSpellValue';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import React from 'react';
+
+const STEALTH_ABILITIES: Spell[] = [
+  SPELLS.PICK_POCKET,
+  SPELLS.CHEAP_SHOT,
+  SPELLS.SAP,
+  SPELLS.AMBUSH,
+  SPELLS.SHADOWSTRIKE,
+];
+
+const debug = true;
+
+/**
+ * Analyzer to track the usage of the correct stealth abilities following
+ * completion of the Sepsis DoT.
+ */
+class StealthAbilityFollowingSepsis extends Analyzer {
+  protected properStealthAbility: Spell;
+  protected badCasts: CastEvent[] = [];
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasCovenant(COVENANTS.NIGHT_FAE.id);
+    STEALTH_ABILITIES.forEach((ability) => {
+      this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(ability), this.onStealthAbility);
+    });
+    const specId = this.selectedCombatant.spec.id;
+    // Outlaw and Assassination should use Ambush, Sub should use Shadowstrike.
+    this.properStealthAbility =
+      specId === SPECS.OUTLAW_ROGUE.id || specId === SPECS.ASSASSINATION_ROGUE.id
+        ? SPELLS.AMBUSH
+        : SPELLS.SHADOWSTRIKE;
+  }
+
+  onStealthAbility(event: CastEvent) {
+    if (!this.selectedCombatant.hasBuff(SPELLS.SEPSIS_BUFF.id, event.timestamp)) {
+      return;
+    }
+    if (event.ability.guid !== this.properStealthAbility.id) {
+      debug && console.log(`Recorded bad cast with id ${event.ability.guid}`);
+      this.badCasts.push(event);
+      event.meta = event.meta || {};
+      event.meta.isInefficientCast = true;
+      event.meta.inefficientCastReason = `You used the incorrect Stealth ability. You should've used ${this.properStealthAbility.name}.`;
+    } else {
+      debug && console.log(`Recurded good cast with id ${event.ability.guid}`);
+    }
+  }
+
+  statistic(): React.ReactNode {
+    const tableEntries: React.ReactNode[] = [];
+    this.badCasts.forEach((cast: CastEvent, idx: number) => {
+      tableEntries.push(
+        <>
+          <tr key={idx}>
+            <td>{this.owner.formatTimestamp(cast.timestamp)}</td>
+            <td>
+              <SpellLink id={cast.ability.guid} />
+            </td>
+          </tr>
+        </>,
+      );
+    });
+
+    return (
+      <>
+        <Statistic
+          position={STATISTIC_ORDER.DEFAULT}
+          size="flexible"
+          category={STATISTIC_CATEGORY.COVENANTS}
+          tooltip={
+            <>
+              You used the incorrect stealth ability instead of{' '}
+              <SpellLink id={this.properStealthAbility.id} />
+              following the completion of <SpellLink id={SPELLS.SEPSIS_POISON.id} />
+            </>
+          }
+          dropdown={
+            <>
+              <table className="table table-condensed">
+                <thead>
+                  <tr>
+                    <th>Cast Timestamp</th>
+                    <th>Bad Ability</th>
+                  </tr>
+                </thead>
+                <tbody>{tableEntries}</tbody>
+              </table>
+            </>
+          }
+        >
+          <BoringSpellValue
+            spell={SPELLS.SEPSIS}
+            value={`${this.badCasts.length}`}
+            label="Bad Casts after Sepsis Finishes"
+          />
+        </Statistic>
+      </>
+    );
+  }
+}
+
+export default StealthAbilityFollowingSepsis;

--- a/analysis/rogue/src/index.ts
+++ b/analysis/rogue/src/index.ts
@@ -18,4 +18,5 @@ export { default as DeeperDaggers } from './conduits/DeeperDaggers';
 export { default as EchoingReprimand } from './covenants/kyrian/EchoingReprimand';
 export { default as SerratedBoneSpike } from './covenants/necrolord/SerratedBoneSpike';
 export { default as Sepsis } from './covenants/nightfae/Sepsis';
+export { default as StealthAbilityFollowingSepsis } from './covenants/nightfae/StealthAbilityFollowingSepsis';
 export { default as Flagellation } from './covenants/venthyr/Flagellation';

--- a/analysis/rogueassassination/src/CHANGELOG.js
+++ b/analysis/rogueassassination/src/CHANGELOG.js
@@ -6,6 +6,7 @@ import React from 'react';
 
 
 export default [
+  change(date(2021, 4, 25), <>Added additional functionality to <SpellLink id={SPELLS.SEPSIS.id} /> analyzers. </>, Hordehobbs),
   change(date(2021, 4, 11), <>Adjusted logic to ensure correct <SpellLink id={SPELLS.MASTER_ASSASSIN_BUFF.id} /> usage is accounted for.</>, Bloodfox),
   change(date(2021,3,4), <>Removed analyzer and suggestion for <SpellLink id={SPELLS.INSTANT_POISON.id} /> application.</>, Hordehobbs),
   change(date(2021,2,27), <>Add analyzer and suggestion for <SpellLink id={SPELLS.INSTANT_POISON.id} /> application.</>, Hordehobbs),

--- a/analysis/rogueassassination/src/CombatLogParser.ts
+++ b/analysis/rogueassassination/src/CombatLogParser.ts
@@ -13,6 +13,7 @@ import {
   Flagellation,
   InvigoratingShadowdust,
   Sepsis,
+  StealthAbilityFollowingSepsis,
   SerratedBoneSpike,
   SpellEnergyCost,
   SpellUsable,
@@ -93,6 +94,7 @@ class CombatLogParser extends CoreCombatLogParser {
     echoingReprimand: EchoingReprimand,
     flagellation: Flagellation,
     sepsis: Sepsis,
+    stealthAbilityFollowingSepsis: StealthAbilityFollowingSepsis,
 
     // Legendaries
     dashingScoundrel: DashingScoundrel,

--- a/analysis/rogueassassination/src/modules/features/Checklist/Component.js
+++ b/analysis/rogueassassination/src/modules/features/Checklist/Component.js
@@ -1,4 +1,5 @@
 import SPELLS from 'common/SPELLS';
+import COVENANTS from 'game/shadowlands/COVENANTS';
 import { SpellLink } from 'interface';
 import Checklist from 'parser/shared/modules/features/Checklist';
 import GenericCastEfficiencyRequirement from 'parser/shared/modules/features/Checklist/GenericCastEfficiencyRequirement';
@@ -90,6 +91,9 @@ const AssassinationRogueChecklist = ({ combatant, castEfficiency, thresholds }) 
         {combatant.hasTalent(SPELLS.MARKED_FOR_DEATH_TALENT.id) && (
           <AbilityRequirement spell={SPELLS.MARKED_FOR_DEATH_TALENT.id} />
         )}
+        {combatant.hasCovenant(COVENANTS.NIGHT_FAE.id) && (
+          <AbilityRequirement spell={SPELLS.SEPSIS.id} />
+        )}
       </Rule>
       <Rule
         name="Maximize Vanish usage"
@@ -170,6 +174,7 @@ AssassinationRogueChecklist.propTypes = {
   castEfficiency: PropTypes.object.isRequired,
   combatant: PropTypes.shape({
     hasTalent: PropTypes.func.isRequired,
+    hasCovenant: PropTypes.func.isRequired,
   }).isRequired,
   thresholds: PropTypes.object.isRequired,
 };

--- a/analysis/rogueoutlaw/src/CHANGELOG.js
+++ b/analysis/rogueoutlaw/src/CHANGELOG.js
@@ -6,6 +6,7 @@ import React from 'react';
 
 
 export default [
+  change(date(2021, 4, 25), <>Added additional functionality to <SpellLink id={SPELLS.SEPSIS.id} /> analyzers. </>, Hordehobbs),
   change(date(2021, 4, 7), <>Refactor Outlaw modules into Typescript for future development.</>, Hordehobbs),
   change(date(2021, 4, 7), <>Updated <SpellLink id={SPELLS.ROLL_THE_BONES.id} /> to use the new combat buff priority list</>, ab),
   change(date(2021, 3, 4), <>Fixed error where <SpellLink id={SPELLS.DREADBLADES_TALENT.id} /> was being suggested even when not talented</>, Akai),

--- a/analysis/rogueoutlaw/src/CombatLogParser.ts
+++ b/analysis/rogueoutlaw/src/CombatLogParser.ts
@@ -14,6 +14,7 @@ import {
   SpellUsable,
   InstantPoison,
   Sepsis,
+  StealthAbilityFollowingSepsis,
 } from '@wowanalyzer/rogue';
 
 import Abilities from './modules/Abilities';
@@ -90,6 +91,7 @@ class CombatLogParser extends CoreCombatLogParser {
     echoingReprimand: EchoingReprimand,
     flagellation: Flagellation,
     sepsis: Sepsis,
+    stealthAbilityFollowingSepsis: StealthAbilityFollowingSepsis,
 
     // Outlaw's throughput benefit isn't as big as for other classes since we don't have a lot of free gcds to use
     arcaneTorrent: [

--- a/analysis/rogueoutlaw/src/modules/Abilities.tsx
+++ b/analysis/rogueoutlaw/src/modules/Abilities.tsx
@@ -312,6 +312,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.SEPSIS,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         enabled: combatant.hasCovenant(COVENANTS.NIGHT_FAE.id),
+        cooldown: 90,
         gcd: {
           static: standardGcd,
         },

--- a/analysis/rogueoutlaw/src/modules/features/Checklist/Component.tsx
+++ b/analysis/rogueoutlaw/src/modules/features/Checklist/Component.tsx
@@ -1,4 +1,5 @@
 import SPELLS from 'common/SPELLS';
+import COVENANTS from 'game/shadowlands/COVENANTS';
 import { SpellLink } from 'interface';
 import Checklist from 'parser/shared/modules/features/Checklist';
 import {
@@ -138,6 +139,9 @@ const OutlawRogueChecklist = ({
           <AbilityRequirement spell={SPELLS.KILLING_SPREE_TALENT.id} />
         )}
         <AbilityRequirement spell={SPELLS.VANISH.id} />
+        {combatant.hasCovenant(COVENANTS.NIGHT_FAE.id) && (
+          <AbilityRequirement spell={SPELLS.SEPSIS.id} />
+        )}
       </Rule>
       <PreparationRule thresholds={thresholds} />
     </Checklist>

--- a/analysis/roguesubtlety/src/CHANGELOG.js
+++ b/analysis/roguesubtlety/src/CHANGELOG.js
@@ -6,6 +6,7 @@ import React from 'react';
 
 
 export default [
+  change(date(2021, 4, 25), <>Added additional functionality to <SpellLink id={SPELLS.SEPSIS.id} /> analyzers. </>, Hordehobbs),
   change(date(2021,2,27), <>Add analyzer and suggestion for <SpellLink id={SPELLS.INSTANT_POISON.id} /> application.</>, Hordehobbs),
   change(date(2021, 1, 23), "Add GeneratorFollowingVanish analyzer.", Hordehobbs),
   change(date(2021, 1, 23), "Update CastsInShadowDance analyzer for proper value of max possible casts.", Hordehobbs),

--- a/analysis/roguesubtlety/src/CombatLogParser.tsx
+++ b/analysis/roguesubtlety/src/CombatLogParser.tsx
@@ -13,6 +13,7 @@ import {
   Flagellation,
   InvigoratingShadowdust,
   Sepsis,
+  StealthAbilityFollowingSepsis,
   SerratedBoneSpike,
   SpellEnergyCost,
   SpellUsable,
@@ -87,6 +88,7 @@ class CombatLogParser extends CoreCombatLogParser {
     echoingReprimand: EchoingReprimand,
     flagellation: Flagellation,
     sepsis: Sepsis,
+    stealthAbilityFollowingSepsis: StealthAbilityFollowingSepsis,
 
     // Legendaries
     akaarisSoulFragment: AkaarisSoulFragment,

--- a/analysis/roguesubtlety/src/modules/features/checklist/Component.tsx
+++ b/analysis/roguesubtlety/src/modules/features/checklist/Component.tsx
@@ -1,4 +1,5 @@
 import SPELLS from 'common/SPELLS';
+import COVENANTS from 'game/shadowlands/COVENANTS';
 import { SpellLink } from 'interface';
 import { TooltipElement } from 'interface';
 import Checklist from 'parser/shared/modules/features/Checklist';
@@ -39,6 +40,9 @@ const SubRogueChecklist = ({ combatant, castEfficiency, thresholds }: ChecklistP
         <AbilityRequirement spell={SPELLS.SHADOW_BLADES.id} />
         {combatant.hasTalent(SPELLS.SECRET_TECHNIQUE_TALENT.id) && (
           <AbilityRequirement spell={SPELLS.SECRET_TECHNIQUE_TALENT.id} />
+        )}
+        {combatant.hasCovenant(COVENANTS.NIGHT_FAE.id) && (
+          <AbilityRequirement spell={SPELLS.SEPSIS.id} />
         )}
       </Rule>
       <Rule

--- a/src/common/SPELLS/shadowlands/covenants/rogue.ts
+++ b/src/common/SPELLS/shadowlands/covenants/rogue.ts
@@ -46,6 +46,11 @@ const covenants = {
     name: 'Sepsis',
     icon: 'ability_ardenweald_rogue',
   },
+  SEPSIS_BUFF: {
+    id: 347037,
+    name: 'Sepsis',
+    icon: 'ability_ardenweald_rogue',
+  },
   //endregion
 
   //region Venthyr


### PR DESCRIPTION
### Notes
- Add CD efficiency tracking to Sepsis analyzer.
- Add CD reduction tracking to Sepsis analyzer.
- Add new analyzer, `StealthAbilityFollowingSepsis` to track proper stealth ability usage following Sepsis DoT completion.

### Screenshots:
![image](https://user-images.githubusercontent.com/6363390/116002810-44adcc80-a5b0-11eb-85a5-e73675501348.png)
![image](https://user-images.githubusercontent.com/6363390/116002826-52635200-a5b0-11eb-9b71-2e97e80bca8e.png)
![image](https://user-images.githubusercontent.com/6363390/116002840-5ee7aa80-a5b0-11eb-9e69-78b3b3ff860a.png)

