### PR TITLE
Add support for TBC analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
         id: cache
         with:
           path: node_modules
-          key: ${{ runner.os }}-node_modules3-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.os }}-node_modules3-
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('package.json', 'yarn.lock') }}
+          restore-keys: ${{ runner.os }}-node_modules-
       - name: Get yarn cache directory path
         if: steps.cache.outputs.cache-hit != 'true'
         id: yarn-cache-dir-path
@@ -61,8 +61,8 @@ jobs:
         uses: martijnhols/cache@read-only
         with:
           path: node_modules
-          key: ${{ runner.os }}-node_modules3-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.os }}-node_modules3-
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('package.json', 'yarn.lock') }}
+          restore-keys: ${{ runner.os }}-node_modules-
           read-only: true
       - run: yarn typecheck
   linting:
@@ -78,8 +78,8 @@ jobs:
         uses: martijnhols/cache@read-only
         with:
           path: node_modules
-          key: ${{ runner.os }}-node_modules3-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.os }}-node_modules3-
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('package.json', 'yarn.lock') }}
+          restore-keys: ${{ runner.os }}-node_modules-
           read-only: true
       - run: yarn lint --max-warnings=0
   test-interface:
@@ -96,8 +96,8 @@ jobs:
         uses: martijnhols/cache@read-only
         with:
           path: node_modules
-          key: ${{ runner.os }}-node_modules3-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.os }}-node_modules3-
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('package.json', 'yarn.lock') }}
+          restore-keys: ${{ runner.os }}-node_modules-
           read-only: true
       - run: yarn test:interface --runInBand
   test-parser:
@@ -113,8 +113,8 @@ jobs:
         uses: martijnhols/cache@read-only
         with:
           path: node_modules
-          key: ${{ runner.os }}-node_modules3-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.os }}-node_modules3-
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('package.json', 'yarn.lock') }}
+          restore-keys: ${{ runner.os }}-node_modules-
           read-only: true
       - run: yarn test:parser --runInBand
   test-integration:
@@ -130,8 +130,8 @@ jobs:
         uses: martijnhols/cache@read-only
         with:
           path: node_modules
-          key: ${{ runner.os }}-node_modules3-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.os }}-node_modules3-
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('package.json', 'yarn.lock') }}
+          restore-keys: ${{ runner.os }}-node_modules-
           read-only: true
       - run: yarn test:integration --runInBand
   build:
@@ -148,8 +148,8 @@ jobs:
         uses: martijnhols/cache@read-only
         with:
           path: node_modules
-          key: ${{ runner.os }}-node_modules3-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.os }}-node_modules3-
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('package.json', 'yarn.lock') }}
+          restore-keys: ${{ runner.os }}-node_modules-
           read-only: true
       - name: Extract messages
         if: github.event_name != 'pull_request' && github.repository == 'wowanalyzer/wowanalyzer'
@@ -187,8 +187,8 @@ jobs:
         uses: martijnhols/cache@read-only
         with:
           path: node_modules
-          key: ${{ runner.os }}-node_modules3-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.os }}-node_modules3-
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('package.json', 'yarn.lock') }}
+          restore-keys: ${{ runner.os }}-node_modules-
           read-only: true
       - name: Extract messages
         run: yarn extract
@@ -253,8 +253,8 @@ jobs:
         uses: martijnhols/cache@read-only
         with:
           path: node_modules
-          key: ${{ runner.os }}-node_modules3-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.os }}-node_modules3-
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('package.json', 'yarn.lock') }}
+          restore-keys: ${{ runner.os }}-node_modules-
           read-only: true
       - name: Extract messages
         run: yarn extract

