### PR TITLE
Add core parts of mistweaver guide

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 2, 12), <>Add guide prototype for Mistweaver</>, Trevor),
   change(date(2023, 2, 7), <>Updated spell values for Feb 7 tuning</>, Trevor),
   change(date(2023, 2, 1), <>Fixed UI bug with <SpellLink id={TALENTS_MONK.SHEILUNS_GIFT_TALENT.id}/> suggestion (again).</>, Trevor),
   change(date(2023, 2, 1), <><SpellLink id={TALENTS_MONK.SHAOHAOS_LESSONS_TALENT.id}/> formatting fix.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
+++ b/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
@@ -78,6 +78,7 @@ import SheilunsGift from './modules/spells/SheilunsGift';
 import MistWrap from './modules/spells/MistWrap';
 import ShaohaosLessons from './modules/spells/ShaohaosLessons';
 import VeilOfPride from './modules/spells/VeilOfPride';
+import Guide from './Guide';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -175,6 +176,7 @@ class CombatLogParser extends CoreCombatLogParser {
     hpmDetails: MistweaverHealingEfficiencyDetails,
     hpmTracker: HealingEfficiencyTracker,
   };
+  static guide = Guide;
 }
 
 export default CombatLogParser;

--- a/src/analysis/retail/monk/mistweaver/Guide.tsx
+++ b/src/analysis/retail/monk/mistweaver/Guide.tsx
@@ -4,6 +4,8 @@ import { GuideProps, Section, SubSection } from 'interface/guide';
 import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
 import SPELLS from 'common/SPELLS';
 import CombatLogParser from '../mistweaver/CombatLogParser';
+import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
+import { GapHighlight } from 'parser/ui/CooldownBar';
 
 /** Common 'rule line' point for the explanation/data in Core Spells section */
 export const GUIDE_CORE_EXPLANATION_PERCENT = 40;
@@ -18,9 +20,14 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
         {modules.thunderFocusTea.guideSubsection}
         <HotGraphSubsection modules={modules} events={events} info={info} />
       </Section>
-      <Section title="Healing Cooldowns">
-        <PreparationSection />
+      <Section title="Short cooldowns">
+        {modules.essenceFont.guideSubsection}
+        {modules.chiBurst.guideSubsection}
       </Section>
+      <Section title="Healing Cooldowns">
+        <CooldownGraphSubsection modules={modules} events={events} info={info} />
+      </Section>
+      <PreparationSection />
     </>
   );
 }
@@ -33,6 +40,30 @@ function HotGraphSubsection({ modules, events, info }: GuideProps<typeof CombatL
       relation to your <SpellLink id={TALENTS_MONK.RISING_SUN_KICK_TALENT.id} /> and{' '}
       <SpellLink id={SPELLS.VIVIFY} /> casts.
       {modules.remGraph.plot}
+    </SubSection>
+  );
+}
+
+function CooldownGraphSubsection({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
+  const invokeId = info.combatant.hasTalent(TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT)
+    ? TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT.id
+    : TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id;
+  return (
+    <SubSection>
+      <strong>Cooldown Graph</strong> - this graph shows when you used your cooldowns and how long
+      you waited to use them again. Grey segments show when the spell was available, yellow segments
+      show when the spell was cooling down. Red segments highlight times when you could have fit a
+      whole extra use of the cooldown.
+      <CastEfficiencyBar
+        spellId={invokeId}
+        gapHighlightMode={GapHighlight.FullCooldown}
+        useThresholds
+      />
+      <CastEfficiencyBar
+        spellId={TALENTS_MONK.REVIVAL_TALENT.id}
+        gapHighlightMode={GapHighlight.FullCooldown}
+        useThresholds
+      />
     </SubSection>
   );
 }

--- a/src/analysis/retail/monk/mistweaver/Guide.tsx
+++ b/src/analysis/retail/monk/mistweaver/Guide.tsx
@@ -1,0 +1,38 @@
+import { TALENTS_MONK } from 'common/TALENTS';
+import { SpellLink } from 'interface';
+import { GuideProps, Section, SubSection } from 'interface/guide';
+import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
+import SPELLS from 'common/SPELLS';
+import CombatLogParser from '../mistweaver/CombatLogParser';
+
+/** Common 'rule line' point for the explanation/data in Core Spells section */
+export const GUIDE_CORE_EXPLANATION_PERCENT = 40;
+
+export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
+  return (
+    <>
+      <Section title="Core Spells">
+        {modules.renewingMist.guideSubsection}
+        {info.combatant.hasTalent(TALENTS_MONK.RISING_SUN_KICK_TALENT) &&
+          modules.risingSunKick.guideSubsection}
+        {modules.thunderFocusTea.guideSubsection}
+        <HotGraphSubsection modules={modules} events={events} info={info} />
+      </Section>
+      <Section title="Healing Cooldowns">
+        <PreparationSection />
+      </Section>
+    </>
+  );
+}
+
+function HotGraphSubsection({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
+  return (
+    <SubSection>
+      <strong>HoT Graph</strong> - this graph shows how many{' '}
+      <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT} /> you have over the course of the fight in
+      relation to your <SpellLink id={TALENTS_MONK.RISING_SUN_KICK_TALENT.id} /> and{' '}
+      <SpellLink id={SPELLS.VIVIFY} /> casts.
+      {modules.remGraph.plot}
+    </SubSection>
+  );
+}

