### PR TITLE
[MW] Normalize Crane Clone Cast Events

### DIFF
--- a/analysis/monkmistweaver/src/CHANGELOG.tsx
+++ b/analysis/monkmistweaver/src/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 
 
 export default [
+  change(date(2021, 11, 15), <>Added Cast events directly into the log and normalized other stats that needed it. My sanity is now back intact :)</>, Abelito75),
   change(date(2021, 11, 14), <>Added A Cool And Interesting Infographic For Average Health of a Target When Fallen Order Crane Clones Cast A Healing Spell On Them.</>, Abelito75),
   change(date(2021, 11, 13), <>Added A Cool And Interesting Infographic For RSK Reset.</>, Abelito75),
   change(date(2021, 11, 12), <>Fixed Fallen Order Mist Wrap stat from crashing.</>, Abelito75),

--- a/analysis/monkmistweaver/src/CombatLogParser.ts
+++ b/analysis/monkmistweaver/src/CombatLogParser.ts
@@ -64,6 +64,7 @@ import RisingMist from './modules/talents/RisingMist';
 import SpiritOfTheCrane from './modules/talents/SpiritOfTheCrane';
 import Tier30Comparison from './modules/talents/Tier30Comparison';
 import Upwelling from './modules/talents/Upwelling';
+import FallenOrderCraneCloneNormalizer from './normalizers/FallenOrderCraneCloneNormalizer';
 import HotApplicationNormalizer from './normalizers/HotApplicationNormalizer';
 import HotRemovalNormalizer from './normalizers/HotRemovalNormalizer';
 
@@ -74,6 +75,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Normalizer
     hotApplicationNormalizer: HotApplicationNormalizer,
     hotRemovalNormalizer: HotRemovalNormalizer,
+    fallenOrderCraneCloneNormalizer: FallenOrderCraneCloneNormalizer,
 
     // Core
     lowHealthHealing: LowHealthHealing,

--- a/analysis/monkmistweaver/src/modules/shadowlands/covenant/FallenOrderCraneAverage.tsx
+++ b/analysis/monkmistweaver/src/modules/shadowlands/covenant/FallenOrderCraneAverage.tsx
@@ -2,7 +2,7 @@ import SPELLS from 'common/SPELLS';
 import COVENANTS from 'game/shadowlands/COVENANTS';
 import { SpellIcon, SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
-import Events, { ApplyBuffEvent, RefreshBuffEvent, SummonEvent } from 'parser/core/Events';
+import Events, { CastEvent, SummonEvent } from 'parser/core/Events';
 import BoringValueText from 'parser/ui/BoringValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -11,7 +11,7 @@ import React from 'react';
 
 class FallenOrderCraneAverage extends Analyzer {
   soomCasts: number = 0;
-  envCasts: number = 0;
+  enmCasts: number = 0;
   mwClones: number = 0;
 
   constructor(options: Options) {
@@ -31,36 +31,26 @@ class FallenOrderCraneAverage extends Analyzer {
 
     //mistweaver spells
     this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER_PET).spell(SPELLS.FALLEN_ORDER_ENVELOPING_MIST),
-      this.envBuffApplied,
+      Events.cast.by(SELECTED_PLAYER_PET).spell(SPELLS.FALLEN_ORDER_ENVELOPING_MIST),
+      this.enmCast,
     );
 
     this.addEventListener(
-      Events.refreshbuff.by(SELECTED_PLAYER_PET).spell(SPELLS.FALLEN_ORDER_ENVELOPING_MIST),
-      this.envBuffApplied,
+      Events.cast.by(SELECTED_PLAYER_PET).spell(SPELLS.FALLEN_ORDER_SOOTHING_MIST),
+      this.soomCast,
     );
+  }
 
-    this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER_PET).spell(SPELLS.FALLEN_ORDER_SOOTHING_MIST),
-      this.soomBuffApplied,
-    );
+  enmCast(event: CastEvent) {
+    this.enmCasts += 1;
+  }
 
