### PR TITLE
Fix conduit parsing bug

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -58,6 +58,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2022, 4, 17), 'Fix conduits not being parsed correctly in some cases', nullDozzer),
   change(date(2022, 4, 17), 'Fix CDR tracking from Effusive Anima Accelerator for Monks and Shamans.', emallson),
   change(date(2022, 4, 15), 'Track CDR from Effusive Anima Accelerator', Tialyss),
   change(date(2022, 4, 15), 'Update tests to produce the same snapshot no matter the locale of running machine', nullDozzer),

--- a/src/parser/core/Combatant.ts
+++ b/src/parser/core/Combatant.ts
@@ -266,8 +266,17 @@ class Combatant extends Entity {
     };
 
     conduits.forEach((conduit: Conduit) => {
-      conduit.itemLevel = conduit.rank; // conduit "rank" passed in is actually its ilvl
-      conduit.rank = ilvlToRankMapping[conduit.rank];
+      if (conduit.itemLevel == null) {
+        // Conduit has not been parsed to ilvl/rank, do it now
+        conduit.itemLevel = conduit.rank;
+        conduit.rank = ilvlToRankMapping[conduit.rank];
+
+        if (conduit.rank == null) {
+          // If rank is undefined after parsing, something has gone horribly wrong
+          console.error('Conduit rank not found', conduit);
+        }
+      }
+
       this.conduitsByConduitID[conduit.spellID] = conduit;
     });
   }


### PR DESCRIPTION
I ran into a bug 

1. View statistics of any analyze. You should see conduit statistics. 
  ![image](https://user-images.githubusercontent.com/13413409/163726642-9d622581-3d20-4d25-a866-038f3d710be3.png)

2. Go back to the player selection screen and select the same player.
  ![image](https://user-images.githubusercontent.com/13413409/163726656-fdb641d4-39d7-4759-9b16-15ab8796288b.png)
  
3. Go back to the statistics. The conduit stats does not show.
  ![image](https://user-images.githubusercontent.com/13413409/163726673-7c1210db-f1db-4deb-86ce-9af440caaceb.png)
 

---

The problem that I could find was that there's a "parsing" of conduits to parse rank/itemlevel. The parsing puts rank into "rank" and the itemlevel into a separate "itemlevel" property. But then when loading the next time, the same objects are passed in again. So now the "rank" is 2 instead of 145 or whatever. 

I think the parsing step should probably store some other object than modifying the original, but since I don't know how things go together, I settled on making sure the object isn't already parsed before parsing it again.
