### PR TITLE
[BrM] Guide Updates

### DIFF
--- a/analysis/monkbrewmaster/src/CHANGELOG.tsx
+++ b/analysis/monkbrewmaster/src/CHANGELOG.tsx
@@ -17,6 +17,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2022, 7, 10), <>Improve display of <SpellLink id={SPELLS.PURIFYING_BREW.id} /> in guide and add warning about <code>/sit</code> use with <SpellLink id={SPELLS.INVOKE_NIUZAO_THE_BLACK_OX.id} />.</>, emallson),
   change(date(2022, 6, 28), <>Squash a couple of bugs in the new overview page.</>, emallson),
   change(date(2022, 6, 27), <>Added prototype "guide"-style overview page.</>, emallson),
   change(date(2022, 6, 6), <>Fixed tracking of <SpellLink id={SPELLS.SCALDING_BREW.id} /> damage</>, nullDozzer),

--- a/analysis/monkbrewmaster/src/modules/problems/InvokeNiuzao/analyzer.ts
+++ b/analysis/monkbrewmaster/src/modules/problems/InvokeNiuzao/analyzer.ts
@@ -1,4 +1,5 @@
 import SPELLS from 'common/SPELLS';
+import HIT_TYPES from 'game/HIT_TYPES';
 import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
 import Events, {
   CastEvent,
@@ -33,6 +34,7 @@ export type NiuzaoCastData = {
   startEvent: SummonEvent;
   endEvent: DeathEvent | FightEndEvent;
   relevantHits: DamageEvent[];
+  sitDetected: boolean;
 };
 
 type StompData = {
@@ -83,7 +85,13 @@ export class InvokeNiuzao extends Analyzer {
       return;
     }
 
-    Object.values(this.activeCasts).forEach((cast) => cast.relevantHits.push(event));
+    Object.values(this.activeCasts).forEach((cast) => {
+      cast.relevantHits.push(event);
+
+      if (event.hitType === HIT_TYPES.CRIT) {
+        cast.sitDetected = true;
+      }
+    });
   }
 
   private removeStagger(event: RemoveStaggerEvent) {
@@ -193,6 +201,7 @@ export class InvokeNiuzao extends Analyzer {
         cooldown: this.spellUsable.cooldownRemaining(SPELLS.PURIFYING_BREW.id),
       },
       startEvent: summonEvent,
+      sitDetected: false,
     };
   }
 }

