### PR TITLE
[Mistweaver] Add Core Rotation Section to Guide - Part 1

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 2, 18), <>Added pt 1 of the Core Rotation Section of the guide - <SpellLink id={TALENTS_MONK.RISING_MIST_TALENT.id}/> / <SpellLink id={TALENTS_MONK.ANCIENT_TEACHINGS_TALENT.id}/> build rotation.</>, Vohrr),
   change(date(2023, 2, 18), <>Updated the sample report to a Dragonflight encounter. Minor wording and formatting fixes for the guide</>, Vohrr),
   change(date(2023, 2, 17), <>Added non-Renewing Mist hot graph to guide and as a statistic</>, Vohrr),
   change(date(2023, 2, 17), <>Added <SpellLink id={TALENTS_MONK.REVIVAL_TALENT}/> checklist to cooldowns guide section</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
+++ b/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
@@ -81,6 +81,7 @@ import Guide from './Guide';
 import SheilunsGiftCloudTracker from './modules/spells/SheilunsGiftCloudTracker';
 import SheilunsGiftCloudGraph from './modules/spells/SheilunsGiftCloudGraph';
 import HotCountGraph from './modules/features/HotCountGraph';
+import AplCheck from './modules/core/AplCheck';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -173,6 +174,8 @@ class CombatLogParser extends CoreCombatLogParser {
     sheilunsGift: SheilunsGift,
     shaohaosLessons: ShaohaosLessons,
     veilOfPride: VeilOfPride,
+
+    apl: AplCheck,
 
     // Borrowed Power
     t29TierSet: T29TierSet,

--- a/src/analysis/retail/monk/mistweaver/Guide.tsx
+++ b/src/analysis/retail/monk/mistweaver/Guide.tsx
@@ -8,7 +8,15 @@ import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
 import { GapHighlight } from 'parser/ui/CooldownBar';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import * as AplCheck from './modules/core/AplCheck';
+import AplChoiceDescription from './modules/core/AplChoiceDescription';
+import { AplSectionData } from 'interface/guide/components/Apl';
+import { defaultExplainers } from 'interface/guide/components/Apl/violations/claims';
 
+const explainers = {
+  overcast: defaultExplainers.overcastFillers,
+  dropped: defaultExplainers.droppedRule,
+};
 /** Common 'rule line' point for the explanation/data in Core Spells section */
 export const GUIDE_CORE_EXPLANATION_PERCENT = 40;
 
@@ -43,7 +51,29 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
           ? modules.invokeChiJi.guideCastBreakdown
           : modules.invokeYulon.guideCastBreakdown}
         {modules.revival.guideCastBreakdown}
-      <HotGraphSubsection modules={modules} events={events} info={info} />
+        <HotGraphSubsection modules={modules} events={events} info={info} />
+      </Section>
+      <Section title="Core Rotation">
+        <p>
+          Healers do not have a static rotation, but Mistweaver gameplay is still driven by a
+          priority list that is valid in the majority of situations. When using an ability, aim to
+          use the abilities that are highest on the list.
+        </p>
+        <AplChoiceDescription aplChoice={AplCheck.chooseApl(info)} />
+        <p>
+          <strong>
+            It is important to note that using abilites like{' '}
+            <SpellLink id={modules.invokeChiJi.getCelestialTalent()} /> have their own priority that
+            supercedes the priority list below.
+          </strong>
+        </p>
+        <SubSection>
+          <AplSectionData
+            checker={AplCheck.check}
+            apl={AplCheck.apl(info)}
+            violationExplainers={explainers}
+          />
+        </SubSection>
       </Section>
       <PreparationSection />
     </>

--- a/src/analysis/retail/monk/mistweaver/Guide.tsx
+++ b/src/analysis/retail/monk/mistweaver/Guide.tsx
@@ -42,8 +42,6 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
         {info.combatant.hasTalent(TALENTS_MONK.SHEILUNS_GIFT_TALENT) && (
           <SheilunsGraph modules={modules} events={events} info={info} />
         )}
-        {info.combatant.hasTalent(TALENTS_MONK.MANA_TEA_TALENT) &&
-          modules.manaTea.guideCastBreakdown}
       </Section>
       <Section title="Healing Cooldowns">
         <CooldownGraphSubsection modules={modules} events={events} info={info} />
@@ -51,6 +49,8 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
           ? modules.invokeChiJi.guideCastBreakdown
           : modules.invokeYulon.guideCastBreakdown}
         {modules.revival.guideCastBreakdown}
+        {info.combatant.hasTalent(TALENTS_MONK.MANA_TEA_TALENT) &&
+          modules.manaTea.guideCastBreakdown}
         <HotGraphSubsection modules={modules} events={events} info={info} />
       </Section>
       <Section title="Core Rotation">

--- a/src/analysis/retail/monk/mistweaver/Guide.tsx
+++ b/src/analysis/retail/monk/mistweaver/Guide.tsx
@@ -12,10 +12,11 @@ import * as AplCheck from './modules/core/AplCheck';
 import AplChoiceDescription from './modules/core/AplChoiceDescription';
 import { AplSectionData } from 'interface/guide/components/Apl';
 import { defaultExplainers } from 'interface/guide/components/Apl/violations/claims';
+import filterCelestial from './modules/core/ExplainCelestial';
 
 const explainers = {
-  overcast: defaultExplainers.overcastFillers,
-  dropped: defaultExplainers.droppedRule,
+  overcast: filterCelestial(defaultExplainers.overcastFillers),
+  dropped: filterCelestial(defaultExplainers.droppedRule),
 };
 /** Common 'rule line' point for the explanation/data in Core Spells section */
 export const GUIDE_CORE_EXPLANATION_PERCENT = 40;
@@ -64,7 +65,7 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
           <strong>
             It is important to note that using abilites like{' '}
             <SpellLink id={modules.invokeChiJi.getCelestialTalent()} /> have their own priority that
-            supercedes the priority list below.
+            supercedes the priority list below. This section omits all casts in those windows.
           </strong>
         </p>
         <SubSection>

--- a/src/analysis/retail/monk/mistweaver/modules/core/AplCheck.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/AplCheck.tsx
@@ -21,31 +21,46 @@ const AOE_SCK = {
   ),
 };
 
