### PR TITLE
[#4816] fix issue with donut chart text

### DIFF
--- a/analysis/priestdiscipline/src/modules/shadowlands/legendaries/ClarityOfMind/ClaritySourceDonut.tsx
+++ b/analysis/priestdiscipline/src/modules/shadowlands/legendaries/ClarityOfMind/ClaritySourceDonut.tsx
@@ -9,7 +9,7 @@ interface ClaritySourceDonutProps {
 }
 
 interface ClaritySourceGraphItem {
-  color?: string;
+  color: string;
   spellId: number;
   label: string;
   value: number;

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -54,6 +54,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2022, 4, 2), 'Fix issue with Donut Chart failing to render.', emallson),
   change(date(2022, 3, 25), 'Handle Unity legendary.', emallson),
   change(date(2022, 3, 23), 'Fixed degraded experience for Venthyr Mistweaver', Trevor),
   change(date(2022, 3, 14), 'Correcting the spelling of Anduin Wrynn.', Abelito75),

--- a/src/parser/ui/DonutChart.tsx
+++ b/src/parser/ui/DonutChart.tsx
@@ -2,33 +2,33 @@ import { formatPercentage } from 'common/format';
 import { SpellLink } from 'interface';
 import { TooltipElement } from 'interface';
 import BaseChart from 'parser/ui/BaseChart';
-import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
+import { VisualizationSpec } from 'react-vega';
 
 import 'parser/ui/DonutChart.scss';
 
-class DonutChart extends PureComponent {
-  static propTypes = {
-    items: PropTypes.arrayOf(
-      PropTypes.shape({
-        value: PropTypes.number.isRequired,
-        label: PropTypes.node.isRequired,
-        color: PropTypes.string.isRequired,
-        tooltip: PropTypes.node,
-        spellId: PropTypes.number,
-        valueTooltip: PropTypes.node,
-      }),
-    ).isRequired,
-    // While you could change the chart size, I strongly recommend you do not for consistency and to avoid breaking whenever this component is modified. Do you really need to adjust the size?
-    chartSize: PropTypes.number,
-    innerRadiusFactor: PropTypes.number,
-  };
+type Item = {
+  label: React.ReactNode;
+  tooltip?: React.ReactNode;
+  color: string;
+  value: number;
+  spellId?: number;
+  valueTooltip?: React.ReactNode;
+};
+
+type Props = {
+  items: Item[];
+  chartSize: number;
+  innerRadiusFactor: number;
+};
+
+class DonutChart extends PureComponent<Props> {
   static defaultProps = {
     chartSize: 90,
     innerRadiusFactor: 0.28,
   };
 
-  renderLegend(items) {
+  renderLegend(items: Item[]) {
     const total = items.reduce((sum, item) => sum + item.value, 0);
 
     return (
@@ -53,13 +53,13 @@ class DonutChart extends PureComponent {
       </div>
     );
   }
-  renderChart(items, chartSize, innerRadiusFactor) {
+  renderChart(items: Item[], chartSize: number, innerRadiusFactor: number) {
     const innerRadius = chartSize * innerRadiusFactor;
 
     const data = {
       items,
     };
-    const spec = {
+    const spec: VisualizationSpec = {
       data: {
         name: 'items',
       },
@@ -73,11 +73,11 @@ class DonutChart extends PureComponent {
           type: 'quantitative',
         },
         color: {
-          field: 'label',
+          field: 'color',
           type: 'nominal',
           legend: null,
           scale: {
-            domain: items.map(({ label }) => label),
+            domain: items.map(({ color }) => color),
             range: items.map(({ color }) => color),
           },
         },


### PR DESCRIPTION
passing react components as the labels for the donut chart was breaking
the rendering. This now uses distinct colors as the keys for the chart,
since we render the legend separately anyway.