### PR TITLE
[Preservation] add dream breath targets hit suggestion and fix empowered casts

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2022, 12, 6), <>Added suggestion based on average targets hit by <SpellLink id={TALENTS_EVOKER.DREAM_BREATH_TALENT.id}/></> ,Trevor),
   change(date(2022, 12, 4), <>Mark Preservation Evoker as fully supported</>, Trevor),
   change(date(2022, 12, 4), <>Added <SpellLink id={TALENTS_EVOKER.CYCLE_OF_LIFE_TALENT.id}/> module</>, Trevor),
   change(date(2022, 12, 4), <>Added <SpellLink id={TALENTS_EVOKER.TIME_LORD_TALENT.id}/> module</>, Trevor),

--- a/src/analysis/retail/evoker/preservation/modules/features/Abilities.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/features/Abilities.tsx
@@ -1,7 +1,6 @@
 import TALENTS from 'common/TALENTS/evoker';
 import CoreAbilities from 'analysis/retail/evoker/shared/modules/Abilities';
 import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
-import SPELLS from 'common/SPELLS';
 import { SpellbookAbility } from 'parser/core/modules/Ability';
 
 class Abilities extends CoreAbilities {
@@ -22,7 +21,7 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.DREAM_BREATH_CAST.id,
+        spell: TALENTS.DREAM_BREATH_TALENT.id,
         enabled: combatant.hasTalent(TALENTS.DREAM_BREATH_TALENT.id),
         category: SPELL_CATEGORY.ROTATIONAL_AOE,
         cooldown: 30,
@@ -52,7 +51,7 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(TALENTS.TIME_DILATION_TALENT.id),
       },
       {
-        spell: SPELLS.SPIRITBLOOM_CAST.id,
+        spell: TALENTS.SPIRITBLOOM_TALENT.id,
         category: SPELL_CATEGORY.ROTATIONAL_AOE,
         cooldown: 30,
         gcd: {

--- a/src/analysis/retail/evoker/preservation/modules/features/Checklist/Component.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/features/Checklist/Component.tsx
@@ -36,9 +36,9 @@ const PreservationEvokerChecklist = ({ combatant, castEfficiency, thresholds }: 
         name="Use core abilities as often as possible"
         description="Aim to keep core rotational abilities on cooldown to maximize healing"
       >
-        <AbilityRequirement spell={SPELLS.DREAM_BREATH_CAST.id} />
+        <AbilityRequirement spell={TALENTS_EVOKER.DREAM_BREATH_TALENT.id} />
         {combatant.hasTalent(TALENTS_EVOKER.SPIRITBLOOM_TALENT) && (
-          <AbilityRequirement spell={SPELLS.SPIRITBLOOM_CAST.id} />
+          <AbilityRequirement spell={TALENTS_EVOKER.SPIRITBLOOM_TALENT.id} />
         )}
         {combatant.hasTalent(TALENTS_EVOKER.REVERSION_TALENT) && (
           <AbilityRequirement spell={TALENTS_EVOKER.REVERSION_TALENT.id} />
@@ -109,11 +109,19 @@ const PreservationEvokerChecklist = ({ combatant, castEfficiency, thresholds }: 
         <Requirement
           name={
             <>
-              Average targets hit by
-              <SpellLink id={SPELLS.EMERALD_BLOSSOM.id} />
+              Average targets hit by <SpellLink id={SPELLS.EMERALD_BLOSSOM.id} />
             </>
           }
           thresholds={thresholds.emeraldBlossom}
+        />
+        <Requirement
+          name={
+            <>
+              Average targets hit by
+              <SpellLink id={TALENTS_EVOKER.DREAM_BREATH_TALENT.id} />
+            </>
+          }
+          thresholds={thresholds.dreamBreath}
         />
       </Rule>
       <PreparationRule thresholds={thresholds} />

--- a/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
@@ -237,7 +237,7 @@ const EVENT_LINKS: EventLink[] = [
     linkRelation: DREAM_BREATH_CALL_OF_YSERA_HOT,
     linkingEventId: [SPELLS.DREAM_BREATH.id, SPELLS.DREAM_BREATH_ECHO.id],
     linkingEventType: [EventType.ApplyBuff, EventType.Heal],
-    referencedEventId: [SPELLS.DREAM_BREATH_CAST.id],
+    referencedEventId: [TALENTS_EVOKER.DREAM_BREATH_TALENT.id],
     referencedEventType: [EventType.RemoveBuff],
     backwardBufferMs: CAST_BUFFER_MS,
     anyTarget: true,
@@ -253,7 +253,7 @@ const EVENT_LINKS: EventLink[] = [
     linkRelation: DREAM_BREATH_CALL_OF_YSERA,
     linkingEventId: [SPELLS.CALL_OF_YSERA_BUFF.id],
     linkingEventType: [EventType.RemoveBuff],
-    referencedEventId: [SPELLS.DREAM_BREATH_CAST.id],
+    referencedEventId: [TALENTS_EVOKER.DREAM_BREATH_TALENT.id],
     referencedEventType: [EventType.RemoveBuff],
     maximumLinks: 1,
     isActive(c) {
@@ -329,6 +329,16 @@ const EVENT_LINKS: EventLink[] = [
       );
     },
   },
+  // link dream breath hot application to cast
+  {
+    linkRelation: FROM_HARDCAST,
+    linkingEventId: [SPELLS.DREAM_BREATH.id],
+    linkingEventType: [EventType.ApplyBuff],
+    referencedEventId: [TALENTS_EVOKER.DREAM_BREATH_TALENT.id],
+    referencedEventType: [EventType.Cast],
+    backwardBufferMs: 2500, // there is some pretty big latency in logs, so being generous
+    anyTarget: true,
+  },
 ];
 
 /**
@@ -368,6 +378,10 @@ export function isFromLivingFlameCallOfYsera(event: HealEvent) {
 
 export function isFromFieldOfDreams(event: HealEvent) {
   return HasRelatedEvent(event, FIELD_OF_DREAMS_PROC);
+}
+
+export function isFromHardcast(event: ApplyBuffEvent) {
+  return HasRelatedEvent(event, FROM_HARDCAST);
 }
 
 export function getEssenceBurstConsumeAbility(

--- a/src/common/SPELLS/evoker.ts
+++ b/src/common/SPELLS/evoker.ts
@@ -38,34 +38,18 @@ const spells = spellIndexableList({
     name: 'Twin Guardian',
     icon: 'ability_skyreach_shielded',
   },
-
   TEMPORAL_ANOMALY_SHIELD: {
     id: 373862,
     name: 'Temporal Anomaly',
     icon: 'ability_evoker_temporalanomaly',
-  },
-  DREAM_BREATH_CAST: {
-    id: 382614,
-    name: 'Dream Breath',
-    icon: 'ability_evoker_dreambreath',
   },
   CALL_OF_YSERA_BUFF: {
     id: 373835,
     name: 'Call of Ysera',
     icon: '4096390',
   },
-  RENEWING_BREATH: {
-    id: 381923,
-    name: 'Renewing Breath',
-    icon: 'ability_evoker_dreambreath',
-  },
   SPIRITBLOOM: {
     id: 367230,
-    name: 'Spiritbloom',
-    icon: 'ability_evoker_spiritbloom2',
-  },
-  SPIRITBLOOM_CAST: {
-    id: 382731,
     name: 'Spiritbloom',
     icon: 'ability_evoker_spiritbloom2',
   },


### PR DESCRIPTION
Empowered cast spellid's were wrong, so I fixed them

Before: 
![image](https://user-images.githubusercontent.com/11250934/206130806-94af23ec-3a5f-4b22-bfb5-05aeeb28a599.png)
After:
![image](https://user-images.githubusercontent.com/11250934/206130730-9f776528-905d-46a8-93f5-246e9bbc4ad4.png)


I added a checklist item and suggestion for dream breath targets hit 
![image](https://user-images.githubusercontent.com/11250934/206128651-2a9c9c64-a7fb-4bc7-ba2d-30cba2d7c0ea.png)
![image](https://user-images.githubusercontent.com/11250934/206128693-9f99d586-aa5f-4401-a745-1ce601a5b8ca.png)


Had to link Dream Breath buff applies to cast's because stasis dream breath applies don't have a corresponding cast, so we don't want to include it in this metric. If we want to include it in this metric, then I can change to use apply grouping linking that we had setup for EB.