### PR TITLE
feat: add blood-spattered scale & codex of the first technique tracking

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -58,6 +58,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2022, 5, 5), 'Add support for Blood-Spattered Scale and Codex of the First Technique trinkets.', xepheris),
   change(date(2022, 4, 30), 'Fix legendary icons not working on Character parses page', nullDozzer),
   change(date(2022, 4, 30), 'Fix broken trinket icons and conduit links on the character page', nullDozzer),
   change(date(2022, 4, 27), 'Updated stat multiplier table for Shadowlands values', Putro),

--- a/src/common/ITEMS/shadowlands/dungeons/index.ts
+++ b/src/common/ITEMS/shadowlands/dungeons/index.ts
@@ -8,6 +8,7 @@ import NecroticWake from './necroticwake';
 import Plaguefall from './plaguefall';
 import SanguineDepths from './sanguinedepths';
 import SpiresOfAscension from './spiresofascension';
+import Tazavesh from './tazavesh';
 import TheatorOfPain from './theaterofpain';
 import Thorgast from './thorgast';
 
@@ -21,5 +22,6 @@ const items: ItemList = safeMerge(
   SpiresOfAscension,
   TheatorOfPain,
   Thorgast,
+  Tazavesh,
 );
 export default items;

--- a/src/common/ITEMS/shadowlands/dungeons/tazavesh/index.ts
+++ b/src/common/ITEMS/shadowlands/dungeons/tazavesh/index.ts
@@ -1,0 +1,11 @@
+import { ItemList } from 'common/ITEMS/Item';
+
+const items: ItemList = {
+  CODEX_OF_THE_FIRST_TECHNIQUE: {
+    id: 185836,
+    name: 'Codex of the First Technique',
+    icon: 'inv_misc_profession_book_enchanting',
+  },
+};
+
+export default items;

--- a/src/common/SPELLS/shadowlands/dungeons/items.ts
+++ b/src/common/SPELLS/shadowlands/dungeons/items.ts
@@ -32,6 +32,27 @@ const dungeonItemSpells = {
     name: 'Anima Field',
     icon: 'inv_trinket_oribos_01_silver',
   },
+  //Tazavesh: Streets
+  CODEX_OF_THE_FIRST_TECHNIQUE_DAMAGE: {
+    id: 351450,
+    name: 'Riposte of the First Technique',
+    icon: 'inv_misc_profession_book_enchanting',
+  },
+  CODEX_OF_THE_FIRST_TECHNIQUE_HEALING: {
+    id: 351316,
+    name: 'First Technique',
+    icon: 'inv_misc_profession_book_enchanting',
+  },
+  BLOOD_SPATTERED_SCALE_DAMAGE: {
+    id: 329840,
+    name: 'Blood Barrier',
+    icon: 'inv_misc_scales_stonyorange',
+  },
+  BLOOD_SPATTERED_SCALE_HEALING: {
+    id: 329849,
+    name: 'Blood Barrier',
+    icon: 'inv_misc_scales_stonyorange',
+  },
 } as const;
 
 export default dungeonItemSpells;

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -13,6 +13,7 @@ import {
 import ModuleError from 'parser/core/ModuleError';
 import EffusiveAnimaAccelerator from 'parser/shadowlands/modules/covenants/kyrian/EffusiveAnimaAccelerator';
 import PreparationRuleAnalyzer from 'parser/shadowlands/modules/features/Checklist/PreparationRuleAnalyzer';
+import BloodSpatteredScale from 'parser/shadowlands/modules/items/dungeons/BloodSpatteredScale';
 import PotionChecker from 'parser/shadowlands/modules/items/PotionChecker';
 import WeaponEnhancementChecker from 'parser/shadowlands/modules/items/WeaponEnhancementChecker';
 import DeathRecapTracker from 'parser/shared/modules/DeathRecapTracker';
@@ -27,6 +28,7 @@ import Config from '../Config';
 import AugmentRuneChecker from '../shadowlands/modules/items/AugmentRuneChecker';
 import CombatPotion from '../shadowlands/modules/items/CombatPotion';
 import DarkmoonDeckVoracity from '../shadowlands/modules/items/crafted/DarkmoonDeckVoracity';
+import CodexOfTheFirstTechnique from '../shadowlands/modules/items/dungeons/CodexOfTheFirstTechnique';
 import OverchargedAnimaBattery from '../shadowlands/modules/items/dungeons/OverchargedAnimaBattery';
 import EnchantChecker from '../shadowlands/modules/items/EnchantChecker';
 import FlaskChecker from '../shadowlands/modules/items/FlaskChecker';
@@ -223,6 +225,8 @@ class CombatLogParser {
 
     // Dungeons
     overchargedAnimaBattery: OverchargedAnimaBattery,
+    codexOfTheFirstTechnique: CodexOfTheFirstTechnique,
+    bloodSpatteredScale: BloodSpatteredScale,
   };
   // Override this with spec specific modules when extending
   static specModules: DependenciesDefinition = {};

--- a/src/parser/shadowlands/modules/items/dungeons/BloodSpatteredScale.tsx
+++ b/src/parser/shadowlands/modules/items/dungeons/BloodSpatteredScale.tsx
@@ -1,0 +1,103 @@
+import ITEMS from 'common/ITEMS';
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { AbsorbedEvent, DamageEvent } from 'parser/core/Events';
+import Abilities from 'parser/core/modules/Abilities';
+import Buffs from 'parser/core/modules/Buffs';
+import CastEfficiency from 'parser/shared/modules/CastEfficiency';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import BoringItemValueText from 'parser/ui/BoringItemValueText';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+
+class BloodSplatteredScale extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+    castEfficiency: CastEfficiency,
+    spellUsable: SpellUsable,
+    buffs: Buffs,
+  };
+
+  protected buffs!: Buffs;
+  protected castEfficiency!: CastEfficiency;
+  protected spellUsable!: SpellUsable;
+
+  protected damage = 0;
+  protected healing = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTrinket(ITEMS.BLOOD_SPATTERED_SCALE.id);
+
+    if (!this.active) {
+      return;
+    }
+
+    (options.buffs as Buffs).add({
+      spellId: SPELLS.BLOOD_SPATTERED_SCALE_HEALING.id,
+      timelineHighlight: true,
+    });
+
+    (options.abilities as Abilities).add({
+      spell: SPELLS.BLOOD_SPATTERED_SCALE_DAMAGE.id,
+      category: Abilities.SPELL_CATEGORIES.ITEMS,
+      gcd: null,
+      cooldown: 120,
+      castEfficiency: {
+        suggestion: true,
+        recommendedEfficiency: 0.8,
+      },
+    });
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.BLOOD_SPATTERED_SCALE_DAMAGE),
+      this.onDamage,
+    );
+
+    this.addEventListener(
+      Events.absorbed.by(SELECTED_PLAYER).spell(SPELLS.BLOOD_SPATTERED_SCALE_HEALING),
+      this.onHeal,
+    );
+  }
+
+  onDamage(event: DamageEvent) {
+    this.damage += event.amount;
+  }
+
+  onHeal(event: AbsorbedEvent) {
+    this.healing += event.amount;
+  }
+
+  private getCastEfficiency() {
+    return (
+      this.castEfficiency.getCastEfficiencyForSpellId(SPELLS.BLOOD_SPATTERED_SCALE_DAMAGE.id) ?? {
+        casts: 0,
+        maxCasts: 0,
+      }
+    );
+  }
+
+  statistic() {
+    const { casts, maxCasts } = this.getCastEfficiency();
+
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE()}
+        size="flexible"
+        category={STATISTIC_CATEGORY.ITEMS}
+      >
+        <BoringItemValueText item={ITEMS.BLOOD_SPATTERED_SCALE}>
+          {casts} Uses <small>{maxCasts} possible</small>
+          <br />
+          <ItemDamageDone amount={this.damage} />
+          <br />
+          <ItemHealingDone amount={this.healing} />
+        </BoringItemValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default BloodSplatteredScale;

