### PR TITLE
Updates to EventLinkNormalizer

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -66,6 +66,7 @@ import { TALENTS_SHAMAN } from 'common/TALENTS';
 
 // prettier-ignore
 export default [
+  change(date(2022, 10, 14), 'Updates to EventLinkNormazlier to allow for more advanced usage.', Sref),
   change(date(2022, 10, 13), 'Adding Hyperspeed Accelerators to WOTLK analysis.', Khadaj),
   change(date(2022, 10, 13), 'Adding Frag Belt to WOTLK analysis.', Khadaj),
   change(date(2022, 10, 11), 'Remove Effusive Anima Accelerator analyzer.', ToppleTheNun),

--- a/src/parser/core/EventLinkNormalizer.ts
+++ b/src/parser/core/EventLinkNormalizer.ts
@@ -11,7 +11,6 @@ import EventsNormalizer from 'parser/core/EventsNormalizer';
 import { encodeEventTargetString } from 'parser/shared/modules/Enemies';
 import Combatant from 'parser/core/Combatant';
 
-// TODO maximum links per event (prevent cast linking with too many)
 /**
  * The specification of an event link to apply.
  * By default, the linking event adds the referenced event to its _linkedEvents, but not vice versa.


### PR DESCRIPTION
 Added optional `maxLinks` and `isActive` fields, and allow user to rely on one link depending on an earlier one in the list. Added to possibly help @trevorm4 with a particularly pernicious problem.