### PR TITLE
add opt-in toggle for hiding rotation explanations

### DIFF
--- a/src/analysis/retail/demonhunter/shared/modules/spells/ImmolationAura/VengeanceGuideSection.tsx
+++ b/src/analysis/retail/demonhunter/shared/modules/spells/ImmolationAura/VengeanceGuideSection.tsx
@@ -4,13 +4,13 @@ import { SpellLink } from 'interface';
 import SPELLS from 'common/SPELLS/demonhunter';
 import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
 import { GapHighlight } from 'parser/ui/CooldownBar';
-import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { ExplanationAndDataSubSection } from 'interface/guide/components/ExplanationRow';
 import { t, Trans } from '@lingui/macro';
 
 import CastSummaryAndBreakdown from '../../../guide/CastSummaryAndBreakdown';
 import FalloutSnippet from './FalloutSnippet';
 
-const VengeanceGuideSection = () => {
+const VengeanceGuideSection = ({ hideExplanation }: { hideExplanation: boolean }) => {
   const info = useInfo();
   const immolationAura = useAnalyzer(ImmolationAura);
   if (!info || !immolationAura) {
@@ -68,9 +68,12 @@ const VengeanceGuideSection = () => {
     </div>
   );
 
-  return explanationAndDataSubsection(
-    explanation,
-    immolationAura.castEntries.length > 0 ? data : noCastData,
+  return (
+    <ExplanationAndDataSubSection
+      explanation={explanation}
+      data={immolationAura.castEntries.length > 0 ? data : noCastData}
+      hideExplanation={hideExplanation}
+    />
   );
 };
 

--- a/src/analysis/retail/demonhunter/shared/modules/spells/ImmolationAura/VengeanceGuideSection.tsx
+++ b/src/analysis/retail/demonhunter/shared/modules/spells/ImmolationAura/VengeanceGuideSection.tsx
@@ -10,7 +10,7 @@ import { t, Trans } from '@lingui/macro';
 import CastSummaryAndBreakdown from '../../../guide/CastSummaryAndBreakdown';
 import FalloutSnippet from './FalloutSnippet';
 
-const VengeanceGuideSection = ({ hideExplanation }: { hideExplanation: boolean }) => {
+const VengeanceGuideSection = () => {
   const info = useInfo();
   const immolationAura = useAnalyzer(ImmolationAura);
   if (!info || !immolationAura) {
@@ -72,7 +72,6 @@ const VengeanceGuideSection = ({ hideExplanation }: { hideExplanation: boolean }
     <ExplanationAndDataSubSection
       explanation={explanation}
       data={immolationAura.castEntries.length > 0 ? data : noCastData}
-      hideExplanation={hideExplanation}
     />
   );
 };

--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import SHARED_CHANGELOG from 'analysis/retail/demonhunter/shared/CHANGELOG';
 
 // prettier-ignore
 export default [
+  change(date(2022, 12, 19), 'Add opt-in toggle for hiding rotation explanations.', ToppleTheNun),
   change(date(2022, 12, 19), 'Add opt-in toggle for new defensives section.', ToppleTheNun),
   change(date(2022, 12, 18), 'Further refine defensive buff tracking.', ToppleTheNun),
   change(date(2022, 12, 18), 'Properly remove defensive buffs on death.', ToppleTheNun),

--- a/src/analysis/retail/demonhunter/vengeance/Guide.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/Guide.tsx
@@ -9,6 +9,7 @@ import ImmolationAuraVengeanceGuideSection from 'analysis/retail/demonhunter/sha
 import { t, Trans } from '@lingui/macro';
 import { PerformanceStrong } from 'analysis/retail/demonhunter/shared/guide/ExtraComponents';
 import VerticallyAlignedToggle from 'interface/VerticallyAlignedToggle';
+import HideExplanationsToggle from 'interface/guide/components/HideExplanationsToggle';
 
 import DemonSpikesSubSection from './modules/spells/DemonSpikes/GuideSection';
 import FieryBrandSubSection from './modules/talents/FieryBrand/GuideSection';
@@ -17,7 +18,6 @@ import MetamorphosisSubSection from './modules/spells/Metamorphosis/GuideSection
 import CooldownGraphSubsection from './guide/CooldownGraphSubSection';
 import MajorDefensives from './modules/core/MajorDefensives';
 import useVdhFeatureFlag from './guide/useVdhFeatureFlag';
-import HideExplanationsToggle from 'interface/guide/components/HideExplanationsToggle';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -127,6 +127,7 @@ function MitigationSection() {
 function OldMitigationSection() {
   return (
     <>
+      <HideExplanationsToggle id="hide-explanations-old-mitigation" />
       <MetamorphosisSubSection />
       <DemonSpikesSubSection />
       <FieryBrandSubSection />
@@ -136,10 +137,6 @@ function OldMitigationSection() {
 }
 
 function RotationSection({ modules, info }: GuideProps<typeof CombatLogParser>) {
-  const [isHideExplanationEnabled, setHideExplanationEnabled] = useVdhFeatureFlag(
-    'rotation-explanation',
-  );
-
   return (
     <Section
       title={t({
@@ -161,17 +158,13 @@ function RotationSection({ modules, info }: GuideProps<typeof CombatLogParser>) 
         </Trans>
       </p>
       <br />
-      <HideExplanationsToggle
-        hideExplanations={isHideExplanationEnabled}
-        setHideExplanations={setHideExplanationEnabled}
-        id="hide-rotation-explanations"
-      />
+      <HideExplanationsToggle id="hide-explanations-rotation" />
       {info.combatant.hasTalent(TALENTS_DEMON_HUNTER.FRACTURE_TALENT) &&
-        modules.fracture.guideSubsection(isHideExplanationEnabled)}
-      <ImmolationAuraVengeanceGuideSection hideExplanation={isHideExplanationEnabled} />
-      {modules.soulCleave.guideSubsection(isHideExplanationEnabled)}
+        modules.fracture.guideSubsection()}
+      <ImmolationAuraVengeanceGuideSection />
+      {modules.soulCleave.guideSubsection()}
       {info.combatant.hasTalent(TALENTS_DEMON_HUNTER.SPIRIT_BOMB_TALENT) &&
-        modules.spiritBomb.guideSubsection(isHideExplanationEnabled)}
+        modules.spiritBomb.guideSubsection()}
     </Section>
   );
 }
@@ -193,6 +186,7 @@ function CooldownSection({ modules, info }: GuideProps<typeof CombatLogParser>) 
           <SpellLink id={TALENTS_DEMON_HUNTER.FEL_DEVASTATION_TALENT.id} /> as often as possible.
         </Trans>
       </p>
+      <HideExplanationsToggle id="hide-explanations-cooldowns" />
       <CooldownGraphSubsection />
       {info.combatant.hasTalent(TALENTS_DEMON_HUNTER.FEL_DEVASTATION_TALENT) &&
         modules.felDevastation.guideBreakdown()}

--- a/src/analysis/retail/demonhunter/vengeance/Guide.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/Guide.tsx
@@ -8,6 +8,7 @@ import PreparationSection from 'interface/guide/components/Preparation/Preparati
 import ImmolationAuraVengeanceGuideSection from 'analysis/retail/demonhunter/shared/modules/spells/ImmolationAura/VengeanceGuideSection';
 import { t, Trans } from '@lingui/macro';
 import { PerformanceStrong } from 'analysis/retail/demonhunter/shared/guide/ExtraComponents';
+import VerticallyAlignedToggle from 'interface/VerticallyAlignedToggle';
 
 import DemonSpikesSubSection from './modules/spells/DemonSpikes/GuideSection';
 import FieryBrandSubSection from './modules/talents/FieryBrand/GuideSection';
@@ -15,8 +16,8 @@ import VoidReaverSubSection from './modules/talents/VoidReaver/GuideSection';
 import MetamorphosisSubSection from './modules/spells/Metamorphosis/GuideSection';
 import CooldownGraphSubsection from './guide/CooldownGraphSubSection';
 import MajorDefensives from './modules/core/MajorDefensives';
-import EnableNewDefensivesSectionToggle from './guide/EnableNewDefensivesSectionToggle';
 import useVdhFeatureFlag from './guide/useVdhFeatureFlag';
+import HideExplanationsToggle from 'interface/guide/components/HideExplanationsToggle';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -108,7 +109,13 @@ function MitigationSection() {
       <div className="flex">
         <div className="flex-main" />
         <div className="flex-sub">
-          <EnableNewDefensivesSectionToggle enabled={enabled} setEnabled={setEnabled} />
+          <VerticallyAlignedToggle
+            id="enable-new-defensives-section-toggle"
+            enabled={enabled}
+            setEnabled={setEnabled}
+            label="View In-Flight Content"
+            tooltipContent="Only click this if you're okay with seeing under-development features. If things don't work how you expect, you can always turn this back off."
+          />
         </div>
       </div>
       {enabled && <MajorDefensives />}
@@ -129,6 +136,10 @@ function OldMitigationSection() {
 }
 
 function RotationSection({ modules, info }: GuideProps<typeof CombatLogParser>) {
+  const [isHideExplanationEnabled, setHideExplanationEnabled] = useVdhFeatureFlag(
+    'rotation-explanation',
+  );
+
   return (
     <Section
       title={t({
@@ -141,6 +152,7 @@ function RotationSection({ modules, info }: GuideProps<typeof CombatLogParser>) 
         the Dragonflight launch. It is currently a reasonable starting point, but may not match the
         optimal rotation yet.
       </AlertWarning>
+      <br />
       <p>
         <Trans id="guide.demonhunter.vengeance.sections.rotation.summary">
           Vengeance's core rotation involves <strong>building</strong> and then{' '}
@@ -148,12 +160,18 @@ function RotationSection({ modules, info }: GuideProps<typeof CombatLogParser>) 
           s, which heal for 6% of damage taken in the 5 seconds before they are absorbed.
         </Trans>
       </p>
+      <br />
+      <HideExplanationsToggle
+        hideExplanations={isHideExplanationEnabled}
+        setHideExplanations={setHideExplanationEnabled}
+        id="hide-rotation-explanations"
+      />
       {info.combatant.hasTalent(TALENTS_DEMON_HUNTER.FRACTURE_TALENT) &&
-        modules.fracture.guideSubsection()}
-      <ImmolationAuraVengeanceGuideSection />
-      {modules.soulCleave.guideSubsection()}
+        modules.fracture.guideSubsection(isHideExplanationEnabled)}
+      <ImmolationAuraVengeanceGuideSection hideExplanation={isHideExplanationEnabled} />
+      {modules.soulCleave.guideSubsection(isHideExplanationEnabled)}
       {info.combatant.hasTalent(TALENTS_DEMON_HUNTER.SPIRIT_BOMB_TALENT) &&
-        modules.spiritBomb.guideSubsection()}
+        modules.spiritBomb.guideSubsection(isHideExplanationEnabled)}
     </Section>
   );
 }

--- a/src/analysis/retail/demonhunter/vengeance/guide/useVdhFeatureFlag.ts
+++ b/src/analysis/retail/demonhunter/vengeance/guide/useVdhFeatureFlag.ts
@@ -1,17 +1,10 @@
-import { useState } from 'react';
+import useSessionFeatureFlag from 'interface/useSessionFeatureFlag';
 
-const useVdhFeatureFlag = (featureFlag: string = '', featureFlagDefault?: boolean) => {
-  const sessionFeatureFlagSetting = window.sessionStorage?.getItem(
-    // This will filter out if featureFlag is an empty string
-    ['wowa-vdh-ff', featureFlag].filter((it) => it).join('-'),
+const useVdhFeatureFlag = (featureFlag: string, featureFlagDefault: boolean = false) => {
+  return useSessionFeatureFlag(
+    ['vdh', featureFlag].filter((it) => it).join('-'),
+    featureFlagDefault,
   );
-  const defaultFeatureFlagSetting = Boolean(featureFlagDefault);
-  const initialFeatureFlagSetting =
-    sessionFeatureFlagSetting === null
-      ? defaultFeatureFlagSetting
-      : Boolean(sessionFeatureFlagSetting);
-
-  return useState(initialFeatureFlagSetting);
 };
 
 export default useVdhFeatureFlag;

--- a/src/analysis/retail/demonhunter/vengeance/modules/core/MajorDefensives/index.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/core/MajorDefensives/index.tsx
@@ -6,9 +6,11 @@ import TALENTS from 'common/TALENTS/demonhunter';
 import SPELLS from 'common/SPELLS/demonhunter';
 import Timeline from './components/Timeline';
 import AllCooldownUsagesList, { Highlight } from './components/AllCooldownUsagesList';
+import HideExplanationsToggle from 'interface/guide/components/HideExplanationsToggle';
 
 const MajorDefensives = () => (
   <>
+    <HideExplanationsToggle id="hide-explanations-major-defensives" />
     <SubSection>
       <Explanation>
         <p>

--- a/src/analysis/retail/demonhunter/vengeance/modules/core/MajorDefensives/index.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/core/MajorDefensives/index.tsx
@@ -9,59 +9,62 @@ import AllCooldownUsagesList, { Highlight } from './components/AllCooldownUsages
 
 const MajorDefensives = () => (
   <>
-    <Explanation>
-      <p>
-        Effectively using your major defensive cooldowns is a core part of playing tank well. This
-        is especially true for Vengeance Demon Hunters, as we rely on our cooldowns to deal with
-        incoming damage.
-      </p>
-      <p>There are two things you should look for in your cooldown usage:</p>
-      <ol>
-        <li>
-          You should cover as many{' '}
-          <TooltipElement
-            content={
-              <>
-                A <strong>damage spike</strong> is when you take much more damage than normal in a
-                small amount of time. These are visible on the Timeline below as tall spikes.
-              </>
-            }
-          >
-            damage spikes
-          </TooltipElement>{' '}
-          as possible, and use any left over to cover periods of heavy, consistent damage.
-          <br />
-          <small>
-            In the damage chart below, a spike highlighted in{' '}
-            <Highlight color={GoodColor} textColor="black">
-              green
-            </Highlight>{' '}
-            was covered by a defensive.
-          </small>
-        </li>
-        <li>
-          You should <em>use</em> your cooldowns. This may seem silly&mdash;but not using major
-          defensives is a common problem! For Vengeance Demon Hunters, it is also likely to be
-          fatal.
-          <br />
-          <small>
-            Below the damage chart, your cooldowns are shown. Large gaps may indicate that you could
-            get more uses&mdash;but remember that covering spikes is more important than maximizing
-            total casts!
-          </small>
-        </li>
-      </ol>
-      <p>
-        Vengeance Demon Hunter is unique in that two of our major defensives (
-        <SpellLink id={TALENTS.FIERY_BRAND_TALENT} /> and <SpellLink id={SPELLS.FRAILTY} /> [with{' '}
-        <SpellLink id={TALENTS.VOID_REAVER_TALENT} />
-        ]) are applied to enemies instead of ourselves. This leads to some headaches when trying to
-        diagram how certain spells/talents (like <SpellLink id={TALENTS.BURNING_ALIVE_TALENT} />)
-        affect your damage intake. Until we get around to allowing you to toggle which enemy you're
-        looking at in the below timeline, <SpellLink id={TALENTS.FIERY_BRAND_TALENT} /> and{' '}
-        <SpellLink id={SPELLS.FRAILTY} /> are excluded.
-      </p>
-    </Explanation>
+    <SubSection>
+      <Explanation>
+        <p>
+          Effectively using your major defensive cooldowns is a core part of playing tank well. This
+          is especially true for Vengeance Demon Hunters, as we rely on our cooldowns to deal with
+          incoming damage.
+        </p>
+        <p>There are two things you should look for in your cooldown usage:</p>
+        <ol>
+          <li>
+            You should cover as many{' '}
+            <TooltipElement
+              content={
+                <>
+                  A <strong>damage spike</strong> is when you take much more damage than normal in a
+                  small amount of time. These are visible on the Timeline below as tall spikes.
+                </>
+              }
+            >
+              damage spikes
+            </TooltipElement>{' '}
+            as possible, and use any left over to cover periods of heavy, consistent damage.
+            <br />
+            <small>
+              In the damage chart below, a spike highlighted in{' '}
+              <Highlight color={GoodColor} textColor="black">
+                green
+              </Highlight>{' '}
+              was covered by a defensive.
+            </small>
+          </li>
+          <li>
+            You should <em>use</em> your cooldowns. This may seem silly&mdash;but not using major
+            defensives is a common problem! For Vengeance Demon Hunters, it is also likely to be
+            fatal.
+            <br />
+            <small>
+              Below the damage chart, your cooldowns are shown. Large gaps may indicate that you
+              could get more uses&mdash;but remember that covering spikes is more important than
+              maximizing total casts!
+            </small>
+          </li>
+        </ol>
+        <p>
+          Vengeance Demon Hunter is unique in that two of our major defensives (
+          <SpellLink id={TALENTS.FIERY_BRAND_TALENT} /> and <SpellLink id={SPELLS.FRAILTY} /> [with{' '}
+          <SpellLink id={TALENTS.VOID_REAVER_TALENT} />
+          ]) are applied to enemies instead of ourselves. This leads to some headaches when trying
+          to diagram how certain spells/talents (like{' '}
+          <SpellLink id={TALENTS.BURNING_ALIVE_TALENT} />) affect your damage intake. Until we get
+          around to allowing you to toggle which enemy you're looking at in the below timeline,{' '}
+          <SpellLink id={TALENTS.FIERY_BRAND_TALENT} /> and <SpellLink id={SPELLS.FRAILTY} /> are
+          excluded.
+        </p>
+      </Explanation>
+    </SubSection>
     <SubSection title="Timeline">
       <Timeline />
     </SubSection>

--- a/src/analysis/retail/demonhunter/vengeance/modules/spells/SoulCleave.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/spells/SoulCleave.tsx
@@ -159,7 +159,7 @@ export default class SoulCleave extends Analyzer {
     return [QualitativePerformance.Good, null];
   }
 
-  guideSubsection(hideExplanation: boolean) {
+  guideSubsection() {
     const explanation = (
       <p>
         <Trans id="guide.demonhunter.vengeance.sections.rotation.soulCleave.explanation">
@@ -208,7 +208,6 @@ export default class SoulCleave extends Analyzer {
       <ExplanationAndDataSubSection
         explanation={explanation}
         data={this.castEntries.length > 0 ? data : noCastData}
-        hideExplanation={hideExplanation}
       />
     );
   }

--- a/src/analysis/retail/demonhunter/vengeance/modules/spells/SoulCleave.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/spells/SoulCleave.tsx
@@ -17,7 +17,7 @@ import { t, Trans } from '@lingui/macro';
 import { SpellLink } from 'interface';
 import TALENTS from 'common/TALENTS/demonhunter';
 import CastSummaryAndBreakdown from 'analysis/retail/demonhunter/shared/guide/CastSummaryAndBreakdown';
-import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { ExplanationAndDataSubSection } from 'interface/guide/components/ExplanationRow';
 
 export default class SoulCleave extends Analyzer {
   static dependencies = {
@@ -159,7 +159,7 @@ export default class SoulCleave extends Analyzer {
     return [QualitativePerformance.Good, null];
   }
 
-  guideSubsection() {
+  guideSubsection(hideExplanation: boolean) {
     const explanation = (
       <p>
         <Trans id="guide.demonhunter.vengeance.sections.rotation.soulCleave.explanation">
@@ -204,9 +204,12 @@ export default class SoulCleave extends Analyzer {
       </div>
     );
 
-    return explanationAndDataSubsection(
-      explanation,
-      this.castEntries.length > 0 ? data : noCastData,
+    return (
+      <ExplanationAndDataSubSection
+        explanation={explanation}
+        data={this.castEntries.length > 0 ? data : noCastData}
+        hideExplanation={hideExplanation}
+      />
     );
   }
 }

--- a/src/analysis/retail/demonhunter/vengeance/modules/talents/Fracture.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/talents/Fracture.tsx
@@ -185,7 +185,7 @@ export default class Fracture extends Analyzer {
     ];
   }
 
-  guideSubsection(hideExplanation: boolean) {
+  guideSubsection() {
     const explanation = (
       <p>
         <Trans id="guide.demonhunter.vengeance.sections.rotation.fracture.explanation">
@@ -229,7 +229,6 @@ export default class Fracture extends Analyzer {
       <ExplanationAndDataSubSection
         explanation={explanation}
         data={this.castEntries.length > 0 ? data : noCastData}
-        hideExplanation={hideExplanation}
       />
     );
   }

--- a/src/analysis/retail/demonhunter/vengeance/modules/talents/Fracture.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/talents/Fracture.tsx
@@ -3,7 +3,7 @@ import Enemies from 'parser/shared/modules/Enemies';
 import TALENTS from 'common/TALENTS/demonhunter';
 import SPELLS from 'common/SPELLS/demonhunter';
 import { BoxRowEntry } from 'interface/guide/components/PerformanceBoxRow';
-import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { ExplanationAndDataSubSection } from 'interface/guide/components/ExplanationRow';
 import { SpellLink } from 'interface';
 import Events, { CastEvent } from 'parser/core/Events';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
@@ -185,7 +185,7 @@ export default class Fracture extends Analyzer {
     ];
   }
 
-  guideSubsection() {
+  guideSubsection(hideExplanation: boolean) {
     const explanation = (
       <p>
         <Trans id="guide.demonhunter.vengeance.sections.rotation.fracture.explanation">
@@ -225,9 +225,12 @@ export default class Fracture extends Analyzer {
       </div>
     );
 
-    return explanationAndDataSubsection(
-      explanation,
-      this.castEntries.length > 0 ? data : noCastData,
+    return (
+      <ExplanationAndDataSubSection
+        explanation={explanation}
+        data={this.castEntries.length > 0 ? data : noCastData}
+        hideExplanation={hideExplanation}
+      />
     );
   }
 }

--- a/src/analysis/retail/demonhunter/vengeance/modules/talents/SpiritBomb.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/talents/SpiritBomb.tsx
@@ -190,7 +190,7 @@ export default class SpiritBomb extends Analyzer {
     );
   }
 
-  guideSubsection(hideExplanation: boolean) {
+  guideSubsection() {
     const explanation = (
       <p>
         <Trans id="guide.demonhunter.vengeance.sections.rotation.spritBomb.explanation">
@@ -238,7 +238,6 @@ export default class SpiritBomb extends Analyzer {
       <ExplanationAndDataSubSection
         explanation={explanation}
         data={this.castEntries.length > 0 ? data : noCastData}
-        hideExplanation={hideExplanation}
       />
     );
   }

--- a/src/analysis/retail/demonhunter/vengeance/modules/talents/SpiritBomb.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/talents/SpiritBomb.tsx
@@ -21,7 +21,7 @@ import { combineQualitativePerformances } from 'common/combineQualitativePerform
 import { t, Trans } from '@lingui/macro';
 import { SpellLink } from 'interface';
 import CastSummaryAndBreakdown from 'analysis/retail/demonhunter/shared/guide/CastSummaryAndBreakdown';
-import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { ExplanationAndDataSubSection } from 'interface/guide/components/ExplanationRow';
 import FieryDemiseExplanation from 'analysis/retail/demonhunter/vengeance/modules/core/FieryDemiseExplanation';
 import {
   SPIRIT_BOMB_SOULS_IN_META,
@@ -190,7 +190,7 @@ export default class SpiritBomb extends Analyzer {
     );
   }
 
-  guideSubsection() {
+  guideSubsection(hideExplanation: boolean) {
     const explanation = (
       <p>
         <Trans id="guide.demonhunter.vengeance.sections.rotation.spritBomb.explanation">
@@ -234,9 +234,12 @@ export default class SpiritBomb extends Analyzer {
       </div>
     );
 
-    return explanationAndDataSubsection(
-      explanation,
-      this.castEntries.length > 0 ? data : noCastData,
+    return (
+      <ExplanationAndDataSubSection
+        explanation={explanation}
+        data={this.castEntries.length > 0 ? data : noCastData}
+        hideExplanation={hideExplanation}
+      />
     );
   }
 }

--- a/src/interface/VerticallyAlignedToggle.tsx
+++ b/src/interface/VerticallyAlignedToggle.tsx
@@ -1,25 +1,28 @@
 import Tooltip from 'interface/Tooltip';
 import InformationIcon from 'interface/icons/Information';
 import Toggle from 'react-toggle';
+import { ReactNode } from 'react';
 
-interface EnableNewDefensivesSectionToggleProps {
+interface VerticallyAlignedToggleProps {
   enabled: boolean;
   setEnabled: (p: boolean) => void;
+  id: string;
+  label: ReactNode;
+  tooltipContent: ReactNode;
 }
-const EnableNewDefensivesSectionToggle = ({
+const VerticallyAlignedToggle = ({
   enabled,
   setEnabled,
-}: EnableNewDefensivesSectionToggleProps) => (
+  id,
+  label,
+  tooltipContent,
+}: VerticallyAlignedToggleProps) => (
   <div className="flex toggle-control" style={{ alignItems: 'center', padding: '5px 0' }}>
-    <label
-      className="flex-main"
-      htmlFor="enable-new-defensives-section-toggle"
-      style={{ marginBottom: '-0.35em' }}
-    >
-      View In-Flight Content
+    <label className="flex-main" htmlFor={id} style={{ marginBottom: '-0.35em' }}>
+      {label}
     </label>
     <div className="flex-sub" style={{ marginBottom: '-0.35em', padding: '0 10px' }}>
-      <Tooltip content="Only click this if you're okay with seeing under-development features. If things don't work how you expect, you can always turn this back off.">
+      <Tooltip content={tooltipContent}>
         <div>
           <InformationIcon style={{ fontSize: '1.4em' }} />
         </div>
@@ -29,10 +32,10 @@ const EnableNewDefensivesSectionToggle = ({
       checked={enabled}
       icons={false}
       onChange={(event) => setEnabled(event.target.checked)}
-      id="enable-new-defensives-section-toggle"
+      id={id}
       className="flex-sub"
     />
   </div>
 );
 
-export default EnableNewDefensivesSectionToggle;
+export default VerticallyAlignedToggle;

--- a/src/interface/guide/components/Explanation.tsx
+++ b/src/interface/guide/components/Explanation.tsx
@@ -1,12 +1,48 @@
 import styled from '@emotion/styled';
+import { ComponentPropsWithoutRef, createContext, ReactNode, useContext } from 'react';
+import useSessionFeatureFlag from 'interface/useSessionFeatureFlag';
+
+interface ExplanationContextValue {
+  hideExplanations: boolean;
+  setHideExplanations: (p: boolean) => void;
+}
+export const ExplanationContext = createContext<ExplanationContextValue>({
+  hideExplanations: false,
+  setHideExplanations: () => {
+    // no-op
+  },
+});
+
+interface ExplanationContextProviderProps {
+  children: ReactNode;
+}
+export const ExplanationContextProvider = ({ children }: ExplanationContextProviderProps) => {
+  const [hideExplanations, setHideExplanations] = useSessionFeatureFlag('hide-explanations');
+  return (
+    <ExplanationContext.Provider value={{ hideExplanations, setHideExplanations }}>
+      {children}
+    </ExplanationContext.Provider>
+  );
+};
+
+export const useExplanationContext = () => useContext(ExplanationContext);
 
 /** A container for explanatory text.
  *  For now this is just a div, a future update will allow a toggle to hide all Explanations. */
-const Explanation = styled.div`
+export const StyledExplanation = styled.div`
   .text-muted,
   small {
     color: rgba(202, 200, 196, 0.77);
   }
 `;
+
+/** A container for explanatory text. */
+const Explanation = (props: ComponentPropsWithoutRef<typeof StyledExplanation>) => {
+  const { hideExplanations } = useExplanationContext();
+  if (hideExplanations) {
+    return null;
+  }
+  return <StyledExplanation {...props} />;
+};
 
 export default Explanation;

--- a/src/interface/guide/components/ExplanationRow.tsx
+++ b/src/interface/guide/components/ExplanationRow.tsx
@@ -1,28 +1,26 @@
 import { ReactNode } from 'react';
 import styled from '@emotion/styled';
 import { SubSection } from 'interface/guide/index';
-import Explanation from 'interface/guide/components/Explanation';
+import Explanation, { useExplanationContext } from 'interface/guide/components/Explanation';
 
 export const leftPercentDefault = 30;
 
 /**
  * A container for holding two side-by-side panels, an explanation and data. By default, the left
- * side panel will be narrow. A future update will add a toggle to make the explanation panel
- * hidden and allow the data row to expand to full width.
+ * side panel will be narrow.
  */
 export default function ExplanationRow({
   children,
   leftPercent,
-  leftHide,
 }: {
   children: ReactNode;
   leftPercent?: number;
-  leftHide?: boolean;
 }) {
+  const { hideExplanations } = useExplanationContext();
   return (
     <StyledExplanationRow
       style={{
-        gridTemplateColumns: leftHide ? '1fr' : `${leftPercent ?? leftPercentDefault}% 1fr`,
+        gridTemplateColumns: hideExplanations ? '1fr' : `${leftPercent ?? leftPercentDefault}% 1fr`,
       }}
     >
       {children}
@@ -35,14 +33,12 @@ export function explanationAndDataSubsection(
   explanation: JSX.Element,
   data: JSX.Element,
   explanationPercent?: number,
-  hideExplanation?: boolean,
 ) {
   return (
     <ExplanationAndDataSubSection
       explanation={explanation}
       data={data}
       explanationPercent={explanationPercent}
-      hideExplanation={hideExplanation}
     />
   );
 }
@@ -51,24 +47,15 @@ export function ExplanationAndDataSubSection({
   explanation,
   data,
   explanationPercent,
-  hideExplanation,
 }: {
   explanation: ReactNode;
   data: ReactNode;
   explanationPercent?: number;
-  hideExplanation?: boolean;
 }) {
   return (
     <SubSection>
-      <ExplanationRow leftHide={hideExplanation} leftPercent={explanationPercent}>
-        <Explanation
-          style={{
-            display: hideExplanation ? 'none' : undefined,
-          }}
-          aria-hidden={hideExplanation}
-        >
-          {explanation}
-        </Explanation>
+      <ExplanationRow leftPercent={explanationPercent}>
+        <Explanation>{explanation}</Explanation>
         {data}
       </ExplanationRow>
     </SubSection>

--- a/src/interface/guide/components/ExplanationRow.tsx
+++ b/src/interface/guide/components/ExplanationRow.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { SubSection } from 'interface/guide/index';
 import Explanation from 'interface/guide/components/Explanation';
 
-const leftPercentDefault = 30;
+export const leftPercentDefault = 30;
 
 /**
  * A container for holding two side-by-side panels, an explanation and data. By default, the left
@@ -13,13 +13,17 @@ const leftPercentDefault = 30;
 export default function ExplanationRow({
   children,
   leftPercent,
+  leftHide,
 }: {
   children: ReactNode;
   leftPercent?: number;
+  leftHide?: boolean;
 }) {
   return (
     <StyledExplanationRow
-      style={{ gridTemplateColumns: `${leftPercent || leftPercentDefault}% 1fr` }}
+      style={{
+        gridTemplateColumns: leftHide ? '1fr' : `${leftPercent ?? leftPercentDefault}% 1fr`,
+      }}
     >
       {children}
     </StyledExplanationRow>
@@ -31,11 +35,40 @@ export function explanationAndDataSubsection(
   explanation: JSX.Element,
   data: JSX.Element,
   explanationPercent?: number,
+  hideExplanation?: boolean,
 ) {
   return (
+    <ExplanationAndDataSubSection
+      explanation={explanation}
+      data={data}
+      explanationPercent={explanationPercent}
+      hideExplanation={hideExplanation}
+    />
+  );
+}
+
+export function ExplanationAndDataSubSection({
+  explanation,
+  data,
+  explanationPercent,
+  hideExplanation,
+}: {
+  explanation: ReactNode;
+  data: ReactNode;
+  explanationPercent?: number;
+  hideExplanation?: boolean;
+}) {
+  return (
     <SubSection>
-      <ExplanationRow leftPercent={explanationPercent}>
-        <Explanation>{explanation}</Explanation>
+      <ExplanationRow leftHide={hideExplanation} leftPercent={explanationPercent}>
+        <Explanation
+          style={{
+            display: hideExplanation ? 'none' : undefined,
+          }}
+          aria-hidden={hideExplanation}
+        >
+          {explanation}
+        </Explanation>
         {data}
       </ExplanationRow>
     </SubSection>

--- a/src/interface/guide/components/HideExplanationsToggle.tsx
+++ b/src/interface/guide/components/HideExplanationsToggle.tsx
@@ -1,34 +1,34 @@
 import VerticallyAlignedToggle from 'interface/VerticallyAlignedToggle';
+import { useExplanationContext } from 'interface/guide/components/Explanation';
 
-interface Props {
-  hideExplanations: boolean;
-  setHideExplanations: (p: boolean) => void;
+interface HideExplanationToggleProps {
   id: string;
   label?: string;
   tooltipContent?: string;
 }
-const HideExplanationsToggle = ({
-  hideExplanations,
-  setHideExplanations,
+export const HideExplanationsToggle = ({
   id,
   label,
   tooltipContent,
-}: Props) => (
-  <div className="flex">
-    <div className="flex-main" />
-    <div className="flex-sub">
-      <VerticallyAlignedToggle
-        id={id}
-        enabled={hideExplanations}
-        setEnabled={setHideExplanations}
-        label={label ?? 'Hide Rotation Explanations'}
-        tooltipContent={
-          tooltipContent ??
-          "Enabling this feature will hide the explanations of what each ability does. Don't worry, you can always bring them back."
-        }
-      />
+}: HideExplanationToggleProps) => {
+  const { hideExplanations, setHideExplanations } = useExplanationContext();
+  return (
+    <div className="flex">
+      <div className="flex-main" />
+      <div className="flex-sub">
+        <VerticallyAlignedToggle
+          id={id}
+          enabled={hideExplanations}
+          setEnabled={setHideExplanations}
+          label={label ?? 'Hide Explanations'}
+          tooltipContent={
+            tooltipContent ??
+            "Enabling this feature will hide explanations throughout the Guide. Don't worry, you can always bring them back."
+          }
+        />
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default HideExplanationsToggle;

--- a/src/interface/guide/components/HideExplanationsToggle.tsx
+++ b/src/interface/guide/components/HideExplanationsToggle.tsx
@@ -1,0 +1,34 @@
+import VerticallyAlignedToggle from 'interface/VerticallyAlignedToggle';
+
+interface Props {
+  hideExplanations: boolean;
+  setHideExplanations: (p: boolean) => void;
+  id: string;
+  label?: string;
+  tooltipContent?: string;
+}
+const HideExplanationsToggle = ({
+  hideExplanations,
+  setHideExplanations,
+  id,
+  label,
+  tooltipContent,
+}: Props) => (
+  <div className="flex">
+    <div className="flex-main" />
+    <div className="flex-sub">
+      <VerticallyAlignedToggle
+        id={id}
+        enabled={hideExplanations}
+        setEnabled={setHideExplanations}
+        label={label ?? 'Hide Rotation Explanations'}
+        tooltipContent={
+          tooltipContent ??
+          "Enabling this feature will hide the explanations of what each ability does. Don't worry, you can always bring them back."
+        }
+      />
+    </div>
+  </div>
+);
+
+export default HideExplanationsToggle;

--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -14,3 +14,4 @@ export { default as ErrorBoundary } from './ErrorBoundary';
 export { default as Tooltip, TooltipElement } from './Tooltip';
 export { default as makeAnalyzerUrl } from './makeAnalyzerUrl';
 export { Expandable, ControlledExpandable } from './Expandable';
+export { default as VerticallyAlignedToggle } from './VerticallyAlignedToggle';

--- a/src/interface/useSessionFeatureFlag.ts
+++ b/src/interface/useSessionFeatureFlag.ts
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+
+const joinArrayToString = (arr: string[], separator: string) =>
+  arr.filter((it) => it).join(separator);
+
+const useSessionFeatureFlag = (featureFlag: string, featureFlagDefault: boolean = false) => {
+  const [sessionFeatureFlag, setSessionFeatureFlagState] = useState(() => {
+    const sessionFeatureFlagSetting = window.sessionStorage?.getItem(
+      // This will filter out if featureFlag is an empty string
+      joinArrayToString(['wowa-ff', featureFlag], '-'),
+    );
+    return sessionFeatureFlagSetting === null
+      ? featureFlagDefault
+      : sessionFeatureFlagSetting.toLowerCase() === 'true';
+  });
+  const setSessionFeatureFlag = (value: boolean) => {
+    try {
+      window.sessionStorage?.setItem(
+        // This will filter out if featureFlag is an empty string
+        joinArrayToString(['wowa-ff', featureFlag], '-'),
+        String(value),
+      );
+    } catch (e) {
+      // ignore it
+    }
+    setSessionFeatureFlagState(value);
+  };
+
+  return [sessionFeatureFlag, setSessionFeatureFlag] as const;
+};
+
+export default useSessionFeatureFlag;

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -88,6 +88,7 @@ import ParseResults from './ParseResults';
 import { PetInfo } from './Pet';
 import { PlayerInfo } from './Player';
 import Report from './Report';
+import { ExplanationContextProvider } from 'interface/guide/components/Explanation';
 
 // This prints to console anything that the DI has to do
 const debugDependencyInjection = false;
@@ -761,7 +762,9 @@ class CombatLogParser {
     return () => (
       <GuideContainer>
         <GuideContext.Provider value={props}>
-          <Component {...props} />
+          <ExplanationContextProvider>
+            <Component {...props} />
+          </ExplanationContextProvider>
         </GuideContext.Provider>
       </GuideContainer>
     );


### PR DESCRIPTION
I had a bit of extra time after raid so I took a swing at the switch to hide explanations. I wanted to allow adoption to be gradual instead of affecting everything, so the current example in VDH is using it as a session-storage-based state value per section.

An alternative to doing it this way and tracking the opt-in/opt-out across multiple sections would be to store it in the Guide context, which shouldn't take very much additional effort.

![hide-explanation-toggle](https://user-images.githubusercontent.com/1672786/208587506-0b5db468-c4f3-4a9f-b1c1-4397170f1ab8.gif)