### PR TITLE
[Mistweaver] Mana Tea Module Refinement

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2022, 11, 8), <>Readded the tooltip for average renewing mists during <SpellLink id={TALENTS_MONK.MANA_TEA_TALENT.id}/> and updated wording to 'mana saved per cast'</>, Vohrr),
   change(date(2022, 11, 8), <>Fixed <SpellLink id={TALENTS_MONK.NOURISHING_CHI_TALENT.id}/> showing up when not talented</>, Vohrr),
   change(date(2022, 11, 8), <>Consolidated <SpellLink id={TALENTS_MONK.MANA_TEA_TALENT.id}/> modules into one statistics box</>, Vohrr),
   change(date(2022, 11, 4), <>Remove Abelito75 from the contribution list.</>, Vetyst),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ManaTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ManaTea.tsx
@@ -13,6 +13,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import TalentSpellText from 'parser/ui/TalentSpellText';
+import Tooltip from 'react-tooltip-lite';
 import RenewingMistDuringManaTea from './RenewingMistDuringManaTea';
 
 class ManaTea extends Analyzer {
@@ -190,7 +191,7 @@ class ManaTea extends Analyzer {
         <TalentSpellText talent={TALENTS_MONK.MANA_TEA_TALENT}>
           <ItemManaGained amount={this.manaSavedMT} useAbbrev/>
           <br />
-          {formatNumber(this.avgMtSaves)} <small>mana per cast</small>
+          {formatNumber(this.avgMtSaves)} <small>mana saved per cast</small>
           <br />
           {this.renewingMistDuringManaTea.subStatistic()}
         </TalentSpellText>

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ManaTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ManaTea.tsx
@@ -13,7 +13,6 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import TalentSpellText from 'parser/ui/TalentSpellText';
-import Tooltip from 'react-tooltip-lite';
 import RenewingMistDuringManaTea from './RenewingMistDuringManaTea';
 
 class ManaTea extends Analyzer {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RenewingMistDuringManaTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RenewingMistDuringManaTea.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
-import { SpellLink } from 'interface';
+import { SpellLink, TooltipElement } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { ApplyBuffEvent, RemoveBuffEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
@@ -127,9 +127,15 @@ class RenewingMistDuringManaTea extends Analyzer {
 
   subStatistic() {
     return (
-      <div>
-        <>{this.avgRemDuringMT.toFixed(2)} <small>average renewing mists</small></>
-      </div>
+      <TooltipElement
+      content={
+        <>
+          This is the average number of Renewing Mists active during Mana Tea
+        </>
+      }
+      >
+        {this.avgRemDuringMT.toFixed(2)} <small>average renewing mists</small>
+      </TooltipElement>
     );
   }
 }


### PR DESCRIPTION
Re-added the tooltip for average renewing mists during mana tea and reworded to 'mana saved per cast'
Before:
![image](https://user-images.githubusercontent.com/26779541/200708671-511ad6d2-42ed-4415-bb2b-5289fe2b7434.png)

After: 
![image](https://user-images.githubusercontent.com/26779541/200708714-74cc206c-3991-40d0-afc0-46789140c40d.png)
