### PR TITLE
windwalker: add initial APL

### DIFF
--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { Durpn, Hursti } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 2, 13), <>Initial APL Added</>, Durpn),
   change(date(2022, 1, 15), <>Clean up Changelog and Include <SpellLink id={talents.INNER_PEACE_TALENT.id} /> to the Energycap</>, Hursti),
   change(date(2022, 1, 14), <>Initial Update for Dragonflight</>, Durpn),
 ];

--- a/src/analysis/retail/monk/windwalker/CombatLogParser.ts
+++ b/src/analysis/retail/monk/windwalker/CombatLogParser.ts
@@ -35,6 +35,7 @@ import TouchOfKarma from './modules/spells/TouchOfKarma';
 import DanceOfChiJi from './modules/talents/DanceOfChiJi';
 import HitCombo from './modules/talents/HitCombo';
 import Serenity from './modules/talents/Serenity';
+import AplCheck from 'analysis/retail/monk/windwalker/modules/apl/AplCheck';
 
 // Tier Set Bonuses
 // todo: add t29 tier sets
@@ -80,6 +81,9 @@ class CombatLogParser extends CoreCombatLogParser {
     invokersDelight: InvokersDelight,
     jadeIgnition: JadeIgnition,
     xuensBattleGear: XuensBattlegear,
+
+    // apl
+    apl: AplCheck,
   };
 }
 

--- a/src/analysis/retail/monk/windwalker/modules/Abilities.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/Abilities.tsx
@@ -177,6 +177,16 @@ class Abilities extends CoreAbilities {
           recommendedEfficiency: 0.95,
         },
       },
