### PR TITLE
Shadowlands Arms minor spells changes

### DIFF
--- a/analysis/warriorarms/src/CHANGELOG.tsx
+++ b/analysis/warriorarms/src/CHANGELOG.tsx
@@ -1,11 +1,12 @@
 
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
-import { Abelito75, carglass, Carrottopp, Otthopsy } from 'CONTRIBUTORS';
+import { Abelito75, carglass, Carrottopp, Otthopsy, bandit } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import React from 'react';
 
 export default [
+  change(date(2021, 10, 7), <>adjusted gcds and added seasoned veteran passive</>, bandit),
   change(date(2021, 8, 10), <>reworked Dot Uptime Statistic Box</>, carglass),
   change(date(2021, 6, 22), <>Support for <SpellLink id={SPELLS.ENDURING_BLOW.id} icon /> Legendary for Arms Warriors</>, carglass),
   change(date(2021, 6, 5), <>Support for <SpellLink id={SPELLS.SIGNET_OF_TORMENTED_KINGS.id} icon /> Legendary for Arms Warriors</>, carglass),

--- a/analysis/warriorarms/src/modules/Abilities.js
+++ b/analysis/warriorarms/src/modules/Abilities.js
@@ -115,7 +115,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
         cooldown: 30,
         gcd: {
-          base: 1500,
+          base: 750,
         },
         buffSpellId: SPELLS.SWEEPING_STRIKES.id,
       },
@@ -194,9 +194,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.AVATAR_TALENT.id,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
         cooldown: 90,
-        gcd: {
-          base: 1500,
-        },
+        gcd: null,
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.9,

--- a/analysis/warriorarms/src/modules/features/RageTracker.js
+++ b/analysis/warriorarms/src/modules/features/RageTracker.js
@@ -24,7 +24,11 @@ class RageUsage extends ResourceTracker {
   }
 
   onDamage(event) {
-    this.processInvisibleEnergize(SPELLS.RAGE_AUTO_ATTACKS.id, RAGE_PER_MELEE_HIT);
+    if (event.hitType === 2) {
+      this.processInvisibleEnergize(SPELLS.RAGE_AUTO_ATTACKS.id, RAGE_PER_MELEE_HIT * 1.3);
+    } else if (event.hitType === 1) {
+      this.processInvisibleEnergize(SPELLS.RAGE_AUTO_ATTACKS.id, RAGE_PER_MELEE_HIT);
+    }
   }
 }
 

--- a/analysis/warriorarms/src/modules/features/RageTracker.js
+++ b/analysis/warriorarms/src/modules/features/RageTracker.js
@@ -1,4 +1,5 @@
 import SPELLS from 'common/SPELLS';
+import HIT_TYPES from 'game/HIT_TYPES';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events from 'parser/core/Events';
@@ -24,9 +25,9 @@ class RageUsage extends ResourceTracker {
   }
 
   onDamage(event) {
-    if (event.hitType === 2) {
+    if (event.hitType === HIT_TYPES.CRIT) {
       this.processInvisibleEnergize(SPELLS.RAGE_AUTO_ATTACKS.id, RAGE_PER_MELEE_HIT * 1.3);
-    } else if (event.hitType === 1) {
+    } else if (event.hitType === HIT_TYPES.NORMAL) {
       this.processInvisibleEnergize(SPELLS.RAGE_AUTO_ATTACKS.id, RAGE_PER_MELEE_HIT);
     }
   }

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -1705,3 +1705,8 @@ export const Charurun: Contributor = {
     },
   ],
 };
+
+export const bandit: Contributor = {
+  nickname: 'bandit',
+  github: 'elasticspoon',
+};

--- a/src/common/ITEMS/shadowlands/raids/index.ts
+++ b/src/common/ITEMS/shadowlands/raids/index.ts
@@ -2,6 +2,7 @@ import { ItemList } from 'common/ITEMS/Item';
 import safeMerge from 'common/safeMerge';
 
 import CastleNathria from './castlenathria';
+import SanctumOfDomination from './sanctumofdomination';
 
-const items: ItemList = safeMerge(CastleNathria);
+const items: ItemList = safeMerge(CastleNathria, SanctumOfDomination);
 export default items;

