### PR TITLE
[Enhancement Shaman] Cleanup changelog + small changes

### DIFF
--- a/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
@@ -1,42 +1,6 @@
 import { change, date } from 'common/changelog';
-import SPELLS from 'common/SPELLS';
-import { TALENTS_SHAMAN } from 'common/TALENTS';
-import { Mae, xunai, Vonn, Vetyst, CamClark } from 'CONTRIBUTORS';
-import { SpellLink } from 'interface';
+import { Vetyst } from 'CONTRIBUTORS';
 
 export default [
-  change(date(2022, 10, 18), <>Cleanup majority of old spells.</>, Vetyst),
-  change(date(2022, 10, 17), <>Remove incorrect reference to paladin Tier28FourSet. </>, CamClark),
-  change(date(2022, 10, 16), <>Updated spellbook for build 46157.</>, Vetyst),
-  change(date(2022, 9, 9), <>Initial implementation of Dragonflight Talent system.</>, Vetyst),
-  change(date(2022, 8, 22), <>Make <SpellLink id={SPELLS.STORMBRINGER.id} /> a priority only if you have <SpellLink id={TALENTS_SHAMAN.STORMFLURRY_TALENT.id} /> talented.</>, Vetyst),
-  change(date(2022, 8, 16), <>Implement an initial version of the Single Target APL checker.</>, Vetyst),
-  change(date(2022, 8, 15), <>Track haste gained from <SpellLink id={SPELLS.ELEMENTAL_BLAST.id} />.</>, Vetyst),
-  change(date(2022, 8, 17), <>Track bad/missed <SpellLink id={TALENTS_SHAMAN.SUNDERING_TALENT.id} /> casts.</>, Vetyst),
-  change(date(2022, 7, 22), <>Properly reduce the cooldown of <SpellLink id={SPELLS.CHAIN_HARVEST.id} /> combined with <SpellLink id={SPELLS.ELEMENTAL_CONDUIT.id}/> legendary effect.</>, Vetyst),
-  change(date(2022, 7, 22), <>Separate Stormstrike and Windstrike cooldowns.</>, Vetyst),
-  change(date(2022, 7, 22), <>Reset cooldown of <SpellLink id={SPELLS.PRIMORDIAL_WAVE_CAST.id} /> when <SpellLink id={SPELLS.TUMBLING_WAVES_CONDUIT.id} /> procs.</>, Vetyst),
-  change(date(2022, 7, 22), <>Show covenant abilities on offensive cooldowns checklist.</>, Vetyst),
-  change(date(2022, 7, 22), <>Add suggestion for the <SpellLink id={TALENTS_SHAMAN.ELEMENTAL_SPIRITS_TALENT.id} /> talent while wearing T28 4 set.</>, Vetyst),
-  change(date(2022, 7, 22), <>Remove <SpellLink id={TALENTS_SHAMAN.EARTH_ELEMENTAL_TALENT.id} />  as suggested offensive cooldown.</>, Vetyst),
-  change(date(2022, 7, 22), <>Reset <SpellLink id={TALENTS_SHAMAN.STORMSTRIKE_TALENT.id} /> cooldown when <SpellLink id={SPELLS.STORMBRINGER.id} /> is refreshed. </>, Vetyst),
-  change(date(2022, 7, 19), <>Reduce the cooldown of <SpellLink id={TALENTS_SHAMAN.LAVA_LASH_TALENT.id} /> when the <SpellLink id={TALENTS_SHAMAN.HOT_HAND_TALENT.id} /> buff is active. </>, Vetyst),
-  change(date(2022, 4, 26), <>Added <SpellLink id={SPELLS.FAE_TRANSFUSION.id} /> to the timeline and support for <SpellLink id={SPELLS.SEEDS_OF_RAMPANT_GROWTH.id} /> </>, xunai),
-  change(date(2022, 4, 24), <>Added cooldown reduction tracking for <SpellLink id={SPELLS.WITCH_DOCTORS_WOLF_BONES.id} /></>, xunai),
-  change(date(2022, 4, 21), <>Added statistics for tier 28 two set bonus and for <SpellLink id={TALENTS_SHAMAN.ELEMENTAL_SPIRITS_TALENT.id} /></>, xunai),
-  change(date(2022, 4, 11), <>Updated Frost Shock and Flame Shock to be treated as separate abilities on the timeline</>, xunai),
-  change(date(2020, 11, 11), <>Added stacks and time spent at cap statisctics for <SpellLink id={SPELLS.MAELSTROM_WEAPON.id} /></>, Mae),
-  change(date(2020, 11, 8), <>Added uptime statisctics for <SpellLink id={TALENTS_SHAMAN.WINDFURY_TOTEM_TALENT.id} /></>, Mae),
-  change(date(2020, 11, 8), <>Added uptime statistic and suggestion for <SpellLink id={SPELLS.LASHING_FLAMES_DEBUFF.id} /></>, Mae),
-  change(date(2020, 11, 8), <>Added stack statictics for <SpellLink id={TALENTS_SHAMAN.HAILSTORM_TALENT.id} /></>, Mae),
-  change(date(2020, 11, 5), <>Added <SpellLink id={SPELLS.FLAME_SHOCK.id} /> statistics</>, Mae),
-  change(date(2020, 11, 3), <>Added <SpellLink id={TALENTS_SHAMAN.SUNDERING_TALENT.id} /> to offensive cooldowns checklist.</>, Mae),
-  change(date(2020, 10, 12), <>Added Maelstrom Weapon stats for <SpellLink id={TALENTS_SHAMAN.FERAL_SPIRIT_TALENT.id} />.</>, Vonn),
-  change(date(2020, 10, 12), <>Updated statistics for <SpellLink id={TALENTS_SHAMAN.FORCEFUL_WINDS_TALENT.id} />.</>, Vonn),
-  change(date(2020, 10, 12), <>Added damage statistics for <SpellLink id={TALENTS_SHAMAN.ELEMENTAL_ASSAULT_TALENT.id} />.</>, Vonn),
-  change(date(2020, 10, 12), <>Updated damage statistics for <SpellLink id={TALENTS_SHAMAN.HOT_HAND_TALENT.id} />.</>, Vonn),
-  change(date(2020, 10, 12), <>Added damage statistics for <SpellLink id={TALENTS_SHAMAN.FIRE_NOVA_TALENT.id} />.</>, Vonn),
-  change(date(2020, 10, 12), <>Added damage statistics for <SpellLink id={TALENTS_SHAMAN.ICE_STRIKE_TALENT.id} />.</>, Vonn),
-  change(date(2020, 10, 11), <>Added damage statistics for the new <SpellLink id={TALENTS_SHAMAN.HAILSTORM_TALENT.id} />.</>, Vonn),
-  change(date(2020, 10, 11), <>Added damage statistics for <SpellLink id={TALENTS_SHAMAN.STORMFLURRY_TALENT.id} />.</>, Vonn),
+  change(date(2022, 11, 1), <>Cleanup changelog for Pre-patch.</>, Vetyst),
 ];