--- a/src/parser/shadowlands/modules/items/dungeons/CodexOfTheFirstTechnique.tsx
+++ b/src/parser/shadowlands/modules/items/dungeons/CodexOfTheFirstTechnique.tsx
@@ -1,0 +1,85 @@
+import ITEMS from 'common/ITEMS';
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { AbsorbedEvent, DamageEvent } from 'parser/core/Events';
+import Abilities from 'parser/core/modules/Abilities';
+import Buffs from 'parser/core/modules/Buffs';
+import BoringItemValueText from 'parser/ui/BoringItemValueText';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+
+class CodexOfTheFirstTechnique extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+    buffs: Buffs,
+  };
+
+  protected buffs!: Buffs;
+  protected damage = 0;
+  protected healing = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTrinket(ITEMS.CODEX_OF_THE_FIRST_TECHNIQUE.id);
+
+    if (!this.active) {
+      return;
+    }
+
+    (options.buffs as Buffs).add({
+      spellId: SPELLS.CODEX_OF_THE_FIRST_TECHNIQUE_HEALING.id,
+      timelineHighlight: true,
+    });
+
+    (options.abilities as Abilities).add({
+      spell: SPELLS.CODEX_OF_THE_FIRST_TECHNIQUE_HEALING.id,
+      category: Abilities.SPELL_CATEGORIES.ITEMS,
+      gcd: null,
+    });
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.CODEX_OF_THE_FIRST_TECHNIQUE_DAMAGE),
+      this.onDamage,
+    );
+
+    this.addEventListener(
+      Events.absorbed.by(SELECTED_PLAYER).spell(SPELLS.CODEX_OF_THE_FIRST_TECHNIQUE_HEALING),
+      this.onHeal,
+    );
+  }
+
+  onDamage(event: DamageEvent) {
+    this.damage += event.amount;
+  }
+
+  onHeal(event: AbsorbedEvent) {
+    this.healing += event.amount;
+  }
+
+  get uptime() {
+    return (
+      this.selectedCombatant.getBuffUptime(SPELLS.CODEX_OF_THE_FIRST_TECHNIQUE_HEALING.id) /
+      this.owner.fightDuration
+    );
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE()}
+        size="flexible"
+        category={STATISTIC_CATEGORY.ITEMS}
+      >
+        <BoringItemValueText item={ITEMS.CODEX_OF_THE_FIRST_TECHNIQUE}>
+          <ItemDamageDone amount={this.damage} />
+          <br />
+          <ItemHealingDone amount={this.healing} />
+        </BoringItemValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default CodexOfTheFirstTechnique;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29307652/166982100-d2a3f9a2-f0b8-4051-a92b-91725fe0ae30.png)
practically this (except no uptime) for both. scale also tracks uses / missed casts