### PR TITLE
Added timeline and simple stat box support for The First Sigil. Added timeline item for Ravenous Frenzy buff.

### DIFF
--- a/analysis/druid/src/index.ts
+++ b/analysis/druid/src/index.ts
@@ -1,4 +1,5 @@
 export { default as ConvokeSpirits } from './shadowlands/ConvokeSpirits';
 export { default as AdaptiveSwarm } from './shadowlands/AdaptiveSwarm';
 export { default as AdaptiveSwarmDamageDealer } from './shadowlands/AdaptiveSwarmDamageDealer';
+export { default as RavenousFrenzy } from './shadowlands/RavenousFrenzy';
 export { default as SinfulHysteria } from './shadowlands/SinfulHysteria';

--- a/analysis/druid/src/shadowlands/RavenousFrenzy.ts
+++ b/analysis/druid/src/shadowlands/RavenousFrenzy.ts
@@ -1,0 +1,40 @@
+import SPELLS from 'common/SPELLS';
+import COVENANTS from 'game/shadowlands/COVENANTS';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import Buffs from 'parser/core/modules/Buffs';
+
+/**
+ * This module handles common things for Ravenous Frenzy
+ *
+ * **Ravenous Frenzy**
+ * Covenant Ability - Venthyr
+ *
+ * For 20 sec, Druid spells you cast increase your damage and healing by 2%, and haste by 1%, stacking.
+ * If you spend 2 sec idle, the Frenzy overcomes you, consuming 1% of your health per stack, stunning you for 1 sec, and ending.
+ */
+class RavenousFrenzy extends Analyzer {
+  static dependencies = {
+    buffs: Buffs,
+  };
+
+  protected buffs!: Buffs;
+
+  constructor(
+    options: Options & {
+      buffs: Buffs;
+    },
+  ) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasCovenant(COVENANTS.VENTHYR.id);
+
+    // Add the buffs to the buff tracker so that they show up in the timeline
+    options.buffs.add({
+      spellId: [SPELLS.RAVENOUS_FRENZY.id, SPELLS.SINFUL_HYSTERIA_BUFF.id],
+      timelineHighlight: true,
+      triggeredBySpellId: SPELLS.RAVENOUS_FRENZY.id,
+    });
+  }
+}
+
+export default RavenousFrenzy;

--- a/analysis/druidbalance/src/CHANGELOG.tsx
+++ b/analysis/druidbalance/src/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { Zeboot, LeoZhekov, Sharrq, Tiboonn, Kartarn, Ciuffi, Sref } from 'CONTR
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2022, 6, 16), <>Added <SpellLink id={SPELLS.RAVENOUS_FRENZY.id}/> to Timeline.</>, Sref),
   change(date(2022, 5, 12), <>Updated to indicate this spec is supported for patch 9.2, and also fixed handling of <SpellLink id={SPELLS.ADAPTIVE_SWARM.id}/></>, Sref),
   change(date(2021, 11, 12), <>Updated to indicate this spec is supported for patch 9.1.5</>, Sref),
   change(date(2021, 8, 3), <>Updated to indicate this spec is supported for patch 9.1</>, Sref),

--- a/analysis/druidbalance/src/CombatLogParser.ts
+++ b/analysis/druidbalance/src/CombatLogParser.ts
@@ -3,6 +3,7 @@ import Channeling from 'parser/shared/normalizers/Channeling';
 
 import { AdaptiveSwarmDamageDealer, ConvokeSpirits, SinfulHysteria } from '@wowanalyzer/druid';
 import ActiveDruidForm from '@wowanalyzer/druid/src/core/ActiveDruidForm';
+import RavenousFrenzy from '@wowanalyzer/druid/src/shadowlands/RavenousFrenzy';
 
 import Abilities from './modules/Abilities';
 import GlobalCooldown from './modules/core/GlobalCooldown';
