### PR TITLE
Handle Unity in `hasLegendary`

### DIFF
--- a/analysis/deathknight/src/Superstrain.tsx
+++ b/analysis/deathknight/src/Superstrain.tsx
@@ -26,7 +26,7 @@ class Superstrain extends Analyzer {
   constructor(options: Options) {
     super(options);
 
-    const active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.SUPERSTRAIN.bonusID);
+    const active = this.selectedCombatant.hasLegendary(SPELLS.SUPERSTRAIN);
     this.active = active;
     if (!active) {
       return;

--- a/analysis/deathknight/src/SwarmingMist.tsx
+++ b/analysis/deathknight/src/SwarmingMist.tsx
@@ -33,11 +33,7 @@ class SwarmingMist extends Analyzer {
     super(options);
 
     const active = this.selectedCombatant.hasCovenant(COVENANTS.VENTHYR.id);
-    this.deathCoilReduction = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.DEADLIEST_COIL.bonusID,
-    )
-      ? -10
-      : 0;
+    this.deathCoilReduction = this.selectedCombatant.hasLegendary(SPELLS.DEADLIEST_COIL) ? -10 : 0;
     this.active = active;
     if (!active) {
       return;

--- a/analysis/deathknightblood/src/modules/items/BrynadaorsMight.tsx
+++ b/analysis/deathknightblood/src/modules/items/BrynadaorsMight.tsx
@@ -18,7 +18,7 @@ class BrynadaorsMight extends Analyzer {
   constructor(options: Options) {
     super(options);
 
-    const active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.BRYNDAORS_MIGHT.bonusID);
+    const active = this.selectedCombatant.hasLegendary(SPELLS.BRYNDAORS_MIGHT);
     this.active = active;
     if (!active) {
       return;

--- a/analysis/demonhunterhavoc/src/modules/shadowlands/legendaries/ChaosTheory.tsx
+++ b/analysis/demonhunterhavoc/src/modules/shadowlands/legendaries/ChaosTheory.tsx
@@ -11,7 +11,7 @@ class ChaosTheory extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.CHAOS_THEORY.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.CHAOS_THEORY);
     if (!this.active) {
       return;
     }

--- a/analysis/demonhunterhavoc/src/modules/shadowlands/legendaries/CollectiveAnguish.tsx
+++ b/analysis/demonhunterhavoc/src/modules/shadowlands/legendaries/CollectiveAnguish.tsx
@@ -12,7 +12,7 @@ class CollectiveAnguish extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.COLLECTIVE_ANGUISH.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.COLLECTIVE_ANGUISH);
     if (!this.active) {
       return;
     }

--- a/analysis/demonhuntervengeance/src/modules/Abilities.js
+++ b/analysis/demonhuntervengeance/src/modules/Abilities.js
@@ -182,12 +182,12 @@ class Abilities extends CoreAbilities {
         },
         enabled: !(
           combatant.hasCovenant(COVENANTS.KYRIAN.id) &&
-          combatant.hasLegendaryByBonusID(SPELLS.RAZELIKHS_DEFILEMENT.bonusID)
+          combatant.hasLegendary(SPELLS.RAZELIKHS_DEFILEMENT)
         ),
         castEfficiency: {
           suggestion: !(
             combatant.hasCovenant(COVENANTS.KYRIAN.id) &&
-            combatant.hasLegendaryByBonusID(SPELLS.RAZELIKHS_DEFILEMENT.bonusID)
+            combatant.hasLegendary(SPELLS.RAZELIKHS_DEFILEMENT)
           ),
           recommendedEfficiency: 0.9,
           extraSuggestion: combatant.hasTalent(SPELLS.ABYSSAL_STRIKE_TALENT.id) ? (

--- a/analysis/demonhuntervengeance/src/modules/shadowlands/legendaries/FierySoul.tsx
+++ b/analysis/demonhuntervengeance/src/modules/shadowlands/legendaries/FierySoul.tsx
@@ -24,7 +24,7 @@ class FierySoul extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.FIERY_SOUL.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.FIERY_SOUL);
     if (!this.active) {
       return;
     }

--- a/analysis/druid/src/core/Abilities.ts
+++ b/analysis/druid/src/core/Abilities.ts
@@ -17,7 +17,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.CONVOKE_SPIRITS.id,
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
-        cooldown: combatant.hasLegendaryByBonusID(SPELLS.CELESTIAL_SPIRITS.bonusID) ? 60 : 120,
+        cooldown: combatant.hasLegendary(SPELLS.CELESTIAL_SPIRITS) ? 60 : 120,
         gcd: {
           base: druidGcd,
         },

--- a/analysis/druid/src/shadowlands/ConvokeSpirits.tsx
+++ b/analysis/druid/src/shadowlands/ConvokeSpirits.tsx
@@ -120,9 +120,7 @@ class ConvokeSpirits extends Analyzer {
     super(options);
     this.active = this.selectedCombatant.hasCovenant(COVENANTS.NIGHT_FAE.id);
 
-    this.spellsPerCast = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.CELESTIAL_SPIRITS.bonusID,
-    )
+    this.spellsPerCast = this.selectedCombatant.hasLegendary(SPELLS.CELESTIAL_SPIRITS)
       ? this.selectedCombatant.specId === SPECS.RESTORATION_DRUID.id
         ? CS_SPELLS_CAST_RESTO
         : CS_SPELLS_CAST

--- a/analysis/druid/src/shadowlands/DraughtOfDeepFocus.tsx
+++ b/analysis/druid/src/shadowlands/DraughtOfDeepFocus.tsx
@@ -28,9 +28,7 @@ class DraughtOfDeepFocus extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.DRAUGHT_OF_DEEP_FOCUS.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.DRAUGHT_OF_DEEP_FOCUS);
 
     // init trackers
     BUFFED_DOTS.forEach((dotSpell) => {

--- a/analysis/druid/src/shadowlands/SinfulHysteria.ts
+++ b/analysis/druid/src/shadowlands/SinfulHysteria.ts
@@ -33,7 +33,7 @@ class SinfulHysteria extends Analyzer {
   constructor(options: Options) {
     super(options);
 
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.SINFUL_HYSTERIA.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.SINFUL_HYSTERIA);
 
     this.lastLingerHaste = 0;
 

--- a/analysis/druidbalance/src/modules/features/BalanceOfAllThingsOpener.tsx
+++ b/analysis/druidbalance/src/modules/features/BalanceOfAllThingsOpener.tsx
@@ -26,9 +26,7 @@ class BalanceOfAllThingsOpener extends Analyzer {
   constructor(options: Options) {
     super(options);
 
-    const active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.BALANCE_OF_ALL_THINGS_SOLAR.bonusID,
-    );
+    const active = this.selectedCombatant.hasLegendary(SPELLS.BALANCE_OF_ALL_THINGS_SOLAR);
     if (!active) {
       return;
     }

--- a/analysis/druidbalance/src/modules/features/BalanceOfAllThingsOpener.tsx
+++ b/analysis/druidbalance/src/modules/features/BalanceOfAllThingsOpener.tsx
@@ -26,7 +26,7 @@ class BalanceOfAllThingsOpener extends Analyzer {
   constructor(options: Options) {
     super(options);
 
-    const active = this.selectedCombatant.hasLegendary(SPELLS.BALANCE_OF_ALL_THINGS_SOLAR);
+    const active = this.selectedCombatant.hasLegendary(SPELLS.BALANCE_OF_ALL_THINGS_ITEM);
     if (!active) {
       return;
     }

--- a/analysis/druidbalance/src/modules/resourcetracker/AstralPowerDetails.tsx
+++ b/analysis/druidbalance/src/modules/resourcetracker/AstralPowerDetails.tsx
@@ -84,7 +84,7 @@ class AstralPowerDetails extends Analyzer {
   }
 
   get usingBoat() {
-    return this.selectedCombatant.hasLegendary(SPELLS.BALANCE_OF_ALL_THINGS_SOLAR);
+    return this.selectedCombatant.hasLegendary(SPELLS.BALANCE_OF_ALL_THINGS_ITEM);
   }
 
   get suggestionThresholdsWasted() {

--- a/analysis/druidbalance/src/modules/resourcetracker/AstralPowerDetails.tsx
+++ b/analysis/druidbalance/src/modules/resourcetracker/AstralPowerDetails.tsx
@@ -84,7 +84,7 @@ class AstralPowerDetails extends Analyzer {
   }
 
   get usingBoat() {
-    return this.selectedCombatant.hasLegendaryByBonusID(SPELLS.BALANCE_OF_ALL_THINGS_SOLAR.bonusID);
+    return this.selectedCombatant.hasLegendary(SPELLS.BALANCE_OF_ALL_THINGS_SOLAR);
   }
 
   get suggestionThresholdsWasted() {

--- a/analysis/druidferal/src/modules/shadowlands/ApexPredatorsCraving.tsx
+++ b/analysis/druidferal/src/modules/shadowlands/ApexPredatorsCraving.tsx
@@ -49,9 +49,7 @@ class ApexPredatorsCraving extends Analyzer {
   constructor(options: Options) {
     super(options);
 
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.APEX_PREDATORS_CRAVING.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.APEX_PREDATORS_CRAVING);
 
     this.hasSotf = this.selectedCombatant.hasTalent(SPELLS.SOUL_OF_THE_FOREST_TALENT_FERAL.id);
 

--- a/analysis/druidferal/src/modules/shadowlands/ConvokeSpiritsFeral.tsx
+++ b/analysis/druidferal/src/modules/shadowlands/ConvokeSpiritsFeral.tsx
@@ -59,7 +59,7 @@ class ConvokeSpiritsFeral extends ConvokeSpirits {
     );
 
     // only alternate way to do Starfall is lycara's, so only need to watch if we have it
-    if (this.selectedCombatant.hasLegendaryByBonusID(SPELLS.LYCARAS_FLEETING_GLIMPSE.bonusID)) {
+    if (this.selectedCombatant.hasLegendary(SPELLS.LYCARAS_FLEETING_GLIMPSE)) {
       this.addEventListener(
         Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.STARFALL_CAST),
         this.onGainStarfall,

--- a/analysis/druidferal/src/modules/shadowlands/Frenzyband.tsx
+++ b/analysis/druidferal/src/modules/shadowlands/Frenzyband.tsx
@@ -46,7 +46,7 @@ class Frenzyband extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.FRENZYBAND.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.FRENZYBAND);
 
     this.cdSpell = this.selectedCombatant.hasTalent(SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT.id)
       ? SPELLS.INCARNATION_KING_OF_THE_JUNGLE_TALENT

--- a/analysis/druidferal/src/modules/spells/FerociousBite.tsx
+++ b/analysis/druidferal/src/modules/spells/FerociousBite.tsx
@@ -78,9 +78,7 @@ class FerociousBite extends Analyzer {
 
   suggestions(when: When) {
     const hasSotf = this.selectedCombatant.hasTalent(SPELLS.SOUL_OF_THE_FOREST_TALENT_FERAL);
-    const hasApex = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.APEX_PREDATORS_CRAVING.bonusID,
-    );
+    const hasApex = this.selectedCombatant.hasLegendary(SPELLS.APEX_PREDATORS_CRAVING);
     let exceptions = 0;
     if (hasSotf) {
       exceptions += 1;

--- a/analysis/druidferal/src/modules/talents/Bloodtalons.tsx
+++ b/analysis/druidferal/src/modules/talents/Bloodtalons.tsx
@@ -77,9 +77,7 @@ class Bloodtalons2 extends Analyzer {
     super(options);
 
     this.active = this.selectedCombatant.hasTalent(SPELLS.BLOODTALONS_TALENT);
-    this.hasApex = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.APEX_PREDATORS_CRAVING.bonusID,
-    );
+    this.hasApex = this.selectedCombatant.hasLegendary(SPELLS.APEX_PREDATORS_CRAVING);
 
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(FINISHERS), this.onFinisherCast);
     this.addEventListener(

--- a/analysis/druidguardian/src/modules/shadowlands/ConvokeSpiritsGuardian.tsx
+++ b/analysis/druidguardian/src/modules/shadowlands/ConvokeSpiritsGuardian.tsx
@@ -53,7 +53,7 @@ class ConvokeSpiritsGuardian extends ConvokeSpirits {
     );
 
     // only alternate way to do Starfall is lycara's, so only need to watch if we have it
-    if (this.selectedCombatant.hasLegendaryByBonusID(SPELLS.LYCARAS_FLEETING_GLIMPSE.bonusID)) {
+    if (this.selectedCombatant.hasLegendary(SPELLS.LYCARAS_FLEETING_GLIMPSE)) {
       this.addEventListener(
         Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.STARFALL_CAST),
         this.onGainStarfall,

--- a/analysis/druidrestoration/src/modules/Abilities.tsx
+++ b/analysis/druidrestoration/src/modules/Abilities.tsx
@@ -160,7 +160,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.LIFEBLOOM_HOT_HEAL.id,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        enabled: !combatant.hasLegendaryByBonusID(SPELLS.LIFEBLOOM_DTL_HOT_HEAL.bonusID),
+        enabled: !combatant.hasLegendary(SPELLS.LIFEBLOOM_DTL_HOT_HEAL),
         gcd: {
           base: 1500,
         },
@@ -169,7 +169,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.LIFEBLOOM_DTL_HOT_HEAL.id,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        enabled: combatant.hasLegendaryByBonusID(SPELLS.LIFEBLOOM_DTL_HOT_HEAL.bonusID),
+        enabled: combatant.hasLegendary(SPELLS.LIFEBLOOM_DTL_HOT_HEAL),
         gcd: {
           base: 1500,
         },

--- a/analysis/druidrestoration/src/modules/Abilities.tsx
+++ b/analysis/druidrestoration/src/modules/Abilities.tsx
@@ -160,7 +160,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.LIFEBLOOM_HOT_HEAL.id,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        enabled: !combatant.hasLegendary(SPELLS.LIFEBLOOM_DTL_HOT_HEAL),
+        enabled: !combatant.hasLegendary(SPELLS.THE_DARK_TITANS_LESSON),
         gcd: {
           base: 1500,
         },
@@ -169,7 +169,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.LIFEBLOOM_DTL_HOT_HEAL.id,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
-        enabled: combatant.hasLegendary(SPELLS.LIFEBLOOM_DTL_HOT_HEAL),
+        enabled: combatant.hasLegendary(SPELLS.THE_DARK_TITANS_LESSON),
         gcd: {
           base: 1500,
         },

--- a/analysis/druidrestoration/src/modules/core/hottracking/HotAttributor.ts
+++ b/analysis/druidrestoration/src/modules/core/hottracking/HotAttributor.ts
@@ -51,14 +51,14 @@ class HotAttributor extends Analyzer {
     super(options);
 
     this.hasOvergrowth = this.selectedCombatant.hasTalent(SPELLS.OVERGROWTH_TALENT.id);
-    this.hasMemoryOfTheMotherTree = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.MEMORY_OF_THE_MOTHER_TREE.bonusID,
+    this.hasMemoryOfTheMotherTree = this.selectedCombatant.hasLegendary(
+      SPELLS.MEMORY_OF_THE_MOTHER_TREE,
     );
-    this.hasVisionOfUnendingGrowth = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.VISION_OF_UNENDING_GROWTH.bonusID,
+    this.hasVisionOfUnendingGrowth = this.selectedCombatant.hasLegendary(
+      SPELLS.VISION_OF_UNENDING_GROWTH,
     );
-    this.hasLycarasFleetingGlimpse = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.LYCARAS_FLEETING_GLIMPSE.bonusID,
+    this.hasLycarasFleetingGlimpse = this.selectedCombatant.hasLegendary(
+      SPELLS.LYCARAS_FLEETING_GLIMPSE,
     );
 
     this.addEventListener(

--- a/analysis/druidrestoration/src/modules/core/hottracking/HotAttributor.ts
+++ b/analysis/druidrestoration/src/modules/core/hottracking/HotAttributor.ts
@@ -52,7 +52,7 @@ class HotAttributor extends Analyzer {
 
     this.hasOvergrowth = this.selectedCombatant.hasTalent(SPELLS.OVERGROWTH_TALENT.id);
     this.hasMemoryOfTheMotherTree = this.selectedCombatant.hasLegendary(
-      SPELLS.MEMORY_OF_THE_MOTHER_TREE,
+      SPELLS.MEMORY_OF_THE_MOTHER_TREE_ITEM,
     );
     this.hasVisionOfUnendingGrowth = this.selectedCombatant.hasLegendary(
       SPELLS.VISION_OF_UNENDING_GROWTH,

--- a/analysis/druidrestoration/src/modules/features/Lifebloom.tsx
+++ b/analysis/druidrestoration/src/modules/features/Lifebloom.tsx
@@ -32,7 +32,7 @@ class Lifebloom extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.hasDTL = this.selectedCombatant.hasLegendary(SPELLS.LIFEBLOOM_DTL_HOT_HEAL);
+    this.hasDTL = this.selectedCombatant.hasLegendary(SPELLS.THE_DARK_TITANS_LESSON);
 
     this.addEventListener(
       Events.applybuff.by(SELECTED_PLAYER).spell(LIFEBLOOM_HOTS),

--- a/analysis/druidrestoration/src/modules/features/Lifebloom.tsx
+++ b/analysis/druidrestoration/src/modules/features/Lifebloom.tsx
@@ -32,9 +32,7 @@ class Lifebloom extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.hasDTL = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.LIFEBLOOM_DTL_HOT_HEAL.bonusID,
-    );
+    this.hasDTL = this.selectedCombatant.hasLegendary(SPELLS.LIFEBLOOM_DTL_HOT_HEAL);
 
     this.addEventListener(
       Events.applybuff.by(SELECTED_PLAYER).spell(LIFEBLOOM_HOTS),

--- a/analysis/druidrestoration/src/modules/shadowlands/legendaries/LycarasFleetingGlimpseResto.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/legendaries/LycarasFleetingGlimpseResto.tsx
@@ -29,9 +29,7 @@ class LycarasFleetingGlimpseResto extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.LYCARAS_FLEETING_GLIMPSE.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.LYCARAS_FLEETING_GLIMPSE);
   }
 
   statistic() {

--- a/analysis/druidrestoration/src/modules/shadowlands/legendaries/MemoryoftheMotherTree.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/legendaries/MemoryoftheMotherTree.tsx
@@ -32,7 +32,7 @@ class MemoryoftheMotherTree extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendary(SPELLS.MEMORY_OF_THE_MOTHER_TREE);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.MEMORY_OF_THE_MOTHER_TREE_ITEM);
 
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.WILD_GROWTH),

--- a/analysis/druidrestoration/src/modules/shadowlands/legendaries/MemoryoftheMotherTree.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/legendaries/MemoryoftheMotherTree.tsx
@@ -32,9 +32,7 @@ class MemoryoftheMotherTree extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.MEMORY_OF_THE_MOTHER_TREE.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.MEMORY_OF_THE_MOTHER_TREE);
 
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.WILD_GROWTH),

--- a/analysis/druidrestoration/src/modules/shadowlands/legendaries/VerdantInfusion.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/legendaries/VerdantInfusion.tsx
@@ -42,7 +42,7 @@ class VerdantInfusion extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.VERDANT_INFUSION.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.VERDANT_INFUSION);
 
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.SWIFTMEND),

--- a/analysis/druidrestoration/src/modules/shadowlands/legendaries/VisionOfUnendingGrowth.tsx
+++ b/analysis/druidrestoration/src/modules/shadowlands/legendaries/VisionOfUnendingGrowth.tsx
@@ -23,9 +23,7 @@ class VisionOfUnendingGrowth extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.VISION_OF_UNENDING_GROWTH.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.VISION_OF_UNENDING_GROWTH);
   }
 
   get procs() {

--- a/analysis/hunter/src/conduits/HarmonyOfTheTortollan.tsx
+++ b/analysis/hunter/src/conduits/HarmonyOfTheTortollan.tsx
@@ -24,7 +24,7 @@ class HarmonyOfTheTortollan extends Analyzer {
         ? BORN_TO_BE_WILD_CD_REDUCTION
         : 0)) *
     (1 -
-      (this.selectedCombatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+      (this.selectedCombatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT)
         ? CALL_OF_THE_WILD_CD_REDUCTION
         : 0));
   lastCast = 0;

--- a/analysis/hunter/src/conduits/HarmonyOfTheTortollan.tsx
+++ b/analysis/hunter/src/conduits/HarmonyOfTheTortollan.tsx
@@ -24,7 +24,7 @@ class HarmonyOfTheTortollan extends Analyzer {
         ? BORN_TO_BE_WILD_CD_REDUCTION
         : 0)) *
     (1 -
-      (this.selectedCombatant.hasLegendaryByBonusID(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+      (this.selectedCombatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
         ? CALL_OF_THE_WILD_CD_REDUCTION
         : 0));
   lastCast = 0;

--- a/analysis/hunter/src/items/FragmentsOfTheElderAntlers.tsx
+++ b/analysis/hunter/src/items/FragmentsOfTheElderAntlers.tsx
@@ -27,9 +27,7 @@ class FragmentsOfTheElderAntlers extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.FRAGMENTS_OF_THE_ELDER_ANTLERS.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.FRAGMENTS_OF_THE_ELDER_ANTLERS);
     if (!this.active) {
       return;
     }

--- a/analysis/hunter/src/items/SoulforgeEmbers.tsx
+++ b/analysis/hunter/src/items/SoulforgeEmbers.tsx
@@ -24,9 +24,7 @@ class SoulforgeEmbers extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.SOULFORGE_EMBERS_EFFECT.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.SOULFORGE_EMBERS_EFFECT);
     if (!this.active) {
       return;
     }

--- a/analysis/hunter/src/talents/BornToBeWild.tsx
+++ b/analysis/hunter/src/talents/BornToBeWild.tsx
@@ -52,7 +52,7 @@ class BornToBeWild extends Analyzer {
   get callOfTheWildReduction() {
     return (
       1 -
-      (this.selectedCombatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+      (this.selectedCombatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT)
         ? CALL_OF_THE_WILD_CD_REDUCTION
         : 0)
     );

--- a/analysis/hunter/src/talents/BornToBeWild.tsx
+++ b/analysis/hunter/src/talents/BornToBeWild.tsx
@@ -52,7 +52,7 @@ class BornToBeWild extends Analyzer {
   get callOfTheWildReduction() {
     return (
       1 -
-      (this.selectedCombatant.hasLegendaryByBonusID(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+      (this.selectedCombatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
         ? CALL_OF_THE_WILD_CD_REDUCTION
         : 0)
     );

--- a/analysis/hunterbeastmastery/src/modules/Abilities.tsx
+++ b/analysis/hunterbeastmastery/src/modules/Abilities.tsx
@@ -89,7 +89,7 @@ class Abilities extends CoreAbilities {
         cooldown:
           120 *
           (1 -
-            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {
@@ -137,7 +137,7 @@ class Abilities extends CoreAbilities {
               ? BORN_TO_BE_WILD_CD_REDUCTION
               : 0)) *
           (1 -
-            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {
@@ -175,7 +175,7 @@ class Abilities extends CoreAbilities {
               ? BORN_TO_BE_WILD_CD_REDUCTION
               : 0)) *
           (1 -
-            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {

--- a/analysis/hunterbeastmastery/src/modules/Abilities.tsx
+++ b/analysis/hunterbeastmastery/src/modules/Abilities.tsx
@@ -89,7 +89,7 @@ class Abilities extends CoreAbilities {
         cooldown:
           120 *
           (1 -
-            (combatant.hasLegendaryByBonusID(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {
@@ -137,7 +137,7 @@ class Abilities extends CoreAbilities {
               ? BORN_TO_BE_WILD_CD_REDUCTION
               : 0)) *
           (1 -
-            (combatant.hasLegendaryByBonusID(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {
@@ -175,7 +175,7 @@ class Abilities extends CoreAbilities {
               ? BORN_TO_BE_WILD_CD_REDUCTION
               : 0)) *
           (1 -
-            (combatant.hasLegendaryByBonusID(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {
@@ -230,9 +230,7 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         castEfficiency: {
-          suggestion: this.selectedCombatant.hasLegendaryByBonusID(
-            SPELLS.SOULFORGE_EMBERS_EFFECT.bonusID,
-          ),
+          suggestion: this.selectedCombatant.hasLegendary(SPELLS.SOULFORGE_EMBERS_EFFECT),
           recommendedEfficiency: 0.55,
         },
       },
@@ -252,9 +250,7 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         castEfficiency: {
-          suggestion: this.selectedCombatant.hasLegendaryByBonusID(
-            SPELLS.SOULFORGE_EMBERS_EFFECT.bonusID,
-          ),
+          suggestion: this.selectedCombatant.hasLegendary(SPELLS.SOULFORGE_EMBERS_EFFECT),
           recommendedEfficiency: 0.9,
         },
       },

--- a/analysis/hunterbeastmastery/src/modules/checklist/Component.tsx
+++ b/analysis/hunterbeastmastery/src/modules/checklist/Component.tsx
@@ -170,7 +170,7 @@ const BeastMasteryChecklist = (props: ChecklistProps & AplRuleProps) => {
         name="Legendaries"
         description="The throughput gain of some legendaries might vary greatly. Consider switching to a more reliable alternative if something is underperforming regularly, even after trying to improve your usage of said legendary."
       >
-        {combatant.hasLegendaryByBonusID(SPELLS.QAPLA_EREDUN_WAR_ORDER_EFFECT.bonusID) && (
+        {combatant.hasLegendary(SPELLS.QAPLA_EREDUN_WAR_ORDER_EFFECT) && (
           <Requirement
             name={
               <>

--- a/analysis/hunterbeastmastery/src/modules/items/DireCommand.tsx
+++ b/analysis/hunterbeastmastery/src/modules/items/DireCommand.tsx
@@ -31,7 +31,7 @@ class DireCommand extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.DIRE_COMMAND_EFFECT.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.DIRE_COMMAND_EFFECT);
     if (!this.active) {
       return;
     }

--- a/analysis/hunterbeastmastery/src/modules/items/FlamewakersCobraSting.tsx
+++ b/analysis/hunterbeastmastery/src/modules/items/FlamewakersCobraSting.tsx
@@ -27,9 +27,7 @@ class FlamewakersCobraSting extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.FLAMEWAKERS_COBRA_STING_EFFECT.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.FLAMEWAKERS_COBRA_STING_EFFECT);
     if (!this.active) {
       return;
     }

--- a/analysis/hunterbeastmastery/src/modules/items/NesingwarysTrappingApparatus.tsx
+++ b/analysis/hunterbeastmastery/src/modules/items/NesingwarysTrappingApparatus.tsx
@@ -32,9 +32,7 @@ class NesingwarysTrappingApparatus extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.NESINGWARYS_TRAPPING_APPARATUS_EFFECT.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.NESINGWARYS_TRAPPING_APPARATUS_EFFECT);
     if (!this.active) {
       return;
     }

--- a/analysis/hunterbeastmastery/src/modules/items/QaplaEredunWarOrder.tsx
+++ b/analysis/hunterbeastmastery/src/modules/items/QaplaEredunWarOrder.tsx
@@ -34,9 +34,7 @@ class QaplaEredunWarOrder extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.QAPLA_EREDUN_WAR_ORDER_EFFECT.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.QAPLA_EREDUN_WAR_ORDER_EFFECT);
     if (!this.active) {
       return;
     }

--- a/analysis/hunterbeastmastery/src/modules/items/RylakstalkersPiercingFangs.tsx
+++ b/analysis/hunterbeastmastery/src/modules/items/RylakstalkersPiercingFangs.tsx
@@ -24,9 +24,7 @@ class RylakstalkersPiercingFangs extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.RYLAKSTALKERS_PIERCING_FANGS_EFFECT.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.RYLAKSTALKERS_PIERCING_FANGS_EFFECT);
     if (!this.active) {
       return;
     }

--- a/analysis/hunterbeastmastery/src/modules/spells/AspectOfTheWild.tsx
+++ b/analysis/hunterbeastmastery/src/modules/spells/AspectOfTheWild.tsx
@@ -31,9 +31,7 @@ class AspectOfTheWild extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.NESINGWARYS_TRAPPING_APPARATUS_EFFECT.bonusID,
-    ) &&
+    this.selectedCombatant.hasLegendary(SPELLS.NESINGWARYS_TRAPPING_APPARATUS_EFFECT) &&
       this.addEventListener(
         Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.ASPECT_OF_THE_WILD),
         this.checkNesingwaryFocusGain,

--- a/analysis/hunterbeastmastery/src/modules/spells/BarbedShot.tsx
+++ b/analysis/hunterbeastmastery/src/modules/spells/BarbedShot.tsx
@@ -56,9 +56,7 @@ class BarbedShot extends Analyzer {
       this.handleStacks,
     );
     this.addEventListener(Events.fightend, this.handleStacks);
-    this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.NESINGWARYS_TRAPPING_APPARATUS_EFFECT.bonusID,
-    ) &&
+    this.selectedCombatant.hasLegendary(SPELLS.NESINGWARYS_TRAPPING_APPARATUS_EFFECT) &&
       this.addEventListener(
         Events.resourcechange.by(SELECTED_PLAYER).spell(BARBED_SHOT_FOCUS_REGEN_BUFFS),
         this.checkNesingwaryFocusGain,

--- a/analysis/hunterbeastmastery/src/modules/theorycraft/AntlerVersusRylak.tsx
+++ b/analysis/hunterbeastmastery/src/modules/theorycraft/AntlerVersusRylak.tsx
@@ -31,13 +31,10 @@ class AntlerVersusRylak extends Analyzer {
   //Because we're comparing a generic legendary (rylak) to antlers that only works when you're NightFae
   //we require the rylak user to also be NF before showing this module
   hasRylakAndIsNF =
-    this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.RYLAKSTALKERS_PIERCING_FANGS_EFFECT.bonusID,
-    ) && this.selectedCombatant.hasCovenant(COVENANTS.NIGHT_FAE.id);
+    this.selectedCombatant.hasLegendary(SPELLS.RYLAKSTALKERS_PIERCING_FANGS_EFFECT) &&
+    this.selectedCombatant.hasCovenant(COVENANTS.NIGHT_FAE.id);
 
-  hasAntlers = this.selectedCombatant.hasLegendaryByBonusID(
-    SPELLS.FRAGMENTS_OF_THE_ELDER_ANTLERS.bonusID,
-  );
+  hasAntlers = this.selectedCombatant.hasLegendary(SPELLS.FRAGMENTS_OF_THE_ELDER_ANTLERS);
   constructor(options: Options) {
     super(options);
 

--- a/analysis/huntermarksmanship/src/modules/Abilities.tsx
+++ b/analysis/huntermarksmanship/src/modules/Abilities.tsx
@@ -78,7 +78,7 @@ class Abilities extends CoreAbilities {
         cooldown:
           120 *
           (1 -
-            (combatant.hasLegendaryByBonusID(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {
@@ -134,7 +134,7 @@ class Abilities extends CoreAbilities {
               ? BORN_TO_BE_WILD_CD_REDUCTION
               : 0)) *
           (1 -
-            (combatant.hasLegendaryByBonusID(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {
@@ -203,7 +203,7 @@ class Abilities extends CoreAbilities {
               ? BORN_TO_BE_WILD_CD_REDUCTION
               : 0)) *
           (1 -
-            (combatant.hasLegendaryByBonusID(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {
@@ -226,9 +226,7 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         castEfficiency: {
-          suggestion: this.selectedCombatant.hasLegendaryByBonusID(
-            SPELLS.SOULFORGE_EMBERS_EFFECT.bonusID,
-          ),
+          suggestion: this.selectedCombatant.hasLegendary(SPELLS.SOULFORGE_EMBERS_EFFECT),
           recommendedEfficiency: 0.55,
         },
       },
@@ -240,9 +238,7 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         castEfficiency: {
-          suggestion: this.selectedCombatant.hasLegendaryByBonusID(
-            SPELLS.SOULFORGE_EMBERS_EFFECT.bonusID,
-          ),
+          suggestion: this.selectedCombatant.hasLegendary(SPELLS.SOULFORGE_EMBERS_EFFECT),
           recommendedEfficiency: 0.9,
         },
       },

--- a/analysis/huntermarksmanship/src/modules/Abilities.tsx
+++ b/analysis/huntermarksmanship/src/modules/Abilities.tsx
@@ -78,7 +78,7 @@ class Abilities extends CoreAbilities {
         cooldown:
           120 *
           (1 -
-            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {
@@ -134,7 +134,7 @@ class Abilities extends CoreAbilities {
               ? BORN_TO_BE_WILD_CD_REDUCTION
               : 0)) *
           (1 -
-            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {
@@ -203,7 +203,7 @@ class Abilities extends CoreAbilities {
               ? BORN_TO_BE_WILD_CD_REDUCTION
               : 0)) *
           (1 -
-            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {

--- a/analysis/huntermarksmanship/src/modules/core/SpellUsable.tsx
+++ b/analysis/huntermarksmanship/src/modules/core/SpellUsable.tsx
@@ -12,7 +12,7 @@ class SpellUsable extends CoreSpellUsable {
 
   onCast(event: CastEvent) {
     const spellId = event.ability.guid;
-    if (this.selectedCombatant.hasLegendaryByBonusID(SPELLS.SURGING_SHOTS_EFFECT.bonusID)) {
+    if (this.selectedCombatant.hasLegendary(SPELLS.SURGING_SHOTS_EFFECT)) {
       if (spellId === SPELLS.AIMED_SHOT.id) {
         this.lastPotentialTriggerForRapidFireReset = event;
       } else if (spellId === SPELLS.RAPID_FIRE.id) {
@@ -25,7 +25,7 @@ class SpellUsable extends CoreSpellUsable {
   beginCooldown(spellId: number, cooldownTriggerEvent: CastEvent | DamageEvent) {
     if (
       spellId === SPELLS.RAPID_FIRE.id &&
-      this.selectedCombatant.hasLegendaryByBonusID(SPELLS.SURGING_SHOTS_EFFECT.bonusID)
+      this.selectedCombatant.hasLegendary(SPELLS.SURGING_SHOTS_EFFECT)
     ) {
       if (this.isOnCooldown(spellId)) {
         this.rapidFireResets += 1;

--- a/analysis/huntermarksmanship/src/modules/items/EagletalonsTrueFocus.tsx
+++ b/analysis/huntermarksmanship/src/modules/items/EagletalonsTrueFocus.tsx
@@ -25,9 +25,7 @@ class EagletalonsTrueFocus extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.EAGLETALONS_TRUE_FOCUS_EFFECT.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.EAGLETALONS_TRUE_FOCUS_EFFECT);
     if (!this.active) {
       return;
     }

--- a/analysis/huntermarksmanship/src/modules/items/NesingwarysTrappingApparatus.tsx
+++ b/analysis/huntermarksmanship/src/modules/items/NesingwarysTrappingApparatus.tsx
@@ -32,9 +32,7 @@ class NesingwarysTrappingApparatus extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.NESINGWARYS_TRAPPING_APPARATUS_EFFECT.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.NESINGWARYS_TRAPPING_APPARATUS_EFFECT);
     if (!this.active) {
       return;
     }

--- a/analysis/huntermarksmanship/src/modules/items/SecretsOfTheUnblinkingVigil.tsx
+++ b/analysis/huntermarksmanship/src/modules/items/SecretsOfTheUnblinkingVigil.tsx
@@ -34,8 +34,8 @@ class SecretsOfTheUnblinkingVigil extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.SECRETS_OF_THE_UNBLINKING_VIGIL_EFFECT.bonusID,
+    this.active = this.selectedCombatant.hasLegendary(
+      SPELLS.SECRETS_OF_THE_UNBLINKING_VIGIL_EFFECT,
     );
     if (!this.active) {
       return;

--- a/analysis/huntermarksmanship/src/modules/items/SerpentstalkersTrickery.tsx
+++ b/analysis/huntermarksmanship/src/modules/items/SerpentstalkersTrickery.tsx
@@ -18,9 +18,7 @@ class SerpentstalkersTrickery extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.SERPENTSTALKERS_TRICKERY_EFFECT.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.SERPENTSTALKERS_TRICKERY_EFFECT);
     if (!this.active) {
       return;
     }

--- a/analysis/huntermarksmanship/src/modules/items/SurgingShots.tsx
+++ b/analysis/huntermarksmanship/src/modules/items/SurgingShots.tsx
@@ -34,7 +34,7 @@ class SurgingShots extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.SURGING_SHOTS_EFFECT.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.SURGING_SHOTS_EFFECT);
     if (!this.active) {
       return;
     }

--- a/analysis/huntersurvival/src/integrationTests/survivalIntegrationTests.test.ts.snap
+++ b/analysis/huntersurvival/src/integrationTests/survivalIntegrationTests.test.ts.snap
@@ -3602,56 +3602,6 @@ exports[`Survival Hunter integration test: Multi Target CastEfficiency matches t
 </div>
 `;
 
-exports[`Survival Hunter integration test: Multi Target CastEfficiency matches the suggestions snapshot 1`] = `
-Array [
-  Object {
-    "details": null,
-    "icon": undefined,
-    "importance": "regular",
-    "issue": <React.Fragment>
-      <Trans
-        components={
-          Object {
-            "0": <ForwardRef
-              id={266779}
-            />,
-          }
-        }
-        id="shared.modules.castEfficiency.suggest"
-        message="Try to cast <0/> more often."
-      />
-       
-      
-    </React.Fragment>,
-    "spell": 266779,
-    "stat": <React.Fragment>
-      <Trans
-        id="shared.modules.castEfficiency.actual"
-        message="{0} out of {1} possible casts. You kept it on cooldown {2}% of the time."
-        values={
-          Object {
-            "0": 2,
-            "1": 3,
-            "2": "70",
-          }
-        }
-      />
-       (
-      <Trans
-        id="shared.modules.castEfficiency.recommended"
-        message=">{0}% is recommended"
-        values={
-          Object {
-            "0": "85",
-          }
-        }
-      />
-      )
-    </React.Fragment>,
-  },
-]
-`;
-
 exports[`Survival Hunter integration test: Multi Target CoordinatedAssault matches the statistic snapshot 1`] = `
 <div
   className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
@@ -10396,56 +10346,6 @@ exports[`Survival Hunter integration test: Single Target CastEfficiency matches 
     </div>
   </div>
 </div>
-`;
-
-exports[`Survival Hunter integration test: Single Target CastEfficiency matches the suggestions snapshot 1`] = `
-Array [
-  Object {
-    "details": null,
-    "icon": undefined,
-    "importance": "major",
-    "issue": <React.Fragment>
-      <Trans
-        components={
-          Object {
-            "0": <ForwardRef
-              id={266779}
-            />,
-          }
-        }
-        id="shared.modules.castEfficiency.suggest"
-        message="Try to cast <0/> more often."
-      />
-       
-      
-    </React.Fragment>,
-    "spell": 266779,
-    "stat": <React.Fragment>
-      <Trans
-        id="shared.modules.castEfficiency.actual"
-        message="{0} out of {1} possible casts. You kept it on cooldown {2}% of the time."
-        values={
-          Object {
-            "0": 3,
-            "1": 4,
-            "2": "62",
-          }
-        }
-      />
-       (
-      <Trans
-        id="shared.modules.castEfficiency.recommended"
-        message=">{0}% is recommended"
-        values={
-          Object {
-            "0": "85",
-          }
-        }
-      />
-      )
-    </React.Fragment>,
-  },
-]
 `;
 
 exports[`Survival Hunter integration test: Single Target CoordinatedAssault matches the statistic snapshot 1`] = `

--- a/analysis/huntersurvival/src/integrationTests/survivalIntegrationTests.test.ts.snap
+++ b/analysis/huntersurvival/src/integrationTests/survivalIntegrationTests.test.ts.snap
@@ -3602,6 +3602,56 @@ exports[`Survival Hunter integration test: Multi Target CastEfficiency matches t
 </div>
 `;
 
+exports[`Survival Hunter integration test: Multi Target CastEfficiency matches the suggestions snapshot 1`] = `
+Array [
+  Object {
+    "details": null,
+    "icon": undefined,
+    "importance": "regular",
+    "issue": <React.Fragment>
+      <Trans
+        components={
+          Object {
+            "0": <ForwardRef
+              id={266779}
+            />,
+          }
+        }
+        id="shared.modules.castEfficiency.suggest"
+        message="Try to cast <0/> more often."
+      />
+       
+      
+    </React.Fragment>,
+    "spell": 266779,
+    "stat": <React.Fragment>
+      <Trans
+        id="shared.modules.castEfficiency.actual"
+        message="{0} out of {1} possible casts. You kept it on cooldown {2}% of the time."
+        values={
+          Object {
+            "0": 2,
+            "1": 3,
+            "2": "70",
+          }
+        }
+      />
+       (
+      <Trans
+        id="shared.modules.castEfficiency.recommended"
+        message=">{0}% is recommended"
+        values={
+          Object {
+            "0": "85",
+          }
+        }
+      />
+      )
+    </React.Fragment>,
+  },
+]
+`;
+
 exports[`Survival Hunter integration test: Multi Target CoordinatedAssault matches the statistic snapshot 1`] = `
 <div
   className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
@@ -10346,6 +10396,56 @@ exports[`Survival Hunter integration test: Single Target CastEfficiency matches 
     </div>
   </div>
 </div>
+`;
+
+exports[`Survival Hunter integration test: Single Target CastEfficiency matches the suggestions snapshot 1`] = `
+Array [
+  Object {
+    "details": null,
+    "icon": undefined,
+    "importance": "major",
+    "issue": <React.Fragment>
+      <Trans
+        components={
+          Object {
+            "0": <ForwardRef
+              id={266779}
+            />,
+          }
+        }
+        id="shared.modules.castEfficiency.suggest"
+        message="Try to cast <0/> more often."
+      />
+       
+      
+    </React.Fragment>,
+    "spell": 266779,
+    "stat": <React.Fragment>
+      <Trans
+        id="shared.modules.castEfficiency.actual"
+        message="{0} out of {1} possible casts. You kept it on cooldown {2}% of the time."
+        values={
+          Object {
+            "0": 3,
+            "1": 4,
+            "2": "62",
+          }
+        }
+      />
+       (
+      <Trans
+        id="shared.modules.castEfficiency.recommended"
+        message=">{0}% is recommended"
+        values={
+          Object {
+            "0": "85",
+          }
+        }
+      />
+      )
+    </React.Fragment>,
+  },
+]
 `;
 
 exports[`Survival Hunter integration test: Single Target CoordinatedAssault matches the statistic snapshot 1`] = `

--- a/analysis/huntersurvival/src/modules/Abilities.tsx
+++ b/analysis/huntersurvival/src/modules/Abilities.tsx
@@ -77,7 +77,7 @@ class Abilities extends CoreAbilities {
         cooldown:
           120 *
           (1 -
-            (combatant.hasLegendaryByBonusID(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {
@@ -223,7 +223,7 @@ class Abilities extends CoreAbilities {
               ? BORN_TO_BE_WILD_CD_REDUCTION
               : 0)) *
           (1 -
-            (combatant.hasLegendaryByBonusID(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {
@@ -243,7 +243,7 @@ class Abilities extends CoreAbilities {
               ? BORN_TO_BE_WILD_CD_REDUCTION
               : 0)) *
           (1 -
-            (combatant.hasLegendaryByBonusID(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {
@@ -260,7 +260,7 @@ class Abilities extends CoreAbilities {
               ? BORN_TO_BE_WILD_CD_REDUCTION
               : 0)) *
           (1 -
-            (combatant.hasLegendaryByBonusID(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {
@@ -307,9 +307,7 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         castEfficiency: {
-          suggestion: this.selectedCombatant.hasLegendaryByBonusID(
-            SPELLS.SOULFORGE_EMBERS_EFFECT.bonusID,
-          ),
+          suggestion: this.selectedCombatant.hasLegendary(SPELLS.SOULFORGE_EMBERS_EFFECT),
           recommendedEfficiency: 0.55,
         },
       },
@@ -321,9 +319,7 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         castEfficiency: {
-          suggestion: this.selectedCombatant.hasLegendaryByBonusID(
-            SPELLS.SOULFORGE_EMBERS_EFFECT.bonusID,
-          ),
+          suggestion: this.selectedCombatant.hasLegendary(SPELLS.SOULFORGE_EMBERS_EFFECT),
           recommendedEfficiency: 0.9,
         },
       },

--- a/analysis/huntersurvival/src/modules/Abilities.tsx
+++ b/analysis/huntersurvival/src/modules/Abilities.tsx
@@ -77,7 +77,7 @@ class Abilities extends CoreAbilities {
         cooldown:
           120 *
           (1 -
-            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {
@@ -223,7 +223,7 @@ class Abilities extends CoreAbilities {
               ? BORN_TO_BE_WILD_CD_REDUCTION
               : 0)) *
           (1 -
-            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {
@@ -243,7 +243,7 @@ class Abilities extends CoreAbilities {
               ? BORN_TO_BE_WILD_CD_REDUCTION
               : 0)) *
           (1 -
-            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {
@@ -260,7 +260,7 @@ class Abilities extends CoreAbilities {
               ? BORN_TO_BE_WILD_CD_REDUCTION
               : 0)) *
           (1 -
-            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT.id)
+            (combatant.hasLegendary(SPELLS.CALL_OF_THE_WILD_EFFECT)
               ? CALL_OF_THE_WILD_CD_REDUCTION
               : 0)),
         gcd: {

--- a/analysis/huntersurvival/src/modules/core/SpellUsable.tsx
+++ b/analysis/huntersurvival/src/modules/core/SpellUsable.tsx
@@ -17,11 +17,7 @@ class SpellUsable extends CoreSpellUsable {
 
   onCast(event: CastEvent) {
     const spell = event.ability;
-    if (
-      this.selectedCombatant.hasLegendaryByBonusID(
-        SPELLS.RYLAKSTALKERS_CONFOUNDING_STRIKES_EFFECT.bonusID,
-      )
-    ) {
+    if (this.selectedCombatant.hasLegendary(SPELLS.RYLAKSTALKERS_CONFOUNDING_STRIKES_EFFECT)) {
       if (RAPTOR_MONGOOSE_VARIANTS.includes(spell)) {
         this.lastPotentialTriggerForBombReset = event;
       } else if (spell.guid === SPELLS.WILDFIRE_BOMB.id) {
@@ -34,9 +30,7 @@ class SpellUsable extends CoreSpellUsable {
   beginCooldown(spellId: number, cooldownTriggerEvent: CastEvent | DamageEvent) {
     if (
       SURVIVAL_BOMB_TYPES.includes(spellId) &&
-      this.selectedCombatant.hasLegendaryByBonusID(
-        SPELLS.RYLAKSTALKERS_CONFOUNDING_STRIKES_EFFECT.bonusID,
-      )
+      this.selectedCombatant.hasLegendary(SPELLS.RYLAKSTALKERS_CONFOUNDING_STRIKES_EFFECT)
     ) {
       if (this.isOnCooldown(spellId) && this.chargesAvailable(spellId) === 0) {
         this.bombResets += 1;

--- a/analysis/huntersurvival/src/modules/items/ButchersBoneFragments.tsx
+++ b/analysis/huntersurvival/src/modules/items/ButchersBoneFragments.tsx
@@ -32,9 +32,7 @@ class ButchersBoneFragments extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.BUTCHERS_BONE_FRAGMENTS_EFFECT.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.BUTCHERS_BONE_FRAGMENTS_EFFECT);
     if (!this.active) {
       return;
     }

--- a/analysis/huntersurvival/src/modules/items/LatentPoisonInjectors.tsx
+++ b/analysis/huntersurvival/src/modules/items/LatentPoisonInjectors.tsx
@@ -33,9 +33,7 @@ class LatentPoisonInjectors extends Analyzer {
 
   constructor(options: any) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.LATENT_POISON_INJECTORS_EFFECT.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.LATENT_POISON_INJECTORS_EFFECT);
 
     this.addEventListener(
       Events.applydebuff.by(SELECTED_PLAYER).spell(SPELLS.LATENT_POISON_INJECTORS_DEBUFF),

--- a/analysis/huntersurvival/src/modules/items/NesingwarysTrappingApparatus.tsx
+++ b/analysis/huntersurvival/src/modules/items/NesingwarysTrappingApparatus.tsx
@@ -29,9 +29,7 @@ class NesingwarysTrappingApparatus extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.NESINGWARYS_TRAPPING_APPARATUS_EFFECT.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.NESINGWARYS_TRAPPING_APPARATUS_EFFECT);
     if (!this.active) {
       return;
     }

--- a/analysis/huntersurvival/src/modules/items/RylakstalkersConfoundingStrikes.tsx
+++ b/analysis/huntersurvival/src/modules/items/RylakstalkersConfoundingStrikes.tsx
@@ -33,8 +33,8 @@ class RylakstalkersConfoundingStrikes extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.RYLAKSTALKERS_CONFOUNDING_STRIKES_EFFECT.bonusID,
+    this.active = this.selectedCombatant.hasLegendary(
+      SPELLS.RYLAKSTALKERS_CONFOUNDING_STRIKES_EFFECT,
     );
     if (!this.active) {
       return;

--- a/analysis/huntersurvival/src/modules/items/WildfireCluster.tsx
+++ b/analysis/huntersurvival/src/modules/items/WildfireCluster.tsx
@@ -18,9 +18,7 @@ class WildfireCluster extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.WILDFIRE_CLUSTER_EFFECT.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.WILDFIRE_CLUSTER_EFFECT);
     this.addEventListener(
       Events.damage.by(SELECTED_PLAYER).spell(SPELLS.WILDFIRE_CLUSTER_DAMAGE),
       this.onDamage,

--- a/analysis/huntersurvival/src/modules/spells/KillCommand.tsx
+++ b/analysis/huntersurvival/src/modules/spells/KillCommand.tsx
@@ -42,9 +42,7 @@ class KillCommand extends Analyzer {
       Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.FLANKERS_ADVANTAGE),
       this.onFlankersProc,
     );
-    this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.NESINGWARYS_TRAPPING_APPARATUS_EFFECT.bonusID,
-    ) &&
+    this.selectedCombatant.hasLegendary(SPELLS.NESINGWARYS_TRAPPING_APPARATUS_EFFECT) &&
       this.addEventListener(
         Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.KILL_COMMAND_CAST_SV),
         this.checkNesingwaryFocusGain,

--- a/analysis/magearcane/src/modules/features/ArcaneMissiles.tsx
+++ b/analysis/magearcane/src/modules/features/ArcaneMissiles.tsx
@@ -23,7 +23,7 @@ class ArcaneMissiles extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = !this.selectedCombatant.hasLegendaryByBonusID(SPELLS.ARCANE_HARMONY.bonusID);
+    this.active = !this.selectedCombatant.hasLegendary(SPELLS.ARCANE_HARMONY);
     this.hasArcaneEcho = this.selectedCombatant.hasTalent(SPELLS.ARCANE_ECHO_TALENT.id);
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.ARCANE_MISSILES),

--- a/analysis/magearcane/src/modules/features/ArcanePowerPreReqs.tsx
+++ b/analysis/magearcane/src/modules/features/ArcanePowerPreReqs.tsx
@@ -47,9 +47,7 @@ class ArcanePowerPreReqs extends Analyzer {
   constructor(options: Options) {
     super(options);
     this.hasOverpowered = this.selectedCombatant.hasTalent(SPELLS.OVERPOWERED_TALENT.id);
-    this.hasArcaneHarmony = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.ARCANE_HARMONY.bonusID,
-    );
+    this.hasArcaneHarmony = this.selectedCombatant.hasLegendary(SPELLS.ARCANE_HARMONY);
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.ARCANE_POWER),
       this.onArcanePower,

--- a/analysis/magearcane/src/modules/items/ArcaneBombardment.tsx
+++ b/analysis/magearcane/src/modules/items/ArcaneBombardment.tsx
@@ -22,7 +22,7 @@ class ArcaneBombardment extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.ARCANE_BOMBARDMENT.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.ARCANE_BOMBARDMENT);
     this.addEventListener(
       Events.damage.by(SELECTED_PLAYER).spell(SPELLS.ARCANE_BARRAGE),
       this.onBarrageDamage,

--- a/analysis/magearcane/src/modules/items/ArcaneHarmony.tsx
+++ b/analysis/magearcane/src/modules/items/ArcaneHarmony.tsx
@@ -23,7 +23,7 @@ class ArcaneHarmony extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.ARCANE_HARMONY.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.ARCANE_HARMONY);
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.ARCANE_BARRAGE),
       this.onBarrageCast,

--- a/analysis/magefire/src/modules/features/HotStreakPreCasts.tsx
+++ b/analysis/magefire/src/modules/features/HotStreakPreCasts.tsx
@@ -39,7 +39,7 @@ class HotStreakPreCasts extends Analyzer {
     this.hasPyroclasm = this.selectedCombatant.hasTalent(SPELLS.PYROCLASM_TALENT.id);
     this.hasFirestarter = this.selectedCombatant.hasTalent(SPELLS.FIRESTARTER_TALENT.id);
     this.hasSearingTouch = this.selectedCombatant.hasTalent(SPELLS.SEARING_TOUCH_TALENT.id);
-    this.hasFirestorm = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.FIRESTORM.bonusID);
+    this.hasFirestorm = this.selectedCombatant.hasLegendary(SPELLS.FIRESTORM);
     if (this.hasFirestarter || this.hasSearingTouch) {
       this.addEventListener(
         Events.damage.by(SELECTED_PLAYER).spell(FIRE_DIRECT_DAMAGE_SPELLS),

--- a/analysis/magefire/src/modules/items/DisciplinaryCommand.tsx
+++ b/analysis/magefire/src/modules/items/DisciplinaryCommand.tsx
@@ -18,7 +18,7 @@ class DisciplinaryCommand extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.DISCIPLINARY_COMMAND.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.DISCIPLINARY_COMMAND);
     this.addEventListener(
       Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.COMBUSTION),
       this.onCombustionStart,

--- a/analysis/magefire/src/modules/items/FeveredIncantation.tsx
+++ b/analysis/magefire/src/modules/items/FeveredIncantation.tsx
@@ -18,7 +18,7 @@ class FeveredIncantation extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.FEVERED_INCANTATION.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.FEVERED_INCANTATION);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDamage);
   }
 

--- a/analysis/magefire/src/modules/items/Firestorm.tsx
+++ b/analysis/magefire/src/modules/items/Firestorm.tsx
@@ -13,7 +13,7 @@ class Firestorm extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.FIRESTORM.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.FIRESTORM);
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell([SPELLS.PYROBLAST, SPELLS.FLAMESTRIKE]),
       this.onCast,

--- a/analysis/magefire/src/modules/items/SunKingsBlessing.tsx
+++ b/analysis/magefire/src/modules/items/SunKingsBlessing.tsx
@@ -34,7 +34,7 @@ class SunKingsBlessing extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.SUN_KINGS_BLESSING.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.SUN_KINGS_BLESSING);
     this.addEventListener(
       Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.SUN_KINGS_BLESSING_BUFF_STACK),
       this.onStackRemoved,

--- a/analysis/magefrost/src/modules/features/IceLance.tsx
+++ b/analysis/magefrost/src/modules/features/IceLance.tsx
@@ -39,9 +39,7 @@ class IceLance extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.hasGlacialFragments = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.GLACIAL_FRAGMENTS.bonusID,
-    );
+    this.hasGlacialFragments = this.selectedCombatant.hasLegendary(SPELLS.GLACIAL_FRAGMENTS);
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.ICE_LANCE), this.onCast);
     this.addEventListener(
       Events.damage.by(SELECTED_PLAYER).spell(SPELLS.ICE_LANCE_DAMAGE),

--- a/analysis/magefrost/src/modules/items/ColdFront.tsx
+++ b/analysis/magefrost/src/modules/items/ColdFront.tsx
@@ -19,7 +19,7 @@ class ColdFront extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.COLD_FRONT.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.COLD_FRONT);
     this.addEventListener(
       Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.COLD_FRONT_BUFF),
       this.onBuffApplied,

--- a/analysis/magefrost/src/modules/items/GlacialFragments.tsx
+++ b/analysis/magefrost/src/modules/items/GlacialFragments.tsx
@@ -16,7 +16,7 @@ class GlacialFragments extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.GLACIAL_FRAGMENTS.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.GLACIAL_FRAGMENTS);
     this.hasSplittingIce = this.selectedCombatant.hasTalent(SPELLS.SPLITTING_ICE_TALENT.id);
     this.addEventListener(
       Events.damage.by(SELECTED_PLAYER).spell(SPELLS.GLACIAL_FRAGMENTS_DAMAGE),

--- a/analysis/monk/src/FaelineHarmony.tsx
+++ b/analysis/monk/src/FaelineHarmony.tsx
@@ -29,7 +29,7 @@ class FaelineHarmony extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.FAELINE_HARMONY.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.FAELINE_HARMONY);
     if (this.active) {
       this.addEventListener(
         Events.damage.by(SELECTED_PLAYER | SELECTED_PLAYER_PET),

--- a/analysis/monk/src/SinisterTeachings.tsx
+++ b/analysis/monk/src/SinisterTeachings.tsx
@@ -36,7 +36,7 @@ export default class SinisterTeachings extends Analyzer {
 
     this.active =
       this.selectedCombatant.hasCovenant(COVENANTS.VENTHYR.id) &&
-      this.selectedCombatant.hasLegendaryByBonusID(SPELLS.SINISTER_TEACHINGS.bonusID);
+      this.selectedCombatant.hasLegendary(SPELLS.SINISTER_TEACHINGS);
 
     this.CDR = this.selectedCombatant.specId === SPECS.MISTWEAVER_MONK.id ? CDR_MW : CDR_DEFAULT;
 

--- a/analysis/monk/src/TouchOfDeath.js
+++ b/analysis/monk/src/TouchOfDeath.js
@@ -26,7 +26,7 @@ class TouchOfDeath extends ExecuteHelper {
     options.abilities.add({
       spell: SPELLS.TOUCH_OF_DEATH.id,
       category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
-      cooldown: this.selectedCombatant.hasLegendaryByBonusID(SPELLS.FATAL_TOUCH.bonusID) ? 60 : 180,
+      cooldown: this.selectedCombatant.hasLegendary(SPELLS.FATAL_TOUCH) ? 60 : 180,
       gcd:
         this.selectedCombatant.specId === SPECS.MISTWEAVER_MONK ? { base: 1500 } : { static: 1000 },
       castEfficiency: {

--- a/analysis/monkbrewmaster/src/modules/Abilities.ts
+++ b/analysis/monkbrewmaster/src/modules/Abilities.ts
@@ -11,7 +11,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.KEG_SMASH.id,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL,
         cooldown: (haste) => 8 / (1 + haste),
-        charges: combatant.hasLegendaryByBonusID(SPELLS.STORMSTOUTS_LAST_KEG.bonusID) ? 2 : 1,
+        charges: combatant.hasLegendary(SPELLS.STORMSTOUTS_LAST_KEG) ? 2 : 1,
         damageSpellIds: [SPELLS.KEG_SMASH.id],
         castEfficiency: {
           suggestion: true,

--- a/analysis/monkbrewmaster/src/modules/shadowlands/legendaries/StormstoutsLastKeg.tsx
+++ b/analysis/monkbrewmaster/src/modules/shadowlands/legendaries/StormstoutsLastKeg.tsx
@@ -34,7 +34,7 @@ class StormstoutsLastKeg extends Analyzer {
   constructor(options: Options) {
     super(options);
 
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.STORMSTOUTS_LAST_KEG.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.STORMSTOUTS_LAST_KEG);
 
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.KEG_SMASH), this.onDamage);
     this.addEventListener(

--- a/analysis/monkmistweaver/src/modules/features/AlwaysBeCasting.tsx
+++ b/analysis/monkmistweaver/src/modules/features/AlwaysBeCasting.tsx
@@ -40,11 +40,7 @@ class AlwaysBeCasting extends CoreAlwaysBeCastingHealing {
       );
       this.addEventListener(Events.death.to(SELECTED_PLAYER_PET), this.handleChijiDeath);
     }
-    if (
-      this.selectedCombatant.hasLegendaryByBonusID(
-        SPELLS.ANCIENT_TEACHINGS_OF_THE_MONASTERY.bonusID,
-      )
-    ) {
+    if (this.selectedCombatant.hasLegendary(SPELLS.ANCIENT_TEACHINGS_OF_THE_MONASTERY)) {
       AlwaysBeCasting.HEALING_ABILITIES_ON_GCD.push(SPELLS.TIGER_PALM.id);
       AlwaysBeCasting.HEALING_ABILITIES_ON_GCD.push(SPELLS.RISING_SUN_KICK.id);
       AlwaysBeCasting.HEALING_ABILITIES_ON_GCD.push(SPELLS.RISING_SUN_KICK_SECOND.id);

--- a/analysis/monkmistweaver/src/modules/shadowlands/legendaries/AncientTeachingsoftheMonastery.tsx
+++ b/analysis/monkmistweaver/src/modules/shadowlands/legendaries/AncientTeachingsoftheMonastery.tsx
@@ -18,9 +18,7 @@ class AncientTeachingsoftheMonastery extends Analyzer {
    */
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.ANCIENT_TEACHINGS_OF_THE_MONASTERY.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.ANCIENT_TEACHINGS_OF_THE_MONASTERY);
     if (!this.active) {
       return;
     }

--- a/analysis/monkmistweaver/src/modules/shadowlands/legendaries/CloudedFocus.tsx
+++ b/analysis/monkmistweaver/src/modules/shadowlands/legendaries/CloudedFocus.tsx
@@ -29,7 +29,7 @@ class CloudedFocus extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.CLOUDED_FOCUS.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.CLOUDED_FOCUS);
     if (!this.active) {
       return;
     }

--- a/analysis/monkwindwalker/src/modules/features/checklist/Component.tsx
+++ b/analysis/monkwindwalker/src/modules/features/checklist/Component.tsx
@@ -67,7 +67,7 @@ const WindwalkerMonkChecklist = ({ combatant, castEfficiency, thresholds }: Chec
           }
           thresholds={thresholds.fistsofFury}
         />
-        {combatant.hasLegendaryByBonusID(SPELLS.JADE_IGNITION.bonusID) && (
+        {combatant.hasLegendary(SPELLS.JADE_IGNITION) && (
           <Requirement
             name={
               <>
@@ -163,7 +163,7 @@ const WindwalkerMonkChecklist = ({ combatant, castEfficiency, thresholds }: Chec
           />
         )}
       </Rule>
-      {combatant.hasLegendaryByBonusID(SPELLS.LAST_EMPERORS_CAPACITOR.bonusID) && (
+      {combatant.hasLegendary(SPELLS.LAST_EMPERORS_CAPACITOR) && (
         <Rule
           name={
             <>

--- a/analysis/monkwindwalker/src/modules/items/JadeIgnition.tsx
+++ b/analysis/monkwindwalker/src/modules/items/JadeIgnition.tsx
@@ -26,7 +26,7 @@ class JadeIgnition extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.JADE_IGNITION.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.JADE_IGNITION);
     if (!this.active) {
       return;
     }

--- a/analysis/monkwindwalker/src/modules/items/LastEmperorsCapacitor.tsx
+++ b/analysis/monkwindwalker/src/modules/items/LastEmperorsCapacitor.tsx
@@ -31,9 +31,7 @@ class LastEmperorsCapacitor extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.LAST_EMPERORS_CAPACITOR.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.LAST_EMPERORS_CAPACITOR);
     if (!this.active) {
       return;
     }

--- a/analysis/monkwindwalker/src/modules/items/XuensBattlegear.tsx
+++ b/analysis/monkwindwalker/src/modules/items/XuensBattlegear.tsx
@@ -30,7 +30,7 @@ class XuensBattlegear extends Analyzer {
   constructor(options: Options) {
     super(options);
 
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.XUENS_BATTLEGEAR.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.XUENS_BATTLEGEAR);
     if (!this.active) {
       return;
     }

--- a/analysis/paladinholy/src/modules/shadowlands/legendaries/MaraadsCastRatio.tsx
+++ b/analysis/paladinholy/src/modules/shadowlands/legendaries/MaraadsCastRatio.tsx
@@ -11,7 +11,7 @@ class MaraadsCastRatio extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.MARAADS_DYING_BREATH.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.MARAADS_DYING_BREATH);
     if (!this.active) {
       return;
     }

--- a/analysis/paladinholy/src/modules/shadowlands/legendaries/MaraadsOverheal.tsx
+++ b/analysis/paladinholy/src/modules/shadowlands/legendaries/MaraadsOverheal.tsx
@@ -14,7 +14,7 @@ class MaraadsOverheal extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.MARAADS_DYING_BREATH.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.MARAADS_DYING_BREATH);
     if (!this.active) {
       return;
     }

--- a/analysis/paladinholy/src/modules/shadowlands/legendaries/ShockBarrier.tsx
+++ b/analysis/paladinholy/src/modules/shadowlands/legendaries/ShockBarrier.tsx
@@ -18,7 +18,7 @@ class ShockBarrier extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendary(SPELLS.SHOCK_BARRIER);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.SHOCK_BARRIER_ITEM);
     if (!this.active) {
       return;
     }

--- a/analysis/paladinholy/src/modules/shadowlands/legendaries/ShockBarrier.tsx
+++ b/analysis/paladinholy/src/modules/shadowlands/legendaries/ShockBarrier.tsx
@@ -18,7 +18,7 @@ class ShockBarrier extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.SHOCK_BARRIER.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.SHOCK_BARRIER);
     if (!this.active) {
       return;
     }

--- a/analysis/paladinholy/src/modules/spells/FillerLightOfTheMartyrs.tsx
+++ b/analysis/paladinholy/src/modules/spells/FillerLightOfTheMartyrs.tsx
@@ -18,9 +18,7 @@ class FillerLightOfTheMartyrs extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = !this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.MARAADS_DYING_BREATH.bonusID,
-    );
+    this.active = !this.selectedCombatant.hasLegendary(SPELLS.MARAADS_DYING_BREATH);
     if (!this.active) {
       return;
     }

--- a/analysis/paladinholy/src/modules/spells/InefficientLightOfTheMartyrs.tsx
+++ b/analysis/paladinholy/src/modules/spells/InefficientLightOfTheMartyrs.tsx
@@ -11,9 +11,7 @@ class InefficientLightOfTheMartyrs extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = !this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.MARAADS_DYING_BREATH.bonusID,
-    );
+    this.active = !this.selectedCombatant.hasLegendary(SPELLS.MARAADS_DYING_BREATH);
     if (!this.active) {
       return;
     }

--- a/analysis/paladinretribution/src/modules/items/FinalVerdict.tsx
+++ b/analysis/paladinretribution/src/modules/items/FinalVerdict.tsx
@@ -19,7 +19,7 @@ class FinalVerdict extends Analyzer {
     },
   ) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.FINAL_VERDICT.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.FINAL_VERDICT);
     if (!this.active) {
       return;
     }

--- a/analysis/priest/src/TwinsOfTheSunPriestess.tsx
+++ b/analysis/priest/src/TwinsOfTheSunPriestess.tsx
@@ -19,9 +19,7 @@ class TwinsOfTheSunPriestess extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.TWINS_OF_THE_SUN_PRIESTESS.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.TWINS_OF_THE_SUN_PRIESTESS);
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.POWER_INFUSION),
       this.onCast,

--- a/analysis/priestdiscipline/src/modules/shadowlands/legendaries/ClarityOfMind/index.tsx
+++ b/analysis/priestdiscipline/src/modules/shadowlands/legendaries/ClarityOfMind/index.tsx
@@ -21,7 +21,7 @@ class ClarityOfMind extends Analyzer {
     super(options);
 
     this.active =
-      this.selectedCombatant.hasLegendaryByBonusID(SPELLS.CLARITY_OF_MIND.bonusID) &&
+      this.selectedCombatant.hasLegendary(SPELLS.CLARITY_OF_MIND) &&
       this.selectedCombatant.hasTalent(SPELLS.SPIRIT_SHELL_TALENT);
 
     if (!this.active) {

--- a/analysis/priestdiscipline/src/modules/shadowlands/legendaries/ThePenitentOne.tsx
+++ b/analysis/priestdiscipline/src/modules/shadowlands/legendaries/ThePenitentOne.tsx
@@ -26,7 +26,7 @@ class ThePenitentOne extends Analyzer {
   constructor(options: Options) {
     super(options);
 
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.THE_PENITENT_ONE.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.THE_PENITENT_ONE);
     if (!this.active) {
       return;
     }

--- a/analysis/priestholy/src/modules/shadowlands/items/DivineImage.tsx
+++ b/analysis/priestholy/src/modules/shadowlands/items/DivineImage.tsx
@@ -23,7 +23,7 @@ class DivineImage extends Analyzer {
   constructor(options: Options) {
     super(options);
 
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.DIVINE_IMAGE.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.DIVINE_IMAGE);
     if (!this.active) {
       return;
     }

--- a/analysis/priestholy/src/modules/shadowlands/items/FlashConcentration.tsx
+++ b/analysis/priestholy/src/modules/shadowlands/items/FlashConcentration.tsx
@@ -47,7 +47,7 @@ class FlashConcentration extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendary(SPELLS.FLASH_CONCENTRATION);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.FLASH_CONCENTRATION_ITEM);
 
     this.addEventListener(
       Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.FLASH_CONCENTRATION),

--- a/analysis/priestholy/src/modules/shadowlands/items/FlashConcentration.tsx
+++ b/analysis/priestholy/src/modules/shadowlands/items/FlashConcentration.tsx
@@ -47,7 +47,7 @@ class FlashConcentration extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.FLASH_CONCENTRATION.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.FLASH_CONCENTRATION);
 
     this.addEventListener(
       Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.FLASH_CONCENTRATION),

--- a/analysis/priestholy/src/modules/shadowlands/items/HarmoniousApparatus.tsx
+++ b/analysis/priestholy/src/modules/shadowlands/items/HarmoniousApparatus.tsx
@@ -22,7 +22,7 @@ class HarmoniousApparatus extends Analyzer {
   constructor(options: Options) {
     super(options);
 
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.HARMONIOUS_APPARATUS.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.HARMONIOUS_APPARATUS);
   }
 
   get reductionForAllSpells() {

--- a/analysis/priestholy/src/modules/spells/holyword/HolyWordBase.tsx
+++ b/analysis/priestholy/src/modules/spells/holyword/HolyWordBase.tsx
@@ -46,7 +46,7 @@ class HolyWordBase extends Analyzer {
       this.lightOfTheNaruActive = true;
     }
 
-    if (this.selectedCombatant.hasLegendaryByBonusID(SPELLS.HARMONIOUS_APPARATUS.bonusID)) {
+    if (this.selectedCombatant.hasLegendary(SPELLS.HARMONIOUS_APPARATUS)) {
       this.harmoniousApparatusActive = true;
     }
 

--- a/analysis/priestholy/src/modules/spells/holyword/HolyWordChastise.tsx
+++ b/analysis/priestholy/src/modules/spells/holyword/HolyWordChastise.tsx
@@ -21,7 +21,7 @@ class HolyWordSanctify extends HolyWordBase {
       },
     };
 
-    if (this.selectedCombatant.hasLegendaryByBonusID(SPELLS.HARMONIOUS_APPARATUS.bonusID)) {
+    if (this.selectedCombatant.hasLegendary(SPELLS.HARMONIOUS_APPARATUS)) {
       this.serendipityProccers[SPELLS.HOLY_FIRE.id] = {
         baseReduction: () => HOLY_FIRE_SERENDIPITY_REDUCTION,
         lightOfTheNaaruReduction: () =>

--- a/analysis/priestholy/src/modules/spells/holyword/HolyWordSanctify.tsx
+++ b/analysis/priestholy/src/modules/spells/holyword/HolyWordSanctify.tsx
@@ -35,7 +35,7 @@ class HolyWordSanctify extends HolyWordBase {
         apotheosisReduction: () => RENEW_SERENDIPITY_REDUCTION * this.apotheosisMultiplier,
       },
     };
-    if (this.selectedCombatant.hasLegendaryByBonusID(SPELLS.HARMONIOUS_APPARATUS.bonusID)) {
+    if (this.selectedCombatant.hasLegendary(SPELLS.HARMONIOUS_APPARATUS)) {
       this.serendipityProccers[SPELLS.CIRCLE_OF_HEALING_TALENT.id] = {
         baseReduction: () => CIRCLE_OF_HEALING_SERENDIPITY_REDUCTION,
         lightOfTheNaaruReduction: () =>

--- a/analysis/priestholy/src/modules/spells/holyword/HolyWordSerenity.tsx
+++ b/analysis/priestholy/src/modules/spells/holyword/HolyWordSerenity.tsx
@@ -35,7 +35,7 @@ class HolyWordSerenity extends HolyWordBase {
       },
     };
 
-    if (this.selectedCombatant.hasLegendaryByBonusID(SPELLS.HARMONIOUS_APPARATUS.bonusID)) {
+    if (this.selectedCombatant.hasLegendary(SPELLS.HARMONIOUS_APPARATUS)) {
       this.serendipityProccers[SPELLS.PRAYER_OF_MENDING_CAST.id] = {
         baseReduction: () => PRAYER_OF_MENDING_SERENDIPITY_REDUCTION,
         lightOfTheNaaruReduction: () =>

--- a/analysis/priestshadow/src/modules/shadowlands/legendaries/EternalCallToTheVoid.tsx
+++ b/analysis/priestshadow/src/modules/shadowlands/legendaries/EternalCallToTheVoid.tsx
@@ -12,9 +12,7 @@ class EternalCallToTheVoid extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.ETERNAL_CALL_TO_THE_VOID.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.ETERNAL_CALL_TO_THE_VOID);
     this.addEventListener(
       Events.damage.by(SELECTED_PLAYER_PET).spell(SPELLS.ETERNAL_CALL_TO_THE_VOID_MIND_FLAY_DAMAGE),
       this.onDamage,

--- a/analysis/priestshadow/src/modules/shadowlands/legendaries/TalbadarsStratagem.tsx
+++ b/analysis/priestshadow/src/modules/shadowlands/legendaries/TalbadarsStratagem.tsx
@@ -21,7 +21,7 @@ class TalbadarsStratagem extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.TALBADARS_STRATAGEM.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.TALBADARS_STRATAGEM);
     this.addEventListener(
       Events.damage.by(SELECTED_PLAYER).spell(SPELLS.MIND_BLAST),
       this.onDamage,

--- a/analysis/rogue/src/EssenceOfBloodfang.tsx
+++ b/analysis/rogue/src/EssenceOfBloodfang.tsx
@@ -13,7 +13,7 @@ class EssenceOfBloodfang extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.ESSENCE_OF_BLOODFANG.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.ESSENCE_OF_BLOODFANG);
     this.addEventListener(
       Events.heal.by(SELECTED_PLAYER).spell(SPELLS.ESSENCE_OF_BLOODFANG_BUFF),
       this.onHeal,

--- a/analysis/rogue/src/InvigoratingShadowdust.tsx
+++ b/analysis/rogue/src/InvigoratingShadowdust.tsx
@@ -41,9 +41,7 @@ class InvigoratingShadowdust extends Analyzer {
       default:
         break;
     }
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.INVIGORATING_SHADOWDUST.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.INVIGORATING_SHADOWDUST);
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.VANISH), this.onCast);
   }
 

--- a/analysis/rogueassassination/src/modules/spells/shadowlands/legendaries/DashingScoundrel.tsx
+++ b/analysis/rogueassassination/src/modules/spells/shadowlands/legendaries/DashingScoundrel.tsx
@@ -20,7 +20,7 @@ class DashingScoundrel extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendary(SPELLS.DASHING_SCOUNDREL);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.DASHING_SCOUNDREL_ITEM);
     this.addEventListener(
       Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.DASHING_SCOUNDREL),
       this.onEnergize,

--- a/analysis/rogueassassination/src/modules/spells/shadowlands/legendaries/DashingScoundrel.tsx
+++ b/analysis/rogueassassination/src/modules/spells/shadowlands/legendaries/DashingScoundrel.tsx
@@ -20,7 +20,7 @@ class DashingScoundrel extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.DASHING_SCOUNDREL.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.DASHING_SCOUNDREL);
     this.addEventListener(
       Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.DASHING_SCOUNDREL),
       this.onEnergize,

--- a/analysis/rogueassassination/src/modules/spells/shadowlands/legendaries/DuskwalkersPatch.tsx
+++ b/analysis/rogueassassination/src/modules/spells/shadowlands/legendaries/DuskwalkersPatch.tsx
@@ -23,7 +23,7 @@ class DuskwalkersPatch extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.DUSKWALKERS_PATCH.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.DUSKWALKERS_PATCH);
     this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onCast);
   }
 

--- a/analysis/rogueoutlaw/src/modules/spells/shadowlands/legendaries/Celerity.tsx
+++ b/analysis/rogueoutlaw/src/modules/spells/shadowlands/legendaries/Celerity.tsx
@@ -33,7 +33,7 @@ class Celerity extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.CELERITY.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.CELERITY);
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.ADRENALINE_RUSH),
       this.onAdrenalineRushCast,

--- a/analysis/rogueoutlaw/src/modules/spells/shadowlands/legendaries/GreenskinsWickers.tsx
+++ b/analysis/rogueoutlaw/src/modules/spells/shadowlands/legendaries/GreenskinsWickers.tsx
@@ -16,7 +16,7 @@ class GreenskinsWickers extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.GREENSKINS_WICKERS.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.GREENSKINS_WICKERS);
     this.addEventListener(
       Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.GREENSKINS_WICKERS_BUFF),
       this.onGreenskinBuff,

--- a/analysis/rogueoutlaw/src/modules/spells/shadowlands/legendaries/GuileCharm.tsx
+++ b/analysis/rogueoutlaw/src/modules/spells/shadowlands/legendaries/GuileCharm.tsx
@@ -18,7 +18,7 @@ class GuileCharm extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.GUILE_CHARM.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.GUILE_CHARM);
   }
 
   get percentUptime() {

--- a/analysis/roguesubtlety/src/modules/spells/shadowlands/legendaries/AkaarisSoulFragment.tsx
+++ b/analysis/roguesubtlety/src/modules/spells/shadowlands/legendaries/AkaarisSoulFragment.tsx
@@ -18,9 +18,7 @@ class AkaarisSoulFragment extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.AKAARIS_SOUL_FRAGMENT.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.AKAARIS_SOUL_FRAGMENT);
     this.addEventListener(
       Events.damage.by(SELECTED_PLAYER).spell(SPELLS.AKAARIS_SOUL_FRAGMENT_SHADOWSTRIKE),
       this.onDamage,

--- a/analysis/roguesubtlety/src/modules/spells/shadowlands/legendaries/TheRotten.tsx
+++ b/analysis/roguesubtlety/src/modules/spells/shadowlands/legendaries/TheRotten.tsx
@@ -19,7 +19,7 @@ class TheRotten extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.THE_ROTTEN.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.THE_ROTTEN);
     this.addEventListener(
       Events.resourcechange
         .by(SELECTED_PLAYER)

--- a/analysis/shamanrestoration/src/modules/shadowlands/legendaries/EarthenHarmony.tsx
+++ b/analysis/shamanrestoration/src/modules/shadowlands/legendaries/EarthenHarmony.tsx
@@ -19,7 +19,7 @@ class EarthenHarmony extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.EARTHEN_HARMONY.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.EARTHEN_HARMONY);
 
     this.addEventListener(
       Events.heal.by(SELECTED_PLAYER).spell(SPELLS.EARTH_SHIELD_HEAL),

--- a/analysis/shamanrestoration/src/modules/shadowlands/legendaries/JonatsNaturalFocus.tsx
+++ b/analysis/shamanrestoration/src/modules/shadowlands/legendaries/JonatsNaturalFocus.tsx
@@ -18,7 +18,7 @@ class JonatsNaturalFocus extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.JONATS_NATURAL_FOCUS.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.JONATS_NATURAL_FOCUS);
 
     this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.CHAIN_HEAL), this.chainHeal);
   }

--- a/analysis/shamanrestoration/src/modules/shadowlands/legendaries/PrimalTideCore.tsx
+++ b/analysis/shamanrestoration/src/modules/shadowlands/legendaries/PrimalTideCore.tsx
@@ -40,7 +40,7 @@ class PrimalTideCore extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.PRIMAL_TIDE_CORE.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.PRIMAL_TIDE_CORE);
 
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell([SPELLS.RIPTIDE, SPELLS.PRIMORDIAL_WAVE_CAST]),

--- a/analysis/warriorarms/src/modules/checklist/Component.tsx
+++ b/analysis/warriorarms/src/modules/checklist/Component.tsx
@@ -53,7 +53,7 @@ const ArmsWarriorChecklist = ({
           </div>
         }
       />
-      {!combatant.hasLegendaryByBonusID(SPELLS.ENDURING_BLOW.bonusID) && (
+      {!combatant.hasLegendary(SPELLS.ENDURING_BLOW) && (
         <Rule
           name={
             <>

--- a/analysis/warriorarms/src/modules/core/AplCheck.tsx
+++ b/analysis/warriorarms/src/modules/core/AplCheck.tsx
@@ -28,7 +28,10 @@ export const apl = build([
   { spell: SPELLS.MORTAL_STRIKE, condition: cnd.hasLegendary(SPELLS.ENDURING_BLOW) },
   {
     spell: SPELLS.MORTAL_STRIKE,
-    condition: cnd.and(cnd.hasLegendary(SPELLS.BATTLELORD), cnd.buffPresent(SPELLS.BATTLELORD)),
+    condition: cnd.and(
+      cnd.hasLegendary(SPELLS.BATTLELORD_ITEM),
+      cnd.buffPresent(SPELLS.BATTLELORD),
+    ),
   },
   {
     spell: SPELLS.MORTAL_STRIKE,

--- a/analysis/warriorarms/src/modules/core/Dots/DeepWoundsRefreshes.tsx
+++ b/analysis/warriorarms/src/modules/core/Dots/DeepWoundsRefreshes.tsx
@@ -77,7 +77,7 @@ class EarlyDotRefresh extends EarlyDotRefreshesCore {
           targetID: event.targetID,
           targetInstance: event.targetInstance,
         }) &&
-          this.selectedCombatant.hasLegendary(SPELLS.ENDURING_BLOW.id) &&
+          this.selectedCombatant.hasLegendary(SPELLS.ENDURING_BLOW) &&
           this.hasTwoOverpowerStacks()))
     ) {
       this.lastCastGoodExtension = true;

--- a/analysis/warriorarms/src/modules/core/Dots/DeepWoundsRefreshes.tsx
+++ b/analysis/warriorarms/src/modules/core/Dots/DeepWoundsRefreshes.tsx
@@ -77,7 +77,7 @@ class EarlyDotRefresh extends EarlyDotRefreshesCore {
           targetID: event.targetID,
           targetInstance: event.targetInstance,
         }) &&
-          this.selectedCombatant.hasLegendaryByBonusID(SPELLS.ENDURING_BLOW.id) &&
+          this.selectedCombatant.hasLegendary(SPELLS.ENDURING_BLOW.id) &&
           this.hasTwoOverpowerStacks()))
     ) {
       this.lastCastGoodExtension = true;

--- a/analysis/warriorarms/src/modules/shadowlands/legendaries/SignetOfTormentedKings.tsx
+++ b/analysis/warriorarms/src/modules/shadowlands/legendaries/SignetOfTormentedKings.tsx
@@ -26,9 +26,7 @@ class SignetOfTormentedKings extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(
-      SPELLS.SIGNET_OF_TORMENTED_KINGS.bonusID,
-    );
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.SIGNET_OF_TORMENTED_KINGS);
 
     this.addEventListener(
       Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.AVATAR_TALENT),

--- a/analysis/warriorprotection/src/modules/features/BlockCheck.tsx
+++ b/analysis/warriorprotection/src/modules/features/BlockCheck.tsx
@@ -36,7 +36,7 @@ class BlockCheck extends Analyzer {
   constructor(options: Options) {
     super(options);
     this.bolster = this.selectedCombatant.hasTalent(SPELLS.BOLSTER_TALENT.id);
-    const reprisal = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.REPRISAL.bonusID);
+    const reprisal = this.selectedCombatant.hasLegendary(SPELLS.REPRISAL);
     const heavyRepercussions = this.selectedCombatant.hasTalent(
       SPELLS.HEAVY_REPERCUSSIONS_TALENT.id,
     );

--- a/analysis/warriorprotection/src/modules/shadowlands/legendaries/TheWall.tsx
+++ b/analysis/warriorprotection/src/modules/shadowlands/legendaries/TheWall.tsx
@@ -33,7 +33,7 @@ class TheWall extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.THE_WALL.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.THE_WALL);
     if (!this.active) {
       return;
     }

--- a/analysis/warriorprotection/src/modules/shadowlands/legendaries/Thunderlord.tsx
+++ b/analysis/warriorprotection/src/modules/shadowlands/legendaries/Thunderlord.tsx
@@ -28,7 +28,7 @@ class Thunderlord extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasLegendaryByBonusID(SPELLS.THUNDERLORD.bonusID);
+    this.active = this.selectedCombatant.hasLegendary(SPELLS.THUNDERLORD);
     if (!this.active) {
       return;
     }

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -54,6 +54,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2022, 3, 25), 'Handle Unity legendary.', emallson),
   change(date(2022, 3, 23), 'Fixed degraded experience for Venthyr Mistweaver', Trevor),
   change(date(2022, 3, 14), 'Correcting the spelling of Anduin Wrynn.', Abelito75),
   change(date(2022, 3, 14), 'Added Cosmic Healing Potion to potions list.', Abelito75),

--- a/src/common/SPELLS/shadowlands/legendaries/druid.ts
+++ b/src/common/SPELLS/shadowlands/legendaries/druid.ts
@@ -1,18 +1,22 @@
 const legendaries = {
   //region Balance
+  BALANCE_OF_ALL_THINGS_ITEM: {
+    id: 339942,
+    name: 'Balance of All Things',
+    icon: 'ability_druid_balanceofpower',
+    bonusID: 7107,
+  },
 
   BALANCE_OF_ALL_THINGS_LUNAR: {
     id: 339946,
     name: 'Balance of All Things',
     icon: 'ability_druid_balanceofpower',
-    bonusID: 7107,
   },
 
   BALANCE_OF_ALL_THINGS_SOLAR: {
     id: 339943,
     name: 'Balance of All Things',
     icon: 'ability_druid_balanceofpower',
-    bonusID: 7107,
   },
   //endregion
 

--- a/src/common/SPELLS/shadowlands/legendaries/druid.ts
+++ b/src/common/SPELLS/shadowlands/legendaries/druid.ts
@@ -78,6 +78,12 @@ const legendaries = {
     icon: 'inv_misc_herb_felblossom',
     manaCost: 800,
   },
+  MEMORY_OF_THE_MOTHER_TREE_ITEM: {
+    id: 339064,
+    name: 'Memory of the Mother Tree',
+    icon: 'spell_druid_rampantgrowth',
+    bonusID: 7096,
+  },
   MEMORY_OF_THE_MOTHER_TREE: {
     id: 189877,
     name: 'Memory of the Mother Tree',

--- a/src/common/SPELLS/shadowlands/legendaries/druid.ts
+++ b/src/common/SPELLS/shadowlands/legendaries/druid.ts
@@ -69,6 +69,7 @@ const legendaries = {
     id: 338831,
     name: "The Dark Titan's Lesson",
     icon: 'spell_druid_germination_rejuvenation',
+    bonusID: 7097,
   },
   LIFEBLOOM_DTL_HOT_HEAL: {
     // with The Dark Titan's Lesson legendary, BOTH lifeblooms will have this ID
@@ -76,7 +77,6 @@ const legendaries = {
     name: 'Lifebloom',
     icon: 'inv_misc_herb_felblossom',
     manaCost: 800,
-    bonusID: 7097,
   },
   MEMORY_OF_THE_MOTHER_TREE: {
     id: 189877,

--- a/src/common/SPELLS/shadowlands/legendaries/mage.ts
+++ b/src/common/SPELLS/shadowlands/legendaries/mage.ts
@@ -102,7 +102,7 @@ const legendaries = {
     bonusID: 6828,
   },
   FREEZING_WINDS: {
-    id: 327478,
+    id: 327364,
     name: 'Freezing Winds',
     icon: 'spell_shadow_soulleech_2',
     bonusID: 6829,

--- a/src/common/SPELLS/shadowlands/legendaries/paladin.ts
+++ b/src/common/SPELLS/shadowlands/legendaries/paladin.ts
@@ -1,10 +1,15 @@
 const legendaries = {
   //region Holy
+  SHOCK_BARRIER_ITEM: {
+    id: 337825,
+    name: 'Shock Barrier',
+    icon: 'ability_paladin_blessedmending',
+    bonusID: 7059,
+  },
   SHOCK_BARRIER: {
     id: 337824,
     name: 'Shock Barrier',
     icon: 'ability_paladin_blessedmending',
-    bonusID: 7059,
   },
 
   MARAADS_DYING_BREATH: {

--- a/src/common/SPELLS/shadowlands/legendaries/priest.ts
+++ b/src/common/SPELLS/shadowlands/legendaries/priest.ts
@@ -32,11 +32,16 @@ const legendaries: SpellList<LegendarySpell> = {
     icon: 'inv_pet_naaru',
     bonusID: 6973,
   },
+  FLASH_CONCENTRATION_ITEM: {
+    id: 336266,
+    name: 'Flash Concentration',
+    icon: 'ability_priest_flashoflight',
+    bonusID: 6974,
+  },
   FLASH_CONCENTRATION: {
     id: 336267,
     name: 'Flash Concentration',
     icon: 'ability_priest_flashoflight',
-    bonusID: 6974,
   },
   //endregion
   // https://www.warcraftlogs.com/reports/NKcbdPzMXRJ1Drk6#fight=9&type=damage-done&source=11

--- a/src/common/SPELLS/shadowlands/legendaries/rogue.ts
+++ b/src/common/SPELLS/shadowlands/legendaries/rogue.ts
@@ -1,8 +1,13 @@
 const legendaries = {
   //region Assassination
+  DASHING_SCOUNDREL_ITEM: {
+    id: 340081,
+    bonusID: 7115,
+    name: 'Dashing Scoundrel',
+    icon: 'ability_rogue_venomouswounds',
+  },
   DASHING_SCOUNDREL: {
     id: 340426,
-    bonusID: 7115,
     name: 'Dashing Scoundrel',
     icon: 'ability_rogue_venomouswounds',
   },

--- a/src/common/SPELLS/shadowlands/legendaries/warrior.ts
+++ b/src/common/SPELLS/shadowlands/legendaries/warrior.ts
@@ -6,22 +6,31 @@ const legendaries = {
     icon: 'ability_titankeeper_piercingcorruption',
     bonusID: 6962,
   },
+  BATTLELORD_ITEM: {
+    id: 335274,
+    name: 'Battlelord',
+    icon: 'ability_pvp_hardiness',
+  },
   BATTLELORD: {
     id: 346369,
     name: 'Battlelord',
     icon: 'ability_pvp_hardiness',
-    bonusID: 6960,
   },
   BATTLELORD_ENERGIZE: {
     id: 346370,
     name: 'Battlelord',
     icon: 'ability_pvp_hardiness',
   },
+  EXPLOITER_ITEM: {
+    id: 335451,
+    name: 'Exploiter',
+    icon: 'inv_sword_48',
+    bonusID: 6961,
+  },
   EXPLOITER: {
     id: 335452,
     name: 'Exploiter',
     icon: 'inv_sword_48',
-    bonusID: 6961,
   },
   //endregion
 

--- a/src/parser/core/Combatant.ts
+++ b/src/parser/core/Combatant.ts
@@ -453,7 +453,7 @@ class Combatant extends Entity {
    * Each legendary is given a specific `effectID` that is the same regardless which slot it appears on.
    * This id is the same as the spell ID on Wowhead.
    */
-  hasLegendary(legendary: Pick<LegendarySpell, 'id'>) {
+  hasLegendary(legendary: LegendarySpell) {
     const foundLegendaryMatch = Object.keys(this._gearItemsBySlotId)
       .map((key: any) => this._gearItemsBySlotId[key])
       .find((item: Item) => item.effectID === legendary.id);

--- a/src/parser/core/Combatant.ts
+++ b/src/parser/core/Combatant.ts
@@ -1,6 +1,7 @@
 import { Enchant } from 'common/ITEMS/Item';
 import { T28_TIER_GEAR_IDS, TIER_BY_CLASSES } from 'common/ITEMS/shadowlands';
 import SPELLS from 'common/SPELLS';
+import { LegendarySpell } from 'common/SPELLS/Spell';
 import { getClassBySpecId } from 'game/CLASSES';
 import GEAR_SLOTS from 'game/GEAR_SLOTS';
 import RACES from 'game/RACES';
@@ -448,17 +449,14 @@ class Combatant extends Entity {
     return this._getGearItemBySlotId(GEAR_SLOTS.OFFHAND);
   }
 
-  //Each legendary is given a specific bonusID that is the same regardless which slot it appears on.
-  hasLegendaryByBonusID(legendaryBonusID: number) {
+  /**
+   * Each legendary is given a specific `effectID` that is the same regardless which slot it appears on.
+   * This id is the same as the spell ID on Wowhead.
+   */
+  hasLegendary(legendary: Pick<LegendarySpell, 'id'>) {
     const foundLegendaryMatch = Object.keys(this._gearItemsBySlotId)
       .map((key: any) => this._gearItemsBySlotId[key])
-      .find((item: Item) => {
-        if (typeof item.bonusIDs === 'number') {
-          return item.bonusIDs === legendaryBonusID;
-        } else {
-          return item?.bonusIDs?.includes(legendaryBonusID);
-        }
-      });
+      .find((item: Item) => item.effectID === legendary.id);
     return typeof foundLegendaryMatch === 'object';
   }
 

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -807,6 +807,7 @@ export interface Item {
   icon: string;
   itemLevel: number;
   bonusIDs?: number | number[];
+  effectID?: number;
   permanentEnchant?: number;
   temporaryEnchant?: number;
   gems?: Gem[];

--- a/src/parser/shared/metrics/apl/conditions/hasLegendary.tsx
+++ b/src/parser/shared/metrics/apl/conditions/hasLegendary.tsx
@@ -6,7 +6,7 @@ import { Condition, tenseAlt } from '../index';
 export default function hasLegendary(legendary: LegendarySpell): Condition<boolean> {
   return {
     key: `hasLegendary-${legendary.id}`,
-    init: ({ combatant }) => combatant.hasLegendaryByBonusID(legendary.bonusID!),
+    init: ({ combatant }) => combatant.hasLegendary(legendary),
     update: (state, _event) => state,
     validate: (state, _event) => state,
     describe: (tense) => (


### PR DESCRIPTION
WCL maps the `effectID` of Unity legendaries to the appropriate covenant legendary, but doesn't touch the bonusIDs. This PR changes our `hasLegendaryByBonusID` to be simply `hasLegendary` and take a `LegendarySpell` as the argument.

This also includes a number of fixes to item ids, as well as a fix to the Call of the Wild hunter legendary which was incorrectly using the spell id instead of the bonus id this whole time.

the only snapshot updates are related to that Call of the Wild fix.