### PR TITLE
Added support for Resto Druid's Kindred Spirits (Kyrian Covenant)

### DIFF
--- a/analysis/druidrestoration/src/CHANGELOG.tsx
+++ b/analysis/druidrestoration/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SpellLink from 'interface/SpellLink';
 import React from 'react';
 
 export default [
+  change(date(2021, 5, 11), <>Added <SpellLink id={SPELLS.KINDRED_SPIRITS.id} /> support</>, Sref),
   change(date(2021, 5, 5), <>Added <SpellLink id={SPELLS.ADAPTIVE_SWARM.id} /> and <SpellLink id={SPELLS.EVOLVED_SWARM.id} /> support</>, Sref),
   change(date(2021, 5, 4), 'Re-added myself as spec maintainer and updated visuals of percent increase stats boxes.', Sref),
   change(date(2021, 5, 4), 'Converted all remaining modules to TypeScript and updated HoT Tracking in preparation for future work', Sref),

--- a/analysis/druidrestoration/src/CombatLogParser.ts
+++ b/analysis/druidrestoration/src/CombatLogParser.ts
@@ -32,6 +32,7 @@ import WildGrowth from './modules/features/WildGrowth';
 import EvolvedSwarmResto from './modules/shadowlands/conduits/EvolvedSwarmResto';
 import FlashOfClarity from './modules/shadowlands/conduits/FlashOfClarity';
 import AdaptiveSwarmResto from './modules/shadowlands/covenants/AdaptiveSwarmResto';
+import KindredSpiritsResto from './modules/shadowlands/covenants/AdaptiveSwarmResto';
 import MemoryoftheMotherTree from './modules/shadowlands/legendaries/MemoryoftheMotherTree';
 import VisionOfUnendingGrowrth from './modules/shadowlands/legendaries/VisionOfUnendingGrowth';
 import Abundance from './modules/talents/Abundance';
@@ -110,6 +111,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Covenants
     convokeSpirits: ConvokeSpirits,
     adaptiveSwarm: AdaptiveSwarmResto,
+    kindredSpirits: KindredSpiritsResto,
 
     // Conduits
     // Potency

--- a/analysis/druidrestoration/src/CombatLogParser.ts
+++ b/analysis/druidrestoration/src/CombatLogParser.ts
@@ -32,7 +32,7 @@ import WildGrowth from './modules/features/WildGrowth';
 import EvolvedSwarmResto from './modules/shadowlands/conduits/EvolvedSwarmResto';
 import FlashOfClarity from './modules/shadowlands/conduits/FlashOfClarity';
 import AdaptiveSwarmResto from './modules/shadowlands/covenants/AdaptiveSwarmResto';
-import KindredSpiritsResto from './modules/shadowlands/covenants/AdaptiveSwarmResto';
+import KindredSpiritsResto from './modules/shadowlands/covenants/KindredSpiritsResto';
 import MemoryoftheMotherTree from './modules/shadowlands/legendaries/MemoryoftheMotherTree';
 import VisionOfUnendingGrowrth from './modules/shadowlands/legendaries/VisionOfUnendingGrowth';
 import Abundance from './modules/talents/Abundance';

--- a/analysis/druidrestoration/src/modules/shadowlands/covenants/KindredSpiritsResto.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/covenants/KindredSpiritsResto.tsx
@@ -1,0 +1,196 @@
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
+import COVENANTS from 'game/shadowlands/COVENANTS';
+import Events, { AbsorbedEvent, CastEvent, DamageEvent, HealEvent } from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { formatNumber } from 'common/format';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
+import React from 'react';
+
+const KINDRED_SPIRITS_DURATION = 10_000;
+const LONE_MEDITATION_BOOST = 0.15;
+
+/**
+ * **Kindred Spirits**
+ * Covenant Ability - Kyrian
+ *
+ * Form a bond with an ally. Every 1 min, you may empower the bond for 10 sec, granting you an
+ * effect based on your partner's role, and granting them an effect based on your role.
+ *
+ * Tank - Kindred Protection: Protect your bonded partner, redirecting 40% of damage
+ * they take to you, unless you fall below 20% health.
+ *
+ * Healer - Kindred Focus: Focus on your bonded partner,
+ * replicating 30% of all healing you deal onto them.
+ *
+ * Damage - Kindred Empowerment: Energize your bonded partner, granting them 20% of your damage
+ * as additional Arcane damage, healing, or absorption.
+ *
+ * NONE - Lone Meditation: Connect with your inner spirit,
+ * increasing healing done by 15% for 10 sec.
+ *
+ */
+class KindredSpiritsResto extends Analyzer {
+
+  _empowerCasts: number = 0;
+  _meditateCasts: number = 0;
+
+  /**
+   * Timestamp of the last time the player cast Empower Bond.
+   * Because the buffs produced by Kindred Spirits are fully symmetrical between the Druid and their
+   * partner, there is no way to tell if the player empowered the bond or if the partner is a
+   * Druid who empowered their bond. The only way to tell is to use the empower bond cast event,
+   * and only attribute healing that happened within the buff duration of a player cast.
+   */
+  _lastEmpowerTimestamp: number | undefined = undefined;
+
+  /** Amount of bonus healing due to Lone Meditation */
+  loneMeditationHealing: number = 0;
+  /** Amount you healed your partner w/ Kindred Focus */
+  kindredFocusHealing: number = 0;
+  /** Amount of heal and absorb procced by your DPS partner's damage */
+  kindredEmpowermentPartnerHealing: number = 0;
+  /** Amount of damage transferred to your Tank partner */
+  kindredProtectionPartnerDamageTransfer: number = 0;
+  /** Amount your healer partner healed you with Kindred Focus */
+  kindredFocusPartnerHealing: number = 0;
+
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasCovenant(COVENANTS.KYRIAN.id);
+
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.EMPOWER_BOND), this.onEmpower);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.LONE_MEDITATION), this.onMeditate);
+
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER), this.onHeal);
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.KINDRED_FOCUS_HEAL), this.onFocusHealPartner);
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.KINDRED_EMPOWERMENT_DPS_HEAL), this.onEmpowermentHeal);
+    this.addEventListener(Events.absorbed.to(this.selectedCombatant.id).spell(SPELLS.KINDRED_EMPOWERMENT_BUFF_ABSORB_INCOMING), this.onEmpowermentAbsorb);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.KINDRED_PROTECTION_BUFF), this.onProtectionDamage);
+    this.addEventListener(Events.heal.to(this.selectedCombatant.id).spell(SPELLS.KINDRED_FOCUS_HEAL), this.onFocusHealPlayer);
+  }
+
+  onHeal(event: HealEvent) {
+    if (this.selectedCombatant.hasBuff(SPELLS.LONE_MEDITATION.id)) {
+      this.loneMeditationHealing += calculateEffectiveHealing(event, LONE_MEDITATION_BOOST);
+    }
+  }
+
+  onEmpower(event: CastEvent) {
+    this._empowerCasts += 1;
+    this._lastEmpowerTimestamp = event.timestamp;
+  }
+
+  onMeditate(_: CastEvent) {
+    this._meditateCasts += 1;
+  }
+
+  onFocusHealPartner(event: HealEvent) {
+    if (this._isPlayerEmpowered()) {
+      this.kindredFocusHealing += event.amount + (event.absorbed || 0);
+    }
+  }
+
+  onEmpowermentHeal(event: HealEvent) {
+    if (this._isPlayerEmpowered()) {
+      this.kindredEmpowermentPartnerHealing += event.amount + (event.absorbed || 0);
+    }
+  }
+
+  onEmpowermentAbsorb(event: AbsorbedEvent) {
+    if (this._isPlayerEmpowered()) {
+      this.kindredEmpowermentPartnerHealing += event.amount;
+    }
+  }
+
+  onProtectionDamage(event: DamageEvent) {
+    if (this._isPlayerEmpowered()) {
+      this.kindredProtectionPartnerDamageTransfer += event.amount + (event.absorbed);
+    }
+  }
+
+  onFocusHealPlayer(event: HealEvent) {
+    if (this._isPlayerEmpowered()) {
+      this.kindredFocusPartnerHealing += event.amount + (event.absorbed);
+    }
+  }
+
+  _isPlayerEmpowered(): boolean {
+    return this._lastEmpowerTimestamp && this._lastEmpowerTimestamp + KINDRED_SPIRITS_DURATION > this.owner.currentTimestamp;
+  }
+
+  get totalHealing(): number {
+    return this.kindredFocusHealing + this.kindredEmpowermentPartnerHealing +
+      this.kindredFocusPartnerHealing + this.loneMeditationHealing;
+  }
+
+  get totalCasts(): number {
+    return this._empowerCasts + this._meditateCasts;
+  }
+
+  statistic() {
+    const displaySpell = this._empowerCasts ? SPELLS.KINDRED_SPIRITS : SPELLS.LONE_MEDITATION;
+    let castString = " Kindred Spirits";
+    if (this._empowerCasts && this._meditateCasts) {
+      castString = " Empower Bond and Lone Meditation";
+    } else if (this._empowerCasts) {
+      castString = " Empower Bond";
+    } else if (this._meditateCasts) {
+      castString = " Lone Meditation";
+    }
+
+    return (
+      <Statistic
+        size="flexible"
+        position={STATISTIC_ORDER.CORE(0)}
+        category={STATISTIC_CATEGORY.COVENANTS}
+        tooltip={
+          <>
+            This is the sum of all healing you caused with{castString}. You averaged
+            <strong>{formatNumber(this.totalHealing / this.totalCasts)} healing per cast</strong>.
+            <ul>
+              {this.kindredFocusHealing > 0 &&
+                <li>
+                  Focus Healing on Partner: <strong>{this.owner.formatItemHealingDone(this.kindredFocusHealing)}</strong>
+                </li>
+              }
+              {this.kindredEmpowermentPartnerHealing > 0 &&
+                <li>
+                  Healing/Absorb from Partner's Damage: <strong>{this.owner.formatItemHealingDone(this.kindredEmpowermentPartnerHealing)}</strong>
+                </li>
+              }
+              {this.kindredProtectionPartnerDamageTransfer > 0 &&
+                <li>
+                  Damage Transferred to Tank Partner (not counted in total): <strong>{this.owner.formatItemHealingDone(this.kindredProtectionPartnerDamageTransfer)}</strong>
+                </li>
+              }
+              {this.kindredFocusPartnerHealing > 0 &&
+                <li>
+                  Partner Focus Healing on You: <strong>{this.owner.formatItemHealingDone(this.kindredFocusPartnerHealing)}</strong>
+                </li>
+              }
+              {this.loneMeditationHealing > 0 &&
+                <li>
+                  Lone Meditation Healing: <strong>{this.owner.formatItemHealingDone(this.loneMeditationHealing)}</strong>
+                </li>
+              }
+            </ul>
+          </>
+        }
+      >
+        <BoringSpellValueText spell={displaySpell}>
+          <ItemPercentHealingDone amount={this.totalHealing} />
+          <br />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+
+export default KindredSpiritsResto;

--- a/src/common/SPELLS/shadowlands/covenants/druid.ts
+++ b/src/common/SPELLS/shadowlands/covenants/druid.ts
@@ -5,6 +5,52 @@ const covenants = {
     name: 'Kindred Spirits',
     icon: 'ability_bastion_druid',
   },
+  LONE_MEDITATION: { // healer solo cast + buff
+    id: 338035,
+    name: 'Lone Meditation',
+    icon: 'spell_animabastion_beam',
+  },
+  // TODO DPS and Tank Solos
+  EMPOWER_BOND: { // bond activation cast
+    id: 326446,
+    name: 'Empower Bond',
+    icon: 'spell_animabastion_beam',
+  },
+  KINDRED_FOCUS_BUFF_OUTGOING: { // healer buff from you to target
+    id: 327071,
+    name: 'Kindred Focus',
+    icon: 'spell_animabastion_buff',
+  },
+  KINDRED_FOCUS_BUFF_INCOMING: { // healer buff from target to you
+    id: 327148,
+    name: 'Kindred Focus',
+    icon: 'spell_animabastion_beam',
+  },
+  KINDRED_EMPOWERMENT_BUFF_OUTGOING: { // DPS buff from you to target
+    id: 327139,
+    name: 'Kindred Empowerment',
+    icon: 'spell_animabastion_beam',
+  },
+  KINDRED_EMPOWERMENT_BUFF_ABSORB_INCOMING: { // DPS buff from target to you (and also absorb ID)
+    id: 327022,
+    name: 'Kindred Empowerment',
+    icon: 'spell_animabastion_buff',
+  },
+  KINDRED_PROTECTION_BUFF: { // Tank buff from target to you (and also damage from you to target)
+    id: 327037,
+    name: 'Kindred Protection',
+    icon: 'spell_animabastion_buff',
+  },
+  KINDRED_FOCUS_HEAL: { // Heal ID when you heal others
+    id: 327149,
+    name: 'Kindred Focus',
+    icon: 'spell_animabastion_beam',
+  },
+  KINDRED_EMPOWERMENT_DPS_HEAL: { // Heal ID from you when targeted DPS does damage
+    id: 338525,
+    name: 'Kindred Empowerment',
+    icon: 'spell_animabastion_beam',
+  },
   //endregion
 
   //region Necrolord

--- a/src/common/SPELLS/shadowlands/covenants/druid.ts
+++ b/src/common/SPELLS/shadowlands/covenants/druid.ts
@@ -5,48 +5,69 @@ const covenants = {
     name: 'Kindred Spirits',
     icon: 'ability_bastion_druid',
   },
-  LONE_MEDITATION: { // healer solo cast + buff
+  LONE_MEDITATION: {
+    // healer solo cast + buff
     id: 338035,
     name: 'Lone Meditation',
     icon: 'spell_animabastion_beam',
   },
   // TODO DPS and Tank Solos
-  EMPOWER_BOND: { // bond activation cast
+  EMPOWER_BOND_TANK: {
+    // bond activation cast targetting a Tank
+    id: 326462,
+    name: 'Empower Bond',
+    icon: 'spell_animabastion_beam',
+  },
+  EMPOWER_BOND_DAMAGE: {
+    // bond activation cast targetting a DPS
     id: 326446,
     name: 'Empower Bond',
     icon: 'spell_animabastion_beam',
   },
-  KINDRED_FOCUS_BUFF_OUTGOING: { // healer buff from you to target
+  EMPOWER_BOND_HEALER: {
+    // bond activation cast targetting a healer
+    id: 326647,
+    name: 'Empower Bond',
+    icon: 'spell_animabastion_beam',
+  },
+  KINDRED_FOCUS_BUFF_OUTGOING: {
+    // healer buff from you to target
     id: 327071,
     name: 'Kindred Focus',
     icon: 'spell_animabastion_buff',
   },
-  KINDRED_FOCUS_BUFF_INCOMING: { // healer buff from target to you
+  KINDRED_FOCUS_BUFF_INCOMING: {
+    // healer buff from target to you
     id: 327148,
     name: 'Kindred Focus',
     icon: 'spell_animabastion_beam',
   },
-  KINDRED_EMPOWERMENT_BUFF_OUTGOING: { // DPS buff from you to target
+  KINDRED_EMPOWERMENT_BUFF_OUTGOING: {
+    // DPS buff from you to target
     id: 327139,
     name: 'Kindred Empowerment',
     icon: 'spell_animabastion_beam',
   },
-  KINDRED_EMPOWERMENT_BUFF_ABSORB_INCOMING: { // DPS buff from target to you (and also absorb ID)
+  KINDRED_EMPOWERMENT_BUFF_ABSORB_INCOMING: {
+    // DPS buff from target to you (and also absorb ID)
     id: 327022,
     name: 'Kindred Empowerment',
     icon: 'spell_animabastion_buff',
   },
-  KINDRED_PROTECTION_BUFF: { // Tank buff from target to you (and also damage from you to target)
+  KINDRED_PROTECTION_BUFF: {
+    // Tank buff from target to you (and also damage from you to target)
     id: 327037,
     name: 'Kindred Protection',
     icon: 'spell_animabastion_buff',
   },
-  KINDRED_FOCUS_HEAL: { // Heal ID when you heal others
+  KINDRED_FOCUS_HEAL: {
+    // Heal ID when you heal others
     id: 327149,
     name: 'Kindred Focus',
     icon: 'spell_animabastion_beam',
   },
-  KINDRED_EMPOWERMENT_DPS_HEAL: { // Heal ID from you when targeted DPS does damage
+  KINDRED_EMPOWERMENT_DPS_HEAL: {
+    // Heal ID from you when targeted DPS does damage
     id: 338525,
     name: 'Kindred Empowerment',
     icon: 'spell_animabastion_beam',


### PR DESCRIPTION
Including 11 new spell IDs! I wasn't able to actually test the "kindred circlejerk" case because I couldn't find any parses where it happened - Kyrian seems to be a rare enough case it's unlikely to come up. In theory it's also possible for the player to gain / lose a partner during the encounter and so have casts of both Empower Bond and Lone Meditation. My code is setup to handle that, but I wasn't able to find any parses where it actually happens.

Parses used for test:
https://www.warcraftlogs.com/reports/87dLBJ2yVnb6vpCK#fight=14&type=healing&source=16 (healer target)
https://www.warcraftlogs.com/reports/z92XcmZwChqFg31v#fight=2&type=healing&source=17 (no target)
https://www.warcraftlogs.com/reports/MnavPWqCzG6AFJ2r#fight=1&type=healing&source=7 (dps target)
https://www.warcraftlogs.com/reports/v9HpBm2PZDrzft6c#fight=4&type=healing&source=53 (tank target)

Screenshots:
![kindred-spirits-box1](https://user-images.githubusercontent.com/7143486/117833557-6cee2a00-b244-11eb-88ef-83d305ffee20.png) (with target)
![kindred-spirits-box2](https://user-images.githubusercontent.com/7143486/117833585-737ca180-b244-11eb-959d-f7cf846b6d37.png) (without target)
![kindred-spirits-lone-tooltip](https://user-images.githubusercontent.com/7143486/117833706-91e29d00-b244-11eb-8c75-3980023b4405.png) (solo tooltip)
![kindred-spirits-healer-tooltip](https://user-images.githubusercontent.com/7143486/117833726-973fe780-b244-11eb-8622-a99b46b5117b.png) (healer target tooltip)
![kindred-spirits-dps-tooltip](https://user-images.githubusercontent.com/7143486/117833762-9d35c880-b244-11eb-87be-6afe9f2f4582.png) (dps target tooltip)
![kindred-spirits-tank-tooltip](https://user-images.githubusercontent.com/7143486/117833795-a1fa7c80-b244-11eb-8a7c-33d61b3a2890.png) (tank target tooltip)






