### PR TITLE
Feral Druid checklist update

### DIFF
--- a/analysis/druid/src/core/Abilities.ts
+++ b/analysis/druid/src/core/Abilities.ts
@@ -34,9 +34,6 @@ class Abilities extends CoreAbilities {
           base: (c: Combatant) => (c.spec === SPECS.FERAL_DRUID ? 1000 : 1500),
         },
         enabled: combatant.hasCovenant(COVENANTS.NECROLORD.id),
-        castEfficiency: {
-          suggestion: true,
-        },
         healSpellIds: [SPELLS.ADAPTIVE_SWARM_HEAL.id],
       },
     ];

--- a/analysis/druidferal/src/CHANGELOG.js
+++ b/analysis/druidferal/src/CHANGELOG.js
@@ -5,9 +5,8 @@ import { SpellLink } from 'interface';
 import React from 'react';
 
 export default [
-  change(date(2021, 5, 17), <>Updated the Checklist to include <SpellLink id={SPELLS.CONVOKE_SPIRITS.id} /> cast efficiency
-    and <SpellLink id={SPELLS.ADAPTIVE_SWARM.id} /> uptime. Fixed an issue where <SpellLink id={SPELLS.BERSERK_BUFF.id} />{' '}
-    showed incorrectly in the Combo Points tab.</>, Sref),
+  change(date(2021, 5, 17), <>Updated the Checklist to include <SpellLink id={SPELLS.CONVOKE_SPIRITS.id} /> and <SpellLink id={SPELLS.HEART_OF_THE_WILD.id} /> cast efficiency
+    and <SpellLink id={SPELLS.ADAPTIVE_SWARM.id} /> uptime. Fixed an issue where <SpellLink id={SPELLS.BERSERK_BUFF.id} /> showed incorrectly in the Combo Points tab.</>, Sref),
   change(date(2021, 5, 16), <>Added <SpellLink id={SPELLS.DRAUGHT_OF_DEEP_FOCUS.id} /> support</>, Sref),
   change(date(2021, 5, 15), <>Improved cast detection for <SpellLink id={SPELLS.CONVOKE_SPIRITS.id} /></>, Sref),
   change(date(2021, 4, 3), 'Verified 9.0.5 patch changes and bumped support to 9.0.5', Adoraci),

--- a/analysis/druidferal/src/CHANGELOG.js
+++ b/analysis/druidferal/src/CHANGELOG.js
@@ -5,6 +5,9 @@ import { SpellLink } from 'interface';
 import React from 'react';
 
 export default [
+  change(date(2021, 5, 17), <>Updated the Checklist to include <SpellLink id={SPELLS.CONVOKE_SPIRITS.id} /> cast efficiency
+    and <SpellLink id={SPELLS.ADAPTIVE_SWARM.id} /> uptime. Fixed an issue where <SpellLink id={SPELLS.BERSERK_BUFF.id} />{' '}
+    showed incorrectly in the Combo Points tab.</>, Sref),
   change(date(2021, 5, 16), <>Added <SpellLink id={SPELLS.DRAUGHT_OF_DEEP_FOCUS.id} /> support</>, Sref),
   change(date(2021, 5, 15), <>Improved cast detection for <SpellLink id={SPELLS.CONVOKE_SPIRITS.id} /></>, Sref),
   change(date(2021, 4, 3), 'Verified 9.0.5 patch changes and bumped support to 9.0.5', Adoraci),

--- a/analysis/druidferal/src/CombatLogParser.js
+++ b/analysis/druidferal/src/CombatLogParser.js
@@ -18,6 +18,7 @@ import EnergyTracker from './modules/features/EnergyTracker';
 import SpellEnergyCost from './modules/features/SpellEnergyCost';
 import SpellUsable from './modules/features/SpellUsable';
 import Shadowmeld from './modules/racials/Shadowmeld';
+import AdaptiveSwarmFeral from './modules/shadowlands/AdaptiveSwarmFeral';
 import DraughtOfDeepFocus from './modules/shadowlands/DraughtOfDeepFocus';
 import FerociousBiteEnergy from './modules/spells/FerociousBiteEnergy';
 import PredatorySwiftness from './modules/spells/PredatorySwiftness';
@@ -33,7 +34,6 @@ import SavageRoar from './modules/talents/SavageRoar';
 import BleedDebuffEvents from './normalizers/BleedDebuffEvents';
 import ComboPointsFromAoE from './normalizers/ComboPointsFromAoE';
 import RakeBleed from './normalizers/RakeBleed';
-import AdaptiveSwarmFeral from './modules/shadowlands/AdaptiveSwarmFeral';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {

--- a/analysis/druidferal/src/CombatLogParser.js
+++ b/analysis/druidferal/src/CombatLogParser.js
@@ -33,6 +33,7 @@ import SavageRoar from './modules/talents/SavageRoar';
 import BleedDebuffEvents from './normalizers/BleedDebuffEvents';
 import ComboPointsFromAoE from './normalizers/ComboPointsFromAoE';
 import RakeBleed from './normalizers/RakeBleed';
+import AdaptiveSwarmFeral from './modules/shadowlands/AdaptiveSwarmFeral';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -82,6 +83,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // shadowlands
     draughtOfDeepFocus: DraughtOfDeepFocus,
+    adaptiveSwarm: AdaptiveSwarmFeral,
   };
 }
 

--- a/analysis/druidferal/src/modules/Abilities.js
+++ b/analysis/druidferal/src/modules/Abilities.js
@@ -145,6 +145,18 @@ class Abilities extends CoreAbilities {
         timelineSortIndex: 22,
       },
       {
+        spell: SPELLS.HEART_OF_THE_WILD,
+        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
+        cooldown: 300,
+        gcd: {
+          base: 1500,
+        },
+        enabled: combatant.hasTalent(SPELLS.HEART_OF_THE_WILD_TALENT.id),
+        castEfficiency: {
+          suggestion: true,
+        },
+      },
+      {
         spell: SPELLS.TIGERS_FURY,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 30,

--- a/analysis/druidferal/src/modules/bleeds/RakeSnapshot.js
+++ b/analysis/druidferal/src/modules/bleeds/RakeSnapshot.js
@@ -4,6 +4,7 @@ import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import { TooltipElement } from 'interface';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticsListBox';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 import React from 'react';
 
 import { RAKE_BASE_DURATION, PANDEMIC_FRACTION } from '../../constants';
@@ -40,7 +41,7 @@ class RakeSnapshot extends Snapshot {
         average: 2.0,
         major: 8.0,
       },
-      style: 'decimal',
+      style: ThresholdStyle.DECIMAL,
     };
   }
 
@@ -52,7 +53,7 @@ class RakeSnapshot extends Snapshot {
         average: 0.15,
         major: 0.6,
       },
-      style: 'percentage',
+      style: ThresholdStyle.PERCENTAGE,
     };
   }
 

--- a/analysis/druidferal/src/modules/bleeds/RakeSnapshot.js
+++ b/analysis/druidferal/src/modules/bleeds/RakeSnapshot.js
@@ -3,8 +3,8 @@ import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import { TooltipElement } from 'interface';
-import { STATISTIC_ORDER } from 'parser/ui/StatisticsListBox';
 import { ThresholdStyle } from 'parser/core/ParseResults';