--- a/analysis/monkbrewmaster/src/modules/problems/InvokeNiuzao/index.tsx
+++ b/analysis/monkbrewmaster/src/modules/problems/InvokeNiuzao/index.tsx
@@ -1,7 +1,7 @@
 import { formatDuration, formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import COVENANTS from 'game/shadowlands/COVENANTS';
-import { ControlledExpandable, SpellLink, Tooltip } from 'interface';
+import { AlertWarning, ControlledExpandable, SpellLink, Tooltip } from 'interface';
 import { GuideProps, PassFailBar, Section, SectionHeader, SubSection } from 'interface/guide';
 import InformationIcon from 'interface/icons/Information';
 import { AnyEvent } from 'parser/core/Events';
@@ -82,6 +82,15 @@ function InvokeNiuzaoChecklist({ events, cast, info }: CommonProps): JSX.Element
       expanded={isExpanded}
       inverseExpanded={() => setIsExpanded(!isExpanded)}
     >
+      {cast.sitDetected && (
+        <p>
+          <AlertWarning>
+            This cast of <SpellLink id={NIUZAO_BUFF_ID_TO_CAST[cast.startEvent.ability.guid]} />{' '}
+            appears to have used <code>/sit</code> to inflate damage taken. This is a risky strat
+            and should only be done with the approval of your raid group.
+          </AlertWarning>
+        </p>
+      )}
       <div
         style={{
           display: 'grid',
@@ -306,6 +315,15 @@ export function InvokeNiuzaoSection({
         </tbody>
       </table>
       <SubSection title="Casts">
+        {module.casts.some((cast) => cast.sitDetected) && (
+          <p>
+            <AlertWarning>
+              One or more of the below casts appears to have used <code>/sit</code> to inflate
+              damage taken. This is a risky strat and should only be done with the approval of your
+              raid group.
+            </AlertWarning>
+          </p>
+        )}
         {module.casts.map((cast, ix) => (
           <InvokeNiuzaoChecklist key={ix} cast={cast} info={info} events={events} />
         ))}

--- a/analysis/monkbrewmaster/src/modules/problems/PurifyingBrew/analyzer.ts
+++ b/analysis/monkbrewmaster/src/modules/problems/PurifyingBrew/analyzer.ts
@@ -116,8 +116,14 @@ export default class PurifyingBrewProblems extends Analyzer {
     }
   }
 
+  private _amountStaggered: number = 0;
+  public get amountStaggered() {
+    return this._amountStaggered;
+  }
+
   private hitStack: TrackedStaggerData[] = [];
   private addStagger(event: AddStaggerEvent) {
+    this._amountStaggered += event.amount;
     this.hitStack.push({
       event,
       purifyCharges: this.spellUsable.chargesAvailable(SPELLS.PURIFYING_BREW.id),

--- a/src/common/WCL_TYPES.ts
+++ b/src/common/WCL_TYPES.ts
@@ -103,6 +103,36 @@ export interface WCLBossResources {
   series: BossSeries[];
 }
 
+export interface WCLThreatBand {
+  startTime: number;
+  endTime: number;
+  startEvent: AnyEvent;
+  endEvent: AnyEvent;
+}
+
+export interface WCLThreatTarget {
+  name: string;
+  id: number;
+  guid: number;
+  type: string;
+  icon: string;
+  totalUptime: number;
+  bands: WCLThreatBand[];
+}
+
+export interface WCLThreatEntry {
+  name: string;
+  id: number;
+  guid: number;
+  type: string;
+  icon: string;
+  targets: WCLThreatTarget[];
+}
+
+export interface WCLThreatTableResponse {
+  threat: WCLThreatEntry[];
+}
+
 export type WCLResponseJSON =
   | WCLGuildReportsResponse
   | WCLFightsResponse
@@ -111,10 +141,27 @@ export type WCLResponseJSON =
   | WCLDamageTakenTableResponse
   | WCLRankingsResponse
   | WCLBossResources
-  | WCLDamageDoneTableResponse;
+  | WCLDamageDoneTableResponse
+  | WCLThreatTableResponse;
 
 export interface WclOptions {
   timeout: number;
 
   [key: string]: number | string | boolean;
+}
+
+export enum WclTable {
+  Summary = 'summary',
+  DamageDone = 'damage-done',
+  DamageTaken = 'damage-taken',
+  Healing = 'healing',
+  Casts = 'casts',
+  Summons = 'summons',
+  Buffs = 'buffs',
+  Debuffs = 'debuffs',
+  Deaths = 'deaths',
+  Survivability = 'survivability',
+  Resources = 'resources',
+  ResourceGains = 'resources-gains',
+  Threat = 'threat',
 }

--- a/src/common/fetchWclApi.ts
+++ b/src/common/fetchWclApi.ts
@@ -4,7 +4,13 @@ import { AnyEvent } from 'parser/core/Events';
 
 import { QueryParams } from './makeApiUrl';
 import makeWclApiUrl from './makeWclApiUrl';
-import { WclOptions, WCLResponseJSON, WCLFightsResponse, WCLEventsResponse } from './WCL_TYPES';
+import {
+  WclTable,
+  WclOptions,
+  WCLResponseJSON,
+  WCLFightsResponse,
+  WCLEventsResponse,
+} from './WCL_TYPES';
 
 export class ApiDownError extends ExtendableError {}
 export class LogNotFoundError extends ExtendableError {}
@@ -233,4 +239,23 @@ export async function fetchEvents(
 }
 export function fetchCombatants(code: string, start: number, end: number) {
   return fetchEvents(code, start, end, undefined, 'type="combatantinfo"');
+}
+
+/**
+ * Fetch a WCL table. These are not often useful for what we do because they
+ * don't provide events, but sometimes the aggregations include behaviors that
+ * we want to mimic (like Threat including active tanking time).
+ */
+export async function fetchTable<T extends WCLResponseJSON>(
+  reportCode: string,
+  fightStart: number,
+  fightEnd: number,
+  tableName: WclTable,
+  sourceId?: number,
+): Promise<T> {
+  return fetchWcl(`report/tables/${tableName}/${reportCode}`, {
+    start: fightStart,
+    end: fightEnd,
+    sourceid: sourceId,
+  });
 }

--- a/src/interface/guide/index.tsx
+++ b/src/interface/guide/index.tsx
@@ -210,7 +210,7 @@ export const SubSection = ({
  * sets `.fail-bar` to be transparent.
  */
 export function PassFailBar({ pass, total }: { pass: number; total: number }) {
-  const perf = pass / total;
+  const perf = Math.min(pass / total, 1);
   return (
     <div className="pass-fail-bar-container">
       <div className="pass-bar" style={{ minWidth: `${perf * 100}%` }} />

--- a/src/parser/shared/modules/hit-tracking/IgnoredAbilities.ts
+++ b/src/parser/shared/modules/hit-tracking/IgnoredAbilities.ts
@@ -5,6 +5,10 @@
  */
 
 const IGNORED: number[] = [
+  // Sepulcher of the First Ones
+  368530, // Halondrus, Eternity Overdrive DoT
+  361312, // Halondrus, Lightshatter Beam DoT
+  368146, // Halondrus, Eternity Engine DoT
   360288, // Lords of Dread, Anguishing Strike DoT
   360302, // Lords of Dread, Swarm of Decay
   360303, // Lords of Dread, Swarm of Darkness


### PR DESCRIPTION
A fix to potential purifying brew graph as well as some other added data.

<details>
<summary>Purifying Brew Improvements</summary>
Now show total amount purified as well as active tanking time. Tanking time requires an extra WCL call similar to the mana chart.
 
<img src="https://user-images.githubusercontent.com/4909458/178152654-bbb2a00d-3d00-43ae-99e0-ea6fa77ed869.png" />
</details>

<details>
<summary>Invoke Niuzao /sit Warning</summary>
<img src="https://user-images.githubusercontent.com/4909458/178152693-ee4eeade-d681-4636-97bf-016caa28c53d.png" />
</details>
