### PR TITLE
Remove deprecated statisticOrder property on all Analyzers.

### DIFF
--- a/analysis/druidbalance/src/modules/features/CancelledCasts.tsx
+++ b/analysis/druidbalance/src/modules/features/CancelledCasts.tsx
@@ -2,7 +2,6 @@ import { t } from '@lingui/macro';
 import { formatPercentage } from 'common/format';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import CoreCancelledCasts from 'parser/shared/modules/CancelledCasts';
-import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 
 class CancelledCasts extends CoreCancelledCasts {
   get suggestionThresholds() {
@@ -16,8 +15,6 @@ class CancelledCasts extends CoreCancelledCasts {
       style: ThresholdStyle.PERCENTAGE,
     };
   }
-
-  statisticOrder = STATISTIC_ORDER.CORE(8);
 
   suggestions(when: When) {
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>

--- a/analysis/druidbalance/src/modules/talents/StellarDrift.tsx
+++ b/analysis/druidbalance/src/modules/talents/StellarDrift.tsx
@@ -25,7 +25,6 @@ class StellarDrift extends Analyzer {
 
   bonusDamage = 0;
   countStarfallCasts = 0;
-  statisticOrder = STATISTIC_ORDER.OPTIONAL();
 
   constructor(options: Options) {
     super(options);

--- a/analysis/druidguardian/src/modules/features/IronFurGoEProcs.js
+++ b/analysis/druidguardian/src/modules/features/IronFurGoEProcs.js
@@ -11,7 +11,6 @@ class IronFurGoEProcs extends Analyzer {
   static dependencies = {
     guardianOfElune: GuardianOfElune,
   };
-  statisticOrder = STATISTIC_ORDER.CORE(9);
 
   constructor(...args) {
     super(...args);

--- a/analysis/magearcane/src/modules/features/AlwaysBeCasting.tsx
+++ b/analysis/magearcane/src/modules/features/AlwaysBeCasting.tsx
@@ -36,7 +36,7 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
     }
   }
 
-  statisticOrder: any = STATISTIC_ORDER.CORE(1);
+  position = STATISTIC_ORDER.CORE(1);
 }
 
 export default AlwaysBeCasting;

--- a/analysis/monkbrewmaster/src/modules/features/AlwaysBeCasting.js
+++ b/analysis/monkbrewmaster/src/modules/features/AlwaysBeCasting.js
@@ -4,7 +4,7 @@ import CoreAlwaysBeCasting from 'parser/shared/modules/AlwaysBeCasting';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 
 class AlwaysBeCasting extends CoreAlwaysBeCasting {
-  statisticOrder = STATISTIC_ORDER.CORE(10);
+  position = STATISTIC_ORDER.CORE(10);
 
   suggestions(when) {
     const deadTimePercentage = this.totalTimeWasted / this.owner.fightDuration;

--- a/analysis/monkbrewmaster/src/modules/spells/BlackoutCombo.js
+++ b/analysis/monkbrewmaster/src/modules/spells/BlackoutCombo.js
@@ -32,7 +32,6 @@ class BlackoutCombo extends Analyzer {
   blackoutComboBuffs = 0;
   lastBlackoutComboCast = 0;
   spellsBOCWasUsedOn = {};
-  statisticOrder = STATISTIC_ORDER.OPTIONAL();
 
   constructor(...args) {
     super(...args);

--- a/analysis/monkwindwalker/src/modules/features/AlwaysBeCasting.tsx
+++ b/analysis/monkwindwalker/src/modules/features/AlwaysBeCasting.tsx
@@ -40,7 +40,7 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
     );
   }
 
-  statisticOrder = STATISTIC_ORDER.CORE(10);
+  position = STATISTIC_ORDER.CORE(10);
 }
 
 export default AlwaysBeCasting;

--- a/analysis/paladinprotection/src/modules/features/AlwaysBeCasting.js
+++ b/analysis/paladinprotection/src/modules/features/AlwaysBeCasting.js
@@ -43,7 +43,7 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
     }
   }
 
-  statisticOrder = STATISTIC_ORDER.CORE(1);
+  position = STATISTIC_ORDER.CORE(1);
 }
 
 export default AlwaysBeCasting;

--- a/analysis/paladinprotection/src/modules/features/ShieldOfTheRighteous.tsx
+++ b/analysis/paladinprotection/src/modules/features/ShieldOfTheRighteous.tsx
@@ -71,6 +71,7 @@ class ShieldOfTheRighteous extends Analyzer {
   statistic() {
     return (
       <StatisticBox
+        position={STATISTIC_ORDER.CORE(10)}
         icon={<SpellIcon id={SPELLS.SHIELD_OF_THE_RIGHTEOUS.id} />}
         value={`${formatPercentage(this.sotrHits / this.totalHits)}%`}
         label="Physical Hits Mitigated"
@@ -100,7 +101,6 @@ class ShieldOfTheRighteous extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.CORE(10);
 }
 
 export default ShieldOfTheRighteous;

--- a/analysis/paladinretribution/src/modules/features/AlwaysBeCasting.js
+++ b/analysis/paladinretribution/src/modules/features/AlwaysBeCasting.js
@@ -47,7 +47,7 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
     activeTime: '/img/wheelchair.png',
     downtime: '/img/afk.png',
   };
-  statisticOrder = STATISTIC_ORDER.CORE(1);
+  position = STATISTIC_ORDER.CORE(1);
 }
 
 export default AlwaysBeCasting;

--- a/analysis/shaman/src/ElementalBlast.tsx
+++ b/analysis/shaman/src/ElementalBlast.tsx
@@ -67,6 +67,7 @@ class ElementalBlast extends Analyzer {
   statistic() {
     return (
       <StatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
         icon={<SpellIcon id={SPELLS.ELEMENTAL_BLAST_TALENT.id} />}
         value={`${formatPercentage(this.elementalBlastUptime)} %`}
         label="Uptime"
@@ -88,7 +89,6 @@ class ElementalBlast extends Analyzer {
       />
     );
   }
-  statisticOrder = STATISTIC_ORDER.OPTIONAL();
 }
 
 export default ElementalBlast;

--- a/analysis/shamanelemental/src/modules/features/CancelledCasts.tsx
+++ b/analysis/shamanelemental/src/modules/features/CancelledCasts.tsx
@@ -2,11 +2,8 @@ import { t } from '@lingui/macro';
 import { formatPercentage } from 'common/format';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import CoreCancelledCasts from 'parser/shared/modules/CancelledCasts';
-import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 
 class CancelledCasts extends CoreCancelledCasts {
-  statisticOrder = STATISTIC_ORDER.CORE(8);
-
   get suggestionThresholds() {
     return {
       actual: this.castsCancelled / this.totalCasts,

--- a/analysis/shamanelemental/src/modules/features/Overload.js
+++ b/analysis/shamanelemental/src/modules/features/Overload.js
@@ -11,7 +11,6 @@ class Overload extends Analyzer {
   };
 
   spells = [];
-  statisticOrder = STATISTIC_ORDER.OPTIONAL();
 
   constructor(...args) {
     super(...args);
@@ -81,6 +80,7 @@ class Overload extends Analyzer {
   statistic() {
     return (
       <StatisticBox
+        position={STATISTIC_ORDER.OPTIONAL()}
         icon={<SpellIcon id={SPELLS.ELEMENTAL_MASTERY.id} />}
         value={
           <ul style={{ listStyle: 'none', paddingLeft: 0 }}>

--- a/analysis/warlockdemonology/src/modules/features/AlwaysBeCasting.js
+++ b/analysis/warlockdemonology/src/modules/features/AlwaysBeCasting.js
@@ -18,7 +18,7 @@ class AlwaysBeCasting extends CoreAlwaysBeCasting {
     };
   }
 
-  statisticOrder = STATISTIC_ORDER.CORE(1);
+  position = STATISTIC_ORDER.CORE(1);
 
   suggestions(when) {
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>

--- a/analysis/warlockdemonology/src/modules/soulshards/SoulShardDetails.js
+++ b/analysis/warlockdemonology/src/modules/soulshards/SoulShardDetails.js
@@ -29,7 +29,6 @@ class SoulShardDetails extends Analyzer {
   static dependencies = {
     soulShardTracker: SoulShardTracker,
   };
-  statisticOrder = STATISTIC_ORDER.CORE(2);
 
   suggestions(when) {
     const shardsWasted = this.soulShardTracker.wasted;

--- a/analysis/warriorfury/src/modules/features/AlwaysBeCasting.tsx
+++ b/analysis/warriorfury/src/modules/features/AlwaysBeCasting.tsx
@@ -7,7 +7,7 @@ import CoreAlwaysBeCasting from 'parser/shared/modules/AlwaysBeCasting';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 
 class AlwaysBeCasting extends CoreAlwaysBeCasting {
-  statisticOrder = STATISTIC_ORDER.CORE(1);
+  position = STATISTIC_ORDER.CORE(1);
 
   get downtimeSuggestionThresholds() {
     return {

--- a/analysis/warriorprotection/src/modules/core/RageDetails.tsx
+++ b/analysis/warriorprotection/src/modules/core/RageDetails.tsx
@@ -16,7 +16,6 @@ class RageDetails extends Analyzer {
   static dependencies = {
     rageTracker: RageTracker,
   };
-  statisticOrder = STATISTIC_ORDER.CORE(3);
   protected rageTracker!: RageTracker;
 
   get wastedPercent() {

--- a/analysis/warriorprotection/src/modules/features/Avatar.tsx
+++ b/analysis/warriorprotection/src/modules/features/Avatar.tsx
@@ -15,7 +15,6 @@ const AVATAR_DAMAGE_INCREASE = 0.2;
 
 class Avatar extends Analyzer {
   bonusDmg = 0;
-  statisticOrder = STATISTIC_ORDER.CORE(5);
 
   constructor(options: Options) {
     super(options);

--- a/analysis/warriorprotection/src/modules/talents/AngerManagement.tsx
+++ b/analysis/warriorprotection/src/modules/talents/AngerManagement.tsx
@@ -21,7 +21,6 @@ class AngerManagement extends Analyzer {
   totalRageSpend = 0;
   wastedReduction: { [spellId: number]: number } = {};
   effectiveReduction: { [spellId: number]: number } = {};
-  statisticOrder = STATISTIC_ORDER.CORE(4);
   protected spellUsable!: SpellUsable;
 
   constructor(options: Options) {

--- a/analysis/warriorprotection/src/modules/talents/BoomingVoice.tsx
+++ b/analysis/warriorprotection/src/modules/talents/BoomingVoice.tsx
@@ -24,7 +24,6 @@ class BoomingVoice extends Analyzer {
   bonusDmg = 0;
   maxRage = 100;
   nextCastWasted = 0;
-  statisticOrder = STATISTIC_ORDER.CORE(5);
   protected enemies!: Enemies;
 
   constructor(options: Options) {

--- a/analysis/warriorprotection/src/modules/talents/HeavyRepercussions.tsx
+++ b/analysis/warriorprotection/src/modules/talents/HeavyRepercussions.tsx
@@ -23,7 +23,6 @@ class HeavyRepercussions extends Analyzer {
 
   sbExtended = 0;
   sbCasts = 0;
-  statisticOrder = STATISTIC_ORDER.CORE(5);
 
   constructor(options: Options) {
     super(options);

--- a/analysis/warriorprotection/src/modules/talents/IntoTheFray.tsx
+++ b/analysis/warriorprotection/src/modules/talents/IntoTheFray.tsx
@@ -24,7 +24,6 @@ class IntoTheFray extends Analyzer {
   buffStacks: number[][];
   lastStacks = 0;
   lastUpdate = this.owner.fight.start_time;
-  statisticOrder = STATISTIC_ORDER.CORE(5);
 
   constructor(options: Options) {
     super(options);

--- a/analysis/warriorprotection/src/modules/talents/Punish.tsx
+++ b/analysis/warriorprotection/src/modules/talents/Punish.tsx
@@ -17,7 +17,7 @@ class Punish extends Analyzer {
     enemies: Enemies,
   };
   bonusDmg: number = 0;
-  statisticOrder = STATISTIC_ORDER.CORE(5);
+
   protected enemies!: Enemies;
 
   constructor(options: Options) {

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -61,6 +61,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2022, 8, 12), 'Remove deprecated statisticOrder property on all Analyzers.', Vetyst),
   change(date(2022, 8, 9), 'Add support for tracking debuffs on timeline.', ToppleTheNun),
   change(date(2022, 8, 9), <>Add the ability to change max charges of a spell such as <SpellLink id={SPELLS.MIND_BLAST.id}/> combined with <SpellLink id={SPELLS.VOIDFORM.id}/> and <SpellLink id={SPELLS.DARK_THOUGHTS.id} />.</>, Vetyst),
   change(date(2022, 8, 9), <>Regenerated talents for season 4.</>, Vetyst),

--- a/src/parser/core/Analyzer.ts
+++ b/src/parser/core/Analyzer.ts
@@ -41,10 +41,6 @@ class Analyzer extends EventSubscriber {
   statistic(): React.ReactNode {
     return undefined;
   }
-  /**
-   * @deprecated Set the `position` property on the Statistic component instead.
-   */
-  statisticOrder?: number = undefined;
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   suggestions(when: When): Suggestion[] | void {}

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -664,25 +664,15 @@ class CombatLogParser {
             if (module instanceof Analyzer) {
               const analyzer = module as Analyzer;
               if (analyzer.statistic) {
-                let basePosition = index;
-                if (analyzer.statisticOrder !== undefined) {
-                  basePosition = analyzer.statisticOrder;
-                  console.warn(
-                    'DEPRECATED',
-                    "Setting the position of a statistic via a module's `statisticOrder` prop is deprecated. Set the `position` prop on the `StatisticBox` instead. Example commit: https://github.com/WoWAnalyzer/WoWAnalyzer/commit/ece1bbeca0d3721ede078d256a30576faacb803d",
-                    module,
-                  );
-                }
-
                 // TODO - confirm removing i18n doesn't actually change anything here
                 const statistic = analyzer.statistic();
                 if (statistic) {
                   if (Array.isArray(statistic)) {
                     statistic.forEach((statistic, statisticIndex) => {
-                      addStatistic(statistic, basePosition, `${key}-statistic-${statisticIndex}`);
+                      addStatistic(statistic, index, `${key}-statistic-${statisticIndex}`);
                     });
                   } else {
-                    addStatistic(statistic, basePosition, `${key}-statistic`);
+                    addStatistic(statistic, index, `${key}-statistic`);
                   }
                 }
               }

--- a/src/parser/shared/modules/resources/ResourceUsage.tsx
+++ b/src/parser/shared/modules/resources/ResourceUsage.tsx
@@ -145,7 +145,7 @@ class ResourceUsage extends Analyzer {
 
   statistic() {
     return (
-      <Statistic position={STATISTIC_ORDER.CORE(10)}>
+      <Statistic position={STATISTIC_ORDER.CORE(12)}>
         <div className="pad">
           <label>
             <ResourceLink id={this.resourceTypeID} /> usage

--- a/src/parser/shared/modules/resources/ResourceUsage.tsx
+++ b/src/parser/shared/modules/resources/ResourceUsage.tsx
@@ -44,11 +44,6 @@ class ResourceUsage extends Analyzer {
     '#8b8dec',
     '#00ec62',
   ];
-
-  /**
-   * If you want to change where this module is shown, change this static.
-   */
-  static statisticOrder = STATISTIC_ORDER.CORE(12);
   //endregion
 
   listOfSpellsUsed: { [key: string]: { casts: number; resourceUsed: number } } = {};
@@ -80,10 +75,6 @@ class ResourceUsage extends Analyzer {
 
   get spellsThatShouldShowAsOtherSpells() {
     return this.ctor.spellsThatShouldShowAsOtherSpells;
-  }
-
-  get resourceUsageStatisticOrder() {
-    return this.ctor.statisticOrder;
   }
 
   onCast(event: CastEvent) {
@@ -154,7 +145,7 @@ class ResourceUsage extends Analyzer {
 
   statistic() {
     return (
-      <Statistic position={this.resourceUsageStatisticOrder}>
+      <Statistic position={STATISTIC_ORDER.CORE(10)}>
         <div className="pad">
           <label>
             <ResourceLink id={this.resourceTypeID} /> usage


### PR DESCRIPTION
There wasn't alot of them left so i decided to completely remove them.

* Moved the value of `statisticOrder` to the `Statistic(Box).position` if it didnt already have one.
* `AlwaysBeCasting` had its own alternative; `position`
* Removed it from `ResourceUsage` is only used by`FocusUsage` but doesnt overwrite the default order of 12 so I defaulted to this.