### PR TITLE
[EncounterStats] Direct Link to comparison logs & a covenant filter toggle

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -54,6 +54,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2021, 12, 13), 'Added a filter by covenant toggle to the Similiar Kill Times module under the Character tab.', Putro),
   change(date(2021, 12, 4), 'Fixed an issue with stat tracking in Mythic+ dungeons. Mythic+ still not officially supported, but at least it shouldn\'t crash', emallson),
   change(date(2021, 11, 30), 'Fixed Spiritual Mana Potion not being tracked issue.', Jeff),
   change(date(2021, 11, 27), 'Internal dependency updates.', emallson),

--- a/src/interface/report/Results/EncounterStats.js
+++ b/src/interface/report/Results/EncounterStats.js
@@ -7,6 +7,7 @@ import SPELLS from 'common/SPELLS';
 import ROLES from 'game/ROLES';
 import { getCovenantById } from 'game/shadowlands/COVENANTS';
 import SOULBINDS from 'game/shadowlands/SOULBINDS';
+import SPECS from 'game/SPECS';
 import { ItemLink } from 'interface';
 import ActivityIndicator from 'interface/ActivityIndicator';
 import Icon from 'interface/Icon';
@@ -15,6 +16,8 @@ import SpellLink from 'interface/SpellLink';
 import Combatant from 'parser/core/Combatant';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