+import { STATISTIC_ORDER } from 'parser/ui/StatisticsListBox';
 import React from 'react';
 
 import { RAKE_BASE_DURATION, PANDEMIC_FRACTION } from '../../constants';

--- a/analysis/druidferal/src/modules/bleeds/RakeUptime.js
+++ b/analysis/druidferal/src/modules/bleeds/RakeUptime.js
@@ -9,6 +9,7 @@ import Enemies from 'parser/shared/modules/Enemies';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 import React from 'react';
 
 class RakeUptime extends Analyzer {
@@ -24,7 +25,7 @@ class RakeUptime extends Analyzer {
         average: 0.9,
         major: 0.8,
       },
-      style: 'percentage',
+      style: ThresholdStyle.PERCENTAGE,
     };
   }
 

--- a/analysis/druidferal/src/modules/bleeds/RakeUptime.js
+++ b/analysis/druidferal/src/modules/bleeds/RakeUptime.js
@@ -5,11 +5,11 @@ import { SpellLink } from 'interface';
 import { TooltipElement } from 'interface';
 import UptimeIcon from 'interface/icons/Uptime';
 import Analyzer from 'parser/core/Analyzer';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 import Enemies from 'parser/shared/modules/Enemies';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
-import { ThresholdStyle } from 'parser/core/ParseResults';
 import React from 'react';
 
 class RakeUptime extends Analyzer {

--- a/analysis/druidferal/src/modules/bleeds/RipSnapshot.js
+++ b/analysis/druidferal/src/modules/bleeds/RipSnapshot.js
@@ -7,6 +7,7 @@ import Events from 'parser/core/Events';
 import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticsListBox';
 import React from 'react';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 
 import {
   PANDEMIC_FRACTION,
@@ -48,7 +49,7 @@ class RipSnapshot extends Snapshot {
         average: 0.1,
         major: 0.2,
       },
-      style: 'percentage',
+      style: ThresholdStyle.PERCENTAGE,
     };
   }
 
@@ -60,7 +61,7 @@ class RipSnapshot extends Snapshot {
         average: 0.1,
         major: 0.2,
       },
-      style: 'percentage',
+      style: ThresholdStyle.PERCENTAGE,
     };
   }
 
@@ -76,7 +77,7 @@ class RipSnapshot extends Snapshot {
         average: 0.15,
         major: 0.6,
       },
-      style: 'percentage',
+      style: ThresholdStyle.PERCENTAGE,
     };
   }
 

--- a/analysis/druidferal/src/modules/bleeds/RipSnapshot.js
+++ b/analysis/druidferal/src/modules/bleeds/RipSnapshot.js
@@ -4,10 +4,10 @@ import { SpellLink } from 'interface';
 import { TooltipElement } from 'interface';
 import { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticsListBox';
 import React from 'react';
-import { ThresholdStyle } from 'parser/core/ParseResults';
 
 import {
   PANDEMIC_FRACTION,

--- a/analysis/druidferal/src/modules/bleeds/RipUptime.js
+++ b/analysis/druidferal/src/modules/bleeds/RipUptime.js
@@ -10,6 +10,7 @@ import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 
 class RipUptime extends Analyzer {
   get uptime() {
@@ -24,7 +25,7 @@ class RipUptime extends Analyzer {
         average: 0.9,
         major: 0.8,
       },
-      style: 'percentage',
+      style: ThresholdStyle.PERCENTAGE,
     };
   }
 

--- a/analysis/druidferal/src/modules/bleeds/RipUptime.js
+++ b/analysis/druidferal/src/modules/bleeds/RipUptime.js
@@ -5,12 +5,12 @@ import { SpellLink } from 'interface';
 import { TooltipElement } from 'interface';
 import UptimeIcon from 'interface/icons/Uptime';
 import Analyzer from 'parser/core/Analyzer';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 import Enemies from 'parser/shared/modules/Enemies';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
-import { ThresholdStyle } from 'parser/core/ParseResults';
 
 class RipUptime extends Analyzer {
   get uptime() {

--- a/analysis/druidferal/src/modules/combopoints/ComboPointDetails.js
+++ b/analysis/druidferal/src/modules/combopoints/ComboPointDetails.js
@@ -2,6 +2,7 @@ import { t } from '@lingui/macro';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { Panel } from 'interface';
 import Analyzer from 'parser/core/Analyzer';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 import BoringResourceValue from 'parser/ui/BoringResourceValue';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
@@ -9,7 +10,6 @@ import React from 'react';
 
 import ResourceBreakdown from './ComboPointBreakdown';
 import ComboPointTracker from './ComboPointTracker';
-import { ThresholdStyle } from 'parser/core/ParseResults';
 
 class ComboPointDetails extends Analyzer {
   get pointsWasted() {

--- a/analysis/druidferal/src/modules/combopoints/ComboPointDetails.js
+++ b/analysis/druidferal/src/modules/combopoints/ComboPointDetails.js
@@ -9,6 +9,7 @@ import React from 'react';
 
 import ResourceBreakdown from './ComboPointBreakdown';
 import ComboPointTracker from './ComboPointTracker';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 
 class ComboPointDetails extends Analyzer {
   get pointsWasted() {
@@ -27,7 +28,7 @@ class ComboPointDetails extends Analyzer {
         average: 5,
         major: 10,
       },
-      style: 'number',
+      style: ThresholdStyle.NUMBER,
     };
   }
 

--- a/analysis/druidferal/src/modules/combopoints/FinisherUse.js
+++ b/analysis/druidferal/src/modules/combopoints/FinisherUse.js
@@ -11,6 +11,7 @@ import React from 'react';
 
 import RipSnapshot from '../bleeds/RipSnapshot';
 import getComboPointsFromEvent from '../core/getComboPointsFromEvent';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 
 const debug = false;
 
@@ -50,7 +51,7 @@ class FinisherUse extends Analyzer {
         average: 0.05,
         major: 0.1,
       },
-      style: 'percentage',
+      style: ThresholdStyle.PERCENTAGE,
     };
   }
 

--- a/analysis/druidferal/src/modules/combopoints/FinisherUse.js
+++ b/analysis/druidferal/src/modules/combopoints/FinisherUse.js
@@ -4,6 +4,7 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { SpellLink } from 'interface';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 import BoringResourceValue from 'parser/ui/BoringResourceValue';
 import Statistic from 'parser/ui/Statistic';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
@@ -11,7 +12,6 @@ import React from 'react';
 
 import RipSnapshot from '../bleeds/RipSnapshot';
 import getComboPointsFromEvent from '../core/getComboPointsFromEvent';
-import { ThresholdStyle } from 'parser/core/ParseResults';
 
 const debug = false;
 

--- a/analysis/druidferal/src/modules/features/EnergyCapTracker.js
+++ b/analysis/druidferal/src/modules/features/EnergyCapTracker.js
@@ -9,6 +9,7 @@ import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
 
 import SpellEnergyCost from './SpellEnergyCost';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 
 const BASE_ENERGY_REGEN = 11;
 const BASE_ENERGY_MAX = 100;
@@ -39,7 +40,7 @@ class EnergyCapTracker extends RegenResourceCapTracker {
         average: 0.7,
         major: 0.65,
       },
-      style: 'percentage',
+      style: ThresholdStyle.PERCENTAGE,
     };
   }
 

--- a/analysis/druidferal/src/modules/features/EnergyCapTracker.js
+++ b/analysis/druidferal/src/modules/features/EnergyCapTracker.js
@@ -2,6 +2,7 @@ import { t } from '@lingui/macro';
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 import RegenResourceCapTracker from 'parser/shared/modules/resources/resourcetracker/RegenResourceCapTracker';
 import BoringResourceValue from 'parser/ui/BoringResourceValue';
 import Statistic from 'parser/ui/Statistic';
@@ -9,7 +10,6 @@ import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
 
 import SpellEnergyCost from './SpellEnergyCost';
-import { ThresholdStyle } from 'parser/core/ParseResults';
 
 const BASE_ENERGY_REGEN = 11;
 const BASE_ENERGY_MAX = 100;

--- a/analysis/druidferal/src/modules/features/checklist/Component.tsx
+++ b/analysis/druidferal/src/modules/features/checklist/Component.tsx
@@ -231,7 +231,7 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }: Checklis
 
         Switch out the whole rule section if we can detect that the player was in a situation where energy was abundant.
       */}
