### PR TITLE
Proxy SPELLS object to throw when accessing a missing spell

### DIFF
--- a/analysis/paladinholy/src/integrationTests/example.test.ts.snap
+++ b/analysis/paladinholy/src/integrationTests/example.test.ts.snap
@@ -6354,6 +6354,69 @@ Array [
 ]
 `;
 
+exports[`Holy Paladin integration test: example log HolyPowerPerMinute matches the statistic snapshot 1`] = `
+<div
+  className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
+>
+  <div
+    className="panel statistic small "
+    position={20}
+  >
+    <div
+      className="panel-body"
+    >
+      <div
+        className="flex boring-value "
+      >
+        <div
+          className="flex-sub icon"
+        >
+          <a
+            href="https://wowhead.com/holy-power"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+             
+            <img
+              alt="Holy Power"
+              className="icon game "
+              src="//render-us.worldofwarcraft.com/icons/56/achievement_bg_winsoa.jpg"
+            />
+          </a>
+        </div>
+        <div
+          className="flex-main value"
+        >
+          <div>
+            0
+          </div>
+          <small>
+            Holy Power Generated Per Minute
+          </small>
+        </div>
+      </div>
+    </div>
+    <div
+      className="detail-corner"
+      data-place="top"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onTouchStart={[Function]}
+    >
+      <svg
+        className="icon"
+        viewBox="0 0 100 100"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M58.9,82.9h7v12.9H34.1V82.9h7.1V45.5h-0.6c-3.6,0-6.4-2.9-6.4-6.4c0-3.6,2.9-6.4,6.4-6.4h0.6h17.4h0.3V82.9z M49,25.8  c6,0,10.8-4.8,10.8-10.8C59.8,9,55,4.2,49,4.2S38.2,9,38.2,15C38.2,21,43,25.8,49,25.8z"
+        />
+      </svg>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Holy Paladin integration test: example log JudgmentOfLight matches the statistic snapshot 1`] = `
 <div
   className="col-lg-3 col-md-4 col-sm-6 col-xs-12"

--- a/analysis/paladinprotection/src/integrationTests/example.test.ts.snap
+++ b/analysis/paladinprotection/src/integrationTests/example.test.ts.snap
@@ -4249,6 +4249,69 @@ Array [
 ]
 `;
 
+exports[`Protection Paladin integration test: example log HolyPowerPerMinute matches the statistic snapshot 1`] = `
+<div
+  className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
+>
+  <div
+    className="panel statistic small "
+    position={20}
+  >
+    <div
+      className="panel-body"
+    >
+      <div
+        className="flex boring-value "
+      >
+        <div
+          className="flex-sub icon"
+        >
+          <a
+            href="https://wowhead.com/holy-power"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+             
+            <img
+              alt="Holy Power"
+              className="icon game "
+              src="//render-us.worldofwarcraft.com/icons/56/achievement_bg_winsoa.jpg"
+            />
+          </a>
+        </div>
+        <div
+          className="flex-main value"
+        >
+          <div>
+            21
+          </div>
+          <small>
+            Holy Power Generated Per Minute
+          </small>
+        </div>
+      </div>
+    </div>
+    <div
+      className="detail-corner"
+      data-place="top"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onTouchStart={[Function]}
+    >
+      <svg
+        className="icon"
+        viewBox="0 0 100 100"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M58.9,82.9h7v12.9H34.1V82.9h7.1V45.5h-0.6c-3.6,0-6.4-2.9-6.4-6.4c0-3.6,2.9-6.4,6.4-6.4h0.6h17.4h0.3V82.9z M49,25.8  c6,0,10.8-4.8,10.8-10.8C59.8,9,55,4.2,49,4.2S38.2,9,38.2,15C38.2,21,43,25.8,49,25.8z"
+        />
+      </svg>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Protection Paladin integration test: example log Judgment matches the statistic snapshot 1`] = `
 <div
   className="col-lg-3 col-md-4 col-sm-6 col-xs-12"

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -58,6 +58,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2022, 4, 19), 'Prevent invalid spells from passing internal tests and getting deployed.', emallson),
   change(date(2022, 4, 17), 'Fix conduits not being parsed correctly in some cases', nullDozzer),
   change(date(2022, 4, 17), 'Fix CDR tracking from Effusive Anima Accelerator for Monks and Shamans.', emallson),
   change(date(2022, 4, 15), 'Track CDR from Effusive Anima Accelerator', Tialyss),

--- a/src/common/SPELLS/index.ts
+++ b/src/common/SPELLS/index.ts
@@ -93,11 +93,19 @@ const SPELLS = new Proxy(InternalSpellTable, {
     const value = Reflect.get(target, prop, receiver);
 
     if (value === undefined) {
-      throw new Error(
-        `Attempted to retrieve invalid or missing spell from SPELLS: ${String(
+      if (process.env.NODE_ENV === 'production') {
+        console.error(
+          'Attempted to retrieve invalid or missing spell from SPELLS. If this is expected, use SPELLS.maybeGet.',
           prop,
-        )}. If this is intended, use SPELLS.maybeGet.`,
-      );
+          target,
+        );
+      } else {
+        throw new Error(
+          `Attempted to retrieve invalid or missing spell from SPELLS: ${String(
+            prop,
+          )}. If this is expected, use SPELLS.maybeGet.`,
+        );
+      }
     }
 
     return value;

