### PR TITLE
Remove accidental 1 in src/CHANGELOG.tsx

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -60,7 +60,7 @@ export default [
   change(date(2022, 4, 8), 'Updated Augment Rune Checker to also tracker eteneral augment rune.', Abelito75),
   change(date(2022, 4, 7), 'Updated conduit ranks to assume the player has all empowered conduits unlocked.', xepheris),
   change(date(2022, 4, 7), 'Updated generated conduit information as of patch 9.2.5.43057', Putro),
-  change(date(20221, 4, 6), 'Add Flametongue and Windfury weapon to max enhancement list', xunai),
+  change(date(2022, 4, 6), 'Add Flametongue and Windfury weapon to max enhancement list', xunai),
   change(date(2022, 4, 2), 'Fix issue with Donut Chart failing to render.', emallson),
   change(date(2022, 3, 25), 'Handle Unity legendary.', emallson),
   change(date(2022, 3, 23), 'Fixed degraded experience for Venthyr Mistweaver', Trevor),


### PR DESCRIPTION
I noticed that the changelog entry added (d4e25ef2236ec525d3af80fa49963b9fa0b48e1f) as part of WoWAnalyzer/WoWAnalyzer#4837 was apparently added 18 199 years into the future, so just thought I could probably fix that.

I considered to modify `date()` to throw for unexpected year/month/day but seemed unecessary.