### PR TITLE
Refactored Convoke Spirits and added a healing attribution for Resto's version

### DIFF
--- a/analysis/druid/src/core/Abilities.ts
+++ b/analysis/druid/src/core/Abilities.ts
@@ -1,0 +1,48 @@
+import CoreAbilities from 'parser/core/modules/Abilities';
+import SPELLS from 'common/SPELLS';
+import Combatant from 'parser/core/Combatant';
+import SPECS from 'game/SPECS';
+import COVENANTS from 'game/shadowlands/COVENANTS';
+import { SpellbookAbility } from 'parser/core/modules/Ability';
+
+/**
+ * Fully shared Druid abilites should go here
+ */
+class Abilities extends CoreAbilities {
+
+  spellbook(): SpellbookAbility[] {
+    const combatant = this.selectedCombatant;
+    return [
+      {
+        spell: SPELLS.CONVOKE_SPIRITS,
+        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
+        cooldown: 120,
+        gcd: {
+          base: (c: Combatant) => (c.spec === SPECS.FERAL_DRUID ? 1000 : 1500),
+        },
+        enabled: combatant.hasCovenant(COVENANTS.NIGHT_FAE.id),
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.8,
+        },
+        timelineSortIndex: 100,
+      },
+      {
+        spell: SPELLS.ADAPTIVE_SWARM,
+        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
+        cooldown: 25,
+        gcd: {
+          base: (c: Combatant) => (c.spec === SPECS.FERAL_DRUID ? 1000 : 1500),
+        },
+        enabled: combatant.hasCovenant(COVENANTS.NECROLORD.id),
+        castEfficiency: {
+          suggestion: true,
+        },
+        healSpellIds: [SPELLS.ADAPTIVE_SWARM_HEAL.id],
+      },
+    ];
+  }
+
+}
+
+export default Abilities

--- a/analysis/druid/src/core/Abilities.ts
+++ b/analysis/druid/src/core/Abilities.ts
@@ -1,15 +1,14 @@
-import CoreAbilities from 'parser/core/modules/Abilities';
 import SPELLS from 'common/SPELLS';
-import Combatant from 'parser/core/Combatant';
-import SPECS from 'game/SPECS';
 import COVENANTS from 'game/shadowlands/COVENANTS';
+import SPECS from 'game/SPECS';
+import Combatant from 'parser/core/Combatant';
+import CoreAbilities from 'parser/core/modules/Abilities';
 import { SpellbookAbility } from 'parser/core/modules/Ability';
 
 /**
  * Fully shared Druid abilites should go here
  */
 class Abilities extends CoreAbilities {
-
   spellbook(): SpellbookAbility[] {
     const combatant = this.selectedCombatant;
     return [
@@ -42,7 +41,6 @@ class Abilities extends CoreAbilities {
       },
     ];
   }
-
 }
 
-export default Abilities
+export default Abilities;

--- a/analysis/druid/src/shadowlands/ConvokeSpirits.tsx
+++ b/analysis/druid/src/shadowlands/ConvokeSpirits.tsx
@@ -31,6 +31,7 @@ const CONVOKE_BUFF_SPELLS = [
   SPELLS.REGROWTH,
   SPELLS.IRONFUR,
   SPELLS.TIGERS_FURY,
+  SPELLS.FERAL_FRENZY_TALENT,
   SPELLS.WILD_GROWTH,
   SPELLS.FLOURISH_TALENT,
   SPELLS.STARFALL_CAST, // apparently this is also the ID for the buff
@@ -41,7 +42,6 @@ const CONVOKE_DEBUFF_SPELLS = [
   SPELLS.MOONFIRE_BEAR,
   SPELLS.MOONFIRE_FERAL,
   SPELLS.RAKE_BLEED,
-  SPELLS.FERAL_FRENZY_DEBUFF,
   SPELLS.THRASH_BEAR_DOT,
 ];
 /** All convokable spells that 'hit' with direct healing */
@@ -75,7 +75,6 @@ const SPELL_IDS_WITH_AOE = [
   SPELLS.FULL_MOON.id,
   SPELLS.THRASH_BEAR_DOT.id,
   SPELLS.WILD_GROWTH.id,
-  // TODO check and add feral frenzy
 ];
 
 const SPELLS_CAST = 16;
@@ -209,7 +208,7 @@ class ConvokeSpirits extends Analyzer {
   }
 
   /**
-   * True iff the player is currently Convoking the Elements.
+   * True iff the player is currently Convoking the Spirits.
    * Includes a small buffer after the end because occasionally the last convoked spell occurs
    * slightly after the end.
    */

--- a/analysis/druid/src/shadowlands/ConvokeSpirits.tsx
+++ b/analysis/druid/src/shadowlands/ConvokeSpirits.tsx
@@ -82,8 +82,8 @@ class ConvokeSpirits extends Analyzer {
       this.travelingSpellTracker[e] = 0;
     });
 
