### PR TITLE
[Havoc DH] add Sinful Brand uptime tracker

### DIFF
--- a/analysis/demonhunterhavoc/src/CHANGELOG.js
+++ b/analysis/demonhunterhavoc/src/CHANGELOG.js
@@ -1,24 +1,124 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
-import { LeoZhekov, flurreN, Elodiel } from 'CONTRIBUTORS';
+import { LeoZhekov, flurreN, Elodiel, ToppleTheNun } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
-  change(date(2021, 9, 26), <>Fixed the issue, that the Analyzer would show 0 uses of <SpellLink id={SPELLS.ELYSIAN_DECREE.id} /> in the suggestions and statistics instead of the actual number of uses.</>, Elodiel),
-  change(date(2021, 2, 2), <>Added <SpellLink id={SPELLS.FEL_DEFENDER.id} /> to Statistics</>, flurreN),
-  change(date(2021, 1, 28), <>Added <SpellLink id={SPELLS.GROWING_INFERNO.id} /> to Statistics</>, flurreN),
-  change(date(2021, 1, 18), <>Suggestions for <SpellLink id={SPELLS.DEMONIC_TALENT_HAVOC.id} />, <SpellLink id={SPELLS.BLADE_DANCE.id} /> and <SpellLink id={SPELLS.DEATH_SWEEP.id} /> have been updated</>, flurreN),
-  change(date(2021, 1, 6), <>Added <SpellLink id={SPELLS.ELYSIAN_DECREE.id} /> to Statistics</>, flurreN),
-  change(date(2020, 12, 30), <>Added <SpellLink id={SPELLS.SINFUL_BRAND.id} /> and <SpellLink id={SPELLS.THE_HUNT.id}/> to Statistics</>, flurreN),
-  change(date(2020, 12, 29), <>Fixed bug where <SpellLink id={SPELLS.DEMONIC_TALENT_HAVOC.id} /> were causing errors</>, flurreN),
-  change(date(2020, 12, 28), <><SpellLink id={SPELLS.COLLECTIVE_ANGUISH.id} /> and <SpellLink id={SPELLS.CHAOS_THEORY.id} /> is added to Statistics</>, flurreN),
-  change(date(2020, 12, 28), <><SpellLink id={SPELLS.FELBLADE_TALENT.id} /> is now shown correctly in timeline and more information added to Statistic box</>, flurreN),
+  change(
+    date(2022, 7, 14),
+    <>
+      Add <SpellLink id={SPELLS.SINFUL_BRAND.id} /> uptime tracking and change{' '}
+      <SpellLink id={SPELLS.SINFUL_BRAND.id} /> cast recommendation.
+    </>,
+    ToppleTheNun,
+  ),
+  change(
+    date(2021, 9, 26),
+    <>
+      Fixed the issue, that the Analyzer would show 0 uses of{' '}
+      <SpellLink id={SPELLS.ELYSIAN_DECREE.id} /> in the suggestions and statistics instead of the
+      actual number of uses.
+    </>,
+    Elodiel,
+  ),
+  change(
+    date(2021, 2, 2),
+    <>
+      Added <SpellLink id={SPELLS.FEL_DEFENDER.id} /> to Statistics
+    </>,
+    flurreN,
+  ),
+  change(
+    date(2021, 1, 28),
+    <>
+      Added <SpellLink id={SPELLS.GROWING_INFERNO.id} /> to Statistics
+    </>,
+    flurreN,
+  ),
+  change(
+    date(2021, 1, 18),
+    <>
+      Suggestions for <SpellLink id={SPELLS.DEMONIC_TALENT_HAVOC.id} />,{' '}
+      <SpellLink id={SPELLS.BLADE_DANCE.id} /> and <SpellLink id={SPELLS.DEATH_SWEEP.id} /> have
+      been updated
+    </>,
+    flurreN,
+  ),
+  change(
+    date(2021, 1, 6),
+    <>
+      Added <SpellLink id={SPELLS.ELYSIAN_DECREE.id} /> to Statistics
+    </>,
+    flurreN,
+  ),
+  change(
+    date(2020, 12, 30),
+    <>
+      Added <SpellLink id={SPELLS.SINFUL_BRAND.id} /> and <SpellLink id={SPELLS.THE_HUNT.id} /> to
+      Statistics
+    </>,
+    flurreN,
+  ),
+  change(
+    date(2020, 12, 29),
+    <>
+      Fixed bug where <SpellLink id={SPELLS.DEMONIC_TALENT_HAVOC.id} /> were causing errors
+    </>,
+    flurreN,
+  ),
+  change(
+    date(2020, 12, 28),
+    <>
+      <SpellLink id={SPELLS.COLLECTIVE_ANGUISH.id} /> and <SpellLink id={SPELLS.CHAOS_THEORY.id} />{' '}
+      is added to Statistics
+    </>,
+    flurreN,
+  ),
+  change(
+    date(2020, 12, 28),
+    <>
+      <SpellLink id={SPELLS.FELBLADE_TALENT.id} /> is now shown correctly in timeline and more
+      information added to Statistic box
+    </>,
+    flurreN,
+  ),
   change(date(2020, 12, 28), 'Legendary, Covenant and Conduits added for Havoc', flurreN),
