### PR TITLE
[Hunter] Add cov buffs to the timeline

### DIFF
--- a/analysis/hunter/src/covenants/kyrian/ResonatingArrow.tsx
+++ b/analysis/hunter/src/covenants/kyrian/ResonatingArrow.tsx
@@ -58,7 +58,7 @@ class ResonatingArrow extends Analyzer {
       this.onDebuff,
     );
     this.addEventListener(
-      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.RESONATING_ARROW_DAMAGE),
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.RESONATING_ARROW_DAMAGE_AND_BUFF),
       this.onDamage,
     );
   }

--- a/analysis/hunterbeastmastery/src/CHANGELOG.tsx
+++ b/analysis/hunterbeastmastery/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Adoraci, Putro, Kartarn } from 'CONTRIBUTORS';
 import { ItemLink, SpellLink } from 'interface';
 
 export default [
+  change(date(2021, 12, 12), <> Added <SpellLink id={SPELLS.WILD_SPIRITS_BUFF.id} />, <SpellLink id={SPELLS.RESONATING_ARROW_DAMAGE_AND_BUFF.id}/> and <SpellLink id={SPELLS.FLAYERS_MARK.id} /> to the timeline to better show when these covenant specifics buffs were active.</>, Putro),
   change(date(2021, 11, 11), <> Added a simple analyzer to track damage gained from <SpellLink id={SPELLS.FRAGMENTS_OF_THE_ELDER_ANTLERS.id}/>. </>, Putro),
   change(date(2021, 11, 11), <> Correct an issue where damage done by <SpellLink id={SPELLS.BEAST_CLEAVE_DAMAGE.id}/> wasn't correctly attributed to <SpellLink id={SPELLS.RYLAKSTALKERS_PIERCING_FANGS_EFFECT.id}/>.  </>, Putro),
   change(date(2021, 11, 6), <> Update APL checker with the new fractional spell charges and cooldown remaining logic as well as moving <SpellLink id={SPELLS.WILD_SPIRITS.id} /> into the major cooldown category instead of an APL item. </>, Putro),

--- a/analysis/hunterbeastmastery/src/modules/Buffs.tsx
+++ b/analysis/hunterbeastmastery/src/modules/Buffs.tsx
@@ -40,6 +40,25 @@ class Buffs extends CoreBuffs {
         spellId: Object.keys(BLOODLUST_BUFFS).map((item) => Number(item)),
         timelineHighlight: true,
       },
+      /** Covenant Specific */
+      //Venthyr
+      {
+        spellId: SPELLS.FLAYERS_MARK.id,
+        timelineHighlight: true,
+        triggeredBySpellId: SPELLS.FLAYED_SHOT.id,
+      },
+      //Night Fae
+      {
+        spellId: SPELLS.WILD_SPIRITS_BUFF.id,
+        timelineHighlight: true,
+        triggeredBySpellId: SPELLS.WILD_SPIRITS.id,
+      },
+      //Kyrian
+      {
+        spellId: SPELLS.RESONATING_ARROW_DAMAGE_AND_BUFF.id,
+        timelineHighlight: true,
+        triggeredBySpellId: SPELLS.RESONATING_ARROW.id,
+      },
     ];
   }
 }

--- a/analysis/huntermarksmanship/src/CHANGELOG.tsx
+++ b/analysis/huntermarksmanship/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Adoraci, Putro, Zeboot, Kartarn } from 'CONTRIBUTORS';
 import { ItemLink, SpellLink } from 'interface';
 
 export default [
+  change(date(2021, 12, 12), <> Added <SpellLink id={SPELLS.WILD_SPIRITS_BUFF.id} />, <SpellLink id={SPELLS.RESONATING_ARROW_DAMAGE_AND_BUFF.id}/> and <SpellLink id={SPELLS.FLAYERS_MARK.id} /> to the timeline to better show when these covenant specifics buffs were active.</>, Putro),
   change(date(2021, 11, 13), 'Implemented an initial version of the APL checker module.', Putro),
   change(date(2021, 11, 11), <> Added a simple analyzer to track damage gained from <SpellLink id={SPELLS.FRAGMENTS_OF_THE_ELDER_ANTLERS.id}/>. </>, Putro),
   change(date(2021, 11, 5), <> Correct an issue where the increased damage attributed to <SpellLink id={SPELLS.BRUTAL_PROJECTILES_CONDUIT.id}/> was ramping up too fast. </>, Putro),

--- a/analysis/huntermarksmanship/src/modules/Buffs.tsx
+++ b/analysis/huntermarksmanship/src/modules/Buffs.tsx
@@ -34,6 +34,25 @@ class Buffs extends CoreBuffs {
         spellId: Object.keys(BLOODLUST_BUFFS).map((item) => Number(item)),
         timelineHighlight: true,
       },
+      /** Covenant Specific */
+      //Venthyr
+      {
+        spellId: SPELLS.FLAYERS_MARK.id,
+        timelineHighlight: true,
+        triggeredBySpellId: SPELLS.FLAYED_SHOT.id,
+      },
+      //Night Fae
+      {
+        spellId: SPELLS.WILD_SPIRITS_BUFF.id,
+        timelineHighlight: true,
+        triggeredBySpellId: SPELLS.WILD_SPIRITS.id,
+      },
+      //Kyrian
+      {
+        spellId: SPELLS.RESONATING_ARROW_DAMAGE_AND_BUFF.id,
+        timelineHighlight: true,
+        triggeredBySpellId: SPELLS.RESONATING_ARROW.id,
+      },
     ];
   }
 }