-    this.spellsToTrack = (this.selectedCombatant.spec === SPECS.RESTORATION_DRUID)
-      ? SPELLS_CAST_RESTO : SPELLS_CAST;
+    this.spellsToTrack =
+      this.selectedCombatant.spec === SPECS.RESTORATION_DRUID ? SPELLS_CAST_RESTO : SPELLS_CAST;
 
     //start tracker
     this.addEventListener(
@@ -478,11 +478,11 @@ class ConvokeSpirits extends Analyzer {
         category={STATISTIC_CATEGORY.COVENANTS}
         tooltip={
           <>
-            Abilities cast by Convoke do not create cast events; this listing is created by
-            tracking related events during the channel. Occasionally a Convoke will cast an ability
-            that hits nothing (like Thrash when only immune targets are in range). In these cases
-            we won't be able to track it and so the number of spells listed may not add up to
-            {' '}{this.spellsToTrack}.
+            Abilities cast by Convoke do not create cast events; this listing is created by tracking
+            related events during the channel. Occasionally a Convoke will cast an ability that hits
+            nothing (like Thrash when only immune targets are in range). In these cases we won't be
+            able to track it and so the number of spells listed may not add up to{' '}
+            {this.spellsToTrack}.
           </>
         }
         dropdown={

--- a/analysis/druid/src/shadowlands/ConvokeSpirits.tsx
+++ b/analysis/druid/src/shadowlands/ConvokeSpirits.tsx
@@ -172,7 +172,7 @@ class ConvokeSpirits extends Analyzer {
 
   onConvoke(_: ApplyBuffEvent) {
     this.cast += 1;
-    this.convokeTracker[this.cast] = { spellIdToCasts: [], form: 'No Form' };
+    this.convokeTracker[this.cast] = { spellIdToCasts: [], form: this.activeDruidForm.form };
   }
 
   onHit(event: AbilityEvent<any> & TargettedEvent<any>) {

--- a/analysis/druid/src/shadowlands/ConvokeSpirits.tsx
+++ b/analysis/druid/src/shadowlands/ConvokeSpirits.tsx
@@ -6,15 +6,8 @@ import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, {
   AbilityEvent,
   ApplyBuffEvent,
-  ApplyBuffStackEvent,
-  ApplyDebuffEvent,
-  ApplyDebuffStackEvent,
   CastEvent,
-  DamageEvent,
-  HealEvent,
-  RefreshBuffEvent,
-  RefreshDebuffEvent,
-  RemoveBuffEvent,
+  TargettedEvent,
 } from 'parser/core/Events';
 import Abilities from 'parser/core/modules/Abilities';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
@@ -25,18 +18,72 @@ import React from 'react';
 
 import ActiveDruidForm, { DruidForm } from '../core/ActiveDruidForm';
 
+/*
+ * For several spells we include multiple IDs for the same spell -
+ * probably only one ID is being used but as of this writing neither Abelito nor Sref
+ * has cared enough to find out which.
+ */
+
+/** All convokable spells that 'hit' with a buff application */
+const CONVOKE_BUFF_SPELLS = [
+  SPELLS.REJUVENATION,
+  SPELLS.REJUVENATION_GERMINATION,
+  SPELLS.REGROWTH,
+  SPELLS.IRONFUR,
+  SPELLS.TIGERS_FURY,
+  SPELLS.WILD_GROWTH,
+  SPELLS.FLOURISH_TALENT,
+  SPELLS.STARFALL_CAST, // apparently this is also the ID for the buff
+];
+/** All convokable spells that 'hit' with a debuff application */
+const CONVOKE_DEBUFF_SPELLS = [
+  SPELLS.MOONFIRE,
+  SPELLS.MOONFIRE_BEAR,
+  SPELLS.MOONFIRE_FERAL,
+  SPELLS.RAKE_BLEED,
+  SPELLS.FERAL_FRENZY_DEBUFF,
+  SPELLS.THRASH_BEAR_DOT,
+];
+/** All convokable spells that 'hit' with direct healing */
+const CONVOKE_HEAL_SPELLS = [SPELLS.SWIFTMEND];
+/** All convokable spells that 'hit' with direct damage */
+const CONVOKE_DAMAGE_SPELLS = [
+  SPELLS.WRATH,
+  SPELLS.WRATH_MOONKIN,
+  SPELLS.STARSURGE_AFFINITY,
+  SPELLS.STARSURGE_MOONKIN,
+  SPELLS.FULL_MOON,
+  SPELLS.FEROCIOUS_BITE,
+  SPELLS.SHRED,
+  SPELLS.MANGLE_BEAR,
+  SPELLS.PULVERIZE_TALENT,
+];
+/** Convokable spells that have travel time */
 const SPELLS_WITH_TRAVEL_TIME = [
-  SPELLS.STARSURGE_AFFINITY.id,
-  SPELLS.STARSURGE_MOONKIN.id,
+  SPELLS.STARSURGE_AFFINITY,
+  SPELLS.STARSURGE_MOONKIN,
+  SPELLS.FULL_MOON,
+  SPELLS.WRATH,
+  SPELLS.WRATH_MOONKIN,
+];
+const SPELL_IDS_WITH_TRAVEL_TIME = SPELLS_WITH_TRAVEL_TIME.map((s) => s.id);
+/** Convokable spells that can hit multiple targets */
+const SPELL_IDS_WITH_AOE = [
+  SPELLS.MOONFIRE.id,
+  SPELLS.MOONFIRE_BEAR.id,
+  SPELLS.MOONFIRE_FERAL.id,
   SPELLS.FULL_MOON.id,
-  SPELLS.WRATH.id,
-  SPELLS.WRATH_MOONKIN.id,
+  SPELLS.THRASH_BEAR_DOT.id,
+  SPELLS.WILD_GROWTH.id,
+  // TODO check and add feral frenzy
 ];
 
 const SPELLS_CAST = 16;
 const SPELLS_CAST_RESTO = 12;
 
 const AOE_BUFFER_MS = 100;
+const AFTER_CHANNEL_BUFFER_MS = 50;
+const TRAVEL_BUFFER_MS = 2_000;
 
 /**
  * **Convoke the Spirits**
@@ -54,421 +101,170 @@ class ConvokeSpirits extends Analyzer {
   protected abilities!: Abilities;
   protected activeDruidForm!: ActiveDruidForm;
 
-  isChannelingConvoke: boolean = false;
-  spellsToTrack: number;
   /** The number of times Convoke has been cast */
   cast: number = 0;
-
-  /** Timestamp of the most recent AoE spell registered during Convoke - used to avoid double counts*/
-  flexTimeStampForMultiApplySpells = 0;
-
-  extraRejuvsFromOtherSources = 0;
+  /** The number of spells cast by a full Convoke channel */
+  spellsPerCast: number;
+  /** Timestamp of the most recent AoE spell hit registered during Convoke - used to avoid double counts */
+  mostRecentAoeTimestamp = 0;
   /** Mapping from convoke cast number to a tracker for that cast - note that index zero will always be empty */
-  whatHappendIneachConvoke: ConvokeCast[] = [];
-
+  convokeTracker: ConvokeCast[] = [];
   /**
-   * A mapping from spellId of spell with travel time to the number of casts we're waiting to land.
-   * For example a Wrath cast will increment this while a Wrath damage event will decrement.
-   * If a damage event happens just after a Convoke with no matching cast, it could be attributed to the Convoke.
+   * A mapping from spellId of a spell with travel time to the last cast for that ID.
+   * If we register a 'hit' during convoke, but the cast was within plausible travel time and
+   * had same target, we assume the hit was due to a hardcast (and not convoke).
+   * Cast entries will be cleared when we find a matching 'hit'.
    */
-  travelingSpellTracker: number[] = [];
+  lastTravelingSpellCast: Array<CastEvent | undefined> = [];
 
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasCovenant(COVENANTS.NIGHT_FAE.id);
 
-    //populate
-    SPELLS_WITH_TRAVEL_TIME.forEach((e) => {
-      this.travelingSpellTracker[e] = 0;
-    });
-
-    this.spellsToTrack =
+    this.spellsPerCast =
       this.selectedCombatant.spec === SPECS.RESTORATION_DRUID ? SPELLS_CAST_RESTO : SPELLS_CAST;
 
-    //start tracker
+    // watch for convokes
     this.addEventListener(
       Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.CONVOKE_SPIRITS),
-      this.startTracking,
+      this.onConvoke,
     );
 
-    //I'm dividing these out so you can see where each is and then if anything changes you're not changing one string in a long ass listener
-    //this is also done in such a way to make sure we don't count the wrong event like whitenoise rejuv healing or moonfire damage etc
-
-    //wouldn't it be lovely if blizzard just gave me cast events : ^)
-    //generic stuff
+    // watch for spell 'hits'
     this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.REJUVENATION),
-      this.newRejuv,
+      Events.applybuff.by(SELECTED_PLAYER).spell(CONVOKE_BUFF_SPELLS),
+      this.onHit,
     );
     this.addEventListener(
-      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.REJUVENATION),
-      this.newRejuv,
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(CONVOKE_BUFF_SPELLS),
+      this.onHit,
     );
     this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.REGROWTH),
-      this.newRegrowth,
-    );
-    this.addEventListener(
-      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.REGROWTH),
-      this.newRegrowth,
-    );
-
-    //I'm not getting paid enough to check a billion logs to figure out which moonfire does this so deal with it
-    //half the reason is because its random on which spells get fired and the fact its based on form so zzz
-    this.addEventListener(
-      Events.applydebuff
-        .by(SELECTED_PLAYER)
-        .spell([SPELLS.MOONFIRE, SPELLS.MOONFIRE_BEAR, SPELLS.MOONFIRE_FERAL]),
-      this.newMoonfire,
-    );
-    this.addEventListener(
-      Events.refreshdebuff
-        .by(SELECTED_PLAYER)
-        .spell([SPELLS.MOONFIRE, SPELLS.MOONFIRE_BEAR, SPELLS.MOONFIRE_FERAL]),
-      this.newMoonfire,
-    );
-    this.addEventListener(
-      Events.damage.by(SELECTED_PLAYER).spell([SPELLS.WRATH, SPELLS.WRATH_MOONKIN]),
-      this.newWrath,
-    );
-
-    //Balance stuff deal with it. idk which one it will be (it should be solar wrath moonkin but like edge cases)
-    this.addEventListener(
-      Events.damage
-        .by(SELECTED_PLAYER)
-        .spell([SPELLS.STARSURGE_AFFINITY, SPELLS.STARSURGE_MOONKIN]),
-      this.newStarSurge,
+      Events.applybuffstack.by(SELECTED_PLAYER).spell(CONVOKE_BUFF_SPELLS),
+      this.onHit,
     );
 
     this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.STARFALL_CAST),
-      this.newStarFall,
+      Events.applydebuff.by(SELECTED_PLAYER).spell(CONVOKE_DEBUFF_SPELLS),
+      this.onHit,
     );
     this.addEventListener(
-      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.STARFALL_CAST),
-      this.newStarFall,
+      Events.refreshdebuff.by(SELECTED_PLAYER).spell(CONVOKE_DEBUFF_SPELLS),
+      this.onHit,
     );
     this.addEventListener(
-      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.FULL_MOON),
-      this.newFullMoon,
-    );
-
-    //Feral Stuff
-    this.addEventListener(
-      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.FEROCIOUS_BITE),
-      this.newFerociousBite,
+      Events.applydebuffstack.by(SELECTED_PLAYER).spell(CONVOKE_DEBUFF_SPELLS),
+      this.onHit,
     );
 
-    this.addEventListener(
-      Events.applydebuff.by(SELECTED_PLAYER).spell(SPELLS.RAKE_BLEED),
-      this.newRake,
-    );
-    this.addEventListener(
-      Events.refreshdebuff.by(SELECTED_PLAYER).spell(SPELLS.RAKE_BLEED),
-      this.newRake,
-    );
-
-    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.SHRED), this.newShred);
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(CONVOKE_HEAL_SPELLS), this.onHit);
 
     this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.TIGERS_FURY),
-      this.newTigersFury,
-    );
-    this.addEventListener(
-      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.TIGERS_FURY),
-      this.newTigersFury,
+      Events.damage.by(SELECTED_PLAYER).spell(CONVOKE_DAMAGE_SPELLS),
+      this.onHit,
     );
 
