### PR TITLE
[Frost Mage] 10.0.5 Support and Rune of Power Fix

### DIFF
--- a/src/analysis/retail/mage/arcane/CombatLogParser.ts
+++ b/src/analysis/retail/mage/arcane/CombatLogParser.ts
@@ -6,6 +6,7 @@ import {
   GroundingSurge,
   MirrorImage,
   RuneOfPower,
+  RuneOfPowerNormalizer,
   ShiftingPower,
   TempestBarrier,
   MasterOfTime,
@@ -53,6 +54,7 @@ class CombatLogParser extends CoreCombatLogParser {
     arcaneChargesNormalizer: ArcaneChargesNormalizer,
     arcanePowerNormalizer: ArcanePowerNormalizer,
     castLinkNormalizer: CastLinkNormalizer,
+    runeOfPowerNormalizer: RuneOfPowerNormalizer,
 
     //Core
     checklist: Checklist,

--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 import { Sharrq } from 'CONTRIBUTORS';
 
 export default [
+	change(date(2023, 2, 12), <>Bumped support up to 10.0.5 and fixed an issue that could cause every <SpellLink id={TALENTS.RUNE_OF_POWER_TALENT} /> cast to count as overlapped.</>, Sharrq),
 	change(date(2023, 1, 14), `Added a link to Toegrinder's Mage Hub guide on the About page. Removed link to Icy Veins and Altered Time forums.`, Sharrq),
 	change(date(2023, 1, 14), `Upgraded Frost Mage support to 10.0.2 and marked as Supported. Also removed Dambroda from spec maintainers.`, Sharrq),
 	change(date(2023, 1, 14), `Reviewed all Suggestions, Tooltips, and Checklist items to ensure the wording is accurate for Dragonflight`, Sharrq),

--- a/src/analysis/retail/mage/frost/CONFIG.tsx
+++ b/src/analysis/retail/mage/frost/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Sharrq],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.2',
+  patchCompatibility: '10.0.5',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more. If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (

--- a/src/analysis/retail/mage/frost/CombatLogParser.ts
+++ b/src/analysis/retail/mage/frost/CombatLogParser.ts
@@ -6,6 +6,7 @@ import {
   GroundingSurge,
   MirrorImage,
   RuneOfPower,
+  RuneOfPowerNormalizer,
   ShiftingPower,
   TempestBarrier,
   MasterOfTime,
@@ -51,6 +52,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     //Normalizers
     cometStormLinkNormalizer: CometStormLinkNormalizer,
+    runeOfPowerNormalizer: RuneOfPowerNormalizer,
 
     //Core
     abilities: Abilities,

--- a/src/analysis/retail/mage/frost/talents/ColdFront.tsx
+++ b/src/analysis/retail/mage/frost/talents/ColdFront.tsx
@@ -41,7 +41,7 @@ class ColdFront extends Analyzer {
   statistic() {
     return (
       <Statistic
-        category={STATISTIC_CATEGORY.ITEMS}
+        category={STATISTIC_CATEGORY.TALENTS}
         size="flexible"
         tooltip="This shows the number of extra Frozen Orb casts that were gained by using the Cold Front legendary effect."
       >

--- a/src/analysis/retail/mage/frost/talents/IcyPropulsion.tsx
+++ b/src/analysis/retail/mage/frost/talents/IcyPropulsion.tsx
@@ -57,7 +57,7 @@ class IcyPropulsion extends Analyzer {
   statistic() {
     return (
       <Statistic
-        category={STATISTIC_CATEGORY.COVENANTS}
+        category={STATISTIC_CATEGORY.TALENTS}
         size="flexible"
         tooltip={
           <>


### PR DESCRIPTION
Bumped the supported version to 10.0.5 as nothing changed for Frost with that update. Also fixed an issue with Rune of Power that was causing every Rune of Power cast to get counted as overlapped.
