### PR TITLE
handle the possibility of multiple combatantinfo events

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -55,6 +55,7 @@ import React from 'react';
 
 // prettier-ignore
 export default [
+  change(date(2021, 12, 4), 'Fixed an issue with stat tracking in Mythic+ dungeons. Mythic+ still not officially supported, but at least it shouldn\'t crash', emallson),
   change(date(2021, 11, 30), 'Fixed Spiritual Mana Potion not being tracked issue.', Jeff),
   change(date(2021, 11, 25), 'Fix compatibility issue with nodejs 16', Jeff),
   change(date(2021, 11, 25), 'Added greaterThanOrEqual & lessThanOrEqual option for checklist conditions', Trevor),

--- a/src/parser/shared/modules/Combatants.ts
+++ b/src/parser/shared/modules/Combatants.ts
@@ -39,7 +39,9 @@ class Combatants extends Entities<Combatant> {
         return;
       }
 
-      this.players[combatantInfo.sourceID] = new Combatant(this.owner, combatantInfo);
+      if (!this.players[combatantInfo.sourceID]) {
+        this.players[combatantInfo.sourceID] = new Combatant(this.owner, combatantInfo);
+      }
     });
     this._selected = this.players[this.owner.playerId];
   }


### PR DESCRIPTION
occurs in M+ logs, each boss emits an event but we're tracking from the
start of the instance anyway