-    this.addEventListener(
-      Events.refreshbuff.by(SELECTED_PLAYER_PET).spell(SPELLS.FALLEN_ORDER_SOOTHING_MIST),
-      this.soomBuffApplied,
-    );
+  soomCast(event: CastEvent) {
+    this.soomCasts += 1;
   }
 
   trackSummons(event: SummonEvent) {
     this.mwClones += 1;
-  }
-
-  envBuffApplied(event: ApplyBuffEvent | RefreshBuffEvent) {
-    this.envCasts += 1;
-  }
-
-  soomBuffApplied(event: ApplyBuffEvent | RefreshBuffEvent) {
-    this.soomCasts += 1;
   }
 
   statistic() {
@@ -74,7 +64,7 @@ class FallenOrderCraneAverage extends Analyzer {
             This is the average number of casts a Crane Clone does.
             <br />
             Number of MW clones: {this.mwClones} <br />
-            Total Enveloping Mist Casts from Clones: {this.envCasts} <br />
+            Total Enveloping Mist Casts from Clones: {this.enmCasts} <br />
             Total Soothing Mist Casts from Clones: {this.soomCasts}
           </>
         }
@@ -87,7 +77,7 @@ class FallenOrderCraneAverage extends Analyzer {
           }
         >
           <SpellLink id={SPELLS.FALLEN_ORDER_ENVELOPING_MIST.id} />{' '}
-          {(this.envCasts / this.mwClones).toFixed(2)}
+          {(this.enmCasts / this.mwClones).toFixed(2)}
           <br />
           <SpellLink id={SPELLS.FALLEN_ORDER_SOOTHING_MIST.id} />{' '}
           {(this.soomCasts / this.mwClones).toFixed(2)}

--- a/analysis/monkmistweaver/src/normalizers/FallenOrderCraneCloneNormalizer.tsx
+++ b/analysis/monkmistweaver/src/normalizers/FallenOrderCraneCloneNormalizer.tsx
@@ -1,0 +1,110 @@
+import SPELLS from 'common/SPELLS';
+import {
+  AnyEvent,
+  ApplyBuffEvent,
+  EventType,
+  HealEvent,
+  RefreshBuffEvent,
+  RemoveBuffEvent,
+} from 'parser/core/Events';
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+
+class FallenOrderCraneCloneNormalizer extends EventsNormalizer {
+  foHealsToListenFor: Map<string, AnyEvent> = new Map<string, AnyEvent>();
+
+  normalize(events: AnyEvent[]) {
+    const fixedEvents: any[] = [];
+
+    events.forEach((event) => {
+      // Apply buff means we need to start listening for healing events
+      if (event.type === EventType.ApplyBuff || event.type === EventType.RefreshBuff) {
+        const abilityGuid = event.ability.guid;
+        if (
+          abilityGuid === SPELLS.FALLEN_ORDER_ENVELOPING_MIST.id ||
+          abilityGuid === SPELLS.FALLEN_ORDER_SOOTHING_MIST.id
+        ) {
+          const paring = this.makingParingStat(event);
+          // save the timestamp so we can use it later to determine cast time
+          this.foHealsToListenFor.set(paring, event);
+          return;
+        }
+      } // Heal events are ones we can use gather targets HP
+      else if (event.type === EventType.Heal) {
+        const abilityGuid = event.ability.guid;
+        if (
+          abilityGuid === SPELLS.FALLEN_ORDER_ENVELOPING_MIST.id ||
+          abilityGuid === SPELLS.FALLEN_ORDER_SOOTHING_MIST.id
+        ) {
+          const paringStat = this.makingParingStat(event);
+          // bygones errors
+          if (!this.foHealsToListenFor.has(paringStat)) {
+            fixedEvents.push(event);
+            return;
+          }
+
+          // grab our timestamp from earlier
+          const buffApplied = this.foHealsToListenFor.get(paringStat);
+          const timestamp = buffApplied?.timestamp;
+          // Instant cast spell so we just blast off a cast
+          const fabricatedCastEvent = {
+            ability: {
+              name: event.ability.name,
+              type: event.ability.type,
+              abilityIcon: event.ability.abilityIcon,
+              guid: abilityGuid,
+            },
+            timestamp: timestamp,
+            absorb: event.absorb,
+            hitPoints: event.hitPoints - event.amount,
+            maxHitPoints: event.maxHitPoints,
+            sourceID: event.sourceID,
+            sourceIsFriendly: event.sourceIsFriendly,
+            targetID: event.targetID,
+            targetInstance: event.targetInstance,
+            targetIsFriendly: event.targetIsFriendly,
+            type: EventType.Cast,
+            __fabricated: true,
+          };
+          fixedEvents.push(fabricatedCastEvent);
+          fixedEvents.push(buffApplied);
+          this.removeOldData(this.makingParingStat(event));
+        }
+      } // Some times we apply a buff but never heal. We should listen for this and remove it from the list
+      else if (event.type === EventType.RemoveBuff) {
+        const abilityGuid = event.ability.guid;
+        if (
+          abilityGuid === SPELLS.FALLEN_ORDER_ENVELOPING_MIST.id ||
+          abilityGuid === SPELLS.FALLEN_ORDER_SOOTHING_MIST.id
+        ) {
+          const paringStat = this.makingParingStat(event);
+          // bygones errors
+          if (!this.foHealsToListenFor.has(paringStat)) {
+            fixedEvents.push(event);
+            return;
+          }
+          this.fixMapping(event);
+        }
+      }
+      fixedEvents.push(event);
+    });
+    return fixedEvents;
+  }
+
+  // ======== Starting Here ========
+  // This bit of code was stolen from another class that didn't use a map here
+  // this means some methods have been modified and now are not "needed" but we live with it
+  fixMapping(event: RemoveBuffEvent) {
+    this.removeOldData(this.makingParingStat(event));
+  }
+
+  removeOldData(paring: string) {
+    this.foHealsToListenFor.delete(paring);
+  }
+
+  makingParingStat(event: HealEvent | ApplyBuffEvent | RefreshBuffEvent | RemoveBuffEvent) {
+    return event.targetID + '|' + event.sourceID + '|' + event.ability.guid;
+  }
+  // ======== Ending Here ========
+}
+
+export default FallenOrderCraneCloneNormalizer;


### PR DESCRIPTION
Daddy Blizzard doesn't think Crane Clones should have cast events so I have to go back and do those for him. 
Updated previous stats to use the new CastEvent being thrown 
![image](https://user-images.githubusercontent.com/25177817/141739147-ed117e7d-3119-45ca-ad96-ef1759762a89.png)
This brings a tear to my EYE