### PR TITLE
[Mistweaver] Faeline Stomp Fixes and Talent Module Reorganizing

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2022, 11, 14), <>Fix broken <SpellLink id={TALENTS_MONK.FAELINE_STOMP_TALENT.id}/> references and reordered the talent modules based on importance</>, Vohrr),
   change(date(2022, 11, 13), <>Fix load conditions for some Mistweaver talents</>, Trevor),
   change(date(2022, 11, 12), <>Updated the spell icon for <SpellLink id={TALENTS_MONK.ENVELOPING_BREATH_TALENT.id}/></>, Vohrr),
   change(date(2022, 11, 12), <>Cleanup covenant files for Mistweaver</>, Trevor),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/BonedustBrewAverageTargets.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/BonedustBrewAverageTargets.tsx
@@ -68,8 +68,8 @@ class BonedustBrewAverageTargets extends Analyzer {
     return (
       <Statistic
         size="flexible"
-        position={STATISTIC_ORDER.OPTIONAL(0)}
-        category={STATISTIC_CATEGORY.COVENANTS}
+        position={STATISTIC_ORDER.OPTIONAL(50)}
+        category={STATISTIC_CATEGORY.TALENTS}
         dropdown={this.baseTable}
       >
         <BoringSpellValueText spellId={SPELLS.BONEDUST_BREW_CAST.id}>

--- a/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
@@ -184,7 +184,7 @@ class InvokeChiJi extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(50)}
+        position={STATISTIC_ORDER.DEFAULT}
         category={STATISTIC_CATEGORY.TALENTS}
         size="flexible"
         tooltip={

--- a/src/analysis/retail/monk/mistweaver/modules/spells/InvokeYulon.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/InvokeYulon.tsx
@@ -41,7 +41,7 @@ class InvokeYulon extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(50)}
+        position={STATISTIC_ORDER.DEFAULT}
         size="flexible"
         tooltip={
           <>

--- a/src/analysis/retail/monk/mistweaver/modules/spells/LifeCocoon.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/LifeCocoon.tsx
@@ -43,7 +43,7 @@ class LifeCocoon extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(20)}
+        position={STATISTIC_ORDER.OPTIONAL(70)}
         category={STATISTIC_CATEGORY.TALENTS}
         size="flexible"
         tooltip={<>Life Cocoon boosts HoTs from other players as wells as your own.</>}

--- a/src/analysis/retail/monk/mistweaver/modules/spells/MistWrapEnvelopingBreath.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/MistWrapEnvelopingBreath.tsx
@@ -105,7 +105,7 @@ class MistWrapEnvelopingBreath extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(70)}
+        position={STATISTIC_ORDER.OPTIONAL(20)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={

--- a/src/analysis/retail/monk/mistweaver/modules/spells/MistyPeaks.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/MistyPeaks.tsx
@@ -92,7 +92,7 @@ class MistyPeaks extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(13)}
+        position={STATISTIC_ORDER.DEFAULT}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RisingMist.js
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RisingMist.js
@@ -274,7 +274,7 @@ class RisingMist extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(10)}
+        position={STATISTIC_ORDER.DEFAULT}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Upwelling.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Upwelling.tsx
@@ -208,7 +208,7 @@ class Upwelling extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(10)}
+        position={STATISTIC_ORDER.DEFAULT}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={

--- a/src/analysis/retail/monk/shared/FaelineStomp.tsx
+++ b/src/analysis/retail/monk/shared/FaelineStomp.tsx
@@ -6,10 +6,10 @@ import Events from 'parser/core/Events';
 import Abilities from 'parser/core/modules/Abilities';
 import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
-import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import TalentSpellText from 'parser/ui/TalentSpellText';
 
 class FaelineStomp extends Analyzer {
   static dependencies = {
@@ -35,7 +35,7 @@ class FaelineStomp extends Analyzer {
     }
 
     (options.abilities as Abilities).add({
-      spell: SPELLS.FAELINE_STOMP_CAST.id,
+      spell: TALENTS_MONK.FAELINE_STOMP_TALENT.id,
       category: SPELL_CATEGORY.ROTATIONAL,
       cooldown: 30,
       gcd:
@@ -47,7 +47,7 @@ class FaelineStomp extends Analyzer {
     });
 
     this.addEventListener(
-      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.FAELINE_STOMP_CAST),
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS_MONK.FAELINE_STOMP_TALENT),
       this.casts,
     );
     this.addEventListener(
@@ -55,11 +55,13 @@ class FaelineStomp extends Analyzer {
       this.reset,
     );
     this.addEventListener(
-      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.FAELINE_STOMP_DAMAGE_AND_HEAL),
+      Events.damage
+        .by(SELECTED_PLAYER)
+        .spell([SPELLS.FAELINE_STOMP_HEAL, SPELLS.FAELINE_STOMP_PULSE_DAMAGE]),
       this.damage,
     );
     this.addEventListener(
-      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.FAELINE_STOMP_DAMAGE_AND_HEAL),
+      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.FAELINE_STOMP_HEAL),
       this.heal,
     );
   }
