### PR TITLE
WOTLK: Hyperspeed Accelerators

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -57,7 +57,8 @@ import {
   ToppleTheNun,
   Vetyst,
   Chizu,
-  Tyndi
+  Tyndi,
+  Khadaj,
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
@@ -65,6 +66,7 @@ import { TALENTS_SHAMAN } from 'common/TALENTS';
 
 // prettier-ignore
 export default [
+  change(date(2022, 10, 13), 'Adding Hyperspeed Accelerators to WOTLK analysis.', Khadaj),
   change(date(2022, 10, 11), 'Remove Effusive Anima Accelerator analyzer.', ToppleTheNun),
   change(date(2022, 10, 11), 'Remove conduits and soulbinds from character page.', ToppleTheNun),
   change(date(2022, 10,  11), 'Convert Discord button to TypeScript.', ToppleTheNun),

--- a/src/parser/classic/CombatLogParser.ts
+++ b/src/parser/classic/CombatLogParser.ts
@@ -43,6 +43,7 @@ import PreparationRuleAnalyzer from './modules/features/Checklist/PreparationRul
 import CombatPotionChecker from './modules/items/CombatPotionChecker';
 import EnchantChecker from './modules/items/EnchantChecker';
 import ManaGained from './statistic/ManaGained';
+import HyperspeedAccelerators from './modules/items/engineering/HyperspeedAccelerators';
 
 class CombatLogParser extends BaseCombatLogParser {
   static defaultModules: DependenciesDefinition = {
@@ -101,6 +102,9 @@ class CombatLogParser extends BaseCombatLogParser {
 
     // Migrated Functional Statistics
     manaGained: ManaGained,
+
+    // Engineering
+    hyperspeedAccelerators: HyperspeedAccelerators,
   };
 }
 

--- a/src/parser/classic/modules/items/engineering/HyperspeedAccelerators.tsx
+++ b/src/parser/classic/modules/items/engineering/HyperspeedAccelerators.tsx
@@ -1,6 +1,5 @@
 import Analyzer, { Options } from 'parser/core/Analyzer';
 
-import { ThresholdStyle } from 'parser/core/ParseResults';
 import Abilities from 'parser/core/modules/Abilities';
 import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
 

--- a/src/parser/classic/modules/items/engineering/HyperspeedAccelerators.tsx
+++ b/src/parser/classic/modules/items/engineering/HyperspeedAccelerators.tsx
@@ -1,0 +1,48 @@
+import Analyzer, { Options } from 'parser/core/Analyzer';
+
+import { ThresholdStyle } from 'parser/core/ParseResults';
+import Abilities from 'parser/core/modules/Abilities';
+import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
+
+const HYPERSPEED_ACCELERATORS_ENCHANT_ID = 3604;
+const HYPERSPEED_ACCELERATORS_SPELL_ID = 54758;
+const HYPERSPEED_ACCELERATORS_SPELL_COOLDOWN = 60;
+
+class HyperspeedAccelerators extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+  };
+
+  protected abilities!: Abilities;
+
+  constructor(options: Options) {
+    super(options);
+    const bracers = this.selectedCombatant._getGearItemBySlotId(9);
+    this.active = bracers.permanentEnchant === HYPERSPEED_ACCELERATORS_ENCHANT_ID;
+    (options.abilities as Abilities).add({
+      spell: HYPERSPEED_ACCELERATORS_SPELL_ID,
+      category: SPELL_CATEGORY.ITEMS,
+      cooldown: HYPERSPEED_ACCELERATORS_SPELL_COOLDOWN,
+      gcd: null,
+      castEfficiency: {
+        suggestion: true,
+        recommendedEfficiency: 0.8,
+      },
+    });
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: 0,
+      isGreaterThan: {
+        minor: 0.03,
+        average: 0.07,
+        major: 0.1,
+      },
+      style: ThresholdStyle.PERCENTAGE,
+    };
+  }
+}
+
+export default HyperspeedAccelerators;
+

--- a/src/parser/classic/modules/items/engineering/HyperspeedAccelerators.tsx
+++ b/src/parser/classic/modules/items/engineering/HyperspeedAccelerators.tsx
@@ -19,28 +19,18 @@ class HyperspeedAccelerators extends Analyzer {
     super(options);
     const bracers = this.selectedCombatant._getGearItemBySlotId(9);
     this.active = bracers.permanentEnchant === HYPERSPEED_ACCELERATORS_ENCHANT_ID;
-    (options.abilities as Abilities).add({
-      spell: HYPERSPEED_ACCELERATORS_SPELL_ID,
-      category: SPELL_CATEGORY.ITEMS,
-      cooldown: HYPERSPEED_ACCELERATORS_SPELL_COOLDOWN,
-      gcd: null,
-      castEfficiency: {
-        suggestion: true,
-        recommendedEfficiency: 0.8,
-      },
-    });
-  }
-
-  get suggestionThresholds() {
-    return {
-      actual: 0,
-      isGreaterThan: {
-        minor: 0.03,
-        average: 0.07,
-        major: 0.1,
-      },
-      style: ThresholdStyle.PERCENTAGE,
-    };
+    if (this.active) {
+      (options.abilities as Abilities).add({
+        spell: HYPERSPEED_ACCELERATORS_SPELL_ID,
+        category: SPELL_CATEGORY.ITEMS,
+        cooldown: HYPERSPEED_ACCELERATORS_SPELL_COOLDOWN,
+        gcd: null,
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.8,
+        },
+      });
+    }
   }
 }
 


### PR DESCRIPTION
Adds a reminder to use the engineering gloves on cooldown. 

The spell link is broken for this, but it's broken for a ton of things in wotlk. I don't know if someone is looking into that.

![TVQh6jl](https://user-images.githubusercontent.com/716498/195624020-6858065f-b5e0-44dc-930a-331045e057ea.png)
