### PR TITLE
Enhancement: Improve Hot Hand stats box

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -1847,6 +1847,18 @@ export const xunni: Contributor = {
   ],
 };
 
+export const Taum: Contributor = {
+  nickname: 'Taum',
+  github: 'Taum',
+  mains: [
+    {
+      name: 'Taum',
+      spec: SPECS.ENHANCEMENT_SHAMAN,
+      link: 'https://worldofwarcraft.com/en-us/character/us/zuljin/Shm',
+    },
+  ],
+};
+
 export const AndreasAlbert: Contributor = {
   nickname: 'AndreasAlbert',
   github: 'AndreasAlbert',

--- a/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
@@ -1,7 +1,8 @@
 import { change, date } from 'common/changelog';
-import { Vetyst, xunni } from 'CONTRIBUTORS';
+import { Taum, Vetyst, xunni } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2022, 12, 31), <>Added Lava Lash per Hot Hand proc stats, fixed misreporting possible casts of Lava Lash.</>, Taum),
   change(date(2022, 12, 28), <>Remove outdated Ice Strike and Crashing Storms modules to avoid confusion.</>, xunni),
   change(date(2022, 11, 1), <>Cleanup changelog for Pre-patch.</>, Vetyst),
 ];

--- a/src/analysis/retail/shaman/enhancement/modules/core/Intervals.ts
+++ b/src/analysis/retail/shaman/enhancement/modules/core/Intervals.ts
@@ -13,6 +13,10 @@ export class Intervals {
     return this.intervals.reduce((acc, interval) => acc + interval.duration, 0);
   }
 
