### PR TITLE
Added statistics for Double-Clawed Rake, Sabertooth, and Sudden Ambush

### DIFF
--- a/src/analysis/retail/druid/feral/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/feral/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS/druid';
 
 export default [
+  change(date(2022, 10, 16), <>Added statistics for <SpellLink id={TALENTS_DRUID.DOUBLE_CLAWED_RAKE_TALENT.id} />, <SpellLink id={TALENTS_DRUID.SABERTOOTH_TALENT.id} />, and <SpellLink id={TALENTS_DRUID.SUDDEN_AMBUSH_TALENT.id} /></>, Sref),
   change(date(2022, 10, 12), <><SpellLink id={TALENTS_DRUID.BLOODTALONS_TALENT.id} /> - updated Statistic and added Guide section.</>, Sref),
   change(date(2022, 10, 9), <>Added statistic for <SpellLink id={TALENTS_DRUID.RAMPANT_FEROCITY_TALENT.id} />. <SpellLink id={TALENTS_DRUID.APEX_PREDATORS_CRAVING_TALENT.id} /> and <SpellLink id={TALENTS_DRUID.CONVOKE_THE_SPIRITS_TALENT.id} /> now account for Rampant Ferocity hits procced by them. Updated modules to to account for balance changes in Beta build 45969.</>, Sref),
   change(date(2022, 10, 8), <>Made Guide default (Checklist removed), and filled in sections for <SpellLink id={SPELLS.RAKE.id} /> and <SpellLink id={SPELLS.RIP.id} />. Fixed duration tracking for DoTs when <SpellLink id={TALENTS_DRUID.CIRCLE_OF_LIFE_AND_DEATH_TALENT.id} /> or <SpellLink id={TALENTS_DRUID.VEINRIPPER_TALENT.id} /> is talented.</>, Sref),

--- a/src/analysis/retail/druid/feral/CombatLogParser.ts
+++ b/src/analysis/retail/druid/feral/CombatLogParser.ts
@@ -30,6 +30,10 @@ import RakeBleed from './normalizers/RakeBleed';
 import Guide from 'analysis/retail/druid/feral/Guide';
 import BloodtalonsLinkNormalizer from 'analysis/retail/druid/feral/normalizers/BloodtalonsLinkNormalizer';
 import RampantFerocity from 'analysis/retail/druid/feral/modules/spells/RampantFerocity';
+import DoubleClawedRake from 'analysis/retail/druid/feral/modules/spells/DoubleClawedRake';
+import Sabertooth from 'analysis/retail/druid/feral/modules/spells/Sabertooth';
+import SuddenAmbushLinkNormalizer from 'analysis/retail/druid/feral/normalizers/SuddenAmbushLinkNormalizer';
+import SuddenAmbush from 'analysis/retail/druid/feral/modules/spells/SuddenAmbush';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -38,6 +42,7 @@ class CombatLogParser extends CoreCombatLogParser {
     castLinkNormalizer: CastLinkNormalizer,
     ferociousBiteDrainLinkNormalizer: FerociousBiteDrainLinkNormalizer,
     bloodtalonsLinkNormalizer: BloodtalonsLinkNormalizer,
+    suddenAmbushLinkNormalizer: SuddenAmbushLinkNormalizer,
 
     // Core
     activeDruidForm: ActiveDruidForm,
@@ -70,6 +75,9 @@ class CombatLogParser extends CoreCombatLogParser {
     adaptiveSwarm: AdaptiveSwarmFeral,
     berserkBoosts: BerserkBoosts,
     rampantFerocity: RampantFerocity,
+    doubleClawedRake: DoubleClawedRake,
+    sabertooth: Sabertooth,
+    suddenAmbush: SuddenAmbush,
 
     // resources
     comboPointTracker: ComboPointTracker,

--- a/src/analysis/retail/druid/feral/constants.ts
+++ b/src/analysis/retail/druid/feral/constants.ts
@@ -2,9 +2,10 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS';
 import Spell from 'common/SPELLS/Spell';
 import Combatant from 'parser/core/Combatant';
-import { CastEvent } from 'parser/core/Events';
+import { CastEvent, DamageEvent } from 'parser/core/Events';
 import getResourceSpent from 'parser/core/getResourceSpent';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import { getHardcast } from 'analysis/retail/druid/feral/normalizers/CastLinkNormalizer';
 
 /** Feral combo point cap */
 export const MAX_CPS = 5;
@@ -128,4 +129,26 @@ export function directAoeBuilder(c: Combatant): Spell {
   return c.hasTalent(TALENTS_DRUID.BRUTAL_SLASH_TALENT)
     ? TALENTS_DRUID.BRUTAL_SLASH_TALENT
     : SPELLS.SWIPE_CAT;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// MISC
+//
+
+/** Damage boost to a Shred or Rake from stealth */
+export const STEALTH_SHRED_RAKE_BOOST = 0.6;
+
+/** Effective combo points used by a Convoke'd Ferocious Bite */
+export const CONVOKE_FB_CPS = 4;
+
+/** Gets the number of CPs that were used to produce this Bite.
+ *  Takes DamageEvent instead of CastEvent to also catch Convoke'd bites */
+export function getBiteCps(event: DamageEvent) {
+  const hardcast = getHardcast(event);
+  if (hardcast) {
+    return getResourceSpent(hardcast, RESOURCE_TYPES.COMBO_POINTS);
+  } else {
+    // no hardcast -> from Convoke
+    return CONVOKE_FB_CPS;
+  }
 }

--- a/src/analysis/retail/druid/feral/modules/spells/DoubleClawedRake.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/DoubleClawedRake.tsx
@@ -1,0 +1,100 @@
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { Options } from 'parser/core/Module';
+import { TALENTS_DRUID } from 'common/TALENTS';
+import SPELLS from 'common/SPELLS';
+import Events, { ApplyDebuffEvent, DamageEvent, RefreshDebuffEvent } from 'parser/core/Events';
+import { isFromDoubleClawedRake } from 'analysis/retail/druid/feral/normalizers/CastLinkNormalizer';
+import { encodeEventTargetString } from 'parser/shared/modules/Enemies';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentDamageDone from 'parser/ui/ItemPercentDamageDone';
+
+const DEBUG = false;
+
+/**
+ * **Double-Clawed Rake**
+ * Spec Talent
+ *
+ * Rake also applies Rake to 1 additional nearby target
+ */
+class DoubleClawedRake extends Analyzer {
+  /** Set of targets for whom the last applied Rake was from DCR */
+  targetsWithDcr: Set<string> = new Set<string>();
+
+  /** Total tallied damage from DCR rakes */
+  dcrDamage: number = 0;
+  /** Additional Rakes applied by DCR */
+  extraRakes: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.DOUBLE_CLAWED_RAKE_TALENT);
+
+    this.addEventListener(
+      Events.applydebuff.by(SELECTED_PLAYER).spell(SPELLS.RAKE_BLEED),
+      this.onRakeApply,
+    );
+    this.addEventListener(
+      Events.refreshdebuff.by(SELECTED_PLAYER).spell(SPELLS.RAKE_BLEED),
+      this.onRakeApply,
+    );
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.RAKE_BLEED),
+      this.onRakeDamage,
+    );
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.RAKE), this.onRakeDamage);
+  }
+
+  onRakeApply(event: ApplyDebuffEvent | RefreshDebuffEvent) {
+    if (isFromDoubleClawedRake(event)) {
+      this.targetsWithDcr.add(encodeEventTargetString(event) || '');
+      this.extraRakes += 1;
+      DEBUG &&
+        console.log(
+          'Double-Clawed Rake apply on ' +
+            encodeEventTargetString(event) +
+            ' @ ' +
+            this.owner.formatTimestamp(event.timestamp),
+        );
+    } else {
+      this.targetsWithDcr.delete(encodeEventTargetString(event) || '');
+    }
+  }
+
+  onRakeDamage(event: DamageEvent) {
+    if (this.targetsWithDcr.has(encodeEventTargetString(event) || '')) {
+      this.dcrDamage += event.amount + (event.absorbed || 0);
+    }
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(3)} // number based on talent row
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            This is the damage from Rake DoTs applied by Double-Clawed Rake. It is at best an
+            approximation of this talent's impact because of opportunity cost factors (Without DCR
+            you might have tab-Raked the 2nd target, with it you cast Swipe instead)
+            <br />
+            <br />
+            Over the course of this encounter, <strong>{this.extraRakes}</strong> extra Rake DoTs
+            were created by this talent, or{' '}
+            <strong>{this.owner.getPerMinute(this.extraRakes).toFixed(1)} per minute</strong>.
+          </>
+        }
+      >
+        <BoringSpellValueText spellId={TALENTS_DRUID.DOUBLE_CLAWED_RAKE_TALENT.id}>
+          <ItemPercentDamageDone approximate amount={this.dcrDamage} />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default DoubleClawedRake;