-  change(date(2020, 12, 28), <><SpellLink id={SPELLS.EYE_BEAM.id} /> is now showed correct in the Timeline.</>, flurreN),
-  change(date(2020, 12, 28), <>Added support for <SpellLink id={SPELLS.GLAIVE_TEMPEST_TALENT.id} /> </>, flurreN),
-  change(date(2020, 12, 26), <><SpellLink id={SPELLS.GLAIVE_TEMPEST_TALENT.id} /> have correct cd, and <SpellLink id={SPELLS.CYCLE_OF_HATRED_TALENT.id} /> is not reducing cooldown correctly on <SpellLink id={SPELLS.EYE_BEAM.id} /></>, flurreN),
-  change(date(2020, 12, 26), <><SpellLink id={SPELLS.NETHERWALK_TALENT.id} /> and <SpellLink id={SPELLS.DARKNESS.id} /> now have a correct gcd.</>, flurreN),
+  change(
+    date(2020, 12, 28),
+    <>
+      <SpellLink id={SPELLS.EYE_BEAM.id} /> is now showed correct in the Timeline.
+    </>,
+    flurreN,
+  ),
+  change(
+    date(2020, 12, 28),
+    <>
+      Added support for <SpellLink id={SPELLS.GLAIVE_TEMPEST_TALENT.id} />{' '}
+    </>,
+    flurreN,
+  ),
+  change(
+    date(2020, 12, 26),
+    <>
+      <SpellLink id={SPELLS.GLAIVE_TEMPEST_TALENT.id} /> have correct cd, and{' '}
+      <SpellLink id={SPELLS.CYCLE_OF_HATRED_TALENT.id} /> is not reducing cooldown correctly on{' '}
+      <SpellLink id={SPELLS.EYE_BEAM.id} />
+    </>,
+    flurreN,
+  ),
+  change(
+    date(2020, 12, 26),
+    <>
+      <SpellLink id={SPELLS.NETHERWALK_TALENT.id} /> and <SpellLink id={SPELLS.DARKNESS.id} /> now
+      have a correct gcd.
+    </>,
+    flurreN,
+  ),
   change(date(2020, 12, 24), 'Updated CDs and baselines for SL', flurreN),
   change(date(2020, 12, 23), 'Updated spells and talents for SL', flurreN),
-  change(date(2020, 10, 30), 'Updated the deprecated StatisticBox elements with the new Statistic ones.', LeoZhekov),
+  change(
+    date(2020, 10, 30),
+    'Updated the deprecated StatisticBox elements with the new Statistic ones.',
+    LeoZhekov,
+  ),
 ];

