### PR TITLE
Adding a module to better suggest Bladestorm use for Arms warriors

### DIFF
--- a/analysis/warriorarms/src/CHANGELOG.tsx
+++ b/analysis/warriorarms/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Abelito75, carglass, Carrottopp, Otthopsy, bandit } from 'CONTRIBUTORS'
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2022, 2, 5), <>Added a module for better suggestions of <SpellLink id={SPELLS.BLADESTORM.id} icon /> usage.</>, Carrottopp),
   change(date(2021, 11, 8), <>Fixed SpellLink issue for Signet Of Tormented Kings.</>, Abelito75),
   change(date(2021, 10, 29), <>Initial Arms APL added. (Still WIP)</>, bandit),
   change(date(2021, 10, 10), <>Fixed <SpellLink id={SPELLS.OVERPOWER.id} icon /> cooldown resets with Tactician</>, bandit),

--- a/analysis/warriorarms/src/CombatLogParser.tsx
+++ b/analysis/warriorarms/src/CombatLogParser.tsx
@@ -4,6 +4,7 @@ import Channeling from 'parser/shared/normalizers/Channeling';
 import Abilities from './modules/Abilities';
 import Checklist from './modules/checklist/Module';
 import AplCheck from './modules/core/AplCheck';
+import Bladestorm from './modules/core/Bladestorm';
 import DeepWoundsUptime from './modules/core/Dots/DeepWoundsUptime';
 import DotUptime from './modules/core/Dots/DotUptime';
 import RendUptime from './modules/core/Dots/RendUptime';
