### PR TITLE
[Druid] Added support for Dreamstate, still need to implement spellUsable 

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,0 @@
-# Copy this file and rename it to `.env.local` to configure your own WCL API key. You can get your own API key from the bottom of the Warcraft Logs settings: https://www.warcraftlogs.com/profile
-# You should also enter the application name "WoWAnalyzer (development)" on that page, just above the key.
-REACT_APP_WCL_API_KEY=INSERT_YOUR_OWN_API_KEY_HERE

--- a/src/analysis/retail/druid/restoration/CombatLogParser.ts
+++ b/src/analysis/retail/druid/restoration/CombatLogParser.ts
@@ -56,6 +56,7 @@ import NaturesVigil from 'analysis/retail/druid/restoration/modules/spells/Natur
 import RampantGrowth from 'analysis/retail/druid/restoration/modules/spells/RampantGrowth';
 import Overgrowth from 'analysis/retail/druid/restoration/modules/spells/Overgrowth';
 import BuddingLeaves from 'analysis/retail/druid/restoration/modules/spells/BuddingLeaves';
+import Dreamstate from 'analysis/retail/druid/restoration/modules/spells/Dreamstate';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -118,6 +119,7 @@ class CombatLogParser extends CoreCombatLogParser {
     rampantGrowth: RampantGrowth,
     overgrowth: Overgrowth,
     buddingLeaves: BuddingLeaves,
+    Dreamstate: Dreamstate,
 
     // Mana Tab
     manaTracker: ManaTracker,

--- a/src/analysis/retail/druid/restoration/modules/spells/Dreamstate.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/Dreamstate.tsx
@@ -1,0 +1,61 @@
+import { TALENTS_DRUID } from 'common/TALENTS';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import Events, { CastEvent } from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import { SpellIcon } from 'interface';
+import BoringValue from 'parser/ui/BoringValueText';
+import { formatNumber } from 'common/format';
+
+const cdrPerTick = 3;
+
+class Dreamstate extends Analyzer {
+  tickCount = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.GROVE_TENDING_TALENT);
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.TRANQUILITY_HEAL),
+      this.onCast,
+    );
+  }
+
+  onCast(event: CastEvent) {
+    this.tickCount += 1;
+  }
+
+  get totalCDR() {
+    return cdrPerTick * this.tickCount;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        size="flexible"
+        position={STATISTIC_ORDER.OPTIONAL(6)} // number based on talent row
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            Total Cooldown Reduction from all Tranquility casts:{' '}
+            <strong>{this.totalCDR} seconds</strong>
+          </>
+        }
+      >
+        <BoringValue
+          label={
+            <>
+              <SpellIcon id={TALENTS_DRUID.DREAMSTATE_TALENT.id} /> Dreamstate CDR per minute
+            </>
+          }
+        >
+          <>{formatNumber(this.owner.getPerMinute(this.totalCDR))} seconds</>
+        </BoringValue>
+      </Statistic>
+    );
+  }
+}
+
+export default Dreamstate;

--- a/src/common/TALENTS/druid.ts
+++ b/src/common/TALENTS/druid.ts
@@ -438,7 +438,12 @@ const talents = createTalentList({
     icon: 'ability_druid_dreamstate',
     maxRanks: 1,
   },
-  DREAMSTATE_TALENT: { id: 392162, name: 'Dreamstate', icon: 'spell_unused', maxRanks: 1 },
+  DREAMSTATE_TALENT: {
+    id: 392162,
+    name: 'Dreamstate',
+    icon: 'spell_unused',
+    maxRanks: 1,
+  },
   IMPROVED_WILD_GROWTH_TALENT: {
     id: 328025,
     name: 'Improved Wild Growth',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/117578254/202066218-65344878-7542-4209-9c14-06e9f95bb03a.png)

![image](https://user-images.githubusercontent.com/117578254/202066266-4870fe97-666c-4383-b75d-6de0c8372a4e.png)

Calculates Dreamstate cooldown reduction based on tranquility ticks.