-      {!thresholds.tigersFuryIgnoreEnergy && (
+      {!thresholds.tigersFuryIgnoreEnergy.actual && (
         <Rule
           name="Manage your energy"
           description={
@@ -271,7 +271,7 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }: Checklis
           />
         </Rule>
       )}
-      {thresholds.tigersFuryIgnoreEnergy && combatant.hasTalent(SPELLS.PREDATOR_TALENT.id) && (
+      {thresholds.tigersFuryIgnoreEnergy.actual && combatant.hasTalent(SPELLS.PREDATOR_TALENT.id) && (
         <Rule
           name="Manage your energy"
           description={

--- a/analysis/druidferal/src/modules/features/checklist/Component.tsx
+++ b/analysis/druidferal/src/modules/features/checklist/Component.tsx
@@ -325,6 +325,9 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }: Checklis
         {combatant.hasCovenant(COVENANTS.NIGHT_FAE.id) && (
           <CastEfficiencyRequirement spell={SPELLS.CONVOKE_SPIRITS.id} />
         )}
+        {combatant.hasTalent(SPELLS.HEART_OF_THE_WILD_TALENT.id) && (
+          <CastEfficiencyRequirement spell={SPELLS.HEART_OF_THE_WILD.id} />
+        )}
         {combatant.race === RACES.NightElf && (
           <Requirement
             name={<SpellLink id={SPELLS.SHADOWMELD.id} />}

--- a/analysis/druidferal/src/modules/features/checklist/Component.tsx
+++ b/analysis/druidferal/src/modules/features/checklist/Component.tsx
@@ -115,6 +115,9 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }: Checklis
             thresholds={thresholds.adaptiveSwarmUptime}
           />
         )}
+        {combatant.hasTalent(SPELLS.FERAL_FRENZY_TALENT.id) && (
+          <CastEfficiencyRequirement spell={SPELLS.FERAL_FRENZY_TALENT.id} />
+        )}
         {combatant.hasTalent(SPELLS.BRUTAL_SLASH_TALENT.id) && (
           <CastEfficiencyRequirement spell={SPELLS.BRUTAL_SLASH_TALENT.id} />
         )}
@@ -319,9 +322,6 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }: Checklis
           <CastEfficiencyRequirement spell={SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id} />
         )}
         <CastEfficiencyRequirement spell={SPELLS.TIGERS_FURY.id} />
-        {combatant.hasTalent(SPELLS.FERAL_FRENZY_TALENT.id) && (
-          <CastEfficiencyRequirement spell={SPELLS.FERAL_FRENZY_TALENT.id} />
-        )}
         {combatant.hasCovenant(COVENANTS.NIGHT_FAE.id) && (
           <CastEfficiencyRequirement spell={SPELLS.CONVOKE_SPIRITS.id} />
         )}

--- a/analysis/druidferal/src/modules/features/checklist/Component.tsx
+++ b/analysis/druidferal/src/modules/features/checklist/Component.tsx
@@ -5,17 +5,24 @@ import { TooltipElement } from 'interface';
 import Checklist from 'parser/shared/modules/features/Checklist';
 import GenericCastEfficiencyRequirement from 'parser/shared/modules/features/Checklist/GenericCastEfficiencyRequirement';
 import PreparationRule from 'parser/shared/modules/features/Checklist/PreparationRule';
-import Requirement from 'parser/shared/modules/features/Checklist/Requirement';
+import Requirement, {
+  RequirementThresholds,
+} from 'parser/shared/modules/features/Checklist/Requirement';
 import Rule from 'parser/shared/modules/features/Checklist/Rule';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {
+  AbilityRequirementProps,
+  ChecklistProps,
+} from 'parser/shared/modules/features/Checklist/ChecklistTypes';
+import COVENANTS from 'game/shadowlands/COVENANTS';
 
-const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }) => {
-  const UptimeRequirement = (props) => (
+const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }: ChecklistProps) => {
+  const UptimeRequirement = (props: { spell: number; thresholds: RequirementThresholds }) => (
     <Requirement
       name={
         <>
-          <SpellLink id={props.spell} /> uptime
+          <SpellLink id={props.spell} icon /> uptime
         </>
       }
       thresholds={props.thresholds}
@@ -24,7 +31,8 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }) => {
   UptimeRequirement.propTypes = {
     spell: PropTypes.object.isRequired,
   };
-  const CastEfficiencyRequirement = (props) => (
+
+  const CastEfficiencyRequirement = (props: AbilityRequirementProps) => (
     <GenericCastEfficiencyRequirement
       castEfficiency={castEfficiency.getCastEfficiencyForSpellId(props.spell)}
       {...props}
@@ -33,7 +41,11 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }) => {
   CastEfficiencyRequirement.propTypes = {
     spell: PropTypes.object.isRequired,
   };
-  const SnapshotDowngradeRequirement = (props) => (
+
+  const SnapshotDowngradeRequirement = (props: {
+    spell: number;
+    thresholds: RequirementThresholds;
+  }) => (
     <Requirement
       name={
         <>
@@ -41,7 +53,8 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }) => {
         </>
       }
       thresholds={props.thresholds}
-      tooltip="Downgrading a snapshot can be unavoidable, but you should let the upgraded version last as long as possible by avoiding early refreshes."
+      tooltip="Downgrading a snapshot can be unavoidable, but you should let the upgraded version
+        last as long as possible by avoiding early refreshes."
     />
   );
   SnapshotDowngradeRequirement.propTypes = {
@@ -50,10 +63,12 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }) => {
 
   return (
     <Checklist>
-      {/* Builders
+      {/** Builders
         🗵 Uptime for Rake DoT
         🗵 Uptime for Moonfire DoT (if talented for it)
-        ☐ Avoid the types of early refresh which aren't already caught by the snapshot analysers. (Can be tricky to determine with certainty if such a refresh is bad, although if the player is just spamming Rake that should be flagged as a mistake.)
+        ☐ Avoid the types of early refresh which aren't already caught by the snapshot analysers.
+          (Can be tricky to determine with certainty if such a refresh is bad, although if the
+          player is just spamming Rake that should be flagged as a mistake.)
         🗵 Cast efficiency of Brutal Slash (if talented)
         🗵 Cast efficiency of Feral Frenzy (if talented)
         🗵 Only use Swipe if it hits multiple enemies
@@ -94,11 +109,14 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }) => {
             thresholds={thresholds.moonfireUptime}
           />
         )}
+        {combatant.hasCovenant(COVENANTS.NECROLORD.id) && (
+          <UptimeRequirement
+            spell={SPELLS.ADAPTIVE_SWARM_DAMAGE.id}
+            thresholds={thresholds.adaptiveSwarmUptime}
+          />
+        )}
         {combatant.hasTalent(SPELLS.BRUTAL_SLASH_TALENT.id) && (
           <CastEfficiencyRequirement spell={SPELLS.BRUTAL_SLASH_TALENT.id} />
-        )}
-        {combatant.hasTalent(SPELLS.FERAL_FRENZY_TALENT.id) && (
-          <CastEfficiencyRequirement spell={SPELLS.FERAL_FRENZY_TALENT.id} />
         )}
         <Requirement
           name={
@@ -107,7 +125,8 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }) => {
             </>
           }
           thresholds={thresholds.swipeHitOne}
-          tooltip="How many times you used Swipe but had it only hit 1 target. Against a single target you should use Shred instead."
+          tooltip="How many times you used Swipe but had it only hit 1 target.
+            Against a single target you should use Shred instead."
         />
         <Requirement
           name={<>Combo points wasted</>}
@@ -116,7 +135,7 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }) => {
         />
       </Rule>
 
-      {/* Finishers
+      {/** Finishers
         🗵 Uptime on Rip DoT
         🗵 Uptime for Savage Roar buff (if talented)
         🗵 Ferocious Bite only at energy >= 50
@@ -134,7 +153,8 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }) => {
             situations and simplifies your finisher use, allowing you to almost always use{' '}
             <SpellLink id={SPELLS.FEROCIOUS_BITE.id} /> as your single target finisher. When casting{' '}
             <SpellLink id={SPELLS.FEROCIOUS_BITE.id} /> make sure you have at least{' '}
-            <TooltipElement content="Ferocious Bite's tooltip says it needs just 25 energy, but you should always give it an additional 25 to double its damage.">
+            <TooltipElement content="Ferocious Bite's tooltip says it needs just 25 energy,
+              but you should always give it an additional 25 to double its damage.">
               50 energy.
             </TooltipElement>
             <br />
@@ -159,7 +179,8 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }) => {
             </>
           }
           thresholds={thresholds.ferociousBiteEnergy}
-          tooltip="Ferocious Bite consumes up to 50 energy, and should always be given that full 50 energy to significantly increase its damage."
+          tooltip="Ferocious Bite consumes up to 50 energy,
+            and should always be given that full 50 energy to significantly increase its damage."
         />
         {combatant.hasTalent(SPELLS.SABERTOOTH_TALENT.id) && (
           <Requirement
@@ -170,7 +191,10 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }) => {
               </>
             }
             thresholds={thresholds.ripShouldBeBite}
-            tooltip="With the Sabertooth talent you can maintain your Rip by using Ferocious Bite. If you instead cast Rip you are missing out on the Ferocious Bite damage. If the replacement Rip has a better snapshot then it may have been worth using, so those cases are not counted here."
+            tooltip="With the Sabertooth talent you can maintain your Rip by using Ferocious Bite.
+              If you instead cast Rip you are missing out on the Ferocious Bite damage.
+              If the replacement Rip has a better snapshot then it may have been worth using,
+              so those cases are not counted here."
           />
         )}
         <Requirement
@@ -180,19 +204,25 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }) => {
             </>
           }
           thresholds={thresholds.ripDurationReduction}
-          tooltip="Because Rip's duration is based on combo points used it is possible to reduce the duration of your existing bleed by reapplying it with low combo points. Not only is this a waste of resources but you're doing less damage than you would if you'd done nothing at all."
+          tooltip="Because Rip's duration is based on combo points used it is possible
+            to reduce the duration of your existing bleed by reapplying it with low combo points.
+            Not only is this a waste of resources but you're doing less damage than you would if you'd done nothing at all."
         />
         <Requirement
           name={<>Needless low combo point finishers</>}
           thresholds={thresholds.badLowComboFinishers}
-          tooltip="Your finishers are most efficient when used with full combo points. However it is still worth using a low combo point Rip if it's not yet up on a target (this exception is detected and taken into account when calculating this metric.)"
+          tooltip="Your finishers are most efficient when used with full combo points.
+            However it is still worth using a low combo point Rip if it's not yet up on a target
+            (this exception is detected and taken into account when calculating this metric.)"
         />
       </Rule>
 
-      {/* Manage your energy
+      {/** Manage your energy
         🗵 Don't cap energy
         🗵 Don't waste energy from Tiger's Fury
-        ☐ Some kind of check for good pooling behaviour (having high energy when using a finisher is generally good, but would benefit from some research to quantify that effect.)
+        ☐ Some kind of check for good pooling behaviour
+          (having high energy when using a finisher is generally good,
+          but would benefit from some research to quantify that effect.)
 
         Switch out the whole rule section if we can detect that the player was in a situation where energy was abundant.
       */}
@@ -219,7 +249,9 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }) => {
           <Requirement
             name={<>Wasted natural regeneration from being capped</>}
             thresholds={thresholds.energyCapped}
-            tooltip="Some waste during Berserk or Incarnation (especially with Bloodlust active) is not a concern. If the fight mechanics force you to not attack for periods of time then capping energy is inevitable. Please use your knowledge of the fight when weighing the importance of this metric."
+            tooltip="Some waste during Berserk or Incarnation (especially with Bloodlust active) is not a concern.
+              If the fight mechanics force you to not attack for periods of time then capping energy is inevitable.
+              Please use your knowledge of the fight when weighing the importance of this metric."
           />
           <Requirement
             name={
@@ -228,7 +260,9 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }) => {
               </>
             }
             thresholds={thresholds.tigersFuryEnergy}
-            tooltip="There are some situations where energy is very abundant and the energy gain from Tiger's Fury becomes unimportant, but that is rare in boss fights. Generally you should aim to use Tiger's Fury both for its energy and damage increase."
+            tooltip="There are some situations where energy is very abundant and the energy gain
+              from Tiger's Fury becomes unimportant, but that is rare in boss fights.
+              Generally you should aim to use Tiger's Fury both for its energy and damage increase."
           />
         </Rule>
       )}
