### PR TITLE
Warlock Component Text

### DIFF
--- a/src/analysis/classic/warlock/CHANGELOG.tsx
+++ b/src/analysis/classic/warlock/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { change, date } from 'common/changelog';
 import { Khadaj, Talador12, emallson, jazminite } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2021, 10, 22), 'Text updates for live build', jazminite),
   change(date(2021, 10, 22), 'Update Curse info for WotLK', jazminite),
   change(date(2021, 10, 18), 'Add specs and update timeline for WotLK', jazminite),
   change(date(2021, 10, 16), 'Update spells for WotLK', jazminite),

--- a/src/analysis/classic/warlock/modules/checklist/Component.tsx
+++ b/src/analysis/classic/warlock/modules/checklist/Component.tsx
@@ -24,33 +24,50 @@ const DotUptime = (props: DotUptimeProps) => (
   />
 );
 
-const curseOfTheElements = <Trans id="warlock.wotlk.shared.curses.curseOfElements"></Trans>;
-const curseOfDoom = <Trans id="warlock.wotlk.shared.curses.curseOfDoom"></Trans>;
-const curseOfAgony = <Trans id="warlock.wotlk.shared.curses.curseOfAgony"></Trans>;
+const curseOfTheElements = (
+  <Trans id="warlock.wotlk.shared.curses.curseOfElements">Curse of Elements</Trans>
+);
+const curseOfDoom = <Trans id="warlock.wotlk.shared.curses.curseOfDoom">Curse of Doom</Trans>;
+const curseOfAgony = <Trans id="warlock.wotlk.shared.curses.curseOfAgony">Curse of Elements</Trans>;
 
 const WarlockChecklist = ({ thresholds, castEfficiency, combatant }: ChecklistProps) => (
   <Checklist>
     <Rule
-      name={<Trans id="warlock.wotlk.checklist.avoidBeingInactive"></Trans>}
+      name={
+        <Trans id="warlock.wotlk.checklist.avoidBeingInactive">
+          Avoid being inactive for a large portion of the fight
+        </Trans>
+      }
       description={
         <>
-          <Trans id="warlock.wotlk.checklist.avoidBeingInactive.description"></Trans>
+          <Trans id="warlock.wotlk.checklist.avoidBeingInactive.description">
+            High downtime is something to avoid. You can reduce your downtime by reducing the delay
+            between casting abilities, anticipating movement, and moving during the GCD.
+          </Trans>
         </>
       }
     >
       <Requirement
-        name={<Trans id="warlock.wotlk.checklist.downtime"></Trans>}
+        name={<Trans id="warlock.wotlk.checklist.downtime">Downtime</Trans>}
         thresholds={thresholds.downtimeSuggestionThresholds}
       />
     </Rule>
     <Rule
-      name={<Trans id="warlock.wotlk.checklist.maintainCurse"></Trans>}
+      name={
+        <Trans id="warlock.wotlk.checklist.maintainCurse">
+          Maintain a curse on the primary target
+        </Trans>
+      }
       description={
         <Fragment>
           <Trans id="warlock.wotlk.checklist.maintainCurse.description">
-            <SpellLink id={CURSE_OF_THE_ELEMENTS}>{curseOfTheElements}</SpellLink>
-            <SpellLink id={CURSE_OF_DOOM}>{curseOfDoom}</SpellLink>
-            <SpellLink id={CURSE_OF_AGONY}>{curseOfAgony}</SpellLink>
+            It is important to maintain a curse on the primary target. If there is no Unholy DK
+            \(using Ebon Plaguebringer\) or Boomkin \(using Earth and Moon\) in the raid, use{' '}
+            <SpellLink id={CURSE_OF_THE_ELEMENTS}>{curseOfTheElements}</SpellLink>. After the
+            priority curse consideration, use{' '}
+            <SpellLink id={CURSE_OF_DOOM}>{curseOfDoom}</SpellLink> for a target alive more than a
+            minute or <SpellLink id={CURSE_OF_AGONY}>{curseOfAgony}</SpellLink> for a target alive
+            less than a minute.
           </Trans>
         </Fragment>
       }

--- a/src/analysis/classic/warlock/modules/checklist/Component.tsx
+++ b/src/analysis/classic/warlock/modules/checklist/Component.tsx
@@ -35,7 +35,7 @@ const WarlockChecklist = ({ thresholds, castEfficiency, combatant }: ChecklistPr
     <Rule
       name={
         <Trans id="warlock.wotlk.checklist.avoidBeingInactive">
-          Avoid being inactive for a large portion of the fight
+          Avoid being inactive during the fight
         </Trans>
       }
       description={

--- a/src/analysis/classic/warlock/modules/spells/Curses.tsx
+++ b/src/analysis/classic/warlock/modules/spells/Curses.tsx
@@ -37,14 +37,16 @@ class Curses extends Analyzer {
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
       suggest(
         <span>
-          <Trans id="warlock.wotlk.suggestions.curse.description"></Trans>
+          <Trans id="warlock.wotlk.suggestions.curse.description">
+            Your curse uptime can be improved.
+          </Trans>
         </span>,
       )
         .icon('classicon_warlock')
         .actual(
           t({
             id: 'warlock.wotlk.suggestions.curse.uptime',
-            message: `${formatPercentage(actual)}`,
+            message: `${formatPercentage(actual)}% Curse uptime`,
           }),
         )
         .recommended(`>${formatPercentage(recommended)}% is recommended`),

--- a/src/localization/en/messages.json
+++ b/src/localization/en/messages.json
@@ -1245,7 +1245,7 @@
   "warlock.destruction.suggestions.immolate.uptime": "{0}% Immolate uptime",
   "warlock.destruction.suggestions.soulShard.wastedPerMinute": "{fragmentsWasted} Soul Shard Fragments wasted ({0} per minute)",
   "warlock.shared.suggestions.grimoireOfSacrifice.uptime": "{0} % Grimoire of Sacrifice uptime.",
-  "warlock.wotlk.checklist.avoidBeingInactive": "Try to avoid being inactive for a large portion of the fight",
+  "warlock.wotlk.checklist.avoidBeingInactive": "Avoid being inactive for a large portion of the fight",
   "warlock.wotlk.checklist.avoidBeingInactive.description": "High downtime is something to avoid. You can reduce your downtime by reducing the delay between casting abilities, anticipating movement, and moving during the GCD.",
   "warlock.wotlk.checklist.maintainCurse": "Maintain a curse on the primary target",
   "warlock.wotlk.checklist.maintainCurse.description": "It is important to maintain a curse on the primary target. If there is no Unholy DK (using Ebon Plaguebringer) or Boomkin (using Earth and Moon) in the raid, use <0>{curseOfTheElements}</0>. After the priority curse consideration, use <1>{curseOfDoom}</1> for a target alive more than a minute or <2>{curseOfAgony}</2> for a target alive less than a minute.",

--- a/src/localization/en/messages.json
+++ b/src/localization/en/messages.json
@@ -1245,7 +1245,7 @@
   "warlock.destruction.suggestions.immolate.uptime": "{0}% Immolate uptime",
   "warlock.destruction.suggestions.soulShard.wastedPerMinute": "{fragmentsWasted} Soul Shard Fragments wasted ({0} per minute)",
   "warlock.shared.suggestions.grimoireOfSacrifice.uptime": "{0} % Grimoire of Sacrifice uptime.",
-  "warlock.wotlk.checklist.avoidBeingInactive": "Avoid being inactive for a large portion of the fight",
+  "warlock.wotlk.checklist.avoidBeingInactive": "Avoid being inactive during the fight",
   "warlock.wotlk.checklist.avoidBeingInactive.description": "High downtime is something to avoid. You can reduce your downtime by reducing the delay between casting abilities, anticipating movement, and moving during the GCD.",
   "warlock.wotlk.checklist.maintainCurse": "Maintain a curse on the primary target",
   "warlock.wotlk.checklist.maintainCurse.description": "It is important to maintain a curse on the primary target. If there is no Unholy DK (using Ebon Plaguebringer) or Boomkin (using Earth and Moon) in the raid, use <0>{curseOfTheElements}</0>. After the priority curse consideration, use <1>{curseOfDoom}</1> for a target alive more than a minute or <2>{curseOfAgony}</2> for a target alive less than a minute.",


### PR DESCRIPTION
- Add back text to Warlock Component. Text showed from `messages.json` on my local build but doesn't show on live:
![image](https://user-images.githubusercontent.com/65823478/197370177-e15f4b69-2c2b-45c3-8df0-92326c917396.png)

- Wording updates