### PR TITLE
[Prot Warrior] [Core] IP Tracker + Wasted + SpellLink Feature

### DIFF
--- a/analysis/warriorprotection/src/CHANGELOG.tsx
+++ b/analysis/warriorprotection/src/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { change, date } from 'common/changelog';
 import { Adoraci, Abelito75, Putro, Zeboot } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2022, 6, 21), 'Ignore Pain Expired Stat added.', Abelito75),
   change(date(2022, 6, 8), 'Dynamic suggestion for Block Check and fixed a bug with Glory.', Abelito75),
   change(date(2022, 5, 12), 'Formatted expected shield slams.', Abelito75),
   change(date(2022, 4, 22), 'Fixed Charge and Intervene\'s cooldown and updated the example log.', Abelito75),

--- a/analysis/warriorprotection/src/CombatLogParser.ts
+++ b/analysis/warriorprotection/src/CombatLogParser.ts
@@ -17,6 +17,8 @@ import TheWall from './modules/shadowlands/legendaries/TheWall';
 import Thunderlord from './modules/shadowlands/legendaries/Thunderlord';
 import FourSetCastRatio from './modules/shadowlands/tierset/FourSetCastRatio';
 import FourSetTimeBetweenBuffs from './modules/shadowlands/tierset/FourSetTimeBetweenBuffs';
+import IgnorePainExpired from './modules/spells/IgnorePainExpired';
+import IgnorePainTracker from './modules/spells/IgnorePainTracker';
 import ShieldBlock from './modules/spells/ShieldBlock';
 import ShieldSlam from './modules/spells/ShieldSlam';
 import SpellReflect from './modules/spells/SpellReflect';
@@ -51,6 +53,8 @@ class CombatLogParser extends CoreCombatLogParser {
     avatar: Avatar,
     shieldSlam: ShieldSlam,
     spellReflect: SpellReflect,
+    ignorePainTracker: IgnorePainTracker,
+    ignorePainExpired: IgnorePainExpired,
 
     //Talents
     angerManagement: AngerManagement,

--- a/analysis/warriorprotection/src/modules/spells/IgnorePainExpired.tsx
+++ b/analysis/warriorprotection/src/modules/spells/IgnorePainExpired.tsx
@@ -1,0 +1,76 @@
+import { formatNumber, formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import { SpellIcon, SpellLink } from 'interface';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { RemoveBuffEvent } from 'parser/core/Events';
+import BoringValueText from 'parser/ui/BoringValueText';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+
+import IgnorePainTracker from './IgnorePainTracker';
+
+/**
+ * IP wasted due to it expiring.
+ * Ignore Pain (IP) grants a buff that is a shield. If the buff expires you just lose all the shield. This just tracks that
+ */
+class IgnorePainExpired extends Analyzer {
+  static dependencies = {
+    ignorePainTracker: IgnorePainTracker,
+  };
+
+  protected ignorePainTracker!: IgnorePainTracker;
+
+  ignorePainWasted: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.IGNORE_PAIN),
+      this.ignorePainExpired,
+    );
+  }
+
+  ignorePainExpired(event: RemoveBuffEvent) {
+    this.ignorePainWasted += event.absorb || 0;
+  }
+
+  statistic() {
+    const percentOfTotalWasted = formatPercentage(
+      this.ignorePainWasted / this.ignorePainTracker.totalIgnorePainGained,
+    );
+
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(13)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.GENERAL}
+        tooltip={
+          <>
+            When <SpellLink id={SPELLS.IGNORE_PAIN} /> expires you lose all the remaining shield it
+            had. This gives you an idea of how much you lost. <br />
+            Total Ignore Pain Gained: {formatNumber(
+              this.ignorePainTracker.totalIgnorePainGained,
+            )}{' '}
+            <br />
+            Total Ignore Pain Wasted: {formatNumber(this.ignorePainWasted)}
+          </>
+        }
+      >
+        <BoringValueText
+          label={
+            <>
+              <SpellIcon id={SPELLS.IGNORE_PAIN.id} /> Ignore Pain Expired
+            </>
+          }
+        >
+          {this.ignorePainWasted} <small> {percentOfTotalWasted} % </small>
+          <br />
+        </BoringValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default IgnorePainExpired;

