### PR TITLE
[Hunter] Update Barbed Shot and Kill Command

### DIFF
--- a/src/analysis/retail/druid/restoration/CONFIG.tsx
+++ b/src/analysis/retail/druid/restoration/CONFIG.tsx
@@ -28,7 +28,9 @@ export default {
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
   exampleReport: '/report/CpDZB9q7tvFdXPMj/14-Heroic+Terros+-+Kill+(4:21)/69-Taurawolo/standard',
-  guideDefault: true,
+  //Only show the guide since restoration druid no longer has a supported checklist
+  //This will also default to the guide
+  guideOnly: true,
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/hunter/beastmastery/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/beastmastery/CHANGELOG.tsx
@@ -1,7 +1,12 @@
 import { change, date } from 'common/changelog';
 import { Putro, Arlie, ToppleTheNun } from 'CONTRIBUTORS';
-
+import { SpellLink } from 'interface';
+import TALENTS from 'common/TALENTS/hunter';
+import SPELLS from 'common/SPELLS';
 export default [
+  change(date(2023, 1, 20), <>Added handling for a large amount of hidden resets on <SpellLink id={TALENTS.KILL_COMMAND_SHARED_TALENT} /> and <SpellLink id={TALENTS.BARBED_SHOT_TALENT} /> to improve cast efficiency metrics.</>, Putro),
+  change(date(2023, 1, 20), <>Separated <SpellLink id={SPELLS.DIRE_BEAST_BUFF}/> uptime attribution into <SpellLink id={TALENTS.DIRE_BEAST_TALENT} /> and <SpellLink id={TALENTS.DIRE_PACK_TALENT} />.</>, Putro),
+  change(date(2023, 1, 20), <>Updated <SpellLink id={TALENTS.DIRE_BEAST_TALENT}/> base cooldown.</>, Putro),
   change(date(2022, 12, 16), 'Re-enable log parser.', ToppleTheNun),
   change(date(2022, 11, 11), 'Initial transition of Beast Mastery to Dragonflight', [Arlie, Putro]),
 ];

--- a/src/analysis/retail/hunter/beastmastery/CombatLogParser.ts
+++ b/src/analysis/retail/hunter/beastmastery/CombatLogParser.ts
@@ -45,6 +45,7 @@ import Stampede from './modules/talents/Stampede';
 import Stomp from './modules/talents/Stomp';
 import ThrillOfTheHunt from './modules/talents/ThrillOfTheHunt';
 import MasterMarksman from '../shared/talents/MasterMarksman';
+import DireCommandNormalizer from './normalizers/DireCommandNormalizer';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -69,6 +70,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     //Normalizers
     wailingArrowPrepullNormalizer: WailingArrowPrepullNormalizer,
+    direCommandNormalizer: DireCommandNormalizer,
 
     //DeathTracker
     deathTracker: DeathTracker,

--- a/src/analysis/retail/hunter/beastmastery/constants.ts
+++ b/src/analysis/retail/hunter/beastmastery/constants.ts
@@ -33,6 +33,11 @@ export const BLOODSHED_DAMAGE_AMP = 0.15;
 /** Dire Beast */
 //Dire Beast increases haste by 5% while active
 export const DIRE_BEAST_HASTE_PERCENT = 0.05;
+//Dire Beast lasts for 8 seconds baseline
+export const DIRE_BEAST_BASE_DURATION = 8000;
+/** Dire Frenzy */
+//Dire Frenzy increases the duration of Dire Beast by 1 second per rank (up to 2 seconds)
+export const DIRE_FRENZY_INCREASE_DB_TIME = [0, 1000, 2000];
 /** Aspect of the Beast */
 //Aspect of the Beast increase pet damage and healing done by 30%
 export const AOTB_MULTIPLIER = 0.3;
@@ -127,8 +132,8 @@ export const LIST_OF_FOCUS_SPENDERS_BM = [
 
 //region Legendaries
 /** Dire Command */
-//Dire Command has a 30% chance to summon a dire beast
-export const DIRE_COMMAND_PROC_CHANCE = 0.3;
+//Dire Command has a 10% chance to summon a dire beast per rank
+export const DIRE_COMMAND_PROC_CHANCE = [0, 0.1, 0.2, 0.3];
 /** Flamewaker's Cobra Sting */
 //Flamewaker's Cobra Sting has a 50% chance to reduce focus cost of next Kill Command by 100%
 export const FLAMEWAKERS_PROC_CHANCE = 0.5;

--- a/src/analysis/retail/hunter/beastmastery/modules/Abilities.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/Abilities.tsx
@@ -99,7 +99,7 @@ class Abilities extends CoreAbilities {
         spell: TALENTS.DIRE_BEAST_TALENT.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         enabled: combatant.hasTalent(TALENTS.DIRE_BEAST_TALENT),
-        cooldown: 15,
+        cooldown: 20,
         gcd: {
           base: 1500,
         },

--- a/src/analysis/retail/hunter/beastmastery/modules/core/SpellUsable.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/core/SpellUsable.tsx
@@ -58,22 +58,12 @@ class SpellUsable extends CoreSpellUsable {
     const spellId = triggerEvent.ability.guid;
     if (spellId === TALENTS.BARBED_SHOT_TALENT.id) {
       if (this.isOnCooldown(spellId) && this.chargesAvailable(spellId) === 0) {
-        this.endCooldown(
-          spellId,
-          this.lastPotentialTriggerForBarbedShotReset
-            ? this.lastPotentialTriggerForBarbedShotReset.timestamp
-            : undefined,
-        );
+        this.endCooldown(spellId, this.lastPotentialTriggerForBarbedShotReset?.timestamp);
       }
     }
     if (spellId === TALENTS.KILL_COMMAND_SHARED_TALENT.id && this._has4pc) {
       if (this.isOnCooldown(spellId) && this.chargesAvailable(spellId) === 0) {
-        this.endCooldown(
-          spellId,
-          this.lastPotentialTriggerForKillCommandReset
-            ? this.lastPotentialTriggerForKillCommandReset.timestamp
-            : undefined,
-        );
+        this.endCooldown(spellId, this.lastPotentialTriggerForKillCommandReset?.timestamp);
       }
     }
 

--- a/src/analysis/retail/hunter/beastmastery/modules/core/SpellUsable.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/core/SpellUsable.tsx
@@ -20,7 +20,7 @@ class SpellUsable extends CoreSpellUsable {
 
   lastPotentialTriggerForBarbedShotReset: AnyEvent | null = null;
   lastPotentialTriggerForKillCommandReset: AnyEvent | null = null;
-  _has4pc: boolean = false;
+  private _has4pc: boolean = false;
 
   constructor(options: Options) {
     super(options);

--- a/src/analysis/retail/hunter/beastmastery/modules/core/SpellUsable.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/core/SpellUsable.tsx
@@ -1,6 +1,16 @@
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/hunter';
-import { AbilityEvent, CastEvent } from 'parser/core/Events';
+import HIT_TYPES from 'game/HIT_TYPES';
+import { TIERS } from 'game/TIERS';
+import { Options } from 'parser/core/Analyzer';
+import { SELECTED_PLAYER } from 'parser/core/EventFilter';
+import Events, {
+  AbilityEvent,
+  AnyEvent,
+  CastEvent,
+  DamageEvent,
+  EventType,
+} from 'parser/core/Events';
 import CoreSpellUsable from 'parser/shared/modules/SpellUsable';
 
 class SpellUsable extends CoreSpellUsable {
@@ -8,24 +18,46 @@ class SpellUsable extends CoreSpellUsable {
     ...CoreSpellUsable.dependencies,
   };
 
-  lastPotentialTriggerForBarbedShotReset: CastEvent | null = null;
+  lastPotentialTriggerForBarbedShotReset: AnyEvent | null = null;
+  lastPotentialTriggerForKillCommandReset: AnyEvent | null = null;
+  _has4pc: boolean = false;
 
-  onCast(event: CastEvent) {
-    super.onCast(event);
+  constructor(options: Options) {
+    super(options);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.AUTO_SHOT), this.onDamage);
+    this._has4pc = this.selectedCombatant.has4PieceByTier(TIERS.T29);
+  }
+
+  onDamage(event: DamageEvent) {
     const spellId = event.ability.guid;
-    if (spellId === SPELLS.AUTO_SHOT.id) {
+    if (spellId === SPELLS.AUTO_SHOT.id && event.hitType === HIT_TYPES.CRIT) {
       this.lastPotentialTriggerForBarbedShotReset = event;
-    } else if (spellId === TALENTS.BARBED_SHOT_TALENT.id) {
-      this.lastPotentialTriggerForBarbedShotReset = null;
+    }
+    if (spellId === TALENTS.KILL_COMMAND_SHARED_TALENT.id && this._has4pc) {
+      this.lastPotentialTriggerForBarbedShotReset = event;
     }
   }
 
-  beginCooldown(triggerEvent: AbilityEvent<any>, spellId: number) {
+  onCast(event: CastEvent) {
+    const spellId = event.ability.guid;
     if (spellId === TALENTS.BARBED_SHOT_TALENT.id) {
-      if (
-        this.isOnCooldown(spellId) &&
-        this.chargesAvailable(TALENTS.BARBED_SHOT_TALENT.id) === 0
-      ) {
+      this.lastPotentialTriggerForBarbedShotReset = null;
+      if (this.selectedCombatant.hasTalent(TALENTS.WAR_ORDERS_TALENT)) {
+        this.lastPotentialTriggerForKillCommandReset = event;
+      }
+    }
+    super.onCast(event);
+  }
+
+  beginCooldown(triggerEvent: AbilityEvent<any>, _spellId: number) {
+    if (triggerEvent.type === EventType.FreeCast) {
+      //Ignore FreeCast events as they are events that have been modified or fabricated
+      //They indicate that a different spell caused it to cast
+      return;
+    }
+    const spellId = triggerEvent.ability.guid;
+    if (spellId === TALENTS.BARBED_SHOT_TALENT.id) {
+      if (this.isOnCooldown(spellId) && this.chargesAvailable(spellId) === 0) {
         this.endCooldown(
           spellId,
           this.lastPotentialTriggerForBarbedShotReset
@@ -34,6 +66,17 @@ class SpellUsable extends CoreSpellUsable {
         );
       }
     }
+    if (spellId === TALENTS.KILL_COMMAND_SHARED_TALENT.id && this._has4pc) {
+      if (this.isOnCooldown(spellId) && this.chargesAvailable(spellId) === 0) {
+        this.endCooldown(
+          spellId,
+          this.lastPotentialTriggerForKillCommandReset
+            ? this.lastPotentialTriggerForKillCommandReset.timestamp
+            : undefined,
+        );
+      }
+    }
+
     super.beginCooldown(triggerEvent, spellId);
   }
 }

--- a/src/analysis/retail/hunter/beastmastery/modules/talents/DireBeast.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/talents/DireBeast.tsx
@@ -1,45 +1,79 @@
+import { MS_BUFFER_100 } from 'analysis/retail/hunter/shared';
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/hunter';
 import Haste from 'interface/icons/Haste';
 import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
-import Events, { DamageEvent, SummonEvent } from 'parser/core/Events';
+import Events, {
+  ApplyBuffEvent,
+  CastEvent,
+  DamageEvent,
+  FightEndEvent,
+  RefreshBuffEvent,
+  RemoveBuffEvent,
+  SummonEvent,
+} from 'parser/core/Events';
 import { encodeEventSourceString, encodeEventTargetString } from 'parser/shared/modules/Enemies';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
-import { DIRE_BEAST_HASTE_PERCENT } from '../../constants';
+import {
+  DIRE_BEAST_BASE_DURATION,
+  DIRE_BEAST_HASTE_PERCENT,
+  DIRE_FRENZY_INCREASE_DB_TIME,
+} from '../../constants';
 
 /**
  * Summons a powerful wild beast that attacks the target and roars, increasing your Haste by 5% for 8 sec.
  *
  * Example log:
- * https://www.warcraftlogs.com/reports/TY846VxkCwAfPLbG#fight=46&type=damage-done&source=411
- *
- * TODO: Ensure it doesn't conflict with Dire Command legendary.
+ * https://www.warcraftlogs.com/reports/NBMbz2Dcq43k17tJ#fight=90&type=damage-done&source=11
  */
 
 class DireBeast extends Analyzer {
   damage = 0;
   activeDireBeasts: string[] = [];
-  targetId: string | null = null;
+  lastKillCommandCast: number = 0;
+  isDireBeastSummon: boolean = false;
+  buffApplicationTimestamp: number = 0; // Timestamp of the last Dire Beast buff application
+  direBeastUptime: number = 0;
+  direbeastDuration = DIRE_BEAST_BASE_DURATION;
 
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS.DIRE_BEAST_TALENT);
+    this.direbeastDuration +=
+      DIRE_FRENZY_INCREASE_DB_TIME[
+        this.selectedCombatant.getTalentRank(TALENTS.DIRE_FRENZY_TALENT)
+      ];
     this.addEventListener(Events.damage.by(SELECTED_PLAYER_PET), this.onPetDamage);
     this.addEventListener(
       Events.summon.by(SELECTED_PLAYER).spell(SPELLS.DIRE_BEAST_SUMMON),
       this.onDireSummon,
     );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.KILL_COMMAND_SHARED_TALENT),
+      this.killCommandCast,
+    );
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.DIRE_BEAST_BUFF),
+      this.applyDireBeast,
+    );
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.DIRE_BEAST_BUFF),
+      this.refreshDireBeast,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.DIRE_BEAST_BUFF),
+      this.removeDireBeast,
+    );
+    this.addEventListener(Events.fightend, this.onFightEnd);
   }
 
   get uptime() {
-    return (
-      this.selectedCombatant.getBuffUptime(SPELLS.DIRE_BEAST_BUFF.id) / this.owner.fightDuration
-    );
+    return this.direBeastUptime / this.owner.fightDuration;
   }
 
   onPetDamage(event: DamageEvent) {
@@ -53,13 +87,55 @@ class DireBeast extends Analyzer {
   }
 
   onDireSummon(event: SummonEvent) {
-    this.targetId = encodeEventTargetString(event);
-    if (!this.targetId) {
+    if (
+      event.timestamp - this.lastKillCommandCast < MS_BUFFER_100 &&
+      this.selectedCombatant.hasTalent(TALENTS.DIRE_COMMAND_TALENT)
+    ) {
+      //Then the summon is caused by a Dire Command proc
+      this.isDireBeastSummon = false;
       return;
     }
-    this.activeDireBeasts = [];
-    this.activeDireBeasts.push(this.targetId);
-    this.targetId = null;
+    const targetId = encodeEventTargetString(event);
+    if (!targetId) {
+      return;
+    }
+    this.activeDireBeasts.push(targetId);
+    this.isDireBeastSummon = true;
+  }
+
+  killCommandCast(event: CastEvent) {
+    this.lastKillCommandCast = event.timestamp;
+  }
+
+  applyDireBeast(event: ApplyBuffEvent) {
+    if (this.isDireBeastSummon) {
+      this.buffApplicationTimestamp = event.timestamp;
+    } else {
+      this.buffApplicationTimestamp = 0;
+    }
+  }
+
+  refreshDireBeast(event: RefreshBuffEvent) {
+    if (this.buffApplicationTimestamp > event.timestamp - this.direbeastDuration) {
+      this.direBeastUptime += event.timestamp - this.buffApplicationTimestamp;
+    }
+    if (this.isDireBeastSummon) {
+      this.buffApplicationTimestamp = event.timestamp;
+    } else {
+      this.buffApplicationTimestamp = 0;
+    }
+  }
+
+  removeDireBeast(event: RemoveBuffEvent) {
+    if (this.isDireBeastSummon) {
+      this.direBeastUptime += event.timestamp - this.buffApplicationTimestamp;
+    }
+  }
+
+  onFightEnd(event: FightEndEvent) {
+    if (this.buffApplicationTimestamp > event.timestamp - this.direbeastDuration) {
+      this.direBeastUptime += event.timestamp - this.buffApplicationTimestamp;
+    }
   }
 
   statistic() {
@@ -68,7 +144,12 @@ class DireBeast extends Analyzer {
         position={STATISTIC_ORDER.OPTIONAL(13)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
-        tooltip={<>You had {formatPercentage(this.uptime)}% uptime on the Dire Beast Haste buff.</>}
+        tooltip={
+          <>
+            You had {formatPercentage(this.uptime)}% uptime on the Dire Beast haste buff that could
+            be attributed to this talent.
+          </>
+        }
       >
         <BoringSpellValueText spellId={TALENTS.DIRE_BEAST_TALENT.id}>
           <>

--- a/src/analysis/retail/hunter/beastmastery/modules/talents/DireCommand.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/talents/DireCommand.tsx
@@ -1,15 +1,26 @@
 import {
+  DIRE_BEAST_BASE_DURATION,
   DIRE_BEAST_HASTE_PERCENT,
   DIRE_COMMAND_PROC_CHANCE,
+  DIRE_FRENZY_INCREASE_DB_TIME,
 } from 'analysis/retail/hunter/beastmastery/constants';
+import { MS_BUFFER_100 } from 'analysis/retail/hunter/shared';
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/hunter';
 import { SpellLink } from 'interface';
 import Haste from 'interface/icons/Haste';
 import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
-import Events, { DamageEvent, SummonEvent } from 'parser/core/Events';
-import { encodeEventSourceString, encodeTargetString } from 'parser/shared/modules/Enemies';
+import Events, {
+  ApplyBuffEvent,
+  CastEvent,
+  DamageEvent,
+  FightEndEvent,
+  RefreshBuffEvent,
+  RemoveBuffEvent,
+  SummonEvent,
+} from 'parser/core/Events';
+import { encodeEventSourceString, encodeEventTargetString } from 'parser/shared/modules/Enemies';
 import { plotOneVariableBinomChart } from 'parser/shared/modules/helpers/Probability';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
@@ -18,18 +29,22 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
 /**
- * TODO Find a log with both Dire Command and Dire Beast talent and account for them using the same spell for buff
- * Kill Command has a 20% chance to also summon a Dire Beast to attack your target.
+ * Kill Command has a 10% (per rank) chance to also summon a Dire Beast to attack your target.
  *
  * Example log:
- *
+ * https://www.warcraftlogs.com/reports/NBMbz2Dcq43k17tJ#fight=90&type=damage-done&source=11
  */
 class DireCommand extends Analyzer {
   damage: number = 0;
   activeDireBeasts: string[] = [];
-  targetId: string = '';
   direCommandProcs: number = 0;
-  killCommandHits: number = 0;
+  killCommandCasts: number = 0;
+  lastKillCommandCast: number = 0;
+  resetChance: number = 0;
+  isDireCommandSummon: boolean = false;
+  buffApplicationTimestamp: number = 0;
+  direbeastDuration = DIRE_BEAST_BASE_DURATION;
+  direBeastUptime: number = 0;
 
   constructor(options: Options) {
     super(options);
@@ -37,29 +52,51 @@ class DireCommand extends Analyzer {
     if (!this.active) {
       return;
     }
+    this.resetChance =
+      DIRE_COMMAND_PROC_CHANCE[this.selectedCombatant.getTalentRank(TALENTS.DIRE_COMMAND_TALENT)];
+    this.direbeastDuration +=
+      DIRE_FRENZY_INCREASE_DB_TIME[
+        this.selectedCombatant.getTalentRank(TALENTS.DIRE_FRENZY_TALENT)
+      ];
     this.addEventListener(
       Events.summon.by(SELECTED_PLAYER).spell(SPELLS.DIRE_BEAST_SUMMON),
       this.direBeastSummon,
     );
     this.addEventListener(
-      Events.damage.by(SELECTED_PLAYER_PET).spell(TALENTS.KILL_COMMAND_SHARED_TALENT),
-      this.killCommandDamage,
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.KILL_COMMAND_SHARED_TALENT),
+      this.killCommandCast,
     );
     this.addEventListener(Events.damage.by(SELECTED_PLAYER_PET), this.onPetDamage);
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.DIRE_BEAST_BUFF),
+      this.applyDireBeast,
+    );
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.DIRE_BEAST_BUFF),
+      this.refreshDireBeast,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.DIRE_BEAST_BUFF),
+      this.removeDireBeast,
+    );
+    this.addEventListener(Events.fightend, this.onFightEnd);
   }
 
   get uptime() {
-    return (
-      this.selectedCombatant.getBuffUptime(SPELLS.DIRE_BEAST_BUFF.id) / this.owner.fightDuration
-    );
+    return this.direBeastUptime / this.owner.fightDuration;
   }
 
   direBeastSummon(event: SummonEvent) {
-    this.direCommandProcs += 1;
-    this.targetId = encodeTargetString(event.targetID);
-    this.activeDireBeasts = [];
-    this.activeDireBeasts.push(this.targetId);
-    this.targetId = '';
+    if (this.lastKillCommandCast + MS_BUFFER_100 > event.timestamp) {
+      this.isDireCommandSummon = true;
+      this.direCommandProcs += 1;
+      const targetId = encodeEventTargetString(event);
+      if (targetId) {
+        this.activeDireBeasts.push(targetId);
+      }
+    } else {
+      this.isDireCommandSummon = false;
+    }
   }
 
   onPetDamage(event: DamageEvent) {
@@ -72,8 +109,40 @@ class DireCommand extends Analyzer {
     }
   }
 
-  killCommandDamage(event: DamageEvent) {
-    this.killCommandHits += 1;
+  killCommandCast(event: CastEvent) {
+    this.killCommandCasts += 1;
+    this.lastKillCommandCast = event.timestamp;
+  }
+
+  applyDireBeast(event: ApplyBuffEvent) {
+    if (this.isDireCommandSummon) {
+      this.buffApplicationTimestamp = event.timestamp;
+    } else {
+      this.buffApplicationTimestamp = 0;
+    }
+  }
+
+  refreshDireBeast(event: RefreshBuffEvent) {
+    if (this.buffApplicationTimestamp > event.timestamp - this.direbeastDuration) {
+      this.direBeastUptime += event.timestamp - this.buffApplicationTimestamp;
+    }
+    if (this.isDireCommandSummon) {
+      this.buffApplicationTimestamp = event.timestamp;
+    } else {
+      this.buffApplicationTimestamp = 0;
+    }
+  }
+
+  removeDireBeast(event: RemoveBuffEvent) {
+    if (this.isDireCommandSummon) {
+      this.direBeastUptime += event.timestamp - this.buffApplicationTimestamp;
+    }
+  }
+
+  onFightEnd(event: FightEndEvent) {
+    if (this.buffApplicationTimestamp > event.timestamp - this.direbeastDuration) {
+      this.direBeastUptime += event.timestamp - this.buffApplicationTimestamp;
+    }
   }
 
   statistic() {
@@ -81,15 +150,20 @@ class DireCommand extends Analyzer {
       <Statistic
         position={STATISTIC_ORDER.CORE()}
         size="flexible"
-        category={STATISTIC_CATEGORY.ITEMS}
-        tooltip={<>You had {formatPercentage(this.uptime)}% uptime on the Dire Beast Haste buff.</>}
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            You had {formatPercentage(this.uptime)}% uptime on the Dire Beast haste buff that could
+            be attributed to this talent.
+          </>
+        }
         dropdown={
           <>
             <div style={{ padding: '8px' }}>
               {plotOneVariableBinomChart(
                 this.direCommandProcs,
-                this.killCommandHits,
-                DIRE_COMMAND_PROC_CHANCE,
+                this.killCommandCasts,
+                this.resetChance,
               )}
               <p>
                 Likelihood of getting <em>exactly</em> as many procs as estimated on a fight given

--- a/src/analysis/retail/hunter/beastmastery/modules/talents/DirePack.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/talents/DirePack.tsx
@@ -1,0 +1,45 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import TALENTS from 'common/TALENTS/hunter';
+import Events, { ApplyBuffEvent, RemoveBuffEvent } from 'parser/core/Events';
+import SPELLS from 'common/SPELLS';
+import SpellUsable from '../core/SpellUsable';
+
+/**
+ * Every 5 Dire Beasts summoned resets the cooldown of Kill Command,
+ * and reduces the Focus cost and cooldown of Kill Command by 50% for 8 sec.
+ */
+class DirePack extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+  };
+
+  protected spellUsable!: SpellUsable;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.DIRE_PACK_TALENT);
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.DIRE_PACK_BUFF),
+      this.onApplyBuff,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.DIRE_PACK_BUFF),
+      this.onRemoveBuff,
+    );
+  }
+
+  onApplyBuff(event: ApplyBuffEvent) {
+    this.spellUsable.applyCooldownRateChange(TALENTS.KILL_COMMAND_SHARED_TALENT.id, 0.5);
+    if (!this.spellUsable.isOnCooldown(TALENTS.KILL_COMMAND_SHARED_TALENT.id)) {
+      return;
+    }
+    this.spellUsable.endCooldown(TALENTS.KILL_COMMAND_SHARED_TALENT.id);
+  }
+
+  onRemoveBuff(event: RemoveBuffEvent) {
+    this.spellUsable.removeCooldownRateChange(TALENTS.KILL_COMMAND_SHARED_TALENT.id, 0.5);
+  }
+}
+
+export default DirePack;

