### PR TITLE
Fixed an issue where Swiftmend cast efficiency was displaying wrong in the Checklist.

### DIFF
--- a/analysis/druidrestoration/src/CHANGELOG.tsx
+++ b/analysis/druidrestoration/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SpellLink from 'interface/SpellLink';
 import React from 'react';
 
 export default [
+  change(date(2021, 5, 11), 'Fixed an issue where the Swiftmend cast efficiency rule displayed wrong at low efficiency', Sref),
   change(date(2021, 5, 5), <>Added <SpellLink id={SPELLS.ADAPTIVE_SWARM.id} /> and <SpellLink id={SPELLS.EVOLVED_SWARM.id} /> support</>, Sref),
   change(date(2021, 5, 4), 'Re-added myself as spec maintainer and updated visuals of percent increase stats boxes.', Sref),
   change(date(2021, 5, 4), 'Converted all remaining modules to TypeScript and updated HoT Tracking in preparation for future work', Sref),

--- a/analysis/druidrestoration/src/modules/Abilities.tsx
+++ b/analysis/druidrestoration/src/modules/Abilities.tsx
@@ -156,9 +156,8 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.4,
-          averageIssueEfficiency: 0.0, // average and "negative" major included for checklist bar scaling in line with a "minor" issue
-          majorIssueEfficiency: -1,
-          importance: ISSUE_IMPORTANCE.MINOR,
+          averageIssueEfficiency: 0.1,
+          importance: ISSUE_IMPORTANCE.REGULAR,
         },
       },
       {


### PR DESCRIPTION
Also upped the seriousness of failing to cast Swiftmend when at extremely low efficiency.

Before:
![swiftmend-ce-before](https://user-images.githubusercontent.com/7143486/117907304-8f179480-b2a4-11eb-95ff-8eec8c1a6c8c.png)

After:
![swiftmend-ce-after](https://user-images.githubusercontent.com/7143486/117907312-92ab1b80-b2a4-11eb-80fc-c859bc242196.png)
