### PR TITLE
fix crash in celestial modules

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 2, 15), <>Fix celestial crash when using summon statues</>, Trevor),
   change(date(2023, 2, 12), <>Add celestials section to guide</>, Trevor),
   change(date(2023, 2, 12), <>Add guide prototype for Mistweaver</>, Trevor),
   change(date(2023, 2, 7), <>Updated spell values for Feb 7 tuning</>, Trevor),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
@@ -58,7 +58,15 @@ class BaseCelestialAnalyzer extends Analyzer {
     this.active =
       this.selectedCombatant.hasTalent(TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT) ||
       this.selectedCombatant.hasTalent(TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT);
-    this.addEventListener(Events.summon.to(SELECTED_PLAYER_PET), this.onSummon);
+    this.addEventListener(
+      Events.summon
+        .to(SELECTED_PLAYER_PET)
+        .spell([
+          TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT,
+          TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT,
+        ]),
+      this.onSummon,
+    );
     this.addEventListener(
       Events.applybuff.by(SELECTED_PLAYER).spell(SECRET_INFUSION_BUFFS),
       this.applySi,
@@ -76,7 +84,15 @@ class BaseCelestialAnalyzer extends Analyzer {
       this.removeLessons,
     );
     this.addEventListener(Events.death.to(SELECTED_PLAYER), this.handleCelestialDeath);
-    this.addEventListener(Events.death.to(SELECTED_PLAYER_PET), this.handleCelestialDeath);
+    this.addEventListener(
+      Events.death
+        .to(SELECTED_PLAYER_PET)
+        .spell([
+          TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT,
+          TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT,
+        ]),
+      this.handleCelestialDeath,
+    );
     this.addEventListener(
       Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.INVOKE_YULON_BUFF),
       this.handleCelestialDeath,
@@ -328,6 +344,9 @@ class BaseCelestialAnalyzer extends Analyzer {
   }
 
   handleCelestialDeath(event: DeathEvent | RemoveBuffEvent) {
+    if (!this.celestialActive) {
+      return;
+    }
     this.celestialActive = false;
     this.castTrackers.at(-1)!.averageHaste = this.curAverageHaste;
     this.castTrackers.at(-1)!.deathTimestamp = event.timestamp;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
@@ -20,6 +20,7 @@ import { PerformanceMark } from 'interface/guide';
 import SPELLS from 'common/SPELLS';
 import { formatNumber } from 'common/format';
 import Haste from 'parser/shared/modules/Haste';
+import Pets from 'parser/shared/modules/Pets';
 
 export interface BaseCelestialTracker {
   lessonsDuration: number; // ms with Lessons buff
@@ -42,8 +43,10 @@ class BaseCelestialAnalyzer extends Analyzer {
   static dependencies = {
     ef: EssenceFont,
     haste: Haste,
+    pets: Pets,
   };
   protected haste!: Haste;
+  protected pets!: Pets;
   siApplyTime: number = -1;
   lessonsApplyTime: number = -1;
   celestialActive: boolean = false;
@@ -84,15 +87,7 @@ class BaseCelestialAnalyzer extends Analyzer {
       this.removeLessons,
     );
     this.addEventListener(Events.death.to(SELECTED_PLAYER), this.handleCelestialDeath);
-    this.addEventListener(
-      Events.death
-        .to(SELECTED_PLAYER_PET)
-        .spell([
-          TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT,
-          TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT,
-        ]),
-      this.handleCelestialDeath,
-    );
+    this.addEventListener(Events.death.to(SELECTED_PLAYER_PET), this.handleCelestialDeath);
     this.addEventListener(
       Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.INVOKE_YULON_BUFF),
       this.handleCelestialDeath,
@@ -344,7 +339,8 @@ class BaseCelestialAnalyzer extends Analyzer {
   }
 
   handleCelestialDeath(event: DeathEvent | RemoveBuffEvent) {
-    if (!this.celestialActive) {
+    const pet = this.pets.getEntityFromEvent(event, true);
+    if (!pet || !pet.name) {
       return;
     }
     this.celestialActive = false;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
@@ -27,6 +27,8 @@ import { MAX_CHIJI_STACKS } from '../../constants';
 import BaseCelestialAnalyzer, { BaseCelestialTracker } from './BaseCelestialAnalyzer';
 import EssenceFont from './EssenceFont';
 
+const debug = false;
+
 /**
  * Blackout Kick, Totm BoKs, Rising Sun Kick and Spinning Crane Kick generate stacks of Invoke Chi-Ji, the Red Crane, which reduce the cast time and mana
  * cost of Enveloping Mist by 33% per stack, up to 3 stacks.
@@ -155,7 +157,7 @@ class InvokeChiJi extends BaseCelestialAnalyzer {
       this.selectedCombatant.getBuffStacks(SPELLS.INVOKE_CHIJI_THE_RED_CRANE_BUFF.id) ===
       MAX_CHIJI_STACKS
     ) {
-      console.log('wasted chiji stack at ', this.owner.formatTimestamp(event.timestamp));
+      debug && console.log('wasted chiji stack at ', this.owner.formatTimestamp(event.timestamp));
       this.castTrackers.at(-1)!.overcappedChijiStacks += 1;
     }
   }
@@ -164,6 +166,7 @@ class InvokeChiJi extends BaseCelestialAnalyzer {
     if (!this.celestialActive) {
       return;
     }
+    // the first cast of BoK in the window should overcap (intentionally). ignore it
     if (!this.castBokInWindow) {
       this.castBokInWindow = true;
       return;
@@ -175,7 +178,7 @@ class InvokeChiJi extends BaseCelestialAnalyzer {
         stacksGained >
       MAX_CHIJI_STACKS
     ) {
-      console.log('wasted chiji stack at ', this.owner.formatTimestamp(event.timestamp));
+      debug && console.log('wasted chiji stack at ', this.owner.formatTimestamp(event.timestamp));
       this.castTrackers.at(-1)!.overcappedChijiStacks +=
         this.selectedCombatant.getBuffStacks(SPELLS.INVOKE_CHIJI_THE_RED_CRANE_BUFF.id) +
         stacksGained -
@@ -189,13 +192,13 @@ class InvokeChiJi extends BaseCelestialAnalyzer {
     }
     if (this.selectedCombatant.getBuffStacks(SPELLS.INVOKE_CHIJI_THE_RED_CRANE_BUFF.id) === 3) {
       this.castTrackers.at(-1)!.overcappedChijiStacks += 1;
-      console.log('wasted chiji stack at ', this.owner.formatTimestamp(event.timestamp));
+      debug && console.log('wasted chiji stack at ', this.owner.formatTimestamp(event.timestamp));
     }
   }
 
   onTotmRefresh(event: RefreshBuffEvent) {
     if (this.celestialActive) {
-      console.log('wasted stack at ', this.owner.formatTimestamp(event.timestamp));
+      debug && console.log('wasted totm stack at ', this.owner.formatTimestamp(event.timestamp));
       this.castTrackers.at(-1)!.overcappedTotmStacks += 1;
     }
   }


### PR DESCRIPTION
Summon tiger statue and ox statue trigger pet death events and we werent filtering pet death events by name, leading to an issue

Also fixed overcapping bug as you should overcap on the first blackout kick of chiji intentionally