### PR TITLE
Allow SpellHistory to have prepull events in it

### DIFF
--- a/analysis/hunterbeastmastery/src/integrationTests/beastMasteryIntegrationTests.test.ts.snap
+++ b/analysis/hunterbeastmastery/src/integrationTests/beastMasteryIntegrationTests.test.ts.snap
@@ -13221,7 +13221,7 @@ exports[`Beast Mastery Hunter integration test: Single Target CastEfficiency mat
                 }
               }
             >
-              0.00
+              0.19
             </td>
             <td
               className="text-right"
@@ -13231,7 +13231,7 @@ exports[`Beast Mastery Hunter integration test: Single Target CastEfficiency mat
                 }
               }
             >
-              0
+              1
               /1
                casts
             </td>
@@ -13250,7 +13250,7 @@ exports[`Beast Mastery Hunter integration test: Single Target CastEfficiency mat
                   style={
                     Object {
                       "backgroundColor": "#70b570",
-                      "width": "0%",
+                      "width": "100%",
                     }
                   }
                 />
@@ -13265,7 +13265,7 @@ exports[`Beast Mastery Hunter integration test: Single Target CastEfficiency mat
                 }
               }
             >
-              0.00%
+              100.00%
             </td>
             <td
               style={

--- a/analysis/huntermarksmanship/src/integrationTests/marksmanshipIntegrationTests.test.ts.snap
+++ b/analysis/huntermarksmanship/src/integrationTests/marksmanshipIntegrationTests.test.ts.snap
@@ -794,7 +794,7 @@ exports[`Marksmanship Hunter integration test: Multi Target CastEfficiency match
                 }
               }
             >
-              0.73
+              0.97
             </td>
             <td
               className="text-right"
@@ -804,7 +804,7 @@ exports[`Marksmanship Hunter integration test: Multi Target CastEfficiency match
                 }
               }
             >
-              3
+              4
               /5
                casts
             </td>
@@ -9306,7 +9306,7 @@ exports[`Marksmanship Hunter integration test: Single Target CastEfficiency matc
                 }
               }
             >
-              0.81
+              1.01
             </td>
             <td
               className="text-right"
@@ -9316,7 +9316,7 @@ exports[`Marksmanship Hunter integration test: Single Target CastEfficiency matc
                 }
               }
             >
-              4
+              5
               /5
                casts
             </td>
@@ -14771,7 +14771,7 @@ exports[`Marksmanship Hunter integration test: Single Target matches the checkli
                   }
                 >
                    
-                  90.15%
+                  100.00%
                    
                    
                 </div>

--- a/analysis/huntersurvival/src/integrationTests/survivalIntegrationTests.test.ts.snap
+++ b/analysis/huntersurvival/src/integrationTests/survivalIntegrationTests.test.ts.snap
@@ -10286,7 +10286,7 @@ exports[`Survival Hunter integration test: Single Target CastEfficiency matches 
                 }
               }
             >
-              0.00
+              0.20
             </td>
             <td
               className="text-right"
@@ -10296,7 +10296,7 @@ exports[`Survival Hunter integration test: Single Target CastEfficiency matches 
                 }
               }
             >
-              0
+              1
               /1
                casts
             </td>
@@ -10315,7 +10315,7 @@ exports[`Survival Hunter integration test: Single Target CastEfficiency matches 
                   style={
                     Object {
                       "backgroundColor": "#70b570",
-                      "width": "0%",
+                      "width": "100%",
                     }
                   }
                 />
@@ -10330,7 +10330,7 @@ exports[`Survival Hunter integration test: Single Target CastEfficiency matches 
                 }
               }
             >
-              0.00%
+              100.00%
             </td>
             <td
               style={

--- a/analysis/magearcane/src/integrationTests/example.test.ts.snap
+++ b/analysis/magearcane/src/integrationTests/example.test.ts.snap
@@ -2342,7 +2342,7 @@ exports[`Arcane Mage integration test: example log CastEfficiency matches the st
                 }
               }
             >
-              0.70
+              0.87
             </td>
             <td
               className="text-right"
@@ -2352,7 +2352,7 @@ exports[`Arcane Mage integration test: example log CastEfficiency matches the st
                 }
               }
             >
-              4
+              5
               /14
                casts
             </td>
@@ -4023,7 +4023,7 @@ exports[`Arcane Mage integration test: example log CastEfficiency matches the st
                 }
               }
             >
