### PR TITLE
[Mistweaver] Refactor Mastery Stats to use Event Linking. Added Sheiluns to mastery Breakdown

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 1, 24), <>Updated <SpellLink id={SPELLS.GUSTS_OF_MISTS}/> breakdown to include <SpellLink id={TALENTS_MONK.SHEILUNS_GIFT_TALENT}/> and improved accuracy.</>, Vohrr),
   change(date(2023, 1, 24), <>Removed Bonedust Brew modules and references for Mistweaver for 10.0.5</>, Vohrr),
   change(date(2023, 1, 16), <>Add <SpellLink id={TALENTS_MONK.SHEILUNS_GIFT_TALENT}/> module and update extension logic for <SpellLink id={TALENTS_MONK.RAPID_DIFFUSION_TALENT}/></>, Trevor),
   change(date(2023, 1, 12), <>Improve accuracy of <SpellLink id={TALENTS_MONK.VIVACIOUS_VIVIFICATION_TALENT.id}/> module and the <SpellLink id={TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT.id}/> missed GCDs tally.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
+++ b/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
@@ -75,6 +75,7 @@ import DancingMists from './modules/spells/DancingMists';
 import MistyPeaksHealingBreakdown from './modules/features/MistyPeaksHealingBreakdown';
 import TalentHealingStatistic from './modules/features/TalentHealingStatistic';
 import MendingProliferation from './modules/spells/MendingProliferation';
+import SheilunsGift from './modules/spells/SheilunsGift';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -160,6 +161,7 @@ class CombatLogParser extends CoreCombatLogParser {
     dancingMists: DancingMists,
     mendingProliferation: MendingProliferation,
     teachingsOfTheMonestary: TeachingsOfTheMonestary,
+    sheilunsGift: SheilunsGift,
 
     // Borrowed Power
     t29TierSet: T29TierSet,

--- a/src/analysis/retail/monk/mistweaver/modules/features/MasteryStats.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/MasteryStats.tsx
@@ -13,6 +13,7 @@ import EssenceFont from '../spells/EssenceFont';
 import ExpelHarm from '../spells/ExpelHarm';
 import RenewingMist from '../spells/RenewingMist';
 import Revival from '../spells/Revival';
+import SheilunsGift from '../spells/SheilunsGift';
 import SoothingMist from '../spells/SoothingMist';
 import Vivify from '../spells/Vivify';
 
@@ -25,6 +26,7 @@ class MasteryStats extends Analyzer {
     vivify: Vivify,
     expelHarm: ExpelHarm,
     revival: Revival,
+    sheilunsGift: SheilunsGift,
   };
 
   protected essenceFont!: EssenceFont;
@@ -34,6 +36,7 @@ class MasteryStats extends Analyzer {
   protected vivify!: Vivify;
   protected expelHarm!: ExpelHarm;
   protected revival!: Revival;
+  protected sheilunsGift!: SheilunsGift;
 
   get totalMasteryHealing() {
     return (
@@ -43,7 +46,8 @@ class MasteryStats extends Analyzer {
       (this.soothingMist.gustsHealing || 0) +
       (this.essenceFont.gomHealing || 0) +
       (this.expelHarm.gustsHealing || 0) +
-      this.revival.gustsHealing
+      (this.revival.gustsHealing || 0) +
+      (this.sheilunsGift.gomHealing || 0)
     );
   }
 
@@ -99,6 +103,16 @@ class MasteryStats extends Analyzer {
         valueTooltip: formatThousands(this.revival.gustsHealing),
       },
     ];
+
+    if (this.selectedCombatant.hasTalent(TALENTS_MONK.SHEILUNS_GIFT_TALENT)) {
+      items.push({
+        color: SPELL_COLORS.ALTERNATE_GUST_OF_MIST,
+        label: 'Sheiluns Gift',
+        spellId: TALENTS_MONK.SHEILUNS_GIFT_TALENT.id,
+        value: this.sheilunsGift.gomHealing,
+        valueTooltip: formatThousands(this.sheilunsGift.gomHealing),
+      });
+    }
 
     return <DonutChart items={items} />;
   }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EnvelopingMists.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EnvelopingMists.tsx
@@ -10,7 +10,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import { ENVELOPING_MIST_INCREASE, MISTWRAP_INCREASE } from '../../constants';
-import { isFromEnvelopingMist, isFromEssenceFont } from '../../normalizers/CastLinkNormalizer';
+import { isFromEnvelopingMist } from '../../normalizers/CastLinkNormalizer';
 
 const UNAFFECTED_SPELLS: number[] = [TALENTS_MONK.ENVELOPING_MIST_TALENT.id];
 
@@ -37,7 +37,7 @@ class EnvelopingMists extends Analyzer {
   }
 
   masteryEnvelopingMist(event: HealEvent) {
-    if (isFromEnvelopingMist(event) && !isFromEssenceFont(event)) {
+    if (isFromEnvelopingMist(event)) {
       this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
     }
   }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ExpelHarm.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ExpelHarm.tsx
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { HealEvent } from 'parser/core/Events';
-import { isFromEssenceFont, isFromExpelHarm } from '../../normalizers/CastLinkNormalizer';
+import { isFromExpelHarm } from '../../normalizers/CastLinkNormalizer';
 
 class ExpelHarm extends Analyzer {
   selfHealing: number = 0;
@@ -37,7 +37,7 @@ class ExpelHarm extends Analyzer {
   }
 
   handleMastery(event: HealEvent) {
-    if (isFromExpelHarm(event) && !isFromEssenceFont(event)) {
+    if (isFromExpelHarm(event)) {
       this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
     }
   }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ExpelHarm.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ExpelHarm.tsx
@@ -1,6 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { HealEvent } from 'parser/core/Events';
+import { isFromEssenceFont, isFromExpelHarm } from '../../normalizers/CastLinkNormalizer';
 
 class ExpelHarm extends Analyzer {
   selfHealing: number = 0;
@@ -8,9 +9,6 @@ class ExpelHarm extends Analyzer {
   targetHealing: number = 0;
   targetOverheal: number = 0;
   gustsHealing: number = 0;
-  lastCastTarget: number = -1;
-  sourceTarget: number = -1;
-  numberToCount: number = 0;
 
   constructor(options: Options) {
     super(options);
@@ -31,24 +29,16 @@ class ExpelHarm extends Analyzer {
   handleExpelHarm(event: HealEvent) {
     this.selfHealing += (event.amount || 0) + (event.absorbed || 0);
     this.selfOverheal += event.overheal || 0;
-    this.numberToCount += 1;
-    this.sourceTarget = event.targetID;
   }
 
   handleTargetExpelHarm(event: HealEvent) {
     this.targetHealing += (event.amount || 0) + (event.absorbed || 0);
     this.targetOverheal += event.overheal || 0;
-    this.numberToCount += 1;
-    this.lastCastTarget = event.targetID;
   }
 
   handleMastery(event: HealEvent) {
-    if (
-      (event.targetID === this.lastCastTarget || event.targetID === this.sourceTarget) &&
-      this.numberToCount > 0
-    ) {
+    if (isFromExpelHarm(event) && !isFromEssenceFont(event)) {
       this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
-      this.numberToCount -= 1;
     }
   }
 }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RenewingMist.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RenewingMist.tsx
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { ApplyBuffEvent, HealEvent, RemoveBuffEvent } from 'parser/core/Events';
-import { isFromEssenceFont, isFromRenewingMist } from '../../normalizers/CastLinkNormalizer';
+import { isFromRenewingMist } from '../../normalizers/CastLinkNormalizer';
 
 class RenewingMist extends Analyzer {
   currentRenewingMists: number = 0;
@@ -40,7 +40,7 @@ class RenewingMist extends Analyzer {
   }
 
   handleGustsOfMists(event: HealEvent) {
-    if (isFromRenewingMist(event) && !isFromEssenceFont(event)) {
+    if (isFromRenewingMist(event)) {
       this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
     }
   }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RenewingMist.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RenewingMist.tsx
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS';
-import { TALENTS_MONK } from 'common/TALENTS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { ApplyBuffEvent, CastEvent, HealEvent, RemoveBuffEvent } from 'parser/core/Events';
+import Events, { ApplyBuffEvent, HealEvent, RemoveBuffEvent } from 'parser/core/Events';
+import { isFromEssenceFont, isFromRenewingMist } from '../../normalizers/CastLinkNormalizer';
 
 class RenewingMist extends Analyzer {
   currentRenewingMists: number = 0;
@@ -9,16 +9,10 @@ class RenewingMist extends Analyzer {
   totalOverhealing: number = 0;
   totalAbsorbs: number = 0;
   gustsHealing: number = 0;
-  lastCastTarget: number = 0;
   healingHits: number = 0;
-  numberToCount: number = 0;
 
   constructor(options: Options) {
     super(options);
-    this.addEventListener(
-      Events.cast.by(SELECTED_PLAYER).spell(TALENTS_MONK.RENEWING_MIST_TALENT),
-      this.castRenewingMist,
-    );
     this.addEventListener(
       Events.heal.by(SELECTED_PLAYER).spell(SPELLS.GUSTS_OF_MISTS),
       this.handleGustsOfMists,
@@ -45,15 +39,9 @@ class RenewingMist extends Analyzer {
     this.currentRenewingMists -= 1;
   }
 
-  castRenewingMist(event: CastEvent) {
-    this.numberToCount += 1;
-    this.lastCastTarget = event.targetID || 0;
-  }
-
   handleGustsOfMists(event: HealEvent) {
-    if (this.lastCastTarget === event.targetID && this.numberToCount > 0) {
+    if (isFromRenewingMist(event) && !isFromEssenceFont(event)) {
       this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
-      this.numberToCount -= 1;
     }
   }
 

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Revival.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Revival.tsx
@@ -11,7 +11,7 @@ import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
 import { SPELL_COLORS } from '../../constants';
 import UpliftedSpirits from './UpliftedSpirits';
-import { isFromEssenceFont, isFromRevival } from '../../normalizers/CastLinkNormalizer';
+import { isFromRevival } from '../../normalizers/CastLinkNormalizer';
 
 class Revival extends Analyzer {
   static dependencies = {
@@ -65,7 +65,7 @@ class Revival extends Analyzer {
   }
 
   handleGustsOfMists(event: HealEvent) {
-    if (isFromRevival(event) && !isFromEssenceFont(event)) {
+    if (isFromRevival(event)) {
       this.gustsHealing += event.amount + (event.absorbed || 0);
       this.gustOverHealing += event.overheal || 0;
     }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Revival.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Revival.tsx
@@ -4,15 +4,14 @@ import { Talent } from 'common/TALENTS/types';
 import { TALENTS_MONK } from 'common/TALENTS';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent, HealEvent } from 'parser/core/Events';
+import Events, { HealEvent } from 'parser/core/Events';
 import DonutChart from 'parser/ui/DonutChart';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
 import { SPELL_COLORS } from '../../constants';
 import UpliftedSpirits from './UpliftedSpirits';
-
-const BUFFER = 500;
+import { isFromEssenceFont, isFromRevival } from '../../normalizers/CastLinkNormalizer';
 
 class Revival extends Analyzer {
   static dependencies = {
@@ -28,8 +27,6 @@ class Revival extends Analyzer {
   gustsHealing: number = 0;
   gustOverHealing: number = 0;
 
-  lastRevival: number = Number.MIN_SAFE_INTEGER;
-
   constructor(options: Options) {
     super(options);
     this.active =
@@ -39,18 +36,7 @@ class Revival extends Analyzer {
     if (!this.active) {
       return;
     }
-
     this.activeTalent = this.getRevivalTalent();
-
-    this.addEventListener(
-      Events.cast.by(SELECTED_PLAYER).spell(TALENTS_MONK.REVIVAL_TALENT),
-      this.revivalCast,
-    );
-    this.addEventListener(
-      Events.cast.by(SELECTED_PLAYER).spell(TALENTS_MONK.RESTORAL_TALENT),
-      this.revivalCast,
-    );
-
     this.addEventListener(
       Events.heal.by(SELECTED_PLAYER).spell(TALENTS_MONK.REVIVAL_TALENT),
       this.handleRevivalDirect,
@@ -73,19 +59,13 @@ class Revival extends Analyzer {
       : TALENTS_MONK.REVIVAL_TALENT;
   }
 
-  revivalCast(event: CastEvent) {
-    this.lastRevival = event.timestamp + BUFFER;
-  }
-
   handleRevivalDirect(event: HealEvent) {
-    if (this.lastRevival > event.timestamp) {
-      this.revivalDirectHealing += event.amount + (event.absorbed || 0);
-      this.revivalDirectOverHealing += event.overheal || 0;
-    }
+    this.revivalDirectHealing += event.amount + (event.absorbed || 0);
+    this.revivalDirectOverHealing += event.overheal || 0;
   }
 
   handleGustsOfMists(event: HealEvent) {
-    if (this.lastRevival > event.timestamp) {
+    if (isFromRevival(event) && !isFromEssenceFont(event)) {
       this.gustsHealing += event.amount + (event.absorbed || 0);
       this.gustOverHealing += event.overheal || 0;
     }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/SheilunsGift.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/SheilunsGift.tsx
@@ -7,18 +7,31 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import TalentSpellText from 'parser/ui/TalentSpellText';
+import { isFromEssenceFont, isFromSheilunsGift } from '../../normalizers/CastLinkNormalizer';
 
 class SheilunsGift extends Analyzer {
   numCasts: number = 0;
   totalStacks: number = 0;
   totalHealing: number = 0;
+  gomHealing: number = 0;
 
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.SHEILUNS_GIFT_TALENT);
+    if (!this.active) {
+      return;
+    }
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(TALENTS_MONK.SHEILUNS_GIFT_TALENT),
       this.onCast,
+    );
+    this.addEventListener(
+      Events.heal.by(SELECTED_PLAYER).spell(TALENTS_MONK.SHEILUNS_GIFT_TALENT),
+      this.onHeal,
+    );
+    this.addEventListener(
+      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.GUSTS_OF_MISTS),
+      this.masterySheilunsGift,
     );
   }
 
@@ -29,6 +42,12 @@ class SheilunsGift extends Analyzer {
 
   onHeal(event: HealEvent) {
     this.totalHealing += event.amount;
+  }
+
+  masterySheilunsGift(event: HealEvent) {
+    if (isFromSheilunsGift(event) && !isFromEssenceFont(event)) {
+      this.gomHealing += (event.amount || 0) + (event.absorbed || 0);
+    }
   }
 
   get averageClouds() {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/SheilunsGift.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/SheilunsGift.tsx
@@ -7,7 +7,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import TalentSpellText from 'parser/ui/TalentSpellText';
-import { isFromEssenceFont, isFromSheilunsGift } from '../../normalizers/CastLinkNormalizer';
+import { isFromSheilunsGift } from '../../normalizers/CastLinkNormalizer';
 
 class SheilunsGift extends Analyzer {
   numCasts: number = 0;
@@ -45,7 +45,7 @@ class SheilunsGift extends Analyzer {
   }
 
   masterySheilunsGift(event: HealEvent) {
-    if (isFromSheilunsGift(event) && !isFromEssenceFont(event)) {
+    if (isFromSheilunsGift(event)) {
       this.gomHealing += (event.amount || 0) + (event.absorbed || 0);
     }
   }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/SoothingMist.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/SoothingMist.tsx
@@ -8,15 +8,14 @@ import Events, { CastEvent, FightEndEvent, HealEvent, RemoveBuffEvent } from 'pa
 import SUGGESTION_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import StatTracker from 'parser/shared/modules/StatTracker';
+import { isFromEssenceFont, isFromSoothingMist } from '../../normalizers/CastLinkNormalizer';
 
 class SoothingMist extends Analyzer {
   static dependencies = {
     statTracker: StatTracker,
   };
   soomTicks: number = 0;
-  gustProc: number = 0;
   gustsHealing: number = 0;
-  lastSoomTickTimestamp: number = 0;
   startStamp: number = 0;
   endStamp: number = 0;
   soomInProgress: boolean = false;
@@ -84,15 +83,10 @@ class SoothingMist extends Analyzer {
 
   handleSoothingMist(event: HealEvent) {
     this.soomTicks += 1;
-    this.lastSoomTickTimestamp = event.timestamp;
   }
 
   masterySoothingMist(event: HealEvent) {
-    if (
-      this.lastSoomTickTimestamp === event.timestamp &&
-      this.gustProc < Math.ceil(this.soomTicks / 8)
-    ) {
-      this.gustProc += 1;
+    if (isFromSoothingMist(event) && !isFromEssenceFont(event)) {
       this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
     }
   }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/SoothingMist.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/SoothingMist.tsx
@@ -8,7 +8,7 @@ import Events, { CastEvent, FightEndEvent, HealEvent, RemoveBuffEvent } from 'pa
 import SUGGESTION_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import StatTracker from 'parser/shared/modules/StatTracker';
-import { isFromEssenceFont, isFromSoothingMist } from '../../normalizers/CastLinkNormalizer';
+import { isFromSoothingMist } from '../../normalizers/CastLinkNormalizer';
 
 class SoothingMist extends Analyzer {
   static dependencies = {
@@ -86,7 +86,7 @@ class SoothingMist extends Analyzer {
   }
 
   masterySoothingMist(event: HealEvent) {
-    if (isFromSoothingMist(event) && !isFromEssenceFont(event)) {
+    if (isFromSoothingMist(event)) {
       this.gustsHealing += (event.amount || 0) + (event.absorbed || 0);
     }
   }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Vivify.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Vivify.tsx
@@ -11,7 +11,7 @@ import Statistic from 'parser/ui/Statistic';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import TalentSpellText from 'parser/ui/TalentSpellText';
 import { DANCING_MIST_CHANCE, RAPID_DIFFUSION_DURATION } from '../../constants';
-import { isFromEssenceFont, isFromVivify } from '../../normalizers/CastLinkNormalizer';
+import { isFromVivify } from '../../normalizers/CastLinkNormalizer';
 
 const RAPID_DIFFUSION_SPELLS = [
   TALENTS_MONK.ENVELOPING_MIST_TALENT,
@@ -131,7 +131,7 @@ class Vivify extends Analyzer {
   }
 
   handleMastery(event: HealEvent) {
-    if (isFromVivify(event) && !isFromEssenceFont(event)) {
+    if (isFromVivify(event)) {
       this.gomHealing += (event.amount || 0) + (event.absorbed || 0);
       this.gomOverhealing += event.overheal || 0;
     }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Vivify.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Vivify.tsx
@@ -11,6 +11,7 @@ import Statistic from 'parser/ui/Statistic';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import TalentSpellText from 'parser/ui/TalentSpellText';
 import { DANCING_MIST_CHANCE, RAPID_DIFFUSION_DURATION } from '../../constants';
+import { isFromEssenceFont, isFromVivify } from '../../normalizers/CastLinkNormalizer';
 
 const RAPID_DIFFUSION_SPELLS = [
   TALENTS_MONK.ENVELOPING_MIST_TALENT,
@@ -31,9 +32,7 @@ class Vivify extends Analyzer {
 
   gomHealing: number = 0;
   gomOverhealing: number = 0;
-
   lastCastTarget: number = 0;
-  gomToCount: number = 0;
 
   expectedAverageReMs: number = 0;
   rdCasts: number = 0;
@@ -115,7 +114,6 @@ class Vivify extends Analyzer {
 
   vivCast(event: CastEvent) {
     this.casts += 1;
-    this.gomToCount += 1;
     this.mainTargetHitsToCount += 1;
     this.lastCastTarget = event.targetID || 0;
   }
@@ -133,10 +131,9 @@ class Vivify extends Analyzer {
   }
 
   handleMastery(event: HealEvent) {
-    if (this.lastCastTarget === event.targetID && this.gomToCount > 0) {
+    if (isFromVivify(event) && !isFromEssenceFont(event)) {
       this.gomHealing += (event.amount || 0) + (event.absorbed || 0);
       this.gomOverhealing += event.overheal || 0;
-      this.gomToCount -= 1;
     }
   }
   suggestions(when: When) {

--- a/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
@@ -11,6 +11,7 @@ import {
   HasRelatedEvent,
   RemoveBuffEvent,
   RefreshBuffEvent,
+  HealEvent,
 } from 'parser/core/Events';
 
 export const APPLIED_HEAL = 'AppliedHeal';
@@ -22,6 +23,14 @@ export const FROM_HARDCAST = 'FromHardcast';
 export const FROM_MISTY_PEAKS = 'FromMistyPeaks';
 export const FROM_MISTS_OF_LIFE = 'FromMOL';
 export const FROM_RAPID_DIFFUSION = 'FromRD'; // can be linked to env mist or rsk cast
+export const ENVELOPING_MIST_GOM = 'EnvGOM';
+export const RENEWING_MIST_GOM = 'ReMGOM';
+export const VIVIFY_GOM = 'ViVGOM';
+export const REVIVAL_GOM = 'RevivalGOM';
+export const ZEN_PULSE_GOM = 'ZPGOM';
+export const SHEILUNS_GIFT_GOM = 'SGGOM';
+export const EXPEL_HARM_GOM = 'EHGOM';
+export const SOOM_GOM = 'SoomGOM';
 
 const RAPID_DIFFUSION_BUFFER_MS = 300;
 const DANCING_MIST_BUFFER_MS = 120;
@@ -165,6 +174,93 @@ const EVENT_LINKS: EventLink[] = [
     forwardBufferMs: CAST_BUFFER_MS,
     backwardBufferMs: CAST_BUFFER_MS,
   },
+  //Mastery event linking
+  {
+    linkRelation: ENVELOPING_MIST_GOM,
+    linkingEventId: [SPELLS.GUSTS_OF_MISTS.id],
+    linkingEventType: [EventType.Heal],
+    referencedEventId: TALENTS_MONK.ENVELOPING_MIST_TALENT.id,
+    referencedEventType: EventType.Cast,
+    backwardBufferMs: CAST_BUFFER_MS,
+    forwardBufferMs: CAST_BUFFER_MS,
+    maximumLinks: 1,
+  },
+  {
+    linkRelation: RENEWING_MIST_GOM,
+    linkingEventId: [SPELLS.GUSTS_OF_MISTS.id],
+    linkingEventType: [EventType.Heal],
+    referencedEventId: TALENTS_MONK.RENEWING_MIST_TALENT.id,
+    referencedEventType: EventType.Cast,
+    backwardBufferMs: CAST_BUFFER_MS,
+    forwardBufferMs: CAST_BUFFER_MS,
+    maximumLinks: 1,
+  },
+  {
+    linkRelation: VIVIFY_GOM,
+    linkingEventId: [SPELLS.GUSTS_OF_MISTS.id],
+    linkingEventType: [EventType.Heal],
+    referencedEventId: SPELLS.VIVIFY.id,
+    referencedEventType: EventType.Cast,
+    backwardBufferMs: CAST_BUFFER_MS,
+    forwardBufferMs: CAST_BUFFER_MS,
+    maximumLinks: 1,
+  },
+  {
+    linkRelation: ZEN_PULSE_GOM,
+    linkingEventId: [SPELLS.GUSTS_OF_MISTS.id],
+    linkingEventType: [EventType.Heal],
+    referencedEventId: TALENTS_MONK.ZEN_PULSE_TALENT.id,
+    referencedEventType: EventType.Cast,
+    backwardBufferMs: CAST_BUFFER_MS,
+    forwardBufferMs: CAST_BUFFER_MS,
+    maximumLinks: 1,
+    isActive(c) {
+      return c.hasTalent(TALENTS_MONK.ZEN_PULSE_TALENT);
+    },
+  },
+  {
+    linkRelation: EXPEL_HARM_GOM,
+    linkingEventId: [SPELLS.GUSTS_OF_MISTS.id],
+    linkingEventType: [EventType.Heal],
+    referencedEventId: SPELLS.EXPEL_HARM.id,
+    referencedEventType: EventType.Heal,
+    backwardBufferMs: CAST_BUFFER_MS,
+    forwardBufferMs: CAST_BUFFER_MS,
+    maximumLinks: 1,
+  },
+  {
+    linkRelation: SOOM_GOM,
+    linkingEventId: [SPELLS.GUSTS_OF_MISTS.id],
+    linkingEventType: [EventType.Heal],
+    referencedEventId: TALENTS_MONK.SOOTHING_MIST_TALENT.id,
+    referencedEventType: EventType.Heal,
+    backwardBufferMs: CAST_BUFFER_MS,
+    forwardBufferMs: CAST_BUFFER_MS,
+    maximumLinks: 1,
+  },
+  {
+    linkRelation: SHEILUNS_GIFT_GOM,
+    linkingEventId: [SPELLS.GUSTS_OF_MISTS.id],
+    linkingEventType: [EventType.Heal],
+    referencedEventId: TALENTS_MONK.SHEILUNS_GIFT_TALENT.id,
+    referencedEventType: EventType.Heal,
+    backwardBufferMs: CAST_BUFFER_MS,
+    forwardBufferMs: CAST_BUFFER_MS,
+    maximumLinks: 1,
+    isActive(c) {
+      return c.hasTalent(TALENTS_MONK.SHEILUNS_GIFT_TALENT);
+    },
+  },
+  {
+    linkRelation: REVIVAL_GOM,
+    linkingEventId: [SPELLS.GUSTS_OF_MISTS.id],
+    linkingEventType: [EventType.Heal],
+    referencedEventId: [TALENTS_MONK.REVIVAL_TALENT.id, TALENTS_MONK.RESTORAL_TALENT.id],
+    referencedEventType: EventType.Heal,
+    backwardBufferMs: CAST_BUFFER_MS,
+    forwardBufferMs: CAST_BUFFER_MS,
+    maximumLinks: 1,
+  },
 ];
 
 /**
@@ -264,6 +360,50 @@ export function isFromMistsOfLife(event: ApplyBuffEvent | RefreshBuffEvent): boo
 
 export function isFromDancingMists(event: ApplyBuffEvent | RefreshBuffEvent): boolean {
   return HasRelatedEvent(event, FROM_DANCING_MISTS) && !HasRelatedEvent(event, FROM_MISTS_OF_LIFE);
+}
+
+export function isFromEnvelopingMist(event: HealEvent) {
+  return HasRelatedEvent(event, ENVELOPING_MIST_GOM);
+}
+
+export function isFromRenewingMist(event: HealEvent) {
+  return HasRelatedEvent(event, RENEWING_MIST_GOM);
+}
+
+export function isFromVivify(event: HealEvent) {
+  return HasRelatedEvent(event, VIVIFY_GOM);
+}
+
+export function isFromSheilunsGift(event: HealEvent) {
+  return HasRelatedEvent(event, SHEILUNS_GIFT_GOM);
+}
+
+export function isFromRevival(event: HealEvent) {
+  return HasRelatedEvent(event, REVIVAL_GOM);
+}
+
+export function isFromZenPulse(event: HealEvent) {
+  return HasRelatedEvent(event, ZEN_PULSE_GOM);
+}
+
+export function isFromExpelHarm(event: HealEvent) {
+  return HasRelatedEvent(event, EXPEL_HARM_GOM);
+}
+
+export function isFromSoothingMist(event: HealEvent) {
+  return HasRelatedEvent(event, SOOM_GOM);
+}
+
+export function isFromEssenceFont(event: HealEvent) {
+  return (
+    !HasRelatedEvent(event, EXPEL_HARM_GOM) &&
+    !HasRelatedEvent(event, ZEN_PULSE_GOM) &&
+    !HasRelatedEvent(event, REVIVAL_GOM) &&
+    !HasRelatedEvent(event, SHEILUNS_GIFT_GOM) &&
+    !HasRelatedEvent(event, VIVIFY_GOM) &&
+    !HasRelatedEvent(event, RENEWING_MIST_GOM) &&
+    !HasRelatedEvent(event, ENVELOPING_MIST_GOM)
+  );
 }
 
 export default CastLinkNormalizer;

--- a/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
@@ -363,35 +363,35 @@ export function isFromDancingMists(event: ApplyBuffEvent | RefreshBuffEvent): bo
 }
 
 export function isFromEnvelopingMist(event: HealEvent) {
-  return HasRelatedEvent(event, ENVELOPING_MIST_GOM);
+  return HasRelatedEvent(event, ENVELOPING_MIST_GOM) && !isFromEssenceFont(event);
 }
 
 export function isFromRenewingMist(event: HealEvent) {
-  return HasRelatedEvent(event, RENEWING_MIST_GOM);
+  return HasRelatedEvent(event, RENEWING_MIST_GOM) && !isFromEssenceFont(event);
 }
 
 export function isFromVivify(event: HealEvent) {
-  return HasRelatedEvent(event, VIVIFY_GOM);
+  return HasRelatedEvent(event, VIVIFY_GOM) && !isFromEssenceFont(event);
 }
 
 export function isFromSheilunsGift(event: HealEvent) {
-  return HasRelatedEvent(event, SHEILUNS_GIFT_GOM);
+  return HasRelatedEvent(event, SHEILUNS_GIFT_GOM) && !isFromEssenceFont(event);
 }
 
 export function isFromRevival(event: HealEvent) {
-  return HasRelatedEvent(event, REVIVAL_GOM);
+  return HasRelatedEvent(event, REVIVAL_GOM) && !isFromEssenceFont(event);
 }
 
 export function isFromZenPulse(event: HealEvent) {
-  return HasRelatedEvent(event, ZEN_PULSE_GOM);
+  return HasRelatedEvent(event, ZEN_PULSE_GOM) && !isFromEssenceFont(event);
 }
 
 export function isFromExpelHarm(event: HealEvent) {
-  return HasRelatedEvent(event, EXPEL_HARM_GOM);
+  return HasRelatedEvent(event, EXPEL_HARM_GOM) && !isFromEssenceFont(event);
 }
 
 export function isFromSoothingMist(event: HealEvent) {
-  return HasRelatedEvent(event, SOOM_GOM);
+  return HasRelatedEvent(event, SOOM_GOM) && !isFromEssenceFont(event);
 }
 
 export function isFromEssenceFont(event: HealEvent) {


### PR DESCRIPTION
Updated the Gust of Mist Mastery Breakdown chart to include Sheiluns Gift when talented

Added Event linking for mastery events and refactored the mastery calcs in the modules using them to improve accuracy
*Revival direct healing/Gust Of Mist screenshots shown below because its the simplest way to showcase the improved accuracy
Before: 
![image](https://user-images.githubusercontent.com/26779541/214397619-90fc9014-36b0-482d-9ec1-1e9840742327.png)
![image](https://user-images.githubusercontent.com/26779541/214397812-508f3036-9fc6-429a-8a34-337cdfbf27ab.png)

Actual:
![image](https://user-images.githubusercontent.com/26779541/214397671-6d462576-fafd-4121-b9ff-0d9c85d3da68.png)


After:
![image](https://user-images.githubusercontent.com/26779541/214397721-c32521ac-d77f-4aea-9b17-a72b676313c6.png)
![image](https://user-images.githubusercontent.com/26779541/214397845-9ddacc63-364e-469c-8393-383709a80a1f.png)


