### PR TITLE
Version bumps from dependabot

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -54,6 +54,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2022, 1, 22), 'Version bumps', emallson),
   change(date(2022, 1, 18), 'Enable ad test system.', emallson),
   change(date(2022, 1, 8), 'Synchronize package versions across all classes/specs.', emallson),
   change(date(2021, 12, 31), 'Begin Sonar Scan fixes.', Jeff),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4414,7 +4414,6 @@ common-tags@^1.8.0:
 
 "common@link:src/common":
   version "0.0.0"
-  uid ""
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -7007,7 +7006,6 @@ fuzzaldrin@^2.1.0:
 
 "game@link:src/game":
   version "0.0.0"
-  uid ""
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -7842,7 +7840,6 @@ inquirer@^7.3.3:
 
 "interface@link:src/interface":
   version "0.0.0"
-  uid ""
 
 internal-ip@^4.3.0:
   version "4.3.0"
@@ -10044,9 +10041,9 @@ nan@^2.12.1, nan@^2.13.2:
   integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
 nanoid@^3.1.30:
-  version "3.1.30"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
-  integrity sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
+  integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -10751,7 +10748,6 @@ parse5@6.0.1, parse5@^6.0.1:
 
 "parser@link:src/parser":
   version "0.0.0"
-  uid ""
 
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
@@ -12349,7 +12345,7 @@ react-vega@^7.4.1:
     fast-deep-equal "^3.1.1"
     vega-embed "^6.5.1"
 
-react-virtualized@^9.21.1, react-virtualized@^9.22.3:
+react-virtualized@^9.22.3:
   version "9.22.3"
   resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.3.tgz#f430f16beb0a42db420dbd4d340403c0de334421"
   integrity sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==
@@ -12360,15 +12356,6 @@ react-virtualized@^9.21.1, react-virtualized@^9.22.3:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-lifecycles-compat "^3.0.4"
-
-react@^16.13.1:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 react@^17.0.2:
   version "17.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4414,7 +4414,6 @@ common-tags@^1.8.0:
 
 "common@link:src/common":
   version "0.0.0"
-  uid ""
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -6813,9 +6812,9 @@ flush-write-stream@^1.0.0:
     readable-stream "^2.3.6"
 
 follow-redirects@^1.0.0:
-  version "1.14.5"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
-  integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
+  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -7007,7 +7006,6 @@ fuzzaldrin@^2.1.0:
 
 "game@link:src/game":
   version "0.0.0"
-  uid ""
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -7842,7 +7840,6 @@ inquirer@^7.3.3:
 
 "interface@link:src/interface":
   version "0.0.0"
-  uid ""
 
 internal-ip@^4.3.0:
   version "4.3.0"
@@ -10751,7 +10748,6 @@ parse5@6.0.1, parse5@^6.0.1:
 
 "parser@link:src/parser":
   version "0.0.0"
-  uid ""
 
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
@@ -12349,7 +12345,7 @@ react-vega@^7.4.1:
     fast-deep-equal "^3.1.1"
     vega-embed "^6.5.1"
 
-react-virtualized@^9.21.1, react-virtualized@^9.22.3:
+react-virtualized@^9.22.3:
   version "9.22.3"
   resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.3.tgz#f430f16beb0a42db420dbd4d340403c0de334421"
   integrity sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==
@@ -12360,15 +12356,6 @@ react-virtualized@^9.21.1, react-virtualized@^9.22.3:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-lifecycles-compat "^3.0.4"
-
-react@^16.13.1:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 react@^17.0.2:
   version "17.0.2"


### PR DESCRIPTION
I looked at the vega iterator.js thing and react-vega hasn't bumped versions yet and overriding in yarn.lock didn't seem to remove the error so I opted to do nothing