### PR TITLE
[Preservation] Add essence burst module

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -1,9 +1,10 @@
 import { change, date } from 'common/changelog';
 import { TALENTS_EVOKER } from 'common/TALENTS';
-import { Tyndi, Vohrr } from 'CONTRIBUTORS';
+import { Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2022, 11, 22), <>Added <SpellLink id={TALENTS_EVOKER.ESSENCE_BURST_TALENT}/> module</>, Trevor),
   change(date(2022, 11, 21), 'Updated contributor and support status for Preservation', Vohrr),
   change(date(2022, 11, 18), <>Added <SpellLink id={TALENTS_EVOKER.CALL_OF_YSERA_TALENT.id}/> module.</>, Vohrr),
   change(date(2022, 11, 16), <>Added <SpellLink id={TALENTS_EVOKER.GRACE_PERIOD_TALENT.id}/> module</>, Vohrr),

--- a/src/analysis/retail/evoker/preservation/CONFIG.tsx
+++ b/src/analysis/retail/evoker/preservation/CONFIG.tsx
@@ -1,4 +1,4 @@
-import { Tyndi, Vohrr } from 'CONTRIBUTORS';
+import { Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 
@@ -6,7 +6,7 @@ import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Tyndi, Vohrr],
+  contributors: [Trevor, Tyndi, Vohrr],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
   patchCompatibility: '10.0.2',

--- a/src/analysis/retail/evoker/preservation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/preservation/CombatLogParser.ts
@@ -21,6 +21,7 @@ import EssenceTracker from './modules/features/EssenceTracker';
 import GracePeriod from './modules/talents/GracePeriod';
 import Reversion from './modules/talents/Reversion';
 import CallOfYsera from './modules/talents/CallOfYsera';
+import EssenceBurst from './modules/talents/EssenceBurst';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -55,6 +56,7 @@ class CombatLogParser extends CoreCombatLogParser {
     gracePeriod: GracePeriod,
     reversion: Reversion,
     callOfYsera: CallOfYsera,
+    essenceBurst: EssenceBurst,
   };
 }
 

--- a/src/analysis/retail/evoker/preservation/constants.ts
+++ b/src/analysis/retail/evoker/preservation/constants.ts
@@ -1,3 +1,16 @@
+export const SPELL_COLORS = {
+  ECHO: '#fffb0a',
+  TA_ECHO: '#6711ad',
+  REVERSION: '#ffbb78',
+  LIVING_FLAME: '#880e0b',
+  VERDANT_EMBRACE: '#96ffd8',
+  DREAM_BREATH: '#c49c94',
+  SPIRITBLOOM: '#fe85ff',
+  EMERALD_BLOSSOM: '#c1e1c1',
+  FLUTTERING_SEEDLING: '#50c878',
+  DISINTEGRATE: '#008080',
+};
+
 //hots
 export const ECHO_BASE_DURATION = 15000;
 export const REVERSION_BASE_DURATION = 12000;

--- a/src/analysis/retail/evoker/preservation/modules/features/Checklist/Component.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/features/Checklist/Component.tsx
@@ -56,6 +56,21 @@ const PreservationEvokerChecklist = ({ combatant, castEfficiency, thresholds }: 
           />
         )}
       </Rule>
+      <Rule
+        name="Use your procs and short CDs"
+        description="Make sure to use your procs and spells at the correct time."
+      >
+        {combatant.hasTalent(TALENTS_EVOKER.ESSENCE_BURST_TALENT) && (
+          <Requirement
+            name={
+              <>
+                <SpellLink id={TALENTS_EVOKER.ESSENCE_BURST_TALENT.id} /> wasted stacks
+              </>
+            }
+            thresholds={thresholds.essenceBurst}
+          />
+        )}
+      </Rule>
       <PreparationRule thresholds={thresholds} />
     </Checklist>
   );

