### PR TITLE
Automatic build selection

### DIFF
--- a/analysis/tbcdruid/src/CONFIG.tsx
+++ b/analysis/tbcdruid/src/CONFIG.tsx
@@ -37,7 +37,7 @@ const config: Config = {
   builds: {
     [Build.DEFAULT]: {
       url: 'standard',
-      name: '20/41/0',
+      name: '0/0/61',
       icon: <Icon icon="spell_nature_healingtouch" />,
       visible: true,
     },

--- a/analysis/tbcdruid/src/CONFIG.tsx
+++ b/analysis/tbcdruid/src/CONFIG.tsx
@@ -38,6 +38,7 @@ const config: Config = {
     [Build.DEFAULT]: {
       url: 'standard',
       name: '0/0/61',
+      talents: [0, 0, 61],
       icon: <Icon icon="spell_nature_healingtouch" />,
       visible: true,
     },

--- a/analysis/tbchunter/src/CONFIG.tsx
+++ b/analysis/tbchunter/src/CONFIG.tsx
@@ -61,6 +61,7 @@ const config: Config = {
     [Build.DEFAULT]: {
       url: 'standard',
       name: '41/20/0',
+      talents: [41, 20, 0],
       icon: <Icon icon="ability_hunter_mendpet" />,
       visible: true,
     },

--- a/analysis/tbcmage/src/CONFIG.tsx
+++ b/analysis/tbcmage/src/CONFIG.tsx
@@ -36,6 +36,7 @@ const config: Config = {
     [Build.DEFAULT]: {
       url: 'standard',
       name: '40/0/21',
+      talents: [40, 0, 21],
       icon: <Icon icon="spell_arcane_blast" />,
       visible: true,
     },

--- a/analysis/tbcpaladin/src/CONFIG.tsx
+++ b/analysis/tbcpaladin/src/CONFIG.tsx
@@ -36,7 +36,7 @@ const config: Config = {
   builds: {
     [Build.DEFAULT]: {
       url: 'standard',
-      name: '20/41/0',
+      name: '45/11/5',
       icon: <Icon icon="spell_holy_holybolt" />,
       visible: true,
     },

--- a/analysis/tbcpaladin/src/CONFIG.tsx
+++ b/analysis/tbcpaladin/src/CONFIG.tsx
@@ -37,12 +37,14 @@ const config: Config = {
     [Build.DEFAULT]: {
       url: 'standard',
       name: '45/11/5',
+      talents: [45, 11, 5],
       icon: <Icon icon="spell_holy_holybolt" />,
       visible: true,
     },
     [Build.RET]: {
       url: 'ret',
       name: '5/11/45',
+      talents: [5, 11, 45],
       icon: <Icon icon="spell_holy_crusaderstrike" />,
       visible: true,
     },

--- a/analysis/tbcpriest/src/CONFIG.tsx
+++ b/analysis/tbcpriest/src/CONFIG.tsx
@@ -39,6 +39,7 @@ const config: Config = {
     [Build.DEFAULT]: {
       url: 'standard',
       name: '20/41/0',
+      talents: [20, 41, 0],
       icon: <Icon icon="spell_holy_summonlightwell" />,
       visible: true,
     },

--- a/analysis/tbcrogue/src/CONFIG.tsx
+++ b/analysis/tbcrogue/src/CONFIG.tsx
@@ -35,7 +35,7 @@ const config: Config = {
   builds: {
     [Build.DEFAULT]: {
       url: 'standard',
-      name: '20/41/0',
+      name: '19/42/0',
       icon: <Icon icon="inv_throwingknife_04" />,
       visible: true,
     },

--- a/analysis/tbcrogue/src/CONFIG.tsx
+++ b/analysis/tbcrogue/src/CONFIG.tsx
@@ -35,7 +35,8 @@ const config: Config = {
   builds: {
     [Build.DEFAULT]: {
       url: 'standard',
-      name: '19/42/0',
+      name: '20/41/0',
+      talents: [20, 41, 0],
       icon: <Icon icon="inv_throwingknife_04" />,
       visible: true,
     },

--- a/analysis/tbcshaman/src/CONFIG.tsx
+++ b/analysis/tbcshaman/src/CONFIG.tsx
@@ -38,18 +38,21 @@ const config: Config = {
     [Build.DEFAULT]: {
       url: 'standard',
       name: '0/5/56',
+      talents: [0, 5, 56],
       icon: <Icon icon="spell_nature_healingwavegreater" />,
       visible: true,
     },
     [Build.ENHANCEMENT]: {
       url: 'enhancement',
       name: '2/45/14',
+      talents: [2, 45, 14],
       icon: <Icon icon="spell_nature_lightningshield" />,
       visible: true,
     },
     [Build.ELEMENTAL]: {
       url: 'elemental',
       name: '41/0/20',
+      talents: [41, 0, 20],
       icon: <Icon icon="spell_nature_lightning" />,
       visible: true,
     },

--- a/analysis/tbcwarlock/src/CONFIG.tsx
+++ b/analysis/tbcwarlock/src/CONFIG.tsx
@@ -36,6 +36,7 @@ const config: Config = {
     [Build.DEFAULT]: {
       url: 'standard',
       name: '0/21/40',
+      talents: [0, 21, 40],
       icon: <Icon icon="spell_shadow_shadowbolt" />,
       visible: true,
     },

--- a/analysis/tbcwarlock/src/CONFIG.tsx
+++ b/analysis/tbcwarlock/src/CONFIG.tsx
@@ -35,7 +35,7 @@ const config: Config = {
   builds: {
     [Build.DEFAULT]: {
       url: 'standard',
-      name: '20/41/0',
+      name: '0/21/40',
       icon: <Icon icon="spell_shadow_shadowbolt" />,
       visible: true,
     },

--- a/analysis/tbcwarrior/src/CONFIG.tsx
+++ b/analysis/tbcwarrior/src/CONFIG.tsx
@@ -39,24 +39,28 @@ const config: Config = {
     [Build.DEFAULT]: {
       url: 'standard',
       name: '12/5/44',
+      talents: [12, 5, 44],
       icon: <Icon icon="ability_defend" />,
       visible: true,
     },
     [Build.ARMS]: {
       url: 'arms',
       name: '33/28/0',
+      talents: [33, 28, 0],
       icon: <Icon icon="ability_warrior_savageblow" />,
       visible: true,
     },
     [Build.FURY]: {
       url: 'fury',
       name: '17/44/0',
+      talents: [17, 44, 0],
       icon: <Icon icon="ability_warrior_rampage" />,
       visible: true,
     },
     [Build.DEATHWISH_FURY]: {
       url: 'deathwishfury',
       name: '21/40/0',
+      talents: [21, 40, 0],
       icon: <Icon icon="spell_shadow_deathpact" />,
       visible: true,
     },

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -8,6 +8,7 @@ import {
   Adoraci,
   Amani,
   Anomoly,
+  Arbixal,
   Barry,
   Barter,
   Buudha,
@@ -52,6 +53,7 @@ import React from 'react';
 
 // prettier-ignore
 export default [
+  change(date(2021, 11, 23), 'Have relevant TBC build selected for the selected character.', Arbixal),
   change(date(2021, 11, 14), 'Clean up caching in GitHub actions CI.', Zerotorescue),
   change(date(2021, 11, 13), 'Removed Healthstone and Healing Pot from Mana Efficiency Tracker.', Abelito75),
   change(date(2021, 11, 11), 'Added an Icon to more easily display which cooldown is which in the cooldown tab.', Abelito75),

--- a/src/interface/report/PlayerLoader.tsx
+++ b/src/interface/report/PlayerLoader.tsx
@@ -25,6 +25,7 @@ import { CombatantInfoEvent } from 'parser/core/Events';
 import { WCLFight } from 'parser/core/Fight';
 import { PlayerInfo } from 'parser/core/Player';
 import Report from 'parser/core/Report';
+import getBuild from 'parser/getBuild';
 import getConfig from 'parser/getConfig';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -258,7 +259,16 @@ class PlayerLoader extends React.PureComponent<Props, State> {
     const config =
       combatant &&
       getConfig(wclGameVersionToExpansion(report.gameVersion), combatant.specID, player.type);
-    if (!player || hasDuplicatePlayers || !combatant || !config || combatant.error) {
+    const build = combatant && getBuild(config, combatant);
+    const missingBuild = config?.builds && !build;
+    if (
+      !player ||
+      hasDuplicatePlayers ||
+      !combatant ||
+      !config ||
+      missingBuild ||
+      combatant.error
+    ) {
       if (player) {
         // Player data was in the report, but there was another issue
         if (hasDuplicatePlayers) {
@@ -282,7 +292,7 @@ class PlayerLoader extends React.PureComponent<Props, State> {
               message: `The data received from WCL for this player is corrupt, this player can not be analyzed in this fight.`,
             }),
           );
-        } else if (!config) {
+        } else if (!config || missingBuild) {
           alert(
             t({
               id: 'interface.report.render.notSupported',
@@ -343,7 +353,9 @@ class PlayerLoader extends React.PureComponent<Props, State> {
           <PlayerSelection
             report={report}
             combatants={combatants}
-            makeUrl={(playerId) => makeAnalyzerUrl(report, fight.id, playerId)}
+            makeUrl={(playerId, build) =>
+              makeAnalyzerUrl(report, fight.id, playerId, undefined, build)
+            }
           />
           <ReportRaidBuffList combatants={combatants} />
         </div>

--- a/src/interface/report/PlayerSelection.tsx
+++ b/src/interface/report/PlayerSelection.tsx
@@ -42,7 +42,7 @@ function sortPlayers(a: Player, b: Player) {
 interface Props {
   report: Report;
   combatants: CombatantInfoEvent[];
-  makeUrl: (playerId: number) => string;
+  makeUrl: (playerId: number, build?: string) => string;
 }
 
 const PlayerSelection = ({ report, combatants, makeUrl }: Props) => (

--- a/src/interface/report/PlayerTile.tsx
+++ b/src/interface/report/PlayerTile.tsx
@@ -9,13 +9,14 @@ import SpecIcon from 'interface/SpecIcon';
 import Config from 'parser/Config';
 import CharacterProfile from 'parser/core/CharacterProfile';
 import Player from 'parser/core/Player';
+import getBuild from 'parser/getBuild';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 
 interface Props {
   player: Player;
-  makeUrl: (playerId: number) => string;
+  makeUrl: (playerId: number, build?: string) => string;
   config?: Config;
 }
 
@@ -54,13 +55,15 @@ const PlayerTile = ({ player, makeUrl, config }: Props) => {
       }.worldofwarcraft.com/character/${characterInfo.thumbnail.replace('avatar', 'inset')}`
     : '/img/fallback-character.jpg';
   const spec = config?.spec;
+  const build = getBuild(config, player.combatant);
+  const missingBuild = config?.builds && !build;
   const covenant = player.combatant.covenantID || null;
   let covenantName: string | undefined = '';
   if (covenant !== null) {
     covenantName = getCovenantById(covenant)?.name;
   }
 
-  if (!config) {
+  if (!config || missingBuild) {
     return (
       <span
         className="player"
@@ -102,7 +105,7 @@ const PlayerTile = ({ player, makeUrl, config }: Props) => {
   }
 
   return (
-    <Link to={makeUrl(player.id)} className={`player ${getClassName(spec?.role)}`}>
+    <Link to={makeUrl(player.id, build?.url)} className={`player ${getClassName(spec?.role)}`}>
       <div className="role" />
       <div className="card">
         <div className="avatar" style={{ backgroundImage: `url(${avatar})` }} />

--- a/src/parser/Config.ts
+++ b/src/parser/Config.ts
@@ -11,6 +11,7 @@ import { Stats } from './shared/modules/StatTracker';
 export type Build = {
   url: string;
   name: string;
+  talents: [number, number, number];
   icon: ReactNode;
   /**
    * Whether the build should be visible. Using `false` can allow you to

--- a/src/parser/DEFAULT_BUILD.tsx
+++ b/src/parser/DEFAULT_BUILD.tsx
@@ -7,6 +7,7 @@ const DEFAULT_BUILD: Build = {
   url: 'standard',
   visible: true,
   icon: <ArmoryIcon />,
+  talents: [0, 0, 0],
 };
 
 export default DEFAULT_BUILD;

--- a/src/parser/getBuild.ts
+++ b/src/parser/getBuild.ts
@@ -1,0 +1,55 @@
+import Expansion from 'game/Expansion';
+
+import Config, { Build } from './Config';
+import { CombatantInfoEvent } from './core/Events';
+
+function compareBuilds(buildA: number[], buildB: number[]) {
+  let total = 0;
+  for (let i = 0; i < 3; i = i + 1) {
+    total = total + Math.abs(buildA[i] - buildB[i]);
+  }
+
+  return total;
+}
+
+export default function getBuild(
+  config: Config | undefined,
+  combatant: CombatantInfoEvent,
+): Build | null {
+  if (
+    !config?.builds ||
+    (config.expansion !== Expansion.Vanilla && config.expansion !== Expansion.TheBurningCrusade)
+  ) {
+    return null;
+  }
+
+  const talents = combatant.talents.reduce((accum: number[], spell) => {
+    if (spell != null) {
+      accum.push(spell.id);
+    }
+
+    return accum;
+  }, [] as number[]);
+
+  // Expecting vanilla and tbc talents in the form of 3 numbers
+  if (talents.length !== 3) {
+    return null;
+  }
+
+  let buildComparison = Object.values(config.builds).map((build) => {
+    const buildTalents = build.name.split('/').map((num) => parseInt(num));
+    if (buildTalents.length !== 3) {
+      return { build: build, score: 999 };
+    }
+
+    return { build: build, score: compareBuilds(talents, buildTalents) };
+  });
+
+  buildComparison = buildComparison.sort((a, b) => a.score - b.score);
+
+  if (buildComparison[0].score < 50) {
+    return buildComparison[0].build;
+  }
+
+  return null;
+}

--- a/src/parser/getBuild.ts
+++ b/src/parser/getBuild.ts
@@ -36,14 +36,10 @@ export default function getBuild(
     return null;
   }
 
-  let buildComparison = Object.values(config.builds).map((build) => {
-    const buildTalents = build.name.split('/').map((num) => parseInt(num));
-    if (buildTalents.length !== 3) {
-      return { build: build, score: 999 };
-    }
-
-    return { build: build, score: compareBuilds(talents, buildTalents) };
-  });
+  let buildComparison = Object.values(config.builds).map((build) => ({
+    build: build,
+    score: compareBuilds(talents, build.talents),
+  }));
 
   buildComparison = buildComparison.sort((a, b) => a.score - b.score);
 


### PR DESCRIPTION
First cut of automatically selecting the closest build (mostly for TBC) based on my suggestions in #4666.
If this isn't the best approach, I'm open to changes.

Comparison is done for all the builds in the relevant config and the talents given by WCL. The builds are sorted in order of closest match and then the first one is selected. 

If a build differs too much (50 talents points) then it is considered not a close enough match. This essentially means 25 points in a different tree as it will differ by 25 points in both trees which adds together to make 50 points of difference.

I also had to adjust the points given to some other builds (druid, paladin, rogue warlock) as they seemed to be copy-pasta.

I'm also thinking of splitting out the talent points from the name of the build as there is nothing forcing the name to adhere to "X/Y/Z" format that I am assuming.