### PR TITLE
[Balance] Implement Statistics Tracking for Rattle The Stars

### DIFF
--- a/src/analysis/retail/druid/balance/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/balance/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { Hartra344, Sref, ToppleTheNun } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 1, 18), <>Added statistics support for <SpellLink id={TALENTS_DRUID.RATTLE_THE_STARS_TALENT} /></>, Hartra344 ),
   change(date(2023, 1, 6), <>Moved <SpellLink id={TALENTS_DRUID.CONVOKE_THE_SPIRITS_TALENT} /> from a covenant section to the general statistic section.</>, Hartra344 ),
   change(date(2022, 12, 31), <>Updated the about description to be up to date with dragonflight.</>, Hartra344 ),
   change(date(2022, 12, 31), <>Add support for <SpellLink id={TALENTS_DRUID.WANING_TWILIGHT_TALENT} /> uptime and DPS contribution statistic</>, Hartra344 ),

--- a/src/analysis/retail/druid/balance/CombatLogParser.ts
+++ b/src/analysis/retail/druid/balance/CombatLogParser.ts
@@ -25,6 +25,7 @@ import AstralPowerDetails from 'analysis/retail/druid/balance/modules/core/astra
 import Guide from 'analysis/retail/druid/balance/Guide';
 import AstralPowerGraph from 'analysis/retail/druid/balance/modules/core/astralpower/AstralPowerGraph';
 import WaningTwilight from './modules/spells/WaningTwilight';
