### PR TITLE
Couple quick fixes to new analyzers

### DIFF
--- a/analysis/monkbrewmaster/src/CHANGELOG.tsx
+++ b/analysis/monkbrewmaster/src/CHANGELOG.tsx
@@ -17,7 +17,8 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
-  change(date(2022, 6, 27), <>Added prototype "guide"-style summary page.</>, emallson),
+  change(date(2022, 6, 28), <>Squash a couple of bugs in the new overview page.</>, emallson),
+  change(date(2022, 6, 27), <>Added prototype "guide"-style overview page.</>, emallson),
   change(date(2022, 6, 6), <>Fixed tracking of <SpellLink id={SPELLS.SCALDING_BREW.id} /> damage</>, nullDozzer),
   change(date(2022, 5, 3), <>Added a Dampen Harm stat. </>, kate),
   change(date(2022, 5, 1), <>Add <SpellLink id={SPELLS.INVOKERS_DELIGHT_BUFF.id} /> to timeline. </>, nullDozzer),

--- a/analysis/monkbrewmaster/src/CombatLogParser.ts
+++ b/analysis/monkbrewmaster/src/CombatLogParser.ts
@@ -30,6 +30,7 @@ import StaggerFabricator from './modules/core/StaggerFabricator';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import StaggerPoolGraph from './modules/features/StaggerPoolGraph';
 import { InvokeNiuzao } from './modules/problems/InvokeNiuzao';
+import { StompOrderNormalizer } from './modules/problems/InvokeNiuzao/normalizer';
 import PurifyingBrewProblems from './modules/problems/PurifyingBrew';
 import CelestialEffervescence from './modules/shadowlands/conduits/CelestialEffervescence';
 import EvasiveStride from './modules/shadowlands/conduits/EvasiveStride';
@@ -125,6 +126,7 @@ class CombatLogParser extends CoreCombatLogParser {
     /// Problem/Guide stuff
     purifyProblems: PurifyingBrewProblems,
     invokeNiuzao: InvokeNiuzao,
+    stompOrder: StompOrderNormalizer,
   };
 
   static guide = Guide;

--- a/analysis/monkbrewmaster/src/modules/problems/InvokeNiuzao/normalizer.ts
+++ b/analysis/monkbrewmaster/src/modules/problems/InvokeNiuzao/normalizer.ts
@@ -1,0 +1,21 @@
+import SPELLS from 'common/SPELLS';
+import { Options } from 'parser/core/Analyzer';
+import EventOrderNormalizer from 'parser/core/EventOrderNormalizer';
+import { EventType } from 'parser/core/Events';
+
+export class StompOrderNormalizer extends EventOrderNormalizer {
+  constructor(options: Options) {
+    super(options, [
+      {
+        beforeEventId: SPELLS.NIUZAO_STOMP_DAMAGE.id,
+        beforeEventType: EventType.Cast,
+        afterEventId: SPELLS.NIUZAO_STOMP_DAMAGE.id,
+        afterEventType: EventType.Damage,
+        bufferMs: 100,
+        anyTarget: true, // Stomp is untargeted, but damage has targets
+        // don't like altering timestamps, but this does make it work
+        updateTimestamp: true,
+      },
+    ]);
+  }
+}

--- a/analysis/monkbrewmaster/src/modules/problems/PurifyingBrew/analyzer.ts
+++ b/analysis/monkbrewmaster/src/modules/problems/PurifyingBrew/analyzer.ts
@@ -244,7 +244,8 @@ export default class PurifyingBrewProblems extends Analyzer {
 
   get problems(): Array<Problem<ProblemData>> {
     const badPurifies: Array<Problem<ProblemData>> = this.purifies
-      .filter(({ reason }) => reason === PurifyReason.Unknown)
+      // the length check *should* never be relevant but in rare cases it crops up.
+      .filter(({ reason, purified }) => reason === PurifyReason.Unknown && purified.length > 0)
       .map((data) => ({
         data: {
           type: ProblemType.BadPurify,


### PR DESCRIPTION
- PB analyzer would crash in the rare (bug) case where there was no hit purified. This should be impossible, but does occasionally happen in logs due to timestamp quirks.
- Niuzao analyzer was missing some stomp damage because of event ordering. Added a normalizer to fix that.