### PR TITLE
[Core] Add enemy pet names to the event tab

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -54,6 +54,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2021, 12, 31), 'Added names to event tab for mobs classified as enemy pets', Putro),
   change(date(2021, 12, 27), 'Removed unnecessary build step.', emallson),
   change(date(2021, 12, 14), 'Fixed translations.', emallson),
   change(date(2021, 12, 13), 'Refactored handling of player channel detection', Sref),

--- a/src/interface/EventsTab.js
+++ b/src/interface/EventsTab.js
@@ -137,6 +137,10 @@ class EventsTab extends Component {
     if (enemy) {
       return enemy;
     }
+    const enemyPet = this.props.parser.report.enemyPets.find((enemyPet) => enemyPet.id === id);
+    if (enemyPet) {
+      return enemyPet;
+    }
     const pet = this.props.parser.playerPets.find((pet) => pet.id === id);
     if (pet) {
       return pet;


### PR DESCRIPTION
# Before
![image](https://user-images.githubusercontent.com/29204244/147834044-684c397c-af78-4bd2-9fde-8bf0aba24407.png)

# After
![image](https://user-images.githubusercontent.com/29204244/147834064-deabc5b0-478e-4021-ad94-a22846431f83.png)