-              0.00
+              0.17
             </td>
             <td
               className="text-right"
@@ -4033,7 +4033,7 @@ exports[`Arcane Mage integration test: example log CastEfficiency matches the st
                 }
               }
             >
-              0
+              1
               /1
                casts
             </td>
@@ -4052,7 +4052,7 @@ exports[`Arcane Mage integration test: example log CastEfficiency matches the st
                   style={
                     Object {
                       "backgroundColor": "#70b570",
-                      "width": "0%",
+                      "width": "100%",
                     }
                   }
                 />
@@ -4067,7 +4067,7 @@ exports[`Arcane Mage integration test: example log CastEfficiency matches the st
                 }
               }
             >
-              0.00%
+              100.00%
             </td>
             <td
               style={

--- a/analysis/magefire/src/integrationTests/example.test.ts.snap
+++ b/analysis/magefire/src/integrationTests/example.test.ts.snap
@@ -1464,7 +1464,7 @@ exports[`Fire Mage integration test: example log CastEfficiency matches the stat
                 }
               }
             >
-              0.63
+              0.78
             </td>
             <td
               className="text-right"
@@ -1474,7 +1474,7 @@ exports[`Fire Mage integration test: example log CastEfficiency matches the stat
                 }
               }
             >
-              4
+              5
               /6
                casts
             </td>
@@ -3419,7 +3419,7 @@ exports[`Fire Mage integration test: example log CastEfficiency matches the stat
                 }
               }
             >
-              0.16
+              0.31
             </td>
             <td
               className="text-right"
@@ -3429,7 +3429,7 @@ exports[`Fire Mage integration test: example log CastEfficiency matches the stat
                 }
               }
             >
-              1
+              2
               /1
                casts
             </td>

--- a/analysis/magefrost/src/integrationTests/example.test.ts.snap
+++ b/analysis/magefrost/src/integrationTests/example.test.ts.snap
@@ -1983,7 +1983,7 @@ exports[`Frost Mage integration test: example log CastEfficiency matches the sta
                 }
               }
             >
-              1.38
+              1.55
             </td>
             <td
               className="text-right"
@@ -1993,7 +1993,7 @@ exports[`Frost Mage integration test: example log CastEfficiency matches the sta
                 }
               }
             >
-              8
+              9
               /14
                casts
             </td>
@@ -2177,7 +2177,7 @@ exports[`Frost Mage integration test: example log CastEfficiency matches the sta
                 }
               }
             >
-              0.17
+              0.34
             </td>
             <td
               className="text-right"
@@ -2187,7 +2187,7 @@ exports[`Frost Mage integration test: example log CastEfficiency matches the sta
                 }
               }
             >
-              1
+              2
               /3
                casts
             </td>

--- a/analysis/shamanelemental/src/integrationTests/example.test.ts.snap
+++ b/analysis/shamanelemental/src/integrationTests/example.test.ts.snap
@@ -1433,7 +1433,7 @@ exports[`Elemental Shaman integration test: Hungering Destroyer log CastEfficien
                 }
               }
             >
-              0.73
+              1.10
             </td>
             <td
               className="text-right"
@@ -1443,7 +1443,7 @@ exports[`Elemental Shaman integration test: Hungering Destroyer log CastEfficien
                 }
               }
             >
-              2
+              3
               /3
                casts
             </td>
@@ -4901,7 +4901,7 @@ exports[`Elemental Shaman integration test: Hungering Destroyer log matches the 
                   }
                 >
                    
-                  99.04%
+                  100.00%
                    
                    
                 </div>
@@ -8094,7 +8094,7 @@ exports[`Elemental Shaman integration test: Huntsman Altimor log CastEfficiency 
                 }
               }
             >
-              0.87
+              1.17
             </td>
             <td
               className="text-right"
@@ -8104,7 +8104,7 @@ exports[`Elemental Shaman integration test: Huntsman Altimor log CastEfficiency 
                 }
               }
             >
-              3
+              4
               /4
                casts
             </td>
@@ -9345,7 +9345,7 @@ exports[`Elemental Shaman integration test: Huntsman Altimor log CastEfficiency 
                 }
               }
             >
-              0.00
+              0.29
             </td>
             <td
               className="text-right"
@@ -9355,7 +9355,7 @@ exports[`Elemental Shaman integration test: Huntsman Altimor log CastEfficiency 
                 }
               }
             >
-              0
+              1
               /1
                casts
             </td>
