### PR TITLE
[Demon Hunter] add support for Fodder to the Flame

### DIFF
--- a/analysis/demonhunter/src/index.ts
+++ b/analysis/demonhunter/src/index.ts
@@ -1,6 +1,7 @@
 export { default as ElysianDecree } from './shadowlands/covenants/ElysianDecree';
 export { default as SinfulBrand } from './shadowlands/covenants/SinfulBrand';
 export { default as TheHunt } from './shadowlands/covenants/TheHunt';
+export { default as FodderToTheFlame } from './shadowlands/covenants/FodderToTheFlame';
 export { default as FelDefender } from './shadowlands/conduits/FelDefender';
 export { default as GrowingInferno } from './shadowlands/conduits/GrowingInferno';
 export { default as RepeatDecree } from './shadowlands/conduits/RepeatDecree';

--- a/analysis/demonhunter/src/shadowlands/covenants/FodderToTheFlame.tsx
+++ b/analysis/demonhunter/src/shadowlands/covenants/FodderToTheFlame.tsx
@@ -1,0 +1,70 @@
+import { formatThousands } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import COVENANTS from 'game/shadowlands/COVENANTS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { DamageEvent, HealEvent } from 'parser/core/Events';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+
+/**
+ * Necrolord - Fodder to the Flame
+ */
+class FodderToTheFlame extends Analyzer {
+  damage = 0;
+  heal = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasCovenant(COVENANTS.NECROLORD.id);
+
+    if (!this.active) {
+      return;
+    }
+
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell([SPELLS.FODDER_TO_THE_FLAME_DAMAGE]),
+      this.onDamage,
+    );
+    this.addEventListener(
+      Events.heal.by(SELECTED_PLAYER).spell([SPELLS.FODDER_TO_THE_FLAME_DAMAGE]),
+      this.onHeal,
+    );
+  }
+
+  onDamage(event: DamageEvent) {
+    this.damage += event.amount + (event.absorbed || 0);
+  }
+
+  onHeal(event: HealEvent) {
+    this.heal += event.amount + (event.absorbed || 0);
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE()}
+        size="flexible"
+        category={STATISTIC_CATEGORY.COVENANTS}
+        tooltip={
+          <>
+            {formatThousands(this.damage)} Total damage
+            {formatThousands(this.heal)} Total heal
+          </>
+        }
+      >
+        <BoringSpellValueText spellId={SPELLS.FODDER_TO_THE_FLAME.id}>
+          <ItemDamageDone amount={this.damage} />
+          <br />
+          <ItemHealingDone amount={this.heal} />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default FodderToTheFlame;

--- a/analysis/demonhunterhavoc/src/CHANGELOG.tsx
+++ b/analysis/demonhunterhavoc/src/CHANGELOG.tsx
@@ -3,148 +3,28 @@ import SPELLS from 'common/SPELLS';
 import { Elodiel, flurreN, LeoZhekov, ToppleTheNun } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
