### PR TITLE
Draught of Deep Focus updates

### DIFF
--- a/analysis/druid/src/shadowlands/DraughtOfDeepFocus.tsx
+++ b/analysis/druid/src/shadowlands/DraughtOfDeepFocus.tsx
@@ -55,6 +55,12 @@ class DraughtOfDeepFocus extends Analyzer {
       Events.damage.by(SELECTED_PLAYER).spell(BUFFED_DOTS),
       this.onDdfDotDamage,
     );
+
+    // special case - Rake direct damage has a different ID from the debuff, but is still buffed
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.RAKE),
+      this.onRakeDirectDamage,
+    );
   }
 
   onDdfDotApply(event: ApplyDebuffEvent) {
@@ -69,6 +75,18 @@ class DraughtOfDeepFocus extends Analyzer {
     const dot: DdfDot = this.ddfDotsOnById[event.ability.guid];
 
     if (dot.targetsOn === 1) {
+      dot.buffedAmount += calculateEffectiveDamage(event, DDF_BOOST);
+      dot.buffedTicks += 1;
+    }
+    dot.totalTicks += 1;
+  }
+
+  onRakeDirectDamage(event: DamageEvent) {
+    // special case - we look up the DoT from the debuff's ID (which is different from damage ID)
+    const dot: DdfDot = this.ddfDotsOnById[SPELLS.RAKE_BLEED.id];
+
+    // direct damage hits before debuff application, but is still buffed
+    if (dot.targetsOn <= 1) {
       dot.buffedAmount += calculateEffectiveDamage(event, DDF_BOOST);
       dot.buffedTicks += 1;
     }

--- a/analysis/druid/src/shadowlands/DraughtOfDeepFocus.tsx
+++ b/analysis/druid/src/shadowlands/DraughtOfDeepFocus.tsx
@@ -11,7 +11,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
-const BUFFED_DOTS = [SPELLS.RIP, SPELLS.RAKE_BLEED, SPELLS.MOONFIRE_FERAL]; // TODO also caster moonfire?
+const BUFFED_DOTS = [SPELLS.RIP, SPELLS.RAKE_BLEED, SPELLS.MOONFIRE_FERAL, SPELLS.MOONFIRE_DEBUFF];
 
 const DDF_BOOST = 0.4;
 

--- a/analysis/druidferal/src/CHANGELOG.tsx
+++ b/analysis/druidferal/src/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { Adoraci, Abelito75, Zeboot, LeoZhekov, Tora, Xcessiv, Tiboonn, Sref } f
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2022, 1, 16), <>Fixed a bug where <SpellLink id={SPELLS.RAKE.id}/> direct damage wasn't being counted by the <SpellLink id={SPELLS.DRAUGHT_OF_DEEP_FOCUS.id}/> statistic.</>, Sref),
   change(date(2021, 12, 3), <>Fixed a bug where <SpellLink id={SPELLS.BALANCE_AFFINITY_TALENT_SHARED.id}/> was giving Moonkin form a cooldown.</>, Sref),
   change(date(2021, 11, 12), <>Updated to indicate this spec is supported for patch 9.1.5</>, Sref),
   change(date(2021, 8, 4), <>Combined AoE spell statistic box and suggestions into a single unified element with visual improvements.</>, Sref),

--- a/analysis/druidferal/src/CombatLogParser.js
+++ b/analysis/druidferal/src/CombatLogParser.js
@@ -23,7 +23,7 @@ import Shadowmeld from './modules/racials/Shadowmeld';
 import AdaptiveSwarmFeral from './modules/shadowlands/AdaptiveSwarmFeral';
 import ApexPredatorsCraving from './modules/shadowlands/ApexPredatorsCraving';
 import ConvokeSpiritsFeral from './modules/shadowlands/ConvokeSpiritsFeral';
-import DraughtOfDeepFocus from './modules/shadowlands/DraughtOfDeepFocus';
+import DraughtOfDeepFocus from '@wowanalyzer/druid/src/shadowlands/DraughtOfDeepFocus';
 import Frenzyband from './modules/shadowlands/Frenzyband';
 import FerociousBite from './modules/spells/FerociousBite';
 import HitCountAoE from './modules/spells/HitCountAoE';

--- a/analysis/druidferal/src/CombatLogParser.js
+++ b/analysis/druidferal/src/CombatLogParser.js
@@ -2,6 +2,7 @@ import CoreCombatLogParser from 'parser/core/CombatLogParser';
 
 import { SinfulHysteria } from '@wowanalyzer/druid';
 import ActiveDruidForm from '@wowanalyzer/druid/src/core/ActiveDruidForm';
+import DraughtOfDeepFocus from '@wowanalyzer/druid/src/shadowlands/DraughtOfDeepFocus';
 
 import Abilities from './modules/Abilities';
 import RakeUptimeAndSnapshots from './modules/bleeds/RakeUptimeAndSnapshots';
@@ -23,7 +24,6 @@ import Shadowmeld from './modules/racials/Shadowmeld';
 import AdaptiveSwarmFeral from './modules/shadowlands/AdaptiveSwarmFeral';
 import ApexPredatorsCraving from './modules/shadowlands/ApexPredatorsCraving';
 import ConvokeSpiritsFeral from './modules/shadowlands/ConvokeSpiritsFeral';
-import DraughtOfDeepFocus from '@wowanalyzer/druid/src/shadowlands/DraughtOfDeepFocus';
 import Frenzyband from './modules/shadowlands/Frenzyband';
 import FerociousBite from './modules/spells/FerociousBite';
 import HitCountAoE from './modules/spells/HitCountAoE';

--- a/analysis/druidrestoration/src/CHANGELOG.tsx
+++ b/analysis/druidrestoration/src/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { Adoraci, Yajinni, Abelito75, Zeboot, LeoZhekov, Putro, Vexxra, Tiboonn,
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2022, 1, 16), <>Added a damage statistic for <SpellLink id={SPELLS.DRAUGHT_OF_DEEP_FOCUS.id}/> for Resto players who are a healer, but...</>, Sref),
   change(date(2021, 11, 13), <>Updated wording of <SpellLink id={SPELLS.REGROWTH.id}/> statistic and made it more permissive of triage casts.</>, Sref),
   change(date(2021, 11, 12), <>Updated to indicate this spec is supported for patch 9.1.5</>, Sref),
   change(date(2021, 11, 11), <>Removed healer stat weights in favor of QElive.</>, Abelito75),

