### PR TITLE
[OUTLAW] Guide resource section

### DIFF
--- a/src/analysis/retail/rogue/outlaw/CHANGELOG.tsx
+++ b/src/analysis/retail/rogue/outlaw/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SHARED_CHANGELOG from 'analysis/retail/rogue/shared/CHANGELOG';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2023, 2, 24), <>First pass at guide with ressource section.</>, zac),
   change(date(2023, 2, 22), <>Add Fan the hammer normalizer to ignore subsequents <SpellLink id={SPELLS.PISTOL_SHOT}/> fake casts events.</>, zac),
   change(date(2023, 2, 20), <>First implementation of <SpellLink id={TALENTS.AUDACITY_TALENT} />.</>, zac),
   change(date(2022,11, 3), <>Enabling Spec for Dragonflight.</>, Anty),

--- a/src/analysis/retail/rogue/outlaw/CombatLogParser.ts
+++ b/src/analysis/retail/rogue/outlaw/CombatLogParser.ts
@@ -43,6 +43,8 @@ import Audacity from './modules/spells/Audacity';
 import AudacityDamageTracker from './modules/spells/AudacityDamageTracker';
 import FanTheHammerNormalizer from './normalizers/FanTheHammerNormalizer';
 import Guide from './Guide';
+import BuilderUse from './modules/core/BuilderUse';
+import FinisherUse from './modules/core/FinisherUse';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -67,6 +69,10 @@ class CombatLogParser extends CoreCombatLogParser {
     energy: Energy,
     energyGraph: EnergyGraph,
     spellEnergyCost: SpellEnergyCost,
+
+    // Core
+    builderUse: BuilderUse,
+    finisherUse: FinisherUse,
 
     //Legendaries
     invigoratingShadowdust: InvigoratingShadowdust,

--- a/src/analysis/retail/rogue/outlaw/CombatLogParser.ts
+++ b/src/analysis/retail/rogue/outlaw/CombatLogParser.ts
@@ -13,6 +13,8 @@ import {
 } from 'analysis/retail/rogue/shared';
 import CoreCombatLogParser from 'parser/core/CombatLogParser';
 import ArcaneTorrent from 'parser/shared/modules/racials/bloodelf/ArcaneTorrent';
+import EnergyGraph from 'analysis/retail/rogue/shared/EnergyGraph';
+import ComboPointGraph from 'analysis/retail/rogue/shared/ComboPointGraph';
 
 import Abilities from './modules/Abilities';
 import Buffs from './modules/Buffs';
@@ -58,10 +60,12 @@ class CombatLogParser extends CoreCombatLogParser {
     comboPointTracker: OutlawComboPointTracker,
     comboPointDetails: ComboPointDetails,
     comboPoints: ComboPoints,
+    comboPointGraph: ComboPointGraph,
     energyTracker: EnergyTracker,
     energyCapTracker: OutlawEnergyCapTracker,
     energyDetails: EnergyDetails,
     energy: Energy,
+    energyGraph: EnergyGraph,
     spellEnergyCost: SpellEnergyCost,
 
     //Legendaries

--- a/src/analysis/retail/rogue/outlaw/CombatLogParser.ts
+++ b/src/analysis/retail/rogue/outlaw/CombatLogParser.ts
@@ -40,6 +40,7 @@ import InvigoratingShadowdust from 'analysis/retail/rogue/shared/shadowlands/leg
 import Audacity from './modules/spells/Audacity';
 import AudacityDamageTracker from './modules/spells/AudacityDamageTracker';
 import FanTheHammerNormalizer from './normalizers/FanTheHammerNormalizer';
+import Guide from './Guide';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -103,6 +104,8 @@ class CombatLogParser extends CoreCombatLogParser {
       },
     ] as const,
   };
+
+  static guide = Guide;
 }
 
 export default CombatLogParser;

--- a/src/analysis/retail/rogue/outlaw/Guide.tsx
+++ b/src/analysis/retail/rogue/outlaw/Guide.tsx
@@ -1,21 +1,63 @@
-import { GuideProps } from 'interface/guide';
+import { GuideProps, Section, SubSection } from 'interface/guide';
 import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
-// import { t, Trans } from '@lingui/macro';
-// import EnergyCapWaste from 'analysis/retail/rogue/shared/guide/EnergyCapWaste';
-// import TALENTS from 'common/TALENTS/rogue';
-// import HideExplanationsToggle from 'interface/guide/components/HideExplanationsToggle';
-// import { ResourceLink, SpellLink } from 'interface';
-// import SPELLS from 'common/SPELLS';
-// import { RoundedPanel, SideBySidePanels } from 'interface/guide/components/GuideDivs';
-// import CooldownUsage from 'parser/core/MajorCooldowns/CooldownUsage';
-// import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import { t, Trans } from '@lingui/macro';
+import EnergyCapWaste from 'analysis/retail/rogue/shared/guide/EnergyCapWaste';
+//import TALENTS from 'common/TALENTS/rogue';
+//import HideExplanationsToggle from 'interface/guide/components/HideExplanationsToggle';
+import { ResourceLink } from 'interface';
+//import SPELLS from 'common/SPELLS';
+//import { RoundedPanel, SideBySidePanels } from 'interface/guide/components/GuideDivs';
+//import CooldownUsage from 'parser/core/MajorCooldowns/CooldownUsage';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 import CombatLogParser from './CombatLogParser';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
     <>
+      <ResourceUsageSection modules={modules} events={events} info={info} />
       <PreparationSection />
     </>
+  );
+}
+
+function ResourceUsageSection({ modules }: GuideProps<typeof CombatLogParser>) {
+  const percentAtCap = modules.energyTracker.percentAtCap;
+  const energyWasted = modules.energyTracker.wasted;
+
+  return (
+    <Section
+      title={t({
+        id: 'guide.rogue.outlaw.sections.resources.title',
+        message: 'Resource Use',
+      })}
+    >
+      <SubSection
+        title={t({
+          id: 'guide.rogue.outlaw.sections.resources.energy.title',
+          message: 'Energy',
+        })}
+      >
+        <p>
+          <Trans id="guide.rogue.outlaw.sections.resources.energy.summary">
+            Your primary resource is <ResourceLink id={RESOURCE_TYPES.ENERGY.id} />. Typically,
+            ability use will be limited by <ResourceLink id={RESOURCE_TYPES.ENERGY.id} />, not time.
+            Avoid capping <ResourceLink id={RESOURCE_TYPES.ENERGY.id} /> - lost{' '}
+            <ResourceLink id={RESOURCE_TYPES.ENERGY.id} /> regeneration is lost DPS. It will
+            occasionally be impossible to avoid capping{' '}
+            <ResourceLink id={RESOURCE_TYPES.ENERGY.id} /> - like while handling mechanics or during
+            intermission phases.
+          </Trans>
+        </p>
+        <EnergyCapWaste
+          percentAtCap={percentAtCap}
+          perfectTimeAtCap={0.05}
+          goodTimeAtCap={0.1}
+          okTimeAtCap={0.15}
+          wasted={energyWasted}
+        />
+        {modules.energyGraph.plot}
+      </SubSection>
+    </Section>
   );
 }

--- a/src/analysis/retail/rogue/outlaw/Guide.tsx
+++ b/src/analysis/retail/rogue/outlaw/Guide.tsx
@@ -6,7 +6,7 @@ import EnergyCapWaste from 'analysis/retail/rogue/shared/guide/EnergyCapWaste';
 //import HideExplanationsToggle from 'interface/guide/components/HideExplanationsToggle';
 import { ResourceLink } from 'interface';
 //import SPELLS from 'common/SPELLS';
-//import { RoundedPanel, SideBySidePanels } from 'interface/guide/components/GuideDivs';
+import { RoundedPanel, SideBySidePanels } from 'interface/guide/components/GuideDivs';
 //import CooldownUsage from 'parser/core/MajorCooldowns/CooldownUsage';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