@@ -63,6 +64,7 @@ class CombatLogParser extends CoreCombatLogParser {
     overpower: Overpower,
     slam: Slam,
     sweepingStrikes: SweepingStrikes,
+    bladestorm: Bladestorm,
 
     // Execute range
     executeRange: ExecuteRange,

--- a/analysis/warriorarms/src/modules/Abilities.js
+++ b/analysis/warriorarms/src/modules/Abilities.js
@@ -138,7 +138,7 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         castEfficiency: {
-          suggestion: true,
+          suggestion: false, // Suggestions are in Bladestorm.js
           recommendedEfficiency: 0.7,
         },
         enabled: !combatant.hasTalent(SPELLS.RAVAGER_TALENT_ARMS.id),

--- a/analysis/warriorarms/src/modules/checklist/Module.tsx
+++ b/analysis/warriorarms/src/modules/checklist/Module.tsx
@@ -4,6 +4,7 @@ import Combatants from 'parser/shared/modules/Combatants';
 import BaseChecklist from 'parser/shared/modules/features/Checklist/Module';
 
 import { apl, check as aplCheck } from '../core/AplCheck';
+import Bladestorm from '../core/Bladestorm';
 import DeepWoundsUptime from '../core/Dots/DeepWoundsUptime';
 import RendUptime from '../core/Dots/RendUptime';
 import MortalStrike from '../core/Execute/MortalStrike';
@@ -21,6 +22,7 @@ class Checklist extends BaseChecklist {
     rendUptime: RendUptime,
     mortalStrike: MortalStrike,
     sweepingStrikes: SweepingStrikes,
+    bladestorm: Bladestorm,
   };
   protected combatants!: Combatants;
   protected castEfficiency!: CastEfficiency;
@@ -30,6 +32,7 @@ class Checklist extends BaseChecklist {
   protected rendUptime!: RendUptime;
   protected mortalStrike!: MortalStrike;
   protected sweepingStrikes!: SweepingStrikes;
+  protected bladestorm!: Bladestorm;
 
   render() {
     const checkResults = aplCheck(this.owner.eventHistory, this.owner.info);
@@ -49,6 +52,7 @@ class Checklist extends BaseChecklist {
           notEnoughMortalStrike: this.mortalStrike.notEnoughMortalStrikeThresholds,
           tooMuchMortalStrike: this.mortalStrike.tooMuchMortalStrikeThresholds,
           badSweepingStrikes: this.sweepingStrikes.suggestionThresholds,
+          badBladestorms: this.bladestorm.suggestionThresholds,
         }}
       />
     );

--- a/analysis/warriorarms/src/modules/core/Bladestorm.tsx
+++ b/analysis/warriorarms/src/modules/core/Bladestorm.tsx
@@ -1,0 +1,199 @@
+import { t } from '@lingui/macro';
+import { formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import { SpellLink } from 'interface';
+import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
+import Events, { EndChannelEvent, CastEvent, DamageEvent } from 'parser/core/Events';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
+
+import SpellUsable from '../features/SpellUsable';
+import ExecuteRangeTracker from './Execute/ExecuteRange';
+
+interface CurrentCast {
+  event: CastEvent | null;
+  enemiesHit: string[];
+  text: string | null;
+}
+
+const RAGE_STARVED_AMOUNT = 50;
+const AVATAR_FORGIVENESS = 4000; // Milliseconds
+const WARBREAKER_FOREGIVENESS = 4000;
+const SWEEPING_STRIKES_FORGIVENESS = 2000;
+
+class Bladestorm extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+    executeRange: ExecuteRangeTracker,
+  };
+
+  protected spellUsable!: SpellUsable;
+  protected executeRange!: ExecuteRangeTracker;
+
+  badCasts: number = 0;
+  totalCasts: number = 0;
+
+  currentCast: CurrentCast = {
+    event: null,
+    enemiesHit: [],
+    text: null,
+  };
+
+  constructor(options: Options) {
+    super(options);
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.BLADESTORM),
+      this._onBladestormCast,
+    );
+
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.BLADESTORM_DAMAGE),
+      this._onBladestormDamage,
+    );
+
+    this.addEventListener(
+      Events.EndChannel.by(SELECTED_PLAYER).spell(SPELLS.BLADESTORM),
+      this._onBladestormEnd,
+    );
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.badCasts / this.totalCasts,
+      isGreaterThan: {
+        minor: 0,
+        average: 0.2,
+        major: 0.5,
+      },
+      style: ThresholdStyle.PERCENTAGE,
+    };
+  }
+
+  _onBladestormCast(event: CastEvent) {
+    this.totalCasts += 1;
+
+    // Set the current cast
+    this.currentCast = {
+      event: event,
+      enemiesHit: [],
+      text: null,
+    };
+  }
+
+  _onBladestormDamage(event: DamageEvent) {
+    const enemy = `${event.targetID} ${event.targetInstance || 0}`;
+
+    if (!this.currentCast.enemiesHit.includes(enemy)) {
+      this.currentCast.enemiesHit.push(enemy);
+    }
+  }
+
+  _onBladestormEnd(event: EndChannelEvent) {
+    this.wasValidBladestorm();
+  }
+
+  wasValidBladestorm() {
+    if (this.currentCast.enemiesHit.length > 3) {
+      this.checkMultiTargetRequirements();
+    } else {
+      this.checkSingleTargetRequirements();
+    }
+  }
+
+  checkSingleTargetRequirements() {
+    if (!this.currentCast.event) {
+      return;
+    }
+
+    // Bladestorm should only be used when rage starved
+    const rage =
+      this.currentCast.event.classResources &&
+      this.currentCast.event.classResources.find((e) => e.type === RESOURCE_TYPES.RAGE.id);
+    if (rage && rage.amount > RAGE_STARVED_AMOUNT) {
+      this.badCasts += 1;
+      this.currentCast.event.meta = this.currentCast.event.meta || {};
+      this.currentCast.event.meta.isInefficientCast = true;
+      this.currentCast.event.meta.inefficientCastReason =
+        'Bladestorm was used while you still had rage to use on higher priority abilities during a single target situation';
+    }
+  }
+
+  checkMultiTargetRequirements() {
+    if (this.currentCast.event === null) {
+      return;
+    }
+
+    let badCast = false;
+
+    // Bladestorm shouldn't overlap with Sweeping Strikes
+    const sweepingStrikesBuff = this.selectedCombatant.getBuff(
+      SPELLS.SWEEPING_STRIKES.id,
+      this.currentCast.event.timestamp,
+    );
+    if (sweepingStrikesBuff && sweepingStrikesBuff.end) {
+      badCast =
+        sweepingStrikesBuff.end - this.currentCast.event.timestamp < SWEEPING_STRIKES_FORGIVENESS;
+    }
+
+    if (badCast && !this.currentCast.text) {
+      this.currentCast.text =
+        'Since Bladestorm does not benefit from Sweeping Strikes, you should not have both up at the same time during mutli-target situations.';
+    }
+
+    // Bladestorm should be aligned with Warbreaker
+    badCast =
+      badCast ||
+      (this.selectedCombatant.hasTalent(SPELLS.WARBREAKER_TALENT.id) &&
+        this.spellUsable.isAvailable(SPELLS.WARBREAKER_TALENT.id)) ||
+      this.spellUsable.cooldownRemaining(SPELLS.WARBREAKER_TALENT.id) < WARBREAKER_FOREGIVENESS;
+
+    if (badCast && !this.currentCast.text) {
+      this.currentCast.text =
+        'Bladestorm was used while you had Warbreaker available or about to become available in a multi-target situation.';
+    }
+
+    // Bladestorm should be aligned with Avatar
+    badCast =
+      badCast ||
+      (this.selectedCombatant.hasTalent(SPELLS.AVATAR_TALENT.id) &&
+        this.spellUsable.isAvailable(SPELLS.AVATAR_TALENT.id)) ||
+      this.spellUsable.cooldownRemaining(SPELLS.AVATAR_TALENT.id) < AVATAR_FORGIVENESS;
+
+    if (badCast && !this.currentCast.text) {
+      this.currentCast.text =
+        'Bladestorm was used while you had Avatar available or about to become available in a multi-target situation.';
+    }
+
+    if (badCast) {
+      this.badCasts += 1;
+      this.currentCast.event.meta = this.currentCast.event.meta || {};
+      this.currentCast.event.meta.isInefficientCast = true;
+      this.currentCast.event.meta.inefficientCastReason = this.currentCast.text;
+    }
+  }
+
+  suggestions(when: When) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
+      suggest(
+        <>
+          Do not cast <SpellLink id={SPELLS.BLADESTORM.id} /> when you have rage to spend during
+          single target fights. In multi-target situations, Bladestorm should not overlap with{' '}
+          <SpellLink id={SPELLS.SWEEPING_STRIKES.id} /> and you should try to align Bladestorm with
+          cooldowns such as <SpellLink id={SPELLS.AVATAR_TALENT.id} /> and{' '}
+          <SpellLink id={SPELLS.WARBREAKER_TALENT.id} />
+        </>,
+      )
+        .icon(SPELLS.BLADESTORM.icon)
+        .actual(
+          t({
+            id: 'warrior.arms.suggestions.bladestorm.efficiency',
+            message: `Bladestorm was used incorrectly  ${formatPercentage(actual)}% of the time.`,
+          }),
+        )
+        .recommended(`${formatPercentage(recommended)}% is recommended`),
+    );
+  }
+}
+
+export default Bladestorm;


### PR DESCRIPTION
Changing the Bladestorm suggestion for Arms warrior by removing the spell from castEfficieny tracker and creating a new module.

Bladestorm rules for Arms are generally as follow:

1. Single Target - Only used if you are rage starved
2. Multi Target - Dont overlap with Sweeping Strikes, Bladestorm doesnt benefit from sweeping strikes
3. Multi Target - Align with big cooldowns such Warbreaker/Avatar

I did this by hooking into 3 events, the cast, on damage and the end of the channel. 

Cast event sets the current event.

On damage will check unqiue Target hits and holds their IDs in an array.

End of the channel triggers the event analysis by checking if this was a single target situation or multi target situation by getting the amount of unique enemies hit. Then checks the rules stated above  to mark this as a bad cast and provide rationale in the event reasoning if nessicary.

Added some "forgiveness" to the cooldown alignment and sweeping strikes falling.

Example Log: 
Single Target
report/h2pfRkbBtGmw8cVg/2-Normal+Shriekwing+-+Kill+(5:49)/Carrottopp/standard/timeline
Multi Target
report/WRqkNnxQV13A2vbg/45-Mythic+Sylvanas+Windrunner+-+Kill+(13:51)/2-Hellring/standard