### PR TITLE
add ef checklist item for mistweaver

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 1, 5), <>Added checklist item for <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT.id}/> module.</>, Trevor),
   change(date(2022, 12, 27), <>Added <SpellLink id={TALENTS_MONK.MENDING_PROLIFERATION_TALENT.id}/> module.</>, Vohrr),
   change(date(2022, 12, 20), <>Fix suggestion for <SpellLink id={TALENTS_MONK.SUMMON_JADE_SERPENT_STATUE_TALENT.id}/></>, Vohrr),
   change(date(2022, 12, 18), <>Fix suggestion for <SpellLink id={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT.id}/> usage based on talent selection</>, Trevor),

--- a/src/analysis/retail/monk/mistweaver/modules/features/Abilities.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/Abilities.tsx
@@ -173,8 +173,13 @@ class Abilities extends CoreAbilities {
         },
         cooldown: 12,
         timelineSortIndex: 2,
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: this.selectedCombatant.hasTalent(TALENTS_MONK.UPWELLING_TALENT)
+            ? 0.4
+            : 0.8,
+        },
       },
-
       {
         spell: TALENTS_MONK.REFRESHING_JADE_WIND_TALENT.id,
         category: SPELL_CATEGORY.OTHERS,

--- a/src/analysis/retail/monk/mistweaver/modules/features/Abilities.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/Abilities.tsx
@@ -177,7 +177,7 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: this.selectedCombatant.hasTalent(TALENTS_MONK.UPWELLING_TALENT)
             ? 0.4
-            : 0.8,
+            : 0.72,
         },
       },
       {

--- a/src/analysis/retail/monk/mistweaver/modules/features/Checklist/Component.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/Checklist/Component.tsx
@@ -70,6 +70,7 @@ const MistweaverMonkChecklist = ({ combatant, castEfficiency, thresholds }: Chec
         {combatant.hasTalent(TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT) && (
           <AbilityRequirement spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT.id} />
         )}
+        <AbilityRequirement spell={TALENTS_MONK.ESSENCE_FONT_TALENT.id} />
         {combatant.hasTalent(TALENTS_MONK.MANA_TEA_TALENT) && (
           <AbilityRequirement spell={TALENTS_MONK.MANA_TEA_TALENT.id} />
         )}


### PR DESCRIPTION
adding ef checklist item to make sure people are casting ef enough. Setting it to 40% cast efficiency if they have upwelling (average tft cd is 22-30 based on talent selection and it takes 18 seconds to stack upwelling and best case 22/ 40 = .55 so using .4 as a safe lower bound).

![image](https://user-images.githubusercontent.com/11250934/210729467-7b6cca2b-b09e-439b-9262-34066f865917.png)
