### PR TITLE
Updated regrowth stat tooltip and made triage slightly more permissive

### DIFF
--- a/analysis/druidrestoration/src/CHANGELOG.tsx
+++ b/analysis/druidrestoration/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SpellLink from 'interface/SpellLink';
 import React from 'react';
 
 export default [
+  change(date(2021, 11, 13), <>Updated wording of <SpellLink id={SPELLS.REGROWTH.id}/> statistic and made it more permissive of triage casts.</>, Sref),
   change(date(2021, 11, 12), <>Updated to indicate this spec is supported for patch 9.1.5</>, Sref),
   change(date(2021, 11, 11), <>Removed healer stat weights in favor of QElive.</>, Abelito75),
   change(date(2021, 8, 3), <>Updated to indicate this spec is supported for patch 9.1</>, Sref),

--- a/analysis/druidrestoration/src/modules/features/RegrowthAndClearcasting.tsx
+++ b/analysis/druidrestoration/src/modules/features/RegrowthAndClearcasting.tsx
@@ -16,7 +16,7 @@ import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import React from 'react';
 
 /** Health percent below which we consider a heal to be 'triage' */
-const TRIAGE_THRESHOLD = 0.4;
+const TRIAGE_THRESHOLD = 0.5;
 /** Max time from cast to heal event to consider the events linked */
 const MS_BUFFER = 100;
 /** Min stacks required to consider a regrowth efficient */
@@ -260,10 +260,10 @@ class RegrowthAndClearcasting extends Analyzer {
         position={STATISTIC_ORDER.CORE(20)}
         tooltip={
           <>
-            <SpellLink id={SPELLS.REGROWTH.id} /> is very mana inefficient and should only be cast
-            when free due to <SpellLink id={SPELLS.INNERVATE.id} />,{' '}
-            <SpellLink id={SPELLS.NATURES_SWIFTNESS.id} /> or{' '}
-            <SpellLink id={SPELLS.CLEARCASTING_BUFF.id} />,{' '}
+            <SpellLink id={SPELLS.REGROWTH.id} /> is mana inefficient relative to{' '}
+            <SpellLink id={SPELLS.REJUVENATION.id} /> and should only be cast when free due to{' '}
+            <SpellLink id={SPELLS.INNERVATE.id} />, <SpellLink id={SPELLS.NATURES_SWIFTNESS.id} />{' '}
+            or <SpellLink id={SPELLS.CLEARCASTING_BUFF.id} />,{' '}
             {this.hasAbundance && (
               <>
                 cheap due to {ABUNDANCE_EXCEPTION_STACKS}+{' '}


### PR DESCRIPTION
This is in response to complaints from Dreamgrove that the Regrowth stat was too strict, and that Regrowth is a better cast now than it was back in Legion

New tooltip:
![regrowth-tooltip-update](https://user-images.githubusercontent.com/7143486/141648424-42c24def-396e-44bb-8248-64a8d541dccb.png)


