### PR TITLE
[Warlock] Add missing entries to Spellbook

### DIFF
--- a/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
@@ -1,11 +1,12 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
-import { Dambroda, Sharrq, Maleficien, Akhtal, Pirrang, ToppleTheNun, Jonfanz } from 'CONTRIBUTORS';
+import { Dambroda, Sharrq, Maleficien, Akhtal, Pirrang, ToppleTheNun, Jonfanz, Arlie } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2022, 11, 10), <>Fix <SpellLink id={TALENTS.DRAIN_SOUL_TALENT.id} /> not showing as intended and add <SpellLink id={SPELLS.IMP_SINGE_MAGIC} />.</>, Arlie),
   change(date(2022, 11, 9), 'Remove Shadowlands covenant abilities from checklist.', ToppleTheNun),
   change(date(2022, 10, 20), <>Fix <SpellLink id={TALENTS.DRAIN_SOUL_TALENT.id} /> damage calculations and add initial support for <SpellLink id={TALENTS.DREAD_TOUCH_TALENT.id} />.</>, Jonfanz),
   change(date(2022, 10, 14), 'Begin working on support for Dragonflight.', Jonfanz),

--- a/src/analysis/retail/warlock/affliction/modules/features/Abilities.ts
+++ b/src/analysis/retail/warlock/affliction/modules/features/Abilities.ts
@@ -74,7 +74,7 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: TALENTS.DRAIN_SOUL_TALENT.id,
+        spell: SPELLS.DRAIN_SOUL_DEBUFF.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         enabled: combatant.hasTalent(TALENTS.DRAIN_SOUL_TALENT.id),
         gcd: {
@@ -359,6 +359,12 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+      },
+      {
+        spell: SPELLS.IMP_SINGE_MAGIC.id,
+        category: SPELL_CATEGORY.UTILITY,
+        cooldown: 15,
+        gcd: null,
       },
     ];
   }

--- a/src/common/SPELLS/warlock.ts
+++ b/src/common/SPELLS/warlock.ts
@@ -414,6 +414,11 @@ const spells = spellIndexableList({
     name: 'Headbutt',
     icon: 'inv_argusfelstalkermountgrey',
   },
+  IMP_SINGE_MAGIC: {
+    id: 119905,
+    name: 'Singe Magic',
+    icon: 'spell_fire_elementaldevastation.jpg',
+  },
   // Inner Demons pet abilities
   INNER_DEMONS_EYE_OF_GULDAN: {
     id: 272131,


### PR DESCRIPTION
- Drain Soul spell id was set to the talent but in combat log it has a different id
- Imp's Singe Magic was missing altogether

WCL log ID to test with (use Arliew): `b2YaxFgRDCqWmwr6`