+      {
+        spell: TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT.id,
+        category: SPELL_CATEGORY.COOLDOWNS,
+        cooldown: 40,
+        enabled: combatant.hasTalent(TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT),
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.95,
+        },
+      },
       // Utility
       {
         spell: TALENTS_MONK.RING_OF_PEACE_TALENT.id,

--- a/src/analysis/retail/monk/windwalker/modules/apl/AplCheck.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/apl/AplCheck.tsx
@@ -1,0 +1,79 @@
+import aplCheck, { build, Condition } from 'parser/shared/metrics/apl';
+import {
+  and,
+  buffMissing,
+  buffPresent,
+  describe,
+  hasResource,
+  lastSpellCast,
+  not,
+  or,
+} from 'parser/shared/metrics/apl/conditions';
+import SPELLS from 'common/SPELLS';
+import { suggestion } from 'parser/core/Analyzer';
+import annotateTimeline from 'parser/shared/metrics/apl/annotate';
+import TALENTS from 'common/TALENTS/monk';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import { SpellLink } from 'interface';
+
+const serenityOr = (cond: Condition<any>) => or(cond, buffPresent(TALENTS.SERENITY_TALENT));
+
+const hasChi = (min: number) => hasResource(RESOURCE_TYPES.CHI, { atLeast: min });
+
+export const apl = build([
+  {
+    spell: TALENTS.FAELINE_STOMP_TALENT,
+    condition: buffMissing(TALENTS.FAELINE_HARMONY_TALENT),
+  },
+  {
+    spell: TALENTS.STRIKE_OF_THE_WINDLORD_TALENT,
+    condition: serenityOr(hasChi(2)),
+  },
+  TALENTS.WHIRLING_DRAGON_PUNCH_TALENT,
+  {
+    spell: TALENTS.RISING_SUN_KICK_TALENT,
+    condition: and(buffPresent(SPELLS.PRESSURE_POINT_BUFF), serenityOr(hasChi(2))),
+  },
+  {
+    spell: TALENTS.FISTS_OF_FURY_TALENT,
+    condition: serenityOr(hasChi(3)),
+  },
+  {
+    spell: TALENTS.RISING_SUN_KICK_TALENT,
+    condition: serenityOr(hasChi(2)),
+  },
+  {
+    spell: SPELLS.SPINNING_CRANE_KICK,
+    condition: buffPresent(TALENTS.DANCE_OF_CHI_JI_TALENT),
+  },
+  {
+    spell: SPELLS.BLACKOUT_KICK,
+    condition: describe(
+      and(serenityOr(hasChi(1)), not(lastSpellCast(SPELLS.BLACKOUT_KICK))),
+      (tense) => (
+        <>
+          <SpellLink id={SPELLS.BLACKOUT_KICK} /> was not your last cast.
+        </>
+      ),
+    ),
+  },
+  TALENTS.RUSHING_JADE_WIND_TALENT,
+  TALENTS.CHI_WAVE_TALENT,
+  TALENTS.FAELINE_STOMP_TALENT,
+  {
+    spell: TALENTS.CHI_BURST_TALENT,
+    condition: and(
+      buffMissing(TALENTS.SERENITY_TALENT),
+      hasResource(RESOURCE_TYPES.CHI, { atMost: 5 }),
+    ),
+  },
+]);
+
+export const check = aplCheck(apl);
+
+export default suggestion((events, info) => {
+  const { violations } = check(events, info);
+  annotateTimeline(violations);
+
+  return undefined;
+});

--- a/src/analysis/retail/monk/windwalker/modules/features/checklist/Component.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/features/checklist/Component.tsx
@@ -10,8 +10,10 @@ import GenericCastEfficiencyRequirement from 'parser/shared/modules/features/Che
 import Requirement from 'parser/shared/modules/features/Checklist/Requirement';
 import Rule from 'parser/shared/modules/features/Checklist/Rule';
 import { TALENTS_MONK } from 'common/TALENTS';
+import AplRule, { AplRuleProps } from 'parser/shared/metrics/apl/ChecklistRule';
 
-const WindwalkerMonkChecklist = ({ combatant, castEfficiency, thresholds }: ChecklistProps) => {
+const WindwalkerMonkChecklist = (props: ChecklistProps & AplRuleProps) => {
+  const { combatant, castEfficiency, thresholds } = props;
   const AbilityRequirement = (props: AbilityRequirementProps) => (
     <GenericCastEfficiencyRequirement
       castEfficiency={castEfficiency.getCastEfficiencyForSpellId(props.spell)}
@@ -244,6 +246,7 @@ const WindwalkerMonkChecklist = ({ combatant, castEfficiency, thresholds }: Chec
           thresholds={thresholds.touchOfKarma}
         />
       </Rule>
+      <AplRule {...props} name="APL checker (beta)" />
       <PreparationRule thresholds={thresholds} />
     </Checklist>
   );

--- a/src/analysis/retail/monk/windwalker/modules/features/checklist/Module.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/features/checklist/Module.tsx
@@ -13,6 +13,7 @@ import FistsofFury from '../../spells/FistsofFury';
 import TouchOfKarma from '../../spells/TouchOfKarma';
 import HitCombo from '../../talents/HitCombo';
 import Component from './Component';
+import { apl, check } from 'analysis/retail/monk/windwalker/modules/apl/AplCheck';
 
 class Checklist extends BaseChecklist {
   static dependencies = {
@@ -50,6 +51,8 @@ class Checklist extends BaseChecklist {
   render() {
     return (
       <Component
+        apl={apl}
+        checkResults={check(this.owner.eventHistory, this.owner.info)}
         combatant={this.combatants.selected}
         castEfficiency={this.castEfficiency}
         thresholds={{


### PR DESCRIPTION
### Description

Add initial APL for windwalker. It does not currently consider Tiger Palm at all.

Signed-off-by: Sam Voss <sam.voss@gmail.com>

### Motivation

No current APL support.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/pB3KHD9yFm2AM4kG/95-Heroic+Terros+-+Kill+(4:42)/Durpn/standard/overview`
- Screenshot(s):

![image](https://user-images.githubusercontent.com/1350045/218642620-5a804d2d-d1e1-4156-9420-25c41a5c2020.png)

