### PR TITLE
fix reference to shadowlands version of radiant spark

### DIFF
--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -1,7 +1,10 @@
 import { change, date } from 'common/changelog';
-import { Sharrq } from 'CONTRIBUTORS';
+import talents from 'common/TALENTS/mage';
+import { Sharrq, emallson } from 'CONTRIBUTORS';
+import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 1, 17), <>Fixed outdated reference to the Shadowlands version of <SpellLink id={talents.RADIANT_SPARK_TALENT} />.</>, emallson),
   change(date(2022, 10, 30), `Update Dragonflight SPELLS, Abilities, and Buffs`, Sharrq),
   change(date(2022, 9, 29), 'Initial Dragonflight support', Sharrq),
 ];

--- a/src/analysis/retail/mage/arcane/core/CooldownThroughputTracker.js
+++ b/src/analysis/retail/mage/arcane/core/CooldownThroughputTracker.js
@@ -1,4 +1,3 @@
-import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/mage';
 import CoreCooldownThroughputTracker, {
   BUILT_IN_SUMMARY_TYPES,
@@ -17,7 +16,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
       summary: [BUILT_IN_SUMMARY_TYPES.DAMAGE],
     },
     {
-      spell: SPELLS.RADIANT_SPARK.id,
+      spell: TALENTS.RADIANT_SPARK_TALENT.id,
       summary: [BUILT_IN_SUMMARY_TYPES.DAMAGE],
     },
   ];


### PR DESCRIPTION
### Description

Fixes the error on this page https://www.wowanalyzer.com/report/ZCdj9WQPD6yBnm71/6-Heroic+Dathea,+Ascended+-+Kill+(6:42)/Z%C3%A2uberh%C3%A2ft/standard

tldr when the Shadowlands spell PR landed some spells in JS files got missed.
