### PR TITLE
[Mistweaver] Updated Mastery Healing from Essence Font

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -1,10 +1,12 @@
 import { change, date } from 'common/changelog';
+import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
 import { emallson, Trevor, ToppleTheNun, Vetyst, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2022, 11, 8), <>Updated the <SpellLink id={SPELLS.GUSTS_OF_MISTS.id}/> from <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT.id}/> module to show healing contribution and <SpellLink id={TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT.id}/> contribution when talented.</>, Vohrr), 
   change(date(2022, 11, 8), <>Readded the tooltip for average renewing mists during <SpellLink id={TALENTS_MONK.MANA_TEA_TALENT.id}/> and updated wording to 'mana saved per cast'</>, Vohrr),
   change(date(2022, 11, 8), <> Fix and update for <SpellLink id={TALENTS_MONK.SUMMON_JADE_SERPENT_STATUE_TALENT.id}/> uptime</>, Vohrr),
   change(date(2022, 11, 8), <>Fixed <SpellLink id={TALENTS_MONK.NOURISHING_CHI_TALENT.id}/> showing up when not talented</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
@@ -167,10 +167,10 @@ class EssenceFont extends Analyzer {
           Mastery:
           <ul>  
             <li>
-            {this.gomEFHits} <small>additional hits</small>
+            {this.gomEFHits} additional hits
             </li>
             <li>
-            {formatNumber(this.gomHealing)} <small>additional healing</small>
+            {formatNumber(this.gomHealing)} additional healing
             </li>
           </ul>
           {this.chijitooltip()}

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
@@ -100,10 +100,6 @@ class EssenceFont extends Analyzer {
     this.chijiGomEFHits += 1;
     this.chijiGomHealing += event.amount + (event.absorbed || 0);
     this.chijiGomOverhealing += event.overheal || 0;
-
-    // Total healing
-    this.totalHealing += event.amount + (event.absorbed || 0);
-    this.totalOverhealing += event.overheal || 0;
   }
 
   gustHealing(event: HealEvent) {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
@@ -60,13 +60,23 @@ class EssenceFont extends Analyzer {
       return false;
     }
 
-    const targetHasEFHot = combatant.hasBuff(
+    let targetHasEFHot = combatant.hasBuff(
       SPELLS.ESSENCE_FONT_BUFF.id,
       event.timestamp,
       0,
       0,
       event.sourceID,
     );
+    //Essence font and FLS Essence font only ever proc one addtional mastery event, so we only need to check for FLS EF whenever EF is not present
+    if(!targetHasEFHot && this.selectedCombatant.hasTalent(TALENTS_MONK.FAELINE_STOMP_TALENT)) {
+      targetHasEFHot = combatant.hasBuff(
+        SPELLS.FAELINE_STOMP_ESSENCE_FONT.id,
+        event.timestamp,
+        0,
+        0,
+        event.sourceID,
+      );
+    }
 
     // if no EF buff die
     if (!targetHasEFHot) {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
@@ -103,7 +103,6 @@ class EssenceFont extends Analyzer {
   }
 
   gustHealing(event: HealEvent) {
-
     if(!this.isValidEFEvent(event)){
       return;
     }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
@@ -54,7 +54,7 @@ class EssenceFont extends Analyzer {
     }
   }
 
-  isValidEFEvent(event: HealEvent){
+  isValidEFEvent(event: HealEvent) {
     const combatant = this.combatants.players[event.targetID];
     if (!combatant) {
       return false;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
@@ -1,3 +1,4 @@
+import { Trans } from '@lingui/macro';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
@@ -7,6 +8,10 @@ import BoringValueText from 'parser/ui/BoringValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
+import { TALENTS_MONK } from 'common/TALENTS';
+import { formatNumber } from 'common/format';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+
 
 class EssenceFont extends Analyzer {
   static dependencies = {
@@ -22,12 +27,17 @@ class EssenceFont extends Analyzer {
   gomOverhealing: number = 0;
   gomEFHits: number = 0;
   gomEFEvent: boolean = false;
+  chijiActive: boolean = false;
+  chijiGomHealing: number = 0;
+  chijiGomOverhealing: number = 0;
+  chijiGomEFHits: number = 0;
 
   totalHealing: number = 0;
   totalOverhealing: number = 0;
 
   constructor(options: Options) {
     super(options);
+    this.chijiActive = this.selectedCombatant.hasTalent(TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT);
     this.addEventListener(
       Events.heal.by(SELECTED_PLAYER).spell(SPELLS.ESSENCE_FONT_BUFF),
       this.handleEssenceFontHealing,
@@ -36,12 +46,18 @@ class EssenceFont extends Analyzer {
       Events.heal.by(SELECTED_PLAYER).spell(SPELLS.GUSTS_OF_MISTS),
       this.gustHealing,
     );
+    if(this.chijiActive) {
+      this.addEventListener(
+        Events.heal.by(SELECTED_PLAYER).spell(SPELLS.GUST_OF_MISTS_CHIJI),
+        this.chijiGustHealing,
+      )
+    }
   }
 
-  gustHealing(event: HealEvent) {
+  isValidEFEvent(event: HealEvent){
     const combatant = this.combatants.players[event.targetID];
     if (!combatant) {
-      return;
+      return false;
     }
 
     const targetHasEFHot = combatant.hasBuff(
@@ -54,6 +70,14 @@ class EssenceFont extends Analyzer {
 
     // if no EF buff die
     if (!targetHasEFHot) {
+      this.gomEFEvent = false;
+      return false;
+    }
+    return true;
+  }
+
+  chijiGustHealing(event: HealEvent) {
+    if(!this.isValidEFEvent(event)){
       return;
     }
 
@@ -61,7 +85,27 @@ class EssenceFont extends Analyzer {
       this.gomEFEvent = true;
       return;
     }
+    // Chi-Ji GoM healing
+    this.gomEFEvent = false;
+    this.chijiGomEFHits += 1;
+    this.chijiGomHealing += event.amount + (event.absorbed || 0);
+    this.chijiGomOverhealing += event.overheal || 0;
 
+    // Total healing
+    this.totalHealing += event.amount + (event.absorbed || 0);
+    this.totalOverhealing += event.overheal || 0;
+  }
+
+  gustHealing(event: HealEvent) {
+
+    if(!this.isValidEFEvent(event)){
+      return;
+    }
+
+    if (!this.gomEFEvent) {
+      this.gomEFEvent = true;
+      return;
+    }
     // GoM healing
     this.gomEFEvent = false;
     this.gomEFHits += 1;
@@ -88,22 +132,53 @@ class EssenceFont extends Analyzer {
     this.totalOverhealing += event.overheal || 0;
   }
 
+  chijitooltip() {
+    if(this.chijiActive){
+      return <>Chi-Ji:
+        <ul>
+          <li>
+            {this.chijiGomEFHits} <small>additional Chi-Ji hits</small>
+          </li>
+          <li>
+            {formatNumber(this.chijiGomHealing)} <small>addtional Chi-Ji healing</small>
+          </li>
+        </ul>
+      </>
+      }
+    else{
+      return <></>
+    }
+  }
+
   statistic() {
     return (
       <Statistic
         position={STATISTIC_ORDER.OPTIONAL(0)}
         size="flexible"
         category={STATISTIC_CATEGORY.THEORYCRAFT}
-        tooltip={<>Gust Of Mist healing events due to Essence Font Hot.</>}
+        tooltip={
+          <Trans>
+          Mastery:
+          <ul>  
+            <li>
+            {this.gomEFHits} <small>additional hits</small>
+            </li>
+            <li>
+            {formatNumber(this.gomHealing)} <small>additional healing</small>
+            </li>
+          </ul>
+          {this.chijitooltip()}
+          </Trans>
+        }
       >
         <BoringValueText
           label={
             <>
-              <SpellLink id={SPELLS.GUSTS_OF_MISTS.id} /> from Essence Font
+              <SpellLink id={SPELLS.GUSTS_OF_MISTS.id}>Gusts of Mists</SpellLink> from <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT}/>
             </>
           }
         >
-          {this.gomEFHits}
+          <ItemHealingDone amount={this.gomHealing + this.chijiGomHealing}></ItemHealingDone>
         </BoringValueText>
       </Statistic>
     );

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
@@ -143,10 +143,10 @@ class EssenceFont extends Analyzer {
       return <>Chi-Ji:
         <ul>
           <li>
-            {this.chijiGomEFHits} <small>additional Chi-Ji hits</small>
+            {this.chijiGomEFHits} additional Chi-Ji hits
           </li>
           <li>
-            {formatNumber(this.chijiGomHealing)} <small>addtional Chi-Ji healing</small>
+            {formatNumber(this.chijiGomHealing)} addtional Chi-Ji healing
           </li>
         </ul>
       </>

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -246,6 +246,17 @@ const spells = spellIndexableList({
     name: "Yu'lon's Whisper",
     icon: 'ability_monk_chiexplosion',
   },
+  FAELINE_STOMP_HEAL: {
+    id: 388207,
+    name: 'Faeline Stomp',
+    icon: 'ability_ardenweald_monk'
+  },
+  FAELINE_STOMP_ESSENCE_FONT: {
+    id: 344006,
+    name: 'Faeline Stomp',
+    icon: 'ability_monk_essencefont',
+  },
+
 
   // Brewmaster
   NIUZAO_STOMP_DAMAGE: {

--- a/src/common/SPELLS/shadowlands/covenants/monk.ts
+++ b/src/common/SPELLS/shadowlands/covenants/monk.ts
@@ -60,11 +60,6 @@ const covenants = spellIndexableList({
     name: 'Faeline Stomp',
     icon: 'ability_ardenweald_monk',
   },
-  FAELINE_STOMP_ESSENCE_FONT: {
-    id: 344006,
-    name: 'Faeline Stomp',
-    icon: 'ability_ardenweald_monk',
-  },
   FAELINE_STOMP_PULSE_DAMAGE: {
     id: 327264,
     name: 'Faeline Stomp',


### PR DESCRIPTION
Updated the Essence Font module and Mastery Healing from Essence Font statistic to show healing contribution in addition to extra hits. 
Showed overall HPS contribution from extra gust of mist hits
Added Chi-Ji Gust of Mist additional hits and additional healing when talented
Added FLS Essence Font logic to EssenceFont.tsx for mastery to increase accuracy
Before: 
![image](https://user-images.githubusercontent.com/26779541/200738513-25fedbde-5af5-4951-8565-be8ba474d304.png)

After:
![image](https://user-images.githubusercontent.com/26779541/200738620-451050db-ccc2-4fe3-bcee-fdf0a6613bfb.png)
