### PR TITLE
Shadow priest: Updated module with patch 9.1 changes

### DIFF
--- a/analysis/priestshadow/src/CHANGELOG.tsx
+++ b/analysis/priestshadow/src/CHANGELOG.tsx
@@ -1,13 +1,16 @@
 
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
-import { Abelito75, Adoraci, Khadaj, Sharrq, Zeboot } from 'CONTRIBUTORS';
+import { Abelito75, Adoraci, Khadaj, Sharrq, Zeboot, Pink } from 'CONTRIBUTORS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { SpellLink } from 'interface';
 import { ResourceLink } from 'interface';
 import React from 'react';
 
 export default [
+  change(date(2021, 8, 27), <>Bump support to 9.1</>, Pink),
+  change(date(2021, 8, 27), <>Reduced <SpellLink id={SPELLS.TALBADARS_STRATAGEM.id} /> damage increase from 60% to 55%. </>, Pink),
+  change(date(2021, 8, 27), <>Reduced <SpellLink id={SPELLS.VOID_BOLT.id} /> damage increase from <SpellLink id={SPELLS.DISSONANT_ECHOES.id} /> from 35% to 15%. </>, Pink),
   change(date(2021, 4, 11), <>Updated <SpellLink id={SPELLS.GUARDIAN_FAERIE.id} /> damage reduction to 20% and corrected DR calculation.</>, Adoraci),
   change(date(2021, 4, 11), <>Removed <SpellLink id={SPELLS.ARCANE_TORRENT_MANA3.id} /> suggestion.</>, Adoraci),
   change(date(2021, 4, 11), <>Added <SpellLink id={SPELLS.VOID_BOLT.id} /> cast efficiency module.</>, Adoraci),

--- a/analysis/priestshadow/src/CONFIG.tsx
+++ b/analysis/priestshadow/src/CONFIG.tsx
@@ -10,7 +10,7 @@ export default {
   contributors: [Adoraci],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.0.5',
+  patchCompatibility: '9.1.0',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/priestshadow/src/constants.ts
+++ b/analysis/priestshadow/src/constants.ts
@@ -26,11 +26,13 @@ export const VOID_FORM_ACTIVATORS = [
   SPELLS.SURRENDER_TO_MADNESS_TALENT.id,
 ];
 
+export const TALBADARS_STRATAGEM_INCREASE = 0.55;
+
 // Abilities that don't show waste in resource gain
 export const SHADOW_SPELLS_WITHOUT_WASTE = [SPELLS.VOID_TORRENT_TALENT.id];
 
 // Shadowlands Conduits
-export const DISSONANT_ECHOES_DAMAGE_INCREASE = 0.35;
+export const DISSONANT_ECHOES_DAMAGE_INCREASE = 0.15;
 export const HAUNTING_APPARITIONS_DAMAGE_INCREASE = [
   0.31,
   0.341,

--- a/analysis/priestshadow/src/integrationTests/example.test.ts.snap
+++ b/analysis/priestshadow/src/integrationTests/example.test.ts.snap
@@ -4264,11 +4264,11 @@ exports[`Shadow Priest integration test: example log DissonantEchoes matches the
             src="/img/sword.png"
           />
            
-          89
+          45
            DPS
            
           <small>
-            1.99
+            1.00
              % of total
           </small>
            

--- a/analysis/priestshadow/src/modules/shadowlands/legendaries/TalbadarsStratagem.tsx
+++ b/analysis/priestshadow/src/modules/shadowlands/legendaries/TalbadarsStratagem.tsx
@@ -10,7 +10,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import React from 'react';
 
-const TALBADARS_STRATAGEM_INCREASE = 0.6;
+import { TALBADARS_STRATAGEM_INCREASE } from '@wowanalyzer/priest-shadow/src/constants';
 
 class TalbadarsStratagem extends Analyzer {
   static dependencies = {

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -1649,3 +1649,15 @@ export const Klex: Contributor = {
     },
   ],
 };
+
+export const Pink: Contributor = {
+  nickname: 'Pink',
+  github: 'marson',
+  mains: [
+    {
+      name: 'Pinklight',
+      spec: SPECS.SHADOW_PRIEST,
+      link: 'https://www.warcraftlogs.com/character/eu/azjolnerub/pinklight',
+    },
+  ],
+};


### PR DESCRIPTION
I implemented the changes to the Talbadars Stratagem legendary and the Dissonant echoes conduit from the 9.1 patch and bumped the supported patch version to 9.1.0.


Question:
Should I create 1 changelog entry describing all the changes or 3 changelog entries 1 for each change?