--- a/src/analysis/retail/hunter/beastmastery/modules/talents/ScentOfBlood.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/talents/ScentOfBlood.tsx
@@ -1,6 +1,6 @@
 import TALENTS from 'common/TALENTS/hunter';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events from 'parser/core/Events';
+import Events, { ApplyBuffEvent, RefreshBuffEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -34,10 +34,19 @@ class ScentOfBlood extends Analyzer {
       Events.applybuff.by(SELECTED_PLAYER).spell(TALENTS.BESTIAL_WRATH_TALENT),
       this.bestialWrathApplication,
     );
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(TALENTS.BESTIAL_WRATH_TALENT),
+      this.bestialWrathApplication,
+    );
   }
 
-  bestialWrathApplication() {
+  bestialWrathApplication(event: ApplyBuffEvent | RefreshBuffEvent) {
     const chargesAvailable = this.spellUsable.chargesAvailable(TALENTS.BARBED_SHOT_TALENT.id);
+    if (this.shotRecharges === 2) {
+      this.spellUsable.endCooldown(TALENTS.BARBED_SHOT_TALENT.id, event.timestamp, false, true);
+    } else {
+      this.spellUsable.endCooldown(TALENTS.BARBED_SHOT_TALENT.id);
+    }
     this.chargesGained += this.shotRecharges - chargesAvailable;
     this.chargesWasted += chargesAvailable;
   }

--- a/src/analysis/retail/hunter/beastmastery/normalizers/DireCommandNormalizer.ts
+++ b/src/analysis/retail/hunter/beastmastery/normalizers/DireCommandNormalizer.ts
@@ -1,0 +1,71 @@
+import SPELLS from 'common/SPELLS';
+import { TALENTS_HUNTER } from 'common/TALENTS';
+import { AnyEvent, EventType } from 'parser/core/Events';
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+
+class DireCommandNormalizer extends EventsNormalizer {
+  normalize(events: AnyEvent[]) {
+    const fixedEvents: AnyEvent[] = [];
+    const killCommandCastId = TALENTS_HUNTER.KILL_COMMAND_SHARED_TALENT.id;
+    const direBeastCastId = TALENTS_HUNTER.DIRE_BEAST_TALENT.id;
+    const direBeastSummonCastId = SPELLS.DIRE_BEAST_SUMMON.id;
+    const relevantIds = [killCommandCastId, direBeastCastId];
+    const bufferMs = 50;
+
+    events.forEach((event: AnyEvent, idx: number) => {
+      //We are only interested in Kill Command and Dire Beast casts
+      fixedEvents.push(event);
+      if (event.type !== EventType.Cast) {
+        return;
+      }
+      const spellId = event.ability.guid;
+      if (!relevantIds.includes(spellId)) {
+        return;
+      }
+      //If it's a Dire Beast cast we need to look forward for a Kill Command cast to identify if it's a Dire Command proc
+      //If it is we have to change it's type to FreeCast
+      if (spellId === direBeastCastId) {
+        for (let forwardIndex = idx; forwardIndex < events.length; forwardIndex += 1) {
+          const forwardEvent = events[forwardIndex];
+          if (forwardEvent.type !== EventType.Cast) {
+            continue;
+          }
+          if (forwardEvent.ability.guid !== killCommandCastId) {
+            continue;
+          }
+          if (forwardEvent.timestamp - event.timestamp > bufferMs) {
+            break;
+          }
+          fixedEvents.splice(idx, 1);
+          fixedEvents.push({
+            ...event,
+            type: EventType.FreeCast,
+          });
+          break;
+        }
+      }
+
+      //If it's a Kill Command cast we need to look backward for a Dire Beast cast to identify if it's a Dire Command proc
+      //if it is we have to move it backwards in the event list
+      if (spellId === killCommandCastId) {
+        for (let backwardsIndex = idx; backwardsIndex >= 0; backwardsIndex -= 1) {
+          const backwardsEvent = events[backwardsIndex];
+          if (backwardsEvent.type !== EventType.Cast) {
+            continue;
+          }
+          if (backwardsEvent.ability.guid !== direBeastSummonCastId) {
+            continue;
+          }
+          if (event.timestamp - backwardsEvent.timestamp > bufferMs) {
+            break;
+          }
+          fixedEvents.splice(idx, 1);
+          fixedEvents.splice(backwardsIndex, 0, event);
+          break;
+        }
+      }
+    });
+    return fixedEvents;
+  }
+}
+export default DireCommandNormalizer;

--- a/src/analysis/retail/hunter/shared/talents/DeathChakrams.tsx
+++ b/src/analysis/retail/hunter/shared/talents/DeathChakrams.tsx
@@ -69,7 +69,7 @@ class DeathChakrams extends Analyzer {
       <Statistic
         position={STATISTIC_ORDER.CORE()}
         size="flexible"
-        category={STATISTIC_CATEGORY.COVENANTS}
+        category={STATISTIC_CATEGORY.TALENTS}
       >
         <BoringSpellValueText spellId={TALENTS.DEATH_CHAKRAM_TALENT.id}>
           <>

--- a/src/analysis/retail/monk/brewmaster/CONFIG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CONFIG.tsx
@@ -57,5 +57,7 @@ export default {
     ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
-  guideDefault: true,
+  //Only show the guide since brewmaster no longer has a supported checklist
+  //This will also default to the guide
+  guideOnly: true,
 };

--- a/src/common/SPELLS/hunter.ts
+++ b/src/common/SPELLS/hunter.ts
@@ -24,8 +24,13 @@ const spells = spellIndexableList({
     icon: 'ability_hunter_longevity',
   },
   DIRE_BEAST_SUMMON: {
-    id: 219199,
+    id: 132764,
     name: 'Dire Beast',
+    icon: 'ability_hunter_sickem',
+  },
+  DIRE_PACK_BUFF: {
+    id: 378747,
+    name: 'Dire Pack',
     icon: 'ability_hunter_sickem',
   },
   STAMPEDE_DAMAGE: {
@@ -424,6 +429,11 @@ const spells = spellIndexableList({
   //endregion
 
   //region Shared
+  KILL_COMMAND_SHARED_DAMAGE: {
+    id: 83381,
+    name: 'Kill Command',
+    icon: 'ability_hunter_killcommand',
+  },
   DEATH_CHAKRAM_DAMAGE: {
     id: 375893,
     icon: 'ability_maldraxxus_hunter',

--- a/src/parser/core/Combatant.ts
+++ b/src/parser/core/Combatant.ts
@@ -121,7 +121,7 @@ class Combatant extends Entity {
     });
   }
 
-  /** Returns true iff this combatant has the specified talent. Will be true for any number of
+  /** Returns true if this combatant has the specified talent. Will be true for any number of
    *  points in the talent, even when not the maximum number of points. */
   hasTalent(talent: Talent): boolean {
     return talent.entryIds.filter((entryId) => this.treeTalentsByEntryId.has(entryId)).length > 0;

--- a/src/parser/core/EventLinkNormalizer.ts
+++ b/src/parser/core/EventLinkNormalizer.ts
@@ -35,15 +35,15 @@ export type EventLink = {
   /** The maximum allowed timestamp difference *backward in time from the linking event to the
    * referenced event* in order for a link to be made. Defaults to 0 ms when omitted. */
   backwardBufferMs?: number;
-  /** Iff true, the two events may be linked even with different sources.
+  /** If true, the two events may be linked even with different sources.
    * In most cases this should be false, and will default to false when omitted */
   anySource?: boolean;
-  /** Iff true, the two events may be linked even with different targets.
+  /** If true, the two events may be linked even with different targets.
    * In most cases this should be false, and will default to false when omitted */
   anyTarget?: boolean;
-  /** Iff defined, links will also be added from the referenced event to the linking event using this relation. */
+  /** If defined, links will also be added from the referenced event to the linking event using this relation. */
   reverseLinkRelation?: string;
-  /** Iff defined, this spec will create at most the given number of links to matching reference events.
+  /** If defined, this spec will create at most the given number of links to matching reference events.
    *  This maximum applies only to this spec (not other specs on the same event), and applies
    *  only *from the linkingEvent* (the same referenceEvent can be pointed to used any number of times).
    *  Scan for referenced events starts forward from the linking event first, then back
@@ -52,9 +52,9 @@ export type EventLink = {
    *  make false positives impossible - only need to use this when situations require it.
    *  By default, any number of links can be made if they meet the parameters */
   maximumLinks?: number | ((c: Combatant) => number);
-  /** Iff defined, this predicate will also be called with the candidate events and iff false no link will be made */
+  /** If defined, this predicate will also be called with the candidate events and iff false no link will be made */
   additionalCondition?: (linkingEvent: AnyEvent, referencedEvent: AnyEvent) => boolean;
-  /** Iff defined, this predicate will be called with the selected combatant to determine if this
+  /** If defined, this predicate will be called with the selected combatant to determine if this
    *  spec should be run. Will be called only once at the start of the normalize function.
    *  Useful if using a list of interdependent specs where some are talent dependent.
    *  Defaults to 'true' when omitted. */

--- a/src/parser/core/EventOrderNormalizer.ts
+++ b/src/parser/core/EventOrderNormalizer.ts
@@ -140,13 +140,13 @@ export type EventOrder = {
    * Should be set to the minimum possible value to avoid false positives.
    * Defaults to 0 ms when omitted. */
   bufferMs?: number;
-  /** Iff true, the two events may be swapped even with different sources.
+  /** If true, the two events may be swapped even with different sources.
    * In most cases this should be false, and will default to false when omitted */
   anySource?: boolean;
-  /** Iff true, the two events may be swapped even with different targets.
+  /** If true, the two events may be swapped even with different targets.
    * In most cases this should be false, and will default to false when omitted */
   anyTarget?: boolean;
-  /** Iff true, and the reordered events have different timestamps,
+  /** If true, and the reordered events have different timestamps,
    * the 'after' event will have its timestamp pushed forward to match the 'before' event.
    * Defaults to 'false' when omitted. */
   updateTimestamp?: boolean;

--- a/src/parser/shared/metrics/apl/ChecklistRule.tsx
+++ b/src/parser/shared/metrics/apl/ChecklistRule.tsx
@@ -179,7 +179,7 @@ export default function ChecklistRule(props: Props) {
                   key={ix}
                   name={
                     <>
-                      <strong>{ix}.</strong> <RuleDescription rule={rule} />
+                      <strong>{ix + 1}.</strong> <RuleDescription rule={rule} />
                     </>
                   }
                   thresholds={thresh}

--- a/src/parser/shared/modules/SpellUsable.ts
+++ b/src/parser/shared/modules/SpellUsable.ts
@@ -265,8 +265,8 @@ class SpellUsable extends Analyzer {
    *     if different from currentTimestamp.
    * @param {boolean} resetCooldown if the cooldown's progress should be reset.
    *     This field is only relevant for spells with more than one charge.
-   *     iff true, a charge will be added and cooldown progress will be set back to zero.
-   *     iff false, a charge will be added and cooldown progress will be retained.
+   *     if true, a charge will be added and cooldown progress will be set back to zero.
+   *     if false, a charge will be added and cooldown progress will be retained.
    *     'Restore charge' effects typically do not reset the cooldown (pass false to this field),
    *     while natural cooldown expiration and effects do (pass true to this field).
    * @param {boolean} restoreAllCharges if all charges should be restored rather than just one.

--- a/src/parser/shared/modules/resources/resourcetracker/ResourceBreakdown.tsx
+++ b/src/parser/shared/modules/resources/resourcetracker/ResourceBreakdown.tsx
@@ -9,7 +9,7 @@ import ResourceTracker from './ResourceTracker';
 interface Props {
   /** Associated tracker module that holds the resource data */
   tracker: ResourceTracker;
-  /** Iff true, there will be a separate section showing resources spent */
+  /** If true, there will be a separate section showing resources spent */
   showSpenders: boolean;
   /** If true, the spenders section will show the number of casts that consumed
    *  the maxResources. (This is primarily for something like Combo Points) */

--- a/src/parser/ui/CooldownBar.tsx
+++ b/src/parser/ui/CooldownBar.tsx
@@ -30,7 +30,7 @@ type Props = {
   spellId: number;
   /** Gap highlight mode - see {@link GapHighlight} */
   gapHighlightMode: GapHighlight;
-  /** Iff true, spell uses will be represented by a minimal white line instead of the spell icon.
+  /** If true, spell uses will be represented by a minimal white line instead of the spell icon.
    *  Useful for spells on CD shorter than 30s where the icons might be too closely packed to
    *  be usable */
   minimizeIcons?: boolean;

--- a/src/parser/ui/UptimeStackBar.tsx
+++ b/src/parser/ui/UptimeStackBar.tsx
@@ -28,7 +28,7 @@ type Props = {
   backgroundHistory?: Uptime[];
   /** Background uptime bar color in format '#rrggbb'. If a background bar is specified, this must be defined */
   backgroundBarColor?: string;
-  /** Iff true, the background bars will have tooltips indicating their time range */
+  /** If true, the background bars will have tooltips indicating their time range */
   timeTooltip?: boolean;
 };
 


### PR DESCRIPTION
### Description

Barbed Shot and Kill Command have a lot of hidden resets and interactions with each other that has a large impact on their cast efficiency. This commit aims to improve that by handling some of them as best as we can by assuming the latest possible reset trigger, is what reset a given spell

### Motivation

Touching up cast efficiency as part of updating to be 10.0 accurate. 
Towards #5561 

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/NBMbz2Dcq43k17tJ/90-Mythic+Eranog+-+Kill+(2:41)/Povish/standard/statistics`
- Screenshot(s):

Before
![image](https://user-images.githubusercontent.com/29204244/213808703-ca080fc7-a21d-474a-b67e-1d6fc7cdb58b.png)


After 
![image](https://user-images.githubusercontent.com/29204244/213808650-054cd687-93ab-4511-afbe-3cb05b6b11ad.png)
