### PR TITLE
Improve accuracy of bountiful bloom module

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2022, 12, 21), <>Improved accuracy of <SpellLink id={TALENTS_EVOKER.BOUNTIFUL_BLOOM_TALENT}/> module</>, Trevor),
   change(date(2022, 12, 14), <>Improved accuracy of <SpellLink id={TALENTS_EVOKER.ECHO_TALENT}/> module</>, Trevor),
   change(date(2022, 12, 14), <>Updated Mastery Effectiveness to include the value of the healing done in the effectiveness evaluation</>, Vohrr),
   change(date(2022, 12, 7), <>Fix load condition for <SpellLink id={TALENTS_EVOKER.DREAM_FLIGHT_TALENT.id}/></>, Trevor),

--- a/src/analysis/retail/evoker/preservation/modules/talents/EmeraldBlossom.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/EmeraldBlossom.tsx
@@ -8,7 +8,7 @@ import TalentSpellText from 'parser/ui/TalentSpellText';
 import { TALENTS_EVOKER } from 'common/TALENTS';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
-import { getHealEvents, isFromFieldOfDreams } from '../../normalizers/CastLinkNormalizer';
+import { getHealEvents } from '../../normalizers/CastLinkNormalizer';
 import { SpellLink } from 'interface';
 import { formatNumber } from 'common/format';
 import { t } from '@lingui/macro';
@@ -20,7 +20,7 @@ class EmeraldBlossom extends Analyzer {
   bountifulBloomHealing: number = 0;
   bountifulBloomOverhealing: number = 0;
   extraBountifulHits: number = 0;
-  numCasts: number = 0;
+  numBlossoms: number = 0;
   totalHits: number = 0;
   totalHealing: number = 0;
   totalOverhealing: number = 0;
@@ -38,11 +38,11 @@ class EmeraldBlossom extends Analyzer {
   }
 
   get averageNumTargets() {
-    return this.totalHits / this.numCasts;
+    return this.totalHits / this.numBlossoms;
   }
 
   get averageExtraTargets() {
-    return this.extraBountifulHits / this.numCasts;
+    return this.extraBountifulHits / this.numBlossoms;
   }
 
   // batch process all healevents for single cast to easily decide which to attribute to bountiful
@@ -52,11 +52,8 @@ class EmeraldBlossom extends Analyzer {
     }
 
     const allHealingEvents = getHealEvents(event);
-    if (!isFromFieldOfDreams(event)) {
-      this.numCasts += 1;
-      this.totalHits += allHealingEvents.length;
-    }
-
+    this.totalHits += allHealingEvents.length;
+    this.numBlossoms += 1;
     for (let i = 0; i < allHealingEvents.length; i += 1) {
       const ev = allHealingEvents[i];
       this.totalHealing += (ev.amount || 0) + (ev.absorbed || 0);

--- a/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
@@ -312,6 +312,8 @@ const EVENT_LINKS: EventLink[] = [
     referencedEventId: [SPELLS.EMERALD_BLOSSOM.id, SPELLS.TEMPORAL_ANOMALY_SHIELD.id],
     referencedEventType: EventType.Heal,
     anyTarget: true,
+    forwardBufferMs: 25,
+    backwardBufferMs: 25,
     additionalCondition(linkingEvent, referencedEvent) {
       if (
         (linkingEvent as AbilityEvent<any>).ability.guid !==


### PR DESCRIPTION
Changed module to ignore field of dreams distinction and just look at avg targets for every blossom
Also added some lag tolerance that fixed some blossom heals being marked as groups of 1 because they were 20 ms before rest of blossom heals

Before:
![image](https://user-images.githubusercontent.com/11250934/208866758-b86b6051-0bb3-4b1f-ad6c-e05bdf752e91.png)

After:
![image](https://user-images.githubusercontent.com/11250934/208866672-b775e17d-2198-4f7e-954f-a18ec7c8e256.png)
