### PR TITLE
[☄️ Destruction] Add Rolling Havoc analyzer

### DIFF
--- a/src/analysis/retail/warlock/destruction/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/destruction/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
-import { Sharrq, ogunb, ToppleTheNun, Omegabiscuit } from 'CONTRIBUTORS';
+import { Sharrq, ogunb, ToppleTheNun, Omegabiscuit, Mae } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2023, 1, 16), 'Add Rolling Havoc analyzer', Mae),
   change(date(2022, 10, 31), 'Update to reflect that Destruction Warlock has been looked at for Dragonflight.', ToppleTheNun),
   change(date(2022, 10, 15), 'updated spells that were converted to talents to use talents list', Omegabiscuit),
   change(date(2022, 7, 22), <>Add tracker for number of <SpellLink id={SPELLS.DEMONIC_CIRCLE_SUMMON.id} /> created.</>, ToppleTheNun),

--- a/src/analysis/retail/warlock/destruction/CombatLogParser.ts
+++ b/src/analysis/retail/warlock/destruction/CombatLogParser.ts
@@ -26,6 +26,7 @@ import Inferno from './modules/talents/Inferno';
 import InternalCombustion from './modules/talents/InternalCombustion';
 import ReverseEntropy from './modules/talents/ReverseEntropy';
 import RoaringBlaze from './modules/talents/RoaringBlaze';
+import RollingHavoc from './modules/talents/RollingHavoc';
 import Shadowburn from './modules/talents/Shadowburn';
 import SoulConduit from './modules/talents/SoulConduit';
 import SoulFire from './modules/talents/SoulFire';
@@ -66,6 +67,7 @@ class CombatLogParser extends CoreCombatLogParser {
     grimoireOfSacrifice: GrimoireOfSacrifice,
     soulConduit: SoulConduit,
     channelDemonfire: ChannelDemonfire,
+    rollingHavoc: RollingHavoc,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,

--- a/src/analysis/retail/warlock/destruction/modules/talents/RollingHavoc.tsx
+++ b/src/analysis/retail/warlock/destruction/modules/talents/RollingHavoc.tsx
@@ -1,0 +1,35 @@
+import { formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/warlock';
+import UptimeIcon from 'interface/icons/Uptime';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import Statistic from 'parser/ui/Statistic';
+import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+
+class RollingHavoc extends Analyzer {
+  static talent = TALENTS.ROLLING_HAVOC_TALENT;
+  static buffId = SPELLS.ROLLING_HAVOC_BUFF.id;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(RollingHavoc.talent);
+  }
+
+  get uptime() {
+    return this.selectedCombatant.getBuffUptime(RollingHavoc.buffId) / this.owner.fightDuration;
+  }
+
+  statistic() {
+    return (
+      <Statistic position={STATISTIC_ORDER.CORE()}>
+        <TalentSpellText talent={RollingHavoc.talent}>
+          <UptimeIcon /> {formatPercentage(this.uptime)}% <small>uptime</small>
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}
+
+export default RollingHavoc;

--- a/src/common/SPELLS/warlock.ts
+++ b/src/common/SPELLS/warlock.ts
@@ -754,6 +754,11 @@ const spells = spellIndexableList({
     name: 'Channel Demonfire',
     icon: 'spell_fire_ragnaros_lavaboltgreen',
   },
+  ROLLING_HAVOC_BUFF: {
+    id: 387570,
+    name: 'Rolling Havoc',
+    icon: 'warlock_pvp_banehavoc',
+  },
 });
 
 export default spells;


### PR DESCRIPTION
### Description

Add Rolling Havoc analyzer with uptime statistic

### Motivation

To see Rolling Havoc uptime

### Testing

- Test report URL: https://www.warcraftlogs.com/reports/JWf2n7G3HmtMxvqc#fight=33&type=auras&ability=387570
- Screenshot(s):
<img width="331" alt="Screenshot 2023-01-16 at 23 34 39" src="https://user-images.githubusercontent.com/10657271/212775179-b5e06a66-b4bf-48cd-b136-1a10ca8da4e7.png">

![Screenshot 2023-01-16 at 23 34 50](https://user-images.githubusercontent.com/10657271/212775176-b99b9ed8-483e-4db5-b93d-a431b56447b4.png)
