### PR TITLE
Rename Energize -> ResourceChange

### DIFF
--- a/analysis/deathknight/src/RuneOfHysteria.tsx
+++ b/analysis/deathknight/src/RuneOfHysteria.tsx
@@ -4,7 +4,7 @@ import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import SPECS from 'game/SPECS';
 import Analyzer, { Options } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
@@ -32,10 +32,10 @@ class RuneOfHysteria extends Analyzer {
       return;
     }
 
-    this.addEventListener(Events.energize, this._onEnergize);
+    this.addEventListener(Events.resourcechange, this._onEnergize);
   }
 
-  _onEnergize(event: EnergizeEvent) {
+  _onEnergize(event: ResourceChangeEvent) {
     const hysteriaUp = this.selectedCombatant.hasBuff(
       SPELLS.RUNE_OF_HYSTERIA_BUFF.id,
       event.timestamp,

--- a/analysis/deathknight/src/Superstrain.tsx
+++ b/analysis/deathknight/src/Superstrain.tsx
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import SPECS from 'game/SPECS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { DamageEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
@@ -36,7 +36,7 @@ class Superstrain extends Analyzer {
     if (
       [SPECS.BLOOD_DEATH_KNIGHT, SPECS.UNHOLY_DEATH_KNIGHT].includes(this.selectedCombatant.spec)
     ) {
-      this.addEventListener(Events.energize, this._onFrostFeverEnergize);
+      this.addEventListener(Events.resourcechange, this._onFrostFeverEnergize);
     }
 
     if (this.selectedCombatant.spec === SPECS.BLOOD_DEATH_KNIGHT) {
@@ -99,7 +99,7 @@ class Superstrain extends Analyzer {
     this.virulentPlagueDamage += event.amount + (event.absorb || 0);
   }
 
-  _onFrostFeverEnergize(event: EnergizeEvent) {
+  _onFrostFeverEnergize(event: ResourceChangeEvent) {
     if (
       event.resourceChangeType !== RESOURCE_TYPES.RUNIC_POWER.id ||
       event.ability.guid !== SPELLS.FROST_FEVER_RP_GAIN.id

--- a/analysis/deathknight/src/SwarmingMist.tsx
+++ b/analysis/deathknight/src/SwarmingMist.tsx
@@ -5,7 +5,7 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import COVENANTS from 'game/shadowlands/COVENANTS';
 import SPECS from 'game/SPECS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { DamageEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
@@ -44,7 +44,7 @@ class SwarmingMist extends Analyzer {
       return;
     }
 
-    this.addEventListener(Events.energize, this._onSwarmingMistEnergize);
+    this.addEventListener(Events.resourcechange, this._onSwarmingMistEnergize);
     this.addEventListener(
       Events.damage.by(SELECTED_PLAYER).spell(SPELLS.SWARMING_MIST_TICK),
       this._onSwarmingMistDamage,
@@ -67,7 +67,7 @@ class SwarmingMist extends Analyzer {
     this.swarmingMistDamage += event.amount + (event.absorb || 0);
   }
 
-  _onSwarmingMistEnergize(event: EnergizeEvent) {
+  _onSwarmingMistEnergize(event: ResourceChangeEvent) {
     if (
       event.resourceChangeType !== RESOURCE_TYPES.RUNIC_POWER.id ||
       event.ability.guid !== SPELLS.SWARMING_MIST_RUNIC_POWER_GAIN.id

--- a/analysis/deathknightblood/src/modules/items/BrynadaorsMight.tsx
+++ b/analysis/deathknightblood/src/modules/items/BrynadaorsMight.tsx
@@ -2,7 +2,7 @@ import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
@@ -25,14 +25,14 @@ class BrynadaorsMight extends Analyzer {
       return;
     }
 
-    this.addEventListener(Events.energize, this._onEnergize);
+    this.addEventListener(Events.resourcechange, this._onEnergize);
     this.addEventListener(
       Events.heal.by(SELECTED_PLAYER).spell(SPELLS.DEATH_STRIKE_HEAL),
       this._onHeal,
     );
   }
 
-  _onEnergize(event: EnergizeEvent) {
+  _onEnergize(event: ResourceChangeEvent) {
     if (
       event.resourceChangeType !== RESOURCE_TYPES.RUNIC_POWER.id ||
       event.ability.guid !== SPELLS.BRYNDAORS_MIGHT_RUNIC_POWER_GAIN.id

--- a/analysis/deathknightblood/src/modules/talents/Heartbreaker.js
+++ b/analysis/deathknightblood/src/modules/talents/Heartbreaker.js
@@ -16,7 +16,7 @@ class Heartbreaker extends Analyzer {
     super(...args);
     this.active = this.selectedCombatant.hasTalent(SPELLS.HEARTBREAKER_TALENT.id);
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.HEART_STRIKE), this.onCast);
-    this.addEventListener(Events.energize.spell(SPELLS.HEARTBREAKER), this.onEnergize);
+    this.addEventListener(Events.resourcechange.spell(SPELLS.HEARTBREAKER), this.onEnergize);
   }
 
   onCast(event) {

--- a/analysis/deathknightblood/src/modules/talents/RelishInBlood.tsx
+++ b/analysis/deathknightblood/src/modules/talents/RelishInBlood.tsx
@@ -3,7 +3,7 @@ import { formatNumber, formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent, HealEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent, HealEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
@@ -21,14 +21,14 @@ class RelishInBlood extends Analyzer {
     super(options);
     this.active = this.selectedCombatant.hasTalent(SPELLS.RELISH_IN_BLOOD_TALENT.id);
 
-    this.addEventListener(Events.energize.spell(SPELLS.RELISH_IN_BLOOD), this._relishBuffed);
+    this.addEventListener(Events.resourcechange.spell(SPELLS.RELISH_IN_BLOOD), this._relishBuffed);
     this.addEventListener(
       Events.heal.by(SELECTED_PLAYER).spell(SPELLS.RELISH_IN_BLOOD),
       this._onHeal,
     );
   }
 
-  _relishBuffed(event: EnergizeEvent) {
+  _relishBuffed(event: ResourceChangeEvent) {
     if (event.resourceChangeType !== RESOURCE_TYPES.RUNIC_POWER.id) {
       return;
     }

--- a/analysis/deathknightblood/src/modules/talents/Tombstone.js
+++ b/analysis/deathknightblood/src/modules/talents/Tombstone.js
@@ -33,7 +33,7 @@ class Tombstone extends Analyzer {
       this.onApplyBuff,
     );
     this.addEventListener(
-      Events.energize.to(SELECTED_PLAYER).spell(SPELLS.TOMBSTONE_TALENT),
+      Events.resourcechange.to(SELECTED_PLAYER).spell(SPELLS.TOMBSTONE_TALENT),
       this.onEnergize,
     );
     this.addEventListener(

--- a/analysis/deathknightunholy/src/modules/spells/conduits/ConvocationOfTheDead.tsx
+++ b/analysis/deathknightunholy/src/modules/spells/conduits/ConvocationOfTheDead.tsx
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import CooldownIcon from 'interface/icons/Cooldown';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent } from 'parser/core/Events';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import ConduitSpellText from 'parser/ui/ConduitSpellText';
 import Statistic from 'parser/ui/Statistic';
@@ -52,12 +52,12 @@ class ConvocationOfTheDead extends Analyzer {
       return;
     }
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.FESTERING_WOUND_BURST),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.FESTERING_WOUND_BURST),
       this.onWoundBurst,
     );
   }
 
-  onWoundBurst(event: EnergizeEvent) {
+  onWoundBurst(event: ResourceChangeEvent) {
     if (this.spellUsable.isOnCooldown(SPELLS.APOCALYPSE.id)) {
       this.cooldownReduction += CONVOCATION_OF_THE_DEAD_EFFECT_BY_RANK[this.conduitRank] / 10;
       this.spellUsable.reduceCooldown(

--- a/analysis/demonhunterhavoc/src/modules/spells/DemonBite.js
+++ b/analysis/demonhunterhavoc/src/modules/spells/DemonBite.js
@@ -39,7 +39,7 @@ class DemonBite extends Analyzer {
     this.active = !this.selectedCombatant.hasTalent(SPELLS.DEMON_BLADES_TALENT.id);
 
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.DEMONS_BITE),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.DEMONS_BITE),
       this.onEnergizeEvent,
     );
     this.addEventListener(

--- a/analysis/demonhunterhavoc/src/modules/talents/CycleOfHatred.js
+++ b/analysis/demonhunterhavoc/src/modules/talents/CycleOfHatred.js
@@ -28,7 +28,7 @@ class CycleOfHatred extends Analyzer {
       return;
     }
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.CHAOS_STRIKE_ENERGIZE),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.CHAOS_STRIKE_ENERGIZE),
       this.onEnergizeEvent,
     );
   }

--- a/analysis/demonhunterhavoc/src/modules/talents/DemonBlades.js
+++ b/analysis/demonhunterhavoc/src/modules/talents/DemonBlades.js
@@ -39,7 +39,7 @@ class DemonBlades extends Analyzer {
       return;
     }
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.DEMON_BLADES_FURY),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.DEMON_BLADES_FURY),
       this.onEnergizeEvent,
     );
     this.addEventListener(

--- a/analysis/demonhunterhavoc/src/modules/talents/DemonicAppetite.js
+++ b/analysis/demonhunterhavoc/src/modules/talents/DemonicAppetite.js
@@ -38,7 +38,7 @@ class DemonicAppetite extends Analyzer {
       return;
     }
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.DEMONIC_APPETITE_FURY),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.DEMONIC_APPETITE_FURY),
       this.onEnergizeEvent,
     );
   }

--- a/analysis/demonhunterhavoc/src/modules/talents/Felblade.js
+++ b/analysis/demonhunterhavoc/src/modules/talents/Felblade.js
@@ -41,7 +41,7 @@ class Felblade extends Analyzer {
       return;
     }
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.FELBLADE_DAMAGE),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.FELBLADE_DAMAGE),
       this.onEnergizeEvent,
     );
     this.addEventListener(

--- a/analysis/demonhunterhavoc/src/modules/talents/ImmolationAura.js
+++ b/analysis/demonhunterhavoc/src/modules/talents/ImmolationAura.js
@@ -45,7 +45,7 @@ class ImmolationAura extends Analyzer {
       return;
     }
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(IMMOLATION_AURA),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(IMMOLATION_AURA),
       this.onEnergizeEvent,
     );
     this.addEventListener(

--- a/analysis/druidbalance/src/modules/resourcetracker/AstralPowerDetails.tsx
+++ b/analysis/druidbalance/src/modules/resourcetracker/AstralPowerDetails.tsx
@@ -4,7 +4,7 @@ import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { SpellLink, Panel } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import ResourceBreakdown from 'parser/shared/modules/resources/resourcetracker/ResourceBreakdown';
 import BoringResourceValue from 'parser/ui/BoringResourceValue';
@@ -50,10 +50,10 @@ class AstralPowerDetails extends Analyzer {
   constructor(options: Options) {
     super(options);
 
-    this.addEventListener(Events.energize.by(SELECTED_PLAYER), this.onEnergize);
+    this.addEventListener(Events.resourcechange.by(SELECTED_PLAYER), this.onEnergize);
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     if (event.resourceChangeType !== RESOURCE_TYPES.ASTRAL_POWER.id) {
       return;
     }

--- a/analysis/druidbalance/src/modules/resourcetracker/AstralPowerTracker.tsx
+++ b/analysis/druidbalance/src/modules/resourcetracker/AstralPowerTracker.tsx
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { Options } from 'parser/core/Analyzer';
-import { CastEvent, EnergizeEvent } from 'parser/core/Events';
+import { CastEvent, ResourceChangeEvent } from 'parser/core/Events';
 import ResourceTracker from 'parser/shared/modules/resources/resourcetracker/ResourceTracker';
 
 const WARRIOR_OF_ELUNE_MULTIPLIER = 0.4;
@@ -13,7 +13,7 @@ class AstralPowerTracker extends ResourceTracker {
   }
 
   // Split Warrior of Elune Astral Power bonus into it's own entry.
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     const spellId = event.ability.guid;
     if (
       spellId !== SPELLS.STARFIRE.id ||

--- a/analysis/druidbalance/src/modules/talents/SoulOfTheForest.tsx
+++ b/analysis/druidbalance/src/modules/talents/SoulOfTheForest.tsx
@@ -2,7 +2,7 @@ import { formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
@@ -14,12 +14,12 @@ class SoulOfTheForest extends Analyzer {
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(SPELLS.SOUL_OF_THE_FOREST_TALENT_BALANCE);
-    this.addEventListener(Events.energize.to(SELECTED_PLAYER), this.onEnergize);
+    this.addEventListener(Events.resourcechange.to(SELECTED_PLAYER), this.onEnergize);
   }
 
   gainedAP = 0;
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     // we only care if we generated Astral Power by using Wrath while inside Solar Eclipse
     if (
       event.resourceChangeType !== RESOURCE_TYPES.ASTRAL_POWER.id ||

--- a/analysis/druidferal/src/modules/shadowlands/ApexPredatorsCraving.tsx
+++ b/analysis/druidferal/src/modules/shadowlands/ApexPredatorsCraving.tsx
@@ -7,7 +7,7 @@ import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, {
   ApplyBuffEvent,
   DamageEvent,
-  EnergizeEvent,
+  ResourceChangeEvent,
   RefreshBuffEvent,
 } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
@@ -42,7 +42,7 @@ class ApexPredatorsCraving extends Analyzer {
 
   damageDone: number = 0;
 
-  lastSotf?: EnergizeEvent;
+  lastSotf?: ResourceChangeEvent;
   sotfEnergyGained: number = 0;
   sotfEnergyEffective: number = 0;
   sotfEnergyWasted: number = 0;
@@ -71,7 +71,7 @@ class ApexPredatorsCraving extends Analyzer {
 
     if (this.hasSotf) {
       this.addEventListener(
-        Events.energize.by(SELECTED_PLAYER).spell(SPELLS.SOUL_OF_THE_FOREST_FERAL_ENERGY),
+        Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.SOUL_OF_THE_FOREST_FERAL_ENERGY),
         this.onSotfEnergize,
       );
     }
@@ -106,7 +106,7 @@ class ApexPredatorsCraving extends Analyzer {
     }
   }
 
-  onSotfEnergize(event: EnergizeEvent) {
+  onSotfEnergize(event: ResourceChangeEvent) {
     this.lastSotf = event;
   }
 

--- a/analysis/druidferal/src/modules/spells/TigersFuryEnergy.tsx
+++ b/analysis/druidferal/src/modules/spells/TigersFuryEnergy.tsx
@@ -3,7 +3,7 @@ import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import React from 'react';
 
@@ -28,12 +28,12 @@ class TigersFuryEnergy extends Analyzer {
     super(options);
 
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.TIGERS_FURY),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.TIGERS_FURY),
       this.onTigersFuryEnergize,
     );
   }
 
-  onTigersFuryEnergize(event: EnergizeEvent) {
+  onTigersFuryEnergize(event: ResourceChangeEvent) {
     const total = event.resourceChange;
     const waste = event.waste;
 

--- a/analysis/druidferal/src/normalizers/ComboPointsFromAoE.js
+++ b/analysis/druidferal/src/normalizers/ComboPointsFromAoE.js
@@ -65,7 +65,7 @@ class ComboPointsFromAoE extends EventsNormalizer {
       const eventComboResource = this.getResource(event, RESOURCE_TYPES.COMBO_POINTS.id);
 
       if (
-        event.type === EventType.Energize &&
+        event.type === EventType.ResourceChange &&
         event.targetID === this.playerId &&
         event.resourceChangeType === RESOURCE_TYPES.COMBO_POINTS.id
       ) {
@@ -96,7 +96,7 @@ class ComboPointsFromAoE extends EventsNormalizer {
       }
 
       if (
-        event.type === EventType.Energize &&
+        event.type === EventType.ResourceChange &&
         event.sourceID === this.playerId &&
         event.resourceChangeType === RESOURCE_TYPES.COMBO_POINTS.id &&
         INVISIBLE_ENERGIZE_ATTACKS.includes(event.ability.guid) &&
@@ -127,7 +127,7 @@ class ComboPointsFromAoE extends EventsNormalizer {
         // We now know that the last castEvent hit and so did produce a combo point.
         const fabricatedEnergize = {
           __fabricated: true,
-          type: EventType.Energize,
+          type: EventType.ResourceChange,
           timestamp: castEvent.timestamp,
           ability: castEvent.ability,
           sourceID: this.playerId,

--- a/analysis/druidguardian/src/modules/features/RageWasted.js
+++ b/analysis/druidguardian/src/modules/features/RageWasted.js
@@ -73,7 +73,7 @@ class RageWasted extends Analyzer {
 
   constructor(options) {
     super(options);
-    this.addEventListener(Events.energize.by(SELECTED_PLAYER), this.onEnergize);
+    this.addEventListener(Events.resourcechange.by(SELECTED_PLAYER), this.onEnergize);
     this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onCast);
   }
 

--- a/analysis/hunter/src/FocusCapTracker.tsx
+++ b/analysis/hunter/src/FocusCapTracker.tsx
@@ -3,7 +3,7 @@ import { formatPercentage, formatThousands } from 'common/format';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { Tooltip } from 'interface';
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent, DamageEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { CastEvent, DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import RegenResourceCapTracker from 'parser/shared/modules/resources/resourcetracker/RegenResourceCapTracker';
 import FlushLineChart from 'parser/ui/FlushLineChart';
@@ -30,7 +30,7 @@ class FocusCapTracker extends RegenResourceCapTracker {
 
   constructor(options: Options) {
     super(options);
-    this.addEventListener(Events.energize.by(SELECTED_PLAYER), this.onEnergizeByPlayer);
+    this.addEventListener(Events.resourcechange.by(SELECTED_PLAYER), this.onEnergizeByPlayer);
   }
 
   get wastedPercent() {
@@ -53,7 +53,7 @@ class FocusCapTracker extends RegenResourceCapTracker {
     return HUNTER_BASE_FOCUS_MAX;
   }
 
-  onEnergizeByPlayer(event: EnergizeEvent) {
+  onEnergizeByPlayer(event: ResourceChangeEvent) {
     const secondsIntoFight = Math.floor((event.timestamp - this.owner.fight.start_time) / 1000);
     this.bySecond[secondsIntoFight] = this.bySecond[secondsIntoFight] || this.current;
   }

--- a/analysis/hunter/src/FocusTracker.tsx
+++ b/analysis/hunter/src/FocusTracker.tsx
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { Options } from 'parser/core/Analyzer';
-import { CastEvent, EnergizeEvent } from 'parser/core/Events';
+import { CastEvent, ResourceChangeEvent } from 'parser/core/Events';
 import ResourceTracker from 'parser/shared/modules/resources/resourcetracker/ResourceTracker';
 
 import {
@@ -19,7 +19,7 @@ class FocusTracker extends ResourceTracker {
   }
 
   //Because energize events associated with certain spells don't provide a waste number, but instead a lower resourceChange number we can calculate the waste ourselves.
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     if (event.resourceChangeType !== this.resource.id) {
       return;
     }

--- a/analysis/hunter/src/conduits/ReversalOfFortune.tsx
+++ b/analysis/hunter/src/conduits/ReversalOfFortune.tsx
@@ -2,7 +2,7 @@ import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { ResourceIcon } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent, InterruptEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent, InterruptEvent } from 'parser/core/Events';
 import ConduitSpellText from 'parser/ui/ConduitSpellText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -27,7 +27,7 @@ class ReversalOfFortune extends Analyzer {
     );
 
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.REVERSAL_OF_FORTUNE_ENERGIZE),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.REVERSAL_OF_FORTUNE_ENERGIZE),
       this.onEnergize,
     );
     this.addEventListener(
@@ -36,7 +36,7 @@ class ReversalOfFortune extends Analyzer {
     );
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     this.focusGained += event.resourceChange;
     this.focusWasted += event.waste;
   }

--- a/analysis/hunter/src/conduits/necrolord/NecroticBarrage.tsx
+++ b/analysis/hunter/src/conduits/necrolord/NecroticBarrage.tsx
@@ -2,7 +2,7 @@ import SPELLS from 'common/SPELLS';
 import COVENANTS from 'game/shadowlands/COVENANTS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
-import Events, { DamageEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
 import ConduitSpellText from 'parser/ui/ConduitSpellText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
@@ -44,7 +44,7 @@ class NecroticBarrage extends Analyzer {
       this.onDeathChakramDamage,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.DEATH_CHAKRAM_ENERGIZE),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.DEATH_CHAKRAM_ENERGIZE),
       this.onEnergize,
     );
   }
@@ -56,7 +56,7 @@ class NecroticBarrage extends Analyzer {
     );
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     this.gainedFocus += event.resourceChange;
     this.wastedFocus += event.waste;
   }

--- a/analysis/hunter/src/covenants/necrolord/DeathChakrams.tsx
+++ b/analysis/hunter/src/covenants/necrolord/DeathChakrams.tsx
@@ -3,7 +3,7 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import COVENANTS from 'game/shadowlands/COVENANTS';
 import { ResourceIcon } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { DamageEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
 import Abilities from 'parser/core/modules/Abilities';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
@@ -52,7 +52,7 @@ class DeathChakrams extends Analyzer {
       this.onDamage,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.DEATH_CHAKRAM_ENERGIZE),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.DEATH_CHAKRAM_ENERGIZE),
       this.onEnergize,
     );
   }
@@ -61,7 +61,7 @@ class DeathChakrams extends Analyzer {
     this.damage += event.amount + (event.absorbed || 0);
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     this.focusGained += event.resourceChange;
     this.focusWasted += event.waste;
   }

--- a/analysis/hunterbeastmastery/src/modules/items/NesingwarysTrappingApparatus.tsx
+++ b/analysis/hunterbeastmastery/src/modules/items/NesingwarysTrappingApparatus.tsx
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { ResourceIcon } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -40,12 +40,14 @@ class NesingwarysTrappingApparatus extends Analyzer {
       return;
     }
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.NESINGWARYS_TRAPPING_APPARATUS_ENERGIZE),
+      Events.resourcechange
+        .by(SELECTED_PLAYER)
+        .spell(SPELLS.NESINGWARYS_TRAPPING_APPARATUS_ENERGIZE),
       this.onEnergize,
     );
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     this.focusGained += event.resourceChange;
     this.focusWasted += event.waste;
   }

--- a/analysis/hunterbeastmastery/src/modules/spells/AspectOfTheWild.tsx
+++ b/analysis/hunterbeastmastery/src/modules/spells/AspectOfTheWild.tsx
@@ -2,7 +2,7 @@ import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import UptimeIcon from 'interface/icons/Uptime';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
@@ -36,7 +36,7 @@ class AspectOfTheWild extends Analyzer {
       SPELLS.NESINGWARYS_TRAPPING_APPARATUS_EFFECT.bonusID,
     ) &&
       this.addEventListener(
-        Events.energize.by(SELECTED_PLAYER).spell(SPELLS.ASPECT_OF_THE_WILD),
+        Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.ASPECT_OF_THE_WILD),
         this.checkNesingwaryFocusGain,
       );
   }
@@ -47,7 +47,7 @@ class AspectOfTheWild extends Analyzer {
     );
   }
 
-  checkNesingwaryFocusGain(event: EnergizeEvent) {
+  checkNesingwaryFocusGain(event: ResourceChangeEvent) {
     const waste = ASPECT_OF_THE_WILD_FOCUS - event.resourceChange;
     if (this.selectedCombatant.hasBuff(SPELLS.NESINGWARYS_TRAPPING_APPARATUS_ENERGIZE.id)) {
       this.additionalFocusFromNesingwary +=

--- a/analysis/hunterbeastmastery/src/modules/spells/BarbedShot.tsx
+++ b/analysis/hunterbeastmastery/src/modules/spells/BarbedShot.tsx
@@ -7,7 +7,7 @@ import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/
 import Events, {
   ApplyBuffEvent,
   ApplyBuffStackEvent,
-  EnergizeEvent,
+  ResourceChangeEvent,
   EventType,
   FightEndEvent,
   RemoveBuffEvent,
@@ -61,7 +61,7 @@ class BarbedShot extends Analyzer {
       SPELLS.NESINGWARYS_TRAPPING_APPARATUS_EFFECT.bonusID,
     ) &&
       this.addEventListener(
-        Events.energize.by(SELECTED_PLAYER).spell(BARBED_SHOT_FOCUS_REGEN_BUFFS),
+        Events.resourcechange.by(SELECTED_PLAYER).spell(BARBED_SHOT_FOCUS_REGEN_BUFFS),
         this.checkNesingwaryFocusGain,
       );
   }
@@ -142,7 +142,7 @@ class BarbedShot extends Analyzer {
     return avgStacks;
   }
 
-  checkNesingwaryFocusGain(event: EnergizeEvent) {
+  checkNesingwaryFocusGain(event: ResourceChangeEvent) {
     const waste = BARBED_SHOT_REGEN - event.resourceChange;
     if (this.selectedCombatant.hasBuff(SPELLS.NESINGWARYS_TRAPPING_APPARATUS_ENERGIZE.id)) {
       this.additionalFocusFromNesingwary +=

--- a/analysis/huntermarksmanship/src/modules/items/NesingwarysTrappingApparatus.tsx
+++ b/analysis/huntermarksmanship/src/modules/items/NesingwarysTrappingApparatus.tsx
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { ResourceIcon } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -40,12 +40,14 @@ class NesingwarysTrappingApparatus extends Analyzer {
       return;
     }
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.NESINGWARYS_TRAPPING_APPARATUS_ENERGIZE),
+      Events.resourcechange
+        .by(SELECTED_PLAYER)
+        .spell(SPELLS.NESINGWARYS_TRAPPING_APPARATUS_ENERGIZE),
       this.onEnergize,
     );
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     this.focusGained += event.resourceChange;
     this.focusWasted += event.waste;
   }

--- a/analysis/huntermarksmanship/src/modules/spells/RapidFire.tsx
+++ b/analysis/huntermarksmanship/src/modules/spells/RapidFire.tsx
@@ -3,7 +3,7 @@ import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, {
   AnyEvent,
   ApplyBuffEvent,
-  EnergizeEvent,
+  ResourceChangeEvent,
   EventType,
   RefreshBuffEvent,
   RemoveBuffEvent,
@@ -70,7 +70,7 @@ class RapidFire extends Analyzer {
       this.onAffectingBuffChange,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.RAPID_FIRE_FOCUS),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.RAPID_FIRE_FOCUS),
       this.onEnergize,
     );
   }
@@ -128,7 +128,7 @@ class RapidFire extends Analyzer {
     this.currentFocusTicks = 0;
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     this.effectiveFocusGain += event.resourceChange - event.waste;
     this.focusWasted += event.waste;
     const hasTrueshot = this.selectedCombatant.hasBuff(SPELLS.TRUESHOT.id);

--- a/analysis/huntermarksmanship/src/modules/spells/SteadyShot.tsx
+++ b/analysis/huntermarksmanship/src/modules/spells/SteadyShot.tsx
@@ -1,6 +1,6 @@
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
@@ -23,12 +23,12 @@ class SteadyShot extends Analyzer {
   constructor(options: Options) {
     super(options);
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.STEADY_SHOT_FOCUS),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.STEADY_SHOT_FOCUS),
       this.onEnergize,
     );
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     this.effectiveFocusGain += event.resourceChange - event.waste;
     this.focusWasted += event.waste;
     const hasTrueshot = this.selectedCombatant.hasBuff(SPELLS.TRUESHOT.id);

--- a/analysis/huntermarksmanship/src/modules/spells/Trueshot.tsx
+++ b/analysis/huntermarksmanship/src/modules/spells/Trueshot.tsx
@@ -4,7 +4,7 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { ResourceIcon } from 'interface';
 import { SpellIcon } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { CastEvent, ResourceChangeEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
@@ -55,7 +55,7 @@ class Trueshot extends Analyzer {
       this.onTrueshotCast,
     );
     this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.focusCheck);
-    this.addEventListener(Events.energize.by(SELECTED_PLAYER), this.focusCheck);
+    this.addEventListener(Events.resourcechange.by(SELECTED_PLAYER), this.focusCheck);
   }
 
   get averageAimedShots() {
@@ -97,7 +97,7 @@ class Trueshot extends Analyzer {
     }
   }
 
-  focusCheck(event: EnergizeEvent | CastEvent) {
+  focusCheck(event: ResourceChangeEvent | CastEvent) {
     if (!this.selectedCombatant.hasBuff(SPELLS.TRUESHOT.id)) {
       return;
     }

--- a/analysis/huntersurvival/src/modules/items/NesingwarysTrappingApparatus.tsx
+++ b/analysis/huntersurvival/src/modules/items/NesingwarysTrappingApparatus.tsx
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { ResourceIcon } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -37,12 +37,14 @@ class NesingwarysTrappingApparatus extends Analyzer {
       return;
     }
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.NESINGWARYS_TRAPPING_APPARATUS_ENERGIZE),
+      Events.resourcechange
+        .by(SELECTED_PLAYER)
+        .spell(SPELLS.NESINGWARYS_TRAPPING_APPARATUS_ENERGIZE),
       this.onEnergize,
     );
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     this.focusGained += event.resourceChange;
     this.focusWasted += event.waste;
   }

--- a/analysis/huntersurvival/src/modules/spells/KillCommand.tsx
+++ b/analysis/huntersurvival/src/modules/spells/KillCommand.tsx
@@ -1,6 +1,6 @@
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { ApplyBuffEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { ApplyBuffEvent, ResourceChangeEvent } from 'parser/core/Events';
 import Abilities from 'parser/core/modules/Abilities';
 import GlobalCooldown from 'parser/shared/modules/GlobalCooldown';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
@@ -47,7 +47,7 @@ class KillCommand extends Analyzer {
       SPELLS.NESINGWARYS_TRAPPING_APPARATUS_EFFECT.bonusID,
     ) &&
       this.addEventListener(
-        Events.energize.by(SELECTED_PLAYER).spell(SPELLS.KILL_COMMAND_CAST_SV),
+        Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.KILL_COMMAND_CAST_SV),
         this.checkNesingwaryFocusGain,
       );
   }