--- a/src/analysis/retail/druid/feral/modules/spells/Sabertooth.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/Sabertooth.tsx
@@ -1,0 +1,123 @@
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { Options } from 'parser/core/Module';
+import { TALENTS_DRUID } from 'common/TALENTS';
+import SPELLS from 'common/SPELLS';
+import Events, { DamageEvent } from 'parser/core/Events';
+import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentDamageDone from 'parser/ui/ItemPercentDamageDone';
+import { SpellLink } from 'interface';
+import { formatPercentage } from 'common/format';
+import { getBiteCps } from 'analysis/retail/druid/feral/constants';
+
+const FEROCIOUS_BITE_BOOST = 0.15;
+const RIP_BOOST_PER_CP = 0.05;
+
+// TODO is there a Tear Open Wounds interaction with this talent? Check with theorycrafters
+/**
+ * **Sabertooth**
+ * Spec Talent
+ *
+ * Ferocious Bite deals 15% increased damage and increases all damage dealt by Rip by 5% per
+ * Combo Point spent for 4 sec.
+ */
+class Sabertooth extends Analyzer {
+  /** Damage due to the increase to Ferocious Bite */
+  fbBoostDamage = 0;
+  /** Damage due to the increase to Rampant Ferocity (same as bite boost because it's a percent of bite damage) */
+  rfBoostDamage = 0;
+  /** Damage due to the buff increase to Rip */
+  ripBoostDamage = 0;
+
+  /** Total ticks of Rip */
+  totalRipTicks = 0;
+  /** Ticks of Rip that were boosted by Sabertooth */
+  boostedRipTicks = 0;
+
+  /** Current boost from Sabertooth due to last FB */
+  currentSbtStrength = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.SABERTOOTH_TALENT);
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.FEROCIOUS_BITE),
+      this.onFbDamage,
+    );
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.RAMPANT_FEROCITY),
+      this.onRfDamage,
+    );
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.RIP), this.onRipDamage);
+  }
+
+  onFbDamage(event: DamageEvent) {
+    this.fbBoostDamage += calculateEffectiveDamage(event, FEROCIOUS_BITE_BOOST);
+    this.currentSbtStrength = getBiteCps(event) * RIP_BOOST_PER_CP;
+  }
+
+  onRfDamage(event: DamageEvent) {
+    this.rfBoostDamage += calculateEffectiveDamage(event, FEROCIOUS_BITE_BOOST);
+  }
+
+  onRipDamage(event: DamageEvent) {
+    this.totalRipTicks += 1;
+    if (this.selectedCombatant.hasBuff(SPELLS.SABERTOOTH.id)) {
+      this.boostedRipTicks += 1;
+      this.ripBoostDamage += calculateEffectiveDamage(event, this.currentSbtStrength);
+    }
+  }
+
+  get totalDamage() {
+    return this.fbBoostDamage + this.ripBoostDamage;
+  }
+
+  get percentBoostedRipTicks() {
+    return this.totalRipTicks === 0 ? 0 : this.boostedRipTicks / this.totalRipTicks;
+  }
+
+  statistic() {
+    const hasRf = this.selectedCombatant.hasTalent(TALENTS_DRUID.RAMPANT_FEROCITY_TALENT);
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(3)} // number based on talent row
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            Percent boosted <SpellLink id={SPELLS.RIP.id} /> ticks:{' '}
+            <strong>{formatPercentage(this.percentBoostedRipTicks, 1)}%</strong>
+            <br />
+            Breakdown by source:
+            <ul>
+              <li>
+                <SpellLink id={SPELLS.FEROCIOUS_BITE.id} />:{' '}
+                <strong>{this.owner.formatItemDamageDone(this.fbBoostDamage)}</strong>
+              </li>
+              {hasRf && (
+                <li>
+                  <SpellLink id={TALENTS_DRUID.RAMPANT_FEROCITY_TALENT.id} />:{' '}
+                  <strong>{this.owner.formatItemDamageDone(this.rfBoostDamage)}</strong>
+                </li>
+              )}
+              <li>
+                <SpellLink id={SPELLS.RIP.id} />:{' '}
+                <strong>{this.owner.formatItemDamageDone(this.ripBoostDamage)}</strong>
+              </li>
+            </ul>
+          </>
+        }
+      >
+        <BoringSpellValueText spellId={TALENTS_DRUID.SABERTOOTH_TALENT.id}>
+          <ItemPercentDamageDone amount={this.totalDamage} />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default Sabertooth;

