### PR TITLE
Fixed icon id for frost mage talent splitting ice.

### DIFF
--- a/src/common/SPELLS/talents/mage.ts
+++ b/src/common/SPELLS/talents/mage.ts
@@ -88,7 +88,7 @@ const talents: SpellList = {
   EBONBOLT_TALENT: { id: 257537, name: 'Ebonbolt', icon: 'artifactability_frostmage_ebonbolt' },
   FRIGID_WINDS_TALENT: { id: 235224, name: 'Frigid Winds', icon: 'ability_mage_deepfreeze' },
   FREEZING_RAIN_TALENT: { id: 270233, name: 'Freezing Rain', icon: 'spell_frost_frozenorb' },
-  SPLITTING_ICE_TALENT: { id: 56377, name: 'Splitting Ice', icon: 'spell_frost_ice_shards' },
+  SPLITTING_ICE_TALENT: { id: 429385, name: 'Splitting Ice', icon: 'spell_frost_ice_shards' },
   COMET_STORM_TALENT: {
     id: 153595,
     name: 'Comet Storm',


### PR DESCRIPTION
First PR here I go...
Fixed the frost mage talent `splitting ice` as it was missing the icon in the `character/ZONE/Realm/character-name/` page.

BEFORE
<img width="277" alt="Screen Shot 2021-10-01 at 14 37 40" src="https://user-images.githubusercontent.com/15150108/135670509-c401ed83-e319-448d-9ae0-6b63a16fd951.png">
.

AFTER
<img width="223" alt="Screen Shot 2021-10-01 at 14 38 06" src="https://user-images.githubusercontent.com/15150108/135670567-70102050-807c-41fb-be63-4bf4e76eb188.png">

