### PR TITLE
Holy Priest Prayerful Litany Talent Support

### DIFF
--- a/src/analysis/retail/priest/holy/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/holy/CHANGELOG.tsx
@@ -5,6 +5,11 @@ import { SpellLink } from 'interface';
 
 export default [
   change(
+    date(2023, 1, 24),
+    <>Added support for <SpellLink id={TALENTS_PRIEST.PRAYERFUL_LITANY_TALENT.id}/>. </>,
+    Squided
+  ),
+  change(
     date(2022, 12, 18),
     <>Added initial holy priest guide for 10.0.</>,
     Squided

--- a/src/analysis/retail/priest/holy/CombatLogParser.tsx
+++ b/src/analysis/retail/priest/holy/CombatLogParser.tsx
@@ -110,6 +110,7 @@ class CombatLogParser extends CoreCombatLogParser {
     SurgeOfLight: Talents.Classwide.SurgeOfLight,
     PrayerCircle: Talents.MiddleRow.PrayerCircle,
     SanctifiedPrayers: Talents.TopRow.SanctifiedPrayers,
+    PrayerfulLitany: Talents.MiddleRow.PrayerfulLitany,
 
     Halo: Talents.Classwide.Halo,
     Benediction: Talents.MiddleRow.Benediction,

--- a/src/analysis/retail/priest/holy/modules/talents/MiddleRow/PrayerfulLitany.tsx
+++ b/src/analysis/retail/priest/holy/modules/talents/MiddleRow/PrayerfulLitany.tsx
@@ -1,0 +1,89 @@
+import TALENTS from 'common/TALENTS/priest';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+import Events, { CastEvent, HealEvent } from 'parser/core/Events';
+import { getPrayerOfHealingEvents } from '../../../normalizers/CastLinkNormalizer';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { calculateEffectiveHealing, calculateOverhealing } from 'parser/core/EventCalculateLib';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import { formatNumber, formatPercentage } from 'common/format';
+
+const PRAYERFUL_LITANY_MULTIPLIER = 0.3;
+
+/*
+  Prayer of Healing heals for 30% more to the most injured ally it affects.
+*/
+class PrayerfulLitany extends Analyzer {
+  effectiveAdditionalHealing: number = 0;
+  overhealing: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.PRAYERFUL_LITANY_TALENT);
+    if (this.active) {
+      this.addEventListener(
+        Events.cast.by(SELECTED_PLAYER).spell(TALENTS.PRAYER_OF_HEALING_TALENT),
+        this.onPohCast,
+      );
+    }
+  }
+
+  onPohCast(event: CastEvent) {
+    const healEvents: HealEvent[] = getPrayerOfHealingEvents(event);
+    let buffedHealEvent: HealEvent | undefined;
+    let lowestHealth = Infinity;
+
+    // find the heal buffed by litany
+    for (const healEvent of healEvents) {
+      // litany buffs heal on lowest health player
+      const healthBeforeHeal = healEvent.hitPoints - healEvent.amount;
+      if (healthBeforeHeal < lowestHealth) {
+        lowestHealth = healthBeforeHeal;
+        buffedHealEvent = healEvent;
+      }
+    }
+
+    if (buffedHealEvent !== undefined) {
+      const effectiveHealAmount = calculateEffectiveHealing(
+        buffedHealEvent,
+        PRAYERFUL_LITANY_MULTIPLIER,
+      );
+      const overHealAmount = calculateOverhealing(buffedHealEvent, PRAYERFUL_LITANY_MULTIPLIER);
+
+      this.effectiveAdditionalHealing += effectiveHealAmount;
+      this.overhealing += overHealAmount;
+    }
+  }
+
+  get percentOverhealing() {
+    const rawHealing = this.effectiveAdditionalHealing + this.overhealing;
+    if (rawHealing === 0) {
+      return 0;
+    }
+    return this.overhealing / rawHealing;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+        position={STATISTIC_ORDER.OPTIONAL(6)}
+        tooltip={
+          <>
+            Total Healing: {formatNumber(this.effectiveAdditionalHealing + this.overhealing)} (
+            {formatPercentage(this.percentOverhealing)}% OH)
+          </>
+        }
+      >
+        <TalentSpellText talent={TALENTS.PRAYERFUL_LITANY_TALENT}>
+          <ItemHealingDone amount={this.effectiveAdditionalHealing} />
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}
+
+export default PrayerfulLitany;

--- a/src/analysis/retail/priest/holy/modules/talents/MiddleRow/index.tsx
+++ b/src/analysis/retail/priest/holy/modules/talents/MiddleRow/index.tsx
@@ -5,6 +5,7 @@ import PrayerCircle from './PrayerCircle';
 import RevitalizingPrayers from './RevitalizingPrayers';
 import TrailOfLight from './TrailOfLight';
 import EverlastingLight from './EverlastingLight';
+import PrayerfulLitany from './PrayerfulLitany';
 
 export {
   Benediction,
@@ -14,4 +15,5 @@ export {
   TrailOfLight,
   RevitalizingPrayers,
   EverlastingLight,
+  PrayerfulLitany,
 };


### PR DESCRIPTION
### Description

Add support for the Prayerful Litany talent to statistics page. https://www.wowhead.com/spell=391209/prayerful-litany

### Motivation

Useful to see how much (or rather how little) hps this talent provides.

### Testing

- Test report URL: https://www.warcraftlogs.com/reports/Cj2xwZThmM4vAQcX#fight=23&type=healing&source=19&options=8
- Screenshot(s):
<img width="328" alt="image" src="https://user-images.githubusercontent.com/6947753/214445124-2b13c7d3-d095-413e-8a35-a100581f34ad.png">
<img width="389" alt="image" src="https://user-images.githubusercontent.com/6947753/214445140-68fabe35-16f8-45cd-98d6-2a7c9827157f.png">