@@ -256,9 +290,10 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }) => {
         </Rule>
       )}
 
-      {/*Use your cooldowns
+      {/**Use your cooldowns
         🗵 Cast efficiency of Berserk or Incarnation (depending on talent)
-        ☐ Make the most of Berserk/Incarnation by using as many abilities as possible during the buff (importance of this may be so low that it's not worth checking - run some simulations to find out)
+        ☐ Make the most of Berserk/Incarnation by using as many abilities as possible during the buff
+          (importance of this may be so low that it's not worth checking - run some simulations to find out)
         🗵 Cast efficiency of Tiger's Fury
         🗵 Shadowmeld for Night Elves: cast efficiency of correctly using it to buff Rake
       */}
@@ -284,6 +319,12 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }) => {
           <CastEfficiencyRequirement spell={SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id} />
         )}
         <CastEfficiencyRequirement spell={SPELLS.TIGERS_FURY.id} />
+        {combatant.hasTalent(SPELLS.FERAL_FRENZY_TALENT.id) && (
+          <CastEfficiencyRequirement spell={SPELLS.FERAL_FRENZY_TALENT.id} />
+        )}
+        {combatant.hasCovenant(COVENANTS.NIGHT_FAE.id) && (
+          <CastEfficiencyRequirement spell={SPELLS.CONVOKE_SPIRITS.id} />
+        )}
         {combatant.race === RACES.NightElf && (
           <Requirement
             name={<SpellLink id={SPELLS.SHADOWMELD.id} />}
@@ -312,11 +353,13 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }) => {
             <br />
             As a general rule it's beneficial to refresh a DoT early if you would increase the
             snapshot. It's better to refresh with a weaker version of the DoT during the{' '}
-            <TooltipElement content="The last 30% of the DoT's duration. If you refresh during this time you don't lose any duration in the process.">
+            <TooltipElement content="The last 30% of the DoT's duration.
+             If you refresh during this time you don't lose any duration in the process.">
               pandemic window
             </TooltipElement>{' '}
             than to let it wear off. The exception is <SpellLink id={SPELLS.RAKE.id} /> empowered by{' '}
-            <TooltipElement content="The effect is also provided by Incarnation: King of the Jungle, and Shadowmeld for Night Elves">
+            <TooltipElement content="The effect is also provided by Incarnation: King of the Jungle,
+              and Shadowmeld for Night Elves">
               Prowl
             </TooltipElement>{' '}
             which is so much stronger that you should wait until the DoT wears off when replacing it
@@ -379,7 +422,8 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }) => {
               </>
             }
             thresholds={thresholds.bloodtalonsWasted}