--- a/analysis/warriorprotection/src/modules/spells/IgnorePainTracker.ts
+++ b/analysis/warriorprotection/src/modules/spells/IgnorePainTracker.ts
@@ -1,0 +1,81 @@
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, {
+  AbsorbedEvent,
+  ApplyBuffEvent,
+  DamageEvent,
+  RefreshBuffEvent,
+  RemoveBuffEvent,
+} from 'parser/core/Events';
+
+/**
+ * IP wasted due to it expiring.
+ * Ignore Pain (IP) grants a buff that is a shield. If the buff expires you just lose all the shield. This just tracks that
+ */
+class IgnorePainTracker extends Analyzer {
+  totalIgnorePainGained: number = 0;
+  currentIgnorePain: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.addEventListener(Events.damage.to(SELECTED_PLAYER), this.tookDamage);
+
+    this.addEventListener(
+      Events.absorbed.to(SELECTED_PLAYER).spell(SPELLS.IGNORE_PAIN),
+      this.absorbedDamage,
+    );
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.IGNORE_PAIN),
+      this.ignorePainGained,
+    );
+
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.IGNORE_PAIN),
+      this.ignorePainedRefreshed,
+    );
+
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.IGNORE_PAIN),
+      this.ignorePainExpired,
+    );
+  }
+
+  tookDamage(event: DamageEvent) {
+    this.handleDamageTaken(event.absorbed || 0);
+  }
+
+  absorbedDamage(event: AbsorbedEvent) {
+    this.handleDamageTaken(event.amount || 0);
+  }
+
+  handleDamageTaken(damageToIP: number) {
+    // If this is zero we assume we don't have IP
+    if (damageToIP === 0) {
+      return;
+    }
+    // Make sure its not another absorb
+    if (this.currentIgnorePain > 0) {
+      this.currentIgnorePain -= damageToIP;
+      this.currentIgnorePain = Math.max(this.currentIgnorePain, 0);
+    }
+  }
+
+  ignorePainGained(event: ApplyBuffEvent) {
+    this.currentIgnorePain = event.absorb || 0;
+    this.totalIgnorePainGained += event.absorb || 0;
+  }
+
+  ignorePainedRefreshed(event: RefreshBuffEvent) {
+    const absorbGained = (event.absorb || 0) - this.currentIgnorePain;
+    this.totalIgnorePainGained += absorbGained;
+    this.currentIgnorePain = event.absorb || 0;
+  }
+
+  ignorePainExpired(event: RemoveBuffEvent) {
+    this.currentIgnorePain = 0;
+  }
+}
+
+export default IgnorePainTracker;

--- a/src/interface/SpellLink.tsx
+++ b/src/interface/SpellLink.tsx
@@ -1,4 +1,5 @@
 import TooltipProvider from 'interface/TooltipProvider';
+import { convertToSpellID } from 'parser/core/ConversionLib';
 import { CSSProperties } from 'react';
 import * as React from 'react';
 
@@ -16,11 +17,13 @@ interface Props extends Omit<React.HTMLAttributes<HTMLAnchorElement>, 'id'> {
 
 const SpellLink = React.forwardRef<HTMLAnchorElement, Props>(
   ({ id, children, icon = true, iconStyle, ilvl, rank, ...other }: Props, ref) => {
-    const spell = useSpellInfo(id);
+    // make sure we are a number... some people forget the .id and pass an object instead
+    const spellId = convertToSpellID(id);
+    const spell = useSpellInfo(spellId);
 
     return (
       <a
-        href={TooltipProvider.spell(id, { ilvl, rank })}
+        href={TooltipProvider.spell(spellId, { ilvl, rank })}
         target="_blank"
         rel="noopener noreferrer"
         ref={ref}
@@ -29,10 +32,10 @@ const SpellLink = React.forwardRef<HTMLAnchorElement, Props>(
       >
         {icon && (
           <>
-            <SpellIcon id={id} noLink style={iconStyle} alt="" />{' '}
+            <SpellIcon id={spellId} noLink style={iconStyle} alt="" />{' '}
           </>
         )}
-        {children || (spell ? spell.name : `Unknown spell: ${id}`)}
+        {children || (spell ? spell.name : `Unknown spell: ${spellId}`)}
       </a>
     );
   },

--- a/src/parser/core/ConversionLib.ts
+++ b/src/parser/core/ConversionLib.ts
@@ -1,5 +1,11 @@
 import Spell from 'common/SPELLS/Spell';
 
+/**
+ * A simple function to convert spell objects or numbers to spell ID
+ *
+ * @param toID The Spell you want to become an ID
+ * @returns the id as a number
+ */
 export function convertToSpellID(toID: number | Spell): number {
   let spellId = toID;
   const spellObj = toID as Spell;

--- a/src/parser/core/ConversionLib.ts
+++ b/src/parser/core/ConversionLib.ts
@@ -1,0 +1,11 @@
+import Spell from 'common/SPELLS/Spell';
+
+export function convertToSpellID(toID: number | Spell): number {
+  let spellId = toID;
+  const spellObj = toID as Spell;
+  if (spellObj.id) {
+    spellId = spellObj.id;
+  }
+
+  return spellId as number;
+}

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -616,6 +616,7 @@ export interface RemoveDebuffStackEvent extends BuffEvent<EventType.RemoveDebuff
 }
 
 export interface RefreshBuffEvent extends BuffEvent<EventType.RefreshBuff> {
+  absorb?: number;
   source?: { name: 'Environment'; id: -1; guid: 0; type: 'NPC'; icon: 'NPC' };
 }
 


### PR DESCRIPTION
SpellLink now can handle passed in spell objects... even though the type is still number
An IP tracker now exists
IP wasted due to expiring stat now exists
![image](https://user-images.githubusercontent.com/25177817/174928936-5dea22e5-5010-4950-bf90-ab5aa3ae3a8e.png)
![image](https://user-images.githubusercontent.com/25177817/174928950-5e011191-b1b4-4224-bbe6-67e87b09e02f.png)
