### PR TITLE
Add elemental blast spell id, update lightning shield spell id, update Elemental shaman patch version

### DIFF
--- a/analysis/shamanelemental/src/CHANGELOG.tsx
+++ b/analysis/shamanelemental/src/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 
 export default [
+  change(date(2021, 6, 9), <>Bumped game version to 9.0.5</>, Maximaw),
   change(date(2021, 1, 28), <>Added check for suboptimal Chain Lightning.</>, Maximaw),
   change(date(2021, 1, 14), 'Updated integration tests to Shadowlands', Putro),
   change(date(2020, 12, 25), <>Allow Echoing Shock to Duplicate EQ</>, HawkCorrigan),

--- a/analysis/shamanelemental/src/CONFIG.tsx
+++ b/analysis/shamanelemental/src/CONFIG.tsx
@@ -8,7 +8,7 @@ export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [HawkCorrigan],
   // The WoW client patch this spec was last updated.
-  patchCompatibility: null,
+  patchCompatibility: '9.0.5',
   isPartial: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 
 // prettier-ignore
 export default [
-  change(date(2021, 6, 9), 'Added elemental blast for shaman module.', Sref),
+  change(date(2021, 6, 9), 'Added elemental blast for shaman module. also updated lightning shield spell id.', Sref),
   change(date(2021, 5, 31), 'Reordered events are now highlighted blue in the events listing, differentiating them from modified events.', Sref),
   change(date(2021, 5, 27), 'German translation fix', maestrohdude),
   change(date(2021, 5, 15), 'Fixed a bug that could cause the Mana Pool graph to crash', Sref),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 
 // prettier-ignore
 export default [
+  change(date(2021, 6, 9), 'Added elemental blast for shaman module.', Sref),
   change(date(2021, 5, 31), 'Reordered events are now highlighted blue in the events listing, differentiating them from modified events.', Sref),
   change(date(2021, 5, 27), 'German translation fix', maestrohdude),
   change(date(2021, 5, 15), 'Fixed a bug that could cause the Mana Pool graph to crash', Sref),

--- a/src/common/SPELLS/shaman.ts
+++ b/src/common/SPELLS/shaman.ts
@@ -97,7 +97,7 @@ const spells = {
     manaCost: 650,
   },
   LIGHTNING_SHIELD: {
-    id: 192106,
+    id: 344174,
     name: 'Lightning Shield',
     icon: 'spell_nature_lightningshield',
     manaCost: 150,

--- a/src/common/SPELLS/shaman.ts
+++ b/src/common/SPELLS/shaman.ts
@@ -224,6 +224,11 @@ const spells = {
     name: 'Lightning Bolt Overload',
     icon: 'spell_nature_lightning',
   },
+  ELEMENTAL_BLAST: {
+    id: 344645,
+    name: 'Elemental Blast',
+    icon: 'shaman_talent_elementalblast',
+  },
   ELEMENTAL_BLAST_OVERLOAD: {
     id: 120588,
     name: 'Elemental Blast',


### PR DESCRIPTION
I added the elemental blast spell id (missing previously), update the lightning shield spell id, and bumped the version for elemental shaman to 9.0.5. I left it as partial support, my local testing show it to be working correctly.

Also updated the changelogs since I missed that step in my previous pull request.