### PR TITLE
Added support for the Conflux of Elements conduit

### DIFF
--- a/analysis/druidrestoration/src/CHANGELOG.tsx
+++ b/analysis/druidrestoration/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SpellLink from 'interface/SpellLink';
 import React from 'react';
 
 export default [
+  change(date(2021, 5, 9), <>Added <SpellLink id={SPELLS.CONFLUX_OF_ELEMENTS.id} /> support</>, Sref),
   change(date(2021, 5, 5), <>Added <SpellLink id={SPELLS.ADAPTIVE_SWARM.id} /> and <SpellLink id={SPELLS.EVOLVED_SWARM.id} /> support</>, Sref),
   change(date(2021, 5, 4), 'Re-added myself as spec maintainer and updated visuals of percent increase stats boxes.', Sref),
   change(date(2021, 5, 4), 'Converted all remaining modules to TypeScript and updated HoT Tracking in preparation for future work', Sref),

--- a/analysis/druidrestoration/src/CombatLogParser.ts
+++ b/analysis/druidrestoration/src/CombatLogParser.ts
@@ -29,6 +29,7 @@ import PrematureRejuvenations from './modules/features/PrematureRejuvenations';
 import HealingEfficiencyTracker from './modules/features/RestoDruidHealingEfficiencyTracker';
 import StatWeights from './modules/features/StatWeights';
 import WildGrowth from './modules/features/WildGrowth';
+import ConfluxOfElementsResto from './modules/shadowlands/conduits/ConfluxOfElementsResto';
 import EvolvedSwarmResto from './modules/shadowlands/conduits/EvolvedSwarmResto';
 import FlashOfClarity from './modules/shadowlands/conduits/FlashOfClarity';
 import AdaptiveSwarmResto from './modules/shadowlands/covenants/AdaptiveSwarmResto';
@@ -115,6 +116,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Potency
     flashOfClarity: FlashOfClarity,
     evolvedSwarmResto: EvolvedSwarmResto,
+    confluxOfElementsResto: ConfluxOfElementsResto,
 
     //legos
     visionOfUnendingGrowrth: VisionOfUnendingGrowrth,

--- a/analysis/druidrestoration/src/modules/shadowlands/conduits/ConfluxOfElementsResto.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/conduits/ConfluxOfElementsResto.tsx
@@ -1,0 +1,82 @@
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
+import Events, { HealEvent } from 'parser/core/Events';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import React from 'react';
+
+const CONFLUX_OF_ELEMENTS_EFFECT_BY_RANK = [
+  0.15,
+  0.165,
+  0.18,
+  0.195,
+  0.21,
+  0.225,
+  0.24,
+  0.255,
+  0.27,
+  0.285,
+  0.3,
+  0.315,
+  0.33,
+  0.345,
+  0.36,
+];
+
+/**
+ * **Conflux of Elements**
+ * Conduit - Night Fae
+ *
+ * While channeling Convoke the Spirits, your damage and healing are increased by X%.
+ */
+class ConfluxOfElementsResto extends Analyzer {
+  _confluxOfElementsBoost: number;
+  healing: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasConduitBySpellID(SPELLS.CONFLUX_OF_ELEMENTS.id);
+    this._confluxOfElementsBoost =
+      CONFLUX_OF_ELEMENTS_EFFECT_BY_RANK[
+        this.selectedCombatant.conduitRankBySpellID(SPELLS.CONFLUX_OF_ELEMENTS.id)
+      ];
+
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER), this.onHeal);
+  }
+
+  onHeal(event: HealEvent) {
+    if (this.selectedCombatant.hasBuff(SPELLS.CONVOKE_SPIRITS.id)) {
+      this.healing += calculateEffectiveHealing(event, this._confluxOfElementsBoost);
+    }
+  }
+
+  statistic(): React.ReactNode {
+    return (
+      <Statistic
+        size="flexible"
+        position={STATISTIC_ORDER.OPTIONAL(0)}
+        category={STATISTIC_CATEGORY.COVENANTS}
+        tooltip={
+          <>
+            This is the healing attributable specifically to Conflux of Elements's boost to healing
+            during Convoke.
+          </>
+        }
+      >
+        <BoringSpellValueText
+          spell={SPELLS.CONFLUX_OF_ELEMENTS}
+          ilvl={this.selectedCombatant.conduitsByConduitID[SPELLS.CONFLUX_OF_ELEMENTS.id].itemLevel}
+        >
+          <ItemPercentHealingDone amount={this.healing} />
+          <br />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default ConfluxOfElementsResto;

--- a/analysis/druidrestoration/src/modules/shadowlands/conduits/EvolvedSwarmResto.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/conduits/EvolvedSwarmResto.tsx
@@ -40,7 +40,10 @@ class EvolvedSwarmResto extends Analyzer {
           </>
         }
       >
-        <BoringSpellValueText spell={SPELLS.EVOLVED_SWARM}>
+        <BoringSpellValueText
+          spell={SPELLS.EVOLVED_SWARM}
+          ilvl={this.selectedCombatant.conduitsByConduitID[SPELLS.EVOLVED_SWARM.id].itemLevel}
+        >
           <ItemPercentHealingDone amount={this.adaptiveSwarmResto.evolvedSwarmHealing} />
           <br />
         </BoringSpellValueText>

--- a/src/parser/core/Combatant.ts
+++ b/src/parser/core/Combatant.ts
@@ -263,6 +263,7 @@ class Combatant extends Entity {
     };
 
     conduits.forEach((conduit: Conduit) => {
+      conduit.itemLevel = conduit.rank; // conduit "rank" passed in is actually its ilvl
       conduit.rank = ilvlToRankMapping[conduit.rank];
       this.conduitsByConduitID[conduit.spellID] = conduit;
     });

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -727,6 +727,7 @@ export interface SoulbindTrait {
 export interface Conduit {
   traitID: number;
   rank: number;
+  itemLevel?: number;
   spellID: number;
   icon: string;
 }

--- a/src/parser/ui/BoringSpellValueText.tsx
+++ b/src/parser/ui/BoringSpellValueText.tsx
@@ -11,12 +11,13 @@ type Props = {
   spell: Spell;
   children: React.ReactNode;
   className?: string;
+  ilvl?: number;
 };
 
-const BoringSpellValueText = ({ spell, children, className }: Props) => (
+const BoringSpellValueText = ({ spell, children, className, ilvl }: Props) => (
   <div className={`pad boring-text ${className || ''}`}>
     <label>
-      <SpellIcon id={spell.id} /> <SpellLink id={spell.id} icon={false} />
+      <SpellIcon id={spell.id} /> <SpellLink id={spell.id} ilvl={ilvl} icon={false} />
     </label>
     <div className="value">{children}</div>
   </div>


### PR DESCRIPTION
Also updated combatantInfo's conduit object to retain the ilvl in addition to the rank, and used that info to display the conduit spell link with the conduit's true ilvl (instead of always rank 0)

Log used for testing: https://www.warcraftlogs.com/reports/nFwTpzXhWfv2BLJc#fight=3&type=healing&source=1

![conflux-of-elements](https://user-images.githubusercontent.com/7143486/117599461-dcb2c680-b117-11eb-86d8-76a1a0b5483f.png)
