### PR TITLE
Move Devastation rotation module down in the guide and mark experimental

### DIFF
--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { change, date } from 'common/changelog';
 import { Tyndi, Vireve } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2022, 12, 31), 'Move rotation module further down and mark experimental', Vireve),
   change(date(2022, 12, 25), 'Initialize a primitive guide for Devastation!', Vireve),
   change(date(2022, 10, 25), 'Updated abilities list to include all available abilities.', Tyndi),
   change(date(2022, 9, 30), <>Added first module to Devastation</>, Tyndi),

--- a/src/analysis/retail/evoker/devastation/Guide.tsx
+++ b/src/analysis/retail/evoker/devastation/Guide.tsx
@@ -12,11 +12,11 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
   return (
     <>
       <IntroSection />
-      <CoreRotation modules={modules} info={info} events={events} />
       <CooldownSection modules={modules} info={info} events={events} />
       <DragonRageSection modules={modules} info={info} events={events} />
       <DamageEfficiency modules={modules} info={info} events={events} />
       <EssenceGraphSection modules={modules} info={info} events={events} />
+      <CoreRotation modules={modules} info={info} events={events} />
       <PreparationSection />
     </>
   );

--- a/src/analysis/retail/evoker/devastation/modules/guide/CoreRotation.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/CoreRotation.tsx
@@ -9,7 +9,7 @@ import CombatLogParser from '../../CombatLogParser';
 
 export function CoreRotation({ modules, info }: GuideProps<typeof CombatLogParser>) {
   return (
-    <Section title="Core Rotation">
+    <Section title="Core Rotation (Experimental)">
       <p>
         The Devastation rotation is driven by a priority list. The priority list is primarily around
         using your empowered spells: <SpellLink id={SPELLS.FIRE_BREATH.id} /> and{' '}

--- a/src/analysis/retail/evoker/devastation/modules/guide/CoreRotation.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/CoreRotation.tsx
@@ -19,12 +19,25 @@ export function CoreRotation({ modules, info }: GuideProps<typeof CombatLogParse
         <SpellLink id={TALENTS_EVOKER.PYRE_TALENT.id} /> for AoE.
       </p>
 
+      <p>
+        This Action Priority List (APL) is based off the simple{' '}
+        <a href="https://www.wowhead.com/guide/classes/evoker/devastation/rotation-cooldowns-pve-dps#single-target">
+          Single Target
+        </a>{' '}
+        and{' '}
+        <a href="https://www.wowhead.com/guide/classes/evoker/devastation/rotation-cooldowns-pve-dps#multi-target">
+          Multi-Target
+        </a>{' '}
+        rotation on Wowhead.
+      </p>
       <AplSectionData checker={AplCheck.check} apl={AplCheck.apl()} />
       <hr />
       <p>
         As mentioned before use the accuracy here as a reference point to compare to other logs.
-        Some examples the accuracy misses out on are
+        It's not as precise as the raidbots APL because then there would be more steps here to
+        explain and would be complex to follow. Some examples the accuracy misses out on are
         <ul>
+          <li>the opener</li>
           <li>boss mechanics that force you to move or change targets</li>
           <li>
             saving up <ResourceLink id={RESOURCE_TYPES.ESSENCE.id} /> for{' '}


### PR DESCRIPTION
Getting some feedback from class discord that people are focusing too much on the checklist and taking the accuracy for granted. I thought about disabling the module as well, but open to hearing opinions. 

Instead, I'm just moving it at the end of the guide,  adding an additional reference to the wowhead guide it is referencing, and marked the section experimental. I've cross-refernced the APL with the raidbots APL, but that one contains far more complex steps that would make the APL not legible.

![image](https://user-images.githubusercontent.com/25225547/210155602-ae4e64db-5c38-40d9-a453-071a385a8f73.png)