+    // watch for travel time casts
     this.addEventListener(
-      Events.applydebuff.by(SELECTED_PLAYER).spell(SPELLS.FERAL_FRENZY_DEBUFF),
-      this.newFeralFrenzy,
-    );
-    this.addEventListener(
-      Events.refreshdebuff.by(SELECTED_PLAYER).spell(SPELLS.FERAL_FRENZY_DEBUFF),
-      this.newFeralFrenzy,
-    );
-
-    //Bear stuff
-    this.addEventListener(
-      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.MANGLE_BEAR),
-      this.newMangle,
-    );
-
-    //from what bear druids say this ability caps at 20 but who knows what blizzard will do *cough* corruption 2.0 *cough*
-    this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.IRONFUR),
-      this.newIronFur,
-    );
-    this.addEventListener(
-      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.IRONFUR),
-      this.newIronFur,
-    );
-    this.addEventListener(
-      Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.IRONFUR),
-      this.newIronFur,
-    );
-
-    this.addEventListener(
-      Events.applydebuff.by(SELECTED_PLAYER).spell(SPELLS.THRASH_BEAR_DOT),
-      this.newThrash,
-    );
-    this.addEventListener(
-      Events.refreshdebuff.by(SELECTED_PLAYER).spell(SPELLS.THRASH_BEAR_DOT),
-      this.newThrash,
-    );
-    this.addEventListener(
-      Events.applydebuffstack.by(SELECTED_PLAYER).spell(SPELLS.THRASH_BEAR_DOT),
-      this.newThrash,
-    );
-
-    this.addEventListener(
-      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.PULVERIZE_TALENT),
-      this.newPulverize,
-    );
-
-    //Resto stuff
-    this.addEventListener(
-      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.SWIFTMEND),
-      this.newSwiftMend,
-    );
-
-    this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.WILD_GROWTH),
-      this.newWildGrowth,
-    );
-    this.addEventListener(
-      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.WILD_GROWTH),
-      this.newWildGrowth,
-    );
-
-    this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.FLOURISH_TALENT),
-      this.newFlourish,
-    );
-    this.addEventListener(
-      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.FLOURISH_TALENT),
-      this.newFlourish,
-    );
-
-    //stop tracker
-    this.addEventListener(
-      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.CONVOKE_SPIRITS),
-      this.stopTracking,
-    );
-
-    //for travel time bs
-    this.addEventListener(
-      Events.cast.by(SELECTED_PLAYER).spell([SPELLS.WRATH, SPELLS.WRATH_MOONKIN]),
-      this.wrathCast,
-    );
-    this.addEventListener(
-      Events.cast.by(SELECTED_PLAYER).spell([SPELLS.STARSURGE_AFFINITY, SPELLS.STARSURGE_MOONKIN]),
-      this.starsurgeCast,
-    );
-    this.addEventListener(
-      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.FULL_MOON),
-      this.fullMoonCast,
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS_WITH_TRAVEL_TIME),
+      this.onTravelTimeCast,
     );
   }
 
