### PR TITLE
Fix time filter

### DIFF
--- a/analysis/monkbrewmaster/src/modules/core/Stagger.tsx
+++ b/analysis/monkbrewmaster/src/modules/core/Stagger.tsx
@@ -88,7 +88,7 @@ class Stagger extends Analyzer {
   }
 
   private _addstagger(event: AddStaggerEvent) {
-    if (event.trigger!.extraAbility.type === PHYSICAL_DAMAGE) {
+    if (event.trigger?.extraAbility?.type === PHYSICAL_DAMAGE) {
       this.totalPhysicalStaggered += event.amount;
     } else {
       this.totalMagicalStaggered += event.amount;
@@ -96,7 +96,7 @@ class Stagger extends Analyzer {
   }
 
   private _removestagger(event: RemoveStaggerEvent) {
-    if (event.trigger!.ability && event.trigger!.ability.guid === SPELLS.STAGGER_TAKEN.id) {
+    if (event.trigger?.ability && event.trigger?.ability.guid === SPELLS.STAGGER_TAKEN.id) {
       this.totalStaggerTaken += event.amount;
     }
   }

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -59,7 +59,8 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
-  change(date(2022, 6, 29), 'CN_translations: add some parts of the report about tbc warlock trans', Lucky0604),
+  change(date(2022, 7, 9), 'Fix issue where time filtering could cause the report to hang.', emallson),
+  change(date(2022, 6, 29), 'CN translations: add some parts of the report about tbc warlock trans', Lucky0604),
   change(date(2022, 6, 28), <>Fixed an issue where the final buff from <ItemLink id={ITEMS.SCARS_OF_FRATERNAL_STRIFE.id}/> falling would be counted as a Dispel.</>, Sref),
   change(date(2022, 6, 19), 'Triage Healing update.', Abelito75),
   change(date(2022, 6, 16), <>Added <ItemLink id={ITEMS.THE_FIRST_SIGIL.id}/> to Statistics and Timeline.</>, Sref),

--- a/src/interface/report/hooks/useEventParser.ts
+++ b/src/interface/report/hooks/useEventParser.ts
@@ -132,7 +132,7 @@ const useEventParser = ({
   const eventEmitter = useMemo(() => parser?.getModule(EventEmitter), [parser]);
 
   useEffect(() => {
-    if (parser === null || normalizedEvents === null || eventIndex === normalizedEvents?.length) {
+    if (parser === null || normalizedEvents === null || eventIndex >= normalizedEvents?.length) {
       return;
     }
 


### PR DESCRIPTION
Time filtering would hang due to `setEventIndex` being called twice in the same loop, overwriting the reset to 0 following the event list / parser getting reset.

Just a missed `>`.

also happened upon a couple stagger issues in the process.