### PR TITLE
Fix scalding brew module not working.

### DIFF
--- a/analysis/monkbrewmaster/src/CHANGELOG.tsx
+++ b/analysis/monkbrewmaster/src/CHANGELOG.tsx
@@ -17,6 +17,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2022, 6, 6), <>Fixed tracking of <SpellLink id={SPELLS.SCALDING_BREW.id} /> damage</>, nullDozzer),
   change(date(2022, 5, 3), <>Added a Dampen Harm stat. </>, kate),
   change(date(2022, 5, 1), <>Add <SpellLink id={SPELLS.INVOKERS_DELIGHT_BUFF.id} /> to timeline. </>, nullDozzer),
   change(date(2022, 4, 16), <>Added a Mystic Touch stat. </>, Abelito75),

--- a/analysis/monkbrewmaster/src/modules/shadowlands/conduits/ScaldingBrew.tsx
+++ b/analysis/monkbrewmaster/src/modules/shadowlands/conduits/ScaldingBrew.tsx
@@ -1,7 +1,6 @@
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
-import Entity from 'parser/core/Entity';
 import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
 import Events, { DamageEvent, CastEvent } from 'parser/core/Events';
 import Combatants from 'parser/shared/modules/Combatants';
@@ -54,8 +53,7 @@ export default class ScaldingBrew extends Analyzer {
   }
 
   private damage(event: DamageEvent) {
-    const target: Entity =
-      this.enemies.enemies[event.targetID] || this.combatants.players[event.targetID];
+    const target = this.enemies.getEntity(event) || this.combatants.getEntity(event);
     if (!target) {
       return;
     }


### PR DESCRIPTION
The enemies modules was updated to track instances of enemies, which ScaldingBrew was not updated to handle.

| Before | After |
|-|-|
|![image](https://user-images.githubusercontent.com/13413409/172235171-6836ec82-967a-4f7f-9cd8-e3887a396966.png) | ![image](https://user-images.githubusercontent.com/13413409/172235378-f38c9d4c-00f8-421d-a44c-0a51da3d85e1.png) |
| ![image](https://user-images.githubusercontent.com/13413409/172235462-d15200a1-6732-427f-a010-65a8c5d99ce8.png) | ![image](https://user-images.githubusercontent.com/13413409/172235508-c2647dd7-8dba-4267-a12f-d52237d8c78e.png) |