@@ -70,7 +70,7 @@ class KillCommand extends Analyzer {
     }
   }
 
-  checkNesingwaryFocusGain(event: EnergizeEvent) {
+  checkNesingwaryFocusGain(event: ResourceChangeEvent) {
     if (this.selectedCombatant.hasBuff(SPELLS.NESINGWARYS_TRAPPING_APPARATUS_ENERGIZE.id)) {
       this.additionalFocusFromNesingwary +=
         event.resourceChange * (1 - 1 / NESINGWARY_FOCUS_GAIN_MULTIPLIER) - event.waste;

--- a/analysis/huntersurvival/src/modules/talents/FlankingStrike.tsx
+++ b/analysis/huntersurvival/src/modules/talents/FlankingStrike.tsx
@@ -1,6 +1,6 @@
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
-import Events, { DamageEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
@@ -51,11 +51,11 @@ class FlankingStrike extends Analyzer {
       this.onPlayerDamage,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER_PET).spell(SPELLS.FLANKING_STRIKE_PET),
+      Events.resourcechange.by(SELECTED_PLAYER_PET).spell(SPELLS.FLANKING_STRIKE_PET),
       this.onPetEnergize,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.FLANKING_STRIKE_PLAYER),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.FLANKING_STRIKE_PLAYER),
       this.onPlayerEnergize,
     );
   }
