### PR TITLE
fix lifebind event linking

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 2, 1), <>Refactor event linking for <SpellLink id={TALENTS_EVOKER.LIFEBIND_TALENT}/></>, Trevor),
   change(date(2023, 1, 30), <>Fix mana cost for <SpellLink id={TALENTS_EVOKER.ECHO_TALENT}/></>, Trevor),
   change(date(2023, 1, 29), <>Fix <SpellLink id={TALENTS_EVOKER.SPARK_OF_INSIGHT_TALENT}/> module</>, Trevor),
   change(date(2023, 1, 29), <>Fix degraded experience</>, Trevor),

--- a/src/analysis/retail/evoker/preservation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/preservation/CombatLogParser.ts
@@ -38,6 +38,7 @@ import AlwaysBeCasting from './modules/core/AlwaysBeCasting';
 import FontOfMagic from './modules/talents/FontOfMagic';
 import EmeraldCommunion from './modules/talents/EmeraldCommunion';
 import SparkOfInsight from './modules/talents/SparkOfInsight';
+import LifebindNormalizer from './normalizers/LifebindNormalizer';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -45,6 +46,7 @@ class CombatLogParser extends CoreCombatLogParser {
     abilities: Abilities,
 
     // Normalizer
+    lifebindNormalizer: LifebindNormalizer,
     castLinkNormalizer: CastLinkNormalizer,
     hotApplicationNormalizer: HotApplicationNormalizer,
     hotRemovalNormalizer: HotRemovalNormalizer,

--- a/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
@@ -486,43 +486,48 @@ const EVENT_LINKS: EventLink[] = [
   },
   {
     linkRelation: LIFEBIND,
-    linkingEventId: SPELLS.LIFEBIND_HEAL.id,
-    linkingEventType: EventType.Heal,
-    referencedEventId: SPELLS.LIFEBIND_BUFF.id,
-    referencedEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
-    backwardBufferMs: LIFEBIND_BUFFER,
+    reverseLinkRelation: LIFEBIND,
+    linkingEventId: SPELLS.LIFEBIND_BUFF.id,
+    linkingEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+    referencedEventId: SPELLS.LIFEBIND_HEAL.id,
+    referencedEventType: EventType.Heal,
+    forwardBufferMs: LIFEBIND_BUFFER,
   },
   {
     linkRelation: LIFEBIND_APPLY,
     reverseLinkRelation: LIFEBIND_APPLY,
-    linkingEventId: SPELLS.LIFEBIND_BUFF.id,
-    linkingEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
-    referencedEventId: SPELLS.VERDANT_EMBRACE_HEAL.id,
-    referencedEventType: EventType.Heal,
-    backwardBufferMs: CAST_BUFFER_MS,
+    linkingEventId: SPELLS.VERDANT_EMBRACE_HEAL.id,
+    linkingEventType: EventType.Heal,
+    referencedEventId: SPELLS.LIFEBIND_BUFF.id,
+    referencedEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
     forwardBufferMs: CAST_BUFFER_MS,
     anyTarget: true,
     additionalCondition(linkingEvent, referencedEvent) {
       // ve applies lifebind to player and target but there is no ve heal on player
-      const applyEvent = linkingEvent as ApplyBuffEvent;
+      const applyEvent = referencedEvent as ApplyBuffEvent;
       return (
-        applyEvent.targetID === (referencedEvent as HealEvent).targetID ||
+        applyEvent.targetID === (linkingEvent as HealEvent).targetID ||
         applyEvent.targetID === applyEvent.sourceID
       );
     },
   },
   {
     linkRelation: LIFEBIND_HEAL,
-    linkingEventId: SPELLS.LIFEBIND_HEAL.id,
+    reverseLinkRelation: LIFEBIND_HEAL,
+    linkingEventId: DUPLICATION_SPELLS,
     linkingEventType: EventType.Heal,
-    referencedEventId: DUPLICATION_SPELLS,
+    referencedEventId: SPELLS.LIFEBIND_HEAL.id,
     referencedEventType: EventType.Heal,
     anyTarget: true,
-    maximumLinks: 1,
-    backwardBufferMs: 50,
-    forwardBufferMs: 50,
+    forwardBufferMs: 150,
     additionalCondition(linkingEvent, referencedEvent) {
-      return HasRelatedEvent(linkingEvent, LIFEBIND); // make sure the heal is on someone with lifebind buff
+      const linkHeal = linkingEvent as HealEvent;
+      const refHeal = referencedEvent as HealEvent;
+      return (
+        !_hasLifebindEventForTarget(linkHeal, refHeal.targetID) &&
+        HasRelatedEvent(referencedEvent, LIFEBIND) &&
+        !HasRelatedEvent(referencedEvent, LIFEBIND_HEAL)
+      ); // make sure the heal is on someone with lifebind buff
     },
   },
   {
@@ -561,6 +566,13 @@ class CastLinkNormalizer extends EventLinkNormalizer {
   constructor(options: Options) {
     super(options, EVENT_LINKS);
   }
+}
+
+function _hasLifebindEventForTarget(event: HealEvent, targetID: number): boolean {
+  const lifebindEvents = GetRelatedEvents(event, LIFEBIND_HEAL);
+  return lifebindEvents.some((ev) => {
+    return (ev as HealEvent).targetID === targetID;
+  });
 }
 
 /** Returns true iff the given buff application or heal can be matched back to a hardcast */

--- a/src/analysis/retail/evoker/preservation/normalizers/LifebindNormalizer.tsx
+++ b/src/analysis/retail/evoker/preservation/normalizers/LifebindNormalizer.tsx
@@ -23,7 +23,7 @@ const EVENT_ORDERS: EventOrder[] = [
 ];
 
 /**
- * Occasionally HoT heal has same timestamp but happens before the applybuff event, which causes issues when attempting to attribute the heal.
+ * Occasionally Lifebind heal has same timestamp but happens before the applybuff event, which causes issues when attempting to attribute the heal.
  * This normalizes the heal to always be after the applybuff
  */
 class LifebindNormalizer extends EventOrderNormalizer {

--- a/src/analysis/retail/evoker/preservation/normalizers/LifebindNormalizer.tsx
+++ b/src/analysis/retail/evoker/preservation/normalizers/LifebindNormalizer.tsx
@@ -1,0 +1,35 @@
+import SPELLS from 'common/SPELLS';
+import EventOrderNormalizer, { EventOrder } from 'parser/core/EventOrderNormalizer';
+import { EventType } from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+
+const MAX_DELAY = 50;
+
+const EVENT_ORDERS: EventOrder[] = [
+  {
+    beforeEventId: SPELLS.LIFEBIND_BUFF.id,
+    beforeEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+    afterEventId: SPELLS.LIFEBIND_HEAL.id,
+    afterEventType: EventType.Heal,
+    bufferMs: MAX_DELAY,
+  },
+  {
+    beforeEventId: SPELLS.VERDANT_EMBRACE_HEAL.id,
+    beforeEventType: EventType.Heal,
+    afterEventId: SPELLS.LIFEBIND_BUFF.id,
+    afterEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+    bufferMs: MAX_DELAY,
+  },
+];
+
+/**
+ * Occasionally HoT heal has same timestamp but happens before the applybuff event, which causes issues when attempting to attribute the heal.
+ * This normalizes the heal to always be after the applybuff
+ */
+class LifebindNormalizer extends EventOrderNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_ORDERS);
+  }
+}
+
+export default LifebindNormalizer;


### PR DESCRIPTION
Lifebind linking was broken due to event ordering and subpar linking, this diff refactors it to be more consistent. It still has some inaccuracies, with latency in broodkeeper's promise events, but its less than 20k unattributed healing per log, so not going to try to fix it.

Before:
![image](https://user-images.githubusercontent.com/11250934/216236584-f1c21309-8675-4673-9e0f-18b1b3c0a5e3.png)

After:
![image](https://user-images.githubusercontent.com/11250934/216236547-9e0dd66e-c420-4933-a0ac-145111585249.png)
