### PR TITLE
add TalentCastEfficiencyRequirement component

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -68,6 +68,7 @@ import { TALENTS_SHAMAN } from 'common/TALENTS';
 
 // prettier-ignore
 export default [
+  change(date(2022, 10, 31), 'Add slightly more ergonomic talent cast efficiency wrapper.', ToppleTheNun),
   change(date(2022, 10, 31), 'Update patch compatibility for specs supporting Dragonflight.', ToppleTheNun),
   change(date(2022, 10, 25), 'Improve patch version detection for retail and classic.', ToppleTheNun),
   change(date(2022, 10, 25), 'Exclude classic from patch version checking.', ToppleTheNun),

--- a/src/analysis/retail/demonhunter/vengeance/modules/checklist/Component.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/checklist/Component.tsx
@@ -10,6 +10,7 @@ import {
 import GenericCastEfficiencyRequirement from 'parser/shared/modules/features/Checklist/GenericCastEfficiencyRequirement';
 import Requirement from 'parser/shared/modules/features/Checklist/Requirement';
 import Rule from 'parser/shared/modules/features/Checklist/Rule';
+import TalentCastEfficiencyRequirement from 'parser/shared/modules/features/Checklist/TalentCastEfficiencyRequirement';
 
 const VengeanceDemonHunterChecklist = (props: ChecklistProps) => {
   const { combatant, castEfficiency, thresholds } = props;
@@ -49,21 +50,11 @@ const VengeanceDemonHunterChecklist = (props: ChecklistProps) => {
           combatant.hasTalent(TALENTS_DEMON_HUNTER.PRECISE_SIGILS_TALENT.id) ||
           combatant.hasTalent(TALENTS_DEMON_HUNTER.CONCENTRATED_SIGILS_TALENT.id)
         ) && <AbilityRequirement spell={TALENTS_DEMON_HUNTER.SIGIL_OF_FLAME_TALENT.id} />}
-        {combatant.hasTalent(TALENTS_DEMON_HUNTER.FEL_DEVASTATION_TALENT.id) && (
-          <AbilityRequirement spell={TALENTS_DEMON_HUNTER.FEL_DEVASTATION_TALENT.id} />
-        )}
-        {combatant.hasTalent(TALENTS_DEMON_HUNTER.FRACTURE_TALENT.id) && (
-          <AbilityRequirement spell={TALENTS_DEMON_HUNTER.FRACTURE_TALENT.id} />
-        )}
-        {combatant.hasTalent(TALENTS_DEMON_HUNTER.FELBLADE_TALENT.id) && (
-          <AbilityRequirement spell={TALENTS_DEMON_HUNTER.FELBLADE_TALENT.id} />
-        )}
-        {combatant.hasTalent(TALENTS_DEMON_HUNTER.ELYSIAN_DECREE_TALENT.id) && (
-          <AbilityRequirement spell={TALENTS_DEMON_HUNTER.ELYSIAN_DECREE_TALENT.id} />
-        )}
-        {combatant.hasTalent(TALENTS_DEMON_HUNTER.THE_HUNT_TALENT.id) && (
-          <AbilityRequirement spell={TALENTS_DEMON_HUNTER.THE_HUNT_TALENT.id} />
-        )}
+        <TalentCastEfficiencyRequirement talent={TALENTS_DEMON_HUNTER.FEL_DEVASTATION_TALENT} />
+        <TalentCastEfficiencyRequirement talent={TALENTS_DEMON_HUNTER.FRACTURE_TALENT} />
+        <TalentCastEfficiencyRequirement talent={TALENTS_DEMON_HUNTER.FELBLADE_TALENT} />
+        <TalentCastEfficiencyRequirement talent={TALENTS_DEMON_HUNTER.ELYSIAN_DECREE_TALENT} />
+        <TalentCastEfficiencyRequirement talent={TALENTS_DEMON_HUNTER.THE_HUNT_TALENT} />
         {combatant.hasTalent(TALENTS_DEMON_HUNTER.RETALIATION_TALENT.id) && (
           <Requirement
             name={
@@ -149,9 +140,7 @@ const VengeanceDemonHunterChecklist = (props: ChecklistProps) => {
         }
       >
         <AbilityRequirement spell={SPELLS.METAMORPHOSIS_TANK.id} />
-        {combatant.hasTalent(TALENTS_DEMON_HUNTER.FIERY_BRAND_TALENT.id) && (
-          <AbilityRequirement spell={TALENTS_DEMON_HUNTER.FIERY_BRAND_TALENT.id} />
-        )}
+        <TalentCastEfficiencyRequirement talent={TALENTS_DEMON_HUNTER.FIERY_BRAND_TALENT} />
       </Rule>
 
       <Rule

--- a/src/interface/report/CombatLogParserContext.tsx
+++ b/src/interface/report/CombatLogParserContext.tsx
@@ -1,0 +1,26 @@
+import CombatLogParser from 'parser/core/CombatLogParser';
+import { createContext, ReactNode, useContext } from 'react';
+
+export interface CombatLogParserContext {
+  combatLogParser: CombatLogParser;
+}
+
+// This starts off undefined as we don't have an instance of CombatLogParser to work with
+// until it gets provided by the Provider.
+export const CombatLogParserCtx = createContext<CombatLogParserContext | undefined>(undefined);
+
+interface Props {
+  children: ReactNode;
+  combatLogParser: CombatLogParser;
+}
+export const CombatLogParserProvider = ({ children, combatLogParser }: Props) => (
+  <CombatLogParserCtx.Provider value={{ combatLogParser }}>{children}</CombatLogParserCtx.Provider>
+);
+
+export const useCombatLogParser = () => {
+  const context = useContext(CombatLogParserCtx);
+  if (context === undefined) {
+    throw new Error('Unable to retrieve CombatLogParser for the current report/player combination');
+  }
+  return context;
+};

--- a/src/interface/report/Results/index.tsx
+++ b/src/interface/report/Results/index.tsx
@@ -51,6 +51,7 @@ import Overview from './Overview';
 import ReportStatistics from './ReportStatistics';
 import ScrollToTop from './ScrollToTop';
 import TABS from './TABS';
+import { CombatLogParserProvider } from 'interface/report/CombatLogParserContext';
 
 const TimelineTab = lazyLoadComponent(
   () =>
@@ -460,7 +461,9 @@ class Results extends React.PureComponent<Props, State> {
             </AlertWarning>
           </div>
         )}
-        {this.renderContent(selectedTab, results)}
+        <CombatLogParserProvider combatLogParser={parser}>
+          {this.renderContent(selectedTab, results)}
+        </CombatLogParserProvider>
 
         <div className="container" style={{ marginTop: 40 }}>
           <div className="row">

--- a/src/parser/shared/modules/CastEfficiency.tsx
+++ b/src/parser/shared/modules/CastEfficiency.tsx
@@ -8,6 +8,7 @@ import Haste from 'parser/shared/modules/Haste';
 import SpellHistory from 'parser/shared/modules/SpellHistory';
 import CastEfficiencyComponent from 'parser/ui/CastEfficiency';
 import Panel from 'parser/ui/Panel';
+import Spell from 'common/SPELLS/Spell';
 
 import Combatant from '../../core/Combatant';
 import { EventType, UpdateSpellUsableEvent, UpdateSpellUsableType } from '../../core/Events';
@@ -228,6 +229,13 @@ class CastEfficiency extends Analyzer {
   ): AbilityCastEfficiency | null {
     const ability = this.abilities.getAbility(spellId);
     return ability ? this.getCastEfficiencyForAbility(ability, includeNoCooldownEfficiency) : null;
+  }
+
+  getCastEfficiencyForSpell(
+    spell: Spell,
+    includeNoCooldownEfficiency = false,
+  ): AbilityCastEfficiency | null {
+    return this.getCastEfficiencyForSpellId(spell.id, includeNoCooldownEfficiency);
   }
 
   getCastEfficiencyForAbility(

--- a/src/parser/shared/modules/features/Checklist/ChecklistTypes.ts
+++ b/src/parser/shared/modules/features/Checklist/ChecklistTypes.ts
@@ -2,6 +2,7 @@ import Combatant from 'parser/core/Combatant';
 import CastEfficiency from 'parser/shared/modules/CastEfficiency';
 
 import { RequirementThresholds } from './Requirement';
+import Spell from 'common/SPELLS/Spell';
 
 export interface ChecklistProps {
   combatant: Combatant;
@@ -11,6 +12,11 @@ export interface ChecklistProps {
 
 export interface AbilityRequirementProps {
   spell: number;
+  name?: string | JSX.Element;
+}
+
+export interface TalentRequirementProps {
+  talent: Spell;
   name?: string | JSX.Element;
 }
 

--- a/src/parser/shared/modules/features/Checklist/GenericCastEfficiencyRequirement.tsx
+++ b/src/parser/shared/modules/features/Checklist/GenericCastEfficiencyRequirement.tsx
@@ -3,12 +3,13 @@ import { SpellLink } from 'interface';
 import { ThresholdStyle } from 'parser/core/ParseResults';
 import { AbilityCastEfficiency } from 'parser/shared/modules/CastEfficiency';
 import { PureComponent } from 'react';
+import Spell from 'common/SPELLS/Spell';
 
 import Requirement, { RequirementThresholds } from './Requirement';
 
 interface Props {
   name?: string | JSX.Element;
-  spell: number;
+  spell: number | Spell;
   castEfficiency: AbilityCastEfficiency | null;
   casts?: number;
   isMaxCasts?: boolean;

--- a/src/parser/shared/modules/features/Checklist/TalentCastEfficiencyRequirement.tsx
+++ b/src/parser/shared/modules/features/Checklist/TalentCastEfficiencyRequirement.tsx
@@ -1,0 +1,33 @@
+import Spell from 'common/SPELLS/Spell';
+import CastEfficiency from 'parser/shared/modules/CastEfficiency';
+import { useCombatLogParser } from 'interface/report/CombatLogParserContext';
+import GenericCastEfficiencyRequirement from 'parser/shared/modules/features/Checklist/GenericCastEfficiencyRequirement';
+
+interface Props {
+  name?: string | JSX.Element;
+  talent: Spell;
+  includeNoCooldownEfficiency?: boolean;
+  casts?: number;
+  isMaxCasts?: boolean;
+}
+
+const TalentCastEfficiencyRequirement = ({
+  talent,
+  includeNoCooldownEfficiency = false,
+  ...props
+}: Props) => {
+  const { combatLogParser } = useCombatLogParser();
+  if (!combatLogParser.selectedCombatant.hasTalent(talent)) {
+    return null;
+  }
+  const castEfficiency = combatLogParser.getModule(CastEfficiency);
+  return (
+    <GenericCastEfficiencyRequirement
+      spell={talent}
+      castEfficiency={castEfficiency.getCastEfficiencyForSpell(talent, includeNoCooldownEfficiency)}
+      {...props}
+    />
+  );
+};
+
+export default TalentCastEfficiencyRequirement;

--- a/src/parser/ui/BaseChart.tsx
+++ b/src/parser/ui/BaseChart.tsx
@@ -42,7 +42,6 @@ export default function BaseChart(props: Props) {
     },
     data: undefined,
   };
-  console.log(JSON.stringify({ ...prp.spec }));
 
   return <VegaLite theme="dark" tooltip={{ theme: 'dark' }} actions={false} {...prp} />;
 }


### PR DESCRIPTION
add CombatLogParserContext to make CombatLogParser available
via hooks for functional components.

add TalentCastEfficiencyRequirement component
that will only render if the selected combatant
has the given talent.

TalentCastEfficiencyRequirement will also fetch
the cast efficiency of the given talent so that
we don't need to set up an AbilityRequirement in
each spec checklist.

update Vengeance checklist to use it as an
example.

screenshot of it in use:
![image](https://user-images.githubusercontent.com/1672786/197911319-94ea1782-29c3-49a7-bd93-07e385efcf0f.png)
