### PR TITLE
Death Knight Runeforge enchants

### DIFF
--- a/analysis/deathknightfrost/src/integrationTests/example.test.ts.snap
+++ b/analysis/deathknightfrost/src/integrationTests/example.test.ts.snap
@@ -4210,7 +4210,7 @@ exports[`Frost Death Knight integration test: example log GatheringStorm matches
             <img
               alt="Gathering Storm"
               className="icon game "
-              src="//render-us.worldofwarcraft.com/icons/56/spell_frost_ice_shards.jpg"
+              src="//render-us.worldofwarcraft.com/icons/56/spell_frost_iceshards.jpg"
             />
           </a>
            

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -61,6 +61,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2022, 7, 22), 'Show Death Knight Runeforge enchants on character overview', Vetyst),
   change(date(2022, 7, 22), 'Add create event for handling spells like Demonic Circle.', ToppleTheNun),
   change(date(2022, 7, 21), 'Reflect the quality of an item through the border of gear shown on the character tab.', Vetyst),
   change(date(2022, 7, 21), 'Updated enchants on character overview for SL and TBC.', Vetyst),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -61,7 +61,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
-  change(date(2022, 7, 22), 'Show Death Knight Runeforge enchants on character overview', Vetyst),
+  change(date(2022, 7, 22), 'Show Death Knight Runeforge enchants on character overview.', Vetyst),
   change(date(2022, 7, 22), 'Add create event for handling spells like Demonic Circle.', ToppleTheNun),
   change(date(2022, 7, 21), 'Reflect the quality of an item through the border of gear shown on the character tab.', Vetyst),
   change(date(2022, 7, 21), 'Updated enchants on character overview for SL and TBC.', Vetyst),

--- a/src/common/SPELLS/talents/deathknight.ts
+++ b/src/common/SPELLS/talents/deathknight.ts
@@ -115,7 +115,7 @@ const talents: SpellList = {
     runesCost: 1,
   },
   PERMAFROST_TALENT: { id: 207200, name: 'Permafrost', icon: 'achievement_zone_frostfire' },
-  GATHERING_STORM_TALENT: { id: 194912, name: 'Gathering Storm', icon: 'spell_frost_ice_shards' },
+  GATHERING_STORM_TALENT: { id: 194912, name: 'Gathering Storm', icon: 'spell_frost_ice-shards' },
   HYPOTHERMIC_PRESENCE_TALENT: {
     id: 321995,
     name: 'Hypothermic Presence',

--- a/src/interface/report/Results/enchantIdMap.ts
+++ b/src/interface/report/Results/enchantIdMap.ts
@@ -107,6 +107,9 @@ const enchantIdMap: { [key: number]: string } = {
   3225: 'Executioner',
   3229: '+12 Resilience Rating',
   3273: 'Deathfrost',
+  3368: 'Rune of the Fallen Crusader',
+  3370: 'Rune of Razorice',
+  3847: 'Rune of the Stoneskin Gargoyle',
 
   // Battle For Azeroth
   5933: 'Kul Tiran Mining',
@@ -177,6 +180,11 @@ const enchantIdMap: { [key: number]: string } = {
   6228: 'Sinful Revelation',
   6229: 'Celestial Guidance',
   6230: 'Primary Stats +30',
+  6241: 'Rune of Sanguination',
+  6242: 'Rune of Spellwarding',
+  6243: 'Rune of Hysteria',
+  6244: 'Rune of Unending Thirst',
+  6245: 'Rune of the Apocalypse',
   6265: 'Eternal Insight',
 };
 


### PR DESCRIPTION
I updated the list for enchant names in #4995 but only now found out that the Runeforging enchants were missing.
Also noticed that one of the icons was not working, that is resolved aswell.

![Screenshot_1](https://user-images.githubusercontent.com/3527340/180622754-935b9d49-cbef-452a-842a-0a65df23d70a.jpg)![Screenshot_2](https://user-images.githubusercontent.com/3527340/180622763-a09dad57-c16a-41cd-a22d-2e25781548d1.jpg)

