### PR TITLE
fix broken lazy-loaded statistics

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -17,6 +17,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2022, 12, 25), 'Fix broken lazy-loaded statistics.', ToppleTheNun),
   change(date(2022, 12, 25), 'Remove Refreshing Healing Potion and Potion of Withering Vitality from combat potion checking.', ToppleTheNun),
   change(date(2022, 12, 25), 'Stop using Wowhead beta links for Dragonflight content.', ToppleTheNun),
   change(date(2022, 12, 20), 'Ignore duplicate spell IDs for talents during development.', ToppleTheNun),

--- a/src/interface/report/Results/ResultsContext.tsx
+++ b/src/interface/report/Results/ResultsContext.tsx
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react';
+import ParseResults from 'parser/core/ParseResults';
+
+export interface ResultsContextValue {
+  generateResults: () => void;
+  results: ParseResults | null;
+}
+
+export const ResultsContext = createContext<ResultsContextValue>({
+  generateResults: () => {
+    // no-op
+  },
+  results: null,
+});
+
+export const useResults = () => useContext(ResultsContext);

--- a/src/interface/report/Results/index.tsx
+++ b/src/interface/report/Results/index.tsx
@@ -20,11 +20,13 @@ import CombatLogParser from 'parser/core/CombatLogParser';
 import Fight from 'parser/core/Fight';
 import { PlayerInfo } from 'parser/core/Player';
 import Report from 'parser/core/Report';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { Link, useLocation } from 'react-router-dom';
 import { CombatLogParserProvider } from 'interface/report/CombatLogParserContext';
 import ResultsContent from 'interface/report/Results/ResultsContent';
+import { ResultsContext } from 'interface/report/Results/ResultsContext';
+import ParseResults from 'parser/core/ParseResults';
 import Expansion from 'game/Expansion';
 
 import './Results.scss';
