### PR TITLE
Fixing WOTLK game version

### DIFF
--- a/src/game/VERSIONS.ts
+++ b/src/game/VERSIONS.ts
@@ -11,7 +11,8 @@ export default VERSIONS;
 export const WCL_GAME_VERSIONS: Partial<{ [expansion in Expansion]: number }> = {
   [Expansion.Dragonflight]: 1,
   [Expansion.Vanilla]: 2,
-  [Expansion.WrathOfTheLichKing]: 3,
+  [Expansion.TheBurningCrusade]: 3,
+  [Expansion.WrathOfTheLichKing]: 4,
 };
 
 export const wclGameVersionToExpansion = (gameVersion: number): Expansion => {
@@ -19,6 +20,8 @@ export const wclGameVersionToExpansion = (gameVersion: number): Expansion => {
     case 2:
       return Expansion.Vanilla;
     case 3:
+      return Expansion.TheBurningCrusade;
+    case 4:
       return Expansion.WrathOfTheLichKing;
     default:
       return Expansion.Dragonflight;

--- a/src/parser/getBuild.ts
+++ b/src/parser/getBuild.ts
@@ -18,7 +18,9 @@ export default function getBuild(
 ): Build | null {
   if (
     !config?.builds ||
-    (config.expansion !== Expansion.Vanilla && config.expansion !== Expansion.TheBurningCrusade)
+    (config.expansion !== Expansion.Vanilla &&
+      config.expansion !== Expansion.TheBurningCrusade &&
+      config.expansion !== Expansion.WrathOfTheLichKing)
   ) {
     return null;
   }


### PR DESCRIPTION
BC was gameversion 3, WOTLK is gameversion  4. No WOTLK analyzers will work until this is updated.

I don't really think this needs a changelog entry, but I can add one if someone feels that it should be included.