### PR TITLE
Re-added myself as Resto Druid maintainer. Updated graphics for 'percent healing' stats boxes.

### DIFF
--- a/analysis/druidrestoration/src/CHANGELOG.tsx
+++ b/analysis/druidrestoration/src/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { change, date } from 'common/changelog';
 import { Adoraci, Yajinni, Abelito75, Zeboot, LeoZhekov, Putro, Vexxra, Tiboonn, Ciuffi, Sref } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2021, 5, 4), 'Re-added myself as spec maintainer and updated visuals of percent increase stats boxes.', Sref),
   change(date(2021, 5, 4), 'Converted all remaining modules to TypeScript and updated HoT Tracking in preparation for future work', Sref),
   change(date(2021, 4, 14), 'Converted Mastery to TypeScript', Sref),
   change(date(2021, 4, 3), 'Verified 9.0.5 patch changes and bumped support to 9.0.5', Adoraci),

--- a/analysis/druidrestoration/src/CONFIG.tsx
+++ b/analysis/druidrestoration/src/CONFIG.tsx
@@ -1,3 +1,4 @@
+import { Sref } from 'CONTRIBUTORS';
 import SPECS from 'game/SPECS';
 import React from 'react';
 
@@ -5,7 +6,7 @@ import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [],
+  contributors: [Sref],
   // The WoW client patch this spec was last updated.
   patchCompatibility: '9.0.5',
   isPartial: false,

