### PR TITLE
fix rune regen tracking from #4880

### DIFF
--- a/analysis/deathknight/src/RuneTracker.js
+++ b/analysis/deathknight/src/RuneTracker.js
@@ -50,14 +50,12 @@ class RuneTracker extends ResourceTracker {
       this._runesReadySum[i] = 0;
     }
     this.addEventListener(Events.fightend, this.onFightend);
-
-    const buffFilter = Object.keys(RUNE_REGEN_BUFFS).map((idStr) => ({
-      id: Number(idStr),
-    }));
-
-    this.addEventListener(Events.applybuff.to(SELECTED_PLAYER).spell(buffFilter), this.onApplybuff);
     this.addEventListener(
-      Events.removebuff.to(SELECTED_PLAYER).spell(buffFilter),
+      Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.RUNIC_CORRUPTION),
+      this.onApplybuff,
+    );
+    this.addEventListener(
+      Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.RUNIC_CORRUPTION),
       this.onRemovebuff,
     );
     this.addEventListener(Events.UpdateSpellUsable.spell(RUNE_IDS), this.onUpdateSpellUsable);
@@ -114,18 +112,24 @@ class RuneTracker extends ResourceTracker {
 
   onApplybuff(event) {
     //decrease cooldown when a buff that increases rune regeneration rate is applied.
-    const multiplier = 1 / (1 + RUNE_REGEN_BUFFS[event.ability.guid]);
-    RUNE_IDS.forEach((spell) => {
-      this.changeCooldown(spell.id, multiplier);
-    });
+    const increase = RUNE_REGEN_BUFFS[event.ability.guid];
+    if (increase) {
+      const multiplier = 1 / (1 + increase);
+      RUNE_IDS.forEach((spell) => {
+        this.changeCooldown(spell.id, multiplier);
+      });
+    }
   }
 
   onRemovebuff(event) {
     //increase cooldown when a buff that increases rune regeneration rate fades.
-    const multiplier = 1 + RUNE_REGEN_BUFFS[event.ability.guid];
-    RUNE_IDS.forEach((spell) => {
-      this.changeCooldown(spell.id, multiplier);
-    });
+    const increase = RUNE_REGEN_BUFFS[event.ability.guid];
+    if (increase) {
+      const multiplier = 1 + increase;
+      RUNE_IDS.forEach((spell) => {
+        this.changeCooldown(spell.id, multiplier);
+      });
+    }
   }
 
   onUpdateSpellUsable(event) {
@@ -197,7 +201,14 @@ class RuneTracker extends ResourceTracker {
   }
 
   changeCooldown(spellId, multiplier) {
-    this.spellUsable.accelerate(spellId, multiplier);
+    //increases or decreases rune cooldown
+    if (!this.spellUsable.isOnCooldown(spellId)) {
+      return;
+    }
+    const remainingCooldown = this.spellUsable.cooldownRemaining(spellId);
+    const newCooldown = remainingCooldown * multiplier;
+    const reduction = remainingCooldown - newCooldown;
+    this.spellUsable.reduceCooldown(spellId, reduction);
   }
 
   addCharge() {

--- a/analysis/deathknightblood/src/modules/Abilities.js
+++ b/analysis/deathknightblood/src/modules/Abilities.js
@@ -317,19 +317,28 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.RUNE_1.id,
         category: Abilities.SPELL_CATEGORIES.HIDDEN,
-        cooldown: (haste) => 10 / (1 + haste),
+        cooldown: (haste) => {
+          const multiplier = combatant.hasBuff(SPELLS.CRIMSON_RUNE_WEAPON_BUFF.id) ? 0.4 : 0;
+          return 10 / (1 + haste) / (1 + multiplier);
+        },
         charges: 2,
       },
       {
         spell: SPELLS.RUNE_2.id,
         category: Abilities.SPELL_CATEGORIES.HIDDEN,
-        cooldown: (haste) => 10 / (1 + haste),
+        cooldown: (haste) => {
+          const multiplier = combatant.hasBuff(SPELLS.CRIMSON_RUNE_WEAPON_BUFF.id) ? 0.4 : 0;
+          return 10 / (1 + haste) / (1 + multiplier);
+        },
         charges: 2,
       },
       {
         spell: SPELLS.RUNE_3.id,
         category: Abilities.SPELL_CATEGORIES.HIDDEN,
-        cooldown: (haste) => 10 / (1 + haste),
+        cooldown: (haste) => {
+          const multiplier = combatant.hasBuff(SPELLS.CRIMSON_RUNE_WEAPON_BUFF.id) ? 0.4 : 0;
+          return 10 / (1 + haste) / (1 + multiplier);
+        },
         charges: 2,
       },
 

--- a/analysis/deathknightunholy/src/CHANGELOG.tsx
+++ b/analysis/deathknightunholy/src/CHANGELOG.tsx
@@ -2,11 +2,10 @@
 
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS'
-import { Adoraci, joshinator, Khazak, LeoZhekov, Pendragon, Tialyss } from 'CONTRIBUTORS';
+import { Adoraci, joshinator, Khazak, LeoZhekov, Pendragon } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
-  change(date(2022, 4, 25), <>More accurate rune cooldown tracking for <SpellLink id={SPELLS.RUNIC_CORRUPTION.id} />.</>, Tialyss),
   change(date(2022, 2, 22), <>Changed cooldown reduction tracking for <SpellLink id={SPELLS.CONVOCATION_OF_THE_DEAD.id} /> to flat CDR per rank to reflect 9.2 changes</>, Khazak),
   change(date(2021, 8, 19), <>Added <SpellLink id ={SPELLS.DEATHS_DUE.id}/> module </>, Pendragon),
   change(date(2021, 4, 3), 'Verified 9.0.5 patch changes and bumped support to 9.0.5', Adoraci),

--- a/analysis/deathknightunholy/src/integrationTests/example.test.ts.snap
+++ b/analysis/deathknightunholy/src/integrationTests/example.test.ts.snap
@@ -4303,7 +4303,7 @@ exports[`Unholy Death Knight integration test: example log RuneTracker matches t
           className="flex-main value"
         >
           <div>
-            28.50 %
+            12.72 %
           </div>
           <small>
             Runes overcapped
@@ -4349,28 +4349,6 @@ exports[`Unholy Death Knight integration test: example log RuneTracker matches t
     </div>
   </div>
 </div>
-`;
-
-exports[`Unholy Death Knight integration test: example log RuneTracker matches the suggestions snapshot 1`] = `
-Array [
-  Object {
-    "details": null,
-    "icon": "spell_deathknight_frozenruneweapon",
-    "importance": "regular",
-    "issue": <React.Fragment>
-      You overcapped 
-      28.50
-      % of your runes. Try to always have at least 3 runes on cooldown.
-    </React.Fragment>,
-    "spell": undefined,
-    "stat": <React.Fragment>
-      {"id":"deathknight.shared.suggestions.runes.overcapped","message":"{0}% runes overcapped","values":{"0":"28.50"}}
-       (
-      &lt;15.00% is recommended
-      )
-    </React.Fragment>,
-  },
-]
 `;
 
 exports[`Unholy Death Knight integration test: example log RunicPowerDetails matches the statistic snapshot 1`] = `
@@ -5678,7 +5656,7 @@ exports[`Unholy Death Knight integration test: example log matches the checklist
     </div>
   </li>
   <li
-    className="expandable expanded failed"
+    className="expandable  passed"
   >
     <div
       className="meta"
@@ -5702,8 +5680,8 @@ exports[`Unholy Death Knight integration test: example log matches the checklist
               className="perf-bar"
               style={
                 Object {
-                  "backgroundColor": "#ffc84a",
-                  "width": "54.94152670469066%",
+                  "backgroundColor": "#4ec04e",
+                  "width": "100%",
                 }
               }
             />
@@ -5796,7 +5774,7 @@ exports[`Unholy Death Knight integration test: example log matches the checklist
                   }
                 >
                    
-                  71.50%
+                  87.28%
                    
                    
                 </div>
@@ -5816,9 +5794,9 @@ exports[`Unholy Death Knight integration test: example log matches the checklist
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#ffc84a",
+                        "backgroundColor": "#4ec04e",
                         "transition": "background-color 800ms",
-                        "width": "54.94152670469066%",
+                        "width": "100%",
                       }
                     }
                   />


### PR DESCRIPTION
Mostly a revert. analysis/deathknightblood/src/modules/Abilities.js is the thing i was missing before, so having the acceleration thing in SpellUsable was causing Runic Corruption to get 4x instead of 2x.