### PR TITLE
fix echo module accuracy

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2022, 12, 14), <>Improved accuracy of <SpellLink id={TALENTS_EVOKER.ECHO_TALENT}/> module</>, Trevor),
   change(date(2022, 12, 14), <>Updated Mastery Effectiveness to include the value of the healing done in the effectiveness evaluation</>, Vohrr),
   change(date(2022, 12, 7), <>Fix load condition for <SpellLink id={TALENTS_EVOKER.DREAM_FLIGHT_TALENT.id}/></>, Trevor),
   change(date(2022, 12, 6), <>Added checklist item for expired <SpellLink id={TALENTS_EVOKER.ECHO_TALENT.id}/> buffs</>, Trevor),

--- a/src/analysis/retail/evoker/preservation/modules/talents/Echo.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/Echo.tsx
@@ -46,6 +46,7 @@ class Echo extends Analyzer {
 
   onRemove(event: RemoveBuffEvent) {
     if (didEchoExpire(event)) {
+      console.log('Echo expired at ' + this.owner.formatTimestamp(event.timestamp));
       this.totalExpired += 1;
     }
   }

--- a/src/analysis/retail/evoker/preservation/modules/talents/Echo.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/Echo.tsx
@@ -46,7 +46,6 @@ class Echo extends Analyzer {
 
   onRemove(event: RemoveBuffEvent) {
     if (didEchoExpire(event)) {
-      console.log('Echo expired at ' + this.owner.formatTimestamp(event.timestamp));
       this.totalExpired += 1;
     }
   }

--- a/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
@@ -31,6 +31,7 @@ export const BUFF_GROUPING = 'BuffGrouping'; // link ApplyBuff events together
 export const SHIELD_FROM_TA_CAST = 'ShieldFromTACast';
 
 const CAST_BUFFER_MS = 100;
+const ECHO_BUFFER = 500;
 const EB_BUFFER_MS = 2000;
 const EB_VARIANCE_BUFFER = 150; // servers are bad and EB can take over or under 2s to actually trigger
 const MAX_ECHO_DURATION = 20000; // 15s with 30% inc = 19s
@@ -117,8 +118,8 @@ const EVENT_LINKS: EventLink[] = [
     linkingEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
     referencedEventId: TALENTS_EVOKER.ECHO_TALENT.id,
     referencedEventType: [EventType.RemoveBuff],
-    forwardBufferMs: CAST_BUFFER_MS,
-    backwardBufferMs: CAST_BUFFER_MS,
+    forwardBufferMs: ECHO_BUFFER,
+    backwardBufferMs: ECHO_BUFFER,
     additionalCondition(linkedEvent, referencedEvent) {
       return HasRelatedEvent(referencedEvent, ECHO_REMOVAL);
     },
@@ -131,8 +132,8 @@ const EVENT_LINKS: EventLink[] = [
     linkingEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
     referencedEventId: TALENTS_EVOKER.ECHO_TALENT.id,
     referencedEventType: [EventType.RemoveBuff],
-    forwardBufferMs: CAST_BUFFER_MS,
-    backwardBufferMs: CAST_BUFFER_MS,
+    forwardBufferMs: ECHO_BUFFER,
+    backwardBufferMs: ECHO_BUFFER,
     additionalCondition(linkingEvent, referencedEvent) {
       return HasRelatedEvent(referencedEvent, TA_ECHO_REMOVAL);
     },
@@ -154,13 +155,13 @@ const EVENT_LINKS: EventLink[] = [
       SPELLS.LIVING_FLAME_HEAL.id,
       SPELLS.SPIRITBLOOM_SPLIT.id,
       SPELLS.SPIRITBLOOM.id,
-      TALENTS_EVOKER.VERDANT_EMBRACE_TALENT.id,
+      SPELLS.VERDANT_EMBRACE_HEAL.id,
     ],
     linkingEventType: [EventType.Heal],
     referencedEventId: TALENTS_EVOKER.ECHO_TALENT.id,
     referencedEventType: [EventType.RemoveBuff],
-    forwardBufferMs: CAST_BUFFER_MS,
-    backwardBufferMs: CAST_BUFFER_MS,
+    forwardBufferMs: ECHO_BUFFER,
+    backwardBufferMs: ECHO_BUFFER,
     additionalCondition(linkingEvent, referencedEvent) {
       return HasRelatedEvent(referencedEvent, ECHO_REMOVAL);
     },
@@ -173,7 +174,7 @@ const EVENT_LINKS: EventLink[] = [
     linkingEventType: EventType.Heal,
     referencedEventId: TALENTS_EVOKER.ECHO_TALENT.id,
     referencedEventType: [EventType.RemoveBuff],
-    backwardBufferMs: EB_BUFFER_MS,
+    backwardBufferMs: ECHO_BUFFER,
     additionalCondition(linkingEvent, referencedEvent) {
       return !HasRelatedEvent(referencedEvent, ECHO_REMOVAL);
     },
@@ -188,13 +189,13 @@ const EVENT_LINKS: EventLink[] = [
       SPELLS.SPIRITBLOOM.id,
       SPELLS.DREAM_BREATH_ECHO.id,
       SPELLS.LIVING_FLAME_HEAL.id,
-      TALENTS_EVOKER.VERDANT_EMBRACE_TALENT.id,
+      SPELLS.VERDANT_EMBRACE_HEAL.id,
     ],
     linkingEventType: EventType.Heal,
     referencedEventId: TALENTS_EVOKER.ECHO_TALENT.id,
     referencedEventType: EventType.RemoveBuff,
-    forwardBufferMs: CAST_BUFFER_MS,
-    backwardBufferMs: CAST_BUFFER_MS,
+    forwardBufferMs: ECHO_BUFFER,
+    backwardBufferMs: ECHO_BUFFER,
     additionalCondition(linkingEvent, referencedEvent) {
       return HasRelatedEvent(referencedEvent, TA_ECHO_REMOVAL);
     },


### PR DESCRIPTION
Had wrong spellId for verdant embrace in cast link normalizzer and buffer was too strict

before:
![image](https://user-images.githubusercontent.com/11250934/207746956-6498838f-297b-43dc-9d09-1cb952d8930b.png)

after:
![image](https://user-images.githubusercontent.com/11250934/207746941-fe669997-ad7b-4f7a-b237-e50c70ed51b8.png)
