### PR TITLE
[Balance] Sundered Firmament

### DIFF
--- a/src/analysis/retail/druid/balance/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/balance/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Hartra344, Sref, ToppleTheNun, ap2355 } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 2, 6), <>Added statistics support for <SpellLink id={TALENTS_DRUID.SUNDERED_FIRMAMENT_TALENT} /></>, ap2355 ),
   change(date(2023, 1, 27), <>Corrected <SpellLink id={TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT} /> and <SpellLink id={TALENTS_DRUID.CELESTIAL_ALIGNMENT_TALENT} /> tracking and cooldown if <SpellLink id={TALENTS_DRUID.ORBITAL_STRIKE_TALENT} /> is talented </>, ap2355 ),
   change(date(2023, 1, 27), <>Adjusted filler suggestions to better align with Dragonflight recommendations</>, Hartra344 ),
   change(date(2023, 1, 27), <>Added statistics support for <SpellLink id={TALENTS_DRUID.FRIEND_OF_THE_FAE_TALENT} /></>, ap2355 ),

--- a/src/analysis/retail/druid/balance/CombatLogParser.ts
+++ b/src/analysis/retail/druid/balance/CombatLogParser.ts
@@ -30,6 +30,7 @@ import RattleTheStars from './modules/spells/RattleTheStars';
 import TouchTheCosmos from './modules/spells/TouchTheCosmos';
 import Starweaver from './modules/spells/Starweaver';
 import FriendOfTheFae from './modules/spells/FriendOfTheFae';
