### PR TITLE
Resto Druid - Added Flourish to Cooldown Tracking

### DIFF
--- a/analysis/druidrestoration/src/CHANGELOG.tsx
+++ b/analysis/druidrestoration/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SpellLink from 'interface/SpellLink';
 import React from 'react';
 
 export default [
+  change(date(2021, 5, 18), <>Added an entry for <SpellLink id={SPELLS.FLOURISH_TALENT.id} /> on the Cooldowns tab</>, Sref),
   change(date(2021, 5, 15), <>Improved cast detection and added healing attribution for <SpellLink id={SPELLS.CONVOKE_SPIRITS.id} /></>, Sref),
   change(date(2021, 5, 14), <>Added <SpellLink id={SPELLS.KINDRED_SPIRITS.id} /> support</>, Sref),
   change(date(2021, 5, 14), <>Added <SpellLink id={SPELLS.VERDANT_INFUSION.id} /> support</>, Sref),

--- a/analysis/druidrestoration/src/modules/features/CooldownThroughputTracker.ts
+++ b/analysis/druidrestoration/src/modules/features/CooldownThroughputTracker.ts
@@ -14,6 +14,15 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
         BUILT_IN_SUMMARY_TYPES.MANA,
       ],
     },
+    {
+      spell: SPELLS.FLOURISH_TALENT,
+      summary: [
+        BUILT_IN_SUMMARY_TYPES.HEALING,
+        BUILT_IN_SUMMARY_TYPES.OVERHEALING,
+        BUILT_IN_SUMMARY_TYPES.MANA,
+      ],
+      startBufferMS: 12_000,
+    },
   ];
 }
 

