### PR TITLE
[Frost Mage] Raise support to 9.1.5

### DIFF
--- a/analysis/magefrost/src/CHANGELOG.tsx
+++ b/analysis/magefrost/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 import React from 'react';
 
 export default [
+  change(date(2021, 11, 13), 'Bumped Frost Mage to supported for 9.1.5.', Sharrq),
   change(date(2021, 10, 29), 'Added myself as a contributor/maintainer for Frost Mage. Spec updates for Frost will be coming soon', Sharrq),
   change(date(2021, 10, 1), 'Fixed frost mage talent image icon on character page.', Karahtar),
   change(date(2021, 6, 29), <>Bumped to 9.1 to remove error.</>, Zea),

--- a/analysis/magefrost/src/CONFIG.tsx
+++ b/analysis/magefrost/src/CONFIG.tsx
@@ -11,7 +11,7 @@ const config: Config = {
   contributors: [Sharrq, Dambroda],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.1.0',
+  patchCompatibility: '9.1.5',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more. If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (


### PR DESCRIPTION
Nothing has really changed for Frost since 9.0.5, so bumping support up to 9.1.5