### PR TITLE
[Mistweaver] Updated Shaohao's Lessons breakdown

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 1, 26), <>Update breakdown for <SpellLink id={TALENTS_MONK.SHAOHAOS_LESSONS_TALENT.id}/>.</>, Vohrr),
   change(date(2023, 1, 25), <>Add <SpellLink id={TALENTS_MONK.VEIL_OF_PRIDE_TALENT}/> module</>, Trevor),
   change(date(2023, 1, 25), <>Fixed but with <SpellLink id={TALENTS_MONK.MIST_WRAP_TALENT.id}/> module.</>, Vohrr),
   change(date(2023, 1, 25), <>Reworked <SpellLink id={TALENTS_MONK.MIST_WRAP_TALENT.id}/> module to show all healing contribution and not just from <SpellLink id={TALENTS_MONK.ENVELOPING_BREATH_TALENT.id}/>. </>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ShaohaosLessons.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ShaohaosLessons.tsx
@@ -161,8 +161,24 @@ class ShaohaosLessons extends Analyzer {
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={
           <>
-            Note: Haste increase is not included in HPS as a haste buff cannot be directly
-            attributed to a healing increase
+            <ul>
+              <li>
+                Note: Lesson of Fear's (haste) increase is not included in HPS as a haste buff
+                cannot be directly attributed to a healing increase
+              </li>
+            </ul>
+            Healing:
+            <ul>
+              <li>Anger: {formatNumber(this.angerHealing)}</li>
+              <li>Despair: {formatNumber(this.despairHealing)}</li>
+              <li>Doubt: {formatNumber(this.doubtHealing)}</li>
+            </ul>
+            Damage:
+            <ul>
+              <li>Anger: {formatNumber(this.angerDamage)}</li>
+              <li>Despair: {formatNumber(this.despairDamage)}</li>
+              <li>Doubt: {formatNumber(this.doubtDamage)}</li>
+            </ul>
           </>
         }
       >
@@ -172,6 +188,7 @@ class ShaohaosLessons extends Analyzer {
           <img alt="Damage Mitigated" src="/img/shield.png" className="icon" />{' '}
           {formatNumber(this.fearMitigated)} <small> damage mitigated</small>
           <br />
+          <img alt="" src="/img/wheelchair.png" className="icon" />{' '}
           {formatPercentage(this.averageHasteIncrease, 1)}% <small>average haste increase</small>
         </TalentSpellText>
       </Statistic>


### PR DESCRIPTION
Added some additional detail in the breakdown to the Shaohao's Lessons module
Before: 
![image](https://user-images.githubusercontent.com/26779541/214863376-b09c62b5-f291-4e8c-9175-85b51931e7ff.png)
![image](https://user-images.githubusercontent.com/26779541/214863481-c4f7de84-e90c-4b38-8b34-f2b9ecbaae4e.png)

After:
![image](https://user-images.githubusercontent.com/26779541/214863197-4ebb96fb-0bb4-4f73-9156-a3519d720d0e.png)
![image](https://user-images.githubusercontent.com/26779541/214863307-22fdddf7-a219-4baa-8060-30ae8f7bdf00.png)
