### PR TITLE
[Priest] Improving Shadow Priest Proc Section

### DIFF
--- a/src/analysis/retail/priest/shadow/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/shadow/CHANGELOG.tsx
@@ -8,7 +8,7 @@ import { SpellLink } from 'interface';
 import { ResourceLink } from 'interface';
 
 export default [
-  change(date(2022, 11, 29), <>Improved checklist section and fixed some missing icons for the procs </>,DoxAshe),
+  change(date(2022, 11, 29), <>Improved proc checklist section and fixed some missing icons for the procs </>,DoxAshe),
   change(date(2022, 11, 24), <>Added checklist section and suggestions for using procs </>,DoxAshe),
   change(date(2022, 11, 15), <>Added support for new Dragonflight talents</>,DoxAshe),
   change(date(2022, 11, 6), <>Updated spells and talents for Dragonflight</>,DoxAshe),

--- a/src/analysis/retail/priest/shadow/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/shadow/CHANGELOG.tsx
@@ -8,6 +8,7 @@ import { SpellLink } from 'interface';
 import { ResourceLink } from 'interface';
 
 export default [
+  change(date(2022, 11, 29), <>Improved checklist section and fixed some missing icons for the procs </>,DoxAshe),
   change(date(2022, 11, 24), <>Added checklist section and suggestions for using procs </>,DoxAshe),
   change(date(2022, 11, 15), <>Added support for new Dragonflight talents</>,DoxAshe),
   change(date(2022, 11, 6), <>Updated spells and talents for Dragonflight</>,DoxAshe),

--- a/src/analysis/retail/priest/shadow/modules/features/ShadowyInsight.tsx
+++ b/src/analysis/retail/priest/shadow/modules/features/ShadowyInsight.tsx
@@ -65,18 +65,18 @@ class ShadowyInsight extends Analyzer {
 
   get suggestionThresholds() {
     return {
-      actual: this.procsWasted / this.procsGained,
+      actual: this.procsWasted,
       isGreaterThan: {
         minor: 0,
-        average: 0,
-        major: 0.1,
+        average: 0.5,
+        major: 1.1,
       },
-      style: ThresholdStyle.PERCENTAGE,
+      style: ThresholdStyle.NUMBER,
     };
   }
 
   suggestions(when: When) {
-    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
+    when(this.suggestionThresholds).addSuggestion((suggest) =>
       suggest(
         <>
           You wasted {this.procsWasted} out of {this.procsGained}{' '}
@@ -86,11 +86,11 @@ class ShadowyInsight extends Analyzer {
         .icon(SPELLS.SHADOWY_INSIGHT.icon)
         .actual(
           t({
-            id: 'priest.shadow.suggestions.darkThoughts.efficiency',
+            id: 'priest.shadow.suggestions.shadowyInsight.efficiency',
             message: `You wasted ${this.procsWasted} out of ${this.procsGained} Shadowy Insight procs.`,
           }),
         )
-        .recommended(`${recommended} is recommended.`),
+        .recommended(`0 is recommended.`),
     );
   }
 

--- a/src/analysis/retail/priest/shadow/modules/talents/Deathspeaker.tsx
+++ b/src/analysis/retail/priest/shadow/modules/talents/Deathspeaker.tsx
@@ -1,5 +1,4 @@
 import { t } from '@lingui/macro';
-import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/priest';
 import { SpellLink } from 'interface';
@@ -63,21 +62,21 @@ class Deathspeaker extends Analyzer {
 
   get suggestionThresholds() {
     return {
-      actual: this.procsWasted / this.procsGained,
+      actual: this.procsWasted,
       isGreaterThan: {
         minor: 0,
-        average: 0,
-        major: 0.05,
+        average: 0.5,
+        major: 1.1,
       },
-      style: ThresholdStyle.PERCENTAGE,
+      style: ThresholdStyle.NUMBER,
     };
   }
 
   suggestions(when: When) {
-    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
+    when(this.suggestionThresholds).addSuggestion((suggest) =>
       suggest(
         <>
-          You wasted {formatPercentage(actual)}% of{' '}
+          You wasted {this.procsWasted} out of {this.procsGained}{' '}
           <SpellLink id={TALENTS.DEATHSPEAKER_TALENT.id} /> procs.{' '}
         </>,
       )
@@ -85,10 +84,10 @@ class Deathspeaker extends Analyzer {
         .actual(
           t({
             id: 'priest.shadow.suggestions.deathspeaker.efficiency',
-            message: `Wasted ${formatPercentage(actual)}% of DeathSpeaker procs.`,
+            message: `You wasted ${this.procsWasted} out of ${this.procsGained} DeathSpeaker procs.`,
           }),
         )
-        .recommended(`<${formatPercentage(recommended)}% is recommended.`),
+        .recommended(`<0 is recommended.`),
     );
   }
 

--- a/src/analysis/retail/priest/shadow/modules/talents/MindDevourer.tsx
+++ b/src/analysis/retail/priest/shadow/modules/talents/MindDevourer.tsx
@@ -1,5 +1,4 @@
 import { t } from '@lingui/macro';
-import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/priest';
 import { SpellLink } from 'interface';
@@ -57,21 +56,21 @@ class MindDevourer extends Analyzer {
 
   get suggestionThresholds() {
     return {
-      actual: this.procsWasted / this.procsGained,
+      actual: this.procsWasted,
       isGreaterThan: {
         minor: 0,
-        average: 0,
-        major: 0.05,
+        average: 0.5,
+        major: 1.1,
       },
-      style: ThresholdStyle.PERCENTAGE,
+      style: ThresholdStyle.NUMBER,
     };
   }
 
   suggestions(when: When) {
-    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
+    when(this.suggestionThresholds).addSuggestion((suggest) =>
       suggest(
         <>
-          You wasted {formatPercentage(actual)}% of{' '}
+          You wasted {this.procsWasted} out of {this.procsGained}{' '}
           <SpellLink id={TALENTS.MIND_DEVOURER_TALENT.id} /> procs.{' '}
         </>,
       )
@@ -79,10 +78,10 @@ class MindDevourer extends Analyzer {
         .actual(
           t({
             id: 'priest.shadow.suggestions.mindDevourer.efficiency',
-            message: `Wasted ${formatPercentage(actual)}% of Mind Devourer procs.`,
+            message: `You wasted ${this.procsWasted} out of ${this.procsGained} of Mind Devourer procs.`,
           }),
         )
-        .recommended(`<${formatPercentage(recommended)}% is recommended.`),
+        .recommended(`0 is recommended.`),
     );
   }
 

--- a/src/analysis/retail/priest/shadow/modules/talents/SurgeOfDarkness.tsx
+++ b/src/analysis/retail/priest/shadow/modules/talents/SurgeOfDarkness.tsx
@@ -81,22 +81,22 @@ class SurgeOfDarkness extends Analyzer {
 
   get suggestionThresholds() {
     return {
-      actual: this.procsWasted / this.procsGained,
+      actual: this.procsWasted,
       isGreaterThan: {
         minor: 0,
-        average: 0,
-        major: 0.1,
+        average: 0.5,
+        major: 1.1,
       },
-      style: ThresholdStyle.PERCENTAGE,
+      style: ThresholdStyle.NUMBER,
     };
   }
 
   suggestions(when: When) {
-    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
+    when(this.suggestionThresholds).addSuggestion((suggest) =>
       suggest(
         <>
           You wasted {this.procsWasted} out of {this.procsGained}{' '}
-          <SpellLink id={TALENTS.SURGE_OF_DARKNESS_TALENT.id} /> procs.
+          <SpellLink id={SPELLS.SURGE_OF_DARKNESS_TALENT_BUFF.id} /> procs.
         </>,
       )
         .icon(TALENTS.SURGE_OF_DARKNESS_TALENT.icon)
@@ -106,7 +106,7 @@ class SurgeOfDarkness extends Analyzer {
             message: `You wasted ${this.procsWasted} out of ${this.procsGained} Surge of Darkness procs.`,
           }),
         )
-        .recommended(`${recommended} is recommended.`),
+        .recommended(`0 is recommended.`),
     );
   }
 

--- a/src/analysis/retail/priest/shadow/modules/talents/UnfurlingDarkness.tsx
+++ b/src/analysis/retail/priest/shadow/modules/talents/UnfurlingDarkness.tsx
@@ -1,5 +1,4 @@
 import { t } from '@lingui/macro';
-import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/priest';
 import { SpellLink } from 'interface';
@@ -57,34 +56,32 @@ class UnfurlingDarkness extends Analyzer {
 
   get suggestionThresholds() {
     return {
-      actual: this.procsWasted / this.procsGained,
+      actual: this.procsWasted,
       isGreaterThan: {
         minor: 0,
-        average: 0,
-        major: 0.05,
+        average: 0.5,
+        major: 1.1,
       },
-      style: ThresholdStyle.PERCENTAGE,
+      style: ThresholdStyle.NUMBER,
     };
   }
 
   suggestions(when: When) {
-    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
+    when(this.suggestionThresholds).addSuggestion((suggest) =>
       suggest(
         <>
-          You wasted {formatPercentage(actual)}% of{' '}
+          You wasted {this.procsWasted} out of {this.procsGained}{' '}
           <SpellLink id={TALENTS.UNFURLING_DARKNESS_TALENT.id} /> procs.{' '}
         </>,
       )
-        .icon(TALENTS.UNFURLING_DARKNESS_TALENT.icon)
+        .icon(SPELLS.UNFURLING_DARKNESS_BUFF.icon)
         .actual(
           t({
             id: 'priest.shadow.suggestions.unfurlingDarkness.efficiency',
-            message: `Wasted ${formatPercentage(
-              actual,
-            )}% of Unfurling Darkness procs. If you're not getting enough uses from Unfurling Darkness, you'll likely benefit more from using a different talent.`,
+            message: `You wasted ${this.procsWasted} out of ${this.procsGained} Unfurling Darkness procs.`,
           }),
         )
-        .recommended(`<${formatPercentage(recommended)}% is recommended.`),
+        .recommended(`0 is recommended.`),
     );
   }
 

--- a/src/localization/en/messages.json
+++ b/src/localization/en/messages.json
@@ -865,7 +865,7 @@
   "priest.shadow.suggestions.shadowWordPain.shadowWordPainOverwrite": "{actual} Shadow Word Pain Overwrites",
   "priest.shadow.suggestions.shadowWordPain.uptime": "{0}% Shadow Word: Pain uptime",
   "priest.shadow.suggestions.surgeofdarkness.efficiency": "You wasted {0} out of {1} Surge of Darkness procs.",
-  "priest.shadow.suggestions.unfurlingDarkness.efficiency": "Wasted {0}% of Unfurling Darkness procs. If you're not getting enough uses from Unfurling Darkness, you'll likely benefit more from using a different talent.",
+  "priest.shadow.suggestions.unfurlingDarkness.efficiency": "You Wasted {0} of Unfurling Darkness procs.",
   "priest.shadow.suggestions.vampiricTouch.uptime": "{0}% Vampiric Touch uptime",
   "priest.shadow.suggestions.voidBolt.efficiency": "You had {0} cast(s) while Void Bolt was off cooldown during Voidform.",
   "priest.shadow.suggestions.voidTorrent.secondsLost": "Lost {0} seconds of Void Torrent.",


### PR DESCRIPTION
- Changed threshold style from percent to number
- Fixed missing Icons in proc suggestions

I think seeing the exact number of missed procs is more useful than a percentage for these abilities.

![ShadowPriestProcsImproved](https://user-images.githubusercontent.com/103148620/204613849-649a3196-37ef-4485-b0c8-88fa46db693b.PNG)
