### PR TITLE
fix rsk uptime calculations for mw

### DIFF
--- a/analysis/monkmistweaver/src/CHANGELOG.tsx
+++ b/analysis/monkmistweaver/src/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
-  change(date(2022, 10, 18), <>Fix <SpellLink id={SPELLS.RISING_SUN_KICK_TALENT.id}/></>, Trevor),
+  change(date(2022, 10, 18), <>Fix <SpellLink id={SPELLS.RISING_SUN_KICK.id}/></>, Trevor),
   change(date(2022, 9, 4), <>Updated guide link in checklist.</>, emallson),
   change(date(2022, 7, 6), <>Created a set color scheme for each spell. A spell's color should remain the same across all infographs.</>, Abelito75),
   change(date(2022, 7, 6), <>Average Renewing Mists during Mana Tea no longer depends on vivify being cast.</>, Abelito75),

--- a/analysis/monkmistweaver/src/CHANGELOG.tsx
+++ b/analysis/monkmistweaver/src/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2022, 10, 18), <>Fix <SpellLink id={SPELLS.RISING_SUN_KICK_TALENT.id}/></>, Trevor),
   change(date(2022, 9, 4), <>Updated guide link in checklist.</>, emallson),
   change(date(2022, 7, 6), <>Created a set color scheme for each spell. A spell's color should remain the same across all infographs.</>, Abelito75),
   change(date(2022, 7, 6), <>Average Renewing Mists during Mana Tea no longer depends on vivify being cast.</>, Abelito75),

--- a/analysis/monkmistweaver/src/modules/spells/RisingSunKick.tsx
+++ b/analysis/monkmistweaver/src/modules/spells/RisingSunKick.tsx
@@ -40,9 +40,6 @@ class RisingSunKick extends Analyzer {
 
     if (this.lastBOK > this.lastRSK) {
       this.rskResets += 1;
-
-      this.spellUsable.endCooldown(SPELLS.RISING_SUN_KICK.id);
-      this.spellUsable.beginCooldown(event, SPELLS.RISING_SUN_KICK.id);
     }
 
     this.lastRSK = event.timestamp;


### PR DESCRIPTION
SpellUsable rewrite broke RSK module because we manually began/ended cooldown for rsk but the module does that for us already which led to bad things