### PR TITLE
Fixes to Player Info, Encounter Stats and Character Parses page

### DIFF
--- a/analysis/hunterbeastmastery/src/integrationTests/beastMasteryIntegrationTests.test.ts.snap
+++ b/analysis/hunterbeastmastery/src/integrationTests/beastMasteryIntegrationTests.test.ts.snap
@@ -4979,7 +4979,6 @@ exports[`Beast Mastery Hunter integration test: Multi Target DarkmoonDeckVoracit
             rel="noopener noreferrer"
             target="_blank"
           >
-             
             <img
               alt="Darkmoon Deck: Voracity"
               className="icon game "
@@ -4993,7 +4992,6 @@ exports[`Beast Mastery Hunter integration test: Multi Target DarkmoonDeckVoracit
             rel="noopener noreferrer"
             target="_blank"
           >
-             
             Darkmoon Deck: Voracity
           </a>
         </label>
@@ -15087,7 +15085,6 @@ exports[`Beast Mastery Hunter integration test: Single Target OverchargedAnimaBa
             rel="noopener noreferrer"
             target="_blank"
           >
-             
             <img
               alt="Overcharged Anima Battery"
               className="icon game "
@@ -15101,7 +15098,6 @@ exports[`Beast Mastery Hunter integration test: Single Target OverchargedAnimaBa
             rel="noopener noreferrer"
             target="_blank"
           >
-             
             Overcharged Anima Battery
           </a>
         </label>

--- a/analysis/huntermarksmanship/src/integrationTests/marksmanshipIntegrationTests.test.ts.snap
+++ b/analysis/huntermarksmanship/src/integrationTests/marksmanshipIntegrationTests.test.ts.snap
@@ -4585,7 +4585,6 @@ exports[`Marksmanship Hunter integration test: Multi Target DarkmoonDeckVoracity
             rel="noopener noreferrer"
             target="_blank"
           >
-             
             <img
               alt="Darkmoon Deck: Voracity"
               className="icon game "
@@ -4599,7 +4598,6 @@ exports[`Marksmanship Hunter integration test: Multi Target DarkmoonDeckVoracity
             rel="noopener noreferrer"
             target="_blank"
           >
-             
             Darkmoon Deck: Voracity
           </a>
         </label>

--- a/analysis/huntersurvival/src/integrationTests/survivalIntegrationTests.test.ts.snap
+++ b/analysis/huntersurvival/src/integrationTests/survivalIntegrationTests.test.ts.snap
@@ -10471,7 +10471,6 @@ exports[`Survival Hunter integration test: Single Target DarkmoonDeckVoracity ma
             rel="noopener noreferrer"
             target="_blank"
           >
-             
             <img
               alt="Darkmoon Deck: Voracity"
               className="icon game "
@@ -10485,7 +10484,6 @@ exports[`Survival Hunter integration test: Single Target DarkmoonDeckVoracity ma
             rel="noopener noreferrer"
             target="_blank"
           >
-             
             Darkmoon Deck: Voracity
           </a>
         </label>

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -58,6 +58,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2022, 4, 30), 'Fix broken trinket icons and conduit links on the character page', nullDozzer),
   change(date(2022, 4, 27), 'Updated stat multiplier table for Shadowlands values', Putro),
   change(date(2022, 4, 20), 'Preformance increase for talent identification.', Abelito75),
   change(date(2022, 4, 19), 'Prevent invalid spells from passing internal tests and getting deployed.', emallson),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -58,6 +58,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2022, 4, 30), 'Fix legendary icons not working on Character parses page', nullDozzer),
   change(date(2022, 4, 30), 'Fix broken trinket icons and conduit links on the character page', nullDozzer),
   change(date(2022, 4, 27), 'Updated stat multiplier table for Shadowlands values', Putro),
   change(date(2022, 4, 20), 'Preformance increase for talent identification.', Abelito75),

