### PR TITLE
Updates to execution sentence for Shadowlands.

### DIFF
--- a/analysis/paladinretribution/src/CHANGELOG.js
+++ b/analysis/paladinretribution/src/CHANGELOG.js
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
-import { Adoraci, Juko8, Skeletor, Zeboot, Hordehobbs } from 'CONTRIBUTORS';
+import { Fashathus, Adoraci, Juko8, Skeletor, Zeboot, Hordehobbs } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import React from 'react';
 
 export default [
+  change(date(2021, 6, 27), <>Changed <SpellLink id={SPELLS.EXECUTION_SENTENCE_TALENT.id} icon /> statistics for Shadowlands. At least partially fixed bug with judgement debuff consumption tracking. </>, Fashathus),
   change(date(2021, 4, 10), <>Added <SpellLink id={SPELLS.FINAL_VERDICT.id} icon />.</>, Juko8),
   change(date(2021, 4, 3), 'Verified patch changes and bumped support to 9.0.5', Adoraci),
   change(date(2020, 12, 1), <>Added <SpellLink id={SPELLS.SANCTIFIED_WRATH_TALENT_RETRIBUTION.id} icon /> module and minor housekeeping.</>, Skeletor),

--- a/analysis/paladinretribution/src/modules/talents/ExecutionSentence.tsx
+++ b/analysis/paladinretribution/src/modules/talents/ExecutionSentence.tsx
@@ -1,8 +1,6 @@
 import { formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
-import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
-import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
-import Events, { DamageEvent } from 'parser/core/Events';
+import Analyzer, { Options } from 'parser/core/Analyzer';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import Enemies from 'parser/shared/modules/Enemies';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
@@ -11,58 +9,23 @@ import Statistic from 'parser/ui/Statistic';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import React from 'react';
 
-import { ABILITIES_AFFECTED_BY_HOLY_DAMAGE_INCREASES } from '../../constants';
-
-const DAMAGE_BONUS = 0.2;
-
-//TODO: Needs updating for Shadowlands
-
 class ExecutionSentence extends Analyzer {
   static dependencies = {
-    enemies: Enemies,
     abilityTracker: AbilityTracker,
   };
 
   protected abilityTracker!: AbilityTracker;
   protected enemies!: Enemies;
 
-  damageIncrease = 0;
-
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(SPELLS.EXECUTION_SENTENCE_TALENT.id);
 
     // event listeners
-    this.addEventListener(
-      Events.damage.by(SELECTED_PLAYER).spell(ABILITIES_AFFECTED_BY_HOLY_DAMAGE_INCREASES),
-      this.onAffectedDamage,
-    );
-  }
-
-  onAffectedDamage(event: DamageEvent) {
-    const enemy = this.enemies.getEntity(event);
-    if (!enemy) {
-      return;
-    }
-    if (enemy.hasBuff(SPELLS.EXECUTION_SENTENCE_DEBUFF.id)) {
-      this.damageIncrease += calculateEffectiveDamage(event, DAMAGE_BONUS);
-    }
-  }
-
-  get directDamage() {
-    return this.abilityTracker.getAbility(SPELLS.EXECUTION_SENTENCE_TALENT.id).damageEffective;
-  }
-
-  get directDps() {
-    return (this.directDamage / this.owner.fightDuration) * 1000;
-  }
-
-  get indirectDps() {
-    return (this.damageIncrease / this.owner.fightDuration) * 1000;
   }
 
   get totalDamage() {
-    return this.damageIncrease + this.directDamage;
+    return this.abilityTracker.getAbility(SPELLS.EXECUTION_SENTENCE_TALENT.id).damageEffective;
   }
 
   get totalDps() {
@@ -77,8 +40,7 @@ class ExecutionSentence extends Analyzer {
         tooltip={
           <>
             Total damage contributed: {formatNumber(this.totalDamage)} <br />
-            DPS from Execution Sentence's direct damage: {formatNumber(this.directDps)} <br />
-            DPS gained from Execution Sentence's debuff: {formatNumber(this.indirectDps)}
+            DPS from Execution Sentence: {formatNumber(this.totalDps)} <br />
           </>
         }
       >

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -94,6 +94,19 @@ export const Zerotorescue: Contributor = {
     },
   ],
 };
+
+export const Fashathus: Contributor = {
+  nickname: 'Fashathus',
+  github: 'SethEArnold',
+  discord: 'Fashathus#7292',
+  mains: [
+    {
+      name: 'Fashathus',
+      spec: SPECS.RETRIBUTION_PALADIN,
+      link: 'https://www.warcraftlogs.com/character/us/thrall/fashathus',
+    },
+  ],
+};
 export const ab: Contributor = {
   nickname: 'ab',
   github: 'alex-bau',


### PR DESCRIPTION
Removed indirect damage calculations as they are no longer necessary and updated tool tip to match.

Seems to have also fixed a bug with not counting Final Verdict's consuming of judgement debuffs. Not sure why, something to do with removing the event listener.