### PR TITLE
[Mistweaver] Add Unison Module

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import { TALENTS_MONK } from 'common/TALENTS';
-import { emallson, Trevor, ToppleTheNun, Vetyst } from 'CONTRIBUTORS';
+import { emallson, Trevor, ToppleTheNun, Vetyst, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2022, 11, 8), <>Added module for <SpellLink id={TALENTS_MONK.UNISON_TALENT}/></>, Vohrr),
   change(date(2022, 11, 4), <>Remove Abelito75 from the contribution list.</>, Vetyst),
   change(date(2022, 10, 26), <>Fix detection for cancelling <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT.id}/></>, Trevor),
   change(date(2022, 10, 25), <>Fix overcapping detection for <SpellLink id={TALENTS_MONK.VIVACIOUS_VIVIFICATION_TALENT.id}/></>, Trevor),

--- a/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
+++ b/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
@@ -67,6 +67,7 @@ import YulonsWhisper from './modules/spells/YulonsWhisper';
 import HotApplicationNormalizer from './normalizers/HotApplicationNormalizer';
 import HotRemovalNormalizer from './normalizers/HotRemovalNormalizer';
 import CastLinkNormalizer from './normalizers/CastLinkNormalizer';
+import Unison from './modules/spells/Unison';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -145,6 +146,7 @@ class CombatLogParser extends CoreCombatLogParser {
     thunderFocusTea: ThunderFocusTea,
     upwelling: Upwelling,
     yulonsWhisper: YulonsWhisper,
+    unison: Unison,
 
     // Mana Tab
     manaTracker: ManaTracker,

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Unison.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Unison.tsx
@@ -1,0 +1,74 @@
+import { TALENTS_MONK } from 'common/TALENTS';
+import SpellLink from 'interface/SpellLink';
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
+import Events, { HealEvent} from 'parser/core/Events';
+import { formatNumber } from 'common/format';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+
+class Unison extends Analyzer {
+healing: number = 0;
+overhealing: number = 0;
+healingFromJss: number = 0;
+
+constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(
+        TALENTS_MONK.UNISON_TALENT.id,
+    );
+    if(!this.active) {
+        return;
+    }
+    this.addEventListener(
+        Events.heal.by(SELECTED_PLAYER).spell(SPELLS.UNISON_HEAL),
+        this.unisonHeal,
+    );
+    if(this.selectedCombatant.hasTalent(TALENTS_MONK.SUMMON_JADE_SERPENT_STATUE_TALENT.id)) {
+        this.addEventListener(
+        Events.heal.by(SELECTED_PLAYER_PET).spell(SPELLS.UNISON_HEAL),
+        this.jssUnisonHeal,
+        );
+    }
+}
+
+unisonHeal(event: HealEvent) {
+    this.healing += (event.amount || 0 ) + (event.absorbed|| 0);
+    this.overhealing += event.overheal || 0;
+}
+
+jssUnisonHeal(event: HealEvent) {
+    this.healing += (event.amount || 0 ) + (event.absorbed || 0);
+    this.overhealing += event.overheal || 0;
+    this.healingFromJss += (event.amount || 0) + (event.absorbed || 0);
+}
+
+statistic() {
+    return (
+        <Statistic
+            position={STATISTIC_ORDER.OPTIONAL(14)}
+            size="flexible"
+            category={STATISTIC_CATEGORY.TALENTS}
+            tooltip={
+                <ul>
+                    <li>
+                        Healing from <SpellLink id={TALENTS_MONK.SUMMON_JADE_SERPENT_STATUE_TALENT.id} />: {formatNumber(this.healingFromJss)} 
+                    </li>
+                    <li>
+                        Healing from <SpellLink id={TALENTS_MONK.SOOTHING_MIST_TALENT.id} />: {formatNumber(this.healing - this.healingFromJss)}
+                    </li>
+                </ul>
+            }
+        >
+            <BoringSpellValueText spellId={SPELLS.UNISON_HEAL.id}>
+                <ItemHealingDone amount={this.healing} />
+            </BoringSpellValueText>
+        </Statistic>
+    )
+}
+}
+
+export default Unison

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Unison.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Unison.tsx
@@ -2,7 +2,7 @@ import { TALENTS_MONK } from 'common/TALENTS';
 import SpellLink from 'interface/SpellLink';
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
-import Events, { HealEvent} from 'parser/core/Events';
+import Events, { HealEvent } from 'parser/core/Events';
 import { formatNumber } from 'common/format';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -11,64 +11,64 @@ import ItemHealingDone from 'parser/ui/ItemHealingDone';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 
 class Unison extends Analyzer {
-healing: number = 0;
-overhealing: number = 0;
-healingFromJss: number = 0;
+  healing: number = 0;
+  overhealing: number = 0;
+  healingFromJss: number = 0;
 
-constructor(options: Options) {
+  constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasTalent(
-        TALENTS_MONK.UNISON_TALENT.id,
-    );
-    if(!this.active) {
-        return;
+    this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.UNISON_TALENT.id);
+    if (!this.active) {
+      return;
     }
     this.addEventListener(
-        Events.heal.by(SELECTED_PLAYER).spell(SPELLS.UNISON_HEAL),
-        this.unisonHeal,
+      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.UNISON_HEAL),
+      this.unisonHeal,
     );
-    if(this.selectedCombatant.hasTalent(TALENTS_MONK.SUMMON_JADE_SERPENT_STATUE_TALENT.id)) {
-        this.addEventListener(
+    if (this.selectedCombatant.hasTalent(TALENTS_MONK.SUMMON_JADE_SERPENT_STATUE_TALENT.id)) {
+      this.addEventListener(
         Events.heal.by(SELECTED_PLAYER_PET).spell(SPELLS.UNISON_HEAL),
         this.jssUnisonHeal,
-        );
+      );
     }
-}
+  }
 
