### PR TITLE
[Hunter] Enable Marksmanship to work on DF logs, as most analysis should work

### DIFF
--- a/src/analysis/retail/hunter/marksmanship/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/marksmanship/CHANGELOG.tsx
@@ -2,5 +2,6 @@ import { change, date } from 'common/changelog';
 import { Arlie, Putro } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2022,12,23), 'Enable Marksmanship for Dragonflight analysis', Putro),
   change(date(2022, 11, 11), 'Initial transition of Marksmanship to Dragonflight', [Arlie, Putro]),
 ];

--- a/src/analysis/retail/hunter/marksmanship/CONFIG.tsx
+++ b/src/analysis/retail/hunter/marksmanship/CONFIG.tsx
@@ -7,7 +7,7 @@ import CHANGELOG from './CHANGELOG';
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Putro],
-  expansion: Expansion.Shadowlands,
+  expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
   patchCompatibility: null,
   isPartial: true,


### PR DESCRIPTION
Seems I forgot this when transitioning to Dragonflight originally