### PR TITLE
Warrior fixes

### DIFF
--- a/analysis/warriorarms/src/CHANGELOG.tsx
+++ b/analysis/warriorarms/src/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 import React from 'react';
 
 export default [
+  change(date(2021, 10, 10), <>Fixed <SpellLink id={SPELLS.OVERPOWER.id} icon /> cooldown resets with Tactician</>, bandit),
   change(date(2021, 10, 7), <>adjusted gcds and added seasoned veteran passive</>, bandit),
   change(date(2021, 8, 10), <>reworked Dot Uptime Statistic Box</>, carglass),
   change(date(2021, 6, 22), <>Support for <SpellLink id={SPELLS.ENDURING_BLOW.id} icon /> Legendary for Arms Warriors</>, carglass),

--- a/analysis/warriorarms/src/modules/Abilities.js
+++ b/analysis/warriorarms/src/modules/Abilities.js
@@ -29,6 +29,10 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         buffSpellId: SPELLS.OVERPOWER.id,
+        castEfficiency: {
+          suggestion: false, // Suggestions are in OverPower.js
+          recommendedEfficiency: 0.8,
+        },
       },
       {
         spell: SPELLS.SLAM.id,
@@ -156,7 +160,11 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.ANCIENT_AFTERSHOCK.id,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,
-        cooldown: 90,
+        cooldown:
+          90 -
+          (this.selectedCombatant.hasConduitBySpellID(SPELLS.DESTRUCTIVE_REVERBERATIONS.id)
+            ? 15
+            : 0),
         gcd: {
           base: 1500,
         },
@@ -241,6 +249,17 @@ class Abilities extends CoreAbilities {
           recommendedEfficiency: 0.4,
         },
         buffSpellId: SPELLS.DIE_BY_THE_SWORD.id,
+      },
+      {
+        spell: SPELLS.SPELL_REFLECTION.id,
+        category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
+        cooldown: 25,
+        gcd: null,
+        castEfficiency: {
+          suggestion: false,
+          recommendedEfficiency: 0.4,
+        },
+        buffSpellId: SPELLS.SPELL_REFLECTION.id,
       },
       {
         spell: SPELLS.IGNORE_PAIN.id,

--- a/analysis/warriorarms/src/modules/Abilities.js
+++ b/analysis/warriorarms/src/modules/Abilities.js
@@ -243,6 +243,12 @@ class Abilities extends CoreAbilities {
         buffSpellId: SPELLS.DIE_BY_THE_SWORD.id,
       },
       {
+        spell: SPELLS.IGNORE_PAIN.id,
+        category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
+        buffSpellId: SPELLS.IGNORE_PAIN.id,
+        gcd: null,
+      },
+      {
         spell: SPELLS.RALLYING_CRY.id,
         category: Abilities.SPELL_CATEGORIES.DEFENSIVE,
         cooldown: 180,

--- a/analysis/warriorarms/src/modules/features/SpellUsable.js
+++ b/analysis/warriorarms/src/modules/features/SpellUsable.js
@@ -22,6 +22,15 @@ class SpellUsable extends CoreSpellUsable {
         }
       }
     }
+
+    // Battlelord legendary: overpower has a chance to reset mortal strike
+    if (event.type === EventType.ApplyBuff || event.type === EventType.RefreshBuff) {
+      if (event.ability.guid === SPELLS.BATTLELORD_ENERGIZE.id) {
+        if (this.isOnCooldown(SPELLS.MORTAL_STRIKE.id)) {
+          this.endCooldown(SPELLS.MORTAL_STRIKE.id);
+        }
+      }
+    }
   }
 }
 

