### PR TITLE
Resto Druid - Updated Stat Boxes Part 2

### DIFF
--- a/analysis/druidrestoration/src/CHANGELOG.tsx
+++ b/analysis/druidrestoration/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SpellLink from 'interface/SpellLink';
 import React from 'react';
 
 export default [
+  change(date(2021, 5, 26), <>Reworked <SpellLink id={SPELLS.REGROWTH.id} /> and <SpellLink id={SPELLS.CLEARCASTING_BUFF.id} /> stats into a single box, and fixed some bugs in their display. Reworked display of average <SpellLink id={SPELLS.WILD_GROWTH.id} /> hits and fixed a bug where it was counting buffs from Convoke.</>, Sref),
   change(date(2021, 5, 26), <>Moved all talent related stat boxes to their own section, and combined <SpellLink id={SPELLS.LIFEBLOOM_HOT_HEAL.id} /> and <SpellLink id={SPELLS.EFFLORESCENCE_CAST.id} /> uptimes into a new graph.</>, Sref),
   change(date(2021, 5, 18), <>Added <SpellLink id={SPELLS.FIELD_OF_BLOSSOMS.id} /> support</>, Sref),
   change(date(2021, 5, 18), <>Added an entry for <SpellLink id={SPELLS.FLOURISH_TALENT.id} /> on the Cooldowns tab</>, Sref),

--- a/analysis/druidrestoration/src/CombatLogParser.ts
+++ b/analysis/druidrestoration/src/CombatLogParser.ts
@@ -18,7 +18,6 @@ import SpellManaCost from './modules/core/SpellManaCost';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import AverageHots from './modules/features/AverageHots';
 import Checklist from './modules/features/Checklist/Module';
-import Clearcasting from './modules/features/Clearcasting';
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
 import Efflorescence from './modules/features/Efflorescence';
 import Innervate from './modules/features/Innervate';
@@ -26,6 +25,7 @@ import Ironbark from './modules/features/Ironbark';
 import Lifebloom from './modules/features/Lifebloom';
 import LifebloomAndEffloUptime from './modules/features/LifebloomAndEffloUptime';
 import PrematureRejuvenations from './modules/features/PrematureRejuvenations';
+import RegrowthAndClearcasting from './modules/features/RegrowthAndClearcasting';
 import HealingEfficiencyTracker from './modules/features/RestoDruidHealingEfficiencyTracker';
 import StatWeights from './modules/features/StatWeights';
 import WildGrowth from './modules/features/WildGrowth';
@@ -90,7 +90,7 @@ class CombatLogParser extends CoreCombatLogParser {
     wildGrowth: WildGrowth,
     lifebloom: Lifebloom,
     efflorescence: Efflorescence,
-    clearcasting: Clearcasting,
+    clearcasting: RegrowthAndClearcasting,
     innervate: Innervate,
     springBlossoms: SpringBlossoms,
     cultivation: Cultivation,

--- a/analysis/druidrestoration/src/modules/features/AverageHots.tsx
+++ b/analysis/druidrestoration/src/modules/features/AverageHots.tsx
@@ -31,12 +31,12 @@ class AverageHots extends Analyzer {
             <br />
             This number should not be read as a measure of performance but rather of talent choices
             and healing style. Doing lots of tank healing will increase this number, as will
-            speccing Talents that spread extra HoTs around like Cultivation and Spring Blossoms.
-            On the other hand, playing in larger groups will tend to reduce average stacks.
+            speccing Talents that spread extra HoTs around like Cultivation and Spring Blossoms. On
+            the other hand, playing in larger groups will tend to reduce average stacks.
             <br />
             <br />
-            This number includes all your healing, even heals that don't benefit from mastery
-            (like most trinkets). Your average mastery stacks counting only heals that benefit from
+            This number includes all your healing, even heals that don't benefit from mastery (like
+            most trinkets). Your average mastery stacks counting only heals that benefit from
             mastery is <strong>{avgDruidHots}</strong>.
           </>
         }

--- a/analysis/druidrestoration/src/modules/features/Checklist/Component.tsx
+++ b/analysis/druidrestoration/src/modules/features/Checklist/Component.tsx
@@ -50,10 +50,11 @@ const RestorationDruidChecklist = ({ combatant, castEfficiency, thresholds }: Ch
         description={
           <>
             Effective use of <SpellLink id={SPELLS.WILD_GROWTH.id} /> is incredibly important to
-            your healing performance. When more than 5 raiders are wounded, it is probably the most
-            efficienct and effective spell you can cast. Try to time your{' '}
+            your healing performance. When more than 5 raiders are wounded, it is easily the most
+            efficient and effective spell you can cast. Try to time your{' '}
             <SpellLink id={SPELLS.WILD_GROWTH.id} /> cast to land just after a boss ability in order
-            to keep raiders healthy even through heavy AoE.
+            to keep raiders healthy even through heavy AoE. Most of its healing is frontloaded and
+            so it should not be precast.
           </>
         }
       >
@@ -73,17 +74,11 @@ const RestorationDruidChecklist = ({ combatant, castEfficiency, thresholds }: Ch
               Low target <SpellLink id={SPELLS.WILD_GROWTH.id} /> casts
             </>
           }
-          tooltip="This is your percent of Wild Growth casts that hit too few wounded targets. Low target casts happen either by casting it when almost all the raid was full health, or casting it on an isolated target. Remember that Wild Growth can only apply to players within 30 yds of the primary target, so if you use it on a target far away from the rest of the raid your cast will not be effective."
-          thresholds={thresholds.wildGrowthPercentBelowRecommendedCasts}
-        />
-        <Requirement
-          name={
-            <>
-              High initial overhealing <SpellLink id={SPELLS.WILD_GROWTH.id} />
-            </>
-          }
-          tooltip="This is your percent of Wild Growth casts that has high initial overhealing. Wild Growth does most of it's healing initially and declines over duration. Make sure you are not precasting it before damaging event but after damage occurs."
-          thresholds={thresholds.wildGrowthPercentBelowRecommendedPrecasts}
+          tooltip="This is your percent of Wild Growth casts that hit too few wounded targets.
+          Low target casts happen either by casting it when almost all the raid was full health,
+          or casting it on an isolated target. Remember that Wild Growth can only apply to players within 30 yds of the primary target,
+          so if you use it on a target far away from the rest of the raid your cast will not be effective."
+          thresholds={thresholds.wildGrowthPercentIneffectiveCasts}
         />
       </Rule>
       <Rule
@@ -169,7 +164,9 @@ const RestorationDruidChecklist = ({ combatant, castEfficiency, thresholds }: Ch
             </>
           }
           thresholds={thresholds.innervateManaSaved}
-          tooltip="All spells cost less mana during Innervate, so take care to chain cast for its duration. Typically this means casting a Wild Growth, refreshing Efflorescence, and spamming Rejuvenation. It's also fine to Regrowth a target that is in immediate danger of dying."
+          tooltip="All spells cost less mana during Innervate, so take care to chain cast for its duration.
+          Typically this means casting a Wild Growth, refreshing Efflorescence, and spamming Rejuvenation.
+          It's also fine to Regrowth a target that is in immediate danger of dying."
         />
         <Requirement
           name={
@@ -178,7 +175,9 @@ const RestorationDruidChecklist = ({ combatant, castEfficiency, thresholds }: Ch
             </>
           }
           thresholds={thresholds.clearCastingUtil}
-          tooltip="This is the percentage of Clearcasting procs that you used. Regrowth is normally very expensive, but it's completely free with a Clearcasting proc. Use your procs in a timely fashion for a lot of free healing."
+          tooltip="This is the percentage of Clearcasting procs that you used.
+          Regrowth is normally very expensive, but it's completely free with a Clearcasting proc.
+          Use your procs in a timely fashion for a lot of free healing."
         />
         <Requirement
           name={
@@ -186,13 +185,18 @@ const RestorationDruidChecklist = ({ combatant, castEfficiency, thresholds }: Ch
               Don't overuse <SpellLink id={SPELLS.REGROWTH.id} />
             </>
           }
-          thresholds={thresholds.nonCCRegrowths}
-          tooltip="This is the number of no-clearcasting Regrowths you cast per minute. Regrowth is very mana inefficient, and should only be used in emergency situations (and when you've already expended Swiftmend). Usually, you should rely on other healers in your raid to triage."
+          thresholds={thresholds.badRegrowths}
+          tooltip="This is the number of bad Regrowths you cast per minute.
+          Regrowth is very mana inefficient, and should only be cast when free due to clearcasting or innervate,
+          cheap due to many stacks of Abundance, or to save a low health target."
         />
         <Requirement
           name="Mana remaining at fight end"
           thresholds={thresholds.manaValues}
-          tooltip="Try to spend your mana at roughly the same rate the boss is dying. Having too much mana left at fight end could mean you were too conservative with your spell casts. If your mana is in good shape but there isn't much to heal, consider mixing Moonfire and Sunfire into your DPS rotation, which will burn some mana for extra DPS contribution."
+          tooltip="Try to spend your mana at roughly the same rate the boss is dying.
+          Having too much mana left at fight end could mean you were too conservative with your spell casts.
+          If your mana is in good shape but there isn't much to heal, consider mixing Moonfire and Sunfire into your DPS rotation,
+          which will burn some mana for extra DPS contribution."
         />
       </Rule>
       <Rule

--- a/analysis/druidrestoration/src/modules/features/Checklist/Module.tsx
+++ b/analysis/druidrestoration/src/modules/features/Checklist/Module.tsx
@@ -67,7 +67,7 @@ class Checklist extends BaseChecklist {
           innervateManaSaved: this.innervate.manaSavedThresholds,
           innervateSelfCasts: this.innervate.selfCastThresholds,
           clearCastingUtil: this.clearCasting.clearcastingUtilSuggestionThresholds,
-          nonCCRegrowths: this.clearCasting.nonCCRegrowthsSuggestionThresholds,
+          badRegrowths: this.clearCasting.badRegrowthsSuggestionThresholds,
           manaValues: this.manaValues.suggestionThresholds,
           cultivationPercent: this.cultivation.suggestionThresholds,
           springBlossomsPercent: this.springBlossoms.suggestionThresholds,

--- a/analysis/druidrestoration/src/modules/features/Checklist/Module.tsx
+++ b/analysis/druidrestoration/src/modules/features/Checklist/Module.tsx
@@ -58,10 +58,8 @@ class Checklist extends BaseChecklist {
           downtime: this.alwaysBeCasting.downtimeSuggestionThresholds,
           nonHealingTime: this.alwaysBeCasting.nonHealingTimeSuggestionThresholds,
           wildGrowthRatio: this.wildGrowth.suggestionThresholds,
-          wildGrowthPercentBelowRecommendedCasts: this.wildGrowth
-            .suggestionpercentBelowRecommendedCastsThresholds,
-          wildGrowthPercentBelowRecommendedPrecasts: this.wildGrowth
-            .suggestionpercentBelowRecommendedPrecastsThresholds,
+          wildGrowthPercentIneffectiveCasts: this.wildGrowth
+            .suggestionPercentIneffectiveCastsThresholds,
           lifebloomUpTime: this.lifebloom.suggestionThresholds,
           efflorescenceUpTime: this.efflorescence.suggestionThresholds,
           innervateManaSaved: this.innervate.manaSavedThresholds,

--- a/analysis/druidrestoration/src/modules/features/Checklist/Module.tsx
+++ b/analysis/druidrestoration/src/modules/features/Checklist/Module.tsx
@@ -9,10 +9,10 @@ import Cultivation from '../../talents/Cultivation';
 import SpringBlossoms from '../../talents/SpringBlossoms';
 import TreeOfLife from '../../talents/TreeOfLife';
 import AlwaysBeCasting from '../AlwaysBeCasting';
-import Clearcasting from '../Clearcasting';
 import Efflorescence from '../Efflorescence';
 import Innervate from '../Innervate';
 import Lifebloom from '../Lifebloom';
+import RegrowthAndClearcasting from '../RegrowthAndClearcasting';
 import WildGrowth from '../WildGrowth';
 import Component from './Component';
 
@@ -26,7 +26,7 @@ class Checklist extends BaseChecklist {
     lifebloom: Lifebloom,
     efflorescence: Efflorescence,
     innervate: Innervate,
-    clearCasting: Clearcasting,
+    regrowthAndClearcasting: RegrowthAndClearcasting,
     manaValues: ManaValues,
     cultivation: Cultivation,
     springBlossoms: SpringBlossoms,
@@ -41,7 +41,7 @@ class Checklist extends BaseChecklist {
   protected lifebloom!: Lifebloom;
   protected efflorescence!: Efflorescence;
   protected innervate!: Innervate;
-  protected clearCasting!: Clearcasting;
+  protected regrowthAndClearcasting!: RegrowthAndClearcasting;
   protected manaValues!: ManaValues;
   protected cultivation!: Cultivation;
   protected springBlossoms!: SpringBlossoms;
@@ -64,8 +64,8 @@ class Checklist extends BaseChecklist {
           efflorescenceUpTime: this.efflorescence.suggestionThresholds,
           innervateManaSaved: this.innervate.manaSavedThresholds,
           innervateSelfCasts: this.innervate.selfCastThresholds,
-          clearCastingUtil: this.clearCasting.clearcastingUtilSuggestionThresholds,
-          badRegrowths: this.clearCasting.badRegrowthsSuggestionThresholds,
+          clearCastingUtil: this.regrowthAndClearcasting.clearcastingUtilSuggestionThresholds,
+          badRegrowths: this.regrowthAndClearcasting.badRegrowthsSuggestionThresholds,
           manaValues: this.manaValues.suggestionThresholds,
           cultivationPercent: this.cultivation.suggestionThresholds,
           springBlossomsPercent: this.springBlossoms.suggestionThresholds,

--- a/analysis/druidrestoration/src/modules/features/Clearcasting.tsx
+++ b/analysis/druidrestoration/src/modules/features/Clearcasting.tsx
@@ -1,18 +1,18 @@
 import { t } from '@lingui/macro';
 import { formatPercentage } from 'common/format';
-import CrossIcon from 'interface/icons/Cross';
-import HealthIcon from 'interface/icons/Health';
-import UptimeIcon from 'interface/icons/Uptime';
 import SPELLS from 'common/SPELLS';
 import { SpellIcon } from 'interface';
 import { SpellLink } from 'interface';
+import CrossIcon from 'interface/icons/Cross';
+import HealthIcon from 'interface/icons/Health';
+import UptimeIcon from 'interface/icons/Uptime';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { ApplyBuffEvent, CastEvent, HealEvent, RefreshBuffEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
-import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 
 /** Health percent below which we consider a heal to be 'triage' */
 const TRIAGE_THRESHOLD = 0.4;
@@ -246,7 +246,7 @@ class Clearcasting extends Analyzer {
               </li>
               <li>
                 <HealthIcon /> Full Price Triage ({'<'}
-                {formatPercentage(TRIAGE_THRESHOLD, 0)}%) Casts:{' '}
+                {formatPercentage(TRIAGE_THRESHOLD, 0)}% HP) Casts:{' '}
                 <strong>{this.triageRegrowths}</strong>
               </li>
               <li>

--- a/analysis/druidrestoration/src/modules/features/RegrowthAndClearcasting.tsx
+++ b/analysis/druidrestoration/src/modules/features/RegrowthAndClearcasting.tsx
@@ -157,7 +157,10 @@ class RegrowthAndClearcasting extends Analyzer {
 
   get clearcastUtilPercent() {
     // return 100% when no clearcasts to avoid suggestion
-    return this.totalClearcasts === 0 ? 1 : this.usedClearcasts / this.totalClearcasts;
+    // clearcast still active at end shouldn't be counted in util, hence the subtraction from total
+    return this.totalClearcasts === 0
+      ? 1
+      : this.usedClearcasts / (this.totalClearcasts - this.endingClearcasts);
   }
 
   get badRegrowthsPerMinute() {

--- a/analysis/druidrestoration/src/modules/features/RestoDruidHealingEfficiencyTracker.ts
+++ b/analysis/druidrestoration/src/modules/features/RestoDruidHealingEfficiencyTracker.ts
@@ -57,7 +57,7 @@ class RestoDruidHealingEfficiencyTracker extends HealingEfficiencyTracker {
     // We don't want regrowth to get Hpm credit for healing that we didn't spend mana on.
     spellInfo.healingDone = this.regrowthAttributor.totalNonCCRegrowthHealing;
     spellInfo.overhealingDone = this.regrowthAttributor.totalNonCCRegrowthOverhealing;
-    spellInfo.casts = this.clearcasting.nonCCRegrowths;
+    spellInfo.casts = this.clearcasting.badRegrowths;
 
     return spellInfo;
   }

--- a/analysis/druidrestoration/src/modules/features/RestoDruidHealingEfficiencyTracker.ts
+++ b/analysis/druidrestoration/src/modules/features/RestoDruidHealingEfficiencyTracker.ts
@@ -10,7 +10,7 @@ import HealingDone from 'parser/shared/modules/throughput/HealingDone';
 
 import Abilities from '../Abilities';
 import RegrowthAttributor from '../core/hottracking/RegrowthAttributor';
-import Clearcasting from '../features/Clearcasting';
+import RegrowthAndClearcasting from '../features/RegrowthAndClearcasting';
 
 /*
     TODO:
@@ -29,7 +29,7 @@ class RestoDruidHealingEfficiencyTracker extends HealingEfficiencyTracker {
     // Custom dependencies
     abilities: Abilities,
     regrowthAttributor: RegrowthAttributor,
-    clearcasting: Clearcasting,
+    clearcasting: RegrowthAndClearcasting,
   };
 
   protected manaTracker!: ManaTracker;
@@ -41,7 +41,7 @@ class RestoDruidHealingEfficiencyTracker extends HealingEfficiencyTracker {
   // Custom dependencies
   protected abilities!: Abilities;
   protected regrowthAttributor!: RegrowthAttributor;
-  protected clearcasting!: Clearcasting;
+  protected clearcasting!: RegrowthAndClearcasting;
 
   getCustomSpellStats(spellInfo: SpellInfoDetails, spellId: number) {
     // If we have a spell that has custom logic for the healing/damage numbers, do that before the rest of our calculations.

--- a/analysis/druidrestoration/src/modules/features/WildGrowth.tsx
+++ b/analysis/druidrestoration/src/modules/features/WildGrowth.tsx
@@ -4,7 +4,7 @@ import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import { SpellIcon } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { ApplyBuffEvent, CastEvent, HealEvent } from 'parser/core/Events';
+import Events, { AnyEvent, ApplyBuffEvent, CastEvent, HealEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import HealingValue from 'parser/shared/modules/HealingValue';
@@ -13,41 +13,128 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
 
-const RECOMMENDED_HIT_THRESHOLD = 5;
-const PRECAST_PERIOD = 3000;
-const PRECAST_THRESHOLD = 0.5;
+/** Number of targets WG must effectively heal in order to be efficient */
+const RECOMMENDED_EFFECTIVE_TARGETS_THRESHOLD = 3;
+/** Max buffer in ms from WG cast to WG apply */
+const APPLY_BUFFER = 100;
+/** Max time after WG apply to watch for high overhealing */
+const OVERHEAL_BUFFER = 3000;
+/** Overheal percent within OVERHEAL_BUFFER of application that will count as 'too much' */
+const OVERHEAL_THRESHOLD = 0.5;
 
 class WildGrowth extends Analyzer {
+  static dependencies = {
+    abilityTracker: AbilityTracker,
+  };
+
+  abilityTracker!: AbilityTracker;
+
+  /** Timestamp of the most recent Wild Growth cast, or undefined if it's too long ago */
+  recentWgCastTimestamp: number | undefined;
+  /** Tracker for the overhealing on targets hit by a recent hardcast Wild Growth, indexed by targetID */
+  recentWgTargetHealing: { [key: number]: { total: number; overheal: number } } = {};
+
+  /** Total Wild Growth hardcasts (not tallied until the rest of the fields) */
+  totalCasts = 0;
+  /** Total Wild Growth HoTs applied by hardcasts */
+  totalHardcastHits = 0;
+  /** Total Wild Growth HoTs applied by hardcasts that didn't overheal too much early */
+  totalEffectiveHits = 0;
+  /** Wild Growth hardcasts that were 'ineffective' */
+  ineffectiveCasts = 0;
+  /** Wild Growth hardcasts that hit too many total targets (effective or not) */
+  tooFewHitsCasts = 0;
+  /** Wild Growth hardcasts that had too much early overhealing */
+  tooMuchOverhealCasts = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.WILD_GROWTH), this.onCastWg);
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.WILD_GROWTH),
+      this.onApplyBuffWg,
+    );
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.WILD_GROWTH), this.onHealWg);
+  }
+
+  onCastWg(event: CastEvent) {
+    this._tallyRecentCast(event); // make sure the previous cast is closed out
+    this.recentWgCastTimestamp = event.timestamp; // spin up a new one
+  }
+
+  onApplyBuffWg(event: ApplyBuffEvent) {
+    if (
+      this.recentWgCastTimestamp !== undefined &&
+      this.recentWgCastTimestamp + APPLY_BUFFER >= event.timestamp
+    ) {
+      this.recentWgTargetHealing[event.targetID] = { total: 0, overheal: 0 };
+    }
+  }
+
+  onHealWg(event: HealEvent) {
+    const recentWgHealTracker = this.recentWgTargetHealing[event.targetID];
+    if (recentWgHealTracker !== undefined) {
+      const healVal = new HealingValue(event.amount, event.absorbed, event.overheal);
+      recentWgHealTracker.total += healVal.raw;
+      recentWgHealTracker.overheal += healVal.overheal;
+    }
+  }
+
+  /**
+   * Closes out the 'recent cast' tallies if there is one open and enough time has passed
+   */
+  _tallyRecentCast(event: AnyEvent) {
+    if (
+      this.recentWgCastTimestamp !== undefined &&
+      this.recentWgCastTimestamp + OVERHEAL_BUFFER < event.timestamp
+    ) {
+      this.totalCasts += 1;
+      const hits = Object.values(this.recentWgTargetHealing);
+      const effectiveHits = hits.filter((wg) => wg.total * OVERHEAL_THRESHOLD > wg.overheal).length;
+      this.totalEffectiveHits += effectiveHits;
+
+      if (effectiveHits < RECOMMENDED_EFFECTIVE_TARGETS_THRESHOLD) {
+        this.ineffectiveCasts += 1;
+        if (hits.length - effectiveHits >= 2) {
+          this.tooMuchOverhealCasts += 1;
+        }
+        if (hits.length < RECOMMENDED_EFFECTIVE_TARGETS_THRESHOLD) {
+          this.tooFewHitsCasts += 1;
+        }
+      }
+
+      this.recentWgCastTimestamp = undefined;
+      this.recentWgTargetHealing = {};
+    }
+  }
+
   get averageEffectiveHits() {
-    return this.wgHistory.reduce((a, b) => a + b.wgBuffs.length, 0) / this.wgs || 0;
+    return this.totalEffectiveHits / this.totalCasts || 0;
   }
 
-  get belowRecommendedCasts() {
-    return this.wgHistory.filter((wg) => wg.wgBuffs.length < RECOMMENDED_HIT_THRESHOLD).length;
-  }
-
-  get belowRecommendedPrecasts() {
-    return this.wgHistory.filter((wg) => wg.badPrecast === true).length;
-  }
-
-  get wgs() {
+  // different from totalCasts because this doesn't consider tallying - used only for ratio vs rejuv
+  get actualWgCasts() {
     return this.abilityTracker.getAbility(SPELLS.WILD_GROWTH.id).casts || 0;
   }
 
-  get rejuvs() {
+  get actualRejuvCasts() {
     return this.abilityTracker.getAbility(SPELLS.REJUVENATION.id).casts || 0;
   }
 
   get wgsPerRejuv() {
-    return this.wgs / this.rejuvs || 0;
+    return this.actualWgCasts / this.actualRejuvCasts || 0;
   }
 
-  get percentBelowRecommendedCasts() {
-    return this.belowRecommendedCasts / this.wgs || 0;
+  get percentIneffectiveCasts() {
+    return this.ineffectiveCasts / this.totalCasts || 0;
   }
 
-  get percentBelowRecommendedPrecasts() {
-    return this.belowRecommendedPrecasts / this.wgs || 0;
+  get percentTooFewTargetCasts() {
+    return this.tooFewHitsCasts / this.totalCasts || 0;
+  }
+
+  get percentTooMuchOverhealCasts() {
+    return this.tooMuchOverhealCasts / this.totalCasts || 0;
   }
 
   get suggestionThresholds() {
@@ -62,9 +149,9 @@ class WildGrowth extends Analyzer {
     };
   }
 
-  get suggestionpercentBelowRecommendedCastsThresholds() {
+  get suggestionPercentIneffectiveCastsThresholds() {
     return {
-      actual: this.percentBelowRecommendedCasts,
+      actual: this.percentIneffectiveCasts,
       isGreaterThan: {
         minor: 0.0,
         average: 0.15,
@@ -74,113 +161,17 @@ class WildGrowth extends Analyzer {
     };
   }
 
-  get suggestionpercentBelowRecommendedPrecastsThresholds() {
-    return {
-      actual: this.percentBelowRecommendedPrecasts,
-      isGreaterThan: {
-        minor: 0.05,
-        average: 0.15,
-        major: 0.35,
-      },
-      style: ThresholdStyle.PERCENTAGE,
-    };
-  }
-
-  static dependencies = {
-    abilityTracker: AbilityTracker,
-  };
-
-  abilityTracker!: AbilityTracker;
-
-  wgHistory: WGTracker[] = [];
-  wgTracker: WGTracker = {
-    wgBuffs: [],
-    startTimestamp: 0,
-    heal: 0,
-    overheal: 0,
-    firstTicksOverheal: 0,
-    firstTicksRaw: 0,
-  };
-
-  constructor(options: Options) {
-    super(options);
-    this.wgTracker.startTimestamp = this.owner.fight.start_time;
-    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.WILD_GROWTH), this.onCast);
-    this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.WILD_GROWTH), this.onHeal);
-    this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.WILD_GROWTH),
-      this.onApplyBuff,
-    );
-    this.addEventListener(Events.fightend, this.onFightend);
-  }
-
-  onCast(event: CastEvent) {
-    if (this.wgTracker.wgBuffs.length > 0) {
-      this.wgTracker.badPrecast =
-        this.wgTracker.firstTicksOverheal / this.wgTracker.firstTicksRaw > PRECAST_THRESHOLD;
-      this.wgHistory.push(this.wgTracker);
-    }
-
-    this.wgTracker = {
-      wgBuffs: [],
-      startTimestamp: event.timestamp,
-      heal: 0,
-      overheal: 0,
-      firstTicksOverheal: 0,
-      firstTicksRaw: 0,
-    };
-  }
-
-  onHeal(event: HealEvent) {
-    const healVal = new HealingValue(event.amount, event.absorbed, event.overheal);
-    this.wgTracker.heal += healVal.effective;
-    this.wgTracker.overheal += healVal.overheal;
-
-    // Track overhealing first couple ticks to determine if WG was precast before damaging event.
-    if (event.timestamp - this.wgTracker.startTimestamp < PRECAST_PERIOD) {
-      this.wgTracker.firstTicksRaw += healVal.raw;
-      this.wgTracker.firstTicksOverheal += healVal.overheal;
-    }
-  }
-
-  onApplyBuff(event: ApplyBuffEvent) {
-    this.wgTracker.wgBuffs.push(event.targetID);
-  }
-
-  onFightend() {
-    this.wgHistory.push(this.wgTracker);
-  }
-
   suggestions(when: When) {
-    when(this.suggestionpercentBelowRecommendedPrecastsThresholds).addSuggestion(
-      (suggest, actual, recommended) =>
-        suggest(
-          <>
-            Your initial healing from <SpellLink id={SPELLS.WILD_GROWTH.id} /> were doing too much
-            overhealing. <SpellLink id={SPELLS.WILD_GROWTH.id} /> does most of it's healing
-            initially and declines over duration. Make sure you are not precasting it before
-            damaging event but after damage occurs.
-          </>,
-        )
-          .icon(SPELLS.WILD_GROWTH.icon)
-          .actual(
-            t({
-              id: 'druid.restoration.suggestions.wildgrowth.overhealing',
-              message: `${formatPercentage(actual)}% of casts with high overhealing.`,
-            }),
-          )
-          .recommended(`<${formatPercentage(recommended)}% is recommended`),
-    );
-    when(this.suggestionpercentBelowRecommendedCastsThresholds).addSuggestion((suggest) =>
+    when(this.suggestionPercentIneffectiveCastsThresholds).addSuggestion((suggest) =>
       suggest(
         <>
-          You sometimes cast <SpellLink id={SPELLS.WILD_GROWTH.id} /> on too few targets.{' '}
-          <SpellLink id={SPELLS.WILD_GROWTH.id} /> is not mana efficient when hitting few targets,
-          you should only cast it when you can hit at least {RECOMMENDED_HIT_THRESHOLD} wounded
-          targets. Make sure you are not casting on a primary target isolated from the raid.{' '}
-          <SpellLink id={SPELLS.WILD_GROWTH.id} /> has a maximum hit radius, the injured raiders
-          could have been out of range. Also, you should never pre-hot with{' '}
-          <SpellLink id={SPELLS.WILD_GROWTH.id} />.
+          You sometimes hit too few injured targets with your{' '}
+          <SpellLink id={SPELLS.WILD_GROWTH.id} /> casts. Wild Growth is not mana efficient when
+          hitting few targets, you should only cast it when you can hit at least{' '}
+          {RECOMMENDED_EFFECTIVE_TARGETS_THRESHOLD} wounded targets. Make sure you are not casting
+          on a primary target isolated from the raid, as it can only hit targets within 30 yds of
+          the primary. Make sure you are not pre-casting on targets before they are hurt, as Wild
+          Growth is a brief HoT and most of its healing is frontloaded.
         </>,
       )
         .icon(SPELLS.WILD_GROWTH.icon)
@@ -188,12 +179,14 @@ class WildGrowth extends Analyzer {
           t({
             id: 'druid.restoration.suggestions.wildgrowth.tooFewTargets',
             message: `${formatPercentage(
-              this.percentBelowRecommendedCasts,
+              this.percentIneffectiveCasts,
               0,
-            )}% of your casts on fewer than ${RECOMMENDED_HIT_THRESHOLD} targets.`,
+            )}% of your casts were effective on fewer than ${RECOMMENDED_EFFECTIVE_TARGETS_THRESHOLD} targets.`,
           }),
         )
-        .recommended(`never casting on fewer than ${RECOMMENDED_HIT_THRESHOLD} is recommended`),
+        .recommended(
+          `never casting on fewer than ${RECOMMENDED_EFFECTIVE_TARGETS_THRESHOLD} wounded targets is recommended`,
+        ),
     );
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
       suggest(
@@ -206,7 +199,7 @@ class WildGrowth extends Analyzer {
         .actual(
           t({
             id: 'druid.restoration.suggestions.wildgrowth.rejuvenationRatio',
-            message: `${this.wgs} WGs / ${this.rejuvs} rejuvs`,
+            message: `${this.actualWgCasts} WGs / ${this.actualRejuvCasts} rejuvs`,
           }),
         )
         .recommended(`>${formatPercentage(recommended)}% is recommended`),
@@ -220,34 +213,28 @@ class WildGrowth extends Analyzer {
         position={STATISTIC_ORDER.CORE(19)}
         tooltip={
           <>
-            Your Wild Growth hit on average {this.averageEffectiveHits.toFixed(2)} players.
-            {this.belowRecommendedCasts} of your cast(s) hit fewer than 5 players which is the
-            recommended targets.
+            This is the average number of effective hits per Wild Growth cast. Because its healing
+            is so frontloaded, we consider a hit effective only if it does less than{' '}
+            {formatPercentage(OVERHEAL_THRESHOLD, 0)}% overhealing over its first{' '}
+            {(OVERHEAL_BUFFER / 1000).toFixed(0)} seconds.
+            <br /> <br />
+            This statistic only considers hardcasts, Wild Growths procced by Convoke the Spirits are
+            ignored.
           </>
         }
       >
         <BoringValue
           label={
             <>
-              <SpellIcon id={SPELLS.WILD_GROWTH.id} /> Average Wild Growth Hits
+              <SpellIcon id={SPELLS.WILD_GROWTH.id} /> Average Effective Wild Growth Hits
             </>
           }
         >
-          <>{this.averageEffectiveHits.toFixed(2)}</>
+          <>{this.averageEffectiveHits.toFixed(1)}</>
         </BoringValue>
       </Statistic>
     );
   }
-}
-
-interface WGTracker {
-  wgBuffs: number[];
-  startTimestamp: number;
-  heal: number;
-  overheal: number;
-  firstTicksOverheal: number;
-  firstTicksRaw: number;
-  badPrecast?: boolean;
 }
 
 export default WildGrowth;

--- a/analysis/druidrestoration/src/modules/features/WildGrowth.tsx
+++ b/analysis/druidrestoration/src/modules/features/WildGrowth.tsx
@@ -22,6 +22,13 @@ const OVERHEAL_BUFFER = 3000;
 /** Overheal percent within OVERHEAL_BUFFER of application that will count as 'too much' */
 const OVERHEAL_THRESHOLD = 0.5;
 
+/**
+ * Tracks stats relating to Wild Growth
+ *
+ * This modules functioning relies on normalizers that ensure:
+ * * Wild Growth cast will always come before Wild Growth HoT apply
+ * * Wild Growth HoT apply will always come before Wild Growth first heal
+ */
 class WildGrowth extends Analyzer {
   static dependencies = {
     abilityTracker: AbilityTracker,


### PR DESCRIPTION
* Combined the Clearcasting and Regrowth stats into one box, fixed a bug in the cast tracking, and rewrote the module to be simpler. Now that MoC no longer exists the code doesn't need to be as complex.
* Rewrote the Wild Growth tracking to be simpler, and combined the 'targets hit' and 'high overhealing' checks into one 'effective targets hit' stat.
![combined-regrowth-stat](https://user-images.githubusercontent.com/7143486/119742401-bdc16d80-be55-11eb-88d7-a98b3d048808.png)
![new-wg-tooltip](https://user-images.githubusercontent.com/7143486/119742402-bdc16d80-be55-11eb-8024-e24a674d2bff.png)
![new-wg-stat](https://user-images.githubusercontent.com/7143486/119742403-bdc16d80-be55-11eb-80ef-be92794e74ac.png)
![combined-regrowth-tooltip](https://user-images.githubusercontent.com/7143486/119742404-be5a0400-be55-11eb-8665-d9a05a733e07.png)