+import SunderedFirmament from './modules/spells/SunderedFirmament';
 
 class CombatLogParser extends MainCombatLogParser {
   static specModules = {
@@ -66,6 +67,7 @@ class CombatLogParser extends MainCombatLogParser {
     rattleTheStars: RattleTheStars,
     starweaver: Starweaver,
     firendOfTheFae: FriendOfTheFae,
+    sunderedFirmament: SunderedFirmament,
     //Tier set
     gatheringStarstuff: GatheringStarstuff,
     touchTheCosmos: TouchTheCosmos,

--- a/src/analysis/retail/druid/balance/Guide.tsx
+++ b/src/analysis/retail/druid/balance/Guide.tsx
@@ -4,7 +4,6 @@ import { SpellLink } from 'interface';
 import { TALENTS_DRUID } from 'common/TALENTS';
 import { formatPercentage } from 'common/format';
 import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
-import { cooldownAbility } from 'analysis/retail/druid/balance/constants';
 import { GapHighlight } from 'parser/ui/CooldownBar';
 import SPELLS from 'common/SPELLS';
 
@@ -98,9 +97,17 @@ function CooldownGraphSubsection({ modules, events, info }: GuideProps<typeof Co
       you waited to use them again. Grey segments show when the spell was available, yellow segments
       show when the spell was cooling down. Red segments highlight times when you could have fit a
       whole extra use of the cooldown.
-      {info.combatant.hasTalent(TALENTS_DRUID.CELESTIAL_ALIGNMENT_TALENT) && (
+      {info.combatant.hasTalent(TALENTS_DRUID.CELESTIAL_ALIGNMENT_TALENT) &&
+        !info.combatant.hasTalent(TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT) && (
+          <CastEfficiencyBar
+            spellId={SPELLS.CELESTIAL_ALIGNMENT.id}
+            gapHighlightMode={GapHighlight.FullCooldown}
+            useThresholds
+          />
+        )}
+      {info.combatant.hasTalent(TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT) && (
         <CastEfficiencyBar
-          spellId={cooldownAbility(info.combatant).id}
+          spellId={SPELLS.INCARNATION_CHOSEN_OF_ELUNE.id}
           gapHighlightMode={GapHighlight.FullCooldown}
           useThresholds
         />

--- a/src/analysis/retail/druid/balance/constants.ts
+++ b/src/analysis/retail/druid/balance/constants.ts
@@ -1,4 +1,7 @@
 import SPELLS from 'common/SPELLS';
+import Spell from 'common/SPELLS/Spell';
+import Combatant from 'parser/core/Combatant';
+import { TALENTS_DRUID } from 'common/TALENTS';
 
 export const DAMAGING_ABILITIES = [
   SPELLS.STARSURGE_MOONKIN.id,
@@ -15,6 +18,13 @@ export const DAMAGING_ABILITIES = [
 
 // Celestial Alignment or Incarnation buff
 export const CA_BUFF = [SPELLS.CELESTIAL_ALIGNMENT, SPELLS.INCARNATION_CHOSEN_OF_ELUNE];
+
+// Need to fix this for DF -> you might take neither CA nor Incarn
+export function cooldownAbility(combatant: Combatant): Spell {
+  return combatant.hasTalent(TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT)
+    ? TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT
+    : SPELLS.CELESTIAL_ALIGNMENT;
+}
 
 export const GUIDE_CORE_EXPLANATION_PERCENT = 40;
 export const STARSURGE_ELUNES_GUIDANCE_DISCOUNT = 5;

--- a/src/analysis/retail/druid/balance/constants.ts
+++ b/src/analysis/retail/druid/balance/constants.ts
@@ -1,7 +1,4 @@
 import SPELLS from 'common/SPELLS';
-import Spell from 'common/SPELLS/Spell';
-import Combatant from 'parser/core/Combatant';
-import { TALENTS_DRUID } from 'common/TALENTS';
 
 export const DAMAGING_ABILITIES = [
   SPELLS.STARSURGE_MOONKIN.id,
@@ -16,14 +13,8 @@ export const DAMAGING_ABILITIES = [
   SPELLS.HALF_MOON.id,
 ];
 
-// Celestial Alignment buff or the talented version of it (Incarnation)
+// Celestial Alignment or Incarnation buff
 export const CA_BUFF = [SPELLS.CELESTIAL_ALIGNMENT, SPELLS.INCARNATION_CHOSEN_OF_ELUNE];
-
-export function cooldownAbility(combatant: Combatant): Spell {
-  return combatant.hasTalent(TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT)
-    ? TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT
-    : SPELLS.CELESTIAL_ALIGNMENT;
-}
 
 export const GUIDE_CORE_EXPLANATION_PERCENT = 40;
 export const STARSURGE_ELUNES_GUIDANCE_DISCOUNT = 5;

--- a/src/analysis/retail/druid/balance/modules/checklist/Component.tsx
+++ b/src/analysis/retail/druid/balance/modules/checklist/Component.tsx
@@ -154,13 +154,8 @@ const BalanceDruidChecklist = ({ combatant, castEfficiency, thresholds }: any) =
         frequently as possible throughout a fight. A cooldown should be held on to only if a priority
         DPS phase is coming soon. Holding cooldowns too long will hurt your DPS."
     >
-      {combatant.hasTalent(TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT) ? (
-        <AbilityRequirement spell={TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT.id} />
-      ) : (
-        <AbilityRequirement spell={SPELLS.CELESTIAL_ALIGNMENT.id} />
-      )}
       {combatant.hasTalent(TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT) && (
-        <AbilityRequirement spell={TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT.id} />
+        <AbilityRequirement spell={SPELLS.INCARNATION_CHOSEN_OF_ELUNE.id} />
       )}
       {!combatant.hasTalent(TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT) &&
         combatant.hasTalent(TALENTS_DRUID.CELESTIAL_ALIGNMENT_TALENT) && (

--- a/src/analysis/retail/druid/balance/modules/core/Buffs.tsx
+++ b/src/analysis/retail/druid/balance/modules/core/Buffs.tsx
@@ -1,7 +1,6 @@
 import SPELLS from 'common/SPELLS';
 import BLOODLUST_BUFFS from 'game/BLOODLUST_BUFFS';
 import CoreAuras from 'parser/core/modules/Auras';
-import { TALENTS_DRUID } from 'common/TALENTS';
 
 class Buffs extends CoreAuras {
   auras() {
@@ -13,7 +12,7 @@ class Buffs extends CoreAuras {
         timelineHighlight: true,
       },
       {
-        spellId: TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT.id,
+        spellId: SPELLS.INCARNATION_CHOSEN_OF_ELUNE.id,
         timelineHighlight: true,
       },
       {

--- a/src/analysis/retail/druid/balance/modules/spells/Starweaver.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/Starweaver.tsx
@@ -73,7 +73,7 @@ class Starweaver extends Analyzer {
       >
         <BoringSpellValueText spellId={TALENTS_DRUID.STARWEAVER_TALENT.id}>
           <>
-            {formatNumber(this.savedAP)} <small> free Astral Power </small>
+            {formatNumber(this.savedAP)} <small> Astral Power accounted in Pulsar </small>
           </>
         </BoringSpellValueText>
       </Statistic>

--- a/src/analysis/retail/druid/balance/modules/spells/SunderedFirmament.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/SunderedFirmament.tsx
@@ -1,0 +1,61 @@
+import { formatNumber } from 'common/format';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { TALENTS_DRUID } from 'common/TALENTS';
+import ItemPercentDamageDone from 'parser/ui/ItemPercentDamageDone';
+import SPELLS from 'common/SPELLS';
+
+const AP_PER_PROC = 8;
+const AP_PER_TICK = 0.5;
+
+class SunderedFirmament extends Analyzer {
+  totalDamage = 0;
+  gainedAP = 0;
+  totalEffectiveAP = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.SUNDERED_FIRMAMENT_TALENT);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDamage);
+    this.addEventListener(Events.resourcechange.by(SELECTED_PLAYER), this.onEnergize);
+  }
+
+  onDamage(event: DamageEvent) {
+    if (event.ability.guid === SPELLS.FURY_OF_ELUNE_DAMAGE_SUNDERED_FIRMAMENT.id) {
+      this.totalDamage += event.amount;
+    }
+  }
+
+  onEnergize(event: ResourceChangeEvent) {
+    if (event.ability.guid === SPELLS.SUNDERED_FIRMAMENT_RESOURCE.id) {
+      this.gainedAP += AP_PER_TICK;
+    }
+  }
+
+  statistic() {
+    const dpsIncrease = formatNumber(this.totalDamage / (this.owner.fightDuration / 1000));
+    const proc = Math.ceil(this.gainedAP / AP_PER_PROC);
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE(14)}
+        size="flexible"
+        tooltip={`You had ${formatNumber(
+          proc,
+        )} procs of this talent which added ${dpsIncrease} to your DPS.`}
+      >
+        <BoringSpellValueText spellId={TALENTS_DRUID.SUNDERED_FIRMAMENT_TALENT.id}>
+          <>
+            <ItemPercentDamageDone greaterThan amount={this.totalDamage} />
+            <br />
+            {formatNumber(this.gainedAP)} <small>additional Astral Power generated</small>
+          </>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default SunderedFirmament;

--- a/src/analysis/retail/druid/balance/modules/spells/TouchTheCosmos.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/TouchTheCosmos.tsx
@@ -72,8 +72,7 @@ class TouchTheCosmos extends Analyzer {
       >
         <BoringSpellValueText spellId={SPELLS.TOUCH_THE_COSMOS.id}>
           <>
-            {formatNumber(this.savedAP)}{' '}
-            <small> Astral Power Saved (accounted toward Pulsar) </small>
+            {formatNumber(this.savedAP)} <small>Astral Power accounted in Pulsar</small>
           </>
         </BoringSpellValueText>
       </Statistic>

--- a/src/analysis/retail/druid/shared/spells/AdaptiveSwarm.ts
+++ b/src/analysis/retail/druid/shared/spells/AdaptiveSwarm.ts
@@ -61,7 +61,7 @@ const PERIODIC_DAMAGE: SpellInfo[] = [
   TALENTS.FERAL_FRENZY_TALENT,
   SPELLS.FERAL_FRENZY_DEBUFF,
   TALENTS.PRIMAL_WRATH_TALENT,
-  SPELLS.FURY_OF_ELUNE_DAMAGE_4P,
+  SPELLS.FURY_OF_ELUNE_DAMAGE_SUNDERED_FIRMAMENT,
   // deliberately doesn't include Adaptive Swarm itself to avoid double count
 ];
 

--- a/src/common/SPELLS/druid.ts
+++ b/src/common/SPELLS/druid.ts
@@ -791,11 +791,17 @@ const spells = spellIndexableList({
     name: 'Fury of Elune',
     icon: 'ability_druid_dreamstate',
   },
-  FURY_OF_ELUNE_DAMAGE_4P: {
-    // damage from Fury of Elune procced by the Shadowlands tier 4p
-    id: 365640,
-    name: 'Fury of Elune',
+  FURY_OF_ELUNE_DAMAGE_SUNDERED_FIRMAMENT: {
+    // damage from Fury of Elune procced by the talent Sundered Firmament
+    id: 394111,
+    name: 'Fury of Elune - Sundered Firmament',
     icon: 'ability_druid_dreamstate',
+  },
+  SUNDERED_FIRMAMENT_RESOURCE: {
+    // AP generated from Fury of Elune procced by the talent Sundered Firmament
+    id: 394108,
+    name: 'Sundered Firmament',
+    icon: 'spell_druid_equinox',
   },
   WANING_TWILIGHT: {
     // Debuff on enemy when druid has waning twilight talent and 3 periodic effects on enemy.


### PR DESCRIPTION
### Description

Add an analysis module for Sundered Firmament Talent.
Fix an issue for the cooldown tracking in the Guide section caused by my previous work.

### Testing

- Test report URL: /report/z3BJ1DkRrqp6y4j8/30-Mythic+Sennarth,+The+Cold+Breath+-+Kill+(6:53)/Idraly/standard/statistics
- Screenshot(s): 
![image](https://user-images.githubusercontent.com/116091849/217114420-5961d044-c6a4-4bfb-a4a3-15f0233ce8e4.png)