--- a/src/analysis/retail/evoker/preservation/modules/features/Checklist/Module.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/features/Checklist/Module.tsx
@@ -6,6 +6,7 @@ import ManaValues from 'parser/shared/modules/ManaValues';
 import CastEfficiency from 'parser/shared/modules/CastEfficiency';
 import Component from './Component';
 import EssenceDetails from '../EssenceDetails';
+import EssenceBurst from '../../talents/EssenceBurst';
 
 class Checklist extends BaseChecklist {
   static dependencies = {
@@ -16,6 +17,7 @@ class Checklist extends BaseChecklist {
     preparationRuleAnalyzer: PreparationRuleAnalyzer,
     dreamBreath: DreamBreath,
     essenceDetails: EssenceDetails,
+    essenceBurst: EssenceBurst,
   };
 
   protected combatants!: Combatants;
@@ -23,6 +25,7 @@ class Checklist extends BaseChecklist {
   protected manaValues!: ManaValues;
   protected preparationRuleAnalyzer!: PreparationRuleAnalyzer;
   protected dreamBreath!: DreamBreath;
+  protected essenceBurst!: EssenceBurst;
   protected essenceDetails!: EssenceDetails;
 
   render() {
@@ -35,6 +38,7 @@ class Checklist extends BaseChecklist {
           manaLeft: this.manaValues.suggestionThresholds,
           dreamBreath: this.dreamBreath.suggestionThresholds,
           essenceDetails: this.essenceDetails.suggestionThresholds,
+          essenceBurst: this.essenceBurst.suggestionThresholds,
         }}
       />
     );

--- a/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
@@ -49,7 +49,6 @@ class EssenceBurst extends Analyzer {
     } else if (event.type === EventType.RemoveBuff) {
       this.totalExpired += 1;
     } else {
-      console.log(`Buff expired at ${this.owner.formatTimestamp(event.timestamp)}`);
       this.totalExpired += (event as RemoveBuffStackEvent).stack;
     }
   }

--- a/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
@@ -97,7 +97,7 @@ class EssenceBurst extends Analyzer {
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
       suggest(
         <>
-          You are wasting <SpellLink id={TALENTS_EVOKER.ESSENCE_BURST_TALENT.id} /> stacks
+          Try to avoid wasting <SpellLink id={TALENTS_EVOKER.ESSENCE_BURST_TALENT.id} /> stacks.
         </>,
       )
         .icon(TALENTS_EVOKER.ESSENCE_BURST_TALENT.icon)

--- a/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
@@ -47,7 +47,6 @@ class EssenceBurst extends Analyzer {
       this.essenceSaved += ESSENCE_COSTS[spellName];
       this.consumptionCount[spellName] += 1;
     } else if (event.type === EventType.RemoveBuff) {
-      console.log(`Buff expired at ${this.owner.formatTimestamp(event.timestamp)}`);
       this.totalExpired += 1;
     } else {
       console.log(`Buff expired at ${this.owner.formatTimestamp(event.timestamp)}`);

--- a/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
@@ -1,0 +1,133 @@
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import Events, { EventType, RemoveBuffEvent, RemoveBuffStackEvent } from 'parser/core/Events';
+import { getEssenceBurstConsumeAbility } from '../../normalizers/CastLinkNormalizer';
+import { TALENTS_EVOKER } from 'common/TALENTS';
+import { SPELL_COLORS } from 'analysis/retail/evoker/preservation/constants';
+import DonutChart from 'parser/ui/DonutChart';
+import { SpellLink } from 'interface';
+import { t } from '@lingui/macro';
+
+const ESSENCE_COSTS: { [name: string]: number } = {
+  'Emerald Blossom': 3,
+  Echo: 2,
+  Disintegrate: 3,
+};
+
+class EssenceBurst extends Analyzer {
+  totalConsumed: number = 0;
+  totalExpired: number = 0;
+  essenceSaved: number = 0;
+  consumptionCount: { [name: string]: number } = { 'Emerald Blossom': 0, Echo: 0, Disintegrate: 0 };
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_EVOKER.ESSENCE_BURST_TALENT);
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.ESSENCE_BURST_BUFF),
+      this.onBuffRemove,
+    );
+    if (this.selectedCombatant.hasTalent(TALENTS_EVOKER.ESSENCE_ATTUNEMENT_TALENT)) {
+      this.addEventListener(
+        Events.removebuffstack.by(SELECTED_PLAYER).spell(SPELLS.ESSENCE_BURST_BUFF),
+        this.onBuffRemove,
+      );
+    }
+  }
+
+  onBuffRemove(event: RemoveBuffEvent | RemoveBuffStackEvent) {
+    const consumeAbility = getEssenceBurstConsumeAbility(event);
+    if (consumeAbility) {
+      const spellName = consumeAbility.ability.name;
+      this.totalConsumed += 1;
+      this.essenceSaved += ESSENCE_COSTS[spellName];
+      this.consumptionCount[spellName] += 1;
+    } else if (event.type === EventType.RemoveBuff) {
+      console.log(`Buff expired at ${this.owner.formatTimestamp(event.timestamp)}`);
+      this.totalExpired += 1;
+    } else {
+      console.log(`Buff expired at ${this.owner.formatTimestamp(event.timestamp)}`);
+      this.totalExpired += (event as RemoveBuffStackEvent).stack;
+    }
+  }
+
+  renderDonutChart() {
+    const items = [
+      {
+        color: SPELL_COLORS.DISINTEGRATE,
+        label: 'Disintegrate',
+        spellId: SPELLS.DISINTEGRATE.id,
+        value: this.consumptionCount['Disintegrate'],
+        valueTooltip: this.consumptionCount['Disintegrate'],
+      },
+      {
+        color: SPELL_COLORS.EMERALD_BLOSSOM,
+        label: 'Emerald Blossom',
+        spellId: SPELLS.EMERALD_BLOSSOM.id,
+        value: this.consumptionCount['Emerald Blossom'],
+        valueTooltip: this.consumptionCount['Emerald Blossom'],
+      },
+      {
+        color: SPELL_COLORS.ECHO,
+        label: 'Echo',
+        spellId: TALENTS_EVOKER.ECHO_TALENT.id,
+        value: this.consumptionCount['Echo'],
+        valueTooltip: this.consumptionCount['Echo'],
+      },
+    ].filter((item) => {
+      return item.value > 0;
+    });
+    return <DonutChart items={items} />;
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.totalExpired,
+      isGreaterThan: {
+        major: 0,
+      },
+      style: ThresholdStyle.NUMBER,
+    };
+  }
+
+  suggestions(when: When) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
+      suggest(
+        <>
+          You are wasting <SpellLink id={TALENTS_EVOKER.ESSENCE_BURST_TALENT.id} /> stacks
+        </>,
+      )
+        .icon(TALENTS_EVOKER.ESSENCE_BURST_TALENT.icon)
+        .actual(
+          `${actual} ${t({
+            id: 'evoker.preservation.suggestions.essenceBurst.wastedStacks',
+            message: ` wasted Essence Burst stacks`,
+          })}`,
+        )
+        .recommended(`${recommended} wasted stacks recommended`),
+    );
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(13)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+      >
+        <div className="pad">
+          <label>
+            <SpellLink id={TALENTS_EVOKER.ESSENCE_BURST_TALENT} /> consumption by spell
+          </label>
+          {this.renderDonutChart()}
+        </div>
+      </Statistic>
+    );
+  }
+}
+
+export default EssenceBurst;

