### PR TITLE
add support for Alacritous Alchemist Stone

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -18,6 +18,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 1, 20), <>Adjust maximum combat potion usages to account for <SpellLink id={SPELLS.ALACRITOUS_ALCHEMIST_STONE} />.</>, ToppleTheNun),
   change(date(2023, 1, 18), 'Add missing 3* weapon enhancements.', ToppleTheNun),
   change(date(2023, 1, 17), 'Add ability to generate PTR talents and add documentation on how to do so.', ToppleTheNun),
   change(date(2023, 1, 17), 'Add 10.0.5 patch information.', ToppleTheNun),

--- a/src/common/SPELLS/dragonflight/crafted/alchemy/index.ts
+++ b/src/common/SPELLS/dragonflight/crafted/alchemy/index.ts
@@ -1,0 +1,18 @@
+/**
+ * NAME: {
+ *   id: number,
+ *   name: string,
+ *   icon: string,
+ * },
+ */
+import { spellIndexableList } from 'common/SPELLS/Spell';
+
+const items = spellIndexableList({
+  ALACRITOUS_ALCHEMIST_STONE: {
+    id: 396047,
+    name: 'Alacritous Alchemist Stone',
+    icon: 'inv_10_alchemy_alchemystone_color1',
+  },
+});
+
+export default items;

--- a/src/common/SPELLS/dragonflight/crafted/index.ts
+++ b/src/common/SPELLS/dragonflight/crafted/index.ts
@@ -1,7 +1,8 @@
 import safeMerge from 'common/safeMerge';
 
+import Alchemy from './alchemy';
 import Leatherworking from './leatherworking';
 
-const spells = safeMerge(Leatherworking);
+const spells = safeMerge(Alchemy, Leatherworking);
 
 export default spells;

--- a/src/interface/guide/components/Preparation/ConsumablesSubSection/PotionPanel/index.tsx
+++ b/src/interface/guide/components/Preparation/ConsumablesSubSection/PotionPanel/index.tsx
@@ -18,7 +18,7 @@ const PotionPanel = () => {
   const strongPotionId = potionChecker.strongPotionId;
 
   const performance =
-    potionsUsed === maxPotions && weakPotionsUsed === 0
+    potionsUsed >= maxPotions && weakPotionsUsed === 0
       ? QualitativePerformance.Good
       : QualitativePerformance.Fail;
 
@@ -33,7 +33,10 @@ const PotionPanel = () => {
         </div>
       </PanelHeader>
       {performance === QualitativePerformance.Good && (
-        <p>You used the appropriate amount of potions during this fight! Good work!</p>
+        <p>
+          You used the appropriate amount of potions ({potionsUsed}/{maxPotions}) during this fight!
+          Good work!
+        </p>
       )}
       {performance === QualitativePerformance.Fail && (
         <p>

--- a/src/parser/retail/modules/items/PotionChecker.tsx
+++ b/src/parser/retail/modules/items/PotionChecker.tsx
@@ -1,6 +1,7 @@
 import { Trans } from '@lingui/macro';
 import ITEMS from 'common/ITEMS/dragonflight/potions';
 import SPELLS from 'common/SPELLS/dragonflight/potions';
+import ALCHEMY from 'common/SPELLS/dragonflight/crafted/alchemy';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import SPECS from 'game/SPECS';
 import { ItemLink } from 'interface';
@@ -9,7 +10,7 @@ import Events, { ApplyBuffEvent, CastEvent, FilterCooldownInfoEvent } from 'pars
 import SUGGESTION_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 
-const debug = false;
+const debug = true;
 
 // these suggestions are all based on Icy Veins guide recommendations, i.e. which potion to use in which situation.
 // most guides recommend to use Battle Potion of Primary Stat, but I have broken out the class/spec combos whose guides
@@ -107,8 +108,10 @@ export const COMBAT_POTIONS: number[] = [
 ];
 
 const COMMON_MANA_POTION_AMOUNT = 11084;
+const ALACRITOUS_ALCHEMIST_STONE_CDR_MS = 10000;
 
 class PotionChecker extends Analyzer {
+  alacritousAlchemistStoneProcs = 0;
   potionsUsed = 0;
   weakPotionsUsed = 0;
   strongPotionsUsed = 0;
@@ -146,6 +149,9 @@ class PotionChecker extends Analyzer {
       this.potionsUsed += 1;
       this.strongPotionsUsed += 1;
     }
+    if (spellId === ALCHEMY.ALACRITOUS_ALCHEMIST_STONE.id) {
+      this.alacritousAlchemistStoneProcs += 1;
+    }
   }
 
   _cast(event: CastEvent | FilterCooldownInfoEvent) {
@@ -182,14 +188,27 @@ class PotionChecker extends Analyzer {
 
   _fightend() {
     if (debug) {
+      console.log(`Alacritous Alchemist Stone Procs: ${this.alacritousAlchemistStoneProcs}`);
+      console.log(
+        `Alacritous Alchemist Stone CDR: ${
+          this.alacritousAlchemistStoneProcs * ALACRITOUS_ALCHEMIST_STONE_CDR_MS
+        }`,
+      );
       console.log(`Potions Used: ${this.potionsUsed}`);
       console.log(`Max Potions: ${this.maxPotions}`);
     }
   }
 
   get maxPotions() {
-    //Adjusted the fight Duration by 25 seconds so that if you couldnt have gotten the full use of a second potion then it wont count it against you if you dont use it
-    return 1 + Math.floor((this.owner.fightDuration - 25000) / 300000);
+    const alacritiousCooldownReduction =
+      this.alacritousAlchemistStoneProcs * ALACRITOUS_ALCHEMIST_STONE_CDR_MS;
+    // Adjusted the fight Duration by 25 seconds so that if you couldnt have gotten the full use of
+    // a second potion then it wont count it against you if you dont use it
+    // Also adjusted the fight duration by the amount of CDR that Alacritious Alchemist Stone
+    // provided to account for additional potion usages
+    return (
+      1 + Math.floor((this.owner.fightDuration + alacritiousCooldownReduction - 25000) / 300000)
+    );
   }
 
   get potionsUsedThresholds() {

--- a/src/parser/retail/modules/items/PotionChecker.tsx
+++ b/src/parser/retail/modules/items/PotionChecker.tsx
@@ -10,7 +10,7 @@ import Events, { ApplyBuffEvent, CastEvent, FilterCooldownInfoEvent } from 'pars
 import SUGGESTION_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 
-const debug = true;
+const debug = false;
 
 // these suggestions are all based on Icy Veins guide recommendations, i.e. which potion to use in which situation.
 // most guides recommend to use Battle Potion of Primary Stat, but I have broken out the class/spec combos whose guides


### PR DESCRIPTION
### Description

Alacritous Alchemist Stone reduces the CD of combat potions by 10s whenever it procs. Adjust the "total combat time" used for calculating max potion usage by the amount of CDR gained to compensate and return the correct amount of usages.

### Motivation

![image](https://user-images.githubusercontent.com/1672786/213773634-093195dc-6e8f-4c60-a8ea-b5099870d601.png)

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/6arMjbd1qNp4mPhJ/9-Heroic+Broodkeeper+Diurna+-+Kill+(8:47)/Azlann/standard/overview`
- Screenshot(s):
![image](https://user-images.githubusercontent.com/1672786/213773923-87f71452-7a9a-4b61-9d0f-b203e3960994.png)
