### PR TITLE
use generated talent info for PlayerInfoTalents

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -67,6 +67,7 @@ import { TALENTS_SHAMAN } from 'common/TALENTS';
 
 // prettier-ignore
 export default [
+  change(date(2022, 10, 17), 'Use generated talent info for character pages.', ToppleTheNun),
   change(date(2022, 10, 16), 'Update SpellLink to accept Spell instances.', ToppleTheNun),
   change(date(2022, 10, 16), 'Add ability to determine if wearing T29 2pc or 4pc.', ToppleTheNun),
   change(date(2022, 10, 16), 'Adding sourceInstance to BuffEvent', Jonfanz),

--- a/src/common/TALENTS/maybeGetTalent.ts
+++ b/src/common/TALENTS/maybeGetTalent.ts
@@ -1,0 +1,42 @@
+// We currently only need to fetch talents by IDs from the large object.
+import { indexOnlyById } from 'common/indexById';
+import { Talent } from 'common/TALENTS/types';
+import {
+  TALENTS_WARRIOR,
+  TALENTS_PALADIN,
+  TALENTS_HUNTER,
+  TALENTS_ROGUE,
+  TALENTS_PRIEST,
+  TALENTS_DEATH_KNIGHT,
+  TALENTS_SHAMAN,
+  TALENTS_MAGE,
+  TALENTS_WARLOCK,
+  TALENTS_MONK,
+  TALENTS_DRUID,
+  TALENTS_DEMON_HUNTER,
+  TALENTS_EVOKER,
+} from './index';
+
+// We currently only need to fetch talents by IDs from the large object.
+// We `indexOnlyById` every talent set individually due to talent name conflicts
+// occurring between classes. FLURRY_TALENT is a very popular talent name, apparently.
+const TALENTS = {
+  ...indexOnlyById<Talent, typeof TALENTS_WARRIOR>(TALENTS_WARRIOR),
+  ...indexOnlyById<Talent, typeof TALENTS_PALADIN>(TALENTS_PALADIN),
+  ...indexOnlyById<Talent, typeof TALENTS_HUNTER>(TALENTS_HUNTER),
+  ...indexOnlyById<Talent, typeof TALENTS_ROGUE>(TALENTS_ROGUE),
+  ...indexOnlyById<Talent, typeof TALENTS_PRIEST>(TALENTS_PRIEST),
+  ...indexOnlyById<Talent, typeof TALENTS_DEATH_KNIGHT>(TALENTS_DEATH_KNIGHT),
+  ...indexOnlyById<Talent, typeof TALENTS_SHAMAN>(TALENTS_SHAMAN),
+  ...indexOnlyById<Talent, typeof TALENTS_MAGE>(TALENTS_MAGE),
+  ...indexOnlyById<Talent, typeof TALENTS_WARLOCK>(TALENTS_WARLOCK),
+  ...indexOnlyById<Talent, typeof TALENTS_MONK>(TALENTS_MONK),
+  ...indexOnlyById<Talent, typeof TALENTS_DRUID>(TALENTS_DRUID),
+  ...indexOnlyById<Talent, typeof TALENTS_DEMON_HUNTER>(TALENTS_DEMON_HUNTER),
+  ...indexOnlyById<Talent, typeof TALENTS_EVOKER>(TALENTS_EVOKER),
+} as const;
+
+const maybeGetTalent = (key: number | undefined): Talent | undefined =>
+  key ? TALENTS[key as any] : undefined;
+
+export default maybeGetTalent;

--- a/src/common/indexById.ts
+++ b/src/common/indexById.ts
@@ -1,3 +1,5 @@
+import { shallowEqual } from 'react-redux';
+
 interface BaseIndexableObj {
   id: number;
   __ignoreDuplication?: boolean;
@@ -36,5 +38,33 @@ const indexById = <ValueT extends BaseIndexableObj, Map extends RestrictedTable<
 export const asRestrictedTable = <T extends BaseIndexableObj>() => <E>(
   value: RestrictedTable<T, E>,
 ): RestrictedTable<T, E> => value;
+
+export const indexOnlyById = <
+  ValueT extends BaseIndexableObj,
+  Map extends RestrictedTable<ValueT, any>
+>(
+  arg: Map,
+): Record<number, ValueT> => {
+  const indexedByNameAndId: Record<number, ValueT> = {};
+  typedKeys(arg).forEach((key) => {
+    const value = arg[key];
+
+    if (process.env.NODE_ENV === 'development') {
+      // check if there's already an existing value by the same ID
+      // and throw an error if it's not exactly equal
+      // the shallow equality check is added to support cases like Warrior's Sudden Death talent
+      if (
+        indexedByNameAndId[value.id] &&
+        !indexedByNameAndId[value.id].__ignoreDuplication &&
+        !value.__ignoreDuplication &&
+        !shallowEqual(indexedByNameAndId[value.id], value)
+      ) {
+        throw new Error(`A spell with this ID already exists: ${value.id}, ${String(key)}`);
+      }
+    }
+    indexedByNameAndId[value.id] = value;
+  });
+  return indexedByNameAndId;
+};
 
 export default indexById;

--- a/src/interface/report/Results/PlayerInfoTalent.tsx
+++ b/src/interface/report/Results/PlayerInfoTalent.tsx
@@ -1,0 +1,47 @@
+import SpellIcon from 'interface/SpellIcon';
+import SpellLink from 'interface/SpellLink';
+import { TalentEntry } from 'parser/core/Events';
+import maybeGetTalent from 'common/TALENTS/maybeGetTalent';
+import Icon from 'interface/Icon';
+
+interface Props {
+  talentEntry: TalentEntry;
+}
+
+const FALLBACK_ICON = 'inv_misc_questionmark';
+
+const PlayerInfoTalent = ({ talentEntry }: Props) => {
+  const talent = maybeGetTalent(talentEntry.spellID);
+  if (!talent) {
+    return (
+      <>
+        <div className="talent-icon">
+          <Icon icon={FALLBACK_ICON} style={{ width: '2em', height: '2em' }} />
+        </div>
+        <div className="talent-name">
+          <SpellLink id={talentEntry.spellID} icon={false}>
+            Unknown talent: {talentEntry.spellID}
+          </SpellLink>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <div className="talent-info-row" style={{ marginBottom: '0.8em', fontSize: '1.3em' }}>
+      <>
+        <div className="talent-icon">
+          <SpellIcon id={talent} style={{ width: '2em', height: '2em' }} />
+        </div>
+        <div className="talent-name">
+          <SpellLink id={talent} icon={false}>
+            {talent.name}
+          </SpellLink>
+        </div>
+        <div className="talent-level">{talentEntry.rank}</div>
+      </>
+    </div>
+  );
+};
+
+export default PlayerInfoTalent;

--- a/src/interface/report/Results/PlayerInfoTalents.tsx
+++ b/src/interface/report/Results/PlayerInfoTalents.tsx
@@ -1,11 +1,6 @@
 import { Trans } from '@lingui/macro';
-import { maybeGetSpell } from 'common/SPELLS';
-import Icon from 'interface/Icon';
-import SpellIcon from 'interface/SpellIcon';
-import SpellLink from 'interface/SpellLink';
 import { TalentEntry } from 'parser/core/Events';
-
-const FALLBACK_ICON = 'inv_misc_questionmark';
+import PlayerInfoTalent from 'interface/report/Results/PlayerInfoTalent';
 
 interface Props {
   talents: TalentEntry[];
@@ -34,35 +29,8 @@ const PlayerInfoTalents = ({ talents }: Props) => {
         <Trans id="common.talents">Talents</Trans>
       </h3>
       <div className="talent-info">
-        {talents.map((talent, index) => (
-          <div
-            key={index}
-            className="talent-info-row"
-            style={{ marginBottom: '0.8em', fontSize: '1.3em' }}
-          >
-            {talent.spellID ? (
-              <>
-                <div className="talent-icon">
-                  <SpellIcon id={talent.spellID} style={{ width: '2em', height: '2em' }} />
-                </div>
-                <div className="talent-name">
-                  <SpellLink id={talent.spellID} icon={false}>
-                    {maybeGetSpell(talent.spellID)?.name ?? `Unknown spell: ${talent.spellID}`}
-                  </SpellLink>
-                </div>
-                <div className="talent-level">{talent.rank}</div>
-              </>
-            ) : (
-              <>
-                <div className="talent-icon">
-                  <Icon icon={FALLBACK_ICON} style={{ width: '2em', height: '2em' }} />
-                </div>
-                <div className="talent-name">
-                  <i>No talent active</i>
-                </div>
-              </>
-            )}
-          </div>
+        {talents.map((talent) => (
+          <PlayerInfoTalent key={talent.id} talentEntry={talent} />
         ))}
       </div>
     </div>


### PR DESCRIPTION
this prevents us from running into a situation
where spells are unknown when rendering on the
character page.

Note that there are still some weird cases where a
talent might not appear due to naming conflicts.
Example of this is War Machine for Warrior. I'm
still looking into a possible fix for this, but this
should be a good starting place.

Log: https://dragonflight.wowanalyzer.com/report/zg96K4TcxkrBWP32/3-Normal+Terros+-+Kill+(5:37)/Daemondie/standard/character

**Before**
![image](https://user-images.githubusercontent.com/1672786/196319490-62fd4c27-2f33-482f-91f8-88de48ccb93d.png)

**After**
![image](https://user-images.githubusercontent.com/1672786/196319553-de9b32c4-b171-40a2-b169-c4b4372e3bef.png)