@@ -103,7 +103,7 @@ class FlankingStrike extends Analyzer {
     this.flankingStrikesPlayer.damage += event.amount + (event.absorbed || 0);
   }
 
-  onPetEnergize(event: EnergizeEvent) {
+  onPetEnergize(event: ResourceChangeEvent) {
     const effectiveFocus = event.resourceChange - event.waste || 0;
     const pet = this.getOrInitializePet(event.sourceID);
     if (!pet) {
@@ -113,7 +113,7 @@ class FlankingStrike extends Analyzer {
     pet.possibleFocus += FLANKING_STRIKE_FOCUS_GAIN;
   }
 
-  onPlayerEnergize(event: EnergizeEvent) {
+  onPlayerEnergize(event: ResourceChangeEvent) {
     const foundPlayer = this.flankingStrikesPlayer;
     foundPlayer.effectiveFocus += event.resourceChange - event.waste || 0;
     foundPlayer.possibleFocus += FLANKING_STRIKE_FOCUS_GAIN;

--- a/analysis/magearcane/src/modules/features/ArcaneChargeTracker.tsx
+++ b/analysis/magearcane/src/modules/features/ArcaneChargeTracker.tsx
@@ -1,6 +1,6 @@
 import SPELLS from 'common/SPELLS';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
-import Events, { CastEvent, EnergizeEvent, DeathEvent } from 'parser/core/Events';
+import Events, { CastEvent, ResourceChangeEvent, DeathEvent } from 'parser/core/Events';
 
 const debug = false;
 
@@ -9,7 +9,7 @@ class ArcaneChargeTracker extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.addEventListener(Events.energize.to(SELECTED_PLAYER), this.onEnergize);
+    this.addEventListener(Events.resourcechange.to(SELECTED_PLAYER), this.onEnergize);
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.ARCANE_BARRAGE),
       this.onBarrage,
@@ -17,7 +17,7 @@ class ArcaneChargeTracker extends Analyzer {
     this.addEventListener(Events.death.to(SELECTED_PLAYER), this.onDeath);
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     const resourceType = event.resourceChangeType;
     if (resourceType !== 16) {
       return;

--- a/analysis/magearcane/src/modules/items/ArtificeOfTheArchmage.tsx
+++ b/analysis/magearcane/src/modules/items/ArtificeOfTheArchmage.tsx
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import { SELECTED_PLAYER } from 'parser/core/EventFilter';
-import Events, { EnergizeEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent } from 'parser/core/Events';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import ConduitSpellText from 'parser/ui/ConduitSpellText';
 import Statistic from 'parser/ui/Statistic';
@@ -24,12 +24,12 @@ class ArtificeOfTheArchmage extends Analyzer {
       SPELLS.ARTIFICE_OF_THE_ARCHMAGE.id,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.ARTIFICE_OF_THE_ARCHMAGE_ENERGIZE),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.ARTIFICE_OF_THE_ARCHMAGE_ENERGIZE),
       this.onEnergize,
     );
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     this.freeCharges += 2;
   }
 

--- a/analysis/magearcane/src/normalizers/ArcaneCharges.ts
+++ b/analysis/magearcane/src/normalizers/ArcaneCharges.ts
@@ -13,7 +13,7 @@ const EVENT_ORDERS: EventOrder[] = [
     ],
     beforeEventType: EventType.Cast,
     afterEventId: null, // FIXME could this be acccidentally matching other kinds of energizes?
-    afterEventType: EventType.Energize,
+    afterEventType: EventType.ResourceChange,
     bufferMs: 50,
   },
 ];

--- a/analysis/monk/src/GroundingBreath.tsx
+++ b/analysis/monk/src/GroundingBreath.tsx
@@ -2,7 +2,7 @@ import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
 import conduitScaling from 'parser/core/conduitScaling';
-import Events, { EnergizeEvent, HealEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent, HealEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
 import ItemManaGained from 'parser/ui/ItemManaGained';
@@ -34,7 +34,7 @@ class GroundingBreath extends Analyzer {
 
     this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.VIVIFY), this.vivifyBoost);
     this.addEventListener(
-      Events.energize
+      Events.resourcechange
         .by(SELECTED_PLAYER)
         .spell([SPELLS.GROUNDING_BREATH_MANA_RETURN, SPELLS.GROUNDING_BREATH_ENERGY_RETURN]),
       this.onResourceRefund,
@@ -48,7 +48,7 @@ class GroundingBreath extends Analyzer {
     this.healing += calculateEffectiveHealing(event, this.healingBoost) || 0;
   }
 
-  onResourceRefund(event: EnergizeEvent) {
+  onResourceRefund(event: ResourceChangeEvent) {
     this.resourceReturned += event.resourceChange;
   }
 

--- a/analysis/monkmistweaver/src/modules/talents/SpiritOfTheCrane.tsx
+++ b/analysis/monkmistweaver/src/modules/talents/SpiritOfTheCrane.tsx
@@ -7,7 +7,7 @@ import Events, {
   ApplyBuffEvent,
   ApplyBuffStackEvent,
   CastEvent,
-  EnergizeEvent,
+  ResourceChangeEvent,
   RemoveBuffEvent,
 } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
@@ -58,7 +58,7 @@ class SpiritOfTheCrane extends Analyzer {
       this.lostStacks,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.SPIRIT_OF_THE_CRANE_BUFF),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.SPIRIT_OF_THE_CRANE_BUFF),
       this.stacksToMana,
     );
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.TIGER_PALM), this.tigerPalm);
@@ -106,7 +106,7 @@ class SpiritOfTheCrane extends Analyzer {
     this.buffTotm = 0;
   }
 
