### PR TITLE
Updated cooldown durations to match new DF talents (Unholy DK)

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -185,6 +185,14 @@ export const Khazak: Contributor = {
 export const Bicepspump: Contributor = {
   nickname: 'Bicepspump',
   github: 'Bicepspump',
+  discord: '💪Bicepspump💪#6318',
+  mains: [
+    {
+      name: 'Bicepspump',
+      spec: SPECS.UNHOLY_DEATH_KNIGHT,
+      link: 'https://worldofwarcraft.com/en-gb/character/eu/kazzak/Bicepspump',
+    },
+  ],
 };
 export const Mamtooth: Contributor = {
   nickname: 'Mamtooth',

--- a/src/analysis/retail/deathknight/unholy/CHANGELOG.tsx
+++ b/src/analysis/retail/deathknight/unholy/CHANGELOG.tsx
@@ -1,6 +1,7 @@
 import { change, date } from 'common/changelog';
-import { AlexanderJKremer } from 'CONTRIBUTORS';
+import { AlexanderJKremer, Bicepspump } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2023, 1, 16), 'Updated Cooldowns to have proper Cooldown', Bicepspump),
   change(date(2022, 12, 19), 'Initial Dragonflight version', AlexanderJKremer),
 ];

--- a/src/analysis/retail/deathknight/unholy/modules/core/SpellUsable.ts
+++ b/src/analysis/retail/deathknight/unholy/modules/core/SpellUsable.ts
@@ -5,7 +5,6 @@ import TALENTS from 'common/TALENTS/deathknight';
 import SPELLS from 'common/SPELLS';
 
 const AOTD_PET_ID = 365;
-const DEATH_COIL_RANK_2_REDUCTION = 1000;
 
 class SpellUsable extends CoreSpellUsable {
   static dependencies = {
@@ -27,10 +26,6 @@ class SpellUsable extends CoreSpellUsable {
       Events.damage.by(SELECTED_PLAYER_PET).spell(SPELLS.MELEE),
       this.onArmyDamage,
     );
-    this.addEventListener(
-      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.IMPROVED_DEATH_COIL_TALENT),
-      this.onDeathCoilCast,
-    );
   }
 
   onApocalypseCast(event: CastEvent) {
@@ -46,16 +41,6 @@ class SpellUsable extends CoreSpellUsable {
 
     if (!this.isOnCooldown(TALENTS.ARMY_OF_THE_DEAD_TALENT.id)) {
       this.beginCooldown(event, TALENTS.ARMY_OF_THE_DEAD_TALENT.id);
-    }
-  }
-
-  onDeathCoilCast(event: CastEvent) {
-    if (this.isOnCooldown(TALENTS.DARK_TRANSFORMATION_TALENT.id)) {
-      this.reduceCooldown(
-        TALENTS.DARK_TRANSFORMATION_TALENT.id,
-        DEATH_COIL_RANK_2_REDUCTION,
-        event.timestamp,
-      );
     }
   }
 }

