### PR TITLE
feat: support ascended vigor

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -58,6 +58,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2022, 5, 5), 'Add support for Ascended Vigor', xepheris),
   change(date(2022, 4, 30), 'Fix legendary icons not working on Character parses page', nullDozzer),
   change(date(2022, 4, 30), 'Fix broken trinket icons and conduit links on the character page', nullDozzer),
   change(date(2022, 4, 27), 'Updated stat multiplier table for Shadowlands values', Putro),

--- a/src/common/SPELLS/shadowlands/enchants.ts
+++ b/src/common/SPELLS/shadowlands/enchants.ts
@@ -4,6 +4,11 @@ const enchants = {
     name: 'Ascended Vigor',
     icon: 'trade_engraving',
   },
+  ASCENDED_VIGOR_CAST: {
+    id: 324226,
+    name: 'Ascended Vigor',
+    icon: 'trade_engraving',
+  },
   CELESTIAL_GUIDANCE: {
     id: 309627,
     name: 'Celestial Guidance',

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -13,8 +13,8 @@ import {
 import ModuleError from 'parser/core/ModuleError';
 import EffusiveAnimaAccelerator from 'parser/shadowlands/modules/covenants/kyrian/EffusiveAnimaAccelerator';
 import PreparationRuleAnalyzer from 'parser/shadowlands/modules/features/Checklist/PreparationRuleAnalyzer';
-import AscendedVigor from 'parser/shadowlands/modules/items/enchants/AscendedVigor';
 import BloodSpatteredScale from 'parser/shadowlands/modules/items/dungeons/BloodSpatteredScale';
+import AscendedVigor from 'parser/shadowlands/modules/items/enchants/AscendedVigor';
 import PotionChecker from 'parser/shadowlands/modules/items/PotionChecker';
 import WeaponEnhancementChecker from 'parser/shadowlands/modules/items/WeaponEnhancementChecker';
 import DeathRecapTracker from 'parser/shared/modules/DeathRecapTracker';

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -13,6 +13,7 @@ import {
 import ModuleError from 'parser/core/ModuleError';
 import EffusiveAnimaAccelerator from 'parser/shadowlands/modules/covenants/kyrian/EffusiveAnimaAccelerator';
 import PreparationRuleAnalyzer from 'parser/shadowlands/modules/features/Checklist/PreparationRuleAnalyzer';
+import AscendedVigor from 'parser/shadowlands/modules/items/enchants/AscendedVigor';
 import PotionChecker from 'parser/shadowlands/modules/items/PotionChecker';
 import WeaponEnhancementChecker from 'parser/shadowlands/modules/items/WeaponEnhancementChecker';
 import DeathRecapTracker from 'parser/shared/modules/DeathRecapTracker';
@@ -212,6 +213,9 @@ class CombatLogParser {
     bloodFury: BloodFury,
 
     // Items:
+
+    // Enchants
+    ascendedViro: AscendedVigor,
 
     // Legendaries
 

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -215,7 +215,7 @@ class CombatLogParser {
     // Items:
 
     // Enchants
-    ascendedViro: AscendedVigor,
+    ascendedVigor: AscendedVigor,
 
     // Legendaries
 

--- a/src/parser/shadowlands/modules/items/enchants/AscendedVigor.tsx
+++ b/src/parser/shadowlands/modules/items/enchants/AscendedVigor.tsx
@@ -1,0 +1,79 @@
+import { formatPercentage } from 'common/format';
+import ITEMS from 'common/ITEMS';
+import SPELLS from 'common/SPELLS';
+import Uptime from 'interface/icons/Uptime';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import calculateEffectiveHealing from 'parser/core/calculateEffectiveHealing';
+import Events, { ApplyBuffEvent, HealEvent, RemoveBuffEvent } from 'parser/core/Events';
+import Buffs from 'parser/core/modules/Buffs';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+
+const PERCENTAGE_HEALING_INCREASE = 0.12;
+
+class AscendedVigor extends Analyzer {
+  static dependencies = {
+    buffs: Buffs,
+  };
+
+  healing = 0;
+  isBuffed = false;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasWeaponEnchant(ITEMS.ENCHANT_WEAPON_ASCENDED_VIGOR);
+
+    if (!this.active) {
+      return;
+    }
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.ASCENDED_VIGOR_CAST),
+      this.toggle,
+    );
+
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.ASCENDED_VIGOR_CAST),
+      this.toggle,
+    );
+
+    this.addEventListener(Events.heal, this.onHeal);
+  }
+
+  toggle = (event: ApplyBuffEvent | RemoveBuffEvent) => {
+    this.isBuffed = event.type === 'applybuff';
+  };
+
+  onHeal = (event: HealEvent) => {
+    if (this.isBuffed) {
+      this.healing += calculateEffectiveHealing(event, PERCENTAGE_HEALING_INCREASE);
+    }
+  };
+
+  get uptime() {
+    return (
+      this.selectedCombatant.getBuffUptime(SPELLS.ASCENDED_VIGOR_CAST.id) / this.owner.fightDuration
+    );
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE()}
+        size="flexible"
+        category={STATISTIC_CATEGORY.ITEMS}
+      >
+        <BoringSpellValueText spellId={SPELLS.ASCENDED_VIGOR_CAST.id}>
+          <ItemHealingDone displayPercentage={false} amount={this.healing} />
+          <br />
+          <Uptime /> {formatPercentage(this.uptime)}% <small>Uptime</small>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default AscendedVigor;

--- a/src/parser/ui/ItemHealingDone.tsx
+++ b/src/parser/ui/ItemHealingDone.tsx
@@ -7,13 +7,17 @@ interface Props {
   approximate?: boolean;
   greaterThan?: boolean;
   lessThan?: boolean;
+  /**
+   * @default {true}
+   */
+  displayPercentage?: boolean;
 }
 interface Context {
   parser: CombatLogParser;
 }
 
 const ItemHealingDone = (
-  { amount, approximate, greaterThan, lessThan }: Props,
+  { amount, approximate, greaterThan, lessThan, displayPercentage = true }: Props,
   { parser }: Context,
 ) => (
   <>
@@ -21,7 +25,9 @@ const ItemHealingDone = (
     {greaterThan && '>'}
     {lessThan && '<'}
     {formatNumber((amount / parser.fightDuration) * 1000)} HPS{' '}
-    <small>{formatPercentage(parser.getPercentageOfTotalHealingDone(amount))}% of total</small>
+    {displayPercentage && (
+      <small>{formatPercentage(parser.getPercentageOfTotalHealingDone(amount))}% of total</small>
+    )}
   </>
 );
 ItemHealingDone.contextTypes = {


### PR DESCRIPTION
has one issue: its indiscernible whether the healing increase is actually applied to your own healing (tanks, leech, etc.) or to healing you receive from any external source (Urh, healers, etc.). 

because of that I've added this `displayPercentage` boolean to `ItemHealingDone` because it would always compare against your personal healing done and thus show misleading info. in my screenshot, approx 80% of the healing comes from myself. 

happy to adjust if theres a way to separate these.

![image](https://user-images.githubusercontent.com/29307652/167203933-372b0e0f-b95b-4364-a37b-d18dda323491.png)
