### PR TITLE
[Classic Restoration Druid] Correctly attribute revitalize when multiple rdruids in raid

### DIFF
--- a/src/analysis/classic/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/classic/druid/restoration/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { change, date } from 'common/changelog';
 import { jazminite, Arbixal } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2023, 2, 20), 'Fixed Revitalize for multiple resto druids in raid.', Arbixal),
   change(date(2023, 1, 25), 'Add Revitalise, Rejuvenation, Wild Growth, Lifebloom, and Swiftmend Analyzers', Arbixal),
   change(date(2023, 1, 10), 'Add Classic Restoration Druid stub.', jazminite),
 ];


### PR DESCRIPTION
### Description

Attributes the Revitalize proc to the correct resto druid. Previously both resto druids would get credit for all revitalize procs.

### Motivation

Reviewing a guild log with the rare situation of two resto druids, and needed more accurate information.

### Testing

Compare current functionality to the new one for logs with two resto druids (finding such logs will be the hardest part).

- Test report URL: `/report/FLh4VKfxZWgnPRw9/14-Normal+General+Vezax+-+Kill+(7:07)/Bixshift/standard/statistics`
- Screenshot(s):
### Before
![image](https://user-images.githubusercontent.com/1750811/220003818-ba542801-02c6-4d03-814c-c70a6ea3f904.png)

### After
![image](https://user-images.githubusercontent.com/1750811/220003893-48d122bc-b811-4b0b-a2cb-026c2adaf988.png)
plus
![image](https://user-images.githubusercontent.com/1750811/220003919-cd2fba8d-e954-4df4-89d7-3c6407220cb9.png)