--- a/analysis/demonhunterhavoc/src/CONFIG.js
+++ b/analysis/demonhunterhavoc/src/CONFIG.js
@@ -1,3 +1,4 @@
+import { ToppleTheNun } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 
@@ -5,7 +6,7 @@ import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [],
+  contributors: [ToppleTheNun],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
   patchCompatibility: null,
@@ -43,7 +44,8 @@ export default {
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/TGzmk4bXDZJndpj7/6-Heroic+Opulence+-+Kill+(8:12)/5-Tarke',
+  exampleReport:
+    '/report/Y9Z4RLcnNbz2TkAX/11-Mythic+Skolex,+the+Insatiable+Ravener+-+Kill+(5:02)/Felahunter',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/analysis/demonhunterhavoc/src/CombatLogParser.tsx
+++ b/analysis/demonhunterhavoc/src/CombatLogParser.tsx
@@ -14,9 +14,11 @@ import {
 import Abilities from './modules/Abilities';
 import Buffs from './modules/Buffs';
 import GlobalCooldown from './modules/core/GlobalCooldown';
+import SinfulBrandUptime from './modules/covenants/SinfulBrandUptime';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import Checklist from './modules/features/Checklist/Module';
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
+import DotUptimes from './modules/features/DotUptimes';
 import FuryDetails from './modules/resourcetracker/FuryDetails';
 import FuryTracker from './modules/resourcetracker/FuryTracker';
 import ChaosTheory from './modules/shadowlands/legendaries/ChaosTheory';
@@ -57,6 +59,10 @@ class CombatLogParser extends CoreCombatLogParser {
     abilities: Abilities,
     cooldownThroughputTracker: CooldownThroughputTracker,
     checklist: Checklist,
+
+    // DoTs
+    sinfulBrandUptime: SinfulBrandUptime,
+    dotUptimes: DotUptimes,
 
     // Spells
     demonBite: DemonBite,

--- a/analysis/demonhunterhavoc/src/modules/Abilities.js
+++ b/analysis/demonhunterhavoc/src/modules/Abilities.js
@@ -233,6 +233,17 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        castEfficiency: {
+          suggestion: combatant.hasCovenant(COVENANTS.VENTHYR.id),
+          recommendedEfficiency: 0.95,
+          extraSuggestion: (
+            <>
+              The only times you should delay casting <SpellLink id={SPELLS.EYE_BEAM.id} /> is when
+              you're expecting adds to spawn soon or your <SpellLink id={SPELLS.SINFUL_BRAND.id} />{' '}
+              is about to fall off.
+            </>
+          ),
+        },
       },
       {
         spell: SPELLS.FEL_BARRAGE_TALENT.id,
@@ -278,7 +289,10 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         castEfficiency: {
-          suggestion: true,
+          // You should only cast Sinful Brand if your primary target does
+          // not already have it applied if you're using the legendary,
+          // as otherwise it overwrites it.
+          suggestion: !combatant.hasLegendary(SPELLS.AGONY_GAZE),
           recommendedEfficiency: 0.95,
           extraSuggestion: `This should be part of your single target rotation.`,
         },

--- a/analysis/demonhunterhavoc/src/modules/covenants/SinfulBrandUptime.tsx
+++ b/analysis/demonhunterhavoc/src/modules/covenants/SinfulBrandUptime.tsx
@@ -1,0 +1,74 @@
+import { t } from '@lingui/macro';
+import { formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import COVENANTS from 'game/shadowlands/COVENANTS';
+import { SpellLink } from 'interface';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import Enemies from 'parser/shared/modules/Enemies';
+import uptimeBarSubStatistic from 'parser/ui/UptimeBarSubStatistic';
+
+/**
+ * Example Report: https://www.warcraftlogs.com/reports/VFc92Gf8dv3Nyjwm#fight=25&source=13
+ */
+
+const BAR_COLOR = '#ff0d0e';
+
+class SinfulBrandUptime extends Analyzer {
+  static dependencies = {
+    enemies: Enemies,
+  };
+  protected enemies!: Enemies;
+
+  get suggestionThresholds() {
+    const sinfulBrandUptime =
+      this.enemies.getBuffUptime(SPELLS.SINFUL_BRAND.id) / this.owner.fightDuration;
+    return {
+      actual: sinfulBrandUptime,
+      isLessThan: {
+        minor: 0.95,
+        average: 0.9,
+        major: 0.8,
+      },
+      style: ThresholdStyle.PERCENTAGE,
+    };
+  }
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasCovenant(COVENANTS.VENTHYR.id);
+  }
+
+  suggestions(when: When) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
+      suggest(
+        <>
+          Your <SpellLink id={SPELLS.SINFUL_BRAND.id} /> uptime can be improved. Try to pay more
+          attention to your Sinful Brand on the boss, perhaps use some debuff tracker.
+        </>,
+      )
+        .icon(SPELLS.SINFUL_BRAND.icon)
+        .actual(
+          t({
+            id: 'demonhunter.havoc.suggestions.sinfulBrand.uptime',
+            message: `${formatPercentage(actual)}% Sinful Brand uptime`,
+          }),
+        )
+        .recommended(`>${formatPercentage(recommended)}% is recommended`),
+    );
+  }
+
+  get uptimeHistory() {
+    return this.enemies.getDebuffHistory(SPELLS.SINFUL_BRAND.id);
+  }
+
+  subStatistic() {
+    return uptimeBarSubStatistic(this.owner.fight, {
+      spells: [SPELLS.SINFUL_BRAND],
+      uptimes: this.uptimeHistory,
+      color: BAR_COLOR,
+    });
+  }
+}
+
+export default SinfulBrandUptime;

--- a/analysis/demonhunterhavoc/src/modules/features/Checklist/Component.js
+++ b/analysis/demonhunterhavoc/src/modules/features/Checklist/Component.js
@@ -1,4 +1,5 @@
 import SPELLS from 'common/SPELLS';
+import COVENANTS from 'game/shadowlands/COVENANTS';
 import { SpellLink } from 'interface';
 import PreparationRule from 'parser/shadowlands/modules/features/Checklist/PreparationRule';
 import Checklist from 'parser/shared/modules/features/Checklist';
@@ -134,6 +135,16 @@ const HavocDemonHunterChecklist = ({ combatant, castEfficiency, thresholds }) =>
             thresholds={thresholds.momentumBuffUptime}
           />
         )}
