### PR TITLE
[Frost Mage] 10.0.2 Support

### DIFF
--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -5,13 +5,18 @@ import { SpellLink } from 'interface';
 import { Sharrq } from 'CONTRIBUTORS';
 
 export default [
-  change(date(2022, 12, 17), <>Fixed an error that was improperly counting <SpellLink id={SPELLS.WINTERS_CHILL} /> Shattered Casts and Pre Casts.</>, Sharrq),
-  change(date(2022, 12, 13), <>Fixed timeline buff highlights for <SpellLink id={TALENTS.FINGERS_OF_FROST_TALENT} /> and <SpellLink id={TALENTS.BRAIN_FREEZE_TALENT} />.</>, Sharrq),
-  change(date(2022, 12, 13), <>Updated <SpellLink id={TALENTS.SHIFTING_POWER_TALENT} /> CDR Spell List.</>, Sharrq),
-  change(date(2022, 12, 13), <>Fixed <SpellLink id={TALENTS.ICY_PROPULSION_TALENT} /> CDR tracking.</>, Sharrq),
-  change(date(2022, 12, 13), <>Fixed <SpellLink id={TALENTS.BRAIN_FREEZE_TALENT} /> proc usage tracking.</>, Sharrq),
-  change(date(2022, 12, 13), <>Fixed <SpellLink id={TALENTS.FINGERS_OF_FROST_TALENT} /> munched proc tracking and used proc usage tracking.</>, Sharrq),
-  change(date(2022, 12, 13), `General fixes for incorrect Spell IDs, leftover Shadowlands stuff, etc.`, Sharrq),
-  change(date(2022, 10, 30), `Update Dragonflight SPELLS, Abilities, and Buffs`, Sharrq),
-  change(date(2022, 9, 29), `Dragonflight initial cleanup`, Sharrq),
+	change(date(2023, 1, 14), `Upgraded Frost Mage support to 10.0.2 and marked as Supported. Also removed Dambroda from spec maintainers.`, Sharrq),
+	change(date(2023, 1, 14), `Reviewed all Suggestions, Tooltips, and Checklist items to ensure the wording is accurate for Dragonflight`, Sharrq),
+	change(date(2023, 1, 14), <>Removed <SpellLink id={TALENTS.BLAST_WAVE_TALENT} /> and <SpellLink id={TALENTS.ICE_NOVA_TALENT} /> from Cast Efficiency.</>, Sharrq),
+	change(date(2023, 1, 14), <>Fixed an issue where <SpellLink id={TALENTS.ICY_PROPULSION_TALENT} /> was not counting cooldown reduction outside of <SpellLink id={TALENTS.ICY_VEINS_TALENT} />.</>, Sharrq),
+	change(date(2023, 1, 14), <>Rebuilt the <SpellLink id={TALENTS.BRAIN_FREEZE_TALENT} /> module and removed the messages about using <SpellLink id={TALENTS.FLURRY_TALENT} /> without <SpellLink id={TALENTS.BRAIN_FREEZE_TALENT} />.</>, Sharrq),
+	change(date(2022, 12, 17), <>Fixed an error that was improperly counting <SpellLink id={SPELLS.WINTERS_CHILL} /> Shattered Casts and Pre Casts.</>, Sharrq),
+  	change(date(2022, 12, 13), <>Fixed timeline buff highlights for <SpellLink id={TALENTS.FINGERS_OF_FROST_TALENT} /> and <SpellLink id={TALENTS.BRAIN_FREEZE_TALENT} />.</>, Sharrq),
+  	change(date(2022, 12, 13), <>Updated <SpellLink id={TALENTS.SHIFTING_POWER_TALENT} /> CDR Spell List.</>, Sharrq),
+  	change(date(2022, 12, 13), <>Fixed <SpellLink id={TALENTS.ICY_PROPULSION_TALENT} /> CDR tracking.</>, Sharrq),
+  	change(date(2022, 12, 13), <>Fixed <SpellLink id={TALENTS.BRAIN_FREEZE_TALENT} /> proc usage tracking.</>, Sharrq),
+  	change(date(2022, 12, 13), <>Fixed <SpellLink id={TALENTS.FINGERS_OF_FROST_TALENT} /> munched proc tracking and used proc usage tracking.</>, Sharrq),
+  	change(date(2022, 12, 13), `General fixes for incorrect Spell IDs, leftover Shadowlands stuff, etc.`, Sharrq),
+  	change(date(2022, 10, 30), `Update Dragonflight SPELLS, Abilities, and Buffs`, Sharrq),
+  	change(date(2022, 9, 29), `Dragonflight initial cleanup`, Sharrq),
 ];