-  stacksToMana(event: EnergizeEvent) {
+  stacksToMana(event: ResourceChangeEvent) {
     this.manaReturnSotc += event.resourceChange - event.waste;
     this.sotcWasted += event.waste;
     debug &&

--- a/analysis/paladin/src/HolyAvenger.tsx
+++ b/analysis/paladin/src/HolyAvenger.tsx
@@ -2,7 +2,7 @@ import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { SpellIcon } from 'interface';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent } from 'parser/core/Events';
 import BoringValueText from 'parser/ui/BoringValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -22,10 +22,10 @@ class HolyAvenger extends Analyzer {
       return;
     }
 
-    this.addEventListener(Events.energize.by(SELECTED_PLAYER), this.getHolyPower);
+    this.addEventListener(Events.resourcechange.by(SELECTED_PLAYER), this.getHolyPower);
   }
 
-  getHolyPower(event: EnergizeEvent) {
+  getHolyPower(event: ResourceChangeEvent) {
     if (!this.selectedCombatant.hasBuff(SPELLS.HOLY_AVENGER_TALENT.id)) {
       return;
     }

--- a/analysis/paladinholy/src/modules/features/MasteryEffectiveness.js
+++ b/analysis/paladinholy/src/modules/features/MasteryEffectiveness.js
@@ -85,7 +85,7 @@ class MasteryEffectiveness extends Analyzer {
     super(options);
     this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onCast);
     this.addEventListener(Events.damage.to(SELECTED_PLAYER), this.onDamageTaken);
-    this.addEventListener(Events.energize.to(SELECTED_PLAYER), this.onEnergize);
+    this.addEventListener(Events.resourcechange.to(SELECTED_PLAYER), this.onEnergize);
     this.addEventListener(Events.heal.to(SELECTED_PLAYER), this.onHealToPlayer);
     this.addEventListener(Events.absorbed.by(SELECTED_PLAYER), this.onAbsorbedByPlayer);
     this.addEventListener(Events.heal.by(SELECTED_PLAYER), this.onHealByPlayer);

--- a/analysis/paladinprotection/src/modules/talents/SanctifiedWrathProtJudgement.tsx
+++ b/analysis/paladinprotection/src/modules/talents/SanctifiedWrathProtJudgement.tsx
@@ -1,7 +1,7 @@
 import { formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
-import Events, { CastEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { CastEvent, ResourceChangeEvent } from 'parser/core/Events';
 import BoringSpellValue from 'parser/ui/BoringSpellValue';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -29,7 +29,7 @@ class SanctifiedWrathProtJudgement extends Analyzer {
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.JUDGMENT_CAST_PROTECTION),
       this.trackJudgmentCasts,
     );
-    this.addEventListener(Events.energize.by(SELECTED_PLAYER), this.trackedWastedJudgmentHP);
+    this.addEventListener(Events.resourcechange.by(SELECTED_PLAYER), this.trackedWastedJudgmentHP);
   }
 
   trackJudgmentCasts(event: CastEvent) {
@@ -38,7 +38,7 @@ class SanctifiedWrathProtJudgement extends Analyzer {
     }
   }
 
-  trackedWastedJudgmentHP(event: EnergizeEvent) {
+  trackedWastedJudgmentHP(event: ResourceChangeEvent) {
     const hasAW: boolean = this.selectedCombatant.hasBuff(SPELLS.AVENGING_WRATH.id);
 
     const judgementSource: boolean = event.ability.guid === SPELLS.JUDGMENT_HP_ENERGIZE.id;
@@ -66,7 +66,7 @@ class SanctifiedWrathProtJudgement extends Analyzer {
    * @param event
    * @returns Number of wasted Holy Power due to Sanctified Wrath talent.
    */
-  wasteDueToSanctifiedWrath(event: EnergizeEvent): number {
+  wasteDueToSanctifiedWrath(event: ResourceChangeEvent): number {
     const hasHA: boolean = this.selectedCombatant.hasBuff(SPELLS.HOLY_AVENGER_TALENT.id);
     const hpChange: number = event.resourceChange;
     const preCastHP = this.MAX_HOLY_POWER - (hpChange - event.waste);

--- a/analysis/paladinretribution/src/modules/core/BladeofJustice.tsx
+++ b/analysis/paladinretribution/src/modules/core/BladeofJustice.tsx
@@ -1,6 +1,6 @@
 import SPELLS from 'common/SPELLS';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent, CastEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent, CastEvent } from 'parser/core/Events';
 
 class BladeofJustice extends Analyzer {
   wastedHP = 0;
@@ -12,12 +12,12 @@ class BladeofJustice extends Analyzer {
       this.onBladeOfJusticeCast,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.BLADE_OF_JUSTICE),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.BLADE_OF_JUSTICE),
       this.onBladeOfJusticeEnergize,
     );
   }
 
-  onBladeOfJusticeEnergize(event: EnergizeEvent) {
+  onBladeOfJusticeEnergize(event: ResourceChangeEvent) {
     if (event.waste > 0) {
       this.wastedHP = event.waste;
     }

--- a/analysis/paladinretribution/src/modules/core/CrusaderStrike.tsx
+++ b/analysis/paladinretribution/src/modules/core/CrusaderStrike.tsx
@@ -1,6 +1,6 @@
 import SPELLS from 'common/SPELLS';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent, CastEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent, CastEvent } from 'parser/core/Events';
 
 class CrusaderStrike extends Analyzer {
   wasteHP = false;
@@ -12,12 +12,12 @@ class CrusaderStrike extends Analyzer {
       this.onCrusaderStrikeCast,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.CRUSADER_STRIKE),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.CRUSADER_STRIKE),
       this.onCrusaderStrikeEnergize,
     );
   }
 
-  onCrusaderStrikeEnergize(event: EnergizeEvent) {
+  onCrusaderStrikeEnergize(event: ResourceChangeEvent) {
     if (event.waste > 0) {
       this.wasteHP = true;
     }

--- a/analysis/paladinretribution/src/modules/core/HammerofWrath.tsx
+++ b/analysis/paladinretribution/src/modules/core/HammerofWrath.tsx
@@ -1,6 +1,6 @@
 import SPELLS from 'common/SPELLS';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent, CastEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent, CastEvent } from 'parser/core/Events';
 
 // TODO: Needs updating with ExecuteHelper
 
@@ -14,12 +14,12 @@ class HammerofWrath extends Analyzer {
       this.onHammerofWrathCast,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.HAMMER_OF_WRATH),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.HAMMER_OF_WRATH),
       this.onHammerofWrathEnergize,
     );
   }
 
-  onHammerofWrathEnergize(event: EnergizeEvent) {
+  onHammerofWrathEnergize(event: ResourceChangeEvent) {
     if (event.waste > 0) {
       this.wasteHP = true;
     }

--- a/analysis/paladinretribution/src/modules/core/WakeofAshes.tsx
+++ b/analysis/paladinretribution/src/modules/core/WakeofAshes.tsx
@@ -3,7 +3,12 @@ import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import { SpellIcon } from 'interface';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
-import Events, { DamageEvent, CastEvent, EnergizeEvent, FightEndEvent } from 'parser/core/Events';
+import Events, {
+  DamageEvent,
+  CastEvent,
+  ResourceChangeEvent,
+  FightEndEvent,
+} from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
@@ -34,7 +39,7 @@ class WakeofAshes extends Analyzer {
       this.onWakeofAshesCast,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.WAKE_OF_ASHES),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.WAKE_OF_ASHES),
       this.onWakeofAshesEnergize,
     );
     this.addEventListener(Events.fightend, this.onFinished);
@@ -45,7 +50,7 @@ class WakeofAshes extends Analyzer {
     this.wakeCast = false;
   }
 
-  onWakeofAshesEnergize(event: EnergizeEvent) {
+  onWakeofAshesEnergize(event: ResourceChangeEvent) {
     if (event.waste > 0) {
       this.wasteHP = true;
     }

--- a/analysis/priest/src/FaeGuardians.tsx
+++ b/analysis/priest/src/FaeGuardians.tsx
@@ -8,7 +8,7 @@ import calculateEffectiveDamageReduction from 'parser/core/calculateEffectiveDam
 import Events, {
   ApplyBuffEvent,
   DamageEvent,
-  EnergizeEvent,
+  ResourceChangeEvent,
   RemoveBuffEvent,
 } from 'parser/core/Events';
 import Abilities from 'parser/core/modules/Abilities';
@@ -83,7 +83,7 @@ class FaeGuardians extends Analyzer {
 
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.FAE_GUARDIANS), this.onCast);
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.WRATHFUL_FAERIE_ENERGIZE),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.WRATHFUL_FAERIE_ENERGIZE),
       this.onEnergize,
     );
     this.addEventListener(
@@ -112,7 +112,7 @@ class FaeGuardians extends Analyzer {
     this.damageReduced += calculateEffectiveDamageReduction(event, GUARDIAN_DAMAGE_REDUCTION);
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     if (event.resourceChangeType === RESOURCE_TYPES.MANA.id) {
       this.manaGenerated += event.resourceChange || 0;
     }

--- a/analysis/priest/src/Mindgames.tsx
+++ b/analysis/priest/src/Mindgames.tsx
@@ -4,7 +4,12 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import COVENANTS from 'game/shadowlands/COVENANTS';
 import SPECS from 'game/SPECS';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { AbsorbedEvent, DamageEvent, EnergizeEvent, HealEvent } from 'parser/core/Events';
+import Events, {
+  AbsorbedEvent,
+  DamageEvent,
+  ResourceChangeEvent,
+  HealEvent,
+} from 'parser/core/Events';
 import { Options } from 'parser/core/Module';
 import Abilities from 'parser/core/modules/Abilities';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
@@ -88,7 +93,7 @@ class Mindgames extends Analyzer {
       this.onMindgamesAbsorbed,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.MINDGAMES_HEAL),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.MINDGAMES_HEAL),
       this.onEnergize,
     );
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.MINDGAMES), this.onDamage);
@@ -118,7 +123,7 @@ class Mindgames extends Analyzer {
     this.preventedDamage += event.amount;
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     if (event.resourceChangeType === RESOURCE_TYPES.MANA.id) {
       this.manaGenerated += event.resourceChange || 0;
     }

--- a/analysis/priestshadow/src/modules/resources/InsanityTracker.tsx
+++ b/analysis/priestshadow/src/modules/resources/InsanityTracker.tsx
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { Options } from 'parser/core/Analyzer';
-import { EnergizeEvent } from 'parser/core/Events';
+import { ResourceChangeEvent } from 'parser/core/Events';
 import ResourceTracker from 'parser/shared/modules/resources/resourcetracker/ResourceTracker';
 
 import {
@@ -16,7 +16,7 @@ class InsanityTracker extends ResourceTracker {
   }
 
   // Because energize events associated with certain spells don't provide a waste number, but instead a lower resourceChange number we can calculate the waste ourselves.
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     if (event.resourceChangeType !== this.resource.id) {
       return;
     }

--- a/analysis/priestshadow/src/modules/talents/DeathAndMadness.tsx
+++ b/analysis/priestshadow/src/modules/talents/DeathAndMadness.tsx
@@ -4,7 +4,7 @@ import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import Insanity from 'interface/icons/Insanity';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent } from 'parser/core/Events';
 import { When, ThresholdStyle } from 'parser/core/ParseResults';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
@@ -32,7 +32,7 @@ class DeathAndMadness extends Analyzer {
       this.onBuff,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.DEATH_AND_MADNESS_BUFF),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.DEATH_AND_MADNESS_BUFF),
       this.onEnergize,
     );
   }
