### PR TITLE
Change Stormbringer priority

### DIFF
--- a/analysis/shamanenhancement/src/CHANGELOG.tsx
+++ b/analysis/shamanenhancement/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2022, 8, 22), <>Make <SpellLink id={SPELLS.STORMBRINGER.id} /> a priority only if you have <SpellLink id={SPELLS.STORMFLURRY_TALENT.id} /> talented.</>, Vetyst),
   change(date(2022, 8, 16), <>Implement an initial version of the Single Target APL checker.</>, Vetyst),
   change(date(2022, 8, 15), <>Bump version to 9.2.7 but still marked as partial.</>, Vetyst),
   change(date(2022, 8, 15), <>Track haste gained from <SpellLink id={SPELLS.ELEMENTAL_BLAST.id} />.</>, Vetyst),

--- a/analysis/shamanenhancement/src/modules/apl/AplCheck.tsx
+++ b/analysis/shamanenhancement/src/modules/apl/AplCheck.tsx
@@ -3,10 +3,12 @@ import { suggestion } from 'parser/core/Analyzer';
 import aplCheck, { build } from 'parser/shared/metrics/apl';
 import annotateTimeline from 'parser/shared/metrics/apl/annotate';
 import {
+  and,
   buffPresent,
   buffStacks,
   debuffMissing,
   debuffPresent,
+  hasTalent,
 } from 'parser/shared/metrics/apl/conditions';
 
 /**
@@ -31,7 +33,7 @@ export const apl = build([
   },
   {
     spell: SPELLS.STORMSTRIKE_CAST,
-    condition: buffPresent(SPELLS.STORMBRINGER_BUFF),
+    condition: and(hasTalent(SPELLS.STORMFLURRY_TALENT), buffPresent(SPELLS.STORMBRINGER_BUFF)),
   },
   {
     spell: SPELLS.LIGHTNING_BOLT,


### PR DESCRIPTION
\+ label Shaman

This was currently displaying incorrectly. Stormbringer procs are only a priority with the Stormflurry talent.