--- a/analysis/druidrestoration/src/modules/shadowlands/conduits/FlashOfClarity.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/conduits/FlashOfClarity.tsx
@@ -3,7 +3,7 @@ import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
 import Events, { CastEvent, HealEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
-import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
@@ -81,7 +81,7 @@ class FlashOfClarity extends Analyzer {
         category={STATISTIC_CATEGORY.COVENANTS}
       >
         <BoringSpellValueText spell={SPELLS.FLASH_OF_CLARITY}>
-          <ItemHealingDone amount={this.healing} />
+          <ItemPercentHealingDone amount={this.healing} />
           <br />
         </BoringSpellValueText>
       </Statistic>

--- a/analysis/druidrestoration/src/modules/shadowlands/legendaries/MemoryoftheMotherTree.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/legendaries/MemoryoftheMotherTree.tsx
@@ -9,7 +9,7 @@ import Events, {
 } from 'parser/core/Events';
 import { plotOneVariableBinomChart } from 'parser/shared/modules/helpers/Probability';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
-import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
@@ -202,7 +202,7 @@ class MemoryoftheMotherTree extends Analyzer {
               <td>Rejuvenation</td>
               <td>{this.extraRejuvs}</td>
               <td>
-                <ItemHealingDone amount={this.rejuvHealing} />
+                <ItemPercentHealingDone amount={this.rejuvHealing} />
               </td>
               <td>{this.rejuvOverhealing}</td>
             </tr>
@@ -210,7 +210,7 @@ class MemoryoftheMotherTree extends Analyzer {
               <td>Regrowth</td>
               <td>{this.extraRegrowths}</td>
               <td>
-                <ItemHealingDone amount={this.regrowthHealing} />
+                <ItemPercentHealingDone amount={this.regrowthHealing} />
               </td>
               <td>{this.regrowthOverhealing}</td>
             </tr>
@@ -218,7 +218,7 @@ class MemoryoftheMotherTree extends Analyzer {
         }
       >
         <BoringSpellValueText spell={SPELLS.MEMORY_OF_THE_MOTHER_TREE}>
-          <ItemHealingDone amount={this.rejuvHealing + this.regrowthHealing} />
+          <ItemPercentHealingDone amount={this.rejuvHealing + this.regrowthHealing} />
           <br />
         </BoringSpellValueText>
         {plotOneVariableBinomChart(this.procsGained, this.totalChances, this.procProbabilities)}

--- a/analysis/druidrestoration/src/modules/shadowlands/legendaries/VisionOfUnendingGrowth.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/legendaries/VisionOfUnendingGrowth.tsx
@@ -8,7 +8,7 @@ import Events, {
   RemoveBuffEvent,
 } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
-import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
@@ -115,7 +115,7 @@ class VisionOfUnendingGrowth extends Analyzer {
         tooltip={<>Extra Rejuvs: {this.extraRejuvs}</>}
       >
         <BoringSpellValueText spell={SPELLS.VISION_OF_UNENDING_GROWTH}>
-          <ItemHealingDone amount={this.healing} />
+          <ItemPercentHealingDone amount={this.healing} />
           <br />
         </BoringSpellValueText>
       </Statistic>

--- a/analysis/druidrestoration/src/modules/talents/CenarionWard.tsx
+++ b/analysis/druidrestoration/src/modules/talents/CenarionWard.tsx
@@ -1,8 +1,7 @@
-import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
-import { SpellIcon } from 'interface';
 import Analyzer, { Options } from 'parser/core/Analyzer';
-import BoringValue from 'parser/ui/BoringValueText';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
@@ -24,12 +23,8 @@ class CenarionWard extends Analyzer {
 
   statistic() {
     const directHealing = this.mastery.getDirectHealing(SPELLS.CENARION_WARD_HEAL.id);
-    const directPercent = this.owner.getPercentageOfTotalHealingDone(directHealing);
-
     const masteryHealing = this.mastery.getMasteryHealing(SPELLS.CENARION_WARD_HEAL.id);
-    const masteryPercent = this.owner.getPercentageOfTotalHealingDone(masteryHealing);
-
-    const totalPercent = directPercent + masteryPercent;
+    const totalHealing = directHealing + masteryHealing;
 
     return (
       <Statistic
@@ -41,24 +36,19 @@ class CenarionWard extends Analyzer {
             Cenarion Ward's extra mastery stack.
             <ul>
               <li>
-                Direct: <strong>{formatPercentage(directPercent)}%</strong>
+                Direct: <strong>{this.owner.formatItemHealingDone(directHealing)}</strong>
               </li>
               <li>
-                Mastery: <strong>{formatPercentage(masteryPercent)}%</strong>
+                Mastery: <strong>{this.owner.formatItemHealingDone(masteryHealing)}</strong>
               </li>
             </ul>
           </>
         }
       >
-        <BoringValue
-          label={
-            <>
-              <SpellIcon id={SPELLS.CENARION_WARD_HEAL.id} /> Cenarion Ward healing
-            </>
-          }
-        >
-          <>{formatPercentage(totalPercent)} %</>
-        </BoringValue>
+        <BoringSpellValueText spell={SPELLS.CENARION_WARD_TALENT}>
+          <ItemPercentHealingDone amount={totalHealing} />
+          <br />
+        </BoringSpellValueText>
       </Statistic>
     );
   }

--- a/analysis/druidrestoration/src/modules/talents/Cultivation.tsx
+++ b/analysis/druidrestoration/src/modules/talents/Cultivation.tsx
@@ -1,11 +1,11 @@
 import { t } from '@lingui/macro';
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
-import { SpellIcon } from 'interface';
 import { SpellLink } from 'interface';
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
-import BoringValue from 'parser/ui/BoringValueText';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
@@ -25,20 +25,20 @@ class Cultivation extends Analyzer {
     this.active = hasCultivation;
   }
 
-  get directPercent() {
-    return this.owner.getPercentageOfTotalHealingDone(
-      this.mastery.getDirectHealing(SPELLS.CULTIVATION.id),
-    );
+  get directHealing() {
+    return this.mastery.getDirectHealing(SPELLS.CULTIVATION.id);
   }
 
-  get masteryPercent() {
-    return this.owner.getPercentageOfTotalHealingDone(
-      this.mastery.getMasteryHealing(SPELLS.CULTIVATION.id),
-    );
+  get masteryHealing() {
+    return this.mastery.getMasteryHealing(SPELLS.CULTIVATION.id);
+  }
+
+  get totalHealing() {
+    return this.directHealing + this.masteryHealing;
   }
 
   get totalPercent() {
-    return this.directPercent + this.masteryPercent;
+    return this.owner.getPercentageOfTotalHealingDone(this.totalHealing);
   }
 
   get suggestionThresholds() {
@@ -84,24 +84,19 @@ class Cultivation extends Analyzer {
             Cultivation's extra mastery stack.
             <ul>
               <li>
-                Direct: <strong>{formatPercentage(this.directPercent)}%</strong>
+                Direct: <strong>{this.owner.formatItemHealingDone(this.directHealing)}</strong>
               </li>
               <li>
-                Mastery: <strong>{formatPercentage(this.masteryPercent)}%</strong>
+                Mastery: <strong>{this.owner.formatItemHealingDone(this.masteryHealing)}</strong>
               </li>
             </ul>
           </>
         }
       >
-        <BoringValue
-          label={
-            <>
-              <SpellIcon id={SPELLS.CULTIVATION.id} /> Cultivation healing{' '}
-            </>
-          }
-        >
-          <>{formatPercentage(this.totalPercent)} %</>
-        </BoringValue>
+        <BoringSpellValueText spell={SPELLS.CULTIVATION_TALENT}>
+          <ItemPercentHealingDone amount={this.totalHealing} />
+          <br />
+        </BoringSpellValueText>
       </Statistic>
     );
   }

--- a/analysis/druidrestoration/src/modules/talents/Flourish.tsx
+++ b/analysis/druidrestoration/src/modules/talents/Flourish.tsx
@@ -1,14 +1,14 @@
 import { t } from '@lingui/macro';
 import { formatPercentage, formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
-import { SpellIcon } from 'interface';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
 import Events, { HealEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import { Attribution } from 'parser/shared/modules/HotTracker';
-import BoringValue from 'parser/ui/BoringValueText';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
@@ -300,9 +300,7 @@ class Flourish extends Analyzer {
     const increasedRatePercent = this.owner.getPercentageOfTotalHealingDone(
       this.increasedRateTotalHealing,
     );
-    const totalPercent = this.owner.getPercentageOfTotalHealingDone(
-      this.totalExtensionHealing + this.increasedRateTotalHealing,
-    );
+    const totalHealing = this.totalExtensionHealing + this.increasedRateTotalHealing;
     return (
       <Statistic
         size="flexible"
@@ -427,15 +425,10 @@ class Flourish extends Analyzer {
           </>
         }
       >
-        <BoringValue
-          label={
-            <>
-              <SpellIcon id={SPELLS.FLOURISH_TALENT.id} /> Flourish healing
-            </>
-          }
-        >
-          <>{formatPercentage(totalPercent)} %</>
-        </BoringValue>
+        <BoringSpellValueText spell={SPELLS.FLOURISH_TALENT}>
+          <ItemPercentHealingDone amount={totalHealing} />
+          <br />
+        </BoringSpellValueText>
       </Statistic>
     );
   }

--- a/analysis/druidrestoration/src/modules/talents/Photosynthesis.tsx
+++ b/analysis/druidrestoration/src/modules/talents/Photosynthesis.tsx
@@ -1,12 +1,12 @@
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
-import { SpellIcon } from 'interface';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
 import Events, { CastEvent, HealEvent, RemoveBuffEvent } from 'parser/core/Events';
 import { Options } from 'parser/core/Module';
 import Combatants from 'parser/shared/modules/Combatants';
-import BoringValue from 'parser/ui/BoringValueText';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
@@ -375,15 +375,10 @@ class Photosynthesis extends Analyzer {
           </>
         }
       >
-        <BoringValue
-          label={
-            <>
-              <SpellIcon id={SPELLS.PHOTOSYNTHESIS_TALENT.id} /> Photosynthesis healing
-            </>
-          }
-        >
-          <>{formatPercentage(this.percentHealing)} %</>
-        </BoringValue>
+        <BoringSpellValueText spell={SPELLS.PHOTOSYNTHESIS_TALENT}>
+          <ItemPercentHealingDone amount={this.totalHealing} />
+          <br />
+        </BoringSpellValueText>
       </Statistic>
     );
   }

--- a/analysis/druidrestoration/src/modules/talents/SoulOfTheForest.tsx
+++ b/analysis/druidrestoration/src/modules/talents/SoulOfTheForest.tsx
@@ -1,7 +1,6 @@
 import { t } from '@lingui/macro';
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
-import { SpellIcon } from 'interface';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
@@ -13,7 +12,8 @@ import Events, {
   RemoveBuffEvent,
 } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
-import BoringValue from 'parser/ui/BoringValueText';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
@@ -262,7 +262,6 @@ class SoulOfTheForest extends Analyzer {
     const proccs = this.wildGrowthsBuffed + this.regrowthBuffed + this.rejuvBuffed;
 
     const total = this.wildGrowthHealing + this.rejuvHealing + this.regrowthHealing;
-    const totalPercent = this.owner.getPercentageOfTotalHealingDone(total);
 
     const wgPercent = this.owner.getPercentageOfTotalHealingDone(this.wildGrowthHealing);
     const rejuvPercent = this.owner.getPercentageOfTotalHealingDone(this.rejuvHealing);
@@ -292,16 +291,10 @@ class SoulOfTheForest extends Analyzer {
           </>
         }
       >
-        <BoringValue
-          label={
-            <>
-              <SpellIcon id={SPELLS.SOUL_OF_THE_FOREST_TALENT_RESTORATION.id} /> Soul of the Forest
-              healing
-            </>
-          }
-        >
-          <>{formatPercentage(totalPercent)} %</>
-        </BoringValue>
+        <BoringSpellValueText spell={SPELLS.SOUL_OF_THE_FOREST_TALENT_RESTORATION}>
+          <ItemPercentHealingDone amount={total} />
+          <br />
+        </BoringSpellValueText>
       </Statistic>
     );
   }

--- a/analysis/druidrestoration/src/modules/talents/SpringBlossoms.tsx
+++ b/analysis/druidrestoration/src/modules/talents/SpringBlossoms.tsx
@@ -1,11 +1,11 @@
 import { t } from '@lingui/macro';
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
-import { SpellIcon } from 'interface';
 import { SpellLink } from 'interface';
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
-import BoringValue from 'parser/ui/BoringValueText';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
@@ -27,6 +27,18 @@ class SpringBlossoms extends Analyzer {
 
   get totalPercent() {
     return this.directPercent + this.masteryPercent;
+  }
+
+  get directHealing() {
+    return this.mastery.getDirectHealing(SPELLS.SPRING_BLOSSOMS.id);
+  }
+
+  get masteryHealing() {
+    return this.mastery.getMasteryHealing(SPELLS.SPRING_BLOSSOMS.id);
+  }
+
+  get totalHealing() {
+    return this.directHealing + this.masteryHealing;
   }
 
   get suggestionThresholds() {
@@ -63,24 +75,19 @@ class SpringBlossoms extends Analyzer {
             Spring Blossom's extra mastery stack.
             <ul>
               <li>
-                Direct: <strong>{formatPercentage(this.directPercent)}%</strong>
+                Direct: <strong>{this.owner.formatItemHealingDone(this.directHealing)}</strong>
               </li>
               <li>
-                Mastery: <strong>{formatPercentage(this.masteryPercent)}%</strong>
+                Mastery: <strong>{this.owner.formatItemHealingDone(this.masteryHealing)}</strong>
               </li>
             </ul>
           </>
         }
       >
-        <BoringValue
-          label={
-            <>
-              <SpellIcon id={SPELLS.SPRING_BLOSSOMS.id} /> Spring Blossoms healing
-            </>
-          }
-        >
-          <>{formatPercentage(this.totalPercent)} %</>
-        </BoringValue>
+        <BoringSpellValueText spell={SPELLS.SPRING_BLOSSOMS_TALENT}>
+          <ItemPercentHealingDone amount={this.totalHealing} />
+          <br />
+        </BoringSpellValueText>
       </Statistic>
     );
   }

--- a/analysis/druidrestoration/src/modules/talents/TreeOfLife.tsx
+++ b/analysis/druidrestoration/src/modules/talents/TreeOfLife.tsx
@@ -2,7 +2,6 @@ import { t } from '@lingui/macro';
 import { formatNumber, formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
-import { SpellIcon } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
 import Events, {
@@ -15,7 +14,8 @@ import Events, {
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import HealingDone from 'parser/shared/modules/throughput/HealingDone';
-import BoringValue from 'parser/ui/BoringValueText';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
@@ -274,20 +274,10 @@ class TreeOfLife extends Analyzer {
           </>
         }
       >
-        <BoringValue
-          label={
-            <>
-              <SpellIcon id={SPELLS.INCARNATION_TREE_OF_LIFE_TALENT.id} /> Tree of Life healing
-            </>
-          }
-        >
-          <>
-            {formatPercentage(
-              this.owner.getPercentageOfTotalHealingDone(this._getTotalHealing(this.hardcast)),
-            )}{' '}
-            %
-          </>
-        </BoringValue>
+        <BoringSpellValueText spell={SPELLS.INCARNATION_TREE_OF_LIFE_TALENT}>
+          <ItemPercentHealingDone amount={this._getTotalHealing(this.hardcast)} />
+          <br />
+        </BoringSpellValueText>
       </Statistic>
     );
   }

--- a/src/parser/core/CombatLogParser.ts
+++ b/src/parser/core/CombatLogParser.ts
@@ -557,13 +557,16 @@ class CombatLogParser {
     return HasTarget(event) && this.playerPets.some((pet) => pet.id === event.targetID);
   }
 
+  getPerSecond(totalAmount: number): number {
+    return (totalAmount / this.fightDuration) * 1000;
+  }
   getPercentageOfTotalHealingDone(healingDone: number) {
     return healingDone / this.getModule(HealingDone).total.effective;
   }
   formatItemHealingDone(healingDone: number) {
     return `${formatPercentage(
       this.getPercentageOfTotalHealingDone(healingDone),
-    )} % / ${formatNumber((healingDone / this.fightDuration) * 1000)} HPS`;
+    )} % / ${formatNumber(this.getPerSecond(healingDone))} HPS`;
   }
   formatItemAbsorbDone(absorbDone: number) {
     return `${formatNumber(absorbDone)}`;
@@ -573,7 +576,7 @@ class CombatLogParser {
   }
   formatItemDamageDone(damageDone: number) {
     return `${formatPercentage(this.getPercentageOfTotalDamageDone(damageDone))} % / ${formatNumber(
-      (damageDone / this.fightDuration) * 1000,
+      this.getPerSecond(damageDone),
     )} DPS`;
   }
   getPercentageOfTotalDamageTaken(damageTaken: number) {

--- a/src/parser/ui/ItemPercentHealingDone.tsx
+++ b/src/parser/ui/ItemPercentHealingDone.tsx
@@ -1,0 +1,35 @@
+import { formatPercentage, formatNumber } from 'common/format';
+import CombatLogParser from 'parser/core/CombatLogParser';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+interface Props {
+  amount: number;
+  approximate?: boolean;
+  greaterThan?: boolean;
+  lessThan?: boolean;
+}
+interface Context {
+  parser: CombatLogParser;
+}
+
+/**
+ * Like ItemHealingDone, but with the emphasis on the percentage over the HPS.
+ */
+const ItemPercentHealingDone = (
+  { amount, approximate, greaterThan, lessThan }: Props,
+  { parser }: Context,
+) => (
+  <>
+    <img src="/img/healing.png" alt="Healing" className="icon" /> {approximate && '≈'}
+    {greaterThan && '>'}
+    {lessThan && '<'}
+    {formatPercentage(parser.getPercentageOfTotalHealingDone(amount))} %{' '}
+    <small>{formatNumber((amount / parser.fightDuration) * 1000)} HPS</small>
+  </>
+);
+ItemPercentHealingDone.contextTypes = {
+  parser: PropTypes.object.isRequired,
+};
+
+export default ItemPercentHealingDone;


### PR DESCRIPTION
I made a new `ItemPercentHealingDone` to complement the existing `ItemHealingDone` because I wanted to take advantage of the pretty graphics, but the Resto Druid community prefers to express boosts in percent of total healing instead of as HPS.

Before:
![percent-box-before](https://user-images.githubusercontent.com/7143486/117038693-f26a5b00-acd5-11eb-8621-f740431eea33.png)
After:
![percent-box-after](https://user-images.githubusercontent.com/7143486/117038704-f6967880-acd5-11eb-8ed9-fc4b1b05e2eb.png)