@@ -46,7 +46,7 @@ class DeathAndMadness extends Analyzer {
     this.casts += 1;
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     this.insanityGained += event.resourceChange;
   }
 

--- a/analysis/priestshadow/src/modules/talents/FortressOfTheMind.tsx
+++ b/analysis/priestshadow/src/modules/talents/FortressOfTheMind.tsx
@@ -2,7 +2,7 @@ import { formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import Insanity from 'interface/icons/Insanity';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
-import Events, { DamageEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
@@ -28,7 +28,7 @@ class FortressOfTheMind extends Analyzer {
       this.onDamage,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(FORTRESS_ABILITIES),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(FORTRESS_ABILITIES),
       this.onEnergize,
     );
   }
@@ -38,7 +38,7 @@ class FortressOfTheMind extends Analyzer {
     this.damage += raw - raw / FORTRESS_OF_THE_MIND_DAMAGE_INCREASE;
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     this.insanity +=
       event.resourceChange - event.resourceChange / FORTRESS_OF_THE_MIND_INSANITY_INCREASE;
   }

--- a/analysis/priestshadow/src/modules/talents/ShadowCrash.tsx
+++ b/analysis/priestshadow/src/modules/talents/ShadowCrash.tsx
@@ -2,7 +2,7 @@ import { formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import Insanity from 'interface/icons/Insanity';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { DamageEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
@@ -30,7 +30,7 @@ class ShadowCrash extends Analyzer {
       this.onDamage,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.SHADOW_CRASH_TALENT),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.SHADOW_CRASH_TALENT),
       this.onEnergize,
     );
   }
@@ -46,7 +46,7 @@ class ShadowCrash extends Analyzer {
     this.damage += event.amount + (event.absorbed || 0);
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     this.insanityGained += event.resourceChange;
   }
 

--- a/analysis/priestshadow/src/modules/talents/VoidTorrent.tsx
+++ b/analysis/priestshadow/src/modules/talents/VoidTorrent.tsx
@@ -4,7 +4,12 @@ import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import Insanity from 'interface/icons/Insanity';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent, DamageEvent, RemoveBuffEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, {
+  CastEvent,
+  DamageEvent,
+  RemoveBuffEvent,
+  ResourceChangeEvent,
+} from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
@@ -45,7 +50,7 @@ class VoidTorrent extends Analyzer {
       this.onDamage,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.VOID_TORRENT_BUFF),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.VOID_TORRENT_BUFF),
       this.onEnergize,
     );
   }
@@ -138,7 +143,7 @@ class VoidTorrent extends Analyzer {
     this.damage += event.amount + (event.absorbed || 0);
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     this.insanityGained += event.resourceChange;
   }
 

--- a/analysis/rogue/src/covenants/kyrian/EchoingReprimand.tsx
+++ b/analysis/rogue/src/covenants/kyrian/EchoingReprimand.tsx
@@ -3,7 +3,7 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import COVENANTS from 'game/shadowlands/COVENANTS';
 import { ResourceIcon } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { DamageEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
 import Abilities from 'parser/core/modules/Abilities';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
@@ -28,7 +28,7 @@ class EchoingReprimand extends Analyzer {
       this.onDamage,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.ECHOING_REPRIMAND_ENERGIZE),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.ECHOING_REPRIMAND_ENERGIZE),
       this.onEnergize,
     );
   }
@@ -37,7 +37,7 @@ class EchoingReprimand extends Analyzer {
     this.damage += event.amount + (event.absorbed || 0);
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     if (event.resourceChangeType === RESOURCE_TYPES.COMBO_POINTS.id) {
       this.comboPointsGained += event.resourceChange;
       this.comboPointsWasted += event.waste;

--- a/analysis/rogue/src/covenants/necrolord/SerratedBoneSpike.tsx
+++ b/analysis/rogue/src/covenants/necrolord/SerratedBoneSpike.tsx
@@ -3,7 +3,7 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import COVENANTS from 'game/shadowlands/COVENANTS';
 import { ResourceIcon } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { DamageEvent, EnergizeEvent, RemoveDebuffEvent } from 'parser/core/Events';
+import Events, { DamageEvent, ResourceChangeEvent, RemoveDebuffEvent } from 'parser/core/Events';
 import Abilities from 'parser/core/modules/Abilities';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
@@ -34,7 +34,7 @@ class SerratedBoneSpike extends Analyzer {
       this.onDamage,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.SERRATED_BONE_SPIKE_ENERGIZE),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.SERRATED_BONE_SPIKE_ENERGIZE),
       this.onEnergize,
     );
     this.addEventListener(
@@ -47,7 +47,7 @@ class SerratedBoneSpike extends Analyzer {
     this.damage += event.amount + (event.absorbed || 0);
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     if (event.resourceChangeType === RESOURCE_TYPES.COMBO_POINTS.id) {
       this.comboPointsGained += event.resourceChange;
       this.comboPointsWasted += event.waste;

--- a/analysis/rogueassassination/src/modules/spells/shadowlands/legendaries/DashingScoundrel.tsx
+++ b/analysis/rogueassassination/src/modules/spells/shadowlands/legendaries/DashingScoundrel.tsx
@@ -2,7 +2,7 @@ import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { ResourceIcon } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent } from 'parser/core/Events';
 import Abilities from 'parser/core/modules/Abilities';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
@@ -23,12 +23,12 @@ class DashingScoundrel extends Analyzer {
     super(options);
     this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.DASHING_SCOUNDREL.bonusID);
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.DASHING_SCOUNDREL),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.DASHING_SCOUNDREL),
       this.onEnergize,
     );
   }
 
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     this.critCount += 1;
     this.comboPointsGained += event.resourceChange;
     this.comboPointsWasted += event.waste;

--- a/analysis/rogueassassination/src/normalizers/GarroteOpenerNormalizer.js
+++ b/analysis/rogueassassination/src/normalizers/GarroteOpenerNormalizer.js
@@ -30,7 +30,7 @@ class GarroteNormalizer extends EventsNormalizer {
             break;
           }
           if (
-            previousEvent.type === EventType.Energize &&
+            previousEvent.type === EventType.ResourceChange &&
             previousEvent.ability.guid === SPELLS.GARROTE.id
           ) {
             event.timestamp = previousEvent.timestamp;

--- a/analysis/roguesubtlety/src/modules/spells/shadowlands/legendaries/TheRotten.tsx
+++ b/analysis/roguesubtlety/src/modules/spells/shadowlands/legendaries/TheRotten.tsx
@@ -2,7 +2,7 @@ import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { ResourceIcon } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent } from 'parser/core/Events';
 import Abilities from 'parser/core/modules/Abilities';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
@@ -22,14 +22,14 @@ class TheRotten extends Analyzer {
     super(options);
     this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.THE_ROTTEN.bonusID);
     this.addEventListener(
-      Events.energize
+      Events.resourcechange
         .by(SELECTED_PLAYER)
         .spell([SPELLS.SHADOWSTRIKE, SPELLS.BACKSTAB, SPELLS.GLOOMBLADE_TALENT]),
       this.onDamage,
     );
   }
 
