### PR TITLE
Fix crashes in TBC Warlock

### DIFF
--- a/analysis/tbcwarlock/src/CHANGELOG.tsx
+++ b/analysis/tbcwarlock/src/CHANGELOG.tsx
@@ -1,7 +1,8 @@
 import { change, date } from 'common/changelog';
-import { Khadaj, Talador12 } from 'CONTRIBUTORS';
+import { Khadaj, Talador12, emallson } from 'CONTRIBUTORS';
 
 export default [
-    change(date(2021, 10, 1), 'Stubbing out Warlock Analyzer', Khadaj),
-    change(date(2021, 10, 6), 'Warlock modules and spell types', Talador12)
+  change(date(2021, 10, 11), 'Fixed crashing errors in Curse modules', emallson),
+  change(date(2021, 10, 6), 'Warlock modules and spell types', Talador12),
+  change(date(2021, 10, 1), 'Stubbing out Warlock Analyzer', Khadaj),
 ];

--- a/analysis/tbcwarlock/src/CombatLogParser.ts
+++ b/analysis/tbcwarlock/src/CombatLogParser.ts
@@ -8,6 +8,9 @@ import Abilities from './modules/Abilities';
 import Buffs from './modules/Buffs';
 import Checklist from './modules/checklist/Module';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
+import CurseOfAgony from './modules/spells/CurseOfAgony';
+import CurseOfDoom from './modules/spells/CurseOfDoom';
+import CurseOfTheElements from './modules/spells/CurseOfTheElements';
 
 class CombatLogParser extends BaseCombatLogParser {
   static specModules = {
@@ -17,6 +20,9 @@ class CombatLogParser extends BaseCombatLogParser {
     buffs: Buffs,
     checklist: Checklist,
     preparationRuleAnalyzer: PreparationRuleAnalyzer,
+    curseOfAgony: CurseOfAgony,
+    curseOfDoom: CurseOfDoom,
+    curseOfTheElements: CurseOfTheElements,
   };
 
   static suggestions = [

--- a/analysis/tbcwarlock/src/modules/spells/CurseOfAgony.tsx
+++ b/analysis/tbcwarlock/src/modules/spells/CurseOfAgony.tsx
@@ -1,6 +1,5 @@
 import { t } from '@lingui/macro';
 import { formatPercentage } from 'common/format';
-import SPELLS from 'common/SPELLS';
 import { SpellIcon, SpellLink } from 'interface';
 import Analyzer from 'parser/core/Analyzer';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
@@ -45,7 +44,6 @@ class CurseOfAgony extends Analyzer {
           to your <SpellLink id={CURSE_OF_AGONY} /> on the boss.
         </span>,
       )
-        .icon(SPELLS.CURSE_OF_AGONY.icon)
         .actual(
           t({
             id: 'priest.shadow.suggestions.vampiricTouch.uptime',

--- a/analysis/tbcwarlock/src/modules/spells/CurseOfDoom.tsx
+++ b/analysis/tbcwarlock/src/modules/spells/CurseOfDoom.tsx
@@ -1,6 +1,5 @@
 import { t } from '@lingui/macro';
 import { formatPercentage } from 'common/format';
-import SPELLS from 'common/SPELLS';
 import { SpellIcon, SpellLink } from 'interface';
 import Analyzer from 'parser/core/Analyzer';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
@@ -45,7 +44,6 @@ class CurseOfDoom extends Analyzer {
           your <SpellLink id={CURSE_OF_DOOM} /> on the boss.
         </span>,
       )
-        .icon(SPELLS.CURSE_OF_DOOM.icon)
         .actual(
           t({
             id: 'priest.shadow.suggestions.vampiricTouch.uptime',

--- a/analysis/tbcwarlock/src/modules/spells/CurseOfTheElements.tsx
+++ b/analysis/tbcwarlock/src/modules/spells/CurseOfTheElements.tsx
@@ -1,6 +1,5 @@
 import { t } from '@lingui/macro';
 import { formatPercentage } from 'common/format';
-import SPELLS from 'common/SPELLS';
 import { SpellIcon, SpellLink } from 'interface';
 import Analyzer from 'parser/core/Analyzer';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
@@ -45,7 +44,6 @@ class CurseOfTheElements extends Analyzer {
           attention to your <SpellLink id={CURSE_OF_THE_ELEMENTS} /> on the boss.
         </span>,
       )
-        .icon(SPELLS.CURSE_OF_THE_ELEMENTS.icon)
         .actual(
           t({
             id: 'priest.shadow.suggestions.vampiricTouch.uptime',


### PR DESCRIPTION
two issues:

1. Curse modules were not added to CLP
2. Curse modules used non-existant spells