### PR TITLE
Fix vivacious vivification module

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2022, 10, 25), <>Fix overcapping detection for <SpellLink id={TALENTS_MONK.VIVACIOUS_VIVIFICATION_TALENT.id}/></>, Trevor),
   change(date(2022, 10, 25), <>Fix another crash caused by <SpellLink id={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id}/></>, Trevor),
   change(date(2022, 10, 25), <>Fix crashes caused by <SpellLink id={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id}/></>, ToppleTheNun),
   change(date(2022, 10, 23), <>Added module for <SpellLink id={TALENTS_MONK.YULONS_WHISPER_TALENT.id}/></>, Trevor),

--- a/src/analysis/retail/monk/mistweaver/modules/features/Checklist/Component.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/Checklist/Component.tsx
@@ -251,6 +251,14 @@ const MistweaverMonkChecklist = ({ combatant, castEfficiency, thresholds }: Chec
           }
           thresholds={thresholds.EssenceFontCancelled}
         />
+        <Requirement
+          name={
+            <>
+              <SpellLink id={TALENTS_MONK.VIVACIOUS_VIVIFICATION_TALENT.id} /> wasted applications
+            </>
+          }
+          thresholds={thresholds.vivaciousVivification}
+        />
       </Rule>
 
       <Rule

--- a/src/analysis/retail/monk/mistweaver/modules/features/Checklist/Module.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/Checklist/Module.tsx
@@ -20,6 +20,7 @@ import RenewingMistDuringManaTea from '../../spells/RenewingMistDuringManaTea';
 import SpiritOfTheCrane from '../../spells/SpiritOfTheCrane';
 import AlwaysBeCasting from '../AlwaysBeCasting';
 import Component from './Component';