--- a/src/common/ITEMS/shadowlands/raids/sanctumofdomination/index.ts
+++ b/src/common/ITEMS/shadowlands/raids/sanctumofdomination/index.ts
@@ -1,0 +1,47 @@
+/**
+ * NAME: {
+ *   id: number,
+ *   name: string,
+ *   icon: string,
+ *   quality: number,
+ * },
+ */
+import { ItemList } from 'common/ITEMS/Item';
+
+const items: ItemList = {
+  //The Tarragrue
+  //endregion
+
+  //Eye of the Jailer
+  //endregion
+
+  //The Nine
+  //endregion
+
+  //Soulrender Dormazain
+  //endregion
+
+  //Remnant of Ner'zhul
+  //endregion
+
+  //Painsmith Raznal
+  //endregion
+
+  //Guardian of the First Ones
+  //endregion
+
+  //Fatescribe Roh-Kalo
+  //endregion
+
+  //Kel'Thuzad
+  //endregion
+
+  //Sylvanas Windrunner
+  OLD_WARRIORS_SOUL: {
+    id: 186438,
+    name: 'Undying Rage',
+    icon: 'ability_warrior_warcry',
+  },
+  //endregion
+};
+export default items;

--- a/src/common/SPELLS/shadowlands/raids/index.ts
+++ b/src/common/SPELLS/shadowlands/raids/index.ts
@@ -1,5 +1,6 @@
 import safeMerge from 'common/safeMerge';
 
 import CastleNathria from './castlenathria';
+import SanctumOfDomination from './sanctumofdomination';
 
-export default safeMerge(CastleNathria);
+export default safeMerge(CastleNathria, SanctumOfDomination);

--- a/src/common/SPELLS/shadowlands/raids/sanctumofdomination/index.ts
+++ b/src/common/SPELLS/shadowlands/raids/sanctumofdomination/index.ts
@@ -1,0 +1,6 @@
+import safeMerge from 'common/safeMerge';
+
+import ITEMS from './items';
+import MECHANICS from './mechanics';
+
+export default safeMerge(ITEMS, MECHANICS);

--- a/src/common/SPELLS/shadowlands/raids/sanctumofdomination/items.ts
+++ b/src/common/SPELLS/shadowlands/raids/sanctumofdomination/items.ts
@@ -1,0 +1,28 @@
+export default {
+  // Group by boss (with comments)
+
+  //The Tarragrue
+
+  //Eye of the Jailer
+
+  //The Nine
+
+  //Soulrender Dormazain
+
+  //Remnant of Ner'zhul
+
+  //Painsmith Raznal
+
+  //Guardian of the First Ones
+
+  //Fatescribe Roh-Kalo
+
+  //Kel'Thuzad
+
+  //Sylvanas Windrunner
+  OLD_WARRIORS_SOUL_HASTE: {
+    id: 356492,
+    name: 'Undying Rage',
+    icon: 'ability_warrior_warcry',
+  },
+};

--- a/src/common/SPELLS/shadowlands/raids/sanctumofdomination/mechanics.ts
+++ b/src/common/SPELLS/shadowlands/raids/sanctumofdomination/mechanics.ts
@@ -1,0 +1,13 @@
+export default {
+  // Group by boss (with comments)
+  //The Tarragrue
+  //Eye of the Jailer
+  //The Nine
+  //Soulrender Dormazain
+  //Remnant of Ner'zhul
+  //Painsmith Raznal
+  //Guardian of the First Ones
+  //Fatescribe Roh-Kalo
+  //Kel'Thuzad
+  //Sylvanas Windrunner
+};

--- a/src/parser/shared/modules/StatTracker.ts
+++ b/src/parser/shared/modules/StatTracker.ts
@@ -145,6 +145,10 @@ class StatTracker extends Analyzer {
       itemId: ITEMS.MACABRE_SHEET_MUSIC.id,
       haste: (_, item) => calculateSecondaryStatDefault(213, 95, item.itemLevel),
     },
+    [SPELLS.OLD_WARRIORS_SOUL_HASTE.id]: {
+      itemId: ITEMS.OLD_WARRIORS_SOUL.id,
+      haste: (_, item) => calculateSecondaryStatDefault(233, 32, item.itemLevel),
+    },
 
     //endregion
 


### PR DESCRIPTION
Took Avatar off GCD and Sweeping Strikes is half GCD. 
Implemented seasoned soldier passive - auto crits generate 30% more rage. 


I plan to fix a bunch more stuff but starting small here. 