### PR TITLE
Add Flametongue and Windfury weapon to max enhancement list

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -47,13 +47,15 @@ import {
   ChrisKaczor,
   Jeff,
   Trevor,
-  bhawkins6177
+  bhawkins6177,
+  sorrellp
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(20221, 4, 6), 'Add Flametongue and Windfury weapon to max enhancement list', sorrellp),
   change(date(2022, 4, 2), 'Fix issue with Donut Chart failing to render.', emallson),
   change(date(2022, 3, 25), 'Handle Unity legendary.', emallson),
   change(date(2022, 3, 23), 'Fixed degraded experience for Venthyr Mistweaver', Trevor),

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -1857,3 +1857,8 @@ export const xizbow: Contributor = {
     },
   ],
 };
+
+export const sorrellp: Contributor = {
+  nickname: 'sorrellp',
+  github: 'sorrellp',
+};

--- a/src/common/ITEMS/shadowlands/enchants.ts
+++ b/src/common/ITEMS/shadowlands/enchants.ts
@@ -231,6 +231,20 @@ const enchants: ItemList<Enchant> = {
     icon: 'inv_blacksmithing_greaterweightstone',
     effectId: 6201,
   },
+
+  //Shaman Only
+  FLAMETONGUE_WEAPON: {
+    id: 334294,
+    name: 'Flametongue Weapon',
+    icon: 'spell_fire_flametounge',
+    effectId: 5400,
+  },
+  WINDFURY_WEAPON: {
+    id: 334302,
+    name: 'Flametongue Weapon',
+    icon: 'spell_fire_flametounge',
+    effectId: 5401,
+  },
 };
 
 export default enchants;

--- a/src/parser/shadowlands/modules/items/WeaponEnhancementChecker.tsx
+++ b/src/parser/shadowlands/modules/items/WeaponEnhancementChecker.tsx
@@ -9,6 +9,8 @@ const MAX_ENHANCEMENT_IDS = [
   ITEMS.EMBALMERS_OIL.effectId,
   ITEMS.SHADED_SHARPENING_STONE.effectId,
   ITEMS.SHADED_WEIGHTSTONE.effectId,
+  ITEMS.FLAMETONGUE_WEAPON.effectId,
+  ITEMS.WINDFURY_WEAPON.effectId,
 ];
 
 class WeaponEnhancementChecker extends BaseWeaponEnhancementChecker {


### PR DESCRIPTION
This is a fix for issue #4782. 

Enhancement shamans are unable to use weapon oils so flametongue and windfury weapon should count as max weapon enhancements.