-            tooltip="Using Bloodtalons to buff any ability counts as it not being wasted. See the statistics results section for details on how those charges were used."
+            tooltip="Using Bloodtalons to buff any ability counts as it not being wasted.
+              See the statistics results section for details on how those charges were used."
           />
         </Rule>
       )}

--- a/analysis/druidferal/src/modules/features/checklist/Component.tsx
+++ b/analysis/druidferal/src/modules/features/checklist/Component.tsx
@@ -1,8 +1,13 @@
 import SPELLS from 'common/SPELLS';
 import RACES from 'game/RACES';
+import COVENANTS from 'game/shadowlands/COVENANTS';
 import { SpellLink } from 'interface';
 import { TooltipElement } from 'interface';
 import Checklist from 'parser/shared/modules/features/Checklist';
+import {
+  AbilityRequirementProps,
+  ChecklistProps,
+} from 'parser/shared/modules/features/Checklist/ChecklistTypes';
 import GenericCastEfficiencyRequirement from 'parser/shared/modules/features/Checklist/GenericCastEfficiencyRequirement';
 import PreparationRule from 'parser/shared/modules/features/Checklist/PreparationRule';
 import Requirement, {
@@ -11,11 +16,6 @@ import Requirement, {
 import Rule from 'parser/shared/modules/features/Checklist/Rule';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {
-  AbilityRequirementProps,
-  ChecklistProps,
-} from 'parser/shared/modules/features/Checklist/ChecklistTypes';
-import COVENANTS from 'game/shadowlands/COVENANTS';
 
 const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }: ChecklistProps) => {
   const UptimeRequirement = (props: { spell: number; thresholds: RequirementThresholds }) => (
@@ -156,8 +156,10 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }: Checklis
             situations and simplifies your finisher use, allowing you to almost always use{' '}
             <SpellLink id={SPELLS.FEROCIOUS_BITE.id} /> as your single target finisher. When casting{' '}
             <SpellLink id={SPELLS.FEROCIOUS_BITE.id} /> make sure you have at least{' '}
-            <TooltipElement content="Ferocious Bite's tooltip says it needs just 25 energy,
-              but you should always give it an additional 25 to double its damage.">
+            <TooltipElement
+              content="Ferocious Bite's tooltip says it needs just 25 energy,
+              but you should always give it an additional 25 to double its damage."
+            >
               50 energy.
             </TooltipElement>
             <br />
@@ -356,13 +358,17 @@ const FeralDruidChecklist = ({ combatant, castEfficiency, thresholds }: Checklis
             <br />
             As a general rule it's beneficial to refresh a DoT early if you would increase the
             snapshot. It's better to refresh with a weaker version of the DoT during the{' '}
-            <TooltipElement content="The last 30% of the DoT's duration.
-             If you refresh during this time you don't lose any duration in the process.">
+            <TooltipElement
+              content="The last 30% of the DoT's duration.
+             If you refresh during this time you don't lose any duration in the process."
+            >
               pandemic window
             </TooltipElement>{' '}
             than to let it wear off. The exception is <SpellLink id={SPELLS.RAKE.id} /> empowered by{' '}
-            <TooltipElement content="The effect is also provided by Incarnation: King of the Jungle,
-              and Shadowmeld for Night Elves">
+            <TooltipElement
+              content="The effect is also provided by Incarnation: King of the Jungle,
+              and Shadowmeld for Night Elves"
+            >
               Prowl
             </TooltipElement>{' '}
             which is so much stronger that you should wait until the DoT wears off when replacing it

--- a/analysis/druidferal/src/modules/features/checklist/Module.tsx
+++ b/analysis/druidferal/src/modules/features/checklist/Module.tsx
@@ -21,6 +21,7 @@ import Predator from '../../talents/Predator';
 import SavageRoar from '../../talents/SavageRoar';
 import EnergyCapTracker from '../EnergyCapTracker';
 import Component from './Component';
+import AdaptiveSwarmFeral from '../../shadowlands/AdaptiveSwarmFeral';
 
 class Checklist extends BaseChecklist {
   static dependencies = {
@@ -30,6 +31,7 @@ class Checklist extends BaseChecklist {
 
     rakeUptime: RakeUptime,
     moonfireUptime: MoonfireUptime,
+    adaptiveSwarm: AdaptiveSwarmFeral,
     swipeHitCount: SwipeHitCount,
     comboPointDetails: ComboPointDetails,
     ripUptime: RipUptime,
@@ -46,6 +48,28 @@ class Checklist extends BaseChecklist {
     finisherUse: FinisherUse,
   };
 
+  protected combatants!: Combatants;
+  protected castEfficiency!: CastEfficiency;
+  protected preparationRuleAnalyzer!: PreparationRuleAnalyzer;
+
+  protected rakeUptime!: RakeUptime;
+  protected moonfireUptime!: MoonfireUptime;
+  protected adaptiveSwarm!: AdaptiveSwarmFeral;
+  protected swipeHitCount!: SwipeHitCount;
+  protected comboPointDetails!: ComboPointDetails;
+  protected ripUptime!: RipUptime;
+  protected savageRoar!: SavageRoar;
+  protected ferociousBiteEnergy!: FerociousBiteEnergy;
+  protected energyCapTracker!: EnergyCapTracker;
+  protected ripSnapshot!: RipSnapshot;
+  protected rakeSnapshot!: RakeSnapshot;
+  protected moonfireSnapshot!: MoonfireSnapshot;
+  protected bloodtalons!: Bloodtalons;
+  protected predator!: Predator;
+  protected tigersFuryEnergy!: TigersFuryEnergy;
+  protected shadowmeld!: Shadowmeld;
+  protected finisherUse!: FinisherUse;
+
   render() {
     return (
       <Component
@@ -58,6 +82,7 @@ class Checklist extends BaseChecklist {
           // builders
           rakeUptime: this.rakeUptime.suggestionThresholds,
           moonfireUptime: this.moonfireUptime.suggestionThresholds,
+          adaptiveSwarmUptime: this.adaptiveSwarm.suggestionThresholds,
           swipeHitOne: this.swipeHitCount.hitJustOneThresholds,
           comboPointsWaste: this.comboPointDetails.wastingSuggestionThresholds,
 
@@ -71,7 +96,7 @@ class Checklist extends BaseChecklist {
 
           // energy
           energyCapped: this.energyCapTracker.suggestionThresholds,
-          tigersFuryIgnoreEnergy: this.tigersFuryEnergy.shouldIgnoreEnergyWaste,
+          // tigersFuryIgnoreEnergy: this.tigersFuryEnergy.shouldIgnoreEnergyWaste,
           tigersFuryEnergy: this.tigersFuryEnergy.suggestionThresholds,
 
           // cooldowns

--- a/analysis/druidferal/src/modules/features/checklist/Module.tsx
+++ b/analysis/druidferal/src/modules/features/checklist/Module.tsx
@@ -11,6 +11,7 @@ import RipUptime from '../../bleeds/RipUptime';
 import ComboPointDetails from '../../combopoints/ComboPointDetails';
 import FinisherUse from '../../combopoints/FinisherUse';
 import Shadowmeld from '../../racials/Shadowmeld';
+import AdaptiveSwarmFeral from '../../shadowlands/AdaptiveSwarmFeral';
 import FerociousBiteEnergy from '../../spells/FerociousBiteEnergy';
 import SwipeHitCount from '../../spells/SwipeHitCount';
 import TigersFuryEnergy from '../../spells/TigersFuryEnergy';
@@ -21,7 +22,6 @@ import Predator from '../../talents/Predator';
 import SavageRoar from '../../talents/SavageRoar';
 import EnergyCapTracker from '../EnergyCapTracker';
 import Component from './Component';
-import AdaptiveSwarmFeral from '../../shadowlands/AdaptiveSwarmFeral';
 
 class Checklist extends BaseChecklist {
   static dependencies = {

--- a/analysis/druidferal/src/modules/features/checklist/Module.tsx
+++ b/analysis/druidferal/src/modules/features/checklist/Module.tsx
@@ -96,7 +96,7 @@ class Checklist extends BaseChecklist {
 
           // energy
           energyCapped: this.energyCapTracker.suggestionThresholds,
-          // tigersFuryIgnoreEnergy: this.tigersFuryEnergy.shouldIgnoreEnergyWaste,
+          tigersFuryIgnoreEnergy: this.tigersFuryEnergy.shouldIgnoreEnergyWaste,
           tigersFuryEnergy: this.tigersFuryEnergy.suggestionThresholds,
 
           // cooldowns

--- a/analysis/druidferal/src/modules/racials/Shadowmeld.js
+++ b/analysis/druidferal/src/modules/racials/Shadowmeld.js
@@ -6,11 +6,11 @@ import { SpellLink } from 'interface';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';
 import Abilities from 'parser/core/modules/Abilities';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
-import { ThresholdStyle } from 'parser/core/ParseResults';
 
 const BUFF_WINDOW_TIME = 60;
 

--- a/analysis/druidferal/src/modules/racials/Shadowmeld.js
+++ b/analysis/druidferal/src/modules/racials/Shadowmeld.js
@@ -10,6 +10,7 @@ import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 
 const BUFF_WINDOW_TIME = 60;
 
@@ -32,7 +33,7 @@ class Shadowmeld extends Analyzer {
         average: 0.8,
         major: 0.7,
       },
-      style: 'percentage',
+      style: ThresholdStyle.PERCENTAGE,
     };
   }
 
@@ -44,7 +45,7 @@ class Shadowmeld extends Analyzer {
         average: 0.1,
         major: 0.2,
       },
-      style: 'percentage',
+      style: ThresholdStyle.PERCENTAGE,
     };
   }
 

--- a/analysis/druidferal/src/modules/shadowlands/AdaptiveSwarmFeral.tsx
+++ b/analysis/druidferal/src/modules/shadowlands/AdaptiveSwarmFeral.tsx
@@ -1,0 +1,46 @@
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import { ThresholdStyle } from 'parser/core/ParseResults';
+import Enemies from 'parser/shared/modules/Enemies';
+import { AdaptiveSwarm } from '@wowanalyzer/druid';
+
+/**
+ * Resto's display module for Adaptive Swarm.
+ */
+class AdaptiveSwarmFeral extends AdaptiveSwarm {
+  static dependencies = {
+    ...AdaptiveSwarm.dependencies,
+    enemies: Enemies,
+  };
+
+  enemies!: Enemies;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(SPELLS.LUNAR_INSPIRATION_TALENT.id);
+  }
+
+  get uptime() {
+    return this.enemies.getBuffUptime(SPELLS.ADAPTIVE_SWARM_DAMAGE.id) / this.owner.fightDuration;
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.uptime,
+      isLessThan: {
+        // TODO double check reasonable numbers
+        minor: 0.60,
+        average: 0.45,
+        major: 0.30,
+      },
+      style: ThresholdStyle.PERCENTAGE,
+    };
+  }
+
+  // TODO suggestion
+
+  // TODO statistic
+
+}
+
+export default AdaptiveSwarmFeral;

--- a/analysis/druidferal/src/modules/shadowlands/AdaptiveSwarmFeral.tsx
+++ b/analysis/druidferal/src/modules/shadowlands/AdaptiveSwarmFeral.tsx
@@ -1,7 +1,8 @@
-import Analyzer, { Options } from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
+import { Options } from 'parser/core/Analyzer';
 import { ThresholdStyle } from 'parser/core/ParseResults';
 import Enemies from 'parser/shared/modules/Enemies';
+
 import { AdaptiveSwarm } from '@wowanalyzer/druid';
 
 /**
@@ -29,9 +30,9 @@ class AdaptiveSwarmFeral extends AdaptiveSwarm {
       actual: this.uptime,
       isLessThan: {
         // TODO double check reasonable numbers
-        minor: 0.60,
+        minor: 0.6,
         average: 0.45,
-        major: 0.30,
+        major: 0.3,
       },
       style: ThresholdStyle.PERCENTAGE,
     };
@@ -40,7 +41,6 @@ class AdaptiveSwarmFeral extends AdaptiveSwarm {
   // TODO suggestion
 
   // TODO statistic
-
 }
 
 export default AdaptiveSwarmFeral;

--- a/analysis/druidferal/src/modules/spells/FerociousBiteEnergy.js
+++ b/analysis/druidferal/src/modules/spells/FerociousBiteEnergy.js
@@ -6,6 +6,7 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { SpellLink } from 'interface';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 import React from 'react';
 
 import {
@@ -41,7 +42,7 @@ class FerociousBiteEnergy extends Analyzer {
         average: 0.95,
         major: 0.8,
       },
-      style: 'percentage',
+      style: ThresholdStyle.PERCENTAGE,
     };
   }
 

--- a/analysis/druidferal/src/modules/spells/SwipeHitCount.js
+++ b/analysis/druidferal/src/modules/spells/SwipeHitCount.js
@@ -1,6 +1,7 @@
 import { t } from '@lingui/macro';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import React from 'react';
 
@@ -19,7 +20,7 @@ class SwipeHitCount extends HitCountAoE {
         average: 0.2,
         major: 0.5,
       },
-      style: 'number',
+      style: ThresholdStyle.NUMBER,
     };
   }
 
@@ -31,7 +32,7 @@ class SwipeHitCount extends HitCountAoE {
         average: 0.5,
         major: 3.0,
       },
-      style: 'number',
+      style: ThresholdStyle.NUMBER,
     };
   }
 

--- a/analysis/druidferal/src/modules/spells/ThrashHitCount.js
+++ b/analysis/druidferal/src/modules/spells/ThrashHitCount.js
@@ -1,9 +1,9 @@
 import { t } from '@lingui/macro';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import React from 'react';
-import { ThresholdStyle } from 'parser/core/ParseResults';
 
 import HitCountAoE from '../core/HitCountAoE';
 

--- a/analysis/druidferal/src/modules/spells/ThrashHitCount.js
+++ b/analysis/druidferal/src/modules/spells/ThrashHitCount.js
@@ -3,6 +3,7 @@ import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import React from 'react';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 
 import HitCountAoE from '../core/HitCountAoE';
 
@@ -18,7 +19,7 @@ class ThrashHitCount extends HitCountAoE {
         average: 0.2,
         major: 0.5,
       },
-      style: 'number',
+      style: ThresholdStyle.NUMBER,
     };
   }
 
@@ -30,7 +31,7 @@ class ThrashHitCount extends HitCountAoE {
         average: 0.5,
         major: 3.0,
       },
-      style: 'number',
+      style: ThresholdStyle.NUMBER,
     };
   }
 

--- a/analysis/druidferal/src/modules/spells/TigersFuryEnergy.js
+++ b/analysis/druidferal/src/modules/spells/TigersFuryEnergy.js
@@ -3,16 +3,16 @@ import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import Analyzer from 'parser/core/Analyzer';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 import React from 'react';
 
 import EnergyTracker from '../features/EnergyTracker';
 import Predator from '../talents/Predator';
-import { ThresholdStyle } from 'parser/core/ParseResults';
 
 class TigersFuryEnergy extends Analyzer {
   get shouldIgnoreEnergyWaste() {
     // If Predator is providing plenty of Tigers Fury resets it's no longer important to use them at the perfect time.
-    return  this.predator.active && this.predator.extraCastsPerMinute > 1.0;
+    return this.predator.active && this.predator.extraCastsPerMinute > 1.0;
   }
 
   get suggestionThresholds() {

--- a/analysis/druidferal/src/modules/spells/TigersFuryEnergy.js
+++ b/analysis/druidferal/src/modules/spells/TigersFuryEnergy.js
@@ -7,11 +7,12 @@ import React from 'react';
 
 import EnergyTracker from '../features/EnergyTracker';
 import Predator from '../talents/Predator';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 
 class TigersFuryEnergy extends Analyzer {
   get shouldIgnoreEnergyWaste() {
     // If Predator is providing plenty of Tigers Fury resets it's no longer important to use them at the perfect time.
-    return this.predator.active && this.predator.extraCastsPerMinute > 1.0;
+    return  this.predator.active && this.predator.extraCastsPerMinute > 1.0;
   }
 
   get suggestionThresholds() {
@@ -25,7 +26,7 @@ class TigersFuryEnergy extends Analyzer {
         average: 0.1,
         major: 0.25,
       },
-      style: 'percentage',
+      style: ThresholdStyle.PERCENTAGE,
     };
   }
 

--- a/analysis/druidferal/src/modules/spells/TigersFuryEnergy.tsx
+++ b/analysis/druidferal/src/modules/spells/TigersFuryEnergy.tsx
@@ -3,16 +3,30 @@ import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import Analyzer from 'parser/core/Analyzer';
-import { ThresholdStyle } from 'parser/core/ParseResults';
+import { BoolThreshold, ThresholdStyle, When } from 'parser/core/ParseResults';
 import React from 'react';
 
 import EnergyTracker from '../features/EnergyTracker';
 import Predator from '../talents/Predator';
 
 class TigersFuryEnergy extends Analyzer {
-  get shouldIgnoreEnergyWaste() {
+  static dependencies = {
+    energyTracker: EnergyTracker,
+    predator: Predator,
+  };
+
+  energyTracker!: EnergyTracker;
+  predator!: Predator;
+
+  get shouldIgnoreEnergyWaste(): BoolThreshold {
     // If Predator is providing plenty of Tigers Fury resets it's no longer important to use them at the perfect time.
-    return this.predator.active && this.predator.extraCastsPerMinute > 1.0;
+    return {
+      actual: this.predator.active && this.predator.extraCastsPerMinute > 1.0,
+      // This is a fake Thresholds object used to smuggle the above boolean into the Checklist
+      // TODO better way to do this?
+      isEqual: true,
+      style: ThresholdStyle.BOOLEAN,
+    };
   }
 
   get suggestionThresholds() {
@@ -30,12 +44,7 @@ class TigersFuryEnergy extends Analyzer {
     };
   }
 
-  static dependencies = {
-    energyTracker: EnergyTracker,
-    predator: Predator,
-  };
-
-  suggestions(when) {
+  suggestions(when: When) {
     if (this.shouldIgnoreEnergyWaste) {
       return;
     }

--- a/analysis/druidferal/src/modules/talents/Bloodtalons.js
+++ b/analysis/druidferal/src/modules/talents/Bloodtalons.js
@@ -8,6 +8,7 @@ import DonutChart from 'parser/ui/DonutChart';
 import Statistic from 'parser/ui/Statistic';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticsListBox';
 import React from 'react';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 
 const debug = false;
 
@@ -61,7 +62,7 @@ class Bloodtalons extends Analyzer {
         average: 0.5,
         major: 2.0,
       },
-      style: 'number',
+      style: ThresholdStyle.NUMBER,
     };
   }
 

--- a/analysis/druidferal/src/modules/talents/Bloodtalons.js
+++ b/analysis/druidferal/src/modules/talents/Bloodtalons.js
@@ -4,11 +4,11 @@ import HIT_TYPES from 'game/HIT_TYPES';
 import { SpellLink } from 'interface';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 import DonutChart from 'parser/ui/DonutChart';
 import Statistic from 'parser/ui/Statistic';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticsListBox';
 import React from 'react';
-import { ThresholdStyle } from 'parser/core/ParseResults';
 
 const debug = false;
 

--- a/analysis/druidferal/src/modules/talents/BrutalSlashHitCount.js
+++ b/analysis/druidferal/src/modules/talents/BrutalSlashHitCount.js
@@ -5,6 +5,7 @@ import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import React from 'react';
 
 import HitCountAoE from '../core/HitCountAoE';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 
 /**
  * Despite being an AoE ability Brutal Slash is usually the best talent on its row for single target fights.
@@ -19,7 +20,7 @@ class BrutalSlashHitCount extends HitCountAoE {
         average: 0.2,
         major: 0.5,
       },
-      style: 'number',
+      style: ThresholdStyle.NUMBER,
     };
   }
 

--- a/analysis/druidferal/src/modules/talents/BrutalSlashHitCount.js
+++ b/analysis/druidferal/src/modules/talents/BrutalSlashHitCount.js
@@ -1,11 +1,11 @@
 import { t } from '@lingui/macro';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import React from 'react';
 
 import HitCountAoE from '../core/HitCountAoE';
-import { ThresholdStyle } from 'parser/core/ParseResults';
 
 /**
  * Despite being an AoE ability Brutal Slash is usually the best talent on its row for single target fights.

--- a/analysis/druidferal/src/modules/talents/MoonfireSnapshot.js
+++ b/analysis/druidferal/src/modules/talents/MoonfireSnapshot.js
@@ -3,12 +3,12 @@ import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import { TooltipElement } from 'interface';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticsListBox';
 import React from 'react';
 
 import { MOONFIRE_FERAL_BASE_DURATION, PANDEMIC_FRACTION } from '../../constants';
 import Snapshot from '../core/Snapshot';
-import { ThresholdStyle } from 'parser/core/ParseResults';
 
 /**
  * Moonfire benefits from the damage bonus of Tiger's Fury over its whole duration, even if the

--- a/analysis/druidferal/src/modules/talents/MoonfireSnapshot.js
+++ b/analysis/druidferal/src/modules/talents/MoonfireSnapshot.js
@@ -8,6 +8,7 @@ import React from 'react';
 
 import { MOONFIRE_FERAL_BASE_DURATION, PANDEMIC_FRACTION } from '../../constants';
 import Snapshot from '../core/Snapshot';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 
 /**
  * Moonfire benefits from the damage bonus of Tiger's Fury over its whole duration, even if the
@@ -28,7 +29,7 @@ class MoonfireSnapshot extends Snapshot {
         average: 0.15,
         major: 0.6,
       },
-      style: 'percentage',
+      style: ThresholdStyle.PERCENTAGE,
     };
   }
 

--- a/analysis/druidferal/src/modules/talents/MoonfireUptime.js
+++ b/analysis/druidferal/src/modules/talents/MoonfireUptime.js
@@ -10,6 +10,7 @@ import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 
 class MoonfireUptime extends Analyzer {
   get uptime() {
@@ -24,7 +25,7 @@ class MoonfireUptime extends Analyzer {
         average: 0.9,
         major: 0.8,
       },
-      style: 'percentage',
+      style: ThresholdStyle.PERCENTAGE,
     };
   }
 

--- a/analysis/druidferal/src/modules/talents/MoonfireUptime.js
+++ b/analysis/druidferal/src/modules/talents/MoonfireUptime.js
@@ -5,12 +5,12 @@ import { SpellLink } from 'interface';
 import { TooltipElement } from 'interface';
 import UptimeIcon from 'interface/icons/Uptime';
 import Analyzer from 'parser/core/Analyzer';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 import Enemies from 'parser/shared/modules/Enemies';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
-import { ThresholdStyle } from 'parser/core/ParseResults';
 
 class MoonfireUptime extends Analyzer {
   get uptime() {

--- a/analysis/druidferal/src/modules/talents/Predator.js
+++ b/analysis/druidferal/src/modules/talents/Predator.js
@@ -3,6 +3,7 @@ import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
@@ -10,7 +11,6 @@ import React from 'react';
 
 import Abilities from '../Abilities';
 import SpellUsable from '../features/SpellUsable';
-import { ThresholdStyle } from 'parser/core/ParseResults';
 
 class Predator extends Analyzer {
   get baseCasts() {

--- a/analysis/druidferal/src/modules/talents/Predator.js
+++ b/analysis/druidferal/src/modules/talents/Predator.js
@@ -10,6 +10,7 @@ import React from 'react';
 
 import Abilities from '../Abilities';
 import SpellUsable from '../features/SpellUsable';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 
 class Predator extends Analyzer {
   get baseCasts() {
@@ -37,7 +38,7 @@ class Predator extends Analyzer {
         average: 0.5,
         major: 0.2,
       },
-      style: 'number',
+      style: ThresholdStyle.NUMBER,
     };
   }
 

--- a/analysis/druidferal/src/modules/talents/SavageRoar.js
+++ b/analysis/druidferal/src/modules/talents/SavageRoar.js
@@ -6,6 +6,7 @@ import { TooltipElement } from 'interface';
 import UptimeIcon from 'interface/icons/Uptime';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 import Enemies from 'parser/shared/modules/Enemies';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
@@ -15,7 +16,6 @@ import React from 'react';
 
 import { SAVAGE_ROAR_DAMAGE_BONUS } from '../../constants';
 import getDamageBonus from '../core/getDamageBonus';
-import { ThresholdStyle } from 'parser/core/ParseResults';
 
 /**
  * Since 8.0 only affects "cat" abilities.

--- a/analysis/druidferal/src/modules/talents/SavageRoar.js
+++ b/analysis/druidferal/src/modules/talents/SavageRoar.js
@@ -15,6 +15,7 @@ import React from 'react';
 
 import { SAVAGE_ROAR_DAMAGE_BONUS } from '../../constants';
 import getDamageBonus from '../core/getDamageBonus';
+import { ThresholdStyle } from 'parser/core/ParseResults';
 
 /**
  * Since 8.0 only affects "cat" abilities.
@@ -57,7 +58,7 @@ class SavageRoar extends Analyzer {
         average: 0.9,
         major: 0.8,
       },
-      style: 'percentage',
+      style: ThresholdStyle.PERCENTAGE,
     };
   }
 

--- a/src/common/SPELLS/druid.ts
+++ b/src/common/SPELLS/druid.ts
@@ -745,6 +745,11 @@ const spells = {
     name: 'Berserk',
     icon: 'ability_druid_berserk',
   },
+  BERSERK_BUFF: {
+    id: 343216,
+    name: 'Berserk',
+    icon: 'ability_druid_berserk',
+  },
   PROWL: {
     id: 5215,
     name: 'Prowl',

--- a/src/common/SPELLS/druid.ts
+++ b/src/common/SPELLS/druid.ts
@@ -89,6 +89,11 @@ const spells = {
     name: 'Wild Charge',
     icon: 'trade_archaeology_antleredcloakclasp',
   },
+  HEART_OF_THE_WILD: {
+    id: 108291,
+    name: 'Heart of the Wild',
+    icon: 'spell_holy_blessingofagility',
+  },
 
   //Affinity Spells
   //Moonkin-Balance


### PR DESCRIPTION
* Added items from Convoke the Spirits, Adaptive Swarm, and Heart of the Wild to the checklist
* Updated Checklist and all Threshold objects to be Typescript compliant
* Removed generic Adaptive Swarm cast efficiency requirement because most specs actually don't want to use it blindly on CD
* Fixed a bug where Berserk wasn't showing properly in the Combo Points tab