### PR TITLE
Classic Arcane Mage updates

### DIFF
--- a/src/analysis/classic/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/classic/mage/arcane/CHANGELOG.tsx
@@ -2,5 +2,6 @@ import { change, date } from 'common/changelog';
 import { jazminite } from 'CONTRIBUTORS';
 
 export default [
-  change(date(2022, 12, 4), 'First draft of guide for Classic Arcane Mage.', jazminite),
+  change(date(2022, 12, 21), 'Add buffs and trinket procs to timeline.', jazminite),
+  change(date(2022, 12, 4), 'Initial guide for Classic Arcane Mage.', jazminite),
 ];

--- a/src/analysis/classic/mage/arcane/CONFIG.tsx
+++ b/src/analysis/classic/mage/arcane/CONFIG.tsx
@@ -15,13 +15,13 @@ const config: Config = {
   expansion: Expansion.WrathOfTheLichKing,
   // The WoW client patch this spec was last updated.
   patchCompatibility: '3.4.0',
-  isPartial: true,
+  isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
-      Welcome! Thank you for using WoWAnalyzer to improve your overall Arcane Mage game play. The
-      tool is under active development and may provide suggestions that are strange.
+      Welcome! Thanks for using WoWAnalyzer to improve your overall Arcane Mage game play. The tool
+      is under active development and may provide suggestions that are strange.
       <br />
       If you have any suggestions or comments, please submit a{' '}
       <a
@@ -42,7 +42,7 @@ const config: Config = {
     },
   },
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/ghKA9Dj8qardP31W/6-Normal+Patchwerk+-+Kill+(2:02)/Jurgy',
+  exampleReport: '/report/GCKaR184npYPM3WF/57-Normal+Patchwerk+-+Kill+(1:29)/Bouncycastle',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/classic/mage/arcane/modules/features/Buffs.tsx
+++ b/src/analysis/classic/mage/arcane/modules/features/Buffs.tsx
@@ -1,16 +1,30 @@
-import SPELLS from 'common/SPELLS/classic/mage';
-import BLOODLUST_BUFFS from 'game/BLOODLUST_BUFFS';
 import CoreAuras from 'parser/core/modules/Auras';
