### PR TITLE
add 'export const' for every generated talent

### DIFF
--- a/scripts/talents/generate-talents.ts
+++ b/scripts/talents/generate-talents.ts
@@ -5,6 +5,7 @@ import {
   createTalentKey,
   csvToObject,
   findResourceCost,
+  printTalentConstExports,
   printTalents,
   readCsvFromUrl,
   readJsonFromUrl,
@@ -126,7 +127,9 @@ async function generateTalents() {
     fs.writeFileSync(
       `./src/common/TALENTS/${lowerCasedClassName}.ts`,
       `// Generated file, changes will eventually be overwritten!
-import { createTalentList } from './types';
+import { createTalentList, Talent } from './types';
+
+${printTalentConstExports(talentObjectByClass[lowerCasedClassName])}
 
 const talents = createTalentList({${printTalents(talentObjectByClass[lowerCasedClassName])}
   });

--- a/scripts/talents/talent-tree-helpers.ts
+++ b/scripts/talents/talent-tree-helpers.ts
@@ -59,6 +59,23 @@ export async function readCsvFromUrl(url: string) {
   return res;
 }
 
+export function printTalentConstExports(talentObj: ITalentObjectByClass[string]) {
+  if (!talentObj) {
+    return "\n//Class doesn't exist in data yet\n";
+  }
+  return Object.entries(talentObj)
+    .map(([specName, specTalents]) => {
+      const header = `\n  //region ${specName}`;
+      const footer = '\n  //endregion';
+      const talents = Object.keys(specTalents)
+        .map((talent) => `export const ${talent}: Talent = ${JSON.stringify(specTalents[talent])};`)
+        .join('\n');
+
+      return [header, talents, footer].join('\n');
+    })
+    .join('\n');
+}
+
 export function printTalents(talentObj: ITalentObjectByClass[string]) {
   if (!talentObj) {
     return "\n//Class doesn't exist in data yet\n";
@@ -67,7 +84,7 @@ export function printTalents(talentObj: ITalentObjectByClass[string]) {
     .map(([specName, specTalents]) => {
       const header = `\n  //${specName}`;
       const talents = Object.keys(specTalents)
-        .map((talent) => `${talent}: ${JSON.stringify(specTalents[talent])},`)
+        .map((talent) => `${talent},`)
         .join('\n');
 
       return [header, talents].join('\n');

--- a/src/common/TALENTS/deathknight.ts
+++ b/src/common/TALENTS/deathknight.ts
@@ -1,1021 +1,1241 @@
 // Generated file, changes will eventually be overwritten!
-import { createTalentList } from './types';
+import { createTalentList, Talent } from './types';
+
+//region Shared
+export const CHAINS_OF_ICE_TALENT: Talent = {
+  id: 45524,
+  name: 'Chains of Ice',
+  icon: 'spell_frost_chainsofice',
+  maxRanks: 1,
+  runesCost: 1,
+};
+export const DEATH_STRIKE_TALENT: Talent = {
+  id: 49998,
+  name: 'Death Strike',
+  icon: 'spell_deathknight_butcher2',
+  maxRanks: 1,
+  runicPowerCost: 45,
+};
+export const RAISE_DEAD_TALENT: Talent = {
+  id: 46585,
+  name: 'Raise Dead',
+  icon: 'inv_pet_ghoul',
+  maxRanks: 1,
+};
+export const MIND_FREEZE_TALENT: Talent = {
+  id: 47528,
+  name: 'Mind Freeze',
+  icon: 'spell_deathknight_mindfreeze',
+  maxRanks: 1,
+  runicPowerCost: 0,
+};
+export const ANTI_MAGIC_SHELL_TALENT: Talent = {
+  id: 48707,
+  name: 'Anti-Magic Shell',
+  icon: 'spell_shadow_antimagicshell',
+  maxRanks: 1,
+};
+export const CLEAVING_STRIKES_TALENT: Talent = {
+  id: 316916,
+  name: 'Cleaving Strikes',
+  icon: 'spell_shadow_deathanddecay',
+  maxRanks: 1,
+};
+export const BLINDING_SLEET_TALENT: Talent = {
+  id: 207167,
+  name: 'Blinding Sleet',
+  icon: 'spell_frost_chillingblast',
+  maxRanks: 1,
+};
+export const ANTICIPATION_TALENT: Talent = {
+  id: 378848,
+  name: 'Anticipation',
+  icon: 'spell_deathknight_mindfreeze',
+  maxRanks: 1,
+};
+export const PERMAFROST_TALENT: Talent = {
+  id: 207200,
+  name: 'Permafrost',
+  icon: 'achievement_zone_frostfire',
+  maxRanks: 1,
+};
+export const IMPROVED_DEATH_STRIKE_TALENT: Talent = {
+  id: 374277,
+  name: 'Improved Death Strike',
+  icon: 'spell_deathknight_butcher2',
+  maxRanks: 1,
+};
+export const ANTI_MAGIC_BARRIER_TALENT: Talent = {
+  id: 205727,
+  name: 'Anti-Magic Barrier',
+  icon: 'spell_shadow_antimagicshell',
+  maxRanks: 1,
+};
+export const MARCH_OF_DARKNESS_TALENT: Talent = {
+  id: 391546,
+  name: 'March of Darkness',
+  icon: 'ability_argus_deathfog',
+  maxRanks: 1,
+};
+export const SACRIFICIAL_PACT_TALENT: Talent = {
+  id: 327574,
+  name: 'Sacrificial Pact',
+  icon: 'spell_shadow_corpseexplode',
+  maxRanks: 1,
+  runicPowerCost: 20,
+};
+export const CONTROL_UNDEAD_TALENT: Talent = {
+  id: 111673,
+  name: 'Control Undead',
+  icon: 'inv_misc_bone_skull_01',
+  maxRanks: 1,
+  runesCost: 1,
+};
+export const ICEBOUND_FORTITUDE_TALENT: Talent = {
+  id: 48792,
+  name: 'Icebound Fortitude',
+  icon: 'spell_deathknight_iceboundfortitude',
+  maxRanks: 1,
+};
+export const BLOOD_SCENT_TALENT: Talent = {
+  id: 374030,
+  name: 'Blood Scent',
+  icon: 'spell_chargepositive',
+  maxRanks: 1,
+};
+export const VETERAN_OF_THE_THIRD_WAR_TALENT: Talent = {
+  id: 48263,
+  name: 'Veteran of the Third War',
+  icon: 'spell_misc_warsongfocus',
+  maxRanks: 2,
+};
+export const SUPPRESSION_TALENT: Talent = {
+  id: 374049,
+  name: 'Suppression',
+  icon: 'spell_chargepositive',
+  maxRanks: 1,
+};
+export const BRITTLE_TALENT: Talent = {
+  id: 374504,
+  name: 'Brittle',
+  icon: 'spell_deathknight_explode_ghoul',
+  maxRanks: 1,
+};
+export const ACCLIMATION_TALENT: Talent = {
+  id: 373926,
+  name: 'Acclimation',
+  icon: 'spell_deathknight_iceboundfortitude',
+  maxRanks: 1,
+};
+export const MERCILESS_STRIKES_TALENT: Talent = {
+  id: 373923,
+  name: 'Merciless Strikes',
+  icon: 'spell_chargepositive',
+  maxRanks: 1,
+};
+export const ANTI_MAGIC_ZONE_TALENT: Talent = {
+  id: 51052,
+  name: 'Anti-Magic Zone',
+  icon: 'spell_deathknight_antimagiczone',
+  maxRanks: 1,
+};
+export const MIGHT_OF_THASSARIAN_TALENT: Talent = {
+  id: 374111,
+  name: 'Might of Thassarian',
+  icon: 'spell_chargepositive',
+  maxRanks: 1,
+};
+export const CLENCHING_GRASP_TALENT: Talent = {
+  id: 389679,
+  name: 'Clenching Grasp',
+  icon: 'ability_deathknight_icygrip',
+  maxRanks: 1,
+};
+export const PROLIFERATING_CHILL_TALENT: Talent = {
+  id: 373930,
+  name: 'Proliferating Chill',
+  icon: 'spell_frost_chainsofice',
+  maxRanks: 1,
+};
+export const GLOOM_WARD_TALENT: Talent = {
+  id: 391571,
+  name: 'Gloom Ward',
+  icon: 'ability_rogue_envelopingshadows',
+  maxRanks: 1,
+};
+export const ASPHYXIATE_TALENT: Talent = {
+  id: 221562,
+  name: 'Asphyxiate',
+  icon: 'ability_deathknight_asphixiate',
+  maxRanks: 1,
+};
+export const ASSIMILATION_TALENT: Talent = {
+  id: 374383,
+  name: 'Assimilation',
+  icon: 'spell_deathknight_antimagiczone',
+  maxRanks: 1,
+};
+export const DEATH_PACT_TALENT: Talent = {
+  id: 48743,
+  name: 'Death Pact',
+  icon: 'spell_shadow_deathpact',
+  maxRanks: 1,
+};
+export const DEATHS_REACH_TALENT: Talent = {
+  id: 276079,
+  name: "Death's Reach",
+  icon: 'spell_deathknight_strangulate',
+  maxRanks: 1,
+};
+export const GRIP_OF_THE_DEAD_TALENT: Talent = {
+  id: 273952,
+  name: 'Grip of the Dead',
+  icon: 'ability_creature_disease_05',
+  maxRanks: 1,
+};
+export const UNHOLY_ENDURANCE_TALENT: Talent = {
+  id: 389682,
+  name: 'Unholy Endurance',
+  icon: 'spell_deathknight_subversion',
+  maxRanks: 1,
+};
+export const RUNIC_ATTENUATION_TALENT: Talent = {
+  id: 207104,
+  name: 'Runic Attenuation',
+  icon: 'boss_odunrunes_blue',
+  maxRanks: 1,
+};
+export const WRAITH_WALK_TALENT: Talent = {
+  id: 212552,
+  name: 'Wraith Walk',
+  icon: 'inv_helm_plate_raiddeathknight_p_01',
+  maxRanks: 1,
+};
+export const UNHOLY_GROUND_TALENT: Talent = {
+  id: 374265,
+  name: 'Unholy Ground',
+  icon: 'ability_deathknight_desecratedground',
+  maxRanks: 1,
+};
+export const INSIDIOUS_CHILL_TALENT: Talent = {
+  id: 391566,
+  name: 'Insidious Chill',
+  icon: 'ability_racial_wardoftheloafrost',
+  maxRanks: 1,
+};
+export const BLOOD_DRAW_TALENT: Talent = {
+  id: 374598,
+  name: 'Blood Draw',
+  icon: 'inv_artifact_bloodoftheassassinated',
+  maxRanks: 2,
+};
+export const WILL_OF_THE_NECROPOLIS_TALENT: Talent = {
+  id: 206967,
+  name: 'Will of the Necropolis',
+  icon: 'achievement_boss_kelthuzad_01',
+  maxRanks: 2,
+};
+export const DEATHS_ECHO_TALENT: Talent = {
+  id: 356367,
+  name: "Death's Echo",
+  icon: 'inv_fabric_ebonweave',
+  maxRanks: 1,
+};
+export const ICY_TALONS_TALENT: Talent = {
+  id: 194878,
+  name: 'Icy Talons',
+  icon: 'spell_deathknight_icytalons',
+  maxRanks: 2,
+};
+export const RUNE_MASTERY_TALENT: Talent = {
+  id: 374574,
+  name: 'Rune Mastery',
+  icon: 'ability_deathknight_hungeringruneblade',
+  maxRanks: 2,
+};
+export const UNHOLY_BOND_TALENT: Talent = {
+  id: 374261,
+  name: 'Unholy Bond',
+  icon: 'inv_sword_1h_felfireraid_d_01',
+  maxRanks: 2,
+};
+export const EMPOWER_RUNE_WEAPON_TALENT: Talent = {
+  id: 47568,
+  name: 'Empower Rune Weapon',
+  icon: 'inv_sword_62',
+  maxRanks: 1,
+};
+export const ABOMINATION_LIMB_TALENT: Talent = {
+  id: 383269,
+  name: 'Abomination Limb',
+  icon: 'ability_maldraxxus_deathknight',
+  maxRanks: 1,
+};
+export const SOUL_REAPER_TALENT: Talent = {
+  id: 343294,
+  name: 'Soul Reaper',
+  icon: 'ability_deathknight_soulreaper',
+  maxRanks: 1,
+  runesCost: 1,
+};
+
+//endregion
+
+//region Blood
+export const HEART_STRIKE_BLOOD_TALENT: Talent = {
+  id: 206930,
+  name: 'Heart Strike',
+  icon: 'inv_weapon_shortblade_40',
+  maxRanks: 1,
+  runesCost: 1,
+};
+export const MARROWREND_BLOOD_TALENT: Talent = {
+  id: 195182,
+  name: 'Marrowrend',
+  icon: 'ability_deathknight_marrowrend',
+  maxRanks: 1,
+  runesCost: 2,
+};
+export const BLOOD_BOIL_BLOOD_TALENT: Talent = {
+  id: 50842,
+  name: 'Blood Boil',
+  icon: 'spell_deathknight_bloodboil',
+  maxRanks: 1,
+};
+export const VAMPIRIC_BLOOD_BLOOD_TALENT: Talent = {
+  id: 55233,
+  name: 'Vampiric Blood',
+  icon: 'spell_shadow_lifedrain',
+  maxRanks: 1,
+};
+export const CRIMSON_SCOURGE_BLOOD_TALENT: Talent = {
+  id: 81136,
+  name: 'Crimson Scourge',
+  icon: 'ability_warrior_bloodnova',
+  maxRanks: 1,
+};
+export const OSSUARY_BLOOD_TALENT: Talent = {
+  id: 219786,
+  name: 'Ossuary',
+  icon: 'ability_deathknight_brittlebones',
+  maxRanks: 1,
+};
+export const IMPROVED_VAMPIRIC_BLOOD_BLOOD_TALENT: Talent = {
+  id: 317133,
+  name: 'Improved Vampiric Blood',
+  icon: 'spell_shadow_lifedrain',
+  maxRanks: 2,
+};
+export const IMPROVED_HEART_STRIKE_BLOOD_TALENT: Talent = {
+  id: 374717,
+  name: 'Improved Heart Strike',
+  icon: 'inv_weapon_shortblade_40',
+  maxRanks: 2,
+};
+export const DEATHS_CARESS_BLOOD_TALENT: Talent = {
+  id: 195292,
+  name: "Death's Caress",
+  icon: 'ability_deathknight_deathscaress',
+  maxRanks: 1,
+  runesCost: 1,
+};
+export const RUNE_TAP_BLOOD_TALENT: Talent = {
+  id: 194679,
+  name: 'Rune Tap',
+  icon: 'spell_deathknight_runetap',
+  maxRanks: 1,
+  runesCost: 1,
+};
+export const HEARTBREAKER_BLOOD_TALENT: Talent = {
+  id: 221536,
+  name: 'Heartbreaker',
+  icon: 'spell_deathknight_deathstrike',
+  maxRanks: 2,
+};
+export const FOUL_BULWARK_BLOOD_TALENT: Talent = {
+  id: 206974,
+  name: 'Foul Bulwark',
+  icon: 'inv_armor_shield_naxxramas_d_02',
+  maxRanks: 1,
+};
+export const DANCING_RUNE_WEAPON_BLOOD_TALENT: Talent = {
+  id: 49028,
+  name: 'Dancing Rune Weapon',
+  icon: 'inv_sword_07',
+  maxRanks: 1,
+};
+export const HEMOSTASIS_BLOOD_TALENT: Talent = {
+  id: 273946,
+  name: 'Hemostasis',
+  icon: 'ability_deathwing_bloodcorruption_earth',
+  maxRanks: 1,
+};
+export const PERSEVERANCE_OF_THE_EBON_BLADE_BLOOD_TALENT: Talent = {
+  id: 374747,
+  name: 'Perseverance of the Ebon Blade',
+  icon: 'ability_deathknight_sanguinfortitude',
+  maxRanks: 2,
+};
+export const RELISH_IN_BLOOD_BLOOD_TALENT: Talent = {
+  id: 317610,
+  name: 'Relish in Blood',
+  icon: 'ability_deathknight_roilingblood',
+  maxRanks: 1,
+};
+export const LEECHING_STRIKE_BLOOD_TALENT: Talent = {
+  id: 377629,
+  name: 'Leeching Strike',
+  icon: 'ability_deathwing_bloodcorruption_death',
+  maxRanks: 1,
+};
+export const IMPROVED_BONESHIELD_BLOOD_TALENT: Talent = {
+  id: 374715,
+  name: 'Improved Boneshield',
+  icon: 'ability_deathknight_marrowrend',
+  maxRanks: 1,
+};
+export const INSATIABLE_BLADE_BLOOD_TALENT: Talent = {
+  id: 377637,
+  name: 'Insatiable Blade',
+  icon: '70_inscription_vantus_rune_nightmare',
+  maxRanks: 1,
+};
+export const BLOODDRINKER_BLOOD_TALENT: Talent = {
+  id: 206931,
+  name: 'Blooddrinker',
+  icon: 'ability_animusdraw',
+  maxRanks: 1,
+  runesCost: 1,
+};
+export const CONSUMPTION_BLOOD_TALENT: Talent = {
+  id: 274156,
+  name: 'Consumption',
+  icon: 'inv_axe_2h_artifactmaw_d_01',
+  maxRanks: 1,
+};
+export const RAPID_DECOMPOSITION_BLOOD_TALENT: Talent = {
+  id: 194662,
+  name: 'Rapid Decomposition',
+  icon: 'ability_deathknight_deathsiphon2',
+  maxRanks: 1,
+};
+export const BLOOD_FEAST_BLOOD_TALENT: Talent = {
+  id: 391386,
+  name: 'Blood Feast',
+  icon: 'inv_artifact_bloodoftheassassinated',
+  maxRanks: 1,
+};
+export const BLOOD_TAP_BLOOD_TALENT: Talent = {
+  id: 221699,
+  name: 'Blood Tap',
+  icon: 'spell_deathknight_bloodtap',
+  maxRanks: 1,
+};
+export const REINFORCED_BONES_BLOOD_TALENT: Talent = {
+  id: 374737,
+  name: 'Reinforced Bones',
+  icon: 'ability_deathknight_boneshield',
+  maxRanks: 1,
+};
+export const EVERLASTING_BOND_BLOOD_TALENT: Talent = {
+  id: 377668,
+  name: 'Everlasting Bond',
+  icon: 'inv_sword_07',
+  maxRanks: 1,
+};
+export const VORACIOUS_BLOOD_TALENT: Talent = {
+  id: 273953,
+  name: 'Voracious',
+  icon: 'ability_ironmaidens_whirlofblood',
+  maxRanks: 1,
+};
+export const BLOODWORMS_BLOOD_TALENT: Talent = {
+  id: 195679,
+  name: 'Bloodworms',
+  icon: 'spell_shadow_soulleech',
+  maxRanks: 1,
+};
+export const COAGULOPATHY_BLOOD_TALENT: Talent = {
+  id: 391477,
+  name: 'Coagulopathy',
+  icon: 'ability_skeer_bloodletting',
+  maxRanks: 1,
+};
+export const MARK_OF_BLOOD_BLOOD_TALENT: Talent = {
+  id: 206940,
+  name: 'Mark of Blood',
+  icon: 'ability_hunter_rapidkilling',
+  maxRanks: 1,
+};
+export const TOMBSTONE_BLOOD_TALENT: Talent = {
+  id: 219809,
+  name: 'Tombstone',
+  icon: 'ability_fiegndead',
+  maxRanks: 1,
+};
+export const GOREFIENDS_GRASP_BLOOD_TALENT: Talent = {
+  id: 108199,
+  name: "Gorefiend's Grasp",
+  icon: 'ability_deathknight_aoedeathgrip',
+  maxRanks: 1,
+};
+export const SANGUINE_GROUND_BLOOD_TALENT: Talent = {
+  id: 391458,
+  name: 'Sanguine Ground',
+  icon: 'inv_artifact_corruptedbloodofzakajz',
+  maxRanks: 1,
+};
+export const SHATTERING_BONE_BLOOD_TALENT: Talent = {
+  id: 377640,
+  name: 'Shattering Bone',
+  icon: 'ability_deathknight_boneshield',
+  maxRanks: 2,
+};
+export const HEARTREND_BLOOD_TALENT: Talent = {
+  id: 377655,
+  name: 'Heartrend',
+  icon: 'inv_weapon_shortblade_40',
+  maxRanks: 1,
+};
+export const TIGHTENING_GRASP_BLOOD_TALENT: Talent = {
+  id: 206970,
+  name: 'Tightening Grasp',
+  icon: 'ability_deathknight_aoedeathgrip',
+  maxRanks: 1,
+};
+export const IRON_HEART_BLOOD_TALENT: Talent = {
+  id: 391395,
+  name: 'Iron Heart',
+  icon: 'inv_ragnaros_heart',
+  maxRanks: 1,
+};
+export const RED_THIRST_BLOOD_TALENT: Talent = {
+  id: 205723,
+  name: 'Red Thirst',
+  icon: 'spell_deathknight_bloodpresence',
+  maxRanks: 2,
+};
+export const BONESTORM_BLOOD_TALENT: Talent = {
+  id: 194844,
+  name: 'Bonestorm',
+  icon: 'achievement_boss_lordmarrowgar',
+  maxRanks: 1,
+  runicPowerCost: 10,
+};
+export const PURGATORY_BLOOD_TALENT: Talent = {
+  id: 114556,
+  name: 'Purgatory',
+  icon: 'inv_misc_shadowegg',
+  maxRanks: 1,
+};
+export const BLOODSHOT_BLOOD_TALENT: Talent = {
+  id: 391398,
+  name: 'Bloodshot',
+  icon: 'ability_warlock_baneofhavoc',
+  maxRanks: 1,
+};
+export const UMBILICUS_ETERNUS_BLOOD_TALENT: Talent = {
+  id: 391517,
+  name: 'Umbilicus Eternus',
+  icon: 'artifactability_blooddeathknight_umbilicuseternus',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Frost
+export const FROST_STRIKE_FROST_TALENT: Talent = {
+  id: 49143,
+  name: 'Frost Strike',
+  icon: 'spell_deathknight_empowerruneblade2',
+  maxRanks: 1,
+  runicPowerCost: 25,
+};
+export const OBLITERATE_FROST_TALENT: Talent = {
+  id: 49020,
+  name: 'Obliterate',
+  icon: 'spell_deathknight_classicon',
+  maxRanks: 1,
+  runesCost: 2,
+};
+export const HOWLING_BLAST_FROST_TALENT: Talent = {
+  id: 49184,
+  name: 'Howling Blast',
+  icon: 'spell_frost_arcticwinds',
+  maxRanks: 1,
+  runesCost: 1,
+};
+export const KILLING_MACHINE_FROST_TALENT: Talent = {
+  id: 51128,
+  name: 'Killing Machine',
+  icon: 'inv_sword_122',
+  maxRanks: 1,
+};
+export const RIME_FROST_TALENT: Talent = {
+  id: 59057,
+  name: 'Rime',
+  icon: 'spell_frost_freezingbreath',
+  maxRanks: 1,
+};
+export const UNLEASHED_FRENZY_FROST_TALENT: Talent = {
+  id: 376905,
+  name: 'Unleashed Frenzy',
+  icon: 'spell_deathknight_icetouch',
+  maxRanks: 1,
+};
+export const RUNIC_COMMAND_FROST_TALENT: Talent = {
+  id: 376251,
+  name: 'Runic Command',
+  icon: 'ability_deathknight_remorselesswinters',
+  maxRanks: 2,
+};
+export const IMPROVED_FROST_STRIKE_FROST_TALENT: Talent = {
+  id: 316803,
+  name: 'Improved Frost Strike',
+  icon: 'spell_deathknight_empowerruneblade2',
+  maxRanks: 2,
+};
+export const REMORSELESS_WINTER_FROST_TALENT: Talent = {
+  id: 196770,
+  name: 'Remorseless Winter',
+  icon: 'ability_deathknight_remorselesswinters2',
+  maxRanks: 1,
+  runesCost: 1,
+};
+export const IMPROVED_OBLITERATE_FROST_TALENT: Talent = {
+  id: 317198,
+  name: 'Improved Obliterate',
+  icon: 'spell_deathknight_classicon',
+  maxRanks: 2,
+};
+export const PILLAR_OF_FROST_FROST_TALENT: Talent = {
+  id: 51271,
+  name: 'Pillar of Frost',
+  icon: 'ability_deathknight_pillaroffrost',
+  maxRanks: 1,
+};
+export const IMPROVED_RIME_FROST_TALENT: Talent = {
+  id: 316838,
+  name: 'Improved Rime',
+  icon: 'spell_frost_freezingbreath',
+  maxRanks: 2,
+};
+export const FRIGID_EXECUTIONER_FROST_TALENT: Talent = {
+  id: 377073,
+  name: 'Frigid Executioner',
+  icon: 'spell_shadow_focusedpower',
+  maxRanks: 1,
+};
+export const RAGE_OF_THE_FROZEN_CHAMPION_FROST_TALENT: Talent = {
+  id: 377076,
+  name: 'Rage of the Frozen Champion',
+  icon: 'spell_mage_frostbomb',
+  maxRanks: 1,
+};
+export const IMPROVED_KILLING_MACHINE_FROST_TALENT: Talent = {
+  id: 317214,
+  name: 'Improved Killing Machine',
+  icon: 'inv_sword_122',
+  maxRanks: 1,
+};
+export const INEXORABLE_ASSAULT_FROST_TALENT: Talent = {
+  id: 253593,
+  name: 'Inexorable Assault',
+  icon: 'achievement_dungeon_icecrown_frostmourne',
+  maxRanks: 1,
+};
+export const COLD_HEART_FROST_TALENT: Talent = {
+  id: 281208,
+  name: 'Cold Heart',
+  icon: 'spell_frost_frozencore',
+  maxRanks: 1,
+};
+export const AVALANCHE_FROST_TALENT: Talent = {
+  id: 207142,
+  name: 'Avalanche',
+  icon: 'spell_frost_icestorm',
+  maxRanks: 1,
+};
+export const FROZEN_PULSE_FROST_TALENT: Talent = {
+  id: 194909,
+  name: 'Frozen Pulse',
+  icon: 'inv_misc_permafrostshard',
+  maxRanks: 1,
+};
+export const BITING_COLD_FROST_TALENT: Talent = {
+  id: 377056,
+  name: 'Biting Cold',
+  icon: 'ability_deathknight_remorselesswinters2',
+  maxRanks: 1,
+};
+export const CHILL_STREAK_FROST_TALENT: Talent = {
+  id: 305392,
+  name: 'Chill Streak',
+  icon: 'spell_frost_piercing_chill',
+  maxRanks: 1,
+  runicPowerCost: 40,
+};
+export const MURDEROUS_EFFICIENCY_FROST_TALENT: Talent = {
+  id: 207061,
+  name: 'Murderous Efficiency',
+  icon: 'spell_frost_frostarmor',
+  maxRanks: 1,
+};
+export const MIGHT_OF_THE_FROZEN_WASTES_FROST_TALENT: Talent = {
+  id: 343252,
+  name: 'Might of the Frozen Wastes',
+  icon: 'inv_sword_120',
+  maxRanks: 1,
+};
+export const ENDURING_STRENGTH_FROST_TALENT: Talent = {
+  id: 377190,
+  name: 'Enduring Strength',
+  icon: 'inv_sword_62',
+  maxRanks: 2,
+};
+export const FROSTWHELPS_AID_FROST_TALENT: Talent = {
+  id: 377226,
+  name: "Frostwhelp's Aid",
+  icon: 'inv_pet_dkwhelplingfrost',
+  maxRanks: 2,
+};
+export const GATHERING_STORM_FROST_TALENT: Talent = {
+  id: 194912,
+  name: 'Gathering Storm',
+  icon: 'spell_frost_ice_shards',
+  maxRanks: 1,
+};
+export const PIERCING_CHILL_FROST_TALENT: Talent = {
+  id: 377351,
+  name: 'Piercing Chill',
+  icon: 'spell_frost_piercing_chill',
+  maxRanks: 1,
+};
+export const ENDURING_CHILL_FROST_TALENT: Talent = {
+  id: 377376,
+  name: 'Enduring Chill',
+  icon: 'spell_frost_piercing_chill',
+  maxRanks: 1,
+};
+export const GLACIAL_ADVANCE_FROST_TALENT: Talent = {
+  id: 194913,
+  name: 'Glacial Advance',
+  icon: 'ability_hunter_glacialtrap',
+  maxRanks: 1,
+  runicPowerCost: 30,
+};
+export const BONEGRINDER_FROST_TALENT: Talent = {
+  id: 377098,
+  name: 'Bonegrinder',
+  icon: 'spell_deathknight_classicon',
+  maxRanks: 2,
+};
+export const EVERFROST_FROST_TALENT: Talent = {
+  id: 376938,
+  name: 'Everfrost',
+  icon: 'ability_mage_deepfreeze',
+  maxRanks: 2,
+};
+export const FROSTSCYTHE_FROST_TALENT: Talent = {
+  id: 207230,
+  name: 'Frostscythe',
+  icon: 'inv_misc_2h_farmscythe_a_01',
+  maxRanks: 1,
+  runesCost: 1,
+};
+export const COLD_BLOODED_RAGE_FROST_TALENT: Talent = {
+  id: 377083,
+  name: 'Cold-Blooded Rage',
+  icon: 'inv_sword_122',
+  maxRanks: 2,
+};
+export const FROSTWYRMS_FURY_FROST_TALENT: Talent = {
+  id: 279302,
+  name: "Frostwyrm's Fury",
+  icon: 'achievement_boss_sindragosa',
+  maxRanks: 1,
+};
+export const INVIGORATING_FREEZE_FROST_TALENT: Talent = {
+  id: 377092,
+  name: 'Invigorating Freeze',
+  icon: 'spell_deathknight_frostfever',
+  maxRanks: 2,
+};
+export const OBLITERATION_FROST_TALENT: Talent = {
+  id: 281238,
+  name: 'Obliteration',
+  icon: 'inv_axe_114',
+  maxRanks: 1,
+};
+export const ICECAP_FROST_TALENT: Talent = {
+  id: 207126,
+  name: 'Icecap',
+  icon: 'inv_misc_herb_icecap',
+  maxRanks: 1,
+};
+export const ABSOLUTE_ZERO_FROST_TALENT: Talent = {
+  id: 377047,
+  name: 'Absolute Zero',
+  icon: 'spell_frost_frostnova',
+  maxRanks: 1,
+};
+export const BREATH_OF_SINDRAGOSA_FROST_TALENT: Talent = {
+  id: 152279,
+  name: 'Breath of Sindragosa',
+  icon: 'spell_deathknight_breathofsindragosa',
+  maxRanks: 1,
+  runicPowerCost: 0,
+};
+
+//endregion
+
+//region Unholy
+export const FESTERING_STRIKE_UNHOLY_TALENT: Talent = {
+  id: 316867,
+  name: 'Festering Strike',
+  icon: 'spell_deathknight_festering_strike',
+  maxRanks: 2,
+};
+export const SCOURGE_STRIKE_UNHOLY_TALENT: Talent = {
+  id: 55090,
+  name: 'Scourge Strike',
+  icon: 'spell_deathknight_scourgestrike',
+  maxRanks: 1,
+  runesCost: 1,
+};
+export const RAISE_DEAD_UNHOLY_TALENT: Talent = {
+  id: 46584,
+  name: 'Raise Dead',
+  icon: 'inv_pet_ghoul',
+  maxRanks: 1,
+};
+export const OUTBREAK_UNHOLY_TALENT: Talent = {
+  id: 77575,
+  name: 'Outbreak',
+  icon: 'spell_deathvortex',
+  maxRanks: 1,
+  runesCost: 1,
+};
+export const DARK_TRANSFORMATION_UNHOLY_TALENT: Talent = {
+  id: 63560,
+  name: 'Dark Transformation',
+  icon: 'achievement_boss_festergutrotface',
+  maxRanks: 1,
+};
+export const UNHOLY_BLIGHT_UNHOLY_TALENT: Talent = {
+  id: 115989,
+  name: 'Unholy Blight',
+  icon: 'spell_shadow_contagion',
+  maxRanks: 1,
+  runesCost: 1,
+};
+export const RUNIC_MASTERY_UNHOLY_TALENT: Talent = {
+  id: 390166,
+  name: 'Runic Mastery',
+  icon: 'ability_deathknight_remorselesswinters',
+  maxRanks: 2,
+};
+export const INFECTED_CLAWS_UNHOLY_TALENT: Talent = {
+  id: 207272,
+  name: 'Infected Claws',
+  icon: 'spell_deathknight_thrash_ghoul',
+  maxRanks: 1,
+};
+export const EPIDEMIC_UNHOLY_TALENT: Talent = {
+  id: 207317,
+  name: 'Epidemic',
+  icon: 'spell_nature_nullifydisease',
+  maxRanks: 1,
+  runicPowerCost: 30,
+};
+export const REPLENISHING_WOUNDS_UNHOLY_TALENT: Talent = {
+  id: 377585,
+  name: 'Replenishing Wounds',
+  icon: 'spell_yorsahj_bloodboil_purpleoil',
+  maxRanks: 1,
+};
+export const FEASTING_STRIKES_UNHOLY_TALENT: Talent = {
+  id: 390161,
+  name: 'Feasting Strikes',
+  icon: 'spell_nature_rune',
+  maxRanks: 1,
+};
+export const APOCALYPSE_UNHOLY_TALENT: Talent = {
+  id: 275699,
+  name: 'Apocalypse',
+  icon: 'artifactability_unholydeathknight_deathsembrace',
+  maxRanks: 1,
+};
+export const CLAWING_SHADOWS_UNHOLY_TALENT: Talent = {
+  id: 207311,
+  name: 'Clawing Shadows',
+  icon: 'warlock_curse_shadow',
+  maxRanks: 1,
+  runesCost: 1,
+};
+export const PLAGUEBRINGER_UNHOLY_TALENT: Talent = {
+  id: 390175,
+  name: 'Plaguebringer',
+  icon: 'spell_deathknight_plaguestrike',
+  maxRanks: 1,
+};
+export const SUDDEN_DOOM_UNHOLY_TALENT: Talent = {
+  id: 49530,
+  name: 'Sudden Doom',
+  icon: 'spell_shadow_painspike',
+  maxRanks: 1,
+};
+export const ALL_WILL_SERVE_UNHOLY_TALENT: Talent = {
+  id: 194916,
+  name: 'All Will Serve',
+  icon: 'ability_fiegndead',
+  maxRanks: 1,
+};
+export const PESTILENT_PUSTULES_UNHOLY_TALENT: Talent = {
+  id: 194917,
+  name: 'Pestilent Pustules',
+  icon: 'ability_creature_disease_03',
+  maxRanks: 1,
+};
+export const BURSTING_SORES_UNHOLY_TALENT: Talent = {
+  id: 207264,
+  name: 'Bursting Sores',
+  icon: 'ability_druid_infectedwound',
+  maxRanks: 1,
+};
+export const EBON_FEVER_UNHOLY_TALENT: Talent = {
+  id: 207269,
+  name: 'Ebon Fever',
+  icon: 'spell_shadow_creepingplague',
+  maxRanks: 1,
+};
+export const UNHOLY_COMMAND_UNHOLY_TALENT: Talent = {
+  id: 316941,
+  name: 'Unholy Command',
+  icon: 'ability_rogue_deadlymomentum',
+  maxRanks: 2,
+};
+export const MAGUS_OF_THE_DEAD_UNHOLY_TALENT: Talent = {
+  id: 390196,
+  name: 'Magus of the Dead',
+  icon: 'ability_maldraxxus_mage',
+  maxRanks: 1,
+};
+export const RUPTURED_VISCERA_UNHOLY_TALENT: Talent = {
+  id: 390236,
+  name: 'Ruptured Viscera',
+  icon: 'artifactability_unholydeathknight_flagellation',
+  maxRanks: 1,
+};
+export const IMPROVED_DEATH_COIL_UNHOLY_TALENT: Talent = {
+  id: 377580,
+  name: 'Improved Death Coil',
+  icon: 'spell_shadow_deathcoil',
+  maxRanks: 2,
+};
+export const ROTTEN_TOUCH_UNHOLY_TALENT: Talent = {
+  id: 390275,
+  name: 'Rotten Touch',
+  icon: 'ability_deathwing_grasping_tendrilsgreen',
+  maxRanks: 1,
+};
+export const UNHOLY_PACT_UNHOLY_TALENT: Talent = {
+  id: 319230,
+  name: 'Unholy Pact',
+  icon: 'spell_shadow_deathsembrace',
+  maxRanks: 1,
+};
+export const DEFILE_UNHOLY_TALENT: Talent = {
+  id: 152280,
+  name: 'Defile',
+  icon: 'spell_deathknight_defile',
+  maxRanks: 1,
+  runesCost: 1,
+};
+export const PLAGUEBEARER_UNHOLY_TALENT: Talent = {
+  id: 390279,
+  name: 'Plaguebearer',
+  icon: 'spell_shadow_plaguecloud',
+  maxRanks: 1,
+  runicPowerCost: 30,
+};
+export const PESTILENCE_UNHOLY_TALENT: Talent = {
+  id: 277234,
+  name: 'Pestilence',
+  icon: 'spell_deathknight_necroticplague',
+  maxRanks: 1,
+};
+export const ETERNAL_AGONY_UNHOLY_TALENT: Talent = {
+  id: 390268,
+  name: 'Eternal Agony',
+  icon: 'spell_necro_deathsdoor',
+  maxRanks: 1,
+};
+export const COIL_OF_DEVASTATION_UNHOLY_TALENT: Talent = {
+  id: 390270,
+  name: 'Coil of Devastation',
+  icon: 'ability_malkorok_blightofyshaarj_green',
+  maxRanks: 1,
+};
+export const HARBINGER_OF_DOOM_UNHOLY_TALENT: Talent = {
+  id: 276023,
+  name: 'Harbinger of Doom',
+  icon: 'spell_shadow_painspike',
+  maxRanks: 1,
+};
+export const REAPING_UNHOLY_TALENT: Talent = {
+  id: 377514,
+  name: 'Reaping',
+  icon: 'ability_deathwing_bloodcorruption_death',
+  maxRanks: 1,
+};
+export const DEATH_ROT_UNHOLY_TALENT: Talent = {
+  id: 377537,
+  name: 'Death Rot',
+  icon: 'ability_creature_cursed_03',
+  maxRanks: 1,
+};
+export const ARMY_OF_THE_DEAD_UNHOLY_TALENT: Talent = {
+  id: 42650,
+  name: 'Army of the Dead',
+  icon: 'spell_deathknight_armyofthedead',
+  maxRanks: 1,
+  runesCost: 1,
+};
+export const SUMMON_GARGOYLE_UNHOLY_TALENT: Talent = {
+  id: 49206,
+  name: 'Summon Gargoyle',
+  icon: 'ability_deathknight_summongargoyle',
+  maxRanks: 1,
+};
+export const FESTERMIGHT_UNHOLY_TALENT: Talent = {
+  id: 377590,
+  name: 'Festermight',
+  icon: 'ability_deathknight_festermight',
+  maxRanks: 2,
+};
+export const GHOULISH_FRENZY_UNHOLY_TALENT: Talent = {
+  id: 377587,
+  name: 'Ghoulish Frenzy',
+  icon: 'ability_warlock_baneofhavoc',
+  maxRanks: 2,
+};
+export const ARMY_OF_THE_DAMNED_UNHOLY_TALENT: Talent = {
+  id: 276837,
+  name: 'Army of the Damned',
+  icon: 'artifactability_unholydeathknight_deathsembrace',
+  maxRanks: 1,
+};
+export const MORBIDITY_UNHOLY_TALENT: Talent = {
+  id: 377592,
+  name: 'Morbidity',
+  icon: 'spell_necro_deathlyecho',
+  maxRanks: 2,
+};
+export const UNHOLY_AURA_UNHOLY_TALENT: Talent = {
+  id: 377440,
+  name: 'Unholy Aura',
+  icon: 'ability_deathknight_decomposingaura',
+  maxRanks: 2,
+};
+export const UNHOLY_ASSAULT_UNHOLY_TALENT: Talent = {
+  id: 207289,
+  name: 'Unholy Assault',
+  icon: 'spell_shadow_unholyfrenzy',
+  maxRanks: 1,
+};
+export const SUPERSTRAIN_UNHOLY_TALENT: Talent = {
+  id: 390283,
+  name: 'Superstrain',
+  icon: 'spell_deathknight_explode_ghoul',
+  maxRanks: 1,
+};
+export const COMMANDER_OF_THE_DEAD_UNHOLY_TALENT: Talent = {
+  id: 390259,
+  name: 'Commander of the Dead',
+  icon: 'spell_shadow_fumble',
+  maxRanks: 1,
+};
+
+//endregion
 
 const talents = createTalentList({
   //Shared
-  CHAINS_OF_ICE_TALENT: {
-    id: 45524,
-    name: 'Chains of Ice',
-    icon: 'spell_frost_chainsofice',
-    maxRanks: 1,
-    runesCost: 1,
-  },
-  DEATH_STRIKE_TALENT: {
-    id: 49998,
-    name: 'Death Strike',
-    icon: 'spell_deathknight_butcher2',
-    maxRanks: 1,
-    runicPowerCost: 45,
-  },
-  RAISE_DEAD_TALENT: { id: 46585, name: 'Raise Dead', icon: 'inv_pet_ghoul', maxRanks: 1 },
-  MIND_FREEZE_TALENT: {
-    id: 47528,
-    name: 'Mind Freeze',
-    icon: 'spell_deathknight_mindfreeze',
-    maxRanks: 1,
-    runicPowerCost: 0,
-  },
-  ANTI_MAGIC_SHELL_TALENT: {
-    id: 48707,
-    name: 'Anti-Magic Shell',
-    icon: 'spell_shadow_antimagicshell',
-    maxRanks: 1,
-  },
-  CLEAVING_STRIKES_TALENT: {
-    id: 316916,
-    name: 'Cleaving Strikes',
-    icon: 'spell_shadow_deathanddecay',
-    maxRanks: 1,
-  },
-  BLINDING_SLEET_TALENT: {
-    id: 207167,
-    name: 'Blinding Sleet',
-    icon: 'spell_frost_chillingblast',
-    maxRanks: 1,
-  },
-  ANTICIPATION_TALENT: {
-    id: 378848,
-    name: 'Anticipation',
-    icon: 'spell_deathknight_mindfreeze',
-    maxRanks: 1,
-  },
-  PERMAFROST_TALENT: {
-    id: 207200,
-    name: 'Permafrost',
-    icon: 'achievement_zone_frostfire',
-    maxRanks: 1,
-  },
-  IMPROVED_DEATH_STRIKE_TALENT: {
-    id: 374277,
-    name: 'Improved Death Strike',
-    icon: 'spell_deathknight_butcher2',
-    maxRanks: 1,
-  },
-  ANTI_MAGIC_BARRIER_TALENT: {
-    id: 205727,
-    name: 'Anti-Magic Barrier',
-    icon: 'spell_shadow_antimagicshell',
-    maxRanks: 1,
-  },
-  MARCH_OF_DARKNESS_TALENT: {
-    id: 391546,
-    name: 'March of Darkness',
-    icon: 'ability_argus_deathfog',
-    maxRanks: 1,
-  },
-  SACRIFICIAL_PACT_TALENT: {
-    id: 327574,
-    name: 'Sacrificial Pact',
-    icon: 'spell_shadow_corpseexplode',
-    maxRanks: 1,
-    runicPowerCost: 20,
-  },
-  CONTROL_UNDEAD_TALENT: {
-    id: 111673,
-    name: 'Control Undead',
-    icon: 'inv_misc_bone_skull_01',
-    maxRanks: 1,
-    runesCost: 1,
-  },
-  ICEBOUND_FORTITUDE_TALENT: {
-    id: 48792,
-    name: 'Icebound Fortitude',
-    icon: 'spell_deathknight_iceboundfortitude',
-    maxRanks: 1,
-  },
-  BLOOD_SCENT_TALENT: {
-    id: 374030,
-    name: 'Blood Scent',
-    icon: 'spell_chargepositive',
-    maxRanks: 1,
-  },
-  VETERAN_OF_THE_THIRD_WAR_TALENT: {
-    id: 48263,
-    name: 'Veteran of the Third War',
-    icon: 'spell_misc_warsongfocus',
-    maxRanks: 2,
-  },
-  SUPPRESSION_TALENT: {
-    id: 374049,
-    name: 'Suppression',
-    icon: 'spell_chargepositive',
-    maxRanks: 1,
-  },
-  BRITTLE_TALENT: {
-    id: 374504,
-    name: 'Brittle',
-    icon: 'spell_deathknight_explode_ghoul',
-    maxRanks: 1,
-  },
-  ACCLIMATION_TALENT: {
-    id: 373926,
-    name: 'Acclimation',
-    icon: 'spell_deathknight_iceboundfortitude',
-    maxRanks: 1,
-  },
-  MERCILESS_STRIKES_TALENT: {
-    id: 373923,
-    name: 'Merciless Strikes',
-    icon: 'spell_chargepositive',
-    maxRanks: 1,
-  },
-  ANTI_MAGIC_ZONE_TALENT: {
-    id: 51052,
-    name: 'Anti-Magic Zone',
-    icon: 'spell_deathknight_antimagiczone',
-    maxRanks: 1,
-  },
-  MIGHT_OF_THASSARIAN_TALENT: {
-    id: 374111,
-    name: 'Might of Thassarian',
-    icon: 'spell_chargepositive',
-    maxRanks: 1,
-  },
-  CLENCHING_GRASP_TALENT: {
-    id: 389679,
-    name: 'Clenching Grasp',
-    icon: 'ability_deathknight_icygrip',
-    maxRanks: 1,
-  },
-  PROLIFERATING_CHILL_TALENT: {
-    id: 373930,
-    name: 'Proliferating Chill',
-    icon: 'spell_frost_chainsofice',
-    maxRanks: 1,
-  },
-  GLOOM_WARD_TALENT: {
-    id: 391571,
-    name: 'Gloom Ward',
-    icon: 'ability_rogue_envelopingshadows',
-    maxRanks: 1,
-  },
-  ASPHYXIATE_TALENT: {
-    id: 221562,
-    name: 'Asphyxiate',
-    icon: 'ability_deathknight_asphixiate',
-    maxRanks: 1,
-  },
-  ASSIMILATION_TALENT: {
-    id: 374383,
-    name: 'Assimilation',
-    icon: 'spell_deathknight_antimagiczone',
-    maxRanks: 1,
-  },
-  DEATH_PACT_TALENT: { id: 48743, name: 'Death Pact', icon: 'spell_shadow_deathpact', maxRanks: 1 },
-  DEATHS_REACH_TALENT: {
-    id: 276079,
-    name: "Death's Reach",
-    icon: 'spell_deathknight_strangulate',
-    maxRanks: 1,
-  },
-  GRIP_OF_THE_DEAD_TALENT: {
-    id: 273952,
-    name: 'Grip of the Dead',
-    icon: 'ability_creature_disease_05',
-    maxRanks: 1,
-  },
-  UNHOLY_ENDURANCE_TALENT: {
-    id: 389682,
-    name: 'Unholy Endurance',
-    icon: 'spell_deathknight_subversion',
-    maxRanks: 1,
-  },
-  RUNIC_ATTENUATION_TALENT: {
-    id: 207104,
-    name: 'Runic Attenuation',
-    icon: 'boss_odunrunes_blue',
-    maxRanks: 1,
-  },
-  WRAITH_WALK_TALENT: {
-    id: 212552,
-    name: 'Wraith Walk',
-    icon: 'inv_helm_plate_raiddeathknight_p_01',
-    maxRanks: 1,
-  },
-  UNHOLY_GROUND_TALENT: {
-    id: 374265,
-    name: 'Unholy Ground',
-    icon: 'ability_deathknight_desecratedground',
-    maxRanks: 1,
-  },
-  INSIDIOUS_CHILL_TALENT: {
-    id: 391566,
-    name: 'Insidious Chill',
-    icon: 'ability_racial_wardoftheloafrost',
-    maxRanks: 1,
-  },
-  BLOOD_DRAW_TALENT: {
-    id: 374598,
-    name: 'Blood Draw',
-    icon: 'inv_artifact_bloodoftheassassinated',
-    maxRanks: 2,
-  },
-  WILL_OF_THE_NECROPOLIS_TALENT: {
-    id: 206967,
-    name: 'Will of the Necropolis',
-    icon: 'achievement_boss_kelthuzad_01',
-    maxRanks: 2,
-  },
-  DEATHS_ECHO_TALENT: {
-    id: 356367,
-    name: "Death's Echo",
-    icon: 'inv_fabric_ebonweave',
-    maxRanks: 1,
-  },
-  ICY_TALONS_TALENT: {
-    id: 194878,
-    name: 'Icy Talons',
-    icon: 'spell_deathknight_icytalons',
-    maxRanks: 2,
-  },
-  RUNE_MASTERY_TALENT: {
-    id: 374574,
-    name: 'Rune Mastery',
-    icon: 'ability_deathknight_hungeringruneblade',
-    maxRanks: 2,
-  },
-  UNHOLY_BOND_TALENT: {
-    id: 374261,
-    name: 'Unholy Bond',
-    icon: 'inv_sword_1h_felfireraid_d_01',
-    maxRanks: 2,
-  },
-  EMPOWER_RUNE_WEAPON_TALENT: {
-    id: 47568,
-    name: 'Empower Rune Weapon',
-    icon: 'inv_sword_62',
-    maxRanks: 1,
-  },
-  ABOMINATION_LIMB_TALENT: {
-    id: 383269,
-    name: 'Abomination Limb',
-    icon: 'ability_maldraxxus_deathknight',
-    maxRanks: 1,
-  },
-  SOUL_REAPER_TALENT: {
-    id: 343294,
-    name: 'Soul Reaper',
-    icon: 'ability_deathknight_soulreaper',
-    maxRanks: 1,
-    runesCost: 1,
-  },
+  CHAINS_OF_ICE_TALENT,
+  DEATH_STRIKE_TALENT,
+  RAISE_DEAD_TALENT,
+  MIND_FREEZE_TALENT,
+  ANTI_MAGIC_SHELL_TALENT,
+  CLEAVING_STRIKES_TALENT,
+  BLINDING_SLEET_TALENT,
+  ANTICIPATION_TALENT,
+  PERMAFROST_TALENT,
+  IMPROVED_DEATH_STRIKE_TALENT,
+  ANTI_MAGIC_BARRIER_TALENT,
+  MARCH_OF_DARKNESS_TALENT,
+  SACRIFICIAL_PACT_TALENT,
+  CONTROL_UNDEAD_TALENT,
+  ICEBOUND_FORTITUDE_TALENT,
+  BLOOD_SCENT_TALENT,
+  VETERAN_OF_THE_THIRD_WAR_TALENT,
+  SUPPRESSION_TALENT,
+  BRITTLE_TALENT,
+  ACCLIMATION_TALENT,
+  MERCILESS_STRIKES_TALENT,
+  ANTI_MAGIC_ZONE_TALENT,
+  MIGHT_OF_THASSARIAN_TALENT,
+  CLENCHING_GRASP_TALENT,
+  PROLIFERATING_CHILL_TALENT,
+  GLOOM_WARD_TALENT,
+  ASPHYXIATE_TALENT,
+  ASSIMILATION_TALENT,
+  DEATH_PACT_TALENT,
+  DEATHS_REACH_TALENT,
+  GRIP_OF_THE_DEAD_TALENT,
+  UNHOLY_ENDURANCE_TALENT,
+  RUNIC_ATTENUATION_TALENT,
+  WRAITH_WALK_TALENT,
+  UNHOLY_GROUND_TALENT,
+  INSIDIOUS_CHILL_TALENT,
+  BLOOD_DRAW_TALENT,
+  WILL_OF_THE_NECROPOLIS_TALENT,
+  DEATHS_ECHO_TALENT,
+  ICY_TALONS_TALENT,
+  RUNE_MASTERY_TALENT,
+  UNHOLY_BOND_TALENT,
+  EMPOWER_RUNE_WEAPON_TALENT,
+  ABOMINATION_LIMB_TALENT,
+  SOUL_REAPER_TALENT,
 
   //Blood
-  HEART_STRIKE_BLOOD_TALENT: {
-    id: 206930,
-    name: 'Heart Strike',
-    icon: 'inv_weapon_shortblade_40',
-    maxRanks: 1,
-    runesCost: 1,
-  },
-  MARROWREND_BLOOD_TALENT: {
-    id: 195182,
-    name: 'Marrowrend',
-    icon: 'ability_deathknight_marrowrend',
-    maxRanks: 1,
-    runesCost: 2,
-  },
-  BLOOD_BOIL_BLOOD_TALENT: {
-    id: 50842,
-    name: 'Blood Boil',
-    icon: 'spell_deathknight_bloodboil',
-    maxRanks: 1,
-  },
-  VAMPIRIC_BLOOD_BLOOD_TALENT: {
-    id: 55233,
-    name: 'Vampiric Blood',
-    icon: 'spell_shadow_lifedrain',
-    maxRanks: 1,
-  },
-  CRIMSON_SCOURGE_BLOOD_TALENT: {
-    id: 81136,
-    name: 'Crimson Scourge',
-    icon: 'ability_warrior_bloodnova',
-    maxRanks: 1,
-  },
-  OSSUARY_BLOOD_TALENT: {
-    id: 219786,
-    name: 'Ossuary',
-    icon: 'ability_deathknight_brittlebones',
-    maxRanks: 1,
-  },
-  IMPROVED_VAMPIRIC_BLOOD_BLOOD_TALENT: {
-    id: 317133,
-    name: 'Improved Vampiric Blood',
-    icon: 'spell_shadow_lifedrain',
-    maxRanks: 2,
-  },
-  IMPROVED_HEART_STRIKE_BLOOD_TALENT: {
-    id: 374717,
-    name: 'Improved Heart Strike',
-    icon: 'inv_weapon_shortblade_40',
-    maxRanks: 2,
-  },
-  DEATHS_CARESS_BLOOD_TALENT: {
-    id: 195292,
-    name: "Death's Caress",
-    icon: 'ability_deathknight_deathscaress',
-    maxRanks: 1,
-    runesCost: 1,
-  },
-  RUNE_TAP_BLOOD_TALENT: {
-    id: 194679,
-    name: 'Rune Tap',
-    icon: 'spell_deathknight_runetap',
-    maxRanks: 1,
-    runesCost: 1,
-  },
-  HEARTBREAKER_BLOOD_TALENT: {
-    id: 221536,
-    name: 'Heartbreaker',
-    icon: 'spell_deathknight_deathstrike',
-    maxRanks: 2,
-  },
-  FOUL_BULWARK_BLOOD_TALENT: {
-    id: 206974,
-    name: 'Foul Bulwark',
-    icon: 'inv_armor_shield_naxxramas_d_02',
-    maxRanks: 1,
-  },
-  DANCING_RUNE_WEAPON_BLOOD_TALENT: {
-    id: 49028,
-    name: 'Dancing Rune Weapon',
-    icon: 'inv_sword_07',
-    maxRanks: 1,
-  },
-  HEMOSTASIS_BLOOD_TALENT: {
-    id: 273946,
-    name: 'Hemostasis',
-    icon: 'ability_deathwing_bloodcorruption_earth',
-    maxRanks: 1,
-  },
-  PERSEVERANCE_OF_THE_EBON_BLADE_BLOOD_TALENT: {
-    id: 374747,
-    name: 'Perseverance of the Ebon Blade',
-    icon: 'ability_deathknight_sanguinfortitude',
-    maxRanks: 2,
-  },
-  RELISH_IN_BLOOD_BLOOD_TALENT: {
-    id: 317610,
-    name: 'Relish in Blood',
-    icon: 'ability_deathknight_roilingblood',
-    maxRanks: 1,
-  },
-  LEECHING_STRIKE_BLOOD_TALENT: {
-    id: 377629,
-    name: 'Leeching Strike',
-    icon: 'ability_deathwing_bloodcorruption_death',
-    maxRanks: 1,
-  },
-  IMPROVED_BONESHIELD_BLOOD_TALENT: {
-    id: 374715,
-    name: 'Improved Boneshield',
-    icon: 'ability_deathknight_marrowrend',
-    maxRanks: 1,
-  },
-  INSATIABLE_BLADE_BLOOD_TALENT: {
-    id: 377637,
-    name: 'Insatiable Blade',
-    icon: '70_inscription_vantus_rune_nightmare',
-    maxRanks: 1,
-  },
-  BLOODDRINKER_BLOOD_TALENT: {
-    id: 206931,
-    name: 'Blooddrinker',
-    icon: 'ability_animusdraw',
-    maxRanks: 1,
-    runesCost: 1,
-  },
-  CONSUMPTION_BLOOD_TALENT: {
-    id: 274156,
-    name: 'Consumption',
-    icon: 'inv_axe_2h_artifactmaw_d_01',
-    maxRanks: 1,
-  },
-  RAPID_DECOMPOSITION_BLOOD_TALENT: {
-    id: 194662,
-    name: 'Rapid Decomposition',
-    icon: 'ability_deathknight_deathsiphon2',
-    maxRanks: 1,
-  },
-  BLOOD_FEAST_BLOOD_TALENT: {
-    id: 391386,
-    name: 'Blood Feast',
-    icon: 'inv_artifact_bloodoftheassassinated',
-    maxRanks: 1,
-  },
-  BLOOD_TAP_BLOOD_TALENT: {
-    id: 221699,
-    name: 'Blood Tap',
-    icon: 'spell_deathknight_bloodtap',
-    maxRanks: 1,
-  },
-  REINFORCED_BONES_BLOOD_TALENT: {
-    id: 374737,
-    name: 'Reinforced Bones',
-    icon: 'ability_deathknight_boneshield',
-    maxRanks: 1,
-  },
-  EVERLASTING_BOND_BLOOD_TALENT: {
-    id: 377668,
-    name: 'Everlasting Bond',
-    icon: 'inv_sword_07',
-    maxRanks: 1,
-  },
-  VORACIOUS_BLOOD_TALENT: {
-    id: 273953,
-    name: 'Voracious',
-    icon: 'ability_ironmaidens_whirlofblood',
-    maxRanks: 1,
-  },
-  BLOODWORMS_BLOOD_TALENT: {
-    id: 195679,
-    name: 'Bloodworms',
-    icon: 'spell_shadow_soulleech',
-    maxRanks: 1,
-  },
-  COAGULOPATHY_BLOOD_TALENT: {
-    id: 391477,
-    name: 'Coagulopathy',
-    icon: 'ability_skeer_bloodletting',
-    maxRanks: 1,
-  },
-  MARK_OF_BLOOD_BLOOD_TALENT: {
-    id: 206940,
-    name: 'Mark of Blood',
-    icon: 'ability_hunter_rapidkilling',
-    maxRanks: 1,
-  },
-  TOMBSTONE_BLOOD_TALENT: { id: 219809, name: 'Tombstone', icon: 'ability_fiegndead', maxRanks: 1 },
-  GOREFIENDS_GRASP_BLOOD_TALENT: {
-    id: 108199,
-    name: "Gorefiend's Grasp",
-    icon: 'ability_deathknight_aoedeathgrip',
-    maxRanks: 1,
-  },
-  SANGUINE_GROUND_BLOOD_TALENT: {
-    id: 391458,
-    name: 'Sanguine Ground',
-    icon: 'inv_artifact_corruptedbloodofzakajz',
-    maxRanks: 1,
-  },
-  SHATTERING_BONE_BLOOD_TALENT: {
-    id: 377640,
-    name: 'Shattering Bone',
-    icon: 'ability_deathknight_boneshield',
-    maxRanks: 2,
-  },
-  HEARTREND_BLOOD_TALENT: {
-    id: 377655,
-    name: 'Heartrend',
-    icon: 'inv_weapon_shortblade_40',
-    maxRanks: 1,
-  },
-  TIGHTENING_GRASP_BLOOD_TALENT: {
-    id: 206970,
-    name: 'Tightening Grasp',
-    icon: 'ability_deathknight_aoedeathgrip',
-    maxRanks: 1,
-  },
-  IRON_HEART_BLOOD_TALENT: {
-    id: 391395,
-    name: 'Iron Heart',
-    icon: 'inv_ragnaros_heart',
-    maxRanks: 1,
-  },
-  RED_THIRST_BLOOD_TALENT: {
-    id: 205723,
-    name: 'Red Thirst',
-    icon: 'spell_deathknight_bloodpresence',
-    maxRanks: 2,
-  },
-  BONESTORM_BLOOD_TALENT: {
-    id: 194844,
-    name: 'Bonestorm',
-    icon: 'achievement_boss_lordmarrowgar',
-    maxRanks: 1,
-    runicPowerCost: 10,
-  },
-  PURGATORY_BLOOD_TALENT: {
-    id: 114556,
-    name: 'Purgatory',
-    icon: 'inv_misc_shadowegg',
-    maxRanks: 1,
-  },
-  BLOODSHOT_BLOOD_TALENT: {
-    id: 391398,
-    name: 'Bloodshot',
-    icon: 'ability_warlock_baneofhavoc',
-    maxRanks: 1,
-  },
-  UMBILICUS_ETERNUS_BLOOD_TALENT: {
-    id: 391517,
-    name: 'Umbilicus Eternus',
-    icon: 'artifactability_blooddeathknight_umbilicuseternus',
-    maxRanks: 1,
-  },
+  HEART_STRIKE_BLOOD_TALENT,
+  MARROWREND_BLOOD_TALENT,
+  BLOOD_BOIL_BLOOD_TALENT,
+  VAMPIRIC_BLOOD_BLOOD_TALENT,
+  CRIMSON_SCOURGE_BLOOD_TALENT,
+  OSSUARY_BLOOD_TALENT,
+  IMPROVED_VAMPIRIC_BLOOD_BLOOD_TALENT,
+  IMPROVED_HEART_STRIKE_BLOOD_TALENT,
+  DEATHS_CARESS_BLOOD_TALENT,
+  RUNE_TAP_BLOOD_TALENT,
+  HEARTBREAKER_BLOOD_TALENT,
+  FOUL_BULWARK_BLOOD_TALENT,
+  DANCING_RUNE_WEAPON_BLOOD_TALENT,
+  HEMOSTASIS_BLOOD_TALENT,
+  PERSEVERANCE_OF_THE_EBON_BLADE_BLOOD_TALENT,
+  RELISH_IN_BLOOD_BLOOD_TALENT,
+  LEECHING_STRIKE_BLOOD_TALENT,
+  IMPROVED_BONESHIELD_BLOOD_TALENT,
+  INSATIABLE_BLADE_BLOOD_TALENT,
+  BLOODDRINKER_BLOOD_TALENT,
+  CONSUMPTION_BLOOD_TALENT,
+  RAPID_DECOMPOSITION_BLOOD_TALENT,
+  BLOOD_FEAST_BLOOD_TALENT,
+  BLOOD_TAP_BLOOD_TALENT,
+  REINFORCED_BONES_BLOOD_TALENT,
+  EVERLASTING_BOND_BLOOD_TALENT,
+  VORACIOUS_BLOOD_TALENT,
+  BLOODWORMS_BLOOD_TALENT,
+  COAGULOPATHY_BLOOD_TALENT,
+  MARK_OF_BLOOD_BLOOD_TALENT,
+  TOMBSTONE_BLOOD_TALENT,
+  GOREFIENDS_GRASP_BLOOD_TALENT,
+  SANGUINE_GROUND_BLOOD_TALENT,
+  SHATTERING_BONE_BLOOD_TALENT,
+  HEARTREND_BLOOD_TALENT,
+  TIGHTENING_GRASP_BLOOD_TALENT,
+  IRON_HEART_BLOOD_TALENT,
+  RED_THIRST_BLOOD_TALENT,
+  BONESTORM_BLOOD_TALENT,
+  PURGATORY_BLOOD_TALENT,
+  BLOODSHOT_BLOOD_TALENT,
+  UMBILICUS_ETERNUS_BLOOD_TALENT,
 
   //Frost
-  FROST_STRIKE_FROST_TALENT: {
-    id: 49143,
-    name: 'Frost Strike',
-    icon: 'spell_deathknight_empowerruneblade2',
-    maxRanks: 1,
-    runicPowerCost: 25,
-  },
-  OBLITERATE_FROST_TALENT: {
-    id: 49020,
-    name: 'Obliterate',
-    icon: 'spell_deathknight_classicon',
-    maxRanks: 1,
-    runesCost: 2,
-  },
-  HOWLING_BLAST_FROST_TALENT: {
-    id: 49184,
-    name: 'Howling Blast',
-    icon: 'spell_frost_arcticwinds',
-    maxRanks: 1,
-    runesCost: 1,
-  },
-  KILLING_MACHINE_FROST_TALENT: {
-    id: 51128,
-    name: 'Killing Machine',
-    icon: 'inv_sword_122',
-    maxRanks: 1,
-  },
-  RIME_FROST_TALENT: { id: 59057, name: 'Rime', icon: 'spell_frost_freezingbreath', maxRanks: 1 },
-  UNLEASHED_FRENZY_FROST_TALENT: {
-    id: 376905,
-    name: 'Unleashed Frenzy',
-    icon: 'spell_deathknight_icetouch',
-    maxRanks: 1,
-  },
-  RUNIC_COMMAND_FROST_TALENT: {
-    id: 376251,
-    name: 'Runic Command',
-    icon: 'ability_deathknight_remorselesswinters',
-    maxRanks: 2,
-  },
-  IMPROVED_FROST_STRIKE_FROST_TALENT: {
-    id: 316803,
-    name: 'Improved Frost Strike',
-    icon: 'spell_deathknight_empowerruneblade2',
-    maxRanks: 2,
-  },
-  REMORSELESS_WINTER_FROST_TALENT: {
-    id: 196770,
-    name: 'Remorseless Winter',
-    icon: 'ability_deathknight_remorselesswinters2',
-    maxRanks: 1,
-    runesCost: 1,
-  },
-  IMPROVED_OBLITERATE_FROST_TALENT: {
-    id: 317198,
-    name: 'Improved Obliterate',
-    icon: 'spell_deathknight_classicon',
-    maxRanks: 2,
-  },
-  PILLAR_OF_FROST_FROST_TALENT: {
-    id: 51271,
-    name: 'Pillar of Frost',
-    icon: 'ability_deathknight_pillaroffrost',
-    maxRanks: 1,
-  },
-  IMPROVED_RIME_FROST_TALENT: {
-    id: 316838,
-    name: 'Improved Rime',
-    icon: 'spell_frost_freezingbreath',
-    maxRanks: 2,
-  },
-  FRIGID_EXECUTIONER_FROST_TALENT: {
-    id: 377073,
-    name: 'Frigid Executioner',
-    icon: 'spell_shadow_focusedpower',
-    maxRanks: 1,
-  },
-  RAGE_OF_THE_FROZEN_CHAMPION_FROST_TALENT: {
-    id: 377076,
-    name: 'Rage of the Frozen Champion',
-    icon: 'spell_mage_frostbomb',
-    maxRanks: 1,
-  },
-  IMPROVED_KILLING_MACHINE_FROST_TALENT: {
-    id: 317214,
-    name: 'Improved Killing Machine',
-    icon: 'inv_sword_122',
-    maxRanks: 1,
-  },
-  INEXORABLE_ASSAULT_FROST_TALENT: {
-    id: 253593,
-    name: 'Inexorable Assault',
-    icon: 'achievement_dungeon_icecrown_frostmourne',
-    maxRanks: 1,
-  },
-  COLD_HEART_FROST_TALENT: {
-    id: 281208,
-    name: 'Cold Heart',
-    icon: 'spell_frost_frozencore',
-    maxRanks: 1,
-  },
-  AVALANCHE_FROST_TALENT: {
-    id: 207142,
-    name: 'Avalanche',
-    icon: 'spell_frost_icestorm',
-    maxRanks: 1,
-  },
-  FROZEN_PULSE_FROST_TALENT: {
-    id: 194909,
-    name: 'Frozen Pulse',
-    icon: 'inv_misc_permafrostshard',
-    maxRanks: 1,
-  },
-  BITING_COLD_FROST_TALENT: {
-    id: 377056,
-    name: 'Biting Cold',
-    icon: 'ability_deathknight_remorselesswinters2',
-    maxRanks: 1,
-  },
-  CHILL_STREAK_FROST_TALENT: {
-    id: 305392,
-    name: 'Chill Streak',
-    icon: 'spell_frost_piercing_chill',
-    maxRanks: 1,
-    runicPowerCost: 40,
-  },
-  MURDEROUS_EFFICIENCY_FROST_TALENT: {
-    id: 207061,
-    name: 'Murderous Efficiency',
-    icon: 'spell_frost_frostarmor',
-    maxRanks: 1,
-  },
-  MIGHT_OF_THE_FROZEN_WASTES_FROST_TALENT: {
-    id: 343252,
-    name: 'Might of the Frozen Wastes',
-    icon: 'inv_sword_120',
-    maxRanks: 1,
-  },
-  ENDURING_STRENGTH_FROST_TALENT: {
-    id: 377190,
-    name: 'Enduring Strength',
-    icon: 'inv_sword_62',
-    maxRanks: 2,
-  },
-  FROSTWHELPS_AID_FROST_TALENT: {
-    id: 377226,
-    name: "Frostwhelp's Aid",
-    icon: 'inv_pet_dkwhelplingfrost',
-    maxRanks: 2,
-  },
-  GATHERING_STORM_FROST_TALENT: {
-    id: 194912,
-    name: 'Gathering Storm',
-    icon: 'spell_frost_ice_shards',
-    maxRanks: 1,
-  },
-  PIERCING_CHILL_FROST_TALENT: {
-    id: 377351,
-    name: 'Piercing Chill',
-    icon: 'spell_frost_piercing_chill',
-    maxRanks: 1,
-  },
-  ENDURING_CHILL_FROST_TALENT: {
-    id: 377376,
-    name: 'Enduring Chill',
-    icon: 'spell_frost_piercing_chill',
-    maxRanks: 1,
-  },
-  GLACIAL_ADVANCE_FROST_TALENT: {
-    id: 194913,
-    name: 'Glacial Advance',
-    icon: 'ability_hunter_glacialtrap',
-    maxRanks: 1,
-    runicPowerCost: 30,
-  },
-  BONEGRINDER_FROST_TALENT: {
-    id: 377098,
-    name: 'Bonegrinder',
-    icon: 'spell_deathknight_classicon',
-    maxRanks: 2,
-  },
-  EVERFROST_FROST_TALENT: {
-    id: 376938,
-    name: 'Everfrost',
-    icon: 'ability_mage_deepfreeze',
-    maxRanks: 2,
-  },
-  FROSTSCYTHE_FROST_TALENT: {
-    id: 207230,
-    name: 'Frostscythe',
-    icon: 'inv_misc_2h_farmscythe_a_01',
-    maxRanks: 1,
-    runesCost: 1,
-  },
-  COLD_BLOODED_RAGE_FROST_TALENT: {
-    id: 377083,
-    name: 'Cold-Blooded Rage',
-    icon: 'inv_sword_122',
-    maxRanks: 2,
-  },
-  FROSTWYRMS_FURY_FROST_TALENT: {
-    id: 279302,
-    name: "Frostwyrm's Fury",
-    icon: 'achievement_boss_sindragosa',
-    maxRanks: 1,
-  },
-  INVIGORATING_FREEZE_FROST_TALENT: {
-    id: 377092,
-    name: 'Invigorating Freeze',
-    icon: 'spell_deathknight_frostfever',
-    maxRanks: 2,
-  },
-  OBLITERATION_FROST_TALENT: { id: 281238, name: 'Obliteration', icon: 'inv_axe_114', maxRanks: 1 },
-  ICECAP_FROST_TALENT: { id: 207126, name: 'Icecap', icon: 'inv_misc_herb_icecap', maxRanks: 1 },
-  ABSOLUTE_ZERO_FROST_TALENT: {
-    id: 377047,
-    name: 'Absolute Zero',
-    icon: 'spell_frost_frostnova',
-    maxRanks: 1,
-  },
-  BREATH_OF_SINDRAGOSA_FROST_TALENT: {
-    id: 152279,
-    name: 'Breath of Sindragosa',
-    icon: 'spell_deathknight_breathofsindragosa',
-    maxRanks: 1,
-    runicPowerCost: 0,
-  },
+  FROST_STRIKE_FROST_TALENT,
+  OBLITERATE_FROST_TALENT,
+  HOWLING_BLAST_FROST_TALENT,
+  KILLING_MACHINE_FROST_TALENT,
+  RIME_FROST_TALENT,
+  UNLEASHED_FRENZY_FROST_TALENT,
+  RUNIC_COMMAND_FROST_TALENT,
+  IMPROVED_FROST_STRIKE_FROST_TALENT,
+  REMORSELESS_WINTER_FROST_TALENT,
+  IMPROVED_OBLITERATE_FROST_TALENT,
+  PILLAR_OF_FROST_FROST_TALENT,
+  IMPROVED_RIME_FROST_TALENT,
+  FRIGID_EXECUTIONER_FROST_TALENT,
+  RAGE_OF_THE_FROZEN_CHAMPION_FROST_TALENT,
+  IMPROVED_KILLING_MACHINE_FROST_TALENT,
+  INEXORABLE_ASSAULT_FROST_TALENT,
+  COLD_HEART_FROST_TALENT,
+  AVALANCHE_FROST_TALENT,
+  FROZEN_PULSE_FROST_TALENT,
+  BITING_COLD_FROST_TALENT,
+  CHILL_STREAK_FROST_TALENT,
+  MURDEROUS_EFFICIENCY_FROST_TALENT,
+  MIGHT_OF_THE_FROZEN_WASTES_FROST_TALENT,
+  ENDURING_STRENGTH_FROST_TALENT,
+  FROSTWHELPS_AID_FROST_TALENT,
+  GATHERING_STORM_FROST_TALENT,
+  PIERCING_CHILL_FROST_TALENT,
+  ENDURING_CHILL_FROST_TALENT,
+  GLACIAL_ADVANCE_FROST_TALENT,
+  BONEGRINDER_FROST_TALENT,
+  EVERFROST_FROST_TALENT,
+  FROSTSCYTHE_FROST_TALENT,
+  COLD_BLOODED_RAGE_FROST_TALENT,
+  FROSTWYRMS_FURY_FROST_TALENT,
+  INVIGORATING_FREEZE_FROST_TALENT,
+  OBLITERATION_FROST_TALENT,
+  ICECAP_FROST_TALENT,
+  ABSOLUTE_ZERO_FROST_TALENT,
+  BREATH_OF_SINDRAGOSA_FROST_TALENT,
 
   //Unholy
-  FESTERING_STRIKE_UNHOLY_TALENT: {
-    id: 316867,
-    name: 'Festering Strike',
-    icon: 'spell_deathknight_festering_strike',
-    maxRanks: 2,
-  },
-  SCOURGE_STRIKE_UNHOLY_TALENT: {
-    id: 55090,
-    name: 'Scourge Strike',
-    icon: 'spell_deathknight_scourgestrike',
-    maxRanks: 1,
-    runesCost: 1,
-  },
-  RAISE_DEAD_UNHOLY_TALENT: { id: 46584, name: 'Raise Dead', icon: 'inv_pet_ghoul', maxRanks: 1 },
-  OUTBREAK_UNHOLY_TALENT: {
-    id: 77575,
-    name: 'Outbreak',
-    icon: 'spell_deathvortex',
-    maxRanks: 1,
-    runesCost: 1,
-  },
-  DARK_TRANSFORMATION_UNHOLY_TALENT: {
-    id: 63560,
-    name: 'Dark Transformation',
-    icon: 'achievement_boss_festergutrotface',
-    maxRanks: 1,
-  },
-  UNHOLY_BLIGHT_UNHOLY_TALENT: {
-    id: 115989,
-    name: 'Unholy Blight',
-    icon: 'spell_shadow_contagion',
-    maxRanks: 1,
-    runesCost: 1,
-  },
-  RUNIC_MASTERY_UNHOLY_TALENT: {
-    id: 390166,
-    name: 'Runic Mastery',
-    icon: 'ability_deathknight_remorselesswinters',
-    maxRanks: 2,
-  },
-  INFECTED_CLAWS_UNHOLY_TALENT: {
-    id: 207272,
-    name: 'Infected Claws',
-    icon: 'spell_deathknight_thrash_ghoul',
-    maxRanks: 1,
-  },
-  EPIDEMIC_UNHOLY_TALENT: {
-    id: 207317,
-    name: 'Epidemic',
-    icon: 'spell_nature_nullifydisease',
-    maxRanks: 1,
-    runicPowerCost: 30,
-  },
-  REPLENISHING_WOUNDS_UNHOLY_TALENT: {
-    id: 377585,
-    name: 'Replenishing Wounds',
-    icon: 'spell_yorsahj_bloodboil_purpleoil',
-    maxRanks: 1,
-  },
-  FEASTING_STRIKES_UNHOLY_TALENT: {
-    id: 390161,
-    name: 'Feasting Strikes',
-    icon: 'spell_nature_rune',
-    maxRanks: 1,
-  },
-  APOCALYPSE_UNHOLY_TALENT: {
-    id: 275699,
-    name: 'Apocalypse',
-    icon: 'artifactability_unholydeathknight_deathsembrace',
-    maxRanks: 1,
-  },
-  CLAWING_SHADOWS_UNHOLY_TALENT: {
-    id: 207311,
-    name: 'Clawing Shadows',
-    icon: 'warlock_curse_shadow',
-    maxRanks: 1,
-    runesCost: 1,
-  },
-  PLAGUEBRINGER_UNHOLY_TALENT: {
-    id: 390175,
-    name: 'Plaguebringer',
-    icon: 'spell_deathknight_plaguestrike',
-    maxRanks: 1,
-  },
-  SUDDEN_DOOM_UNHOLY_TALENT: {
-    id: 49530,
-    name: 'Sudden Doom',
-    icon: 'spell_shadow_painspike',
-    maxRanks: 1,
-  },
-  ALL_WILL_SERVE_UNHOLY_TALENT: {
-    id: 194916,
-    name: 'All Will Serve',
-    icon: 'ability_fiegndead',
-    maxRanks: 1,
-  },
-  PESTILENT_PUSTULES_UNHOLY_TALENT: {
-    id: 194917,
-    name: 'Pestilent Pustules',
-    icon: 'ability_creature_disease_03',
-    maxRanks: 1,
-  },
-  BURSTING_SORES_UNHOLY_TALENT: {
-    id: 207264,
-    name: 'Bursting Sores',
-    icon: 'ability_druid_infectedwound',
-    maxRanks: 1,
-  },
-  EBON_FEVER_UNHOLY_TALENT: {
-    id: 207269,
-    name: 'Ebon Fever',
-    icon: 'spell_shadow_creepingplague',
-    maxRanks: 1,
-  },
-  UNHOLY_COMMAND_UNHOLY_TALENT: {
-    id: 316941,
-    name: 'Unholy Command',
-    icon: 'ability_rogue_deadlymomentum',
-    maxRanks: 2,
-  },
-  MAGUS_OF_THE_DEAD_UNHOLY_TALENT: {
-    id: 390196,
-    name: 'Magus of the Dead',
-    icon: 'ability_maldraxxus_mage',
-    maxRanks: 1,
-  },
-  RUPTURED_VISCERA_UNHOLY_TALENT: {
-    id: 390236,
-    name: 'Ruptured Viscera',
-    icon: 'artifactability_unholydeathknight_flagellation',
-    maxRanks: 1,
-  },
-  IMPROVED_DEATH_COIL_UNHOLY_TALENT: {
-    id: 377580,
-    name: 'Improved Death Coil',
-    icon: 'spell_shadow_deathcoil',
-    maxRanks: 2,
-  },
-  ROTTEN_TOUCH_UNHOLY_TALENT: {
-    id: 390275,
-    name: 'Rotten Touch',
-    icon: 'ability_deathwing_grasping_tendrilsgreen',
-    maxRanks: 1,
-  },
-  UNHOLY_PACT_UNHOLY_TALENT: {
-    id: 319230,
-    name: 'Unholy Pact',
-    icon: 'spell_shadow_deathsembrace',
-    maxRanks: 1,
-  },
-  DEFILE_UNHOLY_TALENT: {
-    id: 152280,
-    name: 'Defile',
-    icon: 'spell_deathknight_defile',
-    maxRanks: 1,
-    runesCost: 1,
-  },
-  PLAGUEBEARER_UNHOLY_TALENT: {
-    id: 390279,
-    name: 'Plaguebearer',
-    icon: 'spell_shadow_plaguecloud',
-    maxRanks: 1,
-    runicPowerCost: 30,
-  },
-  PESTILENCE_UNHOLY_TALENT: {
-    id: 277234,
-    name: 'Pestilence',
-    icon: 'spell_deathknight_necroticplague',
-    maxRanks: 1,
-  },
-  ETERNAL_AGONY_UNHOLY_TALENT: {
-    id: 390268,
-    name: 'Eternal Agony',
-    icon: 'spell_necro_deathsdoor',
-    maxRanks: 1,
-  },
-  COIL_OF_DEVASTATION_UNHOLY_TALENT: {
-    id: 390270,
-    name: 'Coil of Devastation',
-    icon: 'ability_malkorok_blightofyshaarj_green',
-    maxRanks: 1,
-  },
-  HARBINGER_OF_DOOM_UNHOLY_TALENT: {
-    id: 276023,
-    name: 'Harbinger of Doom',
-    icon: 'spell_shadow_painspike',
-    maxRanks: 1,
-  },
-  REAPING_UNHOLY_TALENT: {
-    id: 377514,
-    name: 'Reaping',
-    icon: 'ability_deathwing_bloodcorruption_death',
-    maxRanks: 1,
-  },
-  DEATH_ROT_UNHOLY_TALENT: {
-    id: 377537,
-    name: 'Death Rot',
-    icon: 'ability_creature_cursed_03',
-    maxRanks: 1,
-  },
-  ARMY_OF_THE_DEAD_UNHOLY_TALENT: {
-    id: 42650,
-    name: 'Army of the Dead',
-    icon: 'spell_deathknight_armyofthedead',
-    maxRanks: 1,
-    runesCost: 1,
-  },
-  SUMMON_GARGOYLE_UNHOLY_TALENT: {
-    id: 49206,
-    name: 'Summon Gargoyle',
-    icon: 'ability_deathknight_summongargoyle',
-    maxRanks: 1,
-  },
-  FESTERMIGHT_UNHOLY_TALENT: {
-    id: 377590,
-    name: 'Festermight',
-    icon: 'ability_deathknight_festermight',
-    maxRanks: 2,
-  },
-  GHOULISH_FRENZY_UNHOLY_TALENT: {
-    id: 377587,
-    name: 'Ghoulish Frenzy',
-    icon: 'ability_warlock_baneofhavoc',
-    maxRanks: 2,
-  },
-  ARMY_OF_THE_DAMNED_UNHOLY_TALENT: {
-    id: 276837,
-    name: 'Army of the Damned',
-    icon: 'artifactability_unholydeathknight_deathsembrace',
-    maxRanks: 1,
-  },
-  MORBIDITY_UNHOLY_TALENT: {
-    id: 377592,
-    name: 'Morbidity',
-    icon: 'spell_necro_deathlyecho',
-    maxRanks: 2,
-  },
-  UNHOLY_AURA_UNHOLY_TALENT: {
-    id: 377440,
-    name: 'Unholy Aura',
-    icon: 'ability_deathknight_decomposingaura',
-    maxRanks: 2,
-  },
-  UNHOLY_ASSAULT_UNHOLY_TALENT: {
-    id: 207289,
-    name: 'Unholy Assault',
-    icon: 'spell_shadow_unholyfrenzy',
-    maxRanks: 1,
-  },
-  SUPERSTRAIN_UNHOLY_TALENT: {
-    id: 390283,
-    name: 'Superstrain',
-    icon: 'spell_deathknight_explode_ghoul',
-    maxRanks: 1,
-  },
-  COMMANDER_OF_THE_DEAD_UNHOLY_TALENT: {
-    id: 390259,
-    name: 'Commander of the Dead',
-    icon: 'spell_shadow_fumble',
-    maxRanks: 1,
-  },
+  FESTERING_STRIKE_UNHOLY_TALENT,
+  SCOURGE_STRIKE_UNHOLY_TALENT,
+  RAISE_DEAD_UNHOLY_TALENT,
+  OUTBREAK_UNHOLY_TALENT,
+  DARK_TRANSFORMATION_UNHOLY_TALENT,
+  UNHOLY_BLIGHT_UNHOLY_TALENT,
+  RUNIC_MASTERY_UNHOLY_TALENT,
+  INFECTED_CLAWS_UNHOLY_TALENT,
+  EPIDEMIC_UNHOLY_TALENT,
+  REPLENISHING_WOUNDS_UNHOLY_TALENT,
+  FEASTING_STRIKES_UNHOLY_TALENT,
+  APOCALYPSE_UNHOLY_TALENT,
+  CLAWING_SHADOWS_UNHOLY_TALENT,
+  PLAGUEBRINGER_UNHOLY_TALENT,
+  SUDDEN_DOOM_UNHOLY_TALENT,
+  ALL_WILL_SERVE_UNHOLY_TALENT,
+  PESTILENT_PUSTULES_UNHOLY_TALENT,
+  BURSTING_SORES_UNHOLY_TALENT,
+  EBON_FEVER_UNHOLY_TALENT,
+  UNHOLY_COMMAND_UNHOLY_TALENT,
+  MAGUS_OF_THE_DEAD_UNHOLY_TALENT,
+  RUPTURED_VISCERA_UNHOLY_TALENT,
+  IMPROVED_DEATH_COIL_UNHOLY_TALENT,
+  ROTTEN_TOUCH_UNHOLY_TALENT,
+  UNHOLY_PACT_UNHOLY_TALENT,
+  DEFILE_UNHOLY_TALENT,
+  PLAGUEBEARER_UNHOLY_TALENT,
+  PESTILENCE_UNHOLY_TALENT,
+  ETERNAL_AGONY_UNHOLY_TALENT,
+  COIL_OF_DEVASTATION_UNHOLY_TALENT,
+  HARBINGER_OF_DOOM_UNHOLY_TALENT,
+  REAPING_UNHOLY_TALENT,
+  DEATH_ROT_UNHOLY_TALENT,
+  ARMY_OF_THE_DEAD_UNHOLY_TALENT,
+  SUMMON_GARGOYLE_UNHOLY_TALENT,
+  FESTERMIGHT_UNHOLY_TALENT,
+  GHOULISH_FRENZY_UNHOLY_TALENT,
+  ARMY_OF_THE_DAMNED_UNHOLY_TALENT,
+  MORBIDITY_UNHOLY_TALENT,
+  UNHOLY_AURA_UNHOLY_TALENT,
+  UNHOLY_ASSAULT_UNHOLY_TALENT,
+  SUPERSTRAIN_UNHOLY_TALENT,
+  COMMANDER_OF_THE_DEAD_UNHOLY_TALENT,
 });
 
 export default talents;

--- a/src/common/TALENTS/demonhunter.ts
+++ b/src/common/TALENTS/demonhunter.ts
@@ -1,806 +1,961 @@
 // Generated file, changes will eventually be overwritten!
-import { createTalentList } from './types';
+import { createTalentList, Talent } from './types';
+
+//region Shared
+export const VENGEFUL_RETREAT_TALENT: Talent = {
+  id: 198793,
+  name: 'Vengeful Retreat',
+  icon: 'ability_demonhunter_vengefulretreat2',
+  maxRanks: 1,
+};
+export const HOT_FEET_TALENT: Talent = {
+  id: 320416,
+  name: 'Hot Feet',
+  icon: 'ability_demonhunter_felrush',
+  maxRanks: 1,
+};
+export const SIGIL_OF_FLAME_TALENT: Talent = {
+  id: 204596,
+  name: 'Sigil of Flame',
+  icon: 'ability_demonhunter_sigilofinquisition',
+  maxRanks: 1,
+};
+export const UNRESTRAINED_FURY_TALENT: Talent = {
+  id: 320770,
+  name: 'Unrestrained Fury',
+  icon: 'ability_warrior_improveddisciplines',
+  maxRanks: 2,
+};
+export const IMPRISON_TALENT: Talent = {
+  id: 217832,
+  name: 'Imprison',
+  icon: 'ability_demonhunter_imprison',
+  maxRanks: 1,
+};
+export const SHATTERED_RESTORATION_TALENT: Talent = {
+  id: 389824,
+  name: 'Shattered Restoration',
+  icon: 'ability_warlock_soulsiphon',
+  maxRanks: 2,
+};
+export const VENGEFUL_RESTRAINT_TALENT: Talent = {
+  id: 320635,
+  name: 'Vengeful Restraint',
+  icon: 'ability_demonhunter_vengefulretreat2',
+  maxRanks: 1,
+};
+export const DISRUPT_TALENT: Talent = {
+  id: 320361,
+  name: 'Disrupt',
+  icon: 'ability_demonhunter_consumemagic',
+  maxRanks: 1,
+};
+export const BOUNCING_GLAIVES_TALENT: Talent = {
+  id: 320386,
+  name: 'Bouncing Glaives',
+  icon: 'ability_demonhunter_throwglaive',
+  maxRanks: 1,
+};
+export const CONSUME_MAGIC_TALENT: Talent = {
+  id: 320313,
+  name: 'Consume Magic',
+  icon: 'spell_misc_zandalari_council_soulswap',
+  maxRanks: 1,
+};
+export const FLAMES_OF_FURY_TALENT: Talent = {
+  id: 389694,
+  name: 'Flames of Fury',
+  icon: 'ability_demonhunter_sigilofinquisition',
+  maxRanks: 1,
+};
+export const PURSUIT_TALENT: Talent = {
+  id: 320654,
+  name: 'Pursuit',
+  icon: 'ability_warlock_demonicpower',
+  maxRanks: 1,
+};
+export const DISRUPTING_FURY_TALENT: Talent = {
+  id: 183782,
+  name: 'Disrupting Fury',
+  icon: 'ability_demonhunter_consumemagic',
+  maxRanks: 1,
+};
+export const AURA_OF_PAIN_TALENT: Talent = {
+  id: 207347,
+  name: 'Aura of Pain',
+  icon: 'ability_demonhunter_immolation',
+  maxRanks: 1,
+};
+export const FELBLADE_TALENT: Talent = {
+  id: 232893,
+  name: 'Felblade',
+  icon: 'ability_demonhunter_felblade',
+  maxRanks: 1,
+};
+export const CHARRED_WARBLADES_TALENT: Talent = {
+  id: 213010,
+  name: 'Charred Warblades',
+  icon: 'spell_fire_incinerate',
+  maxRanks: 1,
+};
+export const FELFIRE_HASTE_TALENT: Talent = {
+  id: 389846,
+  name: 'Felfire Haste',
+  icon: 'inv_boots_cloth_35v4',
+  maxRanks: 1,
+};
+export const MASTER_OF_THE_GLAIVE_TALENT: Talent = {
+  id: 389763,
+  name: 'Master of the Glaive',
+  icon: 'inv_glaive_1h_demonhunter_a_01',
+  maxRanks: 1,
+};
+export const RUSH_OF_CHAOS_TALENT: Talent = {
+  id: 320421,
+  name: 'Rush of Chaos',
+  icon: 'ability_demonhunter_metamorphasisdps',
+  maxRanks: 1,
+};
+export const CONCENTRATED_SIGILS_TALENT: Talent = {
+  id: 207666,
+  name: 'Concentrated Sigils',
+  icon: 'ability_bossfelorcs_necromancer_red',
+  maxRanks: 1,
+};
+export const PRECISE_SIGILS_TALENT: Talent = {
+  id: 389799,
+  name: 'Precise Sigils',
+  icon: 'ability_bossfelorcs_necromancer_orange',
+  maxRanks: 1,
+};
+export const LOST_IN_DARKNESS_TALENT: Talent = {
+  id: 389849,
+  name: 'Lost in Darkness',
+  icon: 'inv_pet_inquisitoreye',
+  maxRanks: 1,
+};
+export const ILLIDARI_KNOWLEDGE_TALENT: Talent = {
+  id: 389696,
+  name: 'Illidari Knowledge',
+  icon: 'spell_mage_overpowered',
+  maxRanks: 2,
+};
+export const SOUL_RENDING_TALENT: Talent = {
+  id: 204909,
+  name: 'Soul Rending',
+  icon: 'ability_demonhunter_soulcleave2',
+  maxRanks: 2,
+};
+export const INFERNAL_ARMOR_TALENT: Talent = {
+  id: 320331,
+  name: 'Infernal Armor',
+  icon: 'ability_demonhunter_immolation',
+  maxRanks: 2,
+};
+export const WILL_OF_THE_ILLIDARI_TALENT: Talent = {
+  id: 389695,
+  name: 'Will of the Illidari',
+  icon: 'ability_demonhunter_spectank',
+  maxRanks: 2,
+};
+export const CHAOS_NOVA_TALENT: Talent = {
+  id: 179057,
+  name: 'Chaos Nova',
+  icon: 'spell_fire_felfirenova',
+  maxRanks: 1,
+  furyCost: 30,
+};
+export const DEMONIC_TALENT: Talent = {
+  id: 213410,
+  name: 'Demonic',
+  icon: 'spell_shadow_demonform',
+  maxRanks: 1,
+};
+export const DEMONIC_ORIGINS_TALENT: Talent = {
+  id: 235893,
+  name: 'Demonic Origins',
+  icon: 'artifactability_havocdemonhunter_anguishofthedeceiver',
+  maxRanks: 1,
+};
+export const SIGIL_OF_SILENCE_TALENT: Talent = {
+  id: 202137,
+  name: 'Sigil of Silence',
+  icon: 'ability_demonhunter_sigilofsilence',
+  maxRanks: 1,
+};
+export const CHAOS_FRAGMENTS_TALENT: Talent = {
+  id: 320412,
+  name: 'Chaos Fragments',
+  icon: 'spell_fire_felfirenova',
+  maxRanks: 1,
+};
+export const UNLEASHED_POWER_TALENT: Talent = {
+  id: 206477,
+  name: 'Unleashed Power',
+  icon: 'ability_demonhunter_chaosnova',
+  maxRanks: 1,
+};
+export const BLUR_TALENT: Talent = {
+  id: 198589,
+  name: 'Blur',
+  icon: 'ability_demonhunter_blur',
+  maxRanks: 1,
+};
+export const DARKNESS_TALENT: Talent = {
+  id: 196718,
+  name: 'Darkness',
+  icon: 'ability_demonhunter_darkness',
+  maxRanks: 1,
+};
+export const SIGIL_OF_MISERY_TALENT: Talent = {
+  id: 207684,
+  name: 'Sigil of Misery',
+  icon: 'ability_demonhunter_sigilofmisery',
+  maxRanks: 1,
+};
+export const DEMON_MUZZLE_NYI_TALENT: Talent = {
+  id: 388111,
+  name: 'Demon Muzzle [NYI]',
+  icon: 'spell_fire_fireballgreen',
+  maxRanks: 1,
+};
+export const ALDRACHI_DESIGN_TALENT: Talent = {
+  id: 391409,
+  name: 'Aldrachi Design',
+  icon: 'inv_glaive_1h_artifactaldrochi_d_01dual',
+  maxRanks: 1,
+};
+export const ERRATIC_FELHEART_TALENT: Talent = {
+  id: 391397,
+  name: 'Erratic Felheart',
+  icon: 'inv_archaeology_70_crystallineeyeofundravius',
+  maxRanks: 2,
+};
+export const LONG_NIGHT_TALENT: Talent = {
+  id: 389781,
+  name: 'Long Night',
+  icon: 'spell_fire_twilightimmolation',
+  maxRanks: 1,
+};
+export const PITCH_BLACK_TALENT: Talent = {
+  id: 389783,
+  name: 'Pitch Black',
+  icon: 'sha_spell_warlock_demonsoul',
+  maxRanks: 1,
+};
+export const THE_HUNT_TALENT: Talent = {
+  id: 370965,
+  name: 'The Hunt',
+  icon: 'ability_ardenweald_demonhunter',
+  maxRanks: 1,
+};
+export const IMPROVED_SIGIL_OF_MISERY_TALENT: Talent = {
+  id: 320418,
+  name: 'Improved Sigil of Misery',
+  icon: 'ability_demonhunter_sigilofmisery',
+  maxRanks: 1,
+};
+export const MISERY_IN_DEFEAT_TALENT: Talent = {
+  id: 388110,
+  name: 'Misery in Defeat',
+  icon: 'ability_demonhunter_sigilofmisery',
+  maxRanks: 1,
+};
+export const EXTENDED_SIGILS_TALENT: Talent = {
+  id: 389697,
+  name: 'Extended Sigils',
+  icon: 'ability_demonhunter_sigilofinquisition',
+  maxRanks: 2,
+};
+export const DESPERATE_INSTINCTS_TALENT: Talent = {
+  id: 205411,
+  name: 'Desperate Instincts',
+  icon: 'spell_shadow_manafeed',
+  maxRanks: 1,
+};
+export const UNNATURAL_MALICE_TALENT: Talent = {
+  id: 389811,
+  name: 'Unnatural Malice',
+  icon: 'spell_animaardenweald_missile',
+  maxRanks: 1,
+};
+export const FAE_EMPOWERED_ELIXIR_TALENT: Talent = {
+  id: 389819,
+  name: 'Fae Empowered Elixir',
+  icon: 'ability_demonhunter_demonictrample',
+  maxRanks: 1,
+};
+export const QUICKENED_SIGILS_TALENT: Talent = {
+  id: 209281,
+  name: 'Quickened Sigils',
+  icon: 'ability_demonhunter_concentratedsigils',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Havoc
+export const EYE_BEAM_HAVOC_TALENT: Talent = {
+  id: 198013,
+  name: 'Eye Beam',
+  icon: 'ability_demonhunter_eyebeam',
+  maxRanks: 1,
+  furyCost: 30,
+};
+export const IMPROVED_CHAOS_STRIKE_HAVOC_TALENT: Talent = {
+  id: 343206,
+  name: 'Improved Chaos Strike',
+  icon: 'ability_demonhunter_chaosstrike',
+  maxRanks: 1,
+};
+export const INSATIABLE_HUNGER_HAVOC_TALENT: Talent = {
+  id: 258876,
+  name: 'Insatiable Hunger',
+  icon: 'ability_rogue_hungerforblood',
+  maxRanks: 1,
+};
+export const DEMON_BLADES_HAVOC_TALENT: Talent = {
+  id: 203555,
+  name: 'Demon Blades',
+  icon: 'inv_weapon_shortblade_92',
+  maxRanks: 1,
+};
+export const MOARG_BIONICS_HAVOC_TALENT: Talent = {
+  id: 391275,
+  name: "Mo'arg Bionics",
+  icon: 'ability_demonhunter_throwglaive',
+  maxRanks: 1,
+};
+export const DEMONIC_APPETITE_HAVOC_TALENT: Talent = {
+  id: 206478,
+  name: 'Demonic Appetite',
+  icon: 'ability_creature_poison_01_purple',
+  maxRanks: 1,
+};
+export const IMPROVED_FEL_RUSH_HAVOC_TALENT: Talent = {
+  id: 343017,
+  name: 'Improved Fel Rush',
+  icon: 'ability_demonhunter_felrush',
+  maxRanks: 1,
+};
+export const FIRST_BLOOD_HAVOC_TALENT: Talent = {
+  id: 206416,
+  name: 'First Blood',
+  icon: 'ability_deathwing_bloodcorruption_death',
+  maxRanks: 1,
+};
+export const DANCING_WITH_FATE_HAVOC_TALENT: Talent = {
+  id: 389978,
+  name: 'Dancing with Fate',
+  icon: 'inv_polearm_1h_felfireraid_d_02',
+  maxRanks: 1,
+};
+export const BURNING_HATRED_HAVOC_TALENT: Talent = {
+  id: 320374,
+  name: 'Burning Hatred',
+  icon: 'ability_demonhunter_immolation',
+  maxRanks: 1,
+};
+export const CRITICAL_CHAOS_HAVOC_TALENT: Talent = {
+  id: 320413,
+  name: 'Critical Chaos',
+  icon: 'ability_demonhunter_chaosstrike',
+  maxRanks: 2,
+};
+export const MORTAL_DANCE_HAVOC_TALENT: Talent = {
+  id: 328725,
+  name: 'Mortal Dance',
+  icon: 'ability_demonhunter_vengefulretreat',
+  maxRanks: 1,
+};
+export const FELFIRE_HEART_HAVOC_TALENT: Talent = {
+  id: 388109,
+  name: 'Felfire Heart',
+  icon: 'ability_demonhunter_immolation',
+  maxRanks: 2,
+};
+export const INITIATIVE_HAVOC_TALENT: Talent = {
+  id: 388108,
+  name: 'Initiative',
+  icon: 'ability_rogue_surpriseattack',
+  maxRanks: 1,
+};
+export const NETHERWALK_HAVOC_TALENT: Talent = {
+  id: 196555,
+  name: 'Netherwalk',
+  icon: 'spell_warlock_demonsoul',
+  maxRanks: 1,
+};
+export const FURIOUS_GAZE_HAVOC_TALENT: Talent = {
+  id: 343311,
+  name: 'Furious Gaze',
+  icon: 'ability_demonhunter_eyebeam',
+  maxRanks: 1,
+};
+export const FEL_ERUPTION_HAVOC_TALENT: Talent = {
+  id: 211881,
+  name: 'Fel Eruption',
+  icon: 'ability_bossfellord_felspike',
+  maxRanks: 1,
+  furyCost: 10,
+};
+export const TRAIL_OF_RUIN_HAVOC_TALENT: Talent = {
+  id: 258881,
+  name: 'Trail of Ruin',
+  icon: 'ability_demonhunter_bladedance',
+  maxRanks: 1,
+};
+export const UNBOUND_CHAOS_HAVOC_TALENT: Talent = {
+  id: 347461,
+  name: 'Unbound Chaos',
+  icon: 'artifactability_vengeancedemonhunter_painbringer',
+  maxRanks: 2,
+};
+export const BLIND_FURY_HAVOC_TALENT: Talent = {
+  id: 203550,
+  name: 'Blind Fury',
+  icon: 'ability_bosskilrogg_deadeye',
+  maxRanks: 2,
+};
+export const LOOKS_CAN_KILL_HAVOC_TALENT: Talent = {
+  id: 320415,
+  name: 'Looks Can Kill',
+  icon: 'ability_demonhunter_eyebeam',
+  maxRanks: 1,
+};
+export const SERRATED_GLAIVE_HAVOC_TALENT: Talent = {
+  id: 390154,
+  name: 'Serrated Glaive',
+  icon: 'inv_glaive_1h_artifactaldrochi_d_03dual',
+  maxRanks: 2,
+};
+export const RELENTLESS_ONSLAUGHT_HAVOC_TALENT: Talent = {
+  id: 389977,
+  name: 'Relentless Onslaught',
+  icon: 'ability_demonhunter_soulcleave2',
+  maxRanks: 2,
+};
+export const TACTICAL_RETREAT_HAVOC_TALENT: Talent = {
+  id: 389688,
+  name: 'Tactical Retreat',
+  icon: 'ability_demonhunter_vengefulretreat2',
+  maxRanks: 1,
+};
+export const CHAOS_THEORY_HAVOC_TALENT: Talent = {
+  id: 389687,
+  name: 'Chaos Theory',
+  icon: 'inv_glaive_1h_artifactaldrochi_d_03dual',
+  maxRanks: 1,
+};
+export const CHAOTIC_TRANSFORMATION_HAVOC_TALENT: Talent = {
+  id: 388112,
+  name: 'Chaotic Transformation',
+  icon: 'ability_demonhunter_glide',
+  maxRanks: 1,
+};
+export const GROWING_INFERNO_HAVOC_TALENT: Talent = {
+  id: 390158,
+  name: 'Growing Inferno',
+  icon: 'spell_fel_incinerate',
+  maxRanks: 1,
+};
+export const BURNING_WOUND_NYI_HAVOC_TALENT: Talent = {
+  id: 390274,
+  name: 'Burning Wound [NYI]',
+  icon: 'spell_fire_felhellfire',
+  maxRanks: 1,
+};
+export const MOMENTUM_HAVOC_TALENT: Talent = {
+  id: 206476,
+  name: 'Momentum',
+  icon: 'ability_foundryraid_demolition',
+  maxRanks: 1,
+};
+export const ISOLATED_PREY_HAVOC_TALENT: Talent = {
+  id: 388113,
+  name: 'Isolated Prey',
+  icon: 'spell_shadow_shadesofdarkness',
+  maxRanks: 1,
+};
+export const RESTLESS_HUNTER_HAVOC_TALENT: Talent = {
+  id: 390142,
+  name: 'Restless Hunter',
+  icon: 'ability_demonhunter_doublejump',
+  maxRanks: 1,
+};
+export const INNER_DEMON_HAVOC_TALENT: Talent = {
+  id: 389693,
+  name: 'Inner Demon',
+  icon: 'ability_demonhunter_glide',
+  maxRanks: 1,
+};
+export const FEL_BOMBARDMENT_HAVOC_TALENT: Talent = {
+  id: 389969,
+  name: 'Fel Bombardment',
+  icon: 'inv_glaive_1h_npc_c_02',
+  maxRanks: 1,
+};
+export const GLAIVE_TEMPEST_HAVOC_TALENT: Talent = {
+  id: 342817,
+  name: 'Glaive Tempest',
+  icon: 'inv_glaive_1h_artifactazgalor_d_06dual',
+  maxRanks: 1,
+  furyCost: 30,
+};
+export const FEL_BARRAGE_HAVOC_TALENT: Talent = {
+  id: 258925,
+  name: 'Fel Barrage',
+  icon: 'inv_felbarrage',
+  maxRanks: 1,
+};
+export const KNOW_YOUR_ENEMY_HAVOC_TALENT: Talent = {
+  id: 388118,
+  name: 'Know Your Enemy',
+  icon: 'ability_demonhunter_eyeofleotheras',
+  maxRanks: 2,
+};
+export const RAGEFIRE_HAVOC_TALENT: Talent = {
+  id: 388107,
+  name: 'Ragefire',
+  icon: 'spell_fire_fireballgreen',
+  maxRanks: 1,
+};
+export const CYCLE_OF_HATRED_HAVOC_TALENT: Talent = {
+  id: 258887,
+  name: 'Cycle of Hatred',
+  icon: 'ability_ironmaidens_whirlofblood',
+  maxRanks: 2,
+};
+export const ELYSIAN_DECREE_HAVOC_TALENT: Talent = {
+  id: 390163,
+  name: 'Elysian Decree',
+  icon: 'ability_bastion_demonhunter',
+  maxRanks: 1,
+};
+export const SOULREND_HAVOC_TALENT: Talent = {
+  id: 388106,
+  name: 'Soulrend',
+  icon: 'ability_demonhunter_bloodlet',
+  maxRanks: 2,
+};
+export const ESSENCE_BREAK_HAVOC_TALENT: Talent = {
+  id: 258860,
+  name: 'Essence Break',
+  icon: 'spell_shadow_ritualofsacrifice',
+  maxRanks: 1,
+};
+export const SHATTERED_DESTINY_HAVOC_TALENT: Talent = {
+  id: 388116,
+  name: 'Shattered Destiny',
+  icon: 'achievement_boss_triumvirate_darknaaru',
+  maxRanks: 1,
+};
+export const ANY_MEANS_NECESSARY_HAVOC_TALENT: Talent = {
+  id: 388114,
+  name: 'Any Means Necessary',
+  icon: 'ability_warlock_demonicpower',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Vengeance
+export const FEL_DEVASTATION_VENGEANCE_TALENT: Talent = {
+  id: 212084,
+  name: 'Fel Devastation',
+  icon: 'ability_demonhunter_feldevastation',
+  maxRanks: 1,
+  furyCost: 50,
+};
+export const FRAILTY_VENGEANCE_TALENT: Talent = {
+  id: 389958,
+  name: 'Frailty',
+  icon: 'inv_icon_shadowcouncilorb_purple',
+  maxRanks: 1,
+};
+export const FIERY_BRAND_VENGEANCE_TALENT: Talent = {
+  id: 204021,
+  name: 'Fiery Brand',
+  icon: 'ability_demonhunter_fierybrand',
+  maxRanks: 1,
+};
+export const DEFLECTING_SPIKES_VENGEANCE_TALENT: Talent = {
+  id: 321028,
+  name: 'Deflecting Spikes',
+  icon: 'ability_demonhunter_demonspikes',
+  maxRanks: 1,
+};
+export const RETALIATION_VENGEANCE_TALENT: Talent = {
+  id: 389729,
+  name: 'Retaliation',
+  icon: 'ability_demonhunter_demonspikes2',
+  maxRanks: 1,
+};
+export const CALCIFIED_SPIKES_VENGEANCE_TALENT: Talent = {
+  id: 389720,
+  name: 'Calcified Spikes',
+  icon: 'ability_demonhunter_demonspikes',
+  maxRanks: 1,
+};
+export const SOUL_FURNACE_VENGEANCE_TALENT: Talent = {
+  id: 391165,
+  name: 'Soul Furnace',
+  icon: 'ability_demonhunter_soulcleave4',
+  maxRanks: 1,
+};
+export const PERFECTLY_BALANCED_GLAIVE_VENGEANCE_TALENT: Talent = {
+  id: 320387,
+  name: 'Perfectly Balanced Glaive',
+  icon: 'ability_demonhunter_throwglaive',
+  maxRanks: 1,
+};
+export const ROARING_FIRE_VENGEANCE_TALENT: Talent = {
+  id: 391178,
+  name: 'Roaring Fire',
+  icon: 'spell_fire_felflamering',
+  maxRanks: 1,
+};
+export const BURNING_BLOOD_VENGEANCE_TALENT: Talent = {
+  id: 390213,
+  name: 'Burning Blood',
+  icon: 'ability_demonhunter_immolation',
+  maxRanks: 1,
+};
+export const FEL_FLAME_FORTIFICATION_VENGEANCE_TALENT: Talent = {
+  id: 389705,
+  name: 'Fel Flame Fortification',
+  icon: 'spell_fire_felfire',
+  maxRanks: 1,
+};
+export const FEAST_OF_SOULS_VENGEANCE_TALENT: Talent = {
+  id: 207697,
+  name: 'Feast of Souls',
+  icon: 'spell_shadow_soulleech',
+  maxRanks: 1,
+};
+export const SHEAR_FURY_VENGEANCE_TALENT: Talent = {
+  id: 389997,
+  name: 'Shear Fury',
+  icon: 'ability_demonhunter_hatefulstrike',
+  maxRanks: 1,
+};
+export const FRACTURE_VENGEANCE_TALENT: Talent = {
+  id: 263642,
+  name: 'Fracture',
+  icon: 'ability_creature_felsunder',
+  maxRanks: 1,
+};
+export const CHAINS_OF_ANGER_VENGEANCE_TALENT: Talent = {
+  id: 389715,
+  name: 'Chains of Anger',
+  icon: 'ability_demonhunter_sigilofchains',
+  maxRanks: 2,
+};
+export const EXTENDED_SPIKES_VENGEANCE_TALENT: Talent = {
+  id: 389721,
+  name: 'Extended Spikes',
+  icon: 'ability_demonhunter_demonspikes',
+  maxRanks: 2,
+};
+export const AGONIZING_FLAMES_VENGEANCE_TALENT: Talent = {
+  id: 207548,
+  name: 'Agonizing Flames',
+  icon: 'achievment_raid_houroftwilight',
+  maxRanks: 2,
+};
+export const SOUL_BARRIER_VENGEANCE_TALENT: Talent = {
+  id: 263648,
+  name: 'Soul Barrier',
+  icon: 'inv_soulbarrier',
+  maxRanks: 1,
+};
+export const BULK_EXTRACTION_VENGEANCE_TALENT: Talent = {
+  id: 320341,
+  name: 'Bulk Extraction',
+  icon: 'spell_shadow_shadesofdarkness',
+  maxRanks: 1,
+};
+export const VOID_REAVER_VENGEANCE_TALENT: Talent = {
+  id: 268175,
+  name: 'Void Reaver',
+  icon: 'spell_shadow_demonicempathy',
+  maxRanks: 1,
+};
+export const VOLATILE_FLAMEBLOOD_VENGEANCE_TALENT: Talent = {
+  id: 390808,
+  name: 'Volatile Flameblood',
+  icon: 'ability_demonhunter_immolation',
+  maxRanks: 1,
+};
+export const COLLECTIVE_ANGUISH_VENGEANCE_TALENT: Talent = {
+  id: 390152,
+  name: 'Collective Anguish',
+  icon: 'artifactability_havocdemonhunter_anguishofthedeceiver',
+  maxRanks: 1,
+};
+export const FALLOUT_VENGEANCE_TALENT: Talent = {
+  id: 227174,
+  name: 'Fallout',
+  icon: 'spell_volatilefiregreen',
+  maxRanks: 1,
+};
+export const REVEL_IN_PAIN_VENGEANCE_TALENT: Talent = {
+  id: 343014,
+  name: 'Revel in Pain',
+  icon: 'ability_bossfelmagnaron_handempowered',
+  maxRanks: 1,
+};
+export const SPIRIT_BOMB_VENGEANCE_TALENT: Talent = {
+  id: 247454,
+  name: 'Spirit Bomb',
+  icon: 'inv_icon_shadowcouncilorb_purple',
+  maxRanks: 1,
+  furyCost: 45,
+};
+export const PAINBRINGER_VENGEANCE_TALENT: Talent = {
+  id: 207387,
+  name: 'Painbringer',
+  icon: 'artifactability_vengeancedemonhunter_painbringer',
+  maxRanks: 2,
+};
+export const DARKGLARE_BOON_VENGEANCE_TALENT: Talent = {
+  id: 389708,
+  name: 'Darkglare Boon',
+  icon: 'inv_jewelry_necklace_53',
+  maxRanks: 2,
+};
+export const CYCLE_OF_BINDING_VENGEANCE_TALENT: Talent = {
+  id: 389718,
+  name: 'Cycle of Binding',
+  icon: 'ability_demonhunter_sigilofinquisition',
+  maxRanks: 2,
+};
+export const SIGIL_OF_CHAINS_VENGEANCE_TALENT: Talent = {
+  id: 202138,
+  name: 'Sigil of Chains',
+  icon: 'ability_demonhunter_sigilofchains',
+  maxRanks: 1,
+};
+export const FOCUSED_CLEAVE_VENGEANCE_TALENT: Talent = {
+  id: 343207,
+  name: 'Focused Cleave',
+  icon: 'ability_demonhunter_soulcleave',
+  maxRanks: 1,
+};
+export const SOULMONGER_VENGEANCE_TALENT: Talent = {
+  id: 389711,
+  name: 'Soulmonger',
+  icon: 'ability_demonhunter_shatteredsouls',
+  maxRanks: 1,
+};
+export const RUINOUS_BULWARK_VENGEANCE_TALENT: Talent = {
+  id: 326853,
+  name: 'Ruinous Bulwark',
+  icon: 'ability_demonhunter_feldevastation',
+  maxRanks: 1,
+};
+export const BURNING_ALIVE_VENGEANCE_TALENT: Talent = {
+  id: 207739,
+  name: 'Burning Alive',
+  icon: 'spell_fire_elementaldevastation',
+  maxRanks: 1,
+};
+export const FIERY_DEMISE_VENGEANCE_TALENT: Talent = {
+  id: 389220,
+  name: 'Fiery Demise',
+  icon: 'ability_demonhunter_fierybrand',
+  maxRanks: 1,
+};
+export const VULNERABILITY_VENGEANCE_TALENT: Talent = {
+  id: 389976,
+  name: 'Vulnerability',
+  icon: 'inv_icon_shadowcouncilorb_purple',
+  maxRanks: 2,
+};
+export const FEED_THE_DEMON_VENGEANCE_TALENT: Talent = {
+  id: 218612,
+  name: 'Feed the Demon',
+  icon: 'spell_warlock_demonicempowerment',
+  maxRanks: 2,
+};
+export const CHARRED_FLESH_VENGEANCE_TALENT: Talent = {
+  id: 336639,
+  name: 'Charred Flesh',
+  icon: 'ability_warlock_backdraft',
+  maxRanks: 2,
+};
+export const THE_WEAK_WILLED_VENGEANCE_TALENT: Talent = {
+  id: 389985,
+  name: 'The Weak-Willed',
+  icon: 'inv_icon_shadowcouncilorb_purple',
+  maxRanks: 1,
+};
+export const SOUL_CARVER_VENGEANCE_TALENT: Talent = {
+  id: 207407,
+  name: 'Soul Carver',
+  icon: 'inv_glaive_1h_artifactaldrochi_d_01',
+  maxRanks: 1,
+};
+export const LAST_RESORT_VENGEANCE_TALENT: Talent = {
+  id: 209258,
+  name: 'Last Resort',
+  icon: 'inv_glaive_1h_artifactaldorchi_d_06',
+  maxRanks: 1,
+};
+export const ELYSIAN_DECREE_VENGEANCE_TALENT: Talent = {
+  id: 390163,
+  name: 'Elysian Decree',
+  icon: 'ability_bastion_demonhunter',
+  maxRanks: 1,
+};
+export const DOWN_IN_FLAMES_VENGEANCE_TALENT: Talent = {
+  id: 389732,
+  name: 'Down in Flames',
+  icon: 'ability_demonhunter_fierybrand',
+  maxRanks: 1,
+};
+
+//endregion
 
 const talents = createTalentList({
   //Shared
-  VENGEFUL_RETREAT_TALENT: {
-    id: 198793,
-    name: 'Vengeful Retreat',
-    icon: 'ability_demonhunter_vengefulretreat2',
-    maxRanks: 1,
-  },
-  HOT_FEET_TALENT: {
-    id: 320416,
-    name: 'Hot Feet',
-    icon: 'ability_demonhunter_felrush',
-    maxRanks: 1,
-  },
-  SIGIL_OF_FLAME_TALENT: {
-    id: 204596,
-    name: 'Sigil of Flame',
-    icon: 'ability_demonhunter_sigilofinquisition',
-    maxRanks: 1,
-  },
-  UNRESTRAINED_FURY_TALENT: {
-    id: 320770,
-    name: 'Unrestrained Fury',
-    icon: 'ability_warrior_improveddisciplines',
-    maxRanks: 2,
-  },
-  IMPRISON_TALENT: {
-    id: 217832,
-    name: 'Imprison',
-    icon: 'ability_demonhunter_imprison',
-    maxRanks: 1,
-  },
-  SHATTERED_RESTORATION_TALENT: {
-    id: 389824,
-    name: 'Shattered Restoration',
-    icon: 'ability_warlock_soulsiphon',
-    maxRanks: 2,
-  },
-  VENGEFUL_RESTRAINT_TALENT: {
-    id: 320635,
-    name: 'Vengeful Restraint',
-    icon: 'ability_demonhunter_vengefulretreat2',
-    maxRanks: 1,
-  },
-  DISRUPT_TALENT: {
-    id: 320361,
-    name: 'Disrupt',
-    icon: 'ability_demonhunter_consumemagic',
-    maxRanks: 1,
-  },
-  BOUNCING_GLAIVES_TALENT: {
-    id: 320386,
-    name: 'Bouncing Glaives',
-    icon: 'ability_demonhunter_throwglaive',
-    maxRanks: 1,
-  },
-  CONSUME_MAGIC_TALENT: {
-    id: 320313,
-    name: 'Consume Magic',
-    icon: 'spell_misc_zandalari_council_soulswap',
-    maxRanks: 1,
-  },
-  FLAMES_OF_FURY_TALENT: {
-    id: 389694,
-    name: 'Flames of Fury',
-    icon: 'ability_demonhunter_sigilofinquisition',
-    maxRanks: 1,
-  },
-  PURSUIT_TALENT: {
-    id: 320654,
-    name: 'Pursuit',
-    icon: 'ability_warlock_demonicpower',
-    maxRanks: 1,
-  },
-  DISRUPTING_FURY_TALENT: {
-    id: 183782,
-    name: 'Disrupting Fury',
-    icon: 'ability_demonhunter_consumemagic',
-    maxRanks: 1,
-  },
-  AURA_OF_PAIN_TALENT: {
-    id: 207347,
-    name: 'Aura of Pain',
-    icon: 'ability_demonhunter_immolation',
-    maxRanks: 1,
-  },
-  FELBLADE_TALENT: {
-    id: 232893,
-    name: 'Felblade',
-    icon: 'ability_demonhunter_felblade',
-    maxRanks: 1,
-  },
-  CHARRED_WARBLADES_TALENT: {
-    id: 213010,
-    name: 'Charred Warblades',
-    icon: 'spell_fire_incinerate',
-    maxRanks: 1,
-  },
-  FELFIRE_HASTE_TALENT: {
-    id: 389846,
-    name: 'Felfire Haste',
-    icon: 'inv_boots_cloth_35v4',
-    maxRanks: 1,
-  },
-  MASTER_OF_THE_GLAIVE_TALENT: {
-    id: 389763,
-    name: 'Master of the Glaive',
-    icon: 'inv_glaive_1h_demonhunter_a_01',
-    maxRanks: 1,
-  },
-  RUSH_OF_CHAOS_TALENT: {
-    id: 320421,
-    name: 'Rush of Chaos',
-    icon: 'ability_demonhunter_metamorphasisdps',
-    maxRanks: 1,
-  },
-  CONCENTRATED_SIGILS_TALENT: {
-    id: 207666,
-    name: 'Concentrated Sigils',
-    icon: 'ability_bossfelorcs_necromancer_red',
-    maxRanks: 1,
-  },
-  PRECISE_SIGILS_TALENT: {
-    id: 389799,
-    name: 'Precise Sigils',
-    icon: 'ability_bossfelorcs_necromancer_orange',
-    maxRanks: 1,
-  },
-  LOST_IN_DARKNESS_TALENT: {
-    id: 389849,
-    name: 'Lost in Darkness',
-    icon: 'inv_pet_inquisitoreye',
-    maxRanks: 1,
-  },
-  ILLIDARI_KNOWLEDGE_TALENT: {
-    id: 389696,
-    name: 'Illidari Knowledge',
-    icon: 'spell_mage_overpowered',
-    maxRanks: 2,
-  },
-  SOUL_RENDING_TALENT: {
-    id: 204909,
-    name: 'Soul Rending',
-    icon: 'ability_demonhunter_soulcleave2',
-    maxRanks: 2,
-  },
-  INFERNAL_ARMOR_TALENT: {
-    id: 320331,
-    name: 'Infernal Armor',
-    icon: 'ability_demonhunter_immolation',
-    maxRanks: 2,
-  },
-  WILL_OF_THE_ILLIDARI_TALENT: {
-    id: 389695,
-    name: 'Will of the Illidari',
-    icon: 'ability_demonhunter_spectank',
-    maxRanks: 2,
-  },
-  CHAOS_NOVA_TALENT: {
-    id: 179057,
-    name: 'Chaos Nova',
-    icon: 'spell_fire_felfirenova',
-    maxRanks: 1,
-    furyCost: 30,
-  },
-  DEMONIC_TALENT: { id: 213410, name: 'Demonic', icon: 'spell_shadow_demonform', maxRanks: 1 },
-  DEMONIC_ORIGINS_TALENT: {
-    id: 235893,
-    name: 'Demonic Origins',
-    icon: 'artifactability_havocdemonhunter_anguishofthedeceiver',
-    maxRanks: 1,
-  },
-  SIGIL_OF_SILENCE_TALENT: {
-    id: 202137,
-    name: 'Sigil of Silence',
-    icon: 'ability_demonhunter_sigilofsilence',
-    maxRanks: 1,
-  },
-  CHAOS_FRAGMENTS_TALENT: {
-    id: 320412,
-    name: 'Chaos Fragments',
-    icon: 'spell_fire_felfirenova',
-    maxRanks: 1,
-  },
-  UNLEASHED_POWER_TALENT: {
-    id: 206477,
-    name: 'Unleashed Power',
-    icon: 'ability_demonhunter_chaosnova',
-    maxRanks: 1,
-  },
-  BLUR_TALENT: { id: 198589, name: 'Blur', icon: 'ability_demonhunter_blur', maxRanks: 1 },
-  DARKNESS_TALENT: {
-    id: 196718,
-    name: 'Darkness',
-    icon: 'ability_demonhunter_darkness',
-    maxRanks: 1,
-  },
-  SIGIL_OF_MISERY_TALENT: {
-    id: 207684,
-    name: 'Sigil of Misery',
-    icon: 'ability_demonhunter_sigilofmisery',
-    maxRanks: 1,
-  },
-  DEMON_MUZZLE_NYI_TALENT: {
-    id: 388111,
-    name: 'Demon Muzzle [NYI]',
-    icon: 'spell_fire_fireballgreen',
-    maxRanks: 1,
-  },
-  ALDRACHI_DESIGN_TALENT: {
-    id: 391409,
-    name: 'Aldrachi Design',
-    icon: 'inv_glaive_1h_artifactaldrochi_d_01dual',
-    maxRanks: 1,
-  },
-  ERRATIC_FELHEART_TALENT: {
-    id: 391397,
-    name: 'Erratic Felheart',
-    icon: 'inv_archaeology_70_crystallineeyeofundravius',
-    maxRanks: 2,
-  },
-  LONG_NIGHT_TALENT: {
-    id: 389781,
-    name: 'Long Night',
-    icon: 'spell_fire_twilightimmolation',
-    maxRanks: 1,
-  },
-  PITCH_BLACK_TALENT: {
-    id: 389783,
-    name: 'Pitch Black',
-    icon: 'sha_spell_warlock_demonsoul',
-    maxRanks: 1,
-  },
-  THE_HUNT_TALENT: {
-    id: 370965,
-    name: 'The Hunt',
-    icon: 'ability_ardenweald_demonhunter',
-    maxRanks: 1,
-  },
-  IMPROVED_SIGIL_OF_MISERY_TALENT: {
-    id: 320418,
-    name: 'Improved Sigil of Misery',
-    icon: 'ability_demonhunter_sigilofmisery',
-    maxRanks: 1,
-  },
-  MISERY_IN_DEFEAT_TALENT: {
-    id: 388110,
-    name: 'Misery in Defeat',
-    icon: 'ability_demonhunter_sigilofmisery',
-    maxRanks: 1,
-  },
-  EXTENDED_SIGILS_TALENT: {
-    id: 389697,
-    name: 'Extended Sigils',
-    icon: 'ability_demonhunter_sigilofinquisition',
-    maxRanks: 2,
-  },
-  DESPERATE_INSTINCTS_TALENT: {
-    id: 205411,
-    name: 'Desperate Instincts',
-    icon: 'spell_shadow_manafeed',
-    maxRanks: 1,
-  },
-  UNNATURAL_MALICE_TALENT: {
-    id: 389811,
-    name: 'Unnatural Malice',
-    icon: 'spell_animaardenweald_missile',
-    maxRanks: 1,
-  },
-  FAE_EMPOWERED_ELIXIR_TALENT: {
-    id: 389819,
-    name: 'Fae Empowered Elixir',
-    icon: 'ability_demonhunter_demonictrample',
-    maxRanks: 1,
-  },
-  QUICKENED_SIGILS_TALENT: {
-    id: 209281,
-    name: 'Quickened Sigils',
-    icon: 'ability_demonhunter_concentratedsigils',
-    maxRanks: 1,
-  },
+  VENGEFUL_RETREAT_TALENT,
+  HOT_FEET_TALENT,
+  SIGIL_OF_FLAME_TALENT,
+  UNRESTRAINED_FURY_TALENT,
+  IMPRISON_TALENT,
+  SHATTERED_RESTORATION_TALENT,
+  VENGEFUL_RESTRAINT_TALENT,
+  DISRUPT_TALENT,
+  BOUNCING_GLAIVES_TALENT,
+  CONSUME_MAGIC_TALENT,
+  FLAMES_OF_FURY_TALENT,
+  PURSUIT_TALENT,
+  DISRUPTING_FURY_TALENT,
+  AURA_OF_PAIN_TALENT,
+  FELBLADE_TALENT,
+  CHARRED_WARBLADES_TALENT,
+  FELFIRE_HASTE_TALENT,
+  MASTER_OF_THE_GLAIVE_TALENT,
+  RUSH_OF_CHAOS_TALENT,
+  CONCENTRATED_SIGILS_TALENT,
+  PRECISE_SIGILS_TALENT,
+  LOST_IN_DARKNESS_TALENT,
+  ILLIDARI_KNOWLEDGE_TALENT,
+  SOUL_RENDING_TALENT,
+  INFERNAL_ARMOR_TALENT,
+  WILL_OF_THE_ILLIDARI_TALENT,
+  CHAOS_NOVA_TALENT,
+  DEMONIC_TALENT,
+  DEMONIC_ORIGINS_TALENT,
+  SIGIL_OF_SILENCE_TALENT,
+  CHAOS_FRAGMENTS_TALENT,
+  UNLEASHED_POWER_TALENT,
+  BLUR_TALENT,
+  DARKNESS_TALENT,
+  SIGIL_OF_MISERY_TALENT,
+  DEMON_MUZZLE_NYI_TALENT,
+  ALDRACHI_DESIGN_TALENT,
+  ERRATIC_FELHEART_TALENT,
+  LONG_NIGHT_TALENT,
+  PITCH_BLACK_TALENT,
+  THE_HUNT_TALENT,
+  IMPROVED_SIGIL_OF_MISERY_TALENT,
+  MISERY_IN_DEFEAT_TALENT,
+  EXTENDED_SIGILS_TALENT,
+  DESPERATE_INSTINCTS_TALENT,
+  UNNATURAL_MALICE_TALENT,
+  FAE_EMPOWERED_ELIXIR_TALENT,
+  QUICKENED_SIGILS_TALENT,
 
   //Havoc
-  EYE_BEAM_HAVOC_TALENT: {
-    id: 198013,
-    name: 'Eye Beam',
-    icon: 'ability_demonhunter_eyebeam',
-    maxRanks: 1,
-    furyCost: 30,
-  },
-  IMPROVED_CHAOS_STRIKE_HAVOC_TALENT: {
-    id: 343206,
-    name: 'Improved Chaos Strike',
-    icon: 'ability_demonhunter_chaosstrike',
-    maxRanks: 1,
-  },
-  INSATIABLE_HUNGER_HAVOC_TALENT: {
-    id: 258876,
-    name: 'Insatiable Hunger',
-    icon: 'ability_rogue_hungerforblood',
-    maxRanks: 1,
-  },
-  DEMON_BLADES_HAVOC_TALENT: {
-    id: 203555,
-    name: 'Demon Blades',
-    icon: 'inv_weapon_shortblade_92',
-    maxRanks: 1,
-  },
-  MOARG_BIONICS_HAVOC_TALENT: {
-    id: 391275,
-    name: "Mo'arg Bionics",
-    icon: 'ability_demonhunter_throwglaive',
-    maxRanks: 1,
-  },
-  DEMONIC_APPETITE_HAVOC_TALENT: {
-    id: 206478,
-    name: 'Demonic Appetite',
-    icon: 'ability_creature_poison_01_purple',
-    maxRanks: 1,
-  },
-  IMPROVED_FEL_RUSH_HAVOC_TALENT: {
-    id: 343017,
-    name: 'Improved Fel Rush',
-    icon: 'ability_demonhunter_felrush',
-    maxRanks: 1,
-  },
-  FIRST_BLOOD_HAVOC_TALENT: {
-    id: 206416,
-    name: 'First Blood',
-    icon: 'ability_deathwing_bloodcorruption_death',
-    maxRanks: 1,
-  },
-  DANCING_WITH_FATE_HAVOC_TALENT: {
-    id: 389978,
-    name: 'Dancing with Fate',
-    icon: 'inv_polearm_1h_felfireraid_d_02',
-    maxRanks: 1,
-  },
-  BURNING_HATRED_HAVOC_TALENT: {
-    id: 320374,
-    name: 'Burning Hatred',
-    icon: 'ability_demonhunter_immolation',
-    maxRanks: 1,
-  },
-  CRITICAL_CHAOS_HAVOC_TALENT: {
-    id: 320413,
-    name: 'Critical Chaos',
-    icon: 'ability_demonhunter_chaosstrike',
-    maxRanks: 2,
-  },
-  MORTAL_DANCE_HAVOC_TALENT: {
-    id: 328725,
-    name: 'Mortal Dance',
-    icon: 'ability_demonhunter_vengefulretreat',
-    maxRanks: 1,
-  },
-  FELFIRE_HEART_HAVOC_TALENT: {
-    id: 388109,
-    name: 'Felfire Heart',
-    icon: 'ability_demonhunter_immolation',
-    maxRanks: 2,
-  },
-  INITIATIVE_HAVOC_TALENT: {
-    id: 388108,
-    name: 'Initiative',
-    icon: 'ability_rogue_surpriseattack',
-    maxRanks: 1,
-  },
-  NETHERWALK_HAVOC_TALENT: {
-    id: 196555,
-    name: 'Netherwalk',
-    icon: 'spell_warlock_demonsoul',
-    maxRanks: 1,
-  },
-  FURIOUS_GAZE_HAVOC_TALENT: {
-    id: 343311,
-    name: 'Furious Gaze',
-    icon: 'ability_demonhunter_eyebeam',
-    maxRanks: 1,
-  },
-  FEL_ERUPTION_HAVOC_TALENT: {
-    id: 211881,
-    name: 'Fel Eruption',
-    icon: 'ability_bossfellord_felspike',
-    maxRanks: 1,
-    furyCost: 10,
-  },
-  TRAIL_OF_RUIN_HAVOC_TALENT: {
-    id: 258881,
-    name: 'Trail of Ruin',
-    icon: 'ability_demonhunter_bladedance',
-    maxRanks: 1,
-  },
-  UNBOUND_CHAOS_HAVOC_TALENT: {
-    id: 347461,
-    name: 'Unbound Chaos',
-    icon: 'artifactability_vengeancedemonhunter_painbringer',
-    maxRanks: 2,
-  },
-  BLIND_FURY_HAVOC_TALENT: {
-    id: 203550,
-    name: 'Blind Fury',
-    icon: 'ability_bosskilrogg_deadeye',
-    maxRanks: 2,
-  },
-  LOOKS_CAN_KILL_HAVOC_TALENT: {
-    id: 320415,
-    name: 'Looks Can Kill',
-    icon: 'ability_demonhunter_eyebeam',
-    maxRanks: 1,
-  },
-  SERRATED_GLAIVE_HAVOC_TALENT: {
-    id: 390154,
-    name: 'Serrated Glaive',
-    icon: 'inv_glaive_1h_artifactaldrochi_d_03dual',
-    maxRanks: 2,
-  },
-  RELENTLESS_ONSLAUGHT_HAVOC_TALENT: {
-    id: 389977,
-    name: 'Relentless Onslaught',
-    icon: 'ability_demonhunter_soulcleave2',
-    maxRanks: 2,
-  },
-  TACTICAL_RETREAT_HAVOC_TALENT: {
-    id: 389688,
-    name: 'Tactical Retreat',
-    icon: 'ability_demonhunter_vengefulretreat2',
-    maxRanks: 1,
-  },
-  CHAOS_THEORY_HAVOC_TALENT: {
-    id: 389687,
-    name: 'Chaos Theory',
-    icon: 'inv_glaive_1h_artifactaldrochi_d_03dual',
-    maxRanks: 1,
-  },
-  CHAOTIC_TRANSFORMATION_HAVOC_TALENT: {
-    id: 388112,
-    name: 'Chaotic Transformation',
-    icon: 'ability_demonhunter_glide',
-    maxRanks: 1,
-  },
-  GROWING_INFERNO_HAVOC_TALENT: {
-    id: 390158,
-    name: 'Growing Inferno',
-    icon: 'spell_fel_incinerate',
-    maxRanks: 1,
-  },
-  BURNING_WOUND_NYI_HAVOC_TALENT: {
-    id: 390274,
-    name: 'Burning Wound [NYI]',
-    icon: 'spell_fire_felhellfire',
-    maxRanks: 1,
-  },
-  MOMENTUM_HAVOC_TALENT: {
-    id: 206476,
-    name: 'Momentum',
-    icon: 'ability_foundryraid_demolition',
-    maxRanks: 1,
-  },
-  ISOLATED_PREY_HAVOC_TALENT: {
-    id: 388113,
-    name: 'Isolated Prey',
-    icon: 'spell_shadow_shadesofdarkness',
-    maxRanks: 1,
-  },
-  RESTLESS_HUNTER_HAVOC_TALENT: {
-    id: 390142,
-    name: 'Restless Hunter',
-    icon: 'ability_demonhunter_doublejump',
-    maxRanks: 1,
-  },
-  INNER_DEMON_HAVOC_TALENT: {
-    id: 389693,
-    name: 'Inner Demon',
-    icon: 'ability_demonhunter_glide',
-    maxRanks: 1,
-  },
-  FEL_BOMBARDMENT_HAVOC_TALENT: {
-    id: 389969,
-    name: 'Fel Bombardment',
-    icon: 'inv_glaive_1h_npc_c_02',
-    maxRanks: 1,
-  },
-  GLAIVE_TEMPEST_HAVOC_TALENT: {
-    id: 342817,
-    name: 'Glaive Tempest',
-    icon: 'inv_glaive_1h_artifactazgalor_d_06dual',
-    maxRanks: 1,
-    furyCost: 30,
-  },
-  FEL_BARRAGE_HAVOC_TALENT: {
-    id: 258925,
-    name: 'Fel Barrage',
-    icon: 'inv_felbarrage',
-    maxRanks: 1,
-  },
-  KNOW_YOUR_ENEMY_HAVOC_TALENT: {
-    id: 388118,
-    name: 'Know Your Enemy',
-    icon: 'ability_demonhunter_eyeofleotheras',
-    maxRanks: 2,
-  },
-  RAGEFIRE_HAVOC_TALENT: {
-    id: 388107,
-    name: 'Ragefire',
-    icon: 'spell_fire_fireballgreen',
-    maxRanks: 1,
-  },
-  CYCLE_OF_HATRED_HAVOC_TALENT: {
-    id: 258887,
-    name: 'Cycle of Hatred',
-    icon: 'ability_ironmaidens_whirlofblood',
-    maxRanks: 2,
-  },
-  ELYSIAN_DECREE_HAVOC_TALENT: {
-    id: 390163,
-    name: 'Elysian Decree',
-    icon: 'ability_bastion_demonhunter',
-    maxRanks: 1,
-  },
-  SOULREND_HAVOC_TALENT: {
-    id: 388106,
-    name: 'Soulrend',
-    icon: 'ability_demonhunter_bloodlet',
-    maxRanks: 2,
-  },
-  ESSENCE_BREAK_HAVOC_TALENT: {
-    id: 258860,
-    name: 'Essence Break',
-    icon: 'spell_shadow_ritualofsacrifice',
-    maxRanks: 1,
-  },
-  SHATTERED_DESTINY_HAVOC_TALENT: {
-    id: 388116,
-    name: 'Shattered Destiny',
-    icon: 'achievement_boss_triumvirate_darknaaru',
-    maxRanks: 1,
-  },
-  ANY_MEANS_NECESSARY_HAVOC_TALENT: {
-    id: 388114,
-    name: 'Any Means Necessary',
-    icon: 'ability_warlock_demonicpower',
-    maxRanks: 1,
-  },
+  EYE_BEAM_HAVOC_TALENT,
+  IMPROVED_CHAOS_STRIKE_HAVOC_TALENT,
+  INSATIABLE_HUNGER_HAVOC_TALENT,
+  DEMON_BLADES_HAVOC_TALENT,
+  MOARG_BIONICS_HAVOC_TALENT,
+  DEMONIC_APPETITE_HAVOC_TALENT,
+  IMPROVED_FEL_RUSH_HAVOC_TALENT,
+  FIRST_BLOOD_HAVOC_TALENT,
+  DANCING_WITH_FATE_HAVOC_TALENT,
+  BURNING_HATRED_HAVOC_TALENT,
+  CRITICAL_CHAOS_HAVOC_TALENT,
+  MORTAL_DANCE_HAVOC_TALENT,
+  FELFIRE_HEART_HAVOC_TALENT,
+  INITIATIVE_HAVOC_TALENT,
+  NETHERWALK_HAVOC_TALENT,
+  FURIOUS_GAZE_HAVOC_TALENT,
+  FEL_ERUPTION_HAVOC_TALENT,
+  TRAIL_OF_RUIN_HAVOC_TALENT,
+  UNBOUND_CHAOS_HAVOC_TALENT,
+  BLIND_FURY_HAVOC_TALENT,
+  LOOKS_CAN_KILL_HAVOC_TALENT,
+  SERRATED_GLAIVE_HAVOC_TALENT,
+  RELENTLESS_ONSLAUGHT_HAVOC_TALENT,
+  TACTICAL_RETREAT_HAVOC_TALENT,
+  CHAOS_THEORY_HAVOC_TALENT,
+  CHAOTIC_TRANSFORMATION_HAVOC_TALENT,
+  GROWING_INFERNO_HAVOC_TALENT,
+  BURNING_WOUND_NYI_HAVOC_TALENT,
+  MOMENTUM_HAVOC_TALENT,
+  ISOLATED_PREY_HAVOC_TALENT,
+  RESTLESS_HUNTER_HAVOC_TALENT,
+  INNER_DEMON_HAVOC_TALENT,
+  FEL_BOMBARDMENT_HAVOC_TALENT,
+  GLAIVE_TEMPEST_HAVOC_TALENT,
+  FEL_BARRAGE_HAVOC_TALENT,
+  KNOW_YOUR_ENEMY_HAVOC_TALENT,
+  RAGEFIRE_HAVOC_TALENT,
+  CYCLE_OF_HATRED_HAVOC_TALENT,
+  ELYSIAN_DECREE_HAVOC_TALENT,
+  SOULREND_HAVOC_TALENT,
+  ESSENCE_BREAK_HAVOC_TALENT,
+  SHATTERED_DESTINY_HAVOC_TALENT,
+  ANY_MEANS_NECESSARY_HAVOC_TALENT,
 
   //Vengeance
-  FEL_DEVASTATION_VENGEANCE_TALENT: {
-    id: 212084,
-    name: 'Fel Devastation',
-    icon: 'ability_demonhunter_feldevastation',
-    maxRanks: 1,
-    furyCost: 50,
-  },
-  FRAILTY_VENGEANCE_TALENT: {
-    id: 389958,
-    name: 'Frailty',
-    icon: 'inv_icon_shadowcouncilorb_purple',
-    maxRanks: 1,
-  },
-  FIERY_BRAND_VENGEANCE_TALENT: {
-    id: 204021,
-    name: 'Fiery Brand',
-    icon: 'ability_demonhunter_fierybrand',
-    maxRanks: 1,
-  },
-  DEFLECTING_SPIKES_VENGEANCE_TALENT: {
-    id: 321028,
-    name: 'Deflecting Spikes',
-    icon: 'ability_demonhunter_demonspikes',
-    maxRanks: 1,
-  },
-  RETALIATION_VENGEANCE_TALENT: {
-    id: 389729,
-    name: 'Retaliation',
-    icon: 'ability_demonhunter_demonspikes2',
-    maxRanks: 1,
-  },
-  CALCIFIED_SPIKES_VENGEANCE_TALENT: {
-    id: 389720,
-    name: 'Calcified Spikes',
-    icon: 'ability_demonhunter_demonspikes',
-    maxRanks: 1,
-  },
-  SOUL_FURNACE_VENGEANCE_TALENT: {
-    id: 391165,
-    name: 'Soul Furnace',
-    icon: 'ability_demonhunter_soulcleave4',
-    maxRanks: 1,
-  },
-  PERFECTLY_BALANCED_GLAIVE_VENGEANCE_TALENT: {
-    id: 320387,
-    name: 'Perfectly Balanced Glaive',
-    icon: 'ability_demonhunter_throwglaive',
-    maxRanks: 1,
-  },
-  ROARING_FIRE_VENGEANCE_TALENT: {
-    id: 391178,
-    name: 'Roaring Fire',
-    icon: 'spell_fire_felflamering',
-    maxRanks: 1,
-  },
-  BURNING_BLOOD_VENGEANCE_TALENT: {
-    id: 390213,
-    name: 'Burning Blood',
-    icon: 'ability_demonhunter_immolation',
-    maxRanks: 1,
-  },
-  FEL_FLAME_FORTIFICATION_VENGEANCE_TALENT: {
-    id: 389705,
-    name: 'Fel Flame Fortification',
-    icon: 'spell_fire_felfire',
-    maxRanks: 1,
-  },
-  FEAST_OF_SOULS_VENGEANCE_TALENT: {
-    id: 207697,
-    name: 'Feast of Souls',
-    icon: 'spell_shadow_soulleech',
-    maxRanks: 1,
-  },
-  SHEAR_FURY_VENGEANCE_TALENT: {
-    id: 389997,
-    name: 'Shear Fury',
-    icon: 'ability_demonhunter_hatefulstrike',
-    maxRanks: 1,
-  },
-  FRACTURE_VENGEANCE_TALENT: {
-    id: 263642,
-    name: 'Fracture',
-    icon: 'ability_creature_felsunder',
-    maxRanks: 1,
-  },
-  CHAINS_OF_ANGER_VENGEANCE_TALENT: {
-    id: 389715,
-    name: 'Chains of Anger',
-    icon: 'ability_demonhunter_sigilofchains',
-    maxRanks: 2,
-  },
-  EXTENDED_SPIKES_VENGEANCE_TALENT: {
-    id: 389721,
-    name: 'Extended Spikes',
-    icon: 'ability_demonhunter_demonspikes',
-    maxRanks: 2,
-  },
-  AGONIZING_FLAMES_VENGEANCE_TALENT: {
-    id: 207548,
-    name: 'Agonizing Flames',
-    icon: 'achievment_raid_houroftwilight',
-    maxRanks: 2,
-  },
-  SOUL_BARRIER_VENGEANCE_TALENT: {
-    id: 263648,
-    name: 'Soul Barrier',
-    icon: 'inv_soulbarrier',
-    maxRanks: 1,
-  },
-  BULK_EXTRACTION_VENGEANCE_TALENT: {
-    id: 320341,
-    name: 'Bulk Extraction',
-    icon: 'spell_shadow_shadesofdarkness',
-    maxRanks: 1,
-  },
-  VOID_REAVER_VENGEANCE_TALENT: {
-    id: 268175,
-    name: 'Void Reaver',
-    icon: 'spell_shadow_demonicempathy',
-    maxRanks: 1,
-  },
-  VOLATILE_FLAMEBLOOD_VENGEANCE_TALENT: {
-    id: 390808,
-    name: 'Volatile Flameblood',
-    icon: 'ability_demonhunter_immolation',
-    maxRanks: 1,
-  },
-  COLLECTIVE_ANGUISH_VENGEANCE_TALENT: {
-    id: 390152,
-    name: 'Collective Anguish',
-    icon: 'artifactability_havocdemonhunter_anguishofthedeceiver',
-    maxRanks: 1,
-  },
-  FALLOUT_VENGEANCE_TALENT: {
-    id: 227174,
-    name: 'Fallout',
-    icon: 'spell_volatilefiregreen',
-    maxRanks: 1,
-  },
-  REVEL_IN_PAIN_VENGEANCE_TALENT: {
-    id: 343014,
-    name: 'Revel in Pain',
-    icon: 'ability_bossfelmagnaron_handempowered',
-    maxRanks: 1,
-  },
-  SPIRIT_BOMB_VENGEANCE_TALENT: {
-    id: 247454,
-    name: 'Spirit Bomb',
-    icon: 'inv_icon_shadowcouncilorb_purple',
-    maxRanks: 1,
-    furyCost: 45,
-  },
-  PAINBRINGER_VENGEANCE_TALENT: {
-    id: 207387,
-    name: 'Painbringer',
-    icon: 'artifactability_vengeancedemonhunter_painbringer',
-    maxRanks: 2,
-  },
-  DARKGLARE_BOON_VENGEANCE_TALENT: {
-    id: 389708,
-    name: 'Darkglare Boon',
-    icon: 'inv_jewelry_necklace_53',
-    maxRanks: 2,
-  },
-  CYCLE_OF_BINDING_VENGEANCE_TALENT: {
-    id: 389718,
-    name: 'Cycle of Binding',
-    icon: 'ability_demonhunter_sigilofinquisition',
-    maxRanks: 2,
-  },
-  SIGIL_OF_CHAINS_VENGEANCE_TALENT: {
-    id: 202138,
-    name: 'Sigil of Chains',
-    icon: 'ability_demonhunter_sigilofchains',
-    maxRanks: 1,
-  },
-  FOCUSED_CLEAVE_VENGEANCE_TALENT: {
-    id: 343207,
-    name: 'Focused Cleave',
-    icon: 'ability_demonhunter_soulcleave',
-    maxRanks: 1,
-  },
-  SOULMONGER_VENGEANCE_TALENT: {
-    id: 389711,
-    name: 'Soulmonger',
-    icon: 'ability_demonhunter_shatteredsouls',
-    maxRanks: 1,
-  },
-  RUINOUS_BULWARK_VENGEANCE_TALENT: {
-    id: 326853,
-    name: 'Ruinous Bulwark',
-    icon: 'ability_demonhunter_feldevastation',
-    maxRanks: 1,
-  },
-  BURNING_ALIVE_VENGEANCE_TALENT: {
-    id: 207739,
-    name: 'Burning Alive',
-    icon: 'spell_fire_elementaldevastation',
-    maxRanks: 1,
-  },
-  FIERY_DEMISE_VENGEANCE_TALENT: {
-    id: 389220,
-    name: 'Fiery Demise',
-    icon: 'ability_demonhunter_fierybrand',
-    maxRanks: 1,
-  },
-  VULNERABILITY_VENGEANCE_TALENT: {
-    id: 389976,
-    name: 'Vulnerability',
-    icon: 'inv_icon_shadowcouncilorb_purple',
-    maxRanks: 2,
-  },
-  FEED_THE_DEMON_VENGEANCE_TALENT: {
-    id: 218612,
-    name: 'Feed the Demon',
-    icon: 'spell_warlock_demonicempowerment',
-    maxRanks: 2,
-  },
-  CHARRED_FLESH_VENGEANCE_TALENT: {
-    id: 336639,
-    name: 'Charred Flesh',
-    icon: 'ability_warlock_backdraft',
-    maxRanks: 2,
-  },
-  THE_WEAK_WILLED_VENGEANCE_TALENT: {
-    id: 389985,
-    name: 'The Weak-Willed',
-    icon: 'inv_icon_shadowcouncilorb_purple',
-    maxRanks: 1,
-  },
-  SOUL_CARVER_VENGEANCE_TALENT: {
-    id: 207407,
-    name: 'Soul Carver',
-    icon: 'inv_glaive_1h_artifactaldrochi_d_01',
-    maxRanks: 1,
-  },
-  LAST_RESORT_VENGEANCE_TALENT: {
-    id: 209258,
-    name: 'Last Resort',
-    icon: 'inv_glaive_1h_artifactaldorchi_d_06',
-    maxRanks: 1,
-  },
-  ELYSIAN_DECREE_VENGEANCE_TALENT: {
-    id: 390163,
-    name: 'Elysian Decree',
-    icon: 'ability_bastion_demonhunter',
-    maxRanks: 1,
-  },
-  DOWN_IN_FLAMES_VENGEANCE_TALENT: {
-    id: 389732,
-    name: 'Down in Flames',
-    icon: 'ability_demonhunter_fierybrand',
-    maxRanks: 1,
-  },
+  FEL_DEVASTATION_VENGEANCE_TALENT,
+  FRAILTY_VENGEANCE_TALENT,
+  FIERY_BRAND_VENGEANCE_TALENT,
+  DEFLECTING_SPIKES_VENGEANCE_TALENT,
+  RETALIATION_VENGEANCE_TALENT,
+  CALCIFIED_SPIKES_VENGEANCE_TALENT,
+  SOUL_FURNACE_VENGEANCE_TALENT,
+  PERFECTLY_BALANCED_GLAIVE_VENGEANCE_TALENT,
+  ROARING_FIRE_VENGEANCE_TALENT,
+  BURNING_BLOOD_VENGEANCE_TALENT,
+  FEL_FLAME_FORTIFICATION_VENGEANCE_TALENT,
+  FEAST_OF_SOULS_VENGEANCE_TALENT,
+  SHEAR_FURY_VENGEANCE_TALENT,
+  FRACTURE_VENGEANCE_TALENT,
+  CHAINS_OF_ANGER_VENGEANCE_TALENT,
+  EXTENDED_SPIKES_VENGEANCE_TALENT,
+  AGONIZING_FLAMES_VENGEANCE_TALENT,
+  SOUL_BARRIER_VENGEANCE_TALENT,
+  BULK_EXTRACTION_VENGEANCE_TALENT,
+  VOID_REAVER_VENGEANCE_TALENT,
+  VOLATILE_FLAMEBLOOD_VENGEANCE_TALENT,
+  COLLECTIVE_ANGUISH_VENGEANCE_TALENT,
+  FALLOUT_VENGEANCE_TALENT,
+  REVEL_IN_PAIN_VENGEANCE_TALENT,
+  SPIRIT_BOMB_VENGEANCE_TALENT,
+  PAINBRINGER_VENGEANCE_TALENT,
+  DARKGLARE_BOON_VENGEANCE_TALENT,
+  CYCLE_OF_BINDING_VENGEANCE_TALENT,
+  SIGIL_OF_CHAINS_VENGEANCE_TALENT,
+  FOCUSED_CLEAVE_VENGEANCE_TALENT,
+  SOULMONGER_VENGEANCE_TALENT,
+  RUINOUS_BULWARK_VENGEANCE_TALENT,
+  BURNING_ALIVE_VENGEANCE_TALENT,
+  FIERY_DEMISE_VENGEANCE_TALENT,
+  VULNERABILITY_VENGEANCE_TALENT,
+  FEED_THE_DEMON_VENGEANCE_TALENT,
+  CHARRED_FLESH_VENGEANCE_TALENT,
+  THE_WEAK_WILLED_VENGEANCE_TALENT,
+  SOUL_CARVER_VENGEANCE_TALENT,
+  LAST_RESORT_VENGEANCE_TALENT,
+  ELYSIAN_DECREE_VENGEANCE_TALENT,
+  DOWN_IN_FLAMES_VENGEANCE_TALENT,
 });
 
 export default talents;

--- a/src/common/TALENTS/druid.ts
+++ b/src/common/TALENTS/druid.ts
@@ -1,1203 +1,1493 @@
 // Generated file, changes will eventually be overwritten!
-import { createTalentList } from './types';
+import { createTalentList, Talent } from './types';
+
+//region Shared
+export const RAKE_TALENT: Talent = {
+  id: 1822,
+  name: 'Rake',
+  icon: 'ability_druid_disembowel',
+  maxRanks: 1,
+  energyCost: 35,
+};
+export const FRENZIED_REGENERATION_TALENT: Talent = {
+  id: 22842,
+  name: 'Frenzied Regeneration',
+  icon: 'ability_bullrush',
+  maxRanks: 1,
+  rageCost: 10,
+};
+export const REJUVENATION_TALENT: Talent = {
+  id: 774,
+  name: 'Rejuvenation',
+  icon: 'spell_nature_rejuvenation',
+  maxRanks: 1,
+  manaCost: 1100,
+};
+export const STARFIRE_TALENT: Talent = {
+  id: 194153,
+  name: 'Starfire',
+  icon: 'spell_arcane_starfire',
+  maxRanks: 1,
+};
+export const THRASH_TALENT: Talent = {
+  id: 106832,
+  name: 'Thrash',
+  icon: 'spell_druid_thrash',
+  maxRanks: 1,
+};
+export const IMPROVED_BARKSKIN_TALENT: Talent = {
+  id: 327993,
+  name: 'Improved Barkskin',
+  icon: 'spell_nature_stoneclawtotem',
+  maxRanks: 1,
+};
+export const SWIFTMEND_TALENT: Talent = {
+  id: 18562,
+  name: 'Swiftmend',
+  icon: 'inv_relics_idolofrejuvenation',
+  maxRanks: 1,
+  manaCost: 800,
+};
+export const STARSURGE_TALENT: Talent = {
+  id: 197626,
+  name: 'Starsurge',
+  icon: 'spell_arcane_arcane03',
+  maxRanks: 1,
+  manaCost: 300,
+};
+export const RIP_TALENT: Talent = {
+  id: 1079,
+  name: 'Rip',
+  icon: 'ability_ghoulfrenzy',
+  maxRanks: 1,
+  energyCost: 20,
+};
+export const SWIPE_TALENT: Talent = {
+  id: 213764,
+  name: 'Swipe',
+  icon: 'inv_misc_monsterclaw_03',
+  maxRanks: 1,
+};
+export const IMPROVED_FRENZIED_REGENERATION_NNF_TALENT: Talent = {
+  id: 301768,
+  name: 'Improved Frenzied Regeneration (NNF)',
+  icon: 'ability_bullrush',
+  maxRanks: 1,
+};
+export const REMOVE_CORRUPTION_TALENT: Talent = {
+  id: 2782,
+  name: 'Remove Corruption',
+  icon: 'spell_holy_removecurse',
+  maxRanks: 1,
+  manaCost: 600,
+};
+export const MOONKIN_FORM_TALENT: Talent = {
+  id: 24858,
+  name: 'Moonkin Form',
+  icon: 'spell_nature_forceofnature',
+  maxRanks: 1,
+};
+export const MAIM_TALENT: Talent = {
+  id: 22570,
+  name: 'Maim',
+  icon: 'ability_druid_mangle.tga',
+  maxRanks: 1,
+  energyCost: 30,
+};
+export const KILLER_INSTINCT_TALENT: Talent = {
+  id: 108299,
+  name: 'Killer Instinct',
+  icon: 'ability_druid_predatoryinstincts',
+  maxRanks: 3,
+};
+export const IRONFUR_TALENT: Talent = {
+  id: 192081,
+  name: 'Ironfur',
+  icon: 'ability_druid_ironfur',
+  maxRanks: 1,
+  rageCost: 40,
+};
+export const NURTURING_INSTINCT_TALENT: Talent = {
+  id: 33873,
+  name: 'Nurturing Instinct',
+  icon: 'ability_druid_healinginstincts',
+  maxRanks: 3,
+};
+export const HIBERNATE_TALENT: Talent = {
+  id: 2637,
+  name: 'Hibernate',
+  icon: 'spell_nature_sleep',
+  maxRanks: 1,
+  manaCost: 600,
+};
+export const FELINE_SWIFTNESS_TALENT: Talent = {
+  id: 131768,
+  name: 'Feline Swiftness',
+  icon: 'spell_druid_tirelesspursuit',
+  maxRanks: 2,
+};
+export const SKULL_BASH_TALENT: Talent = {
+  id: 106839,
+  name: 'Skull Bash',
+  icon: 'inv_bone_skull_04',
+  maxRanks: 1,
+};
+export const THICK_HIDE_TALENT: Talent = {
+  id: 16931,
+  name: 'Thick Hide',
+  icon: 'inv_misc_pelt_bear_03',
+  maxRanks: 2,
+};
+export const WILD_CHARGE_TALENT: Talent = {
+  id: 102401,
+  name: 'Wild Charge',
+  icon: 'spell_druid_wildcharge',
+  maxRanks: 1,
+};
+export const TIGER_DASH_TALENT: Talent = {
+  id: 252216,
+  name: 'Tiger Dash',
+  icon: 'ability_druid_dash_orange',
+  maxRanks: 1,
+};
+export const NEW_RESTO_PASSIVE_NNF_TALENT: Talent = {
+  id: 377796,
+  name: 'New Resto Passive (NNF)',
+  icon: 'ability_druid_naturalperfection',
+  maxRanks: 2,
+};
+export const CYCLONE_TALENT: Talent = {
+  id: 33786,
+  name: 'Cyclone',
+  icon: 'spell_nature_earthbind',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const ASTRAL_INFLUENCE_TALENT: Talent = {
+  id: 197524,
+  name: 'Astral Influence',
+  icon: 'ability_skyreach_lens_flare',
+  maxRanks: 2,
+};
+export const TIRELESS_PURSUIT_TALENT: Talent = {
+  id: 377801,
+  name: 'Tireless Pursuit',
+  icon: 'spell_druid_tirelesspursuit',
+  maxRanks: 1,
+};
+export const SOOTHE_TALENT: Talent = {
+  id: 2908,
+  name: 'Soothe',
+  icon: 'ability_hunter_beastsoothe',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const SUNFIRE_TALENT: Talent = {
+  id: 93402,
+  name: 'Sunfire',
+  icon: 'ability_mage_firestarter',
+  maxRanks: 1,
+  manaCost: 1200,
+};
+export const TYPHOON_TALENT: Talent = {
+  id: 132469,
+  name: 'Typhoon',
+  icon: 'ability_druid_typhoon',
+  maxRanks: 1,
+};
+export const PRIMAL_FURY_TALENT: Talent = {
+  id: 159286,
+  name: 'Primal Fury',
+  icon: 'ability_racial_cannibalize',
+  maxRanks: 1,
+};
+export const URSOCS_ENDURANCE_NNF_TALENT: Talent = {
+  id: 385786,
+  name: "Ursoc's Endurance (NNF)",
+  icon: 'spell_nature_stoneclawtotem',
+  maxRanks: 1,
+};
+export const STAMPEDING_ROAR_TALENT: Talent = {
+  id: 106898,
+  name: 'Stampeding Roar',
+  icon: 'spell_druid_stampedingroar_cat',
+  maxRanks: 1,
+};
+export const WILD_GROWTH_TALENT: Talent = {
+  id: 48438,
+  name: 'Wild Growth',
+  icon: 'ability_druid_flourish',
+  maxRanks: 1,
+  manaCost: 2200,
+};
+export const IMPROVED_SUNFIRE_TALENT: Talent = {
+  id: 231050,
+  name: 'Improved Sunfire',
+  icon: 'ability_mage_firestarter',
+  maxRanks: 1,
+};
+export const INCAPACITATING_ROAR_TALENT: Talent = {
+  id: 99,
+  name: 'Incapacitating Roar',
+  icon: 'ability_druid_demoralizingroar',
+  maxRanks: 1,
+};
+export const MIGHTY_BASH_TALENT: Talent = {
+  id: 5211,
+  name: 'Mighty Bash',
+  icon: 'ability_druid_bash',
+  maxRanks: 1,
+};
+export const URSINE_VIGOR_TALENT: Talent = {
+  id: 377842,
+  name: 'Ursine Vigor',
+  icon: 'ability_druid_markofursol',
+  maxRanks: 2,
+};
+export const LYCARAS_TEACHINGS_TALENT: Talent = {
+  id: 378988,
+  name: "Lycara's Teachings",
+  icon: 'inv_trinket_ardenweald_02_green',
+  maxRanks: 3,
+};
+export const IMPROVED_REJUVENATION_TALENT: Talent = {
+  id: 231040,
+  name: 'Improved Rejuvenation',
+  icon: 'spell_nature_rejuvenation',
+  maxRanks: 1,
+};
+export const MASS_ENTANGLEMENT_TALENT: Talent = {
+  id: 102359,
+  name: 'Mass Entanglement',
+  icon: 'spell_druid_massentanglement',
+  maxRanks: 1,
+};
+export const URSOLS_VORTEX_TALENT: Talent = {
+  id: 102793,
+  name: "Ursol's Vortex",
+  icon: 'spell_druid_ursolsvortex',
+  maxRanks: 1,
+};
+export const WELL_HONED_INSTINCTS_TALENT: Talent = {
+  id: 377847,
+  name: 'Well-Honed Instincts',
+  icon: 'ability_druid_tigersroar',
+  maxRanks: 2,
+};
+export const IMPROVED_STAMPEDING_ROAR_TALENT: Talent = {
+  id: 288826,
+  name: 'Improved Stampeding Roar',
+  icon: 'spell_druid_stamedingroar',
+  maxRanks: 1,
+};
+export const RENEWAL_TALENT: Talent = {
+  id: 108238,
+  name: 'Renewal',
+  icon: 'spell_nature_natureblessing',
+  maxRanks: 1,
+};
+export const INNERVATE_TALENT: Talent = {
+  id: 29166,
+  name: 'Innervate',
+  icon: 'spell_nature_lightning',
+  maxRanks: 1,
+};
+export const FUROR_TALENT: Talent = {
+  id: 378986,
+  name: 'Furor',
+  icon: 'spell_holy_blessingofstamina',
+  maxRanks: 1,
+};
+export const HEART_OF_THE_WILD_TALENT: Talent = {
+  id: 319454,
+  name: 'Heart of the Wild',
+  icon: 'spell_holy_blessingofagility',
+  maxRanks: 1,
+};
+export const NATURES_VIGIL_TALENT: Talent = {
+  id: 124974,
+  name: "Nature's Vigil",
+  icon: 'achievement_zone_feralas',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Feral
+export const TIGERS_FURY_FERAL_TALENT: Talent = {
+  id: 231055,
+  name: "Tiger's Fury",
+  icon: 'ability_mount_jungletiger',
+  maxRanks: 3,
+};
+export const TIRELESS_ENERGY_FERAL_TALENT: Talent = {
+  id: 383352,
+  name: 'Tireless Energy',
+  icon: 'spell_chargepositive',
+  maxRanks: 3,
+};
+export const OMEN_OF_CLARITY_FERAL_TALENT: Talent = {
+  id: 16864,
+  name: 'Omen of Clarity',
+  icon: 'spell_nature_crystalball',
+  maxRanks: 1,
+};
+export const IMPROVED_SHRED_FERAL_TALENT: Talent = {
+  id: 343232,
+  name: 'Improved Shred',
+  icon: 'spell_shadow_vampiricaura',
+  maxRanks: 1,
+};
+export const SCENT_OF_BLOOD_FERAL_TALENT: Talent = {
+  id: 285564,
+  name: 'Scent of Blood',
+  icon: 'spell_druid_thrash',
+  maxRanks: 1,
+};
+export const PREDATOR_FERAL_TALENT: Talent = {
+  id: 202021,
+  name: 'Predator',
+  icon: 'ability_hunter_catlikereflexes',
+  maxRanks: 1,
+};
+export const SABERTOOTH_FERAL_TALENT: Talent = {
+  id: 202031,
+  name: 'Sabertooth',
+  icon: 'inv_misc_monsterfang_01',
+  maxRanks: 1,
+};
+export const IMPROVED_PROWL_NEEDS_POINTS_SCALING_FERAL_TALENT: Talent = {
+  id: 231052,
+  name: 'Improved Prowl [Needs Points Scaling]',
+  icon: 'ability_druid_prowl',
+  maxRanks: 2,
+};
+export const IMPROVED_BLEEDS_NEEDS_POINTS_SCALING_FERAL_TALENT: Talent = {
+  id: 231063,
+  name: 'Improved Bleeds (Needs Points Scaling)',
+  icon: 'inv_misc_monsterclaw_03',
+  maxRanks: 2,
+};
+export const SUDDEN_AMBUSH_FERAL_TALENT: Talent = {
+  id: 384667,
+  name: 'Sudden Ambush',
+  icon: 'ability_hunter_catlikereflexes',
+  maxRanks: 3,
+};
+export const BERSERK_FERAL_TALENT: Talent = {
+  id: 343223,
+  name: 'Berserk',
+  icon: 'ability_druid_berserk',
+  maxRanks: 1,
+};
+export const TASTE_FOR_BLOOD_FERAL_TALENT: Talent = {
+  id: 384665,
+  name: 'Taste for Blood',
+  icon: 'ability_druid_ferociousbite',
+  maxRanks: 3,
+};
+export const LUNAR_INSPIRATION_FERAL_TALENT: Talent = {
+  id: 155580,
+  name: 'Lunar Inspiration',
+  icon: 'spell_druid_lunarinspiration',
+  maxRanks: 1,
+};
+export const PRIMAL_WRATH_FERAL_TALENT: Talent = {
+  id: 285381,
+  name: 'Primal Wrath',
+  icon: 'artifactability_feraldruid_ashamanesbite',
+  maxRanks: 1,
+  energyCost: 20,
+};
+export const MOMENT_OF_CLARITY_FERAL_TALENT: Talent = {
+  id: 236068,
+  name: 'Moment of Clarity',
+  icon: 'spell_druid_momentofclarity',
+  maxRanks: 1,
+};
+export const BRUTAL_SLASH_FERAL_TALENT: Talent = {
+  id: 202028,
+  name: 'Brutal Slash',
+  icon: 'ability_druid_ravage',
+  maxRanks: 1,
+  energyCost: 25,
+};
+export const SAVAGE_ROAR_FERAL_TALENT: Talent = {
+  id: 52610,
+  name: 'Savage Roar',
+  icon: 'ability_druid_skinteeth',
+  maxRanks: 1,
+  energyCost: 25,
+};
+export const PREDATORY_SWIFTNESS_FERAL_TALENT: Talent = {
+  id: 16974,
+  name: 'Predatory Swiftness',
+  icon: 'ability_hunter_pet_cat',
+  maxRanks: 1,
+};
+export const SURVIVAL_INSTINCTS_FERAL_TALENT: Talent = {
+  id: 61336,
+  name: 'Survival Instincts',
+  icon: 'ability_druid_tigersroar',
+  maxRanks: 1,
+};
+export const INFECTED_WOUNDS_FERAL_TALENT: Talent = {
+  id: 48484,
+  name: 'Infected Wounds',
+  icon: 'ability_druid_infectedwound',
+  maxRanks: 1,
+};
+export const BERSERK_JUNGLE_STALKER_FERAL_TALENT: Talent = {
+  id: 384671,
+  name: 'Berserk: Jungle Stalker',
+  icon: 'ability_druid_berserk',
+  maxRanks: 1,
+};
+export const CARNIVOROUS_INSTINCT_FERAL_TALENT: Talent = {
+  id: 340705,
+  name: 'Carnivorous Instinct',
+  icon: 'ability_mount_jungletiger',
+  maxRanks: 2,
+};
+export const EYE_OF_FEARFUL_SYMMETRY_FERAL_TALENT: Talent = {
+  id: 339141,
+  name: 'Eye of Fearful Symmetry',
+  icon: 'ability_druid_healinginstincts',
+  maxRanks: 2,
+};
+export const CATS_CURIOSITY_FERAL_TALENT: Talent = {
+  id: 386318,
+  name: "Cat's Curiosity",
+  icon: 'inv_jewelcrafting_gem_30',
+  maxRanks: 2,
+};
+export const BERSERK_FRENZY_FERAL_TALENT: Talent = {
+  id: 384668,
+  name: 'Berserk: Frenzy',
+  icon: 'ability_druid_berserk',
+  maxRanks: 1,
+};
+export const FERAL_FRENZY_FERAL_TALENT: Talent = {
+  id: 274837,
+  name: 'Feral Frenzy',
+  icon: 'ability_druid_rake',
+  maxRanks: 1,
+  energyCost: 25,
+};
+export const BLOODTALONS_FERAL_TALENT: Talent = {
+  id: 319439,
+  name: 'Bloodtalons',
+  icon: 'spell_druid_bloodythrash',
+  maxRanks: 1,
+};
+export const ADAPTIVE_SWARM_FERAL_TALENT: Talent = {
+  id: 325727,
+  name: 'Adaptive Swarm',
+  icon: 'ability_maldraxxus_druid',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const INCARNATION_AVATAR_OF_ASHAMANE_FERAL_TALENT: Talent = {
+  id: 102543,
+  name: 'Incarnation: Avatar of Ashamane',
+  icon: 'spell_druid_incarnation',
+  maxRanks: 1,
+};
+export const CONVOKE_THE_SPIRITS_FERAL_TALENT: Talent = {
+  id: 323764,
+  name: 'Convoke the Spirits',
+  icon: 'ability_ardenweald_druid',
+  maxRanks: 1,
+};
+export const SOUL_OF_THE_FOREST_FERAL_TALENT: Talent = {
+  id: 158476,
+  name: 'Soul of the Forest',
+  icon: 'ability_druid_manatree',
+  maxRanks: 1,
+};
+export const DRAUGHT_OF_DEEP_FOCUS_FERAL_TALENT: Talent = {
+  id: 338658,
+  name: 'Draught of Deep Focus',
+  icon: 'trade_alchemy_dpotion_d12',
+  maxRanks: 1,
+};
+export const APEX_PREDATORS_CRAVING_FERAL_TALENT: Talent = {
+  id: 339139,
+  name: "Apex Predator's Craving",
+  icon: 'ability_druid_primaltenacity',
+  maxRanks: 1,
+};
+export const UNBRIDLED_SWARM_FERAL_TALENT: Talent = {
+  id: 354123,
+  name: 'Unbridled Swarm',
+  icon: 'ability_maldraxxus_druid',
+  maxRanks: 2,
+};
+export const CIRCLE_OF_LIFE_AND_DEATH_FERAL_TALENT: Talent = {
+  id: 338657,
+  name: 'Circle of Life and Death',
+  icon: 'ability_druid_cyclone',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Restoration
+export const LIFEBLOOM_RESTORATION_TALENT: Talent = {
+  id: 33763,
+  name: 'Lifebloom',
+  icon: 'inv_misc_herb_felblossom',
+  maxRanks: 1,
+  manaCost: 800,
+};
+export const EFFLORESCENCE_RESTORATION_TALENT: Talent = {
+  id: 145205,
+  name: 'Efflorescence',
+  icon: 'inv_misc_herb_talandrasrose',
+  maxRanks: 1,
+  manaCost: 1700,
+};
+export const NATURES_SWIFTNESS_RESTORATION_TALENT: Talent = {
+  id: 132158,
+  name: "Nature's Swiftness",
+  icon: 'spell_nature_ravenform',
+  maxRanks: 1,
+};
+export const OMEN_OF_CLARITY_RESTORATION_TALENT: Talent = {
+  id: 113043,
+  name: 'Omen of Clarity',
+  icon: 'spell_nature_crystalball',
+  maxRanks: 1,
+};
+export const READY_FOR_ANYTHING_RESTORATION_TALENT: Talent = {
+  id: 382550,
+  name: 'Ready For Anything',
+  icon: 'spell_nature_ravenform',
+  maxRanks: 2,
+};
+export const IRONBARK_RESTORATION_TALENT: Talent = {
+  id: 102342,
+  name: 'Ironbark',
+  icon: 'spell_druid_ironbark',
+  maxRanks: 1,
+};
+export const IMPROVED_WILD_GROWTH_RESTORATION_TALENT: Talent = {
+  id: 328025,
+  name: 'Improved Wild Growth',
+  icon: 'ability_druid_flourish',
+  maxRanks: 1,
+};
+export const IMPROVED_REGROWTH_RESTORATION_TALENT: Talent = {
+  id: 231032,
+  name: 'Improved Regrowth',
+  icon: 'spell_nature_resistnature',
+  maxRanks: 2,
+};
+export const IMPROVED_IRONBARK_RESTORATION_TALENT: Talent = {
+  id: 382552,
+  name: 'Improved Ironbark',
+  icon: 'spell_druid_ironbark',
+  maxRanks: 2,
+};
+export const UNSTOPPABLE_GROWTH_RESTORATION_TALENT: Talent = {
+  id: 340549,
+  name: 'Unstoppable Growth',
+  icon: 'ability_druid_flourish',
+  maxRanks: 2,
+};
+export const TRANQUILITY_RESTORATION_TALENT: Talent = {
+  id: 740,
+  name: 'Tranquility',
+  icon: 'spell_nature_tranquility',
+  maxRanks: 1,
+  manaCost: 1800,
+};
+export const YSERAS_GIFT_RESTORATION_TALENT: Talent = {
+  id: 145108,
+  name: "Ysera's Gift",
+  icon: 'inv_misc_head_dragon_green',
+  maxRanks: 3,
+};
+export const NOURISH_RESTORATION_TALENT: Talent = {
+  id: 50464,
+  name: 'Nourish',
+  icon: 'ability_druid_nourish',
+  maxRanks: 1,
+  manaCost: 1800,
+};
+export const SOUL_OF_THE_FOREST_RESTORATION_TALENT: Talent = {
+  id: 158478,
+  name: 'Soul of the Forest',
+  icon: 'ability_druid_manatree',
+  maxRanks: 1,
+};
+export const INNER_PEACE_RESTORATION_TALENT: Talent = {
+  id: 197073,
+  name: 'Inner Peace',
+  icon: 'ability_druid_dreamstate',
+  maxRanks: 2,
+};
+export const CULTIVATION_RESTORATION_TALENT: Talent = {
+  id: 200390,
+  name: 'Cultivation',
+  icon: 'spell_nature_healingtouch',
+  maxRanks: 1,
+};
+export const DEEP_ROOTS_RESTORATION_TALENT: Talent = {
+  id: 383191,
+  name: 'Deep Roots',
+  icon: 'inv_misc_herb_liferoot_stem',
+  maxRanks: 2,
+};
+export const CENARION_WARD_RESTORATION_TALENT: Talent = {
+  id: 102351,
+  name: 'Cenarion Ward',
+  icon: 'ability_druid_naturalperfection',
+  maxRanks: 1,
+  manaCost: 900,
+};
+export const ABUNDANCE_RESTORATION_TALENT: Talent = {
+  id: 207383,
+  name: 'Abundance',
+  icon: 'ability_druid_empoweredrejuvination',
+  maxRanks: 1,
+};
+export const STONEBARK_RESTORATION_TALENT: Talent = {
+  id: 197061,
+  name: 'Stonebark',
+  icon: 'spell_druid_ironbark',
+  maxRanks: 2,
+};
+export const SPRING_BLOSSOMS_RESTORATION_TALENT: Talent = {
+  id: 207385,
+  name: 'Spring Blossoms',
+  icon: 'inv_misc_trailofflowers',
+  maxRanks: 1,
+};
+export const OVERGROWTH_RESTORATION_TALENT: Talent = {
+  id: 203651,
+  name: 'Overgrowth',
+  icon: 'ability_druid_overgrowth',
+  maxRanks: 1,
+  manaCost: 1200,
+};
+export const RAMPANT_GROWTH_RESTORATION_TALENT: Talent = {
+  id: 278515,
+  name: 'Rampant Growth',
+  icon: 'spell_nature_resistnature',
+  maxRanks: 1,
+};
+export const AUTUMN_LEAVES_NO_EXTENSION_RESTORATION_TALENT: Talent = {
+  id: 274432,
+  name: 'Autumn Leaves [no extension]',
+  icon: 'spell_nature_rejuvenation',
+  maxRanks: 2,
+};
+export const GROVE_TENDING_RESTORATION_TALENT: Talent = {
+  id: 279778,
+  name: 'Grove Tending',
+  icon: 'inv_relics_idolofrejuvenation',
+  maxRanks: 1,
+};
+export const MEMORY_OF_THE_MOTHER_TREE_RESTORATION_TALENT: Talent = {
+  id: 339064,
+  name: 'Memory of the Mother Tree',
+  icon: 'spell_druid_rampantgrowth',
+  maxRanks: 1,
+};
+export const GERMINATION_RESTORATION_TALENT: Talent = {
+  id: 155675,
+  name: 'Germination',
+  icon: 'spell_druid_germination',
+  maxRanks: 1,
+};
+export const ADAPTIVE_SWARM_RESTORATION_TALENT: Talent = {
+  id: 325727,
+  name: 'Adaptive Swarm',
+  icon: 'ability_maldraxxus_druid',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const INCARNATION_TREE_OF_LIFE_RESTORATION_TALENT: Talent = {
+  id: 33891,
+  name: 'Incarnation: Tree of Life',
+  icon: 'ability_druid_improvedtreeform',
+  maxRanks: 1,
+};
+export const CONVOKE_THE_SPIRITS_RESTORATION_TALENT: Talent = {
+  id: 323764,
+  name: 'Convoke the Spirits',
+  icon: 'ability_ardenweald_druid',
+  maxRanks: 1,
+};
+export const IMPROVED_INNERVATE_RESTORATION_TALENT: Talent = {
+  id: 326228,
+  name: 'Improved Innervate',
+  icon: 'spell_nature_lightning',
+  maxRanks: 1,
+};
+export const CIRCLE_OF_LIFE_AND_DEATH_RESTORATION_TALENT: Talent = {
+  id: 338657,
+  name: 'Circle of Life and Death',
+  icon: 'ability_druid_cyclone',
+  maxRanks: 2,
+};
+export const PHOTOSYNTHESIS_RESTORATION_TALENT: Talent = {
+  id: 274902,
+  name: 'Photosynthesis',
+  icon: 'spell_lifegivingseed',
+  maxRanks: 1,
+};
+export const THE_DARK_TITANS_LESSON_RESTORATION_TALENT: Talent = {
+  id: 338831,
+  name: "The Dark Titan's Lesson",
+  icon: 'spell_druid_germination_rejuvenation',
+  maxRanks: 1,
+};
+export const UNBRIDLED_SWARM_RESTORATION_TALENT: Talent = {
+  id: 354123,
+  name: 'Unbridled Swarm',
+  icon: 'ability_maldraxxus_druid',
+  maxRanks: 2,
+};
+export const EPHEMERAL_INCARNATION_RESTORATION_TALENT: Talent = {
+  id: 363495,
+  name: 'Ephemeral Incarnation',
+  icon: 'spell_progenitor_orb2',
+  maxRanks: 1,
+};
+export const FLOURISH_RESTORATION_TALENT: Talent = {
+  id: 197721,
+  name: 'Flourish',
+  icon: 'spell_druid_wildburst',
+  maxRanks: 1,
+};
+export const VERDANT_INFUSION_RESTORATION_TALENT: Talent = {
+  id: 338829,
+  name: 'Verdant Infusion',
+  icon: 'inv_relics_totemoflife',
+  maxRanks: 1,
+};
+export const VISION_OF_UNENDING_GROWTH_RESTORATION_TALENT: Talent = {
+  id: 338832,
+  name: 'Vision of Unending Growth',
+  icon: 'achievement_dungeon_everbloom',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Balance
+export const ECLIPSE_BALANCE_TALENT: Talent = {
+  id: 79577,
+  name: 'Eclipse',
+  icon: 'ability_druid_eclipseorange',
+  maxRanks: 1,
+};
+export const IMPROVED_ECLIPSE_BALANCE_TALENT: Talent = {
+  id: 328021,
+  name: 'Improved Eclipse',
+  icon: 'ability_druid_eclipseorange',
+  maxRanks: 2,
+};
+export const IMPROVED_MOONFIRE_BALANCE_TALENT: Talent = {
+  id: 328023,
+  name: 'Improved Moonfire',
+  icon: 'spell_nature_starfall',
+  maxRanks: 2,
+};
+export const FORCE_OF_NATURE_BALANCE_TALENT: Talent = {
+  id: 205636,
+  name: 'Force of Nature',
+  icon: 'ability_druid_forceofnature',
+  maxRanks: 1,
+};
+export const NATURES_BALANCE_BALANCE_TALENT: Talent = {
+  id: 202430,
+  name: "Nature's Balance",
+  icon: 'ability_druid_balanceofpower',
+  maxRanks: 2,
+};
+export const WARRIOR_OF_ELUNE_BALANCE_TALENT: Talent = {
+  id: 202425,
+  name: 'Warrior of Elune',
+  icon: 'spell_holy_elunesgrace',
+  maxRanks: 1,
+};
+export const STARFALL_BALANCE_TALENT: Talent = {
+  id: 327541,
+  name: 'Starfall',
+  icon: 'ability_druid_starfall',
+  maxRanks: 2,
+};
+export const OWLKIN_FRENZY_BALANCE_TALENT: Talent = {
+  id: 231042,
+  name: 'Owlkin Frenzy',
+  icon: 'spell_nature_forceofnature',
+  maxRanks: 1,
+};
+export const CELESTIAL_ALIGNMENT_BALANCE_TALENT: Talent = {
+  id: 194223,
+  name: 'Celestial Alignment',
+  icon: 'spell_nature_natureguardian',
+  maxRanks: 1,
+};
+export const IMPROVED_STARSURGE_BALANCE_TALENT: Talent = {
+  id: 328022,
+  name: 'Improved Starsurge',
+  icon: 'spell_arcane_arcane03',
+  maxRanks: 1,
+};
+export const SOLAR_BEAM_BALANCE_TALENT: Talent = {
+  id: 78675,
+  name: 'Solar Beam',
+  icon: 'ability_vehicle_sonicshockwave',
+  maxRanks: 1,
+  manaCost: 1600,
+};
+export const SHOOTING_STARS_BALANCE_TALENT: Talent = {
+  id: 202342,
+  name: 'Shooting Stars',
+  icon: 'spell_priest_divinestar_shadow2',
+  maxRanks: 1,
+};
+export const POWER_OF_GOLDRINN_BALANCE_TALENT: Talent = {
+  id: 202996,
+  name: 'Power of Goldrinn',
+  icon: 'inv_mount_spectralwolf',
+  maxRanks: 2,
+};
+export const STARLORD_BALANCE_TALENT: Talent = {
+  id: 202345,
+  name: 'Starlord',
+  icon: 'spell_shaman_measuredinsight',
+  maxRanks: 2,
+};
+export const STELLAR_DRIFT_BALANCE_TALENT: Talent = {
+  id: 202354,
+  name: 'Stellar Drift',
+  icon: 'ability_druid_starfall',
+  maxRanks: 1,
+};
+export const STELLAR_INSPIRATION_BALANCE_TALENT: Talent = {
+  id: 383194,
+  name: 'Stellar Inspiration',
+  icon: 'ability_skyreach_lens_flare',
+  maxRanks: 2,
+};
+export const LIGHT_OF_THE_SUN_BALANCE_TALENT: Talent = {
+  id: 202918,
+  name: 'Light of the Sun',
+  icon: 'ability_vehicle_sonicshockwave',
+  maxRanks: 1,
+};
+export const UMBRAL_INTENSITY_BALANCE_TALENT: Talent = {
+  id: 383195,
+  name: 'Umbral Intensity',
+  icon: 'ability_druid_eclipse',
+  maxRanks: 2,
+};
+export const PRECISE_ALIGNMENT_BALANCE_TALENT: Talent = {
+  id: 340706,
+  name: 'Precise Alignment',
+  icon: 'spell_nature_natureguardian',
+  maxRanks: 1,
+};
+export const BLESSING_OF_ELUNE_BALANCE_TALENT: Talent = {
+  id: 202737,
+  name: 'Blessing of Elune',
+  icon: 'achievement_worldevent_lunar',
+  maxRanks: 1,
+};
+export const BLESSING_OF_ANSHE_BALANCE_TALENT: Talent = {
+  id: 202739,
+  name: "Blessing of An'she",
+  icon: 'spell_priest_divinestar_holy',
+  maxRanks: 1,
+};
+export const SOUL_OF_THE_FOREST_BALANCE_TALENT: Talent = {
+  id: 114107,
+  name: 'Soul of the Forest',
+  icon: 'ability_druid_manatree',
+  maxRanks: 1,
+};
+export const FURY_OF_THE_SKIES_BALANCE_TALENT: Talent = {
+  id: 384656,
+  name: 'Fury of the Skies',
+  icon: 'spell_druid_equinox',
+  maxRanks: 2,
+};
+export const STELLAR_FLARE_BALANCE_TALENT: Talent = {
+  id: 202347,
+  name: 'Stellar Flare',
+  icon: 'ability_druid_stellarflare',
+  maxRanks: 1,
+};
+export const TWIN_MOONS_BALANCE_TALENT: Talent = {
+  id: 279620,
+  name: 'Twin Moons',
+  icon: 'spell_nature_starfall',
+  maxRanks: 1,
+};
+export const SOLSTICE_BALANCE_TALENT: Talent = {
+  id: 343647,
+  name: 'Solstice',
+  icon: 'artifactability_balancedruid_moonandstars',
+  maxRanks: 2,
+};
+export const TIMEWORN_DREAMBINDER_NNF_BALANCE_TALENT: Talent = {
+  id: 339949,
+  name: 'Timeworn Dreambinder [NNF]',
+  icon: 'ability_creature_cursed_04',
+  maxRanks: 1,
+};
+export const ONETHS_CLEAR_VISION_NNF_BALANCE_TALENT: Talent = {
+  id: 338661,
+  name: "Oneth's Clear Vision [NNF]",
+  icon: 'spell_arcane_invocation',
+  maxRanks: 1,
+};
+export const UMBRAL_INFUSION_NNF_BALANCE_TALENT: Talent = {
+  id: 383196,
+  name: 'Umbral Infusion [NNF]',
+  icon: 'spell_animaardenweald_groundstate',
+  maxRanks: 2,
+};
+export const INCARNATION_CHOSEN_OF_ELUNE_BALANCE_TALENT: Talent = {
+  id: 102560,
+  name: 'Incarnation: Chosen of Elune',
+  icon: 'spell_druid_incarnation',
+  maxRanks: 1,
+};
+export const CONVOKE_THE_SPIRITS_BALANCE_TALENT: Talent = {
+  id: 323764,
+  name: 'Convoke the Spirits',
+  icon: 'ability_ardenweald_druid',
+  maxRanks: 1,
+};
+export const CIRCLE_OF_LIFE_AND_DEATH_BALANCE_TALENT: Talent = {
+  id: 338657,
+  name: 'Circle of Life and Death',
+  icon: 'ability_druid_cyclone',
+  maxRanks: 2,
+};
+export const SYZYGY_BALANCE_TALENT: Talent = {
+  id: 390378,
+  name: 'Syzygy',
+  icon: 'ability_druid_cresentburn',
+  maxRanks: 1,
+};
+export const PRIMORDIAL_ARCANIC_PULSAR_BALANCE_TALENT: Talent = {
+  id: 338668,
+  name: 'Primordial Arcanic Pulsar',
+  icon: 'spell_arcane_arcane03',
+  maxRanks: 1,
+};
+export const FURY_OF_ELUNE_BALANCE_TALENT: Talent = {
+  id: 202770,
+  name: 'Fury of Elune',
+  icon: 'ability_druid_dreamstate',
+  maxRanks: 1,
+};
+export const NEW_MOON_BALANCE_TALENT: Talent = {
+  id: 274281,
+  name: 'New Moon',
+  icon: 'artifactability_balancedruid_newmoon',
+  maxRanks: 1,
+};
+export const BALANCE_OF_ALL_THINGS_BALANCE_TALENT: Talent = {
+  id: 339942,
+  name: 'Balance of All Things',
+  icon: 'ability_druid_balanceofpower',
+  maxRanks: 1,
+};
+export const ADAPTIVE_SWARM_BALANCE_TALENT: Talent = {
+  id: 325727,
+  name: 'Adaptive Swarm',
+  icon: 'ability_maldraxxus_druid',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const ORBIT_BREAKER_BALANCE_TALENT: Talent = {
+  id: 383197,
+  name: 'Orbit Breaker',
+  icon: 'artifactability_balancedruid_moonandstars',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Guardian
+export const MAUL_GUARDIAN_TALENT: Talent = {
+  id: 6807,
+  name: 'Maul',
+  icon: 'ability_druid_maul',
+  maxRanks: 1,
+  rageCost: 40,
+};
+export const GORE_GUARDIAN_TALENT: Talent = {
+  id: 210706,
+  name: 'Gore',
+  icon: 'spell_druid_bearhug',
+  maxRanks: 1,
+};
+export const SURVIVAL_INSTINCTS_GUARDIAN_TALENT: Talent = {
+  id: 328767,
+  name: 'Survival Instincts',
+  icon: 'ability_druid_tigersroar',
+  maxRanks: 1,
+};
+export const BRISTLING_FUR_GUARDIAN_TALENT: Talent = {
+  id: 155835,
+  name: 'Bristling Fur',
+  icon: 'spell_druid_bristlingfur',
+  maxRanks: 1,
+};
+export const BRAMBLES_GUARDIAN_TALENT: Talent = {
+  id: 203953,
+  name: 'Brambles',
+  icon: 'inv_misc_thornnecklace',
+  maxRanks: 1,
+};
+export const URSINE_ADEPT_GUARDIAN_TALENT: Talent = {
+  id: 300346,
+  name: 'Ursine Adept',
+  icon: 'talentspec_druid_feral_bear',
+  maxRanks: 1,
+};
+export const MANGLE_GUARDIAN_TALENT: Talent = {
+  id: 231064,
+  name: 'Mangle',
+  icon: 'ability_druid_mangle2',
+  maxRanks: 1,
+};
+export const INNATE_RESOLVE_GUARDIAN_TALENT: Talent = {
+  id: 377811,
+  name: 'Innate Resolve',
+  icon: 'spell_nature_healingway',
+  maxRanks: 1,
+};
+export const INFECTED_WOUNDS_GUARDIAN_TALENT: Talent = {
+  id: 345208,
+  name: 'Infected Wounds',
+  icon: 'ability_druid_infectedwound',
+  maxRanks: 1,
+};
+export const BERSERK_RAVAGE_GUARDIAN_TALENT: Talent = {
+  id: 343240,
+  name: 'Berserk: Ravage',
+  icon: 'ability_druid_berserk',
+  maxRanks: 1,
+};
+export const URSOCS_ENDURANCE_GUARDIAN_TALENT: Talent = {
+  id: 200399,
+  name: "Ursoc's Endurance",
+  icon: 'ability_hunter_pet_bear',
+  maxRanks: 2,
+};
+export const GORY_FUR_GUARDIAN_TALENT: Talent = {
+  id: 200854,
+  name: 'Gory Fur',
+  icon: 'artifactability_guardiandruid_goryfur',
+  maxRanks: 1,
+};
+export const PAWSITIVE_OUTLOOK_GUARDIAN_TALENT: Talent = {
+  id: 238121,
+  name: 'Pawsitive Outlook',
+  icon: 'spell_druid_thrash',
+  maxRanks: 2,
+};
+export const TOOTH_AND_CLAW_GUARDIAN_TALENT: Talent = {
+  id: 135288,
+  name: 'Tooth and Claw',
+  icon: 'inv_misc_monsterfang_01',
+  maxRanks: 1,
+};
+export const LAYERED_MANE_GUARDIAN_TALENT: Talent = {
+  id: 279552,
+  name: 'Layered Mane',
+  icon: 'ability_druid_ironfur',
+  maxRanks: 2,
+};
+export const SCINTILLATING_MOONLIGHT_GUARDIAN_TALENT: Talent = {
+  id: 238049,
+  name: 'Scintillating Moonlight',
+  icon: 'spell_nature_starfall',
+  maxRanks: 2,
+};
+export const EARTHWARDEN_GUARDIAN_TALENT: Talent = {
+  id: 203974,
+  name: 'Earthwarden',
+  icon: 'spell_shaman_blessingofeternals',
+  maxRanks: 1,
+};
+export const VICIOUS_CYCLE_GUARDIAN_TALENT: Talent = {
+  id: 371999,
+  name: 'Vicious Cycle',
+  icon: 'spell_druid_bearhug',
+  maxRanks: 1,
+};
+export const VULNERABLE_FLESH_GUARDIAN_TALENT: Talent = {
+  id: 372618,
+  name: 'Vulnerable Flesh',
+  icon: 'ability_druid_primalagression',
+  maxRanks: 2,
+};
+export const FRONT_OF_THE_PACK_GUARDIAN_TALENT: Talent = {
+  id: 377835,
+  name: 'Front of the Pack',
+  icon: 'spell_druid_stampedingroar_cat',
+  maxRanks: 1,
+};
+export const REINFORCED_FUR_GUARDIAN_TALENT: Talent = {
+  id: 200395,
+  name: 'Reinforced Fur',
+  icon: 'spell_druid_malfurionstenacity',
+  maxRanks: 1,
+};
+export const GALACTIC_GUARDIAN_GUARDIAN_TALENT: Talent = {
+  id: 203964,
+  name: 'Galactic Guardian',
+  icon: 'spell_frost_iceclaw',
+  maxRanks: 1,
+};
+export const TWIN_MOONFIRE_GUARDIAN_TALENT: Talent = {
+  id: 372567,
+  name: 'Twin Moonfire',
+  icon: 'spell_nature_starfall',
+  maxRanks: 1,
+};
+export const BERSERK_UNCHECKED_AGGRESSION_GUARDIAN_TALENT: Talent = {
+  id: 377623,
+  name: 'Berserk: Unchecked Aggression',
+  icon: 'ability_druid_berserk',
+  maxRanks: 1,
+};
+export const FURY_OF_NATURE_GUARDIAN_TALENT: Talent = {
+  id: 370695,
+  name: 'Fury of Nature',
+  icon: 'spell_nature_moonglow',
+  maxRanks: 2,
+};
+export const BERSERK_PERSISTENCE_GUARDIAN_TALENT: Talent = {
+  id: 377779,
+  name: 'Berserk: Persistence',
+  icon: 'ability_druid_berserk',
+  maxRanks: 1,
+};
+export const REINVIGORATION_GUARDIAN_TALENT: Talent = {
+  id: 372945,
+  name: 'Reinvigoration',
+  icon: 'ability_druid_overgrowth',
+  maxRanks: 2,
+};
+export const CIRCLE_OF_LIFE_AND_DEATH_GUARDIAN_TALENT: Talent = {
+  id: 338657,
+  name: 'Circle of Life and Death',
+  icon: 'ability_druid_cyclone',
+  maxRanks: 2,
+};
+export const ELUNES_FAVORED_GUARDIAN_TALENT: Talent = {
+  id: 370586,
+  name: "Elune's Favored",
+  icon: 'spell_holy_elunesgrace',
+  maxRanks: 1,
+};
+export const SURVIVAL_OF_THE_FITTEST_GUARDIAN_TALENT: Talent = {
+  id: 203965,
+  name: 'Survival of the Fittest',
+  icon: 'ability_druid_enrage',
+  maxRanks: 2,
+};
+export const URSOCS_FURY_GUARDIAN_TALENT: Talent = {
+  id: 377210,
+  name: "Ursoc's Fury",
+  icon: 'achievement_emeraldnightmare_ursoc',
+  maxRanks: 1,
+};
+export const DREAM_OF_CENARIUS_GUARDIAN_TALENT: Talent = {
+  id: 372119,
+  name: 'Dream of Cenarius',
+  icon: 'ability_druid_dreamstate',
+  maxRanks: 1,
+};
+export const PULVERIZE_GUARDIAN_TALENT: Talent = {
+  id: 80313,
+  name: 'Pulverize',
+  icon: 'spell_druid_malfurionstenacity',
+  maxRanks: 1,
+};
+export const INCARNATION_GUARDIAN_OF_URSOC_GUARDIAN_TALENT: Talent = {
+  id: 102558,
+  name: 'Incarnation: Guardian of Ursoc',
+  icon: 'spell_druid_incarnation',
+  maxRanks: 1,
+};
+export const CONVOKE_THE_SPIRITS_GUARDIAN_TALENT: Talent = {
+  id: 337433,
+  name: 'Convoke the Spirits',
+  icon: 'ability_ardenweald_druid',
+  maxRanks: 1,
+};
+export const BLOOD_FRENZY_GUARDIAN_TALENT: Talent = {
+  id: 203962,
+  name: 'Blood Frenzy',
+  icon: 'ability_druid_primaltenacity',
+  maxRanks: 1,
+};
+export const SOUL_OF_THE_FOREST_GUARDIAN_TALENT: Talent = {
+  id: 158477,
+  name: 'Soul of the Forest',
+  icon: 'ability_druid_manatree',
+  maxRanks: 1,
+};
+export const AFTER_THE_WILDFIRE_GUARDIAN_TALENT: Talent = {
+  id: 371905,
+  name: 'After the Wildfire',
+  icon: 'spell_nature_naturetouchgrow',
+  maxRanks: 1,
+};
+export const GUARDIAN_OF_ELUNE_GUARDIAN_TALENT: Talent = {
+  id: 155578,
+  name: 'Guardian of Elune',
+  icon: 'spell_druid_guardianofelune',
+  maxRanks: 1,
+};
+export const REND_AND_TEAR_GUARDIAN_TALENT: Talent = {
+  id: 204053,
+  name: 'Rend and Tear',
+  icon: 'ability_druid_swipe',
+  maxRanks: 1,
+};
+export const UNTAMED_SAVAGERY_GUARDIAN_TALENT: Talent = {
+  id: 372943,
+  name: 'Untamed Savagery',
+  icon: 'spell_druid_bloodythrash',
+  maxRanks: 1,
+};
+export const RAGE_OF_THE_SLEEPER_GUARDIAN_TALENT: Talent = {
+  id: 200851,
+  name: 'Rage of the Sleeper',
+  icon: 'inv_hand_1h_artifactursoc_d_01',
+  maxRanks: 1,
+};
+
+//endregion
 
 const talents = createTalentList({
   //Shared
-  RAKE_TALENT: {
-    id: 1822,
-    name: 'Rake',
-    icon: 'ability_druid_disembowel',
-    maxRanks: 1,
-    energyCost: 35,
-  },
-  FRENZIED_REGENERATION_TALENT: {
-    id: 22842,
-    name: 'Frenzied Regeneration',
-    icon: 'ability_bullrush',
-    maxRanks: 1,
-    rageCost: 10,
-  },
-  REJUVENATION_TALENT: {
-    id: 774,
-    name: 'Rejuvenation',
-    icon: 'spell_nature_rejuvenation',
-    maxRanks: 1,
-    manaCost: 1100,
-  },
-  STARFIRE_TALENT: { id: 194153, name: 'Starfire', icon: 'spell_arcane_starfire', maxRanks: 1 },
-  THRASH_TALENT: { id: 106832, name: 'Thrash', icon: 'spell_druid_thrash', maxRanks: 1 },
-  IMPROVED_BARKSKIN_TALENT: {
-    id: 327993,
-    name: 'Improved Barkskin',
-    icon: 'spell_nature_stoneclawtotem',
-    maxRanks: 1,
-  },
-  SWIFTMEND_TALENT: {
-    id: 18562,
-    name: 'Swiftmend',
-    icon: 'inv_relics_idolofrejuvenation',
-    maxRanks: 1,
-    manaCost: 800,
-  },
-  STARSURGE_TALENT: {
-    id: 197626,
-    name: 'Starsurge',
-    icon: 'spell_arcane_arcane03',
-    maxRanks: 1,
-    manaCost: 300,
-  },
-  RIP_TALENT: { id: 1079, name: 'Rip', icon: 'ability_ghoulfrenzy', maxRanks: 1, energyCost: 20 },
-  SWIPE_TALENT: { id: 213764, name: 'Swipe', icon: 'inv_misc_monsterclaw_03', maxRanks: 1 },
-  IMPROVED_FRENZIED_REGENERATION_NNF_TALENT: {
-    id: 301768,
-    name: 'Improved Frenzied Regeneration (NNF)',
-    icon: 'ability_bullrush',
-    maxRanks: 1,
-  },
-  REMOVE_CORRUPTION_TALENT: {
-    id: 2782,
-    name: 'Remove Corruption',
-    icon: 'spell_holy_removecurse',
-    maxRanks: 1,
-    manaCost: 600,
-  },
-  MOONKIN_FORM_TALENT: {
-    id: 24858,
-    name: 'Moonkin Form',
-    icon: 'spell_nature_forceofnature',
-    maxRanks: 1,
-  },
-  MAIM_TALENT: {
-    id: 22570,
-    name: 'Maim',
-    icon: 'ability_druid_mangle.tga',
-    maxRanks: 1,
-    energyCost: 30,
-  },
-  KILLER_INSTINCT_TALENT: {
-    id: 108299,
-    name: 'Killer Instinct',
-    icon: 'ability_druid_predatoryinstincts',
-    maxRanks: 3,
-  },
-  IRONFUR_TALENT: {
-    id: 192081,
-    name: 'Ironfur',
-    icon: 'ability_druid_ironfur',
-    maxRanks: 1,
-    rageCost: 40,
-  },
-  NURTURING_INSTINCT_TALENT: {
-    id: 33873,
-    name: 'Nurturing Instinct',
-    icon: 'ability_druid_healinginstincts',
-    maxRanks: 3,
-  },
-  HIBERNATE_TALENT: {
-    id: 2637,
-    name: 'Hibernate',
-    icon: 'spell_nature_sleep',
-    maxRanks: 1,
-    manaCost: 600,
-  },
-  FELINE_SWIFTNESS_TALENT: {
-    id: 131768,
-    name: 'Feline Swiftness',
-    icon: 'spell_druid_tirelesspursuit',
-    maxRanks: 2,
-  },
-  SKULL_BASH_TALENT: { id: 106839, name: 'Skull Bash', icon: 'inv_bone_skull_04', maxRanks: 1 },
-  THICK_HIDE_TALENT: { id: 16931, name: 'Thick Hide', icon: 'inv_misc_pelt_bear_03', maxRanks: 2 },
-  WILD_CHARGE_TALENT: {
-    id: 102401,
-    name: 'Wild Charge',
-    icon: 'spell_druid_wildcharge',
-    maxRanks: 1,
-  },
-  TIGER_DASH_TALENT: {
-    id: 252216,
-    name: 'Tiger Dash',
-    icon: 'ability_druid_dash_orange',
-    maxRanks: 1,
-  },
-  NEW_RESTO_PASSIVE_NNF_TALENT: {
-    id: 377796,
-    name: 'New Resto Passive (NNF)',
-    icon: 'ability_druid_naturalperfection',
-    maxRanks: 2,
-  },
-  CYCLONE_TALENT: {
-    id: 33786,
-    name: 'Cyclone',
-    icon: 'spell_nature_earthbind',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  ASTRAL_INFLUENCE_TALENT: {
-    id: 197524,
-    name: 'Astral Influence',
-    icon: 'ability_skyreach_lens_flare',
-    maxRanks: 2,
-  },
-  TIRELESS_PURSUIT_TALENT: {
-    id: 377801,
-    name: 'Tireless Pursuit',
-    icon: 'spell_druid_tirelesspursuit',
-    maxRanks: 1,
-  },
-  SOOTHE_TALENT: {
-    id: 2908,
-    name: 'Soothe',
-    icon: 'ability_hunter_beastsoothe',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  SUNFIRE_TALENT: {
-    id: 93402,
-    name: 'Sunfire',
-    icon: 'ability_mage_firestarter',
-    maxRanks: 1,
-    manaCost: 1200,
-  },
-  TYPHOON_TALENT: { id: 132469, name: 'Typhoon', icon: 'ability_druid_typhoon', maxRanks: 1 },
-  PRIMAL_FURY_TALENT: {
-    id: 159286,
-    name: 'Primal Fury',
-    icon: 'ability_racial_cannibalize',
-    maxRanks: 1,
-  },
-  URSOCS_ENDURANCE_NNF_TALENT: {
-    id: 385786,
-    name: "Ursoc's Endurance (NNF)",
-    icon: 'spell_nature_stoneclawtotem',
-    maxRanks: 1,
-  },
-  STAMPEDING_ROAR_TALENT: {
-    id: 106898,
-    name: 'Stampeding Roar',
-    icon: 'spell_druid_stampedingroar_cat',
-    maxRanks: 1,
-  },
-  WILD_GROWTH_TALENT: {
-    id: 48438,
-    name: 'Wild Growth',
-    icon: 'ability_druid_flourish',
-    maxRanks: 1,
-    manaCost: 2200,
-  },
-  IMPROVED_SUNFIRE_TALENT: {
-    id: 231050,
-    name: 'Improved Sunfire',
-    icon: 'ability_mage_firestarter',
-    maxRanks: 1,
-  },
-  INCAPACITATING_ROAR_TALENT: {
-    id: 99,
-    name: 'Incapacitating Roar',
-    icon: 'ability_druid_demoralizingroar',
-    maxRanks: 1,
-  },
-  MIGHTY_BASH_TALENT: { id: 5211, name: 'Mighty Bash', icon: 'ability_druid_bash', maxRanks: 1 },
-  URSINE_VIGOR_TALENT: {
-    id: 377842,
-    name: 'Ursine Vigor',
-    icon: 'ability_druid_markofursol',
-    maxRanks: 2,
-  },
-  LYCARAS_TEACHINGS_TALENT: {
-    id: 378988,
-    name: "Lycara's Teachings",
-    icon: 'inv_trinket_ardenweald_02_green',
-    maxRanks: 3,
-  },
-  IMPROVED_REJUVENATION_TALENT: {
-    id: 231040,
-    name: 'Improved Rejuvenation',
-    icon: 'spell_nature_rejuvenation',
-    maxRanks: 1,
-  },
-  MASS_ENTANGLEMENT_TALENT: {
-    id: 102359,
-    name: 'Mass Entanglement',
-    icon: 'spell_druid_massentanglement',
-    maxRanks: 1,
-  },
-  URSOLS_VORTEX_TALENT: {
-    id: 102793,
-    name: "Ursol's Vortex",
-    icon: 'spell_druid_ursolsvortex',
-    maxRanks: 1,
-  },
-  WELL_HONED_INSTINCTS_TALENT: {
-    id: 377847,
-    name: 'Well-Honed Instincts',
-    icon: 'ability_druid_tigersroar',
-    maxRanks: 2,
-  },
-  IMPROVED_STAMPEDING_ROAR_TALENT: {
-    id: 288826,
-    name: 'Improved Stampeding Roar',
-    icon: 'spell_druid_stamedingroar',
-    maxRanks: 1,
-  },
-  RENEWAL_TALENT: { id: 108238, name: 'Renewal', icon: 'spell_nature_natureblessing', maxRanks: 1 },
-  INNERVATE_TALENT: { id: 29166, name: 'Innervate', icon: 'spell_nature_lightning', maxRanks: 1 },
-  FUROR_TALENT: { id: 378986, name: 'Furor', icon: 'spell_holy_blessingofstamina', maxRanks: 1 },
-  HEART_OF_THE_WILD_TALENT: {
-    id: 319454,
-    name: 'Heart of the Wild',
-    icon: 'spell_holy_blessingofagility',
-    maxRanks: 1,
-  },
-  NATURES_VIGIL_TALENT: {
-    id: 124974,
-    name: "Nature's Vigil",
-    icon: 'achievement_zone_feralas',
-    maxRanks: 1,
-  },
+  RAKE_TALENT,
+  FRENZIED_REGENERATION_TALENT,
+  REJUVENATION_TALENT,
+  STARFIRE_TALENT,
+  THRASH_TALENT,
+  IMPROVED_BARKSKIN_TALENT,
+  SWIFTMEND_TALENT,
+  STARSURGE_TALENT,
+  RIP_TALENT,
+  SWIPE_TALENT,
+  IMPROVED_FRENZIED_REGENERATION_NNF_TALENT,
+  REMOVE_CORRUPTION_TALENT,
+  MOONKIN_FORM_TALENT,
+  MAIM_TALENT,
+  KILLER_INSTINCT_TALENT,
+  IRONFUR_TALENT,
+  NURTURING_INSTINCT_TALENT,
+  HIBERNATE_TALENT,
+  FELINE_SWIFTNESS_TALENT,
+  SKULL_BASH_TALENT,
+  THICK_HIDE_TALENT,
+  WILD_CHARGE_TALENT,
+  TIGER_DASH_TALENT,
+  NEW_RESTO_PASSIVE_NNF_TALENT,
+  CYCLONE_TALENT,
+  ASTRAL_INFLUENCE_TALENT,
+  TIRELESS_PURSUIT_TALENT,
+  SOOTHE_TALENT,
+  SUNFIRE_TALENT,
+  TYPHOON_TALENT,
+  PRIMAL_FURY_TALENT,
+  URSOCS_ENDURANCE_NNF_TALENT,
+  STAMPEDING_ROAR_TALENT,
+  WILD_GROWTH_TALENT,
+  IMPROVED_SUNFIRE_TALENT,
+  INCAPACITATING_ROAR_TALENT,
+  MIGHTY_BASH_TALENT,
+  URSINE_VIGOR_TALENT,
+  LYCARAS_TEACHINGS_TALENT,
+  IMPROVED_REJUVENATION_TALENT,
+  MASS_ENTANGLEMENT_TALENT,
+  URSOLS_VORTEX_TALENT,
+  WELL_HONED_INSTINCTS_TALENT,
+  IMPROVED_STAMPEDING_ROAR_TALENT,
+  RENEWAL_TALENT,
+  INNERVATE_TALENT,
+  FUROR_TALENT,
+  HEART_OF_THE_WILD_TALENT,
+  NATURES_VIGIL_TALENT,
 
   //Feral
-  TIGERS_FURY_FERAL_TALENT: {
-    id: 231055,
-    name: "Tiger's Fury",
-    icon: 'ability_mount_jungletiger',
-    maxRanks: 3,
-  },
-  TIRELESS_ENERGY_FERAL_TALENT: {
-    id: 383352,
-    name: 'Tireless Energy',
-    icon: 'spell_chargepositive',
-    maxRanks: 3,
-  },
-  OMEN_OF_CLARITY_FERAL_TALENT: {
-    id: 16864,
-    name: 'Omen of Clarity',
-    icon: 'spell_nature_crystalball',
-    maxRanks: 1,
-  },
-  IMPROVED_SHRED_FERAL_TALENT: {
-    id: 343232,
-    name: 'Improved Shred',
-    icon: 'spell_shadow_vampiricaura',
-    maxRanks: 1,
-  },
-  SCENT_OF_BLOOD_FERAL_TALENT: {
-    id: 285564,
-    name: 'Scent of Blood',
-    icon: 'spell_druid_thrash',
-    maxRanks: 1,
-  },
-  PREDATOR_FERAL_TALENT: {
-    id: 202021,
-    name: 'Predator',
-    icon: 'ability_hunter_catlikereflexes',
-    maxRanks: 1,
-  },
-  SABERTOOTH_FERAL_TALENT: {
-    id: 202031,
-    name: 'Sabertooth',
-    icon: 'inv_misc_monsterfang_01',
-    maxRanks: 1,
-  },
-  IMPROVED_PROWL_NEEDS_POINTS_SCALING_FERAL_TALENT: {
-    id: 231052,
-    name: 'Improved Prowl [Needs Points Scaling]',
-    icon: 'ability_druid_prowl',
-    maxRanks: 2,
-  },
-  IMPROVED_BLEEDS_NEEDS_POINTS_SCALING_FERAL_TALENT: {
-    id: 231063,
-    name: 'Improved Bleeds (Needs Points Scaling)',
-    icon: 'inv_misc_monsterclaw_03',
-    maxRanks: 2,
-  },
-  SUDDEN_AMBUSH_FERAL_TALENT: {
-    id: 384667,
-    name: 'Sudden Ambush',
-    icon: 'ability_hunter_catlikereflexes',
-    maxRanks: 3,
-  },
-  BERSERK_FERAL_TALENT: { id: 343223, name: 'Berserk', icon: 'ability_druid_berserk', maxRanks: 1 },
-  TASTE_FOR_BLOOD_FERAL_TALENT: {
-    id: 384665,
-    name: 'Taste for Blood',
-    icon: 'ability_druid_ferociousbite',
-    maxRanks: 3,
-  },
-  LUNAR_INSPIRATION_FERAL_TALENT: {
-    id: 155580,
-    name: 'Lunar Inspiration',
-    icon: 'spell_druid_lunarinspiration',
-    maxRanks: 1,
-  },
-  PRIMAL_WRATH_FERAL_TALENT: {
-    id: 285381,
-    name: 'Primal Wrath',
-    icon: 'artifactability_feraldruid_ashamanesbite',
-    maxRanks: 1,
-    energyCost: 20,
-  },
-  MOMENT_OF_CLARITY_FERAL_TALENT: {
-    id: 236068,
-    name: 'Moment of Clarity',
-    icon: 'spell_druid_momentofclarity',
-    maxRanks: 1,
-  },
-  BRUTAL_SLASH_FERAL_TALENT: {
-    id: 202028,
-    name: 'Brutal Slash',
-    icon: 'ability_druid_ravage',
-    maxRanks: 1,
-    energyCost: 25,
-  },
-  SAVAGE_ROAR_FERAL_TALENT: {
-    id: 52610,
-    name: 'Savage Roar',
-    icon: 'ability_druid_skinteeth',
-    maxRanks: 1,
-    energyCost: 25,
-  },
-  PREDATORY_SWIFTNESS_FERAL_TALENT: {
-    id: 16974,
-    name: 'Predatory Swiftness',
-    icon: 'ability_hunter_pet_cat',
-    maxRanks: 1,
-  },
-  SURVIVAL_INSTINCTS_FERAL_TALENT: {
-    id: 61336,
-    name: 'Survival Instincts',
-    icon: 'ability_druid_tigersroar',
-    maxRanks: 1,
-  },
-  INFECTED_WOUNDS_FERAL_TALENT: {
-    id: 48484,
-    name: 'Infected Wounds',
-    icon: 'ability_druid_infectedwound',
-    maxRanks: 1,
-  },
-  BERSERK_JUNGLE_STALKER_FERAL_TALENT: {
-    id: 384671,
-    name: 'Berserk: Jungle Stalker',
-    icon: 'ability_druid_berserk',
-    maxRanks: 1,
-  },
-  CARNIVOROUS_INSTINCT_FERAL_TALENT: {
-    id: 340705,
-    name: 'Carnivorous Instinct',
-    icon: 'ability_mount_jungletiger',
-    maxRanks: 2,
-  },
-  EYE_OF_FEARFUL_SYMMETRY_FERAL_TALENT: {
-    id: 339141,
-    name: 'Eye of Fearful Symmetry',
-    icon: 'ability_druid_healinginstincts',
-    maxRanks: 2,
-  },
-  CATS_CURIOSITY_FERAL_TALENT: {
-    id: 386318,
-    name: "Cat's Curiosity",
-    icon: 'inv_jewelcrafting_gem_30',
-    maxRanks: 2,
-  },
-  BERSERK_FRENZY_FERAL_TALENT: {
-    id: 384668,
-    name: 'Berserk: Frenzy',
-    icon: 'ability_druid_berserk',
-    maxRanks: 1,
-  },
-  FERAL_FRENZY_FERAL_TALENT: {
-    id: 274837,
-    name: 'Feral Frenzy',
-    icon: 'ability_druid_rake',
-    maxRanks: 1,
-    energyCost: 25,
-  },
-  BLOODTALONS_FERAL_TALENT: {
-    id: 319439,
-    name: 'Bloodtalons',
-    icon: 'spell_druid_bloodythrash',
-    maxRanks: 1,
-  },
-  ADAPTIVE_SWARM_FERAL_TALENT: {
-    id: 325727,
-    name: 'Adaptive Swarm',
-    icon: 'ability_maldraxxus_druid',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  INCARNATION_AVATAR_OF_ASHAMANE_FERAL_TALENT: {
-    id: 102543,
-    name: 'Incarnation: Avatar of Ashamane',
-    icon: 'spell_druid_incarnation',
-    maxRanks: 1,
-  },
-  CONVOKE_THE_SPIRITS_FERAL_TALENT: {
-    id: 323764,
-    name: 'Convoke the Spirits',
-    icon: 'ability_ardenweald_druid',
-    maxRanks: 1,
-  },
-  SOUL_OF_THE_FOREST_FERAL_TALENT: {
-    id: 158476,
-    name: 'Soul of the Forest',
-    icon: 'ability_druid_manatree',
-    maxRanks: 1,
-  },
-  DRAUGHT_OF_DEEP_FOCUS_FERAL_TALENT: {
-    id: 338658,
-    name: 'Draught of Deep Focus',
-    icon: 'trade_alchemy_dpotion_d12',
-    maxRanks: 1,
-  },
-  APEX_PREDATORS_CRAVING_FERAL_TALENT: {
-    id: 339139,
-    name: "Apex Predator's Craving",
-    icon: 'ability_druid_primaltenacity',
-    maxRanks: 1,
-  },
-  UNBRIDLED_SWARM_FERAL_TALENT: {
-    id: 354123,
-    name: 'Unbridled Swarm',
-    icon: 'ability_maldraxxus_druid',
-    maxRanks: 2,
-  },
-  CIRCLE_OF_LIFE_AND_DEATH_FERAL_TALENT: {
-    id: 338657,
-    name: 'Circle of Life and Death',
-    icon: 'ability_druid_cyclone',
-    maxRanks: 1,
-  },
+  TIGERS_FURY_FERAL_TALENT,
+  TIRELESS_ENERGY_FERAL_TALENT,
+  OMEN_OF_CLARITY_FERAL_TALENT,
+  IMPROVED_SHRED_FERAL_TALENT,
+  SCENT_OF_BLOOD_FERAL_TALENT,
+  PREDATOR_FERAL_TALENT,
+  SABERTOOTH_FERAL_TALENT,
+  IMPROVED_PROWL_NEEDS_POINTS_SCALING_FERAL_TALENT,
+  IMPROVED_BLEEDS_NEEDS_POINTS_SCALING_FERAL_TALENT,
+  SUDDEN_AMBUSH_FERAL_TALENT,
+  BERSERK_FERAL_TALENT,
+  TASTE_FOR_BLOOD_FERAL_TALENT,
+  LUNAR_INSPIRATION_FERAL_TALENT,
+  PRIMAL_WRATH_FERAL_TALENT,
+  MOMENT_OF_CLARITY_FERAL_TALENT,
+  BRUTAL_SLASH_FERAL_TALENT,
+  SAVAGE_ROAR_FERAL_TALENT,
+  PREDATORY_SWIFTNESS_FERAL_TALENT,
+  SURVIVAL_INSTINCTS_FERAL_TALENT,
+  INFECTED_WOUNDS_FERAL_TALENT,
+  BERSERK_JUNGLE_STALKER_FERAL_TALENT,
+  CARNIVOROUS_INSTINCT_FERAL_TALENT,
+  EYE_OF_FEARFUL_SYMMETRY_FERAL_TALENT,
+  CATS_CURIOSITY_FERAL_TALENT,
+  BERSERK_FRENZY_FERAL_TALENT,
+  FERAL_FRENZY_FERAL_TALENT,
+  BLOODTALONS_FERAL_TALENT,
+  ADAPTIVE_SWARM_FERAL_TALENT,
+  INCARNATION_AVATAR_OF_ASHAMANE_FERAL_TALENT,
+  CONVOKE_THE_SPIRITS_FERAL_TALENT,
+  SOUL_OF_THE_FOREST_FERAL_TALENT,
+  DRAUGHT_OF_DEEP_FOCUS_FERAL_TALENT,
+  APEX_PREDATORS_CRAVING_FERAL_TALENT,
+  UNBRIDLED_SWARM_FERAL_TALENT,
+  CIRCLE_OF_LIFE_AND_DEATH_FERAL_TALENT,
 
   //Restoration
-  LIFEBLOOM_RESTORATION_TALENT: {
-    id: 33763,
-    name: 'Lifebloom',
-    icon: 'inv_misc_herb_felblossom',
-    maxRanks: 1,
-    manaCost: 800,
-  },
-  EFFLORESCENCE_RESTORATION_TALENT: {
-    id: 145205,
-    name: 'Efflorescence',
-    icon: 'inv_misc_herb_talandrasrose',
-    maxRanks: 1,
-    manaCost: 1700,
-  },
-  NATURES_SWIFTNESS_RESTORATION_TALENT: {
-    id: 132158,
-    name: "Nature's Swiftness",
-    icon: 'spell_nature_ravenform',
-    maxRanks: 1,
-  },
-  OMEN_OF_CLARITY_RESTORATION_TALENT: {
-    id: 113043,
-    name: 'Omen of Clarity',
-    icon: 'spell_nature_crystalball',
-    maxRanks: 1,
-  },
-  READY_FOR_ANYTHING_RESTORATION_TALENT: {
-    id: 382550,
-    name: 'Ready For Anything',
-    icon: 'spell_nature_ravenform',
-    maxRanks: 2,
-  },
-  IRONBARK_RESTORATION_TALENT: {
-    id: 102342,
-    name: 'Ironbark',
-    icon: 'spell_druid_ironbark',
-    maxRanks: 1,
-  },
-  IMPROVED_WILD_GROWTH_RESTORATION_TALENT: {
-    id: 328025,
-    name: 'Improved Wild Growth',
-    icon: 'ability_druid_flourish',
-    maxRanks: 1,
-  },
-  IMPROVED_REGROWTH_RESTORATION_TALENT: {
-    id: 231032,
-    name: 'Improved Regrowth',
-    icon: 'spell_nature_resistnature',
-    maxRanks: 2,
-  },
-  IMPROVED_IRONBARK_RESTORATION_TALENT: {
-    id: 382552,
-    name: 'Improved Ironbark',
-    icon: 'spell_druid_ironbark',
-    maxRanks: 2,
-  },
-  UNSTOPPABLE_GROWTH_RESTORATION_TALENT: {
-    id: 340549,
-    name: 'Unstoppable Growth',
-    icon: 'ability_druid_flourish',
-    maxRanks: 2,
-  },
-  TRANQUILITY_RESTORATION_TALENT: {
-    id: 740,
-    name: 'Tranquility',
-    icon: 'spell_nature_tranquility',
-    maxRanks: 1,
-    manaCost: 1800,
-  },
-  YSERAS_GIFT_RESTORATION_TALENT: {
-    id: 145108,
-    name: "Ysera's Gift",
-    icon: 'inv_misc_head_dragon_green',
-    maxRanks: 3,
-  },
-  NOURISH_RESTORATION_TALENT: {
-    id: 50464,
-    name: 'Nourish',
-    icon: 'ability_druid_nourish',
-    maxRanks: 1,
-    manaCost: 1800,
-  },
-  SOUL_OF_THE_FOREST_RESTORATION_TALENT: {
-    id: 158478,
-    name: 'Soul of the Forest',
-    icon: 'ability_druid_manatree',
-    maxRanks: 1,
-  },
-  INNER_PEACE_RESTORATION_TALENT: {
-    id: 197073,
-    name: 'Inner Peace',
-    icon: 'ability_druid_dreamstate',
-    maxRanks: 2,
-  },
-  CULTIVATION_RESTORATION_TALENT: {
-    id: 200390,
-    name: 'Cultivation',
-    icon: 'spell_nature_healingtouch',
-    maxRanks: 1,
-  },
-  DEEP_ROOTS_RESTORATION_TALENT: {
-    id: 383191,
-    name: 'Deep Roots',
-    icon: 'inv_misc_herb_liferoot_stem',
-    maxRanks: 2,
-  },
-  CENARION_WARD_RESTORATION_TALENT: {
-    id: 102351,
-    name: 'Cenarion Ward',
-    icon: 'ability_druid_naturalperfection',
-    maxRanks: 1,
-    manaCost: 900,
-  },
-  ABUNDANCE_RESTORATION_TALENT: {
-    id: 207383,
-    name: 'Abundance',
-    icon: 'ability_druid_empoweredrejuvination',
-    maxRanks: 1,
-  },
-  STONEBARK_RESTORATION_TALENT: {
-    id: 197061,
-    name: 'Stonebark',
-    icon: 'spell_druid_ironbark',
-    maxRanks: 2,
-  },
-  SPRING_BLOSSOMS_RESTORATION_TALENT: {
-    id: 207385,
-    name: 'Spring Blossoms',
-    icon: 'inv_misc_trailofflowers',
-    maxRanks: 1,
-  },
-  OVERGROWTH_RESTORATION_TALENT: {
-    id: 203651,
-    name: 'Overgrowth',
-    icon: 'ability_druid_overgrowth',
-    maxRanks: 1,
-    manaCost: 1200,
-  },
-  RAMPANT_GROWTH_RESTORATION_TALENT: {
-    id: 278515,
-    name: 'Rampant Growth',
-    icon: 'spell_nature_resistnature',
-    maxRanks: 1,
-  },
-  AUTUMN_LEAVES_NO_EXTENSION_RESTORATION_TALENT: {
-    id: 274432,
-    name: 'Autumn Leaves [no extension]',
-    icon: 'spell_nature_rejuvenation',
-    maxRanks: 2,
-  },
-  GROVE_TENDING_RESTORATION_TALENT: {
-    id: 279778,
-    name: 'Grove Tending',
-    icon: 'inv_relics_idolofrejuvenation',
-    maxRanks: 1,
-  },
-  MEMORY_OF_THE_MOTHER_TREE_RESTORATION_TALENT: {
-    id: 339064,
-    name: 'Memory of the Mother Tree',
-    icon: 'spell_druid_rampantgrowth',
-    maxRanks: 1,
-  },
-  GERMINATION_RESTORATION_TALENT: {
-    id: 155675,
-    name: 'Germination',
-    icon: 'spell_druid_germination',
-    maxRanks: 1,
-  },
-  ADAPTIVE_SWARM_RESTORATION_TALENT: {
-    id: 325727,
-    name: 'Adaptive Swarm',
-    icon: 'ability_maldraxxus_druid',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  INCARNATION_TREE_OF_LIFE_RESTORATION_TALENT: {
-    id: 33891,
-    name: 'Incarnation: Tree of Life',
-    icon: 'ability_druid_improvedtreeform',
-    maxRanks: 1,
-  },
-  CONVOKE_THE_SPIRITS_RESTORATION_TALENT: {
-    id: 323764,
-    name: 'Convoke the Spirits',
-    icon: 'ability_ardenweald_druid',
-    maxRanks: 1,
-  },
-  IMPROVED_INNERVATE_RESTORATION_TALENT: {
-    id: 326228,
-    name: 'Improved Innervate',
-    icon: 'spell_nature_lightning',
-    maxRanks: 1,
-  },
-  CIRCLE_OF_LIFE_AND_DEATH_RESTORATION_TALENT: {
-    id: 338657,
-    name: 'Circle of Life and Death',
-    icon: 'ability_druid_cyclone',
-    maxRanks: 2,
-  },
-  PHOTOSYNTHESIS_RESTORATION_TALENT: {
-    id: 274902,
-    name: 'Photosynthesis',
-    icon: 'spell_lifegivingseed',
-    maxRanks: 1,
-  },
-  THE_DARK_TITANS_LESSON_RESTORATION_TALENT: {
-    id: 338831,
-    name: "The Dark Titan's Lesson",
-    icon: 'spell_druid_germination_rejuvenation',
-    maxRanks: 1,
-  },
-  UNBRIDLED_SWARM_RESTORATION_TALENT: {
-    id: 354123,
-    name: 'Unbridled Swarm',
-    icon: 'ability_maldraxxus_druid',
-    maxRanks: 2,
-  },
-  EPHEMERAL_INCARNATION_RESTORATION_TALENT: {
-    id: 363495,
-    name: 'Ephemeral Incarnation',
-    icon: 'spell_progenitor_orb2',
-    maxRanks: 1,
-  },
-  FLOURISH_RESTORATION_TALENT: {
-    id: 197721,
-    name: 'Flourish',
-    icon: 'spell_druid_wildburst',
-    maxRanks: 1,
-  },
-  VERDANT_INFUSION_RESTORATION_TALENT: {
-    id: 338829,
-    name: 'Verdant Infusion',
-    icon: 'inv_relics_totemoflife',
-    maxRanks: 1,
-  },
-  VISION_OF_UNENDING_GROWTH_RESTORATION_TALENT: {
-    id: 338832,
-    name: 'Vision of Unending Growth',
-    icon: 'achievement_dungeon_everbloom',
-    maxRanks: 1,
-  },
+  LIFEBLOOM_RESTORATION_TALENT,
+  EFFLORESCENCE_RESTORATION_TALENT,
+  NATURES_SWIFTNESS_RESTORATION_TALENT,
+  OMEN_OF_CLARITY_RESTORATION_TALENT,
+  READY_FOR_ANYTHING_RESTORATION_TALENT,
+  IRONBARK_RESTORATION_TALENT,
+  IMPROVED_WILD_GROWTH_RESTORATION_TALENT,
+  IMPROVED_REGROWTH_RESTORATION_TALENT,
+  IMPROVED_IRONBARK_RESTORATION_TALENT,
+  UNSTOPPABLE_GROWTH_RESTORATION_TALENT,
+  TRANQUILITY_RESTORATION_TALENT,
+  YSERAS_GIFT_RESTORATION_TALENT,
+  NOURISH_RESTORATION_TALENT,
+  SOUL_OF_THE_FOREST_RESTORATION_TALENT,
+  INNER_PEACE_RESTORATION_TALENT,
+  CULTIVATION_RESTORATION_TALENT,
+  DEEP_ROOTS_RESTORATION_TALENT,
+  CENARION_WARD_RESTORATION_TALENT,
+  ABUNDANCE_RESTORATION_TALENT,
+  STONEBARK_RESTORATION_TALENT,
+  SPRING_BLOSSOMS_RESTORATION_TALENT,
+  OVERGROWTH_RESTORATION_TALENT,
+  RAMPANT_GROWTH_RESTORATION_TALENT,
+  AUTUMN_LEAVES_NO_EXTENSION_RESTORATION_TALENT,
+  GROVE_TENDING_RESTORATION_TALENT,
+  MEMORY_OF_THE_MOTHER_TREE_RESTORATION_TALENT,
+  GERMINATION_RESTORATION_TALENT,
+  ADAPTIVE_SWARM_RESTORATION_TALENT,
+  INCARNATION_TREE_OF_LIFE_RESTORATION_TALENT,
+  CONVOKE_THE_SPIRITS_RESTORATION_TALENT,
+  IMPROVED_INNERVATE_RESTORATION_TALENT,
+  CIRCLE_OF_LIFE_AND_DEATH_RESTORATION_TALENT,
+  PHOTOSYNTHESIS_RESTORATION_TALENT,
+  THE_DARK_TITANS_LESSON_RESTORATION_TALENT,
+  UNBRIDLED_SWARM_RESTORATION_TALENT,
+  EPHEMERAL_INCARNATION_RESTORATION_TALENT,
+  FLOURISH_RESTORATION_TALENT,
+  VERDANT_INFUSION_RESTORATION_TALENT,
+  VISION_OF_UNENDING_GROWTH_RESTORATION_TALENT,
 
   //Balance
-  ECLIPSE_BALANCE_TALENT: {
-    id: 79577,
-    name: 'Eclipse',
-    icon: 'ability_druid_eclipseorange',
-    maxRanks: 1,
-  },
-  IMPROVED_ECLIPSE_BALANCE_TALENT: {
-    id: 328021,
-    name: 'Improved Eclipse',
-    icon: 'ability_druid_eclipseorange',
-    maxRanks: 2,
-  },
-  IMPROVED_MOONFIRE_BALANCE_TALENT: {
-    id: 328023,
-    name: 'Improved Moonfire',
-    icon: 'spell_nature_starfall',
-    maxRanks: 2,
-  },
-  FORCE_OF_NATURE_BALANCE_TALENT: {
-    id: 205636,
-    name: 'Force of Nature',
-    icon: 'ability_druid_forceofnature',
-    maxRanks: 1,
-  },
-  NATURES_BALANCE_BALANCE_TALENT: {
-    id: 202430,
-    name: "Nature's Balance",
-    icon: 'ability_druid_balanceofpower',
-    maxRanks: 2,
-  },
-  WARRIOR_OF_ELUNE_BALANCE_TALENT: {
-    id: 202425,
-    name: 'Warrior of Elune',
-    icon: 'spell_holy_elunesgrace',
-    maxRanks: 1,
-  },
-  STARFALL_BALANCE_TALENT: {
-    id: 327541,
-    name: 'Starfall',
-    icon: 'ability_druid_starfall',
-    maxRanks: 2,
-  },
-  OWLKIN_FRENZY_BALANCE_TALENT: {
-    id: 231042,
-    name: 'Owlkin Frenzy',
-    icon: 'spell_nature_forceofnature',
-    maxRanks: 1,
-  },
-  CELESTIAL_ALIGNMENT_BALANCE_TALENT: {
-    id: 194223,
-    name: 'Celestial Alignment',
-    icon: 'spell_nature_natureguardian',
-    maxRanks: 1,
-  },
-  IMPROVED_STARSURGE_BALANCE_TALENT: {
-    id: 328022,
-    name: 'Improved Starsurge',
-    icon: 'spell_arcane_arcane03',
-    maxRanks: 1,
-  },
-  SOLAR_BEAM_BALANCE_TALENT: {
-    id: 78675,
-    name: 'Solar Beam',
-    icon: 'ability_vehicle_sonicshockwave',
-    maxRanks: 1,
-    manaCost: 1600,
-  },
-  SHOOTING_STARS_BALANCE_TALENT: {
-    id: 202342,
-    name: 'Shooting Stars',
-    icon: 'spell_priest_divinestar_shadow2',
-    maxRanks: 1,
-  },
-  POWER_OF_GOLDRINN_BALANCE_TALENT: {
-    id: 202996,
-    name: 'Power of Goldrinn',
-    icon: 'inv_mount_spectralwolf',
-    maxRanks: 2,
-  },
-  STARLORD_BALANCE_TALENT: {
-    id: 202345,
-    name: 'Starlord',
-    icon: 'spell_shaman_measuredinsight',
-    maxRanks: 2,
-  },
-  STELLAR_DRIFT_BALANCE_TALENT: {
-    id: 202354,
-    name: 'Stellar Drift',
-    icon: 'ability_druid_starfall',
-    maxRanks: 1,
-  },
-  STELLAR_INSPIRATION_BALANCE_TALENT: {
-    id: 383194,
-    name: 'Stellar Inspiration',
-    icon: 'ability_skyreach_lens_flare',
-    maxRanks: 2,
-  },
-  LIGHT_OF_THE_SUN_BALANCE_TALENT: {
-    id: 202918,
-    name: 'Light of the Sun',
-    icon: 'ability_vehicle_sonicshockwave',
-    maxRanks: 1,
-  },
-  UMBRAL_INTENSITY_BALANCE_TALENT: {
-    id: 383195,
-    name: 'Umbral Intensity',
-    icon: 'ability_druid_eclipse',
-    maxRanks: 2,
-  },
-  PRECISE_ALIGNMENT_BALANCE_TALENT: {
-    id: 340706,
-    name: 'Precise Alignment',
-    icon: 'spell_nature_natureguardian',
-    maxRanks: 1,
-  },
-  BLESSING_OF_ELUNE_BALANCE_TALENT: {
-    id: 202737,
-    name: 'Blessing of Elune',
-    icon: 'achievement_worldevent_lunar',
-    maxRanks: 1,
-  },
-  BLESSING_OF_ANSHE_BALANCE_TALENT: {
-    id: 202739,
-    name: "Blessing of An'she",
-    icon: 'spell_priest_divinestar_holy',
-    maxRanks: 1,
-  },
-  SOUL_OF_THE_FOREST_BALANCE_TALENT: {
-    id: 114107,
-    name: 'Soul of the Forest',
-    icon: 'ability_druid_manatree',
-    maxRanks: 1,
-  },
-  FURY_OF_THE_SKIES_BALANCE_TALENT: {
-    id: 384656,
-    name: 'Fury of the Skies',
-    icon: 'spell_druid_equinox',
-    maxRanks: 2,
-  },
-  STELLAR_FLARE_BALANCE_TALENT: {
-    id: 202347,
-    name: 'Stellar Flare',
-    icon: 'ability_druid_stellarflare',
-    maxRanks: 1,
-  },
-  TWIN_MOONS_BALANCE_TALENT: {
-    id: 279620,
-    name: 'Twin Moons',
-    icon: 'spell_nature_starfall',
-    maxRanks: 1,
-  },
-  SOLSTICE_BALANCE_TALENT: {
-    id: 343647,
-    name: 'Solstice',
-    icon: 'artifactability_balancedruid_moonandstars',
-    maxRanks: 2,
-  },
-  TIMEWORN_DREAMBINDER_NNF_BALANCE_TALENT: {
-    id: 339949,
-    name: 'Timeworn Dreambinder [NNF]',
-    icon: 'ability_creature_cursed_04',
-    maxRanks: 1,
-  },
-  ONETHS_CLEAR_VISION_NNF_BALANCE_TALENT: {
-    id: 338661,
-    name: "Oneth's Clear Vision [NNF]",
-    icon: 'spell_arcane_invocation',
-    maxRanks: 1,
-  },
-  UMBRAL_INFUSION_NNF_BALANCE_TALENT: {
-    id: 383196,
-    name: 'Umbral Infusion [NNF]',
-    icon: 'spell_animaardenweald_groundstate',
-    maxRanks: 2,
-  },
-  INCARNATION_CHOSEN_OF_ELUNE_BALANCE_TALENT: {
-    id: 102560,
-    name: 'Incarnation: Chosen of Elune',
-    icon: 'spell_druid_incarnation',
-    maxRanks: 1,
-  },
-  CONVOKE_THE_SPIRITS_BALANCE_TALENT: {
-    id: 323764,
-    name: 'Convoke the Spirits',
-    icon: 'ability_ardenweald_druid',
-    maxRanks: 1,
-  },
-  CIRCLE_OF_LIFE_AND_DEATH_BALANCE_TALENT: {
-    id: 338657,
-    name: 'Circle of Life and Death',
-    icon: 'ability_druid_cyclone',
-    maxRanks: 2,
-  },
-  SYZYGY_BALANCE_TALENT: {
-    id: 390378,
-    name: 'Syzygy',
-    icon: 'ability_druid_cresentburn',
-    maxRanks: 1,
-  },
-  PRIMORDIAL_ARCANIC_PULSAR_BALANCE_TALENT: {
-    id: 338668,
-    name: 'Primordial Arcanic Pulsar',
-    icon: 'spell_arcane_arcane03',
-    maxRanks: 1,
-  },
-  FURY_OF_ELUNE_BALANCE_TALENT: {
-    id: 202770,
-    name: 'Fury of Elune',
-    icon: 'ability_druid_dreamstate',
-    maxRanks: 1,
-  },
-  NEW_MOON_BALANCE_TALENT: {
-    id: 274281,
-    name: 'New Moon',
-    icon: 'artifactability_balancedruid_newmoon',
-    maxRanks: 1,
-  },
-  BALANCE_OF_ALL_THINGS_BALANCE_TALENT: {
-    id: 339942,
-    name: 'Balance of All Things',
-    icon: 'ability_druid_balanceofpower',
-    maxRanks: 1,
-  },
-  ADAPTIVE_SWARM_BALANCE_TALENT: {
-    id: 325727,
-    name: 'Adaptive Swarm',
-    icon: 'ability_maldraxxus_druid',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  ORBIT_BREAKER_BALANCE_TALENT: {
-    id: 383197,
-    name: 'Orbit Breaker',
-    icon: 'artifactability_balancedruid_moonandstars',
-    maxRanks: 1,
-  },
+  ECLIPSE_BALANCE_TALENT,
+  IMPROVED_ECLIPSE_BALANCE_TALENT,
+  IMPROVED_MOONFIRE_BALANCE_TALENT,
+  FORCE_OF_NATURE_BALANCE_TALENT,
+  NATURES_BALANCE_BALANCE_TALENT,
+  WARRIOR_OF_ELUNE_BALANCE_TALENT,
+  STARFALL_BALANCE_TALENT,
+  OWLKIN_FRENZY_BALANCE_TALENT,
+  CELESTIAL_ALIGNMENT_BALANCE_TALENT,
+  IMPROVED_STARSURGE_BALANCE_TALENT,
+  SOLAR_BEAM_BALANCE_TALENT,
+  SHOOTING_STARS_BALANCE_TALENT,
+  POWER_OF_GOLDRINN_BALANCE_TALENT,
+  STARLORD_BALANCE_TALENT,
+  STELLAR_DRIFT_BALANCE_TALENT,
+  STELLAR_INSPIRATION_BALANCE_TALENT,
+  LIGHT_OF_THE_SUN_BALANCE_TALENT,
+  UMBRAL_INTENSITY_BALANCE_TALENT,
+  PRECISE_ALIGNMENT_BALANCE_TALENT,
+  BLESSING_OF_ELUNE_BALANCE_TALENT,
+  BLESSING_OF_ANSHE_BALANCE_TALENT,
+  SOUL_OF_THE_FOREST_BALANCE_TALENT,
+  FURY_OF_THE_SKIES_BALANCE_TALENT,
+  STELLAR_FLARE_BALANCE_TALENT,
+  TWIN_MOONS_BALANCE_TALENT,
+  SOLSTICE_BALANCE_TALENT,
+  TIMEWORN_DREAMBINDER_NNF_BALANCE_TALENT,
+  ONETHS_CLEAR_VISION_NNF_BALANCE_TALENT,
+  UMBRAL_INFUSION_NNF_BALANCE_TALENT,
+  INCARNATION_CHOSEN_OF_ELUNE_BALANCE_TALENT,
+  CONVOKE_THE_SPIRITS_BALANCE_TALENT,
+  CIRCLE_OF_LIFE_AND_DEATH_BALANCE_TALENT,
+  SYZYGY_BALANCE_TALENT,
+  PRIMORDIAL_ARCANIC_PULSAR_BALANCE_TALENT,
+  FURY_OF_ELUNE_BALANCE_TALENT,
+  NEW_MOON_BALANCE_TALENT,
+  BALANCE_OF_ALL_THINGS_BALANCE_TALENT,
+  ADAPTIVE_SWARM_BALANCE_TALENT,
+  ORBIT_BREAKER_BALANCE_TALENT,
 
   //Guardian
-  MAUL_GUARDIAN_TALENT: {
-    id: 6807,
-    name: 'Maul',
-    icon: 'ability_druid_maul',
-    maxRanks: 1,
-    rageCost: 40,
-  },
-  GORE_GUARDIAN_TALENT: { id: 210706, name: 'Gore', icon: 'spell_druid_bearhug', maxRanks: 1 },
-  SURVIVAL_INSTINCTS_GUARDIAN_TALENT: {
-    id: 328767,
-    name: 'Survival Instincts',
-    icon: 'ability_druid_tigersroar',
-    maxRanks: 1,
-  },
-  BRISTLING_FUR_GUARDIAN_TALENT: {
-    id: 155835,
-    name: 'Bristling Fur',
-    icon: 'spell_druid_bristlingfur',
-    maxRanks: 1,
-  },
-  BRAMBLES_GUARDIAN_TALENT: {
-    id: 203953,
-    name: 'Brambles',
-    icon: 'inv_misc_thornnecklace',
-    maxRanks: 1,
-  },
-  URSINE_ADEPT_GUARDIAN_TALENT: {
-    id: 300346,
-    name: 'Ursine Adept',
-    icon: 'talentspec_druid_feral_bear',
-    maxRanks: 1,
-  },
-  MANGLE_GUARDIAN_TALENT: {
-    id: 231064,
-    name: 'Mangle',
-    icon: 'ability_druid_mangle2',
-    maxRanks: 1,
-  },
-  INNATE_RESOLVE_GUARDIAN_TALENT: {
-    id: 377811,
-    name: 'Innate Resolve',
-    icon: 'spell_nature_healingway',
-    maxRanks: 1,
-  },
-  INFECTED_WOUNDS_GUARDIAN_TALENT: {
-    id: 345208,
-    name: 'Infected Wounds',
-    icon: 'ability_druid_infectedwound',
-    maxRanks: 1,
-  },
-  BERSERK_RAVAGE_GUARDIAN_TALENT: {
-    id: 343240,
-    name: 'Berserk: Ravage',
-    icon: 'ability_druid_berserk',
-    maxRanks: 1,
-  },
-  URSOCS_ENDURANCE_GUARDIAN_TALENT: {
-    id: 200399,
-    name: "Ursoc's Endurance",
-    icon: 'ability_hunter_pet_bear',
-    maxRanks: 2,
-  },
-  GORY_FUR_GUARDIAN_TALENT: {
-    id: 200854,
-    name: 'Gory Fur',
-    icon: 'artifactability_guardiandruid_goryfur',
-    maxRanks: 1,
-  },
-  PAWSITIVE_OUTLOOK_GUARDIAN_TALENT: {
-    id: 238121,
-    name: 'Pawsitive Outlook',
-    icon: 'spell_druid_thrash',
-    maxRanks: 2,
-  },
-  TOOTH_AND_CLAW_GUARDIAN_TALENT: {
-    id: 135288,
-    name: 'Tooth and Claw',
-    icon: 'inv_misc_monsterfang_01',
-    maxRanks: 1,
-  },
-  LAYERED_MANE_GUARDIAN_TALENT: {
-    id: 279552,
-    name: 'Layered Mane',
-    icon: 'ability_druid_ironfur',
-    maxRanks: 2,
-  },
-  SCINTILLATING_MOONLIGHT_GUARDIAN_TALENT: {
-    id: 238049,
-    name: 'Scintillating Moonlight',
-    icon: 'spell_nature_starfall',
-    maxRanks: 2,
-  },
-  EARTHWARDEN_GUARDIAN_TALENT: {
-    id: 203974,
-    name: 'Earthwarden',
-    icon: 'spell_shaman_blessingofeternals',
-    maxRanks: 1,
-  },
-  VICIOUS_CYCLE_GUARDIAN_TALENT: {
-    id: 371999,
-    name: 'Vicious Cycle',
-    icon: 'spell_druid_bearhug',
-    maxRanks: 1,
-  },
-  VULNERABLE_FLESH_GUARDIAN_TALENT: {
-    id: 372618,
-    name: 'Vulnerable Flesh',
-    icon: 'ability_druid_primalagression',
-    maxRanks: 2,
-  },
-  FRONT_OF_THE_PACK_GUARDIAN_TALENT: {
-    id: 377835,
-    name: 'Front of the Pack',
-    icon: 'spell_druid_stampedingroar_cat',
-    maxRanks: 1,
-  },
-  REINFORCED_FUR_GUARDIAN_TALENT: {
-    id: 200395,
-    name: 'Reinforced Fur',
-    icon: 'spell_druid_malfurionstenacity',
-    maxRanks: 1,
-  },
-  GALACTIC_GUARDIAN_GUARDIAN_TALENT: {
-    id: 203964,
-    name: 'Galactic Guardian',
-    icon: 'spell_frost_iceclaw',
-    maxRanks: 1,
-  },
-  TWIN_MOONFIRE_GUARDIAN_TALENT: {
-    id: 372567,
-    name: 'Twin Moonfire',
-    icon: 'spell_nature_starfall',
-    maxRanks: 1,
-  },
-  BERSERK_UNCHECKED_AGGRESSION_GUARDIAN_TALENT: {
-    id: 377623,
-    name: 'Berserk: Unchecked Aggression',
-    icon: 'ability_druid_berserk',
-    maxRanks: 1,
-  },
-  FURY_OF_NATURE_GUARDIAN_TALENT: {
-    id: 370695,
-    name: 'Fury of Nature',
-    icon: 'spell_nature_moonglow',
-    maxRanks: 2,
-  },
-  BERSERK_PERSISTENCE_GUARDIAN_TALENT: {
-    id: 377779,
-    name: 'Berserk: Persistence',
-    icon: 'ability_druid_berserk',
-    maxRanks: 1,
-  },
-  REINVIGORATION_GUARDIAN_TALENT: {
-    id: 372945,
-    name: 'Reinvigoration',
-    icon: 'ability_druid_overgrowth',
-    maxRanks: 2,
-  },
-  CIRCLE_OF_LIFE_AND_DEATH_GUARDIAN_TALENT: {
-    id: 338657,
-    name: 'Circle of Life and Death',
-    icon: 'ability_druid_cyclone',
-    maxRanks: 2,
-  },
-  ELUNES_FAVORED_GUARDIAN_TALENT: {
-    id: 370586,
-    name: "Elune's Favored",
-    icon: 'spell_holy_elunesgrace',
-    maxRanks: 1,
-  },
-  SURVIVAL_OF_THE_FITTEST_GUARDIAN_TALENT: {
-    id: 203965,
-    name: 'Survival of the Fittest',
-    icon: 'ability_druid_enrage',
-    maxRanks: 2,
-  },
-  URSOCS_FURY_GUARDIAN_TALENT: {
-    id: 377210,
-    name: "Ursoc's Fury",
-    icon: 'achievement_emeraldnightmare_ursoc',
-    maxRanks: 1,
-  },
-  DREAM_OF_CENARIUS_GUARDIAN_TALENT: {
-    id: 372119,
-    name: 'Dream of Cenarius',
-    icon: 'ability_druid_dreamstate',
-    maxRanks: 1,
-  },
-  PULVERIZE_GUARDIAN_TALENT: {
-    id: 80313,
-    name: 'Pulverize',
-    icon: 'spell_druid_malfurionstenacity',
-    maxRanks: 1,
-  },
-  INCARNATION_GUARDIAN_OF_URSOC_GUARDIAN_TALENT: {
-    id: 102558,
-    name: 'Incarnation: Guardian of Ursoc',
-    icon: 'spell_druid_incarnation',
-    maxRanks: 1,
-  },
-  CONVOKE_THE_SPIRITS_GUARDIAN_TALENT: {
-    id: 337433,
-    name: 'Convoke the Spirits',
-    icon: 'ability_ardenweald_druid',
-    maxRanks: 1,
-  },
-  BLOOD_FRENZY_GUARDIAN_TALENT: {
-    id: 203962,
-    name: 'Blood Frenzy',
-    icon: 'ability_druid_primaltenacity',
-    maxRanks: 1,
-  },
-  SOUL_OF_THE_FOREST_GUARDIAN_TALENT: {
-    id: 158477,
-    name: 'Soul of the Forest',
-    icon: 'ability_druid_manatree',
-    maxRanks: 1,
-  },
-  AFTER_THE_WILDFIRE_GUARDIAN_TALENT: {
-    id: 371905,
-    name: 'After the Wildfire',
-    icon: 'spell_nature_naturetouchgrow',
-    maxRanks: 1,
-  },
-  GUARDIAN_OF_ELUNE_GUARDIAN_TALENT: {
-    id: 155578,
-    name: 'Guardian of Elune',
-    icon: 'spell_druid_guardianofelune',
-    maxRanks: 1,
-  },
-  REND_AND_TEAR_GUARDIAN_TALENT: {
-    id: 204053,
-    name: 'Rend and Tear',
-    icon: 'ability_druid_swipe',
-    maxRanks: 1,
-  },
-  UNTAMED_SAVAGERY_GUARDIAN_TALENT: {
-    id: 372943,
-    name: 'Untamed Savagery',
-    icon: 'spell_druid_bloodythrash',
-    maxRanks: 1,
-  },
-  RAGE_OF_THE_SLEEPER_GUARDIAN_TALENT: {
-    id: 200851,
-    name: 'Rage of the Sleeper',
-    icon: 'inv_hand_1h_artifactursoc_d_01',
-    maxRanks: 1,
-  },
+  MAUL_GUARDIAN_TALENT,
+  GORE_GUARDIAN_TALENT,
+  SURVIVAL_INSTINCTS_GUARDIAN_TALENT,
+  BRISTLING_FUR_GUARDIAN_TALENT,
+  BRAMBLES_GUARDIAN_TALENT,
+  URSINE_ADEPT_GUARDIAN_TALENT,
+  MANGLE_GUARDIAN_TALENT,
+  INNATE_RESOLVE_GUARDIAN_TALENT,
+  INFECTED_WOUNDS_GUARDIAN_TALENT,
+  BERSERK_RAVAGE_GUARDIAN_TALENT,
+  URSOCS_ENDURANCE_GUARDIAN_TALENT,
+  GORY_FUR_GUARDIAN_TALENT,
+  PAWSITIVE_OUTLOOK_GUARDIAN_TALENT,
+  TOOTH_AND_CLAW_GUARDIAN_TALENT,
+  LAYERED_MANE_GUARDIAN_TALENT,
+  SCINTILLATING_MOONLIGHT_GUARDIAN_TALENT,
+  EARTHWARDEN_GUARDIAN_TALENT,
+  VICIOUS_CYCLE_GUARDIAN_TALENT,
+  VULNERABLE_FLESH_GUARDIAN_TALENT,
+  FRONT_OF_THE_PACK_GUARDIAN_TALENT,
+  REINFORCED_FUR_GUARDIAN_TALENT,
+  GALACTIC_GUARDIAN_GUARDIAN_TALENT,
+  TWIN_MOONFIRE_GUARDIAN_TALENT,
+  BERSERK_UNCHECKED_AGGRESSION_GUARDIAN_TALENT,
+  FURY_OF_NATURE_GUARDIAN_TALENT,
+  BERSERK_PERSISTENCE_GUARDIAN_TALENT,
+  REINVIGORATION_GUARDIAN_TALENT,
+  CIRCLE_OF_LIFE_AND_DEATH_GUARDIAN_TALENT,
+  ELUNES_FAVORED_GUARDIAN_TALENT,
+  SURVIVAL_OF_THE_FITTEST_GUARDIAN_TALENT,
+  URSOCS_FURY_GUARDIAN_TALENT,
+  DREAM_OF_CENARIUS_GUARDIAN_TALENT,
+  PULVERIZE_GUARDIAN_TALENT,
+  INCARNATION_GUARDIAN_OF_URSOC_GUARDIAN_TALENT,
+  CONVOKE_THE_SPIRITS_GUARDIAN_TALENT,
+  BLOOD_FRENZY_GUARDIAN_TALENT,
+  SOUL_OF_THE_FOREST_GUARDIAN_TALENT,
+  AFTER_THE_WILDFIRE_GUARDIAN_TALENT,
+  GUARDIAN_OF_ELUNE_GUARDIAN_TALENT,
+  REND_AND_TEAR_GUARDIAN_TALENT,
+  UNTAMED_SAVAGERY_GUARDIAN_TALENT,
+  RAGE_OF_THE_SLEEPER_GUARDIAN_TALENT,
 });
 
 export default talents;

--- a/src/common/TALENTS/evoker.ts
+++ b/src/common/TALENTS/evoker.ts
@@ -1,796 +1,971 @@
 // Generated file, changes will eventually be overwritten!
-import { createTalentList } from './types';
+import { createTalentList, Talent } from './types';
+
+//region Shared
+export const LANDSLIDE_TALENT: Talent = {
+  id: 358385,
+  name: 'Landslide',
+  icon: 'ability_earthen_pillar',
+  maxRanks: 1,
+  manaCost: 200,
+};
+export const OBSIDIAN_SCALES_TALENT: Talent = {
+  id: 363916,
+  name: 'Obsidian Scales',
+  icon: 'inv_artifact_dragonscales',
+  maxRanks: 1,
+};
+export const EXPUNGE_TALENT: Talent = {
+  id: 365585,
+  name: 'Expunge',
+  icon: 'ability_evoker_fontofmagic_green',
+  maxRanks: 1,
+  manaCost: 100,
+};
+export const NATURAL_CONVERGENCE_TALENT: Talent = {
+  id: 369913,
+  name: 'Natural Convergence',
+  icon: 'spell_frost_frostblast',
+  maxRanks: 1,
+};
+export const PERMEATING_CHILL_TALENT: Talent = {
+  id: 370897,
+  name: 'Permeating Chill',
+  icon: 'spell_frost_coldhearted',
+  maxRanks: 1,
+};
+export const RESCUE_TALENT: Talent = {
+  id: 360995,
+  name: 'Rescue',
+  icon: 'ability_evoker_rescue',
+  maxRanks: 1,
+  manaCost: 300,
+};
+export const FORGER_OF_MOUNTAINS_TALENT: Talent = {
+  id: 375528,
+  name: 'Forger of Mountains',
+  icon: 'ability_earthen_pillar',
+  maxRanks: 1,
+};
+export const INNATE_MAGIC_TALENT: Talent = {
+  id: 375520,
+  name: 'Innate Magic',
+  icon: 'ability_evoker_innatemagic4',
+  maxRanks: 2,
+};
+export const OBSIDIAN_BULWARK_TALENT: Talent = {
+  id: 375406,
+  name: 'Obsidian Bulwark',
+  icon: 'inv_shield_1h_revenantfire_d_01',
+  maxRanks: 1,
+};
+export const ENKINDLED_TALENT: Talent = {
+  id: 375554,
+  name: 'Enkindled',
+  icon: 'ability_evoker_livingflame',
+  maxRanks: 2,
+};
+export const SCARLET_ADAPTATION_TALENT: Talent = {
+  id: 372469,
+  name: 'Scarlet Adaptation',
+  icon: 'inv_bijou_red',
+  maxRanks: 1,
+};
+export const QUELL_TALENT: Talent = {
+  id: 351338,
+  name: 'Quell',
+  icon: 'ability_evoker_quell',
+  maxRanks: 1,
+};
+export const RECALL_TALENT: Talent = {
+  id: 371806,
+  name: 'Recall',
+  icon: 'ability_evoker_recall',
+  maxRanks: 1,
+};
+export const HEAVY_WINGBEATS_TALENT: Talent = {
+  id: 368838,
+  name: 'Heavy Wingbeats',
+  icon: 'ability_racial_wingbuffet',
+  maxRanks: 1,
+};
+export const CLOBBERING_SWEEP_TALENT: Talent = {
+  id: 375443,
+  name: 'Clobbering Sweep',
+  icon: 'ability_racial_tailswipe',
+  maxRanks: 1,
+};
+export const TAILWIND_TALENT: Talent = {
+  id: 375556,
+  name: 'Tailwind',
+  icon: 'ability_skyreach_wind',
+  maxRanks: 1,
+};
+export const CAUTERIZING_FLAME_TALENT: Talent = {
+  id: 374251,
+  name: 'Cauterizing Flame',
+  icon: 'ability_evoker_fontofmagic_red',
+  maxRanks: 1,
+  manaCost: 100,
+};
+export const ROAR_OF_EXHILARATION_TALENT: Talent = {
+  id: 375507,
+  name: 'Roar of Exhilaration',
+  icon: 'ability_hunter_mastertactitian',
+  maxRanks: 1,
+};
+export const SUFFUSED_WITH_POWER_TALENT: Talent = {
+  id: 376164,
+  name: 'Suffused With Power',
+  icon: 'spell_arcane_studentofmagic',
+  maxRanks: 2,
+};
+export const TIP_THE_SCALES_TALENT: Talent = {
+  id: 370553,
+  name: 'Tip the Scales',
+  icon: 'ability_evoker_tipthescales',
+  maxRanks: 1,
+};
+export const ATTUNED_TO_THE_DREAM_TALENT: Talent = {
+  id: 376930,
+  name: 'Attuned to the Dream',
+  icon: 'ability_rogue_imrovedrecuperate',
+  maxRanks: 2,
+};
+export const SLEEP_WALK_TALENT: Talent = {
+  id: 360806,
+  name: 'Sleep Walk',
+  icon: 'ability_xavius_dreamsimulacrum',
+  maxRanks: 1,
+  manaCost: 200,
+};
+export const DRACONIC_LEGACY_TALENT: Talent = {
+  id: 376166,
+  name: 'Draconic Legacy',
+  icon: 'inv_helm_mail_dracthyrquest_b_02',
+  maxRanks: 2,
+};
+export const TEMPERED_SCALES_TALENT: Talent = {
+  id: 375544,
+  name: 'Tempered Scales',
+  icon: 'inv_misc_rubysanctum1',
+  maxRanks: 2,
+};
+export const EXTENDED_FLIGHT_TALENT: Talent = {
+  id: 375517,
+  name: 'Extended Flight',
+  icon: 'ability_evoker_hover',
+  maxRanks: 2,
+};
+export const BOUNTIFUL_BLOOM_TALENT: Talent = {
+  id: 370886,
+  name: 'Bountiful Bloom',
+  icon: 'ability_evoker_emeraldblossom',
+  maxRanks: 1,
+};
+export const ANCIENT_FLAME_TALENT: Talent = {
+  id: 369990,
+  name: 'Ancient Flame',
+  icon: 'inv_elemental_mote_fire01',
+  maxRanks: 1,
+};
+export const BLAST_FURNACE_TALENT: Talent = {
+  id: 375510,
+  name: 'Blast Furnace',
+  icon: 'ability_evoker_firebreath',
+  maxRanks: 2,
+};
+export const EXUBERANCE_TALENT: Talent = {
+  id: 375542,
+  name: 'Exuberance',
+  icon: 'achievement_guildperk_mountup',
+  maxRanks: 1,
+};
+export const SOURCE_OF_MAGIC_TALENT: Talent = {
+  id: 369459,
+  name: 'Source of Magic',
+  icon: 'ability_evoker_blue_01',
+  maxRanks: 1,
+};
+export const WALLOPING_BLOW_TALENT: Talent = {
+  id: 387341,
+  name: 'Walloping Blow',
+  icon: 'inv_misc_monsterscales_06',
+  maxRanks: 1,
+};
+export const GROVETENDERS_GIFT_TALENT: Talent = {
+  id: 387761,
+  name: "Grovetender's Gift",
+  icon: 'ability_druid_protectionofthegrove',
+  maxRanks: 1,
+};
+export const UNRAVEL_TALENT: Talent = {
+  id: 368432,
+  name: 'Unravel',
+  icon: 'ability_evoker_unravel',
+  maxRanks: 1,
+  manaCost: 100,
+};
+export const PROTRACTED_TALONS_TALENT: Talent = {
+  id: 369909,
+  name: 'Protracted Talons',
+  icon: 'ability_evoker_azurestrike',
+  maxRanks: 1,
+};
+export const OPPRESSING_ROAR_TALENT: Talent = {
+  id: 372048,
+  name: 'Oppressing Roar',
+  icon: 'ability_evoker_oppressingroar',
+  maxRanks: 1,
+};
+export const REGENERATIVE_MAGIC_TALENT: Talent = {
+  id: 387787,
+  name: 'Regenerative Magic',
+  icon: 'spell_frost_manarecharge',
+  maxRanks: 1,
+};
+export const FLY_WITH_ME_TALENT: Talent = {
+  id: 370665,
+  name: 'Fly With Me',
+  icon: 'ability_evoker_flywithme',
+  maxRanks: 1,
+};
+export const LUSH_GROWTH_TALENT: Talent = {
+  id: 375561,
+  name: 'Lush Growth',
+  icon: 'inv_staff_2h_bloodelf_c_01',
+  maxRanks: 2,
+};
+export const RENEWING_BLAZE_TALENT: Talent = {
+  id: 374348,
+  name: 'Renewing Blaze',
+  icon: 'ability_evoker_masterylifebinder_red',
+  maxRanks: 1,
+};
+export const LEAPING_FLAMES_TALENT: Talent = {
+  id: 369939,
+  name: 'Leaping Flames',
+  icon: 'spell_fire_flare',
+  maxRanks: 1,
+};
+export const OVERAWE_TALENT: Talent = {
+  id: 374346,
+  name: 'Overawe',
+  icon: 'ability_evoker_oppressingroar2',
+  maxRanks: 1,
+};
+export const AERIAL_MASTERY_TALENT: Talent = {
+  id: 365933,
+  name: 'Aerial Mastery',
+  icon: 'ability_evoker_aerialmastery',
+  maxRanks: 1,
+};
+export const TWIN_GUARDIAN_TALENT: Talent = {
+  id: 370888,
+  name: 'Twin Guardian',
+  icon: 'ability_skyreach_shielded',
+  maxRanks: 1,
+};
+export const PYREXIA_TALENT: Talent = {
+  id: 375574,
+  name: 'Pyrexia',
+  icon: 'spell_fire_incinerate',
+  maxRanks: 1,
+};
+export const FIRE_WITHIN_TALENT: Talent = {
+  id: 375577,
+  name: 'Fire Within',
+  icon: 'item_sparkofragnoros',
+  maxRanks: 1,
+};
+export const TERROR_OF_THE_SKIES_TALENT: Talent = {
+  id: 371032,
+  name: 'Terror of the Skies',
+  icon: 'ability_evoker_terroroftheskies',
+  maxRanks: 1,
+};
+export const TIME_SPIRAL_TALENT: Talent = {
+  id: 374968,
+  name: 'Time Spiral',
+  icon: 'ability_evoker_timespiral',
+  maxRanks: 1,
+};
+export const ZEPHYR_TALENT: Talent = {
+  id: 374227,
+  name: 'Zephyr',
+  icon: 'ability_evoker_hoverblack',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Devastation
+export const PYRE_DEVASTATION_TALENT: Talent = {
+  id: 357211,
+  name: 'Pyre',
+  icon: 'ability_evoker_pyre',
+  maxRanks: 1,
+  essenceCost: 3,
+};
+export const RUBY_ESSENCE_BURST_DEVASTATION_TALENT: Talent = {
+  id: 376872,
+  name: 'Ruby Essence Burst',
+  icon: 'ability_evoker_essenceburst4',
+  maxRanks: 1,
+};
+export const AZURE_ESSENCE_BURST_DEVASTATION_TALENT: Talent = {
+  id: 375721,
+  name: 'Azure Essence Burst',
+  icon: 'ability_evoker_essenceburst2',
+  maxRanks: 1,
+};
+export const DENSE_ENERGY_DEVASTATION_TALENT: Talent = {
+  id: 370962,
+  name: 'Dense Energy',
+  icon: 'ability_evoker_pyre',
+  maxRanks: 1,
+};
+export const IMPOSING_PRESENCE_DEVASTATION_TALENT: Talent = {
+  id: 371016,
+  name: 'Imposing Presence',
+  icon: 'ability_evoker_quell',
+  maxRanks: 1,
+};
+export const INNER_RADIANCE_DEVASTATION_TALENT: Talent = {
+  id: 386405,
+  name: 'Inner Radiance',
+  icon: 'spell_holy_spellwarding',
+  maxRanks: 1,
+};
+export const ETERNITY_SURGE_DEVASTATION_TALENT: Talent = {
+  id: 359073,
+  name: 'Eternity Surge',
+  icon: 'ability_evoker_eternitysurge',
+  maxRanks: 1,
+};
+export const VOLATILITY_DEVASTATION_TALENT: Talent = {
+  id: 369089,
+  name: 'Volatility',
+  icon: 'spell_fire_ragnaros_lavabolt',
+  maxRanks: 2,
+};
+export const POWER_NEXUS_DEVASTATION_TALENT: Talent = {
+  id: 369908,
+  name: 'Power Nexus',
+  icon: 'ability_evoker_powernexus',
+  maxRanks: 1,
+};
+export const DRAGONRAGE_DEVASTATION_TALENT: Talent = {
+  id: 375087,
+  name: 'Dragonrage',
+  icon: 'ability_evoker_dragonrage',
+  maxRanks: 1,
+};
+export const LAY_WASTE_DEVASTATION_TALENT: Talent = {
+  id: 371034,
+  name: 'Lay Waste',
+  icon: 'ability_evoker_deepbreath',
+  maxRanks: 2,
+};
+export const ARCANE_INTENSITY_DEVASTATION_TALENT: Talent = {
+  id: 375618,
+  name: 'Arcane Intensity',
+  icon: 'ability_evoker_disintegrate',
+  maxRanks: 2,
+};
+export const RUBY_EMBERS_DEVASTATION_TALENT: Talent = {
+  id: 365937,
+  name: 'Ruby Embers',
+  icon: 'inv_tradeskillitem_lessersorcerersfire',
+  maxRanks: 1,
+};
+export const ENGULFING_BLAZE_DEVASTATION_TALENT: Talent = {
+  id: 370837,
+  name: 'Engulfing Blaze',
+  icon: 'inv_inscription_pigment_ruby',
+  maxRanks: 1,
+};
+export const ANIMOSITY_DEVASTATION_TALENT: Talent = {
+  id: 375797,
+  name: 'Animosity',
+  icon: 'spell_nature_shamanrage',
+  maxRanks: 1,
+};
+export const ESSENCE_ATTUNEMENT_DEVASTATION_TALENT: Talent = {
+  id: 375722,
+  name: 'Essence Attunement',
+  icon: 'ability_evoker_essenceburststacks',
+  maxRanks: 1,
+};
+export const FIRESTORM_DEVASTATION_TALENT: Talent = {
+  id: 368847,
+  name: 'Firestorm',
+  icon: 'ability_evoker_firestorm',
+  maxRanks: 1,
+};
+export const HEAT_WAVE_DEVASTATION_TALENT: Talent = {
+  id: 375725,
+  name: 'Heat Wave',
+  icon: 'spell_fire_moltenblood',
+  maxRanks: 2,
+};
+export const MIGHT_OF_THE_ASPECTS_DEVASTATION_TALENT: Talent = {
+  id: 386272,
+  name: 'Might of the Aspects',
+  icon: 'spell_fireresistancetotem_01',
+  maxRanks: 2,
+};
+export const HONED_AGGRESSION_DEVASTATION_TALENT: Talent = {
+  id: 371038,
+  name: 'Honed Aggression',
+  icon: 'spell_fire_blueimmolation',
+  maxRanks: 2,
+};
+export const ETERNITYS_SPAN_DEVASTATION_TALENT: Talent = {
+  id: 375757,
+  name: "Eternity's Span",
+  icon: 'spell_arcane_arcanetorrent',
+  maxRanks: 1,
+};
+export const CONTINUUM_DEVASTATION_TALENT: Talent = {
+  id: 369375,
+  name: 'Continuum',
+  icon: 'ability_socererking_arcanewrath',
+  maxRanks: 1,
+};
+export const CAUSALITY_DEVASTATION_TALENT: Talent = {
+  id: 375777,
+  name: 'Causality',
+  icon: 'spell_azerite_essence_16',
+  maxRanks: 1,
+};
+export const CATALYZE_DEVASTATION_TALENT: Talent = {
+  id: 386283,
+  name: 'Catalyze',
+  icon: 'spell_fire_masterofelements',
+  maxRanks: 1,
+};
+export const RUIN_DEVASTATION_TALENT: Talent = {
+  id: 376888,
+  name: 'Ruin',
+  icon: 'ability_evoker_dragonrage2',
+  maxRanks: 1,
+};
+export const CHARGED_BLAST_DEVASTATION_TALENT: Talent = {
+  id: 370455,
+  name: 'Charged Blast',
+  icon: 'spell_arcane_arcanepotency',
+  maxRanks: 1,
+};
+export const SHATTERING_STAR_DEVASTATION_TALENT: Talent = {
+  id: 370452,
+  name: 'Shattering Star',
+  icon: 'ability_evoker_chargedblast',
+  maxRanks: 1,
+};
+export const SNAPFIRE_DEVASTATION_TALENT: Talent = {
+  id: 370783,
+  name: 'Snapfire',
+  icon: 'spell_shaman_improvedfirenova',
+  maxRanks: 1,
+};
+export const FONT_OF_MAGIC_DEVASTATION_TALENT: Talent = {
+  id: 375783,
+  name: 'Font of Magic',
+  icon: 'ability_evoker_fontofmagic',
+  maxRanks: 1,
+};
+export const ONYX_LEGACY_DEVASTATION_TALENT: Talent = {
+  id: 386348,
+  name: 'Onyx Legacy',
+  icon: 'inv_misc_head_dragon_black',
+  maxRanks: 1,
+};
+export const TYRANNY_DEVASTATION_TALENT: Talent = {
+  id: 370845,
+  name: 'Tyranny',
+  icon: 'spell_shaman_shockinglava',
+  maxRanks: 1,
+};
+export const FOCUSING_IRIS_DEVASTATION_TALENT: Talent = {
+  id: 386336,
+  name: 'Focusing Iris',
+  icon: 'spell_mage_temporalshield',
+  maxRanks: 1,
+};
+export const ARCANE_VIGOR_DEVASTATION_TALENT: Talent = {
+  id: 386342,
+  name: 'Arcane Vigor',
+  icon: 'spell_arcane_arcane01',
+  maxRanks: 1,
+};
+export const BURNOUT_DEVASTATION_TALENT: Talent = {
+  id: 375801,
+  name: 'Burnout',
+  icon: 'spell_fire_soulburn',
+  maxRanks: 2,
+};
+export const IMMINENT_DESTRUCTION_DEVASTATION_TALENT: Talent = {
+  id: 370781,
+  name: 'Imminent Destruction',
+  icon: 'spell_burningbladeshaman_blazing_radiance',
+  maxRanks: 2,
+};
+export const SCINTILLATION_DEVASTATION_TALENT: Talent = {
+  id: 370821,
+  name: 'Scintillation',
+  icon: 'spell_arcane_arcane03',
+  maxRanks: 2,
+};
+export const POWER_SWELL_DEVASTATION_TALENT: Talent = {
+  id: 370839,
+  name: 'Power Swell',
+  icon: 'ability_evoker_powernexus2',
+  maxRanks: 2,
+};
+export const FEED_THE_FLAMES_DEVASTATION_TALENT: Talent = {
+  id: 369846,
+  name: 'Feed the Flames',
+  icon: 'mace_1h_blacksmithing_d_04_icon',
+  maxRanks: 1,
+};
+export const EVERBURNING_FLAME_DEVASTATION_TALENT: Talent = {
+  id: 370819,
+  name: 'Everburning Flame',
+  icon: 'spell_fire_burnout',
+  maxRanks: 1,
+};
+export const CASCADING_POWER_DEVASTATION_TALENT: Talent = {
+  id: 375796,
+  name: 'Cascading Power',
+  icon: 'ability_evoker_innatemagic2',
+  maxRanks: 1,
+};
+export const IRIDESCENCE_DEVASTATION_TALENT: Talent = {
+  id: 370867,
+  name: 'Iridescence',
+  icon: 'ability_evoker_powerswell',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Preservation
+export const ECHO_PRESERVATION_TALENT: Talent = {
+  id: 364343,
+  name: 'Echo',
+  icon: 'ability_evoker_echo',
+  maxRanks: 1,
+  essenceCost: 2,
+};
+export const DREAM_BREATH_PRESERVATION_TALENT: Talent = {
+  id: 355936,
+  name: 'Dream Breath',
+  icon: 'ability_evoker_dreambreath',
+  maxRanks: 1,
+  manaCost: 400,
+};
+export const REVERSION_PRESERVATION_TALENT: Talent = {
+  id: 366155,
+  name: 'Reversion',
+  icon: 'ability_evoker_reversion',
+  maxRanks: 1,
+  manaCost: 200,
+};
+export const TEMPORAL_COMPRESSION_PRESERVATION_TALENT: Talent = {
+  id: 362874,
+  name: 'Temporal Compression',
+  icon: 'ability_evoker_rewind2',
+  maxRanks: 1,
+};
+export const ESSENCE_BURST_PRESERVATION_TALENT: Talent = {
+  id: 369297,
+  name: 'Essence Burst',
+  icon: 'ability_evoker_essenceburst',
+  maxRanks: 1,
+};
+export const REWIND_PRESERVATION_TALENT: Talent = {
+  id: 363534,
+  name: 'Rewind',
+  icon: 'ability_evoker_rewind',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const SPIRITBLOOM_PRESERVATION_TALENT: Talent = {
+  id: 367226,
+  name: 'Spiritbloom',
+  icon: 'ability_evoker_spiritbloom2',
+  maxRanks: 1,
+  manaCost: 300,
+};
+export const ESSENCE_ATTUNEMENT_PRESERVATION_TALENT: Talent = {
+  id: 375722,
+  name: 'Essence Attunement',
+  icon: 'ability_evoker_essenceburststacks',
+  maxRanks: 1,
+};
+export const TIME_DILATION_PRESERVATION_TALENT: Talent = {
+  id: 357170,
+  name: 'Time Dilation',
+  icon: 'ability_evoker_timedilation',
+  maxRanks: 1,
+  manaCost: 200,
+};
+export const EMERALD_COMMUNION_PRESERVATION_TALENT: Talent = {
+  id: 370960,
+  name: 'Emerald Communion',
+  icon: 'ability_evoker_green_01',
+  maxRanks: 1,
+};
+export const EMPATH_PRESERVATION_TALENT: Talent = {
+  id: 376138,
+  name: 'Empath',
+  icon: 'ability_evoker_powernexus2',
+  maxRanks: 1,
+};
+export const SPIRITUAL_CLARITY_PRESERVATION_TALENT: Talent = {
+  id: 376150,
+  name: 'Spiritual Clarity',
+  icon: 'ability_evoker_spiritbloom',
+  maxRanks: 1,
+};
+export const FLUTTERING_SEEDLINGS_PRESERVATION_TALENT: Talent = {
+  id: 359793,
+  name: 'Fluttering Seedlings',
+  icon: 'inv_herbalism_70_yserallineseed',
+  maxRanks: 2,
+};
+export const LIFE_GIVERS_FLAME_PRESERVATION_TALENT: Talent = {
+  id: 371426,
+  name: "Life Giver's Flame",
+  icon: 'item_sparkofragnoros',
+  maxRanks: 2,
+};
+export const GOLDEN_HOUR_PRESERVATION_TALENT: Talent = {
+  id: 378196,
+  name: 'Golden Hour',
+  icon: 'inv_belt_armor_waistoftime_d_01',
+  maxRanks: 1,
+};
+export const DELAY_HARM_PRESERVATION_TALENT: Talent = {
+  id: 376207,
+  name: 'Delay Harm',
+  icon: 'ability_racial_magicalresistance',
+  maxRanks: 1,
+};
+export const JUST_IN_TIME_PRESERVATION_TALENT: Talent = {
+  id: 376204,
+  name: 'Just in Time',
+  icon: 'inv_offhand_1h_artifactsilverhand_d_01',
+  maxRanks: 1,
+};
+export const TEMPORAL_ANOMALY_PRESERVATION_TALENT: Talent = {
+  id: 373861,
+  name: 'Temporal Anomaly',
+  icon: 'ability_evoker_temporalanomaly',
+  maxRanks: 1,
+  manaCost: 700,
+};
+export const DREAMWALKER_PRESERVATION_TALENT: Talent = {
+  id: 377082,
+  name: 'Dreamwalker',
+  icon: 'ability_hunter_onewithnature',
+  maxRanks: 1,
+};
+export const RUSH_OF_VITALITY_PRESERVATION_TALENT: Talent = {
+  id: 377086,
+  name: 'Rush of Vitality',
+  icon: 'trade_enchanting_greatermysteriousessence',
+  maxRanks: 1,
+};
+export const EXHILARATING_BURST_PRESERVATION_TALENT: Talent = {
+  id: 377100,
+  name: 'Exhilarating Burst',
+  icon: 'ability_evoker_essenceburst3',
+  maxRanks: 2,
+};
+export const FIELD_OF_DREAMS_PRESERVATION_TALENT: Talent = {
+  id: 370062,
+  name: 'Field of Dreams',
+  icon: 'inv_misc_herb_chamlotus',
+  maxRanks: 1,
+};
+export const LIFEFORCE_MENDER_PRESERVATION_TALENT: Talent = {
+  id: 376179,
+  name: 'Lifeforce Mender',
+  icon: 'ability_evoker_dragonrage2',
+  maxRanks: 3,
+};
+export const TIME_LORD_PRESERVATION_TALENT: Talent = {
+  id: 372527,
+  name: 'Time Lord',
+  icon: 'ability_evoker_innatemagic4',
+  maxRanks: 2,
+};
+export const FLOW_STATE_PRESERVATION_TALENT: Talent = {
+  id: 385696,
+  name: 'Flow State',
+  icon: 'ability_evoker_timespiral',
+  maxRanks: 2,
+};
+export const RESONATING_SPHERE_PRESERVATION_TALENT: Talent = {
+  id: 376236,
+  name: 'Resonating Sphere',
+  icon: 'ability_evoker_bronze_01',
+  maxRanks: 1,
+};
+export const NOZDORMUS_TEACHINGS_PRESERVATION_TALENT: Talent = {
+  id: 376237,
+  name: "Nozdormu's Teachings",
+  icon: 'inv_misc_head_dragon_bronze',
+  maxRanks: 1,
+};
+export const LIFEBIND_PRESERVATION_TALENT: Talent = {
+  id: 373270,
+  name: 'Lifebind',
+  icon: 'ability_evoker_hoverred',
+  maxRanks: 1,
+};
+export const CALL_OF_YSERA_PRESERVATION_TALENT: Talent = {
+  id: 373834,
+  name: 'Call of Ysera',
+  icon: '',
+  maxRanks: 1,
+};
+export const TIME_KEEPER_PRESERVATION_TALENT: Talent = {
+  id: 371270,
+  name: 'Time Keeper',
+  icon: 'inv_offhand_1h_ulduarraid_d_01',
+  maxRanks: 1,
+};
+export const SACRAL_EMPOWERMENT_PRESERVATION_TALENT: Talent = {
+  id: 377099,
+  name: 'Sacral Empowerment',
+  icon: 'ability_evoker_essenceburststacks',
+  maxRanks: 1,
+};
+export const POWER_NEXUS_PRESERVATION_TALENT: Talent = {
+  id: 369908,
+  name: 'Power Nexus',
+  icon: 'ability_evoker_powernexus',
+  maxRanks: 1,
+};
+export const OUROBOROS_PRESERVATION_TALENT: Talent = {
+  id: 381921,
+  name: 'Ouroboros',
+  icon: 'ability_evoker_innatemagic',
+  maxRanks: 1,
+};
+export const FONT_OF_MAGIC_PRESERVATION_TALENT: Talent = {
+  id: 375783,
+  name: 'Font of Magic',
+  icon: 'ability_evoker_fontofmagic',
+  maxRanks: 1,
+};
+export const BORROWED_TIME_PRESERVATION_TALENT: Talent = {
+  id: 376210,
+  name: 'Borrowed Time',
+  icon: 'ability_bossmagistrix_timewarp2',
+  maxRanks: 1,
+};
+export const TEMPORAL_ARTIFICER_PRESERVATION_TALENT: Talent = {
+  id: 381922,
+  name: 'Temporal Artificer',
+  icon: 'ability_evoker_rewind',
+  maxRanks: 1,
+};
+export const ENERGY_LOOP_PRESERVATION_TALENT: Talent = {
+  id: 372233,
+  name: 'Energy Loop',
+  icon: 'inv_elemental_mote_mana',
+  maxRanks: 1,
+};
+export const TIME_OF_NEED_PRESERVATION_TALENT: Talent = {
+  id: 368412,
+  name: 'Time of Need',
+  icon: 'ability_evoker_masterylifebinder_bronze',
+  maxRanks: 1,
+};
+export const RENEWING_BREATH_PRESERVATION_TALENT: Talent = {
+  id: 371257,
+  name: 'Renewing Breath',
+  icon: 'ability_evoker_dreambreath',
+  maxRanks: 2,
+};
+export const GRACE_PERIOD_PRESERVATION_TALENT: Talent = {
+  id: 376239,
+  name: 'Grace Period',
+  icon: 'ability_evoker_reversion_green',
+  maxRanks: 2,
+};
+export const TIMELESS_MAGIC_PRESERVATION_TALENT: Talent = {
+  id: 376240,
+  name: 'Timeless Magic',
+  icon: 'inv_artifact_xp05',
+  maxRanks: 2,
+};
+export const DREAM_FLIGHT_PRESERVATION_TALENT: Talent = {
+  id: 359816,
+  name: 'Dream Flight',
+  icon: 'ability_evoker_dreamflight',
+  maxRanks: 1,
+  manaCost: 400,
+};
+export const CYCLE_OF_LIFE_PRESERVATION_TALENT: Talent = {
+  id: 371832,
+  name: 'Cycle of Life',
+  icon: 'spell_lifegivingseed',
+  maxRanks: 1,
+};
+export const STASIS_PRESERVATION_TALENT: Talent = {
+  id: 370537,
+  name: 'Stasis',
+  icon: 'ability_evoker_stasis',
+  maxRanks: 1,
+  manaCost: 400,
+};
+
+//endregion
 
 const talents = createTalentList({
   //Shared
-  LANDSLIDE_TALENT: {
-    id: 358385,
-    name: 'Landslide',
-    icon: 'ability_earthen_pillar',
-    maxRanks: 1,
-    manaCost: 200,
-  },
-  OBSIDIAN_SCALES_TALENT: {
-    id: 363916,
-    name: 'Obsidian Scales',
-    icon: 'inv_artifact_dragonscales',
-    maxRanks: 1,
-  },
-  EXPUNGE_TALENT: {
-    id: 365585,
-    name: 'Expunge',
-    icon: 'ability_evoker_fontofmagic_green',
-    maxRanks: 1,
-    manaCost: 100,
-  },
-  NATURAL_CONVERGENCE_TALENT: {
-    id: 369913,
-    name: 'Natural Convergence',
-    icon: 'spell_frost_frostblast',
-    maxRanks: 1,
-  },
-  PERMEATING_CHILL_TALENT: {
-    id: 370897,
-    name: 'Permeating Chill',
-    icon: 'spell_frost_coldhearted',
-    maxRanks: 1,
-  },
-  RESCUE_TALENT: {
-    id: 360995,
-    name: 'Rescue',
-    icon: 'ability_evoker_rescue',
-    maxRanks: 1,
-    manaCost: 300,
-  },
-  FORGER_OF_MOUNTAINS_TALENT: {
-    id: 375528,
-    name: 'Forger of Mountains',
-    icon: 'ability_earthen_pillar',
-    maxRanks: 1,
-  },
-  INNATE_MAGIC_TALENT: {
-    id: 375520,
-    name: 'Innate Magic',
-    icon: 'ability_evoker_innatemagic4',
-    maxRanks: 2,
-  },
-  OBSIDIAN_BULWARK_TALENT: {
-    id: 375406,
-    name: 'Obsidian Bulwark',
-    icon: 'inv_shield_1h_revenantfire_d_01',
-    maxRanks: 1,
-  },
-  ENKINDLED_TALENT: {
-    id: 375554,
-    name: 'Enkindled',
-    icon: 'ability_evoker_livingflame',
-    maxRanks: 2,
-  },
-  SCARLET_ADAPTATION_TALENT: {
-    id: 372469,
-    name: 'Scarlet Adaptation',
-    icon: 'inv_bijou_red',
-    maxRanks: 1,
-  },
-  QUELL_TALENT: { id: 351338, name: 'Quell', icon: 'ability_evoker_quell', maxRanks: 1 },
-  RECALL_TALENT: { id: 371806, name: 'Recall', icon: 'ability_evoker_recall', maxRanks: 1 },
-  HEAVY_WINGBEATS_TALENT: {
-    id: 368838,
-    name: 'Heavy Wingbeats',
-    icon: 'ability_racial_wingbuffet',
-    maxRanks: 1,
-  },
-  CLOBBERING_SWEEP_TALENT: {
-    id: 375443,
-    name: 'Clobbering Sweep',
-    icon: 'ability_racial_tailswipe',
-    maxRanks: 1,
-  },
-  TAILWIND_TALENT: { id: 375556, name: 'Tailwind', icon: 'ability_skyreach_wind', maxRanks: 1 },
-  CAUTERIZING_FLAME_TALENT: {
-    id: 374251,
-    name: 'Cauterizing Flame',
-    icon: 'ability_evoker_fontofmagic_red',
-    maxRanks: 1,
-    manaCost: 100,
-  },
-  ROAR_OF_EXHILARATION_TALENT: {
-    id: 375507,
-    name: 'Roar of Exhilaration',
-    icon: 'ability_hunter_mastertactitian',
-    maxRanks: 1,
-  },
-  SUFFUSED_WITH_POWER_TALENT: {
-    id: 376164,
-    name: 'Suffused With Power',
-    icon: 'spell_arcane_studentofmagic',
-    maxRanks: 2,
-  },
-  TIP_THE_SCALES_TALENT: {
-    id: 370553,
-    name: 'Tip the Scales',
-    icon: 'ability_evoker_tipthescales',
-    maxRanks: 1,
-  },
-  ATTUNED_TO_THE_DREAM_TALENT: {
-    id: 376930,
-    name: 'Attuned to the Dream',
-    icon: 'ability_rogue_imrovedrecuperate',
-    maxRanks: 2,
-  },
-  SLEEP_WALK_TALENT: {
-    id: 360806,
-    name: 'Sleep Walk',
-    icon: 'ability_xavius_dreamsimulacrum',
-    maxRanks: 1,
-    manaCost: 200,
-  },
-  DRACONIC_LEGACY_TALENT: {
-    id: 376166,
-    name: 'Draconic Legacy',
-    icon: 'inv_helm_mail_dracthyrquest_b_02',
-    maxRanks: 2,
-  },
-  TEMPERED_SCALES_TALENT: {
-    id: 375544,
-    name: 'Tempered Scales',
-    icon: 'inv_misc_rubysanctum1',
-    maxRanks: 2,
-  },
-  EXTENDED_FLIGHT_TALENT: {
-    id: 375517,
-    name: 'Extended Flight',
-    icon: 'ability_evoker_hover',
-    maxRanks: 2,
-  },
-  BOUNTIFUL_BLOOM_TALENT: {
-    id: 370886,
-    name: 'Bountiful Bloom',
-    icon: 'ability_evoker_emeraldblossom',
-    maxRanks: 1,
-  },
-  ANCIENT_FLAME_TALENT: {
-    id: 369990,
-    name: 'Ancient Flame',
-    icon: 'inv_elemental_mote_fire01',
-    maxRanks: 1,
-  },
-  BLAST_FURNACE_TALENT: {
-    id: 375510,
-    name: 'Blast Furnace',
-    icon: 'ability_evoker_firebreath',
-    maxRanks: 2,
-  },
-  EXUBERANCE_TALENT: {
-    id: 375542,
-    name: 'Exuberance',
-    icon: 'achievement_guildperk_mountup',
-    maxRanks: 1,
-  },
-  SOURCE_OF_MAGIC_TALENT: {
-    id: 369459,
-    name: 'Source of Magic',
-    icon: 'ability_evoker_blue_01',
-    maxRanks: 1,
-  },
-  WALLOPING_BLOW_TALENT: {
-    id: 387341,
-    name: 'Walloping Blow',
-    icon: 'inv_misc_monsterscales_06',
-    maxRanks: 1,
-  },
-  GROVETENDERS_GIFT_TALENT: {
-    id: 387761,
-    name: "Grovetender's Gift",
-    icon: 'ability_druid_protectionofthegrove',
-    maxRanks: 1,
-  },
-  UNRAVEL_TALENT: {
-    id: 368432,
-    name: 'Unravel',
-    icon: 'ability_evoker_unravel',
-    maxRanks: 1,
-    manaCost: 100,
-  },
-  PROTRACTED_TALONS_TALENT: {
-    id: 369909,
-    name: 'Protracted Talons',
-    icon: 'ability_evoker_azurestrike',
-    maxRanks: 1,
-  },
-  OPPRESSING_ROAR_TALENT: {
-    id: 372048,
-    name: 'Oppressing Roar',
-    icon: 'ability_evoker_oppressingroar',
-    maxRanks: 1,
-  },
-  REGENERATIVE_MAGIC_TALENT: {
-    id: 387787,
-    name: 'Regenerative Magic',
-    icon: 'spell_frost_manarecharge',
-    maxRanks: 1,
-  },
-  FLY_WITH_ME_TALENT: {
-    id: 370665,
-    name: 'Fly With Me',
-    icon: 'ability_evoker_flywithme',
-    maxRanks: 1,
-  },
-  LUSH_GROWTH_TALENT: {
-    id: 375561,
-    name: 'Lush Growth',
-    icon: 'inv_staff_2h_bloodelf_c_01',
-    maxRanks: 2,
-  },
-  RENEWING_BLAZE_TALENT: {
-    id: 374348,
-    name: 'Renewing Blaze',
-    icon: 'ability_evoker_masterylifebinder_red',
-    maxRanks: 1,
-  },
-  LEAPING_FLAMES_TALENT: {
-    id: 369939,
-    name: 'Leaping Flames',
-    icon: 'spell_fire_flare',
-    maxRanks: 1,
-  },
-  OVERAWE_TALENT: {
-    id: 374346,
-    name: 'Overawe',
-    icon: 'ability_evoker_oppressingroar2',
-    maxRanks: 1,
-  },
-  AERIAL_MASTERY_TALENT: {
-    id: 365933,
-    name: 'Aerial Mastery',
-    icon: 'ability_evoker_aerialmastery',
-    maxRanks: 1,
-  },
-  TWIN_GUARDIAN_TALENT: {
-    id: 370888,
-    name: 'Twin Guardian',
-    icon: 'ability_skyreach_shielded',
-    maxRanks: 1,
-  },
-  PYREXIA_TALENT: { id: 375574, name: 'Pyrexia', icon: 'spell_fire_incinerate', maxRanks: 1 },
-  FIRE_WITHIN_TALENT: {
-    id: 375577,
-    name: 'Fire Within',
-    icon: 'item_sparkofragnoros',
-    maxRanks: 1,
-  },
-  TERROR_OF_THE_SKIES_TALENT: {
-    id: 371032,
-    name: 'Terror of the Skies',
-    icon: 'ability_evoker_terroroftheskies',
-    maxRanks: 1,
-  },
-  TIME_SPIRAL_TALENT: {
-    id: 374968,
-    name: 'Time Spiral',
-    icon: 'ability_evoker_timespiral',
-    maxRanks: 1,
-  },
-  ZEPHYR_TALENT: { id: 374227, name: 'Zephyr', icon: 'ability_evoker_hoverblack', maxRanks: 1 },
+  LANDSLIDE_TALENT,
+  OBSIDIAN_SCALES_TALENT,
+  EXPUNGE_TALENT,
+  NATURAL_CONVERGENCE_TALENT,
+  PERMEATING_CHILL_TALENT,
+  RESCUE_TALENT,
+  FORGER_OF_MOUNTAINS_TALENT,
+  INNATE_MAGIC_TALENT,
+  OBSIDIAN_BULWARK_TALENT,
+  ENKINDLED_TALENT,
+  SCARLET_ADAPTATION_TALENT,
+  QUELL_TALENT,
+  RECALL_TALENT,
+  HEAVY_WINGBEATS_TALENT,
+  CLOBBERING_SWEEP_TALENT,
+  TAILWIND_TALENT,
+  CAUTERIZING_FLAME_TALENT,
+  ROAR_OF_EXHILARATION_TALENT,
+  SUFFUSED_WITH_POWER_TALENT,
+  TIP_THE_SCALES_TALENT,
+  ATTUNED_TO_THE_DREAM_TALENT,
+  SLEEP_WALK_TALENT,
+  DRACONIC_LEGACY_TALENT,
+  TEMPERED_SCALES_TALENT,
+  EXTENDED_FLIGHT_TALENT,
+  BOUNTIFUL_BLOOM_TALENT,
+  ANCIENT_FLAME_TALENT,
+  BLAST_FURNACE_TALENT,
+  EXUBERANCE_TALENT,
+  SOURCE_OF_MAGIC_TALENT,
+  WALLOPING_BLOW_TALENT,
+  GROVETENDERS_GIFT_TALENT,
+  UNRAVEL_TALENT,
+  PROTRACTED_TALONS_TALENT,
+  OPPRESSING_ROAR_TALENT,
+  REGENERATIVE_MAGIC_TALENT,
+  FLY_WITH_ME_TALENT,
+  LUSH_GROWTH_TALENT,
+  RENEWING_BLAZE_TALENT,
+  LEAPING_FLAMES_TALENT,
+  OVERAWE_TALENT,
+  AERIAL_MASTERY_TALENT,
+  TWIN_GUARDIAN_TALENT,
+  PYREXIA_TALENT,
+  FIRE_WITHIN_TALENT,
+  TERROR_OF_THE_SKIES_TALENT,
+  TIME_SPIRAL_TALENT,
+  ZEPHYR_TALENT,
 
   //Devastation
-  PYRE_DEVASTATION_TALENT: {
-    id: 357211,
-    name: 'Pyre',
-    icon: 'ability_evoker_pyre',
-    maxRanks: 1,
-    essenceCost: 3,
-  },
-  RUBY_ESSENCE_BURST_DEVASTATION_TALENT: {
-    id: 376872,
-    name: 'Ruby Essence Burst',
-    icon: 'ability_evoker_essenceburst4',
-    maxRanks: 1,
-  },
-  AZURE_ESSENCE_BURST_DEVASTATION_TALENT: {
-    id: 375721,
-    name: 'Azure Essence Burst',
-    icon: 'ability_evoker_essenceburst2',
-    maxRanks: 1,
-  },
-  DENSE_ENERGY_DEVASTATION_TALENT: {
-    id: 370962,
-    name: 'Dense Energy',
-    icon: 'ability_evoker_pyre',
-    maxRanks: 1,
-  },
-  IMPOSING_PRESENCE_DEVASTATION_TALENT: {
-    id: 371016,
-    name: 'Imposing Presence',
-    icon: 'ability_evoker_quell',
-    maxRanks: 1,
-  },
-  INNER_RADIANCE_DEVASTATION_TALENT: {
-    id: 386405,
-    name: 'Inner Radiance',
-    icon: 'spell_holy_spellwarding',
-    maxRanks: 1,
-  },
-  ETERNITY_SURGE_DEVASTATION_TALENT: {
-    id: 359073,
-    name: 'Eternity Surge',
-    icon: 'ability_evoker_eternitysurge',
-    maxRanks: 1,
-  },
-  VOLATILITY_DEVASTATION_TALENT: {
-    id: 369089,
-    name: 'Volatility',
-    icon: 'spell_fire_ragnaros_lavabolt',
-    maxRanks: 2,
-  },
-  POWER_NEXUS_DEVASTATION_TALENT: {
-    id: 369908,
-    name: 'Power Nexus',
-    icon: 'ability_evoker_powernexus',
-    maxRanks: 1,
-  },
-  DRAGONRAGE_DEVASTATION_TALENT: {
-    id: 375087,
-    name: 'Dragonrage',
-    icon: 'ability_evoker_dragonrage',
-    maxRanks: 1,
-  },
-  LAY_WASTE_DEVASTATION_TALENT: {
-    id: 371034,
-    name: 'Lay Waste',
-    icon: 'ability_evoker_deepbreath',
-    maxRanks: 2,
-  },
-  ARCANE_INTENSITY_DEVASTATION_TALENT: {
-    id: 375618,
-    name: 'Arcane Intensity',
-    icon: 'ability_evoker_disintegrate',
-    maxRanks: 2,
-  },
-  RUBY_EMBERS_DEVASTATION_TALENT: {
-    id: 365937,
-    name: 'Ruby Embers',
-    icon: 'inv_tradeskillitem_lessersorcerersfire',
-    maxRanks: 1,
-  },
-  ENGULFING_BLAZE_DEVASTATION_TALENT: {
-    id: 370837,
-    name: 'Engulfing Blaze',
-    icon: 'inv_inscription_pigment_ruby',
-    maxRanks: 1,
-  },
-  ANIMOSITY_DEVASTATION_TALENT: {
-    id: 375797,
-    name: 'Animosity',
-    icon: 'spell_nature_shamanrage',
-    maxRanks: 1,
-  },
-  ESSENCE_ATTUNEMENT_DEVASTATION_TALENT: {
-    id: 375722,
-    name: 'Essence Attunement',
-    icon: 'ability_evoker_essenceburststacks',
-    maxRanks: 1,
-  },
-  FIRESTORM_DEVASTATION_TALENT: {
-    id: 368847,
-    name: 'Firestorm',
-    icon: 'ability_evoker_firestorm',
-    maxRanks: 1,
-  },
-  HEAT_WAVE_DEVASTATION_TALENT: {
-    id: 375725,
-    name: 'Heat Wave',
-    icon: 'spell_fire_moltenblood',
-    maxRanks: 2,
-  },
-  MIGHT_OF_THE_ASPECTS_DEVASTATION_TALENT: {
-    id: 386272,
-    name: 'Might of the Aspects',
-    icon: 'spell_fireresistancetotem_01',
-    maxRanks: 2,
-  },
-  HONED_AGGRESSION_DEVASTATION_TALENT: {
-    id: 371038,
-    name: 'Honed Aggression',
-    icon: 'spell_fire_blueimmolation',
-    maxRanks: 2,
-  },
-  ETERNITYS_SPAN_DEVASTATION_TALENT: {
-    id: 375757,
-    name: "Eternity's Span",
-    icon: 'spell_arcane_arcanetorrent',
-    maxRanks: 1,
-  },
-  CONTINUUM_DEVASTATION_TALENT: {
-    id: 369375,
-    name: 'Continuum',
-    icon: 'ability_socererking_arcanewrath',
-    maxRanks: 1,
-  },
-  CAUSALITY_DEVASTATION_TALENT: {
-    id: 375777,
-    name: 'Causality',
-    icon: 'spell_azerite_essence_16',
-    maxRanks: 1,
-  },
-  CATALYZE_DEVASTATION_TALENT: {
-    id: 386283,
-    name: 'Catalyze',
-    icon: 'spell_fire_masterofelements',
-    maxRanks: 1,
-  },
-  RUIN_DEVASTATION_TALENT: {
-    id: 376888,
-    name: 'Ruin',
-    icon: 'ability_evoker_dragonrage2',
-    maxRanks: 1,
-  },
-  CHARGED_BLAST_DEVASTATION_TALENT: {
-    id: 370455,
-    name: 'Charged Blast',
-    icon: 'spell_arcane_arcanepotency',
-    maxRanks: 1,
-  },
-  SHATTERING_STAR_DEVASTATION_TALENT: {
-    id: 370452,
-    name: 'Shattering Star',
-    icon: 'ability_evoker_chargedblast',
-    maxRanks: 1,
-  },
-  SNAPFIRE_DEVASTATION_TALENT: {
-    id: 370783,
-    name: 'Snapfire',
-    icon: 'spell_shaman_improvedfirenova',
-    maxRanks: 1,
-  },
-  FONT_OF_MAGIC_DEVASTATION_TALENT: {
-    id: 375783,
-    name: 'Font of Magic',
-    icon: 'ability_evoker_fontofmagic',
-    maxRanks: 1,
-  },
-  ONYX_LEGACY_DEVASTATION_TALENT: {
-    id: 386348,
-    name: 'Onyx Legacy',
-    icon: 'inv_misc_head_dragon_black',
-    maxRanks: 1,
-  },
-  TYRANNY_DEVASTATION_TALENT: {
-    id: 370845,
-    name: 'Tyranny',
-    icon: 'spell_shaman_shockinglava',
-    maxRanks: 1,
-  },
-  FOCUSING_IRIS_DEVASTATION_TALENT: {
-    id: 386336,
-    name: 'Focusing Iris',
-    icon: 'spell_mage_temporalshield',
-    maxRanks: 1,
-  },
-  ARCANE_VIGOR_DEVASTATION_TALENT: {
-    id: 386342,
-    name: 'Arcane Vigor',
-    icon: 'spell_arcane_arcane01',
-    maxRanks: 1,
-  },
-  BURNOUT_DEVASTATION_TALENT: {
-    id: 375801,
-    name: 'Burnout',
-    icon: 'spell_fire_soulburn',
-    maxRanks: 2,
-  },
-  IMMINENT_DESTRUCTION_DEVASTATION_TALENT: {
-    id: 370781,
-    name: 'Imminent Destruction',
-    icon: 'spell_burningbladeshaman_blazing_radiance',
-    maxRanks: 2,
-  },
-  SCINTILLATION_DEVASTATION_TALENT: {
-    id: 370821,
-    name: 'Scintillation',
-    icon: 'spell_arcane_arcane03',
-    maxRanks: 2,
-  },
-  POWER_SWELL_DEVASTATION_TALENT: {
-    id: 370839,
-    name: 'Power Swell',
-    icon: 'ability_evoker_powernexus2',
-    maxRanks: 2,
-  },
-  FEED_THE_FLAMES_DEVASTATION_TALENT: {
-    id: 369846,
-    name: 'Feed the Flames',
-    icon: 'mace_1h_blacksmithing_d_04_icon',
-    maxRanks: 1,
-  },
-  EVERBURNING_FLAME_DEVASTATION_TALENT: {
-    id: 370819,
-    name: 'Everburning Flame',
-    icon: 'spell_fire_burnout',
-    maxRanks: 1,
-  },
-  CASCADING_POWER_DEVASTATION_TALENT: {
-    id: 375796,
-    name: 'Cascading Power',
-    icon: 'ability_evoker_innatemagic2',
-    maxRanks: 1,
-  },
-  IRIDESCENCE_DEVASTATION_TALENT: {
-    id: 370867,
-    name: 'Iridescence',
-    icon: 'ability_evoker_powerswell',
-    maxRanks: 1,
-  },
+  PYRE_DEVASTATION_TALENT,
+  RUBY_ESSENCE_BURST_DEVASTATION_TALENT,
+  AZURE_ESSENCE_BURST_DEVASTATION_TALENT,
+  DENSE_ENERGY_DEVASTATION_TALENT,
+  IMPOSING_PRESENCE_DEVASTATION_TALENT,
+  INNER_RADIANCE_DEVASTATION_TALENT,
+  ETERNITY_SURGE_DEVASTATION_TALENT,
+  VOLATILITY_DEVASTATION_TALENT,
+  POWER_NEXUS_DEVASTATION_TALENT,
+  DRAGONRAGE_DEVASTATION_TALENT,
+  LAY_WASTE_DEVASTATION_TALENT,
+  ARCANE_INTENSITY_DEVASTATION_TALENT,
+  RUBY_EMBERS_DEVASTATION_TALENT,
+  ENGULFING_BLAZE_DEVASTATION_TALENT,
+  ANIMOSITY_DEVASTATION_TALENT,
+  ESSENCE_ATTUNEMENT_DEVASTATION_TALENT,
+  FIRESTORM_DEVASTATION_TALENT,
+  HEAT_WAVE_DEVASTATION_TALENT,
+  MIGHT_OF_THE_ASPECTS_DEVASTATION_TALENT,
+  HONED_AGGRESSION_DEVASTATION_TALENT,
+  ETERNITYS_SPAN_DEVASTATION_TALENT,
+  CONTINUUM_DEVASTATION_TALENT,
+  CAUSALITY_DEVASTATION_TALENT,
+  CATALYZE_DEVASTATION_TALENT,
+  RUIN_DEVASTATION_TALENT,
+  CHARGED_BLAST_DEVASTATION_TALENT,
+  SHATTERING_STAR_DEVASTATION_TALENT,
+  SNAPFIRE_DEVASTATION_TALENT,
+  FONT_OF_MAGIC_DEVASTATION_TALENT,
+  ONYX_LEGACY_DEVASTATION_TALENT,
+  TYRANNY_DEVASTATION_TALENT,
+  FOCUSING_IRIS_DEVASTATION_TALENT,
+  ARCANE_VIGOR_DEVASTATION_TALENT,
+  BURNOUT_DEVASTATION_TALENT,
+  IMMINENT_DESTRUCTION_DEVASTATION_TALENT,
+  SCINTILLATION_DEVASTATION_TALENT,
+  POWER_SWELL_DEVASTATION_TALENT,
+  FEED_THE_FLAMES_DEVASTATION_TALENT,
+  EVERBURNING_FLAME_DEVASTATION_TALENT,
+  CASCADING_POWER_DEVASTATION_TALENT,
+  IRIDESCENCE_DEVASTATION_TALENT,
 
   //Preservation
-  ECHO_PRESERVATION_TALENT: {
-    id: 364343,
-    name: 'Echo',
-    icon: 'ability_evoker_echo',
-    maxRanks: 1,
-    essenceCost: 2,
-  },
-  DREAM_BREATH_PRESERVATION_TALENT: {
-    id: 355936,
-    name: 'Dream Breath',
-    icon: 'ability_evoker_dreambreath',
-    maxRanks: 1,
-    manaCost: 400,
-  },
-  REVERSION_PRESERVATION_TALENT: {
-    id: 366155,
-    name: 'Reversion',
-    icon: 'ability_evoker_reversion',
-    maxRanks: 1,
-    manaCost: 200,
-  },
-  TEMPORAL_COMPRESSION_PRESERVATION_TALENT: {
-    id: 362874,
-    name: 'Temporal Compression',
-    icon: 'ability_evoker_rewind2',
-    maxRanks: 1,
-  },
-  ESSENCE_BURST_PRESERVATION_TALENT: {
-    id: 369297,
-    name: 'Essence Burst',
-    icon: 'ability_evoker_essenceburst',
-    maxRanks: 1,
-  },
-  REWIND_PRESERVATION_TALENT: {
-    id: 363534,
-    name: 'Rewind',
-    icon: 'ability_evoker_rewind',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  SPIRITBLOOM_PRESERVATION_TALENT: {
-    id: 367226,
-    name: 'Spiritbloom',
-    icon: 'ability_evoker_spiritbloom2',
-    maxRanks: 1,
-    manaCost: 300,
-  },
-  ESSENCE_ATTUNEMENT_PRESERVATION_TALENT: {
-    id: 375722,
-    name: 'Essence Attunement',
-    icon: 'ability_evoker_essenceburststacks',
-    maxRanks: 1,
-  },
-  TIME_DILATION_PRESERVATION_TALENT: {
-    id: 357170,
-    name: 'Time Dilation',
-    icon: 'ability_evoker_timedilation',
-    maxRanks: 1,
-    manaCost: 200,
-  },
-  EMERALD_COMMUNION_PRESERVATION_TALENT: {
-    id: 370960,
-    name: 'Emerald Communion',
-    icon: 'ability_evoker_green_01',
-    maxRanks: 1,
-  },
-  EMPATH_PRESERVATION_TALENT: {
-    id: 376138,
-    name: 'Empath',
-    icon: 'ability_evoker_powernexus2',
-    maxRanks: 1,
-  },
-  SPIRITUAL_CLARITY_PRESERVATION_TALENT: {
-    id: 376150,
-    name: 'Spiritual Clarity',
-    icon: 'ability_evoker_spiritbloom',
-    maxRanks: 1,
-  },
-  FLUTTERING_SEEDLINGS_PRESERVATION_TALENT: {
-    id: 359793,
-    name: 'Fluttering Seedlings',
-    icon: 'inv_herbalism_70_yserallineseed',
-    maxRanks: 2,
-  },
-  LIFE_GIVERS_FLAME_PRESERVATION_TALENT: {
-    id: 371426,
-    name: "Life Giver's Flame",
-    icon: 'item_sparkofragnoros',
-    maxRanks: 2,
-  },
-  GOLDEN_HOUR_PRESERVATION_TALENT: {
-    id: 378196,
-    name: 'Golden Hour',
-    icon: 'inv_belt_armor_waistoftime_d_01',
-    maxRanks: 1,
-  },
-  DELAY_HARM_PRESERVATION_TALENT: {
-    id: 376207,
-    name: 'Delay Harm',
-    icon: 'ability_racial_magicalresistance',
-    maxRanks: 1,
-  },
-  JUST_IN_TIME_PRESERVATION_TALENT: {
-    id: 376204,
-    name: 'Just in Time',
-    icon: 'inv_offhand_1h_artifactsilverhand_d_01',
-    maxRanks: 1,
-  },
-  TEMPORAL_ANOMALY_PRESERVATION_TALENT: {
-    id: 373861,
-    name: 'Temporal Anomaly',
-    icon: 'ability_evoker_temporalanomaly',
-    maxRanks: 1,
-    manaCost: 700,
-  },
-  DREAMWALKER_PRESERVATION_TALENT: {
-    id: 377082,
-    name: 'Dreamwalker',
-    icon: 'ability_hunter_onewithnature',
-    maxRanks: 1,
-  },
-  RUSH_OF_VITALITY_PRESERVATION_TALENT: {
-    id: 377086,
-    name: 'Rush of Vitality',
-    icon: 'trade_enchanting_greatermysteriousessence',
-    maxRanks: 1,
-  },
-  EXHILARATING_BURST_PRESERVATION_TALENT: {
-    id: 377100,
-    name: 'Exhilarating Burst',
-    icon: 'ability_evoker_essenceburst3',
-    maxRanks: 2,
-  },
-  FIELD_OF_DREAMS_PRESERVATION_TALENT: {
-    id: 370062,
-    name: 'Field of Dreams',
-    icon: 'inv_misc_herb_chamlotus',
-    maxRanks: 1,
-  },
-  LIFEFORCE_MENDER_PRESERVATION_TALENT: {
-    id: 376179,
-    name: 'Lifeforce Mender',
-    icon: 'ability_evoker_dragonrage2',
-    maxRanks: 3,
-  },
-  TIME_LORD_PRESERVATION_TALENT: {
-    id: 372527,
-    name: 'Time Lord',
-    icon: 'ability_evoker_innatemagic4',
-    maxRanks: 2,
-  },
-  FLOW_STATE_PRESERVATION_TALENT: {
-    id: 385696,
-    name: 'Flow State',
-    icon: 'ability_evoker_timespiral',
-    maxRanks: 2,
-  },
-  RESONATING_SPHERE_PRESERVATION_TALENT: {
-    id: 376236,
-    name: 'Resonating Sphere',
-    icon: 'ability_evoker_bronze_01',
-    maxRanks: 1,
-  },
-  NOZDORMUS_TEACHINGS_PRESERVATION_TALENT: {
-    id: 376237,
-    name: "Nozdormu's Teachings",
-    icon: 'inv_misc_head_dragon_bronze',
-    maxRanks: 1,
-  },
-  LIFEBIND_PRESERVATION_TALENT: {
-    id: 373270,
-    name: 'Lifebind',
-    icon: 'ability_evoker_hoverred',
-    maxRanks: 1,
-  },
-  CALL_OF_YSERA_PRESERVATION_TALENT: { id: 373834, name: 'Call of Ysera', icon: '', maxRanks: 1 },
-  TIME_KEEPER_PRESERVATION_TALENT: {
-    id: 371270,
-    name: 'Time Keeper',
-    icon: 'inv_offhand_1h_ulduarraid_d_01',
-    maxRanks: 1,
-  },
-  SACRAL_EMPOWERMENT_PRESERVATION_TALENT: {
-    id: 377099,
-    name: 'Sacral Empowerment',
-    icon: 'ability_evoker_essenceburststacks',
-    maxRanks: 1,
-  },
-  POWER_NEXUS_PRESERVATION_TALENT: {
-    id: 369908,
-    name: 'Power Nexus',
-    icon: 'ability_evoker_powernexus',
-    maxRanks: 1,
-  },
-  OUROBOROS_PRESERVATION_TALENT: {
-    id: 381921,
-    name: 'Ouroboros',
-    icon: 'ability_evoker_innatemagic',
-    maxRanks: 1,
-  },
-  FONT_OF_MAGIC_PRESERVATION_TALENT: {
-    id: 375783,
-    name: 'Font of Magic',
-    icon: 'ability_evoker_fontofmagic',
-    maxRanks: 1,
-  },
-  BORROWED_TIME_PRESERVATION_TALENT: {
-    id: 376210,
-    name: 'Borrowed Time',
-    icon: 'ability_bossmagistrix_timewarp2',
-    maxRanks: 1,
-  },
-  TEMPORAL_ARTIFICER_PRESERVATION_TALENT: {
-    id: 381922,
-    name: 'Temporal Artificer',
-    icon: 'ability_evoker_rewind',
-    maxRanks: 1,
-  },
-  ENERGY_LOOP_PRESERVATION_TALENT: {
-    id: 372233,
-    name: 'Energy Loop',
-    icon: 'inv_elemental_mote_mana',
-    maxRanks: 1,
-  },
-  TIME_OF_NEED_PRESERVATION_TALENT: {
-    id: 368412,
-    name: 'Time of Need',
-    icon: 'ability_evoker_masterylifebinder_bronze',
-    maxRanks: 1,
-  },
-  RENEWING_BREATH_PRESERVATION_TALENT: {
-    id: 371257,
-    name: 'Renewing Breath',
-    icon: 'ability_evoker_dreambreath',
-    maxRanks: 2,
-  },
-  GRACE_PERIOD_PRESERVATION_TALENT: {
-    id: 376239,
-    name: 'Grace Period',
-    icon: 'ability_evoker_reversion_green',
-    maxRanks: 2,
-  },
-  TIMELESS_MAGIC_PRESERVATION_TALENT: {
-    id: 376240,
-    name: 'Timeless Magic',
-    icon: 'inv_artifact_xp05',
-    maxRanks: 2,
-  },
-  DREAM_FLIGHT_PRESERVATION_TALENT: {
-    id: 359816,
-    name: 'Dream Flight',
-    icon: 'ability_evoker_dreamflight',
-    maxRanks: 1,
-    manaCost: 400,
-  },
-  CYCLE_OF_LIFE_PRESERVATION_TALENT: {
-    id: 371832,
-    name: 'Cycle of Life',
-    icon: 'spell_lifegivingseed',
-    maxRanks: 1,
-  },
-  STASIS_PRESERVATION_TALENT: {
-    id: 370537,
-    name: 'Stasis',
-    icon: 'ability_evoker_stasis',
-    maxRanks: 1,
-    manaCost: 400,
-  },
+  ECHO_PRESERVATION_TALENT,
+  DREAM_BREATH_PRESERVATION_TALENT,
+  REVERSION_PRESERVATION_TALENT,
+  TEMPORAL_COMPRESSION_PRESERVATION_TALENT,
+  ESSENCE_BURST_PRESERVATION_TALENT,
+  REWIND_PRESERVATION_TALENT,
+  SPIRITBLOOM_PRESERVATION_TALENT,
+  ESSENCE_ATTUNEMENT_PRESERVATION_TALENT,
+  TIME_DILATION_PRESERVATION_TALENT,
+  EMERALD_COMMUNION_PRESERVATION_TALENT,
+  EMPATH_PRESERVATION_TALENT,
+  SPIRITUAL_CLARITY_PRESERVATION_TALENT,
+  FLUTTERING_SEEDLINGS_PRESERVATION_TALENT,
+  LIFE_GIVERS_FLAME_PRESERVATION_TALENT,
+  GOLDEN_HOUR_PRESERVATION_TALENT,
+  DELAY_HARM_PRESERVATION_TALENT,
+  JUST_IN_TIME_PRESERVATION_TALENT,
+  TEMPORAL_ANOMALY_PRESERVATION_TALENT,
+  DREAMWALKER_PRESERVATION_TALENT,
+  RUSH_OF_VITALITY_PRESERVATION_TALENT,
+  EXHILARATING_BURST_PRESERVATION_TALENT,
+  FIELD_OF_DREAMS_PRESERVATION_TALENT,
+  LIFEFORCE_MENDER_PRESERVATION_TALENT,
+  TIME_LORD_PRESERVATION_TALENT,
+  FLOW_STATE_PRESERVATION_TALENT,
+  RESONATING_SPHERE_PRESERVATION_TALENT,
+  NOZDORMUS_TEACHINGS_PRESERVATION_TALENT,
+  LIFEBIND_PRESERVATION_TALENT,
+  CALL_OF_YSERA_PRESERVATION_TALENT,
+  TIME_KEEPER_PRESERVATION_TALENT,
+  SACRAL_EMPOWERMENT_PRESERVATION_TALENT,
+  POWER_NEXUS_PRESERVATION_TALENT,
+  OUROBOROS_PRESERVATION_TALENT,
+  FONT_OF_MAGIC_PRESERVATION_TALENT,
+  BORROWED_TIME_PRESERVATION_TALENT,
+  TEMPORAL_ARTIFICER_PRESERVATION_TALENT,
+  ENERGY_LOOP_PRESERVATION_TALENT,
+  TIME_OF_NEED_PRESERVATION_TALENT,
+  RENEWING_BREATH_PRESERVATION_TALENT,
+  GRACE_PERIOD_PRESERVATION_TALENT,
+  TIMELESS_MAGIC_PRESERVATION_TALENT,
+  DREAM_FLIGHT_PRESERVATION_TALENT,
+  CYCLE_OF_LIFE_PRESERVATION_TALENT,
+  STASIS_PRESERVATION_TALENT,
 });
 
 export default talents;

--- a/src/common/TALENTS/hunter.ts
+++ b/src/common/TALENTS/hunter.ts
@@ -1,1026 +1,1231 @@
 // Generated file, changes will eventually be overwritten!
-import { createTalentList } from './types';
+import { createTalentList, Talent } from './types';
+
+//region Shared
+export const KILL_COMMAND_TALENT: Talent = {
+  id: 259489,
+  name: 'Kill Command',
+  icon: 'ability_hunter_killcommand',
+  maxRanks: 1,
+};
+export const CONCUSSIVE_SHOT_TALENT: Talent = {
+  id: 5116,
+  name: 'Concussive Shot',
+  icon: 'spell_frost_stun',
+  maxRanks: 1,
+};
+export const KILL_SHOT_TALENT: Talent = {
+  id: 320976,
+  name: 'Kill Shot',
+  icon: 'ability_hunter_assassinate2',
+  maxRanks: 1,
+  focusCost: 10,
+};
+export const TRAILBLAZER_TALENT: Talent = {
+  id: 199921,
+  name: 'Trailblazer',
+  icon: 'ability_hunter_aspectmastery',
+  maxRanks: 2,
+};
+export const POSTHASTE_TALENT: Talent = {
+  id: 109215,
+  name: 'Posthaste',
+  icon: 'ability_hunter_posthaste',
+  maxRanks: 2,
+};
+export const IMPROVED_KILL_SHOT_TALENT: Talent = {
+  id: 343248,
+  name: 'Improved Kill Shot',
+  icon: 'ability_hunter_snipertraining',
+  maxRanks: 1,
+};
+export const IMPROVED_MEND_PET_TALENT: Talent = {
+  id: 343242,
+  name: 'Improved Mend Pet',
+  icon: 'ability_hunter_mendpet',
+  maxRanks: 2,
+};
+export const COUNTER_SHOT_TALENT: Talent = {
+  id: 147362,
+  name: 'Counter Shot',
+  icon: 'inv_ammo_arrow_03',
+  maxRanks: 1,
+};
+export const NATURAL_MENDING_TALENT: Talent = {
+  id: 270581,
+  name: 'Natural Mending',
+  icon: 'ability_hunter_onewithnature',
+  maxRanks: 2,
+};
+export const TAR_TRAP_TALENT: Talent = {
+  id: 187698,
+  name: 'Tar Trap',
+  icon: 'spell_yorsahj_bloodboil_black',
+  maxRanks: 1,
+};
+export const MISDIRECTION_TALENT: Talent = {
+  id: 34477,
+  name: 'Misdirection',
+  icon: 'ability_hunter_misdirection',
+  maxRanks: 1,
+};
+export const SURVIVAL_OF_THE_FITTEST_TALENT: Talent = {
+  id: 264735,
+  name: 'Survival of the Fittest',
+  icon: 'spell_nature_spiritarmor',
+  maxRanks: 1,
+};
+export const TRANQUILIZING_SHOT_TALENT: Talent = {
+  id: 19801,
+  name: 'Tranquilizing Shot',
+  icon: 'spell_nature_drowsy',
+  maxRanks: 1,
+};
+export const REJUVENATING_WIND_TALENT: Talent = {
+  id: 385539,
+  name: 'Rejuvenating Wind',
+  icon: 'ability_druid_galewinds',
+  maxRanks: 2,
+};
+export const HUNTERS_AGILITY_NYI_TALENT: Talent = {
+  id: 384799,
+  name: "Hunter's Agility (NYI)",
+  icon: 'rogue_burstofspeed',
+  maxRanks: 2,
+};
+export const LONE_SURVIVOR_TALENT: Talent = {
+  id: 388039,
+  name: 'Lone Survivor',
+  icon: 'ability_hunter_huntervswild',
+  maxRanks: 1,
+};
+export const NATURES_ENDURANCE_TALENT: Talent = {
+  id: 388042,
+  name: "Nature's Endurance",
+  icon: 'spell_nature_protectionformnature',
+  maxRanks: 1,
+};
+export const CAMOUFLAGE_TALENT: Talent = {
+  id: 199483,
+  name: 'Camouflage',
+  icon: 'ability_hunter_camouflage',
+  maxRanks: 1,
+};
+export const SCARE_BEAST_TALENT: Talent = {
+  id: 1513,
+  name: 'Scare Beast',
+  icon: 'ability_druid_cower',
+  maxRanks: 1,
+  focusCost: 25,
+};
+export const IMPROVED_TRANQUILIZING_SHOT_TALENT: Talent = {
+  id: 343244,
+  name: 'Improved Tranquilizing Shot',
+  icon: 'hunter_pvp_vipersting',
+  maxRanks: 1,
+};
+export const INTIMIDATION_TALENT: Talent = {
+  id: 19577,
+  name: 'Intimidation',
+  icon: 'ability_devour',
+  maxRanks: 1,
+};
+export const HI_EXPLOSIVE_TRAP_TALENT: Talent = {
+  id: 236776,
+  name: 'Hi-Explosive Trap',
+  icon: 'spell_fire_selfdestruct',
+  maxRanks: 1,
+};
+export const SCATTER_SHOT_TALENT: Talent = {
+  id: 213691,
+  name: 'Scatter Shot',
+  icon: 'ability_golemstormbolt',
+  maxRanks: 1,
+};
+export const BINDING_SHOT_TALENT: Talent = {
+  id: 109248,
+  name: 'Binding Shot',
+  icon: 'spell_shaman_bindelemental',
+  maxRanks: 1,
+};
+export const IMPROVED_TRAPS_TALENT: Talent = {
+  id: 343247,
+  name: 'Improved Traps',
+  icon: 'ability_hunter_traplauncher',
+  maxRanks: 2,
+};
+export const BORN_TO_BE_WILD_TALENT: Talent = {
+  id: 266921,
+  name: 'Born To Be Wild',
+  icon: 'ability_hunter_aspectoftheviper',
+  maxRanks: 2,
+};
+export const BINDING_SHACKLES_TALENT: Talent = {
+  id: 321468,
+  name: 'Binding Shackles',
+  icon: 'inv_misc_steelweaponchain',
+  maxRanks: 1,
+};
+export const AGILE_MOVEMENT_TALENT: Talent = {
+  id: 378002,
+  name: 'Agile Movement',
+  icon: 'ability_hunter_displacement',
+  maxRanks: 2,
+};
+export const SENTINEL_NYI_TALENT: Talent = {
+  id: 388045,
+  name: 'Sentinel (NYI)',
+  icon: 'ability_hunter_sentinelowl',
+  maxRanks: 1,
+};
+export const BEAST_MASTER_TALENT: Talent = {
+  id: 378007,
+  name: 'Beast Master',
+  icon: 'ability_hunter_catlikereflexes',
+  maxRanks: 2,
+};
+export const KEEN_EYESIGHT_TALENT: Talent = {
+  id: 378004,
+  name: 'Keen Eyesight',
+  icon: 'ability_hunter_silenthunter',
+  maxRanks: 2,
+};
+export const MASTER_MARKSMAN_TALENT: Talent = {
+  id: 260309,
+  name: 'Master Marksman',
+  icon: 'ability_hunter_mastermarksman',
+  maxRanks: 2,
+};
+export const SENTINELS_PERCEPTION_NYI_TALENT: Talent = {
+  id: 388056,
+  name: "Sentinel's Perception (NYI)",
+  icon: 'spell_nature_sentinal',
+  maxRanks: 1,
+};
+export const SENTINELS_WISDOM_NYI_TALENT: Talent = {
+  id: 388057,
+  name: "Sentinel's Wisdom (NYI)",
+  icon: 'ability_hunter_pet_owl',
+  maxRanks: 1,
+};
+export const IMPROVED_KILL_COMMAND_TALENT: Talent = {
+  id: 378010,
+  name: 'Improved Kill Command',
+  icon: 'ability_hunter_ferociousinspiration',
+  maxRanks: 2,
+};
+export const NESINGWARYS_TRAPPING_APPARATUS_TALENT: Talent = {
+  id: 378759,
+  name: "Nesingwary's Trapping Apparatus",
+  icon: 'ability_hunter_blackicetrap',
+  maxRanks: 2,
+};
+export const ARCTIC_BOLA_TALENT: Talent = {
+  id: 390231,
+  name: 'Arctic Bola',
+  icon: 'inv_engineering_90_bola',
+  maxRanks: 2,
+};
+export const SERPENT_STING_TALENT: Talent = {
+  id: 271788,
+  name: 'Serpent Sting',
+  icon: 'spell_hunter_exoticmunitions_poisoned',
+  maxRanks: 1,
+  focusCost: 10,
+};
+export const KILLER_INSTINCT_TALENT: Talent = {
+  id: 273887,
+  name: 'Killer Instinct',
+  icon: 'ability_hunter_killcommand',
+  maxRanks: 1,
+};
+export const ALPHA_PREDATOR_TALENT: Talent = {
+  id: 269737,
+  name: 'Alpha Predator',
+  icon: 'spell_druid_savagery',
+  maxRanks: 1,
+};
+export const STEEL_TRAP_TALENT: Talent = {
+  id: 162488,
+  name: 'Steel Trap',
+  icon: 'ability_hunter_steeltrap',
+  maxRanks: 1,
+};
+export const STAMPEDE_TALENT: Talent = {
+  id: 201430,
+  name: 'Stampede',
+  icon: 'ability_hunter_bestialdiscipline',
+  maxRanks: 1,
+};
+export const DEATH_CHAKRAM_TALENT: Talent = {
+  id: 375891,
+  name: 'Death Chakram',
+  icon: 'ability_maldraxxus_hunter',
+  maxRanks: 1,
+};
+export const EXPLOSIVE_SHOT_TALENT: Talent = {
+  id: 212431,
+  name: 'Explosive Shot',
+  icon: 'ability_hunter_explosiveshot',
+  maxRanks: 1,
+  focusCost: 20,
+};
+export const BARRAGE_TALENT: Talent = {
+  id: 120360,
+  name: 'Barrage',
+  icon: 'ability_hunter_rapidregeneration',
+  maxRanks: 1,
+  focusCost: 60,
+};
+export const SERRATED_SHOTS_TALENT: Talent = {
+  id: 389882,
+  name: 'Serrated Shots',
+  icon: 'ability_skeer_bloodletting',
+  maxRanks: 2,
+};
+export const LATENT_POISON_INJECTORS_TALENT: Talent = {
+  id: 378014,
+  name: 'Latent Poison Injectors',
+  icon: 'ability_poisonarrow',
+  maxRanks: 1,
+};
+export const HYDRAS_BITE_TALENT: Talent = {
+  id: 260241,
+  name: "Hydra's Bite",
+  icon: 'inv_hydrasbite',
+  maxRanks: 1,
+};
+export const MUZZLE_TALENT: Talent = {
+  id: 187707,
+  name: 'Muzzle',
+  icon: 'ability_hunter_negate',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Marksmanship
+export const AIMED_SHOT_MARKSMANSHIP_TALENT: Talent = {
+  id: 19434,
+  name: 'Aimed Shot',
+  icon: 'inv_spear_07',
+  maxRanks: 1,
+  focusCost: 35,
+};
+export const CRACK_SHOT_MARKSMANSHIP_TALENT: Talent = {
+  id: 321293,
+  name: 'Crack Shot',
+  icon: 'ability_hunter_focusfire',
+  maxRanks: 1,
+};
+export const IMPROVED_STEADY_SHOT_MARKSMANSHIP_TALENT: Talent = {
+  id: 321018,
+  name: 'Improved Steady Shot',
+  icon: 'ability_hunter_improvedsteadyshot',
+  maxRanks: 1,
+};
+export const PRECISE_SHOTS_MARKSMANSHIP_TALENT: Talent = {
+  id: 260240,
+  name: 'Precise Shots',
+  icon: 'ability_hunter_focusedaim',
+  maxRanks: 2,
+};
+export const RAPID_FIRE_MARKSMANSHIP_TALENT: Talent = {
+  id: 257044,
+  name: 'Rapid Fire',
+  icon: 'ability_hunter_efficiency',
+  maxRanks: 1,
+};
+export const LONE_WOLF_MARKSMANSHIP_TALENT: Talent = {
+  id: 155228,
+  name: 'Lone Wolf',
+  icon: 'spell_hunter_lonewolf',
+  maxRanks: 1,
+};
+export const CHIMAERA_SHOT_MARKSMANSHIP_TALENT: Talent = {
+  id: 342049,
+  name: 'Chimaera Shot',
+  icon: 'ability_hunter_chimerashot2',
+  maxRanks: 1,
+  focusCost: 40,
+};
+export const STREAMLINE_MARKSMANSHIP_TALENT: Talent = {
+  id: 260367,
+  name: 'Streamline',
+  icon: 'ability_hunter_aimedshot',
+  maxRanks: 2,
+};
+export const KILLING_BLOW_MARKSMANSHIP_TALENT: Talent = {
+  id: 378765,
+  name: 'Killing Blow',
+  icon: 'ability_hunter_piercingshots',
+  maxRanks: 2,
+};
+export const HUNTERS_KNOWLEDGE_MARKSMANSHIP_TALENT: Talent = {
+  id: 378766,
+  name: "Hunter's Knowledge",
+  icon: 'hunter_pvp_snipershot',
+  maxRanks: 2,
+};
+export const CAREFUL_AIM_MARKSMANSHIP_TALENT: Talent = {
+  id: 260228,
+  name: 'Careful Aim',
+  icon: 'ability_hunter_zenarchery',
+  maxRanks: 2,
+};
+export const LETHAL_SHOTS_MARKSMANSHIP_TALENT: Talent = {
+  id: 260393,
+  name: 'Lethal Shots',
+  icon: 'ability_hunter_longshots',
+  maxRanks: 1,
+};
+export const SURGING_SHOTS_MARKSMANSHIP_TALENT: Talent = {
+  id: 391559,
+  name: 'Surging Shots',
+  icon: 'ability_hunter_resistanceisfutile',
+  maxRanks: 1,
+};
+export const DEATHBLOW_MARKSMANSHIP_TALENT: Talent = {
+  id: 378769,
+  name: 'Deathblow',
+  icon: 'ability_hunter_runningshot',
+  maxRanks: 1,
+};
+export const TRUE_AIM_MARKSMANSHIP_TALENT: Talent = {
+  id: 321287,
+  name: 'True Aim',
+  icon: 'buff_epichunter',
+  maxRanks: 1,
+};
+export const FOCUSED_AIM_MARKSMANSHIP_TALENT: Talent = {
+  id: 378767,
+  name: 'Focused Aim',
+  icon: 'ability_hunter_mastermarksman',
+  maxRanks: 2,
+};
+export const MULTI_SHOT_MARKSMANSHIP_TALENT: Talent = {
+  id: 257620,
+  name: 'Multi-Shot',
+  icon: 'ability_upgrademoonglaive',
+  maxRanks: 1,
+  focusCost: 20,
+};
+export const RAZOR_FRAGMENTS_MARKSMANSHIP_TALENT: Talent = {
+  id: 384790,
+  name: 'Razor Fragments',
+  icon: 'ability_hunter_razorwire',
+  maxRanks: 1,
+};
+export const DOUBLE_TAP_MARKSMANSHIP_TALENT: Talent = {
+  id: 260402,
+  name: 'Double Tap',
+  icon: 'ability_hunter_crossfire',
+  maxRanks: 1,
+};
+export const DEAD_EYE_MARKSMANSHIP_TALENT: Talent = {
+  id: 321460,
+  name: 'Dead Eye',
+  icon: 'spell_hunter_focusingshot',
+  maxRanks: 1,
+};
+export const BURSTING_SHOT_MARKSMANSHIP_TALENT: Talent = {
+  id: 186387,
+  name: 'Bursting Shot',
+  icon: 'ability_hunter_burstingshot',
+  maxRanks: 1,
+  focusCost: 10,
+};
+export const TRICK_SHOTS_MARKSMANSHIP_TALENT: Talent = {
+  id: 257621,
+  name: 'Trick Shots',
+  icon: 'inv_trickshot',
+  maxRanks: 1,
+};
+export const BOMBARDMENT_MARKSMANSHIP_TALENT: Talent = {
+  id: 378880,
+  name: 'Bombardment',
+  icon: 'ability_hunter_thrillofthehunt',
+  maxRanks: 1,
+};
+export const VOLLEY_MARKSMANSHIP_TALENT: Talent = {
+  id: 260243,
+  name: 'Volley',
+  icon: 'ability_hunter_rapidkilling',
+  maxRanks: 1,
+};
+export const STEADY_FOCUS_MARKSMANSHIP_TALENT: Talent = {
+  id: 193533,
+  name: 'Steady Focus',
+  icon: 'hunter_pvp_snipershot',
+  maxRanks: 2,
+};
+export const SERPENTSTALKERS_TRICKERY_MARKSMANSHIP_TALENT: Talent = {
+  id: 378888,
+  name: "Serpentstalker's Trickery",
+  icon: 'ability_hunter_serpentswiftness',
+  maxRanks: 1,
+};
+export const QUICK_LOAD_MARKSMANSHIP_TALENT: Talent = {
+  id: 378771,
+  name: 'Quick Load',
+  icon: 'ability_hunter_wildquiver',
+  maxRanks: 1,
+};
+export const HEAVY_AMMO_MARKSMANSHIP_TALENT: Talent = {
+  id: 378910,
+  name: 'Heavy Ammo',
+  icon: 'inv_ammo_bullet_04',
+  maxRanks: 1,
+};
+export const LIGHT_AMMO_MARKSMANSHIP_TALENT: Talent = {
+  id: 378913,
+  name: 'Light Ammo',
+  icon: 'ships_ability_armorpiercingammo',
+  maxRanks: 1,
+};
+export const TRUESHOT_MARKSMANSHIP_TALENT: Talent = {
+  id: 288613,
+  name: 'Trueshot',
+  icon: 'ability_trueshot',
+  maxRanks: 1,
+};
+export const LOCK_AND_LOAD_MARKSMANSHIP_TALENT: Talent = {
+  id: 194595,
+  name: 'Lock and Load',
+  icon: 'ability_hunter_lockandload',
+  maxRanks: 1,
+};
+export const BULLSEYE_MARKSMANSHIP_TALENT: Talent = {
+  id: 204089,
+  name: 'Bullseye',
+  icon: 'ability_hunter_focusedaim',
+  maxRanks: 2,
+};
+export const BULLETSTORM_MARKSMANSHIP_TALENT: Talent = {
+  id: 389019,
+  name: 'Bulletstorm',
+  icon: 'ability_hunter_markedshot',
+  maxRanks: 1,
+};
+export const SHARPSHOOTER_MARKSMANSHIP_TALENT: Talent = {
+  id: 378907,
+  name: 'Sharpshooter',
+  icon: 'ability_hunter_aimedshot',
+  maxRanks: 2,
+};
+export const EAGLETALONS_TRUE_FOCUS_MARKSMANSHIP_TALENT: Talent = {
+  id: 389449,
+  name: "Eagletalon's True Focus",
+  icon: 'ability_hunter_aspectoftheironhawk',
+  maxRanks: 2,
+};
+export const WAILING_ARROW_MARKSMANSHIP_TALENT: Talent = {
+  id: 355589,
+  name: 'Wailing Arrow',
+  icon: 'ability_theblackarrow',
+  maxRanks: 1,
+  focusCost: 15,
+};
+export const LEGACY_OF_THE_WINDRUNNERS_MARKSMANSHIP_TALENT: Talent = {
+  id: 190852,
+  name: 'Legacy of the Windrunners',
+  icon: 'artifactability_marksmanhunter_legacyofthewindrunners',
+  maxRanks: 2,
+};
+export const SALVO_MARKSMANSHIP_TALENT: Talent = {
+  id: 384791,
+  name: 'Salvo',
+  icon: 'spell_hunter_exoticmunitions_incendiary',
+  maxRanks: 1,
+};
+export const CALLING_THE_SHOTS_MARKSMANSHIP_TALENT: Talent = {
+  id: 260404,
+  name: 'Calling the Shots',
+  icon: 'ability_hunter_assassinate',
+  maxRanks: 1,
+};
+export const UNERRING_VISION_MARKSMANSHIP_TALENT: Talent = {
+  id: 386878,
+  name: 'Unerring Vision',
+  icon: 'spell_hunter_exoticmunitions_frozen',
+  maxRanks: 1,
+};
+export const WINDRUNNERS_BARRAGE_MARKSMANSHIP_TALENT: Talent = {
+  id: 389866,
+  name: "Windrunner's Barrage",
+  icon: 'inv_ammo_arrow_06',
+  maxRanks: 1,
+};
+export const READINESS_MARKSMANSHIP_TALENT: Talent = {
+  id: 389865,
+  name: 'Readiness',
+  icon: 'ability_hunter_readiness',
+  maxRanks: 1,
+};
+export const WINDRUNNERS_GUIDANCE_MARKSMANSHIP_TALENT: Talent = {
+  id: 378905,
+  name: "Windrunner's Guidance",
+  icon: 'ability_hunter_laceration',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Beast Mastery
+export const COBRA_SHOT_BEAST_MASTERY_TALENT: Talent = {
+  id: 193455,
+  name: 'Cobra Shot',
+  icon: 'ability_hunter_cobrashot',
+  maxRanks: 1,
+  focusCost: 35,
+};
+export const PACK_TACTICS_BEAST_MASTERY_TALENT: Talent = {
+  id: 321014,
+  name: 'Pack Tactics',
+  icon: 'ability_hunter_invigeration',
+  maxRanks: 1,
+};
+export const MULTI_SHOT_BEAST_MASTERY_TALENT: Talent = {
+  id: 2643,
+  name: 'Multi-Shot',
+  icon: 'ability_upgrademoonglaive',
+  maxRanks: 1,
+  focusCost: 40,
+};
+export const BARBED_SHOT_BEAST_MASTERY_TALENT: Talent = {
+  id: 217200,
+  name: 'Barbed Shot',
+  icon: 'ability_hunter_barbedshot',
+  maxRanks: 1,
+};
+export const ASPECT_OF_THE_BEAST_BEAST_MASTERY_TALENT: Talent = {
+  id: 191384,
+  name: 'Aspect of the Beast',
+  icon: 'ability_deathwing_assualtaspects',
+  maxRanks: 1,
+};
+export const KINDRED_SPIRITS_BEAST_MASTERY_TALENT: Talent = {
+  id: 56315,
+  name: 'Kindred Spirits',
+  icon: 'ability_hunter_separationanxiety',
+  maxRanks: 2,
+};
+export const TRAINING_EXPERT_BEAST_MASTERY_TALENT: Talent = {
+  id: 378209,
+  name: 'Training Expert',
+  icon: 'spell_hunter_adaptation',
+  maxRanks: 2,
+};
+export const ANIMAL_COMPANION_BEAST_MASTERY_TALENT: Talent = {
+  id: 267116,
+  name: 'Animal Companion',
+  icon: 'ability_hunter_bestialdiscipline',
+  maxRanks: 1,
+};
+export const BEAST_CLEAVE_BEAST_MASTERY_TALENT: Talent = {
+  id: 115939,
+  name: 'Beast Cleave',
+  icon: 'ability_hunter_sickem',
+  maxRanks: 2,
+};
+export const KILLER_COMMAND_BEAST_MASTERY_TALENT: Talent = {
+  id: 378740,
+  name: 'Killer Command',
+  icon: 'ability_physical_taunt',
+  maxRanks: 2,
+};
+export const SHARP_BARBS_BEAST_MASTERY_TALENT: Talent = {
+  id: 378205,
+  name: 'Sharp Barbs',
+  icon: 'ability_hunter_laceration',
+  maxRanks: 2,
+};
+export const FLAMEWAKERS_COBRA_STING_BEAST_MASTERY_TALENT: Talent = {
+  id: 378750,
+  name: "Flamewaker's Cobra Sting",
+  icon: 'ability_hunter_cobrashot',
+  maxRanks: 2,
+};
+export const THRILL_OF_THE_HUNT_BEAST_MASTERY_TALENT: Talent = {
+  id: 257944,
+  name: 'Thrill of the Hunt',
+  icon: 'ability_hunter_thrillofthehunt',
+  maxRanks: 3,
+};
+export const KILL_CLEAVE_BEAST_MASTERY_TALENT: Talent = {
+  id: 378207,
+  name: 'Kill Cleave',
+  icon: 'spell_druid_bloodythrash',
+  maxRanks: 1,
+};
+export const A_MURDER_OF_CROWS_BEAST_MASTERY_TALENT: Talent = {
+  id: 131894,
+  name: 'A Murder of Crows',
+  icon: 'ability_hunter_murderofcrows',
+  maxRanks: 1,
+  focusCost: 30,
+};
+export const BLOODSHED_BEAST_MASTERY_TALENT: Talent = {
+  id: 321530,
+  name: 'Bloodshed',
+  icon: 'ability_druid_primaltenacity',
+  maxRanks: 1,
+};
+export const COBRA_SENSES_BEAST_MASTERY_TALENT: Talent = {
+  id: 378244,
+  name: 'Cobra Senses',
+  icon: 'ability_hunter_cobrastrikes',
+  maxRanks: 1,
+};
+export const DIRE_BEAST_BEAST_MASTERY_TALENT: Talent = {
+  id: 120679,
+  name: 'Dire Beast',
+  icon: 'ability_hunter_longevity',
+  maxRanks: 1,
+};
+export const BESTIAL_WRATH_BEAST_MASTERY_TALENT: Talent = {
+  id: 19574,
+  name: 'Bestial Wrath',
+  icon: 'ability_druid_ferociousbite',
+  maxRanks: 1,
+};
+export const QAPLA_EREDUN_WAR_ORDER_BEAST_MASTERY_TALENT: Talent = {
+  id: 336830,
+  name: "Qa'pla, Eredun War Order",
+  icon: 'ability_hunter_barbedshot',
+  maxRanks: 2,
+};
+export const IN_FOR_THE_KILL_BEAST_MASTERY_TALENT: Talent = {
+  id: 378210,
+  name: 'In for the Kill',
+  icon: 'ability_hunter_assassinate',
+  maxRanks: 1,
+};
+export const STOMP_BEAST_MASTERY_TALENT: Talent = {
+  id: 199530,
+  name: 'Stomp',
+  icon: 'warrior_talent_icon_thunderstruck',
+  maxRanks: 2,
+};
+export const BARBED_WRATH_BEAST_MASTERY_TALENT: Talent = {
+  id: 231548,
+  name: 'Barbed Wrath',
+  icon: 'ability_druid_ferociousbite',
+  maxRanks: 1,
+};
+export const WILD_CALL_BEAST_MASTERY_TALENT: Talent = {
+  id: 185789,
+  name: 'Wild Call',
+  icon: 'ability_hunter_masterscall',
+  maxRanks: 1,
+};
+export const ASPECT_OF_THE_WILD_BEAST_MASTERY_TALENT: Talent = {
+  id: 193530,
+  name: 'Aspect of the Wild',
+  icon: 'spell_nature_protectionformnature',
+  maxRanks: 1,
+};
+export const DIRE_COMMAND_BEAST_MASTERY_TALENT: Talent = {
+  id: 378743,
+  name: 'Dire Command',
+  icon: 'ability_hunter_ferociousinspiration',
+  maxRanks: 3,
+};
+export const SCENT_OF_BLOOD_BEAST_MASTERY_TALENT: Talent = {
+  id: 193532,
+  name: 'Scent of Blood',
+  icon: 'spell_shadow_lifedrain',
+  maxRanks: 2,
+};
+export const ONE_WITH_THE_PACK_BEAST_MASTERY_TALENT: Talent = {
+  id: 199528,
+  name: 'One with the Pack',
+  icon: 'icon_upgradestone_beast_uncommon',
+  maxRanks: 2,
+};
+export const MASTER_HANDLER_BEAST_MASTERY_TALENT: Talent = {
+  id: 389654,
+  name: 'Master Handler',
+  icon: 'ability_hunter_beastwithin',
+  maxRanks: 1,
+};
+export const SNAKE_BITE_BEAST_MASTERY_TALENT: Talent = {
+  id: 389660,
+  name: 'Snake Bite',
+  icon: 'inv_waepon_bow_zulgrub_d_01',
+  maxRanks: 1,
+};
+export const DIRE_FRENZY_BEAST_MASTERY_TALENT: Talent = {
+  id: 385810,
+  name: 'Dire Frenzy',
+  icon: 'ability_hunter_huntervswild',
+  maxRanks: 2,
+};
+export const WAILING_ARROW_BEAST_MASTERY_TALENT: Talent = {
+  id: 355589,
+  name: 'Wailing Arrow',
+  icon: 'ability_theblackarrow',
+  maxRanks: 1,
+  focusCost: 15,
+};
+export const BRUTAL_COMPANION_BEAST_MASTERY_TALENT: Talent = {
+  id: 386870,
+  name: 'Brutal Companion',
+  icon: 'ability_druid_rake',
+  maxRanks: 1,
+};
+export const CALL_OF_THE_WILD_BEAST_MASTERY_TALENT: Talent = {
+  id: 359844,
+  name: 'Call of the Wild',
+  icon: 'ability_hunter_callofthewild',
+  maxRanks: 1,
+};
+export const DIRE_PACK_BEAST_MASTERY_TALENT: Talent = {
+  id: 378745,
+  name: 'Dire Pack',
+  icon: 'ability_hunter_sickem',
+  maxRanks: 1,
+};
+export const KILLER_COBRA_BEAST_MASTERY_TALENT: Talent = {
+  id: 199532,
+  name: 'Killer Cobra',
+  icon: 'ability_hunter_snaketrap',
+  maxRanks: 1,
+};
+export const RYLAKSTALKERS_PIERCING_FANGS_BEAST_MASTERY_TALENT: Talent = {
+  id: 336844,
+  name: "Rylakstalker's Piercing Fangs",
+  icon: 'inv_misc_monsterfang_02',
+  maxRanks: 1,
+};
+export const WILD_INSTINCTS_BEAST_MASTERY_TALENT: Talent = {
+  id: 378442,
+  name: 'Wild Instincts',
+  icon: 'ability_hunter_beastwithin',
+  maxRanks: 1,
+};
+export const BLOODY_FRENZY_BEAST_MASTERY_TALENT: Talent = {
+  id: 378739,
+  name: 'Bloody Frenzy',
+  icon: 'ability_racial_cannibalize',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Survival
+export const RAPTOR_STRIKE_SURVIVAL_TALENT: Talent = {
+  id: 186270,
+  name: 'Raptor Strike',
+  icon: 'ability_hunter_raptorstrike',
+  maxRanks: 1,
+  focusCost: 30,
+};
+export const WILDFIRE_BOMB_SURVIVAL_TALENT: Talent = {
+  id: 259495,
+  name: 'Wildfire Bomb',
+  icon: 'inv_wildfirebomb',
+  maxRanks: 1,
+};
+export const TIP_OF_THE_SPEAR_SURVIVAL_TALENT: Talent = {
+  id: 260285,
+  name: 'Tip of the Spear',
+  icon: 'ability_bossmannoroth_glaivethrust',
+  maxRanks: 2,
+};
+export const FEROCITY_SURVIVAL_TALENT: Talent = {
+  id: 378916,
+  name: 'Ferocity',
+  icon: 'ability_hunter_sickem',
+  maxRanks: 2,
+};
+export const PREDATOR_SURVIVAL_TALENT: Talent = {
+  id: 263186,
+  name: 'Predator',
+  icon: 'ability_hunter_killcommand',
+  maxRanks: 1,
+};
+export const HARPOON_SURVIVAL_TALENT: Talent = {
+  id: 190925,
+  name: 'Harpoon',
+  icon: 'ability_hunter_harpoon',
+  maxRanks: 1,
+};
+export const ENERGETIC_ALLY_SURVIVAL_TALENT: Talent = {
+  id: 378961,
+  name: 'Energetic Ally',
+  icon: 'ability_hunter_invigeration',
+  maxRanks: 1,
+};
+export const BLOODSEEKER_SURVIVAL_TALENT: Talent = {
+  id: 260248,
+  name: 'Bloodseeker',
+  icon: 'ability_druid_primaltenacity',
+  maxRanks: 1,
+};
+export const ASPECT_OF_THE_EAGLE_SURVIVAL_TALENT: Talent = {
+  id: 186289,
+  name: 'Aspect of the Eagle',
+  icon: 'spell_hunter_aspectoftheironhawk',
+  maxRanks: 1,
+};
+export const TERMS_OF_ENGAGEMENT_SURVIVAL_TALENT: Talent = {
+  id: 265895,
+  name: 'Terms of Engagement',
+  icon: 'ability_hunter_harpoon',
+  maxRanks: 1,
+};
+export const GUERRILLA_TACTICS_SURVIVAL_TALENT: Talent = {
+  id: 264332,
+  name: 'Guerrilla Tactics',
+  icon: 'spell_mage_flameorb',
+  maxRanks: 1,
+};
+export const LUNGE_SURVIVAL_TALENT: Talent = {
+  id: 378934,
+  name: 'Lunge',
+  icon: 'ability_bossmannoroth_glaivethrust',
+  maxRanks: 1,
+};
+export const CARVE_SURVIVAL_TALENT: Talent = {
+  id: 187708,
+  name: 'Carve',
+  icon: 'ability_hunter_carve',
+  maxRanks: 1,
+  focusCost: 35,
+};
+export const BUTCHERY_SURVIVAL_TALENT: Talent = {
+  id: 212436,
+  name: 'Butchery',
+  icon: 'ability_butcher_cleave',
+  maxRanks: 1,
+  focusCost: 30,
+};
+export const MONGOOSE_BITE_SURVIVAL_TALENT: Talent = {
+  id: 259387,
+  name: 'Mongoose Bite',
+  icon: 'ability_hunter_mongoosebite',
+  maxRanks: 1,
+  focusCost: 30,
+};
+export const INTENSE_FOCUS_SURVIVAL_TALENT: Talent = {
+  id: 385709,
+  name: 'Intense Focus',
+  icon: 'ability_hunter_mastertactitian',
+  maxRanks: 2,
+};
+export const IMPROVED_WILDFIRE_BOMB_SURVIVAL_TALENT: Talent = {
+  id: 321290,
+  name: 'Improved Wildfire Bomb',
+  icon: 'inv_eng_bombfire',
+  maxRanks: 2,
+};
+export const FRENZY_STRIKES_SURVIVAL_TALENT: Talent = {
+  id: 294029,
+  name: 'Frenzy Strikes',
+  icon: 'ability_demonhunter_manabreak',
+  maxRanks: 1,
+};
+export const FLANKING_STRIKE_SURVIVAL_TALENT: Talent = {
+  id: 269751,
+  name: 'Flanking Strike',
+  icon: 'ability_hunter_invigeration',
+  maxRanks: 1,
+};
+export const SPEAR_FOCUS_SURVIVAL_TALENT: Talent = {
+  id: 378953,
+  name: 'Spear Focus',
+  icon: 'inv_polearm_2h_heirloomspear_c_01',
+  maxRanks: 2,
+};
+export const VIPERS_VENOM_SURVIVAL_TALENT: Talent = {
+  id: 268501,
+  name: "Viper's Venom",
+  icon: 'ability_hunter_potentvenom',
+  maxRanks: 2,
+};
+export const SHARP_EDGES_SURVIVAL_TALENT: Talent = {
+  id: 378948,
+  name: 'Sharp Edges',
+  icon: 'inv_polearm_2h_kultirasharpoon_a_01',
+  maxRanks: 2,
+};
+export const SWEEPING_SPEAR_SURVIVAL_TALENT: Talent = {
+  id: 378950,
+  name: 'Sweeping Spear',
+  icon: 'spell_warrior_wildstrike',
+  maxRanks: 2,
+};
+export const TACTICAL_ADVANTAGE_SURVIVAL_TALENT: Talent = {
+  id: 378951,
+  name: 'Tactical Advantage',
+  icon: 'ability_hunter_zenarchery',
+  maxRanks: 2,
+};
+export const BLOODY_CLAWS_SURVIVAL_TALENT: Talent = {
+  id: 385737,
+  name: 'Bloody Claws',
+  icon: 'ability_druid_disembowel',
+  maxRanks: 2,
+};
+export const WILDFIRE_INFUSION_SURVIVAL_TALENT: Talent = {
+  id: 271014,
+  name: 'Wildfire Infusion',
+  icon: 'inv_misc_5potionbag_special',
+  maxRanks: 1,
+};
+export const QUICK_SHOT_SURVIVAL_TALENT: Talent = {
+  id: 378940,
+  name: 'Quick Shot',
+  icon: 'ability_hunter_fervor',
+  maxRanks: 1,
+};
+export const COORDINATED_ASSAULT_SURVIVAL_TALENT: Talent = {
+  id: 360952,
+  name: 'Coordinated Assault',
+  icon: 'inv__coordinatedassault',
+  maxRanks: 1,
+};
+export const KILLER_COMPANION_SURVIVAL_TALENT: Talent = {
+  id: 378955,
+  name: 'Killer Companion',
+  icon: 'ability_hunter_masterscall',
+  maxRanks: 2,
+};
+export const FURY_OF_THE_EAGLE_SURVIVAL_TALENT: Talent = {
+  id: 203415,
+  name: 'Fury of the Eagle',
+  icon: 'inv_polearm_2h_artifacteagle_d_01',
+  maxRanks: 1,
+};
+export const RANGER_SURVIVAL_TALENT: Talent = {
+  id: 385695,
+  name: 'Ranger',
+  icon: 'ability_hunter_thrillofthehunt',
+  maxRanks: 2,
+};
+export const COORDINATED_KILL_SURVIVAL_TALENT: Talent = {
+  id: 385739,
+  name: 'Coordinated Kill',
+  icon: 'ability_hunter_pet_goto',
+  maxRanks: 2,
+};
+export const EXPLOSIVES_EXPERT_SURVIVAL_TALENT: Talent = {
+  id: 378937,
+  name: 'Explosives Expert',
+  icon: 'inv_misc_bomb_05',
+  maxRanks: 2,
+};
+export const SPEARHEAD_SURVIVAL_TALENT: Talent = {
+  id: 360966,
+  name: 'Spearhead',
+  icon: 'ability_hunter_spearhead',
+  maxRanks: 1,
+};
+export const RUTHLESS_MARAUDER_SURVIVAL_TALENT: Talent = {
+  id: 385718,
+  name: 'Ruthless Marauder',
+  icon: 'ability_rogue_findweakness',
+  maxRanks: 3,
+};
+export const BIRDS_OF_PREY_SURVIVAL_TALENT: Talent = {
+  id: 260331,
+  name: 'Birds of Prey',
+  icon: 'spell_hunter_aspectofthehawk',
+  maxRanks: 1,
+};
+export const BOMBARDIER_SURVIVAL_TALENT: Talent = {
+  id: 389880,
+  name: 'Bombardier',
+  icon: 'inv_eng_bombfire',
+  maxRanks: 1,
+};
+export const DEADLY_DUO_SURVIVAL_TALENT: Talent = {
+  id: 378962,
+  name: 'Deadly Duo',
+  icon: 'ability_hunter_separationanxiety',
+  maxRanks: 2,
+};
+
+//endregion
 
 const talents = createTalentList({
   //Shared
-  KILL_COMMAND_TALENT: {
-    id: 259489,
-    name: 'Kill Command',
-    icon: 'ability_hunter_killcommand',
-    maxRanks: 1,
-  },
-  CONCUSSIVE_SHOT_TALENT: {
-    id: 5116,
-    name: 'Concussive Shot',
-    icon: 'spell_frost_stun',
-    maxRanks: 1,
-  },
-  KILL_SHOT_TALENT: {
-    id: 320976,
-    name: 'Kill Shot',
-    icon: 'ability_hunter_assassinate2',
-    maxRanks: 1,
-    focusCost: 10,
-  },
-  TRAILBLAZER_TALENT: {
-    id: 199921,
-    name: 'Trailblazer',
-    icon: 'ability_hunter_aspectmastery',
-    maxRanks: 2,
-  },
-  POSTHASTE_TALENT: {
-    id: 109215,
-    name: 'Posthaste',
-    icon: 'ability_hunter_posthaste',
-    maxRanks: 2,
-  },
-  IMPROVED_KILL_SHOT_TALENT: {
-    id: 343248,
-    name: 'Improved Kill Shot',
-    icon: 'ability_hunter_snipertraining',
-    maxRanks: 1,
-  },
-  IMPROVED_MEND_PET_TALENT: {
-    id: 343242,
-    name: 'Improved Mend Pet',
-    icon: 'ability_hunter_mendpet',
-    maxRanks: 2,
-  },
-  COUNTER_SHOT_TALENT: { id: 147362, name: 'Counter Shot', icon: 'inv_ammo_arrow_03', maxRanks: 1 },
-  NATURAL_MENDING_TALENT: {
-    id: 270581,
-    name: 'Natural Mending',
-    icon: 'ability_hunter_onewithnature',
-    maxRanks: 2,
-  },
-  TAR_TRAP_TALENT: {
-    id: 187698,
-    name: 'Tar Trap',
-    icon: 'spell_yorsahj_bloodboil_black',
-    maxRanks: 1,
-  },
-  MISDIRECTION_TALENT: {
-    id: 34477,
-    name: 'Misdirection',
-    icon: 'ability_hunter_misdirection',
-    maxRanks: 1,
-  },
-  SURVIVAL_OF_THE_FITTEST_TALENT: {
-    id: 264735,
-    name: 'Survival of the Fittest',
-    icon: 'spell_nature_spiritarmor',
-    maxRanks: 1,
-  },
-  TRANQUILIZING_SHOT_TALENT: {
-    id: 19801,
-    name: 'Tranquilizing Shot',
-    icon: 'spell_nature_drowsy',
-    maxRanks: 1,
-  },
-  REJUVENATING_WIND_TALENT: {
-    id: 385539,
-    name: 'Rejuvenating Wind',
-    icon: 'ability_druid_galewinds',
-    maxRanks: 2,
-  },
-  HUNTERS_AGILITY_NYI_TALENT: {
-    id: 384799,
-    name: "Hunter's Agility (NYI)",
-    icon: 'rogue_burstofspeed',
-    maxRanks: 2,
-  },
-  LONE_SURVIVOR_TALENT: {
-    id: 388039,
-    name: 'Lone Survivor',
-    icon: 'ability_hunter_huntervswild',
-    maxRanks: 1,
-  },
-  NATURES_ENDURANCE_TALENT: {
-    id: 388042,
-    name: "Nature's Endurance",
-    icon: 'spell_nature_protectionformnature',
-    maxRanks: 1,
-  },
-  CAMOUFLAGE_TALENT: {
-    id: 199483,
-    name: 'Camouflage',
-    icon: 'ability_hunter_camouflage',
-    maxRanks: 1,
-  },
-  SCARE_BEAST_TALENT: {
-    id: 1513,
-    name: 'Scare Beast',
-    icon: 'ability_druid_cower',
-    maxRanks: 1,
-    focusCost: 25,
-  },
-  IMPROVED_TRANQUILIZING_SHOT_TALENT: {
-    id: 343244,
-    name: 'Improved Tranquilizing Shot',
-    icon: 'hunter_pvp_vipersting',
-    maxRanks: 1,
-  },
-  INTIMIDATION_TALENT: { id: 19577, name: 'Intimidation', icon: 'ability_devour', maxRanks: 1 },
-  HI_EXPLOSIVE_TRAP_TALENT: {
-    id: 236776,
-    name: 'Hi-Explosive Trap',
-    icon: 'spell_fire_selfdestruct',
-    maxRanks: 1,
-  },
-  SCATTER_SHOT_TALENT: {
-    id: 213691,
-    name: 'Scatter Shot',
-    icon: 'ability_golemstormbolt',
-    maxRanks: 1,
-  },
-  BINDING_SHOT_TALENT: {
-    id: 109248,
-    name: 'Binding Shot',
-    icon: 'spell_shaman_bindelemental',
-    maxRanks: 1,
-  },
-  IMPROVED_TRAPS_TALENT: {
-    id: 343247,
-    name: 'Improved Traps',
-    icon: 'ability_hunter_traplauncher',
-    maxRanks: 2,
-  },
-  BORN_TO_BE_WILD_TALENT: {
-    id: 266921,
-    name: 'Born To Be Wild',
-    icon: 'ability_hunter_aspectoftheviper',
-    maxRanks: 2,
-  },
-  BINDING_SHACKLES_TALENT: {
-    id: 321468,
-    name: 'Binding Shackles',
-    icon: 'inv_misc_steelweaponchain',
-    maxRanks: 1,
-  },
-  AGILE_MOVEMENT_TALENT: {
-    id: 378002,
-    name: 'Agile Movement',
-    icon: 'ability_hunter_displacement',
-    maxRanks: 2,
-  },
-  SENTINEL_NYI_TALENT: {
-    id: 388045,
-    name: 'Sentinel (NYI)',
-    icon: 'ability_hunter_sentinelowl',
-    maxRanks: 1,
-  },
-  BEAST_MASTER_TALENT: {
-    id: 378007,
-    name: 'Beast Master',
-    icon: 'ability_hunter_catlikereflexes',
-    maxRanks: 2,
-  },
-  KEEN_EYESIGHT_TALENT: {
-    id: 378004,
-    name: 'Keen Eyesight',
-    icon: 'ability_hunter_silenthunter',
-    maxRanks: 2,
-  },
-  MASTER_MARKSMAN_TALENT: {
-    id: 260309,
-    name: 'Master Marksman',
-    icon: 'ability_hunter_mastermarksman',
-    maxRanks: 2,
-  },
-  SENTINELS_PERCEPTION_NYI_TALENT: {
-    id: 388056,
-    name: "Sentinel's Perception (NYI)",
-    icon: 'spell_nature_sentinal',
-    maxRanks: 1,
-  },
-  SENTINELS_WISDOM_NYI_TALENT: {
-    id: 388057,
-    name: "Sentinel's Wisdom (NYI)",
-    icon: 'ability_hunter_pet_owl',
-    maxRanks: 1,
-  },
-  IMPROVED_KILL_COMMAND_TALENT: {
-    id: 378010,
-    name: 'Improved Kill Command',
-    icon: 'ability_hunter_ferociousinspiration',
-    maxRanks: 2,
-  },
-  NESINGWARYS_TRAPPING_APPARATUS_TALENT: {
-    id: 378759,
-    name: "Nesingwary's Trapping Apparatus",
-    icon: 'ability_hunter_blackicetrap',
-    maxRanks: 2,
-  },
-  ARCTIC_BOLA_TALENT: {
-    id: 390231,
-    name: 'Arctic Bola',
-    icon: 'inv_engineering_90_bola',
-    maxRanks: 2,
-  },
-  SERPENT_STING_TALENT: {
-    id: 271788,
-    name: 'Serpent Sting',
-    icon: 'spell_hunter_exoticmunitions_poisoned',
-    maxRanks: 1,
-    focusCost: 10,
-  },
-  KILLER_INSTINCT_TALENT: {
-    id: 273887,
-    name: 'Killer Instinct',
-    icon: 'ability_hunter_killcommand',
-    maxRanks: 1,
-  },
-  ALPHA_PREDATOR_TALENT: {
-    id: 269737,
-    name: 'Alpha Predator',
-    icon: 'spell_druid_savagery',
-    maxRanks: 1,
-  },
-  STEEL_TRAP_TALENT: {
-    id: 162488,
-    name: 'Steel Trap',
-    icon: 'ability_hunter_steeltrap',
-    maxRanks: 1,
-  },
-  STAMPEDE_TALENT: {
-    id: 201430,
-    name: 'Stampede',
-    icon: 'ability_hunter_bestialdiscipline',
-    maxRanks: 1,
-  },
-  DEATH_CHAKRAM_TALENT: {
-    id: 375891,
-    name: 'Death Chakram',
-    icon: 'ability_maldraxxus_hunter',
-    maxRanks: 1,
-  },
-  EXPLOSIVE_SHOT_TALENT: {
-    id: 212431,
-    name: 'Explosive Shot',
-    icon: 'ability_hunter_explosiveshot',
-    maxRanks: 1,
-    focusCost: 20,
-  },
-  BARRAGE_TALENT: {
-    id: 120360,
-    name: 'Barrage',
-    icon: 'ability_hunter_rapidregeneration',
-    maxRanks: 1,
-    focusCost: 60,
-  },
-  SERRATED_SHOTS_TALENT: {
-    id: 389882,
-    name: 'Serrated Shots',
-    icon: 'ability_skeer_bloodletting',
-    maxRanks: 2,
-  },
-  LATENT_POISON_INJECTORS_TALENT: {
-    id: 378014,
-    name: 'Latent Poison Injectors',
-    icon: 'ability_poisonarrow',
-    maxRanks: 1,
-  },
-  HYDRAS_BITE_TALENT: { id: 260241, name: "Hydra's Bite", icon: 'inv_hydrasbite', maxRanks: 1 },
-  MUZZLE_TALENT: { id: 187707, name: 'Muzzle', icon: 'ability_hunter_negate', maxRanks: 1 },
+  KILL_COMMAND_TALENT,
+  CONCUSSIVE_SHOT_TALENT,
+  KILL_SHOT_TALENT,
+  TRAILBLAZER_TALENT,
+  POSTHASTE_TALENT,
+  IMPROVED_KILL_SHOT_TALENT,
+  IMPROVED_MEND_PET_TALENT,
+  COUNTER_SHOT_TALENT,
+  NATURAL_MENDING_TALENT,
+  TAR_TRAP_TALENT,
+  MISDIRECTION_TALENT,
+  SURVIVAL_OF_THE_FITTEST_TALENT,
+  TRANQUILIZING_SHOT_TALENT,
+  REJUVENATING_WIND_TALENT,
+  HUNTERS_AGILITY_NYI_TALENT,
+  LONE_SURVIVOR_TALENT,
+  NATURES_ENDURANCE_TALENT,
+  CAMOUFLAGE_TALENT,
+  SCARE_BEAST_TALENT,
+  IMPROVED_TRANQUILIZING_SHOT_TALENT,
+  INTIMIDATION_TALENT,
+  HI_EXPLOSIVE_TRAP_TALENT,
+  SCATTER_SHOT_TALENT,
+  BINDING_SHOT_TALENT,
+  IMPROVED_TRAPS_TALENT,
+  BORN_TO_BE_WILD_TALENT,
+  BINDING_SHACKLES_TALENT,
+  AGILE_MOVEMENT_TALENT,
+  SENTINEL_NYI_TALENT,
+  BEAST_MASTER_TALENT,
+  KEEN_EYESIGHT_TALENT,
+  MASTER_MARKSMAN_TALENT,
+  SENTINELS_PERCEPTION_NYI_TALENT,
+  SENTINELS_WISDOM_NYI_TALENT,
+  IMPROVED_KILL_COMMAND_TALENT,
+  NESINGWARYS_TRAPPING_APPARATUS_TALENT,
+  ARCTIC_BOLA_TALENT,
+  SERPENT_STING_TALENT,
+  KILLER_INSTINCT_TALENT,
+  ALPHA_PREDATOR_TALENT,
+  STEEL_TRAP_TALENT,
+  STAMPEDE_TALENT,
+  DEATH_CHAKRAM_TALENT,
+  EXPLOSIVE_SHOT_TALENT,
+  BARRAGE_TALENT,
+  SERRATED_SHOTS_TALENT,
+  LATENT_POISON_INJECTORS_TALENT,
+  HYDRAS_BITE_TALENT,
+  MUZZLE_TALENT,
 
   //Marksmanship
-  AIMED_SHOT_MARKSMANSHIP_TALENT: {
-    id: 19434,
-    name: 'Aimed Shot',
-    icon: 'inv_spear_07',
-    maxRanks: 1,
-    focusCost: 35,
-  },
-  CRACK_SHOT_MARKSMANSHIP_TALENT: {
-    id: 321293,
-    name: 'Crack Shot',
-    icon: 'ability_hunter_focusfire',
-    maxRanks: 1,
-  },
-  IMPROVED_STEADY_SHOT_MARKSMANSHIP_TALENT: {
-    id: 321018,
-    name: 'Improved Steady Shot',
-    icon: 'ability_hunter_improvedsteadyshot',
-    maxRanks: 1,
-  },
-  PRECISE_SHOTS_MARKSMANSHIP_TALENT: {
-    id: 260240,
-    name: 'Precise Shots',
-    icon: 'ability_hunter_focusedaim',
-    maxRanks: 2,
-  },
-  RAPID_FIRE_MARKSMANSHIP_TALENT: {
-    id: 257044,
-    name: 'Rapid Fire',
-    icon: 'ability_hunter_efficiency',
-    maxRanks: 1,
-  },
-  LONE_WOLF_MARKSMANSHIP_TALENT: {
-    id: 155228,
-    name: 'Lone Wolf',
-    icon: 'spell_hunter_lonewolf',
-    maxRanks: 1,
-  },
-  CHIMAERA_SHOT_MARKSMANSHIP_TALENT: {
-    id: 342049,
-    name: 'Chimaera Shot',
-    icon: 'ability_hunter_chimerashot2',
-    maxRanks: 1,
-    focusCost: 40,
-  },
-  STREAMLINE_MARKSMANSHIP_TALENT: {
-    id: 260367,
-    name: 'Streamline',
-    icon: 'ability_hunter_aimedshot',
-    maxRanks: 2,
-  },
-  KILLING_BLOW_MARKSMANSHIP_TALENT: {
-    id: 378765,
-    name: 'Killing Blow',
-    icon: 'ability_hunter_piercingshots',
-    maxRanks: 2,
-  },
-  HUNTERS_KNOWLEDGE_MARKSMANSHIP_TALENT: {
-    id: 378766,
-    name: "Hunter's Knowledge",
-    icon: 'hunter_pvp_snipershot',
-    maxRanks: 2,
-  },
-  CAREFUL_AIM_MARKSMANSHIP_TALENT: {
-    id: 260228,
-    name: 'Careful Aim',
-    icon: 'ability_hunter_zenarchery',
-    maxRanks: 2,
-  },
-  LETHAL_SHOTS_MARKSMANSHIP_TALENT: {
-    id: 260393,
-    name: 'Lethal Shots',
-    icon: 'ability_hunter_longshots',
-    maxRanks: 1,
-  },
-  SURGING_SHOTS_MARKSMANSHIP_TALENT: {
-    id: 391559,
-    name: 'Surging Shots',
-    icon: 'ability_hunter_resistanceisfutile',
-    maxRanks: 1,
-  },
-  DEATHBLOW_MARKSMANSHIP_TALENT: {
-    id: 378769,
-    name: 'Deathblow',
-    icon: 'ability_hunter_runningshot',
-    maxRanks: 1,
-  },
-  TRUE_AIM_MARKSMANSHIP_TALENT: {
-    id: 321287,
-    name: 'True Aim',
-    icon: 'buff_epichunter',
-    maxRanks: 1,
-  },
-  FOCUSED_AIM_MARKSMANSHIP_TALENT: {
-    id: 378767,
-    name: 'Focused Aim',
-    icon: 'ability_hunter_mastermarksman',
-    maxRanks: 2,
-  },
-  MULTI_SHOT_MARKSMANSHIP_TALENT: {
-    id: 257620,
-    name: 'Multi-Shot',
-    icon: 'ability_upgrademoonglaive',
-    maxRanks: 1,
-    focusCost: 20,
-  },
-  RAZOR_FRAGMENTS_MARKSMANSHIP_TALENT: {
-    id: 384790,
-    name: 'Razor Fragments',
-    icon: 'ability_hunter_razorwire',
-    maxRanks: 1,
-  },
-  DOUBLE_TAP_MARKSMANSHIP_TALENT: {
-    id: 260402,
-    name: 'Double Tap',
-    icon: 'ability_hunter_crossfire',
-    maxRanks: 1,
-  },
-  DEAD_EYE_MARKSMANSHIP_TALENT: {
-    id: 321460,
-    name: 'Dead Eye',
-    icon: 'spell_hunter_focusingshot',
-    maxRanks: 1,
-  },
-  BURSTING_SHOT_MARKSMANSHIP_TALENT: {
-    id: 186387,
-    name: 'Bursting Shot',
-    icon: 'ability_hunter_burstingshot',
-    maxRanks: 1,
-    focusCost: 10,
-  },
-  TRICK_SHOTS_MARKSMANSHIP_TALENT: {
-    id: 257621,
-    name: 'Trick Shots',
-    icon: 'inv_trickshot',
-    maxRanks: 1,
-  },
-  BOMBARDMENT_MARKSMANSHIP_TALENT: {
-    id: 378880,
-    name: 'Bombardment',
-    icon: 'ability_hunter_thrillofthehunt',
-    maxRanks: 1,
-  },
-  VOLLEY_MARKSMANSHIP_TALENT: {
-    id: 260243,
-    name: 'Volley',
-    icon: 'ability_hunter_rapidkilling',
-    maxRanks: 1,
-  },
-  STEADY_FOCUS_MARKSMANSHIP_TALENT: {
-    id: 193533,
-    name: 'Steady Focus',
-    icon: 'hunter_pvp_snipershot',
-    maxRanks: 2,
-  },
-  SERPENTSTALKERS_TRICKERY_MARKSMANSHIP_TALENT: {
-    id: 378888,
-    name: "Serpentstalker's Trickery",
-    icon: 'ability_hunter_serpentswiftness',
-    maxRanks: 1,
-  },
-  QUICK_LOAD_MARKSMANSHIP_TALENT: {
-    id: 378771,
-    name: 'Quick Load',
-    icon: 'ability_hunter_wildquiver',
-    maxRanks: 1,
-  },
-  HEAVY_AMMO_MARKSMANSHIP_TALENT: {
-    id: 378910,
-    name: 'Heavy Ammo',
-    icon: 'inv_ammo_bullet_04',
-    maxRanks: 1,
-  },
-  LIGHT_AMMO_MARKSMANSHIP_TALENT: {
-    id: 378913,
-    name: 'Light Ammo',
-    icon: 'ships_ability_armorpiercingammo',
-    maxRanks: 1,
-  },
-  TRUESHOT_MARKSMANSHIP_TALENT: {
-    id: 288613,
-    name: 'Trueshot',
-    icon: 'ability_trueshot',
-    maxRanks: 1,
-  },
-  LOCK_AND_LOAD_MARKSMANSHIP_TALENT: {
-    id: 194595,
-    name: 'Lock and Load',
-    icon: 'ability_hunter_lockandload',
-    maxRanks: 1,
-  },
-  BULLSEYE_MARKSMANSHIP_TALENT: {
-    id: 204089,
-    name: 'Bullseye',
-    icon: 'ability_hunter_focusedaim',
-    maxRanks: 2,
-  },
-  BULLETSTORM_MARKSMANSHIP_TALENT: {
-    id: 389019,
-    name: 'Bulletstorm',
-    icon: 'ability_hunter_markedshot',
-    maxRanks: 1,
-  },
-  SHARPSHOOTER_MARKSMANSHIP_TALENT: {
-    id: 378907,
-    name: 'Sharpshooter',
-    icon: 'ability_hunter_aimedshot',
-    maxRanks: 2,
-  },
-  EAGLETALONS_TRUE_FOCUS_MARKSMANSHIP_TALENT: {
-    id: 389449,
-    name: "Eagletalon's True Focus",
-    icon: 'ability_hunter_aspectoftheironhawk',
-    maxRanks: 2,
-  },
-  WAILING_ARROW_MARKSMANSHIP_TALENT: {
-    id: 355589,
-    name: 'Wailing Arrow',
-    icon: 'ability_theblackarrow',
-    maxRanks: 1,
-    focusCost: 15,
-  },
-  LEGACY_OF_THE_WINDRUNNERS_MARKSMANSHIP_TALENT: {
-    id: 190852,
-    name: 'Legacy of the Windrunners',
-    icon: 'artifactability_marksmanhunter_legacyofthewindrunners',
-    maxRanks: 2,
-  },
-  SALVO_MARKSMANSHIP_TALENT: {
-    id: 384791,
-    name: 'Salvo',
-    icon: 'spell_hunter_exoticmunitions_incendiary',
-    maxRanks: 1,
-  },
-  CALLING_THE_SHOTS_MARKSMANSHIP_TALENT: {
-    id: 260404,
-    name: 'Calling the Shots',
-    icon: 'ability_hunter_assassinate',
-    maxRanks: 1,
-  },
-  UNERRING_VISION_MARKSMANSHIP_TALENT: {
-    id: 386878,
-    name: 'Unerring Vision',
-    icon: 'spell_hunter_exoticmunitions_frozen',
-    maxRanks: 1,
-  },
-  WINDRUNNERS_BARRAGE_MARKSMANSHIP_TALENT: {
-    id: 389866,
-    name: "Windrunner's Barrage",
-    icon: 'inv_ammo_arrow_06',
-    maxRanks: 1,
-  },
-  READINESS_MARKSMANSHIP_TALENT: {
-    id: 389865,
-    name: 'Readiness',
-    icon: 'ability_hunter_readiness',
-    maxRanks: 1,
-  },
-  WINDRUNNERS_GUIDANCE_MARKSMANSHIP_TALENT: {
-    id: 378905,
-    name: "Windrunner's Guidance",
-    icon: 'ability_hunter_laceration',
-    maxRanks: 1,
-  },
+  AIMED_SHOT_MARKSMANSHIP_TALENT,
+  CRACK_SHOT_MARKSMANSHIP_TALENT,
+  IMPROVED_STEADY_SHOT_MARKSMANSHIP_TALENT,
+  PRECISE_SHOTS_MARKSMANSHIP_TALENT,
+  RAPID_FIRE_MARKSMANSHIP_TALENT,
+  LONE_WOLF_MARKSMANSHIP_TALENT,
+  CHIMAERA_SHOT_MARKSMANSHIP_TALENT,
+  STREAMLINE_MARKSMANSHIP_TALENT,
+  KILLING_BLOW_MARKSMANSHIP_TALENT,
+  HUNTERS_KNOWLEDGE_MARKSMANSHIP_TALENT,
+  CAREFUL_AIM_MARKSMANSHIP_TALENT,
+  LETHAL_SHOTS_MARKSMANSHIP_TALENT,
+  SURGING_SHOTS_MARKSMANSHIP_TALENT,
+  DEATHBLOW_MARKSMANSHIP_TALENT,
+  TRUE_AIM_MARKSMANSHIP_TALENT,
+  FOCUSED_AIM_MARKSMANSHIP_TALENT,
+  MULTI_SHOT_MARKSMANSHIP_TALENT,
+  RAZOR_FRAGMENTS_MARKSMANSHIP_TALENT,
+  DOUBLE_TAP_MARKSMANSHIP_TALENT,
+  DEAD_EYE_MARKSMANSHIP_TALENT,
+  BURSTING_SHOT_MARKSMANSHIP_TALENT,
+  TRICK_SHOTS_MARKSMANSHIP_TALENT,
+  BOMBARDMENT_MARKSMANSHIP_TALENT,
+  VOLLEY_MARKSMANSHIP_TALENT,
+  STEADY_FOCUS_MARKSMANSHIP_TALENT,
+  SERPENTSTALKERS_TRICKERY_MARKSMANSHIP_TALENT,
+  QUICK_LOAD_MARKSMANSHIP_TALENT,
+  HEAVY_AMMO_MARKSMANSHIP_TALENT,
+  LIGHT_AMMO_MARKSMANSHIP_TALENT,
+  TRUESHOT_MARKSMANSHIP_TALENT,
+  LOCK_AND_LOAD_MARKSMANSHIP_TALENT,
+  BULLSEYE_MARKSMANSHIP_TALENT,
+  BULLETSTORM_MARKSMANSHIP_TALENT,
+  SHARPSHOOTER_MARKSMANSHIP_TALENT,
+  EAGLETALONS_TRUE_FOCUS_MARKSMANSHIP_TALENT,
+  WAILING_ARROW_MARKSMANSHIP_TALENT,
+  LEGACY_OF_THE_WINDRUNNERS_MARKSMANSHIP_TALENT,
+  SALVO_MARKSMANSHIP_TALENT,
+  CALLING_THE_SHOTS_MARKSMANSHIP_TALENT,
+  UNERRING_VISION_MARKSMANSHIP_TALENT,
+  WINDRUNNERS_BARRAGE_MARKSMANSHIP_TALENT,
+  READINESS_MARKSMANSHIP_TALENT,
+  WINDRUNNERS_GUIDANCE_MARKSMANSHIP_TALENT,
 
   //Beast Mastery
-  COBRA_SHOT_BEAST_MASTERY_TALENT: {
-    id: 193455,
-    name: 'Cobra Shot',
-    icon: 'ability_hunter_cobrashot',
-    maxRanks: 1,
-    focusCost: 35,
-  },
-  PACK_TACTICS_BEAST_MASTERY_TALENT: {
-    id: 321014,
-    name: 'Pack Tactics',
-    icon: 'ability_hunter_invigeration',
-    maxRanks: 1,
-  },
-  MULTI_SHOT_BEAST_MASTERY_TALENT: {
-    id: 2643,
-    name: 'Multi-Shot',
-    icon: 'ability_upgrademoonglaive',
-    maxRanks: 1,
-    focusCost: 40,
-  },
-  BARBED_SHOT_BEAST_MASTERY_TALENT: {
-    id: 217200,
-    name: 'Barbed Shot',
-    icon: 'ability_hunter_barbedshot',
-    maxRanks: 1,
-  },
-  ASPECT_OF_THE_BEAST_BEAST_MASTERY_TALENT: {
-    id: 191384,
-    name: 'Aspect of the Beast',
-    icon: 'ability_deathwing_assualtaspects',
-    maxRanks: 1,
-  },
-  KINDRED_SPIRITS_BEAST_MASTERY_TALENT: {
-    id: 56315,
-    name: 'Kindred Spirits',
-    icon: 'ability_hunter_separationanxiety',
-    maxRanks: 2,
-  },
-  TRAINING_EXPERT_BEAST_MASTERY_TALENT: {
-    id: 378209,
-    name: 'Training Expert',
-    icon: 'spell_hunter_adaptation',
-    maxRanks: 2,
-  },
-  ANIMAL_COMPANION_BEAST_MASTERY_TALENT: {
-    id: 267116,
-    name: 'Animal Companion',
-    icon: 'ability_hunter_bestialdiscipline',
-    maxRanks: 1,
-  },
-  BEAST_CLEAVE_BEAST_MASTERY_TALENT: {
-    id: 115939,
-    name: 'Beast Cleave',
-    icon: 'ability_hunter_sickem',
-    maxRanks: 2,
-  },
-  KILLER_COMMAND_BEAST_MASTERY_TALENT: {
-    id: 378740,
-    name: 'Killer Command',
-    icon: 'ability_physical_taunt',
-    maxRanks: 2,
-  },
-  SHARP_BARBS_BEAST_MASTERY_TALENT: {
-    id: 378205,
-    name: 'Sharp Barbs',
-    icon: 'ability_hunter_laceration',
-    maxRanks: 2,
-  },
-  FLAMEWAKERS_COBRA_STING_BEAST_MASTERY_TALENT: {
-    id: 378750,
-    name: "Flamewaker's Cobra Sting",
-    icon: 'ability_hunter_cobrashot',
-    maxRanks: 2,
-  },
-  THRILL_OF_THE_HUNT_BEAST_MASTERY_TALENT: {
-    id: 257944,
-    name: 'Thrill of the Hunt',
-    icon: 'ability_hunter_thrillofthehunt',
-    maxRanks: 3,
-  },
-  KILL_CLEAVE_BEAST_MASTERY_TALENT: {
-    id: 378207,
-    name: 'Kill Cleave',
-    icon: 'spell_druid_bloodythrash',
-    maxRanks: 1,
-  },
-  A_MURDER_OF_CROWS_BEAST_MASTERY_TALENT: {
-    id: 131894,
-    name: 'A Murder of Crows',
-    icon: 'ability_hunter_murderofcrows',
-    maxRanks: 1,
-    focusCost: 30,
-  },
-  BLOODSHED_BEAST_MASTERY_TALENT: {
-    id: 321530,
-    name: 'Bloodshed',
-    icon: 'ability_druid_primaltenacity',
-    maxRanks: 1,
-  },
-  COBRA_SENSES_BEAST_MASTERY_TALENT: {
-    id: 378244,
-    name: 'Cobra Senses',
-    icon: 'ability_hunter_cobrastrikes',
-    maxRanks: 1,
-  },
-  DIRE_BEAST_BEAST_MASTERY_TALENT: {
-    id: 120679,
-    name: 'Dire Beast',
-    icon: 'ability_hunter_longevity',
-    maxRanks: 1,
-  },
-  BESTIAL_WRATH_BEAST_MASTERY_TALENT: {
-    id: 19574,
-    name: 'Bestial Wrath',
-    icon: 'ability_druid_ferociousbite',
-    maxRanks: 1,
-  },
-  QAPLA_EREDUN_WAR_ORDER_BEAST_MASTERY_TALENT: {
-    id: 336830,
-    name: "Qa'pla, Eredun War Order",
-    icon: 'ability_hunter_barbedshot',
-    maxRanks: 2,
-  },
-  IN_FOR_THE_KILL_BEAST_MASTERY_TALENT: {
-    id: 378210,
-    name: 'In for the Kill',
-    icon: 'ability_hunter_assassinate',
-    maxRanks: 1,
-  },
-  STOMP_BEAST_MASTERY_TALENT: {
-    id: 199530,
-    name: 'Stomp',
-    icon: 'warrior_talent_icon_thunderstruck',
-    maxRanks: 2,
-  },
-  BARBED_WRATH_BEAST_MASTERY_TALENT: {
-    id: 231548,
-    name: 'Barbed Wrath',
-    icon: 'ability_druid_ferociousbite',
-    maxRanks: 1,
-  },
-  WILD_CALL_BEAST_MASTERY_TALENT: {
-    id: 185789,
-    name: 'Wild Call',
-    icon: 'ability_hunter_masterscall',
-    maxRanks: 1,
-  },
-  ASPECT_OF_THE_WILD_BEAST_MASTERY_TALENT: {
-    id: 193530,
-    name: 'Aspect of the Wild',
-    icon: 'spell_nature_protectionformnature',
-    maxRanks: 1,
-  },
-  DIRE_COMMAND_BEAST_MASTERY_TALENT: {
-    id: 378743,
-    name: 'Dire Command',
-    icon: 'ability_hunter_ferociousinspiration',
-    maxRanks: 3,
-  },
-  SCENT_OF_BLOOD_BEAST_MASTERY_TALENT: {
-    id: 193532,
-    name: 'Scent of Blood',
-    icon: 'spell_shadow_lifedrain',
-    maxRanks: 2,
-  },
-  ONE_WITH_THE_PACK_BEAST_MASTERY_TALENT: {
-    id: 199528,
-    name: 'One with the Pack',
-    icon: 'icon_upgradestone_beast_uncommon',
-    maxRanks: 2,
-  },
-  MASTER_HANDLER_BEAST_MASTERY_TALENT: {
-    id: 389654,
-    name: 'Master Handler',
-    icon: 'ability_hunter_beastwithin',
-    maxRanks: 1,
-  },
-  SNAKE_BITE_BEAST_MASTERY_TALENT: {
-    id: 389660,
-    name: 'Snake Bite',
-    icon: 'inv_waepon_bow_zulgrub_d_01',
-    maxRanks: 1,
-  },
-  DIRE_FRENZY_BEAST_MASTERY_TALENT: {
-    id: 385810,
-    name: 'Dire Frenzy',
-    icon: 'ability_hunter_huntervswild',
-    maxRanks: 2,
-  },
-  WAILING_ARROW_BEAST_MASTERY_TALENT: {
-    id: 355589,
-    name: 'Wailing Arrow',
-    icon: 'ability_theblackarrow',
-    maxRanks: 1,
-    focusCost: 15,
-  },
-  BRUTAL_COMPANION_BEAST_MASTERY_TALENT: {
-    id: 386870,
-    name: 'Brutal Companion',
-    icon: 'ability_druid_rake',
-    maxRanks: 1,
-  },
-  CALL_OF_THE_WILD_BEAST_MASTERY_TALENT: {
-    id: 359844,
-    name: 'Call of the Wild',
-    icon: 'ability_hunter_callofthewild',
-    maxRanks: 1,
-  },
-  DIRE_PACK_BEAST_MASTERY_TALENT: {
-    id: 378745,
-    name: 'Dire Pack',
-    icon: 'ability_hunter_sickem',
-    maxRanks: 1,
-  },
-  KILLER_COBRA_BEAST_MASTERY_TALENT: {
-    id: 199532,
-    name: 'Killer Cobra',
-    icon: 'ability_hunter_snaketrap',
-    maxRanks: 1,
-  },
-  RYLAKSTALKERS_PIERCING_FANGS_BEAST_MASTERY_TALENT: {
-    id: 336844,
-    name: "Rylakstalker's Piercing Fangs",
-    icon: 'inv_misc_monsterfang_02',
-    maxRanks: 1,
-  },
-  WILD_INSTINCTS_BEAST_MASTERY_TALENT: {
-    id: 378442,
-    name: 'Wild Instincts',
-    icon: 'ability_hunter_beastwithin',
-    maxRanks: 1,
-  },
-  BLOODY_FRENZY_BEAST_MASTERY_TALENT: {
-    id: 378739,
-    name: 'Bloody Frenzy',
-    icon: 'ability_racial_cannibalize',
-    maxRanks: 1,
-  },
+  COBRA_SHOT_BEAST_MASTERY_TALENT,
+  PACK_TACTICS_BEAST_MASTERY_TALENT,
+  MULTI_SHOT_BEAST_MASTERY_TALENT,
+  BARBED_SHOT_BEAST_MASTERY_TALENT,
+  ASPECT_OF_THE_BEAST_BEAST_MASTERY_TALENT,
+  KINDRED_SPIRITS_BEAST_MASTERY_TALENT,
+  TRAINING_EXPERT_BEAST_MASTERY_TALENT,
+  ANIMAL_COMPANION_BEAST_MASTERY_TALENT,
+  BEAST_CLEAVE_BEAST_MASTERY_TALENT,
+  KILLER_COMMAND_BEAST_MASTERY_TALENT,
+  SHARP_BARBS_BEAST_MASTERY_TALENT,
+  FLAMEWAKERS_COBRA_STING_BEAST_MASTERY_TALENT,
+  THRILL_OF_THE_HUNT_BEAST_MASTERY_TALENT,
+  KILL_CLEAVE_BEAST_MASTERY_TALENT,
+  A_MURDER_OF_CROWS_BEAST_MASTERY_TALENT,
+  BLOODSHED_BEAST_MASTERY_TALENT,
+  COBRA_SENSES_BEAST_MASTERY_TALENT,
+  DIRE_BEAST_BEAST_MASTERY_TALENT,
+  BESTIAL_WRATH_BEAST_MASTERY_TALENT,
+  QAPLA_EREDUN_WAR_ORDER_BEAST_MASTERY_TALENT,
+  IN_FOR_THE_KILL_BEAST_MASTERY_TALENT,
+  STOMP_BEAST_MASTERY_TALENT,
+  BARBED_WRATH_BEAST_MASTERY_TALENT,
+  WILD_CALL_BEAST_MASTERY_TALENT,
+  ASPECT_OF_THE_WILD_BEAST_MASTERY_TALENT,
+  DIRE_COMMAND_BEAST_MASTERY_TALENT,
+  SCENT_OF_BLOOD_BEAST_MASTERY_TALENT,
+  ONE_WITH_THE_PACK_BEAST_MASTERY_TALENT,
+  MASTER_HANDLER_BEAST_MASTERY_TALENT,
+  SNAKE_BITE_BEAST_MASTERY_TALENT,
+  DIRE_FRENZY_BEAST_MASTERY_TALENT,
+  WAILING_ARROW_BEAST_MASTERY_TALENT,
+  BRUTAL_COMPANION_BEAST_MASTERY_TALENT,
+  CALL_OF_THE_WILD_BEAST_MASTERY_TALENT,
+  DIRE_PACK_BEAST_MASTERY_TALENT,
+  KILLER_COBRA_BEAST_MASTERY_TALENT,
+  RYLAKSTALKERS_PIERCING_FANGS_BEAST_MASTERY_TALENT,
+  WILD_INSTINCTS_BEAST_MASTERY_TALENT,
+  BLOODY_FRENZY_BEAST_MASTERY_TALENT,
 
   //Survival
-  RAPTOR_STRIKE_SURVIVAL_TALENT: {
-    id: 186270,
-    name: 'Raptor Strike',
-    icon: 'ability_hunter_raptorstrike',
-    maxRanks: 1,
-    focusCost: 30,
-  },
-  WILDFIRE_BOMB_SURVIVAL_TALENT: {
-    id: 259495,
-    name: 'Wildfire Bomb',
-    icon: 'inv_wildfirebomb',
-    maxRanks: 1,
-  },
-  TIP_OF_THE_SPEAR_SURVIVAL_TALENT: {
-    id: 260285,
-    name: 'Tip of the Spear',
-    icon: 'ability_bossmannoroth_glaivethrust',
-    maxRanks: 2,
-  },
-  FEROCITY_SURVIVAL_TALENT: {
-    id: 378916,
-    name: 'Ferocity',
-    icon: 'ability_hunter_sickem',
-    maxRanks: 2,
-  },
-  PREDATOR_SURVIVAL_TALENT: {
-    id: 263186,
-    name: 'Predator',
-    icon: 'ability_hunter_killcommand',
-    maxRanks: 1,
-  },
-  HARPOON_SURVIVAL_TALENT: {
-    id: 190925,
-    name: 'Harpoon',
-    icon: 'ability_hunter_harpoon',
-    maxRanks: 1,
-  },
-  ENERGETIC_ALLY_SURVIVAL_TALENT: {
-    id: 378961,
-    name: 'Energetic Ally',
-    icon: 'ability_hunter_invigeration',
-    maxRanks: 1,
-  },
-  BLOODSEEKER_SURVIVAL_TALENT: {
-    id: 260248,
-    name: 'Bloodseeker',
-    icon: 'ability_druid_primaltenacity',
-    maxRanks: 1,
-  },
-  ASPECT_OF_THE_EAGLE_SURVIVAL_TALENT: {
-    id: 186289,
-    name: 'Aspect of the Eagle',
-    icon: 'spell_hunter_aspectoftheironhawk',
-    maxRanks: 1,
-  },
-  TERMS_OF_ENGAGEMENT_SURVIVAL_TALENT: {
-    id: 265895,
-    name: 'Terms of Engagement',
-    icon: 'ability_hunter_harpoon',
-    maxRanks: 1,
-  },
-  GUERRILLA_TACTICS_SURVIVAL_TALENT: {
-    id: 264332,
-    name: 'Guerrilla Tactics',
-    icon: 'spell_mage_flameorb',
-    maxRanks: 1,
-  },
-  LUNGE_SURVIVAL_TALENT: {
-    id: 378934,
-    name: 'Lunge',
-    icon: 'ability_bossmannoroth_glaivethrust',
-    maxRanks: 1,
-  },
-  CARVE_SURVIVAL_TALENT: {
-    id: 187708,
-    name: 'Carve',
-    icon: 'ability_hunter_carve',
-    maxRanks: 1,
-    focusCost: 35,
-  },
-  BUTCHERY_SURVIVAL_TALENT: {
-    id: 212436,
-    name: 'Butchery',
-    icon: 'ability_butcher_cleave',
-    maxRanks: 1,
-    focusCost: 30,
-  },
-  MONGOOSE_BITE_SURVIVAL_TALENT: {
-    id: 259387,
-    name: 'Mongoose Bite',
-    icon: 'ability_hunter_mongoosebite',
-    maxRanks: 1,
-    focusCost: 30,
-  },
-  INTENSE_FOCUS_SURVIVAL_TALENT: {
-    id: 385709,
-    name: 'Intense Focus',
-    icon: 'ability_hunter_mastertactitian',
-    maxRanks: 2,
-  },
-  IMPROVED_WILDFIRE_BOMB_SURVIVAL_TALENT: {
-    id: 321290,
-    name: 'Improved Wildfire Bomb',
-    icon: 'inv_eng_bombfire',
-    maxRanks: 2,
-  },
-  FRENZY_STRIKES_SURVIVAL_TALENT: {
-    id: 294029,
-    name: 'Frenzy Strikes',
-    icon: 'ability_demonhunter_manabreak',
-    maxRanks: 1,
-  },
-  FLANKING_STRIKE_SURVIVAL_TALENT: {
-    id: 269751,
-    name: 'Flanking Strike',
-    icon: 'ability_hunter_invigeration',
-    maxRanks: 1,
-  },
-  SPEAR_FOCUS_SURVIVAL_TALENT: {
-    id: 378953,
-    name: 'Spear Focus',
-    icon: 'inv_polearm_2h_heirloomspear_c_01',
-    maxRanks: 2,
-  },
-  VIPERS_VENOM_SURVIVAL_TALENT: {
-    id: 268501,
-    name: "Viper's Venom",
-    icon: 'ability_hunter_potentvenom',
-    maxRanks: 2,
-  },
-  SHARP_EDGES_SURVIVAL_TALENT: {
-    id: 378948,
-    name: 'Sharp Edges',
-    icon: 'inv_polearm_2h_kultirasharpoon_a_01',
-    maxRanks: 2,
-  },
-  SWEEPING_SPEAR_SURVIVAL_TALENT: {
-    id: 378950,
-    name: 'Sweeping Spear',
-    icon: 'spell_warrior_wildstrike',
-    maxRanks: 2,
-  },
-  TACTICAL_ADVANTAGE_SURVIVAL_TALENT: {
-    id: 378951,
-    name: 'Tactical Advantage',
-    icon: 'ability_hunter_zenarchery',
-    maxRanks: 2,
-  },
-  BLOODY_CLAWS_SURVIVAL_TALENT: {
-    id: 385737,
-    name: 'Bloody Claws',
-    icon: 'ability_druid_disembowel',
-    maxRanks: 2,
-  },
-  WILDFIRE_INFUSION_SURVIVAL_TALENT: {
-    id: 271014,
-    name: 'Wildfire Infusion',
-    icon: 'inv_misc_5potionbag_special',
-    maxRanks: 1,
-  },
-  QUICK_SHOT_SURVIVAL_TALENT: {
-    id: 378940,
-    name: 'Quick Shot',
-    icon: 'ability_hunter_fervor',
-    maxRanks: 1,
-  },
-  COORDINATED_ASSAULT_SURVIVAL_TALENT: {
-    id: 360952,
-    name: 'Coordinated Assault',
-    icon: 'inv__coordinatedassault',
-    maxRanks: 1,
-  },
-  KILLER_COMPANION_SURVIVAL_TALENT: {
-    id: 378955,
-    name: 'Killer Companion',
-    icon: 'ability_hunter_masterscall',
-    maxRanks: 2,
-  },
-  FURY_OF_THE_EAGLE_SURVIVAL_TALENT: {
-    id: 203415,
-    name: 'Fury of the Eagle',
-    icon: 'inv_polearm_2h_artifacteagle_d_01',
-    maxRanks: 1,
-  },
-  RANGER_SURVIVAL_TALENT: {
-    id: 385695,
-    name: 'Ranger',
-    icon: 'ability_hunter_thrillofthehunt',
-    maxRanks: 2,
-  },
-  COORDINATED_KILL_SURVIVAL_TALENT: {
-    id: 385739,
-    name: 'Coordinated Kill',
-    icon: 'ability_hunter_pet_goto',
-    maxRanks: 2,
-  },
-  EXPLOSIVES_EXPERT_SURVIVAL_TALENT: {
-    id: 378937,
-    name: 'Explosives Expert',
-    icon: 'inv_misc_bomb_05',
-    maxRanks: 2,
-  },
-  SPEARHEAD_SURVIVAL_TALENT: {
-    id: 360966,
-    name: 'Spearhead',
-    icon: 'ability_hunter_spearhead',
-    maxRanks: 1,
-  },
-  RUTHLESS_MARAUDER_SURVIVAL_TALENT: {
-    id: 385718,
-    name: 'Ruthless Marauder',
-    icon: 'ability_rogue_findweakness',
-    maxRanks: 3,
-  },
-  BIRDS_OF_PREY_SURVIVAL_TALENT: {
-    id: 260331,
-    name: 'Birds of Prey',
-    icon: 'spell_hunter_aspectofthehawk',
-    maxRanks: 1,
-  },
-  BOMBARDIER_SURVIVAL_TALENT: {
-    id: 389880,
-    name: 'Bombardier',
-    icon: 'inv_eng_bombfire',
-    maxRanks: 1,
-  },
-  DEADLY_DUO_SURVIVAL_TALENT: {
-    id: 378962,
-    name: 'Deadly Duo',
-    icon: 'ability_hunter_separationanxiety',
-    maxRanks: 2,
-  },
+  RAPTOR_STRIKE_SURVIVAL_TALENT,
+  WILDFIRE_BOMB_SURVIVAL_TALENT,
+  TIP_OF_THE_SPEAR_SURVIVAL_TALENT,
+  FEROCITY_SURVIVAL_TALENT,
+  PREDATOR_SURVIVAL_TALENT,
+  HARPOON_SURVIVAL_TALENT,
+  ENERGETIC_ALLY_SURVIVAL_TALENT,
+  BLOODSEEKER_SURVIVAL_TALENT,
+  ASPECT_OF_THE_EAGLE_SURVIVAL_TALENT,
+  TERMS_OF_ENGAGEMENT_SURVIVAL_TALENT,
+  GUERRILLA_TACTICS_SURVIVAL_TALENT,
+  LUNGE_SURVIVAL_TALENT,
+  CARVE_SURVIVAL_TALENT,
+  BUTCHERY_SURVIVAL_TALENT,
+  MONGOOSE_BITE_SURVIVAL_TALENT,
+  INTENSE_FOCUS_SURVIVAL_TALENT,
+  IMPROVED_WILDFIRE_BOMB_SURVIVAL_TALENT,
+  FRENZY_STRIKES_SURVIVAL_TALENT,
+  FLANKING_STRIKE_SURVIVAL_TALENT,
+  SPEAR_FOCUS_SURVIVAL_TALENT,
+  VIPERS_VENOM_SURVIVAL_TALENT,
+  SHARP_EDGES_SURVIVAL_TALENT,
+  SWEEPING_SPEAR_SURVIVAL_TALENT,
+  TACTICAL_ADVANTAGE_SURVIVAL_TALENT,
+  BLOODY_CLAWS_SURVIVAL_TALENT,
+  WILDFIRE_INFUSION_SURVIVAL_TALENT,
+  QUICK_SHOT_SURVIVAL_TALENT,
+  COORDINATED_ASSAULT_SURVIVAL_TALENT,
+  KILLER_COMPANION_SURVIVAL_TALENT,
+  FURY_OF_THE_EAGLE_SURVIVAL_TALENT,
+  RANGER_SURVIVAL_TALENT,
+  COORDINATED_KILL_SURVIVAL_TALENT,
+  EXPLOSIVES_EXPERT_SURVIVAL_TALENT,
+  SPEARHEAD_SURVIVAL_TALENT,
+  RUTHLESS_MARAUDER_SURVIVAL_TALENT,
+  BIRDS_OF_PREY_SURVIVAL_TALENT,
+  BOMBARDIER_SURVIVAL_TALENT,
+  DEADLY_DUO_SURVIVAL_TALENT,
 });
 
 export default talents;

--- a/src/common/TALENTS/mage.ts
+++ b/src/common/TALENTS/mage.ts
@@ -1,1026 +1,1264 @@
 // Generated file, changes will eventually be overwritten!
-import { createTalentList } from './types';
+import { createTalentList, Talent } from './types';
+
+//region Shared
+export const BLAZING_BARRIER_TALENT: Talent = {
+  id: 235313,
+  name: 'Blazing Barrier',
+  icon: 'ability_mage_moltenarmor',
+  maxRanks: 1,
+  manaCost: 1500,
+};
+export const ICE_BLOCK_TALENT: Talent = {
+  id: 45438,
+  name: 'Ice Block',
+  icon: 'spell_frost_frost',
+  maxRanks: 1,
+};
+export const OVERFLOWING_ENERGY_NYI_TALENT: Talent = {
+  id: 390218,
+  name: 'Overflowing Energy [NYI]',
+  icon: 'spell_arcane_manatap',
+  maxRanks: 1,
+};
+export const INVISIBILITY_TALENT: Talent = {
+  id: 66,
+  name: 'Invisibility',
+  icon: 'ability_mage_invisibility',
+  maxRanks: 1,
+  manaCost: 1500,
+};
+export const WINTERS_PROTECTION_TALENT: Talent = {
+  id: 382424,
+  name: "Winter's Protection",
+  icon: 'spell_ice_rune',
+  maxRanks: 2,
+};
+export const SPELLSTEAL_TALENT: Talent = {
+  id: 30449,
+  name: 'Spellsteal',
+  icon: 'spell_arcane_arcane02',
+  maxRanks: 1,
+  manaCost: 10500,
+};
+export const TEMPEST_BARRIER_TALENT: Talent = {
+  id: 382289,
+  name: 'Tempest Barrier',
+  icon: 'inv_shield_1h_artifactstormfist_d_04',
+  maxRanks: 2,
+};
+export const INCANTATION_OF_SWIFTNESS_TALENT: Talent = {
+  id: 382293,
+  name: 'Incantation of Swiftness',
+  icon: 'rogue_burstofspeed',
+  maxRanks: 2,
+};
+export const REMOVE_CURSE_TALENT: Talent = {
+  id: 475,
+  name: 'Remove Curse',
+  icon: 'spell_nature_removecurse',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const ARCANE_WARDING_TALENT: Talent = {
+  id: 383092,
+  name: 'Arcane Warding',
+  icon: 'spell_arcane_arcaneresilience',
+  maxRanks: 2,
+};
+export const MIRROR_IMAGE_TALENT: Talent = {
+  id: 55342,
+  name: 'Mirror Image',
+  icon: 'spell_magic_lesserinvisibilty',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const INCANTERS_FLOW_TALENT: Talent = {
+  id: 1463,
+  name: "Incanter's Flow",
+  icon: 'ability_mage_incantersabsorbtion',
+  maxRanks: 1,
+};
+export const RUNE_OF_POWER_TALENT: Talent = {
+  id: 116011,
+  name: 'Rune of Power',
+  icon: 'spell_mage_runeofpower',
+  maxRanks: 1,
+};
+export const ALTER_TIME_TALENT: Talent = {
+  id: 342245,
+  name: 'Alter Time',
+  icon: 'spell_mage_altertime',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const CRYO_FREEZE_TALENT: Talent = {
+  id: 382292,
+  name: 'Cryo-Freeze',
+  icon: 'spell_frost_icefloes',
+  maxRanks: 2,
+};
+export const REDUPLICATION_TALENT: Talent = {
+  id: 382569,
+  name: 'Reduplication',
+  icon: 'spell_magic_lesserinvisibilty',
+  maxRanks: 1,
+};
+export const REABSORPTION_TALENT: Talent = {
+  id: 382820,
+  name: 'Reabsorption',
+  icon: 'spell_arcane_studentofmagic',
+  maxRanks: 1,
+};
+export const GROUNDING_SURGE_TALENT: Talent = {
+  id: 382297,
+  name: 'Grounding Surge',
+  icon: 'ability_priest_surgeofdarkness',
+  maxRanks: 1,
+};
+export const MASS_POLYMORPH_TALENT: Talent = {
+  id: 383121,
+  name: 'Mass Polymorph',
+  icon: 'spell_nature_doublepolymorph1',
+  maxRanks: 1,
+  manaCost: 2000,
+};
+export const SLOW_TALENT: Talent = {
+  id: 31589,
+  name: 'Slow',
+  icon: 'spell_nature_slow',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const MASTER_OF_TIME_TALENT: Talent = {
+  id: 342249,
+  name: 'Master of Time',
+  icon: 'inv_belt_armor_waistoftime_d_01',
+  maxRanks: 1,
+};
+export const DIVERTED_ENERGY_TALENT: Talent = {
+  id: 382270,
+  name: 'Diverted Energy',
+  icon: 'inv_soulbarrier',
+  maxRanks: 2,
+};
+export const RING_OF_FROST_TALENT: Talent = {
+  id: 113724,
+  name: 'Ring of Frost',
+  icon: 'spell_frost_ring_of_frost',
+  maxRanks: 1,
+  manaCost: 4000,
+};
+export const ICE_NOVA_TALENT: Talent = {
+  id: 157997,
+  name: 'Ice Nova',
+  icon: 'spell_mage_icenova',
+  maxRanks: 1,
+};
+export const SHIMMER_TALENT: Talent = {
+  id: 212653,
+  name: 'Shimmer',
+  icon: 'spell_arcane_massdispel',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const ICE_FLOES_TALENT: Talent = {
+  id: 108839,
+  name: 'Ice Floes',
+  icon: 'spell_mage_iceflows',
+  maxRanks: 1,
+};
+export const SLOOOOW_DOWN_TALENT: Talent = {
+  id: 391102,
+  name: 'Sloooow Down',
+  icon: 'inv_enchant_essencearcanelarge',
+  maxRanks: 1,
+};
+export const BLAST_WAVE_TALENT: Talent = {
+  id: 157981,
+  name: 'Blast Wave',
+  icon: 'spell_holy_excorcism_02',
+  maxRanks: 1,
+};
+export const IMPROVED_FROST_NOVA_TALENT: Talent = {
+  id: 343183,
+  name: 'Improved Frost Nova',
+  icon: 'spell_frost_frostnova',
+  maxRanks: 1,
+};
+export const RIGID_ICE_TALENT: Talent = {
+  id: 382481,
+  name: 'Rigid Ice',
+  icon: 'spell_frost_frostnova',
+  maxRanks: 1,
+};
+export const TOME_OF_RHONIN_TALENT: Talent = {
+  id: 382493,
+  name: 'Tome of Rhonin',
+  icon: 'spell_chargepositive',
+  maxRanks: 1,
+};
+export const TOME_OF_ANTONIDAS_TALENT: Talent = {
+  id: 382490,
+  name: 'Tome of Antonidas',
+  icon: 'spell_chargepositive',
+  maxRanks: 1,
+};
+export const VOLATILE_DETONATION_TALENT: Talent = {
+  id: 389627,
+  name: 'Volatile Detonation',
+  icon: 'spell_fire_burnout',
+  maxRanks: 1,
+};
+export const ENERGIZED_BARRIERS_TALENT: Talent = {
+  id: 386828,
+  name: 'Energized Barriers',
+  icon: 'spell_mage_temporalshield',
+  maxRanks: 1,
+};
+export const FRIGID_WINDS_TALENT: Talent = {
+  id: 235224,
+  name: 'Frigid Winds',
+  icon: 'ability_mage_deepfreeze',
+  maxRanks: 2,
+};
+export const FLOW_OF_TIME_TALENT: Talent = {
+  id: 382268,
+  name: 'Flow of Time',
+  icon: 'spell_arcane_blink',
+  maxRanks: 2,
+};
+export const TEMPORAL_VELOCITY_TALENT: Talent = {
+  id: 382826,
+  name: 'Temporal Velocity',
+  icon: 'ability_socererking_arcaneacceleration',
+  maxRanks: 2,
+};
+export const ICE_WARD_TALENT: Talent = {
+  id: 205036,
+  name: 'Ice Ward',
+  icon: 'spell_frost_frostward',
+  maxRanks: 1,
+};
+export const TIME_MANIPULATION_TALENT: Talent = {
+  id: 387807,
+  name: 'Time Manipulation',
+  icon: 'spell_nature_timestop',
+  maxRanks: 2,
+};
+export const GREATER_INVISIBILITY_TALENT: Talent = {
+  id: 110959,
+  name: 'Greater Invisibility',
+  icon: 'ability_mage_greaterinvisibility',
+  maxRanks: 1,
+};
+export const ACCUMULATIVE_SHIELDING_TALENT: Talent = {
+  id: 382800,
+  name: 'Accumulative Shielding',
+  icon: 'ability_mage_shattershield',
+  maxRanks: 2,
+};
+export const DRAGONS_BREATH_TALENT: Talent = {
+  id: 31661,
+  name: "Dragon's Breath",
+  icon: 'inv_misc_head_dragon_01',
+  maxRanks: 1,
+  manaCost: 2000,
+};
+export const SHIFTING_POWER_TALENT: Talent = {
+  id: 382440,
+  name: 'Shifting Power',
+  icon: 'ability_ardenweald_mage',
+  maxRanks: 1,
+  manaCost: 2500,
+};
+export const FREEZING_COLD_TALENT: Talent = {
+  id: 386763,
+  name: 'Freezing Cold',
+  icon: 'spell_frost_glacier',
+  maxRanks: 1,
+};
+export const TIME_ANOMALY_TALENT: Talent = {
+  id: 383243,
+  name: 'Time Anomaly',
+  icon: 'ability_mage_timewarp',
+  maxRanks: 1,
+};
+export const TEMPORAL_WARP_TALENT: Talent = {
+  id: 386539,
+  name: 'Temporal Warp',
+  icon: 'ability_bossmagistrix_timewarp2',
+  maxRanks: 1,
+};
+export const REFLECTION_TALENT: Talent = {
+  id: 389713,
+  name: 'Reflection',
+  icon: 'ability_hunter_displacement',
+  maxRanks: 1,
+};
+export const METEOR_TALENT: Talent = {
+  id: 153561,
+  name: 'Meteor',
+  icon: 'spell_mage_meteor',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const ICE_BARRIER_TALENT: Talent = {
+  id: 11426,
+  name: 'Ice Barrier',
+  icon: 'spell_ice_lament',
+  maxRanks: 1,
+  manaCost: 1500,
+};
+export const PRISMATIC_BARRIER_TALENT: Talent = {
+  id: 235450,
+  name: 'Prismatic Barrier',
+  icon: 'spell_magearmor',
+  maxRanks: 1,
+  manaCost: 1500,
+};
+
+//endregion
+
+//region Fire
+export const PYROBLAST_FIRE_TALENT: Talent = {
+  id: 11366,
+  name: 'Pyroblast',
+  icon: 'spell_fire_fireball02',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const FIRE_BLAST_FIRE_TALENT: Talent = {
+  id: 108853,
+  name: 'Fire Blast',
+  icon: 'spell_fire_fireball',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const FLAMESTRIKE_FIRE_TALENT: Talent = {
+  id: 2120,
+  name: 'Flamestrike',
+  icon: 'spell_fire_selfdestruct',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const SCORCH_FIRE_TALENT: Talent = {
+  id: 2948,
+  name: 'Scorch',
+  icon: 'spell_fire_soulburn',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const PHOENIX_FLAMES_FIRE_TALENT: Talent = {
+  id: 343222,
+  name: 'Phoenix Flames',
+  icon: 'artifactability_firemage_phoenixbolt',
+  maxRanks: 1,
+};
+export const FERVENT_FLICKERING_FIRE_TALENT: Talent = {
+  id: 387044,
+  name: 'Fervent Flickering',
+  icon: 'ability_warlock_burningembers',
+  maxRanks: 1,
+};
+export const SEARING_TOUCH_FIRE_TALENT: Talent = {
+  id: 269644,
+  name: 'Searing Touch',
+  icon: 'ability_warlock_backdraft',
+  maxRanks: 1,
+};
+export const FIRESTARTER_FIRE_TALENT: Talent = {
+  id: 205026,
+  name: 'Firestarter',
+  icon: 'spell_fire_fire',
+  maxRanks: 1,
+};
+export const ENHANCED_PYROTECHNICS_FIRE_TALENT: Talent = {
+  id: 157642,
+  name: 'Enhanced Pyrotechnics',
+  icon: 'spell_fire_flamebolt',
+  maxRanks: 1,
+};
+export const IMPROVED_FLAMESTRIKE_FIRE_TALENT: Talent = {
+  id: 343230,
+  name: 'Improved Flamestrike',
+  icon: 'spell_fire_selfdestruct',
+  maxRanks: 1,
+};
+export const IMPROVED_SCORCH_FIRE_TALENT: Talent = {
+  id: 383604,
+  name: 'Improved Scorch',
+  icon: 'ability_mage_fierypayback',
+  maxRanks: 2,
+};
+export const CRITICAL_MASS_FIRE_TALENT: Talent = {
+  id: 117216,
+  name: 'Critical Mass',
+  icon: 'ability_mage_firestarter',
+  maxRanks: 2,
+};
+export const CAUTERIZE_FIRE_TALENT: Talent = {
+  id: 86949,
+  name: 'Cauterize',
+  icon: 'spell_fire_rune',
+  maxRanks: 1,
+};
+export const FLAME_ON_FIRE_TALENT: Talent = {
+  id: 205029,
+  name: 'Flame On',
+  icon: 'inv_helm_circlet_firelands_d_01',
+  maxRanks: 2,
+};
+export const FLAME_PATCH_FIRE_TALENT: Talent = {
+  id: 205037,
+  name: 'Flame Patch',
+  icon: 'spell_mage_flameorb',
+  maxRanks: 1,
+};
+export const FROM_THE_ASHES_FIRE_TALENT: Talent = {
+  id: 342344,
+  name: 'From the Ashes',
+  icon: 'inv_misc_phoenixegg',
+  maxRanks: 1,
+};
+export const ALEXSTRASZAS_FURY_FIRE_TALENT: Talent = {
+  id: 235870,
+  name: "Alexstrasza's Fury",
+  icon: 'spell_warrior_dragoncharge',
+  maxRanks: 1,
+};
+export const COMBUSTION_FIRE_TALENT: Talent = {
+  id: 190319,
+  name: 'Combustion',
+  icon: 'spell_fire_sealoffire',
+  maxRanks: 1,
+  manaCost: 5000,
+};
+export const LIVING_BOMB_FIRE_TALENT: Talent = {
+  id: 44457,
+  name: 'Living Bomb',
+  icon: 'ability_mage_livingbomb',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const INCENDIARY_ERUPTIONS_FIRE_TALENT: Talent = {
+  id: 383665,
+  name: 'Incendiary Eruptions',
+  icon: 'spell_fire_moltenblood',
+  maxRanks: 1,
+};
+export const FIREMIND_FIRE_TALENT: Talent = {
+  id: 383499,
+  name: 'Firemind',
+  icon: 'ability_mage_hotstreak',
+  maxRanks: 2,
+};
+export const TEMPERED_FLAMES_FIRE_TALENT: Talent = {
+  id: 383659,
+  name: 'Tempered Flames',
+  icon: 'ability_mage_greaterpyroblast',
+  maxRanks: 1,
+};
+export const COMBUSTION_DURATION_FIRE_TALENT: Talent = {
+  id: 321710,
+  name: 'Combustion Duration',
+  icon: 'spell_fire_sealoffire',
+  maxRanks: 1,
+};
+export const BLASTER_MASTER_FIRE_TALENT: Talent = {
+  id: 383391,
+  name: 'Blaster Master',
+  icon: 'spell_fire_fireball',
+  maxRanks: 2,
+};
+export const CONFLAGRATION_FIRE_TALENT: Talent = {
+  id: 205023,
+  name: 'Conflagration',
+  icon: 'spell_shaman_firenova',
+  maxRanks: 1,
+};
+export const PHOENIX_REBORN_FIRE_TALENT: Talent = {
+  id: 383476,
+  name: 'Phoenix Reborn',
+  icon: 'inv_sword_1h_artifactfelomelorn_d_01',
+  maxRanks: 1,
+};
+export const TINDER_FIRE_TALENT: Talent = {
+  id: 203275,
+  name: 'Tinder',
+  icon: 'inv_ember',
+  maxRanks: 2,
+};
+export const KINDLING_FIRE_TALENT: Talent = {
+  id: 155148,
+  name: 'Kindling',
+  icon: 'spell_mage_kindling',
+  maxRanks: 1,
+};
+export const WILDFIRE_FIRE_TALENT: Talent = {
+  id: 383489,
+  name: 'Wildfire',
+  icon: 'ability_warlock_inferno',
+  maxRanks: 2,
+};
+export const MASTER_OF_FLAME_FIRE_TALENT: Talent = {
+  id: 384174,
+  name: 'Master of Flame',
+  icon: 'inv_trinket_firelands_02',
+  maxRanks: 1,
+};
+export const CONTROLLED_DESTRUCTION_FIRE_TALENT: Talent = {
+  id: 383669,
+  name: 'Controlled Destruction',
+  icon: 'spell_fire_playingwithfire',
+  maxRanks: 2,
+};
+export const PYROCLASM_FIRE_TALENT: Talent = {
+  id: 269650,
+  name: 'Pyroclasm',
+  icon: 'spell_shaman_lavasurge',
+  maxRanks: 1,
+};
+export const PYROMANIAC_FIRE_TALENT: Talent = {
+  id: 205020,
+  name: 'Pyromaniac',
+  icon: 'inv_misc_volatilefire',
+  maxRanks: 1,
+};
+export const MOLTEN_SKYFALL_FIRE_TALENT: Talent = {
+  id: 384033,
+  name: 'Molten Skyfall',
+  icon: 'spell_mage_meteor',
+  maxRanks: 1,
+};
+export const FEVERED_INCANTATION_FIRE_TALENT: Talent = {
+  id: 383810,
+  name: 'Fevered Incantation',
+  icon: 'inv_misc_enchantedpearld',
+  maxRanks: 2,
+};
+export const SUN_KINGS_BLESSING_FIRE_TALENT: Talent = {
+  id: 383886,
+  name: "Sun King's Blessing",
+  icon: 'ability_mage_firestarter',
+  maxRanks: 1,
+};
+export const FIERY_RUSH_FIRE_TALENT: Talent = {
+  id: 383634,
+  name: 'Fiery Rush',
+  icon: 'inv_summerfest_firespirit',
+  maxRanks: 1,
+};
+export const FIRE_FRENZY_FIRE_TALENT: Talent = {
+  id: 383860,
+  name: 'Fire Frenzy',
+  icon: 'spell_fire_burnout',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Frost
+export const ICE_LANCE_FROST_TALENT: Talent = {
+  id: 30455,
+  name: 'Ice Lance',
+  icon: 'spell_frost_frostblast',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const FROZEN_ORB_FROST_TALENT: Talent = {
+  id: 84714,
+  name: 'Frozen Orb',
+  icon: 'spell_frost_frozenorb',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const BLIZZARD_FROST_TALENT: Talent = {
+  id: 190356,
+  name: 'Blizzard',
+  icon: 'spell_frost_icestorm',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const FINGERS_OF_FROST_FROST_TALENT: Talent = {
+  id: 112965,
+  name: 'Fingers of Frost',
+  icon: 'ability_mage_wintersgrasp',
+  maxRanks: 1,
+};
+export const FLURRY_FROST_TALENT: Talent = {
+  id: 44614,
+  name: 'Flurry',
+  icon: 'ability_warlock_burningembersblue',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const SHATTER_FROST_TALENT: Talent = {
+  id: 12982,
+  name: 'Shatter',
+  icon: 'spell_frost_frostshock',
+  maxRanks: 1,
+};
+export const BRAIN_FREEZE_FROST_TALENT: Talent = {
+  id: 190447,
+  name: 'Brain Freeze',
+  icon: 'ability_mage_brainfreeze',
+  maxRanks: 1,
+};
+export const COLD_SNAP_FROST_TALENT: Talent = {
+  id: 235219,
+  name: 'Cold Snap',
+  icon: 'spell_frost_wizardmark',
+  maxRanks: 1,
+};
+export const FROSTBITE_FROST_TALENT: Talent = {
+  id: 378756,
+  name: 'Frostbite',
+  icon: 'spell_frost_frostarmor',
+  maxRanks: 1,
+};
+export const ARCTIC_PIERCING_FROST_TALENT: Talent = {
+  id: 378919,
+  name: 'Arctic Piercing',
+  icon: 'spell_frost_frostbolt',
+  maxRanks: 1,
+};
+export const EBONBOLT_FROST_TALENT: Talent = {
+  id: 257537,
+  name: 'Ebonbolt',
+  icon: 'artifactability_frostmage_ebonbolt',
+  maxRanks: 1,
+};
+export const FROZEN_TOUCH_FROST_TALENT: Talent = {
+  id: 205030,
+  name: 'Frozen Touch',
+  icon: 'ability_mage_burstofcold',
+  maxRanks: 1,
+};
+export const LONELY_WINTER_FROST_TALENT: Talent = {
+  id: 205024,
+  name: 'Lonely Winter',
+  icon: 'achievement_dungeon_frozenthrone',
+  maxRanks: 1,
+};
+export const SUMMON_WATER_ELEMENTAL_FROST_TALENT: Talent = {
+  id: 31687,
+  name: 'Summon Water Elemental',
+  icon: 'spell_frost_summonwaterelemental_2',
+  maxRanks: 1,
+  manaCost: 1500,
+};
+export const IMPROVED_BLIZZARD_FROST_TALENT: Talent = {
+  id: 236662,
+  name: 'Improved Blizzard',
+  icon: 'spell_frost_icestorm',
+  maxRanks: 1,
+};
+export const EVERLASTING_FROST_FROST_TALENT: Talent = {
+  id: 385167,
+  name: 'Everlasting Frost',
+  icon: 'spell_frost_chillingbolt',
+  maxRanks: 1,
+};
+export const BONE_CHILLING_FROST_TALENT: Talent = {
+  id: 205027,
+  name: 'Bone Chilling',
+  icon: 'ability_mage_chilledtothebone',
+  maxRanks: 1,
+};
+export const DEEP_SHATTER_FROST_TALENT: Talent = {
+  id: 378749,
+  name: 'Deep Shatter',
+  icon: 'inv_misc_frostemblem_01',
+  maxRanks: 2,
+};
+export const PERPETUAL_WINTER_FROST_TALENT: Talent = {
+  id: 378198,
+  name: 'Perpetual Winter',
+  icon: 'ability_warlock_burningembersblue',
+  maxRanks: 1,
+};
+export const WINTERTIDE_FROST_TALENT: Talent = {
+  id: 378406,
+  name: 'Wintertide',
+  icon: 'ability_mage_burstofcold',
+  maxRanks: 2,
+};
+export const SNOWSTORM_FROST_TALENT: Talent = {
+  id: 381706,
+  name: 'Snowstorm',
+  icon: 'spell_fire_bluerainoffire',
+  maxRanks: 2,
+};
+export const FLASH_FREEZE_FROST_TALENT: Talent = {
+  id: 379993,
+  name: 'Flash Freeze',
+  icon: 'ability_mage_coldasice',
+  maxRanks: 1,
+};
+export const FRIGID_SHATTERING_FROST_TALENT: Talent = {
+  id: 380154,
+  name: 'Frigid Shattering',
+  icon: 'spell_ice_magicdamage',
+  maxRanks: 2,
+};
+export const GLACIAL_ASSAULT_FROST_TALENT: Talent = {
+  id: 378947,
+  name: 'Glacial Assault',
+  icon: 'spell_mage_cometstorm2',
+  maxRanks: 2,
+};
+export const ICY_VEINS_FROST_TALENT: Talent = {
+  id: 12472,
+  name: 'Icy Veins',
+  icon: 'spell_frost_coldhearted',
+  maxRanks: 1,
+};
+export const ICE_NINE_FROST_TALENT: Talent = {
+  id: 379049,
+  name: 'Ice Nine',
+  icon: 'spell_frost_iceshard',
+  maxRanks: 2,
+};
+export const COMET_STORM_FROST_TALENT: Talent = {
+  id: 153595,
+  name: 'Comet Storm',
+  icon: 'spell_mage_cometstorm2',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const FREEZING_RAIN_FROST_TALENT: Talent = {
+  id: 270233,
+  name: 'Freezing Rain',
+  icon: 'spell_frost_frozenorb',
+  maxRanks: 1,
+};
+export const ICY_PROPULSION_FROST_TALENT: Talent = {
+  id: 378433,
+  name: 'Icy Propulsion',
+  icon: 'spell_frost_coldhearted',
+  maxRanks: 1,
+};
+export const RAY_OF_FROST_FROST_TALENT: Talent = {
+  id: 205021,
+  name: 'Ray of Frost',
+  icon: 'ability_mage_rayoffrost',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const SPLITTING_ICE_FROST_TALENT: Talent = {
+  id: 56377,
+  name: 'Splitting Ice',
+  icon: 'spell_frost_ice_shards',
+  maxRanks: 1,
+};
+export const FRACTURED_FROST_FROST_TALENT: Talent = {
+  id: 378448,
+  name: 'Fractured Frost',
+  icon: 'spell_fire_frostresistancetotem',
+  maxRanks: 2,
+};
+export const SNAP_FREEZE_FROST_TALENT: Talent = {
+  id: 378901,
+  name: 'Snap Freeze',
+  icon: 'spell_frost_coldhearted',
+  maxRanks: 1,
+};
+export const IMPROVED_ICY_VEINS_FROST_TALENT: Talent = {
+  id: 321702,
+  name: 'Improved Icy Veins',
+  icon: 'spell_frost_coldhearted',
+  maxRanks: 2,
+};
+export const CHAIN_REACTION_FROST_TALENT: Talent = {
+  id: 278309,
+  name: 'Chain Reaction',
+  icon: 'spell_frost_frostblast',
+  maxRanks: 1,
+};
+export const HAILSTONES_FROST_TALENT: Talent = {
+  id: 381244,
+  name: 'Hailstones',
+  icon: 'artifactability_frostmage_blackicicles',
+  maxRanks: 2,
+};
+export const COLD_FRONT_FROST_TALENT: Talent = {
+  id: 382110,
+  name: 'Cold Front',
+  icon: 'ability_mage_coldasice',
+  maxRanks: 1,
+};
+export const FREEZING_WINDS_FROST_TALENT: Talent = {
+  id: 382103,
+  name: 'Freezing Winds',
+  icon: 'spell_shadow_soulleech_2',
+  maxRanks: 1,
+};
+export const SLICK_ICE_FROST_TALENT: Talent = {
+  id: 382144,
+  name: 'Slick Ice',
+  icon: 'inv_enchant_shardshadowfrostlarge',
+  maxRanks: 1,
+};
+export const THERMAL_VOID_FROST_TALENT: Talent = {
+  id: 155149,
+  name: 'Thermal Void',
+  icon: 'spell_mage_thermalvoid',
+  maxRanks: 1,
+};
+export const GLACIAL_SPIKE_FROST_TALENT: Talent = {
+  id: 199786,
+  name: 'Glacial Spike',
+  icon: 'ability_mage_glacialspike',
+  maxRanks: 1,
+  manaCost: 500,
+};
+
+//endregion
+
+//region Arcane
+export const ARCANE_BARRAGE_ARCANE_TALENT: Talent = {
+  id: 44425,
+  name: 'Arcane Barrage',
+  icon: 'ability_mage_arcanebarrage',
+  maxRanks: 1,
+};
+export const ARCANE_MISSILES_ARCANE_TALENT: Talent = {
+  id: 5143,
+  name: 'Arcane Missiles',
+  icon: 'spell_nature_starfall',
+  maxRanks: 1,
+  manaCost: 7500,
+};
+export const ARCANE_ORB_ARCANE_TALENT: Talent = {
+  id: 153626,
+  name: 'Arcane Orb',
+  icon: 'spell_mage_arcaneorb',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const CLEARCASTING_ARCANE_TALENT: Talent = {
+  id: 79684,
+  name: 'Clearcasting',
+  icon: 'spell_shadow_manaburn',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const ARCANE_TEMPO_ARCANE_TALENT: Talent = {
+  id: 383980,
+  name: 'Arcane Tempo',
+  icon: 'ability_socererking_arcaneacceleration',
+  maxRanks: 1,
+};
+export const IMPROVED_ARCANE_MISSILES_ARCANE_TALENT: Talent = {
+  id: 383661,
+  name: 'Improved Arcane Missiles',
+  icon: 'spell_nature_starfall',
+  maxRanks: 2,
+};
+export const ARCANE_SURGE_ARCANE_TALENT: Talent = {
+  id: 365350,
+  name: 'Arcane Surge',
+  icon: 'ability_mage_arcanesurge',
+  maxRanks: 1,
+  manaCost: 1,
+};
+export const IMPROVED_ARCANE_EXPLOSION_ARCANE_TALENT: Talent = {
+  id: 321752,
+  name: 'Improved Arcane Explosion',
+  icon: 'spell_nature_wispsplode',
+  maxRanks: 2,
+};
+export const IMPETUS_ARCANE_TALENT: Talent = {
+  id: 383676,
+  name: 'Impetus',
+  icon: 'spell_arcane_arcanetorrent',
+  maxRanks: 1,
+};
+export const ARCANE_FAMILIAR_ARCANE_TALENT: Talent = {
+  id: 205022,
+  name: 'Arcane Familiar',
+  icon: 'ability_socererking_arcanemines',
+  maxRanks: 1,
+};
+export const RULE_OF_THREES_ARCANE_TALENT: Talent = {
+  id: 264354,
+  name: 'Rule of Threes',
+  icon: 'spell_arcane_starfire',
+  maxRanks: 1,
+};
+export const CHARGED_ORB_ARCANE_TALENT: Talent = {
+  id: 384651,
+  name: 'Charged Orb',
+  icon: 'spell_mage_arcaneorb',
+  maxRanks: 1,
+};
+export const IMPROVED_ARCANE_BARRAGE_ARCANE_TALENT: Talent = {
+  id: 231564,
+  name: 'Improved Arcane Barrage',
+  icon: 'ability_mage_arcanebarrage',
+  maxRanks: 1,
+};
+export const ARCANE_POWER_ARCANE_TALENT: Talent = {
+  id: 321739,
+  name: 'Arcane Power',
+  icon: 'spell_nature_lightning',
+  maxRanks: 1,
+};
+export const MANA_ADEPT_ARCANE_TALENT: Talent = {
+  id: 321526,
+  name: 'Mana Adept',
+  icon: 'ability_mage_arcanebarrage',
+  maxRanks: 1,
+};
+export const NETHER_PRECISION_ARCANE_TALENT: Talent = {
+  id: 383782,
+  name: 'Nether Precision',
+  icon: 'spell_arcane_blast_nightborne',
+  maxRanks: 1,
+};
+export const AMPLIFICATION_ARCANE_TALENT: Talent = {
+  id: 236628,
+  name: 'Amplification',
+  icon: 'spell_arcane_invocation',
+  maxRanks: 1,
+};
+export const PRESENCE_OF_MIND_ARCANE_TALENT: Talent = {
+  id: 205025,
+  name: 'Presence of Mind',
+  icon: 'spell_nature_enchantarmor',
+  maxRanks: 1,
+};
+export const FORESIGHT_ARCANE_TALENT: Talent = {
+  id: 384861,
+  name: 'Foresight',
+  icon: 'spell_mage_presenceofmind',
+  maxRanks: 1,
+};
+export const RESONANCE_ARCANE_TALENT: Talent = {
+  id: 205028,
+  name: 'Resonance',
+  icon: 'spell_arcane_arcane01',
+  maxRanks: 1,
+};
+export const NETHER_TEMPEST_ARCANE_TALENT: Talent = {
+  id: 114923,
+  name: 'Nether Tempest',
+  icon: 'spell_mage_nethertempest',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const REVERBERATE_ARCANE_TALENT: Talent = {
+  id: 281482,
+  name: 'Reverberate',
+  icon: 'spell_arcane_arcane04',
+  maxRanks: 1,
+};
+export const IMPROVED_PRISMATIC_BARRIER_ARCANE_TALENT: Talent = {
+  id: 321745,
+  name: 'Improved Prismatic Barrier',
+  icon: 'spell_magearmor',
+  maxRanks: 1,
+};
+export const SLIPSTREAM_ARCANE_TALENT: Talent = {
+  id: 236457,
+  name: 'Slipstream',
+  icon: 'spell_holy_mindsooth',
+  maxRanks: 1,
+};
+export const IMPROVED_CLEARCASTING_ARCANE_TALENT: Talent = {
+  id: 321420,
+  name: 'Improved Clearcasting',
+  icon: 'spell_shadow_manaburn',
+  maxRanks: 1,
+};
+export const CHRONO_SHIFT_ARCANE_TALENT: Talent = {
+  id: 235711,
+  name: 'Chrono Shift',
+  icon: 'ability_monk_deadlyreach',
+  maxRanks: 1,
+};
+export const TOUCH_OF_THE_MAGI_ARCANE_TALENT: Talent = {
+  id: 321507,
+  name: 'Touch of the Magi',
+  icon: 'spell_mage_icenova',
+  maxRanks: 1,
+  manaCost: 2500,
+};
+export const SUPERNOVA_ARCANE_TALENT: Talent = {
+  id: 157980,
+  name: 'Supernova',
+  icon: 'spell_mage_supernova',
+  maxRanks: 1,
+};
+export const EVOCATION_ARCANE_TALENT: Talent = {
+  id: 12051,
+  name: 'Evocation',
+  icon: 'spell_nature_purge',
+  maxRanks: 1,
+};
+export const ENLIGHTENED_ARCANE_TALENT: Talent = {
+  id: 321387,
+  name: 'Enlightened',
+  icon: 'ability_socererking_arcanefortification',
+  maxRanks: 1,
+};
+export const ARCANE_ECHO_ARCANE_TALENT: Talent = {
+  id: 342231,
+  name: 'Arcane Echo',
+  icon: 'ability_socererking_arcanewrath',
+  maxRanks: 1,
+};
+export const ARCANE_BOMBARDMENT_ARCANE_TALENT: Talent = {
+  id: 384581,
+  name: 'Arcane Bombardment',
+  icon: 'ability_socererking_arcanereplication',
+  maxRanks: 1,
+};
+export const ILLUMINATED_THOUGHTS_ARCANE_TALENT: Talent = {
+  id: 384060,
+  name: 'Illuminated Thoughts',
+  icon: 'spell_arcane_focusedpower',
+  maxRanks: 2,
+};
+export const CONJURE_MANA_GEM_ARCANE_TALENT: Talent = {
+  id: 759,
+  name: 'Conjure Mana Gem',
+  icon: 'inv_misc_gem_sapphire_02',
+  maxRanks: 1,
+  manaCost: 9000,
+};
+export const SIPHON_STORM_ARCANE_TALENT: Talent = {
+  id: 384187,
+  name: 'Siphon Storm',
+  icon: 'ability_monk_forcesphere_arcane',
+  maxRanks: 1,
+};
+export const PRODIGIOUS_SAVANT_ARCANE_TALENT: Talent = {
+  id: 384612,
+  name: 'Prodigious Savant',
+  icon: 'ability_mage_studentofthemind',
+  maxRanks: 2,
+};
+export const RADIANT_SPARK_ARCANE_TALENT: Talent = {
+  id: 376103,
+  name: 'Radiant Spark',
+  icon: 'ability_bastion_mage',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const CONCENTRATION_ARCANE_TALENT: Talent = {
+  id: 384374,
+  name: 'Concentration',
+  icon: 'ability_mage_potentspirit',
+  maxRanks: 1,
+};
+export const CASCADING_POWER_ARCANE_TALENT: Talent = {
+  id: 384276,
+  name: 'Cascading Power',
+  icon: 'inv_misc_gem_sapphire_02',
+  maxRanks: 1,
+};
+export const ORB_BARRAGE_ARCANE_TALENT: Talent = {
+  id: 384858,
+  name: 'Orb Barrage',
+  icon: 'spell_mage_arcaneorb_nightborne',
+  maxRanks: 1,
+};
+export const HARMONIC_ECHO_ARCANE_TALENT: Talent = {
+  id: 384683,
+  name: 'Harmonic Echo',
+  icon: 'ability_bastion_mage',
+  maxRanks: 1,
+};
+export const ARCANE_HARMONY_ARCANE_TALENT: Talent = {
+  id: 384452,
+  name: 'Arcane Harmony',
+  icon: 'ability_creature_cursed_04',
+  maxRanks: 1,
+};
+
+//endregion
 
 const talents = createTalentList({
   //Shared
-  BLAZING_BARRIER_TALENT: {
-    id: 235313,
-    name: 'Blazing Barrier',
-    icon: 'ability_mage_moltenarmor',
-    maxRanks: 1,
-    manaCost: 1500,
-  },
-  ICE_BLOCK_TALENT: { id: 45438, name: 'Ice Block', icon: 'spell_frost_frost', maxRanks: 1 },
-  OVERFLOWING_ENERGY_NYI_TALENT: {
-    id: 390218,
-    name: 'Overflowing Energy [NYI]',
-    icon: 'spell_arcane_manatap',
-    maxRanks: 1,
-  },
-  INVISIBILITY_TALENT: {
-    id: 66,
-    name: 'Invisibility',
-    icon: 'ability_mage_invisibility',
-    maxRanks: 1,
-    manaCost: 1500,
-  },
-  WINTERS_PROTECTION_TALENT: {
-    id: 382424,
-    name: "Winter's Protection",
-    icon: 'spell_ice_rune',
-    maxRanks: 2,
-  },
-  SPELLSTEAL_TALENT: {
-    id: 30449,
-    name: 'Spellsteal',
-    icon: 'spell_arcane_arcane02',
-    maxRanks: 1,
-    manaCost: 10500,
-  },
-  TEMPEST_BARRIER_TALENT: {
-    id: 382289,
-    name: 'Tempest Barrier',
-    icon: 'inv_shield_1h_artifactstormfist_d_04',
-    maxRanks: 2,
-  },
-  INCANTATION_OF_SWIFTNESS_TALENT: {
-    id: 382293,
-    name: 'Incantation of Swiftness',
-    icon: 'rogue_burstofspeed',
-    maxRanks: 2,
-  },
-  REMOVE_CURSE_TALENT: {
-    id: 475,
-    name: 'Remove Curse',
-    icon: 'spell_nature_removecurse',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  ARCANE_WARDING_TALENT: {
-    id: 383092,
-    name: 'Arcane Warding',
-    icon: 'spell_arcane_arcaneresilience',
-    maxRanks: 2,
-  },
-  MIRROR_IMAGE_TALENT: {
-    id: 55342,
-    name: 'Mirror Image',
-    icon: 'spell_magic_lesserinvisibilty',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  INCANTERS_FLOW_TALENT: {
-    id: 1463,
-    name: "Incanter's Flow",
-    icon: 'ability_mage_incantersabsorbtion',
-    maxRanks: 1,
-  },
-  RUNE_OF_POWER_TALENT: {
-    id: 116011,
-    name: 'Rune of Power',
-    icon: 'spell_mage_runeofpower',
-    maxRanks: 1,
-  },
-  ALTER_TIME_TALENT: {
-    id: 342245,
-    name: 'Alter Time',
-    icon: 'spell_mage_altertime',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  CRYO_FREEZE_TALENT: {
-    id: 382292,
-    name: 'Cryo-Freeze',
-    icon: 'spell_frost_icefloes',
-    maxRanks: 2,
-  },
-  REDUPLICATION_TALENT: {
-    id: 382569,
-    name: 'Reduplication',
-    icon: 'spell_magic_lesserinvisibilty',
-    maxRanks: 1,
-  },
-  REABSORPTION_TALENT: {
-    id: 382820,
-    name: 'Reabsorption',
-    icon: 'spell_arcane_studentofmagic',
-    maxRanks: 1,
-  },
-  GROUNDING_SURGE_TALENT: {
-    id: 382297,
-    name: 'Grounding Surge',
-    icon: 'ability_priest_surgeofdarkness',
-    maxRanks: 1,
-  },
-  MASS_POLYMORPH_TALENT: {
-    id: 383121,
-    name: 'Mass Polymorph',
-    icon: 'spell_nature_doublepolymorph1',
-    maxRanks: 1,
-    manaCost: 2000,
-  },
-  SLOW_TALENT: { id: 31589, name: 'Slow', icon: 'spell_nature_slow', maxRanks: 1, manaCost: 500 },
-  MASTER_OF_TIME_TALENT: {
-    id: 342249,
-    name: 'Master of Time',
-    icon: 'inv_belt_armor_waistoftime_d_01',
-    maxRanks: 1,
-  },
-  DIVERTED_ENERGY_TALENT: {
-    id: 382270,
-    name: 'Diverted Energy',
-    icon: 'inv_soulbarrier',
-    maxRanks: 2,
-  },
-  RING_OF_FROST_TALENT: {
-    id: 113724,
-    name: 'Ring of Frost',
-    icon: 'spell_frost_ring_of_frost',
-    maxRanks: 1,
-    manaCost: 4000,
-  },
-  ICE_NOVA_TALENT: { id: 157997, name: 'Ice Nova', icon: 'spell_mage_icenova', maxRanks: 1 },
-  SHIMMER_TALENT: {
-    id: 212653,
-    name: 'Shimmer',
-    icon: 'spell_arcane_massdispel',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  ICE_FLOES_TALENT: { id: 108839, name: 'Ice Floes', icon: 'spell_mage_iceflows', maxRanks: 1 },
-  SLOOOOW_DOWN_TALENT: {
-    id: 391102,
-    name: 'Sloooow Down',
-    icon: 'inv_enchant_essencearcanelarge',
-    maxRanks: 1,
-  },
-  BLAST_WAVE_TALENT: {
-    id: 157981,
-    name: 'Blast Wave',
-    icon: 'spell_holy_excorcism_02',
-    maxRanks: 1,
-  },
-  IMPROVED_FROST_NOVA_TALENT: {
-    id: 343183,
-    name: 'Improved Frost Nova',
-    icon: 'spell_frost_frostnova',
-    maxRanks: 1,
-  },
-  RIGID_ICE_TALENT: { id: 382481, name: 'Rigid Ice', icon: 'spell_frost_frostnova', maxRanks: 1 },
-  TOME_OF_RHONIN_TALENT: {
-    id: 382493,
-    name: 'Tome of Rhonin',
-    icon: 'spell_chargepositive',
-    maxRanks: 1,
-  },
-  TOME_OF_ANTONIDAS_TALENT: {
-    id: 382490,
-    name: 'Tome of Antonidas',
-    icon: 'spell_chargepositive',
-    maxRanks: 1,
-  },
-  VOLATILE_DETONATION_TALENT: {
-    id: 389627,
-    name: 'Volatile Detonation',
-    icon: 'spell_fire_burnout',
-    maxRanks: 1,
-  },
-  ENERGIZED_BARRIERS_TALENT: {
-    id: 386828,
-    name: 'Energized Barriers',
-    icon: 'spell_mage_temporalshield',
-    maxRanks: 1,
-  },
-  FRIGID_WINDS_TALENT: {
-    id: 235224,
-    name: 'Frigid Winds',
-    icon: 'ability_mage_deepfreeze',
-    maxRanks: 2,
-  },
-  FLOW_OF_TIME_TALENT: {
-    id: 382268,
-    name: 'Flow of Time',
-    icon: 'spell_arcane_blink',
-    maxRanks: 2,
-  },
-  TEMPORAL_VELOCITY_TALENT: {
-    id: 382826,
-    name: 'Temporal Velocity',
-    icon: 'ability_socererking_arcaneacceleration',
-    maxRanks: 2,
-  },
-  ICE_WARD_TALENT: { id: 205036, name: 'Ice Ward', icon: 'spell_frost_frostward', maxRanks: 1 },
-  TIME_MANIPULATION_TALENT: {
-    id: 387807,
-    name: 'Time Manipulation',
-    icon: 'spell_nature_timestop',
-    maxRanks: 2,
-  },
-  GREATER_INVISIBILITY_TALENT: {
-    id: 110959,
-    name: 'Greater Invisibility',
-    icon: 'ability_mage_greaterinvisibility',
-    maxRanks: 1,
-  },
-  ACCUMULATIVE_SHIELDING_TALENT: {
-    id: 382800,
-    name: 'Accumulative Shielding',
-    icon: 'ability_mage_shattershield',
-    maxRanks: 2,
-  },
-  DRAGONS_BREATH_TALENT: {
-    id: 31661,
-    name: "Dragon's Breath",
-    icon: 'inv_misc_head_dragon_01',
-    maxRanks: 1,
-    manaCost: 2000,
-  },
-  SHIFTING_POWER_TALENT: {
-    id: 382440,
-    name: 'Shifting Power',
-    icon: 'ability_ardenweald_mage',
-    maxRanks: 1,
-    manaCost: 2500,
-  },
-  FREEZING_COLD_TALENT: {
-    id: 386763,
-    name: 'Freezing Cold',
-    icon: 'spell_frost_glacier',
-    maxRanks: 1,
-  },
-  TIME_ANOMALY_TALENT: {
-    id: 383243,
-    name: 'Time Anomaly',
-    icon: 'ability_mage_timewarp',
-    maxRanks: 1,
-  },
-  TEMPORAL_WARP_TALENT: {
-    id: 386539,
-    name: 'Temporal Warp',
-    icon: 'ability_bossmagistrix_timewarp2',
-    maxRanks: 1,
-  },
-  REFLECTION_TALENT: {
-    id: 389713,
-    name: 'Reflection',
-    icon: 'ability_hunter_displacement',
-    maxRanks: 1,
-  },
-  METEOR_TALENT: {
-    id: 153561,
-    name: 'Meteor',
-    icon: 'spell_mage_meteor',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  ICE_BARRIER_TALENT: {
-    id: 11426,
-    name: 'Ice Barrier',
-    icon: 'spell_ice_lament',
-    maxRanks: 1,
-    manaCost: 1500,
-  },
-  PRISMATIC_BARRIER_TALENT: {
-    id: 235450,
-    name: 'Prismatic Barrier',
-    icon: 'spell_magearmor',
-    maxRanks: 1,
-    manaCost: 1500,
-  },
+  BLAZING_BARRIER_TALENT,
+  ICE_BLOCK_TALENT,
+  OVERFLOWING_ENERGY_NYI_TALENT,
+  INVISIBILITY_TALENT,
+  WINTERS_PROTECTION_TALENT,
+  SPELLSTEAL_TALENT,
+  TEMPEST_BARRIER_TALENT,
+  INCANTATION_OF_SWIFTNESS_TALENT,
+  REMOVE_CURSE_TALENT,
+  ARCANE_WARDING_TALENT,
+  MIRROR_IMAGE_TALENT,
+  INCANTERS_FLOW_TALENT,
+  RUNE_OF_POWER_TALENT,
+  ALTER_TIME_TALENT,
+  CRYO_FREEZE_TALENT,
+  REDUPLICATION_TALENT,
+  REABSORPTION_TALENT,
+  GROUNDING_SURGE_TALENT,
+  MASS_POLYMORPH_TALENT,
+  SLOW_TALENT,
+  MASTER_OF_TIME_TALENT,
+  DIVERTED_ENERGY_TALENT,
+  RING_OF_FROST_TALENT,
+  ICE_NOVA_TALENT,
+  SHIMMER_TALENT,
+  ICE_FLOES_TALENT,
+  SLOOOOW_DOWN_TALENT,
+  BLAST_WAVE_TALENT,
+  IMPROVED_FROST_NOVA_TALENT,
+  RIGID_ICE_TALENT,
+  TOME_OF_RHONIN_TALENT,
+  TOME_OF_ANTONIDAS_TALENT,
+  VOLATILE_DETONATION_TALENT,
+  ENERGIZED_BARRIERS_TALENT,
+  FRIGID_WINDS_TALENT,
+  FLOW_OF_TIME_TALENT,
+  TEMPORAL_VELOCITY_TALENT,
+  ICE_WARD_TALENT,
+  TIME_MANIPULATION_TALENT,
+  GREATER_INVISIBILITY_TALENT,
+  ACCUMULATIVE_SHIELDING_TALENT,
+  DRAGONS_BREATH_TALENT,
+  SHIFTING_POWER_TALENT,
+  FREEZING_COLD_TALENT,
+  TIME_ANOMALY_TALENT,
+  TEMPORAL_WARP_TALENT,
+  REFLECTION_TALENT,
+  METEOR_TALENT,
+  ICE_BARRIER_TALENT,
+  PRISMATIC_BARRIER_TALENT,
 
   //Fire
-  PYROBLAST_FIRE_TALENT: {
-    id: 11366,
-    name: 'Pyroblast',
-    icon: 'spell_fire_fireball02',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  FIRE_BLAST_FIRE_TALENT: {
-    id: 108853,
-    name: 'Fire Blast',
-    icon: 'spell_fire_fireball',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  FLAMESTRIKE_FIRE_TALENT: {
-    id: 2120,
-    name: 'Flamestrike',
-    icon: 'spell_fire_selfdestruct',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  SCORCH_FIRE_TALENT: {
-    id: 2948,
-    name: 'Scorch',
-    icon: 'spell_fire_soulburn',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  PHOENIX_FLAMES_FIRE_TALENT: {
-    id: 343222,
-    name: 'Phoenix Flames',
-    icon: 'artifactability_firemage_phoenixbolt',
-    maxRanks: 1,
-  },
-  FERVENT_FLICKERING_FIRE_TALENT: {
-    id: 387044,
-    name: 'Fervent Flickering',
-    icon: 'ability_warlock_burningembers',
-    maxRanks: 1,
-  },
-  SEARING_TOUCH_FIRE_TALENT: {
-    id: 269644,
-    name: 'Searing Touch',
-    icon: 'ability_warlock_backdraft',
-    maxRanks: 1,
-  },
-  FIRESTARTER_FIRE_TALENT: {
-    id: 205026,
-    name: 'Firestarter',
-    icon: 'spell_fire_fire',
-    maxRanks: 1,
-  },
-  ENHANCED_PYROTECHNICS_FIRE_TALENT: {
-    id: 157642,
-    name: 'Enhanced Pyrotechnics',
-    icon: 'spell_fire_flamebolt',
-    maxRanks: 1,
-  },
-  IMPROVED_FLAMESTRIKE_FIRE_TALENT: {
-    id: 343230,
-    name: 'Improved Flamestrike',
-    icon: 'spell_fire_selfdestruct',
-    maxRanks: 1,
-  },
-  IMPROVED_SCORCH_FIRE_TALENT: {
-    id: 383604,
-    name: 'Improved Scorch',
-    icon: 'ability_mage_fierypayback',
-    maxRanks: 2,
-  },
-  CRITICAL_MASS_FIRE_TALENT: {
-    id: 117216,
-    name: 'Critical Mass',
-    icon: 'ability_mage_firestarter',
-    maxRanks: 2,
-  },
-  CAUTERIZE_FIRE_TALENT: { id: 86949, name: 'Cauterize', icon: 'spell_fire_rune', maxRanks: 1 },
-  FLAME_ON_FIRE_TALENT: {
-    id: 205029,
-    name: 'Flame On',
-    icon: 'inv_helm_circlet_firelands_d_01',
-    maxRanks: 2,
-  },
-  FLAME_PATCH_FIRE_TALENT: {
-    id: 205037,
-    name: 'Flame Patch',
-    icon: 'spell_mage_flameorb',
-    maxRanks: 1,
-  },
-  FROM_THE_ASHES_FIRE_TALENT: {
-    id: 342344,
-    name: 'From the Ashes',
-    icon: 'inv_misc_phoenixegg',
-    maxRanks: 1,
-  },
-  ALEXSTRASZAS_FURY_FIRE_TALENT: {
-    id: 235870,
-    name: "Alexstrasza's Fury",
-    icon: 'spell_warrior_dragoncharge',
-    maxRanks: 1,
-  },
-  COMBUSTION_FIRE_TALENT: {
-    id: 190319,
-    name: 'Combustion',
-    icon: 'spell_fire_sealoffire',
-    maxRanks: 1,
-    manaCost: 5000,
-  },
-  LIVING_BOMB_FIRE_TALENT: {
-    id: 44457,
-    name: 'Living Bomb',
-    icon: 'ability_mage_livingbomb',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  INCENDIARY_ERUPTIONS_FIRE_TALENT: {
-    id: 383665,
-    name: 'Incendiary Eruptions',
-    icon: 'spell_fire_moltenblood',
-    maxRanks: 1,
-  },
-  FIREMIND_FIRE_TALENT: {
-    id: 383499,
-    name: 'Firemind',
-    icon: 'ability_mage_hotstreak',
-    maxRanks: 2,
-  },
-  TEMPERED_FLAMES_FIRE_TALENT: {
-    id: 383659,
-    name: 'Tempered Flames',
-    icon: 'ability_mage_greaterpyroblast',
-    maxRanks: 1,
-  },
-  COMBUSTION_DURATION_FIRE_TALENT: {
-    id: 321710,
-    name: 'Combustion Duration',
-    icon: 'spell_fire_sealoffire',
-    maxRanks: 1,
-  },
-  BLASTER_MASTER_FIRE_TALENT: {
-    id: 383391,
-    name: 'Blaster Master',
-    icon: 'spell_fire_fireball',
-    maxRanks: 2,
-  },
-  CONFLAGRATION_FIRE_TALENT: {
-    id: 205023,
-    name: 'Conflagration',
-    icon: 'spell_shaman_firenova',
-    maxRanks: 1,
-  },
-  PHOENIX_REBORN_FIRE_TALENT: {
-    id: 383476,
-    name: 'Phoenix Reborn',
-    icon: 'inv_sword_1h_artifactfelomelorn_d_01',
-    maxRanks: 1,
-  },
-  TINDER_FIRE_TALENT: { id: 203275, name: 'Tinder', icon: 'inv_ember', maxRanks: 2 },
-  KINDLING_FIRE_TALENT: { id: 155148, name: 'Kindling', icon: 'spell_mage_kindling', maxRanks: 1 },
-  WILDFIRE_FIRE_TALENT: {
-    id: 383489,
-    name: 'Wildfire',
-    icon: 'ability_warlock_inferno',
-    maxRanks: 2,
-  },
-  MASTER_OF_FLAME_FIRE_TALENT: {
-    id: 384174,
-    name: 'Master of Flame',
-    icon: 'inv_trinket_firelands_02',
-    maxRanks: 1,
-  },
-  CONTROLLED_DESTRUCTION_FIRE_TALENT: {
-    id: 383669,
-    name: 'Controlled Destruction',
-    icon: 'spell_fire_playingwithfire',
-    maxRanks: 2,
-  },
-  PYROCLASM_FIRE_TALENT: {
-    id: 269650,
-    name: 'Pyroclasm',
-    icon: 'spell_shaman_lavasurge',
-    maxRanks: 1,
-  },
-  PYROMANIAC_FIRE_TALENT: {
-    id: 205020,
-    name: 'Pyromaniac',
-    icon: 'inv_misc_volatilefire',
-    maxRanks: 1,
-  },
-  MOLTEN_SKYFALL_FIRE_TALENT: {
-    id: 384033,
-    name: 'Molten Skyfall',
-    icon: 'spell_mage_meteor',
-    maxRanks: 1,
-  },
-  FEVERED_INCANTATION_FIRE_TALENT: {
-    id: 383810,
-    name: 'Fevered Incantation',
-    icon: 'inv_misc_enchantedpearld',
-    maxRanks: 2,
-  },
-  SUN_KINGS_BLESSING_FIRE_TALENT: {
-    id: 383886,
-    name: "Sun King's Blessing",
-    icon: 'ability_mage_firestarter',
-    maxRanks: 1,
-  },
-  FIERY_RUSH_FIRE_TALENT: {
-    id: 383634,
-    name: 'Fiery Rush',
-    icon: 'inv_summerfest_firespirit',
-    maxRanks: 1,
-  },
-  FIRE_FRENZY_FIRE_TALENT: {
-    id: 383860,
-    name: 'Fire Frenzy',
-    icon: 'spell_fire_burnout',
-    maxRanks: 1,
-  },
+  PYROBLAST_FIRE_TALENT,
+  FIRE_BLAST_FIRE_TALENT,
+  FLAMESTRIKE_FIRE_TALENT,
+  SCORCH_FIRE_TALENT,
+  PHOENIX_FLAMES_FIRE_TALENT,
+  FERVENT_FLICKERING_FIRE_TALENT,
+  SEARING_TOUCH_FIRE_TALENT,
+  FIRESTARTER_FIRE_TALENT,
+  ENHANCED_PYROTECHNICS_FIRE_TALENT,
+  IMPROVED_FLAMESTRIKE_FIRE_TALENT,
+  IMPROVED_SCORCH_FIRE_TALENT,
+  CRITICAL_MASS_FIRE_TALENT,
+  CAUTERIZE_FIRE_TALENT,
+  FLAME_ON_FIRE_TALENT,
+  FLAME_PATCH_FIRE_TALENT,
+  FROM_THE_ASHES_FIRE_TALENT,
+  ALEXSTRASZAS_FURY_FIRE_TALENT,
+  COMBUSTION_FIRE_TALENT,
+  LIVING_BOMB_FIRE_TALENT,
+  INCENDIARY_ERUPTIONS_FIRE_TALENT,
+  FIREMIND_FIRE_TALENT,
+  TEMPERED_FLAMES_FIRE_TALENT,
+  COMBUSTION_DURATION_FIRE_TALENT,
+  BLASTER_MASTER_FIRE_TALENT,
+  CONFLAGRATION_FIRE_TALENT,
+  PHOENIX_REBORN_FIRE_TALENT,
+  TINDER_FIRE_TALENT,
+  KINDLING_FIRE_TALENT,
+  WILDFIRE_FIRE_TALENT,
+  MASTER_OF_FLAME_FIRE_TALENT,
+  CONTROLLED_DESTRUCTION_FIRE_TALENT,
+  PYROCLASM_FIRE_TALENT,
+  PYROMANIAC_FIRE_TALENT,
+  MOLTEN_SKYFALL_FIRE_TALENT,
+  FEVERED_INCANTATION_FIRE_TALENT,
+  SUN_KINGS_BLESSING_FIRE_TALENT,
+  FIERY_RUSH_FIRE_TALENT,
+  FIRE_FRENZY_FIRE_TALENT,
 
   //Frost
-  ICE_LANCE_FROST_TALENT: {
-    id: 30455,
-    name: 'Ice Lance',
-    icon: 'spell_frost_frostblast',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  FROZEN_ORB_FROST_TALENT: {
-    id: 84714,
-    name: 'Frozen Orb',
-    icon: 'spell_frost_frozenorb',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  BLIZZARD_FROST_TALENT: {
-    id: 190356,
-    name: 'Blizzard',
-    icon: 'spell_frost_icestorm',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  FINGERS_OF_FROST_FROST_TALENT: {
-    id: 112965,
-    name: 'Fingers of Frost',
-    icon: 'ability_mage_wintersgrasp',
-    maxRanks: 1,
-  },
-  FLURRY_FROST_TALENT: {
-    id: 44614,
-    name: 'Flurry',
-    icon: 'ability_warlock_burningembersblue',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  SHATTER_FROST_TALENT: { id: 12982, name: 'Shatter', icon: 'spell_frost_frostshock', maxRanks: 1 },
-  BRAIN_FREEZE_FROST_TALENT: {
-    id: 190447,
-    name: 'Brain Freeze',
-    icon: 'ability_mage_brainfreeze',
-    maxRanks: 1,
-  },
-  COLD_SNAP_FROST_TALENT: {
-    id: 235219,
-    name: 'Cold Snap',
-    icon: 'spell_frost_wizardmark',
-    maxRanks: 1,
-  },
-  FROSTBITE_FROST_TALENT: {
-    id: 378756,
-    name: 'Frostbite',
-    icon: 'spell_frost_frostarmor',
-    maxRanks: 1,
-  },
-  ARCTIC_PIERCING_FROST_TALENT: {
-    id: 378919,
-    name: 'Arctic Piercing',
-    icon: 'spell_frost_frostbolt',
-    maxRanks: 1,
-  },
-  EBONBOLT_FROST_TALENT: {
-    id: 257537,
-    name: 'Ebonbolt',
-    icon: 'artifactability_frostmage_ebonbolt',
-    maxRanks: 1,
-  },
-  FROZEN_TOUCH_FROST_TALENT: {
-    id: 205030,
-    name: 'Frozen Touch',
-    icon: 'ability_mage_burstofcold',
-    maxRanks: 1,
-  },
-  LONELY_WINTER_FROST_TALENT: {
-    id: 205024,
-    name: 'Lonely Winter',
-    icon: 'achievement_dungeon_frozenthrone',
-    maxRanks: 1,
-  },
-  SUMMON_WATER_ELEMENTAL_FROST_TALENT: {
-    id: 31687,
-    name: 'Summon Water Elemental',
-    icon: 'spell_frost_summonwaterelemental_2',
-    maxRanks: 1,
-    manaCost: 1500,
-  },
-  IMPROVED_BLIZZARD_FROST_TALENT: {
-    id: 236662,
-    name: 'Improved Blizzard',
-    icon: 'spell_frost_icestorm',
-    maxRanks: 1,
-  },
-  EVERLASTING_FROST_FROST_TALENT: {
-    id: 385167,
-    name: 'Everlasting Frost',
-    icon: 'spell_frost_chillingbolt',
-    maxRanks: 1,
-  },
-  BONE_CHILLING_FROST_TALENT: {
-    id: 205027,
-    name: 'Bone Chilling',
-    icon: 'ability_mage_chilledtothebone',
-    maxRanks: 1,
-  },
-  DEEP_SHATTER_FROST_TALENT: {
-    id: 378749,
-    name: 'Deep Shatter',
-    icon: 'inv_misc_frostemblem_01',
-    maxRanks: 2,
-  },
-  PERPETUAL_WINTER_FROST_TALENT: {
-    id: 378198,
-    name: 'Perpetual Winter',
-    icon: 'ability_warlock_burningembersblue',
-    maxRanks: 1,
-  },
-  WINTERTIDE_FROST_TALENT: {
-    id: 378406,
-    name: 'Wintertide',
-    icon: 'ability_mage_burstofcold',
-    maxRanks: 2,
-  },
-  SNOWSTORM_FROST_TALENT: {
-    id: 381706,
-    name: 'Snowstorm',
-    icon: 'spell_fire_bluerainoffire',
-    maxRanks: 2,
-  },
-  FLASH_FREEZE_FROST_TALENT: {
-    id: 379993,
-    name: 'Flash Freeze',
-    icon: 'ability_mage_coldasice',
-    maxRanks: 1,
-  },
-  FRIGID_SHATTERING_FROST_TALENT: {
-    id: 380154,
-    name: 'Frigid Shattering',
-    icon: 'spell_ice_magicdamage',
-    maxRanks: 2,
-  },
-  GLACIAL_ASSAULT_FROST_TALENT: {
-    id: 378947,
-    name: 'Glacial Assault',
-    icon: 'spell_mage_cometstorm2',
-    maxRanks: 2,
-  },
-  ICY_VEINS_FROST_TALENT: {
-    id: 12472,
-    name: 'Icy Veins',
-    icon: 'spell_frost_coldhearted',
-    maxRanks: 1,
-  },
-  ICE_NINE_FROST_TALENT: {
-    id: 379049,
-    name: 'Ice Nine',
-    icon: 'spell_frost_iceshard',
-    maxRanks: 2,
-  },
-  COMET_STORM_FROST_TALENT: {
-    id: 153595,
-    name: 'Comet Storm',
-    icon: 'spell_mage_cometstorm2',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  FREEZING_RAIN_FROST_TALENT: {
-    id: 270233,
-    name: 'Freezing Rain',
-    icon: 'spell_frost_frozenorb',
-    maxRanks: 1,
-  },
-  ICY_PROPULSION_FROST_TALENT: {
-    id: 378433,
-    name: 'Icy Propulsion',
-    icon: 'spell_frost_coldhearted',
-    maxRanks: 1,
-  },
-  RAY_OF_FROST_FROST_TALENT: {
-    id: 205021,
-    name: 'Ray of Frost',
-    icon: 'ability_mage_rayoffrost',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  SPLITTING_ICE_FROST_TALENT: {
-    id: 56377,
-    name: 'Splitting Ice',
-    icon: 'spell_frost_ice_shards',
-    maxRanks: 1,
-  },
-  FRACTURED_FROST_FROST_TALENT: {
-    id: 378448,
-    name: 'Fractured Frost',
-    icon: 'spell_fire_frostresistancetotem',
-    maxRanks: 2,
-  },
-  SNAP_FREEZE_FROST_TALENT: {
-    id: 378901,
-    name: 'Snap Freeze',
-    icon: 'spell_frost_coldhearted',
-    maxRanks: 1,
-  },
-  IMPROVED_ICY_VEINS_FROST_TALENT: {
-    id: 321702,
-    name: 'Improved Icy Veins',
-    icon: 'spell_frost_coldhearted',
-    maxRanks: 2,
-  },
-  CHAIN_REACTION_FROST_TALENT: {
-    id: 278309,
-    name: 'Chain Reaction',
-    icon: 'spell_frost_frostblast',
-    maxRanks: 1,
-  },
-  HAILSTONES_FROST_TALENT: {
-    id: 381244,
-    name: 'Hailstones',
-    icon: 'artifactability_frostmage_blackicicles',
-    maxRanks: 2,
-  },
-  COLD_FRONT_FROST_TALENT: {
-    id: 382110,
-    name: 'Cold Front',
-    icon: 'ability_mage_coldasice',
-    maxRanks: 1,
-  },
-  FREEZING_WINDS_FROST_TALENT: {
-    id: 382103,
-    name: 'Freezing Winds',
-    icon: 'spell_shadow_soulleech_2',
-    maxRanks: 1,
-  },
-  SLICK_ICE_FROST_TALENT: {
-    id: 382144,
-    name: 'Slick Ice',
-    icon: 'inv_enchant_shardshadowfrostlarge',
-    maxRanks: 1,
-  },
-  THERMAL_VOID_FROST_TALENT: {
-    id: 155149,
-    name: 'Thermal Void',
-    icon: 'spell_mage_thermalvoid',
-    maxRanks: 1,
-  },
-  GLACIAL_SPIKE_FROST_TALENT: {
-    id: 199786,
-    name: 'Glacial Spike',
-    icon: 'ability_mage_glacialspike',
-    maxRanks: 1,
-    manaCost: 500,
-  },
+  ICE_LANCE_FROST_TALENT,
+  FROZEN_ORB_FROST_TALENT,
+  BLIZZARD_FROST_TALENT,
+  FINGERS_OF_FROST_FROST_TALENT,
+  FLURRY_FROST_TALENT,
+  SHATTER_FROST_TALENT,
+  BRAIN_FREEZE_FROST_TALENT,
+  COLD_SNAP_FROST_TALENT,
+  FROSTBITE_FROST_TALENT,
+  ARCTIC_PIERCING_FROST_TALENT,
+  EBONBOLT_FROST_TALENT,
+  FROZEN_TOUCH_FROST_TALENT,
+  LONELY_WINTER_FROST_TALENT,
+  SUMMON_WATER_ELEMENTAL_FROST_TALENT,
+  IMPROVED_BLIZZARD_FROST_TALENT,
+  EVERLASTING_FROST_FROST_TALENT,
+  BONE_CHILLING_FROST_TALENT,
+  DEEP_SHATTER_FROST_TALENT,
+  PERPETUAL_WINTER_FROST_TALENT,
+  WINTERTIDE_FROST_TALENT,
+  SNOWSTORM_FROST_TALENT,
+  FLASH_FREEZE_FROST_TALENT,
+  FRIGID_SHATTERING_FROST_TALENT,
+  GLACIAL_ASSAULT_FROST_TALENT,
+  ICY_VEINS_FROST_TALENT,
+  ICE_NINE_FROST_TALENT,
+  COMET_STORM_FROST_TALENT,
+  FREEZING_RAIN_FROST_TALENT,
+  ICY_PROPULSION_FROST_TALENT,
+  RAY_OF_FROST_FROST_TALENT,
+  SPLITTING_ICE_FROST_TALENT,
+  FRACTURED_FROST_FROST_TALENT,
+  SNAP_FREEZE_FROST_TALENT,
+  IMPROVED_ICY_VEINS_FROST_TALENT,
+  CHAIN_REACTION_FROST_TALENT,
+  HAILSTONES_FROST_TALENT,
+  COLD_FRONT_FROST_TALENT,
+  FREEZING_WINDS_FROST_TALENT,
+  SLICK_ICE_FROST_TALENT,
+  THERMAL_VOID_FROST_TALENT,
+  GLACIAL_SPIKE_FROST_TALENT,
 
   //Arcane
-  ARCANE_BARRAGE_ARCANE_TALENT: {
-    id: 44425,
-    name: 'Arcane Barrage',
-    icon: 'ability_mage_arcanebarrage',
-    maxRanks: 1,
-  },
-  ARCANE_MISSILES_ARCANE_TALENT: {
-    id: 5143,
-    name: 'Arcane Missiles',
-    icon: 'spell_nature_starfall',
-    maxRanks: 1,
-    manaCost: 7500,
-  },
-  ARCANE_ORB_ARCANE_TALENT: {
-    id: 153626,
-    name: 'Arcane Orb',
-    icon: 'spell_mage_arcaneorb',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  CLEARCASTING_ARCANE_TALENT: {
-    id: 79684,
-    name: 'Clearcasting',
-    icon: 'spell_shadow_manaburn',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  ARCANE_TEMPO_ARCANE_TALENT: {
-    id: 383980,
-    name: 'Arcane Tempo',
-    icon: 'ability_socererking_arcaneacceleration',
-    maxRanks: 1,
-  },
-  IMPROVED_ARCANE_MISSILES_ARCANE_TALENT: {
-    id: 383661,
-    name: 'Improved Arcane Missiles',
-    icon: 'spell_nature_starfall',
-    maxRanks: 2,
-  },
-  ARCANE_SURGE_ARCANE_TALENT: {
-    id: 365350,
-    name: 'Arcane Surge',
-    icon: 'ability_mage_arcanesurge',
-    maxRanks: 1,
-    manaCost: 1,
-  },
-  IMPROVED_ARCANE_EXPLOSION_ARCANE_TALENT: {
-    id: 321752,
-    name: 'Improved Arcane Explosion',
-    icon: 'spell_nature_wispsplode',
-    maxRanks: 2,
-  },
-  IMPETUS_ARCANE_TALENT: {
-    id: 383676,
-    name: 'Impetus',
-    icon: 'spell_arcane_arcanetorrent',
-    maxRanks: 1,
-  },
-  ARCANE_FAMILIAR_ARCANE_TALENT: {
-    id: 205022,
-    name: 'Arcane Familiar',
-    icon: 'ability_socererking_arcanemines',
-    maxRanks: 1,
-  },
-  RULE_OF_THREES_ARCANE_TALENT: {
-    id: 264354,
-    name: 'Rule of Threes',
-    icon: 'spell_arcane_starfire',
-    maxRanks: 1,
-  },
-  CHARGED_ORB_ARCANE_TALENT: {
-    id: 384651,
-    name: 'Charged Orb',
-    icon: 'spell_mage_arcaneorb',
-    maxRanks: 1,
-  },
-  IMPROVED_ARCANE_BARRAGE_ARCANE_TALENT: {
-    id: 231564,
-    name: 'Improved Arcane Barrage',
-    icon: 'ability_mage_arcanebarrage',
-    maxRanks: 1,
-  },
-  ARCANE_POWER_ARCANE_TALENT: {
-    id: 321739,
-    name: 'Arcane Power',
-    icon: 'spell_nature_lightning',
-    maxRanks: 1,
-  },
-  MANA_ADEPT_ARCANE_TALENT: {
-    id: 321526,
-    name: 'Mana Adept',
-    icon: 'ability_mage_arcanebarrage',
-    maxRanks: 1,
-  },
-  NETHER_PRECISION_ARCANE_TALENT: {
-    id: 383782,
-    name: 'Nether Precision',
-    icon: 'spell_arcane_blast_nightborne',
-    maxRanks: 1,
-  },
-  AMPLIFICATION_ARCANE_TALENT: {
-    id: 236628,
-    name: 'Amplification',
-    icon: 'spell_arcane_invocation',
-    maxRanks: 1,
-  },
-  PRESENCE_OF_MIND_ARCANE_TALENT: {
-    id: 205025,
-    name: 'Presence of Mind',
-    icon: 'spell_nature_enchantarmor',
-    maxRanks: 1,
-  },
-  FORESIGHT_ARCANE_TALENT: {
-    id: 384861,
-    name: 'Foresight',
-    icon: 'spell_mage_presenceofmind',
-    maxRanks: 1,
-  },
-  RESONANCE_ARCANE_TALENT: {
-    id: 205028,
-    name: 'Resonance',
-    icon: 'spell_arcane_arcane01',
-    maxRanks: 1,
-  },
-  NETHER_TEMPEST_ARCANE_TALENT: {
-    id: 114923,
-    name: 'Nether Tempest',
-    icon: 'spell_mage_nethertempest',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  REVERBERATE_ARCANE_TALENT: {
-    id: 281482,
-    name: 'Reverberate',
-    icon: 'spell_arcane_arcane04',
-    maxRanks: 1,
-  },
-  IMPROVED_PRISMATIC_BARRIER_ARCANE_TALENT: {
-    id: 321745,
-    name: 'Improved Prismatic Barrier',
-    icon: 'spell_magearmor',
-    maxRanks: 1,
-  },
-  SLIPSTREAM_ARCANE_TALENT: {
-    id: 236457,
-    name: 'Slipstream',
-    icon: 'spell_holy_mindsooth',
-    maxRanks: 1,
-  },
-  IMPROVED_CLEARCASTING_ARCANE_TALENT: {
-    id: 321420,
-    name: 'Improved Clearcasting',
-    icon: 'spell_shadow_manaburn',
-    maxRanks: 1,
-  },
-  CHRONO_SHIFT_ARCANE_TALENT: {
-    id: 235711,
-    name: 'Chrono Shift',
-    icon: 'ability_monk_deadlyreach',
-    maxRanks: 1,
-  },
-  TOUCH_OF_THE_MAGI_ARCANE_TALENT: {
-    id: 321507,
-    name: 'Touch of the Magi',
-    icon: 'spell_mage_icenova',
-    maxRanks: 1,
-    manaCost: 2500,
-  },
-  SUPERNOVA_ARCANE_TALENT: {
-    id: 157980,
-    name: 'Supernova',
-    icon: 'spell_mage_supernova',
-    maxRanks: 1,
-  },
-  EVOCATION_ARCANE_TALENT: {
-    id: 12051,
-    name: 'Evocation',
-    icon: 'spell_nature_purge',
-    maxRanks: 1,
-  },
-  ENLIGHTENED_ARCANE_TALENT: {
-    id: 321387,
-    name: 'Enlightened',
-    icon: 'ability_socererking_arcanefortification',
-    maxRanks: 1,
-  },
-  ARCANE_ECHO_ARCANE_TALENT: {
-    id: 342231,
-    name: 'Arcane Echo',
-    icon: 'ability_socererking_arcanewrath',
-    maxRanks: 1,
-  },
-  ARCANE_BOMBARDMENT_ARCANE_TALENT: {
-    id: 384581,
-    name: 'Arcane Bombardment',
-    icon: 'ability_socererking_arcanereplication',
-    maxRanks: 1,
-  },
-  ILLUMINATED_THOUGHTS_ARCANE_TALENT: {
-    id: 384060,
-    name: 'Illuminated Thoughts',
-    icon: 'spell_arcane_focusedpower',
-    maxRanks: 2,
-  },
-  CONJURE_MANA_GEM_ARCANE_TALENT: {
-    id: 759,
-    name: 'Conjure Mana Gem',
-    icon: 'inv_misc_gem_sapphire_02',
-    maxRanks: 1,
-    manaCost: 9000,
-  },
-  SIPHON_STORM_ARCANE_TALENT: {
-    id: 384187,
-    name: 'Siphon Storm',
-    icon: 'ability_monk_forcesphere_arcane',
-    maxRanks: 1,
-  },
-  PRODIGIOUS_SAVANT_ARCANE_TALENT: {
-    id: 384612,
-    name: 'Prodigious Savant',
-    icon: 'ability_mage_studentofthemind',
-    maxRanks: 2,
-  },
-  RADIANT_SPARK_ARCANE_TALENT: {
-    id: 376103,
-    name: 'Radiant Spark',
-    icon: 'ability_bastion_mage',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  CONCENTRATION_ARCANE_TALENT: {
-    id: 384374,
-    name: 'Concentration',
-    icon: 'ability_mage_potentspirit',
-    maxRanks: 1,
-  },
-  CASCADING_POWER_ARCANE_TALENT: {
-    id: 384276,
-    name: 'Cascading Power',
-    icon: 'inv_misc_gem_sapphire_02',
-    maxRanks: 1,
-  },
-  ORB_BARRAGE_ARCANE_TALENT: {
-    id: 384858,
-    name: 'Orb Barrage',
-    icon: 'spell_mage_arcaneorb_nightborne',
-    maxRanks: 1,
-  },
-  HARMONIC_ECHO_ARCANE_TALENT: {
-    id: 384683,
-    name: 'Harmonic Echo',
-    icon: 'ability_bastion_mage',
-    maxRanks: 1,
-  },
-  ARCANE_HARMONY_ARCANE_TALENT: {
-    id: 384452,
-    name: 'Arcane Harmony',
-    icon: 'ability_creature_cursed_04',
-    maxRanks: 1,
-  },
+  ARCANE_BARRAGE_ARCANE_TALENT,
+  ARCANE_MISSILES_ARCANE_TALENT,
+  ARCANE_ORB_ARCANE_TALENT,
+  CLEARCASTING_ARCANE_TALENT,
+  ARCANE_TEMPO_ARCANE_TALENT,
+  IMPROVED_ARCANE_MISSILES_ARCANE_TALENT,
+  ARCANE_SURGE_ARCANE_TALENT,
+  IMPROVED_ARCANE_EXPLOSION_ARCANE_TALENT,
+  IMPETUS_ARCANE_TALENT,
+  ARCANE_FAMILIAR_ARCANE_TALENT,
+  RULE_OF_THREES_ARCANE_TALENT,
+  CHARGED_ORB_ARCANE_TALENT,
+  IMPROVED_ARCANE_BARRAGE_ARCANE_TALENT,
+  ARCANE_POWER_ARCANE_TALENT,
+  MANA_ADEPT_ARCANE_TALENT,
+  NETHER_PRECISION_ARCANE_TALENT,
+  AMPLIFICATION_ARCANE_TALENT,
+  PRESENCE_OF_MIND_ARCANE_TALENT,
+  FORESIGHT_ARCANE_TALENT,
+  RESONANCE_ARCANE_TALENT,
+  NETHER_TEMPEST_ARCANE_TALENT,
+  REVERBERATE_ARCANE_TALENT,
+  IMPROVED_PRISMATIC_BARRIER_ARCANE_TALENT,
+  SLIPSTREAM_ARCANE_TALENT,
+  IMPROVED_CLEARCASTING_ARCANE_TALENT,
+  CHRONO_SHIFT_ARCANE_TALENT,
+  TOUCH_OF_THE_MAGI_ARCANE_TALENT,
+  SUPERNOVA_ARCANE_TALENT,
+  EVOCATION_ARCANE_TALENT,
+  ENLIGHTENED_ARCANE_TALENT,
+  ARCANE_ECHO_ARCANE_TALENT,
+  ARCANE_BOMBARDMENT_ARCANE_TALENT,
+  ILLUMINATED_THOUGHTS_ARCANE_TALENT,
+  CONJURE_MANA_GEM_ARCANE_TALENT,
+  SIPHON_STORM_ARCANE_TALENT,
+  PRODIGIOUS_SAVANT_ARCANE_TALENT,
+  RADIANT_SPARK_ARCANE_TALENT,
+  CONCENTRATION_ARCANE_TALENT,
+  CASCADING_POWER_ARCANE_TALENT,
+  ORB_BARRAGE_ARCANE_TALENT,
+  HARMONIC_ECHO_ARCANE_TALENT,
+  ARCANE_HARMONY_ARCANE_TALENT,
 });
 
 export default talents;

--- a/src/common/TALENTS/monk.ts
+++ b/src/common/TALENTS/monk.ts
@@ -1,1142 +1,1383 @@
 // Generated file, changes will eventually be overwritten!
-import { createTalentList } from './types';
+import { createTalentList, Talent } from './types';
+
+//region Shared
+export const SOOTHING_MIST_TALENT: Talent = {
+  id: 115175,
+  name: 'Soothing Mist',
+  icon: 'ability_monk_soothingmists',
+  maxRanks: 1,
+  manaCost: 0,
+};
+export const RISING_SUN_KICK_TALENT: Talent = {
+  id: 107428,
+  name: 'Rising Sun Kick',
+  icon: 'ability_monk_risingsunkick',
+  maxRanks: 1,
+  chiCost: 2,
+};
+export const TIGERS_LUST_TALENT: Talent = {
+  id: 116841,
+  name: "Tiger's Lust",
+  icon: 'ability_monk_tigerslust',
+  maxRanks: 1,
+};
+export const ROLL_TALENT: Talent = {
+  id: 109132,
+  name: 'Roll',
+  icon: 'ability_monk_roll',
+  maxRanks: 1,
+};
+export const CALMING_PRESENCE_TALENT: Talent = {
+  id: 388664,
+  name: 'Calming Presence',
+  icon: 'inv_misc_orb_01',
+  maxRanks: 1,
+};
+export const PARALYSIS_TALENT: Talent = {
+  id: 344359,
+  name: 'Paralysis',
+  icon: 'ability_monk_paralysis',
+  maxRanks: 1,
+};
+export const TIGER_TAIL_SWEEP_TALENT: Talent = {
+  id: 264348,
+  name: 'Tiger Tail Sweep',
+  icon: 'ability_monk_legsweep',
+  maxRanks: 2,
+};
+export const HEAVY_AIR_TALENT: Talent = {
+  id: 388671,
+  name: 'Heavy Air',
+  icon: 'spell_lightning_lightningbolt01',
+  maxRanks: 1,
+};
+export const VIVIFY_TALENT: Talent = {
+  id: 231602,
+  name: 'Vivify',
+  icon: 'ability_monk_vivify',
+  maxRanks: 2,
+};
+export const DETOX_TALENT: Talent = {
+  id: 218164,
+  name: 'Detox',
+  icon: 'ability_rogue_imrovedrecuperate',
+  maxRanks: 1,
+  energyCost: 20,
+};
+export const DISABLE_TALENT: Talent = {
+  id: 116095,
+  name: 'Disable',
+  icon: 'ability_shockwave',
+  maxRanks: 1,
+  energyCost: 15,
+};
+export const GRACE_OF_THE_CRANE_TALENT: Talent = {
+  id: 388811,
+  name: 'Grace of the Crane',
+  icon: 'monk_ability_cherrymanatea',
+  maxRanks: 2,
+};
+export const VIVACIOUS_VIVIFICATION_TALENT: Talent = {
+  id: 388812,
+  name: 'Vivacious Vivification',
+  icon: 'ability_monk_vivify',
+  maxRanks: 1,
+};
+export const FEROCITY_OF_XUEN_TALENT: Talent = {
+  id: 388674,
+  name: 'Ferocity of Xuen',
+  icon: 'ability_mount_pinktiger',
+  maxRanks: 2,
+};
+export const ELUSIVE_MISTS_TALENT: Talent = {
+  id: 115175,
+  name: 'Elusive Mists',
+  icon: 'ability_monk_soothingmists',
+  maxRanks: 2,
+  manaCost: 0,
+};
+export const TRANSCENDENCE_TALENT: Talent = {
+  id: 101643,
+  name: 'Transcendence',
+  icon: 'monk_ability_transcendence',
+  maxRanks: 1,
+};
+export const SPEAR_HAND_STRIKE_TALENT: Talent = {
+  id: 116705,
+  name: 'Spear Hand Strike',
+  icon: 'ability_monk_spearhand',
+  maxRanks: 1,
+};
+export const FORTIFYING_BREW_TALENT: Talent = {
+  id: 388813,
+  name: 'Fortifying Brew',
+  icon: 'ability_monk_fortifyingale_new',
+  maxRanks: 1,
+};
+export const CHI_WAVE_TALENT: Talent = {
+  id: 115098,
+  name: 'Chi Wave',
+  icon: 'ability_monk_chiwave',
+  maxRanks: 1,
+};
+export const CHI_BURST_TALENT: Talent = {
+  id: 123986,
+  name: 'Chi Burst',
+  icon: 'spell_arcane_arcanetorrent',
+  maxRanks: 1,
+};
+export const PROVOKE_TALENT: Talent = {
+  id: 328670,
+  name: 'Provoke',
+  icon: 'ability_monk_provoke',
+  maxRanks: 1,
+};
+export const RING_OF_PEACE_TALENT: Talent = {
+  id: 116844,
+  name: 'Ring of Peace',
+  icon: 'spell_monk_ringofpeace',
+  maxRanks: 1,
+};
+export const FAST_FEET_TALENT: Talent = {
+  id: 388809,
+  name: 'Fast Feet',
+  icon: 'ability_monk_risingsunkick',
+  maxRanks: 2,
+};
+export const CELERITY_TALENT: Talent = {
+  id: 115173,
+  name: 'Celerity',
+  icon: 'ability_monk_quipunch',
+  maxRanks: 1,
+};
+export const CHI_TORPEDO_TALENT: Talent = {
+  id: 115008,
+  name: 'Chi Torpedo',
+  icon: 'ability_monk_quitornado',
+  maxRanks: 1,
+};
+export const ROLL_OUT_TALENT: Talent = {
+  id: 388810,
+  name: 'Roll Out',
+  icon: 'ability_monk_roll',
+  maxRanks: 1,
+};
+export const DIFFUSE_MAGIC_TALENT: Talent = {
+  id: 122783,
+  name: 'Diffuse Magic',
+  icon: 'spell_monk_diffusemagic',
+  maxRanks: 1,
+};
+export const EYE_OF_THE_TIGER_TALENT: Talent = {
+  id: 196607,
+  name: 'Eye of the Tiger',
+  icon: 'ability_druid_primalprecision',
+  maxRanks: 1,
+};
+export const DAMPEN_HARM_TALENT: Talent = {
+  id: 122278,
+  name: 'Dampen Harm',
+  icon: 'ability_monk_dampenharm',
+  maxRanks: 1,
+};
+export const TOUCH_OF_DEATH_TALENT: Talent = {
+  id: 322113,
+  name: 'Touch of Death',
+  icon: 'ability_monk_touchofdeath',
+  maxRanks: 1,
+};
+export const EXPEL_HARM_TALENT: Talent = {
+  id: 322101,
+  name: 'Expel Harm',
+  icon: 'ability_monk_expelharm',
+  maxRanks: 1,
+  energyCost: 15,
+};
+export const CLOSE_TO_HEART_TALENT: Talent = {
+  id: 389574,
+  name: 'Close to Heart',
+  icon: 'inv_offhand_1h_pvppandarias2_c_01',
+  maxRanks: 2,
+};
+export const ESCAPE_FROM_REALITY_TALENT: Talent = {
+  id: 343250,
+  name: 'Escape from Reality',
+  icon: 'monk_ability_transcendence',
+  maxRanks: 2,
+};
+export const WINDWALKING_TALENT: Talent = {
+  id: 157411,
+  name: 'Windwalking',
+  icon: 'monk_stance_whitetiger',
+  maxRanks: 2,
+};
+export const FATAL_TOUCH_TALENT: Talent = {
+  id: 337296,
+  name: 'Fatal Touch',
+  icon: 'ability_monk_touchofdeath',
+  maxRanks: 2,
+};
+export const GENEROUS_POUR_TALENT: Talent = {
+  id: 389575,
+  name: 'Generous Pour',
+  icon: 'inv_misc_food_legion_goocaramel_bottle',
+  maxRanks: 2,
+};
+export const SAVE_THEM_ALL_TALENT: Talent = {
+  id: 389579,
+  name: 'Save Them All',
+  icon: 'inv_weapon_hand_22',
+  maxRanks: 2,
+};
+export const RESONANT_FISTS_TALENT: Talent = {
+  id: 389578,
+  name: 'Resonant Fists',
+  icon: 'inv_weapon_hand_16',
+  maxRanks: 2,
+};
+export const BOUNCE_BACK_TALENT: Talent = {
+  id: 389577,
+  name: 'Bounce Back',
+  icon: 'ability_butcher_heavyhanded',
+  maxRanks: 2,
+};
+export const SUMMON_JADE_SERPENT_STATUE_TALENT: Talent = {
+  id: 115313,
+  name: 'Summon Jade Serpent Statue',
+  icon: 'ability_monk_summonserpentstatue',
+  maxRanks: 1,
+};
+export const SUMMON_WHITE_TIGER_STATUE_TALENT: Talent = {
+  id: 388686,
+  name: 'Summon White Tiger Statue',
+  icon: 'ability_monk_summonwhitetigerstatue',
+  maxRanks: 1,
+};
+export const SUMMON_BLACK_OX_STATUE_TALENT: Talent = {
+  id: 115315,
+  name: 'Summon Black Ox Statue',
+  icon: 'monk_ability_summonoxstatue',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Brewmaster
+export const KEG_SMASH_BREWMASTER_TALENT: Talent = {
+  id: 121253,
+  name: 'Keg Smash',
+  icon: 'achievement_brewery_2',
+  maxRanks: 1,
+  energyCost: 40,
+};
+export const STAGGER_BREWMASTER_TALENT: Talent = {
+  id: 115069,
+  name: 'Stagger',
+  icon: 'monk_stance_drunkenox',
+  maxRanks: 1,
+};
+export const PURIFYING_BREW_BREWMASTER_TALENT: Talent = {
+  id: 343743,
+  name: 'Purifying Brew',
+  icon: 'inv_misc_beer_06',
+  maxRanks: 1,
+};
+export const SHUFFLE_BREWMASTER_TALENT: Talent = {
+  id: 322120,
+  name: 'Shuffle',
+  icon: 'ability_monk_shuffle',
+  maxRanks: 1,
+};
+export const HIT_SCHEME_BREWMASTER_TALENT: Talent = {
+  id: 383695,
+  name: 'Hit Scheme',
+  icon: 'ability_monk_roundhousekick',
+  maxRanks: 1,
+};
+export const GIFT_OF_THE_OX_BREWMASTER_TALENT: Talent = {
+  id: 124502,
+  name: 'Gift of the Ox',
+  icon: 'ability_druid_giftoftheearthmother',
+  maxRanks: 2,
+};
+export const HEALING_ELIXIR_BREWMASTER_TALENT: Talent = {
+  id: 122281,
+  name: 'Healing Elixir',
+  icon: 'ability_monk_jasmineforcetea',
+  maxRanks: 1,
+};
+export const QUICK_SIP_BREWMASTER_TALENT: Talent = {
+  id: 388505,
+  name: 'Quick Sip',
+  icon: 'achievement_faction_brewmaster',
+  maxRanks: 2,
+};
+export const RUSHING_JADE_WIND_BREWMASTER_TALENT: Talent = {
+  id: 116847,
+  name: 'Rushing Jade Wind',
+  icon: 'ability_monk_rushingjadewind',
+  maxRanks: 1,
+  chiCost: 1,
+};
+export const SPECIAL_DELIVERY_BREWMASTER_TALENT: Talent = {
+  id: 196730,
+  name: 'Special Delivery',
+  icon: 'achievement_brewery_2',
+  maxRanks: 1,
+};
+export const CELESTIAL_FLAMES_BREWMASTER_TALENT: Talent = {
+  id: 325177,
+  name: 'Celestial Flames',
+  icon: 'inv_misc_volatilefire',
+  maxRanks: 1,
+};
+export const CELESTIAL_BREW_BREWMASTER_TALENT: Talent = {
+  id: 322510,
+  name: 'Celestial Brew',
+  icon: 'ability_monk_ironskinbrew',
+  maxRanks: 1,
+};
+export const STAGGERING_STRIKES_BREWMASTER_TALENT: Talent = {
+  id: 387625,
+  name: 'Staggering Strikes',
+  icon: 'ability_monk_blackoutstrike',
+  maxRanks: 2,
+};
+export const GRACEFUL_EXIT_BREWMASTER_TALENT: Talent = {
+  id: 387256,
+  name: 'Graceful Exit',
+  icon: 'ability_rogue_sprint_blue',
+  maxRanks: 2,
+};
+export const ZEN_MEDITATION_BREWMASTER_TALENT: Talent = {
+  id: 115176,
+  name: 'Zen Meditation',
+  icon: 'ability_monk_zenmeditation',
+  maxRanks: 1,
+};
+export const CLASH_BREWMASTER_TALENT: Talent = {
+  id: 324312,
+  name: 'Clash',
+  icon: 'ability_monk_clashingoxcharge',
+  maxRanks: 1,
+};
+export const BREATH_OF_FIRE_BREWMASTER_TALENT: Talent = {
+  id: 115181,
+  name: 'Breath of Fire',
+  icon: 'ability_monk_breathoffire',
+  maxRanks: 1,
+};
+export const STRENGTH_OF_SPIRIT_BREWMASTER_TALENT: Talent = {
+  id: 387276,
+  name: 'Strength of Spirit',
+  icon: 'ability_monk_healthsphere',
+  maxRanks: 1,
+};
+export const GAI_PLINS_IMPERIAL_BREW_BREWMASTER_TALENT: Talent = {
+  id: 383700,
+  name: "Gai Plin's Imperial Brew",
+  icon: 'inv_misc_beer_05',
+  maxRanks: 1,
+};
+export const FUNDAMENTAL_OBSERVATION_BREWMASTER_TALENT: Talent = {
+  id: 387035,
+  name: 'Fundamental Observation',
+  icon: 'ability_monk_zenmeditation',
+  maxRanks: 1,
+};
+export const SHADOWBOXING_TREADS_BREWMASTER_TALENT: Talent = {
+  id: 387638,
+  name: 'Shadowboxing Treads',
+  icon: 'ability_monk_roundhousekick',
+  maxRanks: 1,
+};
+export const FLUIDITY_OF_MOTION_BREWMASTER_TALENT: Talent = {
+  id: 387230,
+  name: 'Fluidity of Motion',
+  icon: 'ability_monk_standingkick',
+  maxRanks: 1,
+};
+export const SCALDING_BREW_BREWMASTER_TALENT: Talent = {
+  id: 383698,
+  name: 'Scalding Brew',
+  icon: 'spell_brew_bolt_dark',
+  maxRanks: 1,
+};
+export const SALSALABIMS_STRENGTH_BREWMASTER_TALENT: Talent = {
+  id: 383697,
+  name: "Sal'salabim's Strength",
+  icon: 'ability_warrior_unrelentingassault',
+  maxRanks: 1,
+};
+export const FORTIFYING_BREW_BREWMASTER_TALENT: Talent = {
+  id: 322960,
+  name: 'Fortifying Brew',
+  icon: 'ability_monk_fortifyingale_new',
+  maxRanks: 1,
+};
+export const BLACK_OX_BREW_BREWMASTER_TALENT: Talent = {
+  id: 115399,
+  name: 'Black Ox Brew',
+  icon: 'ability_monk_chibrew',
+  maxRanks: 1,
+};
+export const BOB_AND_WEAVE_BREWMASTER_TALENT: Talent = {
+  id: 280515,
+  name: 'Bob and Weave',
+  icon: 'ability_creature_cursed_04',
+  maxRanks: 1,
+};
+export const INVOKE_NIUZAO_THE_BLACK_OX_BREWMASTER_TALENT: Talent = {
+  id: 322740,
+  name: 'Invoke Niuzao, the Black Ox',
+  icon: 'spell_monk_brewmaster_spec',
+  maxRanks: 1,
+};
+export const LIGHT_BREWING_BREWMASTER_TALENT: Talent = {
+  id: 325093,
+  name: 'Light Brewing',
+  icon: 'spell_brew_wheat',
+  maxRanks: 1,
+};
+export const TRAINING_OF_NIUZAO_BREWMASTER_TALENT: Talent = {
+  id: 383714,
+  name: 'Training of Niuzao',
+  icon: 'monk_stance_drunkenox',
+  maxRanks: 1,
+};
+export const SHOCKING_BLOW_NYI_BREWMASTER_TALENT: Talent = {
+  id: 389982,
+  name: 'Shocking Blow [NYI]',
+  icon: 'spell_shaman_crashlightning',
+  maxRanks: 1,
+};
+export const FACE_PALM_BREWMASTER_TALENT: Talent = {
+  id: 389942,
+  name: 'Face Palm',
+  icon: 'ability_monk_tigerpalm',
+  maxRanks: 1,
+};
+export const DRAGONFIRE_BREW_BREWMASTER_TALENT: Talent = {
+  id: 383994,
+  name: 'Dragonfire Brew',
+  icon: 'spell_fire_burnout',
+  maxRanks: 1,
+};
+export const CHARRED_PASSIONS_BREWMASTER_TALENT: Talent = {
+  id: 386965,
+  name: 'Charred Passions',
+  icon: 'ability_monk_mightyoxkick',
+  maxRanks: 1,
+};
+export const HIGH_TOLERANCE_BREWMASTER_TALENT: Talent = {
+  id: 196737,
+  name: 'High Tolerance',
+  icon: 'monk_ability_avertharm',
+  maxRanks: 2,
+};
+export const WALK_WITH_THE_OX_BREWMASTER_TALENT: Talent = {
+  id: 387219,
+  name: 'Walk with the Ox',
+  icon: 'monk_stance_drunkenox',
+  maxRanks: 2,
+};
+export const ELUSIVE_FOOTWORK_BREWMASTER_TALENT: Talent = {
+  id: 387046,
+  name: 'Elusive Footwork',
+  icon: 'ability_monk_shuffle',
+  maxRanks: 2,
+};
+export const ANVIL__STAVE_BREWMASTER_TALENT: Talent = {
+  id: 386937,
+  name: 'Anvil & Stave',
+  icon: 'ability_monk_elusiveale',
+  maxRanks: 2,
+};
+export const COUNTERSTRIKE_BREWMASTER_TALENT: Talent = {
+  id: 383785,
+  name: 'Counterstrike',
+  icon: 'ability_monk_palmstrike',
+  maxRanks: 1,
+};
+export const BONEDUST_BREW_BREWMASTER_TALENT: Talent = {
+  id: 386276,
+  name: 'Bonedust Brew',
+  icon: 'ability_maldraxxus_monk',
+  maxRanks: 1,
+};
+export const EXPLODING_KEG_BREWMASTER_TALENT: Talent = {
+  id: 325153,
+  name: 'Exploding Keg',
+  icon: 'archaeology_5_0_emptykegofbrewfatherxinwoyin',
+  maxRanks: 1,
+};
+export const BLACKOUT_COMBO_BREWMASTER_TALENT: Talent = {
+  id: 196736,
+  name: 'Blackout Combo',
+  icon: 'ability_monk_blackoutkick',
+  maxRanks: 1,
+};
+export const WEAPONS_OF_ORDER_BREWMASTER_TALENT: Talent = {
+  id: 387184,
+  name: 'Weapons of Order',
+  icon: 'ability_bastion_monk',
+  maxRanks: 1,
+  manaCost: 2500,
+};
+export const BOUNTIFUL_BREW_BREWMASTER_TALENT: Talent = {
+  id: 386949,
+  name: 'Bountiful Brew',
+  icon: 'ability_maldraxxus_monk',
+  maxRanks: 1,
+};
+export const ATTENUATION_BREWMASTER_TALENT: Talent = {
+  id: 386941,
+  name: 'Attenuation',
+  icon: 'spell_animamaldraxxus_nova',
+  maxRanks: 1,
+};
+export const STORMSTOUTS_LAST_KEG_BREWMASTER_TALENT: Talent = {
+  id: 383707,
+  name: "Stormstout's Last Keg",
+  icon: 'achievement_brewery_2',
+  maxRanks: 1,
+};
+export const CALL_TO_ARMS_BREWMASTER_TALENT: Talent = {
+  id: 356684,
+  name: 'Call to Arms',
+  icon: 'ability_bastion_monk',
+  maxRanks: 1,
+};
+export const EFFUSIVE_ANIMA_ACCELERATOR_BREWMASTER_TALENT: Talent = {
+  id: 352188,
+  name: 'Effusive Anima Accelerator',
+  icon: 'inv_offhand_1h_bastion_d_01',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Mistweaver
+export const ENVELOPING_MIST_MISTWEAVER_TALENT: Talent = {
+  id: 124682,
+  name: 'Enveloping Mist',
+  icon: 'spell_monk_envelopingmist',
+  maxRanks: 1,
+  manaCost: 2500,
+};
+export const ESSENCE_FONT_MISTWEAVER_TALENT: Talent = {
+  id: 191837,
+  name: 'Essence Font',
+  icon: 'ability_monk_essencefont',
+  maxRanks: 1,
+  manaCost: 3500,
+};
+export const RENEWING_MIST_MISTWEAVER_TALENT: Talent = {
+  id: 115151,
+  name: 'Renewing Mist',
+  icon: 'ability_monk_renewingmists',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const LIFE_COCOON_MISTWEAVER_TALENT: Talent = {
+  id: 116849,
+  name: 'Life Cocoon',
+  icon: 'ability_monk_chicocoon',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const THUNDER_FOCUS_TEA_MISTWEAVER_TALENT: Talent = {
+  id: 116680,
+  name: 'Thunder Focus Tea',
+  icon: 'ability_monk_thunderfocustea',
+  maxRanks: 1,
+};
+export const INVIGORATING_MISTS_MISTWEAVER_TALENT: Talent = {
+  id: 274586,
+  name: 'Invigorating Mists',
+  icon: 'ability_monk_vivify',
+  maxRanks: 1,
+};
+export const TEACHINGS_OF_THE_MONASTERY_MISTWEAVER_TALENT: Talent = {
+  id: 116645,
+  name: 'Teachings of the Monastery',
+  icon: 'passive_monk_teachingsofmonastery',
+  maxRanks: 1,
+};
+export const REVIVAL_MISTWEAVER_TALENT: Talent = {
+  id: 115310,
+  name: 'Revival',
+  icon: 'spell_monk_revival',
+  maxRanks: 1,
+  manaCost: 2000,
+};
+export const RESTORAL_MISTWEAVER_TALENT: Talent = {
+  id: 388615,
+  name: 'Restoral',
+  icon: 'spell_monk_revival',
+  maxRanks: 1,
+  manaCost: 2000,
+};
+export const SONG_OF_CHI_JI_MISTWEAVER_TALENT: Talent = {
+  id: 198898,
+  name: 'Song of Chi-Ji',
+  icon: 'inv_chaos_orb',
+  maxRanks: 1,
+};
+export const MASTERY_OF_MIST_MISTWEAVER_TALENT: Talent = {
+  id: 281231,
+  name: 'Mastery of Mist',
+  icon: 'ability_monk_renewingmists',
+  maxRanks: 1,
+};
+export const SPIRIT_OF_THE_CRANE_MISTWEAVER_TALENT: Talent = {
+  id: 210802,
+  name: 'Spirit of the Crane',
+  icon: 'monk_stance_redcrane',
+  maxRanks: 1,
+};
+export const MISTS_OF_LIFE_MISTWEAVER_TALENT: Talent = {
+  id: 388548,
+  name: 'Mists of Life',
+  icon: 'ability_monk_chicocoon',
+  maxRanks: 1,
+};
+export const UPLIFTED_SPIRITS_MISTWEAVER_TALENT: Talent = {
+  id: 388551,
+  name: 'Uplifted Spirits',
+  icon: 'spell_monk_revival',
+  maxRanks: 1,
+};
+export const FONT_OF_LIFE_MISTWEAVER_TALENT: Talent = {
+  id: 337209,
+  name: 'Font of Life',
+  icon: 'ability_monk_essencefont',
+  maxRanks: 1,
+};
+export const ZEN_PULSE_MISTWEAVER_TALENT: Talent = {
+  id: 124081,
+  name: 'Zen Pulse',
+  icon: 'ability_monk_forcesphere',
+  maxRanks: 1,
+};
+export const HEALING_ELIXIR_MISTWEAVER_TALENT: Talent = {
+  id: 122281,
+  name: 'Healing Elixir',
+  icon: 'ability_monk_jasmineforcetea',
+  maxRanks: 1,
+};
+export const NOURISHING_CHI_MISTWEAVER_TALENT: Talent = {
+  id: 387765,
+  name: 'Nourishing Chi',
+  icon: 'inv_misc_gem_pearl_06',
+  maxRanks: 1,
+};
+export const PEACEFUL_MENDING_MISTWEAVER_TALENT: Talent = {
+  id: 388593,
+  name: 'Peaceful Mending',
+  icon: 'ability_monk_surgingmist',
+  maxRanks: 2,
+};
+export const INVOKE_YULON_THE_JADE_SERPENT_MISTWEAVER_TALENT: Talent = {
+  id: 322118,
+  name: "Invoke Yu'lon, the Jade Serpent",
+  icon: 'ability_monk_dragonkick',
+  maxRanks: 1,
+  manaCost: 2500,
+};
+export const INVOKE_CHI_JI_THE_RED_CRANE_MISTWEAVER_TALENT: Talent = {
+  id: 325197,
+  name: 'Invoke Chi-Ji, the Red Crane',
+  icon: 'inv_pet_cranegod',
+  maxRanks: 1,
+  manaCost: 2500,
+};
+export const ZEN_REVERBERATION_MISTWEAVER_TALENT: Talent = {
+  id: 388604,
+  name: 'Zen Reverberation',
+  icon: 'spell_monk_nimblebrew',
+  maxRanks: 1,
+};
+export const ACCUMULATING_MIST_MISTWEAVER_TALENT: Talent = {
+  id: 388564,
+  name: 'Accumulating Mist',
+  icon: 'ability_monk_zenmeditation',
+  maxRanks: 1,
+};
+export const RAPID_DIFFUSION_MISTWEAVER_TALENT: Talent = {
+  id: 388847,
+  name: 'Rapid Diffusion',
+  icon: 'ability_monk_chiswirl',
+  maxRanks: 2,
+};
+export const CALMING_COALESCENCE_MISTWEAVER_TALENT: Talent = {
+  id: 388218,
+  name: 'Calming Coalescence',
+  icon: 'ability_monk_healthsphere',
+  maxRanks: 1,
+};
+export const YULONS_WHISPER_MISTWEAVER_TALENT: Talent = {
+  id: 388038,
+  name: "Yu'lon's Whisper",
+  icon: 'ability_monk_dragonkick',
+  maxRanks: 1,
+};
+export const MIST_WRAP_MISTWEAVER_TALENT: Talent = {
+  id: 197900,
+  name: 'Mist Wrap',
+  icon: 'ability_monk_pathofmists',
+  maxRanks: 1,
+};
+export const REFRESHING_JADE_WIND_MISTWEAVER_TALENT: Talent = {
+  id: 196725,
+  name: 'Refreshing Jade Wind',
+  icon: 'ability_monk_rushingjadewind',
+  maxRanks: 1,
+  manaCost: 1500,
+};
+export const ENVELOPING_BREATH_MISTWEAVER_TALENT: Talent = {
+  id: 343655,
+  name: 'Enveloping Breath',
+  icon: 'ability_monk_dragonkick',
+  maxRanks: 1,
+};
+export const DANCING_MISTS_MISTWEAVER_TALENT: Talent = {
+  id: 388701,
+  name: 'Dancing Mists',
+  icon: 'ability_monk_souldance',
+  maxRanks: 2,
+};
+export const LIFECYCLES_MISTWEAVER_TALENT: Talent = {
+  id: 197915,
+  name: 'Lifecycles',
+  icon: 'ability_monk_souldance',
+  maxRanks: 1,
+};
+export const MANA_TEA_MISTWEAVER_TALENT: Talent = {
+  id: 197908,
+  name: 'Mana Tea',
+  icon: 'monk_ability_cherrymanatea',
+  maxRanks: 1,
+};
+export const FAELINE_STOMP_MISTWEAVER_TALENT: Talent = {
+  id: 388193,
+  name: 'Faeline Stomp',
+  icon: 'ability_ardenweald_monk',
+  maxRanks: 1,
+  manaCost: 2000,
+};
+export const ANCIENT_TEACHINGS_OF_THE_MONASTERY_MISTWEAVER_TALENT: Talent = {
+  id: 388023,
+  name: 'Ancient Teachings of the Monastery',
+  icon: 'passive_monk_teachingsofmonastery',
+  maxRanks: 1,
+};
+export const CLOUDED_FOCUS_MISTWEAVER_TALENT: Talent = {
+  id: 388047,
+  name: 'Clouded Focus',
+  icon: 'ability_monk_soothingmists',
+  maxRanks: 1,
+};
+export const JADE_BOND_MISTWEAVER_TALENT: Talent = {
+  id: 388031,
+  name: 'Jade Bond',
+  icon: 'inv_inscription_deck_jadeserpent',
+  maxRanks: 1,
+};
+export const GIFT_OF_THE_CELESTIALS_MISTWEAVER_TALENT: Talent = {
+  id: 388212,
+  name: 'Gift of the Celestials',
+  icon: 'inv_pet_jadeserpentpet',
+  maxRanks: 1,
+};
+export const FOCUSED_THUNDER_MISTWEAVER_TALENT: Talent = {
+  id: 197895,
+  name: 'Focused Thunder',
+  icon: 'spell_monk_nimblebrew',
+  maxRanks: 1,
+};
+export const UPWELLING_MISTWEAVER_TALENT: Talent = {
+  id: 274963,
+  name: 'Upwelling',
+  icon: 'ability_monk_surgingmist',
+  maxRanks: 1,
+};
+export const BONEDUST_BREW_MISTWEAVER_TALENT: Talent = {
+  id: 386276,
+  name: 'Bonedust Brew',
+  icon: 'ability_maldraxxus_monk',
+  maxRanks: 1,
+};
+export const ANCIENT_CONCORDANCE_MISTWEAVER_TALENT: Talent = {
+  id: 388740,
+  name: 'Ancient Concordance',
+  icon: 'spell_animaardenweald_beam',
+  maxRanks: 2,
+};
+export const OVERFLOWING_MISTS_MISTWEAVER_TALENT: Talent = {
+  id: 388511,
+  name: 'Overflowing Mists',
+  icon: 'spell_monk_envelopingmist',
+  maxRanks: 2,
+};
+export const SECRET_INFUSION_MISTWEAVER_TALENT: Talent = {
+  id: 388491,
+  name: 'Secret Infusion',
+  icon: 'ability_monk_thunderfocustea',
+  maxRanks: 2,
+};
+export const MISTY_PEAKS_MISTWEAVER_TALENT: Talent = {
+  id: 388682,
+  name: 'Misty Peaks',
+  icon: 'ability_monk_renewingmists',
+  maxRanks: 2,
+};
+export const RESPLENDENT_MIST_MISTWEAVER_TALENT: Talent = {
+  id: 388020,
+  name: 'Resplendent Mist',
+  icon: 'spell_nature_abolishmagic',
+  maxRanks: 2,
+};
+export const AWAKENED_FAELINE_MISTWEAVER_TALENT: Talent = {
+  id: 388779,
+  name: 'Awakened Faeline',
+  icon: 'ability_ardenweald_monk',
+  maxRanks: 1,
+};
+export const RESTORATIVE_PROLIFERATION_MISTWEAVER_TALENT: Talent = {
+  id: 388509,
+  name: 'Restorative Proliferation',
+  icon: 'ability_monk_souldance',
+  maxRanks: 1,
+};
+export const TEA_OF_PLENTY_MISTWEAVER_TALENT: Talent = {
+  id: 388517,
+  name: 'Tea of Plenty',
+  icon: 'inv_misc_pearlmilktea',
+  maxRanks: 1,
+};
+export const UNISON_MISTWEAVER_TALENT: Talent = {
+  id: 388477,
+  name: 'Unison',
+  icon: 'ability_creature_cursed_04',
+  maxRanks: 1,
+};
+export const INVOKERS_DELIGHT_MISTWEAVER_TALENT: Talent = {
+  id: 388661,
+  name: "Invoker's Delight",
+  icon: 'inv_inscription_80_warscroll_battleshout',
+  maxRanks: 1,
+};
+export const TEAR_OF_MORNING_MISTWEAVER_TALENT: Talent = {
+  id: 387991,
+  name: 'Tear of Morning',
+  icon: 'ability_monk_uplift',
+  maxRanks: 1,
+};
+export const RISING_MIST_MISTWEAVER_TALENT: Talent = {
+  id: 274909,
+  name: 'Rising Mist',
+  icon: 'ability_monk_effuse',
+  maxRanks: 1,
+};
+export const BOUNTIFUL_BREW_MISTWEAVER_TALENT: Talent = {
+  id: 386949,
+  name: 'Bountiful Brew',
+  icon: 'ability_maldraxxus_monk',
+  maxRanks: 1,
+};
+export const ATTENUATION_MISTWEAVER_TALENT: Talent = {
+  id: 386941,
+  name: 'Attenuation',
+  icon: 'spell_animamaldraxxus_nova',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Windwalker
+export const FISTS_OF_FURY_WINDWALKER_TALENT: Talent = {
+  id: 113656,
+  name: 'Fists of Fury',
+  icon: 'monk_ability_fistoffury',
+  maxRanks: 1,
+  chiCost: 3,
+};
+export const TOUCH_OF_KARMA_WINDWALKER_TALENT: Talent = {
+  id: 122470,
+  name: 'Touch of Karma',
+  icon: 'ability_monk_touchofkarma',
+  maxRanks: 1,
+};
+export const ASCENSION_WINDWALKER_TALENT: Talent = {
+  id: 115396,
+  name: 'Ascension',
+  icon: 'ability_monk_ascension',
+  maxRanks: 1,
+};
+export const POWER_STRIKES_WINDWALKER_TALENT: Talent = {
+  id: 121817,
+  name: 'Power Strikes',
+  icon: 'ability_monk_powerstrikes',
+  maxRanks: 1,
+};
+export const FEATHERS_OF_A_HUNDRED_FLOCKS_WINDWALKER_TALENT: Talent = {
+  id: 388846,
+  name: 'Feathers of a Hundred Flocks',
+  icon: 'ability_monk_forcesphere_pink',
+  maxRanks: 1,
+};
+export const TOUCH_OF_THE_TIGER_WINDWALKER_TALENT: Talent = {
+  id: 388856,
+  name: 'Touch of the Tiger',
+  icon: 'ability_monk_tigerpalm',
+  maxRanks: 2,
+};
+export const HARDENED_SOLES_WINDWALKER_TALENT: Talent = {
+  id: 391383,
+  name: 'Hardened Soles',
+  icon: 'ability_monk_roundhousekick',
+  maxRanks: 2,
+};
+export const FLASHING_FISTS_WINDWALKER_TALENT: Talent = {
+  id: 388854,
+  name: 'Flashing Fists',
+  icon: 'monk_ability_fistoffury',
+  maxRanks: 2,
+};
+export const OPEN_PALM_STRIKES_WINDWALKER_TALENT: Talent = {
+  id: 279918,
+  name: 'Open Palm Strikes',
+  icon: 'monk_ability_fistoffury',
+  maxRanks: 1,
+};
+export const MARK_OF_THE_CRANE_WINDWALKER_TALENT: Talent = {
+  id: 228287,
+  name: 'Mark of the Crane',
+  icon: 'ability_monk_cranekick_new',
+  maxRanks: 1,
+};
+export const FLYING_SERPENT_KICK_WINDWALKER_TALENT: Talent = {
+  id: 101545,
+  name: 'Flying Serpent Kick',
+  icon: 'ability_monk_flyingdragonkick',
+  maxRanks: 1,
+};
+export const GLORY_OF_THE_DAWN_WINDWALKER_TALENT: Talent = {
+  id: 288634,
+  name: 'Glory of the Dawn',
+  icon: 'ability_monk_mightyoxkick',
+  maxRanks: 1,
+};
+export const SHADOWBOXING_TREADS_WINDWALKER_TALENT: Talent = {
+  id: 331512,
+  name: 'Shadowboxing Treads',
+  icon: 'ability_monk_roundhousekick',
+  maxRanks: 1,
+};
+export const INNER_PEACE_WINDWALKER_TALENT: Talent = {
+  id: 195243,
+  name: 'Inner Peace',
+  icon: 'ability_monk_jasmineforcetea',
+  maxRanks: 1,
+};
+export const STORM_EARTH_AND_FIRE_WINDWALKER_TALENT: Talent = {
+  id: 137639,
+  name: 'Storm, Earth, and Fire',
+  icon: 'spell_nature_giftofthewild',
+  maxRanks: 1,
+};
+export const SERENITY_WINDWALKER_TALENT: Talent = {
+  id: 152173,
+  name: 'Serenity',
+  icon: 'ability_monk_serenity',
+  maxRanks: 1,
+};
+export const MERIDIAN_STRIKES_WINDWALKER_TALENT: Talent = {
+  id: 391330,
+  name: 'Meridian Strikes',
+  icon: 'ability_monk_touchofdeath',
+  maxRanks: 1,
+};
+export const JADE_IGNITION_WINDWALKER_TALENT: Talent = {
+  id: 337483,
+  name: 'Jade Ignition',
+  icon: 'ability_monk_chiexplosion',
+  maxRanks: 1,
+};
+export const DANCE_OF_CHI_JI_WINDWALKER_TALENT: Talent = {
+  id: 325201,
+  name: 'Dance of Chi-Ji',
+  icon: 'ability_monk_cranekick_new',
+  maxRanks: 1,
+};
+export const HIT_COMBO_WINDWALKER_TALENT: Talent = {
+  id: 196740,
+  name: 'Hit Combo',
+  icon: 'ability_monk_palmstrike',
+  maxRanks: 1,
+};
+export const DRINKING_HORN_COVER_WINDWALKER_TALENT: Talent = {
+  id: 391370,
+  name: 'Drinking Horn Cover',
+  icon: 'ability_warrior_unrelentingassault',
+  maxRanks: 1,
+};
+export const SPIRITUAL_FOCUS_WINDWALKER_TALENT: Talent = {
+  id: 280197,
+  name: 'Spiritual Focus',
+  icon: 'spell_nature_giftofthewild',
+  maxRanks: 1,
+};
+export const STRIKE_OF_THE_WINDLORD_WINDWALKER_TALENT: Talent = {
+  id: 205320,
+  name: 'Strike of the Windlord',
+  icon: 'inv_hand_1h_artifactskywall_d_01',
+  maxRanks: 1,
+  chiCost: 2,
+};
+export const RUSHING_JADE_WIND_WINDWALKER_TALENT: Talent = {
+  id: 116847,
+  name: 'Rushing Jade Wind',
+  icon: 'ability_monk_rushingjadewind',
+  maxRanks: 1,
+  chiCost: 1,
+};
+export const HIDDEN_MASTERS_FORBIDDEN_TOUCH_WINDWALKER_TALENT: Talent = {
+  id: 213112,
+  name: "Hidden Master's Forbidden Touch",
+  icon: 'ability_monk_touchofdeath',
+  maxRanks: 1,
+};
+export const INVOKE_XUEN_THE_WHITE_TIGER_WINDWALKER_TALENT: Talent = {
+  id: 123904,
+  name: 'Invoke Xuen, the White Tiger',
+  icon: 'ability_monk_summontigerstatue',
+  maxRanks: 1,
+};
+export const TEACHINGS_OF_THE_MONASTERY_WINDWALKER_TALENT: Talent = {
+  id: 116645,
+  name: 'Teachings of the Monastery',
+  icon: 'passive_monk_teachingsofmonastery',
+  maxRanks: 1,
+};
+export const THUNDERFIST_WINDWALKER_TALENT: Talent = {
+  id: 238131,
+  name: 'Thunderfist',
+  icon: 'inv_hand_1h_artifactskywall_d_01',
+  maxRanks: 1,
+};
+export const CRANE_VORTEX_WINDWALKER_TALENT: Talent = {
+  id: 388848,
+  name: 'Crane Vortex',
+  icon: 'ability_monk_cranekick_new',
+  maxRanks: 2,
+};
+export const XUENS_BOND_WINDWALKER_TALENT: Talent = {
+  id: 336616,
+  name: "Xuen's Bond",
+  icon: 'ability_demonhunter_netherbond',
+  maxRanks: 1,
+};
+export const FURY_OF_XUEN_WINDWALKER_TALENT: Talent = {
+  id: 287055,
+  name: 'Fury of Xuen',
+  icon: 'ability_monk_prideofthetiger',
+  maxRanks: 1,
+};
+export const EMPOWERED_TIGER_LIGHTNING_WINDWALKER_TALENT: Talent = {
+  id: 335913,
+  name: 'Empowered Tiger Lightning',
+  icon: 'ability_monk_summontigerstatue',
+  maxRanks: 1,
+};
+export const RISING_STAR_WINDWALKER_TALENT: Talent = {
+  id: 388849,
+  name: 'Rising Star',
+  icon: 'ability_monk_risingsunkick',
+  maxRanks: 2,
+};
+export const BONEDUST_BREW_WINDWALKER_TALENT: Talent = {
+  id: 325216,
+  name: 'Bonedust Brew',
+  icon: 'ability_maldraxxus_monk',
+  maxRanks: 1,
+};
+export const FATAL_FLYING_GUILLOTINE_WINDWALKER_TALENT: Talent = {
+  id: 331679,
+  name: 'Fatal Flying Guillotine',
+  icon: 'ability_monk_touchofdeath',
+  maxRanks: 1,
+};
+export const LAST_EMPERORS_CAPACITOR_WINDWALKER_TALENT: Talent = {
+  id: 337292,
+  name: "Last Emperor's Capacitor",
+  icon: 'ability_warrior_unrelentingassault',
+  maxRanks: 1,
+};
+export const XUENS_BATTLEGEAR_WINDWALKER_TALENT: Talent = {
+  id: 337481,
+  name: "Xuen's Battlegear",
+  icon: 'monk_stance_whitetiger',
+  maxRanks: 1,
+};
+export const TRANSFER_THE_POWER_WINDWALKER_TALENT: Talent = {
+  id: 195300,
+  name: 'Transfer the Power',
+  icon: 'monk_ability_fistoffury',
+  maxRanks: 1,
+};
+export const WHIRLING_DRAGON_PUNCH_WINDWALKER_TALENT: Talent = {
+  id: 152175,
+  name: 'Whirling Dragon Punch',
+  icon: 'ability_monk_hurricanestrike',
+  maxRanks: 1,
+};
+export const FAELINE_STOMP_WINDWALKER_TALENT: Talent = {
+  id: 388193,
+  name: 'Faeline Stomp',
+  icon: 'ability_ardenweald_monk',
+  maxRanks: 1,
+  manaCost: 2000,
+};
+export const CALCULATED_STRIKES_WINDWALKER_TALENT: Talent = {
+  id: 336526,
+  name: 'Calculated Strikes',
+  icon: 'spell_magic_lesserinvisibilty',
+  maxRanks: 1,
+};
+export const BONE_MARROW_HOPS_WINDWALKER_TALENT: Talent = {
+  id: 337295,
+  name: 'Bone Marrow Hops',
+  icon: 'spell_animamaldraxxus_nova',
+  maxRanks: 1,
+};
+export const KEEFERS_SKYREACH_WINDWALKER_TALENT: Talent = {
+  id: 337334,
+  name: "Keefer's Skyreach",
+  icon: 'inv__fistofthewhitetiger',
+  maxRanks: 1,
+};
+export const INVOKERS_DELIGHT_WINDWALKER_TALENT: Talent = {
+  id: 388661,
+  name: "Invoker's Delight",
+  icon: 'inv_inscription_80_warscroll_battleshout',
+  maxRanks: 1,
+};
+export const WAY_OF_THE_FAE_WINDWALKER_TALENT: Talent = {
+  id: 337303,
+  name: 'Way of the Fae',
+  icon: 'spell_animaardenweald_beam',
+  maxRanks: 1,
+};
+export const FAELINE_HARMONY_WINDWALKER_TALENT: Talent = {
+  id: 391412,
+  name: 'Faeline Harmony',
+  icon: 'ability_ardenweald_monk',
+  maxRanks: 1,
+};
+
+//endregion
 
 const talents = createTalentList({
   //Shared
-  SOOTHING_MIST_TALENT: {
-    id: 115175,
-    name: 'Soothing Mist',
-    icon: 'ability_monk_soothingmists',
-    maxRanks: 1,
-    manaCost: 0,
-  },
-  RISING_SUN_KICK_TALENT: {
-    id: 107428,
-    name: 'Rising Sun Kick',
-    icon: 'ability_monk_risingsunkick',
-    maxRanks: 1,
-    chiCost: 2,
-  },
-  TIGERS_LUST_TALENT: {
-    id: 116841,
-    name: "Tiger's Lust",
-    icon: 'ability_monk_tigerslust',
-    maxRanks: 1,
-  },
-  ROLL_TALENT: { id: 109132, name: 'Roll', icon: 'ability_monk_roll', maxRanks: 1 },
-  CALMING_PRESENCE_TALENT: {
-    id: 388664,
-    name: 'Calming Presence',
-    icon: 'inv_misc_orb_01',
-    maxRanks: 1,
-  },
-  PARALYSIS_TALENT: { id: 344359, name: 'Paralysis', icon: 'ability_monk_paralysis', maxRanks: 1 },
-  TIGER_TAIL_SWEEP_TALENT: {
-    id: 264348,
-    name: 'Tiger Tail Sweep',
-    icon: 'ability_monk_legsweep',
-    maxRanks: 2,
-  },
-  HEAVY_AIR_TALENT: {
-    id: 388671,
-    name: 'Heavy Air',
-    icon: 'spell_lightning_lightningbolt01',
-    maxRanks: 1,
-  },
-  VIVIFY_TALENT: { id: 231602, name: 'Vivify', icon: 'ability_monk_vivify', maxRanks: 2 },
-  DETOX_TALENT: {
-    id: 218164,
-    name: 'Detox',
-    icon: 'ability_rogue_imrovedrecuperate',
-    maxRanks: 1,
-    energyCost: 20,
-  },
-  DISABLE_TALENT: {
-    id: 116095,
-    name: 'Disable',
-    icon: 'ability_shockwave',
-    maxRanks: 1,
-    energyCost: 15,
-  },
-  GRACE_OF_THE_CRANE_TALENT: {
-    id: 388811,
-    name: 'Grace of the Crane',
-    icon: 'monk_ability_cherrymanatea',
-    maxRanks: 2,
-  },
-  VIVACIOUS_VIVIFICATION_TALENT: {
-    id: 388812,
-    name: 'Vivacious Vivification',
-    icon: 'ability_monk_vivify',
-    maxRanks: 1,
-  },
-  FEROCITY_OF_XUEN_TALENT: {
-    id: 388674,
-    name: 'Ferocity of Xuen',
-    icon: 'ability_mount_pinktiger',
-    maxRanks: 2,
-  },
-  ELUSIVE_MISTS_TALENT: {
-    id: 115175,
-    name: 'Elusive Mists',
-    icon: 'ability_monk_soothingmists',
-    maxRanks: 2,
-    manaCost: 0,
-  },
-  TRANSCENDENCE_TALENT: {
-    id: 101643,
-    name: 'Transcendence',
-    icon: 'monk_ability_transcendence',
-    maxRanks: 1,
-  },
-  SPEAR_HAND_STRIKE_TALENT: {
-    id: 116705,
-    name: 'Spear Hand Strike',
-    icon: 'ability_monk_spearhand',
-    maxRanks: 1,
-  },
-  FORTIFYING_BREW_TALENT: {
-    id: 388813,
-    name: 'Fortifying Brew',
-    icon: 'ability_monk_fortifyingale_new',
-    maxRanks: 1,
-  },
-  CHI_WAVE_TALENT: { id: 115098, name: 'Chi Wave', icon: 'ability_monk_chiwave', maxRanks: 1 },
-  CHI_BURST_TALENT: {
-    id: 123986,
-    name: 'Chi Burst',
-    icon: 'spell_arcane_arcanetorrent',
-    maxRanks: 1,
-  },
-  PROVOKE_TALENT: { id: 328670, name: 'Provoke', icon: 'ability_monk_provoke', maxRanks: 1 },
-  RING_OF_PEACE_TALENT: {
-    id: 116844,
-    name: 'Ring of Peace',
-    icon: 'spell_monk_ringofpeace',
-    maxRanks: 1,
-  },
-  FAST_FEET_TALENT: {
-    id: 388809,
-    name: 'Fast Feet',
-    icon: 'ability_monk_risingsunkick',
-    maxRanks: 2,
-  },
-  CELERITY_TALENT: { id: 115173, name: 'Celerity', icon: 'ability_monk_quipunch', maxRanks: 1 },
-  CHI_TORPEDO_TALENT: {
-    id: 115008,
-    name: 'Chi Torpedo',
-    icon: 'ability_monk_quitornado',
-    maxRanks: 1,
-  },
-  ROLL_OUT_TALENT: { id: 388810, name: 'Roll Out', icon: 'ability_monk_roll', maxRanks: 1 },
-  DIFFUSE_MAGIC_TALENT: {
-    id: 122783,
-    name: 'Diffuse Magic',
-    icon: 'spell_monk_diffusemagic',
-    maxRanks: 1,
-  },
-  EYE_OF_THE_TIGER_TALENT: {
-    id: 196607,
-    name: 'Eye of the Tiger',
-    icon: 'ability_druid_primalprecision',
-    maxRanks: 1,
-  },
-  DAMPEN_HARM_TALENT: {
-    id: 122278,
-    name: 'Dampen Harm',
-    icon: 'ability_monk_dampenharm',
-    maxRanks: 1,
-  },
-  TOUCH_OF_DEATH_TALENT: {
-    id: 322113,
-    name: 'Touch of Death',
-    icon: 'ability_monk_touchofdeath',
-    maxRanks: 1,
-  },
-  EXPEL_HARM_TALENT: {
-    id: 322101,
-    name: 'Expel Harm',
-    icon: 'ability_monk_expelharm',
-    maxRanks: 1,
-    energyCost: 15,
-  },
-  CLOSE_TO_HEART_TALENT: {
-    id: 389574,
-    name: 'Close to Heart',
-    icon: 'inv_offhand_1h_pvppandarias2_c_01',
-    maxRanks: 2,
-  },
-  ESCAPE_FROM_REALITY_TALENT: {
-    id: 343250,
-    name: 'Escape from Reality',
-    icon: 'monk_ability_transcendence',
-    maxRanks: 2,
-  },
-  WINDWALKING_TALENT: {
-    id: 157411,
-    name: 'Windwalking',
-    icon: 'monk_stance_whitetiger',
-    maxRanks: 2,
-  },
-  FATAL_TOUCH_TALENT: {
-    id: 337296,
-    name: 'Fatal Touch',
-    icon: 'ability_monk_touchofdeath',
-    maxRanks: 2,
-  },
-  GENEROUS_POUR_TALENT: {
-    id: 389575,
-    name: 'Generous Pour',
-    icon: 'inv_misc_food_legion_goocaramel_bottle',
-    maxRanks: 2,
-  },
-  SAVE_THEM_ALL_TALENT: {
-    id: 389579,
-    name: 'Save Them All',
-    icon: 'inv_weapon_hand_22',
-    maxRanks: 2,
-  },
-  RESONANT_FISTS_TALENT: {
-    id: 389578,
-    name: 'Resonant Fists',
-    icon: 'inv_weapon_hand_16',
-    maxRanks: 2,
-  },
-  BOUNCE_BACK_TALENT: {
-    id: 389577,
-    name: 'Bounce Back',
-    icon: 'ability_butcher_heavyhanded',
-    maxRanks: 2,
-  },
-  SUMMON_JADE_SERPENT_STATUE_TALENT: {
-    id: 115313,
-    name: 'Summon Jade Serpent Statue',
-    icon: 'ability_monk_summonserpentstatue',
-    maxRanks: 1,
-  },
-  SUMMON_WHITE_TIGER_STATUE_TALENT: {
-    id: 388686,
-    name: 'Summon White Tiger Statue',
-    icon: 'ability_monk_summonwhitetigerstatue',
-    maxRanks: 1,
-  },
-  SUMMON_BLACK_OX_STATUE_TALENT: {
-    id: 115315,
-    name: 'Summon Black Ox Statue',
-    icon: 'monk_ability_summonoxstatue',
-    maxRanks: 1,
-  },
+  SOOTHING_MIST_TALENT,
+  RISING_SUN_KICK_TALENT,
+  TIGERS_LUST_TALENT,
+  ROLL_TALENT,
+  CALMING_PRESENCE_TALENT,
+  PARALYSIS_TALENT,
+  TIGER_TAIL_SWEEP_TALENT,
+  HEAVY_AIR_TALENT,
+  VIVIFY_TALENT,
+  DETOX_TALENT,
+  DISABLE_TALENT,
+  GRACE_OF_THE_CRANE_TALENT,
+  VIVACIOUS_VIVIFICATION_TALENT,
+  FEROCITY_OF_XUEN_TALENT,
+  ELUSIVE_MISTS_TALENT,
+  TRANSCENDENCE_TALENT,
+  SPEAR_HAND_STRIKE_TALENT,
+  FORTIFYING_BREW_TALENT,
+  CHI_WAVE_TALENT,
+  CHI_BURST_TALENT,
+  PROVOKE_TALENT,
+  RING_OF_PEACE_TALENT,
+  FAST_FEET_TALENT,
+  CELERITY_TALENT,
+  CHI_TORPEDO_TALENT,
+  ROLL_OUT_TALENT,
+  DIFFUSE_MAGIC_TALENT,
+  EYE_OF_THE_TIGER_TALENT,
+  DAMPEN_HARM_TALENT,
+  TOUCH_OF_DEATH_TALENT,
+  EXPEL_HARM_TALENT,
+  CLOSE_TO_HEART_TALENT,
+  ESCAPE_FROM_REALITY_TALENT,
+  WINDWALKING_TALENT,
+  FATAL_TOUCH_TALENT,
+  GENEROUS_POUR_TALENT,
+  SAVE_THEM_ALL_TALENT,
+  RESONANT_FISTS_TALENT,
+  BOUNCE_BACK_TALENT,
+  SUMMON_JADE_SERPENT_STATUE_TALENT,
+  SUMMON_WHITE_TIGER_STATUE_TALENT,
+  SUMMON_BLACK_OX_STATUE_TALENT,
 
   //Brewmaster
-  KEG_SMASH_BREWMASTER_TALENT: {
-    id: 121253,
-    name: 'Keg Smash',
-    icon: 'achievement_brewery_2',
-    maxRanks: 1,
-    energyCost: 40,
-  },
-  STAGGER_BREWMASTER_TALENT: {
-    id: 115069,
-    name: 'Stagger',
-    icon: 'monk_stance_drunkenox',
-    maxRanks: 1,
-  },
-  PURIFYING_BREW_BREWMASTER_TALENT: {
-    id: 343743,
-    name: 'Purifying Brew',
-    icon: 'inv_misc_beer_06',
-    maxRanks: 1,
-  },
-  SHUFFLE_BREWMASTER_TALENT: {
-    id: 322120,
-    name: 'Shuffle',
-    icon: 'ability_monk_shuffle',
-    maxRanks: 1,
-  },
-  HIT_SCHEME_BREWMASTER_TALENT: {
-    id: 383695,
-    name: 'Hit Scheme',
-    icon: 'ability_monk_roundhousekick',
-    maxRanks: 1,
-  },
-  GIFT_OF_THE_OX_BREWMASTER_TALENT: {
-    id: 124502,
-    name: 'Gift of the Ox',
-    icon: 'ability_druid_giftoftheearthmother',
-    maxRanks: 2,
-  },
-  HEALING_ELIXIR_BREWMASTER_TALENT: {
-    id: 122281,
-    name: 'Healing Elixir',
-    icon: 'ability_monk_jasmineforcetea',
-    maxRanks: 1,
-  },
-  QUICK_SIP_BREWMASTER_TALENT: {
-    id: 388505,
-    name: 'Quick Sip',
-    icon: 'achievement_faction_brewmaster',
-    maxRanks: 2,
-  },
-  RUSHING_JADE_WIND_BREWMASTER_TALENT: {
-    id: 116847,
-    name: 'Rushing Jade Wind',
-    icon: 'ability_monk_rushingjadewind',
-    maxRanks: 1,
-    chiCost: 1,
-  },
-  SPECIAL_DELIVERY_BREWMASTER_TALENT: {
-    id: 196730,
-    name: 'Special Delivery',
-    icon: 'achievement_brewery_2',
-    maxRanks: 1,
-  },
-  CELESTIAL_FLAMES_BREWMASTER_TALENT: {
-    id: 325177,
-    name: 'Celestial Flames',
-    icon: 'inv_misc_volatilefire',
-    maxRanks: 1,
-  },
-  CELESTIAL_BREW_BREWMASTER_TALENT: {
-    id: 322510,
-    name: 'Celestial Brew',
-    icon: 'ability_monk_ironskinbrew',
-    maxRanks: 1,
-  },
-  STAGGERING_STRIKES_BREWMASTER_TALENT: {
-    id: 387625,
-    name: 'Staggering Strikes',
-    icon: 'ability_monk_blackoutstrike',
-    maxRanks: 2,
-  },
-  GRACEFUL_EXIT_BREWMASTER_TALENT: {
-    id: 387256,
-    name: 'Graceful Exit',
-    icon: 'ability_rogue_sprint_blue',
-    maxRanks: 2,
-  },
-  ZEN_MEDITATION_BREWMASTER_TALENT: {
-    id: 115176,
-    name: 'Zen Meditation',
-    icon: 'ability_monk_zenmeditation',
-    maxRanks: 1,
-  },
-  CLASH_BREWMASTER_TALENT: {
-    id: 324312,
-    name: 'Clash',
-    icon: 'ability_monk_clashingoxcharge',
-    maxRanks: 1,
-  },
-  BREATH_OF_FIRE_BREWMASTER_TALENT: {
-    id: 115181,
-    name: 'Breath of Fire',
-    icon: 'ability_monk_breathoffire',
-    maxRanks: 1,
-  },
-  STRENGTH_OF_SPIRIT_BREWMASTER_TALENT: {
-    id: 387276,
-    name: 'Strength of Spirit',
-    icon: 'ability_monk_healthsphere',
-    maxRanks: 1,
-  },
-  GAI_PLINS_IMPERIAL_BREW_BREWMASTER_TALENT: {
-    id: 383700,
-    name: "Gai Plin's Imperial Brew",
-    icon: 'inv_misc_beer_05',
-    maxRanks: 1,
-  },
-  FUNDAMENTAL_OBSERVATION_BREWMASTER_TALENT: {
-    id: 387035,
-    name: 'Fundamental Observation',
-    icon: 'ability_monk_zenmeditation',
-    maxRanks: 1,
-  },
-  SHADOWBOXING_TREADS_BREWMASTER_TALENT: {
-    id: 387638,
-    name: 'Shadowboxing Treads',
-    icon: 'ability_monk_roundhousekick',
-    maxRanks: 1,
-  },
-  FLUIDITY_OF_MOTION_BREWMASTER_TALENT: {
-    id: 387230,
-    name: 'Fluidity of Motion',
-    icon: 'ability_monk_standingkick',
-    maxRanks: 1,
-  },
-  SCALDING_BREW_BREWMASTER_TALENT: {
-    id: 383698,
-    name: 'Scalding Brew',
-    icon: 'spell_brew_bolt_dark',
-    maxRanks: 1,
-  },
-  SALSALABIMS_STRENGTH_BREWMASTER_TALENT: {
-    id: 383697,
-    name: "Sal'salabim's Strength",
-    icon: 'ability_warrior_unrelentingassault',
-    maxRanks: 1,
-  },
-  FORTIFYING_BREW_BREWMASTER_TALENT: {
-    id: 322960,
-    name: 'Fortifying Brew',
-    icon: 'ability_monk_fortifyingale_new',
-    maxRanks: 1,
-  },
-  BLACK_OX_BREW_BREWMASTER_TALENT: {
-    id: 115399,
-    name: 'Black Ox Brew',
-    icon: 'ability_monk_chibrew',
-    maxRanks: 1,
-  },
-  BOB_AND_WEAVE_BREWMASTER_TALENT: {
-    id: 280515,
-    name: 'Bob and Weave',
-    icon: 'ability_creature_cursed_04',
-    maxRanks: 1,
-  },
-  INVOKE_NIUZAO_THE_BLACK_OX_BREWMASTER_TALENT: {
-    id: 322740,
-    name: 'Invoke Niuzao, the Black Ox',
-    icon: 'spell_monk_brewmaster_spec',
-    maxRanks: 1,
-  },
-  LIGHT_BREWING_BREWMASTER_TALENT: {
-    id: 325093,
-    name: 'Light Brewing',
-    icon: 'spell_brew_wheat',
-    maxRanks: 1,
-  },
-  TRAINING_OF_NIUZAO_BREWMASTER_TALENT: {
-    id: 383714,
-    name: 'Training of Niuzao',
-    icon: 'monk_stance_drunkenox',
-    maxRanks: 1,
-  },
-  SHOCKING_BLOW_NYI_BREWMASTER_TALENT: {
-    id: 389982,
-    name: 'Shocking Blow [NYI]',
-    icon: 'spell_shaman_crashlightning',
-    maxRanks: 1,
-  },
-  FACE_PALM_BREWMASTER_TALENT: {
-    id: 389942,
-    name: 'Face Palm',
-    icon: 'ability_monk_tigerpalm',
-    maxRanks: 1,
-  },
-  DRAGONFIRE_BREW_BREWMASTER_TALENT: {
-    id: 383994,
-    name: 'Dragonfire Brew',
-    icon: 'spell_fire_burnout',
-    maxRanks: 1,
-  },
-  CHARRED_PASSIONS_BREWMASTER_TALENT: {
-    id: 386965,
-    name: 'Charred Passions',
-    icon: 'ability_monk_mightyoxkick',
-    maxRanks: 1,
-  },
-  HIGH_TOLERANCE_BREWMASTER_TALENT: {
-    id: 196737,
-    name: 'High Tolerance',
-    icon: 'monk_ability_avertharm',
-    maxRanks: 2,
-  },
-  WALK_WITH_THE_OX_BREWMASTER_TALENT: {
-    id: 387219,
-    name: 'Walk with the Ox',
-    icon: 'monk_stance_drunkenox',
-    maxRanks: 2,
-  },
-  ELUSIVE_FOOTWORK_BREWMASTER_TALENT: {
-    id: 387046,
-    name: 'Elusive Footwork',
-    icon: 'ability_monk_shuffle',
-    maxRanks: 2,
-  },
-  ANVIL__STAVE_BREWMASTER_TALENT: {
-    id: 386937,
-    name: 'Anvil & Stave',
-    icon: 'ability_monk_elusiveale',
-    maxRanks: 2,
-  },
-  COUNTERSTRIKE_BREWMASTER_TALENT: {
-    id: 383785,
-    name: 'Counterstrike',
-    icon: 'ability_monk_palmstrike',
-    maxRanks: 1,
-  },
-  BONEDUST_BREW_BREWMASTER_TALENT: {
-    id: 386276,
-    name: 'Bonedust Brew',
-    icon: 'ability_maldraxxus_monk',
-    maxRanks: 1,
-  },
-  EXPLODING_KEG_BREWMASTER_TALENT: {
-    id: 325153,
-    name: 'Exploding Keg',
-    icon: 'archaeology_5_0_emptykegofbrewfatherxinwoyin',
-    maxRanks: 1,
-  },
-  BLACKOUT_COMBO_BREWMASTER_TALENT: {
-    id: 196736,
-    name: 'Blackout Combo',
-    icon: 'ability_monk_blackoutkick',
-    maxRanks: 1,
-  },
-  WEAPONS_OF_ORDER_BREWMASTER_TALENT: {
-    id: 387184,
-    name: 'Weapons of Order',
-    icon: 'ability_bastion_monk',
-    maxRanks: 1,
-    manaCost: 2500,
-  },
-  BOUNTIFUL_BREW_BREWMASTER_TALENT: {
-    id: 386949,
-    name: 'Bountiful Brew',
-    icon: 'ability_maldraxxus_monk',
-    maxRanks: 1,
-  },
-  ATTENUATION_BREWMASTER_TALENT: {
-    id: 386941,
-    name: 'Attenuation',
-    icon: 'spell_animamaldraxxus_nova',
-    maxRanks: 1,
-  },
-  STORMSTOUTS_LAST_KEG_BREWMASTER_TALENT: {
-    id: 383707,
-    name: "Stormstout's Last Keg",
-    icon: 'achievement_brewery_2',
-    maxRanks: 1,
-  },
-  CALL_TO_ARMS_BREWMASTER_TALENT: {
-    id: 356684,
-    name: 'Call to Arms',
-    icon: 'ability_bastion_monk',
-    maxRanks: 1,
-  },
-  EFFUSIVE_ANIMA_ACCELERATOR_BREWMASTER_TALENT: {
-    id: 352188,
-    name: 'Effusive Anima Accelerator',
-    icon: 'inv_offhand_1h_bastion_d_01',
-    maxRanks: 1,
-  },
+  KEG_SMASH_BREWMASTER_TALENT,
+  STAGGER_BREWMASTER_TALENT,
+  PURIFYING_BREW_BREWMASTER_TALENT,
+  SHUFFLE_BREWMASTER_TALENT,
+  HIT_SCHEME_BREWMASTER_TALENT,
+  GIFT_OF_THE_OX_BREWMASTER_TALENT,
+  HEALING_ELIXIR_BREWMASTER_TALENT,
+  QUICK_SIP_BREWMASTER_TALENT,
+  RUSHING_JADE_WIND_BREWMASTER_TALENT,
+  SPECIAL_DELIVERY_BREWMASTER_TALENT,
+  CELESTIAL_FLAMES_BREWMASTER_TALENT,
+  CELESTIAL_BREW_BREWMASTER_TALENT,
+  STAGGERING_STRIKES_BREWMASTER_TALENT,
+  GRACEFUL_EXIT_BREWMASTER_TALENT,
+  ZEN_MEDITATION_BREWMASTER_TALENT,
+  CLASH_BREWMASTER_TALENT,
+  BREATH_OF_FIRE_BREWMASTER_TALENT,
+  STRENGTH_OF_SPIRIT_BREWMASTER_TALENT,
+  GAI_PLINS_IMPERIAL_BREW_BREWMASTER_TALENT,
+  FUNDAMENTAL_OBSERVATION_BREWMASTER_TALENT,
+  SHADOWBOXING_TREADS_BREWMASTER_TALENT,
+  FLUIDITY_OF_MOTION_BREWMASTER_TALENT,
+  SCALDING_BREW_BREWMASTER_TALENT,
+  SALSALABIMS_STRENGTH_BREWMASTER_TALENT,
+  FORTIFYING_BREW_BREWMASTER_TALENT,
+  BLACK_OX_BREW_BREWMASTER_TALENT,
+  BOB_AND_WEAVE_BREWMASTER_TALENT,
+  INVOKE_NIUZAO_THE_BLACK_OX_BREWMASTER_TALENT,
+  LIGHT_BREWING_BREWMASTER_TALENT,
+  TRAINING_OF_NIUZAO_BREWMASTER_TALENT,
+  SHOCKING_BLOW_NYI_BREWMASTER_TALENT,
+  FACE_PALM_BREWMASTER_TALENT,
+  DRAGONFIRE_BREW_BREWMASTER_TALENT,
+  CHARRED_PASSIONS_BREWMASTER_TALENT,
+  HIGH_TOLERANCE_BREWMASTER_TALENT,
+  WALK_WITH_THE_OX_BREWMASTER_TALENT,
+  ELUSIVE_FOOTWORK_BREWMASTER_TALENT,
+  ANVIL__STAVE_BREWMASTER_TALENT,
+  COUNTERSTRIKE_BREWMASTER_TALENT,
+  BONEDUST_BREW_BREWMASTER_TALENT,
+  EXPLODING_KEG_BREWMASTER_TALENT,
+  BLACKOUT_COMBO_BREWMASTER_TALENT,
+  WEAPONS_OF_ORDER_BREWMASTER_TALENT,
+  BOUNTIFUL_BREW_BREWMASTER_TALENT,
+  ATTENUATION_BREWMASTER_TALENT,
+  STORMSTOUTS_LAST_KEG_BREWMASTER_TALENT,
+  CALL_TO_ARMS_BREWMASTER_TALENT,
+  EFFUSIVE_ANIMA_ACCELERATOR_BREWMASTER_TALENT,
 
   //Mistweaver
-  ENVELOPING_MIST_MISTWEAVER_TALENT: {
-    id: 124682,
-    name: 'Enveloping Mist',
-    icon: 'spell_monk_envelopingmist',
-    maxRanks: 1,
-    manaCost: 2500,
-  },
-  ESSENCE_FONT_MISTWEAVER_TALENT: {
-    id: 191837,
-    name: 'Essence Font',
-    icon: 'ability_monk_essencefont',
-    maxRanks: 1,
-    manaCost: 3500,
-  },
-  RENEWING_MIST_MISTWEAVER_TALENT: {
-    id: 115151,
-    name: 'Renewing Mist',
-    icon: 'ability_monk_renewingmists',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  LIFE_COCOON_MISTWEAVER_TALENT: {
-    id: 116849,
-    name: 'Life Cocoon',
-    icon: 'ability_monk_chicocoon',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  THUNDER_FOCUS_TEA_MISTWEAVER_TALENT: {
-    id: 116680,
-    name: 'Thunder Focus Tea',
-    icon: 'ability_monk_thunderfocustea',
-    maxRanks: 1,
-  },
-  INVIGORATING_MISTS_MISTWEAVER_TALENT: {
-    id: 274586,
-    name: 'Invigorating Mists',
-    icon: 'ability_monk_vivify',
-    maxRanks: 1,
-  },
-  TEACHINGS_OF_THE_MONASTERY_MISTWEAVER_TALENT: {
-    id: 116645,
-    name: 'Teachings of the Monastery',
-    icon: 'passive_monk_teachingsofmonastery',
-    maxRanks: 1,
-  },
-  REVIVAL_MISTWEAVER_TALENT: {
-    id: 115310,
-    name: 'Revival',
-    icon: 'spell_monk_revival',
-    maxRanks: 1,
-    manaCost: 2000,
-  },
-  RESTORAL_MISTWEAVER_TALENT: {
-    id: 388615,
-    name: 'Restoral',
-    icon: 'spell_monk_revival',
-    maxRanks: 1,
-    manaCost: 2000,
-  },
-  SONG_OF_CHI_JI_MISTWEAVER_TALENT: {
-    id: 198898,
-    name: 'Song of Chi-Ji',
-    icon: 'inv_chaos_orb',
-    maxRanks: 1,
-  },
-  MASTERY_OF_MIST_MISTWEAVER_TALENT: {
-    id: 281231,
-    name: 'Mastery of Mist',
-    icon: 'ability_monk_renewingmists',
-    maxRanks: 1,
-  },
-  SPIRIT_OF_THE_CRANE_MISTWEAVER_TALENT: {
-    id: 210802,
-    name: 'Spirit of the Crane',
-    icon: 'monk_stance_redcrane',
-    maxRanks: 1,
-  },
-  MISTS_OF_LIFE_MISTWEAVER_TALENT: {
-    id: 388548,
-    name: 'Mists of Life',
-    icon: 'ability_monk_chicocoon',
-    maxRanks: 1,
-  },
-  UPLIFTED_SPIRITS_MISTWEAVER_TALENT: {
-    id: 388551,
-    name: 'Uplifted Spirits',
-    icon: 'spell_monk_revival',
-    maxRanks: 1,
-  },
-  FONT_OF_LIFE_MISTWEAVER_TALENT: {
-    id: 337209,
-    name: 'Font of Life',
-    icon: 'ability_monk_essencefont',
-    maxRanks: 1,
-  },
-  ZEN_PULSE_MISTWEAVER_TALENT: {
-    id: 124081,
-    name: 'Zen Pulse',
-    icon: 'ability_monk_forcesphere',
-    maxRanks: 1,
-  },
-  HEALING_ELIXIR_MISTWEAVER_TALENT: {
-    id: 122281,
-    name: 'Healing Elixir',
-    icon: 'ability_monk_jasmineforcetea',
-    maxRanks: 1,
-  },
-  NOURISHING_CHI_MISTWEAVER_TALENT: {
-    id: 387765,
-    name: 'Nourishing Chi',
-    icon: 'inv_misc_gem_pearl_06',
-    maxRanks: 1,
-  },
-  PEACEFUL_MENDING_MISTWEAVER_TALENT: {
-    id: 388593,
-    name: 'Peaceful Mending',
-    icon: 'ability_monk_surgingmist',
-    maxRanks: 2,
-  },
-  INVOKE_YULON_THE_JADE_SERPENT_MISTWEAVER_TALENT: {
-    id: 322118,
-    name: "Invoke Yu'lon, the Jade Serpent",
-    icon: 'ability_monk_dragonkick',
-    maxRanks: 1,
-    manaCost: 2500,
-  },
-  INVOKE_CHI_JI_THE_RED_CRANE_MISTWEAVER_TALENT: {
-    id: 325197,
-    name: 'Invoke Chi-Ji, the Red Crane',
-    icon: 'inv_pet_cranegod',
-    maxRanks: 1,
-    manaCost: 2500,
-  },
-  ZEN_REVERBERATION_MISTWEAVER_TALENT: {
-    id: 388604,
-    name: 'Zen Reverberation',
-    icon: 'spell_monk_nimblebrew',
-    maxRanks: 1,
-  },
-  ACCUMULATING_MIST_MISTWEAVER_TALENT: {
-    id: 388564,
-    name: 'Accumulating Mist',
-    icon: 'ability_monk_zenmeditation',
-    maxRanks: 1,
-  },
-  RAPID_DIFFUSION_MISTWEAVER_TALENT: {
-    id: 388847,
-    name: 'Rapid Diffusion',
-    icon: 'ability_monk_chiswirl',
-    maxRanks: 2,
-  },
-  CALMING_COALESCENCE_MISTWEAVER_TALENT: {
-    id: 388218,
-    name: 'Calming Coalescence',
-    icon: 'ability_monk_healthsphere',
-    maxRanks: 1,
-  },
-  YULONS_WHISPER_MISTWEAVER_TALENT: {
-    id: 388038,
-    name: "Yu'lon's Whisper",
-    icon: 'ability_monk_dragonkick',
-    maxRanks: 1,
-  },
-  MIST_WRAP_MISTWEAVER_TALENT: {
-    id: 197900,
-    name: 'Mist Wrap',
-    icon: 'ability_monk_pathofmists',
-    maxRanks: 1,
-  },
-  REFRESHING_JADE_WIND_MISTWEAVER_TALENT: {
-    id: 196725,
-    name: 'Refreshing Jade Wind',
-    icon: 'ability_monk_rushingjadewind',
-    maxRanks: 1,
-    manaCost: 1500,
-  },
-  ENVELOPING_BREATH_MISTWEAVER_TALENT: {
-    id: 343655,
-    name: 'Enveloping Breath',
-    icon: 'ability_monk_dragonkick',
-    maxRanks: 1,
-  },
-  DANCING_MISTS_MISTWEAVER_TALENT: {
-    id: 388701,
-    name: 'Dancing Mists',
-    icon: 'ability_monk_souldance',
-    maxRanks: 2,
-  },
-  LIFECYCLES_MISTWEAVER_TALENT: {
-    id: 197915,
-    name: 'Lifecycles',
-    icon: 'ability_monk_souldance',
-    maxRanks: 1,
-  },
-  MANA_TEA_MISTWEAVER_TALENT: {
-    id: 197908,
-    name: 'Mana Tea',
-    icon: 'monk_ability_cherrymanatea',
-    maxRanks: 1,
-  },
-  FAELINE_STOMP_MISTWEAVER_TALENT: {
-    id: 388193,
-    name: 'Faeline Stomp',
-    icon: 'ability_ardenweald_monk',
-    maxRanks: 1,
-    manaCost: 2000,
-  },
-  ANCIENT_TEACHINGS_OF_THE_MONASTERY_MISTWEAVER_TALENT: {
-    id: 388023,
-    name: 'Ancient Teachings of the Monastery',
-    icon: 'passive_monk_teachingsofmonastery',
-    maxRanks: 1,
-  },
-  CLOUDED_FOCUS_MISTWEAVER_TALENT: {
-    id: 388047,
-    name: 'Clouded Focus',
-    icon: 'ability_monk_soothingmists',
-    maxRanks: 1,
-  },
-  JADE_BOND_MISTWEAVER_TALENT: {
-    id: 388031,
-    name: 'Jade Bond',
-    icon: 'inv_inscription_deck_jadeserpent',
-    maxRanks: 1,
-  },
-  GIFT_OF_THE_CELESTIALS_MISTWEAVER_TALENT: {
-    id: 388212,
-    name: 'Gift of the Celestials',
-    icon: 'inv_pet_jadeserpentpet',
-    maxRanks: 1,
-  },
-  FOCUSED_THUNDER_MISTWEAVER_TALENT: {
-    id: 197895,
-    name: 'Focused Thunder',
-    icon: 'spell_monk_nimblebrew',
-    maxRanks: 1,
-  },
-  UPWELLING_MISTWEAVER_TALENT: {
-    id: 274963,
-    name: 'Upwelling',
-    icon: 'ability_monk_surgingmist',
-    maxRanks: 1,
-  },
-  BONEDUST_BREW_MISTWEAVER_TALENT: {
-    id: 386276,
-    name: 'Bonedust Brew',
-    icon: 'ability_maldraxxus_monk',
-    maxRanks: 1,
-  },
-  ANCIENT_CONCORDANCE_MISTWEAVER_TALENT: {
-    id: 388740,
-    name: 'Ancient Concordance',
-    icon: 'spell_animaardenweald_beam',
-    maxRanks: 2,
-  },
-  OVERFLOWING_MISTS_MISTWEAVER_TALENT: {
-    id: 388511,
-    name: 'Overflowing Mists',
-    icon: 'spell_monk_envelopingmist',
-    maxRanks: 2,
-  },
-  SECRET_INFUSION_MISTWEAVER_TALENT: {
-    id: 388491,
-    name: 'Secret Infusion',
-    icon: 'ability_monk_thunderfocustea',
-    maxRanks: 2,
-  },
-  MISTY_PEAKS_MISTWEAVER_TALENT: {
-    id: 388682,
-    name: 'Misty Peaks',
-    icon: 'ability_monk_renewingmists',
-    maxRanks: 2,
-  },
-  RESPLENDENT_MIST_MISTWEAVER_TALENT: {
-    id: 388020,
-    name: 'Resplendent Mist',
-    icon: 'spell_nature_abolishmagic',
-    maxRanks: 2,
-  },
-  AWAKENED_FAELINE_MISTWEAVER_TALENT: {
-    id: 388779,
-    name: 'Awakened Faeline',
-    icon: 'ability_ardenweald_monk',
-    maxRanks: 1,
-  },
-  RESTORATIVE_PROLIFERATION_MISTWEAVER_TALENT: {
-    id: 388509,
-    name: 'Restorative Proliferation',
-    icon: 'ability_monk_souldance',
-    maxRanks: 1,
-  },
-  TEA_OF_PLENTY_MISTWEAVER_TALENT: {
-    id: 388517,
-    name: 'Tea of Plenty',
-    icon: 'inv_misc_pearlmilktea',
-    maxRanks: 1,
-  },
-  UNISON_MISTWEAVER_TALENT: {
-    id: 388477,
-    name: 'Unison',
-    icon: 'ability_creature_cursed_04',
-    maxRanks: 1,
-  },
-  INVOKERS_DELIGHT_MISTWEAVER_TALENT: {
-    id: 388661,
-    name: "Invoker's Delight",
-    icon: 'inv_inscription_80_warscroll_battleshout',
-    maxRanks: 1,
-  },
-  TEAR_OF_MORNING_MISTWEAVER_TALENT: {
-    id: 387991,
-    name: 'Tear of Morning',
-    icon: 'ability_monk_uplift',
-    maxRanks: 1,
-  },
-  RISING_MIST_MISTWEAVER_TALENT: {
-    id: 274909,
-    name: 'Rising Mist',
-    icon: 'ability_monk_effuse',
-    maxRanks: 1,
-  },
-  BOUNTIFUL_BREW_MISTWEAVER_TALENT: {
-    id: 386949,
-    name: 'Bountiful Brew',
-    icon: 'ability_maldraxxus_monk',
-    maxRanks: 1,
-  },
-  ATTENUATION_MISTWEAVER_TALENT: {
-    id: 386941,
-    name: 'Attenuation',
-    icon: 'spell_animamaldraxxus_nova',
-    maxRanks: 1,
-  },
+  ENVELOPING_MIST_MISTWEAVER_TALENT,
+  ESSENCE_FONT_MISTWEAVER_TALENT,
+  RENEWING_MIST_MISTWEAVER_TALENT,
+  LIFE_COCOON_MISTWEAVER_TALENT,
+  THUNDER_FOCUS_TEA_MISTWEAVER_TALENT,
+  INVIGORATING_MISTS_MISTWEAVER_TALENT,
+  TEACHINGS_OF_THE_MONASTERY_MISTWEAVER_TALENT,
+  REVIVAL_MISTWEAVER_TALENT,
+  RESTORAL_MISTWEAVER_TALENT,
+  SONG_OF_CHI_JI_MISTWEAVER_TALENT,
+  MASTERY_OF_MIST_MISTWEAVER_TALENT,
+  SPIRIT_OF_THE_CRANE_MISTWEAVER_TALENT,
+  MISTS_OF_LIFE_MISTWEAVER_TALENT,
+  UPLIFTED_SPIRITS_MISTWEAVER_TALENT,
+  FONT_OF_LIFE_MISTWEAVER_TALENT,
+  ZEN_PULSE_MISTWEAVER_TALENT,
+  HEALING_ELIXIR_MISTWEAVER_TALENT,
+  NOURISHING_CHI_MISTWEAVER_TALENT,
+  PEACEFUL_MENDING_MISTWEAVER_TALENT,
+  INVOKE_YULON_THE_JADE_SERPENT_MISTWEAVER_TALENT,
+  INVOKE_CHI_JI_THE_RED_CRANE_MISTWEAVER_TALENT,
+  ZEN_REVERBERATION_MISTWEAVER_TALENT,
+  ACCUMULATING_MIST_MISTWEAVER_TALENT,
+  RAPID_DIFFUSION_MISTWEAVER_TALENT,
+  CALMING_COALESCENCE_MISTWEAVER_TALENT,
+  YULONS_WHISPER_MISTWEAVER_TALENT,
+  MIST_WRAP_MISTWEAVER_TALENT,
+  REFRESHING_JADE_WIND_MISTWEAVER_TALENT,
+  ENVELOPING_BREATH_MISTWEAVER_TALENT,
+  DANCING_MISTS_MISTWEAVER_TALENT,
+  LIFECYCLES_MISTWEAVER_TALENT,
+  MANA_TEA_MISTWEAVER_TALENT,
+  FAELINE_STOMP_MISTWEAVER_TALENT,
+  ANCIENT_TEACHINGS_OF_THE_MONASTERY_MISTWEAVER_TALENT,
+  CLOUDED_FOCUS_MISTWEAVER_TALENT,
+  JADE_BOND_MISTWEAVER_TALENT,
+  GIFT_OF_THE_CELESTIALS_MISTWEAVER_TALENT,
+  FOCUSED_THUNDER_MISTWEAVER_TALENT,
+  UPWELLING_MISTWEAVER_TALENT,
+  BONEDUST_BREW_MISTWEAVER_TALENT,
+  ANCIENT_CONCORDANCE_MISTWEAVER_TALENT,
+  OVERFLOWING_MISTS_MISTWEAVER_TALENT,
+  SECRET_INFUSION_MISTWEAVER_TALENT,
+  MISTY_PEAKS_MISTWEAVER_TALENT,
+  RESPLENDENT_MIST_MISTWEAVER_TALENT,
+  AWAKENED_FAELINE_MISTWEAVER_TALENT,
+  RESTORATIVE_PROLIFERATION_MISTWEAVER_TALENT,
+  TEA_OF_PLENTY_MISTWEAVER_TALENT,
+  UNISON_MISTWEAVER_TALENT,
+  INVOKERS_DELIGHT_MISTWEAVER_TALENT,
+  TEAR_OF_MORNING_MISTWEAVER_TALENT,
+  RISING_MIST_MISTWEAVER_TALENT,
+  BOUNTIFUL_BREW_MISTWEAVER_TALENT,
+  ATTENUATION_MISTWEAVER_TALENT,
 
   //Windwalker
-  FISTS_OF_FURY_WINDWALKER_TALENT: {
-    id: 113656,
-    name: 'Fists of Fury',
-    icon: 'monk_ability_fistoffury',
-    maxRanks: 1,
-    chiCost: 3,
-  },
-  TOUCH_OF_KARMA_WINDWALKER_TALENT: {
-    id: 122470,
-    name: 'Touch of Karma',
-    icon: 'ability_monk_touchofkarma',
-    maxRanks: 1,
-  },
-  ASCENSION_WINDWALKER_TALENT: {
-    id: 115396,
-    name: 'Ascension',
-    icon: 'ability_monk_ascension',
-    maxRanks: 1,
-  },
-  POWER_STRIKES_WINDWALKER_TALENT: {
-    id: 121817,
-    name: 'Power Strikes',
-    icon: 'ability_monk_powerstrikes',
-    maxRanks: 1,
-  },
-  FEATHERS_OF_A_HUNDRED_FLOCKS_WINDWALKER_TALENT: {
-    id: 388846,
-    name: 'Feathers of a Hundred Flocks',
-    icon: 'ability_monk_forcesphere_pink',
-    maxRanks: 1,
-  },
-  TOUCH_OF_THE_TIGER_WINDWALKER_TALENT: {
-    id: 388856,
-    name: 'Touch of the Tiger',
-    icon: 'ability_monk_tigerpalm',
-    maxRanks: 2,
-  },
-  HARDENED_SOLES_WINDWALKER_TALENT: {
-    id: 391383,
-    name: 'Hardened Soles',
-    icon: 'ability_monk_roundhousekick',
-    maxRanks: 2,
-  },
-  FLASHING_FISTS_WINDWALKER_TALENT: {
-    id: 388854,
-    name: 'Flashing Fists',
-    icon: 'monk_ability_fistoffury',
-    maxRanks: 2,
-  },
-  OPEN_PALM_STRIKES_WINDWALKER_TALENT: {
-    id: 279918,
-    name: 'Open Palm Strikes',
-    icon: 'monk_ability_fistoffury',
-    maxRanks: 1,
-  },
-  MARK_OF_THE_CRANE_WINDWALKER_TALENT: {
-    id: 228287,
-    name: 'Mark of the Crane',
-    icon: 'ability_monk_cranekick_new',
-    maxRanks: 1,
-  },
-  FLYING_SERPENT_KICK_WINDWALKER_TALENT: {
-    id: 101545,
-    name: 'Flying Serpent Kick',
-    icon: 'ability_monk_flyingdragonkick',
-    maxRanks: 1,
-  },
-  GLORY_OF_THE_DAWN_WINDWALKER_TALENT: {
-    id: 288634,
-    name: 'Glory of the Dawn',
-    icon: 'ability_monk_mightyoxkick',
-    maxRanks: 1,
-  },
-  SHADOWBOXING_TREADS_WINDWALKER_TALENT: {
-    id: 331512,
-    name: 'Shadowboxing Treads',
-    icon: 'ability_monk_roundhousekick',
-    maxRanks: 1,
-  },
-  INNER_PEACE_WINDWALKER_TALENT: {
-    id: 195243,
-    name: 'Inner Peace',
-    icon: 'ability_monk_jasmineforcetea',
-    maxRanks: 1,
-  },
-  STORM_EARTH_AND_FIRE_WINDWALKER_TALENT: {
-    id: 137639,
-    name: 'Storm, Earth, and Fire',
-    icon: 'spell_nature_giftofthewild',
-    maxRanks: 1,
-  },
-  SERENITY_WINDWALKER_TALENT: {
-    id: 152173,
-    name: 'Serenity',
-    icon: 'ability_monk_serenity',
-    maxRanks: 1,
-  },
-  MERIDIAN_STRIKES_WINDWALKER_TALENT: {
-    id: 391330,
-    name: 'Meridian Strikes',
-    icon: 'ability_monk_touchofdeath',
-    maxRanks: 1,
-  },
-  JADE_IGNITION_WINDWALKER_TALENT: {
-    id: 337483,
-    name: 'Jade Ignition',
-    icon: 'ability_monk_chiexplosion',
-    maxRanks: 1,
-  },
-  DANCE_OF_CHI_JI_WINDWALKER_TALENT: {
-    id: 325201,
-    name: 'Dance of Chi-Ji',
-    icon: 'ability_monk_cranekick_new',
-    maxRanks: 1,
-  },
-  HIT_COMBO_WINDWALKER_TALENT: {
-    id: 196740,
-    name: 'Hit Combo',
-    icon: 'ability_monk_palmstrike',
-    maxRanks: 1,
-  },
-  DRINKING_HORN_COVER_WINDWALKER_TALENT: {
-    id: 391370,
-    name: 'Drinking Horn Cover',
-    icon: 'ability_warrior_unrelentingassault',
-    maxRanks: 1,
-  },
-  SPIRITUAL_FOCUS_WINDWALKER_TALENT: {
-    id: 280197,
-    name: 'Spiritual Focus',
-    icon: 'spell_nature_giftofthewild',
-    maxRanks: 1,
-  },
-  STRIKE_OF_THE_WINDLORD_WINDWALKER_TALENT: {
-    id: 205320,
-    name: 'Strike of the Windlord',
-    icon: 'inv_hand_1h_artifactskywall_d_01',
-    maxRanks: 1,
-    chiCost: 2,
-  },
-  RUSHING_JADE_WIND_WINDWALKER_TALENT: {
-    id: 116847,
-    name: 'Rushing Jade Wind',
-    icon: 'ability_monk_rushingjadewind',
-    maxRanks: 1,
-    chiCost: 1,
-  },
-  HIDDEN_MASTERS_FORBIDDEN_TOUCH_WINDWALKER_TALENT: {
-    id: 213112,
-    name: "Hidden Master's Forbidden Touch",
-    icon: 'ability_monk_touchofdeath',
-    maxRanks: 1,
-  },
-  INVOKE_XUEN_THE_WHITE_TIGER_WINDWALKER_TALENT: {
-    id: 123904,
-    name: 'Invoke Xuen, the White Tiger',
-    icon: 'ability_monk_summontigerstatue',
-    maxRanks: 1,
-  },
-  TEACHINGS_OF_THE_MONASTERY_WINDWALKER_TALENT: {
-    id: 116645,
-    name: 'Teachings of the Monastery',
-    icon: 'passive_monk_teachingsofmonastery',
-    maxRanks: 1,
-  },
-  THUNDERFIST_WINDWALKER_TALENT: {
-    id: 238131,
-    name: 'Thunderfist',
-    icon: 'inv_hand_1h_artifactskywall_d_01',
-    maxRanks: 1,
-  },
-  CRANE_VORTEX_WINDWALKER_TALENT: {
-    id: 388848,
-    name: 'Crane Vortex',
-    icon: 'ability_monk_cranekick_new',
-    maxRanks: 2,
-  },
-  XUENS_BOND_WINDWALKER_TALENT: {
-    id: 336616,
-    name: "Xuen's Bond",
-    icon: 'ability_demonhunter_netherbond',
-    maxRanks: 1,
-  },
-  FURY_OF_XUEN_WINDWALKER_TALENT: {
-    id: 287055,
-    name: 'Fury of Xuen',
-    icon: 'ability_monk_prideofthetiger',
-    maxRanks: 1,
-  },
-  EMPOWERED_TIGER_LIGHTNING_WINDWALKER_TALENT: {
-    id: 335913,
-    name: 'Empowered Tiger Lightning',
-    icon: 'ability_monk_summontigerstatue',
-    maxRanks: 1,
-  },
-  RISING_STAR_WINDWALKER_TALENT: {
-    id: 388849,
-    name: 'Rising Star',
-    icon: 'ability_monk_risingsunkick',
-    maxRanks: 2,
-  },
-  BONEDUST_BREW_WINDWALKER_TALENT: {
-    id: 325216,
-    name: 'Bonedust Brew',
-    icon: 'ability_maldraxxus_monk',
-    maxRanks: 1,
-  },
-  FATAL_FLYING_GUILLOTINE_WINDWALKER_TALENT: {
-    id: 331679,
-    name: 'Fatal Flying Guillotine',
-    icon: 'ability_monk_touchofdeath',
-    maxRanks: 1,
-  },
-  LAST_EMPERORS_CAPACITOR_WINDWALKER_TALENT: {
-    id: 337292,
-    name: "Last Emperor's Capacitor",
-    icon: 'ability_warrior_unrelentingassault',
-    maxRanks: 1,
-  },
-  XUENS_BATTLEGEAR_WINDWALKER_TALENT: {
-    id: 337481,
-    name: "Xuen's Battlegear",
-    icon: 'monk_stance_whitetiger',
-    maxRanks: 1,
-  },
-  TRANSFER_THE_POWER_WINDWALKER_TALENT: {
-    id: 195300,
-    name: 'Transfer the Power',
-    icon: 'monk_ability_fistoffury',
-    maxRanks: 1,
-  },
-  WHIRLING_DRAGON_PUNCH_WINDWALKER_TALENT: {
-    id: 152175,
-    name: 'Whirling Dragon Punch',
-    icon: 'ability_monk_hurricanestrike',
-    maxRanks: 1,
-  },
-  FAELINE_STOMP_WINDWALKER_TALENT: {
-    id: 388193,
-    name: 'Faeline Stomp',
-    icon: 'ability_ardenweald_monk',
-    maxRanks: 1,
-    manaCost: 2000,
-  },
-  CALCULATED_STRIKES_WINDWALKER_TALENT: {
-    id: 336526,
-    name: 'Calculated Strikes',
-    icon: 'spell_magic_lesserinvisibilty',
-    maxRanks: 1,
-  },
-  BONE_MARROW_HOPS_WINDWALKER_TALENT: {
-    id: 337295,
-    name: 'Bone Marrow Hops',
-    icon: 'spell_animamaldraxxus_nova',
-    maxRanks: 1,
-  },
-  KEEFERS_SKYREACH_WINDWALKER_TALENT: {
-    id: 337334,
-    name: "Keefer's Skyreach",
-    icon: 'inv__fistofthewhitetiger',
-    maxRanks: 1,
-  },
-  INVOKERS_DELIGHT_WINDWALKER_TALENT: {
-    id: 388661,
-    name: "Invoker's Delight",
-    icon: 'inv_inscription_80_warscroll_battleshout',
-    maxRanks: 1,
-  },
-  WAY_OF_THE_FAE_WINDWALKER_TALENT: {
-    id: 337303,
-    name: 'Way of the Fae',
-    icon: 'spell_animaardenweald_beam',
-    maxRanks: 1,
-  },
-  FAELINE_HARMONY_WINDWALKER_TALENT: {
-    id: 391412,
-    name: 'Faeline Harmony',
-    icon: 'ability_ardenweald_monk',
-    maxRanks: 1,
-  },
+  FISTS_OF_FURY_WINDWALKER_TALENT,
+  TOUCH_OF_KARMA_WINDWALKER_TALENT,
+  ASCENSION_WINDWALKER_TALENT,
+  POWER_STRIKES_WINDWALKER_TALENT,
+  FEATHERS_OF_A_HUNDRED_FLOCKS_WINDWALKER_TALENT,
+  TOUCH_OF_THE_TIGER_WINDWALKER_TALENT,
+  HARDENED_SOLES_WINDWALKER_TALENT,
+  FLASHING_FISTS_WINDWALKER_TALENT,
+  OPEN_PALM_STRIKES_WINDWALKER_TALENT,
+  MARK_OF_THE_CRANE_WINDWALKER_TALENT,
+  FLYING_SERPENT_KICK_WINDWALKER_TALENT,
+  GLORY_OF_THE_DAWN_WINDWALKER_TALENT,
+  SHADOWBOXING_TREADS_WINDWALKER_TALENT,
+  INNER_PEACE_WINDWALKER_TALENT,
+  STORM_EARTH_AND_FIRE_WINDWALKER_TALENT,
+  SERENITY_WINDWALKER_TALENT,
+  MERIDIAN_STRIKES_WINDWALKER_TALENT,
+  JADE_IGNITION_WINDWALKER_TALENT,
+  DANCE_OF_CHI_JI_WINDWALKER_TALENT,
+  HIT_COMBO_WINDWALKER_TALENT,
+  DRINKING_HORN_COVER_WINDWALKER_TALENT,
+  SPIRITUAL_FOCUS_WINDWALKER_TALENT,
+  STRIKE_OF_THE_WINDLORD_WINDWALKER_TALENT,
+  RUSHING_JADE_WIND_WINDWALKER_TALENT,
+  HIDDEN_MASTERS_FORBIDDEN_TOUCH_WINDWALKER_TALENT,
+  INVOKE_XUEN_THE_WHITE_TIGER_WINDWALKER_TALENT,
+  TEACHINGS_OF_THE_MONASTERY_WINDWALKER_TALENT,
+  THUNDERFIST_WINDWALKER_TALENT,
+  CRANE_VORTEX_WINDWALKER_TALENT,
+  XUENS_BOND_WINDWALKER_TALENT,
+  FURY_OF_XUEN_WINDWALKER_TALENT,
+  EMPOWERED_TIGER_LIGHTNING_WINDWALKER_TALENT,
+  RISING_STAR_WINDWALKER_TALENT,
+  BONEDUST_BREW_WINDWALKER_TALENT,
+  FATAL_FLYING_GUILLOTINE_WINDWALKER_TALENT,
+  LAST_EMPERORS_CAPACITOR_WINDWALKER_TALENT,
+  XUENS_BATTLEGEAR_WINDWALKER_TALENT,
+  TRANSFER_THE_POWER_WINDWALKER_TALENT,
+  WHIRLING_DRAGON_PUNCH_WINDWALKER_TALENT,
+  FAELINE_STOMP_WINDWALKER_TALENT,
+  CALCULATED_STRIKES_WINDWALKER_TALENT,
+  BONE_MARROW_HOPS_WINDWALKER_TALENT,
+  KEEFERS_SKYREACH_WINDWALKER_TALENT,
+  INVOKERS_DELIGHT_WINDWALKER_TALENT,
+  WAY_OF_THE_FAE_WINDWALKER_TALENT,
+  FAELINE_HARMONY_WINDWALKER_TALENT,
 });
 
 export default talents;

--- a/src/common/TALENTS/paladin.ts
+++ b/src/common/TALENTS/paladin.ts
@@ -1,1127 +1,1341 @@
 // Generated file, changes will eventually be overwritten!
-import { createTalentList } from './types';
+import { createTalentList, Talent } from './types';
+
+//region Shared
+export const LAY_ON_HANDS_TALENT: Talent = {
+  id: 633,
+  name: 'Lay on Hands',
+  icon: 'spell_holy_layonhands',
+  maxRanks: 1,
+};
+export const BLESSING_OF_FREEDOM_TALENT: Talent = {
+  id: 1044,
+  name: 'Blessing of Freedom',
+  icon: 'spell_holy_sealofvalor',
+  maxRanks: 1,
+  manaCost: 700,
+};
+export const HAMMER_OF_WRATH_TALENT: Talent = {
+  id: 24275,
+  name: 'Hammer of Wrath',
+  icon: 'spell_paladin_hammerofwrath',
+  maxRanks: 1,
+};
+export const AURAS_OF_THE_RESOLUTE_TALENT: Talent = {
+  id: 385633,
+  name: 'Auras of the Resolute',
+  icon: 'spell_holy_devotionaura',
+  maxRanks: 1,
+};
+export const AURAS_OF_SWIFT_VENGEANCE_TALENT: Talent = {
+  id: 385639,
+  name: 'Auras of Swift Vengeance',
+  icon: 'spell_holy_crusade',
+  maxRanks: 1,
+};
+export const REPENTANCE_TALENT: Talent = {
+  id: 20066,
+  name: 'Repentance',
+  icon: 'spell_holy_prayerofhealing',
+  maxRanks: 1,
+  manaCost: 600,
+};
+export const BLINDING_LIGHT_TALENT: Talent = {
+  id: 115750,
+  name: 'Blinding Light',
+  icon: 'ability_paladin_blindinglight',
+  maxRanks: 1,
+  manaCost: 600,
+};
+export const DIVINE_STEED_TALENT: Talent = {
+  id: 190784,
+  name: 'Divine Steed',
+  icon: 'ability_paladin_divinesteed',
+  maxRanks: 1,
+};
+export const FIST_OF_JUSTICE_TALENT: Talent = {
+  id: 234299,
+  name: 'Fist of Justice',
+  icon: 'spell_holy_fistofjustice',
+  maxRanks: 2,
+};
+export const CLEANSE_TOXINS_TALENT: Talent = {
+  id: 213644,
+  name: 'Cleanse Toxins',
+  icon: 'spell_holy_renew',
+  maxRanks: 1,
+  manaCost: 600,
+};
+export const CAVALIER_TALENT: Talent = {
+  id: 230332,
+  name: 'Cavalier',
+  icon: 'ability_paladin_divinesteed',
+  maxRanks: 1,
+};
+export const SEASONED_WARHORSE_TALENT: Talent = {
+  id: 376996,
+  name: 'Seasoned Warhorse',
+  icon: 'spell_nature_swiftness',
+  maxRanks: 2,
+};
+export const JUDGMENT_TALENT: Talent = {
+  id: 231663,
+  name: 'Judgment',
+  icon: 'spell_holy_righteousfury',
+  maxRanks: 1,
+};
+export const HOLY_AEGIS_TALENT: Talent = {
+  id: 385515,
+  name: 'Holy Aegis',
+  icon: 'spell_holy_divineprotection',
+  maxRanks: 2,
+};
+export const AVENGING_WRATH_TALENT: Talent = {
+  id: 384376,
+  name: 'Avenging Wrath',
+  icon: 'spell_holy_avenginewrath',
+  maxRanks: 1,
+};
+export const SEAL_OF_THE_TEMPLAR_TALENT: Talent = {
+  id: 377016,
+  name: 'Seal of the Templar',
+  icon: 'ability_paladin_artofwar',
+  maxRanks: 1,
+};
+export const REBUKE_TALENT: Talent = {
+  id: 96231,
+  name: 'Rebuke',
+  icon: 'spell_holy_rebuke',
+  maxRanks: 1,
+};
+export const GOLDEN_PATH_TALENT: Talent = {
+  id: 377128,
+  name: 'Golden Path',
+  icon: 'ability_priest_cascade',
+  maxRanks: 1,
+};
+export const JUDGMENT_OF_LIGHT_TALENT: Talent = {
+  id: 183778,
+  name: 'Judgment of Light',
+  icon: 'spell_holy_divineprovidence',
+  maxRanks: 1,
+};
+export const BLESSING_OF_SACRIFICE_TALENT: Talent = {
+  id: 6940,
+  name: 'Blessing of Sacrifice',
+  icon: 'spell_holy_sealofsacrifice',
+  maxRanks: 1,
+  manaCost: 700,
+};
+export const TURN_EVIL_TALENT: Talent = {
+  id: 10326,
+  name: 'Turn Evil',
+  icon: 'ability_paladin_turnevil',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const BLESSING_OF_PROTECTION_TALENT: Talent = {
+  id: 1022,
+  name: 'Blessing of Protection',
+  icon: 'spell_holy_sealofprotection',
+  maxRanks: 1,
+  manaCost: 1500,
+};
+export const SEAL_OF_REPRISAL_TALENT: Talent = {
+  id: 377053,
+  name: 'Seal of Reprisal',
+  icon: 'spell_holy_sealoffury',
+  maxRanks: 2,
+};
+export const SEAL_OF_MERCY_TALENT: Talent = {
+  id: 384897,
+  name: 'Seal of Mercy',
+  icon: 'spell_holy_greaterblessingofsalvation',
+  maxRanks: 2,
+};
+export const AFTERIMAGE_TALENT: Talent = {
+  id: 385414,
+  name: 'Afterimage',
+  icon: 'spell_holy_aspiration',
+  maxRanks: 1,
+};
+export const SACRIFICE_OF_THE_JUST_TALENT: Talent = {
+  id: 384820,
+  name: 'Sacrifice of the Just',
+  icon: 'spell_holy_sealofsacrifice',
+  maxRanks: 1,
+};
+export const RECOMPENSE_TALENT: Talent = {
+  id: 384914,
+  name: 'Recompense',
+  icon: 'ability_racial_foregedinflames',
+  maxRanks: 1,
+};
+export const UNBREAKABLE_SPIRIT_TALENT: Talent = {
+  id: 114154,
+  name: 'Unbreakable Spirit',
+  icon: 'spell_holy_holyguidance',
+  maxRanks: 1,
+};
+export const IMPROVED_BLESSING_OF_PROTECTION_TALENT: Talent = {
+  id: 384909,
+  name: 'Improved Blessing of Protection',
+  icon: 'spell_holy_sealofprotection',
+  maxRanks: 1,
+};
+export const BLESSING_OF_SPELLWARDING_TALENT: Talent = {
+  id: 204018,
+  name: 'Blessing of Spellwarding',
+  icon: 'spell_holy_blessingofprotection',
+  maxRanks: 1,
+  manaCost: 1500,
+};
+export const INCANDESCENCE_TALENT: Talent = {
+  id: 385464,
+  name: 'Incandescence',
+  icon: 'inv_summerfest_firespirit',
+  maxRanks: 1,
+};
+export const TOUCH_OF_LIGHT_TALENT: Talent = {
+  id: 385349,
+  name: 'Touch of Light',
+  icon: 'achievment_raid_houroftwilight',
+  maxRanks: 1,
+};
+export const SEAL_OF_CLARITY_TALENT: Talent = {
+  id: 384815,
+  name: 'Seal of Clarity',
+  icon: 'spell_priest_power_word',
+  maxRanks: 2,
+};
+export const ASPIRATIONS_OF_DIVINITY_TALENT: Talent = {
+  id: 385416,
+  name: 'Aspirations of Divinity',
+  icon: 'spell_holy_fanaticism',
+  maxRanks: 2,
+};
+export const DIVINE_PURPOSE_TALENT: Talent = {
+  id: 223817,
+  name: 'Divine Purpose',
+  icon: 'spell_holy_divinepurpose',
+  maxRanks: 1,
+};
+export const HOLY_AVENGER_TALENT: Talent = {
+  id: 105809,
+  name: 'Holy Avenger',
+  icon: 'ability_paladin_holyavenger',
+  maxRanks: 1,
+};
+export const OBDURACY_TALENT: Talent = {
+  id: 385427,
+  name: 'Obduracy',
+  icon: 'ability_paladin_speedoflight',
+  maxRanks: 1,
+};
+export const HALLOWED_GROUND_TALENT: Talent = {
+  id: 377043,
+  name: 'Hallowed Ground',
+  icon: 'ability_paladin_empoweredsealsrighteous',
+  maxRanks: 1,
+};
+export const OF_DUSK_AND_DAWN_TALENT: Talent = {
+  id: 385125,
+  name: 'Of Dusk and Dawn',
+  icon: 'spell_paladin_lightofdawn',
+  maxRanks: 1,
+};
+export const SEAL_OF_MIGHT_NYI_TALENT: Talent = {
+  id: 385450,
+  name: 'Seal of Might [NYI]',
+  icon: 'spell_holy_sealofwrath',
+  maxRanks: 2,
+};
+export const SEAL_OF_ALACRITY_TALENT: Talent = {
+  id: 385425,
+  name: 'Seal of Alacrity',
+  icon: 'spell_holy_sealofvengeance',
+  maxRanks: 2,
+};
+export const SEAL_OF_THE_CRUSADER_TALENT: Talent = {
+  id: 385728,
+  name: 'Seal of the Crusader',
+  icon: 'spell_holy_holysmite',
+  maxRanks: 2,
+};
+export const SEAL_OF_ORDER_TALENT: Talent = {
+  id: 385129,
+  name: 'Seal of Order',
+  icon: 'spell_holy_sealofwisdom',
+  maxRanks: 1,
+};
+export const SERAPHIM_TALENT: Talent = {
+  id: 152262,
+  name: 'Seraphim',
+  icon: 'ability_paladin_seraphim',
+  maxRanks: 1,
+  holyPowerCost: 3,
+};
+export const SANCTIFIED_WRATH_TALENT: Talent = {
+  id: 171648,
+  name: 'Sanctified Wrath',
+  icon: 'ability_paladin_judgementsofthejust',
+  maxRanks: 1,
+};
+export const THE_MAD_PARAGON_TALENT: Talent = {
+  id: 391142,
+  name: 'The Mad Paragon',
+  icon: 'ability_paladin_conviction',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Protection
+export const AVENGERS_SHIELD_PROTECTION_TALENT: Talent = {
+  id: 31935,
+  name: "Avenger's Shield",
+  icon: 'spell_holy_avengersshield',
+  maxRanks: 1,
+};
+export const HAMMER_OF_THE_RIGHTEOUS_PROTECTION_TALENT: Talent = {
+  id: 53595,
+  name: 'Hammer of the Righteous',
+  icon: 'ability_paladin_hammeroftherighteous',
+  maxRanks: 1,
+};
+export const BLESSED_HAMMER_PROTECTION_TALENT: Talent = {
+  id: 204019,
+  name: 'Blessed Hammer',
+  icon: 'paladin_retribution',
+  maxRanks: 1,
+};
+export const INNER_LIGHT_PROTECTION_TALENT: Talent = {
+  id: 386568,
+  name: 'Inner Light',
+  icon: 'ability_paladin_shieldofvengeance',
+  maxRanks: 1,
+};
+export const REDOUBT_PROTECTION_TALENT: Talent = {
+  id: 280373,
+  name: 'Redoubt',
+  icon: 'ability_warrior_shieldguard',
+  maxRanks: 1,
+};
+export const HOLY_SHIELD_PROTECTION_TALENT: Talent = {
+  id: 152261,
+  name: 'Holy Shield',
+  icon: 'inv_shield_1h_hyrja_d_01',
+  maxRanks: 1,
+};
+export const GRAND_CRUSADER_PROTECTION_TALENT: Talent = {
+  id: 85043,
+  name: 'Grand Crusader',
+  icon: 'inv_helmet_74',
+  maxRanks: 1,
+};
+export const SHINING_LIGHT_PROTECTION_TALENT: Talent = {
+  id: 321136,
+  name: 'Shining Light',
+  icon: 'ability_paladin_toweroflight',
+  maxRanks: 1,
+};
+export const CONSECRATED_GROUND_PROTECTION_TALENT: Talent = {
+  id: 204054,
+  name: 'Consecrated Ground',
+  icon: 'ability_paladin_righteousvengeance',
+  maxRanks: 1,
+};
+export const INSPIRING_VANGUARD_PROTECTION_TALENT: Talent = {
+  id: 279387,
+  name: 'Inspiring Vanguard',
+  icon: 'inv_helmet_74',
+  maxRanks: 1,
+};
+export const ARDENT_DEFENDER_PROTECTION_TALENT: Talent = {
+  id: 31850,
+  name: 'Ardent Defender',
+  icon: 'spell_holy_ardentdefender',
+  maxRanks: 1,
+};
+export const FAITH_BARRICADE_PROTECTION_TALENT: Talent = {
+  id: 385726,
+  name: 'Faith Barricade',
+  icon: 'ability_paladin_barrieroffaith',
+  maxRanks: 1,
+};
+export const CONSECRATION_IN_FLAME_PROTECTION_TALENT: Talent = {
+  id: 379022,
+  name: 'Consecration in Flame',
+  icon: 'spell_fire_sealoffire',
+  maxRanks: 1,
+};
+export const CRUSADERS_RESOLVE_PROTECTION_TALENT: Talent = {
+  id: 380188,
+  name: "Crusader's Resolve",
+  icon: 'ability_priest_angelicbulwark',
+  maxRanks: 2,
+};
+export const BULWARK_OF_ORDER_PROTECTION_TALENT: Talent = {
+  id: 209389,
+  name: 'Bulwark of Order',
+  icon: 'spell_holy_pureofheart',
+  maxRanks: 2,
+};
+export const LIGHT_OF_THE_TITANS_PROTECTION_TALENT: Talent = {
+  id: 378405,
+  name: 'Light of the Titans',
+  icon: 'spell_paladin_lightofdawn',
+  maxRanks: 2,
+};
+export const SANCTUARY_PROTECTION_TALENT: Talent = {
+  id: 379021,
+  name: 'Sanctuary',
+  icon: 'spell_holy_innerfire',
+  maxRanks: 2,
+};
+export const TYRS_ENFORCER_PROTECTION_TALENT: Talent = {
+  id: 378285,
+  name: "Tyr's Enforcer",
+  icon: 'inv_summerfest_firespirit',
+  maxRanks: 2,
+};
+export const RELENTLESS_INQUISITOR_PROTECTION_TALENT: Talent = {
+  id: 383388,
+  name: 'Relentless Inquisitor',
+  icon: 'spell_holy_divinepurpose',
+  maxRanks: 1,
+};
+export const AVENGING_WRATH_MIGHT_PROTECTION_TALENT: Talent = {
+  id: 384442,
+  name: 'Avenging Wrath: Might',
+  icon: 'spell_holy_avenginewrath',
+  maxRanks: 1,
+};
+export const SENTINEL_PROTECTION_TALENT: Talent = {
+  id: 385438,
+  name: 'Sentinel',
+  icon: 'spell_holy_holynova',
+  maxRanks: 1,
+};
+export const HAND_OF_THE_PROTECTOR_PROTECTION_TALENT: Talent = {
+  id: 315924,
+  name: 'Hand of the Protector',
+  icon: 'ability_paladin_blessedhands',
+  maxRanks: 1,
+};
+export const STRENGTH_OF_CONVICTION_PROTECTION_TALENT: Talent = {
+  id: 379008,
+  name: 'Strength of Conviction',
+  icon: 'spell_holy_eyeforaneye',
+  maxRanks: 2,
+};
+export const RESOLUTE_DEFENDER_PROTECTION_TALENT: Talent = {
+  id: 385422,
+  name: 'Resolute Defender',
+  icon: 'ability_crown_of_the_heavens_icon',
+  maxRanks: 1,
+};
+export const BASTION_OF_LIGHT_PROTECTION_TALENT: Talent = {
+  id: 378974,
+  name: 'Bastion of Light',
+  icon: 'paladin_protection',
+  maxRanks: 1,
+};
+export const GUARDIAN_OF_ANCIENT_KINGS_PROTECTION_TALENT: Talent = {
+  id: 86659,
+  name: 'Guardian of Ancient Kings',
+  icon: 'spell_holy_heroism',
+  maxRanks: 1,
+};
+export const CRUSADERS_JUDGMENT_PROTECTION_TALENT: Talent = {
+  id: 204023,
+  name: "Crusader's Judgment",
+  icon: 'ability_paladin_enlightenedjudgements',
+  maxRanks: 1,
+};
+export const UTHERS_GUARD_PROTECTION_TALENT: Talent = {
+  id: 378425,
+  name: "Uther's Guard",
+  icon: 'spell_holy_greaterblessingofsalvation',
+  maxRanks: 1,
+};
+export const FOCUSED_ENMITY_PROTECTION_TALENT: Talent = {
+  id: 378845,
+  name: 'Focused Enmity',
+  icon: 'ability_priest_flashoflight',
+  maxRanks: 1,
+};
+export const SOARING_SHIELD_PROTECTION_TALENT: Talent = {
+  id: 378457,
+  name: 'Soaring Shield',
+  icon: 'spell_burningbladeshaman_lavaslash',
+  maxRanks: 1,
+};
+export const GIFT_OF_THE_GOLDEN_VALKYR_PROTECTION_TALENT: Talent = {
+  id: 378279,
+  name: "Gift of the Golden Val'kyr",
+  icon: 'inv_valkiergoldpet',
+  maxRanks: 2,
+};
+export const EYE_OF_TYR_PROTECTION_TALENT: Talent = {
+  id: 209202,
+  name: 'Eye of Tyr',
+  icon: 'inv_shield_1h_artifactnorgannon_d_01',
+  maxRanks: 1,
+};
+export const RIGHTEOUS_PROTECTOR_PROTECTION_TALENT: Talent = {
+  id: 204074,
+  name: 'Righteous Protector',
+  icon: 'ability_paladin_shieldofthetemplar',
+  maxRanks: 2,
+};
+export const FAITH_IN_THE_LIGHT_PROTECTION_TALENT: Talent = {
+  id: 379043,
+  name: 'Faith in the Light',
+  icon: 'spell_holy_redemption',
+  maxRanks: 2,
+};
+export const FERREN_MARCUSS_STRENGTH_PROTECTION_TALENT: Talent = {
+  id: 378762,
+  name: "Ferren Marcus's Strength",
+  icon: 'spell_holy_sealofwrath',
+  maxRanks: 2,
+};
+export const FAITHS_ARMOR_PROTECTION_TALENT: Talent = {
+  id: 379017,
+  name: "Faith's Armor",
+  icon: 'ability_paladin_shieldofvengeance',
+  maxRanks: 1,
+};
+export const FINAL_STAND_PROTECTION_TALENT: Talent = {
+  id: 204077,
+  name: 'Final Stand',
+  icon: 'spell_holy_crusade',
+  maxRanks: 1,
+};
+export const DIVINE_TOLL_PROTECTION_TALENT: Talent = {
+  id: 375576,
+  name: 'Divine Toll',
+  icon: 'ability_bastion_paladin',
+  maxRanks: 1,
+  manaCost: 1500,
+};
+export const MOMENT_OF_GLORY_PROTECTION_TALENT: Talent = {
+  id: 327193,
+  name: 'Moment of Glory',
+  icon: 'spell_holy_aspiration',
+  maxRanks: 1,
+};
+export const BULWARK_OF_RIGHTEOUS_FURY_PROTECTION_TALENT: Talent = {
+  id: 386653,
+  name: 'Bulwark of Righteous Fury',
+  icon: 'spell_holy_sealofrighteousness',
+  maxRanks: 1,
+};
+export const DIVINE_RESONANCE_PROTECTION_TALENT: Talent = {
+  id: 386738,
+  name: 'Divine Resonance',
+  icon: 'ability_bastion_paladin',
+  maxRanks: 1,
+};
+export const IMPROVED_SERA__DT_PROTECTION_TALENT: Talent = {
+  id: 379391,
+  name: 'Improved Sera & DT',
+  icon: 'spell_holy_pureofheart',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Retribution
+export const BLADE_OF_JUSTICE_RETRIBUTION_TALENT: Talent = {
+  id: 184575,
+  name: 'Blade of Justice',
+  icon: 'ability_paladin_bladeofjustice',
+  maxRanks: 1,
+};
+export const DIVINE_STORM_RETRIBUTION_TALENT: Talent = {
+  id: 53385,
+  name: 'Divine Storm',
+  icon: 'ability_paladin_divinestorm',
+  maxRanks: 1,
+  holyPowerCost: 3,
+};
+export const ART_OF_WAR_RETRIBUTION_TALENT: Talent = {
+  id: 267344,
+  name: 'Art of War',
+  icon: 'ability_paladin_artofwar',
+  maxRanks: 1,
+};
+export const TIMELY_JUDGMENT_RETRIBUTION_TALENT: Talent = {
+  id: 383228,
+  name: 'Timely Judgment',
+  icon: 'ability_paladin_judgementofthepure',
+  maxRanks: 1,
+};
+export const IMPROVED_CRUSADER_STRIKE_RETRIBUTION_TALENT: Talent = {
+  id: 383254,
+  name: 'Improved Crusader Strike',
+  icon: 'spell_holy_crusaderstrike',
+  maxRanks: 1,
+};
+export const HOLY_CRUSADER_RETRIBUTION_TALENT: Talent = {
+  id: 386967,
+  name: 'Holy Crusader',
+  icon: 'spell_holy_power',
+  maxRanks: 1,
+};
+export const HOLY_BLADE_RETRIBUTION_TALENT: Talent = {
+  id: 383342,
+  name: 'Holy Blade',
+  icon: 'ability_paladin_lightoftheprotector',
+  maxRanks: 1,
+};
+export const CONDEMNING_BLADE_RETRIBUTION_TALENT: Talent = {
+  id: 383263,
+  name: 'Condemning Blade',
+  icon: 'ability_skyreach_spinning_blade',
+  maxRanks: 1,
+};
+export const ZEAL_RETRIBUTION_TALENT: Talent = {
+  id: 269569,
+  name: 'Zeal',
+  icon: 'spell_holy_sealofblood',
+  maxRanks: 1,
+};
+export const SHIELD_OF_VENGEANCE_RETRIBUTION_TALENT: Talent = {
+  id: 184662,
+  name: 'Shield of Vengeance',
+  icon: 'ability_paladin_shieldofthetemplar',
+  maxRanks: 1,
+};
+export const DIVINE_PROTECTION_RETRIBUTION_TALENT: Talent = {
+  id: 498,
+  name: 'Divine Protection',
+  icon: 'spell_holy_divineprotection',
+  maxRanks: 1,
+  manaCost: 300,
+};
+export const BLADE_OF_WRATH_RETRIBUTION_TALENT: Talent = {
+  id: 231832,
+  name: 'Blade of Wrath',
+  icon: 'ability_paladin_bladeofjustice',
+  maxRanks: 1,
+};
+export const HIGHLORDS_JUDGMENT_RETRIBUTION_TALENT: Talent = {
+  id: 383271,
+  name: "Highlord's Judgment",
+  icon: 'spell_holy_righteousfury',
+  maxRanks: 2,
+};
+export const RIGHTEOUS_VERDICT_RETRIBUTION_TALENT: Talent = {
+  id: 267610,
+  name: 'Righteous Verdict',
+  icon: 'spell_paladin_templarsverdict',
+  maxRanks: 1,
+};
+export const CALM_BEFORE_THE_STORM_RETRIBUTION_TALENT: Talent = {
+  id: 382536,
+  name: 'Calm Before the Storm',
+  icon: 'achievement_zone_firelands',
+  maxRanks: 1,
+};
+export const WAKE_OF_ASHES_RETRIBUTION_TALENT: Talent = {
+  id: 255937,
+  name: 'Wake of Ashes',
+  icon: 'inv_sword_2h_artifactashbringerfire_d_03',
+  maxRanks: 1,
+};
+export const CONSECRATED_BLADE_RETRIBUTION_TALENT: Talent = {
+  id: 382275,
+  name: 'Consecrated Blade',
+  icon: 'ability_mage_firestarter',
+  maxRanks: 1,
+};
+export const SEAL_OF_WRATH_RETRIBUTION_TALENT: Talent = {
+  id: 386901,
+  name: 'Seal of Wrath',
+  icon: 'ability_paladin_empoweredsealstruth',
+  maxRanks: 1,
+};
+export const EXPURGATION_RETRIBUTION_TALENT: Talent = {
+  id: 383344,
+  name: 'Expurgation',
+  icon: 'ability_paladin_bladeofjusticeblue',
+  maxRanks: 1,
+};
+export const BOUNDLESS_JUDGMENT_RETRIBUTION_TALENT: Talent = {
+  id: 383876,
+  name: 'Boundless Judgment',
+  icon: 'ability_paladin_judgementofthewise',
+  maxRanks: 1,
+};
+export const SANCTIFICATION_RETRIBUTION_TALENT: Talent = {
+  id: 382430,
+  name: 'Sanctification',
+  icon: 'spell_holy_surgeoflight',
+  maxRanks: 1,
+};
+export const INNER_POWER_RETRIBUTION_TALENT: Talent = {
+  id: 383334,
+  name: 'Inner Power',
+  icon: 'ability_paladin_toweroflight',
+  maxRanks: 1,
+};
+export const ASHES_TO_DUST_RETRIBUTION_TALENT: Talent = {
+  id: 383300,
+  name: 'Ashes to Dust',
+  icon: 'inv_sword_2h_artifactashbringerpurified_d_02',
+  maxRanks: 1,
+};
+export const PATH_OF_RUIN_RETRIBUTION_TALENT: Talent = {
+  id: 384052,
+  name: 'Path of Ruin',
+  icon: 'inv_sword_2h_artifactashbringerfire_d_02',
+  maxRanks: 1,
+};
+export const AVENGING_WRATH_MIGHT_RETRIBUTION_TALENT: Talent = {
+  id: 384442,
+  name: 'Avenging Wrath: Might',
+  icon: 'spell_holy_avenginewrath',
+  maxRanks: 1,
+};
+export const CRUSADE_RETRIBUTION_TALENT: Talent = {
+  id: 384392,
+  name: 'Crusade',
+  icon: 'ability_paladin_sanctifiedwrath',
+  maxRanks: 1,
+};
+export const TRUTHS_WAKE_RETRIBUTION_TALENT: Talent = {
+  id: 383350,
+  name: "Truth's Wake",
+  icon: 'inv_mace_104',
+  maxRanks: 1,
+};
+export const EMPYREAN_POWER_RETRIBUTION_TALENT: Talent = {
+  id: 326732,
+  name: 'Empyrean Power',
+  icon: 'ability_paladin_sheathoflight',
+  maxRanks: 1,
+};
+export const FIRES_OF_JUSTICE_RETRIBUTION_TALENT: Talent = {
+  id: 203316,
+  name: 'Fires of Justice',
+  icon: 'spell_holy_crusaderstrike',
+  maxRanks: 1,
+};
+export const SEALED_VERDICT_RETRIBUTION_TALENT: Talent = {
+  id: 387640,
+  name: 'Sealed Verdict',
+  icon: 'ability_paladin_swiftretribution',
+  maxRanks: 2,
+};
+export const CONSECRATED_GROUND_RETRIBUTION_TALENT: Talent = {
+  id: 204054,
+  name: 'Consecrated Ground',
+  icon: 'ability_paladin_righteousvengeance',
+  maxRanks: 1,
+};
+export const SANCTIFIED_GROUND_RETRIBUTION_TALENT: Talent = {
+  id: 387479,
+  name: 'Sanctified Ground',
+  icon: 'warrior_talent_icon_skirmisher',
+  maxRanks: 1,
+};
+export const EXORCISM_RETRIBUTION_TALENT: Talent = {
+  id: 383185,
+  name: 'Exorcism',
+  icon: 'spell_holy_excorcism_02',
+  maxRanks: 1,
+};
+export const HAND_OF_HINDRANCE_RETRIBUTION_TALENT: Talent = {
+  id: 183218,
+  name: 'Hand of Hindrance',
+  icon: 'ability_paladin_handofhindrance',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const SELFLESS_HEALER_RETRIBUTION_TALENT: Talent = {
+  id: 85804,
+  name: 'Selfless Healer',
+  icon: 'ability_paladin_gaurdedbythelight',
+  maxRanks: 1,
+};
+export const HEALING_HANDS_RETRIBUTION_TALENT: Talent = {
+  id: 326734,
+  name: 'Healing Hands',
+  icon: 'ability_paladin_infusionoflight',
+  maxRanks: 1,
+};
+export const TEMPEST_OF_THE_LIGHTBRINGER_RETRIBUTION_TALENT: Talent = {
+  id: 383396,
+  name: 'Tempest of the Lightbringer',
+  icon: 'ability_malkorok_blightofyshaarj_yellow',
+  maxRanks: 1,
+};
+export const JUSTICARS_VENGEANCE_RETRIBUTION_TALENT: Talent = {
+  id: 215661,
+  name: "Justicar's Vengeance",
+  icon: 'spell_holy_retributionaura',
+  maxRanks: 1,
+  holyPowerCost: 3,
+};
+export const EYE_FOR_AN_EYE_RETRIBUTION_TALENT: Talent = {
+  id: 205191,
+  name: 'Eye for an Eye',
+  icon: 'spell_holy_weaponmastery',
+  maxRanks: 1,
+};
+export const RELENTLESS_INQUISITOR_RETRIBUTION_TALENT: Talent = {
+  id: 383388,
+  name: 'Relentless Inquisitor',
+  icon: 'spell_holy_divinepurpose',
+  maxRanks: 2,
+};
+export const ASHES_TO_ASHES_RETRIBUTION_TALENT: Talent = {
+  id: 383276,
+  name: 'Ashes to Ashes',
+  icon: 'inv_artifact_ashes_to_ashes',
+  maxRanks: 2,
+};
+export const TEMPLARS_VINDICATION_RETRIBUTION_TALENT: Talent = {
+  id: 383274,
+  name: "Templar's Vindication",
+  icon: 'ability_priest_evangelism',
+  maxRanks: 2,
+};
+export const EXECUTION_SENTENCE_RETRIBUTION_TALENT: Talent = {
+  id: 343527,
+  name: 'Execution Sentence',
+  icon: 'spell_paladin_executionsentence',
+  maxRanks: 1,
+  holyPowerCost: 3,
+};
+export const DIVINE_TOLL_RETRIBUTION_TALENT: Talent = {
+  id: 375576,
+  name: 'Divine Toll',
+  icon: 'ability_bastion_paladin',
+  maxRanks: 1,
+  manaCost: 1500,
+};
+export const EMPYREAN_ENDOWMENT_RETRIBUTION_TALENT: Talent = {
+  id: 387170,
+  name: 'Empyrean Endowment',
+  icon: 'item_holyspark',
+  maxRanks: 1,
+};
+export const VIRTUOUS_COMMAND_RETRIBUTION_TALENT: Talent = {
+  id: 383304,
+  name: 'Virtuous Command',
+  icon: 'spell_holy_sealofvengeance',
+  maxRanks: 2,
+};
+export const FINAL_VERDICT_RETRIBUTION_TALENT: Talent = {
+  id: 383327,
+  name: 'Final Verdict',
+  icon: 'spell_paladin_templarsverdict',
+  maxRanks: 1,
+};
+export const EXECUTIONERS_WILL_RETRIBUTION_TALENT: Talent = {
+  id: 384162,
+  name: "Executioner's Will",
+  icon: 'inv_helm_plate_raidpaladinmythic_q_01',
+  maxRanks: 1,
+};
+export const EXECUTIONERS_WRATH_RETRIBUTION_TALENT: Talent = {
+  id: 387196,
+  name: "Executioner's Wrath",
+  icon: 'inv_glove_plate_raidpaladinmythic_q_01',
+  maxRanks: 1,
+};
+export const DIVINE_RESONANCE_RETRIBUTION_TALENT: Talent = {
+  id: 384027,
+  name: 'Divine Resonance',
+  icon: 'ability_bastion_paladin',
+  maxRanks: 1,
+};
+export const FINAL_RECKONING_RETRIBUTION_TALENT: Talent = {
+  id: 343721,
+  name: 'Final Reckoning',
+  icon: 'spell_holy_blessedresillience',
+  maxRanks: 1,
+};
+export const VANGUARDS_MOMENTUM_RETRIBUTION_TALENT: Talent = {
+  id: 383314,
+  name: "Vanguard's Momentum",
+  icon: 'ability_paladin_speedoflight',
+  maxRanks: 2,
+};
+
+//endregion
+
+//region Holy
+export const HOLY_SHOCK_HOLY_TALENT: Talent = {
+  id: 20473,
+  name: 'Holy Shock',
+  icon: 'spell_holy_searinglight',
+  maxRanks: 1,
+  manaCost: 1600,
+};
+export const HOLY_LIGHT_HOLY_TALENT: Talent = {
+  id: 82326,
+  name: 'Holy Light',
+  icon: 'spell_holy_surgeoflight',
+  maxRanks: 1,
+  manaCost: 1500,
+};
+export const LIGHT_OF_DAWN_HOLY_TALENT: Talent = {
+  id: 85222,
+  name: 'Light of Dawn',
+  icon: 'spell_paladin_lightofdawn',
+  maxRanks: 1,
+  holyPowerCost: 3,
+};
+export const ILLUMINATION_HOLY_TALENT: Talent = {
+  id: 387993,
+  name: 'Illumination',
+  icon: 'spell_paladin_clarityofpurpose',
+  maxRanks: 1,
+};
+export const INFUSION_OF_LIGHT_HOLY_TALENT: Talent = {
+  id: 53576,
+  name: 'Infusion of Light',
+  icon: 'ability_paladin_infusionoflight',
+  maxRanks: 1,
+};
+export const BESTOW_FAITH_HOLY_TALENT: Talent = {
+  id: 223306,
+  name: 'Bestow Faith',
+  icon: 'ability_paladin_blessedmending',
+  maxRanks: 1,
+  manaCost: 600,
+};
+export const UNENDING_LIGHT_NYI_HOLY_TALENT: Talent = {
+  id: 387998,
+  name: 'Unending Light (NYI)',
+  icon: 'spell_holy_holybolt',
+  maxRanks: 1,
+};
+export const FOCAL_LIGHT_HOLY_TALENT: Talent = {
+  id: 387781,
+  name: 'Focal Light',
+  icon: 'ability_paladin_beaconoflight',
+  maxRanks: 2,
+};
+export const DIVINE_PROTECTION_HOLY_TALENT: Talent = {
+  id: 498,
+  name: 'Divine Protection',
+  icon: 'spell_holy_divineprotection',
+  maxRanks: 1,
+  manaCost: 300,
+};
+export const SAVED_BY_THE_LIGHT_HOLY_TALENT: Talent = {
+  id: 157047,
+  name: 'Saved by the Light',
+  icon: 'ability_paladin_savedbythelight',
+  maxRanks: 2,
+};
+export const RADIANT_ONSLAUGHT_HOLY_TALENT: Talent = {
+  id: 231667,
+  name: 'Radiant Onslaught',
+  icon: 'spell_holy_crusaderstrike',
+  maxRanks: 1,
+};
+export const LIGHTS_HAMMER_HOLY_TALENT: Talent = {
+  id: 114158,
+  name: "Light's Hammer",
+  icon: 'spell_paladin_lightshammer',
+  maxRanks: 1,
+  manaCost: 1800,
+};
+export const HOLY_PRISM_HOLY_TALENT: Talent = {
+  id: 114165,
+  name: 'Holy Prism',
+  icon: 'spell_paladin_holyprism',
+  maxRanks: 1,
+  manaCost: 1300,
+};
+export const MOMENT_OF_COMPASSION_HOLY_TALENT: Talent = {
+  id: 387786,
+  name: 'Moment of Compassion',
+  icon: 'spell_holy_flashheal',
+  maxRanks: 1,
+};
+export const AURA_MASTERY_HOLY_TALENT: Talent = {
+  id: 31821,
+  name: 'Aura Mastery',
+  icon: 'spell_holy_auramastery',
+  maxRanks: 1,
+};
+export const TOWER_OF_RADIANCE_HOLY_TALENT: Talent = {
+  id: 231642,
+  name: 'Tower of Radiance',
+  icon: 'ability_paladin_beaconoflight',
+  maxRanks: 1,
+};
+export const SHINING_SAVIOR_HOLY_TALENT: Talent = {
+  id: 388005,
+  name: 'Shining Savior',
+  icon: 'ability_paladin_longarmofthelaw',
+  maxRanks: 1,
+};
+export const LIGHT_OF_THE_MARTYR_HOLY_TALENT: Talent = {
+  id: 183998,
+  name: 'Light of the Martyr',
+  icon: 'ability_paladin_lightofthemartyr',
+  maxRanks: 1,
+  manaCost: 700,
+};
+export const EMPYREAL_WARD_HOLY_TALENT: Talent = {
+  id: 387791,
+  name: 'Empyreal Ward',
+  icon: 'spell_holy_layonhands',
+  maxRanks: 1,
+};
+export const PROTECTION_OF_TYR_HOLY_TALENT: Talent = {
+  id: 200430,
+  name: 'Protection of Tyr',
+  icon: 'spell_holy_auramastery',
+  maxRanks: 2,
+};
+export const RULE_OF_LAW_HOLY_TALENT: Talent = {
+  id: 214202,
+  name: 'Rule of Law',
+  icon: 'ability_paladin_longarmofthelaw',
+  maxRanks: 1,
+};
+export const ECHOING_BLESSINGS_HOLY_TALENT: Talent = {
+  id: 387801,
+  name: 'Echoing Blessings',
+  icon: 'achievement_dungeon_heroic_gloryoftheraider',
+  maxRanks: 1,
+};
+export const SCINTILLATION_HOLY_TALENT: Talent = {
+  id: 387805,
+  name: 'Scintillation',
+  icon: 'achievement_dungeon_heroic_gloryoftheraider',
+  maxRanks: 2,
+};
+export const DIVINE_REVELATIONS_HOLY_TALENT: Talent = {
+  id: 387808,
+  name: 'Divine Revelations',
+  icon: 'ability_paladin_infusionoflight',
+  maxRanks: 3,
+};
+export const SECOND_SUNRISE_HOLY_TALENT: Talent = {
+  id: 200482,
+  name: 'Second Sunrise',
+  icon: 'spell_paladin_lightofdawn',
+  maxRanks: 2,
+};
+export const UNTEMPERED_DEDICATION_HOLY_TALENT: Talent = {
+  id: 387814,
+  name: 'Untempered Dedication',
+  icon: 'achievement_admiral_of_the_light',
+  maxRanks: 1,
+};
+export const CRUSADERS_MIGHT_HOLY_TALENT: Talent = {
+  id: 196926,
+  name: "Crusader's Might",
+  icon: 'ability_paladin_swiftretribution',
+  maxRanks: 2,
+};
+export const BLESSING_OF_SUMMER_HOLY_TALENT: Talent = {
+  id: 388007,
+  name: 'Blessing of Summer',
+  icon: 'ability_ardenweald_paladin_summer',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const GLIMMER_OF_LIGHT_HOLY_TALENT: Talent = {
+  id: 325966,
+  name: 'Glimmer of Light',
+  icon: 'ability_paladin_toweroflight',
+  maxRanks: 1,
+};
+export const POWER_OF_THE_SILVER_HAND_HOLY_TALENT: Talent = {
+  id: 200474,
+  name: 'Power of the Silver Hand',
+  icon: 'ability_paladin_blessedhands',
+  maxRanks: 1,
+};
+export const BEACON_OF_FAITH_HOLY_TALENT: Talent = {
+  id: 156910,
+  name: 'Beacon of Faith',
+  icon: 'ability_paladin_beaconsoflight',
+  maxRanks: 1,
+  manaCost: 300,
+};
+export const BEACON_OF_VIRTUE_HOLY_TALENT: Talent = {
+  id: 200025,
+  name: 'Beacon of Virtue',
+  icon: 'ability_paladin_beaconofinsight',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const MARAADS_DYING_BREATH_HOLY_TALENT: Talent = {
+  id: 388018,
+  name: "Maraad's Dying Breath",
+  icon: 'paladin_icon_speedoflight',
+  maxRanks: 1,
+};
+export const DIVINE_TOLL_HOLY_TALENT: Talent = {
+  id: 375576,
+  name: 'Divine Toll',
+  icon: 'ability_bastion_paladin',
+  maxRanks: 1,
+  manaCost: 1500,
+};
+export const BARRIER_OF_FAITH_HOLY_TALENT: Talent = {
+  id: 148039,
+  name: 'Barrier of Faith',
+  icon: 'ability_paladin_blessedmending',
+  maxRanks: 1,
+  manaCost: 900,
+};
+export const AVENGING_WRATH_MIGHT_NYI_HOLY_TALENT: Talent = {
+  id: 388006,
+  name: 'Avenging Wrath: Might (NYI)',
+  icon: 'spell_holy_avenginewrath',
+  maxRanks: 1,
+};
+export const AVENGING_CRUSADER_HOLY_TALENT: Talent = {
+  id: 216331,
+  name: 'Avenging Crusader',
+  icon: 'ability_paladin_veneration',
+  maxRanks: 1,
+  manaCost: 5000,
+};
+export const BREAKING_DAWN_HOLY_TALENT: Talent = {
+  id: 387879,
+  name: 'Breaking Dawn',
+  icon: 'spell_paladin_lightofdawn',
+  maxRanks: 1,
+};
+export const TYRS_DELIVERANCE_HOLY_TALENT: Talent = {
+  id: 200652,
+  name: "Tyr's Deliverance",
+  icon: 'inv_mace_2h_artifactsilverhand_d_01',
+  maxRanks: 1,
+};
+export const DIVINE_RESONANCE_HOLY_TALENT: Talent = {
+  id: 387893,
+  name: 'Divine Resonance',
+  icon: 'ability_bastion_paladin',
+  maxRanks: 1,
+};
+export const LIADRINS_FURY_UNLEASHED_HOLY_TALENT: Talent = {
+  id: 208408,
+  name: "Liadrin's Fury Unleashed",
+  icon: 'ability_warrior_unrelentingassault',
+  maxRanks: 2,
+};
+export const AWAKENING_HOLY_TALENT: Talent = {
+  id: 248033,
+  name: 'Awakening',
+  icon: 'inv_helm_plate_raidpaladin_n_01',
+  maxRanks: 2,
+};
+export const TYRS_MUNIFICENCE_HOLY_TALENT: Talent = {
+  id: 238060,
+  name: "Tyr's Munificence",
+  icon: 'inv_mace_2h_artifactsilverhand_d_01',
+  maxRanks: 1,
+};
+
+//endregion
 
 const talents = createTalentList({
   //Shared
-  LAY_ON_HANDS_TALENT: {
-    id: 633,
-    name: 'Lay on Hands',
-    icon: 'spell_holy_layonhands',
-    maxRanks: 1,
-  },
-  BLESSING_OF_FREEDOM_TALENT: {
-    id: 1044,
-    name: 'Blessing of Freedom',
-    icon: 'spell_holy_sealofvalor',
-    maxRanks: 1,
-    manaCost: 700,
-  },
-  HAMMER_OF_WRATH_TALENT: {
-    id: 24275,
-    name: 'Hammer of Wrath',
-    icon: 'spell_paladin_hammerofwrath',
-    maxRanks: 1,
-  },
-  AURAS_OF_THE_RESOLUTE_TALENT: {
-    id: 385633,
-    name: 'Auras of the Resolute',
-    icon: 'spell_holy_devotionaura',
-    maxRanks: 1,
-  },
-  AURAS_OF_SWIFT_VENGEANCE_TALENT: {
-    id: 385639,
-    name: 'Auras of Swift Vengeance',
-    icon: 'spell_holy_crusade',
-    maxRanks: 1,
-  },
-  REPENTANCE_TALENT: {
-    id: 20066,
-    name: 'Repentance',
-    icon: 'spell_holy_prayerofhealing',
-    maxRanks: 1,
-    manaCost: 600,
-  },
-  BLINDING_LIGHT_TALENT: {
-    id: 115750,
-    name: 'Blinding Light',
-    icon: 'ability_paladin_blindinglight',
-    maxRanks: 1,
-    manaCost: 600,
-  },
-  DIVINE_STEED_TALENT: {
-    id: 190784,
-    name: 'Divine Steed',
-    icon: 'ability_paladin_divinesteed',
-    maxRanks: 1,
-  },
-  FIST_OF_JUSTICE_TALENT: {
-    id: 234299,
-    name: 'Fist of Justice',
-    icon: 'spell_holy_fistofjustice',
-    maxRanks: 2,
-  },
-  CLEANSE_TOXINS_TALENT: {
-    id: 213644,
-    name: 'Cleanse Toxins',
-    icon: 'spell_holy_renew',
-    maxRanks: 1,
-    manaCost: 600,
-  },
-  CAVALIER_TALENT: {
-    id: 230332,
-    name: 'Cavalier',
-    icon: 'ability_paladin_divinesteed',
-    maxRanks: 1,
-  },
-  SEASONED_WARHORSE_TALENT: {
-    id: 376996,
-    name: 'Seasoned Warhorse',
-    icon: 'spell_nature_swiftness',
-    maxRanks: 2,
-  },
-  JUDGMENT_TALENT: { id: 231663, name: 'Judgment', icon: 'spell_holy_righteousfury', maxRanks: 1 },
-  HOLY_AEGIS_TALENT: {
-    id: 385515,
-    name: 'Holy Aegis',
-    icon: 'spell_holy_divineprotection',
-    maxRanks: 2,
-  },
-  AVENGING_WRATH_TALENT: {
-    id: 384376,
-    name: 'Avenging Wrath',
-    icon: 'spell_holy_avenginewrath',
-    maxRanks: 1,
-  },
-  SEAL_OF_THE_TEMPLAR_TALENT: {
-    id: 377016,
-    name: 'Seal of the Templar',
-    icon: 'ability_paladin_artofwar',
-    maxRanks: 1,
-  },
-  REBUKE_TALENT: { id: 96231, name: 'Rebuke', icon: 'spell_holy_rebuke', maxRanks: 1 },
-  GOLDEN_PATH_TALENT: {
-    id: 377128,
-    name: 'Golden Path',
-    icon: 'ability_priest_cascade',
-    maxRanks: 1,
-  },
-  JUDGMENT_OF_LIGHT_TALENT: {
-    id: 183778,
-    name: 'Judgment of Light',
-    icon: 'spell_holy_divineprovidence',
-    maxRanks: 1,
-  },
-  BLESSING_OF_SACRIFICE_TALENT: {
-    id: 6940,
-    name: 'Blessing of Sacrifice',
-    icon: 'spell_holy_sealofsacrifice',
-    maxRanks: 1,
-    manaCost: 700,
-  },
-  TURN_EVIL_TALENT: {
-    id: 10326,
-    name: 'Turn Evil',
-    icon: 'ability_paladin_turnevil',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  BLESSING_OF_PROTECTION_TALENT: {
-    id: 1022,
-    name: 'Blessing of Protection',
-    icon: 'spell_holy_sealofprotection',
-    maxRanks: 1,
-    manaCost: 1500,
-  },
-  SEAL_OF_REPRISAL_TALENT: {
-    id: 377053,
-    name: 'Seal of Reprisal',
-    icon: 'spell_holy_sealoffury',
-    maxRanks: 2,
-  },
-  SEAL_OF_MERCY_TALENT: {
-    id: 384897,
-    name: 'Seal of Mercy',
-    icon: 'spell_holy_greaterblessingofsalvation',
-    maxRanks: 2,
-  },
-  AFTERIMAGE_TALENT: { id: 385414, name: 'Afterimage', icon: 'spell_holy_aspiration', maxRanks: 1 },
-  SACRIFICE_OF_THE_JUST_TALENT: {
-    id: 384820,
-    name: 'Sacrifice of the Just',
-    icon: 'spell_holy_sealofsacrifice',
-    maxRanks: 1,
-  },
-  RECOMPENSE_TALENT: {
-    id: 384914,
-    name: 'Recompense',
-    icon: 'ability_racial_foregedinflames',
-    maxRanks: 1,
-  },
-  UNBREAKABLE_SPIRIT_TALENT: {
-    id: 114154,
-    name: 'Unbreakable Spirit',
-    icon: 'spell_holy_holyguidance',
-    maxRanks: 1,
-  },
-  IMPROVED_BLESSING_OF_PROTECTION_TALENT: {
-    id: 384909,
-    name: 'Improved Blessing of Protection',
-    icon: 'spell_holy_sealofprotection',
-    maxRanks: 1,
-  },
-  BLESSING_OF_SPELLWARDING_TALENT: {
-    id: 204018,
-    name: 'Blessing of Spellwarding',
-    icon: 'spell_holy_blessingofprotection',
-    maxRanks: 1,
-    manaCost: 1500,
-  },
-  INCANDESCENCE_TALENT: {
-    id: 385464,
-    name: 'Incandescence',
-    icon: 'inv_summerfest_firespirit',
-    maxRanks: 1,
-  },
-  TOUCH_OF_LIGHT_TALENT: {
-    id: 385349,
-    name: 'Touch of Light',
-    icon: 'achievment_raid_houroftwilight',
-    maxRanks: 1,
-  },
-  SEAL_OF_CLARITY_TALENT: {
-    id: 384815,
-    name: 'Seal of Clarity',
-    icon: 'spell_priest_power_word',
-    maxRanks: 2,
-  },
-  ASPIRATIONS_OF_DIVINITY_TALENT: {
-    id: 385416,
-    name: 'Aspirations of Divinity',
-    icon: 'spell_holy_fanaticism',
-    maxRanks: 2,
-  },
-  DIVINE_PURPOSE_TALENT: {
-    id: 223817,
-    name: 'Divine Purpose',
-    icon: 'spell_holy_divinepurpose',
-    maxRanks: 1,
-  },
-  HOLY_AVENGER_TALENT: {
-    id: 105809,
-    name: 'Holy Avenger',
-    icon: 'ability_paladin_holyavenger',
-    maxRanks: 1,
-  },
-  OBDURACY_TALENT: {
-    id: 385427,
-    name: 'Obduracy',
-    icon: 'ability_paladin_speedoflight',
-    maxRanks: 1,
-  },
-  HALLOWED_GROUND_TALENT: {
-    id: 377043,
-    name: 'Hallowed Ground',
-    icon: 'ability_paladin_empoweredsealsrighteous',
-    maxRanks: 1,
-  },
-  OF_DUSK_AND_DAWN_TALENT: {
-    id: 385125,
-    name: 'Of Dusk and Dawn',
-    icon: 'spell_paladin_lightofdawn',
-    maxRanks: 1,
-  },
-  SEAL_OF_MIGHT_NYI_TALENT: {
-    id: 385450,
-    name: 'Seal of Might [NYI]',
-    icon: 'spell_holy_sealofwrath',
-    maxRanks: 2,
-  },
-  SEAL_OF_ALACRITY_TALENT: {
-    id: 385425,
-    name: 'Seal of Alacrity',
-    icon: 'spell_holy_sealofvengeance',
-    maxRanks: 2,
-  },
-  SEAL_OF_THE_CRUSADER_TALENT: {
-    id: 385728,
-    name: 'Seal of the Crusader',
-    icon: 'spell_holy_holysmite',
-    maxRanks: 2,
-  },
-  SEAL_OF_ORDER_TALENT: {
-    id: 385129,
-    name: 'Seal of Order',
-    icon: 'spell_holy_sealofwisdom',
-    maxRanks: 1,
-  },
-  SERAPHIM_TALENT: {
-    id: 152262,
-    name: 'Seraphim',
-    icon: 'ability_paladin_seraphim',
-    maxRanks: 1,
-    holyPowerCost: 3,
-  },
-  SANCTIFIED_WRATH_TALENT: {
-    id: 171648,
-    name: 'Sanctified Wrath',
-    icon: 'ability_paladin_judgementsofthejust',
-    maxRanks: 1,
-  },
-  THE_MAD_PARAGON_TALENT: {
-    id: 391142,
-    name: 'The Mad Paragon',
-    icon: 'ability_paladin_conviction',
-    maxRanks: 1,
-  },
+  LAY_ON_HANDS_TALENT,
+  BLESSING_OF_FREEDOM_TALENT,
+  HAMMER_OF_WRATH_TALENT,
+  AURAS_OF_THE_RESOLUTE_TALENT,
+  AURAS_OF_SWIFT_VENGEANCE_TALENT,
+  REPENTANCE_TALENT,
+  BLINDING_LIGHT_TALENT,
+  DIVINE_STEED_TALENT,
+  FIST_OF_JUSTICE_TALENT,
+  CLEANSE_TOXINS_TALENT,
+  CAVALIER_TALENT,
+  SEASONED_WARHORSE_TALENT,
+  JUDGMENT_TALENT,
+  HOLY_AEGIS_TALENT,
+  AVENGING_WRATH_TALENT,
+  SEAL_OF_THE_TEMPLAR_TALENT,
+  REBUKE_TALENT,
+  GOLDEN_PATH_TALENT,
+  JUDGMENT_OF_LIGHT_TALENT,
+  BLESSING_OF_SACRIFICE_TALENT,
+  TURN_EVIL_TALENT,
+  BLESSING_OF_PROTECTION_TALENT,
+  SEAL_OF_REPRISAL_TALENT,
+  SEAL_OF_MERCY_TALENT,
+  AFTERIMAGE_TALENT,
+  SACRIFICE_OF_THE_JUST_TALENT,
+  RECOMPENSE_TALENT,
+  UNBREAKABLE_SPIRIT_TALENT,
+  IMPROVED_BLESSING_OF_PROTECTION_TALENT,
+  BLESSING_OF_SPELLWARDING_TALENT,
+  INCANDESCENCE_TALENT,
+  TOUCH_OF_LIGHT_TALENT,
+  SEAL_OF_CLARITY_TALENT,
+  ASPIRATIONS_OF_DIVINITY_TALENT,
+  DIVINE_PURPOSE_TALENT,
+  HOLY_AVENGER_TALENT,
+  OBDURACY_TALENT,
+  HALLOWED_GROUND_TALENT,
+  OF_DUSK_AND_DAWN_TALENT,
+  SEAL_OF_MIGHT_NYI_TALENT,
+  SEAL_OF_ALACRITY_TALENT,
+  SEAL_OF_THE_CRUSADER_TALENT,
+  SEAL_OF_ORDER_TALENT,
+  SERAPHIM_TALENT,
+  SANCTIFIED_WRATH_TALENT,
+  THE_MAD_PARAGON_TALENT,
 
   //Protection
-  AVENGERS_SHIELD_PROTECTION_TALENT: {
-    id: 31935,
-    name: "Avenger's Shield",
-    icon: 'spell_holy_avengersshield',
-    maxRanks: 1,
-  },
-  HAMMER_OF_THE_RIGHTEOUS_PROTECTION_TALENT: {
-    id: 53595,
-    name: 'Hammer of the Righteous',
-    icon: 'ability_paladin_hammeroftherighteous',
-    maxRanks: 1,
-  },
-  BLESSED_HAMMER_PROTECTION_TALENT: {
-    id: 204019,
-    name: 'Blessed Hammer',
-    icon: 'paladin_retribution',
-    maxRanks: 1,
-  },
-  INNER_LIGHT_PROTECTION_TALENT: {
-    id: 386568,
-    name: 'Inner Light',
-    icon: 'ability_paladin_shieldofvengeance',
-    maxRanks: 1,
-  },
-  REDOUBT_PROTECTION_TALENT: {
-    id: 280373,
-    name: 'Redoubt',
-    icon: 'ability_warrior_shieldguard',
-    maxRanks: 1,
-  },
-  HOLY_SHIELD_PROTECTION_TALENT: {
-    id: 152261,
-    name: 'Holy Shield',
-    icon: 'inv_shield_1h_hyrja_d_01',
-    maxRanks: 1,
-  },
-  GRAND_CRUSADER_PROTECTION_TALENT: {
-    id: 85043,
-    name: 'Grand Crusader',
-    icon: 'inv_helmet_74',
-    maxRanks: 1,
-  },
-  SHINING_LIGHT_PROTECTION_TALENT: {
-    id: 321136,
-    name: 'Shining Light',
-    icon: 'ability_paladin_toweroflight',
-    maxRanks: 1,
-  },
-  CONSECRATED_GROUND_PROTECTION_TALENT: {
-    id: 204054,
-    name: 'Consecrated Ground',
-    icon: 'ability_paladin_righteousvengeance',
-    maxRanks: 1,
-  },
-  INSPIRING_VANGUARD_PROTECTION_TALENT: {
-    id: 279387,
-    name: 'Inspiring Vanguard',
-    icon: 'inv_helmet_74',
-    maxRanks: 1,
-  },
-  ARDENT_DEFENDER_PROTECTION_TALENT: {
-    id: 31850,
-    name: 'Ardent Defender',
-    icon: 'spell_holy_ardentdefender',
-    maxRanks: 1,
-  },
-  FAITH_BARRICADE_PROTECTION_TALENT: {
-    id: 385726,
-    name: 'Faith Barricade',
-    icon: 'ability_paladin_barrieroffaith',
-    maxRanks: 1,
-  },
-  CONSECRATION_IN_FLAME_PROTECTION_TALENT: {
-    id: 379022,
-    name: 'Consecration in Flame',
-    icon: 'spell_fire_sealoffire',
-    maxRanks: 1,
-  },
-  CRUSADERS_RESOLVE_PROTECTION_TALENT: {
-    id: 380188,
-    name: "Crusader's Resolve",
-    icon: 'ability_priest_angelicbulwark',
-    maxRanks: 2,
-  },
-  BULWARK_OF_ORDER_PROTECTION_TALENT: {
-    id: 209389,
-    name: 'Bulwark of Order',
-    icon: 'spell_holy_pureofheart',
-    maxRanks: 2,
-  },
-  LIGHT_OF_THE_TITANS_PROTECTION_TALENT: {
-    id: 378405,
-    name: 'Light of the Titans',
-    icon: 'spell_paladin_lightofdawn',
-    maxRanks: 2,
-  },
-  SANCTUARY_PROTECTION_TALENT: {
-    id: 379021,
-    name: 'Sanctuary',
-    icon: 'spell_holy_innerfire',
-    maxRanks: 2,
-  },
-  TYRS_ENFORCER_PROTECTION_TALENT: {
-    id: 378285,
-    name: "Tyr's Enforcer",
-    icon: 'inv_summerfest_firespirit',
-    maxRanks: 2,
-  },
-  RELENTLESS_INQUISITOR_PROTECTION_TALENT: {
-    id: 383388,
-    name: 'Relentless Inquisitor',
-    icon: 'spell_holy_divinepurpose',
-    maxRanks: 1,
-  },
-  AVENGING_WRATH_MIGHT_PROTECTION_TALENT: {
-    id: 384442,
-    name: 'Avenging Wrath: Might',
-    icon: 'spell_holy_avenginewrath',
-    maxRanks: 1,
-  },
-  SENTINEL_PROTECTION_TALENT: {
-    id: 385438,
-    name: 'Sentinel',
-    icon: 'spell_holy_holynova',
-    maxRanks: 1,
-  },
-  HAND_OF_THE_PROTECTOR_PROTECTION_TALENT: {
-    id: 315924,
-    name: 'Hand of the Protector',
-    icon: 'ability_paladin_blessedhands',
-    maxRanks: 1,
-  },
-  STRENGTH_OF_CONVICTION_PROTECTION_TALENT: {
-    id: 379008,
-    name: 'Strength of Conviction',
-    icon: 'spell_holy_eyeforaneye',
-    maxRanks: 2,
-  },
-  RESOLUTE_DEFENDER_PROTECTION_TALENT: {
-    id: 385422,
-    name: 'Resolute Defender',
-    icon: 'ability_crown_of_the_heavens_icon',
-    maxRanks: 1,
-  },
-  BASTION_OF_LIGHT_PROTECTION_TALENT: {
-    id: 378974,
-    name: 'Bastion of Light',
-    icon: 'paladin_protection',
-    maxRanks: 1,
-  },
-  GUARDIAN_OF_ANCIENT_KINGS_PROTECTION_TALENT: {
-    id: 86659,
-    name: 'Guardian of Ancient Kings',
-    icon: 'spell_holy_heroism',
-    maxRanks: 1,
-  },
-  CRUSADERS_JUDGMENT_PROTECTION_TALENT: {
-    id: 204023,
-    name: "Crusader's Judgment",
-    icon: 'ability_paladin_enlightenedjudgements',
-    maxRanks: 1,
-  },
-  UTHERS_GUARD_PROTECTION_TALENT: {
-    id: 378425,
-    name: "Uther's Guard",
-    icon: 'spell_holy_greaterblessingofsalvation',
-    maxRanks: 1,
-  },
-  FOCUSED_ENMITY_PROTECTION_TALENT: {
-    id: 378845,
-    name: 'Focused Enmity',
-    icon: 'ability_priest_flashoflight',
-    maxRanks: 1,
-  },
-  SOARING_SHIELD_PROTECTION_TALENT: {
-    id: 378457,
-    name: 'Soaring Shield',
-    icon: 'spell_burningbladeshaman_lavaslash',
-    maxRanks: 1,
-  },
-  GIFT_OF_THE_GOLDEN_VALKYR_PROTECTION_TALENT: {
-    id: 378279,
-    name: "Gift of the Golden Val'kyr",
-    icon: 'inv_valkiergoldpet',
-    maxRanks: 2,
-  },
-  EYE_OF_TYR_PROTECTION_TALENT: {
-    id: 209202,
-    name: 'Eye of Tyr',
-    icon: 'inv_shield_1h_artifactnorgannon_d_01',
-    maxRanks: 1,
-  },
-  RIGHTEOUS_PROTECTOR_PROTECTION_TALENT: {
-    id: 204074,
-    name: 'Righteous Protector',
-    icon: 'ability_paladin_shieldofthetemplar',
-    maxRanks: 2,
-  },
-  FAITH_IN_THE_LIGHT_PROTECTION_TALENT: {
-    id: 379043,
-    name: 'Faith in the Light',
-    icon: 'spell_holy_redemption',
-    maxRanks: 2,
-  },
-  FERREN_MARCUSS_STRENGTH_PROTECTION_TALENT: {
-    id: 378762,
-    name: "Ferren Marcus's Strength",
-    icon: 'spell_holy_sealofwrath',
-    maxRanks: 2,
-  },
-  FAITHS_ARMOR_PROTECTION_TALENT: {
-    id: 379017,
-    name: "Faith's Armor",
-    icon: 'ability_paladin_shieldofvengeance',
-    maxRanks: 1,
-  },
-  FINAL_STAND_PROTECTION_TALENT: {
-    id: 204077,
-    name: 'Final Stand',
-    icon: 'spell_holy_crusade',
-    maxRanks: 1,
-  },
-  DIVINE_TOLL_PROTECTION_TALENT: {
-    id: 375576,
-    name: 'Divine Toll',
-    icon: 'ability_bastion_paladin',
-    maxRanks: 1,
-    manaCost: 1500,
-  },
-  MOMENT_OF_GLORY_PROTECTION_TALENT: {
-    id: 327193,
-    name: 'Moment of Glory',
-    icon: 'spell_holy_aspiration',
-    maxRanks: 1,
-  },
-  BULWARK_OF_RIGHTEOUS_FURY_PROTECTION_TALENT: {
-    id: 386653,
-    name: 'Bulwark of Righteous Fury',
-    icon: 'spell_holy_sealofrighteousness',
-    maxRanks: 1,
-  },
-  DIVINE_RESONANCE_PROTECTION_TALENT: {
-    id: 386738,
-    name: 'Divine Resonance',
-    icon: 'ability_bastion_paladin',
-    maxRanks: 1,
-  },
-  IMPROVED_SERA__DT_PROTECTION_TALENT: {
-    id: 379391,
-    name: 'Improved Sera & DT',
-    icon: 'spell_holy_pureofheart',
-    maxRanks: 1,
-  },
+  AVENGERS_SHIELD_PROTECTION_TALENT,
+  HAMMER_OF_THE_RIGHTEOUS_PROTECTION_TALENT,
+  BLESSED_HAMMER_PROTECTION_TALENT,
+  INNER_LIGHT_PROTECTION_TALENT,
+  REDOUBT_PROTECTION_TALENT,
+  HOLY_SHIELD_PROTECTION_TALENT,
+  GRAND_CRUSADER_PROTECTION_TALENT,
+  SHINING_LIGHT_PROTECTION_TALENT,
+  CONSECRATED_GROUND_PROTECTION_TALENT,
+  INSPIRING_VANGUARD_PROTECTION_TALENT,
+  ARDENT_DEFENDER_PROTECTION_TALENT,
+  FAITH_BARRICADE_PROTECTION_TALENT,
+  CONSECRATION_IN_FLAME_PROTECTION_TALENT,
+  CRUSADERS_RESOLVE_PROTECTION_TALENT,
+  BULWARK_OF_ORDER_PROTECTION_TALENT,
+  LIGHT_OF_THE_TITANS_PROTECTION_TALENT,
+  SANCTUARY_PROTECTION_TALENT,
+  TYRS_ENFORCER_PROTECTION_TALENT,
+  RELENTLESS_INQUISITOR_PROTECTION_TALENT,
+  AVENGING_WRATH_MIGHT_PROTECTION_TALENT,
+  SENTINEL_PROTECTION_TALENT,
+  HAND_OF_THE_PROTECTOR_PROTECTION_TALENT,
+  STRENGTH_OF_CONVICTION_PROTECTION_TALENT,
+  RESOLUTE_DEFENDER_PROTECTION_TALENT,
+  BASTION_OF_LIGHT_PROTECTION_TALENT,
+  GUARDIAN_OF_ANCIENT_KINGS_PROTECTION_TALENT,
+  CRUSADERS_JUDGMENT_PROTECTION_TALENT,
+  UTHERS_GUARD_PROTECTION_TALENT,
+  FOCUSED_ENMITY_PROTECTION_TALENT,
+  SOARING_SHIELD_PROTECTION_TALENT,
+  GIFT_OF_THE_GOLDEN_VALKYR_PROTECTION_TALENT,
+  EYE_OF_TYR_PROTECTION_TALENT,
+  RIGHTEOUS_PROTECTOR_PROTECTION_TALENT,
+  FAITH_IN_THE_LIGHT_PROTECTION_TALENT,
+  FERREN_MARCUSS_STRENGTH_PROTECTION_TALENT,
+  FAITHS_ARMOR_PROTECTION_TALENT,
+  FINAL_STAND_PROTECTION_TALENT,
+  DIVINE_TOLL_PROTECTION_TALENT,
+  MOMENT_OF_GLORY_PROTECTION_TALENT,
+  BULWARK_OF_RIGHTEOUS_FURY_PROTECTION_TALENT,
+  DIVINE_RESONANCE_PROTECTION_TALENT,
+  IMPROVED_SERA__DT_PROTECTION_TALENT,
 
   //Retribution
-  BLADE_OF_JUSTICE_RETRIBUTION_TALENT: {
-    id: 184575,
-    name: 'Blade of Justice',
-    icon: 'ability_paladin_bladeofjustice',
-    maxRanks: 1,
-  },
-  DIVINE_STORM_RETRIBUTION_TALENT: {
-    id: 53385,
-    name: 'Divine Storm',
-    icon: 'ability_paladin_divinestorm',
-    maxRanks: 1,
-    holyPowerCost: 3,
-  },
-  ART_OF_WAR_RETRIBUTION_TALENT: {
-    id: 267344,
-    name: 'Art of War',
-    icon: 'ability_paladin_artofwar',
-    maxRanks: 1,
-  },
-  TIMELY_JUDGMENT_RETRIBUTION_TALENT: {
-    id: 383228,
-    name: 'Timely Judgment',
-    icon: 'ability_paladin_judgementofthepure',
-    maxRanks: 1,
-  },
-  IMPROVED_CRUSADER_STRIKE_RETRIBUTION_TALENT: {
-    id: 383254,
-    name: 'Improved Crusader Strike',
-    icon: 'spell_holy_crusaderstrike',
-    maxRanks: 1,
-  },
-  HOLY_CRUSADER_RETRIBUTION_TALENT: {
-    id: 386967,
-    name: 'Holy Crusader',
-    icon: 'spell_holy_power',
-    maxRanks: 1,
-  },
-  HOLY_BLADE_RETRIBUTION_TALENT: {
-    id: 383342,
-    name: 'Holy Blade',
-    icon: 'ability_paladin_lightoftheprotector',
-    maxRanks: 1,
-  },
-  CONDEMNING_BLADE_RETRIBUTION_TALENT: {
-    id: 383263,
-    name: 'Condemning Blade',
-    icon: 'ability_skyreach_spinning_blade',
-    maxRanks: 1,
-  },
-  ZEAL_RETRIBUTION_TALENT: {
-    id: 269569,
-    name: 'Zeal',
-    icon: 'spell_holy_sealofblood',
-    maxRanks: 1,
-  },
-  SHIELD_OF_VENGEANCE_RETRIBUTION_TALENT: {
-    id: 184662,
-    name: 'Shield of Vengeance',
-    icon: 'ability_paladin_shieldofthetemplar',
-    maxRanks: 1,
-  },
-  DIVINE_PROTECTION_RETRIBUTION_TALENT: {
-    id: 498,
-    name: 'Divine Protection',
-    icon: 'spell_holy_divineprotection',
-    maxRanks: 1,
-    manaCost: 300,
-  },
-  BLADE_OF_WRATH_RETRIBUTION_TALENT: {
-    id: 231832,
-    name: 'Blade of Wrath',
-    icon: 'ability_paladin_bladeofjustice',
-    maxRanks: 1,
-  },
-  HIGHLORDS_JUDGMENT_RETRIBUTION_TALENT: {
-    id: 383271,
-    name: "Highlord's Judgment",
-    icon: 'spell_holy_righteousfury',
-    maxRanks: 2,
-  },
-  RIGHTEOUS_VERDICT_RETRIBUTION_TALENT: {
-    id: 267610,
-    name: 'Righteous Verdict',
-    icon: 'spell_paladin_templarsverdict',
-    maxRanks: 1,
-  },
-  CALM_BEFORE_THE_STORM_RETRIBUTION_TALENT: {
-    id: 382536,
-    name: 'Calm Before the Storm',
-    icon: 'achievement_zone_firelands',
-    maxRanks: 1,
-  },
-  WAKE_OF_ASHES_RETRIBUTION_TALENT: {
-    id: 255937,
-    name: 'Wake of Ashes',
-    icon: 'inv_sword_2h_artifactashbringerfire_d_03',
-    maxRanks: 1,
-  },
-  CONSECRATED_BLADE_RETRIBUTION_TALENT: {
-    id: 382275,
-    name: 'Consecrated Blade',
-    icon: 'ability_mage_firestarter',
-    maxRanks: 1,
-  },
-  SEAL_OF_WRATH_RETRIBUTION_TALENT: {
-    id: 386901,
-    name: 'Seal of Wrath',
-    icon: 'ability_paladin_empoweredsealstruth',
-    maxRanks: 1,
-  },
-  EXPURGATION_RETRIBUTION_TALENT: {
-    id: 383344,
-    name: 'Expurgation',
-    icon: 'ability_paladin_bladeofjusticeblue',
-    maxRanks: 1,
-  },
-  BOUNDLESS_JUDGMENT_RETRIBUTION_TALENT: {
-    id: 383876,
-    name: 'Boundless Judgment',
-    icon: 'ability_paladin_judgementofthewise',
-    maxRanks: 1,
-  },
-  SANCTIFICATION_RETRIBUTION_TALENT: {
-    id: 382430,
-    name: 'Sanctification',
-    icon: 'spell_holy_surgeoflight',
-    maxRanks: 1,
-  },
-  INNER_POWER_RETRIBUTION_TALENT: {
-    id: 383334,
-    name: 'Inner Power',
-    icon: 'ability_paladin_toweroflight',
-    maxRanks: 1,
-  },
-  ASHES_TO_DUST_RETRIBUTION_TALENT: {
-    id: 383300,
-    name: 'Ashes to Dust',
-    icon: 'inv_sword_2h_artifactashbringerpurified_d_02',
-    maxRanks: 1,
-  },
-  PATH_OF_RUIN_RETRIBUTION_TALENT: {
-    id: 384052,
-    name: 'Path of Ruin',
-    icon: 'inv_sword_2h_artifactashbringerfire_d_02',
-    maxRanks: 1,
-  },
-  AVENGING_WRATH_MIGHT_RETRIBUTION_TALENT: {
-    id: 384442,
-    name: 'Avenging Wrath: Might',
-    icon: 'spell_holy_avenginewrath',
-    maxRanks: 1,
-  },
-  CRUSADE_RETRIBUTION_TALENT: {
-    id: 384392,
-    name: 'Crusade',
-    icon: 'ability_paladin_sanctifiedwrath',
-    maxRanks: 1,
-  },
-  TRUTHS_WAKE_RETRIBUTION_TALENT: {
-    id: 383350,
-    name: "Truth's Wake",
-    icon: 'inv_mace_104',
-    maxRanks: 1,
-  },
-  EMPYREAN_POWER_RETRIBUTION_TALENT: {
-    id: 326732,
-    name: 'Empyrean Power',
-    icon: 'ability_paladin_sheathoflight',
-    maxRanks: 1,
-  },
-  FIRES_OF_JUSTICE_RETRIBUTION_TALENT: {
-    id: 203316,
-    name: 'Fires of Justice',
-    icon: 'spell_holy_crusaderstrike',
-    maxRanks: 1,
-  },
-  SEALED_VERDICT_RETRIBUTION_TALENT: {
-    id: 387640,
-    name: 'Sealed Verdict',
-    icon: 'ability_paladin_swiftretribution',
-    maxRanks: 2,
-  },
-  CONSECRATED_GROUND_RETRIBUTION_TALENT: {
-    id: 204054,
-    name: 'Consecrated Ground',
-    icon: 'ability_paladin_righteousvengeance',
-    maxRanks: 1,
-  },
-  SANCTIFIED_GROUND_RETRIBUTION_TALENT: {
-    id: 387479,
-    name: 'Sanctified Ground',
-    icon: 'warrior_talent_icon_skirmisher',
-    maxRanks: 1,
-  },
-  EXORCISM_RETRIBUTION_TALENT: {
-    id: 383185,
-    name: 'Exorcism',
-    icon: 'spell_holy_excorcism_02',
-    maxRanks: 1,
-  },
-  HAND_OF_HINDRANCE_RETRIBUTION_TALENT: {
-    id: 183218,
-    name: 'Hand of Hindrance',
-    icon: 'ability_paladin_handofhindrance',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  SELFLESS_HEALER_RETRIBUTION_TALENT: {
-    id: 85804,
-    name: 'Selfless Healer',
-    icon: 'ability_paladin_gaurdedbythelight',
-    maxRanks: 1,
-  },
-  HEALING_HANDS_RETRIBUTION_TALENT: {
-    id: 326734,
-    name: 'Healing Hands',
-    icon: 'ability_paladin_infusionoflight',
-    maxRanks: 1,
-  },
-  TEMPEST_OF_THE_LIGHTBRINGER_RETRIBUTION_TALENT: {
-    id: 383396,
-    name: 'Tempest of the Lightbringer',
-    icon: 'ability_malkorok_blightofyshaarj_yellow',
-    maxRanks: 1,
-  },
-  JUSTICARS_VENGEANCE_RETRIBUTION_TALENT: {
-    id: 215661,
-    name: "Justicar's Vengeance",
-    icon: 'spell_holy_retributionaura',
-    maxRanks: 1,
-    holyPowerCost: 3,
-  },
-  EYE_FOR_AN_EYE_RETRIBUTION_TALENT: {
-    id: 205191,
-    name: 'Eye for an Eye',
-    icon: 'spell_holy_weaponmastery',
-    maxRanks: 1,
-  },
-  RELENTLESS_INQUISITOR_RETRIBUTION_TALENT: {
-    id: 383388,
-    name: 'Relentless Inquisitor',
-    icon: 'spell_holy_divinepurpose',
-    maxRanks: 2,
-  },
-  ASHES_TO_ASHES_RETRIBUTION_TALENT: {
-    id: 383276,
-    name: 'Ashes to Ashes',
-    icon: 'inv_artifact_ashes_to_ashes',
-    maxRanks: 2,
-  },
-  TEMPLARS_VINDICATION_RETRIBUTION_TALENT: {
-    id: 383274,
-    name: "Templar's Vindication",
-    icon: 'ability_priest_evangelism',
-    maxRanks: 2,
-  },
-  EXECUTION_SENTENCE_RETRIBUTION_TALENT: {
-    id: 343527,
-    name: 'Execution Sentence',
-    icon: 'spell_paladin_executionsentence',
-    maxRanks: 1,
-    holyPowerCost: 3,
-  },
-  DIVINE_TOLL_RETRIBUTION_TALENT: {
-    id: 375576,
-    name: 'Divine Toll',
-    icon: 'ability_bastion_paladin',
-    maxRanks: 1,
-    manaCost: 1500,
-  },
-  EMPYREAN_ENDOWMENT_RETRIBUTION_TALENT: {
-    id: 387170,
-    name: 'Empyrean Endowment',
-    icon: 'item_holyspark',
-    maxRanks: 1,
-  },
-  VIRTUOUS_COMMAND_RETRIBUTION_TALENT: {
-    id: 383304,
-    name: 'Virtuous Command',
-    icon: 'spell_holy_sealofvengeance',
-    maxRanks: 2,
-  },
-  FINAL_VERDICT_RETRIBUTION_TALENT: {
-    id: 383327,
-    name: 'Final Verdict',
-    icon: 'spell_paladin_templarsverdict',
-    maxRanks: 1,
-  },
-  EXECUTIONERS_WILL_RETRIBUTION_TALENT: {
-    id: 384162,
-    name: "Executioner's Will",
-    icon: 'inv_helm_plate_raidpaladinmythic_q_01',
-    maxRanks: 1,
-  },
-  EXECUTIONERS_WRATH_RETRIBUTION_TALENT: {
-    id: 387196,
-    name: "Executioner's Wrath",
-    icon: 'inv_glove_plate_raidpaladinmythic_q_01',
-    maxRanks: 1,
-  },
-  DIVINE_RESONANCE_RETRIBUTION_TALENT: {
-    id: 384027,
-    name: 'Divine Resonance',
-    icon: 'ability_bastion_paladin',
-    maxRanks: 1,
-  },
-  FINAL_RECKONING_RETRIBUTION_TALENT: {
-    id: 343721,
-    name: 'Final Reckoning',
-    icon: 'spell_holy_blessedresillience',
-    maxRanks: 1,
-  },
-  VANGUARDS_MOMENTUM_RETRIBUTION_TALENT: {
-    id: 383314,
-    name: "Vanguard's Momentum",
-    icon: 'ability_paladin_speedoflight',
-    maxRanks: 2,
-  },
+  BLADE_OF_JUSTICE_RETRIBUTION_TALENT,
+  DIVINE_STORM_RETRIBUTION_TALENT,
+  ART_OF_WAR_RETRIBUTION_TALENT,
+  TIMELY_JUDGMENT_RETRIBUTION_TALENT,
+  IMPROVED_CRUSADER_STRIKE_RETRIBUTION_TALENT,
+  HOLY_CRUSADER_RETRIBUTION_TALENT,
+  HOLY_BLADE_RETRIBUTION_TALENT,
+  CONDEMNING_BLADE_RETRIBUTION_TALENT,
+  ZEAL_RETRIBUTION_TALENT,
+  SHIELD_OF_VENGEANCE_RETRIBUTION_TALENT,
+  DIVINE_PROTECTION_RETRIBUTION_TALENT,
+  BLADE_OF_WRATH_RETRIBUTION_TALENT,
+  HIGHLORDS_JUDGMENT_RETRIBUTION_TALENT,
+  RIGHTEOUS_VERDICT_RETRIBUTION_TALENT,
+  CALM_BEFORE_THE_STORM_RETRIBUTION_TALENT,
+  WAKE_OF_ASHES_RETRIBUTION_TALENT,
+  CONSECRATED_BLADE_RETRIBUTION_TALENT,
+  SEAL_OF_WRATH_RETRIBUTION_TALENT,
+  EXPURGATION_RETRIBUTION_TALENT,
+  BOUNDLESS_JUDGMENT_RETRIBUTION_TALENT,
+  SANCTIFICATION_RETRIBUTION_TALENT,
+  INNER_POWER_RETRIBUTION_TALENT,
+  ASHES_TO_DUST_RETRIBUTION_TALENT,
+  PATH_OF_RUIN_RETRIBUTION_TALENT,
+  AVENGING_WRATH_MIGHT_RETRIBUTION_TALENT,
+  CRUSADE_RETRIBUTION_TALENT,
+  TRUTHS_WAKE_RETRIBUTION_TALENT,
+  EMPYREAN_POWER_RETRIBUTION_TALENT,
+  FIRES_OF_JUSTICE_RETRIBUTION_TALENT,
+  SEALED_VERDICT_RETRIBUTION_TALENT,
+  CONSECRATED_GROUND_RETRIBUTION_TALENT,
+  SANCTIFIED_GROUND_RETRIBUTION_TALENT,
+  EXORCISM_RETRIBUTION_TALENT,
+  HAND_OF_HINDRANCE_RETRIBUTION_TALENT,
+  SELFLESS_HEALER_RETRIBUTION_TALENT,
+  HEALING_HANDS_RETRIBUTION_TALENT,
+  TEMPEST_OF_THE_LIGHTBRINGER_RETRIBUTION_TALENT,
+  JUSTICARS_VENGEANCE_RETRIBUTION_TALENT,
+  EYE_FOR_AN_EYE_RETRIBUTION_TALENT,
+  RELENTLESS_INQUISITOR_RETRIBUTION_TALENT,
+  ASHES_TO_ASHES_RETRIBUTION_TALENT,
+  TEMPLARS_VINDICATION_RETRIBUTION_TALENT,
+  EXECUTION_SENTENCE_RETRIBUTION_TALENT,
+  DIVINE_TOLL_RETRIBUTION_TALENT,
+  EMPYREAN_ENDOWMENT_RETRIBUTION_TALENT,
+  VIRTUOUS_COMMAND_RETRIBUTION_TALENT,
+  FINAL_VERDICT_RETRIBUTION_TALENT,
+  EXECUTIONERS_WILL_RETRIBUTION_TALENT,
+  EXECUTIONERS_WRATH_RETRIBUTION_TALENT,
+  DIVINE_RESONANCE_RETRIBUTION_TALENT,
+  FINAL_RECKONING_RETRIBUTION_TALENT,
+  VANGUARDS_MOMENTUM_RETRIBUTION_TALENT,
 
   //Holy
-  HOLY_SHOCK_HOLY_TALENT: {
-    id: 20473,
-    name: 'Holy Shock',
-    icon: 'spell_holy_searinglight',
-    maxRanks: 1,
-    manaCost: 1600,
-  },
-  HOLY_LIGHT_HOLY_TALENT: {
-    id: 82326,
-    name: 'Holy Light',
-    icon: 'spell_holy_surgeoflight',
-    maxRanks: 1,
-    manaCost: 1500,
-  },
-  LIGHT_OF_DAWN_HOLY_TALENT: {
-    id: 85222,
-    name: 'Light of Dawn',
-    icon: 'spell_paladin_lightofdawn',
-    maxRanks: 1,
-    holyPowerCost: 3,
-  },
-  ILLUMINATION_HOLY_TALENT: {
-    id: 387993,
-    name: 'Illumination',
-    icon: 'spell_paladin_clarityofpurpose',
-    maxRanks: 1,
-  },
-  INFUSION_OF_LIGHT_HOLY_TALENT: {
-    id: 53576,
-    name: 'Infusion of Light',
-    icon: 'ability_paladin_infusionoflight',
-    maxRanks: 1,
-  },
-  BESTOW_FAITH_HOLY_TALENT: {
-    id: 223306,
-    name: 'Bestow Faith',
-    icon: 'ability_paladin_blessedmending',
-    maxRanks: 1,
-    manaCost: 600,
-  },
-  UNENDING_LIGHT_NYI_HOLY_TALENT: {
-    id: 387998,
-    name: 'Unending Light (NYI)',
-    icon: 'spell_holy_holybolt',
-    maxRanks: 1,
-  },
-  FOCAL_LIGHT_HOLY_TALENT: {
-    id: 387781,
-    name: 'Focal Light',
-    icon: 'ability_paladin_beaconoflight',
-    maxRanks: 2,
-  },
-  DIVINE_PROTECTION_HOLY_TALENT: {
-    id: 498,
-    name: 'Divine Protection',
-    icon: 'spell_holy_divineprotection',
-    maxRanks: 1,
-    manaCost: 300,
-  },
-  SAVED_BY_THE_LIGHT_HOLY_TALENT: {
-    id: 157047,
-    name: 'Saved by the Light',
-    icon: 'ability_paladin_savedbythelight',
-    maxRanks: 2,
-  },
-  RADIANT_ONSLAUGHT_HOLY_TALENT: {
-    id: 231667,
-    name: 'Radiant Onslaught',
-    icon: 'spell_holy_crusaderstrike',
-    maxRanks: 1,
-  },
-  LIGHTS_HAMMER_HOLY_TALENT: {
-    id: 114158,
-    name: "Light's Hammer",
-    icon: 'spell_paladin_lightshammer',
-    maxRanks: 1,
-    manaCost: 1800,
-  },
-  HOLY_PRISM_HOLY_TALENT: {
-    id: 114165,
-    name: 'Holy Prism',
-    icon: 'spell_paladin_holyprism',
-    maxRanks: 1,
-    manaCost: 1300,
-  },
-  MOMENT_OF_COMPASSION_HOLY_TALENT: {
-    id: 387786,
-    name: 'Moment of Compassion',
-    icon: 'spell_holy_flashheal',
-    maxRanks: 1,
-  },
-  AURA_MASTERY_HOLY_TALENT: {
-    id: 31821,
-    name: 'Aura Mastery',
-    icon: 'spell_holy_auramastery',
-    maxRanks: 1,
-  },
-  TOWER_OF_RADIANCE_HOLY_TALENT: {
-    id: 231642,
-    name: 'Tower of Radiance',
-    icon: 'ability_paladin_beaconoflight',
-    maxRanks: 1,
-  },
-  SHINING_SAVIOR_HOLY_TALENT: {
-    id: 388005,
-    name: 'Shining Savior',
-    icon: 'ability_paladin_longarmofthelaw',
-    maxRanks: 1,
-  },
-  LIGHT_OF_THE_MARTYR_HOLY_TALENT: {
-    id: 183998,
-    name: 'Light of the Martyr',
-    icon: 'ability_paladin_lightofthemartyr',
-    maxRanks: 1,
-    manaCost: 700,
-  },
-  EMPYREAL_WARD_HOLY_TALENT: {
-    id: 387791,
-    name: 'Empyreal Ward',
-    icon: 'spell_holy_layonhands',
-    maxRanks: 1,
-  },
-  PROTECTION_OF_TYR_HOLY_TALENT: {
-    id: 200430,
-    name: 'Protection of Tyr',
-    icon: 'spell_holy_auramastery',
-    maxRanks: 2,
-  },
-  RULE_OF_LAW_HOLY_TALENT: {
-    id: 214202,
-    name: 'Rule of Law',
-    icon: 'ability_paladin_longarmofthelaw',
-    maxRanks: 1,
-  },
-  ECHOING_BLESSINGS_HOLY_TALENT: {
-    id: 387801,
-    name: 'Echoing Blessings',
-    icon: 'achievement_dungeon_heroic_gloryoftheraider',
-    maxRanks: 1,
-  },
-  SCINTILLATION_HOLY_TALENT: {
-    id: 387805,
-    name: 'Scintillation',
-    icon: 'achievement_dungeon_heroic_gloryoftheraider',
-    maxRanks: 2,
-  },
-  DIVINE_REVELATIONS_HOLY_TALENT: {
-    id: 387808,
-    name: 'Divine Revelations',
-    icon: 'ability_paladin_infusionoflight',
-    maxRanks: 3,
-  },
-  SECOND_SUNRISE_HOLY_TALENT: {
-    id: 200482,
-    name: 'Second Sunrise',
-    icon: 'spell_paladin_lightofdawn',
-    maxRanks: 2,
-  },
-  UNTEMPERED_DEDICATION_HOLY_TALENT: {
-    id: 387814,
-    name: 'Untempered Dedication',
-    icon: 'achievement_admiral_of_the_light',
-    maxRanks: 1,
-  },
-  CRUSADERS_MIGHT_HOLY_TALENT: {
-    id: 196926,
-    name: "Crusader's Might",
-    icon: 'ability_paladin_swiftretribution',
-    maxRanks: 2,
-  },
-  BLESSING_OF_SUMMER_HOLY_TALENT: {
-    id: 388007,
-    name: 'Blessing of Summer',
-    icon: 'ability_ardenweald_paladin_summer',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  GLIMMER_OF_LIGHT_HOLY_TALENT: {
-    id: 325966,
-    name: 'Glimmer of Light',
-    icon: 'ability_paladin_toweroflight',
-    maxRanks: 1,
-  },
-  POWER_OF_THE_SILVER_HAND_HOLY_TALENT: {
-    id: 200474,
-    name: 'Power of the Silver Hand',
-    icon: 'ability_paladin_blessedhands',
-    maxRanks: 1,
-  },
-  BEACON_OF_FAITH_HOLY_TALENT: {
-    id: 156910,
-    name: 'Beacon of Faith',
-    icon: 'ability_paladin_beaconsoflight',
-    maxRanks: 1,
-    manaCost: 300,
-  },
-  BEACON_OF_VIRTUE_HOLY_TALENT: {
-    id: 200025,
-    name: 'Beacon of Virtue',
-    icon: 'ability_paladin_beaconofinsight',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  MARAADS_DYING_BREATH_HOLY_TALENT: {
-    id: 388018,
-    name: "Maraad's Dying Breath",
-    icon: 'paladin_icon_speedoflight',
-    maxRanks: 1,
-  },
-  DIVINE_TOLL_HOLY_TALENT: {
-    id: 375576,
-    name: 'Divine Toll',
-    icon: 'ability_bastion_paladin',
-    maxRanks: 1,
-    manaCost: 1500,
-  },
-  BARRIER_OF_FAITH_HOLY_TALENT: {
-    id: 148039,
-    name: 'Barrier of Faith',
-    icon: 'ability_paladin_blessedmending',
-    maxRanks: 1,
-    manaCost: 900,
-  },
-  AVENGING_WRATH_MIGHT_NYI_HOLY_TALENT: {
-    id: 388006,
-    name: 'Avenging Wrath: Might (NYI)',
-    icon: 'spell_holy_avenginewrath',
-    maxRanks: 1,
-  },
-  AVENGING_CRUSADER_HOLY_TALENT: {
-    id: 216331,
-    name: 'Avenging Crusader',
-    icon: 'ability_paladin_veneration',
-    maxRanks: 1,
-    manaCost: 5000,
-  },
-  BREAKING_DAWN_HOLY_TALENT: {
-    id: 387879,
-    name: 'Breaking Dawn',
-    icon: 'spell_paladin_lightofdawn',
-    maxRanks: 1,
-  },
-  TYRS_DELIVERANCE_HOLY_TALENT: {
-    id: 200652,
-    name: "Tyr's Deliverance",
-    icon: 'inv_mace_2h_artifactsilverhand_d_01',
-    maxRanks: 1,
-  },
-  DIVINE_RESONANCE_HOLY_TALENT: {
-    id: 387893,
-    name: 'Divine Resonance',
-    icon: 'ability_bastion_paladin',
-    maxRanks: 1,
-  },
-  LIADRINS_FURY_UNLEASHED_HOLY_TALENT: {
-    id: 208408,
-    name: "Liadrin's Fury Unleashed",
-    icon: 'ability_warrior_unrelentingassault',
-    maxRanks: 2,
-  },
-  AWAKENING_HOLY_TALENT: {
-    id: 248033,
-    name: 'Awakening',
-    icon: 'inv_helm_plate_raidpaladin_n_01',
-    maxRanks: 2,
-  },
-  TYRS_MUNIFICENCE_HOLY_TALENT: {
-    id: 238060,
-    name: "Tyr's Munificence",
-    icon: 'inv_mace_2h_artifactsilverhand_d_01',
-    maxRanks: 1,
-  },
+  HOLY_SHOCK_HOLY_TALENT,
+  HOLY_LIGHT_HOLY_TALENT,
+  LIGHT_OF_DAWN_HOLY_TALENT,
+  ILLUMINATION_HOLY_TALENT,
+  INFUSION_OF_LIGHT_HOLY_TALENT,
+  BESTOW_FAITH_HOLY_TALENT,
+  UNENDING_LIGHT_NYI_HOLY_TALENT,
+  FOCAL_LIGHT_HOLY_TALENT,
+  DIVINE_PROTECTION_HOLY_TALENT,
+  SAVED_BY_THE_LIGHT_HOLY_TALENT,
+  RADIANT_ONSLAUGHT_HOLY_TALENT,
+  LIGHTS_HAMMER_HOLY_TALENT,
+  HOLY_PRISM_HOLY_TALENT,
+  MOMENT_OF_COMPASSION_HOLY_TALENT,
+  AURA_MASTERY_HOLY_TALENT,
+  TOWER_OF_RADIANCE_HOLY_TALENT,
+  SHINING_SAVIOR_HOLY_TALENT,
+  LIGHT_OF_THE_MARTYR_HOLY_TALENT,
+  EMPYREAL_WARD_HOLY_TALENT,
+  PROTECTION_OF_TYR_HOLY_TALENT,
+  RULE_OF_LAW_HOLY_TALENT,
+  ECHOING_BLESSINGS_HOLY_TALENT,
+  SCINTILLATION_HOLY_TALENT,
+  DIVINE_REVELATIONS_HOLY_TALENT,
+  SECOND_SUNRISE_HOLY_TALENT,
+  UNTEMPERED_DEDICATION_HOLY_TALENT,
+  CRUSADERS_MIGHT_HOLY_TALENT,
+  BLESSING_OF_SUMMER_HOLY_TALENT,
+  GLIMMER_OF_LIGHT_HOLY_TALENT,
+  POWER_OF_THE_SILVER_HAND_HOLY_TALENT,
+  BEACON_OF_FAITH_HOLY_TALENT,
+  BEACON_OF_VIRTUE_HOLY_TALENT,
+  MARAADS_DYING_BREATH_HOLY_TALENT,
+  DIVINE_TOLL_HOLY_TALENT,
+  BARRIER_OF_FAITH_HOLY_TALENT,
+  AVENGING_WRATH_MIGHT_NYI_HOLY_TALENT,
+  AVENGING_CRUSADER_HOLY_TALENT,
+  BREAKING_DAWN_HOLY_TALENT,
+  TYRS_DELIVERANCE_HOLY_TALENT,
+  DIVINE_RESONANCE_HOLY_TALENT,
+  LIADRINS_FURY_UNLEASHED_HOLY_TALENT,
+  AWAKENING_HOLY_TALENT,
+  TYRS_MUNIFICENCE_HOLY_TALENT,
 });
 
 export default talents;

--- a/src/common/TALENTS/priest.ts
+++ b/src/common/TALENTS/priest.ts
@@ -1,1256 +1,1515 @@
 // Generated file, changes will eventually be overwritten!
-import { createTalentList } from './types';
+import { createTalentList, Talent } from './types';
+
+//region Shared
+export const RENEW_TALENT: Talent = {
+  id: 139,
+  name: 'Renew',
+  icon: 'spell_holy_renew',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const DISPEL_MAGIC_TALENT: Talent = {
+  id: 528,
+  name: 'Dispel Magic',
+  icon: 'spell_nature_nullifydisease',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const SHADOWFIEND_TALENT: Talent = {
+  id: 34433,
+  name: 'Shadowfiend',
+  icon: 'spell_shadow_shadowfiend',
+  maxRanks: 1,
+};
+export const PRAYER_OF_MENDING_TALENT: Talent = {
+  id: 33076,
+  name: 'Prayer of Mending',
+  icon: 'spell_holy_prayerofmendingtga',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const LEAP_OF_FAITH_TALENT: Talent = {
+  id: 73325,
+  name: 'Leap of Faith',
+  icon: 'priest_spell_leapoffaith_a',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const IMPROVED_PURIFY_TALENT: Talent = {
+  id: 390632,
+  name: 'Improved Purify',
+  icon: 'spell_holy_nullifydisease',
+  maxRanks: 1,
+};
+export const SHADOW_MEND_TALENT: Talent = {
+  id: 186263,
+  name: 'Shadow Mend',
+  icon: 'spell_shadow_shadowmend',
+  maxRanks: 1,
+  manaCost: 1500,
+};
+export const SHADOW_WORD_DEATH_TALENT: Talent = {
+  id: 32379,
+  name: 'Shadow Word: Death',
+  icon: 'spell_shadow_demonicfortitude',
+  maxRanks: 1,
+  manaCost: 0,
+};
+export const FOCUSED_MENDING_TALENT: Talent = {
+  id: 372354,
+  name: 'Focused Mending',
+  icon: 'achievement_bg_returnxflags_def_wsg',
+  maxRanks: 1,
+};
+export const HOLY_NOVA_TALENT: Talent = {
+  id: 132157,
+  name: 'Holy Nova',
+  icon: 'spell_holy_holynova',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const MOVE_WITH_GRACE_TALENT: Talent = {
+  id: 390620,
+  name: 'Move with Grace',
+  icon: 'ability_priest_savinggrace',
+  maxRanks: 1,
+};
+export const BODY_AND_SOUL_TALENT: Talent = {
+  id: 64129,
+  name: 'Body and Soul',
+  icon: 'spell_holy_symbolofhope',
+  maxRanks: 1,
+};
+export const MASOCHISM_TALENT: Talent = {
+  id: 193063,
+  name: 'Masochism',
+  icon: 'spell_shadow_misery',
+  maxRanks: 1,
+};
+export const DEPTH_OF_THE_SHADOWS_TALENT: Talent = {
+  id: 390615,
+  name: 'Depth of the Shadows',
+  icon: 'spell_shadow_shadowmend',
+  maxRanks: 1,
+};
+export const THROES_OF_PAIN_TALENT: Talent = {
+  id: 377422,
+  name: 'Throes of Pain',
+  icon: 'spell_shadow_haunting',
+  maxRanks: 1,
+};
+export const DEATH_AND_MADNESS_TALENT: Talent = {
+  id: 321291,
+  name: 'Death and Madness',
+  icon: 'spell_shadow_demonicfortitude',
+  maxRanks: 1,
+};
+export const SPELL_WARDING_TALENT: Talent = {
+  id: 390667,
+  name: 'Spell Warding',
+  icon: 'spell_holy_spellwarding',
+  maxRanks: 1,
+};
+export const RHAPSODY_TALENT: Talent = {
+  id: 390622,
+  name: 'Rhapsody',
+  icon: 'spell_holy_holynova',
+  maxRanks: 1,
+};
+export const ANGELIC_FEATHER_TALENT: Talent = {
+  id: 121536,
+  name: 'Angelic Feather',
+  icon: 'ability_priest_angelicfeather',
+  maxRanks: 1,
+};
+export const SHACKLE_UNDEAD_TALENT: Talent = {
+  id: 9484,
+  name: 'Shackle Undead',
+  icon: 'spell_nature_slow',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const SHEER_TERROR_TALENT: Talent = {
+  id: 390919,
+  name: 'Sheer Terror',
+  icon: 'spell_nzinsanity_fearofdeath',
+  maxRanks: 1,
+};
+export const VOID_TENDRILS_TALENT: Talent = {
+  id: 108920,
+  name: 'Void Tendrils',
+  icon: 'spell_priest_voidtendrils',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const MIND_CONTROL_TALENT: Talent = {
+  id: 605,
+  name: 'Mind Control',
+  icon: 'spell_shadow_shadowworddominate',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const TOOLS_OF_THE_CLOTH_TALENT: Talent = {
+  id: 377438,
+  name: 'Tools of the Cloth',
+  icon: 'spell_holy_devineaegis',
+  maxRanks: 1,
+};
+export const MASS_DISPEL_TALENT: Talent = {
+  id: 32375,
+  name: 'Mass Dispel',
+  icon: 'spell_arcane_massdispel',
+  maxRanks: 1,
+  manaCost: 4000,
+};
+export const POWER_INFUSION_TALENT: Talent = {
+  id: 10060,
+  name: 'Power Infusion',
+  icon: 'spell_holy_powerinfusion',
+  maxRanks: 1,
+};
+export const VAMPIRIC_EMBRACE_TALENT: Talent = {
+  id: 15286,
+  name: 'Vampiric Embrace',
+  icon: 'spell_shadow_unsummonbuilding',
+  maxRanks: 1,
+};
+export const DOMINANT_MIND_TALENT: Talent = {
+  id: 205367,
+  name: 'Dominant Mind',
+  icon: 'spell_priest_void_flay',
+  maxRanks: 1,
+};
+export const INSPIRATION_TALENT: Talent = {
+  id: 390676,
+  name: 'Inspiration',
+  icon: 'spell_holy_layonhands',
+  maxRanks: 1,
+};
+export const BLESSED_RECOVERY_TALENT: Talent = {
+  id: 390767,
+  name: 'Blessed Recovery',
+  icon: 'spell_holy_blessedrecovery',
+  maxRanks: 1,
+};
+export const IMPROVED_MASS_DISPEL_TALENT: Talent = {
+  id: 341167,
+  name: 'Improved Mass Dispel',
+  icon: 'spell_arcane_massdispel',
+  maxRanks: 1,
+};
+export const PSYCHIC_VOICE_TALENT: Talent = {
+  id: 196704,
+  name: 'Psychic Voice',
+  icon: 'ability_warrior_commandingshout',
+  maxRanks: 1,
+};
+export const TWINS_OF_THE_SUN_PRIESTESS_TALENT: Talent = {
+  id: 373466,
+  name: 'Twins of the Sun Priestess',
+  icon: 'spell_fire_felflamering_red',
+  maxRanks: 1,
+};
+export const VOID_SHIELD_TALENT: Talent = {
+  id: 280749,
+  name: 'Void Shield',
+  icon: 'inv_enchant_voidsphere',
+  maxRanks: 1,
+};
+export const SANLAYN_TALENT: Talent = {
+  id: 199855,
+  name: "San'layn",
+  icon: 'achievement_boss_lanathel',
+  maxRanks: 1,
+};
+export const APATHY_TALENT: Talent = {
+  id: 390668,
+  name: 'Apathy',
+  icon: 'ability_rogue_masterofsubtlety',
+  maxRanks: 1,
+};
+export const UNWAVERING_WILL_TALENT: Talent = {
+  id: 373456,
+  name: 'Unwavering Will',
+  icon: 'ability_warrior_unrelentingassault',
+  maxRanks: 2,
+};
+export const TWIST_OF_FATE_TALENT: Talent = {
+  id: 390972,
+  name: 'Twist of Fate',
+  icon: 'spell_shadow_mindtwisting',
+  maxRanks: 2,
+};
+export const IMPROVED_MIND_BLAST_TALENT: Talent = {
+  id: 319899,
+  name: 'Improved Mind Blast',
+  icon: 'spell_shadow_unholyfrenzy',
+  maxRanks: 2,
+};
+export const ANGELS_MERCY_TALENT: Talent = {
+  id: 238100,
+  name: "Angel's Mercy",
+  icon: 'spell_holy_testoffaith',
+  maxRanks: 1,
+};
+export const BINDING_HEALS_TALENT: Talent = {
+  id: 368275,
+  name: 'Binding Heals',
+  icon: 'spell_holy_blindingheal',
+  maxRanks: 1,
+};
+export const DIVINE_STAR_TALENT: Talent = {
+  id: 110744,
+  name: 'Divine Star',
+  icon: 'spell_priest_divinestar',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const HALO_TALENT: Talent = {
+  id: 120517,
+  name: 'Halo',
+  icon: 'ability_priest_halo',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const TRANSLUCENT_IMAGE_TALENT: Talent = {
+  id: 373446,
+  name: 'Translucent Image',
+  icon: 'spell_nature_invisibilty',
+  maxRanks: 1,
+};
+export const PHANTASM_TALENT: Talent = {
+  id: 108942,
+  name: 'Phantasm',
+  icon: 'ability_priest_phantasm',
+  maxRanks: 1,
+};
+export const MINDGAMES_TALENT: Talent = {
+  id: 375901,
+  name: 'Mindgames',
+  icon: 'ability_revendreth_priest',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const SURGE_OF_LIGHT_TALENT: Talent = {
+  id: 109186,
+  name: 'Surge of Light',
+  icon: 'spell_holy_surgeoflight',
+  maxRanks: 2,
+};
+export const LIGHTS_INSPIRATION_TALENT: Talent = {
+  id: 373450,
+  name: "Light's Inspiration",
+  icon: 'spell_holy_restoration',
+  maxRanks: 2,
+};
+export const CRYSTALLINE_REFLECTION_TALENT: Talent = {
+  id: 373457,
+  name: 'Crystalline Reflection',
+  icon: 'ability_priest_reflectiveshield',
+  maxRanks: 2,
+};
+export const IMPROVED_FADE_TALENT: Talent = {
+  id: 390670,
+  name: 'Improved Fade',
+  icon: 'spell_magic_lesserinvisibilty',
+  maxRanks: 2,
+};
+export const MANIPULATION_TALENT: Talent = {
+  id: 390996,
+  name: 'Manipulation',
+  icon: 'ability_revendreth_priest',
+  maxRanks: 2,
+};
+export const HOLY_WORD_LIFE_TALENT: Talent = {
+  id: 373481,
+  name: 'Holy Word: Life',
+  icon: 'ability_priest_holywordlife',
+  maxRanks: 1,
+  manaCost: 0,
+};
+export const ANGELIC_BULWARK_TALENT: Talent = {
+  id: 108945,
+  name: 'Angelic Bulwark',
+  icon: 'ability_priest_angelicbulwark',
+  maxRanks: 1,
+};
+export const VOID_SHIFT_TALENT: Talent = {
+  id: 108968,
+  name: 'Void Shift',
+  icon: 'spell_priest_voidshift',
+  maxRanks: 1,
+};
+export const SHATTERED_PERCEPTIONS_TALENT: Talent = {
+  id: 391112,
+  name: 'Shattered Perceptions',
+  icon: 'spell_animarevendreth_debuff',
+  maxRanks: 1,
+};
+export const PURIFY_DISEASE_TALENT: Talent = {
+  id: 213634,
+  name: 'Purify Disease',
+  icon: 'spell_holy_nullifydisease',
+  maxRanks: 1,
+  manaCost: 500,
+};
+
+//endregion
+
+//region Discipline
+export const ATONEMENT_DISCIPLINE_TALENT: Talent = {
+  id: 81749,
+  name: 'Atonement',
+  icon: 'ability_priest_atonement',
+  maxRanks: 1,
+};
+export const POWER_WORD_RADIANCE_DISCIPLINE_TALENT: Talent = {
+  id: 194509,
+  name: 'Power Word: Radiance',
+  icon: 'spell_priest_power_word',
+  maxRanks: 1,
+  manaCost: 3000,
+};
+export const PAIN_SUPPRESSION_DISCIPLINE_TALENT: Talent = {
+  id: 33206,
+  name: 'Pain Suppression',
+  icon: 'spell_holy_painsupression',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const POWER_OF_THE_DARK_SIDE_DISCIPLINE_TALENT: Talent = {
+  id: 198068,
+  name: 'Power of the Dark Side',
+  icon: 'inv_artifact_powerofthedarkside',
+  maxRanks: 1,
+};
+export const LIGHTS_PROMISE_DISCIPLINE_TALENT: Talent = {
+  id: 322115,
+  name: "Light's Promise",
+  icon: 'spell_priest_power_word',
+  maxRanks: 1,
+};
+export const PAIN_TRANSFORMATION_DISCIPLINE_TALENT: Talent = {
+  id: 372991,
+  name: 'Pain Transformation',
+  icon: 'spell_holy_blessedrecovery',
+  maxRanks: 1,
+};
+export const PROTECTOR_OF_THE_FRAIL_DISCIPLINE_TALENT: Talent = {
+  id: 373035,
+  name: 'Protector of the Frail',
+  icon: 'ability_racial_forceshield',
+  maxRanks: 1,
+};
+export const DARK_INDULGENCE_DISCIPLINE_TALENT: Talent = {
+  id: 372972,
+  name: 'Dark Indulgence',
+  icon: 'spell_shadow_painandsuffering',
+  maxRanks: 1,
+};
+export const SCHISM_DISCIPLINE_TALENT: Talent = {
+  id: 214621,
+  name: 'Schism',
+  icon: 'spell_warlock_focusshadow',
+  maxRanks: 1,
+  manaCost: 0,
+};
+export const BRIGHT_PUPIL_DISCIPLINE_TALENT: Talent = {
+  id: 390684,
+  name: 'Bright Pupil',
+  icon: 'spell_holy_surgeoflight',
+  maxRanks: 1,
+};
+export const ENDURING_LUMINESCENCE_DISCIPLINE_TALENT: Talent = {
+  id: 390685,
+  name: 'Enduring Luminescence',
+  icon: 'ability_priest_holybolts01',
+  maxRanks: 1,
+};
+export const SHIELD_DISCIPLINE_DISCIPLINE_TALENT: Talent = {
+  id: 197045,
+  name: 'Shield Discipline',
+  icon: 'spell_holy_divineprotection',
+  maxRanks: 1,
+};
+export const POWER_WORD_SOLACE_DISCIPLINE_TALENT: Talent = {
+  id: 129250,
+  name: 'Power Word: Solace',
+  icon: 'ability_priest_flashoflight',
+  maxRanks: 1,
+};
+export const POWER_WORD_BARRIER_DISCIPLINE_TALENT: Talent = {
+  id: 62618,
+  name: 'Power Word: Barrier',
+  icon: 'spell_holy_powerwordbarrier',
+  maxRanks: 1,
+  manaCost: 2000,
+};
+export const PAINFUL_PUNISHMENT_DISCIPLINE_TALENT: Talent = {
+  id: 390686,
+  name: 'Painful Punishment',
+  icon: 'ability_priest_clarityofpower',
+  maxRanks: 1,
+};
+export const MALICIOUS_SCISSION_DISCIPLINE_TALENT: Talent = {
+  id: 372969,
+  name: 'Malicious Scission',
+  icon: 'ability_demonhunter_darkness',
+  maxRanks: 1,
+};
+export const PURGE_THE_WICKED_DISCIPLINE_TALENT: Talent = {
+  id: 204197,
+  name: 'Purge the Wicked',
+  icon: 'ability_mage_firestarter',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const RAPTURE_DISCIPLINE_TALENT: Talent = {
+  id: 47536,
+  name: 'Rapture',
+  icon: 'spell_holy_rapture',
+  maxRanks: 1,
+  manaCost: 1500,
+};
+export const SPIRIT_SHELL_DISCIPLINE_TALENT: Talent = {
+  id: 109964,
+  name: 'Spirit Shell',
+  icon: 'ability_shaman_astralshift',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const SHADOW_COVENANT_DISCIPLINE_TALENT: Talent = {
+  id: 314867,
+  name: 'Shadow Covenant',
+  icon: 'spell_shadow_summonvoidwalker',
+  maxRanks: 1,
+  manaCost: 2000,
+};
+export const REVEL_IN_PURITY_DISCIPLINE_TALENT: Talent = {
+  id: 373003,
+  name: 'Revel in Purity',
+  icon: 'spell_fire_felflamering_red',
+  maxRanks: 1,
+};
+export const CONTRITION_DISCIPLINE_TALENT: Talent = {
+  id: 197419,
+  name: 'Contrition',
+  icon: 'ability_priest_savinggrace',
+  maxRanks: 2,
+};
+export const EXALTATION_DISCIPLINE_TALENT: Talent = {
+  id: 373042,
+  name: 'Exaltation',
+  icon: 'spell_holy_spiritualguidence',
+  maxRanks: 1,
+};
+export const IMPROVED_SHADOW_WORD_PAIN_DISCIPLINE_TALENT: Talent = {
+  id: 390689,
+  name: 'Improved Shadow Word: Pain',
+  icon: 'spell_shadow_shadowwordpain',
+  maxRanks: 2,
+};
+export const EMBRACE_SHADOW_DISCIPLINE_TALENT: Talent = {
+  id: 372985,
+  name: 'Embrace Shadow',
+  icon: 'spell_warlock_demonsoul',
+  maxRanks: 1,
+};
+export const TWILIGHT_CORRUPTION_DISCIPLINE_TALENT: Talent = {
+  id: 373065,
+  name: 'Twilight Corruption',
+  icon: 'spell_fire_twilightimmolation',
+  maxRanks: 1,
+};
+export const BORROWED_TIME_DISCIPLINE_TALENT: Talent = {
+  id: 390691,
+  name: 'Borrowed Time',
+  icon: 'spell_holy_borrowedtime',
+  maxRanks: 2,
+};
+export const CASTIGATION_DISCIPLINE_TALENT: Talent = {
+  id: 193134,
+  name: 'Castigation',
+  icon: 'spell_holy_searinglightpriest',
+  maxRanks: 1,
+};
+export const STOLEN_PSYCHE_DISCIPLINE_TALENT: Talent = {
+  id: 373054,
+  name: 'Stolen Psyche',
+  icon: 'ability_priest_surgeofdarkness',
+  maxRanks: 2,
+};
+export const TRAIN_OF_THOUGHT_DISCIPLINE_TALENT: Talent = {
+  id: 390693,
+  name: 'Train of Thought',
+  icon: 'ability_mage_studentofthemind',
+  maxRanks: 1,
+};
+export const MAKE_AMENDS_DISCIPLINE_TALENT: Talent = {
+  id: 391079,
+  name: 'Make Amends',
+  icon: 'spell_holy_penance',
+  maxRanks: 1,
+};
+export const LIGHTS_WRATH_DISCIPLINE_TALENT: Talent = {
+  id: 373178,
+  name: "Light's Wrath",
+  icon: 'inv_staff_2h_artifacttome_d_01',
+  maxRanks: 1,
+};
+export const BALANCE_IN_ALL_THINGS_DISCIPLINE_TALENT: Talent = {
+  id: 390705,
+  name: 'Balance In All Things',
+  icon: 'ability_priest_innerlightandshadow',
+  maxRanks: 1,
+};
+export const MINDBENDER_DISCIPLINE_TALENT: Talent = {
+  id: 123040,
+  name: 'Mindbender',
+  icon: 'spell_shadow_soulleech_3',
+  maxRanks: 1,
+};
+export const DIVINE_AEGIS_DISCIPLINE_TALENT: Talent = {
+  id: 47515,
+  name: 'Divine Aegis',
+  icon: 'spell_holy_devineaegis',
+  maxRanks: 2,
+};
+export const SINS_OF_THE_MANY_DISCIPLINE_TALENT: Talent = {
+  id: 280391,
+  name: 'Sins of the Many',
+  icon: 'spell_holy_holyguidance',
+  maxRanks: 2,
+};
+export const RESPLENDENT_LIGHT_DISCIPLINE_TALENT: Talent = {
+  id: 390765,
+  name: 'Resplendent Light',
+  icon: 'spell_priest_divinestar_holy',
+  maxRanks: 2,
+};
+export const HARSH_DISCIPLINE_DISCIPLINE_TALENT: Talent = {
+  id: 373180,
+  name: 'Harsh Discipline',
+  icon: 'ability_paladin_handoflight',
+  maxRanks: 2,
+};
+export const FIENDING_DARK_DISCIPLINE_TALENT: Talent = {
+  id: 390770,
+  name: 'Fiending Dark',
+  icon: 'spell_shadow_shadowfiend',
+  maxRanks: 2,
+};
+export const EXPIATION_DISCIPLINE_TALENT: Talent = {
+  id: 390832,
+  name: 'Expiation',
+  icon: 'spell_shadow_shadowpower',
+  maxRanks: 2,
+};
+export const INDEMNITY_DISCIPLINE_TALENT: Talent = {
+  id: 373049,
+  name: 'Indemnity',
+  icon: 'spell_holy_divineprotection',
+  maxRanks: 1,
+};
+export const AEGIS_OF_WRATH_DISCIPLINE_TALENT: Talent = {
+  id: 238135,
+  name: 'Aegis of Wrath',
+  icon: 'spell_holy_powerwordshield',
+  maxRanks: 1,
+};
+export const LENIENCE_DISCIPLINE_TALENT: Talent = {
+  id: 238063,
+  name: 'Lenience',
+  icon: 'ability_priest_atonement',
+  maxRanks: 1,
+};
+export const EVANGELISM_DISCIPLINE_TALENT: Talent = {
+  id: 246287,
+  name: 'Evangelism',
+  icon: 'spell_holy_divineillumination',
+  maxRanks: 1,
+};
+export const WRATH_UNLEASHED_DISCIPLINE_TALENT: Talent = {
+  id: 390781,
+  name: 'Wrath, Unleashed',
+  icon: 'inv_staff_2h_artifacttome_d_01',
+  maxRanks: 1,
+};
+export const WEAL_AND_WOE_DISCIPLINE_TALENT: Talent = {
+  id: 390786,
+  name: 'Weal and Woe',
+  icon: 'spell_priest_burningwill',
+  maxRanks: 1,
+};
+export const SHADOWFLAME_PRISM_DISCIPLINE_TALENT: Talent = {
+  id: 373427,
+  name: 'Shadowflame Prism',
+  icon: 'inv_jewelcrafting_shadowsongamethyst_02',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Shadow
+export const DEVOURING_PLAGUE_SHADOW_TALENT: Talent = {
+  id: 335467,
+  name: 'Devouring Plague',
+  icon: 'spell_shadow_devouringplague',
+  maxRanks: 1,
+  insanityCost: 5000,
+};
+export const SILENCE_SHADOW_TALENT: Talent = {
+  id: 15487,
+  name: 'Silence',
+  icon: 'ability_priest_silence',
+  maxRanks: 1,
+};
+export const SHADOWY_APPARITIONS_SHADOW_TALENT: Talent = {
+  id: 341491,
+  name: 'Shadowy Apparitions',
+  icon: 'ability_priest_shadowyapparition',
+  maxRanks: 1,
+};
+export const MIND_SEAR_SHADOW_TALENT: Talent = {
+  id: 48045,
+  name: 'Mind Sear',
+  icon: 'spell_shadow_mindshear',
+  maxRanks: 1,
+};
+export const PSYCHIC_HORROR_SHADOW_TALENT: Talent = {
+  id: 64044,
+  name: 'Psychic Horror',
+  icon: 'spell_shadow_psychichorrors',
+  maxRanks: 1,
+};
+export const LAST_WORD_SHADOW_TALENT: Talent = {
+  id: 263716,
+  name: 'Last Word',
+  icon: 'ability_priest_silence',
+  maxRanks: 1,
+};
+export const MISERY_SHADOW_TALENT: Talent = {
+  id: 238558,
+  name: 'Misery',
+  icon: 'ability_rogue_envelopingshadows',
+  maxRanks: 1,
+};
+export const DARK_VOID_SHADOW_TALENT: Talent = {
+  id: 263346,
+  name: 'Dark Void',
+  icon: 'inv_elemental_primal_shadow',
+  maxRanks: 1,
+};
+export const AUSPICIOUS_SPIRITS_SHADOW_TALENT: Talent = {
+  id: 155271,
+  name: 'Auspicious Spirits',
+  icon: 'ability_priest_auspiciousspirits',
+  maxRanks: 1,
+};
+export const TORMENTED_SPIRITS_SHADOW_TALENT: Talent = {
+  id: 391284,
+  name: 'Tormented Spirits',
+  icon: 'spell_shadow_painandsuffering',
+  maxRanks: 1,
+};
+export const DISPERSION_SHADOW_TALENT: Talent = {
+  id: 47585,
+  name: 'Dispersion',
+  icon: 'spell_shadow_dispersion',
+  maxRanks: 1,
+};
+export const SHADOW_ORBS_NYI_SHADOW_TALENT: Talent = {
+  id: 391242,
+  name: 'Shadow Orbs [NYI]',
+  icon: 'spell_priest_shadoworbs',
+  maxRanks: 1,
+};
+export const HALLUCINATIONS_SHADOW_TALENT: Talent = {
+  id: 280752,
+  name: 'Hallucinations',
+  icon: 'spell_shadow_misery',
+  maxRanks: 1,
+};
+export const TITHE_EVASION_SHADOW_TALENT: Talent = {
+  id: 373223,
+  name: 'Tithe Evasion',
+  icon: 'spell_nzinsanity_bloodthirst',
+  maxRanks: 1,
+};
+export const MIND_SPIKE_SHADOW_TALENT: Talent = {
+  id: 73510,
+  name: 'Mind Spike',
+  icon: 'spell_priest_mindspike',
+  maxRanks: 1,
+};
+export const VAMPIRIC_INSIGHT_SHADOW_TALENT: Talent = {
+  id: 375888,
+  name: 'Vampiric Insight',
+  icon: 'spell_shadow_possession',
+  maxRanks: 1,
+};
+export const INTANGIBILITY_SHADOW_TALENT: Talent = {
+  id: 288733,
+  name: 'Intangibility',
+  icon: 'spell_shadow_dispersion',
+  maxRanks: 1,
+};
+export const MENTAL_FORTITUDE_SHADOW_TALENT: Talent = {
+  id: 377065,
+  name: 'Mental Fortitude',
+  icon: 'ability_priest_clarityofpower',
+  maxRanks: 1,
+};
+export const PUPPET_MASTER_NYI_SHADOW_TALENT: Talent = {
+  id: 377387,
+  name: 'Puppet Master [NYI]',
+  icon: 'ability_rogue_masterofsubtlety',
+  maxRanks: 1,
+};
+export const DAMNATION_SHADOW_TALENT: Talent = {
+  id: 341374,
+  name: 'Damnation',
+  icon: 'ability_warlock_eradication',
+  maxRanks: 1,
+};
+export const MIND_MELT_SHADOW_TALENT: Talent = {
+  id: 391090,
+  name: 'Mind Melt',
+  icon: 'spell_shadow_skull',
+  maxRanks: 1,
+};
+export const SURGE_OF_DARKNESS_SHADOW_TALENT: Talent = {
+  id: 162448,
+  name: 'Surge of Darkness',
+  icon: 'ability_priest_surgeofdarkness',
+  maxRanks: 1,
+};
+export const MENTAL_DECAY_SHADOW_TALENT: Talent = {
+  id: 375994,
+  name: 'Mental Decay',
+  icon: 'ability_kaztik_dominatemind',
+  maxRanks: 1,
+};
+export const DARK_EVANGELISM_SHADOW_TALENT: Talent = {
+  id: 391095,
+  name: 'Dark Evangelism',
+  icon: 'spell_mage_presenceofmind',
+  maxRanks: 2,
+};
+export const HARNESSED_SHADOWS_NYI_SHADOW_TALENT: Talent = {
+  id: 391296,
+  name: 'Harnessed Shadows [NYI]',
+  icon: 'inv_chaos_orb',
+  maxRanks: 1,
+};
+export const MALEDICTION_SHADOW_TALENT: Talent = {
+  id: 373221,
+  name: 'Malediction',
+  icon: 'spell_shadow_deathsembrace',
+  maxRanks: 1,
+};
+export const PSYCHIC_LINK_SHADOW_TALENT: Talent = {
+  id: 199484,
+  name: 'Psychic Link',
+  icon: 'ability_priest_psychiclink',
+  maxRanks: 2,
+};
+export const VOID_TORRENT_SHADOW_TALENT: Talent = {
+  id: 263165,
+  name: 'Void Torrent',
+  icon: 'spell_priest_voidsear',
+  maxRanks: 1,
+};
+export const SHADOW_CRASH_SHADOW_TALENT: Talent = {
+  id: 205385,
+  name: 'Shadow Crash',
+  icon: 'spell_shadow_shadowfury',
+  maxRanks: 1,
+};
+export const DARK_ASCENSION_SHADOW_TALENT: Talent = {
+  id: 391109,
+  name: 'Dark Ascension',
+  icon: 'ability_priest_darkarchangel',
+  maxRanks: 1,
+};
+export const UNFURLING_DARKNESS_SHADOW_TALENT: Talent = {
+  id: 341273,
+  name: 'Unfurling Darkness',
+  icon: 'spell_priest_shadow_mend',
+  maxRanks: 1,
+};
+export const MADDENING_TOUCH_SHADOW_TALENT: Talent = {
+  id: 391228,
+  name: 'Maddening Touch',
+  icon: 'spell_holy_stoicism',
+  maxRanks: 2,
+};
+export const WHISPERS_OF_THE_DAMNED_SHADOW_TALENT: Talent = {
+  id: 391137,
+  name: 'Whispers of the Damned',
+  icon: 'inv_misc_eye_03',
+  maxRanks: 2,
+};
+export const PIERCING_SHADOWS_SHADOW_TALENT: Talent = {
+  id: 391125,
+  name: 'Piercing Shadows',
+  icon: 'spell_shadow_shadetruesight',
+  maxRanks: 2,
+};
+export const MINDBENDER_SHADOW_TALENT: Talent = {
+  id: 200174,
+  name: 'Mindbender',
+  icon: 'spell_shadow_soulleech_3',
+  maxRanks: 1,
+};
+export const IDOL_OF_YSHAARJ_SHADOW_TALENT: Talent = {
+  id: 373310,
+  name: "Idol of Y'Shaarj",
+  icon: 'achievement_raid_terraceofendlessspring04',
+  maxRanks: 1,
+};
+export const PAIN_OF_DEATH_SHADOW_TALENT: Talent = {
+  id: 391288,
+  name: 'Pain of Death',
+  icon: 'spell_shadow_deadofnight',
+  maxRanks: 1,
+};
+export const MIND_FLAY_INSANITY_SHADOW_TALENT: Talent = {
+  id: 391399,
+  name: 'Mind Flay: Insanity',
+  icon: 'spell_fire_twilightflamebreath',
+  maxRanks: 1,
+};
+export const DERANGEMENT_SHADOW_TALENT: Talent = {
+  id: 391235,
+  name: 'Derangement',
+  icon: 'spell_shadow_coneofsilence',
+  maxRanks: 1,
+};
+export const VOID_ERUPTION_SHADOW_TALENT: Talent = {
+  id: 228260,
+  name: 'Void Eruption',
+  icon: 'spell_priest_void_blast',
+  maxRanks: 1,
+};
+export const FIENDING_DARK_SHADOW_TALENT: Talent = {
+  id: 391218,
+  name: 'Fiending Dark',
+  icon: 'spell_shadow_shadowfiend',
+  maxRanks: 2,
+};
+export const MONOMANIA_SHADOW_TALENT: Talent = {
+  id: 375767,
+  name: 'Monomania',
+  icon: 'ability_warlock_improvedsoulleech',
+  maxRanks: 2,
+};
+export const PAINBREAKERS_PSALM_SHADOW_TALENT: Talent = {
+  id: 391316,
+  name: "Painbreaker's Psalm",
+  icon: 'inv_misc_scrollunrolled01d',
+  maxRanks: 2,
+};
+export const MASTERMIND_SHADOW_TALENT: Talent = {
+  id: 391151,
+  name: 'Mastermind',
+  icon: 'spell_shadow_unholyfrenzy',
+  maxRanks: 2,
+};
+export const INSIDIOUS_IRE_SHADOW_TALENT: Talent = {
+  id: 373212,
+  name: 'Insidious Ire',
+  icon: 'spell_fire_twilightcano',
+  maxRanks: 2,
+};
+export const MIND_DEVOURER_SHADOW_TALENT: Talent = {
+  id: 373202,
+  name: 'Mind Devourer',
+  icon: 'spell_arcane_mindmastery',
+  maxRanks: 2,
+};
+export const ANCIENT_MADNESS_SHADOW_TALENT: Talent = {
+  id: 341240,
+  name: 'Ancient Madness',
+  icon: 'spell_priest_void_flay',
+  maxRanks: 2,
+};
+export const SHADOWFLAME_PRISM_SHADOW_TALENT: Talent = {
+  id: 373427,
+  name: 'Shadowflame Prism',
+  icon: 'inv_jewelcrafting_shadowsongamethyst_02',
+  maxRanks: 1,
+};
+export const IDOL_OF_CTHUN_SHADOW_TALENT: Talent = {
+  id: 377349,
+  name: "Idol of C'Thun",
+  icon: 'achievement_boss_cthun',
+  maxRanks: 1,
+};
+export const IDOL_OF_YOGG_SARON_SHADOW_TALENT: Talent = {
+  id: 373273,
+  name: 'Idol of Yogg-Saron',
+  icon: 'achievement_boss_heraldvolazj',
+  maxRanks: 1,
+};
+export const IDOL_OF_NZOTH_SHADOW_TALENT: Talent = {
+  id: 373280,
+  name: "Idol of N'Zoth",
+  icon: 'achievement_nzothraid_nzoth',
+  maxRanks: 1,
+};
+export const LUNACY_SHADOW_TALENT: Talent = {
+  id: 391338,
+  name: 'Lunacy',
+  icon: 'ability_demonhunter_darkness',
+  maxRanks: 1,
+};
+export const HUNGERING_VOID_SHADOW_TALENT: Talent = {
+  id: 345218,
+  name: 'Hungering Void',
+  icon: 'ability_ironmaidens_convulsiveshadows',
+  maxRanks: 1,
+};
+export const SURRENDER_TO_MADNESS_SHADOW_TALENT: Talent = {
+  id: 319952,
+  name: 'Surrender to Madness',
+  icon: 'achievement_boss_generalvezax_01',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Holy
+export const HOLY_WORD_SERENITY_HOLY_TALENT: Talent = {
+  id: 2050,
+  name: 'Holy Word: Serenity',
+  icon: 'spell_holy_persuitofjustice',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const PRAYER_OF_HEALING_HOLY_TALENT: Talent = {
+  id: 596,
+  name: 'Prayer of Healing',
+  icon: 'spell_holy_prayerofhealing02',
+  maxRanks: 1,
+  manaCost: 2500,
+};
+export const GUARDIAN_SPIRIT_HOLY_TALENT: Talent = {
+  id: 47788,
+  name: 'Guardian Spirit',
+  icon: 'spell_holy_guardianspirit',
+  maxRanks: 1,
+  manaCost: 0,
+};
+export const HOLY_WORD_CHASTISE_HOLY_TALENT: Talent = {
+  id: 88625,
+  name: 'Holy Word: Chastise',
+  icon: 'spell_holy_chastise',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const HOLY_WORD_SANCTIFY_HOLY_TALENT: Talent = {
+  id: 34861,
+  name: 'Holy Word: Sanctify',
+  icon: 'spell_holy_divineprovidence',
+  maxRanks: 1,
+  manaCost: 1500,
+};
+export const GUARDIAN_ANGEL_HOLY_TALENT: Talent = {
+  id: 200209,
+  name: 'Guardian Angel',
+  icon: 'ability_priest_pathofthedevout',
+  maxRanks: 1,
+};
+export const GUARDIANS_OF_THE_LIGHT_HOLY_TALENT: Talent = {
+  id: 196437,
+  name: 'Guardians of the Light',
+  icon: 'spell_holy_guardianspirit',
+  maxRanks: 1,
+};
+export const CENSURE_HOLY_TALENT: Talent = {
+  id: 200199,
+  name: 'Censure',
+  icon: 'spell_holy_eyeforaneye',
+  maxRanks: 1,
+};
+export const HOLY_FIRE_HOLY_TALENT: Talent = {
+  id: 14914,
+  name: 'Holy Fire',
+  icon: 'spell_holy_searinglight',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const CIRCLE_OF_HEALING_HOLY_TALENT: Talent = {
+  id: 204883,
+  name: 'Circle of Healing',
+  icon: 'spell_holy_circleofrenewal',
+  maxRanks: 1,
+  manaCost: 1500,
+};
+export const REVITALIZING_PRAYERS_HOLY_TALENT: Talent = {
+  id: 391208,
+  name: 'Revitalizing Prayers',
+  icon: 'inv_staff_2h_artifacttome_d_06',
+  maxRanks: 1,
+};
+export const SANCTIFIED_PRAYERS_HOLY_TALENT: Talent = {
+  id: 196489,
+  name: 'Sanctified Prayers',
+  icon: 'spell_holy_pureofheart',
+  maxRanks: 1,
+};
+export const COSMIC_RIPPLE_HOLY_TALENT: Talent = {
+  id: 238136,
+  name: 'Cosmic Ripple',
+  icon: 'spell_holy_summonlightwell',
+  maxRanks: 1,
+};
+export const AFTERLIFE_HOLY_TALENT: Talent = {
+  id: 196707,
+  name: 'Afterlife',
+  icon: 'inv_enchant_essencemagiclarge',
+  maxRanks: 1,
+};
+export const ARCHBISHOP_BENEDICTUS_RESTITUTION_HOLY_TALENT: Talent = {
+  id: 391124,
+  name: "Archbishop Benedictus' Restitution",
+  icon: 'inv_staff_2h_artifactheartofkure_d_03',
+  maxRanks: 1,
+};
+export const BENEDICTION_HOLY_TALENT: Talent = {
+  id: 193157,
+  name: 'Benediction',
+  icon: 'spell_monk_diffusemagic',
+  maxRanks: 1,
+};
+export const HOLY_MENDING_HOLY_TALENT: Talent = {
+  id: 391154,
+  name: 'Holy Mending',
+  icon: 'spell_holy_healingfocus',
+  maxRanks: 1,
+};
+export const BURNING_VEHEMENCE_HOLY_TALENT: Talent = {
+  id: 372307,
+  name: 'Burning Vehemence',
+  icon: 'spell_nature_unleashedrage',
+  maxRanks: 1,
+};
+export const PRAYER_CIRCLE_HOLY_TALENT: Talent = {
+  id: 321377,
+  name: 'Prayer Circle',
+  icon: 'spell_paladin_divinecircle',
+  maxRanks: 1,
+};
+export const HEALING_CHORUS_HOLY_TALENT: Talent = {
+  id: 390881,
+  name: 'Healing Chorus',
+  icon: 'spell_holy_circleofrenewal',
+  maxRanks: 1,
+};
+export const PRAYERFUL_LITANY_HOLY_TALENT: Talent = {
+  id: 391209,
+  name: 'Prayerful Litany',
+  icon: 'spell_holy_prayerofhealing02',
+  maxRanks: 1,
+};
+export const TRAIL_OF_LIGHT_HOLY_TALENT: Talent = {
+  id: 200128,
+  name: 'Trail of Light',
+  icon: 'ability_priest_wordsofmeaning',
+  maxRanks: 2,
+};
+export const DIVINE_HYMN_HOLY_TALENT: Talent = {
+  id: 64843,
+  name: 'Divine Hymn',
+  icon: 'spell_holy_divinehymn',
+  maxRanks: 1,
+  manaCost: 2000,
+};
+export const CONVERTED_FOLLOWERS_NYI_HOLY_TALENT: Talent = {
+  id: 391233,
+  name: 'Converted Followers [NYI]',
+  icon: 'spell_holy_prayerofspirit',
+  maxRanks: 1,
+};
+export const RENEWED_FAITH_HOLY_TALENT: Talent = {
+  id: 341997,
+  name: 'Renewed Faith',
+  icon: 'ability_pvp_innerrenewal',
+  maxRanks: 1,
+};
+export const ORISON_HOLY_TALENT: Talent = {
+  id: 390947,
+  name: 'Orison',
+  icon: 'spell_holy_fanaticism',
+  maxRanks: 1,
+};
+export const EVERLASTING_LIGHT_HOLY_TALENT: Talent = {
+  id: 391161,
+  name: 'Everlasting Light',
+  icon: 'inv_mace_1h_artifactheartofkure_d_01',
+  maxRanks: 1,
+};
+export const GALES_OF_SONG_HOLY_TALENT: Talent = {
+  id: 372370,
+  name: 'Gales of Song',
+  icon: 'inv_misc_volatileair',
+  maxRanks: 2,
+};
+export const SYMBOL_OF_HOPE_HOLY_TALENT: Talent = {
+  id: 64901,
+  name: 'Symbol of Hope',
+  icon: 'spell_holy_symbolofhope',
+  maxRanks: 1,
+};
+export const ENLIGHTENMENT_HOLY_TALENT: Talent = {
+  id: 193155,
+  name: 'Enlightenment',
+  icon: 'spell_arcane_mindmastery',
+  maxRanks: 1,
+};
+export const CRISIS_MANAGEMENT_HOLY_TALENT: Talent = {
+  id: 390954,
+  name: 'Crisis Management',
+  icon: 'spell_holy_flashheal',
+  maxRanks: 2,
+};
+export const PRISMATIC_ECHOES_HOLY_TALENT: Talent = {
+  id: 390967,
+  name: 'Prismatic Echoes',
+  icon: 'spell_holy_aspiration',
+  maxRanks: 2,
+};
+export const PRAYERS_OF_THE_VIRTUOUS_HOLY_TALENT: Talent = {
+  id: 390977,
+  name: 'Prayers of the Virtuous',
+  icon: 'spell_holy_prayerofmendingtga',
+  maxRanks: 2,
+};
+export const PONTIFEX_HOLY_TALENT: Talent = {
+  id: 390980,
+  name: 'Pontifex',
+  icon: 'spell_priest_pontifex',
+  maxRanks: 1,
+};
+export const EMPOWERED_RENEW_HOLY_TALENT: Talent = {
+  id: 391339,
+  name: 'Empowered Renew',
+  icon: 'ability_paladin_infusionoflight',
+  maxRanks: 1,
+};
+export const RAPID_RECOVERY_HOLY_TALENT: Talent = {
+  id: 391368,
+  name: 'Rapid Recovery',
+  icon: 'spell_holy_renew',
+  maxRanks: 1,
+};
+export const SAY_YOUR_PRAYERS_HOLY_TALENT: Talent = {
+  id: 391186,
+  name: 'Say Your Prayers',
+  icon: 'ability_priest_bindingprayers',
+  maxRanks: 1,
+};
+export const EMPYREAL_BLAZE_HOLY_TALENT: Talent = {
+  id: 372616,
+  name: 'Empyreal Blaze',
+  icon: 'spell_fire_ragnaros_lavabolt',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const RESONANT_WORDS_HOLY_TALENT: Talent = {
+  id: 372309,
+  name: 'Resonant Words',
+  icon: 'spell_holy_holybolt',
+  maxRanks: 2,
+};
+export const LIGHT_OF_THE_NAARU_HOLY_TALENT: Talent = {
+  id: 196985,
+  name: 'Light of the Naaru',
+  icon: 'inv_pet_naaru',
+  maxRanks: 2,
+};
+export const DESPERATE_TIMES_HOLY_TALENT: Talent = {
+  id: 391381,
+  name: 'Desperate Times',
+  icon: 'ability_paladin_infusionoflight',
+  maxRanks: 2,
+};
+export const HARMONIOUS_APPARATUS_HOLY_TALENT: Talent = {
+  id: 390994,
+  name: 'Harmonious Apparatus',
+  icon: 'spell_holy_serendipity',
+  maxRanks: 2,
+};
+export const SPIRITED_LITANY_HOLY_TALENT: Talent = {
+  id: 391387,
+  name: 'Spirited Litany',
+  icon: 'spell_holy_absolution',
+  maxRanks: 2,
+};
+export const SEARING_LIGHT_HOLY_TALENT: Talent = {
+  id: 372611,
+  name: 'Searing Light',
+  icon: 'inv_summerfest_firespirit',
+  maxRanks: 2,
+};
+export const LIGHTWEAVER_HOLY_TALENT: Talent = {
+  id: 390992,
+  name: 'Lightweaver',
+  icon: 'spell_holy_greaterheal',
+  maxRanks: 1,
+};
+export const LIGHTWELL_HOLY_TALENT: Talent = {
+  id: 372835,
+  name: 'Lightwell',
+  icon: 'spell_holy_summonlightwell',
+  maxRanks: 1,
+  manaCost: 1500,
+};
+export const APOTHEOSIS_HOLY_TALENT: Talent = {
+  id: 200183,
+  name: 'Apotheosis',
+  icon: 'ability_priest_ascension',
+  maxRanks: 1,
+};
+export const HOLY_WORD_SALVATION_HOLY_TALENT: Talent = {
+  id: 265202,
+  name: 'Holy Word: Salvation',
+  icon: 'ability_priest_archangel',
+  maxRanks: 1,
+  manaCost: 3000,
+};
+export const MIRACLE_WORKER_HOLY_TALENT: Talent = {
+  id: 235587,
+  name: 'Miracle Worker',
+  icon: 'spell_holy_persuitofjustice',
+  maxRanks: 1,
+};
+export const DIVINE_WORD_HOLY_TALENT: Talent = {
+  id: 372760,
+  name: 'Divine Word',
+  icon: 'spell_priest_chakra',
+  maxRanks: 1,
+};
+
+//endregion
 
 const talents = createTalentList({
   //Shared
-  RENEW_TALENT: { id: 139, name: 'Renew', icon: 'spell_holy_renew', maxRanks: 1, manaCost: 500 },
-  DISPEL_MAGIC_TALENT: {
-    id: 528,
-    name: 'Dispel Magic',
-    icon: 'spell_nature_nullifydisease',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  SHADOWFIEND_TALENT: {
-    id: 34433,
-    name: 'Shadowfiend',
-    icon: 'spell_shadow_shadowfiend',
-    maxRanks: 1,
-  },
-  PRAYER_OF_MENDING_TALENT: {
-    id: 33076,
-    name: 'Prayer of Mending',
-    icon: 'spell_holy_prayerofmendingtga',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  LEAP_OF_FAITH_TALENT: {
-    id: 73325,
-    name: 'Leap of Faith',
-    icon: 'priest_spell_leapoffaith_a',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  IMPROVED_PURIFY_TALENT: {
-    id: 390632,
-    name: 'Improved Purify',
-    icon: 'spell_holy_nullifydisease',
-    maxRanks: 1,
-  },
-  SHADOW_MEND_TALENT: {
-    id: 186263,
-    name: 'Shadow Mend',
-    icon: 'spell_shadow_shadowmend',
-    maxRanks: 1,
-    manaCost: 1500,
-  },
-  SHADOW_WORD_DEATH_TALENT: {
-    id: 32379,
-    name: 'Shadow Word: Death',
-    icon: 'spell_shadow_demonicfortitude',
-    maxRanks: 1,
-    manaCost: 0,
-  },
-  FOCUSED_MENDING_TALENT: {
-    id: 372354,
-    name: 'Focused Mending',
-    icon: 'achievement_bg_returnxflags_def_wsg',
-    maxRanks: 1,
-  },
-  HOLY_NOVA_TALENT: {
-    id: 132157,
-    name: 'Holy Nova',
-    icon: 'spell_holy_holynova',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  MOVE_WITH_GRACE_TALENT: {
-    id: 390620,
-    name: 'Move with Grace',
-    icon: 'ability_priest_savinggrace',
-    maxRanks: 1,
-  },
-  BODY_AND_SOUL_TALENT: {
-    id: 64129,
-    name: 'Body and Soul',
-    icon: 'spell_holy_symbolofhope',
-    maxRanks: 1,
-  },
-  MASOCHISM_TALENT: { id: 193063, name: 'Masochism', icon: 'spell_shadow_misery', maxRanks: 1 },
-  DEPTH_OF_THE_SHADOWS_TALENT: {
-    id: 390615,
-    name: 'Depth of the Shadows',
-    icon: 'spell_shadow_shadowmend',
-    maxRanks: 1,
-  },
-  THROES_OF_PAIN_TALENT: {
-    id: 377422,
-    name: 'Throes of Pain',
-    icon: 'spell_shadow_haunting',
-    maxRanks: 1,
-  },
-  DEATH_AND_MADNESS_TALENT: {
-    id: 321291,
-    name: 'Death and Madness',
-    icon: 'spell_shadow_demonicfortitude',
-    maxRanks: 1,
-  },
-  SPELL_WARDING_TALENT: {
-    id: 390667,
-    name: 'Spell Warding',
-    icon: 'spell_holy_spellwarding',
-    maxRanks: 1,
-  },
-  RHAPSODY_TALENT: { id: 390622, name: 'Rhapsody', icon: 'spell_holy_holynova', maxRanks: 1 },
-  ANGELIC_FEATHER_TALENT: {
-    id: 121536,
-    name: 'Angelic Feather',
-    icon: 'ability_priest_angelicfeather',
-    maxRanks: 1,
-  },
-  SHACKLE_UNDEAD_TALENT: {
-    id: 9484,
-    name: 'Shackle Undead',
-    icon: 'spell_nature_slow',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  SHEER_TERROR_TALENT: {
-    id: 390919,
-    name: 'Sheer Terror',
-    icon: 'spell_nzinsanity_fearofdeath',
-    maxRanks: 1,
-  },
-  VOID_TENDRILS_TALENT: {
-    id: 108920,
-    name: 'Void Tendrils',
-    icon: 'spell_priest_voidtendrils',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  MIND_CONTROL_TALENT: {
-    id: 605,
-    name: 'Mind Control',
-    icon: 'spell_shadow_shadowworddominate',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  TOOLS_OF_THE_CLOTH_TALENT: {
-    id: 377438,
-    name: 'Tools of the Cloth',
-    icon: 'spell_holy_devineaegis',
-    maxRanks: 1,
-  },
-  MASS_DISPEL_TALENT: {
-    id: 32375,
-    name: 'Mass Dispel',
-    icon: 'spell_arcane_massdispel',
-    maxRanks: 1,
-    manaCost: 4000,
-  },
-  POWER_INFUSION_TALENT: {
-    id: 10060,
-    name: 'Power Infusion',
-    icon: 'spell_holy_powerinfusion',
-    maxRanks: 1,
-  },
-  VAMPIRIC_EMBRACE_TALENT: {
-    id: 15286,
-    name: 'Vampiric Embrace',
-    icon: 'spell_shadow_unsummonbuilding',
-    maxRanks: 1,
-  },
-  DOMINANT_MIND_TALENT: {
-    id: 205367,
-    name: 'Dominant Mind',
-    icon: 'spell_priest_void_flay',
-    maxRanks: 1,
-  },
-  INSPIRATION_TALENT: {
-    id: 390676,
-    name: 'Inspiration',
-    icon: 'spell_holy_layonhands',
-    maxRanks: 1,
-  },
-  BLESSED_RECOVERY_TALENT: {
-    id: 390767,
-    name: 'Blessed Recovery',
-    icon: 'spell_holy_blessedrecovery',
-    maxRanks: 1,
-  },
-  IMPROVED_MASS_DISPEL_TALENT: {
-    id: 341167,
-    name: 'Improved Mass Dispel',
-    icon: 'spell_arcane_massdispel',
-    maxRanks: 1,
-  },
-  PSYCHIC_VOICE_TALENT: {
-    id: 196704,
-    name: 'Psychic Voice',
-    icon: 'ability_warrior_commandingshout',
-    maxRanks: 1,
-  },
-  TWINS_OF_THE_SUN_PRIESTESS_TALENT: {
-    id: 373466,
-    name: 'Twins of the Sun Priestess',
-    icon: 'spell_fire_felflamering_red',
-    maxRanks: 1,
-  },
-  VOID_SHIELD_TALENT: {
-    id: 280749,
-    name: 'Void Shield',
-    icon: 'inv_enchant_voidsphere',
-    maxRanks: 1,
-  },
-  SANLAYN_TALENT: { id: 199855, name: "San'layn", icon: 'achievement_boss_lanathel', maxRanks: 1 },
-  APATHY_TALENT: {
-    id: 390668,
-    name: 'Apathy',
-    icon: 'ability_rogue_masterofsubtlety',
-    maxRanks: 1,
-  },
-  UNWAVERING_WILL_TALENT: {
-    id: 373456,
-    name: 'Unwavering Will',
-    icon: 'ability_warrior_unrelentingassault',
-    maxRanks: 2,
-  },
-  TWIST_OF_FATE_TALENT: {
-    id: 390972,
-    name: 'Twist of Fate',
-    icon: 'spell_shadow_mindtwisting',
-    maxRanks: 2,
-  },
-  IMPROVED_MIND_BLAST_TALENT: {
-    id: 319899,
-    name: 'Improved Mind Blast',
-    icon: 'spell_shadow_unholyfrenzy',
-    maxRanks: 2,
-  },
-  ANGELS_MERCY_TALENT: {
-    id: 238100,
-    name: "Angel's Mercy",
-    icon: 'spell_holy_testoffaith',
-    maxRanks: 1,
-  },
-  BINDING_HEALS_TALENT: {
-    id: 368275,
-    name: 'Binding Heals',
-    icon: 'spell_holy_blindingheal',
-    maxRanks: 1,
-  },
-  DIVINE_STAR_TALENT: {
-    id: 110744,
-    name: 'Divine Star',
-    icon: 'spell_priest_divinestar',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  HALO_TALENT: {
-    id: 120517,
-    name: 'Halo',
-    icon: 'ability_priest_halo',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  TRANSLUCENT_IMAGE_TALENT: {
-    id: 373446,
-    name: 'Translucent Image',
-    icon: 'spell_nature_invisibilty',
-    maxRanks: 1,
-  },
-  PHANTASM_TALENT: { id: 108942, name: 'Phantasm', icon: 'ability_priest_phantasm', maxRanks: 1 },
-  MINDGAMES_TALENT: {
-    id: 375901,
-    name: 'Mindgames',
-    icon: 'ability_revendreth_priest',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  SURGE_OF_LIGHT_TALENT: {
-    id: 109186,
-    name: 'Surge of Light',
-    icon: 'spell_holy_surgeoflight',
-    maxRanks: 2,
-  },
-  LIGHTS_INSPIRATION_TALENT: {
-    id: 373450,
-    name: "Light's Inspiration",
-    icon: 'spell_holy_restoration',
-    maxRanks: 2,
-  },
-  CRYSTALLINE_REFLECTION_TALENT: {
-    id: 373457,
-    name: 'Crystalline Reflection',
-    icon: 'ability_priest_reflectiveshield',
-    maxRanks: 2,
-  },
-  IMPROVED_FADE_TALENT: {
-    id: 390670,
-    name: 'Improved Fade',
-    icon: 'spell_magic_lesserinvisibilty',
-    maxRanks: 2,
-  },
-  MANIPULATION_TALENT: {
-    id: 390996,
-    name: 'Manipulation',
-    icon: 'ability_revendreth_priest',
-    maxRanks: 2,
-  },
-  HOLY_WORD_LIFE_TALENT: {
-    id: 373481,
-    name: 'Holy Word: Life',
-    icon: 'ability_priest_holywordlife',
-    maxRanks: 1,
-    manaCost: 0,
-  },
-  ANGELIC_BULWARK_TALENT: {
-    id: 108945,
-    name: 'Angelic Bulwark',
-    icon: 'ability_priest_angelicbulwark',
-    maxRanks: 1,
-  },
-  VOID_SHIFT_TALENT: {
-    id: 108968,
-    name: 'Void Shift',
-    icon: 'spell_priest_voidshift',
-    maxRanks: 1,
-  },
-  SHATTERED_PERCEPTIONS_TALENT: {
-    id: 391112,
-    name: 'Shattered Perceptions',
-    icon: 'spell_animarevendreth_debuff',
-    maxRanks: 1,
-  },
-  PURIFY_DISEASE_TALENT: {
-    id: 213634,
-    name: 'Purify Disease',
-    icon: 'spell_holy_nullifydisease',
-    maxRanks: 1,
-    manaCost: 500,
-  },
+  RENEW_TALENT,
+  DISPEL_MAGIC_TALENT,
+  SHADOWFIEND_TALENT,
+  PRAYER_OF_MENDING_TALENT,
+  LEAP_OF_FAITH_TALENT,
+  IMPROVED_PURIFY_TALENT,
+  SHADOW_MEND_TALENT,
+  SHADOW_WORD_DEATH_TALENT,
+  FOCUSED_MENDING_TALENT,
+  HOLY_NOVA_TALENT,
+  MOVE_WITH_GRACE_TALENT,
+  BODY_AND_SOUL_TALENT,
+  MASOCHISM_TALENT,
+  DEPTH_OF_THE_SHADOWS_TALENT,
+  THROES_OF_PAIN_TALENT,
+  DEATH_AND_MADNESS_TALENT,
+  SPELL_WARDING_TALENT,
+  RHAPSODY_TALENT,
+  ANGELIC_FEATHER_TALENT,
+  SHACKLE_UNDEAD_TALENT,
+  SHEER_TERROR_TALENT,
+  VOID_TENDRILS_TALENT,
+  MIND_CONTROL_TALENT,
+  TOOLS_OF_THE_CLOTH_TALENT,
+  MASS_DISPEL_TALENT,
+  POWER_INFUSION_TALENT,
+  VAMPIRIC_EMBRACE_TALENT,
+  DOMINANT_MIND_TALENT,
+  INSPIRATION_TALENT,
+  BLESSED_RECOVERY_TALENT,
+  IMPROVED_MASS_DISPEL_TALENT,
+  PSYCHIC_VOICE_TALENT,
+  TWINS_OF_THE_SUN_PRIESTESS_TALENT,
+  VOID_SHIELD_TALENT,
+  SANLAYN_TALENT,
+  APATHY_TALENT,
+  UNWAVERING_WILL_TALENT,
+  TWIST_OF_FATE_TALENT,
+  IMPROVED_MIND_BLAST_TALENT,
+  ANGELS_MERCY_TALENT,
+  BINDING_HEALS_TALENT,
+  DIVINE_STAR_TALENT,
+  HALO_TALENT,
+  TRANSLUCENT_IMAGE_TALENT,
+  PHANTASM_TALENT,
+  MINDGAMES_TALENT,
+  SURGE_OF_LIGHT_TALENT,
+  LIGHTS_INSPIRATION_TALENT,
+  CRYSTALLINE_REFLECTION_TALENT,
+  IMPROVED_FADE_TALENT,
+  MANIPULATION_TALENT,
+  HOLY_WORD_LIFE_TALENT,
+  ANGELIC_BULWARK_TALENT,
+  VOID_SHIFT_TALENT,
+  SHATTERED_PERCEPTIONS_TALENT,
+  PURIFY_DISEASE_TALENT,
 
   //Discipline
-  ATONEMENT_DISCIPLINE_TALENT: {
-    id: 81749,
-    name: 'Atonement',
-    icon: 'ability_priest_atonement',
-    maxRanks: 1,
-  },
-  POWER_WORD_RADIANCE_DISCIPLINE_TALENT: {
-    id: 194509,
-    name: 'Power Word: Radiance',
-    icon: 'spell_priest_power_word',
-    maxRanks: 1,
-    manaCost: 3000,
-  },
-  PAIN_SUPPRESSION_DISCIPLINE_TALENT: {
-    id: 33206,
-    name: 'Pain Suppression',
-    icon: 'spell_holy_painsupression',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  POWER_OF_THE_DARK_SIDE_DISCIPLINE_TALENT: {
-    id: 198068,
-    name: 'Power of the Dark Side',
-    icon: 'inv_artifact_powerofthedarkside',
-    maxRanks: 1,
-  },
-  LIGHTS_PROMISE_DISCIPLINE_TALENT: {
-    id: 322115,
-    name: "Light's Promise",
-    icon: 'spell_priest_power_word',
-    maxRanks: 1,
-  },
-  PAIN_TRANSFORMATION_DISCIPLINE_TALENT: {
-    id: 372991,
-    name: 'Pain Transformation',
-    icon: 'spell_holy_blessedrecovery',
-    maxRanks: 1,
-  },
-  PROTECTOR_OF_THE_FRAIL_DISCIPLINE_TALENT: {
-    id: 373035,
-    name: 'Protector of the Frail',
-    icon: 'ability_racial_forceshield',
-    maxRanks: 1,
-  },
-  DARK_INDULGENCE_DISCIPLINE_TALENT: {
-    id: 372972,
-    name: 'Dark Indulgence',
-    icon: 'spell_shadow_painandsuffering',
-    maxRanks: 1,
-  },
-  SCHISM_DISCIPLINE_TALENT: {
-    id: 214621,
-    name: 'Schism',
-    icon: 'spell_warlock_focusshadow',
-    maxRanks: 1,
-    manaCost: 0,
-  },
-  BRIGHT_PUPIL_DISCIPLINE_TALENT: {
-    id: 390684,
-    name: 'Bright Pupil',
-    icon: 'spell_holy_surgeoflight',
-    maxRanks: 1,
-  },
-  ENDURING_LUMINESCENCE_DISCIPLINE_TALENT: {
-    id: 390685,
-    name: 'Enduring Luminescence',
-    icon: 'ability_priest_holybolts01',
-    maxRanks: 1,
-  },
-  SHIELD_DISCIPLINE_DISCIPLINE_TALENT: {
-    id: 197045,
-    name: 'Shield Discipline',
-    icon: 'spell_holy_divineprotection',
-    maxRanks: 1,
-  },
-  POWER_WORD_SOLACE_DISCIPLINE_TALENT: {
-    id: 129250,
-    name: 'Power Word: Solace',
-    icon: 'ability_priest_flashoflight',
-    maxRanks: 1,
-  },
-  POWER_WORD_BARRIER_DISCIPLINE_TALENT: {
-    id: 62618,
-    name: 'Power Word: Barrier',
-    icon: 'spell_holy_powerwordbarrier',
-    maxRanks: 1,
-    manaCost: 2000,
-  },
-  PAINFUL_PUNISHMENT_DISCIPLINE_TALENT: {
-    id: 390686,
-    name: 'Painful Punishment',
-    icon: 'ability_priest_clarityofpower',
-    maxRanks: 1,
-  },
-  MALICIOUS_SCISSION_DISCIPLINE_TALENT: {
-    id: 372969,
-    name: 'Malicious Scission',
-    icon: 'ability_demonhunter_darkness',
-    maxRanks: 1,
-  },
-  PURGE_THE_WICKED_DISCIPLINE_TALENT: {
-    id: 204197,
-    name: 'Purge the Wicked',
-    icon: 'ability_mage_firestarter',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  RAPTURE_DISCIPLINE_TALENT: {
-    id: 47536,
-    name: 'Rapture',
-    icon: 'spell_holy_rapture',
-    maxRanks: 1,
-    manaCost: 1500,
-  },
-  SPIRIT_SHELL_DISCIPLINE_TALENT: {
-    id: 109964,
-    name: 'Spirit Shell',
-    icon: 'ability_shaman_astralshift',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  SHADOW_COVENANT_DISCIPLINE_TALENT: {
-    id: 314867,
-    name: 'Shadow Covenant',
-    icon: 'spell_shadow_summonvoidwalker',
-    maxRanks: 1,
-    manaCost: 2000,
-  },
-  REVEL_IN_PURITY_DISCIPLINE_TALENT: {
-    id: 373003,
-    name: 'Revel in Purity',
-    icon: 'spell_fire_felflamering_red',
-    maxRanks: 1,
-  },
-  CONTRITION_DISCIPLINE_TALENT: {
-    id: 197419,
-    name: 'Contrition',
-    icon: 'ability_priest_savinggrace',
-    maxRanks: 2,
-  },
-  EXALTATION_DISCIPLINE_TALENT: {
-    id: 373042,
-    name: 'Exaltation',
-    icon: 'spell_holy_spiritualguidence',
-    maxRanks: 1,
-  },
-  IMPROVED_SHADOW_WORD_PAIN_DISCIPLINE_TALENT: {
-    id: 390689,
-    name: 'Improved Shadow Word: Pain',
-    icon: 'spell_shadow_shadowwordpain',
-    maxRanks: 2,
-  },
-  EMBRACE_SHADOW_DISCIPLINE_TALENT: {
-    id: 372985,
-    name: 'Embrace Shadow',
-    icon: 'spell_warlock_demonsoul',
-    maxRanks: 1,
-  },
-  TWILIGHT_CORRUPTION_DISCIPLINE_TALENT: {
-    id: 373065,
-    name: 'Twilight Corruption',
-    icon: 'spell_fire_twilightimmolation',
-    maxRanks: 1,
-  },
-  BORROWED_TIME_DISCIPLINE_TALENT: {
-    id: 390691,
-    name: 'Borrowed Time',
-    icon: 'spell_holy_borrowedtime',
-    maxRanks: 2,
-  },
-  CASTIGATION_DISCIPLINE_TALENT: {
-    id: 193134,
-    name: 'Castigation',
-    icon: 'spell_holy_searinglightpriest',
-    maxRanks: 1,
-  },
-  STOLEN_PSYCHE_DISCIPLINE_TALENT: {
-    id: 373054,
-    name: 'Stolen Psyche',
-    icon: 'ability_priest_surgeofdarkness',
-    maxRanks: 2,
-  },
-  TRAIN_OF_THOUGHT_DISCIPLINE_TALENT: {
-    id: 390693,
-    name: 'Train of Thought',
-    icon: 'ability_mage_studentofthemind',
-    maxRanks: 1,
-  },
-  MAKE_AMENDS_DISCIPLINE_TALENT: {
-    id: 391079,
-    name: 'Make Amends',
-    icon: 'spell_holy_penance',
-    maxRanks: 1,
-  },
-  LIGHTS_WRATH_DISCIPLINE_TALENT: {
-    id: 373178,
-    name: "Light's Wrath",
-    icon: 'inv_staff_2h_artifacttome_d_01',
-    maxRanks: 1,
-  },
-  BALANCE_IN_ALL_THINGS_DISCIPLINE_TALENT: {
-    id: 390705,
-    name: 'Balance In All Things',
-    icon: 'ability_priest_innerlightandshadow',
-    maxRanks: 1,
-  },
-  MINDBENDER_DISCIPLINE_TALENT: {
-    id: 123040,
-    name: 'Mindbender',
-    icon: 'spell_shadow_soulleech_3',
-    maxRanks: 1,
-  },
-  DIVINE_AEGIS_DISCIPLINE_TALENT: {
-    id: 47515,
-    name: 'Divine Aegis',
-    icon: 'spell_holy_devineaegis',
-    maxRanks: 2,
-  },
-  SINS_OF_THE_MANY_DISCIPLINE_TALENT: {
-    id: 280391,
-    name: 'Sins of the Many',
-    icon: 'spell_holy_holyguidance',
-    maxRanks: 2,
-  },
-  RESPLENDENT_LIGHT_DISCIPLINE_TALENT: {
-    id: 390765,
-    name: 'Resplendent Light',
-    icon: 'spell_priest_divinestar_holy',
-    maxRanks: 2,
-  },
-  HARSH_DISCIPLINE_DISCIPLINE_TALENT: {
-    id: 373180,
-    name: 'Harsh Discipline',
-    icon: 'ability_paladin_handoflight',
-    maxRanks: 2,
-  },
-  FIENDING_DARK_DISCIPLINE_TALENT: {
-    id: 390770,
-    name: 'Fiending Dark',
-    icon: 'spell_shadow_shadowfiend',
-    maxRanks: 2,
-  },
-  EXPIATION_DISCIPLINE_TALENT: {
-    id: 390832,
-    name: 'Expiation',
-    icon: 'spell_shadow_shadowpower',
-    maxRanks: 2,
-  },
-  INDEMNITY_DISCIPLINE_TALENT: {
-    id: 373049,
-    name: 'Indemnity',
-    icon: 'spell_holy_divineprotection',
-    maxRanks: 1,
-  },
-  AEGIS_OF_WRATH_DISCIPLINE_TALENT: {
-    id: 238135,
-    name: 'Aegis of Wrath',
-    icon: 'spell_holy_powerwordshield',
-    maxRanks: 1,
-  },
-  LENIENCE_DISCIPLINE_TALENT: {
-    id: 238063,
-    name: 'Lenience',
-    icon: 'ability_priest_atonement',
-    maxRanks: 1,
-  },
-  EVANGELISM_DISCIPLINE_TALENT: {
-    id: 246287,
-    name: 'Evangelism',
-    icon: 'spell_holy_divineillumination',
-    maxRanks: 1,
-  },
-  WRATH_UNLEASHED_DISCIPLINE_TALENT: {
-    id: 390781,
-    name: 'Wrath, Unleashed',
-    icon: 'inv_staff_2h_artifacttome_d_01',
-    maxRanks: 1,
-  },
-  WEAL_AND_WOE_DISCIPLINE_TALENT: {
-    id: 390786,
-    name: 'Weal and Woe',
-    icon: 'spell_priest_burningwill',
-    maxRanks: 1,
-  },
-  SHADOWFLAME_PRISM_DISCIPLINE_TALENT: {
-    id: 373427,
-    name: 'Shadowflame Prism',
-    icon: 'inv_jewelcrafting_shadowsongamethyst_02',
-    maxRanks: 1,
-  },
+  ATONEMENT_DISCIPLINE_TALENT,
+  POWER_WORD_RADIANCE_DISCIPLINE_TALENT,
+  PAIN_SUPPRESSION_DISCIPLINE_TALENT,
+  POWER_OF_THE_DARK_SIDE_DISCIPLINE_TALENT,
+  LIGHTS_PROMISE_DISCIPLINE_TALENT,
+  PAIN_TRANSFORMATION_DISCIPLINE_TALENT,
+  PROTECTOR_OF_THE_FRAIL_DISCIPLINE_TALENT,
+  DARK_INDULGENCE_DISCIPLINE_TALENT,
+  SCHISM_DISCIPLINE_TALENT,
+  BRIGHT_PUPIL_DISCIPLINE_TALENT,
+  ENDURING_LUMINESCENCE_DISCIPLINE_TALENT,
+  SHIELD_DISCIPLINE_DISCIPLINE_TALENT,
+  POWER_WORD_SOLACE_DISCIPLINE_TALENT,
+  POWER_WORD_BARRIER_DISCIPLINE_TALENT,
+  PAINFUL_PUNISHMENT_DISCIPLINE_TALENT,
+  MALICIOUS_SCISSION_DISCIPLINE_TALENT,
+  PURGE_THE_WICKED_DISCIPLINE_TALENT,
+  RAPTURE_DISCIPLINE_TALENT,
+  SPIRIT_SHELL_DISCIPLINE_TALENT,
+  SHADOW_COVENANT_DISCIPLINE_TALENT,
+  REVEL_IN_PURITY_DISCIPLINE_TALENT,
+  CONTRITION_DISCIPLINE_TALENT,
+  EXALTATION_DISCIPLINE_TALENT,
+  IMPROVED_SHADOW_WORD_PAIN_DISCIPLINE_TALENT,
+  EMBRACE_SHADOW_DISCIPLINE_TALENT,
+  TWILIGHT_CORRUPTION_DISCIPLINE_TALENT,
+  BORROWED_TIME_DISCIPLINE_TALENT,
+  CASTIGATION_DISCIPLINE_TALENT,
+  STOLEN_PSYCHE_DISCIPLINE_TALENT,
+  TRAIN_OF_THOUGHT_DISCIPLINE_TALENT,
+  MAKE_AMENDS_DISCIPLINE_TALENT,
+  LIGHTS_WRATH_DISCIPLINE_TALENT,
+  BALANCE_IN_ALL_THINGS_DISCIPLINE_TALENT,
+  MINDBENDER_DISCIPLINE_TALENT,
+  DIVINE_AEGIS_DISCIPLINE_TALENT,
+  SINS_OF_THE_MANY_DISCIPLINE_TALENT,
+  RESPLENDENT_LIGHT_DISCIPLINE_TALENT,
+  HARSH_DISCIPLINE_DISCIPLINE_TALENT,
+  FIENDING_DARK_DISCIPLINE_TALENT,
+  EXPIATION_DISCIPLINE_TALENT,
+  INDEMNITY_DISCIPLINE_TALENT,
+  AEGIS_OF_WRATH_DISCIPLINE_TALENT,
+  LENIENCE_DISCIPLINE_TALENT,
+  EVANGELISM_DISCIPLINE_TALENT,
+  WRATH_UNLEASHED_DISCIPLINE_TALENT,
+  WEAL_AND_WOE_DISCIPLINE_TALENT,
+  SHADOWFLAME_PRISM_DISCIPLINE_TALENT,
 
   //Shadow
-  DEVOURING_PLAGUE_SHADOW_TALENT: {
-    id: 335467,
-    name: 'Devouring Plague',
-    icon: 'spell_shadow_devouringplague',
-    maxRanks: 1,
-    insanityCost: 5000,
-  },
-  SILENCE_SHADOW_TALENT: {
-    id: 15487,
-    name: 'Silence',
-    icon: 'ability_priest_silence',
-    maxRanks: 1,
-  },
-  SHADOWY_APPARITIONS_SHADOW_TALENT: {
-    id: 341491,
-    name: 'Shadowy Apparitions',
-    icon: 'ability_priest_shadowyapparition',
-    maxRanks: 1,
-  },
-  MIND_SEAR_SHADOW_TALENT: {
-    id: 48045,
-    name: 'Mind Sear',
-    icon: 'spell_shadow_mindshear',
-    maxRanks: 1,
-  },
-  PSYCHIC_HORROR_SHADOW_TALENT: {
-    id: 64044,
-    name: 'Psychic Horror',
-    icon: 'spell_shadow_psychichorrors',
-    maxRanks: 1,
-  },
-  LAST_WORD_SHADOW_TALENT: {
-    id: 263716,
-    name: 'Last Word',
-    icon: 'ability_priest_silence',
-    maxRanks: 1,
-  },
-  MISERY_SHADOW_TALENT: {
-    id: 238558,
-    name: 'Misery',
-    icon: 'ability_rogue_envelopingshadows',
-    maxRanks: 1,
-  },
-  DARK_VOID_SHADOW_TALENT: {
-    id: 263346,
-    name: 'Dark Void',
-    icon: 'inv_elemental_primal_shadow',
-    maxRanks: 1,
-  },
-  AUSPICIOUS_SPIRITS_SHADOW_TALENT: {
-    id: 155271,
-    name: 'Auspicious Spirits',
-    icon: 'ability_priest_auspiciousspirits',
-    maxRanks: 1,
-  },
-  TORMENTED_SPIRITS_SHADOW_TALENT: {
-    id: 391284,
-    name: 'Tormented Spirits',
-    icon: 'spell_shadow_painandsuffering',
-    maxRanks: 1,
-  },
-  DISPERSION_SHADOW_TALENT: {
-    id: 47585,
-    name: 'Dispersion',
-    icon: 'spell_shadow_dispersion',
-    maxRanks: 1,
-  },
-  SHADOW_ORBS_NYI_SHADOW_TALENT: {
-    id: 391242,
-    name: 'Shadow Orbs [NYI]',
-    icon: 'spell_priest_shadoworbs',
-    maxRanks: 1,
-  },
-  HALLUCINATIONS_SHADOW_TALENT: {
-    id: 280752,
-    name: 'Hallucinations',
-    icon: 'spell_shadow_misery',
-    maxRanks: 1,
-  },
-  TITHE_EVASION_SHADOW_TALENT: {
-    id: 373223,
-    name: 'Tithe Evasion',
-    icon: 'spell_nzinsanity_bloodthirst',
-    maxRanks: 1,
-  },
-  MIND_SPIKE_SHADOW_TALENT: {
-    id: 73510,
-    name: 'Mind Spike',
-    icon: 'spell_priest_mindspike',
-    maxRanks: 1,
-  },
-  VAMPIRIC_INSIGHT_SHADOW_TALENT: {
-    id: 375888,
-    name: 'Vampiric Insight',
-    icon: 'spell_shadow_possession',
-    maxRanks: 1,
-  },
-  INTANGIBILITY_SHADOW_TALENT: {
-    id: 288733,
-    name: 'Intangibility',
-    icon: 'spell_shadow_dispersion',
-    maxRanks: 1,
-  },
-  MENTAL_FORTITUDE_SHADOW_TALENT: {
-    id: 377065,
-    name: 'Mental Fortitude',
-    icon: 'ability_priest_clarityofpower',
-    maxRanks: 1,
-  },
-  PUPPET_MASTER_NYI_SHADOW_TALENT: {
-    id: 377387,
-    name: 'Puppet Master [NYI]',
-    icon: 'ability_rogue_masterofsubtlety',
-    maxRanks: 1,
-  },
-  DAMNATION_SHADOW_TALENT: {
-    id: 341374,
-    name: 'Damnation',
-    icon: 'ability_warlock_eradication',
-    maxRanks: 1,
-  },
-  MIND_MELT_SHADOW_TALENT: {
-    id: 391090,
-    name: 'Mind Melt',
-    icon: 'spell_shadow_skull',
-    maxRanks: 1,
-  },
-  SURGE_OF_DARKNESS_SHADOW_TALENT: {
-    id: 162448,
-    name: 'Surge of Darkness',
-    icon: 'ability_priest_surgeofdarkness',
-    maxRanks: 1,
-  },
-  MENTAL_DECAY_SHADOW_TALENT: {
-    id: 375994,
-    name: 'Mental Decay',
-    icon: 'ability_kaztik_dominatemind',
-    maxRanks: 1,
-  },
-  DARK_EVANGELISM_SHADOW_TALENT: {
-    id: 391095,
-    name: 'Dark Evangelism',
-    icon: 'spell_mage_presenceofmind',
-    maxRanks: 2,
-  },
-  HARNESSED_SHADOWS_NYI_SHADOW_TALENT: {
-    id: 391296,
-    name: 'Harnessed Shadows [NYI]',
-    icon: 'inv_chaos_orb',
-    maxRanks: 1,
-  },
-  MALEDICTION_SHADOW_TALENT: {
-    id: 373221,
-    name: 'Malediction',
-    icon: 'spell_shadow_deathsembrace',
-    maxRanks: 1,
-  },
-  PSYCHIC_LINK_SHADOW_TALENT: {
-    id: 199484,
-    name: 'Psychic Link',
-    icon: 'ability_priest_psychiclink',
-    maxRanks: 2,
-  },
-  VOID_TORRENT_SHADOW_TALENT: {
-    id: 263165,
-    name: 'Void Torrent',
-    icon: 'spell_priest_voidsear',
-    maxRanks: 1,
-  },
-  SHADOW_CRASH_SHADOW_TALENT: {
-    id: 205385,
-    name: 'Shadow Crash',
-    icon: 'spell_shadow_shadowfury',
-    maxRanks: 1,
-  },
-  DARK_ASCENSION_SHADOW_TALENT: {
-    id: 391109,
-    name: 'Dark Ascension',
-    icon: 'ability_priest_darkarchangel',
-    maxRanks: 1,
-  },
-  UNFURLING_DARKNESS_SHADOW_TALENT: {
-    id: 341273,
-    name: 'Unfurling Darkness',
-    icon: 'spell_priest_shadow_mend',
-    maxRanks: 1,
-  },
-  MADDENING_TOUCH_SHADOW_TALENT: {
-    id: 391228,
-    name: 'Maddening Touch',
-    icon: 'spell_holy_stoicism',
-    maxRanks: 2,
-  },
-  WHISPERS_OF_THE_DAMNED_SHADOW_TALENT: {
-    id: 391137,
-    name: 'Whispers of the Damned',
-    icon: 'inv_misc_eye_03',
-    maxRanks: 2,
-  },
-  PIERCING_SHADOWS_SHADOW_TALENT: {
-    id: 391125,
-    name: 'Piercing Shadows',
-    icon: 'spell_shadow_shadetruesight',
-    maxRanks: 2,
-  },
-  MINDBENDER_SHADOW_TALENT: {
-    id: 200174,
-    name: 'Mindbender',
-    icon: 'spell_shadow_soulleech_3',
-    maxRanks: 1,
-  },
-  IDOL_OF_YSHAARJ_SHADOW_TALENT: {
-    id: 373310,
-    name: "Idol of Y'Shaarj",
-    icon: 'achievement_raid_terraceofendlessspring04',
-    maxRanks: 1,
-  },
-  PAIN_OF_DEATH_SHADOW_TALENT: {
-    id: 391288,
-    name: 'Pain of Death',
-    icon: 'spell_shadow_deadofnight',
-    maxRanks: 1,
-  },
-  MIND_FLAY_INSANITY_SHADOW_TALENT: {
-    id: 391399,
-    name: 'Mind Flay: Insanity',
-    icon: 'spell_fire_twilightflamebreath',
-    maxRanks: 1,
-  },
-  DERANGEMENT_SHADOW_TALENT: {
-    id: 391235,
-    name: 'Derangement',
-    icon: 'spell_shadow_coneofsilence',
-    maxRanks: 1,
-  },
-  VOID_ERUPTION_SHADOW_TALENT: {
-    id: 228260,
-    name: 'Void Eruption',
-    icon: 'spell_priest_void_blast',
-    maxRanks: 1,
-  },
-  FIENDING_DARK_SHADOW_TALENT: {
-    id: 391218,
-    name: 'Fiending Dark',
-    icon: 'spell_shadow_shadowfiend',
-    maxRanks: 2,
-  },
-  MONOMANIA_SHADOW_TALENT: {
-    id: 375767,
-    name: 'Monomania',
-    icon: 'ability_warlock_improvedsoulleech',
-    maxRanks: 2,
-  },
-  PAINBREAKERS_PSALM_SHADOW_TALENT: {
-    id: 391316,
-    name: "Painbreaker's Psalm",
-    icon: 'inv_misc_scrollunrolled01d',
-    maxRanks: 2,
-  },
-  MASTERMIND_SHADOW_TALENT: {
-    id: 391151,
-    name: 'Mastermind',
-    icon: 'spell_shadow_unholyfrenzy',
-    maxRanks: 2,
-  },
-  INSIDIOUS_IRE_SHADOW_TALENT: {
-    id: 373212,
-    name: 'Insidious Ire',
-    icon: 'spell_fire_twilightcano',
-    maxRanks: 2,
-  },
-  MIND_DEVOURER_SHADOW_TALENT: {
-    id: 373202,
-    name: 'Mind Devourer',
-    icon: 'spell_arcane_mindmastery',
-    maxRanks: 2,
-  },
-  ANCIENT_MADNESS_SHADOW_TALENT: {
-    id: 341240,
-    name: 'Ancient Madness',
-    icon: 'spell_priest_void_flay',
-    maxRanks: 2,
-  },
-  SHADOWFLAME_PRISM_SHADOW_TALENT: {
-    id: 373427,
-    name: 'Shadowflame Prism',
-    icon: 'inv_jewelcrafting_shadowsongamethyst_02',
-    maxRanks: 1,
-  },
-  IDOL_OF_CTHUN_SHADOW_TALENT: {
-    id: 377349,
-    name: "Idol of C'Thun",
-    icon: 'achievement_boss_cthun',
-    maxRanks: 1,
-  },
-  IDOL_OF_YOGG_SARON_SHADOW_TALENT: {
-    id: 373273,
-    name: 'Idol of Yogg-Saron',
-    icon: 'achievement_boss_heraldvolazj',
-    maxRanks: 1,
-  },
-  IDOL_OF_NZOTH_SHADOW_TALENT: {
-    id: 373280,
-    name: "Idol of N'Zoth",
-    icon: 'achievement_nzothraid_nzoth',
-    maxRanks: 1,
-  },
-  LUNACY_SHADOW_TALENT: {
-    id: 391338,
-    name: 'Lunacy',
-    icon: 'ability_demonhunter_darkness',
-    maxRanks: 1,
-  },
-  HUNGERING_VOID_SHADOW_TALENT: {
-    id: 345218,
-    name: 'Hungering Void',
-    icon: 'ability_ironmaidens_convulsiveshadows',
-    maxRanks: 1,
-  },
-  SURRENDER_TO_MADNESS_SHADOW_TALENT: {
-    id: 319952,
-    name: 'Surrender to Madness',
-    icon: 'achievement_boss_generalvezax_01',
-    maxRanks: 1,
-  },
+  DEVOURING_PLAGUE_SHADOW_TALENT,
+  SILENCE_SHADOW_TALENT,
+  SHADOWY_APPARITIONS_SHADOW_TALENT,
+  MIND_SEAR_SHADOW_TALENT,
+  PSYCHIC_HORROR_SHADOW_TALENT,
+  LAST_WORD_SHADOW_TALENT,
+  MISERY_SHADOW_TALENT,
+  DARK_VOID_SHADOW_TALENT,
+  AUSPICIOUS_SPIRITS_SHADOW_TALENT,
+  TORMENTED_SPIRITS_SHADOW_TALENT,
+  DISPERSION_SHADOW_TALENT,
+  SHADOW_ORBS_NYI_SHADOW_TALENT,
+  HALLUCINATIONS_SHADOW_TALENT,
+  TITHE_EVASION_SHADOW_TALENT,
+  MIND_SPIKE_SHADOW_TALENT,
+  VAMPIRIC_INSIGHT_SHADOW_TALENT,
+  INTANGIBILITY_SHADOW_TALENT,
+  MENTAL_FORTITUDE_SHADOW_TALENT,
+  PUPPET_MASTER_NYI_SHADOW_TALENT,
+  DAMNATION_SHADOW_TALENT,
+  MIND_MELT_SHADOW_TALENT,
+  SURGE_OF_DARKNESS_SHADOW_TALENT,
+  MENTAL_DECAY_SHADOW_TALENT,
+  DARK_EVANGELISM_SHADOW_TALENT,
+  HARNESSED_SHADOWS_NYI_SHADOW_TALENT,
+  MALEDICTION_SHADOW_TALENT,
+  PSYCHIC_LINK_SHADOW_TALENT,
+  VOID_TORRENT_SHADOW_TALENT,
+  SHADOW_CRASH_SHADOW_TALENT,
+  DARK_ASCENSION_SHADOW_TALENT,
+  UNFURLING_DARKNESS_SHADOW_TALENT,
+  MADDENING_TOUCH_SHADOW_TALENT,
+  WHISPERS_OF_THE_DAMNED_SHADOW_TALENT,
+  PIERCING_SHADOWS_SHADOW_TALENT,
+  MINDBENDER_SHADOW_TALENT,
+  IDOL_OF_YSHAARJ_SHADOW_TALENT,
+  PAIN_OF_DEATH_SHADOW_TALENT,
+  MIND_FLAY_INSANITY_SHADOW_TALENT,
+  DERANGEMENT_SHADOW_TALENT,
+  VOID_ERUPTION_SHADOW_TALENT,
+  FIENDING_DARK_SHADOW_TALENT,
+  MONOMANIA_SHADOW_TALENT,
+  PAINBREAKERS_PSALM_SHADOW_TALENT,
+  MASTERMIND_SHADOW_TALENT,
+  INSIDIOUS_IRE_SHADOW_TALENT,
+  MIND_DEVOURER_SHADOW_TALENT,
+  ANCIENT_MADNESS_SHADOW_TALENT,
+  SHADOWFLAME_PRISM_SHADOW_TALENT,
+  IDOL_OF_CTHUN_SHADOW_TALENT,
+  IDOL_OF_YOGG_SARON_SHADOW_TALENT,
+  IDOL_OF_NZOTH_SHADOW_TALENT,
+  LUNACY_SHADOW_TALENT,
+  HUNGERING_VOID_SHADOW_TALENT,
+  SURRENDER_TO_MADNESS_SHADOW_TALENT,
 
   //Holy
-  HOLY_WORD_SERENITY_HOLY_TALENT: {
-    id: 2050,
-    name: 'Holy Word: Serenity',
-    icon: 'spell_holy_persuitofjustice',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  PRAYER_OF_HEALING_HOLY_TALENT: {
-    id: 596,
-    name: 'Prayer of Healing',
-    icon: 'spell_holy_prayerofhealing02',
-    maxRanks: 1,
-    manaCost: 2500,
-  },
-  GUARDIAN_SPIRIT_HOLY_TALENT: {
-    id: 47788,
-    name: 'Guardian Spirit',
-    icon: 'spell_holy_guardianspirit',
-    maxRanks: 1,
-    manaCost: 0,
-  },
-  HOLY_WORD_CHASTISE_HOLY_TALENT: {
-    id: 88625,
-    name: 'Holy Word: Chastise',
-    icon: 'spell_holy_chastise',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  HOLY_WORD_SANCTIFY_HOLY_TALENT: {
-    id: 34861,
-    name: 'Holy Word: Sanctify',
-    icon: 'spell_holy_divineprovidence',
-    maxRanks: 1,
-    manaCost: 1500,
-  },
-  GUARDIAN_ANGEL_HOLY_TALENT: {
-    id: 200209,
-    name: 'Guardian Angel',
-    icon: 'ability_priest_pathofthedevout',
-    maxRanks: 1,
-  },
-  GUARDIANS_OF_THE_LIGHT_HOLY_TALENT: {
-    id: 196437,
-    name: 'Guardians of the Light',
-    icon: 'spell_holy_guardianspirit',
-    maxRanks: 1,
-  },
-  CENSURE_HOLY_TALENT: { id: 200199, name: 'Censure', icon: 'spell_holy_eyeforaneye', maxRanks: 1 },
-  HOLY_FIRE_HOLY_TALENT: {
-    id: 14914,
-    name: 'Holy Fire',
-    icon: 'spell_holy_searinglight',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  CIRCLE_OF_HEALING_HOLY_TALENT: {
-    id: 204883,
-    name: 'Circle of Healing',
-    icon: 'spell_holy_circleofrenewal',
-    maxRanks: 1,
-    manaCost: 1500,
-  },
-  REVITALIZING_PRAYERS_HOLY_TALENT: {
-    id: 391208,
-    name: 'Revitalizing Prayers',
-    icon: 'inv_staff_2h_artifacttome_d_06',
-    maxRanks: 1,
-  },
-  SANCTIFIED_PRAYERS_HOLY_TALENT: {
-    id: 196489,
-    name: 'Sanctified Prayers',
-    icon: 'spell_holy_pureofheart',
-    maxRanks: 1,
-  },
-  COSMIC_RIPPLE_HOLY_TALENT: {
-    id: 238136,
-    name: 'Cosmic Ripple',
-    icon: 'spell_holy_summonlightwell',
-    maxRanks: 1,
-  },
-  AFTERLIFE_HOLY_TALENT: {
-    id: 196707,
-    name: 'Afterlife',
-    icon: 'inv_enchant_essencemagiclarge',
-    maxRanks: 1,
-  },
-  ARCHBISHOP_BENEDICTUS_RESTITUTION_HOLY_TALENT: {
-    id: 391124,
-    name: "Archbishop Benedictus' Restitution",
-    icon: 'inv_staff_2h_artifactheartofkure_d_03',
-    maxRanks: 1,
-  },
-  BENEDICTION_HOLY_TALENT: {
-    id: 193157,
-    name: 'Benediction',
-    icon: 'spell_monk_diffusemagic',
-    maxRanks: 1,
-  },
-  HOLY_MENDING_HOLY_TALENT: {
-    id: 391154,
-    name: 'Holy Mending',
-    icon: 'spell_holy_healingfocus',
-    maxRanks: 1,
-  },
-  BURNING_VEHEMENCE_HOLY_TALENT: {
-    id: 372307,
-    name: 'Burning Vehemence',
-    icon: 'spell_nature_unleashedrage',
-    maxRanks: 1,
-  },
-  PRAYER_CIRCLE_HOLY_TALENT: {
-    id: 321377,
-    name: 'Prayer Circle',
-    icon: 'spell_paladin_divinecircle',
-    maxRanks: 1,
-  },
-  HEALING_CHORUS_HOLY_TALENT: {
-    id: 390881,
-    name: 'Healing Chorus',
-    icon: 'spell_holy_circleofrenewal',
-    maxRanks: 1,
-  },
-  PRAYERFUL_LITANY_HOLY_TALENT: {
-    id: 391209,
-    name: 'Prayerful Litany',
-    icon: 'spell_holy_prayerofhealing02',
-    maxRanks: 1,
-  },
-  TRAIL_OF_LIGHT_HOLY_TALENT: {
-    id: 200128,
-    name: 'Trail of Light',
-    icon: 'ability_priest_wordsofmeaning',
-    maxRanks: 2,
-  },
-  DIVINE_HYMN_HOLY_TALENT: {
-    id: 64843,
-    name: 'Divine Hymn',
-    icon: 'spell_holy_divinehymn',
-    maxRanks: 1,
-    manaCost: 2000,
-  },
-  CONVERTED_FOLLOWERS_NYI_HOLY_TALENT: {
-    id: 391233,
-    name: 'Converted Followers [NYI]',
-    icon: 'spell_holy_prayerofspirit',
-    maxRanks: 1,
-  },
-  RENEWED_FAITH_HOLY_TALENT: {
-    id: 341997,
-    name: 'Renewed Faith',
-    icon: 'ability_pvp_innerrenewal',
-    maxRanks: 1,
-  },
-  ORISON_HOLY_TALENT: { id: 390947, name: 'Orison', icon: 'spell_holy_fanaticism', maxRanks: 1 },
-  EVERLASTING_LIGHT_HOLY_TALENT: {
-    id: 391161,
-    name: 'Everlasting Light',
-    icon: 'inv_mace_1h_artifactheartofkure_d_01',
-    maxRanks: 1,
-  },
-  GALES_OF_SONG_HOLY_TALENT: {
-    id: 372370,
-    name: 'Gales of Song',
-    icon: 'inv_misc_volatileair',
-    maxRanks: 2,
-  },
-  SYMBOL_OF_HOPE_HOLY_TALENT: {
-    id: 64901,
-    name: 'Symbol of Hope',
-    icon: 'spell_holy_symbolofhope',
-    maxRanks: 1,
-  },
-  ENLIGHTENMENT_HOLY_TALENT: {
-    id: 193155,
-    name: 'Enlightenment',
-    icon: 'spell_arcane_mindmastery',
-    maxRanks: 1,
-  },
-  CRISIS_MANAGEMENT_HOLY_TALENT: {
-    id: 390954,
-    name: 'Crisis Management',
-    icon: 'spell_holy_flashheal',
-    maxRanks: 2,
-  },
-  PRISMATIC_ECHOES_HOLY_TALENT: {
-    id: 390967,
-    name: 'Prismatic Echoes',
-    icon: 'spell_holy_aspiration',
-    maxRanks: 2,
-  },
-  PRAYERS_OF_THE_VIRTUOUS_HOLY_TALENT: {
-    id: 390977,
-    name: 'Prayers of the Virtuous',
-    icon: 'spell_holy_prayerofmendingtga',
-    maxRanks: 2,
-  },
-  PONTIFEX_HOLY_TALENT: {
-    id: 390980,
-    name: 'Pontifex',
-    icon: 'spell_priest_pontifex',
-    maxRanks: 1,
-  },
-  EMPOWERED_RENEW_HOLY_TALENT: {
-    id: 391339,
-    name: 'Empowered Renew',
-    icon: 'ability_paladin_infusionoflight',
-    maxRanks: 1,
-  },
-  RAPID_RECOVERY_HOLY_TALENT: {
-    id: 391368,
-    name: 'Rapid Recovery',
-    icon: 'spell_holy_renew',
-    maxRanks: 1,
-  },
-  SAY_YOUR_PRAYERS_HOLY_TALENT: {
-    id: 391186,
-    name: 'Say Your Prayers',
-    icon: 'ability_priest_bindingprayers',
-    maxRanks: 1,
-  },
-  EMPYREAL_BLAZE_HOLY_TALENT: {
-    id: 372616,
-    name: 'Empyreal Blaze',
-    icon: 'spell_fire_ragnaros_lavabolt',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  RESONANT_WORDS_HOLY_TALENT: {
-    id: 372309,
-    name: 'Resonant Words',
-    icon: 'spell_holy_holybolt',
-    maxRanks: 2,
-  },
-  LIGHT_OF_THE_NAARU_HOLY_TALENT: {
-    id: 196985,
-    name: 'Light of the Naaru',
-    icon: 'inv_pet_naaru',
-    maxRanks: 2,
-  },
-  DESPERATE_TIMES_HOLY_TALENT: {
-    id: 391381,
-    name: 'Desperate Times',
-    icon: 'ability_paladin_infusionoflight',
-    maxRanks: 2,
-  },
-  HARMONIOUS_APPARATUS_HOLY_TALENT: {
-    id: 390994,
-    name: 'Harmonious Apparatus',
-    icon: 'spell_holy_serendipity',
-    maxRanks: 2,
-  },
-  SPIRITED_LITANY_HOLY_TALENT: {
-    id: 391387,
-    name: 'Spirited Litany',
-    icon: 'spell_holy_absolution',
-    maxRanks: 2,
-  },
-  SEARING_LIGHT_HOLY_TALENT: {
-    id: 372611,
-    name: 'Searing Light',
-    icon: 'inv_summerfest_firespirit',
-    maxRanks: 2,
-  },
-  LIGHTWEAVER_HOLY_TALENT: {
-    id: 390992,
-    name: 'Lightweaver',
-    icon: 'spell_holy_greaterheal',
-    maxRanks: 1,
-  },
-  LIGHTWELL_HOLY_TALENT: {
-    id: 372835,
-    name: 'Lightwell',
-    icon: 'spell_holy_summonlightwell',
-    maxRanks: 1,
-    manaCost: 1500,
-  },
-  APOTHEOSIS_HOLY_TALENT: {
-    id: 200183,
-    name: 'Apotheosis',
-    icon: 'ability_priest_ascension',
-    maxRanks: 1,
-  },
-  HOLY_WORD_SALVATION_HOLY_TALENT: {
-    id: 265202,
-    name: 'Holy Word: Salvation',
-    icon: 'ability_priest_archangel',
-    maxRanks: 1,
-    manaCost: 3000,
-  },
-  MIRACLE_WORKER_HOLY_TALENT: {
-    id: 235587,
-    name: 'Miracle Worker',
-    icon: 'spell_holy_persuitofjustice',
-    maxRanks: 1,
-  },
-  DIVINE_WORD_HOLY_TALENT: {
-    id: 372760,
-    name: 'Divine Word',
-    icon: 'spell_priest_chakra',
-    maxRanks: 1,
-  },
+  HOLY_WORD_SERENITY_HOLY_TALENT,
+  PRAYER_OF_HEALING_HOLY_TALENT,
+  GUARDIAN_SPIRIT_HOLY_TALENT,
+  HOLY_WORD_CHASTISE_HOLY_TALENT,
+  HOLY_WORD_SANCTIFY_HOLY_TALENT,
+  GUARDIAN_ANGEL_HOLY_TALENT,
+  GUARDIANS_OF_THE_LIGHT_HOLY_TALENT,
+  CENSURE_HOLY_TALENT,
+  HOLY_FIRE_HOLY_TALENT,
+  CIRCLE_OF_HEALING_HOLY_TALENT,
+  REVITALIZING_PRAYERS_HOLY_TALENT,
+  SANCTIFIED_PRAYERS_HOLY_TALENT,
+  COSMIC_RIPPLE_HOLY_TALENT,
+  AFTERLIFE_HOLY_TALENT,
+  ARCHBISHOP_BENEDICTUS_RESTITUTION_HOLY_TALENT,
+  BENEDICTION_HOLY_TALENT,
+  HOLY_MENDING_HOLY_TALENT,
+  BURNING_VEHEMENCE_HOLY_TALENT,
+  PRAYER_CIRCLE_HOLY_TALENT,
+  HEALING_CHORUS_HOLY_TALENT,
+  PRAYERFUL_LITANY_HOLY_TALENT,
+  TRAIL_OF_LIGHT_HOLY_TALENT,
+  DIVINE_HYMN_HOLY_TALENT,
+  CONVERTED_FOLLOWERS_NYI_HOLY_TALENT,
+  RENEWED_FAITH_HOLY_TALENT,
+  ORISON_HOLY_TALENT,
+  EVERLASTING_LIGHT_HOLY_TALENT,
+  GALES_OF_SONG_HOLY_TALENT,
+  SYMBOL_OF_HOPE_HOLY_TALENT,
+  ENLIGHTENMENT_HOLY_TALENT,
+  CRISIS_MANAGEMENT_HOLY_TALENT,
+  PRISMATIC_ECHOES_HOLY_TALENT,
+  PRAYERS_OF_THE_VIRTUOUS_HOLY_TALENT,
+  PONTIFEX_HOLY_TALENT,
+  EMPOWERED_RENEW_HOLY_TALENT,
+  RAPID_RECOVERY_HOLY_TALENT,
+  SAY_YOUR_PRAYERS_HOLY_TALENT,
+  EMPYREAL_BLAZE_HOLY_TALENT,
+  RESONANT_WORDS_HOLY_TALENT,
+  LIGHT_OF_THE_NAARU_HOLY_TALENT,
+  DESPERATE_TIMES_HOLY_TALENT,
+  HARMONIOUS_APPARATUS_HOLY_TALENT,
+  SPIRITED_LITANY_HOLY_TALENT,
+  SEARING_LIGHT_HOLY_TALENT,
+  LIGHTWEAVER_HOLY_TALENT,
+  LIGHTWELL_HOLY_TALENT,
+  APOTHEOSIS_HOLY_TALENT,
+  HOLY_WORD_SALVATION_HOLY_TALENT,
+  MIRACLE_WORKER_HOLY_TALENT,
+  DIVINE_WORD_HOLY_TALENT,
 });
 
 export default talents;

--- a/src/common/TALENTS/rogue.ts
+++ b/src/common/TALENTS/rogue.ts
@@ -1,1007 +1,1263 @@
 // Generated file, changes will eventually be overwritten!
-import { createTalentList } from './types';
+import { createTalentList, Talent } from './types';
+
+//region Shared
+export const SHIV_TALENT: Talent = {
+  id: 5938,
+  name: 'Shiv',
+  icon: 'inv_throwingknife_04',
+  maxRanks: 1,
+  energyCost: 20,
+};
+export const BLIND_TALENT: Talent = {
+  id: 2094,
+  name: 'Blind',
+  icon: 'spell_shadow_mindsteal',
+  maxRanks: 1,
+};
+export const SAP_TALENT: Talent = {
+  id: 6770,
+  name: 'Sap',
+  icon: 'ability_sap',
+  maxRanks: 1,
+  energyCost: 35,
+};
+export const EVASION_TALENT: Talent = {
+  id: 5277,
+  name: 'Evasion',
+  icon: 'spell_shadow_shadowward',
+  maxRanks: 1,
+};
+export const FEINT_TALENT: Talent = {
+  id: 1966,
+  name: 'Feint',
+  icon: 'ability_rogue_feint',
+  maxRanks: 1,
+  energyCost: 35,
+};
+export const CLOAK_OF_SHADOWS_TALENT: Talent = {
+  id: 31224,
+  name: 'Cloak of Shadows',
+  icon: 'spell_shadow_nethercloak',
+  maxRanks: 1,
+};
+export const MASTER_POISONER_TALENT: Talent = {
+  id: 378436,
+  name: 'Master Poisoner',
+  icon: 'ability_creature_poison_06',
+  maxRanks: 1,
+};
+export const NUMBING_POISON_TALENT: Talent = {
+  id: 5761,
+  name: 'Numbing Poison',
+  icon: 'spell_nature_nullifydisease',
+  maxRanks: 1,
+};
+export const NIMBLE_FINGERS_TALENT: Talent = {
+  id: 378427,
+  name: 'Nimble Fingers',
+  icon: 'ability_rogue_crimsonvial',
+  maxRanks: 1,
+};
+export const GOUGE_TALENT: Talent = {
+  id: 1776,
+  name: 'Gouge',
+  icon: 'ability_gouge',
+  maxRanks: 1,
+  energyCost: 25,
+};
+export const RUSHED_SETUP_TALENT: Talent = {
+  id: 378803,
+  name: 'Rushed Setup',
+  icon: 'ability_skyreach_piercing_rush',
+  maxRanks: 1,
+};
+export const TRICKS_OF_THE_TRADE_TALENT: Talent = {
+  id: 57934,
+  name: 'Tricks of the Trade',
+  icon: 'ability_rogue_tricksofthetrade',
+  maxRanks: 1,
+};
+export const SHADOWRUNNER_TALENT: Talent = {
+  id: 378807,
+  name: 'Shadowrunner',
+  icon: 'ability_stealth',
+  maxRanks: 1,
+};
+export const IMPROVED_WOUND_POISON_TALENT: Talent = {
+  id: 319066,
+  name: 'Improved Wound Poison',
+  icon: 'inv_misc_herb_16',
+  maxRanks: 1,
+};
+export const FLEET_FOOTED_TALENT: Talent = {
+  id: 378813,
+  name: 'Fleet Footed',
+  icon: 'ability_rogue_quickrecovery',
+  maxRanks: 1,
+};
+export const IRON_STOMACH_TALENT: Talent = {
+  id: 193546,
+  name: 'Iron Stomach',
+  icon: 'inv_misc_organ_11',
+  maxRanks: 1,
+};
+export const IMPROVED_SPRINT_TALENT: Talent = {
+  id: 231691,
+  name: 'Improved Sprint',
+  icon: 'ability_rogue_sprint',
+  maxRanks: 1,
+};
+export const PREY_ON_THE_WEAK_TALENT: Talent = {
+  id: 131511,
+  name: 'Prey on the Weak',
+  icon: 'ability_rogue_preyontheweak',
+  maxRanks: 1,
+};
+export const SHADOWSTEP_TALENT: Talent = {
+  id: 36554,
+  name: 'Shadowstep',
+  icon: 'ability_rogue_shadowstep',
+  maxRanks: 1,
+};
+export const SUBTERFUGE_TALENT: Talent = {
+  id: 108208,
+  name: 'Subterfuge',
+  icon: 'rogue_subterfuge',
+  maxRanks: 1,
+};
+export const DEADENED_NERVES_TALENT: Talent = {
+  id: 231719,
+  name: 'Deadened Nerves',
+  icon: 'ability_rogue_nervesofsteel',
+  maxRanks: 1,
+};
+export const RECUPERATOR_TALENT: Talent = {
+  id: 378996,
+  name: 'Recuperator',
+  icon: 'inv_gizmo_runichealthinjector',
+  maxRanks: 1,
+};
+export const IMPROVED_SAP_TALENT: Talent = {
+  id: 379005,
+  name: 'Improved Sap',
+  icon: 'ability_sap',
+  maxRanks: 1,
+};
+export const DEADLY_PRECISION_TALENT: Talent = {
+  id: 381542,
+  name: 'Deadly Precision',
+  icon: 'ability_rogue_deadenednerves',
+  maxRanks: 2,
+};
+export const VIRULENT_POISONS_TALENT: Talent = {
+  id: 381543,
+  name: 'Virulent Poisons',
+  icon: 'ability_creature_poison_06',
+  maxRanks: 2,
+};
+export const SO_VERSATILE_TALENT: Talent = {
+  id: 381619,
+  name: 'So Versatile',
+  icon: 'ability_rogue_versatility',
+  maxRanks: 2,
+};
+export const IMPROVED_AMBUSH_TALENT: Talent = {
+  id: 381620,
+  name: 'Improved Ambush',
+  icon: 'ability_rogue_ambush',
+  maxRanks: 2,
+};
+export const TIGHT_SPENDER_TALENT: Talent = {
+  id: 381621,
+  name: 'Tight Spender',
+  icon: 'inv_misc_coin_03',
+  maxRanks: 2,
+};
+export const NIGHTSTALKER_TALENT: Talent = {
+  id: 14062,
+  name: 'Nightstalker',
+  icon: 'ability_stealth',
+  maxRanks: 2,
+};
+export const MARKED_FOR_DEATH_TALENT: Talent = {
+  id: 137619,
+  name: 'Marked for Death',
+  icon: 'achievement_bg_killingblow_berserker',
+  maxRanks: 1,
+};
+export const ACROBATIC_STRIKES_TALENT: Talent = {
+  id: 196924,
+  name: 'Acrobatic Strikes',
+  icon: 'spell_warrior_wildstrike',
+  maxRanks: 1,
+};
+export const COLD_BLOOD_TALENT: Talent = {
+  id: 382245,
+  name: 'Cold Blood',
+  icon: 'spell_ice_lament',
+  maxRanks: 1,
+};
+export const LEECHING_POISON_TALENT: Talent = {
+  id: 280716,
+  name: 'Leeching Poison',
+  icon: 'rogue_leeching_poison',
+  maxRanks: 1,
+};
+export const LETHALITY_TALENT: Talent = {
+  id: 382238,
+  name: 'Lethality',
+  icon: 'ability_criticalstrike',
+  maxRanks: 3,
+};
+export const ELUSIVENESS_TALENT: Talent = {
+  id: 79008,
+  name: 'Elusiveness',
+  icon: 'ability_rogue_turnthetables',
+  maxRanks: 1,
+};
+export const ALACRITY_TALENT: Talent = {
+  id: 193539,
+  name: 'Alacrity',
+  icon: 'ability_paladin_speedoflight',
+  maxRanks: 3,
+};
+export const CHEAT_DEATH_TALENT: Talent = {
+  id: 31230,
+  name: 'Cheat Death',
+  icon: 'ability_rogue_cheatdeath',
+  maxRanks: 1,
+};
+export const SEAL_FATE_TALENT: Talent = {
+  id: 14190,
+  name: 'Seal Fate',
+  icon: 'ability_rogue_stayofexecution',
+  maxRanks: 2,
+};
+export const VIGOR_TALENT: Talent = {
+  id: 14983,
+  name: 'Vigor',
+  icon: 'ability_rogue_vigor',
+  maxRanks: 1,
+};
+export const ECHOING_REPRIMAND_TALENT: Talent = {
+  id: 385616,
+  name: 'Echoing Reprimand',
+  icon: 'ability_bastion_rogue',
+  maxRanks: 1,
+  energyCost: 10,
+};
+export const DEEPER_STRATAGEM_TALENT: Talent = {
+  id: 193531,
+  name: 'Deeper Stratagem',
+  icon: 'archaeology_5_0_changkiboard',
+  maxRanks: 1,
+};
+export const FIND_WEAKNESS_TALENT: Talent = {
+  id: 91023,
+  name: 'Find Weakness',
+  icon: 'ability_rogue_findweakness',
+  maxRanks: 2,
+};
+export const THISTLE_TEA_TALENT: Talent = {
+  id: 381623,
+  name: 'Thistle Tea',
+  icon: 'inv_drink_milk_05',
+  maxRanks: 1,
+};
+export const RESOUNDING_CLARITY_TALENT: Talent = {
+  id: 381622,
+  name: 'Resounding Clarity',
+  icon: 'ability_bastion_rogue',
+  maxRanks: 2,
+};
+export const SHADOW_DANCE_TALENT: Talent = {
+  id: 185313,
+  name: 'Shadow Dance',
+  icon: 'ability_rogue_shadowdance',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Assassination
+export const DEADLY_POISON_ASSASSINATION_TALENT: Talent = {
+  id: 2823,
+  name: 'Deadly Poison',
+  icon: 'ability_rogue_dualweild',
+  maxRanks: 1,
+};
+export const SHIV_ASSASSINATION_TALENT: Talent = {
+  id: 5938,
+  name: 'Shiv',
+  icon: 'inv_throwingknife_04',
+  maxRanks: 1,
+  energyCost: 20,
+};
+export const VENOMOUS_WOUNDS_ASSASSINATION_TALENT: Talent = {
+  id: 79134,
+  name: 'Venomous Wounds',
+  icon: 'ability_rogue_venomouswounds',
+  maxRanks: 1,
+};
+export const SHADOWSTEP_ASSASSINATION_TALENT: Talent = {
+  id: 36554,
+  name: 'Shadowstep',
+  icon: 'ability_rogue_shadowstep',
+  maxRanks: 1,
+};
+export const CUT_TO_THE_CHASE_ASSASSINATION_TALENT: Talent = {
+  id: 51667,
+  name: 'Cut to the Chase',
+  icon: 'ability_rogue_cuttothechase',
+  maxRanks: 2,
+};
+export const ELABORATE_PLANNING_ASSASSINATION_TALENT: Talent = {
+  id: 193640,
+  name: 'Elaborate Planning',
+  icon: 'inv_misc_map08',
+  maxRanks: 2,
+};
+export const IMPROVED_POISONS_ASSASSINATION_TALENT: Talent = {
+  id: 381624,
+  name: 'Improved Poisons',
+  icon: 'ability_poisons',
+  maxRanks: 2,
+};
+export const BLOODY_MESS_ASSASSINATION_TALENT: Talent = {
+  id: 381626,
+  name: 'Bloody Mess',
+  icon: 'ability_rogue_rupture',
+  maxRanks: 2,
+};
+export const INTERNAL_BLEEDING_ASSASSINATION_TALENT: Talent = {
+  id: 381627,
+  name: 'Internal Bleeding',
+  icon: 'ability_rogue_bloodsplatter',
+  maxRanks: 2,
+};
+export const POISONED_KATAR_ASSASSINATION_TALENT: Talent = {
+  id: 381629,
+  name: 'Poisoned Katar',
+  icon: 'ability_hunter_cobrashot',
+  maxRanks: 1,
+};
+export const IMPROVED_SHIV_ASSASSINATION_TALENT: Talent = {
+  id: 319032,
+  name: 'Improved Shiv',
+  icon: 'inv_throwingknife_04',
+  maxRanks: 1,
+};
+export const ATROPHIC_POISON_NYI_ASSASSINATION_TALENT: Talent = {
+  id: 381637,
+  name: 'Atrophic Poison [NYI]',
+  icon: 'ability_rogue_nervesofsteel',
+  maxRanks: 1,
+};
+export const IMPROVED_GARROTE_ASSASSINATION_TALENT: Talent = {
+  id: 381632,
+  name: 'Improved Garrote',
+  icon: 'ability_rogue_garrote',
+  maxRanks: 1,
+};
+export const INTENT_TO_KILL_ASSASSINATION_TALENT: Talent = {
+  id: 381630,
+  name: 'Intent to Kill',
+  icon: 'ability_rogue_bloodyeye',
+  maxRanks: 1,
+};
+export const CRIMSON_TEMPEST_ASSASSINATION_TALENT: Talent = {
+  id: 121411,
+  name: 'Crimson Tempest',
+  icon: 'inv_knife_1h_cataclysm_c_05',
+  maxRanks: 1,
+  energyCost: 35,
+};
+export const VENOM_RUSH_ASSASSINATION_TALENT: Talent = {
+  id: 152152,
+  name: 'Venom Rush',
+  icon: 'rogue_venomzest',
+  maxRanks: 1,
+};
+export const DEATHMARK_ASSASSINATION_TALENT: Talent = {
+  id: 360194,
+  name: 'Deathmark',
+  icon: 'ability_rogue_deathmark',
+  maxRanks: 1,
+};
+export const MASTER_ASSASSIN_ASSASSINATION_TALENT: Talent = {
+  id: 255989,
+  name: 'Master Assassin',
+  icon: 'ability_criticalstrike',
+  maxRanks: 1,
+};
+export const EXSANGUINATE_ASSASSINATION_TALENT: Talent = {
+  id: 200806,
+  name: 'Exsanguinate',
+  icon: 'ability_deathwing_bloodcorruption_earth',
+  maxRanks: 1,
+  energyCost: 25,
+};
+export const FLYING_DAGGERS_ASSASSINATION_TALENT: Talent = {
+  id: 381631,
+  name: 'Flying Daggers',
+  icon: 'ability_rogue_fanofknives',
+  maxRanks: 1,
+};
+export const VICIOUS_VENOMS_ASSASSINATION_TALENT: Talent = {
+  id: 381634,
+  name: 'Vicious Venoms',
+  icon: 'ability_rogue_deadlybrew',
+  maxRanks: 2,
+};
+export const LETHAL_DOSE_NYI_ASSASSINATION_TALENT: Talent = {
+  id: 381640,
+  name: 'Lethal Dose [NYI]',
+  icon: 'ability_rogue_deviouspoisons',
+  maxRanks: 2,
+};
+export const IRON_WIRE_ASSASSINATION_TALENT: Talent = {
+  id: 196861,
+  name: 'Iron Wire',
+  icon: 'inv_jewelcrafting_delicatecopperwire',
+  maxRanks: 1,
+};
+export const MAIM_MANGLE_ASSASSINATION_TALENT: Talent = {
+  id: 381652,
+  name: 'Maim, Mangle',
+  icon: 'ability_skeer_bloodletting',
+  maxRanks: 1,
+};
+export const AMPLIFYING_POISON_ASSASSINATION_TALENT: Talent = {
+  id: 381664,
+  name: 'Amplifying Poison',
+  icon: 'inv_misc_herb_fellotus',
+  maxRanks: 1,
+};
+export const TWIST_THE_KNIFE_ASSASSINATION_TALENT: Talent = {
+  id: 381669,
+  name: 'Twist the Knife',
+  icon: 'ability_rogue_bladetwisting',
+  maxRanks: 1,
+};
+export const DOOMBLADE_ASSASSINATION_TALENT: Talent = {
+  id: 381673,
+  name: 'Doomblade',
+  icon: 'ability_deathwing_bloodcorruption_earth',
+  maxRanks: 1,
+};
+export const BLINDSIDE_ASSASSINATION_TALENT: Talent = {
+  id: 328085,
+  name: 'Blindside',
+  icon: 'ability_rogue_focusedattacks',
+  maxRanks: 1,
+};
+export const TINY_TOXIC_BLADE_ASSASSINATION_TALENT: Talent = {
+  id: 381800,
+  name: 'Tiny Toxic Blade',
+  icon: 'ability_rogue_poisonedknife',
+  maxRanks: 1,
+};
+export const POISON_BOMB_ASSASSINATION_TALENT: Talent = {
+  id: 255544,
+  name: 'Poison Bomb',
+  icon: 'rogue_paralytic_poison',
+  maxRanks: 2,
+};
+export const SHROUDED_SUFFOCATION_ASSASSINATION_TALENT: Talent = {
+  id: 385478,
+  name: 'Shrouded Suffocation',
+  icon: 'ability_rogue_garrote',
+  maxRanks: 1,
+};
+export const SEPSIS_ASSASSINATION_TALENT: Talent = {
+  id: 385408,
+  name: 'Sepsis',
+  icon: 'ability_ardenweald_rogue',
+  maxRanks: 1,
+  energyCost: 25,
+};
+export const SERRATED_BONE_SPIKE_ASSASSINATION_TALENT: Talent = {
+  id: 385424,
+  name: 'Serrated Bone Spike',
+  icon: 'ability_maldraxxus_rogue',
+  maxRanks: 1,
+  energyCost: 15,
+};
+export const ZOLDYCK_RECIPE_ASSASSINATION_TALENT: Talent = {
+  id: 381798,
+  name: 'Zoldyck Recipe',
+  icon: 'archaeology_5_0_thunderkinginsignia',
+  maxRanks: 3,
+};
+export const DASHING_SCOUNDREL_ASSASSINATION_TALENT: Talent = {
+  id: 381797,
+  name: 'Dashing Scoundrel',
+  icon: 'ability_rogue_venomouswounds',
+  maxRanks: 3,
+};
+export const SCENT_OF_BLOOD_ASSASSINATION_TALENT: Talent = {
+  id: 381799,
+  name: 'Scent of Blood',
+  icon: 'ability_rogue_rupture',
+  maxRanks: 3,
+};
+export const KINGSBANE_ASSASSINATION_TALENT: Talent = {
+  id: 385627,
+  name: 'Kingsbane',
+  icon: 'inv_knife_1h_artifactgarona_d_01',
+  maxRanks: 1,
+  energyCost: 35,
+};
+export const DRAGON_TEMPERED_BLADES_ASSASSINATION_TALENT: Talent = {
+  id: 381801,
+  name: 'Dragon-Tempered Blades',
+  icon: 'spell_fire_flameblades',
+  maxRanks: 1,
+};
+export const INDISCRIMINATE_CARNAGE_ASSASSINATION_TALENT: Talent = {
+  id: 381802,
+  name: 'Indiscriminate Carnage',
+  icon: 'ability_rogue_indiscriminatecarnage',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Outlaw
+export const OPPORTUNITY_OUTLAW_TALENT: Talent = {
+  id: 279876,
+  name: 'Opportunity',
+  icon: 'spell_shadow_ritualofsacrifice',
+  maxRanks: 1,
+};
+export const BLADE_FLURRY_OUTLAW_TALENT: Talent = {
+  id: 13877,
+  name: 'Blade Flurry',
+  icon: 'ability_warrior_punishingblow',
+  maxRanks: 1,
+  energyCost: 15,
+};
+export const GRAPPLING_HOOK_OUTLAW_TALENT: Talent = {
+  id: 195457,
+  name: 'Grappling Hook',
+  icon: 'ability_rogue_grapplinghook',
+  maxRanks: 1,
+};
+export const WEAPONMASTER_OUTLAW_TALENT: Talent = {
+  id: 200733,
+  name: 'Weaponmaster',
+  icon: 'ability_ironmaidens_bladerush',
+  maxRanks: 1,
+};
+export const COMBAT_POTENCY_OUTLAW_TALENT: Talent = {
+  id: 61329,
+  name: 'Combat Potency',
+  icon: 'inv_weapon_shortblade_38',
+  maxRanks: 1,
+};
+export const AMBIDEXTERITY_OUTLAW_TALENT: Talent = {
+  id: 381822,
+  name: 'Ambidexterity',
+  icon: 'inv_glove_cloth_oribosdungeon_c_01',
+  maxRanks: 1,
+};
+export const BETWEEN_THE_EYES_OUTLAW_TALENT: Talent = {
+  id: 315341,
+  name: 'Between the Eyes',
+  icon: 'inv_weapon_rifle_01',
+  maxRanks: 1,
+  energyCost: 25,
+};
+export const RETRACTABLE_HOOK_OUTLAW_TALENT: Talent = {
+  id: 256188,
+  name: 'Retractable Hook',
+  icon: 'ability_rogue_grapplinghook',
+  maxRanks: 1,
+};
+export const COMBAT_STAMINA_OUTLAW_TALENT: Talent = {
+  id: 381877,
+  name: 'Combat Stamina',
+  icon: 'ability_rogue_imrovedrecuperate',
+  maxRanks: 1,
+};
+export const ADRENALINE_RUSH_OUTLAW_TALENT: Talent = {
+  id: 13750,
+  name: 'Adrenaline Rush',
+  icon: 'spell_shadow_shadowworddominate',
+  maxRanks: 1,
+};
+export const RIPOSTE_OUTLAW_TALENT: Talent = {
+  id: 344363,
+  name: 'Riposte',
+  icon: 'ability_warrior_challange',
+  maxRanks: 1,
+};
+export const HIT_AND_RUN_OUTLAW_TALENT: Talent = {
+  id: 196922,
+  name: 'Hit and Run',
+  icon: 'ability_rogue_fleetfooted',
+  maxRanks: 1,
+};
+export const BLINDING_POWDER_OUTLAW_TALENT: Talent = {
+  id: 256165,
+  name: 'Blinding Powder',
+  icon: 'inv_misc_ammo_gunpowder_06',
+  maxRanks: 1,
+};
+export const RUTHLESSNESS_OUTLAW_TALENT: Talent = {
+  id: 14161,
+  name: 'Ruthlessness',
+  icon: 'ability_druid_disembowel',
+  maxRanks: 1,
+};
+export const SLICERDICER_OUTLAW_TALENT: Talent = {
+  id: 381988,
+  name: 'Slicerdicer',
+  icon: 'ability_rogue_slicedice',
+  maxRanks: 1,
+};
+export const RESTLESS_BLADES_OUTLAW_TALENT: Talent = {
+  id: 79096,
+  name: 'Restless Blades',
+  icon: 'ability_rogue_restlessblades',
+  maxRanks: 1,
+};
+export const FATAL_FLOURISH_OUTLAW_TALENT: Talent = {
+  id: 35551,
+  name: 'Fatal Flourish',
+  icon: 'ability_rogue_unfairadvantage',
+  maxRanks: 1,
+};
+export const ACE_UP_YOUR_SLEEVE_OUTLAW_TALENT: Talent = {
+  id: 381828,
+  name: 'Ace Up Your Sleeve',
+  icon: 'inv_weapon_rifle_01',
+  maxRanks: 1,
+};
+export const DIRTY_TRICKS_OUTLAW_TALENT: Talent = {
+  id: 108216,
+  name: 'Dirty Tricks',
+  icon: 'ability_rogue_dirtydeeds',
+  maxRanks: 1,
+};
+export const HEAVY_HITTER_NYI_OUTLAW_TALENT: Talent = {
+  id: 381885,
+  name: 'Heavy Hitter [NYI]',
+  icon: 'ability_rogue_ambush',
+  maxRanks: 1,
+};
+export const DEEPER_STRATAGEM_OUTLAW_TALENT: Talent = {
+  id: 193531,
+  name: 'Deeper Stratagem',
+  icon: 'archaeology_5_0_changkiboard',
+  maxRanks: 1,
+};
+export const ROLL_THE_BONES_OUTLAW_TALENT: Talent = {
+  id: 315508,
+  name: 'Roll the Bones',
+  icon: 'ability_rogue_rollthebones',
+  maxRanks: 1,
+  energyCost: 25,
+};
+export const QUICK_DRAW_OUTLAW_TALENT: Talent = {
+  id: 196938,
+  name: 'Quick Draw',
+  icon: 'inv_weapon_rifle_40',
+  maxRanks: 1,
+};
+export const LONG_ARM_OF_THE_OUTLAW_OUTLAW_TALENT: Talent = {
+  id: 381878,
+  name: 'Long Arm of the Outlaw',
+  icon: 'spell_warrior_wildstrike',
+  maxRanks: 1,
+};
+export const AUDACITY_OUTLAW_TALENT: Talent = {
+  id: 381845,
+  name: 'Audacity',
+  icon: 'ability_rogue_ambush',
+  maxRanks: 1,
+};
+export const LOADED_DICE_OUTLAW_TALENT: Talent = {
+  id: 256170,
+  name: 'Loaded Dice',
+  icon: 'ability_rogue_rollthebones',
+  maxRanks: 1,
+};
+export const FLOAT_LIKE_A_BUTTERFLY_OUTLAW_TALENT: Talent = {
+  id: 354897,
+  name: 'Float Like a Butterfly',
+  icon: 'inv_pet_butterfly_orange',
+  maxRanks: 1,
+};
+export const SLEIGHT_OF_HAND_OUTLAW_TALENT: Talent = {
+  id: 381839,
+  name: 'Sleight of Hand',
+  icon: 'inv_misc_dice_02',
+  maxRanks: 1,
+};
+export const DANCING_STEEL_OUTLAW_TALENT: Talent = {
+  id: 272026,
+  name: 'Dancing Steel',
+  icon: 'ability_warrior_punishingblow',
+  maxRanks: 1,
+};
+export const TRIPLE_THREAT_OUTLAW_TALENT: Talent = {
+  id: 381894,
+  name: 'Triple Threat',
+  icon: 'ability_dualwield',
+  maxRanks: 2,
+};
+export const COUNT_THE_ODDS_OUTLAW_TALENT: Talent = {
+  id: 381982,
+  name: 'Count the Odds',
+  icon: 'inv_misc_dice_01',
+  maxRanks: 2,
+};
+export const IMPROVED_MAIN_GAUCHE_OUTLAW_TALENT: Talent = {
+  id: 382746,
+  name: 'Improved Main Gauche',
+  icon: 'inv_weapon_shortblade_15',
+  maxRanks: 2,
+};
+export const SEPSIS_OUTLAW_TALENT: Talent = {
+  id: 385408,
+  name: 'Sepsis',
+  icon: 'ability_ardenweald_rogue',
+  maxRanks: 1,
+  energyCost: 25,
+};
+export const GHOSTLY_STRIKE_OUTLAW_TALENT: Talent = {
+  id: 196937,
+  name: 'Ghostly Strike',
+  icon: 'ability_creature_cursed_02',
+  maxRanks: 1,
+  energyCost: 30,
+};
+export const BLADE_RUSH_OUTLAW_TALENT: Talent = {
+  id: 271877,
+  name: 'Blade Rush',
+  icon: 'ability_arakkoa_spinning_blade',
+  maxRanks: 1,
+};
+export const RESTLESS_CREW_NYI_OUTLAW_TALENT: Talent = {
+  id: 382794,
+  name: 'Restless Crew [NYI]',
+  icon: 'ability_rogue_restlessblades',
+  maxRanks: 1,
+};
+export const KILLING_SPREE_OUTLAW_TALENT: Talent = {
+  id: 51690,
+  name: 'Killing Spree',
+  icon: 'ability_rogue_murderspree',
+  maxRanks: 1,
+};
+export const DREADBLADES_OUTLAW_TALENT: Talent = {
+  id: 343142,
+  name: 'Dreadblades',
+  icon: 'inv_sword_1h_artifactskywall_d_01dual',
+  maxRanks: 1,
+  energyCost: 30,
+};
+export const PRECISE_CUTS_NYI_OUTLAW_TALENT: Talent = {
+  id: 381985,
+  name: 'Precise Cuts [NYI]',
+  icon: 'ability_warrior_punishingblow',
+  maxRanks: 1,
+};
+export const TAKE_EM_BY_SURPRISE_OUTLAW_TALENT: Talent = {
+  id: 382742,
+  name: "Take 'em by Surprise",
+  icon: 'ability_stealth',
+  maxRanks: 2,
+};
+export const DISPATCHER_OUTLAW_TALENT: Talent = {
+  id: 381990,
+  name: 'Dispatcher',
+  icon: 'ability_rogue_waylay',
+  maxRanks: 2,
+};
+export const FAN_THE_HAMMER_OUTLAW_TALENT: Talent = {
+  id: 381846,
+  name: 'Fan the Hammer',
+  icon: 'ability_rogue_pistolshot',
+  maxRanks: 2,
+};
+export const HIDDEN_OPPORTUNITY_OUTLAW_TALENT: Talent = {
+  id: 383281,
+  name: 'Hidden Opportunity',
+  icon: 'ability_rogue_ambush',
+  maxRanks: 1,
+};
+export const KEEP_IT_ROLLING_OUTLAW_TALENT: Talent = {
+  id: 381989,
+  name: 'Keep It Rolling',
+  icon: 'ability_rogue_keepitrolling',
+  maxRanks: 1,
+};
+export const GREENSKINS_WICKERS_OUTLAW_TALENT: Talent = {
+  id: 386823,
+  name: "Greenskin's Wickers",
+  icon: 'ability_creature_cursed_04',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Subtlety
+export const IMPROVED_BACKSTAB_SUBTLETY_TALENT: Talent = {
+  id: 319949,
+  name: 'Improved Backstab',
+  icon: 'ability_backstab',
+  maxRanks: 1,
+};
+export const SHADOWSTEP_SUBTLETY_TALENT: Talent = {
+  id: 36554,
+  name: 'Shadowstep',
+  icon: 'ability_rogue_shadowstep',
+  maxRanks: 1,
+};
+export const IMPROVED_SHURIKEN_STORM_SUBTLETY_TALENT: Talent = {
+  id: 319951,
+  name: 'Improved Shuriken Storm',
+  icon: 'ability_rogue_shuriken_storm',
+  maxRanks: 1,
+};
+export const WEAPONMASTER_SUBTLETY_TALENT: Talent = {
+  id: 193537,
+  name: 'Weaponmaster',
+  icon: 'ability_ironmaidens_bladerush',
+  maxRanks: 1,
+};
+export const SHADOW_FOCUS_SUBTLETY_TALENT: Talent = {
+  id: 108209,
+  name: 'Shadow Focus',
+  icon: 'rogue_shadowfocus',
+  maxRanks: 1,
+};
+export const QUICK_DECISIONS_SUBTLETY_TALENT: Talent = {
+  id: 382503,
+  name: 'Quick Decisions',
+  icon: 'inv_misc_hook_01',
+  maxRanks: 1,
+};
+export const RELENTLESS_STRIKES_SUBTLETY_TALENT: Talent = {
+  id: 58423,
+  name: 'Relentless Strikes',
+  icon: 'ability_warrior_decisivestrike',
+  maxRanks: 1,
+};
+export const BLACK_POWDER_SUBTLETY_TALENT: Talent = {
+  id: 319175,
+  name: 'Black Powder',
+  icon: 'spell_priest_divinestar_shadow',
+  maxRanks: 1,
+  energyCost: 35,
+};
+export const SHOT_IN_THE_DARK_SUBTLETY_TALENT: Talent = {
+  id: 257505,
+  name: 'Shot in the Dark',
+  icon: 'ability_cheapshot',
+  maxRanks: 1,
+};
+export const PREMEDITATION_SUBTLETY_TALENT: Talent = {
+  id: 343160,
+  name: 'Premeditation',
+  icon: 'spell_shadow_possession',
+  maxRanks: 1,
+};
+export const SHADOW_DANCE_SUBTLETY_TALENT: Talent = {
+  id: 185313,
+  name: 'Shadow Dance',
+  icon: 'ability_rogue_shadowdance',
+  maxRanks: 1,
+};
+export const SILENT_STORM_SUBTLETY_TALENT: Talent = {
+  id: 385722,
+  name: 'Silent Storm',
+  icon: 'ability_rogue_shuriken_storm',
+  maxRanks: 1,
+};
+export const NIGHT_TERRORS_SUBTLETY_TALENT: Talent = {
+  id: 277953,
+  name: 'Night Terrors',
+  icon: 'spell_shadow_shadesofdarkness',
+  maxRanks: 1,
+};
+export const GLOOMBLADE_SUBTLETY_TALENT: Talent = {
+  id: 200758,
+  name: 'Gloomblade',
+  icon: 'ability_ironmaidens_convulsiveshadows',
+  maxRanks: 1,
+  energyCost: 35,
+};
+export const SHADOW_TECHNIQUES_SUBTLETY_TALENT: Talent = {
+  id: 196912,
+  name: 'Shadow Techniques',
+  icon: 'ability_rogue_masterofsubtlety',
+  maxRanks: 1,
+};
+export const SHADOW_BLADES_SUBTLETY_TALENT: Talent = {
+  id: 121471,
+  name: 'Shadow Blades',
+  icon: 'inv_knife_1h_grimbatolraid_d_03',
+  maxRanks: 1,
+};
+export const VEILTOUCHED_SUBTLETY_TALENT: Talent = {
+  id: 382017,
+  name: 'Veiltouched',
+  icon: 'spell_nature_slowpoison',
+  maxRanks: 1,
+};
+export const SECRET_TECHNIQUE_SUBTLETY_TALENT: Talent = {
+  id: 280719,
+  name: 'Secret Technique',
+  icon: 'ability_rogue_sinistercalling',
+  maxRanks: 1,
+  energyCost: 30,
+};
+export const SYMBOLS_OF_DEATH_SUBTLETY_TALENT: Talent = {
+  id: 212283,
+  name: 'Symbols of Death',
+  icon: 'spell_shadow_rune',
+  maxRanks: 1,
+};
+export const MASTER_OF_SHADOWS_SUBTLETY_TALENT: Talent = {
+  id: 196976,
+  name: 'Master of Shadows',
+  icon: 'spell_shadow_charm',
+  maxRanks: 1,
+};
+export const DEEPENING_SHADOWS_SUBTLETY_TALENT: Talent = {
+  id: 185314,
+  name: 'Deepening Shadows',
+  icon: 'spell_shadow_twilight',
+  maxRanks: 1,
+};
+export const THE_FIRST_DANCE_SUBTLETY_TALENT: Talent = {
+  id: 382505,
+  name: 'The First Dance',
+  icon: 'ability_rogue_shadowdance',
+  maxRanks: 1,
+};
+export const REPLICATING_SHADOWS_NYI_SUBTLETY_TALENT: Talent = {
+  id: 382506,
+  name: 'Replicating Shadows [NYI]',
+  icon: 'spell_deathknight_strangulate',
+  maxRanks: 1,
+};
+export const SHROUDED_IN_DARKNESS_SUBTLETY_TALENT: Talent = {
+  id: 382507,
+  name: 'Shrouded in Darkness',
+  icon: 'ability_rogue_envelopingshadows',
+  maxRanks: 1,
+};
+export const PLANNED_EXECUTION_SUBTLETY_TALENT: Talent = {
+  id: 382508,
+  name: 'Planned Execution',
+  icon: 'ability_creature_cursed_02',
+  maxRanks: 2,
+};
+export const STILETTO_STACCATO_SUBTLETY_TALENT: Talent = {
+  id: 382509,
+  name: 'Stiletto Staccato',
+  icon: 'ability_rogue_shadowyduel',
+  maxRanks: 2,
+};
+export const SHADOWED_FINISHERS_SUBTLETY_TALENT: Talent = {
+  id: 382511,
+  name: 'Shadowed Finishers',
+  icon: 'ability_rogue_eviscerate',
+  maxRanks: 2,
+};
+export const SHURIKEN_TORNADO_SUBTLETY_TALENT: Talent = {
+  id: 277925,
+  name: 'Shuriken Tornado',
+  icon: 'ability_rogue_throwingspecialization',
+  maxRanks: 1,
+  energyCost: 60,
+};
+export const INEVITABILITY_SUBTLETY_TALENT: Talent = {
+  id: 278683,
+  name: 'Inevitability',
+  icon: 'spell_shadow_rune',
+  maxRanks: 1,
+};
+export const WITHOUT_A_TRACE_SUBTLETY_TALENT: Talent = {
+  id: 382513,
+  name: 'Without a Trace',
+  icon: 'ability_vanish',
+  maxRanks: 1,
+};
+export const FADE_TO_NOTHING_SUBTLETY_TALENT: Talent = {
+  id: 382514,
+  name: 'Fade to Nothing',
+  icon: 'ability_warlock_everlastingaffliction',
+  maxRanks: 1,
+};
+export const CLOAKED_IN_SHADOWS_SUBTLETY_TALENT: Talent = {
+  id: 382515,
+  name: 'Cloaked in Shadows',
+  icon: 'inv_helm_cloth_shadowmoonclan_b_01',
+  maxRanks: 1,
+};
+export const DEEPER_DAGGERS_SUBTLETY_TALENT: Talent = {
+  id: 382517,
+  name: 'Deeper Daggers',
+  icon: 'inv_weapon_shortblade_15',
+  maxRanks: 1,
+};
+export const SEPSIS_SUBTLETY_TALENT: Talent = {
+  id: 385408,
+  name: 'Sepsis',
+  icon: 'ability_ardenweald_rogue',
+  maxRanks: 1,
+  energyCost: 25,
+};
+export const PERFORATED_VEINS_SUBTLETY_TALENT: Talent = {
+  id: 382518,
+  name: 'Perforated Veins',
+  icon: 'ability_warrior_bloodfrenzy',
+  maxRanks: 1,
+};
+export const DARK_SHADOW_SUBTLETY_TALENT: Talent = {
+  id: 245687,
+  name: 'Dark Shadow',
+  icon: 'spell_warlock_demonsoul',
+  maxRanks: 1,
+};
+export const DEEPER_STRATAGEM_SUBTLETY_TALENT: Talent = {
+  id: 193531,
+  name: 'Deeper Stratagem',
+  icon: 'archaeology_5_0_changkiboard',
+  maxRanks: 1,
+};
+export const FLAGELLATION_SUBTLETY_TALENT: Talent = {
+  id: 384631,
+  name: 'Flagellation',
+  icon: 'ability_revendreth_rogue',
+  maxRanks: 1,
+};
+export const INVIGORATING_SHADOWDUST_SUBTLETY_TALENT: Talent = {
+  id: 382523,
+  name: 'Invigorating Shadowdust',
+  icon: 'ability_vanish',
+  maxRanks: 2,
+};
+export const LINGERING_SHADOW_SUBTLETY_TALENT: Talent = {
+  id: 382524,
+  name: 'Lingering Shadow',
+  icon: 'spell_fire_twilightnova',
+  maxRanks: 2,
+};
+export const FINALITY_SUBTLETY_TALENT: Talent = {
+  id: 382525,
+  name: 'Finality',
+  icon: 'ability_rogue_eviscerate',
+  maxRanks: 2,
+};
+export const THE_ROTTEN_SUBTLETY_TALENT: Talent = {
+  id: 382015,
+  name: 'The Rotten',
+  icon: 'spell_shadow_nightofthedead',
+  maxRanks: 1,
+};
+export const SHADOW_MIST_NYI_SUBTLETY_TALENT: Talent = {
+  id: 382528,
+  name: 'Shadow Mist [NYI]',
+  icon: 'ability_druid_typhoon',
+  maxRanks: 1,
+};
+export const DARK_BREW_SUBTLETY_TALENT: Talent = {
+  id: 382504,
+  name: 'Dark Brew',
+  icon: 'spell_nature_slowpoison',
+  maxRanks: 1,
+};
+
+//endregion
 
 const talents = createTalentList({
   //Shared
-  SHIV_TALENT: {
-    id: 5938,
-    name: 'Shiv',
-    icon: 'inv_throwingknife_04',
-    maxRanks: 1,
-    energyCost: 20,
-  },
-  BLIND_TALENT: { id: 2094, name: 'Blind', icon: 'spell_shadow_mindsteal', maxRanks: 1 },
-  SAP_TALENT: { id: 6770, name: 'Sap', icon: 'ability_sap', maxRanks: 1, energyCost: 35 },
-  EVASION_TALENT: { id: 5277, name: 'Evasion', icon: 'spell_shadow_shadowward', maxRanks: 1 },
-  FEINT_TALENT: {
-    id: 1966,
-    name: 'Feint',
-    icon: 'ability_rogue_feint',
-    maxRanks: 1,
-    energyCost: 35,
-  },
-  CLOAK_OF_SHADOWS_TALENT: {
-    id: 31224,
-    name: 'Cloak of Shadows',
-    icon: 'spell_shadow_nethercloak',
-    maxRanks: 1,
-  },
-  MASTER_POISONER_TALENT: {
-    id: 378436,
-    name: 'Master Poisoner',
-    icon: 'ability_creature_poison_06',
-    maxRanks: 1,
-  },
-  NUMBING_POISON_TALENT: {
-    id: 5761,
-    name: 'Numbing Poison',
-    icon: 'spell_nature_nullifydisease',
-    maxRanks: 1,
-  },
-  NIMBLE_FINGERS_TALENT: {
-    id: 378427,
-    name: 'Nimble Fingers',
-    icon: 'ability_rogue_crimsonvial',
-    maxRanks: 1,
-  },
-  GOUGE_TALENT: { id: 1776, name: 'Gouge', icon: 'ability_gouge', maxRanks: 1, energyCost: 25 },
-  RUSHED_SETUP_TALENT: {
-    id: 378803,
-    name: 'Rushed Setup',
-    icon: 'ability_skyreach_piercing_rush',
-    maxRanks: 1,
-  },
-  TRICKS_OF_THE_TRADE_TALENT: {
-    id: 57934,
-    name: 'Tricks of the Trade',
-    icon: 'ability_rogue_tricksofthetrade',
-    maxRanks: 1,
-  },
-  SHADOWRUNNER_TALENT: { id: 378807, name: 'Shadowrunner', icon: 'ability_stealth', maxRanks: 1 },
-  IMPROVED_WOUND_POISON_TALENT: {
-    id: 319066,
-    name: 'Improved Wound Poison',
-    icon: 'inv_misc_herb_16',
-    maxRanks: 1,
-  },
-  FLEET_FOOTED_TALENT: {
-    id: 378813,
-    name: 'Fleet Footed',
-    icon: 'ability_rogue_quickrecovery',
-    maxRanks: 1,
-  },
-  IRON_STOMACH_TALENT: { id: 193546, name: 'Iron Stomach', icon: 'inv_misc_organ_11', maxRanks: 1 },
-  IMPROVED_SPRINT_TALENT: {
-    id: 231691,
-    name: 'Improved Sprint',
-    icon: 'ability_rogue_sprint',
-    maxRanks: 1,
-  },
-  PREY_ON_THE_WEAK_TALENT: {
-    id: 131511,
-    name: 'Prey on the Weak',
-    icon: 'ability_rogue_preyontheweak',
-    maxRanks: 1,
-  },
-  SHADOWSTEP_TALENT: {
-    id: 36554,
-    name: 'Shadowstep',
-    icon: 'ability_rogue_shadowstep',
-    maxRanks: 1,
-  },
-  SUBTERFUGE_TALENT: { id: 108208, name: 'Subterfuge', icon: 'rogue_subterfuge', maxRanks: 1 },
-  DEADENED_NERVES_TALENT: {
-    id: 231719,
-    name: 'Deadened Nerves',
-    icon: 'ability_rogue_nervesofsteel',
-    maxRanks: 1,
-  },
-  RECUPERATOR_TALENT: {
-    id: 378996,
-    name: 'Recuperator',
-    icon: 'inv_gizmo_runichealthinjector',
-    maxRanks: 1,
-  },
-  IMPROVED_SAP_TALENT: { id: 379005, name: 'Improved Sap', icon: 'ability_sap', maxRanks: 1 },
-  DEADLY_PRECISION_TALENT: {
-    id: 381542,
-    name: 'Deadly Precision',
-    icon: 'ability_rogue_deadenednerves',
-    maxRanks: 2,
-  },
-  VIRULENT_POISONS_TALENT: {
-    id: 381543,
-    name: 'Virulent Poisons',
-    icon: 'ability_creature_poison_06',
-    maxRanks: 2,
-  },
-  SO_VERSATILE_TALENT: {
-    id: 381619,
-    name: 'So Versatile',
-    icon: 'ability_rogue_versatility',
-    maxRanks: 2,
-  },
-  IMPROVED_AMBUSH_TALENT: {
-    id: 381620,
-    name: 'Improved Ambush',
-    icon: 'ability_rogue_ambush',
-    maxRanks: 2,
-  },
-  TIGHT_SPENDER_TALENT: {
-    id: 381621,
-    name: 'Tight Spender',
-    icon: 'inv_misc_coin_03',
-    maxRanks: 2,
-  },
-  NIGHTSTALKER_TALENT: { id: 14062, name: 'Nightstalker', icon: 'ability_stealth', maxRanks: 2 },
-  MARKED_FOR_DEATH_TALENT: {
-    id: 137619,
-    name: 'Marked for Death',
-    icon: 'achievement_bg_killingblow_berserker',
-    maxRanks: 1,
-  },
-  ACROBATIC_STRIKES_TALENT: {
-    id: 196924,
-    name: 'Acrobatic Strikes',
-    icon: 'spell_warrior_wildstrike',
-    maxRanks: 1,
-  },
-  COLD_BLOOD_TALENT: { id: 382245, name: 'Cold Blood', icon: 'spell_ice_lament', maxRanks: 1 },
-  LEECHING_POISON_TALENT: {
-    id: 280716,
-    name: 'Leeching Poison',
-    icon: 'rogue_leeching_poison',
-    maxRanks: 1,
-  },
-  LETHALITY_TALENT: { id: 382238, name: 'Lethality', icon: 'ability_criticalstrike', maxRanks: 3 },
-  ELUSIVENESS_TALENT: {
-    id: 79008,
-    name: 'Elusiveness',
-    icon: 'ability_rogue_turnthetables',
-    maxRanks: 1,
-  },
-  ALACRITY_TALENT: {
-    id: 193539,
-    name: 'Alacrity',
-    icon: 'ability_paladin_speedoflight',
-    maxRanks: 3,
-  },
-  CHEAT_DEATH_TALENT: {
-    id: 31230,
-    name: 'Cheat Death',
-    icon: 'ability_rogue_cheatdeath',
-    maxRanks: 1,
-  },
-  SEAL_FATE_TALENT: {
-    id: 14190,
-    name: 'Seal Fate',
-    icon: 'ability_rogue_stayofexecution',
-    maxRanks: 2,
-  },
-  VIGOR_TALENT: { id: 14983, name: 'Vigor', icon: 'ability_rogue_vigor', maxRanks: 1 },
-  ECHOING_REPRIMAND_TALENT: {
-    id: 385616,
-    name: 'Echoing Reprimand',
-    icon: 'ability_bastion_rogue',
-    maxRanks: 1,
-    energyCost: 10,
-  },
-  DEEPER_STRATAGEM_TALENT: {
-    id: 193531,
-    name: 'Deeper Stratagem',
-    icon: 'archaeology_5_0_changkiboard',
-    maxRanks: 1,
-  },
-  FIND_WEAKNESS_TALENT: {
-    id: 91023,
-    name: 'Find Weakness',
-    icon: 'ability_rogue_findweakness',
-    maxRanks: 2,
-  },
-  THISTLE_TEA_TALENT: { id: 381623, name: 'Thistle Tea', icon: 'inv_drink_milk_05', maxRanks: 1 },
-  RESOUNDING_CLARITY_TALENT: {
-    id: 381622,
-    name: 'Resounding Clarity',
-    icon: 'ability_bastion_rogue',
-    maxRanks: 2,
-  },
-  SHADOW_DANCE_TALENT: {
-    id: 185313,
-    name: 'Shadow Dance',
-    icon: 'ability_rogue_shadowdance',
-    maxRanks: 1,
-  },
+  SHIV_TALENT,
+  BLIND_TALENT,
+  SAP_TALENT,
+  EVASION_TALENT,
+  FEINT_TALENT,
+  CLOAK_OF_SHADOWS_TALENT,
+  MASTER_POISONER_TALENT,
+  NUMBING_POISON_TALENT,
+  NIMBLE_FINGERS_TALENT,
+  GOUGE_TALENT,
+  RUSHED_SETUP_TALENT,
+  TRICKS_OF_THE_TRADE_TALENT,
+  SHADOWRUNNER_TALENT,
+  IMPROVED_WOUND_POISON_TALENT,
+  FLEET_FOOTED_TALENT,
+  IRON_STOMACH_TALENT,
+  IMPROVED_SPRINT_TALENT,
+  PREY_ON_THE_WEAK_TALENT,
+  SHADOWSTEP_TALENT,
+  SUBTERFUGE_TALENT,
+  DEADENED_NERVES_TALENT,
+  RECUPERATOR_TALENT,
+  IMPROVED_SAP_TALENT,
+  DEADLY_PRECISION_TALENT,
+  VIRULENT_POISONS_TALENT,
+  SO_VERSATILE_TALENT,
+  IMPROVED_AMBUSH_TALENT,
+  TIGHT_SPENDER_TALENT,
+  NIGHTSTALKER_TALENT,
+  MARKED_FOR_DEATH_TALENT,
+  ACROBATIC_STRIKES_TALENT,
+  COLD_BLOOD_TALENT,
+  LEECHING_POISON_TALENT,
+  LETHALITY_TALENT,
+  ELUSIVENESS_TALENT,
+  ALACRITY_TALENT,
+  CHEAT_DEATH_TALENT,
+  SEAL_FATE_TALENT,
+  VIGOR_TALENT,
+  ECHOING_REPRIMAND_TALENT,
+  DEEPER_STRATAGEM_TALENT,
+  FIND_WEAKNESS_TALENT,
+  THISTLE_TEA_TALENT,
+  RESOUNDING_CLARITY_TALENT,
+  SHADOW_DANCE_TALENT,
 
   //Assassination
-  DEADLY_POISON_ASSASSINATION_TALENT: {
-    id: 2823,
-    name: 'Deadly Poison',
-    icon: 'ability_rogue_dualweild',
-    maxRanks: 1,
-  },
-  SHIV_ASSASSINATION_TALENT: {
-    id: 5938,
-    name: 'Shiv',
-    icon: 'inv_throwingknife_04',
-    maxRanks: 1,
-    energyCost: 20,
-  },
-  VENOMOUS_WOUNDS_ASSASSINATION_TALENT: {
-    id: 79134,
-    name: 'Venomous Wounds',
-    icon: 'ability_rogue_venomouswounds',
-    maxRanks: 1,
-  },
-  SHADOWSTEP_ASSASSINATION_TALENT: {
-    id: 36554,
-    name: 'Shadowstep',
-    icon: 'ability_rogue_shadowstep',
-    maxRanks: 1,
-  },
-  CUT_TO_THE_CHASE_ASSASSINATION_TALENT: {
-    id: 51667,
-    name: 'Cut to the Chase',
-    icon: 'ability_rogue_cuttothechase',
-    maxRanks: 2,
-  },
-  ELABORATE_PLANNING_ASSASSINATION_TALENT: {
-    id: 193640,
-    name: 'Elaborate Planning',
-    icon: 'inv_misc_map08',
-    maxRanks: 2,
-  },
-  IMPROVED_POISONS_ASSASSINATION_TALENT: {
-    id: 381624,
-    name: 'Improved Poisons',
-    icon: 'ability_poisons',
-    maxRanks: 2,
-  },
-  BLOODY_MESS_ASSASSINATION_TALENT: {
-    id: 381626,
-    name: 'Bloody Mess',
-    icon: 'ability_rogue_rupture',
-    maxRanks: 2,
-  },
-  INTERNAL_BLEEDING_ASSASSINATION_TALENT: {
-    id: 381627,
-    name: 'Internal Bleeding',
-    icon: 'ability_rogue_bloodsplatter',
-    maxRanks: 2,
-  },
-  POISONED_KATAR_ASSASSINATION_TALENT: {
-    id: 381629,
-    name: 'Poisoned Katar',
-    icon: 'ability_hunter_cobrashot',
-    maxRanks: 1,
-  },
-  IMPROVED_SHIV_ASSASSINATION_TALENT: {
-    id: 319032,
-    name: 'Improved Shiv',
-    icon: 'inv_throwingknife_04',
-    maxRanks: 1,
-  },
-  ATROPHIC_POISON_NYI_ASSASSINATION_TALENT: {
-    id: 381637,
-    name: 'Atrophic Poison [NYI]',
-    icon: 'ability_rogue_nervesofsteel',
-    maxRanks: 1,
-  },
-  IMPROVED_GARROTE_ASSASSINATION_TALENT: {
-    id: 381632,
-    name: 'Improved Garrote',
-    icon: 'ability_rogue_garrote',
-    maxRanks: 1,
-  },
-  INTENT_TO_KILL_ASSASSINATION_TALENT: {
-    id: 381630,
-    name: 'Intent to Kill',
-    icon: 'ability_rogue_bloodyeye',
-    maxRanks: 1,
-  },
-  CRIMSON_TEMPEST_ASSASSINATION_TALENT: {
-    id: 121411,
-    name: 'Crimson Tempest',
-    icon: 'inv_knife_1h_cataclysm_c_05',
-    maxRanks: 1,
-    energyCost: 35,
-  },
-  VENOM_RUSH_ASSASSINATION_TALENT: {
-    id: 152152,
-    name: 'Venom Rush',
-    icon: 'rogue_venomzest',
-    maxRanks: 1,
-  },
-  DEATHMARK_ASSASSINATION_TALENT: {
-    id: 360194,
-    name: 'Deathmark',
-    icon: 'ability_rogue_deathmark',
-    maxRanks: 1,
-  },
-  MASTER_ASSASSIN_ASSASSINATION_TALENT: {
-    id: 255989,
-    name: 'Master Assassin',
-    icon: 'ability_criticalstrike',
-    maxRanks: 1,
-  },
-  EXSANGUINATE_ASSASSINATION_TALENT: {
-    id: 200806,
-    name: 'Exsanguinate',
-    icon: 'ability_deathwing_bloodcorruption_earth',
-    maxRanks: 1,
-    energyCost: 25,
-  },
-  FLYING_DAGGERS_ASSASSINATION_TALENT: {
-    id: 381631,
-    name: 'Flying Daggers',
-    icon: 'ability_rogue_fanofknives',
-    maxRanks: 1,
-  },
-  VICIOUS_VENOMS_ASSASSINATION_TALENT: {
-    id: 381634,
-    name: 'Vicious Venoms',
-    icon: 'ability_rogue_deadlybrew',
-    maxRanks: 2,
-  },
-  LETHAL_DOSE_NYI_ASSASSINATION_TALENT: {
-    id: 381640,
-    name: 'Lethal Dose [NYI]',
-    icon: 'ability_rogue_deviouspoisons',
-    maxRanks: 2,
-  },
-  IRON_WIRE_ASSASSINATION_TALENT: {
-    id: 196861,
-    name: 'Iron Wire',
-    icon: 'inv_jewelcrafting_delicatecopperwire',
-    maxRanks: 1,
-  },
-  MAIM_MANGLE_ASSASSINATION_TALENT: {
-    id: 381652,
-    name: 'Maim, Mangle',
-    icon: 'ability_skeer_bloodletting',
-    maxRanks: 1,
-  },
-  AMPLIFYING_POISON_ASSASSINATION_TALENT: {
-    id: 381664,
-    name: 'Amplifying Poison',
-    icon: 'inv_misc_herb_fellotus',
-    maxRanks: 1,
-  },
-  TWIST_THE_KNIFE_ASSASSINATION_TALENT: {
-    id: 381669,
-    name: 'Twist the Knife',
-    icon: 'ability_rogue_bladetwisting',
-    maxRanks: 1,
-  },
-  DOOMBLADE_ASSASSINATION_TALENT: {
-    id: 381673,
-    name: 'Doomblade',
-    icon: 'ability_deathwing_bloodcorruption_earth',
-    maxRanks: 1,
-  },
-  BLINDSIDE_ASSASSINATION_TALENT: {
-    id: 328085,
-    name: 'Blindside',
-    icon: 'ability_rogue_focusedattacks',
-    maxRanks: 1,
-  },
-  TINY_TOXIC_BLADE_ASSASSINATION_TALENT: {
-    id: 381800,
-    name: 'Tiny Toxic Blade',
-    icon: 'ability_rogue_poisonedknife',
-    maxRanks: 1,
-  },
-  POISON_BOMB_ASSASSINATION_TALENT: {
-    id: 255544,
-    name: 'Poison Bomb',
-    icon: 'rogue_paralytic_poison',
-    maxRanks: 2,
-  },
-  SHROUDED_SUFFOCATION_ASSASSINATION_TALENT: {
-    id: 385478,
-    name: 'Shrouded Suffocation',
-    icon: 'ability_rogue_garrote',
-    maxRanks: 1,
-  },
-  SEPSIS_ASSASSINATION_TALENT: {
-    id: 385408,
-    name: 'Sepsis',
-    icon: 'ability_ardenweald_rogue',
-    maxRanks: 1,
-    energyCost: 25,
-  },
-  SERRATED_BONE_SPIKE_ASSASSINATION_TALENT: {
-    id: 385424,
-    name: 'Serrated Bone Spike',
-    icon: 'ability_maldraxxus_rogue',
-    maxRanks: 1,
-    energyCost: 15,
-  },
-  ZOLDYCK_RECIPE_ASSASSINATION_TALENT: {
-    id: 381798,
-    name: 'Zoldyck Recipe',
-    icon: 'archaeology_5_0_thunderkinginsignia',
-    maxRanks: 3,
-  },
-  DASHING_SCOUNDREL_ASSASSINATION_TALENT: {
-    id: 381797,
-    name: 'Dashing Scoundrel',
-    icon: 'ability_rogue_venomouswounds',
-    maxRanks: 3,
-  },
-  SCENT_OF_BLOOD_ASSASSINATION_TALENT: {
-    id: 381799,
-    name: 'Scent of Blood',
-    icon: 'ability_rogue_rupture',
-    maxRanks: 3,
-  },
-  KINGSBANE_ASSASSINATION_TALENT: {
-    id: 385627,
-    name: 'Kingsbane',
-    icon: 'inv_knife_1h_artifactgarona_d_01',
-    maxRanks: 1,
-    energyCost: 35,
-  },
-  DRAGON_TEMPERED_BLADES_ASSASSINATION_TALENT: {
-    id: 381801,
-    name: 'Dragon-Tempered Blades',
-    icon: 'spell_fire_flameblades',
-    maxRanks: 1,
-  },
-  INDISCRIMINATE_CARNAGE_ASSASSINATION_TALENT: {
-    id: 381802,
-    name: 'Indiscriminate Carnage',
-    icon: 'ability_rogue_indiscriminatecarnage',
-    maxRanks: 1,
-  },
+  DEADLY_POISON_ASSASSINATION_TALENT,
+  SHIV_ASSASSINATION_TALENT,
+  VENOMOUS_WOUNDS_ASSASSINATION_TALENT,
+  SHADOWSTEP_ASSASSINATION_TALENT,
+  CUT_TO_THE_CHASE_ASSASSINATION_TALENT,
+  ELABORATE_PLANNING_ASSASSINATION_TALENT,
+  IMPROVED_POISONS_ASSASSINATION_TALENT,
+  BLOODY_MESS_ASSASSINATION_TALENT,
+  INTERNAL_BLEEDING_ASSASSINATION_TALENT,
+  POISONED_KATAR_ASSASSINATION_TALENT,
+  IMPROVED_SHIV_ASSASSINATION_TALENT,
+  ATROPHIC_POISON_NYI_ASSASSINATION_TALENT,
+  IMPROVED_GARROTE_ASSASSINATION_TALENT,
+  INTENT_TO_KILL_ASSASSINATION_TALENT,
+  CRIMSON_TEMPEST_ASSASSINATION_TALENT,
+  VENOM_RUSH_ASSASSINATION_TALENT,
+  DEATHMARK_ASSASSINATION_TALENT,
+  MASTER_ASSASSIN_ASSASSINATION_TALENT,
+  EXSANGUINATE_ASSASSINATION_TALENT,
+  FLYING_DAGGERS_ASSASSINATION_TALENT,
+  VICIOUS_VENOMS_ASSASSINATION_TALENT,
+  LETHAL_DOSE_NYI_ASSASSINATION_TALENT,
+  IRON_WIRE_ASSASSINATION_TALENT,
+  MAIM_MANGLE_ASSASSINATION_TALENT,
+  AMPLIFYING_POISON_ASSASSINATION_TALENT,
+  TWIST_THE_KNIFE_ASSASSINATION_TALENT,
+  DOOMBLADE_ASSASSINATION_TALENT,
+  BLINDSIDE_ASSASSINATION_TALENT,
+  TINY_TOXIC_BLADE_ASSASSINATION_TALENT,
+  POISON_BOMB_ASSASSINATION_TALENT,
+  SHROUDED_SUFFOCATION_ASSASSINATION_TALENT,
+  SEPSIS_ASSASSINATION_TALENT,
+  SERRATED_BONE_SPIKE_ASSASSINATION_TALENT,
+  ZOLDYCK_RECIPE_ASSASSINATION_TALENT,
+  DASHING_SCOUNDREL_ASSASSINATION_TALENT,
+  SCENT_OF_BLOOD_ASSASSINATION_TALENT,
+  KINGSBANE_ASSASSINATION_TALENT,
+  DRAGON_TEMPERED_BLADES_ASSASSINATION_TALENT,
+  INDISCRIMINATE_CARNAGE_ASSASSINATION_TALENT,
 
   //Outlaw
-  OPPORTUNITY_OUTLAW_TALENT: {
-    id: 279876,
-    name: 'Opportunity',
-    icon: 'spell_shadow_ritualofsacrifice',
-    maxRanks: 1,
-  },
-  BLADE_FLURRY_OUTLAW_TALENT: {
-    id: 13877,
-    name: 'Blade Flurry',
-    icon: 'ability_warrior_punishingblow',
-    maxRanks: 1,
-    energyCost: 15,
-  },
-  GRAPPLING_HOOK_OUTLAW_TALENT: {
-    id: 195457,
-    name: 'Grappling Hook',
-    icon: 'ability_rogue_grapplinghook',
-    maxRanks: 1,
-  },
-  WEAPONMASTER_OUTLAW_TALENT: {
-    id: 200733,
-    name: 'Weaponmaster',
-    icon: 'ability_ironmaidens_bladerush',
-    maxRanks: 1,
-  },
-  COMBAT_POTENCY_OUTLAW_TALENT: {
-    id: 61329,
-    name: 'Combat Potency',
-    icon: 'inv_weapon_shortblade_38',
-    maxRanks: 1,
-  },
-  AMBIDEXTERITY_OUTLAW_TALENT: {
-    id: 381822,
-    name: 'Ambidexterity',
-    icon: 'inv_glove_cloth_oribosdungeon_c_01',
-    maxRanks: 1,
-  },
-  BETWEEN_THE_EYES_OUTLAW_TALENT: {
-    id: 315341,
-    name: 'Between the Eyes',
-    icon: 'inv_weapon_rifle_01',
-    maxRanks: 1,
-    energyCost: 25,
-  },
-  RETRACTABLE_HOOK_OUTLAW_TALENT: {
-    id: 256188,
-    name: 'Retractable Hook',
-    icon: 'ability_rogue_grapplinghook',
-    maxRanks: 1,
-  },
-  COMBAT_STAMINA_OUTLAW_TALENT: {
-    id: 381877,
-    name: 'Combat Stamina',
-    icon: 'ability_rogue_imrovedrecuperate',
-    maxRanks: 1,
-  },
-  ADRENALINE_RUSH_OUTLAW_TALENT: {
-    id: 13750,
-    name: 'Adrenaline Rush',
-    icon: 'spell_shadow_shadowworddominate',
-    maxRanks: 1,
-  },
-  RIPOSTE_OUTLAW_TALENT: {
-    id: 344363,
-    name: 'Riposte',
-    icon: 'ability_warrior_challange',
-    maxRanks: 1,
-  },
-  HIT_AND_RUN_OUTLAW_TALENT: {
-    id: 196922,
-    name: 'Hit and Run',
-    icon: 'ability_rogue_fleetfooted',
-    maxRanks: 1,
-  },
-  BLINDING_POWDER_OUTLAW_TALENT: {
-    id: 256165,
-    name: 'Blinding Powder',
-    icon: 'inv_misc_ammo_gunpowder_06',
-    maxRanks: 1,
-  },
-  RUTHLESSNESS_OUTLAW_TALENT: {
-    id: 14161,
-    name: 'Ruthlessness',
-    icon: 'ability_druid_disembowel',
-    maxRanks: 1,
-  },
-  SLICERDICER_OUTLAW_TALENT: {
-    id: 381988,
-    name: 'Slicerdicer',
-    icon: 'ability_rogue_slicedice',
-    maxRanks: 1,
-  },
-  RESTLESS_BLADES_OUTLAW_TALENT: {
-    id: 79096,
-    name: 'Restless Blades',
-    icon: 'ability_rogue_restlessblades',
-    maxRanks: 1,
-  },
-  FATAL_FLOURISH_OUTLAW_TALENT: {
-    id: 35551,
-    name: 'Fatal Flourish',
-    icon: 'ability_rogue_unfairadvantage',
-    maxRanks: 1,
-  },
-  ACE_UP_YOUR_SLEEVE_OUTLAW_TALENT: {
-    id: 381828,
-    name: 'Ace Up Your Sleeve',
-    icon: 'inv_weapon_rifle_01',
-    maxRanks: 1,
-  },
-  DIRTY_TRICKS_OUTLAW_TALENT: {
-    id: 108216,
-    name: 'Dirty Tricks',
-    icon: 'ability_rogue_dirtydeeds',
-    maxRanks: 1,
-  },
-  HEAVY_HITTER_NYI_OUTLAW_TALENT: {
-    id: 381885,
-    name: 'Heavy Hitter [NYI]',
-    icon: 'ability_rogue_ambush',
-    maxRanks: 1,
-  },
-  DEEPER_STRATAGEM_OUTLAW_TALENT: {
-    id: 193531,
-    name: 'Deeper Stratagem',
-    icon: 'archaeology_5_0_changkiboard',
-    maxRanks: 1,
-  },
-  ROLL_THE_BONES_OUTLAW_TALENT: {
-    id: 315508,
-    name: 'Roll the Bones',
-    icon: 'ability_rogue_rollthebones',
-    maxRanks: 1,
-    energyCost: 25,
-  },
-  QUICK_DRAW_OUTLAW_TALENT: {
-    id: 196938,
-    name: 'Quick Draw',
-    icon: 'inv_weapon_rifle_40',
-    maxRanks: 1,
-  },
-  LONG_ARM_OF_THE_OUTLAW_OUTLAW_TALENT: {
-    id: 381878,
-    name: 'Long Arm of the Outlaw',
-    icon: 'spell_warrior_wildstrike',
-    maxRanks: 1,
-  },
-  AUDACITY_OUTLAW_TALENT: {
-    id: 381845,
-    name: 'Audacity',
-    icon: 'ability_rogue_ambush',
-    maxRanks: 1,
-  },
-  LOADED_DICE_OUTLAW_TALENT: {
-    id: 256170,
-    name: 'Loaded Dice',
-    icon: 'ability_rogue_rollthebones',
-    maxRanks: 1,
-  },
-  FLOAT_LIKE_A_BUTTERFLY_OUTLAW_TALENT: {
-    id: 354897,
-    name: 'Float Like a Butterfly',
-    icon: 'inv_pet_butterfly_orange',
-    maxRanks: 1,
-  },
-  SLEIGHT_OF_HAND_OUTLAW_TALENT: {
-    id: 381839,
-    name: 'Sleight of Hand',
-    icon: 'inv_misc_dice_02',
-    maxRanks: 1,
-  },
-  DANCING_STEEL_OUTLAW_TALENT: {
-    id: 272026,
-    name: 'Dancing Steel',
-    icon: 'ability_warrior_punishingblow',
-    maxRanks: 1,
-  },
-  TRIPLE_THREAT_OUTLAW_TALENT: {
-    id: 381894,
-    name: 'Triple Threat',
-    icon: 'ability_dualwield',
-    maxRanks: 2,
-  },
-  COUNT_THE_ODDS_OUTLAW_TALENT: {
-    id: 381982,
-    name: 'Count the Odds',
-    icon: 'inv_misc_dice_01',
-    maxRanks: 2,
-  },
-  IMPROVED_MAIN_GAUCHE_OUTLAW_TALENT: {
-    id: 382746,
-    name: 'Improved Main Gauche',
-    icon: 'inv_weapon_shortblade_15',
-    maxRanks: 2,
-  },
-  SEPSIS_OUTLAW_TALENT: {
-    id: 385408,
-    name: 'Sepsis',
-    icon: 'ability_ardenweald_rogue',
-    maxRanks: 1,
-    energyCost: 25,
-  },
-  GHOSTLY_STRIKE_OUTLAW_TALENT: {
-    id: 196937,
-    name: 'Ghostly Strike',
-    icon: 'ability_creature_cursed_02',
-    maxRanks: 1,
-    energyCost: 30,
-  },
-  BLADE_RUSH_OUTLAW_TALENT: {
-    id: 271877,
-    name: 'Blade Rush',
-    icon: 'ability_arakkoa_spinning_blade',
-    maxRanks: 1,
-  },
-  RESTLESS_CREW_NYI_OUTLAW_TALENT: {
-    id: 382794,
-    name: 'Restless Crew [NYI]',
-    icon: 'ability_rogue_restlessblades',
-    maxRanks: 1,
-  },
-  KILLING_SPREE_OUTLAW_TALENT: {
-    id: 51690,
-    name: 'Killing Spree',
-    icon: 'ability_rogue_murderspree',
-    maxRanks: 1,
-  },
-  DREADBLADES_OUTLAW_TALENT: {
-    id: 343142,
-    name: 'Dreadblades',
-    icon: 'inv_sword_1h_artifactskywall_d_01dual',
-    maxRanks: 1,
-    energyCost: 30,
-  },
-  PRECISE_CUTS_NYI_OUTLAW_TALENT: {
-    id: 381985,
-    name: 'Precise Cuts [NYI]',
-    icon: 'ability_warrior_punishingblow',
-    maxRanks: 1,
-  },
-  TAKE_EM_BY_SURPRISE_OUTLAW_TALENT: {
-    id: 382742,
-    name: "Take 'em by Surprise",
-    icon: 'ability_stealth',
-    maxRanks: 2,
-  },
-  DISPATCHER_OUTLAW_TALENT: {
-    id: 381990,
-    name: 'Dispatcher',
-    icon: 'ability_rogue_waylay',
-    maxRanks: 2,
-  },
-  FAN_THE_HAMMER_OUTLAW_TALENT: {
-    id: 381846,
-    name: 'Fan the Hammer',
-    icon: 'ability_rogue_pistolshot',
-    maxRanks: 2,
-  },
-  HIDDEN_OPPORTUNITY_OUTLAW_TALENT: {
-    id: 383281,
-    name: 'Hidden Opportunity',
-    icon: 'ability_rogue_ambush',
-    maxRanks: 1,
-  },
-  KEEP_IT_ROLLING_OUTLAW_TALENT: {
-    id: 381989,
-    name: 'Keep It Rolling',
-    icon: 'ability_rogue_keepitrolling',
-    maxRanks: 1,
-  },
-  GREENSKINS_WICKERS_OUTLAW_TALENT: {
-    id: 386823,
-    name: "Greenskin's Wickers",
-    icon: 'ability_creature_cursed_04',
-    maxRanks: 1,
-  },
+  OPPORTUNITY_OUTLAW_TALENT,
+  BLADE_FLURRY_OUTLAW_TALENT,
+  GRAPPLING_HOOK_OUTLAW_TALENT,
+  WEAPONMASTER_OUTLAW_TALENT,
+  COMBAT_POTENCY_OUTLAW_TALENT,
+  AMBIDEXTERITY_OUTLAW_TALENT,
+  BETWEEN_THE_EYES_OUTLAW_TALENT,
+  RETRACTABLE_HOOK_OUTLAW_TALENT,
+  COMBAT_STAMINA_OUTLAW_TALENT,
+  ADRENALINE_RUSH_OUTLAW_TALENT,
+  RIPOSTE_OUTLAW_TALENT,
+  HIT_AND_RUN_OUTLAW_TALENT,
+  BLINDING_POWDER_OUTLAW_TALENT,
+  RUTHLESSNESS_OUTLAW_TALENT,
+  SLICERDICER_OUTLAW_TALENT,
+  RESTLESS_BLADES_OUTLAW_TALENT,
+  FATAL_FLOURISH_OUTLAW_TALENT,
+  ACE_UP_YOUR_SLEEVE_OUTLAW_TALENT,
+  DIRTY_TRICKS_OUTLAW_TALENT,
+  HEAVY_HITTER_NYI_OUTLAW_TALENT,
+  DEEPER_STRATAGEM_OUTLAW_TALENT,
+  ROLL_THE_BONES_OUTLAW_TALENT,
+  QUICK_DRAW_OUTLAW_TALENT,
+  LONG_ARM_OF_THE_OUTLAW_OUTLAW_TALENT,
+  AUDACITY_OUTLAW_TALENT,
+  LOADED_DICE_OUTLAW_TALENT,
+  FLOAT_LIKE_A_BUTTERFLY_OUTLAW_TALENT,
+  SLEIGHT_OF_HAND_OUTLAW_TALENT,
+  DANCING_STEEL_OUTLAW_TALENT,
+  TRIPLE_THREAT_OUTLAW_TALENT,
+  COUNT_THE_ODDS_OUTLAW_TALENT,
+  IMPROVED_MAIN_GAUCHE_OUTLAW_TALENT,
+  SEPSIS_OUTLAW_TALENT,
+  GHOSTLY_STRIKE_OUTLAW_TALENT,
+  BLADE_RUSH_OUTLAW_TALENT,
+  RESTLESS_CREW_NYI_OUTLAW_TALENT,
+  KILLING_SPREE_OUTLAW_TALENT,
+  DREADBLADES_OUTLAW_TALENT,
+  PRECISE_CUTS_NYI_OUTLAW_TALENT,
+  TAKE_EM_BY_SURPRISE_OUTLAW_TALENT,
+  DISPATCHER_OUTLAW_TALENT,
+  FAN_THE_HAMMER_OUTLAW_TALENT,
+  HIDDEN_OPPORTUNITY_OUTLAW_TALENT,
+  KEEP_IT_ROLLING_OUTLAW_TALENT,
+  GREENSKINS_WICKERS_OUTLAW_TALENT,
 
   //Subtlety
-  IMPROVED_BACKSTAB_SUBTLETY_TALENT: {
-    id: 319949,
-    name: 'Improved Backstab',
-    icon: 'ability_backstab',
-    maxRanks: 1,
-  },
-  SHADOWSTEP_SUBTLETY_TALENT: {
-    id: 36554,
-    name: 'Shadowstep',
-    icon: 'ability_rogue_shadowstep',
-    maxRanks: 1,
-  },
-  IMPROVED_SHURIKEN_STORM_SUBTLETY_TALENT: {
-    id: 319951,
-    name: 'Improved Shuriken Storm',
-    icon: 'ability_rogue_shuriken_storm',
-    maxRanks: 1,
-  },
-  WEAPONMASTER_SUBTLETY_TALENT: {
-    id: 193537,
-    name: 'Weaponmaster',
-    icon: 'ability_ironmaidens_bladerush',
-    maxRanks: 1,
-  },
-  SHADOW_FOCUS_SUBTLETY_TALENT: {
-    id: 108209,
-    name: 'Shadow Focus',
-    icon: 'rogue_shadowfocus',
-    maxRanks: 1,
-  },
-  QUICK_DECISIONS_SUBTLETY_TALENT: {
-    id: 382503,
-    name: 'Quick Decisions',
-    icon: 'inv_misc_hook_01',
-    maxRanks: 1,
-  },
-  RELENTLESS_STRIKES_SUBTLETY_TALENT: {
-    id: 58423,
-    name: 'Relentless Strikes',
-    icon: 'ability_warrior_decisivestrike',
-    maxRanks: 1,
-  },
-  BLACK_POWDER_SUBTLETY_TALENT: {
-    id: 319175,
-    name: 'Black Powder',
-    icon: 'spell_priest_divinestar_shadow',
-    maxRanks: 1,
-    energyCost: 35,
-  },
-  SHOT_IN_THE_DARK_SUBTLETY_TALENT: {
-    id: 257505,
-    name: 'Shot in the Dark',
-    icon: 'ability_cheapshot',
-    maxRanks: 1,
-  },
-  PREMEDITATION_SUBTLETY_TALENT: {
-    id: 343160,
-    name: 'Premeditation',
-    icon: 'spell_shadow_possession',
-    maxRanks: 1,
-  },
-  SHADOW_DANCE_SUBTLETY_TALENT: {
-    id: 185313,
-    name: 'Shadow Dance',
-    icon: 'ability_rogue_shadowdance',
-    maxRanks: 1,
-  },
-  SILENT_STORM_SUBTLETY_TALENT: {
-    id: 385722,
-    name: 'Silent Storm',
-    icon: 'ability_rogue_shuriken_storm',
-    maxRanks: 1,
-  },
-  NIGHT_TERRORS_SUBTLETY_TALENT: {
-    id: 277953,
-    name: 'Night Terrors',
-    icon: 'spell_shadow_shadesofdarkness',
-    maxRanks: 1,
-  },
-  GLOOMBLADE_SUBTLETY_TALENT: {
-    id: 200758,
-    name: 'Gloomblade',
-    icon: 'ability_ironmaidens_convulsiveshadows',
-    maxRanks: 1,
-    energyCost: 35,
-  },
-  SHADOW_TECHNIQUES_SUBTLETY_TALENT: {
-    id: 196912,
-    name: 'Shadow Techniques',
-    icon: 'ability_rogue_masterofsubtlety',
-    maxRanks: 1,
-  },
-  SHADOW_BLADES_SUBTLETY_TALENT: {
-    id: 121471,
-    name: 'Shadow Blades',
-    icon: 'inv_knife_1h_grimbatolraid_d_03',
-    maxRanks: 1,
-  },
-  VEILTOUCHED_SUBTLETY_TALENT: {
-    id: 382017,
-    name: 'Veiltouched',
-    icon: 'spell_nature_slowpoison',
-    maxRanks: 1,
-  },
-  SECRET_TECHNIQUE_SUBTLETY_TALENT: {
-    id: 280719,
-    name: 'Secret Technique',
-    icon: 'ability_rogue_sinistercalling',
-    maxRanks: 1,
-    energyCost: 30,
-  },
-  SYMBOLS_OF_DEATH_SUBTLETY_TALENT: {
-    id: 212283,
-    name: 'Symbols of Death',
-    icon: 'spell_shadow_rune',
-    maxRanks: 1,
-  },
-  MASTER_OF_SHADOWS_SUBTLETY_TALENT: {
-    id: 196976,
-    name: 'Master of Shadows',
-    icon: 'spell_shadow_charm',
-    maxRanks: 1,
-  },
-  DEEPENING_SHADOWS_SUBTLETY_TALENT: {
-    id: 185314,
-    name: 'Deepening Shadows',
-    icon: 'spell_shadow_twilight',
-    maxRanks: 1,
-  },
-  THE_FIRST_DANCE_SUBTLETY_TALENT: {
-    id: 382505,
-    name: 'The First Dance',
-    icon: 'ability_rogue_shadowdance',
-    maxRanks: 1,
-  },
-  REPLICATING_SHADOWS_NYI_SUBTLETY_TALENT: {
-    id: 382506,
-    name: 'Replicating Shadows [NYI]',
-    icon: 'spell_deathknight_strangulate',
-    maxRanks: 1,
-  },
-  SHROUDED_IN_DARKNESS_SUBTLETY_TALENT: {
-    id: 382507,
-    name: 'Shrouded in Darkness',
-    icon: 'ability_rogue_envelopingshadows',
-    maxRanks: 1,
-  },
-  PLANNED_EXECUTION_SUBTLETY_TALENT: {
-    id: 382508,
-    name: 'Planned Execution',
-    icon: 'ability_creature_cursed_02',
-    maxRanks: 2,
-  },
-  STILETTO_STACCATO_SUBTLETY_TALENT: {
-    id: 382509,
-    name: 'Stiletto Staccato',
-    icon: 'ability_rogue_shadowyduel',
-    maxRanks: 2,
-  },
-  SHADOWED_FINISHERS_SUBTLETY_TALENT: {
-    id: 382511,
-    name: 'Shadowed Finishers',
-    icon: 'ability_rogue_eviscerate',
-    maxRanks: 2,
-  },
-  SHURIKEN_TORNADO_SUBTLETY_TALENT: {
-    id: 277925,
-    name: 'Shuriken Tornado',
-    icon: 'ability_rogue_throwingspecialization',
-    maxRanks: 1,
-    energyCost: 60,
-  },
-  INEVITABILITY_SUBTLETY_TALENT: {
-    id: 278683,
-    name: 'Inevitability',
-    icon: 'spell_shadow_rune',
-    maxRanks: 1,
-  },
-  WITHOUT_A_TRACE_SUBTLETY_TALENT: {
-    id: 382513,
-    name: 'Without a Trace',
-    icon: 'ability_vanish',
-    maxRanks: 1,
-  },
-  FADE_TO_NOTHING_SUBTLETY_TALENT: {
-    id: 382514,
-    name: 'Fade to Nothing',
-    icon: 'ability_warlock_everlastingaffliction',
-    maxRanks: 1,
-  },
-  CLOAKED_IN_SHADOWS_SUBTLETY_TALENT: {
-    id: 382515,
-    name: 'Cloaked in Shadows',
-    icon: 'inv_helm_cloth_shadowmoonclan_b_01',
-    maxRanks: 1,
-  },
-  DEEPER_DAGGERS_SUBTLETY_TALENT: {
-    id: 382517,
-    name: 'Deeper Daggers',
-    icon: 'inv_weapon_shortblade_15',
-    maxRanks: 1,
-  },
-  SEPSIS_SUBTLETY_TALENT: {
-    id: 385408,
-    name: 'Sepsis',
-    icon: 'ability_ardenweald_rogue',
-    maxRanks: 1,
-    energyCost: 25,
-  },
-  PERFORATED_VEINS_SUBTLETY_TALENT: {
-    id: 382518,
-    name: 'Perforated Veins',
-    icon: 'ability_warrior_bloodfrenzy',
-    maxRanks: 1,
-  },
-  DARK_SHADOW_SUBTLETY_TALENT: {
-    id: 245687,
-    name: 'Dark Shadow',
-    icon: 'spell_warlock_demonsoul',
-    maxRanks: 1,
-  },
-  DEEPER_STRATAGEM_SUBTLETY_TALENT: {
-    id: 193531,
-    name: 'Deeper Stratagem',
-    icon: 'archaeology_5_0_changkiboard',
-    maxRanks: 1,
-  },
-  FLAGELLATION_SUBTLETY_TALENT: {
-    id: 384631,
-    name: 'Flagellation',
-    icon: 'ability_revendreth_rogue',
-    maxRanks: 1,
-  },
-  INVIGORATING_SHADOWDUST_SUBTLETY_TALENT: {
-    id: 382523,
-    name: 'Invigorating Shadowdust',
-    icon: 'ability_vanish',
-    maxRanks: 2,
-  },
-  LINGERING_SHADOW_SUBTLETY_TALENT: {
-    id: 382524,
-    name: 'Lingering Shadow',
-    icon: 'spell_fire_twilightnova',
-    maxRanks: 2,
-  },
-  FINALITY_SUBTLETY_TALENT: {
-    id: 382525,
-    name: 'Finality',
-    icon: 'ability_rogue_eviscerate',
-    maxRanks: 2,
-  },
-  THE_ROTTEN_SUBTLETY_TALENT: {
-    id: 382015,
-    name: 'The Rotten',
-    icon: 'spell_shadow_nightofthedead',
-    maxRanks: 1,
-  },
-  SHADOW_MIST_NYI_SUBTLETY_TALENT: {
-    id: 382528,
-    name: 'Shadow Mist [NYI]',
-    icon: 'ability_druid_typhoon',
-    maxRanks: 1,
-  },
-  DARK_BREW_SUBTLETY_TALENT: {
-    id: 382504,
-    name: 'Dark Brew',
-    icon: 'spell_nature_slowpoison',
-    maxRanks: 1,
-  },
+  IMPROVED_BACKSTAB_SUBTLETY_TALENT,
+  SHADOWSTEP_SUBTLETY_TALENT,
+  IMPROVED_SHURIKEN_STORM_SUBTLETY_TALENT,
+  WEAPONMASTER_SUBTLETY_TALENT,
+  SHADOW_FOCUS_SUBTLETY_TALENT,
+  QUICK_DECISIONS_SUBTLETY_TALENT,
+  RELENTLESS_STRIKES_SUBTLETY_TALENT,
+  BLACK_POWDER_SUBTLETY_TALENT,
+  SHOT_IN_THE_DARK_SUBTLETY_TALENT,
+  PREMEDITATION_SUBTLETY_TALENT,
+  SHADOW_DANCE_SUBTLETY_TALENT,
+  SILENT_STORM_SUBTLETY_TALENT,
+  NIGHT_TERRORS_SUBTLETY_TALENT,
+  GLOOMBLADE_SUBTLETY_TALENT,
+  SHADOW_TECHNIQUES_SUBTLETY_TALENT,
+  SHADOW_BLADES_SUBTLETY_TALENT,
+  VEILTOUCHED_SUBTLETY_TALENT,
+  SECRET_TECHNIQUE_SUBTLETY_TALENT,
+  SYMBOLS_OF_DEATH_SUBTLETY_TALENT,
+  MASTER_OF_SHADOWS_SUBTLETY_TALENT,
+  DEEPENING_SHADOWS_SUBTLETY_TALENT,
+  THE_FIRST_DANCE_SUBTLETY_TALENT,
+  REPLICATING_SHADOWS_NYI_SUBTLETY_TALENT,
+  SHROUDED_IN_DARKNESS_SUBTLETY_TALENT,
+  PLANNED_EXECUTION_SUBTLETY_TALENT,
+  STILETTO_STACCATO_SUBTLETY_TALENT,
+  SHADOWED_FINISHERS_SUBTLETY_TALENT,
+  SHURIKEN_TORNADO_SUBTLETY_TALENT,
+  INEVITABILITY_SUBTLETY_TALENT,
+  WITHOUT_A_TRACE_SUBTLETY_TALENT,
+  FADE_TO_NOTHING_SUBTLETY_TALENT,
+  CLOAKED_IN_SHADOWS_SUBTLETY_TALENT,
+  DEEPER_DAGGERS_SUBTLETY_TALENT,
+  SEPSIS_SUBTLETY_TALENT,
+  PERFORATED_VEINS_SUBTLETY_TALENT,
+  DARK_SHADOW_SUBTLETY_TALENT,
+  DEEPER_STRATAGEM_SUBTLETY_TALENT,
+  FLAGELLATION_SUBTLETY_TALENT,
+  INVIGORATING_SHADOWDUST_SUBTLETY_TALENT,
+  LINGERING_SHADOW_SUBTLETY_TALENT,
+  FINALITY_SUBTLETY_TALENT,
+  THE_ROTTEN_SUBTLETY_TALENT,
+  SHADOW_MIST_NYI_SUBTLETY_TALENT,
+  DARK_BREW_SUBTLETY_TALENT,
 });
 
 export default talents;

--- a/src/common/TALENTS/shaman.ts
+++ b/src/common/TALENTS/shaman.ts
@@ -1,1247 +1,1492 @@
 // Generated file, changes will eventually be overwritten!
-import { createTalentList } from './types';
+import { createTalentList, Talent } from './types';
+
+//region Shared
+export const CHAIN_HEAL_TALENT: Talent = {
+  id: 1064,
+  name: 'Chain Heal',
+  icon: 'spell_nature_healingwavegreater',
+  maxRanks: 1,
+  manaCost: 3000,
+};
+export const LAVA_BURST_TALENT: Talent = {
+  id: 51505,
+  name: 'Lava Burst',
+  icon: 'spell_shaman_lavaburst',
+  maxRanks: 1,
+  manaCost: 200,
+};
+export const ASTRAL_SHIFT_TALENT: Talent = {
+  id: 108271,
+  name: 'Astral Shift',
+  icon: 'ability_shaman_astralshift',
+  maxRanks: 1,
+};
+export const CHAIN_LIGHTNING_TALENT: Talent = {
+  id: 188443,
+  name: 'Chain Lightning',
+  icon: 'spell_nature_chainlightning',
+  maxRanks: 1,
+  manaCost: 100,
+};
+export const EARTH_ELEMENTAL_TALENT: Talent = {
+  id: 198103,
+  name: 'Earth Elemental',
+  icon: 'spell_nature_earthelemental_totem',
+  maxRanks: 1,
+};
+export const WIND_SHEAR_TALENT: Talent = {
+  id: 57994,
+  name: 'Wind Shear',
+  icon: 'spell_nature_cyclone',
+  maxRanks: 1,
+};
+export const PLANES_TRAVELER_TALENT: Talent = {
+  id: 381647,
+  name: 'Planes Traveler',
+  icon: 'spell_shaman_astralshift',
+  maxRanks: 1,
+};
+export const ASTRAL_BULWARK_TALENT: Talent = {
+  id: 377933,
+  name: 'Astral Bulwark',
+  icon: 'spell_shaman_ancestralawakening',
+  maxRanks: 1,
+};
+export const SPIRIT_WOLF_TALENT: Talent = {
+  id: 260878,
+  name: 'Spirit Wolf',
+  icon: 'spell_hunter_lonewolf',
+  maxRanks: 1,
+};
+export const THUNDEROUS_PAWS_TALENT: Talent = {
+  id: 378075,
+  name: 'Thunderous Paws',
+  icon: 'ability_hunter_longevity',
+  maxRanks: 1,
+};
+export const FROST_SHOCK_TALENT: Talent = {
+  id: 196840,
+  name: 'Frost Shock',
+  icon: 'spell_frost_frostshock',
+  maxRanks: 1,
+  manaCost: 100,
+};
+export const MAELSTROM_WEAPON_TALENT: Talent = {
+  id: 187880,
+  name: 'Maelstrom Weapon',
+  icon: 'spell_shaman_maelstromweapon',
+  maxRanks: 1,
+};
+export const EARTH_SHIELD_TALENT: Talent = {
+  id: 974,
+  name: 'Earth Shield',
+  icon: 'spell_nature_skinofearth',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const FIRE_AND_ICE_TALENT: Talent = {
+  id: 382886,
+  name: 'Fire and Ice',
+  icon: 'spell_firefrost_orb',
+  maxRanks: 1,
+};
+export const CAPACITOR_TOTEM_TALENT: Talent = {
+  id: 192058,
+  name: 'Capacitor Totem',
+  icon: 'spell_nature_brilliance',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const CLEANSE_SPIRIT_TALENT: Talent = {
+  id: 51886,
+  name: 'Cleanse Spirit',
+  icon: 'ability_shaman_cleansespirit',
+  maxRanks: 1,
+  manaCost: 600,
+};
+export const FOCUSED_INSIGHT_TALENT: Talent = {
+  id: 381666,
+  name: 'Focused Insight',
+  icon: 'spell_shaman_measuredinsight',
+  maxRanks: 2,
+};
+export const ELEMENTAL_ORBIT_TALENT: Talent = {
+  id: 383010,
+  name: 'Elemental Orbit',
+  icon: 'ability_mage_shattershield',
+  maxRanks: 1,
+};
+export const SPIRITWALKERS_GRACE_TALENT: Talent = {
+  id: 79206,
+  name: "Spiritwalker's Grace",
+  icon: 'spell_shaman_spiritwalkersgrace',
+  maxRanks: 1,
+  manaCost: 1400,
+};
+export const ANCESTRAL_DEFENSE_TALENT: Talent = {
+  id: 382947,
+  name: 'Ancestral Defense',
+  icon: 'ability_earthen_pillar',
+  maxRanks: 1,
+};
+export const TREMOR_TOTEM_TALENT: Talent = {
+  id: 8143,
+  name: 'Tremor Totem',
+  icon: 'spell_nature_tremortotem',
+  maxRanks: 1,
+  manaCost: 200,
+};
+export const STATIC_CHARGE_TALENT: Talent = {
+  id: 265046,
+  name: 'Static Charge',
+  icon: 'spell_nature_brilliance',
+  maxRanks: 1,
+};
+export const GUARDIANS_CUDGEL_TALENT: Talent = {
+  id: 381819,
+  name: "Guardian's Cudgel",
+  icon: 'inv_mace_2h_draenorcrafted_d_01_b_alliance',
+  maxRanks: 1,
+};
+export const PURGE_TALENT: Talent = {
+  id: 370,
+  name: 'Purge',
+  icon: 'spell_nature_purge',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const GREATER_PURGE_TALENT: Talent = {
+  id: 378773,
+  name: 'Greater Purge',
+  icon: 'spell_shaman_focusedstrikes',
+  maxRanks: 1,
+  manaCost: 2000,
+};
+export const FLURRY_TALENT: Talent = {
+  id: 382888,
+  name: 'Flurry',
+  icon: 'ability_ghoulfrenzy',
+  maxRanks: 1,
+};
+export const GRACEFUL_SPIRIT_TALENT: Talent = {
+  id: 192088,
+  name: 'Graceful Spirit',
+  icon: 'spell_shaman_spectraltransformation',
+  maxRanks: 1,
+};
+export const SPIRITWALKERS_AEGIS_TALENT: Talent = {
+  id: 378077,
+  name: "Spiritwalker's Aegis",
+  icon: 'ability_racial_forceshield',
+  maxRanks: 1,
+};
+export const WIND_RUSH_TOTEM_TALENT: Talent = {
+  id: 192077,
+  name: 'Wind Rush Totem',
+  icon: 'ability_shaman_windwalktotem',
+  maxRanks: 1,
+};
+export const EARTHGRAB_TOTEM_TALENT: Talent = {
+  id: 51485,
+  name: 'Earthgrab Totem',
+  icon: 'spell_nature_stranglevines',
+  maxRanks: 1,
+  manaCost: 200,
+};
+export const HEX_TALENT: Talent = { id: 51514, name: 'Hex', icon: 'spell_shaman_hex', maxRanks: 1 };
+export const NATURES_FURY_TALENT: Talent = {
+  id: 381655,
+  name: "Nature's Fury",
+  icon: 'spell_nature_spiritarmor',
+  maxRanks: 2,
+};
+export const TOTEMIC_SURGE_TALENT: Talent = {
+  id: 381867,
+  name: 'Totemic Surge',
+  icon: 'spell_nature_agitatingtotem',
+  maxRanks: 2,
+};
+export const ELEMENTAL_WARDING_TALENT: Talent = {
+  id: 381650,
+  name: 'Elemental Warding',
+  icon: 'inv_10_elementalcombinedfoozles_primordial',
+  maxRanks: 2,
+};
+export const NATURES_GUARDIAN_TALENT: Talent = {
+  id: 30884,
+  name: "Nature's Guardian",
+  icon: 'spell_nature_natureguardian',
+  maxRanks: 2,
+};
+export const VOODOO_MASTERY_TALENT: Talent = {
+  id: 204268,
+  name: 'Voodoo Mastery',
+  icon: 'spell_shaman_hex',
+  maxRanks: 1,
+};
+export const ENFEEBLEMENT_TALENT: Talent = {
+  id: 378079,
+  name: 'Enfeeblement',
+  icon: 'inv_frog2_teal',
+  maxRanks: 1,
+};
+export const WINDS_OF_ALAKIR_TALENT: Talent = {
+  id: 382215,
+  name: "Winds of Al'Akir",
+  icon: 'ability_druid_galewinds',
+  maxRanks: 2,
+};
+export const BRIMMING_WITH_LIFE_TALENT: Talent = {
+  id: 381689,
+  name: 'Brimming with Life',
+  icon: 'inv_jewelry_talisman_06',
+  maxRanks: 1,
+};
+export const HEALING_STREAM_TOTEM_TALENT: Talent = {
+  id: 5394,
+  name: 'Healing Stream Totem',
+  icon: 'inv_spear_04',
+  maxRanks: 1,
+  manaCost: 900,
+};
+export const IMPROVED_LIGHTNING_BOLT_TALENT: Talent = {
+  id: 381674,
+  name: 'Improved Lightning Bolt',
+  icon: 'spell_nature_lightning',
+  maxRanks: 2,
+};
+export const TOTEMIC_PROJECTION_TALENT: Talent = {
+  id: 108287,
+  name: 'Totemic Projection',
+  icon: 'ability_shaman_totemrelocation',
+  maxRanks: 1,
+};
+export const SPIRIT_WALK_TALENT: Talent = {
+  id: 58875,
+  name: 'Spirit Walk',
+  icon: 'ability_tracking',
+  maxRanks: 1,
+};
+export const GUST_OF_WIND_TALENT: Talent = {
+  id: 192063,
+  name: 'Gust of Wind',
+  icon: 'ability_skyreach_four_wind',
+  maxRanks: 1,
+};
+export const SWIRLING_CURRENTS_TALENT: Talent = {
+  id: 378094,
+  name: 'Swirling Currents',
+  icon: 'spell_holy_serendipity',
+  maxRanks: 2,
+};
+export const NATURES_SWIFTNESS_TALENT: Talent = {
+  id: 378081,
+  name: "Nature's Swiftness",
+  icon: 'spell_nature_ravenform',
+  maxRanks: 1,
+};
+export const THUNDERSTORM_TALENT: Talent = {
+  id: 51490,
+  name: 'Thunderstorm',
+  icon: 'spell_shaman_thunderstorm',
+  maxRanks: 1,
+};
+export const TOTEMIC_FOCUS_TALENT: Talent = {
+  id: 382201,
+  name: 'Totemic Focus',
+  icon: 'inv_relics_totemofrebirth',
+  maxRanks: 2,
+};
+export const SURGING_SHIELDS_TALENT: Talent = {
+  id: 382033,
+  name: 'Surging Shields',
+  icon: 'spell_nature_lightningshield',
+  maxRanks: 2,
+};
+export const GO_WITH_THE_FLOW_TALENT: Talent = {
+  id: 381678,
+  name: 'Go With The Flow',
+  icon: 'ability_racial_runningwild',
+  maxRanks: 2,
+};
+export const MANA_SPRING_TOTEM_TALENT: Talent = {
+  id: 381930,
+  name: 'Mana Spring Totem',
+  icon: 'spell_nature_manaregentotem',
+  maxRanks: 1,
+  manaCost: 100,
+};
+export const THUNDERSHOCK_TALENT: Talent = {
+  id: 378779,
+  name: 'Thundershock',
+  icon: 'ability_thunderking_thunderstruck',
+  maxRanks: 1,
+};
+export const LIGHTNING_LASSO_TALENT: Talent = {
+  id: 305483,
+  name: 'Lightning Lasso',
+  icon: 'shaman_pvp_lightninglasso',
+  maxRanks: 1,
+};
+export const POISON_CLEANSING_TOTEM_TALENT: Talent = {
+  id: 383013,
+  name: 'Poison Cleansing Totem',
+  icon: 'spell_nature_poisoncleansingtotem',
+  maxRanks: 1,
+  manaCost: 200,
+};
+export const CALL_OF_THE_ELEMENTS_TALENT: Talent = {
+  id: 108285,
+  name: 'Call of the Elements',
+  icon: 'ability_shaman_multitotemactivation',
+  maxRanks: 1,
+};
+export const ANCESTRAL_GUIDANCE_TALENT: Talent = {
+  id: 108281,
+  name: 'Ancestral Guidance',
+  icon: 'ability_shaman_ancestralguidance',
+  maxRanks: 1,
+};
+export const STONESKIN_TOTEM_TALENT: Talent = {
+  id: 383017,
+  name: 'Stoneskin Totem',
+  icon: 'ability_shaman_stoneskintotem',
+  maxRanks: 1,
+  manaCost: 100,
+};
+export const TRANQUIL_AIR_TOTEM_TALENT: Talent = {
+  id: 383019,
+  name: 'Tranquil Air Totem',
+  icon: 'ability_shaman_tranquilmindtotem',
+  maxRanks: 1,
+  manaCost: 100,
+};
+export const IMPROVED_CALL_OF_THE_ELEMENTS_TALENT: Talent = {
+  id: 383011,
+  name: 'Improved Call of the Elements',
+  icon: 'ability_shaman_multitotemactivation',
+  maxRanks: 1,
+};
+export const CREATION_CORE_TALENT: Talent = {
+  id: 383012,
+  name: 'Creation Core',
+  icon: 'inv_artifact_xp03',
+  maxRanks: 1,
+};
+export const IMPROVED_PURIFY_SPIRIT_TALENT: Talent = {
+  id: 383016,
+  name: 'Improved Purify Spirit',
+  icon: 'ability_shaman_cleansespirit',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Enhancement
+export const STORMSTRIKE_ENHANCEMENT_TALENT: Talent = {
+  id: 17364,
+  name: 'Stormstrike',
+  icon: 'ability_shaman_stormstrike',
+  maxRanks: 1,
+  manaCost: 200,
+};
+export const WINDFURY_WEAPON_ENHANCEMENT_TALENT: Talent = {
+  id: 33757,
+  name: 'Windfury Weapon',
+  icon: 'spell_shaman_unleashweapon_wind',
+  maxRanks: 1,
+};
+export const LAVA_LASH_ENHANCEMENT_TALENT: Talent = {
+  id: 334033,
+  name: 'Lava Lash',
+  icon: 'spell_shaman_improvelavalash',
+  maxRanks: 2,
+};
+export const FORCEFUL_WINDS_ENHANCEMENT_TALENT: Talent = {
+  id: 262647,
+  name: 'Forceful Winds',
+  icon: 'spell_shaman_unleashweapon_wind',
+  maxRanks: 1,
+};
+export const IMPROVED_MAELSTROM_WEAPON_ENHANCEMENT_TALENT: Talent = {
+  id: 383303,
+  name: 'Improved Maelstrom Weapon',
+  icon: 'spell_shaman_maelstromweapon',
+  maxRanks: 1,
+};
+export const UNRULY_WINDS_ENHANCEMENT_TALENT: Talent = {
+  id: 390288,
+  name: 'Unruly Winds',
+  icon: 'ability_skyreach_wind_wall',
+  maxRanks: 1,
+};
+export const RAGING_MAELSTROM_ENHANCEMENT_TALENT: Talent = {
+  id: 384143,
+  name: 'Raging Maelstrom',
+  icon: 'spell_shaman_stormearthfire',
+  maxRanks: 1,
+};
+export const FERAL_LUNGE_ENHANCEMENT_TALENT: Talent = {
+  id: 196884,
+  name: 'Feral Lunge',
+  icon: 'spell_beastmaster_wolf',
+  maxRanks: 1,
+};
+export const PRIMAL_LAVA_ACTUATORS_ENHANCEMENT_TALENT: Talent = {
+  id: 390370,
+  name: 'Primal Lava Actuators',
+  icon: 'spell_shaman_stormearthfire',
+  maxRanks: 1,
+};
+export const DOOM_WINDS_ENHANCEMENT_TALENT: Talent = {
+  id: 384352,
+  name: 'Doom Winds',
+  icon: 'ability_ironmaidens_swirlingvortex',
+  maxRanks: 1,
+};
+export const SUNDERING_ENHANCEMENT_TALENT: Talent = {
+  id: 197214,
+  name: 'Sundering',
+  icon: 'ability_rhyolith_lavapool',
+  maxRanks: 1,
+  manaCost: 600,
+};
+export const FOCUSED_MAELSTROM_ENHANCEMENT_TALENT: Talent = {
+  id: 384146,
+  name: 'Focused Maelstrom',
+  icon: 'spell_shaman_spectraltransformation',
+  maxRanks: 1,
+};
+export const OVERFLOWING_MAELSTROM_ENHANCEMENT_TALENT: Talent = {
+  id: 384149,
+  name: 'Overflowing Maelstrom',
+  icon: 'spell_shaman_maelstromweapon',
+  maxRanks: 1,
+};
+export const WINDFURY_TOTEM_ENHANCEMENT_TALENT: Talent = {
+  id: 8512,
+  name: 'Windfury Totem',
+  icon: 'spell_nature_windfury',
+  maxRanks: 1,
+  manaCost: 100,
+};
+export const HAILSTORM_ENHANCEMENT_TALENT: Talent = {
+  id: 334195,
+  name: 'Hailstorm',
+  icon: 'spell_frost_icestorm',
+  maxRanks: 1,
+};
+export const FIRE_NOVA_ENHANCEMENT_TALENT: Talent = {
+  id: 333974,
+  name: 'Fire Nova',
+  icon: 'spell_shaman_improvedfirenova',
+  maxRanks: 1,
+  manaCost: 100,
+};
+export const HOT_HAND_ENHANCEMENT_TALENT: Talent = {
+  id: 201900,
+  name: 'Hot Hand',
+  icon: 'spell_fire_playingwithfire',
+  maxRanks: 2,
+};
+export const STORMBRINGER_ENHANCEMENT_TALENT: Talent = {
+  id: 201845,
+  name: 'Stormbringer',
+  icon: 'spell_nature_stormreach',
+  maxRanks: 1,
+};
+export const REFRESHING_WATERS_ENHANCEMENT_TALENT: Talent = {
+  id: 337974,
+  name: 'Refreshing Waters',
+  icon: 'ability_shaman_fortifyingwaters',
+  maxRanks: 1,
+};
+export const ANCESTRAL_WOLF_AFFINITY_ENHANCEMENT_TALENT: Talent = {
+  id: 382197,
+  name: 'Ancestral Wolf Affinity',
+  icon: 'spell_beastmaster_wolf',
+  maxRanks: 1,
+};
+export const CRASH_LIGHTNING_ENHANCEMENT_TALENT: Talent = {
+  id: 187874,
+  name: 'Crash Lightning',
+  icon: 'spell_shaman_crashlightning',
+  maxRanks: 1,
+  manaCost: 100,
+};
+export const STORMFLURRY_ENHANCEMENT_TALENT: Talent = {
+  id: 344357,
+  name: 'Stormflurry',
+  icon: 'ability_shaman_stormstrike',
+  maxRanks: 1,
+};
+export const ICE_STRIKE_ENHANCEMENT_TALENT: Talent = {
+  id: 342240,
+  name: 'Ice Strike',
+  icon: 'spell_frost_frostbolt',
+  maxRanks: 1,
+  manaCost: 300,
+};
+export const ELEMENTAL_BLAST_ENHANCEMENT_TALENT: Talent = {
+  id: 117014,
+  name: 'Elemental Blast',
+  icon: 'shaman_talent_elementalblast',
+  maxRanks: 1,
+  manaCost: 200,
+};
+export const STORMBLAST_ENHANCEMENT_TALENT: Talent = {
+  id: 319930,
+  name: 'Stormblast',
+  icon: 'spell_nature_stormreach',
+  maxRanks: 1,
+};
+export const ELEMENTAL_WEAPONS_ENHANCEMENT_TALENT: Talent = {
+  id: 384355,
+  name: 'Elemental Weapons',
+  icon: 'spell_nature_elementalprecision_1',
+  maxRanks: 2,
+};
+export const GATHERING_STORMS_ENHANCEMENT_TALENT: Talent = {
+  id: 384363,
+  name: 'Gathering Storms',
+  icon: 'warrior_talent_icon_stormbolt',
+  maxRanks: 1,
+};
+export const CRASHING_STORMS_ENHANCEMENT_TALENT: Talent = {
+  id: 334308,
+  name: 'Crashing Storms',
+  icon: 'spell_nature_chainlightning',
+  maxRanks: 1,
+};
+export const SWIRLING_MAELSTROM_ENHANCEMENT_TALENT: Talent = {
+  id: 384359,
+  name: 'Swirling Maelstrom',
+  icon: 'spell_shadow_soulleech_2',
+  maxRanks: 1,
+};
+export const PRIMORDIAL_WAVE_ENHANCEMENT_TALENT: Talent = {
+  id: 375982,
+  name: 'Primordial Wave',
+  icon: 'ability_maldraxxus_shaman',
+  maxRanks: 1,
+  manaCost: 300,
+};
+export const FERAL_SPIRIT_ENHANCEMENT_TALENT: Talent = {
+  id: 51533,
+  name: 'Feral Spirit',
+  icon: 'spell_shaman_feralspirit',
+  maxRanks: 1,
+};
+export const ASCENDANCE_ENHANCEMENT_TALENT: Talent = {
+  id: 114051,
+  name: 'Ascendance',
+  icon: 'spell_fire_elementaldevastation',
+  maxRanks: 1,
+};
+export const DEEPLY_ROOTED_ELEMENTS_ENHANCEMENT_TALENT: Talent = {
+  id: 378270,
+  name: 'Deeply Rooted Elements',
+  icon: 'inv_misc_herb_liferoot_stem',
+  maxRanks: 1,
+};
+export const PRIMAL_MAELSTROM_ENHANCEMENT_TALENT: Talent = {
+  id: 384405,
+  name: 'Primal Maelstrom',
+  icon: 'shaman_talent_unleashedfury',
+  maxRanks: 2,
+};
+export const ELEMENTAL_ASSAULT_ENHANCEMENT_TALENT: Talent = {
+  id: 210853,
+  name: 'Elemental Assault',
+  icon: 'spell_shaman_improvedstormstrike',
+  maxRanks: 2,
+};
+export const WITCH_DOCTORS_WOLF_BONES_ENHANCEMENT_TALENT: Talent = {
+  id: 384447,
+  name: "Witch Doctor's Wolf Bones",
+  icon: 'inv_misc_bone_09',
+  maxRanks: 2,
+};
+export const LEGACY_OF_THE_FROST_WITCH_ENHANCEMENT_TALENT: Talent = {
+  id: 384450,
+  name: 'Legacy of the Frost Witch',
+  icon: 'ability_thunderking_thunderstruck',
+  maxRanks: 2,
+};
+export const STATIC_ACCUMULATION_ENHANCEMENT_TALENT: Talent = {
+  id: 384411,
+  name: 'Static Accumulation',
+  icon: 'spell_nature_callstorm',
+  maxRanks: 2,
+};
+export const SPLINTERED_ELEMENTS_ENHANCEMENT_TALENT: Talent = {
+  id: 382042,
+  name: 'Splintered Elements',
+  icon: 'spell_nature_elementalprecision_1',
+  maxRanks: 1,
+};
+export const ELEMENTAL_SPIRITS_ENHANCEMENT_TALENT: Talent = {
+  id: 262624,
+  name: 'Elemental Spirits',
+  icon: 'spell_shaman_feralspirit',
+  maxRanks: 1,
+};
+export const ALPHA_WOLF_ENHANCEMENT_TALENT: Talent = {
+  id: 198434,
+  name: 'Alpha Wolf',
+  icon: 'spell_beastmaster_wolf',
+  maxRanks: 1,
+};
+export const THORIMS_INVOCATION_ENHANCEMENT_TALENT: Talent = {
+  id: 384444,
+  name: "Thorim's Invocation",
+  icon: 'spell_shaman_ancestralawakening',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Elemental
+export const EARTH_SHOCK_ELEMENTAL_TALENT: Talent = {
+  id: 8042,
+  name: 'Earth Shock',
+  icon: 'spell_nature_earthshock',
+  maxRanks: 1,
+  maelstromCost: 60,
+};
+export const EARTHQUAKE_ELEMENTAL_TALENT: Talent = {
+  id: 61882,
+  name: 'Earthquake',
+  icon: 'spell_shaman_earthquake',
+  maxRanks: 1,
+  maelstromCost: 60,
+};
+export const ELEMENTAL_FURY_ELEMENTAL_TALENT: Talent = {
+  id: 60188,
+  name: 'Elemental Fury',
+  icon: 'spell_fire_volcano',
+  maxRanks: 1,
+};
+export const FIRE_ELEMENTAL_ELEMENTAL_TALENT: Talent = {
+  id: 198067,
+  name: 'Fire Elemental',
+  icon: 'spell_fire_elemental_totem',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const STORM_ELEMENTAL_ELEMENTAL_TALENT: Talent = {
+  id: 192249,
+  name: 'Storm Elemental',
+  icon: 'inv_stormelemental',
+  maxRanks: 1,
+};
+export const TUMULTUOUS_FISSURES_ELEMENTAL_TALENT: Talent = {
+  id: 381743,
+  name: 'Tumultuous Fissures',
+  icon: 'ability_rogue_fleetfooted',
+  maxRanks: 1,
+};
+export const INUNDATE_ELEMENTAL_TALENT: Talent = {
+  id: 378776,
+  name: 'Inundate',
+  icon: 'ability_shawaterelemental_swirl',
+  maxRanks: 1,
+};
+export const PRIMORDIAL_FURY_ELEMENTAL_TALENT: Talent = {
+  id: 378193,
+  name: 'Primordial Fury',
+  icon: 'inv_10_elementalshardfoozles_primordial',
+  maxRanks: 1,
+};
+export const ANCESTRAL_WOLF_AFFINITY_ELEMENTAL_TALENT: Talent = {
+  id: 382197,
+  name: 'Ancestral Wolf Affinity',
+  icon: 'spell_beastmaster_wolf',
+  maxRanks: 1,
+};
+export const REFRESHING_WATERS_ELEMENTAL_TALENT: Talent = {
+  id: 378211,
+  name: 'Refreshing Waters',
+  icon: 'ability_shaman_fortifyingwaters',
+  maxRanks: 1,
+};
+export const PRIMORDIAL_BOND_ELEMENTAL_TALENT: Talent = {
+  id: 381764,
+  name: 'Primordial Bond',
+  icon: 'inv_elemental_primal_earth',
+  maxRanks: 1,
+};
+export const CALL_OF_THUNDER_ELEMENTAL_TALENT: Talent = {
+  id: 378241,
+  name: 'Call of Thunder',
+  icon: 'ability_thunderking_balllightning',
+  maxRanks: 1,
+};
+export const FLOW_OF_POWER_ELEMENTAL_TALENT: Talent = {
+  id: 385923,
+  name: 'Flow of Power',
+  icon: 'spell_shaman_shockinglava',
+  maxRanks: 1,
+};
+export const LAVA_SURGE_ELEMENTAL_TALENT: Talent = {
+  id: 77756,
+  name: 'Lava Surge',
+  icon: 'spell_shaman_lavasurge',
+  maxRanks: 1,
+};
+export const UNRELENTING_CALAMITY_ELEMENTAL_TALENT: Talent = {
+  id: 382685,
+  name: 'Unrelenting Calamity',
+  icon: 'ability_vehicle_electrocharge',
+  maxRanks: 1,
+};
+export const ICEFURY_ELEMENTAL_TALENT: Talent = {
+  id: 210714,
+  name: 'Icefury',
+  icon: 'spell_frost_iceshard',
+  maxRanks: 1,
+  manaCost: 300,
+};
+export const SWELLING_MAELSTROM_ELEMENTAL_TALENT: Talent = {
+  id: 381707,
+  name: 'Swelling Maelstrom',
+  icon: 'spell_shaman_maelstromweapon',
+  maxRanks: 1,
+};
+export const ECHO_OF_THE_ELEMENTS_ELEMENTAL_TALENT: Talent = {
+  id: 333919,
+  name: 'Echo of the Elements',
+  icon: 'ability_shaman_echooftheelements',
+  maxRanks: 1,
+};
+export const CALL_OF_FIRE_ELEMENTAL_TALENT: Talent = {
+  id: 378255,
+  name: 'Call of Fire',
+  icon: 'spell_fire_ragnaros_molteninferno',
+  maxRanks: 1,
+};
+export const STORMKEEPER_ELEMENTAL_TALENT: Talent = {
+  id: 191634,
+  name: 'Stormkeeper',
+  icon: 'ability_thunderking_lightningwhip',
+  maxRanks: 1,
+};
+export const FLUX_MELTING_ELEMENTAL_TALENT: Talent = {
+  id: 381776,
+  name: 'Flux Melting',
+  icon: 'spell_frostfire_orb',
+  maxRanks: 1,
+};
+export const ELECTRIFIED_SHOCKS_ELEMENTAL_TALENT: Talent = {
+  id: 382086,
+  name: 'Electrified Shocks',
+  icon: 'inv_offhand_1h_artifactdoomhammer_d_02',
+  maxRanks: 1,
+};
+export const AFTERSHOCK_ELEMENTAL_TALENT: Talent = {
+  id: 273221,
+  name: 'Aftershock',
+  icon: 'spell_nature_stormreach',
+  maxRanks: 1,
+};
+export const SURGE_OF_POWER_ELEMENTAL_TALENT: Talent = {
+  id: 262303,
+  name: 'Surge of Power',
+  icon: 'spell_nature_shamanrage',
+  maxRanks: 1,
+};
+export const FLAMES_OF_THE_CAULDRON_ELEMENTAL_TALENT: Talent = {
+  id: 378266,
+  name: 'Flames of the Cauldron',
+  icon: 'inv_misc_cauldron_fire',
+  maxRanks: 1,
+};
+export const FLASH_OF_LIGHTNING_ELEMENTAL_TALENT: Talent = {
+  id: 381936,
+  name: 'Flash of Lightning',
+  icon: 'spell_lightning_lightningbolt01',
+  maxRanks: 1,
+};
+export const EYE_OF_THE_STORM_ELEMENTAL_TALENT: Talent = {
+  id: 381708,
+  name: 'Eye of the Storm',
+  icon: 'spell_shadow_soulleech_2',
+  maxRanks: 2,
+};
+export const POWER_OF_THE_MAELSTROM_ELEMENTAL_TALENT: Talent = {
+  id: 191861,
+  name: 'Power of the Maelstrom',
+  icon: 'spell_fire_masterofelements',
+  maxRanks: 2,
+};
+export const MASTER_OF_THE_ELEMENTS_ELEMENTAL_TALENT: Talent = {
+  id: 16166,
+  name: 'Master of the Elements',
+  icon: 'spell_nature_elementalabsorption',
+  maxRanks: 2,
+};
+export const IMPROVED_FLAMETONGUE_WEAPON_ELEMENTAL_TALENT: Talent = {
+  id: 382027,
+  name: 'Improved Flametongue Weapon',
+  icon: 'spell_fire_flametounge',
+  maxRanks: 1,
+};
+export const ELEMENTAL_BLAST_ELEMENTAL_TALENT: Talent = {
+  id: 117014,
+  name: 'Elemental Blast',
+  icon: 'shaman_talent_elementalblast',
+  maxRanks: 1,
+  manaCost: 200,
+};
+export const PRIMORDIAL_WAVE_ELEMENTAL_TALENT: Talent = {
+  id: 375982,
+  name: 'Primordial Wave',
+  icon: 'ability_maldraxxus_shaman',
+  maxRanks: 1,
+  manaCost: 300,
+};
+export const DEEPLY_ROOTED_ELEMENTS_ELEMENTAL_TALENT: Talent = {
+  id: 378270,
+  name: 'Deeply Rooted Elements',
+  icon: 'inv_misc_herb_liferoot_stem',
+  maxRanks: 1,
+};
+export const ASCENDANCE_ELEMENTAL_TALENT: Talent = {
+  id: 114050,
+  name: 'Ascendance',
+  icon: 'spell_fire_elementaldevastation',
+  maxRanks: 1,
+};
+export const PRIMAL_ELEMENTALIST_ELEMENTAL_TALENT: Talent = {
+  id: 117013,
+  name: 'Primal Elementalist',
+  icon: 'shaman_talent_primalelementalist',
+  maxRanks: 1,
+};
+export const LIQUID_MAGMA_TOTEM_ELEMENTAL_TALENT: Talent = {
+  id: 192222,
+  name: 'Liquid Magma Totem',
+  icon: 'spell_shaman_spewlava',
+  maxRanks: 1,
+  manaCost: 300,
+};
+export const ECHOES_OF_GREAT_SUNDERING_ELEMENTAL_TALENT: Talent = {
+  id: 384087,
+  name: 'Echoes of Great Sundering',
+  icon: 'spell_shaman_earthquake',
+  maxRanks: 2,
+};
+export const ELEMENTAL_EQUILIBRIUM_ELEMENTAL_TALENT: Talent = {
+  id: 378271,
+  name: 'Elemental Equilibrium',
+  icon: 'ability_shaman_ascendance',
+  maxRanks: 2,
+};
+export const ROLLING_MAGMA_ELEMENTAL_TALENT: Talent = {
+  id: 386443,
+  name: 'Rolling Magma',
+  icon: 'ability_rhyolith_volcano',
+  maxRanks: 2,
+};
+export const ECHO_CHAMBER_ELEMENTAL_TALENT: Talent = {
+  id: 382032,
+  name: 'Echo Chamber',
+  icon: 'spell_nature_lightningoverload',
+  maxRanks: 2,
+};
+export const OATH_OF_THE_FAR_SEER_ELEMENTAL_TALENT: Talent = {
+  id: 381785,
+  name: 'Oath of the Far Seer',
+  icon: 'spell_shaman_elementaloath',
+  maxRanks: 2,
+};
+export const MAGMA_CHAMBER_ELEMENTAL_TALENT: Talent = {
+  id: 381932,
+  name: 'Magma Chamber',
+  icon: 'ability_rhyolith_magmaflow_whole',
+  maxRanks: 2,
+};
+export const SEARING_FLAMES_ELEMENTAL_TALENT: Talent = {
+  id: 381782,
+  name: 'Searing Flames',
+  icon: 'inv_offhand_1h_artifactdoomhammer_d_01',
+  maxRanks: 2,
+};
+export const LIGHTNING_ROD_ELEMENTAL_TALENT: Talent = {
+  id: 210689,
+  name: 'Lightning Rod',
+  icon: 'inv_rod_enchantedcobalt',
+  maxRanks: 1,
+};
+export const HEAT_WAVE_ELEMENTAL_TALENT: Talent = {
+  id: 386474,
+  name: 'Heat Wave',
+  icon: 'ability_rhyolith_magmaflow_wave',
+  maxRanks: 1,
+};
+export const SPLINTERED_ELEMENTS_ELEMENTAL_TALENT: Talent = {
+  id: 382042,
+  name: 'Splintered Elements',
+  icon: 'spell_nature_elementalprecision_1',
+  maxRanks: 1,
+};
+export const MOUNTAINS_WILL_FALL_ELEMENTAL_TALENT: Talent = {
+  id: 381726,
+  name: 'Mountains Will Fall',
+  icon: 'inv_elementalearth2',
+  maxRanks: 1,
+};
+export const FURTHER_BEYOND_ELEMENTAL_TALENT: Talent = {
+  id: 381787,
+  name: 'Further Beyond',
+  icon: 'spell_holy_spiritualguidence',
+  maxRanks: 1,
+};
+export const WINDSPEAKERS_LAVA_RESURGENCE_ELEMENTAL_TALENT: Talent = {
+  id: 378268,
+  name: "Windspeaker's Lava Resurgence",
+  icon: 'ability_rhyolith_lavapool',
+  maxRanks: 1,
+};
+export const SKYBREAKERS_FIERY_DEMISE_ELEMENTAL_TALENT: Talent = {
+  id: 378310,
+  name: "Skybreaker's Fiery Demise",
+  icon: 'spell_fire_elemental_totem',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Restoration
+export const RIPTIDE_RESTORATION_TALENT: Talent = {
+  id: 61295,
+  name: 'Riptide',
+  icon: 'spell_nature_riptide',
+  maxRanks: 1,
+  manaCost: 800,
+};
+export const DELUGE_RESTORATION_TALENT: Talent = {
+  id: 200076,
+  name: 'Deluge',
+  icon: 'ability_shawaterelemental_reform',
+  maxRanks: 2,
+};
+export const HEALING_WAVE_RESTORATION_TALENT: Talent = {
+  id: 77472,
+  name: 'Healing Wave',
+  icon: 'spell_nature_healingwavelesser',
+  maxRanks: 1,
+  manaCost: 1500,
+};
+export const HEALING_STREAM_TOTEM_RESTORATION_TALENT: Talent = {
+  id: 5394,
+  name: 'Healing Stream Totem',
+  icon: 'inv_spear_04',
+  maxRanks: 1,
+  manaCost: 900,
+};
+export const HEALING_RAIN_RESTORATION_TALENT: Talent = {
+  id: 73920,
+  name: 'Healing Rain',
+  icon: 'spell_nature_giftofthewaterspirit',
+  maxRanks: 1,
+  manaCost: 2100,
+};
+export const ANCESTRAL_WOLF_AFFINITY_RESTORATION_TALENT: Talent = {
+  id: 382197,
+  name: 'Ancestral Wolf Affinity',
+  icon: 'spell_beastmaster_wolf',
+  maxRanks: 1,
+};
+export const STORMKEEPER_RESTORATION_TALENT: Talent = {
+  id: 383009,
+  name: 'Stormkeeper',
+  icon: 'ability_thunderking_lightningwhip',
+  maxRanks: 1,
+};
+export const WATER_SHIELD_RESTORATION_TALENT: Talent = {
+  id: 52127,
+  name: 'Water Shield',
+  icon: 'ability_shaman_watershield',
+  maxRanks: 1,
+};
+export const CALL_OF_THUNDER_RESTORATION_TALENT: Talent = {
+  id: 378241,
+  name: 'Call of Thunder',
+  icon: 'ability_thunderking_balllightning',
+  maxRanks: 1,
+};
+export const TIDAL_WAVES_RESTORATION_TALENT: Talent = {
+  id: 51564,
+  name: 'Tidal Waves',
+  icon: 'spell_shaman_tidalwaves',
+  maxRanks: 1,
+};
+export const OVERFLOWING_SHORES_RESTORATION_TALENT: Talent = {
+  id: 383222,
+  name: 'Overflowing Shores',
+  icon: 'spell_nature_giftofthewaterspirit',
+  maxRanks: 1,
+};
+export const ACID_RAIN_RESTORATION_TALENT: Talent = {
+  id: 378443,
+  name: 'Acid Rain',
+  icon: 'spell_nature_acid_01',
+  maxRanks: 1,
+};
+export const ANCESTRAL_VIGOR_RESTORATION_TALENT: Talent = {
+  id: 207401,
+  name: 'Ancestral Vigor',
+  icon: 'spell_shaman_blessingoftheeternals',
+  maxRanks: 2,
+};
+export const RESURGENCE_RESTORATION_TALENT: Talent = {
+  id: 16196,
+  name: 'Resurgence',
+  icon: 'ability_shaman_watershield',
+  maxRanks: 1,
+};
+export const FLASH_FLOOD_RESTORATION_TALENT: Talent = {
+  id: 280614,
+  name: 'Flash Flood',
+  icon: 'spell_frost_summonwaterelemental',
+  maxRanks: 2,
+};
+export const WATER_TOTEM_MASTERY_RESTORATION_TALENT: Talent = {
+  id: 382030,
+  name: 'Water Totem Mastery',
+  icon: 'ability_shaman_totemcooldownrefund',
+  maxRanks: 1,
+};
+export const ANCESTRAL_REACH_RESTORATION_TALENT: Talent = {
+  id: 382732,
+  name: 'Ancestral Reach',
+  icon: 'spell_nature_healingwavegreater',
+  maxRanks: 1,
+};
+export const FLOW_OF_THE_TIDES_RESTORATION_TALENT: Talent = {
+  id: 382039,
+  name: 'Flow of the Tides',
+  icon: 'spell_frost_manarecharge',
+  maxRanks: 1,
+};
+export const SPIRIT_LINK_TOTEM_RESTORATION_TALENT: Talent = {
+  id: 98008,
+  name: 'Spirit Link Totem',
+  icon: 'spell_shaman_spiritlink',
+  maxRanks: 1,
+  manaCost: 1100,
+};
+export const REFRESHING_WATERS_RESTORATION_TALENT: Talent = {
+  id: 378211,
+  name: 'Refreshing Waters',
+  icon: 'ability_shaman_fortifyingwaters',
+  maxRanks: 1,
+};
+export const MASTER_OF_THE_ELEMENTS_RESTORATION_TALENT: Talent = {
+  id: 16166,
+  name: 'Master of the Elements',
+  icon: 'spell_nature_elementalabsorption',
+  maxRanks: 1,
+};
+export const LIVING_STREAM_RESTORATION_TALENT: Talent = {
+  id: 382482,
+  name: 'Living Stream',
+  icon: 'spell_nature_natureresistancetotem',
+  maxRanks: 1,
+};
+export const CLOUDBURST_TOTEM_RESTORATION_TALENT: Talent = {
+  id: 157153,
+  name: 'Cloudburst Totem',
+  icon: 'ability_shaman_condensationtotem',
+  maxRanks: 1,
+  manaCost: 800,
+};
+export const WAVESPEAKERS_BLESSING_RESTORATION_TALENT: Talent = {
+  id: 381946,
+  name: "Wavespeaker's Blessing",
+  icon: 'inv_alchemist_81_spiritedalchemiststone',
+  maxRanks: 1,
+};
+export const HEALING_TIDE_TOTEM_RESTORATION_TALENT: Talent = {
+  id: 108280,
+  name: 'Healing Tide Totem',
+  icon: 'ability_shaman_healingtide',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const LAVA_SURGE_RESTORATION_TALENT: Talent = {
+  id: 77756,
+  name: 'Lava Surge',
+  icon: 'spell_shaman_lavasurge',
+  maxRanks: 1,
+};
+export const MANA_TIDE_TOTEM_RESTORATION_TALENT: Talent = {
+  id: 16191,
+  name: 'Mana Tide Totem',
+  icon: 'ability_shaman_manatidetotem',
+  maxRanks: 1,
+};
+export const TORRENT_RESTORATION_TALENT: Talent = {
+  id: 200072,
+  name: 'Torrent',
+  icon: 'spell_nature_riptide',
+  maxRanks: 2,
+};
+export const UNDULATION_RESTORATION_TALENT: Talent = {
+  id: 200071,
+  name: 'Undulation',
+  icon: 'spell_nature_healingway',
+  maxRanks: 1,
+};
+export const UNLEASH_LIFE_RESTORATION_TALENT: Talent = {
+  id: 73685,
+  name: 'Unleash Life',
+  icon: 'spell_shaman_unleashweapon_life',
+  maxRanks: 1,
+  manaCost: 400,
+};
+export const ECHO_OF_THE_ELEMENTS_RESTORATION_TALENT: Talent = {
+  id: 333919,
+  name: 'Echo of the Elements',
+  icon: 'ability_shaman_echooftheelements',
+  maxRanks: 1,
+};
+export const EARTHEN_WALL_TOTEM_RESTORATION_TALENT: Talent = {
+  id: 198838,
+  name: 'Earthen Wall Totem',
+  icon: 'spell_nature_stoneskintotem',
+  maxRanks: 1,
+  manaCost: 1100,
+};
+export const ANCESTRAL_PROTECTION_TOTEM_RESTORATION_TALENT: Talent = {
+  id: 207399,
+  name: 'Ancestral Protection Totem',
+  icon: 'spell_nature_reincarnation',
+  maxRanks: 1,
+  manaCost: 1100,
+};
+export const EARTHLIVING_WEAPON_RESTORATION_TALENT: Talent = {
+  id: 382021,
+  name: 'Earthliving Weapon',
+  icon: 'spell_shaman_giftearthmother',
+  maxRanks: 1,
+};
+export const PRIMORDIAL_WAVE_RESTORATION_TALENT: Talent = {
+  id: 375982,
+  name: 'Primordial Wave',
+  icon: 'ability_maldraxxus_shaman',
+  maxRanks: 1,
+  manaCost: 300,
+};
+export const ANCESTRAL_AWAKENING_RESTORATION_TALENT: Talent = {
+  id: 382309,
+  name: 'Ancestral Awakening',
+  icon: 'spell_shaman_ancestralawakening',
+  maxRanks: 2,
+};
+export const EARTHEN_HARMONY_RESTORATION_TALENT: Talent = {
+  id: 382020,
+  name: 'Earthen Harmony',
+  icon: 'spell_shaman_improvedearthshield',
+  maxRanks: 2,
+};
+export const UNDERCURRENT_RESTORATION_TALENT: Talent = {
+  id: 382194,
+  name: 'Undercurrent',
+  icon: 'spell_fire_bluehellfire',
+  maxRanks: 2,
+};
+export const IMPROVED_PRIMORDIAL_WAVE_RESTORATION_TALENT: Talent = {
+  id: 382191,
+  name: 'Improved Primordial Wave',
+  icon: 'ability_maldraxxus_shaman',
+  maxRanks: 2,
+};
+export const DOWNPOUR_RESTORATION_TALENT: Talent = {
+  id: 207778,
+  name: 'Downpour',
+  icon: 'ability_mage_waterjet',
+  maxRanks: 1,
+  manaCost: 1500,
+};
+export const NATURES_FOCUS_RESTORATION_TALENT: Talent = {
+  id: 382019,
+  name: "Nature's Focus",
+  icon: 'spell_shaman_blessingofeternals',
+  maxRanks: 1,
+};
+export const EVER_RISING_TIDE_RESTORATION_TALENT: Talent = {
+  id: 382029,
+  name: 'Ever-Rising Tide',
+  icon: 'inv_elemental_primal_water',
+  maxRanks: 1,
+};
+export const EARTHWARDEN_RESTORATION_TALENT: Talent = {
+  id: 382315,
+  name: 'Earthwarden',
+  icon: 'spell_shaman_giftearthmother',
+  maxRanks: 2,
+};
+export const CONTINUOUS_WAVES_RESTORATION_TALENT: Talent = {
+  id: 382046,
+  name: 'Continuous Waves',
+  icon: 'spell_animabastion_wave',
+  maxRanks: 1,
+};
+export const TUMBLING_WAVES_RESTORATION_TALENT: Talent = {
+  id: 382040,
+  name: 'Tumbling Waves',
+  icon: 'spell_animamaldraxxus_wave',
+  maxRanks: 1,
+};
+export const PRIMAL_TIDE_CORE_RESTORATION_TALENT: Talent = {
+  id: 382045,
+  name: 'Primal Tide Core',
+  icon: 'ability_shaman_repulsiontotem',
+  maxRanks: 1,
+};
+export const HIGH_TIDE_RESTORATION_TALENT: Talent = {
+  id: 157154,
+  name: 'High Tide',
+  icon: 'spell_shaman_hightide',
+  maxRanks: 1,
+  manaCost: 100,
+};
+export const ASCENDANCE_RESTORATION_TALENT: Talent = {
+  id: 114052,
+  name: 'Ascendance',
+  icon: 'spell_fire_elementaldevastation',
+  maxRanks: 1,
+};
+export const DEEPLY_ROOTED_ELEMENTS_RESTORATION_TALENT: Talent = {
+  id: 378270,
+  name: 'Deeply Rooted Elements',
+  icon: 'inv_misc_herb_liferoot_stem',
+  maxRanks: 1,
+};
+export const WELLSPRING_RESTORATION_TALENT: Talent = {
+  id: 197995,
+  name: 'Wellspring',
+  icon: 'ability_shawaterelemental_split',
+  maxRanks: 1,
+  manaCost: 2000,
+};
+
+//endregion
 
 const talents = createTalentList({
   //Shared
-  CHAIN_HEAL_TALENT: {
-    id: 1064,
-    name: 'Chain Heal',
-    icon: 'spell_nature_healingwavegreater',
-    maxRanks: 1,
-    manaCost: 3000,
-  },
-  LAVA_BURST_TALENT: {
-    id: 51505,
-    name: 'Lava Burst',
-    icon: 'spell_shaman_lavaburst',
-    maxRanks: 1,
-    manaCost: 200,
-  },
-  ASTRAL_SHIFT_TALENT: {
-    id: 108271,
-    name: 'Astral Shift',
-    icon: 'ability_shaman_astralshift',
-    maxRanks: 1,
-  },
-  CHAIN_LIGHTNING_TALENT: {
-    id: 188443,
-    name: 'Chain Lightning',
-    icon: 'spell_nature_chainlightning',
-    maxRanks: 1,
-    manaCost: 100,
-  },
-  EARTH_ELEMENTAL_TALENT: {
-    id: 198103,
-    name: 'Earth Elemental',
-    icon: 'spell_nature_earthelemental_totem',
-    maxRanks: 1,
-  },
-  WIND_SHEAR_TALENT: { id: 57994, name: 'Wind Shear', icon: 'spell_nature_cyclone', maxRanks: 1 },
-  PLANES_TRAVELER_TALENT: {
-    id: 381647,
-    name: 'Planes Traveler',
-    icon: 'spell_shaman_astralshift',
-    maxRanks: 1,
-  },
-  ASTRAL_BULWARK_TALENT: {
-    id: 377933,
-    name: 'Astral Bulwark',
-    icon: 'spell_shaman_ancestralawakening',
-    maxRanks: 1,
-  },
-  SPIRIT_WOLF_TALENT: {
-    id: 260878,
-    name: 'Spirit Wolf',
-    icon: 'spell_hunter_lonewolf',
-    maxRanks: 1,
-  },
-  THUNDEROUS_PAWS_TALENT: {
-    id: 378075,
-    name: 'Thunderous Paws',
-    icon: 'ability_hunter_longevity',
-    maxRanks: 1,
-  },
-  FROST_SHOCK_TALENT: {
-    id: 196840,
-    name: 'Frost Shock',
-    icon: 'spell_frost_frostshock',
-    maxRanks: 1,
-    manaCost: 100,
-  },
-  MAELSTROM_WEAPON_TALENT: {
-    id: 187880,
-    name: 'Maelstrom Weapon',
-    icon: 'spell_shaman_maelstromweapon',
-    maxRanks: 1,
-  },
-  EARTH_SHIELD_TALENT: {
-    id: 974,
-    name: 'Earth Shield',
-    icon: 'spell_nature_skinofearth',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  FIRE_AND_ICE_TALENT: {
-    id: 382886,
-    name: 'Fire and Ice',
-    icon: 'spell_firefrost_orb',
-    maxRanks: 1,
-  },
-  CAPACITOR_TOTEM_TALENT: {
-    id: 192058,
-    name: 'Capacitor Totem',
-    icon: 'spell_nature_brilliance',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  CLEANSE_SPIRIT_TALENT: {
-    id: 51886,
-    name: 'Cleanse Spirit',
-    icon: 'ability_shaman_cleansespirit',
-    maxRanks: 1,
-    manaCost: 600,
-  },
-  FOCUSED_INSIGHT_TALENT: {
-    id: 381666,
-    name: 'Focused Insight',
-    icon: 'spell_shaman_measuredinsight',
-    maxRanks: 2,
-  },
-  ELEMENTAL_ORBIT_TALENT: {
-    id: 383010,
-    name: 'Elemental Orbit',
-    icon: 'ability_mage_shattershield',
-    maxRanks: 1,
-  },
-  SPIRITWALKERS_GRACE_TALENT: {
-    id: 79206,
-    name: "Spiritwalker's Grace",
-    icon: 'spell_shaman_spiritwalkersgrace',
-    maxRanks: 1,
-    manaCost: 1400,
-  },
-  ANCESTRAL_DEFENSE_TALENT: {
-    id: 382947,
-    name: 'Ancestral Defense',
-    icon: 'ability_earthen_pillar',
-    maxRanks: 1,
-  },
-  TREMOR_TOTEM_TALENT: {
-    id: 8143,
-    name: 'Tremor Totem',
-    icon: 'spell_nature_tremortotem',
-    maxRanks: 1,
-    manaCost: 200,
-  },
-  STATIC_CHARGE_TALENT: {
-    id: 265046,
-    name: 'Static Charge',
-    icon: 'spell_nature_brilliance',
-    maxRanks: 1,
-  },
-  GUARDIANS_CUDGEL_TALENT: {
-    id: 381819,
-    name: "Guardian's Cudgel",
-    icon: 'inv_mace_2h_draenorcrafted_d_01_b_alliance',
-    maxRanks: 1,
-  },
-  PURGE_TALENT: { id: 370, name: 'Purge', icon: 'spell_nature_purge', maxRanks: 1, manaCost: 1000 },
-  GREATER_PURGE_TALENT: {
-    id: 378773,
-    name: 'Greater Purge',
-    icon: 'spell_shaman_focusedstrikes',
-    maxRanks: 1,
-    manaCost: 2000,
-  },
-  FLURRY_TALENT: { id: 382888, name: 'Flurry', icon: 'ability_ghoulfrenzy', maxRanks: 1 },
-  GRACEFUL_SPIRIT_TALENT: {
-    id: 192088,
-    name: 'Graceful Spirit',
-    icon: 'spell_shaman_spectraltransformation',
-    maxRanks: 1,
-  },
-  SPIRITWALKERS_AEGIS_TALENT: {
-    id: 378077,
-    name: "Spiritwalker's Aegis",
-    icon: 'ability_racial_forceshield',
-    maxRanks: 1,
-  },
-  WIND_RUSH_TOTEM_TALENT: {
-    id: 192077,
-    name: 'Wind Rush Totem',
-    icon: 'ability_shaman_windwalktotem',
-    maxRanks: 1,
-  },
-  EARTHGRAB_TOTEM_TALENT: {
-    id: 51485,
-    name: 'Earthgrab Totem',
-    icon: 'spell_nature_stranglevines',
-    maxRanks: 1,
-    manaCost: 200,
-  },
-  HEX_TALENT: { id: 51514, name: 'Hex', icon: 'spell_shaman_hex', maxRanks: 1 },
-  NATURES_FURY_TALENT: {
-    id: 381655,
-    name: "Nature's Fury",
-    icon: 'spell_nature_spiritarmor',
-    maxRanks: 2,
-  },
-  TOTEMIC_SURGE_TALENT: {
-    id: 381867,
-    name: 'Totemic Surge',
-    icon: 'spell_nature_agitatingtotem',
-    maxRanks: 2,
-  },
-  ELEMENTAL_WARDING_TALENT: {
-    id: 381650,
-    name: 'Elemental Warding',
-    icon: 'inv_10_elementalcombinedfoozles_primordial',
-    maxRanks: 2,
-  },
-  NATURES_GUARDIAN_TALENT: {
-    id: 30884,
-    name: "Nature's Guardian",
-    icon: 'spell_nature_natureguardian',
-    maxRanks: 2,
-  },
-  VOODOO_MASTERY_TALENT: {
-    id: 204268,
-    name: 'Voodoo Mastery',
-    icon: 'spell_shaman_hex',
-    maxRanks: 1,
-  },
-  ENFEEBLEMENT_TALENT: { id: 378079, name: 'Enfeeblement', icon: 'inv_frog2_teal', maxRanks: 1 },
-  WINDS_OF_ALAKIR_TALENT: {
-    id: 382215,
-    name: "Winds of Al'Akir",
-    icon: 'ability_druid_galewinds',
-    maxRanks: 2,
-  },
-  BRIMMING_WITH_LIFE_TALENT: {
-    id: 381689,
-    name: 'Brimming with Life',
-    icon: 'inv_jewelry_talisman_06',
-    maxRanks: 1,
-  },
-  HEALING_STREAM_TOTEM_TALENT: {
-    id: 5394,
-    name: 'Healing Stream Totem',
-    icon: 'inv_spear_04',
-    maxRanks: 1,
-    manaCost: 900,
-  },
-  IMPROVED_LIGHTNING_BOLT_TALENT: {
-    id: 381674,
-    name: 'Improved Lightning Bolt',
-    icon: 'spell_nature_lightning',
-    maxRanks: 2,
-  },
-  TOTEMIC_PROJECTION_TALENT: {
-    id: 108287,
-    name: 'Totemic Projection',
-    icon: 'ability_shaman_totemrelocation',
-    maxRanks: 1,
-  },
-  SPIRIT_WALK_TALENT: { id: 58875, name: 'Spirit Walk', icon: 'ability_tracking', maxRanks: 1 },
-  GUST_OF_WIND_TALENT: {
-    id: 192063,
-    name: 'Gust of Wind',
-    icon: 'ability_skyreach_four_wind',
-    maxRanks: 1,
-  },
-  SWIRLING_CURRENTS_TALENT: {
-    id: 378094,
-    name: 'Swirling Currents',
-    icon: 'spell_holy_serendipity',
-    maxRanks: 2,
-  },
-  NATURES_SWIFTNESS_TALENT: {
-    id: 378081,
-    name: "Nature's Swiftness",
-    icon: 'spell_nature_ravenform',
-    maxRanks: 1,
-  },
-  THUNDERSTORM_TALENT: {
-    id: 51490,
-    name: 'Thunderstorm',
-    icon: 'spell_shaman_thunderstorm',
-    maxRanks: 1,
-  },
-  TOTEMIC_FOCUS_TALENT: {
-    id: 382201,
-    name: 'Totemic Focus',
-    icon: 'inv_relics_totemofrebirth',
-    maxRanks: 2,
-  },
-  SURGING_SHIELDS_TALENT: {
-    id: 382033,
-    name: 'Surging Shields',
-    icon: 'spell_nature_lightningshield',
-    maxRanks: 2,
-  },
-  GO_WITH_THE_FLOW_TALENT: {
-    id: 381678,
-    name: 'Go With The Flow',
-    icon: 'ability_racial_runningwild',
-    maxRanks: 2,
-  },
-  MANA_SPRING_TOTEM_TALENT: {
-    id: 381930,
-    name: 'Mana Spring Totem',
-    icon: 'spell_nature_manaregentotem',
-    maxRanks: 1,
-    manaCost: 100,
-  },
-  THUNDERSHOCK_TALENT: {
-    id: 378779,
-    name: 'Thundershock',
-    icon: 'ability_thunderking_thunderstruck',
-    maxRanks: 1,
-  },
-  LIGHTNING_LASSO_TALENT: {
-    id: 305483,
-    name: 'Lightning Lasso',
-    icon: 'shaman_pvp_lightninglasso',
-    maxRanks: 1,
-  },
-  POISON_CLEANSING_TOTEM_TALENT: {
-    id: 383013,
-    name: 'Poison Cleansing Totem',
-    icon: 'spell_nature_poisoncleansingtotem',
-    maxRanks: 1,
-    manaCost: 200,
-  },
-  CALL_OF_THE_ELEMENTS_TALENT: {
-    id: 108285,
-    name: 'Call of the Elements',
-    icon: 'ability_shaman_multitotemactivation',
-    maxRanks: 1,
-  },
-  ANCESTRAL_GUIDANCE_TALENT: {
-    id: 108281,
-    name: 'Ancestral Guidance',
-    icon: 'ability_shaman_ancestralguidance',
-    maxRanks: 1,
-  },
-  STONESKIN_TOTEM_TALENT: {
-    id: 383017,
-    name: 'Stoneskin Totem',
-    icon: 'ability_shaman_stoneskintotem',
-    maxRanks: 1,
-    manaCost: 100,
-  },
-  TRANQUIL_AIR_TOTEM_TALENT: {
-    id: 383019,
-    name: 'Tranquil Air Totem',
-    icon: 'ability_shaman_tranquilmindtotem',
-    maxRanks: 1,
-    manaCost: 100,
-  },
-  IMPROVED_CALL_OF_THE_ELEMENTS_TALENT: {
-    id: 383011,
-    name: 'Improved Call of the Elements',
-    icon: 'ability_shaman_multitotemactivation',
-    maxRanks: 1,
-  },
-  CREATION_CORE_TALENT: {
-    id: 383012,
-    name: 'Creation Core',
-    icon: 'inv_artifact_xp03',
-    maxRanks: 1,
-  },
-  IMPROVED_PURIFY_SPIRIT_TALENT: {
-    id: 383016,
-    name: 'Improved Purify Spirit',
-    icon: 'ability_shaman_cleansespirit',
-    maxRanks: 1,
-  },
+  CHAIN_HEAL_TALENT,
+  LAVA_BURST_TALENT,
+  ASTRAL_SHIFT_TALENT,
+  CHAIN_LIGHTNING_TALENT,
+  EARTH_ELEMENTAL_TALENT,
+  WIND_SHEAR_TALENT,
+  PLANES_TRAVELER_TALENT,
+  ASTRAL_BULWARK_TALENT,
+  SPIRIT_WOLF_TALENT,
+  THUNDEROUS_PAWS_TALENT,
+  FROST_SHOCK_TALENT,
+  MAELSTROM_WEAPON_TALENT,
+  EARTH_SHIELD_TALENT,
+  FIRE_AND_ICE_TALENT,
+  CAPACITOR_TOTEM_TALENT,
+  CLEANSE_SPIRIT_TALENT,
+  FOCUSED_INSIGHT_TALENT,
+  ELEMENTAL_ORBIT_TALENT,
+  SPIRITWALKERS_GRACE_TALENT,
+  ANCESTRAL_DEFENSE_TALENT,
+  TREMOR_TOTEM_TALENT,
+  STATIC_CHARGE_TALENT,
+  GUARDIANS_CUDGEL_TALENT,
+  PURGE_TALENT,
+  GREATER_PURGE_TALENT,
+  FLURRY_TALENT,
+  GRACEFUL_SPIRIT_TALENT,
+  SPIRITWALKERS_AEGIS_TALENT,
+  WIND_RUSH_TOTEM_TALENT,
+  EARTHGRAB_TOTEM_TALENT,
+  HEX_TALENT,
+  NATURES_FURY_TALENT,
+  TOTEMIC_SURGE_TALENT,
+  ELEMENTAL_WARDING_TALENT,
+  NATURES_GUARDIAN_TALENT,
+  VOODOO_MASTERY_TALENT,
+  ENFEEBLEMENT_TALENT,
+  WINDS_OF_ALAKIR_TALENT,
+  BRIMMING_WITH_LIFE_TALENT,
+  HEALING_STREAM_TOTEM_TALENT,
+  IMPROVED_LIGHTNING_BOLT_TALENT,
+  TOTEMIC_PROJECTION_TALENT,
+  SPIRIT_WALK_TALENT,
+  GUST_OF_WIND_TALENT,
+  SWIRLING_CURRENTS_TALENT,
+  NATURES_SWIFTNESS_TALENT,
+  THUNDERSTORM_TALENT,
+  TOTEMIC_FOCUS_TALENT,
+  SURGING_SHIELDS_TALENT,
+  GO_WITH_THE_FLOW_TALENT,
+  MANA_SPRING_TOTEM_TALENT,
+  THUNDERSHOCK_TALENT,
+  LIGHTNING_LASSO_TALENT,
+  POISON_CLEANSING_TOTEM_TALENT,
+  CALL_OF_THE_ELEMENTS_TALENT,
+  ANCESTRAL_GUIDANCE_TALENT,
+  STONESKIN_TOTEM_TALENT,
+  TRANQUIL_AIR_TOTEM_TALENT,
+  IMPROVED_CALL_OF_THE_ELEMENTS_TALENT,
+  CREATION_CORE_TALENT,
+  IMPROVED_PURIFY_SPIRIT_TALENT,
 
   //Enhancement
-  STORMSTRIKE_ENHANCEMENT_TALENT: {
-    id: 17364,
-    name: 'Stormstrike',
-    icon: 'ability_shaman_stormstrike',
-    maxRanks: 1,
-    manaCost: 200,
-  },
-  WINDFURY_WEAPON_ENHANCEMENT_TALENT: {
-    id: 33757,
-    name: 'Windfury Weapon',
-    icon: 'spell_shaman_unleashweapon_wind',
-    maxRanks: 1,
-  },
-  LAVA_LASH_ENHANCEMENT_TALENT: {
-    id: 334033,
-    name: 'Lava Lash',
-    icon: 'spell_shaman_improvelavalash',
-    maxRanks: 2,
-  },
-  FORCEFUL_WINDS_ENHANCEMENT_TALENT: {
-    id: 262647,
-    name: 'Forceful Winds',
-    icon: 'spell_shaman_unleashweapon_wind',
-    maxRanks: 1,
-  },
-  IMPROVED_MAELSTROM_WEAPON_ENHANCEMENT_TALENT: {
-    id: 383303,
-    name: 'Improved Maelstrom Weapon',
-    icon: 'spell_shaman_maelstromweapon',
-    maxRanks: 1,
-  },
-  UNRULY_WINDS_ENHANCEMENT_TALENT: {
-    id: 390288,
-    name: 'Unruly Winds',
-    icon: 'ability_skyreach_wind_wall',
-    maxRanks: 1,
-  },
-  RAGING_MAELSTROM_ENHANCEMENT_TALENT: {
-    id: 384143,
-    name: 'Raging Maelstrom',
-    icon: 'spell_shaman_stormearthfire',
-    maxRanks: 1,
-  },
-  FERAL_LUNGE_ENHANCEMENT_TALENT: {
-    id: 196884,
-    name: 'Feral Lunge',
-    icon: 'spell_beastmaster_wolf',
-    maxRanks: 1,
-  },
-  PRIMAL_LAVA_ACTUATORS_ENHANCEMENT_TALENT: {
-    id: 390370,
-    name: 'Primal Lava Actuators',
-    icon: 'spell_shaman_stormearthfire',
-    maxRanks: 1,
-  },
-  DOOM_WINDS_ENHANCEMENT_TALENT: {
-    id: 384352,
-    name: 'Doom Winds',
-    icon: 'ability_ironmaidens_swirlingvortex',
-    maxRanks: 1,
-  },
-  SUNDERING_ENHANCEMENT_TALENT: {
-    id: 197214,
-    name: 'Sundering',
-    icon: 'ability_rhyolith_lavapool',
-    maxRanks: 1,
-    manaCost: 600,
-  },
-  FOCUSED_MAELSTROM_ENHANCEMENT_TALENT: {
-    id: 384146,
-    name: 'Focused Maelstrom',
-    icon: 'spell_shaman_spectraltransformation',
-    maxRanks: 1,
-  },
-  OVERFLOWING_MAELSTROM_ENHANCEMENT_TALENT: {
-    id: 384149,
-    name: 'Overflowing Maelstrom',
-    icon: 'spell_shaman_maelstromweapon',
-    maxRanks: 1,
-  },
-  WINDFURY_TOTEM_ENHANCEMENT_TALENT: {
-    id: 8512,
-    name: 'Windfury Totem',
-    icon: 'spell_nature_windfury',
-    maxRanks: 1,
-    manaCost: 100,
-  },
-  HAILSTORM_ENHANCEMENT_TALENT: {
-    id: 334195,
-    name: 'Hailstorm',
-    icon: 'spell_frost_icestorm',
-    maxRanks: 1,
-  },
-  FIRE_NOVA_ENHANCEMENT_TALENT: {
-    id: 333974,
-    name: 'Fire Nova',
-    icon: 'spell_shaman_improvedfirenova',
-    maxRanks: 1,
-    manaCost: 100,
-  },
-  HOT_HAND_ENHANCEMENT_TALENT: {
-    id: 201900,
-    name: 'Hot Hand',
-    icon: 'spell_fire_playingwithfire',
-    maxRanks: 2,
-  },
-  STORMBRINGER_ENHANCEMENT_TALENT: {
-    id: 201845,
-    name: 'Stormbringer',
-    icon: 'spell_nature_stormreach',
-    maxRanks: 1,
-  },
-  REFRESHING_WATERS_ENHANCEMENT_TALENT: {
-    id: 337974,
-    name: 'Refreshing Waters',
-    icon: 'ability_shaman_fortifyingwaters',
-    maxRanks: 1,
-  },
-  ANCESTRAL_WOLF_AFFINITY_ENHANCEMENT_TALENT: {
-    id: 382197,
-    name: 'Ancestral Wolf Affinity',
-    icon: 'spell_beastmaster_wolf',
-    maxRanks: 1,
-  },
-  CRASH_LIGHTNING_ENHANCEMENT_TALENT: {
-    id: 187874,
-    name: 'Crash Lightning',
-    icon: 'spell_shaman_crashlightning',
-    maxRanks: 1,
-    manaCost: 100,
-  },
-  STORMFLURRY_ENHANCEMENT_TALENT: {
-    id: 344357,
-    name: 'Stormflurry',
-    icon: 'ability_shaman_stormstrike',
-    maxRanks: 1,
-  },
-  ICE_STRIKE_ENHANCEMENT_TALENT: {
-    id: 342240,
-    name: 'Ice Strike',
-    icon: 'spell_frost_frostbolt',
-    maxRanks: 1,
-    manaCost: 300,
-  },
-  ELEMENTAL_BLAST_ENHANCEMENT_TALENT: {
-    id: 117014,
-    name: 'Elemental Blast',
-    icon: 'shaman_talent_elementalblast',
-    maxRanks: 1,
-    manaCost: 200,
-  },
-  STORMBLAST_ENHANCEMENT_TALENT: {
-    id: 319930,
-    name: 'Stormblast',
-    icon: 'spell_nature_stormreach',
-    maxRanks: 1,
-  },
-  ELEMENTAL_WEAPONS_ENHANCEMENT_TALENT: {
-    id: 384355,
-    name: 'Elemental Weapons',
-    icon: 'spell_nature_elementalprecision_1',
-    maxRanks: 2,
-  },
-  GATHERING_STORMS_ENHANCEMENT_TALENT: {
-    id: 384363,
-    name: 'Gathering Storms',
-    icon: 'warrior_talent_icon_stormbolt',
-    maxRanks: 1,
-  },
-  CRASHING_STORMS_ENHANCEMENT_TALENT: {
-    id: 334308,
-    name: 'Crashing Storms',
-    icon: 'spell_nature_chainlightning',
-    maxRanks: 1,
-  },
-  SWIRLING_MAELSTROM_ENHANCEMENT_TALENT: {
-    id: 384359,
-    name: 'Swirling Maelstrom',
-    icon: 'spell_shadow_soulleech_2',
-    maxRanks: 1,
-  },
-  PRIMORDIAL_WAVE_ENHANCEMENT_TALENT: {
-    id: 375982,
-    name: 'Primordial Wave',
-    icon: 'ability_maldraxxus_shaman',
-    maxRanks: 1,
-    manaCost: 300,
-  },
-  FERAL_SPIRIT_ENHANCEMENT_TALENT: {
-    id: 51533,
-    name: 'Feral Spirit',
-    icon: 'spell_shaman_feralspirit',
-    maxRanks: 1,
-  },
-  ASCENDANCE_ENHANCEMENT_TALENT: {
-    id: 114051,
-    name: 'Ascendance',
-    icon: 'spell_fire_elementaldevastation',
-    maxRanks: 1,
-  },
-  DEEPLY_ROOTED_ELEMENTS_ENHANCEMENT_TALENT: {
-    id: 378270,
-    name: 'Deeply Rooted Elements',
-    icon: 'inv_misc_herb_liferoot_stem',
-    maxRanks: 1,
-  },
-  PRIMAL_MAELSTROM_ENHANCEMENT_TALENT: {
-    id: 384405,
-    name: 'Primal Maelstrom',
-    icon: 'shaman_talent_unleashedfury',
-    maxRanks: 2,
-  },
-  ELEMENTAL_ASSAULT_ENHANCEMENT_TALENT: {
-    id: 210853,
-    name: 'Elemental Assault',
-    icon: 'spell_shaman_improvedstormstrike',
-    maxRanks: 2,
-  },
-  WITCH_DOCTORS_WOLF_BONES_ENHANCEMENT_TALENT: {
-    id: 384447,
-    name: "Witch Doctor's Wolf Bones",
-    icon: 'inv_misc_bone_09',
-    maxRanks: 2,
-  },
-  LEGACY_OF_THE_FROST_WITCH_ENHANCEMENT_TALENT: {
-    id: 384450,
-    name: 'Legacy of the Frost Witch',
-    icon: 'ability_thunderking_thunderstruck',
-    maxRanks: 2,
-  },
-  STATIC_ACCUMULATION_ENHANCEMENT_TALENT: {
-    id: 384411,
-    name: 'Static Accumulation',
-    icon: 'spell_nature_callstorm',
-    maxRanks: 2,
-  },
-  SPLINTERED_ELEMENTS_ENHANCEMENT_TALENT: {
-    id: 382042,
-    name: 'Splintered Elements',
-    icon: 'spell_nature_elementalprecision_1',
-    maxRanks: 1,
-  },
-  ELEMENTAL_SPIRITS_ENHANCEMENT_TALENT: {
-    id: 262624,
-    name: 'Elemental Spirits',
-    icon: 'spell_shaman_feralspirit',
-    maxRanks: 1,
-  },
-  ALPHA_WOLF_ENHANCEMENT_TALENT: {
-    id: 198434,
-    name: 'Alpha Wolf',
-    icon: 'spell_beastmaster_wolf',
-    maxRanks: 1,
-  },
-  THORIMS_INVOCATION_ENHANCEMENT_TALENT: {
-    id: 384444,
-    name: "Thorim's Invocation",
-    icon: 'spell_shaman_ancestralawakening',
-    maxRanks: 1,
-  },
+  STORMSTRIKE_ENHANCEMENT_TALENT,
+  WINDFURY_WEAPON_ENHANCEMENT_TALENT,
+  LAVA_LASH_ENHANCEMENT_TALENT,
+  FORCEFUL_WINDS_ENHANCEMENT_TALENT,
+  IMPROVED_MAELSTROM_WEAPON_ENHANCEMENT_TALENT,
+  UNRULY_WINDS_ENHANCEMENT_TALENT,
+  RAGING_MAELSTROM_ENHANCEMENT_TALENT,
+  FERAL_LUNGE_ENHANCEMENT_TALENT,
+  PRIMAL_LAVA_ACTUATORS_ENHANCEMENT_TALENT,
+  DOOM_WINDS_ENHANCEMENT_TALENT,
+  SUNDERING_ENHANCEMENT_TALENT,
+  FOCUSED_MAELSTROM_ENHANCEMENT_TALENT,
+  OVERFLOWING_MAELSTROM_ENHANCEMENT_TALENT,
+  WINDFURY_TOTEM_ENHANCEMENT_TALENT,
+  HAILSTORM_ENHANCEMENT_TALENT,
+  FIRE_NOVA_ENHANCEMENT_TALENT,
+  HOT_HAND_ENHANCEMENT_TALENT,
+  STORMBRINGER_ENHANCEMENT_TALENT,
+  REFRESHING_WATERS_ENHANCEMENT_TALENT,
+  ANCESTRAL_WOLF_AFFINITY_ENHANCEMENT_TALENT,
+  CRASH_LIGHTNING_ENHANCEMENT_TALENT,
+  STORMFLURRY_ENHANCEMENT_TALENT,
+  ICE_STRIKE_ENHANCEMENT_TALENT,
+  ELEMENTAL_BLAST_ENHANCEMENT_TALENT,
+  STORMBLAST_ENHANCEMENT_TALENT,
+  ELEMENTAL_WEAPONS_ENHANCEMENT_TALENT,
+  GATHERING_STORMS_ENHANCEMENT_TALENT,
+  CRASHING_STORMS_ENHANCEMENT_TALENT,
+  SWIRLING_MAELSTROM_ENHANCEMENT_TALENT,
+  PRIMORDIAL_WAVE_ENHANCEMENT_TALENT,
+  FERAL_SPIRIT_ENHANCEMENT_TALENT,
+  ASCENDANCE_ENHANCEMENT_TALENT,
+  DEEPLY_ROOTED_ELEMENTS_ENHANCEMENT_TALENT,
+  PRIMAL_MAELSTROM_ENHANCEMENT_TALENT,
+  ELEMENTAL_ASSAULT_ENHANCEMENT_TALENT,
+  WITCH_DOCTORS_WOLF_BONES_ENHANCEMENT_TALENT,
+  LEGACY_OF_THE_FROST_WITCH_ENHANCEMENT_TALENT,
+  STATIC_ACCUMULATION_ENHANCEMENT_TALENT,
+  SPLINTERED_ELEMENTS_ENHANCEMENT_TALENT,
+  ELEMENTAL_SPIRITS_ENHANCEMENT_TALENT,
+  ALPHA_WOLF_ENHANCEMENT_TALENT,
+  THORIMS_INVOCATION_ENHANCEMENT_TALENT,
 
   //Elemental
-  EARTH_SHOCK_ELEMENTAL_TALENT: {
-    id: 8042,
-    name: 'Earth Shock',
-    icon: 'spell_nature_earthshock',
-    maxRanks: 1,
-    maelstromCost: 60,
-  },
-  EARTHQUAKE_ELEMENTAL_TALENT: {
-    id: 61882,
-    name: 'Earthquake',
-    icon: 'spell_shaman_earthquake',
-    maxRanks: 1,
-    maelstromCost: 60,
-  },
-  ELEMENTAL_FURY_ELEMENTAL_TALENT: {
-    id: 60188,
-    name: 'Elemental Fury',
-    icon: 'spell_fire_volcano',
-    maxRanks: 1,
-  },
-  FIRE_ELEMENTAL_ELEMENTAL_TALENT: {
-    id: 198067,
-    name: 'Fire Elemental',
-    icon: 'spell_fire_elemental_totem',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  STORM_ELEMENTAL_ELEMENTAL_TALENT: {
-    id: 192249,
-    name: 'Storm Elemental',
-    icon: 'inv_stormelemental',
-    maxRanks: 1,
-  },
-  TUMULTUOUS_FISSURES_ELEMENTAL_TALENT: {
-    id: 381743,
-    name: 'Tumultuous Fissures',
-    icon: 'ability_rogue_fleetfooted',
-    maxRanks: 1,
-  },
-  INUNDATE_ELEMENTAL_TALENT: {
-    id: 378776,
-    name: 'Inundate',
-    icon: 'ability_shawaterelemental_swirl',
-    maxRanks: 1,
-  },
-  PRIMORDIAL_FURY_ELEMENTAL_TALENT: {
-    id: 378193,
-    name: 'Primordial Fury',
-    icon: 'inv_10_elementalshardfoozles_primordial',
-    maxRanks: 1,
-  },
-  ANCESTRAL_WOLF_AFFINITY_ELEMENTAL_TALENT: {
-    id: 382197,
-    name: 'Ancestral Wolf Affinity',
-    icon: 'spell_beastmaster_wolf',
-    maxRanks: 1,
-  },
-  REFRESHING_WATERS_ELEMENTAL_TALENT: {
-    id: 378211,
-    name: 'Refreshing Waters',
-    icon: 'ability_shaman_fortifyingwaters',
-    maxRanks: 1,
-  },
-  PRIMORDIAL_BOND_ELEMENTAL_TALENT: {
-    id: 381764,
-    name: 'Primordial Bond',
-    icon: 'inv_elemental_primal_earth',
-    maxRanks: 1,
-  },
-  CALL_OF_THUNDER_ELEMENTAL_TALENT: {
-    id: 378241,
-    name: 'Call of Thunder',
-    icon: 'ability_thunderking_balllightning',
-    maxRanks: 1,
-  },
-  FLOW_OF_POWER_ELEMENTAL_TALENT: {
-    id: 385923,
-    name: 'Flow of Power',
-    icon: 'spell_shaman_shockinglava',
-    maxRanks: 1,
-  },
-  LAVA_SURGE_ELEMENTAL_TALENT: {
-    id: 77756,
-    name: 'Lava Surge',
-    icon: 'spell_shaman_lavasurge',
-    maxRanks: 1,
-  },
-  UNRELENTING_CALAMITY_ELEMENTAL_TALENT: {
-    id: 382685,
-    name: 'Unrelenting Calamity',
-    icon: 'ability_vehicle_electrocharge',
-    maxRanks: 1,
-  },
-  ICEFURY_ELEMENTAL_TALENT: {
-    id: 210714,
-    name: 'Icefury',
-    icon: 'spell_frost_iceshard',
-    maxRanks: 1,
-    manaCost: 300,
-  },
-  SWELLING_MAELSTROM_ELEMENTAL_TALENT: {
-    id: 381707,
-    name: 'Swelling Maelstrom',
-    icon: 'spell_shaman_maelstromweapon',
-    maxRanks: 1,
-  },
-  ECHO_OF_THE_ELEMENTS_ELEMENTAL_TALENT: {
-    id: 333919,
-    name: 'Echo of the Elements',
-    icon: 'ability_shaman_echooftheelements',
-    maxRanks: 1,
-  },
-  CALL_OF_FIRE_ELEMENTAL_TALENT: {
-    id: 378255,
-    name: 'Call of Fire',
-    icon: 'spell_fire_ragnaros_molteninferno',
-    maxRanks: 1,
-  },
-  STORMKEEPER_ELEMENTAL_TALENT: {
-    id: 191634,
-    name: 'Stormkeeper',
-    icon: 'ability_thunderking_lightningwhip',
-    maxRanks: 1,
-  },
-  FLUX_MELTING_ELEMENTAL_TALENT: {
-    id: 381776,
-    name: 'Flux Melting',
-    icon: 'spell_frostfire_orb',
-    maxRanks: 1,
-  },
-  ELECTRIFIED_SHOCKS_ELEMENTAL_TALENT: {
-    id: 382086,
-    name: 'Electrified Shocks',
-    icon: 'inv_offhand_1h_artifactdoomhammer_d_02',
-    maxRanks: 1,
-  },
-  AFTERSHOCK_ELEMENTAL_TALENT: {
-    id: 273221,
-    name: 'Aftershock',
-    icon: 'spell_nature_stormreach',
-    maxRanks: 1,
-  },
-  SURGE_OF_POWER_ELEMENTAL_TALENT: {
-    id: 262303,
-    name: 'Surge of Power',
-    icon: 'spell_nature_shamanrage',
-    maxRanks: 1,
-  },
-  FLAMES_OF_THE_CAULDRON_ELEMENTAL_TALENT: {
-    id: 378266,
-    name: 'Flames of the Cauldron',
-    icon: 'inv_misc_cauldron_fire',
-    maxRanks: 1,
-  },
-  FLASH_OF_LIGHTNING_ELEMENTAL_TALENT: {
-    id: 381936,
-    name: 'Flash of Lightning',
-    icon: 'spell_lightning_lightningbolt01',
-    maxRanks: 1,
-  },
-  EYE_OF_THE_STORM_ELEMENTAL_TALENT: {
-    id: 381708,
-    name: 'Eye of the Storm',
-    icon: 'spell_shadow_soulleech_2',
-    maxRanks: 2,
-  },
-  POWER_OF_THE_MAELSTROM_ELEMENTAL_TALENT: {
-    id: 191861,
-    name: 'Power of the Maelstrom',
-    icon: 'spell_fire_masterofelements',
-    maxRanks: 2,
-  },
-  MASTER_OF_THE_ELEMENTS_ELEMENTAL_TALENT: {
-    id: 16166,
-    name: 'Master of the Elements',
-    icon: 'spell_nature_elementalabsorption',
-    maxRanks: 2,
-  },
-  IMPROVED_FLAMETONGUE_WEAPON_ELEMENTAL_TALENT: {
-    id: 382027,
-    name: 'Improved Flametongue Weapon',
-    icon: 'spell_fire_flametounge',
-    maxRanks: 1,
-  },
-  ELEMENTAL_BLAST_ELEMENTAL_TALENT: {
-    id: 117014,
-    name: 'Elemental Blast',
-    icon: 'shaman_talent_elementalblast',
-    maxRanks: 1,
-    manaCost: 200,
-  },
-  PRIMORDIAL_WAVE_ELEMENTAL_TALENT: {
-    id: 375982,
-    name: 'Primordial Wave',
-    icon: 'ability_maldraxxus_shaman',
-    maxRanks: 1,
-    manaCost: 300,
-  },
-  DEEPLY_ROOTED_ELEMENTS_ELEMENTAL_TALENT: {
-    id: 378270,
-    name: 'Deeply Rooted Elements',
-    icon: 'inv_misc_herb_liferoot_stem',
-    maxRanks: 1,
-  },
-  ASCENDANCE_ELEMENTAL_TALENT: {
-    id: 114050,
-    name: 'Ascendance',
-    icon: 'spell_fire_elementaldevastation',
-    maxRanks: 1,
-  },
-  PRIMAL_ELEMENTALIST_ELEMENTAL_TALENT: {
-    id: 117013,
-    name: 'Primal Elementalist',
-    icon: 'shaman_talent_primalelementalist',
-    maxRanks: 1,
-  },
-  LIQUID_MAGMA_TOTEM_ELEMENTAL_TALENT: {
-    id: 192222,
-    name: 'Liquid Magma Totem',
-    icon: 'spell_shaman_spewlava',
-    maxRanks: 1,
-    manaCost: 300,
-  },
-  ECHOES_OF_GREAT_SUNDERING_ELEMENTAL_TALENT: {
-    id: 384087,
-    name: 'Echoes of Great Sundering',
-    icon: 'spell_shaman_earthquake',
-    maxRanks: 2,
-  },
-  ELEMENTAL_EQUILIBRIUM_ELEMENTAL_TALENT: {
-    id: 378271,
-    name: 'Elemental Equilibrium',
-    icon: 'ability_shaman_ascendance',
-    maxRanks: 2,
-  },
-  ROLLING_MAGMA_ELEMENTAL_TALENT: {
-    id: 386443,
-    name: 'Rolling Magma',
-    icon: 'ability_rhyolith_volcano',
-    maxRanks: 2,
-  },
-  ECHO_CHAMBER_ELEMENTAL_TALENT: {
-    id: 382032,
-    name: 'Echo Chamber',
-    icon: 'spell_nature_lightningoverload',
-    maxRanks: 2,
-  },
-  OATH_OF_THE_FAR_SEER_ELEMENTAL_TALENT: {
-    id: 381785,
-    name: 'Oath of the Far Seer',
-    icon: 'spell_shaman_elementaloath',
-    maxRanks: 2,
-  },
-  MAGMA_CHAMBER_ELEMENTAL_TALENT: {
-    id: 381932,
-    name: 'Magma Chamber',
-    icon: 'ability_rhyolith_magmaflow_whole',
-    maxRanks: 2,
-  },
-  SEARING_FLAMES_ELEMENTAL_TALENT: {
-    id: 381782,
-    name: 'Searing Flames',
-    icon: 'inv_offhand_1h_artifactdoomhammer_d_01',
-    maxRanks: 2,
-  },
-  LIGHTNING_ROD_ELEMENTAL_TALENT: {
-    id: 210689,
-    name: 'Lightning Rod',
-    icon: 'inv_rod_enchantedcobalt',
-    maxRanks: 1,
-  },
-  HEAT_WAVE_ELEMENTAL_TALENT: {
-    id: 386474,
-    name: 'Heat Wave',
-    icon: 'ability_rhyolith_magmaflow_wave',
-    maxRanks: 1,
-  },
-  SPLINTERED_ELEMENTS_ELEMENTAL_TALENT: {
-    id: 382042,
-    name: 'Splintered Elements',
-    icon: 'spell_nature_elementalprecision_1',
-    maxRanks: 1,
-  },
-  MOUNTAINS_WILL_FALL_ELEMENTAL_TALENT: {
-    id: 381726,
-    name: 'Mountains Will Fall',
-    icon: 'inv_elementalearth2',
-    maxRanks: 1,
-  },
-  FURTHER_BEYOND_ELEMENTAL_TALENT: {
-    id: 381787,
-    name: 'Further Beyond',
-    icon: 'spell_holy_spiritualguidence',
-    maxRanks: 1,
-  },
-  WINDSPEAKERS_LAVA_RESURGENCE_ELEMENTAL_TALENT: {
-    id: 378268,
-    name: "Windspeaker's Lava Resurgence",
-    icon: 'ability_rhyolith_lavapool',
-    maxRanks: 1,
-  },
-  SKYBREAKERS_FIERY_DEMISE_ELEMENTAL_TALENT: {
-    id: 378310,
-    name: "Skybreaker's Fiery Demise",
-    icon: 'spell_fire_elemental_totem',
-    maxRanks: 1,
-  },
+  EARTH_SHOCK_ELEMENTAL_TALENT,
+  EARTHQUAKE_ELEMENTAL_TALENT,
+  ELEMENTAL_FURY_ELEMENTAL_TALENT,
+  FIRE_ELEMENTAL_ELEMENTAL_TALENT,
+  STORM_ELEMENTAL_ELEMENTAL_TALENT,
+  TUMULTUOUS_FISSURES_ELEMENTAL_TALENT,
+  INUNDATE_ELEMENTAL_TALENT,
+  PRIMORDIAL_FURY_ELEMENTAL_TALENT,
+  ANCESTRAL_WOLF_AFFINITY_ELEMENTAL_TALENT,
+  REFRESHING_WATERS_ELEMENTAL_TALENT,
+  PRIMORDIAL_BOND_ELEMENTAL_TALENT,
+  CALL_OF_THUNDER_ELEMENTAL_TALENT,
+  FLOW_OF_POWER_ELEMENTAL_TALENT,
+  LAVA_SURGE_ELEMENTAL_TALENT,
+  UNRELENTING_CALAMITY_ELEMENTAL_TALENT,
+  ICEFURY_ELEMENTAL_TALENT,
+  SWELLING_MAELSTROM_ELEMENTAL_TALENT,
+  ECHO_OF_THE_ELEMENTS_ELEMENTAL_TALENT,
+  CALL_OF_FIRE_ELEMENTAL_TALENT,
+  STORMKEEPER_ELEMENTAL_TALENT,
+  FLUX_MELTING_ELEMENTAL_TALENT,
+  ELECTRIFIED_SHOCKS_ELEMENTAL_TALENT,
+  AFTERSHOCK_ELEMENTAL_TALENT,
+  SURGE_OF_POWER_ELEMENTAL_TALENT,
+  FLAMES_OF_THE_CAULDRON_ELEMENTAL_TALENT,
+  FLASH_OF_LIGHTNING_ELEMENTAL_TALENT,
+  EYE_OF_THE_STORM_ELEMENTAL_TALENT,
+  POWER_OF_THE_MAELSTROM_ELEMENTAL_TALENT,
+  MASTER_OF_THE_ELEMENTS_ELEMENTAL_TALENT,
+  IMPROVED_FLAMETONGUE_WEAPON_ELEMENTAL_TALENT,
+  ELEMENTAL_BLAST_ELEMENTAL_TALENT,
+  PRIMORDIAL_WAVE_ELEMENTAL_TALENT,
+  DEEPLY_ROOTED_ELEMENTS_ELEMENTAL_TALENT,
+  ASCENDANCE_ELEMENTAL_TALENT,
+  PRIMAL_ELEMENTALIST_ELEMENTAL_TALENT,
+  LIQUID_MAGMA_TOTEM_ELEMENTAL_TALENT,
+  ECHOES_OF_GREAT_SUNDERING_ELEMENTAL_TALENT,
+  ELEMENTAL_EQUILIBRIUM_ELEMENTAL_TALENT,
+  ROLLING_MAGMA_ELEMENTAL_TALENT,
+  ECHO_CHAMBER_ELEMENTAL_TALENT,
+  OATH_OF_THE_FAR_SEER_ELEMENTAL_TALENT,
+  MAGMA_CHAMBER_ELEMENTAL_TALENT,
+  SEARING_FLAMES_ELEMENTAL_TALENT,
+  LIGHTNING_ROD_ELEMENTAL_TALENT,
+  HEAT_WAVE_ELEMENTAL_TALENT,
+  SPLINTERED_ELEMENTS_ELEMENTAL_TALENT,
+  MOUNTAINS_WILL_FALL_ELEMENTAL_TALENT,
+  FURTHER_BEYOND_ELEMENTAL_TALENT,
+  WINDSPEAKERS_LAVA_RESURGENCE_ELEMENTAL_TALENT,
+  SKYBREAKERS_FIERY_DEMISE_ELEMENTAL_TALENT,
 
   //Restoration
-  RIPTIDE_RESTORATION_TALENT: {
-    id: 61295,
-    name: 'Riptide',
-    icon: 'spell_nature_riptide',
-    maxRanks: 1,
-    manaCost: 800,
-  },
-  DELUGE_RESTORATION_TALENT: {
-    id: 200076,
-    name: 'Deluge',
-    icon: 'ability_shawaterelemental_reform',
-    maxRanks: 2,
-  },
-  HEALING_WAVE_RESTORATION_TALENT: {
-    id: 77472,
-    name: 'Healing Wave',
-    icon: 'spell_nature_healingwavelesser',
-    maxRanks: 1,
-    manaCost: 1500,
-  },
-  HEALING_STREAM_TOTEM_RESTORATION_TALENT: {
-    id: 5394,
-    name: 'Healing Stream Totem',
-    icon: 'inv_spear_04',
-    maxRanks: 1,
-    manaCost: 900,
-  },
-  HEALING_RAIN_RESTORATION_TALENT: {
-    id: 73920,
-    name: 'Healing Rain',
-    icon: 'spell_nature_giftofthewaterspirit',
-    maxRanks: 1,
-    manaCost: 2100,
-  },
-  ANCESTRAL_WOLF_AFFINITY_RESTORATION_TALENT: {
-    id: 382197,
-    name: 'Ancestral Wolf Affinity',
-    icon: 'spell_beastmaster_wolf',
-    maxRanks: 1,
-  },
-  STORMKEEPER_RESTORATION_TALENT: {
-    id: 383009,
-    name: 'Stormkeeper',
-    icon: 'ability_thunderking_lightningwhip',
-    maxRanks: 1,
-  },
-  WATER_SHIELD_RESTORATION_TALENT: {
-    id: 52127,
-    name: 'Water Shield',
-    icon: 'ability_shaman_watershield',
-    maxRanks: 1,
-  },
-  CALL_OF_THUNDER_RESTORATION_TALENT: {
-    id: 378241,
-    name: 'Call of Thunder',
-    icon: 'ability_thunderking_balllightning',
-    maxRanks: 1,
-  },
-  TIDAL_WAVES_RESTORATION_TALENT: {
-    id: 51564,
-    name: 'Tidal Waves',
-    icon: 'spell_shaman_tidalwaves',
-    maxRanks: 1,
-  },
-  OVERFLOWING_SHORES_RESTORATION_TALENT: {
-    id: 383222,
-    name: 'Overflowing Shores',
-    icon: 'spell_nature_giftofthewaterspirit',
-    maxRanks: 1,
-  },
-  ACID_RAIN_RESTORATION_TALENT: {
-    id: 378443,
-    name: 'Acid Rain',
-    icon: 'spell_nature_acid_01',
-    maxRanks: 1,
-  },
-  ANCESTRAL_VIGOR_RESTORATION_TALENT: {
-    id: 207401,
-    name: 'Ancestral Vigor',
-    icon: 'spell_shaman_blessingoftheeternals',
-    maxRanks: 2,
-  },
-  RESURGENCE_RESTORATION_TALENT: {
-    id: 16196,
-    name: 'Resurgence',
-    icon: 'ability_shaman_watershield',
-    maxRanks: 1,
-  },
-  FLASH_FLOOD_RESTORATION_TALENT: {
-    id: 280614,
-    name: 'Flash Flood',
-    icon: 'spell_frost_summonwaterelemental',
-    maxRanks: 2,
-  },
-  WATER_TOTEM_MASTERY_RESTORATION_TALENT: {
-    id: 382030,
-    name: 'Water Totem Mastery',
-    icon: 'ability_shaman_totemcooldownrefund',
-    maxRanks: 1,
-  },
-  ANCESTRAL_REACH_RESTORATION_TALENT: {
-    id: 382732,
-    name: 'Ancestral Reach',
-    icon: 'spell_nature_healingwavegreater',
-    maxRanks: 1,
-  },
-  FLOW_OF_THE_TIDES_RESTORATION_TALENT: {
-    id: 382039,
-    name: 'Flow of the Tides',
-    icon: 'spell_frost_manarecharge',
-    maxRanks: 1,
-  },
-  SPIRIT_LINK_TOTEM_RESTORATION_TALENT: {
-    id: 98008,
-    name: 'Spirit Link Totem',
-    icon: 'spell_shaman_spiritlink',
-    maxRanks: 1,
-    manaCost: 1100,
-  },
-  REFRESHING_WATERS_RESTORATION_TALENT: {
-    id: 378211,
-    name: 'Refreshing Waters',
-    icon: 'ability_shaman_fortifyingwaters',
-    maxRanks: 1,
-  },
-  MASTER_OF_THE_ELEMENTS_RESTORATION_TALENT: {
-    id: 16166,
-    name: 'Master of the Elements',
-    icon: 'spell_nature_elementalabsorption',
-    maxRanks: 1,
-  },
-  LIVING_STREAM_RESTORATION_TALENT: {
-    id: 382482,
-    name: 'Living Stream',
-    icon: 'spell_nature_natureresistancetotem',
-    maxRanks: 1,
-  },
-  CLOUDBURST_TOTEM_RESTORATION_TALENT: {
-    id: 157153,
-    name: 'Cloudburst Totem',
-    icon: 'ability_shaman_condensationtotem',
-    maxRanks: 1,
-    manaCost: 800,
-  },
-  WAVESPEAKERS_BLESSING_RESTORATION_TALENT: {
-    id: 381946,
-    name: "Wavespeaker's Blessing",
-    icon: 'inv_alchemist_81_spiritedalchemiststone',
-    maxRanks: 1,
-  },
-  HEALING_TIDE_TOTEM_RESTORATION_TALENT: {
-    id: 108280,
-    name: 'Healing Tide Totem',
-    icon: 'ability_shaman_healingtide',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  LAVA_SURGE_RESTORATION_TALENT: {
-    id: 77756,
-    name: 'Lava Surge',
-    icon: 'spell_shaman_lavasurge',
-    maxRanks: 1,
-  },
-  MANA_TIDE_TOTEM_RESTORATION_TALENT: {
-    id: 16191,
-    name: 'Mana Tide Totem',
-    icon: 'ability_shaman_manatidetotem',
-    maxRanks: 1,
-  },
-  TORRENT_RESTORATION_TALENT: {
-    id: 200072,
-    name: 'Torrent',
-    icon: 'spell_nature_riptide',
-    maxRanks: 2,
-  },
-  UNDULATION_RESTORATION_TALENT: {
-    id: 200071,
-    name: 'Undulation',
-    icon: 'spell_nature_healingway',
-    maxRanks: 1,
-  },
-  UNLEASH_LIFE_RESTORATION_TALENT: {
-    id: 73685,
-    name: 'Unleash Life',
-    icon: 'spell_shaman_unleashweapon_life',
-    maxRanks: 1,
-    manaCost: 400,
-  },
-  ECHO_OF_THE_ELEMENTS_RESTORATION_TALENT: {
-    id: 333919,
-    name: 'Echo of the Elements',
-    icon: 'ability_shaman_echooftheelements',
-    maxRanks: 1,
-  },
-  EARTHEN_WALL_TOTEM_RESTORATION_TALENT: {
-    id: 198838,
-    name: 'Earthen Wall Totem',
-    icon: 'spell_nature_stoneskintotem',
-    maxRanks: 1,
-    manaCost: 1100,
-  },
-  ANCESTRAL_PROTECTION_TOTEM_RESTORATION_TALENT: {
-    id: 207399,
-    name: 'Ancestral Protection Totem',
-    icon: 'spell_nature_reincarnation',
-    maxRanks: 1,
-    manaCost: 1100,
-  },
-  EARTHLIVING_WEAPON_RESTORATION_TALENT: {
-    id: 382021,
-    name: 'Earthliving Weapon',
-    icon: 'spell_shaman_giftearthmother',
-    maxRanks: 1,
-  },
-  PRIMORDIAL_WAVE_RESTORATION_TALENT: {
-    id: 375982,
-    name: 'Primordial Wave',
-    icon: 'ability_maldraxxus_shaman',
-    maxRanks: 1,
-    manaCost: 300,
-  },
-  ANCESTRAL_AWAKENING_RESTORATION_TALENT: {
-    id: 382309,
-    name: 'Ancestral Awakening',
-    icon: 'spell_shaman_ancestralawakening',
-    maxRanks: 2,
-  },
-  EARTHEN_HARMONY_RESTORATION_TALENT: {
-    id: 382020,
-    name: 'Earthen Harmony',
-    icon: 'spell_shaman_improvedearthshield',
-    maxRanks: 2,
-  },
-  UNDERCURRENT_RESTORATION_TALENT: {
-    id: 382194,
-    name: 'Undercurrent',
-    icon: 'spell_fire_bluehellfire',
-    maxRanks: 2,
-  },
-  IMPROVED_PRIMORDIAL_WAVE_RESTORATION_TALENT: {
-    id: 382191,
-    name: 'Improved Primordial Wave',
-    icon: 'ability_maldraxxus_shaman',
-    maxRanks: 2,
-  },
-  DOWNPOUR_RESTORATION_TALENT: {
-    id: 207778,
-    name: 'Downpour',
-    icon: 'ability_mage_waterjet',
-    maxRanks: 1,
-    manaCost: 1500,
-  },
-  NATURES_FOCUS_RESTORATION_TALENT: {
-    id: 382019,
-    name: "Nature's Focus",
-    icon: 'spell_shaman_blessingofeternals',
-    maxRanks: 1,
-  },
-  EVER_RISING_TIDE_RESTORATION_TALENT: {
-    id: 382029,
-    name: 'Ever-Rising Tide',
-    icon: 'inv_elemental_primal_water',
-    maxRanks: 1,
-  },
-  EARTHWARDEN_RESTORATION_TALENT: {
-    id: 382315,
-    name: 'Earthwarden',
-    icon: 'spell_shaman_giftearthmother',
-    maxRanks: 2,
-  },
-  CONTINUOUS_WAVES_RESTORATION_TALENT: {
-    id: 382046,
-    name: 'Continuous Waves',
-    icon: 'spell_animabastion_wave',
-    maxRanks: 1,
-  },
-  TUMBLING_WAVES_RESTORATION_TALENT: {
-    id: 382040,
-    name: 'Tumbling Waves',
-    icon: 'spell_animamaldraxxus_wave',
-    maxRanks: 1,
-  },
-  PRIMAL_TIDE_CORE_RESTORATION_TALENT: {
-    id: 382045,
-    name: 'Primal Tide Core',
-    icon: 'ability_shaman_repulsiontotem',
-    maxRanks: 1,
-  },
-  HIGH_TIDE_RESTORATION_TALENT: {
-    id: 157154,
-    name: 'High Tide',
-    icon: 'spell_shaman_hightide',
-    maxRanks: 1,
-    manaCost: 100,
-  },
-  ASCENDANCE_RESTORATION_TALENT: {
-    id: 114052,
-    name: 'Ascendance',
-    icon: 'spell_fire_elementaldevastation',
-    maxRanks: 1,
-  },
-  DEEPLY_ROOTED_ELEMENTS_RESTORATION_TALENT: {
-    id: 378270,
-    name: 'Deeply Rooted Elements',
-    icon: 'inv_misc_herb_liferoot_stem',
-    maxRanks: 1,
-  },
-  WELLSPRING_RESTORATION_TALENT: {
-    id: 197995,
-    name: 'Wellspring',
-    icon: 'ability_shawaterelemental_split',
-    maxRanks: 1,
-    manaCost: 2000,
-  },
+  RIPTIDE_RESTORATION_TALENT,
+  DELUGE_RESTORATION_TALENT,
+  HEALING_WAVE_RESTORATION_TALENT,
+  HEALING_STREAM_TOTEM_RESTORATION_TALENT,
+  HEALING_RAIN_RESTORATION_TALENT,
+  ANCESTRAL_WOLF_AFFINITY_RESTORATION_TALENT,
+  STORMKEEPER_RESTORATION_TALENT,
+  WATER_SHIELD_RESTORATION_TALENT,
+  CALL_OF_THUNDER_RESTORATION_TALENT,
+  TIDAL_WAVES_RESTORATION_TALENT,
+  OVERFLOWING_SHORES_RESTORATION_TALENT,
+  ACID_RAIN_RESTORATION_TALENT,
+  ANCESTRAL_VIGOR_RESTORATION_TALENT,
+  RESURGENCE_RESTORATION_TALENT,
+  FLASH_FLOOD_RESTORATION_TALENT,
+  WATER_TOTEM_MASTERY_RESTORATION_TALENT,
+  ANCESTRAL_REACH_RESTORATION_TALENT,
+  FLOW_OF_THE_TIDES_RESTORATION_TALENT,
+  SPIRIT_LINK_TOTEM_RESTORATION_TALENT,
+  REFRESHING_WATERS_RESTORATION_TALENT,
+  MASTER_OF_THE_ELEMENTS_RESTORATION_TALENT,
+  LIVING_STREAM_RESTORATION_TALENT,
+  CLOUDBURST_TOTEM_RESTORATION_TALENT,
+  WAVESPEAKERS_BLESSING_RESTORATION_TALENT,
+  HEALING_TIDE_TOTEM_RESTORATION_TALENT,
+  LAVA_SURGE_RESTORATION_TALENT,
+  MANA_TIDE_TOTEM_RESTORATION_TALENT,
+  TORRENT_RESTORATION_TALENT,
+  UNDULATION_RESTORATION_TALENT,
+  UNLEASH_LIFE_RESTORATION_TALENT,
+  ECHO_OF_THE_ELEMENTS_RESTORATION_TALENT,
+  EARTHEN_WALL_TOTEM_RESTORATION_TALENT,
+  ANCESTRAL_PROTECTION_TOTEM_RESTORATION_TALENT,
+  EARTHLIVING_WEAPON_RESTORATION_TALENT,
+  PRIMORDIAL_WAVE_RESTORATION_TALENT,
+  ANCESTRAL_AWAKENING_RESTORATION_TALENT,
+  EARTHEN_HARMONY_RESTORATION_TALENT,
+  UNDERCURRENT_RESTORATION_TALENT,
+  IMPROVED_PRIMORDIAL_WAVE_RESTORATION_TALENT,
+  DOWNPOUR_RESTORATION_TALENT,
+  NATURES_FOCUS_RESTORATION_TALENT,
+  EVER_RISING_TIDE_RESTORATION_TALENT,
+  EARTHWARDEN_RESTORATION_TALENT,
+  CONTINUOUS_WAVES_RESTORATION_TALENT,
+  TUMBLING_WAVES_RESTORATION_TALENT,
+  PRIMAL_TIDE_CORE_RESTORATION_TALENT,
+  HIGH_TIDE_RESTORATION_TALENT,
+  ASCENDANCE_RESTORATION_TALENT,
+  DEEPLY_ROOTED_ELEMENTS_RESTORATION_TALENT,
+  WELLSPRING_RESTORATION_TALENT,
 });
 
 export default talents;

--- a/src/common/TALENTS/warlock.ts
+++ b/src/common/TALENTS/warlock.ts
@@ -1,1063 +1,1289 @@
 // Generated file, changes will eventually be overwritten!
-import { createTalentList } from './types';
+import { createTalentList, Talent } from './types';
+
+//region Shared
+export const FEL_DOMINATION_TALENT: Talent = {
+  id: 333889,
+  name: 'Fel Domination',
+  icon: 'spell_shadow_felmending',
+  maxRanks: 1,
+};
+export const SPELL_LOCK_TALENT: Talent = {
+  id: 19647,
+  name: 'Spell Lock',
+  icon: 'spell_shadow_mindrot',
+  maxRanks: 1,
+};
+export const BURNING_RUSH_TALENT: Talent = {
+  id: 111400,
+  name: 'Burning Rush',
+  icon: 'ability_deathwing_sealarmorbreachtga',
+  maxRanks: 1,
+};
+export const QUICK_FIENDS_TALENT: Talent = {
+  id: 386113,
+  name: 'Quick Fiends',
+  icon: 'spell_shadow_impphaseshift',
+  maxRanks: 2,
+};
+export const DEMON_SKIN_TALENT: Talent = {
+  id: 219272,
+  name: 'Demon Skin',
+  icon: 'spell_shadow_ragingscream',
+  maxRanks: 2,
+};
+export const FEL_ARMOR_TALENT: Talent = {
+  id: 386124,
+  name: 'Fel Armor',
+  icon: 'spell_shadow_felarmour',
+  maxRanks: 2,
+};
+export const IMP_STEP_TALENT: Talent = {
+  id: 386110,
+  name: 'Imp Step',
+  icon: 'inv_misc_moosehoof_fel',
+  maxRanks: 2,
+};
+export const CURSES_OF_ENFEEBLEMENT_TALENT: Talent = {
+  id: 386105,
+  name: 'Curses of Enfeeblement',
+  icon: 'ability_creature_cursed_02',
+  maxRanks: 1,
+};
+export const DEMONIC_CIRCLE_TALENT: Talent = {
+  id: 48018,
+  name: 'Demonic Circle',
+  icon: 'spell_shadow_demoniccirclesummon',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const HOWL_OF_TERROR_TALENT: Talent = {
+  id: 5484,
+  name: 'Howl of Terror',
+  icon: 'ability_warlock_howlofterror',
+  maxRanks: 1,
+};
+export const MORTAL_COIL_TALENT: Talent = {
+  id: 6789,
+  name: 'Mortal Coil',
+  icon: 'ability_warlock_mortalcoil',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const AMPLIFY_CURSE_TALENT: Talent = {
+  id: 328774,
+  name: 'Amplify Curse',
+  icon: 'spell_shadow_contagion',
+  maxRanks: 1,
+};
+export const DEMONIC_EMBRACE_TALENT: Talent = {
+  id: 288843,
+  name: 'Demonic Embrace',
+  icon: 'spell_shadow_metamorphosis',
+  maxRanks: 1,
+};
+export const DEMONIC_INSPIRATION_TALENT: Talent = {
+  id: 386858,
+  name: 'Demonic Inspiration',
+  icon: 'ability_warlock_demonicpower',
+  maxRanks: 1,
+};
+export const ABYSS_WALKER_TALENT: Talent = {
+  id: 389609,
+  name: 'Abyss Walker',
+  icon: 'achievement_explore_argus',
+  maxRanks: 1,
+};
+export const WRATHFUL_MINION_TALENT: Talent = {
+  id: 386864,
+  name: 'Wrathful Minion',
+  icon: 'spell_fel_incinerate',
+  maxRanks: 1,
+};
+export const DEMONIC_FORTITUDE_TALENT: Talent = {
+  id: 386617,
+  name: 'Demonic Fortitude',
+  icon: 'spell_warlock_summonimpoutland',
+  maxRanks: 1,
+};
+export const BANISH_TALENT: Talent = {
+  id: 710,
+  name: 'Banish',
+  icon: 'spell_shadow_cripple',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const FOUL_MOUTH_TALENT: Talent = {
+  id: 387972,
+  name: 'Foul Mouth',
+  icon: 'spell_shadow_carrionswarm',
+  maxRanks: 1,
+};
+export const DESPERATE_POWER_TALENT: Talent = {
+  id: 386619,
+  name: 'Desperate Power',
+  icon: 'spell_shadow_lifedrain02',
+  maxRanks: 2,
+};
+export const SWEET_SOULS_TALENT: Talent = {
+  id: 386620,
+  name: 'Sweet Souls',
+  icon: 'spell_shadow_soulleech',
+  maxRanks: 1,
+};
+export const GOREFIENDS_RESOLVE_TALENT: Talent = {
+  id: 389623,
+  name: "Gorefiend's Resolve",
+  icon: 'inv_helmet_90',
+  maxRanks: 2,
+};
+export const DEMONIC_GATEWAY_TALENT: Talent = {
+  id: 111771,
+  name: 'Demonic Gateway',
+  icon: 'spell_warlock_demonicportal_green',
+  maxRanks: 1,
+  manaCost: 10000,
+};
+export const NIGHTMARE_TALENT: Talent = {
+  id: 386648,
+  name: 'Nightmare',
+  icon: 'spell_shadow_possession',
+  maxRanks: 2,
+};
+export const GREATER_BANISH_TALENT: Talent = {
+  id: 386651,
+  name: 'Greater Banish',
+  icon: 'spell_shadow_cripple',
+  maxRanks: 1,
+};
+export const DARK_PACT_TALENT: Talent = {
+  id: 108416,
+  name: 'Dark Pact',
+  icon: 'spell_shadow_deathpact',
+  maxRanks: 1,
+};
+export const STRENGTH_OF_WILL_TALENT: Talent = {
+  id: 317138,
+  name: 'Strength of Will',
+  icon: 'spell_shadow_demonictactics',
+  maxRanks: 1,
+};
+export const DEMONIC_DURABILITY_TALENT: Talent = {
+  id: 386659,
+  name: 'Demonic Durability',
+  icon: 'ability_warlock_improveddemonictactics',
+  maxRanks: 1,
+};
+export const SHADOWFURY_TALENT: Talent = {
+  id: 30283,
+  name: 'Shadowfury',
+  icon: 'ability_warlock_shadowfurytga',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const ICHOR_OF_DEVILS_TALENT: Talent = {
+  id: 386664,
+  name: 'Ichor of Devils',
+  icon: 'spell_yorsahj_bloodboil_greenoil',
+  maxRanks: 1,
+};
+export const FREQUENT_DONOR_TALENT: Talent = {
+  id: 386686,
+  name: 'Frequent Donor',
+  icon: 'ability_ironmaidens_bloodritual',
+  maxRanks: 1,
+};
+export const ACCRUED_VITALITY_TALENT: Talent = {
+  id: 386613,
+  name: 'Accrued Vitality',
+  icon: 'spell_shadow_lifedrain',
+  maxRanks: 2,
+};
+export const LIFEBLOOD_TALENT: Talent = {
+  id: 386646,
+  name: 'Lifeblood',
+  icon: 'warlock__healthstone',
+  maxRanks: 2,
+};
+export const DARKFURY_TALENT: Talent = {
+  id: 264874,
+  name: 'Darkfury',
+  icon: 'ability_warlock_shadowfurytga',
+  maxRanks: 1,
+};
+export const SHADOWFLAME_TALENT: Talent = {
+  id: 384069,
+  name: 'Shadowflame',
+  icon: 'ability_warlock_shadowflame',
+  maxRanks: 1,
+};
+export const FEL_SYNERGY_TALENT: Talent = {
+  id: 389367,
+  name: 'Fel Synergy',
+  icon: 'inv_sword_1h_felfireraid_d_01',
+  maxRanks: 1,
+};
+export const SOUL_LINK_TALENT: Talent = {
+  id: 108415,
+  name: 'Soul Link',
+  icon: 'ability_warlock_soullink',
+  maxRanks: 1,
+};
+export const TEACHINGS_OF_THE_BLACK_HARVEST_TALENT: Talent = {
+  id: 385881,
+  name: 'Teachings of the Black Harvest',
+  icon: 'inv_misc_codexofxerrath_nochains',
+  maxRanks: 1,
+};
+export const RESOLUTE_BARRIER_TALENT: Talent = {
+  id: 389359,
+  name: 'Resolute Barrier',
+  icon: 'inv_shield_1h_demonweapon_c_01',
+  maxRanks: 2,
+};
+export const GRIMOIRE_OF_SYNERGY_TALENT: Talent = {
+  id: 171975,
+  name: 'Grimoire of Synergy',
+  icon: 'warlock_grimoireofsacrifice',
+  maxRanks: 2,
+};
+export const SOUL_ARMOR_TALENT: Talent = {
+  id: 389576,
+  name: 'Soul Armor',
+  icon: 'ability_argus_deathfog',
+  maxRanks: 2,
+};
+export const SOUL_CONDUIT_TALENT: Talent = {
+  id: 215941,
+  name: 'Soul Conduit',
+  icon: 'spell_shadow_soulleech_2',
+  maxRanks: 2,
+};
+export const DEMONIC_RESILIENCE_TALENT: Talent = {
+  id: 389590,
+  name: 'Demonic Resilience',
+  icon: 'ability_warlock_avoidance',
+  maxRanks: 2,
+};
+export const CLAW_OF_ENDERETH_TALENT: Talent = {
+  id: 386689,
+  name: 'Claw of Endereth',
+  icon: 'inv_flaming_splinter',
+  maxRanks: 1,
+};
+export const SUMMON_SOULKEEPER_TALENT: Talent = {
+  id: 386244,
+  name: 'Summon Soulkeeper',
+  icon: 'spell_fel_elementaldevastation',
+  maxRanks: 1,
+};
+export const INQUISITORS_GAZE_TALENT: Talent = {
+  id: 386344,
+  name: "Inquisitor's Gaze",
+  icon: 'inv_pet_inquisitoreye',
+  maxRanks: 1,
+};
+export const SOULBURN_TALENT: Talent = {
+  id: 385899,
+  name: 'Soulburn',
+  icon: 'spell_warlock_soulburn',
+  maxRanks: 1,
+  soulShardsCost: 1,
+};
+
+//endregion
+
+//region Affliction
+export const MALEFIC_RAPTURE_AFFLICTION_TALENT: Talent = {
+  id: 324536,
+  name: 'Malefic Rapture',
+  icon: 'ability_warlock_everlastingaffliction',
+  maxRanks: 1,
+  soulShardsCost: 1,
+};
+export const UNSTABLE_AFFLICTION_AFFLICTION_TALENT: Talent = {
+  id: 316099,
+  name: 'Unstable Affliction',
+  icon: 'spell_shadow_unstableaffliction_3',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const SEED_OF_CORRUPTION_AFFLICTION_TALENT: Talent = {
+  id: 27243,
+  name: 'Seed of Corruption',
+  icon: 'spell_shadow_seedofdestruction',
+  maxRanks: 1,
+  soulShardsCost: 1,
+};
+export const NIGHTFALL_AFFLICTION_TALENT: Talent = {
+  id: 108558,
+  name: 'Nightfall',
+  icon: 'spell_shadow_twilight',
+  maxRanks: 1,
+};
+export const XAVIAN_TEACHINGS_AFFLICTION_TALENT: Talent = {
+  id: 317031,
+  name: 'Xavian Teachings',
+  icon: 'spell_shadow_abominationexplosion',
+  maxRanks: 1,
+};
+export const SOW_THE_SEEDS_AFFLICTION_TALENT: Talent = {
+  id: 196226,
+  name: 'Sow the Seeds',
+  icon: 'spell_shadow_seedofdestruction',
+  maxRanks: 1,
+};
+export const SHADOW_EMBRACE_AFFLICTION_TALENT: Talent = {
+  id: 32388,
+  name: 'Shadow Embrace',
+  icon: 'spell_shadow_shadowembrace',
+  maxRanks: 2,
+};
+export const HARVESTER_OF_SOULS_AFFLICTION_TALENT: Talent = {
+  id: 201424,
+  name: 'Harvester of Souls',
+  icon: 'warlock_spelldrain',
+  maxRanks: 2,
+};
+export const WRITHE_IN_AGONY_AFFLICTION_TALENT: Talent = {
+  id: 196102,
+  name: 'Writhe in Agony',
+  icon: 'spell_shadow_curseofsargeras',
+  maxRanks: 2,
+};
+export const AGONIZING_CORRUPTION_AFFLICTION_TALENT: Talent = {
+  id: 386922,
+  name: 'Agonizing Corruption',
+  icon: 'spell_warlock_darkregeneration',
+  maxRanks: 2,
+};
+export const DRAIN_SOUL_AFFLICTION_TALENT: Talent = {
+  id: 388667,
+  name: 'Drain Soul',
+  icon: 'spell_shadow_haunting',
+  maxRanks: 1,
+};
+export const SIPHON_LIFE_AFFLICTION_TALENT: Talent = {
+  id: 63106,
+  name: 'Siphon Life',
+  icon: 'spell_shadow_requiem',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const ABSOLUTE_CORRUPTION_AFFLICTION_TALENT: Talent = {
+  id: 196103,
+  name: 'Absolute Corruption',
+  icon: 'ability_bossmannoroth_empoweredmannorothsgaze',
+  maxRanks: 1,
+};
+export const PHANTOM_SINGULARITY_AFFLICTION_TALENT: Talent = {
+  id: 205179,
+  name: 'Phantom Singularity',
+  icon: 'inv_enchant_voidsphere',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const VILE_TAINT_AFFLICTION_TALENT: Talent = {
+  id: 278350,
+  name: 'Vile Taint',
+  icon: 'sha_spell_shadow_shadesofdarkness_nightborne',
+  maxRanks: 1,
+  soulShardsCost: 1,
+};
+export const SOUL_TAP_AFFLICTION_TALENT: Talent = {
+  id: 387073,
+  name: 'Soul Tap',
+  icon: 'spell_shadow_burningspirit',
+  maxRanks: 1,
+};
+export const INEVITABLE_DEMISE_AFFLICTION_TALENT: Talent = {
+  id: 334319,
+  name: 'Inevitable Demise',
+  icon: 'spell_warlock_harvestoflife',
+  maxRanks: 2,
+};
+export const SOUL_SWAP_AFFLICTION_TALENT: Talent = {
+  id: 386951,
+  name: 'Soul Swap',
+  icon: 'ability_warlock_soulswap',
+  maxRanks: 1,
+  soulShardsCost: 1,
+};
+export const SOUL_FLAME_AFFLICTION_TALENT: Talent = {
+  id: 199471,
+  name: 'Soul Flame',
+  icon: 'ability_argus_soulburst',
+  maxRanks: 2,
+};
+export const GRIMOIRE_OF_SACRIFICE_AFFLICTION_TALENT: Talent = {
+  id: 108503,
+  name: 'Grimoire of Sacrifice',
+  icon: 'warlock_grimoireofsacrifice',
+  maxRanks: 1,
+};
+export const PANDEMIC_INVOCATION_AFFLICTION_TALENT: Talent = {
+  id: 386759,
+  name: 'Pandemic Invocation',
+  icon: 'spell_shadow_unsummonbuilding',
+  maxRanks: 2,
+};
+export const WITHERING_BOLT_AFFLICTION_TALENT: Talent = {
+  id: 386976,
+  name: 'Withering Bolt',
+  icon: 'spell_shadow_shadowbolt',
+  maxRanks: 2,
+};
+export const SACROLASHS_DARK_STRIKE_AFFLICTION_TALENT: Talent = {
+  id: 386986,
+  name: "Sacrolash's Dark Strike",
+  icon: 'spell_nzinsanity_fearofdeath',
+  maxRanks: 2,
+};
+export const CREEPING_DEATH_AFFLICTION_TALENT: Talent = {
+  id: 264000,
+  name: 'Creeping Death',
+  icon: 'ability_creature_cursed_03',
+  maxRanks: 1,
+};
+export const HAUNT_AFFLICTION_TALENT: Talent = {
+  id: 48181,
+  name: 'Haunt',
+  icon: 'ability_warlock_haunt',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const SUMMON_DARKGLARE_AFFLICTION_TALENT: Talent = {
+  id: 205180,
+  name: 'Summon Darkglare',
+  icon: 'inv_beholderwarlock',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const SOUL_ROT_AFFLICTION_TALENT: Talent = {
+  id: 386997,
+  name: 'Soul Rot',
+  icon: 'ability_ardenweald_warlock',
+  maxRanks: 1,
+  manaCost: 0,
+};
+export const MALEFIC_AFFLICTION_AFFLICTION_TALENT: Talent = {
+  id: 389761,
+  name: 'Malefic Affliction',
+  icon: 'spell_shadow_unstableaffliction_3_purple',
+  maxRanks: 2,
+};
+export const CALAMITOUS_CRESCENDO_AFFLICTION_TALENT: Talent = {
+  id: 387075,
+  name: 'Calamitous Crescendo',
+  icon: 'spell_warlock_soulburn',
+  maxRanks: 1,
+};
+export const SEIZED_VITALITY_AFFLICTION_TALENT: Talent = {
+  id: 387250,
+  name: 'Seized Vitality',
+  icon: 'spell_shadow_skull',
+  maxRanks: 2,
+};
+export const ANTORAN_PLATING_AFFLICTION_TALENT: Talent = {
+  id: 387273,
+  name: 'Antoran Plating',
+  icon: 'inv_antorus_grey',
+  maxRanks: 2,
+};
+export const WRATH_OF_CONSUMPTION_AFFLICTION_TALENT: Talent = {
+  id: 387065,
+  name: 'Wrath of Consumption',
+  icon: 'spell_nature_drowsy',
+  maxRanks: 1,
+};
+export const SOUL_EATERS_GLUTTONY_AFFLICTION_TALENT: Talent = {
+  id: 389630,
+  name: "Soul-Eater's Gluttony",
+  icon: 'ability_bossgorefiend_gorefiendscorruption',
+  maxRanks: 2,
+};
+export const DOOM_BLOSSOM_AFFLICTION_TALENT: Talent = {
+  id: 389764,
+  name: 'Doom Blossom',
+  icon: 'ability_xavius_corruptingnova',
+  maxRanks: 1,
+};
+export const DREAD_TOUCH_AFFLICTION_TALENT: Talent = {
+  id: 389775,
+  name: 'Dread Touch',
+  icon: 'ability_priest_touchofdecay',
+  maxRanks: 1,
+};
+export const HAUNTED_SOUL_AFFLICTION_TALENT: Talent = {
+  id: 387301,
+  name: 'Haunted Soul',
+  icon: 'spell_warlock_soulburn_haunt',
+  maxRanks: 1,
+};
+export const WILFREDS_SIGIL_OF_SUPERIOR_SUMMONING_AFFLICTION_TALENT: Talent = {
+  id: 337020,
+  name: "Wilfred's Sigil of Superior Summoning",
+  icon: 'spell_warlock_demonicportal_purple',
+  maxRanks: 1,
+};
+export const GRIM_REACH_AFFLICTION_TALENT: Talent = {
+  id: 389992,
+  name: 'Grim Reach',
+  icon: 'warlock_curse_shadow',
+  maxRanks: 1,
+};
+export const DECAYING_SOUL_SATCHEL_AFFLICTION_TALENT: Talent = {
+  id: 387016,
+  name: 'Decaying Soul Satchel',
+  icon: 'spell_misc_zandalari_council_soulswap',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Destruction
+export const CHAOS_BOLT_DESTRUCTION_TALENT: Talent = {
+  id: 116858,
+  name: 'Chaos Bolt',
+  icon: 'ability_warlock_chaosbolt',
+  maxRanks: 1,
+  soulShardsCost: 2,
+};
+export const CONFLAGRATE_DESTRUCTION_TALENT: Talent = {
+  id: 17962,
+  name: 'Conflagrate',
+  icon: 'spell_fire_fireball',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const REVERSE_ENTROPY_DESTRUCTION_TALENT: Talent = {
+  id: 205148,
+  name: 'Reverse Entropy',
+  icon: 'spell_fire_playingwithfiregreen',
+  maxRanks: 1,
+};
+export const INTERNAL_COMBUSTION_DESTRUCTION_TALENT: Talent = {
+  id: 266134,
+  name: 'Internal Combustion',
+  icon: 'ability_mage_livingbomb',
+  maxRanks: 1,
+};
+export const RAIN_OF_FIRE_DESTRUCTION_TALENT: Talent = {
+  id: 5740,
+  name: 'Rain of Fire',
+  icon: 'spell_shadow_rainoffire',
+  maxRanks: 1,
+  soulShardsCost: 3,
+};
+export const BACKDRAFT_DESTRUCTION_TALENT: Talent = {
+  id: 196406,
+  name: 'Backdraft',
+  icon: 'ability_warlock_backdraft',
+  maxRanks: 1,
+};
+export const MAYHEM_NYI_DESTRUCTION_TALENT: Talent = {
+  id: 387506,
+  name: 'Mayhem [NYI]',
+  icon: 'spell_warlock_demonbolt',
+  maxRanks: 1,
+};
+export const HAVOC_DESTRUCTION_TALENT: Talent = {
+  id: 80240,
+  name: 'Havoc',
+  icon: 'ability_warlock_baneofhavoc',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const PYROGENICS_DESTRUCTION_TALENT: Talent = {
+  id: 387095,
+  name: 'Pyrogenics',
+  icon: 'inv_jewelry_ring_65',
+  maxRanks: 1,
+};
+export const ROARING_BLAZE_DESTRUCTION_TALENT: Talent = {
+  id: 205184,
+  name: 'Roaring Blaze',
+  icon: 'ability_warlock_inferno',
+  maxRanks: 1,
+};
+export const IMPROVED_CONFLAGRATE_DESTRUCTION_TALENT: Talent = {
+  id: 231793,
+  name: 'Improved Conflagrate',
+  icon: 'spell_fire_fireball',
+  maxRanks: 1,
+};
+export const EXPLOSIVE_POTENTIAL_DESTRUCTION_TALENT: Talent = {
+  id: 388827,
+  name: 'Explosive Potential',
+  icon: 'spell_fire_felflamering_red',
+  maxRanks: 1,
+};
+export const CHANNEL_DEMONFIRE_DESTRUCTION_TALENT: Talent = {
+  id: 196447,
+  name: 'Channel Demonfire',
+  icon: 'spell_fire_ragnaros_lavaboltgreen',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const PANDEMONIUM_DESTRUCTION_TALENT: Talent = {
+  id: 387509,
+  name: 'Pandemonium',
+  icon: 'ability_ironmaidens_whirlofblood',
+  maxRanks: 1,
+};
+export const CRY_HAVOC_DESTRUCTION_TALENT: Talent = {
+  id: 387522,
+  name: 'Cry Havoc',
+  icon: 'inv_offhand_1h_artifactskulloferedar_d_05',
+  maxRanks: 1,
+};
+export const IMPROVED_IMMOLATE_DESTRUCTION_TALENT: Talent = {
+  id: 387093,
+  name: 'Improved Immolate',
+  icon: 'spell_fire_immolation',
+  maxRanks: 2,
+};
+export const INFERNO_DESTRUCTION_TALENT: Talent = {
+  id: 270545,
+  name: 'Inferno',
+  icon: 'spell_shadow_rainoffire',
+  maxRanks: 1,
+};
+export const CATACLYSM_DESTRUCTION_TALENT: Talent = {
+  id: 152108,
+  name: 'Cataclysm',
+  icon: 'achievement_zone_cataclysm',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const SOUL_FIRE_DESTRUCTION_TALENT: Talent = {
+  id: 6353,
+  name: 'Soul Fire',
+  icon: 'spell_fire_firebolt',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const SHADOWBURN_DESTRUCTION_TALENT: Talent = {
+  id: 17877,
+  name: 'Shadowburn',
+  icon: 'spell_shadow_scourgebuild',
+  maxRanks: 1,
+  soulShardsCost: 1,
+};
+export const RAGING_DEMONFIRE_DESTRUCTION_TALENT: Talent = {
+  id: 387166,
+  name: 'Raging Demonfire',
+  icon: 'spell_fire_ragnaros_lavaboltgreen',
+  maxRanks: 2,
+};
+export const ROLLING_HAVOC_DESTRUCTION_TALENT: Talent = {
+  id: 387569,
+  name: 'Rolling Havoc',
+  icon: 'warlock_pvp_banehavoc',
+  maxRanks: 2,
+};
+export const BACKLASH_DESTRUCTION_TALENT: Talent = {
+  id: 387384,
+  name: 'Backlash',
+  icon: 'spell_fire_playingwithfire',
+  maxRanks: 1,
+};
+export const FIRE_AND_BRIMSTONE_DESTRUCTION_TALENT: Talent = {
+  id: 196408,
+  name: 'Fire and Brimstone',
+  icon: 'ability_warlock_fireandbrimstone',
+  maxRanks: 2,
+};
+export const DECIMATION_DESTRUCTION_TALENT: Talent = {
+  id: 387176,
+  name: 'Decimation',
+  icon: 'spell_fire_firebolt',
+  maxRanks: 1,
+};
+export const CONFLAGRATION_OF_CHAOS_DESTRUCTION_TALENT: Talent = {
+  id: 387108,
+  name: 'Conflagration of Chaos',
+  icon: 'spell_shadow_scourgebuild',
+  maxRanks: 2,
+};
+export const FLASHPOINT_DESTRUCTION_TALENT: Talent = {
+  id: 387259,
+  name: 'Flashpoint',
+  icon: 'spell_fire_moltenblood',
+  maxRanks: 2,
+};
+export const SCALDING_FLAMES_DESTRUCTION_TALENT: Talent = {
+  id: 388832,
+  name: 'Scalding Flames',
+  icon: 'spell_burningsoul',
+  maxRanks: 2,
+};
+export const RUIN_DESTRUCTION_TALENT: Talent = {
+  id: 387103,
+  name: 'Ruin',
+  icon: 'spell_fire_fire',
+  maxRanks: 2,
+};
+export const ERADICATION_DESTRUCTION_TALENT: Talent = {
+  id: 196412,
+  name: 'Eradication',
+  icon: 'ability_warlock_eradication',
+  maxRanks: 2,
+};
+export const ASHEN_REMAINS_DESTRUCTION_TALENT: Talent = {
+  id: 387252,
+  name: 'Ashen Remains',
+  icon: 'inv_enchanting_dust',
+  maxRanks: 2,
+};
+export const GRIMOIRE_OF_SACRIFICE_DESTRUCTION_TALENT: Talent = {
+  id: 108503,
+  name: 'Grimoire of Sacrifice',
+  icon: 'warlock_grimoireofsacrifice',
+  maxRanks: 1,
+};
+export const SUMMON_INFERNAL_DESTRUCTION_TALENT: Talent = {
+  id: 1122,
+  name: 'Summon Infernal',
+  icon: 'spell_shadow_summoninfernal',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const EMBERS_OF_THE_DIABOLIC_DESTRUCTION_TALENT: Talent = {
+  id: 387173,
+  name: 'Embers of the Diabolic',
+  icon: 'inv_shoulder_robe_raidmage_j_01',
+  maxRanks: 1,
+};
+export const RITUAL_OF_RUIN_DESTRUCTION_TALENT: Talent = {
+  id: 387156,
+  name: 'Ritual of Ruin',
+  icon: 'spell_fire_twilightrainoffire',
+  maxRanks: 1,
+};
+export const CRASHING_CHAOS_DESTRUCTION_TALENT: Talent = {
+  id: 387355,
+  name: 'Crashing Chaos',
+  icon: 'inv_infernalmount',
+  maxRanks: 2,
+};
+export const INFERNAL_BRAND_DESTRUCTION_TALENT: Talent = {
+  id: 387475,
+  name: 'Infernal Brand',
+  icon: 'warlock_pvp_burninglegion',
+  maxRanks: 2,
+};
+export const POWER_OVERWHELMING_DESTRUCTION_TALENT: Talent = {
+  id: 387279,
+  name: 'Power Overwhelming',
+  icon: 'ability_warlock_improvedsoulleech',
+  maxRanks: 2,
+};
+export const MADNESS_OF_THE_AZJAQIR_DESTRUCTION_TALENT: Talent = {
+  id: 387400,
+  name: "Madness of the Azj'Aqir",
+  icon: 'inv_eyeofnzothpet',
+  maxRanks: 2,
+};
+export const MASTER_RITUALIST_DESTRUCTION_TALENT: Talent = {
+  id: 387165,
+  name: 'Master Ritualist',
+  icon: 'spell_warlock_focusshadow',
+  maxRanks: 2,
+};
+export const BURN_TO_ASHES_DESTRUCTION_TALENT: Talent = {
+  id: 387153,
+  name: 'Burn to Ashes',
+  icon: 'ability_racial_foregedinflames',
+  maxRanks: 2,
+};
+export const RAIN_OF_CHAOS_DESTRUCTION_TALENT: Talent = {
+  id: 266086,
+  name: 'Rain of Chaos',
+  icon: 'spell_fire_felrainoffire',
+  maxRanks: 1,
+};
+export const WILFREDS_SIGIL_OF_SUPERIOR_SUMMONING_DESTRUCTION_TALENT: Talent = {
+  id: 387084,
+  name: "Wilfred's Sigil of Superior Summoning",
+  icon: 'spell_warlock_demonicportal_purple',
+  maxRanks: 1,
+};
+export const CHAOS_INCARNATE_DESTRUCTION_TALENT: Talent = {
+  id: 387275,
+  name: 'Chaos Incarnate',
+  icon: 'spell_fire_felflamering',
+  maxRanks: 1,
+};
+export const DIMENSIONAL_RIFT_DESTRUCTION_TALENT: Talent = {
+  id: 387976,
+  name: 'Dimensional Rift',
+  icon: 'spell_warlock_demonicportal_purple',
+  maxRanks: 1,
+};
+export const AVATAR_OF_DESTRUCTION_DESTRUCTION_TALENT: Talent = {
+  id: 387159,
+  name: 'Avatar of Destruction',
+  icon: 'inv_infernalmountblue',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Demonology
+export const CALL_DREADSTALKERS_DEMONOLOGY_TALENT: Talent = {
+  id: 104316,
+  name: 'Call Dreadstalkers',
+  icon: 'spell_warlock_calldreadstalkers',
+  maxRanks: 1,
+  soulShardsCost: 2,
+};
+export const DEMONBOLT_DEMONOLOGY_TALENT: Talent = {
+  id: 264178,
+  name: 'Demonbolt',
+  icon: 'inv__demonbolt',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const DREADLASH_DEMONOLOGY_TALENT: Talent = {
+  id: 264078,
+  name: 'Dreadlash',
+  icon: 'spell_shadow_summonvoidwalker',
+  maxRanks: 1,
+};
+export const FEL_COMMANDO_DEMONOLOGY_TALENT: Talent = {
+  id: 386174,
+  name: 'Fel Commando',
+  icon: 'spell_warlock_summonwrathguard',
+  maxRanks: 1,
+};
+export const SHADOWS_BITE_DEMONOLOGY_TALENT: Talent = {
+  id: 387322,
+  name: "Shadow's Bite",
+  icon: 'spell_shadow_painspike',
+  maxRanks: 1,
+};
+export const SUMMON_VILEFIEND_DEMONOLOGY_TALENT: Talent = {
+  id: 264119,
+  name: 'Summon Vilefiend',
+  icon: 'inv_argusfelstalkermount',
+  maxRanks: 1,
+  soulShardsCost: 1,
+};
+export const SOUL_STRIKE_DEMONOLOGY_TALENT: Talent = {
+  id: 264057,
+  name: 'Soul Strike',
+  icon: 'inv_polearm_2h_fellord_04',
+  maxRanks: 1,
+};
+export const BILESCOURGE_BOMBERS_DEMONOLOGY_TALENT: Talent = {
+  id: 267211,
+  name: 'Bilescourge Bombers',
+  icon: 'ability_hunter_pet_bat',
+  maxRanks: 1,
+  soulShardsCost: 2,
+};
+export const DEMONIC_STRENGTH_DEMONOLOGY_TALENT: Talent = {
+  id: 267171,
+  name: 'Demonic Strength',
+  icon: 'ability_warlock_demonicempowerment',
+  maxRanks: 1,
+};
+export const FROM_THE_SHADOWS_DEMONOLOGY_TALENT: Talent = {
+  id: 267170,
+  name: 'From the Shadows',
+  icon: 'spell_warlock_calldreadstalkers',
+  maxRanks: 1,
+};
+export const IMPLOSION_DEMONOLOGY_TALENT: Talent = {
+  id: 196277,
+  name: 'Implosion',
+  icon: 'inv_implosion',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const BORNE_OF_BLOOD_DEMONOLOGY_TALENT: Talent = {
+  id: 386185,
+  name: 'Borne of Blood',
+  icon: 'ability_warlock_improveddemonictactics',
+  maxRanks: 1,
+};
+export const CARNIVOROUS_STALKERS_DEMONOLOGY_TALENT: Talent = {
+  id: 386194,
+  name: 'Carnivorous Stalkers',
+  icon: 'warlock_pvp_callfelhunter',
+  maxRanks: 1,
+};
+export const FEL_AND_STEEL_DEMONOLOGY_TALENT: Talent = {
+  id: 386200,
+  name: 'Fel and Steel',
+  icon: 'ability_creature_poison_01',
+  maxRanks: 1,
+};
+export const FEL_MIGHT_DEMONOLOGY_TALENT: Talent = {
+  id: 387338,
+  name: 'Fel Might',
+  icon: 'ability_bossfelmagnaron_hand',
+  maxRanks: 1,
+};
+export const POWER_SIPHON_DEMONOLOGY_TALENT: Talent = {
+  id: 264130,
+  name: 'Power Siphon',
+  icon: 'ability_warlock_backdraft',
+  maxRanks: 1,
+};
+export const INNER_DEMONS_DEMONOLOGY_TALENT: Talent = {
+  id: 267216,
+  name: 'Inner Demons',
+  icon: 'ability_warlock_eradication',
+  maxRanks: 2,
+};
+export const DEMONIC_CALLING_DEMONOLOGY_TALENT: Talent = {
+  id: 205145,
+  name: 'Demonic Calling',
+  icon: 'ability_warlock_impoweredimp',
+  maxRanks: 2,
+};
+export const GRIMOIRE_FELGUARD_DEMONOLOGY_TALENT: Talent = {
+  id: 111898,
+  name: 'Grimoire: Felguard',
+  icon: 'spell_shadow_summonfelguard',
+  maxRanks: 1,
+  soulShardsCost: 1,
+};
+export const BLOODBOUND_IMPS_DEMONOLOGY_TALENT: Talent = {
+  id: 387349,
+  name: 'Bloodbound Imps',
+  icon: 'inv_misc_skullfel_06',
+  maxRanks: 1,
+};
+export const GRIM_INQUISITORS_DREAD_CALLING_DEMONOLOGY_TALENT: Talent = {
+  id: 387391,
+  name: "Grim Inquisitor's Dread Calling",
+  icon: 'spell_warlock_calldreadstalkers',
+  maxRanks: 1,
+};
+export const DOOM_DEMONOLOGY_TALENT: Talent = {
+  id: 603,
+  name: 'Doom',
+  icon: 'spell_shadow_auraofdarkness',
+  maxRanks: 1,
+  manaCost: 500,
+};
+export const DEMONIC_METEOR_DEMONOLOGY_TALENT: Talent = {
+  id: 387396,
+  name: 'Demonic Meteor',
+  icon: 'ability_warlock_handofguldan',
+  maxRanks: 1,
+};
+export const FEL_SUNDER_DEMONOLOGY_TALENT: Talent = {
+  id: 387399,
+  name: 'Fel Sunder',
+  icon: 'ability_creature_felsunder',
+  maxRanks: 1,
+};
+export const BALESPIDERS_BURNING_CORE_DEMONOLOGY_TALENT: Talent = {
+  id: 387432,
+  name: "Balespider's Burning Core",
+  icon: 'inv_trinket_firelands_02',
+  maxRanks: 2,
+};
+export const IMP_GANG_BOSS_DEMONOLOGY_TALENT: Talent = {
+  id: 387445,
+  name: 'Imp Gang Boss',
+  icon: 'ability_warlock_empoweredimp',
+  maxRanks: 2,
+};
+export const KAZAAKS_FINAL_CURSE_DEMONOLOGY_TALENT: Talent = {
+  id: 387483,
+  name: "Kazaak's Final Curse",
+  icon: 'inv_feldreadravenmount',
+  maxRanks: 2,
+};
+export const RIPPED_THROUGH_THE_PORTAL_DEMONOLOGY_TALENT: Talent = {
+  id: 387485,
+  name: 'Ripped through the Portal',
+  icon: 'spell_shadow_summonfelhunter',
+  maxRanks: 2,
+};
+export const HOUNDMASTERS_GAMBIT_DEMONOLOGY_TALENT: Talent = {
+  id: 387488,
+  name: "Houndmaster's Gambit",
+  icon: 'achievement_boss_hellfire_fellord',
+  maxRanks: 2,
+};
+export const NETHER_PORTAL_DEMONOLOGY_TALENT: Talent = {
+  id: 267217,
+  name: 'Nether Portal',
+  icon: 'inv_netherportal',
+  maxRanks: 1,
+  soulShardsCost: 1,
+};
+export const SUMMON_DEMONIC_TYRANT_DEMONOLOGY_TALENT: Talent = {
+  id: 265187,
+  name: 'Summon Demonic Tyrant',
+  icon: 'inv_summondemonictyrant',
+  maxRanks: 1,
+  manaCost: 1000,
+};
+export const ANTORAN_ARMAMENTS_DEMONOLOGY_TALENT: Talent = {
+  id: 387494,
+  name: 'Antoran Armaments',
+  icon: 'inv_axe_1h_felfireraid_d_01',
+  maxRanks: 1,
+};
+export const NERZHULS_VOLITION_DEMONOLOGY_TALENT: Talent = {
+  id: 387526,
+  name: "Ner'zhul's Volition",
+  icon: 'achievement_dungeon_shadowmoonhideout',
+  maxRanks: 2,
+};
+export const STOLEN_POWER_DEMONOLOGY_TALENT: Talent = {
+  id: 387602,
+  name: 'Stolen Power',
+  icon: 'ability_bossfelmagnaron_waveempowered',
+  maxRanks: 1,
+};
+export const SACRIFICED_SOULS_DEMONOLOGY_TALENT: Talent = {
+  id: 267214,
+  name: 'Sacrificed Souls',
+  icon: 'ability_creature_disease_05',
+  maxRanks: 2,
+};
+export const SOULBOUND_TYRANT_DEMONOLOGY_TALENT: Talent = {
+  id: 334585,
+  name: 'Soulbound Tyrant',
+  icon: 'inv_summondemonictyrant',
+  maxRanks: 2,
+};
+export const FORCES_OF_THE_HORNED_NIGHTMARE_DEMONOLOGY_TALENT: Talent = {
+  id: 387541,
+  name: 'Forces of the Horned Nightmare',
+  icon: 'ability_warlock_handofguldan',
+  maxRanks: 2,
+};
+export const THE_EXPENDABLES_DEMONOLOGY_TALENT: Talent = {
+  id: 387600,
+  name: 'The Expendables',
+  icon: 'ability_warlock_impoweredimp',
+  maxRanks: 1,
+};
+export const COMMAND_AURA_DEMONOLOGY_TALENT: Talent = {
+  id: 387549,
+  name: 'Command Aura',
+  icon: 'ability_bossdarkvindicator_auraofcontempt',
+  maxRanks: 2,
+};
+export const GULDANS_AMBITION_DEMONOLOGY_TALENT: Talent = {
+  id: 387578,
+  name: "Gul'dan's Ambition",
+  icon: 'achievement_dungeon_outland_dungeonmaster',
+  maxRanks: 1,
+};
+export const REIGN_OF_TYRANNY_DEMONOLOGY_TALENT: Talent = {
+  id: 390173,
+  name: 'Reign of Tyranny',
+  icon: 'ability_bossdarkvindicator_auraofoppression',
+  maxRanks: 1,
+};
+export const WILFREDS_SIGIL_OF_SUPERIOR_SUMMONING_DEMONOLOGY_TALENT: Talent = {
+  id: 337020,
+  name: "Wilfred's Sigil of Superior Summoning",
+  icon: 'spell_warlock_demonicportal_purple',
+  maxRanks: 1,
+};
+export const GUILLOTINE_DEMONOLOGY_TALENT: Talent = {
+  id: 386833,
+  name: 'Guillotine',
+  icon: 'inv_axe_2h_felfireraid_d_01',
+  maxRanks: 1,
+};
+
+//endregion
 
 const talents = createTalentList({
   //Shared
-  FEL_DOMINATION_TALENT: {
-    id: 333889,
-    name: 'Fel Domination',
-    icon: 'spell_shadow_felmending',
-    maxRanks: 1,
-  },
-  SPELL_LOCK_TALENT: { id: 19647, name: 'Spell Lock', icon: 'spell_shadow_mindrot', maxRanks: 1 },
-  BURNING_RUSH_TALENT: {
-    id: 111400,
-    name: 'Burning Rush',
-    icon: 'ability_deathwing_sealarmorbreachtga',
-    maxRanks: 1,
-  },
-  QUICK_FIENDS_TALENT: {
-    id: 386113,
-    name: 'Quick Fiends',
-    icon: 'spell_shadow_impphaseshift',
-    maxRanks: 2,
-  },
-  DEMON_SKIN_TALENT: {
-    id: 219272,
-    name: 'Demon Skin',
-    icon: 'spell_shadow_ragingscream',
-    maxRanks: 2,
-  },
-  FEL_ARMOR_TALENT: { id: 386124, name: 'Fel Armor', icon: 'spell_shadow_felarmour', maxRanks: 2 },
-  IMP_STEP_TALENT: { id: 386110, name: 'Imp Step', icon: 'inv_misc_moosehoof_fel', maxRanks: 2 },
-  CURSES_OF_ENFEEBLEMENT_TALENT: {
-    id: 386105,
-    name: 'Curses of Enfeeblement',
-    icon: 'ability_creature_cursed_02',
-    maxRanks: 1,
-  },
-  DEMONIC_CIRCLE_TALENT: {
-    id: 48018,
-    name: 'Demonic Circle',
-    icon: 'spell_shadow_demoniccirclesummon',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  HOWL_OF_TERROR_TALENT: {
-    id: 5484,
-    name: 'Howl of Terror',
-    icon: 'ability_warlock_howlofterror',
-    maxRanks: 1,
-  },
-  MORTAL_COIL_TALENT: {
-    id: 6789,
-    name: 'Mortal Coil',
-    icon: 'ability_warlock_mortalcoil',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  AMPLIFY_CURSE_TALENT: {
-    id: 328774,
-    name: 'Amplify Curse',
-    icon: 'spell_shadow_contagion',
-    maxRanks: 1,
-  },
-  DEMONIC_EMBRACE_TALENT: {
-    id: 288843,
-    name: 'Demonic Embrace',
-    icon: 'spell_shadow_metamorphosis',
-    maxRanks: 1,
-  },
-  DEMONIC_INSPIRATION_TALENT: {
-    id: 386858,
-    name: 'Demonic Inspiration',
-    icon: 'ability_warlock_demonicpower',
-    maxRanks: 1,
-  },
-  ABYSS_WALKER_TALENT: {
-    id: 389609,
-    name: 'Abyss Walker',
-    icon: 'achievement_explore_argus',
-    maxRanks: 1,
-  },
-  WRATHFUL_MINION_TALENT: {
-    id: 386864,
-    name: 'Wrathful Minion',
-    icon: 'spell_fel_incinerate',
-    maxRanks: 1,
-  },
-  DEMONIC_FORTITUDE_TALENT: {
-    id: 386617,
-    name: 'Demonic Fortitude',
-    icon: 'spell_warlock_summonimpoutland',
-    maxRanks: 1,
-  },
-  BANISH_TALENT: {
-    id: 710,
-    name: 'Banish',
-    icon: 'spell_shadow_cripple',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  FOUL_MOUTH_TALENT: {
-    id: 387972,
-    name: 'Foul Mouth',
-    icon: 'spell_shadow_carrionswarm',
-    maxRanks: 1,
-  },
-  DESPERATE_POWER_TALENT: {
-    id: 386619,
-    name: 'Desperate Power',
-    icon: 'spell_shadow_lifedrain02',
-    maxRanks: 2,
-  },
-  SWEET_SOULS_TALENT: {
-    id: 386620,
-    name: 'Sweet Souls',
-    icon: 'spell_shadow_soulleech',
-    maxRanks: 1,
-  },
-  GOREFIENDS_RESOLVE_TALENT: {
-    id: 389623,
-    name: "Gorefiend's Resolve",
-    icon: 'inv_helmet_90',
-    maxRanks: 2,
-  },
-  DEMONIC_GATEWAY_TALENT: {
-    id: 111771,
-    name: 'Demonic Gateway',
-    icon: 'spell_warlock_demonicportal_green',
-    maxRanks: 1,
-    manaCost: 10000,
-  },
-  NIGHTMARE_TALENT: { id: 386648, name: 'Nightmare', icon: 'spell_shadow_possession', maxRanks: 2 },
-  GREATER_BANISH_TALENT: {
-    id: 386651,
-    name: 'Greater Banish',
-    icon: 'spell_shadow_cripple',
-    maxRanks: 1,
-  },
-  DARK_PACT_TALENT: { id: 108416, name: 'Dark Pact', icon: 'spell_shadow_deathpact', maxRanks: 1 },
-  STRENGTH_OF_WILL_TALENT: {
-    id: 317138,
-    name: 'Strength of Will',
-    icon: 'spell_shadow_demonictactics',
-    maxRanks: 1,
-  },
-  DEMONIC_DURABILITY_TALENT: {
-    id: 386659,
-    name: 'Demonic Durability',
-    icon: 'ability_warlock_improveddemonictactics',
-    maxRanks: 1,
-  },
-  SHADOWFURY_TALENT: {
-    id: 30283,
-    name: 'Shadowfury',
-    icon: 'ability_warlock_shadowfurytga',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  ICHOR_OF_DEVILS_TALENT: {
-    id: 386664,
-    name: 'Ichor of Devils',
-    icon: 'spell_yorsahj_bloodboil_greenoil',
-    maxRanks: 1,
-  },
-  FREQUENT_DONOR_TALENT: {
-    id: 386686,
-    name: 'Frequent Donor',
-    icon: 'ability_ironmaidens_bloodritual',
-    maxRanks: 1,
-  },
-  ACCRUED_VITALITY_TALENT: {
-    id: 386613,
-    name: 'Accrued Vitality',
-    icon: 'spell_shadow_lifedrain',
-    maxRanks: 2,
-  },
-  LIFEBLOOD_TALENT: { id: 386646, name: 'Lifeblood', icon: 'warlock__healthstone', maxRanks: 2 },
-  DARKFURY_TALENT: {
-    id: 264874,
-    name: 'Darkfury',
-    icon: 'ability_warlock_shadowfurytga',
-    maxRanks: 1,
-  },
-  SHADOWFLAME_TALENT: {
-    id: 384069,
-    name: 'Shadowflame',
-    icon: 'ability_warlock_shadowflame',
-    maxRanks: 1,
-  },
-  FEL_SYNERGY_TALENT: {
-    id: 389367,
-    name: 'Fel Synergy',
-    icon: 'inv_sword_1h_felfireraid_d_01',
-    maxRanks: 1,
-  },
-  SOUL_LINK_TALENT: {
-    id: 108415,
-    name: 'Soul Link',
-    icon: 'ability_warlock_soullink',
-    maxRanks: 1,
-  },
-  TEACHINGS_OF_THE_BLACK_HARVEST_TALENT: {
-    id: 385881,
-    name: 'Teachings of the Black Harvest',
-    icon: 'inv_misc_codexofxerrath_nochains',
-    maxRanks: 1,
-  },
-  RESOLUTE_BARRIER_TALENT: {
-    id: 389359,
-    name: 'Resolute Barrier',
-    icon: 'inv_shield_1h_demonweapon_c_01',
-    maxRanks: 2,
-  },
-  GRIMOIRE_OF_SYNERGY_TALENT: {
-    id: 171975,
-    name: 'Grimoire of Synergy',
-    icon: 'warlock_grimoireofsacrifice',
-    maxRanks: 2,
-  },
-  SOUL_ARMOR_TALENT: {
-    id: 389576,
-    name: 'Soul Armor',
-    icon: 'ability_argus_deathfog',
-    maxRanks: 2,
-  },
-  SOUL_CONDUIT_TALENT: {
-    id: 215941,
-    name: 'Soul Conduit',
-    icon: 'spell_shadow_soulleech_2',
-    maxRanks: 2,
-  },
-  DEMONIC_RESILIENCE_TALENT: {
-    id: 389590,
-    name: 'Demonic Resilience',
-    icon: 'ability_warlock_avoidance',
-    maxRanks: 2,
-  },
-  CLAW_OF_ENDERETH_TALENT: {
-    id: 386689,
-    name: 'Claw of Endereth',
-    icon: 'inv_flaming_splinter',
-    maxRanks: 1,
-  },
-  SUMMON_SOULKEEPER_TALENT: {
-    id: 386244,
-    name: 'Summon Soulkeeper',
-    icon: 'spell_fel_elementaldevastation',
-    maxRanks: 1,
-  },
-  INQUISITORS_GAZE_TALENT: {
-    id: 386344,
-    name: "Inquisitor's Gaze",
-    icon: 'inv_pet_inquisitoreye',
-    maxRanks: 1,
-  },
-  SOULBURN_TALENT: {
-    id: 385899,
-    name: 'Soulburn',
-    icon: 'spell_warlock_soulburn',
-    maxRanks: 1,
-    soulShardsCost: 1,
-  },
+  FEL_DOMINATION_TALENT,
+  SPELL_LOCK_TALENT,
+  BURNING_RUSH_TALENT,
+  QUICK_FIENDS_TALENT,
+  DEMON_SKIN_TALENT,
+  FEL_ARMOR_TALENT,
+  IMP_STEP_TALENT,
+  CURSES_OF_ENFEEBLEMENT_TALENT,
+  DEMONIC_CIRCLE_TALENT,
+  HOWL_OF_TERROR_TALENT,
+  MORTAL_COIL_TALENT,
+  AMPLIFY_CURSE_TALENT,
+  DEMONIC_EMBRACE_TALENT,
+  DEMONIC_INSPIRATION_TALENT,
+  ABYSS_WALKER_TALENT,
+  WRATHFUL_MINION_TALENT,
+  DEMONIC_FORTITUDE_TALENT,
+  BANISH_TALENT,
+  FOUL_MOUTH_TALENT,
+  DESPERATE_POWER_TALENT,
+  SWEET_SOULS_TALENT,
+  GOREFIENDS_RESOLVE_TALENT,
+  DEMONIC_GATEWAY_TALENT,
+  NIGHTMARE_TALENT,
+  GREATER_BANISH_TALENT,
+  DARK_PACT_TALENT,
+  STRENGTH_OF_WILL_TALENT,
+  DEMONIC_DURABILITY_TALENT,
+  SHADOWFURY_TALENT,
+  ICHOR_OF_DEVILS_TALENT,
+  FREQUENT_DONOR_TALENT,
+  ACCRUED_VITALITY_TALENT,
+  LIFEBLOOD_TALENT,
+  DARKFURY_TALENT,
+  SHADOWFLAME_TALENT,
+  FEL_SYNERGY_TALENT,
+  SOUL_LINK_TALENT,
+  TEACHINGS_OF_THE_BLACK_HARVEST_TALENT,
+  RESOLUTE_BARRIER_TALENT,
+  GRIMOIRE_OF_SYNERGY_TALENT,
+  SOUL_ARMOR_TALENT,
+  SOUL_CONDUIT_TALENT,
+  DEMONIC_RESILIENCE_TALENT,
+  CLAW_OF_ENDERETH_TALENT,
+  SUMMON_SOULKEEPER_TALENT,
+  INQUISITORS_GAZE_TALENT,
+  SOULBURN_TALENT,
 
   //Affliction
-  MALEFIC_RAPTURE_AFFLICTION_TALENT: {
-    id: 324536,
-    name: 'Malefic Rapture',
-    icon: 'ability_warlock_everlastingaffliction',
-    maxRanks: 1,
-    soulShardsCost: 1,
-  },
-  UNSTABLE_AFFLICTION_AFFLICTION_TALENT: {
-    id: 316099,
-    name: 'Unstable Affliction',
-    icon: 'spell_shadow_unstableaffliction_3',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  SEED_OF_CORRUPTION_AFFLICTION_TALENT: {
-    id: 27243,
-    name: 'Seed of Corruption',
-    icon: 'spell_shadow_seedofdestruction',
-    maxRanks: 1,
-    soulShardsCost: 1,
-  },
-  NIGHTFALL_AFFLICTION_TALENT: {
-    id: 108558,
-    name: 'Nightfall',
-    icon: 'spell_shadow_twilight',
-    maxRanks: 1,
-  },
-  XAVIAN_TEACHINGS_AFFLICTION_TALENT: {
-    id: 317031,
-    name: 'Xavian Teachings',
-    icon: 'spell_shadow_abominationexplosion',
-    maxRanks: 1,
-  },
-  SOW_THE_SEEDS_AFFLICTION_TALENT: {
-    id: 196226,
-    name: 'Sow the Seeds',
-    icon: 'spell_shadow_seedofdestruction',
-    maxRanks: 1,
-  },
-  SHADOW_EMBRACE_AFFLICTION_TALENT: {
-    id: 32388,
-    name: 'Shadow Embrace',
-    icon: 'spell_shadow_shadowembrace',
-    maxRanks: 2,
-  },
-  HARVESTER_OF_SOULS_AFFLICTION_TALENT: {
-    id: 201424,
-    name: 'Harvester of Souls',
-    icon: 'warlock_spelldrain',
-    maxRanks: 2,
-  },
-  WRITHE_IN_AGONY_AFFLICTION_TALENT: {
-    id: 196102,
-    name: 'Writhe in Agony',
-    icon: 'spell_shadow_curseofsargeras',
-    maxRanks: 2,
-  },
-  AGONIZING_CORRUPTION_AFFLICTION_TALENT: {
-    id: 386922,
-    name: 'Agonizing Corruption',
-    icon: 'spell_warlock_darkregeneration',
-    maxRanks: 2,
-  },
-  DRAIN_SOUL_AFFLICTION_TALENT: {
-    id: 388667,
-    name: 'Drain Soul',
-    icon: 'spell_shadow_haunting',
-    maxRanks: 1,
-  },
-  SIPHON_LIFE_AFFLICTION_TALENT: {
-    id: 63106,
-    name: 'Siphon Life',
-    icon: 'spell_shadow_requiem',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  ABSOLUTE_CORRUPTION_AFFLICTION_TALENT: {
-    id: 196103,
-    name: 'Absolute Corruption',
-    icon: 'ability_bossmannoroth_empoweredmannorothsgaze',
-    maxRanks: 1,
-  },
-  PHANTOM_SINGULARITY_AFFLICTION_TALENT: {
-    id: 205179,
-    name: 'Phantom Singularity',
-    icon: 'inv_enchant_voidsphere',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  VILE_TAINT_AFFLICTION_TALENT: {
-    id: 278350,
-    name: 'Vile Taint',
-    icon: 'sha_spell_shadow_shadesofdarkness_nightborne',
-    maxRanks: 1,
-    soulShardsCost: 1,
-  },
-  SOUL_TAP_AFFLICTION_TALENT: {
-    id: 387073,
-    name: 'Soul Tap',
-    icon: 'spell_shadow_burningspirit',
-    maxRanks: 1,
-  },
-  INEVITABLE_DEMISE_AFFLICTION_TALENT: {
-    id: 334319,
-    name: 'Inevitable Demise',
-    icon: 'spell_warlock_harvestoflife',
-    maxRanks: 2,
-  },
-  SOUL_SWAP_AFFLICTION_TALENT: {
-    id: 386951,
-    name: 'Soul Swap',
-    icon: 'ability_warlock_soulswap',
-    maxRanks: 1,
-    soulShardsCost: 1,
-  },
-  SOUL_FLAME_AFFLICTION_TALENT: {
-    id: 199471,
-    name: 'Soul Flame',
-    icon: 'ability_argus_soulburst',
-    maxRanks: 2,
-  },
-  GRIMOIRE_OF_SACRIFICE_AFFLICTION_TALENT: {
-    id: 108503,
-    name: 'Grimoire of Sacrifice',
-    icon: 'warlock_grimoireofsacrifice',
-    maxRanks: 1,
-  },
-  PANDEMIC_INVOCATION_AFFLICTION_TALENT: {
-    id: 386759,
-    name: 'Pandemic Invocation',
-    icon: 'spell_shadow_unsummonbuilding',
-    maxRanks: 2,
-  },
-  WITHERING_BOLT_AFFLICTION_TALENT: {
-    id: 386976,
-    name: 'Withering Bolt',
-    icon: 'spell_shadow_shadowbolt',
-    maxRanks: 2,
-  },
-  SACROLASHS_DARK_STRIKE_AFFLICTION_TALENT: {
-    id: 386986,
-    name: "Sacrolash's Dark Strike",
-    icon: 'spell_nzinsanity_fearofdeath',
-    maxRanks: 2,
-  },
-  CREEPING_DEATH_AFFLICTION_TALENT: {
-    id: 264000,
-    name: 'Creeping Death',
-    icon: 'ability_creature_cursed_03',
-    maxRanks: 1,
-  },
-  HAUNT_AFFLICTION_TALENT: {
-    id: 48181,
-    name: 'Haunt',
-    icon: 'ability_warlock_haunt',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  SUMMON_DARKGLARE_AFFLICTION_TALENT: {
-    id: 205180,
-    name: 'Summon Darkglare',
-    icon: 'inv_beholderwarlock',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  SOUL_ROT_AFFLICTION_TALENT: {
-    id: 386997,
-    name: 'Soul Rot',
-    icon: 'ability_ardenweald_warlock',
-    maxRanks: 1,
-    manaCost: 0,
-  },
-  MALEFIC_AFFLICTION_AFFLICTION_TALENT: {
-    id: 389761,
-    name: 'Malefic Affliction',
-    icon: 'spell_shadow_unstableaffliction_3_purple',
-    maxRanks: 2,
-  },
-  CALAMITOUS_CRESCENDO_AFFLICTION_TALENT: {
-    id: 387075,
-    name: 'Calamitous Crescendo',
-    icon: 'spell_warlock_soulburn',
-    maxRanks: 1,
-  },
-  SEIZED_VITALITY_AFFLICTION_TALENT: {
-    id: 387250,
-    name: 'Seized Vitality',
-    icon: 'spell_shadow_skull',
-    maxRanks: 2,
-  },
-  ANTORAN_PLATING_AFFLICTION_TALENT: {
-    id: 387273,
-    name: 'Antoran Plating',
-    icon: 'inv_antorus_grey',
-    maxRanks: 2,
-  },
-  WRATH_OF_CONSUMPTION_AFFLICTION_TALENT: {
-    id: 387065,
-    name: 'Wrath of Consumption',
-    icon: 'spell_nature_drowsy',
-    maxRanks: 1,
-  },
-  SOUL_EATERS_GLUTTONY_AFFLICTION_TALENT: {
-    id: 389630,
-    name: "Soul-Eater's Gluttony",
-    icon: 'ability_bossgorefiend_gorefiendscorruption',
-    maxRanks: 2,
-  },
-  DOOM_BLOSSOM_AFFLICTION_TALENT: {
-    id: 389764,
-    name: 'Doom Blossom',
-    icon: 'ability_xavius_corruptingnova',
-    maxRanks: 1,
-  },
-  DREAD_TOUCH_AFFLICTION_TALENT: {
-    id: 389775,
-    name: 'Dread Touch',
-    icon: 'ability_priest_touchofdecay',
-    maxRanks: 1,
-  },
-  HAUNTED_SOUL_AFFLICTION_TALENT: {
-    id: 387301,
-    name: 'Haunted Soul',
-    icon: 'spell_warlock_soulburn_haunt',
-    maxRanks: 1,
-  },
-  WILFREDS_SIGIL_OF_SUPERIOR_SUMMONING_AFFLICTION_TALENT: {
-    id: 337020,
-    name: "Wilfred's Sigil of Superior Summoning",
-    icon: 'spell_warlock_demonicportal_purple',
-    maxRanks: 1,
-  },
-  GRIM_REACH_AFFLICTION_TALENT: {
-    id: 389992,
-    name: 'Grim Reach',
-    icon: 'warlock_curse_shadow',
-    maxRanks: 1,
-  },
-  DECAYING_SOUL_SATCHEL_AFFLICTION_TALENT: {
-    id: 387016,
-    name: 'Decaying Soul Satchel',
-    icon: 'spell_misc_zandalari_council_soulswap',
-    maxRanks: 1,
-  },
+  MALEFIC_RAPTURE_AFFLICTION_TALENT,
+  UNSTABLE_AFFLICTION_AFFLICTION_TALENT,
+  SEED_OF_CORRUPTION_AFFLICTION_TALENT,
+  NIGHTFALL_AFFLICTION_TALENT,
+  XAVIAN_TEACHINGS_AFFLICTION_TALENT,
+  SOW_THE_SEEDS_AFFLICTION_TALENT,
+  SHADOW_EMBRACE_AFFLICTION_TALENT,
+  HARVESTER_OF_SOULS_AFFLICTION_TALENT,
+  WRITHE_IN_AGONY_AFFLICTION_TALENT,
+  AGONIZING_CORRUPTION_AFFLICTION_TALENT,
+  DRAIN_SOUL_AFFLICTION_TALENT,
+  SIPHON_LIFE_AFFLICTION_TALENT,
+  ABSOLUTE_CORRUPTION_AFFLICTION_TALENT,
+  PHANTOM_SINGULARITY_AFFLICTION_TALENT,
+  VILE_TAINT_AFFLICTION_TALENT,
+  SOUL_TAP_AFFLICTION_TALENT,
+  INEVITABLE_DEMISE_AFFLICTION_TALENT,
+  SOUL_SWAP_AFFLICTION_TALENT,
+  SOUL_FLAME_AFFLICTION_TALENT,
+  GRIMOIRE_OF_SACRIFICE_AFFLICTION_TALENT,
+  PANDEMIC_INVOCATION_AFFLICTION_TALENT,
+  WITHERING_BOLT_AFFLICTION_TALENT,
+  SACROLASHS_DARK_STRIKE_AFFLICTION_TALENT,
+  CREEPING_DEATH_AFFLICTION_TALENT,
+  HAUNT_AFFLICTION_TALENT,
+  SUMMON_DARKGLARE_AFFLICTION_TALENT,
+  SOUL_ROT_AFFLICTION_TALENT,
+  MALEFIC_AFFLICTION_AFFLICTION_TALENT,
+  CALAMITOUS_CRESCENDO_AFFLICTION_TALENT,
+  SEIZED_VITALITY_AFFLICTION_TALENT,
+  ANTORAN_PLATING_AFFLICTION_TALENT,
+  WRATH_OF_CONSUMPTION_AFFLICTION_TALENT,
+  SOUL_EATERS_GLUTTONY_AFFLICTION_TALENT,
+  DOOM_BLOSSOM_AFFLICTION_TALENT,
+  DREAD_TOUCH_AFFLICTION_TALENT,
+  HAUNTED_SOUL_AFFLICTION_TALENT,
+  WILFREDS_SIGIL_OF_SUPERIOR_SUMMONING_AFFLICTION_TALENT,
+  GRIM_REACH_AFFLICTION_TALENT,
+  DECAYING_SOUL_SATCHEL_AFFLICTION_TALENT,
 
   //Destruction
-  CHAOS_BOLT_DESTRUCTION_TALENT: {
-    id: 116858,
-    name: 'Chaos Bolt',
-    icon: 'ability_warlock_chaosbolt',
-    maxRanks: 1,
-    soulShardsCost: 2,
-  },
-  CONFLAGRATE_DESTRUCTION_TALENT: {
-    id: 17962,
-    name: 'Conflagrate',
-    icon: 'spell_fire_fireball',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  REVERSE_ENTROPY_DESTRUCTION_TALENT: {
-    id: 205148,
-    name: 'Reverse Entropy',
-    icon: 'spell_fire_playingwithfiregreen',
-    maxRanks: 1,
-  },
-  INTERNAL_COMBUSTION_DESTRUCTION_TALENT: {
-    id: 266134,
-    name: 'Internal Combustion',
-    icon: 'ability_mage_livingbomb',
-    maxRanks: 1,
-  },
-  RAIN_OF_FIRE_DESTRUCTION_TALENT: {
-    id: 5740,
-    name: 'Rain of Fire',
-    icon: 'spell_shadow_rainoffire',
-    maxRanks: 1,
-    soulShardsCost: 3,
-  },
-  BACKDRAFT_DESTRUCTION_TALENT: {
-    id: 196406,
-    name: 'Backdraft',
-    icon: 'ability_warlock_backdraft',
-    maxRanks: 1,
-  },
-  MAYHEM_NYI_DESTRUCTION_TALENT: {
-    id: 387506,
-    name: 'Mayhem [NYI]',
-    icon: 'spell_warlock_demonbolt',
-    maxRanks: 1,
-  },
-  HAVOC_DESTRUCTION_TALENT: {
-    id: 80240,
-    name: 'Havoc',
-    icon: 'ability_warlock_baneofhavoc',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  PYROGENICS_DESTRUCTION_TALENT: {
-    id: 387095,
-    name: 'Pyrogenics',
-    icon: 'inv_jewelry_ring_65',
-    maxRanks: 1,
-  },
-  ROARING_BLAZE_DESTRUCTION_TALENT: {
-    id: 205184,
-    name: 'Roaring Blaze',
-    icon: 'ability_warlock_inferno',
-    maxRanks: 1,
-  },
-  IMPROVED_CONFLAGRATE_DESTRUCTION_TALENT: {
-    id: 231793,
-    name: 'Improved Conflagrate',
-    icon: 'spell_fire_fireball',
-    maxRanks: 1,
-  },
-  EXPLOSIVE_POTENTIAL_DESTRUCTION_TALENT: {
-    id: 388827,
-    name: 'Explosive Potential',
-    icon: 'spell_fire_felflamering_red',
-    maxRanks: 1,
-  },
-  CHANNEL_DEMONFIRE_DESTRUCTION_TALENT: {
-    id: 196447,
-    name: 'Channel Demonfire',
-    icon: 'spell_fire_ragnaros_lavaboltgreen',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  PANDEMONIUM_DESTRUCTION_TALENT: {
-    id: 387509,
-    name: 'Pandemonium',
-    icon: 'ability_ironmaidens_whirlofblood',
-    maxRanks: 1,
-  },
-  CRY_HAVOC_DESTRUCTION_TALENT: {
-    id: 387522,
-    name: 'Cry Havoc',
-    icon: 'inv_offhand_1h_artifactskulloferedar_d_05',
-    maxRanks: 1,
-  },
-  IMPROVED_IMMOLATE_DESTRUCTION_TALENT: {
-    id: 387093,
-    name: 'Improved Immolate',
-    icon: 'spell_fire_immolation',
-    maxRanks: 2,
-  },
-  INFERNO_DESTRUCTION_TALENT: {
-    id: 270545,
-    name: 'Inferno',
-    icon: 'spell_shadow_rainoffire',
-    maxRanks: 1,
-  },
-  CATACLYSM_DESTRUCTION_TALENT: {
-    id: 152108,
-    name: 'Cataclysm',
-    icon: 'achievement_zone_cataclysm',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  SOUL_FIRE_DESTRUCTION_TALENT: {
-    id: 6353,
-    name: 'Soul Fire',
-    icon: 'spell_fire_firebolt',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  SHADOWBURN_DESTRUCTION_TALENT: {
-    id: 17877,
-    name: 'Shadowburn',
-    icon: 'spell_shadow_scourgebuild',
-    maxRanks: 1,
-    soulShardsCost: 1,
-  },
-  RAGING_DEMONFIRE_DESTRUCTION_TALENT: {
-    id: 387166,
-    name: 'Raging Demonfire',
-    icon: 'spell_fire_ragnaros_lavaboltgreen',
-    maxRanks: 2,
-  },
-  ROLLING_HAVOC_DESTRUCTION_TALENT: {
-    id: 387569,
-    name: 'Rolling Havoc',
-    icon: 'warlock_pvp_banehavoc',
-    maxRanks: 2,
-  },
-  BACKLASH_DESTRUCTION_TALENT: {
-    id: 387384,
-    name: 'Backlash',
-    icon: 'spell_fire_playingwithfire',
-    maxRanks: 1,
-  },
-  FIRE_AND_BRIMSTONE_DESTRUCTION_TALENT: {
-    id: 196408,
-    name: 'Fire and Brimstone',
-    icon: 'ability_warlock_fireandbrimstone',
-    maxRanks: 2,
-  },
-  DECIMATION_DESTRUCTION_TALENT: {
-    id: 387176,
-    name: 'Decimation',
-    icon: 'spell_fire_firebolt',
-    maxRanks: 1,
-  },
-  CONFLAGRATION_OF_CHAOS_DESTRUCTION_TALENT: {
-    id: 387108,
-    name: 'Conflagration of Chaos',
-    icon: 'spell_shadow_scourgebuild',
-    maxRanks: 2,
-  },
-  FLASHPOINT_DESTRUCTION_TALENT: {
-    id: 387259,
-    name: 'Flashpoint',
-    icon: 'spell_fire_moltenblood',
-    maxRanks: 2,
-  },
-  SCALDING_FLAMES_DESTRUCTION_TALENT: {
-    id: 388832,
-    name: 'Scalding Flames',
-    icon: 'spell_burningsoul',
-    maxRanks: 2,
-  },
-  RUIN_DESTRUCTION_TALENT: { id: 387103, name: 'Ruin', icon: 'spell_fire_fire', maxRanks: 2 },
-  ERADICATION_DESTRUCTION_TALENT: {
-    id: 196412,
-    name: 'Eradication',
-    icon: 'ability_warlock_eradication',
-    maxRanks: 2,
-  },
-  ASHEN_REMAINS_DESTRUCTION_TALENT: {
-    id: 387252,
-    name: 'Ashen Remains',
-    icon: 'inv_enchanting_dust',
-    maxRanks: 2,
-  },
-  GRIMOIRE_OF_SACRIFICE_DESTRUCTION_TALENT: {
-    id: 108503,
-    name: 'Grimoire of Sacrifice',
-    icon: 'warlock_grimoireofsacrifice',
-    maxRanks: 1,
-  },
-  SUMMON_INFERNAL_DESTRUCTION_TALENT: {
-    id: 1122,
-    name: 'Summon Infernal',
-    icon: 'spell_shadow_summoninfernal',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  EMBERS_OF_THE_DIABOLIC_DESTRUCTION_TALENT: {
-    id: 387173,
-    name: 'Embers of the Diabolic',
-    icon: 'inv_shoulder_robe_raidmage_j_01',
-    maxRanks: 1,
-  },
-  RITUAL_OF_RUIN_DESTRUCTION_TALENT: {
-    id: 387156,
-    name: 'Ritual of Ruin',
-    icon: 'spell_fire_twilightrainoffire',
-    maxRanks: 1,
-  },
-  CRASHING_CHAOS_DESTRUCTION_TALENT: {
-    id: 387355,
-    name: 'Crashing Chaos',
-    icon: 'inv_infernalmount',
-    maxRanks: 2,
-  },
-  INFERNAL_BRAND_DESTRUCTION_TALENT: {
-    id: 387475,
-    name: 'Infernal Brand',
-    icon: 'warlock_pvp_burninglegion',
-    maxRanks: 2,
-  },
-  POWER_OVERWHELMING_DESTRUCTION_TALENT: {
-    id: 387279,
-    name: 'Power Overwhelming',
-    icon: 'ability_warlock_improvedsoulleech',
-    maxRanks: 2,
-  },
-  MADNESS_OF_THE_AZJAQIR_DESTRUCTION_TALENT: {
-    id: 387400,
-    name: "Madness of the Azj'Aqir",
-    icon: 'inv_eyeofnzothpet',
-    maxRanks: 2,
-  },
-  MASTER_RITUALIST_DESTRUCTION_TALENT: {
-    id: 387165,
-    name: 'Master Ritualist',
-    icon: 'spell_warlock_focusshadow',
-    maxRanks: 2,
-  },
-  BURN_TO_ASHES_DESTRUCTION_TALENT: {
-    id: 387153,
-    name: 'Burn to Ashes',
-    icon: 'ability_racial_foregedinflames',
-    maxRanks: 2,
-  },
-  RAIN_OF_CHAOS_DESTRUCTION_TALENT: {
-    id: 266086,
-    name: 'Rain of Chaos',
-    icon: 'spell_fire_felrainoffire',
-    maxRanks: 1,
-  },
-  WILFREDS_SIGIL_OF_SUPERIOR_SUMMONING_DESTRUCTION_TALENT: {
-    id: 387084,
-    name: "Wilfred's Sigil of Superior Summoning",
-    icon: 'spell_warlock_demonicportal_purple',
-    maxRanks: 1,
-  },
-  CHAOS_INCARNATE_DESTRUCTION_TALENT: {
-    id: 387275,
-    name: 'Chaos Incarnate',
-    icon: 'spell_fire_felflamering',
-    maxRanks: 1,
-  },
-  DIMENSIONAL_RIFT_DESTRUCTION_TALENT: {
-    id: 387976,
-    name: 'Dimensional Rift',
-    icon: 'spell_warlock_demonicportal_purple',
-    maxRanks: 1,
-  },
-  AVATAR_OF_DESTRUCTION_DESTRUCTION_TALENT: {
-    id: 387159,
-    name: 'Avatar of Destruction',
-    icon: 'inv_infernalmountblue',
-    maxRanks: 1,
-  },
+  CHAOS_BOLT_DESTRUCTION_TALENT,
+  CONFLAGRATE_DESTRUCTION_TALENT,
+  REVERSE_ENTROPY_DESTRUCTION_TALENT,
+  INTERNAL_COMBUSTION_DESTRUCTION_TALENT,
+  RAIN_OF_FIRE_DESTRUCTION_TALENT,
+  BACKDRAFT_DESTRUCTION_TALENT,
+  MAYHEM_NYI_DESTRUCTION_TALENT,
+  HAVOC_DESTRUCTION_TALENT,
+  PYROGENICS_DESTRUCTION_TALENT,
+  ROARING_BLAZE_DESTRUCTION_TALENT,
+  IMPROVED_CONFLAGRATE_DESTRUCTION_TALENT,
+  EXPLOSIVE_POTENTIAL_DESTRUCTION_TALENT,
+  CHANNEL_DEMONFIRE_DESTRUCTION_TALENT,
+  PANDEMONIUM_DESTRUCTION_TALENT,
+  CRY_HAVOC_DESTRUCTION_TALENT,
+  IMPROVED_IMMOLATE_DESTRUCTION_TALENT,
+  INFERNO_DESTRUCTION_TALENT,
+  CATACLYSM_DESTRUCTION_TALENT,
+  SOUL_FIRE_DESTRUCTION_TALENT,
+  SHADOWBURN_DESTRUCTION_TALENT,
+  RAGING_DEMONFIRE_DESTRUCTION_TALENT,
+  ROLLING_HAVOC_DESTRUCTION_TALENT,
+  BACKLASH_DESTRUCTION_TALENT,
+  FIRE_AND_BRIMSTONE_DESTRUCTION_TALENT,
+  DECIMATION_DESTRUCTION_TALENT,
+  CONFLAGRATION_OF_CHAOS_DESTRUCTION_TALENT,
+  FLASHPOINT_DESTRUCTION_TALENT,
+  SCALDING_FLAMES_DESTRUCTION_TALENT,
+  RUIN_DESTRUCTION_TALENT,
+  ERADICATION_DESTRUCTION_TALENT,
+  ASHEN_REMAINS_DESTRUCTION_TALENT,
+  GRIMOIRE_OF_SACRIFICE_DESTRUCTION_TALENT,
+  SUMMON_INFERNAL_DESTRUCTION_TALENT,
+  EMBERS_OF_THE_DIABOLIC_DESTRUCTION_TALENT,
+  RITUAL_OF_RUIN_DESTRUCTION_TALENT,
+  CRASHING_CHAOS_DESTRUCTION_TALENT,
+  INFERNAL_BRAND_DESTRUCTION_TALENT,
+  POWER_OVERWHELMING_DESTRUCTION_TALENT,
+  MADNESS_OF_THE_AZJAQIR_DESTRUCTION_TALENT,
+  MASTER_RITUALIST_DESTRUCTION_TALENT,
+  BURN_TO_ASHES_DESTRUCTION_TALENT,
+  RAIN_OF_CHAOS_DESTRUCTION_TALENT,
+  WILFREDS_SIGIL_OF_SUPERIOR_SUMMONING_DESTRUCTION_TALENT,
+  CHAOS_INCARNATE_DESTRUCTION_TALENT,
+  DIMENSIONAL_RIFT_DESTRUCTION_TALENT,
+  AVATAR_OF_DESTRUCTION_DESTRUCTION_TALENT,
 
   //Demonology
-  CALL_DREADSTALKERS_DEMONOLOGY_TALENT: {
-    id: 104316,
-    name: 'Call Dreadstalkers',
-    icon: 'spell_warlock_calldreadstalkers',
-    maxRanks: 1,
-    soulShardsCost: 2,
-  },
-  DEMONBOLT_DEMONOLOGY_TALENT: {
-    id: 264178,
-    name: 'Demonbolt',
-    icon: 'inv__demonbolt',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  DREADLASH_DEMONOLOGY_TALENT: {
-    id: 264078,
-    name: 'Dreadlash',
-    icon: 'spell_shadow_summonvoidwalker',
-    maxRanks: 1,
-  },
-  FEL_COMMANDO_DEMONOLOGY_TALENT: {
-    id: 386174,
-    name: 'Fel Commando',
-    icon: 'spell_warlock_summonwrathguard',
-    maxRanks: 1,
-  },
-  SHADOWS_BITE_DEMONOLOGY_TALENT: {
-    id: 387322,
-    name: "Shadow's Bite",
-    icon: 'spell_shadow_painspike',
-    maxRanks: 1,
-  },
-  SUMMON_VILEFIEND_DEMONOLOGY_TALENT: {
-    id: 264119,
-    name: 'Summon Vilefiend',
-    icon: 'inv_argusfelstalkermount',
-    maxRanks: 1,
-    soulShardsCost: 1,
-  },
-  SOUL_STRIKE_DEMONOLOGY_TALENT: {
-    id: 264057,
-    name: 'Soul Strike',
-    icon: 'inv_polearm_2h_fellord_04',
-    maxRanks: 1,
-  },
-  BILESCOURGE_BOMBERS_DEMONOLOGY_TALENT: {
-    id: 267211,
-    name: 'Bilescourge Bombers',
-    icon: 'ability_hunter_pet_bat',
-    maxRanks: 1,
-    soulShardsCost: 2,
-  },
-  DEMONIC_STRENGTH_DEMONOLOGY_TALENT: {
-    id: 267171,
-    name: 'Demonic Strength',
-    icon: 'ability_warlock_demonicempowerment',
-    maxRanks: 1,
-  },
-  FROM_THE_SHADOWS_DEMONOLOGY_TALENT: {
-    id: 267170,
-    name: 'From the Shadows',
-    icon: 'spell_warlock_calldreadstalkers',
-    maxRanks: 1,
-  },
-  IMPLOSION_DEMONOLOGY_TALENT: {
-    id: 196277,
-    name: 'Implosion',
-    icon: 'inv_implosion',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  BORNE_OF_BLOOD_DEMONOLOGY_TALENT: {
-    id: 386185,
-    name: 'Borne of Blood',
-    icon: 'ability_warlock_improveddemonictactics',
-    maxRanks: 1,
-  },
-  CARNIVOROUS_STALKERS_DEMONOLOGY_TALENT: {
-    id: 386194,
-    name: 'Carnivorous Stalkers',
-    icon: 'warlock_pvp_callfelhunter',
-    maxRanks: 1,
-  },
-  FEL_AND_STEEL_DEMONOLOGY_TALENT: {
-    id: 386200,
-    name: 'Fel and Steel',
-    icon: 'ability_creature_poison_01',
-    maxRanks: 1,
-  },
-  FEL_MIGHT_DEMONOLOGY_TALENT: {
-    id: 387338,
-    name: 'Fel Might',
-    icon: 'ability_bossfelmagnaron_hand',
-    maxRanks: 1,
-  },
-  POWER_SIPHON_DEMONOLOGY_TALENT: {
-    id: 264130,
-    name: 'Power Siphon',
-    icon: 'ability_warlock_backdraft',
-    maxRanks: 1,
-  },
-  INNER_DEMONS_DEMONOLOGY_TALENT: {
-    id: 267216,
-    name: 'Inner Demons',
-    icon: 'ability_warlock_eradication',
-    maxRanks: 2,
-  },
-  DEMONIC_CALLING_DEMONOLOGY_TALENT: {
-    id: 205145,
-    name: 'Demonic Calling',
-    icon: 'ability_warlock_impoweredimp',
-    maxRanks: 2,
-  },
-  GRIMOIRE_FELGUARD_DEMONOLOGY_TALENT: {
-    id: 111898,
-    name: 'Grimoire: Felguard',
-    icon: 'spell_shadow_summonfelguard',
-    maxRanks: 1,
-    soulShardsCost: 1,
-  },
-  BLOODBOUND_IMPS_DEMONOLOGY_TALENT: {
-    id: 387349,
-    name: 'Bloodbound Imps',
-    icon: 'inv_misc_skullfel_06',
-    maxRanks: 1,
-  },
-  GRIM_INQUISITORS_DREAD_CALLING_DEMONOLOGY_TALENT: {
-    id: 387391,
-    name: "Grim Inquisitor's Dread Calling",
-    icon: 'spell_warlock_calldreadstalkers',
-    maxRanks: 1,
-  },
-  DOOM_DEMONOLOGY_TALENT: {
-    id: 603,
-    name: 'Doom',
-    icon: 'spell_shadow_auraofdarkness',
-    maxRanks: 1,
-    manaCost: 500,
-  },
-  DEMONIC_METEOR_DEMONOLOGY_TALENT: {
-    id: 387396,
-    name: 'Demonic Meteor',
-    icon: 'ability_warlock_handofguldan',
-    maxRanks: 1,
-  },
-  FEL_SUNDER_DEMONOLOGY_TALENT: {
-    id: 387399,
-    name: 'Fel Sunder',
-    icon: 'ability_creature_felsunder',
-    maxRanks: 1,
-  },
-  BALESPIDERS_BURNING_CORE_DEMONOLOGY_TALENT: {
-    id: 387432,
-    name: "Balespider's Burning Core",
-    icon: 'inv_trinket_firelands_02',
-    maxRanks: 2,
-  },
-  IMP_GANG_BOSS_DEMONOLOGY_TALENT: {
-    id: 387445,
-    name: 'Imp Gang Boss',
-    icon: 'ability_warlock_empoweredimp',
-    maxRanks: 2,
-  },
-  KAZAAKS_FINAL_CURSE_DEMONOLOGY_TALENT: {
-    id: 387483,
-    name: "Kazaak's Final Curse",
-    icon: 'inv_feldreadravenmount',
-    maxRanks: 2,
-  },
-  RIPPED_THROUGH_THE_PORTAL_DEMONOLOGY_TALENT: {
-    id: 387485,
-    name: 'Ripped through the Portal',
-    icon: 'spell_shadow_summonfelhunter',
-    maxRanks: 2,
-  },
-  HOUNDMASTERS_GAMBIT_DEMONOLOGY_TALENT: {
-    id: 387488,
-    name: "Houndmaster's Gambit",
-    icon: 'achievement_boss_hellfire_fellord',
-    maxRanks: 2,
-  },
-  NETHER_PORTAL_DEMONOLOGY_TALENT: {
-    id: 267217,
-    name: 'Nether Portal',
-    icon: 'inv_netherportal',
-    maxRanks: 1,
-    soulShardsCost: 1,
-  },
-  SUMMON_DEMONIC_TYRANT_DEMONOLOGY_TALENT: {
-    id: 265187,
-    name: 'Summon Demonic Tyrant',
-    icon: 'inv_summondemonictyrant',
-    maxRanks: 1,
-    manaCost: 1000,
-  },
-  ANTORAN_ARMAMENTS_DEMONOLOGY_TALENT: {
-    id: 387494,
-    name: 'Antoran Armaments',
-    icon: 'inv_axe_1h_felfireraid_d_01',
-    maxRanks: 1,
-  },
-  NERZHULS_VOLITION_DEMONOLOGY_TALENT: {
-    id: 387526,
-    name: "Ner'zhul's Volition",
-    icon: 'achievement_dungeon_shadowmoonhideout',
-    maxRanks: 2,
-  },
-  STOLEN_POWER_DEMONOLOGY_TALENT: {
-    id: 387602,
-    name: 'Stolen Power',
-    icon: 'ability_bossfelmagnaron_waveempowered',
-    maxRanks: 1,
-  },
-  SACRIFICED_SOULS_DEMONOLOGY_TALENT: {
-    id: 267214,
-    name: 'Sacrificed Souls',
-    icon: 'ability_creature_disease_05',
-    maxRanks: 2,
-  },
-  SOULBOUND_TYRANT_DEMONOLOGY_TALENT: {
-    id: 334585,
-    name: 'Soulbound Tyrant',
-    icon: 'inv_summondemonictyrant',
-    maxRanks: 2,
-  },
-  FORCES_OF_THE_HORNED_NIGHTMARE_DEMONOLOGY_TALENT: {
-    id: 387541,
-    name: 'Forces of the Horned Nightmare',
-    icon: 'ability_warlock_handofguldan',
-    maxRanks: 2,
-  },
-  THE_EXPENDABLES_DEMONOLOGY_TALENT: {
-    id: 387600,
-    name: 'The Expendables',
-    icon: 'ability_warlock_impoweredimp',
-    maxRanks: 1,
-  },
-  COMMAND_AURA_DEMONOLOGY_TALENT: {
-    id: 387549,
-    name: 'Command Aura',
-    icon: 'ability_bossdarkvindicator_auraofcontempt',
-    maxRanks: 2,
-  },
-  GULDANS_AMBITION_DEMONOLOGY_TALENT: {
-    id: 387578,
-    name: "Gul'dan's Ambition",
-    icon: 'achievement_dungeon_outland_dungeonmaster',
-    maxRanks: 1,
-  },
-  REIGN_OF_TYRANNY_DEMONOLOGY_TALENT: {
-    id: 390173,
-    name: 'Reign of Tyranny',
-    icon: 'ability_bossdarkvindicator_auraofoppression',
-    maxRanks: 1,
-  },
-  WILFREDS_SIGIL_OF_SUPERIOR_SUMMONING_DEMONOLOGY_TALENT: {
-    id: 337020,
-    name: "Wilfred's Sigil of Superior Summoning",
-    icon: 'spell_warlock_demonicportal_purple',
-    maxRanks: 1,
-  },
-  GUILLOTINE_DEMONOLOGY_TALENT: {
-    id: 386833,
-    name: 'Guillotine',
-    icon: 'inv_axe_2h_felfireraid_d_01',
-    maxRanks: 1,
-  },
+  CALL_DREADSTALKERS_DEMONOLOGY_TALENT,
+  DEMONBOLT_DEMONOLOGY_TALENT,
+  DREADLASH_DEMONOLOGY_TALENT,
+  FEL_COMMANDO_DEMONOLOGY_TALENT,
+  SHADOWS_BITE_DEMONOLOGY_TALENT,
+  SUMMON_VILEFIEND_DEMONOLOGY_TALENT,
+  SOUL_STRIKE_DEMONOLOGY_TALENT,
+  BILESCOURGE_BOMBERS_DEMONOLOGY_TALENT,
+  DEMONIC_STRENGTH_DEMONOLOGY_TALENT,
+  FROM_THE_SHADOWS_DEMONOLOGY_TALENT,
+  IMPLOSION_DEMONOLOGY_TALENT,
+  BORNE_OF_BLOOD_DEMONOLOGY_TALENT,
+  CARNIVOROUS_STALKERS_DEMONOLOGY_TALENT,
+  FEL_AND_STEEL_DEMONOLOGY_TALENT,
+  FEL_MIGHT_DEMONOLOGY_TALENT,
+  POWER_SIPHON_DEMONOLOGY_TALENT,
+  INNER_DEMONS_DEMONOLOGY_TALENT,
+  DEMONIC_CALLING_DEMONOLOGY_TALENT,
+  GRIMOIRE_FELGUARD_DEMONOLOGY_TALENT,
+  BLOODBOUND_IMPS_DEMONOLOGY_TALENT,
+  GRIM_INQUISITORS_DREAD_CALLING_DEMONOLOGY_TALENT,
+  DOOM_DEMONOLOGY_TALENT,
+  DEMONIC_METEOR_DEMONOLOGY_TALENT,
+  FEL_SUNDER_DEMONOLOGY_TALENT,
+  BALESPIDERS_BURNING_CORE_DEMONOLOGY_TALENT,
+  IMP_GANG_BOSS_DEMONOLOGY_TALENT,
+  KAZAAKS_FINAL_CURSE_DEMONOLOGY_TALENT,
+  RIPPED_THROUGH_THE_PORTAL_DEMONOLOGY_TALENT,
+  HOUNDMASTERS_GAMBIT_DEMONOLOGY_TALENT,
+  NETHER_PORTAL_DEMONOLOGY_TALENT,
+  SUMMON_DEMONIC_TYRANT_DEMONOLOGY_TALENT,
+  ANTORAN_ARMAMENTS_DEMONOLOGY_TALENT,
+  NERZHULS_VOLITION_DEMONOLOGY_TALENT,
+  STOLEN_POWER_DEMONOLOGY_TALENT,
+  SACRIFICED_SOULS_DEMONOLOGY_TALENT,
+  SOULBOUND_TYRANT_DEMONOLOGY_TALENT,
+  FORCES_OF_THE_HORNED_NIGHTMARE_DEMONOLOGY_TALENT,
+  THE_EXPENDABLES_DEMONOLOGY_TALENT,
+  COMMAND_AURA_DEMONOLOGY_TALENT,
+  GULDANS_AMBITION_DEMONOLOGY_TALENT,
+  REIGN_OF_TYRANNY_DEMONOLOGY_TALENT,
+  WILFREDS_SIGIL_OF_SUPERIOR_SUMMONING_DEMONOLOGY_TALENT,
+  GUILLOTINE_DEMONOLOGY_TALENT,
 });
 
 export default talents;

--- a/src/common/TALENTS/warrior.ts
+++ b/src/common/TALENTS/warrior.ts
@@ -1,1175 +1,1495 @@
 // Generated file, changes will eventually be overwritten!
-import { createTalentList } from './types';
+import { createTalentList, Talent } from './types';
+
+//region Shared
+export const BATTLE_STANCE_TALENT: Talent = {
+  id: 386164,
+  name: 'Battle Stance',
+  icon: 'ability_warrior_offensivestance',
+  maxRanks: 1,
+};
+export const DEFENSIVE_STANCE_TALENT: Talent = {
+  id: 386208,
+  name: 'Defensive Stance',
+  icon: 'ability_warrior_defensivestance',
+  maxRanks: 1,
+};
+export const BERSERKER_STANCE_TALENT: Talent = {
+  id: 386196,
+  name: 'Berserker Stance',
+  icon: 'ability_racial_avatar',
+  maxRanks: 1,
+};
+export const FAST_FOOTWORK_TALENT: Talent = {
+  id: 382260,
+  name: 'Fast Footwork',
+  icon: 'ability_hunter_posthaste',
+  maxRanks: 1,
+};
+export const RALLYING_CRY_TALENT: Talent = {
+  id: 97462,
+  name: 'Rallying Cry',
+  icon: 'ability_warrior_rallyingcry',
+  maxRanks: 1,
+};
+export const INTERVENE_TALENT: Talent = {
+  id: 3411,
+  name: 'Intervene',
+  icon: 'ability_warrior_victoryrush',
+  maxRanks: 1,
+};
+export const BERSERKER_RAGE_TALENT: Talent = {
+  id: 18499,
+  name: 'Berserker Rage',
+  icon: 'spell_nature_ancestralguardian',
+  maxRanks: 1,
+};
+export const SIPHONING_STRIKES_TALENT: Talent = {
+  id: 382258,
+  name: 'Siphoning Strikes',
+  icon: 'inv_artifact_bloodoftheassassinated',
+  maxRanks: 1,
+};
+export const IMPENDING_VICTORY_TALENT: Talent = {
+  id: 202168,
+  name: 'Impending Victory',
+  icon: 'spell_impending_victory',
+  maxRanks: 1,
+  rageCost: 10,
+};
+export const INSPIRING_PRESENCE_TALENT: Talent = {
+  id: 382310,
+  name: 'Inspiring Presence',
+  icon: 'ability_toughness',
+  maxRanks: 1,
+};
+export const SECOND_WIND_TALENT: Talent = {
+  id: 29838,
+  name: 'Second Wind',
+  icon: 'ability_hunter_harass',
+  maxRanks: 1,
+};
+export const SPELL_REFLECTION_TALENT: Talent = {
+  id: 23920,
+  name: 'Spell Reflection',
+  icon: 'ability_warrior_shieldreflection',
+  maxRanks: 1,
+};
+export const BERSERKER_SHOUT_TALENT: Talent = {
+  id: 384100,
+  name: 'Berserker Shout',
+  icon: 'spell_nature_ancestralguardian',
+  maxRanks: 1,
+};
+export const PIERCING_HOWL_TALENT: Talent = {
+  id: 12323,
+  name: 'Piercing Howl',
+  icon: 'spell_shadow_deathscream',
+  maxRanks: 1,
+};
+export const WAR_MACHINE_TALENT: Talent = {
+  id: 262231,
+  name: 'War Machine',
+  icon: 'ability_hunter_rapidkilling',
+  maxRanks: 1,
+};
+export const HONED_REFLEXES_TALENT: Talent = {
+  id: 382461,
+  name: 'Honed Reflexes',
+  icon: 'spell_holy_borrowedtime',
+  maxRanks: 1,
+};
+export const HEROIC_LEAP_TALENT: Talent = {
+  id: 6544,
+  name: 'Heroic Leap',
+  icon: 'ability_heroicleap',
+  maxRanks: 1,
+};
+export const INTIMIDATING_SHOUT_TALENT: Talent = {
+  id: 5246,
+  name: 'Intimidating Shout',
+  icon: 'ability_golemthunderclap',
+  maxRanks: 1,
+};
+export const THUNDER_CLAP_TALENT: Talent = {
+  id: 6343,
+  name: 'Thunder Clap',
+  icon: 'spell_nature_thunderclap',
+  maxRanks: 1,
+  rageCost: 30,
+};
+export const FURIOUS_BLOWS_TALENT: Talent = {
+  id: 390354,
+  name: 'Furious Blows',
+  icon: 'ability_ghoulfrenzy',
+  maxRanks: 1,
+};
+export const WRECKING_THROW_TALENT: Talent = {
+  id: 384110,
+  name: 'Wrecking Throw',
+  icon: 'ability_warrior_shatteringthrow',
+  maxRanks: 1,
+};
+export const SHATTERING_THROW_TALENT: Talent = {
+  id: 64382,
+  name: 'Shattering Throw',
+  icon: 'ability_warrior_shatteringthrow',
+  maxRanks: 1,
+};
+export const CRUSHING_FORCE_TALENT: Talent = {
+  id: 382764,
+  name: 'Crushing Force',
+  icon: 'spell_shadow_unholystrength',
+  maxRanks: 2,
+};
+export const CONCUSSIVE_BLOWS_TALENT: Talent = {
+  id: 383115,
+  name: 'Concussive Blows',
+  icon: 'ability_warrior_intervene',
+  maxRanks: 1,
+};
+export const CACOPHONOUS_ROAR_TALENT: Talent = {
+  id: 382954,
+  name: 'Cacophonous Roar',
+  icon: 'ability_fomor_boss_shout',
+  maxRanks: 1,
+};
+export const MENACE_TALENT: Talent = {
+  id: 275338,
+  name: 'Menace',
+  icon: 'ability_golemthunderclap',
+  maxRanks: 1,
+};
+export const STORM_BOLT_TALENT: Talent = {
+  id: 107570,
+  name: 'Storm Bolt',
+  icon: 'warrior_talent_icon_stormbolt',
+  maxRanks: 1,
+};
+export const PAIN_AND_GAIN_TALENT: Talent = {
+  id: 382549,
+  name: 'Pain and Gain',
+  icon: 'spell_holy_painsupression',
+  maxRanks: 1,
+};
+export const OVERWHELMING_RAGE_TALENT: Talent = {
+  id: 382767,
+  name: 'Overwhelming Rage',
+  icon: 'racial_orc_berserkerstrength',
+  maxRanks: 2,
+};
+export const TITANIC_THROW_TALENT: Talent = {
+  id: 384090,
+  name: 'Titanic Throw',
+  icon: 'inv_axe_66',
+  maxRanks: 1,
+};
+export const BARBARIC_TRAINING_TALENT: Talent = {
+  id: 383082,
+  name: 'Barbaric Training',
+  icon: 'ability_garrosh_whirling_corruption',
+  maxRanks: 1,
+};
+export const FROTHING_BERSERKER_TALENT: Talent = {
+  id: 215571,
+  name: 'Frothing Berserker',
+  icon: 'warrior_talent_icon_furyintheblood',
+  maxRanks: 1,
+};
+export const BOUNDING_STRIDE_TALENT: Talent = {
+  id: 202163,
+  name: 'Bounding Stride',
+  icon: 'ability_heroicleap',
+  maxRanks: 1,
+};
+export const PLACEHOLDER_TALENT_TALENT: Talent = {
+  id: 390376,
+  name: 'Placeholder Talent',
+  icon: 'garrison_building_workshop',
+  maxRanks: 1,
+};
+export const BLOOD_AND_THUNDER_TALENT: Talent = {
+  id: 384277,
+  name: 'Blood and Thunder',
+  icon: 'warrior_talent_icon_bloodandthunder',
+  maxRanks: 1,
+};
+export const CRACKLING_THUNDER_TALENT: Talent = {
+  id: 203201,
+  name: 'Crackling Thunder',
+  icon: 'ability_thunderking_overcharge',
+  maxRanks: 1,
+};
+export const SEISMIC_REVERBERATION_TALENT: Talent = {
+  id: 382956,
+  name: 'Seismic Reverberation',
+  icon: 'ability_warrior_bloodnova',
+  maxRanks: 1,
+};
+export const ARMORED_TO_THE_TEETH_TALENT: Talent = {
+  id: 384124,
+  name: 'Armored to the Teeth',
+  icon: 'inv_shoulder_22',
+  maxRanks: 1,
+};
+export const DOUBLE_TIME_TALENT: Talent = {
+  id: 103827,
+  name: 'Double Time',
+  icon: 'inv_misc_horn_04',
+  maxRanks: 1,
+};
+export const MASSACRE_TALENT: Talent = {
+  id: 206315,
+  name: 'Massacre',
+  icon: 'inv_sword_48',
+  maxRanks: 1,
+};
+export const REINFORCED_PLATES_TALENT: Talent = {
+  id: 382939,
+  name: 'Reinforced Plates',
+  icon: 'inv_chest_plate04',
+  maxRanks: 2,
+};
+export const ENDURANCE_TRAINING_TALENT: Talent = {
+  id: 391273,
+  name: 'Endurance Training',
+  icon: 'spell_holy_blessingofstamina',
+  maxRanks: 2,
+};
+export const DUAL_WIELD_SPECIALIZATION_TALENT: Talent = {
+  id: 382900,
+  name: 'Dual Wield Specialization',
+  icon: 'ability_dualwield',
+  maxRanks: 1,
+};
+export const CRUEL_STRIKES_TALENT: Talent = {
+  id: 391324,
+  name: 'Cruel Strikes',
+  icon: 'ability_criticalstrike',
+  maxRanks: 2,
+};
+export const QUICK_THINKING_TALENT: Talent = {
+  id: 382946,
+  name: 'Quick Thinking',
+  icon: 'ability_rogue_sprint',
+  maxRanks: 2,
+};
+export const AVATAR_TALENT: Talent = {
+  id: 107574,
+  name: 'Avatar',
+  icon: 'warrior_talent_icon_avatar',
+  maxRanks: 1,
+};
+export const SHOCKWAVE_TALENT: Talent = {
+  id: 46968,
+  name: 'Shockwave',
+  icon: 'ability_warrior_shockwave',
+  maxRanks: 1,
+};
+export const BITTER_IMMUNITY_TALENT: Talent = {
+  id: 383762,
+  name: 'Bitter Immunity',
+  icon: 'spell_nature_shamanrage',
+  maxRanks: 1,
+};
+export const SPEAR_OF_BASTION_TALENT: Talent = {
+  id: 376079,
+  name: 'Spear of Bastion',
+  icon: 'ability_bastion_warrior',
+  maxRanks: 1,
+};
+export const THUNDEROUS_ROAR_TALENT: Talent = {
+  id: 384318,
+  name: 'Thunderous Roar',
+  icon: 'ability_warrior_dragonroar',
+  maxRanks: 1,
+};
+export const MEMORY_OF_A_TORMENTED_BERSERKER_TALENT: Talent = {
+  id: 390123,
+  name: 'Memory of a Tormented Berserker',
+  icon: 'ability_warrior_innerrage',
+  maxRanks: 1,
+};
+export const MEMORY_OF_A_TORMENTED_TITAN_TALENT: Talent = {
+  id: 390135,
+  name: 'Memory of a Tormented Titan',
+  icon: '70_inscription_vantus_rune_odyn',
+  maxRanks: 1,
+};
+export const RUMBLING_EARTH_TALENT: Talent = {
+  id: 275339,
+  name: 'Rumbling Earth',
+  icon: 'spell_shaman_earthquake',
+  maxRanks: 1,
+};
+export const SONIC_BOOM_TALENT: Talent = {
+  id: 390725,
+  name: 'Sonic Boom',
+  icon: 'warrior_talent_icon_thunderstruck',
+  maxRanks: 1,
+};
+export const PIERCING_VERDICT_TALENT: Talent = {
+  id: 382948,
+  name: 'Piercing Verdict',
+  icon: 'spell_animabastion_missile',
+  maxRanks: 1,
+};
+export const ELYSIAN_MIGHT_TALENT: Talent = {
+  id: 386285,
+  name: 'Elysian Might',
+  icon: 'ability_bastion_warrior',
+  maxRanks: 1,
+};
+export const THUNDEROUS_WORDS_TALENT: Talent = {
+  id: 384969,
+  name: 'Thunderous Words',
+  icon: 'spell_nature_earthquake',
+  maxRanks: 1,
+};
+export const SUDDEN_DEATH_TALENT: Talent = {
+  id: 29725,
+  name: 'Sudden Death',
+  icon: 'ability_warrior_improveddisciplines',
+  maxRanks: 1,
+};
+export const ONE_HANDED_WEAPON_SPECIALIZATION_TALENT: Talent = {
+  id: 382895,
+  name: 'One-Handed Weapon Specialization',
+  icon: 'inv_sword_20',
+  maxRanks: 1,
+};
+export const SIGNET_OF_TORMENTED_KINGS_TALENT: Talent = {
+  id: 382949,
+  name: 'Signet of Tormented Kings',
+  icon: 'inv_60crafted_ring4b',
+  maxRanks: 1,
+};
+export const UNSTOPPABLE_FORCE_TALENT: Talent = {
+  id: 275336,
+  name: 'Unstoppable Force',
+  icon: 'warrior_talent_icon_thunderstruck',
+  maxRanks: 1,
+};
+export const TWO_HANDED_WEAPON_SPECIALIZATION_TALENT: Talent = {
+  id: 382896,
+  name: 'Two-Handed Weapon Specialization',
+  icon: 'inv_axe_09',
+  maxRanks: 1,
+};
+export const MEMORY_OF_A_TORMENTED_BLADEMASTER_TALENT: Talent = {
+  id: 390138,
+  name: 'Memory of a Tormented Blademaster',
+  icon: 'spell_nature_mirrorimage',
+  maxRanks: 1,
+};
+export const MEMORY_OF_A_TORMENTED_WARLORD_TALENT: Talent = {
+  id: 390140,
+  name: 'Memory of a Tormented Warlord',
+  icon: 'warrior_talent_icon_innerrage',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Fury
+export const BLOODTHIRST_FURY_TALENT: Talent = {
+  id: 23881,
+  name: 'Bloodthirst',
+  icon: 'spell_nature_bloodlust',
+  maxRanks: 1,
+};
+export const RAGING_BLOW_FURY_TALENT: Talent = {
+  id: 85288,
+  name: 'Raging Blow',
+  icon: 'warrior_wild_strike',
+  maxRanks: 1,
+};
+export const IMPROVED_ENRAGE_FURY_TALENT: Talent = {
+  id: 383848,
+  name: 'Improved Enrage',
+  icon: 'spell_shadow_unholyfrenzy',
+  maxRanks: 1,
+};
+export const ENRAGED_REGENERATION_FURY_TALENT: Talent = {
+  id: 184364,
+  name: 'Enraged Regeneration',
+  icon: 'ability_warrior_focusedrage',
+  maxRanks: 1,
+};
+export const IMPROVED_EXECUTE_FURY_TALENT: Talent = {
+  id: 316402,
+  name: 'Improved Execute',
+  icon: 'inv_sword_48',
+  maxRanks: 1,
+};
+export const IMPROVED_BLOODTHIRST_FURY_TALENT: Talent = {
+  id: 383852,
+  name: 'Improved Bloodthirst',
+  icon: 'spell_nature_bloodlust',
+  maxRanks: 1,
+};
+export const FRESH_MEAT_FURY_TALENT: Talent = {
+  id: 215568,
+  name: 'Fresh Meat',
+  icon: 'ability_deathwing_bloodcorruption_death',
+  maxRanks: 1,
+};
+export const WARPAINT_FURY_TALENT: Talent = {
+  id: 208154,
+  name: 'Warpaint',
+  icon: 'ability_rogue_preparation',
+  maxRanks: 1,
+};
+export const INVIGORATING_FURY_FURY_TALENT: Talent = {
+  id: 383468,
+  name: 'Invigorating Fury',
+  icon: 'spell_misc_emotionangry',
+  maxRanks: 1,
+};
+export const SUDDEN_DEATH_FURY_TALENT: Talent = {
+  id: 280721,
+  name: 'Sudden Death',
+  icon: 'ability_warrior_improveddisciplines',
+  maxRanks: 1,
+};
+export const IMPROVED_RAGING_BLOW_FURY_TALENT: Talent = {
+  id: 383854,
+  name: 'Improved Raging Blow',
+  icon: 'warrior_wild_strike',
+  maxRanks: 1,
+};
+export const FOCUS_IN_CHAOS_FURY_TALENT: Talent = {
+  id: 383486,
+  name: 'Focus In Chaos',
+  icon: 'ability_hunter_mastermarksman',
+  maxRanks: 1,
+};
+export const RAMPAGE_FURY_TALENT: Talent = {
+  id: 184367,
+  name: 'Rampage',
+  icon: 'ability_warrior_rampage',
+  maxRanks: 1,
+  rageCost: 80,
+};
+export const IMPROVED_WHIRLWIND_FURY_TALENT: Talent = {
+  id: 12950,
+  name: 'Improved Whirlwind',
+  icon: 'ability_whirlwind',
+  maxRanks: 1,
+};
+export const SINGLE_MINDED_FURY_FURY_TALENT: Talent = {
+  id: 81099,
+  name: 'Single-Minded Fury',
+  icon: 'warrior_talent_icon_singlemindedfury',
+  maxRanks: 1,
+};
+export const COLD_STEEL_HOT_BLOOD_FURY_TALENT: Talent = {
+  id: 383959,
+  name: 'Cold Steel, Hot Blood',
+  icon: 'ability_rogue_hungerforblood',
+  maxRanks: 1,
+};
+export const VICIOUS_CONTEMPT_FURY_TALENT: Talent = {
+  id: 383885,
+  name: 'Vicious Contempt',
+  icon: 'ability_ironmaidens_sorkasprey',
+  maxRanks: 2,
+};
+export const FRENZY_FURY_TALENT: Talent = {
+  id: 335077,
+  name: 'Frenzy',
+  icon: 'ability_rogue_bloodyeye',
+  maxRanks: 1,
+};
+export const HACK_AND_SLASH_FURY_TALENT: Talent = {
+  id: 383877,
+  name: 'Hack And Slash',
+  icon: 'ability_rogue_rollthebones02',
+  maxRanks: 1,
+};
+export const SLAUGHTERING_STRIKES_FURY_TALENT: Talent = {
+  id: 388004,
+  name: 'Slaughtering Strikes',
+  icon: 'inv_axe_2h_orcwarrior_c_01',
+  maxRanks: 1,
+};
+export const CRUELTY_FURY_TALENT: Talent = {
+  id: 335070,
+  name: 'Cruelty',
+  icon: 'spell_nature_focusedmind',
+  maxRanks: 2,
+};
+export const SIEGEBREAKER_FURY_TALENT: Talent = {
+  id: 280772,
+  name: 'Siegebreaker',
+  icon: 'inv_mace_101',
+  maxRanks: 1,
+};
+export const MEAT_CLEAVER_FURY_TALENT: Talent = {
+  id: 280392,
+  name: 'Meat Cleaver',
+  icon: 'ability_whirlwind',
+  maxRanks: 2,
+};
+export const FRENZIED_FLURRY_FURY_TALENT: Talent = {
+  id: 383605,
+  name: 'Frenzied Flurry',
+  icon: 'ability_ghoulfrenzy',
+  maxRanks: 2,
+};
+export const BLOODBORNE_FURY_TALENT: Talent = {
+  id: 385703,
+  name: 'Bloodborne',
+  icon: 'inv_artifact_bloodoftheassassinated',
+  maxRanks: 1,
+};
+export const CADENCE_OF_FUJIEDA_FURY_TALENT: Talent = {
+  id: 383919,
+  name: 'Cadence of Fujieda',
+  icon: 'ability_garrosh_hellscreams_warsong',
+  maxRanks: 1,
+};
+export const BLOODCRAZE_FURY_TALENT: Talent = {
+  id: 385735,
+  name: 'Bloodcraze',
+  icon: 'ability_creature_cursed_02',
+  maxRanks: 1,
+};
+export const RECKLESSNESS_FURY_TALENT: Talent = {
+  id: 1719,
+  name: 'Recklessness',
+  icon: 'warrior_talent_icon_innerrage',
+  maxRanks: 1,
+};
+export const WRATH_AND_FURY_FURY_TALENT: Talent = {
+  id: 386045,
+  name: 'Wrath and Fury',
+  icon: 'warrior_wild_strike',
+  maxRanks: 1,
+};
+export const DEAFENING_CRASH_FURY_TALENT: Talent = {
+  id: 383613,
+  name: 'Deafening Crash',
+  icon: 'spell_nature_earthquake',
+  maxRanks: 1,
+};
+export const RAGING_ARMAMENTS_FURY_TALENT: Talent = {
+  id: 388049,
+  name: 'Raging Armaments',
+  icon: 'warrior_wild_strike',
+  maxRanks: 1,
+};
+export const DEFT_EXPERIENCE_FURY_TALENT: Talent = {
+  id: 383295,
+  name: 'Deft Experience',
+  icon: 'inv_misc_book_07',
+  maxRanks: 2,
+};
+export const SWIFT_STRIKES_FURY_TALENT: Talent = {
+  id: 383459,
+  name: 'Swift Strikes',
+  icon: 'ability_rogue_sprint',
+  maxRanks: 2,
+};
+export const CRITICAL_THINKING_FURY_TALENT: Talent = {
+  id: 383297,
+  name: 'Critical Thinking',
+  icon: 'ability_criticalstrike',
+  maxRanks: 2,
+};
+export const STORM_OF_SWORDS_FURY_TALENT: Talent = {
+  id: 388903,
+  name: 'Storm of Swords',
+  icon: 'ability_skyreach_fourblades',
+  maxRanks: 1,
+};
+export const ODYNS_FURY_FURY_TALENT: Talent = {
+  id: 385059,
+  name: "Odyn's Fury",
+  icon: 'inv_sword_1h_artifactvigfus_d_01',
+  maxRanks: 1,
+};
+export const ANGER_MANAGEMENT_FURY_TALENT: Talent = {
+  id: 152278,
+  name: 'Anger Management',
+  icon: 'warrior_talent_icon_angermanagement',
+  maxRanks: 1,
+};
+export const RECKLESS_ABANDON_FURY_TALENT: Talent = {
+  id: 202751,
+  name: 'Reckless Abandon',
+  icon: 'ability_warrior_battleshout',
+  maxRanks: 1,
+};
+export const ONSLAUGHT_FURY_TALENT: Talent = {
+  id: 315720,
+  name: 'Onslaught',
+  icon: 'ability_warrior_trauma',
+  maxRanks: 1,
+};
+export const RAVAGER_FURY_TALENT: Talent = {
+  id: 228920,
+  name: 'Ravager',
+  icon: 'warrior_talent_icon_ravager',
+  maxRanks: 1,
+};
+export const ANNIHILATOR_FURY_TALENT: Talent = {
+  id: 383916,
+  name: 'Annihilator',
+  icon: 'ability_warrior_annihilator',
+  maxRanks: 1,
+};
+export const ODYNS_FURY_MODIFIER_FURY_TALENT: Talent = {
+  id: 389014,
+  name: "Odyn's Fury Modifier",
+  icon: 'garrison_building_workshop',
+  maxRanks: 1,
+};
+export const PLACEHOLDER_TALENT_FURY_TALENT: Talent = {
+  id: 390376,
+  name: 'Placeholder Talent',
+  icon: 'garrison_building_workshop',
+  maxRanks: 1,
+};
+export const UNBRIDLED_FEROCITY_FURY_TALENT: Talent = {
+  id: 389603,
+  name: 'Unbridled Ferocity',
+  icon: 'ability_warrior_endlessrage',
+  maxRanks: 1,
+};
+export const SKULL_BANNER_FURY_TALENT: Talent = {
+  id: 385348,
+  name: 'Skull Banner',
+  icon: 'warrior_skullbanner',
+  maxRanks: 1,
+};
+export const SIDEARM_FURY_TALENT: Talent = {
+  id: 384404,
+  name: 'Sidearm',
+  icon: 'inv_throwingaxe_06',
+  maxRanks: 1,
+};
+export const DEPTHS_OF_INSANITY_FURY_TALENT: Talent = {
+  id: 383922,
+  name: 'Depths of Insanity',
+  icon: 'racial_troll_berserk',
+  maxRanks: 1,
+};
+export const PULVERIZE_FURY_TALENT: Talent = {
+  id: 388933,
+  name: 'Pulverize',
+  icon: 'inv_mace_1h_blacksmithing_b_01_black',
+  maxRanks: 1,
+};
+export const STORM_OF_STEEL_FURY_TALENT: Talent = {
+  id: 382953,
+  name: 'Storm of Steel',
+  icon: 'ability_creature_cursed_04',
+  maxRanks: 1,
+};
+export const GATHERING_STORM_FURY_TALENT: Talent = {
+  id: 390563,
+  name: 'Gathering Storm',
+  icon: 'ability_warrior_bladestorm',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Protection
+export const IGNORE_PAIN_PROTECTION_TALENT: Talent = {
+  id: 190456,
+  name: 'Ignore Pain',
+  icon: 'ability_warrior_renewedvigor',
+  maxRanks: 1,
+  rageCost: 40,
+};
+export const REVENGE_PROTECTION_TALENT: Talent = {
+  id: 6572,
+  name: 'Revenge',
+  icon: 'ability_warrior_revenge',
+  maxRanks: 1,
+  rageCost: 20,
+};
+export const DEMORALIZING_SHOUT_PROTECTION_TALENT: Talent = {
+  id: 1160,
+  name: 'Demoralizing Shout',
+  icon: 'ability_warrior_warcry',
+  maxRanks: 1,
+};
+export const DEVASTATE_PROTECTION_TALENT: Talent = {
+  id: 20243,
+  name: 'Devastate',
+  icon: 'inv_sword_11',
+  maxRanks: 1,
+};
+export const LAST_STAND_PROTECTION_TALENT: Talent = {
+  id: 12975,
+  name: 'Last Stand',
+  icon: 'spell_holy_ashestoashes',
+  maxRanks: 1,
+};
+export const BOOMING_VOICE_PROTECTION_TALENT: Talent = {
+  id: 202743,
+  name: 'Booming Voice',
+  icon: 'ability_warrior_commandingshout',
+  maxRanks: 1,
+};
+export const BEST_SERVED_COLD_PROTECTION_TALENT: Talent = {
+  id: 202560,
+  name: 'Best Served Cold',
+  icon: 'ability_warrior_revenge',
+  maxRanks: 1,
+};
+export const STRATEGIST_PROTECTION_TALENT: Talent = {
+  id: 384041,
+  name: 'Strategist',
+  icon: 'inv_shield_05',
+  maxRanks: 1,
+};
+export const BRACE_FOR_IMPACT_PROTECTION_TALENT: Talent = {
+  id: 386030,
+  name: 'Brace For Impact',
+  icon: 'ability_warrior_shieldguard',
+  maxRanks: 1,
+};
+export const UNNERVING_FOCUS_PROTECTION_TALENT: Talent = {
+  id: 384042,
+  name: 'Unnerving Focus',
+  icon: 'rogue_shadowfocus',
+  maxRanks: 1,
+};
+export const CHALLENGING_SHOUT_PROTECTION_TALENT: Talent = {
+  id: 1161,
+  name: 'Challenging Shout',
+  icon: 'ability_bullrush',
+  maxRanks: 1,
+};
+export const DEVASTATOR_PROTECTION_TALENT: Talent = {
+  id: 236279,
+  name: 'Devastator',
+  icon: 'inv_sword_11',
+  maxRanks: 1,
+};
+export const BLOODSURGE_PROTECTION_TALENT: Talent = {
+  id: 384361,
+  name: 'Bloodsurge',
+  icon: 'ability_warrior_bloodsurge',
+  maxRanks: 1,
+};
+export const REND_PROTECTION_TALENT: Talent = {
+  id: 772,
+  name: 'Rend',
+  icon: 'ability_gouge',
+  maxRanks: 1,
+  rageCost: 30,
+};
+export const FUELED_BY_VIOLENCE_PROTECTION_TALENT: Talent = {
+  id: 383103,
+  name: 'Fueled by Violence',
+  icon: 'ability_demonhunter_bloodlet',
+  maxRanks: 1,
+};
+export const BRUTAL_VITALITY_PROTECTION_TALENT: Talent = {
+  id: 384036,
+  name: 'Brutal Vitality',
+  icon: 'ability_warrior_renewedvigor',
+  maxRanks: 1,
+};
+export const DISRUPTING_SHOUT_PROTECTION_TALENT: Talent = {
+  id: 386071,
+  name: 'Disrupting Shout',
+  icon: 'ability_bullrush',
+  maxRanks: 1,
+};
+export const SHOW_OF_FORCE_PROTECTION_TALENT: Talent = {
+  id: 385843,
+  name: 'Show of Force',
+  icon: 'ability_rogue_reinforcedleather',
+  maxRanks: 1,
+};
+export const IMPROVED_HEROIC_THROW_PROTECTION_TALENT: Talent = {
+  id: 386034,
+  name: 'Improved Heroic Throw',
+  icon: 'inv_axe_66',
+  maxRanks: 1,
+};
+export const THUNDERLORD_PROTECTION_TALENT: Talent = {
+  id: 385840,
+  name: 'Thunderlord',
+  icon: 'ability_vehicle_electrocharge',
+  maxRanks: 1,
+};
+export const SHIELD_WALL_PROTECTION_TALENT: Talent = {
+  id: 871,
+  name: 'Shield Wall',
+  icon: 'ability_warrior_shieldwall',
+  maxRanks: 1,
+};
+export const BOLSTER_PROTECTION_TALENT: Talent = {
+  id: 280001,
+  name: 'Bolster',
+  icon: 'shield_draenorcrafted_d_02_c_alliance',
+  maxRanks: 1,
+};
+export const SPIKED_SHIELD_PROTECTION_TALENT: Talent = {
+  id: 385888,
+  name: 'Spiked Shield',
+  icon: 'inv_titanium_shield_spike',
+  maxRanks: 1,
+};
+export const NEVER_SURRENDER_PROTECTION_TALENT: Talent = {
+  id: 279996,
+  name: 'Never Surrender',
+  icon: 'ability_butcher_gushingwounds',
+  maxRanks: 1,
+};
+export const BLOODBORNE_PROTECTION_TALENT: Talent = {
+  id: 385704,
+  name: 'Bloodborne',
+  icon: 'inv_artifact_bloodoftheassassinated',
+  maxRanks: 2,
+};
+export const HEAVY_REPERCUSSIONS_PROTECTION_TALENT: Talent = {
+  id: 203177,
+  name: 'Heavy Repercussions',
+  icon: 'inv_shield_32',
+  maxRanks: 1,
+};
+export const INTO_THE_FRAY_PROTECTION_TALENT: Talent = {
+  id: 202603,
+  name: 'Into the Fray',
+  icon: 'ability_warrior_bloodfrenzy',
+  maxRanks: 1,
+};
+export const ENDURING_DEFENSES_PROTECTION_TALENT: Talent = {
+  id: 386027,
+  name: 'Enduring Defenses',
+  icon: 'ability_defend',
+  maxRanks: 1,
+};
+export const MASSACRE_PROTECTION_TALENT: Talent = {
+  id: 281001,
+  name: 'Massacre',
+  icon: 'inv_sword_48',
+  maxRanks: 1,
+};
+export const ANGER_MANAGEMENT_PROTECTION_TALENT: Talent = {
+  id: 152278,
+  name: 'Anger Management',
+  icon: 'warrior_talent_icon_angermanagement',
+  maxRanks: 1,
+};
+export const UNBREAKABLE_WILL_PROTECTION_TALENT: Talent = {
+  id: 384074,
+  name: 'Unbreakable Will',
+  icon: 'ability_warrior_stalwartprotector',
+  maxRanks: 1,
+};
+export const THE_WALL_PROTECTION_TALENT: Talent = {
+  id: 384072,
+  name: 'The Wall',
+  icon: 'ability_warrior_shieldguard',
+  maxRanks: 1,
+};
+export const PUNISH_PROTECTION_TALENT: Talent = {
+  id: 275334,
+  name: 'Punish',
+  icon: 'ability_deathknight_sanguinfortitude',
+  maxRanks: 1,
+};
+export const JUGGERNAUT_PROTECTION_TALENT: Talent = {
+  id: 383292,
+  name: 'Juggernaut',
+  icon: 'warrior_talent_icon_skirmisher',
+  maxRanks: 1,
+};
+export const ENDURING_ALACRITY_PROTECTION_TALENT: Talent = {
+  id: 384063,
+  name: 'Enduring Alacrity',
+  icon: 'spell_nature_unyeildingstamina',
+  maxRanks: 2,
+};
+export const SHIELD_SPECIALIZATION_PROTECTION_TALENT: Talent = {
+  id: 386011,
+  name: 'Shield Specialization',
+  icon: 'inv_shield_76',
+  maxRanks: 2,
+};
+export const FOCUSED_VIGOR_PROTECTION_TALENT: Talent = {
+  id: 384067,
+  name: 'Focused Vigor',
+  icon: 'spell_nature_strength',
+  maxRanks: 2,
+};
+export const SHIELD_CHARGE_PROTECTION_TALENT: Talent = {
+  id: 385952,
+  name: 'Shield Charge',
+  icon: 'ability_warrior_shieldcharge',
+  maxRanks: 1,
+};
+export const OUTBURST_PROTECTION_TALENT: Talent = {
+  id: 386477,
+  name: 'Outburst',
+  icon: 'ability_warrior_furiousresolve',
+  maxRanks: 1,
+};
+export const INDOMITABLE_PROTECTION_TALENT: Talent = {
+  id: 202095,
+  name: 'Indomitable',
+  icon: 'ability_warrior_intensifyrage',
+  maxRanks: 1,
+};
+export const SPELL_BLOCK_PROTECTION_TALENT: Talent = {
+  id: 386014,
+  name: 'Spell Block',
+  icon: 'ability_warrior_shieldbreak',
+  maxRanks: 1,
+};
+export const RAVAGER_PROTECTION_TALENT: Talent = {
+  id: 228920,
+  name: 'Ravager',
+  icon: 'warrior_talent_icon_ravager',
+  maxRanks: 1,
+};
+export const CHAMPIONS_BULWARK_PROTECTION_TALENT: Talent = {
+  id: 386328,
+  name: "Champion's Bulwark",
+  icon: 'ability_warrior_shieldmastery',
+  maxRanks: 1,
+};
+export const BATTLE_SCARRED_VETERAN_PROTECTION_TALENT: Talent = {
+  id: 386394,
+  name: 'Battle-Scarred Veteran',
+  icon: 'ability_warrior_endlessrage',
+  maxRanks: 1,
+};
+export const STORM_OF_STEEL_PROTECTION_TALENT: Talent = {
+  id: 382953,
+  name: 'Storm of Steel',
+  icon: 'ability_creature_cursed_04',
+  maxRanks: 1,
+};
+
+//endregion
+
+//region Arms
+export const MORTAL_STRIKE_ARMS_TALENT: Talent = {
+  id: 12294,
+  name: 'Mortal Strike',
+  icon: 'ability_warrior_savageblow',
+  maxRanks: 1,
+  rageCost: 30,
+};
+export const OVERPOWER_ARMS_TALENT: Talent = {
+  id: 7384,
+  name: 'Overpower',
+  icon: 'ability_meleedamage',
+  maxRanks: 1,
+};
+export const TACTICIAN_ARMS_TALENT: Talent = {
+  id: 184783,
+  name: 'Tactician',
+  icon: 'ability_warrior_unrelentingassault',
+  maxRanks: 1,
+};
+export const DIE_BY_THE_SWORD_ARMS_TALENT: Talent = {
+  id: 118038,
+  name: 'Die by the Sword',
+  icon: 'ability_warrior_challange',
+  maxRanks: 1,
+};
+export const MARTIAL_PROWESS_ARMS_TALENT: Talent = {
+  id: 316440,
+  name: 'Martial Prowess',
+  icon: 'ability_warrior_weaponmastery',
+  maxRanks: 1,
+};
+export const IMPROVED_OVERPOWER_ARMS_TALENT: Talent = {
+  id: 385571,
+  name: 'Improved Overpower',
+  icon: 'ability_meleedamage',
+  maxRanks: 1,
+};
+export const BLOODSURGE_ARMS_TALENT: Talent = {
+  id: 384361,
+  name: 'Bloodsurge',
+  icon: 'ability_warrior_bloodsurge',
+  maxRanks: 1,
+};
+export const FUELED_BY_VIOLENCE_ARMS_TALENT: Talent = {
+  id: 383103,
+  name: 'Fueled by Violence',
+  icon: 'ability_demonhunter_bloodlet',
+  maxRanks: 1,
+};
+export const STORM_WALL_ARMS_TALENT: Talent = {
+  id: 388807,
+  name: 'Storm Wall',
+  icon: 'spell_sandstorm',
+  maxRanks: 1,
+};
+export const IMPROVED_EXECUTE_ARMS_TALENT: Talent = {
+  id: 316405,
+  name: 'Improved Execute',
+  icon: 'inv_sword_48',
+  maxRanks: 1,
+};
+export const IMPROVED_MORTAL_STRIKE_ARMS_TALENT: Talent = {
+  id: 385573,
+  name: 'Improved Mortal Strike',
+  icon: 'ability_warrior_savageblow',
+  maxRanks: 1,
+};
+export const IMPALE_ARMS_TALENT: Talent = {
+  id: 383430,
+  name: 'Impale',
+  icon: 'ability_searingarrow',
+  maxRanks: 1,
+};
+export const EXPLOIT_THE_WEAKNESS_ARMS_TALENT: Talent = {
+  id: 383162,
+  name: 'Exploit the Weakness',
+  icon: 'ability_warrior_warbringer',
+  maxRanks: 1,
+};
+export const PUNISHMENT_ARMS_TALENT: Talent = {
+  id: 383136,
+  name: 'Punishment',
+  icon: 'ability_warrior_secondwind',
+  maxRanks: 1,
+};
+export const COLOSSUS_SMASH_ARMS_TALENT: Talent = {
+  id: 167105,
+  name: 'Colossus Smash',
+  icon: 'ability_warrior_colossussmash',
+  maxRanks: 1,
+};
+export const SKULLSPLITTER_ARMS_TALENT: Talent = {
+  id: 260643,
+  name: 'Skullsplitter',
+  icon: 'inv_skullsplitter',
+  maxRanks: 1,
+};
+export const REND_ARMS_TALENT: Talent = {
+  id: 772,
+  name: 'Rend',
+  icon: 'ability_gouge',
+  maxRanks: 1,
+  rageCost: 30,
+};
+export const EXHILARATING_BLOWS_ARMS_TALENT: Talent = {
+  id: 383219,
+  name: 'Exhilarating Blows',
+  icon: 'warrior_talent_icon_igniteweapon',
+  maxRanks: 1,
+};
+export const SWEEPING_STRIKES_ARMS_TALENT: Talent = {
+  id: 260708,
+  name: 'Sweeping Strikes',
+  icon: 'ability_rogue_slicedice',
+  maxRanks: 1,
+};
+export const ANGER_MANAGEMENT_ARMS_TALENT: Talent = {
+  id: 152278,
+  name: 'Anger Management',
+  icon: 'warrior_talent_icon_angermanagement',
+  maxRanks: 1,
+};
+export const IN_FOR_THE_KILL_ARMS_TALENT: Talent = {
+  id: 248621,
+  name: 'In For The Kill',
+  icon: 'ability_blackhand_marked4death',
+  maxRanks: 1,
+};
+export const TEST_OF_MIGHT_ARMS_TALENT: Talent = {
+  id: 385008,
+  name: 'Test of Might',
+  icon: 'ability_warrior_strengthofarms',
+  maxRanks: 1,
+};
+export const CLEAVE_ARMS_TALENT: Talent = {
+  id: 845,
+  name: 'Cleave',
+  icon: 'ability_warrior_cleave',
+  maxRanks: 1,
+  rageCost: 20,
+};
+export const FRACTURE_ARMS_TALENT: Talent = {
+  id: 386357,
+  name: 'Fracture',
+  icon: 'inv_skinning_80_bloodsoakedbone',
+  maxRanks: 1,
+};
+export const BLOODBORNE_ARMS_TALENT: Talent = {
+  id: 383287,
+  name: 'Bloodborne',
+  icon: 'inv_artifact_bloodoftheassassinated',
+  maxRanks: 2,
+};
+export const DREADNAUGHT_ARMS_TALENT: Talent = {
+  id: 262150,
+  name: 'Dreadnaught',
+  icon: 'inv_sword_05',
+  maxRanks: 1,
+};
+export const IMPROVED_SWEEPING_STRIKES_ARMS_TALENT: Talent = {
+  id: 383155,
+  name: 'Improved Sweeping Strikes',
+  icon: 'ability_rogue_slicedice',
+  maxRanks: 1,
+};
+export const FERVOR_OF_BATTLE_ARMS_TALENT: Talent = {
+  id: 202316,
+  name: 'Fervor of Battle',
+  icon: 'ability_rogue_waylay',
+  maxRanks: 1,
+};
+export const STORM_OF_SWORDS_ARMS_TALENT: Talent = {
+  id: 385512,
+  name: 'Storm of Swords',
+  icon: 'ability_skyreach_fourblades',
+  maxRanks: 1,
+};
+export const COLLATERAL_DAMAGE_ARMS_TALENT: Talent = {
+  id: 334779,
+  name: 'Collateral Damage',
+  icon: 'ability_warrior_incite',
+  maxRanks: 1,
+};
+export const WARBREAKER_ARMS_TALENT: Talent = {
+  id: 262161,
+  name: 'Warbreaker',
+  icon: 'inv_warbreaker',
+  maxRanks: 1,
+};
+export const MASSACRE_ARMS_TALENT: Talent = {
+  id: 281001,
+  name: 'Massacre',
+  icon: 'inv_sword_48',
+  maxRanks: 1,
+};
+export const REAPING_SWINGS_ARMS_TALENT: Talent = {
+  id: 383293,
+  name: 'Reaping Swings',
+  icon: 'ability_rogue_cuttothechase',
+  maxRanks: 1,
+};
+export const DEFT_EXPERIENCE_ARMS_TALENT: Talent = {
+  id: 389308,
+  name: 'Deft Experience',
+  icon: 'inv_misc_book_07',
+  maxRanks: 2,
+};
+export const VALOR_IN_VICTORY_ARMS_TALENT: Talent = {
+  id: 383338,
+  name: 'Valor in Victory',
+  icon: 'spell_holy_summonchampion',
+  maxRanks: 2,
+};
+export const CRITICAL_THINKING_ARMS_TALENT: Talent = {
+  id: 389306,
+  name: 'Critical Thinking',
+  icon: 'ability_criticalstrike',
+  maxRanks: 2,
+};
+export const BLOODLETTING_ARMS_TALENT: Talent = {
+  id: 383154,
+  name: 'Bloodletting',
+  icon: 'ability_skeer_bloodletting',
+  maxRanks: 1,
+};
+export const BATTLELORD_ARMS_TALENT: Talent = {
+  id: 386630,
+  name: 'Battlelord',
+  icon: 'ability_pvp_hardiness',
+  maxRanks: 1,
+};
+export const BLADESTORM_ARMS_TALENT: Talent = {
+  id: 227847,
+  name: 'Bladestorm',
+  icon: 'ability_warrior_bladestorm',
+  maxRanks: 1,
+};
+export const EXPLOITER_ARMS_TALENT: Talent = {
+  id: 335451,
+  name: 'Exploiter',
+  icon: 'inv_sword_48',
+  maxRanks: 1,
+};
+export const SKULL_BANNER_ARMS_TALENT: Talent = {
+  id: 385348,
+  name: 'Skull Banner',
+  icon: 'warrior_skullbanner',
+  maxRanks: 1,
+};
+export const FATALITY_ARMS_TALENT: Talent = {
+  id: 383703,
+  name: 'Fatality',
+  icon: 'achievement_bg_killingblow_berserker',
+  maxRanks: 1,
+};
+export const UNHINGED_ARMS_TALENT: Talent = {
+  id: 386628,
+  name: 'Unhinged',
+  icon: 'ability_warrior_savageblow',
+  maxRanks: 1,
+};
+export const GATHERING_STORM_ARMS_TALENT: Talent = {
+  id: 390563,
+  name: 'Gathering Storm',
+  icon: 'ability_warrior_bladestorm',
+  maxRanks: 1,
+};
+export const SHARPENED_BLADES_ARMS_TALENT: Talent = {
+  id: 383341,
+  name: 'Sharpened Blades',
+  icon: 'inv_sword_27',
+  maxRanks: 1,
+};
+export const BLUNT_INSTRUMENTS_ARMS_TALENT: Talent = {
+  id: 383442,
+  name: 'Blunt Instruments',
+  icon: 'inv_mace_01',
+  maxRanks: 1,
+};
+export const MERCILESS_BONEGRINDER_ARMS_TALENT: Talent = {
+  id: 383317,
+  name: 'Merciless Bonegrinder',
+  icon: 'ability_ironmaidens_whirlofblood',
+  maxRanks: 1,
+};
+export const DANCE_OF_DEATH_ARMS_TALENT: Talent = {
+  id: 390713,
+  name: 'Dance of Death',
+  icon: 'ability_butcher_whirl',
+  maxRanks: 1,
+};
+export const JUGGERNAUT_ARMS_TALENT: Talent = {
+  id: 383292,
+  name: 'Juggernaut',
+  icon: 'warrior_talent_icon_skirmisher',
+  maxRanks: 1,
+};
+
+//endregion
 
 const talents = createTalentList({
   //Shared
-  BATTLE_STANCE_TALENT: {
-    id: 386164,
-    name: 'Battle Stance',
-    icon: 'ability_warrior_offensivestance',
-    maxRanks: 1,
-  },
-  DEFENSIVE_STANCE_TALENT: {
-    id: 386208,
-    name: 'Defensive Stance',
-    icon: 'ability_warrior_defensivestance',
-    maxRanks: 1,
-  },
-  BERSERKER_STANCE_TALENT: {
-    id: 386196,
-    name: 'Berserker Stance',
-    icon: 'ability_racial_avatar',
-    maxRanks: 1,
-  },
-  FAST_FOOTWORK_TALENT: {
-    id: 382260,
-    name: 'Fast Footwork',
-    icon: 'ability_hunter_posthaste',
-    maxRanks: 1,
-  },
-  RALLYING_CRY_TALENT: {
-    id: 97462,
-    name: 'Rallying Cry',
-    icon: 'ability_warrior_rallyingcry',
-    maxRanks: 1,
-  },
-  INTERVENE_TALENT: {
-    id: 3411,
-    name: 'Intervene',
-    icon: 'ability_warrior_victoryrush',
-    maxRanks: 1,
-  },
-  BERSERKER_RAGE_TALENT: {
-    id: 18499,
-    name: 'Berserker Rage',
-    icon: 'spell_nature_ancestralguardian',
-    maxRanks: 1,
-  },
-  SIPHONING_STRIKES_TALENT: {
-    id: 382258,
-    name: 'Siphoning Strikes',
-    icon: 'inv_artifact_bloodoftheassassinated',
-    maxRanks: 1,
-  },
-  IMPENDING_VICTORY_TALENT: {
-    id: 202168,
-    name: 'Impending Victory',
-    icon: 'spell_impending_victory',
-    maxRanks: 1,
-    rageCost: 10,
-  },
-  INSPIRING_PRESENCE_TALENT: {
-    id: 382310,
-    name: 'Inspiring Presence',
-    icon: 'ability_toughness',
-    maxRanks: 1,
-  },
-  SECOND_WIND_TALENT: {
-    id: 29838,
-    name: 'Second Wind',
-    icon: 'ability_hunter_harass',
-    maxRanks: 1,
-  },
-  SPELL_REFLECTION_TALENT: {
-    id: 23920,
-    name: 'Spell Reflection',
-    icon: 'ability_warrior_shieldreflection',
-    maxRanks: 1,
-  },
-  BERSERKER_SHOUT_TALENT: {
-    id: 384100,
-    name: 'Berserker Shout',
-    icon: 'spell_nature_ancestralguardian',
-    maxRanks: 1,
-  },
-  PIERCING_HOWL_TALENT: {
-    id: 12323,
-    name: 'Piercing Howl',
-    icon: 'spell_shadow_deathscream',
-    maxRanks: 1,
-  },
-  WAR_MACHINE_TALENT: {
-    id: 262231,
-    name: 'War Machine',
-    icon: 'ability_hunter_rapidkilling',
-    maxRanks: 1,
-  },
-  HONED_REFLEXES_TALENT: {
-    id: 382461,
-    name: 'Honed Reflexes',
-    icon: 'spell_holy_borrowedtime',
-    maxRanks: 1,
-  },
-  HEROIC_LEAP_TALENT: { id: 6544, name: 'Heroic Leap', icon: 'ability_heroicleap', maxRanks: 1 },
-  INTIMIDATING_SHOUT_TALENT: {
-    id: 5246,
-    name: 'Intimidating Shout',
-    icon: 'ability_golemthunderclap',
-    maxRanks: 1,
-  },
-  THUNDER_CLAP_TALENT: {
-    id: 6343,
-    name: 'Thunder Clap',
-    icon: 'spell_nature_thunderclap',
-    maxRanks: 1,
-    rageCost: 30,
-  },
-  FURIOUS_BLOWS_TALENT: {
-    id: 390354,
-    name: 'Furious Blows',
-    icon: 'ability_ghoulfrenzy',
-    maxRanks: 1,
-  },
-  WRECKING_THROW_TALENT: {
-    id: 384110,
-    name: 'Wrecking Throw',
-    icon: 'ability_warrior_shatteringthrow',
-    maxRanks: 1,
-  },
-  SHATTERING_THROW_TALENT: {
-    id: 64382,
-    name: 'Shattering Throw',
-    icon: 'ability_warrior_shatteringthrow',
-    maxRanks: 1,
-  },
-  CRUSHING_FORCE_TALENT: {
-    id: 382764,
-    name: 'Crushing Force',
-    icon: 'spell_shadow_unholystrength',
-    maxRanks: 2,
-  },
-  CONCUSSIVE_BLOWS_TALENT: {
-    id: 383115,
-    name: 'Concussive Blows',
-    icon: 'ability_warrior_intervene',
-    maxRanks: 1,
-  },
-  CACOPHONOUS_ROAR_TALENT: {
-    id: 382954,
-    name: 'Cacophonous Roar',
-    icon: 'ability_fomor_boss_shout',
-    maxRanks: 1,
-  },
-  MENACE_TALENT: { id: 275338, name: 'Menace', icon: 'ability_golemthunderclap', maxRanks: 1 },
-  STORM_BOLT_TALENT: {
-    id: 107570,
-    name: 'Storm Bolt',
-    icon: 'warrior_talent_icon_stormbolt',
-    maxRanks: 1,
-  },
-  PAIN_AND_GAIN_TALENT: {
-    id: 382549,
-    name: 'Pain and Gain',
-    icon: 'spell_holy_painsupression',
-    maxRanks: 1,
-  },
-  OVERWHELMING_RAGE_TALENT: {
-    id: 382767,
-    name: 'Overwhelming Rage',
-    icon: 'racial_orc_berserkerstrength',
-    maxRanks: 2,
-  },
-  TITANIC_THROW_TALENT: { id: 384090, name: 'Titanic Throw', icon: 'inv_axe_66', maxRanks: 1 },
-  BARBARIC_TRAINING_TALENT: {
-    id: 383082,
-    name: 'Barbaric Training',
-    icon: 'ability_garrosh_whirling_corruption',
-    maxRanks: 1,
-  },
-  FROTHING_BERSERKER_TALENT: {
-    id: 215571,
-    name: 'Frothing Berserker',
-    icon: 'warrior_talent_icon_furyintheblood',
-    maxRanks: 1,
-  },
-  BOUNDING_STRIDE_TALENT: {
-    id: 202163,
-    name: 'Bounding Stride',
-    icon: 'ability_heroicleap',
-    maxRanks: 1,
-  },
-  PLACEHOLDER_TALENT_TALENT: {
-    id: 390376,
-    name: 'Placeholder Talent',
-    icon: 'garrison_building_workshop',
-    maxRanks: 1,
-  },
-  BLOOD_AND_THUNDER_TALENT: {
-    id: 384277,
-    name: 'Blood and Thunder',
-    icon: 'warrior_talent_icon_bloodandthunder',
-    maxRanks: 1,
-  },
-  CRACKLING_THUNDER_TALENT: {
-    id: 203201,
-    name: 'Crackling Thunder',
-    icon: 'ability_thunderking_overcharge',
-    maxRanks: 1,
-  },
-  SEISMIC_REVERBERATION_TALENT: {
-    id: 382956,
-    name: 'Seismic Reverberation',
-    icon: 'ability_warrior_bloodnova',
-    maxRanks: 1,
-  },
-  ARMORED_TO_THE_TEETH_TALENT: {
-    id: 384124,
-    name: 'Armored to the Teeth',
-    icon: 'inv_shoulder_22',
-    maxRanks: 1,
-  },
-  DOUBLE_TIME_TALENT: { id: 103827, name: 'Double Time', icon: 'inv_misc_horn_04', maxRanks: 1 },
-  MASSACRE_TALENT: { id: 206315, name: 'Massacre', icon: 'inv_sword_48', maxRanks: 1 },
-  REINFORCED_PLATES_TALENT: {
-    id: 382939,
-    name: 'Reinforced Plates',
-    icon: 'inv_chest_plate04',
-    maxRanks: 2,
-  },
-  ENDURANCE_TRAINING_TALENT: {
-    id: 391273,
-    name: 'Endurance Training',
-    icon: 'spell_holy_blessingofstamina',
-    maxRanks: 2,
-  },
-  DUAL_WIELD_SPECIALIZATION_TALENT: {
-    id: 382900,
-    name: 'Dual Wield Specialization',
-    icon: 'ability_dualwield',
-    maxRanks: 1,
-  },
-  CRUEL_STRIKES_TALENT: {
-    id: 391324,
-    name: 'Cruel Strikes',
-    icon: 'ability_criticalstrike',
-    maxRanks: 2,
-  },
-  QUICK_THINKING_TALENT: {
-    id: 382946,
-    name: 'Quick Thinking',
-    icon: 'ability_rogue_sprint',
-    maxRanks: 2,
-  },
-  AVATAR_TALENT: { id: 107574, name: 'Avatar', icon: 'warrior_talent_icon_avatar', maxRanks: 1 },
-  SHOCKWAVE_TALENT: {
-    id: 46968,
-    name: 'Shockwave',
-    icon: 'ability_warrior_shockwave',
-    maxRanks: 1,
-  },
-  BITTER_IMMUNITY_TALENT: {
-    id: 383762,
-    name: 'Bitter Immunity',
-    icon: 'spell_nature_shamanrage',
-    maxRanks: 1,
-  },
-  SPEAR_OF_BASTION_TALENT: {
-    id: 376079,
-    name: 'Spear of Bastion',
-    icon: 'ability_bastion_warrior',
-    maxRanks: 1,
-  },
-  THUNDEROUS_ROAR_TALENT: {
-    id: 384318,
-    name: 'Thunderous Roar',
-    icon: 'ability_warrior_dragonroar',
-    maxRanks: 1,
-  },
-  MEMORY_OF_A_TORMENTED_BERSERKER_TALENT: {
-    id: 390123,
-    name: 'Memory of a Tormented Berserker',
-    icon: 'ability_warrior_innerrage',
-    maxRanks: 1,
-  },
-  MEMORY_OF_A_TORMENTED_TITAN_TALENT: {
-    id: 390135,
-    name: 'Memory of a Tormented Titan',
-    icon: '70_inscription_vantus_rune_odyn',
-    maxRanks: 1,
-  },
-  RUMBLING_EARTH_TALENT: {
-    id: 275339,
-    name: 'Rumbling Earth',
-    icon: 'spell_shaman_earthquake',
-    maxRanks: 1,
-  },
-  SONIC_BOOM_TALENT: {
-    id: 390725,
-    name: 'Sonic Boom',
-    icon: 'warrior_talent_icon_thunderstruck',
-    maxRanks: 1,
-  },
-  PIERCING_VERDICT_TALENT: {
-    id: 382948,
-    name: 'Piercing Verdict',
-    icon: 'spell_animabastion_missile',
-    maxRanks: 1,
-  },
-  ELYSIAN_MIGHT_TALENT: {
-    id: 386285,
-    name: 'Elysian Might',
-    icon: 'ability_bastion_warrior',
-    maxRanks: 1,
-  },
-  THUNDEROUS_WORDS_TALENT: {
-    id: 384969,
-    name: 'Thunderous Words',
-    icon: 'spell_nature_earthquake',
-    maxRanks: 1,
-  },
-  SUDDEN_DEATH_TALENT: {
-    id: 29725,
-    name: 'Sudden Death',
-    icon: 'ability_warrior_improveddisciplines',
-    maxRanks: 1,
-  },
-  ONE_HANDED_WEAPON_SPECIALIZATION_TALENT: {
-    id: 382895,
-    name: 'One-Handed Weapon Specialization',
-    icon: 'inv_sword_20',
-    maxRanks: 1,
-  },
-  SIGNET_OF_TORMENTED_KINGS_TALENT: {
-    id: 382949,
-    name: 'Signet of Tormented Kings',
-    icon: 'inv_60crafted_ring4b',
-    maxRanks: 1,
-  },
-  UNSTOPPABLE_FORCE_TALENT: {
-    id: 275336,
-    name: 'Unstoppable Force',
-    icon: 'warrior_talent_icon_thunderstruck',
-    maxRanks: 1,
-  },
-  TWO_HANDED_WEAPON_SPECIALIZATION_TALENT: {
-    id: 382896,
-    name: 'Two-Handed Weapon Specialization',
-    icon: 'inv_axe_09',
-    maxRanks: 1,
-  },
-  MEMORY_OF_A_TORMENTED_BLADEMASTER_TALENT: {
-    id: 390138,
-    name: 'Memory of a Tormented Blademaster',
-    icon: 'spell_nature_mirrorimage',
-    maxRanks: 1,
-  },
-  MEMORY_OF_A_TORMENTED_WARLORD_TALENT: {
-    id: 390140,
-    name: 'Memory of a Tormented Warlord',
-    icon: 'warrior_talent_icon_innerrage',
-    maxRanks: 1,
-  },
+  BATTLE_STANCE_TALENT,
+  DEFENSIVE_STANCE_TALENT,
+  BERSERKER_STANCE_TALENT,
+  FAST_FOOTWORK_TALENT,
+  RALLYING_CRY_TALENT,
+  INTERVENE_TALENT,
+  BERSERKER_RAGE_TALENT,
+  SIPHONING_STRIKES_TALENT,
+  IMPENDING_VICTORY_TALENT,
+  INSPIRING_PRESENCE_TALENT,
+  SECOND_WIND_TALENT,
+  SPELL_REFLECTION_TALENT,
+  BERSERKER_SHOUT_TALENT,
+  PIERCING_HOWL_TALENT,
+  WAR_MACHINE_TALENT,
+  HONED_REFLEXES_TALENT,
+  HEROIC_LEAP_TALENT,
+  INTIMIDATING_SHOUT_TALENT,
+  THUNDER_CLAP_TALENT,
+  FURIOUS_BLOWS_TALENT,
+  WRECKING_THROW_TALENT,
+  SHATTERING_THROW_TALENT,
+  CRUSHING_FORCE_TALENT,
+  CONCUSSIVE_BLOWS_TALENT,
+  CACOPHONOUS_ROAR_TALENT,
+  MENACE_TALENT,
+  STORM_BOLT_TALENT,
+  PAIN_AND_GAIN_TALENT,
+  OVERWHELMING_RAGE_TALENT,
+  TITANIC_THROW_TALENT,
+  BARBARIC_TRAINING_TALENT,
+  FROTHING_BERSERKER_TALENT,
+  BOUNDING_STRIDE_TALENT,
+  PLACEHOLDER_TALENT_TALENT,
+  BLOOD_AND_THUNDER_TALENT,
+  CRACKLING_THUNDER_TALENT,
+  SEISMIC_REVERBERATION_TALENT,
+  ARMORED_TO_THE_TEETH_TALENT,
+  DOUBLE_TIME_TALENT,
+  MASSACRE_TALENT,
+  REINFORCED_PLATES_TALENT,
+  ENDURANCE_TRAINING_TALENT,
+  DUAL_WIELD_SPECIALIZATION_TALENT,
+  CRUEL_STRIKES_TALENT,
+  QUICK_THINKING_TALENT,
+  AVATAR_TALENT,
+  SHOCKWAVE_TALENT,
+  BITTER_IMMUNITY_TALENT,
+  SPEAR_OF_BASTION_TALENT,
+  THUNDEROUS_ROAR_TALENT,
+  MEMORY_OF_A_TORMENTED_BERSERKER_TALENT,
+  MEMORY_OF_A_TORMENTED_TITAN_TALENT,
+  RUMBLING_EARTH_TALENT,
+  SONIC_BOOM_TALENT,
+  PIERCING_VERDICT_TALENT,
+  ELYSIAN_MIGHT_TALENT,
+  THUNDEROUS_WORDS_TALENT,
+  SUDDEN_DEATH_TALENT,
+  ONE_HANDED_WEAPON_SPECIALIZATION_TALENT,
+  SIGNET_OF_TORMENTED_KINGS_TALENT,
+  UNSTOPPABLE_FORCE_TALENT,
+  TWO_HANDED_WEAPON_SPECIALIZATION_TALENT,
+  MEMORY_OF_A_TORMENTED_BLADEMASTER_TALENT,
+  MEMORY_OF_A_TORMENTED_WARLORD_TALENT,
 
   //Fury
-  BLOODTHIRST_FURY_TALENT: {
-    id: 23881,
-    name: 'Bloodthirst',
-    icon: 'spell_nature_bloodlust',
-    maxRanks: 1,
-  },
-  RAGING_BLOW_FURY_TALENT: {
-    id: 85288,
-    name: 'Raging Blow',
-    icon: 'warrior_wild_strike',
-    maxRanks: 1,
-  },
-  IMPROVED_ENRAGE_FURY_TALENT: {
-    id: 383848,
-    name: 'Improved Enrage',
-    icon: 'spell_shadow_unholyfrenzy',
-    maxRanks: 1,
-  },
-  ENRAGED_REGENERATION_FURY_TALENT: {
-    id: 184364,
-    name: 'Enraged Regeneration',
-    icon: 'ability_warrior_focusedrage',
-    maxRanks: 1,
-  },
-  IMPROVED_EXECUTE_FURY_TALENT: {
-    id: 316402,
-    name: 'Improved Execute',
-    icon: 'inv_sword_48',
-    maxRanks: 1,
-  },
-  IMPROVED_BLOODTHIRST_FURY_TALENT: {
-    id: 383852,
-    name: 'Improved Bloodthirst',
-    icon: 'spell_nature_bloodlust',
-    maxRanks: 1,
-  },
-  FRESH_MEAT_FURY_TALENT: {
-    id: 215568,
-    name: 'Fresh Meat',
-    icon: 'ability_deathwing_bloodcorruption_death',
-    maxRanks: 1,
-  },
-  WARPAINT_FURY_TALENT: {
-    id: 208154,
-    name: 'Warpaint',
-    icon: 'ability_rogue_preparation',
-    maxRanks: 1,
-  },
-  INVIGORATING_FURY_FURY_TALENT: {
-    id: 383468,
-    name: 'Invigorating Fury',
-    icon: 'spell_misc_emotionangry',
-    maxRanks: 1,
-  },
-  SUDDEN_DEATH_FURY_TALENT: {
-    id: 280721,
-    name: 'Sudden Death',
-    icon: 'ability_warrior_improveddisciplines',
-    maxRanks: 1,
-  },
-  IMPROVED_RAGING_BLOW_FURY_TALENT: {
-    id: 383854,
-    name: 'Improved Raging Blow',
-    icon: 'warrior_wild_strike',
-    maxRanks: 1,
-  },
-  FOCUS_IN_CHAOS_FURY_TALENT: {
-    id: 383486,
-    name: 'Focus In Chaos',
-    icon: 'ability_hunter_mastermarksman',
-    maxRanks: 1,
-  },
-  RAMPAGE_FURY_TALENT: {
-    id: 184367,
-    name: 'Rampage',
-    icon: 'ability_warrior_rampage',
-    maxRanks: 1,
-    rageCost: 80,
-  },
-  IMPROVED_WHIRLWIND_FURY_TALENT: {
-    id: 12950,
-    name: 'Improved Whirlwind',
-    icon: 'ability_whirlwind',
-    maxRanks: 1,
-  },
-  SINGLE_MINDED_FURY_FURY_TALENT: {
-    id: 81099,
-    name: 'Single-Minded Fury',
-    icon: 'warrior_talent_icon_singlemindedfury',
-    maxRanks: 1,
-  },
-  COLD_STEEL_HOT_BLOOD_FURY_TALENT: {
-    id: 383959,
-    name: 'Cold Steel, Hot Blood',
-    icon: 'ability_rogue_hungerforblood',
-    maxRanks: 1,
-  },
-  VICIOUS_CONTEMPT_FURY_TALENT: {
-    id: 383885,
-    name: 'Vicious Contempt',
-    icon: 'ability_ironmaidens_sorkasprey',
-    maxRanks: 2,
-  },
-  FRENZY_FURY_TALENT: { id: 335077, name: 'Frenzy', icon: 'ability_rogue_bloodyeye', maxRanks: 1 },
-  HACK_AND_SLASH_FURY_TALENT: {
-    id: 383877,
-    name: 'Hack And Slash',
-    icon: 'ability_rogue_rollthebones02',
-    maxRanks: 1,
-  },
-  SLAUGHTERING_STRIKES_FURY_TALENT: {
-    id: 388004,
-    name: 'Slaughtering Strikes',
-    icon: 'inv_axe_2h_orcwarrior_c_01',
-    maxRanks: 1,
-  },
-  CRUELTY_FURY_TALENT: {
-    id: 335070,
-    name: 'Cruelty',
-    icon: 'spell_nature_focusedmind',
-    maxRanks: 2,
-  },
-  SIEGEBREAKER_FURY_TALENT: { id: 280772, name: 'Siegebreaker', icon: 'inv_mace_101', maxRanks: 1 },
-  MEAT_CLEAVER_FURY_TALENT: {
-    id: 280392,
-    name: 'Meat Cleaver',
-    icon: 'ability_whirlwind',
-    maxRanks: 2,
-  },
-  FRENZIED_FLURRY_FURY_TALENT: {
-    id: 383605,
-    name: 'Frenzied Flurry',
-    icon: 'ability_ghoulfrenzy',
-    maxRanks: 2,
-  },
-  BLOODBORNE_FURY_TALENT: {
-    id: 385703,
-    name: 'Bloodborne',
-    icon: 'inv_artifact_bloodoftheassassinated',
-    maxRanks: 1,
-  },
-  CADENCE_OF_FUJIEDA_FURY_TALENT: {
-    id: 383919,
-    name: 'Cadence of Fujieda',
-    icon: 'ability_garrosh_hellscreams_warsong',
-    maxRanks: 1,
-  },
-  BLOODCRAZE_FURY_TALENT: {
-    id: 385735,
-    name: 'Bloodcraze',
-    icon: 'ability_creature_cursed_02',
-    maxRanks: 1,
-  },
-  RECKLESSNESS_FURY_TALENT: {
-    id: 1719,
-    name: 'Recklessness',
-    icon: 'warrior_talent_icon_innerrage',
-    maxRanks: 1,
-  },
-  WRATH_AND_FURY_FURY_TALENT: {
-    id: 386045,
-    name: 'Wrath and Fury',
-    icon: 'warrior_wild_strike',
-    maxRanks: 1,
-  },
-  DEAFENING_CRASH_FURY_TALENT: {
-    id: 383613,
-    name: 'Deafening Crash',
-    icon: 'spell_nature_earthquake',
-    maxRanks: 1,
-  },
-  RAGING_ARMAMENTS_FURY_TALENT: {
-    id: 388049,
-    name: 'Raging Armaments',
-    icon: 'warrior_wild_strike',
-    maxRanks: 1,
-  },
-  DEFT_EXPERIENCE_FURY_TALENT: {
-    id: 383295,
-    name: 'Deft Experience',
-    icon: 'inv_misc_book_07',
-    maxRanks: 2,
-  },
-  SWIFT_STRIKES_FURY_TALENT: {
-    id: 383459,
-    name: 'Swift Strikes',
-    icon: 'ability_rogue_sprint',
-    maxRanks: 2,
-  },
-  CRITICAL_THINKING_FURY_TALENT: {
-    id: 383297,
-    name: 'Critical Thinking',
-    icon: 'ability_criticalstrike',
-    maxRanks: 2,
-  },
-  STORM_OF_SWORDS_FURY_TALENT: {
-    id: 388903,
-    name: 'Storm of Swords',
-    icon: 'ability_skyreach_fourblades',
-    maxRanks: 1,
-  },
-  ODYNS_FURY_FURY_TALENT: {
-    id: 385059,
-    name: "Odyn's Fury",
-    icon: 'inv_sword_1h_artifactvigfus_d_01',
-    maxRanks: 1,
-  },
-  ANGER_MANAGEMENT_FURY_TALENT: {
-    id: 152278,
-    name: 'Anger Management',
-    icon: 'warrior_talent_icon_angermanagement',
-    maxRanks: 1,
-  },
-  RECKLESS_ABANDON_FURY_TALENT: {
-    id: 202751,
-    name: 'Reckless Abandon',
-    icon: 'ability_warrior_battleshout',
-    maxRanks: 1,
-  },
-  ONSLAUGHT_FURY_TALENT: {
-    id: 315720,
-    name: 'Onslaught',
-    icon: 'ability_warrior_trauma',
-    maxRanks: 1,
-  },
-  RAVAGER_FURY_TALENT: {
-    id: 228920,
-    name: 'Ravager',
-    icon: 'warrior_talent_icon_ravager',
-    maxRanks: 1,
-  },
-  ANNIHILATOR_FURY_TALENT: {
-    id: 383916,
-    name: 'Annihilator',
-    icon: 'ability_warrior_annihilator',
-    maxRanks: 1,
-  },
-  ODYNS_FURY_MODIFIER_FURY_TALENT: {
-    id: 389014,
-    name: "Odyn's Fury Modifier",
-    icon: 'garrison_building_workshop',
-    maxRanks: 1,
-  },
-  PLACEHOLDER_TALENT_FURY_TALENT: {
-    id: 390376,
-    name: 'Placeholder Talent',
-    icon: 'garrison_building_workshop',
-    maxRanks: 1,
-  },
-  UNBRIDLED_FEROCITY_FURY_TALENT: {
-    id: 389603,
-    name: 'Unbridled Ferocity',
-    icon: 'ability_warrior_endlessrage',
-    maxRanks: 1,
-  },
-  SKULL_BANNER_FURY_TALENT: {
-    id: 385348,
-    name: 'Skull Banner',
-    icon: 'warrior_skullbanner',
-    maxRanks: 1,
-  },
-  SIDEARM_FURY_TALENT: { id: 384404, name: 'Sidearm', icon: 'inv_throwingaxe_06', maxRanks: 1 },
-  DEPTHS_OF_INSANITY_FURY_TALENT: {
-    id: 383922,
-    name: 'Depths of Insanity',
-    icon: 'racial_troll_berserk',
-    maxRanks: 1,
-  },
-  PULVERIZE_FURY_TALENT: {
-    id: 388933,
-    name: 'Pulverize',
-    icon: 'inv_mace_1h_blacksmithing_b_01_black',
-    maxRanks: 1,
-  },
-  STORM_OF_STEEL_FURY_TALENT: {
-    id: 382953,
-    name: 'Storm of Steel',
-    icon: 'ability_creature_cursed_04',
-    maxRanks: 1,
-  },
-  GATHERING_STORM_FURY_TALENT: {
-    id: 390563,
-    name: 'Gathering Storm',
-    icon: 'ability_warrior_bladestorm',
-    maxRanks: 1,
-  },
+  BLOODTHIRST_FURY_TALENT,
+  RAGING_BLOW_FURY_TALENT,
+  IMPROVED_ENRAGE_FURY_TALENT,
+  ENRAGED_REGENERATION_FURY_TALENT,
+  IMPROVED_EXECUTE_FURY_TALENT,
+  IMPROVED_BLOODTHIRST_FURY_TALENT,
+  FRESH_MEAT_FURY_TALENT,
+  WARPAINT_FURY_TALENT,
+  INVIGORATING_FURY_FURY_TALENT,
+  SUDDEN_DEATH_FURY_TALENT,
+  IMPROVED_RAGING_BLOW_FURY_TALENT,
+  FOCUS_IN_CHAOS_FURY_TALENT,
+  RAMPAGE_FURY_TALENT,
+  IMPROVED_WHIRLWIND_FURY_TALENT,
+  SINGLE_MINDED_FURY_FURY_TALENT,
+  COLD_STEEL_HOT_BLOOD_FURY_TALENT,
+  VICIOUS_CONTEMPT_FURY_TALENT,
+  FRENZY_FURY_TALENT,
+  HACK_AND_SLASH_FURY_TALENT,
+  SLAUGHTERING_STRIKES_FURY_TALENT,
+  CRUELTY_FURY_TALENT,
+  SIEGEBREAKER_FURY_TALENT,
+  MEAT_CLEAVER_FURY_TALENT,
+  FRENZIED_FLURRY_FURY_TALENT,
+  BLOODBORNE_FURY_TALENT,
+  CADENCE_OF_FUJIEDA_FURY_TALENT,
+  BLOODCRAZE_FURY_TALENT,
+  RECKLESSNESS_FURY_TALENT,
+  WRATH_AND_FURY_FURY_TALENT,
+  DEAFENING_CRASH_FURY_TALENT,
+  RAGING_ARMAMENTS_FURY_TALENT,
+  DEFT_EXPERIENCE_FURY_TALENT,
+  SWIFT_STRIKES_FURY_TALENT,
+  CRITICAL_THINKING_FURY_TALENT,
+  STORM_OF_SWORDS_FURY_TALENT,
+  ODYNS_FURY_FURY_TALENT,
+  ANGER_MANAGEMENT_FURY_TALENT,
+  RECKLESS_ABANDON_FURY_TALENT,
+  ONSLAUGHT_FURY_TALENT,
+  RAVAGER_FURY_TALENT,
+  ANNIHILATOR_FURY_TALENT,
+  ODYNS_FURY_MODIFIER_FURY_TALENT,
+  PLACEHOLDER_TALENT_FURY_TALENT,
+  UNBRIDLED_FEROCITY_FURY_TALENT,
+  SKULL_BANNER_FURY_TALENT,
+  SIDEARM_FURY_TALENT,
+  DEPTHS_OF_INSANITY_FURY_TALENT,
+  PULVERIZE_FURY_TALENT,
+  STORM_OF_STEEL_FURY_TALENT,
+  GATHERING_STORM_FURY_TALENT,
 
   //Protection
-  IGNORE_PAIN_PROTECTION_TALENT: {
-    id: 190456,
-    name: 'Ignore Pain',
-    icon: 'ability_warrior_renewedvigor',
-    maxRanks: 1,
-    rageCost: 40,
-  },
-  REVENGE_PROTECTION_TALENT: {
-    id: 6572,
-    name: 'Revenge',
-    icon: 'ability_warrior_revenge',
-    maxRanks: 1,
-    rageCost: 20,
-  },
-  DEMORALIZING_SHOUT_PROTECTION_TALENT: {
-    id: 1160,
-    name: 'Demoralizing Shout',
-    icon: 'ability_warrior_warcry',
-    maxRanks: 1,
-  },
-  DEVASTATE_PROTECTION_TALENT: { id: 20243, name: 'Devastate', icon: 'inv_sword_11', maxRanks: 1 },
-  LAST_STAND_PROTECTION_TALENT: {
-    id: 12975,
-    name: 'Last Stand',
-    icon: 'spell_holy_ashestoashes',
-    maxRanks: 1,
-  },
-  BOOMING_VOICE_PROTECTION_TALENT: {
-    id: 202743,
-    name: 'Booming Voice',
-    icon: 'ability_warrior_commandingshout',
-    maxRanks: 1,
-  },
-  BEST_SERVED_COLD_PROTECTION_TALENT: {
-    id: 202560,
-    name: 'Best Served Cold',
-    icon: 'ability_warrior_revenge',
-    maxRanks: 1,
-  },
-  STRATEGIST_PROTECTION_TALENT: {
-    id: 384041,
-    name: 'Strategist',
-    icon: 'inv_shield_05',
-    maxRanks: 1,
-  },
-  BRACE_FOR_IMPACT_PROTECTION_TALENT: {
-    id: 386030,
-    name: 'Brace For Impact',
-    icon: 'ability_warrior_shieldguard',
-    maxRanks: 1,
-  },
-  UNNERVING_FOCUS_PROTECTION_TALENT: {
-    id: 384042,
-    name: 'Unnerving Focus',
-    icon: 'rogue_shadowfocus',
-    maxRanks: 1,
-  },
-  CHALLENGING_SHOUT_PROTECTION_TALENT: {
-    id: 1161,
-    name: 'Challenging Shout',
-    icon: 'ability_bullrush',
-    maxRanks: 1,
-  },
-  DEVASTATOR_PROTECTION_TALENT: {
-    id: 236279,
-    name: 'Devastator',
-    icon: 'inv_sword_11',
-    maxRanks: 1,
-  },
-  BLOODSURGE_PROTECTION_TALENT: {
-    id: 384361,
-    name: 'Bloodsurge',
-    icon: 'ability_warrior_bloodsurge',
-    maxRanks: 1,
-  },
-  REND_PROTECTION_TALENT: {
-    id: 772,
-    name: 'Rend',
-    icon: 'ability_gouge',
-    maxRanks: 1,
-    rageCost: 30,
-  },
-  FUELED_BY_VIOLENCE_PROTECTION_TALENT: {
-    id: 383103,
-    name: 'Fueled by Violence',
-    icon: 'ability_demonhunter_bloodlet',
-    maxRanks: 1,
-  },
-  BRUTAL_VITALITY_PROTECTION_TALENT: {
-    id: 384036,
-    name: 'Brutal Vitality',
-    icon: 'ability_warrior_renewedvigor',
-    maxRanks: 1,
-  },
-  DISRUPTING_SHOUT_PROTECTION_TALENT: {
-    id: 386071,
-    name: 'Disrupting Shout',
-    icon: 'ability_bullrush',
-    maxRanks: 1,
-  },
-  SHOW_OF_FORCE_PROTECTION_TALENT: {
-    id: 385843,
-    name: 'Show of Force',
-    icon: 'ability_rogue_reinforcedleather',
-    maxRanks: 1,
-  },
-  IMPROVED_HEROIC_THROW_PROTECTION_TALENT: {
-    id: 386034,
-    name: 'Improved Heroic Throw',
-    icon: 'inv_axe_66',
-    maxRanks: 1,
-  },
-  THUNDERLORD_PROTECTION_TALENT: {
-    id: 385840,
-    name: 'Thunderlord',
-    icon: 'ability_vehicle_electrocharge',
-    maxRanks: 1,
-  },
-  SHIELD_WALL_PROTECTION_TALENT: {
-    id: 871,
-    name: 'Shield Wall',
-    icon: 'ability_warrior_shieldwall',
-    maxRanks: 1,
-  },
-  BOLSTER_PROTECTION_TALENT: {
-    id: 280001,
-    name: 'Bolster',
-    icon: 'shield_draenorcrafted_d_02_c_alliance',
-    maxRanks: 1,
-  },
-  SPIKED_SHIELD_PROTECTION_TALENT: {
-    id: 385888,
-    name: 'Spiked Shield',
-    icon: 'inv_titanium_shield_spike',
-    maxRanks: 1,
-  },
-  NEVER_SURRENDER_PROTECTION_TALENT: {
-    id: 279996,
-    name: 'Never Surrender',
-    icon: 'ability_butcher_gushingwounds',
-    maxRanks: 1,
-  },
-  BLOODBORNE_PROTECTION_TALENT: {
-    id: 385704,
-    name: 'Bloodborne',
-    icon: 'inv_artifact_bloodoftheassassinated',
-    maxRanks: 2,
-  },
-  HEAVY_REPERCUSSIONS_PROTECTION_TALENT: {
-    id: 203177,
-    name: 'Heavy Repercussions',
-    icon: 'inv_shield_32',
-    maxRanks: 1,
-  },
-  INTO_THE_FRAY_PROTECTION_TALENT: {
-    id: 202603,
-    name: 'Into the Fray',
-    icon: 'ability_warrior_bloodfrenzy',
-    maxRanks: 1,
-  },
-  ENDURING_DEFENSES_PROTECTION_TALENT: {
-    id: 386027,
-    name: 'Enduring Defenses',
-    icon: 'ability_defend',
-    maxRanks: 1,
-  },
-  MASSACRE_PROTECTION_TALENT: { id: 281001, name: 'Massacre', icon: 'inv_sword_48', maxRanks: 1 },
-  ANGER_MANAGEMENT_PROTECTION_TALENT: {
-    id: 152278,
-    name: 'Anger Management',
-    icon: 'warrior_talent_icon_angermanagement',
-    maxRanks: 1,
-  },
-  UNBREAKABLE_WILL_PROTECTION_TALENT: {
-    id: 384074,
-    name: 'Unbreakable Will',
-    icon: 'ability_warrior_stalwartprotector',
-    maxRanks: 1,
-  },
-  THE_WALL_PROTECTION_TALENT: {
-    id: 384072,
-    name: 'The Wall',
-    icon: 'ability_warrior_shieldguard',
-    maxRanks: 1,
-  },
-  PUNISH_PROTECTION_TALENT: {
-    id: 275334,
-    name: 'Punish',
-    icon: 'ability_deathknight_sanguinfortitude',
-    maxRanks: 1,
-  },
-  JUGGERNAUT_PROTECTION_TALENT: {
-    id: 383292,
-    name: 'Juggernaut',
-    icon: 'warrior_talent_icon_skirmisher',
-    maxRanks: 1,
-  },
-  ENDURING_ALACRITY_PROTECTION_TALENT: {
-    id: 384063,
-    name: 'Enduring Alacrity',
-    icon: 'spell_nature_unyeildingstamina',
-    maxRanks: 2,
-  },
-  SHIELD_SPECIALIZATION_PROTECTION_TALENT: {
-    id: 386011,
-    name: 'Shield Specialization',
-    icon: 'inv_shield_76',
-    maxRanks: 2,
-  },
-  FOCUSED_VIGOR_PROTECTION_TALENT: {
-    id: 384067,
-    name: 'Focused Vigor',
-    icon: 'spell_nature_strength',
-    maxRanks: 2,
-  },
-  SHIELD_CHARGE_PROTECTION_TALENT: {
-    id: 385952,
-    name: 'Shield Charge',
-    icon: 'ability_warrior_shieldcharge',
-    maxRanks: 1,
-  },
-  OUTBURST_PROTECTION_TALENT: {
-    id: 386477,
-    name: 'Outburst',
-    icon: 'ability_warrior_furiousresolve',
-    maxRanks: 1,
-  },
-  INDOMITABLE_PROTECTION_TALENT: {
-    id: 202095,
-    name: 'Indomitable',
-    icon: 'ability_warrior_intensifyrage',
-    maxRanks: 1,
-  },
-  SPELL_BLOCK_PROTECTION_TALENT: {
-    id: 386014,
-    name: 'Spell Block',
-    icon: 'ability_warrior_shieldbreak',
-    maxRanks: 1,
-  },
-  RAVAGER_PROTECTION_TALENT: {
-    id: 228920,
-    name: 'Ravager',
-    icon: 'warrior_talent_icon_ravager',
-    maxRanks: 1,
-  },
-  CHAMPIONS_BULWARK_PROTECTION_TALENT: {
-    id: 386328,
-    name: "Champion's Bulwark",
-    icon: 'ability_warrior_shieldmastery',
-    maxRanks: 1,
-  },
-  BATTLE_SCARRED_VETERAN_PROTECTION_TALENT: {
-    id: 386394,
-    name: 'Battle-Scarred Veteran',
-    icon: 'ability_warrior_endlessrage',
-    maxRanks: 1,
-  },
-  STORM_OF_STEEL_PROTECTION_TALENT: {
-    id: 382953,
-    name: 'Storm of Steel',
-    icon: 'ability_creature_cursed_04',
-    maxRanks: 1,
-  },
+  IGNORE_PAIN_PROTECTION_TALENT,
+  REVENGE_PROTECTION_TALENT,
+  DEMORALIZING_SHOUT_PROTECTION_TALENT,
+  DEVASTATE_PROTECTION_TALENT,
+  LAST_STAND_PROTECTION_TALENT,
+  BOOMING_VOICE_PROTECTION_TALENT,
+  BEST_SERVED_COLD_PROTECTION_TALENT,
+  STRATEGIST_PROTECTION_TALENT,
+  BRACE_FOR_IMPACT_PROTECTION_TALENT,
+  UNNERVING_FOCUS_PROTECTION_TALENT,
+  CHALLENGING_SHOUT_PROTECTION_TALENT,
+  DEVASTATOR_PROTECTION_TALENT,
+  BLOODSURGE_PROTECTION_TALENT,
+  REND_PROTECTION_TALENT,
+  FUELED_BY_VIOLENCE_PROTECTION_TALENT,
+  BRUTAL_VITALITY_PROTECTION_TALENT,
+  DISRUPTING_SHOUT_PROTECTION_TALENT,
+  SHOW_OF_FORCE_PROTECTION_TALENT,
+  IMPROVED_HEROIC_THROW_PROTECTION_TALENT,
+  THUNDERLORD_PROTECTION_TALENT,
+  SHIELD_WALL_PROTECTION_TALENT,
+  BOLSTER_PROTECTION_TALENT,
+  SPIKED_SHIELD_PROTECTION_TALENT,
+  NEVER_SURRENDER_PROTECTION_TALENT,
+  BLOODBORNE_PROTECTION_TALENT,
+  HEAVY_REPERCUSSIONS_PROTECTION_TALENT,
+  INTO_THE_FRAY_PROTECTION_TALENT,
+  ENDURING_DEFENSES_PROTECTION_TALENT,
+  MASSACRE_PROTECTION_TALENT,
+  ANGER_MANAGEMENT_PROTECTION_TALENT,
+  UNBREAKABLE_WILL_PROTECTION_TALENT,
+  THE_WALL_PROTECTION_TALENT,
+  PUNISH_PROTECTION_TALENT,
+  JUGGERNAUT_PROTECTION_TALENT,
+  ENDURING_ALACRITY_PROTECTION_TALENT,
+  SHIELD_SPECIALIZATION_PROTECTION_TALENT,
+  FOCUSED_VIGOR_PROTECTION_TALENT,
+  SHIELD_CHARGE_PROTECTION_TALENT,
+  OUTBURST_PROTECTION_TALENT,
+  INDOMITABLE_PROTECTION_TALENT,
+  SPELL_BLOCK_PROTECTION_TALENT,
+  RAVAGER_PROTECTION_TALENT,
+  CHAMPIONS_BULWARK_PROTECTION_TALENT,
+  BATTLE_SCARRED_VETERAN_PROTECTION_TALENT,
+  STORM_OF_STEEL_PROTECTION_TALENT,
 
   //Arms
-  MORTAL_STRIKE_ARMS_TALENT: {
-    id: 12294,
-    name: 'Mortal Strike',
-    icon: 'ability_warrior_savageblow',
-    maxRanks: 1,
-    rageCost: 30,
-  },
-  OVERPOWER_ARMS_TALENT: { id: 7384, name: 'Overpower', icon: 'ability_meleedamage', maxRanks: 1 },
-  TACTICIAN_ARMS_TALENT: {
-    id: 184783,
-    name: 'Tactician',
-    icon: 'ability_warrior_unrelentingassault',
-    maxRanks: 1,
-  },
-  DIE_BY_THE_SWORD_ARMS_TALENT: {
-    id: 118038,
-    name: 'Die by the Sword',
-    icon: 'ability_warrior_challange',
-    maxRanks: 1,
-  },
-  MARTIAL_PROWESS_ARMS_TALENT: {
-    id: 316440,
-    name: 'Martial Prowess',
-    icon: 'ability_warrior_weaponmastery',
-    maxRanks: 1,
-  },
-  IMPROVED_OVERPOWER_ARMS_TALENT: {
-    id: 385571,
-    name: 'Improved Overpower',
-    icon: 'ability_meleedamage',
-    maxRanks: 1,
-  },
-  BLOODSURGE_ARMS_TALENT: {
-    id: 384361,
-    name: 'Bloodsurge',
-    icon: 'ability_warrior_bloodsurge',
-    maxRanks: 1,
-  },
-  FUELED_BY_VIOLENCE_ARMS_TALENT: {
-    id: 383103,
-    name: 'Fueled by Violence',
-    icon: 'ability_demonhunter_bloodlet',
-    maxRanks: 1,
-  },
-  STORM_WALL_ARMS_TALENT: { id: 388807, name: 'Storm Wall', icon: 'spell_sandstorm', maxRanks: 1 },
-  IMPROVED_EXECUTE_ARMS_TALENT: {
-    id: 316405,
-    name: 'Improved Execute',
-    icon: 'inv_sword_48',
-    maxRanks: 1,
-  },
-  IMPROVED_MORTAL_STRIKE_ARMS_TALENT: {
-    id: 385573,
-    name: 'Improved Mortal Strike',
-    icon: 'ability_warrior_savageblow',
-    maxRanks: 1,
-  },
-  IMPALE_ARMS_TALENT: { id: 383430, name: 'Impale', icon: 'ability_searingarrow', maxRanks: 1 },
-  EXPLOIT_THE_WEAKNESS_ARMS_TALENT: {
-    id: 383162,
-    name: 'Exploit the Weakness',
-    icon: 'ability_warrior_warbringer',
-    maxRanks: 1,
-  },
-  PUNISHMENT_ARMS_TALENT: {
-    id: 383136,
-    name: 'Punishment',
-    icon: 'ability_warrior_secondwind',
-    maxRanks: 1,
-  },
-  COLOSSUS_SMASH_ARMS_TALENT: {
-    id: 167105,
-    name: 'Colossus Smash',
-    icon: 'ability_warrior_colossussmash',
-    maxRanks: 1,
-  },
-  SKULLSPLITTER_ARMS_TALENT: {
-    id: 260643,
-    name: 'Skullsplitter',
-    icon: 'inv_skullsplitter',
-    maxRanks: 1,
-  },
-  REND_ARMS_TALENT: { id: 772, name: 'Rend', icon: 'ability_gouge', maxRanks: 1, rageCost: 30 },
-  EXHILARATING_BLOWS_ARMS_TALENT: {
-    id: 383219,
-    name: 'Exhilarating Blows',
-    icon: 'warrior_talent_icon_igniteweapon',
-    maxRanks: 1,
-  },
-  SWEEPING_STRIKES_ARMS_TALENT: {
-    id: 260708,
-    name: 'Sweeping Strikes',
-    icon: 'ability_rogue_slicedice',
-    maxRanks: 1,
-  },
-  ANGER_MANAGEMENT_ARMS_TALENT: {
-    id: 152278,
-    name: 'Anger Management',
-    icon: 'warrior_talent_icon_angermanagement',
-    maxRanks: 1,
-  },
-  IN_FOR_THE_KILL_ARMS_TALENT: {
-    id: 248621,
-    name: 'In For The Kill',
-    icon: 'ability_blackhand_marked4death',
-    maxRanks: 1,
-  },
-  TEST_OF_MIGHT_ARMS_TALENT: {
-    id: 385008,
-    name: 'Test of Might',
-    icon: 'ability_warrior_strengthofarms',
-    maxRanks: 1,
-  },
-  CLEAVE_ARMS_TALENT: {
-    id: 845,
-    name: 'Cleave',
-    icon: 'ability_warrior_cleave',
-    maxRanks: 1,
-    rageCost: 20,
-  },
-  FRACTURE_ARMS_TALENT: {
-    id: 386357,
-    name: 'Fracture',
-    icon: 'inv_skinning_80_bloodsoakedbone',
-    maxRanks: 1,
-  },
-  BLOODBORNE_ARMS_TALENT: {
-    id: 383287,
-    name: 'Bloodborne',
-    icon: 'inv_artifact_bloodoftheassassinated',
-    maxRanks: 2,
-  },
-  DREADNAUGHT_ARMS_TALENT: { id: 262150, name: 'Dreadnaught', icon: 'inv_sword_05', maxRanks: 1 },
-  IMPROVED_SWEEPING_STRIKES_ARMS_TALENT: {
-    id: 383155,
-    name: 'Improved Sweeping Strikes',
-    icon: 'ability_rogue_slicedice',
-    maxRanks: 1,
-  },
-  FERVOR_OF_BATTLE_ARMS_TALENT: {
-    id: 202316,
-    name: 'Fervor of Battle',
-    icon: 'ability_rogue_waylay',
-    maxRanks: 1,
-  },
-  STORM_OF_SWORDS_ARMS_TALENT: {
-    id: 385512,
-    name: 'Storm of Swords',
-    icon: 'ability_skyreach_fourblades',
-    maxRanks: 1,
-  },
-  COLLATERAL_DAMAGE_ARMS_TALENT: {
-    id: 334779,
-    name: 'Collateral Damage',
-    icon: 'ability_warrior_incite',
-    maxRanks: 1,
-  },
-  WARBREAKER_ARMS_TALENT: { id: 262161, name: 'Warbreaker', icon: 'inv_warbreaker', maxRanks: 1 },
-  MASSACRE_ARMS_TALENT: { id: 281001, name: 'Massacre', icon: 'inv_sword_48', maxRanks: 1 },
-  REAPING_SWINGS_ARMS_TALENT: {
-    id: 383293,
-    name: 'Reaping Swings',
-    icon: 'ability_rogue_cuttothechase',
-    maxRanks: 1,
-  },
-  DEFT_EXPERIENCE_ARMS_TALENT: {
-    id: 389308,
-    name: 'Deft Experience',
-    icon: 'inv_misc_book_07',
-    maxRanks: 2,
-  },
-  VALOR_IN_VICTORY_ARMS_TALENT: {
-    id: 383338,
-    name: 'Valor in Victory',
-    icon: 'spell_holy_summonchampion',
-    maxRanks: 2,
-  },
-  CRITICAL_THINKING_ARMS_TALENT: {
-    id: 389306,
-    name: 'Critical Thinking',
-    icon: 'ability_criticalstrike',
-    maxRanks: 2,
-  },
-  BLOODLETTING_ARMS_TALENT: {
-    id: 383154,
-    name: 'Bloodletting',
-    icon: 'ability_skeer_bloodletting',
-    maxRanks: 1,
-  },
-  BATTLELORD_ARMS_TALENT: {
-    id: 386630,
-    name: 'Battlelord',
-    icon: 'ability_pvp_hardiness',
-    maxRanks: 1,
-  },
-  BLADESTORM_ARMS_TALENT: {
-    id: 227847,
-    name: 'Bladestorm',
-    icon: 'ability_warrior_bladestorm',
-    maxRanks: 1,
-  },
-  EXPLOITER_ARMS_TALENT: { id: 335451, name: 'Exploiter', icon: 'inv_sword_48', maxRanks: 1 },
-  SKULL_BANNER_ARMS_TALENT: {
-    id: 385348,
-    name: 'Skull Banner',
-    icon: 'warrior_skullbanner',
-    maxRanks: 1,
-  },
-  FATALITY_ARMS_TALENT: {
-    id: 383703,
-    name: 'Fatality',
-    icon: 'achievement_bg_killingblow_berserker',
-    maxRanks: 1,
-  },
-  UNHINGED_ARMS_TALENT: {
-    id: 386628,
-    name: 'Unhinged',
-    icon: 'ability_warrior_savageblow',
-    maxRanks: 1,
-  },
-  GATHERING_STORM_ARMS_TALENT: {
-    id: 390563,
-    name: 'Gathering Storm',
-    icon: 'ability_warrior_bladestorm',
-    maxRanks: 1,
-  },
-  SHARPENED_BLADES_ARMS_TALENT: {
-    id: 383341,
-    name: 'Sharpened Blades',
-    icon: 'inv_sword_27',
-    maxRanks: 1,
-  },
-  BLUNT_INSTRUMENTS_ARMS_TALENT: {
-    id: 383442,
-    name: 'Blunt Instruments',
-    icon: 'inv_mace_01',
-    maxRanks: 1,
-  },
-  MERCILESS_BONEGRINDER_ARMS_TALENT: {
-    id: 383317,
-    name: 'Merciless Bonegrinder',
-    icon: 'ability_ironmaidens_whirlofblood',
-    maxRanks: 1,
-  },
-  DANCE_OF_DEATH_ARMS_TALENT: {
-    id: 390713,
-    name: 'Dance of Death',
-    icon: 'ability_butcher_whirl',
-    maxRanks: 1,
-  },
-  JUGGERNAUT_ARMS_TALENT: {
-    id: 383292,
-    name: 'Juggernaut',
-    icon: 'warrior_talent_icon_skirmisher',
-    maxRanks: 1,
-  },
+  MORTAL_STRIKE_ARMS_TALENT,
+  OVERPOWER_ARMS_TALENT,
+  TACTICIAN_ARMS_TALENT,
+  DIE_BY_THE_SWORD_ARMS_TALENT,
+  MARTIAL_PROWESS_ARMS_TALENT,
+  IMPROVED_OVERPOWER_ARMS_TALENT,
+  BLOODSURGE_ARMS_TALENT,
+  FUELED_BY_VIOLENCE_ARMS_TALENT,
+  STORM_WALL_ARMS_TALENT,
+  IMPROVED_EXECUTE_ARMS_TALENT,
+  IMPROVED_MORTAL_STRIKE_ARMS_TALENT,
+  IMPALE_ARMS_TALENT,
+  EXPLOIT_THE_WEAKNESS_ARMS_TALENT,
+  PUNISHMENT_ARMS_TALENT,
+  COLOSSUS_SMASH_ARMS_TALENT,
+  SKULLSPLITTER_ARMS_TALENT,
+  REND_ARMS_TALENT,
+  EXHILARATING_BLOWS_ARMS_TALENT,
+  SWEEPING_STRIKES_ARMS_TALENT,
+  ANGER_MANAGEMENT_ARMS_TALENT,
+  IN_FOR_THE_KILL_ARMS_TALENT,
+  TEST_OF_MIGHT_ARMS_TALENT,
+  CLEAVE_ARMS_TALENT,
+  FRACTURE_ARMS_TALENT,
+  BLOODBORNE_ARMS_TALENT,
+  DREADNAUGHT_ARMS_TALENT,
+  IMPROVED_SWEEPING_STRIKES_ARMS_TALENT,
+  FERVOR_OF_BATTLE_ARMS_TALENT,
+  STORM_OF_SWORDS_ARMS_TALENT,
+  COLLATERAL_DAMAGE_ARMS_TALENT,
+  WARBREAKER_ARMS_TALENT,
+  MASSACRE_ARMS_TALENT,
+  REAPING_SWINGS_ARMS_TALENT,
+  DEFT_EXPERIENCE_ARMS_TALENT,
+  VALOR_IN_VICTORY_ARMS_TALENT,
+  CRITICAL_THINKING_ARMS_TALENT,
+  BLOODLETTING_ARMS_TALENT,
+  BATTLELORD_ARMS_TALENT,
+  BLADESTORM_ARMS_TALENT,
+  EXPLOITER_ARMS_TALENT,
+  SKULL_BANNER_ARMS_TALENT,
+  FATALITY_ARMS_TALENT,
+  UNHINGED_ARMS_TALENT,
+  GATHERING_STORM_ARMS_TALENT,
+  SHARPENED_BLADES_ARMS_TALENT,
+  BLUNT_INSTRUMENTS_ARMS_TALENT,
+  MERCILESS_BONEGRINDER_ARMS_TALENT,
+  DANCE_OF_DEATH_ARMS_TALENT,
+  JUGGERNAUT_ARMS_TALENT,
 });
 
 export default talents;


### PR DESCRIPTION
enables the use of single imports like the below while maintaining existing behavior:
```tsx
import {THE_HUNT_TALENT} from 'common/TALENTS/demonhunter';
```