### PR TITLE
fix: Only run import/no-extraneous-dependencies in CI

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 const CHECK_CODESTYLE = process.env.CODE_STYLE === 'true';
+const CI = Boolean(process.env.CI);
 
 module.exports = {
   extends: ['@emico/eslint-config', 'plugin:react/jsx-runtime'],
@@ -25,6 +26,7 @@ module.exports = {
         },
       },
     ],
+    'import/no-extraneous-dependencies': [CI ? 'warn' : 'off'],
   },
   overrides: [
     // Disable some rules for .js files to not have to update all old files in one go


### PR DESCRIPTION
This speeds up local ESLint by about 40%. I don't think [this rule](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md) gets triggered very often, since it only checks for missing dependencies and spec devs rarely change dependencies. Still I think it's a good rule to keep enabled in CI, since it does ensure the required dependencies are listed and avoids issues in the future when an unrelated dependency gets updated.