### PR TITLE
Replace cookies with localStorage API

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "redux-thunk": "^2.3.0",
     "sass-text-stroke": "1.2.0",
     "swr": "^0.5.6",
-    "universal-cookie": "^4.0.4",
     "vega": "~5.21.0",
     "vega-lite": "^5.2.0"
   },

--- a/src/interface/reducers/language.ts
+++ b/src/interface/reducers/language.ts
@@ -1,21 +1,16 @@
 import { SET_LANGUAGE } from 'interface/actions/language';
 import { AnyAction } from 'redux';
-import Cookies from 'universal-cookie';
 
-const cookies = new Cookies();
-const COOKIE_NAME = 'LANGUAGE';
-const cookieOptions = {
-  path: '/',
-  maxAge: 86400 * 365, // 1 year
-};
-const defaultState = cookies.get(COOKIE_NAME) || 'en';
+const LOCAL_STORAGE_KEY = 'LANGUAGE';
+
+const defaultState = localStorage.getItem(LOCAL_STORAGE_KEY) || 'en';
 
 export type LanguageState = string;
 
 export default function language(state: LanguageState = defaultState, action: AnyAction) {
   switch (action.type) {
     case SET_LANGUAGE:
-      cookies.set(COOKIE_NAME, action.payload, cookieOptions);
+      localStorage.setItem(LOCAL_STORAGE_KEY, action.payload);
       return action.payload;
     default:
       return state;

--- a/src/interface/reducers/reportHistory.js
+++ b/src/interface/reducers/reportHistory.js
@@ -1,14 +1,9 @@
 import { APPEND_REPORT_HISTORY } from 'interface/actions/reportHistory';
-import Cookies from 'universal-cookie';
 
+const LOCAL_STORAGE_KEY = 'REPORT_HISTORY';
 const MAX_ITEMS = 5;
-const cookies = new Cookies();
-const COOKIE_NAME = 'REPORT_HISTORY';
-const cookieOptions = {
-  path: '/',
-  maxAge: 86400 * 365, // 1 year
-};
-const defaultState = cookies.get(COOKIE_NAME) || [];
+
+const defaultState = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY)) || [];
 
 export default function reportHistory(state = defaultState, action) {
   switch (action.type) {
@@ -21,7 +16,7 @@ export default function reportHistory(state = defaultState, action) {
       if (numItems > MAX_ITEMS) {
         newState = newState.slice(numItems - MAX_ITEMS);
       }
-      cookies.set(COOKIE_NAME, newState, cookieOptions);
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newState));
       return newState;
     }
     default:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2941,11 +2941,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/cookie@^0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
-  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
-
 "@types/enzyme@^3.10.7":
   version "3.10.10"
   resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.10.tgz#3a44cc66571432ab9e1773a831af3742beb39275"
@@ -4863,6 +4858,7 @@ common-tags@^1.8.0:
 
 "common@link:src/common":
   version "0.0.0"
+  uid ""
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -4957,11 +4953,6 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
-
-cookie@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
-  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
@@ -7293,6 +7284,7 @@ fuzzaldrin@^2.1.0:
 
 "game@link:src/game":
   version "0.0.0"
+  uid ""
 
 gemini-scrollbar@^1.5.3:
   version "1.5.3"
@@ -7962,6 +7954,7 @@ inquirer@^7.3.3:
 
 "interface@link:src/interface":
   version "0.0.0"
+  uid ""
 
 internal-slot@^1.0.3:
   version "1.0.3"
@@ -10420,6 +10413,7 @@ parse5@6.0.1, parse5@^6.0.1:
 
 "parser@link:src/parser":
   version "0.0.0"
+  uid ""
 
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
@@ -13525,14 +13519,6 @@ unique-string@^2.0.0:
   integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
   dependencies:
     crypto-random-string "^2.0.0"
-
-universal-cookie@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-4.0.4.tgz#06e8b3625bf9af049569ef97109b4bb226ad798d"
-  integrity sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==
-  dependencies:
-    "@types/cookie" "^0.3.3"
-    cookie "^0.4.0"
 
 universalify@^0.1.0, universalify@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
Moderen browsers have an alternative to browser-only cookies. This would be through the localStorage API; [caniuse.com](https://caniuse.com/?search=localStorage) | [documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)

There were three instances of cookie usage as far as i could find;
* The Privacy Page
* Language selector
* Report History.

The privacy page makes direct usage of the cookies using `document.cookie`. Whereas the later two used the `universal-cookie` package. 

Implementing this new method gets rid of a package but comes with a con; Language preference and Report History will be reset.

