### PR TITLE
improve types for FilteredDamageTracker

### DIFF
--- a/src/analysis/retail/rogue/outlaw/CHANGELOG.tsx
+++ b/src/analysis/retail/rogue/outlaw/CHANGELOG.tsx
@@ -2,10 +2,12 @@ import { change, date } from 'common/changelog';
 import { Anty, zac } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 import TALENTS from 'common/TALENTS/rogue';
+import SHARED_CHANGELOG from 'analysis/retail/rogue/shared/CHANGELOG';
 import SPELLS from 'common/SPELLS';
 
 export default [
   change(date(2023, 2, 22), <>Add Fan the hammer normalizer to ignore subsequents <SpellLink id={SPELLS.PISTOL_SHOT}/> fake casts events.</>, zac),
   change(date(2023, 2, 20), <>First implementation of <SpellLink id={TALENTS.AUDACITY_TALENT} />.</>, zac),
   change(date(2022,11, 3), <>Enabling Spec for Dragonflight.</>, Anty),
+  ...SHARED_CHANGELOG,
 ];

--- a/src/analysis/retail/rogue/shared/CHANGELOG.tsx
+++ b/src/analysis/retail/rogue/shared/CHANGELOG.tsx
@@ -5,6 +5,6 @@ import { ToppleTheNun } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
-  change(date(2023, 2, 8), <>Improve <ResourceLink id={RESOURCE_TYPES.FURY.id} /> waste display in Guide.</>, ToppleTheNun),
-
+  change(date(2023, 2, 23), 'Improve types for FilteredDamageTracker.', ToppleTheNun),
+  change(date(2023, 2, 8), <>Improve <ResourceLink id={RESOURCE_TYPES.ENERGY.id} /> waste display in Guide.</>, ToppleTheNun),
 ];

--- a/src/analysis/retail/rogue/shared/FilteredDamageTracker.ts
+++ b/src/analysis/retail/rogue/shared/FilteredDamageTracker.ts
@@ -1,9 +1,12 @@
 import Spell from 'common/SPELLS/Spell';
-import { CastEvent, DamageEvent, HealEvent } from 'parser/core/Events';
+import { AnyEvent, CastEvent, DamageEvent, HealEvent } from 'parser/core/Events';
 import DamageTracker from 'parser/shared/modules/AbilityTracker';
+import { ReactNode } from 'react';
+
+export type FilteredDamageObserver = (event: CastEvent) => void;
 
 class FilteredDamageTracker extends DamageTracker {
-  castObservers: any[] = [];
+  castObservers: FilteredDamageObserver[] = [];
 
   onDamage(event: DamageEvent) {
     if (!this.shouldProcessEvent(event)) {
@@ -27,16 +30,16 @@ class FilteredDamageTracker extends DamageTracker {
     super.onCast(event);
   }
 
-  shouldProcessEvent(event: any) {
+  shouldProcessEvent(event: AnyEvent) {
     return false;
   }
 
-  subscribeToCastEvent(fn: any) {
+  subscribeToCastEvent(fn: FilteredDamageObserver) {
     this.castObservers.push(fn);
   }
 
-  subscribeInefficientCast(spells: Spell[], messageFunction: any) {
-    this.subscribeToCastEvent((event: any) => {
+  subscribeInefficientCast(spells: Spell[], messageFunction: (spell: Spell) => ReactNode) {
+    this.subscribeToCastEvent((event) => {
       const spell = spells.find((s) => event.ability.guid === s.id);
       if (spell) {
         event.meta = event.meta || {};

--- a/src/analysis/retail/rogue/subtlety/CHANGELOG.tsx
+++ b/src/analysis/retail/rogue/subtlety/CHANGELOG.tsx
@@ -1,5 +1,6 @@
 import { change, date } from 'common/changelog';
 import { Anty, Chizu, ToppleTheNun } from 'CONTRIBUTORS';
+import SHARED_CHANGELOG from 'analysis/retail/rogue/shared/CHANGELOG';
 
 export default [
   change(date(2022, 12, 16), 'Fix Shuriken Storm throwing errors.', ToppleTheNun),
@@ -7,4 +8,5 @@ export default [
   change(date(2022, 11, 5), <>Enabling Spec for Dragonflight.</>, Anty),
   change(date(2022, 10, 31), 'Update to reflect that Subtlety Rogue has been looked at for Dragonflight.', ToppleTheNun),
   change(date(2022, 10, 15), 'Initial support for Dragonflight - cleanup of old effects', Chizu),
+  ...SHARED_CHANGELOG
 ];


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Remove `any` usage from FilteredDamageTracker.

### Motivation

<!-- Why are you submitting this pull request?-->

`any` causes issues with knowing what you can/should provide to an API.