### PR TITLE
fix reference to Fury in Guide

### DIFF
--- a/src/analysis/retail/rogue/assassination/CHANGELOG.tsx
+++ b/src/analysis/retail/rogue/assassination/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS/rogue';
 import TALENTS from 'common/TALENTS/rogue';
 
 export default [
+  change(date(2023, 1, 28), 'Fix reference to Fury in Guide.', ToppleTheNun),
   change(date(2023, 1, 28), <>Update <SpellLink id={TALENTS.EXSANGUINATE_TALENT} /> to check duration of <SpellLink id={SPELLS.GARROTE} /> and <SpellLink id={SPELLS.RUPTURE} />.</>, ToppleTheNun),
   change(date(2023, 1, 28), <>Add breakdown of <SpellLink id={TALENTS.EXSANGUINATE_TALENT} /> usage to Guide.</>, ToppleTheNun),
   change(date(2023, 1, 28), <>Add details for <SpellLink id={TALENTS.THISTLE_TEA_TALENT} /> usage to Guide.</>, ToppleTheNun),

--- a/src/analysis/retail/rogue/shared/guide/EnergyCapWaste.tsx
+++ b/src/analysis/retail/rogue/shared/guide/EnergyCapWaste.tsx
@@ -47,7 +47,7 @@ const EnergyCapWaste = ({
   return (
     <p>
       <Trans id="guide.rogue.sections.resources.energy.chart">
-        The chart below shows your Fury over the course of the encounter. You spent{' '}
+        The chart below shows your Energy over the course of the encounter. You spent{' '}
         <PerformancePercentage
           performance={performance}
           perfectPercentage={perfectTimeAtCap}


### PR DESCRIPTION
### Description

Rogues use Energy, not Fury.

### Motivation

Rogues use Energy, not Fury.
