### PR TITLE
Ehancement Shaman - Crash Lightning CD Reduction

### DIFF
--- a/analysis/shamanenhancement/src/CHANGELOG.tsx
+++ b/analysis/shamanenhancement/src/CHANGELOG.tsx
@@ -1,11 +1,11 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
-import { Abelito75, HawkCorrigan, Mae, MusicMeister, xunai, Vonn } from 'CONTRIBUTORS';
+import { Abelito75, HawkCorrigan, Mae, MusicMeister, xunai, Vonn, Vetyst } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 
 export default [
-  change(date(2022, 4, 26), <>Reduce the CD of <SpellLink id={SPELLS.CRASH_LIGHTNING.id} /> for each target hit by <SpellLink id={SPELLS.CHAIN_LIGHTNING.id} /> </>, xunai),
+  change(date(2022, 7, 19), <>Reduce cooldown of <SpellLink id={SPELLS.CRASH_LIGHTNING.id} /> for each target hit by <SpellLink id={SPELLS.CHAIN_LIGHTNING.id} />.</>, Vetyst),
   change(date(2022, 4, 26), <>Added <SpellLink id={SPELLS.FAE_TRANSFUSION.id} /> to the timeline and support for <SpellLink id={SPELLS.SEEDS_OF_RAMPANT_GROWTH.id} /> </>, xunai),
   change(date(2022, 4, 24), <>Added cooldown reduction tracking for <SpellLink id={SPELLS.WITCH_DOCTORS_WOLF_BONES.id} /></>, xunai),
   change(date(2022, 4, 21), <>Added statistics for tier 28 two set bonus and for <SpellLink id={SPELLS.ELEMENTAL_SPIRITS_TALENT.id} /></>, xunai),

--- a/analysis/shamanenhancement/src/CHANGELOG.tsx
+++ b/analysis/shamanenhancement/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2022, 4, 26), <>Reduce the CD of <SpellLink id={SPELLS.CRASH_LIGHTNING.id} /> for each target hit by <SpellLink id={SPELLS.CHAIN_LIGHTNING.id} /> </>, xunai),
   change(date(2022, 4, 26), <>Added <SpellLink id={SPELLS.FAE_TRANSFUSION.id} /> to the timeline and support for <SpellLink id={SPELLS.SEEDS_OF_RAMPANT_GROWTH.id} /> </>, xunai),
   change(date(2022, 4, 24), <>Added cooldown reduction tracking for <SpellLink id={SPELLS.WITCH_DOCTORS_WOLF_BONES.id} /></>, xunai),
   change(date(2022, 4, 21), <>Added statistics for tier 28 two set bonus and for <SpellLink id={SPELLS.ELEMENTAL_SPIRITS_TALENT.id} /></>, xunai),

--- a/analysis/shamanenhancement/src/CombatLogParser.tsx
+++ b/analysis/shamanenhancement/src/CombatLogParser.tsx
@@ -14,6 +14,7 @@ import Abilities from './modules/Abilities';
 // Features
 import Buffs from './modules/Buffs';
 import Checklist from './modules/checklist/Module';
+import ChainLightning from './modules/core/ChainLightning';
 import FeralSpirit from './modules/core/FeralSpirit';
 import MaelstromWeapon from './modules/core/MaelstromWeapon';
 import Stormbringer from './modules/core/Stormbringer';
@@ -55,6 +56,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Shaman Core
     stormbringer: Stormbringer,
     feralSpirit: FeralSpirit,
+    chainLightning: ChainLightning,
 
     // Features
     alwaysBeCasting: AlwaysBeCasting,

--- a/analysis/shamanenhancement/src/modules/core/ChainLightning.tsx
+++ b/analysis/shamanenhancement/src/modules/core/ChainLightning.tsx
@@ -1,0 +1,40 @@
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+
+const CRASH_LIGHTNING_REDUCTION = 1000;
+
+/**
+ * Hurls a lightning bolt at the enemy, dealing (63.5% of Spell power) Nature damage and then jumping to additional nearby enemies. Affects 3 total targets.
+ *
+ *  Enhancement (Level 38)
+ * If Chain Lightning hits more than 1 target, each target hit by your Chain Lightning increases the damage of your next Crash Lightning by 20%
+ *
+ *  Enhancement (Level 52)
+ * Each target hit by Chain Lightning reduces the cooldown of Crash Lightning by 1.0 sec
+ */
+class ChainLightning extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+  };
+
+  protected spellUsable!: SpellUsable;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.CHAIN_LIGHTNING),
+      this.onDamage,
+    );
+  }
+
+  onDamage() {
+    if (this.spellUsable.isOnCooldown(SPELLS.CRASH_LIGHTNING.id)) {
+      this.spellUsable.reduceCooldown(SPELLS.CRASH_LIGHTNING.id, CRASH_LIGHTNING_REDUCTION);
+    }
+  }
+}
+
+export default ChainLightning;


### PR DESCRIPTION
Each target hit by Chain Lightning reduces the cooldown of Crash Lightning by 1.0 sec

There is also an interation which increases the damage of your next Crash Lightning. I'm unsure which buff id this is which is why i have not implemented it.