--- a/src/analysis/retail/shaman/enhancement/CONFIG.tsx
+++ b/src/analysis/retail/shaman/enhancement/CONFIG.tsx
@@ -9,13 +9,13 @@ import CHANGELOG from './CHANGELOG';
 const config: Config = {
   contributors: [Vetyst],
   expansion: Expansion.Dragonflight,
-  patchCompatibility: null,
+  patchCompatibility: '10.0.2',
   isPartial: true,
   description: (
     <>
       <AlertWarning>
-        Right now the Enhancement Analyzer is a work-in-progress, and only holds very basic
-        functionality.
+        Analytics are being developed for a level 70 dragonflight character on beta. Right now the
+        Enhancement Analyzer is a work-in-progress, and only holds very basic functionality.
       </AlertWarning>
       <br />
       Hey there! Thanks for checking out the Enhancement Analyzer. If you have any feedback or

--- a/src/analysis/retail/shaman/enhancement/CombatLogParser.tsx
+++ b/src/analysis/retail/shaman/enhancement/CombatLogParser.tsx
@@ -50,8 +50,6 @@ class CombatLogParser extends CoreCombatLogParser {
     checklist: Checklist,
     cooldownThroughputTracker: CooldownThroughputTracker,
 
-    // TODO: Rework below modules
-
     // Shaman Class Core
     flameShock: FlameShock,
 

--- a/src/analysis/retail/shaman/enhancement/constants.tsx
+++ b/src/analysis/retail/shaman/enhancement/constants.tsx
@@ -1,9 +1,6 @@
 import SPELLS from 'common/SPELLS';
 import { TALENTS_SHAMAN } from 'common/TALENTS';
 
-// TODO: either spell or talent depends on the next build.
-export const ASCENDANCE_ID = 114051;
-
 export const STORMSTRIKE_CAST_SPELLS = [TALENTS_SHAMAN.STORMSTRIKE_TALENT, SPELLS.WINDSTRIKE_CAST];
 
 export const STORMSTRIKE_DAMAGE_SPELLS = [

--- a/src/analysis/retail/shaman/enhancement/modules/Abilities.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/Abilities.tsx
@@ -6,11 +6,7 @@ import CoreAbilities from 'parser/core/modules/Abilities';
 import { SpellbookAbility } from 'parser/core/modules/Ability';
 import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
 
-import {
-  MOLTEN_ASSAULT_SCALING,
-  ESSENTIAL_EXTRACTION_EFFECT_BY_RANK,
-  ASCENDANCE_ID,
-} from '../constants';
+import { MOLTEN_ASSAULT_SCALING, ESSENTIAL_EXTRACTION_EFFECT_BY_RANK } from '../constants';
 
 import {
   TOTEMIC_SURGE_SCALING,
@@ -484,7 +480,8 @@ class Abilities extends CoreAbilities {
             // Placeholder for enhancement's ascendance
             calculateMaxCasts(
               cooldown,
-              this.owner.fightDuration - combatant.getBuffUptime(ASCENDANCE_ID),
+              this.owner.fightDuration -
+                combatant.getBuffUptime(TALENTS_SHAMAN.ASCENDANCE_ENHANCEMENT_TALENT.id),
             ),
         },
       },
@@ -493,7 +490,7 @@ class Abilities extends CoreAbilities {
         // Placeholder for enhancement's ascendance
         enabled:
           combatant.hasTalent(TALENTS_SHAMAN.DEEPLY_ROOTED_ELEMENTS_TALENT.id) ||
-          combatant.hasTalent(ASCENDANCE_ID),
+          combatant.hasTalent(TALENTS_SHAMAN.ASCENDANCE_ENHANCEMENT_TALENT.id),
         category: SPELL_CATEGORY.ROTATIONAL,
         cooldown: (haste) => 3 / (1 + haste),
         gcd: {
@@ -504,7 +501,10 @@ class Abilities extends CoreAbilities {
           recommendedEfficiency: 0.85,
           maxCasts: (cooldown: number) =>
             // Placeholder for enhancement's ascendance
-            calculateMaxCasts(cooldown, combatant.getBuffUptime(ASCENDANCE_ID)),
+            calculateMaxCasts(
+              cooldown,
+              combatant.getBuffUptime(TALENTS_SHAMAN.ASCENDANCE_ENHANCEMENT_TALENT.id),
+            ),
         },
       },
       {
@@ -606,7 +606,6 @@ class Abilities extends CoreAbilities {
         },
         enabled: combatant.hasCovenant(COVENANTS.KYRIAN.id),
       },
-
       {
         spell: TALENTS_SHAMAN.WINDFURY_TOTEM_TALENT.id,
         enabled: combatant.hasTalent(TALENTS_SHAMAN.WINDFURY_TOTEM_TALENT.id),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,7 +36,6 @@
     "src/analysis/retail/priest/shadow",
     "src/analysis/retail/rogue/assassination",
     "src/analysis/retail/rogue/outlaw",
-    "src/analysis/retail/shaman/shared",
     "src/analysis/retail/warrior/arms"
   ],
   "ts-node": {


### PR DESCRIPTION
* Emptied out enhancement shaman changelog
* Enabled errors for shaman/shared folder.
  * This was thankfully all patched up already! So no code changes were required.
* Added a message that analyzers will be based on level 70 characters on the about page.
* Adjusted the version to the beta version (10.0.2)
* Updated Ascendance to work from the TALENTS rather then hardcoded id.