--- a/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
+++ b/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
@@ -24,9 +24,6 @@ const spells: number[] = [
   SPELLS.CLOUDBURST_TOTEM_RECALL.id, // Cloudburst reactivation
   SPELLS.SPIRITWALKERS_GRACE.id,
 
-  //region Enchants
-  SPELLS.CELESTIAL_GUIDANCE_CAST.id, //Celestial Guidance enchant proc
-
   //endregion
 
   //region Consumables
@@ -35,6 +32,7 @@ const spells: number[] = [
 
   //region Enchants
   SPELLS.SINFUL_REVELATION_PROC.id,
+  SPELLS.CELESTIAL_GUIDANCE_CAST.id,
 
   //region Death Knight
   SPELLS.BREATH_OF_SINDRAGOSA_TALENT_DAMAGE_TICK.id,

--- a/src/parser/shared/modules/CooldownThroughputTracker.tsx
+++ b/src/parser/shared/modules/CooldownThroughputTracker.tsx
@@ -149,8 +149,9 @@ class CooldownThroughputTracker extends Analyzer {
       // Default to only including cast events by the player
       const filter = cooldownSpell.startBufferFilter || Events.cast.by(SELECTED_PLAYER);
       const ctor = this.constructor as typeof CooldownThroughputTracker;
-      events = this.eventHistory.last(cooldownSpell.startBufferEvents, startBufferMS, filter)
-        .filter(event => !ctor.ignoredSpells.includes(event.ability.guid));
+      events = this.eventHistory
+        .last(cooldownSpell.startBufferEvents, startBufferMS, filter)
+        .filter((event) => !ctor.ignoredSpells.includes(event.ability.guid));
       if (startBufferMS) {
         start = timestamp - startBufferMS;
       } else {

--- a/src/parser/shared/modules/CooldownThroughputTracker.tsx
+++ b/src/parser/shared/modules/CooldownThroughputTracker.tsx
@@ -52,7 +52,11 @@ export type CooldownSpell = {
 };
 
 export type TrackedCooldown = CooldownSpell & {
+  /** The timestamp to begin tracking events */
   start: number;
+  /** The timestamp the Cooldown was cast/applied */
+  cdStart: number;
+  /** The timestamp the Cooldown ends / we stop trakcing */
   end: number | null;
   events: AnyEvent[];
 };
@@ -138,12 +142,15 @@ class CooldownThroughputTracker extends Analyzer {
 
   addCooldown(cooldownSpell: CooldownSpell, timestamp: number): TrackedCooldown {
     let events: AnyEvent[] = [];
-    let start = timestamp;
+    const cdStart = timestamp;
+    let start = cdStart;
     const startBufferMS = cooldownSpell.startBufferMS;
     if (startBufferMS || cooldownSpell.startBufferEvents) {
       // Default to only including cast events by the player
       const filter = cooldownSpell.startBufferFilter || Events.cast.by(SELECTED_PLAYER);
-      events = this.eventHistory.last(cooldownSpell.startBufferEvents, startBufferMS, filter);
+      const ctor = this.constructor as typeof CooldownThroughputTracker;
+      events = this.eventHistory.last(cooldownSpell.startBufferEvents, startBufferMS, filter)
+        .filter(event => !ctor.ignoredSpells.includes(event.ability.guid));
       if (startBufferMS) {
         start = timestamp - startBufferMS;
       } else {
@@ -154,6 +161,7 @@ class CooldownThroughputTracker extends Analyzer {
     const cooldown = {
       ...cooldownSpell,
       start: start,
+      cdStart: cdStart,
       end: cooldownSpell.duration ? cooldownSpell.duration * 1000 + timestamp : null,
       events: events,
     };

--- a/src/parser/ui/Cooldown.js
+++ b/src/parser/ui/Cooldown.js
@@ -22,6 +22,7 @@ class Cooldown extends React.Component {
         icon: PropTypes.string.isRequired,
       }),
       start: PropTypes.number.isRequired,
+      cdStart: PropTypes.number.isRequired,
       end: PropTypes.number,
       events: PropTypes.arrayOf(
         PropTypes.shape({
@@ -114,12 +115,18 @@ class Cooldown extends React.Component {
     return { damageDone };
   }
 
+  formatRelativeTimestamp(event, cooldown) {
+    const relativeTimestamp = event.timestamp - cooldown.cdStart;
+    return ((relativeTimestamp > 0) ? "+" : "") + (relativeTimestamp / 1000).toFixed(3);
+  }
+
   render() {
     const { cooldown, fightStart, fightEnd } = this.props;
 
     let healingStatistics = null;
 
     const start = cooldown.start;
+    const cdStart = cooldown.cdStart;
     const end = cooldown.end || fightEnd;
 
     /* eslint-disable no-script-url */
@@ -135,7 +142,7 @@ class Cooldown extends React.Component {
           <div className={this.state.showAllEvents ? 'col-md-12' : 'col-md-6'}>
             <header style={{ marginTop: 5, fontSize: '1.25em', marginBottom: '.1em' }}>
               <SpellLink id={cooldown.spell.id} icon={false} /> (
-              {formatDuration((start - fightStart) / 1000)} -&gt;{' '}
+              {formatDuration((cdStart - fightStart) / 1000)} -&gt;{' '}
               {formatDuration((end - fightStart) / 1000)}) &nbsp;
               <TooltipElement
                 content={
@@ -192,7 +199,7 @@ class Cooldown extends React.Component {
                   .map((event, i) => (
                     <div className="row" key={i}>
                       <div className="col-xs-2 text-right" style={{ padding: 0 }}>
-                        +{((event.timestamp - cooldown.start) / 1000).toFixed(3)}
+                        {this.formatRelativeTimestamp(event, cooldown)}
                       </div>
                       <div className="col-xs-10">
                         <SpellLink
@@ -248,7 +255,7 @@ class Cooldown extends React.Component {
                   return (
                     <div className="row" key={i}>
                       <div className="col-xs-1 text-right" style={{ padding: 0 }}>
-                        +{((event.timestamp - cooldown.start) / 1000).toFixed(3)}
+                        {this.formatRelativeTimestamp(event, cooldown)}
                       </div>
                       <div
                         className={`col-xs-4 ${

--- a/src/parser/ui/Cooldown.js
+++ b/src/parser/ui/Cooldown.js
@@ -117,7 +117,7 @@ class Cooldown extends React.Component {
 
   formatRelativeTimestamp(event, cooldown) {
     const relativeTimestamp = event.timestamp - cooldown.cdStart;
-    return ((relativeTimestamp > 0) ? "+" : "") + (relativeTimestamp / 1000).toFixed(3);
+    return (relativeTimestamp > 0 ? '+' : '') + (relativeTimestamp / 1000).toFixed(3);
   }
 
   render() {

--- a/src/parser/ui/CooldownOverview.js
+++ b/src/parser/ui/CooldownOverview.js
@@ -32,6 +32,7 @@ CooldownOverview.propTypes = {
         icon: PropTypes.string.isRequired,
       }),
       start: PropTypes.number.isRequired,
+      cdStart: PropTypes.number.isRequired,
       end: PropTypes.number,
       events: PropTypes.arrayOf(
         PropTypes.shape({


### PR DESCRIPTION
Also updated cooldown tracking with startBufferMs option to index the actual CD cast from zero and to not include the buffer in the listed time period, and fixed a bug where cast events that were supposed to be filtered were being included in the buffer period.