--- a/src/analysis/retail/monk/mistweaver/modules/features/REMGraph.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/REMGraph.tsx
@@ -138,6 +138,7 @@ class REMGraph extends Analyzer {
                 format: '~s',
               },
             },
+            color: { datum: 'Renewing Mist' },
           },
         },
 
@@ -165,6 +166,7 @@ class REMGraph extends Analyzer {
               type: 'quantitative' as const,
               title: null,
             },
+            color: { datum: 'Vivify cast' },
           },
         },
 
@@ -192,6 +194,7 @@ class REMGraph extends Analyzer {
               type: 'quantitative' as const,
               title: null,
             },
+            color: { datum: 'Rising Sun Kick cast' },
           },
         },
       ],

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
@@ -11,6 +11,11 @@ import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import { TALENTS_MONK } from 'common/TALENTS';
 import { formatNumber } from 'common/format';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
+import { GapHighlight } from 'parser/ui/CooldownBar';
+import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
 
 class EssenceFont extends Analyzer {
   static dependencies = {
@@ -152,6 +157,47 @@ class EssenceFont extends Analyzer {
     } else {
       return <></>;
     }
+  }
+
+  /** Guide subsection describing the proper usage of Lifebloom */
+  get guideSubsection(): JSX.Element {
+    const explanation = (
+      <p>
+        <b>
+          <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT.id} />
+        </b>{' '}
+        is your core AoE heal and used to activate{' '}
+        <SpellLink id={TALENTS_MONK.ANCIENT_TEACHINGS_TALENT} />. You should aim to avoid cancelling
+        it at all costs and you should only use it with{' '}
+        <SpellLink id={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT} /> (if talented into{' '}
+        <SpellLink id={TALENTS_MONK.UPWELLING_TALENT} />) and on CD otherwise.
+      </p>
+    );
+
+    const data = (
+      <div>
+        <RoundedPanel>
+          <strong>
+            <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT} /> cast efficiency
+          </strong>
+          {this.subStatistic()}
+        </RoundedPanel>
+      </div>
+    );
+
+    return explanationAndDataSubsection(explanation, data, GUIDE_CORE_EXPLANATION_PERCENT);
+  }
+
+  /** Guide subsection describing the proper usage of Rejuvenation */
+  subStatistic() {
+    return (
+      <CastEfficiencyBar
+        spellId={TALENTS_MONK.ESSENCE_FONT_TALENT.id}
+        gapHighlightMode={GapHighlight.FullCooldown}
+        minimizeIcons
+        useThresholds
+      />
+    );
   }
 
   statistic() {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
@@ -202,7 +202,7 @@ class EssenceFont extends Analyzer {
     this.castEntries.push({ value, tooltip });
   }
 
-  /** Guide subsection describing the proper usage of Lifebloom */
+  /** Guide subsection describing the proper usage of EF */
   get guideSubsection(): JSX.Element {
     const explanation = (
       <p>

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
@@ -191,7 +191,7 @@ class EssenceFont extends Analyzer {
         </>
       );
     } else {
-      value = this.efTargetsHit.getPerformance(totalHit);
+      value = this.efCancelled.getPerformance(totalHit);
       tooltip = (
         <>
           Cast @ {this.owner.formatTimestamp(this.efCancelled.lastEf!.timestamp)}: You hit{' '}

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFontCancelled.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFontCancelled.tsx
@@ -11,6 +11,7 @@ import Events, {
 } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import { SpellLink } from 'interface';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 
 const debug = false;
 const NUM_EF_BOLTS = 18;
@@ -68,6 +69,20 @@ class EssenceFontCancelled extends Analyzer {
     }
     this.lastCdEnd = event.timestamp;
     debug && console.log(`Cooldown for EF ended at ${this.owner.formatTimestamp(event.timestamp)}`);
+  }
+
+  getPerformance(targetsHit: number) {
+    const percentHit = targetsHit / this.getExpectedApplies(this.lastEf!);
+    let perf = QualitativePerformance.Perfect;
+    if (percentHit < 0.85) {
+      // generally these will be counted as cancels but adding it here to be safe
+      perf = QualitativePerformance.Fail;
+    } else if (percentHit < 0.9) {
+      perf = QualitativePerformance.Ok;
+    } else if (percentHit < 1) {
+      perf = QualitativePerformance.Good;
+    }
+    return perf;
   }
 
   getExpectedApplies(event: CastEvent) {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFontTargetsHit.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFontTargetsHit.tsx
@@ -5,10 +5,12 @@ import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent, HealEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 
 class EssenceFontTargetsHit extends Analyzer {
   efCasts: number = 0;
   targetsEF: number = 0;
+  hitsBeforeCast: number = 0;
 
   constructor(options: Options) {
     super(options);
@@ -33,6 +35,17 @@ class EssenceFontTargetsHit extends Analyzer {
     }
 
     this.targetsEF += 1;
+  }
+
+  getPerformance(targetsHit: number) {
+    if (targetsHit < 12) {
+      return QualitativePerformance.Fail;
+    } else if (targetsHit < 14) {
+      return QualitativePerformance.Ok;
+    } else if (targetsHit < 17) {
+      return QualitativePerformance.Good;
+    }
+    return QualitativePerformance.Perfect;
   }
 
   get avgTargetsHitPerEF() {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFontTargetsHit.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFontTargetsHit.tsx
@@ -5,7 +5,6 @@ import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent, HealEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
-import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 
 class EssenceFontTargetsHit extends Analyzer {
   efCasts: number = 0;
@@ -35,17 +34,6 @@ class EssenceFontTargetsHit extends Analyzer {
     }
 
     this.targetsEF += 1;
-  }
-
-  getPerformance(targetsHit: number) {
-    if (targetsHit < 12) {
-      return QualitativePerformance.Fail;
-    } else if (targetsHit < 14) {
-      return QualitativePerformance.Ok;
-    } else if (targetsHit < 17) {
-      return QualitativePerformance.Good;
-    }
-    return QualitativePerformance.Perfect;
   }
 
   get avgTargetsHitPerEF() {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFontUniqueTargets.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFontUniqueTargets.tsx
@@ -13,6 +13,7 @@ class EssenceFontUniqueTargets extends Analyzer {
   efCasts: number = 0;
   uniqueHits: number = 0;
   totalHits: number = 0;
+  uniqueHitsBeforeCast: number = 0;
   currentHits: Set<string> = new Set<string>();
 
   constructor(options: Options) {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RenewingMist.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RenewingMist.tsx
@@ -77,7 +77,8 @@ class RenewingMist extends Analyzer {
         pandemic if there are no players to jump to in range. Using{' '}
         <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT} /> as much as possible is extremely
         important due to its synergy with <SpellLink id={SPELLS.VIVIFY} />,{' '}
-        <SpellLink id={TALENTS_MONK.RISING_MIST_TALENT} />, and{' '}
+        <SpellLink id={TALENTS_MONK.RISING_MIST_TALENT} />,{' '}
+        <SpellLink id={TALENTS_MONK.DANCING_MISTS_TALENT} />, and{' '}
         <SpellLink id={TALENTS_MONK.MISTY_PEAKS_TALENT} />
       </p>
     );
@@ -103,6 +104,7 @@ class RenewingMist extends Analyzer {
         spellId={TALENTS_MONK.RENEWING_MIST_TALENT.id}
         gapHighlightMode={GapHighlight.FullCooldown}
         minimizeIcons
+        slimLines
       />
     );
   }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RenewingMist.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RenewingMist.tsx
@@ -2,14 +2,26 @@ import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { ApplyBuffEvent, HealEvent, RemoveBuffEvent } from 'parser/core/Events';
 import { isFromRenewingMist } from '../../normalizers/CastLinkNormalizer';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { TALENTS_MONK } from 'common/TALENTS';
+import { SpellLink } from 'interface';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
+import REMGraph from '../features/REMGraph';
+import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
+import { GapHighlight } from 'parser/ui/CooldownBar';
 
 class RenewingMist extends Analyzer {
+  static dependencies = {
+    remGraph: REMGraph,
+  };
   currentRenewingMists: number = 0;
   totalHealing: number = 0;
   totalOverhealing: number = 0;
   totalAbsorbs: number = 0;
   gustsHealing: number = 0;
   healingHits: number = 0;
+  protected remGraph!: REMGraph;
 
   constructor(options: Options) {
     super(options);
@@ -50,6 +62,49 @@ class RenewingMist extends Analyzer {
     this.totalOverhealing += event.overheal || 0;
     this.totalAbsorbs += event.absorbed || 0;
     this.healingHits += 1;
+  }
+
+  /** Guide subsection describing the proper usage of Lifebloom */
+  get guideSubsection(): JSX.Element {
+    const explanation = (
+      <p>
+        <b>
+          <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT.id} />
+        </b>{' '}
+        is your primary healing spell. You can use it on any target and it will either stay on the
+        target, jump targets if the chosen target has a{' '}
+        <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT} /> and there are players in range, or
+        pandemic if there are no players to jump to in range. Using{' '}
+        <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT} /> as much as possible is extremely
+        important due to its synergy with <SpellLink id={SPELLS.VIVIFY} />,{' '}
+        <SpellLink id={TALENTS_MONK.RISING_MIST_TALENT} />, and{' '}
+        <SpellLink id={TALENTS_MONK.MISTY_PEAKS_TALENT} />
+      </p>
+    );
+
+    const data = (
+      <div>
+        <RoundedPanel>
+          <strong>
+            <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT} /> cast efficiency
+          </strong>
+          {this.subStatistic()}
+        </RoundedPanel>
+      </div>
+    );
+
+    return explanationAndDataSubsection(explanation, data, GUIDE_CORE_EXPLANATION_PERCENT);
+  }
+
+  /** Guide subsection describing the proper usage of Rejuvenation */
+  subStatistic() {
+    return (
+      <CastEfficiencyBar
+        spellId={TALENTS_MONK.RENEWING_MIST_TALENT.id}
+        gapHighlightMode={GapHighlight.FullCooldown}
+        minimizeIcons
+      />
+    );
   }
 }
 

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RenewingMist.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RenewingMist.tsx
@@ -64,7 +64,7 @@ class RenewingMist extends Analyzer {
     this.healingHits += 1;
   }
 
-  /** Guide subsection describing the proper usage of Lifebloom */
+  /** Guide subsection describing the proper usage of ReM */
   get guideSubsection(): JSX.Element {
     const explanation = (
       <p>

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RisingSunKick.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RisingSunKick.tsx
@@ -1,8 +1,14 @@
 import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
+import { SpellLink } from 'interface';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent } from 'parser/core/Events';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
+import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
+import { GapHighlight } from 'parser/ui/CooldownBar';
+import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
 
 class RisingSunKick extends Analyzer {
   static dependencies = {
@@ -44,6 +50,45 @@ class RisingSunKick extends Analyzer {
 
   blackoutKickCast(event: CastEvent) {
     this.lastBOK = event.timestamp;
+  }
+
+  /** Guide subsection describing the proper usage of Lifebloom */
+  get guideSubsection(): JSX.Element {
+    const explanation = (
+      <p>
+        <b>
+          <SpellLink id={TALENTS_MONK.RISING_SUN_KICK_TALENT.id} />
+        </b>{' '}
+        is one of your primary damaging spells and also an important healing spell due to{' '}
+        <SpellLink id={TALENTS_MONK.RISING_MIST_TALENT} />. Using it as much as possible is
+        essential for maintaining high counts of{' '}
+        <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT} />
+      </p>
+    );
+
+    const data = (
+      <div>
+        <RoundedPanel>
+          <strong>
+            <SpellLink id={TALENTS_MONK.RISING_SUN_KICK_TALENT} /> cast efficiency
+          </strong>
+          {this.guideSubStatistic()}
+        </RoundedPanel>
+      </div>
+    );
+
+    return explanationAndDataSubsection(explanation, data, GUIDE_CORE_EXPLANATION_PERCENT);
+  }
+
+  /** Guide subsection describing the proper usage of Rejuvenation */
+  guideSubStatistic() {
+    return (
+      <CastEfficiencyBar
+        spellId={TALENTS_MONK.RISING_SUN_KICK_TALENT.id}
+        gapHighlightMode={GapHighlight.FullCooldown}
+        minimizeIcons
+      />
+    );
   }
 
   subStatistic() {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RisingSunKick.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RisingSunKick.tsx
@@ -52,7 +52,7 @@ class RisingSunKick extends Analyzer {
     this.lastBOK = event.timestamp;
   }
 
-  /** Guide subsection describing the proper usage of Lifebloom */
+  /** Guide subsection describing the proper usage of RSK */
   get guideSubsection(): JSX.Element {
     const explanation = (
       <p>

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RisingSunKick.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RisingSunKick.tsx
@@ -59,9 +59,10 @@ class RisingSunKick extends Analyzer {
         <b>
           <SpellLink id={TALENTS_MONK.RISING_SUN_KICK_TALENT.id} />
         </b>{' '}
-        is one of your primary damaging spells and also an important healing spell due to{' '}
-        <SpellLink id={TALENTS_MONK.RISING_MIST_TALENT} />. Using it as much as possible is
-        essential for maintaining high counts of{' '}
+        is one of your primary damaging spells but is also the 2nd highest priority healing spell{' '}
+        {'(behind '} <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT} />
+        {') '}due to its synergy with <SpellLink id={TALENTS_MONK.RISING_MIST_TALENT} />. Using it
+        as much as possible is essential for maintaining high counts of{' '}
         <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT} />
       </p>
     );
@@ -87,6 +88,7 @@ class RisingSunKick extends Analyzer {
         spellId={TALENTS_MONK.RISING_SUN_KICK_TALENT.id}
         gapHighlightMode={GapHighlight.FullCooldown}
         minimizeIcons
+        slimLines
       />
     );
   }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
@@ -16,11 +16,14 @@ import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
 import { GapHighlight } from 'parser/ui/CooldownBar';
 import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
+import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 
 const debug = false;
 
 //TODO clean up and make easier to add triggers
 class ThunderFocusTea extends Analyzer {
+  castEntries: BoxRowEntry[] = [];
   castsTftRsk: number = 0;
   castsTftViv: number = 0;
   castsTftEnm: number = 0;
@@ -129,11 +132,28 @@ class ThunderFocusTea extends Analyzer {
       this.castsUnderTft += 1;
       this.castsTftEF += 1;
       debug && console.log('REM EF Check ', event.timestamp);
+    } else {
+      return;
     }
-
+    let tooltip = null;
+    let value = null;
     if (this.correctSpells.includes(spellId)) {
+      value = QualitativePerformance.Good;
+      tooltip = (
+        <>
+          Correct cast: buffed <SpellLink id={spellId} />
+        </>
+      );
       this.correctCasts += 1;
+    } else {
+      value = QualitativePerformance.Fail;
+      tooltip = (
+        <>
+          Incorrect cast: buffed <SpellLink id={spellId} />
+        </>
+      );
     }
+    this.castEntries.push({ value, tooltip });
   }
 
   renderCastRatioChart() {
@@ -193,14 +213,20 @@ class ThunderFocusTea extends Analyzer {
         ), otherwise use it on <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT.id} />
       </p>
     );
-
     const data = (
       <div>
         <RoundedPanel>
           <strong>
             <SpellLink id={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT.id} /> cast efficiency
           </strong>
-          {this.subStatistic()}
+          <div>
+            {this.subStatistic()} <br />
+            <small>
+              Green indicates a correct <SpellLink id={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT} />{' '}
+              cast, while red indicates a bad cast.
+            </small>
+            <PerformanceBoxRow values={this.castEntries} />
+          </div>
         </RoundedPanel>
       </div>
     );

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
@@ -11,6 +11,11 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticsListBox';
 import Haste from 'parser/shared/modules/Haste';
 import { SPELL_COLORS } from '../../constants';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
+import { GapHighlight } from 'parser/ui/CooldownBar';
+import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
 
 const debug = false;
 
@@ -166,6 +171,52 @@ class ThunderFocusTea extends Analyzer {
     ];
 
     return <DonutChart items={items} />;
+  }
+
+  /** Guide subsection describing the proper usage of Lifebloom */
+  get guideSubsection(): JSX.Element {
+    const explanation = (
+      <p>
+        <b>
+          <SpellLink id={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT.id} />
+        </b>{' '}
+        is an important spell used to empower other abilities. It should be used on cooldown at all
+        times and the spell that you use it on depends on your talent selection. If you have{' '}
+        <SpellLink id={TALENTS_MONK.SECRET_INFUSION_TALENT} />, then you should always use{' '}
+        <SpellLink id={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT.id} /> on{' '}
+        <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT} /> (with high{' '}
+        <SpellLink id={TALENTS_MONK.UPWELLING_TALENT.id} /> stacks) or{' '}
+        <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT.id} />. If you do not have{' '}
+        <SpellLink id={TALENTS_MONK.SECRET_INFUSION_TALENT.id} />, then always use it on{' '}
+        <SpellLink id={TALENTS_MONK.RISING_SUN_KICK_TALENT.id} /> (with{' '}
+        <SpellLink id={TALENTS_MONK.RISING_MIST_TALENT.id} />
+        ), otherwise use it on <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT.id} />
+      </p>
+    );
+
+    const data = (
+      <div>
+        <RoundedPanel>
+          <strong>
+            <SpellLink id={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT.id} /> cast efficiency
+          </strong>
+          {this.subStatistic()}
+        </RoundedPanel>
+      </div>
+    );
+
+    return explanationAndDataSubsection(explanation, data, GUIDE_CORE_EXPLANATION_PERCENT);
+  }
+
+  /** Guide subsection describing the proper usage of Rejuvenation */
+  subStatistic() {
+    return (
+      <CastEfficiencyBar
+        spellId={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT.id}
+        gapHighlightMode={GapHighlight.FullCooldown}
+        minimizeIcons
+      />
+    );
   }
 
   suggestions(when: When) {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
@@ -193,7 +193,7 @@ class ThunderFocusTea extends Analyzer {
     return <DonutChart items={items} />;
   }
 
-  /** Guide subsection describing the proper usage of Lifebloom */
+  /** Guide subsection describing the proper usage of TFT */
   get guideSubsection(): JSX.Element {
     const explanation = (
       <p>

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
@@ -223,7 +223,7 @@ class ThunderFocusTea extends Analyzer {
             {this.subStatistic()} <br />
             <small>
               Green indicates a correct <SpellLink id={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT} />{' '}
-              cast, while red indicates a bad cast.
+              cast, while red indicates an incorrect cast.
             </small>
             <PerformanceBoxRow values={this.castEntries} />
           </div>

--- a/src/analysis/retail/monk/mistweaver/normalizers/HotApplicationNormalizer.tsx
+++ b/src/analysis/retail/monk/mistweaver/normalizers/HotApplicationNormalizer.tsx
@@ -15,7 +15,7 @@ const EVENT_ORDERS: EventOrder[] = [
   },
   {
     beforeEventId: SPELLS.ESSENCE_FONT_BUFF.id,
-    beforeEventType: EventType.ApplyBuff,
+    beforeEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
     afterEventId: SPELLS.ESSENCE_FONT_BUFF.id,
     afterEventType: EventType.Heal,
     bufferMs: MAX_DELAY,

--- a/src/analysis/retail/monk/mistweaver/normalizers/HotRemovalNormalizer.tsx
+++ b/src/analysis/retail/monk/mistweaver/normalizers/HotRemovalNormalizer.tsx
@@ -1,4 +1,5 @@
 import SPELLS from 'common/SPELLS';
+import { TALENTS_MONK } from 'common/TALENTS';
 import EventOrderNormalizer, { EventOrder } from 'parser/core/EventOrderNormalizer';
 import { EventType } from 'parser/core/Events';
 import { Options } from 'parser/core/Module';
@@ -19,6 +20,13 @@ const EVENT_ORDERS: EventOrder[] = [
     afterEventId: SPELLS.ESSENCE_FONT_BUFF.id,
     afterEventType: EventType.RemoveBuff,
     bufferMs: MAX_DELAY,
+  },
+  {
+    beforeEventId: SPELLS.ESSENCE_FONT_BUFF.id,
+    beforeEventType: [EventType.RefreshBuff, EventType.ApplyBuff],
+    afterEventId: TALENTS_MONK.ESSENCE_FONT_TALENT.id,
+    afterEventType: EventType.EndChannel,
+    bufferMs: 200,
   },
 ];
 

--- a/src/parser/ui/CastEfficiencyBar.tsx
+++ b/src/parser/ui/CastEfficiencyBar.tsx
@@ -13,16 +13,19 @@ import { formatPercentage } from 'common/format';
  * @param minimizeIcons see {@link CooldownBar} props
  * @param useThresholds iff true, the cast efficiency percentage will be color coded by performance
  *    using the abilities efficiency requirements.
+ * @param slimLines iff true, then cast lines will be skinnier. Very useful for high CPM abilities!
  */
 export default function CastEfficiencyBar({
   spellId,
   gapHighlightMode,
   minimizeIcons,
   useThresholds,
+  slimLines,
 }: {
   spellId: number;
   gapHighlightMode: GapHighlight;
   minimizeIcons?: boolean;
+  slimLines?: boolean;
   useThresholds?: boolean;
 }): JSX.Element {
   const castEffic = useAnalyzer(CastEfficiency)?.getCastEfficiencyForSpellId(spellId);
@@ -70,6 +73,7 @@ export default function CastEfficiencyBar({
         spellId={spellId}
         gapHighlightMode={gapHighlightMode}
         minimizeIcons={minimizeIcons}
+        slimLines={slimLines}
       />
     </CooldownUtilBarContainer>
   );

--- a/src/parser/ui/CooldownBar.tsx
+++ b/src/parser/ui/CooldownBar.tsx
@@ -34,6 +34,7 @@ type Props = {
    *  Useful for spells on CD shorter than 30s where the icons might be too closely packed to
    *  be usable */
   minimizeIcons?: boolean;
+  slimLines?: boolean;
 };
 
 /**
@@ -46,6 +47,7 @@ export function CooldownBar({
   spellId,
   gapHighlightMode,
   minimizeIcons,
+  slimLines,
   ...others
 }: Props): JSX.Element {
   const info = useInfo()!;
@@ -79,6 +81,7 @@ export function CooldownBar({
     abilityCdMs,
     abilityName,
     hasCharges,
+    slimLines,
   };
 
   let lastAvailable = info.fightStart;
@@ -141,7 +144,7 @@ export function CooldownBar({
         const left = `${((cd.timestamp - info.fightStart) / info.fightDuration) * 100}%`;
         return (
           <div style={{ left }} key={ix + '-usecharge'}>
-            {iconOrChip(spellId, minimizeIcons)}
+            {iconOrChip(spellId, minimizeIcons, slimLines)}
           </div>
         );
       })}
@@ -160,6 +163,7 @@ function CooldownBarSegment({
   type,
   gapHighlightMode,
   minimizeIcons,
+  slimLines,
   hasCharges,
 }: {
   abilityId: number;
@@ -172,6 +176,7 @@ function CooldownBarSegment({
   type: 'onCooldown' | 'available';
   gapHighlightMode: GapHighlight;
   minimizeIcons?: boolean;
+  slimLines?: boolean;
   hasCharges?: boolean;
 }): JSX.Element {
   const fightDuration = fightEnd - fightStart;
@@ -224,15 +229,16 @@ function CooldownBarSegment({
   return (
     <Tooltip content={tooltipContent}>
       <div className={className} style={{ left, width }}>
-        {type === 'onCooldown' && iconOrChip(abilityId, minimizeIcons)}
+        {type === 'onCooldown' && iconOrChip(abilityId, minimizeIcons, slimLines)}
       </div>
     </Tooltip>
   );
 }
 
-function iconOrChip(spellId: number, minimizeIcons?: boolean): JSX.Element {
+function iconOrChip(spellId: number, minimizeIcons?: boolean, slimLines?: boolean): JSX.Element {
+  const w = slimLines ? 1 : 3;
   return minimizeIcons ? (
-    <div className="cast-chip" style={{ width: 3, height: '100%' }} />
+    <div className="cast-chip" style={{ width: w, height: '100%' }} />
   ) : (
     <SpellIcon noLink id={spellId} />
   );


### PR DESCRIPTION
Adds core abilities, short cooldowns, and healing cd sections. The healing cd/short cooldown section are not complete quite yet, but want to split up the PRs to make it easier to review

example report: report/7VQTDLB24m6NHMAF/9-Mythic+Raszageth+the+Storm-Eater+-+Kill+(13:26)/Sweggles/standard/overview

![image](https://user-images.githubusercontent.com/11250934/218353061-f9f8c84f-a9d2-442d-b917-fcf42762f142.png)
![image](https://user-images.githubusercontent.com/11250934/218353089-0cfff041-27dc-43df-aace-519c6c3c9517.png)
