### PR TITLE
Fixed timeline cooldown tooltips for spells with charges

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -62,6 +62,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2022, 8, 23), "Fixed a bug where the timeline's cooldown tooltips weren't showing properly", Sref),
   change(date(2022, 8, 22), "Overhauled cooldown tracker, fixed a bug in the cooldown interactions between CDR and haste changes, and added preliminary support for cooldown rate changes", Sref),
   change(date(2022, 8, 19), <>Convert Abilities.SPELL_CATEGORIES to SPELL_CATEGORY enum.</>, Vetyst),
   change(date(2022, 8, 18), "Updated lint-staged to newest version", Putro),

--- a/src/interface/report/Results/Timeline/Lane.tsx
+++ b/src/interface/report/Results/Timeline/Lane.tsx
@@ -13,7 +13,7 @@ import {
   UpdateSpellUsableEvent,
   UpdateSpellUsableType,
 } from 'parser/core/Events';
-import { PureComponent, Fragment } from 'react';
+import { Fragment, PureComponent } from 'react';
 
 const PREPHASE_BUFFER = 1000; //ms a prephase event gets displayed before the phase start
 
@@ -45,8 +45,10 @@ class Lane extends PureComponent<Props> {
               {this.renderRecharge(event)}
             </Fragment>
           );
-        } else {
+        } else if (event.updateType === UpdateSpellUsableType.EndCooldown) {
           return this.renderCooldown(event);
+        } else {
+          return null;
         }
       case EventType.ApplyBuff:
         if (this.props.castableBuff === event.ability.guid) {
@@ -87,11 +89,11 @@ class Lane extends PureComponent<Props> {
   renderCooldown(event: UpdateSpellUsableEvent) {
     //let pre phase events be displayed one second tick before the phase
     const left = this.getOffsetLeft(
-      Math.max(this.props.fightStartTimestamp - PREPHASE_BUFFER, event.overallStartTimestamp),
+      Math.max(this.props.fightStartTimestamp - PREPHASE_BUFFER, event.chargeStartTimestamp),
     );
     const width =
       ((Math.min(this.props.fightEndTimestamp, event.timestamp) -
-        Math.max(this.props.fightStartTimestamp - PREPHASE_BUFFER, event.overallStartTimestamp)) /
+        Math.max(this.props.fightStartTimestamp - PREPHASE_BUFFER, event.chargeStartTimestamp)) /
         1000) *
       this.props.secondWidth;
     return (
@@ -100,7 +102,7 @@ class Lane extends PureComponent<Props> {
         content={
           <Trans id="interface.report.results.timeline.lane.tooltip.eventOrAbilityCooldown">
             {event.ability.name} cooldown:{' '}
-            {((event.timestamp - event.overallStartTimestamp) / 1000).toFixed(1)}s
+            {((event.timestamp - event.chargeStartTimestamp) / 1000).toFixed(1)}s
           </Trans>
         }
       >

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -790,6 +790,10 @@ export interface UpdateSpellUsableEvent extends Event<EventType.UpdateSpellUsabl
    *  for this ability, and if this is a BeginCooldown it will be the same as this event's timestamp.
    *  Note this is the overall beginning, *not* the beginning of the most recent charge's cooldown. */
   overallStartTimestamp: number;
+  /** The timestamp the cooldown of this charge began - always the timestamp of the most recent
+   *  BeginCooldown or RestoreCharge for this ability. If this is a BeginCooldown it will be the
+   *  same as the event's timestamp. */
+  chargeStartTimestamp: number;
   /** The timestamp the next charge is expected to be restored, based on current conditions.
    *  For a spell without charges, this is the expected time of the cooldown's end. (for an
    *  EndCooldown updateType, it will be the actual time of the cooldown's end - this event's timestamp)

--- a/src/parser/shared/modules/SpellUsable.test.js
+++ b/src/parser/shared/modules/SpellUsable.test.js
@@ -190,6 +190,7 @@ describe('core/Modules/SpellUsable', () => {
         maxCharges: 1,
 
         overallStartTimestamp: 0,
+        chargeStartTimestamp: 0,
         expectedRechargeTimestamp: 7500,
         expectedRechargeDuration: 7500,
 
@@ -225,6 +226,7 @@ describe('core/Modules/SpellUsable', () => {
           maxCharges: 1,
 
           overallStartTimestamp: 0,
+          chargeStartTimestamp: 0,
           expectedRechargeTimestamp: 0, // for an endcooldown this value always matches the timestamp
           expectedRechargeDuration: 7500,
 
@@ -254,6 +256,7 @@ describe('core/Modules/SpellUsable', () => {
           maxCharges: 1,
 
           overallStartTimestamp: 0,
+          chargeStartTimestamp: 0,
           expectedRechargeTimestamp: 7500,
           expectedRechargeDuration: 7500,
 
@@ -290,6 +293,7 @@ describe('core/Modules/SpellUsable', () => {
         maxCharges: 2,
 
         overallStartTimestamp: 0,
+        chargeStartTimestamp: 0,
         expectedRechargeTimestamp: 7500,
         expectedRechargeDuration: 7500,
 
@@ -326,6 +330,7 @@ describe('core/Modules/SpellUsable', () => {
         maxCharges: 1,
 
         overallStartTimestamp: 0,
+        chargeStartTimestamp: 0,
         expectedRechargeTimestamp: 7500,
         expectedRechargeDuration: 7500,
 
@@ -363,6 +368,7 @@ describe('core/Modules/SpellUsable', () => {
         maxCharges: 2,
 
         overallStartTimestamp: 0,
+        chargeStartTimestamp: 0,
         expectedRechargeTimestamp: 15000,
         expectedRechargeDuration: 7500,
 

--- a/src/parser/shared/modules/SpellUsable.ts
+++ b/src/parser/shared/modules/SpellUsable.ts
@@ -34,6 +34,8 @@ function spellName(spellId: number) {
 type CooldownInfo = {
   /** Timestamp this cooldown started overall (not the most recent charge) */
   overallStart: number;
+  /** Timestamp the most recent charge started cooling down */
+  chargeStart: number;
   /** The duration of the spell's recharge time based on current conditions */
   currentRechargeDuration: number;
   /** The expected time of the next recharge based on current conditions */
@@ -195,6 +197,7 @@ class SpellUsable extends Analyzer {
 
       const newInfo: CooldownInfo = {
         overallStart: triggeringEvent.timestamp,
+        chargeStart: triggeringEvent.timestamp,
         expectedEnd: triggeringEvent.timestamp + expectedCooldownDuration,
         currentRechargeDuration: expectedCooldownDuration,
         chargesAvailable: maxCharges - 1,
@@ -318,6 +321,8 @@ class SpellUsable extends Analyzer {
         timestamp,
         cdInfo,
       );
+      // restore charge event needs to point to previous chargeStart, then we can update
+      cdInfo.chargeStart = timestamp;
     }
   }
 
@@ -683,6 +688,7 @@ class SpellUsable extends Analyzer {
       isAvailable: info.chargesAvailable > 0,
       chargesAvailable: info.chargesAvailable,
       maxCharges: info.maxCharges,
+      chargeStartTimestamp: info.chargeStart,
       overallStartTimestamp: info.overallStart,
       expectedRechargeTimestamp: info.expectedEnd,
       expectedRechargeDuration: info.currentRechargeDuration,


### PR DESCRIPTION
(my previous PR made them show overall cooldown for multiple possible overlapping charges, now it shows for each restore charge , like it was before)