### PR TITLE
Account for tip the scales in Stasis

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2022, 12, 30), <>Improve accuracy of <SpellLink id={TALENTS_EVOKER.STASIS_TALENT.id}/> module</>, Trevor),
   change(date(2022, 12, 30), <>Fix degraded experience in <SpellLink id={TALENTS_EVOKER.STASIS_TALENT.id}/> spell breakdown</>, Trevor),
   change(date(2022, 12, 30), <>Add module for <SpellLink id={TALENTS_EVOKER.STASIS_TALENT.id}/> spell breakdown</>, Trevor),
   change(date(2022, 12, 28), <>Add module for <SpellLink id={TALENTS_EVOKER.EXHILARATING_BURST_TALENT.id}/></>, Trevor),

--- a/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
@@ -504,7 +504,6 @@ export function getStasisSpell(event: RemoveBuffStackEvent | RemoveBuffEvent): n
   if (!relatedEvents.length) {
     return null;
   }
-  console.log(event, relatedEvents[0]);
   if (relatedEvents[0].type === EventType.Cast) {
     return (relatedEvents[0] as CastEvent).ability.guid;
   }


### PR DESCRIPTION
When player used tip the scales with spiritbloom, even though its an empowered ability there isn't actually an empowerend event and for non-tip the scales, we were double counting cast and empowerend if they were close together. This PR fixes accounts for both cases.