--- a/src/game/raids/sepulcher/Jailer.ts
+++ b/src/game/raids/sepulcher/Jailer.ts
@@ -3,7 +3,7 @@ import { Boss } from 'game/raids';
 import Background from './images/Jailer.jpg';
 
 const Jailer: Boss = {
-  id: 2544,
+  id: 2537,
   name: 'The Jailer, Zovaal',
   background: Background,
   icon: 'inv_achievement_raid_progenitorraid_jailer',

--- a/src/interface/CharacterParses.js
+++ b/src/interface/CharacterParses.js
@@ -601,7 +601,7 @@ class CharacterParses extends Component {
                     {Object.values(ZONES)
                       .reverse()
                       .map((elem) => (
-                        <option key={'ZONES' + elem.id} value={elem.id}>
+                        <option key={elem.id} value={elem.id}>
                           {elem.name}
                         </option>
                       ))}
@@ -618,7 +618,7 @@ class CharacterParses extends Component {
                       All bosses
                     </option>
                     {this.zoneBosses.map((e) => (
-                      <option key={e.id + e.name} value={e.name}>
+                      <option key={e.id} value={e.name}>
                         {e.name}
                       </option>
                     ))}
@@ -667,7 +667,7 @@ class CharacterParses extends Component {
               <div className="panel character-filters">
                 {this.state.specs.map((elem, index) => (
                   <div
-                    key={'SPECS' + index}
+                    key={index}
                     onClick={() => this.updateSpec(elem.replace(' ', ''))}
                     className={
                       this.state.activeSpec.includes(elem.replace(' ', ''))

--- a/src/interface/CharacterParses.js
+++ b/src/interface/CharacterParses.js
@@ -3,7 +3,7 @@ import { Trans, defineMessage } from '@lingui/macro';
 import { captureException } from 'common/errorLogger';
 import fetchWcl, { CharacterNotFoundError, UnknownApiError, WclApiError } from 'common/fetchWclApi';
 import ITEMS from 'common/ITEMS';
-import { makeCharacterApiUrl, makeItemApiUrl } from 'common/makeApiUrl';
+import { makeCharacterApiUrl } from 'common/makeApiUrl';
 import retryingPromise from 'common/retryingPromise';
 import DIFFICULTIES, { getLabel as getDifficultyLabel } from 'game/DIFFICULTIES';
 import SPECS from 'game/SPECS';
@@ -93,7 +93,6 @@ class CharacterParses extends Component {
       isLoading: true,
       error: null,
       errorMessage: null,
-      trinkets: ITEMS,
       realmSlug: this.props.realm,
     };
 
@@ -190,60 +189,28 @@ class CharacterParses extends Component {
   }
 
   changeParseStructure(rawParses) {
-    const updatedTrinkets = { ...this.state.trinkets };
-    const parses = rawParses.map((elem) => {
-      // get missing trinket-icons later
-      TRINKET_SLOTS.forEach((slotID) => {
-        if (!updatedTrinkets[elem.gear[slotID].id]) {
-          updatedTrinkets[elem.gear[slotID].id] = {
-            name: elem.gear[slotID].name,
-            id: elem.gear[slotID].id,
-            icon: ITEMS[0].icon,
-            quality: elem.gear[slotID].quality,
-          };
-        }
-      });
+    const parses = rawParses.map((elem) => ({
+      name: elem.encounterName,
+      spec: elem.spec.replace(' ', ''),
+      difficulty: elem.difficulty,
 
-      return {
-        name: elem.encounterName,
-        spec: elem.spec.replace(' ', ''),
-        difficulty: elem.difficulty,
+      report_code: elem.reportID,
 
-        report_code: elem.reportID,
+      report_fight: elem.fightID,
 
-        report_fight: elem.fightID,
+      historical_percent: 100 - (elem.rank / elem.outOf) * 100,
+      persecondamount: elem.total,
 
-        historical_percent: 100 - (elem.rank / elem.outOf) * 100,
-        persecondamount: elem.total,
+      start_time: elem.startTime,
 
-        start_time: elem.startTime,
-
-        character_name: elem.characterName,
-        talents: elem.talents,
-        gear: elem.gear,
-        legendaryEffects: elem.legendaryEffects
-          // the effects can come in different order. Sort for most consistent view
-          .sort((a, b) => b.id - a.id),
-        advanced: Object.values(elem.talents).filter((talent) => talent.id === null).length === 0,
-      };
-    });
-
-    Object.values(updatedTrinkets).map((trinket) => {
-      if (trinket.icon === ITEMS[0].icon && trinket.id !== 0) {
-        return fetch(makeItemApiUrl(trinket.id))
-          .then((response) => response.json())
-          .then((data) => {
-            updatedTrinkets[trinket.id].icon = data.icon.split('/').pop();
-            this.setState({
-              trinkets: updatedTrinkets,
-            });
-          })
-          .catch(() => {
-            // ignore errors;;
-          });
-      }
-      return null;
-    });
+      character_name: elem.characterName,
+      talents: elem.talents,
+      gear: elem.gear,
+      legendaryEffects: elem.legendaryEffects
+        // the effects can come in different order. Sort for most consistent view
+        .sort((a, b) => b.id - a.id),
+      advanced: Object.values(elem.talents).filter((talent) => talent.id === null).length === 0,
+    }));
 
     return parses;
   }
@@ -803,7 +770,6 @@ class CharacterParses extends Component {
                         parses={this.filterParses}
                         class={this.state.class}
                         metric={this.state.metric}
-                        trinkets={this.state.trinkets}
                       />
                     )}
                   </div>

--- a/src/interface/CharacterParses.js
+++ b/src/interface/CharacterParses.js
@@ -682,7 +682,7 @@ class CharacterParses extends Component {
 
                 {Object.values(DIFFICULTIES).map((difficultyId) => (
                   <div
-                    key={'DIFFICULTY' + difficultyId}
+                    key={difficultyId}
                     onClick={() => this.updateDifficulty(difficultyId)}
                     className={
                       this.state.activeDifficultyIds.includes(difficultyId)

--- a/src/interface/CharacterParses.js
+++ b/src/interface/CharacterParses.js
@@ -230,7 +230,7 @@ class CharacterParses extends Component {
         return fetch(makeItemApiUrl(trinket.id))
           .then((response) => response.json())
           .then((data) => {
-            updatedTrinkets[trinket.id].icon = data.icon;
+            updatedTrinkets[trinket.id].icon = data.icon.split('/').pop();
             this.setState({
               trinkets: updatedTrinkets,
             });

--- a/src/interface/CharacterParsesList.js
+++ b/src/interface/CharacterParsesList.js
@@ -1,6 +1,5 @@
 import { formatNumber, formatPercentage } from 'common/format';
 import rankingColor from 'common/getRankingColor';
-import SPELLS from 'common/SPELLS';
 import { getLabel as getDifficultyLabel } from 'game/DIFFICULTIES';
 import GEAR_SLOTS from 'game/GEAR_SLOTS';
 import { ItemLink, SpellLink } from 'interface';
@@ -10,6 +9,7 @@ import SpellIcon from 'interface/SpellIcon';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { Link } from 'react-router-dom';
+
 const TRINKET_SLOTS = [GEAR_SLOTS.TRINKET1, GEAR_SLOTS.TRINKET2];
 
 const styles = {

--- a/src/interface/CharacterParsesList.js
+++ b/src/interface/CharacterParsesList.js
@@ -1,15 +1,15 @@
 import { formatNumber, formatPercentage } from 'common/format';
 import rankingColor from 'common/getRankingColor';
+import SPELLS from 'common/SPELLS';
 import { getLabel as getDifficultyLabel } from 'game/DIFFICULTIES';
 import GEAR_SLOTS from 'game/GEAR_SLOTS';
-import { ItemLink } from 'interface';
+import { ItemLink, SpellLink } from 'interface';
 import Icon from 'interface/Icon';
 import { makePlainUrl } from 'interface/makeAnalyzerUrl';
 import SpellIcon from 'interface/SpellIcon';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { Link } from 'react-router-dom';
-
 const TRINKET_SLOTS = [GEAR_SLOTS.TRINKET1, GEAR_SLOTS.TRINKET2];
 
 const styles = {
@@ -26,10 +26,12 @@ class CharacterParsesList extends PureComponent {
     class: PropTypes.string.isRequired,
     metric: PropTypes.string.isRequired,
     trinkets: PropTypes.object.isRequired,
+    spellIcons: PropTypes.object.isRequired,
   };
 
   constructor(props) {
     super(props);
+    this.renderLegendaryEffect = this.renderLegendaryEffect.bind(this);
     this.renderItem = this.renderItem.bind(this);
   }
 
@@ -38,7 +40,23 @@ class CharacterParsesList extends PureComponent {
   }
 
   itemFilter(item, index) {
-    return TRINKET_SLOTS.includes(index) || item.quality === 'legendary';
+    return TRINKET_SLOTS.includes(index);
+  }
+  renderLegendaryEffect(
+    /** @type {{ name: string, id: number, icon: string }} */
+    le,
+  ) {
+    return (
+      <SpellLink key={le.id} id={le.id} icon={false}>
+        <Icon
+          icon={this.props.spellIcons[le.id] ?? SPELLS[1].icon}
+          style={{
+            ...styles.icon,
+            border: '1px solid',
+          }}
+        ></Icon>
+      </SpellLink>
+    );
   }
   renderItem(item) {
     return (
@@ -49,7 +67,10 @@ class CharacterParsesList extends PureComponent {
               ? this.props.trinkets[item.id].icon
               : this.props.trinkets[0].icon
           }
-          style={{ ...styles.icon, border: '1px solid' }}
+          style={{
+            ...styles.icon,
+            border: '1px solid',
+          }}
         />
       </ItemLink>
     );
@@ -89,8 +110,13 @@ class CharacterParsesList extends PureComponent {
                       {this.formatPerformance(elem)}
                     </div>
                   </div>
-                  <div className="col-md-1 text-right">
-                    {elem.advanced && elem.gear.filter(this.itemFilter).map(this.renderItem)}
+                  <div className="col-md-1 text-center">
+                    {elem.advanced && (
+                      <>
+                        <div>{elem.legendaryEffects.map(this.renderLegendaryEffect)}</div>
+                        <div>{elem.gear.filter(this.itemFilter).map(this.renderItem)}</div>
+                      </>
+                    )}
                   </div>
                   <div className="col-md-3">
                     {elem.advanced &&

--- a/src/interface/CharacterParsesList.js
+++ b/src/interface/CharacterParsesList.js
@@ -26,7 +26,6 @@ class CharacterParsesList extends PureComponent {
     class: PropTypes.string.isRequired,
     metric: PropTypes.string.isRequired,
     trinkets: PropTypes.object.isRequired,
-    spellIcons: PropTypes.object.isRequired,
   };
 
   constructor(props) {
@@ -44,12 +43,12 @@ class CharacterParsesList extends PureComponent {
   }
   renderLegendaryEffect(
     /** @type {{ name: string, id: number, icon: string }} */
-    le,
+    { id, icon },
   ) {
     return (
-      <SpellLink key={le.id} id={le.id} icon={false}>
+      <SpellLink key={id} id={id} icon={false}>
         <Icon
-          icon={this.props.spellIcons[le.id] ?? SPELLS[1].icon}
+          icon={icon}
           style={{
             ...styles.icon,
             border: '1px solid',

--- a/src/interface/CharacterParsesList.js
+++ b/src/interface/CharacterParsesList.js
@@ -25,7 +25,6 @@ class CharacterParsesList extends PureComponent {
     parses: PropTypes.array.isRequired,
     class: PropTypes.string.isRequired,
     metric: PropTypes.string.isRequired,
-    trinkets: PropTypes.object.isRequired,
   };
 
   constructor(props) {
@@ -61,11 +60,7 @@ class CharacterParsesList extends PureComponent {
     return (
       <ItemLink key={item.id} id={item.id} className={item.quality} icon={false}>
         <Icon
-          icon={
-            this.props.trinkets[item.id]
-              ? this.props.trinkets[item.id].icon
-              : this.props.trinkets[0].icon
-          }
+          icon={item.icon}
           style={{
             ...styles.icon,
             border: '1px solid',

--- a/src/interface/ConduitLink.tsx
+++ b/src/interface/ConduitLink.tsx
@@ -1,11 +1,10 @@
 import CombatLogParser from 'parser/core/CombatLogParser';
 import PropTypes from 'prop-types';
+import { ComponentProps } from 'react';
 
 import SpellLink from './SpellLink';
 
-interface Props {
-  id: number;
-}
+type Props = ComponentProps<typeof SpellLink>;
 
 interface Context {
   parser: CombatLogParser;
@@ -16,10 +15,10 @@ interface Context {
  *
  * Must have parser context.
  */
-const ConduitLink = ({ id }: Props, { parser: { selectedCombatant } }: Context) => {
+const ConduitLink = ({ id, ...rest }: Props, { parser: { selectedCombatant } }: Context) => {
   const rank = selectedCombatant.conduitRankBySpellID(id);
 
-  return <SpellLink id={id} rank={rank} />;
+  return <SpellLink id={id} rank={rank} {...rest} />;
 };
 ConduitLink.contextTypes = {
   parser: PropTypes.object.isRequired,

--- a/src/interface/ItemLink.tsx
+++ b/src/interface/ItemLink.tsx
@@ -53,7 +53,12 @@ const ItemLink = (props: Props) => {
       }}
       {...others}
     >
-      {props.icon && <ItemIcon id={id} noLink />} {children || ITEMS[id].name}
+      {props.icon && (
+        <>
+          <ItemIcon id={id} noLink />{' '}
+        </>
+      )}
+      {children || ITEMS[id].name}
     </a>
   );
 };

--- a/src/interface/report/Results/EncounterStats.js
+++ b/src/interface/report/Results/EncounterStats.js
@@ -2,7 +2,6 @@ import { Trans } from '@lingui/macro';
 import fetchWcl from 'common/fetchWclApi';
 import { formatDuration, formatPercentage, formatThousands } from 'common/format';
 import ITEMS from 'common/ITEMS';
-import { makeItemApiUrl } from 'common/makeApiUrl';
 import SPELLS from 'common/SPELLS';
 import ROLES from 'game/ROLES';
 import { getCovenantById } from 'game/shadowlands/COVENANTS';
@@ -241,9 +240,6 @@ class EncounterStats extends PureComponent {
           loaded: true,
           rankingsCount: stats.rankings.length,
         });
-
-        //fetch all missing icons from bnet-api and display them
-        this.fillMissingIcons();
       })
       .catch(() => {
         this.setState({
@@ -252,33 +248,6 @@ class EncounterStats extends PureComponent {
           ),
         });
       });
-  }
-
-  fillMissingIcons() {
-    this.state.mostUsedTrinkets.forEach((trinket) => {
-      if (ITEMS[trinket.id] === undefined) {
-        return fetch(makeItemApiUrl(trinket.id))
-          .then((response) => response.json())
-          .then((data) => {
-            const updatedItems = this.state.items;
-            updatedItems[trinket.id] = {
-              icon: data.icon.split('/').pop(),
-              id: trinket.id,
-              name: trinket.name,
-            };
-
-            this.setState({
-              items: updatedItems,
-            });
-
-            this.forceUpdate();
-          })
-          .catch(() => {
-            // ignore errors;
-          });
-      }
-      return null;
-    });
   }
 
   singleItem(item) {
@@ -298,11 +267,7 @@ class EncounterStats extends PureComponent {
           <div className="col-md-10">
             <ItemLink id={item.id} className={item.quality} details={item} icon={false}>
               <Icon
-                icon={
-                  this.state.items[item.id] === undefined
-                    ? this.state.items[0].icon
-                    : this.state.items[item.id].icon
-                }
+                icon={item.icon}
                 className={item.quality}
                 details={item}
                 style={{ width: '2em', height: '2em', border: '1px solid', marginRight: 10 }}
@@ -332,11 +297,7 @@ class EncounterStats extends PureComponent {
           <div className="col-md-10">
             <SpellLink id={spell.id} icon={false}>
               <Icon
-                icon={
-                  this.state.spells.maybeGet(spell.id) === undefined
-                    ? this.state.spells[1].icon
-                    : this.state.spells[spell.id].icon
-                }
+                icon={spell.icon}
                 style={{ width: '2em', height: '2em', border: '1px solid', marginRight: 10 }}
               />
               {spell.name}
@@ -401,11 +362,7 @@ class EncounterStats extends PureComponent {
           </div>
           <SpellLink id={covenant.spellID} icon={false}>
             <Icon
-              icon={
-                this.state.spells[covenant.spellID] === undefined
-                  ? this.state.spells[1].icon
-                  : this.state.spells[covenant.spellID].icon
-              }
+              icon={covenant.icon}
               style={{ width: '2em', height: '2em', border: '1px solid', marginRight: 10 }}
             />
             {covenant.name}

--- a/src/interface/report/Results/EncounterStats.js
+++ b/src/interface/report/Results/EncounterStats.js
@@ -262,7 +262,7 @@ class EncounterStats extends PureComponent {
           .then((data) => {
             const updatedItems = this.state.items;
             updatedItems[trinket.id] = {
-              icon: data.icon,
+              icon: data.icon.split('/').pop(),
               id: trinket.id,
               name: trinket.name,
             };

--- a/src/interface/report/Results/PlayerInfo.tsx
+++ b/src/interface/report/Results/PlayerInfo.tsx
@@ -1,7 +1,6 @@
 import { RETAIL_EXPANSION } from 'game/Expansion';
 import getAverageItemLevel from 'game/getAverageItemLevel';
-import Icon from 'interface/Icon';
-import SpellLink from 'interface/SpellLink';
+import { ConduitLink } from 'interface';
 import Combatant from 'parser/core/Combatant';
 import { Item } from 'parser/core/Events';
 
@@ -49,12 +48,10 @@ function renderConduit(conduit: Conduit) {
     >
       <div className="row">
         <div className="col-md-10">
-          <SpellLink id={conduit.spellID} icon={false}>
-            <Icon
-              icon={conduit.icon}
-              style={{ width: '2em', height: '2em', border: '1px solid', marginRight: 10 }}
-            />
-          </SpellLink>
+          <ConduitLink
+            id={conduit.spellID}
+            iconStyle={{ width: '2em', height: '2em', border: '1px solid', marginRight: 10 }}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
Saw some issues on the "PlayerInfo"/"EncouterStats" part of the parse. aka the "Character" tab

Fixed trinkets that are not in hardcoded files having broken icons

| Before | After | 
|:-:|:-:|
| ![image](https://user-images.githubusercontent.com/13413409/166068095-140d6790-fe22-4e9d-a2b4-cdfa2d754bb8.png) | ![image](https://user-images.githubusercontent.com/13413409/166068125-c2e52498-3c36-4bc4-87ba-4de132b328af.png) |

Fix conduits not having working links. I expect it's intended to show the name of the conduit next to it, instead of just icons like it was. Bonus: now also shows tooltip/link to the correct rank of conduit.

| Before | After |
|:-:|:-:|
| ![image](https://user-images.githubusercontent.com/13413409/166068363-4ebc8b1c-baed-4020-a347-1dfadfeebdf0.png) | ![image](https://user-images.githubusercontent.com/13413409/166068388-a3d9708a-ffb7-4ccb-af89-9ea80bd8353c.png) |
| ![image](https://user-images.githubusercontent.com/13413409/166068428-0819496a-56b9-498d-a2af-65679556375d.png) | ![image](https://user-images.githubusercontent.com/13413409/166068458-3b9c1939-a3b5-4e1a-9338-1aecc017dec8.png) |


Also fixes broken trinket icon and legendary link/icon on character parses page

| Before | After |
|:-:|:-:|
| ![image](https://user-images.githubusercontent.com/13413409/166081471-cb990ed2-423c-4848-b9e1-0273d15b5c18.png) | ![image](https://user-images.githubusercontent.com/13413409/166081497-ebd05710-0c4e-46c2-ae9f-c696bdf18543.png) |
| ![image](https://user-images.githubusercontent.com/13413409/166081528-bc630c74-43df-437d-931d-7fdf5fc7416a.png) | ![image](https://user-images.githubusercontent.com/13413409/166081538-b81a0eb7-c093-492e-9e3e-f1f5fb835037.png) |


### Bonus

I was seeing errors about duplicate `key=2544` and managed to track it down to the fact that two different bosses was rendering with id 2544. I found that the jailer encounter had the wrong id, the same as Prototype Pantheon. Not sure where these IDs are used, but feels like it could/should manifest in more places than just rendering the boss selection list on the character parses page.