### PR TITLE
Kyrian Havoc DH Elysian Decree 

### DIFF
--- a/analysis/demonhunterhavoc/src/CHANGELOG.js
+++ b/analysis/demonhunterhavoc/src/CHANGELOG.js
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
-import { LeoZhekov, flurreN } from 'CONTRIBUTORS';
+import { LeoZhekov, flurreN, Elodiel } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import React from 'react';
 
 export default [
+  change(date(2021, 9, 26), <>Fixed the issue, that would show 0 uses of <SpellLink id={SPELLS.ELYSIAN_DECREE.id} /> instead of the actual amount.</>, Elodiel),
   change(date(2021, 2, 2), <>Added <SpellLink id={SPELLS.FEL_DEFENDER.id} /> to Statistics</>, flurreN),
   change(date(2021, 1, 28), <>Added <SpellLink id={SPELLS.GROWING_INFERNO.id} /> to Statistics</>, flurreN),
   change(date(2021, 1, 18), <>Suggestions for <SpellLink id={SPELLS.DEMONIC_TALENT_HAVOC.id} />, <SpellLink id={SPELLS.BLADE_DANCE.id} /> and <SpellLink id={SPELLS.DEATH_SWEEP.id} /> have been updated</>, flurreN),

--- a/analysis/demonhunterhavoc/src/CHANGELOG.js
+++ b/analysis/demonhunterhavoc/src/CHANGELOG.js
@@ -5,7 +5,7 @@ import { SpellLink } from 'interface';
 import React from 'react';
 
 export default [
-  change(date(2021, 9, 26), <>Fixed the issue, that would show 0 uses of <SpellLink id={SPELLS.ELYSIAN_DECREE.id} /> instead of the actual amount.</>, Elodiel),
+  change(date(2021, 9, 26), <>Fixed the issue, that the Analyzer would show 0 uses of <SpellLink id={SPELLS.ELYSIAN_DECREE.id} /> in the suggestions and statistics instead of the actual number of uses.</>, Elodiel),
   change(date(2021, 2, 2), <>Added <SpellLink id={SPELLS.FEL_DEFENDER.id} /> to Statistics</>, flurreN),
   change(date(2021, 1, 28), <>Added <SpellLink id={SPELLS.GROWING_INFERNO.id} /> to Statistics</>, flurreN),
   change(date(2021, 1, 18), <>Suggestions for <SpellLink id={SPELLS.DEMONIC_TALENT_HAVOC.id} />, <SpellLink id={SPELLS.BLADE_DANCE.id} /> and <SpellLink id={SPELLS.DEATH_SWEEP.id} /> have been updated</>, flurreN),

--- a/analysis/demonhunterhavoc/src/modules/Abilities.js
+++ b/analysis/demonhunterhavoc/src/modules/Abilities.js
@@ -285,7 +285,7 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.ELYSIAN_DECREE.id,
+        spell: [SPELLS.ELYSIAN_DECREE.id, SPELLS.ELYSIAN_DECREE_REPEAT_DECREE.id],
         enabled: combatant.hasCovenant(COVENANTS.KYRIAN.id),
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 60,

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -1674,3 +1674,16 @@ export const Pirrang: Contributor = {
     },
   ],
 };
+
+export const Elodiel: Contributor = {
+  nickname: 'Elodiel',
+  discord: 'Elodiel#5981',
+  github: 'ElodielAirea',
+  mains: [
+    {
+      name: 'Yusun',
+      spec: SPECS.HAVOC_DEMON_HUNTER,
+      link: 'https://www.warcraftlogs.com/character/eu/thrall/yusun',
+    },
+  ],
+};


### PR DESCRIPTION
Fixed the issue, where Kyrian Havoc players would see a total of 0 casts of their decree on the statistics page instead of the actual number of decrees cast.

This was always just a problem with Havoc, Vengeance was showing the right numbers.

Attached picture for comparison 
![compare_local_server](https://user-images.githubusercontent.com/43266338/134816737-04a739ff-9339-41f7-a7ce-c3d845e63f9f.jpg)
.