### PR TITLE
[Unholy DK] Added Vile Infusion tracker v2

### DIFF
--- a/src/analysis/retail/deathknight/unholy/CHANGELOG.tsx
+++ b/src/analysis/retail/deathknight/unholy/CHANGELOG.tsx
@@ -4,8 +4,9 @@ import { AlexanderJKremer, Bicepspump, Khazak } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
-  change(date(2023, 1, 18), 'Moved from partial to full support', Bicepspump),
+  change(date(2023, 1, 27), 'Added tracker for Vile Infusion', Bicepspump),
   change(date(2023, 1, 24), `Added ${<SpellLink id={SPELLS.T29_GHOULISH_INFUSION}/>}'s haste buff`, Khazak),
+  change(date(2023, 1, 18), 'Moved from partial to full support', Bicepspump),
   change(date(2023, 1, 18), 'Added Plaguebringer Tracker', Bicepspump),
   change(date(2023, 1, 17), 'Added module for tracking Summon Gargoyle Empowerment', Bicepspump),
   change(date(2023, 1, 16), 'Updated Cooldowns to have proper Cooldown', Bicepspump),

--- a/src/analysis/retail/deathknight/unholy/CombatLogParser.ts
+++ b/src/analysis/retail/deathknight/unholy/CombatLogParser.ts
@@ -26,6 +26,7 @@ import ArmyOfTheDamned from './modules/talents/ArmyOfTheDamned';
 import SoulReaper from './modules/talents/SoulReaper';
 import SummonGargoyleBuffs from './modules/talents/SummonGargoyleBuffs';
 import PlagueBringer from './modules/talents/PlagueBringer';
+import VileInfusion from './modules/spells/VileInfusion';
 
 // Covenants
 
