### PR TITLE
Fixed a bug where a missing combatantinfo could cause the Mana Pool chart to crash

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 
 // prettier-ignore
 export default [
+  change(date(2021, 5, 15), 'Fixed a bug that could cause the Mana Pool graph to crash', Sref),
   change(date(2021, 5, 4), 'German translations', maestrohdude),
   change(date(2021, 4, 26), <>Fixed <SpellLink id={SPELLS.CHAOS_BRAND.id} /> count in Raid Buffs</>, niko),
   change(date(2021, 4, 24), 'German translations', maestrohdude),

--- a/src/parser/shared/modules/resources/mana/ManaLevelChartComponent.js
+++ b/src/parser/shared/modules/resources/mana/ManaLevelChartComponent.js
@@ -92,7 +92,7 @@ class ManaLevelChartComponent extends React.PureComponent {
         .filter((death) => Boolean(death.targetIsFriendly))
         .map(({ timestamp, targetID, killingAbility }) => ({
           x: timestamp - start,
-          name: combatants.players[targetID].name,
+          name: combatants.players[targetID] ? combatants.players[targetID].name : 'Unknown Player',
           ability: killingAbility ? killingAbility.name : 'Unknown Ability',
         }));
     }


### PR DESCRIPTION
Bug observed here: https://wowanalyzer.com/report/nVjCaFAvq9tBWdHY/4-Heroic+The+Nine+-+Kill+(6:43)/Moovomo/standard/statistics