### PR TITLE
Feral Druid - Fixed display issues in energy cap tracker

### DIFF
--- a/analysis/druidferal/src/CHANGELOG.js
+++ b/analysis/druidferal/src/CHANGELOG.js
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 import React from 'react';
 
 export default [
+  change(date(2021, 5, 17), 'Fixed confusing display of energy wasted statistic / suggestion', Sref),
   change(date(2021, 5, 17), <>Updated the Checklist to include <SpellLink id={SPELLS.CONVOKE_SPIRITS.id} /> and <SpellLink id={SPELLS.HEART_OF_THE_WILD.id} /> cast efficiency
     and <SpellLink id={SPELLS.ADAPTIVE_SWARM.id} /> uptime. Fixed an issue where <SpellLink id={SPELLS.BERSERK_BUFF.id} /> showed incorrectly in the Combo Points tab.</>, Sref),
   change(date(2021, 5, 16), <>Added <SpellLink id={SPELLS.DRAUGHT_OF_DEEP_FOCUS.id} /> support</>, Sref),

--- a/analysis/druidferal/src/modules/features/EnergyCapTracker.js
+++ b/analysis/druidferal/src/modules/features/EnergyCapTracker.js
@@ -1,12 +1,14 @@
 import { t } from '@lingui/macro';
-import { formatPercentage } from 'common/format';
+import { formatPercentage, formatDuration } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import { Icon, Tooltip } from 'interface';
 import { ThresholdStyle } from 'parser/core/ParseResults';
 import RegenResourceCapTracker from 'parser/shared/modules/resources/resourcetracker/RegenResourceCapTracker';
 import BoringResourceValue from 'parser/ui/BoringResourceValue';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import StatisticBox from 'parser/ui/StatisticBox';
 import React from 'react';
 
 import SpellEnergyCost from './SpellEnergyCost';
@@ -28,13 +30,13 @@ const RESOURCE_REFUND_ON_MISS = 0.8;
  * Reduced drain cost from Berserk/Incarnation on Ferocious Bite is already applied in the log.
  */
 class EnergyCapTracker extends RegenResourceCapTracker {
-  get percentCapped() {
+  get percentNotCapped() {
     return (this.naturalRegen - this.missedRegen) / this.naturalRegen;
   }
 
   get suggestionThresholds() {
     return {
-      actual: this.percentCapped,
+      actual: this.percentNotCapped,
       isLessThan: {
         minor: 0.8,
         average: 0.7,
@@ -95,32 +97,50 @@ class EnergyCapTracker extends RegenResourceCapTracker {
             )}% regenerated energy lost per minute due to being capped.`,
           }),
         )
-        .recommended(`<${recommended}% is recommended.`),
+        .recommended(`<${formatPercentage(recommended)}% is recommended.`),
     );
   }
 
   statistic() {
     return (
-      <Statistic
+      <StatisticBox
+        position={STATISTIC_ORDER.CORE(1)}
+        icon={<Icon icon="spell_shadow_shadowworddominate" alt="Capped Energy" />}
+        value={`${formatPercentage(this.cappedProportion)}%`}
+        label="Time with capped energy"
         tooltip={
           <>
             Although it can be beneficial to wait and let your energy pool ready to be used at the
             right time, you should still avoid letting it reach the cap.
             <br />
-            You spent <strong>{formatPercentage(this.cappedProportion)}%</strong> of the fight at
-            capped energy, causing you to miss out on a total of{' '}
-            <strong>{this.missedRegen.toFixed(0)}</strong> energy from regeneration.
+            You spent <b>{formatPercentage(this.cappedProportion)}%</b> of the fight at capped
+            energy, causing you to miss out on <b>{this.missedRegenPerMinute.toFixed(1)}</b> energy
+            per minute from regeneration.
           </>
         }
-        size="flexible"
-        position={STATISTIC_ORDER.CORE(1)}
-      >
-        <BoringResourceValue
-          resource={RESOURCE_TYPES.ENERGY}
-          value={`${formatPercentage(this.percentCapped)}%`}
-          label="Wasted energy per minute from being capped"
-        />
-      </Statistic>
+        footer={
+          <div className="statistic-box-bar">
+            <Tooltip
+              content={`Not at capped energy for ${formatDuration(
+                (this.owner.fightDuration - this.atCap) / 1000,
+              )}`}
+            >
+              <div
+                className="stat-healing-bg"
+                style={{ width: `${(1 - this.cappedProportion) * 100}%` }}
+              >
+                <img src="/img/sword.png" alt="Uncapped Energy" />
+              </div>
+            </Tooltip>
+
+            <Tooltip content={`At capped energy for ${formatDuration(this.atCap / 1000)}`}>
+              <div className="remainder DeathKnight-bg">
+                <img src="/img/overhealing.png" alt="Capped Energy" />
+              </div>
+            </Tooltip>
+          </div>
+        }
+      />
     );
   }
 }


### PR DESCRIPTION
The existing Feral Druid energy cap tracker was confusing and appears to have its numbers inverted.

Below is what it currently looks like, note that 75.72% is actually the percent time NOT capped.
![image](https://user-images.githubusercontent.com/7143486/118502368-a2d55780-b6f7-11eb-9fc5-2b0228344aeb.png)

I swapped out the stats box for the same one currently used by Rogue and WW Monk modules, as I like the look of it. Below is what the same log looks like now:
![image](https://user-images.githubusercontent.com/7143486/118502538-ca2c2480-b6f7-11eb-9b54-597eb47de52d.png)

Note the numbers don't quite match because the calculation used is slightly changed - time based instead of amount based.
