### PR TITLE
[Preservation] Add checklist and dream flight module

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2022, 12, 4), <>Add <SpellLink id={TALENTS_EVOKER.DREAM_FLIGHT_TALENT.id}/> module and update checklist</>, Trevor),
   change(date(2022, 12, 4), <>Add <SpellLink id={TALENTS_EVOKER.RENEWING_BREATH_TALENT.id}/> module</>, Trevor),
   change(date(2022, 12, 4), <>Added module for <SpellLink id={TALENTS_EVOKER.FIELD_OF_DREAMS_TALENT.id}/></>, Trevor),
   change(date(2022, 12, 4), <>Add suggestion for <SpellLink id={TALENTS_EVOKER.ESSENCE_BURST_TALENT.id}/> based on buffs consumed</>, Trevor),

--- a/src/analysis/retail/evoker/preservation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/preservation/CombatLogParser.ts
@@ -27,6 +27,7 @@ import Echo from './modules/talents/Echo';
 import ResonatingSphere from './modules/talents/ResonatingSphere';
 import RenewingBreath from './modules/talents/RenewingBreath';
 import FieldOfDreams from './modules/talents/FieldOfDreams';
+import DreamFlight from './modules/talents/DreamFlight';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -57,6 +58,7 @@ class CombatLogParser extends CoreCombatLogParser {
     //talents
     echo: Echo,
     dreamBreath: DreamBreath,
+    dreamFlight: DreamFlight,
     livingFlame: LivingFlame,
     masteryEffectiveness: MasteryEffectiveness,
     spiritBloom: Spiritbloom,

--- a/src/analysis/retail/evoker/preservation/modules/features/Abilities.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/features/Abilities.tsx
@@ -17,6 +17,9 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         enabled: combatant.hasTalent(TALENTS.REVERSION_TALENT.id),
+        castEfficiency: {
+          suggestion: true,
+        },
       },
       {
         spell: SPELLS.DREAM_BREATH_CAST.id,
@@ -25,6 +28,9 @@ class Abilities extends CoreAbilities {
         cooldown: 25,
         gcd: {
           base: 1500,
+        },
+        castEfficiency: {
+          suggestion: true,
         },
       },
       {
@@ -46,13 +52,16 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(TALENTS.TIME_DILATION_TALENT.id),
       },
       {
-        spell: TALENTS.SPIRITBLOOM_TALENT.id,
+        spell: SPELLS.SPIRITBLOOM_CAST.id,
         category: SPELL_CATEGORY.ROTATIONAL_AOE,
         cooldown: 30,
         gcd: {
           base: 1500,
         },
         enabled: combatant.hasTalent(TALENTS.SPIRITBLOOM_TALENT.id),
+        castEfficiency: {
+          suggestion: true,
+        },
       },
       {
         spell: TALENTS.TEMPORAL_ANOMALY_TALENT.id,
@@ -90,6 +99,9 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         enabled: combatant.hasTalent(TALENTS.DREAM_FLIGHT_TALENT.id),
+        castEfficiency: {
+          suggestion: true,
+        },
       },
       {
         spell: TALENTS.STASIS_TALENT.id,

--- a/src/analysis/retail/evoker/preservation/modules/features/Checklist/Component.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/features/Checklist/Component.tsx
@@ -33,6 +33,31 @@ const PreservationEvokerChecklist = ({ combatant, castEfficiency, thresholds }: 
         <Requirement name="Essence Wasted" thresholds={thresholds.essenceDetails} />
       </Rule>
       <Rule
+        name="Use core abilities as often as possible"
+        description="Aim to keep core rotational abilities on cooldown to maximize healing"
+      >
+        <AbilityRequirement spell={SPELLS.DREAM_BREATH_CAST.id} />
+        {combatant.hasTalent(TALENTS_EVOKER.SPIRITBLOOM_TALENT) && (
+          <AbilityRequirement spell={SPELLS.SPIRITBLOOM_CAST.id} />
+        )}
+        {combatant.hasTalent(TALENTS_EVOKER.REVERSION_TALENT) && (
+          <AbilityRequirement spell={TALENTS_EVOKER.REVERSION_TALENT.id} />
+        )}
+      </Rule>
+      <Rule
+        name="Use your cooldowns effectively"
+        description="Try to use your powerful raid cooldowns effectively"
+      >
+        <Requirement
+          name={
+            <>
+              % of group hit with <SpellLink id={TALENTS_EVOKER.DREAM_FLIGHT_TALENT.id} />
+            </>
+          }
+          thresholds={thresholds.dreamFlight}
+        />
+      </Rule>
+      <Rule
         name="Use rotational spells based on talent selection"
         description={
           <>
@@ -52,30 +77,6 @@ const PreservationEvokerChecklist = ({ combatant, castEfficiency, thresholds }: 
             }
             thresholds={thresholds.essenceBurstBuffApplies}
           ></Requirement>
-        )}
-      </Rule>
-      <Rule
-        name="Use your empowered spells wisely"
-        description={
-          <>
-            Empowered spells like <SpellLink id={TALENTS_EVOKER.DREAM_BREATH_TALENT.id} /> make up a
-            large portion of your healing. Be sure to use them often while keeping your overheal
-            low.
-          </>
-        }
-      >
-        {combatant.hasTalent(TALENTS_EVOKER.DREAM_BREATH_TALENT.id) && (
-          <AbilityRequirement spell={SPELLS.DREAM_BREATH_CAST.id} />
-        )}
-        {combatant.hasTalent(TALENTS_EVOKER.DREAM_BREATH_TALENT.id) && (
-          <Requirement
-            name={
-              <>
-                <SpellLink id={TALENTS_EVOKER.DREAM_BREATH_TALENT.id} /> % Overheal
-              </>
-            }
-            thresholds={thresholds.dreamBreath}
-          />
         )}
       </Rule>
       <Rule

--- a/src/analysis/retail/evoker/preservation/modules/features/Checklist/Component.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/features/Checklist/Component.tsx
@@ -48,14 +48,16 @@ const PreservationEvokerChecklist = ({ combatant, castEfficiency, thresholds }: 
         name="Use your cooldowns effectively"
         description="Try to use your powerful raid cooldowns effectively"
       >
-        <Requirement
-          name={
-            <>
-              % of group hit with <SpellLink id={TALENTS_EVOKER.DREAM_FLIGHT_TALENT.id} />
-            </>
-          }
-          thresholds={thresholds.dreamFlight}
-        />
+        {combatant.hasTalent(TALENTS_EVOKER.DREAM_FLIGHT_TALENT) && (
+          <Requirement
+            name={
+              <>
+                % of group hit with <SpellLink id={TALENTS_EVOKER.DREAM_FLIGHT_TALENT.id} />
+              </>
+            }
+            thresholds={thresholds.dreamFlight}
+          />
+        )}
       </Rule>
       <Rule
         name="Use rotational spells based on talent selection"

--- a/src/analysis/retail/evoker/preservation/modules/features/Checklist/Module.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/features/Checklist/Module.tsx
@@ -8,6 +8,7 @@ import Component from './Component';
 import EssenceDetails from '../EssenceDetails';
 import EssenceBurst from '../../talents/EssenceBurst';
 import EmeraldBlossom from '../../talents/EmeraldBlossom';
+import DreamFlight from '../../talents/DreamFlight';
 
 class Checklist extends BaseChecklist {
   static dependencies = {
@@ -17,6 +18,7 @@ class Checklist extends BaseChecklist {
     manaValues: ManaValues,
     preparationRuleAnalyzer: PreparationRuleAnalyzer,
     dreamBreath: DreamBreath,
+    dreamFlight: DreamFlight,
     essenceDetails: EssenceDetails,
     essenceBurst: EssenceBurst,
     emeraldBlossom: EmeraldBlossom,
@@ -27,6 +29,7 @@ class Checklist extends BaseChecklist {
   protected manaValues!: ManaValues;
   protected preparationRuleAnalyzer!: PreparationRuleAnalyzer;
   protected dreamBreath!: DreamBreath;
+  protected dreamFlight!: DreamFlight;
   protected emeraldBlossom!: EmeraldBlossom;
   protected essenceBurst!: EssenceBurst;
   protected essenceDetails!: EssenceDetails;
@@ -40,6 +43,7 @@ class Checklist extends BaseChecklist {
           ...this.preparationRuleAnalyzer.thresholds,
           manaLeft: this.manaValues.suggestionThresholds,
           dreamBreath: this.dreamBreath.suggestionThresholds,
+          dreamFlight: this.dreamFlight.suggestionThresholds,
           emeraldBlossom: this.emeraldBlossom.suggestionThresholds,
           essenceDetails: this.essenceDetails.suggestionThresholds,
           essenceBurst: this.essenceBurst.suggestionThresholds,

--- a/src/analysis/retail/evoker/preservation/modules/talents/DreamFlight.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/DreamFlight.tsx
@@ -64,7 +64,7 @@ class DreamFlight extends Analyzer {
           targets.
         </>,
       )
-        .icon(SPELLS.DREAM_BREATH.icon)
+        .icon(TALENTS_EVOKER.DREAM_FLIGHT_TALENT.icon)
         .actual(
           `${formatPercentage(this.percentOfGroupHit, 2)} ${t({
             id: 'evoker.preservation.suggestions.dreamFlight.targetsHit',

--- a/src/analysis/retail/evoker/preservation/modules/talents/DreamFlight.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/DreamFlight.tsx
@@ -1,0 +1,79 @@
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { ApplyBuffEvent, CastEvent } from 'parser/core/Events';
+import { formatPercentage } from 'common/format';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import { t } from '@lingui/macro';
+import { SpellLink } from 'interface';
+import { TALENTS_EVOKER } from 'common/TALENTS';
+import Combatants from 'parser/shared/modules/Combatants';
+
+class DreamFlight extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+  protected combatants!: Combatants;
+  numCasts: number = 0;
+  numApply: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.DREAM_FLIGHT_HEAL),
+      this.onApply,
+    );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS_EVOKER.DREAM_FLIGHT_TALENT),
+      this.onCast,
+    );
+  }
+
+  onApply(event: ApplyBuffEvent) {
+    if (!this.combatants.getEntity(event)) {
+      return;
+    }
+    this.numApply += 1;
+  }
+
+  onCast(event: CastEvent) {
+    this.numCasts += 1;
+  }
+
+  get percentOfGroupHit() {
+    const averageHit = this.numApply / this.numCasts;
+    return averageHit / Object.keys(this.combatants.getEntities()).length;
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.percentOfGroupHit,
+      isLessThan: {
+        major: 0.5,
+        average: 0.6,
+        minor: 0.7,
+      },
+      style: ThresholdStyle.PERCENTAGE,
+    };
+  }
+
+  suggestions(when: When) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
+      suggest(
+        <>
+          Your <SpellLink id={TALENTS_EVOKER.DREAM_FLIGHT_TALENT.id} /> is not hitting enough
+          targets.
+        </>,
+      )
+        .icon(SPELLS.DREAM_BREATH.icon)
+        .actual(
+          `${formatPercentage(this.percentOfGroupHit, 2)} ${t({
+            id: 'evoker.preservation.suggestions.dreamFlight.targetsHit',
+            message: `% of group hit with Dream Flight`,
+          })}`,
+        )
+        .recommended(`${recommended * 100}% or more is recommended`),
+    );
+  }
+}
+
+export default DreamFlight;

--- a/src/analysis/retail/evoker/preservation/modules/talents/DreamFlight.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/DreamFlight.tsx
@@ -66,7 +66,7 @@ class DreamFlight extends Analyzer {
       )
         .icon(TALENTS_EVOKER.DREAM_FLIGHT_TALENT.icon)
         .actual(
-          `${formatPercentage(this.percentOfGroupHit, 2)} ${t({
+          `${formatPercentage(this.percentOfGroupHit, 2)}${t({
             id: 'evoker.preservation.suggestions.dreamFlight.targetsHit',
             message: `% of group hit with Dream Flight`,
           })}`,

--- a/src/common/SPELLS/evoker.ts
+++ b/src/common/SPELLS/evoker.ts
@@ -64,6 +64,11 @@ const spells = spellIndexableList({
     name: 'Spiritbloom',
     icon: 'ability_evoker_spiritbloom2',
   },
+  SPIRITBLOOM_CAST: {
+    id: 382731,
+    name: 'Spiritbloom',
+    icon: 'ability_evoker_spiritbloom2',
+  },
   SPIRITBLOOM_SPLIT: {
     id: 367231,
     name: 'Spiritbloom',


### PR DESCRIPTION
Added module to check what percent of raid is being hit by dream flight and also added checklist entries for spirit bloom, reversion, dream breath, and dream flight

![image](https://user-images.githubusercontent.com/11250934/205574332-4150f83b-91cd-4aa3-9431-d952f168ec4d.png)
![image](https://user-images.githubusercontent.com/11250934/205574728-121c5432-d812-407d-bcf1-f8f60e735a3c.png)

Open to input on the thresholds as I kinda made them up but they seem reasonable