### PR TITLE
Fix uplifted spirits CDR module

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2022, 10, 16), <>Fixed Uplifted Spirits CDR</>, Trevor),
   change(date(2022, 10, 13), <>Cleaned up MW spells/talents files</>, Trevor),
   change(date(2022, 10, 13), <>Updated Rising Mist module for Dragonflight</>, Trevor),
   change(date(2022, 10, 9), <>Added Secret Infusion haste buff and fixed <SpellLink id={TALENTS_MONK.UPLIFTED_SPIRITS_TALENT.id}/></>, Trevor),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/UpliftedSpirits.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/UpliftedSpirits.tsx
@@ -42,6 +42,7 @@ class UpliftedSpirits extends Analyzer {
       Events.damage.by(SELECTED_PLAYER).spell(SPELLS.RISING_SUN_KICK_SECOND),
       this.rskHit,
     );
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.VIVIFY), this.vivifyHit);
   }
 
   rskHit(event: DamageEvent) {


### PR DESCRIPTION
Forgot to add event listener to vivify hit, so cdr wasn't accurate
After fix:
 ![image_2022-10-16_184500988](https://user-images.githubusercontent.com/11250934/196071953-e7f27384-49c9-4d28-9e67-9ba7887bb756.png) 

Before fix: 
![image_2022-10-16_184526019](https://user-images.githubusercontent.com/11250934/196071984-87acc27d-c8df-4c07-bc22-c5c3d27ef71c.png)



