### PR TITLE
TBCHunter: Fix Kill Command cast efficiency

### DIFF
--- a/analysis/tbchunter/src/CHANGELOG.tsx
+++ b/analysis/tbchunter/src/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { change, date } from 'common/changelog';
 import { Zerotorescue } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2021, 7, 27), 'The Kill Command cast count now only includes time with the buff up, and enabled the cast efficiency suggestion for Kill Command.', Zerotorescue),
   change(date(2021, 7, 24), 'Add Kill Command buff indicator to timeline.', Zerotorescue),
   change(date(2021, 7, 20), 'Add Go for the Throat statistic.', Zerotorescue),
   change(date(2021, 7, 2), 'Add suggestions when player is casting lower rank spells.', Zerotorescue),

--- a/analysis/tbchunter/src/metrics/killCommandMaxCasts.ts
+++ b/analysis/tbchunter/src/metrics/killCommandMaxCasts.ts
@@ -1,0 +1,57 @@
+import { AnyEvent, EventType } from 'parser/core/Events';
+import metric, { Info } from 'parser/core/metric';
+
+import * as SPELLS from '../SPELLS';
+
+/**
+ * Returns the max amount of Kill Command casts considering the buff uptime.
+ * Does not account for fluctuating cooldowns.
+ */
+const killCommandMaxCasts = (
+  events: AnyEvent[],
+  { playerId, fightStart, fightEnd }: Pick<Info, 'playerId' | 'fightStart' | 'fightEnd'>,
+  cooldown: number,
+) => {
+  let lastAppliedAt: number | undefined;
+  // The buff lasts 5 sec and the CD is 5 sec, so in theory with spell queueing a player may be able to achieve two casts. This is practically impossible though, since you can not cast KC immediately on proc. Therefore we assume the player needs 200ms to react. This is still optimistic, but this buffer is not intended to be a buffer for player reaction. We can use the recommended cast efficiency config for that.
+  const buffer = 200;
+
+  const maxCasts = events.reduce<number>((max, event) => {
+    if (
+      event.type === EventType.ApplyBuff &&
+      event.targetID === playerId &&
+      event.ability.guid === SPELLS.KILL_COMMAND
+    ) {
+      lastAppliedAt = event.timestamp;
+    }
+    if (
+      event.type === EventType.RemoveBuff &&
+      event.targetID === playerId &&
+      event.ability.guid === SPELLS.KILL_COMMAND
+    ) {
+      if (max > 0 && lastAppliedAt === undefined) {
+        // RemoveBuff should only be possible for prepull buffs, afterwards it can not occur
+        throw new Error('Missing ApplyBuff event');
+      }
+
+      const start = lastAppliedAt !== undefined ? lastAppliedAt : fightStart;
+      const duration = event.timestamp - start;
+      const maxCastsInWindow = 1 + Math.floor((duration - buffer) / cooldown);
+
+      max += maxCastsInWindow;
+      lastAppliedAt = undefined;
+    }
+    return max;
+  }, 0);
+
+  if (lastAppliedAt !== undefined) {
+    const duration = fightEnd - lastAppliedAt;
+    const maxCastsInWindow = 1 + Math.floor((duration - buffer) / cooldown);
+
+    return maxCasts + maxCastsInWindow;
+  } else {
+    return maxCasts;
+  }
+};
+
+export default metric(killCommandMaxCasts);

--- a/analysis/tbchunter/src/modules/Abilities.tsx
+++ b/analysis/tbchunter/src/modules/Abilities.tsx
@@ -2,6 +2,7 @@ import CoreAbilities from 'parser/core/modules/Abilities';
 import { SpellbookAbility } from 'parser/core/modules/Ability';
 
 import { Build } from '../CONFIG';
+import killCommandMaxCasts from '../metrics/killCommandMaxCasts';
 import * as SPELLS from '../SPELLS';
 
 class Abilities extends CoreAbilities {
@@ -44,7 +45,12 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         cooldown: 5,
         gcd: null,
-        // TODO: instead of cast efficiency use usage / proc rate
+        castEfficiency: {
+          maxCasts: (cooldown) =>
+            killCommandMaxCasts(this.owner.normalizedEvents, this.owner.info, cooldown * 1000),
+          suggestion: true,
+          recommendedEfficiency: 0.8,
+        },
       },
       {
         spell: SPELLS.AIMED_SHOT,

--- a/src/interface/report/EventParser.tsx
+++ b/src/interface/report/EventParser.tsx
@@ -141,6 +141,7 @@ class EventParser extends React.PureComponent<Props, State> {
       bench('initialize');
       const parser = this.makeParser();
       const events = this.makeEvents(parser);
+      parser.normalizedEvents = events;
 
       const numEvents = events.length;
 

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -695,15 +695,7 @@ class CombatLogParser {
 
     console.time('functional');
     const ctor = this.constructor as typeof CombatLogParser;
-    const info = {
-      abilities: this.getModule(Abilities).abilities,
-      playerId: this.selectedCombatant.id,
-      fightStart: this.fight.start_time,
-      fightEnd: this.fight.end_time,
-      fightDuration: this.fight.end_time - this.fight.start_time,
-      fightId: this.fight.id,
-      reportCode: this.report.code,
-    };
+    const info = this.info;
 
     console.time('functional suggestions');
     ctor.suggestions.forEach((suggestionFactory) => {
@@ -723,6 +715,27 @@ class CombatLogParser {
     console.timeEnd('functional');
 
     return results;
+  }
+
+  /**
+   * All fight events after normalization. This does not include (non
+   * normalizer) modules that fabricate or alter events.
+   *
+   * Do note that events may be mutated by those modules, so at a later point in
+   * time some events may be modified. Fabricated events will never appear in
+   * this array (unless fabricated in a normalizer).
+   */
+  normalizedEvents: AnyEvent[] = [];
+  get info() {
+    return {
+      abilities: this.getModule(Abilities).abilities,
+      playerId: this.selectedCombatant.id,
+      fightStart: this.fight.start_time,
+      fightEnd: this.fight.end_time,
+      fightDuration: this.fight.end_time - this.fight.start_time,
+      fightId: this.fight.id,
+      reportCode: this.report.code,
+    };
   }
 }
 


### PR DESCRIPTION
Sets max casts based on buff uptime (5 sec window in which it can be cast) divided by CD.