### PR TITLE
Fixed an issue where the guideOnly setting wasn't working

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -18,6 +18,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 1, 24), "Fixed an issue where Guide pages weren't showing by default", Sref),
   change(date(2023, 1, 20), <>Adjust maximum combat potion usages to account for <SpellLink id={SPELLS.ALACRITOUS_ALCHEMIST_STONE} />.</>, ToppleTheNun),
   change(date(2023, 1, 18), 'Add missing 3* weapon enhancements.', ToppleTheNun),
   change(date(2023, 1, 17), 'Add ability to generate PTR talents and add documentation on how to do so.', ToppleTheNun),

--- a/src/interface/report/Results/Overview.tsx
+++ b/src/interface/report/Results/Overview.tsx
@@ -42,7 +42,7 @@ const Overview = ({ guide: GuideComponent, checklist, issues }: Props) => {
   const configOnlyGuideSetting = Boolean(config.guideOnly);
   let initialGuideSetting =
     sessionGuideSetting === null ? configGuideSetting : Boolean(sessionGuideSetting);
-  if (configGuideSetting && configOnlyGuideSetting) {
+  if (configGuideSetting || configOnlyGuideSetting) {
     initialGuideSetting = true;
   }
 


### PR DESCRIPTION
Got many reports that Resto Druid, which was recently changed to use `guideOnly`, was defaulting to the blank Checklist/Suggestion page. I think this fixes the issue.