### PR TITLE
Support Prot Paladin 4pc

### DIFF
--- a/analysis/paladinprotection/src/CHANGELOG.tsx
+++ b/analysis/paladinprotection/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2022, 5, 7), <>Added support for Sepulcher 4-set bonus.</>, emallson),
   change(date(2022, 4, 15), <>Added Holy Power Generated Per Minute statistic </>, xizbow),
   change(date(2022, 2, 5), <>Improved APL handling of <SpellLink id={SPELLS.JUDGMENT_CAST_PROTECTION.id} /> when <SpellLink id={SPELLS.CRUSADERS_JUDGMENT_TALENT.id} /> is used.</>, emallson),
   change(date(2021, 11, 6), <>Added AoE condition for <SpellLink id={SPELLS.AVENGERS_SHIELD.id} />.</>, emallson),

--- a/analysis/paladinprotection/src/CombatLogParser.ts
+++ b/analysis/paladinprotection/src/CombatLogParser.ts
@@ -13,6 +13,7 @@ import {
 
 import Abilities from './modules/Abilities';
 import AplCheck from './modules/core/AplCheck';
+import GlobalCooldown from './modules/core/GlobalCooldown';
 import GrandCrusader from './modules/core/GrandCrusader';
 import Haste from './modules/core/Haste';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
@@ -35,6 +36,7 @@ import Redoubt from './modules/talents/Redoubt';
 import RighteousProtector from './modules/talents/RighteousProtector';
 import SanctifiedWrathProtJudgement from './modules/talents/SanctifiedWrathProtJudgement';
 import Seraphim from './modules/talents/Seraphim';
+import SepulcherTierSet from './modules/shadowlands/SepulcherTierSet';
 
 //import CooldownTracker from './Modules/Features/CooldownTracker';
 
@@ -53,6 +55,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Features
     abilities: Abilities,
     alwaysBeCasting: AlwaysBeCasting,
+    globalCooldown: GlobalCooldown,
     spellUsable: SpellUsable,
     checklist: Checklist,
     wogTiming: WordOfGloryTiming,
@@ -85,6 +88,9 @@ class CombatLogParser extends CoreCombatLogParser {
     divineToll: DivineToll,
     ashenHallow: AshenHallow,
     vanquishersHammer: VanquishersHammer,
+
+    // Tier Set
+    sepulcherSet: SepulcherTierSet,
   };
 
   static suggestions = [...CoreCombatLogParser.suggestions, AplCheck()];

--- a/analysis/paladinprotection/src/CombatLogParser.ts
+++ b/analysis/paladinprotection/src/CombatLogParser.ts
@@ -24,6 +24,7 @@ import OvercapShieldOfTheRighteous from './modules/features/OvercapShieldOfTheRi
 import ShieldOfTheRighteous from './modules/features/ShieldOfTheRighteous';
 import SpellUsable from './modules/features/SpellUsable';
 import WordOfGloryTiming from './modules/features/WordOfGloryTiming';
+import SepulcherTierSet from './modules/shadowlands/SepulcherTierSet';
 import Consecration from './modules/spells/Consecration';
 import HammerOfTheRighteous from './modules/spells/HammerOfTheRighteous';
 import LightOfTheProtector from './modules/spells/LightOfTheProtector';
@@ -36,7 +37,6 @@ import Redoubt from './modules/talents/Redoubt';
 import RighteousProtector from './modules/talents/RighteousProtector';
 import SanctifiedWrathProtJudgement from './modules/talents/SanctifiedWrathProtJudgement';
 import Seraphim from './modules/talents/Seraphim';
-import SepulcherTierSet from './modules/shadowlands/SepulcherTierSet';
 
 //import CooldownTracker from './Modules/Features/CooldownTracker';
 

--- a/analysis/paladinprotection/src/modules/core/GlobalCooldown.ts
+++ b/analysis/paladinprotection/src/modules/core/GlobalCooldown.ts
@@ -1,0 +1,31 @@
+import SPELLS from 'common/SPELLS';
+import { CastEvent } from 'parser/core/Events';
+import CoreGlobalCooldown from 'parser/shared/modules/GlobalCooldown';
+import SepulcherTierSet from '../shadowlands/SepulcherTierSet';
+
+export default class GlobalCooldown extends CoreGlobalCooldown {
+  priority = Number.NEGATIVE_INFINITY;
+
+  static dependencies = {
+    ...CoreGlobalCooldown.dependencies,
+    sepulcher4pc: SepulcherTierSet,
+  };
+
+  sepulcher4pc!: SepulcherTierSet;
+
+  onCast(event: CastEvent) {
+    const spellId = event.ability.guid;
+
+    if (
+      spellId !== SPELLS.JUDGMENT_CAST_PROTECTION.id ||
+      !this.selectedCombatant.has4Piece() ||
+      !this.sepulcher4pc.isPotential4pcProc(event)
+    ) {
+      return super.onCast(event);
+    } else {
+      this.sepulcher4pc.triggerInferredProc(event);
+    }
+
+    // do nothing
+  }
+}

--- a/analysis/paladinprotection/src/modules/core/GlobalCooldown.ts
+++ b/analysis/paladinprotection/src/modules/core/GlobalCooldown.ts
@@ -1,6 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import { CastEvent } from 'parser/core/Events';
 import CoreGlobalCooldown from 'parser/shared/modules/GlobalCooldown';
+
 import SepulcherTierSet from '../shadowlands/SepulcherTierSet';
 
 export default class GlobalCooldown extends CoreGlobalCooldown {
@@ -18,7 +19,6 @@ export default class GlobalCooldown extends CoreGlobalCooldown {
 
     if (
       spellId !== SPELLS.JUDGMENT_CAST_PROTECTION.id ||
-      !this.selectedCombatant.has4Piece() ||
       !this.sepulcher4pc.isPotential4pcProc(event)
     ) {
       return super.onCast(event);

--- a/analysis/paladinprotection/src/modules/features/SpellUsable.tsx
+++ b/analysis/paladinprotection/src/modules/features/SpellUsable.tsx
@@ -1,43 +1,57 @@
 import SPELLS from 'common/SPELLS';
 import { Options } from 'parser/core/Analyzer';
-import { DamageEvent, CastEvent } from 'parser/core/Events';
+import Events, {
+  DamageEvent,
+  CastEvent,
+  GlobalCooldownEvent,
+  AnyEvent,
+  EventType,
+  FreeCastEvent,
+} from 'parser/core/Events';
 import CoreSpellUsable, {
   INVALID_COOLDOWN_CONFIG_LAG_MARGIN,
 } from 'parser/shared/modules/SpellUsable';
 
 import GrandCrusader from '../core/GrandCrusader';
+import SepulcherTierSet from '../shadowlands/SepulcherTierSet';
 
 class SpellUsable extends CoreSpellUsable {
   static dependencies = {
     ...CoreSpellUsable.dependencies,
     gc: GrandCrusader,
+    sepulcher4pc: SepulcherTierSet,
   };
-  _hasCJ: boolean = false;
+  private _hasCJ: boolean = false;
   gc!: GrandCrusader;
+  sepulcher4pc!: SepulcherTierSet;
 
   constructor(options: Options) {
     super(options);
     this._hasCJ = this.selectedCombatant.hasTalent(SPELLS.CRUSADERS_JUDGMENT_TALENT.id);
   }
 
-  beginCooldown(spellId: number, cooldownTriggerEvent: CastEvent | DamageEvent) {
-    if (spellId === SPELLS.AVENGERS_SHIELD.id) {
-      if (
-        this.isOnCooldown(spellId) &&
-        this.cooldownRemaining(spellId) > INVALID_COOLDOWN_CONFIG_LAG_MARGIN
-      ) {
-        this.gc.triggerInferredReset(this, cooldownTriggerEvent);
-      }
-    } else if (this._hasCJ && spellId === SPELLS.JUDGMENT_CAST_PROTECTION.id) {
-      if (
-        !this.isAvailable(spellId) &&
-        this.cooldownRemaining(spellId) > INVALID_COOLDOWN_CONFIG_LAG_MARGIN
-      ) {
-        this.gc.triggerInferredReset(this, cooldownTriggerEvent);
-      }
+  beginCooldown(spellId: number, event: CastEvent | FreeCastEvent) {
+    if (event.type === EventType.FreeCast) {
+      // ignore the event
+      console.log('ignoring freecast event', event);
+      return;
     }
 
-    super.beginCooldown(spellId, cooldownTriggerEvent);
+    if (
+      this.isAvailable(spellId) ||
+      this.cooldownRemaining(spellId) <= INVALID_COOLDOWN_CONFIG_LAG_MARGIN
+    ) {
+      super.beginCooldown(spellId, event);
+      return;
+    }
+
+    if (
+      spellId === SPELLS.AVENGERS_SHIELD.id ||
+      (this._hasCJ && spellId === SPELLS.JUDGMENT_CAST_PROTECTION.id)
+    ) {
+      this.gc.triggerInferredReset(this, event as CastEvent);
+      super.beginCooldown(spellId, event);
+    }
   }
 }
 

--- a/analysis/paladinprotection/src/modules/features/SpellUsable.tsx
+++ b/analysis/paladinprotection/src/modules/features/SpellUsable.tsx
@@ -1,57 +1,44 @@
 import SPELLS from 'common/SPELLS';
 import { Options } from 'parser/core/Analyzer';
-import Events, {
-  DamageEvent,
-  CastEvent,
-  GlobalCooldownEvent,
-  AnyEvent,
-  EventType,
-  FreeCastEvent,
-} from 'parser/core/Events';
+import { CastEvent, EventType, FreeCastEvent } from 'parser/core/Events';
 import CoreSpellUsable, {
   INVALID_COOLDOWN_CONFIG_LAG_MARGIN,
 } from 'parser/shared/modules/SpellUsable';
 
 import GrandCrusader from '../core/GrandCrusader';
-import SepulcherTierSet from '../shadowlands/SepulcherTierSet';
 
 class SpellUsable extends CoreSpellUsable {
   static dependencies = {
     ...CoreSpellUsable.dependencies,
     gc: GrandCrusader,
-    sepulcher4pc: SepulcherTierSet,
   };
-  private _hasCJ: boolean = false;
+  _hasCJ: boolean = false;
   gc!: GrandCrusader;
-  sepulcher4pc!: SepulcherTierSet;
 
   constructor(options: Options) {
     super(options);
     this._hasCJ = this.selectedCombatant.hasTalent(SPELLS.CRUSADERS_JUDGMENT_TALENT.id);
   }
 
-  beginCooldown(spellId: number, event: CastEvent | FreeCastEvent) {
-    if (event.type === EventType.FreeCast) {
+  beginCooldown(spellId: number, cooldownTriggerEvent: CastEvent | FreeCastEvent) {
+    if (cooldownTriggerEvent.type === EventType.FreeCast) {
       // ignore the event
-      console.log('ignoring freecast event', event);
       return;
     }
 
-    if (
-      this.isAvailable(spellId) ||
-      this.cooldownRemaining(spellId) <= INVALID_COOLDOWN_CONFIG_LAG_MARGIN
-    ) {
-      super.beginCooldown(spellId, event);
-      return;
-    }
-
-    if (
+    const validSpell =
       spellId === SPELLS.AVENGERS_SHIELD.id ||
-      (this._hasCJ && spellId === SPELLS.JUDGMENT_CAST_PROTECTION.id)
+      (spellId === SPELLS.JUDGMENT_CAST_PROTECTION.id && this._hasCJ);
+
+    if (
+      validSpell &&
+      !this.isAvailable(spellId) &&
+      this.cooldownRemaining(spellId) > INVALID_COOLDOWN_CONFIG_LAG_MARGIN
     ) {
-      this.gc.triggerInferredReset(this, event as CastEvent);
-      super.beginCooldown(spellId, event);
+      this.gc.triggerInferredReset(this, cooldownTriggerEvent);
     }
+
+    super.beginCooldown(spellId, cooldownTriggerEvent);
   }
 }
 

--- a/analysis/paladinprotection/src/modules/shadowlands/SepulcherTierSet.tsx
+++ b/analysis/paladinprotection/src/modules/shadowlands/SepulcherTierSet.tsx
@@ -1,0 +1,118 @@
+import SPELLS from 'common/SPELLS';
+import { SpellIcon, SpellLink } from 'interface';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, {
+  Event,
+  AnyEvent,
+  CastEvent,
+  DamageEvent,
+  EventType,
+  FreeCastEvent,
+  GlobalCooldownEvent,
+} from 'parser/core/Events';
+import { INVALID_COOLDOWN_CONFIG_LAG_MARGIN } from 'parser/shared/modules/SpellUsable';
+import Statistic from 'parser/ui/Statistic';
+import BoringValueText from 'parser/ui/BoringValueText';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import AbilityTracker from 'parser/shared/modules/AbilityTracker';
+
+export default class SepulcherTierSet extends Analyzer {
+  static dependencies = {
+    abilityTracker: AbilityTracker,
+  };
+
+  abilityTracker!: AbilityTracker;
+
+  lastDamageEvent?: DamageEvent;
+  lastTriggerEvent?: FreeCastEvent;
+  gcd?: GlobalCooldownEvent;
+
+  triggers: FreeCastEvent[] = [];
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.has4Piece();
+
+    this.addEventListener(
+      Events.damage.to(SELECTED_PLAYER),
+      (event) => (this.lastDamageEvent = event),
+    );
+
+    this.addEventListener(Events.GlobalCooldown, (event) => (this.gcd = event));
+  }
+
+  private remainingGcd(event: AnyEvent): number {
+    if (this.gcd === undefined) {
+      return 0;
+    }
+
+    return Math.max(this.gcd.timestamp + this.gcd.duration - event.timestamp, 0);
+  }
+
+  public isPotential4pcProc(event: CastEvent | DamageEvent): boolean {
+    if (!this.active || event.type === EventType.Damage) {
+      // not even going to try to do timestamp stuff with judgment damage events due to travel time
+      return false;
+    }
+
+    // force it even without checking for a damage event if we have an impossible gcd
+    if (this.remainingGcd(event) > INVALID_COOLDOWN_CONFIG_LAG_MARGIN) {
+      return true;
+    }
+
+    const triggerOffset = Math.abs(event.timestamp - (this.lastTriggerEvent?.timestamp ?? 0));
+    const damageOffset = Math.abs(event.timestamp - (this.lastDamageEvent?.timestamp ?? 0));
+    // console.log(event, triggerOffset, damageOffset, this.lastTriggerEvent, this.lastDamageEvent);
+
+    return (
+      triggerOffset >= 3000 - INVALID_COOLDOWN_CONFIG_LAG_MARGIN &&
+      damageOffset < INVALID_COOLDOWN_CONFIG_LAG_MARGIN
+    );
+  }
+
+  public triggerInferredProc(event: CastEvent | DamageEvent) {
+    if (event.type === EventType.Damage) {
+      console.warn('Damage event somehow reached SepulcherTierSet.triggerInferredProc', event);
+      return;
+    }
+
+    const freeCast = (event as unknown) as FreeCastEvent;
+    freeCast.type = EventType.FreeCast;
+
+    freeCast.meta = {
+      isEnhancedCast: true,
+      enhancedCastReason: (
+        <>
+          Triggered by <SpellLink id={SPELLS.GLORIOUS_PURPOSE_4PC.id} />
+        </>
+      ),
+    };
+
+    this.lastTriggerEvent = freeCast;
+    this.triggers.push(freeCast);
+
+    this.abilityTracker.getAbility(SPELLS.JUDGMENT_CAST_PROTECTION.id).casts -= 1;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.DEFAULT}
+        size="flexible"
+        category={STATISTIC_CATEGORY.ITEMS}
+      >
+        <BoringValueText
+          label={
+            <>
+              <SpellIcon id={SPELLS.GLORIOUS_PURPOSE_4PC.id} /> Bonus{' '}
+              <SpellLink id={SPELLS.JUDGMENT_CAST_PROTECTION.id} /> triggers
+            </>
+          }
+        >
+          ~{this.triggers.length}
+        </BoringValueText>
+      </Statistic>
+    );
+  }
+}

--- a/src/common/SPELLS/paladin.ts
+++ b/src/common/SPELLS/paladin.ts
@@ -594,6 +594,11 @@ const spells = {
     name: 'Dawn Will Come',
     icon: 'ability_priest_flashoflight',
   },
+  GLORIOUS_PURPOSE_4PC: {
+    id: 363675,
+    name: 'Glorious Purpose',
+    icon: 'spell_holy_holyprotection',
+  },
 } as const;
 
 export default spells;

--- a/src/interface/report/Results/Timeline/Casts.tsx
+++ b/src/interface/report/Results/Timeline/Casts.tsx
@@ -12,6 +12,7 @@ import {
   CastEvent,
   EndChannelEvent,
   EventType,
+  FreeCastEvent,
   GlobalCooldownEvent,
 } from 'parser/core/Events';
 import { Fragment, CSSProperties, HTMLAttributes, ReactNode } from 'react';
@@ -20,7 +21,7 @@ import './Casts.scss';
 
 const ICON_WIDTH = 22;
 
-const isApplicableCastEvent = (event: CastEvent | BeginChannelEvent) => {
+const isApplicableCastEvent = (event: CastEvent | BeginChannelEvent | FreeCastEvent) => {
   const spellId = event.ability.guid;
   if (CASTS_THAT_ARENT_CASTS.includes(spellId)) {
     return false;
@@ -34,6 +35,7 @@ export const isApplicableEvent = (parser: CombatLogParser) => (event: AnyEvent) 
   }
 
   switch (event.type) {
+    case EventType.FreeCast:
     case EventType.Cast:
     case EventType.BeginChannel:
       return isApplicableCastEvent(event);
@@ -58,7 +60,7 @@ const Casts = ({ start, secondWidth, events, movement, ...others }: Props) => {
   const getOffsetLeft = (timestamp: number) => ((timestamp - start) / 1000) * secondWidth;
 
   const renderIcon = (
-    event: CastEvent | BeginChannelEvent,
+    event: CastEvent | BeginChannelEvent | FreeCastEvent,
     {
       className = '',
       style = {},
@@ -115,7 +117,7 @@ const Casts = ({ start, secondWidth, events, movement, ...others }: Props) => {
   let _lastLowered: number | null = null;
   let _level = 0;
   let _maxLevel = 0;
-  const renderCast = (event: CastEvent) => {
+  const renderCast = (event: CastEvent | FreeCastEvent) => {
     if (event.channel) {
       // If a spell has a channel event, it has a cast time/is channeled and we already rendered it in the `beginchannel` event
       return null;
@@ -275,6 +277,7 @@ const Casts = ({ start, secondWidth, events, movement, ...others }: Props) => {
 
   const renderEvent = (event: AnyEvent) => {
     switch (event.type) {
+      case EventType.FreeCast:
       case EventType.Cast:
         return renderCast(event);
       case EventType.BeginChannel:

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -63,6 +63,8 @@ export enum EventType {
   Time = 'time',
   Test = 'test',
   SpendResource = 'spendresource',
+  // casts that are triggered for free by something else
+  FreeCast = 'freecast',
 
   // Demon Hunter
   ConsumeSoulFragments = 'consumesoulfragments',
@@ -112,6 +114,7 @@ export interface RemoveStaggerEvent extends Event<EventType.RemoveStagger> {
 
 type MappedEventTypes = {
   [EventType.Event]: Event<EventType.Event>;
+  [EventType.FreeCast]: FreeCastEvent;
   [EventType.Heal]: HealEvent;
   [EventType.Absorbed]: AbsorbedEvent;
   [EventType.Damage]: DamageEvent;
@@ -375,6 +378,7 @@ export interface BaseCastEvent<T extends string> extends Event<T> {
 }
 
 export type CastEvent = BaseCastEvent<EventType.Cast>;
+export type FreeCastEvent = BaseCastEvent<EventType.FreeCast>;
 
 export interface FilterCooldownInfoEvent extends BaseCastEvent<EventType.FilterCooldownInfo> {
   trigger: EventType;


### PR DESCRIPTION
The protection paladin 4pc triggers "casts" of Judgment, which kinda breaks everything everywhere. This overrides the type of those events to `freecast` so that they get ignored, and adds off-gcd proc annotations to the timeline as well as a stat for them.
![Screenshot from 2022-05-07 20-26-57](https://user-images.githubusercontent.com/4909458/167276570-d413e075-a448-43f9-ba07-738cdf5b535f.png)
![Screenshot from 2022-05-07 19-33-54](https://user-images.githubusercontent.com/4909458/167276571-3eeedaa1-c85e-46f6-b63d-659e07bbbc6f.png)
