### PR TITLE
 fixed bug in Rough Outlaw module stating incorrect high value buffs.

### DIFF
--- a/analysis/rogueoutlaw/src/CHANGELOG.js
+++ b/analysis/rogueoutlaw/src/CHANGELOG.js
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
-import { Putro, Tyndi, Zeboot, Canotsa, Hordehobbs, Akai, ab } from 'CONTRIBUTORS';
+import { Putro, Tyndi, Zeboot, Canotsa, Hordehobbs, Akai, ab, bhawkins6177 } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2022, 3, 1), <>Fixed bug where <SpellLink id={SPELLS.ROLL_THE_BONES.id} /> had incorrect high value buffs listed.</>, bhawkins6177),
   change(date(2021, 8, 12), <>Added <SpellLink id={SPELLS.FLAGELLATION.id} /> suggestion in overview section. Fixed Flagellation damage in statistics section.</>, Akai),
   change(date(2021, 5, 2), <>Fix bug in Sepsis analyzer in mythic plus analysis.</>, Hordehobbs),
   change(date(2021, 5, 1), <>Added analyzer for <SpellLink id={SPELLS.CELERITY.id} /> legendary. </>, Hordehobbs),

--- a/analysis/rogueoutlaw/src/modules/features/Checklist/Component.tsx
+++ b/analysis/rogueoutlaw/src/modules/features/Checklist/Component.tsx
@@ -43,10 +43,9 @@ const OutlawRogueChecklist = ({
             Efficient use of <SpellLink id={SPELLS.ROLL_THE_BONES.id} /> is a critical part of
             Outlaw rogue. You should try to keep as high of an uptime as possible with any of the
             buffs, and reroll efficiently to get higher value buffs.{' '}
-            <SpellLink id={SPELLS.RUTHLESS_PRECISION.id} /> and{' '}
-            <SpellLink id={SPELLS.GRAND_MELEE.id} /> are the highest value of the six possible
-            buffs. You should reroll until you get one of them, or any two other buffs. Any high
-            value roll should be kept for the full duration.
+            <SpellLink id={SPELLS.TRUE_BEARING.id} /> and <SpellLink id={SPELLS.BROADSIDE.id} /> are
+            the highest value of the six possible buffs. You should reroll until you get one of
+            them, or any two other buffs. Any high value roll should be kept for the full duration.
           </>
         }
       >


### PR DESCRIPTION
This is a bug fix for issue ##4570.

I changed the high value buffs listed as Ruthless Precision and Grand Melee to True Bearing and Broadside. 