### PR TITLE
[Mistweaver] Mending Proliferation 

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2022, 12, 27), <>Added <SpellLink id={TALENTS_MONK.MENDING_PROLIFERATION_TALENT.id}/> module.</>, Vohrr),
   change(date(2022, 12, 20), <>Fix suggestion for <SpellLink id={TALENTS_MONK.SUMMON_JADE_SERPENT_STATUE_TALENT.id}/></>, Vohrr),
   change(date(2022, 12, 18), <>Fix suggestion for <SpellLink id={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT.id}/> usage based on talent selection</>, Trevor),
   change(date(2022, 12, 18), <>Add suggestion for <SpellLink id={TALENTS_MONK.ANCIENT_TEACHINGS_TALENT.id}/> buff uptime</>, Trevor),

--- a/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
+++ b/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
@@ -74,6 +74,7 @@ import T29TierSet from './modules/dragonflight/tier/T29MWTier';
 import DancingMists from './modules/spells/DancingMists';
 import MistyPeaksHealingBreakdown from './modules/features/MistyPeaksHealingBreakdown';
 import TalentHealingStatistic from './modules/features/TalentHealingStatistic';
+import MendingProliferation from './modules/spells/MendingProliferation';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -158,6 +159,7 @@ class CombatLogParser extends CoreCombatLogParser {
     unison: Unison,
     rapidDiffusion: RapidDiffusion,
     dancingMists: DancingMists,
+    mendingProliferation: MendingProliferation,
 
     // Borrowed Power
     t29TierSet: T29TierSet,

--- a/src/analysis/retail/monk/mistweaver/constants.ts
+++ b/src/analysis/retail/monk/mistweaver/constants.ts
@@ -38,6 +38,8 @@ export const NOURISHING_CHI_INC = 0.2;
 export const DANCING_MIST_CHANCE = 0.05; // per rank
 export const RAPID_DIFFUSION_DURATION = 3000; // per rank
 export const RISING_MIST_EXTENSION = 4000;
+export const ENVELOPING_MIST_INCREASE = 0.3;
+export const MISTWRAP_INCREASE = 0.1;
 
 export const LIFECYCLES_MANA_PERC_REDUCTION = 0.25;
 

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EnvelopingMists.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EnvelopingMists.tsx
@@ -9,6 +9,7 @@ import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { ENVELOPING_MIST_INCREASE, MISTWRAP_INCREASE } from '../../constants';
 
 const UNAFFECTED_SPELLS: number[] = [TALENTS_MONK.ENVELOPING_MIST_TALENT.id];
 
@@ -27,8 +28,8 @@ class EnvelopingMists extends Analyzer {
   constructor(options: Options) {
     super(options);
     this.evmHealingIncrease = this.selectedCombatant.hasTalent(TALENTS_MONK.MIST_WRAP_TALENT.id)
-      ? 0.4
-      : 0.3;
+      ? ENVELOPING_MIST_INCREASE + MISTWRAP_INCREASE
+      : ENVELOPING_MIST_INCREASE;
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(TALENTS_MONK.ENVELOPING_MIST_TALENT),
       this.castEnvelopingMist,

--- a/src/analysis/retail/monk/mistweaver/modules/spells/MendingProliferation.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/MendingProliferation.tsx
@@ -25,11 +25,9 @@ class MendingProliferation extends Analyzer {
     if (!this.active) {
       return;
     }
-    this.mendingProlifHealingIncrease = this.selectedCombatant.hasTalent(
-      TALENTS_MONK.MIST_WRAP_TALENT.id,
-    )
-      ? ENVELOPING_MIST_INCREASE + MISTWRAP_INCREASE
-      : ENVELOPING_MIST_INCREASE;
+    this.mendingProlifHealingIncrease =
+      ENVELOPING_MIST_INCREASE +
+      MISTWRAP_INCREASE * this.selectedCombatant.getTalentRank(TALENTS_MONK.MIST_WRAP_TALENT);
     this.addEventListener(Events.heal.by(SELECTED_PLAYER), this.handleHeal);
   }
 

--- a/src/analysis/retail/monk/mistweaver/modules/spells/MendingProliferation.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/MendingProliferation.tsx
@@ -1,0 +1,80 @@
+import { TALENTS_MONK } from 'common/TALENTS';
+import { SpellIcon } from 'interface';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
+import Events, { HealEvent } from 'parser/core/Events';
+import Combatants from 'parser/shared/modules/Combatants';
+import BoringValueText from 'parser/ui/BoringValueText';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { ENVELOPING_MIST_INCREASE, MISTWRAP_INCREASE } from '../../constants';
+
+class MendingProliferation extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+  protected combatants!: Combatants;
+  mendingProlifHealingIncrease: number = 0;
+  bonusHealingFromMendingProlif: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.MENDING_PROLIFERATION_TALENT.id);
+    if (!this.active) {
+      return;
+    }
+    this.mendingProlifHealingIncrease = this.selectedCombatant.hasTalent(
+      TALENTS_MONK.MIST_WRAP_TALENT.id,
+    )
+      ? ENVELOPING_MIST_INCREASE + MISTWRAP_INCREASE
+      : ENVELOPING_MIST_INCREASE;
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER), this.handleHeal);
+  }
+
+  handleHeal(event: HealEvent) {
+    const targetID = event.targetID;
+    if (
+      !this.combatants.players[targetID] ||
+      event.ability.guid === TALENTS_MONK.ENVELOPING_MIST_TALENT.id
+    ) {
+      return;
+    }
+    if (
+      this.combatants.players[targetID].hasBuff(
+        TALENTS_MONK.MENDING_PROLIFERATION_TALENT.id,
+        event.timestamp,
+        0,
+        0,
+      )
+    ) {
+      this.bonusHealingFromMendingProlif += calculateEffectiveHealing(
+        event,
+        this.mendingProlifHealingIncrease,
+      );
+    }
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(500)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+      >
+        <BoringValueText
+          label={
+            <>
+              <SpellIcon id={TALENTS_MONK.MENDING_PROLIFERATION_TALENT.id} /> Mending Proliferation
+            </>
+          }
+        >
+          <ItemHealingDone amount={this.bonusHealingFromMendingProlif}></ItemHealingDone>
+        </BoringValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default MendingProliferation;


### PR DESCRIPTION
Added module for the healing increase gained from the Mending Proliferation Talent

![image](https://user-images.githubusercontent.com/26779541/209694946-b74e7a8e-9bde-49f5-b12a-88a2376432ae.png)

Had the issue again on this with TalentSpellText and SpellLink breaking and returning 'unknown' so for now only the Spell Icon is linked