--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 import { Sharrq } from 'CONTRIBUTORS';
 
 export default [
+	change(date(2023, 1, 14), `Added a link to Toegrinder's Mage Hub guide on the About page. Removed link to Icy Veins and Altered Time forums.`, Sharrq),
 	change(date(2023, 1, 14), `Upgraded Frost Mage support to 10.0.2 and marked as Supported. Also removed Dambroda from spec maintainers.`, Sharrq),
 	change(date(2023, 1, 14), `Reviewed all Suggestions, Tooltips, and Checklist items to ensure the wording is accurate for Dragonflight`, Sharrq),
 	change(date(2023, 1, 14), <>Removed <SpellLink id={TALENTS.BLAST_WAVE_TALENT} /> and <SpellLink id={TALENTS.ICE_NOVA_TALENT} /> from Cast Efficiency.</>, Sharrq),

--- a/src/analysis/retail/mage/frost/CONFIG.tsx
+++ b/src/analysis/retail/mage/frost/CONFIG.tsx
@@ -21,27 +21,18 @@ const config: Config = {
         Mage Class Discord
       </a>{' '}
       <br />
-      <a href="https://www.altered-time.com/forum/" target="_blank" rel="noopener noreferrer">
-        Altered Time (Mage Forums/Guides)
+      <a href="https://www.mage-hub.com/frost" target="_blank" rel="noopener noreferrer">
+        Mage Hub Guide (Mage Guides/Sims)
       </a>{' '}
       <br />
       <a href="https://www.wowhead.com/frost-mage-guide" target="_blank" rel="noopener noreferrer">
         Wowhead (Frost Mage Guide)
       </a>{' '}
       <br />
-      <a
-        href="https://www.icy-veins.com/wow/frost-mage-pve-dps-guide"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Icy Veins (Frost Mage Guide)
-      </a>{' '}
-      <br />
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport:
-    '/report/ydqQLTvJfCNtcDYR/13-Normal+Dausegne,+the+Fallen+Oracle+-+Kill+(4:22)/Arcanfrost/standard',
+  exampleReport: '/report/d23LNg8XqhFZKWGk/17-Heroic+Terros+-+Kill+(5:42)/Critsangel/standard',
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.FROST_MAGE,

--- a/src/analysis/retail/mage/frost/CONFIG.tsx
+++ b/src/analysis/retail/mage/frost/CONFIG.tsx
@@ -1,4 +1,4 @@
-import { Sharrq, Dambroda } from 'CONTRIBUTORS';
+import { Sharrq } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import Config from 'parser/Config';
@@ -7,11 +7,11 @@ import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Sharrq, Dambroda],
+  contributors: [Sharrq],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.0',
-  isPartial: true,
+  patchCompatibility: '10.0.2',
+  isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more. If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>

--- a/src/analysis/retail/mage/frost/CombatLogParser.ts
+++ b/src/analysis/retail/mage/frost/CombatLogParser.ts
@@ -10,6 +10,7 @@ import {
   TempestBarrier,
   MasterOfTime,
   TimeAnomaly,
+  SharedCode,
 } from 'analysis/retail/mage/shared';
 import CoreCombatLogParser from 'parser/core/CombatLogParser';
 import ArcaneTorrent from 'parser/shared/modules/racials/bloodelf/ArcaneTorrent';
@@ -29,6 +30,7 @@ import WintersChill from './core/WintersChill';
 //Talents
 import ColdSnap from './talents/ColdSnap';
 import FrozenOrb from './talents/FrozenOrb';
+import Flurry from './talents/Flurry';
 import WaterElemental from './talents/WaterElemental';
 import ColdFront from './talents/ColdFront';
 import IcyPropulsion from './talents/IcyPropulsion';
@@ -52,6 +54,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     //Core
     abilities: Abilities,
+    sharedCode: SharedCode,
     alwaysBeCasting: AlwaysBeCasting,
     cancelledCasts: CancelledCasts,
     cooldownThroughputTracker: CooldownThroughputTracker,
@@ -73,6 +76,7 @@ class CombatLogParser extends CoreCombatLogParser {
     icyPropulsion: IcyPropulsion,
     coldFront: ColdFront,
     mirrorImage: MirrorImage,
+    flurry: Flurry,
     frozenOrb: FrozenOrb,
     coldSnap: ColdSnap,
 

--- a/src/analysis/retail/mage/frost/checklist/Component.tsx
+++ b/src/analysis/retail/mage/frost/checklist/Component.tsx
@@ -59,13 +59,12 @@ const FrostMageChecklist = ({ combatant, castEfficiency, thresholds }: Checklist
             you are <SpellLink id={TALENTS.SHATTER_TALENT.id} />
             ing as many of your spells as possible. The key aspect of this is taking advantage of
             the <SpellLink id={SPELLS.WINTERS_CHILL.id} /> debuff. Winter's Chill is applied to the
-            target when you use a <SpellLink id={TALENTS.BRAIN_FREEZE_TALENT.id} /> proc and makes
-            the target act as if it is frozen for a short duration of time. Therefore, you should
-            cast a rotational ability like <SpellLink id={SPELLS.FROSTBOLT.id} />,{' '}
+            target when you cast <SpellLink id={TALENTS.FLURRY_TALENT.id} /> and makes the target
+            act as if it is frozen for a short duration of time. Therefore, you should cast a
+            rotational ability like <SpellLink id={SPELLS.FROSTBOLT.id} />,{' '}
             <SpellLink id={TALENTS.EBONBOLT_TALENT.id} />, or{' '}
-            <SpellLink id={TALENTS.GLACIAL_SPIKE_TALENT.id} />, followed immediately by the Brain
-            Freeze buffed Flurry and then end with two{' '}
-            <SpellLink id={TALENTS.ICE_LANCE_TALENT.id} />
+            <SpellLink id={TALENTS.GLACIAL_SPIKE_TALENT.id} />, followed immediately by Flurry and
+            then end with two <SpellLink id={TALENTS.ICE_LANCE_TALENT.id} />
             s. Against non-boss enemies, you can also utilize other things like{' '}
             <SpellLink id={SPELLS.FROST_NOVA.id} /> or your pet's{' '}
             <SpellLink id={SPELLS.FREEZE.id} /> to shatter spells as well.
@@ -75,12 +74,12 @@ const FrostMageChecklist = ({ combatant, castEfficiency, thresholds }: Checklist
         <Requirement
           name="Ice Lance into Winter's Chill"
           thresholds={thresholds.wintersChillShatter}
-          tooltip="Using Brain Freeze will apply the Winter's Chill debuff to the target which causes your spells to act as if the target is frozen. Therefore, you should always cast Ice Lance twice after every instant cast Flurry so that the Ice Lance hits the target while Winter's Chill is up."
+          tooltip="Casting Flurry will apply the Winter's Chill debuff to the target which causes your spells to act as if the target is frozen. Therefore, you should always cast Ice Lance twice after every Flurry cast so that the Ice Lance hits the target while Winter's Chill is up."
         />
         <Requirement
           name="Hardcast into Winter's Chill"
           thresholds={thresholds.wintersChillHardCasts}
-          tooltip="Flurry travels faster than your other spells, so you can pre-cast Frostbolt, Ebonbolt, or Glacial Spike before using your instant cast Flurry. This will result in the pre-cast spell landing in the Winter's Chill debuff and dealing bonus shatter damage. If you are Kyrian, you can also use Radiant Spark instead of a Pre-cast ability."
+          tooltip="Flurry travels faster than your other spells, so you can pre-cast Frostbolt, Ebonbolt, or Glacial Spike before casting Flurry. This will result in the pre-cast spell landing in the Winter's Chill debuff and dealing bonus shatter damage."
         />
       </Rule>
       <Rule
@@ -122,22 +121,21 @@ const FrostMageChecklist = ({ combatant, castEfficiency, thresholds }: Checklist
         name="Use Glacial Spike properly"
         description={
           <>
-            <SpellLink id={TALENTS.GLACIAL_SPIKE_TALENT.id} /> is one of the most impactful talents
-            that you can choose and it plays a large part in your rotation; So you should always
+            When talented into <SpellLink id={TALENTS.GLACIAL_SPIKE_TALENT.id} /> you should always
             ensure that you are getting the most out of it, because a large part of your damage will
             come from making sure that you are handling Glacial Spike properly. As a rule, once you
-            have Glacial Spike available, you should not cast it unless you have a{' '}
-            <SpellLink id={TALENTS.BRAIN_FREEZE_TALENT.id} /> proc to use alongside it (
+            have Glacial Spike available, you should not cast it unless you can cast{' '}
+            <SpellLink id={TALENTS.FLURRY_TALENT.id} /> alongside it (
             <SpellLink id={TALENTS.GLACIAL_SPIKE_TALENT.id} /> {'>'}{' '}
             <SpellLink id={TALENTS.FLURRY_TALENT.id} /> {'>'}
             <SpellLink id={TALENTS.ICE_LANCE_TALENT.id} />) or if you also have the{' '}
             <SpellLink id={TALENTS.SPLITTING_ICE_TALENT.id} /> and the Glacial Spike will hit a
             second target. If neither of those are true, then you should continue casting{' '}
-            <SpellLink id={SPELLS.FROSTBOLT.id} /> until you have a{' '}
-            <SpellLink id={TALENTS.BRAIN_FREEZE_TALENT.id} /> proc. If you are consistently in
-            situations where you are waiting to get a Brain Freeze proc, then consider taking the{' '}
-            <SpellLink id={TALENTS.EBONBOLT_TALENT.id} /> talent and saving it for when you need to
-            generate a proc to use with Glacial Spike.
+            <SpellLink id={SPELLS.FROSTBOLT.id} /> until <SpellLink id={TALENTS.FLURRY_TALENT.id} />{' '}
+            is available or you get a <SpellLink id={TALENTS.BRAIN_FREEZE_TALENT} /> proc. If you
+            are consistently in situations where you are waiting to get a Brain Freeze proc, then
+            consider taking the <SpellLink id={TALENTS.EBONBOLT_TALENT.id} /> talent and saving it
+            for when you need to generate a proc to use with Glacial Spike.
           </>
         }
       >

--- a/src/analysis/retail/mage/frost/checklist/Module.tsx
+++ b/src/analysis/retail/mage/frost/checklist/Module.tsx
@@ -64,7 +64,6 @@ class Checklist extends BaseChecklist {
           brainFreezeUtilization: this.brainFreeze.brainFreezeUtilizationThresholds,
           brainFreezeOverwrites: this.brainFreeze.brainFreezeOverwritenThresholds,
           brainFreezeExpired: this.brainFreeze.brainFreezeExpiredThresholds,
-          brainFreezeUnbuffedFlurry: this.brainFreeze.flurryWithoutBrainFreezeThresholds,
           glacialSpikeUtilization: this.glacialSpike.glacialSpikeUtilizationThresholds,
           fingersOfFrostUtilization: this.iceLance.fingersProcUtilizationThresholds,
           iceLanceNotShattered: this.iceLance.nonShatteredIceLanceThresholds,

--- a/src/analysis/retail/mage/frost/core/BrainFreeze.tsx
+++ b/src/analysis/retail/mage/frost/core/BrainFreeze.tsx
@@ -181,7 +181,7 @@ class BrainFreeze extends Analyzer {
           <>
             You got {this.totalProcs} total procs.
             <ul>
-              <li>{this.totalProcs - this.expiredProcs} used</li>
+              <li>{this.totalProcs - this.expiredProcs - this.overwrittenProcs} used</li>
               <li>{this.overwrittenProcs} overwritten</li>
               <li>{this.expiredProcs} expired</li>
             </ul>

--- a/src/analysis/retail/mage/frost/core/IcyVeins.tsx
+++ b/src/analysis/retail/mage/frost/core/IcyVeins.tsx
@@ -103,10 +103,10 @@ class IcyVeins extends Analyzer {
         tooltip={
           <>
             When using Icy Veins, you should ensure you are getting the most out of it by using
-            every second of the cooldown as any time spent not casting anything is lost damage.
-            While sometimes this will be out of your control due to boss mechanics, you should try
-            to minimize that risk by using your cooldowns when you are least likely to get
-            interrupted or the boss is vulnerable.
+            every second of the cooldown as any time spent not casting anything is lost damage and
+            will result in less cooldown reduction on Icy Veins. While sometimes this will be out of
+            your control due to boss mechanics, you should try to minimize that risk by using your
+            cooldowns when you are least likely to get interrupted or the boss is vulnerable.
           </>
         }
       >

--- a/src/analysis/retail/mage/frost/core/WintersChill.tsx
+++ b/src/analysis/retail/mage/frost/core/WintersChill.tsx
@@ -243,10 +243,9 @@ class WintersChill extends Analyzer {
     when(this.wintersChillPreCastThresholds).addSuggestion((suggest, actual, recommended) =>
       suggest(
         <>
-          You failed to use a pre-cast ability before spending your{' '}
-          <SpellLink id={TALENTS.BRAIN_FREEZE_TALENT.id} /> {this.missedPreCasts} times (
-          {formatPercentage(1 - actual)}%). Because of the travel time of{' '}
-          <SpellLink id={TALENTS.FLURRY_TALENT.id} />, you should cast a damaging ability such as{' '}
+          You failed to use a pre-cast ability before <SpellLink id={TALENTS.FLURRY_TALENT.id} />{' '}
+          {this.missedPreCasts} times ({formatPercentage(1 - actual)}%). Because of the travel time
+          of <SpellLink id={TALENTS.FLURRY_TALENT.id} />, you should cast a damaging ability such as{' '}
           <SpellLink id={SPELLS.FROSTBOLT.id} />{' '}
           {this.hasEbonbolt ? (
             <>
@@ -255,12 +254,10 @@ class WintersChill extends Analyzer {
           ) : (
             ''
           )}{' '}
-          immediately before using your instant cast <SpellLink id={TALENTS.FLURRY_TALENT.id} />.
-          Doing this will allow your pre-cast ability to hit the target after{' '}
+          immediately before using <SpellLink id={TALENTS.FLURRY_TALENT.id} />. Doing this will
+          allow your pre-cast ability to hit the target after{' '}
           <SpellLink id={TALENTS.FLURRY_TALENT.id} /> (unless you are standing too close to the
-          target) allowing it to benefit from <SpellLink id={TALENTS.SHATTER_TALENT.id} />. If you
-          are a Kyrian, it is also acceptable to pre-cast <SpellLink id={SPELLS.RADIANT_SPARK.id} />{' '}
-          instead.
+          target) allowing it to benefit from <SpellLink id={TALENTS.SHATTER_TALENT.id} />.
         </>,
       )
         .icon(SPELLS.FROSTBOLT.icon)
@@ -281,13 +278,13 @@ class WintersChill extends Analyzer {
         size="flexible"
         tooltip={
           <>
-            When using your Brain Freeze procs, you should always ensure that you have something
-            immediately before it (Like Frostbolt, Ebonbolt, or Radiant Spark) as well as 2 Ice
-            Lance Casts (Or Glacial Spike + Ice Lance) immediately after to get the most out of the
-            Winter's Chill debuff that is applied to the target. Doing so will allow the cast before
-            and the 2 casts after to all benefit from Shatter. Note that if you are very close to
-            your target, then the ability you used immediately before Flurry might hit the target
-            too quickly and not get shattered.
+            When casting Flurry, you should always ensure that you have something immediately before
+            it (Like Frostbolt or Ebonbolt) as well as 2 Ice Lance Casts (Or Glacial Spike + Ice
+            Lance) immediately after to get the most out of the Winter's Chill debuff that is
+            applied to the target. Doing so will allow the cast before and the 2 casts after to all
+            benefit from Shatter. Note that if you are very close to your target, then the ability
+            you used immediately before Flurry might hit the target too quickly and not get
+            shattered.
           </>
         }
       >

--- a/src/analysis/retail/mage/frost/talents/CometStorm.tsx
+++ b/src/analysis/retail/mage/frost/talents/CometStorm.tsx
@@ -91,10 +91,10 @@ class CometStorm extends Analyzer {
           casts {this.badCometStormCast} times. Because the projectiles from{' '}
           <SpellLink id={TALENTS.COMET_STORM_TALENT.id} /> no longer remove your stacks of{' '}
           <SpellLink id={SPELLS.WINTERS_CHILL.id} />, you should always cast{' '}
-          <SpellLink id={TALENTS.COMET_STORM_TALENT.id} /> immediately after using your{' '}
-          <SpellLink id={TALENTS.BRAIN_FREEZE_TALENT.id} /> proc on{' '}
-          <SpellLink id={TALENTS.FLURRY_TALENT.id} />. This way there is time for most/all of the
-          comets to hit the target before <SpellLink id={SPELLS.WINTERS_CHILL.id} /> expires.
+          <SpellLink id={TALENTS.COMET_STORM_TALENT.id} /> immediately after casting{' '}
+          <SpellLink id={TALENTS.FLURRY_TALENT.id} /> and applying{' '}
+          <SpellLink id={SPELLS.WINTERS_CHILL} />. This way there is time for most/all of the comets
+          to hit the target before <SpellLink id={SPELLS.WINTERS_CHILL.id} /> expires.
           Alternatively, if <SpellLink id={TALENTS.COMET_STORM_TALENT.id} /> will hit at least{' '}
           {COMET_STORM_AOE_MIN_TARGETS} targets, then it is acceptable to use it without{' '}
           <SpellLink id={TALENTS.SHATTER_TALENT.id} />/<SpellLink id={SPELLS.WINTERS_CHILL.id} />

--- a/src/analysis/retail/mage/frost/talents/Flurry.tsx
+++ b/src/analysis/retail/mage/frost/talents/Flurry.tsx
@@ -5,9 +5,9 @@ import { SELECTED_PLAYER } from 'parser/core/EventFilter';
 import Events from 'parser/core/Events';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 
-const REDUCTION_MS = 300;
+const REDUCTION_MS = 30000;
 
-class FrozenOrb extends Analyzer {
+class Flurry extends Analyzer {
   static dependencies = {
     spellUsable: SpellUsable,
   };
@@ -15,18 +15,17 @@ class FrozenOrb extends Analyzer {
 
   constructor(props: Options) {
     super(props);
-    this.active = this.selectedCombatant.hasTalent(TALENTS.ICE_CALLER_TALENT);
     this.addEventListener(
-      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.BLIZZARD_DAMAGE),
-      this._reduceCooldown,
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.BRAIN_FREEZE_BUFF),
+      this._gainCharge,
     );
   }
 
-  _reduceCooldown() {
-    if (this.spellUsable.isOnCooldown(TALENTS.FROZEN_ORB_TALENT.id)) {
-      this.spellUsable.reduceCooldown(TALENTS.FROZEN_ORB_TALENT.id, REDUCTION_MS);
+  _gainCharge() {
+    if (this.spellUsable.isOnCooldown(TALENTS.FLURRY_TALENT.id)) {
+      this.spellUsable.reduceCooldown(TALENTS.FLURRY_TALENT.id, REDUCTION_MS);
     }
   }
 }
 
-export default FrozenOrb;
+export default Flurry;

--- a/src/analysis/retail/mage/frost/talents/IcyPropulsion.tsx
+++ b/src/analysis/retail/mage/frost/talents/IcyPropulsion.tsx
@@ -33,7 +33,6 @@ class IcyPropulsion extends Analyzer {
 
   onDamage(event: DamageEvent) {
     if (
-      !this.selectedCombatant.hasBuff(TALENTS.ICY_VEINS_TALENT.id) ||
       event.hitType !== HIT_TYPES.CRIT ||
       !this.spellUsable.isOnCooldown(TALENTS.ICY_VEINS_TALENT.id)
     ) {

--- a/src/analysis/retail/mage/shared/Abilities.tsx
+++ b/src/analysis/retail/mage/shared/Abilities.tsx
@@ -60,10 +60,6 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         cooldown: 25,
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: 0.9,
-        },
       },
       {
         spell: TALENTS.METEOR_TALENT.id,
@@ -86,10 +82,6 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         cooldown: 25,
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: 0.9,
-        },
         timelineSortIndex: 9,
         //damageSpellIds: [SPELLS.ICE_NOVA_TALENT.id], // needs verification
       },


### PR DESCRIPTION
- Adds support for Dragonflight 10.0.2
- Removed Dambroda as a maintainer (they asked to be removed)
- Updated Brain Freeze to not yell about Flurry cast without Brain Freeze
- Added the charge reset for Flurry with Brain Freeze
- Removed Blast Wave and Ice Nova from Cast Efficiency
- Fixed Icy Propulsion to count CDR outside of Icy Veins as well as during
- Adjusted the wording on some suggestions, tooltips, and checklist items to ensure they are accurate for Dragonflight