-unisonHeal(event: HealEvent) {
-    this.healing += (event.amount || 0 ) + (event.absorbed|| 0);
+  unisonHeal(event: HealEvent) {
+    this.healing += (event.amount || 0) + (event.absorbed || 0);
     this.overhealing += event.overheal || 0;
-}
+  }
 
-jssUnisonHeal(event: HealEvent) {
-    this.healing += (event.amount || 0 ) + (event.absorbed || 0);
+  jssUnisonHeal(event: HealEvent) {
+    this.healing += (event.amount || 0) + (event.absorbed || 0);
     this.overhealing += event.overheal || 0;
     this.healingFromJss += (event.amount || 0) + (event.absorbed || 0);
-}
+  }
 
-statistic() {
+  statistic() {
     return (
-        <Statistic
-            position={STATISTIC_ORDER.OPTIONAL(14)}
-            size="flexible"
-            category={STATISTIC_CATEGORY.TALENTS}
-            tooltip={
-                <ul>
-                    <li>
-                        Healing from <SpellLink id={TALENTS_MONK.SUMMON_JADE_SERPENT_STATUE_TALENT.id} />: {formatNumber(this.healingFromJss)} 
-                    </li>
-                    <li>
-                        Healing from <SpellLink id={TALENTS_MONK.SOOTHING_MIST_TALENT.id} />: {formatNumber(this.healing - this.healingFromJss)}
-                    </li>
-                </ul>
-            }
-        >
-            <BoringSpellValueText spellId={SPELLS.UNISON_HEAL.id}>
-                <ItemHealingDone amount={this.healing} />
-            </BoringSpellValueText>
-        </Statistic>
-    )
-}
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(14)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <ul>
+            <li>
+              Healing from <SpellLink id={TALENTS_MONK.SUMMON_JADE_SERPENT_STATUE_TALENT.id} />:{' '}
+              {formatNumber(this.healingFromJss)}
+            </li>
+            <li>
+              Healing from <SpellLink id={TALENTS_MONK.SOOTHING_MIST_TALENT.id} />:{' '}
+              {formatNumber(this.healing - this.healingFromJss)}
+            </li>
+          </ul>
+        }
+      >
+        <BoringSpellValueText spellId={SPELLS.UNISON_HEAL.id}>
+          <ItemHealingDone amount={this.healing} />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
 }
 
-export default Unison
+export default Unison;

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -211,6 +211,11 @@ const spells = spellIndexableList({
     name: 'Soothing Mist',
     icon: 'ability_monk_soothingmists',
   },
+  UNISON_HEAL: {
+    id: 388480,
+    name: 'Unison',
+    icon: 'ability_monk_soothingmists',
+  },
   REFRESHING_JADE_WIND_HEAL: {
     id: 162530,
     name: 'Refreshing Jade Wind',


### PR DESCRIPTION
Added unison module with support for Jade Serpent Statue

![image](https://user-images.githubusercontent.com/26779541/200617110-8387887a-22b7-403c-b0e8-1aeb323baa68.png)

![image](https://user-images.githubusercontent.com/26779541/200617194-882aae94-70af-43df-9e7b-e70d7a8b3af9.png)

Had to use BoringSpellValueText and the Spell Id for Unison-Heal instead of the talent due to a documented issue with certain Talents not being part of the  Spells object and also having different IDs resulting in an unknown value for the SpellLink