### PR TITLE
[Unholy DK] Implemented Plaguebringer uptime tracker for Unholy DK

### DIFF
--- a/src/analysis/retail/deathknight/unholy/CHANGELOG.tsx
+++ b/src/analysis/retail/deathknight/unholy/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { change, date } from 'common/changelog';
 import { AlexanderJKremer, Bicepspump } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2023, 1, 18), 'Added Plaguebringer Tracker', Bicepspump),
   change(date(2023, 1, 16), 'Updated Cooldowns to have proper Cooldown', Bicepspump),
   change(date(2022, 12, 19), 'Initial Dragonflight version', AlexanderJKremer),
 ];

--- a/src/analysis/retail/deathknight/unholy/CombatLogParser.ts
+++ b/src/analysis/retail/deathknight/unholy/CombatLogParser.ts
@@ -1,7 +1,7 @@
 import {
   RuneDetails,
   RuneOfTheFallenCrusader,
-  RuneOfHysteria
+  RuneOfHysteria,
 } from 'analysis/retail/deathknight/shared';
 import CoreCombatLogParser from 'parser/core/CombatLogParser';
 import ArcaneTorrent from 'parser/shared/modules/racials/bloodelf/ArcaneTorrent';
@@ -24,6 +24,7 @@ import ScourgeStrikeEfficiency from './modules/spells/ScourgeStrikeEfficiency';
 import VirulentPlagueEfficiency from './modules/spells/VirulentPlagueEfficiency';
 import ArmyOfTheDamned from './modules/talents/ArmyOfTheDamned';
 import SoulReaper from './modules/talents/SoulReaper';
+import PlagueBringer from './modules/talents/PlagueBringer';
 
 // Covenants
 
@@ -49,6 +50,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // Talents
     soulReaper: SoulReaper,
     armyOfTheDamned: ArmyOfTheDamned,
+    plagueBringer: PlagueBringer,
 
     // RunicPower
     runicPowerTracker: RunicPowerTracker,

--- a/src/analysis/retail/deathknight/unholy/modules/talents/PlagueBringer.tsx
+++ b/src/analysis/retail/deathknight/unholy/modules/talents/PlagueBringer.tsx
@@ -10,10 +10,6 @@ import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import { formatPercentage } from 'common/format';
 
 class PlagueBringer extends Analyzer {
-  lastBuffTime = 0;
-  totalBuffTime = 0;
-  buffIsUp = false;
-
   constructor(options: Options) {
     super(options);
 

--- a/src/analysis/retail/deathknight/unholy/modules/talents/PlagueBringer.tsx
+++ b/src/analysis/retail/deathknight/unholy/modules/talents/PlagueBringer.tsx
@@ -1,0 +1,100 @@
+import { t } from '@lingui/macro';
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/deathknight';
+import { SpellLink } from 'interface';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { ApplyBuffEvent, RemoveBuffEvent, FightEndEvent } from 'parser/core/Events';
+import { When } from 'parser/core/ParseResults';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { formatPercentage } from 'common/format';
+
+class PlagueBringer extends Analyzer {
+  lastBuffTime = 0;
+  totalBuffTime = 0;
+  buffIsUp = false;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS.PLAGUEBRINGER_TALENT);
+    if (!this.active) {
+      return;
+    }
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.PLAGUEBRINGER_BUFF),
+      this.onBuffEvent,
+    );
+
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.PLAGUEBRINGER_BUFF),
+      this.onRemoveBuffEvent,
+    );
+
+    this.addEventListener(Events.fightend, this.onFightEnd);
+  }
+
+  onBuffEvent(event: ApplyBuffEvent) {
+    this.lastBuffTime = event.timestamp;
+    this.buffIsUp = true;
+  }
+
+  onRemoveBuffEvent(event: RemoveBuffEvent) {
+    this.totalBuffTime += event.timestamp - this.lastBuffTime;
+    this.buffIsUp = false;
+  }
+
+  onFightEnd(event: FightEndEvent) {
+    if (this.buffIsUp === true) {
+      this.totalBuffTime += event.timestamp - this.lastBuffTime;
+    }
+  }
+
+  suggestions(when: When) {
+    const averageBuffUptime = Number(this.totalBuffTime / this.owner.fightDuration);
+    // Plaguebringer should have 90% uptime or more
+    when(averageBuffUptime)
+      .isLessThan(0.9)
+      .addSuggestion((suggest, actual, recommended) =>
+        suggest(
+          <span>
+            You are not keeping up your <SpellLink id={SPELLS.PLAGUEBRINGER_BUFF.id} /> enough.{' '}
+            Prioritise maintaining it by using <SpellLink id={SPELLS.SCOURGE_STRIKE.id} />.
+          </span>,
+        )
+          .icon(SPELLS.PLAGUEBRINGER_BUFF.icon)
+          .actual(
+            t({
+              id: 'deathknight.unholy.suggestions.plaguebringer.uptime',
+              message: `Plaguebringer was up ${(averageBuffUptime * 100).toFixed(2)}% of the time`,
+            }),
+          )
+          .recommended(`${recommended * 100}% is recommended`)
+          .regular(recommended - 0.05)
+          .major(recommended - 0.1),
+      );
+  }
+
+  statistic() {
+    const averageBuffUptime = Number(this.totalBuffTime / this.owner.fightDuration);
+    return (
+      <Statistic
+        tooltip={`Your Plaguebringer was up ${(this.totalBuffTime / 1000).toFixed(0)} out of ${(
+          this.owner.fightDuration / 1000
+        ).toFixed(0)} seconds`}
+        position={STATISTIC_ORDER.CORE(1)}
+        size="flexible"
+      >
+        <BoringSpellValueText spellId={TALENTS.PLAGUEBRINGER_TALENT.id}>
+          <>
+            {formatPercentage(averageBuffUptime)}% <small>Plaguebringer uptime</small>
+          </>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default PlagueBringer;

--- a/src/common/SPELLS/deathknight.ts
+++ b/src/common/SPELLS/deathknight.ts
@@ -275,6 +275,12 @@ const spells = spellIndexableList({
     icon: 'spell_yorsahj_bloodboil_purpleoil',
   },
 
+  PLAGUEBRINGER_BUFF: {
+    id: 390178,
+    name: 'Plaguebringer',
+    icon: 'spell_deathknight_plaguestrike',
+  },
+
   // scourge strike has one cast event but two damage events, the cast and physical
   // damage happen on id 55090, the shadow damage is on id 70890
   SCOURGE_STRIKE: {


### PR DESCRIPTION
### Description

Tracks the % uptime on the plaguebringer buff when the talent has been selected.

### Motivation

Plaguebringer is a crucial part of doing good damage when running the Disease build for Unholy. This PR implements a tracker that checks the buff uptime.

### Testing

- Test report URL: https://www.warcraftlogs.com/reports/jXn6BbyPh97JV1Fm/#fight=12&source=58
![image](https://user-images.githubusercontent.com/34515306/213205995-251d435e-3842-49fe-a3dd-57501a855047.png)
