### PR TITLE
[Hunter] Add Rylak vs Antler module

### DIFF
--- a/analysis/hunter/src/constants.ts
+++ b/analysis/hunter/src/constants.ts
@@ -11,7 +11,7 @@ export const MIN_GCD = 750;
 export const MAX_GCD = 1500;
 /** MS Buffers */
 //A 100ms buffer is standard to use since logs aren't precise to the millisecond for events
-export const MS_BUFFER = 100;
+export const MS_BUFFER_100 = 100;
 //Whenever we ned to use 1 second buffers
 export const ONE_SECOND_IN_MS = 1000;
 //Whenever we need to use a buffer that is slightly above that of the maximum GCD
@@ -112,6 +112,10 @@ export const RESONATING_ARROW_CRIT_INCREASE = 0.3;
 export const WILD_MARK_DAMAGE_AMP = 0.05;
 //Wild Spirits lasts 15 seconds baseline
 export const WILD_SPIRITS_BASELINE_DURATION = 15000;
+
+/** Fragment of the Elder Antlers */
+//When Wild Spirits hits fewer than 5 targets, there is a 100% chance to cause Wild Spirits damage a second time.
+export const MAX_TARGETS_FOR_ANTLERS_TRIGGER = 4;
 //endregion
 
 //region Venthyr