+import RattleTheStars from './modules/spells/RattleTheStars';
 
 class CombatLogParser extends MainCombatLogParser {
   static specModules = {
@@ -59,6 +60,7 @@ class CombatLogParser extends MainCombatLogParser {
     waningTwilight: WaningTwilight,
     //Covenants
     convokeSpiritsBalance: ConvokeSpiritsBalance,
+    rattleTheStars: RattleTheStars,
   };
 
   static guide = Guide;

--- a/src/analysis/retail/druid/balance/constants.ts
+++ b/src/analysis/retail/druid/balance/constants.ts
@@ -17,10 +17,7 @@ export const DAMAGING_ABILITIES = [
 ];
 
 // Celestial Alignment buff or the talented version of it (Incarnation)
-export const CA_BUFF = [
-  SPELLS.CELESTIAL_ALIGNMENT,
-  TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT,
-];
+export const CA_BUFF = [SPELLS.CELESTIAL_ALIGNMENT, SPELLS.INCARNATION_CHOSEN_OF_ELUNE];
 
 export function cooldownAbility(combatant: Combatant): Spell {
   return combatant.hasTalent(TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT)
@@ -29,3 +26,7 @@ export function cooldownAbility(combatant: Combatant): Spell {
 }
 
 export const GUIDE_CORE_EXPLANATION_PERCENT = 40;
+export const STARSURGE_ELUNES_GUIDANCE_DISCOUNT = 5;
+export const STARFALL_ELUNES_GUIDANCE_DISCOUNT = 8;
+export const STARSURGE_BASE_COST = 40;
+export const STARFALL_BASE_COST = 50;

--- a/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
@@ -1,0 +1,188 @@
+import { formatDuration, formatNumber, formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import HasteIcon from 'interface/icons/Haste';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, {
+  EventType,
+  ApplyBuffEvent,
+  ApplyBuffStackEvent,
+  RemoveBuffEvent,
+  RemoveBuffStackEvent,
+  FightEndEvent,
+  CastEvent,
+  DamageEvent,
+} from 'parser/core/Events';
+import { currentStacks } from 'parser/shared/modules/helpers/Stacks';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { TALENTS_DRUID } from 'common/TALENTS';
+import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
+import {
+  STARFALL_BASE_COST,
+  STARFALL_ELUNES_GUIDANCE_DISCOUNT,
+  STARSURGE_BASE_COST,
+  STARSURGE_ELUNES_GUIDANCE_DISCOUNT,
+} from '../../constants';
+
+const MAX_STACKS = 2;
+export const PERCENT_DAMAGE_INCREASE_PER_STACK = 0.1;
+export const PERCENT_AP_SAVED_PER_STACK = 0.05;
+
+class RattleTheStars extends Analyzer {
+  buffStacks: number[][];
+  buffedStarsurges: number[];
+  buffedStarfalls: number[];
+  lastStacks = 0;
+  totalAPSaved = 0;
+  lastUpdate = this.owner.fight.start_time;
+  totalAddedDamage = 0;
+
+  private get elunedGuidanceDiscountActive() {
+    return (
+      this.selectedCombatant.hasTalent(TALENTS_DRUID.ELUNES_GUIDANCE_TALENT) &&
+      this.selectedCombatant.hasBuff(SPELLS.INCARNATION_CHOSEN_OF_ELUNE.id)
+    );
+  }
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.RATTLE_THE_STARS_TALENT);
+    this.buffStacks = Array.from({ length: MAX_STACKS + 1 }, (x) => [0]);
+    this.buffedStarsurges = Array.from({ length: MAX_STACKS + 1 }, (x) => 0);
+    this.buffedStarfalls = Array.from({ length: MAX_STACKS + 1 }, (x) => 0);
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.RATTLED_STARS),
+      this.handleStacks,
+    );
+    this.addEventListener(
+      Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.RATTLED_STARS),
+      this.handleStacks,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.RATTLED_STARS),
+      this.handleStacks,
+    );
+    this.addEventListener(
+      Events.removebuffstack.by(SELECTED_PLAYER).spell(SPELLS.RATTLED_STARS),
+      this.handleStacks,
+    );
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.STARFALL_CAST),
+      this.handleStarfallCast,
+    );
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.STARSURGE_MOONKIN),
+      this.handleStarsurgeCast,
+    );
+
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.STARFALL_CAST),
+      this.handleDamage,
+    );
+
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.STARSURGE_MOONKIN),
+      this.handleDamage,
+    );
+
+    this.addEventListener(Events.fightend, this.handleStacks);
+  }
+
+  handleStacks(
+    event:
+      | ApplyBuffEvent
+      | ApplyBuffStackEvent
+      | RemoveBuffEvent
+      | RemoveBuffStackEvent
+      | FightEndEvent,
+    stack = null,
+  ) {
+    this.buffStacks[this.lastStacks].push(event.timestamp - this.lastUpdate);
+    if (event.type === EventType.FightEnd) {
+      return;
+    }
+    this.lastUpdate = event.timestamp;
+    this.lastStacks = currentStacks(event);
+  }
+
+  handleStarsurgeCast(event: CastEvent) {
+    this.totalAPSaved +=
+      (STARSURGE_BASE_COST -
+        (this.elunedGuidanceDiscountActive ? STARSURGE_ELUNES_GUIDANCE_DISCOUNT : 0)) *
+      PERCENT_AP_SAVED_PER_STACK;
+
+    this.buffedStarsurges[this.lastStacks] = this.buffedStarsurges[this.lastStacks] + 1;
+  }
+
+  handleStarfallCast(event: CastEvent) {
+    this.totalAPSaved +=
+      (STARFALL_BASE_COST -
+        (this.elunedGuidanceDiscountActive ? STARFALL_ELUNES_GUIDANCE_DISCOUNT : 0)) *
+      PERCENT_AP_SAVED_PER_STACK;
+    this.buffedStarfalls[this.lastStacks] = this.buffedStarfalls[this.lastStacks] + 1;
+  }
+
+  handleDamage(event: DamageEvent) {
+    const buffStacks = this.selectedCombatant.getBuffStacks(SPELLS.RATTLED_STARS.id);
+    console.log(buffStacks);
+    this.totalAddedDamage += calculateEffectiveDamage(
+      event,
+      buffStacks * PERCENT_DAMAGE_INCREASE_PER_STACK,
+    );
+  }
+
+  statistic() {
+    console.log(this.totalAddedDamage);
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE(7)}
+        wide
+        size="flexible"
+        dropdown={
+          <>
+            <table className="table table-condensed">
+              <thead>
+                <tr>
+                  <th>Stacks</th>
+                  <th>Starsurges</th>
+                  <th>Starfalls</th>
+                  <th>Time (s)</th>
+                  <th>Time (%)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {this.buffStacks.map((e, i) => (
+                  <tr key={i}>
+                    <th>{i} Stacks</th>
+                    <td>{this.buffedStarsurges[i]}</td>
+                    <td>{this.buffedStarfalls[i]}</td>
+                    <td>6</td>
+                    <td>{formatDuration(e.reduce((a, b) => a + b, 0))}</td>
+                    <td>
+                      {formatPercentage(e.reduce((a, b) => a + b, 0) / this.owner.fightDuration)}%
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </>
+        }
+      >
+        <BoringSpellValueText spellId={TALENTS_DRUID.RATTLE_THE_STARS_TALENT.id}>
+          <>
+            <HasteIcon /> {formatNumber(this.totalAPSaved)} <small>Astral Power Saved</small>
+            <br />
+            <HasteIcon /> {formatNumber(
+              this.totalAddedDamage / (this.owner.fightDuration / 1000),
+            )}{' '}
+            <small> approx. DPS added</small>
+          </>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default RattleTheStars;

--- a/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
@@ -175,8 +175,7 @@ class RattleTheStars extends Analyzer {
           <>
             {formatNumber(this.totalAPSaved)} <small>Astral Power Saved</small>
             <br />
-            {formatNumber(dpsIncrease)}
-            <small> approx. DPS added</small>
+            {formatNumber(dpsIncrease)} <small>approx. DPS added</small>
           </>
         </BoringSpellValueText>
       </Statistic>

--- a/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
@@ -174,9 +174,9 @@ class RattleTheStars extends Analyzer {
       >
         <BoringSpellValueText spellId={TALENTS_DRUID.RATTLE_THE_STARS_TALENT.id}>
           <>
-            <HasteIcon /> {formatNumber(this.totalAPSaved)} <small>Astral Power Saved</small>
+            {formatNumber(this.totalAPSaved)} <small>Astral Power Saved</small>
             <br />
-            <HasteIcon /> {formatNumber(dpsIncrease)}
+            {formatNumber(dpsIncrease)}
             <small> approx. DPS added</small>
           </>
         </BoringSpellValueText>

--- a/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
@@ -23,6 +23,7 @@ import {
   STARSURGE_BASE_COST,
   STARSURGE_ELUNES_GUIDANCE_DISCOUNT,
 } from '../../constants';
+import ItemPercentDamageDone from 'parser/ui/ItemPercentDamageDone';
 
 const MAX_STACKS = 2;
 export const PERCENT_DAMAGE_INCREASE_PER_STACK = 0.1;
@@ -178,8 +179,7 @@ class RattleTheStars extends Analyzer {
           <>
             {formatNumber(this.totalAPSaved)} <small>Astral Power Saved</small>
             <br />
-            {'>'}
-            {formatNumber(dpsIncrease)} <small>approx. DPS added</small>
+            <ItemPercentDamageDone greaterThan amount={this.totalAddedDamage} />
           </>
         </BoringSpellValueText>
       </Statistic>

--- a/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
@@ -1,4 +1,4 @@
-import { formatDuration, formatNumber, formatPercentage } from 'common/format';
+import { formatNumber, formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, {

--- a/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
@@ -155,8 +155,7 @@ class RattleTheStars extends Analyzer {
                   <th>Stacks</th>
                   <th>Starsurges</th>
                   <th>Starfalls</th>
-                  <th>Time (s)</th>
-                  <th>Time (%)</th>
+                  <th>Uptime</th>
                 </tr>
               </thead>
               <tbody>
@@ -165,8 +164,6 @@ class RattleTheStars extends Analyzer {
                     <th>{i} Stacks</th>
                     <td>{this.buffedStarsurges[i]}</td>
                     <td>{this.buffedStarfalls[i]}</td>
-                    <td>6</td>
-                    <td>{formatDuration(e.reduce((a, b) => a + b, 0))}</td>
                     <td>
                       {formatPercentage(e.reduce((a, b) => a + b, 0) / this.owner.fightDuration)}%
                     </td>

--- a/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
@@ -43,6 +43,7 @@ class RattleTheStars extends Analyzer {
       this.selectedCombatant.hasBuff(SPELLS.INCARNATION_CHOSEN_OF_ELUNE.id)
     );
   }
+
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.RATTLE_THE_STARS_TALENT);
@@ -107,19 +108,22 @@ class RattleTheStars extends Analyzer {
   }
 
   handleStarsurgeCast(event: CastEvent) {
-    this.totalAPSaved +=
-      (STARSURGE_BASE_COST -
-        (this.elunedGuidanceDiscountActive ? STARSURGE_ELUNES_GUIDANCE_DISCOUNT : 0)) *
-      PERCENT_AP_SAVED_PER_STACK;
-
+    if (this.selectedCombatant.hasBuff(SPELLS.TOUCH_THE_COSMOS.id)) {
+      this.totalAPSaved +=
+        (STARSURGE_BASE_COST -
+          (this.elunedGuidanceDiscountActive ? STARSURGE_ELUNES_GUIDANCE_DISCOUNT : 0)) *
+        PERCENT_AP_SAVED_PER_STACK;
+    }
     this.buffedStarsurges[this.lastStacks] = this.buffedStarsurges[this.lastStacks] + 1;
   }
 
   handleStarfallCast(event: CastEvent) {
-    this.totalAPSaved +=
-      (STARFALL_BASE_COST -
-        (this.elunedGuidanceDiscountActive ? STARFALL_ELUNES_GUIDANCE_DISCOUNT : 0)) *
-      PERCENT_AP_SAVED_PER_STACK;
+    if (!this.selectedCombatant.hasBuff(SPELLS.TOUCH_THE_COSMOS.id)) {
+      this.totalAPSaved +=
+        (STARFALL_BASE_COST -
+          (this.elunedGuidanceDiscountActive ? STARFALL_ELUNES_GUIDANCE_DISCOUNT : 0)) *
+        PERCENT_AP_SAVED_PER_STACK;
+    }
     this.buffedStarfalls[this.lastStacks] = this.buffedStarfalls[this.lastStacks] + 1;
   }
 

--- a/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
@@ -126,7 +126,6 @@ class RattleTheStars extends Analyzer {
 
   handleDamage(event: DamageEvent) {
     const buffStacks = this.selectedCombatant.getBuffStacks(SPELLS.RATTLED_STARS.id);
-    console.log(buffStacks);
     this.totalAddedDamage += calculateEffectiveDamage(
       event,
       buffStacks * PERCENT_DAMAGE_INCREASE_PER_STACK,
@@ -134,12 +133,15 @@ class RattleTheStars extends Analyzer {
   }
 
   statistic() {
-    console.log(this.totalAddedDamage);
+    const dpsIncrease = this.totalAddedDamage / (this.owner.fightDuration / 1000);
     return (
       <Statistic
         position={STATISTIC_ORDER.CORE(7)}
         wide
         size="flexible"
+        tooltip={`This approximate DPS increase of ${formatNumber(
+          dpsIncrease,
+        )} on considers the damage increase from the talent, not increased Starsurge or Starfall usages from astral power that was saved`}
         dropdown={
           <>
             <table className="table table-condensed">
@@ -174,9 +176,7 @@ class RattleTheStars extends Analyzer {
           <>
             <HasteIcon /> {formatNumber(this.totalAPSaved)} <small>Astral Power Saved</small>
             <br />
-            <HasteIcon /> {formatNumber(
-              this.totalAddedDamage / (this.owner.fightDuration / 1000),
-            )}{' '}
+            <HasteIcon /> {formatNumber(dpsIncrease)}
             <small> approx. DPS added</small>
           </>
         </BoringSpellValueText>

--- a/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
@@ -178,6 +178,7 @@ class RattleTheStars extends Analyzer {
           <>
             {formatNumber(this.totalAPSaved)} <small>Astral Power Saved</small>
             <br />
+            {'>'}
             {formatNumber(dpsIncrease)} <small>approx. DPS added</small>
           </>
         </BoringSpellValueText>

--- a/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
@@ -1,6 +1,5 @@
 import { formatDuration, formatNumber, formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
-import HasteIcon from 'interface/icons/Haste';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, {
   EventType,

--- a/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/RattleTheStars.tsx
@@ -36,7 +36,7 @@ class RattleTheStars extends Analyzer {
   totalAPSaved = 0;
   lastUpdate = this.owner.fight.start_time;
   totalAddedDamage = 0;
-
+  inTouchOfCosmosProc = false;
   private get elunedGuidanceDiscountActive() {
     return (
       this.selectedCombatant.hasTalent(TALENTS_DRUID.ELUNES_GUIDANCE_TALENT) &&
@@ -108,11 +108,12 @@ class RattleTheStars extends Analyzer {
   }
 
   handleStarsurgeCast(event: CastEvent) {
-    if (this.selectedCombatant.hasBuff(SPELLS.TOUCH_THE_COSMOS.id)) {
+    if (!this.selectedCombatant.hasBuff(SPELLS.TOUCH_THE_COSMOS.id)) {
       this.totalAPSaved +=
         (STARSURGE_BASE_COST -
           (this.elunedGuidanceDiscountActive ? STARSURGE_ELUNES_GUIDANCE_DISCOUNT : 0)) *
-        PERCENT_AP_SAVED_PER_STACK;
+        PERCENT_AP_SAVED_PER_STACK *
+        this.selectedCombatant.getBuffStacks(SPELLS.RATTLED_STARS.id);
     }
     this.buffedStarsurges[this.lastStacks] = this.buffedStarsurges[this.lastStacks] + 1;
   }
@@ -122,7 +123,8 @@ class RattleTheStars extends Analyzer {
       this.totalAPSaved +=
         (STARFALL_BASE_COST -
           (this.elunedGuidanceDiscountActive ? STARFALL_ELUNES_GUIDANCE_DISCOUNT : 0)) *
-        PERCENT_AP_SAVED_PER_STACK;
+        PERCENT_AP_SAVED_PER_STACK *
+        this.selectedCombatant.getBuffStacks(SPELLS.RATTLED_STARS.id);
     }
     this.buffedStarfalls[this.lastStacks] = this.buffedStarfalls[this.lastStacks] + 1;
   }

--- a/src/common/SPELLS/druid.ts
+++ b/src/common/SPELLS/druid.ts
@@ -440,6 +440,12 @@ const spells = spellIndexableList({
     name: 'Ephemeral Incarnation',
     icon: 'spell_progenitor_orb2',
   },
+  //Tier 29 Balance set bonus proc
+  TOUCH_THE_COSMOS: {
+    id: 394414,
+    name: 'Touch the Cosmos',
+    icon: 'ability_bossgorefiend_touchofdoom',
+  },
   RENEWING_BLOOM: {
     // HoT procced by T28 2pc
     id: 364686,

--- a/src/common/SPELLS/druid.ts
+++ b/src/common/SPELLS/druid.ts
@@ -163,6 +163,16 @@ const spells = spellIndexableList({
     name: 'Frenzied Regeneration',
     icon: 'ability_bullrush',
   },
+  RATTLED_STARS: {
+    id: 393955,
+    name: 'Rattled Stars',
+    icon: 'spell_arcane_arcane01',
+  },
+  INCARNATION_CHOSEN_OF_ELUNE: {
+    id: 102560,
+    name: 'Incarnation: Chosen of Elune',
+    icon: 'spell_druid_incarnation',
+  },
   BEAR_FORM: {
     id: 5487,
     name: 'Bear Form',
@@ -789,12 +799,12 @@ const spells = spellIndexableList({
   BALANCE_OF_ALL_THINGS_LUNAR: {
     id: 394050,
     name: 'Balance of All Things',
-    icon: 'ability_druid_earthandsky'
+    icon: 'ability_druid_earthandsky',
   },
   BALANCE_OF_ALL_THINGS_SOLAR: {
     id: 394049,
     name: 'Balance of All Things',
-    icon: 'ability_druid_earthandsky'
+    icon: 'ability_druid_earthandsky',
   },
 
   /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Description
A set of statistics to track the usefulness of Rattle The Stars boomkin talent.

### Motivation
One of the primary buffs that Moonkins need to manage, this lets Boomkin analyze how well they managed it and what they were able to get from it.

### Testing
<img width="615" alt="image" src="https://user-images.githubusercontent.com/13208452/213380987-a78f54bb-f908-4c22-8494-e738ad0e6a20.png">