-  onDamage(event: EnergizeEvent) {
+  onDamage(event: ResourceChangeEvent) {
     if (this.selectedCombatant.hasBuff(SPELLS.SYMBOLS_OF_DEATH.id)) {
       this.cpGained += event.resourceChange;
       this.cpWasted += event.waste;

--- a/analysis/roguesubtlety/src/normalizers/ShurikenStormNormalizer.ts
+++ b/analysis/roguesubtlety/src/normalizers/ShurikenStormNormalizer.ts
@@ -33,7 +33,10 @@ class ShurikenStormNormalizer extends EventsNormalizer {
       fixedEvents.push(event);
 
       // Find Shuriken Storm CP Events
-      if (event.type === EventType.Energize && event.ability.guid === SPELLS.SHURIKEN_STORM_CP.id) {
+      if (
+        event.type === EventType.ResourceChange &&
+        event.ability.guid === SPELLS.SHURIKEN_STORM_CP.id
+      ) {
         //Remove excess waste from Shuriken Storm.
         if (event.waste > 0) {
           if (event.resourceChange - event.waste >= this.minCPs) {

--- a/analysis/shamanelemental/src/modules/talents/Aftershock.tsx
+++ b/analysis/shamanelemental/src/modules/talents/Aftershock.tsx
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import Analyzer, { Options } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ResourceGenerated from 'parser/ui/ResourceGenerated';
 import Statistic from 'parser/ui/Statistic';
@@ -16,10 +16,10 @@ class Aftershock extends Analyzer {
     super(options);
     this.active = this.selectedCombatant.hasTalent(SPELLS.AFTERSHOCK_TALENT.id);
 
-    this.addEventListener(Events.energize.spell(SPELLS.AFTERSHOCK), this.onAftershock);
+    this.addEventListener(Events.resourcechange.spell(SPELLS.AFTERSHOCK), this.onAftershock);
   }
 
-  onAftershock(event: EnergizeEvent) {
+  onAftershock(event: ResourceChangeEvent) {
     this.refund += event.resourceChange;
   }
 

--- a/analysis/shamanrestoration/src/modules/spells/Resurgence.tsx
+++ b/analysis/shamanrestoration/src/modules/spells/Resurgence.tsx
@@ -6,7 +6,7 @@ import { SpellLink } from 'interface';
 import { SpellIcon } from 'interface';
 import ManaIcon from 'interface/icons/Mana';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent, HealEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent, HealEvent } from 'parser/core/Events';
 import ManaTracker from 'parser/core/healingEfficiency/ManaTracker';
 import BoringValue from 'parser/ui/BoringValueText';
 import Statistic from 'parser/ui/Statistic';
@@ -62,7 +62,7 @@ class Resurgence extends Analyzer {
       this.onRelevantHeal,
     );
     this.addEventListener(
-      Events.energize.to(SELECTED_PLAYER).spell(SPELLS.RESURGENCE),
+      Events.resourcechange.to(SELECTED_PLAYER).spell(SPELLS.RESURGENCE),
       this.onResurgenceProc,
     );
   }
@@ -88,7 +88,7 @@ class Resurgence extends Analyzer {
     }
   }
 
-  onResurgenceProc(event: EnergizeEvent) {
+  onResurgenceProc(event: ResourceChangeEvent) {
     const spellId = event.ability.guid;
 
     if (spellId !== SPELLS.RESURGENCE.id) {

--- a/analysis/shamanrestoration/src/modules/spells/WaterShield.tsx
+++ b/analysis/shamanrestoration/src/modules/spells/WaterShield.tsx
@@ -5,7 +5,7 @@ import { SpellLink } from 'interface';
 import { TooltipElement } from 'interface';
 import ManaIcon from 'interface/icons/Mana';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { ApplyBuffEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { ApplyBuffEvent, ResourceChangeEvent } from 'parser/core/Events';
 import { ThresholdStyle } from 'parser/core/ParseResults';
 import BoringValue from 'parser/ui/BoringValueText';
 import Statistic from 'parser/ui/Statistic';
@@ -27,7 +27,7 @@ class WaterShield extends Analyzer {
     this.active = false;
 
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.WATER_SHIELD_ENERGIZE),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.WATER_SHIELD_ENERGIZE),
       this.waterShield,
     );
     this.addEventListener(
@@ -36,7 +36,7 @@ class WaterShield extends Analyzer {
     );
   }
 
-  waterShield(event: EnergizeEvent) {
+  waterShield(event: ResourceChangeEvent) {
     this.manaGain += event.resourceChange;
   }
 

--- a/analysis/tbcpriest/src/modules/spells/Shadowfiend.tsx
+++ b/analysis/tbcpriest/src/modules/spells/Shadowfiend.tsx
@@ -1,6 +1,6 @@
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
-import Events, { DamageEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import ItemManaGained from 'parser/ui/ItemManaGained';
@@ -28,7 +28,7 @@ class Shadowfiend extends Analyzer {
 
     this.addEventListener(Events.damage.by(SELECTED_PLAYER_PET), this.onShadowfiendDamage);
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER_PET).spell({ id: SPELLS.SHADOW_FIEND_MANA_LEECH }),
+      Events.resourcechange.by(SELECTED_PLAYER_PET).spell({ id: SPELLS.SHADOW_FIEND_MANA_LEECH }),
       this.onShadowfiendRegen,
     );
   }
@@ -37,7 +37,7 @@ class Shadowfiend extends Analyzer {
     this.damageFromShadowfiend += event.amount + (event.absorb || 0);
   }
 
-  onShadowfiendRegen(event: EnergizeEvent) {
+  onShadowfiendRegen(event: ResourceChangeEvent) {
     this.manaFromShadowFiend += event.resourceChange;
   }
 

--- a/analysis/warlockaffliction/src/modules/talents/DrainSoul.tsx
+++ b/analysis/warlockaffliction/src/modules/talents/DrainSoul.tsx
@@ -4,7 +4,7 @@ import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import CriticalStrikeIcon from 'interface/icons/CriticalStrike';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { EnergizeEvent, RemoveDebuffEvent } from 'parser/core/Events';
+import Events, { ResourceChangeEvent, RemoveDebuffEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import Enemies from 'parser/shared/modules/Enemies';
@@ -53,7 +53,7 @@ class DrainSoul extends Analyzer {
     super(options);
     this.active = this.selectedCombatant.hasTalent(SPELLS.DRAIN_SOUL_TALENT.id);
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.DRAIN_SOUL_KILL_SHARD_GEN),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.DRAIN_SOUL_KILL_SHARD_GEN),
       this.onDrainSoulEnergize,
     );
     this.addEventListener(
@@ -63,7 +63,7 @@ class DrainSoul extends Analyzer {
     this.addEventListener(Events.fightend, this.onFinished);
   }
 
-  onDrainSoulEnergize(event: EnergizeEvent) {
+  onDrainSoulEnergize(event: ResourceChangeEvent) {
     this.mobsSniped += 1;
     if (this._lastEnergize !== event.timestamp) {
       this._lastEnergize = event.timestamp;

--- a/analysis/warlockdemonology/src/modules/pets/DemoPets/PetSummonHandler.js
+++ b/analysis/warlockdemonology/src/modules/pets/DemoPets/PetSummonHandler.js
@@ -33,7 +33,7 @@ class PetSummonHandler extends Analyzer {
     this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onCast);
     this.addEventListener(Events.SpendResource.by(SELECTED_PLAYER), this.onSpendResource);
     this.addEventListener(Events.damage.to(SELECTED_PLAYER), this.onDamageTaken);
-    this.addEventListener(Events.energize.to(SELECTED_PLAYER), this.onEnergize);
+    this.addEventListener(Events.resourcechange.to(SELECTED_PLAYER), this.onEnergize);
     this.addEventListener(Events.heal.to(SELECTED_PLAYER), this.onHealTaken);
     this.addEventListener(Events.absorbed.to(SELECTED_PLAYER), this.onAbsorb);
   }

--- a/analysis/warlockdestruction/src/modules/soulshards/SoulShardTracker.ts
+++ b/analysis/warlockdestruction/src/modules/soulshards/SoulShardTracker.ts
@@ -6,7 +6,7 @@ import EventFilter, { SELECTED_PLAYER } from 'parser/core/EventFilter';
 import Events, {
   DamageEvent,
   EventType,
-  EnergizeEvent,
+  ResourceChangeEvent,
   CastEvent,
   AnyEvent,
   ClassResources,
@@ -57,7 +57,7 @@ class SoulShardTracker extends ResourceTracker {
   }
 
   // this accounts for Soul Conduit and possibly Feretory of Souls (they grant whole Soul Shards and appear as energize events, but their resourceChange field is in values 0 - 5 and we want 0 - 50
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     if (event.resourceChangeType !== this.resource.id) {
       return;
     }

--- a/analysis/warriorarms/src/modules/shadowlands/legendaries/SignetOfTormentedKings.tsx
+++ b/analysis/warriorarms/src/modules/shadowlands/legendaries/SignetOfTormentedKings.tsx
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { ApplyBuffEvent, CastEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { ApplyBuffEvent, CastEvent, ResourceChangeEvent } from 'parser/core/Events';
 import SUGGESTION_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import DonutChart from 'parser/ui/DonutChart';
@@ -32,7 +32,7 @@ class SignetOfTormentedKings extends Analyzer {
     );
 
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.AVATAR_TALENT),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.AVATAR_TALENT),
       this.onByPlayerSignetTriggeredBuff,
     );
     this.addEventListener(
@@ -44,7 +44,7 @@ class SignetOfTormentedKings extends Analyzer {
       this.onByPlayerSignetTriggeredBuff,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.SIGNET_OF_TORMENTED_KINGS_ENERGIZE),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.SIGNET_OF_TORMENTED_KINGS_ENERGIZE),
       this.onByPlayerSignetTriggeredBuff,
     );
 
@@ -62,7 +62,7 @@ class SignetOfTormentedKings extends Analyzer {
     );
   }
 
-  onByPlayerSignetTriggeredBuff(event: ApplyBuffEvent | EnergizeEvent) {
+  onByPlayerSignetTriggeredBuff(event: ApplyBuffEvent | ResourceChangeEvent) {
     if (this._signetIsUp === true && event.ability.guid !== this._lastSignetTrigger) {
       if (
         event.ability.guid === SPELLS.AVATAR_TALENT.id ||

--- a/analysis/warriorfury/src/modules/spells/Recklessness.tsx
+++ b/analysis/warriorfury/src/modules/spells/Recklessness.tsx
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import UptimeIcon from 'interface/icons/Uptime';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { DamageEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import React from 'react';
@@ -17,7 +17,7 @@ class Recklessness extends Analyzer {
     super(options);
 
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).to(SELECTED_PLAYER),
+      Events.resourcechange.by(SELECTED_PLAYER).to(SELECTED_PLAYER),
       this.onPlayerEnergize,
     );
     this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onPlayerDamage);
@@ -35,7 +35,7 @@ class Recklessness extends Analyzer {
     return this.owner.getPercentageOfTotalDamageDone(this.reckDamage);
   }
 
-  onPlayerEnergize(event: EnergizeEvent) {
+  onPlayerEnergize(event: ResourceChangeEvent) {
     const resource =
       event.classResources &&
       event.classResources.find((classResources) => classResources.type === RESOURCE_TYPES.RAGE.id);

--- a/analysis/warriorfury/src/modules/talents/Bladestorm.tsx
+++ b/analysis/warriorfury/src/modules/talents/Bladestorm.tsx
@@ -3,7 +3,7 @@ import { formatNumber, formatPercentage, formatThousands } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent, DamageEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { CastEvent, DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
@@ -36,7 +36,7 @@ class Bladestorm extends Analyzer {
       this.onBladestormDamage,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.BLADESTORM_TALENT),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.BLADESTORM_TALENT),
       this.onBladestormEnergize,
     );
   }
@@ -72,7 +72,7 @@ class Bladestorm extends Analyzer {
     this.totalDamage += event.amount + (event.absorbed || 0);
   }
 
-  onBladestormEnergize(event: EnergizeEvent) {
+  onBladestormEnergize(event: ResourceChangeEvent) {
     this.rageGained += event.resourceChange;
   }
 

--- a/analysis/warriorfury/src/modules/talents/DragonRoar.tsx
+++ b/analysis/warriorfury/src/modules/talents/DragonRoar.tsx
@@ -3,7 +3,7 @@ import { formatNumber, formatPercentage, formatThousands } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent, DamageEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { CastEvent, DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
@@ -35,7 +35,7 @@ class DragonRoar extends Analyzer {
       this.onDragonRoarDamage,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.DRAGON_ROAR_TALENT),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.DRAGON_ROAR_TALENT),
       this.onDragonRoarEnergize,
     );
     this.addEventListener(
@@ -75,7 +75,7 @@ class DragonRoar extends Analyzer {
     this.totalDamage += event.amount + (event.absorbed || 0);
   }
 
-  onDragonRoarEnergize(event: EnergizeEvent) {
+  onDragonRoarEnergize(event: ResourceChangeEvent) {
     this.rageGained += event.resourceChange;
   }
 

--- a/analysis/warriorfury/src/modules/talents/MeatCleaver.tsx
+++ b/analysis/warriorfury/src/modules/talents/MeatCleaver.tsx
@@ -1,6 +1,6 @@
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { ApplyBuffEvent, DamageEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { ApplyBuffEvent, DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -33,7 +33,7 @@ class MeatCleaver extends Analyzer {
     }
 
     this.addEventListener(
-      Events.energize.to(SELECTED_PLAYER).spell(SPELLS.WHIRLWIND_FURY_ENERGIZE),
+      Events.resourcechange.to(SELECTED_PLAYER).spell(SPELLS.WHIRLWIND_FURY_ENERGIZE),
       this.onWhirlwindEnergize,
     );
     this.addEventListener(
@@ -66,7 +66,7 @@ class MeatCleaver extends Analyzer {
   }
 
   // The Energize event ligns up with the cast, so using it for both the rage gain, and timings of the cast.
-  onWhirlwindEnergize(event: EnergizeEvent) {
+  onWhirlwindEnergize(event: ResourceChangeEvent) {
     this.lastWhirlwindCast = event.timestamp;
     this.whirlwindEvents[this.lastWhirlwindCast] = {
       resourceChange: event.resourceChange,

--- a/analysis/warriorfury/src/modules/talents/RecklessAbandon.tsx
+++ b/analysis/warriorfury/src/modules/talents/RecklessAbandon.tsx
@@ -1,7 +1,7 @@
 import { formatNumber, formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { DamageEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -25,11 +25,11 @@ class RecklessAbandon extends Analyzer {
     }
 
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).spell(SPELLS.RECKLESSNESS),
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.RECKLESSNESS),
       this.onRecklessAbandonEnergize,
     );
     this.addEventListener(
-      Events.energize.by(SELECTED_PLAYER).to(SELECTED_PLAYER),
+      Events.resourcechange.by(SELECTED_PLAYER).to(SELECTED_PLAYER),
       this.onPlayerEnergize,
     );
     this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onPlayerDamage);
@@ -39,16 +39,16 @@ class RecklessAbandon extends Analyzer {
     return this.owner.getPercentageOfTotalDamageDone(this.damage);
   }
 
-  hasLast4SecondsOfRecklessness(event: EnergizeEvent | DamageEvent) {
+  hasLast4SecondsOfRecklessness(event: ResourceChangeEvent | DamageEvent) {
     const reck = this.selectedCombatant.getBuff(SPELLS.RECKLESSNESS.id);
     return reck && event.timestamp - reck.start > BASE_RECKLESSNESS_DURATION;
   }
 
-  onRecklessAbandonEnergize(event: EnergizeEvent) {
+  onRecklessAbandonEnergize(event: ResourceChangeEvent) {
     this.instantRageGained += event.resourceChange;
   }
 
-  onPlayerEnergize(event: EnergizeEvent) {
+  onPlayerEnergize(event: ResourceChangeEvent) {
     if (this.hasLast4SecondsOfRecklessness(event)) {
       this.rageGained += event.resourceChange / 2;
     }

--- a/analysis/warriorprotection/src/modules/talents/BoomingVoice.tsx
+++ b/analysis/warriorprotection/src/modules/talents/BoomingVoice.tsx
@@ -4,7 +4,7 @@ import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import calculateEffectiveDamage from 'parser/core/calculateEffectiveDamage';
-import Events, { CastEvent, DamageEvent, EnergizeEvent } from 'parser/core/Events';
+import Events, { CastEvent, DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import Enemies from 'parser/shared/modules/Enemies';
 import BoringValueText from 'parser/ui/BoringValueText';
@@ -36,7 +36,7 @@ class BoomingVoice extends Analyzer {
       this.onShoutCast,
     );
     this.addEventListener(
-      Events.energize.to(SELECTED_PLAYER).spell(SPELLS.DEMORALIZING_SHOUT),
+      Events.resourcechange.to(SELECTED_PLAYER).spell(SPELLS.DEMORALIZING_SHOUT),
       this.onShoutEnergize,
     );
     this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDamage);
@@ -65,7 +65,7 @@ class BoomingVoice extends Analyzer {
     this.nextCastWasted = 0;
   }
 
-  onShoutEnergize(event: EnergizeEvent) {
+  onShoutEnergize(event: ResourceChangeEvent) {
     this.rageGenerated += event.resourceChange;
     const waste = event.waste || 0;
     this.rageWasted += waste;

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -52,6 +52,7 @@ import React from 'react';
 
 // prettier-ignore
 export default [
+  change(date(2021, 10, 31), 'Prepare for "energize" event rename.', emallson),
   change(date(2021, 10, 27), 'Clean up character page for TBC characters.', emallson),
   change(date(2021, 10, 21), 'Remove paywall on timeline.', emallson),
   change(date(2021, 10, 20), 'Fix a crashing issue with Sanctum of Domination Vantus Runes.', emallson),

--- a/src/interface/EventsTab.js
+++ b/src/interface/EventsTab.js
@@ -452,7 +452,10 @@ class EventsTab extends React.Component {
                           </>
                         );
                       }
-                      if (rowData.type === EventType.Energize || rowData.type === EventType.Drain) {
+                      if (
+                        rowData.type === EventType.ResourceChange ||
+                        rowData.type === EventType.Drain
+                      ) {
                         const resource = RESOURCE_TYPES[rowData.resourceChangeType];
                         const change = rowData.resourceChange - (rowData.waste || 0);
                         if (resource) {
@@ -516,7 +519,7 @@ class EventsTab extends React.Component {
                           </span>
                         );
                       }
-                      if (rowData.type === EventType.Energize) {
+                      if (rowData.type === EventType.ResourceChange) {
                         const resource = RESOURCE_TYPES[rowData.resourceChangeType];
                         if (resource) {
                           return (

--- a/src/interface/EventsTab.js
+++ b/src/interface/EventsTab.js
@@ -82,8 +82,8 @@ const FILTERABLE_TYPES = {
     explanation:
       'Triggered at the start of the fight with advanced combat logging on. This includes gear, talents, etc.',
   },
-  energize: {
-    name: 'Energize',
+  resourcechange: {
+    name: 'Resource Change',
   },
   drain: {
     name: 'Drain',

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -18,6 +18,7 @@ import DeathRecapTracker from 'parser/shared/modules/DeathRecapTracker';
 import Haste from 'parser/shared/modules/Haste';
 import ManaValues from 'parser/shared/modules/ManaValues';
 import StatTracker from 'parser/shared/modules/StatTracker';
+import EnergizeCompat from 'parser/shared/normalizers/EnergizeCompat';
 import React, { ComponentType } from 'react';
 
 import Config from '../Config';
@@ -140,6 +141,7 @@ class CombatLogParser {
     deathDowntime: DeathDowntime,
     totalDowntime: TotalDowntime,
     spellInfo: SpellInfo,
+    energizeCompat: EnergizeCompat,
   };
   static defaultModules: DependenciesDefinition = {
     // Normalizers

--- a/src/parser/core/EventOrderNormalizer.test.js
+++ b/src/parser/core/EventOrderNormalizer.test.js
@@ -198,18 +198,18 @@ const tests = [
         beforeEventId: 50,
         beforeEventType: EventType.ApplyBuff,
         afterEventId: null,
-        afterEventType: EventType.Energize,
+        afterEventType: EventType.ResourceChange,
       },
     ],
     events: [
       // matches any ID
-      fakeEvent(1337, EventType.Energize, 100, 1, 1),
+      fakeEvent(1337, EventType.ResourceChange, 100, 1, 1),
       fakeEvent(50, EventType.ApplyBuff, 100, 1, 1),
       // matches any ID
-      fakeEvent(1, EventType.Energize, 200, 1, 1),
+      fakeEvent(1, EventType.ResourceChange, 200, 1, 1),
       fakeEvent(50, EventType.ApplyBuff, 200, 1, 1),
       // even an undefined ID!
-      fakeEvent(undefined, EventType.Energize, 300, 1, 1),
+      fakeEvent(undefined, EventType.ResourceChange, 300, 1, 1),
       fakeEvent(50, EventType.ApplyBuff, 300, 1, 1),
       // still needs to match type - won't swap
       fakeEvent(1337, EventType.Damage, 400, 1, 1),

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -27,7 +27,11 @@ export enum EventType {
   RemoveBuff = 'removebuff',
   RemoveDebuff = 'removedebuff',
   Summon = 'summon',
-  ResourceChange = 'energize',
+  /**
+   * @deprecated Use `EventType.ResourceChange` instead. This enum variant will be removed soon.
+   */
+  Energize = 'resourcechange',
+  ResourceChange = 'resourcechange',
   Interrupt = 'interrupt',
   Death = 'death',
   Resurrect = 'resurrect',
@@ -111,7 +115,7 @@ type MappedEventTypes = {
   [EventType.RemoveBuff]: RemoveBuffEvent;
   [EventType.RemoveDebuff]: RemoveDebuffEvent;
   [EventType.Summon]: SummonEvent;
-  [EventType.ResourceChange]: EnergizeEvent;
+  [EventType.ResourceChange]: ResourceChangeEvent;
   [EventType.Drain]: DrainEvent;
   [EventType.Death]: DeathEvent;
   [EventType.CombatantInfo]: CombatantInfoEvent;
@@ -543,7 +547,7 @@ export interface RefreshDebuffEvent extends BuffEvent<EventType.RefreshDebuff> {
   source?: { name: 'Environment'; id: -1; guid: 0; type: 'NPC'; icon: 'NPC' };
 }
 
-export interface EnergizeEvent extends Event<EventType.ResourceChange> {
+export interface ResourceChangeEvent extends Event<EventType.ResourceChange> {
   ability: Ability;
   sourceID: number;
   sourceIsFriendly: boolean;
@@ -1062,7 +1066,7 @@ const Events = {
   get summon() {
     return new EventFilter(EventType.Summon);
   },
-  get energize() {
+  get resourcechange() {
     return new EventFilter(EventType.ResourceChange);
   },
   get drain() {

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -27,7 +27,7 @@ export enum EventType {
   RemoveBuff = 'removebuff',
   RemoveDebuff = 'removedebuff',
   Summon = 'summon',
-  Energize = 'energize',
+  ResourceChange = 'energize',
   Interrupt = 'interrupt',
   Death = 'death',
   Resurrect = 'resurrect',
@@ -111,7 +111,7 @@ type MappedEventTypes = {
   [EventType.RemoveBuff]: RemoveBuffEvent;
   [EventType.RemoveDebuff]: RemoveDebuffEvent;
   [EventType.Summon]: SummonEvent;
-  [EventType.Energize]: EnergizeEvent;
+  [EventType.ResourceChange]: EnergizeEvent;
   [EventType.Drain]: DrainEvent;
   [EventType.Death]: DeathEvent;
   [EventType.CombatantInfo]: CombatantInfoEvent;
@@ -543,7 +543,7 @@ export interface RefreshDebuffEvent extends BuffEvent<EventType.RefreshDebuff> {
   source?: { name: 'Environment'; id: -1; guid: 0; type: 'NPC'; icon: 'NPC' };
 }
 
-export interface EnergizeEvent extends Event<EventType.Energize> {
+export interface EnergizeEvent extends Event<EventType.ResourceChange> {
   ability: Ability;
   sourceID: number;
   sourceIsFriendly: boolean;
@@ -1063,7 +1063,7 @@ const Events = {
     return new EventFilter(EventType.Summon);
   },
   get energize() {
-    return new EventFilter(EventType.Energize);
+    return new EventFilter(EventType.ResourceChange);
   },
   get drain() {
     return new EventFilter(EventType.Drain);

--- a/src/parser/shared/metrics/apl/conditions/hasResource.tsx
+++ b/src/parser/shared/metrics/apl/conditions/hasResource.tsx
@@ -12,7 +12,7 @@ export default function hasResource(resource: Resource, range: Range): Condition
     key: `hasResource-${resource.id}`,
     init: () => 0,
     update: (state, event) => {
-      if (event.type === EventType.Energize && event.resourceChangeType === resource.id) {
+      if (event.type === EventType.ResourceChange && event.resourceChangeType === resource.id) {
         return event.resourceChange - event.waste + state;
       } else if (
         event.type === EventType.SpendResource &&

--- a/src/parser/shared/metrics/resourceGained.test.ts
+++ b/src/parser/shared/metrics/resourceGained.test.ts
@@ -3,7 +3,7 @@ import { EnergizeEvent, EventType } from 'parser/core/Events';
 import resourceGained from './resourceGained';
 
 const energizeEvent = (id: number, amount: number = 100): EnergizeEvent => ({
-  type: EventType.Energize,
+  type: EventType.ResourceChange,
   ability: {
     guid: id,
     name: 'test',

--- a/src/parser/shared/metrics/resourceGained.test.ts
+++ b/src/parser/shared/metrics/resourceGained.test.ts
@@ -1,8 +1,8 @@
-import { EnergizeEvent, EventType } from 'parser/core/Events';
+import { ResourceChangeEvent, EventType } from 'parser/core/Events';
 
 import resourceGained from './resourceGained';
 
-const energizeEvent = (id: number, amount: number = 100): EnergizeEvent => ({
+const energizeEvent = (id: number, amount: number = 100): ResourceChangeEvent => ({
   type: EventType.ResourceChange,
   ability: {
     guid: id,

--- a/src/parser/shared/metrics/resourceGained.ts
+++ b/src/parser/shared/metrics/resourceGained.ts
@@ -14,7 +14,7 @@ interface ResourcesGained {
  */
 const resourceGained = (events: AnyEvent[]) =>
   events.reduce<ResourcesGained>((obj, event) => {
-    if (event.type === EventType.Energize) {
+    if (event.type === EventType.ResourceChange) {
       obj[event.targetID] = obj[event.targetID] || {};
       obj[event.targetID][event.resourceChangeType] =
         obj[event.targetID][event.resourceChangeType] || {};

--- a/src/parser/shared/metrics/resourceWasted.test.ts
+++ b/src/parser/shared/metrics/resourceWasted.test.ts
@@ -3,7 +3,7 @@ import { EnergizeEvent, EventType } from 'parser/core/Events';
 import resourceWasted from './resourceWasted';
 
 const energizeEvent = (id: number, amount: number = 100): EnergizeEvent => ({
-  type: EventType.Energize,
+  type: EventType.ResourceChange,
   ability: {
     guid: id,
     name: 'test',

--- a/src/parser/shared/metrics/resourceWasted.test.ts
+++ b/src/parser/shared/metrics/resourceWasted.test.ts
@@ -1,8 +1,8 @@
-import { EnergizeEvent, EventType } from 'parser/core/Events';
+import { ResourceChangeEvent, EventType } from 'parser/core/Events';
 
 import resourceWasted from './resourceWasted';
 
-const energizeEvent = (id: number, amount: number = 100): EnergizeEvent => ({
+const energizeEvent = (id: number, amount: number = 100): ResourceChangeEvent => ({
   type: EventType.ResourceChange,
   ability: {
     guid: id,

--- a/src/parser/shared/metrics/resourceWasted.ts
+++ b/src/parser/shared/metrics/resourceWasted.ts
@@ -14,7 +14,7 @@ interface ResourcesWasted {
  */
 const resourceWasted = (events: AnyEvent[]) =>
   events.reduce<ResourcesWasted>((obj, event) => {
-    if (event.type === EventType.Energize) {
+    if (event.type === EventType.ResourceChange) {
       obj[event.targetID] = obj[event.targetID] || {};
       obj[event.targetID][event.resourceChangeType] =
         obj[event.targetID][event.resourceChangeType] || {};

--- a/src/parser/shared/modules/DistanceMoved.tsx
+++ b/src/parser/shared/modules/DistanceMoved.tsx
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro';
 import { formatPercentage, formatThousands } from 'common/format';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent, DamageEvent, EnergizeEvent, HealEvent } from 'parser/core/Events';
+import Events, { CastEvent, DamageEvent, ResourceChangeEvent, HealEvent } from 'parser/core/Events';
 import FlushLineChart from 'parser/ui/FlushLineChart';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
@@ -28,7 +28,7 @@ class DistanceMoved extends Analyzer {
     this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.updatePlayerPosition);
     // These coordinates are for the target, so they are only accurate when done TO player
     this.addEventListener(Events.damage.to(SELECTED_PLAYER), this.updatePlayerPosition);
-    this.addEventListener(Events.energize.to(SELECTED_PLAYER), this.updatePlayerPosition);
+    this.addEventListener(Events.resourcechange.to(SELECTED_PLAYER), this.updatePlayerPosition);
     this.addEventListener(Events.heal.to(SELECTED_PLAYER), this.updatePlayerPosition);
     /* I couldn't find any instances of absorbed events containing location,
      * if it can actually happen we can update the AbsorbedEvent shape and
@@ -72,7 +72,7 @@ class DistanceMoved extends Analyzer {
     }
   }
 
-  updatePlayerPosition(event: CastEvent | HealEvent | DamageEvent | EnergizeEvent) {
+  updatePlayerPosition(event: CastEvent | HealEvent | DamageEvent | ResourceChangeEvent) {
     if (!event.x || !event.y) {
       return;
     }

--- a/src/parser/shared/modules/resources/resourcetracker/RegenResourceCapTracker.js
+++ b/src/parser/shared/modules/resources/resourcetracker/RegenResourceCapTracker.js
@@ -180,7 +180,7 @@ class RegenResourceCapTracker extends Analyzer {
       timestamp: this.owner.fight.start_time,
     };
     this.addEventListener(Events.fightend, this.onFightend);
-    this.addEventListener(Events.energize.to(SELECTED_PLAYER), this.onEnergize);
+    this.addEventListener(Events.resourcechange.to(SELECTED_PLAYER), this.onEnergize);
     this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onCast);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDamage);
     this.addEventListener(Events.drain.by(SELECTED_PLAYER), this.onDrain);

--- a/src/parser/shared/modules/resources/resourcetracker/ResourceTracker.ts
+++ b/src/parser/shared/modules/resources/resourcetracker/ResourceTracker.ts
@@ -3,7 +3,7 @@ import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
 import Events, {
   EventType,
   ClassResources,
-  EnergizeEvent,
+  ResourceChangeEvent,
   CastEvent,
   HealEvent,
   SpendResourceEvent,
@@ -58,7 +58,7 @@ class ResourceTracker extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.addEventListener(Events.energize.to(SELECTED_PLAYER), this.onEnergize);
+    this.addEventListener(Events.resourcechange.to(SELECTED_PLAYER), this.onEnergize);
     this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onCast);
   }
 
@@ -77,7 +77,7 @@ class ResourceTracker extends Analyzer {
   }
 
   // BUILDERS - Handled on energize, using the 'resourceChange' field
-  onEnergize(event: EnergizeEvent) {
+  onEnergize(event: ResourceChangeEvent) {
     const spellId = event.ability.guid;
 
     if (event.resourceChangeType !== this.resource.id) {
@@ -193,7 +193,7 @@ class ResourceTracker extends Analyzer {
     return this.getResource(event)?.cost;
   }
 
-  getResource(event: CastEvent | HealEvent | EnergizeEvent) {
+  getResource(event: CastEvent | HealEvent | ResourceChangeEvent) {
     if (!event.classResources) {
       return undefined;
     } else {

--- a/src/parser/shared/normalizers/EnergizeCompat.ts
+++ b/src/parser/shared/normalizers/EnergizeCompat.ts
@@ -1,0 +1,25 @@
+import { EventType, Event, AnyEvent } from 'parser/core/Events';
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+
+type EnergizeEvent = Event<'energize'>;
+
+type CompatEvent = AnyEvent | EnergizeEvent;
+
+/**
+ * Temporary compatibility class to convert old energize events to new
+ * resourcechange events.
+ *
+ * WCL will be renaming the event from `energize` to `resourcechange` in an
+ * upcoming update.
+ **/
+export default class EnergizeCompat extends EventsNormalizer {
+  priority = -1000;
+  normalize(events: AnyEvent[]) {
+    return events.map((event) => {
+      if ((event as CompatEvent).type === 'energize') {
+        event.type = EventType.ResourceChange;
+      }
+      return event;
+    });
+  }
+}


### PR DESCRIPTION
WarcraftLogs will be performing an event rename soon:tm:. This PR does two things:

1. Replace `EventType.Energize` with `EventType.ResourceChange` (same with `Events.energize` and `EnergizeEvent`). This is not a change in functionality. `EventType.Energize` still exists as a deprecated enum variant to help point people to the new name.
2. Add the `EnergizeCompat` normalizer to replace `type: "energize"` with `type: "resourcechange"`. This normalizer will be removed once the rename has occurred.

There should be no changes to the snapshots, confirming that this doesn't change anything about the WoWA output.

There are still a few references to `energize` in relatively prominent places (*cough* ResourceTracker *cough*) but I'm not going on a crusade to remove the term, just adding compat.