### PR TITLE
handle RP "fights" for classic

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -19,6 +19,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 2, 19), 'Added a workaround for handling of combatantinfo on Algalon, Yogg-Saron, and Hodir in WotLK Classic.', emallson),
   change(date(2023, 2, 9), <>Add <ItemLink id={ITEMS.POTION_OF_SHOCKING_DISCLOSURE_R3.id} /> to combat potion list.</>, ToppleTheNun),
   change(date(2023, 2, 6), 'Rewrite test utilities in TypeScript.', ToppleTheNun),
   change(date(2023, 2, 3), 'Remove old Classic Spec data for unsupported specs.', jazminite),

--- a/src/game/Expansion.ts
+++ b/src/game/Expansion.ts
@@ -23,3 +23,7 @@ export function isCurrentExpansion(expansion: Expansion): boolean {
 export function isRetailExpansion(expansion: Expansion): boolean {
   return expansion >= Expansion.Legion;
 }
+
+export function isClassicExpansion(expansion: Expansion): boolean {
+  return expansion >= Expansion.Vanilla && expansion <= Expansion.WrathOfTheLichKing;
+}

--- a/src/interface/report/PlayerLoader.tsx
+++ b/src/interface/report/PlayerLoader.tsx
@@ -102,6 +102,11 @@ const fcReducer = (state: State, action: Action): State => {
   }
 };
 
+/**
+ * This is a workaround for certain fights in classic having RP (especially buggy/inconsistent RP) split off into a separate dummy fight.
+ *
+ * Eventually, this will be obviated by switching to the PlayerDetails query of the v2 API, but we aren't there yet.
+ */
 async function fetchCombatantsWithClassicRP(
   report: Report,
   fight: WCLFight,

--- a/src/parser/core/Fight.ts
+++ b/src/parser/core/Fight.ts
@@ -4,6 +4,11 @@ export interface WCLFight {
   start_time: number;
   end_time: number;
   boss: number;
+  /**
+   * Set on fast wipe pulls (e.g. resets) and on trash "RP" fights when `boss`
+   * has been overridden to 0.
+   */
+  originalBoss?: number;
   name: string;
   size?: number;
   difficulty?: number;


### PR DESCRIPTION
there is a small chance that on rare occasions this could load out-of-date combatantinfo. we could whitelist specific fights (Algalon, Yogg-Saron, and Thorim all have this problem. Previously several fights in SWP/BT did as well), but that requires maintaining a whitelist and I'd rather not.

the consequences of using the wrong combatantinfo basically means loading the wrong gear/talents (and thus potentially picking the wrong spec)

you can see the issue in action here: https://classic.warcraftlogs.com/reports/1TNz8XaFcb7KhVAP#fight=43&type=summary&view=events

if you switch to fight 42, you can see the combatantinfo and encounterstart events. this is due to the way that WCL splits (buggy) RP from fights. 
