### PR TITLE
[Fire Mage] Fix number rounding on Combustion suggestion

### DIFF
--- a/analysis/magefire/src/CHANGELOG.tsx
+++ b/analysis/magefire/src/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { Adoraci, Sharrq } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2021, 12, 8), <>Fixed the number rounding for one of the <SpellLink id={SPELLS.COMBUSTION.id} /> modules.</>, Sharrq),
   change(date(2021, 12, 8), <>Changed the <SpellLink id={SPELLS.PHOENIX_FLAMES.id} /> module to consider capping charges a minor issue.</>, Sharrq),
   change(date(2021, 12, 8), <>Added a check to ensure the player is not using <SpellLink id={SPELLS.COMBUSTION.id} /> while it is already active (via <SpellLink id={SPELLS.SUN_KINGS_BLESSING.id} />).</>, Sharrq),
   change(date(2021, 12, 8), <>Added a check for <SpellLink id={SPELLS.PYROCLASM_TALENT.id} /> to ensure the player is not using it during <SpellLink id={SPELLS.COMBUSTION.id} /> if they are capped or about to cap on <SpellLink id={SPELLS.FIRE_BLAST.id} /> or <SpellLink id={SPELLS.PHOENIX_FLAMES.id} />.</>, Sharrq),

--- a/analysis/magefire/src/modules/features/CombustionPreCastDelay.tsx
+++ b/analysis/magefire/src/modules/features/CombustionPreCastDelay.tsx
@@ -1,4 +1,5 @@
 import { Trans } from '@lingui/macro';
+import { formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
@@ -88,9 +89,9 @@ class CombustionPreCastDelay extends Analyzer {
     when(this.combustionCastDelayThresholds).addSuggestion((suggest, actual, recommended) =>
       suggest(
         <>
-          On average, you used <SpellLink id={SPELLS.COMBUSTION.id} /> with {this.averageCastDelay}{' '}
-          seconds left on your pre-cast ability (The spell you were casting when you used{' '}
-          <SpellLink id={SPELLS.COMBUSTION.id} />
+          On average, you used <SpellLink id={SPELLS.COMBUSTION.id} /> with{' '}
+          {formatNumber(this.averageCastDelay)} seconds left on your pre-cast ability (The spell you
+          were casting when you used <SpellLink id={SPELLS.COMBUSTION.id} />
           ). In order to maximize the number of casts you can get in during{' '}
           <SpellLink id={SPELLS.COMBUSTION.id} />, it is recommended that you are activating{' '}
           <SpellLink id={SPELLS.COMBUSTION.id} /> closer to the end of your pre-cast (preferably
@@ -100,7 +101,7 @@ class CombustionPreCastDelay extends Analyzer {
         .icon(SPELLS.COMBUSTION.icon)
         .actual(
           <Trans id="mage.fire.suggestions.combustion.castDelay">
-            {actual}s Avg. Pre-Cast Delay
+            {formatNumber(actual)}s Avg. Pre-Cast Delay
           </Trans>,
         )
         .recommended(`${recommended} is recommended`),


### PR DESCRIPTION
One of the Combustion suggestions isnt rounding numbers so it is producing a number to like the 10th decimal.

![image](https://user-images.githubusercontent.com/1304554/145311027-a9500add-4275-4591-b706-add34e055a32.png)
