### PR TITLE
convert the report load process to FCs and hooks

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -70,6 +70,7 @@ import { TALENTS_SHAMAN } from 'common/TALENTS';
 export default [
   change(date(2022, 10, 31), 'Add slightly more ergonomic talent cast efficiency wrapper.', ToppleTheNun),
   change(date(2022, 10, 31), 'Update patch compatibility for specs supporting Dragonflight.', ToppleTheNun),
+  change(date(2022, 10, 26), 'Convert most of report loading process to functions.', ToppleTheNun),
   change(date(2022, 10, 25), 'Improve patch version detection for retail and classic.', ToppleTheNun),
   change(date(2022, 10, 25), 'Exclude classic from patch version checking.', ToppleTheNun),
   change(date(2022, 10, 25), 'Add prepatch warning and add prepatch details.', ToppleTheNun),

--- a/src/game/VERSIONS.ts
+++ b/src/game/VERSIONS.ts
@@ -27,3 +27,7 @@ export const wclGameVersionToExpansion = (gameVersion: number): Expansion => {
       return Expansion.Dragonflight;
   }
 };
+
+export const isUnsupportedClassicVersion = (gameVersion: number): boolean => {
+  return gameVersion === 2 || gameVersion === 3;
+};

--- a/src/interface/report/ConfigContext.ts
+++ b/src/interface/report/ConfigContext.ts
@@ -1,8 +1,0 @@
-import Config from 'parser/Config';
-import { createContext, useContext } from 'react';
-
-const ConfigContext = createContext<Config | undefined>(undefined);
-
-export default ConfigContext;
-
-export const useConfig = () => useContext(ConfigContext)!;

--- a/src/interface/report/ConfigContext.tsx
+++ b/src/interface/report/ConfigContext.tsx
@@ -1,0 +1,45 @@
+import Config from 'parser/Config';
+import { createContext, useContext, ReactNode } from 'react';
+import { usePlayer } from 'interface/report/context/PlayerContext';
+import { useReport } from 'interface/report/context/ReportContext';
+import getConfig from 'parser/getConfig';
+import { wclGameVersionToExpansion } from 'game/VERSIONS';
+
+const ConfigContext = createContext<Config | undefined>(undefined);
+
+export default ConfigContext;
+
+export const useConfig = () => {
+  const ctx = useContext(ConfigContext);
+  if (ctx === undefined) {
+    throw new Error('Unable to get Config for selected report/player combination');
+  }
+  return ctx;
+};
+
+interface ConfigProviderProps {
+  children: ReactNode;
+  config: Config | undefined;
+}
+export const ConfigProvider = ({ children, config }: ConfigProviderProps) => (
+  <ConfigContext.Provider value={config}>{children}</ConfigContext.Provider>
+);
+
+interface ReportPlayerConfigProviderProps {
+  children: ReactNode;
+}
+export const ReportPlayerConfigProvider = ({ children }: ReportPlayerConfigProviderProps) => {
+  const { combatant, player } = usePlayer();
+  const { report } = useReport();
+  return (
+    <ConfigProvider
+      config={getConfig(
+        wclGameVersionToExpansion(report.gameVersion),
+        combatant.specID,
+        player.type,
+      )}
+    >
+      {children}
+    </ConfigProvider>
+  );
+};

--- a/src/interface/report/ExpansionContext.tsx
+++ b/src/interface/report/ExpansionContext.tsx
@@ -1,10 +1,11 @@
 import React, { createContext, useContext } from 'react';
 import Expansion from 'game/Expansion';
 import { wclGameVersionToExpansion } from 'game/VERSIONS';
