### PR TITLE
convert ShearFracture to use EventLinkNormalizer

### DIFF
--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -1,8 +1,12 @@
 import { change, date } from 'common/changelog';
 import { ToppleTheNun } from 'CONTRIBUTORS';
+import SpellLink from 'interface/SpellLink';
+import SPELLS from 'common/SPELLS/demonhunter';
+import TALENTS from 'common/TALENTS/demonhunter';
 
 // prettier-ignore
 export default [
+  change(date(2022, 10, 10), <>Improve detection of bad <SpellLink id={SPELLS.SHEAR.id} /> and <SpellLink id={TALENTS.FRACTURE_TALENT.id}/> casts.</>, ToppleTheNun),
   change(date(2022, 9, 22), 'Update to latest Havoc patch from 9/21/2022.', ToppleTheNun),
   change(date(2022, 9, 7), 'Begin working on support for Dragonflight.', ToppleTheNun),
 ];

--- a/src/analysis/retail/demonhunter/vengeance/CombatLogParser.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CombatLogParser.tsx
@@ -36,6 +36,7 @@ import FrailtyDebuff from './modules/talents/FrailtyDebuff';
 import SpiritBombSoulsConsume from './modules/talents/SpiritBombSoulsConsume';
 import PainbringerBuff from './modules/talents/PainbringerBuff';
 import DarkglareBoon from './modules/talents/DarkglareBoon';
+import ShearFractureNormalizer from './normalizers/ShearFractureNormalizer';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -53,6 +54,9 @@ class CombatLogParser extends CoreCombatLogParser {
     // Resource Tracker
     furyTracker: FuryTracker,
     furyDetails: FuryDetails,
+
+    // normalizers
+    shearFractureNormalizer: ShearFractureNormalizer,
 
     // Talents
     painbringer: PainbringerBuff,

--- a/src/analysis/retail/demonhunter/vengeance/modules/spells/ShearFracture.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/spells/ShearFracture.tsx
@@ -8,36 +8,28 @@ import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent, RemoveBuffStackEvent } from 'parser/core/Events';
 import { NumberThreshold, ThresholdStyle, When } from 'parser/core/ParseResults';
 
+import {
+  getGeneratingCast,
+  getWastedSoulFragment,
+} from '../../normalizers/ShearFractureNormalizer';
+
 /*WCL: https://www.warcraftlogs.com/reports/Y7BWyCx3mHVZzPrk#fight=last&type=summary&view=events&pins=2%24Off%24%23244F4B%24casts%7Cauras%24-1%240.0.0.Any%240.0.0.Any%24true%240.0.0.Any%24true%24258920%7C204255%7C203981%7C263642
 Default spell is Shear (generates 1 soul). Fracture (generates 2 souls) talent replaces it.
 Vengence can have a maxium of 5 souls. Log has 4 fracture casts. Meaning 5 gained souls and 3 wasted. 2 of the 4 casts are bad.
-Souls are generated on a slight delay. Souls should be casted with in 1.3 seconds.
-If a soul is casted and then a buff is removed within 50 ms that means it was a wasted soul generation.
+Souls are generated on a slight delay. Souls should be cast within 1.3 seconds.
+If a soul is cast and then a buff is removed within 100 ms that means it was a wasted soul generation.
 */
 
