### PR TITLE
improve Envenom phrasing and Animacharged

### DIFF
--- a/src/analysis/retail/rogue/assassination/CHANGELOG.tsx
+++ b/src/analysis/retail/rogue/assassination/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS/rogue';
 import TALENTS from 'common/TALENTS/rogue';
 
 export default [
+  change(date(2023, 2, 3), <>Fix some bugs related to log ordering/latency with <SpellLink id={SPELLS.ENVENOM} />.</>, ToppleTheNun),
   change(date(2023, 1, 28), 'Fix reference to Fury in Guide.', ToppleTheNun),
   change(date(2023, 1, 28), <>Update <SpellLink id={TALENTS.EXSANGUINATE_TALENT} /> to check duration of <SpellLink id={SPELLS.GARROTE} /> and <SpellLink id={SPELLS.RUPTURE} />.</>, ToppleTheNun),
   change(date(2023, 1, 28), <>Add breakdown of <SpellLink id={TALENTS.EXSANGUINATE_TALENT} /> usage to Guide.</>, ToppleTheNun),

--- a/src/analysis/retail/rogue/assassination/constants.tsx
+++ b/src/analysis/retail/rogue/assassination/constants.tsx
@@ -119,11 +119,26 @@ export const FINISHERS: Spell[] = [
   SPELLS.KIDNEY_SHOT,
 ];
 
+// Adjust for possible log latency
+const ANIMACHARGED_FINISHER_BUFFER = 200;
+
 export const isAnimachargedFinisherCast = (c: Combatant, event: CastEvent): boolean => {
   const cpsSpent = getResourceSpent(event, RESOURCE_TYPES.COMBO_POINTS);
-  const hasAnimacharged2CP = c.hasBuff(SPELLS.ANIMACHARGED_CP2.id, event.timestamp);
-  const hasAnimacharged3CP = c.hasBuff(SPELLS.ANIMACHARGED_CP3.id, event.timestamp);
-  const hasAnimacharged4CP = c.hasBuff(SPELLS.ANIMACHARGED_CP4.id, event.timestamp);
+  const hasAnimacharged2CP = c.hasBuff(
+    SPELLS.ANIMACHARGED_CP2.id,
+    event.timestamp,
+    ANIMACHARGED_FINISHER_BUFFER,
+  );
+  const hasAnimacharged3CP = c.hasBuff(
+    SPELLS.ANIMACHARGED_CP3.id,
+    event.timestamp,
+    ANIMACHARGED_FINISHER_BUFFER,
+  );
+  const hasAnimacharged4CP = c.hasBuff(
+    SPELLS.ANIMACHARGED_CP4.id,
+    event.timestamp,
+    ANIMACHARGED_FINISHER_BUFFER,
+  );
 
   if (cpsSpent === 2 && hasAnimacharged2CP) {
     return true;

--- a/src/analysis/retail/rogue/assassination/modules/spells/Envenom.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/spells/Envenom.tsx
@@ -97,13 +97,23 @@ export default class Envenom extends Analyzer {
           {formatDurationMillisMinSec(timeLeftOnRupture)} left on <SpellLink id={SPELLS.RUPTURE} />.
         </div>
       );
-    } else if (timeLeftOnRupture > 0) {
+    } else if (timeLeftOnRupture > 1000) {
       ruptureDetails = (
         <div>
           You cast <SpellLink id={SPELLS.ENVENOM} /> with{' '}
           {formatDurationMillisMinSec(timeLeftOnRupture)} left on <SpellLink id={SPELLS.RUPTURE} />.
           Try not to cast <SpellLink id={SPELLS.ENVENOM} /> with less than{' '}
           {formatDurationMillisMinSec(MIN_ACCEPTABLE_TIME_LEFT_ON_RUPTURE_MS)} left on{' '}
+          <SpellLink id={SPELLS.RUPTURE} />, as it may cause you to miss pandemic-ing{' '}
+          <SpellLink id={SPELLS.RUPTURE} />.
+        </div>
+      );
+    } else if (timeLeftOnRupture > 0) {
+      ruptureDetails = (
+        <div>
+          You cast <SpellLink id={SPELLS.ENVENOM} /> with less than 1s left on{' '}
+          <SpellLink id={SPELLS.RUPTURE} />. Try not to cast <SpellLink id={SPELLS.ENVENOM} /> with
+          less than {formatDurationMillisMinSec(MIN_ACCEPTABLE_TIME_LEFT_ON_RUPTURE_MS)} left on{' '}
           <SpellLink id={SPELLS.RUPTURE} />, as it may cause you to miss pandemic-ing{' '}
           <SpellLink id={SPELLS.RUPTURE} />.
         </div>


### PR DESCRIPTION
### Description

Animacharged buffs can have a buffer early or late of around 200ms when casting a finisher.

### Motivation

Animacharged finishers were being reported as not animacharged.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/CBdbh3Wcx9XF1Gj7/2-4+Eranog/Viggyy/standard`
- Screenshot(s):
![image](https://user-images.githubusercontent.com/1672786/216691038-944b8868-bc29-4fb8-bd6e-9a7c256c1e4f.png)
![image](https://user-images.githubusercontent.com/1672786/216691071-3d5a6516-78e2-49a0-92a2-846ceace2db0.png)
