### PR TITLE
[☄️ Destruction] Enrich `Backdraft` and `Roaring Blaze` analyzers. Add `Flashpoint` analyzer

### DIFF
--- a/src/analysis/retail/warlock/destruction/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/destruction/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2023, 1, 17), "Add more data to Backdraft and Roaring Blaze analyzers. Add Flashpoint analyzer.", Mae),
   change(date(2023, 1, 17), "Add Madness of Azh'aqir analyzer", Mae),
   change(date(2023, 1, 16), 'Add Rolling Havoc analyzer', Mae),
   change(date(2022, 10, 31), 'Update to reflect that Destruction Warlock has been looked at for Dragonflight.', ToppleTheNun),

--- a/src/analysis/retail/warlock/destruction/CombatLogParser.ts
+++ b/src/analysis/retail/warlock/destruction/CombatLogParser.ts
@@ -31,6 +31,7 @@ import RollingHavoc from './modules/talents/RollingHavoc';
 import Shadowburn from './modules/talents/Shadowburn';
 import SoulConduit from './modules/talents/SoulConduit';
 import SoulFire from './modules/talents/SoulFire';
+import FlashPoint from './modules/talents/FlashPoint';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -70,6 +71,7 @@ class CombatLogParser extends CoreCombatLogParser {
     channelDemonfire: ChannelDemonfire,
     rollingHavoc: RollingHavoc,
     madnessOfAzhaqir: MadnessOfAzhaqir,
+    flashPoint: FlashPoint,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,

--- a/src/analysis/retail/warlock/destruction/modules/talents/Backdraft.tsx
+++ b/src/analysis/retail/warlock/destruction/modules/talents/Backdraft.tsx
@@ -1,14 +1,14 @@
 import { t } from '@lingui/macro';
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/warlock';
 import { SpellLink, TooltipElement } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent, RemoveBuffEvent } from 'parser/core/Events';
 import { NumberThreshold, ThresholdStyle, When } from 'parser/core/ParseResults';
-import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
-
+import TalentSpellText from 'parser/ui/TalentSpellText';
 const debug = false;
 
 const BUFF_DURATION = 10000;
