### PR TITLE
Druid Feral - Abilities - Convoke no longer shows when player doesn't have talent, and also added Adaptive Swarm

### DIFF
--- a/src/analysis/retail/druid/feral/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/feral/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS/druid';
 
 export default [
+  change(date(2023, 1, 8), <>Fixed a bug where <SpellLink id={TALENTS_DRUID.CONVOKE_THE_SPIRITS_TALENT.id} /> would show in the Statistic / Details cooldown bar even when it wasn't talented, and where <SpellLink id={TALENTS_DRUID.ADAPTIVE_SWARM_TALENT.id} /> would never show.</>, Sref),
   change(date(2022, 12, 14), <>Added Preparation Section to Guide.</>, Sref),
   change(date(2022, 12, 14), <>Bumped patch compatibility to 10.0.2.</>, emallson),
   change(date(2022, 11, 19), <>Added per-Berserk breakdown to Guide, and fixed an issue where Berserk CDR was being applied even when player wasn't talented for <SpellLink id={TALENTS_DRUID.BERSERK_HEART_OF_THE_LION_TALENT.id} /></>, Sref),

--- a/src/analysis/retail/druid/feral/modules/Abilities.ts
+++ b/src/analysis/retail/druid/feral/modules/Abilities.ts
@@ -148,6 +148,7 @@ class Abilities extends CoreAbilities {
         spell: TALENTS_DRUID.CONVOKE_THE_SPIRITS_TALENT.id,
         category: SPELL_CATEGORY.COOLDOWNS,
         cooldown: combatant.hasTalent(TALENTS_DRUID.ASHAMANES_GUIDANCE_TALENT) ? 60 : 120,
+        enabled: combatant.hasTalent(TALENTS_DRUID.CONVOKE_THE_SPIRITS_TALENT),
         gcd: {
           base: druidGcd,
         },
@@ -156,6 +157,22 @@ class Abilities extends CoreAbilities {
           recommendedEfficiency: 0.9,
           averageIssueEfficiency: 0.8,
           majorIssueEfficiency: 0.6,
+        },
+      },
+      {
+        spell: SPELLS.ADAPTIVE_SWARM.id,
+        enabled: combatant.hasTalent(TALENTS_DRUID.ADAPTIVE_SWARM_TALENT),
+        category: SPELL_CATEGORY.ROTATIONAL,
+        cooldown: 25,
+        gcd: {
+          base: druidGcd,
+        },
+        // Swarm sometimes best not to cast purely on CD in single target encounters
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.7,
+          averageIssueEfficiency: 0.5,
+          majorIssueEfficiency: 0.3,
         },
       },
       {


### PR DESCRIPTION


- Test report URL: `/report/LV74Fga2D3NGZYKv/52-Mythic+Terros+-+Kill+(6:16)/Maymays/standard/statistics`