--- a/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
@@ -5,10 +5,14 @@ import { TALENTS_EVOKER } from 'common/TALENTS';
 import {
   AbilityEvent,
   ApplyBuffEvent,
+  CastEvent,
   EventType,
+  GetRelatedEvents,
   HasRelatedEvent,
   HealEvent,
   RefreshBuffEvent,
+  RemoveBuffEvent,
+  RemoveBuffStackEvent,
 } from 'parser/core/Events';
 
 export const FROM_HARDCAST = 'FromHardcast';
@@ -18,6 +22,7 @@ export const ECHO = 'Echo';
 export const DREAM_BREATH_CALL_OF_YSERA = 'DreamBreathCallOfYsera';
 export const DREAM_BREATH_CALL_OF_YSERA_HOT = 'DreamBreathCallOfYseraHoT';
 export const LIVING_FLAME_CALL_OF_YSERA = 'LivingFlameCallOfYsera';
+export const ESSENCE_BURST_CONSUME = 'EssenceBurstConsumption'; // link essence cast to removing the essence burst buff
 
 const CAST_BUFFER_MS = 100;
 /*
@@ -132,6 +137,25 @@ const EVENT_LINKS: EventLink[] = [
       return c.hasTalent(TALENTS_EVOKER.CALL_OF_YSERA_TALENT);
     },
   },
+  // link essence burst remove to a cast to track expirations vs consumptions
+  {
+    linkRelation: ESSENCE_BURST_CONSUME,
+    reverseLinkRelation: ESSENCE_BURST_CONSUME,
+    linkingEventId: SPELLS.ESSENCE_BURST_BUFF.id,
+    linkingEventType: [EventType.RemoveBuff, EventType.RemoveBuffStack],
+    referencedEventId: [
+      SPELLS.EMERALD_BLOSSOM_CAST.id,
+      SPELLS.DISINTEGRATE.id,
+      TALENTS_EVOKER.ECHO_TALENT.id,
+    ],
+    referencedEventType: EventType.Cast,
+    anyTarget: true,
+    forwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: CAST_BUFFER_MS,
+    isActive(c) {
+      return c.hasTalent(TALENTS_EVOKER.ESSENCE_BURST_TALENT.id);
+    },
+  },
 ];
 
 /**
@@ -170,6 +194,15 @@ export function isFromLivingFlameCallOfYsera(event: HealEvent) {
   //   return false;
   // }
   return HasRelatedEvent(event, LIVING_FLAME_CALL_OF_YSERA);
+}
+
+export function getEssenceBurstConsumeAbility(
+  event: RemoveBuffEvent | RemoveBuffStackEvent,
+): null | CastEvent {
+  if (!HasRelatedEvent(event, ESSENCE_BURST_CONSUME)) {
+    return null;
+  }
+  return GetRelatedEvents(event, ESSENCE_BURST_CONSUME)[0] as CastEvent;
 }
 
 export default CastLinkNormalizer;

--- a/src/common/SPELLS/evoker.ts
+++ b/src/common/SPELLS/evoker.ts
@@ -137,6 +137,11 @@ const spells = spellIndexableList({
     essenceCost: 3,
     manaCost: 12000,
   },
+  ESSENCE_BURST_BUFF: {
+    id: 369299,
+    name: 'Essence Burst',
+    icon: 'ability_evoker_essenceburst',
+  },
   PANACEA_HEAL: {
     id: 387763,
     name: 'Panacea',


### PR DESCRIPTION
Essence Burst is a buff that makes the next Disintegrate, Emerald Blossom, or Echo free (stacks up to 2 times if you have Essence Attunement)

This module tracks to make sure player is not wasting buffs and adds a suggestion if they are.

Checklist stats
![image](https://user-images.githubusercontent.com/11250934/203464282-1b95a678-df28-478a-bf77-b32e56454d2b.png)
![image](https://user-images.githubusercontent.com/11250934/203464292-865ee6dc-2b7b-435b-b506-8ad92d6d3c4b.png)

Buff consumption breakdown in stats tab
![image](https://user-images.githubusercontent.com/11250934/203464324-6a25cf32-464f-4262-aef1-2e9139af85e5.png)
