### PR TITLE
Verify patch 9.1.5 compatibility and bump support

### DIFF
--- a/analysis/deathknightfrost/src/CHANGELOG.tsx
+++ b/analysis/deathknightfrost/src/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 
 
 export default [
+  change(date(2021, 11, 5), 'Verified 9.1.5 patch changes and bumped support to 9.1.5', darkpsy3934),
   change(date(2021, 8, 19), <> Added <SpellLink id ={SPELLS.DEATHS_DUE.id}/> module </>, Pendragon),
   change(date(2021, 4, 3), 'Verified 9.0.5 patch changes and bumped support to 9.0.5', Adoraci),
   change(date(2021, 3, 7), 'Added Frost specific runeforge suggestions', Khazak),

--- a/analysis/deathknightfrost/src/CHANGELOG.tsx
+++ b/analysis/deathknightfrost/src/CHANGELOG.tsx
@@ -1,6 +1,6 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
-import { Adoraci, joshinator, Khazak, LeoZhekov, Putro, Pendragon } from 'CONTRIBUTORS';
+import { Adoraci, joshinator, Khazak, LeoZhekov, Putro, Pendragon, darkpsy3934 } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import React from 'react';
 

--- a/analysis/deathknightfrost/src/CONFIG.tsx
+++ b/analysis/deathknightfrost/src/CONFIG.tsx
@@ -10,7 +10,7 @@ export default {
   contributors: [Khazak],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.0.5',
+  patchCompatibility: '9.1.5',
   isPartial: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -1759,3 +1759,14 @@ export const Yax: Contributor = {
     },
   ],
 };
+export const darkpsy3934: Contributor = {
+  nickname: 'Terise',
+  github: 'darkpsy3934',
+  mains: [
+    {
+      name: 'Terise',
+      spec: SPECS.FROST_DEATH_KNIGHT,
+      link: 'https://www.warcraftlogs.com/character/us/blades-edge/terise',
+    },
+  ],
+};

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -1759,6 +1759,7 @@ export const Yax: Contributor = {
     },
   ],
 };
+
 export const darkpsy3934: Contributor = {
   nickname: 'Terise',
   github: 'darkpsy3934',


### PR DESCRIPTION
After looking at patch notes and confirming no changes have been done since 9.0.5, I have determined the analysis is correct for 9.1.5.  Bumped patch support to 9.1.5, added to CONTRIBUTORS, and added changelog entry.