### PR TITLE
[Balance] Move convoke to general statistic category rather than cove…

### DIFF
--- a/src/analysis/retail/druid/balance/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/balance/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { Hartra344, Sref, ToppleTheNun } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2022, 12, 31), <>Moved <SpellLink id={TALENTS_DRUID.CONVOKE_THE_SPIRITS_TALENT} /> from a covenant section to the general statistic section.</>, Hartra344 ),
   change(date(2022, 12, 31), <>Add support for <SpellLink id={TALENTS_DRUID.WANING_TWILIGHT_TALENT} /> uptime and DPS contribution statistic</>, Hartra344 ),
   change(date(2022, 10, 17), <>Only check <SpellLink id={TALENTS_DRUID.INNERVATE_TALENT} /> efficiency if talented into it.</>, ToppleTheNun),
   change(date(2022, 10, 17), <>Add <SpellLink id={TALENTS_DRUID.CONVOKE_THE_SPIRITS_TALENT} /> to Abilities list.</>, ToppleTheNun),

--- a/src/analysis/retail/druid/balance/modules/spells/ConvokeSpiritsBalance.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/ConvokeSpiritsBalance.tsx
@@ -3,7 +3,6 @@ import SPELLS from 'common/SPELLS';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemPercentDamageDone from 'parser/ui/ItemPercentDamageDone';
 import Statistic from 'parser/ui/Statistic';
-import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
 class ConvokeSpiritsBalance extends ConvokeSpirits {
@@ -16,9 +15,8 @@ class ConvokeSpiritsBalance extends ConvokeSpirits {
     return (
       <Statistic
         wide
-        position={STATISTIC_ORDER.CORE()}
+        position={STATISTIC_ORDER.CORE(8)}
         size="flexible"
-        category={STATISTIC_CATEGORY.COVENANTS}
         tooltip={
           <>
             <strong>


### PR DESCRIPTION
### Description
Convoke is now part of the talent tree and not a covenant ability. This moves it into the main statistics with the other talent choices

### Testing
<img width="1399" alt="image" src="https://user-images.githubusercontent.com/13208452/210926755-aecf329d-2b9c-48eb-9af7-67b146b9ba59.png">