@@ -69,8 +71,8 @@ class FaelineStomp extends Analyzer {
   }
 
   reset() {
-    if (this.spellUsable.isOnCooldown(SPELLS.FAELINE_STOMP_CAST.id)) {
-      this.spellUsable.endCooldown(SPELLS.FAELINE_STOMP_CAST.id);
+    if (this.spellUsable.isOnCooldown(TALENTS_MONK.FAELINE_STOMP_TALENT.id)) {
+      this.spellUsable.endCooldown(TALENTS_MONK.FAELINE_STOMP_TALENT.id);
       this.resets += 1;
     }
   }
@@ -86,15 +88,15 @@ class FaelineStomp extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.CORE()}
+        position={STATISTIC_ORDER.OPTIONAL()}
         size="flexible"
-        category={STATISTIC_CATEGORY.COVENANTS}
+        category={STATISTIC_CATEGORY.TALENTS}
       >
-        <BoringSpellValueText spellId={SPELLS.FAELINE_STOMP_CAST.id}>
+        <TalentSpellText talent={TALENTS_MONK.FAELINE_STOMP_TALENT}>
           {this.resets} <small>resets</small> <br />
           {(this.targetsDamaged / this.flsCasts).toFixed(2)} <small>Foes Hit per cast</small> <br />
           {(this.targetsHealed / this.flsCasts).toFixed(2)} <small>Allies Hit per cast</small>
-        </BoringSpellValueText>
+        </TalentSpellText>
       </Statistic>
     );
   }

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -266,6 +266,11 @@ const spells = spellIndexableList({
     name: 'Faeline Stomp',
     icon: 'ability_monk_essencefont',
   },
+  FAELINE_STOMP_RESET: {
+    id: 388203,
+    name: 'Faeline Stomp',
+    icon: 'ability_ardenweald_monk',
+  },
 
   // Brewmaster
   NIUZAO_STOMP_DAMAGE: {

--- a/src/common/SPELLS/shadowlands/covenants/monk.ts
+++ b/src/common/SPELLS/shadowlands/covenants/monk.ts
@@ -65,11 +65,6 @@ const covenants = spellIndexableList({
     name: 'Faeline Stomp',
     icon: 'ability_ardenweald_monk',
   },
-  FAELINE_STOMP_RESET: {
-    id: 327276,
-    name: 'Faeline Stomp',
-    icon: 'ability_ardenweald_monk',
-  },
   //endregion
 
   //region Venthyr


### PR DESCRIPTION
Reordered certain talents due to their importance. Fixed the broken references to covenant spellids in the Faeline stomp module.
Before: 
![image](https://user-images.githubusercontent.com/26779541/201781586-02d48a76-d398-4dd8-9e64-4fad94197254.png)
After:
![image](https://user-images.githubusercontent.com/26779541/201781481-fed6aad8-1249-42c9-a882-95c24951b1da.png)