-
-
 const SHEILUNS_SHAOHAOS = {
-    spell: talents.SHEILUNS_GIFT_TALENT,
-    condition: cnd.optional(cnd.buffStacks(SPELLS.SHEILUN_CLOUD_BUFF, {atLeast: 4, atMost:10})),
+  spell: talents.SHEILUNS_GIFT_TALENT,
+  condition: cnd.optional(cnd.buffStacks(SPELLS.SHEILUN_CLOUD_BUFF, { atLeast: 4, atMost: 10 })),
 };
 
 const VIVIFY_8_REMS = {
   spell: SPELLS.VIVIFY,
-  condition: cnd.targetsHit(
-    { atLeast: 8 },
-    {
-      targetSpell: SPELLS.VIVIFY,
-      targetType: EventType.Heal,
-    },
+  condition: cnd.describe(
+    cnd.targetsHit(
+      { atLeast: 9 }, // 8 rems + 1 primary target
+      {
+        targetSpell: SPELLS.VIVIFY,
+        targetType: EventType.Heal,
+      },
+    ),
+    (tense) => (
+      <>
+        you {tenseAlt(tense, 'have', 'had')} 8 active{' '}
+        <SpellLink id={talents.RENEWING_MIST_TALENT} />
+      </>
+    ),
   ),
 };
+
 const VIVIFY_6_REMS = {
   spell: SPELLS.VIVIFY,
-  condition: cnd.targetsHit(
-    { atLeast: 6 },
-    {
-      targetSpell: SPELLS.VIVIFY,
-      targetType: EventType.Heal,
-    },
+  condition: cnd.describe(
+    cnd.targetsHit(
+      { atLeast: 7 }, // 6 rems + 1 primary target
+      {
+        targetSpell: SPELLS.VIVIFY,
+        targetType: EventType.Heal,
+      },
+    ),
+    (tense) => (
+      <>
+        you {tenseAlt(tense, 'have', 'had')} 6 active{' '}
+        <SpellLink id={talents.RENEWING_MIST_TALENT} />
+      </>
+    ),
   ),
 };
 
@@ -59,7 +74,7 @@ const commonTop = [
       ),
       (tense) => <>you {tenseAlt(tense, 'have', 'had')} 2 charges</>,
     ),
-  }, 
+  },
   talents.RISING_SUN_KICK_TALENT,
 ];
 