@@ -58,6 +59,7 @@ class CombatLogParser extends MainCombatLogParser {
     convokeSpirits: ConvokeSpirits,
     adaptiveSwarm: AdaptiveSwarmDamageDealer,
     sinfulHysteria: SinfulHysteria,
+    ravenousFrenzy: RavenousFrenzy,
 
     //Resources
     astralPowerTracker: AstralPowerTracker,

--- a/analysis/druidbalance/src/modules/features/Buffs.tsx
+++ b/analysis/druidbalance/src/modules/features/Buffs.tsx
@@ -12,6 +12,10 @@ class Buffs extends CoreBuffs {
         timelineHighlight: true,
       },
       {
+        spellId: SPELLS.INCARNATION_CHOSEN_OF_ELUNE_TALENT.id,
+        timelineHighlight: true,
+      },
+      {
         spellId: SPELLS.WILD_CHARGE_TALENT.id,
         timelineHighlight: false,
       },

--- a/analysis/druidferal/src/CHANGELOG.tsx
+++ b/analysis/druidferal/src/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { Adoraci, Abelito75, Zeboot, LeoZhekov, Tora, Xcessiv, Tiboonn, Sref } f
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2022, 6, 16), <>Added <SpellLink id={SPELLS.RAVENOUS_FRENZY.id}/> to Timeline.</>, Sref),
   change(date(2022, 6, 12), <>Added support for the Tier 2pc and 4pc bonuses, and fixed handling of Berserk CDR with <SpellLink id={SPELLS.FRENZYBAND.id} />.</>, Sref),
   change(date(2022, 4, 22), <>Changed <SpellLink id={SPELLS.SHADOWMELD.id}/> suggestion to be minor only, and fixed a tooltip with wrong number.</>, Sref),
   change(date(2022, 1, 16), <>Fixed a bug where <SpellLink id={SPELLS.ADAPTIVE_SWARM.id}/> statistic wasn't counting boost to Feral Moonfire or Feral Thrash.</>, Sref),

--- a/analysis/druidferal/src/CombatLogParser.js
+++ b/analysis/druidferal/src/CombatLogParser.js
@@ -3,6 +3,7 @@ import CoreCombatLogParser from 'parser/core/CombatLogParser';
 import { SinfulHysteria } from '@wowanalyzer/druid';
 import ActiveDruidForm from '@wowanalyzer/druid/src/core/ActiveDruidForm';
 import DraughtOfDeepFocus from '@wowanalyzer/druid/src/shadowlands/DraughtOfDeepFocus';
+import RavenousFrenzy from '@wowanalyzer/druid/src/shadowlands/RavenousFrenzy';
 
 import Abilities from './modules/Abilities';
 import RakeUptimeAndSnapshots from './modules/bleeds/RakeUptimeAndSnapshots';
@@ -95,6 +96,7 @@ class CombatLogParser extends CoreCombatLogParser {
     frenzyband: Frenzyband,
     adaptiveSwarm: AdaptiveSwarmFeral,
     sinfulHysteria: SinfulHysteria,
+    ravenousFrenzy: RavenousFrenzy,
     tier28_2pc: Tier28_2pc,
     tier28_4pc: Tier28_4pc,
   };

--- a/analysis/druidguardian/src/CHANGELOG.tsx
+++ b/analysis/druidguardian/src/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { Kettlepaw, Zeboot, g3neral, Tiboonn, Buudha, Sref } from 'CONTRIBUTORS'
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2022, 6, 16), <>Added <SpellLink id={SPELLS.RAVENOUS_FRENZY.id}/> to Timeline.</>, Sref),
   change(date(2021, 11, 12), <>Updated to indicate this spec is supported for patch 9.1.5</>, Sref),
   change(date(2021, 7, 25), <>Added proper haste tracking for <SpellLink id={SPELLS.RAVENOUS_FRENZY.id}/> and <SpellLink id={SPELLS.SINFUL_HYSTERIA.id}/>.</>, Sref),
   change(date(2021, 7, 22), <>Fixed an issue causing the <SpellLink id={SPELLS.CONVOKE_SPIRITS.id} /> to crash.</>, Sref),

--- a/analysis/druidguardian/src/CombatLogParser.tsx
+++ b/analysis/druidguardian/src/CombatLogParser.tsx
@@ -3,6 +3,7 @@ import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 
 import { SinfulHysteria } from '@wowanalyzer/druid';
 import ActiveDruidForm from '@wowanalyzer/druid/src/core/ActiveDruidForm';