--- a/src/analysis/retail/druid/feral/modules/spells/SuddenAmbush.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/SuddenAmbush.tsx
@@ -1,0 +1,204 @@
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { TALENTS_DRUID } from 'common/TALENTS';
+import { Options } from 'parser/core/Module';
+import SPELLS from 'common/SPELLS';
+import Events, {
+  ApplyBuffEvent,
+  ApplyDebuffEvent,
+  DamageEvent,
+  RefreshDebuffEvent,
+  RemoveBuffEvent,
+} from 'parser/core/Events';
+import {
+  getSuddenAmbushBoostedDamage,
+  isBoostedBySuddenAmbush,
+} from 'analysis/retail/druid/feral/normalizers/SuddenAmbushLinkNormalizer';
+import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
+import { STEALTH_SHRED_RAKE_BOOST } from 'analysis/retail/druid/feral/constants';
+import { encodeEventTargetString } from 'parser/shared/modules/Enemies';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import ItemPercentDamageDone from 'parser/ui/ItemPercentDamageDone';
+import { SpellIcon, SpellLink } from 'interface';
+import CrossIcon from 'interface/icons/Cross';
+import UptimeIcon from 'interface/icons/Uptime';
+import { formatPercentage } from 'common/format';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+
+/**
+ * **Sudden Ambush**
+ * Spec Talent
+ *
+ * Finishing moves have a (5 / 10)% chance per combo point spent to make your next Rake or Shred
+ * deal damage as though you were stealthed.
+ */
+class SuddenAmbush extends Analyzer {
+  /** Number of shreads boosted by SA */
+  boostedShreds = 0;
+  /** Number of rakes boosted by SA */
+  boostedRakes = 0;
+  /** Total damage added to Shred by SA boost */
+  boostedShredDamage = 0;
+  /** Total damage added to Rake by SA boost */
+  boostedRakeDamage = 0;
+
+  /** SA buffs gained */
+  saGained = 0;
+  /** SA buffs used */
+  saUsed = 0;
+  /** SA buffs expired */
+  saExpired = 0;
+  /** SA buffs overwritten */
+  saOverwritten = 0;
+
+  /** Set of targets for whom the last applied Rake was boosted by SA */
+  saBoostedRakeTargets: Set<string> = new Set<string>();
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.SUDDEN_AMBUSH_TALENT);
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.SUDDEN_AMBUSH_BUFF),
+      this.onGainSa,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.SUDDEN_AMBUSH_BUFF),
+      this.onUseSa,
+    );
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.SUDDEN_AMBUSH_BUFF),
+      this.onOverwriteSa,
+    );
+
+    this.addEventListener(
+      Events.applydebuff.by(SELECTED_PLAYER).spell(SPELLS.RAKE_BLEED),
+      this.onApplyRake,
+    );
+    this.addEventListener(
+      Events.refreshdebuff.by(SELECTED_PLAYER).spell(SPELLS.RAKE_BLEED),
+      this.onApplyRake,
+    );
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.RAKE_BLEED),
+      this.onRakeBleedDamage,
+    );
+  }
+
+  onGainSa(event: ApplyBuffEvent) {
+    this.saGained += 1;
+  }
+
+  onUseSa(event: RemoveBuffEvent) {
+    const boostedDamageEvents: DamageEvent[] = getSuddenAmbushBoostedDamage(event);
+    if (boostedDamageEvents.length === 0) {
+      this.saExpired += 1;
+    } else {
+      this.saUsed += 1;
+      // with Double Clawed Rake, possible more than one damage event is boosted
+      boostedDamageEvents.forEach((d) => {
+        if (d.ability.guid === SPELLS.SHRED.id) {
+          this.boostedShreds += 1;
+          this.boostedShredDamage += calculateEffectiveDamage(d, STEALTH_SHRED_RAKE_BOOST);
+        } else if (d.ability.guid === SPELLS.RAKE.id) {
+          this.boostedRakes += 1;
+          this.boostedRakeDamage += calculateEffectiveDamage(d, STEALTH_SHRED_RAKE_BOOST);
+        }
+      });
+    }
+  }
+
+  onOverwriteSa() {
+    this.saOverwritten += 1;
+  }
+
+  onApplyRake(event: ApplyDebuffEvent | RefreshDebuffEvent) {
+    if (isBoostedBySuddenAmbush(event)) {
+      this.saBoostedRakeTargets.add(encodeEventTargetString(event) || '');
+    } else {
+      this.saBoostedRakeTargets.delete(encodeEventTargetString(event) || '');
+    }
+  }
+
+  onRakeBleedDamage(event: DamageEvent) {
+    if (this.saBoostedRakeTargets.has(encodeEventTargetString(event) || '')) {
+      this.boostedRakeDamage += calculateEffectiveDamage(event, STEALTH_SHRED_RAKE_BOOST);
+    }
+  }
+
+  get saEnding() {
+    return this.saGained - this.saUsed - this.saExpired - this.saOverwritten;
+  }
+
+  get saUtil() {
+    return this.saGained === 0 ? 0 : this.saUsed / (this.saGained - this.saEnding);
+  }
+
+  get totalDamage() {
+    return this.boostedRakeDamage + this.boostedShredDamage;
+  }
+
+  statistic() {
+    const hasDcr = this.selectedCombatant.hasTalent(TALENTS_DRUID.DOUBLE_CLAWED_RAKE_TALENT);
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(3)} // number based on talent row
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            This is the damage from the increase to Shred and Rake damage caused by Sudden Ambush
+            procs. This underrates the total benefit of Sudden Ambush because it does not count the
+            increased crit chance and additional combo point from Shred.
+            <br />
+            <br />
+            Buff Utilization: <strong>{formatPercentage(this.saUtil, 1)}%</strong>
+            <ul>
+              <li>
+                <SpellIcon id={SPELLS.SUDDEN_AMBUSH.id} /> Used: <strong>{this.saUsed}</strong>
+              </li>
+              <li>
+                <CrossIcon /> Overwritten: <strong>{this.saOverwritten}</strong>
+              </li>
+              <li>
+                <UptimeIcon /> Expired: <strong>{this.saExpired}</strong>
+              </li>
+              {this.saEnding > 0 && (
+                <li>
+                  Still active at fight end: <strong>{this.saEnding}</strong>
+                </li>
+              )}
+            </ul>
+            <br />
+            Breakdown by spell{' '}
+            {hasDcr && (
+              <>
+                (possibly more hits than uses due to{' '}
+                <SpellLink id={TALENTS_DRUID.DOUBLE_CLAWED_RAKE_TALENT.id} />)
+              </>
+            )}
+            :
+            <ul>
+              <li>
+                <SpellLink id={SPELLS.SHRED.id} />: Boosted <strong>{this.boostedShreds}</strong>{' '}
+                hits for{' '}
+                <strong>&gt;{this.owner.formatItemDamageDone(this.boostedShredDamage)}</strong>
+              </li>
+              <li>
+                <SpellLink id={SPELLS.RAKE.id} />: Boosted <strong>{this.boostedRakes}</strong> hits
+                for <strong>{this.owner.formatItemDamageDone(this.boostedRakeDamage)}</strong>
+              </li>
+            </ul>
+          </>
+        }
+      >
+        <TalentSpellText talent={TALENTS_DRUID.SUDDEN_AMBUSH_TALENT}>
+          <ItemPercentDamageDone greaterThan amount={this.totalDamage} />
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}
+
+export default SuddenAmbush;