--- a/analysis/hunter/src/items/FragmentsOfTheElderAntlers.tsx
+++ b/analysis/hunter/src/items/FragmentsOfTheElderAntlers.tsx
@@ -10,7 +10,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
-import { MS_BUFFER } from '../constants';
+import { MS_BUFFER_100 } from '../constants';
 
 /**
  * When Wild Spirits hits fewer than 5 targets, there is a 100% chance to cause Wild Spirits damage a second time.
@@ -40,17 +40,18 @@ class FragmentsOfTheElderAntlers extends Analyzer {
   }
 
   onWildSpiritsDamage(event: DamageEvent) {
-    if (event.timestamp > this.lastWSTimestamp + MS_BUFFER) {
+    if (event.timestamp > this.lastWSTimestamp + MS_BUFFER_100) {
       this.targetsHit = [];
     }
     this.lastWSTimestamp = event.timestamp;
     const targetHit = encodeTargetString(event.targetID, event.targetInstance);
-    if (!this.targetsHit.includes(targetHit)) {
-      this.wildSpiritsHits += 1;
-      this.targetsHit.push(targetHit);
-    } else {
+    this.targetsHit.push(targetHit);
+    const isAntlersHit = this.targetsHit.filter((x) => x === targetHit).length % 2 === 0;
+    if (isAntlersHit) {
       this.antlerHits += 1;
       this.damage += event.amount + (event.absorb || 0);
+    } else {
+      this.wildSpiritsHits += 1;
     }
   }
 

--- a/analysis/hunter/src/talents/AMurderOfCrows.tsx
+++ b/analysis/hunter/src/talents/AMurderOfCrows.tsx
@@ -9,7 +9,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
-import { AMOC_BASE_DURATION, AMOC_TICK_RATE, MS_BUFFER } from '../constants';
+import { AMOC_BASE_DURATION, AMOC_TICK_RATE, MS_BUFFER_100 } from '../constants';
 
 /**
  * Summons a flock of crows to attack your target over the next 15 sec. If the target dies while under attack, A Murder of Crows' cooldown is reset.
@@ -74,7 +74,7 @@ class AMurderOfCrows extends Analyzer {
       this.applicationTimestamp &&
       event.timestamp < this.crowsEndingTimestamp &&
       // Checks to see if more than 1 second has passed since last tick
-      event.timestamp > this.lastDamageTick + AMOC_TICK_RATE + MS_BUFFER
+      event.timestamp > this.lastDamageTick + AMOC_TICK_RATE + MS_BUFFER_100
     ) {
       // If more than 1 second has passed and less than the duration has elapsed, we can assume that crows has been reset, and thus we reset the CD.
       this.spellUsable.endCooldown(SPELLS.A_MURDER_OF_CROWS_TALENT.id, false, event.timestamp);

--- a/analysis/hunterbeastmastery/src/CHANGELOG.tsx
+++ b/analysis/hunterbeastmastery/src/CHANGELOG.tsx
@@ -5,6 +5,8 @@ import { Adoraci, Putro, Kartarn } from 'CONTRIBUTORS';
 import { ItemLink, SpellLink } from 'interface';
 
 export default [
+  change(date(2021, 12, 26), <> Correct an error that was attributing too much damage to <SpellLink id={SPELLS.FRAGMENTS_OF_THE_ELDER_ANTLERS.id}/> on rare occasions. </>, Putro),
+  change(date(2021, 12, 26), <> Added a module that aims to simulate either <SpellLink id={SPELLS.RYLAKSTALKERS_PIERCING_FANGS_EFFECT.id} /> or <SpellLink id={SPELLS.FRAGMENTS_OF_THE_ELDER_ANTLERS.id} />, to provide a better comparison between the two for different bosses or dungeons, as it is a highly debated topic. </>, Putro),
   change(date(2021, 12, 12), <> Added <SpellLink id={SPELLS.WILD_SPIRITS_BUFF.id} />, <SpellLink id={SPELLS.RESONATING_ARROW_DAMAGE_AND_BUFF.id}/> and <SpellLink id={SPELLS.FLAYERS_MARK.id} /> to the timeline to better show when these covenant specifics buffs were active.</>, Putro),
   change(date(2021, 11, 11), <> Added a simple analyzer to track damage gained from <SpellLink id={SPELLS.FRAGMENTS_OF_THE_ELDER_ANTLERS.id}/>. </>, Putro),
   change(date(2021, 11, 11), <> Correct an issue where damage done by <SpellLink id={SPELLS.BEAST_CLEAVE_DAMAGE.id}/> wasn't correctly attributed to <SpellLink id={SPELLS.RYLAKSTALKERS_PIERCING_FANGS_EFFECT.id}/>.  </>, Putro),

--- a/analysis/hunterbeastmastery/src/CombatLogParser.ts
+++ b/analysis/hunterbeastmastery/src/CombatLogParser.ts
@@ -70,6 +70,7 @@ import SpittingCobra from './modules/talents/SpittingCobra';
 import Stampede from './modules/talents/Stampede';
 import Stomp from './modules/talents/Stomp';
 import ThrillOfTheHunt from './modules/talents/ThrillOfTheHunt';
+import AntlerVersusRylak from './modules/theorycraft/AntlerVersusRylak';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -161,6 +162,9 @@ class CombatLogParser extends CoreCombatLogParser {
     flamewakersCobraSting: FlamewakersCobraSting,
     qaplaEredunWarOrder: QaplaEredunWarOrder,
     rylakstalkersPiercingFangs: RylakstalkersPiercingFangs,
+
+    //Theorycraft
+    antlerVersusRylak: AntlerVersusRylak,
   };
 
   static suggestions = [...CoreCombatLogParser.suggestions, AplCheck()];

--- a/analysis/hunterbeastmastery/src/integrationTests/beastMasteryIntegrationTests.test.ts.snap
+++ b/analysis/hunterbeastmastery/src/integrationTests/beastMasteryIntegrationTests.test.ts.snap
@@ -10029,6 +10029,104 @@ exports[`Beast Mastery Hunter integration test: Single Target AnimalCompanion ma
 </div>
 `;
 
+exports[`Beast Mastery Hunter integration test: Single Target AntlerVersusRylak matches the statistic snapshot 1`] = `
+<div
+  className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
+>
+  <div
+    category="THEORYCRAFT"
+    className="panel statistic flexible "
+    position={0}
+    style={
+      Object {
+        "zIndex": 1,
+      }
+    }
+  >
+    <div
+      className="panel-body"
+    >
+      <div
+        className="pad boring-text "
+      >
+        <label>
+          <a
+            className="spell-link-text"
+            href="http://wowhead.com/spell=356375"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <img
+              alt="Fragments of the Elder Antlers"
+              className="icon game "
+              src="//render-us.worldofwarcraft.com/icons/56/trade_archaeology_antleredcloakclasp.jpg"
+            />
+          </a>
+           Antlers &
+           
+          <a
+            className="spell-link-text"
+            href="http://wowhead.com/spell=336844"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <img
+              alt="Rylakstalker's Piercing Fangs"
+              className="icon game "
+              src="//render-us.worldofwarcraft.com/icons/56/inv_misc_monsterfang_02.jpg"
+            />
+          </a>
+           Rylaks comparison
+        </label>
+        <div
+          className="value"
+        >
+          <strong>
+            !!EXPERIMENTAL!!
+          </strong>
+        </div>
+      </div>
+      <div
+        className="row"
+      >
+        <div
+          className="col-xs-12"
+        />
+      </div>
+      <div
+        className="statistic-expansion-button-holster"
+      >
+        <button
+          className="btn btn-primary"
+          onClick={[Function]}
+        >
+          <span
+            className="glyphicon glyphicon-chevron-down"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      className="detail-corner"
+      data-place="top"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onTouchStart={[Function]}
+    >
+      <svg
+        className="icon"
+        viewBox="0 0 100 100"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M58.9,82.9h7v12.9H34.1V82.9h7.1V45.5h-0.6c-3.6,0-6.4-2.9-6.4-6.4c0-3.6,2.9-6.4,6.4-6.4h0.6h17.4h0.3V82.9z M49,25.8  c6,0,10.8-4.8,10.8-10.8C59.8,9,55,4.2,49,4.2S38.2,9,38.2,15C38.2,21,43,25.8,49,25.8z"
+        />
+      </svg>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Beast Mastery Hunter integration test: Single Target AspectOfTheWild matches the statistic snapshot 1`] = `
 <div
   className="col-lg-3 col-md-4 col-sm-6 col-xs-12"

--- a/analysis/hunterbeastmastery/src/modules/items/RylakstalkersPiercingFangs.tsx
+++ b/analysis/hunterbeastmastery/src/modules/items/RylakstalkersPiercingFangs.tsx
@@ -9,7 +9,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
-import { MS_BUFFER } from '@wowanalyzer/hunter';
+import { MS_BUFFER_100 } from '@wowanalyzer/hunter';
 import { RYLAKSTALKERS_PIERCING_FANGS_CRIT_DMG_INCREASE } from '@wowanalyzer/hunter-beastmastery/src/constants';
 
 /**
@@ -39,12 +39,13 @@ class RylakstalkersPiercingFangs extends Analyzer {
     }
     if (
       event.ability.guid === SPELLS.BEAST_CLEAVE_DAMAGE.id &&
-      event.timestamp < this.lastCritTimestamp + MS_BUFFER
+      event.timestamp < this.lastCritTimestamp + MS_BUFFER_100
     ) {
       this.damage += calculateEffectiveDamage(
         event,
         RYLAKSTALKERS_PIERCING_FANGS_CRIT_DMG_INCREASE,
       );
+      return;
     }
     if (event.hitType !== HIT_TYPES.CRIT) {
       return;

--- a/analysis/hunterbeastmastery/src/modules/spells/BeastCleave.tsx
+++ b/analysis/hunterbeastmastery/src/modules/spells/BeastCleave.tsx
@@ -16,7 +16,7 @@ import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
-import { MS_BUFFER } from '@wowanalyzer/hunter';
+import { MS_BUFFER_100 } from '@wowanalyzer/hunter';
 
 /**
  * After you Multi-Shot, your pet's melee attacks also strike all other nearby enemy targets for 100% as much for the next 4 sec.
@@ -74,7 +74,7 @@ class BeastCleave extends Analyzer {
   }
 
   onApplyBuff(event: ApplyBuffEvent) {
-    if (this.timestamp + MS_BUFFER > event.timestamp) {
+    if (this.timestamp + MS_BUFFER_100 > event.timestamp) {
       return;
     }
     this.casts += 1;
@@ -84,7 +84,7 @@ class BeastCleave extends Analyzer {
   }
 
   onRemoveBuff(event: RemoveBuffEvent) {
-    if (this.timestamp + MS_BUFFER > event.timestamp) {
+    if (this.timestamp + MS_BUFFER_100 > event.timestamp) {
       return;
     }
     this.checkAmountOfHits();
@@ -93,7 +93,7 @@ class BeastCleave extends Analyzer {
   }
 
   onRefreshBuff(event: RefreshBuffEvent) {
-    if (this.timestamp + MS_BUFFER > event.timestamp) {
+    if (this.timestamp + MS_BUFFER_100 > event.timestamp) {
       return;
     }
     this.casts += 1;

--- a/analysis/hunterbeastmastery/src/modules/theorycraft/AntlerVersusRylak.tsx
+++ b/analysis/hunterbeastmastery/src/modules/theorycraft/AntlerVersusRylak.tsx
@@ -1,0 +1,169 @@
+import { formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import HIT_TYPES from 'game/HIT_TYPES';
+import COVENANTS from 'game/shadowlands/COVENANTS';
+import { SpellIcon } from 'interface';
+import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
+import Events, { DamageEvent } from 'parser/core/Events';
+import { encodeTargetString } from 'parser/shared/modules/EnemyInstances';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import BoringValueText from 'parser/ui/BoringValueText';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+
+import { MAX_TARGETS_FOR_ANTLERS_TRIGGER, MS_BUFFER_100 } from '@wowanalyzer/hunter';
+
+import { RYLAKSTALKERS_PIERCING_FANGS_CRIT_DMG_INCREASE } from '../../constants';
+
+class AntlerVersusRylak extends Analyzer {
+  potentialAntlerDamage = 0;
+  potentialAntlerHits = 0;
+  wildSpiritHits = 0;
+  lastWSTimestamp = 0;
+  targetsHit: string[] = [];
+  recentWSDamage = 0;
+
+  potentialRylakDamage = 0;
+  lastCritTimestamp = 0;
+
+  //Because we're comparing a generic legendary (rylak) to antlers that only works when you're NightFae
+  //we require the rylak user to also be NF before showing this module
+  hasRylakAndIsNF =
+    this.selectedCombatant.hasLegendaryByBonusID(
+      SPELLS.RYLAKSTALKERS_PIERCING_FANGS_EFFECT.bonusID,
+    ) && this.selectedCombatant.hasCovenant(COVENANTS.NIGHT_FAE.id);
+
+  hasAntlers = this.selectedCombatant.hasLegendaryByBonusID(
+    SPELLS.FRAGMENTS_OF_THE_ELDER_ANTLERS.bonusID,
+  );
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.hasRylakAndIsNF || this.hasAntlers;
+
+    if (!this.active) {
+      return;
+    }
+
+    !this.hasRylakAndIsNF &&
+      this.addEventListener(Events.damage.by(SELECTED_PLAYER_PET), this.onPetDamage);
+    !this.hasAntlers &&
+      this.addEventListener(
+        Events.damage.by(SELECTED_PLAYER).spell(SPELLS.WILD_SPIRITS_DAMAGE_AOE),
+        this.onWildSpiritsDamage,
+      );
+    !this.hasAntlers && this.addEventListener(Events.fightend.by(SELECTED_PLAYER), this.onFightEnd);
+  }
+
+  calculateTheoreticEffectiveDamage(event: DamageEvent, increase: number): number {
+    const raw = (event.amount || 0) + (event.absorbed || 0);
+
+    return raw;
+  }
+
+  onPetDamage(event: DamageEvent) {
+    if (!this.selectedCombatant.hasBuff(SPELLS.BESTIAL_WRATH.id)) {
+      return;
+    }
+    if (
+      event.ability.guid === SPELLS.BEAST_CLEAVE_DAMAGE.id &&
+      event.timestamp < this.lastCritTimestamp + MS_BUFFER_100
+    ) {
+      this.potentialRylakDamage +=
+        ((event.amount || 0) + (event.absorbed || 0)) *
+        RYLAKSTALKERS_PIERCING_FANGS_CRIT_DMG_INCREASE;
+      return;
+    }
+    if (event.hitType !== HIT_TYPES.CRIT) {
+      return;
+    }
+
+    this.lastCritTimestamp = event.timestamp;
+    this.potentialRylakDamage +=
+      ((event.amount || 0) + (event.absorbed || 0)) *
+      RYLAKSTALKERS_PIERCING_FANGS_CRIT_DMG_INCREASE;
+  }
+
+  attributePotentialAntlers = (recentHits: number, recentDamage: number) => {
+    this.potentialAntlerHits += recentHits;
+    this.potentialAntlerDamage += recentDamage;
+  };
+
+  onWildSpiritsDamage(event: DamageEvent) {
+    if (event.timestamp > this.lastWSTimestamp + MS_BUFFER_100) {
+      const uniqueTargets = Array.from(new Set(this.targetsHit));
+      if (uniqueTargets.length <= MAX_TARGETS_FOR_ANTLERS_TRIGGER) {
+        this.attributePotentialAntlers(this.targetsHit.length, this.recentWSDamage);
+      }
+      //Reset for new Wild Spirit triggers
+      this.recentWSDamage = 0;
+      this.targetsHit = [];
+    }
+    this.lastWSTimestamp = event.timestamp;
+    const targetHit = encodeTargetString(event.targetID, event.targetInstance);
+    this.targetsHit.push(targetHit);
+    this.recentWSDamage += event.amount + (event.absorb || 0);
+    this.wildSpiritHits += 1;
+  }
+
+  onFightEnd() {
+    const uniqueTargets = Array.from(new Set(this.targetsHit));
+    if (uniqueTargets.length < MAX_TARGETS_FOR_ANTLERS_TRIGGER) {
+      this.attributePotentialAntlers(this.targetsHit.length, this.recentWSDamage);
+    }
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE()}
+        size="flexible"
+        category={STATISTIC_CATEGORY.THEORYCRAFT}
+        dropdown={
+          <div className="pad">
+            {!this.hasAntlers && (
+              <BoringSpellValueText spellId={SPELLS.FRAGMENTS_OF_THE_ELDER_ANTLERS.id}>
+                <ItemDamageDone amount={this.potentialAntlerDamage} />
+                <br />
+                {formatPercentage((1 / this.wildSpiritHits) * this.potentialAntlerHits)}%{' '}
+                <small>
+                  added <SpellIcon id={SPELLS.WILD_SPIRITS.id} /> hits
+                </small>
+              </BoringSpellValueText>
+            )}
+            {!this.hasRylakAndIsNF && (
+              <BoringSpellValueText spellId={SPELLS.RYLAKSTALKERS_PIERCING_FANGS_EFFECT.id}>
+                <ItemDamageDone amount={this.potentialRylakDamage} />
+              </BoringSpellValueText>
+            )}
+          </div>
+        }
+        tooltip={
+          <>
+            This is an infographic attempting to compare the two legendaries, Ryalk Stalker's
+            Piercing Fangs and Fragments of the Elder Antlers, against each other to provide a
+            better understanding where each legendary performs better than the other as it is an oft
+            discussed topic.
+          </>
+        }
+      >
+        <BoringValueText
+          label={
+            <>
+              <SpellIcon id={SPELLS.FRAGMENTS_OF_THE_ELDER_ANTLERS.id} /> Antlers &{' '}
+              <SpellIcon id={SPELLS.RYLAKSTALKERS_PIERCING_FANGS_EFFECT.id} /> Rylaks comparison
+            </>
+          }
+        >
+          <>
+            <strong>!!EXPERIMENTAL!!</strong>
+          </>
+        </BoringValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default AntlerVersusRylak;

--- a/analysis/hunterbeastmastery/src/modules/theorycraft/AntlerVersusRylak.tsx
+++ b/analysis/hunterbeastmastery/src/modules/theorycraft/AntlerVersusRylak.tsx
@@ -57,12 +57,6 @@ class AntlerVersusRylak extends Analyzer {
     !this.hasAntlers && this.addEventListener(Events.fightend.by(SELECTED_PLAYER), this.onFightEnd);
   }
 
-  calculateTheoreticEffectiveDamage(event: DamageEvent, increase: number): number {
-    const raw = (event.amount || 0) + (event.absorbed || 0);
-
-    return raw;
-  }
-
   onPetDamage(event: DamageEvent) {
     if (!this.selectedCombatant.hasBuff(SPELLS.BESTIAL_WRATH.id)) {
       return;

--- a/analysis/huntermarksmanship/src/modules/spells/RapidFire.tsx
+++ b/analysis/huntermarksmanship/src/modules/spells/RapidFire.tsx
@@ -14,7 +14,7 @@ import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
-import { MS_BUFFER, NESINGWARY_FOCUS_GAIN_MULTIPLIER } from '@wowanalyzer/hunter';
+import { MS_BUFFER_100, NESINGWARY_FOCUS_GAIN_MULTIPLIER } from '@wowanalyzer/hunter';
 import {
   RAPID_FIRE_FOCUS_PER_TICK,
   TRUESHOT_RAPID_FIRE_RECHARGE_INCREASE,
@@ -140,7 +140,7 @@ class RapidFire extends Analyzer {
      *  However if Nesingwary is also active - the focus amount goes up to 3 because 1.5 * 2 = 3, and that works despite 1.5 focus not working.. In this case we can attribute 2 focus to Nesingwary, since that isn't possible otherwise and only 1 to Trueshot (if it was in excess of the regular 7 energize events).
      *
      */
