### PR TITLE
[Classic] Demo Warlock updates

### DIFF
--- a/src/analysis/classic/warlock/demonology/CHANGELOG.tsx
+++ b/src/analysis/classic/warlock/demonology/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { change, date } from 'common/changelog';
 import { jazminite } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2022, 2, 24), 'Add Molten Core buff to timeline + GCD reduction. Track Shadow Mastery debuff uptime.', jazminite),
   change(date(2022, 12, 30), 'Add trinkets to Buffs for timeline highlight.', jazminite),
   change(date(2022, 11, 21), 'Update example report and set partial to false.', jazminite),
   change(date(2022, 11, 21), 'Add first draft of Classic Demonology Warlock spec.', jazminite),

--- a/src/analysis/classic/warlock/demonology/CombatLogParser.ts
+++ b/src/analysis/classic/warlock/demonology/CombatLogParser.ts
@@ -5,6 +5,7 @@ import {
   lowRankSpells,
   whitelist,
   DemonicCirclesCreated,
+  GlobalCooldown,
   Spellstone,
 } from 'analysis/classic/warlock/shared';
 // Normalizers
@@ -25,12 +26,14 @@ import CurseOfAgony from './modules/spells/CurseOfAgony';
 import CurseOfDoom from './modules/spells/CurseOfDoom';
 import CurseOfTheElements from './modules/spells/CurseOfTheElements';
 import Immolate from './modules/spells/Immolate';