@@ -70,18 +85,19 @@ const atMissingCondition = cnd.buffMissing(talents.ANCIENT_TEACHINGS_TALENT, {
 });
 
 const EF_AT = {
-    spell: talents.ESSENCE_FONT_TALENT,
-    condition: atMissingCondition,
-}
+  spell: talents.ESSENCE_FONT_TALENT,
+  condition: atMissingCondition,
+};
 
 const rotation_rm_at_sg = build([
   {
     spell: talents.RENEWING_MIST_TALENT,
-    condition: cnd.describe(
-      cnd.lastSpellCast(talents.THUNDER_FOCUS_TEA_TALENT),
-    (tense) => 
-      <> you cast <SpellLink id={talents.THUNDER_FOCUS_TEA_TALENT}/></>,
-    ),
+    condition: cnd.describe(cnd.lastSpellCast(talents.THUNDER_FOCUS_TEA_TALENT), (tense) => (
+      <>
+        {' '}
+        you cast <SpellLink id={talents.THUNDER_FOCUS_TEA_TALENT} />
+      </>
+    )),
   },
   ...commonTop,
   SHEILUNS_SHAOHAOS,
@@ -97,11 +113,12 @@ const rotation_rm_at_sg = build([
 const rotation_rm_at_upw = build([
   {
     spell: talents.ESSENCE_FONT_TALENT,
-    condition: cnd.describe(
-      cnd.lastSpellCast(talents.THUNDER_FOCUS_TEA_TALENT),
-    (tense) => 
-      <> you cast <SpellLink id={talents.THUNDER_FOCUS_TEA_TALENT}/></>,
-    ),
+    condition: cnd.describe(cnd.lastSpellCast(talents.THUNDER_FOCUS_TEA_TALENT), (tense) => (
+      <>
+        {' '}
+        you cast <SpellLink id={talents.THUNDER_FOCUS_TEA_TALENT} />
+      </>
+    )),
   },
   ...commonTop,
   SHEILUNS_SHAOHAOS,
@@ -143,23 +160,21 @@ export enum MistweaverApl {
 export const chooseApl = (info: PlayerInfo): MistweaverApl => {
   if (
     info.combatant.hasTalent(talents.ANCIENT_TEACHINGS_TALENT) &&
-    info.combatant.hasTalent(talents.RISING_MIST_TALENT) && 
+    info.combatant.hasTalent(talents.RISING_MIST_TALENT) &&
     info.combatant.hasTalent(talents.SHAOHAOS_LESSONS_TALENT)
   ) {
     return MistweaverApl.RisingMistAncientTeachingsShaohaos;
-  }
-  else if( 
+  } else if (
     info.combatant.hasTalent(talents.ANCIENT_TEACHINGS_TALENT) &&
-    info.combatant.hasTalent(talents.RISING_MIST_TALENT) && 
+    info.combatant.hasTalent(talents.RISING_MIST_TALENT) &&
     info.combatant.hasTalent(talents.UPWELLING_TALENT)
-    ) {
-  return MistweaverApl.RisingMistAncientTeachingsUpwellFls;
-  }
-  else if(
+  ) {
+    return MistweaverApl.RisingMistAncientTeachingsUpwellFls;
+  } else if (
     info.combatant.hasTalent(talents.CLOUDED_FOCUS_TALENT) &&
-    info.combatant.hasTalent(talents.RISING_MIST_TALENT) && 
+    info.combatant.hasTalent(talents.RISING_MIST_TALENT) &&
     info.combatant.hasTalent(talents.SHAOHAOS_LESSONS_TALENT)
-  ){
+  ) {
     return MistweaverApl.RisingMistCloudedFocusShaohaos;
   }
   return MistweaverApl.Fallback;

--- a/src/analysis/retail/monk/mistweaver/modules/core/AplCheck.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/AplCheck.tsx
@@ -21,10 +21,17 @@ const AOE_SCK = {
   ),
 };
 
-const VIVIFY_10_REMS = {
+
+
+const SHEILUNS_SHAOHAOS = {
+    spell: talents.SHEILUNS_GIFT_TALENT,
+    condition: cnd.optional(cnd.buffStacks(SPELLS.SHEILUN_CLOUD_BUFF, {atLeast: 4, atMost:10})),
+};
+
+const VIVIFY_8_REMS = {
   spell: SPELLS.VIVIFY,
   condition: cnd.targetsHit(
-    { atLeast: 10 },
+    { atLeast: 8 },
     {
       targetSpell: SPELLS.VIVIFY,
       targetType: EventType.Heal,
@@ -52,8 +59,8 @@ const commonTop = [
       ),
       (tense) => <>you {tenseAlt(tense, 'have', 'had')} 2 charges</>,
     ),
-  },
-  talents.THUNDER_FOCUS_TEA_TALENT,
+  }, 
+  talents.RISING_SUN_KICK_TALENT,
 ];
 
 const commonBottom = [talents.CHI_WAVE_TALENT, SPELLS.EXPEL_HARM];
@@ -62,14 +69,44 @@ const atMissingCondition = cnd.buffMissing(talents.ANCIENT_TEACHINGS_TALENT, {
   timeRemaining: 1500,
 });
 
-const rotation_rm_at = build([
-  ...commonTop,
-  talents.RISING_SUN_KICK_TALENT,
-  VIVIFY_10_REMS,
-  {
+const EF_AT = {
     spell: talents.ESSENCE_FONT_TALENT,
     condition: atMissingCondition,
+}
+
+const rotation_rm_at_sg = build([
+  {
+    spell: talents.RENEWING_MIST_TALENT,
+    condition: cnd.describe(
+      cnd.lastSpellCast(talents.THUNDER_FOCUS_TEA_TALENT),
+    (tense) => 
+      <> you cast <SpellLink id={talents.THUNDER_FOCUS_TEA_TALENT}/></>,
+    ),
   },
+  ...commonTop,
+  SHEILUNS_SHAOHAOS,
+  VIVIFY_8_REMS,
+  EF_AT,
+  VIVIFY_6_REMS,
+  SPELLS.BLACKOUT_KICK,
+  talents.CHI_BURST_TALENT,
+  SPELLS.TIGER_PALM,
+  ...commonBottom,
+]);
+
+const rotation_rm_at_upw = build([
+  {
+    spell: talents.ESSENCE_FONT_TALENT,
+    condition: cnd.describe(
+      cnd.lastSpellCast(talents.THUNDER_FOCUS_TEA_TALENT),
+    (tense) => 
+      <> you cast <SpellLink id={talents.THUNDER_FOCUS_TEA_TALENT}/></>,
+    ),
+  },
+  ...commonTop,
+  SHEILUNS_SHAOHAOS,
+  VIVIFY_8_REMS,
+  EF_AT,
   VIVIFY_6_REMS,
   {
     spell: talents.FAELINE_STOMP_TALENT,
@@ -89,10 +126,7 @@ const rotation_rm_at = build([
     ),
   },
   SPELLS.BLACKOUT_KICK,
-  {
-    spell: talents.CHI_BURST_TALENT,
-    condition: cnd.hasTalent(talents.CHI_BURST_TALENT),
-  },
+  talents.CHI_BURST_TALENT,
   SPELLS.TIGER_PALM,
   ...commonBottom,
 ]);
@@ -100,22 +134,41 @@ const rotation_rm_at = build([
 const rotation_fallback = build([...commonTop, ...commonBottom]);
 
 export enum MistweaverApl {
-  RisingMistAncientTeachings,
+  RisingMistAncientTeachingsShaohaos,
+  RisingMistAncientTeachingsUpwellFls,
+  RisingMistCloudedFocusShaohaos,
   Fallback,
 }
 
 export const chooseApl = (info: PlayerInfo): MistweaverApl => {
   if (
     info.combatant.hasTalent(talents.ANCIENT_TEACHINGS_TALENT) &&
-    info.combatant.hasTalent(talents.RISING_MIST_TALENT)
+    info.combatant.hasTalent(talents.RISING_MIST_TALENT) && 
+    info.combatant.hasTalent(talents.SHAOHAOS_LESSONS_TALENT)
   ) {
-    return MistweaverApl.RisingMistAncientTeachings;
+    return MistweaverApl.RisingMistAncientTeachingsShaohaos;
+  }
+  else if( 
+    info.combatant.hasTalent(talents.ANCIENT_TEACHINGS_TALENT) &&
+    info.combatant.hasTalent(talents.RISING_MIST_TALENT) && 
+    info.combatant.hasTalent(talents.UPWELLING_TALENT)
+    ) {
+  return MistweaverApl.RisingMistAncientTeachingsUpwellFls;
+  }
+  else if(
+    info.combatant.hasTalent(talents.CLOUDED_FOCUS_TALENT) &&
+    info.combatant.hasTalent(talents.RISING_MIST_TALENT) && 
+    info.combatant.hasTalent(talents.SHAOHAOS_LESSONS_TALENT)
+  ){
+    return MistweaverApl.RisingMistCloudedFocusShaohaos;
   }
   return MistweaverApl.Fallback;
 };
 
 const apls: Record<MistweaverApl, Apl> = {
-  [MistweaverApl.RisingMistAncientTeachings]: rotation_rm_at,
+  [MistweaverApl.RisingMistAncientTeachingsShaohaos]: rotation_rm_at_sg,
+  [MistweaverApl.RisingMistAncientTeachingsUpwellFls]: rotation_rm_at_upw,
+  [MistweaverApl.RisingMistCloudedFocusShaohaos]: rotation_fallback, //todo
   [MistweaverApl.Fallback]: rotation_fallback,
 };
 

--- a/src/analysis/retail/monk/mistweaver/modules/core/AplCheck.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/AplCheck.tsx
@@ -77,13 +77,13 @@ const rotation_rm_at = build([
       cnd.and(
         cnd.hasTalent(talents.FAELINE_STOMP_TALENT),
         cnd.hasTalent(talents.UPWELLING_TALENT),
-        cnd.spellAvailable(talents.ESSENCE_FONT_TALENT, true),
+        cnd.spellCooldownRemaining(talents.ESSENCE_FONT_TALENT, { atLeast: 0.00001 }),
         atMissingCondition,
       ),
       (tense) => (
         <>
-          and <SpellLink id={talents.ESSENCE_FONT_TALENT} /> {tenseAlt(tense, 'is', 'was')} on
-          cooldown
+          <SpellLink id={talents.ESSENCE_FONT_TALENT} /> {tenseAlt(tense, 'is', 'was')} on cooldown
+          and <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} /> is missing or about to expire.
         </>
       ),
     ),

--- a/src/analysis/retail/monk/mistweaver/modules/core/AplCheck.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/AplCheck.tsx
@@ -1,0 +1,135 @@
+import SPELLS from 'common/SPELLS';
+import { suggestion } from 'parser/core/Analyzer';
+import aplCheck, { Apl, build, CheckResult, PlayerInfo, tenseAlt } from 'parser/shared/metrics/apl';
+import annotateTimeline from 'parser/shared/metrics/apl/annotate';
+import * as cnd from 'parser/shared/metrics/apl/conditions';
+import talents from 'common/TALENTS/monk';
+import { AnyEvent, EventType } from 'parser/core/Events';
+import { SpellLink } from 'interface';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const AOE_SCK = {
+  spell: SPELLS.SPINNING_CRANE_KICK,
+  condition: cnd.and(
+    cnd.targetsHit(
+      { atLeast: 4 },
+      {
+        targetSpell: SPELLS.SPINNING_CRANE_KICK_DAMAGE,
+      },
+    ),
+    cnd.hasTalent(talents.AWAKENED_FAELINE_TALENT),
+  ),
+};
+
+const VIVIFY_10_REMS = {
+  spell: SPELLS.VIVIFY,
+  condition: cnd.targetsHit(
+    { atLeast: 10 },
+    {
+      targetSpell: SPELLS.VIVIFY,
+      targetType: EventType.Heal,
+    },
+  ),
+};
+const VIVIFY_6_REMS = {
+  spell: SPELLS.VIVIFY,
+  condition: cnd.targetsHit(
+    { atLeast: 6 },
+    {
+      targetSpell: SPELLS.VIVIFY,
+      targetType: EventType.Heal,
+    },
+  ),
+};
+
+const commonTop = [
+  {
+    spell: talents.RENEWING_MIST_TALENT,
+    condition: cnd.describe(
+      cnd.and(
+        cnd.spellCharges(talents.RENEWING_MIST_TALENT, { atLeast: 2 }),
+        cnd.spellAvailable(talents.RENEWING_MIST_TALENT),
+      ),
+      (tense) => <>you {tenseAlt(tense, 'have', 'had')} 2 charges</>,
+    ),
+  },
+  talents.THUNDER_FOCUS_TEA_TALENT,
+];
+
+const commonBottom = [talents.CHI_WAVE_TALENT, SPELLS.EXPEL_HARM];
+const atMissingCondition = cnd.buffMissing(talents.ANCIENT_TEACHINGS_TALENT, {
+  duration: 15000,
+  timeRemaining: 1500,
+});
+
+const rotation_rm_at = build([
+  ...commonTop,
+  talents.RISING_SUN_KICK_TALENT,
+  VIVIFY_10_REMS,
+  {
+    spell: talents.ESSENCE_FONT_TALENT,
+    condition: atMissingCondition,
+  },
+  VIVIFY_6_REMS,
+  {
+    spell: talents.FAELINE_STOMP_TALENT,
+    condition: cnd.describe(
+      cnd.and(
+        cnd.hasTalent(talents.FAELINE_STOMP_TALENT),
+        cnd.hasTalent(talents.UPWELLING_TALENT),
+        cnd.spellAvailable(talents.ESSENCE_FONT_TALENT, true),
+        atMissingCondition,
+      ),
+      (tense) => (
+        <>
+          and <SpellLink id={talents.ESSENCE_FONT_TALENT} /> {tenseAlt(tense, 'is', 'was')} on
+          cooldown
+        </>
+      ),
+    ),
+  },
+  SPELLS.BLACKOUT_KICK,
+  {
+    spell: talents.CHI_BURST_TALENT,
+    condition: cnd.hasTalent(talents.CHI_BURST_TALENT),
+  },
+  SPELLS.TIGER_PALM,
+  ...commonBottom,
+]);
+
+const rotation_fallback = build([...commonTop, ...commonBottom]);
+
+export enum MistweaverApl {
+  RisingMistAncientTeachings,
+  Fallback,
+}
+
+export const chooseApl = (info: PlayerInfo): MistweaverApl => {
+  if (
+    info.combatant.hasTalent(talents.ANCIENT_TEACHINGS_TALENT) &&
+    info.combatant.hasTalent(talents.RISING_MIST_TALENT)
+  ) {
+    return MistweaverApl.RisingMistAncientTeachings;
+  }
+  return MistweaverApl.Fallback;
+};
+
+const apls: Record<MistweaverApl, Apl> = {
+  [MistweaverApl.RisingMistAncientTeachings]: rotation_rm_at,
+  [MistweaverApl.Fallback]: rotation_fallback,
+};
+
+export const apl = (info: PlayerInfo): Apl => {
+  return apls[chooseApl(info)];
+};
+
+export const check = (events: AnyEvent[], info: PlayerInfo): CheckResult => {
+  const check = aplCheck(apl(info));
+  return check(events, info);
+};
+
+export default suggestion((events, info) => {
+  const { violations } = check(events, info);
+  annotateTimeline(violations);
+  return undefined;
+});

--- a/src/analysis/retail/monk/mistweaver/modules/core/AplChoiceDescription.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/AplChoiceDescription.tsx
@@ -11,15 +11,15 @@ const aplTitle = (choice: MistweaverApl) => {
         <>
           <SpellLink id={talents.RISING_MIST_TALENT} /> /{' '}
           <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} /> /{' '}
-          <SpellLink id={talents.SHAOHAOS_LESSONS_TALENT}/>
+          <SpellLink id={talents.SHAOHAOS_LESSONS_TALENT} />
         </>
       );
-      case MistweaverApl.RisingMistAncientTeachingsUpwellFls:
-         return (
+    case MistweaverApl.RisingMistAncientTeachingsUpwellFls:
+      return (
         <>
           <SpellLink id={talents.RISING_MIST_TALENT} /> /{' '}
           <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} /> /{' '}
-          <SpellLink id={talents.UPWELLING_TALENT}/>
+          <SpellLink id={talents.UPWELLING_TALENT} />
         </>
       );
     default:
@@ -36,19 +36,10 @@ const RisingMistDescription = () => {
 };
 
 const AncientTeachingsDescription = () => {
-  const info = useInfo();
   return (
     <>
-      <SpellLink id={talents.ESSENCE_FONT_TALENT} />{' '}
-      {info?.combatant.hasTalent(talents.FAELINE_STOMP_TALENT) ? (
-        <>
-          or <SpellLink id={talents.FAELINE_STOMP_TALENT} />{' '}
-        </>
-      ) : (
-        <></>
-      )}
-      to empower your damaging abilities <SpellLink id={talents.RISING_SUN_KICK_TALENT} />,{' '}
-      <SpellLink id={SPELLS.BLACKOUT_KICK} />, and <SpellLink id={SPELLS.TIGER_PALM} /> to heal via{' '}
+      to heal by using your damaging abilities (<SpellLink id={talents.RISING_SUN_KICK_TALENT} />,{' '}
+      <SpellLink id={SPELLS.BLACKOUT_KICK} />, and <SpellLink id={SPELLS.TIGER_PALM} />) via{' '}
       <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} />.
     </>
   );
@@ -64,14 +55,17 @@ const RisingMistAncientTeachingsShaohaosDescription = () => {
       </p>
       <p>
         When playing <SpellLink id={talents.RISING_MIST_TALENT} /> and{' '}
-        <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} /> with <SpellLink id={talents.SHAOHAOS_LESSONS_TALENT}/>, you cast{' '}
+        <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} /> with{' '}
+        <SpellLink id={talents.SHAOHAOS_LESSONS_TALENT} />, you cast{' '}
         <SpellLink id={talents.RENEWING_MIST_TALENT} /> and{' '}
         <SpellLink id={talents.RISING_SUN_KICK_TALENT} /> as often as possible, and cast{' '}
-        <SpellLink id={talents.ESSENCE_FONT_TALENT} />{' '}
-        as often as necessary to maintain the <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} />{' '}
-        buff. You will aim to cast <SpellLink id={talents.SHEILUNS_GIFT_TALENT}/> to align with your cooldown usage and moments of heavy healing to make use of the various
-        {' '}<SpellLink id={talents.SHAOHAOS_LESSONS_TALENT}/> buffs.{' '}
-        <SpellLink id={talents.THUNDER_FOCUS_TEA_TALENT}/> is primarily used on <SpellLink id={talents.RENEWING_MIST_TALENT}/> with this build.
+        <SpellLink id={talents.ESSENCE_FONT_TALENT} /> as often as necessary to maintain the{' '}
+        <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} /> buff. You will aim to cast{' '}
+        <SpellLink id={talents.SHEILUNS_GIFT_TALENT} /> to align with your cooldown usage and
+        moments of heavy healing to make use of the various{' '}
+        <SpellLink id={talents.SHAOHAOS_LESSONS_TALENT} /> buffs.{' '}
+        <SpellLink id={talents.THUNDER_FOCUS_TEA_TALENT} /> is primarily used on{' '}
+        <SpellLink id={talents.RENEWING_MIST_TALENT} /> with this build.
       </p>
     </>
   );
@@ -91,7 +85,7 @@ const RisingMistAncientTeachingsUpwelFlsDescription = () => {
         <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} />, you cast{' '}
         <SpellLink id={talents.RENEWING_MIST_TALENT} /> and{' '}
         <SpellLink id={talents.RISING_SUN_KICK_TALENT} /> as often as possible, and cast{' '}
-        <SpellLink id={talents.ESSENCE_FONT_TALENT} />
+        <SpellLink id={talents.ESSENCE_FONT_TALENT} />{' '}
         {info?.combatant.hasTalent(talents.FAELINE_STOMP_TALENT) ? (
           <>
             or <SpellLink id={talents.FAELINE_STOMP_TALENT} /> if{' '}
@@ -101,7 +95,8 @@ const RisingMistAncientTeachingsUpwelFlsDescription = () => {
           <></>
         )}{' '}
         as often as necessary to maintain the <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} />{' '}
-        buff. <SpellLink id={talents.THUNDER_FOCUS_TEA_TALENT}/> is primarily used on <SpellLink id={talents.ESSENCE_FONT_TALENT}/> with this build.
+        buff. <SpellLink id={talents.THUNDER_FOCUS_TEA_TALENT} /> is primarily used on{' '}
+        <SpellLink id={talents.ESSENCE_FONT_TALENT} /> with this build.
       </p>
     </>
   );
@@ -128,7 +123,7 @@ const Description = ({ aplChoice }: { aplChoice: MistweaverApl }) => {
       return <RisingMistAncientTeachingsShaohaosDescription />;
     case MistweaverApl.RisingMistAncientTeachingsUpwellFls:
       return <RisingMistAncientTeachingsUpwelFlsDescription />;
-      default:
+    default:
       return <FallbackDescription />;
   }
 };

--- a/src/analysis/retail/monk/mistweaver/modules/core/AplChoiceDescription.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/AplChoiceDescription.tsx
@@ -6,11 +6,20 @@ import { MistweaverApl } from './AplCheck';
 
 const aplTitle = (choice: MistweaverApl) => {
   switch (choice) {
-    case MistweaverApl.RisingMistAncientTeachings:
+    case MistweaverApl.RisingMistAncientTeachingsShaohaos:
       return (
         <>
           <SpellLink id={talents.RISING_MIST_TALENT} /> /{' '}
-          <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} />
+          <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} /> /{' '}
+          <SpellLink id={talents.SHAOHAOS_LESSONS_TALENT}/>
+        </>
+      );
+      case MistweaverApl.RisingMistAncientTeachingsUpwellFls:
+         return (
+        <>
+          <SpellLink id={talents.RISING_MIST_TALENT} /> /{' '}
+          <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} /> /{' '}
+          <SpellLink id={talents.UPWELLING_TALENT}/>
         </>
       );
     default:
@@ -45,12 +54,35 @@ const AncientTeachingsDescription = () => {
   );
 };
 
-const RisingMistAncientTeachingsDescription = () => {
+const RisingMistAncientTeachingsShaohaosDescription = () => {
+  return (
+    <>
+      <p>
+        The {aplTitle(MistweaverApl.RisingMistAncientTeachingsShaohaos)} rotation uses{' '}
+        <RisingMistDescription />
+        <AncientTeachingsDescription />
+      </p>
+      <p>
+        When playing <SpellLink id={talents.RISING_MIST_TALENT} /> and{' '}
+        <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} /> with <SpellLink id={talents.SHAOHAOS_LESSONS_TALENT}/>, you cast{' '}
+        <SpellLink id={talents.RENEWING_MIST_TALENT} /> and{' '}
+        <SpellLink id={talents.RISING_SUN_KICK_TALENT} /> as often as possible, and cast{' '}
+        <SpellLink id={talents.ESSENCE_FONT_TALENT} />{' '}
+        as often as necessary to maintain the <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} />{' '}
+        buff. You will aim to cast <SpellLink id={talents.SHEILUNS_GIFT_TALENT}/> to align with your cooldown usage and moments of heavy healing to make use of the various
+        {' '}<SpellLink id={talents.SHAOHAOS_LESSONS_TALENT}/> buffs.{' '}
+        <SpellLink id={talents.THUNDER_FOCUS_TEA_TALENT}/> is primarily used on <SpellLink id={talents.RENEWING_MIST_TALENT}/> with this build.
+      </p>
+    </>
+  );
+};
+
+const RisingMistAncientTeachingsUpwelFlsDescription = () => {
   const info = useInfo();
   return (
     <>
       <p>
-        The {aplTitle(MistweaverApl.RisingMistAncientTeachings)} rotation uses{' '}
+        The {aplTitle(MistweaverApl.RisingMistAncientTeachingsUpwellFls)} rotation uses{' '}
         <RisingMistDescription />
         <AncientTeachingsDescription />
       </p>
@@ -69,7 +101,7 @@ const RisingMistAncientTeachingsDescription = () => {
           <></>
         )}{' '}
         as often as necessary to maintain the <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} />{' '}
-        buff.
+        buff. <SpellLink id={talents.THUNDER_FOCUS_TEA_TALENT}/> is primarily used on <SpellLink id={talents.ESSENCE_FONT_TALENT}/> with this build.
       </p>
     </>
   );
@@ -92,9 +124,11 @@ const FallbackDescription = () => (
 
 const Description = ({ aplChoice }: { aplChoice: MistweaverApl }) => {
   switch (aplChoice) {
-    case MistweaverApl.RisingMistAncientTeachings:
-      return <RisingMistAncientTeachingsDescription />;
-    default:
+    case MistweaverApl.RisingMistAncientTeachingsShaohaos:
+      return <RisingMistAncientTeachingsShaohaosDescription />;
+    case MistweaverApl.RisingMistAncientTeachingsUpwellFls:
+      return <RisingMistAncientTeachingsUpwelFlsDescription />;
+      default:
       return <FallbackDescription />;
   }
 };

--- a/src/analysis/retail/monk/mistweaver/modules/core/AplChoiceDescription.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/AplChoiceDescription.tsx
@@ -1,0 +1,122 @@
+import SPELLS from 'common/SPELLS';
+import talents from 'common/TALENTS/monk';
+import { AlertWarning, SpellLink } from 'interface';
+import { useInfo } from 'interface/guide';
+import { MistweaverApl } from './AplCheck';
+
+const aplTitle = (choice: MistweaverApl) => {
+  switch (choice) {
+    case MistweaverApl.RisingMistAncientTeachings:
+      return (
+        <>
+          <SpellLink id={talents.RISING_MIST_TALENT} /> /{' '}
+          <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} />
+        </>
+      );
+    default:
+      return <em>Fallback</em>;
+  }
+};
+
+const RisingMistDescription = () => {
+  return (
+    <>
+      <SpellLink id={talents.RISING_SUN_KICK_TALENT} /> to extend hots and{' '}
+    </>
+  );
+};
+
+const AncientTeachingsDescription = () => {
+  const info = useInfo();
+  return (
+    <>
+      <SpellLink id={talents.ESSENCE_FONT_TALENT} />
+      {info?.combatant.hasTalent(talents.FAELINE_STOMP_TALENT) ? (
+        <>
+          or <SpellLink id={talents.FAELINE_STOMP_TALENT} />
+        </>
+      ) : (
+        <></>
+      )}{' '}
+      to empower your damaging abilities <SpellLink id={talents.RISING_SUN_KICK_TALENT} />,{' '}
+      <SpellLink id={SPELLS.BLACKOUT_KICK} />, and <SpellLink id={SPELLS.TIGER_PALM} /> to heal via{' '}
+      <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} />.
+    </>
+  );
+};
+
+const RisingMistAncientTeachingsDescription = () => {
+  const info = useInfo();
+  return (
+    <>
+      <p>
+        The {aplTitle(MistweaverApl.RisingMistAncientTeachings)} rotation uses{' '}
+        <RisingMistDescription />
+        <AncientTeachingsDescription />
+      </p>
+      <p>
+        When playing <SpellLink id={talents.RISING_MIST_TALENT} /> and{' '}
+        <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} />, you cast{' '}
+        <SpellLink id={talents.RENEWING_MIST_TALENT} /> and{' '}
+        <SpellLink id={talents.RISING_SUN_KICK_TALENT} /> as often as possible, and cast{' '}
+        <SpellLink id={talents.ESSENCE_FONT_TALENT} />
+        {info?.combatant.hasTalent(talents.FAELINE_STOMP_TALENT) ? (
+          <>
+            or <SpellLink id={talents.FAELINE_STOMP_TALENT} /> if{' '}
+            <SpellLink id={talents.ESSENCE_FONT_TALENT} /> is on cooldown
+          </>
+        ) : (
+          <></>
+        )}{' '}
+        as often as necessary to maintain the <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} />{' '}
+        buff.
+      </p>
+    </>
+  );
+};
+
+const FallbackDescription = () => (
+  <>
+    <p>
+      The {aplTitle(MistweaverApl.Fallback)} rotation is used when you don't have any
+      rotation-changing talents selected. You follow the core priority: high mana efficient spells
+      and short cooldowns, then filler damage spells. This is the simplest rotation, but practicing
+      it will build good habits that work with the other variations.
+    </p>
+    <AlertWarning>
+      Using <SpellLink id={talents.RISING_MIST_TALENT} /> is recommended, as it brings the entire
+      spec's toolkit together by creating multiple synergies between talents.
+    </AlertWarning>
+  </>
+);
+
+const Description = ({ aplChoice }: { aplChoice: MistweaverApl }) => {
+  switch (aplChoice) {
+    case MistweaverApl.RisingMistAncientTeachings:
+      return <RisingMistAncientTeachingsDescription />;
+    default:
+      return <FallbackDescription />;
+  }
+};
+
+export default function AplChoiceDescription({
+  aplChoice,
+}: {
+  aplChoice: MistweaverApl;
+}): JSX.Element {
+  return (
+    <>
+      <p>
+        Mistweavers have a few different variations to their core rotation, depending on your talent
+        selection. The core of the rotations does not change with{' '}
+        <SpellLink id={talents.RENEWING_MIST_TALENT} />,{' '}
+        <SpellLink id={talents.RISING_SUN_KICK_TALENT} />, and{' '}
+        <SpellLink id={talents.THUNDER_FOCUS_TEA_TALENT} /> always being the top priority abilities.
+      </p>
+      <p>
+        <strong>Selected Build:</strong> {aplTitle(aplChoice)}
+      </p>
+      <Description aplChoice={aplChoice} />
+    </>
+  );
+}