@@ -57,6 +57,24 @@ function ResourceUsageSection({ modules }: GuideProps<typeof CombatLogParser>) {
           wasted={energyWasted}
         />
         {modules.energyGraph.plot}
+      </SubSection>
+      <SubSection
+        title={t({
+          id: 'guide.rogue.outlaw.sections.resources.comboPoints.title',
+          message: 'Combo Points',
+        })}
+      >
+        <p>
+          <Trans id="guide.rogue.outlaw.sections.resources.comboPoints.summary">
+            Most of your abilities either <strong>build</strong> or <strong>spend</strong>{' '}
+            <ResourceLink id={RESOURCE_TYPES.COMBO_POINTS.id} />. Never use a builder at 6 or 7 CPs,
+            and always wait until 6 or more cps to use a spender.
+          </Trans>
+        </p>
+        <SideBySidePanels>
+          <RoundedPanel>{modules.builderUse.chart}</RoundedPanel>
+          <RoundedPanel>{modules.finisherUse.chart}</RoundedPanel>
+        </SideBySidePanels>
       </SubSection>
     </Section>
   );

--- a/src/analysis/retail/rogue/outlaw/Guide.tsx
+++ b/src/analysis/retail/rogue/outlaw/Guide.tsx
@@ -2,16 +2,11 @@ import { GuideProps, Section, SubSection } from 'interface/guide';
 import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
 import { t, Trans } from '@lingui/macro';
 import EnergyCapWaste from 'analysis/retail/rogue/shared/guide/EnergyCapWaste';
-//import TALENTS from 'common/TALENTS/rogue';
-//import HideExplanationsToggle from 'interface/guide/components/HideExplanationsToggle';
+import TALENTS from 'common/TALENTS/rogue';
 import { ResourceLink, SpellLink } from 'interface';
-//import SPELLS from 'common/SPELLS';
 import { RoundedPanel, SideBySidePanels } from 'interface/guide/components/GuideDivs';
-//import CooldownUsage from 'parser/core/MajorCooldowns/CooldownUsage';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
-
 import CombatLogParser from './CombatLogParser';
-import { TALENTS_ROGUE } from 'common/TALENTS';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -62,8 +57,8 @@ function ResourceUsageSection({ modules }: GuideProps<typeof CombatLogParser>) {
         <p>
           <Trans id="guide.rogue.outlaw.sections.resources.energy.BRandKS">
             -- WIP section -- This will highlight{' '}
-            <SpellLink id={TALENTS_ROGUE.BLADE_RUSH_TALENT.id} />
-            and <SpellLink id={TALENTS_ROGUE.KILLING_SPREE_TALENT.id} />
+            <SpellLink id={TALENTS.BLADE_RUSH_TALENT.id} /> 
+            and <SpellLink id={TALENTS.KILLING_SPREE_TALENT.id} /> 
             usage when talented as we primarly use both these spells for energy efficiency.
           </Trans>
         </p>

--- a/src/analysis/retail/rogue/outlaw/Guide.tsx
+++ b/src/analysis/retail/rogue/outlaw/Guide.tsx
@@ -1,0 +1,21 @@
+import { GuideProps } from 'interface/guide';
+import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
+// import { t, Trans } from '@lingui/macro';
+// import EnergyCapWaste from 'analysis/retail/rogue/shared/guide/EnergyCapWaste';
+// import TALENTS from 'common/TALENTS/rogue';
+// import HideExplanationsToggle from 'interface/guide/components/HideExplanationsToggle';
+// import { ResourceLink, SpellLink } from 'interface';
+// import SPELLS from 'common/SPELLS';
+// import { RoundedPanel, SideBySidePanels } from 'interface/guide/components/GuideDivs';
+// import CooldownUsage from 'parser/core/MajorCooldowns/CooldownUsage';
+// import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+
+import CombatLogParser from './CombatLogParser';
+
+export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
+  return (
+    <>
+      <PreparationSection />
+    </>
+  );
+}

--- a/src/analysis/retail/rogue/outlaw/Guide.tsx
+++ b/src/analysis/retail/rogue/outlaw/Guide.tsx
@@ -4,13 +4,14 @@ import { t, Trans } from '@lingui/macro';
 import EnergyCapWaste from 'analysis/retail/rogue/shared/guide/EnergyCapWaste';
 //import TALENTS from 'common/TALENTS/rogue';
 //import HideExplanationsToggle from 'interface/guide/components/HideExplanationsToggle';
-import { ResourceLink } from 'interface';
+import { ResourceLink, SpellLink } from 'interface';
 //import SPELLS from 'common/SPELLS';
 import { RoundedPanel, SideBySidePanels } from 'interface/guide/components/GuideDivs';
 //import CooldownUsage from 'parser/core/MajorCooldowns/CooldownUsage';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 import CombatLogParser from './CombatLogParser';
