### PR TITLE
Implement greaterThanOrEqual and lessThanOrEqual for checklists

### DIFF
--- a/analysis/monkmistweaver/src/modules/spells/EssenceFont.tsx
+++ b/analysis/monkmistweaver/src/modules/spells/EssenceFont.tsx
@@ -61,7 +61,10 @@ class EssenceFont extends Analyzer {
       Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.ESSENCE_FONT_BUFF),
       this.refreshEssenceFontBuff,
     );
-    this.addEventListener(Events.EndChannel.by(SELECTED_PLAYER), this.handleEndChannel);
+    this.addEventListener(
+      Events.EndChannel.by(SELECTED_PLAYER).spell(SPELLS.ESSENCE_FONT),
+      this.handleEndChannel,
+    );
     this.hasUpwelling = this.selectedCombatant.hasTalent(SPELLS.UPWELLING_TALENT.id);
   }
 
@@ -96,8 +99,8 @@ class EssenceFont extends Analyzer {
   get suggestionThresholdsCancel() {
     return {
       actual: this.cancelled_ef,
-      isGreaterThan: {
-        major: 0,
+      isGreaterThanOrEqual: {
+        major: 1,
       },
       style: ThresholdStyle.NUMBER,
     };
@@ -105,8 +108,8 @@ class EssenceFont extends Analyzer {
   castEssenceFont(event: CastEvent) {
     let extra_secs = 0;
     if (this.hasUpwelling) {
-      extra_secs = Math.max(
-        (event.timestamp - (this.last_ef + SPELLS.ESSENCE_FONT.cooldown * 1000)) / 6000,
+      extra_secs = Math.min(
+        (event.timestamp - (this.last_ef + 12000)) / 6000, //12000 is the cooldown of EF in MS and 6000 corresponds to the number of MS for UW to get a full second in channels
         3,
       );
     }
@@ -145,18 +148,7 @@ class EssenceFont extends Analyzer {
   }
 
   handleEndChannel(event: EndChannelEvent) {
-    if (
-      event.ability.guid === SPELLS.ESSENCE_FONT.id &&
-      event.duration < this.expected_duration - this.cancelDelta
-    ) {
-      console.log(
-        'Cancelled ef at timestamp ' +
-          event.timestamp +
-          ' with expected duration ' +
-          this.expected_duration +
-          ' and actual duration' +
-          event.duration,
-      );
+    if (event.duration < this.expected_duration - this.cancelDelta) {
       this.cancelled_ef += 1;
     }
   }

--- a/analysis/monkmistweaver/src/modules/spells/EssenceFont.tsx
+++ b/analysis/monkmistweaver/src/modules/spells/EssenceFont.tsx
@@ -105,6 +105,7 @@ class EssenceFont extends Analyzer {
       style: ThresholdStyle.NUMBER,
     };
   }
+
   castEssenceFont(event: CastEvent) {
     let extra_secs = 0;
     if (this.hasUpwelling) {

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -44,6 +44,7 @@ import {
   niko,
   Pirrang,
   ChrisKaczor,
+  Trevor
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
@@ -52,6 +53,7 @@ import React from 'react';
 
 // prettier-ignore
 export default [
+  change(date(2021, 11, 24), 'Added GreaterThanOrEqual and LessThanOrEqual comparators for checklists', Trevor),
   change(date(2021, 11, 14), 'Clean up caching in GitHub actions CI.', Zerotorescue),
   change(date(2021, 11, 13), 'Removed Healthstone and Healing Pot from Mana Efficiency Tracker.', Abelito75),
   change(date(2021, 11, 11), 'Added an Icon to more easily display which cooldown is which in the cooldown tab.', Abelito75),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -44,7 +44,8 @@ import {
   Zerotorescue,
   niko,
   Pirrang,
-  ChrisKaczor
+  ChrisKaczor,
+  Trevor
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
@@ -53,6 +54,7 @@ import React from 'react';
 
 // prettier-ignore
 export default [
+  change(date(2021, 11, 25), 'Added greaterThanOrEqual & lessThanOrEqual option for checklist conditions', Trevor),
   change(date(2021, 11, 25), 'Force-update translations for Mistweaver', emallson),
   change(date(2021, 11, 23), 'Have relevant TBC build selected for the selected character.', Arbixal),
   change(date(2021, 11, 14), 'Clean up caching in GitHub actions CI.', Zerotorescue),

--- a/src/parser/shared/modules/features/Checklist/helpers/performanceForThresholds.ts
+++ b/src/parser/shared/modules/features/Checklist/helpers/performanceForThresholds.ts
@@ -47,6 +47,44 @@ function performanceForGreaterThanThresholds(
   }
 }
 
+function performanceForGreaterThanOrEqualThresholds(
+  actual: number,
+  { minor, average, major }: { minor: number; average: number; major: number },
+) {
+  if (actual >= major) {
+    // major issue
+    return (0.333 * major) / actual;
+  } else if (actual >= average) {
+    // average issue (between major and average issue)
+    return 0.666 - 0.333 * ((actual - average) / (major - average));
+  } else if (actual >= minor) {
+    // minor issue (between average and minor issue)
+    return 1 - 0.333 * ((actual - minor) / (average - minor));
+  } else {
+    // no issue
+    return 1;
+  }
+}
+
+function performanceForLessThanOrEqualThresholds(
+  actual: number,
+  { minor, average, major }: { minor: number; average: number; major: number },
+) {
+  if (actual <= major) {
+    // major issue
+    return (0.333 * actual) / major;
+  } else if (actual <= average) {
+    // average issue (between major and average issue)
+    return 0.333 + 0.333 * ((actual - major) / (average - major));
+  } else if (actual <= minor) {
+    // minor issue (between average and minor issue)
+    return 0.666 + 0.333 * ((actual - average) / (minor - average));
+  } else {
+    // no issue
+    return 1;
+  }
+}
+
 export default function performanceForThresholds(thresholds: any) {
   if (thresholds.isGreaterThan || thresholds.isGreaterThan === 0) {
     if (typeof thresholds.isGreaterThan === 'object') {
@@ -59,6 +97,24 @@ export default function performanceForThresholds(thresholds: any) {
       return performanceForLessThanThresholds(thresholds.actual, thresholds.isLessThan);
     } else {
       return thresholds.actual / thresholds.isLessThan;
+    }
+  } else if (thresholds.isGreaterThanOrEqual || thresholds.isGreaterThanOrEqual === 0) {
+    if (typeof thresholds.isGreaterThanOrEqual === 'object') {
+      return performanceForGreaterThanOrEqualThresholds(
+        thresholds.actual,
+        thresholds.isGreaterThanOrEqual,
+      );
+    } else {
+      return thresholds.isGreaterThanOrEqual / thresholds.actual;
+    }
+  } else if (thresholds.isLessThanOrEqual || thresholds.isLessThanOrEqual === 0) {
+    if (typeof thresholds.isLessThanOrEqual === 'object') {
+      return performanceForLessThanOrEqualThresholds(
+        thresholds.actual,
+        thresholds.isLessThanOrEqual,
+      );
+    } else {
+      return thresholds.actual / thresholds.isLessThanOrEqual;
     }
   } else if (thresholds.isEqual !== undefined) {
     return thresholds.actual !== thresholds.isEqual ? 1 : 0;

--- a/src/parser/shared/modules/features/Checklist/helpers/performanceForThresholds.ts
+++ b/src/parser/shared/modules/features/Checklist/helpers/performanceForThresholds.ts
@@ -1,3 +1,5 @@
+const minorReturn = 0.99; // fixed percentage for when actual == minor (need to differentiate from no issues)
+
 /**
  *   0 - 33% major This is different from the *minor* threshold which is at 100% instead of 66%. The reason for this is that the minor threshold being at 75% and then 75%-100% being minor - max is that this would suggest going for max is best while this is not always the case. Something like Crusader Strike (with the Crusader's Might talent) has a recommended cast efficiency of 35% *because* you should only cast it enough to benefit you, more than that would be good but not 100% cast efficiency as then you're losing healing.
  * 33% - 66% average
@@ -47,11 +49,15 @@ function performanceForGreaterThanThresholds(
   }
 }
 
+//  Essentially same as greaterThan, but if bounds are changed
+//  and manually return minorReturn to force different color when actual = minor
 function performanceForGreaterThanOrEqualThresholds(
   actual: number,
   { minor, average, major }: { minor: number; average: number; major: number },
 ) {
-  if (actual >= major) {
+  if (actual === minor) {
+    return minorReturn;
+  } else if (actual >= major) {
     // major issue
     return (0.333 * major) / actual;
   } else if (actual >= average) {
@@ -66,10 +72,15 @@ function performanceForGreaterThanOrEqualThresholds(
   }
 }
 
+//  Essentially same as lessThan, but if bounds are changed
+//  and manually return minorReturn to force different color when actual = minor
 function performanceForLessThanOrEqualThresholds(
   actual: number,
   { minor, average, major }: { minor: number; average: number; major: number },
 ) {
+  if (actual === minor) {
+    return minorReturn;
+  }
   if (actual <= major) {
     // major issue
     return (0.333 * actual) / major;


### PR DESCRIPTION
Added `performanceForGreaterThanOrEqualThresholds` and `performanceForLessThanOrEqualThresholds` to `performanceForThresholds.ts`, allowing for >= and <= to be used in checklists.

Also, modified `EssenceFont.tsx` in MW analysis module to change the threshold for cancellations (as discussed in previous PR)