### PR TITLE
Reduced prio

### DIFF
--- a/analysis/paladinholy/src/CHANGELOG.tsx
+++ b/analysis/paladinholy/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Abelito75, acornellier, Putro, Sref, xizbow, Zeboot, HolySchmidt } from
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2022, 5, 30), <>Lowered recommended cast efficiency of <SpellLink id={SPELLS.JUDGMENT_CAST.id}/> and <SpellLink id={SPELLS.HOLY_SHOCK_CAST.id}/> due to repeat feedback.</>, xizbow),
   change(date(2022, 5, 30), <>Added statistic for healing per holy power</>, xizbow),
   change(date(2022, 5, 18), <>Fixed the analysis for Vanquishers Hammer</>, Abelito75),
   change(date(2022, 5, 18), <>Added analysis for <SpellLink id={SPELLS.VANQUISHERS_HAMMER.id}/></>, xizbow),

--- a/analysis/paladinholy/src/integrationTests/example.test.ts.snap
+++ b/analysis/paladinholy/src/integrationTests/example.test.ts.snap
@@ -1962,7 +1962,7 @@ exports[`Holy Paladin integration test: example log CastEfficiency matches the s
                   className="flex-sub performance-bar"
                   style={
                     Object {
-                      "backgroundColor": "#ff8000",
+                      "backgroundColor": "#70b570",
                       "width": "47.71438429787018%",
                     }
                   }
@@ -1987,12 +1987,7 @@ exports[`Holy Paladin integration test: example log CastEfficiency matches the s
                   "width": "25%",
                 }
               }
-            >
-              <trans
-                id="shared.castEfficiency.canBeImproved"
-                message="Can be improved."
-              />
-            </td>
+            />
           </tr>
           <tr>
             <td
@@ -5059,62 +5054,7 @@ Array [
         message=">{0}% is recommended"
         values={
           Object {
-            "0": "90",
-          }
-        }
-      />
-      )
-    </React.Fragment>,
-  },
-  Object {
-    "details": null,
-    "icon": undefined,
-    "importance": "major",
-    "issue": <React.Fragment>
-      <Trans
-        components={
-          Object {
-            "0": <ForwardRef
-              id={275773}
-            />,
-          }
-        }
-        id="shared.modules.castEfficiency.suggest"
-        message="Try to cast <0/> more often."
-      />
-       
-      <Trans
-        components={
-          Object {
-            "0": <ForwardRef
-              id={183778}
-            />,
-          }
-        }
-        id="paladin.holy.modules.abilities.judgmentOfLightTalent"
-        message="You should cast it whenever <0/> has dropped, which is usually on cooldown without delay. Alternatively you can ignore the debuff and just cast it whenever Judgment is available; there's nothing wrong with ignoring unimportant things to focus on important things."
-      />
-    </React.Fragment>,
-    "spell": 275773,
-    "stat": <React.Fragment>
-      <Trans
-        id="shared.modules.castEfficiency.actual"
-        message="{0} out of {1} possible casts. You kept it on cooldown {2}% of the time."
-        values={
-          Object {
-            "0": 21,
-            "1": 44,
-            "2": "48",
-          }
-        }
-      />
-       (
-      <Trans
-        id="shared.modules.castEfficiency.recommended"
-        message=">{0}% is recommended"
-        values={
-          Object {
-            "0": "75",
+            "0": "80",
           }
         }
       />
@@ -6192,6 +6132,52 @@ Array [
     "stat": null,
   },
 ]
+`;
+
+exports[`Holy Paladin integration test: example log HealingPerHolyPower matches the statistic snapshot 1`] = `
+<div
+  className="col-lg-3 col-md-4 col-sm-6 col-xs-12"
+>
+  <div
+    category="GENERAL"
+    className="panel statistic flexible "
+    position={13}
+  >
+    <div
+      className="panel-body"
+    >
+      <div
+        className="pad boring-text "
+      >
+        <label>
+          Average Healing per Holy Power
+        </label>
+        <div
+          className="value"
+        >
+          9,981
+        </div>
+      </div>
+    </div>
+    <div
+      className="detail-corner"
+      data-place="top"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onTouchStart={[Function]}
+    >
+      <svg
+        className="icon"
+        viewBox="0 0 100 100"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M58.9,82.9h7v12.9H34.1V82.9h7.1V45.5h-0.6c-3.6,0-6.4-2.9-6.4-6.4c0-3.6,2.9-6.4,6.4-6.4h0.6h17.4h0.3V82.9z M49,25.8  c6,0,10.8-4.8,10.8-10.8C59.8,9,55,4.2,49,4.2S38.2,9,38.2,15C38.2,21,43,25.8,49,25.8z"
+        />
+      </svg>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`Holy Paladin integration test: example log HolyPowerDetails matches the statistic snapshot 1`] = `
@@ -8831,7 +8817,7 @@ exports[`Holy Paladin integration test: example log matches the checklist snapsh
               style={
                 Object {
                   "backgroundColor": "#ac1f39",
-                  "width": "14.27837417263663%",
+                  "width": "7.179639899555116%",
                 }
               }
             />
