### PR TITLE
Update patch information - Old Patch Warning

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -61,6 +61,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2022, 8, 12), 'Update patch information in order to warn that a report is earlier patch.', Vetyst),
   change(date(2022, 8, 12), 'Remove deprecated statisticOrder property on all Analyzers.', Vetyst),
   change(date(2022, 8, 9), 'Add support for tracking debuffs on timeline.', ToppleTheNun),
   change(date(2022, 8, 9), <>Add the ability to change max charges of a spell such as <SpellLink id={SPELLS.MIND_BLAST.id}/> combined with <SpellLink id={SPELLS.VOIDFORM.id}/> and <SpellLink id={SPELLS.DARK_THOUGHTS.id} />.</>, Vetyst),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -61,7 +61,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
-  change(date(2022, 8, 12), 'Update patch information in order to warn that a report is earlier patch.', Vetyst),
+  change(date(2022, 8, 12), 'Update patch information in order to warn that a report is from an earlier patch.', Vetyst),
   change(date(2022, 8, 12), 'Remove deprecated statisticOrder property on all Analyzers.', Vetyst),
   change(date(2022, 8, 9), 'Add support for tracking debuffs on timeline.', ToppleTheNun),
   change(date(2022, 8, 9), <>Add the ability to change max charges of a spell such as <SpellLink id={SPELLS.MIND_BLAST.id}/> combined with <SpellLink id={SPELLS.VOIDFORM.id}/> and <SpellLink id={SPELLS.DARK_THOUGHTS.id} />.</>, Vetyst),

--- a/src/interface/report/PATCHES.ts
+++ b/src/interface/report/PATCHES.ts
@@ -14,40 +14,58 @@ export interface Patch {
 
 const PATCHES: Patch[] = [
   {
-    name: '8.0',
+    name: 'BFA',
     timestamp: 1534197600000, // GMT: Monday, 13 August 2018 22:00:00
-    urlPrefix: '80',
+    urlPrefix: 'bfa',
     isCurrent: false,
   },
   {
-    name: '8.1',
-    timestamp: 1544565600000, // GMT: Tuesday, 11 December 2018 22:00:00, PST: Tuesday, 11 December 2018 14:00:00
+    name: '9.0.2',
+    timestamp: 1605564000000, // GMT: Monday, 16 November 2020 22:00:00
     urlPrefix: '',
     isCurrent: false,
   },
   {
-    name: '8.1.5',
-    timestamp: 1552428000000, // GMT: Tuesday, 12 March 2019 22:00:00
+    name: '9.0.5',
+    timestamp: 1615240800000, // GMT: Monday, 8 March 2021 22:00:00
     urlPrefix: '',
     isCurrent: false,
   },
   {
-    name: '8.2',
-    timestamp: 1561500000000, // GMT: Tuesday, 25 June 2019 22:00:00
+    name: '9.1.0',
+    timestamp: 1624917600000, // GMT: Monday, 28 June 2021 22:00:00
     urlPrefix: '',
     isCurrent: false,
   },
   {
-    name: '8.2.5',
-    timestamp: 1569362400000, // GMT: Tuesday, 24 September 2019 22:00:00
+    name: '9.1.5',
+    timestamp: 1635804000000, // GMT: Monday, 1 November 2021 22:00:00
     urlPrefix: '',
     isCurrent: false,
   },
   {
-    name: '8.3',
-    timestamp: 1579039200000, // GMT: Tuesday, 14 January 2020 22:00:00
+    name: '9.2.0',
+    timestamp: 1645480800000, // GMT: Monday, 21 February 2022 22:00:00
+    urlPrefix: '',
+    isCurrent: false,
+  },
+  {
+    name: '9.2.5 Season 3',
+    timestamp: 1653948000000, // GMT: Monday, 30 May 2022 22:00:00
+    urlPrefix: '',
+    isCurrent: false,
+  },
+  {
+    name: '9.2.5 Season 4',
+    timestamp: 1659391200000, // GMT: Monday, 1 August 2022 22:00:00
     urlPrefix: '',
     isCurrent: true,
+  },
+  {
+    name: '9.2.7',
+    timestamp: 1660600800000, // GMT: Monday, 15 August 2022 22:00:00
+    urlPrefix: '',
+    isCurrent: false,
   },
 ];
 


### PR DESCRIPTION
This hasn't been updated since hte launch of BFA. eventhough its a great notification. eg with the recent trinket nerfs that were implemented at the start of season 4.  This is what it would look like;

![image](https://user-images.githubusercontent.com/3527340/184402987-f131d012-8d67-4ba0-982c-8fbe9af03159.png)
