### PR TITLE
remove covenant abilities from checklist

### DIFF
--- a/src/analysis/retail/mage/fire/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/fire/CHANGELOG.tsx
@@ -1,8 +1,9 @@
 import { change, date } from 'common/changelog';
-import { Sharrq } from 'CONTRIBUTORS';
+import { Sharrq, ToppleTheNun } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2022, 11, 8), 'Remove Shadowlands covenant abilities from checklist.', ToppleTheNun),
   change(date(2022, 10, 30), `Update Dragonflight SPELLS, Abilities, and Buffs`, Sharrq),
   change(date(2022, 10, 9), 'Initial Dragonflight support', Sharrq),
 ];

--- a/src/analysis/retail/mage/fire/Checklist/Component.tsx
+++ b/src/analysis/retail/mage/fire/Checklist/Component.tsx
@@ -211,46 +211,6 @@ const FireMageChecklist = ({ combatant, castEfficiency, thresholds }: ChecklistP
             spell={TALENTS.LIVING_BOMB_TALENT.id}
           />
         )}
-        {combatant.hasCovenant(COVENANTS.NIGHT_FAE.id) && (
-          <AbilityRequirement
-            name={
-              <>
-                <SpellLink id={SPELLS.SHIFTING_POWER.id} /> Cast Efficiency
-              </>
-            }
-            spell={SPELLS.SHIFTING_POWER.id}
-          />
-        )}
-        {combatant.hasCovenant(COVENANTS.VENTHYR.id) && (
-          <AbilityRequirement
-            name={
-              <>
-                <SpellLink id={SPELLS.MIRRORS_OF_TORMENT.id} /> Cast Efficiency
-              </>
-            }
-            spell={SPELLS.MIRRORS_OF_TORMENT.id}
-          />
-        )}
-        {combatant.hasCovenant(COVENANTS.KYRIAN.id) && (
-          <AbilityRequirement
-            name={
-              <>
-                <SpellLink id={SPELLS.RADIANT_SPARK.id} /> Cast Efficiency
-              </>
-            }
-            spell={SPELLS.RADIANT_SPARK.id}
-          />
-        )}
-        {combatant.hasCovenant(COVENANTS.NECROLORD.id) && (
-          <AbilityRequirement
-            name={
-              <>
-                <SpellLink id={SPELLS.DEATHBORNE.id} /> Cast Efficiency
-              </>
-            }
-            spell={SPELLS.DEATHBORNE.id}
-          />
-        )}
         {combatant.hasTalent(TALENTS.METEOR_TALENT.id) && (
           <Requirement
             name={


### PR DESCRIPTION
fire mage checklist was only mage spec
that still had covenant abilities on their
checklist. these abilities were not included
in Abilities.tsx, which means that they
would not have cast efficiencies available
for retrieval.