+  get intervalsCount() {
+    return this.intervals.length;
+  }
+
   private get isLastIntervalInProgress() {
     const length = this.intervals.length;
     if (length === 0) {

--- a/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
@@ -1,6 +1,7 @@
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_SHAMAN } from 'common/TALENTS';
+import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
 import Events, { ApplyBuffEvent, DamageEvent, RemoveBuffEvent } from 'parser/core/Events';
@@ -74,7 +75,6 @@ class HotHand extends Analyzer {
     // on application both resets the CD and applies a mod rate
     this.spellUsable.endCooldown(TALENTS_SHAMAN.LAVA_LASH_TALENT.id);
     this.spellUsable.applyCooldownRateChange(TALENTS_SHAMAN.LAVA_LASH_TALENT.id, HOT_HAND.MOD_RATE);
-
     this.hotHandActive.startInterval(event.timestamp);
   }
 
@@ -117,7 +117,7 @@ class HotHand extends Analyzer {
         tooltip={
           <ul>  
             <li>Gained buff {this.hotHandActive.intervalsCount} times ({formatPercentage(this.timePercentageHotHandsActive)}% uptime)</li>
-            <li>{this.buffedCasts} total Lava Lash casts with Hot Hand buff</li>
+            <li>{this.buffedCasts} total <SpellLink id={TALENTS_SHAMAN.LAVA_LASH_TALENT}/> casts with Hot Hand buff</li>
           </ul>
         }
         category={STATISTIC_CATEGORY.TALENTS}

--- a/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
@@ -1,8 +1,9 @@
+import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_SHAMAN } from 'common/TALENTS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
-import Events, { DamageEvent } from 'parser/core/Events';
+import Events, { ApplyBuffEvent, DamageEvent, RemoveBuffEvent } from 'parser/core/Events';
 import Haste from 'parser/shared/modules/Haste';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
@@ -10,6 +11,7 @@ import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { Intervals } from '../core/Intervals';
 
 // TODO: scale with talent rank.
 const HOT_HAND = {
@@ -34,6 +36,8 @@ class HotHand extends Analyzer {
   protected haste!: Haste;
 
   protected buffedLavaLashDamage: number = 0;
+  protected hotHandActive: Intervals = new Intervals();
+  protected buffedCasts: number = 0;
 
   constructor(options: Options) {
     super(options);
@@ -52,7 +56,7 @@ class HotHand extends Analyzer {
     // Very unlikely to happen but it does.
     this.addEventListener(
       Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.HOT_HAND_BUFF),
-      this.applyHotHand,
+      this.refreshHotHand,
     );
 
     this.addEventListener(
@@ -66,17 +70,26 @@ class HotHand extends Analyzer {
     );
   }
 
-  applyHotHand() {
+  applyHotHand(event: ApplyBuffEvent) {
     // on application both resets the CD and applies a mod rate
     this.spellUsable.endCooldown(TALENTS_SHAMAN.LAVA_LASH_TALENT.id);
     this.spellUsable.applyCooldownRateChange(TALENTS_SHAMAN.LAVA_LASH_TALENT.id, HOT_HAND.MOD_RATE);
+
+    this.hotHandActive.startInterval(event.timestamp);
   }
 
-  removeHotHand() {
+  refreshHotHand() {
+    // on refresh, we only need to reset the CD, since we've already applied the mod rate
+    this.spellUsable.endCooldown(TALENTS_SHAMAN.LAVA_LASH_TALENT.id);
+  }
+
+  removeHotHand(event: RemoveBuffEvent) {
     this.spellUsable.removeCooldownRateChange(
       TALENTS_SHAMAN.LAVA_LASH_TALENT.id,
       HOT_HAND.MOD_RATE,
     );
+
+    this.hotHandActive.endInterval(event.timestamp);
   }
 
   onLavaLashDamage(event: DamageEvent) {
@@ -84,7 +97,16 @@ class HotHand extends Analyzer {
       return;
     }
 
+    this.buffedCasts += 1
     this.buffedLavaLashDamage += calculateEffectiveDamage(event, HOT_HAND.INCREASE);
+  }
+
+  get timePercentageHotHandsActive() {
+    return this.hotHandActive.totalDuration / this.owner.fightDuration;
+  }
+
+  get castsPerSecond() {
+    return this.buffedCasts / (this.hotHandActive.intervalsCount);
   }
 
   statistic() {
@@ -92,11 +114,19 @@ class HotHand extends Analyzer {
       <Statistic
         position={STATISTIC_ORDER.OPTIONAL()}
         size="flexible"
+        tooltip={
+          <ul>  
+            <li>Gained buff {this.hotHandActive.intervalsCount} times ({formatPercentage(this.timePercentageHotHandsActive)}% uptime)</li>
+            <li>{this.buffedCasts} total Lava Lash casts with Hot Hand buff</li>
+          </ul>
+        }
         category={STATISTIC_CATEGORY.TALENTS}
       >
         <BoringSpellValueText spellId={TALENTS_SHAMAN.HOT_HAND_TALENT.id}>
           <>
             <ItemDamageDone amount={this.buffedLavaLashDamage} />
+            <br />
+            {(this.castsPerSecond).toFixed(2)} <small>average casts per proc</small>
             <br />
           </>
         </BoringSpellValueText>


### PR DESCRIPTION
Improve Hot Hand statistics box
* Added average casts per proc count
* Added tooltip with activations count, uptime and total casts

This PR also fixes a bug that I discovered accidentally, that caused the total possible casts of Lava Lash to be misreported.
If Hot Hand was reapplied while already active, the cooldown reduction was re-applied in the analyzer, leading to a very short cooldown for the duration.

This can be seen on the live website where logs have very low cooldown usage on Lava Lash and extremely high number of possible casts, e.g: [log showing 868 possible casts in ~4min fight](https://wowanalyzer.com/report/nNDmJXw2zQbARfyW/58-Heroic+Terros+-+Kill+(4:09)/Paddingrat/standard/statistics)

Demo of new statistics box:
![image](https://user-images.githubusercontent.com/4512156/210131656-2a225b24-aeab-4906-81ae-1cdf6084a827.png)
