### PR TITLE
[Fire Mage] Requested Updates

### DIFF
--- a/analysis/magefire/src/CHANGELOG.tsx
+++ b/analysis/magefire/src/CHANGELOG.tsx
@@ -4,6 +4,10 @@ import { Adoraci, Sharrq } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2021, 12, 8), <>Changed the <SpellLink id={SPELLS.PHOENIX_FLAMES.id} /> module to consider capping charges a minor issue.</>, Sharrq),
+  change(date(2021, 12, 8), <>Added a check to ensure the player is not using <SpellLink id={SPELLS.COMBUSTION.id} /> while it is already active (via <SpellLink id={SPELLS.SUN_KINGS_BLESSING.id} />).</>, Sharrq),
+  change(date(2021, 12, 8), <>Added a check for <SpellLink id={SPELLS.PYROCLASM_TALENT.id} /> to ensure the player is not using it during <SpellLink id={SPELLS.COMBUSTION.id} /> if they are capped or about to cap on <SpellLink id={SPELLS.FIRE_BLAST.id} /> or <SpellLink id={SPELLS.PHOENIX_FLAMES.id} />.</>, Sharrq),
+  change(date(2021, 12, 8), <>Removed the <SpellLink id={SPELLS.SCORCH.id} /> during <SpellLink id={SPELLS.COMBUSTION.id} /> check as it was no longer relevant.</>, Sharrq),
   change(date(2021, 12, 5), 'Updated support to 9.1.5.', Sharrq),
   change(date(2021, 12, 5), <>Added support for <SpellLink id={SPELLS.MIRRORS_OF_TORMENT.id} /></>, Sharrq),
   change(date(2021, 12, 5), <>Added support for <SpellLink id={SPELLS.SUN_KINGS_BLESSING.id} /></>, Sharrq),

