### PR TITLE
[MW] change vivacious vivification module to limit scope of refresh counting

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2022, 12, 14), <>Update <SpellLink id={TALENTS_MONK.VIVACIOUS_VIVIFICATION_TALENT}/> module suggestion thresholds</>, Trevor),
   change(date(2022, 12, 3), <>Update <SpellLink id={TALENTS_MONK.JADE_BOND_TALENT.id}/> module to show average CDR</>, Trevor),
   change(date(2022, 12, 3), <>Update <SpellLink id={TALENTS_MONK.YULONS_WHISPER_TALENT.id}/> suggestions for Mistweaver</>, Trevor),
   change(date(2022, 11, 28), <>Updated the <SpellLink id={TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT.id}/> and <SpellLink id={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id}/> modules to include <SpellLink id={TALENTS_MONK.ENVELOPING_BREATH_TALENT.id}/> in the title now that it is its own talent. Updated tooltips to use SpellLinks.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RapidDiffusion.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RapidDiffusion.tsx
@@ -208,7 +208,8 @@ class RapidDiffusion extends Analyzer {
               </li>
             )}
             <li>
-              Additional Renewing Mist Total Throughput: {formatNumber(this.totalRemThroughput)}
+              Additional <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT.id} /> Total Throughput:{' '}
+              {formatNumber(this.totalRemThroughput)}
             </li>
             <li>Extra Vivify Cleaves: {this.extraVivCleaves}</li>
             <li>Extra Vivify Healing: {formatNumber(this.totalVivifyThroughput)}</li>

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RenewingMist.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RenewingMist.tsx
@@ -1,9 +1,10 @@
 import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent, HealEvent } from 'parser/core/Events';
+import Events, { ApplyBuffEvent, CastEvent, HealEvent, RemoveBuffEvent } from 'parser/core/Events';
 
 class RenewingMist extends Analyzer {
+  currentRenewingMists: number = 0;
   totalHealing: number = 0;
   totalOverhealing: number = 0;
   totalAbsorbs: number = 0;
@@ -26,6 +27,22 @@ class RenewingMist extends Analyzer {
       Events.heal.by(SELECTED_PLAYER).spell(SPELLS.RENEWING_MIST_HEAL),
       this.handleRenewingMist,
     );
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.RENEWING_MIST_HEAL),
+      this.onApplyRem,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.RENEWING_MIST_HEAL),
+      this.onRemoveRem,
+    );
+  }
+
+  onApplyRem(event: ApplyBuffEvent) {
+    this.currentRenewingMists += 1;
+  }
+
+  onRemoveRem(event: RemoveBuffEvent) {
+    this.currentRenewingMists -= 1;
   }
 
   castRenewingMist(event: CastEvent) {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
@@ -47,7 +47,7 @@ class VivaciousVivification extends Analyzer {
 
   onRefresh(event: RefreshBuffEvent) {
     // every refresh is a wasted buff application and the CD restarts
-    if (this.currentRenewingMists > this.vivify.estimatedAverageReMs) {
+    if (this.currentRenewingMists >= this.vivify.estimatedAverageReMs) {
       this.wastedApplications += 1;
     }
   }
@@ -56,9 +56,9 @@ class VivaciousVivification extends Analyzer {
     return {
       actual: this.wastedApplications,
       isGreaterThan: {
-        minor: 0,
-        average: 3,
-        major: 5,
+        minor: 4,
+        average: 8,
+        major: 12,
       },
       recommended: 0,
       style: ThresholdStyle.NUMBER,

--- a/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
@@ -3,14 +3,17 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { ApplyBuffEvent, RefreshBuffEvent, RemoveBuffEvent } from 'parser/core/Events';
+import Events, { RefreshBuffEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import RenewingMist from './RenewingMist';
 import Vivify from './Vivify';
 
 class VivaciousVivification extends Analyzer {
   static dependencies = {
     vivify: Vivify,
+    renewingMist: RenewingMist,
   };
+  protected renewingMist!: RenewingMist;
   protected vivify!: Vivify;
   currentRenewingMists: number = 0;
   totalCasts: number = 0;
@@ -27,27 +30,11 @@ class VivaciousVivification extends Analyzer {
       Events.refreshbuff.to(SELECTED_PLAYER).spell(SPELLS.VIVIFICATION_BUFF),
       this.onRefresh,
     );
-    this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.RENEWING_MIST_HEAL),
-      this.onApplyRem,
-    );
-    this.addEventListener(
-      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.RENEWING_MIST_HEAL),
-      this.onRemoveRem,
-    );
-  }
-
-  onApplyRem(event: ApplyBuffEvent) {
-    this.currentRenewingMists += 1;
-  }
-
-  onRemoveRem(event: RemoveBuffEvent) {
-    this.currentRenewingMists -= 1;
   }
 
   onRefresh(event: RefreshBuffEvent) {
     // every refresh is a wasted buff application and the CD restarts
-    if (this.currentRenewingMists >= this.vivify.estimatedAverageReMs) {
+    if (this.renewingMist.currentRenewingMists >= this.vivify.estimatedAverageReMs) {
       this.wastedApplications += 1;
     }
   }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
@@ -56,7 +56,7 @@ class VivaciousVivification extends Analyzer {
     return {
       actual: this.wastedApplications,
       isGreaterThan: {
-        minor: 4,
+        minor: 3,
         average: 8,
         major: 12,
       },

--- a/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
@@ -78,7 +78,7 @@ class VivaciousVivification extends Analyzer {
         .actual(
           `${this.wastedApplications + ' '}${t({
             id: 'monk.mistweaver.suggestions.vivaciousVivification.wastedApplications',
-            message: `wasted applications with high Renewing Mist Counts`,
+            message: `wasted applications`,
           })}`,
         )
         .recommended(`0 wasted applications is recommended`),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
@@ -57,8 +57,8 @@ class VivaciousVivification extends Analyzer {
       actual: this.wastedApplications,
       isGreaterThan: {
         minor: 0,
-        average: 5,
-        major: 8,
+        average: 3,
+        major: 5,
       },
       recommended: 0,
       style: ThresholdStyle.NUMBER,


### PR DESCRIPTION
Changed the module to only count a wasted refresh when the amount of rems on the raid is greater than the expected number of rems

Also changed tooltip of Rapid Diffusion to use Icon for rem

Before:
![image](https://user-images.githubusercontent.com/11250934/207548144-7bfa2970-1ed8-48b6-94a7-54d541607c35.png)

After: 
![image](https://user-images.githubusercontent.com/11250934/207548071-4dfb4358-8016-4f5e-be44-ef12b9180c76.png)
