### PR TITLE
Set analyzer version to 9.2.7

### DIFF
--- a/analysis/deathknightfrost/src/CONFIG.tsx
+++ b/analysis/deathknightfrost/src/CONFIG.tsx
@@ -9,7 +9,7 @@ export default {
   contributors: [Khazak],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/deathknightunholy/src/CONFIG.tsx
+++ b/analysis/deathknightunholy/src/CONFIG.tsx
@@ -9,7 +9,7 @@ export default {
   contributors: [Khazak],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/druidbalance/src/CONFIG.tsx
+++ b/analysis/druidbalance/src/CONFIG.tsx
@@ -9,7 +9,7 @@ export default {
   contributors: [Sref, Kartarn],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/druidferal/src/CONFIG.tsx
+++ b/analysis/druidferal/src/CONFIG.tsx
@@ -9,7 +9,7 @@ export default {
   contributors: [Sref],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/druidrestoration/src/CONFIG.tsx
+++ b/analysis/druidrestoration/src/CONFIG.tsx
@@ -9,7 +9,7 @@ export default {
   contributors: [Sref],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/magearcane/src/CONFIG.tsx
+++ b/analysis/magearcane/src/CONFIG.tsx
@@ -9,7 +9,7 @@ export default {
   contributors: [Sharrq, Dambroda],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/magefire/src/CONFIG.tsx
+++ b/analysis/magefire/src/CONFIG.tsx
@@ -9,7 +9,7 @@ export default {
   contributors: [Sharrq, Dambroda],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/magefrost/src/CONFIG.tsx
+++ b/analysis/magefrost/src/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Sharrq, Dambroda],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more. If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (

--- a/analysis/monkbrewmaster/src/CONFIG.tsx
+++ b/analysis/monkbrewmaster/src/CONFIG.tsx
@@ -9,7 +9,7 @@ export default {
   contributors: [emallson],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/monkmistweaver/src/CONFIG.tsx
+++ b/analysis/monkmistweaver/src/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Abelito75],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/monkwindwalker/src/CONFIG.tsx
+++ b/analysis/monkwindwalker/src/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Juko8, nullDozzer],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/paladinholy/src/CONFIG.tsx
+++ b/analysis/paladinholy/src/CONFIG.tsx
@@ -10,7 +10,7 @@ import CHANGELOG from './CHANGELOG';
 const config: Config = {
   contributors: [xizbow],
   expansion: Expansion.Shadowlands,
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: false,
   description: (
     <>

--- a/analysis/paladinprotection/src/CONFIG.tsx
+++ b/analysis/paladinprotection/src/CONFIG.tsx
@@ -13,7 +13,7 @@ export default {
   contributors: [emallson, Hordehobbs],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/priestdiscipline/src/CONFIG.tsx
+++ b/analysis/priestdiscipline/src/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Khadaj, Oratio, Reglitch, Hana],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/rogueassassination/src/CONFIG.js
+++ b/analysis/rogueassassination/src/CONFIG.js
@@ -9,7 +9,7 @@ export default {
   contributors: [],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/rogueoutlaw/src/CONFIG.js
+++ b/analysis/rogueoutlaw/src/CONFIG.js
@@ -9,7 +9,7 @@ export default {
   contributors: [],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/roguesubtlety/src/CONFIG.js
+++ b/analysis/roguesubtlety/src/CONFIG.js
@@ -8,7 +8,7 @@ export default {
   contributors: [],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/shamanrestoration/src/CONFIG.tsx
+++ b/analysis/shamanrestoration/src/CONFIG.tsx
@@ -12,7 +12,7 @@ const CONFIG: Config = {
   contributors: [niseko],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/warriorarms/src/CONFIG.tsx
+++ b/analysis/warriorarms/src/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Carrottopp],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/warriorfury/src/CONFIG.tsx
+++ b/analysis/warriorfury/src/CONFIG.tsx
@@ -9,7 +9,7 @@ export default {
   contributors: [Tyndi],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/analysis/warriorprotection/src/CONFIG.tsx
+++ b/analysis/warriorprotection/src/CONFIG.tsx
@@ -14,7 +14,7 @@ const CONFIG: Config = {
   contributors: [Abelito75],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.5',
+  patchCompatibility: '9.2.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -62,7 +62,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
-  change(date(2022, 8, 16), 'Set analyzer version to 9.2.7', Vetyst),
+  change(date(2022, 8, 17), <>Bumped version to indicate 9.2.5 is supported.</>, Vetyst),
   change(date(2022, 8, 14), 'Improve boss phase typing.', ToppleTheNun),
   change(date(2022, 8, 14), 'Add spell and item data for missing Sanctum of Domination items.', ToppleTheNun),
   change(date(2022, 8, 13), 'Updated translations of core DK modules', Chizu),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -62,6 +62,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2022, 8, 16), 'Set analyzer version to 9.2.7', Vetyst),
   change(date(2022, 8, 14), 'Improve boss phase typing.', ToppleTheNun),
   change(date(2022, 8, 14), 'Add spell and item data for missing Sanctum of Domination items.', ToppleTheNun),
   change(date(2022, 8, 13), 'Updated translations of core DK modules', Chizu),

--- a/src/game/VERSIONS.ts
+++ b/src/game/VERSIONS.ts
@@ -3,7 +3,7 @@ import Expansion from './Expansion';
 // The current version of the game. Used to check spec patch compatibility and as a caching key.
 const VERSIONS: Partial<{ [expansion in Expansion]: string }> = {
   [Expansion.TheBurningCrusade]: '2.5.2',
-  [Expansion.Shadowlands]: '9.2.5',
+  [Expansion.Shadowlands]: '9.2.7',
 };
 
 export default VERSIONS;

--- a/src/interface/report/PATCHES.ts
+++ b/src/interface/report/PATCHES.ts
@@ -59,7 +59,7 @@ const PATCHES: Patch[] = [
     name: '9.2.5 Season 4',
     timestamp: 1659391200000, // GMT: Monday, 1 August 2022 22:00:00
     urlPrefix: '',
-    isCurrent: false,
+    isCurrent: true,
   },
   {
     name: '9.2.7',

--- a/src/interface/report/PATCHES.ts
+++ b/src/interface/report/PATCHES.ts
@@ -59,13 +59,13 @@ const PATCHES: Patch[] = [
     name: '9.2.5 Season 4',
     timestamp: 1659391200000, // GMT: Monday, 1 August 2022 22:00:00
     urlPrefix: '',
-    isCurrent: true,
+    isCurrent: false,
   },
   {
     name: '9.2.7',
     timestamp: 1660600800000, // GMT: Monday, 15 August 2022 22:00:00
     urlPrefix: '',
-    isCurrent: false,
+    isCurrent: true,
   },
 ];
 

--- a/src/parser/Config.ts
+++ b/src/parser/Config.ts
@@ -38,14 +38,14 @@ interface Config {
    */
   patchCompatibility:
     | null
-    | '8.0.1'
-    | '8.1'
-    | '8.1.5'
-    | '8.2.5'
-    | '8.3'
     | '9.0.1'
     | '9.0.2'
     | '9.0.5'
+    | '9.1.0'
+    | '9.1.5'
+    | '9.2.0'
+    | '9.2.5'
+    | '9.2.7'
     | string;
   /**
    * Whether support for the spec is only partial and some important elements


### PR DESCRIPTION
Since 9.2.7 is going live today i think its a wise idea to update when a report is considered 'outdated'.
Also bumped all 9.2.5 parsers to 9.2.7 since no class changes were made.

~~Best to merge this change as close to 17:00 CEST(+2) or 15:00 GMT (sorry im eu, no clue when servers restart in NA time)~~