@@ -132,14 +132,14 @@ class Backdraft extends Analyzer {
   statistic() {
     return (
       <Statistic category={STATISTIC_CATEGORY.TALENTS}>
-        <BoringSpellValueText spellId={SPELLS.BACKDRAFT.id}>
+        <TalentSpellText talent={TALENTS.BACKDRAFT_TALENT}>
           {this.wastedStacks} <small>Wasted procs</small>
           <br />
           {formatPercentage(this.percentageOfChaosBoltsAmongBuffedCasts, 0)}%
           <TooltipElement content={`${this.buffedChaosBoltCasts}/${this.totalBuffedCasts}`}>
             <small> buffed casts - Chaos Bolt</small>
           </TooltipElement>
-        </BoringSpellValueText>
+        </TalentSpellText>
       </Statistic>
     );
   }

--- a/src/analysis/retail/warlock/destruction/modules/talents/FlashPoint.tsx
+++ b/src/analysis/retail/warlock/destruction/modules/talents/FlashPoint.tsx
@@ -26,7 +26,7 @@ class FlashPoint extends Analyzer {
 
   statistic() {
     return (
-      <Statistic category={STATISTIC_CATEGORY.TALENTS}>
+      <Statistic category={STATISTIC_CATEGORY.TALENTS} size="flexible">
         <TalentSpellText talent={FlashPoint.talent}>
           <UptimeIcon /> {formatPercentage(this.uptime)}% <small>uptime</small>
         </TalentSpellText>

--- a/src/analysis/retail/warlock/destruction/modules/talents/FlashPoint.tsx
+++ b/src/analysis/retail/warlock/destruction/modules/talents/FlashPoint.tsx
@@ -1,0 +1,38 @@
+import { formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/warlock';
+import UptimeIcon from 'interface/icons/Uptime';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+
+/**
+ * When your Immolate deals periodic damage to a target above 80% health, gain 2% Haste for 10 sec.
+ */
+class FlashPoint extends Analyzer {
+  static talent = TALENTS.FLASHPOINT_TALENT;
+  static buffId = SPELLS.FLASHPOINT_BUFF.id;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(FlashPoint.talent);
+  }
+
+  get uptime() {
+    return this.selectedCombatant.getBuffUptime(FlashPoint.buffId) / this.owner.fightDuration;
+  }
+
+  statistic() {
+    return (
+      <Statistic category={STATISTIC_CATEGORY.TALENTS}>
+        <TalentSpellText talent={FlashPoint.talent}>
+          <UptimeIcon /> {formatPercentage(this.uptime)}% <small>uptime</small>
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}
+
+export default FlashPoint;

--- a/src/analysis/retail/warlock/destruction/modules/talents/RoaringBlaze.tsx
+++ b/src/analysis/retail/warlock/destruction/modules/talents/RoaringBlaze.tsx
@@ -1,13 +1,13 @@
-import { formatThousands, formatNumber, formatPercentage } from 'common/format';
+import { formatNumber, formatPercentage, formatThousands } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
+import UptimeIcon from 'interface/icons/Uptime';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { DamageEvent } from 'parser/core/Events';
 import Enemies from 'parser/shared/modules/Enemies';
-import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
-import UptimeIcon from 'interface/icons/Uptime';
+import TalentSpellText from 'parser/ui/TalentSpellText';
 
 /*
   Roaring Blaze (Tier 90 Destruction talent):
@@ -49,7 +49,7 @@ class RoaringBlaze extends Analyzer {
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={`${formatThousands(this.damage)} damage`}
       >
-        <BoringSpellValueText spellId={TALENTS.ROARING_BLAZE_TALENT.id}>
+        <TalentSpellText talent={TALENTS.ROARING_BLAZE_TALENT}>
           {formatNumber(this.dps)} DPS{' '}
           <small>
             {formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.damage))} % of total
@@ -57,7 +57,7 @@ class RoaringBlaze extends Analyzer {
           <br />
           <UptimeIcon />
           {formatPercentage(this.uptime, 0)}%<small> uptime</small>
-        </BoringSpellValueText>
+        </TalentSpellText>
       </Statistic>
     );
   }

--- a/src/analysis/retail/warlock/destruction/modules/talents/RoaringBlaze.tsx
+++ b/src/analysis/retail/warlock/destruction/modules/talents/RoaringBlaze.tsx
@@ -3,18 +3,22 @@ import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { DamageEvent } from 'parser/core/Events';
+import Enemies from 'parser/shared/modules/Enemies';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import UptimeIcon from 'interface/icons/Uptime';
 
 /*
   Roaring Blaze (Tier 90 Destruction talent):
     Conflagrate burns the target for an additional (48% of Spell power) Fire damage over 6 sec.
  */
 class RoaringBlaze extends Analyzer {
-  get dps() {
-    return (this.damage / this.owner.fightDuration) * 1000;
-  }
+  static dependencies = {
+    enemies: Enemies,
+  };
+
+  protected enemies!: Enemies;
 
   damage = 0;
 
@@ -31,11 +35,18 @@ class RoaringBlaze extends Analyzer {
     this.damage += (event.amount || 0) + (event.absorbed || 0);
   }
 
+  get dps() {
+    return (this.damage / this.owner.fightDuration) * 1000;
+  }
+
+  get uptime() {
+    return this.enemies.getBuffUptime(SPELLS.ROARING_BLAZE_DAMAGE.id) / this.owner.fightDuration;
+  }
+
   statistic() {
     return (
       <Statistic
         category={STATISTIC_CATEGORY.TALENTS}
-        size="small"
         tooltip={`${formatThousands(this.damage)} damage`}
       >
         <BoringSpellValueText spellId={TALENTS.ROARING_BLAZE_TALENT.id}>
@@ -43,6 +54,9 @@ class RoaringBlaze extends Analyzer {
           <small>
             {formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.damage))} % of total
           </small>
+          <br />
+          <UptimeIcon />
+          {formatPercentage(this.uptime, 0)}%<small> uptime</small>
         </BoringSpellValueText>
       </Statistic>
     );

--- a/src/common/SPELLS/warlock.ts
+++ b/src/common/SPELLS/warlock.ts
@@ -764,6 +764,11 @@ const spells = spellIndexableList({
     name: "Madness of Azh'Aqir",
     icon: 'ability_warlock_chaosbolt',
   },
+  FLASHPOINT_BUFF: {
+    id: 387263,
+    name: 'Flashpoint',
+    icon: 'spell_fire_moltenblood',
+  },
 });
 
 export default spells;


### PR DESCRIPTION
### Description

- Backdraft analyzer:
  - Display % of stacks used for Chaos Bolt buff
  - Display % of stacks used for Soul Fire buff
- Roaring Blaze analyzer:
  - Display debuff uptime
- Add Flashpoint analyzer

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: https://www.warcraftlogs.com/reports/JWf2n7G3HmtMxvqc#fight=33
- Screenshot(s):
<img width="297" alt="Screenshot 2023-01-17 at 22 19 42" src="https://user-images.githubusercontent.com/10657271/213014748-20c4204b-3306-4de9-9ab8-1d6571834503.png">
<img width="303" alt="Screenshot 2023-01-17 at 22 18 09" src="https://user-images.githubusercontent.com/10657271/213014755-7123e511-85f5-468d-8daa-8bf1a23a63b9.png">
<img width="306" alt="Screenshot 2023-01-17 at 22 18 05" src="https://user-images.githubusercontent.com/10657271/213014759-f777b3e6-e5b5-46c0-87e2-c3ccc74c5cd8.png">
<img width="386" alt="Screenshot 2023-01-17 at 22 18 56" src="https://user-images.githubusercontent.com/10657271/213014754-6dd3f927-476c-4232-968e-1594ef60e18c.png">

