### PR TITLE
add Garrote snapshots and improve stealth detection

### DIFF
--- a/src/analysis/retail/rogue/assassination/CHANGELOG.tsx
+++ b/src/analysis/retail/rogue/assassination/CHANGELOG.tsx
@@ -1,8 +1,12 @@
 import { change, date } from 'common/changelog';
 import { ToppleTheNun } from 'CONTRIBUTORS';
+import SpellLink from 'interface/SpellLink';
+import SPELLS from 'common/SPELLS/rogue';
+import TALENTS from 'common/TALENTS/rogue';
 
 export default [
-  change(date(2023, 1, 27), 'Fix Animacharged not working for Envenom.', ToppleTheNun),
+  change(date(2023, 1, 27), <>Add snapshotting information for <SpellLink id={SPELLS.GARROTE} /> and improve <SpellLink id={TALENTS.IMPROVED_GARROTE_TALENT} /> stealth detection.</>, ToppleTheNun),
+  change(date(2023, 1, 27), <>Fix Animacharged not working for <SpellLink id={SPELLS.ENVENOM} />.</>, ToppleTheNun),
   change(date(2023, 1, 26), 'Fix finisher cast breakdowns showing as bad casts if finisher was Animacharged.', ToppleTheNun),
   change(date(2023, 1, 26), 'Add support for Animacharged CPs and low CP finishers in opener.', ToppleTheNun),
   change(date(2023, 1, 24), 'Update for Dragonflight.', ToppleTheNun),

--- a/src/analysis/retail/rogue/assassination/modules/core/Snapshots.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/core/Snapshots.tsx
@@ -1,17 +1,20 @@
 import { BUFF_DROP_BUFFER, StaticSnapshotSpec } from 'parser/core/DotSnapshots';
 import SPELLS from 'common/SPELLS/rogue';
 import TALENTS from 'common/TALENTS/rogue';
-import { NIGHTSTALKER_DAMAGE_BUFF } from 'analysis/retail/rogue/shared';
+
+// Improved Garrote works off of 3s from last stealth drop
+const IMPROVED_GARROTE_STEALTH_BUFFER = 3000 + BUFF_DROP_BUFFER;
 
 export const IMPROVED_GARROTE_SPEC: StaticSnapshotSpec = {
   name: 'Improved Garrote',
   spellFunc: () => [TALENTS.IMPROVED_GARROTE_TALENT],
   isActive: (c) => c.hasTalent(TALENTS.IMPROVED_GARROTE_TALENT),
   isPresent: (c, timestamp) =>
-    c.hasBuff(SPELLS.STEALTH.id, timestamp, BUFF_DROP_BUFFER) ||
-    c.hasBuff(SPELLS.STEALTH_BUFF.id, timestamp, BUFF_DROP_BUFFER) ||
-    c.hasBuff(SPELLS.VANISH_BUFF.id, timestamp, BUFF_DROP_BUFFER) ||
-    c.hasBuff(SPELLS.SHADOW_DANCE_BUFF.id, timestamp, BUFF_DROP_BUFFER),
+    c.hasBuff(SPELLS.STEALTH.id, timestamp, IMPROVED_GARROTE_STEALTH_BUFFER) ||
+    c.hasBuff(SPELLS.STEALTH_BUFF.id, timestamp, IMPROVED_GARROTE_STEALTH_BUFFER) ||
+    c.hasBuff(SPELLS.VANISH_BUFF.id, timestamp, IMPROVED_GARROTE_STEALTH_BUFFER) ||
+    c.hasBuff(SPELLS.SHADOW_DANCE_BUFF.id, timestamp, IMPROVED_GARROTE_STEALTH_BUFFER) ||
+    c.hasBuff(SPELLS.IMPROVED_GARROTE_BUFF.id, timestamp, IMPROVED_GARROTE_STEALTH_BUFFER),
   displayColor: '#dd0022',
-  boostStrength: (c) => NIGHTSTALKER_DAMAGE_BUFF[c.getTalentRank(TALENTS.NIGHTSTALKER_TALENT)],
+  boostStrength: () => 0.5,
 };

--- a/src/analysis/retail/rogue/assassination/modules/spells/GarroteUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/spells/GarroteUptimeAndSnapshots.tsx
@@ -70,7 +70,25 @@ export default class GarroteUptimeAndSnapshots extends DotSnapshots {
 
     let snapshotPerformance: QualitativePerformance = QualitativePerformance.Good;
     let snapshotSummary = <div>Good snapshot usage</div>;
-    let snapshotDetails = <div>Good snapshot usage.</div>;
+    let snapshotDetails = (
+      <div>
+        Good snapshot usage.
+        <br />
+        Snapshots:{' '}
+        <strong>
+          {snapshots.length === 0 ? 'NONE' : snapshots.map((it) => it.name).join(', ')}
+        </strong>
+        {prevSnapshots != null && (
+          <>
+            <br />
+            Previous Snapshots:{' '}
+            <strong>
+              {prevSnapshots.length === 0 ? 'NONE' : prevSnapshots.map((it) => it.name).join(', ')}
+            </strong>
+          </>
+        )}
+      </div>
+    );
     if (wasUnacceptableDowngrade) {
       snapshotPerformance = QualitativePerformance.Fail;
       snapshotSummary = <div>Unacceptable downgrade of snapshot</div>;
@@ -78,10 +96,29 @@ export default class GarroteUptimeAndSnapshots extends DotSnapshots {
         <div>
           Unacceptable downgrade of snapshot. Try not to overwrite your snapshotted Garrote unless
           it's within the last {formatDurationMillisMinSec(SNAPSHOT_DOWNGRADE_BUFFER)}.
+          <br />
+          Snapshots:{' '}
+          <strong>
+            {snapshots.length === 0 ? 'NONE' : snapshots.map((it) => it.name).join(', ')}
+          </strong>
+          {prevSnapshots != null && (
+            <>
+              <br />
+              Previous Snapshots:{' '}
+              <strong>
+                {prevSnapshots.length === 0
+                  ? 'NONE'
+                  : prevSnapshots.map((it) => it.name).join(', ')}
+              </strong>
+            </>
+          )}
         </div>
       );
     }
-    if (clipped > 0) {
+    if (
+      clipped > 0 &&
+      !snapshots.some((snapshot) => snapshot.name === IMPROVED_GARROTE_SPEC.name)
+    ) {
       snapshotPerformance = wasUpgrade ? QualitativePerformance.Ok : QualitativePerformance.Fail;
       snapshotSummary = wasUpgrade ? (
         <div>Clipped but upgraded existing snapshotted Garrote</div>
@@ -94,7 +131,25 @@ export default class GarroteUptimeAndSnapshots extends DotSnapshots {
           Garotte.
         </div>
       ) : (
-        <div>Clipped existing snapshotted Garrote. Try not to clip your snapshotted Garotte.</div>
+        <div>
+          Clipped existing snapshotted Garrote. Try not to clip your snapshotted Garotte.
+          <br />
+          Snapshots:{' '}
+          <strong>
+            {snapshots.length === 0 ? 'NONE' : snapshots.map((it) => it.name).join(', ')}
+          </strong>
+          {prevSnapshots != null && (
+            <>
+              <br />
+              Previous Snapshots:{' '}
+              <strong>
+                {prevSnapshots.length === 0
+                  ? 'NONE'
+                  : prevSnapshots.map((it) => it.name).join(', ')}
+              </strong>
+            </>
+          )}
+        </div>
       );
     }
 
@@ -107,35 +162,6 @@ export default class GarroteUptimeAndSnapshots extends DotSnapshots {
         details: snapshotDetails,
       },
     ];
-
-    // const tooltip = (
-    //   <>
-    //     @ <strong>{this.owner.formatTimestamp(cast.timestamp)}</strong> targetting{' '}
-    //     <strong>{targetName || 'unknown'}</strong>
-    //     <br />
-    //     {prevSnapshotNames !== null && (
-    //       <>
-    //         Refreshed on target w/ {(remainingOnPrev / 1000).toFixed(1)}s remaining{' '}
-    //         {clipped > 0 && (
-    //           <>
-    //             <strong>- Clipped {(clipped / 1000).toFixed(1)}s!</strong>
-    //           </>
-    //         )}
-    //         <br />
-    //       </>
-    //     )}
-    //     Snapshots: <strong>{snapshotNames.length === 0 ? 'NONE' : snapshotNames.join(', ')}</strong>
-    //     <br />
-    //     {prevSnapshotNames !== null && (
-    //       <>
-    //         Prev Snapshots:{' '}
-    //         <strong>
-    //           {prevSnapshotNames.length === 0 ? 'NONE' : prevSnapshotNames.join(', ')}
-    //         </strong>
-    //       </>
-    //     )}
-    //   </>
-    // );
 
     const actualChecklistItems = animachargedCheckedUsageInfo(
       this.selectedCombatant,

--- a/src/analysis/retail/rogue/assassination/modules/spells/RuptureUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/spells/RuptureUptimeAndSnapshots.tsx
@@ -15,7 +15,7 @@ import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import uptimeBarSubStatistic, { SubPercentageStyle } from 'parser/ui/UptimeBarSubStatistic';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { formatDurationMillisMinSec } from 'common/format';
-import { ChecklistUsageInfo, SpellUse, spellUseToBoxRowEntry } from 'parser/core/SpellUsage/core';
+import { SpellUse, spellUseToBoxRowEntry } from 'parser/core/SpellUsage/core';
 import SpellUsageSubSection from 'parser/core/SpellUsage/SpellUsageSubSection';
 
 import { getHardcast } from '../../normalizers/CastLinkNormalizer';
@@ -108,7 +108,7 @@ export default class RuptureUptimeAndSnapshots extends DotSnapshots {
       );
     }
 
-    const checklistItems: ChecklistUsageInfo[] = [
+    const actualChecklistItems = animachargedCheckedUsageInfo(this.selectedCombatant, cast, [
       {
         check: 'snapshot',
         timestamp: cast.timestamp,
@@ -116,42 +116,7 @@ export default class RuptureUptimeAndSnapshots extends DotSnapshots {
         summary: snapshotSummary,
         details: snapshotDetails,
       },
-    ];
-
-    // const tooltip = (
-    //   <>
-    //     @ <strong>{this.owner.formatTimestamp(cast.timestamp)}</strong> targetting{' '}
-    //     <strong>{targetName || 'unknown'}</strong>
-    //     <br />
-    //     {prevSnapshotNames !== null && (
-    //       <>
-    //         Refreshed on target w/ {(remainingOnPrev / 1000).toFixed(1)}s remaining{' '}
-    //         {clipped > 0 && (
-    //           <>
-    //             <strong>- Clipped {(clipped / 1000).toFixed(1)}s!</strong>
-    //           </>
-    //         )}
-    //         <br />
-    //       </>
-    //     )}
-    //     Snapshots: <strong>{snapshotNames.length === 0 ? 'NONE' : snapshotNames.join(', ')}</strong>
-    //     <br />
-    //     {prevSnapshotNames !== null && (
-    //       <>
-    //         Prev Snapshots:{' '}
-    //         <strong>
-    //           {prevSnapshotNames.length === 0 ? 'NONE' : prevSnapshotNames.join(', ')}
-    //         </strong>
-    //       </>
-    //     )}
-    //   </>
-    // );
-
-    const actualChecklistItems = animachargedCheckedUsageInfo(
-      this.selectedCombatant,
-      cast,
-      checklistItems,
-    );
+    ]);
     const actualPerformance = combineQualitativePerformances(
       actualChecklistItems.map((it) => it.performance),
     );

--- a/src/analysis/retail/rogue/assassination/modules/talents/CrimsonTempestUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/talents/CrimsonTempestUptimeAndSnapshots.tsx
@@ -15,7 +15,7 @@ import TALENTS from 'common/TALENTS/rogue';
 import uptimeBarSubStatistic, { SubPercentageStyle } from 'parser/ui/UptimeBarSubStatistic';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { formatDurationMillisMinSec } from 'common/format';
-import { ChecklistUsageInfo, SpellUse, spellUseToBoxRowEntry } from 'parser/core/SpellUsage/core';
+import { SpellUse, spellUseToBoxRowEntry } from 'parser/core/SpellUsage/core';
 import SpellUsageSubSection from 'parser/core/SpellUsage/SpellUsageSubSection';
 
 import { getHardcast } from '../../normalizers/CastLinkNormalizer';
@@ -111,7 +111,7 @@ export default class CrimsonTempestUptimeAndSnapshots extends DotSnapshots {
       );
     }
 
-    const checklistItems: ChecklistUsageInfo[] = [
+    const actualChecklistItems = animachargedCheckedUsageInfo(this.selectedCombatant, cast, [
       {
         check: 'snapshot',
         timestamp: cast.timestamp,
@@ -119,42 +119,7 @@ export default class CrimsonTempestUptimeAndSnapshots extends DotSnapshots {
         summary: snapshotSummary,
         details: snapshotDetails,
       },
-    ];
-
-    // const tooltip = (
-    //   <>
-    //     @ <strong>{this.owner.formatTimestamp(cast.timestamp)}</strong> targetting{' '}
-    //     <strong>{targetName || 'unknown'}</strong>
-    //     <br />
-    //     {prevSnapshotNames !== null && (
-    //       <>
-    //         Refreshed on target w/ {(remainingOnPrev / 1000).toFixed(1)}s remaining{' '}
-    //         {clipped > 0 && (
-    //           <>
-    //             <strong>- Clipped {(clipped / 1000).toFixed(1)}s!</strong>
-    //           </>
-    //         )}
-    //         <br />
-    //       </>
-    //     )}
-    //     Snapshots: <strong>{snapshotNames.length === 0 ? 'NONE' : snapshotNames.join(', ')}</strong>
-    //     <br />
-    //     {prevSnapshotNames !== null && (
-    //       <>
-    //         Prev Snapshots:{' '}
-    //         <strong>
-    //           {prevSnapshotNames.length === 0 ? 'NONE' : prevSnapshotNames.join(', ')}
-    //         </strong>
-    //       </>
-    //     )}
-    //   </>
-    // );
-
-    const actualChecklistItems = animachargedCheckedUsageInfo(
-      this.selectedCombatant,
-      cast,
-      checklistItems,
-    );
+    ]);
     const actualPerformance = combineQualitativePerformances(
       actualChecklistItems.map((it) => it.performance),
     );

--- a/src/common/SPELLS/rogue.ts
+++ b/src/common/SPELLS/rogue.ts
@@ -441,6 +441,11 @@ const spells = spellIndexableList({
     name: 'Toxic Blade',
     icon: 'inv_weapon_shortblade_62',
   },
+  IMPROVED_GARROTE_BUFF: {
+    id: 392403,
+    name: 'Improved Garrote',
+    icon: 'ability_rogue_garrote',
+  },
 
   // Sets
   ASSA_ROGUE_TIER_28_2P_SET_BONUS: {


### PR DESCRIPTION
### Description

Add Garrote snapshot information to the Garrote details in cast breakdowns. Improved Garrote is triggered when casting Garrote from stealth or within 3s of stealth breaking.

### Motivation

Garrotes cast from stealth or within 3s of breaking stealth are good and I was saying they were bad. 😢 

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/2NJQ6xK9jbDtVkWq/40-Mythic+Terros+-+Kill+(5:55)/181-Whíspyr/standard`
- Screenshot(s):
![image](https://user-images.githubusercontent.com/1672786/215205146-367d9882-c122-4c25-9c52-ea8e582fe4b1.png)