--- a/src/analysis/retail/druid/feral/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/druid/feral/normalizers/CastLinkNormalizer.ts
@@ -16,6 +16,7 @@ import { Options } from 'parser/core/Module';
 const CAST_BUFFER_MS = 200;
 
 export const FROM_HARDCAST = 'FromHardcast';
+export const FROM_DOUBLE_CLAWED_RAKE = 'FromDoubleClawedRake';
 export const FROM_PRIMAL_WRATH = 'FromPrimalWrath';
 export const HIT_TARGET = 'HitTarget';
 
@@ -48,6 +49,17 @@ const EVENT_LINKS: EventLink[] = [
     referencedEventType: EventType.Cast,
     forwardBufferMs: CAST_BUFFER_MS,
     backwardBufferMs: CAST_BUFFER_MS,
+  },
+  {
+    linkRelation: FROM_DOUBLE_CLAWED_RAKE,
+    linkingEventId: [SPELLS.RAKE_BLEED.id, SPELLS.RAKE_STUN.id],
+    linkingEventType: [EventType.ApplyDebuff, EventType.RefreshDebuff],
+    referencedEventId: SPELLS.RAKE.id,
+    referencedEventType: EventType.Cast,
+    forwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: CAST_BUFFER_MS,
+    anyTarget: true,
+    additionalCondition: (le, re) => !isFromHardcast(le),
   },
   {
     linkRelation: FROM_HARDCAST,
@@ -130,10 +142,12 @@ class CastLinkNormalizer extends EventLinkNormalizer {
   }
 }
 
