### PR TITLE
allow Ctrl/Cmd-R to "force" a refresh of the fight list when used on the fight selection page

### DIFF
--- a/src/interface/report/ReportLoader.tsx
+++ b/src/interface/report/ReportLoader.tsx
@@ -4,7 +4,7 @@ import { fetchFights, LogNotFoundError } from 'common/fetchWclApi';
 import { setReport } from 'interface/actions/report';
 import ActivityIndicator from 'interface/ActivityIndicator';
 import makeAnalyzerUrl from 'interface/makeAnalyzerUrl';
-import { getReportCode } from 'interface/selectors/url/report';
+import { getFightId, getReportCode } from 'interface/selectors/url/report';
 import Report from 'parser/core/Report';
 import { ReactNode, useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
@@ -14,10 +14,74 @@ import { Helmet } from 'react-helmet';
 
 import handleApiError from './handleApiError';
 
-// During peak traffic we might want to disable automatic refreshes to avoid hitting the rate limit.
-// During regular traffic we should enable this as the fight caching is confusing users.
-// Actually leaving this disabled for now so we can continue to serve reports when WCL goes down and high traffic to a specific report page doesn't bring us down (since everything would be logged). To solve the issue of confusion, I'll try improving the fight selection text instead.
-const REFRESH_BY_DEFAULT = false;
+const pageWasReloaded = () =>
+  performance
+    .getEntriesByType('navigation')
+    .filter((event) => (event as PerformanceNavigationTiming).type === 'reload').length > 0;
+
+const pageFirstInputTime = () => {
+  const startTime = performance.getEntriesByType('first-input')[0]?.startTime;
+
+  if (startTime === undefined) {
+    return undefined;
+  }
+
+  return Date.now() - performance.now() + startTime;
+};
+
+// TODO: this can be lifted to a shared file
+const useSessionState = (
+  key: string,
+  initialValue: string | null,
+): [string | null, (newValue: string | null) => void] => {
+  const [value, setValue] = useState(window.sessionStorage.getItem(key) ?? initialValue);
+
+  useEffect(() => {
+    if (initialValue !== null && window.sessionStorage.getItem(key) === null) {
+      window.sessionStorage.setItem(key, initialValue);
+    }
+    // intentionally omitting initialValue to avoid accidental overwrites
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  const setSessionValue = useCallback(
+    (newValue: string | null) => {
+      if (newValue === null) {
+        window.sessionStorage.removeItem(key);
+      } else {
+        window.sessionStorage.setItem(key, newValue);
+      }
+      setValue(newValue);
+    },
+    [key],
+  );
+
+  return [value, setSessionValue];
+};
+
+/**
+ * Allow a "natural" refresh (aka Ctrl/Cmd-R) to refresh the fight list, which is probably what the user wants.
+ *
+ * This is rate-limited to once per 30 seconds (per browser tab) using session storage.
+ */
+const shouldForceRefresh = (fightId: number | null, lastForceRefreshTime: number) => {
+  // we use the first input time to avoid chain refreshes in cases where the state gets trashed by a parent component
+  const inputTime = pageFirstInputTime() ?? 0;
+  if (
+    // if a fight is selected, never force refresh
+    fightId === null &&
+    pageWasReloaded() &&
+    // only refresh if the first input hasn't happened or happened very shortly before this.
+    // this is done to avoid forcing refreshes when doing normal navigations within
+    // the SPA *after* having refreshed an unrelated page.
+    (inputTime === 0 || Date.now() - inputTime <= 1000) &&
+    // rate limit --- once per 30s
+    Date.now() - lastForceRefreshTime >= 30000
+  ) {
+    return true;
+  }
+  return false;
+};
 
 interface Props {
   children: ReactNode;
@@ -29,6 +93,12 @@ const ReportLoader = ({ children }: Props) => {
   const dispatch = useDispatch();
   const [error, setError] = useState<Error | null>(null);
   const [report, setReportState] = useState<Report | null>(null);
+
+  const [lastForceRefreshTimestamp, setForceRefreshTimestamp] = useSessionState(
+    'report:last-force-refresh',
+    null,
+  );
+  const fightId = getFightId(location.pathname);
 
   const updateState = useCallback(
     (error: Error | null, report: Report | null) => {
@@ -77,9 +147,19 @@ const ReportLoader = ({ children }: Props) => {
 
   useEffect(() => {
     if (reportCode) {
+      const refresh = shouldForceRefresh(
+        fightId,
+        lastForceRefreshTimestamp ? Number(lastForceRefreshTimestamp) : 0,
+      );
+      if (refresh) {
+        setForceRefreshTimestamp(String(Date.now()));
+      }
+
       // noinspection JSIgnoredPromiseFromCall
-      loadReport(reportCode, REFRESH_BY_DEFAULT);
+      loadReport(reportCode, refresh);
     }
+    // intentionally omit refresh-related state from this effect's deps to avoid triggering another load after a force refresh
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loadReport, reportCode]);
 
   if (error) {


### PR DESCRIPTION
this addresses one of the most common UX issues on WoWA: "why doesn't wowa show all of the fights?"

this may eventually be coupled with a backend change that does some more intelligent cache-busting for ongoing reports (e.g. auto-refresh if the last-known end is between 3 and 30 minutes ago and we last checked at least 30 seconds ago), but I want to see the effect this has first