### PR TITLE
Added logic to show the benefit of activating NS before Convoke

### DIFF
--- a/analysis/druidrestoration/src/CHANGELOG.tsx
+++ b/analysis/druidrestoration/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SpellLink from 'interface/SpellLink';
 import React from 'react';
 
 export default [
+  change(date(2021, 6, 14), <>Added to the stat box tooltip of <SpellLink id={SPELLS.CONVOKE_SPIRITS.id} /> showing the beneift of activating <SpellLink id={SPELLS.NATURES_SWIFTNESS} /> before convoking.</>, Sref),
   change(date(2021, 6, 14), <>Updated <SpellLink id={SPELLS.SOUL_OF_THE_FOREST_TALENT_RESTORATION.id} /> stat to properly account for Convoke, to better account for edge case issues, and updated the tooltip.</>, Sref),
   change(date(2021, 6, 6), <>Fixed an issue where <SpellLink id={SPELLS.ABUNDANCE_TALENT.id} /> related items were referenced in the Regrowth stat box even when the player doesn't have the talent.</>, Sref),
   change(date(2021, 6, 6), <>Fixed an issue where <SpellLink id={SPELLS.IRONBARK.id} /> cooldown was listed at 60 instead of 90.</>, Sref),

--- a/analysis/druidrestoration/src/modules/shadowlands/covenants/ConvokeSpiritsResto.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/covenants/ConvokeSpiritsResto.tsx
@@ -3,6 +3,7 @@ import SPELLS from 'common/SPELLS';
 import COVENANTS from 'game/shadowlands/COVENANTS';
 import { SpellLink } from 'interface';
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
 import Events, { ApplyBuffEvent, HealEvent, RefreshBuffEvent } from 'parser/core/Events';
 import HotTracker, { Attribution } from 'parser/shared/modules/HotTracker';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
@@ -14,9 +15,8 @@ import React from 'react';
 
 import { ConvokeSpirits } from '@wowanalyzer/druid';
 
-import HotTrackerRestoDruid from '../../core/hottracking/HotTrackerRestoDruid';
 import { isFromHardcast } from '../../../normalizers/HotCastLinkNormalizer';
-import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
+import HotTrackerRestoDruid from '../../core/hottracking/HotTrackerRestoDruid';
 
 const CONVOKED_HOTS = [
   SPELLS.REJUVENATION,
@@ -166,12 +166,14 @@ class ConvokeSpiritsResto extends ConvokeSpirits {
               <>
                 <br />
                 <br />
-                In addition, you took advantage of the fact that <SpellLink id={SPELLS.NATURES_SWIFTNESS.id} /> boosts convoked
-                Regrowth healing without consuming the buff. Nature's swiftness was active during{' '}
+                In addition, you took advantage of the fact that{' '}
+                <SpellLink id={SPELLS.NATURES_SWIFTNESS.id} /> boosts convoked Regrowth healing
+                without consuming the buff. Nature's swiftness was active during{' '}
                 <strong>
                   {this.nsBoostedConvokeCount} out of {this.convokeCount}
                 </strong>{' '}
-                casts, during which it boosted <strong>{this.nsBoostedConvokeRegrowthCount} Regrowths</strong> and caused{' '}
+                casts, during which it boosted{' '}
+                <strong>{this.nsBoostedConvokeRegrowthCount} Regrowths</strong> and caused{' '}
                 <strong>
                   {formatPercentage(
                     this.owner.getPercentageOfTotalHealingDone(this.totalNsConvokeHealing),

--- a/analysis/druidrestoration/src/modules/talents/SoulOfTheForest.tsx
+++ b/analysis/druidrestoration/src/modules/talents/SoulOfTheForest.tsx
@@ -3,6 +3,7 @@ import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
 import Events, {
   ApplyBuffEvent,
   EventType,
@@ -22,7 +23,6 @@ import { isFromHardcast } from '../../normalizers/HotCastLinkNormalizer';
 import { buffedBySotf } from '../../normalizers/SoulOfTheForestLinkNormalizer';
 import HotTrackerRestoDruid from '../core/hottracking/HotTrackerRestoDruid';
 import ConvokeSpiritsResto from '../shadowlands/covenants/ConvokeSpiritsResto';
-import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
 
 const SOTF_SPELLS = [
   SPELLS.REJUVENATION,


### PR DESCRIPTION
By request on Dreamgrove Discord, added an element to the Convoke tooltip that shows the benefit of activating Nature's Swiftness before Convoking.