### PR TITLE
TbcPriest: Cleanup

### DIFF
--- a/analysis/tbcpriest/src/CHANGELOG.tsx
+++ b/analysis/tbcpriest/src/CHANGELOG.tsx
@@ -6,6 +6,11 @@ import React from 'react';
 import * as SPELLS from './SPELLS';
 
 export default [
+  change(
+    date(2021, 9, 29),
+    'TBC Priest Fixing mana efficiency and adding CanceledCasts module.',
+    Khadaj,
+  ),
   change(date(2021, 9, 2), 'TBC Priest T5 cleanup', Khadaj),
   change(date(2021, 9, 2), 'Adding more TBC checklist items', Khadaj),
   change(date(2021, 9, 1), 'Adding basic checklist for TBC and PoM analysis module', Khadaj),

--- a/analysis/tbcpriest/src/CONFIG.tsx
+++ b/analysis/tbcpriest/src/CONFIG.tsx
@@ -33,7 +33,8 @@ const config: Config = {
     },
   },
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/8AaZGQvkzJdDYfMR/11-Normal+Magtheridon+-+Kill+(7:42)/RatherBeBelf',
+  exampleReport:
+    '/report/mDyrvWa7QHzN2jFM/50-Normal+Morogrim+Tidewalker+-+Kill+(6:25)/Ratherbebelf',
   builds: {
     [Build.DEFAULT]: {
       url: 'standard',

--- a/analysis/tbcpriest/src/CombatLogParser.ts
+++ b/analysis/tbcpriest/src/CombatLogParser.ts
@@ -1,4 +1,4 @@
-import ManaTracker from 'parser/core/healingEfficiency/ManaTracker';
+import ManaTracker from 'parser/tbc/modules/resources/ManaTracker';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import ManaLevelChart from 'parser/shared/modules/resources/mana/ManaLevelChart';
 import ManaUsageChart from 'parser/shared/modules/resources/mana/ManaUsageChart';
@@ -18,6 +18,7 @@ import CircleOfHealing from './modules/spells/CircleOfHealing';
 import PrayerOfHealing from './modules/spells/PrayerOfHealing';
 import PrayerOfMending from './modules/spells/PrayerOfMending';
 import Shadowfiend from './modules/spells/Shadowfiend';
+import CanceledCasts from './modules/features/CanceledCasts';
 
 class CombatLogParser extends BaseCombatLogParser {
   static specModules = {
@@ -29,6 +30,7 @@ class CombatLogParser extends BaseCombatLogParser {
     manaLevelChart: ManaLevelChart,
     manaUsageChart: ManaUsageChart,
     alwaysBeCasting: AlwaysBeCasting,
+    canceledCasts: CanceledCasts,
     // Mana Tab
     manaTracker: ManaTracker,
     hpmTracker: HealingEfficiencyTracker,

--- a/analysis/tbcpriest/src/CombatLogParser.ts
+++ b/analysis/tbcpriest/src/CombatLogParser.ts
@@ -1,9 +1,9 @@
-import ManaTracker from 'parser/tbc/modules/resources/ManaTracker';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import ManaLevelChart from 'parser/shared/modules/resources/mana/ManaLevelChart';
 import ManaUsageChart from 'parser/shared/modules/resources/mana/ManaUsageChart';
 import SpellManaCost from 'parser/shared/modules/SpellManaCost';
 import BaseCombatLogParser from 'parser/tbc/CombatLogParser';
+import ManaTracker from 'parser/tbc/modules/resources/ManaTracker';
 import lowRankSpellsSuggestion from 'parser/tbc/suggestions/lowRankSpells';
 
 import lowRankSpells, { whitelist } from './lowRankSpells';
@@ -11,6 +11,7 @@ import Abilities from './modules/Abilities';
 import Buffs from './modules/Buffs';
 import Checklist from './modules/checklist/Module';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
+import CanceledCasts from './modules/features/CanceledCasts';
 import HealingEfficiencyDetails from './modules/features/HealingEfficiencyDetails';
 import HealingEfficiencyTracker from './modules/features/HealingEfficiencyTracker';
 import Haste from './modules/Haste';
@@ -18,7 +19,6 @@ import CircleOfHealing from './modules/spells/CircleOfHealing';
 import PrayerOfHealing from './modules/spells/PrayerOfHealing';
 import PrayerOfMending from './modules/spells/PrayerOfMending';
 import Shadowfiend from './modules/spells/Shadowfiend';
-import CanceledCasts from './modules/features/CanceledCasts';
 
 class CombatLogParser extends BaseCombatLogParser {
   static specModules = {

--- a/analysis/tbcpriest/src/modules/Abilities.tsx
+++ b/analysis/tbcpriest/src/modules/Abilities.tsx
@@ -55,8 +55,14 @@ class Abilities extends CoreAbilities {
         gcd: {
           static: 1500,
         },
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.75,
+          extraSuggestion: 'You should aim to use this off CD.',
+        },
         buffSpellId: SPELLS.PRAYER_OF_MENDING_BUFF,
         healSpellIds: [SPELLS.PRAYER_OF_MENDING_HEAL],
+        cooldown: 10,
       },
       {
         spell: [SPELLS.PRAYER_OF_HEALING, ...lowRankSpells[SPELLS.PRAYER_OF_HEALING]],
@@ -115,6 +121,12 @@ class Abilities extends CoreAbilities {
         gcd: {
           static: 1500,
         },
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.75,
+          extraSuggestion: 'You should aim to use this any time you are below 70% mana.',
+        },
+        cooldown: 300,
       },
       {
         spell: [SPELLS.PSYCHIC_SCREAM, ...lowRankSpells[SPELLS.PSYCHIC_SCREAM]],

--- a/analysis/tbcpriest/src/modules/checklist/Component.tsx
+++ b/analysis/tbcpriest/src/modules/checklist/Component.tsx
@@ -12,7 +12,7 @@ import Rule from 'parser/shared/modules/features/Checklist/Rule';
 import PreparationRule from 'parser/tbc/modules/features/Checklist/PreparationRule';
 import React from 'react';
 
-import { POWER_INFUSION } from '../../SPELLS';
+import * as SPELLS from '../../SPELLS';
 
 const PriestChecklist = ({ thresholds, castEfficiency, combatant }: ChecklistProps) => {
   const AbilityRequirement = (props: AbilityRequirementProps) => (
@@ -24,8 +24,35 @@ const PriestChecklist = ({ thresholds, castEfficiency, combatant }: ChecklistPro
 
   return (
     <Checklist>
-      <Rule name="Use cooldowns effectively" description="blah blah blah">
-        {combatant.talents[0] >= 31 && <AbilityRequirement spell={POWER_INFUSION} />}
+      <Rule
+        name="Use core abilities as often as possible"
+        description={
+          <>
+            Using your core abilities as often as possible will typically result in better
+            performance. <SpellLink id={SPELLS.PRAYER_OF_MENDING} /> should be used on cooldown any
+            time that you don't have 5 stacks up on a tank. Prayer of mending also gives any threat
+            to the target it heals, so you can help your tanks generate more threat!
+          </>
+        }
+      >
+        <AbilityRequirement spell={SPELLS.PRAYER_OF_MENDING} />
+      </Rule>
+      <Rule
+        name="Use cooldowns effectively"
+        description={
+          <>
+            TBC doesn't have as many cooldowns as retails, but they still play an important part of
+            optimizing your play. <SpellLink id={SPELLS.SHADOW_FIEND} /> should be used any time you
+            are below 70% mana, and If you spec into <SpellLink id={SPELLS.PAIN_SUPPRESSION} />,{' '}
+            <SpellLink id={SPELLS.POWER_INFUSION} />, or <SpellLink id={SPELLS.INNER_FOCUS} />, you
+            should try and use them as often as possible.
+          </>
+        }
+      >
+        {combatant.talents[0] >= 11 && <AbilityRequirement spell={SPELLS.INNER_FOCUS} />}
+        {combatant.talents[0] >= 31 && <AbilityRequirement spell={SPELLS.POWER_INFUSION} />}
+        {combatant.talents[0] >= 41 && <AbilityRequirement spell={SPELLS.PAIN_SUPPRESSION} />}
+        <AbilityRequirement spell={SPELLS.SHADOW_FIEND} />
       </Rule>
       <Rule
         name="Try to avoid being inactive for a large portion of the fight"

--- a/analysis/tbcpriest/src/modules/checklist/Module.tsx
+++ b/analysis/tbcpriest/src/modules/checklist/Module.tsx
@@ -3,12 +3,12 @@ import Combatants from 'parser/shared/modules/Combatants';
 import BaseChecklist from 'parser/shared/modules/features/Checklist/Module';
 import ManaValues from 'parser/shared/modules/ManaValues';
 import PreparationRuleAnalyzer from 'parser/tbc/modules/features/Checklist/PreparationRuleAnalyzer';
+import CombatPotionChecker from 'parser/tbc/modules/items/CombatPotionChecker';
 import React from 'react';
 
 import AlwaysBeCasting from '../features/AlwaysBeCasting';
 import PrayerOfMending from '../spells/PrayerOfMending';
 import Component from './Component';
-import CombatPotionChecker from 'parser/tbc/modules/items/CombatPotionChecker';
 
 class Checklist extends BaseChecklist {
   static dependencies = {

--- a/analysis/tbcpriest/src/modules/checklist/Module.tsx
+++ b/analysis/tbcpriest/src/modules/checklist/Module.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import AlwaysBeCasting from '../features/AlwaysBeCasting';
 import PrayerOfMending from '../spells/PrayerOfMending';
 import Component from './Component';
+import CombatPotionChecker from 'parser/tbc/modules/items/CombatPotionChecker';
 
 class Checklist extends BaseChecklist {
   static dependencies = {
@@ -17,6 +18,7 @@ class Checklist extends BaseChecklist {
     alwaysBeCasting: AlwaysBeCasting,
     prayerOfMending: PrayerOfMending,
     preparationRuleAnalyzer: PreparationRuleAnalyzer,
+    combatPotionChecker: CombatPotionChecker,
   };
 
   protected combatants!: Combatants;
@@ -25,6 +27,7 @@ class Checklist extends BaseChecklist {
   protected prayerOfMending!: PrayerOfMending;
   protected manaValues!: ManaValues;
   protected alwaysBeCasting!: AlwaysBeCasting;
+  protected combatPotionChecker!: CombatPotionChecker;
 
   render() {
     return (
@@ -39,6 +42,7 @@ class Checklist extends BaseChecklist {
           nonHealingTimeSuggestionThresholds: this.alwaysBeCasting
             .nonHealingTimeSuggestionThresholds,
           downtimeSuggestionThresholds: this.alwaysBeCasting.downtimeSuggestionThresholds,
+          combatPotionThresholds: this.combatPotionChecker.suggestionThresholds,
         }}
       />
     );

--- a/analysis/tbcpriest/src/modules/features/AlwaysBeCasting.tsx
+++ b/analysis/tbcpriest/src/modules/features/AlwaysBeCasting.tsx
@@ -39,7 +39,7 @@ class AlwaysBeCasting extends CoreAlwaysBeCastingHealing {
     const deadTimePercentage = this.totalTimeWasted / this.owner.fightDuration;
 
     when(deadTimePercentage)
-      .isGreaterThan(0.15)
+      .isGreaterThan(0.25)
       .addSuggestion((suggest, actual, recommended) =>
         suggest('Your downtime can be improved. Try to Always Be Casting (ABC).')
           .icon('spell_mage_altertime')

--- a/analysis/tbcpriest/src/modules/features/CanceledCasts.tsx
+++ b/analysis/tbcpriest/src/modules/features/CanceledCasts.tsx
@@ -1,9 +1,9 @@
+import { formatNumber } from 'common/format';
+import { SpellIcon, SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import React from 'react';
 import Events, { BeginCastEvent } from 'parser/core/Events';
 import Statistic from 'parser/ui/Statistic';
-import { SpellIcon, SpellLink } from 'interface';
-import { formatNumber } from 'common/format';
+import React from 'react';
 
 class CanceledCasts extends Analyzer {
   canceledCasts: any = {};

--- a/analysis/tbcpriest/src/modules/features/CanceledCasts.tsx
+++ b/analysis/tbcpriest/src/modules/features/CanceledCasts.tsx
@@ -1,5 +1,5 @@
 import { formatNumber } from 'common/format';
-import { SpellIcon, SpellLink } from 'interface';
+import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { BeginCastEvent } from 'parser/core/Events';
 import Statistic from 'parser/ui/Statistic';
@@ -25,7 +25,7 @@ class CanceledCasts extends Analyzer {
   onPlayerCast(event: BeginCastEvent) {
     if (event.isCancelled) {
       this.canceledCasts[event.ability.guid] = this.canceledCasts[event.ability.guid] || 0;
-      this.canceledCasts[event.ability.guid]++;
+      this.canceledCasts[event.ability.guid] += 1;
     }
   }
 

--- a/analysis/tbcpriest/src/modules/features/CanceledCasts.tsx
+++ b/analysis/tbcpriest/src/modules/features/CanceledCasts.tsx
@@ -1,0 +1,67 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import React from 'react';
+import Events, { BeginCastEvent } from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import { SpellIcon, SpellLink } from 'interface';
+import { formatNumber } from 'common/format';
+
+class CanceledCasts extends Analyzer {
+  canceledCasts: any = {};
+
+  get TotalCanceledCastCount() {
+    let total = 0;
+    for (const spellId in this.canceledCasts) {
+      total += this.canceledCasts[spellId];
+    }
+    return total;
+  }
+
+  constructor(options: Options) {
+    super(options);
+
+    this.addEventListener(Events.begincast.by(SELECTED_PLAYER), this.onPlayerCast);
+  }
+
+  onPlayerCast(event: BeginCastEvent) {
+    if (event.isCancelled) {
+      this.canceledCasts[event.ability.guid] = this.canceledCasts[event.ability.guid] || 0;
+      this.canceledCasts[event.ability.guid]++;
+    }
+  }
+
+  get CanceledCastTable() {
+    const rows = [];
+    for (const spellId in this.canceledCasts) {
+      rows.push(
+        <tr>
+          <td>
+            <SpellLink id={Number(spellId)} style={{ height: '2.4em' }} />
+          </td>
+          <td>{formatNumber(this.canceledCasts[spellId])}</td>
+        </tr>,
+      );
+    }
+    return rows;
+  }
+
+  statistic() {
+    return (
+      <Statistic size="flexible">
+        <div className="pad">
+          <label>{this.TotalCanceledCastCount} total canceled casts</label>
+          <table className="table table-condensed">
+            <thead>
+              <tr>
+                <th>Spell</th>
+                <th>Canceled Casts</th>
+              </tr>
+            </thead>
+            <tbody>{this.CanceledCastTable}</tbody>
+          </table>
+        </div>
+      </Statistic>
+    );
+  }
+}
+
+export default CanceledCasts;

--- a/analysis/tbcpriest/src/modules/spells/CircleOfHealing.tsx
+++ b/analysis/tbcpriest/src/modules/spells/CircleOfHealing.tsx
@@ -60,6 +60,9 @@ class CircleOfHealing extends Analyzer {
   }
 
   statistic() {
+    if (this.castCount === 0) {
+      return null;
+    }
     return (
       <StatisticBox
         icon={<SpellLink id={SPELLS.CIRCLE_OF_HEALING} />}

--- a/analysis/tbcpriest/src/modules/spells/PrayerOfHealing.tsx
+++ b/analysis/tbcpriest/src/modules/spells/PrayerOfHealing.tsx
@@ -50,6 +50,9 @@ class PrayerOfHealing extends Analyzer {
   }
 
   statistic() {
+    if (this.castCount === 0) {
+      return null;
+    }
     return (
       <StatisticBox
         icon={<SpellLink id={SPELLS.PRAYER_OF_HEALING} />}

--- a/analysis/tbcpriest/src/modules/spells/PrayerOfMending.tsx
+++ b/analysis/tbcpriest/src/modules/spells/PrayerOfMending.tsx
@@ -108,8 +108,8 @@ class PrayerOfMending extends Analyzer {
     when(this.prayerOfMendingThreshold).addSuggestion((suggest, actual, recommended) =>
       suggest(
         <>
-          You should not cast <SpellLink id={SPELLS.PRAYER_OF_MENDING} /> when there is already an
-          active prayer of mending with 5 stacks.
+          You should avoid casting <SpellLink id={SPELLS.PRAYER_OF_MENDING} /> when there is already
+          an active prayer of mending with 5 stacks.
         </>,
       )
         .icon('spell_holy_prayerofmendingtga')

--- a/src/parser/shared/modules/features/Checklist/helpers/performanceForThresholds.ts
+++ b/src/parser/shared/modules/features/Checklist/helpers/performanceForThresholds.ts
@@ -9,7 +9,10 @@
  * @param major
  * @returns {number}
  */
-function performanceForLessThanThresholds(actual, { minor, average, major }) {
+function performanceForLessThanThresholds(
+  actual: number,
+  { minor, average, major }: { minor: number; average: number; major: number },
+) {
   if (actual < major) {
     // major issue
     return (0.333 * actual) / major;
@@ -24,7 +27,11 @@ function performanceForLessThanThresholds(actual, { minor, average, major }) {
     return 1;
   }
 }
-function performanceForGreaterThanThresholds(actual, { minor, average, major }) {
+
+function performanceForGreaterThanThresholds(
+  actual: number,
+  { minor, average, major }: { minor: number; average: number; major: number },
+) {
   if (actual > major) {
     // major issue
     return (0.333 * major) / actual;
@@ -39,7 +46,8 @@ function performanceForGreaterThanThresholds(actual, { minor, average, major }) 
     return 1;
   }
 }
-export default function performanceForThresholds(thresholds) {
+
+export default function performanceForThresholds(thresholds: any) {
   if (thresholds.isGreaterThan || thresholds.isGreaterThan === 0) {
     if (typeof thresholds.isGreaterThan === 'object') {
       return performanceForGreaterThanThresholds(thresholds.actual, thresholds.isGreaterThan);

--- a/src/parser/tbc/CombatLogParser.ts
+++ b/src/parser/tbc/CombatLogParser.ts
@@ -1,4 +1,4 @@
-import CombatPotionChecker from 'parser/tbc/modules/items/CombatPotionChecker';
+import CombatPotionChecker from './modules/items/CombatPotionChecker';
 import FlaskChecker from 'parser/tbc/modules/items/FlaskChecker';
 import FoodChecker from 'parser/tbc/modules/items/FoodChecker';
 import WeaponEnhancementChecker from 'parser/tbc/modules/items/WeaponEnhancementChecker';

--- a/src/parser/tbc/CombatLogParser.ts
+++ b/src/parser/tbc/CombatLogParser.ts
@@ -1,4 +1,3 @@
-import CombatPotionChecker from './modules/items/CombatPotionChecker';
 import FlaskChecker from 'parser/tbc/modules/items/FlaskChecker';
 import FoodChecker from 'parser/tbc/modules/items/FoodChecker';
 import WeaponEnhancementChecker from 'parser/tbc/modules/items/WeaponEnhancementChecker';
@@ -41,6 +40,7 @@ import PhaseChangesNormalizer from '../shared/normalizers/PhaseChanges';
 import PrePullCooldownsNormalizer from '../shared/normalizers/PrePullCooldowns';
 import ManaValues from '../tbc/modules/ManaValues';
 import PreparationRuleAnalyzer from './modules/features/Checklist/PreparationRuleAnalyzer';
+import CombatPotionChecker from './modules/items/CombatPotionChecker';
 import EnchantChecker from './modules/items/EnchantChecker';
 import ManaGained from './statistic/ManaGained';
 

--- a/src/parser/tbc/modules/features/Checklist/PreparationRule.tsx
+++ b/src/parser/tbc/modules/features/Checklist/PreparationRule.tsx
@@ -62,18 +62,16 @@ const PreparationRule = ({
     </>
   );
 
-  const RenderPotionRequirements = () => {
-    return (
-      <Requirement
-        name={
-          <Trans id="shared.modules.features.checklist.combatPotionEfficiency">
-            Combat Potion Efficiency
-          </Trans>
-        }
-        thresholds={thresholds.combatPotionThresholds}
-      />
-    );
-  };
+  const RenderPotionRequirements = () => (
+    <Requirement
+      name={
+        <Trans id="shared.modules.features.checklist.combatPotionEfficiency">
+          Combat Potion Efficiency
+        </Trans>
+      }
+      thresholds={thresholds.combatPotionThresholds}
+    />
+  );
 
   return (
     <Rule

--- a/src/parser/tbc/modules/features/Checklist/PreparationRule.tsx
+++ b/src/parser/tbc/modules/features/Checklist/PreparationRule.tsx
@@ -62,6 +62,19 @@ const PreparationRule = ({
     </>
   );
 
+  const RenderPotionRequirements = () => {
+    return (
+      <Requirement
+        name={
+          <Trans id="shared.modules.features.checklist.combatPotionEfficiency">
+            Combat Potion Efficiency
+          </Trans>
+        }
+        thresholds={thresholds.combatPotionThresholds}
+      />
+    );
+  };
+
   return (
     <Rule
       name={<Trans id="shared.modules.features.checklist.wellPrepared">Be well prepared</Trans>}
@@ -76,6 +89,7 @@ const PreparationRule = ({
       <RenderEnchantRequirements />
       <RenderFlaskRequirements />
       <RenderFoodRequirements />
+      <RenderPotionRequirements />
       {children}
     </Rule>
   );

--- a/src/parser/tbc/modules/items/CombatPotionChecker.tsx
+++ b/src/parser/tbc/modules/items/CombatPotionChecker.tsx
@@ -1,24 +1,16 @@
-import Potion from 'parser/shadowlands/modules/items/Potion';
+import Potion from './Potion';
 
 const CONSUMABLE_IDS = [
   28499, // https://tbc.wowhead.com/spell=28499/restore-mana
 ];
 
 class CombatPotionChecker extends Potion {
-  static spells = [28499];
-  static recommendedEfficiency = 0.5;
+  static spells = CONSUMABLE_IDS;
+  static recommendedEfficiency = 0.75;
   static extraAbilityInfo = {
     name: 'Combat Potion',
     buffSpellId: [28499],
   };
-
-  get ConsumableIds(): number[] {
-    return CONSUMABLE_IDS;
-  }
-
-  get CooldownTime(): number {
-    return 6000;
-  }
 }
 
 export default CombatPotionChecker;

--- a/src/parser/tbc/modules/items/Potion.ts
+++ b/src/parser/tbc/modules/items/Potion.ts
@@ -3,8 +3,8 @@ import Abilities from 'parser/core/modules/Abilities';
 import Buffs from 'parser/core/modules/Buffs';
 import { ThresholdStyle } from 'parser/core/ParseResults';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
-import SpellUsable from 'parser/shared/modules/SpellUsable';
 import CastEfficiency from 'parser/shared/modules/CastEfficiency';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
 
 /**
  * Abstract class for potions and healthstone.

--- a/src/parser/tbc/modules/items/Potion.ts
+++ b/src/parser/tbc/modules/items/Potion.ts
@@ -1,0 +1,99 @@
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import Abilities from 'parser/core/modules/Abilities';
+import Buffs from 'parser/core/modules/Buffs';
+import { ThresholdStyle } from 'parser/core/ParseResults';
+import AbilityTracker from 'parser/shared/modules/AbilityTracker';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import CastEfficiency from 'parser/shared/modules/CastEfficiency';
+
+/**
+ * Abstract class for potions and healthstone.
+ * There are three different categories of pots that share cooldown:
+ * Healthstones, health pots and combat pots (DPS, HPS, mana and mitigation).
+ * All potions have a 5 minute cooldown.
+ *
+ * @property {Abilities} abilities
+ * @property {Buffs} buffs
+ * @property {SpellUsable} spellUsable
+ * @property {AbilityTracker} abilityTracker
+ */
+class Potion extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+    buffs: Buffs,
+    spellUsable: SpellUsable,
+    abilityTracker: AbilityTracker,
+    castEfficiency: CastEfficiency,
+  };
+
+  protected abilities!: Abilities;
+  protected buffs!: Buffs;
+  protected spellUsable!: SpellUsable;
+  protected abilityTracker!: AbilityTracker;
+  protected castEfficiency!: CastEfficiency;
+
+  static spells: number[];
+  static recommendedEfficiency: number;
+  static extraAbilityInfo: { name?: string; buffSpellId?: number[]; isDefensive?: boolean };
+  static cooldown = 120;
+
+  get static() {
+    return this.constructor as typeof Potion;
+  }
+
+  constructor(options: Options) {
+    super(options);
+
+    if (!this.isAvailable) {
+      this.active = false;
+      return;
+    }
+    (options.abilities as Abilities).add({
+      spell: this.static.spells,
+      category: Abilities.SPELL_CATEGORIES.CONSUMABLE,
+      cooldown: this.static.cooldown,
+      castEfficiency: {
+        suggestion: false,
+      },
+      ...this.static.extraAbilityInfo,
+    });
+    if (this.static.extraAbilityInfo.buffSpellId) {
+      //assign each buff its corresponding spell ID
+      this.static.extraAbilityInfo.buffSpellId.forEach((buff, buffIndex) => {
+        (options.buffs as Buffs).add({
+          spellId: buff,
+          triggeredBySpellId: this.static.spells.find((_, spellIndex) => spellIndex === buffIndex)!,
+        });
+      });
+    }
+  }
+
+  // To be overwriten by classes extending the Potion module.
+  get isAvailable() {
+    return true;
+  }
+
+  get spellId() {
+    const spells = this.static.spells;
+    const ability = this.abilities.getAbility(spells[0])!;
+
+    return ability.primarySpell;
+  }
+
+  get potionCasts() {
+    return this.abilityTracker.getAbility(this.spellId).casts;
+  }
+
+  get suggestionThresholds() {
+    const efficiency = this.castEfficiency.getCastEfficiencyForSpellId(this.spellId)?.efficiency;
+    return {
+      actual: efficiency ? efficiency : 0,
+      isLessThan: {
+        minor: this.static.recommendedEfficiency,
+      },
+      style: ThresholdStyle.PERCENTAGE,
+    };
+  }
+}
+
+export default Potion;

--- a/src/parser/tbc/modules/resources/ManaTracker.ts
+++ b/src/parser/tbc/modules/resources/ManaTracker.ts
@@ -1,0 +1,10 @@
+import { CastEvent } from 'parser/core/Events';
+import ManaTracker from 'parser/core/healingEfficiency/ManaTracker';
+
+class TbcManaTracker extends ManaTracker {
+  getReducedCost(event: CastEvent) {
+    return this.getResource(event)?.cost;
+  }
+}
+
+export default TbcManaTracker;


### PR DESCRIPTION
## Features

- Added castEfficiency for PoM
- Added castEfficiency for Shadowfiend
- Added core abilities to checklist
- Added additional cooldowns to checklist
- Added mana potion checker to checklist
- Added CanceledCasts module
- CoH and PoH no longer show up if never cast

## Changes

- Relaxed ABC threshold to 75% (from 85%)


## Bugfixes

- Fixed an error where the mana efficiency module was using retail mana values for some TBCPriest spells