--- a/src/interface/useSpellInfo.ts
+++ b/src/interface/useSpellInfo.ts
@@ -8,7 +8,7 @@ const fetcher = (...args: Parameters<typeof fetch>) => fetch(...args).then((res)
 const useSpellInfo = (spellId: number) => {
   const { data, error } = useSWR(makeApiUrl(`spell/${spellId}`), {
     fetcher,
-    isPaused: () => SPELLS[spellId] !== undefined,
+    isPaused: () => SPELLS.maybeGet(spellId) !== undefined,
   });
 
   if (error) {
@@ -21,7 +21,7 @@ const useSpellInfo = (spellId: number) => {
     }
   }, [data, spellId]);
 
-  return SPELLS[spellId] || data;
+  return SPELLS.maybeGet(spellId) ?? data;
 };
 
 export default useSpellInfo;

--- a/src/parser/core/Combatant.ts
+++ b/src/parser/core/Combatant.ts
@@ -546,7 +546,8 @@ class Combatant extends Entity {
     // combatantinfo too (or better yet, make a new normalizer for that).
     const timestamp = this.owner.fight.start_time;
     buffs.forEach((buff) => {
-      const spell = SPELLS[buff.ability];
+      const spell = SPELLS.maybeGet(buff.ability);
+
       this.applyBuff({
         type: EventType.ApplyBuff,
         timestamp: timestamp,

--- a/src/parser/core/modules/SpellInfo.ts
+++ b/src/parser/core/modules/SpellInfo.ts
@@ -22,7 +22,7 @@ class SpellInfo extends Analyzer {
   }
 
   addSpellInfo(ability: Omit<Ability, 'type'>) {
-    if (SPELLS[ability.guid] || !ability.name || !ability.abilityIcon) {
+    if (SPELLS.maybeGet(ability.guid) || !ability.name || !ability.abilityIcon) {
       return;
     }
 

--- a/src/parser/shared/normalizers/ApplyBuff.ts
+++ b/src/parser/shared/normalizers/ApplyBuff.ts
@@ -143,12 +143,14 @@ class ApplyBuff extends EventsNormalizer {
             return;
           }
 
+          const spell = SPELLS.maybeGet(spellId);
+
           debug &&
             console.warn(
               'Found a buff on',
               (playersById[targetId] && playersById[targetId].name) || '???',
               'in the combatantinfo that was applied before the pull and never dropped:',
-              (SPELLS[spellId] && SPELLS[spellId].name) || '???',
+              spell?.name ?? '???',
               spellId,
               "! Fabricating an `applybuff` event so you don't have to do anything special to take this into account.",
             );
@@ -158,7 +160,7 @@ class ApplyBuff extends EventsNormalizer {
             type: EventType.ApplyBuff,
             ability: {
               guid: spellId,
-              name: SPELLS[spellId] ? SPELLS[spellId].name : 'Unknown',
+              name: spell?.name ?? 'Unknown',
               abilityIcon: aura.icon,
               type: 0,
             },

--- a/src/parser/tbc/suggestions/lowRankSpells.tsx
+++ b/src/parser/tbc/suggestions/lowRankSpells.tsx
@@ -33,7 +33,7 @@ const lowRankSpells = (spells: LowRankSpells, whitelist: LowRankSpells = []) => 
             </TooltipElement>
           ),
           importance: SuggestionImportance.Regular,
-          icon: (SPELLS[primarySpellId] || SPELLS[spellId])?.icon,
+          icon: (SPELLS.maybeGet(primarySpellId) ?? SPELLS.maybeGet(spellId))?.icon,
         })),
   );
 };


### PR DESCRIPTION
This will help avoid things like `EffusiveAnimaAccelerator` ending up in production and sneakily breaking all Kyrian logs.

The changes are:

- When using the `SPELLS.NAME` or `SPELLS[spellId]` forms, an error is thrown if the spell is not found. This error is not intended to be caught.
- If you want to get a spell by `NAME` or `spellId` and expect that the spell may not be present, use `SPELLS.maybeGet(...)` instead. `SPELLS.maybeGet` will never throw.

I spent a good deal of time looking at fixing `SPELLS` to use the correct types instead of `any`, but it just causes so many spurious type errors to do it right because of incorrect/inspecific types used across the codebase. There are a few actual issues in there as well, but they're a minority. Since we want to switch from the global `SPELLS` to spec/class `SPELLS` for 10.0 I just reverted those changes in favor of this 90% solution (which unfortunately still doesn't give autocompletion, but it will catch typos / bad spell names early!)

(the two snapshot changes are not related to this---they were just missing in the `shadowlands` branch)