@@ -8910,20 +8896,13 @@ exports[`Holy Paladin integration test: example log matches the checklist snapsh
                 }
               }
               id="paladin.holy.modules.checklist.usePrimarySpells.description"
-              message="<0/>{0} {1} {2} {3} {4} are your most efficient healing spells available. Try to cast them as much as possible without overhealing.<1>On Mythic</1> you can often still cast these spells more even if you were overhealing by casting it quicker when it comes off cooldown and improving your target selection. <2>More info.</2>"
+              message="<0/>{0} {1} is your most efficient healing spell available. Try to cast them as much as possible without overhealing.<1>On Mythic</1> you can often still cast these spells more even if you were overhealing by casting it quicker when it comes off cooldown and improving your target selection. <2>More info.</2>"
               values={
                 Object {
                   "0": <ForwardRef
                     id={223306}
                   />,
-                  "1": <ForwardRef
-                    id={275773}
-                  />,
-                  "2": "when using",
-                  "3": <ForwardRef
-                    id={183811}
-                  />,
-                  "4": "",
+                  "1": "",
                 }
               }
             />
@@ -8997,7 +8976,7 @@ exports[`Holy Paladin integration test: example log matches the checklist snapsh
                       Object {
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
-                        "width": "23.452373505673442%",
+                        "width": "27.060430968084738%",
                       }
                     }
                   />
@@ -9071,79 +9050,6 @@ exports[`Holy Paladin integration test: example log matches the checklist snapsh
                         "backgroundColor": "#ac1f39",
                         "transition": "background-color 800ms",
                         "width": "0%",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="col-md-6"
-          >
-            <div
-              className="flex"
-            >
-              <div
-                className="flex-main"
-              >
-                <a
-                  className="spell-link-text"
-                  href="https://wowhead.com/spell=275773"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  <img
-                    alt=""
-                    className="icon game "
-                    src="//render-us.worldofwarcraft.com/icons/56/spell_holy_righteousfury.jpg"
-                  />
-                   
-                  Judgment
-                </a>
-              </div>
-              <div
-                className="flex-sub content-middle text-muted"
-                style={
-                  Object {
-                    "marginLeft": 5,
-                    "marginRight": 10,
-                    "minWidth": 55,
-                  }
-                }
-              >
-                <div
-                  className="text-right"
-                  style={
-                    Object {
-                      "width": "100%",
-                    }
-                  }
-                >
-                   
-                  47.71%
-                   
-                   
-                </div>
-              </div>
-              <div
-                className="flex-sub content-middle"
-                style={
-                  Object {
-                    "width": 50,
-                  }
-                }
-              >
-                <div
-                  className="performance-bar-container"
-                >
-                  <div
-                    className="performance-bar small"
-                    style={
-                      Object {
-                        "backgroundColor": "#ac1f39",
-                        "transition": "background-color 800ms",
-                        "width": "26.481483285317957%",
                       }
                     }
                   />

--- a/analysis/paladinholy/src/modules/checklist/Component.tsx
+++ b/analysis/paladinholy/src/modules/checklist/Component.tsx
@@ -41,23 +41,12 @@ const HolyPaladinChecklist = ({ combatant, castEfficiency, thresholds }: Checkli
             ) : (
               ''
             )}{' '}
-            {combatant.hasTalent(SPELLS.JUDGMENT_OF_LIGHT_TALENT) ? (
-              <SpellLink id={SPELLS.JUDGMENT_CAST_HOLY.id} />
-            ) : (
-              ''
-            )}{' '}
-            {combatant.hasTalent(SPELLS.JUDGMENT_OF_LIGHT_TALENT) ? 'when using' : ''}{' '}
-            {combatant.hasTalent(SPELLS.JUDGMENT_OF_LIGHT_TALENT) ? (
-              <SpellLink id={SPELLS.JUDGMENT_OF_LIGHT_HEAL.id} />
-            ) : (
-              ''
-            )}{' '}
             {combatant.hasTalent(SPELLS.CRUSADERS_MIGHT_TALENT) ? (
               <SpellLink id={SPELLS.CRUSADER_STRIKE.id} />
             ) : (
               ''
             )}{' '}
-            are your most efficient healing spells available. Try to cast them as much as possible
+            is your most efficient healing spell available. Try to cast them as much as possible
             without overhealing.
             <TooltipElement
               content={t({
@@ -81,9 +70,6 @@ const HolyPaladinChecklist = ({ combatant, castEfficiency, thresholds }: Checkli
       >
         <AbilityRequirement spell={SPELLS.HOLY_SHOCK_CAST.id} />
         <AbilityRequirement spell={SPELLS.HAMMER_OF_WRATH.id} />
-        {combatant.hasTalent(SPELLS.JUDGMENT_OF_LIGHT_TALENT.id) && (
-          <AbilityRequirement spell={SPELLS.JUDGMENT_CAST_HOLY.id} />
-        )}
         {combatant.hasTalent(SPELLS.BESTOW_FAITH_TALENT.id) && (
           <AbilityRequirement spell={SPELLS.BESTOW_FAITH_TALENT.id} />
         )}

--- a/analysis/paladinholy/src/modules/features/Abilities.tsx
+++ b/analysis/paladinholy/src/modules/features/Abilities.tsx
@@ -29,7 +29,7 @@ class Abilities extends CoreAbilities {
               Casting Holy Shock regularly is very important for performing well.
             </Trans>
           ),
-          recommendedEfficiency: 0.9,
+          recommendedEfficiency: 0.8,
         },
         timelineSortIndex: 0,
         isDefensive: true,
@@ -62,7 +62,7 @@ class Abilities extends CoreAbilities {
               ignoring unimportant things to focus on important things.
             </Trans>
           ),
-          recommendedEfficiency: 0.75,
+          recommendedEfficiency: 0.2,
         },
         timelineSortIndex: 20,
       },


### PR DESCRIPTION
I have received lots of feedback from people in HOF guilds and others that the recommended CPM of a spells in way too high, with most of them directed at judgment. This is likely due to the fact that hpal is much more gcd-locked playing necrolord, maraads, and (sometimes) beacon of virtue, leading to not many globals to press things like judge.