### PR TITLE
show all specs on specializations page

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -68,6 +68,7 @@ import { TALENTS_SHAMAN } from 'common/TALENTS';
 
 // prettier-ignore
 export default [
+  change(date(2022, 11, 1), 'Re-add missing specs to the specializations page.', ToppleTheNun),
   change(date(2022, 10, 31), 'Add slightly more ergonomic talent cast efficiency wrapper.', ToppleTheNun),
   change(date(2022, 10, 31), 'Update patch compatibility for specs supporting Dragonflight.', ToppleTheNun),
   change(date(2022, 10, 25), 'Improve patch version detection for retail and classic.', ToppleTheNun),

--- a/src/analysis/retail/deathknight/unholy/CONFIG.tsx
+++ b/src/analysis/retail/deathknight/unholy/CONFIG.tsx
@@ -2,15 +2,15 @@ import { Khazak } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Khazak],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.7',
-  isPartial: false,
+  patchCompatibility: null,
+  isPartial: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
@@ -60,12 +60,12 @@ export default {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.UNHOLY_DEATH_KNIGHT,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [],
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "UnholyDeathKnight" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "UnholyDeathKnight" */).then(
+  //     (exports) => exports.default,
+  //   ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };

--- a/src/analysis/retail/druid/guardian/CONFIG.tsx
+++ b/src/analysis/retail/druid/guardian/CONFIG.tsx
@@ -1,17 +1,18 @@
-import SPELLS from 'common/SPELLS';
+import SPELLS from 'common/SPELLS/druid';
+import TALENTS from 'common/TALENTS/druid';
 import { Buudha, Kettlepaw } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import { SpellLink } from 'interface';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Buudha, Kettlepaw],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.1.5',
+  patchCompatibility: null,
   isPartial: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