+import VivaciousVivification from '../../spells/VivaciousVivify';
 
 class Checklist extends BaseChecklist {
   static dependencies = {
@@ -43,6 +44,7 @@ class Checklist extends BaseChecklist {
     soothingMist: SoothingMist,
     envelopingBreath: EnvelopingBreath,
     EssenceFontCancelled: EssenceFontCancelled,
+    vivaciousVivification: VivaciousVivification,
   };
 
   protected combatants!: Combatants;
@@ -64,6 +66,7 @@ class Checklist extends BaseChecklist {
   protected soothingMist!: SoothingMist;
   protected envelopingBreath!: EnvelopingBreath;
   protected EssenceFontCancelled!: EssenceFontCancelled;
+  protected vivaciousVivification!: VivaciousVivification;
 
   render() {
     return (
@@ -92,6 +95,7 @@ class Checklist extends BaseChecklist {
           jadeSerpentStatue: this.jadeSerpentStatue.suggestionThresholds,
           soothingMist: this.soothingMist.suggestionThresholdsCasting,
           EssenceFontCancelled: this.EssenceFontCancelled.suggestionThresholds,
+          vivaciousVivification: this.vivaciousVivification.suggestionThresholds,
         }}
       />
     );

--- a/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
@@ -1,27 +1,15 @@
 import { t } from '@lingui/macro';
-import { formatDuration, formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { ApplyBuffEvent, CastEvent, HealEvent, RemoveBuffEvent } from 'parser/core/Events';
+import Events, { RefreshBuffEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
-import ItemHealingDone from 'parser/ui/ItemHealingDone';
-import Statistic from 'parser/ui/Statistic';
-import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
-import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
-import TalentSpellText from 'parser/ui/TalentSpellText';
-
-const debug = false;
-const BUFF_CD = 10000;
-const HEAL_EVENT_BUFFER = 100;
 
 class VivaciousVivification extends Analyzer {
-  lastApply: number = 0;
-  lastRemove: number = 0;
   totalCasts: number = 0;
   totalHealed: number = 0;
-  wastedTime: number = 0;
+  wastedApplications: number = 0;
 
   constructor(options: Options) {
     super(options);
@@ -29,62 +17,24 @@ class VivaciousVivification extends Analyzer {
     if (!this.active) {
       return;
     }
-    this.addEventListener(Events.death.by(SELECTED_PLAYER), (event) => {
-      this.lastApply = 0;
-      this.lastRemove = 0;
-    });
     this.addEventListener(
-      Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.VIVIFICATION_BUFF),
-      this.onApply,
+      Events.refreshbuff.to(SELECTED_PLAYER).spell(SPELLS.VIVIFICATION_BUFF),
+      this.onRefresh,
     );
-    this.addEventListener(
-      Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.VIVIFICATION_BUFF),
-      this.onRemove,
-    );
-    this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.VIVIFY), this.onHeal);
-    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.VIVIFY), this.onCast);
   }
 
-  onApply(event: ApplyBuffEvent) {
-    this.lastApply = event.timestamp;
-  }
-
-  onRemove(event: RemoveBuffEvent) {
-    // overcap when more than 10 seconds since last apply (CD for next application starts on apply)
-    if (this.lastApply && event.timestamp - this.lastApply > BUFF_CD) {
-      this.wastedTime += event.timestamp - this.lastApply - BUFF_CD;
-      debug &&
-        console.log(
-          'Capped by ' +
-            (event.timestamp - this.lastApply - BUFF_CD) +
-            ' seconds at ' +
-            this.owner.formatTimestamp(event.timestamp),
-        );
-    }
-    this.lastRemove = event.timestamp;
-  }
-
-  onHeal(event: HealEvent) {
-    if (event.timestamp - this.lastRemove < HEAL_EVENT_BUFFER) {
-      this.totalHealed += event.amount;
-    }
-  }
-
-  onCast(event: CastEvent) {
-    if (
-      this.selectedCombatant.hasBuff(SPELLS.VIVIFICATION_BUFF.id) &&
-      event.ability.guid === SPELLS.VIVIFY.id
-    ) {
-      this.totalCasts += 1;
-    }
+  onRefresh(event: RefreshBuffEvent) {
+    // every refresh is a wasted buff application and the CD restarts
+    this.wastedApplications += 1;
   }
 
   get suggestionThresholds() {
     return {
-      actual: this.wastedTime,
+      actual: this.wastedApplications,
       isGreaterThan: {
-        minor: 30000, // 30 seconds
-        average: 60000, // 1 minute
+        minor: 2,
+        average: 5,
+        major: 8,
       },
       recommended: 0,
       style: ThresholdStyle.NUMBER,
@@ -95,39 +45,18 @@ class VivaciousVivification extends Analyzer {
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
       suggest(
         <>
-          You are currently overcapping on{' '}
-          <SpellLink id={TALENTS_MONK.VIVACIOUS_VIVIFICATION_TALENT.id} /> and wasting instant{' '}
-          <SpellLink id={SPELLS.VIVIFY.id} /> casts
+          You are overcapping on <SpellLink id={TALENTS_MONK.VIVACIOUS_VIVIFICATION_TALENT.id} />{' '}
+          and wasting instant <SpellLink id={SPELLS.VIVIFY.id} /> casts
         </>,
       )
         .icon(TALENTS_MONK.VIVACIOUS_VIVIFICATION_TALENT.icon)
         .actual(
-          `${formatDuration(this.wastedTime) + ' '}${t({
-            id: 'monk.mistweaver.suggestions.vivaciousVivification.wastedTime',
-            message: `of overcapping`,
+          `${this.wastedApplications + ' '}${t({
+            id: 'monk.mistweaver.suggestions.vivaciousVivification.wastedApplications',
+            message: `wasted applications`,
           })}`,
         )
-        .recommended(`<${formatNumber(recommended / 1000)} seconds of overcapping is recommended`),
-    );
-  }
-
-  statistic() {
-    return (
-      <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(20)}
-        size="flexible"
-        category={STATISTIC_CATEGORY.TALENTS}
-        tooltip={
-          <ul>
-            <li>Total Healed: {formatNumber(this.totalHealed)} </li>
-            <li>Total Instant Casts: {this.totalCasts}</li>
-          </ul>
-        }
-      >
-        <TalentSpellText talent={TALENTS_MONK.VIVACIOUS_VIVIFICATION_TALENT}>
-          <ItemHealingDone amount={this.totalHealed} />
-        </TalentSpellText>
-      </Statistic>
+        .recommended(`0 wasted applications is recommended`),
     );
   }
 }


### PR DESCRIPTION
Fixed overcapping Vivacious Vivification detection as I had an incorrect understanding when I first implemented this module. Essentially, every 10 seconds a buff is applied to you that grants you an instant vivify and this internal clock is always running. If the buff is ever refreshed on you, it means you missed an application. Similarly, if you have the buff and you are 1 second away from refreshing and then you consume the buff, then you will get it reapplied to you 1 second later. 

This PR essentially just counts the number of RefreshBuffEvent that happen and spits it out in the suggestion/checklist.

I also removed it from the statistics as it really isn't an hps talent, so it didn't quite make sense to give it an hps statistic. 


Before

![image](https://user-images.githubusercontent.com/11250934/198174841-374b21a8-3752-48ab-85e3-239dc09f769b.png)


After
![image](https://user-images.githubusercontent.com/11250934/198174916-d6d6ac9c-a75f-409c-b98f-e49f30d9c24b.png)
![image](https://user-images.githubusercontent.com/11250934/198174991-15735929-f070-42d8-aaa4-bf920ff79dd6.png)
