### PR TITLE
Update `hasTalent` for Dragonflight talents

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -63,6 +63,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2022, 9, 8), 'Add support for Dragonflight talent detection.', emallson),
   change(date(2022, 8, 28), 'Add capability of auto-generating talents for Dragonflight based on gamedata', Putro),
   change(date(2022, 8, 25), "Added support for querying cooldown status at any point in the fight", Sref),
   change(date(2022, 8, 23), "Fixed a bug where the timeline's cooldown tooltips weren't showing properly", Sref),

--- a/src/analysis/classic/priest/modules/Abilities.tsx
+++ b/src/analysis/classic/priest/modules/Abilities.tsx
@@ -278,12 +278,12 @@ class Abilities extends CoreAbilities {
         gcd: {
           static: 1500,
         },
-        enabled: this.selectedCombatant.talents[1] >= 41,
+        enabled: this.selectedCombatant.talentPoints[1] >= 41,
       },
       {
         spell: SPELLS.INNER_FOCUS,
         category: SPELL_CATEGORY.COOLDOWNS,
-        enabled: this.selectedCombatant.talents[0] >= 11,
+        enabled: this.selectedCombatant.talentPoints[0] >= 11,
         cooldown: 180,
         castEfficiency: {
           suggestion: true,
@@ -303,7 +303,7 @@ class Abilities extends CoreAbilities {
           recommendedEfficiency: 0.85,
           extraSuggestion: 'You should aim to use this off CD.',
         },
-        enabled: this.selectedCombatant.talents[0] >= 31,
+        enabled: this.selectedCombatant.talentPoints[0] >= 31,
       },
       {
         spell: SPELLS.PAIN_SUPPRESSION,
@@ -311,7 +311,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           static: 1500,
         },
-        enabled: this.selectedCombatant.talents[0] >= 41,
+        enabled: this.selectedCombatant.talentPoints[0] >= 41,
       },
       {
         spell: [SPELLS.MIND_FLAY, ...lowRankSpells[SPELLS.MIND_FLAY]],
@@ -319,7 +319,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           static: 1500,
         },
-        enabled: this.selectedCombatant.talents[2] >= 11,
+        enabled: this.selectedCombatant.talentPoints[2] >= 11,
       },
       {
         spell: SPELLS.SILENCE,
@@ -334,7 +334,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           static: 1500,
         },
-        enabled: this.selectedCombatant.talents[2] >= 21,
+        enabled: this.selectedCombatant.talentPoints[2] >= 21,
       },
       {
         spell: SPELLS.SHADOW_FORM,
@@ -342,7 +342,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           static: 1500,
         },
