### PR TITLE
Fixed an issue where the Events tab would 404

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -18,6 +18,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 1, 14), "Fixed an issue where the Events tab wouldn't load", Sref),
   change(date(2023, 1, 15), 'Overhauls enchants recommendations (removing gloves, adding bracers & boots).', Lapideas),
   change(date(2023, 1, 7), 'Update dependencies.', ToppleTheNun),
   change(date(2023, 1, 7), 'Remove support for Wowdb tooltips.', ToppleTheNun),

--- a/src/interface/report/Results/About.tsx
+++ b/src/interface/report/Results/About.tsx
@@ -6,6 +6,10 @@ import Panel from 'interface/Panel';
 import ReadableListing from 'interface/ReadableListing';
 import Config from 'parser/Config';
 import { Link } from 'react-router-dom';
+import { makeAnalyzerUrl } from 'interface/index';
+import { useReport } from 'interface/report/context/ReportContext';
+import { useFight } from 'interface/report/context/FightContext';
+import { usePlayer } from 'interface/report/context/PlayerContext';
 
 interface Props {
   config: Config;
@@ -28,7 +32,14 @@ const About = ({ config }: Props) => {
         </Trans>
       }
       actions={
-        <Link to="events">
+        <Link
+          to={makeAnalyzerUrl(
+            useReport()!.report,
+            useFight()!.fight.id,
+            usePlayer().player.id,
+            'events',
+          )}
+        >
           <Trans id="interface.report.results.about.viewEvents">View all events</Trans>
         </Link>
       }


### PR DESCRIPTION
The Events tab link wasn't being called right after the changes. The below fix works, but I'm not sure if it's the "right" way to do it.