### PR TITLE
[Core] Bumping to wow version check to 9.1.5

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -52,6 +52,7 @@ import React from 'react';
 
 // prettier-ignore
 export default [
+  change(date(2021, 11, 8), 'Bumping current version of wow from 9.1 -> 9.1.5', Abelito75),
   change(date(2021, 11, 8), 'Manual internationalization update to satisfy CI.', emallson),
   change(date(2021, 11, 6), 'Add additional functionality to APL checker to check for present/missing debuffs, fractional charges and remaining time of spell cooldowns', Putro),
   change(date(2021, 11, 5), 'Correctly adjust spell history to include prepull casts as they should count as casts related to the encounter.', Putro),

--- a/src/game/VERSIONS.ts
+++ b/src/game/VERSIONS.ts
@@ -2,8 +2,8 @@ import Expansion from './Expansion';
 
 // The current version of the game. Used to check spec patch compatibility and as a caching key.
 const VERSIONS: Partial<{ [expansion in Expansion]: string }> = {
-  [Expansion.TheBurningCrusade]: '2.5.1',
-  [Expansion.Shadowlands]: '9.1',
+  [Expansion.TheBurningCrusade]: '2.5.2',
+  [Expansion.Shadowlands]: '9.1.5',
 };
 
 export default VERSIONS;


### PR DESCRIPTION
Version check should now know that wow's current patch is 9.1.5 instead of 9.1
Also updating TBC to 2.5.2