--- a/analysis/magefire/src/integrationTests/example.test.ts.snap
+++ b/analysis/magefire/src/integrationTests/example.test.ts.snap
@@ -3857,55 +3857,6 @@ Array [
 ]
 `;
 
-exports[`Fire Mage integration test: example log CombustionSpellUsage matches the suggestions snapshot 1`] = `
-Array [
-  Object {
-    "details": null,
-    "icon": "spell_fire_sealoffire",
-    "importance": "minor",
-    "issue": <React.Fragment>
-      You started to cast 
-      <ForwardRef
-        id={2948}
-      />
-       
-      2
-       times (
-      0.40
-       per Combustion), and completed
-       
-      1
-       casts, while you had charges of
-       
-      <ForwardRef
-        id={108853}
-      />
-       or 
-      <ForwardRef
-        id={257541}
-      />
-       
-      available. Make sure you are using up all of your charges of Fire Blast and Phoenix Flames before using Scorch during Combustion.
-    </React.Fragment>,
-    "spell": undefined,
-    "stat": <React.Fragment>
-      <Trans
-        id="mage.fire.suggestions.combustion.charge.utilization"
-        message="{0} Casts Per Combustion"
-        values={
-          Object {
-            "0": "0.40",
-          }
-        }
-      />
-       (
-      0 is recommended
-      )
-    </React.Fragment>,
-  },
-]
-`;
-
 exports[`Fire Mage integration test: example log DeathTracker matches the suggestions snapshot 1`] = `
 Array [
   Object {
@@ -4830,7 +4781,7 @@ Array [
   Object {
     "details": null,
     "icon": "artifactability_firemage_phoenixbolt",
-    "importance": "regular",
+    "importance": "minor",
     "issue": <React.Fragment>
       You spent 
       75
@@ -4844,7 +4795,7 @@ Array [
       <ForwardRef
         id={190319}
       />
-      , it is also important that you avoid capping on charges whenever possible. To avoid this, you should use a charge of 
+      , you should also try to avoid capping on charges whenever possible. To avoid this, you should use a charge of 
       <ForwardRef
         id={257541}
       />
@@ -4862,7 +4813,7 @@ Array [
         }
       />
        (
-      5.00% is recommended
+      10.00% is recommended
       )
     </React.Fragment>,
   },
@@ -5872,7 +5823,7 @@ exports[`Fire Mage integration test: example log matches the checklist snapshot 
               style={
                 Object {
                   "backgroundColor": "#a6c34c",
-                  "width": "78.25202515090974%",
+                  "width": "77.04802874389684%",
                 }
               }
             />
@@ -6290,96 +6241,6 @@ exports[`Fire Mage integration test: example log matches the checklist snapshot 
                         "backgroundColor": "#4ec04e",
                         "transition": "background-color 800ms",
                         "width": "100%",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="col-md-6"
-          >
-            <div
-              className="flex"
-            >
-              <div
-                className="flex-main"
-              >
-                Scorch used with instants available
-              </div>
-              <div
-                className="flex-sub"
-                style={
-                  Object {
-                    "marginLeft": 10,
-                  }
-                }
-              >
-                <div
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onTouchStart={[Function]}
-                >
-                  <svg
-                    className="icon"
-                    viewBox="0 0 100 100"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M53.1,73h-7.2c-1.1,0-1.9-0.9-1.9-1.9V44h11v27.1C55,72.1,54.1,73,53.1,73z"
-                    />
-                    <path
-                      d="M55,39H44v-9.1c0-1.1,0.9-1.9,1.9-1.9h7.2c1.1,0,1.9,0.9,1.9,1.9V39z"
-                    />
-                    <path
-                      d="M50,96C24.6,96,4,75.4,4,50S24.6,4,50,4s46,20.6,46,46S75.4,96,50,96z M50,12c-21,0-38,17-38,38s17,38,38,38s38-17,38-38   S71,12,50,12z"
-                    />
-                  </svg>
-                </div>
-              </div>
-              <div
-                className="flex-sub content-middle text-muted"
-                style={
-                  Object {
-                    "marginLeft": 5,
-                    "marginRight": 10,
-                    "minWidth": 55,
-                  }
-                }
-              >
-                <div
-                  className="text-right"
-                  style={
-                    Object {
-                      "width": "100%",
-                    }
-                  }
-                >
-                   
-                  0
-                   
-                   
-                </div>
-              </div>
-              <div
-                className="flex-sub content-middle"
-                style={
-                  Object {
-                    "width": 50,
-                  }
-                }
-              >
-                <div
-                  className="performance-bar-container"
-                >
-                  <div
-                    className="performance-bar small"
-                    style={
-                      Object {
-                        "backgroundColor": "#a6c34c",
-                        "transition": "background-color 800ms",
-                        "width": "86.68%",
                       }
                     }
                   />

--- a/analysis/magefire/src/modules/Checklist/Component.tsx
+++ b/analysis/magefire/src/modules/Checklist/Component.tsx
@@ -83,11 +83,6 @@ const FireMageChecklist = ({ combatant, castEfficiency, thresholds }: ChecklistP
           />
         )}
         <Requirement
-          name="Scorch used with instants available"
-          thresholds={thresholds.scorchSpellUsageDuringCombustion}
-          tooltip="It is very important to use your time during Combustion wisely to get as many Hot Streak procs as possible before Combustion ends. To accomplish this, you should be stringing your guaranteed crit spells (Fireblast and Phoenix Flames) together to perpetually convert Heating Up to Hot Streak as many times as possible. If you run out of instant spells, cast Scorch instead."
-        />
-        <Requirement
           name="Fireball casts during Combustion"
           thresholds={thresholds.fireballSpellUsageDuringCombustion}
           tooltip="Due to Combustion's short duration, you should never cast Fireball during Combustion. Instead, you should use your instant cast abilities like Fireblast and Phoenix Flames. If you run out of instant abilities, cast Scorch instead since it's cast time is shorter."

--- a/analysis/magefire/src/modules/Checklist/Module.tsx
+++ b/analysis/magefire/src/modules/Checklist/Module.tsx
@@ -86,8 +86,6 @@ class Checklist extends BaseChecklist {
           phoenixFlamesCombustionCharges: this.combustionCharges.phoenixFlamesThresholds,
           fireBlastCombustionCharges: this.combustionCharges.fireBlastThresholds,
           firestarterCombustionUsage: this.combustionFirestarter.SuggestionThresholds,
-          scorchSpellUsageDuringCombustion: this.combustionSpellUsage
-            .scorchDuringCombustionThresholds,
           fireballSpellUsageDuringCombustion: this.combustionSpellUsage
             .fireballDuringCombustionThresholds,
           combustionActiveTime: this.combustionActiveTime.combustionActiveTimeThresholds,

--- a/analysis/magefire/src/modules/features/PhoenixFlames.tsx
+++ b/analysis/magefire/src/modules/features/PhoenixFlames.tsx
@@ -58,9 +58,7 @@ class PhoenixFlames extends Analyzer {
     return {
       actual: this.percentCapped,
       isGreaterThan: {
-        minor: 0.05,
-        average: 0.1,
-        major: 0.2,
+        minor: 0.1,
       },
       style: ThresholdStyle.PERCENTAGE,
     };
@@ -72,10 +70,10 @@ class PhoenixFlames extends Analyzer {
         <>
           You spent {formatNumber(this.cappedSeconds)}s ({formatPercentage(this.percentCapped)}% of
           the fight) capped on <SpellLink id={SPELLS.PHOENIX_FLAMES.id} /> charges. While it is
-          important to pool charges for your next <SpellLink id={SPELLS.COMBUSTION.id} />, it is
-          also important that you avoid capping on charges whenever possible. To avoid this, you
-          should use a charge of <SpellLink id={SPELLS.PHOENIX_FLAMES.id} /> if you are capped or
-          are about to cap on charges.
+          important to pool charges for your next <SpellLink id={SPELLS.COMBUSTION.id} />, you
+          should also try to avoid capping on charges whenever possible. To avoid this, you should
+          use a charge of <SpellLink id={SPELLS.PHOENIX_FLAMES.id} /> if you are capped or are about
+          to cap on charges.
         </>,
       )
         .icon(SPELLS.PHOENIX_FLAMES.icon)

--- a/analysis/magefire/src/modules/items/SunKingsBlessing.tsx
+++ b/analysis/magefire/src/modules/items/SunKingsBlessing.tsx
@@ -7,7 +7,6 @@ import { SELECTED_PLAYER } from 'parser/core/EventFilter';
 import Events, { CastEvent, ApplyBuffEvent, RemoveBuffEvent } from 'parser/core/Events';
 import { When, ThresholdStyle } from 'parser/core/ParseResults';
 import EventHistory from 'parser/shared/modules/EventHistory';
-import FilteredActiveTime from 'parser/shared/modules/FilteredActiveTime';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
@@ -24,10 +23,8 @@ const debug = false;
 class SunKingsBlessing extends Analyzer {
   static dependencies = {
     eventHistory: EventHistory,
-    filteredActiveTime: FilteredActiveTime,
   };
   protected eventHistory!: EventHistory;
-  protected filteredActiveTime!: FilteredActiveTime;
 
   expiredBuffs = 0;
   sunKingApplied = 0;

--- a/analysis/magefire/src/modules/items/SunKingsBlessing.tsx
+++ b/analysis/magefire/src/modules/items/SunKingsBlessing.tsx
@@ -1,11 +1,11 @@
 import { Trans } from '@lingui/macro';
 import { formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
+import { SpellLink } from 'interface';
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import { SELECTED_PLAYER } from 'parser/core/EventFilter';
 import Events, { CastEvent, ApplyBuffEvent, RemoveBuffEvent } from 'parser/core/Events';
 import { When, ThresholdStyle } from 'parser/core/ParseResults';
-import { SpellLink } from 'interface';
 import EventHistory from 'parser/shared/modules/EventHistory';
 import FilteredActiveTime from 'parser/shared/modules/FilteredActiveTime';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';


### PR DESCRIPTION
The following were requested from members of the mage discord.

- Remove the check for Scorch during Combustion and whether or not instant charges were available. This is not relevant anymore.
- Change the Phoenix Flames capping charges issue to be minor as it is no longer a big deal (this might change in 9.2)
- Add a check to see if Combustion was cast while Combustion was already active (via SKB)
- Add a check to see if the player used their Pyroclasm proc during Combustion while they were capped or close to capping on Fire Blast or Phoenix Flames charges.