### PR TITLE
Resto Druid - Added modules for the covenant ability 'Adaptive Swarm' and the related conduit 'Evolved Swarm'

### DIFF
--- a/analysis/druid/src/index.ts
+++ b/analysis/druid/src/index.ts
@@ -1,1 +1,1 @@
-export { default as ConvokeSpirits } from './ConvokeSpirits';
+export { default as ConvokeSpirits } from './shadowlands/ConvokeSpirits';

--- a/analysis/druid/src/index.ts
+++ b/analysis/druid/src/index.ts
@@ -1,1 +1,2 @@
 export { default as ConvokeSpirits } from './shadowlands/ConvokeSpirits';
+export { default as AdaptiveSwarm } from './shadowlands/AdaptiveSwarm';

--- a/analysis/druid/src/shadowlands/AdaptiveSwarm.ts
+++ b/analysis/druid/src/shadowlands/AdaptiveSwarm.ts
@@ -1,0 +1,292 @@
+import SPELLS from 'common/SPELLS';
+import COVENANTS from 'game/shadowlands/COVENANTS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
+import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
+import { SpellInfo } from 'parser/core/EventFilter';
+import Events, { DamageEvent, HealEvent } from 'parser/core/Events';
+import AbilityTracker from 'parser/shared/modules/AbilityTracker';
+import Combatants from 'parser/shared/modules/Combatants';
+import Enemies from 'parser/shared/modules/Enemies';
+
+const BASE_PERIODIC_BOOST = 0.25; // the amount Adaptive Swarm boosts periodic effects
+
+// the amount Evolved Swarm adds to the base periodic boost
+const EVOLVED_SWARM_EFFECT_BY_RANK = [
+  0.06,
+  0.066,
+  0.072,
+  0.078,
+  0.084,
+  0.09,
+  0.096,
+  0.102,
+  0.108,
+  0.114,
+  0.12,
+  0.126,
+  0.132,
+  0.138,
+  0.144,
+];
+
+const PERIODIC_HEALS: SpellInfo[] = [
+  SPELLS.REJUVENATION,
+  SPELLS.REJUVENATION_GERMINATION,
+  SPELLS.REGROWTH, // adaptive swarm also boosts the direct healing, so no need for 'tick' differentiation
+  SPELLS.WILD_GROWTH,
+  SPELLS.CULTIVATION,
+  SPELLS.SPRING_BLOSSOMS,
+  SPELLS.CENARION_WARD_HEAL,
+  SPELLS.FRENZIED_REGENERATION,
+  SPELLS.LIFEBLOOM_HOT_HEAL,
+  SPELLS.LIFEBLOOM_DTL_HOT_HEAL,
+  SPELLS.TRANQUILITY_HEAL,
+  SPELLS.EFFLORESCENCE_HEAL,
+  // deliberately doesn't include Adaptive Swarm itself to avoid double count
+];
+
+const PERIODIC_DAMAGE: SpellInfo[] = [
+  SPELLS.THRASH_BEAR_DOT,
+  SPELLS.MOONFIRE_BEAR, // apparently the DoT for everyone
+  SPELLS.SUNFIRE,
+  SPELLS.RIP,
+  SPELLS.RAKE, // adaptive swarm also boosts the direct damage, so no need for 'tick' differentiation
+  SPELLS.RAKE_BLEED,
+  SPELLS.FERAL_FRENZY_DEBUFF,
+  // deliberately doesn't include Adaptive Swarm itself to avoid double count
+];
+
+/**
+ * This module performs calculations for both Adaptive Swarm and Evolved Swarm, but does not
+ * display any of it. Spec specific modules should take care of display.
+ *
+ *
+ * **Adaptive Swarm**
+ * Covenant Ability - Necrolord
+ *
+ * Command a swarm that heals (157.5% of Spell power) or deals (150% of Spell power) Shadow damage
+ * over 12 sec to a target, and increases the effectiveness of your periodic effects on them by 25%.
+ * Upon expiration, jumps to a target within 25 yards, alternating between friend and foe up to 3 times.
+ *
+ *
+ * **Evolved Swarm**
+ * Conduit - Necrolord
+ *
+ * Adaptive Swarm increases periodic effects by an additional X%.
+ */
+class AdaptiveSwarm extends Analyzer {
+  static dependencies = {
+    abilityTracker: AbilityTracker,
+    combatants: Combatants,
+    enemies: Enemies,
+  };
+
+  protected abilityTracker!: AbilityTracker;
+  protected combatants!: Combatants;
+  protected enemies!: Enemies;
+
+  hasEvolvedSwarm: boolean;
+
+  // the strength of the periodic boost, calculated dynamically based on conduit ilvl (if present)
+  _evolvedSwarmPeriodicBoost: number;
+  // evolved swarm's boost relative to the total heal - for calculating attribution
+  _evolvedSwarmRelativeBoost: number;
+  _totalPeriodicBoost: number;
+
+  // A tally of the healing attributable to Adaptive Swarm's boost on periodic effects,
+  // including any additional boost from Evolved Swarm. While it does buff itself,
+  // we don't count that because it's already covered by the 'direct healing' category
+  _periodicBoostHealingAttribution: number = 0;
+
+  // A tally of the healing attributable specifically to Evolved Swarm's additional boost.
+  // This will effectively double count with respect to the overall period boost attribution
+  _evolvedSwarmHealingAttribution: number = 0;
+
+  // A tally of the damage attributable to Adaptive Swarm's boost on periodic effects,
+  // including any additional boost from Evolved Swarm. While it does buff itself,
+  // we don't count that because it's already covered by the 'direct damage' category
+  _periodicBoostDamageAttribution: number = 0;
+
+  // A tally of the damage attributable specifically to Evolved Swarm's additional boost.
+  // This will effectively double count with respect to the overall period boost attribution
+  _evolvedSwarmDamageAttribution: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasCovenant(COVENANTS.NECROLORD.id);
+    this.hasEvolvedSwarm = this.selectedCombatant.hasConduitBySpellID(SPELLS.EVOLVED_SWARM.id);
+
+    this._totalPeriodicBoost = BASE_PERIODIC_BOOST;
+    this._evolvedSwarmPeriodicBoost = 0;
+    this._evolvedSwarmRelativeBoost = 0;
+    if (this.hasEvolvedSwarm) {
+      this._evolvedSwarmPeriodicBoost =
+        EVOLVED_SWARM_EFFECT_BY_RANK[
+          this.selectedCombatant.conduitRankBySpellID(SPELLS.EVOLVED_SWARM.id)
+        ];
+      this._evolvedSwarmRelativeBoost = this._evolvedSwarmPeriodicBoost / (1 + BASE_PERIODIC_BOOST);
+      this._totalPeriodicBoost += this._evolvedSwarmPeriodicBoost;
+
+      // listeners for tallying extra boost attribution to direct healing/damaging
+      this.addEventListener(
+        Events.heal.by(SELECTED_PLAYER).spell(SPELLS.ADAPTIVE_SWARM_HEAL),
+        this.onAdaptiveSwarmHeal,
+      );
+      this.addEventListener(
+        Events.damage.by(SELECTED_PLAYER).spell(SPELLS.ADAPTIVE_SWARM_DAMAGE),
+        this.onAdaptiveSwarmDamage,
+      );
+    }
+
+    this.addEventListener(
+      Events.heal.by(SELECTED_PLAYER).spell(PERIODIC_HEALS),
+      this.onPeriodicHeal,
+    );
+
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(PERIODIC_DAMAGE),
+      this.onPeriodicDamage,
+    );
+  }
+
+  onPeriodicHeal(event: HealEvent) {
+    const target = this.combatants.getEntity(event);
+    if (
+      target === null ||
+      !target.hasBuff(
+        SPELLS.ADAPTIVE_SWARM_HEAL.id,
+        this.owner.currentTimestamp,
+        0,
+        0,
+        this.selectedCombatant.id,
+      )
+    ) {
+      return;
+    }
+
+    // if we got this far, our adaptive swarm is on the heal target
+    this._periodicBoostHealingAttribution += calculateEffectiveHealing(
+      event,
+      this._totalPeriodicBoost,
+    );
+
+    if (this.hasEvolvedSwarm) {
+      this._evolvedSwarmHealingAttribution += calculateEffectiveHealing(
+        event,
+        this._evolvedSwarmRelativeBoost,
+      );
+    }
+  }
+
+  onAdaptiveSwarmHeal(event: HealEvent) {
+    this._evolvedSwarmHealingAttribution += calculateEffectiveHealing(
+      event,
+      this._evolvedSwarmRelativeBoost,
+    );
+  }
+
+  onPeriodicDamage(event: DamageEvent) {
+    const target = this.enemies.getEntity(event);
+    if (
+      target === null ||
+      !target.hasBuff(
+        SPELLS.ADAPTIVE_SWARM_DAMAGE.id,
+        this.owner.currentTimestamp,
+        0,
+        0,
+        this.selectedCombatant.id,
+      )
+    ) {
+      return;
+    }
+
+    // if we got this far, our adaptive swarm is on the damage target
+    this._periodicBoostDamageAttribution += calculateEffectiveDamage(
+      event,
+      this._totalPeriodicBoost,
+    );
+
+    if (this.hasEvolvedSwarm) {
+      this._evolvedSwarmDamageAttribution += calculateEffectiveDamage(
+        event,
+        this._evolvedSwarmRelativeBoost,
+      );
+    }
+  }
+
+  onAdaptiveSwarmDamage(event: DamageEvent) {
+    this._evolvedSwarmDamageAttribution += calculateEffectiveDamage(
+      event,
+      this._evolvedSwarmRelativeBoost,
+    );
+  }
+
+  /** The total healing done directly by Adaptive Swarm (this includes the boost to itself) */
+  get directHealing(): number {
+    return this.abilityTracker.getAbility(SPELLS.ADAPTIVE_SWARM_HEAL.id).healingEffective;
+  }
+
+  /** The total healing done due to Adaptive Swarm's boost to other periodic effects */
+  get boostedHealing(): number {
+    return this._periodicBoostHealingAttribution;
+  }
+
+  /** The sum total healing due to Adaptive Swarm's direct and boost components */
+  get totalHealing(): number {
+    return this.directHealing + this.boostedHealing;
+  }
+
+  /** The total healing done due specifically to Evolved Swarm's extra boost. */
+  get evolvedSwarmHealing(): number {
+    return this._evolvedSwarmHealingAttribution;
+  }
+
+  /** The total damage done directly by Adaptive Swarm (this includes the boost to itself) */
+  get directDamage(): number {
+    return this.abilityTracker.getAbility(SPELLS.ADAPTIVE_SWARM_DAMAGE.id).damageEffective;
+  }
+
+  /** The total damage done due to Adaptive Swarm's boost to other periodic effects */
+  get boostedDamage(): number {
+    return this._periodicBoostDamageAttribution;
+  }
+
+  /** The sum total damage due to Adaptive Swarm's direct and boost components */
+  get totalDamage(): number {
+    return this.directDamage + this.boostedDamage;
+  }
+
+  /** The total damage done due specifically to Evolved Swarm's extra boost */
+  get evolvedSwarmDamage(): number {
+    return this._evolvedSwarmDamageAttribution;
+  }
+
+  /** The total number of times the player cast Adaptive Swarm */
+  get casts(): number {
+    return this.abilityTracker.getAbility(SPELLS.ADAPTIVE_SWARM.id).casts;
+  }
+
+  /** The total ms of uptime for the player's Adaptive Swarm healing buff (HoT) */
+  get buffUptime(): number {
+    return this.combatants.getBuffUptime(SPELLS.ADAPTIVE_SWARM_HEAL.id);
+  }
+
+  /** The average ms of uptime for the player's Adaptive Swarm healing buff (HoT) per cast */
+  get buffTimePerCast(): number {
+    return this.casts === 0 ? 0 : this.buffUptime / this.casts;
+  }
+
+  /** The total ms of uptime for the player's Adaptive Swarm damage debuff (DoT) */
+  get debuffUptime(): number {
+    return this.enemies.getBuffUptime(SPELLS.ADAPTIVE_SWARM_DAMAGE.id);
+  }
+
+  /** The average ms of uptime for the player's Adaptive Swarm damage debuff (DoT) per cast */
+  get debuffTimePerCast(): number {
+    return this.casts === 0 ? 0 : this.debuffUptime / this.casts;
+  }
+}
+
+export default AdaptiveSwarm;

