### PR TITLE
Add a few more Arms warrior rotational cooldowns to suggestions and APL

### DIFF
--- a/analysis/warriorarms/src/CHANGELOG.tsx
+++ b/analysis/warriorarms/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Abelito75, carglass, Carrottopp, Otthopsy, bandit } from 'CONTRIBUTORS'
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2022, 2, 26), <>Added more abilites into rotational cooldown tracker.</>, Carrottopp),
   change(date(2022, 2, 7), <>Updated <SpellLink id={SPELLS.REND_TALENT.id} icon /> and <SpellLink id={SPELLS.MASTERY_DEEP_WOUNDS_DEBUFF.id} icon /> dot refresh modules.</>, Carrottopp),
   change(date(2022, 2, 5), <>Added a module for better suggestions of <SpellLink id={SPELLS.BLADESTORM.id} icon /> usage.</>, Carrottopp),
   change(date(2021, 11, 8), <>Fixed SpellLink issue for Signet Of Tormented Kings.</>, Abelito75),

--- a/analysis/warriorarms/src/modules/Abilities.js
+++ b/analysis/warriorarms/src/modules/Abilities.js
@@ -168,6 +168,10 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.7,
+        },
         enabled: combatant.hasCovenant(COVENANTS.NIGHT_FAE.id),
       },
       {
@@ -176,6 +180,10 @@ class Abilities extends CoreAbilities {
         cooldown: 60,
         gcd: {
           base: 1500,
+        },
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.7,
         },
         enabled: combatant.hasCovenant(COVENANTS.KYRIAN.id),
       },
@@ -227,6 +235,10 @@ class Abilities extends CoreAbilities {
         cooldown: 180,
         gcd: {
           base: 1500,
+        },
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.7,
         },
         enabled: combatant.hasCovenant(COVENANTS.NECROLORD.id),
       },

--- a/analysis/warriorarms/src/modules/checklist/Component.tsx
+++ b/analysis/warriorarms/src/modules/checklist/Component.tsx
@@ -38,6 +38,9 @@ const ArmsWarriorChecklist = ({
           SPELLS.WARBREAKER_TALENT,
           SPELLS.AVATAR_TALENT,
           SPELLS.DEADLY_CALM_TALENT,
+          SPELLS.ANCIENT_AFTERSHOCK,
+          SPELLS.SPEAR_OF_BASTION,
+          SPELLS.CONQUERORS_BANNER,
         ]}
         description={
           <div style={{ color: 'white' }}>


### PR DESCRIPTION
Minor update to include Spears of Bastion, Ancient Aftershock and Conquerors Banner into the APL rotational check and suggestions.

Sample Report (Check under Rotational Efficiency): 
report/ANwRk34FcG9YhpVW/10-Mythic+Guardian+of+the+First+Ones+-+Kill+(5:12)/Xévikan/standard/overview

Also, Arms warrior didn't have any game play updates in Patch 9.2 (besides a new legendary that just adds passive buffs). Is there anything I need to do to have this class be "Supported" now? I think the analyzer is good to go.

I might start taking a look at the Fury updates in 9.2.