--- a/analysis/druidrestoration/src/CombatLogParser.ts
+++ b/analysis/druidrestoration/src/CombatLogParser.ts
@@ -7,6 +7,7 @@ import ManaUsageChart from 'parser/shared/modules/resources/mana/ManaUsageChart'
 
 import { SinfulHysteria } from '@wowanalyzer/druid';
 import ActiveDruidForm from '@wowanalyzer/druid/src/core/ActiveDruidForm';
+import DraughtOfDeepFocus from '@wowanalyzer/druid/src/shadowlands/DraughtOfDeepFocus';
 
 import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from './constants';
 import Abilities from './modules/Abilities';
@@ -31,7 +32,6 @@ import StatWeights from './modules/features/StatWeights';
 import WildGrowth from './modules/features/WildGrowth';
 import AdaptiveArmorFragment from './modules/shadowlands/conduits/AdaptiveArmorFragment';
 import ConfluxOfElementsResto from './modules/shadowlands/conduits/ConfluxOfElementsResto';
-import DraughtOfDeepFocus from '@wowanalyzer/druid/src/shadowlands/DraughtOfDeepFocus';
 import EvolvedSwarmResto from './modules/shadowlands/conduits/EvolvedSwarmResto';
 import FieldOfBlossomsResto from './modules/shadowlands/conduits/FieldOfBlossomsResto';
 import FlashOfClarity from './modules/shadowlands/conduits/FlashOfClarity';

--- a/analysis/druidrestoration/src/CombatLogParser.ts
+++ b/analysis/druidrestoration/src/CombatLogParser.ts
@@ -31,6 +31,7 @@ import StatWeights from './modules/features/StatWeights';
 import WildGrowth from './modules/features/WildGrowth';
 import AdaptiveArmorFragment from './modules/shadowlands/conduits/AdaptiveArmorFragment';
 import ConfluxOfElementsResto from './modules/shadowlands/conduits/ConfluxOfElementsResto';
+import DraughtOfDeepFocus from '@wowanalyzer/druid/src/shadowlands/DraughtOfDeepFocus';
 import EvolvedSwarmResto from './modules/shadowlands/conduits/EvolvedSwarmResto';
 import FieldOfBlossomsResto from './modules/shadowlands/conduits/FieldOfBlossomsResto';
 import FlashOfClarity from './modules/shadowlands/conduits/FlashOfClarity';
@@ -138,6 +139,7 @@ class CombatLogParser extends CoreCombatLogParser {
     memoryoftheMotherTree: MemoryoftheMotherTree,
     verdantInfusion: VerdantInfusion,
     lycarasFleetingGlimpse: LycarasFleetingGlimpseResto,
+    draughtOfDeepFocus: DraughtOfDeepFocus,
   };
 }
 


### PR DESCRIPTION
Activated Draught of Deep Focus module, by request of more DPS focused Resto Druids. Updated Draught stat to correctly handle that it also buffs Rake direct damage.