### PR TITLE
[Healers] Ignoring Healthstones and Healing Pots in the MANA EFFICIENCY tracker

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -52,6 +52,7 @@ import React from 'react';
 
 // prettier-ignore
 export default [
+  change(date(2021, 11, 13), 'Removed Healthstone and Healing Pot from Mana Efficiency Tracker.', Abelito75),
   change(date(2021, 11, 11), 'Added an Icon to more easily display which cooldown is which in the cooldown tab.', Abelito75),
   change(date(2021, 11, 8), 'Bumping current version of wow from 9.1 -> 9.1.5', Abelito75),
   change(date(2021, 11, 8), 'Manual internationalization update to satisfy CI.', emallson),

--- a/src/parser/core/healingEfficiency/HealingEfficiencyTracker.ts
+++ b/src/parser/core/healingEfficiency/HealingEfficiencyTracker.ts
@@ -10,6 +10,8 @@ import HealingDone from 'parser/shared/modules/throughput/HealingDone';
 import { SpellbookAbility } from '../modules/Ability';
 import ManaTracker from './ManaTracker';
 
+const SPELLS_TO_IGNORE: number[] = [SPELLS.HEALTHSTONE.id, SPELLS.SPIRITUAL_HEALING_POTION.id];
+
 export interface SpellInfoDetails {
   spell: Spell;
   casts: number;
@@ -154,6 +156,10 @@ class HealingEfficiencyTracker extends Analyzer {
 
       if (ability.spell instanceof Array) {
         for (const lowerRankSpell of ability.spell) {
+          if (SPELLS_TO_IGNORE.includes(lowerRankSpell)) {
+            continue;
+          }
+
           spells[lowerRankSpell] = this.getSpellStats(lowerRankSpell, ability.healSpellIds);
           if (spells[lowerRankSpell].hpm !== Infinity) {
             topHpm = Math.max(topHpm, spells[lowerRankSpell].hpm);
@@ -165,6 +171,10 @@ class HealingEfficiencyTracker extends Analyzer {
           topDpet = Math.max(topDpet, spells[lowerRankSpell].dpet);
         }
       } else {
+        if (SPELLS_TO_IGNORE.includes(ability.spell)) {
+          continue;
+        }
+
         spells[ability.spell] = this.getSpellStats(ability.spell, ability.healSpellIds);
         if (spells[ability.spell].hpm !== Infinity) {
           topHpm = Math.max(topHpm, spells[ability.spell].hpm);

--- a/src/parser/core/healingEfficiency/HealingEfficiencyTracker.ts
+++ b/src/parser/core/healingEfficiency/HealingEfficiencyTracker.ts
@@ -10,8 +10,6 @@ import HealingDone from 'parser/shared/modules/throughput/HealingDone';
 import { SpellbookAbility } from '../modules/Ability';
 import ManaTracker from './ManaTracker';
 
-const SPELLS_TO_IGNORE: number[] = [SPELLS.HEALTHSTONE.id, SPELLS.SPIRITUAL_HEALING_POTION.id];
-
 export interface SpellInfoDetails {
   spell: Spell;
   casts: number;
@@ -156,34 +154,30 @@ class HealingEfficiencyTracker extends Analyzer {
 
       if (ability.spell instanceof Array) {
         for (const lowerRankSpell of ability.spell) {
-          if (SPELLS_TO_IGNORE.includes(lowerRankSpell)) {
+          const spellData = this.getSpellStats(lowerRankSpell, ability.healSpellIds);
+          if (spellData.manaSpent === 0) {
             continue;
           }
-
-          spells[lowerRankSpell] = this.getSpellStats(lowerRankSpell, ability.healSpellIds);
-          if (spells[lowerRankSpell].hpm !== Infinity) {
-            topHpm = Math.max(topHpm, spells[lowerRankSpell].hpm);
+          topHpm = Math.max(topHpm, spellData.hpm);
+          topDpm = Math.max(topDpm, spellData.dpm);
+          if (spellData.timeSpentCasting !== 0) {
+            topHpet = Math.max(topHpet, spellData.hpet);
+            topDpet = Math.max(topDpet, spellData.dpet);
           }
-          if (spells[lowerRankSpell].dpm !== Infinity) {
-            topDpm = Math.max(topDpm, spells[lowerRankSpell].dpm);
-          }
-          topHpet = Math.max(topHpet, spells[lowerRankSpell].hpet);
-          topDpet = Math.max(topDpet, spells[lowerRankSpell].dpet);
+          spells[lowerRankSpell] = spellData;
         }
       } else {
-        if (SPELLS_TO_IGNORE.includes(ability.spell)) {
+        const spellData = this.getSpellStats(ability.spell, ability.healSpellIds);
+        if (spellData.manaSpent === 0) {
           continue;
         }
-
-        spells[ability.spell] = this.getSpellStats(ability.spell, ability.healSpellIds);
-        if (spells[ability.spell].hpm !== Infinity) {
-          topHpm = Math.max(topHpm, spells[ability.spell].hpm);
+        topHpm = Math.max(topHpm, spellData.hpm);
+        topDpm = Math.max(topDpm, spellData.dpm);
+        if (spellData.timeSpentCasting !== 0) {
+          topHpet = Math.max(topHpet, spellData.hpet);
+          topDpet = Math.max(topDpet, spellData.dpet);
         }
-        if (spells[ability.spell].dpm !== Infinity) {
-          topDpm = Math.max(topDpm, spells[ability.spell].dpm);
-        }
-        topHpet = Math.max(topHpet, spells[ability.spell].hpet);
-        topDpet = Math.max(topDpet, spells[ability.spell].dpet);
+        spells[ability.spell] = spellData;
       }
     }
 


### PR DESCRIPTION
Since these cost 0 mana it would basically invalidate the whole UI
Before: 
![image](https://user-images.githubusercontent.com/25177817/141663356-e5621b6f-ef58-4f39-a12f-cb689c58dfc4.png)


After: 
![image](https://user-images.githubusercontent.com/25177817/141663357-cb028491-9ad3-458d-ae40-291cdbc92840.png)
