### PR TITLE
[Mistweaver] Fixed inconsistency in the Qualitative Performance flags on vivify casts

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 2, 23), <>Fixed inconsistent QualitativePerformance marks for <SpellLink id={SPELLS.VIVIFY.id}/> casts in the Guide.</>, Vohrr),
   change(date(2023, 2, 21), <>Added Initial version of <SpellLink id={TALENTS_MONK.CLOUDED_FOCUS_TALENT.id}/> apl.</>, Vohrr),
   change(date(2023, 2, 19), <>Added better APL handling for <SpellLink id={SPELLS.BLACKOUT_KICK}/> and <SpellLink id={SPELLS.VIVIFY.id}/>.</>, Vohrr),
   change(date(2023, 2, 18), <>Added pt 1 of the Core Rotation Section of the guide - <SpellLink id={TALENTS_MONK.RISING_MIST_TALENT.id}/> / <SpellLink id={TALENTS_MONK.ANCIENT_TEACHINGS_TALENT.id}/> build rotation.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Vivify.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Vivify.tsx
@@ -260,7 +260,7 @@ class Vivify extends Analyzer {
       value = QualitativePerformance.Perfect;
     } else if (rems >= 8) {
       value = QualitativePerformance.Good;
-    } else if (rems >= Math.round(this.estimatedAverageReMs)) {
+    } else if (rems >= 6) {
       value = QualitativePerformance.Ok;
     }
 


### PR DESCRIPTION
Setting to > 6 ReMs because Math.Floor and Math.Round were giving inconsistent results 