### PR TITLE
Fixed a bug where EVENT_ORDERS were being passed the spell object instead of the id

### DIFF
--- a/analysis/demonhunterhavoc/src/normalizers/EyeBeam.ts
+++ b/analysis/demonhunterhavoc/src/normalizers/EyeBeam.ts
@@ -7,7 +7,7 @@ const EVENT_ORDERS: EventOrder[] = [
   {
     beforeEventId: SPELLS.EYE_BEAM.id,
     beforeEventType: EventType.ApplyBuff,
-    afterEventId: SPELLS.METAMORPHOSIS_HAVOC_BUFF,
+    afterEventId: SPELLS.METAMORPHOSIS_HAVOC_BUFF.id,
     afterEventType: EventType.ApplyBuff,
     bufferMs: 50,
   },

--- a/analysis/druidrestoration/src/normalizers/ClearcastingNormalizer.ts
+++ b/analysis/druidrestoration/src/normalizers/ClearcastingNormalizer.ts
@@ -7,7 +7,7 @@ const EVENT_ORDERS: EventOrder[] = [
   {
     beforeEventId: SPELLS.REGROWTH.id,
     beforeEventType: EventType.Cast,
-    afterEventId: SPELLS.CLEARCASTING_BUFF,
+    afterEventId: SPELLS.CLEARCASTING_BUFF.id,
     afterEventType: EventType.RemoveBuff,
     bufferMs: 50,
     anyTarget: true,

--- a/analysis/magearcane/src/normalizers/ArcaneCharges.ts
+++ b/analysis/magearcane/src/normalizers/ArcaneCharges.ts
@@ -6,10 +6,10 @@ import { Options } from 'parser/core/Module';
 const EVENT_ORDERS: EventOrder[] = [
   {
     beforeEventId: [
-      SPELLS.ARCANE_BLAST,
-      SPELLS.ARCANE_EXPLOSION,
-      SPELLS.TOUCH_OF_THE_MAGI,
-      SPELLS.ARTIFICE_OF_THE_ARCHMAGE,
+      SPELLS.ARCANE_BLAST.id,
+      SPELLS.ARCANE_EXPLOSION.id,
+      SPELLS.TOUCH_OF_THE_MAGI.id,
+      SPELLS.ARTIFICE_OF_THE_ARCHMAGE.id,
     ],
     beforeEventType: EventType.Cast,
     afterEventId: null, // FIXME could this be acccidentally matching other kinds of energizes?


### PR DESCRIPTION
I don't know how this made it past the typechecker...