--- a/analysis/deathknightblood/src/integrationTests/example.test.ts.snap
+++ b/analysis/deathknightblood/src/integrationTests/example.test.ts.snap
@@ -3199,6 +3199,103 @@ exports[`Blood Death Knight integration test: example log CastEfficiency matches
             >
               <a
                 className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.00
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              0
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              0.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
                 href="http://wowhead.com/spell=307192"
                 rel="noopener noreferrer"
                 style={

--- a/analysis/deathknightfrost/src/integrationTests/example.test.ts.snap
+++ b/analysis/deathknightfrost/src/integrationTests/example.test.ts.snap
@@ -3253,6 +3253,103 @@ exports[`Frost Death Knight integration test: example log CastEfficiency matches
             >
               <a
                 className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.00
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              0
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              0.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
                 href="http://wowhead.com/spell=307192"
                 rel="noopener noreferrer"
                 style={

--- a/analysis/druidrestoration/src/modules/core/Mastery.ts
+++ b/analysis/druidrestoration/src/modules/core/Mastery.ts
@@ -265,7 +265,7 @@ class Mastery extends Analyzer {
         this.statTracker.ratingNeededForNextPercentage(
           this.statTracker.currentMasteryRating,
           this.statTracker.statBaselineRatingPerPercent[STAT.MASTERY],
-          this.selectedCombatant.spec.masteryCoefficient,
+          this.selectedCombatant.spec?.masteryCoefficient,
         );
       return buffBonus / healMasteryMult;
     };

--- a/analysis/druidrestoration/src/modules/features/StatWeights.tsx
+++ b/analysis/druidrestoration/src/modules/features/StatWeights.tsx
@@ -167,7 +167,7 @@ class StatWeights extends BaseHealerStatValues {
       this.statTracker.ratingNeededForNextPercentage(
         this.statTracker.currentMasteryRating,
         this.statTracker.statBaselineRatingPerPercent[STAT.MASTERY],
-        this.selectedCombatant.spec.masteryCoefficient,
+        this.selectedCombatant.spec?.masteryCoefficient,
       );
     const hotCount = this.mastery.getHotCount(target);
     const noMasteryHealing =

--- a/analysis/hunterbeastmastery/src/integrationTests/beastMasteryIntegrationTests.test.ts.snap
+++ b/analysis/hunterbeastmastery/src/integrationTests/beastMasteryIntegrationTests.test.ts.snap
@@ -4387,6 +4387,103 @@ exports[`Beast Mastery Hunter integration test: Multi Target CastEfficiency matc
             >
               <a
                 className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.00
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              0
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              0.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
                 href="http://wowhead.com/spell=307192"
                 rel="noopener noreferrer"
                 style={
@@ -12870,6 +12967,103 @@ exports[`Beast Mastery Hunter integration test: Single Target CastEfficiency mat
               </dfn>
             </th>
             <th />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.19
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              1
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "100%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              100.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
           </tr>
           <tr>
             <td

--- a/analysis/huntermarksmanship/src/integrationTests/marksmanshipIntegrationTests.test.ts.snap
+++ b/analysis/huntermarksmanship/src/integrationTests/marksmanshipIntegrationTests.test.ts.snap
@@ -3796,6 +3796,103 @@ exports[`Marksmanship Hunter integration test: Multi Target CastEfficiency match
             >
               <a
                 className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.00
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              0
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              0.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
                 href="http://wowhead.com/spell=307192"
                 rel="noopener noreferrer"
                 style={
@@ -11835,6 +11932,103 @@ exports[`Marksmanship Hunter integration test: Single Target CastEfficiency matc
               </dfn>
             </th>
             <th />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.00
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              0
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              0.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
           </tr>
           <tr>
             <td

--- a/analysis/huntersurvival/src/integrationTests/survivalIntegrationTests.test.ts.snap
+++ b/analysis/huntersurvival/src/integrationTests/survivalIntegrationTests.test.ts.snap
@@ -3314,6 +3314,103 @@ exports[`Survival Hunter integration test: Multi Target CastEfficiency matches t
             >
               <a
                 className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.00
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              0
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              0.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
                 href="http://wowhead.com/spell=307192"
                 rel="noopener noreferrer"
                 style={
@@ -9949,6 +10046,103 @@ exports[`Survival Hunter integration test: Single Target CastEfficiency matches 
               </dfn>
             </th>
             <th />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.20
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              1
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "100%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              100.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
           </tr>
           <tr>
             <td

--- a/analysis/magearcane/src/integrationTests/example.test.ts.snap
+++ b/analysis/magearcane/src/integrationTests/example.test.ts.snap
@@ -3790,6 +3790,103 @@ exports[`Arcane Mage integration test: example log CastEfficiency matches the st
             >
               <a
                 className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.00
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              0
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              0.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
                 href="http://wowhead.com/spell=307192"
                 rel="noopener noreferrer"
                 style={

--- a/analysis/magefire/src/integrationTests/example.test.ts.snap
+++ b/analysis/magefire/src/integrationTests/example.test.ts.snap
@@ -3189,6 +3189,103 @@ exports[`Fire Mage integration test: example log CastEfficiency matches the stat
             >
               <a
                 className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.16
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              1
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "100%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              100.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
                 href="http://wowhead.com/spell=307192"
                 rel="noopener noreferrer"
                 style={

--- a/analysis/magefrost/src/integrationTests/example.test.ts.snap
+++ b/analysis/magefrost/src/integrationTests/example.test.ts.snap
@@ -3445,6 +3445,103 @@ exports[`Frost Mage integration test: example log CastEfficiency matches the sta
             >
               <a
                 className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.17
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              1
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "100%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              100.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
                 href="http://wowhead.com/spell=307192"
                 rel="noopener noreferrer"
                 style={

--- a/analysis/monk/src/WeaponsOfOrder.tsx
+++ b/analysis/monk/src/WeaponsOfOrder.tsx
@@ -35,7 +35,7 @@ class WeaponsOfOrder extends Analyzer {
   }
 
   get masteryBuffPercentage() {
-    return BASE_MASTERY_PERCENTAGE * this.selectedCombatant.spec.masteryCoefficient;
+    return BASE_MASTERY_PERCENTAGE * (this.selectedCombatant.spec?.masteryCoefficient || 1);
   }
 }
 

--- a/analysis/monkbrewmaster/src/CONFIG.js
+++ b/analysis/monkbrewmaster/src/CONFIG.js
@@ -33,6 +33,13 @@ export default {
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
   exampleReport: '/report/bdf9wjm7XJQn3DCR/31-Mythic+The+Council+of+Blood+-+Wipe+15+(4:38)/Xaronbm',
+  // These are multipliers to the stats applied *on pull* that are not
+  // included in the stats reported by WCL. These are *baked in* and do
+  // not multiply temporary buffs.
+  //
+  // In general, it looks like armor is the only one that isn't applied
+  // by WCL.
+  statMultipliers: { armor: 1.25 },
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/analysis/monkbrewmaster/src/integrationTests/example.test.ts.snap
+++ b/analysis/monkbrewmaster/src/integrationTests/example.test.ts.snap
@@ -2879,6 +2879,103 @@ exports[`Brewmaster Monk integration test: example log CastEfficiency matches th
             >
               <a
                 className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.22
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              1
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "100%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              100.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
                 href="http://wowhead.com/spell=307192"
                 rel="noopener noreferrer"
                 style={

--- a/analysis/monkbrewmaster/src/modules/spells/CelestialFortune.js
+++ b/analysis/monkbrewmaster/src/modules/spells/CelestialFortune.js
@@ -192,7 +192,7 @@ class CelestialFortune extends Analyzer {
       const specClassName = spec.className.replace(' ', '');
       return (
         <span style={style} className={specClassName}>
-          <SpecIcon id={spec.id} />
+          <SpecIcon spec={spec} />
           {` ${combatant.name}`}
         </span>
       );

--- a/analysis/monkbrewmaster/src/modules/spells/CelestialFortune.js
+++ b/analysis/monkbrewmaster/src/modules/spells/CelestialFortune.js
@@ -188,11 +188,10 @@ class CelestialFortune extends Analyzer {
       if (!combatant) {
         return '';
       }
-      const spec = SPECS[combatant.specId];
-      const specClassName = spec.className.replace(' ', '');
+      const specClassName = combatant.player.type.replace(' ', '');
       return (
         <span style={style} className={specClassName}>
-          <SpecIcon spec={spec} />
+          <SpecIcon icon={combatant.player.icon} />
           {` ${combatant.name}`}
         </span>
       );

--- a/analysis/monkmistweaver/src/integrationTests/example.test.ts.snap
+++ b/analysis/monkmistweaver/src/integrationTests/example.test.ts.snap
@@ -3397,6 +3397,103 @@ exports[`Mistweaver Monk integration test: example log CastEfficiency matches th
             >
               <a
                 className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.00
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              0
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              0.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
                 href="http://wowhead.com/spell=307192"
                 rel="noopener noreferrer"
                 style={

--- a/analysis/paladinholy/src/integrationTests/example.test.ts.snap
+++ b/analysis/paladinholy/src/integrationTests/example.test.ts.snap
@@ -4739,6 +4739,103 @@ exports[`Holy Paladin integration test: example log CastEfficiency matches the s
             >
               <a
                 className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.15
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              1
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "100%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              100.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
                 href="http://wowhead.com/spell=307192"
                 rel="noopener noreferrer"
                 style={
@@ -6667,9 +6764,8 @@ Array [
               }
             >
               <img
-                alt="{\\"id\\":\\"specs.arms\\",\\"message\\":\\"Arms\\"} {\\"id\\":\\"specs.warrior\\",\\"message\\":\\"Warrior\\"}"
                 className="icon "
-                src="/specs/{\\"id\\":\\"specs.warrior\\",\\"message\\":\\"Warrior\\"}-{\\"id\\":\\"specs.arms\\",\\"message\\":\\"Arms\\"}.jpg"
+                src="/specs/undefined.jpg"
               />
                
               Relicprince
@@ -6696,7 +6792,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.warrior\\",\\"message\\":\\"Warrior\\"}-bg"
+                  className="flex-sub performance-bar Warrior-bg"
                   style={
                     Object {
                       "width": "100%",
@@ -6727,7 +6823,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.warrior\\",\\"message\\":\\"Warrior\\"}-bg"
+                  className="flex-sub performance-bar Warrior-bg"
                   style={
                     Object {
                       "width": "7.776232572766344%",
@@ -6756,9 +6852,8 @@ Array [
               }
             >
               <img
-                alt="{\\"id\\":\\"specs.holy\\",\\"message\\":\\"Holy\\"} {\\"id\\":\\"specs.paladin\\",\\"message\\":\\"Paladin\\"}"
                 className="icon "
-                src="/specs/{\\"id\\":\\"specs.paladin\\",\\"message\\":\\"Paladin\\"}-{\\"id\\":\\"specs.holy\\",\\"message\\":\\"Holy\\"}.jpg"
+                src="/specs/undefined.jpg"
               />
                
               Villahseen
@@ -6785,7 +6880,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.paladin\\",\\"message\\":\\"Paladin\\"}-bg"
+                  className="flex-sub performance-bar Paladin-bg"
                   style={
                     Object {
                       "width": "99.90453264906459%",
@@ -6816,7 +6911,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.paladin\\",\\"message\\":\\"Paladin\\"}-bg"
+                  className="flex-sub performance-bar Paladin-bg"
                   style={
                     Object {
                       "width": "100%",
@@ -6845,9 +6940,8 @@ Array [
               }
             >
               <img
-                alt="{\\"id\\":\\"specs.subtlety\\",\\"message\\":\\"Subtlety\\"} {\\"id\\":\\"specs.rogue\\",\\"message\\":\\"Rogue\\"}"
                 className="icon "
-                src="/specs/{\\"id\\":\\"specs.rogue\\",\\"message\\":\\"Rogue\\"}-{\\"id\\":\\"specs.subtlety\\",\\"message\\":\\"Subtlety\\"}.jpg"
+                src="/specs/undefined.jpg"
               />
                
               Miguro
@@ -6874,7 +6968,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.rogue\\",\\"message\\":\\"Rogue\\"}-bg"
+                  className="flex-sub performance-bar Rogue-bg"
                   style={
                     Object {
                       "width": "99.75837816275181%",
@@ -6905,7 +6999,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.rogue\\",\\"message\\":\\"Rogue\\"}-bg"
+                  className="flex-sub performance-bar Rogue-bg"
                   style={
                     Object {
                       "width": "63.182920437471616%",
@@ -6934,9 +7028,8 @@ Array [
               }
             >
               <img
-                alt="{\\"id\\":\\"specs.beastMastery\\",\\"message\\":\\"Beast Mastery\\"} {\\"id\\":\\"specs.hunter\\",\\"message\\":\\"Hunter\\"}"
                 className="icon "
-                src="/specs/{\\"id\\":\\"specs.hunter\\",\\"message\\":\\"Hunter\\"}-{\\"id\\":\\"specs.beastMastery\\",\\"message\\":\\"BeastMastery\\"}.jpg"
+                src="/specs/undefined.jpg"
               />
                
               Uniiq
@@ -6963,7 +7056,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.hunter\\",\\"message\\":\\"Hunter\\"}-bg"
+                  className="flex-sub performance-bar Hunter-bg"
                   style={
                     Object {
                       "width": "98.82772145283883%",
@@ -6994,7 +7087,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.hunter\\",\\"message\\":\\"Hunter\\"}-bg"
+                  className="flex-sub performance-bar Hunter-bg"
                   style={
                     Object {
                       "width": "33.534924350955656%",
@@ -7023,9 +7116,8 @@ Array [
               }
             >
               <img
-                alt="{\\"id\\":\\"specs.arms\\",\\"message\\":\\"Arms\\"} {\\"id\\":\\"specs.warrior\\",\\"message\\":\\"Warrior\\"}"
                 className="icon "
-                src="/specs/{\\"id\\":\\"specs.warrior\\",\\"message\\":\\"Warrior\\"}-{\\"id\\":\\"specs.arms\\",\\"message\\":\\"Arms\\"}.jpg"
+                src="/specs/undefined.jpg"
               />
                
               Prüttan
@@ -7052,7 +7144,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.warrior\\",\\"message\\":\\"Warrior\\"}-bg"
+                  className="flex-sub performance-bar Warrior-bg"
                   style={
                     Object {
                       "width": "96.7527230206816%",
@@ -7083,7 +7175,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.warrior\\",\\"message\\":\\"Warrior\\"}-bg"
+                  className="flex-sub performance-bar Warrior-bg"
                   style={
                     Object {
                       "width": "23.98700164226563%",
@@ -7112,9 +7204,8 @@ Array [
               }
             >
               <img
-                alt="{\\"id\\":\\"specs.havoc\\",\\"message\\":\\"Havoc\\"} {\\"id\\":\\"specs.demonHunter\\",\\"message\\":\\"Demon Hunter\\"}"
                 className="icon "
-                src="/specs/{\\"id\\":\\"specs.demonHunter\\",\\"message\\":\\"DemonHunter\\"}-{\\"id\\":\\"specs.havoc\\",\\"message\\":\\"Havoc\\"}.jpg"
+                src="/specs/undefined.jpg"
               />
                
               Demolicious
@@ -7141,7 +7232,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.demonHunter\\",\\"message\\":\\"DemonHunter\\"}-bg"
+                  className="flex-sub performance-bar DemonHunter-bg"
                   style={
                     Object {
                       "width": "95.02652453637467%",
@@ -7172,7 +7263,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.demonHunter\\",\\"message\\":\\"DemonHunter\\"}-bg"
+                  className="flex-sub performance-bar DemonHunter-bg"
                   style={
                     Object {
                       "width": "36.795555400258564%",
@@ -7201,9 +7292,8 @@ Array [
               }
             >
               <img
-                alt="{\\"id\\":\\"specs.guardian\\",\\"message\\":\\"Guardian\\"} {\\"id\\":\\"specs.druid\\",\\"message\\":\\"Druid\\"}"
                 className="icon "
-                src="/specs/{\\"id\\":\\"specs.druid\\",\\"message\\":\\"Druid\\"}-{\\"id\\":\\"specs.guardian\\",\\"message\\":\\"Guardian\\"}.jpg"
+                src="/specs/undefined.jpg"
               />
                
               Hildelyst
@@ -7230,7 +7320,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.druid\\",\\"message\\":\\"Druid\\"}-bg"
+                  className="flex-sub performance-bar Druid-bg"
                   style={
                     Object {
                       "width": "92.36189391256022%",
@@ -7261,7 +7351,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.druid\\",\\"message\\":\\"Druid\\"}-bg"
+                  className="flex-sub performance-bar Druid-bg"
                   style={
                     Object {
                       "width": "22.691638422027324%",
@@ -7290,9 +7380,8 @@ Array [
               }
             >
               <img
-                alt="{\\"id\\":\\"specs.brewmaster\\",\\"message\\":\\"Brewmaster\\"} {\\"id\\":\\"specs.monk\\",\\"message\\":\\"Monk\\"}"
                 className="icon "
-                src="/specs/{\\"id\\":\\"specs.monk\\",\\"message\\":\\"Monk\\"}-{\\"id\\":\\"specs.brewmaster\\",\\"message\\":\\"Brewmaster\\"}.jpg"
+                src="/specs/undefined.jpg"
               />
                
               Dobbadon
@@ -7319,7 +7408,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.monk\\",\\"message\\":\\"Monk\\"}-bg"
+                  className="flex-sub performance-bar Monk-bg"
                   style={
                     Object {
                       "width": "91.38361345054697%",
@@ -7350,7 +7439,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.monk\\",\\"message\\":\\"Monk\\"}-bg"
+                  className="flex-sub performance-bar Monk-bg"
                   style={
                     Object {
                       "width": "20.533212201684194%",
@@ -7379,9 +7468,8 @@ Array [
               }
             >
               <img
-                alt="{\\"id\\":\\"specs.restoration\\",\\"message\\":\\"Restoration\\"} {\\"id\\":\\"specs.druid\\",\\"message\\":\\"Druid\\"}"
                 className="icon "
-                src="/specs/{\\"id\\":\\"specs.druid\\",\\"message\\":\\"Druid\\"}-{\\"id\\":\\"specs.restoration\\",\\"message\\":\\"Restoration\\"}.jpg"
+                src="/specs/undefined.jpg"
               />
                
               Cónqs
@@ -7408,7 +7496,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.druid\\",\\"message\\":\\"Druid\\"}-bg"
+                  className="flex-sub performance-bar Druid-bg"
                   style={
                     Object {
                       "width": "90.06108731455261%",
@@ -7439,7 +7527,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.druid\\",\\"message\\":\\"Druid\\"}-bg"
+                  className="flex-sub performance-bar Druid-bg"
                   style={
                     Object {
                       "width": "18.76878996470876%",
@@ -7468,9 +7556,8 @@ Array [
               }
             >
               <img
-                alt="{\\"id\\":\\"specs.retribution\\",\\"message\\":\\"Retribution\\"} {\\"id\\":\\"specs.paladin\\",\\"message\\":\\"Paladin\\"}"
                 className="icon "
-                src="/specs/{\\"id\\":\\"specs.paladin\\",\\"message\\":\\"Paladin\\"}-{\\"id\\":\\"specs.retribution\\",\\"message\\":\\"Retribution\\"}.jpg"
+                src="/specs/undefined.jpg"
               />
                
               Sanctues
@@ -7497,7 +7584,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.paladin\\",\\"message\\":\\"Paladin\\"}-bg"
+                  className="flex-sub performance-bar Paladin-bg"
                   style={
                     Object {
                       "width": "89.42101282580826%",
@@ -7528,7 +7615,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.paladin\\",\\"message\\":\\"Paladin\\"}-bg"
+                  className="flex-sub performance-bar Paladin-bg"
                   style={
                     Object {
                       "width": "24.32551801250917%",
@@ -7557,9 +7644,8 @@ Array [
               }
             >
               <img
-                alt="{\\"id\\":\\"specs.holy\\",\\"message\\":\\"Holy\\"} {\\"id\\":\\"specs.paladin\\",\\"message\\":\\"Paladin\\"}"
                 className="icon "
-                src="/specs/{\\"id\\":\\"specs.paladin\\",\\"message\\":\\"Paladin\\"}-{\\"id\\":\\"specs.holy\\",\\"message\\":\\"Holy\\"}.jpg"
+                src="/specs/undefined.jpg"
               />
                
               Mooladin
@@ -7586,7 +7672,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.paladin\\",\\"message\\":\\"Paladin\\"}-bg"
+                  className="flex-sub performance-bar Paladin-bg"
                   style={
                     Object {
                       "width": "88.23653957419722%",
@@ -7617,7 +7703,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.paladin\\",\\"message\\":\\"Paladin\\"}-bg"
+                  className="flex-sub performance-bar Paladin-bg"
                   style={
                     Object {
                       "width": "2.1772948041510887%",
@@ -7646,9 +7732,8 @@ Array [
               }
             >
               <img
-                alt="{\\"id\\":\\"specs.frost\\",\\"message\\":\\"Frost\\"} {\\"id\\":\\"specs.mage\\",\\"message\\":\\"Mage\\"}"
                 className="icon "
-                src="/specs/{\\"id\\":\\"specs.mage\\",\\"message\\":\\"Mage\\"}-{\\"id\\":\\"specs.frost\\",\\"message\\":\\"Frost\\"}.jpg"
+                src="/specs/undefined.jpg"
               />
                
               Jodiefroster
@@ -7675,7 +7760,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.mage\\",\\"message\\":\\"Mage\\"}-bg"
+                  className="flex-sub performance-bar Mage-bg"
                   style={
                     Object {
                       "width": "87.6714126923483%",
@@ -7706,7 +7791,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.mage\\",\\"message\\":\\"Mage\\"}-bg"
+                  className="flex-sub performance-bar Mage-bg"
                   style={
                     Object {
                       "width": "14.997309479716273%",
@@ -7735,9 +7820,8 @@ Array [
               }
             >
               <img
-                alt="{\\"id\\":\\"specs.affliction\\",\\"message\\":\\"Affliction\\"} {\\"id\\":\\"specs.warlock\\",\\"message\\":\\"Warlock\\"}"
                 className="icon "
-                src="/specs/{\\"id\\":\\"specs.warlock\\",\\"message\\":\\"Warlock\\"}-{\\"id\\":\\"specs.affliction\\",\\"message\\":\\"Affliction\\"}.jpg"
+                src="/specs/undefined.jpg"
               />
                
               Diagentez
@@ -7764,7 +7848,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.warlock\\",\\"message\\":\\"Warlock\\"}-bg"
+                  className="flex-sub performance-bar Warlock-bg"
                   style={
                     Object {
                       "width": "82.53549868889384%",
@@ -7795,7 +7879,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.warlock\\",\\"message\\":\\"Warlock\\"}-bg"
+                  className="flex-sub performance-bar Warlock-bg"
                   style={
                     Object {
                       "width": "3.704951256158496%",
@@ -7824,9 +7908,8 @@ Array [
               }
             >
               <img
-                alt="{\\"id\\":\\"specs.frost\\",\\"message\\":\\"Frost\\"} {\\"id\\":\\"specs.mage\\",\\"message\\":\\"Mage\\"}"
                 className="icon "
-                src="/specs/{\\"id\\":\\"specs.mage\\",\\"message\\":\\"Mage\\"}-{\\"id\\":\\"specs.frost\\",\\"message\\":\\"Frost\\"}.jpg"
+                src="/specs/undefined.jpg"
               />
                
               Snusraketten
@@ -7853,7 +7936,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.mage\\",\\"message\\":\\"Mage\\"}-bg"
+                  className="flex-sub performance-bar Mage-bg"
                   style={
                     Object {
                       "width": "80.0775139814152%",
@@ -7884,7 +7967,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.mage\\",\\"message\\":\\"Mage\\"}-bg"
+                  className="flex-sub performance-bar Mage-bg"
                   style={
                     Object {
                       "width": "5.307522974247878%",
@@ -7913,9 +7996,8 @@ Array [
               }
             >
               <img
-                alt="{\\"id\\":\\"specs.mage.arcane\\",\\"message\\":\\"Arcane\\"} {\\"id\\":\\"specs.mage\\",\\"message\\":\\"Mage\\"}"
                 className="icon "
-                src="/specs/{\\"id\\":\\"specs.mage\\",\\"message\\":\\"Mage\\"}-{\\"id\\":\\"specs.mage.arcane\\",\\"message\\":\\"Arcane\\"}.jpg"
+                src="/specs/undefined.jpg"
               />
                
               Nuffemis
@@ -7942,7 +8024,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.mage\\",\\"message\\":\\"Mage\\"}-bg"
+                  className="flex-sub performance-bar Mage-bg"
                   style={
                     Object {
                       "width": "72.62709335906682%",
@@ -7973,7 +8055,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.mage\\",\\"message\\":\\"Mage\\"}-bg"
+                  className="flex-sub performance-bar Mage-bg"
                   style={
                     Object {
                       "width": "12.392326775918097%",
@@ -8002,9 +8084,8 @@ Array [
               }
             >
               <img
-                alt="{\\"id\\":\\"specs.restoration\\",\\"message\\":\\"Restoration\\"} {\\"id\\":\\"specs.druid\\",\\"message\\":\\"Druid\\"}"
                 className="icon "
-                src="/specs/{\\"id\\":\\"specs.druid\\",\\"message\\":\\"Druid\\"}-{\\"id\\":\\"specs.restoration\\",\\"message\\":\\"Restoration\\"}.jpg"
+                src="/specs/undefined.jpg"
               />
                
               Smusk
@@ -8031,7 +8112,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.druid\\",\\"message\\":\\"Druid\\"}-bg"
+                  className="flex-sub performance-bar Druid-bg"
                   style={
                     Object {
                       "width": "55.20479425239239%",
@@ -8062,7 +8143,7 @@ Array [
                 className="flex performance-bar-container"
               >
                 <div
-                  className="flex-sub performance-bar {\\"id\\":\\"specs.druid\\",\\"message\\":\\"Druid\\"}-bg"
+                  className="flex-sub performance-bar Druid-bg"
                   style={
                     Object {
                       "width": "15.60473811104511%",

--- a/analysis/paladinprotection/src/integrationTests/example.test.ts.snap
+++ b/analysis/paladinprotection/src/integrationTests/example.test.ts.snap
@@ -2587,6 +2587,103 @@ exports[`Protection Paladin integration test: example log CastEfficiency matches
             >
               <a
                 className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.00
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              0
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              0.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
                 href="http://wowhead.com/spell=307192"
                 rel="noopener noreferrer"
                 style={

--- a/analysis/priestshadow/src/integrationTests/example.test.ts.snap
+++ b/analysis/priestshadow/src/integrationTests/example.test.ts.snap
@@ -3736,6 +3736,103 @@ exports[`Shadow Priest integration test: example log CastEfficiency matches the 
             >
               <a
                 className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.00
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              0
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              0.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
                 href="http://wowhead.com/spell=307192"
                 rel="noopener noreferrer"
                 style={

--- a/analysis/rogue/src/InvigoratingShadowdust.tsx
+++ b/analysis/rogue/src/InvigoratingShadowdust.tsx
@@ -22,15 +22,13 @@ class InvigoratingShadowdust extends Analyzer {
     abilities: Abilities,
     spellUsable: SpellUsable,
   };
-  spec: string = '';
   cooldownReduction: number = 15000; // 15 seconds
   cooldowns: SpellList[] = [];
   protected spellUsable!: SpellUsable;
 
   constructor(options: Options) {
     super(options);
-    this.spec = this.selectedCombatant.spec.specName;
-    switch (this.spec) {
+    switch (this.selectedCombatant.spec?.specName) {
       case 'Assassination':
         this.cooldowns = ASSASSINATION_ABILITY_COOLDOWNS;
         break;

--- a/analysis/rogue/src/covenants/nightfae/StealthAbilityFollowingSepsis.tsx
+++ b/analysis/rogue/src/covenants/nightfae/StealthAbilityFollowingSepsis.tsx
@@ -35,7 +35,7 @@ class StealthAbilityFollowingSepsis extends Analyzer {
     STEALTH_ABILITIES.forEach((ability) => {
       this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(ability), this.onStealthAbility);
     });
-    const specId = this.selectedCombatant.spec.id;
+    const specId = this.selectedCombatant.specId;
     // Outlaw and Assassination should use Ambush, Sub should use Shadowstrike.
     this.properStealthAbility =
       specId === SPECS.OUTLAW_ROGUE.id || specId === SPECS.ASSASSINATION_ROGUE.id

--- a/analysis/shamanelemental/src/integrationTests/example.test.ts.snap
+++ b/analysis/shamanelemental/src/integrationTests/example.test.ts.snap
@@ -2554,6 +2554,103 @@ exports[`Elemental Shaman integration test: Hungering Destroyer log CastEfficien
             >
               <a
                 className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.37
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              1
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "100%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              100.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
                 href="http://wowhead.com/spell=307192"
                 rel="noopener noreferrer"
                 style={
@@ -9006,6 +9103,103 @@ exports[`Elemental Shaman integration test: Huntsman Altimor log CastEfficiency 
               </dfn>
             </th>
             <th />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.00
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              0
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              0.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
           </tr>
           <tr>
             <td

--- a/analysis/shamanrestoration/src/modules/spells/ChainHeal.tsx
+++ b/analysis/shamanrestoration/src/modules/spells/ChainHeal.tsx
@@ -2,7 +2,6 @@ import { t } from '@lingui/macro';
 import { Trans } from '@lingui/macro';
 import { formatNth, formatDuration } from 'common/format';
 import SPELLS from 'common/SPELLS';
-import SPECS, { Spec } from 'game/SPECS';
 import { SpellIcon, SpellLink, SpecIcon } from 'interface';
 import { TooltipElement } from 'interface';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
@@ -21,7 +20,7 @@ interface ChainHealInfo {
   target: {
     id: number | undefined;
     name: string;
-    spec: Spec;
+    specIcon: string;
     specClassName: string;
   };
   timestamp: number;
@@ -81,8 +80,8 @@ class ChainHeal extends Analyzer {
       target: {
         id: currentCast.targetID,
         name: combatant.name,
-        spec: SPECS[combatant.specId],
-        specClassName: SPECS[combatant.specId].className.replace(' ', ''),
+        specIcon: combatant.player.icon,
+        specClassName: combatant.player.type,
       },
       timestamp: currentCast.timestamp,
       castNo: this.castIndex,
@@ -203,9 +202,9 @@ class ChainHeal extends Analyzer {
                     <tr key={cast.timestamp}>
                       <th scope="row">{formatNth(cast.castNo)}</th>
                       <td>{formatDuration(cast.timestamp - this.owner.fight.start_time, 0)}</td>
-                      <td className={cast.target.specClassName}>
+                      <td className={cast.target.specClassName.replace(' ', '')}>
                         {' '}
-                        <SpecIcon spec={cast.target.spec} /> {cast.target.name}
+                        <SpecIcon icon={cast.target.specIcon} /> {cast.target.name}
                       </td>
                     </tr>
                   ))}

--- a/analysis/shamanrestoration/src/modules/spells/ChainHeal.tsx
+++ b/analysis/shamanrestoration/src/modules/spells/ChainHeal.tsx
@@ -205,7 +205,7 @@ class ChainHeal extends Analyzer {
                       <td>{formatDuration(cast.timestamp - this.owner.fight.start_time, 0)}</td>
                       <td className={cast.target.specClassName}>
                         {' '}
-                        <SpecIcon id={cast.target.spec.id} /> {cast.target.name}
+                        <SpecIcon spec={cast.target.spec} /> {cast.target.name}
                       </td>
                     </tr>
                   ))}

--- a/analysis/shamanrestoration/src/modules/spells/ManaTideTotem.tsx
+++ b/analysis/shamanrestoration/src/modules/spells/ManaTideTotem.tsx
@@ -50,7 +50,7 @@ class ManaTideTotem extends Analyzer {
     return Object.assign(
       {},
       ...Object.values(this.combatants.players)
-        .filter((player) => player.spec.role === ROLES.HEALER)
+        .filter((player) => player.spec?.role === ROLES.HEALER)
         .map((player) => ({
           [player.id]: {
             healer: player,

--- a/analysis/shamanrestoration/src/modules/spells/ManaTideTotem.tsx
+++ b/analysis/shamanrestoration/src/modules/spells/ManaTideTotem.tsx
@@ -90,7 +90,7 @@ class ManaTideTotem extends Analyzer {
                 return (
                   <tr key={p.healer.id}>
                     <th className={specClassName}>
-                      <SpecIcon id={p.healer.specId} /> {p.healer.name}
+                      <SpecIcon spec={spec} /> {p.healer.name}
                     </th>
                     <td>{formatNumber(this.regenFromUptime(p.uptime))}</td>
                   </tr>

--- a/analysis/shamanrestoration/src/modules/spells/ManaTideTotem.tsx
+++ b/analysis/shamanrestoration/src/modules/spells/ManaTideTotem.tsx
@@ -2,7 +2,6 @@ import { Trans } from '@lingui/macro';
 import { formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import ROLES from 'game/ROLES';
-import SPECS from 'game/SPECS';
 import { SpellLink } from 'interface';
 import { SpecIcon } from 'interface';
 import ManaIcon from 'interface/icons/Mana';
@@ -84,13 +83,12 @@ class ManaTideTotem extends Analyzer {
             </thead>
             <tbody>
               {Object.values(this.regenPerHealer).map((p) => {
-                const spec = SPECS[p.healer.specId];
-                const specClassName = spec.className.replace(' ', '');
+                const specClassName = p.healer.player.type.replace(' ', '');
 
                 return (
                   <tr key={p.healer.id}>
                     <th className={specClassName}>
-                      <SpecIcon spec={spec} /> {p.healer.name}
+                      <SpecIcon icon={p.healer.player.icon} /> {p.healer.name}
                     </th>
                     <td>{formatNumber(this.regenFromUptime(p.uptime))}</td>
                   </tr>

--- a/analysis/shamanrestoration/src/modules/talents/AncestralProtectionTotem.tsx
+++ b/analysis/shamanrestoration/src/modules/talents/AncestralProtectionTotem.tsx
@@ -3,7 +3,6 @@ import fetchWcl from 'common/fetchWclApi';
 import { formatDuration } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { WCLEventsResponse, WclOptions } from 'common/WCL_TYPES';
-import SPECS from 'game/SPECS';
 import { SpellIcon } from 'interface';
 import { SpellLink } from 'interface';
 import { Icon } from 'interface';
@@ -137,8 +136,7 @@ class AncestralProtectionTotem extends Analyzer {
                   return null; // pet or something
                 }
 
-                const spec = SPECS[combatant.specId];
-                const specClassName = spec.className.replace(' ', '');
+                const specClassName = combatant.player.type.replace(' ', '');
 
                 return (
                   <tr key={index}>

--- a/analysis/shamanrestoration/src/modules/talents/AncestralVigor.tsx
+++ b/analysis/shamanrestoration/src/modules/talents/AncestralVigor.tsx
@@ -154,8 +154,7 @@ class AncestralVigor extends Analyzer {
                 if (!combatant) {
                   return null;
                 }
-                const spec = SPECS[combatant.specId];
-                const specClassName = spec.className.replace(' ', '');
+                const specClassName = combatant.player.type.replace(' ', '');
 
                 return (
                   <tr key={index}>

--- a/analysis/tbchunter/package.json
+++ b/analysis/tbchunter/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@wowanalyzer/tbc-hunter",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "typings": "src/index.ts",
+  "files": [
+    "src"
+  ],
+  "dependencies": {
+    "@lingui/macro": "^3.3.0",
+    "common": "link:../../src/common",
+    "game": "link:../../src/game",
+    "interface": "link:../../src/interface",
+    "parser": "link:../../src/parser",
+    "prop-types": "^15.7.2",
+    "react": "^16.13.1",
+    "react-toggle": "^4.0.2"
+  }
+}

--- a/analysis/tbchunter/src/CHANGELOG.tsx
+++ b/analysis/tbchunter/src/CHANGELOG.tsx
@@ -1,0 +1,6 @@
+import { change, date } from 'common/changelog';
+import { Zerotorescue } from 'CONTRIBUTORS';
+
+export default [
+  change(date(2021, 6, 7), 'Initial setup', Zerotorescue),
+];

--- a/analysis/tbchunter/src/CONFIG.tsx
+++ b/analysis/tbchunter/src/CONFIG.tsx
@@ -1,0 +1,50 @@
+import { t } from '@lingui/macro';
+import { Zerotorescue } from 'CONTRIBUTORS';
+import PRIMARY_STATS from 'game/PRIMARY_STATS';
+import ROLES from 'game/ROLES';
+import Config from 'parser/Config';
+import React from 'react';
+
+import CHANGELOG from './CHANGELOG';
+
+const config: Config = {
+  // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
+  contributors: [Zerotorescue],
+  // The WoW client patch this spec was last updated.
+  patchCompatibility: '2.0.0',
+  isPartial: true,
+  // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
+  // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
+  description: <>Proof of Concept analysis for BM Hunters.</>,
+  // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
+  exampleReport: '/report/Dd4mA7LtyGqhCanN/10-Heroic+Hungering+Destroyer+-+Kill+(4:04)/Sucker',
+
+  // Don't change anything below this line;
+  // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
+  spec: {
+    id: 0,
+    type: 'Hunter',
+    index: 35,
+    className: t({
+      id: 'className.hunter',
+      message: `Hunter`,
+    }),
+    role: ROLES.TANK,
+    primaryStat: PRIMARY_STATS.AGILITY,
+    ranking: {
+      class: 12,
+      spec: 2,
+    },
+  },
+  // The contents of your changelog.
+  changelog: CHANGELOG,
+  // The CombatLogParser class for your spec.
+  parser: () =>
+    import('./CombatLogParser' /* webpackChunkName: "TBCHunter" */).then(
+      (exports) => exports.default,
+    ),
+  // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
+  path: __dirname,
+};
+
+export default config;

--- a/analysis/tbchunter/src/CombatLogParser.ts
+++ b/analysis/tbchunter/src/CombatLogParser.ts
@@ -1,0 +1,13 @@
+import CoreCombatLogParser from 'parser/core/CombatLogParser';
+
+import Abilities from './modules/Abilities';
+import Buffs from './modules/Buffs';
+
+class CombatLogParser extends CoreCombatLogParser {
+  static specModules = {
+    abilities: Abilities,
+    buffs: Buffs,
+  };
+}
+
+export default CombatLogParser;

--- a/analysis/tbchunter/src/CombatLogParser.ts
+++ b/analysis/tbchunter/src/CombatLogParser.ts
@@ -1,4 +1,4 @@
-import CoreCombatLogParser from 'parser/core/CombatLogParser';
+import CoreCombatLogParser from 'parser/tbc/CombatLogParser';
 
 import Abilities from './modules/Abilities';
 import Buffs from './modules/Buffs';

--- a/analysis/tbchunter/src/index.ts
+++ b/analysis/tbchunter/src/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CONFIG';

--- a/analysis/tbchunter/src/modules/Abilities.tsx
+++ b/analysis/tbchunter/src/modules/Abilities.tsx
@@ -1,0 +1,12 @@
+import CoreAbilities from 'parser/core/modules/Abilities';
+import { SpellbookAbility } from 'parser/core/modules/Ability';
+
+class Abilities extends CoreAbilities {
+  spellbook(): SpellbookAbility[] {
+    return [
+      // TODO
+    ];
+  }
+}
+
+export default Abilities;

--- a/analysis/tbchunter/src/modules/Buffs.tsx
+++ b/analysis/tbchunter/src/modules/Buffs.tsx
@@ -1,0 +1,11 @@
+import CoreBuffs from 'parser/core/modules/Buffs';
+
+class Buffs extends CoreBuffs {
+  buffs() {
+    return [
+      // TODO
+    ];
+  }
+}
+
+export default Buffs;

--- a/analysis/warlockaffliction/src/integrationTests/example.test.ts.snap
+++ b/analysis/warlockaffliction/src/integrationTests/example.test.ts.snap
@@ -3723,6 +3723,103 @@ exports[`Affliction Warlock integration test: example log CastEfficiency matches
             >
               <a
                 className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.00
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              0
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              0.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
                 href="http://wowhead.com/spell=307192"
                 rel="noopener noreferrer"
                 style={

--- a/analysis/warlockdemonology/src/integrationTests/example.test.ts.snap
+++ b/analysis/warlockdemonology/src/integrationTests/example.test.ts.snap
@@ -3339,6 +3339,103 @@ exports[`Demonology Warlock integration test: example log CastEfficiency matches
             >
               <a
                 className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.21
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              1
+              /2
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "50%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              50.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
                 href="http://wowhead.com/spell=307192"
                 rel="noopener noreferrer"
                 style={

--- a/analysis/warlockdestruction/src/integrationTests/example.test.ts.snap
+++ b/analysis/warlockdestruction/src/integrationTests/example.test.ts.snap
@@ -3595,6 +3595,103 @@ exports[`Destruction Warlock integration test: example log CastEfficiency matche
             >
               <a
                 className="spell-link-text"
+                href="http://wowhead.com/spell=6262"
+                rel="noopener noreferrer"
+                style={
+                  Object {
+                    "color": "#fff",
+                  }
+                }
+                target="_blank"
+              >
+                <img
+                  alt=""
+                  className="icon game "
+                  src="//render-us.worldofwarcraft.com/icons/56/warlock_healthstone.jpg"
+                  style={
+                    Object {
+                      "height": undefined,
+                      "marginTop": undefined,
+                    }
+                  }
+                />
+                 
+                Healthstone
+              </a>
+            </td>
+            <td
+              className="text-center"
+              style={
+                Object {
+                  "minWidth": 80,
+                }
+              }
+            >
+              0.00
+            </td>
+            <td
+              className="text-right"
+              style={
+                Object {
+                  "minWidth": 110,
+                }
+              }
+            >
+              0
+              /1
+               casts
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "20%",
+                }
+              }
+            >
+              <div
+                className="flex performance-bar-container"
+              >
+                <div
+                  className="flex-sub performance-bar"
+                  style={
+                    Object {
+                      "backgroundColor": "#70b570",
+                      "width": "0%",
+                    }
+                  }
+                />
+              </div>
+            </td>
+            <td
+              className="text-left"
+              style={
+                Object {
+                  "minWidth": 50,
+                  "paddingRight": 5,
+                }
+              }
+            >
+              0.00%
+            </td>
+            <td
+              style={
+                Object {
+                  "color": "orange",
+                  "width": "25%",
+                }
+              }
+            />
+          </tr>
+          <tr>
+            <td
+              style={
+                Object {
+                  "width": "35%",
+                }
+              }
+            >
+              <a
+                className="spell-link-text"
                 href="http://wowhead.com/spell=307192"
                 rel="noopener noreferrer"
                 style={

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@wowanalyzer/shaman-elemental": "*",
     "@wowanalyzer/shaman-enhancement": "*",
     "@wowanalyzer/shaman-restoration": "*",
+    "@wowanalyzer/tbc-hunter": "*",
     "@wowanalyzer/warlock-affliction": "*",
     "@wowanalyzer/warlock-demonology": "*",
     "@wowanalyzer/warlock-destruction": "*",

--- a/src/articles/2018-01-31-1st-Anniversary/index.tsx
+++ b/src/articles/2018-01-31-1st-Anniversary/index.tsx
@@ -109,7 +109,7 @@ interface SpecIconProps {
 
 const SpecIcon = ({ spec }: SpecIconProps) => (
   <img
-    src={`/specs/${spec.className.replace(' ', '')}-${spec.specName.replace(' ', '')}.jpg`}
+    src={`/specs/${spec.className.replace(' ', '')}-${spec.specName?.replace(' ', '')}.jpg`}
     alt={`${spec.specName} ${spec.className}`}
     style={{ float: 'left', borderRadius: 5, margin: '5px 10px 10px 0px' }}
   />

--- a/src/game/SPECS.ts
+++ b/src/game/SPECS.ts
@@ -6,13 +6,17 @@ import ROLES from './ROLES';
 
 export interface Spec {
   id: number;
+  /**
+   * The "type" as provided in the player object by WCL. Used for expansions without specs, such as TBC.
+   */
+  type?: string;
   index: number;
   className: string;
-  specName: string;
+  specName?: string;
   role: number;
   primaryStat: string;
-  masterySpellId: number;
-  masteryCoefficient: number;
+  masterySpellId?: number;
+  masteryCoefficient?: number;
   ranking: {
     class: number;
     spec: number;

--- a/src/game/raids/index.ts
+++ b/src/game/raids/index.ts
@@ -18,7 +18,7 @@ interface EncounterConfig {
   };
   resultsWarning?: string;
   phases?: { [key: string]: PhaseConfig };
-  raceTranslation?: (race: Race, spec: Spec) => Race;
+  raceTranslation?: (race: Race, spec?: Spec) => Race;
   disableDeathSuggestion?: boolean;
   disableDowntimeSuggestion?: boolean;
   disableDowntimeStatistic?: boolean;

--- a/src/interface/ContributorDetails.tsx
+++ b/src/interface/ContributorDetails.tsx
@@ -30,7 +30,7 @@ class ContributorDetails extends React.PureComponent<ContributorProps> {
     return (
       <div key={character.name}>
         <a href={character.link} className={this.removeWhiteSpaces(character.spec.className)}>
-          <SpecIcon id={character.spec.id} /> {character.name}
+          <SpecIcon spec={character.spec} /> {character.name}
         </a>
       </div>
     );
@@ -56,7 +56,7 @@ class ContributorDetails extends React.PureComponent<ContributorProps> {
 
     return (
       <>
-        <SpecIcon id={spec} style={{ height: '2em', width: '2em', marginRight: 10 }} />
+        <SpecIcon spec={SPECS[spec]} style={{ height: '2em', width: '2em', marginRight: 10 }} />
         {SPECS[spec].specName} {SPECS[spec].className}
       </>
     );
@@ -141,7 +141,7 @@ class ContributorDetails extends React.PureComponent<ContributorProps> {
         <div className="col-md-9">
           {maintainedSpecs.map((spec) => (
             <div key={spec.id} className={this.removeWhiteSpaces(spec.className)}>
-              <SpecIcon id={spec.id} /> {spec.specName} {spec.className}
+              <SpecIcon spec={spec} /> {spec.specName} {spec.className}
             </div>
           ))}
         </div>

--- a/src/interface/NewsList.tsx
+++ b/src/interface/NewsList.tsx
@@ -92,7 +92,7 @@ const NewsList = ({ topAnchor }: Props) => {
                     </>
                   ) : (
                     <>
-                      <SpecIcon id={item.spec.id} /> {item.spec.specName} {item.spec.className}
+                      <SpecIcon spec={item.spec} /> {item.spec.specName} {item.spec.className}
                     </>
                   )}{' '}
                   updated at {item.date.toLocaleDateString()} by{' '}

--- a/src/interface/SpecIcon.tsx
+++ b/src/interface/SpecIcon.tsx
@@ -1,26 +1,18 @@
-import SPECS from 'game/SPECS';
+import { Spec } from 'game/SPECS';
 import React from 'react';
 
 interface Props extends Omit<React.HTMLAttributes<HTMLImageElement>, 'id'> {
-  id: number;
+  spec: Spec;
   className?: string;
 }
 
-const SpecIcon = ({ id, className, ...others }: Props) => {
-  if (!SPECS[id]) {
-    throw new Error(`Unknown spec: ${id}`);
-  }
-
-  const spec = SPECS[id];
-
-  return (
-    <img
-      src={`/specs/${spec.className.replace(' ', '')}-${spec.specName.replace(' ', '')}.jpg`}
-      alt={`${spec.specName} ${spec.className}`}
-      className={`icon ${className || ''}`}
-      {...others}
-    />
-  );
-};
+const SpecIcon = ({ spec, className, ...others }: Props) => (
+  <img
+    src={`/specs/${[spec.className, spec.specName].filter(Boolean).join('-').replace(' ', '')}.jpg`}
+    alt={`${spec.specName} ${spec.className}`}
+    className={`icon ${className || ''}`}
+    {...others}
+  />
+);
 
 export default SpecIcon;

--- a/src/interface/SpecIcon.tsx
+++ b/src/interface/SpecIcon.tsx
@@ -2,14 +2,17 @@ import { Spec } from 'game/SPECS';
 import React from 'react';
 
 interface Props extends Omit<React.HTMLAttributes<HTMLImageElement>, 'id'> {
-  spec: Spec;
+  spec?: Spec;
+  icon?: string;
   className?: string;
 }
 
-const SpecIcon = ({ spec, className, ...others }: Props) => (
+const SpecIcon = ({ spec, icon, className, ...others }: Props) => (
   <img
-    src={`/specs/${[spec.className, spec.specName].filter(Boolean).join('-').replace(' ', '')}.jpg`}
-    alt={`${spec.specName} ${spec.className}`}
+    src={`/specs/${
+      spec ? [spec.className, spec.specName].filter(Boolean).join('-').replace(' ', '') : icon
+    }.jpg`}
+    alt={spec ? `${spec.specName} ${spec.className}` : icon}
     className={`icon ${className || ''}`}
     {...others}
   />

--- a/src/interface/SpecListItem.tsx
+++ b/src/interface/SpecListItem.tsx
@@ -4,6 +4,8 @@ import ReadableListing from 'interface/ReadableListing';
 import Config from 'parser/Config';
 import React from 'react';
 
+import SpecIcon from './SpecIcon';
+
 const SpecListItem = ({
   spec,
   exampleReport,
@@ -31,10 +33,7 @@ const SpecListItem = ({
     >
       <div className="icon">
         <figure>
-          <img
-            src={`/specs/${className}-${spec.specName.replace(' ', '')}.jpg`}
-            alt={`${spec.specName} ${spec.className}`}
-          />
+          <SpecIcon spec={spec} />
         </figure>
       </div>
       <div className="description">

--- a/src/interface/report/ConfigLoader.tsx
+++ b/src/interface/report/ConfigLoader.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 interface Props {
   specId: number;
+  type: string;
   children: (config: Config) => React.ReactNode;
 }
 
@@ -16,7 +17,7 @@ class ConfigLoader extends React.PureComponent<Props, State> {
   static getDerivedStateFromProps(props: Props, state: State) {
     if (!state.config || props.specId !== state.config.spec.id) {
       return {
-        config: getConfig(props.specId),
+        config: getConfig(props.specId, props.type),
       };
     }
     return state;

--- a/src/interface/report/EventParser.tsx
+++ b/src/interface/report/EventParser.tsx
@@ -3,7 +3,7 @@ import sleep from 'common/sleep';
 import ExtendableError from 'es6-error';
 import { RootState } from 'interface/reducers';
 import { getBuild } from 'interface/selectors/url/report';
-import { Builds } from 'parser/Config';
+import Config, { Builds } from 'parser/Config';
 import CharacterProfile from 'parser/core/CharacterProfile';
 import CombatLogParser from 'parser/core/CombatLogParser';
 import { AnyEvent, CombatantInfoEvent, EventType } from 'parser/core/Events';
@@ -35,6 +35,7 @@ export class EventsParseError extends ExtendableError {
 interface Props {
   report: Report;
   fight: Fight;
+  config: Config;
   player: PlayerInfo;
   combatants: CombatantInfoEvent[];
   applyTimeFilter: (start: number, end: number) => null;
@@ -92,6 +93,7 @@ class EventParser extends React.PureComponent<Props, State> {
 
   makeParser() {
     const {
+      config,
       report,
       fight,
       combatants,
@@ -108,13 +110,13 @@ class EventParser extends React.PureComponent<Props, State> {
       });
     //set current build to undefined if default build or non-existing build selected
     const parser = new parserClass(
+      config,
       report,
       player,
       fight,
       combatants,
       characterProfile,
       buildKey && build,
-      builds,
     );
     parser.applyTimeFilter = this.props.applyTimeFilter;
     parser.applyPhaseFilter = this.props.applyPhaseFilter;

--- a/src/interface/report/PlayerLoader.tsx
+++ b/src/interface/report/PlayerLoader.tsx
@@ -24,6 +24,7 @@ import { CombatantInfoEvent } from 'parser/core/Events';
 import { WCLFight } from 'parser/core/Fight';
 import { PlayerInfo } from 'parser/core/Player';
 import Report from 'parser/core/Report';
+import getConfig from 'parser/getConfig';
 import React from 'react';
 import { connect } from 'react-redux';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
@@ -251,7 +252,8 @@ class PlayerLoader extends React.PureComponent<Props, State> {
     const player = players[0];
     const hasDuplicatePlayers = players.length > 1;
     const combatant = player && combatants.find((combatant) => combatant.sourceID === player.id);
-    if (!player || hasDuplicatePlayers || !combatant || !combatant.specID || combatant.error) {
+    const config = combatant && getConfig(combatant.specID, player.type);
+    if (!player || hasDuplicatePlayers || !combatant || !config || combatant.error) {
       if (player) {
         // Player data was in the report, but there was another issue
         if (hasDuplicatePlayers) {
@@ -268,11 +270,18 @@ class PlayerLoader extends React.PureComponent<Props, State> {
               message: `Player data does not seem to be available for the selected player in this fight.`,
             }),
           );
-        } else if (combatant.error || !combatant.specID) {
+        } else if (combatant.error || (!combatant.specID && combatant.specID !== 0)) {
           alert(
             t({
               id: 'interface.report.render.logCorrupted',
               message: `The data received from WCL for this player is corrupt, this player can not be analyzed in this fight.`,
+            }),
+          );
+        } else if (!config) {
+          alert(
+            t({
+              id: 'interface.report.render.notSupported',
+              message: `This spec is not supported for this expansion.`,
             }),
           );
         }

--- a/src/interface/report/PlayerLoader.tsx
+++ b/src/interface/report/PlayerLoader.tsx
@@ -122,7 +122,7 @@ class PlayerLoader extends React.PureComponent<Props, State> {
           );
           player = generateFakeCombatantInfo(player);
         }
-        if (player.error || player.specID === 0 || player.specID === -1) {
+        if (player.error || player.specID === -1) {
           return;
         }
         const friendly = report.friendlies.find((friendly) => friendly.id === player.sourceID);
@@ -130,21 +130,24 @@ class PlayerLoader extends React.PureComponent<Props, State> {
           console.error('friendly missing from report for player', player.sourceID);
           return;
         }
-        switch (SPECS[player.specID].role) {
-          case ROLES.TANK:
-            this.tanks += 1;
-            break;
-          case ROLES.HEALER:
-            this.healers += 1;
-            break;
-          case ROLES.DPS.MELEE:
-            this.dps += 1;
-            break;
-          case ROLES.DPS.RANGED:
-            this.ranged += 1;
-            break;
-          default:
-            break;
+        if (SPECS[player.specID]) {
+          // TODO: TBC support: specID is always null, so look at talents to figure out the most likely spec. Or use friendly.icon. Then make a table that has roles for that. Cumbersome, but not too difficult.
+          switch (SPECS[player.specID].role) {
+            case ROLES.TANK:
+              this.tanks += 1;
+              break;
+            case ROLES.HEALER:
+              this.healers += 1;
+              break;
+            case ROLES.DPS.MELEE:
+              this.dps += 1;
+              break;
+            case ROLES.DPS.RANGED:
+              this.ranged += 1;
+              break;
+            default:
+              break;
+          }
         }
         // Gear may be null for broken combatants
         this.ilvl += player.gear ? getAverageItemLevel(player.gear) : 0;

--- a/src/interface/report/PlayerLoader.tsx
+++ b/src/interface/report/PlayerLoader.tsx
@@ -116,24 +116,26 @@ class PlayerLoader extends React.PureComponent<Props, State> {
         fight.start_time,
         fight.end_time,
       )) as CombatantInfoEvent[];
-      combatants.forEach((player) => {
+      combatants.forEach((combatant) => {
         if (process.env.NODE_ENV === 'development' && FAKE_PLAYER_IF_DEV_ENV) {
           console.error(
-            `This player (sourceID: ${player.sourceID!}) has an error. Because you're in development environment, we have faked the missing information, see CombatantInfoFaker.ts for more information.`,
+            `This player (sourceID: ${combatant.sourceID!}) has an error. Because you're in development environment, we have faked the missing information, see CombatantInfoFaker.ts for more information.`,
           );
-          player = generateFakeCombatantInfo(player);
+          combatant = generateFakeCombatantInfo(combatant);
         }
-        if (player.error || player.specID === -1) {
+        if (combatant.error || combatant.specID === -1) {
           return;
         }
-        const friendly = report.friendlies.find((friendly) => friendly.id === player.sourceID);
-        if (!friendly) {
-          console.error('friendly missing from report for player', player.sourceID);
+        const player = report.friendlies.find((friendly) => friendly.id === combatant.sourceID);
+        if (!player) {
+          console.error('friendly missing from report for player', combatant.sourceID);
           return;
         }
-        if (SPECS[player.specID]) {
+        combatant.player = player;
+        if (SPECS[combatant.specID]) {
           // TODO: TBC support: specID is always null, so look at talents to figure out the most likely spec. Or use friendly.icon. Then make a table that has roles for that. Cumbersome, but not too difficult.
-          switch (SPECS[player.specID].role) {
+          // TODO: Move this code to the component that renders the tanks/healers/dps/ranged
+          switch (SPECS[combatant.specID].role) {
             case ROLES.TANK:
               this.tanks += 1;
               break;
@@ -151,7 +153,7 @@ class PlayerLoader extends React.PureComponent<Props, State> {
           }
         }
         // Gear may be null for broken combatants
-        this.ilvl += player.gear ? getAverageItemLevel(player.gear) : 0;
+        this.ilvl += combatant.gear ? getAverageItemLevel(combatant.gear) : 0;
       });
       this.ilvl /= combatants.length;
       if (this.props.report !== report || this.props.fight !== fight) {

--- a/src/interface/report/PlayerTile.tsx
+++ b/src/interface/report/PlayerTile.tsx
@@ -58,7 +58,7 @@ const PlayerTile = (props: Props) => {
   }
 
   return !player.combatant.error && spec ? (
-    <Link to={analysisUrl} className={`player ${getClassName(spec.role)}`}>
+    <Link to={analysisUrl} className={`player ${getClassName(spec?.role)}`}>
       <div className="role" />
       <div className="card">
         <div className="avatar" style={{ backgroundImage: `url(${avatar})` }} />

--- a/src/interface/report/PlayerTile.tsx
+++ b/src/interface/report/PlayerTile.tsx
@@ -1,13 +1,13 @@
 import getAverageItemLevel from 'game/getAverageItemLevel';
 import { getClassName } from 'game/ROLES';
 import { getCovenantById } from 'game/shadowlands/COVENANTS';
-import SPECS from 'game/SPECS';
 import { fetchCharacter, SUPPORTED_REGIONS } from 'interface/actions/characters';
 import Icon from 'interface/Icon';
 import { getCharacterById } from 'interface/selectors/characters';
 import SpecIcon from 'interface/SpecIcon';
 import CharacterProfile from 'parser/core/CharacterProfile';
 import Player from 'parser/core/Player';
+import getConfig from 'parser/getConfig';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
@@ -48,7 +48,8 @@ const PlayerTile = (props: Props) => {
         characterInfo.region
       }.worldofwarcraft.com/character/${characterInfo.thumbnail.replace('avatar', 'inset')}`
     : '/img/fallback-character.jpg';
-  const spec = SPECS[player.combatant.specID];
+  const config = getConfig(player.combatant.specID, player.type);
+  const spec = config?.spec;
   const analysisUrl = makeUrl(player.id);
   const covenant = player.combatant.covenantID || null;
   let covenantName: string | undefined = '';
@@ -56,9 +57,7 @@ const PlayerTile = (props: Props) => {
     covenantName = getCovenantById(covenant)?.name;
   }
 
-  const isParsable = !player.combatant.error && spec;
-
-  return isParsable ? (
+  return !player.combatant.error && spec ? (
     <Link to={analysisUrl} className={`player ${getClassName(spec.role)}`}>
       <div className="role" />
       <div className="card">
@@ -72,7 +71,7 @@ const PlayerTile = (props: Props) => {
             {player.name}
           </h1>
           <small title={`${spec.specName} ${spec.className}`}>
-            <SpecIcon id={spec.id} /> {spec.specName} {spec.className}
+            <SpecIcon spec={spec} /> {spec.specName} {spec.className}
           </small>
           {covenant && (
             <div className="flex-main text-muted text-small">

--- a/src/interface/report/Results/EncounterStats.js
+++ b/src/interface/report/Results/EncounterStats.js
@@ -7,7 +7,6 @@ import SPELLS from 'common/SPELLS';
 import ROLES from 'game/ROLES';
 import { getCovenantById } from 'game/shadowlands/COVENANTS';
 import SOULBINDS from 'game/shadowlands/SOULBINDS';
-import SPECS from 'game/SPECS';
 import { ItemLink } from 'interface';
 import ActivityIndicator from 'interface/ActivityIndicator';
 import Icon from 'interface/Icon';
@@ -26,8 +25,8 @@ const LEVEL_15_TALENT_ROW_INDEX = 0;
 
 class EncounterStats extends React.PureComponent {
   static propTypes = {
+    config: PropTypes.object.isRequired,
     currentBoss: PropTypes.number.isRequired,
-    spec: PropTypes.number.isRequired,
     difficulty: PropTypes.number.isRequired,
     duration: PropTypes.number.isRequired,
     combatant: PropTypes.instanceOf(Combatant).isRequired,
@@ -102,7 +101,7 @@ class EncounterStats extends React.PureComponent {
   }
 
   load() {
-    switch (SPECS[this.props.spec].role) {
+    switch (this.props.config.spec.role) {
       case ROLES.HEALER:
         this.metric = 'hps';
         break;
@@ -117,8 +116,8 @@ class EncounterStats extends React.PureComponent {
     const currentWeek = Math.ceil(((now - onejan) / 86400000 + onejan.getDay() + 1) / 7); // current calendar-week
 
     return fetchWcl(`rankings/encounter/${this.props.currentBoss}`, {
-      class: SPECS[this.props.spec].ranking.class,
-      spec: SPECS[this.props.spec].ranking.spec,
+      class: this.props.config.spec.ranking.class,
+      spec: this.props.config.spec.ranking.spec,
       difficulty: this.props.difficulty,
       limit: this.LIMIT, //Currently does nothing but if Kihra reimplements it'd be nice to have
       metric: this.metric,

--- a/src/interface/report/Results/EncounterStats.js
+++ b/src/interface/report/Results/EncounterStats.js
@@ -101,7 +101,7 @@ class EncounterStats extends React.PureComponent {
   }
 
   load() {
-    switch (this.props.config.spec.role) {
+    switch (this.props.config.spec?.role) {
       case ROLES.HEALER:
         this.metric = 'hps';
         break;

--- a/src/interface/report/Results/PlayerGearHeader.tsx
+++ b/src/interface/report/Results/PlayerGearHeader.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 const PlayerGearHeader = ({ player, averageIlvl }: Props) => (
   <div className="player-gear-header">
-    <div className={`${player.spec.className.replace(' ', '')} player-name`}>
+    <div className={`${player.player.type.replace(' ', '')} player-name`}>
       <Link to={makeCharacterUrl(player)}>
         {player.name}
         <br></br>
@@ -18,7 +18,7 @@ const PlayerGearHeader = ({ player, averageIlvl }: Props) => (
       </Link>
     </div>
     <div>
-      {player.race && player.race.name} {player.spec.className}
+      {player.race && player.race.name} {player.player.type}
     </div>
     <div>
       <b>Average ilvl:</b> {Math.round(averageIlvl)}

--- a/src/interface/report/Results/index.tsx
+++ b/src/interface/report/Results/index.tsx
@@ -177,6 +177,7 @@ class Results extends React.PureComponent<Props, State> {
 
   renderContent(selectedTab: string, results: ParseResults | null) {
     const { parser, premium } = this.props;
+    const config = this.context.config;
 
     switch (selectedTab) {
       case TABS.OVERVIEW: {
@@ -228,6 +229,7 @@ class Results extends React.PureComponent<Props, State> {
             )}
 
             <EncounterStats
+              config={config}
               currentBoss={parser.fight.boss}
               difficulty={parser.fight.difficulty}
               spec={parser.selectedCombatant._combatantInfo.specID}
@@ -238,7 +240,6 @@ class Results extends React.PureComponent<Props, State> {
         );
       }
       case TABS.ABOUT: {
-        const config = this.context.config;
         return (
           <div className="container">
             <About config={config} />

--- a/src/interface/report/index.tsx
+++ b/src/interface/report/index.tsx
@@ -289,7 +289,7 @@ const Report = () => (
               {(fight) => (
                 <PlayerLoader report={report} fight={fight}>
                   {(player, combatant, combatants) => (
-                    <ConfigLoader specId={combatant.specID}>
+                    <ConfigLoader specId={combatant.specID} type={player.type}>
                       {(config) => (
                         <SupportChecker
                           config={config}

--- a/src/interface/report/index.tsx
+++ b/src/interface/report/index.tsx
@@ -231,6 +231,7 @@ class ResultsLoader extends React.PureComponent<Props, State> {
             <EventParser
               report={report}
               fight={this.state.filteredFight!}
+              config={config}
               player={player}
               combatants={combatants!}
               applyTimeFilter={this.applyTimeFilter}

--- a/src/localization/de/messages.json
+++ b/src/localization/de/messages.json
@@ -1,6 +1,7 @@
 {
   "All weapons enhanced (oils/stones)": "Alle Waffen verbessert (Öle/Steine)",
   "Using high quality weapon enhancements": "Waffen-Verbesserungen hoher Qualität werden verwendet",
+  "className.hunter": "",
   "common.abilities": "Fähigkeiten",
   "common.ability": "Fähigkeit",
   "common.cast": "Wirken",
@@ -381,6 +382,7 @@
   "interface.report.render.hasDuplicatePlayers": "Es scheint, dass es mehrere Spieler namens \"{playerName}\" in diesem Log gibt. Bitte wähle den richtigen aus.",
   "interface.report.render.labelFightSelection": "Kampfauswahl",
   "interface.report.render.logCorrupted": "Die von WCL empfangenen Daten für diesen Spieler sind fehlerhaft. Dieser Spieler kann in diesem Kampf nicht analysiert werden.",
+  "interface.report.render.notSupported": "",
   "interface.report.render.playerSelection": "Spielerauswahl",
   "interface.report.render.playerSelectionDetails": "Wähle den Spieler aus, den du analysieren möchtest.",
   "interface.report.renderClassicWarning.classicUnsupported": "Entschuldigung, Classic WoW Logs werden nicht unterstützt.",

--- a/src/localization/en/messages.json
+++ b/src/localization/en/messages.json
@@ -1,6 +1,7 @@
 {
   "All weapons enhanced (oils/stones)": "",
   "Using high quality weapon enhancements": "",
+  "className.hunter": "Hunter",
   "common.abilities": "Abilities",
   "common.ability": "Ability",
   "common.cast": "Cast",
@@ -381,6 +382,7 @@
   "interface.report.render.hasDuplicatePlayers": "It appears like another \"{playerName}\" is in this log, please select the correct one",
   "interface.report.render.labelFightSelection": "Fight selection",
   "interface.report.render.logCorrupted": "The data received from WCL for this player is corrupt, this player can not be analyzed in this fight.",
+  "interface.report.render.notSupported": "This spec is not supported for this expansion.",
   "interface.report.render.playerSelection": "Player selection",
   "interface.report.render.playerSelectionDetails": "Select the player you wish to analyze.",
   "interface.report.renderClassicWarning.classicUnsupported": "Sorry, Classic WoW Logs are not supported",

--- a/src/localization/es/messages.json
+++ b/src/localization/es/messages.json
@@ -1,6 +1,7 @@
 {
   "All weapons enhanced (oils/stones)": "",
   "Using high quality weapon enhancements": "",
+  "className.hunter": "",
   "common.abilities": "",
   "common.ability": "",
   "common.cast": "",
@@ -381,6 +382,7 @@
   "interface.report.render.hasDuplicatePlayers": "",
   "interface.report.render.labelFightSelection": "",
   "interface.report.render.logCorrupted": "",
+  "interface.report.render.notSupported": "",
   "interface.report.render.playerSelection": "",
   "interface.report.render.playerSelectionDetails": "",
   "interface.report.renderClassicWarning.classicUnsupported": "",

--- a/src/localization/fr/messages.json
+++ b/src/localization/fr/messages.json
@@ -1,6 +1,7 @@
 {
   "All weapons enhanced (oils/stones)": "",
   "Using high quality weapon enhancements": "",
+  "className.hunter": "",
   "common.abilities": "",
   "common.ability": "",
   "common.cast": "",
@@ -381,6 +382,7 @@
   "interface.report.render.hasDuplicatePlayers": "Il semble qu'un autre \"{playerName}\" se trouve dans ce rapport, veuillez sélectionner celui qui convient",
   "interface.report.render.labelFightSelection": "",
   "interface.report.render.logCorrupted": "Les données reçus de Warcraft Logs pour ce joueur sont corrompus, il ne peut pas être analysé sur ce combat.",
+  "interface.report.render.notSupported": "",
   "interface.report.render.playerSelection": "",
   "interface.report.render.playerSelectionDetails": "",
   "interface.report.renderClassicWarning.classicUnsupported": "",

--- a/src/localization/it/messages.json
+++ b/src/localization/it/messages.json
@@ -1,6 +1,7 @@
 {
   "All weapons enhanced (oils/stones)": "",
   "Using high quality weapon enhancements": "",
+  "className.hunter": "",
   "common.abilities": "",
   "common.ability": "",
   "common.cast": "",
@@ -381,6 +382,7 @@
   "interface.report.render.hasDuplicatePlayers": "",
   "interface.report.render.labelFightSelection": "",
   "interface.report.render.logCorrupted": "",
+  "interface.report.render.notSupported": "",
   "interface.report.render.playerSelection": "",
   "interface.report.render.playerSelectionDetails": "",
   "interface.report.renderClassicWarning.classicUnsupported": "",

--- a/src/localization/ko/messages.json
+++ b/src/localization/ko/messages.json
@@ -1,6 +1,7 @@
 {
   "All weapons enhanced (oils/stones)": "",
   "Using high quality weapon enhancements": "",
+  "className.hunter": "",
   "common.abilities": "",
   "common.ability": "",
   "common.cast": "",
@@ -381,6 +382,7 @@
   "interface.report.render.hasDuplicatePlayers": "",
   "interface.report.render.labelFightSelection": "",
   "interface.report.render.logCorrupted": "",
+  "interface.report.render.notSupported": "",
   "interface.report.render.playerSelection": "",
   "interface.report.render.playerSelectionDetails": "",
   "interface.report.renderClassicWarning.classicUnsupported": "",

--- a/src/localization/pl/messages.json
+++ b/src/localization/pl/messages.json
@@ -1,6 +1,7 @@
 {
   "All weapons enhanced (oils/stones)": "",
   "Using high quality weapon enhancements": "",
+  "className.hunter": "",
   "common.abilities": "",
   "common.ability": "",
   "common.cast": "",
@@ -381,6 +382,7 @@
   "interface.report.render.hasDuplicatePlayers": "",
   "interface.report.render.labelFightSelection": "",
   "interface.report.render.logCorrupted": "",
+  "interface.report.render.notSupported": "",
   "interface.report.render.playerSelection": "",
   "interface.report.render.playerSelectionDetails": "",
   "interface.report.renderClassicWarning.classicUnsupported": "",

--- a/src/localization/pt/messages.json
+++ b/src/localization/pt/messages.json
@@ -1,6 +1,7 @@
 {
   "All weapons enhanced (oils/stones)": "",
   "Using high quality weapon enhancements": "",
+  "className.hunter": "",
   "common.abilities": "",
   "common.ability": "",
   "common.cast": "",
@@ -381,6 +382,7 @@
   "interface.report.render.hasDuplicatePlayers": "Parece que outro \"{playerName}\" está nesse log, por favor, selecione o correto",
   "interface.report.render.labelFightSelection": "",
   "interface.report.render.logCorrupted": "",
+  "interface.report.render.notSupported": "",
   "interface.report.render.playerSelection": "",
   "interface.report.render.playerSelectionDetails": "",
   "interface.report.renderClassicWarning.classicUnsupported": "",

--- a/src/localization/ru/messages.json
+++ b/src/localization/ru/messages.json
@@ -1,6 +1,7 @@
 {
   "All weapons enhanced (oils/stones)": "",
   "Using high quality weapon enhancements": "",
+  "className.hunter": "",
   "common.abilities": "Способности",
   "common.ability": "Способность",
   "common.cast": "Заклинание",
@@ -381,6 +382,7 @@
   "interface.report.render.hasDuplicatePlayers": "Похоже, что в этом отчете присутствует еще один \"{playerName}\", пожалуйста, выберите нужного.",
   "interface.report.render.labelFightSelection": "Выбор боя",
   "interface.report.render.logCorrupted": "Полученные от Warcraft Logs данные игрока повреждены. Этот игрок не может быть проанализирован в этом бою.",
+  "interface.report.render.notSupported": "",
   "interface.report.render.playerSelection": "Выбор игрока",
   "interface.report.render.playerSelectionDetails": "Выберите игрока, данные которого Вы хотите проанализировать",
   "interface.report.renderClassicWarning.classicUnsupported": "Извините, но отчеты с WoW Classic не поддерживаются",

--- a/src/localization/zh/messages.json
+++ b/src/localization/zh/messages.json
@@ -1,6 +1,7 @@
 {
   "All weapons enhanced (oils/stones)": "",
   "Using high quality weapon enhancements": "",
+  "className.hunter": "",
   "common.abilities": "",
   "common.ability": "",
   "common.cast": "",
@@ -381,6 +382,7 @@
   "interface.report.render.hasDuplicatePlayers": "",
   "interface.report.render.labelFightSelection": "",
   "interface.report.render.logCorrupted": "",
+  "interface.report.render.notSupported": "",
   "interface.report.render.playerSelection": "",
   "interface.report.render.playerSelectionDetails": "",
   "interface.report.renderClassicWarning.classicUnsupported": "",

--- a/src/parser/Config.ts
+++ b/src/parser/Config.ts
@@ -68,6 +68,10 @@ interface Config {
    */
   spec: Spec;
   /**
+   * The expansion this config is for, if not the latest retail expansion.
+   */
+  expansion?: 'tbc' | string;
+  /**
    * The contents of your changelog.
    */
   changelog: ChangelogEntry[];

--- a/src/parser/Config.ts
+++ b/src/parser/Config.ts
@@ -4,6 +4,8 @@ import { Spec } from 'game/SPECS';
 import CombatLogParser from 'parser/core/CombatLogParser';
 import { ReactNode } from 'react';
 
+import { Stats } from './shared/modules/StatTracker';
+
 export type Build = {
   url: string;
   name: string;
@@ -61,6 +63,16 @@ interface Config {
    */
   exampleReport: string;
   builds?: Builds;
+  /**
+   * These are multipliers to the stats applied *on pull* that are not
+   * included in the stats reported by WCL. These are *baked in* and do
+   * not multiply temporary buffs.
+   *
+   * In general, it looks like armor is the only one that isn't applied
+   * by WCL.
+   */
+  statMultipliers?: Partial<Stats>;
+
   // Don't change values for props below this line;
   /**
    * The spec this config is for . This is the only place (in code) that

--- a/src/parser/core/CombatLogParser.ts
+++ b/src/parser/core/CombatLogParser.ts
@@ -16,7 +16,7 @@ import Haste from 'parser/shared/modules/Haste';
 import StatTracker from 'parser/shared/modules/StatTracker';
 import React from 'react';
 
-import { Builds } from '../Config';
+import Config from '../Config';
 import SpellTimeWaitingOnGlobalCooldown from '../shared/enhancers/SpellTimeWaitingOnGlobalCooldown';
 import AbilitiesMissing from '../shared/modules/AbilitiesMissing';
 import AbilityTracker from '../shared/modules/AbilityTracker';
@@ -206,6 +206,7 @@ class CombatLogParser {
   applyTimeFilter = (start: number, end: number) => null; //dummy function gets filled in by event parser
   applyPhaseFilter = (phase: string, instance: any) => null; //dummy function gets filled in by event parser
 
+  config: Config;
   report: Report;
   characterProfile: CharacterProfile;
 
@@ -214,7 +215,6 @@ class CombatLogParser {
   playerPets: PetInfo[];
   fight: Fight;
   build?: string;
-  builds?: Builds;
   boss: Boss | null;
   combatantInfoEvents: CombatantInfoEvent[];
 
@@ -259,20 +259,20 @@ class CombatLogParser {
   }
 
   constructor(
+    config: Config,
     report: Report,
     selectedPlayer: PlayerInfo,
     selectedFight: Fight,
     combatantInfoEvents: CombatantInfoEvent[],
     characterProfile: CharacterProfile,
     build?: string,
-    builds?: Builds,
   ) {
+    this.config = config;
     this.report = report;
     this.player = selectedPlayer;
     this.playerPets = report.friendlyPets.filter((pet) => pet.petOwner === selectedPlayer.id);
     this.fight = selectedFight;
     this.build = build;
-    this.builds = builds;
     this.combatantInfoEvents = combatantInfoEvents;
     // combatantinfo events aren't included in the regular events, but they're still used to analysis. We should have them show in the history to make it complete.
     combatantInfoEvents.forEach((event) => this.eventHistory.push(event));

--- a/src/parser/core/Combatant.ts
+++ b/src/parser/core/Combatant.ts
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import GEAR_SLOTS from 'game/GEAR_SLOTS';
 import RACES from 'game/RACES';
 import { findByBossId } from 'game/raids';
-import SPECS from 'game/SPECS';
+import SPECS, { Spec } from 'game/SPECS';
 import TALENT_ROWS from 'game/TALENT_ROWS';
 import CombatLogParser from 'parser/core/CombatLogParser';
 import {
@@ -50,7 +50,7 @@ class Combatant extends Entity {
   }
 
   /** @deprecated Use player.icon instead. */
-  get spec() {
+  get spec(): Spec | undefined {
     return SPECS[this.specId];
   }
 

--- a/src/parser/core/Combatant.ts
+++ b/src/parser/core/Combatant.ts
@@ -45,7 +45,11 @@ class Combatant extends Entity {
   get specId() {
     return this._combatantInfo.specID;
   }
+  get player() {
+    return this._combatantInfo.player;
+  }
 
+  /** @deprecated Use player.icon instead. */
   get spec() {
     return SPECS[this.specId];
   }

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -4,6 +4,7 @@ import React from 'react';
 
 import EventFilter from './EventFilter';
 import { PetInfo } from './Pet';
+import { PlayerInfo } from './Player';
 
 export enum EventType {
   Heal = 'heal',
@@ -771,6 +772,7 @@ export interface Conduit {
 }
 
 export interface CombatantInfoEvent extends Event<EventType.CombatantInfo> {
+  player: PlayerInfo;
   expansion: 'tbc' | string;
   pin: string;
   sourceID: number;

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -771,7 +771,7 @@ export interface Conduit {
 }
 
 export interface CombatantInfoEvent extends Event<EventType.CombatantInfo> {
-  expansion: string;
+  expansion: 'tbc' | string;
   pin: string;
   sourceID: number;
   gear: Item[];

--- a/src/parser/core/Module.ts
+++ b/src/parser/core/Module.ts
@@ -22,6 +22,9 @@ class Module {
   get selectedCombatant(): Combatant {
     return this.owner.selectedCombatant;
   }
+  get config() {
+    return this.owner.config;
+  }
   constructor(options: Options) {
     if (!options) {
       throw new Error(

--- a/src/parser/core/modules/EventEmitter.ts
+++ b/src/parser/core/modules/EventEmitter.ts
@@ -326,10 +326,7 @@ class EventEmitter extends Module {
     this.owner.deepDisable(module, ModuleError.EVENTS, err);
     window.Sentry?.withScope((scope) => {
       scope.setTag('type', 'module_error');
-      scope.setTag(
-        'spec',
-        `${this.selectedCombatant.spec.specName} ${this.selectedCombatant.spec.className}`,
-      );
+      scope.setTag('spec', this.selectedCombatant.player.icon);
       scope.setExtra('module', name);
       window.Sentry?.captureException(err);
     });

--- a/src/parser/core/tests/log-tools.js
+++ b/src/parser/core/tests/log-tools.js
@@ -57,29 +57,33 @@ export function parseLog(
   suppressLog = true,
   suppressWarn = true,
 ) {
-  const friendlies = log.report.friendlies.find(({ id }) => id === log.meta.player.id);
+  const player = log.report.friendlies.find(({ id }) => id === log.meta.player.id);
   const fight = {
     ...log.report.fights.find(({ id }) => id === log.meta.fight.id),
 
     offset_time: 0,
   };
-  const builds = getConfig(log.meta.player.specID).builds;
+  const config = getConfig(log.meta.player.specID, log.meta.player.type);
+  const builds = config.builds;
   const buildKey = builds && Object.keys(builds).find((b) => builds[b].url === build);
   builds &&
     Object.keys(builds).forEach((key) => {
       builds[key].active = key === buildKey;
     });
   const parser = new parserClass(
+    config,
     {
       ...log.report,
       code: log.meta.reportCode || 'TEST',
     },
-    friendlies,
+    player,
     fight,
-    log.combatants,
+    log.combatants.map((combatant) => ({
+      ...combatant,
+      player: log.report.friendlies.find((friendly) => friendly.id === combatant.sourceID),
+    })),
     null,
     build,
-    builds,
   );
   return suppressLogging(suppressLog, suppressWarn, false, () => {
     parser

--- a/src/parser/getConfig.ts
+++ b/src/parser/getConfig.ts
@@ -1,7 +1,10 @@
 import AVAILABLE_CONFIGS from 'parser';
 
-export default function getConfig(specId: number) {
-  const config = AVAILABLE_CONFIGS.find((config) => config.spec.id === specId);
+export default function getConfig(specId: number, type: string) {
+  let config = specId !== 0 && AVAILABLE_CONFIGS.find((config) => config.spec.id === specId);
+  if (!config) {
+    config = AVAILABLE_CONFIGS.find((config) => config.spec.id === 0 && config.spec.type === type);
+  }
   if (!config) {
     return undefined;
   }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -28,6 +28,7 @@ import SubtletyRogue from '@wowanalyzer/rogue-subtlety';
 import ElementalShaman from '@wowanalyzer/shaman-elemental';
 import EnhancementShaman from '@wowanalyzer/shaman-enhancement';
 import RestorationShaman from '@wowanalyzer/shaman-restoration';
+import TbcHunter from '@wowanalyzer/tbc-hunter';
 import AfflictionWarlock from '@wowanalyzer/warlock-affliction';
 import DemonologyWarlock from '@wowanalyzer/warlock-demonology';
 import DestructionWarlock from '@wowanalyzer/warlock-destruction';
@@ -85,6 +86,8 @@ const configs: Config[] = [
   ProtectionWarrior,
   ArmsWarrior,
   FuryWarrior,
+
+  TbcHunter,
 ];
 
 export default configs;

--- a/src/parser/shared/modules/ManaValues.js
+++ b/src/parser/shared/modules/ManaValues.js
@@ -25,7 +25,7 @@ class ManaValues extends Analyzer {
     super(...args);
     this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onCast);
     this.active =
-      this.selectedCombatant.spec.role === ROLES.HEALER &&
+      this.selectedCombatant.spec?.role === ROLES.HEALER &&
       this.selectedCombatant.spec !== SPECS.HOLY_PALADIN;
   }
 

--- a/src/parser/shared/modules/StatTracker.ts
+++ b/src/parser/shared/modules/StatTracker.ts
@@ -36,16 +36,6 @@ class StatTracker extends Analyzer {
 
   protected eventEmitter!: EventEmitter;
 
-  // These are multipliers to the stats applied *on pull* that are not
-  // included in the stats reported by WCL. These are *baked in* and do
-  // not multiply temporary buffs.
-  //
-  // In general, it looks like armor is the only one that isn't applied
-  // by WCL.
-  static SPEC_MULTIPLIERS = {
-    [SPECS.BREWMASTER_MONK.id]: { armor: 1.25 },
-  };
-
   static DEFAULT_BUFFS: StatBuffsByGuid = {
     // region Potions
     [SPELLS.POTION_OF_SPECTRAL_AGILITY.id]: { agility: 190 },
@@ -393,8 +383,7 @@ class StatTracker extends Analyzer {
   }
 
   applySpecModifiers(): void {
-    const modifiers: StatMultiplier =
-      StatTracker.SPEC_MULTIPLIERS[this.selectedCombatant.spec.id] || {};
+    const modifiers: StatMultiplier = this.owner.config.statMultipliers || {};
     Object.entries(modifiers).forEach(([stat, multiplier]: [string, number | undefined]) => {
       if (multiplier !== undefined) {
         this._pullStats[stat as keyof Stats] *= multiplier;

--- a/src/parser/shared/modules/StatTracker.ts
+++ b/src/parser/shared/modules/StatTracker.ts
@@ -531,7 +531,7 @@ class StatTracker extends Analyzer {
 
   get baseMasteryPercentage() {
     const spellPoints = 8; // Spellpoint is a unit of mastery, each class has 8 base Spellpoints
-    return (spellPoints * this.selectedCombatant.spec.masteryCoefficient) / 100;
+    return (spellPoints * (this.selectedCombatant.spec?.masteryCoefficient || 1)) / 100;
   }
 
   get hasMasteryCoefficient() {
@@ -666,7 +666,7 @@ class StatTracker extends Analyzer {
         this.statBaselineRatingPerPercent[STAT.MASTERY],
         false,
         true,
-        this.selectedCombatant.spec.masteryCoefficient,
+        this.selectedCombatant.spec?.masteryCoefficient || 1,
       )
     );
   }

--- a/src/parser/shared/modules/features/LowHealthHealing/Component.js
+++ b/src/parser/shared/modules/features/LowHealthHealing/Component.js
@@ -117,8 +117,7 @@ class LowHealthHealing extends React.Component {
                 console.error('Missing combatant for event:', event);
                 return null; // pet or something
               }
-              const spec = SPECS[combatant.specId];
-              const specClassName = spec.className.replace(' ', '');
+              const specClassName = combatant.player.type.replace(' ', '');
 
               return (
                 <tr key={`${event.timestamp}${effectiveHealing}${hitPointsBeforeHeal}`}>
@@ -130,7 +129,7 @@ class LowHealthHealing extends React.Component {
                     </SpellLink>
                   </td>
                   <td style={{ width: '20%' }} className={specClassName}>
-                    <SpecIcon spec={spec} /> {combatant.name}
+                    <SpecIcon icon={combatant.player.icon} /> {combatant.name}
                   </td>
                   <td style={{ width: 170, paddingRight: 5, textAlign: 'right' }}>
                     {formatNumber(effectiveHealing)} @{' '}

--- a/src/parser/shared/modules/features/LowHealthHealing/Component.js
+++ b/src/parser/shared/modules/features/LowHealthHealing/Component.js
@@ -130,7 +130,7 @@ class LowHealthHealing extends React.Component {
                     </SpellLink>
                   </td>
                   <td style={{ width: '20%' }} className={specClassName}>
-                    <SpecIcon id={spec.id} /> {combatant.name}
+                    <SpecIcon spec={spec} /> {combatant.name}
                   </td>
                   <td style={{ width: 170, paddingRight: 5, textAlign: 'right' }}>
                     {formatNumber(effectiveHealing)} @{' '}

--- a/src/parser/shared/modules/features/RaidHealthTab/index.js
+++ b/src/parser/shared/modules/features/RaidHealthTab/index.js
@@ -7,7 +7,7 @@ import TabComponent from './TabComponent';
 class RaidHealthTab extends Analyzer {
   constructor(...args) {
     super(...args);
-    this.active = this.selectedCombatant.spec.role === ROLES.HEALER;
+    this.active = this.selectedCombatant.spec?.role === ROLES.HEALER;
   }
 
   tab() {

--- a/src/parser/shared/modules/items/Healthstone.ts
+++ b/src/parser/shared/modules/items/Healthstone.ts
@@ -35,7 +35,7 @@ class Healthstone extends Potion {
 
   get isAvailable() {
     const players = Object.values(this.combatants.players);
-    return players.some((combatant) => combatant.spec.className === Class.Warlock);
+    return players.some((combatant) => combatant.player.type === Class.Warlock);
   }
 
   onDeath(event: DeathEvent) {

--- a/src/parser/shared/modules/racials/dwarf/MightOfTheMountain.js
+++ b/src/parser/shared/modules/racials/dwarf/MightOfTheMountain.js
@@ -100,7 +100,7 @@ class MightOfTheMountain extends Analyzer {
 
   statistic() {
     let value;
-    switch (this.selectedCombatant.spec.role) {
+    switch (this.selectedCombatant.spec?.role) {
       case ROLES.HEALER:
         value = <ItemHealingDone amount={this.healing} />;
         break;

--- a/src/parser/shared/modules/throughput/DamageDone.tsx
+++ b/src/parser/shared/modules/throughput/DamageDone.tsx
@@ -131,9 +131,9 @@ class DamageDone extends Analyzer {
                     content={
                       <>
                         Your DPS compared to the DPS of a top 100 player. To become a top 100{' '}
-                        <span className={this.selectedCombatant.spec.className.replace(' ', '')}>
-                          {this.selectedCombatant.spec.specName}{' '}
-                          {this.selectedCombatant.spec.className}
+                        <span className={this.selectedCombatant.player.type.replace(' ', '')}>
+                          {this.selectedCombatant.spec?.specName || null}{' '}
+                          {this.selectedCombatant.player.type}
                         </span>{' '}
                         on this fight you need to do at least{' '}
                         <strong>{formatThousands(topThroughput || 0)} DPS</strong>.

--- a/src/parser/shared/modules/throughput/HealingDone.tsx
+++ b/src/parser/shared/modules/throughput/HealingDone.tsx
@@ -151,9 +151,9 @@ class HealingDone extends Analyzer {
                     content={
                       <>
                         Your HPS compared to the HPS of a top 100 player. To become a top 100{' '}
-                        <span className={this.selectedCombatant.spec.className.replace(' ', '')}>
-                          {this.selectedCombatant.spec.specName}{' '}
-                          {this.selectedCombatant.spec.className}
+                        <span className={this.selectedCombatant.player.type.replace(' ', '')}>
+                          {this.selectedCombatant.spec?.specName || null}{' '}
+                          {this.selectedCombatant.player.type}
                         </span>{' '}
                         on this fight you need to do at least{' '}
                         <strong>{formatThousands(topThroughput || 0)} HPS</strong>.

--- a/src/parser/tbc/CombatLogParser.ts
+++ b/src/parser/tbc/CombatLogParser.ts
@@ -18,6 +18,7 @@ import FilteredActiveTime from '../shared/modules/FilteredActiveTime';
 import GlobalCooldown from '../shared/modules/GlobalCooldown';
 import Haste from '../shared/modules/Haste';
 import CritEffectBonus from '../shared/modules/helpers/CritEffectBonus';
+import Healthstone from '../shared/modules/items/Healthstone';
 import ManaValues from '../shared/modules/ManaValues';
 import DistanceMoved from '../shared/modules/others/DistanceMoved';
 import Pets from '../shared/modules/Pets';
@@ -83,6 +84,7 @@ class CombatLogParser extends BaseCombatLogParser {
 
     // Tabs
     raidHealthTab: RaidHealthTab,
+    healthstone: Healthstone,
   };
 }
 

--- a/src/parser/tbc/CombatLogParser.ts
+++ b/src/parser/tbc/CombatLogParser.ts
@@ -1,0 +1,89 @@
+import BaseCombatLogParser, { DependenciesDefinition } from '../core/CombatLogParser';
+import Abilities from '../core/modules/Abilities';
+import Buffs from '../core/modules/Buffs';
+import SpellTimeWaitingOnGlobalCooldown from '../shared/enhancers/SpellTimeWaitingOnGlobalCooldown';
+import AbilitiesMissing from '../shared/modules/AbilitiesMissing';
+import AbilityTracker from '../shared/modules/AbilityTracker';
+import AlwaysBeCasting from '../shared/modules/AlwaysBeCasting';
+import CastEfficiency from '../shared/modules/CastEfficiency';
+import Channeling from '../shared/modules/Channeling';
+import DeathRecapTracker from '../shared/modules/DeathRecapTracker';
+import DeathTracker from '../shared/modules/DeathTracker';
+import DispelTracker from '../shared/modules/DispelTracker';
+import Enemies from '../shared/modules/Enemies';
+import EnemyInstances from '../shared/modules/EnemyInstances';
+import EventHistory from '../shared/modules/EventHistory';
+import RaidHealthTab from '../shared/modules/features/RaidHealthTab';
+import FilteredActiveTime from '../shared/modules/FilteredActiveTime';
+import GlobalCooldown from '../shared/modules/GlobalCooldown';
+import Haste from '../shared/modules/Haste';
+import CritEffectBonus from '../shared/modules/helpers/CritEffectBonus';
+import ManaValues from '../shared/modules/ManaValues';
+import DistanceMoved from '../shared/modules/others/DistanceMoved';
+import Pets from '../shared/modules/Pets';
+import SpellHistory from '../shared/modules/SpellHistory';
+import SpellManaCost from '../shared/modules/SpellManaCost';
+import VantusRune from '../shared/modules/spells/VantusRune';
+import SpellUsable from '../shared/modules/SpellUsable';
+import StatTracker from '../shared/modules/StatTracker';
+import DamageDone from '../shared/modules/throughput/DamageDone';
+import DamageTaken from '../shared/modules/throughput/DamageTaken';
+import HealingDone from '../shared/modules/throughput/HealingDone';
+import ThroughputStatisticGroup from '../shared/modules/throughput/ThroughputStatisticGroup';
+import ApplyBuffNormalizer from '../shared/normalizers/ApplyBuff';
+import CancelledCastsNormalizer from '../shared/normalizers/CancelledCasts';
+import MissingCastsNormalizer from '../shared/normalizers/MissingCasts';
+import PhaseChangesNormalizer from '../shared/normalizers/PhaseChanges';
+import PrePullCooldownsNormalizer from '../shared/normalizers/PrePullCooldowns';
+
+class CombatLogParser extends BaseCombatLogParser {
+  static defaultModules: DependenciesDefinition = {
+    // Normalizers
+    applyBuffNormalizer: ApplyBuffNormalizer,
+    cancelledCastsNormalizer: CancelledCastsNormalizer,
+    prepullNormalizer: PrePullCooldownsNormalizer,
+    phaseChangesNormalizer: PhaseChangesNormalizer,
+    missingCastsNormalize: MissingCastsNormalizer,
+
+    // Enhancers
+    spellTimeWaitingOnGlobalCooldown: SpellTimeWaitingOnGlobalCooldown,
+
+    // Analyzers
+    healingDone: HealingDone,
+    damageDone: DamageDone,
+    damageTaken: DamageTaken,
+    throughputStatisticGroup: ThroughputStatisticGroup,
+    deathTracker: DeathTracker,
+
+    enemies: Enemies,
+    enemyInstances: EnemyInstances,
+    pets: Pets,
+    spellManaCost: SpellManaCost,
+    channeling: Channeling,
+    eventHistory: EventHistory,
+    abilityTracker: AbilityTracker,
+    haste: Haste,
+    statTracker: StatTracker,
+    alwaysBeCasting: AlwaysBeCasting,
+    filteredActiveTime: FilteredActiveTime,
+    abilities: Abilities,
+    buffs: Buffs,
+    abilitiesMissing: AbilitiesMissing,
+    CastEfficiency: CastEfficiency,
+    spellUsable: SpellUsable,
+    spellHistory: SpellHistory,
+    globalCooldown: GlobalCooldown,
+    manaValues: ManaValues,
+    vantusRune: VantusRune,
+    distanceMoved: DistanceMoved,
+    deathRecapTracker: DeathRecapTracker,
+    dispels: DispelTracker,
+
+    critEffectBonus: CritEffectBonus,
+
+    // Tabs
+    raidHealthTab: RaidHealthTab,
+  };
+}
+
+export default CombatLogParser;

--- a/src/parser/ui/PlayerBreakdown.js
+++ b/src/parser/ui/PlayerBreakdown.js
@@ -205,7 +205,7 @@ class PlayerBreakdown extends React.Component {
                   return (
                     <tr key={combatant.id}>
                       <td style={{ width: '20%' }}>
-                        <SpecIcon id={spec.id} /> {combatant.name}
+                        <SpecIcon spec={spec} /> {combatant.name}
                       </td>
                       <td style={{ width: 50, textAlign: 'right' }}>
                         {(Math.round(player.masteryEffectiveness * 10000) / 100).toFixed(2)}%

--- a/src/parser/ui/PlayerBreakdown.js
+++ b/src/parser/ui/PlayerBreakdown.js
@@ -191,8 +191,7 @@ class PlayerBreakdown extends React.Component {
                     console.error('Missing combatant:', player);
                     return null; // pet or something
                   }
-                  const spec = SPECS[combatant.specId];
-                  const specClassName = spec.className.replace(' ', '');
+                  const specClassName = combatant.player.type.replace(' ', '');
                   // We want the performance bar to show a full bar for whatever healing done percentage is highest to make
                   // it easier to see relative amounts.
                   const performanceBarMasteryEffectiveness =
@@ -205,7 +204,7 @@ class PlayerBreakdown extends React.Component {
                   return (
                     <tr key={combatant.id}>
                       <td style={{ width: '20%' }}>
-                        <SpecIcon spec={spec} /> {combatant.name}
+                        <SpecIcon icon={combatant.player.icon} /> {combatant.name}
                       </td>
                       <td style={{ width: 50, textAlign: 'right' }}>
                         {(Math.round(player.masteryEffectiveness * 10000) / 100).toFixed(2)}%


### PR DESCRIPTION
This is based around a concept where we can have any number of configs in the app and the config determines if it's applicable to a player/fight/expansion. Analysis folders / configs will need to become standalone packages. I'll call each instance of this a "config" further down, though I am still looking for a better name since config is generally just the object with settings while it's being used here to include anything in the analysis folder.

In the future I'd like to:
- remove `defaultModules` from `core/CombatLogParser`, instead in a config we can do `import DefaultModules from '@wowanalyzer/shadowlands'` and spread that in the modules object. This gives more freedom (e.g. you can stop spreading or `delete` modules you don't want) and makes configs more standalone while reducing the spaghetti in the core
- SPELLS become config specific, no more global spells object
- remove SPECS file, it's a reference from core to configs which shouldn't exist (core should not have any config-specific code)
- stat tracker buffs list should become expansion specific (and disappear from core/shared)
- Allow for multiple configs per spec
- lots more

But all of that is a ton of work and refactoring which is risky and I'll only try to do when necessary and/or low risk.

More pragmatic I'll probably do:

- set up basic Hunter analysis with a working timeline and perhaps statistics to indicate auto shot clipping and such that are essential to the spec
- fix cross-expansion issues such as tooltips not working, SPELLs not existing
- clean up the checklist. As mentioned many times in Discord I want to make it possible to have different levels of spec-support. Checklist being the highest, but earlier steps where there are just some statistics should be encouraged too.