### PR TITLE
[APLCheck] replace spread operator with mutation

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -52,6 +52,7 @@ import React from 'react';
 
 // prettier-ignore
 export default [
+  change(date(2021, 10, 17), 'Improved APL checker performance.', emallson),
   change(date(2021, 10, 16), 'Add support for automatic checklist generation & timeline annotation from an APL.', emallson),
   change(date(2021, 10, 15), 'Another batch of basic TypeScript conversions and improvements.', ChrisKaczor),
   change(date(2021, 10, 14), 'Batch of basic TypeScript conversions and improvements.', ChrisKaczor),

--- a/src/parser/shared/metrics/apl/ChecklistRule.tsx
+++ b/src/parser/shared/metrics/apl/ChecklistRule.tsx
@@ -64,13 +64,10 @@ const Tooltip = ({
   const mistakes = Object.entries(
     violations
       .filter((v) => v.rule === rule)
-      .reduce(
-        (counts: { [spellId: number]: number }, v) => ({
-          ...counts,
-          [v.actualCast.ability.guid]: (counts[v.actualCast.ability.guid] || 0) + 1,
-        }),
-        {},
-      ),
+      .reduce((counts: { [spellId: number]: number }, v) => {
+        counts[v.actualCast.ability.guid] = (counts[v.actualCast.ability.guid] || 0) + 1;
+        return counts;
+      }, {}),
   )
     .sort((a, b) => b[1] - a[1])
     .slice(0, 3);

--- a/src/parser/shared/metrics/apl/conditions/and.tsx
+++ b/src/parser/shared/metrics/apl/conditions/and.tsx
@@ -2,21 +2,28 @@ import React from 'react';
 
 import type { Condition } from '../index';
 
+type ConditionMap = { [k: string]: Condition<any> };
+
 // TODO: this doesn't state-share with other conditions. don't think its a real big issue tho?
+/**
+   NOTE: this module is untested and may not work as intended. I implemented it
+   then realized I didn't need it. It remains here because it *should* still
+   work, but take care.
+**/
 export default function and(...conditions: Array<Condition<any>>): Condition<any> {
-  const cndMap: { [k: string]: Condition<any> } = conditions.reduce(
-    (map, cnd) => ({ ...map, [cnd.key]: cnd }),
-    {},
-  );
+  const cndMap: ConditionMap = conditions.reduce((map: ConditionMap, cnd) => {
+    map[cnd.key] = cnd;
+    return map;
+  }, {});
 
   return {
     key: `and-${conditions.map((cnd) => cnd.key).join('-')}`,
     init: (info) => Object.fromEntries(conditions.map(({ key, init }) => [key, init(info)])),
     update: (state, event) =>
-      Object.keys(state).reduce(
-        (nextState, key) => ({ ...nextState, [key]: cndMap[key]!.update(state[key], event) }),
-        {},
-      ),
+      Object.keys(state).reduce((nextState: ConditionMap, key) => {
+        nextState[key] = cndMap[key]!.update(state[key], event);
+        return nextState;
+      }, {}),
     validate: (state, event, spell) =>
       Object.keys(state).every((key) => cndMap[key]!.validate(state[key], event, spell)),
     describe: () =>


### PR DESCRIPTION
APL performance was *pretty bad* in production mode but not
development mode. it turns out that in prod the spread operator gets compiled down to
an es5-compatible method call that is way less efficient than modifying
the object in place.

this makes things faster in dev mode by about 50ms on my sylvanas test
log (2.6x). if it were under 100ms in prod i probably wouldn't care, but
it was over 400ms and the majority of the time was spent doing the
spread operation. we'll see how this performs in production and go from there.