+import RavenousFrenzy from '@wowanalyzer/druid/src/shadowlands/RavenousFrenzy';
 
 import Abilities from './modules/Abilities';
 import ActiveTargets from './modules/features/ActiveTargets';
@@ -58,6 +59,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Covenants
     convokeSpirits: ConvokeSpiritsGuardian,
     sinfulHysteria: SinfulHysteria,
+    ravenousFrenzy: RavenousFrenzy,
   };
 }
 

--- a/analysis/druidrestoration/src/CHANGELOG.tsx
+++ b/analysis/druidrestoration/src/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { Adoraci, Yajinni, Abelito75, Zeboot, LeoZhekov, Putro, Vexxra, Tiboonn,
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2022, 6, 16), <>Added <SpellLink id={SPELLS.RAVENOUS_FRENZY.id}/> to Timeline.</>, Sref),
   change(date(2022, 6, 9), <>Fixed handling of <SpellLink id={SPELLS.PHOTOSYNTHESIS_TALENT.id} /> to count <SpellLink id={SPELLS.ADAPTIVE_SWARM.id} /> in increase HoT rate and to work properly with <SpellLink id={SPELLS.THE_DARK_TITANS_LESSON.id} />. Also cleaned up the tooltip and made some minor fixes to spell lists.</>, Sref),
   change(date(2022, 5, 19), <>Fixed Always be Healing.</>, Abelito75),
   change(date(2022, 4, 24), <>Added healing boosted by <SpellLink id={SPELLS.IRONBARK.id} /> its statistic box.</>, Sref),

--- a/analysis/druidrestoration/src/CombatLogParser.ts
+++ b/analysis/druidrestoration/src/CombatLogParser.ts
@@ -7,6 +7,7 @@ import ManaUsageChart from 'parser/shared/modules/resources/mana/ManaUsageChart'
 import { SinfulHysteria } from '@wowanalyzer/druid';
 import ActiveDruidForm from '@wowanalyzer/druid/src/core/ActiveDruidForm';
 import DraughtOfDeepFocus from '@wowanalyzer/druid/src/shadowlands/DraughtOfDeepFocus';
+import RavenousFrenzy from '@wowanalyzer/druid/src/shadowlands/RavenousFrenzy';
 
 import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from './constants';
 import Abilities from './modules/Abilities';
@@ -127,6 +128,7 @@ class CombatLogParser extends CoreCombatLogParser {
     adaptiveSwarm: AdaptiveSwarmResto,
     kindredSpirits: KindredSpiritsResto,
     sinfulHysteria: SinfulHysteria,
+    ravenousFrenzy: RavenousFrenzy,
 
     // Conduits
     // Potency

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -51,14 +51,14 @@ import {
   xunai,
   xepheris,
   nullDozzer,
-  Tialyss, sref,
+  Tialyss,
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
-  change(date(2022, 6, 16), <>Added <ItemLink id={ITEMS.THE_FIRST_SIGIL.id}/> to Statistics and Timeline.</>, sref),
+  change(date(2022, 6, 16), <>Added <ItemLink id={ITEMS.THE_FIRST_SIGIL.id}/> to Statistics and Timeline.</>, Sref),
   change(date(2022, 5, 29), 'Smattering of bugfixes.', emallson),
   change(date(2022, 5, 28), 'Fix statistics page for TBC logs when viewing a spec with incomplete support or switching builds.', emallson),
   change(date(2022, 5, 28), <>Added <ItemLink id={ITEMS.EARTHBREAKERS_IMPACT.id}/> to Statistics and Timeline.</>, nullDozzer),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -51,13 +51,14 @@ import {
   xunai,
   xepheris,
   nullDozzer,
-  Tialyss,
+  Tialyss, sref,
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2022, 6, 16), <>Added <ItemLink id={ITEMS.THE_FIRST_SIGIL.id}/> to Statistics and Timeline.</>, sref),
   change(date(2022, 5, 29), 'Smattering of bugfixes.', emallson),
   change(date(2022, 5, 28), 'Fix statistics page for TBC logs when viewing a spec with incomplete support or switching builds.', emallson),
   change(date(2022, 5, 28), <>Added <ItemLink id={ITEMS.EARTHBREAKERS_IMPACT.id}/> to Statistics and Timeline.</>, nullDozzer),

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -102,9 +102,10 @@ export const Stui: Contributor = {
     },
   ],
 };
