### PR TITLE
wrap performance box rows in cast breakdowns

### DIFF
--- a/src/analysis/retail/demonhunter/shared/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/shared/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SPELLS from 'common/SPELLS/demonhunter';
 
 // prettier-ignore
 export default [
+  change(date(2022, 12, 30), 'Wrap performance box rows in cast breakdowns.', ToppleTheNun),
   change(date(2022, 12, 29), <>Add statistic for damage added by <SpellLink id={SPELLS.DEMON_SOUL_BUFF_NON_FODDER}/>, <SpellLink id={SPELLS.DEMON_SOUL_BUFF_FODDER}/>, and <SpellLink id={TALENTS.FODDER_TO_THE_FLAME_TALENT} />.</>, ToppleTheNun),
   change(date(2022, 12, 7), 'Fix cast breakdowns showing "[object Object]" in summary.', ToppleTheNun),
   change(date(2022, 12, 5), 'Make time spent capped on fury more visible.', ToppleTheNun),

--- a/src/analysis/retail/demonhunter/shared/guide/CastSummaryAndBreakdown.module.scss
+++ b/src/analysis/retail/demonhunter/shared/guide/CastSummaryAndBreakdown.module.scss
@@ -1,0 +1,7 @@
+.castSummaryAndBreakdown {
+  margin-bottom: 10px;
+
+  :global(.performance-block-row) {
+    flex-wrap: wrap;
+  }
+}

--- a/src/analysis/retail/demonhunter/shared/guide/CastSummaryAndBreakdown.tsx
+++ b/src/analysis/retail/demonhunter/shared/guide/CastSummaryAndBreakdown.tsx
@@ -11,6 +11,8 @@ import { ClickToExpand, MouseoverForMoreDetails } from './CommonLinguiTranslatio
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import CastPerformanceSummary from 'analysis/retail/demonhunter/shared/guide/CastPerformanceSummary';
 
+import styles from './CastSummaryAndBreakdown.module.scss';
+
 const toGradiatedPerformanceBarProp = (
   count: number,
   label: string | undefined,
@@ -118,7 +120,7 @@ const CastSummaryAndBreakdown = ({
     ));
 
   return (
-    <div style={{ marginBottom: 10 }}>
+    <div className={styles.castSummaryAndBreakdown}>
       {includePerfectCastPercentage && (
         <CastPerformanceSummary
           casts={perfect}


### PR DESCRIPTION
this is a temporary fix until I can make a better
visualization for rotation breakdowns.