### PR TITLE
Fix Fire Elemental cast requirement in Ele Shaman checklist

### DIFF
--- a/analysis/shamanelemental/src/CHANGELOG.tsx
+++ b/analysis/shamanelemental/src/CHANGELOG.tsx
@@ -1,8 +1,11 @@
 import { change, date } from 'common/changelog';
-import { HawkCorrigan, Putro, Zeboot, Maximaw, Zea } from 'CONTRIBUTORS';
+import SPELLS from 'common/SPELLS';
+import { HawkCorrigan, Putro, Zeboot, Maximaw, Zea, emallson } from 'CONTRIBUTORS';
+import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2022, 3, 4), <>Fixed issue with <SpellLink id={SPELLS.FIRE_ELEMENTAL.id} /> on the checklist when <SpellLink id={SPELLS.STORM_ELEMENTAL_TALENT.id} /> is selected.</>, emallson),
   change(date(2021, 6, 29), <>Bumped to 9.1, moved from partial.</>, Zea),
   change(date(2021, 6, 14), <>Added additional LIGHTNING_SHIELD_ELEMENTAL spellid. Fixed Stormkeeper damage calculation.</>, Zea),
   change(date(2021, 6, 11), <>Bumped version to 9.0.5, left as partial support. Also added spellID for elemental blast.</>, Zea),

--- a/analysis/shamanelemental/src/integrationTests/example.test.ts.snap
+++ b/analysis/shamanelemental/src/integrationTests/example.test.ts.snap
@@ -4713,8 +4713,8 @@ exports[`Elemental Shaman integration test: Hungering Destroyer log matches the 
               className="perf-bar"
               style={
                 Object {
-                  "backgroundColor": "#4ec04e",
-                  "width": "100%",
+                  "backgroundColor": "#a6c34c",
+                  "width": "75.88355642337345%",
                 }
               }
             />
@@ -4785,6 +4785,79 @@ exports[`Elemental Shaman integration test: Hungering Destroyer log matches the 
         <div
           className="row"
         >
+          <div
+            className="col-md-6"
+          >
+            <div
+              className="flex"
+            >
+              <div
+                className="flex-main"
+              >
+                <a
+                  className="spell-link-text"
+                  href="https://wowhead.com/spell=198067"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <img
+                    alt=""
+                    className="icon game "
+                    src="//render-us.worldofwarcraft.com/icons/56/spell_fire_elemental_totem.jpg"
+                  />
+                   
+                  Fire Elemental
+                </a>
+              </div>
+              <div
+                className="flex-sub content-middle text-muted"
+                style={
+                  Object {
+                    "marginLeft": 5,
+                    "marginRight": 10,
+                    "minWidth": 55,
+                  }
+                }
+              >
+                <div
+                  className="text-right"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                >
+                   
+                  9.02%
+                   
+                   
+                </div>
+              </div>
+              <div
+                className="flex-sub content-middle"
+                style={
+                  Object {
+                    "width": 50,
+                  }
+                }
+              >
+                <div
+                  className="performance-bar-container"
+                >
+                  <div
+                    className="performance-bar small"
+                    style={
+                      Object {
+                        "backgroundColor": "#ac1f39",
+                        "transition": "background-color 800ms",
+                        "width": "3.5342256934938505%",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
           <div
             className="col-md-6"
           >
@@ -11139,6 +11212,79 @@ exports[`Elemental Shaman integration test: Huntsman Altimor log matches the che
         <div
           className="row"
         >
+          <div
+            className="col-md-6"
+          >
+            <div
+              className="flex"
+            >
+              <div
+                className="flex-main"
+              >
+                <a
+                  className="spell-link-text"
+                  href="https://wowhead.com/spell=198067"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <img
+                    alt=""
+                    className="icon game "
+                    src="//render-us.worldofwarcraft.com/icons/56/spell_fire_elemental_totem.jpg"
+                  />
+                   
+                  Fire Elemental
+                </a>
+              </div>
+              <div
+                className="flex-sub content-middle text-muted"
+                style={
+                  Object {
+                    "marginLeft": 5,
+                    "marginRight": 10,
+                    "minWidth": 55,
+                  }
+                }
+              >
+                <div
+                  className="text-right"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                >
+                   
+                  100.00%
+                   
+                   
+                </div>
+              </div>
+              <div
+                className="flex-sub content-middle"
+                style={
+                  Object {
+                    "width": 50,
+                  }
+                }
+              >
+                <div
+                  className="performance-bar-container"
+                >
+                  <div
+                    className="performance-bar small"
+                    style={
+                      Object {
+                        "backgroundColor": "#4ec04e",
+                        "transition": "background-color 800ms",
+                        "width": "100%",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
           <div
             className="col-md-6"
           >

--- a/analysis/shamanelemental/src/modules/checklist/Component.tsx
+++ b/analysis/shamanelemental/src/modules/checklist/Component.tsx
@@ -41,7 +41,7 @@ const ElementalShamanChecklist = ({ combatant, castEfficiency, thresholds }: Che
         {combatant.hasTalent(SPELLS.ASCENDANCE_TALENT_ELEMENTAL.id) && (
           <AbilityRequirement spell={SPELLS.ASCENDANCE_TALENT_ELEMENTAL.id} />
         )}
-        {combatant.hasTalent(SPELLS.STORM_ELEMENTAL_TALENT.id) && (
+        {!combatant.hasTalent(SPELLS.STORM_ELEMENTAL_TALENT.id) && (
           <AbilityRequirement spell={SPELLS.FIRE_ELEMENTAL.id} />
         )}
         {combatant.hasTalent(SPELLS.STORM_ELEMENTAL_TALENT.id) && (


### PR DESCRIPTION
it was throwing an error because Fire Ele was only enabled when Storm Ele talent was on, which is backwards.