-export const sref: Contributor = {
-  nickname: 'sref',
+export const Sref: Contributor = {
+  nickname: 'Sref',
   github: 'kfinch',
+  discord: 'Sref#1337',
   avatar: avatar('sref-avatar.jpg'),
 };
 export const Iskalla: Contributor = {
@@ -1534,12 +1535,6 @@ export const maestrohdude: Contributor = {
   nickname: 'maestrohdude',
   github: 'maestrohdude',
   discord: 'maestrohdude#6100',
-};
-
-export const Sref: Contributor = {
-  nickname: 'Sref',
-  github: 'kfinch',
-  discord: 'Sref#1337',
 };
 
 export const Bloodfox: Contributor = {

--- a/src/articles/2018-01-31-1st-Anniversary/index.tsx
+++ b/src/articles/2018-01-31-1st-Anniversary/index.tsx
@@ -328,7 +328,7 @@ const Article = (props: ArticleProps) => {
         that we use today for fixing all sorts of weird combatlog bugs. He also improved a couple of
         features of the Resto Druid analyzer.
         <br />
-        <Contributor {...CONTRIBUTORS.sref} /> has done a lot of work on the Restoration Druid
+        <Contributor {...CONTRIBUTORS.Sref} /> has done a lot of work on the Restoration Druid
         implementation and has added and improved a large part of the spec implementation.
       </Item>
 
@@ -1199,7 +1199,7 @@ const Article = (props: ArticleProps) => {
         <br />
         <Image source={FrostMage} description="Initial version of the Frost Mage analyzer" />
         <br />
-        <Contributor {...CONTRIBUTORS.sref} /> has also done a considerable amount of work on this
+        <Contributor {...CONTRIBUTORS.Sref} /> has also done a considerable amount of work on this
         spec.
       </Item>
 
@@ -1261,7 +1261,7 @@ const Article = (props: ArticleProps) => {
       </Item>
 
       <Item title="Implemented accurate stat tracking" date="14 Oct">
-        <Contributor {...CONTRIBUTORS.sref} />{' '}
+        <Contributor {...CONTRIBUTORS.Sref} />{' '}
         <a href="https://github.com/WoWAnalyzer/WoWAnalyzer/pull/520">implemented</a> a module for
         accurate stat rating tracking. This is a utility module intended to track the selected
         player's current stat rating at any point in the fight.
@@ -1319,7 +1319,7 @@ const Article = (props: ArticleProps) => {
         Initial version was <a href="https://github.com/WoWAnalyzer/WoWAnalyzer/pull/521">
           added
         </a>{' '}
-        by <Contributor {...CONTRIBUTORS.Fyruna} />. <Contributor {...CONTRIBUTORS.sref} /> added a
+        by <Contributor {...CONTRIBUTORS.Fyruna} />. <Contributor {...CONTRIBUTORS.Sref} /> added a
         couple of things. <Contributor {...CONTRIBUTORS.Sharrq} /> added a lot of modules.
         <br />
         <br />
@@ -1359,7 +1359,7 @@ const Article = (props: ArticleProps) => {
       </Item>
 
       <Item title="Added support for healer stat weights" date="24 Oct">
-        <Contributor {...CONTRIBUTORS.sref} />{' '}
+        <Contributor {...CONTRIBUTORS.Sref} />{' '}
         <a href="https://github.com/WoWAnalyzer/WoWAnalyzer/pull/604">added</a> a module to generate
         stat weights based on what actually happened in a fight. This module generates the players
         stat weights using the actual logged events. We keep a listing of all the player's healing
@@ -1369,7 +1369,7 @@ const Article = (props: ArticleProps) => {
         this module is pretty brilliant and makes calculating stat weights from logs pretty easy.
         <br />
         <br />
-        <Contributor {...CONTRIBUTORS.sref} /> wrote a full explanation of the calculation of the
+        <Contributor {...CONTRIBUTORS.Sref} /> wrote a full explanation of the calculation of the
         Restoration Druid Stat Weights{' '}
         <a href="https://github.com/WoWAnalyzer/WoWAnalyzer/blob/e650befd581620eaf62503e96550f4507ea56450/src/parser/Druid/Restoration/Modules/Features/StatWeights.js#L14">
           here
@@ -1379,7 +1379,7 @@ const Article = (props: ArticleProps) => {
         <Image source={RestoDruidStatWeights} description="The initial Stat Weights panel" />
         <br />
         Since the initial version the stat weights module has had several improvements by both{' '}
-        <Contributor {...CONTRIBUTORS.sref} /> and <Contributor {...CONTRIBUTORS.Zerotorescue} />{' '}
+        <Contributor {...CONTRIBUTORS.Sref} /> and <Contributor {...CONTRIBUTORS.Zerotorescue} />{' '}
         (he also implemented the weights for Holy Paladins).
         <br />
         <br />
@@ -1458,7 +1458,7 @@ const Article = (props: ArticleProps) => {
           wide
         />
         <br />
-        <Contributor {...CONTRIBUTORS.sref} />{' '}
+        <Contributor {...CONTRIBUTORS.Sref} />{' '}
         <a href="https://github.com/WoWAnalyzer/WoWAnalyzer/pull/843">added</a> the white indicators
         that show when a spell gains an extra charge.
       </Item>
@@ -1570,7 +1570,7 @@ const Article = (props: ArticleProps) => {
       </Item>
 
       <Item title="Using the time on cooldown for cast efficiency" date="12 Nov">
-        <Contributor {...CONTRIBUTORS.sref} />{' '}
+        <Contributor {...CONTRIBUTORS.Sref} />{' '}
         <a href="https://github.com/WoWAnalyzer/WoWAnalyzer/pull/799">changed</a> the basis for cast
         efficiency into the time on cooldown as recorded by the <i>spell usable</i> module (the
         cooldown tracker mentioned earlier). This should increase the accuracy.

--- a/src/common/ITEMS/shadowlands/raids/sepulcherofthefirstones/index.ts
+++ b/src/common/ITEMS/shadowlands/raids/sepulcherofthefirstones/index.ts
@@ -25,6 +25,11 @@ const items: ItemList = {
     icon: 'spell_nature_earthquake',
   },
   //Prototype Pantheon
+  THE_FIRST_SIGIL: {
+    id: 188271,
+    name: 'The First Sigil',
+    icon: 'inv_legendary_sigilofwisdom',
+  },
   //endregion
   //Lihuvim, Principle Architect
   //endregion

--- a/src/common/SPELLS/shadowlands/raids/sepulcherofthefirstones/items.ts
+++ b/src/common/SPELLS/shadowlands/raids/sepulcherofthefirstones/items.ts
@@ -6,6 +6,11 @@ export default {
   //Halondrus the Reclaimer
   //Dausegne, the Fallen Oracle
   //Prototype Pantheon
+  THE_FIRST_SIGIL: {
+    id: 367241,
+    name: 'The First Sigil',
+    icon: 'achievement_mythicdungeons_shadowlands',
+  },
   //Lihuvim, Principle Architect
   //Anduin Wrynn
   EARTHBREAKERS_IMPACT: {

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -40,6 +40,7 @@ import FoodChecker from '../shadowlands/modules/items/FoodChecker';
 import HealthPotion from '../shadowlands/modules/items/HealthPotion';
 import Healthstone from '../shadowlands/modules/items/Healthstone';
 import EarthbreakersImpact from '../shadowlands/modules/items/raid/sepulcherofthefirstones/EarthbreakersImpact';
+import TheFirstSigil from '../shadowlands/modules/items/raid/sepulcherofthefirstones/TheFirstSigil';
 import SpellTimeWaitingOnGlobalCooldown from '../shared/enhancers/SpellTimeWaitingOnGlobalCooldown';
 import AbilitiesMissing from '../shared/modules/AbilitiesMissing';
 import AbilityTracker from '../shared/modules/AbilityTracker';
@@ -235,6 +236,7 @@ class CombatLogParser {
     // Raids
     // Sepulcher of the First Ones
     earthbreakersImpact: EarthbreakersImpact,
+    theFirstSigil: TheFirstSigil,
   };
   // Override this with spec specific modules when extending
   static specModules: DependenciesDefinition = {};

--- a/src/parser/shadowlands/modules/items/raid/sepulcherofthefirstones/TheFirstSigil.tsx
+++ b/src/parser/shadowlands/modules/items/raid/sepulcherofthefirstones/TheFirstSigil.tsx
@@ -1,0 +1,96 @@
+import ITEMS from 'common/ITEMS';
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import { Item } from 'parser/core/Events';
+import Abilities from 'parser/core/modules/Abilities';
+import Buffs from 'parser/core/modules/Buffs';
+import CastEfficiency from 'parser/shared/modules/CastEfficiency';
+import StatTracker from 'parser/shared/modules/StatTracker';
+import BoringItemValueText from 'parser/ui/BoringItemValueText';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+
+const COOLDOWN_SECONDS = 300 as const;
+
+/**
+ * Tracks usage of The First Sigil - https://www.wowhead.com/item=188271/the-first-sigil?bonus=6805
+ */
+class TheFirstSigil extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+    buffs: Buffs,
+    castEfficiency: CastEfficiency,
+    statTracker: StatTracker,
+  };
+
+  protected abilities!: Abilities;
+  protected buffs!: Buffs;
+  protected castEfficiency!: CastEfficiency;
+  protected statTracker!: StatTracker;
+
+  private readonly item: Item;
+
+  constructor(
+    options: Options & {
+      abilities: Abilities;
+      buffs: Buffs;
+      castEfficiency: CastEfficiency;
+      statTracker: StatTracker;
+    },
+  ) {
+    super(options);
+
+    this.item = this.selectedCombatant.getItem(ITEMS.THE_FIRST_SIGIL.id)!;
+    if (this.item == null) {
+      this.active = false;
+      return;
+    }
+
+    // Add the buffs to the buff tracker so that they show up in the timeline
+    options.buffs.add({
+      spellId: SPELLS.THE_FIRST_SIGIL.id,
+      timelineHighlight: true,
+      triggeredBySpellId: SPELLS.THE_FIRST_SIGIL.id,
+    });
+
+    // Add the main cast as an ability so that we can track cooldown and usage in timeline
+    options.abilities.add({
+      spell: SPELLS.THE_FIRST_SIGIL.id,
+      category: Abilities.SPELL_CATEGORIES.ITEMS,
+      cooldown: COOLDOWN_SECONDS,
+      gcd: null,
+      castEfficiency: {
+        suggestion: true,
+        recommendedEfficiency: 0.8,
+      },
+    });
+  }
+
+  private getCastEfficiency() {
+    return (
+      this.castEfficiency.getCastEfficiencyForSpellId(SPELLS.THE_FIRST_SIGIL.id) ?? {
+        casts: 0,
+        maxCasts: 0,
+      }
+    );
+  }
+
+  statistic() {
+    const { casts, maxCasts } = this.getCastEfficiency();
+    // TODO track damage contribution and add to stat bar (should be easy because it's vers)
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE()}
+        size="flexible"
+        category={STATISTIC_CATEGORY.ITEMS}
+      >
+        <BoringItemValueText item={ITEMS.THE_FIRST_SIGIL}>
+          {casts} Uses <small>{maxCasts} possible</small>
+        </BoringItemValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default TheFirstSigil;

--- a/src/parser/shared/modules/StatTracker.ts
+++ b/src/parser/shared/modules/StatTracker.ts
@@ -133,6 +133,10 @@ class StatTracker extends Analyzer {
       itemId: ITEMS.OLD_WARRIORS_SOUL.id,
       haste: (_, item) => calculateSecondaryStatDefault(246, 43, item.itemLevel),
     },
+    [SPELLS.THE_FIRST_SIGIL.id]: {
+      itemId: ITEMS.THE_FIRST_SIGIL.id,
+      versatility: (_, item) => calculateSecondaryStatDefault(226, 1037, item.itemLevel),
+    },
 
     //endregion
 


### PR DESCRIPTION
Makes the timeline a little busy for these CD popping Balance Druids - but it was requested for analysis so here it is. Also added Balance Incarn to buff tracking because it was missing even though Celestial Alignment was there...

![image](https://user-images.githubusercontent.com/7143486/174098570-63776496-1091-48f8-b908-f7a9adc75d64.png)
