### PR TITLE
Resto Druid - Added Grove Invigoration stat

### DIFF
--- a/analysis/druidrestoration/src/CHANGELOG.tsx
+++ b/analysis/druidrestoration/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SpellLink from 'interface/SpellLink';
 import React from 'react';
 
 export default [
+  change(date(2021, 5, 18), <>Added <SpellLink id={SPELLS.GROVE_INVIGORATION.id} /> support</>, Sref),
   change(date(2021, 5, 15), <>Improved cast detection and added healing attribution for <SpellLink id={SPELLS.CONVOKE_SPIRITS.id} /></>, Sref),
   change(date(2021, 5, 14), <>Added <SpellLink id={SPELLS.KINDRED_SPIRITS.id} /> support</>, Sref),
   change(date(2021, 5, 14), <>Added <SpellLink id={SPELLS.VERDANT_INFUSION.id} /> support</>, Sref),

--- a/analysis/druidrestoration/src/CombatLogParser.ts
+++ b/analysis/druidrestoration/src/CombatLogParser.ts
@@ -29,6 +29,7 @@ import HealingEfficiencyTracker from './modules/features/RestoDruidHealingEffici
 import StatWeights from './modules/features/StatWeights';
 import WildGrowth from './modules/features/WildGrowth';
 import ConfluxOfElementsResto from './modules/shadowlands/conduits/ConfluxOfElementsResto';
+import GroveInvigorationResto from './modules/shadowlands/conduits/GroveInvigorationResto';
 import EvolvedSwarmResto from './modules/shadowlands/conduits/EvolvedSwarmResto';
 import FlashOfClarity from './modules/shadowlands/conduits/FlashOfClarity';
 import AdaptiveSwarmResto from './modules/shadowlands/covenants/AdaptiveSwarmResto';
@@ -120,6 +121,8 @@ class CombatLogParser extends CoreCombatLogParser {
     flashOfClarity: FlashOfClarity,
     evolvedSwarmResto: EvolvedSwarmResto,
     confluxOfElementsResto: ConfluxOfElementsResto,
+    // Soulbind
+    groveInvigoration: GroveInvigorationResto,
 
     //legos
     visionOfUnendingGrowrth: VisionOfUnendingGrowrth,

--- a/analysis/druidrestoration/src/CombatLogParser.ts
+++ b/analysis/druidrestoration/src/CombatLogParser.ts
@@ -29,9 +29,9 @@ import HealingEfficiencyTracker from './modules/features/RestoDruidHealingEffici
 import StatWeights from './modules/features/StatWeights';
 import WildGrowth from './modules/features/WildGrowth';
 import ConfluxOfElementsResto from './modules/shadowlands/conduits/ConfluxOfElementsResto';
-import GroveInvigorationResto from './modules/shadowlands/conduits/GroveInvigorationResto';
 import EvolvedSwarmResto from './modules/shadowlands/conduits/EvolvedSwarmResto';
 import FlashOfClarity from './modules/shadowlands/conduits/FlashOfClarity';
+import GroveInvigorationResto from './modules/shadowlands/conduits/GroveInvigorationResto';
 import AdaptiveSwarmResto from './modules/shadowlands/covenants/AdaptiveSwarmResto';
 import ConvokeSpiritsResto from './modules/shadowlands/covenants/ConvokeSpiritsResto';
 import KindredSpiritsResto from './modules/shadowlands/covenants/KindredSpiritsResto';

--- a/analysis/druidrestoration/src/modules/core/Mastery.ts
+++ b/analysis/druidrestoration/src/modules/core/Mastery.ts
@@ -105,7 +105,9 @@ class Mastery extends Analyzer {
 
           this.buffAttributions[buffId].attributable += calculateEffectiveHealing(
             event,
-            decomposedHeal.relativeBuffBenefit(this.buffAttributions[buffId].buffAmount),
+            decomposedHeal.relativeBuffBenefit(
+              this.buffAttributions[buffId].buffAmount * buff.stacks,
+            ),
           );
         });
     } else {

--- a/analysis/druidrestoration/src/modules/shadowlands/conduits/GroveInvigorationResto.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/conduits/GroveInvigorationResto.tsx
@@ -1,13 +1,14 @@
-import Analyzer, { Options } from 'parser/core/Analyzer';
-import Mastery, { MasteryBuffAttribution } from '../../../modules/core/Mastery';
+import { formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
-import React from 'react';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
-import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
-import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
-import { formatNumber } from 'common/format';
+import React from 'react';
+
+import Mastery from '../../../modules/core/Mastery';
 
 /**
  * **Grove Invigoration**
@@ -55,9 +56,12 @@ class GroveInvigorationResto extends Analyzer {
         tooltip={
           <>
             This is the healing attributable to the mastery proc from Grove Invigoration.
-            <br/>
-            You averaged <strong>{this.avgStacks.toFixed(1)} stacks
-            / {formatNumber(this.avgRatingGain)} bonus mastery</strong> over the course of the encounter.
+            <br />
+            You averaged{' '}
+            <strong>
+              {this.avgStacks.toFixed(1)} stacks / {formatNumber(this.avgRatingGain)} bonus mastery
+            </strong>{' '}
+            over the course of the encounter.
           </>
         }
       >

--- a/analysis/druidrestoration/src/modules/shadowlands/conduits/GroveInvigorationResto.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/conduits/GroveInvigorationResto.tsx
@@ -1,0 +1,73 @@
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import Mastery, { MasteryBuffAttribution } from '../../../modules/core/Mastery';
+import SPELLS from 'common/SPELLS';
+import React from 'react';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
+import { formatNumber } from 'common/format';
+
+/**
+ * **Grove Invigoration**
+ * Soulbind Conduit - Night Fae
+ *
+ * Healing or dealing damage has a chance to grant you a stack of Redirected Anima.
+ * Redirected Anima increases your maximum health by 1% and your Mastery by 25 for 30 sec, and stacks overlap.
+ * Activating Convoke the Spirits grants you 16 stacks of Redirected Anima.
+ */
+class GroveInvigorationResto extends Analyzer {
+  static dependencies = {
+    mastery: Mastery,
+  };
+
+  protected mastery!: Mastery;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasSoulbindTrait(SPELLS.GROVE_INVIGORATION.id);
+  }
+
+  get totalHealing() {
+    const buffAtt = this.mastery.getBuffBenefit(SPELLS.REDIRECTED_ANIMA.id);
+    return buffAtt === undefined ? 0 : buffAtt.attributable;
+  }
+
+  get avgStacks() {
+    return (
+      this.selectedCombatant.getStackWeightedBuffUptime(SPELLS.REDIRECTED_ANIMA.id) /
+      this.owner.fightDuration
+    );
+  }
+
+  get avgRatingGain() {
+    const buffAtt = this.mastery.getBuffBenefit(SPELLS.REDIRECTED_ANIMA.id);
+    return buffAtt === undefined ? 0 : this.avgStacks * buffAtt.buffAmount;
+  }
+
+  statistic(): React.ReactNode {
+    return (
+      <Statistic
+        size="flexible"
+        position={STATISTIC_ORDER.OPTIONAL(100)}
+        category={STATISTIC_CATEGORY.COVENANTS}
+        tooltip={
+          <>
+            This is the healing attributable to the mastery proc from Grove Invigoration.
+            <br/>
+            You averaged <strong>{this.avgStacks.toFixed(1)} stacks
+            / {formatNumber(this.avgRatingGain)} bonus mastery</strong> over the course of the encounter.
+          </>
+        }
+      >
+        <BoringSpellValueText spell={SPELLS.GROVE_INVIGORATION}>
+          <ItemPercentHealingDone amount={this.totalHealing} />
+          <br />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default GroveInvigorationResto;

--- a/src/common/SPELLS/druid.ts
+++ b/src/common/SPELLS/druid.ts
@@ -95,6 +95,8 @@ const spells = {
     icon: 'spell_holy_blessingofagility',
   },
 
+  // shared items / conduits
+
   //Affinity Spells
   //Moonkin-Balance
   //The moonkin form granted by Balance Affinity

--- a/src/common/SPELLS/shadowlands/soulbinds/niya.ts
+++ b/src/common/SPELLS/shadowlands/soulbinds/niya.ts
@@ -4,7 +4,8 @@ const soulbindPowers = {
     name: 'Grove Invigoration',
     icon: 'ability_druid_manatree',
   },
-  REDIRECTED_ANIMA: { // Buff from the Grove Invigoration soulbind conduit
+  REDIRECTED_ANIMA: {
+    // Buff from the Grove Invigoration soulbind conduit
     id: 342814,
     name: 'Redirected Anima',
     icon: 'ability_druid_manatree',

--- a/src/common/SPELLS/shadowlands/soulbinds/niya.ts
+++ b/src/common/SPELLS/shadowlands/soulbinds/niya.ts
@@ -1,2 +1,13 @@
-const soulbindPowers = {} as const;
+const soulbindPowers = {
+  GROVE_INVIGORATION: {
+    id: 322721,
+    name: 'Grove Invigoration',
+    icon: 'ability_druid_manatree',
+  },
+  REDIRECTED_ANIMA: { // Buff from the Grove Invigoration soulbind conduit
+    id: 342814,
+    name: 'Redirected Anima',
+    icon: 'ability_druid_manatree',
+  },
+} as const;
 export default soulbindPowers;

--- a/src/parser/shared/modules/StatTracker.ts
+++ b/src/parser/shared/modules/StatTracker.ts
@@ -107,6 +107,10 @@ class StatTracker extends Analyzer {
     [SPELLS.FEAST_OF_GLUTTONOUS_HEDONISM_AGI.id]: { agility: 20 },
     //endregion
 
+    // region Conduits
+    [SPELLS.REDIRECTED_ANIMA.id]: { mastery: 25 },
+    // endregion
+
     // region Misc
     [SPELLS.JACINS_RUSE.id]: { mastery: 48 },
     [SPELLS.MARK_OF_THE_CLAW.id]: { crit: 45, haste: 45 },


### PR DESCRIPTION
Also added the mastery buff to StatTracker and fixed a bug in Resto Druid's Mastery module where it wasn't handling stacking buffs.