@@ -9374,7 +9374,7 @@ exports[`Elemental Shaman integration test: Huntsman Altimor log CastEfficiency 
                   style={
                     Object {
                       "backgroundColor": "#70b570",
-                      "width": "0%",
+                      "width": "100%",
                     }
                   }
                 />
@@ -9389,7 +9389,7 @@ exports[`Elemental Shaman integration test: Huntsman Altimor log CastEfficiency 
                 }
               }
             >
-              0.00%
+              100.00%
             </td>
             <td
               style={
@@ -11182,7 +11182,7 @@ exports[`Elemental Shaman integration test: Huntsman Altimor log matches the che
                   }
                 >
                    
-                  95.50%
+                  100.00%
                    
                    
                 </div>

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -52,6 +52,7 @@ import React from 'react';
 
 // prettier-ignore
 export default [
+  change(date(2021, 11, 5), 'Correctly adjust spell history to include prepull casts as they should count as casts related to the encounter.', Putro),
   change(date(2021, 10, 31), 'Prepare for "energize" event rename.', emallson),
   change(date(2021, 10, 27), 'Clean up character page for TBC characters.', emallson),
   change(date(2021, 10, 21), 'Remove paywall on timeline.', emallson),

--- a/src/parser/shared/modules/SpellHistory.ts
+++ b/src/parser/shared/modules/SpellHistory.ts
@@ -72,8 +72,7 @@ class SpellHistory extends Analyzer {
   private append(event: SpellHistoryEvent) {
     const spellId = event.ability.guid;
     const history = this.getAbility(spellId);
-    if (history && event.timestamp > this.owner.fight.start_time) {
-      //don't save prephase events in history
+    if (history) {
       history.push(event);
     }
   }


### PR DESCRIPTION
On a report like [this](https://wowanalyzer.com/report/Mwf9KAbVP8JNhdHG/26-Mythic+Guardian+of+the+First+Ones+-+Kill+(4:25)/Schmub%C3%A4rchi/standard/statistics). 
![image](https://user-images.githubusercontent.com/29204244/140576176-f0d467de-d14d-4f83-a362-b99eb10c44d7.png)

We end up in a scenario where Double Tap is correctly registered as precast. 
This means that the begincooldown event has been triggered correctly. That's why the cast efficiency bar graph correctly can show 98% since it uses timeOnCooldown/timeInCombat (+some GCD tom foolery). 
However as you can see the casts still show as 4 out of 5 possible. The maxCasts looks at fightDuration/spellCooldown which means a 4m25s fight lets you have 5 1 minute cooldown casts off. The casts however looks at spellhistory in order to get the casts amount which currently do NOT allow for prepull events. 
This mean we end up looking at 4 casts done out of possible 5, even though the player DID get the possible 5 casts. 
The metrics are comparing completely different things, timeOnCooldown accounts for us triggering the cooldown during prepull which fixes cast efficiency graph, but then we don't care about what happens in prepull for the casts comparison which doesn't make much sense. 

This fix allows prepull spell events to go into the spellhistory, as it seems like there is no reason they shouldn't be in there. 

As you can see from the test snapshots this also fixes issues with pot usage precombat, and by extension also any other precombat spell issue where that cast event wasn't counted as a cast. 

An alternate fix is to subtract 1 from maxCasts if precast, but to me that would display the wrong information. In this case it is correct that there were 5 possible casts, and not 4 as we'd show in that case. 

The above report ends up looking like this with this fix: 
![image](https://user-images.githubusercontent.com/29204244/140576785-a00e2ad6-69f5-466a-ae07-58a4e81e1255.png)



On Live we correctly show the spells in the timeline: 
![image](https://user-images.githubusercontent.com/29204244/140576950-91848712-75f8-4657-a1d0-d880793033b8.png)
We also include it in our (fabricated casts enabled) view:
![image](https://user-images.githubusercontent.com/29204244/140577027-a639cd78-1458-4cb3-877d-a08b4a898d90.png)

Nothing is changed in that regard with this fix:
![image](https://user-images.githubusercontent.com/29204244/140577081-c8bd4939-fd0d-45ff-818b-107e26cd4893.png)
![image](https://user-images.githubusercontent.com/29204244/140577116-84747c29-a3af-48bf-9c80-5fb09d755f36.png)

Edit: I know it looks like there's a double cooldown event for that Double Tap, will dig into that but it's unrelated to this issue as I could showcase the same issue with any other prepull spell. 