+        {combatant.hasCovenant(COVENANTS.VENTHYR.id) && (
+          <Requirement
+            name={
+              <>
+                <SpellLink id={SPELLS.SINFUL_BRAND.id} /> debuff uptime
+              </>
+            }
+            thresholds={thresholds.sinfulBrandUptime}
+          />
+        )}
       </Rule>
 
       <Rule
@@ -237,6 +248,7 @@ const HavocDemonHunterChecklist = ({ combatant, castEfficiency, thresholds }) =>
 HavocDemonHunterChecklist.propTypes = {
   castEfficiency: PropTypes.object.isRequired,
   combatant: PropTypes.shape({
+    hasCovenant: PropTypes.func.isRequired,
     hasTalent: PropTypes.func.isRequired,
   }).isRequired,
   thresholds: PropTypes.object.isRequired,

--- a/analysis/demonhunterhavoc/src/modules/features/Checklist/Module.js
+++ b/analysis/demonhunterhavoc/src/modules/features/Checklist/Module.js
@@ -4,6 +4,7 @@ import Combatants from 'parser/shared/modules/Combatants';
 import BaseModule from 'parser/shared/modules/features/Checklist/Module';
 import ManaValues from 'parser/shared/modules/ManaValues';
 
+import SinfulBrandUptime from '../../covenants/SinfulBrandUptime';
 import FuryDetails from '../../resourcetracker/FuryDetails';
 import DemonBite from '../../spells/DemonBite';
 import BlindFury from '../../talents/BlindFury';
@@ -38,6 +39,7 @@ class Checklist extends BaseModule {
 
     // Maintain buffs/debuffs
     momentum: Momentum,
+    sinfulBrandUptime: SinfulBrandUptime,
 
     // Use your offensive cool downs
 
@@ -70,6 +72,7 @@ class Checklist extends BaseModule {
 
           // Maintain buffs/debuffs
           momentumBuffUptime: this.momentum.suggestionThresholds,
+          sinfulBrandUptime: this.sinfulBrandUptime.suggestionThresholds,
 
           // Use your offensive cool downs
 

--- a/analysis/demonhunterhavoc/src/modules/features/DotUptimes.tsx
+++ b/analysis/demonhunterhavoc/src/modules/features/DotUptimes.tsx
@@ -1,0 +1,42 @@
+import COVENANTS from 'game/shadowlands/COVENANTS';
+import UptimeIcon from 'interface/icons/Uptime';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import { STATISTIC_ORDER } from 'parser/ui/StatisticsListBox';
+import UptimeMultiBarStatistic from 'parser/ui/UptimeMultiBarStatistic';
+
+import SinfulBrandUptime from '../covenants/SinfulBrandUptime';
+
+/**
+ * Wide statistics box for tracking the most important Havoc DH DoT uptimes
+ */
+class DotUptimes extends Analyzer {
+  static dependencies = {
+    sinfulBrandUptime: SinfulBrandUptime,
+  };
+
+  protected sinfulBrandUptime!: SinfulBrandUptime;
+
+  constructor(options: Options) {
+    super(options);
+    // this should change if something is added that isn't Sinful Brand
+    this.active = this.selectedCombatant.hasCovenant(COVENANTS.VENTHYR.id);
+  }
+
+  statistic() {
+    return (
+      <UptimeMultiBarStatistic
+        title={
+          <>
+            <UptimeIcon /> DoT Uptimes
+          </>
+        }
+        position={STATISTIC_ORDER.CORE(1)}
+        tooltip={<>These uptime bars show the times your DoT was active on at least one target.</>}
+      >
+        {this.sinfulBrandUptime.active && this.sinfulBrandUptime.subStatistic()}
+      </UptimeMultiBarStatistic>
+    );
+  }
+}
+
+export default DotUptimes;

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -1900,3 +1900,16 @@ export const Lucky0604: Contributor = {
   avatar: avatar('lucky0604.png'),
   discord: 'Lucky0604#8966',
 };
+
+export const ToppleTheNun: Contributor = {
+  nickname: 'ToppleTheNun',
+  github: 'ToppleTheNun',
+  discord: 'ToppleTheNun#6969',
+  mains: [
+    {
+      name: 'Sigilweaver',
+      spec: SPECS.HAVOC_DEMON_HUNTER,
+      link: 'https://worldofwarcraft.com/en-us/character/us/thrall/Sigilweaver',
+    },
+  ],
+};

--- a/src/common/SPELLS/shadowlands/legendaries/demonhunter.ts
+++ b/src/common/SPELLS/shadowlands/legendaries/demonhunter.ts
@@ -98,6 +98,11 @@ const legendaries: SpellList<LegendarySpell> = {
     icon: 'ability_bastion_demonhunter',
     bonusID: 7699,
   },
+  AGONY_GAZE: {
+    id: 355886,
+    name: 'Agony Gaze',
+    icon: 'ability_revendreth_demonhunter',
+  },
   //endregion
 } as const;
 export default legendaries;

--- a/src/localization/de/messages.json
+++ b/src/localization/de/messages.json
@@ -113,6 +113,7 @@
   "demonhunter.havoc.suggestions.fury.wasted": "{0}% Jähzorn verschwendet",
   "demonhunter.havoc.suggestions.immolationAura.furyWasted": "{0}% Jähzorn verschwendet",
   "demonhunter.havoc.suggestions.momentum.uptime": "{0}% Buff Uptime",
+  "demonhunter.havoc.suggestions.sinfulBrand.uptime": "{0}% uptime",
   "demonhunter.vengeance.spiritBombFrailtyBuff.uptime": "{0}% Gebrechlichkeit Uptime",
   "demonhunter.vengeance.suggestions.alwaysBeCasting.downtime": "{0}% Downtime",
   "demonhunter.vengeance.suggestions.demonSpikes.unmitgatedHits": "{0}% ungemilderte physische Treffer",

--- a/src/localization/en/messages.json
+++ b/src/localization/en/messages.json
@@ -113,6 +113,7 @@
   "demonhunter.havoc.suggestions.fury.wasted": "{0}% Fury wasted",
   "demonhunter.havoc.suggestions.immolationAura.furyWasted": "{0}% Fury wasted",
   "demonhunter.havoc.suggestions.momentum.uptime": "{0}% buff uptime",
+  "demonhunter.havoc.suggestions.sinfulBrand.uptime": "{0}% uptime",
   "demonhunter.vengeance.spiritBombFrailtyBuff.uptime": "{0}% Frailty uptime",
   "demonhunter.vengeance.suggestions.alwaysBeCasting.downtime": "{0}% downtime",
   "demonhunter.vengeance.suggestions.demonSpikes.unmitgatedHits": "{0}% unmitigated physical hits",

--- a/src/localization/es/messages.json
+++ b/src/localization/es/messages.json
@@ -113,6 +113,7 @@
   "demonhunter.havoc.suggestions.fury.wasted": "",
   "demonhunter.havoc.suggestions.immolationAura.furyWasted": "",
   "demonhunter.havoc.suggestions.momentum.uptime": "",
+  "demonhunter.havoc.suggestions.sinfulBrand.uptime": "",
   "demonhunter.vengeance.spiritBombFrailtyBuff.uptime": "",
   "demonhunter.vengeance.suggestions.alwaysBeCasting.downtime": "",
   "demonhunter.vengeance.suggestions.demonSpikes.unmitgatedHits": "",

--- a/src/localization/fr/messages.json
+++ b/src/localization/fr/messages.json
@@ -113,6 +113,7 @@
   "demonhunter.havoc.suggestions.fury.wasted": "",
   "demonhunter.havoc.suggestions.immolationAura.furyWasted": "",
   "demonhunter.havoc.suggestions.momentum.uptime": "",
+  "demonhunter.havoc.suggestions.sinfulBrand.uptime": "",
   "demonhunter.vengeance.spiritBombFrailtyBuff.uptime": "",
   "demonhunter.vengeance.suggestions.alwaysBeCasting.downtime": "",
   "demonhunter.vengeance.suggestions.demonSpikes.unmitgatedHits": "",

--- a/src/localization/it/messages.json
+++ b/src/localization/it/messages.json
@@ -113,6 +113,7 @@
   "demonhunter.havoc.suggestions.fury.wasted": "",
   "demonhunter.havoc.suggestions.immolationAura.furyWasted": "",
   "demonhunter.havoc.suggestions.momentum.uptime": "",
+  "demonhunter.havoc.suggestions.sinfulBrand.uptime": "",
   "demonhunter.vengeance.spiritBombFrailtyBuff.uptime": "",
   "demonhunter.vengeance.suggestions.alwaysBeCasting.downtime": "",
   "demonhunter.vengeance.suggestions.demonSpikes.unmitgatedHits": "",

--- a/src/localization/ko/messages.json
+++ b/src/localization/ko/messages.json
@@ -113,6 +113,7 @@
   "demonhunter.havoc.suggestions.fury.wasted": "",
   "demonhunter.havoc.suggestions.immolationAura.furyWasted": "",
   "demonhunter.havoc.suggestions.momentum.uptime": "",
+  "demonhunter.havoc.suggestions.sinfulBrand.uptime": "",
   "demonhunter.vengeance.spiritBombFrailtyBuff.uptime": "",
   "demonhunter.vengeance.suggestions.alwaysBeCasting.downtime": "",
   "demonhunter.vengeance.suggestions.demonSpikes.unmitgatedHits": "",

--- a/src/localization/pl/messages.json
+++ b/src/localization/pl/messages.json
@@ -113,6 +113,7 @@
   "demonhunter.havoc.suggestions.fury.wasted": "",
   "demonhunter.havoc.suggestions.immolationAura.furyWasted": "",
   "demonhunter.havoc.suggestions.momentum.uptime": "",
+  "demonhunter.havoc.suggestions.sinfulBrand.uptime": "",
   "demonhunter.vengeance.spiritBombFrailtyBuff.uptime": "",
   "demonhunter.vengeance.suggestions.alwaysBeCasting.downtime": "",
   "demonhunter.vengeance.suggestions.demonSpikes.unmitgatedHits": "",

--- a/src/localization/pt/messages.json
+++ b/src/localization/pt/messages.json
@@ -113,6 +113,7 @@
   "demonhunter.havoc.suggestions.fury.wasted": "",
   "demonhunter.havoc.suggestions.immolationAura.furyWasted": "",
   "demonhunter.havoc.suggestions.momentum.uptime": "",
+  "demonhunter.havoc.suggestions.sinfulBrand.uptime": "",
   "demonhunter.vengeance.spiritBombFrailtyBuff.uptime": "",
   "demonhunter.vengeance.suggestions.alwaysBeCasting.downtime": "",
   "demonhunter.vengeance.suggestions.demonSpikes.unmitgatedHits": "",

--- a/src/localization/ru/messages.json
+++ b/src/localization/ru/messages.json
@@ -113,6 +113,7 @@
   "demonhunter.havoc.suggestions.fury.wasted": "{0}% Fury wasted",
   "demonhunter.havoc.suggestions.immolationAura.furyWasted": "{0}% Fury wasted",
   "demonhunter.havoc.suggestions.momentum.uptime": "{0}% buff uptime",
+  "demonhunter.havoc.suggestions.sinfulBrand.uptime": "{0}% uptime",
   "demonhunter.vengeance.spiritBombFrailtyBuff.uptime": "{0}% Frailty uptime",
   "demonhunter.vengeance.suggestions.alwaysBeCasting.downtime": "{0}% downtime",
   "demonhunter.vengeance.suggestions.demonSpikes.unmitgatedHits": "{0}% unmitigated physical hits",

--- a/src/localization/zh/messages.json
+++ b/src/localization/zh/messages.json
@@ -113,6 +113,7 @@
   "demonhunter.havoc.suggestions.fury.wasted": "",
   "demonhunter.havoc.suggestions.immolationAura.furyWasted": "",
   "demonhunter.havoc.suggestions.momentum.uptime": "",
+  "demonhunter.havoc.suggestions.sinfulBrand.uptime": "",
   "demonhunter.vengeance.spiritBombFrailtyBuff.uptime": "",
   "demonhunter.vengeance.suggestions.alwaysBeCasting.downtime": "",
   "demonhunter.vengeance.suggestions.demonSpikes.unmitgatedHits": "",


### PR DESCRIPTION
Add Sinful Brand uptime tracker as it's where the majority of HDH damage comes from in raid.

Change the recommendation of casting Sinful Brand on cooldown as it's actually harmful if you're using double legendary (will add a PR for this check later).

**Sinful Brand DoT Uptime included in Checklist**
![image](https://user-images.githubusercontent.com/1672786/180076653-7ecc960f-56b9-401c-be04-7d4073733aea.png)

**Substatistic for Sinful Brand DoT Uptime**
![image](https://user-images.githubusercontent.com/1672786/180076531-a6466926-9fac-46be-babf-44196faa1955.png)

**Non-Venthyr Havoc DH**
![image](https://user-images.githubusercontent.com/1672786/180077226-272695a1-f64e-47ff-b735-517ebd99ae29.png)