### PR TITLE
make Exsanguinate check Garrote and Rupture duration

### DIFF
--- a/src/analysis/retail/rogue/assassination/CHANGELOG.tsx
+++ b/src/analysis/retail/rogue/assassination/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS/rogue';
 import TALENTS from 'common/TALENTS/rogue';
 
 export default [
+  change(date(2023, 1, 28), <>Update <SpellLink id={TALENTS.EXSANGUINATE_TALENT} /> to check duration of <SpellLink id={SPELLS.GARROTE} /> and <SpellLink id={SPELLS.RUPTURE} />.</>, ToppleTheNun),
   change(date(2023, 1, 28), <>Add breakdown of <SpellLink id={TALENTS.EXSANGUINATE_TALENT} /> usage to Guide.</>, ToppleTheNun),
   change(date(2023, 1, 28), <>Add details for <SpellLink id={TALENTS.THISTLE_TEA_TALENT} /> usage to Guide.</>, ToppleTheNun),
   change(date(2023, 1, 27), <>Fix max duration calculation for <SpellLink id={SPELLS.RUPTURE} /> not respecting Animacharged.</>, ToppleTheNun),

--- a/src/analysis/retail/rogue/assassination/constants.tsx
+++ b/src/analysis/retail/rogue/assassination/constants.tsx
@@ -1,12 +1,13 @@
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/rogue';
-import { CastEvent } from 'parser/core/Events';
+import { AnyEvent, CastEvent } from 'parser/core/Events';
 import getResourceSpent from 'parser/core/getResourceSpent';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import Combatant from 'parser/core/Combatant';
 import Spell from 'common/SPELLS/Spell';
 import { ChecklistUsageInfo } from 'parser/core/SpellUsage/core';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import Fight from 'parser/core/Fight';
 
 // from https://www.wowhead.com/spell=137037/assassination-rogue
 export const ABILITIES_AFFECTED_BY_DAMAGE_INCREASES = [
@@ -159,3 +160,6 @@ export const animachargedCheckedUsageInfo = (
 };
 
 export const pandemicMaxDuration = (duration: number) => duration * 1.3;
+
+export const isInOpener = (event: AnyEvent, fight: Fight) =>
+  event.timestamp - fight.start_time <= OPENER_MAX_DURATION_MS;

--- a/src/analysis/retail/rogue/assassination/modules/core/FinisherUse.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/core/FinisherUse.tsx
@@ -13,6 +13,7 @@ import {
   FINISHERS,
   getMaxComboPoints,
   isAnimachargedFinisherCast,
+  isInOpener,
   OPENER_MAX_DURATION_MS,
 } from '../../constants';
 import { formatDurationMillisMinSec } from 'common/format';
@@ -101,14 +102,11 @@ export default class FinisherUse extends Analyzer {
       return;
     }
 
-    const timeIntoEncounter = event.timestamp - this.owner.fight.start_time;
-    const isInOpener = timeIntoEncounter <= OPENER_MAX_DURATION_MS;
-
     this.totalFinisherCasts += 1;
     if (isAnimachargedFinisherCast(this.selectedCombatant, event)) {
       this.animachargedCasts += 1;
     } else if (cpsSpent < getMaxComboPoints(this.selectedCombatant) - 1) {
-      if (isInOpener) {
+      if (isInOpener(event, this.owner.fight)) {
         this.openerLowCpFinisherCasts += 1;
       } else {
         this.lowCpFinisherCasts += 1;

--- a/src/analysis/retail/rogue/assassination/modules/spells/RuptureUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/spells/RuptureUptimeAndSnapshots.tsx
@@ -8,7 +8,7 @@ import {
   animachargedCheckedUsageInfo,
   getRuptureDuration,
   getRuptureFullDuration,
-  OPENER_MAX_DURATION_MS,
+  isInOpener,
   RUPTURE_BASE_DURATION,
   SNAPSHOT_DOWNGRADE_BUFFER,
 } from 'analysis/retail/rogue/assassination/constants';
@@ -75,8 +75,6 @@ export default class RuptureUptimeAndSnapshots extends DotSnapshots {
     const wasUnacceptableDowngrade =
       prevPower > power && remainingOnPrev > SNAPSHOT_DOWNGRADE_BUFFER;
     const wasUpgrade = prevPower < power;
-    const timeIntoEncounter = cast.timestamp - this.owner.fight.start_time;
-    const isInOpener = timeIntoEncounter <= OPENER_MAX_DURATION_MS;
 
     let snapshotPerformance: QualitativePerformance = QualitativePerformance.Good;
     let snapshotSummary = <div>Good snapshot usage</div>;
@@ -92,7 +90,7 @@ export default class RuptureUptimeAndSnapshots extends DotSnapshots {
       );
     }
     if (clipped > 0) {
-      if (isInOpener) {
+      if (isInOpener(cast, this.owner.fight)) {
         snapshotPerformance = QualitativePerformance.Ok;
         snapshotSummary = <div>Clipped but upgraded existing snapshotted Rupture</div>;
         snapshotDetails = (

--- a/src/analysis/retail/rogue/assassination/modules/talents/ThistleTea.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/talents/ThistleTea.tsx
@@ -5,7 +5,7 @@ import { SpellUse, spellUseToBoxRowEntry } from 'parser/core/SpellUsage/core';
 import Events, { CastEvent } from 'parser/core/Events';
 import { getResourceChange } from 'analysis/retail/rogue/shared/talents/ThistleTeaCastLinkNormalizer';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
-import { OPENER_MAX_DURATION_MS } from 'analysis/retail/rogue/assassination/constants';
+import { isInOpener } from 'analysis/retail/rogue/assassination/constants';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import ResourceLink from 'interface/ResourceLink';
 import SpellLink from 'interface/SpellLink';
@@ -87,9 +87,6 @@ export default class ThistleTea extends Analyzer {
       return; // we didn't get energy from the cast
     }
 
-    const timeIntoEncounter = event.timestamp - this.owner.fight.start_time;
-    const isInOpener = timeIntoEncounter <= OPENER_MAX_DURATION_MS;
-
     const wasted = resourceChange.waste;
     const gained = resourceChange.resourceChange - resourceChange.waste;
 
@@ -105,7 +102,7 @@ export default class ThistleTea extends Analyzer {
       </div>
     );
     if (wasted > 0) {
-      if (isInOpener) {
+      if (isInOpener(event, this.owner.fight)) {
         performance = QualitativePerformance.Ok;
         details = (
           <div>


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Make Exsanguinate check Garrote and Rupture durations for performance reporting.

### Motivation

<!-- Why are you submitting this pull request?-->

Whispyr wanted more detail on the check.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/RbPVKrmfA26pTq4F/6-Mythic+Terros+-+Kill+(5:19)/13-Ceverion/standard`
- Screenshot(s): 
![image](https://user-images.githubusercontent.com/1672786/215298277-208f12e8-0dfc-46cc-ac71-168709f013f9.png)