+// prettier-ignore
 export default [
-  change(
-    date(2022, 7, 25),
-    <>
-      Add tracker for <SpellLink id={SPELLS.FURIOUS_GAZE.id} />.
-    </>,
-    ToppleTheNun,
-  ),
-  change(
-    date(2022, 7, 24),
-    'Remove talents that were removed in BFA/Shadowlands prepatch.',
-    ToppleTheNun,
-  ),
-  change(
-    date(2022, 7, 24),
-    <>
-      Correct <SpellLink id={SPELLS.SINFUL_BRAND.id} /> cooldown.
-    </>,
-    ToppleTheNun,
-  ),
-  change(
-    date(2022, 7, 24),
-    <>
-      Correct spelling of <SpellLink id={SPELLS.FEL_DEVASTATION_DAMAGE.id} />.
-    </>,
-    ToppleTheNun,
-  ),
-  change(
-    date(2022, 7, 14),
-    <>
-      Add <SpellLink id={SPELLS.SINFUL_BRAND.id} /> uptime tracking and change{' '}
-      <SpellLink id={SPELLS.SINFUL_BRAND.id} /> cast recommendation.
-    </>,
-    ToppleTheNun,
-  ),
-  change(
-    date(2021, 9, 26),
-    <>
-      Fixed the issue, that the Analyzer would show 0 uses of{' '}
-      <SpellLink id={SPELLS.ELYSIAN_DECREE.id} /> in the suggestions and statistics instead of the
-      actual number of uses.
-    </>,
-    Elodiel,
-  ),
-  change(
-    date(2021, 2, 2),
-    <>
-      Added <SpellLink id={SPELLS.FEL_DEFENDER.id} /> to Statistics
-    </>,
-    flurreN,
-  ),
-  change(
-    date(2021, 1, 28),
-    <>
-      Added <SpellLink id={SPELLS.GROWING_INFERNO.id} /> to Statistics
-    </>,
-    flurreN,
-  ),
-  change(
-    date(2021, 1, 18),
-    <>
-      Suggestions for <SpellLink id={SPELLS.DEMONIC_TALENT_HAVOC.id} />,{' '}
-      <SpellLink id={SPELLS.BLADE_DANCE.id} /> and <SpellLink id={SPELLS.DEATH_SWEEP.id} /> have
-      been updated
-    </>,
-    flurreN,
-  ),
-  change(
-    date(2021, 1, 6),
-    <>
-      Added <SpellLink id={SPELLS.ELYSIAN_DECREE.id} /> to Statistics
-    </>,
-    flurreN,
-  ),
-  change(
-    date(2020, 12, 30),
-    <>
-      Added <SpellLink id={SPELLS.SINFUL_BRAND.id} /> and <SpellLink id={SPELLS.THE_HUNT.id} /> to
-      Statistics
-    </>,
-    flurreN,
-  ),
-  change(
-    date(2020, 12, 29),
-    <>
-      Fixed bug where <SpellLink id={SPELLS.DEMONIC_TALENT_HAVOC.id} /> were causing errors
-    </>,
-    flurreN,
-  ),
-  change(
-    date(2020, 12, 28),
-    <>
-      <SpellLink id={SPELLS.COLLECTIVE_ANGUISH.id} /> and <SpellLink id={SPELLS.CHAOS_THEORY.id} />{' '}
-      is added to Statistics
-    </>,
-    flurreN,
-  ),
-  change(
-    date(2020, 12, 28),
-    <>
-      <SpellLink id={SPELLS.FELBLADE_TALENT.id} /> is now shown correctly in timeline and more
-      information added to Statistic box
-    </>,
-    flurreN,
-  ),
+  change(date(2022, 7, 25), <>Add tracker for <SpellLink id={SPELLS.FURIOUS_GAZE.id} />.</>, ToppleTheNun),
+  change(date(2022, 7, 24), 'Remove talents that were removed in BFA/Shadowlands prepatch.', ToppleTheNun),
+  change(date(2022, 7, 24), <>Correct <SpellLink id={SPELLS.SINFUL_BRAND.id} /> cooldown.</>, ToppleTheNun),
+  change(date(2022, 7, 24), <>Correct spelling of <SpellLink id={SPELLS.FEL_DEVASTATION_DAMAGE.id} />.</>, ToppleTheNun),
+  change(date(2022, 7, 14), <>Add <SpellLink id={SPELLS.SINFUL_BRAND.id} /> uptime tracking and change <SpellLink id={SPELLS.SINFUL_BRAND.id} /> cast recommendation.</>, ToppleTheNun),
+  change(date(2021, 9, 26), <>Fixed the issue, that the Analyzer would show 0 uses of <SpellLink id={SPELLS.ELYSIAN_DECREE.id} /> in the suggestions and statistics instead of the actual number of uses.</>, Elodiel),
+  change(date(2021, 2, 2), <>Added <SpellLink id={SPELLS.FEL_DEFENDER.id} /> to Statistics</>, flurreN),
+  change(date(2021, 1, 28), <>Added <SpellLink id={SPELLS.GROWING_INFERNO.id} /> to Statistics</>, flurreN),
+  change(date(2021, 1, 18), <>Suggestions for <SpellLink id={SPELLS.DEMONIC_TALENT_HAVOC.id} />, <SpellLink id={SPELLS.BLADE_DANCE.id} /> and <SpellLink id={SPELLS.DEATH_SWEEP.id} /> have been updated</>, flurreN),
+  change(date(2021, 1, 6), <>Added <SpellLink id={SPELLS.ELYSIAN_DECREE.id} /> to Statistics</>, flurreN),
+  change(date(2020, 12, 30), <>Added <SpellLink id={SPELLS.SINFUL_BRAND.id} /> and <SpellLink id={SPELLS.THE_HUNT.id} /> to Statistics</>, flurreN),
+  change(date(2020, 12, 29), <>Fixed bug where <SpellLink id={SPELLS.DEMONIC_TALENT_HAVOC.id} /> were causing errors</>, flurreN),
+  change(date(2020, 12, 28), <><SpellLink id={SPELLS.COLLECTIVE_ANGUISH.id} /> and <SpellLink id={SPELLS.CHAOS_THEORY.id} /> is added to Statistics</>, flurreN),
+  change(date(2020, 12, 28), <><SpellLink id={SPELLS.FELBLADE_TALENT.id} /> is now shown correctly in timeline and more information added to Statistic box</>, flurreN),
   change(date(2020, 12, 28), 'Legendary, Covenant and Conduits added for Havoc', flurreN),
-  change(
-    date(2020, 12, 28),
-    <>
-      <SpellLink id={SPELLS.EYE_BEAM.id} /> is now showed correct in the Timeline.
-    </>,
-    flurreN,
-  ),
-  change(
-    date(2020, 12, 28),
-    <>
-      Added support for <SpellLink id={SPELLS.GLAIVE_TEMPEST_TALENT.id} />{' '}
-    </>,
-    flurreN,
-  ),
-  change(
-    date(2020, 12, 26),
-    <>
-      <SpellLink id={SPELLS.GLAIVE_TEMPEST_TALENT.id} /> have correct cd, and{' '}
-      <SpellLink id={SPELLS.CYCLE_OF_HATRED_TALENT.id} /> is not reducing cooldown correctly on{' '}
-      <SpellLink id={SPELLS.EYE_BEAM.id} />
-    </>,
-    flurreN,
-  ),
-  change(
-    date(2020, 12, 26),
-    <>
-      <SpellLink id={SPELLS.NETHERWALK_TALENT.id} /> and <SpellLink id={SPELLS.DARKNESS.id} /> now
-      have a correct gcd.
-    </>,
-    flurreN,
-  ),
+  change(date(2020, 12, 28), <><SpellLink id={SPELLS.EYE_BEAM.id} /> is now showed correct in the Timeline.</>, flurreN),
+  change(date(2020, 12, 28), <>Added support for <SpellLink id={SPELLS.GLAIVE_TEMPEST_TALENT.id} /> </>, flurreN),
+  change(date(2020, 12, 26), <><SpellLink id={SPELLS.GLAIVE_TEMPEST_TALENT.id} /> have correct cd, and <SpellLink id={SPELLS.CYCLE_OF_HATRED_TALENT.id} /> is not reducing cooldown correctly on <SpellLink id={SPELLS.EYE_BEAM.id} /></>, flurreN),
+  change(date(2020, 12, 26), <><SpellLink id={SPELLS.NETHERWALK_TALENT.id} /> and <SpellLink id={SPELLS.DARKNESS.id} /> now have a correct gcd.</>, flurreN),
   change(date(2020, 12, 24), 'Updated CDs and baselines for SL', flurreN),
   change(date(2020, 12, 23), 'Updated spells and talents for SL', flurreN),
-  change(
-    date(2020, 10, 30),
-    'Updated the deprecated StatisticBox elements with the new Statistic ones.',
-    LeoZhekov,
-  ),
+  change(date(2020, 10, 30), 'Updated the deprecated StatisticBox elements with the new Statistic ones.', LeoZhekov),
 ];