--- a/src/analysis/retail/monk/mistweaver/modules/core/AplChoiceDescription.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/AplChoiceDescription.tsx
@@ -30,14 +30,14 @@ const AncientTeachingsDescription = () => {
   const info = useInfo();
   return (
     <>
-      <SpellLink id={talents.ESSENCE_FONT_TALENT} />
+      <SpellLink id={talents.ESSENCE_FONT_TALENT} />{' '}
       {info?.combatant.hasTalent(talents.FAELINE_STOMP_TALENT) ? (
         <>
-          or <SpellLink id={talents.FAELINE_STOMP_TALENT} />
+          or <SpellLink id={talents.FAELINE_STOMP_TALENT} />{' '}
         </>
       ) : (
         <></>
-      )}{' '}
+      )}
       to empower your damaging abilities <SpellLink id={talents.RISING_SUN_KICK_TALENT} />,{' '}
       <SpellLink id={SPELLS.BLACKOUT_KICK} />, and <SpellLink id={SPELLS.TIGER_PALM} /> to heal via{' '}
       <SpellLink id={talents.ANCIENT_TEACHINGS_TALENT} />.

--- a/src/analysis/retail/monk/mistweaver/modules/core/ExplainCelestial.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/ExplainCelestial.tsx
@@ -1,0 +1,27 @@
+import Spell from 'common/SPELLS/Spell';
+import { useAnalyzer } from 'interface/guide';
+import { ViolationExplainer } from 'interface/guide/components/Apl/violations/claims';
+import { InternalRule } from 'parser/shared/metrics/apl';
+import BaseCelestialAnalyzer from '../spells/BaseCelestialAnalyzer';
+
+export const filterCelestial = (
+  explainer: ViolationExplainer<{ rule: InternalRule; spell: Spell }>,
+): typeof explainer => ({
+  ...explainer,
+  claim: (apl, result) =>
+    explainer.claim(apl, result).filter(({ claims }) => {
+      const celestial = useAnalyzer(BaseCelestialAnalyzer);
+      if (celestial) {
+        celestial.celestialWindows.forEach((end, start) => {
+          claims.forEach((violation) => {
+            if (violation.actualCast.timestamp >= start && violation.actualCast.timestamp <= end) {
+              claims.delete(violation);
+            }
+          });
+        });
+      }
+      return claims;
+    }),
+});
+
+export default filterCelestial;