+import ShadowMastery from './modules/spells/ShadowMastery';
 
 class CombatLogParser extends BaseCombatLogParser {
   static specModules = {
     // Shared
     abilityTracker: AbilityTracker,
     demonicCirclesCreated: DemonicCirclesCreated,
+    globalCooldown: GlobalCooldown,
     spellstone: Spellstone,
     // Normalizers
     channeling: Channeling,
@@ -50,6 +53,7 @@ class CombatLogParser extends BaseCombatLogParser {
     curseOfDoom: CurseOfDoom,
     curseOfTheElements: CurseOfTheElements,
     immolate: Immolate,
+    shadowMastery: ShadowMastery,
   };
 }
 

--- a/src/analysis/classic/warlock/demonology/modules/checklist/Component.tsx
+++ b/src/analysis/classic/warlock/demonology/modules/checklist/Component.tsx
@@ -71,6 +71,7 @@ const ClassicDemonologyChecklist = ({ combatant, castEfficiency, thresholds }: C
       >
         <DotUptime id={SPELLS.CORRUPTION.id} thresholds={thresholds.corruption} />
         <DotUptime id={SPELLS.IMMOLATE.id} thresholds={thresholds.immolate} />
+        <DotUptime id={SPELLS.SHADOW_MASTERY_DEBUFF.id} thresholds={thresholds.shadowMastery} />
       </Rule>
       <Rule
         name="Always Be Casting"

--- a/src/analysis/classic/warlock/demonology/modules/checklist/Module.tsx
+++ b/src/analysis/classic/warlock/demonology/modules/checklist/Module.tsx
@@ -12,6 +12,7 @@ import CurseOfAgony from '../spells/CurseOfAgony';
 import CurseOfDoom from '../spells/CurseOfDoom';
 import CurseOfTheElements from '../spells/CurseOfTheElements';
 import Immolate from '../spells/Immolate';
+import ShadowMastery from '../spells/ShadowMastery';
 
 import Component from './Component';
 
@@ -31,6 +32,7 @@ class Checklist extends BaseChecklist {
     curseOfDoom: CurseOfDoom,
     curseOfTheElements: CurseOfTheElements,
     immolate: Immolate,
+    shadowMastery: ShadowMastery,
   };
   protected castEfficiency!: CastEfficiency;
   protected combatants!: Combatants;
@@ -42,6 +44,7 @@ class Checklist extends BaseChecklist {
   protected curseOfTheElements!: CurseOfTheElements;
   protected immolate!: Immolate;
   protected preparationRuleAnalyzer!: PreparationRuleAnalyzer;
+  protected shadowMastery!: ShadowMastery;
 
   render() {
     return (
@@ -56,6 +59,7 @@ class Checklist extends BaseChecklist {
           curseOfTheElements: this.curseOfTheElements.suggestionThresholds,
           curseUptime: this.curseUptime.suggestionThresholds,
           immolate: this.immolate.suggestionThresholds,
+          shadowMastery: this.shadowMastery.suggestionThresholds,
           downtimeSuggestionThresholds: this.alwaysBeCasting.downtimeSuggestionThresholds,
         }}
       />

--- a/src/analysis/classic/warlock/demonology/modules/features/Buffs.tsx
+++ b/src/analysis/classic/warlock/demonology/modules/features/Buffs.tsx
@@ -15,6 +15,10 @@ class Buffs extends CoreAuras {
         timelineHighlight: true,
       },
       {
+        spellId: SPELLS.MOLTEN_CORE_BUFF.id,
+        timelineHighlight: true,
+      },
+      {
         spellId: Object.keys(BLOODLUST_BUFFS).map((item) => Number(item)),
         timelineHighlight: true,
       },

--- a/src/analysis/classic/warlock/demonology/modules/features/DotUptimes.tsx
+++ b/src/analysis/classic/warlock/demonology/modules/features/DotUptimes.tsx
@@ -4,20 +4,24 @@ import { STATISTIC_ORDER } from 'parser/ui/StatisticsListBox';
 
 import Corruption from '../spells/Corruption';
 import Immolate from '../spells/Immolate';
+import ShadowMastery from '../spells/ShadowMastery';
 
 class DotUptimeStatisticBox extends Analyzer {
   static dependencies = {
     corruptionUptime: Corruption,
     immolateUptime: Immolate,
+    shadowMasteryUptime: ShadowMastery,
   };
   protected corruptionUptime!: Corruption;
   protected immolateUptime!: Immolate;
+  protected shadowMasteryUptime!: ShadowMastery;
 
   statistic() {
     return (
       <StatisticBar wide position={STATISTIC_ORDER.CORE(1)}>
         {this.corruptionUptime.subStatistic()}
         {this.immolateUptime.subStatistic()}
+        {this.shadowMasteryUptime.subStatistic()}
       </StatisticBar>
     );
   }

--- a/src/analysis/classic/warlock/demonology/modules/spells/ShadowMastery.tsx
+++ b/src/analysis/classic/warlock/demonology/modules/spells/ShadowMastery.tsx
@@ -1,0 +1,74 @@
+import { t } from '@lingui/macro';
+import { formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS/classic/warlock';
+import { SpellLink } from 'interface';
+import { SpellIcon } from 'interface';
+import Analyzer from 'parser/core/Analyzer';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import Enemies from 'parser/shared/modules/Enemies';
+import UptimeBar from 'parser/ui/UptimeBar';
+
+class ShadowMasteryUptime extends Analyzer {
+  static dependencies = {
+    enemies: Enemies,
+  };
+  protected enemies!: Enemies;
+
+  get uptime() {
+    return this.enemies.getBuffUptime(SPELLS.SHADOW_MASTERY_DEBUFF.id) / this.owner.fightDuration;
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.uptime,
+      isLessThan: {
+        minor: 0.85,
+        average: 0.8,
+        major: 0.75,
+      },
+      style: ThresholdStyle.PERCENTAGE,
+    };
+  }
+
+  suggestions(when: When) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
+      suggest(
+        <>
+          Your <SpellLink id={SPELLS.SHADOW_MASTERY_DEBUFF} /> uptime can be improved. Use a debuff
+          tracker to see your uptime on the boss.
+        </>,
+      )
+        .icon(SPELLS.SHADOW_MASTERY_DEBUFF.icon)
+        .actual(
+          t({
+            id: 'warlock.suggestions.shadowmastery.uptime',
+            message: `${formatPercentage(actual)}% Shadow Mastery uptime`,
+          }),
+        )
+        .recommended(`>${formatPercentage(recommended)}% is recommended`),
+    );
+  }
+
+  subStatistic() {
+    const history = this.enemies.getDebuffHistory(SPELLS.SHADOW_MASTERY_DEBUFF.id);
+    return (
+      <div className="flex">
+        <div className="flex-sub icon">
+          <SpellIcon id={SPELLS.SHADOW_MASTERY_DEBUFF} />
+        </div>
+        <div className="flex-sub value" style={{ width: 140 }}>
+          {formatPercentage(this.uptime, 0)} % <small>uptime</small>
+        </div>
+        <div className="flex-main chart" style={{ padding: 15 }}>
+          <UptimeBar
+            uptimeHistory={history}
+            start={this.owner.fight.start_time}
+            end={this.owner.fight.end_time}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ShadowMasteryUptime;

--- a/src/analysis/classic/warlock/shared/GlobalCooldown.ts
+++ b/src/analysis/classic/warlock/shared/GlobalCooldown.ts
@@ -1,0 +1,24 @@
+import SPELLS from 'common/SPELLS/classic/warlock';
+import CoreGlobalCooldown from 'parser/shared/modules/GlobalCooldown';
+
+const MC_GCD_REDUCTION = 0.3;
+const MIN_GCD = 750;
+
+/**
+ * Molten Core reduces the GCD of Incinerate by 30%
+ * Min GCD is 750 ms
+ */
+
+class GlobalCooldown extends CoreGlobalCooldown {
+  getGlobalCooldownDuration(spellId: number) {
+    const gcd = super.getGlobalCooldownDuration(spellId);
+    const incinerate = spellId === SPELLS.INCINERATE.id;
+    const mcBuff = this.selectedCombatant.hasBuff(SPELLS.MOLTEN_CORE_BUFF.id);
+    if (gcd && incinerate && mcBuff) {
+      return Math.max(gcd * (1 - MC_GCD_REDUCTION), MIN_GCD);
+    }
+    return gcd;
+  }
+}
+
+export default GlobalCooldown;

--- a/src/analysis/classic/warlock/shared/index.ts
+++ b/src/analysis/classic/warlock/shared/index.ts
@@ -2,3 +2,4 @@ export { default as lowRankSpells } from './lowRankSpells';
 export { whitelist } from './lowRankSpells';
 export { default as DemonicCirclesCreated } from './DemonicCirclesCreated';
 export { default as Spellstone } from './Spellstone';
+export { default as GlobalCooldown } from './GlobalCooldown';

--- a/src/common/SPELLS/classic/warlock.ts
+++ b/src/common/SPELLS/classic/warlock.ts
@@ -231,6 +231,11 @@ const spells = spellIndexableList({
     icon: 'spell_shadow_shadowbolt',
     lowRanks: [47808, 27209, 25307, 11661, 11660, 11659, 7641, 1106, 1088, 705, 695, 686],
   },
+  SHADOW_MASTERY_DEBUFF: {
+    id: 17800,
+    name: 'Shadow Mastery',
+    icon: 'spell_shadow_shadowbolt',
+  },
   SHADOW_WARD: {
     id: 47891,
     name: 'Shadow Ward',
@@ -403,6 +408,11 @@ const spells = spellIndexableList({
     icon: 'ability_warlock_avoidance',
   },
   // --------------------------------
+  MOLTEN_CORE_BUFF: {
+    id: 71165,
+    name: 'Molten Core',
+    icon: 'ability_warlock_moltencore',
+  },
   SOUL_LINK: {
     id: 19028,
     name: 'Soul Link',


### PR DESCRIPTION
### Description

- Add Molten Core buff to timeline + GCD reduction.
- Track Shadow Mastery debuff uptime.

### Motivation

Better downtime / buff / debuff tracking.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/DJYqTNxGCjnghVw3/11-Normal+Kologarn+-+Kill+(1:53)/Jazminites`
- Screenshot(s):
![image](https://user-images.githubusercontent.com/65823478/221115001-98dad786-9676-4bcb-80b6-21421b21c815.png)
![image](https://user-images.githubusercontent.com/65823478/221115072-d37ffb4e-fa59-41f5-b196-d0891196080f.png)