+
+import BLOODLUST_BUFFS from 'game/BLOODLUST_BUFFS';
+import ITEMS from 'game/classic/ITEM_BUFFS';
+import SPELLS from 'common/SPELLS/classic';
 
 class Buffs extends CoreAuras {
   auras() {
     return [
+      {
+        spellId: SPELLS.INCANTERS_ABSORPTION.id,
+        timelineHighlight: true,
+      },
+      {
+        spellId: SPELLS.LIGHTWEAVE_BUFF.id,
+        timelineHighlight: true,
+      },
       {
         spellId: SPELLS.MISSILE_BARRAGE.id,
         timelineHighlight: true,
       },
       {
         spellId: Object.keys(BLOODLUST_BUFFS).map((item) => Number(item)),
+        timelineHighlight: true,
+      },
+      {
+        spellId: Object.keys(ITEMS).map((item) => Number(item)),
         timelineHighlight: true,
       },
     ];

--- a/src/common/ITEMS/classic/index.ts
+++ b/src/common/ITEMS/classic/index.ts
@@ -1,9 +1,11 @@
 import safeMerge from '../../safeMerge';
+import Cooking from './cooking';
 import OTHERS from './others';
-import Cooking from 'common/ITEMS/classic/cooking';
+import Trinkets from './trinkets';
 
 const items = {
   ...safeMerge(Cooking),
   ...safeMerge(OTHERS),
+  ...safeMerge(Trinkets),
 };
 export default items;

--- a/src/common/ITEMS/classic/trinkets.ts
+++ b/src/common/ITEMS/classic/trinkets.ts
@@ -1,0 +1,30 @@
+import { itemIndexableList } from 'common/ITEMS/Item';
+
+const items = itemIndexableList({
+  // Dying Curse - https://www.wowhead.com/wotlk/item=40255
+  DYING_CURSE_BUFF: {
+    id: 60494,
+    name: 'Dying Curse',
+    icon: 'spell_holy_mindvision',
+  },
+  // Embrace of the Spider - https://www.wowhead.com/wotlk/item=39229
+  EMBRACE_SPIDER_BUFF: {
+    id: 60492,
+    name: 'Embrace of the Spider',
+    icon: 'spell_holy_searinglight',
+  },
+  // Illustration of the Dragon Soul - https://www.wowhead.com/wotlk/item=40432
+  ILLUSTRATION_DRAGON_SOUL_BUFF: {
+    id: 60486,
+    name: 'Illustration of the Dragon Soul',
+    icon: 'inv_offhand_hyjal_d_01',
+  },
+  // Sundial of the Exiled - https://www.wowhead.com/wotlk/item=40682
+  SUNDIAL_BUFF: {
+    id: 60064,
+    name: 'Now is the time!',
+    icon: 'ability_hunter_readiness',
+  },
+});
+
+export default items;

--- a/src/common/SPELLS/classic/index.ts
+++ b/src/common/SPELLS/classic/index.ts
@@ -27,6 +27,7 @@ import WARRIOR from './warrior';
 // Other
 import Engineering from './engineering';
 import Racials from './racials';
+import Tailoring from './tailoring';
 
 const ABILITIES = {
   ...DEATH_KNIGHT,
@@ -39,6 +40,7 @@ const ABILITIES = {
   ...WARRIOR,
   ...Engineering,
   ...Racials,
+  ...Tailoring,
 } as const;
 
 const InternalSpellTable = indexById<Spell | Enchant, typeof ABILITIES>(ABILITIES);

--- a/src/common/SPELLS/classic/mage.ts
+++ b/src/common/SPELLS/classic/mage.ts
@@ -323,6 +323,11 @@ const spells = spellIndexableList({
     name: 'Focus Magic',
     icon: 'spell_arcane_studentofmagic',
   },
+  INCANTERS_ABSORPTION: {
+    id: 44413,
+    name: "Incanter's Absorption",
+    icon: 'spell_arcane_studentofmagic',
+  },
   MISSILE_BARRAGE: {
     id: 44401,
     name: 'Missile Barrage',

--- a/src/common/SPELLS/classic/tailoring.ts
+++ b/src/common/SPELLS/classic/tailoring.ts
@@ -1,0 +1,11 @@
+import { spellIndexableList } from '../Spell';
+
+const spells = spellIndexableList({
+  LIGHTWEAVE_BUFF: {
+    id: 55637,
+    name: 'Lightweave',
+    icon: 'spell_arcane_prismaticcloak',
+  },
+});
+
+export default spells;

--- a/src/game/classic/ITEM_BUFFS.ts
+++ b/src/game/classic/ITEM_BUFFS.ts
@@ -1,0 +1,22 @@
+import ITEMS from 'common/ITEMS/classic';
+
+const ITEM_BUFFS: {
+  [key: number]: {
+    haste_rating?: number;
+    spell_power?: number;
+  };
+} = {
+  [ITEMS.DYING_CURSE_BUFF.id]: {
+    spell_power: 765,
+  },
+  [ITEMS.EMBRACE_SPIDER_BUFF.id]: {
+    haste_rating: 505,
+  },
+  [ITEMS.ILLUSTRATION_DRAGON_SOUL_BUFF.id]: {
+    spell_power: 20,
+  },
+  [ITEMS.SUNDIAL_BUFF.id]: {
+    spell_power: 505,
+  },
+};
+export default ITEM_BUFFS;


### PR DESCRIPTION
### Add buffs and trinket procs to timeline
- Incantor's Absorption
- Lightweave (for Tailors)
- Caster trinkets

Example report: `/report/GCKaR184npYPM3WF/57-Normal+Patchwerk+-+Kill+(1:29)/Bouncycastle/standard/timeline`
![image](https://user-images.githubusercontent.com/65823478/209022273-2c68f41f-a773-457f-af33-a7caaae25f5f.png)

### Minor updates
- Set partial to false
- Update example report
