### PR TITLE
[Resto Shaman] Ancestal Vigor shouldn't care about non-players

### DIFF
--- a/analysis/shamanrestoration/src/CHANGELOG.tsx
+++ b/analysis/shamanrestoration/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 import React from 'react';
 
 export default [
+  change(date(2021, 11, 13), <>Fixed a bug with Ancestral Vigor where it was including non-players and damage events from friendly targets.</>, Abelito75),
   change(date(2021, 4, 3), <>Bumped support to 9.0.5, updated <SpellLink id={SPELLS.JONATS_NATURAL_FOCUS.id} /> chain heal increase value.</>, Adoraci),
   change(date(2020, 12, 15), <>Fixed mana costs of a few spells being vastly off.</>, niseko),
   change(date(2020, 12, 15), <>Added support for <SpellLink id={SPELLS.PRIMORDIAL_WAVE_CAST.id} /> and <SpellLink id={SPELLS.CHAIN_HARVEST.id} />.</>, niseko),

--- a/analysis/shamanrestoration/src/modules/talents/AncestralVigor.tsx
+++ b/analysis/shamanrestoration/src/modules/talents/AncestralVigor.tsx
@@ -63,7 +63,9 @@ class AncestralVigor extends Analyzer {
       filter: `(
         IN RANGE
         WHEN type='${EventType.Damage}'
+          AND source.disposition='enemy'
           AND target.disposition='friendly'
+          AND target.type='player'
           AND resources.hitPoints>0
           AND 100*resources.hpPercent<=${Math.ceil(10000 * HP_THRESHOLD)}
           AND 10000*(resources.hitPoints+effectiveDamage)/resources.maxHitPoints>=${Math.floor(


### PR DESCRIPTION
It was caring about healing NPCs before. This is dumb. I also hate WCL queries.