### PR TITLE
totm module

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 1, 5), <>Added statistic for average <SpellLink id={TALENTS_MONK.TEACHINGS_OF_THE_MONASTERY_TALENT.id}/> stacks.</>, Trevor),
   change(date(2023, 1, 5), <>Added checklist item for <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT.id}/> module.</>, Trevor),
   change(date(2022, 12, 27), <>Added <SpellLink id={TALENTS_MONK.MENDING_PROLIFERATION_TALENT.id}/> module.</>, Vohrr),
   change(date(2022, 12, 20), <>Fix suggestion for <SpellLink id={TALENTS_MONK.SUMMON_JADE_SERPENT_STATUE_TALENT.id}/></>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
+++ b/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
@@ -5,6 +5,7 @@ import {
   TouchOfDeath,
   DampenHarm,
   SaveThemAll,
+  TeachingsOfTheMonestary,
 } from 'analysis/retail/monk/shared';
 import CoreCombatLogParser from 'parser/core/CombatLogParser';
 import ManaTracker from 'parser/core/healingEfficiency/ManaTracker';
@@ -160,6 +161,7 @@ class CombatLogParser extends CoreCombatLogParser {
     rapidDiffusion: RapidDiffusion,
     dancingMists: DancingMists,
     mendingProliferation: MendingProliferation,
+    teachingsOfTheMonestary: TeachingsOfTheMonestary,
 
     // Borrowed Power
     t29TierSet: T29TierSet,

--- a/src/analysis/retail/monk/shared/TeachingsOfTheMonestary.tsx
+++ b/src/analysis/retail/monk/shared/TeachingsOfTheMonestary.tsx
@@ -8,7 +8,8 @@ import { TALENTS_MONK } from 'common/TALENTS';
 import TalentSpellText from 'parser/ui/TalentSpellText';
 
 class TeachingsOfTheMonestary extends Analyzer {
-  stackList: number[] = [];
+  numCasts: number = 0;
+  totalStacks: number = 0;
 
   constructor(options: Options) {
     super(options);
@@ -17,13 +18,12 @@ class TeachingsOfTheMonestary extends Analyzer {
   }
 
   onCast(event: CastEvent) {
-    const numStacks = this.selectedCombatant.getBuffStacks(SPELLS.TEACHINGS_OF_THE_MONASTERY.id);
-    console.log(this.owner.formatTimestamp(event.timestamp), numStacks);
-    this.stackList.push(numStacks);
+    this.numCasts += 1;
+    this.totalStacks += this.selectedCombatant.getBuffStacks(SPELLS.TEACHINGS_OF_THE_MONASTERY.id);
   }
 
   get averageStacks() {
-    return this.stackList.reduce((prev, cur) => prev + cur, 0) / this.stackList.length;
+    return this.totalStacks / this.numCasts;
   }
 
   statistic() {

--- a/src/analysis/retail/monk/shared/TeachingsOfTheMonestary.tsx
+++ b/src/analysis/retail/monk/shared/TeachingsOfTheMonestary.tsx
@@ -1,0 +1,44 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import Events, { CastEvent } from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { TALENTS_MONK } from 'common/TALENTS';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+
+class TeachingsOfTheMonestary extends Analyzer {
+  stackList: number[] = [];
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.TEACHINGS_OF_THE_MONASTERY_TALENT);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.BLACKOUT_KICK), this.onCast);
+  }
+
+  onCast(event: CastEvent) {
+    const numStacks = this.selectedCombatant.getBuffStacks(SPELLS.TEACHINGS_OF_THE_MONASTERY.id);
+    console.log(this.owner.formatTimestamp(event.timestamp), numStacks);
+    this.stackList.push(numStacks);
+  }
+
+  get averageStacks() {
+    return this.stackList.reduce((prev, cur) => prev + cur, 0) / this.stackList.length;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(10)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+      >
+        <TalentSpellText talent={TALENTS_MONK.TEACHINGS_OF_THE_MONASTERY_TALENT}>
+          {this.averageStacks.toFixed(2)} <small> average stacks</small>
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}
+
+export default TeachingsOfTheMonestary;

--- a/src/analysis/retail/monk/shared/index.ts
+++ b/src/analysis/retail/monk/shared/index.ts
@@ -4,4 +4,5 @@ export { default as TouchOfDeath } from './TouchOfDeath';
 export { default as MysticTouch } from './MysticTouch';
 export { default as DampenHarm } from './DampenHarm';
 export { default as SaveThemAll } from './SaveThemAll';
+export { default as TeachingsOfTheMonestary } from './TeachingsOfTheMonestary';
 export * from './constants';


### PR DESCRIPTION
### Description

Add statistic for average teachings of the monestary stacks when blackout kick is casted

- Test report URL: report/HznQk1ZhvA9mP8rW/41-Mythic+Terros+-+Wipe+25+(6:41)/Jadefunk/standard/statistics
- Screenshot(s):
![image](https://user-images.githubusercontent.com/11250934/210825800-86cc6715-043a-44da-b451-a7f72cd87300.png)

