### PR TITLE
Druid Resto Guide tooltip updates and PerformanceBoxRow populate refactor. Also some core utilities added.

### DIFF
--- a/src/analysis/retail/druid/feral/modules/spells/AdaptiveSwarmFeral.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/AdaptiveSwarmFeral.tsx
@@ -52,7 +52,6 @@ class AdaptiveSwarmFeral extends AdaptiveSwarmDamageDealer {
       <RoundedPanel>
         <div>
           <strong>Adaptive Swarm uptime</strong>
-          <small> - Try to get as close to 100% as the encounter allows!</small>
         </div>
         {this.subStatistic()}
       </RoundedPanel>

--- a/src/analysis/retail/druid/feral/modules/spells/AdaptiveSwarmFeral.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/AdaptiveSwarmFeral.tsx
@@ -51,7 +51,7 @@ class AdaptiveSwarmFeral extends AdaptiveSwarmDamageDealer {
     const data = (
       <RoundedPanel>
         <div>
-          <strong>Moonfire uptime / snapshots</strong>
+          <strong>Adaptive Swarm uptime</strong>
           <small> - Try to get as close to 100% as the encounter allows!</small>
         </div>
         {this.subStatistic()}

--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -2,8 +2,10 @@ import { change, date } from 'common/changelog';
 import { Sref } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import { TALENTS_DRUID } from 'common/TALENTS';
+import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2022, 10, 23), <>Updated Guide's 'cast box' displays with better tooltips. Made high overheal <SpellLink id={SPELLS.WILD_GROWTH.id} /> detection slightly less strict. Fixed an issue where <SpellLink id={SPELLS.SWIFTMEND.id} /> tracking wasn't detecting <SpellLink id={SPELLS.REJUVENATION_GERMINATION.id} /> removal.</>, Sref),
   change(date(2022, 10, 19), <>Rearranged Guide's 'Core Rotation' section for improved readability</>, Sref),
   change(date(2022, 10, 16), <>Fixed a bug where casting Flourish before your first Convoke caused a crash in the Flourish module.</>, Sref),
   change(date(2022, 10, 14), <>Updated statistics for <SpellLink id={TALENTS_DRUID.POWER_OF_THE_ARCHDRUID_TALENT.id} /> and <SpellLink id={TALENTS_DRUID.REGENESIS_TALENT.id} /> to provide breakdown by spell.</>, Sref),

--- a/src/analysis/retail/druid/restoration/Guide.tsx
+++ b/src/analysis/retail/druid/restoration/Guide.tsx
@@ -22,9 +22,8 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
         {modules.swiftmend.guideSubsection}
         {info.combatant.hasTalent(TALENTS_DRUID.SOUL_OF_THE_FOREST_RESTORATION_TALENT) &&
           modules.soulOfTheForest.guideSubsection}
-        {info.combatant.hasTalent(TALENTS_DRUID.CENARION_WARD_TALENT) && (
-          <CenarionWardSubsection modules={modules} events={events} info={info} />
-        )}
+        {info.combatant.hasTalent(TALENTS_DRUID.CENARION_WARD_TALENT) &&
+          modules.cenarionWard.guideSubsection}
       </Section>
       <Section title="Healing Cooldowns">
         <p>
@@ -42,29 +41,6 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
         <CooldownBreakdownSubsection modules={modules} events={events} info={info} />
       </Section>
     </>
-  );
-}
-
-function CenarionWardSubsection({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
-  return (
-    <SubSection>
-      <p>
-        <b>
-          <SpellLink id={TALENTS_DRUID.CENARION_WARD_TALENT.id} />
-        </b>{' '}
-        is a talented HoT on a short cooldown. It is extremely powerful and efficient and should be
-        cast virtually on cooldown. A tank is usually the best target.
-      </p>
-      <strong>Cenarion Ward usage and cooldown</strong>
-      <div className="flex-main chart" style={{ padding: 5 }}>
-        <CooldownBar
-          spellId={TALENTS_DRUID.CENARION_WARD_TALENT.id}
-          events={events}
-          info={info}
-          highlightGaps
-        />
-      </div>
-    </SubSection>
   );
 }
 

--- a/src/analysis/retail/druid/restoration/modules/spells/Abundance.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/Abundance.tsx
@@ -9,8 +9,8 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
-const MS_BUFFER = 200;
-const ABUNDANCE_MANA_REDUCTION = 0.05;
+const MS_BUFFER = 100;
+export const ABUNDANCE_MANA_REDUCTION = 0.05;
 const ABUNDANCE_INCREASED_CRIT = 0.05;
 
 /**

--- a/src/analysis/retail/druid/restoration/modules/spells/CenarionWard.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/CenarionWard.tsx
@@ -8,6 +8,10 @@ import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
 import Mastery from 'analysis/retail/druid/restoration/modules/core/Mastery';
 import { TALENTS_DRUID } from 'common/TALENTS';
+import { SpellLink } from 'interface';
+import { CooldownBar } from 'parser/ui/CooldownBar';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { GUIDE_CORE_EXPLANATION_PERCENT } from 'analysis/retail/druid/restoration/Guide';
 
 /**
  * **Cenarion Ward**
@@ -26,6 +30,34 @@ class CenarionWard extends Analyzer {
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.CENARION_WARD_TALENT);
+  }
+
+  get guideSubsection() {
+    const explanation = (
+      <p>
+        <b>
+          <SpellLink id={TALENTS_DRUID.CENARION_WARD_TALENT.id} />
+        </b>{' '}
+        is a talented HoT on a short cooldown. It is extremely powerful and efficient and should be
+        cast virtually on cooldown. A tank is usually the best target.
+      </p>
+    );
+
+    const data = (
+      <div>
+        <strong>Cenarion Ward usage and cooldown</strong>
+        <div className="flex-main chart" style={{ padding: 5 }}>
+          <CooldownBar
+            spellId={TALENTS_DRUID.CENARION_WARD_TALENT.id}
+            events={this.owner.eventHistory}
+            info={this.owner.info}
+            highlightGaps
+          />
+        </div>
+      </div>
+    );
+
+    return explanationAndDataSubsection(explanation, data, GUIDE_CORE_EXPLANATION_PERCENT);
   }
 
   statistic() {

--- a/src/analysis/retail/druid/restoration/modules/spells/RegrowthAndClearcasting.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/RegrowthAndClearcasting.tsx
@@ -16,7 +16,7 @@ import { getDirectHeal } from 'analysis/retail/druid/restoration/normalizers/Cas
 import { buffedByClearcast } from 'analysis/retail/druid/restoration/normalizers/ClearcastingNormalizer';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
-import { calculateTargetHealthPercent } from 'parser/core/EventCalculateLib';
+import { calculateHealTargetHealthPercent } from 'parser/core/EventCalculateLib';
 import { ABUNDANCE_MANA_REDUCTION } from 'analysis/retail/druid/restoration/modules/spells/Abundance';
 
 /** Health percent below which we consider a heal to be 'triage' */
@@ -93,7 +93,7 @@ class RegrowthAndClearcasting extends Analyzer {
     let targetHealthPercent = undefined;
     const regrowthHeal = getDirectHeal(event);
     if (regrowthHeal) {
-      targetHealthPercent = calculateTargetHealthPercent(regrowthHeal);
+      targetHealthPercent = calculateHealTargetHealthPercent(regrowthHeal);
     }
 
     let castNote = '';
@@ -138,7 +138,8 @@ class RegrowthAndClearcasting extends Analyzer {
         <>
           @ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong> - {castNote}
           <br />
-          targetting <strong>{this.owner.getTargetName(event)}</strong> w/ {targetHealthString}%
+          targetting <strong>{this.owner.getTargetName(event)}</strong> w/{' '}
+          <strong>{targetHealthString}%</strong>
           health
         </>
       ),

--- a/src/analysis/retail/druid/restoration/modules/spells/RegrowthAndClearcasting.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/RegrowthAndClearcasting.tsx
@@ -6,9 +6,9 @@ import CrossIcon from 'interface/icons/Cross';
 import HealthIcon from 'interface/icons/Health';
 import UptimeIcon from 'interface/icons/Uptime';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent, HealEvent } from 'parser/core/Events';
+import Events, { CastEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
-import { PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import { TALENTS_DRUID } from 'common/TALENTS';
@@ -16,6 +16,8 @@ import { getDirectHeal } from 'analysis/retail/druid/restoration/normalizers/Cas
 import { buffedByClearcast } from 'analysis/retail/druid/restoration/normalizers/ClearcastingNormalizer';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
+import { calculateTargetHealthPercent } from 'parser/core/EventCalculateLib';
+import { ABUNDANCE_MANA_REDUCTION } from 'analysis/retail/druid/restoration/modules/spells/Abundance';
 
 /** Health percent below which we consider a heal to be 'triage' */
 const TRIAGE_THRESHOLD = 0.5;
@@ -50,7 +52,8 @@ class RegrowthAndClearcasting extends Analyzer {
   /** full price regrowth hardcasts on healthy targets */
   badRegrowths = 0;
 
-  castRegrowthLog: RegrowthCast[] = [];
+  /** Box row entry for each Regrowth cast */
+  castEntries: BoxRowEntry[] = [];
 
   hasAbundance: boolean;
 
@@ -86,56 +89,66 @@ class RegrowthAndClearcasting extends Analyzer {
 
   onCastRegrowth(event: CastEvent) {
     this.totalRegrowths += 1;
+
+    let targetHealthPercent = undefined;
+    const regrowthHeal = getDirectHeal(event);
+    if (regrowthHeal) {
+      targetHealthPercent = calculateTargetHealthPercent(regrowthHeal);
+    }
+
+    let castNote = '';
+    let wasGood = true;
     if (this.selectedCombatant.hasBuff(SPELLS.INNERVATE.id)) {
       this.innervateRegrowths += 1;
-      this._pushToCastLog(event, 'innervate');
-      return;
+      castNote = 'Free due to Innervate';
     } else if (
       this.selectedCombatant.hasBuff(SPELLS.NATURES_SWIFTNESS.id, event.timestamp, MS_BUFFER)
     ) {
       this.nsRegrowths += 1;
-      this._pushToCastLog(event, 'ns');
+      castNote = "Free due to Nature's Swiftness";
     } else if (buffedByClearcast(event)) {
       this.ccRegrowths += 1;
-      this._pushToCastLog(event, 'clearcast');
+      castNote = 'Free due to Clearcasting';
     } else if (
       this.selectedCombatant.getBuffStacks(SPELLS.ABUNDANCE_BUFF.id) >= ABUNDANCE_EXCEPTION_STACKS
     ) {
       this.abundanceRegrowths += 1;
-      this._pushToCastLog(event, 'abundance');
+      const abundanceStacks = this.selectedCombatant.getBuffStacks(SPELLS.ABUNDANCE_BUFF.id);
+      castNote =
+        ABUNDANCE_MANA_REDUCTION * abundanceStacks >= 1
+          ? `Free due to ${abundanceStacks} stacks of Abundance`
+          : `Cheap due to ${abundanceStacks} stacks of Abundance`;
     } else {
-      // use the heal event to determine if this Regrowth was triage (saving low health player)
-      const regrowthHeal = getDirectHeal(event);
-      if (regrowthHeal !== undefined) {
-        // heals absorbs not technically part of player heal percent,
-        // but they're important to remove so we'll include it
-        const effectiveHealing = regrowthHeal.amount + (regrowthHeal.absorbed || 0);
-        const hitPointsBeforeHeal = regrowthHeal.hitPoints - effectiveHealing;
-        const healthPercentage = hitPointsBeforeHeal / regrowthHeal.maxHitPoints;
-        if (healthPercentage < TRIAGE_THRESHOLD) {
-          this.triageRegrowths += 1;
-          this._pushToCastLog(event, 'triage');
-        } else {
-          this.badRegrowths += 1;
-          this._pushToCastLog(event, 'bad');
-        }
+      // use the heal to determine if this Regrowth was triage (saving low health player)
+      if (targetHealthPercent !== undefined && targetHealthPercent < TRIAGE_THRESHOLD) {
+        this.triageRegrowths += 1;
+        castNote = 'Cast full price on a low health target';
       } else {
-        // shouldn't happen, but just in case something weird is going on
-        console.warn("Regrowth cast couldn't be matched to a heal", event);
+        this.badRegrowths += 1;
+        wasGood = false;
+        castNote = 'Cast full price on a high health target';
       }
     }
+
+    const targetHealthString =
+      targetHealthPercent !== undefined ? `${formatPercentage(targetHealthPercent, 0)}` : 'unknown';
+    this.castEntries.push({
+      value: wasGood,
+      tooltip: (
+        <>
+          @ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong> - {castNote}
+          <br />
+          targetting <strong>{this.owner.getTargetName(event)}</strong> w/ {targetHealthString}%
+          health
+        </>
+      ),
+    });
   }
 
   onFightEnd() {
     if (this.selectedCombatant.hasBuff(SPELLS.CLEARCASTING_BUFF.id)) {
       this.endingClearcasts = 1;
     }
-  }
-
-  _pushToCastLog(event: CastEvent | HealEvent, reason: RegrowthReason) {
-    const wasGood = reason !== 'bad';
-    const abundanceStacks = this.selectedCombatant.getBuffStacks(SPELLS.ABUNDANCE_BUFF.id);
-    this.castRegrowthLog.push({ timestamp: event.timestamp, wasGood, reason, abundanceStacks });
   }
 
   get usedClearcasts() {
@@ -190,26 +203,6 @@ class RegrowthAndClearcasting extends Analyzer {
       </p>
     );
 
-    const castPerfBoxes = this.castRegrowthLog.map((rgCast) => {
-      let message = '';
-      if (rgCast.reason === 'innervate') {
-        message = 'Free due to Innervate';
-      } else if (rgCast.reason === 'ns') {
-        message = "Free due to Nature's Swiftness";
-      } else if (rgCast.reason === 'clearcast') {
-        message = 'Free due to Clearcasting';
-      } else if (rgCast.reason === 'abundance') {
-        message = `Cheap due to ${rgCast.abundanceStacks} stacks of Abundance`;
-      } else if (rgCast.reason === 'triage') {
-        message = 'Cast full price on a low health target';
-      } else if (rgCast.reason === 'bad') {
-        message = 'Cast full price on a high health target';
-      }
-      return {
-        value: rgCast.wasGood,
-        tooltip: `@ ${this.owner.formatTimestamp(rgCast.timestamp)} - ${message}`,
-      };
-    });
     const data = (
       <div>
         <strong>Regrowth casts</strong>
@@ -218,7 +211,7 @@ class RegrowthAndClearcasting extends Analyzer {
           - Green is a good cast, Red is a bad cast (at full mana cost on a high health target).
           Mouseover boxes for details.
         </small>
-        <PerformanceBoxRow values={castPerfBoxes} />
+        <PerformanceBoxRow values={this.castEntries} />
       </div>
     );
 
@@ -308,15 +301,5 @@ class RegrowthAndClearcasting extends Analyzer {
     );
   }
 }
-
-/** Stats about a Regrowth cast */
-type RegrowthCast = {
-  timestamp: number;
-  wasGood: boolean;
-  reason: RegrowthReason;
-  abundanceStacks: number;
-};
-
-type RegrowthReason = 'innervate' | 'ns' | 'clearcast' | 'abundance' | 'triage' | 'bad';
 
 export default RegrowthAndClearcasting;

--- a/src/analysis/retail/druid/restoration/modules/spells/Swiftmend.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/Swiftmend.tsx
@@ -3,7 +3,7 @@ import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent, HealEvent } from 'parser/core/Events';
 import Combatants from 'parser/shared/modules/Combatants';
-import { PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 
 import {
@@ -15,8 +15,8 @@ import HotTrackerRestoDruid from 'analysis/retail/druid/restoration/modules/core
 import { TALENTS_DRUID } from 'common/TALENTS';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
-
-const DEBUG = false;
+import { calculateTargetHealthPercent } from 'parser/core/EventCalculateLib';
+import { formatPercentage } from 'common/format';
 
 const TRIAGE_THRESHOLD = 0.5;
 const HIGH_VALUE_HOTS = [
@@ -50,8 +50,10 @@ class Swiftmend extends Analyzer {
   hasReforestation: boolean;
   /** Number of procs player has from Swiftmend (between VI, SotF, and Reforestation) */
   numProcs: number;
-  /** Info about each Swiftmend cast */
-  swiftmendCastInfo: CastInfo[] = [];
+  // /** Info about each Swiftmend cast */
+  // swiftmendCastInfo: CastInfo[] = [];
+  /** Box row entry for each Swiftmend cast */
+  castEntries: BoxRowEntry[] = [];
 
   constructor(options: Options) {
     super(options);
@@ -80,37 +82,92 @@ class Swiftmend extends Analyzer {
   }
 
   onSwiftmendCast(event: CastEvent) {
-    const timestamp = event.timestamp;
     const directHeal = getDirectHeal(event);
-    let targetHealthPercent = undefined;
-    if (directHeal) {
-      // technically the amount absorbed shouldn't be counted when calculating health before heal,
-      // but because heal absorbs are important to remove we'll consider this legit triage
-      const effectiveHealing = directHeal.amount + (directHeal.absorbed || 0);
-      const hitPointsBeforeHeal = directHeal.hitPoints - effectiveHealing;
-      targetHealthPercent = hitPointsBeforeHeal / directHeal.maxHitPoints;
+    const targetHealthPercent = directHeal ? calculateTargetHealthPercent(directHeal) : undefined;
+    const target = this.combatants.getEntity(event);
+    if (!target) {
+      console.warn("Couldn't find target for Swiftmend cast", event);
+      return; // can't do further handling without target
     }
-    const targetName = this.combatants.getEntity(event)?.name;
+    const wasTriage = targetHealthPercent && targetHealthPercent <= TRIAGE_THRESHOLD;
+    const targetHealthPercentText = targetHealthPercent
+      ? formatPercentage(targetHealthPercent, 0)
+      : 'unknown';
 
+    /*
+     * Build value and tooltip text depending on if player had VI
+     */
+
+    let hotChangeText: React.ReactNode = '';
+    let value: QualitativePerformance;
     if (this.hasVi) {
-      let extendedHots: SpellIdAndName[] = [];
-      const target = this.combatants.getEntity(event);
-      if (target && this.hotTracker.hots[target.id]) {
-        extendedHots = Object.values(this.hotTracker.hots[target.id]).map((tracker) => ({
-          name: tracker.name,
-          id: tracker.spellId,
-        }));
+      const extendedHotIds: number[] = [];
+      if (this.hotTracker.hots[target.id]) {
+        Object.values(this.hotTracker.hots[target.id]).forEach((tracker) =>
+          extendedHotIds.push(tracker.spellId),
+        );
       }
-      this.swiftmendCastInfo.push({ timestamp, extendedHots, targetHealthPercent, targetName });
-      DEBUG && console.log('Swiftmend extended ' + extendedHots);
+      const extendedHighValue =
+        extendedHotIds.includes(VERY_HIGH_VALUE_HOT) ||
+        extendedHotIds.filter((id) => HIGH_VALUE_HOTS.includes(id)).length >= 2;
+      if (extendedHighValue) {
+        value = 'perfect';
+      } else if (wasTriage) {
+        value = 'good';
+      } else {
+        value = 'ok';
+      }
+
+      if (extendedHotIds.length === 0) {
+        hotChangeText = 'extended Nothing!';
+      } else {
+        hotChangeText = (
+          <>
+            extended{' '}
+            <strong>
+              {extendedHotIds.map((id, index) => (
+                <>
+                  <SpellLink key={id} id={id} />{' '}
+                </>
+              ))}
+            </strong>
+          </>
+        );
+      }
     } else {
       const removedHotHeal = getRemovedHot(event);
-      const removedHot = removedHotHeal
-        ? { name: removedHotHeal.ability.name, id: removedHotHeal.ability.guid }
-        : undefined;
-      this.swiftmendCastInfo.push({ timestamp, removedHot, targetHealthPercent, targetName });
-      DEBUG && console.log('Swiftmend removed ' + removedHot);
+
+      const removedHighValue =
+        HIGH_VALUE_HOTS.find((id) => id === removedHotHeal?.ability.guid) !== undefined;
+      if (wasTriage || !removedHighValue) {
+        value = 'good';
+      } else if (this.numProcs > 0) {
+        value = 'ok';
+      } else {
+        value = 'fail';
+      }
+
+      hotChangeText = (
+        <>
+          removed{' '}
+          <strong>
+            {removedHotHeal ? <SpellLink id={removedHotHeal.ability.guid} /> : 'unknown HoT'}
+          </strong>
+        </>
+      );
     }
+
+    const tooltip = (
+      <>
+        @ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong>
+        <br />
+        targetting <strong>{target.name}</strong> w/ {targetHealthPercentText}% health
+        <br />
+        {hotChangeText}
+      </>
+    );
+
+    this.castEntries.push({ value, tooltip });
   }
 
   /** Guide subsectopm describing the proper usage of Swiftmend */
@@ -169,91 +226,16 @@ class Swiftmend extends Analyzer {
     }
     chartDescription += ' Mouseover for more details.';
 
-    // Build up perf boxes for each cast, which vary a lot based on talents
-    const castPerfBoxes = this.swiftmendCastInfo.map((cast) => {
-      const wasTriage = cast.targetHealthPercent && cast.targetHealthPercent <= TRIAGE_THRESHOLD;
-      const targetName = cast.targetName || 'unknown target';
-      const targetHealthString = cast.targetHealthPercent
-        ? (cast.targetHealthPercent * 100).toFixed(0)
-        : 'unknown';
-      let value: QualitativePerformance;
-      let hotTooltip: JSX.Element;
-      if (this.hasVi) {
-        const extendedIds = cast.extendedHots ? cast.extendedHots.map((hot) => hot.id) : [];
-        const extendedHighValue =
-          extendedIds.includes(VERY_HIGH_VALUE_HOT) ||
-          extendedIds.filter((id) => HIGH_VALUE_HOTS.includes(id)).length >= 2;
-        if (extendedHighValue) {
-          value = 'perfect';
-        } else if (wasTriage) {
-          value = 'good';
-        } else {
-          value = 'ok';
-        }
-        if (extendedIds.length === 0) {
-          hotTooltip = <> extended unknown HoT</>;
-        } else {
-          hotTooltip = (
-            <>
-              {' '}
-              extended <strong>{cast.extendedHots?.map((hot) => ' ' + hot.name)}</strong>
-            </>
-          );
-        }
-      } else {
-        const removedHighValue =
-          HIGH_VALUE_HOTS.find((id) => id === cast.removedHot?.id) !== undefined;
-        if (wasTriage || !removedHighValue) {
-          value = 'good';
-        } else if (this.numProcs > 0) {
-          value = 'ok';
-        } else {
-          value = 'fail';
-        }
-        const removedHotName = cast.removedHot?.name || 'unknown HoT';
-        hotTooltip = (
-          <>
-            {' '}
-            removed <strong>{removedHotName}</strong>
-          </>
-        );
-      }
-
-      const tooltip = (
-        <>
-          @ <strong>{this.owner.formatTimestamp(cast.timestamp)}</strong>
-          <br />
-          targetting <strong>{targetName}</strong> w/ {targetHealthString}% health
-          <br />
-          {hotTooltip}
-        </>
-      );
-
-      return { value, tooltip };
-    });
     const data = (
       <div>
         <strong>Swiftmend casts</strong>
         <small>{chartDescription}</small>
-        <PerformanceBoxRow values={castPerfBoxes} />
+        <PerformanceBoxRow values={this.castEntries} />
       </div>
     );
 
     return explanationAndDataSubsection(explanation, data, GUIDE_CORE_EXPLANATION_PERCENT);
   }
 }
-
-type CastInfo = {
-  timestamp: number;
-  removedHot?: SpellIdAndName;
-  extendedHots?: SpellIdAndName[];
-  targetHealthPercent?: number;
-  targetName?: string;
-};
-
-type SpellIdAndName = {
-  name: string;
-  id: number;
-};
 
 export default Swiftmend;

--- a/src/analysis/retail/druid/restoration/modules/spells/Swiftmend.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/Swiftmend.tsx
@@ -15,7 +15,7 @@ import HotTrackerRestoDruid from 'analysis/retail/druid/restoration/modules/core
 import { TALENTS_DRUID } from 'common/TALENTS';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
-import { calculateTargetHealthPercent } from 'parser/core/EventCalculateLib';
+import { calculateHealTargetHealthPercent } from 'parser/core/EventCalculateLib';
 import { formatPercentage } from 'common/format';
 
 const TRIAGE_THRESHOLD = 0.5;
@@ -83,7 +83,9 @@ class Swiftmend extends Analyzer {
 
   onSwiftmendCast(event: CastEvent) {
     const directHeal = getDirectHeal(event);
-    const targetHealthPercent = directHeal ? calculateTargetHealthPercent(directHeal) : undefined;
+    const targetHealthPercent = directHeal
+      ? calculateHealTargetHealthPercent(directHeal)
+      : undefined;
     const target = this.combatants.getEntity(event);
     if (!target) {
       console.warn("Couldn't find target for Swiftmend cast", event);
@@ -161,7 +163,8 @@ class Swiftmend extends Analyzer {
       <>
         @ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong>
         <br />
-        targetting <strong>{target.name}</strong> w/ {targetHealthPercentText}% health
+        targetting <strong>{target.name}</strong> w/ <strong>{targetHealthPercentText}%</strong>{' '}
+        health
         <br />
         {hotChangeText}
       </>

--- a/src/analysis/retail/druid/restoration/modules/spells/WildGrowth.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/WildGrowth.tsx
@@ -19,7 +19,7 @@ const RECOMMENDED_EFFECTIVE_TARGETS_THRESHOLD = 3;
 /** Max time after WG apply to watch for high overhealing */
 const OVERHEAL_BUFFER = 3000;
 /** Overheal percent within OVERHEAL_BUFFER of application that will count as 'too much' */
-const OVERHEAL_THRESHOLD = 0.7;
+const OVERHEAL_THRESHOLD = 0.6;
 
 /**
  * Tracks stats relating to Wild Growth
@@ -158,8 +158,8 @@ class WildGrowth extends Analyzer {
         <small>
           {' '}
           - Green is a good cast, Red was effective on fewer than three targets. A hit is considered
-          "ineffective" if over the first 3 seconds it did more than 50% overhealing. Mouseover
-          boxes for details.
+          "ineffective" if over the first {(OVERHEAL_BUFFER / 1000).toFixed(0)} seconds it did more
+          than {formatPercentage(OVERHEAL_THRESHOLD, 0)}% overhealing. Mouseover boxes for details.
         </small>
         <PerformanceBoxRow values={this.castEntries} />
       </div>

--- a/src/analysis/retail/druid/restoration/modules/spells/WildGrowth.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/WildGrowth.tsx
@@ -6,7 +6,7 @@ import Events, { AnyEvent, CastEvent, EventType, HealEvent } from 'parser/core/E
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import HealingValue from 'parser/shared/modules/HealingValue';
 import BoringValue from 'parser/ui/BoringValueText';
-import { PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
@@ -19,7 +19,7 @@ const RECOMMENDED_EFFECTIVE_TARGETS_THRESHOLD = 3;
 /** Max time after WG apply to watch for high overhealing */
 const OVERHEAL_BUFFER = 3000;
 /** Overheal percent within OVERHEAL_BUFFER of application that will count as 'too much' */
-const OVERHEAL_THRESHOLD = 0.5;
+const OVERHEAL_THRESHOLD = 0.7;
 
 /**
  * Tracks stats relating to Wild Growth
@@ -50,8 +50,8 @@ class WildGrowth extends Analyzer {
   /** Wild Growth hardcasts that had too much early overhealing */
   tooMuchOverhealCasts = 0;
 
-  /** Log of each WG cast, and how many targets were healed and how many were effective */
-  castWgHitsLog: WgCast[] = [];
+  /** Box row entry for each WG cast */
+  castEntries: BoxRowEntry[] = [];
 
   constructor(options: Options) {
     super(options);
@@ -119,11 +119,15 @@ class WildGrowth extends Analyzer {
       }
     }
 
-    this.castWgHitsLog.push({
-      timestamp: this.recentWgTimestamp,
-      hits: hits.length,
-      effectiveHits,
-    });
+    // add cast perf entry
+    const value = effectiveHits >= 3;
+    const tooltip = (
+      <>
+        @ <strong>{this.owner.formatTimestamp(this.recentWgTimestamp)}</strong>, Hits:{' '}
+        <strong>{hits.length}</strong>, Effective: <strong>{effectiveHits}</strong>
+      </>
+    );
+    this.castEntries.push({ value, tooltip });
   }
 
   get averageEffectiveHits() {
@@ -148,12 +152,6 @@ class WildGrowth extends Analyzer {
       </p>
     );
 
-    const castPerfBoxes = this.castWgHitsLog.map((wgCast) => ({
-      value: wgCast.effectiveHits >= 3,
-      tooltip: `@ ${this.owner.formatTimestamp(wgCast.timestamp)} - Hits: ${
-        wgCast.hits
-      }, Effective: ${wgCast.effectiveHits}`,
-    }));
     const data = (
       <div>
         <strong>Wild Growth casts</strong>
@@ -163,7 +161,7 @@ class WildGrowth extends Analyzer {
           "ineffective" if over the first 3 seconds it did more than 50% overhealing. Mouseover
           boxes for details.
         </small>
-        <PerformanceBoxRow values={castPerfBoxes} />
+        <PerformanceBoxRow values={this.castEntries} />
       </div>
     );
 
@@ -200,7 +198,5 @@ class WildGrowth extends Analyzer {
     );
   }
 }
-
-type WgCast = { timestamp: number; hits: number; effectiveHits: number };
 
 export default WildGrowth;

--- a/src/analysis/retail/druid/restoration/normalizers/SwiftmendNormalizer.ts
+++ b/src/analysis/retail/druid/restoration/normalizers/SwiftmendNormalizer.ts
@@ -22,6 +22,7 @@ const EVENT_LINKS: EventLink[] = [
     linkingEventType: EventType.Cast,
     referencedEventId: [
       SPELLS.REJUVENATION.id,
+      SPELLS.REJUVENATION_GERMINATION.id,
       SPELLS.REGROWTH.id,
       SPELLS.WILD_GROWTH.id,
       SPELLS.RENEWING_BLOOM.id,

--- a/src/common/format.ts
+++ b/src/common/format.ts
@@ -37,7 +37,7 @@ export function formatPercentage(percentage: number, precision: number = 2): str
  * with the given decimal second precision (default 0).
  * Ex: 317.3 => 5:17
  */
-export function formatDuration(duration: number, precision: number = 0) {
+export function formatDuration(duration: number, precision: number = 0): string {
   const totalSeconds = duration / 1000;
   const neg = totalSeconds < 0 ? '-' : '';
   const posSeconds = Math.abs(totalSeconds);

--- a/src/interface/guide/components/PerformanceBoxRow/index.tsx
+++ b/src/interface/guide/components/PerformanceBoxRow/index.tsx
@@ -29,11 +29,12 @@ export function PerformanceBoxRow({ values }: PerformanceBoxRowProps) {
 }
 
 type PerformanceBoxRowProps = {
-  values: TimelineEntry[];
+  values: BoxRowEntry[];
   style?: React.CSSProperties;
 };
 
-type TimelineEntry = {
+/** An entry for a PerformanceBoxRow */
+export type BoxRowEntry = {
   value: QualitativePerformance;
   tooltip?: React.ReactNode | string; // TODO default tooltip
 };
@@ -44,7 +45,7 @@ function blockSize(numValues: number, refWidth: number): number {
   return Math.max(Math.min(Math.floor(size), 60), 10); // min size = 10, max size = 60
 }
 
-function getBlockClassName(value: TimelineEntry) {
+function getBlockClassName(value: BoxRowEntry) {
   if (value.value === 'perfect') {
     return 'perfect-block';
   } else if (value.value === 'good' || value.value === true) {

--- a/src/parser/core/EventCalculateLib.tsx
+++ b/src/parser/core/EventCalculateLib.tsx
@@ -178,7 +178,10 @@ export function calculateEffectiveDamage(event: DamageEvent, increase: number): 
  * @return the target's health percent *before* the heal, in range 0 to 1. Note that if `includeHealAbsorbs` is true,
  * targets with a large heal absorb could report as having 0 health.
  */
-export function calculateTargetHealthPercent(event: HealEvent, includeHealAbsorbs: boolean = true) {
+export function calculateHealTargetHealthPercent(
+  event: HealEvent,
+  includeHealAbsorbs: boolean = true,
+) {
   const effectiveHealing = event.amount + (event.absorbed || 0);
   const hitPointsBeforeHeal = event.hitPoints - effectiveHealing;
   const targetHealthPercent = hitPointsBeforeHeal / event.maxHitPoints;

--- a/src/parser/core/EventCalculateLib.tsx
+++ b/src/parser/core/EventCalculateLib.tsx
@@ -1,4 +1,4 @@
-import { DamageEvent } from 'parser/core/Events';
+import { DamageEvent, HealEvent } from 'parser/core/Events';
 
 /**
  * This should honestly be done away with but there are so many unique Events/Sub-Events that call the calculateEffectiveHealing fucntions
@@ -163,4 +163,30 @@ export function calculateEffectiveDamageReduction(event: DamageEvent, reduction:
 export function calculateEffectiveDamage(event: DamageEvent, increase: number): number {
   const raw = (event.amount || 0) + (event.absorbed || 0);
   return raw - raw / (1 + increase);
+}
+
+/**
+ * Calculates the target's health percent *before* the heal. Useful for evaluation of triage healing.
+ *
+ * By default, this calculation will consider removed healing absorbs to be part of 'missing health' because they
+ * are usually important to remove. For example, if the target had 2000 max health,
+ * 1000 current health, a 1000 healing abosrb, and the given heal removed 500 of that absorb,
+ * this function would report the target as having being at 25% health.
+ *
+ * @param event the event to get target health from
+ * @param includeHealAbsorbs iff true, removed healing absorbs on the target will be counted as missing health.
+ * @return the target's health percent *before* the heal, in range 0 to 1. Note that if `includeHealAbsorbs` is true,
+ * targets with a large heal absorb could report as having 0 health.
+ */
+export function calculateTargetHealthPercent(event: HealEvent, includeHealAbsorbs: boolean = true) {
+  const effectiveHealing = event.amount + (event.absorbed || 0);
+  const hitPointsBeforeHeal = event.hitPoints - effectiveHealing;
+  const targetHealthPercent = hitPointsBeforeHeal / event.maxHitPoints;
+  if (targetHealthPercent > 1) {
+    return 1;
+  } else if (targetHealthPercent < 0) {
+    return 0;
+  } else {
+    return targetHealthPercent;
+  }
 }

--- a/src/parser/shared/modules/Combatants.ts
+++ b/src/parser/shared/modules/Combatants.ts
@@ -1,5 +1,5 @@
 import Combatant from 'parser/core/Combatant';
-import { AnyEvent, HasTarget } from 'parser/core/Events';
+import { AnyEvent, HasSource, HasTarget } from 'parser/core/Events';
 import { Options } from 'parser/core/Module';
 
 import Entities from './Entities';
@@ -17,6 +17,17 @@ class Combatants extends Entities<Combatant> {
       return null;
     }
     const combatant = this.players[event.targetID];
+    if (!combatant) {
+      return null; // a pet or something probably, either way we don't care.
+    }
+    return combatant;
+  }
+
+  getSourceEntity(event: AnyEvent) {
+    if (!HasSource(event)) {
+      return null;
+    }
+    const combatant = this.players[event.sourceID];
     if (!combatant) {
       return null; // a pet or something probably, either way we don't care.
     }


### PR DESCRIPTION
My use of the `PerformanceBoxRow` component involved tracking spell casts, packing information about the spell casts into a custom object, and then when the Guide subsection is built converting those objects into a value / tooltip pair. The issue was the intermediate object exists only to eventually produce the value / tooltip pair, so why not just skip the middleman? I was able to cut down on some complexity by doing this.

Also added new utility functions to cut down on repeated code: `calculateHealTargetHealthPercent`, `getTargetName` and `getSourceName`.

Also fixed a few minor bugs in Guide displays.