+import { TALENTS_ROGUE } from 'common/TALENTS';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -57,6 +58,15 @@ function ResourceUsageSection({ modules }: GuideProps<typeof CombatLogParser>) {
           wasted={energyWasted}
         />
         {modules.energyGraph.plot}
+        <p></p>
+        <p>
+          <Trans id="guide.rogue.outlaw.sections.resources.energy.BRandKS">
+            -- WIP section -- This will highlight{' '}
+            <SpellLink id={TALENTS_ROGUE.BLADE_RUSH_TALENT.id} />
+            and <SpellLink id={TALENTS_ROGUE.KILLING_SPREE_TALENT.id} />
+            usage when talented as we primarly use both these spells for energy efficiency.
+          </Trans>
+        </p>
       </SubSection>
       <SubSection
         title={t({
@@ -75,6 +85,12 @@ function ResourceUsageSection({ modules }: GuideProps<typeof CombatLogParser>) {
           <RoundedPanel>{modules.builderUse.chart}</RoundedPanel>
           <RoundedPanel>{modules.finisherUse.chart}</RoundedPanel>
         </SideBySidePanels>
+        <p></p>
+        <p>
+          <Trans id="guide.rogue.outlaw.sections.resources.comboPoints.buildersBreakdown">
+            -- WIP section -- Maybe highlight which builders the user is commonly overcapping with.
+          </Trans>
+        </p>
       </SubSection>
     </Section>
   );

--- a/src/analysis/retail/rogue/outlaw/Guide.tsx
+++ b/src/analysis/retail/rogue/outlaw/Guide.tsx
@@ -3,7 +3,7 @@ import PreparationSection from 'interface/guide/components/Preparation/Preparati
 import { t, Trans } from '@lingui/macro';
 import EnergyCapWaste from 'analysis/retail/rogue/shared/guide/EnergyCapWaste';
 import TALENTS from 'common/TALENTS/rogue';
-import { ResourceLink, SpellLink } from 'interface';
+import { ResourceLink } from 'interface';
 import { RoundedPanel, SideBySidePanels } from 'interface/guide/components/GuideDivs';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import CombatLogParser from './CombatLogParser';
@@ -17,7 +17,7 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
   );
 }
 
-function ResourceUsageSection({ modules }: GuideProps<typeof CombatLogParser>) {
+function ResourceUsageSection({ modules, info }: GuideProps<typeof CombatLogParser>) {
   const percentAtCap = modules.energyTracker.percentAtCap;
   const energyWasted = modules.energyTracker.wasted;
 
@@ -54,14 +54,7 @@ function ResourceUsageSection({ modules }: GuideProps<typeof CombatLogParser>) {
         />
         {modules.energyGraph.plot}
         <p></p>
-        <p>
-          <Trans id="guide.rogue.outlaw.sections.resources.energy.BRandKS">
-            -- WIP section -- This will highlight{' '}
-            <SpellLink id={TALENTS.BLADE_RUSH_TALENT.id} /> 
-            and <SpellLink id={TALENTS.KILLING_SPREE_TALENT.id} /> 
-            usage when talented as we primarly use both these spells for energy efficiency.
-          </Trans>
-        </p>
+        {info.combatant.hasTalent(TALENTS.BLADE_RUSH_TALENT) && modules.bladeRush.guide}
       </SubSection>
       <SubSection
         title={t({
@@ -83,7 +76,7 @@ function ResourceUsageSection({ modules }: GuideProps<typeof CombatLogParser>) {
         <p></p>
         <p>
           <Trans id="guide.rogue.outlaw.sections.resources.comboPoints.buildersBreakdown">
-            -- WIP section -- Maybe highlight which builders the user is commonly overcapping with.
+            -- WIP section -- Higlight which builders the user is commonly overcapping with.
           </Trans>
         </p>
       </SubSection>

--- a/src/analysis/retail/rogue/outlaw/constants.ts
+++ b/src/analysis/retail/rogue/outlaw/constants.ts
@@ -1,5 +1,7 @@
 import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/rogue';
 import Spell from 'common/SPELLS/Spell';
+import Combatant from 'parser/core/Combatant';
 
 // The 6 buffs that Roll the Bones can grant, so does not include Roll the Bones itself
 export const ROLL_THE_BONES_BUFFS: Spell[] = [
@@ -12,3 +14,28 @@ export const ROLL_THE_BONES_BUFFS: Spell[] = [
 ];
 
 export const ROLL_THE_BONES_DURATION = 30000;
+
+export const getMaxComboPoints = (c: Combatant) => {
+  return 5 + c.getTalentRank(TALENTS.DEEPER_STRATAGEM_TALENT) +
+      c.getTalentRank(TALENTS.SECRET_STRATAGEM_TALENT);
+};
+
+export const BUILDERS: Spell[] = [
+  SPELLS.SINISTER_STRIKE,
+  SPELLS.AMBUSH,
+  SPELLS.PISTOL_SHOT,
+  SPELLS.CHEAP_SHOT,
+  TALENTS.SHIV_TALENT,
+  TALENTS.GOUGE_TALENT,
+  TALENTS.ECHOING_REPRIMAND_TALENT,
+  TALENTS.MARKED_FOR_DEATH_TALENT,
+  TALENTS.SEPSIS_TALENT,
+  TALENTS.GHOSTLY_STRIKE_TALENT,
+];
+
+export const FINISHERS: Spell[] = [
+  SPELLS.DISPATCH,
+  SPELLS.BETWEEN_THE_EYES,
+  SPELLS.SLICE_AND_DICE,
+  SPELLS.KIDNEY_SHOT,
+];

--- a/src/analysis/retail/rogue/outlaw/constants.ts
+++ b/src/analysis/retail/rogue/outlaw/constants.ts
@@ -16,8 +16,11 @@ export const ROLL_THE_BONES_BUFFS: Spell[] = [
 export const ROLL_THE_BONES_DURATION = 30000;
 
 export const getMaxComboPoints = (c: Combatant) => {
-  return 5 + c.getTalentRank(TALENTS.DEEPER_STRATAGEM_TALENT) +
-      c.getTalentRank(TALENTS.SECRET_STRATAGEM_TALENT);
+  return (
+    5 +
+    c.getTalentRank(TALENTS.DEEPER_STRATAGEM_TALENT) +
+    c.getTalentRank(TALENTS.DEVIOUS_STRATAGEM_TALENT)
+  );
 };
 
 export const BUILDERS: Spell[] = [

--- a/src/analysis/retail/rogue/outlaw/modules/core/BuilderUse.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/core/BuilderUse.tsx
@@ -1,0 +1,104 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { ResourceChangeEvent } from 'parser/core/Events';
+import { BadColor, GoodColor } from 'interface/guide';
+import { ResourceLink } from 'interface';
+import DonutChart from 'parser/ui/DonutChart';
+import Statistic from 'parser/ui/Statistic';
+import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import { BUILDERS } from '../../constants';
+import Finishers from '../features/Finishers';
+import SPELLS from 'common/SPELLS';
+import talents from 'common/TALENTS/rogue';
+import Enemies from 'parser/shared/modules/Enemies';
+
+export default class BuilderUse extends Analyzer {
+  static dependencies = {
+    finishers: Finishers,
+    enemies: Enemies,
+  };
+  protected finishers!: Finishers;
+  protected enemies!: Enemies;
+
+  totalBuilderCasts = 0;
+  wastedBuilderCasts = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.addEventListener(
+      Events.resourcechange.by(SELECTED_PLAYER).spell(BUILDERS),
+      this.onResourceChange,
+    );
+  }
+
+  get effectiveBuilderCasts() {
+    return this.totalBuilderCasts - this.wastedBuilderCasts;
+  }
+
+  get chart() {
+    const items = [
+      {
+        color: GoodColor,
+        label: 'Effective Builders',
+        value: this.effectiveBuilderCasts,
+      },
+      {
+        color: BadColor,
+        label: 'Wasted Builders',
+        value: this.wastedBuilderCasts,
+      },
+    ];
+
+    return <DonutChart items={items} />;
+  }
+
+  statistic() {
+    return (
+      <Statistic position={STATISTIC_ORDER.CORE(5)}>
+        <div className="pad">
+          <label>
+            <ResourceLink id={RESOURCE_TYPES.COMBO_POINTS.id} /> builder usage
+          </label>
+          {this.chart}
+        </div>
+      </Statistic>
+    );
+  }
+
+  private onResourceChange(event: ResourceChangeEvent) {
+    this.totalBuilderCasts += 1;
+
+    if(!this.IsBuilderCPEfficient(event)){
+        this.wastedBuilderCasts +=1;
+    }
+  }
+
+  public IsBuilderCPEfficient(event: ResourceChangeEvent) {
+    const cpGain = event.resourceChange - event.waste;
+    const cpAtEvent = this.finishers.maximumComboPoints - cpGain;
+    const spellID = event.ability.guid;
+    const target = this.enemies.getEntity(event);
+
+    if (!target) {
+      return false;
+    }
+
+    if(cpAtEvent > this.finishers.recommendedFinisherPoints())
+    {
+      return false;
+    }
+    else if (cpAtEvent == this.finishers.recommendedFinisherPoints())
+    {
+      //this is neutral
+      if(!(spellID == SPELLS.SINISTER_STRIKE.id && this.selectedCombatant.hasBuff(SPELLS.BROADSIDE.id))
+      // Ambushes at 6cp with tier are correct
+      || !(spellID == SPELLS.AMBUSH.id && this.selectedCombatant.hasBuff(SPELLS.OUTLAW_ROGUE_TIER_28_2P_SET_BONUS.id, null, 200))
+      // GS debuff maintainance is more important than cp overcap if the debuff is down
+      || !(spellID == talents.GHOSTLY_STRIKE_TALENT.id && target.getRemainingBuffTimeAtTimestamp(talents.GHOSTLY_STRIKE_TALENT.id, 10000, 13000,event.timestamp)<=1))
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/src/analysis/retail/rogue/outlaw/modules/core/BuilderUse.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/core/BuilderUse.tsx
@@ -1,7 +1,7 @@
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import Events, { CastEvent } from 'parser/core/Events';
 import { BadColor, GoodColor } from 'interface/guide';
-import { ResourceLink } from 'interface';
+import { ResourceLink, SpellLink } from 'interface';
 import DonutChart from 'parser/ui/DonutChart';
 import Statistic from 'parser/ui/Statistic';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
@@ -28,7 +28,7 @@ export default class BuilderUse extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.addEventListener(Events.cast.spell(BUILDERS), this.onCastBuilder,);
+    this.addEventListener(Events.cast.spell(BUILDERS), this.onCastBuilder);
   }
 
   get effectiveBuilderCasts() {
@@ -46,6 +46,29 @@ export default class BuilderUse extends Analyzer {
         color: BadColor,
         label: 'Wasted Builders',
         value: this.wastedBuilderCasts,
+        tooltip: (
+          <div>
+            Builders casted at or above {this.finishers.recommendedFinisherPoints()} CPs, this
+            doesn't include:
+            <ul>
+              <li>
+                {' '}
+                <SpellLink id={SPELLS.SINISTER_STRIKE.id} /> casted at 6cp without{' '}
+                <SpellLink id={SPELLS.BROADSIDE.id} /> buff up
+              </li>
+              <li>
+                {' '}
+                <SpellLink id={SPELLS.AMBUSH.id} /> casted at 6cp with{' '}
+                <SpellLink id={SPELLS.OUTLAW_ROGUE_TIER_28_2P_SET_BONUS.id} /> buff up
+              </li>
+              <li>
+                {' '}
+                <SpellLink id={talents.GHOSTLY_STRIKE_TALENT.id} /> casted at 6cp without{' '}
+                <SpellLink id={SPELLS.BROADSIDE.id} /> buff up
+              </li>
+            </ul>
+          </div>
+        ),
       },
     ];
 
@@ -73,42 +96,51 @@ export default class BuilderUse extends Analyzer {
     }
   }
 
-  private IsBuilderCPEfficient(event: CastEvent){
+  private IsBuilderCPEfficient(event: CastEvent) {
     const cpUpdate = this.comboPointTracker.resourceUpdates.at(-1);
     const spellID = event.ability.guid;
 
-    if(!cpUpdate){
-      console.log("NO CP UPDATE", this.owner.formatTimestamp(event.timestamp, 1), event, cpUpdate);
+    if (!cpUpdate) {
+      console.log('NO CP UPDATE', this.owner.formatTimestamp(event.timestamp, 1), event, cpUpdate);
       return;
     }
 
     //Some events seems to have a changeWaste instead, need to find out why and when this happen
-    if(!cpUpdate.change){
-      console.log("NO CP CHANGE", this.owner.formatTimestamp(event.timestamp, 1), event, cpUpdate);
+    if (!cpUpdate.change) {
+      console.log('NO CP CHANGE', this.owner.formatTimestamp(event.timestamp, 1), event, cpUpdate);
       return true;
     }
 
     const cpAtCast = this.comboPointTracker.current - cpUpdate.change;
 
     if (cpAtCast > this.finishers.recommendedFinisherPoints()) {
-      console.log("At", this.owner.formatTimestamp(event.timestamp, 1), " Cast at max cp ", event.ability.name);
+      console.log(
+        'At',
+        this.owner.formatTimestamp(event.timestamp, 1),
+        ' Cast at max cp ',
+        event.ability.name,
+      );
       return false;
     } else if (cpAtCast === this.finishers.recommendedFinisherPoints()) {
       //this is neutral
-      if (!((
+      if (
+        !(
           spellID === SPELLS.SINISTER_STRIKE.id &&
-          !this.selectedCombatant.hasBuff(SPELLS.BROADSIDE.id)
-        ) &&
-        // Ambushes at 6cp with tier are correct
-        (
+          !this.selectedCombatant.hasBuff(SPELLS.BROADSIDE.id) &&
+          // Ambushes at 6cp with tier are correct
           spellID === SPELLS.AMBUSH.id &&
-          this.selectedCombatant.hasBuff(SPELLS.OUTLAW_ROGUE_TIER_28_2P_SET_BONUS.id, null, 200)
-        ) &&
-        // GS debuff maintainance is more important than cp overcap if the debuff is down
-        (spellID === talents.GHOSTLY_STRIKE_TALENT.id))
+          this.selectedCombatant.hasBuff(SPELLS.OUTLAW_ROGUE_TIER_28_2P_SET_BONUS.id, null, 200) &&
+          // GS debuff maintainance is more important than cp overcap if the debuff is down
+          spellID === talents.GHOSTLY_STRIKE_TALENT.id
+        )
       ) {
         // try to find a way to make this work at some point&& target.getRemainingBuffTimeAtTimestamp(talents.GHOSTLY_STRIKE_TALENT.id, 10000, 13000,event.timestamp)<=1))
-        console.log("At", this.owner.formatTimestamp(event.timestamp,1), " Cast at 6 cp ", event.ability.name);
+        console.log(
+          'At',
+          this.owner.formatTimestamp(event.timestamp, 1),
+          ' Cast at 6 cp ',
+          event.ability.name,
+        );
         return false;
       }
     }

--- a/src/analysis/retail/rogue/outlaw/modules/core/BuilderUse.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/core/BuilderUse.tsx
@@ -1,5 +1,5 @@
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { ResourceChangeEvent } from 'parser/core/Events';
+import Events, { EventType, ResourceChangeEvent } from 'parser/core/Events';
 import { BadColor, GoodColor } from 'interface/guide';
 import { ResourceLink } from 'interface';
 import DonutChart from 'parser/ui/DonutChart';
@@ -85,26 +85,26 @@ export default class BuilderUse extends Analyzer {
     //   return false;
     // }
     //console.log("cast", event.ability);
+    
     if (cpAtEvent > this.finishers.recommendedFinisherPoints()) {
       //console.log("At", timestamp, " Cast at max cp ", event.ability.name);
       return false;
     } else if (cpAtEvent === this.finishers.recommendedFinisherPoints()) {
       //this is neutral
-      if (
-        !(
+      if (!((
           spellID === SPELLS.SINISTER_STRIKE.id &&
           !this.selectedCombatant.hasBuff(SPELLS.BROADSIDE.id)
         ) &&
         // Ambushes at 6cp with tier are correct
-        !(
+        (
           spellID === SPELLS.AMBUSH.id &&
           this.selectedCombatant.hasBuff(SPELLS.OUTLAW_ROGUE_TIER_28_2P_SET_BONUS.id, null, 200)
         ) &&
         // GS debuff maintainance is more important than cp overcap if the debuff is down
-        !(spellID === talents.GHOSTLY_STRIKE_TALENT.id)
+        (spellID === talents.GHOSTLY_STRIKE_TALENT.id))
       ) {
         // try to find a way to make this work at some point&& target.getRemainingBuffTimeAtTimestamp(talents.GHOSTLY_STRIKE_TALENT.id, 10000, 13000,event.timestamp)<=1))
-        //console.log("At", timestamp, " Cast at 6 cp ", event.ability.name);
+        console.log("At", this.owner.formatTimestamp(event.timestamp), " Cast at 6 cp ", event.ability.name);
         return false;
       }
     }

--- a/src/analysis/retail/rogue/outlaw/modules/core/BuilderUse.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/core/BuilderUse.tsx
@@ -118,13 +118,19 @@ export default class BuilderUse extends Analyzer {
       return false;
     } else if (cpAtCast === this.finishers.recommendedFinisherPoints()) {
       //this is neutral
-      if (!(spellID === SPELLS.SINISTER_STRIKE.id &&
-          !this.selectedCombatant.hasBuff(SPELLS.BROADSIDE.id)) &&
-          // Ambushes at 6cp with tier are correct
-          !(spellID === SPELLS.AMBUSH.id && this.selectedCombatant.hasBuff(SPELLS.OUTLAW_ROGUE_TIER_28_2P_SET_BONUS.id, null, 200)) &&
-          // GS debuff maintainance is more important than cp overcap if the debuff is down
-          spellID !== talents.GHOSTLY_STRIKE_TALENT.id //try to find a way to make this work at some point: && target.getRemainingBuffTimeAtTimestamp(talents.GHOSTLY_STRIKE_TALENT.id, 10000, 13000,event.timestamp)<=1))
-      ){
+      if (
+        !(
+          spellID === SPELLS.SINISTER_STRIKE.id &&
+          !this.selectedCombatant.hasBuff(SPELLS.BROADSIDE.id)
+        ) &&
+        // Ambushes at 6cp with tier are correct
+        !(
+          spellID === SPELLS.AMBUSH.id &&
+          this.selectedCombatant.hasBuff(SPELLS.OUTLAW_ROGUE_TIER_28_2P_SET_BONUS.id, null, 200)
+        ) &&
+        // GS debuff maintainance is more important than cp overcap if the debuff is down
+        spellID !== talents.GHOSTLY_STRIKE_TALENT.id //try to find a way to make this work at some point: && target.getRemainingBuffTimeAtTimestamp(talents.GHOSTLY_STRIKE_TALENT.id, 10000, 13000,event.timestamp)<=1))
+      ) {
         //console.log('At', this.owner.formatTimestamp(event.timestamp, 1),' Cast at 6 cp ', event.ability.name);
         return false;
       }

--- a/src/analysis/retail/rogue/outlaw/modules/core/BuilderUse.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/core/BuilderUse.tsx
@@ -107,40 +107,25 @@ export default class BuilderUse extends Analyzer {
 
     //Some events seems to have a changeWaste instead, need to find out why and when this happen
     if (!cpUpdate.change) {
-      console.log('NO CP CHANGE', this.owner.formatTimestamp(event.timestamp, 1), event, cpUpdate);
+      //console.log('NO CP CHANGE', this.owner.formatTimestamp(event.timestamp, 1), event, cpUpdate);
       return true;
     }
 
     const cpAtCast = this.comboPointTracker.current - cpUpdate.change;
 
     if (cpAtCast > this.finishers.recommendedFinisherPoints()) {
-      console.log(
-        'At',
-        this.owner.formatTimestamp(event.timestamp, 1),
-        ' Cast at max cp ',
-        event.ability.name,
-      );
+      //console.log('At', this.owner.formatTimestamp(event.timestamp, 1), ' Cast at max cp ', event.ability.name);
       return false;
     } else if (cpAtCast === this.finishers.recommendedFinisherPoints()) {
       //this is neutral
-      if (
-        !(
-          spellID === SPELLS.SINISTER_STRIKE.id &&
-          !this.selectedCombatant.hasBuff(SPELLS.BROADSIDE.id) &&
+      if (!(spellID === SPELLS.SINISTER_STRIKE.id &&
+          !this.selectedCombatant.hasBuff(SPELLS.BROADSIDE.id)) &&
           // Ambushes at 6cp with tier are correct
-          spellID === SPELLS.AMBUSH.id &&
-          this.selectedCombatant.hasBuff(SPELLS.OUTLAW_ROGUE_TIER_28_2P_SET_BONUS.id, null, 200) &&
+          !(spellID === SPELLS.AMBUSH.id && this.selectedCombatant.hasBuff(SPELLS.OUTLAW_ROGUE_TIER_28_2P_SET_BONUS.id, null, 200)) &&
           // GS debuff maintainance is more important than cp overcap if the debuff is down
-          spellID === talents.GHOSTLY_STRIKE_TALENT.id
-        )
-      ) {
-        // try to find a way to make this work at some point&& target.getRemainingBuffTimeAtTimestamp(talents.GHOSTLY_STRIKE_TALENT.id, 10000, 13000,event.timestamp)<=1))
-        console.log(
-          'At',
-          this.owner.formatTimestamp(event.timestamp, 1),
-          ' Cast at 6 cp ',
-          event.ability.name,
-        );
+          spellID !== talents.GHOSTLY_STRIKE_TALENT.id //try to find a way to make this work at some point: && target.getRemainingBuffTimeAtTimestamp(talents.GHOSTLY_STRIKE_TALENT.id, 10000, 13000,event.timestamp)<=1))
+      ){
+        //console.log('At', this.owner.formatTimestamp(event.timestamp, 1),' Cast at 6 cp ', event.ability.name);
         return false;
       }
     }

--- a/src/analysis/retail/rogue/outlaw/modules/core/FinisherUse.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/core/FinisherUse.tsx
@@ -7,13 +7,19 @@ import Statistic from 'parser/ui/Statistic';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import getResourceSpent from 'parser/core/getResourceSpent';
-
 import {
   FINISHERS,
   getMaxComboPoints,
 } from '../../constants';
+import Finishers from '../features/Finishers';
 
 export default class FinisherUse extends Analyzer {
+  static dependencies = {
+    finishers: Finishers,
+  };
+
+  protected finishers!: Finishers;
+
   totalFinisherCasts = 0;
   lowCpFinisherCasts = 0;
 
@@ -69,7 +75,7 @@ export default class FinisherUse extends Analyzer {
     }
 
     this.totalFinisherCasts += 1;
-    if (cpsSpent < getMaxComboPoints(this.selectedCombatant) - 1) {
+    if (cpsSpent < this.finishers.recommendedFinisherPoints()) {
         this.lowCpFinisherCasts += 1;
     }
   }

--- a/src/analysis/retail/rogue/outlaw/modules/core/FinisherUse.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/core/FinisherUse.tsx
@@ -1,0 +1,76 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent } from 'parser/core/Events';
+import { BadColor, GoodColor } from 'interface/guide';
+import { ResourceLink} from 'interface';
+import DonutChart from 'parser/ui/DonutChart';
+import Statistic from 'parser/ui/Statistic';
+import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import getResourceSpent from 'parser/core/getResourceSpent';
+
+import {
+  FINISHERS,
+  getMaxComboPoints,
+} from '../../constants';
+
+export default class FinisherUse extends Analyzer {
+  totalFinisherCasts = 0;
+  lowCpFinisherCasts = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(FINISHERS), this.onCast);
+  }
+
+  get maxCpFinishers() {
+    return (
+      this.totalFinisherCasts -
+      this.lowCpFinisherCasts
+    );
+  }
+
+  get chart() {
+    const items = [
+      {
+        color: GoodColor,
+        label: 'Max CP Finishers',
+        value: this.maxCpFinishers,
+        tooltip: (
+          <>This includes finishers cast at {getMaxComboPoints(this.selectedCombatant) - 1} CPs.</>
+        ),
+      },
+      {
+        color: BadColor,
+        label: 'Low CP Finishers',
+        value: this.lowCpFinisherCasts,
+      },
+    ];
+
+    return <DonutChart items={items} />;
+  }
+
+  statistic() {
+    return (
+      <Statistic position={STATISTIC_ORDER.CORE(6)}>
+        <div className="pad">
+          <label>
+            <ResourceLink id={RESOURCE_TYPES.COMBO_POINTS.id} /> spender usage
+          </label>
+          {this.chart}
+        </div>
+      </Statistic>
+    );
+  }
+
+  private onCast(event: CastEvent) {
+    const cpsSpent = getResourceSpent(event, RESOURCE_TYPES.COMBO_POINTS);
+    if (cpsSpent === 0) {
+      return;
+    }
+
+    this.totalFinisherCasts += 1;
+    if (cpsSpent < getMaxComboPoints(this.selectedCombatant) - 1) {
+        this.lowCpFinisherCasts += 1;
+    }
+  }
+}

--- a/src/analysis/retail/rogue/outlaw/modules/core/FinisherUse.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/core/FinisherUse.tsx
@@ -1,16 +1,13 @@
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent } from 'parser/core/Events';
 import { BadColor, GoodColor } from 'interface/guide';
-import { ResourceLink} from 'interface';
+import { ResourceLink } from 'interface';
 import DonutChart from 'parser/ui/DonutChart';
 import Statistic from 'parser/ui/Statistic';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import getResourceSpent from 'parser/core/getResourceSpent';
-import {
-  FINISHERS,
-  getMaxComboPoints,
-} from '../../constants';
+import { FINISHERS, getMaxComboPoints } from '../../constants';
 import Finishers from '../features/Finishers';
 
 export default class FinisherUse extends Analyzer {
@@ -29,10 +26,7 @@ export default class FinisherUse extends Analyzer {
   }
 
   get maxCpFinishers() {
-    return (
-      this.totalFinisherCasts -
-      this.lowCpFinisherCasts
-    );
+    return this.totalFinisherCasts - this.lowCpFinisherCasts;
   }
 
   get chart() {
@@ -76,7 +70,7 @@ export default class FinisherUse extends Analyzer {
 
     this.totalFinisherCasts += 1;
     if (cpsSpent < this.finishers.recommendedFinisherPoints()) {
-        this.lowCpFinisherCasts += 1;
+      this.lowCpFinisherCasts += 1;
     }
   }
 }

--- a/src/analysis/retail/rogue/outlaw/modules/talents/BladeRush.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/talents/BladeRush.tsx
@@ -1,10 +1,24 @@
 import RESOURCE_TYPES, { getResource } from 'game/RESOURCE_TYPES';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent } from 'parser/core/Events';
+import Events, {
+  CastEvent,
+  ResourceChangeEvent,
+  UpdateSpellUsableEvent,
+  UpdateSpellUsableType,
+} from 'parser/core/Events';
 import Abilities from 'parser/core/modules/Abilities';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
-import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/rogue';
+import { BadColor, GoodColor } from 'interface/guide';
+import DonutChart from 'parser/ui/DonutChart';
+import { SpellLink } from 'interface';
+import { RoundedPanel, SideBySidePanels } from 'interface/guide/components/GuideDivs';
+
+const MIN_ENERGY_TRESHOLD = 70;
+const MAX_ENERGY_TRESHOLD = 80;
+
+//-- TODO: MAX_ENERGY_TRESHOLD should scale with targets hit to support aoe fights
+// Not entirely sure if this is the optimal way to display this information, will have to come back to this
 
 class BladeRush extends Analyzer {
   static dependencies = {
@@ -15,43 +29,148 @@ class BladeRush extends Analyzer {
   protected abilities!: Abilities;
   protected spellUsable!: SpellUsable;
 
+  lastTimeStamp: number = 0;
+  timeSpentUnderTreshold: number = 0;
+
+  castsTotal: number = 0;
+  castsOverEnergyTreshold: number = 0;
+
+  timestampFromCD: number = 0;
+  totalTimeOffCD: number = 0;
+  isFirstCast: boolean = true;
+
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS.BLADE_RUSH_TALENT);
+
+    this.addEventListener(Events.resourcechange.by(SELECTED_PLAYER), this.onResourceChange);
+
     this.addEventListener(
-      Events.cast
-        .by(SELECTED_PLAYER)
-        .spell([
-          SPELLS.DISPATCH,
-          SPELLS.EVISCERATE,
-          SPELLS.KIDNEY_SHOT,
-          SPELLS.BETWEEN_THE_EYES,
-          SPELLS.SLICE_AND_DICE,
-        ]),
-      this.onFinishMove,
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.BLADE_RUSH_TALENT),
+      this.onBladeRush,
+    );
+
+    this.addEventListener(
+      Events.UpdateSpellUsable.by(SELECTED_PLAYER).spell(TALENTS.BLADE_RUSH_TALENT),
+      this.onBladeRushUsable,
     );
   }
 
-  onFinishMove(event: CastEvent) {
-    const cpCost = getResource(event.classResources, RESOURCE_TYPES.COMBO_POINTS.id)?.cost;
-    if (!cpCost) {
+  // Count total BR casts and casts over energy treshold
+  protected onBladeRush(event: CastEvent) {
+    const energy = getResource(event.classResources, RESOURCE_TYPES.ENERGY.id);
+    this.castsTotal += 1;
+
+    if (energy!.amount > MAX_ENERGY_TRESHOLD) {
+      this.castsOverEnergyTreshold += 1;
+    }
+  }
+
+  // Count time spent under MIN_ENERGY_TRESHOLD with BR off cd
+  protected onResourceChange(event: ResourceChangeEvent) {
+    const energy = getResource(event.classResources, RESOURCE_TYPES.ENERGY.id);
+    const energyAmount = energy?.amount;
+    if (!energy || !energyAmount) {
       return;
     }
+
     if (this.spellUsable.isOnCooldown(TALENTS.BLADE_RUSH_TALENT.id)) {
-      const cooldownRemaining = this.spellUsable.cooldownRemaining(TALENTS.BLADE_RUSH_TALENT.id);
-      const extraCDR = this.selectedCombatant.hasBuff(SPELLS.TRUE_BEARING.id) ? cpCost * 1000 : 0;
-      const cooldownReduction = cpCost * 1000 + extraCDR;
-      const newChargeCDR = cooldownRemaining - cooldownReduction;
-      if (newChargeCDR < 0) {
-        this.spellUsable.endCooldown(TALENTS.BLADE_RUSH_TALENT.id);
-      } else {
-        this.spellUsable.reduceCooldown(
-          TALENTS.BLADE_RUSH_TALENT.id,
-          cooldownReduction,
-          event.timestamp,
-        );
+      this.lastTimeStamp = 0;
+      return;
+    }
+
+    if (energyAmount <= MIN_ENERGY_TRESHOLD) {
+      if (this.lastTimeStamp !== 0) {
+        this.timeSpentUnderTreshold += event.timestamp - this.lastTimeStamp;
+      }
+      this.lastTimeStamp = event.timestamp;
+    } else {
+      this.lastTimeStamp = 0;
+    }
+  }
+
+  // Count blade rush time spent off cd
+  onBladeRushUsable(event: UpdateSpellUsableEvent) {
+    switch (event.updateType) {
+      case UpdateSpellUsableType.BeginCooldown: {
+        if (!this.isFirstCast) {
+          this.totalTimeOffCD += event.timestamp - this.timestampFromCD;
+        } else {
+          this.isFirstCast = false;
+        }
+        break;
+      }
+
+      case UpdateSpellUsableType.EndCooldown: {
+        this.timestampFromCD = event.timestamp;
+        break;
       }
     }
+  }
+
+  get castsChart() {
+    const items = [
+      {
+        color: GoodColor,
+        label: 'Effective casts',
+        value: this.castsTotal - this.castsOverEnergyTreshold,
+      },
+      {
+        color: BadColor,
+        label: 'Wasted casts',
+        value: this.castsOverEnergyTreshold,
+      },
+    ];
+
+    return <DonutChart items={items} />;
+  }
+
+  get cooldownChart() {
+    const items = [
+      {
+        color: GoodColor,
+        label: 'Time off cd above energy treshold',
+        value: (this.totalTimeOffCD - this.timeSpentUnderTreshold) / 1000,
+      },
+      {
+        color: BadColor,
+        label: 'Time off cd under energy treshold',
+        value: this.timeSpentUnderTreshold / 1000,
+      },
+    ];
+
+    return <DonutChart items={items} />;
+  }
+
+  get guide(): JSX.Element {
+    return (
+      <p>
+        <p>
+          <strong>
+            <SpellLink id={TALENTS.BLADE_RUSH_TALENT} />
+          </strong>{' '}
+          should be used whenever your energy drop under 70-80, this energy treshold increase with
+          target count. At around 9 targets it is safe to use{' '}
+          <SpellLink id={TALENTS.BLADE_RUSH_TALENT} /> on cooldown regardless of energy.
+        </p>
+        <SideBySidePanels>
+          <RoundedPanel>
+            <div>
+              This chart display the percentage of <SpellLink id={TALENTS.BLADE_RUSH_TALENT} />{' '}
+              casts used at an higher than recommended energy treshold.
+            </div>
+            {this.castsChart}
+          </RoundedPanel>
+          <RoundedPanel>
+            <div>
+              This chart display the amount of time (in seconds) that you spent under the energy
+              threshold without pressing <SpellLink id={TALENTS.BLADE_RUSH_TALENT} />.
+            </div>
+            {this.cooldownChart}
+          </RoundedPanel>
+        </SideBySidePanels>
+      </p>
+    );
   }
 }
 

--- a/src/analysis/retail/rogue/outlaw/modules/talents/BladeRush.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/talents/BladeRush.tsx
@@ -9,10 +9,8 @@ import Events, {
 import Abilities from 'parser/core/modules/Abilities';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import TALENTS from 'common/TALENTS/rogue';
-import { BadColor, GoodColor } from 'interface/guide';
-import DonutChart from 'parser/ui/DonutChart';
 import { SpellLink } from 'interface';
-import { RoundedPanel, SideBySidePanels } from 'interface/guide/components/GuideDivs';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { Uptime } from 'parser/ui/UptimeBar';
 import uptimeBarSubStatistic from 'parser/ui/UptimeBarSubStatistic';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
@@ -25,7 +23,6 @@ const ACCEPTABLE_ENERGY_TRESHOLD = 80;
 
 
 //-- TODO: MAX_ENERGY_TRESHOLD should scale with targets hit to support aoe fights
-// Not entirely sure if this is the optimal way to display this information, will have to come back to this
 
 class BladeRush extends Analyzer {
   static dependencies = {
@@ -35,16 +32,6 @@ class BladeRush extends Analyzer {
 
   protected abilities!: Abilities;
   protected spellUsable!: SpellUsable;
-
-  lastTimeStamp: number = 0;
-  timeSpentUnderTreshold: number = 0;
-
-  castsTotal: number = 0;
-  castsOverEnergyTreshold: number = 0;
-
-  timestampFromCD: number = 0;
-  totalTimeOffCD: number = 0;
-  isFirstCast: boolean = true;
 
   unusableUptimes: Uptime[] = [];
   isInUsablePeriod: boolean = false;
@@ -91,157 +78,49 @@ class BladeRush extends Analyzer {
     }
   }
 
-  // Count total BR casts and casts over energy treshold
+  // Record the accuracy of every Blade Rush casts
   protected onBladeRush(event: CastEvent) {
     let value = QualitativePerformance.Good;
     const energy = getResource(event.classResources, RESOURCE_TYPES.ENERGY.id);
     const tooltip = (
       <>
-        Cast @ {this.owner.formatTimestamp(event.timestamp)}: You cast 
+        At {this.owner.formatTimestamp(event.timestamp)} you cast 
         <SpellLink id={TALENTS.BLADE_RUSH_TALENT}/> at {energy!.amount} energy
       </>
     );
 
-    this.castsTotal += 1;
-
     if (energy!.amount > MAX_ENERGY_TRESHOLD) {
-      this.castsOverEnergyTreshold += 1;
       value = QualitativePerformance.Fail;
     }
     else if(energy!.amount > ACCEPTABLE_ENERGY_TRESHOLD){
-      this.castsOverEnergyTreshold += 1;
       value = QualitativePerformance.Ok;
     }
     this.castEntries.push({ value, tooltip });
   }
 
-  // Count time spent under MIN_ENERGY_TRESHOLD with BR off cd
+  // Record periods spent under MIN_ENERGY_TRESHOLD with BR off cd
   protected onResourceChange(event: ResourceChangeEvent) {
     const energy = getResource(event.classResources, RESOURCE_TYPES.ENERGY.id);
     const energyAmount = energy?.amount;
-    if (!energy || !energyAmount) {
-      return;
-    }
-
-    if (this.spellUsable.isOnCooldown(TALENTS.BLADE_RUSH_TALENT.id)) {
-      this.lastTimeStamp = 0;
+    if (!energy ||
+       !energyAmount ||
+       this.spellUsable.isOnCooldown(TALENTS.BLADE_RUSH_TALENT.id)) {
       return;
     }
 
     if (energyAmount <= MIN_ENERGY_TRESHOLD) {
-      if (this.lastTimeStamp !== 0) {
-        this.timeSpentUnderTreshold += event.timestamp - this.lastTimeStamp;
-      }
-      this.lastTimeStamp = event.timestamp;
-
       this.startUsablePeriod(event.timestamp);
       
     } else {
       this.endUsablePeriod(event.timestamp);
-      this.lastTimeStamp = 0;
     }
   }
 
   // Count blade rush time spent off cd
   onBladeRushUsable(event: UpdateSpellUsableEvent) {
-    switch (event.updateType) {
-      case UpdateSpellUsableType.BeginCooldown: {
-        if (!this.isFirstCast) {
-          this.totalTimeOffCD += event.timestamp - this.timestampFromCD;
-        } else {
-          this.isFirstCast = false;
-        }
+    if(event.updateType === UpdateSpellUsableType.BeginCooldown) {
         this.endUsablePeriod(event.timestamp);
-
-        break;
       }
-
-      case UpdateSpellUsableType.EndCooldown: {
-        this.timestampFromCD = event.timestamp;
-        break;
-      }
-    }
-  }
-
-  get castsChart() {
-    const items = [
-      {
-        color: GoodColor,
-        label: 'Effective casts',
-        value: this.castsTotal - this.castsOverEnergyTreshold,
-      },
-      {
-        color: BadColor,
-        label: 'Wasted casts',
-        value: this.castsOverEnergyTreshold,
-      },
-    ];
-
-    return <DonutChart items={items} />;
-  }
-
-  get cooldownChart() {
-    const items = [
-      {
-        color: GoodColor,
-        label: 'Time off cd above energy treshold',
-        value: (this.totalTimeOffCD - this.timeSpentUnderTreshold) / 1000,
-      },
-      {
-        color: BadColor,
-        label: 'Time off cd under energy treshold',
-        value: this.timeSpentUnderTreshold / 1000,
-      },
-    ];
-
-    return <DonutChart items={items} />;
-  }
-
-  get guideOld(): JSX.Element {
-    return (
-      <p>
-        <p>
-          <strong>
-            <SpellLink id={TALENTS.BLADE_RUSH_TALENT} />
-          </strong>{' '}
-          should be used whenever your energy drop under 70-80, this energy treshold increase with
-          target count. At around 9 targets it is safe to use{' '}
-          <SpellLink id={TALENTS.BLADE_RUSH_TALENT} /> on cooldown regardless of energy.
-        </p>
-        <SideBySidePanels>
-          <RoundedPanel>
-            <div>
-              This chart display the percentage of <SpellLink id={TALENTS.BLADE_RUSH_TALENT} />{' '}
-              casts used at an higher than recommended energy treshold. (Ignore this if aoe fights
-              for now)
-            </div>
-            {this.castsChart}
-          </RoundedPanel>
-          <RoundedPanel>
-            <div>
-              This chart display the amount of time (in seconds) that you spent under the energy
-              threshold without pressing <SpellLink id={TALENTS.BLADE_RUSH_TALENT} />.
-            </div>
-            {this.cooldownChart}
-          </RoundedPanel>
-        </SideBySidePanels>
-        <small>
-          Grey periods indicate times that you should have used 
-          <SpellLink id={TALENTS.BLADE_RUSH_TALENT}/>, but did not.
-        </small>
-        {uptimeBarSubStatistic(
-            this.owner.fight,
-            {
-              spells: [TALENTS.BLADE_RUSH_TALENT],
-              uptimes: this.unusableUptimes,
-            },
-            undefined,
-            undefined,
-            undefined,
-            'utilization',
-          )}
-      </p>
-    );
   }
 
   get guide(): JSX.Element {
@@ -281,8 +160,8 @@ class BladeRush extends Analyzer {
           )}
           <strong>Casts </strong>
             <small>
-              - Green indicates a good cast under 80 energy, yellow indicate a cast slighlty above the recommended energy treshold, 
-              while red indicates a "wasted" cast casted above the recommended energy treshold (Ignore this section in aoe for now)
+              - Green indicates an efficient cast under {ACCEPTABLE_ENERGY_TRESHOLD} energy, yellow indicate a cast slighlty above the recommended energy treshold, 
+              while red indicates a "wasted" cast above the recommended energy treshold (Ignore this section in aoe for now)
             </small>
           <PerformanceBoxRow values={this.castEntries}/>
           </div>

--- a/src/analysis/retail/rogue/outlaw/modules/talents/BladeRush.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/talents/BladeRush.tsx
@@ -157,7 +157,8 @@ class BladeRush extends Analyzer {
           <RoundedPanel>
             <div>
               This chart display the percentage of <SpellLink id={TALENTS.BLADE_RUSH_TALENT} />{' '}
-              casts used at an higher than recommended energy treshold.
+              casts used at an higher than recommended energy treshold. (Ignore this if aoe fights
+              for now)
             </div>
             {this.castsChart}
           </RoundedPanel>

--- a/src/analysis/retail/rogue/outlaw/modules/talents/BladeRush.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/talents/BladeRush.tsx
@@ -17,12 +17,11 @@ import { explanationAndDataSubsection } from 'interface/guide/components/Explana
 import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 
-const MIN_ENERGY_TRESHOLD = 70;
-const MAX_ENERGY_TRESHOLD = 90;
-const ACCEPTABLE_ENERGY_TRESHOLD = 80;
+const MIN_ENERGY_THRESHOLD = 70;
+const MAX_ENERGY_THRESHOLD = 90;
+const ACCEPTABLE_ENERGY_THRESHOLD = 80;
 
-
-//-- TODO: MAX_ENERGY_TRESHOLD should scale with targets hit to support aoe fights
+//-- TODO: MAX_ENERGY_THRESHOLD should scale with targets hit to support aoe fights
 
 class BladeRush extends Analyzer {
   static dependencies = {
@@ -52,16 +51,17 @@ class BladeRush extends Analyzer {
       Events.UpdateSpellUsable.by(SELECTED_PLAYER).spell(TALENTS.BLADE_RUSH_TALENT),
       this.onBladeRushUsable,
     );
-    
+
     this.unusableUptimes.push({
       start: this.owner.fight.start_time,
       end: -1,
     });
+
+    this.addEventListener(Events.fightend, this.finalize);
   }
 
-  endUsablePeriod(timestamp: number) {
-    if(this.isInUsablePeriod)
-    {
+  private endUsablePeriod(timestamp: number) {
+    if (this.isInUsablePeriod) {
       this.isInUsablePeriod = false;
       this.unusableUptimes.push({
         start: timestamp,
@@ -70,69 +70,72 @@ class BladeRush extends Analyzer {
     }
   }
 
-  startUsablePeriod(timestamp: number) {
-    if(!this.isInUsablePeriod)
-    {
+  private startUsablePeriod(timestamp: number) {
+    if (!this.isInUsablePeriod) {
       this.isInUsablePeriod = true;
       this.unusableUptimes.at(-1)!.end = timestamp;
     }
   }
 
   // Record the accuracy of every Blade Rush casts
-  protected onBladeRush(event: CastEvent) {
+  private onBladeRush(event: CastEvent) {
     let value = QualitativePerformance.Good;
     const energy = getResource(event.classResources, RESOURCE_TYPES.ENERGY.id);
     const tooltip = (
       <>
-        At {this.owner.formatTimestamp(event.timestamp)} you cast 
-        <SpellLink id={TALENTS.BLADE_RUSH_TALENT}/> at {energy!.amount} energy
+        At {this.owner.formatTimestamp(event.timestamp)} you cast{' '}
+        <SpellLink id={TALENTS.BLADE_RUSH_TALENT} /> at {energy!.amount} energy
       </>
     );
 
-    if (energy!.amount > MAX_ENERGY_TRESHOLD) {
+    if (energy!.amount > MAX_ENERGY_THRESHOLD) {
       value = QualitativePerformance.Fail;
-    }
-    else if(energy!.amount > ACCEPTABLE_ENERGY_TRESHOLD){
+    } else if (energy!.amount > ACCEPTABLE_ENERGY_THRESHOLD) {
       value = QualitativePerformance.Ok;
     }
     this.castEntries.push({ value, tooltip });
   }
 
-  // Record periods spent under MIN_ENERGY_TRESHOLD with BR off cd
-  protected onResourceChange(event: ResourceChangeEvent) {
+  // Record periods spent under MIN_ENERGY_THRESHOLD with BR off cd
+  private onResourceChange(event: ResourceChangeEvent) {
     const energy = getResource(event.classResources, RESOURCE_TYPES.ENERGY.id);
     const energyAmount = energy?.amount;
-    if (!energy ||
-       !energyAmount ||
-       this.spellUsable.isOnCooldown(TALENTS.BLADE_RUSH_TALENT.id)) {
+    if (!energy || !energyAmount || this.spellUsable.isOnCooldown(TALENTS.BLADE_RUSH_TALENT.id)) {
       return;
     }
 
-    if (energyAmount <= MIN_ENERGY_TRESHOLD) {
+    if (energyAmount <= MIN_ENERGY_THRESHOLD) {
       this.startUsablePeriod(event.timestamp);
-      
     } else {
       this.endUsablePeriod(event.timestamp);
     }
   }
 
   // Count blade rush time spent off cd
-  onBladeRushUsable(event: UpdateSpellUsableEvent) {
-    if(event.updateType === UpdateSpellUsableType.BeginCooldown) {
-        this.endUsablePeriod(event.timestamp);
-      }
+  private onBladeRushUsable(event: UpdateSpellUsableEvent) {
+    if (event.updateType === UpdateSpellUsableType.BeginCooldown) {
+      this.endUsablePeriod(event.timestamp);
+    }
+  }
+
+  private finalize() {
+    const uptime = this.unusableUptimes.at(-1);
+    if (!uptime) {
+      return;
+    }
+
+    uptime.end = this.owner.fight.end_time;
   }
 
   get guide(): JSX.Element {
-    this.unusableUptimes.at(-1)!.end = this.owner.fight.end_time;
     const explanation = (
       <p>
-          <strong>
-            <SpellLink id={TALENTS.BLADE_RUSH_TALENT} />
-          </strong>{' '}
-          should be used whenever your energy drop under 70-80, this energy treshold increase with
-          target count. At around 9 targets it is safe to use{' '}
-          <SpellLink id={TALENTS.BLADE_RUSH_TALENT} /> on cooldown regardless of energy.
+        <strong>
+          <SpellLink id={TALENTS.BLADE_RUSH_TALENT} />
+        </strong>{' '}
+        should be used whenever your energy drop under 70-80, this energy threshold increase with
+        target count. At around 9 targets it is safe to use{' '}
+        <SpellLink id={TALENTS.BLADE_RUSH_TALENT} /> on cooldown regardless of energy.
       </p>
     );
 
@@ -140,30 +143,32 @@ class BladeRush extends Analyzer {
       <div>
         <RoundedPanel>
           <strong>
-          <SpellLink id={TALENTS.BLADE_RUSH_TALENT} /> utilization
+            <SpellLink id={TALENTS.BLADE_RUSH_TALENT} /> utilization
           </strong>
           <div>
-          <small>
-            Grey periods indicate periods where your energy went under the
-            recommended energy treshold but you did not use <SpellLink id={TALENTS.BLADE_RUSH_TALENT}/>.
-          </small>
-          {uptimeBarSubStatistic(
-            this.owner.fight,
-            {
-              spells: [TALENTS.BLADE_RUSH_TALENT],
-              uptimes: this.unusableUptimes,
-            },
-            undefined,
-            undefined,
-            undefined,
-            'utilization',
-          )}
-          <strong>Casts </strong>
             <small>
-              - Green indicates an efficient cast under {ACCEPTABLE_ENERGY_TRESHOLD} energy, yellow indicate a cast slighlty above the recommended energy treshold, 
-              while red indicates a "wasted" cast above the recommended energy treshold (Ignore this section in aoe for now)
+              Grey periods indicate periods where your energy went under the recommended energy
+              threshold but you did not use <SpellLink id={TALENTS.BLADE_RUSH_TALENT} />.
             </small>
-          <PerformanceBoxRow values={this.castEntries}/>
+            {uptimeBarSubStatistic(
+              this.owner.fight,
+              {
+                spells: [TALENTS.BLADE_RUSH_TALENT],
+                uptimes: this.unusableUptimes,
+              },
+              undefined,
+              undefined,
+              undefined,
+              'utilization',
+            )}
+            <strong>Casts </strong>
+            <small>
+              - Green indicates an efficient cast under {ACCEPTABLE_ENERGY_THRESHOLD} energy, yellow
+              indicate a cast slighlty above the recommended energy threshold, while red indicates a
+              "wasted" cast above the recommended energy threshold (Ignore this section in aoe for
+              now)
+            </small>
+            <PerformanceBoxRow values={this.castEntries} />
           </div>
         </RoundedPanel>
       </div>

--- a/src/analysis/retail/rogue/shared/ComboPointTracker.ts
+++ b/src/analysis/retail/rogue/shared/ComboPointTracker.ts
@@ -14,7 +14,8 @@ class ComboPointTracker extends ResourceTracker {
     this.maxResource =
       5 +
       this.selectedCombatant.getTalentRank(TALENTS.DEEPER_STRATAGEM_TALENT) +
-      this.selectedCombatant.getTalentRank(TALENTS.SECRET_STRATAGEM_TALENT);
+      this.selectedCombatant.getTalentRank(TALENTS.SECRET_STRATAGEM_TALENT) +
+      this.selectedCombatant.getTalentRank(TALENTS.DEVIOUS_STRATAGEM_TALENT);
     this.refundOnMiss = true;
     this.refundOnMissAmount = 1;
   }

--- a/src/common/SPELLS/rogue.ts
+++ b/src/common/SPELLS/rogue.ts
@@ -584,9 +584,8 @@ const spells = spellIndexableList({
   OUTLAW_ROGUE_TIER_28_2P_SET_BONUS: {
     id: 394879,
     name: 'Vicious Follow-up',
-    icon: 'ability_rogue_sabreslash',
+    icon: 'spell_shadow_ritualofsacrifice',
   },
-
 });
 
 export default spells;

--- a/src/common/SPELLS/rogue.ts
+++ b/src/common/SPELLS/rogue.ts
@@ -578,6 +578,15 @@ const spells = spellIndexableList({
     name: 'Audacity',
     icon: 'ability_rogue_ambush',
   },
+
+  //Tiers
+
+  OUTLAW_ROGUE_TIER_28_2P_SET_BONUS: {
+    id: 394879,
+    name: 'Vicious Follow-up',
+    icon: 'ability_rogue_sabreslash',
+  },
+
 });
 
 export default spells;


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->
First pass at a guide with a resource section for now, mostly copied from the assassination one although there are some slight differences.

Added a small section to track Blade rush usage as it's a spell mostly used for energy efficiency (currently would have small issues in aoe fights), will also add killing spree(and maybe thistle tea) here in the future since its used for the same purpose.

The builderUse section is tracking builders casted above the recommended finisher points threshold (with some exceptions) instead of checking if cp were wasted, this seems more relevant for outlaw as we have been overcaping a decent amount of combo point in DF (and even with some SL builds) making raw cp waste tracking almost irrelevant.

### Motivation

<!-- Why are you submitting this pull request?-->

Working toward outlaw 10.0.5+ support.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `https://www.warcraftlogs.com/reports/t27zV8NLgPvJq3Kk#fight=17&type=damage-done&source=18`
- Screenshot(s):
![image](https://user-images.githubusercontent.com/109383107/221428166-c6e1145c-89ef-40f5-9c23-7bfc1da87613.png)