--- a/analysis/demonhunterhavoc/src/CHANGELOG.tsx
+++ b/analysis/demonhunterhavoc/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2022, 8, 12), <>Add support for <SpellLink id={SPELLS.FODDER_TO_THE_FLAME_DAMAGE.id} />.</>, ToppleTheNun),
   change(date(2022, 7, 25), <>Add tracker for <SpellLink id={SPELLS.FURIOUS_GAZE.id} />.</>, ToppleTheNun),
   change(date(2022, 7, 24), 'Remove talents that were removed in BFA/Shadowlands prepatch.', ToppleTheNun),
   change(date(2022, 7, 24), <>Correct <SpellLink id={SPELLS.SINFUL_BRAND.id} /> cooldown.</>, ToppleTheNun),

--- a/analysis/demonhunterhavoc/src/CombatLogParser.tsx
+++ b/analysis/demonhunterhavoc/src/CombatLogParser.tsx
@@ -5,6 +5,7 @@ import Channeling from 'parser/shared/normalizers/Channeling';
 import {
   ElysianDecree,
   FelDefender,
+  FodderToTheFlame,
   GrowingInferno,
   RepeatDecree,
   SinfulBrand,
@@ -103,6 +104,7 @@ class CombatLogParser extends CoreCombatLogParser {
     sinfulBrand: SinfulBrand,
     theHunt: TheHunt,
     elysianDecree: ElysianDecree,
+    fodderToTheFlame: FodderToTheFlame,
 
     //Conduits
     growingInferno: GrowingInferno,

--- a/analysis/demonhunterhavoc/src/modules/Abilities.tsx
+++ b/analysis/demonhunterhavoc/src/modules/Abilities.tsx
@@ -324,15 +324,6 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.FODDER_TO_THE_FLAME.id,
-        enabled: combatant.hasCovenant(COVENANTS.NECROLORD.id),
-        category: Abilities.SPELL_CATEGORIES.COOLDOWNS,
-        cooldown: 120,
-        gcd: {
-          base: 1500,
-        },
-      },
-      {
         spell: SPELLS.THE_HUNT.id,
         enabled: combatant.hasCovenant(COVENANTS.NIGHT_FAE.id),
         category: Abilities.SPELL_CATEGORIES.COOLDOWNS,

--- a/analysis/demonhuntervengeance/src/CHANGELOG.tsx
+++ b/analysis/demonhuntervengeance/src/CHANGELOG.tsx
@@ -17,7 +17,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
-  change(date(2022, 8, 12), <>Add support for <SpellLink id={SPELLS.FODDER_TO_THE_FLAME_DAMAGE} />.</>, ToppleTheNun),
+  change(date(2022, 8, 12), <>Add support for <SpellLink id={SPELLS.FODDER_TO_THE_FLAME_DAMAGE.id} />.</>, ToppleTheNun),
   change(date(2022, 7, 24), <>Correct <SpellLink id={SPELLS.SINFUL_BRAND.id} /> cooldown.</>, ToppleTheNun),
   change(date(2022, 4, 7), <>Added several conduits and updated <SpellLink id={SPELLS.AGONIZING_FLAMES_TALENT.id} /> implementation.</>, xepheris),
   change(date(2022, 4, 7), <>Added Average <SpellLink id={SPELLS.BLIND_FAITH_BUFF.id} /> versatility buff stat tracking.</>, xepheris),

--- a/analysis/demonhuntervengeance/src/CHANGELOG.tsx
+++ b/analysis/demonhuntervengeance/src/CHANGELOG.tsx
@@ -15,93 +15,23 @@ import {
 } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
+// prettier-ignore
 export default [
-  change(
-    date(2022, 7, 24),
-    <>
-      Correct <SpellLink id={SPELLS.SINFUL_BRAND.id} /> cooldown.
-    </>,
-    ToppleTheNun,
-  ),
-  change(
-    date(2022, 4, 7),
-    <>
-      Added several conduits and updated <SpellLink id={SPELLS.AGONIZING_FLAMES_TALENT.id} />{' '}
-      implementation.
-    </>,
-    xepheris,
-  ),
-  change(
-    date(2022, 4, 7),
-    <>
-      Added Average <SpellLink id={SPELLS.BLIND_FAITH_BUFF.id} /> versatility buff stat tracking.
-    </>,
-    xepheris,
-  ),
+  change(date(2022, 8, 12), <>Add support for <SpellLink id={SPELLS.FODDER_TO_THE_FLAME_DAMAGE} />.</>, ToppleTheNun),
+  change(date(2022, 7, 24), <>Correct <SpellLink id={SPELLS.SINFUL_BRAND.id} /> cooldown.</>, ToppleTheNun),
+  change(date(2022, 4, 7), <>Added several conduits and updated <SpellLink id={SPELLS.AGONIZING_FLAMES_TALENT.id} /> implementation.</>, xepheris),
+  change(date(2022, 4, 7), <>Added Average <SpellLink id={SPELLS.BLIND_FAITH_BUFF.id} /> versatility buff stat tracking.</>, xepheris),
   change(date(2022, 3, 26), 'Fix crash related to Unity legendary support.', emallson),
-  change(
-    date(2021, 10, 15),
-    <>
-      Added <SpellLink id={SPELLS.FIERY_SOUL.id} /> support.
-    </>,
-    Yax,
-  ),
+  change(date(2021, 10, 15), <>Added <SpellLink id={SPELLS.FIERY_SOUL.id} /> support.</>, Yax),
   change(date(2021, 10, 15), <>Fixed Fury Usage costs.</>, Yax),
-  change(
-    date(2021, 4, 4),
-    <>
-      Added <SpellLink id={SPELLS.FEL_DEFENDER.id} /> conduit support.
-    </>,
-    Adoraci,
-  ),
+  change(date(2021, 4, 4), <>Added <SpellLink id={SPELLS.FEL_DEFENDER.id} /> conduit support.</>, Adoraci),
   change(date(2021, 4, 3), 'Verified 9.0.5 patch changes and bumped support to 9.0.5', Adoraci),
-  change(
-    date(2021, 1, 20),
-    <>
-      {' '}
-      Added <SpellLink id={SPELLS.ELYSIAN_DECREE.id} /> <SpellLink id={SPELLS.SINFUL_BRAND.id} />{' '}
-      and <SpellLink id={SPELLS.THE_HUNT.id} /> to Statistics
-    </>,
-    Makhai,
-  ),
-  change(
-    date(2021, 1, 10),
-    <>
-      {' '}
-      Added tracking of wasted soul generation by <SpellLink
-        id={SPELLS.FRACTURE_TALENT.id}
-      /> / <SpellLink id={SPELLS.SHEAR.id} />. Added to suggestions and checklist.{' '}
-    </>,
-    Yajinni,
-  ),
-  change(
-    date(2021, 1, 10),
-    <>
-      {' '}
-      Updated <SpellLink id={SPELLS.ELYSIAN_DECREE.id} /> to take into accoun the conduit{' '}
-      <SpellLink id={SPELLS.REPEAT_DECREE.id} />.
-    </>,
-    Yajinni,
-  ),
-  change(
-    date(2020, 12, 28),
-    'Updated Demonic Spikes, implemented Infernal Strikes (but disabling due to blizzard bug)',
-    Geeii,
-  ),
-  change(
-    date(2020, 12, 27),
-    'Updated to use Fury resource, instead of outdated Pain. Updated Soul Cleave reporting, updated ability tracking for Sigil of Flame for some cases',
-    Geeii,
-  ),
-  change(
-    date(2020, 12, 27),
-    'Initial SL update for talent changes and covenant abilities',
-    TurianSniper,
-  ),
-  change(
-    date(2020, 10, 30),
-    'Replaced the deprecated StatisticBox with the new Statistic',
-    LeoZhekov,
-  ),
+  change(date(2021, 1, 20), <>Added <SpellLink id={SPELLS.ELYSIAN_DECREE.id} /> <SpellLink id={SPELLS.SINFUL_BRAND.id} /> and <SpellLink id={SPELLS.THE_HUNT.id} /> to Statistics</>, Makhai),
+  change(date(2021, 1, 10), <>Added tracking of wasted soul generation by <SpellLink id={SPELLS.FRACTURE_TALENT.id} /> / <SpellLink id={SPELLS.SHEAR.id} />. Added to suggestions and checklist.</>, Yajinni),
+  change(date(2021, 1, 10), <>Updated <SpellLink id={SPELLS.ELYSIAN_DECREE.id} /> to take into accoun the conduit <SpellLink id={SPELLS.REPEAT_DECREE.id} />.</>, Yajinni),
+  change(date(2020, 12, 28), 'Updated Demonic Spikes, implemented Infernal Strikes (but disabling due to blizzard bug)', Geeii),
+  change(date(2020, 12, 27), 'Updated to use Fury resource, instead of outdated Pain. Updated Soul Cleave reporting, updated ability tracking for Sigil of Flame for some cases', Geeii),
+  change(date(2020, 12, 27), 'Initial SL update for talent changes and covenant abilities', TurianSniper),
+  change(date(2020, 10, 30), 'Replaced the deprecated StatisticBox with the new Statistic', LeoZhekov),
   change(date(2020, 10, 18), 'Converted legacy listeners to new event filters', Zeboot),
 ];

--- a/analysis/demonhuntervengeance/src/CombatLogParser.tsx
+++ b/analysis/demonhuntervengeance/src/CombatLogParser.tsx
@@ -3,6 +3,7 @@ import CoreCombatLogParser from 'parser/core/CombatLogParser';
 import {
   ElysianDecree,
   FelDefender,
+  FodderToTheFlame,
   GrowingInferno,
   RepeatDecree,
   SinfulBrand,
@@ -79,6 +80,7 @@ class CombatLogParser extends CoreCombatLogParser {
     sinfulBrand: SinfulBrand,
     theHunt: TheHunt,
     elysianDecree: ElysianDecree,
+    fodderToTheFlame: FodderToTheFlame,
 
     // Conduits
     felDefender: FelDefender,

--- a/analysis/demonhuntervengeance/src/modules/Abilities.tsx
+++ b/analysis/demonhuntervengeance/src/modules/Abilities.tsx
@@ -289,15 +289,6 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasCovenant(COVENANTS.VENTHYR.id),
       },
       {
-        spell: SPELLS.FODDER_TO_THE_FLAME.id,
-        category: Abilities.SPELL_CATEGORIES.UTILITY,
-        cooldown: 120,
-        gcd: {
-          base: 1500,
-        },
-        enabled: combatant.hasCovenant(COVENANTS.NECROLORD.id),
-      },
-      {
         spell: SPELLS.THE_HUNT.id,
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: 90,

--- a/src/common/SPELLS/shadowlands/covenants/demonhunter.ts
+++ b/src/common/SPELLS/shadowlands/covenants/demonhunter.ts
@@ -29,7 +29,12 @@ const covenants = {
 
   //region Necrolord
   FODDER_TO_THE_FLAME: {
-    id: 329554,
+    id: 350570,
+    name: 'Fodder to the Flame',
+    icon: 'ability_maldraxxus_demonhunter',
+  },
+  FODDER_TO_THE_FLAME_DAMAGE: {
+    id: 350631,
     name: 'Fodder to the Flame',
     icon: 'ability_maldraxxus_demonhunter',
   },


### PR DESCRIPTION
Add support for Fodder to the Flame.

Fodder to the Flame was changed in 9.0.5 to be a completely passive ability, so it has no cooldown or GCD.

![image](https://user-images.githubusercontent.com/1672786/184466015-0818b0d0-f7ef-460b-9235-1ee831f80b62.png)
