### PR TITLE
[Priest] Fix error with Dark Evangelism Buff

### DIFF
--- a/src/analysis/retail/priest/shadow/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/shadow/CHANGELOG.tsx
@@ -8,6 +8,7 @@ import { SpellLink } from 'interface';
 import { ResourceLink } from 'interface';
 
 export default [
+  change(date(2022, 12, 7), <>Fix error with <SpellLink id={TALENTS.DARK_EVANGELISM_TALENT}/> if the buff exists prepull</>,DoxAshe),
   change(date(2022, 11, 29), <>Improved proc checklist section and fixed some missing icons for the procs </>,DoxAshe),
   change(date(2022, 11, 24), <>Added checklist section and suggestions for using procs </>,DoxAshe),
   change(date(2022, 11, 15), <>Added support for new Dragonflight talents</>,DoxAshe),

--- a/src/analysis/retail/priest/shadow/modules/features/Buffs.tsx
+++ b/src/analysis/retail/priest/shadow/modules/features/Buffs.tsx
@@ -22,7 +22,7 @@ class Buffs extends CoreAuras {
       },
       {
         spellId: SPELLS.DARK_EVANGELISM_TALENT_BUFF.id,
-        triggeredBySpellId: TALENTS.DARK_EVANGELISM_TALENT.id,
+        //triggeredBySpellId: TALENTS.DARK_EVANGELISM_TALENT.id,  // If the log starts with the buff active, having this active causes "no ability available" error in PrePullCooldowns.
         enabled: combatant.hasTalent(TALENTS.DARK_EVANGELISM_TALENT.id),
         timelineHighlight: false,
       },

--- a/src/analysis/retail/priest/shadow/modules/features/Buffs.tsx
+++ b/src/analysis/retail/priest/shadow/modules/features/Buffs.tsx
@@ -17,12 +17,12 @@ class Buffs extends CoreAuras {
       },
       {
         spellId: SPELLS.SHADOWY_INSIGHT_BUFF.id,
-        triggeredBySpellId: SPELLS.SHADOWY_INSIGHT.id,
+        //triggeredBySpellId: SPELLS.SHADOWY_INSIGHT.id, // If the log starts with the buff active, having this active causes "no ability available" error in PrePullCooldowns.
         timelineHighlight: true,
       },
       {
         spellId: SPELLS.DARK_EVANGELISM_TALENT_BUFF.id,
-        //triggeredBySpellId: TALENTS.DARK_EVANGELISM_TALENT.id,  // If the log starts with the buff active, having this active causes "no ability available" error in PrePullCooldowns.
+        triggeredBySpellId: SPELLS.MIND_FLAY.id,
         enabled: combatant.hasTalent(TALENTS.DARK_EVANGELISM_TALENT.id),
         timelineHighlight: false,
       },


### PR DESCRIPTION
If the Dark Evangelism buff exists at the start of the fight it causes an error in PrePullCooldown.  Removing the triggeredBySpellId fixes this issue.