### PR TITLE
fix vantus runes in Sanctum logs

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -52,6 +52,7 @@ import React from 'react';
 
 // prettier-ignore
 export default [
+  change(date(2021, 10, 20), 'Fix a crashing issue with Sanctum of Domination Vantus Runes.', emallson),
   change(date(2021, 10, 19), 'Fix issue with loading in boss data', Adoraci),
   change(date(2021, 10, 19), 'Added Sanctum of Domination boss phases and details.', Adoraci),
   change(date(2021, 10, 19), 'Fixed typo in footer links.', emallson),

--- a/src/common/ITEMS/shadowlands/crafted/inscription/index.ts
+++ b/src/common/ITEMS/shadowlands/crafted/inscription/index.ts
@@ -8,6 +8,11 @@ import { ItemList } from 'common/ITEMS/Item';
  * },
  */
 const items: ItemList = {
+  VANTUS_RUNE_SANCTUM_OF_DOMINATION: {
+    id: 186662,
+    name: 'Vantus Rune',
+    icon: 'inv_inscription_90_vantusrune_torghast',
+  },
   VANTUS_RUNE_CASTLE_NATHRIA: {
     id: 173067,
     name: 'Vantus Rune',


### PR DESCRIPTION
the issue was that the item wasn't added to the runes list, leading to
an inconsistent state where the module was active but the rune was
null (leading to a crash).

this will no longer lead to a crash (instead a warning will be logged),
and I added the item for Sanctum