+import { useReport } from 'interface/report/context/ReportContext';
 
 export interface ExpansionContext {
-  expansion: Expansion,
-  gameVersion: number
+  expansion: Expansion;
+  gameVersion: number;
 }
 
 export const ExpansionCtx = createContext<ExpansionContext>({
@@ -12,15 +13,33 @@ export const ExpansionCtx = createContext<ExpansionContext>({
   gameVersion: 0,
 });
 
-export const ExpansionContextProvider = ({ children, gameVersion }: { children: React.ReactNode, gameVersion: number }) => {
-  return (<ExpansionCtx.Provider
-    value={{
-      expansion: wclGameVersionToExpansion(gameVersion),
-      gameVersion: 0,
-    }}
-  >
-    {children}
-  </ExpansionCtx.Provider>);
+export const ExpansionContextProvider = ({
+  children,
+  gameVersion,
+}: {
+  children: React.ReactNode;
+  gameVersion: number;
+}) => {
+  return (
+    <ExpansionCtx.Provider
+      value={{
+        expansion: wclGameVersionToExpansion(gameVersion),
+        gameVersion: 0,
+      }}
+    >
+      {children}
+    </ExpansionCtx.Provider>
+  );
 };
 
 export const useExpansionContext = () => useContext(ExpansionCtx);
+
+interface Props {
+  children: React.ReactNode;
+}
+export const ReportExpansionContextProvider = ({ children }: Props) => {
+  const { report } = useReport();
+  return (
+    <ExpansionContextProvider gameVersion={report.gameVersion}>{children}</ExpansionContextProvider>
+  );
+};

--- a/src/interface/report/PatchChecker.tsx
+++ b/src/interface/report/PatchChecker.tsx
@@ -7,173 +7,158 @@ import Panel from 'interface/Panel';
 import { RootState } from 'interface/reducers';
 import { getReportCodesIgnoredPreviousPatchWarning } from 'interface/selectors/skipPreviousPatchWarning';
 import Tooltip from 'interface/Tooltip';
-import Report from 'parser/core/Report';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { wclGameVersionToExpansion } from 'game/VERSIONS';
+import { useReport } from 'interface/report/context/ReportContext';
 
 import Background from './images/weirdnelf.png';
 import PATCHES, { Patch } from './PATCHES';
 
+const makePreviousPatchUrl = (patch: Patch) => {
+  // Handle the case where we don't need a URL prefix
+  // This is specifically for patches within expansion, expansion changes usually merit a prefix
+  if (!patch.urlPrefix) {
+    return `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
+  }
+  return `${window.location.protocol}//${patch.urlPrefix}.${window.location.host}${window.location.pathname}`;
+};
+
 interface Props {
   children: React.ReactNode;
-  report: Report;
   ignorePreviousPatchWarning: (code: string) => void;
   ignored: string[];
 }
 
-class PatchChecker extends React.PureComponent<Props> {
-  constructor(props: Props) {
-    super(props);
-    this.handleClickContinue = this.handleClickContinue.bind(this);
+const PatchChecker = ({ children, ignorePreviousPatchWarning, ignored }: Props) => {
+  const { report } = useReport();
+
+  const handleClickContinue = () => {
+    ignorePreviousPatchWarning(report.code);
+  };
+  const isContinue = ignored.includes(report.code);
+
+  const reportTimestamp = report.start;
+  const reportDate = new Date(report.start).toLocaleDateString();
+  const reportGameVersion = report.gameVersion;
+
+  // Only check patches with matching game version
+  const patchesForGameVersion = PATCHES.filter((it) => it.gameVersion === reportGameVersion);
+
+  // Sort from latest to oldest
+  const orderedPatches = patchesForGameVersion.sort((a, b) => b.timestamp - a.timestamp);
+
+  const reportPatch = orderedPatches.find((patch) => reportTimestamp > patch.timestamp);
+  // This will get the expansion expected based on the game version of the report, which
+  // _can_ be different from the expansion from the report patch.
+  // If they're different, it might be a bug OR the patch might be missing from the patches file.
+  const reportExpansion = wclGameVersionToExpansion(report.gameVersion);
+
+  if ((reportPatch && reportPatch.isCurrent) || isContinue) {
+    return <>{children}</>;
   }
 
-  handleClickContinue() {
-    // I chose on purpose not to store this in a cookie since I don't want this to be forgotten. It should not be a big deal if this happens every time the page is loaded, so long as it isn't shown every fight.
-    this.props.ignorePreviousPatchWarning(this.props.report.code);
-  }
+  const isThisExpansion = reportPatch?.expansion === reportExpansion;
+  return (
+    <div className="container offset">
+      <h1>
+        {report.title} - {reportDate}
+      </h1>
 
-  makePreviousPatchUrl(patch: Patch) {
-    // Handle the case where we don't need a URL prefix
-    // This is specifically for patches within expansion, expansion changes usually merit a prefix
-    if (!patch.urlPrefix) {
-      return `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
-    }
-    return `${window.location.protocol}//${patch.urlPrefix}.${window.location.host}${window.location.pathname}`;
-  }
-
-  get continue() {
-    return this.props.ignored.includes(this.props.report.code);
-  }
-
-  render() {
-    const { children, report } = this.props;
-
-    const reportTimestamp = report.start;
-    const reportDate = new Date(report.start).toLocaleDateString();
-    const reportGameVersion = report.gameVersion;
-
-    // Only check patches with matching game version
-    const patchesForGameVersion = PATCHES.filter((it) => it.gameVersion === reportGameVersion);
-
-    // Sort from latest to oldest
-    const orderedPatches = patchesForGameVersion.sort((a, b) => b.timestamp - a.timestamp);
-
-    const reportPatch = orderedPatches.find((patch) => reportTimestamp > patch.timestamp);
-    // This will get the expansion expected based on the game version of the report, which
-    // _can_ be different from the expansion from the report patch.
-    // If they're different, it might be a bug OR the patch might be missing from the patches file.
-    const reportExpansion = wclGameVersionToExpansion(report.gameVersion);
-
-    if ((reportPatch && reportPatch.isCurrent) || this.continue) {
-      return children;
-    } else {
-      const isThisExpansion = reportPatch?.expansion === reportExpansion;
-
-      return (
-        <div className="container offset">
-          <h1>
-            {report.title} - {reportDate}
-          </h1>
-
-          <Panel
-            title={
-              isThisExpansion ? (
-                <Trans id="interface.report.patchChecker.earlierPatch">
-                  This report is for an earlier patch
-                </Trans>
-              ) : (
-                <Trans id="interface.report.patchChecker.previousExpansion">
-                  This report is for a previous expansion
-                </Trans>
-              )
-            }
-            pad={false}
-          >
-            <div className="flex wrapable">
-              <div className="flex-main pad">
-                {isThisExpansion ? (
-                  <Trans id="interface.report.patchChecker.viewAnalysisOnOlderVersion">
-                    WoWAnalyzer is constantly being updated to support the latest changes. This can
-                    cause some functionality to be modified for the latest talents/traits/trinkets
-                    or be removed.
-                    <br />
-                    <br />
-                    This could mean that some parts of your report will no longer be analysed
-                    accurately.
-                    <br />
-                    <br />
-                    If you would still like to view the analysis using the latest updates, you can
-                    click 'Continue anyway' below.
-                  </Trans>
-                ) : (
-                  <Trans id="interface.report.patchChecker.viewAnalysisOldExpansion">
-                    Due to the number of class changes since the last expansion (class abilities,
-                    talents, etc.), the analysis provided by WoWAnalyzer will most likely be
-                    inaccurate.
-                    <br />
-                    <br />
-                    You can still access the Analysis by clicking 'Continue anyway' below if
-                    required.
-                    <br />
-                    <br />
-                    If you would like to view the analysis on an older version of WoWAnalyzer,{' '}
-                    <a
-                      href={reportPatch && this.makePreviousPatchUrl(reportPatch)}
-                      onClick={this.handleClickContinue}
-                      style={{ fontSize: '1.1em' }}
-                    >
-                      <Trans id="interface.report.patchChecker.clickHere">click here</Trans>
-                    </a>
-                    .
-                    <br />
-                    <br />
-                    If you would still like to view the analysis using the latest updates, you can
-                    click 'Continue anyway' below.
-                  </Trans>
-                )}
+      <Panel
+        title={
+          isThisExpansion ? (
+            <Trans id="interface.report.patchChecker.earlierPatch">
+              This report is for an earlier patch
+            </Trans>
+          ) : (
+            <Trans id="interface.report.patchChecker.previousExpansion">
+              This report is for a previous expansion
+            </Trans>
+          )
+        }
+        pad={false}
+      >
+        <div className="flex wrapable">
+          <div className="flex-main pad">
+            {isThisExpansion ? (
+              <Trans id="interface.report.patchChecker.viewAnalysisOnOlderVersion">
+                WoWAnalyzer is constantly being updated to support the latest changes. This can
+                cause some functionality to be modified for the latest talents/traits/trinkets or be
+                removed.
                 <br />
                 <br />
-
-                <div style={{ marginBottom: 15 }}>
-                  <GitHubButton /> <DiscordButton />
-                </div>
-                <Tooltip
-                  content={
-                    <Trans id="interface.report.patchChecker.khadgarApproves">
-                      Khadgar approves your bravery
-                    </Trans>
-                  }
+                This could mean that some parts of your report will no longer be analysed
+                accurately.
+                <br />
+                <br />
+                If you would still like to view the analysis using the latest updates, you can click
+                'Continue anyway' below.
+              </Trans>
+            ) : (
+              <Trans id="interface.report.patchChecker.viewAnalysisOldExpansion">
+                Due to the number of class changes since the last expansion (class abilities,
+                talents, etc.), the analysis provided by WoWAnalyzer will most likely be inaccurate.
+                <br />
+                <br />
+                You can still access the Analysis by clicking 'Continue anyway' below if required.
+                <br />
+                <br />
+                If you would like to view the analysis on an older version of WoWAnalyzer,{' '}
+                <a
+                  href={reportPatch && makePreviousPatchUrl(reportPatch)}
+                  onClick={handleClickContinue}
+                  style={{ fontSize: '1.1em' }}
                 >
-                  <Link
-                    to={window.location.pathname}
-                    onClick={this.handleClickContinue}
-                    style={{ fontSize: '1.1em' }}
-                  >
-                    <Icon icon="quest_khadgar" />{' '}
-                    <Trans id="interface.report.patchChecker.continueAnyway">Continue anyway</Trans>
-                  </Link>
-                </Tooltip>
-              </div>
-              <div className="flex-sub">
-                <img
-                  src={Background}
-                  alt=""
-                  style={{
-                    paddingLeft: 15,
-                    maxWidth: 250,
-                    marginBottom: -15,
-                  }}
-                />
-              </div>
+                  <Trans id="interface.report.patchChecker.clickHere">click here</Trans>
+                </a>
+                .
+                <br />
+                <br />
+                If you would still like to view the analysis using the latest updates, you can click
+                'Continue anyway' below.
+              </Trans>
+            )}
+            <br />
+            <br />
+
+            <div style={{ marginBottom: 15 }}>
+              <GitHubButton /> <DiscordButton />
             </div>
-          </Panel>
+            <Tooltip
+              content={
+                <Trans id="interface.report.patchChecker.khadgarApproves">
+                  Khadgar approves your bravery
+                </Trans>
+              }
+            >
+              <Link
+                to={window.location.pathname}
+                onClick={handleClickContinue}
+                style={{ fontSize: '1.1em' }}
+              >
+                <Icon icon="quest_khadgar" />{' '}
+                <Trans id="interface.report.patchChecker.continueAnyway">Continue anyway</Trans>
+              </Link>
+            </Tooltip>
+          </div>
+          <div className="flex-sub">
+            <img
+              src={Background}
+              alt=""
+              style={{
+                paddingLeft: 15,
+                maxWidth: 250,
+                marginBottom: -15,
+              }}
+            />
+          </div>
         </div>
-      );
-    }
-  }
-}
+      </Panel>
+    </div>
+  );
+};
 
 const mapStateToProps = (state: RootState) => ({
   ignored: getReportCodesIgnoredPreviousPatchWarning(state),

--- a/src/interface/report/PlayerLoader.tsx
+++ b/src/interface/report/PlayerLoader.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useReducer } from 'react';
 import { Trans, t } from '@lingui/macro';
 import { captureException } from 'common/errorLogger';
 import { fetchCombatants, LogNotFoundError } from 'common/fetchWclApi';
@@ -5,11 +6,10 @@ import getFightName from 'common/getFightName';
 import getAverageItemLevel from 'game/getAverageItemLevel';
 import ROLES from 'game/ROLES';
 import SPECS from 'game/SPECS';
-import { wclGameVersionToExpansion } from 'game/VERSIONS';
+import { isUnsupportedClassicVersion, wclGameVersionToExpansion } from 'game/VERSIONS';
 import { fetchCharacter } from 'interface/actions/characters';
 import { setCombatants } from 'interface/actions/combatants';
 import ActivityIndicator from 'interface/ActivityIndicator';
-import DocumentTitle from 'interface/DocumentTitle';
 import makeAnalyzerUrl from 'interface/makeAnalyzerUrl';
 import Panel from 'interface/Panel';
 import { RootState } from 'interface/reducers';
@@ -23,7 +23,6 @@ import Tooltip from 'interface/Tooltip';
 import CharacterProfile from 'parser/core/CharacterProfile';
 import { CombatantInfoEvent } from 'parser/core/Events';
 import { WCLFight } from 'parser/core/Fight';
-import { PlayerInfo } from 'parser/core/Player';
 import Report from 'parser/core/Report';
 import getBuild from 'parser/getBuild';
 import getConfig from 'parser/getConfig';
@@ -31,9 +30,13 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'redux';
+import { Helmet } from 'react-helmet';
 
 import handleApiError from './handleApiError';
 import PlayerSelection from './PlayerSelection';
+import { PlayerProvider } from 'interface/report/context/PlayerContext';
+import { useReport } from 'interface/report/context/ReportContext';
+import { useFight } from 'interface/report/context/FightContext';
 
 const FAKE_PLAYER_IF_DEV_ENV = false;
 
@@ -45,13 +48,7 @@ interface ConnectedProps extends RouteComponentProps {
 }
 
 interface PassedProps {
-  report: Report;
-  fight: WCLFight;
-  children: (
-    player: PlayerInfo,
-    combatant: CombatantInfoEvent,
-    combatants: CombatantInfoEvent[],
-  ) => React.ReactNode;
+  children: React.ReactNode;
 }
 
 type Props = ConnectedProps & PassedProps;
@@ -62,148 +59,188 @@ interface State {
   combatantsFightId: number | null;
 }
 
+interface StateFC extends State {
+  tanks: number;
+  healers: number;
+  dps: number;
+  ranged: number;
+  ilvl: number;
+}
+
 const defaultState: State = {
   error: null,
   combatants: null,
   combatantsFightId: null,
 };
 
-class PlayerLoader extends React.PureComponent<Props, State> {
-  tanks = 0;
-  healers = 0;
-  dps = 0;
-  ranged = 0;
-  ilvl = 0;
+const defaultStateFC: StateFC = {
+  ...defaultState,
+  tanks: 0,
+  healers: 0,
+  dps: 0,
+  ranged: 0,
+  ilvl: 0,
+};
 
-  static getDerivedStateFromProps(props: Props, state: State) {
-    if (props.fight.id !== state.combatantsFightId) {
-      // When switching fights we need to unset combatants before rendering to avoid children from doing API calls twice
-      return defaultState;
+type Action =
+  | { type: 'reset' }
+  | {
+      type: 'update_composition';
+      tanks: number;
+      healers: number;
+      dps: number;
+      ranged: number;
+      ilvl: number;
     }
-    return state;
+  | { type: 'set_combatants'; combatants: CombatantInfoEvent[]; combatantsFightId: number }
+  | { type: 'set_error'; error: Error };
+
+const fcReducer = (state: StateFC, action: Action): StateFC => {
+  switch (action.type) {
+    case 'reset':
+      return { ...defaultStateFC };
+    case 'update_composition':
+      return {
+        ...state,
+        tanks: action.tanks,
+        healers: action.healers,
+        dps: action.dps,
+        ranged: action.ranged,
+        ilvl: action.ilvl,
+      };
+    case 'set_combatants':
+      return {
+        ...state,
+        combatants: action.combatants,
+        combatantsFightId: action.combatantsFightId,
+      };
+    case 'set_error':
+      return { ...defaultStateFC, error: action.error };
+    default:
+      return { ...state };
   }
+};
 
-  state = defaultState;
+const PlayerLoaderFC = ({ children, setCombatants, history, playerName, playerId }: Props) => {
+  const [
+    { error, combatants, combatantsFightId, tanks, healers, dps, ranged, ilvl },
+    dispatchFC,
+  ] = useReducer(fcReducer, defaultStateFC);
+  const { report: selectedReport } = useReport();
+  const { fight: selectedFight } = useFight();
 
-  componentDidMount() {
-    // noinspection JSIgnoredPromiseFromCall
-    this.loadCombatants(this.props.report, this.props.fight);
-    this.scrollToTop();
-  }
+  const loadCombatants = useCallback(
+    async (report: Report, fight: WCLFight) => {
+      if (isUnsupportedClassicVersion(report.gameVersion)) {
+        return;
+      }
 
-  componentDidUpdate(prevProps: Props, prevState: State) {
-    const changedReport = this.props.report !== prevProps.report;
-    const changedFight = this.props.fight !== prevProps.fight;
-    if (changedReport || changedFight) {
-      // noinspection JSIgnoredPromiseFromCall
-      this.loadCombatants(this.props.report, this.props.fight);
-    }
-    if (
-      this.props.playerId &&
-      (!this.props.playerName || this.props.playerName === `${this.props.playerId}`)
-    ) {
-      this.props.history.replace(
-        makeAnalyzerUrl(this.props.report, this.props.fight.id, this.props.playerId),
-      );
-    }
-  }
+      try {
+        const combatants = (await fetchCombatants(
+          report.code,
+          fight.start_time,
+          fight.end_time,
+        )) as CombatantInfoEvent[];
 
-  async loadCombatants(report: Report, fight: WCLFight) {
-    if (report.gameVersion === 2) {
-      return;
-    }
-    try {
-      const combatants = (await fetchCombatants(
-        report.code,
-        fight.start_time,
-        fight.end_time,
-      )) as CombatantInfoEvent[];
+        let combatantsWithGear = 0;
+        let tanks = 0;
+        let healers = 0;
+        let dps = 0;
+        let ranged = 0;
+        let ilvl = 0;
 
-      let combatantsWithGear = 0;
-
-      combatants.forEach((combatant) => {
-        if (process.env.NODE_ENV === 'development' && FAKE_PLAYER_IF_DEV_ENV) {
-          console.error(
-            `This player (sourceID: ${combatant.sourceID!}) has an error. Because you're in development environment, we have faked the missing information, see CombatantInfoFaker.ts for more information.`,
-          );
-          combatant = generateFakeCombatantInfo(combatant);
-        }
-        if (combatant.error || combatant.specID === -1) {
-          return;
-        }
-        const player = report.friendlies.find((friendly) => friendly.id === combatant.sourceID);
-        if (!player) {
-          console.error('friendly missing from report for player', combatant.sourceID);
-          return;
-        }
-        combatant.player = player;
-        if (SPECS[combatant.specID]) {
-          // TODO: TBC support: specID is always null, so look at talents to figure out the most likely spec. Or use friendly.icon. Then make a table that has roles for that. Cumbersome, but not too difficult.
-          // TODO: Move this code to the component that renders the tanks/healers/dps/ranged
-          switch (SPECS[combatant.specID].role) {
-            case ROLES.TANK:
-              this.tanks += 1;
-              break;
-            case ROLES.HEALER:
-              this.healers += 1;
-              break;
-            case ROLES.DPS.MELEE:
-              this.dps += 1;
-              break;
-            case ROLES.DPS.RANGED:
-              this.ranged += 1;
-              break;
-            default:
-              break;
+        combatants.forEach((combatant) => {
+          if (process.env.NODE_ENV === 'development' && FAKE_PLAYER_IF_DEV_ENV) {
+            console.error(
+              `This player (sourceID: ${combatant.sourceID!}) has an error. Because you're in development environment, we have faked the missing information, see CombatantInfoFaker.ts for more information.`,
+            );
+            combatant = generateFakeCombatantInfo(combatant);
           }
-        }
+          if (combatant.error || combatant.specID === -1) {
+            return;
+          }
+          const player = report.friendlies.find((friendly) => friendly.id === combatant.sourceID);
+          if (!player) {
+            console.error('friendly missing from report for player', combatant.sourceID);
+            return;
+          }
+          combatant.player = player;
+          if (SPECS[combatant.specID]) {
+            // TODO: TBC support: specID is always null, so look at talents to figure out the most likely spec. Or use friendly.icon. Then make a table that has roles for that. Cumbersome, but not too difficult.
+            // TODO: Move this code to the component that renders the tanks/healers/dps/ranged
+            switch (SPECS[combatant.specID].role) {
+              case ROLES.TANK:
+                tanks += 1;
+                break;
+              case ROLES.HEALER:
+                healers += 1;
+                break;
+              case ROLES.DPS.MELEE:
+                dps += 1;
+                break;
+              case ROLES.DPS.RANGED:
+                ranged += 1;
+                break;
+              default:
+                break;
+            }
+          }
 
-        // Gear may be null for broken combatants
-        const combatantILvl = combatant.gear ? getAverageItemLevel(combatant.gear) : 0;
-        if (combatantILvl !== 0) {
-          combatantsWithGear += 1;
-          this.ilvl += combatantILvl;
+          // Gear may be null for broken combatants
+          const combatantILvl = combatant.gear ? getAverageItemLevel(combatant.gear) : 0;
+          if (combatantILvl !== 0) {
+            combatantsWithGear += 1;
+            ilvl += combatantILvl;
+          }
+        });
+        ilvl /= combatantsWithGear;
+        dispatchFC({ type: 'update_composition', tanks, healers, dps, ranged, ilvl });
+        if (selectedReport !== report || selectedFight !== fight) {
+          return; // the user switched report/fight already
         }
-      });
-      this.ilvl /= combatantsWithGear;
-      if (this.props.report !== report || this.props.fight !== fight) {
-        return; // the user switched report/fight already
+        dispatchFC({ type: 'set_combatants', combatants, combatantsFightId: fight.id });
+        // We need to set the combatants in the global state so the NavigationBar, which is not a child of this component, can also use it
+        setCombatants(combatants);
+      } catch (error) {
+        const isCommonError = error instanceof LogNotFoundError;
+        if (!isCommonError) {
+          captureException(error as Error);
+        }
+        dispatchFC({ type: 'set_error', error: error as Error });
+        // We need to set the combatants in the global state so the NavigationBar, which is not a child of this component, can also use it
+        setCombatants(null);
       }
-      this.setState({
-        ...defaultState,
-        combatants,
-        combatantsFightId: fight.id,
-      });
-      // We need to set the combatants in the global state so the NavigationBar, which is not a child of this component, can also use it
-      this.props.setCombatants(combatants);
-    } catch (error) {
-      const isCommonError = error instanceof LogNotFoundError;
-      if (!isCommonError) {
-        captureException(error as Error);
-      }
-      this.setState({
-        ...defaultState,
-        error: error as Error,
-      });
-      // We need to set the combatants in the global state so the NavigationBar, which is not a child of this component, can also use it
-      this.props.setCombatants(null);
+    },
+    [selectedFight, selectedReport, setCombatants],
+  );
+
+  useEffect(() => {
+    if (selectedFight.id !== combatantsFightId) {
+      console.log('Dispatching reset');
+      dispatchFC({ type: 'reset' });
     }
-  }
+  }, [combatantsFightId, selectedFight.id]);
 
-  scrollToTop() {
+  useEffect(() => {
+    // noinspection JSIgnoredPromiseFromCall
+    loadCombatants(selectedReport, selectedFight);
+  }, [loadCombatants, selectedReport, selectedFight]);
+
+  useEffect(() => {
+    // scroll to top of window
     window.scrollTo(0, 0);
-  }
+  }, []);
 
-  renderError(error: Error) {
+  const renderError = (error: Error) => {
     return handleApiError(error, () => {
-      this.setState(defaultState);
+      dispatchFC({ type: 'reset' });
       // We need to set the combatants in the global state so the NavigationBar, which is not a child of this component, can also use it
-      this.props.setCombatants(null);
-      this.props.history.push(makeAnalyzerUrl());
+      setCombatants(null);
+      history.push(makeAnalyzerUrl());
     });
-  }
+  };
 
-  renderLoading() {
+  const renderLoading = () => {
     return (
       <ActivityIndicator
         text={t({
@@ -212,9 +249,9 @@ class PlayerLoader extends React.PureComponent<Props, State> {
         })}
       />
     );
-  }
+  };
 
-  renderClassicWarning() {
+  const renderClassicWarning = () => {
     return (
       <div className="container offset">
         <Panel
@@ -237,154 +274,146 @@ class PlayerLoader extends React.PureComponent<Props, State> {
         </Panel>
       </div>
     );
+  };
+
+  if (error) {
+    return renderError(error);
   }
 
-  render() {
-    const { report, fight, playerName, playerId } = this.props;
+  if (isUnsupportedClassicVersion(selectedReport.gameVersion)) {
+    return renderClassicWarning();
+  }
 
-    const error = this.state.error;
-    if (error) {
-      return this.renderError(error);
-    }
+  if (!combatants) {
+    return renderLoading();
+  }
 
-    if (report.gameVersion === 2) {
-      return this.renderClassicWarning();
-    }
+  const reportDuration = selectedReport.end - selectedReport.start;
 
-    const combatants = this.state.combatants;
-    if (!combatants) {
-      return this.renderLoading();
-    }
-
-    const reportDuration = report.end - report.start;
-
-    const players = playerId
-      ? report.friendlies.filter((friendly) => friendly.id === playerId)
-      : report.friendlies.filter((friendly) => friendly.name === playerName);
-    const player = players[0];
-    const hasDuplicatePlayers = players.length > 1;
-    const combatant = player && combatants.find((combatant) => combatant.sourceID === player.id);
-    const config =
-      combatant &&
-      getConfig(wclGameVersionToExpansion(report.gameVersion), combatant.specID, player.type);
-    const build = combatant && getBuild(config, combatant);
-    const missingBuild = config?.builds && !build;
-    if (
-      !player ||
-      hasDuplicatePlayers ||
-      !combatant ||
-      !config ||
-      missingBuild ||
-      combatant.error
-    ) {
-      if (player) {
-        // Player data was in the report, but there was another issue
-        if (hasDuplicatePlayers) {
-          alert(
-            t({
-              id: 'interface.report.render.hasDuplicatePlayers',
-              message: `It appears like another "${playerName}" is in this log, please select the correct one`,
-            }),
-          );
-        } else if (!combatant) {
-          alert(
-            t({
-              id: 'interface.report.render.dataNotAvailable',
-              message: `Player data does not seem to be available for the selected player in this fight.`,
-            }),
-          );
-        } else if (combatant.error || (!combatant.specID && combatant.specID !== 0)) {
-          alert(
-            t({
-              id: 'interface.report.render.logCorrupted',
-              message: `The data received from WCL for this player is corrupt, this player can not be analyzed in this fight.`,
-            }),
-          );
-        } else if (!config || missingBuild) {
-          alert(
-            t({
-              id: 'interface.report.render.notSupported',
-              message: `This spec is not supported for this expansion.`,
-            }),
-          );
-        }
+  const players = playerId
+    ? selectedReport.friendlies.filter((friendly) => friendly.id === playerId)
+    : selectedReport.friendlies.filter((friendly) => friendly.name === playerName);
+  const player = players[0];
+  const hasDuplicatePlayers = players.length > 1;
+  const combatant = player && combatants.find((combatant) => combatant.sourceID === player.id);
+  const config =
+    combatant &&
+    getConfig(wclGameVersionToExpansion(selectedReport.gameVersion), combatant.specID, player.type);
+  const build = combatant && getBuild(config, combatant);
+  const missingBuild = config?.builds && !build;
+  if (!player || hasDuplicatePlayers || !combatant || !config || missingBuild || combatant.error) {
+    if (player) {
+      // Player data was in the report, but there was another issue
+      if (hasDuplicatePlayers) {
+        alert(
+          t({
+            id: 'interface.report.render.hasDuplicatePlayers',
+            message: `It appears like another "${playerName}" is in this log, please select the correct one`,
+          }),
+        );
+      } else if (!combatant) {
+        alert(
+          t({
+            id: 'interface.report.render.dataNotAvailable',
+            message: `Player data does not seem to be available for the selected player in this fight.`,
+          }),
+        );
+      } else if (combatant.error || (!combatant.specID && combatant.specID !== 0)) {
+        alert(
+          t({
+            id: 'interface.report.render.logCorrupted',
+            message: `The data received from WCL for this player is corrupt, this player can not be analyzed in this fight.`,
+          }),
+        );
+      } else if (!config || missingBuild) {
+        alert(
+          t({
+            id: 'interface.report.render.notSupported',
+            message: `This spec is not supported for this expansion.`,
+          }),
+        );
       }
-
-      return (
-        <div className="container offset">
-          <div style={{ position: 'relative', marginBottom: 15 }}>
-            <div className="back-button">
-              <Tooltip
-                content={t({
-                  id: 'interface.report.render.backToFightSelection',
-                  message: `Back to fight selection`,
-                })}
-              >
-                <Link to={`/report/${report.code}`}>
-                  <span className="glyphicon glyphicon-chevron-left" aria-hidden="true" />
-                  <label>
-                    {' '}
-                    <Trans id="interface.report.render.labelFightSelection">Fight selection</Trans>
-                  </label>
-                </Link>
-              </Tooltip>
-            </div>
-            <div className="flex wrapable" style={{ marginBottom: 15 }}>
-              <div className="flex-main">
-                <h1 style={{ lineHeight: 1.4, margin: 0 }}>
-                  <Trans id="interface.report.render.playerSelection">Player selection</Trans>
-                </h1>
-                <small style={{ marginTop: -5 }}>
-                  <Trans id="interface.report.render.playerSelectionDetails">
-                    Select the player you wish to analyze.
-                  </Trans>
-                </small>
-              </div>
-              <div className="flex-sub">
-                <RaidCompositionDetails
-                  tanks={this.tanks}
-                  healers={this.healers}
-                  dps={this.dps}
-                  ranged={this.ranged}
-                  ilvl={this.ilvl}
-                />
-              </div>
-            </div>
-          </div>
-
-          {fight.end_time > MAX_REPORT_DURATION && (
-            <ReportDurationWarning duration={reportDuration} />
-          )}
-
-          {combatants.length === 0 && <AdvancedLoggingWarning />}
-
-          <PlayerSelection
-            report={report}
-            combatants={combatants}
-            makeUrl={(playerId, build) =>
-              makeAnalyzerUrl(report, fight.id, playerId, undefined, build)
-            }
-          />
-          <ReportRaidBuffList combatants={combatants} />
-        </div>
-      );
     }
 
     return (
-      <>
-        {/* TODO: Refactor the DocumentTitle away */}
-        <DocumentTitle
-          title={t({
-            id: 'interface.report.render.documentTitle',
-            message: `${getFightName(report, fight)} by ${player.name} in ${report.title}`,
-          })}
-        />
+      <div className="container offset">
+        <div style={{ position: 'relative', marginBottom: 15 }}>
+          <div className="back-button">
+            <Tooltip
+              content={t({
+                id: 'interface.report.render.backToFightSelection',
+                message: `Back to fight selection`,
+              })}
+            >
+              <Link to={`/report/${selectedReport.code}`}>
+                <span className="glyphicon glyphicon-chevron-left" aria-hidden="true" />
+                <label>
+                  {' '}
+                  <Trans id="interface.report.render.labelFightSelection">Fight selection</Trans>
+                </label>
+              </Link>
+            </Tooltip>
+          </div>
+          <div className="flex wrapable" style={{ marginBottom: 15 }}>
+            <div className="flex-main">
+              <h1 style={{ lineHeight: 1.4, margin: 0 }}>
+                <Trans id="interface.report.render.playerSelection">Player selection</Trans>
+              </h1>
+              <small style={{ marginTop: -5 }}>
+                <Trans id="interface.report.render.playerSelectionDetails">
+                  Select the player you wish to analyze.
+                </Trans>
+              </small>
+            </div>
+            <div className="flex-sub">
+              <RaidCompositionDetails
+                tanks={tanks}
+                healers={healers}
+                dps={dps}
+                ranged={ranged}
+                ilvl={ilvl}
+              />
+            </div>
+          </div>
+        </div>
 
-        {this.props.children(player, combatant, combatants)}
-      </>
+        {selectedFight.end_time > MAX_REPORT_DURATION && (
+          <ReportDurationWarning duration={reportDuration} />
+        )}
+
+        {combatants.length === 0 && <AdvancedLoggingWarning />}
+
+        <PlayerSelection
+          report={selectedReport}
+          combatants={combatants}
+          makeUrl={(playerId, build) =>
+            makeAnalyzerUrl(selectedReport, selectedFight.id, playerId, undefined, build)
+          }
+        />
+        <ReportRaidBuffList combatants={combatants} />
+      </div>
     );
   }
-}
+
+  return (
+    <>
+      <Helmet>
+        <title>
+          {t({
+            id: 'interface.report.render.documentTitle',
+            message: `${getFightName(selectedReport, selectedFight)} by ${player.name} in ${
+              selectedReport.title
+            }`,
+          })}
+        </title>
+      </Helmet>
+
+      <PlayerProvider player={player} combatant={combatant} combatants={combatants}>
+        {children}
+      </PlayerProvider>
+    </>
+  );
+};
 
 const mapStateToProps = (state: RootState, props: RouteComponentProps) => ({
   playerName: getPlayerName(props.location.pathname),
@@ -396,4 +425,4 @@ export default compose(
     setCombatants,
     fetchCharacter,
   }),
-)(PlayerLoader) as React.ComponentType<PassedProps>;
+)(PlayerLoaderFC) as React.ComponentType<PassedProps>;

--- a/src/interface/report/ReportLoader.tsx
+++ b/src/interface/report/ReportLoader.tsx
@@ -3,7 +3,6 @@ import { captureException } from 'common/errorLogger';
 import { fetchFights, LogNotFoundError } from 'common/fetchWclApi';
 import { setReport } from 'interface/actions/report';
 import ActivityIndicator from 'interface/ActivityIndicator';
-import DocumentTitle from 'interface/DocumentTitle';
 import makeAnalyzerUrl from 'interface/makeAnalyzerUrl';
 import { RootState } from 'interface/reducers';
 import { getReportCode } from 'interface/selectors/url/report';
@@ -12,6 +11,8 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'redux';
+import { ReportProvider } from 'interface/report/context/ReportContext';
+import { Helmet } from 'react-helmet';
 
 import handleApiError from './handleApiError';
 
@@ -26,7 +27,7 @@ interface ConnectedProps extends RouteComponentProps {
 }
 
 interface PassedProps {
-  children: (report: Report, handleRefresh: () => void) => React.ReactNode;
+  children: React.ReactNode;
 }
 
 type Props = ConnectedProps & PassedProps;
@@ -127,10 +128,13 @@ class ReportLoader extends React.PureComponent<Props, State> {
 
     return (
       <>
-        {/* TODO: Refactor the DocumentTitle away */}
-        <DocumentTitle title={report.title} />
+        <Helmet>
+          <title>{report.title}</title>
+        </Helmet>
 
-        {this.props.children(report, this.handleRefresh)}
+        <ReportProvider report={report} refreshReport={this.handleRefresh}>
+          {this.props.children}
+        </ReportProvider>
       </>
     );
   }

--- a/src/interface/report/SupportChecker.tsx
+++ b/src/interface/report/SupportChecker.tsx
@@ -4,32 +4,25 @@ import { RootState } from 'interface/reducers';
 import SupportCheckerSpecOutOfDate from 'interface/report/SupportCheckerSpecOutOfDate';
 import SupportCheckerSpecPartialSupport from 'interface/report/SupportCheckerSpecPartialSupport';
 import { getSpecsIgnoredNotSupportedWarning } from 'interface/selectors/skipSpecNotSupported';
-import { WCLFight } from 'parser/core/Fight';
-import { PlayerInfo } from 'parser/core/Player';
-import Report from 'parser/core/Report';
 import { ReactElement } from 'react';
 import { connect } from 'react-redux';
+import { usePlayer } from 'interface/report/context/PlayerContext';
+import { useReport } from 'interface/report/context/ReportContext';
+import { useFight } from 'interface/report/context/FightContext';
 
 import { useConfig } from './ConfigContext';
 
 interface Props {
   children: ReactElement<any, any> | null;
-  report: Report;
-  fight: WCLFight;
-  player: PlayerInfo;
   ignoreSpecNotSupportedWarning: (specId: number) => void;
   ignored: number[];
 }
 
-const SupportChecker = ({
-  children,
-  report,
-  fight,
-  player,
-  ignored,
-  ignoreSpecNotSupportedWarning,
-}: Props) => {
+const SupportChecker = ({ children, ignored, ignoreSpecNotSupportedWarning }: Props) => {
   const config = useConfig();
+  const { player } = usePlayer();
+  const { report } = useReport();
+  const { fight } = useFight();
 
   const handleClickContinue = () => {
     // I chose on purpose not to store this in a cookie since I don't want this to be forgotten. It should not be a big deal if this happens every time the page is loaded, so long as it isn't shown every fight.

--- a/src/interface/report/context/FightContext.tsx
+++ b/src/interface/report/context/FightContext.tsx
@@ -1,0 +1,25 @@
+import { createContext, ReactNode, useContext } from 'react';
+import { WCLFight } from 'parser/core/Fight';
+
+interface FightContext {
+  fight: WCLFight;
+}
+const FightCtx = createContext<FightContext | undefined>(undefined);
+
+export default FightCtx;
+
+export const useFight = () => {
+  const ctx = useContext(FightCtx);
+  if (ctx === undefined) {
+    throw new Error('Unable to get report');
+  }
+  return ctx;
+};
+
+interface Props {
+  children: ReactNode;
+  fight: WCLFight;
+}
+export const FightProvider = ({ children, fight }: Props) => {
+  return <FightCtx.Provider value={{ fight }}>{children}</FightCtx.Provider>;
+};

--- a/src/interface/report/context/PlayerContext.tsx
+++ b/src/interface/report/context/PlayerContext.tsx
@@ -1,0 +1,33 @@
+import { createContext, ReactNode, useContext } from 'react';
+import { PlayerInfo } from 'parser/core/Player';
+import { CombatantInfoEvent } from 'parser/core/Events';
+
+interface PlayerContext {
+  player: PlayerInfo;
+  combatant: CombatantInfoEvent;
+  combatants: CombatantInfoEvent[];
+}
+
+const PlayerCtx = createContext<PlayerContext | undefined>(undefined);
+
+export default PlayerCtx;
+
+export const usePlayer = () => {
+  const ctx = useContext(PlayerCtx);
+  if (ctx === undefined) {
+    throw new Error('Unable to get Config for selected report/player combination');
+  }
+  return ctx;
+};
+
+interface Props {
+  children: ReactNode;
+  player: PlayerInfo;
+  combatant: CombatantInfoEvent;
+  combatants: CombatantInfoEvent[];
+}
+export const PlayerProvider = ({ children, player, combatant, combatants }: Props) => {
+  return (
+    <PlayerCtx.Provider value={{ player, combatant, combatants }}>{children}</PlayerCtx.Provider>
+  );
+};

--- a/src/interface/report/context/ReportContext.tsx
+++ b/src/interface/report/context/ReportContext.tsx
@@ -1,0 +1,27 @@
+import { createContext, ReactNode, useContext } from 'react';
+import Report from 'parser/core/Report';
+
+interface ReportContext {
+  report: Report;
+  refreshReport: () => void;
+}
+const ReportCtx = createContext<ReportContext | undefined>(undefined);
+
+export default ReportCtx;
+
+export const useReport = () => {
+  const ctx = useContext(ReportCtx);
+  if (ctx === undefined) {
+    throw new Error('Unable to get report');
+  }
+  return ctx;
+};
+
+interface Props {
+  children: ReactNode;
+  report: Report;
+  refreshReport: () => void;
+}
+export const ReportProvider = ({ children, report, refreshReport }: Props) => {
+  return <ReportCtx.Provider value={{ report, refreshReport }}>{children}</ReportCtx.Provider>;
+};


### PR DESCRIPTION
Provide all data previously passed via functions through context instead. Enables consumption
farther down the component tree without needing to prop drill.

Can break this down into smaller PRs if needed.

Demonstration of report loading still working as expected

![report_loading](https://user-images.githubusercontent.com/1672786/198147105-647df976-8daf-4e0e-b043-7cb10a271c3b.gif)
