### PR TITLE
enable SoulsOvercap analyzer when FtD is taken

### DIFF
--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import TALENTS from 'common/TALENTS/demonhunter';
 
 // prettier-ignore
 export default [
+  change(date(2022, 10, 22), <>Enable Soul Overcap analysis even when <SpellLink id={TALENTS.FEED_THE_DEMON_TALENT.id}/> is taken.</>, ToppleTheNun),
   change(date(2022, 10, 16), <>Add mitigation tracking for <SpellLink id={TALENTS.FIERY_BRAND_TALENT.id}/>.</>, ToppleTheNun),
   change(date(2022, 10, 16), <>Add support for <SpellLink id={TALENTS.DISRUPTING_FURY_TALENT.id}/>.</>, ToppleTheNun),
   change(date(2022, 10, 15), <>Add support for <SpellLink id={TALENTS.FLAMES_OF_FURY_TALENT.id}/>.</>, ToppleTheNun),

--- a/src/analysis/retail/demonhunter/vengeance/modules/checklist/Component.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/checklist/Component.tsx
@@ -74,6 +74,10 @@ const VengeanceDemonHunterChecklist = (props: ChecklistProps) => {
             thresholds={thresholds.demonSpikes}
           />
         )}
+        {combatant.hasTalent(TALENTS_DEMON_HUNTER.FIERY_BRAND_TALENT.id) &&
+          combatant.hasTalent(TALENTS_DEMON_HUNTER.FIERY_DEMISE_TALENT.id) && (
+            <AbilityRequirement spell={TALENTS_DEMON_HUNTER.FIERY_BRAND_TALENT.id} />
+          )}
       </Rule>
 
       <Rule

--- a/src/analysis/retail/demonhunter/vengeance/modules/spells/DemonSpikes.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/spells/DemonSpikes.tsx
@@ -68,7 +68,7 @@ class DemonSpikes extends Analyzer {
         <>
           {' '}
           Cast <SpellLink id={SPELLS.DEMON_SPIKES.id} /> more regularly while actively tanking the
-          boss or when they use a big phsyical attack. You missed having it up for{' '}
+          boss or when they use a big physical attack. You missed having it up for{' '}
           {formatPercentage(this.hitsWithDSOffCDPercent)}% of physical hits.
         </>,
       )

--- a/src/analysis/retail/demonhunter/vengeance/modules/statistics/SoulsOvercap.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/statistics/SoulsOvercap.tsx
@@ -21,12 +21,6 @@ class SoulsOvercap extends Analyzer {
   protected abilityTracker!: AbilityTracker;
   protected soulFragmentsTracker!: SoulFragmentsTracker;
 
-  /* Feed The Demon talent is taken in defensive builds. In those cases you want to generate and consume souls as quickly
- as possible. So how you consume your souls down matter. If you dont take that talent your taking a more balanced
- build meaning you want to consume souls in a way that boosts your dps. That means feeding the souls into spirit
- bomb as efficiently as possible (cast at 4+ souls) for a dps boost and have soul cleave absorb souls as little as
- possible since it provides no extra dps.
-*/
   constructor(options: Options) {
     super(options);
     this.active =


### PR DESCRIPTION
previously, this analyzer was disabled due to
FtD having a level of conflict with SpB. they
are both taken regularly now, however, so the
analysis can still be useful.