### PR TITLE
Fixed a bug where erroneous costs could be assigned to pre-cast spells

### DIFF
--- a/analysis/hunterbeastmastery/src/integrationTests/beastMasteryIntegrationTests.test.ts.snap
+++ b/analysis/hunterbeastmastery/src/integrationTests/beastMasteryIntegrationTests.test.ts.snap
@@ -16168,7 +16168,7 @@ exports[`Beast Mastery Hunter integration test: Single Target matches the checkl
                   }
                 >
                    
-                  97.02%
+                  96.89%
                    
                    
                 </div>

--- a/analysis/huntermarksmanship/src/integrationTests/marksmanshipIntegrationTests.test.ts.snap
+++ b/analysis/huntermarksmanship/src/integrationTests/marksmanshipIntegrationTests.test.ts.snap
@@ -13202,7 +13202,7 @@ Array [
       You're allowing your focus to reach its cap. While at its maximum value you miss out on the focus that would have regenerated. Although it can be beneficial to let focus pool ready to be used at the right time, try to spend some before it reaches the cap.
     </React.Fragment>,
     "stat": <React.Fragment>
-      {"id":"hunter.marksmanship.suggestions.focusCapTracker.focusLost","message":"{0}% regenerated focus lost due to being capped.","values":{"0":"10.11"}}
+      {"id":"hunter.marksmanship.suggestions.focusCapTracker.focusLost","message":"{0}% regenerated focus lost due to being capped.","values":{"0":"10.25"}}
        (
       &lt;10% is recommended.
       )
@@ -13460,7 +13460,7 @@ exports[`Marksmanship Hunter integration test: Single Target NaturalMending matc
         >
           41
           s/
-          182
+          180
           s 
           <small>
              cooldown reduction
@@ -15278,7 +15278,7 @@ exports[`Marksmanship Hunter integration test: Single Target matches the checkli
               style={
                 Object {
                   "backgroundColor": "#ffc84a",
-                  "width": "65.94612701388884%",
+                  "width": "65.47342026878047%",
                 }
               }
             />
@@ -15448,7 +15448,7 @@ exports[`Marksmanship Hunter integration test: Single Target matches the checkli
                   }
                 >
                    
-                  89.89%
+                  89.75%
                    
                    
                 </div>
@@ -15470,7 +15470,7 @@ exports[`Marksmanship Hunter integration test: Single Target matches the checkli
                       Object {
                         "backgroundColor": "#a6c34c",
                         "transition": "background-color 800ms",
-                        "width": "99.17682440042938%",
+                        "width": "98.23141091021262%",
                       }
                     }
                   />

--- a/analysis/huntersurvival/src/integrationTests/survivalIntegrationTests.test.ts.snap
+++ b/analysis/huntersurvival/src/integrationTests/survivalIntegrationTests.test.ts.snap
@@ -11121,7 +11121,7 @@ exports[`Survival Hunter integration test: Single Target NaturalMending matches 
         >
           93
           s/
-          152
+          151
           s 
           <small>
              cooldown reduction

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 
 // prettier-ignore
 export default [
+  change(date(2021, 7, 4), 'Fixed a bug where erroneous costs could be assigned to pre-cast spells', Sref),
   change(date(2021, 7, 1), 'Clarify the error shown when a character has no analysis available (e.g. for TBC reports).', Zerotorescue),
   change(date(2021, 6, 29), 'Added Mountaineer Racial to Highmountain Taurens and the same to StatTracker', Soulhealer95),
   change(date(2021, 6, 28), 'Add movement indicator to the timeline.', Zerotorescue),

--- a/src/parser/shared/normalizers/PrePullCooldowns.js
+++ b/src/parser/shared/normalizers/PrePullCooldowns.js
@@ -140,14 +140,15 @@ class PrePullCooldowns extends EventsNormalizer {
          * information more accurately.
          */
         if (precastClassResources === null && event.classResources) {
-          debug && console.debug('Setting prepull class resources (but stripping costs) to:', event.classResources);
-          precastClassResources = event.classResources;
-          // make a new class resources with costs stripped - have to deep copy to avoid messing with the original cast event
-          precastClassResources = precastClassResources.map(classResource => {
-            const noCostClassResource = Object.assign({}, classResource);
-            noCostClassResource.cost = undefined;
-            return noCostClassResource;
-          });
+          debug &&
+            console.debug(
+              'Setting prepull class resources (but stripping costs) to:',
+              event.classResources,
+            );
+          precastClassResources = event.classResources.map((classResource) => ({
+            ...classResource,
+            cost: undefined,
+          }));
         }
 
         // If a cast is found for a damage spell, remove it from the search

--- a/src/parser/shared/normalizers/PrePullCooldowns.js
+++ b/src/parser/shared/normalizers/PrePullCooldowns.js
@@ -142,7 +142,8 @@ class PrePullCooldowns extends EventsNormalizer {
         if (precastClassResources === null && event.classResources) {
           debug && console.debug('Setting prepull class resources (but stripping costs) to:', event.classResources);
           precastClassResources = event.classResources;
-          precastClassResources.map(classResource => {
+          // make a new class resources with costs stripped - have to deep copy to avoid messing with the original cast event
+          precastClassResources = precastClassResources.map(classResource => {
             const noCostClassResource = Object.assign({}, classResource);
             noCostClassResource.cost = undefined;
             return noCostClassResource;

--- a/src/parser/shared/normalizers/PrePullCooldowns.js
+++ b/src/parser/shared/normalizers/PrePullCooldowns.js
@@ -140,8 +140,13 @@ class PrePullCooldowns extends EventsNormalizer {
          * information more accurately.
          */
         if (precastClassResources === null && event.classResources) {
-          debug && console.debug('Setting prepull class resources to:', event.classResources);
+          debug && console.debug('Setting prepull class resources (but stripping costs) to:', event.classResources);
           precastClassResources = event.classResources;
+          precastClassResources.map(classResource => {
+            const noCostClassResource = Object.assign({}, classResource);
+            noCostClassResource.cost = undefined;
+            return noCostClassResource;
+          });
         }
 
         // If a cast is found for a damage spell, remove it from the search


### PR DESCRIPTION
Caused by classResource field being copied with cost included into pre-cast spells - see bug in action here with a potion being listed as costing Astral Power: https://wowanalyzer.com/report/vra49mt8BjdPwDGZ/23-Mythic+Lady+Inerva+Darkvein+-+Kill+(5:33)/Coolbeanss/standard/astral-power-usage