### PR TITLE
Update shaman.ts

### DIFF
--- a/src/common/SPELLS/shaman.ts
+++ b/src/common/SPELLS/shaman.ts
@@ -224,6 +224,11 @@ const spells = {
     name: 'Lightning Bolt Overload',
     icon: 'spell_nature_lightning',
   },
+  ELEMENTAL_BLAST: {
+    id: 344645,
+    name: 'Elemental Blast',
+    icon: 'shaman_talent_elementalblast',
+  },
   ELEMENTAL_BLAST_OVERLOAD: {
     id: 120588,
     name: 'Elemental Blast',


### PR DESCRIPTION
Added elemental blast spell id to shaman spells.

Previously missing spell ID for elemental blast initial cast.