--- a/src/analysis/retail/monk/mistweaver/modules/core/ExplainCelestial.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/ExplainCelestial.tsx
@@ -25,3 +25,4 @@ export const filterCelestial = (
 });
 
 export default filterCelestial;
+

--- a/src/analysis/retail/monk/mistweaver/modules/features/Abilities.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/Abilities.tsx
@@ -207,6 +207,15 @@ class Abilities extends CoreAbilities {
         },
         cooldown: 15,
       },
+      {
+        spell: TALENTS_MONK.SHEILUNS_GIFT_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS_MONK.SHEILUNS_GIFT_TALENT),
+        category: SPELL_CATEGORY.OTHERS,
+        gcd: {
+          base: 1500,
+        },
+        cooldown: combatant.hasTalent(TALENTS_MONK.VEIL_OF_PRIDE_TALENT) ? 4 : 8,
+      },
 
       // Utility Spells
       {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/AncientTeachingsoftheMonastery.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/AncientTeachingsoftheMonastery.tsx
@@ -47,25 +47,22 @@ class AncientTeachingsoftheMonastery extends Analyzer {
       this.lastDamageEvent,
     );
     this.addEventListener(
-      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.ATOTM_HEAL),
+      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.AT_HEAL),
       this.calculateEffectiveHealing,
     );
     this.addEventListener(
-      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.ATOTM_CRIT_HEAL),
+      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.AT_CRIT_HEAL),
       this.calculateEffectiveHealing,
     );
