### PR TITLE
Resto Druid: Fixed a bug where a hardcast Flourish could be counted as part of a Convoke if cast immediately before or after the Convoke

### DIFF
--- a/analysis/druidrestoration/src/CHANGELOG.tsx
+++ b/analysis/druidrestoration/src/CHANGELOG.tsx
@@ -5,7 +5,8 @@ import SpellLink from 'interface/SpellLink';
 import React from 'react';
 
 export default [
-  change(date(2021, 6, 14), <>Added to the stat box tooltip of <SpellLink id={SPELLS.CONVOKE_SPIRITS.id} /> showing the beneift of activating <SpellLink id={SPELLS.NATURES_SWIFTNESS} /> before convoking.</>, Sref),
+  change(date(2021, 6, 14), <>Fixed a bug where a hardcast <SpellLink id={SPELLS.FLOURISH_TALENT.id} /> could be counted as part of a Convoke if cast immediately before or after the Convoke.</>, Sref),
+  change(date(2021, 6, 14), <>Added to the stat box tooltip of <SpellLink id={SPELLS.CONVOKE_SPIRITS.id} /> showing the beneift of activating <SpellLink id={SPELLS.NATURES_SWIFTNESS.id} /> before convoking.</>, Sref),
   change(date(2021, 6, 14), <>Updated <SpellLink id={SPELLS.SOUL_OF_THE_FOREST_TALENT_RESTORATION.id} /> stat to properly account for Convoke, to better account for edge case issues, and updated the tooltip.</>, Sref),
   change(date(2021, 6, 6), <>Fixed an issue where <SpellLink id={SPELLS.ABUNDANCE_TALENT.id} /> related items were referenced in the Regrowth stat box even when the player doesn't have the talent.</>, Sref),
   change(date(2021, 6, 6), <>Fixed an issue where <SpellLink id={SPELLS.IRONBARK.id} /> cooldown was listed at 60 instead of 90.</>, Sref),

--- a/analysis/druidrestoration/src/CombatLogParser.ts
+++ b/analysis/druidrestoration/src/CombatLogParser.ts
@@ -50,7 +50,7 @@ import SpringBlossoms from './modules/talents/SpringBlossoms';
 import TreeOfLife from './modules/talents/TreeOfLife';
 import ClearcastingNormalizer from './normalizers/ClearcastingNormalizer';
 import HotApplicationNormalizer from './normalizers/HotApplicationNormalizer';
-import HotCastLinkNormalizer from './normalizers/HotCastLinkNormalizer';
+import CastLinkNormalizer from './normalizers/CastLinkNormalizer';
 import SoulOfTheForestLinkNormalizer from './normalizers/SoulOfTheForestLinkNormalizer';
 import TreeOfLifeNormalizer from './normalizers/TreeOfLifeNormalizer';
 
@@ -61,7 +61,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Normalizers
     clearcastingNormalizer: ClearcastingNormalizer,
     hotApplicationNormalizer: HotApplicationNormalizer,
-    hotCastLinkNormalizer: HotCastLinkNormalizer,
+    hotCastLinkNormalizer: CastLinkNormalizer,
     soulOfTheForestLinkNormalizer: SoulOfTheForestLinkNormalizer,
     treeOfLifeNormalizer: TreeOfLifeNormalizer,
 

--- a/analysis/druidrestoration/src/CombatLogParser.ts
+++ b/analysis/druidrestoration/src/CombatLogParser.ts
@@ -48,9 +48,9 @@ import Photosynthesis from './modules/talents/Photosynthesis';
 import SoulOfTheForest from './modules/talents/SoulOfTheForest';
 import SpringBlossoms from './modules/talents/SpringBlossoms';
 import TreeOfLife from './modules/talents/TreeOfLife';
+import CastLinkNormalizer from './normalizers/CastLinkNormalizer';
 import ClearcastingNormalizer from './normalizers/ClearcastingNormalizer';
 import HotApplicationNormalizer from './normalizers/HotApplicationNormalizer';
-import CastLinkNormalizer from './normalizers/CastLinkNormalizer';
 import SoulOfTheForestLinkNormalizer from './normalizers/SoulOfTheForestLinkNormalizer';
 import TreeOfLifeNormalizer from './normalizers/TreeOfLifeNormalizer';
 

--- a/analysis/druidrestoration/src/modules/core/hottracking/HotAttributor.ts
+++ b/analysis/druidrestoration/src/modules/core/hottracking/HotAttributor.ts
@@ -4,7 +4,7 @@ import Events, { ApplyBuffEvent, HealEvent, RefreshBuffEvent } from 'parser/core
 import HotTracker, { Attribution } from 'parser/shared/modules/HotTracker';
 
 import { LIFEBLOOM_BUFFS, REJUVENATION_BUFFS } from '../../../constants';
-import { isFromHardcast, isFromOvergrowth } from '../../../normalizers/HotCastLinkNormalizer';
+import { isFromHardcast, isFromOvergrowth } from '../../../normalizers/CastLinkNormalizer';
 import ConvokeSpiritsResto from '../../shadowlands/covenants/ConvokeSpiritsResto';
 import HotTrackerRestoDruid from '../hottracking/HotTrackerRestoDruid';
 

--- a/analysis/druidrestoration/src/modules/shadowlands/covenants/ConvokeSpiritsResto.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/covenants/ConvokeSpiritsResto.tsx
@@ -15,7 +15,7 @@ import React from 'react';
 
 import { ConvokeSpirits } from '@wowanalyzer/druid';
 
-import { isFromHardcast } from '../../../normalizers/HotCastLinkNormalizer';
+import { isFromHardcast } from '../../../normalizers/CastLinkNormalizer';
 import HotTrackerRestoDruid from '../../core/hottracking/HotTrackerRestoDruid';
 
 const CONVOKED_HOTS = [

--- a/analysis/druidrestoration/src/modules/talents/Flourish.tsx
+++ b/analysis/druidrestoration/src/modules/talents/Flourish.tsx
@@ -17,9 +17,9 @@ import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
 
 import { HOTS_INCREASED_RATE } from '../../constants';
+import { isFromHardcast } from '../../normalizers/CastLinkNormalizer';
 import HotTrackerRestoDruid from '../core/hottracking/HotTrackerRestoDruid';
 import ConvokeSpiritsResto from '../shadowlands/covenants/ConvokeSpiritsResto';
-import { isFromHardcast } from '../../normalizers/CastLinkNormalizer';
 
 const FLOURISH_EXTENSION = 8000;
 const FLOURISH_HEALING_INCREASE = 1;

--- a/analysis/druidrestoration/src/modules/talents/Flourish.tsx
+++ b/analysis/druidrestoration/src/modules/talents/Flourish.tsx
@@ -5,7 +5,7 @@ import COVENANTS from 'game/shadowlands/COVENANTS';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
-import Events, { HealEvent } from 'parser/core/Events';
+import Events, { ApplyBuffEvent, HealEvent, RefreshBuffEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import HotTracker, { Attribution } from 'parser/shared/modules/HotTracker';
@@ -19,6 +19,7 @@ import React from 'react';
 import { HOTS_INCREASED_RATE } from '../../constants';
 import HotTrackerRestoDruid from '../core/hottracking/HotTrackerRestoDruid';
 import ConvokeSpiritsResto from '../shadowlands/covenants/ConvokeSpiritsResto';
+import { isFromHardcast } from '../../normalizers/CastLinkNormalizer';
 
 const FLOURISH_EXTENSION = 8000;
 const FLOURISH_HEALING_INCREASE = 1;
@@ -114,9 +115,9 @@ class Flourish extends Analyzer {
     }
   }
 
-  onFlourishApplyBuff() {
+  onFlourishApplyBuff(event: ApplyBuffEvent | RefreshBuffEvent) {
     let extensionAttribution: Attribution;
-    if (this.selectedCombatant.hasBuff(SPELLS.CONVOKE_SPIRITS.id)) {
+    if (!isFromHardcast(event) && this.convokeSpirits.isConvoking()) {
       extensionAttribution = this.convokeSpirits.currentConvokeAttribution;
       this.currentRateAttribution = this.convokeSpirits.currentConvokeRateAttribution;
     } else {

--- a/analysis/druidrestoration/src/modules/talents/SoulOfTheForest.tsx
+++ b/analysis/druidrestoration/src/modules/talents/SoulOfTheForest.tsx
@@ -19,7 +19,7 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
 
-import { isFromHardcast } from '../../normalizers/HotCastLinkNormalizer';
+import { isFromHardcast } from '../../normalizers/CastLinkNormalizer';
 import { buffedBySotf } from '../../normalizers/SoulOfTheForestLinkNormalizer';
 import HotTrackerRestoDruid from '../core/hottracking/HotTrackerRestoDruid';
 import ConvokeSpiritsResto from '../shadowlands/covenants/ConvokeSpiritsResto';

--- a/analysis/druidrestoration/src/normalizers/CastLinkNormalizer.ts
+++ b/analysis/druidrestoration/src/normalizers/CastLinkNormalizer.ts
@@ -62,6 +62,16 @@ const EVENT_LINKS: EventLink[] = [
     backwardBufferMs: CAST_BUFFER_MS,
   },
   {
+    linkRelation: FROM_HARDCAST,
+    linkingEventId: SPELLS.FLOURISH_TALENT.id,
+    linkingEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+    referencedEventId: SPELLS.FLOURISH_TALENT.id,
+    referencedEventType: EventType.Cast,
+    forwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: CAST_BUFFER_MS,
+    anyTarget: true,
+  },
+  {
     linkRelation: FROM_OVERGROWTH,
     linkingEventId: [
       SPELLS.REJUVENATION.id,
@@ -80,17 +90,17 @@ const EVENT_LINKS: EventLink[] = [
 ];
 
 /**
- * When a HoT is cast on a target, the ordering of the Cast and ApplyBuff/RefreshBuff/(direct)Heal
+ * When a spell is cast on a target, the ordering of the Cast and ApplyBuff/RefreshBuff/(direct)Heal
  * can be semi-arbitrary, making analysis difficult.
  *
  * This normalizer adds a _linkedEvent to the ApplyBuff/RefreshBuff/Heal linking back to the Cast event
  * that caused it (if one can be found).
  *
  * This normalizer adds links for the buffs Rejuvenation, Regrowth, Wild Growth, Lifebloom,
- * and for the direct heals of Swiftmend and Regrowth. A special link key is used
- * when the HoTs were applied by an Overgrowth cast instead of a normal hardcast.
+ * and for the direct heals of Swiftmend and Regrowth, and the self buff from Flourish.
+ * A special link key is used when the HoTs were applied by an Overgrowth cast instead of a normal hardcast.
  */
-class HotCastLinkNormalizer extends EventLinkNormalizer {
+class CastLinkNormalizer extends EventLinkNormalizer {
   constructor(options: Options) {
     super(options, EVENT_LINKS);
   }
@@ -104,4 +114,4 @@ export function isFromOvergrowth(event: ApplyBuffEvent | RefreshBuffEvent): bool
   return HasRelatedEvent(event, FROM_OVERGROWTH);
 }
 
-export default HotCastLinkNormalizer;
+export default CastLinkNormalizer;


### PR DESCRIPTION
Bug comes up twice in the following log, I confirmed using it: https://wowanalyzer.com/report/VL6Gn9yt47j831rT/1-Mythic+Shriekwing+-+Kill+(3:07)/Fayoria/standard/about