### PR TITLE
Events: Add space to Demon Hunter Class

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -1,7 +1,7 @@
 import { change, date } from 'common/changelog';
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
-import { Abelito75, acornellier, AdamKelly, Adoraci, Amani, Barry, Barter, Buudha, ChagriAli, ChristopherKiss, Dambroda, emallson, flurreN, Guyius, Haelrail, HolySchmidt, Jafowler, jos3p, joshinator, Juko8, Kartarn, Keraldi, Khazak, Kruzershtern, Mae, maestrohdude, Maldark, Moonrabbit, niseko, Procyon, Putro, Sharrq, Sref, Ssabbar, wmavis, Zeboot, Zerotorescue } from 'CONTRIBUTORS';
+import { Abelito75, acornellier, AdamKelly, Adoraci, Amani, Barry, Barter, Buudha, ChagriAli, ChristopherKiss, Dambroda, emallson, flurreN, Guyius, Haelrail, HolySchmidt, Jafowler, jos3p, joshinator, Juko8, Kartarn, Keraldi, Khazak, Kruzershtern, Mae, maestrohdude, Maldark, Moonrabbit, niseko, Procyon, Putro, Sharrq, Sref, Ssabbar, wmavis, Zeboot, Zerotorescue, niko } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 import React from 'react';
@@ -9,6 +9,7 @@ import React from 'react';
 
 // prettier-ignore
 export default [
+  change(date(2021, 4, 26), <>Fixed <SpellLink id={SPELLS.CHAOS_BRAND.id} /> count in Raid Buffs</>, niko),
   change(date(2021, 4, 20), 'Normalized normalizers', Sref),
   change(date(2021, 4, 20), 'More German translations for the interface', maestrohdude),
   change(date(2021, 4, 20), 'Update README api key wording.', wmavis),

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -1569,3 +1569,16 @@ export const wmavis: Contributor = {
     },
   ],
 };
+
+export const niko: Contributor = {
+  nickname: 'niko',
+  github: 'nicholasRutherford',
+  discord: 'niko#8550',
+  mains: [
+    {
+      name: 'Poro',
+      spec: SPECS.BREWMASTER_MONK,
+      link: 'https://worldofwarcraft.com/en-us/character/us/wildhammer/poro',
+    },
+  ],
+};

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -147,7 +147,7 @@ export interface ClassResources {
 
 // TODO: Find a good place for this
 export enum Class {
-  DemonHunter = 'DemonHunter',
+  DemonHunter = 'Demon Hunter',
   DeathKnight = 'Death Knight',
   Druid = 'Druid',
   Hunter = 'Hunter',


### PR DESCRIPTION
# Description

In [SPECS.ts](https://github.com/WoWAnalyzer/WoWAnalyzer/blob/shadowlands/src/game/SPECS.ts#L711) they use `Demon Hunter` (with a space) which was causing the[ class string comparison in ReportRaidBuffList.tsx](https://github.com/WoWAnalyzer/WoWAnalyzer/blob/shadowlands/src/interface/ReportRaidBuffList.tsx#L55) to fail. This now matches the class string formatting of Death Knight as well (which was fixed in cd93544).


# Motivation
I noticed that the Chaos Brand raid buff was incorrectly reporting. For [this report](https://wowanalyzer.com/report/7ZwWpynfCtRaQMTA/8-Normal+Sludgefist+-+Kill+(4:35)) it was saying 0, even though we had three demon hunters.

<details>
<summary>Current production screenshot</summary>

![image](https://user-images.githubusercontent.com/4751193/116132111-041e8380-a682-11eb-9184-20dc48afce60.png)
(Note the 0 for Chaos Brand despite having three demon hunters)
</details>

<details>
<summary>Local fix screenshot</summary>

![image](https://user-images.githubusercontent.com/4751193/116133173-41374580-a683-11eb-80eb-28933d08baed.png)
(Note the 3 for Chaos Brand for having three demon hunters)
</details>

# Testing
I checked the player selection screen locally. I also searched for everywhere else we use `Class`, which looks to only be here. So everything should be fine? Let me know if there is more I should be testing!