+    this.addEventListener(Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.AT_BUFF), this.onApply);
     this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.ATOTM_BUFF),
-      this.onApply,
-    );
-    this.addEventListener(
-      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.ATOTM_BUFF),
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.AT_BUFF),
       this.onRemove,
     );
   }
 
   lastDamageEvent(event: DamageEvent) {
-    if (!this.selectedCombatant.hasBuff(SPELLS.ATOTM_BUFF.id)) {
+    if (!this.selectedCombatant.hasBuff(SPELLS.AT_BUFF.id)) {
       return;
     }
     this.lastDamageSpellID = event.ability.guid;
@@ -170,7 +167,7 @@ class AncientTeachingsoftheMonastery extends Analyzer {
 
   get suggestionThresholds() {
     return {
-      actual: this.selectedCombatant.getBuffUptime(SPELLS.ATOTM_BUFF.id) / this.owner.fightDuration,
+      actual: this.selectedCombatant.getBuffUptime(SPELLS.AT_BUFF.id) / this.owner.fightDuration,
       isLessThan: {
         minor: 0.8,
         average: 0.7,
@@ -210,8 +207,7 @@ class AncientTeachingsoftheMonastery extends Analyzer {
       >
         <div className="pad">
           <label>
-            <SpellLink id={SPELLS.ATOTM_HEAL.id}>Ancient Teachings of the Monastery</SpellLink>{' '}
-            breakdown
+            <SpellLink id={SPELLS.AT_HEAL.id}>Ancient Teachings</SpellLink> breakdown
           </label>
           {this.renderDonutChart()}
         </div>

--- a/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
@@ -51,6 +51,9 @@ class BaseCelestialAnalyzer extends Analyzer {
   siApplyTime: number = -1;
   lessonsApplyTime: number = -1;
   celestialActive: boolean = false;
+  currentCelestialStart: number = -1;
+  lastCelestialEnd: number = -1;
+  celestialWindows: Map<number, number> = new Map<number, number>();
   castTrackers: BaseCelestialTracker[] = [];
   hasteDataPoints: number[] = []; // use this to estimate average haste during celestial
   goodSiDuration: number = 0; // how long SI should last during celestial
@@ -132,6 +135,7 @@ class BaseCelestialAnalyzer extends Analyzer {
 
   onSummon(event: SummonEvent) {
     this.celestialActive = true;
+    this.currentCelestialStart = event.timestamp;
     this.hasteDataPoints = [];
     SECRET_INFUSION_BUFFS.forEach((spell) => {
       if (this.selectedCombatant.hasBuff(spell.id)) {
@@ -382,6 +386,9 @@ class BaseCelestialAnalyzer extends Analyzer {
       return;
     }
     this.celestialActive = false;
+    this.celestialWindows.set(this.currentCelestialStart, event.timestamp);
+    this.currentCelestialStart = -1;
+    this.lastCelestialEnd = event.timestamp;
     this.castTrackers.at(-1)!.averageHaste = this.curAverageHaste;
     this.castTrackers.at(-1)!.deathTimestamp = event.timestamp;
     const hasInfusion = SECRET_INFUSION_BUFFS.some((spell) => {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ManaTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ManaTea.tsx
@@ -214,7 +214,7 @@ class ManaTea extends Analyzer {
   }
 
   get guideCastBreakdown() {
-    const explanationPercent = 50;
+    const explanationPercent = 55;
     const explanation = (
       <p>
         <strong>
@@ -263,7 +263,7 @@ class ManaTea extends Analyzer {
               </>
             ),
             result: <PerformanceMark perf={manaPerf} />,
-            details: <>{formatNumber(cast.manaSaved)} mana saved</>,
+            details: <>{formatNumber(cast.manaSaved)}</>,
           });
           const overhealingPercent = this.getCastOverhealingPercent(cast);
           let overhealingPerf = QualitativePerformance.Good;
@@ -293,11 +293,11 @@ class ManaTea extends Analyzer {
             checklistItems.push({
               label: (
                 <>
-                  Avg number of <SpellLink id={SPELLS.VIVIFY} /> cleaves per cast
+                  Avg <SpellLink id={SPELLS.VIVIFY} /> cleaves per cast
                 </>
               ),
               result: <PerformanceMark perf={vivCleavePerf} />,
-              details: <>{avgCleaves.toFixed(1)} avg cleaves</>,
+              details: <>{avgCleaves.toFixed(1)}</>,
             });
             allPerfs.push(vivCleavePerf);
           }

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -143,19 +143,19 @@ const spells = spellIndexableList({
     name: 'Vivifacious Vivification',
     icon: 'ability_monk_vivify',
   },
-  ATOTM_BUFF: {
+  AT_BUFF: {
     id: 388026,
-    name: 'Ancient Teachings of the Monestary',
+    name: 'Ancient Teachings',
     icon: 'inv_misc_book_07',
   },
-  ATOTM_HEAL: {
+  AT_HEAL: {
     id: 388024,
-    name: 'Ancient Teachings of the Monestary',
+    name: 'Ancient Teachings',
     icon: 'inv_jewelcrafting_jadeserpent',
   },
-  ATOTM_CRIT_HEAL: {
+  AT_CRIT_HEAL: {
     id: 388025,
-    name: 'Ancient Teachings of the Monestary',
+    name: 'Ancient Teachings',
     icon: 'inv_jewelcrafting_jadeserpent',
   },
   INVOKERS_DELIGHT_BUFF: {

--- a/src/interface/guide/components/Apl/violations/claims.tsx
+++ b/src/interface/guide/components/Apl/violations/claims.tsx
@@ -15,6 +15,7 @@ import {
 import { ConditionDescription } from 'parser/shared/metrics/apl/annotate';
 import Enemies from 'parser/shared/modules/Enemies';
 import useTooltip from 'interface/useTooltip';
+import Combatants from 'parser/shared/modules/Combatants';
 
 export type AplProblemData<T> = {
   claims: Set<Violation>;
@@ -61,6 +62,7 @@ const defaultClaimFilter = (
 
 function TargetName({ event }: { event: AnyEvent }) {
   const combatants = useAnalyzer(Enemies);
+  const friendlies = useAnalyzer(Combatants);
   const { npc: npcTooltip } = useTooltip();
 
   if (!combatants) {
@@ -68,12 +70,13 @@ function TargetName({ event }: { event: AnyEvent }) {
   }
 
   const enemy = combatants.getEntity(event);
-
-  if (!enemy) {
-    return <span className="spell-link-text">Unknown</span>;
+  const friendly = friendlies?.getEntity(event);
+  if (!enemy && friendly) {
+    return <span className={friendly.spec?.className}>{friendly.name}</span>;
+  } else if (enemy && !friendly) {
+    return <a href={npcTooltip(enemy.guid)}>{enemy.name}</a>;
   }
-
-  return <a href={npcTooltip(enemy.guid)}>{enemy.name}</a>;
+  return <span className="spell-link-text">Unknown</span>;
 }
 
 function EventTimestamp({ event }: { event: AnyEvent }) {

--- a/src/parser/shared/metrics/apl/conditions/targetsHit.tsx
+++ b/src/parser/shared/metrics/apl/conditions/targetsHit.tsx
@@ -1,7 +1,7 @@
 import type Spell from 'common/SPELLS/Spell';
 import { HasAbility, HasTarget, EventType } from 'parser/core/Events';
 import { encodeEventTargetString } from 'parser/shared/modules/Enemies';
-
+import { encodeFriendlyEventTargetString } from 'parser/shared/modules/Entities';
 import { tenseAlt, Condition } from '../index';
 import { Range, formatRange } from './index';
 
@@ -30,9 +30,13 @@ export interface Options {
  * then load times will suffer.
  **/
 export default function targetsHit(range: Range, options?: Partial<Options>): Condition<void> {
-  const { lookahead, targetType: type, targetSpell } = {
+  const {
+    lookahead,
+    targetType: type,
+    targetSpell,
+  } = {
     lookahead: 100,
-    targetType: EventType.Damage,
+    targetType: EventType.Damage || EventType.Heal,
     ...options,
   };
 
@@ -57,7 +61,11 @@ export default function targetsHit(range: Range, options?: Partial<Options>): Co
           HasTarget(fwdEvent) &&
           fwdEvent.ability.guid === targetSpellId
         ) {
-          targets.add(encodeEventTargetString(fwdEvent));
+          if (!fwdEvent.targetIsFriendly) {
+            targets.add(encodeEventTargetString(fwdEvent));
+          } else {
+            targets.add(encodeFriendlyEventTargetString(fwdEvent));
+          }
         }
       }
       return (

--- a/src/parser/shared/modules/Entities.ts
+++ b/src/parser/shared/modules/Entities.ts
@@ -13,6 +13,7 @@ import Events, {
   RemoveBuffStackEvent,
   RemoveDebuffEvent,
   RemoveDebuffStackEvent,
+  HasTarget,
 } from 'parser/core/Events';
 import EventEmitter from 'parser/core/modules/EventEmitter';
 
@@ -20,6 +21,17 @@ const debug = false;
 
 const APPLY = 'apply';
 const REMOVE = 'remove';
+
+export function encodeFriendlyEventTargetString(event: AnyEvent) {
+  if (!HasTarget(event)) {
+    return null;
+  }
+  return encodeTargetString(event.targetID, event.targetInstance);
+}
+
+export function encodeTargetString(id: number, instance = 0) {
+  return `${id}.${instance}`;
+}
 
 abstract class Entities<T extends Entity> extends Analyzer {
   static dependencies = {


### PR DESCRIPTION
Added Core Rotation section to the mistweaver guide 
Added base files for multiple talent builds (similar to brewmaster)
Updated targetsHit condition and claims to accomodate friendly spells
Implemented first rotation priority checklist  for the most common raid build
![image](https://user-images.githubusercontent.com/26779541/219904865-91d62ecd-f14a-4a6d-9b2a-1ec826a95fc3.png)

More to add, but this is effective and functional where it is at. 
Breaking this up into multiple PRs to keep it less wieldy
