### PR TITLE
Fixed a bug which would sometimes cause Kindred Focus to overcount when partnered with a healer

### DIFF
--- a/analysis/druidrestoration/src/CHANGELOG.tsx
+++ b/analysis/druidrestoration/src/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { Adoraci, Yajinni, Abelito75, Zeboot, LeoZhekov, Putro, Vexxra, Tiboonn,
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2022, 1, 29), <>Fixed a bug where <SpellLink id={SPELLS.KINDRED_SPIRITS.id} /> statistic would occasionally overcount when linked to another healer</>, Sref),
   change(date(2022, 1, 17), <>Fixed many issues with the Mana Efficiency chart, and added explanation text.</>, Sref),
   change(date(2022, 1, 16), <>Added a damage statistic for <SpellLink id={SPELLS.DRAUGHT_OF_DEEP_FOCUS.id}/> for Resto players who are a healer, but...</>, Sref),
   change(date(2021, 11, 13), <>Updated wording of <SpellLink id={SPELLS.REGROWTH.id}/> statistic and made it more permissive of triage casts.</>, Sref),

--- a/analysis/druidrestoration/src/modules/shadowlands/covenants/KindredSpiritsResto.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/covenants/KindredSpiritsResto.tsx
@@ -92,7 +92,7 @@ class KindredSpiritsResto extends Analyzer {
       this.onProtectionDamage,
     );
     this.addEventListener(
-      Events.heal.to(this.selectedCombatant.id).spell(SPELLS.KINDRED_FOCUS_HEAL),
+      Events.heal.to(SELECTED_PLAYER).spell(SPELLS.KINDRED_FOCUS_HEAL),
       this.onFocusHealPlayer,
     );
   }


### PR DESCRIPTION
`SELECTED_COMBATANT` and `this.selectedCombatant.id` are apparently not the same thing, and using the wrong one caused the changed "to" filter to occasionally fail to apply