### PR TITLE
add SuggestionSection Guide component

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -67,6 +67,7 @@ import SpellLink from 'interface/SpellLink';
 import { TALENTS_SHAMAN } from 'common/TALENTS';
 
 export default [
+  change(date(2022, 11, 15), 'Add SuggestionSection component to help transition into Guides.', ToppleTheNun),
   change(date(2022, 11, 13), 'Hide Dragonflight warning on Classic logs that don\'t have a build selected', emallson),
   change(date(2022, 11, 12), 'Backend work on resource tracking, including light bug fixes and ability to query stats for specific time periods', Sref),
   change(date(2022, 11, 11), 'Add player icon lookup for configs to Classic specs.', jazminite),

--- a/src/interface/guide/components/Suggestions/SuggestionSection.tsx
+++ b/src/interface/guide/components/Suggestions/SuggestionSection.tsx
@@ -1,0 +1,86 @@
+import ParseResults from 'parser/core/ParseResults';
+import { Section, useAnalyzers } from 'interface/guide/index';
+import { t, Trans } from '@lingui/macro';
+import Analyzer from 'parser/core/Analyzer';
+import { useMemo, useState } from 'react';
+import Toggle from 'react-toggle';
+
+import Suggestions from './Suggestions';
+
+interface SuggestionSectionProps<T extends typeof Analyzer> {
+  analyzers?: T[];
+}
+
+/**
+ * Section that can be included in Guides in order to make transitioning away from
+ * Suggestions easier.
+ *
+ * # Example
+ *
+ * ```
+ * <SuggestionSection analyzers={[FoodChecker, WeaponEnhancementChecker]} />
+ * ```
+ */
+const SuggestionSection = <T extends typeof Analyzer>({ analyzers }: SuggestionSectionProps<T>) => {
+  const [showMinorIssues, setShowMinorIssues] = useState(false);
+  const analyzerInstances = useAnalyzers(analyzers ?? []);
+  const parseResults = useMemo(() => {
+    const results = new ParseResults();
+    analyzerInstances.forEach((analyzer) => {
+      const maybeResult = analyzer.suggestions(results.suggestions.when);
+      if (maybeResult) {
+        maybeResult.forEach((issue) => results.addIssue(issue));
+      }
+    });
+    return results;
+  }, [analyzerInstances]);
+
+  return (
+    <Section
+      title={t({
+        id: 'interface.report.results.overview.suggestions.suggestions',
+        message: 'Suggestions',
+      })}
+    >
+      <div className="flex wrapable">
+        <div className="flex-main">
+          <small>
+            <Trans id="interface.report.results.overview.suggestions.explanation">
+              Based on what you did in this fight, here are some things we think you might be able
+              to improve.
+            </Trans>
+          </small>
+        </div>
+        <div className="flex-sub action-buttons">
+          <div className="pull-right toggle-control">
+            <Toggle
+              defaultChecked={showMinorIssues}
+              icons={false}
+              onChange={(event) => setShowMinorIssues(event.target.checked)}
+              id="minor-issues-toggle"
+            />
+            <label htmlFor="minor-issues-toggle">
+              <Trans id="interface.report.results.overview.suggestions.minorImportance">
+                Minor importance
+              </Trans>
+            </label>
+          </div>
+        </div>
+      </div>
+      <div className="flex" style={{ paddingTop: 10, paddingBottom: 10 }}>
+        <Suggestions parseResults={parseResults} showMinorIssues={showMinorIssues} />
+      </div>
+      <div className="flex">
+        <small>
+          <Trans id="interface.report.results.overview.suggestions.improve">
+            Some of these suggestions may be nitpicky or fight dependent, but often it's still
+            something you could look to improve. Try to focus on improving one thing at a time -
+            don't try to improve everything at once.
+          </Trans>
+        </small>
+      </div>
+    </Section>
+  );
+};
+
+export default SuggestionSection;

--- a/src/interface/guide/components/Suggestions/Suggestions.tsx
+++ b/src/interface/guide/components/Suggestions/Suggestions.tsx
@@ -1,0 +1,62 @@
+import ParseResults from 'parser/core/ParseResults';
+import ISSUE_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
+import Icon from 'interface/Icon';
+import { Trans } from '@lingui/macro';
+import Suggestion from 'interface/report/Results/Suggestion';
+
+interface SuggestionsProps {
+  parseResults: ParseResults;
+  showMinorIssues: boolean;
+}
+const Suggestions = ({ parseResults, showMinorIssues }: SuggestionsProps) => (
+  <ul className="list issues">
+    {!parseResults.issues.find((issue) => issue.importance === ISSUE_IMPORTANCE.MAJOR) && (
+      <li className="item major" style={{ color: '#25ff00' }}>
+        <div className="icon">
+          <Icon icon="thumbsup" alt="Thumbsup" />
+        </div>
+        <div className="suggestion">
+          <Trans id="interface.report.results.overview.suggestions.noMajorIssues">
+            There are no major issues in this fight. Good job!
+          </Trans>
+        </div>
+      </li>
+    )}
+    {parseResults.issues
+      .filter((issue) => showMinorIssues || issue.importance !== ISSUE_IMPORTANCE.MINOR)
+      .map((issue, i) =>
+        'issue' in issue ? (
+          <Suggestion
+            key={i}
+            icon={issue.icon}
+            spell={issue.spell}
+            importance={issue.importance}
+            stat={issue.stat}
+            details={issue.details}
+          >
+            {issue.issue}
+          </Suggestion>
+        ) : (
+          <Suggestion
+            key={i}
+            spell={issue.spell}
+            icon={issue.icon}
+            stat={
+              issue.actual && issue.recommended ? (
+                <>
+                  {issue.actual} ({issue.recommended})
+                </>
+              ) : (
+                issue.actual || issue.recommended
+              )
+            }
+            importance={(issue.importance as unknown) as ISSUE_IMPORTANCE}
+          >
+            {issue.text}
+          </Suggestion>
+        ),
+      )}
+  </ul>
+);
+
+export default Suggestions;

--- a/src/interface/guide/index.tsx
+++ b/src/interface/guide/index.tsx
@@ -236,6 +236,50 @@ export function useAnalyzer<T extends typeof Module>(value: string | T) {
 }
 
 /**
+ * Get multiple analysis modules from within a Guide section.
+ *
+ * # Example
+ *
+ * ```
+ * import BrewCDR from 'analysis/retail/monk/brewmaster/modules/core/BrewCDR';
+ * import PurifyingBrew from 'analysis/retail/monk/brewmaster/modules/spells/PurifyingBrew';
+ *
+ * function MySection() {
+ *   const analyzers = useAnalyzer([BrewCDR, PurifyingBrew]);
+ *   // ...
+ * }
+ *
+ * // ... later, in the Guide component
+ *
+ * function Guide(props) {
+ *   return (
+ *    // ...
+ *    <MySection />
+ *    // ...
+ *   )
+ * }
+ * ```
+ */
+export function useAnalyzers<T extends typeof Module>(moduleTypes: T[]): InstanceType<T>[];
+export function useAnalyzers(moduleKeys: string[]): Module[];
+export function useAnalyzers<T extends typeof Module>(values: (string | T)[]) {
+  const ctx = useContext(GuideContext);
+  return useMemo(
+    () =>
+      values.map((value) => {
+        if (typeof value === 'string') {
+          return ctx.modules[value];
+        } else {
+          return Object.values(ctx.modules).find((module) => module instanceof value) as
+            | InstanceType<T>
+            | undefined;
+        }
+      }),
+    [values, ctx],
+  );
+}
+
+/**
  * The overall guide container. You will never need this, it is used by the WoWA
  * core to hold your `Guide` component.
  */


### PR DESCRIPTION
add SuggestionSection that can render the
suggestions returned by any provided module
definitions. for instance, giving this section
the FoodChecker and WeaponEnhancementChecker
modules as props will cause it to render
suggestions for the selected player having a
food buff when the fight started.

![image](https://user-images.githubusercontent.com/1672786/202074774-3b603531-0250-434e-8343-89c74d61666b.png)

