### PR TITLE
fix Animacharged not working for Envenom

### DIFF
--- a/src/analysis/retail/rogue/assassination/CHANGELOG.tsx
+++ b/src/analysis/retail/rogue/assassination/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { change, date } from 'common/changelog';
 import { ToppleTheNun } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2023, 1, 27), 'Fix Animacharged not working for Envenom.', ToppleTheNun),
   change(date(2023, 1, 26), 'Fix finisher cast breakdowns showing as bad casts if finisher was Animacharged.', ToppleTheNun),
   change(date(2023, 1, 26), 'Add support for Animacharged CPs and low CP finishers in opener.', ToppleTheNun),
   change(date(2023, 1, 24), 'Update for Dragonflight.', ToppleTheNun),

--- a/src/analysis/retail/rogue/assassination/modules/core/Snapshots.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/core/Snapshots.tsx
@@ -3,19 +3,6 @@ import SPELLS from 'common/SPELLS/rogue';
 import TALENTS from 'common/TALENTS/rogue';
 import { NIGHTSTALKER_DAMAGE_BUFF } from 'analysis/retail/rogue/shared';
 
-export const NIGHTSTALKER_SPEC: StaticSnapshotSpec = {
-  name: 'Nightstalker',
-  spellFunc: () => [TALENTS.NIGHTSTALKER_TALENT],
-  isActive: (c) => c.hasTalent(TALENTS.NIGHTSTALKER_TALENT),
-  isPresent: (c, timestamp) =>
-    c.hasBuff(SPELLS.STEALTH.id, timestamp, BUFF_DROP_BUFFER) ||
-    c.hasBuff(SPELLS.STEALTH_BUFF.id, timestamp, BUFF_DROP_BUFFER) ||
-    c.hasBuff(SPELLS.VANISH_BUFF.id, timestamp, BUFF_DROP_BUFFER) ||
-    c.hasBuff(SPELLS.SHADOW_DANCE_BUFF.id, timestamp, BUFF_DROP_BUFFER),
-  displayColor: '#5555ff',
-  boostStrength: (c) => NIGHTSTALKER_DAMAGE_BUFF[c.getTalentRank(TALENTS.NIGHTSTALKER_TALENT)],
-};
-
 export const IMPROVED_GARROTE_SPEC: StaticSnapshotSpec = {
   name: 'Improved Garrote',
   spellFunc: () => [TALENTS.IMPROVED_GARROTE_TALENT],

--- a/src/analysis/retail/rogue/assassination/modules/spells/Envenom.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/spells/Envenom.tsx
@@ -9,7 +9,10 @@ import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { formatDurationMillisMinSec } from 'common/format';
 import { ReactNode } from 'react';
 import SpellLink from 'interface/SpellLink';
-import { getMaxComboPoints } from 'analysis/retail/rogue/assassination/constants';
+import {
+  animachargedCheckedUsageInfo,
+  getMaxComboPoints,
+} from 'analysis/retail/rogue/assassination/constants';
 import { combineQualitativePerformances } from 'common/combineQualitativePerformances';
 import SpellUsageSubSection from 'parser/core/SpellUsage/SpellUsageSubSection';
 
@@ -53,6 +56,13 @@ export default class Envenom extends Analyzer {
         explanation={explanation}
         performance={performances}
         uses={this.cooldownUses}
+        castBreakdownSmallText={
+          <>
+            {' '}
+            - Blue is an Animacharged cast, Green is a good cast, Yellow is an ok cast, Red is a bad
+            cast.
+          </>
+        }
       />
     );
   }
@@ -127,7 +137,6 @@ export default class Envenom extends Analyzer {
       );
     }
 