@@ -67,19 +69,37 @@ const Results = (props: PassedProps) => {
   const selectedTab = getResultTab(location.pathname);
   const dispatch = useDispatch();
   const [adjustForDowntime, setAdjustForDowntime] = useState(false);
+  const [results, setResults] = useState<ParseResults | null>(null);
 
-  const isLoading =
-    props.isLoadingParser ||
-    props.isLoadingEvents ||
-    props.bossPhaseEventsLoadingState === BOSS_PHASES_STATE.LOADING ||
-    props.isLoadingCharacterProfile ||
-    props.isLoadingPhases ||
-    props.isFilteringEvents ||
-    props.parsingState !== EVENT_PARSING_STATE.DONE;
+  const generateResults = useCallback(() => {
+    if (props.parser == null) {
+      setResults(null);
+      return;
+    }
+    setResults(props.parser.generateResults(adjustForDowntime));
+  }, [adjustForDowntime, props.parser]);
+
+  const isLoading = useMemo(
+    () =>
+      props.isLoadingParser ||
+      props.isLoadingEvents ||
+      props.bossPhaseEventsLoadingState === BOSS_PHASES_STATE.LOADING ||
+      props.isLoadingCharacterProfile ||
+      props.isLoadingPhases ||
+      props.isFilteringEvents ||
+      props.parsingState !== EVENT_PARSING_STATE.DONE,
+    [
+      props.bossPhaseEventsLoadingState,
+      props.isFilteringEvents,
+      props.isLoadingCharacterProfile,
+      props.isLoadingEvents,
+      props.isLoadingParser,
+      props.isLoadingPhases,
+      props.parsingState,
+    ],
+  );
 
   const boss = findByBossId(props.fight.boss);
-
-  const results = isLoading ? null : props.parser.generateResults(adjustForDowntime);
 
   const appendHistory = useCallback(
     (report: Report, fight: Fight, player: PlayerInfo) => {
@@ -100,6 +120,12 @@ const Results = (props: PassedProps) => {
     },
     [dispatch],
   );
+
+  useEffect(() => {
+    if (!isLoading) {
+      generateResults();
+    }
+  }, [generateResults, isLoading]);
 
   // on game version change
   useEffect(() => {
@@ -146,159 +172,163 @@ const Results = (props: PassedProps) => {
   const reportDuration = props.report.end - props.report.start;
 
   return (
-    <div className={`results boss-${props.fight.boss}`}>
-      <Header
-        config={props.config}
-        player={props.player}
-        characterProfile={props.characterProfile}
-        boss={boss}
-        fight={props.fight}
-        tabs={results ? results.tabs : []}
-        makeTabUrl={props.makeTabUrl}
-        selectedTab={selectedTab}
-        selectedPhase={props.selectedPhase}
-        selectedInstance={props.selectedInstance}
-        phases={props.phases}
-        handlePhaseSelection={props.handlePhaseSelection}
-        applyFilter={props.applyFilter}
-        build={props.build}
-        isLoading={isLoading}
-      />
-
-      {props.fight.end_time > MAX_REPORT_DURATION && (
-        <ReportDurationWarning duration={reportDuration} />
-      )}
-
-      {props.parser && props.parser.disabledModules && (
-        <DegradedExperience disabledModules={props.parser.disabledModules} />
-      )}
-      {boss && boss.fight.resultsWarning && (
-        <div className="container">
-          <AlertWarning style={{ marginBottom: 30 }}>{boss.fight.resultsWarning}</AlertWarning>
-        </div>
-      )}
-      {props.parser && props.parser.selectedCombatant.gear && (
-        <ItemWarning gear={props.parser.selectedCombatant.gear} />
-      )}
-      {props.timeFilter && (
-        <div className="container">
-          <AlertWarning style={{ marginBottom: 30 }}>
-            <Trans id="interface.report.results.warning.timeFilter">
-              These results are filtered to the selected time period. Time filtered results are
-              under development and may not be entirely accurate. <br /> Please report any issues
-              you may find on our GitHub or Discord.
-            </Trans>
-          </AlertWarning>
-        </div>
-      )}
-      {props.build && props.build !== 'default' && (
-        <div className="container">
-          <AlertWarning style={{ marginBottom: 30 }}>
-            <Trans id="interface.report.results.warning.build">
-              These results are analyzed under build different from the standard build. While this
-              will make some modules more accurate, some may also not provide the information you
-              expect them to. <br /> Please report any issues you may find on our GitHub or Discord.
-            </Trans>
-          </AlertWarning>
-        </div>
-      )}
-      <CombatLogParserProvider combatLogParser={props.parser}>
-        <ResultsContent
+    <ResultsContext.Provider value={{ results, generateResults }}>
+      <div className={`results boss-${props.fight.boss}`}>
+        <Header
           config={props.config}
-          isLoading={isLoading}
-          parser={props.parser}
-          results={results}
+          player={props.player}
+          characterProfile={props.characterProfile}
+          boss={boss}
+          fight={props.fight}
+          tabs={results ? results.tabs : []}
+          makeTabUrl={props.makeTabUrl}
           selectedTab={selectedTab}
-          adjustForDowntime={adjustForDowntime}
-          setAdjustForDowntime={setAdjustForDowntime}
-          progress={props.progress}
-          isLoadingParser={props.isLoadingParser}
-          isLoadingEvents={props.isLoadingEvents}
-          bossPhaseEventsLoadingState={props.bossPhaseEventsLoadingState}
-          isLoadingCharacterProfile={props.isLoadingCharacterProfile}
-          isLoadingPhases={props.isLoadingPhases}
-          isFilteringEvents={props.isFilteringEvents}
-          parsingState={props.parsingState}
+          selectedPhase={props.selectedPhase}
+          selectedInstance={props.selectedInstance}
+          phases={props.phases}
+          handlePhaseSelection={props.handlePhaseSelection}
+          applyFilter={props.applyFilter}
+          build={props.build}
+          isLoading={isLoading}
         />
-      </CombatLogParserProvider>
 
-      <div className="container" style={{ marginTop: 40 }}>
-        <div className="row">
-          <div className="col-md-8">
-            <small>
-              <Trans id="interface.report.results.providedBy">Provided by</Trans>
-            </small>
-            <div style={{ fontSize: 16 }}>
-              <Trans id="interface.report.results.providedByDetails">
-                {props.config.spec.specName} {props.config.spec.className} analysis has been
-                provided by {contributorinfo}. They love hearing what you think, so please let them
-                know!{' '}
-                <Link to={props.makeTabUrl('about')}>
-                  More information about this spec's analyzer.
-                </Link>
+        {props.fight.end_time > MAX_REPORT_DURATION && (
+          <ReportDurationWarning duration={reportDuration} />
+        )}
+
+        {props.parser && props.parser.disabledModules && (
+          <DegradedExperience disabledModules={props.parser.disabledModules} />
+        )}
+        {boss && boss.fight.resultsWarning && (
+          <div className="container">
+            <AlertWarning style={{ marginBottom: 30 }}>{boss.fight.resultsWarning}</AlertWarning>
+          </div>
+        )}
+        {props.parser && props.parser.selectedCombatant.gear && (
+          <ItemWarning gear={props.parser.selectedCombatant.gear} />
+        )}
+        {props.timeFilter && (
+          <div className="container">
+            <AlertWarning style={{ marginBottom: 30 }}>
+              <Trans id="interface.report.results.warning.timeFilter">
+                These results are filtered to the selected time period. Time filtered results are
+                under development and may not be entirely accurate. <br /> Please report any issues
+                you may find on our GitHub or Discord.
               </Trans>
-            </div>
+            </AlertWarning>
           </div>
-          <div className="col-md-3">
-            <small>
-              <Trans id="interface.report.results.viewOn">View on</Trans>
-            </small>
-            <br />
-            <Tooltip
-              content={t({
-                id: 'interface.report.results.tooltip.newTab.originalReport',
-                message: `Opens in a new tab. View the original report.`,
-              })}
-            >
-              <a
-                href={makeWclUrl(
-                  props.report.code,
-                  {
-                    fight: props.fight.id,
-                    source: props.parser ? props.parser.playerId : undefined,
-                  },
-                  wclGameVersionToExpansion(props.report.gameVersion),
-                )}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="btn"
-                style={{ fontSize: 20, padding: '6px 0' }}
-              >
-                <WarcraftLogsIcon style={{ height: '1.2em', marginTop: '-0.1em' }} /> Warcraft Logs
-              </a>
-            </Tooltip>
-            <br />
-            <Tooltip
-              content={t({
-                id: 'interface.report.results.tooltip.newTab.insightsAndTimelines',
-                message: `Opens in a new tab. View insights and timelines for raid encounters.`,
-              })}
-            >
-              <a
-                href={`https://www.wipefest.net/report/${props.report.code}/fight/${props.fight.id}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="btn"
-                style={{ fontSize: 20, padding: '6px 0' }}
-              >
-                <WipefestIcon style={{ height: '1.2em', marginTop: '-0.1em' }} /> Wipefest
-              </a>
-            </Tooltip>
+        )}
+        {props.build && props.build !== 'default' && (
+          <div className="container">
+            <AlertWarning style={{ marginBottom: 30 }}>
+              <Trans id="interface.report.results.warning.build">
+                These results are analyzed under build different from the standard build. While this
+                will make some modules more accurate, some may also not provide the information you
+                expect them to. <br /> Please report any issues you may find on our GitHub or
+                Discord.
+              </Trans>
+            </AlertWarning>
           </div>
-          <div className="col-md-1">
-            <Tooltip
-              content={
-                <Trans id="interface.report.results.tooltip.backToTop">
-                  Scroll back to the top.
+        )}
+        <CombatLogParserProvider combatLogParser={props.parser}>
+          <ResultsContent
+            config={props.config}
+            isLoading={isLoading}
+            parser={props.parser}
+            results={results}
+            selectedTab={selectedTab}
+            adjustForDowntime={adjustForDowntime}
+            setAdjustForDowntime={setAdjustForDowntime}
+            progress={props.progress}
+            isLoadingParser={props.isLoadingParser}
+            isLoadingEvents={props.isLoadingEvents}
+            bossPhaseEventsLoadingState={props.bossPhaseEventsLoadingState}
+            isLoadingCharacterProfile={props.isLoadingCharacterProfile}
+            isLoadingPhases={props.isLoadingPhases}
+            isFilteringEvents={props.isFilteringEvents}
+            parsingState={props.parsingState}
+          />
+        </CombatLogParserProvider>
+
+        <div className="container" style={{ marginTop: 40 }}>
+          <div className="row">
+            <div className="col-md-8">
+              <small>
+                <Trans id="interface.report.results.providedBy">Provided by</Trans>
+              </small>
+              <div style={{ fontSize: 16 }}>
+                <Trans id="interface.report.results.providedByDetails">
+                  {props.config.spec.specName} {props.config.spec.className} analysis has been
+                  provided by {contributorinfo}. They love hearing what you think, so please let
+                  them know!{' '}
+                  <Link to={props.makeTabUrl('about')}>
+                    More information about this spec's analyzer.
+                  </Link>
                 </Trans>
-              }
-            >
-              <ScrollToTop />
-            </Tooltip>
+              </div>
+            </div>
+            <div className="col-md-3">
+              <small>
+                <Trans id="interface.report.results.viewOn">View on</Trans>
+              </small>
+              <br />
+              <Tooltip
+                content={t({
+                  id: 'interface.report.results.tooltip.newTab.originalReport',
+                  message: `Opens in a new tab. View the original report.`,
+                })}
+              >
+                <a
+                  href={makeWclUrl(
+                    props.report.code,
+                    {
+                      fight: props.fight.id,
+                      source: props.parser ? props.parser.playerId : undefined,
+                    },
+                    wclGameVersionToExpansion(props.report.gameVersion),
+                  )}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn"
+                  style={{ fontSize: 20, padding: '6px 0' }}
+                >
+                  <WarcraftLogsIcon style={{ height: '1.2em', marginTop: '-0.1em' }} /> Warcraft
+                  Logs
+                </a>
+              </Tooltip>
+              <br />
+              <Tooltip
+                content={t({
+                  id: 'interface.report.results.tooltip.newTab.insightsAndTimelines',
+                  message: `Opens in a new tab. View insights and timelines for raid encounters.`,
+                })}
+              >
+                <a
+                  href={`https://www.wipefest.net/report/${props.report.code}/fight/${props.fight.id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn"
+                  style={{ fontSize: 20, padding: '6px 0' }}
+                >
+                  <WipefestIcon style={{ height: '1.2em', marginTop: '-0.1em' }} /> Wipefest
+                </a>
+              </Tooltip>
+            </div>
+            <div className="col-md-1">
+              <Tooltip
+                content={
+                  <Trans id="interface.report.results.tooltip.backToTop">
+                    Scroll back to the top.
+                  </Trans>
+                }
+              >
+                <ScrollToTop />
+              </Tooltip>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </ResultsContext.Provider>
   );
 };
 

--- a/src/parser/ui/LazyLoadStatisticBox.tsx
+++ b/src/parser/ui/LazyLoadStatisticBox.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useState } from 'react';
 
 import StatisticBox from './StatisticBox';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import { useResults } from 'interface/report/Results/ResultsContext';
 
 export { STATISTIC_ORDER } from './StatisticBox';
 
@@ -31,6 +32,7 @@ interface Props {
 const LazyLoadStatisticBox = ({ loader, value, children, ...others }: Props) => {
   const [loaded, setLoaded] = useState(false);
   const [loading, setLoading] = useState(false);
+  const { generateResults } = useResults();
 
   const handleClick = () => {
     if (loaded) {
@@ -40,6 +42,7 @@ const LazyLoadStatisticBox = ({ loader, value, children, ...others }: Props) => 
     loader().then((result) => {
       setLoading(false);
       setLoaded(true);
+      generateResults();
       return result;
     });
   };


### PR DESCRIPTION
certain statistics like Power Word: Barrier use
LazyLoadStatisticBox in order to lazily load certain data from WCL. when clicking on the box to load the statistic, they are not currently updating with the appropriate value.

before the functional component rewrite of Results, Results exposed a `forceUpdate` function via the legacy context API. this `forceUpdate` function called a `forceUpdate` function exposed by the React `Component` class. the `forceUpdate` function caused a full-rerender of the Results component tree. once the Results component was rewritten as a functional component, access to this method was lost.

Analyzer instances are not React components, but they expose multiple functions that can return React components. `statistic` is one of these. React components returned by `statistic` are combined in the `CombatLogParser#generateResults` function and only update with data from their Analyzer instance if `statistic` is invoked.

after tracing the render tree for the Analyzer `statistic` function, I came to the conclusion that this below line was no longer being invoked once the statistic was clicked, causing the `statistic` function to subsequently not be invoked:
```
const results = isLoading ? null : props.parser.generateResults(adjustForDowntime);
```

as it is written, it is intended to be evaluated every time the Results component is rendered. since we currently only render the Results component when a full report/fight/player combination is selected, this leads to Results only being rendered once (and generateResults only being invoked once) - though clicking the toggle that adjusts statistics for downtime can cause a re-render of the Results component. this proved that a re-render of Results would resolve the issue.

for functional components, re-renders typically happen when props change or internal hook state changes occur. as mentioned previously, functional components don't have a built-in equivalent of `forceUpdate`. the React docs have a suggested alternative using hooks (though they do caution against this pattern):
```
const [ignored, forceUpdate] = useReducer(x => x + 1, 0);
```

I came to the conclusion that `forceUpdate` wasn't actually what we want the LazyLoadStatisticBox component to cause. what the LazyLoadStatisticBox really wants is to cause the `CombatLogParser#generateResults` function to be evaluated. as a result, my solution is to store the `ParseResults` from the evaluation in state, evaluate it whenever the CombatLogParser instance changes, and provide a React context that can be consumed by LazyLoadStatisticBox to force a re-evaluation. the evaluation whenever the CombatLogParser instance changes allows the current desired behavior to be maintained while also not invoking the "expensive" evaluation on every single prop change.

![lazyloadstatisticbox-fix](https://user-images.githubusercontent.com/1672786/209504655-f73bb42e-d1a7-42b1-962b-9e4a801992db.gif)