+
+import { FilterByCovenantToggle } from './FilterByCovenantToggle';
 
 /**
  * Show statistics (talents and trinkets) for the current boss, specID and difficulty
@@ -54,6 +57,7 @@ class EncounterStats extends PureComponent {
       spells: SPELLS,
       loaded: false,
       message: 'Loading statistics...',
+      filterByCovenant: false,
     };
 
     this.load = this.load.bind(this);
@@ -178,7 +182,13 @@ class EncounterStats extends PureComponent {
             }
           }
 
-          if (!rank.name.match(combatantName)) {
+          if (
+            !rank.name.match(combatantName) &&
+            (!this.state.filterByCovenant ||
+              (this.state.filterByCovenant &&
+                rank.covenantID === this.props.combatant._combatantInfo.covenantID))
+          ) {
+            console.log(this.props.combatant._combatantInfo);
             if (
               this.props.duration > rank.duration * (1 - this.durationVariancePercentage) &&
               this.props.duration < rank.duration * (1 + this.durationVariancePercentage)
@@ -348,7 +358,7 @@ class EncounterStats extends PureComponent {
         <div className="row" style={{ opacity: '.8', fontSize: '.9em', lineHeight: '2em' }}>
           <div className="flex-column col-md-6">
             <a
-              href={`https://wowanalyzer.com/report/${log.reportID}/${log.fightID}/`}
+              href={`https://wowanalyzer.com/report/${log.reportID}/${log.fightID}/${log.name}`}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -366,6 +376,8 @@ class EncounterStats extends PureComponent {
           </div>
           <div className="col-md-6">
             {formatThousands(log.total)} {this.metric}
+            <br />
+            {getCovenantById(log.covenantID).name}
           </div>
         </div>
       </div>
@@ -422,7 +434,8 @@ class EncounterStats extends PureComponent {
         {this.state.similiarKillTimes.length} of the top {this.amountOfParses}{' '}
         {this.state.similiarKillTimes.length > 1 ? 'logs' : 'log'} that{' '}
         {this.state.similiarKillTimes.length > 1 ? 'are' : 'is'} closest to your kill-time within{' '}
-        {formatPercentage(this.durationVariancePercentage, 0)}% variance.
+        {formatPercentage(this.durationVariancePercentage, 0)}% variance
+        {this.state.filterByCovenant ? ' using the same covenant as you' : ''}.
         {this.state.similiarKillTimes.map((log) => this.singleLog(log.rank))}
       </div>
     );
@@ -438,8 +451,9 @@ class EncounterStats extends PureComponent {
         {this.state.closestKillTimes.length > 1 ? 'These are' : 'This is'}{' '}
         {this.state.closestKillTimes.length} of the top {this.amountOfParses}{' '}
         {this.state.closestKillTimes.length > 1 ? 'logs' : 'log'} that{' '}
-        {this.state.closestKillTimes.length > 1 ? 'are' : 'is'} closest to your kill-time. Large
-        differences won't be good for comparing.
+        {this.state.closestKillTimes.length > 1 ? 'are' : 'is'} closest to your kill-time
+        {this.state.filterByCovenant ? ' using the same covenant as you' : ''}. Large differences
+        won't be good for comparing.
         {this.state.closestKillTimes.map((log) => this.singleLog(log.rank))}
       </div>
     );
@@ -560,8 +574,15 @@ class EncounterStats extends PureComponent {
                 <div className="row" style={{ marginBottom: '1em' }}>
                   <div className="col-md-12">
                     <h2>
-                      {this.state.similiarKillTimes.length > 0 ? 'Similiar' : 'Closest'} kill times
+                      {this.state.similiarKillTimes.length > 0 ? 'Similiar' : 'Closest'} kill times{' '}
                     </h2>
+                    <FilterByCovenantToggle
+                      initialValue={this.state.filterByCovenant}
+                      onChange={(val) => {
+                        this.setState({ filterByCovenant: val });
+                        this.load();
+                      }}
+                    />
                   </div>
                 </div>
                 <div className="row" style={{ marginBottom: '2em' }}>
@@ -570,6 +591,14 @@ class EncounterStats extends PureComponent {
                   this.state.closestKillTimes.length > 0
                     ? this.closestLogs
                     : ''}
+                  {this.state.similiarKillTimes.length === 0 &&
+                    this.state.closestKillTimes.length === 0 &&
+                    this.state.filterByCovenant &&
+                    `No ${SPECS[this.props.combatant._combatantInfo.specID].specName} ${
+                      SPECS[this.props.combatant._combatantInfo.specID].className
+                    }s in the top ${this.amountOfParses} logs were ${
+                      getCovenantById(this.props.combatant._combatantInfo.covenantID).name
+                    }.`}
                 </div>
               </div>
             </div>

--- a/src/interface/report/Results/EncounterStats.js
+++ b/src/interface/report/Results/EncounterStats.js
@@ -188,7 +188,6 @@ class EncounterStats extends PureComponent {
               (this.state.filterByCovenant &&
                 rank.covenantID === this.props.combatant._combatantInfo.covenantID))
           ) {
-            console.log(this.props.combatant._combatantInfo);
             if (
               this.props.duration > rank.duration * (1 - this.durationVariancePercentage) &&
               this.props.duration < rank.duration * (1 + this.durationVariancePercentage)

--- a/src/interface/report/Results/FilterByCovenantToggle.tsx
+++ b/src/interface/report/Results/FilterByCovenantToggle.tsx
@@ -1,0 +1,26 @@
+import { Trans } from '@lingui/macro';
+import { HTMLAttributes } from 'react';
+import Toggle from 'react-toggle';
+
+interface Props extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
+  initialValue: boolean;
+  onChange: (newValue: boolean) => void;
+}
+
+export const FilterByCovenantToggle = ({ initialValue, onChange, ...props }: Props) => (
+  <div className="toggle-control" {...props}>
+    <Toggle
+      defaultChecked={initialValue}
+      icons={false}
+      onChange={(event) => onChange(event.target.checked)}
+      id="filter-for-covenant-toggle"
+    />
+    <label htmlFor="filter-for-covenant-toggle">
+      <small>
+        <Trans id="interface.report.results.character.killTimes.filterByCovenant">
+          Filter similiar kill times by your covenant
+        </Trans>
+      </small>
+    </label>
+  </div>
+);


### PR DESCRIPTION
The similiar kill times should link directly to the persons log you click on and not just to the report, and added a filter by covenant toggle