### PR TITLE
Fix 2 piece for rdruid

### DIFF
--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
-import { Sref, Phased, emallson } from 'CONTRIBUTORS';
+import { Sref, Phased, emallson, Trevor } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import { TALENTS_DRUID } from 'common/TALENTS';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2022, 12, 30), <>Improve accuracy of 2 piece module </>, Trevor),
   change(date(2022, 12, 29), <>Added statistic for Vault of the Incarnates 2 Piece. </>, Phased),
   change(date(2022, 12, 14), <>Added Preparation Section to Guide.</>, Sref),
   change(date(2022, 12, 14), <>Bump patch compatibility to 10.0.2.</>, emallson),

--- a/src/analysis/retail/druid/restoration/modules/spells/VotI2pc.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/VotI2pc.tsx
@@ -1,5 +1,4 @@
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import { calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
 import SPELLS from 'common/SPELLS';
 import { TIERS } from 'game/TIERS';
 import Events, { HealEvent } from 'parser/core/Events';
@@ -41,8 +40,8 @@ class VotI2pc extends Analyzer {
     return this.stats.currentCritPercentage;
   }
 
-  get healingIncrease() {
-    return TWO_PIECE_CRIT_BONUS / (TWO_PIECE_CRIT_BONUS + this.critPercentage) / 2; // divide by 2 because it only affects crit part of the heal
+  get critIncrease() {
+    return TWO_PIECE_CRIT_BONUS / (TWO_PIECE_CRIT_BONUS + this.critPercentage);
   }
 
   get totalHealing() {
@@ -63,7 +62,7 @@ class VotI2pc extends Analyzer {
 
   handle2PcHeal(event: HealEvent) {
     if (event.hitType === HIT_TYPES.CRIT) {
-      this.twoPieceHealing += calculateEffectiveHealing(event, this.healingIncrease);
+      this.twoPieceHealing += (event.amount / 2) * this.critIncrease;
     }
   }
 

--- a/src/analysis/retail/druid/restoration/modules/spells/VotI2pc.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/VotI2pc.tsx
@@ -41,8 +41,8 @@ class VotI2pc extends Analyzer {
     return this.stats.currentCritPercentage;
   }
 
-  get critIncrease() {
-    return TWO_PIECE_CRIT_BONUS / (TWO_PIECE_CRIT_BONUS + this.critPercentage);
+  get healingIncrease() {
+    return TWO_PIECE_CRIT_BONUS / (TWO_PIECE_CRIT_BONUS + this.critPercentage) / 2; // divide by 2 because it only affects crit part of the heal
   }
 
   get totalHealing() {
@@ -63,7 +63,7 @@ class VotI2pc extends Analyzer {
 
   handle2PcHeal(event: HealEvent) {
     if (event.hitType === HIT_TYPES.CRIT) {
-      this.twoPieceHealing += calculateEffectiveHealing(event, this.critIncrease) / 2;
+      this.twoPieceHealing += calculateEffectiveHealing(event, this.healingIncrease);
     }
   }
 


### PR DESCRIPTION
Our healing boost was too large and was getting counted as overhealing, let's just take the crit healing and count a percent of it as 2 piece healing