### PR TITLE
Resolve NaN item level

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -62,6 +62,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2022, 8, 18), 'Resolve calculating the average item level if no gear is equipped.', Vetyst),
   change(date(2022, 8, 14), 'Updated core Death Knight modules to Typescript', Chizu),
   change(date(2022, 8, 14), 'Improve boss phase typing.', ToppleTheNun),
   change(date(2022, 8, 14), 'Add spell and item data for missing Sanctum of Domination items.', ToppleTheNun),

--- a/src/game/getAverageItemLevel.ts
+++ b/src/game/getAverageItemLevel.ts
@@ -9,8 +9,9 @@ export default function getAverageItemLevel(gear: Item[]) {
   const filteredGear = gear.filter(
     (item: Item, slotId: number) => !EXCLUDED_ITEM_SLOTS.includes(slotId) && item.id !== 0,
   );
-  return (
-    filteredGear.reduce((total: number, item: Item) => total + item.itemLevel, 0) /
-    filteredGear.length
-  );
+
+  return filteredGear.length === 0
+    ? 0
+    : filteredGear.reduce((total: number, item: Item) => total + item.itemLevel, 0) /
+        filteredGear.length;
 }

--- a/src/interface/report/PlayerLoader.tsx
+++ b/src/interface/report/PlayerLoader.tsx
@@ -118,6 +118,9 @@ class PlayerLoader extends React.PureComponent<Props, State> {
         fight.start_time,
         fight.end_time,
       )) as CombatantInfoEvent[];
+
+      let combatantsWithGear = 0;
+
       combatants.forEach((combatant) => {
         if (process.env.NODE_ENV === 'development' && FAKE_PLAYER_IF_DEV_ENV) {
           console.error(
@@ -154,10 +157,15 @@ class PlayerLoader extends React.PureComponent<Props, State> {
               break;
           }
         }
+
         // Gear may be null for broken combatants
-        this.ilvl += combatant.gear ? getAverageItemLevel(combatant.gear) : 0;
+        const combatantILvl = combatant.gear ? getAverageItemLevel(combatant.gear) : 0;
+        if (combatantILvl !== 0) {
+          combatantsWithGear += 1;
+          this.ilvl += combatantILvl;
+        }
       });
-      this.ilvl /= combatants.length;
+      this.ilvl /= combatantsWithGear;
       if (this.props.report !== report || this.props.fight !== fight) {
         return; // the user switched report/fight already
       }


### PR DESCRIPTION
Noticed that ~~bugged~~ characters without gear would result in calculating NaN for item level. See ReportCompensition and PlayerTile for [this report](https://wowanalyzer.com/report/J64knxvhHqVfWAb1/3-Heroic+Vigilant+Guardian+-+Kill+(5:37))

This changes it so that
* Players without gear have an iLvl of 0 (zero)
* The average raid comp ilvl is no longer based on them

![image](https://user-images.githubusercontent.com/3527340/185351680-6fd4b3e0-748a-43a3-9248-28c0b6c49dd2.png)