--- a/analysis/druid/src/shadowlands/ConvokeSpirits.tsx
+++ b/analysis/druid/src/shadowlands/ConvokeSpirits.tsx
@@ -22,7 +22,7 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
 
-import ActiveDruidForm, { DruidForm } from './core/ActiveDruidForm';
+import ActiveDruidForm, { DruidForm } from '../core/ActiveDruidForm';
 
 const SPELLS_WITH_TRAVEL_TIME = [
   SPELLS.STARSURGE_AFFINITY.id,

--- a/analysis/druidrestoration/src/CHANGELOG.tsx
+++ b/analysis/druidrestoration/src/CHANGELOG.tsx
@@ -1,7 +1,11 @@
 import { change, date } from 'common/changelog';
+import SPELLS from 'common/SPELLS';
 import { Adoraci, Yajinni, Abelito75, Zeboot, LeoZhekov, Putro, Vexxra, Tiboonn, Ciuffi, Sref } from 'CONTRIBUTORS';
+import SpellLink from 'interface/SpellLink';
+import React from 'react';
 
 export default [
+  change(date(2021, 5, 5), <>Added <SpellLink id={SPELLS.ADAPTIVE_SWARM.id} /> and <SpellLink id={SPELLS.EVOLVED_SWARM.id} /> support</>, Sref),
   change(date(2021, 5, 4), 'Re-added myself as spec maintainer and updated visuals of percent increase stats boxes.', Sref),
   change(date(2021, 5, 4), 'Converted all remaining modules to TypeScript and updated HoT Tracking in preparation for future work', Sref),
   change(date(2021, 4, 14), 'Converted Mastery to TypeScript', Sref),

--- a/analysis/druidrestoration/src/CombatLogParser.ts
+++ b/analysis/druidrestoration/src/CombatLogParser.ts
@@ -29,7 +29,9 @@ import PrematureRejuvenations from './modules/features/PrematureRejuvenations';
 import HealingEfficiencyTracker from './modules/features/RestoDruidHealingEfficiencyTracker';
 import StatWeights from './modules/features/StatWeights';
 import WildGrowth from './modules/features/WildGrowth';
+import EvolvedSwarmResto from './modules/shadowlands/conduits/EvolvedSwarmResto';
 import FlashOfClarity from './modules/shadowlands/conduits/FlashOfClarity';
+import AdaptiveSwarmResto from './modules/shadowlands/covenants/AdaptiveSwarmResto';
 import MemoryoftheMotherTree from './modules/shadowlands/legendaries/MemoryoftheMotherTree';
 import VisionOfUnendingGrowrth from './modules/shadowlands/legendaries/VisionOfUnendingGrowth';
 import Abundance from './modules/talents/Abundance';
@@ -107,10 +109,12 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Covenants
     convokeSpirits: ConvokeSpirits,
+    adaptiveSwarm: AdaptiveSwarmResto,
 
     // Conduits
     // Potency
     flashOfClarity: FlashOfClarity,
+    evolvedSwarmResto: EvolvedSwarmResto,
 
     //legos
     visionOfUnendingGrowrth: VisionOfUnendingGrowrth,

--- a/analysis/druidrestoration/src/SpellInfo.ts
+++ b/analysis/druidrestoration/src/SpellInfo.ts
@@ -153,6 +153,15 @@ export const DRUID_HEAL_INFO: ListOfHealerSpellInfo = {
     masteryStack: false,
     vers: true,
   },
+  [SPELLS.ADAPTIVE_SWARM_HEAL.id]: {
+    int: true,
+    crit: true,
+    hasteHpm: true,
+    hasteHpct: false,
+    mastery: true,
+    masteryStack: true,
+    vers: true,
+  },
   [SPELLS.YSERAS_GIFT_OTHERS.id]: {
     // TODO does it really scale with nothing (except stam)?
     int: false,

--- a/analysis/druidrestoration/src/modules/Abilities.tsx
+++ b/analysis/druidrestoration/src/modules/Abilities.tsx
@@ -90,7 +90,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.ADAPTIVE_SWARM,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        cooldown: 25, // TODO any modifiers to this?
+        cooldown: 25,
         gcd: {
           base: 1500,
         },

--- a/analysis/druidrestoration/src/modules/Abilities.tsx
+++ b/analysis/druidrestoration/src/modules/Abilities.tsx
@@ -1,4 +1,5 @@
 import SPELLS from 'common/SPELLS';
+import COVENANTS from 'game/shadowlands/COVENANTS';
 import ISSUE_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
 import CoreAbilities from 'parser/core/modules/Abilities';
 
@@ -85,6 +86,19 @@ class Abilities extends CoreAbilities {
           averageIssueEfficiency: 0.55,
           majorIssueEfficiency: 0.3,
         },
+      },
+      {
+        spell: SPELLS.ADAPTIVE_SWARM,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        cooldown: 25, // TODO any modifiers to this?
+        gcd: {
+          base: 1500,
+        },
+        enabled: combatant.hasCovenant(COVENANTS.NECROLORD.id),
+        castEfficiency: {
+          suggestion: true,
+        },
+        healSpellIds: [SPELLS.ADAPTIVE_SWARM_HEAL.id],
       },
       {
         spell: SPELLS.WILD_GROWTH,

--- a/analysis/druidrestoration/src/modules/features/Checklist/Component.tsx
+++ b/analysis/druidrestoration/src/modules/features/Checklist/Component.tsx
@@ -1,4 +1,5 @@
 import SPELLS from 'common/SPELLS';
+import COVENANTS from 'game/shadowlands/COVENANTS';
 import { SpellLink } from 'interface';
 import Checklist from 'parser/shared/modules/features/Checklist';
 import {
@@ -100,6 +101,9 @@ const RestorationDruidChecklist = ({ combatant, castEfficiency, thresholds }: Ch
       >
         {combatant.hasTalent(SPELLS.CENARION_WARD_TALENT.id) && (
           <AbilityRequirement spell={SPELLS.CENARION_WARD_TALENT.id} />
+        )}
+        {combatant.hasCovenant(COVENANTS.NECROLORD.id) && (
+          <AbilityRequirement spell={SPELLS.ADAPTIVE_SWARM.id} />
         )}
         {combatant.hasTalent(SPELLS.FLOURISH_TALENT.id) && (
           <AbilityRequirement spell={SPELLS.FLOURISH_TALENT.id} />

--- a/analysis/druidrestoration/src/modules/shadowlands/conduits/EvolvedSwarmResto.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/conduits/EvolvedSwarmResto.tsx
@@ -1,0 +1,52 @@
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import React from 'react';
+
+import AdaptiveSwarmResto from '../covenants/AdaptiveSwarmResto';
+
+/**
+ * Resto's display module for Evolved Swarm.
+ */
+class EvolvedSwarmResto extends Analyzer {
+  static dependencies = {
+    adaptiveSwarmResto: AdaptiveSwarmResto,
+  };
+
+  protected adaptiveSwarmResto!: AdaptiveSwarmResto;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasConduitBySpellID(SPELLS.EVOLVED_SWARM.id);
+  }
+
+  // All the actual calculations are centralized in AdaptiveSwarm,
+  // this class is just here for the extra statistic box.
+  statistic(): React.ReactNode {
+    return (
+      <Statistic
+        size="flexible"
+        position={STATISTIC_ORDER.OPTIONAL(0)}
+        category={STATISTIC_CATEGORY.COVENANTS}
+        tooltip={
+          <>
+            This is the healing attributable specifically to Evolved Swarm's boost to Adaptive
+            Swarm. Note that healing represented here is also being counted in Adaptive Swarm's
+            statistic box.
+          </>
+        }
+      >
+        <BoringSpellValueText spell={SPELLS.EVOLVED_SWARM}>
+          <ItemPercentHealingDone amount={this.adaptiveSwarmResto.evolvedSwarmHealing} />
+          <br />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default EvolvedSwarmResto;

--- a/analysis/druidrestoration/src/modules/shadowlands/covenants/AdaptiveSwarmResto.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/covenants/AdaptiveSwarmResto.tsx
@@ -1,0 +1,80 @@
+import { formatNumber } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import COVENANTS from 'game/shadowlands/COVENANTS';
+import { Options } from 'parser/core/Analyzer';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import React from 'react';
+
+import { AdaptiveSwarm } from '@wowanalyzer/druid';
+
+import Mastery from '../../core/Mastery';
+
+/**
+ * Resto's display module for Adaptive Swarm.
+ */
+class AdaptiveSwarmResto extends AdaptiveSwarm {
+  static dependencies = {
+    ...AdaptiveSwarm.dependencies,
+    mastery: Mastery,
+  };
+
+  protected mastery!: Mastery;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasCovenant(COVENANTS.NECROLORD.id);
+  }
+
+  get masteryHealing() {
+    return this.mastery.getMasteryHealing(SPELLS.ADAPTIVE_SWARM_HEAL.id);
+  }
+
+  /** The actual total healing for Resto must also include the mastery attribution */
+  get totalHealingWithMastery() {
+    return this.totalHealing + this.masteryHealing;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        size="flexible"
+        position={STATISTIC_ORDER.CORE(0)}
+        category={STATISTIC_CATEGORY.COVENANTS}
+        tooltip={
+          <>
+            This is the sum of the direct healing from Adaptive Swarm, the healing enabled by its
+            extra mastery stack, and the healing enabled by its boost to periodic effects. It had an
+            average healing uptime per cast of{' '}
+            <strong>{(this.buffTimePerCast / 1000).toFixed(0)}s</strong>.
+            <ul>
+              <li>
+                Direct: <strong>{this.owner.formatItemHealingDone(this.directHealing)}</strong>
+              </li>
+              <li>
+                Mastery: <strong>{this.owner.formatItemHealingDone(this.masteryHealing)}</strong>
+              </li>
+              <li>
+                Boost: <strong>{this.owner.formatItemHealingDone(this.boostedHealing)}</strong>
+              </li>
+            </ul>
+            In addition, Adaptive Swarm did{' '}
+            <strong>{formatNumber(this.owner.getPerSecond(this.totalDamage))} DPS</strong> over the
+            encounter with an average damage uptime per cast of{' '}
+            <strong>{(this.debuffTimePerCast / 1000).toFixed(0)}s</strong>.
+          </>
+        }
+      >
+        <BoringSpellValueText spell={SPELLS.ADAPTIVE_SWARM}>
+          <ItemPercentHealingDone amount={this.totalHealingWithMastery} />
+          <br />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default AdaptiveSwarmResto;

--- a/src/common/SPELLS/shadowlands/covenants/druid.ts
+++ b/src/common/SPELLS/shadowlands/covenants/druid.ts
@@ -9,7 +9,20 @@ const covenants = {
 
   //region Necrolord
   ADAPTIVE_SWARM: {
+    // cast
     id: 325727,
+    name: 'Adaptive Swarm',
+    icon: 'ability_maldraxxus_druid',
+  },
+  ADAPTIVE_SWARM_HEAL: {
+    // buff, heal
+    id: 325748,
+    name: 'Adaptive Swarm',
+    icon: 'ability_maldraxxus_druid',
+  },
+  ADAPTIVE_SWARM_DAMAGE: {
+    // debuff, damage
+    id: 325733,
     name: 'Adaptive Swarm',
     icon: 'ability_maldraxxus_druid',
   },


### PR DESCRIPTION
Because Adaptive Swarm is basically the same for all druid specs, I made a 'calculations module' for it in the general druid folder and then made resto specific display modules.

Parse used for checking: https://www.warcraftlogs.com/reports/y1KxNGHg9YdQJkVa/#fight=9&source=3

Screenshots:
![adaptive-swarm-pr1](https://user-images.githubusercontent.com/7143486/117091539-9f21f800-ad29-11eb-9b6b-cf6f314ddc1b.png)
![adaptive-swarm-pr2](https://user-images.githubusercontent.com/7143486/117091544-a0ebbb80-ad29-11eb-8583-d79c8806a669.png)
