### PR TITLE
[Mistweaver] Combining Rising Sun Kick Statistics & Reordering Statistic Boxes

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2022, 11, 11), <>Combined the <SpellLink id={TALENTS_MONK.RISING_SUN_KICK_TALENT.id}/> module and moved into general. Reordered the statistics in general to make more sense.</>, Vohrr),
   change(date(2022, 11, 9), <>Fixed changelog breaking the build</>, Vohrr),
   change(date(2022, 11, 9), <>Removed shadowlands spell references from the <SpellLink id={TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT.id}/> module and updated the statistic to use TalentSpellText. Added Vohrr to mistweaver contributors. </>, Vohrr),
   change(date(2022, 11, 8), <>Add module for <SpellLink id={TALENTS_MONK.SAVE_THEM_ALL_TALENT}/></>, Trevor),

--- a/src/analysis/retail/monk/mistweaver/modules/features/EssenceFontHealingBreakdown.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/EssenceFontHealingBreakdown.tsx
@@ -47,7 +47,7 @@ class EssenceFontHealingBreakdown extends Analyzer {
 
   statistic() {
     return (
-      <Statistic position={STATISTIC_ORDER.CORE(20)} size="flexible">
+      <Statistic position={STATISTIC_ORDER.CORE(1)} size="flexible">
         <div className="pad">
           <label>
             <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT.id}>Essence Font</SpellLink> breakdown

--- a/src/analysis/retail/monk/mistweaver/modules/features/MasteryStats.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/MasteryStats.tsx
@@ -105,7 +105,7 @@ class MasteryStats extends Analyzer {
 
   statistic() {
     return (
-      <Statistic position={STATISTIC_ORDER.CORE(20)} size="flexible">
+      <Statistic position={STATISTIC_ORDER.CORE(2)} size="flexible">
         <div className="pad">
           <label>
             <SpellLink id={SPELLS.GUSTS_OF_MISTS.id}>Gusts of Mists</SpellLink> breakdown

--- a/src/analysis/retail/monk/mistweaver/modules/spells/AverageTimeBetweenRSKs.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/AverageTimeBetweenRSKs.tsx
@@ -1,16 +1,21 @@
 import { TALENTS_MONK } from 'common/TALENTS';
-import { SpellIcon } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent } from 'parser/core/Events';
-import BoringValueText from 'parser/ui/BoringValueText';
+import TalentSpellText from 'parser/ui/TalentSpellText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import RisingSunKick from './RisingSunKick';
 
 /*
  * Add in Statistic box to show average time between RSK casts when Rising Mist is talented.
  */
 class TimeBetweenRSKs extends Analyzer {
+  static dependencies = {
+    risingSunKick: RisingSunKick,
+  };
+
+  protected risingSunKick!: RisingSunKick;
   totalRSKCasts: number = 0;
   firstRSKTimestamp: number = 0;
   lastRSKTimestamp: number = 0;
@@ -53,22 +58,17 @@ class TimeBetweenRSKs extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(13)}
+        position={STATISTIC_ORDER.CORE(22)}
         size="flexible"
-        category={STATISTIC_CATEGORY.TALENTS}
+        category={STATISTIC_CATEGORY.GENERAL}
       >
-        <BoringValueText
-          label={
-            <>
-              <SpellIcon id={TALENTS_MONK.RISING_SUN_KICK_TALENT.id} /> Average Time Between Rising
-              Sun Kick casts
-            </>
-          }
-        >
+        <TalentSpellText talent={TALENTS_MONK.RISING_SUN_KICK_TALENT}>
           <>
-            {this.averageTimeBetweenRSKSeconds} <small>Average Time Between</small>
+            {this.averageTimeBetweenRSKSeconds} <small>Average Time Between casts</small>
           </>
-        </BoringValueText>
+          <br />
+          <>{this.risingSunKick.subStatistic()}</>
+        </TalentSpellText>
       </Statistic>
     );
   }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Revival.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Revival.tsx
@@ -150,7 +150,7 @@ class Revival extends Analyzer {
 
   statistic() {
     return (
-      <Statistic position={STATISTIC_ORDER.CORE(20)} size="flexible">
+      <Statistic position={STATISTIC_ORDER.CORE(3)} size="flexible">
         <div className="pad">
           <label>
             <SpellLink id={this.activeTalent.id}>{this.activeTalent.name}</SpellLink> breakdown

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RisingSunKick.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RisingSunKick.tsx
@@ -1,12 +1,8 @@
 import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
-import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent } from 'parser/core/Events';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
-import BoringValueText from 'parser/ui/BoringValueText';
-import Statistic from 'parser/ui/Statistic';
-import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
 class RisingSunKick extends Analyzer {
   static dependencies = {
@@ -50,19 +46,11 @@ class RisingSunKick extends Analyzer {
     this.lastBOK = event.timestamp;
   }
 
-  statistic() {
+  subStatistic() {
     return (
-      <Statistic position={STATISTIC_ORDER.CORE(20)} size="flexible">
-        <BoringValueText
-          label={
-            <>
-              <SpellLink id={TALENTS_MONK.RISING_SUN_KICK_TALENT.id} /> Resets
-            </>
-          }
-        >
-          <>{this.rskResets}</>
-        </BoringValueText>
-      </Statistic>
+      <>
+        {this.rskResets} <small>Resets</small>
+      </>
     );
   }
 }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
@@ -195,7 +195,7 @@ class ThunderFocusTea extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.CORE(20)}
+        position={STATISTIC_ORDER.CORE(23)}
         size="flexible"
         category={STATISTIC_CATEGORY.GENERAL}
       >

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Vivify.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Vivify.tsx
@@ -105,7 +105,7 @@ class Vivify extends Analyzer {
   statistic() {
     return (
       <StatisticBox
-        postion={STATISTIC_ORDER.CORE(15)}
+        postion={STATISTIC_ORDER.CORE(20)}
         icon={<SpellIcon id={SPELLS.VIVIFY.id} />}
         value={`${this.averageRemPerVivify.toFixed(2)}`}
         label={


### PR DESCRIPTION
Combined the two Rising Sun Kick statistics and moved them into general given their importance to the kit. Reordered the General section to make more sense
Before: 
![image](https://user-images.githubusercontent.com/26779541/201451832-1b860d7d-ea4d-4917-82a5-d697e8fbf4aa.png)

After: 
![image](https://user-images.githubusercontent.com/26779541/201451878-493f24bf-1cb0-41af-94fe-d73b658ada41.png)