--- a/src/analysis/retail/deathknight/unholy/modules/features/Abilities.tsx
+++ b/src/analysis/retail/deathknight/unholy/modules/features/Abilities.tsx
@@ -8,6 +8,7 @@ import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
 class Abilities extends CoreAbilities {
   spellbook(): SpellbookAbility[] {
     const combatant = this.selectedCombatant;
+    const UNHOLY_COMMAND_SCALING = [0, 8, 15];
     return [
       // roational
       {
@@ -55,7 +56,8 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.DARK_TRANSFORMATION.id,
         category: SPELL_CATEGORY.COOLDOWNS,
-        cooldown: 60 - combatant.getTalentRank(talents.UNHOLY_COMMAND_TALENT) * 7.5,
+        cooldown:
+          60 - UNHOLY_COMMAND_SCALING[combatant.getTalentRank(talents.UNHOLY_COMMAND_TALENT)],
         gcd: {
           base: 1500,
         },

--- a/src/analysis/retail/deathknight/unholy/modules/features/Abilities.tsx
+++ b/src/analysis/retail/deathknight/unholy/modules/features/Abilities.tsx
@@ -55,7 +55,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.DARK_TRANSFORMATION.id,
         category: SPELL_CATEGORY.COOLDOWNS,
-        cooldown: 60,
+        cooldown: 60 - combatant.getTalentRank(talents.UNHOLY_COMMAND_TALENT) * 7.5,
         gcd: {
           base: 1500,
         },
@@ -92,13 +92,13 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.APOCALYPSE.id,
         category: SPELL_CATEGORY.COOLDOWNS,
-        cooldown: 75,
+        cooldown: combatant.hasTalent(talents.ARMY_OF_THE_DAMNED_TALENT) ? 45 : 90,
         gcd: {
           base: 1500,
         },
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: 0.95,
+          recommendedEfficiency: 0.9,
           extraSuggestion: (
             <span>
               Making sure to use <SpellLink id={SPELLS.APOCALYPSE.id} /> immediately after it's
@@ -190,7 +190,7 @@ class Abilities extends CoreAbilities {
       {
         spell: talents.UNHOLY_ASSAULT_TALENT.id,
         category: SPELL_CATEGORY.COOLDOWNS,
-        cooldown: 75,
+        cooldown: 90,
         enabled: combatant.hasTalent(talents.UNHOLY_ASSAULT_TALENT),
         castEfficiency: {
           suggestion: true,

--- a/src/analysis/retail/deathknight/unholy/modules/talents/ArmyOfTheDamned.tsx
+++ b/src/analysis/retail/deathknight/unholy/modules/talents/ArmyOfTheDamned.tsx
@@ -8,7 +8,6 @@ import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 
-const AOTD_APOCALYPSE_REDUCTION_MS = 1000;
 const AOTD_ARMY_REDUCTION_MS = 5000;
 
 class ArmyOfTheDamned extends Analyzer {
@@ -18,7 +17,6 @@ class ArmyOfTheDamned extends Analyzer {
 
   protected spellUsable!: SpellUsable;
 
-  totalApocalypseReductionMs: number = 0;
   totalArmyReductionMs: number = 0;
 
   constructor(options: Options) {
@@ -36,15 +34,6 @@ class ArmyOfTheDamned extends Analyzer {
   }
 
   onCdrCast(event: CastEvent) {
-    if (this.spellUsable.isOnCooldown(SPELLS.APOCALYPSE.id)) {
-      this.spellUsable.reduceCooldown(
-        SPELLS.APOCALYPSE.id,
-        AOTD_APOCALYPSE_REDUCTION_MS,
-        event.timestamp,
-      );
-      this.totalApocalypseReductionMs += AOTD_APOCALYPSE_REDUCTION_MS;
-    }
-
     if (this.spellUsable.isOnCooldown(SPELLS.ARMY_OF_THE_DEAD.id)) {
       this.spellUsable.reduceCooldown(
         SPELLS.ARMY_OF_THE_DEAD.id,
@@ -59,10 +48,6 @@ class ArmyOfTheDamned extends Analyzer {
     if (this.spellUsable.isOnCooldown(SPELLS.ARMY_OF_THE_DEAD.id)) {
       this.spellUsable.endCooldown(SPELLS.ARMY_OF_THE_DEAD.id);
     }
-
-    if (this.spellUsable.isOnCooldown(SPELLS.APOCALYPSE.id)) {
-      this.spellUsable.endCooldown(SPELLS.APOCALYPSE.id);
-    }
   }
 
   statistic() {
@@ -70,9 +55,6 @@ class ArmyOfTheDamned extends Analyzer {
       <Statistic category={STATISTIC_CATEGORY.TALENTS} size="flexible">
         <BoringSpellValueText spellId={TALENTS.ARMY_OF_THE_DAMNED_TALENT.id}>
           <>
-            <CooldownIcon /> {this.totalApocalypseReductionMs / 1000}s{' '}
-            <small> of Apocalypse CDR</small>
-            <br />
             <CooldownIcon /> {this.totalArmyReductionMs / 1000}s{' '}
             <small> of Army of the Dead CDR</small>
           </>


### PR DESCRIPTION
### Description

Updated outdated Cooldown durations to match new Dragonflight version.

Talents covered:

- Dark Transformation
- Apocalypse
- Unholy Assault

### Motivation

Spec is currently not indicated as supported, I intend to change that through a set of PRs.

### Testing

Load up https://www.warcraftlogs.com/reports/jXn6BbyPh97JV1Fm#fight=24&type=damage-done, cooldowns now correctly state 95% or so, was previously more than 100% (used old CDR logic for cooldowns).

- Test report URL: https://www.warcraftlogs.com/reports/jXn6BbyPh97JV1Fm#fight=24&type=damage-done
