### PR TITLE
healing subtraction for upwelling

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 1, 5), <>Update <SpellLink id={TALENTS_MONK.UPWELLING_TALENT.id}/> to subtract out estimated healing from missed casts.</>, Trevor),
   change(date(2023, 1, 5), <>Added statistic for average <SpellLink id={TALENTS_MONK.TEACHINGS_OF_THE_MONASTERY_TALENT.id}/> stacks.</>, Trevor),
   change(date(2023, 1, 5), <>Added checklist item for <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT.id}/> module.</>, Trevor),
   change(date(2022, 12, 27), <>Added <SpellLink id={TALENTS_MONK.MENDING_PROLIFERATION_TALENT.id}/> module.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Upwelling.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Upwelling.tsx
@@ -81,12 +81,17 @@ class Upwelling extends Analyzer {
     );
   }
 
-  get averageExtraBolts() {
+  get averageStacks() {
     return this.extraBolts / this.castEF;
   }
 
   get lostEfHealing() {
-    return (this.baseEfHealing * this.averageExtraBolts) / (BASE_BOLTS + 1);
+    if (this.averageStacks < 12) {
+      // number of bolts is 1:1 with normal ef if less than 12 stacks
+      return 0;
+    }
+    const wastedBolts = this.averageStacks - 12;
+    return this.baseEfHealing * (1 - wastedBolts / 6);
   }
 
   get totalHealingAll() {
@@ -217,12 +222,8 @@ class Upwelling extends Analyzer {
         this.masteryOverhealing += event.overheal || 0;
         this.masteryAbsorbed += event.absorbed || 0;
       }
-    } else {
-      if (!this.masteryTickTock) {
-        this.baseEfHealing += event.amount;
-      }
+      this.masteryTickTock = !this.masteryTickTock;
     }
-    this.masteryTickTock = !this.masteryTickTock;
   }
 
   subStatistic() {
@@ -269,7 +270,10 @@ class Upwelling extends Analyzer {
                 Extra Mastery Healing: {formatNumber(this.masteryHealing)} (
                 {formatPercentage(this.overhealingMastery)}% overhealing)
               </li>
-              <li>Average number of extra bolts: {this.averageExtraBolts.toFixed(2)}</li>
+              <li>
+                Average <SpellLink id={TALENTS_MONK.UPWELLING_TALENT} /> stacks:{' '}
+                {this.averageStacks.toFixed(2)}
+              </li>
             </ul>
           </>
         }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Upwelling.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Upwelling.tsx
@@ -174,7 +174,7 @@ class Upwelling extends Analyzer {
       this.extraBolts += 1;
       this.fromExtraBolts.add(targetID);
     } else {
-      this.baseEfHealing += event.amount || 0;
+      this.baseEfHealing += (event.amount || 0) + (event.absorbed || 0);
     }
     this.boltCount += 1; //increase current bolt
   }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Upwelling.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Upwelling.tsx
@@ -45,6 +45,7 @@ class Upwelling extends Analyzer {
   masteryHealing: number = 0;
   masteryOverhealing: number = 0;
   masteryAbsorbed: number = 0;
+  baseEfHealing: number = 0; // count healing from base ef and then subtract it out at end to account for missing ef casts
   protected hotTracker!: HotTrackerMW;
 
   constructor(options: Options) {
@@ -80,13 +81,22 @@ class Upwelling extends Analyzer {
     );
   }
 
+  get averageExtraBolts() {
+    return this.extraBolts / this.castEF;
+  }
+
+  get lostEfHealing() {
+    return (this.baseEfHealing * this.averageExtraBolts) / (BASE_BOLTS + 1);
+  }
+
   get totalHealingAll() {
     return (
       this.totalHealing +
       this.totalAbsorbs +
       this.efHotHeal +
       this.masteryHealing +
-      this.masteryAbsorbed
+      this.masteryAbsorbed -
+      this.lostEfHealing
     );
   }
 
@@ -140,6 +150,8 @@ class Upwelling extends Analyzer {
       //check if its an extra bolt from ef or was part of the core 18
       this.efHotHeal += (event.amount || 0) + (event.absorbed || 0);
       this.efHotOverheal += event.overheal || 0;
+    } else {
+      this.baseEfHealing += (event.amount || 0) + (event.absorbed || 0);
     }
   }
 
@@ -156,6 +168,8 @@ class Upwelling extends Analyzer {
       this.totalAbsorbs += event.absorbed || 0;
       this.extraBolts += 1;
       this.fromExtraBolts.add(targetID);
+    } else {
+      this.baseEfHealing += event.amount || 0;
     }
     this.boltCount += 1; //increase current bolt
   }
@@ -203,8 +217,12 @@ class Upwelling extends Analyzer {
         this.masteryOverhealing += event.overheal || 0;
         this.masteryAbsorbed += event.absorbed || 0;
       }
-      this.masteryTickTock = !this.masteryTickTock;
+    } else {
+      if (!this.masteryTickTock) {
+        this.baseEfHealing += event.amount;
+      }
     }
+    this.masteryTickTock = !this.masteryTickTock;
   }
 
   subStatistic() {
@@ -228,8 +246,12 @@ class Upwelling extends Analyzer {
           <>
             <div>
               Counts healing from extra bolts, healing from the extra 4 second of a hot on a normal
-              bolt (first 18), healing from the full hot on upwelling bolts (post 18), and any
-              mastery event from the hot under the same idea as hot counting
+              bolt (first 18), healing from the full hot on{' '}
+              <SpellLink id={TALENTS_MONK.UPWELLING_TALENT} /> bolts (post 18), and any mastery
+              event from the hot under the same idea as hot counting. We then subtract out the
+              healing from estimated missed casts of{' '}
+              <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT} /> to account for less casts from
+              utilizing <SpellLink id={TALENTS_MONK.UPWELLING_TALENT} /> stacks.
             </div>
             <ul>
               <li>Extra Bolts: {formatNumber(this.extraBolts)}</li>
@@ -247,6 +269,7 @@ class Upwelling extends Analyzer {
                 Extra Mastery Healing: {formatNumber(this.masteryHealing)} (
                 {formatPercentage(this.overhealingMastery)}% overhealing)
               </li>
+              <li>Average number of extra bolts: {this.averageExtraBolts.toFixed(2)}</li>
             </ul>
           </>
         }


### PR DESCRIPTION
### Description

Subtract out base ef healing (i.e. not from extra bolts or extra hot duration) from upwelling number. 

### Motivation

Upwelling is overcounting and is not nearly as good as wowa says.

### Testing

Before
![image](https://user-images.githubusercontent.com/11250934/210897907-12c73c30-41a3-443a-84dd-130f1a438bbb.png)


After

![image](https://user-images.githubusercontent.com/11250934/210897860-6fb8d362-e077-4c9c-9d28-d9295fdb133a.png)