@@ -26,7 +27,7 @@ export default {
       The most important thing is to keep your hard-hitting, rage generating spells on cooldown at
       all times (<SpellLink id={SPELLS.THRASH_BEAR.id} />, <SpellLink id={SPELLS.MANGLE_BEAR.id} />,{' '}
       <SpellLink id={SPELLS.MOONFIRE_CAST.id} /> with{' '}
-      <SpellLink id={SPELLS.GALACTIC_GUARDIAN_TALENT.id} />
+      <SpellLink id={TALENTS.GALACTIC_GUARDIAN_TALENT.id} />
       ). Keep <SpellLink id={SPELLS.IRONFUR.id} /> up when you're tanking the boss, use{' '}
       <SpellLink id={SPELLS.FRENZIED_REGENERATION.id} /> when you're low or taking heavy damage, use{' '}
       <SpellLink id={SPELLS.BARKSKIN.id} /> frequently to mitigate damage, and save{' '}
@@ -48,12 +49,12 @@ export default {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.GUARDIAN_DRUID,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [],
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "GuardianDruid" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "GuardianDruid" */).then(
+  //     (exports) => exports.default,
+  //   ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };

--- a/src/analysis/retail/hunter/beastmastery/CONFIG.tsx
+++ b/src/analysis/retail/hunter/beastmastery/CONFIG.tsx
@@ -3,15 +3,15 @@ import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import Config from 'parser/Config';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Putro],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.0.5',
-  isPartial: false,
+  patchCompatibility: null,
+  isPartial: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
@@ -42,12 +42,12 @@ const config: Config = {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.BEAST_MASTERY_HUNTER,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [],
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "BeastMasteryHunter" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "BeastMasteryHunter" */).then(
+  //     (exports) => exports.default,
+  //   ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };

--- a/src/analysis/retail/hunter/marksmanship/CONFIG.tsx
+++ b/src/analysis/retail/hunter/marksmanship/CONFIG.tsx
@@ -3,15 +3,15 @@ import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import Config from 'parser/Config';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Putro],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.0.5',
-  isPartial: false,
+  patchCompatibility: null,
+  isPartial: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
@@ -42,12 +42,12 @@ const config: Config = {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.MARKSMANSHIP_HUNTER,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [],
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "MarksmanshipHunter" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "MarksmanshipHunter" */).then(
+  //     (exports) => exports.default,
+  //   ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };

--- a/src/analysis/retail/hunter/survival/CONFIG.tsx
+++ b/src/analysis/retail/hunter/survival/CONFIG.tsx
@@ -3,15 +3,15 @@ import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import Config from 'parser/Config';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Putro],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.0.5',
-  isPartial: false,
+  patchCompatibility: null,
+  isPartial: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
@@ -47,12 +47,12 @@ const config: Config = {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.SURVIVAL_HUNTER,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [],
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import(
-      'analysis/retail/hunter/survival/CombatLogParser' /* webpackChunkName: "SurvivalHunter" */
-    ).then((exports) => exports.default),
+  // parser: () =>
+  //   import(
+  //     'analysis/retail/hunter/survival/CombatLogParser' /* webpackChunkName: "SurvivalHunter" */
+  //   ).then((exports) => exports.default),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };

--- a/src/analysis/retail/monk/windwalker/CONFIG.tsx
+++ b/src/analysis/retail/monk/windwalker/CONFIG.tsx
@@ -3,15 +3,15 @@ import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import Config from 'parser/Config';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Juko8, nullDozzer],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.7',
-  isPartial: false,
+  patchCompatibility: null,
+  isPartial: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
@@ -26,7 +26,7 @@ const config: Config = {
       </a>{' '}
       and talk to us. You can reach me there as Juko8. Make sure to also check out our resources on
       the{' '}
-      <a href="http://peakofserenity.com/windwalker/" target="_blank" rel="noopener noreferrer">
+      <a href="https://peakofserenity.com/windwalker/" target="_blank" rel="noopener noreferrer">
         Peak of Serenity website
       </a>{' '}
       as well, it has pretty much everything you need to know.
@@ -39,12 +39,12 @@ const config: Config = {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.WINDWALKER_MONK,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [],
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "WindwalkerMonk" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "WindwalkerMonk" */).then(
+  //     (exports) => exports.default,
+  //   ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };

--- a/src/analysis/retail/paladin/protection/CONFIG.tsx
+++ b/src/analysis/retail/paladin/protection/CONFIG.tsx
@@ -1,4 +1,4 @@
-import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/paladin';
 import { emallson, Hordehobbs } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
@@ -6,15 +6,15 @@ import { SpellLink } from 'interface';
 import { TooltipElement } from 'interface';
 import { AlertWarning } from 'interface';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [emallson, Hordehobbs],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.7',
-  isPartial: false,
+  patchCompatibility: null,
+  isPartial: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
@@ -39,12 +39,12 @@ export default {
       <br />
       <br />
       <AlertWarning>
-        Because <SpellLink id={SPELLS.GRAND_CRUSADER.id} />{' '}
+        Because <SpellLink id={TALENTS.GRAND_CRUSADER_TALENT.id} />{' '}
         <TooltipElement content="The combatlog does not contain any events for random cooldown resets.">
           can't be tracked
         </TooltipElement>{' '}
-        properly, any cooldown information of <SpellLink id={SPELLS.AVENGERS_SHIELD.id} /> should be
-        treated as{' '}
+        properly, any cooldown information of <SpellLink id={TALENTS.AVENGERS_SHIELD_TALENT.id} />{' '}
+        should be treated as{' '}
         <TooltipElement content="Whenever Avenger's Shield would be cast before its cooldown would have expired normally, the cooldown expiry will be set back to the last possible trigger of Grand Crusade. This may lead to higher times on cooldown than you actually experienced in-game.">
           educated guesses
         </TooltipElement>
@@ -60,12 +60,12 @@ export default {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.PROTECTION_PALADIN,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [],
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "ProtectionPaladin" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "ProtectionPaladin" */).then(
+  //     (exports) => exports.default,
+  //   ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };

--- a/src/analysis/retail/paladin/retribution/CONFIG.tsx
+++ b/src/analysis/retail/paladin/retribution/CONFIG.tsx
@@ -3,13 +3,13 @@ import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import Config from 'parser/Config';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   contributors: [Juko8, Skeletor],
   expansion: Expansion.Shadowlands,
-  patchCompatibility: '9.0.5',
-  isPartial: false,
+  patchCompatibility: null,
+  isPartial: true,
   description: (
     <>
       We hope you get some use out this analyzer we have been working on.
@@ -47,11 +47,11 @@ const config: Config = {
     '/report/XWL82zKpNdFykwGg/11-Mythic+Hungering+Destroyer+-+Kill+(5:06)/Zïwak/standard',
 
   spec: SPECS.RETRIBUTION_PALADIN,
-  changelog: CHANGELOG,
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "RetributionPaladin" */).then(
-      (exports) => exports.default,
-    ),
+  changelog: [],
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "RetributionPaladin" */).then(
+  //     (exports) => exports.default,
+  //   ),
   path: __dirname,
 };
 

--- a/src/analysis/retail/priest/shadow/CONFIG.tsx
+++ b/src/analysis/retail/priest/shadow/CONFIG.tsx
@@ -2,15 +2,15 @@ import { Adoraci } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Adoraci],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.1.0',
-  isPartial: false,
+  patchCompatibility: null,
+  isPartial: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
@@ -45,12 +45,12 @@ export default {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.SHADOW_PRIEST,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [],
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "ShadowPriest" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "ShadowPriest" */).then(
+  //     (exports) => exports.default,
+  //   ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };

--- a/src/analysis/retail/rogue/assassination/CONFIG.js
+++ b/src/analysis/retail/rogue/assassination/CONFIG.js
@@ -2,15 +2,15 @@ import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import { AlertWarning } from 'interface';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.7',
-  isPartial: false,
+  patchCompatibility: null,
+  isPartial: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
@@ -38,12 +38,12 @@ export default {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.ASSASSINATION_ROGUE,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [],
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "AssassinationRogue" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "AssassinationRogue" */).then(
+  //     (exports) => exports.default,
+  //   ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };

--- a/src/analysis/retail/rogue/outlaw/CONFIG.js
+++ b/src/analysis/retail/rogue/outlaw/CONFIG.js
@@ -2,14 +2,14 @@ import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import { AlertWarning } from 'interface';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.7',
+  patchCompatibility: null,
   isPartial: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
@@ -36,12 +36,12 @@ export default {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.OUTLAW_ROGUE,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [],
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "OutlawRogue" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "OutlawRogue" */).then(
+  //     (exports) => exports.default,
+  //   ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };

--- a/src/analysis/retail/warrior/arms/CONFIG.tsx
+++ b/src/analysis/retail/warrior/arms/CONFIG.tsx
@@ -3,15 +3,15 @@ import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import Config from 'parser/Config';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Carrottopp],
   expansion: Expansion.Shadowlands,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '9.2.7',
-  isPartial: false,
+  patchCompatibility: null,
+  isPartial: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
@@ -42,12 +42,12 @@ const config: Config = {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.ARMS_WARRIOR,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [],
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "ArmsWarrior" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "ArmsWarrior" */).then(
+  //     (exports) => exports.default,
+  //   ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };

--- a/src/game/Expansion.ts
+++ b/src/game/Expansion.ts
@@ -15,3 +15,7 @@ export default Expansion;
 
 export const CLASSIC_EXPANSION = Expansion.WrathOfTheLichKing;
 export const RETAIL_EXPANSION = Expansion.Dragonflight;
+
+export function isCurrentExpansion(expansion: Expansion): boolean {
+  return expansion === CLASSIC_EXPANSION || expansion === RETAIL_EXPANSION;
+}

--- a/src/interface/SpecList.tsx
+++ b/src/interface/SpecList.tsx
@@ -9,9 +9,9 @@ import SpecListItem from './SpecListItem';
 import './SpecList.css';
 
 const isAnySpecSupported = (configs: Config[]) =>
-  configs.some((config) => config.patchCompatibility);
+  configs.some((config) => config.patchCompatibility && config.expansion === RETAIL_EXPANSION);
 
-const retailSpecs = AVAILABLE_CONFIGS.filter((it) => it.expansion >= RETAIL_EXPANSION);
+const retailSpecs = AVAILABLE_CONFIGS.filter((it) => it.expansion > CLASSIC_EXPANSION);
 const retailSpecsAsMap = groupByToMap(retailSpecs, (spec) => spec.spec.className);
 const retailSpecsGroupedByClass = Array.from(retailSpecsAsMap.entries());
 const retailClassesOrderedBySupport = retailSpecsGroupedByClass.sort(

--- a/src/interface/SpecListItem.tsx
+++ b/src/interface/SpecListItem.tsx
@@ -1,4 +1,5 @@
 import { Trans } from '@lingui/macro';
+import { isCurrentExpansion } from 'game/Expansion';
 import Contributor from 'interface/ContributorButton';
 import ReadableListing from 'interface/ReadableListing';
 import Config from 'parser/Config';
@@ -11,9 +12,10 @@ const SpecListItem = ({
   contributors,
   patchCompatibility,
   isPartial,
+  expansion,
 }: Config) => {
   const className = spec.className.replace(/ /g, '');
-  const Component = exampleReport ? 'a' : 'div';
+  const Component = exampleReport && isCurrentExpansion(expansion) ? 'a' : 'div';
 
   const maintainers = (
     <ReadableListing>

--- a/src/interface/report/hooks/useParser.ts
+++ b/src/interface/report/hooks/useParser.ts
@@ -17,7 +17,10 @@ const useParser = (config: Config) => {
     };
 
     setParserClass(undefined);
-    load(config.parser);
+    if (config.parser) {
+      // noinspection JSIgnoredPromiseFromCall
+      load(config.parser);
+    }
   }, [config]);
 
   return parserClass;

--- a/src/parser/Config.ts
+++ b/src/parser/Config.ts
@@ -106,7 +106,7 @@ interface Config {
   /**
    * The CombatLogParser class for your spec.
    */
-  parser: () => Promise<typeof CombatLogParser>;
+  parser?: () => Promise<typeof CombatLogParser>;
   /**
    * The path to the current directory (relative form project root). This is
    * used for generating a GitHub link directly to your spec's code.

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,27 +1,27 @@
 import BloodDeathKnight from 'analysis/retail/deathknight/blood';
 import FrostDeathKnight from 'analysis/retail/deathknight/frost';
-// import UnholyDeathKnight from 'analysis/retail/deathknight/unholy';
+import UnholyDeathKnight from 'analysis/retail/deathknight/unholy';
 import BalanceDruid from 'analysis/retail/druid/balance';
 import FeralDruid from 'analysis/retail/druid/feral';
-// import GuardianDruid from 'analysis/retail/druid/guardian';
+import GuardianDruid from 'analysis/retail/druid/guardian';
 import RestoDruid from 'analysis/retail/druid/restoration';
-// import BeastMasteryHunter from 'analysis/retail/hunter/beastmastery';
-// import MarksmanshipHunter from 'analysis/retail/hunter/marksmanship';
-// import SurvivalHunter from 'analysis/retail/hunter/survival';
+import BeastMasteryHunter from 'analysis/retail/hunter/beastmastery';
+import MarksmanshipHunter from 'analysis/retail/hunter/marksmanship';
+import SurvivalHunter from 'analysis/retail/hunter/survival';
 import ArcaneMage from 'analysis/retail/mage/arcane';
 import FireMage from 'analysis/retail/mage/fire';
 import FrostMage from 'analysis/retail/mage/frost';
 import BrewmasterMonk from 'analysis/retail/monk/brewmaster';
 import MistweaverMonk from 'analysis/retail/monk/mistweaver';
-// import WindwalkerMonk from 'analysis/retail/monk/windwalker';
+import WindwalkerMonk from 'analysis/retail/monk/windwalker';
 import HolyPaladin from 'analysis/retail/paladin/holy';
-// import ProtectionPaladin from 'analysis/retail/paladin/protection';
-// import RetributionPaladin from 'analysis/retail/paladin/retribution';
+import ProtectionPaladin from 'analysis/retail/paladin/protection';
+import RetributionPaladin from 'analysis/retail/paladin/retribution';
 import DisciplinePriest from 'analysis/retail/priest/discipline';
 import HolyPriest from 'analysis/retail/priest/holy';
-// import ShadowPriest from 'analysis/retail/priest/shadow';
-// import AssassinationRogue from 'analysis/retail/rogue/assassination';
-// import OutlawRogue from 'analysis/retail/rogue/outlaw';
+import ShadowPriest from 'analysis/retail/priest/shadow';
+import AssassinationRogue from 'analysis/retail/rogue/assassination';
+import OutlawRogue from 'analysis/retail/rogue/outlaw';
 import ElementalShaman from 'analysis/retail/shaman/elemental';
 import SubtletyRogue from 'analysis/retail/rogue/subtlety';
 import EnhancementShaman from 'analysis/retail/shaman/enhancement';
@@ -29,7 +29,7 @@ import RestorationShaman from 'analysis/retail/shaman/restoration';
 import AfflictionWarlock from 'analysis/retail/warlock/affliction';
 import DemonologyWarlock from 'analysis/retail/warlock/demonology';
 import DestructionWarlock from 'analysis/retail/warlock/destruction';
-// import ArmsWarrior from 'analysis/retail/warrior/arms';
+import ArmsWarrior from 'analysis/retail/warrior/arms';
 import FuryWarrior from 'analysis/retail/warrior/fury';
 import ProtectionWarrior from 'analysis/retail/warrior/protection';
 import ClassicDruid from 'analysis/classic/druid';
@@ -50,7 +50,7 @@ import Config from './Config';
 
 const configs: Config[] = [
   BloodDeathKnight,
-  // UnholyDeathKnight,
+  UnholyDeathKnight,
   FrostDeathKnight,
 
   HavocDemonHunter,
@@ -58,35 +58,35 @@ const configs: Config[] = [
 
   BalanceDruid,
   FeralDruid,
-  // GuardianDruid,
+  GuardianDruid,
   RestoDruid,
 
   DevastationEvoker,
   PreservationEvoker,
 
-  // BeastMasteryHunter,
-  // MarksmanshipHunter,
-  // SurvivalHunter,
+  BeastMasteryHunter,
+  MarksmanshipHunter,
+  SurvivalHunter,
 
   FrostMage,
   FireMage,
   ArcaneMage,
 
   BrewmasterMonk,
-  // WindwalkerMonk,
+  WindwalkerMonk,
   MistweaverMonk,
 
   HolyPaladin,
-  // RetributionPaladin,
-  // ProtectionPaladin,
+  RetributionPaladin,
+  ProtectionPaladin,
 
   DisciplinePriest,
   HolyPriest,
-  // ShadowPriest,
+  ShadowPriest,
 
   SubtletyRogue,
-  // AssassinationRogue,
-  // OutlawRogue,
+  AssassinationRogue,
+  OutlawRogue,
 
   ElementalShaman,
   EnhancementShaman,
@@ -97,7 +97,7 @@ const configs: Config[] = [
   DestructionWarlock,
 
   ProtectionWarrior,
-  // ArmsWarrior,
+  ArmsWarrior,
   FuryWarrior,
 
   ClassicMage,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,18 @@
     "src/analysis/retail/shaman/shared",
     "src/analysis/retail/warrior/arms"
   ],
+  "files": [
+    "src/analysis/retail/deathknight/unholy/CONFIG.tsx",
+    "src/analysis/retail/druid/guardian/CONFIG.tsx",
+    "src/analysis/retail/hunter/beastmastery/CONFIG.tsx",
+    "src/analysis/retail/hunter/marksmanship/CONFIG.tsx",
+    "src/analysis/retail/hunter/survival/CONFIG.tsx",
+    "src/analysis/retail/monk/windwalker/CONFIG.tsx",
+    "src/analysis/retail/paladin/protection/CONFIG.tsx",
+    "src/analysis/retail/paladin/retribution/CONFIG.tsx",
+    "src/analysis/retail/priest/shadow/CONFIG.tsx",
+    "src/analysis/retail/warrior/arms/CONFIG.tsx"
+  ],
   "ts-node": {
     // these options are overrides used only by ts-node
     "compilerOptions": {


### PR DESCRIPTION
all specs are now visible on the specializations page, along with
whether or not they are supported. classes that have no supported
specs are now at the bottom of the list, subsequently ordered by
name.

addresses #5090, #5091, #5093

![image](https://user-images.githubusercontent.com/1672786/199319980-a3e6a2c2-a8d8-4698-b697-a5a89c9deb63.png)
