### PR TITLE
Ehancement Shaman - Properly reset cooldown on Stormstike

### DIFF
--- a/analysis/shamanenhancement/src/CHANGELOG.tsx
+++ b/analysis/shamanenhancement/src/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
-import { Abelito75, HawkCorrigan, Mae, MusicMeister, xunai, Vonn } from 'CONTRIBUTORS';
+import { Abelito75, HawkCorrigan, Mae, MusicMeister, xunai, Vonn, Vetyst } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2022, 7, 19), <>Reset <SpellLink id={SPELLS.STORMSTRIKE_CAST.id} /> cooldown when <SpellLink id={SPELLS.STORMBRINGER.id} /> is refreshed. </>, Vetyst),
   change(date(2022, 4, 26), <>Added <SpellLink id={SPELLS.FAE_TRANSFUSION.id} /> to the timeline and support for <SpellLink id={SPELLS.SEEDS_OF_RAMPANT_GROWTH.id} /> </>, xunai),
   change(date(2022, 4, 24), <>Added cooldown reduction tracking for <SpellLink id={SPELLS.WITCH_DOCTORS_WOLF_BONES.id} /></>, xunai),
   change(date(2022, 4, 21), <>Added statistics for tier 28 two set bonus and for <SpellLink id={SPELLS.ELEMENTAL_SPIRITS_TALENT.id} /></>, xunai),

--- a/analysis/shamanenhancement/src/modules/core/Stormbringer.tsx
+++ b/analysis/shamanenhancement/src/modules/core/Stormbringer.tsx
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS/shaman';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
-import Events, { ApplyBuffEvent, CastEvent, DamageEvent } from 'parser/core/Events';
+import Events, { DamageEvent } from 'parser/core/Events';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
@@ -31,6 +31,11 @@ class Stormbringer extends Analyzer {
     );
 
     this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.STORMBRINGER_BUFF),
+      this.onStormbringerApplied,
+    );
+
+    this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(STORMSTRIKE_CAST_SPELLS),
       this.onStormstrikeUseWithStormbringerBuff,
     );
@@ -41,7 +46,7 @@ class Stormbringer extends Analyzer {
     );
   }
 
-  onStormbringerApplied(event: ApplyBuffEvent) {
+  onStormbringerApplied() {
     if (this.spellUsable.isOnCooldown(SPELLS.STORMSTRIKE_CAST.id)) {
       this.spellUsable.endCooldown(SPELLS.STORMSTRIKE_CAST.id);
     }
@@ -51,7 +56,7 @@ class Stormbringer extends Analyzer {
     }
   }
 
-  onStormstrikeUseWithStormbringerBuff(event: CastEvent) {
+  onStormstrikeUseWithStormbringerBuff() {
     if (!this.selectedCombatant.hasBuff(SPELLS.STORMBRINGER_BUFF.id)) {
       return;
     }


### PR DESCRIPTION
There was an issue where the cooldown was not properly reset according to the analyzer. This is because it is also reset when the Stormbringer buff is refreshed.