### PR TITLE
Update Kindling CDR time and workaround some crashes when time filters are used

### DIFF
--- a/analysis/magefire/src/CHANGELOG.tsx
+++ b/analysis/magefire/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2022, 8, 8), <>Fix crash when time is filtered to include the end of <SpellLink id={SPELLS.COMBUSTION.id} /> but not the start.</>, emallson),
   change(date(2022, 8, 8), <>Updated the cooldown reduction for <SpellLink id={SPELLS.KINDLING_TALENT.id} />.</>, emallson),
   change(date(2022, 5, 21), <>Added the <SpellLink id={SPELLS.MIRRORS_OF_TORMENT.id} /> cooldown reduction from <SpellLink id={SPELLS.SINFUL_DELIGHT.id} />.</>, Sharrq),
   change(date(2022, 5, 21), <>Removed the suggestion and associated checks for casting <SpellLink id={SPELLS.COMBUSTION.id} /> during <SpellLink id={SPELLS.FIRESTARTER_TALENT.id} />.</>, Sharrq),

--- a/analysis/magefire/src/CHANGELOG.tsx
+++ b/analysis/magefire/src/CHANGELOG.tsx
@@ -1,9 +1,11 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
-import { Adoraci, Sharrq } from 'CONTRIBUTORS';
+import { emallson, Adoraci, Sharrq } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
+// prettier-ignore
 export default [
+  change(date(2022, 8, 8), <>Updated the cooldown reduction for <SpellLink id={SPELLS.KINDLING_TALENT.id} />.</>, emallson),
   change(date(2022, 5, 21), <>Added the <SpellLink id={SPELLS.MIRRORS_OF_TORMENT.id} /> cooldown reduction from <SpellLink id={SPELLS.SINFUL_DELIGHT.id} />.</>, Sharrq),
   change(date(2022, 5, 21), <>Removed the suggestion and associated checks for casting <SpellLink id={SPELLS.COMBUSTION.id} /> during <SpellLink id={SPELLS.FIRESTARTER_TALENT.id} />.</>, Sharrq),
   change(date(2022, 5, 21), <>Removed <SpellLink id={SPELLS.MIRROR_IMAGE.id} /> from the Throughput Cooldowns list.</>, Sharrq),

--- a/analysis/magefire/src/integrationTests/example.test.ts.snap
+++ b/analysis/magefire/src/integrationTests/example.test.ts.snap
@@ -3590,7 +3590,7 @@ exports[`Fire Mage integration test: example log CombustionActiveTime matches th
         <div
           className="value"
         >
-          87.05
+          110.58
           % 
           <small>
             Combustion Active Time
@@ -3643,48 +3643,6 @@ exports[`Fire Mage integration test: example log CombustionActiveTime matches th
     </div>
   </div>
 </div>
-`;
-
-exports[`Fire Mage integration test: example log CombustionActiveTime matches the suggestions snapshot 1`] = `
-Array [
-  Object {
-    "details": null,
-    "icon": "spell_fire_sealoffire",
-    "importance": "regular",
-    "issue": <React.Fragment>
-      You spent 
-      10
-       seconds (
-      3
-      s per cast) not casting anything while
-       
-      <ForwardRef
-        id={190319}
-      />
-       was active. Because a large portion of your damage comes from Combustion, you should ensure that you are getting the most out of it every time it is cast. While sometimes this is out of your control (you got targeted by a mechanic at the worst possible time), you should try to minimize that risk by casting
-       
-      <ForwardRef
-        id={190319}
-      />
-       when you are at a low risk of being interrupted or when the target is vulnerable.
-    </React.Fragment>,
-    "spell": undefined,
-    "stat": <React.Fragment>
-      <Trans
-        id="mage.frost.suggestions.combustion.combustionActiveTime"
-        message="{0}% Active Time during Combustion"
-        values={
-          Object {
-            "0": "87.05",
-          }
-        }
-      />
-       (
-      95.00% is recommended
-      )
-    </React.Fragment>,
-  },
-]
 `;
 
 exports[`Fire Mage integration test: example log CombustionCasts matches the statistic snapshot 1`] = `
@@ -6344,7 +6302,7 @@ exports[`Fire Mage integration test: example log matches the checklist snapshot 
               style={
                 Object {
                   "backgroundColor": "#a6c34c",
-                  "width": "82.07726058211462%",
+                  "width": "88.25398708540243%",
                 }
               }
             />
@@ -6919,7 +6877,7 @@ exports[`Fire Mage integration test: example log matches the checklist snapshot 
                   }
                 >
                    
-                  87.05%
+                  110.58%
                    
                    
                 </div>
@@ -6939,9 +6897,9 @@ exports[`Fire Mage integration test: example log matches the checklist snapshot 
                     className="performance-bar small"
                     style={
                       Object {
-                        "backgroundColor": "#ffc84a",
+                        "backgroundColor": "#4ec04e",
                         "transition": "background-color 800ms",
-                        "width": "56.76291447698527%",
+                        "width": "100%",
                       }
                     }
                   />

--- a/analysis/magefire/src/modules/items/InfernalCascade.tsx
+++ b/analysis/magefire/src/modules/items/InfernalCascade.tsx
@@ -141,8 +141,9 @@ class InfernalCascade extends Analyzer {
       1,
       undefined,
       Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.COMBUSTION),
-    )[0].timestamp;
-    this.totalCombustionDuration += event.timestamp - lastCombustStart;
+    );
+    this.totalCombustionDuration +=
+      event.timestamp - (lastCombustStart[0]?.timestamp ?? this.owner.fight.start_time);
   }
 
   onBuffRemoved(event: RemoveBuffEvent) {

--- a/analysis/magefire/src/modules/talents/Kindling.tsx
+++ b/analysis/magefire/src/modules/talents/Kindling.tsx
@@ -8,7 +8,7 @@ import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 
-const REDUCTION_MS = 1500;
+const REDUCTION_MS = 1000;
 const COMBUST_REDUCTION_SPELLS = [
   SPELLS.FIREBALL,
   SPELLS.PYROBLAST,


### PR DESCRIPTION
Kindling got nerfed to 1s (was 1.5s) in 9.1 but the update got missed here.

The crashes were caused by the combustion `applybuff` being missing. The code now falls back to using the fight (or filter) start time when this occurs.