### PR TITLE
fix Emerald Communion breaking

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_EVOKER } from 'common/TALENTS';
-import { Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
+import { ToppleTheNun, Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 2, 9), <>Fix <SpellLink id={TALENTS_EVOKER.EMERALD_COMMUNION_TALENT}/> analysis breaking.</>, ToppleTheNun),
   change(date(2023, 2, 3), <>Change <SpellLink id={TALENTS_EVOKER.EMERALD_COMMUNION_TALENT}/> module to only count missing <SpellLink id={TALENTS_EVOKER.LIFEBIND_TALENT}/> on targets you have healed recently</>, Trevor),
   change(date(2023, 1, 30), <>Fix mana cost for <SpellLink id={TALENTS_EVOKER.ECHO_TALENT}/></>, Trevor),
   change(date(2023, 1, 29), <>Fix <SpellLink id={TALENTS_EVOKER.SPARK_OF_INSIGHT_TALENT}/> module</>, Trevor),

--- a/src/analysis/retail/evoker/preservation/modules/talents/EmeraldCommunion.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/EmeraldCommunion.tsx
@@ -59,7 +59,7 @@ class EmeraldCommunion extends Analyzer {
     return (
       this.percentCovered.reduce((prev, cur) => {
         return cur + prev;
-      }) / this.percentCovered.length
+      }, 0) / this.percentCovered.length
     );
   }
 


### PR DESCRIPTION
### Description

add initial value to `reduce` invocation in Emerald Communion analysis.

### Motivation

no default value for the `reduce` invocation caused it to fail when the array was empty.

![image](https://user-images.githubusercontent.com/1672786/217935448-d23e74c8-c0ba-4750-a627-cfaa63a0c436.png)

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/ZvcTXDrHmJNb7dn2/3-Normal+Terros+-+Kill+(5:04)/Rainson/standard`
- Screenshot(s):
![image](https://user-images.githubusercontent.com/1672786/217935582-36e3599c-e547-4bb2-b625-4f4fc098ac8f.png)