-export function isFromHardcast(
-  event: ApplyDebuffEvent | RefreshDebuffEvent | DamageEvent,
-): boolean {
+export function isFromHardcast(event: AnyEvent): boolean {
   return HasRelatedEvent(event, FROM_HARDCAST);
+}
+
+export function isFromDoubleClawedRake(event: AnyEvent): boolean {
+  return HasRelatedEvent(event, FROM_DOUBLE_CLAWED_RAKE);
 }
 
 export function getHardcast(

--- a/src/analysis/retail/druid/feral/normalizers/SuddenAmbushLinkNormalizer.ts
+++ b/src/analysis/retail/druid/feral/normalizers/SuddenAmbushLinkNormalizer.ts
@@ -1,0 +1,71 @@
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import { Options } from 'parser/core/Module';
+import SPELLS from 'common/SPELLS';
+import {
+  ApplyDebuffEvent,
+  BuffEvent,
+  DamageEvent,
+  EventType,
+  GetRelatedEvents,
+  HasRelatedEvent,
+  RefreshDebuffEvent,
+  RemoveBuffEvent,
+} from 'parser/core/Events';
+
+const BOOSTED_BLEED = 'BoostedBleed';
+const BOOSTED_DAMAGE = 'BoostedDamage';
+const BOOSTED_BY_SA = 'BoostedBySuddenAmbush';
+
+const CAST_BUFFER_MS = 50;
+
+const EVENT_LINKS: EventLink[] = [
+  {
+    linkRelation: BOOSTED_BLEED,
+    reverseLinkRelation: BOOSTED_BY_SA,
+    linkingEventId: SPELLS.SUDDEN_AMBUSH_BUFF.id,
+    linkingEventType: EventType.RemoveBuff,
+    referencedEventId: SPELLS.RAKE_BLEED.id,
+    referencedEventType: [EventType.ApplyDebuff, EventType.RefreshDebuff],
+    forwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: CAST_BUFFER_MS,
+    anyTarget: true,
+  },
+  {
+    linkRelation: BOOSTED_DAMAGE,
+    linkingEventId: SPELLS.SUDDEN_AMBUSH_BUFF.id,
+    linkingEventType: EventType.RemoveBuff,
+    referencedEventId: [SPELLS.RAKE.id, SPELLS.SHRED.id],
+    referencedEventType: EventType.Damage,
+    forwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: CAST_BUFFER_MS,
+    anyTarget: true,
+  },
+];
+
+/**
+ * This normalizer links each Sudden Ambush buff consume to the damage / debuffs it boosted
+ */
+class SuddenAmbushLinkNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_LINKS);
+  }
+}
+
+export default SuddenAmbushLinkNormalizer;
+
+export function getSuddenAmbushBoostedBleeds(event: RemoveBuffEvent): BuffEvent<any>[] {
+  return GetRelatedEvents(event, BOOSTED_BLEED).filter(
+    (e): e is BuffEvent<any> =>
+      e.type === EventType.ApplyDebuff || e.type === EventType.RefreshDebuff,
+  );
+}
+
+export function getSuddenAmbushBoostedDamage(event: RemoveBuffEvent): DamageEvent[] {
+  return GetRelatedEvents(event, BOOSTED_DAMAGE).filter(
+    (e): e is DamageEvent => e.type === EventType.Damage,
+  );
+}
+
+export function isBoostedBySuddenAmbush(event: ApplyDebuffEvent | RefreshDebuffEvent) {
+  return HasRelatedEvent(event, BOOSTED_BY_SA);
+}

