### PR TITLE
[Hunter] Update Rylakstalkers Piercing Fangs

### DIFF
--- a/analysis/hunterbeastmastery/src/CHANGELOG.tsx
+++ b/analysis/hunterbeastmastery/src/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { ItemLink, SpellLink } from 'interface';
 import React from 'react';
 
 export default [
+  change(date(2021, 11, 11), <> Correct an issue where damage done by <SpellLink id={SPELLS.BEAST_CLEAVE_DAMAGE.id}/> wasn't correctly attributed to <SpellLink id={SPELLS.RYLAKSTALKERS_PIERCING_FANGS_EFFECT.id}/>.  </>, Putro),
   change(date(2021, 11, 6), <> Update APL checker with the new fractional spell charges and cooldown remaining logic as well as moving <SpellLink id={SPELLS.WILD_SPIRITS.id} /> into the major cooldown category instead of an APL item. </>, Putro),
   change(date(2021, 11, 6), 'Implement an initial version of the APL checker', Putro),
   change(date(2021, 11, 5), <> Added support for <SpellLink id={SPELLS.WAILING_ARROW_CAST.id}/> as provided by <ItemLink id={ITEMS.RAESHALARE_DEATHS_WHISPER.id} />. </>, Putro),

--- a/analysis/hunterbeastmastery/src/modules/items/RylakstalkersPiercingFangs.tsx
+++ b/analysis/hunterbeastmastery/src/modules/items/RylakstalkersPiercingFangs.tsx
@@ -10,16 +10,18 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
 
+import { MS_BUFFER } from '@wowanalyzer/hunter';
 import { RYLAKSTALKERS_PIERCING_FANGS_CRIT_DMG_INCREASE } from '@wowanalyzer/hunter-beastmastery/src/constants';
 
 /**
- * While Bestial Wrath is active, your pet's critical damage dealt is increased by 20%.
+ * While Bestial Wrath is active, your pet's critical damage dealt is increased by 35%.
  *
  * Example log:
- *
+ * https://www.warcraftlogs.com/reports/TqAf9F8tKkL4NWCj#fight=50&type=damage-done
  */
 class RylakstalkersPiercingFangs extends Analyzer {
-  damage: number = 0;
+  damage = 0;
+  lastCritTimestamp = 0;
 
   constructor(options: Options) {
     super(options);
@@ -36,9 +38,20 @@ class RylakstalkersPiercingFangs extends Analyzer {
     if (!this.selectedCombatant.hasBuff(SPELLS.BESTIAL_WRATH.id)) {
       return;
     }
+    if (
+      event.ability.guid === SPELLS.BEAST_CLEAVE_DAMAGE.id &&
+      event.timestamp < this.lastCritTimestamp + MS_BUFFER
+    ) {
+      this.damage += calculateEffectiveDamage(
+        event,
+        RYLAKSTALKERS_PIERCING_FANGS_CRIT_DMG_INCREASE,
+      );
+    }
     if (event.hitType !== HIT_TYPES.CRIT) {
       return;
     }
+
+    this.lastCritTimestamp = event.timestamp;
     this.damage += calculateEffectiveDamage(event, RYLAKSTALKERS_PIERCING_FANGS_CRIT_DMG_INCREASE);
   }
 


### PR DESCRIPTION
A simple bugfix to correctly attribute damage to this legendary. since beast cleave can't crit but the increased damage makes beast cleave do more damage hence the increased damage from the crit should be attributed to this legendary. 