### PR TITLE
Refactored formatDuration to take milliseconds LIKE EVERYONE ELSE

### DIFF
--- a/analysis/deathknight/src/RuneTracker.js
+++ b/analysis/deathknight/src/RuneTracker.js
@@ -382,7 +382,7 @@ class RuneTracker extends ResourceTracker {
                   .map((value, index) => (
                     <tr key={index}>
                       <th>{index}</th>
-                      <td>{formatDuration(this._runesReadySum[index] / 1000)}</td>
+                      <td>{formatDuration(this._runesReadySum[index])}</td>
                       <td>{formatPercentage(timeSpentAtRuneCount[index])}%</td>
                     </tr>
                   ))
@@ -392,7 +392,7 @@ class RuneTracker extends ResourceTracker {
                 .map((value, index) => (
                   <tr key={index + badThreshold}>
                     <th style={{ color: 'red' }}>{index + badThreshold}</th>
-                    <td>{formatDuration(this._runesReadySum[index + badThreshold] / 1000)}</td>
+                    <td>{formatDuration(this._runesReadySum[index + badThreshold])}</td>
                     <td>{formatPercentage(timeSpentAtRuneCount[index + badThreshold])}%</td>
                   </tr>
                 ))}

--- a/analysis/deathknightblood/src/modules/features/BoneShield.js
+++ b/analysis/deathknightblood/src/modules/features/BoneShield.js
@@ -70,7 +70,7 @@ class BoneShield extends Analyzer {
                 {Object.values(this.boneShieldTimesByStack).map((e, i) => (
                   <tr key={i}>
                     <th>{i}</th>
-                    <td>{formatDuration(e.reduce((a, b) => a + b, 0) / 1000)}</td>
+                    <td>{formatDuration(e.reduce((a, b) => a + b, 0))}</td>
                     <td>
                       {formatPercentage(e.reduce((a, b) => a + b, 0) / this.owner.fightDuration)}%
                     </td>

--- a/analysis/deathknightblood/src/modules/talents/FoulBulwark.js
+++ b/analysis/deathknightblood/src/modules/talents/FoulBulwark.js
@@ -49,7 +49,7 @@ class FoulBulwark extends Analyzer {
             {this.boneShieldTimesByStack.map((e, i) => (
               <tr key={i}>
                 <th>{(i * HP_PER_BONE_SHIELD_STACK * 100).toFixed(0)}%</th>
-                <td>{formatDuration(e.reduce((a, b) => a + b, 0) / 1000)}</td>
+                <td>{formatDuration(e.reduce((a, b) => a + b, 0))}</td>
                 <td>
                   {formatPercentage(e.reduce((a, b) => a + b, 0) / this.owner.fightDuration)}%
                 </td>

--- a/analysis/demonhunterhavoc/src/modules/spells/MetaBuffUptime.js
+++ b/analysis/demonhunterhavoc/src/modules/spells/MetaBuffUptime.js
@@ -28,9 +28,7 @@ class MetaBuffUptime extends Analyzer {
       <Statistic
         position={STATISTIC_ORDER.CORE(3)}
         size="flexible"
-        tooltip={`The Metamorphosis buff total uptime was ${formatDuration(
-          this.buffDuration,
-        )}.`}
+        tooltip={`The Metamorphosis buff total uptime was ${formatDuration(this.buffDuration)}.`}
       >
         <BoringSpellValueText spell={SPELLS.METAMORPHOSIS_HAVOC_BUFF}>
           <>

--- a/analysis/demonhunterhavoc/src/modules/spells/MetaBuffUptime.js
+++ b/analysis/demonhunterhavoc/src/modules/spells/MetaBuffUptime.js
@@ -29,7 +29,7 @@ class MetaBuffUptime extends Analyzer {
         position={STATISTIC_ORDER.CORE(3)}
         size="flexible"
         tooltip={`The Metamorphosis buff total uptime was ${formatDuration(
-          this.buffDuration / 1000,
+          this.buffDuration,
         )}.`}
       >
         <BoringSpellValueText spell={SPELLS.METAMORPHOSIS_HAVOC_BUFF}>

--- a/analysis/demonhunterhavoc/src/modules/talents/Momentum.js
+++ b/analysis/demonhunterhavoc/src/modules/talents/Momentum.js
@@ -63,7 +63,7 @@ class Momentum extends Analyzer {
       <Statistic
         position={STATISTIC_ORDER.CORE(3)}
         size="flexible"
-        tooltip={`The Momentum buff total uptime was ${formatDuration(this.buffDuration / 1000)}.`}
+        tooltip={`The Momentum buff total uptime was ${formatDuration(this.buffDuration)}.`}
       >
         <BoringSpellValueText spell={SPELLS.MOMENTUM_TALENT}>
           <>

--- a/analysis/demonhuntervengeance/src/modules/spells/ImmolationAura.js
+++ b/analysis/demonhuntervengeance/src/modules/spells/ImmolationAura.js
@@ -29,7 +29,7 @@ class ImmolationAura extends Analyzer {
         tooltip={
           <>
             The Immolation Aura total damage was {formatThousands(this.immolationAuraDamage)}.<br />
-            The Immolation Aura total uptime was {formatDuration(immolationAuraUptime / 1000)}
+            The Immolation Aura total uptime was {formatDuration(immolationAuraUptime)}
           </>
         }
       >

--- a/analysis/demonhuntervengeance/src/modules/spells/SigilOfFlame.js
+++ b/analysis/demonhuntervengeance/src/modules/spells/SigilOfFlame.js
@@ -64,7 +64,7 @@ class SigilOfFlame extends Analyzer {
             <br />
             <br />
             Sigil of Flame uptime: {formatPercentage(sigilOfFlameUptimePercentage)}% / (
-            {formatDuration(sigilOfFlameUptime / 1000)})<br />
+            {formatDuration(sigilOfFlameUptime)})<br />
             Sigil of Flame total damage: {formatThousands(sigilOfFlameDamage)}.
           </>
         }

--- a/analysis/demonhuntervengeance/src/modules/talents/SpiritBombFrailtyDebuff.js
+++ b/analysis/demonhuntervengeance/src/modules/talents/SpiritBombFrailtyDebuff.js
@@ -73,7 +73,7 @@ class SpiritBombFrailtyDebuff extends Analyzer {
         tooltip={
           <>
             Total damage was {formatThousands(spiritBombDamage)}.<br />
-            Total uptime was {formatDuration(spiritBombUptime / 1000)}.
+            Total uptime was {formatDuration(spiritBombUptime)}.
           </>
         }
       >

--- a/analysis/druidbalance/src/modules/talents/Starlord.tsx
+++ b/analysis/druidbalance/src/modules/talents/Starlord.tsx
@@ -92,7 +92,7 @@ class Starlord extends Analyzer {
                 {this.buffStacks.map((e, i) => (
                   <tr key={i}>
                     <th>{(i * HASTE_PER_STACK).toFixed(0)}%</th>
-                    <td>{formatDuration(e.reduce((a, b) => a + b, 0) / 1000)}</td>
+                    <td>{formatDuration(e.reduce((a, b) => a + b, 0))}</td>
                     <td>
                       {formatPercentage(e.reduce((a, b) => a + b, 0) / this.owner.fightDuration)}%
                     </td>

--- a/analysis/druidferal/src/modules/features/EnergyCapTracker.js
+++ b/analysis/druidferal/src/modules/features/EnergyCapTracker.js
@@ -122,7 +122,7 @@ class EnergyCapTracker extends RegenResourceCapTracker {
           <div className="statistic-box-bar">
             <Tooltip
               content={`Not at capped energy for ${formatDuration(
-                (this.owner.fightDuration - this.atCap) / 1000,
+                (this.owner.fightDuration - this.atCap),
               )}`}
             >
               <div
@@ -133,7 +133,7 @@ class EnergyCapTracker extends RegenResourceCapTracker {
               </div>
             </Tooltip>
 
-            <Tooltip content={`At capped energy for ${formatDuration(this.atCap / 1000)}`}>
+            <Tooltip content={`At capped energy for ${formatDuration(this.atCap)}`}>
               <div className="remainder DeathKnight-bg">
                 <img src="/img/overhealing.png" alt="Capped Energy" />
               </div>

--- a/analysis/druidferal/src/modules/features/EnergyCapTracker.js
+++ b/analysis/druidferal/src/modules/features/EnergyCapTracker.js
@@ -122,7 +122,7 @@ class EnergyCapTracker extends RegenResourceCapTracker {
           <div className="statistic-box-bar">
             <Tooltip
               content={`Not at capped energy for ${formatDuration(
-                (this.owner.fightDuration - this.atCap),
+                this.owner.fightDuration - this.atCap,
               )}`}
             >
               <div

--- a/analysis/druidguardian/src/modules/features/AntiFillerSpam.js
+++ b/analysis/druidguardian/src/modules/features/AntiFillerSpam.js
@@ -75,7 +75,7 @@ class AntiFillerSpam extends Analyzer {
     debug &&
       console.group(
         `[FILLER SPELL] - ${spellId} ${SPELLS[spellId].name} - ${formatDuration(
-          (event.timestamp - this.owner.fight.start_time) / 1000,
+          (event.timestamp - this.owner.fight.start_time),
         )}`,
       );
 

--- a/analysis/druidguardian/src/modules/features/AntiFillerSpam.js
+++ b/analysis/druidguardian/src/modules/features/AntiFillerSpam.js
@@ -75,7 +75,7 @@ class AntiFillerSpam extends Analyzer {
     debug &&
       console.group(
         `[FILLER SPELL] - ${spellId} ${SPELLS[spellId].name} - ${formatDuration(
-          (event.timestamp - this.owner.fight.start_time),
+          event.timestamp - this.owner.fight.start_time,
         )}`,
       );
 

--- a/analysis/hunterbeastmastery/src/modules/spells/BarbedShot.tsx
+++ b/analysis/hunterbeastmastery/src/modules/spells/BarbedShot.tsx
@@ -233,7 +233,7 @@ class BarbedShot extends Analyzer {
                 {Object.values(this.barbedShotTimesByStacks).map((e, i) => (
                   <tr key={i}>
                     <th>{i}</th>
-                    <td>{formatDuration(e.reduce((a: number, b: number) => a + b, 0) / 1000)}</td>
+                    <td>{formatDuration(e.reduce((a: number, b: number) => a + b, 0))}</td>
                     <td>
                       {formatPercentage(
                         e.reduce((a: number, b: number) => a + b, 0) / this.owner.fightDuration,

--- a/analysis/hunterbeastmastery/src/modules/talents/ThrillOfTheHunt.tsx
+++ b/analysis/hunterbeastmastery/src/modules/talents/ThrillOfTheHunt.tsx
@@ -104,7 +104,7 @@ class ThrillOfTheHunt extends Analyzer {
                 {Object.values(this.thrillOfTheHuntTimesByStacks).map((e, i) => (
                   <tr key={i}>
                     <th>{i}</th>
-                    <td>{formatDuration(e.reduce((a, b) => a + b, 0) / 1000)}</td>
+                    <td>{formatDuration(e.reduce((a, b) => a + b, 0))}</td>
                     <td>
                       {formatPercentage(e.reduce((a, b) => a + b, 0) / this.owner.fightDuration)}%
                     </td>

--- a/analysis/huntermarksmanship/src/modules/talents/CarefulAim.tsx
+++ b/analysis/huntermarksmanship/src/modules/talents/CarefulAim.tsx
@@ -152,7 +152,7 @@ class CarefulAim extends ExecuteHelper {
                     <td>
                       {boss[0] === 'Adds'
                         ? 'N/A'
-                        : formatDuration((boss[1].timestampSub70 - boss[1].timestampSub100) / 1000)}
+                        : formatDuration(boss[1].timestampSub70 - boss[1].timestampSub100)}
                     </td>
                   </tr>
                 ))}

--- a/analysis/huntersurvival/src/modules/talents/WildfireInfusion/VolatileBomb.tsx
+++ b/analysis/huntersurvival/src/modules/talents/WildfireInfusion/VolatileBomb.tsx
@@ -183,8 +183,8 @@ class VolatileBomb extends Analyzer {
               <tbody>
                 <tr>
                   <td>{this.extendedSerpentStings}</td>
-                  <td>{formatDuration(this.extendedInMs / this.casts / 1000)}</td>
-                  <td>{formatDuration(this.extendedInMs / 1000)}</td>
+                  <td>{formatDuration(this.extendedInMs / this.casts)}</td>
+                  <td>{formatDuration(this.extendedInMs)}</td>
                   <td>{this.focusSaved}</td>
                   <td>{this.missedSerpentResets}</td>
                 </tr>

--- a/analysis/magefire/src/modules/features/CombustionActiveTime.tsx
+++ b/analysis/magefire/src/modules/features/CombustionActiveTime.tsx
@@ -155,7 +155,7 @@ class CombustionActiveTime extends Analyzer {
                 {Object.keys(this.combustionPreCastDelay.combustionCasts).map((cast) => (
                   <tr key={cast}>
                     <th style={{ textAlign: 'left' }}>
-                      {formatDuration((Number(cast) - this.owner.fight.start_time) / 1000)}
+                      {formatDuration(Number(cast) - this.owner.fight.start_time)}
                     </th>
                     <th style={{ textAlign: 'left' }}>
                       {formatPercentage(this.combustionCasts[Number(cast)])}

--- a/analysis/magefrost/src/modules/features/WaterElemental.tsx
+++ b/analysis/magefrost/src/modules/features/WaterElemental.tsx
@@ -167,7 +167,7 @@ class WaterElemental extends Analyzer {
             {this._timestampFirstCast === 0
               ? 'Never attacked or not summoned'
               : 'First attack: ' +
-                formatDuration((this._timestampFirstCast - this.owner.fight.start_time) / 1000) +
+                formatDuration(this._timestampFirstCast - this.owner.fight.start_time) +
                 ' into the fight'}
           </Trans>,
         )

--- a/analysis/magefrost/src/modules/talents/ThermalVoid.tsx
+++ b/analysis/magefrost/src/modules/talents/ThermalVoid.tsx
@@ -7,7 +7,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import React from 'react';
 
-const BASE_DURATION = 20;
+const BASE_DURATION = 20_000;
 
 /*
  * Icy Veins' duration is increased by 10 sec.

--- a/analysis/magefrost/src/modules/talents/ThermalVoid.tsx
+++ b/analysis/magefrost/src/modules/talents/ThermalVoid.tsx
@@ -29,8 +29,8 @@ class ThermalVoid extends Analyzer {
     let totalDuration = 0; // We could use getBuffUptime but we are doing the math anyway
     const castRows = hist.map((buff: any, idx: any) => {
       const end = buff.end || this.owner.currentTimestamp;
-      const castTime = (buff.start - this.owner.fight.start_time) / 1000;
-      const duration = (end - buff.start) / 1000;
+      const castTime = buff.start - this.owner.fight.start_time;
+      const duration = end - buff.start;
       totalDuration += duration;
       // If the buff ended early because of death or fight end, don't blame the talent
       const increase = Math.max(0, duration - BASE_DURATION);
@@ -73,7 +73,7 @@ class ThermalVoid extends Analyzer {
       >
         <BoringSpellValueText spell={SPELLS.THERMAL_VOID_TALENT}>
           <>
-            <SpellIcon id={SPELLS.ICY_VEINS.id} /> +{formatNumber(totalIncrease)} seconds
+            <SpellIcon id={SPELLS.ICY_VEINS.id} /> +{formatNumber(totalIncrease * 1000)} seconds
           </>
         </BoringSpellValueText>
       </Statistic>

--- a/analysis/magefrost/src/modules/talents/ThermalVoid.tsx
+++ b/analysis/magefrost/src/modules/talents/ThermalVoid.tsx
@@ -73,7 +73,7 @@ class ThermalVoid extends Analyzer {
       >
         <BoringSpellValueText spell={SPELLS.THERMAL_VOID_TALENT}>
           <>
-            <SpellIcon id={SPELLS.ICY_VEINS.id} /> +{formatNumber(totalIncrease * 1000)} seconds
+            <SpellIcon id={SPELLS.ICY_VEINS.id} /> +{formatNumber(totalIncrease / 1000)} seconds
           </>
         </BoringSpellValueText>
       </Statistic>

--- a/analysis/monkbrewmaster/src/modules/shadowlands/legendaries/StormstoutsLastKeg.tsx
+++ b/analysis/monkbrewmaster/src/modules/shadowlands/legendaries/StormstoutsLastKeg.tsx
@@ -94,9 +94,9 @@ class StormstoutsLastKeg extends Analyzer {
               not reflect the potential damage gain from having 2 charges of Keg Smashs.
             </p>
             <p>
-              This legendary prevented {formatDuration(this.extraCD)} of wasted cooldown
-              time, equal to about {(this.extraCD / 1000 / this.avgCooldown()).toFixed(1)} extra
-              casts of Keg Smash. This includes the initial extra cast.
+              This legendary prevented {formatDuration(this.extraCD)} of wasted cooldown time, equal
+              to about {(this.extraCD / 1000 / this.avgCooldown()).toFixed(1)} extra casts of Keg
+              Smash. This includes the initial extra cast.
             </p>
           </>
         }

--- a/analysis/monkbrewmaster/src/modules/shadowlands/legendaries/StormstoutsLastKeg.tsx
+++ b/analysis/monkbrewmaster/src/modules/shadowlands/legendaries/StormstoutsLastKeg.tsx
@@ -94,7 +94,7 @@ class StormstoutsLastKeg extends Analyzer {
               not reflect the potential damage gain from having 2 charges of Keg Smashs.
             </p>
             <p>
-              This legendary prevented {formatDuration(this.extraCD / 1000)} of wasted cooldown
+              This legendary prevented {formatDuration(this.extraCD)} of wasted cooldown
               time, equal to about {(this.extraCD / 1000 / this.avgCooldown()).toFixed(1)} extra
               casts of Keg Smash. This includes the initial extra cast.
             </p>

--- a/analysis/monkwindwalker/src/modules/resources/EnergyCapTracker.js
+++ b/analysis/monkwindwalker/src/modules/resources/EnergyCapTracker.js
@@ -83,7 +83,7 @@ class EnergyCapTracker extends RegenResourceCapTracker {
               </div>
             </Tooltip>
 
-            <Tooltip content={`At capped energy for ${formatDuration(this.atCap / 1000)}`}>
+            <Tooltip content={`At capped energy for ${formatDuration(this.atCap)}`}>
               <div className="remainder DeathKnight-bg">
                 <img src="/img/overhealing.png" alt="Capped Energy" />
               </div>

--- a/analysis/monkwindwalker/src/modules/spells/ComboStrikes.tsx
+++ b/analysis/monkwindwalker/src/modules/spells/ComboStrikes.tsx
@@ -124,7 +124,7 @@ class ComboStrikes extends Analyzer {
                   {this.masteryDropSpellSequence.map((item, index) => (
                     <tr key={index}>
                       <th scope="row">
-                        {formatDuration((item[0].timestamp - this.owner.fight.start_time) / 1000)}
+                        {formatDuration(item[0].timestamp - this.owner.fight.start_time)}
                       </th>
                       <td>
                         <SpellIcon id={item[0].ability} style={{ height: '2.4em' }} />

--- a/analysis/paladin/src/DivinePurpose.tsx
+++ b/analysis/paladin/src/DivinePurpose.tsx
@@ -135,7 +135,7 @@ class DivinePurpose extends Analyzer {
             <ul>
               <li>
                 Average Time Till Buff Consumed:{' '}
-                {formatDuration(this.averageTimeTillBuffConsumed / 1000 / this.procsGained)}
+                {formatDuration(this.averageTimeTillBuffConsumed / this.procsGained)}
               </li>
               <li>Total Buffs: {this.procsGained}</li>
               <li>Damage: {formatNumber(this.damageDone)}</li>

--- a/analysis/paladinretribution/src/modules/talents/EmpyreanPower.tsx
+++ b/analysis/paladinretribution/src/modules/talents/EmpyreanPower.tsx
@@ -94,7 +94,7 @@ class EmpyreanPower extends Analyzer {
             <ul>
               <li>
                 Average Time Till Buff Consumed:{' '}
-                {formatDuration(this.averageTimeTillBuffConsumed / 1000 / this.procsGained)}
+                {formatDuration(this.averageTimeTillBuffConsumed / this.procsGained)}
               </li>
               <li>Total Buffs: {this.procsGained}</li>
               <li>Damage: {formatNumber(this.damageDone)}</li>

--- a/analysis/rogue/src/EnergyCapTracker.js
+++ b/analysis/rogue/src/EnergyCapTracker.js
@@ -110,7 +110,7 @@ class EnergyCapTracker extends RegenResourceCapTracker {
           <div className="statistic-box-bar">
             <Tooltip
               content={`Not at capped energy for ${formatDuration(
-                (this.owner.fightDuration - this.atCap) / 1000,
+                (this.owner.fightDuration - this.atCap),
               )}`}
             >
               <div
@@ -121,7 +121,7 @@ class EnergyCapTracker extends RegenResourceCapTracker {
               </div>
             </Tooltip>
 
-            <Tooltip content={`At capped energy for ${formatDuration(this.atCap / 1000)}`}>
+            <Tooltip content={`At capped energy for ${formatDuration(this.atCap)}`}>
               <div className="remainder DeathKnight-bg">
                 <img src="/img/overhealing.png" alt="Capped Energy" />
               </div>

--- a/analysis/rogue/src/EnergyCapTracker.js
+++ b/analysis/rogue/src/EnergyCapTracker.js
@@ -110,7 +110,7 @@ class EnergyCapTracker extends RegenResourceCapTracker {
           <div className="statistic-box-bar">
             <Tooltip
               content={`Not at capped energy for ${formatDuration(
-                (this.owner.fightDuration - this.atCap),
+                this.owner.fightDuration - this.atCap,
               )}`}
             >
               <div

--- a/analysis/shamanelemental/src/modules/talents/UnlimitedPower.tsx
+++ b/analysis/shamanelemental/src/modules/talents/UnlimitedPower.tsx
@@ -58,7 +58,7 @@ class UnlimitedPower extends Analyzer {
                 {Object.values(this.unlimitedPowerTimesByStack).map((e, i) => (
                   <tr key={i}>
                     <th>{i}</th>
-                    <td>{formatDuration(e.reduce((a, b) => a + b, 0) / 1000)}</td>
+                    <td>{formatDuration(e.reduce((a, b) => a + b, 0))}</td>
                     <td>
                       {formatPercentage(e.reduce((a, b) => a + b, 0) / this.owner.fightDuration)}%
                     </td>

--- a/analysis/shamanrestoration/src/modules/spells/ChainHeal.tsx
+++ b/analysis/shamanrestoration/src/modules/spells/ChainHeal.tsx
@@ -202,9 +202,7 @@ class ChainHeal extends Analyzer {
                   .map((cast) => (
                     <tr key={cast.timestamp}>
                       <th scope="row">{formatNth(cast.castNo)}</th>
-                      <td>
-                        {formatDuration((cast.timestamp - this.owner.fight.start_time), 0)}
-                      </td>
+                      <td>{formatDuration(cast.timestamp - this.owner.fight.start_time, 0)}</td>
                       <td className={cast.target.specClassName}>
                         {' '}
                         <SpecIcon id={cast.target.spec.id} /> {cast.target.name}

--- a/analysis/shamanrestoration/src/modules/spells/ChainHeal.tsx
+++ b/analysis/shamanrestoration/src/modules/spells/ChainHeal.tsx
@@ -203,7 +203,7 @@ class ChainHeal extends Analyzer {
                     <tr key={cast.timestamp}>
                       <th scope="row">{formatNth(cast.castNo)}</th>
                       <td>
-                        {formatDuration((cast.timestamp - this.owner.fight.start_time) / 1000, 0)}
+                        {formatDuration((cast.timestamp - this.owner.fight.start_time), 0)}
                       </td>
                       <td className={cast.target.specClassName}>
                         {' '}

--- a/analysis/shamanrestoration/src/modules/talents/AncestralProtectionTotem.tsx
+++ b/analysis/shamanrestoration/src/modules/talents/AncestralProtectionTotem.tsx
@@ -143,7 +143,7 @@ class AncestralProtectionTotem extends Analyzer {
                 return (
                   <tr key={index}>
                     <th scope="row">
-                      {formatDuration((event.timestamp - this.owner.fight.start_time), 0)}
+                      {formatDuration(event.timestamp - this.owner.fight.start_time, 0)}
                     </th>
                     <td className={specClassName}>{combatant.name}</td>
                     <td style={{ textAlign: 'center' }}>

--- a/analysis/shamanrestoration/src/modules/talents/AncestralProtectionTotem.tsx
+++ b/analysis/shamanrestoration/src/modules/talents/AncestralProtectionTotem.tsx
@@ -143,7 +143,7 @@ class AncestralProtectionTotem extends Analyzer {
                 return (
                   <tr key={index}>
                     <th scope="row">
-                      {formatDuration((event.timestamp - this.owner.fight.start_time) / 1000, 0)}
+                      {formatDuration((event.timestamp - this.owner.fight.start_time), 0)}
                     </th>
                     <td className={specClassName}>{combatant.name}</td>
                     <td style={{ textAlign: 'center' }}>

--- a/analysis/shamanrestoration/src/modules/talents/AncestralVigor.tsx
+++ b/analysis/shamanrestoration/src/modules/talents/AncestralVigor.tsx
@@ -160,7 +160,7 @@ class AncestralVigor extends Analyzer {
                 return (
                   <tr key={index}>
                     <th scope="row">
-                      {formatDuration((event.timestamp - this.owner.fight.start_time), 0)}
+                      {formatDuration(event.timestamp - this.owner.fight.start_time, 0)}
                     </th>
                     <td className={specClassName}>{combatant.name}</td>
                     <td style={{ textAlign: 'center' }}>

--- a/analysis/shamanrestoration/src/modules/talents/AncestralVigor.tsx
+++ b/analysis/shamanrestoration/src/modules/talents/AncestralVigor.tsx
@@ -160,7 +160,7 @@ class AncestralVigor extends Analyzer {
                 return (
                   <tr key={index}>
                     <th scope="row">
-                      {formatDuration((event.timestamp - this.owner.fight.start_time) / 1000, 0)}
+                      {formatDuration((event.timestamp - this.owner.fight.start_time), 0)}
                     </th>
                     <td className={specClassName}>{combatant.name}</td>
                     <td style={{ textAlign: 'center' }}>

--- a/analysis/shamanrestoration/src/modules/talents/EarthenWallTotem.tsx
+++ b/analysis/shamanrestoration/src/modules/talents/EarthenWallTotem.tsx
@@ -216,9 +216,7 @@ class EarthenWallTotem extends Analyzer {
                 return (
                   <tr key={index}>
                     <th scope="row">{formatNth(index + 1)}</th>
-                    <td>
-                      {formatDuration(cast.timestamp - this.owner.fight.start_time) || 0}
-                    </td>
+                    <td>{formatDuration(cast.timestamp - this.owner.fight.start_time) || 0}</td>
                     <td
                       style={
                         castEfficiency < RECOMMENDED_EFFICIENCY

--- a/analysis/shamanrestoration/src/modules/talents/EarthenWallTotem.tsx
+++ b/analysis/shamanrestoration/src/modules/talents/EarthenWallTotem.tsx
@@ -217,7 +217,7 @@ class EarthenWallTotem extends Analyzer {
                   <tr key={index}>
                     <th scope="row">{formatNth(index + 1)}</th>
                     <td>
-                      {formatDuration((cast.timestamp - this.owner.fight.start_time) / 1000) || 0}
+                      {formatDuration(cast.timestamp - this.owner.fight.start_time) || 0}
                     </td>
                     <td
                       style={

--- a/analysis/shamanrestoration/src/modules/talents/Wellspring.tsx
+++ b/analysis/shamanrestoration/src/modules/talents/Wellspring.tsx
@@ -209,9 +209,8 @@ class Wellspring extends Analyzer {
               <tr key={index}>
                 <th scope="row">{formatNth(index)}</th>
                 <td>
-                  {formatDuration(
-                    (this.wellspringTimestamps[index] - this.owner.fight.start_time),
-                  ) || 0}
+                  {formatDuration(this.wellspringTimestamps[index] - this.owner.fight.start_time) ||
+                    0}
                 </td>
                 <td style={hits < 6 ? { color: 'red', fontWeight: 'bold' } : {}}>{hits} hits</td>
               </tr>

--- a/analysis/shamanrestoration/src/modules/talents/Wellspring.tsx
+++ b/analysis/shamanrestoration/src/modules/talents/Wellspring.tsx
@@ -210,7 +210,7 @@ class Wellspring extends Analyzer {
                 <th scope="row">{formatNth(index)}</th>
                 <td>
                   {formatDuration(
-                    (this.wellspringTimestamps[index] - this.owner.fight.start_time) / 1000,
+                    (this.wellspringTimestamps[index] - this.owner.fight.start_time),
                   ) || 0}
                 </td>
                 <td style={hits < 6 ? { color: 'red', fontWeight: 'bold' } : {}}>{hits} hits</td>

--- a/analysis/warlockdemonology/src/modules/pets/PetTimelineTab/TabComponent/DeathEvents.js
+++ b/analysis/warlockdemonology/src/modules/pets/PetTimelineTab/TabComponent/DeathEvents.js
@@ -10,7 +10,7 @@ const DeathEvents = (props) => {
     <>
       {deaths.map((event) => {
         const eventStart = event.start || event.timestamp;
-        const fightDuration = (eventStart - start);
+        const fightDuration = eventStart - start;
         const left = ((eventStart - start) / 1000) * secondWidth;
         return (
           <Tooltip
@@ -28,7 +28,7 @@ const DeathEvents = (props) => {
       })}
       {resurrections.map((event) => {
         const eventStart = event.start || event.timestamp;
-        const fightDuration = (eventStart - start);
+        const fightDuration = eventStart - start;
         const left = ((eventStart - start) / 1000) * secondWidth;
         return (
           <Tooltip

--- a/analysis/warlockdemonology/src/modules/pets/PetTimelineTab/TabComponent/DeathEvents.js
+++ b/analysis/warlockdemonology/src/modules/pets/PetTimelineTab/TabComponent/DeathEvents.js
@@ -10,7 +10,7 @@ const DeathEvents = (props) => {
     <>
       {deaths.map((event) => {
         const eventStart = event.start || event.timestamp;
-        const fightDuration = (eventStart - start) / 1000;
+        const fightDuration = (eventStart - start);
         const left = ((eventStart - start) / 1000) * secondWidth;
         return (
           <Tooltip
@@ -28,7 +28,7 @@ const DeathEvents = (props) => {
       })}
       {resurrections.map((event) => {
         const eventStart = event.start || event.timestamp;
-        const fightDuration = (eventStart - start) / 1000;
+        const fightDuration = (eventStart - start);
         const left = ((eventStart - start) / 1000) * secondWidth;
         return (
           <Tooltip

--- a/analysis/warlockdemonology/src/modules/pets/PetTimelineTab/TabComponent/PetTimeline.js
+++ b/analysis/warlockdemonology/src/modules/pets/PetTimelineTab/TabComponent/PetTimeline.js
@@ -250,7 +250,7 @@ class PetTimeline extends React.PureComponent {
                 }
                 return (
                   <div key={second} className="lane" style={{ width: secondWidth * skipInterval }}>
-                    {formatDuration(second)}
+                    {formatDuration(second * 1000)}
                   </div>
                 );
               })}

--- a/analysis/warriorarms/src/modules/core/Execute/EarlyDotRefreshes.js
+++ b/analysis/warriorarms/src/modules/core/Execute/EarlyDotRefreshes.js
@@ -151,9 +151,9 @@ class EarlyDotRefreshes extends Analyzer {
   // Get the suggestion for last bad cast. If empty, cast will be considered good.
   getLastBadCastText(event, dot) {
     return `${dot.name} was refreshed ${formatDuration(
-      this.lastCastMinWaste / 1000,
+      this.lastCastMinWaste,
     )} seconds before the pandemic window. It should be refreshed with at most ${formatDuration(
-      (PANDEMIC_WINDOW * dot.duration) / 1000,
+      PANDEMIC_WINDOW * dot.duration,
     )} left or part of the dot will be wasted.`;
   }
 

--- a/analysis/warriorarms/src/modules/talents/AngerManagement.js
+++ b/analysis/warriorarms/src/modules/talents/AngerManagement.js
@@ -19,8 +19,8 @@ class AngerManagement extends Analyzer {
   get tooltip() {
     return this.cooldownsAffected.map((id) => (
       <>
-        {SPELLS[id].name}: {formatDuration(this.effectiveReduction[id] / 1000)} reduction (
-        {formatDuration(this.wastedReduction[id] / 1000)} wasted)
+        {SPELLS[id].name}: {formatDuration(this.effectiveReduction[id])} reduction (
+        {formatDuration(this.wastedReduction[id])} wasted)
         <br />
       </>
     ));
@@ -82,9 +82,8 @@ class AngerManagement extends Analyzer {
           </>
         }
         value={`${formatDuration(
-          (this.effectiveReduction[SPELLS.BLADESTORM.id] +
-            this.wastedReduction[SPELLS.BLADESTORM.id]) /
-            1000,
+          this.effectiveReduction[SPELLS.BLADESTORM.id] +
+            this.wastedReduction[SPELLS.BLADESTORM.id],
         )} min`}
         valueTooltip={this.tooltip}
       />

--- a/analysis/warriorprotection/src/modules/shadowlands/legendaries/TheWall.tsx
+++ b/analysis/warriorprotection/src/modules/shadowlands/legendaries/TheWall.tsx
@@ -69,13 +69,13 @@ class TheWall extends Analyzer {
         tooltip={
           <>
             Wasted Rage: {this.wastedRage} <br />
-            Wasted CDR: {formatDuration(this.wastedCDR / 1000)}
+            Wasted CDR: {formatDuration(this.wastedCDR)}
           </>
         }
       >
         <BoringSpellValueText spell={SPELLS.THE_WALL}>
           {this.effectiveRage} <small>rage</small> <br />
-          {formatDuration(this.effectiveCDR / 1000)} <small>cdr</small>
+          {formatDuration(this.effectiveCDR)} <small>cdr</small>
         </BoringSpellValueText>
       </Statistic>
     );

--- a/analysis/warriorprotection/src/modules/shadowlands/legendaries/Thunderlord.tsx
+++ b/analysis/warriorprotection/src/modules/shadowlands/legendaries/Thunderlord.tsx
@@ -67,10 +67,10 @@ class Thunderlord extends Analyzer {
         position={STATISTIC_ORDER.OPTIONAL(13)}
         size="flexible"
         category={STATISTIC_CATEGORY.COVENANTS}
-        tooltip={<>Wasted CDR: {formatDuration(this.wastedCDR / 1000)}</>}
+        tooltip={<>Wasted CDR: {formatDuration(this.wastedCDR)}</>}
       >
         <BoringSpellValueText spell={SPELLS.THUNDERLORD}>
-          {formatDuration(this.effectiveCDR / 1000)} <small>cdr</small>
+          {formatDuration(this.effectiveCDR)} <small>cdr</small>
         </BoringSpellValueText>
       </Statistic>
     );

--- a/analysis/warriorprotection/src/modules/talents/AngerManagement.tsx
+++ b/analysis/warriorprotection/src/modules/talents/AngerManagement.tsx
@@ -49,8 +49,8 @@ class AngerManagement extends Analyzer {
           {COOLDOWNS_AFFECTED_BY_ANGER_MANAGEMENT.map((value) => (
             <tr key={value}>
               <td>{SPELLS[value].name}</td>
-              <td>{formatDuration(this.effectiveReduction[value] / 1000)}</td>
-              <td>{formatDuration(this.wastedReduction[value] / 1000)}</td>
+              <td>{formatDuration(this.effectiveReduction[value])}</td>
+              <td>{formatDuration(this.wastedReduction[value])}</td>
             </tr>
           ))}
         </tbody>

--- a/analysis/warriorprotection/src/modules/talents/IntoTheFray.tsx
+++ b/analysis/warriorprotection/src/modules/talents/IntoTheFray.tsx
@@ -108,7 +108,7 @@ class IntoTheFray extends Analyzer {
               {this.buffStacks.map((e, i) => (
                 <tr key={i}>
                   <th>{(i * HASTE_PER_STACK).toFixed(0)}%</th>
-                  <td>{formatDuration(e.reduce((a, b) => a + b, 0) / 1000)}</td>
+                  <td>{formatDuration(e.reduce((a, b) => a + b, 0))}</td>
                   <td>
                     {formatPercentage(e.reduce((a, b) => a + b, 0) / this.owner.fightDuration)}%
                   </td>

--- a/src/common/format.test.ts
+++ b/src/common/format.test.ts
@@ -18,26 +18,26 @@ describe('formatThousands', () => {
 describe('formatDuration', () => {
   test('regular values', () => {
     expect(formatDuration(0)).toBe('0:00');
-    expect(formatDuration(1)).toBe('0:01');
-    expect(formatDuration(10)).toBe('0:10');
-    expect(formatDuration(59)).toBe('0:59');
-    expect(formatDuration(60)).toBe('1:00');
-    expect(formatDuration(61)).toBe('1:01');
-    expect(formatDuration(120)).toBe('2:00');
+    expect(formatDuration(1000)).toBe('0:01');
+    expect(formatDuration(10000)).toBe('0:10');
+    expect(formatDuration(59000)).toBe('0:59');
+    expect(formatDuration(60000)).toBe('1:00');
+    expect(formatDuration(61000)).toBe('1:01');
+    expect(formatDuration(120000)).toBe('2:00');
   });
   test('decimal values', () => {
-    expect(formatDuration(9.9)).toBe('0:09');
-    expect(formatDuration(59.9)).toBe('0:59');
+    expect(formatDuration(9900)).toBe('0:09');
+    expect(formatDuration(59900)).toBe('0:59');
   });
   test('decimals', () => {
-    expect(formatDuration(1, 1)).toBe('0:01.0');
-    expect(formatDuration(9.9, 1)).toBe('0:09.9');
-    expect(formatDuration(59.9, 1)).toBe('0:59.9');
-    expect(formatDuration(59.9, 1)).toBe('0:59.9');
-    expect(formatDuration(60, 1)).toBe('1:00.0');
-    expect(formatDuration(9.9, 2)).toBe('0:09.90');
-    expect(formatDuration(9.987, 2)).toBe('0:09.98');
-    expect(formatDuration(9.987, 3)).toBe('0:09.987');
-    expect(formatDuration(9.987, 0)).toBe('0:09');
+    expect(formatDuration(1000, 1)).toBe('0:01.0');
+    expect(formatDuration(9900, 1)).toBe('0:09.9');
+    expect(formatDuration(59900, 1)).toBe('0:59.9');
+    expect(formatDuration(59900, 1)).toBe('0:59.9');
+    expect(formatDuration(60000, 1)).toBe('1:00.0');
+    expect(formatDuration(9900, 2)).toBe('0:09.90');
+    expect(formatDuration(9987, 2)).toBe('0:09.98');
+    expect(formatDuration(9987, 3)).toBe('0:09.987');
+    expect(formatDuration(9987, 0)).toBe('0:09');
   });
 });

--- a/src/common/format.ts
+++ b/src/common/format.ts
@@ -2,7 +2,7 @@
  * Rounds to nearest integer and returns as a String with added thousands seperators.
  * Ex: 5842923.7 => 5,842,924
  */
-export function formatThousands(number: number) {
+export function formatThousands(number: number): string {
   return `${Math.round(number || 0)}`.replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,');
 }
 
@@ -13,7 +13,7 @@ export function formatThousands(number: number) {
  *     78921 => 79k
  *     3444789 => 3.44m
  */
-export function formatNumber(number: number) {
+export function formatNumber(number: number): string {
   if (number > 1000000) {
     return `${(number / 1000000).toFixed(2)}m`;
   }
@@ -27,20 +27,22 @@ export function formatNumber(number: number) {
  * Formats a number as a percentage with the given precision (default 2), with 0 = 0 percent and 1 = 100 percent.
  * Ex: 0.79832 => 79.83
  */
-export function formatPercentage(percentage: number, precision: number = 2) {
+export function formatPercentage(percentage: number, precision: number = 2): string {
   return ((percentage || 0) * 100).toFixed(precision);
 }
 
 /**
- * Formats a duration in seconds to be a String expressed as minutes and seconds.
+ * Formats a duration in milliseconds to be a String expressed as minutes and seconds
+ * with the given decimal second precision (default 0).
  * Ex: 317.3 => 5:17
  */
 export function formatDuration(duration: number, precision: number = 0) {
-  const neg = duration < 0 ? '-' : '';
-  duration = Math.abs(duration);
-  const minutes = Math.floor(duration / 60);
+  const totalSeconds = duration / 1000;
+  const neg = totalSeconds < 0 ? '-' : '';
+  const posSeconds = Math.abs(totalSeconds);
+  const minutes = Math.floor(posSeconds / 60);
   const mult = Math.pow(10, precision);
-  const rest = (Math.floor((duration % 60) * mult) / mult).toFixed(precision);
+  const rest = (Math.floor((posSeconds % 60) * mult) / mult).toFixed(precision);
   const seconds = Number(rest) < 10 ? `0${rest}` : rest;
 
   return `${neg}${minutes}:${seconds}`;
@@ -51,7 +53,7 @@ export function formatDuration(duration: number, precision: number = 0) {
  * Formatting maintains ordering but is pretty ugly, mostly suitable for debug logging instead of user facing content.
  * Ex. 317327 => 05:17.327
  */
-export function formatMilliseconds(duration: number) {
+export function formatMilliseconds(duration: number): string {
   const sumSeconds = duration / 1000;
   const minutes = Math.floor(sumSeconds / 60);
   const seconds = sumSeconds % 60;
@@ -74,6 +76,6 @@ export function formatMilliseconds(duration: number) {
  * Formats a number into the ordinal form.
  * Ex: 2nd, 7th, 20th, 23rd, 52nd, 135th, 301st
  */
-export function formatNth(number: number) {
+export function formatNth(number: number): string {
   return number.toString() + (['st', 'nd', 'rd'][((((number + 90) % 100) - 10) % 10) - 1] || 'th');
 }

--- a/src/common/getFightName.ts
+++ b/src/common/getFightName.ts
@@ -18,7 +18,7 @@ export default function getFightName(report: WCLFightsResponse, fight: WCLFight)
         id: 'common.getFightName.wipe',
         message: `Wipe ${wipes}`,
       });
-  const duration = formatDuration((fight.end_time - fight.start_time) / 1000);
+  const duration = formatDuration(fight.end_time - fight.start_time);
 
   return t({
     id: 'common.getFightName.fightname',

--- a/src/interface/EventsTab.js
+++ b/src/interface/EventsTab.js
@@ -338,7 +338,7 @@ class EventsTab extends React.Component {
                     label="Time"
                     cellRenderer={({ cellData }) =>
                       formatDuration(
-                        (cellData - parser.fight.start_time + parser.fight.offset_time) / 1000,
+                        cellData - parser.fight.start_time + parser.fight.offset_time,
                         3,
                       )
                     }

--- a/src/interface/report/FightSelectionPanelList.tsx
+++ b/src/interface/report/FightSelectionPanelList.tsx
@@ -66,7 +66,7 @@ class FightSelectionPanelList extends React.PureComponent<Props> {
                   <h2 style={{ marginTop: 0 }}>{getFightName(report, firstPull)}</h2>
                   <div className="pulls">
                     {pulls.map((pull) => {
-                      const duration = Math.round((pull.end_time - pull.start_time) / 1000);
+                      const duration = Math.round(pull.end_time - pull.start_time);
                       const Icon = pull.kill ? SkullIcon : CancelIcon;
 
                       return (

--- a/src/interface/report/Results/EncounterStats.js
+++ b/src/interface/report/Results/EncounterStats.js
@@ -356,7 +356,7 @@ class EncounterStats extends React.PureComponent {
               </div>
             </a>
             <div>
-              {formatDuration(log.duration / 1000)} (
+              {formatDuration(log.duration)} (
               {log.duration > this.props.duration
                 ? ((log.duration - this.props.duration) / 1000).toFixed(1) + 's slower'
                 : ((this.props.duration - log.duration) / 1000).toFixed(1) + 's faster'}

--- a/src/interface/report/Results/Timeline/Buffs.js
+++ b/src/interface/report/Results/Timeline/Buffs.js
@@ -108,7 +108,7 @@ class Buffs extends React.PureComponent {
     }
     const left = this.getOffsetLeft(applied.timestamp);
     const duration = event.timestamp - applied.timestamp;
-    const fightDuration = (applied.timestamp - this.props.start) / 1000;
+    const fightDuration = applied.timestamp - this.props.start;
 
     const level = this._levels.indexOf(event.ability.guid);
     this._levels[level] = undefined;

--- a/src/interface/report/Results/Timeline/Casts.js
+++ b/src/interface/report/Results/Timeline/Casts.js
@@ -203,7 +203,7 @@ class Casts extends React.PureComponent {
   renderChannel(event) {
     const start = this.props.start;
     const left = this.getOffsetLeft(event.start);
-    const fightDuration = (event.start - start) / 1000;
+    const fightDuration = event.start - start;
 
     return (
       <Tooltip
@@ -228,7 +228,7 @@ class Casts extends React.PureComponent {
   renderGlobalCooldown(event) {
     const start = this.props.start;
     const left = this.getOffsetLeft(event.timestamp);
-    const fightDuration = (event.timestamp - start) / 1000;
+    const fightDuration = event.timestamp - start;
 
     return (
       <Tooltip

--- a/src/interface/report/Results/Timeline/Component.js
+++ b/src/interface/report/Results/Timeline/Component.js
@@ -184,7 +184,7 @@ class Timeline extends React.PureComponent {
                   <div
                     key={second + this.offset / 1000}
                     style={{ width: this.secondWidth * skipInterval }}
-                    data-duration={formatDuration(second + this.offset / 1000)}
+                    data-duration={formatDuration(second * 1000 + this.offset)}
                   />
                 ))}
             </div>

--- a/src/parser/core/CombatLogParser.ts
+++ b/src/parser/core/CombatLogParser.ts
@@ -583,7 +583,7 @@ class CombatLogParser {
     return damageTaken / this.getModule(DamageTaken).total.effective;
   }
   formatTimestamp(timestamp: number, precision = 0) {
-    return formatDuration((timestamp - this.fight.start_time) / 1000, precision);
+    return formatDuration(timestamp - this.fight.start_time, precision);
   }
 
   generateResults(adjustForDowntime: boolean): ParseResults {

--- a/src/parser/core/healingEfficiency/HealingEfficiencyBreakdown.tsx
+++ b/src/parser/core/healingEfficiency/HealingEfficiencyBreakdown.tsx
@@ -274,7 +274,7 @@ class HealingEfficiencyBreakdown extends React.Component<Props, State> {
         </td>
         <td>
           {spellDetail.timeSpentCasting !== 0
-            ? formatDuration(spellDetail.timeSpentCasting / 1000) +
+            ? formatDuration(spellDetail.timeSpentCasting) +
               ' (' +
               formatPercentage(spellDetail.percentTimeSpentCasting) +
               '%)'

--- a/src/parser/shared/modules/DeathRecap.js
+++ b/src/parser/shared/modules/DeathRecap.js
@@ -244,10 +244,7 @@ class DeathRecap extends React.PureComponent {
                     return (
                       <tr key={eventIndex}>
                         <td style={{ width: '5%' }}>
-                          {formatDuration(
-                            event.time + this.props.report.fight.offset_time,
-                            2,
-                          )}
+                          {formatDuration(event.time + this.props.report.fight.offset_time, 2)}
                         </td>
                         <td style={{ width: '20%' }}>
                           <SpellLink id={event.ability.guid} icon={false}>

--- a/src/parser/shared/modules/DeathRecap.js
+++ b/src/parser/shared/modules/DeathRecap.js
@@ -245,7 +245,7 @@ class DeathRecap extends React.PureComponent {
                       <tr key={eventIndex}>
                         <td style={{ width: '5%' }}>
                           {formatDuration(
-                            (event.time + this.props.report.fight.offset_time) / 1000,
+                            event.time + this.props.report.fight.offset_time,
                             2,
                           )}
                         </td>

--- a/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes.tsx
+++ b/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes.tsx
@@ -177,7 +177,7 @@ class EarlyDotRefreshes extends Analyzer {
     return `${dot.name} was refreshed ${formatDuration(
       this.lastCastMinWaste,
     )} seconds before the pandemic window. It should be refreshed with at most ${formatDuration(
-      (PANDEMIC_WINDOW * dot.duration),
+      PANDEMIC_WINDOW * dot.duration,
     )} left or part of the dot will be wasted.`;
   }
 

--- a/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes.tsx
+++ b/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes.tsx
@@ -175,9 +175,9 @@ class EarlyDotRefreshes extends Analyzer {
   // Get the suggestion for last bad cast. If empty, cast will be considered good.
   getLastBadCastText(event: CastEvent, dot: Dot) {
     return `${dot.name} was refreshed ${formatDuration(
-      this.lastCastMinWaste / 1000,
+      this.lastCastMinWaste,
     )} seconds before the pandemic window. It should be refreshed with at most ${formatDuration(
-      (PANDEMIC_WINDOW * dot.duration) / 1000,
+      (PANDEMIC_WINDOW * dot.duration),
     )} left or part of the dot will be wasted.`;
   }
 

--- a/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesSuggestion.js
+++ b/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesSuggestion.js
@@ -8,8 +8,8 @@ function suggest(when, suggestion) {
     suggest(
       <>
         You refreshed <SpellLink id={suggestion.spell.id} /> early {suggestion.count} times,
-        resulting in {formatDuration(suggestion.wastedDuration)} seconds lost. The individual
-        casts are highlighted on the timeline.
+        resulting in {formatDuration(suggestion.wastedDuration)} seconds lost. The individual casts
+        are highlighted on the timeline.
       </>,
     )
       .icon(suggestion.spell.icon)

--- a/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesSuggestion.js
+++ b/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesSuggestion.js
@@ -8,7 +8,7 @@ function suggest(when, suggestion) {
     suggest(
       <>
         You refreshed <SpellLink id={suggestion.spell.id} /> early {suggestion.count} times,
-        resulting in {formatDuration(suggestion.wastedDuration / 1000)} seconds lost. The individual
+        resulting in {formatDuration(suggestion.wastedDuration)} seconds lost. The individual
         casts are highlighted on the timeline.
       </>,
     )

--- a/src/parser/shared/modules/features/LowHealthHealing/Component.js
+++ b/src/parser/shared/modules/features/LowHealthHealing/Component.js
@@ -123,7 +123,7 @@ class LowHealthHealing extends React.Component {
               return (
                 <tr key={`${event.timestamp}${effectiveHealing}${hitPointsBeforeHeal}`}>
                   <td style={{ width: '5%' }}>
-                    {formatDuration((event.timestamp - fightStart) / 1000)}
+                    {formatDuration(event.timestamp - fightStart)}
                   </td>
                   <td style={{ width: '25%' }}>
                     <SpellLink id={event.ability.guid} icon={false}>

--- a/src/parser/shared/modules/features/LowHealthHealing/Component.js
+++ b/src/parser/shared/modules/features/LowHealthHealing/Component.js
@@ -122,9 +122,7 @@ class LowHealthHealing extends React.Component {
 
               return (
                 <tr key={`${event.timestamp}${effectiveHealing}${hitPointsBeforeHeal}`}>
-                  <td style={{ width: '5%' }}>
-                    {formatDuration(event.timestamp - fightStart)}
-                  </td>
+                  <td style={{ width: '5%' }}>{formatDuration(event.timestamp - fightStart)}</td>
                   <td style={{ width: '25%' }}>
                     <SpellLink id={event.ability.guid} icon={false}>
                       <Icon icon={event.ability.abilityIcon} alt={event.ability.abilityIcon} />{' '}

--- a/src/parser/shared/modules/items/shadowlands/crafted/DarkmoonDeckVoracity.tsx
+++ b/src/parser/shared/modules/items/shadowlands/crafted/DarkmoonDeckVoracity.tsx
@@ -221,7 +221,7 @@ class DarkmoonDeckVoracity extends Analyzer {
                 <tr key={index}>
                   <td>{card.name}</td>
                   <td>{card.hasteDrain}</td>
-                  <td>{formatDuration(card.uptime / 1000)}</td>
+                  <td>{formatDuration(card.uptime)}</td>
                   <td>{formatPercentage(card.uptime / this.owner.fightDuration)}%</td>
                 </tr>
               ))}

--- a/src/parser/ui/Cooldown.js
+++ b/src/parser/ui/Cooldown.js
@@ -142,8 +142,8 @@ class Cooldown extends React.Component {
           <div className={this.state.showAllEvents ? 'col-md-12' : 'col-md-6'}>
             <header style={{ marginTop: 5, fontSize: '1.25em', marginBottom: '.1em' }}>
               <SpellLink id={cooldown.spell.id} icon={false} /> (
-              {formatDuration(cdStart - fightStart)} -&gt;{' '}
-              {formatDuration(end - fightStart)}) &nbsp;
+              {formatDuration(cdStart - fightStart)} -&gt; {formatDuration(end - fightStart)})
+              &nbsp;
               <TooltipElement
                 content={
                   <Trans id="shared.cooldownThroughputTracker.cooldown.events.tooltip">

--- a/src/parser/ui/Cooldown.js
+++ b/src/parser/ui/Cooldown.js
@@ -142,8 +142,8 @@ class Cooldown extends React.Component {
           <div className={this.state.showAllEvents ? 'col-md-12' : 'col-md-6'}>
             <header style={{ marginTop: 5, fontSize: '1.25em', marginBottom: '.1em' }}>
               <SpellLink id={cooldown.spell.id} icon={false} /> (
-              {formatDuration((cdStart - fightStart) / 1000)} -&gt;{' '}
-              {formatDuration((end - fightStart) / 1000)}) &nbsp;
+              {formatDuration(cdStart - fightStart)} -&gt;{' '}
+              {formatDuration(end - fightStart)}) &nbsp;
               <TooltipElement
                 content={
                   <Trans id="shared.cooldownThroughputTracker.cooldown.events.tooltip">

--- a/src/parser/ui/UptimeBar.tsx
+++ b/src/parser/ui/UptimeBar.tsx
@@ -35,11 +35,7 @@ const UptimeBar = ({
         return timeTooltip ? (
           <Tooltip
             key={`${start}-${end}`}
-            content={
-              formatDuration((start - fightStart) / 1000) +
-              `-` +
-              formatDuration((end - fightStart) / 1000)
-            }
+            content={formatDuration(start - fightStart) + `-` + formatDuration(end - fightStart)}
           >
             <div style={getSegmentStyle(start, end, fightStart, fightDuration, barColor)} />
           </Tooltip>


### PR DESCRIPTION
I couldn't take it anymore. All of the other format functions take milliseconds but formatDuration takes seconds, and 95% of the people calling it were passing milliseconds and dividing by 1000 in the call. This is the refactor to fix it.