@@ -47,6 +48,7 @@ class CombatLogParser extends CoreCombatLogParser {
     spellUsable: SpellUsable,
     suddenDoom: SuddenDoom,
     unholyRuneForge: UnholyRuneForgeChecker,
+    fileInfusion: VileInfusion,
 
     // Talents
     soulReaper: SoulReaper,

--- a/src/analysis/retail/deathknight/unholy/modules/spells/VileInfusion.tsx
+++ b/src/analysis/retail/deathknight/unholy/modules/spells/VileInfusion.tsx
@@ -84,8 +84,6 @@ class VileInfusion extends Analyzer {
   }
 
   statistic() {
-    console.log(this);
-    console.log(this.selectedCombatant);
     return (
       <Statistic
         tooltip={`Your Vile Infusion was up ${Math.round(this.totalBuffTime)} out of ${Math.round(

--- a/src/analysis/retail/deathknight/unholy/modules/spells/VileInfusion.tsx
+++ b/src/analysis/retail/deathknight/unholy/modules/spells/VileInfusion.tsx
@@ -24,12 +24,12 @@ class VileInfusion extends Analyzer {
     }
 
     this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.VILE_INFUSION_BUFF),
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.T29_VILE_INFUSION_BUFF),
       this.onBuffEvent,
     );
 
     this.addEventListener(
-      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.VILE_INFUSION_BUFF),
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.T29_VILE_INFUSION_BUFF),
       this.onRemoveBuff,
     );
 
@@ -63,7 +63,7 @@ class VileInfusion extends Analyzer {
       .addSuggestion((suggest, actual, recommended) =>
         suggest(
           <span>
-            You are not keeping up your <SpellLink id={SPELLS.VILE_INFUSION_BUFF.id} /> enough.{' '}
+            You are not keeping up your <SpellLink id={SPELLS.T29_VILE_INFUSION_BUFF.id} /> enough.{' '}
             Prioritise maintaining it by bursting <SpellLink id={SPELLS.FESTERING_WOUND.id} />
             s.
           </span>,
@@ -92,7 +92,7 @@ class VileInfusion extends Analyzer {
         position={STATISTIC_ORDER.CORE(1)}
         size="flexible"
       >
-        <BoringSpellValueText spellId={SPELLS.VILE_INFUSION_BUFF.id}>
+        <BoringSpellValueText spellId={SPELLS.T29_VILE_INFUSION_BUFF.id}>
           <>
             {formatPercentage(this.averageBuffUptime)}% <small>Vile Infusion uptime</small>
           </>

--- a/src/analysis/retail/deathknight/unholy/modules/spells/VileInfusion.tsx
+++ b/src/analysis/retail/deathknight/unholy/modules/spells/VileInfusion.tsx
@@ -1,14 +1,14 @@
 import { t } from '@lingui/macro';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
-import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { ApplyBuffEvent, RemoveBuffEvent, FightEndEvent } from 'parser/core/Events';
+import Analyzer, { Options } from 'parser/core/Analyzer';
 import { When } from 'parser/core/ParseResults';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import { formatPercentage } from 'common/format';
 import { TIERS } from 'game/TIERS';
+import Pets from 'parser/shared/modules/Pets';
 
 class VileInfusion extends Analyzer {
   lastBuffTime = 0;
@@ -22,38 +22,14 @@ class VileInfusion extends Analyzer {
     if (!this.active) {
       return;
     }
-
-    this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.T29_VILE_INFUSION_BUFF),
-      this.onBuffEvent,
-    );
-
-    this.addEventListener(
-      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.T29_VILE_INFUSION_BUFF),
-      this.onRemoveBuff,
-    );
-
-    this.addEventListener(Events.fightend, this.onFightEnd);
   }
 
-  onBuffEvent(event: ApplyBuffEvent) {
-    this.lastBuffTime = event.timestamp;
-    this.buffIsUp = true;
-  }
-
-  onRemoveBuff(event: RemoveBuffEvent) {
-    this.totalBuffTime += (event.timestamp - this.lastBuffTime) / 1000;
-    this.buffIsUp = false;
-  }
-
-  onFightEnd(event: FightEndEvent) {
-    if (this.buffIsUp === true) {
-      this.totalBuffTime += (event.timestamp - this.lastBuffTime) / 1000;
-    }
-  }
-
+  static dependencies = {
+    pets: Pets,
+  };
+  protected pets!: Pets;
   get averageBuffUptime() {
-    return this.totalBuffTime / (this.owner.fightDuration / 1000);
+    return this.pets.getBuffUptime(SPELLS.T29_VILE_INFUSION_BUFF.id) / this.owner.fightDuration;
   }
 
   suggestions(when: When) {

--- a/src/analysis/retail/deathknight/unholy/modules/spells/VileInfusion.tsx
+++ b/src/analysis/retail/deathknight/unholy/modules/spells/VileInfusion.tsx
@@ -1,0 +1,107 @@
+import { t } from '@lingui/macro';
+import SPELLS from 'common/SPELLS';
+import { SpellLink } from 'interface';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { ApplyBuffEvent, RemoveBuffEvent, FightEndEvent } from 'parser/core/Events';
+import { When } from 'parser/core/ParseResults';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { formatPercentage } from 'common/format';
+import { TIERS } from 'game/TIERS';
+
+class VileInfusion extends Analyzer {
+  lastBuffTime = 0;
+  totalBuffTime = 0;
+  buffIsUp = false;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.has2PieceByTier(TIERS.T29);
+    if (!this.active) {
+      return;
+    }
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.VILE_INFUSION_BUFF),
+      this.onBuffEvent,
+    );
+
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.VILE_INFUSION_BUFF),
+      this.onRemoveBuff,
+    );
+
+    this.addEventListener(Events.fightend, this.onFightEnd);
+  }
+
+  onBuffEvent(event: ApplyBuffEvent) {
+    this.lastBuffTime = event.timestamp;
+    this.buffIsUp = true;
+  }
+
+  onRemoveBuff(event: RemoveBuffEvent) {
+    this.totalBuffTime += (event.timestamp - this.lastBuffTime) / 1000;
+    this.buffIsUp = false;
+  }
+
+  onFightEnd(event: FightEndEvent) {
+    if (this.buffIsUp === true) {
+      this.totalBuffTime += (event.timestamp - this.lastBuffTime) / 1000;
+    }
+  }
+
+  get averageBuffUptime() {
+    return this.totalBuffTime / (this.owner.fightDuration / 1000);
+  }
+
+  suggestions(when: When) {
+    // Vile Infusion should have 75% uptime or more
+    when(this.averageBuffUptime)
+      .isLessThan(0.75)
+      .addSuggestion((suggest, actual, recommended) =>
+        suggest(
+          <span>
+            You are not keeping up your <SpellLink id={SPELLS.VILE_INFUSION_BUFF.id} /> enough.{' '}
+            Prioritise maintaining it by bursting <SpellLink id={SPELLS.FESTERING_WOUND.id} />
+            s.
+          </span>,
+        )
+          .icon(SPELLS.PLAGUEBRINGER_BUFF.icon)
+          .actual(
+            t({
+              id: 'deathknight.unholy.suggestions.plaguebringer.uptime',
+              message: `Vile Infusion was up ${formatPercentage(
+                this.averageBuffUptime,
+              )}% of the time`,
+            }),
+          )
+          .recommended(`${formatPercentage(recommended)}% is recommended`)
+          .regular(recommended - 0.05)
+          .major(recommended - 0.1),
+      );
+  }
+
+  statistic() {
+    console.log(this);
+    console.log(this.selectedCombatant);
+    return (
+      <Statistic
+        tooltip={`Your Vile Infusion was up ${Math.round(this.totalBuffTime)} out of ${Math.round(
+          this.owner.fightDuration / 1000,
+        )} seconds`}
+        position={STATISTIC_ORDER.CORE(1)}
+        size="flexible"
+      >
+        <BoringSpellValueText spellId={SPELLS.VILE_INFUSION_BUFF.id}>
+          <>
+            {formatPercentage(this.averageBuffUptime)}% <small>Vile Infusion uptime</small>
+          </>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default VileInfusion;

--- a/src/common/SPELLS/deathknight.ts
+++ b/src/common/SPELLS/deathknight.ts
@@ -301,6 +301,12 @@ const spells = spellIndexableList({
     icon: 'ability_creature_disease_02',
   },
 
+  VILE_INFUSION_BUFF: {
+    id: 394863,
+    name: 'Vile Infusion',
+    icon: 'spell_necro_deathsknell',
+  },
+
   DARK_ARBITER_TALENT_GLYPH: {
     id: 207349,
     name: 'Dark Arbiter',

--- a/src/common/SPELLS/deathknight.ts
+++ b/src/common/SPELLS/deathknight.ts
@@ -301,7 +301,7 @@ const spells = spellIndexableList({
     icon: 'ability_creature_disease_02',
   },
 
-  VILE_INFUSION_BUFF: {
+  T29_VILE_INFUSION_BUFF: {
     id: 394863,
     name: 'Vile Infusion',
     icon: 'spell_necro_deathsknell',


### PR DESCRIPTION
### Description

Added a tracker for Vile Infusion uptime.

### Motivation

Upkeeping the unholy dk 2p bonus is important to maximise DPS. Either through passively weaving your abilities or actively managing it, it's important.

### Testing

- Test report URL: https://www.warcraftlogs.com/reports/jXn6BbyPh97JV1Fm/#fight=12&source=58
![image](https://user-images.githubusercontent.com/34515306/213206273-9c8ad6bd-8c22-4610-8d05-cebc842595cb.png)

