### PR TITLE
Various Resto Druid updates

### DIFF
--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { SpellLink } from 'interface';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
+  change(date(2022, 9, 29), <>Updated <SpellLink id={TALENTS_DRUID.ABUNDANCE_RESTORATION_TALENT.id} /> and <SpellLink id={TALENTS_DRUID.NURTURING_DORMANCY_RESTORATION_TALENT.id} /> to account for nerfs on beta. Fixed an issue where <SpellLink id={TALENTS_DRUID.REFORESTATION_RESTORATION_TALENT.id} /> showed in the wrong category. Fixed an issue where <SpellLink id={TALENTS_DRUID.POWER_OF_THE_ARCHDRUID_RESTORATION_TALENT.id} /> used the wrong ID.</>, Sref),
   change(date(2022, 9, 26), <>Added handling and stats for <SpellLink id={TALENTS_DRUID.GROVE_TENDING_RESTORATION_TALENT.id} />, <SpellLink id={TALENTS_DRUID.NURTURING_DORMANCY_RESTORATION_TALENT.id} />, <SpellLink id={TALENTS_DRUID.VERDANCY_RESTORATION_TALENT.id} />, <SpellLink id={TALENTS_DRUID.HARMONIOUS_BLOOMING_RESTORATION_TALENT.id} />, and <SpellLink id={TALENTS_DRUID.REGENESIS_RESTORATION_TALENT.id} />. First pass on updating text in Guide.</>, Sref),
   change(date(2022, 9, 23), <>Updates for this week's Beta build.</>, Sref),
   change(date(2022, 9, 13), <>Initial updates for Dragonflight Talent system.</>, Sref),

--- a/src/analysis/retail/druid/restoration/modules/core/hottracking/HotAttributor.ts
+++ b/src/analysis/retail/druid/restoration/modules/core/hottracking/HotAttributor.ts
@@ -109,11 +109,7 @@ class HotAttributor extends Analyzer {
       this._logAttrib(event, this.overgrowthAttrib);
     } else if (
       this.hasPowerOfTheArchdruid &&
-      this.selectedCombatant.hasBuff(
-        SPELLS.MEMORY_OF_THE_MOTHER_TREE.id,
-        event.timestamp,
-        BUFFER_MS,
-      )
+      this.selectedCombatant.hasBuff(SPELLS.POWER_OF_THE_ARCHDRUID.id, event.timestamp, BUFFER_MS)
     ) {
       this.hotTracker.addAttributionFromApply(this.powerOfTheArchdruid, event);
       this._logAttrib(event, this.powerOfTheArchdruid);
@@ -137,11 +133,7 @@ class HotAttributor extends Analyzer {
       this._logAttrib(event, this.overgrowthAttrib);
     } else if (
       this.hasPowerOfTheArchdruid &&
-      this.selectedCombatant.hasBuff(
-        SPELLS.MEMORY_OF_THE_MOTHER_TREE.id,
-        event.timestamp,
-        BUFFER_MS,
-      )
+      this.selectedCombatant.hasBuff(SPELLS.POWER_OF_THE_ARCHDRUID.id, event.timestamp, BUFFER_MS)
     ) {
       this.hotTracker.addAttributionFromApply(this.powerOfTheArchdruid, event);
       this._logAttrib(event, this.powerOfTheArchdruid);
@@ -158,11 +150,7 @@ class HotAttributor extends Analyzer {
       !isFromHardcast(event) &&
       !(this.convokeSpirits.active && this.convokeSpirits.isConvoking()) &&
       this.hasPowerOfTheArchdruid &&
-      this.selectedCombatant.hasBuff(
-        SPELLS.MEMORY_OF_THE_MOTHER_TREE.id,
-        event.timestamp,
-        BUFFER_MS,
-      )
+      this.selectedCombatant.hasBuff(SPELLS.POWER_OF_THE_ARCHDRUID.id, event.timestamp, BUFFER_MS)
     ) {
       this.powerOfTheArchdruid.healing += event.amount + (event.absorbed || 0);
     } else if (isFromHardcast(event)) {

--- a/src/analysis/retail/druid/restoration/modules/spells/Abundance.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/Abundance.tsx
@@ -10,15 +10,15 @@ import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 const MS_BUFFER = 200;
-const ABUNDANCE_MANA_REDUCTION = 0.06;
-const ABUNDANCE_INCREASED_CRIT = 0.06;
+const ABUNDANCE_MANA_REDUCTION = 0.05;
+const ABUNDANCE_INCREASED_CRIT = 0.05;
 
 /**
  * **Abundance**
  * Spec Talent Tier 4
  *
  * For each Rejuvenation you have active,
- * Regrowth's cost is reduced by 6% and critical effect chance is increased by 6%.
+ * Regrowth's cost is reduced by 5% and critical effect chance is increased by 5%.
  */
 class Abundance extends Analyzer {
   manaSavings: number[] = [];

--- a/src/analysis/retail/druid/restoration/modules/spells/Nurturing Dormancy.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/Nurturing Dormancy.tsx
@@ -12,15 +12,15 @@ import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 import { SpellLink } from 'interface';
 
-const EXTENSION_AMOUNT = 3000;
+const EXTENSION_AMOUNT = 2000;
 const MAX_PROCS = 3;
 
 /**
  * **Nurturing Dormancy**
  * Spec Talent
  *
- * When your Rejuvenation heals a full health target, its duration is increased by 3 sec, up to a
- * maximum total increase of 9 sec per cast.
+ * When your Rejuvenation heals a full health target, its duration is increased by 2 sec, up to a
+ * maximum total increase of 6 sec per cast.
  */
 class NurturingDormancy extends Analyzer {
   static dependencies = {

--- a/src/analysis/retail/druid/restoration/modules/spells/PowerOfTheArchdruid.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/PowerOfTheArchdruid.tsx
@@ -42,11 +42,11 @@ class PowerOfTheArchdruid extends Analyzer {
       this.onCastWildGrowth,
     );
     this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.MEMORY_OF_THE_MOTHER_TREE),
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.POWER_OF_THE_ARCHDRUID),
       this.onApply,
     );
     this.addEventListener(
-      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.MEMORY_OF_THE_MOTHER_TREE),
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.POWER_OF_THE_ARCHDRUID),
       this.onApply,
     );
   }

--- a/src/analysis/retail/druid/restoration/modules/spells/Reforestation.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/Reforestation.tsx
@@ -33,7 +33,7 @@ class Reforestation extends Analyzer {
     return (
       <Statistic
         position={STATISTIC_ORDER.OPTIONAL(10)} // number based on talent row
-        category={STATISTIC_CATEGORY.ITEMS}
+        category={STATISTIC_CATEGORY.TALENTS}
         size="flexible"
         tooltip={
           <>

--- a/src/common/SPELLS/druid.ts
+++ b/src/common/SPELLS/druid.ts
@@ -405,6 +405,12 @@ const spells = spellIndexableList({
     name: 'Verdancy',
     icon: 'inv_10_herb_seed_magiccolor5',
   },
+  // buff from Power of the Archdruid talent
+  POWER_OF_THE_ARCHDRUID: {
+    id: 392303,
+    name: 'Power of the Archdruid',
+    icon: 'spell_druid_rampantgrowth',
+  },
   // Sets/Items:
   ASTRAL_HARMONY: {
     // 2pc T19


### PR DESCRIPTION
Updated Abundance and Nurturing Dormancy for the nerfs on beta. Fixed an issue where Reforestation showed in the wrong category. Fixed an issue where Power of the Archdruid was using the wrong spell id.