-        enabled: this.selectedCombatant.talents[2] >= 41,
+        enabled: this.selectedCombatant.talentPoints[2] >= 41,
       },
       {
         spell: SPELLS.SYMBOL_OF_HOPE,

--- a/src/analysis/classic/priest/modules/checklist/Component.tsx
+++ b/src/analysis/classic/priest/modules/checklist/Component.tsx
@@ -48,9 +48,9 @@ const PriestChecklist = ({ thresholds, castEfficiency, combatant }: ChecklistPro
           </>
         }
       >
-        {combatant.talents[0] >= 11 && <AbilityRequirement spell={SPELLS.INNER_FOCUS} />}
-        {combatant.talents[0] >= 31 && <AbilityRequirement spell={SPELLS.POWER_INFUSION} />}
-        {combatant.talents[0] >= 41 && <AbilityRequirement spell={SPELLS.PAIN_SUPPRESSION} />}
+        {combatant.talentPoints[0] >= 11 && <AbilityRequirement spell={SPELLS.INNER_FOCUS} />}
+        {combatant.talentPoints[0] >= 31 && <AbilityRequirement spell={SPELLS.POWER_INFUSION} />}
+        {combatant.talentPoints[0] >= 41 && <AbilityRequirement spell={SPELLS.PAIN_SUPPRESSION} />}
         <AbilityRequirement spell={SPELLS.SHADOW_FIEND} />
       </Rule>
       <Rule

--- a/src/analysis/classic/priest/modules/spells/CircleOfHealing.tsx
+++ b/src/analysis/classic/priest/modules/spells/CircleOfHealing.tsx
@@ -16,7 +16,7 @@ class CircleOfHealing extends Analyzer {
   protected abilityTracker!: AbilityTracker;
 
   get cohEnabled() {
-    return this.selectedCombatant.talents[1] >= 41;
+    return this.selectedCombatant.talentPoints[1] >= 41;
   }
 
   get castCount() {

--- a/src/analysis/classic/priest/modules/spells/PowerInfusion.ts
+++ b/src/analysis/classic/priest/modules/spells/PowerInfusion.ts
@@ -15,7 +15,7 @@ class PowerInfusion extends Analyzer {
   }
 
   get hasPowerInfusion(): boolean {
-    return this.selectedCombatant.talents[0] >= 31;
+    return this.selectedCombatant.talentPoints[0] >= 31;
   }
 }
 

--- a/src/interface/report/Results/PlayerGearHeader.tsx
+++ b/src/interface/report/Results/PlayerGearHeader.tsx
@@ -19,7 +19,7 @@ const PlayerGearHeader = ({ player, averageIlvl }: Props) => (
     </div>
     <div>
       {player.race && player.race.name} {player.player.type}{' '}
-      {player.owner.config.expansion !== RETAIL_EXPANSION && `(${player.talents.join('/')})`}
+      {player.owner.config.expansion !== RETAIL_EXPANSION && `(${player.talentPoints.join('/')})`}
     </div>
     <div>
       <b>Average ilvl:</b> {Math.round(averageIlvl)}

--- a/src/parser/core/Combatant.ts
+++ b/src/parser/core/Combatant.ts
@@ -119,11 +119,11 @@ class Combatant extends Entity {
   }
 
   // region Talents
-  _talentsByRow: Set<number> = new Set<number>();
+  _talentPointsBySpec: Set<number> = new Set<number>();
 
   _parseTalents(talents: Spell[]) {
     talents?.forEach(({ id }) => {
-      this._talentsByRow.add(id);
+      this._talentPointsBySpec.add(id);
     });
   }
 
@@ -136,7 +136,7 @@ class Combatant extends Entity {
 
   hasTalent(spell: number | Spell) {
     const spellId = typeof spell === 'number' ? spell : spell.id;
-    return this.treeTalentsBySpellId.has(spellId) || this._talentsByRow.has(spellId);
+    return this.treeTalentsBySpellId.has(spellId);
   }
 
   /**
@@ -147,7 +147,7 @@ class Combatant extends Entity {
   get talentPoints(): number[] {
     const expansion = this._combatantInfo.expansion;
     if (expansion === 'tbc' || expansion === 'wotlk') {
-      return Object.values(this._talentsByRow);
+      return Object.values(this._talentPointsBySpec);
     } else {
       return [];
     }

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -1009,9 +1009,22 @@ export interface Conduit {
   icon: string;
 }
 
+/**
+ * A talent entry from the log.
+ *
+ * Note: this is *different* from the Talent type for spells.
+ */
+export interface TalentEntry {
+  id: number;
+  nodeID: number;
+  spellID: number;
+  rank: number;
+  icon?: string;
+}
+
 export interface CombatantInfoEvent extends Event<EventType.CombatantInfo> {
   player: PlayerInfo;
-  expansion: 'tbc' | 'shadowlands' | string;
+  expansion: 'wotlk' | 'tbc' | 'shadowlands' | 'dragonflight' | string;
   pin: string;
   sourceID: number;
   gear: Item[];
@@ -1039,7 +1052,8 @@ export interface CombatantInfoEvent extends Event<EventType.CombatantInfo> {
   versatilityDamageDone: number;
   versatilityHealingDone: number;
   versatilityDamageReduction: number;
-  talents: [Spell, Spell, Spell, Spell, Spell, Spell, Spell];
+  talentTree: TalentEntry[];
+  talents: Spell[];
   pvpTalents: Spell[];
   covenantID: number;
   soulbindID: number;


### PR DESCRIPTION
Two changes:

1. `hasTalent` now uses the dragonflight `talentTree` field to check if you've got a talent.
2. the old `talents` getter has been renamed to `talentPoints` for use in Classic analyzers.