### PR TITLE
Fix performance box row css

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -16,6 +16,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2022, 12, 19), 'Fix rendering issue with performance boxes on Brewmaster Monk and Restoration Druid summaries.', emallson),
   change(date(2022, 12, 19), 'Regenerate talents.', ToppleTheNun),
   change(date(2022, 12, 14), 'Remove Shadowlands items.', ToppleTheNun),
   change(date(2022, 12, 17), 'Fixed an issue with forward event lookups in Event History.', Sharrq),

--- a/src/analysis/retail/demonhunter/vengeance/modules/core/MajorDefensives/components/AllCooldownUsagesList.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/core/MajorDefensives/components/AllCooldownUsagesList.tsx
@@ -278,9 +278,14 @@ const CooldownDetails = <ApplyEventType extends EventType, RemoveEventType exten
             </td>
           </tr>
           {damageTakenRows.map(([spellId, events], ix) => {
-            // FIXME: this is unchecked. possible undefined error
-            const keyEvent = events.find(({ event }) => HasAbility(event))!
-              .event as AbilityEvent<any>;
+            const keyEvent = events.find(({ event }) => HasAbility(event))?.event as
+              | AbilityEvent<any>
+              | undefined;
+
+            if (!keyEvent) {
+              return null;
+            }
+
             const rowColor = color(keyEvent.ability.type);
 
             const mitigatedAmount = events.reduce((a, b) => a + b.mitigatedAmount, 0);

--- a/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/components/AllCooldownUsagesList.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/components/AllCooldownUsagesList.tsx
@@ -200,9 +200,14 @@ const CooldownDetails = ({ analyzer, mit }: { analyzer: MajorDefensive; mit?: Mi
             </td>
           </tr>
           {damageTakenRows.map(([spellId, events], ix) => {
-            // FIXME: this is unchecked. possible undefined error
-            const keyEvent = events.find(({ event }) => HasAbility(event))!
-              .event as AbilityEvent<any>;
+            const keyEvent = events.find(({ event }) => HasAbility(event))?.event as
+              | AbilityEvent<any>
+              | undefined;
+
+            if (!keyEvent) {
+              return null;
+            }
+
             const rowColor = color(keyEvent.ability.type);
 
             const mitigatedAmount = events.reduce((a, b) => a + b.mitigatedAmount, 0);

--- a/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/components/AllCooldownUsagesList.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/components/AllCooldownUsagesList.tsx
@@ -102,6 +102,12 @@ const CooldownDetailsContainer = styled.div`
   }
   & > table td {
     padding-right: 1rem;
+
+    &:first-of-type {
+      max-width: 14em;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 `;
 
@@ -171,7 +177,7 @@ const CooldownDetails = ({ analyzer, mit }: { analyzer: MajorDefensive; mit?: Mi
           </tr>
           {segments.map((seg, ix) => (
             <tr key={ix}>
-              <td style={{ width: '100%' }}>{seg.tooltip}</td>
+              <td>{seg.tooltip}</td>
               <NumericColumn>{formatNumber(seg.amount)}</NumericColumn>
               <TableSegmentContainer>
                 {ix > 0 && (

--- a/src/interface/guide/components/PerformanceBoxRow/PerformanceBoxRow.scss
+++ b/src/interface/guide/components/PerformanceBoxRow/PerformanceBoxRow.scss
@@ -13,6 +13,9 @@ $shadow: 0 0 0px 1px hsla(45, 100%, 60%, 0.7);
   .performance-block {
     height: 0.8em;
     display: inline-block;
+    flex-grow: 1;
+    max-width: 60px;
+    min-width: 10px;
 
     &:hover {
       box-shadow: $shadow;

--- a/src/interface/guide/components/PerformanceBoxRow/index.tsx
+++ b/src/interface/guide/components/PerformanceBoxRow/index.tsx
@@ -1,27 +1,16 @@
 import { Tooltip } from 'interface/index';
 import './PerformanceBoxRow.scss';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
-import { useCallback, useState } from 'react';
 
 /** A row of boxes colored based on performance */
 export function PerformanceBoxRow({ values, onClickBox }: PerformanceBoxRowProps) {
-  // size boxes to fit in one row, if practically possible
-  const [refWidth, setRefWidth] = useState(800);
-  const ref = useCallback((node: HTMLDivElement) => {
-    node && setRefWidth(node.getBoundingClientRect().width);
-  }, []);
-  const size = blockSize(values.length, refWidth);
-
   return (
-    <div className="performance-block-row" ref={ref}>
+    <div className="performance-block-row">
       {values.map((value, ix) => (
         <Tooltip key={ix} content={value.tooltip}>
           <div
             className={`performance-block ${getBlockClassName(value)} ${value.className ?? ''}`}
             onClick={() => onClickBox?.(ix)}
-            style={{
-              width: size - 2, // minus 2 to account for margin
-            }}
           />
         </Tooltip>
       ))}
@@ -41,12 +30,6 @@ export type BoxRowEntry = {
   tooltip?: React.ReactNode | string; // TODO default tooltip
   className?: string;
 };
-
-/** Gets the width a block should be so it fits neatly in one row */
-function blockSize(numValues: number, refWidth: number): number {
-  const size = refWidth / numValues;
-  return Math.max(Math.min(Math.floor(size), 60), 10); // min size = 10, max size = 60
-}
 
 function getBlockClassName(value: BoxRowEntry) {
   switch (value.value) {


### PR DESCRIPTION
We can use flexbox to avoid doing width calculation in JS. This should reproduce the old behavior exactly in CSS.

Also a couple other related fixes I found while poking around. That FIXME definitely bit me in the ass :)