### PR TITLE
Quick Signet Of TormentedKings error fix

### DIFF
--- a/analysis/warriorarms/src/CHANGELOG.tsx
+++ b/analysis/warriorarms/src/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 import React from 'react';
 
 export default [
+  change(date(2021, 11, 8), <>Fixed SpellLink issue for Signet Of Tormented Kings.</>, Abelito75),
   change(date(2021, 10, 29), <>Initial Arms APL added. (Still WIP)</>, bandit),
   change(date(2021, 10, 10), <>Fixed <SpellLink id={SPELLS.OVERPOWER.id} icon /> cooldown resets with Tactician</>, bandit),
   change(date(2021, 10, 7), <>adjusted gcds and added seasoned veteran passive</>, bandit),

--- a/analysis/warriorarms/src/modules/shadowlands/legendaries/SignetOfTormentedKings.tsx
+++ b/analysis/warriorarms/src/modules/shadowlands/legendaries/SignetOfTormentedKings.tsx
@@ -149,12 +149,12 @@ class SignetOfTormentedKings extends Analyzer {
         <>
           Try not to use{' '}
           {this.selectedCombatant.hasTalent(SPELLS.RAVAGER_TALENT_ARMS) ? (
-            <SpellLink id={SPELLS.RAVAGER_TALENT_ARMS} />
+            <SpellLink id={SPELLS.RAVAGER_TALENT_ARMS.id} />
           ) : (
-            <SpellLink id={SPELLS.BLADESTORM} />
+            <SpellLink id={SPELLS.BLADESTORM.id} />
           )}{' '}
-          right before using <SpellLink id={SPELLS.AVATAR_TALENT} />, potentially wasting{' '}
-          <SpellLink id={SPELLS.SIGNET_OF_TORMENTED_KINGS} /> Procs
+          right before using <SpellLink id={SPELLS.AVATAR_TALENT.id} />, potentially wasting{' '}
+          <SpellLink id={SPELLS.SIGNET_OF_TORMENTED_KINGS.id} /> Procs
         </>,
       )
         .icon(SPELLS.SIGNET_OF_TORMENTED_KINGS.icon)


### PR DESCRIPTION
Spell links were using Objects instead of IDs
Good catch @emallson 