### PR TITLE
Revert "Fix empowered cast efficiency ids for prevoker"

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -5,7 +5,6 @@ import { Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
-  change(date(2022, 12, 20), <>Fix cast efficiency tracking for empowered spells</>, Trevor),
   change(date(2022, 12, 14), <>Improved accuracy of <SpellLink id={TALENTS_EVOKER.ECHO_TALENT}/> module</>, Trevor),
   change(date(2022, 12, 14), <>Updated Mastery Effectiveness to include the value of the healing done in the effectiveness evaluation</>, Vohrr),
   change(date(2022, 12, 7), <>Fix load condition for <SpellLink id={TALENTS_EVOKER.DREAM_FLIGHT_TALENT.id}/></>, Trevor),

--- a/src/analysis/retail/evoker/preservation/modules/features/Abilities.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/features/Abilities.tsx
@@ -1,5 +1,4 @@
 import TALENTS from 'common/TALENTS/evoker';
-import SPELLS from 'common/SPELLS';
 import CoreAbilities from 'analysis/retail/evoker/shared/modules/Abilities';
 import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
 import { SpellbookAbility } from 'parser/core/modules/Ability';
@@ -22,7 +21,7 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.DREAM_BREATH_EMPOWER.id,
+        spell: TALENTS.DREAM_BREATH_TALENT.id,
         enabled: combatant.hasTalent(TALENTS.DREAM_BREATH_TALENT.id),
         category: SPELL_CATEGORY.ROTATIONAL_AOE,
         cooldown: 30,
@@ -52,7 +51,7 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(TALENTS.TIME_DILATION_TALENT.id),
       },
       {
-        spell: SPELLS.SPIRITBLOOM_EMPOWER.id,
+        spell: TALENTS.SPIRITBLOOM_TALENT.id,
         category: SPELL_CATEGORY.ROTATIONAL_AOE,
         cooldown: 30,
         gcd: {

--- a/src/analysis/retail/evoker/preservation/modules/features/Checklist/Component.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/features/Checklist/Component.tsx
@@ -36,9 +36,9 @@ const PreservationEvokerChecklist = ({ combatant, castEfficiency, thresholds }: 
         name="Use core abilities as often as possible"
         description="Aim to keep core rotational abilities on cooldown to maximize healing"
       >
-        <AbilityRequirement spell={SPELLS.DREAM_BREATH_EMPOWER.id} />
+        <AbilityRequirement spell={TALENTS_EVOKER.DREAM_BREATH_TALENT.id} />
         {combatant.hasTalent(TALENTS_EVOKER.SPIRITBLOOM_TALENT) && (
-          <AbilityRequirement spell={SPELLS.SPIRITBLOOM_EMPOWER.id} />
+          <AbilityRequirement spell={TALENTS_EVOKER.SPIRITBLOOM_TALENT.id} />
         )}
         {combatant.hasTalent(TALENTS_EVOKER.REVERSION_TALENT) && (
           <AbilityRequirement spell={TALENTS_EVOKER.REVERSION_TALENT.id} />

--- a/src/analysis/retail/evoker/shared/modules/Abilities.tsx
+++ b/src/analysis/retail/evoker/shared/modules/Abilities.tsx
@@ -32,7 +32,7 @@ class Abilities extends CoreAbilities {
       //endregion
       //region Damage Spells
       {
-        spell: SPELLS.FIRE_BREATH_EMPOWER.id,
+        spell: SPELLS.FIRE_BREATH.id,
         category: SPELL_CATEGORY.HEALER_DAMAGING_SPELL,
         cooldown: 30,
         gcd: {

--- a/src/common/SPELLS/evoker.ts
+++ b/src/common/SPELLS/evoker.ts
@@ -33,11 +33,6 @@ const spells = spellIndexableList({
     name: 'Dream Breath',
     icon: 'ability_evoker_dreambreath',
   },
-  DREAM_BREATH_EMPOWER: {
-    id: 382614,
-    name: 'Dream Breath',
-    icon: 'ability_evoker_dreambreath',
-  },
   TWIN_GUARDIAN_SHIELD: {
     id: 370889,
     name: 'Twin Guardian',
@@ -55,11 +50,6 @@ const spells = spellIndexableList({
   },
   SPIRITBLOOM: {
     id: 367230,
-    name: 'Spiritbloom',
-    icon: 'ability_evoker_spiritbloom2',
-  },
-  SPIRITBLOOM_EMPOWER: {
-    id: 382731,
     name: 'Spiritbloom',
     icon: 'ability_evoker_spiritbloom2',
   },
@@ -181,11 +171,6 @@ const spells = spellIndexableList({
     name: 'Fire Breath',
     icon: 'ability_evoker_firebreath',
   },
-  FIRE_BREATH_EMPOWER: {
-    id: 382266,
-    name: 'Fire Breath',
-    icon: 'ability_evoker_firebreath',
-  },
   DISINTEGRATE: {
     id: 356995,
     name: 'Disintegrate',
@@ -215,11 +200,6 @@ const spells = spellIndexableList({
     id: 374349,
     name: 'Renewing Blaze',
     icon: 'ability_evoker_masterylifebinder_red',
-  },
-  STASIS_BUFF: {
-    id: 370562,
-    name: 'Stasis',
-    icon: 'ability_evoker_stasis',
   },
   VERDANT_EMBRACE_HEAL: {
     id: 361195,


### PR DESCRIPTION
Reverts WoWAnalyzer/WoWAnalyzer#5553

Turns out blizzard changed spell ids between this week and last week and it was actually correct before but old logs are invalidated because blizzard is dumb