--- a/src/analysis/retail/priest/holy/modules/talents/BottomRow/DesperateTimes.tsx
+++ b/src/analysis/retail/priest/holy/modules/talents/BottomRow/DesperateTimes.tsx
@@ -53,10 +53,7 @@ class DesperateTimes extends Analyzer {
         category={STATISTIC_CATEGORY.TALENTS}
         position={STATISTIC_ORDER.OPTIONAL(1)}
       >
-        <TalentSpellText
-          spellId={TALENTS.DESPERATE_TIMES_TALENT.id}
-          maxRanks={TALENTS.DESPERATE_TIMES_TALENT.maxRanks}
-        >
+        <TalentSpellText talent={TALENTS.DESPERATE_TIMES_TALENT}>
           <ItemHealingDone amount={this.healingDoneFromTalent} />
         </TalentSpellText>
       </Statistic>

--- a/src/analysis/retail/priest/holy/modules/talents/BottomRow/ResonantWords.tsx
+++ b/src/analysis/retail/priest/holy/modules/talents/BottomRow/ResonantWords.tsx
@@ -85,10 +85,7 @@ class ResonantWords extends Analyzer {
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={`${this.wastedResonantWords}/${this.totalResonantWords} wasted resonant word buffs.`}
       >
-        <TalentSpellText
-          spellId={TALENTS.RESONANT_WORDS_TALENT.id}
-          maxRanks={TALENTS.RESONANT_WORDS_TALENT.maxRanks}
-        >
+        <TalentSpellText talent={TALENTS.RESONANT_WORDS_TALENT}>
           <ItemHealingDone amount={this.healingDoneFromTalent} />
           <br />
           {formatPercentage(

--- a/src/parser/ui/TalentSpellText.tsx
+++ b/src/parser/ui/TalentSpellText.tsx
@@ -3,10 +3,10 @@ import { SpellLink } from 'interface';
 import CombatLogParser from 'parser/core/CombatLogParser';
 import PropTypes from 'prop-types';
 import { ReactNode } from 'react';
+import { Talent } from 'common/TALENTS/types';
 
 interface Props {
-  spellId: number;
-  maxRanks: number;
+  talent: Talent;
   children: ReactNode;
   className?: string;
 }
@@ -21,21 +21,21 @@ interface Context {
  * Component will link to the talent with the current rank as well".
  */
 const TalentSpellText = (
-  { spellId, maxRanks, children, className }: Props,
+  { talent, children, className }: Props,
   { parser: { selectedCombatant } }: Context,
 ) => {
+  const spellId = talent.id;
   const rank = selectedCombatant.getTalentRank(spellId);
+  const maxRanks = talent.maxRanks;
   return (
     <div className={`pad boring-text ${className || ''}`}>
       <label>
         <SpellIcon id={spellId} /> <SpellLink id={spellId} icon={false} /> -{' '}
         <TooltipElement
-            content={`Talented into with ${rank} point${
-              rank > 1 ? 's' : ''
-            } out of ${maxRanks} point${maxRanks > 1 ? 's' : ''}`}
-          >
-            {rank}/{maxRanks}
-          </TooltipElement>
+          content={`Talented into with ${rank} out of ${maxRanks} point${maxRanks > 1 ? 's' : ''}`}
+        >
+          {rank}/{maxRanks}
+        </TooltipElement>
       </label>
       <div className="value">{children}</div>
     </div>


### PR DESCRIPTION
Also made some improvements to TalentSpellText so you can just pass it the Talent object rather than spellId and maxRanks separately.

![sudden_ambush_tooltip](https://user-images.githubusercontent.com/7143486/196018756-561471c6-50c1-4bbf-b6ba-8ce9f21cfdca.png)
![sabertooth_tooltip](https://user-images.githubusercontent.com/7143486/196018759-234a3c1b-c60e-4a4c-958f-f52a748599df.png)
![](https://cdn.discordapp.com/attachments/965665097655681064/1031017356689940551/unknown.png)