-    const overallPerf = combineQualitativePerformances([rupturePerformance, cpsPerformance]);
     const checklistItems: ChecklistUsageInfo[] = [
       {
         check: 'rupture',
@@ -145,12 +154,23 @@ export default class Envenom extends Analyzer {
       },
     ];
 
+    const actualChecklistItems = animachargedCheckedUsageInfo(
+      this.selectedCombatant,
+      event,
+      checklistItems,
+    );
+    const actualPerformance = combineQualitativePerformances(
+      actualChecklistItems.map((it) => it.performance),
+    );
+
     this.cooldownUses.push({
       event,
-      performance: overallPerf,
-      checklistItems,
+      performance: actualPerformance,
+      checklistItems: actualChecklistItems,
       performanceExplanation:
-        overallPerf !== QualitativePerformance.Fail ? `${overallPerf} Usage` : 'Bad Usage',
+        actualPerformance !== QualitativePerformance.Fail
+          ? `${actualPerformance} Usage`
+          : 'Bad Usage',
     });
 
     // TODO also highlight 'bad' Envenoms in the timeline

--- a/src/analysis/retail/rogue/assassination/modules/spells/GarroteUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/spells/GarroteUptimeAndSnapshots.tsx
@@ -3,7 +3,7 @@ import { SpellLink } from 'interface';
 import { Options } from 'parser/core/Analyzer';
 import Enemies from 'parser/shared/modules/Enemies';
 import DotSnapshots, { SnapshotSpec } from 'parser/core/DotSnapshots';
-import { IMPROVED_GARROTE_SPEC, NIGHTSTALKER_SPEC } from '../core/Snapshots';
+import { IMPROVED_GARROTE_SPEC } from '../core/Snapshots';
 import { ApplyDebuffEvent, RefreshDebuffEvent } from 'parser/core/Events';
 import {
   animachargedCheckedUsageInfo,
@@ -31,7 +31,7 @@ export default class GarroteUptimeAndSnapshots extends DotSnapshots {
   protected enemies!: Enemies;
 
   constructor(options: Options) {
-    super(SPELLS.GARROTE, SPELLS.GARROTE, [NIGHTSTALKER_SPEC, IMPROVED_GARROTE_SPEC], options);
+    super(SPELLS.GARROTE, SPELLS.GARROTE, [IMPROVED_GARROTE_SPEC], options);
   }
 
   getDotExpectedDuration(event: ApplyDebuffEvent | RefreshDebuffEvent): number {
@@ -172,7 +172,6 @@ export default class GarroteUptimeAndSnapshots extends DotSnapshots {
         </strong>{' '}
         is your highest damage-per-energy single target builder. Try to keep it active on all
         targets (except when in a many-target AoE situation). Garrote snapshots{' '}
-        <SpellLink id={TALENTS.NIGHTSTALKER_TALENT.id} /> and{' '}
         <SpellLink id={TALENTS.IMPROVED_GARROTE_TALENT.id} /> - when forced to refresh with a weaker
         snapshot, try to wait until the last moment in order to overwrite the minimum amount of the
         stronger DoT.
@@ -218,6 +217,7 @@ export default class GarroteUptimeAndSnapshots extends DotSnapshots {
       },
       this.snapshotUptimes,
       SubPercentageStyle.RELATIVE,
+      true,
     );
   }
 }

--- a/src/analysis/retail/rogue/assassination/modules/spells/RuptureUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/spells/RuptureUptimeAndSnapshots.tsx
@@ -3,7 +3,6 @@ import { SpellLink } from 'interface';
 import { Options } from 'parser/core/Analyzer';
 import Enemies from 'parser/shared/modules/Enemies';
 import DotSnapshots, { SnapshotSpec } from 'parser/core/DotSnapshots';
-import { NIGHTSTALKER_SPEC } from '../core/Snapshots';
 import { ApplyDebuffEvent, RefreshDebuffEvent } from 'parser/core/Events';
 import {
   animachargedCheckedUsageInfo,
@@ -33,7 +32,7 @@ export default class RuptureUptimeAndSnapshots extends DotSnapshots {
   protected enemies!: Enemies;
 
   constructor(options: Options) {
-    super(SPELLS.RUPTURE, SPELLS.RUPTURE, [NIGHTSTALKER_SPEC], options);
+    super(SPELLS.RUPTURE, SPELLS.RUPTURE, [], options);
   }
 
   getDotExpectedDuration(event: ApplyDebuffEvent | RefreshDebuffEvent): number {
@@ -207,8 +206,9 @@ export default class RuptureUptimeAndSnapshots extends DotSnapshots {
         castBreakdownSmallText={
           <>
             {' '}
-            - Green is a good cast, Yellow is an ok cast (clipped duration but upgraded snapshot),
-            Red is a bad cast (clipped duration or downgraded snapshot w/ &gt;
+            - Blue is an Animacharged cast, Green is a good cast, Yellow is an ok cast (clipped
+            duration but upgraded snapshot), Red is a bad cast (clipped duration or downgraded
+            snapshot w/ &gt;
             {formatDurationMillisMinSec(SNAPSHOT_DOWNGRADE_BUFFER)} remaining).
           </>
         }

--- a/src/analysis/retail/rogue/assassination/modules/talents/CrimsonTempestUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/talents/CrimsonTempestUptimeAndSnapshots.tsx
@@ -2,7 +2,6 @@ import { SpellLink } from 'interface';
 import { Options } from 'parser/core/Analyzer';
 import Enemies from 'parser/shared/modules/Enemies';
 import DotSnapshots, { SnapshotSpec } from 'parser/core/DotSnapshots';
-import { NIGHTSTALKER_SPEC } from '../core/Snapshots';
 import { ApplyDebuffEvent, RefreshDebuffEvent } from 'parser/core/Events';
 import {
   animachargedCheckedUsageInfo,
@@ -33,12 +32,7 @@ export default class CrimsonTempestUptimeAndSnapshots extends DotSnapshots {
   protected enemies!: Enemies;
 
   constructor(options: Options) {
-    super(
-      TALENTS.CRIMSON_TEMPEST_TALENT,
-      TALENTS.CRIMSON_TEMPEST_TALENT,
-      [NIGHTSTALKER_SPEC],
-      options,
-    );
+    super(TALENTS.CRIMSON_TEMPEST_TALENT, TALENTS.CRIMSON_TEMPEST_TALENT, [], options);
   }
 
   getDotExpectedDuration(event: ApplyDebuffEvent | RefreshDebuffEvent): number {
@@ -215,8 +209,9 @@ export default class CrimsonTempestUptimeAndSnapshots extends DotSnapshots {
         castBreakdownSmallText={
           <>
             {' '}
-            - Green is a good cast, Yellow is an ok cast (clipped duration but upgraded snapshot),
-            Red is a bad cast (clipped duration or downgraded snapshot w/ &gt;
+            - Blue is an Animacharged cast, Green is a good cast, Yellow is an ok cast (clipped
+            duration but upgraded snapshot), Red is a bad cast (clipped duration or downgraded
+            snapshot w/ &gt;
             {formatDurationMillisMinSec(SNAPSHOT_DOWNGRADE_BUFFER)} remaining).
           </>
         }

--- a/src/parser/ui/UptimeBarSubStatistic.tsx
+++ b/src/parser/ui/UptimeBarSubStatistic.tsx
@@ -34,13 +34,15 @@ export enum SubPercentageStyle {
  *   For example, if a fight had a duration of 1000, the primary uptime was 500,
  *   and the sub uptime was 200, with 'absolute' the relative uptime will be listed as 20%
  *   and with 'relative' it will be listed as 40%
- *
+ * @param subIncludeUptimeText should 'uptime' be displayed after sub bar
+ *   if omitted, will not include
  */
 export default function uptimeBarSubStatistic(
   fight: Pick<WCLFight, 'start_time' | 'end_time'>,
   primaryBar: UptimeBarSpec,
   subBars: UptimeBarSpec[] = [],
   subPercentageStyle: SubPercentageStyle = SubPercentageStyle.RELATIVE,
+  subIncludeUptimeText: boolean = false,
 ): React.ReactNode {
   const primaryUptime = getCombinedUptime(primaryBar.uptimes);
   const totalFightTime = fight.end_time - fight.start_time;
@@ -68,6 +70,12 @@ export default function uptimeBarSubStatistic(
           <div className="flex-sub bar-label" style={{ color: spec.color }}>
             {getSubUptimeIcon(spec)}{' '}
             {formatPercentUptime(getCombinedUptime(spec.uptimes), subBarUptimeReference)}
+            {subIncludeUptimeText && (
+              <>
+                {' '}
+                <small>uptime</small>
+              </>
+            )}
           </div>
           <div className="flex-main chart">
             <UptimeBar


### PR DESCRIPTION
### Description

Use Animacharged `CheckedUsageInfo[]` function for Envenom casts.

### Motivation

I forgot to do this in my previous PR.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/2NJQ6xK9jbDtVkWq/40-Mythic+Terros+-+Kill+(5:55)/Whíspyr/standard`
- Screenshot(s):
![image](https://user-images.githubusercontent.com/1672786/215189805-2e595dbc-5ca8-4e60-8b40-d6ed9f85fb5d.png)
