### PR TITLE
[Mistweaver] Improved accuracy of the Vivacious Vivification module 

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 1, 12), <>Improve accuracy of <SpellLink id={TALENTS_MONK.VIVACIOUS_VIVIFICATION_TALENT.id}/> module and the <SpellLink id={TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT.id}/> missed GCDs tally.</>, Vohrr),
   change(date(2023, 1, 8), <>Improve accuracy of <SpellLink id={TALENTS_MONK.UPWELLING_TALENT.id}/> module.</>, Trevor),
   change(date(2023, 1, 6), <>Improve accuracy of <SpellLink id={TALENTS_MONK.UPWELLING_TALENT.id}/> module.</>, Trevor),
   change(date(2023, 1, 5), <>Update <SpellLink id={TALENTS_MONK.UPWELLING_TALENT.id}/> to subtract out estimated healing from missed casts.</>, Trevor),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
@@ -112,8 +112,11 @@ class InvokeChiJi extends Analyzer {
     if (this.chijiActive) {
       this.chijiGlobals += 1;
       //if timebetween globals is longer than the gcd add the difference to the missed gcd tally
-      //we only care about accounting for channels of essence font, other than that it should be the gcd during chiji
-      if (event.ability.guid === TALENTS_MONK.ESSENCE_FONT_TALENT.id) {
+      //we only care about accounting casts of essence font or fls, other than that it should be the gcd during chiji
+      if (
+        event.ability.guid === TALENTS_MONK.ESSENCE_FONT_TALENT.id ||
+        event.ability.guid === TALENTS_MONK.FAELINE_STOMP_TALENT.id
+      ) {
         this.efGcd = event.duration;
       } else if (event.timestamp - this.lastGlobal > event.duration) {
         this.missedGlobals += (event.timestamp - this.lastGlobal - event.duration) / event.duration;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
@@ -39,8 +39,8 @@ class VivaciousVivification extends Analyzer {
     // every refresh is a wasted buff application and the CD restarts. ignore refreshes during cooldown windows
     if (
       this.renewingMist.currentRenewingMists >= this.vivify.estimatedAverageReMs &&
-      (!this.invokeChiji.chijiActive ||
-        !this.selectedCombatant.hasBuff(TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id))
+      !this.invokeChiji.chijiActive &&
+      !this.selectedCombatant.hasBuff(TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id)
     ) {
       this.wastedApplications += 1;
     }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { RefreshBuffEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import InvokeChiJi from './InvokeChiJi';
 import RenewingMist from './RenewingMist';
 import Vivify from './Vivify';
 
@@ -12,7 +13,9 @@ class VivaciousVivification extends Analyzer {
   static dependencies = {
     vivify: Vivify,
     renewingMist: RenewingMist,
+    invokeChiji: InvokeChiJi,
   };
+  protected invokeChiji!: InvokeChiJi;
   protected renewingMist!: RenewingMist;
   protected vivify!: Vivify;
   currentRenewingMists: number = 0;
@@ -33,8 +36,12 @@ class VivaciousVivification extends Analyzer {
   }
 
   onRefresh(event: RefreshBuffEvent) {
-    // every refresh is a wasted buff application and the CD restarts
-    if (this.renewingMist.currentRenewingMists >= this.vivify.estimatedAverageReMs) {
+    // every refresh is a wasted buff application and the CD restarts. ignore refreshes during cooldown windows
+    if (
+      this.renewingMist.currentRenewingMists >= this.vivify.estimatedAverageReMs &&
+      (!this.invokeChiji.chijiActive ||
+        !this.selectedCombatant.hasBuff(TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id))
+    ) {
       this.wastedApplications += 1;
     }
   }


### PR DESCRIPTION
Improving the modules accuracy to a real world analysis to not count missed casts against players for not pressing vivify during cooldown windows.

Added Faeline to acceptable casts during chiji so that those GCDs are not counted as missed GCDs