-  startTracking(event: ApplyBuffEvent) {
-    this.isChannelingConvoke = true;
+  onConvoke(_: ApplyBuffEvent) {
     this.cast += 1;
-    this.whatHappendIneachConvoke[this.cast] = { spellIdToCasts: [], form: 'No Form' };
+    this.convokeTracker[this.cast] = { spellIdToCasts: [], form: 'No Form' };
   }
 
-  newRejuv(event: ApplyBuffEvent | RefreshBuffEvent) {
-    this.addemUp(event);
-  }
-
-  newRegrowth(event: ApplyBuffEvent | RefreshBuffEvent) {
-    this.addemUp(event);
-  }
-
-  newMoonfire(event: ApplyDebuffEvent | RefreshDebuffEvent) {
-    this.addemUp(event);
-    this.multiSpellSafety(event.timestamp);
-  }
-
-  newWrath(event: DamageEvent) {
-    this.addemUp(event);
-  }
-
-  newStarSurge(event: DamageEvent) {
-    this.addemUp(event);
-  }
-
-  newStarFall(event: ApplyBuffEvent | RefreshBuffEvent) {
-    this.addemUp(event);
-  }
-
-  newFullMoon(event: DamageEvent) {
-    this.addemUp(event);
-    this.multiSpellSafety(event.timestamp);
-  }
-
-  newFerociousBite(event: DamageEvent) {
-    this.addemUp(event);
-  }
-
-  newRake(event: ApplyDebuffEvent | RefreshDebuffEvent) {
-    this.addemUp(event);
-  }
-
-  newShred(event: DamageEvent) {
-    this.addemUp(event);
-  }
-
-  newTigersFury(event: ApplyBuffEvent | RefreshBuffEvent) {
-    this.addemUp(event);
-  }
-
-  newFeralFrenzy(event: ApplyDebuffEvent | RefreshDebuffEvent) {
-    this.addemUp(event);
-  }
-
-  newMangle(event: DamageEvent) {
-    this.addemUp(event);
-  }
-
-  newIronFur(event: ApplyBuffEvent | RefreshBuffEvent | ApplyBuffStackEvent) {
-    this.addemUp(event);
-  }
-
-  newThrash(event: ApplyDebuffEvent | RefreshDebuffEvent | ApplyDebuffStackEvent) {
-    this.addemUp(event);
-    this.multiSpellSafety(event.timestamp);
-  }
-
-  newPulverize(event: DamageEvent) {
-    this.addemUp(event);
-  }
-
-  newSwiftMend(event: HealEvent) {
-    this.addemUp(event);
-  }
-
-  newWildGrowth(event: ApplyBuffEvent | RefreshBuffEvent) {
-    this.addemUp(event);
-    this.multiSpellSafety(event.timestamp);
-  }
-
-  newFlourish(event: ApplyBuffEvent | RefreshBuffEvent) {
-    this.addemUp(event);
-  }
-
-  stopTracking(event: RemoveBuffEvent) {
-    this.isChannelingConvoke = false;
-    this.whatHappendIneachConvoke[this.cast].form = this.activeDruidForm.form;
-    this.houseKeeping();
-  }
-
-  /*
-   * TODO TODO TODO
-   * The handling of travel time spells is incorrect in two ways:
-   * 1) Casts that happen before the first convoke casue a tracker increment, but damage events before the first convoke DON'T decrement
-   * 2) Travel time spells that hit during a Convoke decrement the tracker but still get counted in the Convoke
-   *
-   * In practice these two issues typically cancel one another out and the overall reading is correct,
-   * but in rare can cause wrong results. This is too complicated for me to want to deal with it right now,
-   * but I'm documenting the issue here.
-   *
-   * - Sref
-   */
-
-  wrathCast(event: CastEvent) {
-    this.travelingSpellTracker[event.ability.guid] += 1;
-  }
-
-  starsurgeCast(event: CastEvent) {
-    this.travelingSpellTracker[event.ability.guid] += 1;
-  }
-
-  fullMoonCast(event: CastEvent) {
-    this.travelingSpellTracker[event.ability.guid] += 1;
-  }
-
-  /** Registers the given event as a evidence of a possible Convoke cast */
-  addemUp(event: AbilityEvent<any>) {
+  onHit(event: AbilityEvent<any> & TargettedEvent<any>) {
     const spellId = event.ability.guid;
-    const timestamp = event.timestamp;
-    // if Convoke hasn't been casted in this fight, there is nothing to analyze here.
-    // This also fixes crashes resulting from precasting spells, as they don't have a cast Event associated with them
-    if (this.cast === 0) {
-      return;
+
+    const isNewHit = this.isNewHit(spellId);
+    const isTravelTime = SPELL_IDS_WITH_TRAVEL_TIME.includes(spellId);
+    const wasProbablyHardcast = isTravelTime && this.wasProbablyHardcast(event);
+    const isConvoking = this.isConvoking();
+
+    if (isNewHit && isConvoking && !wasProbablyHardcast) {
+      // spell hit during convoke and was due to convoke
+      this.registerConvokedSpell(spellId);
+    } else if (isTravelTime && !wasProbablyHardcast && this.isWithinTravelFromConvoke()) {
+      // spell hit soon after convoke but was due to convoke
+      this.registerConvokedSpell(spellId);
     }
 
-    // spells with travel times will damage at different times from when they cast
-    // a spell hardcast before convoke could hit during convoke
-    // or a spell procced by convoke could hit afterwards
-    let fromConvokeButWeNoticeAfterwards = false;
-    if (SPELLS_WITH_TRAVEL_TIME.includes(spellId)) {
-      //check if its from convoke or not (if 0 then it is)
-      if (this.travelingSpellTracker[spellId] === 0) {
-        fromConvokeButWeNoticeAfterwards = true;
-      } else {
-        this.travelingSpellTracker[spellId] -= 1;
-      }
-    }
-
-    if (!this.isChannelingConvoke && !fromConvokeButWeNoticeAfterwards) {
-      return;
-    }
-
-    //check for weird multiapplication spells
-    if (this.flexTimeStampForMultiApplySpells + AOE_BUFFER_MS > timestamp) {
-      return;
-    }
-
-    //we know it exists
-    const oneCast = this.whatHappendIneachConvoke[this.cast];
-    if (!oneCast.spellIdToCasts[spellId]) {
-      oneCast.spellIdToCasts[spellId] = 0;
-    }
-    oneCast.spellIdToCasts[spellId] += 1;
-
-    //Might seem weird but we gotta do this if we get extra events.
-    if (fromConvokeButWeNoticeAfterwards) {
-      this.houseKeeping();
+    if (isTravelTime) {
+      this.onTravelTimeHit(spellId);
     }
   }
 
   /**
-   * Possibly sets the 'first hit' timestamp for an AoE ability,
-   * avoiding double counting for any subsequent hits
+   * Tallies the given spellId as a convoked cast during the current convoke.
    */
-  multiSpellSafety(timestamp: number) {
-    if (this.flexTimeStampForMultiApplySpells + AOE_BUFFER_MS < timestamp) {
-      this.flexTimeStampForMultiApplySpells = timestamp;
+  registerConvokedSpell(spellId: number): void {
+    const currentConvoke = this.convokeTracker[this.cast];
+    if (!currentConvoke.spellIdToCasts[spellId]) {
+      currentConvoke.spellIdToCasts[spellId] = 0;
     }
+    currentConvoke.spellIdToCasts[spellId] += 1;
   }
 
   /**
-   * If we counted too many abilities, subtract due to possible procs from other effects
+   * True iff the player is currently Convoking the Elements.
+   * Includes a small buffer after the end because occasionally the last convoked spell occurs
+   * slightly after the end.
    */
-  houseKeeping() {
-    //gotta have our safety : ^)
-    if (this.isChannelingConvoke) {
-      return;
-    }
+  isConvoking(): boolean {
+    return this.selectedCombatant.hasBuff(SPELLS.CONVOKE_SPIRITS.id, null, AFTER_CHANNEL_BUFFER_MS);
+  }
 
-    const howManyDidWeCount = this.whatHappendIneachConvoke[this.cast].spellIdToCasts.reduce(
-      (previousValue: number, currentValue: number) => previousValue + currentValue,
-      0,
+  /**
+   * True iff we're soon enough after Convoking that a convoked spell with travel time
+   * could still plausibly be in the air.
+   */
+  isWithinTravelFromConvoke(): boolean {
+    return this.selectedCombatant.hasBuff(SPELLS.CONVOKE_SPIRITS.id, null, TRAVEL_BUFFER_MS);
+  }
+
+  /**
+   * True iff a hit with the given traveling spellId could plausibly have come from a hardcast
+   */
+  wasProbablyHardcast(event: AbilityEvent<any> & TargettedEvent<any>): boolean {
+    const lastCast: CastEvent | undefined = this.lastTravelingSpellCast[event.ability.guid];
+    return (
+      lastCast !== undefined &&
+      lastCast.timestamp + TRAVEL_BUFFER_MS > this.owner.currentTimestamp &&
+      lastCast.targetID === event.targetID
     );
+  }
 
-    //this can happen due to a resto druid lego that just randomly adds rejuvs (with no cast event)
-    //so lets remove those if possible. if not then ??? sorry fam
-    if (howManyDidWeCount > this.spellsToTrack) {
-      const diff = howManyDidWeCount - this.spellsToTrack;
-      const rejuvs = this.whatHappendIneachConvoke[this.cast].spellIdToCasts[
-        SPELLS.REJUVENATION.id
-      ];
-      if (rejuvs - diff > 0) {
-        this.whatHappendIneachConvoke[this.cast].spellIdToCasts[SPELLS.REJUVENATION.id] -= diff;
-      }
+  /**
+   * Checks if the hit from the given spellId is 'new', and updates trackers appropriately.
+   * A hit from a single target spell is always new.
+   * A hit from an AoE spell is only new if there wasn't another very recent hit.
+   */
+  isNewHit(spellId: number): boolean {
+    const isAoe: boolean = SPELL_IDS_WITH_AOE.includes(spellId);
+    if (!isAoe) {
+      return true;
+    }
+    if (this.owner.currentTimestamp <= this.mostRecentAoeTimestamp + AOE_BUFFER_MS) {
+      return false; // still within the same AoE
+    } else {
+      // new AoE
+      this.mostRecentAoeTimestamp = this.owner.currentTimestamp;
+      return true;
     }
   }
+
+  onTravelTimeCast(event: CastEvent) {
+    this.lastTravelingSpellCast[event.ability.guid] = event;
+  }
+
+  onTravelTimeHit(spellId: number) {
+    this.lastTravelingSpellCast[spellId] = undefined;
+  }
+
+  // TODO discount rejuvs procced from other sources?
 
   statistic() {
     return (
@@ -482,7 +278,7 @@ class ConvokeSpirits extends Analyzer {
             related events during the channel. Occasionally a Convoke will cast an ability that hits
             nothing (like Thrash when only immune targets are in range). In these cases we won't be
             able to track it and so the number of spells listed may not add up to{' '}
-            {this.spellsToTrack}.
+            {this.spellsPerCast}.
           </>
         }
         dropdown={
@@ -496,7 +292,7 @@ class ConvokeSpirits extends Analyzer {
                 </tr>
               </thead>
               <tbody>
-                {this.whatHappendIneachConvoke.map((spellIdToCasts, index) => (
+                {this.convokeTracker.map((spellIdToCasts, index) => (
                   <tr key={index}>
                     <th scope="row">{index}</th>
                     <td>{spellIdToCasts.form}</td>

--- a/analysis/druidbalance/src/CHANGELOG.tsx
+++ b/analysis/druidbalance/src/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
-import { Zeboot, LeoZhekov, Sharrq, Tiboonn, Kartarn, Ciuffi } from 'CONTRIBUTORS';
+import { Zeboot, LeoZhekov, Sharrq, Tiboonn, Kartarn, Ciuffi, Sref } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import React from 'react';
 
 export default [
+  change(date(2021, 5, 15), <>Improved cast detection for <SpellLink id={SPELLS.CONVOKE_SPIRITS.id} /></>, Sref),
   change(date(2021, 4, 2), 'Updated \'About\' page for Shadowlands and current state of the spec\'s analyzer.', Kartarn),
   change(date(2021, 3, 20), <> Astral Power usage efficiency now takes into consideration if <SpellLink id={SPELLS.BALANCE_OF_ALL_THINGS_SOLAR.id} /> legendary is used. </>, Kartarn),
   change(date(2021, 3, 10), 'Updated Starlord, Stellar Drift and Twin Moons talents for Shadowlands.', Kartarn),

--- a/analysis/druidbalance/src/modules/Abilities.tsx
+++ b/analysis/druidbalance/src/modules/Abilities.tsx
@@ -1,8 +1,9 @@
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import ISSUE_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
-import CoreAbilities from '@wowanalyzer/druid/src/core/Abilities';
 import React from 'react';
+
+import CoreAbilities from '@wowanalyzer/druid/src/core/Abilities';
 
 class Abilities extends CoreAbilities {
   spellbook() {

--- a/analysis/druidbalance/src/modules/Abilities.tsx
+++ b/analysis/druidbalance/src/modules/Abilities.tsx
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import ISSUE_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
-import CoreAbilities from 'parser/core/modules/Abilities';
+import CoreAbilities from '@wowanalyzer/druid/src/core/Abilities';
 import React from 'react';
 
 class Abilities extends CoreAbilities {
@@ -378,6 +378,7 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
       },
+      ...super.spellbook(),
     ];
   }
 }

--- a/analysis/druidferal/src/CHANGELOG.js
+++ b/analysis/druidferal/src/CHANGELOG.js
@@ -1,9 +1,12 @@
 import { change, date } from 'common/changelog';
-import { Adoraci, Abelito75, Zeboot, LeoZhekov, Tora, Xcessiv, Tiboonn } from 'CONTRIBUTORS';
+import SPELLS from 'common/SPELLS';
+import { Adoraci, Abelito75, Zeboot, LeoZhekov, Tora, Xcessiv, Tiboonn, Sref } from 'CONTRIBUTORS';
+import { SpellLink } from 'interface';
 import React from 'react';
 
 
 export default [
+  change(date(2021, 5, 15), <>Improved cast detection for <SpellLink id={SPELLS.CONVOKE_SPIRITS.id} /></>, Sref),
   change(date(2021, 4, 3), 'Verified 9.0.5 patch changes and bumped support to 9.0.5', Adoraci),
   change(date(2021, 1, 16), 'Added spell information for conduits', Tiboonn),
   change(date(2020, 12, 15), <>Update Bloodtalons for Shadowlands</>, Tora),

--- a/analysis/druidferal/src/modules/Abilities.js
+++ b/analysis/druidferal/src/modules/Abilities.js
@@ -1,4 +1,5 @@
 import SPELLS from 'common/SPELLS';
+
 import CoreAbilities from '@wowanalyzer/druid/src/core/Abilities';
 
 class Abilities extends CoreAbilities {

--- a/analysis/druidferal/src/modules/Abilities.js
+++ b/analysis/druidferal/src/modules/Abilities.js
@@ -1,5 +1,5 @@
 import SPELLS from 'common/SPELLS';
-import CoreAbilities from 'parser/core/modules/Abilities';
+import CoreAbilities from '@wowanalyzer/druid/src/core/Abilities';
 
 class Abilities extends CoreAbilities {
   spellbook() {
@@ -569,6 +569,7 @@ class Abilities extends CoreAbilities {
         },
         cooldown: 60,
       },
+      ...super.spellbook(),
     ];
   }
 }

--- a/analysis/druidguardian/src/CHANGELOG.tsx
+++ b/analysis/druidguardian/src/CHANGELOG.tsx
@@ -1,7 +1,11 @@
 import { change, date } from 'common/changelog';
-import { Kettlepaw, Zeboot, g3neral, Tiboonn, Buudha } from 'CONTRIBUTORS';
+import SPELLS from 'common/SPELLS';
+import { Kettlepaw, Zeboot, g3neral, Tiboonn, Buudha, Sref } from 'CONTRIBUTORS';
+import { SpellLink } from 'interface';
+import React from 'react';
 
 export default [
+  change(date(2021, 5, 15), <>Improved cast detection for <SpellLink id={SPELLS.CONVOKE_SPIRITS.id} /></>, Sref),
   change(date(2021, 4, 10), 'Updated class syntax to re-enable AntiFillerSpam info', Kettlepaw),
   change(date(2021, 4, 7), 'Correct reporting for Earthwarden absorb events', Kettlepaw),
   change(date(2021, 3, 25), 'Added basic checklist section to be expanded on, and upgraded touched files to Typescript', Buudha),

--- a/analysis/druidguardian/src/modules/Abilities.js
+++ b/analysis/druidguardian/src/modules/Abilities.js
@@ -1,6 +1,7 @@
 import SPELLS from 'common/SPELLS';
-import CoreAbilities from '@wowanalyzer/druid/src/core/Abilities';
 import Enemies from 'parser/shared/modules/Enemies';
+
+import CoreAbilities from '@wowanalyzer/druid/src/core/Abilities';
 
 import Ability from './Ability';
 

--- a/analysis/druidguardian/src/modules/Abilities.js
+++ b/analysis/druidguardian/src/modules/Abilities.js
@@ -1,5 +1,5 @@
 import SPELLS from 'common/SPELLS';
-import CoreAbilities from 'parser/core/modules/Abilities';
+import CoreAbilities from '@wowanalyzer/druid/src/core/Abilities';
 import Enemies from 'parser/shared/modules/Enemies';
 
 import Ability from './Ability';
@@ -365,6 +365,7 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
       },
+      ...super.spellbook(),
     ];
   }
 }

--- a/analysis/druidrestoration/src/CHANGELOG.tsx
+++ b/analysis/druidrestoration/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SpellLink from 'interface/SpellLink';
 import React from 'react';
 
 export default [
+  change(date(2021, 5, 15), <>Improved cast detection and added healing attribution for <SpellLink id={SPELLS.CONVOKE_SPIRITS.id} /></>, Sref),
   change(date(2021, 5, 8), <>Cleaned up <SpellLink id={SPELLS.FLOURISH_TALENT.id} /> module and improved its attribution to be better in some edge cases.</>, Sref),
   change(date(2021, 5, 5), <>Added <SpellLink id={SPELLS.ADAPTIVE_SWARM.id} /> and <SpellLink id={SPELLS.EVOLVED_SWARM.id} /> support</>, Sref),
   change(date(2021, 5, 4), 'Re-added myself as spec maintainer and updated visuals of percent increase stats boxes.', Sref),

--- a/analysis/druidrestoration/src/CombatLogParser.ts
+++ b/analysis/druidrestoration/src/CombatLogParser.ts
@@ -5,7 +5,6 @@ import LowHealthHealing from 'parser/shared/modules/features/LowHealthHealing';
 import ManaLevelChart from 'parser/shared/modules/resources/mana/ManaLevelChart';
 import ManaUsageChart from 'parser/shared/modules/resources/mana/ManaUsageChart';
 
-import { ConvokeSpirits } from '@wowanalyzer/druid';
 import ActiveDruidForm from '@wowanalyzer/druid/src/core/ActiveDruidForm';
 
 import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from './constants';
@@ -32,6 +31,7 @@ import WildGrowth from './modules/features/WildGrowth';
 import EvolvedSwarmResto from './modules/shadowlands/conduits/EvolvedSwarmResto';
 import FlashOfClarity from './modules/shadowlands/conduits/FlashOfClarity';
 import AdaptiveSwarmResto from './modules/shadowlands/covenants/AdaptiveSwarmResto';
+import ConvokeSpiritsResto from './modules/shadowlands/covenants/ConvokeSpiritsResto';
 import MemoryoftheMotherTree from './modules/shadowlands/legendaries/MemoryoftheMotherTree';
 import VisionOfUnendingGrowrth from './modules/shadowlands/legendaries/VisionOfUnendingGrowth';
 import Abundance from './modules/talents/Abundance';
@@ -46,7 +46,6 @@ import ClearcastingNormalizer from './normalizers/ClearcastingNormalizer';
 import HotApplicationNormalizer from './normalizers/HotApplicationNormalizer';
 import TreeOfLifeNormalizer from './normalizers/TreeOfLifeNormalizer';
 import WildGrowthNormalizer from './normalizers/WildGrowth';
-import ConvokeSpiritsResto from './modules/shadowlands/covenants/ConvokeSpiritsResto';
 
 class CombatLogParser extends CoreCombatLogParser {
   static abilitiesAffectedByHealingIncreases = ABILITIES_AFFECTED_BY_HEALING_INCREASES;

--- a/analysis/druidrestoration/src/CombatLogParser.ts
+++ b/analysis/druidrestoration/src/CombatLogParser.ts
@@ -46,6 +46,7 @@ import ClearcastingNormalizer from './normalizers/ClearcastingNormalizer';
 import HotApplicationNormalizer from './normalizers/HotApplicationNormalizer';
 import TreeOfLifeNormalizer from './normalizers/TreeOfLifeNormalizer';
 import WildGrowthNormalizer from './normalizers/WildGrowth';
+import ConvokeSpiritsResto from './modules/shadowlands/covenants/ConvokeSpiritsResto';
 
 class CombatLogParser extends CoreCombatLogParser {
   static abilitiesAffectedByHealingIncreases = ABILITIES_AFFECTED_BY_HEALING_INCREASES;
@@ -108,7 +109,7 @@ class CombatLogParser extends CoreCombatLogParser {
     hpmTracker: HealingEfficiencyTracker,
 
     // Covenants
-    convokeSpirits: ConvokeSpirits,
+    convokeSpirits: ConvokeSpiritsResto,
     adaptiveSwarm: AdaptiveSwarmResto,
 
     // Conduits

--- a/analysis/druidrestoration/src/modules/Abilities.tsx
+++ b/analysis/druidrestoration/src/modules/Abilities.tsx
@@ -1,7 +1,4 @@
 import SPELLS from 'common/SPELLS';
-import COVENANTS from 'game/shadowlands/COVENANTS';
-import SPECS from 'game/SPECS';
-import Combatant from 'parser/core/Combatant';
 import ISSUE_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
 import { SpellbookAbility } from 'parser/core/modules/Ability';
 

--- a/analysis/druidrestoration/src/modules/Abilities.tsx
+++ b/analysis/druidrestoration/src/modules/Abilities.tsx
@@ -1,9 +1,9 @@
 import SPELLS from 'common/SPELLS';
 import COVENANTS from 'game/shadowlands/COVENANTS';
-import ISSUE_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
-import CoreAbilities from 'parser/core/modules/Abilities';
 import SPECS from 'game/SPECS';
 import Combatant from 'parser/core/Combatant';
+import ISSUE_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
+import CoreAbilities from 'parser/core/modules/Abilities';
 
 class Abilities extends CoreAbilities {
   spellbook() {
@@ -94,7 +94,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 120,
         gcd: {
-          base: (c: Combatant) => c.spec === SPECS.FERAL_DRUID ? 1000 : 1500,
+          base: (c: Combatant) => (c.spec === SPECS.FERAL_DRUID ? 1000 : 1500),
         },
         enabled: combatant.hasCovenant(COVENANTS.NIGHT_FAE.id),
         castEfficiency: {

--- a/analysis/druidrestoration/src/modules/Abilities.tsx
+++ b/analysis/druidrestoration/src/modules/Abilities.tsx
@@ -2,6 +2,8 @@ import SPELLS from 'common/SPELLS';
 import COVENANTS from 'game/shadowlands/COVENANTS';
 import ISSUE_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
 import CoreAbilities from 'parser/core/modules/Abilities';
+import SPECS from 'game/SPECS';
+import Combatant from 'parser/core/Combatant';
 
 class Abilities extends CoreAbilities {
   spellbook() {
@@ -85,6 +87,19 @@ class Abilities extends CoreAbilities {
           recommendedEfficiency: 0.75,
           averageIssueEfficiency: 0.55,
           majorIssueEfficiency: 0.3,
+        },
+      },
+      {
+        spell: SPELLS.CONVOKE_SPIRITS,
+        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
+        cooldown: 120,
+        gcd: {
+          base: (c: Combatant) => c.spec === SPECS.FERAL_DRUID ? 1000 : 1500,
+        },
+        enabled: combatant.hasCovenant(COVENANTS.NIGHT_FAE.id),
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.8,
         },
       },
       {

--- a/analysis/druidrestoration/src/modules/Abilities.tsx
+++ b/analysis/druidrestoration/src/modules/Abilities.tsx
@@ -1,12 +1,13 @@
 import SPELLS from 'common/SPELLS';
 import COVENANTS from 'game/shadowlands/COVENANTS';
-import SPECS from 'game/SPECS';
-import Combatant from 'parser/core/Combatant';
 import ISSUE_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
-import CoreAbilities from 'parser/core/modules/Abilities';
+import CoreAbilities from '@wowanalyzer/druid/src/core/Abilities';
+import { SpellbookAbility } from 'parser/core/modules/Ability';
+import Combatant from 'parser/core/Combatant';
+import SPECS from 'game/SPECS';
 
 class Abilities extends CoreAbilities {
-  spellbook() {
+  spellbook(): SpellbookAbility[]  {
     const combatant = this.selectedCombatant;
     return [
       {
@@ -88,32 +89,6 @@ class Abilities extends CoreAbilities {
           averageIssueEfficiency: 0.55,
           majorIssueEfficiency: 0.3,
         },
-      },
-      {
-        spell: SPELLS.CONVOKE_SPIRITS,
-        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
-        cooldown: 120,
-        gcd: {
-          base: (c: Combatant) => (c.spec === SPECS.FERAL_DRUID ? 1000 : 1500),
-        },
-        enabled: combatant.hasCovenant(COVENANTS.NIGHT_FAE.id),
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: 0.8,
-        },
-      },
-      {
-        spell: SPELLS.ADAPTIVE_SWARM,
-        category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        cooldown: 25,
-        gcd: {
-          base: 1500,
-        },
-        enabled: combatant.hasCovenant(COVENANTS.NECROLORD.id),
-        castEfficiency: {
-          suggestion: true,
-        },
-        healSpellIds: [SPELLS.ADAPTIVE_SWARM_HEAL.id],
       },
       {
         spell: SPELLS.WILD_GROWTH,
@@ -507,6 +482,7 @@ class Abilities extends CoreAbilities {
         },
         enabled: combatant.hasTalent(SPELLS.OVERGROWTH_TALENT.id),
       },
+      ...super.spellbook(),
     ];
   }
 }

--- a/analysis/druidrestoration/src/modules/Abilities.tsx
+++ b/analysis/druidrestoration/src/modules/Abilities.tsx
@@ -1,13 +1,14 @@
 import SPELLS from 'common/SPELLS';
 import COVENANTS from 'game/shadowlands/COVENANTS';
-import ISSUE_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
-import CoreAbilities from '@wowanalyzer/druid/src/core/Abilities';
-import { SpellbookAbility } from 'parser/core/modules/Ability';
-import Combatant from 'parser/core/Combatant';
 import SPECS from 'game/SPECS';
+import Combatant from 'parser/core/Combatant';
+import ISSUE_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
+import { SpellbookAbility } from 'parser/core/modules/Ability';
+
+import CoreAbilities from '@wowanalyzer/druid/src/core/Abilities';
 
 class Abilities extends CoreAbilities {
-  spellbook(): SpellbookAbility[]  {
+  spellbook(): SpellbookAbility[] {
     const combatant = this.selectedCombatant;
     return [
       {

--- a/analysis/druidrestoration/src/modules/shadowlands/covenants/ConvokeSpiritsResto.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/covenants/ConvokeSpiritsResto.tsx
@@ -110,10 +110,9 @@ class ConvokeSpiritsResto extends ConvokeSpirits {
             nothing (like Thrash when only immune targets are in range). In these cases we won't be
             able to track it and so the number of spells listed may not add up to{' '}
             {this.spellsPerCast}.
-            <br />
+            <br /><br />
             Healing amount is attributed by tracking the healing spells cast by Convoke, including
-            possible Flourish casts. When Flourish is cast some double counting within this module
-            occurs, so the listed number will be somewhat higher than the true amount.
+            possible Flourish casts. This amount includes mastery benefit from the proceed HoTs.
           </>
         }
         dropdown={

--- a/analysis/druidrestoration/src/modules/shadowlands/covenants/ConvokeSpiritsResto.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/covenants/ConvokeSpiritsResto.tsx
@@ -1,0 +1,155 @@
+import SPELLS from 'common/SPELLS';
+import { ConvokeSpirits } from '@wowanalyzer/druid';
+import HotTrackerRestoDruid from '../../core/hottracking/HotTrackerRestoDruid';
+import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import COVENANTS from 'game/shadowlands/COVENANTS';
+import { Attribution } from 'parser/shared/modules/HotTracker';
+import Events, { ApplyBuffEvent, HealEvent, RefreshBuffEvent } from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { SpellLink } from 'interface';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import React from 'react';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
+import { formatNumber } from 'common/format';
+
+const CONVOKED_HOTS = [
+  SPELLS.REJUVENATION,
+  SPELLS.REJUVENATION_GERMINATION,
+  SPELLS.REGROWTH,
+  SPELLS.WILD_GROWTH,
+];
+
+
+/**
+ * Resto's extension to the Convoke the Spirits display. Includes healing attribution.
+ * Convokable healing abilities:
+ * * Rejuvenation - track apply/refresh - use HotTracker
+ * * Regrowth - track apply/refresh - use HotTracker
+ * * Swiftmend - track heal - directly attribute healing
+ * * Wild Growth - track apply/refresh - use HotTracker
+ * * Flourish - track apply/refresh - use integration with Flourish module
+ */
+class ConvokeSpiritsResto extends ConvokeSpirits {
+  static dependencies = {
+    ...ConvokeSpirits.dependencies,
+    hotTracker: HotTrackerRestoDruid,
+  };
+
+  hotTracker!: HotTrackerRestoDruid;
+
+  convokeAttributions: Attribution[] = [];
+  convokeFlourishRateAttributions: { amount: number }[] = [];
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasCovenant(COVENANTS.NIGHT_FAE.id);
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(CONVOKED_HOTS), this.onRestoHotApply
+    );
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(CONVOKED_HOTS), this.onRestoHotApply
+    );
+    this.addEventListener(
+      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.SWIFTMEND), this.onRestoSwiftmend
+    );
+    // Flourish is tracked from the Flourish module, which calls into this one to update the attribution
+  }
+
+  onRestoHotApply(event: ApplyBuffEvent | RefreshBuffEvent) {
+    if (this.isChannelingConvoke) {
+      this.hotTracker.addAttributionFromApply(this.currentConvokeAttribution, event);
+    }
+  }
+
+  onRestoSwiftmend(event: HealEvent) {
+    if (this.isChannelingConvoke) {
+      this.currentConvokeAttribution.healing += event.amount + (event.absorbed || 0);
+    }
+  }
+
+  startTracking(event: ApplyBuffEvent) {
+    super.startTracking(event);
+    this.convokeAttributions[this.cast] = this.hotTracker.getNewAttribution(
+      SPELLS.CONVOKE_SPIRITS.id, 'Convoke #' + this.cast);
+    this.convokeFlourishRateAttributions[this.cast] = { amount: 0 };
+  }
+
+  get currentConvokeAttribution(): Attribution {
+    return this.convokeAttributions[this.cast];
+  }
+
+  get currentConvokeRateAttribution() {
+    return this.convokeFlourishRateAttributions[this.cast];
+  }
+
+  get totalHealing(): number {
+    const attributorHealing = this.convokeAttributions.reduce((sum, att) => att.healing + sum, 0);
+    const flourishRateHealing = this.convokeFlourishRateAttributions.reduce((sum, att) => att.amount + sum, 0);
+    return attributorHealing + flourishRateHealing;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE()}
+        size="flexible"
+        category={STATISTIC_CATEGORY.COVENANTS}
+        tooltip={
+          <>
+            Abilities cast by Convoke do not create cast events; this listing is created by
+            tracking related events during the channel. Occasionally a Convoke will cast an ability
+            that hits nothing (like Thrash when only immune targets are in range). In these cases
+            we won't be able to track it and so the number of spells listed may not add up to
+            {' '}{this.spellsToTrack}.
+            <br />
+            Healing amount is attributed by tracking the healing spells cast by Convoke, including
+            possible Flourish casts. When Flourish is cast some double counting within this module
+            occurs, so the listed number will be somewhat higher than the true amount.
+          </>
+        }
+        dropdown={
+          <>
+            <table className="table table-condensed">
+              <thead>
+                <tr>
+                  <th>Cast #</th>
+                  <th>Form</th>
+                  <th>Healing</th>
+                  <th>Spells In Cast</th>
+                </tr>
+              </thead>
+              <tbody>
+                {this.whatHappendIneachConvoke.map((spellIdToCasts, index) => (
+                  <tr key={index}>
+                    <th scope="row">{index}</th>
+                    <td>{spellIdToCasts.form}</td>
+                    <td>{formatNumber(this.convokeAttributions[index].healing + this.convokeFlourishRateAttributions[index].amount)}</td>
+                    <td>
+                      {spellIdToCasts.spellIdToCasts.map((casts, spellId) => (
+                        <>
+                          <SpellLink id={spellId} /> {casts} <br />
+                        </>
+                      ))}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </>
+        }
+      >
+        <BoringSpellValueText spell={SPELLS.CONVOKE_SPIRITS}>
+          <ItemPercentHealingDone approximate amount={this.totalHealing} />
+          <br />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+
+
+}
+
+export default ConvokeSpiritsResto;

--- a/analysis/druidrestoration/src/modules/shadowlands/covenants/ConvokeSpiritsResto.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/covenants/ConvokeSpiritsResto.tsx
@@ -1,18 +1,20 @@
+import { formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
-import { ConvokeSpirits } from '@wowanalyzer/druid';
-import HotTrackerRestoDruid from '../../core/hottracking/HotTrackerRestoDruid';
-import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import COVENANTS from 'game/shadowlands/COVENANTS';
-import { Attribution } from 'parser/shared/modules/HotTracker';
+import { SpellLink } from 'interface';
+import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { ApplyBuffEvent, HealEvent, RefreshBuffEvent } from 'parser/core/Events';
+import { Attribution } from 'parser/shared/modules/HotTracker';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
-import { SpellLink } from 'interface';
-import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import React from 'react';
-import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
-import { formatNumber } from 'common/format';
+
+import { ConvokeSpirits } from '@wowanalyzer/druid';
+
+import HotTrackerRestoDruid from '../../core/hottracking/HotTrackerRestoDruid';
 
 const CONVOKED_HOTS = [
   SPELLS.REJUVENATION,
@@ -20,7 +22,6 @@ const CONVOKED_HOTS = [
   SPELLS.REGROWTH,
   SPELLS.WILD_GROWTH,
 ];
-
 
 /**
  * Resto's extension to the Convoke the Spirits display. Includes healing attribution.
@@ -40,20 +41,23 @@ class ConvokeSpiritsResto extends ConvokeSpirits {
   hotTracker!: HotTrackerRestoDruid;
 
   convokeAttributions: Attribution[] = [];
-  convokeFlourishRateAttributions: { amount: number }[] = [];
+  convokeFlourishRateAttributions: Array<{ amount: number }> = [];
 
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasCovenant(COVENANTS.NIGHT_FAE.id);
 
     this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(CONVOKED_HOTS), this.onRestoHotApply
+      Events.applybuff.by(SELECTED_PLAYER).spell(CONVOKED_HOTS),
+      this.onRestoHotApply,
     );
     this.addEventListener(
-      Events.refreshbuff.by(SELECTED_PLAYER).spell(CONVOKED_HOTS), this.onRestoHotApply
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(CONVOKED_HOTS),
+      this.onRestoHotApply,
     );
     this.addEventListener(
-      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.SWIFTMEND), this.onRestoSwiftmend
+      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.SWIFTMEND),
+      this.onRestoSwiftmend,
     );
     // Flourish is tracked from the Flourish module, which calls into this one to update the attribution
   }
@@ -73,7 +77,9 @@ class ConvokeSpiritsResto extends ConvokeSpirits {
   startTracking(event: ApplyBuffEvent) {
     super.startTracking(event);
     this.convokeAttributions[this.cast] = this.hotTracker.getNewAttribution(
-      SPELLS.CONVOKE_SPIRITS.id, 'Convoke #' + this.cast);
+      SPELLS.CONVOKE_SPIRITS.id,
+      'Convoke #' + this.cast,
+    );
     this.convokeFlourishRateAttributions[this.cast] = { amount: 0 };
   }
 
@@ -87,7 +93,10 @@ class ConvokeSpiritsResto extends ConvokeSpirits {
 
   get totalHealing(): number {
     const attributorHealing = this.convokeAttributions.reduce((sum, att) => att.healing + sum, 0);
-    const flourishRateHealing = this.convokeFlourishRateAttributions.reduce((sum, att) => att.amount + sum, 0);
+    const flourishRateHealing = this.convokeFlourishRateAttributions.reduce(
+      (sum, att) => att.amount + sum,
+      0,
+    );
     return attributorHealing + flourishRateHealing;
   }
 
@@ -99,11 +108,11 @@ class ConvokeSpiritsResto extends ConvokeSpirits {
         category={STATISTIC_CATEGORY.COVENANTS}
         tooltip={
           <>
-            Abilities cast by Convoke do not create cast events; this listing is created by
-            tracking related events during the channel. Occasionally a Convoke will cast an ability
-            that hits nothing (like Thrash when only immune targets are in range). In these cases
-            we won't be able to track it and so the number of spells listed may not add up to
-            {' '}{this.spellsToTrack}.
+            Abilities cast by Convoke do not create cast events; this listing is created by tracking
+            related events during the channel. Occasionally a Convoke will cast an ability that hits
+            nothing (like Thrash when only immune targets are in range). In these cases we won't be
+            able to track it and so the number of spells listed may not add up to{' '}
+            {this.spellsToTrack}.
             <br />
             Healing amount is attributed by tracking the healing spells cast by Convoke, including
             possible Flourish casts. When Flourish is cast some double counting within this module
@@ -126,7 +135,12 @@ class ConvokeSpiritsResto extends ConvokeSpirits {
                   <tr key={index}>
                     <th scope="row">{index}</th>
                     <td>{spellIdToCasts.form}</td>
-                    <td>{formatNumber(this.convokeAttributions[index].healing + this.convokeFlourishRateAttributions[index].amount)}</td>
+                    <td>
+                      {formatNumber(
+                        this.convokeAttributions[index].healing +
+                          this.convokeFlourishRateAttributions[index].amount,
+                      )}
+                    </td>
                     <td>
                       {spellIdToCasts.spellIdToCasts.map((casts, spellId) => (
                         <>
@@ -148,8 +162,6 @@ class ConvokeSpiritsResto extends ConvokeSpirits {
       </Statistic>
     );
   }
-
-
 }
 
 export default ConvokeSpiritsResto;

--- a/analysis/druidrestoration/src/modules/shadowlands/covenants/ConvokeSpiritsResto.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/covenants/ConvokeSpiritsResto.tsx
@@ -110,7 +110,8 @@ class ConvokeSpiritsResto extends ConvokeSpirits {
             nothing (like Thrash when only immune targets are in range). In these cases we won't be
             able to track it and so the number of spells listed may not add up to{' '}
             {this.spellsPerCast}.
-            <br /><br />
+            <br />
+            <br />
             Healing amount is attributed by tracking the healing spells cast by Convoke, including
             possible Flourish casts. This amount includes mastery benefit from the proceed HoTs.
           </>

--- a/analysis/druidrestoration/src/modules/shadowlands/covenants/ConvokeSpiritsResto.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/covenants/ConvokeSpiritsResto.tsx
@@ -63,19 +63,19 @@ class ConvokeSpiritsResto extends ConvokeSpirits {
   }
 
   onRestoHotApply(event: ApplyBuffEvent | RefreshBuffEvent) {
-    if (this.isChannelingConvoke) {
+    if (this.isConvoking()) {
       this.hotTracker.addAttributionFromApply(this.currentConvokeAttribution, event);
     }
   }
 
   onRestoSwiftmend(event: HealEvent) {
-    if (this.isChannelingConvoke) {
+    if (this.isConvoking()) {
       this.currentConvokeAttribution.healing += event.amount + (event.absorbed || 0);
     }
   }
 
-  startTracking(event: ApplyBuffEvent) {
-    super.startTracking(event);
+  onConvoke(event: ApplyBuffEvent) {
+    super.onConvoke(event);
     this.convokeAttributions[this.cast] = this.hotTracker.getNewAttribution(
       SPELLS.CONVOKE_SPIRITS.id,
       'Convoke #' + this.cast,
@@ -112,7 +112,7 @@ class ConvokeSpiritsResto extends ConvokeSpirits {
             related events during the channel. Occasionally a Convoke will cast an ability that hits
             nothing (like Thrash when only immune targets are in range). In these cases we won't be
             able to track it and so the number of spells listed may not add up to{' '}
-            {this.spellsToTrack}.
+            {this.spellsPerCast}.
             <br />
             Healing amount is attributed by tracking the healing spells cast by Convoke, including
             possible Flourish casts. When Flourish is cast some double counting within this module
@@ -131,7 +131,7 @@ class ConvokeSpiritsResto extends ConvokeSpirits {
                 </tr>
               </thead>
               <tbody>
-                {this.whatHappendIneachConvoke.map((spellIdToCasts, index) => (
+                {this.convokeTracker.map((spellIdToCasts, index) => (
                   <tr key={index}>
                     <th scope="row">{index}</th>
                     <td>{spellIdToCasts.form}</td>

--- a/analysis/druidrestoration/src/modules/shadowlands/covenants/ConvokeSpiritsResto.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/covenants/ConvokeSpiritsResto.tsx
@@ -4,7 +4,7 @@ import COVENANTS from 'game/shadowlands/COVENANTS';
 import { SpellLink } from 'interface';
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { ApplyBuffEvent, HealEvent, RefreshBuffEvent } from 'parser/core/Events';
-import { Attribution } from 'parser/shared/modules/HotTracker';
+import HotTracker, { Attribution } from 'parser/shared/modules/HotTracker';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 import Statistic from 'parser/ui/Statistic';
@@ -76,10 +76,7 @@ class ConvokeSpiritsResto extends ConvokeSpirits {
 
   onConvoke(event: ApplyBuffEvent) {
     super.onConvoke(event);
-    this.convokeAttributions[this.cast] = this.hotTracker.getNewAttribution(
-      SPELLS.CONVOKE_SPIRITS.id,
-      'Convoke #' + this.cast,
-    );
+    this.convokeAttributions[this.cast] = HotTracker.getNewAttribution('Convoke #' + this.cast);
     this.convokeFlourishRateAttributions[this.cast] = { amount: 0 };
   }
 

--- a/analysis/druidrestoration/src/modules/shadowlands/legendaries/VerdantInfusion.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/legendaries/VerdantInfusion.tsx
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent } from 'parser/core/Events';
 import Combatants from 'parser/shared/modules/Combatants';
-import { Attribution, TrackersBySpell } from 'parser/shared/modules/HotTracker';
+import HotTracker, { Attribution, TrackersBySpell } from 'parser/shared/modules/HotTracker';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 import Statistic from 'parser/ui/Statistic';
@@ -38,13 +38,7 @@ class VerdantInfusion extends Analyzer {
   hotTracker!: HotTrackerRestoDruid;
   combatants!: Combatants;
 
-  attribution: Attribution = {
-    attributionId: SPELLS.VERDANT_INFUSION.id,
-    name: 'Verdant Infusion',
-    healing: 0,
-    procs: 0,
-    totalExtension: 0,
-  };
+  attribution: Attribution = HotTracker.getNewAttribution('Verdant Infusion');
   casts: number = 0;
 
   constructor(options: Options) {

--- a/analysis/druidrestoration/src/modules/talents/Flourish.tsx
+++ b/analysis/druidrestoration/src/modules/talents/Flourish.tsx
@@ -8,7 +8,7 @@ import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
 import Events, { HealEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
-import { Attribution } from 'parser/shared/modules/HotTracker';
+import HotTracker, { Attribution } from 'parser/shared/modules/HotTracker';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 import Statistic from 'parser/ui/Statistic';
@@ -120,10 +120,7 @@ class Flourish extends Analyzer {
       this.currentRateAttribution = this.convokeSpirits.currentConvokeRateAttribution;
     } else {
       this.hardcastCount += 1;
-      extensionAttribution = this.hotTracker.getNewAttribution(
-        SPELLS.FLOURISH_TALENT.id,
-        `Flourish #${this.hardcastCount}`,
-      );
+      extensionAttribution = HotTracker.getNewAttribution(`Flourish #${this.hardcastCount}`);
       this.currentRateAttribution = { amount: 0 };
       this.rateAttributions.push(this.currentRateAttribution);
       this.extensionAttributions.push(extensionAttribution);

--- a/analysis/druidrestoration/src/modules/talents/Flourish.tsx
+++ b/analysis/druidrestoration/src/modules/talents/Flourish.tsx
@@ -17,6 +17,7 @@ import React from 'react';
 
 import { HOTS_INCREASED_RATE } from '../../constants';
 import HotTrackerRestoDruid from '../core/hottracking/HotTrackerRestoDruid';
+import ConvokeSpiritsResto from '../shadowlands/covenants/ConvokeSpiritsResto';
 
 const FLOURISH_EXTENSION = 8000;
 const FLOURISH_HEALING_INCREASE = 1;
@@ -31,10 +32,12 @@ class Flourish extends Analyzer {
   static dependencies = {
     hotTracker: HotTrackerRestoDruid,
     abilityTracker: AbilityTracker,
+    convokeSpirits: ConvokeSpiritsResto,
   };
 
   hotTracker!: HotTrackerRestoDruid;
   abilityTracker!: AbilityTracker;
+  convokeSpirits!: ConvokeSpiritsResto;
 
   extensionAttributions: Attribution[] = [];
   rateAttributions: MutableAmount[] = [];
@@ -42,11 +45,7 @@ class Flourish extends Analyzer {
   hardcastCount: number = 0;
   wgsExtended = 0; // tracks how many flourishes extended Wild Growth
 
-  // separate attributors for Flourishes cast by Convoke the Spirits
-  convokeExtensionAttribution?: Attribution;
-  convokeRateAttribution: MutableAmount = { amount: 0 };
-
-  currentRateAttribution: MutableAmount = this.convokeRateAttribution;
+  currentRateAttribution: MutableAmount = { amount: 0 };
 
   constructor(options: Options) {
     super(options);
@@ -117,14 +116,8 @@ class Flourish extends Analyzer {
   onFlourishApplyBuff() {
     let extensionAttribution: Attribution;
     if (this.selectedCombatant.hasBuff(SPELLS.CONVOKE_SPIRITS.id)) {
-      if (this.convokeExtensionAttribution === undefined) {
-        this.convokeExtensionAttribution = this.hotTracker.getNewAttribution(
-          SPELLS.FLOURISH_TALENT.id,
-          `Convoked Flourishes`,
-        );
-      }
-      extensionAttribution = this.convokeExtensionAttribution;
-      this.currentRateAttribution = this.convokeRateAttribution;
+      extensionAttribution = this.convokeSpirits.currentConvokeAttribution;
+      this.currentRateAttribution = this.convokeSpirits.currentConvokeRateAttribution;
     } else {
       this.hardcastCount += 1;
       extensionAttribution = this.hotTracker.getNewAttribution(
@@ -247,7 +240,7 @@ class Flourish extends Analyzer {
   }
 }
 
-type MutableAmount = {
+export type MutableAmount = {
   amount: number;
 };
 

--- a/analysis/monkmistweaver/src/modules/talents/RisingMist.js
+++ b/analysis/monkmistweaver/src/modules/talents/RisingMist.js
@@ -5,6 +5,7 @@ import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
 import Events from 'parser/core/Events';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
+import HotTracker from 'parser/shared/modules/HotTracker';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import BoringValueText from 'parser/ui/BoringValueText';
 import Statistic from 'parser/ui/Statistic';
@@ -24,7 +25,7 @@ class RisingMist extends Analyzer {
   get averageExtension() {
     return this.risingMistCount === 0
       ? 0
-      : this.risingMists.reduce((acc, risingMist) => acc + risingMist.duration, 0) /
+      : this.risingMists.reduce((acc, risingMist) => acc + risingMist.totalExtension, 0) /
           this.risingMistCount /
           1000;
   }
@@ -196,12 +197,7 @@ class RisingMist extends Analyzer {
     this.risingMistCount += 1;
     debug && console.log(`risingMist cast #: ${this.risingMistCount}`);
 
-    const newRisingMist = {
-      name: `RisingMist #${this.risingMistCount}`,
-      healing: 0,
-      procs: 0,
-      duration: 0,
-    };
+    const newRisingMist = HotTracker.getNewAttribution(`RisingMist #${this.risingMistCount}`);
     this.risingMists.push(newRisingMist);
 
     let foundEf = false;

--- a/src/parser/shared/modules/HotTracker.ts
+++ b/src/parser/shared/modules/HotTracker.ts
@@ -162,6 +162,21 @@ abstract class HotTracker extends Analyzer {
   }
 
   /**
+   * Provides an attribution for a HoT application. All healing done by the HoT will be tallied
+   * to the given attribution object.
+   *
+   * Typically this will be added at the same time the HoT is applied. In order for an Attribution
+   * to be addable, the Tracker for the given HoT must already be present. This means the module
+   * adding this attribution MUST come after HotTracker in the processing order.
+   *
+   * @param attribution the Attribution object to attach
+   * @param event the event marking the application of the HoT to attribute.
+   */
+  public addAttributionFromApply(attribution: Attribution, event: ApplyBuffEvent | RefreshBuffEvent | ApplyBuffStackEvent): void {
+    this.addAttribution(attribution, event.targetID, event.ability.guid);
+  }
+
+  /**
    * Extends a HoT and optionally attributes that extension.
    *
    * Healing done at the end of the HoT (the time due to the extension) will be tallied to the given Attribution.

--- a/src/parser/shared/modules/HotTracker.ts
+++ b/src/parser/shared/modules/HotTracker.ts
@@ -172,7 +172,10 @@ abstract class HotTracker extends Analyzer {
    * @param attribution the Attribution object to attach
    * @param event the event marking the application of the HoT to attribute.
    */
-  public addAttributionFromApply(attribution: Attribution, event: ApplyBuffEvent | RefreshBuffEvent | ApplyBuffStackEvent): void {
+  public addAttributionFromApply(
+    attribution: Attribution,
+    event: ApplyBuffEvent | RefreshBuffEvent | ApplyBuffStackEvent,
+  ): void {
     this.addAttribution(attribution, event.targetID, event.ability.guid);
   }
 


### PR DESCRIPTION
Refactored Convoke Spirits for improved readability and also to fix some edge cases bugs, including:
* Documented everything
* Merged handling code to be more general
* Moved Convoke 'ability' object out to the main abilities file
* Fixed issue where Feral Frenzy was counted 5 times
* Fixed issue where instant spells that happen just after the Convoke buff fades were missed.
* Fixed issue where travel time casts tracking could get 'out of sync' when cast before the first Convoke