### PR TITLE
Fixed Rising Sun Kick usage for Mistweaver monks

### DIFF
--- a/analysis/monkmistweaver/src/CHANGELOG.tsx
+++ b/analysis/monkmistweaver/src/CHANGELOG.tsx
@@ -1,11 +1,12 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
-import { Abelito75, Anomoly, Moonrabbit, Putro, Tyndi, Vohrr } from 'CONTRIBUTORS';
+import { Abelito75, Anomoly, Moonrabbit, Putro, Tyndi, Vohrr, Trevor } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import React from 'react';
 
 
 export default [
+  change(date(2021, 11, 17), <> Fixed bug in Rising Sun Kick cooldown tracking</>, Trevor),
   change(date(2021, 11, 15), <>Added Cast events directly into the log and normalized other stats that needed it. My sanity is now back intact :)</>, Abelito75),
   change(date(2021, 11, 14), <>Added A Cool And Interesting Infographic For Average Health of a Target When Fallen Order Crane Clones Cast A Healing Spell On Them.</>, Abelito75),
   change(date(2021, 11, 13), <>Added A Cool And Interesting Infographic For RSK Reset.</>, Abelito75),

--- a/analysis/monkmistweaver/src/modules/spells/RisingSunKick.tsx
+++ b/analysis/monkmistweaver/src/modules/spells/RisingSunKick.tsx
@@ -43,6 +43,7 @@ class RisingSunKick extends Analyzer {
       this.rskResets += 1;
 
       this.spellUsable.endCooldown(SPELLS.RISING_SUN_KICK.id);
+      this.spellUsable.beginCooldown(SPELLS.RISING_SUN_KICK.id, event);
     }
 
     this.lastRSK = event.timestamp;

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -1779,3 +1779,16 @@ export const Arbixal: Contributor = {
   about: 'TBC healer theorycrafter, but mostly resto shaman.',
   avatar: avatar('arbixal-avatar.png'),
 };
+
+export const Trevor: Contributor = {
+  nickname: 'Trevor',
+  discord: 'Trevor#9816',
+  github: 'trevorm4',
+  mains: [
+    {
+      name: 'Sardent',
+      spec: SPECS.MISTWEAVER_MONK,
+      link: 'https://worldofwarcraft.com/en-us/character/us/tichondrius/Sardent',
+    },
+  ],
+};


### PR DESCRIPTION
Fixed a bug in RisingSunKick.tsx where it was not properly restarting the cooldown when a Rising Sun Kick was cast because of a blackout kick reset.

Also added myself to Contributors 