--- a/analysis/warriorarms/src/modules/features/SpellUsable.js
+++ b/analysis/warriorarms/src/modules/features/SpellUsable.js
@@ -12,24 +12,25 @@ class SpellUsable extends CoreSpellUsable {
     super.onEvent(event);
     // Tactician passive: You have a 1.40% chance per Rage spent on damaging abilities to reset the remaining cooldown on Overpower.
     // normally charges dont count down simultaneously. these do
-    if (event.type === EventType.ApplyBuff || event.type === EventType.RefreshBuff) {
-      if (event.ability.guid === SPELLS.TACTICIAN.id) {
-        if (this.isOnCooldown(SPELLS.OVERPOWER.id)) {
-          const remainingCD =
-            this.abilities.getAbility(SPELLS.OVERPOWER.id).cooldown * 1000 -
-            this.cooldownRemaining(SPELLS.OVERPOWER.id);
-          this.endCooldown(SPELLS.OVERPOWER.id, false, this.owner.currentTimestamp, remainingCD);
-        }
-      }
+    if (
+      (event.type === EventType.ApplyBuff || event.type === EventType.RefreshBuff) &&
+      event.ability.guid === SPELLS.TACTICIAN.id &&
+      this.isOnCooldown(SPELLS.OVERPOWER.id)
+    ) {
+      const remainingCD =
+        this.abilities.getAbility(SPELLS.OVERPOWER.id).cooldown * 1000 -
+        this.cooldownRemaining(SPELLS.OVERPOWER.id);
+
+      this.endCooldown(SPELLS.OVERPOWER.id, false, this.owner.currentTimestamp, remainingCD);
     }
 
     // Battlelord legendary: overpower has a chance to reset mortal strike
-    if (event.type === EventType.ApplyBuff || event.type === EventType.RefreshBuff) {
-      if (event.ability.guid === SPELLS.BATTLELORD_ENERGIZE.id) {
-        if (this.isOnCooldown(SPELLS.MORTAL_STRIKE.id)) {
-          this.endCooldown(SPELLS.MORTAL_STRIKE.id);
-        }
-      }
+    if (
+      (event.type === EventType.ApplyBuff || event.type === EventType.RefreshBuff) &&
+      event.ability.guid === SPELLS.BATTLELORD_ENERGIZE.id &&
+      this.isOnCooldown(SPELLS.MORTAL_STRIKE.id)
+    ) {
+      this.endCooldown(SPELLS.MORTAL_STRIKE.id);
     }
   }
 }

--- a/analysis/warriorarms/src/modules/features/SpellUsable.js
+++ b/analysis/warriorarms/src/modules/features/SpellUsable.js
@@ -1,21 +1,27 @@
 import SPELLS from 'common/SPELLS';
+import { EventType } from 'parser/core/Events';
+import Abilities from 'parser/core/modules/Abilities';
 import CoreSpellUsable from 'parser/shared/modules/SpellUsable';
 
 class SpellUsable extends CoreSpellUsable {
   static dependencies = {
     ...CoreSpellUsable.dependencies,
+    abilities: Abilities,
   };
-
-  beginCooldown(spellId, ...args) {
+  onEvent(event) {
+    super.onEvent(event);
     // Tactician passive: You have a 1.40% chance per Rage spent on damaging abilities to reset the remaining cooldown on Overpower.
-    if (spellId === SPELLS.OVERPOWER.id) {
-      if (this.isOnCooldown(spellId)) {
-        this.endCooldown(spellId);
+    // normally charges dont count down simultaneously. these do
+    if (event.type === EventType.ApplyBuff || event.type === EventType.RefreshBuff) {
+      if (event.ability.guid === SPELLS.TACTICIAN.id) {
+        if (this.isOnCooldown(SPELLS.OVERPOWER.id)) {
+          const remainingCD =
+            this.abilities.getAbility(SPELLS.OVERPOWER.id).cooldown * 1000 -
+            this.cooldownRemaining(SPELLS.OVERPOWER.id);
+          this.endCooldown(SPELLS.OVERPOWER.id, false, this.owner.currentTimestamp, remainingCD);
+        }
       }
     }
-
-    // We must do this after ending the cd or it will trigger an error
-    super.beginCooldown(spellId, ...args);
   }
 }
 

--- a/src/common/SPELLS/shadowlands/legendaries/warrior.ts
+++ b/src/common/SPELLS/shadowlands/legendaries/warrior.ts
@@ -6,6 +6,23 @@ const legendaries = {
     icon: 'ability_titankeeper_piercingcorruption',
     bonusID: 6962,
   },
+  BATTLELORD: {
+    id: 346369,
+    name: 'Battlelord',
+    icon: 'ability_pvp_hardiness',
+    bonusID: '6960',
+  },
+  BATTLELORD_ENERGIZE: {
+    id: 346370,
+    name: 'Battlelord',
+    icon: 'ability_pvp_hardiness',
+  },
+  EXPLOITER: {
+    id: 335452,
+    name: 'Exploiter',
+    icon: 'inv_sword_48',
+    bonusID: 6961,
+  },
   //endregion
 
   //region Fury
@@ -38,6 +55,12 @@ const legendaries = {
     id: 347829,
     name: 'Signet of Tormented Kings',
     icon: 'inv_60crafted_ring4b',
+  },
+  SINFUL_SURGE: {
+    id: 354131,
+    name: 'Sinful Surge',
+    icon: 'ability_revendreth_warrior',
+    bonusID: 7470,
   },
   //endregion
 } as const;

--- a/src/parser/shared/modules/Haste.js
+++ b/src/parser/shared/modules/Haste.js
@@ -28,7 +28,7 @@ class Haste extends Analyzer {
     [SPELLS.ENRAGE.id]: 0.25, // Fury Warrior
     [SPELLS.EMPOWER_RUNE_WEAPON.id]: 0.15, // Frost DK
     [SPELLS.EUPHORIA.id]: 0.2, //Buff from Thrill Seeker (Nadjia Soulbind Venthyr)
-    [SPELLS.FIELD_OF_BLOSSOMS_BUFF.id]: 0.12, // Buff from Field of Blossoms (Dreamweaver Soulbind Night Fae)
+    [SPELLS.FIELD_OF_BLOSSOMS_BUFF.id]: 0.15, // Buff from Field of Blossoms (Dreamweaver Soulbind Night Fae)
 
     //region Druid Haste Buffs
     [SPELLS.STARLORD.id]: {


### PR DESCRIPTION
Mainly tried to fix Spell Usable for Overpower. 

Ended up fixing up few other spells that were not properly coming off cooldown:
 - Mortal Strike with battlelord
 - Ancient aftershock with flat conduit cdr

Also the haste value for field of blossoms was incorrect.  And I added some missing legendaries to make code cleaner. 