### PR TITLE
[Balance] bugfix to Incarn et CA tracking

### DIFF
--- a/src/analysis/retail/druid/balance/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/balance/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Hartra344, Sref, ToppleTheNun, ap2355 } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 1, 27), <>Corrected <SpellLink id={TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT} /> and <SpellLink id={TALENTS_DRUID.CELESTIAL_ALIGNMENT_TALENT} /> tracking and cooldown if <SpellLink id={TALENTS_DRUID.ORBITAL_STRIKE_TALENT} /> is talented </>, ap2355 ),
   change(date(2023, 1, 27), <>Adjusted filler suggestions to better align with Dragonflight recommendations</>, Hartra344 ),
   change(date(2023, 1, 27), <>Added statistics support for <SpellLink id={TALENTS_DRUID.FRIEND_OF_THE_FAE_TALENT} /></>, ap2355 ),
   change(date(2023, 1, 24), <>Added statistics support for <SpellLink id={SPELLS.TOUCH_THE_COSMOS} /></>, ap2355 ),

--- a/src/analysis/retail/druid/balance/modules/Abilities.tsx
+++ b/src/analysis/retail/druid/balance/modules/Abilities.tsx
@@ -73,10 +73,10 @@ class Abilities extends CoreAbilities {
 
       // Cooldowns
       {
-        spell: TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT.id,
-        buffSpellId: TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT.id,
+        spell: SPELLS.INCARNATION_CHOSEN_OF_ELUNE.id,
+        buffSpellId: SPELLS.INCARNATION_CHOSEN_OF_ELUNE.id,
         category: SPELL_CATEGORY.COOLDOWNS,
-        cooldown: 180,
+        cooldown: combatant.hasTalent(TALENTS_DRUID.ORBITAL_STRIKE_TALENT) ? 120 : 180,
         enabled: combatant.hasTalent(TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT),
         castEfficiency: {
           suggestion: true,
@@ -88,8 +88,10 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.CELESTIAL_ALIGNMENT.id,
         buffSpellId: SPELLS.CELESTIAL_ALIGNMENT.id,
         category: SPELL_CATEGORY.COOLDOWNS,
-        cooldown: 180,
-        enabled: !combatant.hasTalent(TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT),
+        cooldown: combatant.hasTalent(TALENTS_DRUID.ORBITAL_STRIKE_TALENT) ? 120 : 180,
+        enabled:
+          combatant.hasTalent(TALENTS_DRUID.CELESTIAL_ALIGNMENT_TALENT) &&
+          !combatant.hasTalent(TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT),
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.8,

--- a/src/analysis/retail/druid/balance/modules/checklist/Component.tsx
+++ b/src/analysis/retail/druid/balance/modules/checklist/Component.tsx
@@ -159,6 +159,13 @@ const BalanceDruidChecklist = ({ combatant, castEfficiency, thresholds }: any) =
       ) : (
         <AbilityRequirement spell={SPELLS.CELESTIAL_ALIGNMENT.id} />
       )}
+      {combatant.hasTalent(TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT) && (
+        <AbilityRequirement spell={TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT.id} />
+      )}
+      {!combatant.hasTalent(TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT) &&
+        combatant.hasTalent(TALENTS_DRUID.CELESTIAL_ALIGNMENT_TALENT) && (
+          <AbilityRequirement spell={SPELLS.CELESTIAL_ALIGNMENT.id} />
+        )}
       {combatant.hasTalent(TALENTS_DRUID.CONVOKE_THE_SPIRITS_TALENT) && (
         <AbilityRequirement spell={SPELLS.CONVOKE_SPIRITS.id} />
       )}


### PR DESCRIPTION
### Description
Since DF release, Incarn wasn't tracked correctly because of the changes in the talent tree.
Also change the cooldown of Incarn and CA if Orbital Strikes is talented.

### Testing

- Test report URL: report/z3BJ1DkRrqp6y4j8/30-Mythic+Sennarth,+The+Cold+Breath+-+Kill+(6:53)/Idraly/standard/statistics
- Screenshot(s):
-
![image](https://user-images.githubusercontent.com/116091849/215846868-3e6e724c-0f63-4daf-974c-216a1fcae8a8.png)