--- a/analysis/huntersurvival/src/CHANGELOG.tsx
+++ b/analysis/huntersurvival/src/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { Adoraci, Putro, Kartarn } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2021, 12, 12), <> Added <SpellLink id={SPELLS.WILD_SPIRITS_BUFF.id} />, <SpellLink id={SPELLS.RESONATING_ARROW_DAMAGE_AND_BUFF.id}/> and <SpellLink id={SPELLS.FLAYERS_MARK.id} /> to the timeline to better show when these covenant specifics buffs were active.</>, Putro),
   change(date(2021, 11, 11), <> Added a simple analyzer to track damage gained from <SpellLink id={SPELLS.FRAGMENTS_OF_THE_ELDER_ANTLERS.id}/>. </>, Putro),
   change(date(2021, 4, 3), 'Verified 9.0.5 patch changes and bumped support to 9.0.5', Adoraci),
   change(date(2021, 3, 6), 'Fixed suggestion for wasted regenerated focus.', Kartarn),

--- a/analysis/huntersurvival/src/modules/Buffs.tsx
+++ b/analysis/huntersurvival/src/modules/Buffs.tsx
@@ -19,6 +19,25 @@ class Buffs extends CoreBuffs {
         spellId: Object.keys(BLOODLUST_BUFFS).map((item) => Number(item)),
         timelineHighlight: true,
       },
+      /** Covenant Specific */
+      //Venthyr
+      {
+        spellId: SPELLS.FLAYERS_MARK.id,
+        timelineHighlight: true,
+        triggeredBySpellId: SPELLS.FLAYED_SHOT.id,
+      },
+      //Night Fae
+      {
+        spellId: SPELLS.WILD_SPIRITS_BUFF.id,
+        timelineHighlight: true,
+        triggeredBySpellId: SPELLS.WILD_SPIRITS.id,
+      },
+      //Kyrian
+      {
+        spellId: SPELLS.RESONATING_ARROW_DAMAGE_AND_BUFF.id,
+        timelineHighlight: true,
+        triggeredBySpellId: SPELLS.RESONATING_ARROW.id,
+      },
     ];
   }
 }

--- a/src/common/SPELLS/shadowlands/covenants/hunter.ts
+++ b/src/common/SPELLS/shadowlands/covenants/hunter.ts
@@ -10,7 +10,7 @@ const covenants = {
     name: 'Resonating Arrow',
     icon: 'ability_bastion_hunter',
   },
-  RESONATING_ARROW_DAMAGE: {
+  RESONATING_ARROW_DAMAGE_AND_BUFF: {
     id: 308495,
     name: 'Resonating Arrow',
     icon: 'ability_bastion_hunter',

--- a/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
+++ b/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
@@ -48,7 +48,7 @@ const spells: number[] = [
   SPELLS.DIRE_BEAST_SUMMON.id, //A secondary cast event from Dire Beast talent
   SPELLS.WILD_MARK.id, //The debuff applied from enemies inside Wild Spirits
   SPELLS.RESONATING_ARROW_DEBUFF.id, //The debuff applied to mobs inside Kyrian hunter ability resonating arrow area of effect
-  SPELLS.RESONATING_ARROW_DAMAGE.id, //The damage event from the Kyrian Hunter Ability also has a cast event tied to it which we shouldn't track
+  SPELLS.RESONATING_ARROW_DAMAGE_AND_BUFF.id, //The damage event from the Kyrian Hunter Ability also has a cast event tied to it which we shouldn't track
   //endregion
 
   //region Mage


### PR DESCRIPTION
Makes it easier to analyze logs when you can see these buffs on the timeline