### PR TITLE
[Evoker] Fix empty essence burst chart

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import { Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
-  change(date(2022, 12, 3), <>Fix empty <SpellLink id={TALENTS_EVOKER.ESSENCE_BURST_TALENT.id}/> chart when player never gains the buff</>, Trevor),
+  change(date(2022, 12, 3), <>Fixed empty <SpellLink id={TALENTS_EVOKER.ESSENCE_BURST_TALENT.id}/> chart when player never gains the buff</>, Trevor),
   change(date(2022, 11, 29), <>Added <SpellLink id={SPELLS.EMERALD_BLOSSOM.id}/> module</>, Trevor),
   change(date(2022, 11, 27), <>Add modules for <SpellLink id={TALENTS_EVOKER.ECHO_TALENT.id}/> and <SpellLink id={TALENTS_EVOKER.RESONATING_SPHERE_TALENT.id}/></>, Trevor),
   change(date(2022, 11, 22), 'Cleanup Preservation Evoker files', Trevor),

--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2022, 12, 3), <>Fix empty <SpellLink id={TALENTS_EVOKER.ESSENCE_BURST_TALENT.id}/> chart when player never gains the buff</>, Trevor),
   change(date(2022, 11, 29), <>Added <SpellLink id={SPELLS.EMERALD_BLOSSOM.id}/> module</>, Trevor),
   change(date(2022, 11, 27), <>Add modules for <SpellLink id={TALENTS_EVOKER.ECHO_TALENT.id}/> and <SpellLink id={TALENTS_EVOKER.RESONATING_SPHERE_TALENT.id}/></>, Trevor),
   change(date(2022, 11, 22), 'Cleanup Preservation Evoker files', Trevor),

--- a/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
@@ -112,7 +112,7 @@ class EssenceBurst extends Analyzer {
 
   statistic() {
     const donutChart = this.renderDonutChart();
-    return donutChart ? (
+    return (
       <Statistic
         position={STATISTIC_ORDER.OPTIONAL(13)}
         size="flexible"
@@ -122,10 +122,17 @@ class EssenceBurst extends Analyzer {
           <label>
             <SpellLink id={TALENTS_EVOKER.ESSENCE_BURST_TALENT} /> consumption by spell
           </label>
-          {donutChart}
+          {donutChart ? (
+            donutChart
+          ) : (
+            <small>
+              You gained no <SpellLink id={TALENTS_EVOKER.ESSENCE_BURST_TALENT.id} /> buffs during
+              the encounter
+            </small>
+          )}
         </div>
       </Statistic>
-    ) : null;
+    );
   }
 }
 

--- a/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
@@ -79,7 +79,7 @@ class EssenceBurst extends Analyzer {
     ].filter((item) => {
       return item.value > 0;
     });
-    return <DonutChart items={items} />;
+    return items.length > 0 ? <DonutChart items={items} /> : null;
   }
 
   get suggestionThresholds() {
@@ -111,7 +111,8 @@ class EssenceBurst extends Analyzer {
   }
 
   statistic() {
-    return (
+    const donutChart = this.renderDonutChart();
+    return donutChart ? (
       <Statistic
         position={STATISTIC_ORDER.OPTIONAL(13)}
         size="flexible"
@@ -121,10 +122,10 @@ class EssenceBurst extends Analyzer {
           <label>
             <SpellLink id={TALENTS_EVOKER.ESSENCE_BURST_TALENT} /> consumption by spell
           </label>
-          {this.renderDonutChart()}
+          {donutChart}
         </div>
       </Statistic>
-    );
+    ) : null;
   }
 }
 


### PR DESCRIPTION
If a player talented into essence burst, but never gained the buff, then the chart would be empty

Before:
![image](https://user-images.githubusercontent.com/11250934/205433632-d2a23f1a-9017-437f-95a9-9d461d9949d6.png)
After:
![image](https://user-images.githubusercontent.com/11250934/205433616-245ef50b-2baf-40bd-9868-457dcc4859b8.png)