-const WASTED_SOUL_MS_BUFFER = 50;
-const FRACTURE_SOUL_GENERATE_BUFFER = 1300;
-
-class ShearFracture extends Analyzer {
-  castTimeStamp = 0;
+export default class ShearFracture extends Analyzer {
   badCasts = 0;
-  onSoulFragmentCastTimeStamp = 0;
-  wastedSoulsPerCast = 0;
-  soulFragmentBuffFadeTimeStamp = 0;
-  lastCastEvent?: CastEvent;
   cast: Spell | Talent = SPELLS.SHEAR;
+  lastCast: CastEvent | undefined;
 
   constructor(options: Options) {
     super(options);
-
     if (this.selectedCombatant.hasTalent(TALENTS_DEMON_HUNTER.FRACTURE_TALENT.id)) {
       this.cast = TALENTS_DEMON_HUNTER.FRACTURE_TALENT;
     }
-    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(this.cast), this.onCast);
-    this.addEventListener(
-      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.SOUL_FRAGMENT),
-      this.onSoulFragmentCast,
-    );
     this.addEventListener(
       Events.removebuffstack.by(SELECTED_PLAYER).spell(SPELLS.SOUL_FRAGMENT_STACK),
       this.onSoulFragmentBuffFade,
@@ -56,48 +48,33 @@ class ShearFracture extends Analyzer {
     };
   }
 
-  onCast(event: CastEvent) {
-    this.castTimeStamp = event.timestamp;
-    this.lastCastEvent = event;
-  }
-
-  onSoulFragmentCast(event: CastEvent) {
-    this.onSoulFragmentCastTimeStamp = event.timestamp;
-  }
-
   onSoulFragmentBuffFade(event: RemoveBuffStackEvent) {
-    if (!this.lastCastEvent) {
+    const wastedSoulFragment = getWastedSoulFragment(event);
+    if (!wastedSoulFragment) {
       return;
     }
-    this.soulFragmentBuffFadeTimeStamp = event.timestamp;
-    if (this.soulFragmentBuffFadeTimeStamp - this.castTimeStamp > FRACTURE_SOUL_GENERATE_BUFFER) {
+    const generatingCast = getGeneratingCast(wastedSoulFragment);
+    if (!generatingCast) {
       return;
     }
 
-    if (
-      this.soulFragmentBuffFadeTimeStamp - this.onSoulFragmentCastTimeStamp <
-      WASTED_SOUL_MS_BUFFER
-    ) {
-      this.wastedSoulsPerCast += 1;
-
-      //Exit early if the wasted soul is from the same fracture cast
-      if (this.wastedSoulsPerCast > 1) {
-        this.wastedSoulsPerCast = 0;
-        return;
-      }
-
-      this.badCasts += 1;
-      this.lastCastEvent.meta = this.lastCastEvent.meta || {};
-      this.lastCastEvent.meta.isInefficientCast = true;
-      this.lastCastEvent.meta.inefficientCastReason = 'Fracture cast that over capped souls';
+    // Exit early if the wasted soul is from the same fracture cast
+    if (this.lastCast?.timestamp === generatingCast.timestamp) {
+      return;
     }
+
+    this.lastCast = generatingCast;
+    this.badCasts += 1;
+    this.lastCast.meta = this.lastCast.meta || {};
+    this.lastCast.meta.isInefficientCast = true;
+    this.lastCast.meta.inefficientCastReason = 'Fracture cast that over capped souls';
   }
 
   suggestions(when: When) {
     when(this.wastedCasts).addSuggestion((suggest, actual, recommended) =>
       suggest(
         <>
-          You cast of <SpellLink id={this.cast.id} /> generated souls beyond the cap of 5.
+          Your cast of <SpellLink id={this.cast.id} /> generated souls beyond the cap of 5.
         </>,
       )
         .icon(this.cast.icon)
@@ -111,5 +88,3 @@ class ShearFracture extends Analyzer {
     );
   }
 }
-
-export default ShearFracture;

--- a/src/analysis/retail/demonhunter/vengeance/normalizers/ShearFractureNormalizer.ts
+++ b/src/analysis/retail/demonhunter/vengeance/normalizers/ShearFractureNormalizer.ts
@@ -1,0 +1,65 @@
+import SPELLS from 'common/SPELLS/demonhunter';
+import TALENTS from 'common/TALENTS/demonhunter';
+import { CastEvent, EventType, GetRelatedEvents, RemoveBuffStackEvent } from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+
+/*
+WCL: https://www.warcraftlogs.com/reports/Y7BWyCx3mHVZzPrk#fight=last&type=summary&view=events&pins=2%24Off%24%23244F4B%24casts%7Cauras%24-1%240.0.0.Any%240.0.0.Any%24true%240.0.0.Any%24true%24258920%7C204255%7C203981%7C263642
+Default spell is Shear (generates 1 soul). Fracture (generates 2 souls) talent replaces it.
+Vengence can have a maxium of 5 souls. Log has 4 fracture casts. Meaning 5 gained souls and 3 wasted. 2 of the 4 casts are bad.
+Souls are generated on a slight delay. Souls should be cast within 1.3 seconds.
+If a soul is cast and then a buff is removed within 100 ms that means it was a wasted soul generation.
+ */
+
+// Note that this number may need to change with sufficient levels of haste.
+const SOUL_GENERATE_BUFFER = 1300;
+const SOUL_WASTED_BUFFER = 100;
+
+const GENERATED_SOUL_FRAGMENT = 'ShearFractureGeneratedSoulFragment';
+const WASTED_SOUL_FRAGMENT = 'ShearFractureWastedSoulFragment';
+
+const EVENT_LINKS: EventLink[] = [
+  {
+    linkRelation: GENERATED_SOUL_FRAGMENT,
+    referencedEventId: [SPELLS.SHEAR.id, TALENTS.FRACTURE_TALENT.id],
+    referencedEventType: EventType.Cast,
+    linkingEventId: SPELLS.SOUL_FRAGMENT.id,
+    linkingEventType: EventType.Cast,
+    forwardBufferMs: 0,
+    backwardBufferMs: SOUL_GENERATE_BUFFER,
+    anyTarget: true,
+  },
+  {
+    linkRelation: WASTED_SOUL_FRAGMENT,
+    referencedEventId: SPELLS.SOUL_FRAGMENT.id,
+    referencedEventType: EventType.Cast,
+    linkingEventId: SPELLS.SOUL_FRAGMENT_STACK.id,
+    linkingEventType: EventType.RemoveBuffStack,
+    forwardBufferMs: SOUL_WASTED_BUFFER,
+    backwardBufferMs: SOUL_WASTED_BUFFER,
+    anyTarget: true,
+  },
+];
+
+/**
+ * The applybuff from demonic is logged before the cast of Eye Beam.
+ * This normalizes events so that the Eye Beam applybuff always comes before the Meta Havoc buff
+ **/
+export default class ShearFractureNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_LINKS);
+  }
+}
+
+export function getGeneratingCast(event: CastEvent): CastEvent | undefined {
+  return GetRelatedEvents(event, GENERATED_SOUL_FRAGMENT)
+    .filter((e): e is CastEvent => e.type === EventType.Cast)
+    .pop();
+}
+
+export function getWastedSoulFragment(event: RemoveBuffStackEvent): CastEvent | undefined {
+  return GetRelatedEvents(event, WASTED_SOUL_FRAGMENT)
+    .filter((e): e is CastEvent => e.type === EventType.Cast)
+    .pop();
+}


### PR DESCRIPTION
It does change how bad casts are detected (likely in a good way) so the numbers may end up different than they are on live.

**Changed version**
![image](https://user-images.githubusercontent.com/1672786/194119891-09b9273c-eb55-4fb3-8829-16f4b0ecbfad.png)

**Live version**
![image](https://user-images.githubusercontent.com/1672786/194119957-ea12fa46-53a7-4601-979b-9f11d0801e38.png)
https://dragonflight.wowanalyzer.com/report/vQFkL6GbpzyHCwmc/12-Heroic+Kurog+Grimtotem+-+Wipe+2+(8:00)/Devonhunter/standard/overview