-    if (hasTrueshot && this.lastFocusTickTimestamp + MS_BUFFER / 2 > event.timestamp) {
+    if (hasTrueshot && this.lastFocusTickTimestamp + MS_BUFFER_100 / 2 > event.timestamp) {
       this.additionalFocusFromTrueshot += event.resourceChange - event.waste;
       this.possibleAdditionalFocusFromTrueshot += RAPID_FIRE_FOCUS_PER_TICK;
     }

--- a/analysis/huntermarksmanship/src/modules/spells/Trueshot.tsx
+++ b/analysis/huntermarksmanship/src/modules/spells/Trueshot.tsx
@@ -9,7 +9,7 @@ import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
-import { HUNTER_BASE_FOCUS_MAX, MS_BUFFER } from '@wowanalyzer/hunter';
+import { HUNTER_BASE_FOCUS_MAX, MS_BUFFER_100 } from '@wowanalyzer/hunter';
 import { TRUESHOT_FOCUS_INCREASE } from '@wowanalyzer/hunter-marksmanship/src/constants';
 import MarksmanshipFocusCapTracker from '@wowanalyzer/hunter-marksmanship/src/modules/resources/MarksmanshipFocusCapTracker';
 import RapidFire from '@wowanalyzer/hunter-marksmanship/src/modules/spells/RapidFire';
@@ -106,7 +106,7 @@ class Trueshot extends Analyzer {
     if (!resource) {
       return;
     }
-    if (event.timestamp >= this.lastCheckedPassiveRegenTimestamp + MS_BUFFER) {
+    if (event.timestamp >= this.lastCheckedPassiveRegenTimestamp + MS_BUFFER_100) {
       const timeSinceLastCheck = event.timestamp - this.lastCheckedPassiveRegenTimestamp;
       const possibleTSGainSinceLastCheck =
         timeSinceLastCheck *

--- a/analysis/huntermarksmanship/src/modules/talents/CallingTheShots.tsx
+++ b/analysis/huntermarksmanship/src/modules/talents/CallingTheShots.tsx
@@ -11,7 +11,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
-import { MS_BUFFER } from '@wowanalyzer/hunter';
+import { MS_BUFFER_100 } from '@wowanalyzer/hunter';
 import { CTS_CDR_MS } from '@wowanalyzer/hunter-marksmanship/src/constants';
 
 /**
@@ -68,7 +68,7 @@ class CallingTheShots extends Analyzer {
   }
 
   onCTSPotentialProc(event: DamageEvent) {
-    if (event.timestamp > this.reductionTimestamp + MS_BUFFER) {
+    if (event.timestamp > this.reductionTimestamp + MS_BUFFER_100) {
       if (this.spellUsable.isOnCooldown(SPELLS.TRUESHOT.id)) {
         if (this.spellUsable.cooldownRemaining(SPELLS.TRUESHOT.id) < CTS_CDR_MS) {
           const effectiveReductionMs = this.spellUsable.reduceCooldown(

--- a/analysis/huntermarksmanship/src/modules/talents/LethalShots.tsx
+++ b/analysis/huntermarksmanship/src/modules/talents/LethalShots.tsx
@@ -10,7 +10,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
-import { MS_BUFFER } from '@wowanalyzer/hunter';
+import { MS_BUFFER_100 } from '@wowanalyzer/hunter';
 import {
   ARCANE_SHOT_MAX_TRAVEL_TIME,
   LETHAL_SHOTS_CHANCE,
@@ -80,7 +80,7 @@ class LethalShots extends Analyzer {
     if (this.shotInFlight > event.timestamp + ARCANE_SHOT_MAX_TRAVEL_TIME) {
       this.shotInFlight = null;
     }
-    if (event.timestamp < this.lastDamageEvent + MS_BUFFER) {
+    if (event.timestamp < this.lastDamageEvent + MS_BUFFER_100) {
       return;
     }
     this.procChances += 1;

--- a/analysis/huntersurvival/src/modules/spells/WildfireBomb.tsx
+++ b/analysis/huntersurvival/src/modules/spells/WildfireBomb.tsx
@@ -13,7 +13,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
-import { MS_BUFFER } from '@wowanalyzer/hunter';
+import { MS_BUFFER_100 } from '@wowanalyzer/hunter';
 import { WILDFIRE_BOMB_LEEWAY_BUFFER } from '@wowanalyzer/hunter-survival/src/constants';
 
 /**
@@ -109,7 +109,7 @@ class WildfireBomb extends Analyzer {
     }
     if (
       enemy.hasBuff(SPELLS.WILDFIRE_BOMB_DOT.id) &&
-      event.timestamp > this.lastRefresh + MS_BUFFER
+      event.timestamp > this.lastRefresh + MS_BUFFER_100
     ) {
       this.badRefreshes += 1;
       this.lastRefresh = event.timestamp;

--- a/analysis/huntersurvival/src/modules/talents/BirdOfPrey.tsx
+++ b/analysis/huntersurvival/src/modules/talents/BirdOfPrey.tsx
@@ -11,7 +11,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
-import { MS_BUFFER } from '@wowanalyzer/hunter';
+import { MS_BUFFER_100 } from '@wowanalyzer/hunter';
 import {
   BOP_CA_EXTENSION_PER_CAST,
   RAPTOR_MONGOOSE_VARIANTS,
@@ -90,7 +90,7 @@ class BirdOfPrey extends Analyzer {
     if (
       !this.aoeChecked &&
       this.timestampAoE > 0 &&
-      event.timestamp > this.timestampAoE + MS_BUFFER
+      event.timestamp > this.timestampAoE + MS_BUFFER_100
     ) {
       this.aoeCheck();
     }

--- a/analysis/huntersurvival/src/modules/talents/Bloodseeker.tsx
+++ b/analysis/huntersurvival/src/modules/talents/Bloodseeker.tsx
@@ -8,7 +8,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
-import { MS_BUFFER } from '@wowanalyzer/hunter';
+import { MS_BUFFER_100 } from '@wowanalyzer/hunter';
 import { BLOODSEEKER_ATTACK_SPEED_GAIN } from '@wowanalyzer/hunter-survival/src/constants';
 
 /**
@@ -53,7 +53,7 @@ class Bloodseeker extends Analyzer {
   }
 
   onPetDamage(event: DamageEvent) {
-    if (event.timestamp > this.kcCastTimestamp + MS_BUFFER) {
+    if (event.timestamp > this.kcCastTimestamp + MS_BUFFER_100) {
       this.damage += event.amount + (event.absorbed || 0);
     }
   }

--- a/analysis/huntersurvival/src/modules/talents/TipOfTheSpear.tsx
+++ b/analysis/huntersurvival/src/modules/talents/TipOfTheSpear.tsx
@@ -8,7 +8,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
-import { MS_BUFFER } from '@wowanalyzer/hunter';
+import { MS_BUFFER_100 } from '@wowanalyzer/hunter';
 import {
   RAPTOR_MONGOOSE_VARIANTS,
   TIP_DAMAGE_INCREASE,
@@ -60,7 +60,7 @@ class TipOfTheSpear extends Analyzer {
   onKillCommandCast(event: CastEvent) {
     if (
       this.stacks === TIP_MAX_STACKS &&
-      event.timestamp > this.lastApplicationTimestamp + MS_BUFFER
+      event.timestamp > this.lastApplicationTimestamp + MS_BUFFER_100
     ) {
       this.wastedStacks += 1;
     }

--- a/analysis/huntersurvival/src/modules/talents/WildfireInfusion/PheromoneBomb.tsx
+++ b/analysis/huntersurvival/src/modules/talents/WildfireInfusion/PheromoneBomb.tsx
@@ -8,7 +8,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
-import { MS_BUFFER } from '@wowanalyzer/hunter';
+import { MS_BUFFER_100 } from '@wowanalyzer/hunter';
 import { SV_KILL_COMMAND_FOCUS_GAIN } from '@wowanalyzer/hunter-survival/src/constants';
 
 /**
@@ -64,7 +64,7 @@ class PheromoneBomb extends Analyzer {
     if (!enemy || !enemy.hasBuff(SPELLS.PHEROMONE_BOMB_WFI_DOT.id)) {
       return;
     }
-    if (event.timestamp < this.kcCastTimestamp + MS_BUFFER) {
+    if (event.timestamp < this.kcCastTimestamp + MS_BUFFER_100) {
       this.focusGained += SV_KILL_COMMAND_FOCUS_GAIN;
       this.resets += 1;
     }


### PR DESCRIPTION
Creates a module that 'simulates' the impact of a different legendary equipped than your current one. 

This module is simply comparing Rylak and Antlers as it is a hotly debated topic.

It only "simulates" the unused legendary, resulting in this view: 

![image](https://user-images.githubusercontent.com/29204244/147408619-c4958a99-f74c-4cab-9d19-56dad778ba9c.png)
 