### PR TITLE
[Mistweaver] Refactor rising mist to typescript and added Rising Mist Healing Breakdown statistic

### DIFF
--- a/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/core.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/core.tsx
@@ -3,6 +3,7 @@ import { formatDuration, formatNumber } from 'common/format';
 import Spell from 'common/SPELLS/Spell';
 import { Talent } from 'common/TALENTS/types';
 import MAGIC_SCHOOLS, { color } from 'game/MAGIC_SCHOOLS';
+import SPECS from 'game/SPECS';
 import { SpellLink, Tooltip } from 'interface';
 import { PerformanceMark } from 'interface/guide';
 import { CooldownExpandableItem } from 'interface/guide/components/CooldownExpandable';
@@ -146,6 +147,7 @@ export class MajorDefensive extends Analyzer {
 
   private talent: Talent;
   private buff: Spell;
+  private talentCategory: STATISTIC_CATEGORY;
 
   get spell() {
     return this.talent;
@@ -157,7 +159,10 @@ export class MajorDefensive extends Analyzer {
 
   constructor({ talent, buffSpell }: DefensiveOptions, options: Options) {
     super(options);
-
+    this.talentCategory =
+      this.selectedCombatant.specId === SPECS.MISTWEAVER_MONK.id
+        ? STATISTIC_CATEGORY.THEORYCRAFT
+        : STATISTIC_CATEGORY.TALENTS;
     this.active = this.selectedCombatant.hasTalent(talent);
     this.talent = talent;
     this.buff = buffSpell ?? talent;
@@ -301,7 +306,7 @@ export class MajorDefensive extends Analyzer {
       </MitigationTooltipBody>
     );
     return (
-      <Statistic category={STATISTIC_CATEGORY.TALENTS} size="flexible" tooltip={tooltip}>
+      <Statistic category={this.talentCategory} size="flexible" tooltip={tooltip}>
         <BoringValue
           label={
             <>

--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 2, 25), <>Added TalentAggregateStatictic, added new <SpellLink id={TALENTS_MONK.RISING_MIST_TALENT.id}/> healing breakdown module. Fixed bugs in the HotTracker</>, Vohrr),
   change(date(2023, 2, 24), <>Bug fix in the Hot Tracker to improve the accuracy of <SpellLink id={TALENTS_MONK.RISING_MIST_TALENT.id}/>, <SpellLink id={TALENTS_MONK.DANCING_MISTS_TALENT.id}/>, <SpellLink id={TALENTS_MONK.MISTY_PEAKS_TALENT.id}/>, <SpellLink id={TALENTS_MONK.MIST_WRAP_TALENT.id}/> and <SpellLink id={TALENTS_MONK.RAPID_DIFFUSION_TALENT.id}/>.</>, Vohrr),
   change(date(2023, 2, 23), <>Fixed inconsistent QualitativePerformance marks for <SpellLink id={SPELLS.VIVIFY.id}/> casts in the Guide.</>, Vohrr),
   change(date(2023, 2, 21), <>Added Initial version of <SpellLink id={TALENTS_MONK.CLOUDED_FOCUS_TALENT.id}/> apl.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
+++ b/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
@@ -82,6 +82,7 @@ import SheilunsGiftCloudTracker from './modules/spells/SheilunsGiftCloudTracker'
 import SheilunsGiftCloudGraph from './modules/spells/SheilunsGiftCloudGraph';
 import HotCountGraph from './modules/features/HotCountGraph';
 import AplCheck from './modules/core/apl/AplCheck';
+import RisingMistBreakdown from './modules/features/RisingMistBreakdown';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -116,6 +117,7 @@ class CombatLogParser extends CoreCombatLogParser {
     remGraph: REMGraph,
     hotCountGraph: HotCountGraph,
     talentHealingStatistic: TalentHealingStatistic,
+    risingMistBreakdown: RisingMistBreakdown,
 
     // Guide helpers
     sheilunsGiftCloudTracker: SheilunsGiftCloudTracker,

--- a/src/analysis/retail/monk/mistweaver/modules/core/HotAttributor.ts
+++ b/src/analysis/retail/monk/mistweaver/modules/core/HotAttributor.ts
@@ -58,7 +58,15 @@ class HotAttributor extends Analyzer {
       this.onApplyEnvm,
     );
     this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(TALENTS_MONK.ENVELOPING_MIST_TALENT),
+      this.onApplyEnvm,
+    );
+    this.addEventListener(
       Events.applybuff.by(SELECTED_PLAYER).spell([SPELLS.ESSENCE_FONT_BUFF]),
+      this.onApplyEF,
+    );
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell([SPELLS.ESSENCE_FONT_BUFF]),
       this.onApplyEF,
     );
     this.addEventListener(
@@ -157,6 +165,9 @@ class HotAttributor extends Analyzer {
   }
 
   onApplyEF(event: ApplyBuffEvent | RefreshBuffEvent) {
+    if (this._hasAttribution(event)) {
+      return;
+    }
     this.hotTracker.addAttributionFromApply(this.EFAttrib, event);
   }
 

--- a/src/analysis/retail/monk/mistweaver/modules/core/HotTrackerMW.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/HotTrackerMW.tsx
@@ -146,9 +146,8 @@ class HotTrackerMW extends HotTracker {
 
   _getMistyPeaksMaxDuration(combatant: Combatant): number {
     return (
-      (combatant.hasTalent(TALENTS_MONK.RISING_MIST_TALENT)
-        ? MISTY_PEAKS_DURATION * RISING_MIST + ENV_BASE_DURATION // TODO: REMOVE ENV BASE DURATION WHEN 10.0.7 HITS
-        : MISTY_PEAKS_DURATION) * combatant.getTalentRank(TALENTS_MONK.MISTY_PEAKS_TALENT)
+      MISTY_PEAKS_DURATION * combatant.getTalentRank(TALENTS_MONK.MISTY_PEAKS_TALENT) +
+      combatant.getTalentRank(TALENTS_MONK.RISING_MIST_TALENT) * ENV_BASE_DURATION // TODO: REMOVE ENV BASE DURATION WHEN 10.0.7 HIT
     );
   }
 
@@ -173,8 +172,7 @@ class HotTrackerMW extends HotTracker {
         maxDuration: this._calculateMaxEnvDuration,
         procDuration: this.owner.selectedCombatant.hasTalent(TALENTS_MONK.MISTY_PEAKS_TALENT)
           ? MISTY_PEAKS_DURATION *
-              this.selectedCombatant.getTalentRank(TALENTS_MONK.MISTY_PEAKS_TALENT) +
-            ENV_BASE_DURATION // TODO: REMOVE ENV BASE DURATION WHEN 10.0.7 HITS
+            this.selectedCombatant.getTalentRank(TALENTS_MONK.MISTY_PEAKS_TALENT)
           : undefined,
       },
       {

--- a/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
@@ -268,7 +268,7 @@ class RisingMistBreakdown extends Analyzer {
       <TalentAggregateStatisticContainer
         title={
           <>
-            <SpellLink id={talents.RISING_MIST_TALENT.id} /> Breakdown -{' '}
+            <SpellLink id={talents.RISING_MIST_TALENT.id} /> -{' '}
             <ItemHealingDone amount={this.risingMist.totalHealing} />
           </>
         }

--- a/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
@@ -272,10 +272,11 @@ class RisingMistBreakdown extends Analyzer {
             <ItemHealingDone amount={this.risingMist.totalHealing} />
           </>
         }
-        category={STATISTIC_CATEGORY.GENERAL}
+        category={STATISTIC_CATEGORY.TALENTS}
         position={STATISTIC_ORDER.CORE(1)}
         footer={<>*Mouseover for a detailed breakdown of each spell's contribution</>}
         smallFooter
+        tooltip={this.risingMist.toolTip()}
       >
         {talentAggregateBars(
           this.sortedRisingMistItems().sortedRisingMistItems,

--- a/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
@@ -239,7 +239,7 @@ class RisingMistBreakdown extends Analyzer {
         }
         category={STATISTIC_CATEGORY.TALENTS}
         position={STATISTIC_ORDER.CORE(1)}
-        footer={<>*Mouseover for a detailed breakdown of each spell's contribution</>}
+        footer={<>Mouseover for a detailed breakdown of each spell's contribution</>}
         smallFooter
         tooltip={this.risingMist.toolTip()}
       >

--- a/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
@@ -4,10 +4,10 @@ import talents from 'common/TALENTS/monk';
 import { SpellLink } from 'interface';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
-import sourceContributionBars, { TalentAggregateBarSpec } from 'parser/ui/TalentAggregateStatistic';
+import talentAggregateBars, { TalentAggregateBarSpec } from 'parser/ui/TalentAggregateStatistic';
 import SPELLS from 'common/SPELLS';
 import { SPELL_COLORS } from '../../constants';
-import SourceContributionContainer from 'parser/ui/TalentAggregateStatisticContainer';
+import TalentAggregateStatisticContainer from 'parser/ui/TalentAggregateStatisticContainer';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
 import { formatNumber, formatPercentage } from 'common/format';
 
@@ -258,7 +258,7 @@ class RisingMistBreakdown extends Analyzer {
 
   statistic() {
     return (
-      <SourceContributionContainer
+      <TalentAggregateStatisticContainer
         title={
           <>
             <SpellLink id={talents.RISING_MIST_TALENT.id} /> Breakdown -{' '}
@@ -270,11 +270,11 @@ class RisingMistBreakdown extends Analyzer {
         footer={<>*Mouseover for a detailed breakdown of each spell's contribution</>}
         smallFooter
       >
-        {sourceContributionBars(
+        {talentAggregateBars(
           this.sortedRisingMistItems().sortedRisingMistItems,
           this.sortedRisingMistItems().scaleFactor,
         )}
-      </SourceContributionContainer>
+      </TalentAggregateStatisticContainer>
     );
   }
 }

--- a/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
@@ -1,0 +1,282 @@
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import RisingMist from '../spells/RisingMist';
+import talents from 'common/TALENTS/monk';
+import { SpellLink } from 'interface';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import sourceContributionBars, { TalentAggregateBarSpec } from 'parser/ui/TalentAggregateStatistic';
+import SPELLS from 'common/SPELLS';
+import { SPELL_COLORS } from '../../constants';
+import SourceContributionContainer from 'parser/ui/TalentAggregateStatisticContainer';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import { formatNumber, formatPercentage } from 'common/format';
+
+class RisingMistBreakdown extends Analyzer {
+  static dependencies = {
+    risingMist: RisingMist,
+  };
+  risingMistItems: TalentAggregateBarSpec[] = [];
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(talents.RISING_MIST_TALENT);
+  }
+  protected risingMist!: RisingMist;
+
+  sortedRisingMistItems() {
+    this.risingMistItems = [
+      {
+        spell: SPELLS.RISING_MIST_HEAL,
+        amount: this.risingMist.directHealing,
+        color: SPELL_COLORS.DANCING_MIST,
+        tooltip: this.risingMistDirectTooltip(),
+      },
+      {
+        spell: SPELLS.RENEWING_MIST_HEAL,
+        amount: this.risingMist.renewingMistExtensionHealing,
+        color: SPELL_COLORS.RENEWING_MIST,
+        tooltip: this.renewingMistTooltip(),
+      },
+      {
+        //enveloping mist extension healing
+        spell: talents.ENVELOPING_MIST_TALENT,
+        amount:
+          this.risingMist.envMistyPeaksExtensionHealing +
+          this.risingMist.envHardcastExtensionHealing,
+        color: SPELL_COLORS.ENVELOPING_MIST,
+        tooltip: this.envelopingMistTooltip(),
+        subSpecs: [
+          {
+            //bonus healing from healing bonus
+            spell: talents.ENVELOPING_MIST_TALENT,
+            amount: this.risingMist.extraEnvBonusHealing,
+            color: SPELL_COLORS.BLACKOUT_KICK_TOTM,
+            tooltip: this.envelopingMistBonusHealingTooltip(),
+          },
+        ],
+      },
+      {
+        spell: SPELLS.VIVIFY,
+        amount: this.risingMist.extraVivHealing,
+        color: SPELL_COLORS.VIVIFY,
+        tooltip: this.vivifyTooltip(),
+      },
+      {
+        //essence font extension healing
+        spell: talents.ESSENCE_FONT_TALENT,
+        amount: this.risingMist.essenceFontExtensionHealing,
+        color: SPELL_COLORS.ESSENCE_FONT,
+        tooltip: this.essenceFontTooltip(),
+        subSpecs: [
+          {
+            //additional mastery hits from extended EF hots
+            spell: SPELLS.GUSTS_OF_MISTS,
+            amount: this.risingMist.extraMasteryhealing,
+            color: SPELL_COLORS.GUSTS_OF_MISTS,
+            tooltip: this.gustsOfMistsTooltip(),
+          },
+        ],
+      },
+    ];
+    const sortedRisingMistItems = this.risingMistItems.sort(
+      (a, b) =>
+        b.amount +
+        (b.subSpecs ? b.subSpecs?.reduce((sum, subSpec) => sum + (subSpec?.amount || 0), 0) : 0) -
+        a.amount +
+        (a.subSpecs ? a.subSpecs?.reduce((sum, subSpec) => sum + (subSpec?.amount || 0), 0) : 0),
+    );
+
+    //determine scale factor for chart based on data
+    const scaleFactor = sortedRisingMistItems.reduce(
+      (factor, item) =>
+        factor <
+        this.risingMist.totalHealing /
+          (item.amount +
+            (item.subSpecs
+              ? item.subSpecs?.reduce((sum, subSpec) => sum + (subSpec?.amount || 0), 0)
+              : 0))
+          ? factor
+          : this.risingMist.totalHealing /
+            (item.amount +
+              (item.subSpecs
+                ? item.subSpecs?.reduce((sum, subSpec) => sum + (subSpec?.amount || 0), 0)
+                : 0)),
+      100,
+    );
+
+    return { sortedRisingMistItems, scaleFactor };
+  }
+
+  envelopingMistTooltip() {
+    return (
+      <>
+        <SpellLink id={talents.ENVELOPING_MIST_TALENT} /> extension healing (
+        {formatPercentage(
+          (this.risingMist.envHardcastExtensionHealing +
+            this.risingMist.envMistyPeaksExtensionHealing) /
+            this.risingMist.totalHealing,
+        )}
+        % of Total)
+        <ul>
+          <li>
+            {formatNumber(this.risingMist.envMistyPeaksExtensionHealing)} from extended{' '}
+            <SpellLink id={talents.MISTY_PEAKS_TALENT} />
+          </li>
+          <li>
+            {formatNumber(this.risingMist.envHardcastExtensionHealing)} from extended harcasts
+          </li>
+        </ul>
+      </>
+    );
+  }
+
+  envelopingMistBonusHealingTooltip() {
+    return (
+      <>
+        Additional bonus healing from the extra <SpellLink id={talents.ENVELOPING_MIST_TALENT} />{' '}
+        buff uptime (
+        {formatPercentage(this.risingMist.extraEnvBonusHealing / this.risingMist.totalHealing)}% of
+        Total)
+        <ul>
+          <li>
+            {formatNumber(this.risingMist.extraEnvBonusMistyPeaks)} from extended{' '}
+            <SpellLink id={talents.MISTY_PEAKS_TALENT} />
+          </li>
+          <li>{formatNumber(this.risingMist.extraEnvBonusHardcast)} from extended harcasts</li>
+        </ul>
+      </>
+    );
+  }
+
+  renewingMistTooltip() {
+    return (
+      <>
+        <SpellLink id={talents.RENEWING_MIST_TALENT} /> extension healing (
+        {formatPercentage(
+          this.risingMist.renewingMistExtensionHealing / this.risingMist.totalHealing,
+        )}
+        % of Total)
+        <ul>
+          <li>
+            {formatNumber(this.risingMist.renewingMistDancingMistExtensionHealing)} from extended{' '}
+            <SpellLink id={talents.DANCING_MISTS_TALENT} />{' '}
+            <SpellLink id={talents.RENEWING_MIST_TALENT} />
+          </li>
+          <li>
+            {formatNumber(this.risingMist.renewingMistHardcastExtensionHealing)} from extended
+            hardcast <SpellLink id={talents.RENEWING_MIST_TALENT} />
+          </li>
+          <li>
+            {formatNumber(this.risingMist.renewingMistRapidDiffusionExtensionHealing)} from extended{' '}
+            <SpellLink id={talents.RAPID_DIFFUSION_TALENT} />{' '}
+            <SpellLink id={talents.RENEWING_MIST_TALENT} />
+          </li>
+        </ul>
+      </>
+    );
+  }
+
+  risingMistDirectTooltip() {
+    return (
+      <>
+        <SpellLink id={talents.RISING_MIST_TALENT} /> direct healing from{' '}
+        <SpellLink id={talents.RISING_SUN_KICK_TALENT} /> casts (
+        {formatPercentage(this.risingMist.directHealing / this.risingMist.totalHealing)}% of Total)
+        <ul>
+          <li>{formatNumber(this.risingMist.averageHealing)} average healing per kick</li>
+          <li>{this.risingMist.averageTargetsPerRSKCast()} average hits per kick</li>
+        </ul>
+      </>
+    );
+  }
+
+  vivifyTooltip() {
+    return (
+      <>
+        <SpellLink id={SPELLS.VIVIFY} /> healing from extended{' '}
+        <SpellLink id={talents.RENEWING_MIST_TALENT} /> (
+        {formatPercentage(this.risingMist.extraVivHealing / this.risingMist.totalHealing)}% of
+        Total)
+        <ul>
+          <li>
+            {this.risingMist.extraVivCleaves} extra cleave hits via{' '}
+            <SpellLink id={talents.INVIGORATING_MISTS_TALENT} />
+          </li>
+          <li>
+            {formatNumber(this.risingMist.extraVivhealingFromDancingMistRems)} from extended{' '}
+            <SpellLink id={talents.DANCING_MISTS_TALENT} />{' '}
+            <SpellLink id={talents.RENEWING_MIST_TALENT} />
+          </li>
+          <li>
+            {formatNumber(this.risingMist.extraVivHealingFromHardcastRems)} from extended hardcast{' '}
+            <SpellLink id={talents.RENEWING_MIST_TALENT} />
+          </li>
+          <li>
+            {formatNumber(this.risingMist.extraVivHealingFromRapidDiffusionRems)} from extended{' '}
+            <SpellLink id={talents.RAPID_DIFFUSION_TALENT} />{' '}
+            <SpellLink id={talents.RENEWING_MIST_TALENT} />
+          </li>
+        </ul>
+      </>
+    );
+  }
+
+  essenceFontTooltip() {
+    return (
+      <>
+        Additional <SpellLink id={SPELLS.ESSENCE_FONT_BUFF} /> healing from extensions (
+        {formatPercentage(
+          this.risingMist.essenceFontExtensionHealing / this.risingMist.totalHealing,
+        )}
+        % of Total)
+      </>
+    );
+  }
+
+  gustsOfMistsTooltip() {
+    return (
+      <>
+        Additional <SpellLink id={SPELLS.GUSTS_OF_MISTS} /> healing from extended{' '}
+        <SpellLink id={talents.ESSENCE_FONT_TALENT} /> (
+        {formatPercentage(this.risingMist.extraMasteryhealing / this.risingMist.totalHealing)}% of
+        Total)
+        <ul>
+          {this.selectedCombatant.hasTalent(talents.INVOKE_CHI_JI_THE_RED_CRANE_TALENT) && (
+            <li>
+              {formatNumber(this.risingMist.extraChijiGomHealing)}{' '}
+              <SpellLink id={SPELLS.GUST_OF_MISTS_CHIJI} /> healing from extended{' '}
+              <SpellLink id={talents.ESSENCE_FONT_TALENT} />
+            </li>
+          )}
+          <li>
+            {formatNumber(this.risingMist.extraGomHealing)} <SpellLink id={SPELLS.GUSTS_OF_MISTS} />{' '}
+            healing from extended <SpellLink id={talents.ESSENCE_FONT_TALENT} />
+          </li>
+        </ul>
+      </>
+    );
+  }
+
+  statistic() {
+    return (
+      <SourceContributionContainer
+        title={
+          <>
+            <SpellLink id={talents.RISING_MIST_TALENT.id} /> Breakdown -{' '}
+            <ItemHealingDone amount={this.risingMist.totalHealing} />
+          </>
+        }
+        category={STATISTIC_CATEGORY.GENERAL}
+        position={STATISTIC_ORDER.CORE(1)}
+        footer={<>*Mouseover for a detailed breakdown of each spell's contribution</>}
+        smallFooter
+      >
+        {sourceContributionBars(
+          this.sortedRisingMistItems().sortedRisingMistItems,
+          this.sortedRisingMistItems().scaleFactor,
+        )}
+      </SourceContributionContainer>
+    );
+  }
+}
+
+export default RisingMistBreakdown;

--- a/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
@@ -4,7 +4,10 @@ import talents, { TALENTS_MONK } from 'common/TALENTS/monk';
 import { SpellLink } from 'interface';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
-import talentAggregateBars, { TalentAggregateBarSpec } from 'parser/ui/TalentAggregateStatistic';
+import talentAggregateBars, {
+  getSpecSubtotal,
+  TalentAggregateBarSpec,
+} from 'parser/ui/TalentAggregateStatistic';
 import SPELLS from 'common/SPELLS';
 import { SPELL_COLORS } from '../../constants';
 import TalentAggregateStatisticContainer from 'parser/ui/TalentAggregateStatisticContainer';
@@ -78,29 +81,16 @@ class RisingMistBreakdown extends Analyzer {
       },
     ];
     const sortedRisingMistItems = this.risingMistItems.sort(
-      (a, b) =>
-        b.amount +
-        (b.subSpecs ? b.subSpecs?.reduce((sum, subSpec) => sum + (subSpec?.amount || 0), 0) : 0) -
-        a.amount +
-        (a.subSpecs ? a.subSpecs?.reduce((sum, subSpec) => sum + (subSpec?.amount || 0), 0) : 0),
+      (a, b) => getSpecSubtotal(b) - getSpecSubtotal(a),
     );
 
     //determine scale factor for chart based on data items - calculate the inverse of each items percentage of total and take the lowest
     //i.e if 50% of healing done is the highest then the scale factor should be 2
     const scaleFactor = sortedRisingMistItems.reduce(
       (factor, item) =>
-        factor <
-        this.risingMist.totalHealing /
-          (item.amount +
-            (item.subSpecs
-              ? item.subSpecs?.reduce((sum, subSpec) => sum + (subSpec?.amount || 0), 0)
-              : 0))
+        factor < this.risingMist.totalHealing / getSpecSubtotal(item)
           ? factor
-          : this.risingMist.totalHealing /
-            (item.amount +
-              (item.subSpecs
-                ? item.subSpecs?.reduce((sum, subSpec) => sum + (subSpec?.amount || 0), 0)
-                : 0)),
+          : this.risingMist.totalHealing / getSpecSubtotal(item),
       100,
     );
 

--- a/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
@@ -1,6 +1,6 @@
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import RisingMist from '../spells/RisingMist';
-import talents from 'common/TALENTS/monk';
+import talents, { TALENTS_MONK } from 'common/TALENTS/monk';
 import { SpellLink } from 'interface';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
@@ -85,7 +85,8 @@ class RisingMistBreakdown extends Analyzer {
         (a.subSpecs ? a.subSpecs?.reduce((sum, subSpec) => sum + (subSpec?.amount || 0), 0) : 0),
     );
 
-    //determine scale factor for chart based on data
+    //determine scale factor for chart based on data items - calculate the inverse of each items percentage of total and take the lowest
+    //i.e if 50% of healing done is the highest then the scale factor should be 2
     const scaleFactor = sortedRisingMistItems.reduce(
       (factor, item) =>
         factor <
@@ -119,10 +120,10 @@ class RisingMistBreakdown extends Analyzer {
         <ul>
           <li>
             {formatNumber(this.risingMist.envMistyPeaksExtensionHealing)} from extended{' '}
-            <SpellLink id={talents.MISTY_PEAKS_TALENT} />
+            <SpellLink id={talents.MISTY_PEAKS_TALENT} /> procs
           </li>
           <li>
-            {formatNumber(this.risingMist.envHardcastExtensionHealing)} from extended harcasts
+            {formatNumber(this.risingMist.envHardcastExtensionHealing)} from extended hardcasts
           </li>
         </ul>
       </>
@@ -139,9 +140,9 @@ class RisingMistBreakdown extends Analyzer {
         <ul>
           <li>
             {formatNumber(this.risingMist.extraEnvBonusMistyPeaks)} from extended{' '}
-            <SpellLink id={talents.MISTY_PEAKS_TALENT} />
+            <SpellLink id={talents.MISTY_PEAKS_TALENT} /> procs
           </li>
-          <li>{formatNumber(this.risingMist.extraEnvBonusHardcast)} from extended harcasts</li>
+          <li>{formatNumber(this.risingMist.extraEnvBonusHardcast)} from extended hardcasts</li>
         </ul>
       </>
     );
@@ -182,8 +183,14 @@ class RisingMistBreakdown extends Analyzer {
         <SpellLink id={talents.RISING_SUN_KICK_TALENT} /> casts (
         {formatPercentage(this.risingMist.directHealing / this.risingMist.totalHealing)}% of Total)
         <ul>
-          <li>{formatNumber(this.risingMist.averageHealing)} average healing per kick</li>
-          <li>{this.risingMist.averageTargetsPerRSKCast()} average hits per kick</li>
+          <li>
+            {formatNumber(this.risingMist.averageHealing)} average healing per{' '}
+            <SpellLink id={TALENTS_MONK.RISING_SUN_KICK_TALENT} />
+          </li>
+          <li>
+            {this.risingMist.averageTargetsPerRSKCast()} average hits per{' '}
+            <SpellLink id={TALENTS_MONK.RISING_SUN_KICK_TALENT} />
+          </li>
         </ul>
       </>
     );

--- a/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
@@ -137,17 +137,15 @@ class RisingMistBreakdown extends Analyzer {
         <ul>
           <li>
             {formatNumber(this.risingMist.renewingMistDancingMistExtensionHealing)} from extended{' '}
-            <SpellLink id={talents.DANCING_MISTS_TALENT} />{' '}
-            <SpellLink id={talents.RENEWING_MIST_TALENT} />
+            <SpellLink id={talents.DANCING_MISTS_TALENT} /> procs
           </li>
           <li>
             {formatNumber(this.risingMist.renewingMistHardcastExtensionHealing)} from extended
-            hardcast <SpellLink id={talents.RENEWING_MIST_TALENT} />
+            hardcasts
           </li>
           <li>
             {formatNumber(this.risingMist.renewingMistRapidDiffusionExtensionHealing)} from extended{' '}
-            <SpellLink id={talents.RAPID_DIFFUSION_TALENT} />{' '}
-            <SpellLink id={talents.RENEWING_MIST_TALENT} />
+            <SpellLink id={talents.RAPID_DIFFUSION_TALENT} /> procs
           </li>
         </ul>
       </>
@@ -185,8 +183,7 @@ class RisingMistBreakdown extends Analyzer {
           </li>
           <li>
             {formatNumber(this.risingMist.extraVivhealingFromDancingMistRems)} from extended{' '}
-            <SpellLink id={talents.DANCING_MISTS_TALENT} />{' '}
-            <SpellLink id={talents.RENEWING_MIST_TALENT} />
+            <SpellLink id={talents.DANCING_MISTS_TALENT} /> procs
           </li>
           <li>
             {formatNumber(this.risingMist.extraVivHealingFromHardcastRems)} from extended hardcast{' '}
@@ -194,8 +191,7 @@ class RisingMistBreakdown extends Analyzer {
           </li>
           <li>
             {formatNumber(this.risingMist.extraVivHealingFromRapidDiffusionRems)} from extended{' '}
-            <SpellLink id={talents.RAPID_DIFFUSION_TALENT} />{' '}
-            <SpellLink id={talents.RENEWING_MIST_TALENT} />
+            <SpellLink id={talents.RAPID_DIFFUSION_TALENT} /> procs
           </li>
         </ul>
       </>
@@ -205,7 +201,8 @@ class RisingMistBreakdown extends Analyzer {
   essenceFontTooltip() {
     return (
       <>
-        Additional <SpellLink id={SPELLS.ESSENCE_FONT_BUFF} /> healing from extensions
+        {formatNumber(this.risingMist.essenceFontExtensionHealing)}{' '}
+        <SpellLink id={SPELLS.ESSENCE_FONT_BUFF} /> extension healing
       </>
     );
   }
@@ -219,13 +216,12 @@ class RisingMistBreakdown extends Analyzer {
           {this.selectedCombatant.hasTalent(talents.INVOKE_CHI_JI_THE_RED_CRANE_TALENT) && (
             <li>
               {formatNumber(this.risingMist.extraChijiGomHealing)}{' '}
-              <SpellLink id={SPELLS.GUST_OF_MISTS_CHIJI} /> healing from extended{' '}
-              <SpellLink id={talents.ESSENCE_FONT_TALENT} />
+              <SpellLink id={SPELLS.GUST_OF_MISTS_CHIJI} /> healing
             </li>
           )}
           <li>
             {formatNumber(this.risingMist.extraGomHealing)} <SpellLink id={SPELLS.GUSTS_OF_MISTS} />{' '}
-            healing from extended <SpellLink id={talents.ESSENCE_FONT_TALENT} />
+            healing
           </li>
         </ul>
       </>

--- a/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
@@ -9,7 +9,7 @@ import SPELLS from 'common/SPELLS';
 import { SPELL_COLORS } from '../../constants';
 import TalentAggregateStatisticContainer from 'parser/ui/TalentAggregateStatisticContainer';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
-import { formatNumber, formatPercentage } from 'common/format';
+import { formatNumber } from 'common/format';
 
 class RisingMistBreakdown extends Analyzer {
   static dependencies = {
@@ -110,13 +110,7 @@ class RisingMistBreakdown extends Analyzer {
   envelopingMistTooltip() {
     return (
       <>
-        <SpellLink id={talents.ENVELOPING_MIST_TALENT} /> extension healing (
-        {formatPercentage(
-          (this.risingMist.envHardcastExtensionHealing +
-            this.risingMist.envMistyPeaksExtensionHealing) /
-            this.risingMist.totalHealing,
-        )}
-        % of Total)
+        <SpellLink id={talents.ENVELOPING_MIST_TALENT} /> extension healing
         <ul>
           <li>
             {formatNumber(this.risingMist.envMistyPeaksExtensionHealing)} from extended{' '}
@@ -134,9 +128,7 @@ class RisingMistBreakdown extends Analyzer {
     return (
       <>
         Additional bonus healing from the extra <SpellLink id={talents.ENVELOPING_MIST_TALENT} />{' '}
-        buff uptime (
-        {formatPercentage(this.risingMist.extraEnvBonusHealing / this.risingMist.totalHealing)}% of
-        Total)
+        buff uptime
         <ul>
           <li>
             {formatNumber(this.risingMist.extraEnvBonusMistyPeaks)} from extended{' '}
@@ -151,11 +143,7 @@ class RisingMistBreakdown extends Analyzer {
   renewingMistTooltip() {
     return (
       <>
-        <SpellLink id={talents.RENEWING_MIST_TALENT} /> extension healing (
-        {formatPercentage(
-          this.risingMist.renewingMistExtensionHealing / this.risingMist.totalHealing,
-        )}
-        % of Total)
+        <SpellLink id={talents.RENEWING_MIST_TALENT} /> extension healing
         <ul>
           <li>
             {formatNumber(this.risingMist.renewingMistDancingMistExtensionHealing)} from extended{' '}
@@ -180,8 +168,7 @@ class RisingMistBreakdown extends Analyzer {
     return (
       <>
         <SpellLink id={talents.RISING_MIST_TALENT} /> direct healing from{' '}
-        <SpellLink id={talents.RISING_SUN_KICK_TALENT} /> casts (
-        {formatPercentage(this.risingMist.directHealing / this.risingMist.totalHealing)}% of Total)
+        <SpellLink id={talents.RISING_SUN_KICK_TALENT} /> casts
         <ul>
           <li>
             {formatNumber(this.risingMist.averageHealing)} average healing per{' '}
@@ -200,9 +187,7 @@ class RisingMistBreakdown extends Analyzer {
     return (
       <>
         <SpellLink id={SPELLS.VIVIFY} /> healing from extended{' '}
-        <SpellLink id={talents.RENEWING_MIST_TALENT} /> (
-        {formatPercentage(this.risingMist.extraVivHealing / this.risingMist.totalHealing)}% of
-        Total)
+        <SpellLink id={talents.RENEWING_MIST_TALENT} />
         <ul>
           <li>
             {this.risingMist.extraVivCleaves} extra cleave hits via{' '}
@@ -230,11 +215,7 @@ class RisingMistBreakdown extends Analyzer {
   essenceFontTooltip() {
     return (
       <>
-        Additional <SpellLink id={SPELLS.ESSENCE_FONT_BUFF} /> healing from extensions (
-        {formatPercentage(
-          this.risingMist.essenceFontExtensionHealing / this.risingMist.totalHealing,
-        )}
-        % of Total)
+        Additional <SpellLink id={SPELLS.ESSENCE_FONT_BUFF} /> healing from extensions
       </>
     );
   }
@@ -243,9 +224,7 @@ class RisingMistBreakdown extends Analyzer {
     return (
       <>
         Additional <SpellLink id={SPELLS.GUSTS_OF_MISTS} /> healing from extended{' '}
-        <SpellLink id={talents.ESSENCE_FONT_TALENT} /> (
-        {formatPercentage(this.risingMist.extraMasteryhealing / this.risingMist.totalHealing)}% of
-        Total)
+        <SpellLink id={talents.ESSENCE_FONT_TALENT} />
         <ul>
           {this.selectedCombatant.hasTalent(talents.INVOKE_CHI_JI_THE_RED_CRANE_TALENT) && (
             <li>

--- a/src/analysis/retail/monk/mistweaver/modules/spells/MistyPeaks.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/MistyPeaks.tsx
@@ -91,7 +91,7 @@ class MistyPeaks extends Analyzer {
     }
 
     const hot = this.hotTracker.hots[targetId][TALENTS_MONK.ENVELOPING_MIST_TALENT.id];
-    if (!this.hotTracker.fromMistyPeaks(hot) || event.timestamp >= hot.originalEnd) {
+    if (!this.hotTracker.fromMistyPeaks(hot)) {
       return;
     }
     this.extraEnvBonusHealing += calculateEffectiveHealing(event, this.envmHealingIncrease);

--- a/src/analysis/retail/monk/mistweaver/modules/spells/MistyPeaks.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/MistyPeaks.tsx
@@ -70,7 +70,8 @@ class MistyPeaks extends Analyzer {
       return;
     }
     const hot = this.hotTracker.hots[playerId][TALENTS_MONK.ENVELOPING_MIST_TALENT.id];
-    if (this.hotTracker.fromMistyPeaks(hot)) {
+    if (this.hotTracker.fromMistyPeaks(hot) && event.timestamp <= hot.originalEnd) {
+      //filter out hard casted envelops and healing from extension -> attributed in the rising mist module
       this.extraHits += 1;
       this.extraHealing += event.amount || 0;
       this.extraAbsorb += event.absorbed || 0;
@@ -90,7 +91,7 @@ class MistyPeaks extends Analyzer {
     }
 
     const hot = this.hotTracker.hots[targetId][TALENTS_MONK.ENVELOPING_MIST_TALENT.id];
-    if (!this.hotTracker.fromMistyPeaks(hot)) {
+    if (!this.hotTracker.fromMistyPeaks(hot) || event.timestamp >= hot.originalEnd) {
       return;
     }
     this.extraEnvBonusHealing += calculateEffectiveHealing(event, this.envmHealingIncrease);

--- a/src/analysis/retail/monk/mistweaver/modules/spells/MistyPeaks.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/MistyPeaks.tsx
@@ -70,7 +70,7 @@ class MistyPeaks extends Analyzer {
       return;
     }
     const hot = this.hotTracker.hots[playerId][TALENTS_MONK.ENVELOPING_MIST_TALENT.id];
-    if (this.hotTracker.fromMistyPeaks(hot) && event.timestamp <= hot.originalEnd) {
+    if (this.hotTracker.fromMistyPeaks(hot)) {
       //filter out hard casted envelops and healing from extension -> attributed in the rising mist module
       this.extraHits += 1;
       this.extraHealing += event.amount || 0;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RapidDiffusion.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RapidDiffusion.tsx
@@ -108,7 +108,7 @@ class RapidDiffusion extends Analyzer {
       return;
     }
     const hot = this.hotTracker.hots[playerId][SPELLS.RENEWING_MIST_HEAL.id];
-    if (this.hotTracker.fromRapidDiffusion(hot)) {
+    if (this.hotTracker.fromRapidDiffusion(hot) && event.timestamp <= hot.originalEnd) {
       this.remHealing += event.amount || 0;
       this.remAbsorbed += event.absorbed || 0;
       this.remOverHealing += event.overheal || 0;
@@ -129,7 +129,7 @@ class RapidDiffusion extends Analyzer {
       return;
     }
     const hot = this.hotTracker.hots[targetId][SPELLS.RENEWING_MIST_HEAL.id];
-    if (this.hotTracker.fromRapidDiffusion(hot)) {
+    if (this.hotTracker.fromRapidDiffusion(hot) && event.timestamp <= hot.originalEnd) {
       this.extraVivCleaves += 1;
       this.extraVivHealing += event.amount || 0;
       this.extraVivOverhealing += event.overheal || 0;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RapidDiffusion.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RapidDiffusion.tsx
@@ -129,7 +129,7 @@ class RapidDiffusion extends Analyzer {
       return;
     }
     const hot = this.hotTracker.hots[targetId][SPELLS.RENEWING_MIST_HEAL.id];
-    if (this.hotTracker.fromRapidDiffusion(hot) && event.timestamp <= hot.originalEnd) {
+    if (this.hotTracker.fromRapidDiffusion(hot)) {
       this.extraVivCleaves += 1;
       this.extraVivHealing += event.amount || 0;
       this.extraVivOverhealing += event.overheal || 0;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RapidDiffusion.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RapidDiffusion.tsx
@@ -108,7 +108,7 @@ class RapidDiffusion extends Analyzer {
       return;
     }
     const hot = this.hotTracker.hots[playerId][SPELLS.RENEWING_MIST_HEAL.id];
-    if (this.hotTracker.fromRapidDiffusion(hot) && event.timestamp <= hot.originalEnd) {
+    if (this.hotTracker.fromRapidDiffusion(hot)) {
       this.remHealing += event.amount || 0;
       this.remAbsorbed += event.absorbed || 0;
       this.remOverHealing += event.overheal || 0;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RisingMist.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RisingMist.tsx
@@ -9,11 +9,6 @@ import Events, { HealEvent, CastEvent } from 'parser/core/Events';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import HotTracker, { Attribution, Tracker } from 'parser/shared/modules/HotTracker';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
-import ItemHealingDone from 'parser/ui/ItemHealingDone';
-import Statistic from 'parser/ui/Statistic';
-import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
-import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
-import TalentSpellText from 'parser/ui/TalentSpellText';
 import { ATTRIBUTION_STRINGS, RISING_MIST_EXTENSION } from '../../constants';
 import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
 
@@ -380,38 +375,21 @@ class RisingMist extends Analyzer {
     );
   }
 
-  statistic() {
+  toolTip() {
     return (
-      <Statistic
-        position={STATISTIC_ORDER.DEFAULT}
-        size="flexible"
-        category={STATISTIC_CATEGORY.TALENTS}
-        tooltip={
-          <>
-            Your {this.risingMistCount} Rising Sun Kick casts contributed the following healing:
-            <ul>
-              <li>HoT Extension Healing: {formatNumber(this.hotHealing)}</li>
-              <li>
-                Rising Mist Direct Healing: {formatNumber(this.directHealing)} (
-                {formatNumber(this.averageHealing)} per cast)
-              </li>
-              <li>Average HoT Extension Seconds per cast: {this.averageExtension.toFixed(2)}</li>
-              <ul>
-                <li>Essence Font HoTs Extended: {this.efCount}</li>
-                {this.selectedCombatant.hasTalent(TALENTS_MONK.FAELINE_STOMP_TALENT) && (
-                  <li>FLS Essence Font HoTs extended: {this.flsEfCount}</li>
-                )}
-                <li>Renewing Mist HoTs Extended: {this.remCount}</li>
-                <li>Enveloping Mist HoTs Extended: {this.evmCount}</li>
-              </ul>
-            </ul>
-          </>
-        }
-      >
-        <TalentSpellText talent={TALENTS_MONK.RISING_MIST_TALENT}>
-          <ItemHealingDone amount={this.totalHealing} />
-        </TalentSpellText>
-      </Statistic>
+      <>
+        Your {this.risingMistCount} Rising Sun Kick casts contributed the following:
+        <ul>
+          <li>HoT Extension Healing: {formatNumber(this.hotHealing)}</li>
+          <li>Average HoT Extension Seconds per cast: {this.averageExtension.toFixed(2)}</li>
+          <li>Essence Font HoTs Extended: {this.efCount}</li>
+          {this.selectedCombatant.hasTalent(TALENTS_MONK.FAELINE_STOMP_TALENT) && (
+            <li>FLS Essence Font HoTs extended: {this.flsEfCount}</li>
+          )}
+          <li>Renewing Mist HoTs Extended: {this.remCount}</li>
+          <li>Enveloping Mist HoTs Extended: {this.evmCount}</li>
+        </ul>
+      </>
     );
   }
 }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RisingMist.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RisingMist.tsx
@@ -315,7 +315,7 @@ class RisingMist extends Analyzer {
 
     Object.keys(this.hotTracker.hots).forEach((player) => {
       const playerId = Number(player);
-      Object.keys(this.hotTracker.hots[Number(playerId)]).forEach((spellIdString) => {
+      Object.keys(this.hotTracker.hots[playerId]).forEach((spellIdString) => {
         const spellId = Number(spellIdString);
         const attribution = newRisingMist;
         if (spellId === SPELLS.ENVELOPING_BREATH_HEAL.id) {

--- a/src/parser/ui/TalentAggregateBar.scss
+++ b/src/parser/ui/TalentAggregateBar.scss
@@ -1,0 +1,13 @@
+@import 'interface/Theme.scss';
+
+.source-bar {
+  position: relative;
+  width: auto;
+  height: 100%;
+
+  > div {
+    display: inline-block;
+    position: relative;
+    height: 100%;
+  }
+}

--- a/src/parser/ui/TalentAggregateBar.scss
+++ b/src/parser/ui/TalentAggregateBar.scss
@@ -7,7 +7,7 @@
     width: auto;
     height: 100%;
 
-    small {
+    span {
       float: right;
       padding: 7.5px;
       font-weight: 1200;

--- a/src/parser/ui/TalentAggregateBar.scss
+++ b/src/parser/ui/TalentAggregateBar.scss
@@ -1,7 +1,5 @@
 @import 'interface/Theme.scss';
 .chart {
-  border-radius: 5px;
-
   .source-bar {
     position: relative;
     width: auto;

--- a/src/parser/ui/TalentAggregateBar.scss
+++ b/src/parser/ui/TalentAggregateBar.scss
@@ -1,13 +1,25 @@
 @import 'interface/Theme.scss';
+.chart {
+  border-radius: 5px;
 
-.source-bar {
-  position: relative;
-  width: auto;
-  height: 100%;
-
-  > div {
-    display: inline-block;
+  .source-bar {
     position: relative;
+    width: auto;
     height: 100%;
+
+    small {
+      float: right;
+      padding: 7.5px;
+      font-weight: 1200;
+      font-size: 13px;
+      text-shadow: 1px 1px 2px black;
+      color: white;
+    }
+
+    > div {
+      display: inline-block;
+      position: relative;
+      height: 100%;
+    }
   }
 }

--- a/src/parser/ui/TalentAggregateBar.tsx
+++ b/src/parser/ui/TalentAggregateBar.tsx
@@ -1,0 +1,66 @@
+import { formatPercentage } from 'common/format';
+import { Tooltip } from 'interface';
+import * as React from 'react';
+import { ReactNode } from 'react';
+import './TalentAggregateBar.scss';
+import { TalentAggregateBarSpec } from './TalentAggregateStatistic';
+
+type Props = {
+  amount: number;
+  percentTotal: number;
+  barColor?: string;
+  barTooltip?: ReactNode | string;
+  scaleFactor?: number;
+  subSpecs?: TalentAggregateBarSpec[];
+  subSpecPercents?: number[];
+};
+
+const TalentAggregateBar = ({
+  amount,
+  percentTotal,
+  barColor,
+  barTooltip,
+  scaleFactor,
+  subSpecs,
+  subSpecPercents,
+  ...others
+}: Props) => {
+  return (
+    <div className="source-bar" {...others}>
+      <Tooltip content={barTooltip ? barTooltip : formatPercentage(percentTotal) + '%'}>
+        <div style={getSegment(percentTotal, barColor, scaleFactor)}></div>
+      </Tooltip>
+      {subSpecs &&
+        subSpecPercents &&
+        subSpecs.map((subSpec, idx) => (
+          <Tooltip
+            key={subSpec.spell.name}
+            content={
+              subSpec.tooltip ? subSpec.tooltip : formatPercentage(subSpecPercents[idx]) + '%'
+            }
+          >
+            <div style={getSegment(subSpecPercents[idx], subSpec.color, scaleFactor)}></div>
+          </Tooltip>
+        ))}
+    </div>
+  );
+};
+
+function getSegment(
+  percentTotal: number,
+  barColor: string | undefined,
+  scaleFactor?: number,
+): React.CSSProperties {
+  return barColor !== undefined
+    ? {
+        left: `0%`,
+        width: `${percentTotal * 100 * (scaleFactor ? scaleFactor : 1)}%`,
+        background: `${barColor}`,
+      }
+    : {
+        left: `0%`,
+        width: `${percentTotal * 100 * (scaleFactor ? scaleFactor : 1)}%`,
+      };
+}
+
+export default TalentAggregateBar;

--- a/src/parser/ui/TalentAggregateBar.tsx
+++ b/src/parser/ui/TalentAggregateBar.tsx
@@ -29,9 +29,11 @@ const TalentAggregateBar = ({
     <div className="source-bar" {...others}>
       <Tooltip content={barTooltip ? barTooltip : percentTotal + '%'}>
         <div style={getSegment(percentTotal, barColor, scaleFactor)}>
-          <span>
-            <strong>{formatPercentage(percentTotal, 1)}%</strong>
-          </span>
+          {showLabel(percentTotal, scaleFactor) && (
+            <span>
+              <strong>{formatPercentage(percentTotal, 1)}%</strong>
+            </span>
+          )}
         </div>
       </Tooltip>
       {subSpecs &&
@@ -39,14 +41,14 @@ const TalentAggregateBar = ({
         subSpecs.map((subSpec, idx) => (
           <Tooltip
             key={subSpec.spell.name}
-            content={
-              subSpec.tooltip ? subSpec.tooltip : formatPercentage(subSpecPercents[idx]) + '%'
-            }
+            content={subSpec.tooltip || formatPercentage(subSpecPercents[idx]) + '%'}
           >
             <div style={getSegment(subSpecPercents[idx], subSpec.color, scaleFactor)}>
-              <span>
-                <strong>{formatPercentage(subSpecPercents[idx], 1)}%</strong>
-              </span>
+              {showLabel(subSpecPercents[idx], scaleFactor) && (
+                <span>
+                  <strong>{formatPercentage(subSpecPercents[idx], 1)}%</strong>
+                </span>
+              )}
             </div>
           </Tooltip>
         ))}
@@ -54,6 +56,24 @@ const TalentAggregateBar = ({
   );
 };
 
+/**
+ * Determines if the TalentAggregateBar being generated is large enough relative to the
+ * scaleFactor provided to fit the Percent Label. Used to control the viewstate of the bar label
+ * @param percentTotal percent width of the TalentAggregateBar being rendered
+ * @param scaleFactor the provided scale factor the component uses to size the chart
+ * @returns true or false
+ */
+function showLabel(percentTotal: number, scaleFactor?: number): boolean {
+  return 1 / percentTotal / 10 < (scaleFactor || 1);
+}
+
+/**
+ * Function to get the CSS properties for the TalentAggregateBar being rendered based on provided parameters
+ * @param percentTotal percent of the current TalentAggregateBarSpec amount relative to the Total amount. Used to determine the width of the TalentAggregateBar being rendered.
+ * @param barColor optional parameter to set the color of the TalentAggregateBar
+ * @param scaleFactor the provided scale factor the component uses to size the chart
+ * @returns the CSS properties for the TalentAggregateBar being rendered
+ */
 function getSegment(
   percentTotal: number,
   barColor: string | undefined,

--- a/src/parser/ui/TalentAggregateBar.tsx
+++ b/src/parser/ui/TalentAggregateBar.tsx
@@ -28,7 +28,11 @@ const TalentAggregateBar = ({
   return (
     <div className="source-bar" {...others}>
       <Tooltip content={barTooltip ? barTooltip : percentTotal + '%'}>
-        <div style={getSegment(percentTotal, barColor, scaleFactor)}><small><strong>{formatPercentage(percentTotal)}%</strong></small></div>
+        <div style={getSegment(percentTotal, barColor, scaleFactor)}>
+          <span>
+            <strong>{formatPercentage(percentTotal, 1)}%</strong>
+          </span>
+        </div>
       </Tooltip>
       {subSpecs &&
         subSpecPercents &&
@@ -39,7 +43,11 @@ const TalentAggregateBar = ({
               subSpec.tooltip ? subSpec.tooltip : formatPercentage(subSpecPercents[idx]) + '%'
             }
           >
-            <div style={getSegment(subSpecPercents[idx], subSpec.color, scaleFactor)}><small><strong>{formatPercentage(subSpecPercents[idx])}%</strong></small></div>
+            <div style={getSegment(subSpecPercents[idx], subSpec.color, scaleFactor)}>
+              <span>
+                <strong>{formatPercentage(subSpecPercents[idx], 1)}%</strong>
+              </span>
+            </div>
           </Tooltip>
         ))}
     </div>
@@ -55,12 +63,12 @@ function getSegment(
     ? {
         //borderRadius: `2px`,
         left: `0%`,
-        width: `${percentTotal * 100 * (scaleFactor ? scaleFactor : 1)}%`,
+        width: `${percentTotal * 100 * (scaleFactor || 1)}%`,
         background: `${barColor}`,
       }
     : {
         left: `0%`,
-        width: `${percentTotal * 100 * (scaleFactor ? scaleFactor : 1)}%`,
+        width: `${percentTotal * 100 * (scaleFactor || 1)}%`,
       };
 }
 

--- a/src/parser/ui/TalentAggregateBar.tsx
+++ b/src/parser/ui/TalentAggregateBar.tsx
@@ -28,7 +28,7 @@ const TalentAggregateBar = ({
   return (
     <div className="source-bar" {...others}>
       <Tooltip content={barTooltip ? barTooltip : percentTotal + '%'}>
-        <div style={getSegment(percentTotal, barColor, scaleFactor)}></div>
+        <div style={getSegment(percentTotal, barColor, scaleFactor)}><small><strong>{formatPercentage(percentTotal)}%</strong></small></div>
       </Tooltip>
       {subSpecs &&
         subSpecPercents &&
@@ -39,7 +39,7 @@ const TalentAggregateBar = ({
               subSpec.tooltip ? subSpec.tooltip : formatPercentage(subSpecPercents[idx]) + '%'
             }
           >
-            <div style={getSegment(subSpecPercents[idx], subSpec.color, scaleFactor)}></div>
+            <div style={getSegment(subSpecPercents[idx], subSpec.color, scaleFactor)}><small><strong>{formatPercentage(subSpecPercents[idx])}%</strong></small></div>
           </Tooltip>
         ))}
     </div>
@@ -53,6 +53,7 @@ function getSegment(
 ): React.CSSProperties {
   return barColor !== undefined
     ? {
+        //borderRadius: `2px`,
         left: `0%`,
         width: `${percentTotal * 100 * (scaleFactor ? scaleFactor : 1)}%`,
         background: `${barColor}`,

--- a/src/parser/ui/TalentAggregateBar.tsx
+++ b/src/parser/ui/TalentAggregateBar.tsx
@@ -27,7 +27,7 @@ const TalentAggregateBar = ({
 }: Props) => {
   return (
     <div className="source-bar" {...others}>
-      <Tooltip content={barTooltip ? barTooltip : formatPercentage(percentTotal) + '%'}>
+      <Tooltip content={barTooltip ? barTooltip : percentTotal + '%'}>
         <div style={getSegment(percentTotal, barColor, scaleFactor)}></div>
       </Tooltip>
       {subSpecs &&

--- a/src/parser/ui/TalentAggregateStatistic.scss
+++ b/src/parser/ui/TalentAggregateStatistic.scss
@@ -1,4 +1,22 @@
-.multi-source-contribution-bar {
+.talent-aggregate-container {
+  h3 {
+    font-family: 'Open Sans', 'Century Gothic', sans-serif;
+    margin-top: 5px;
+    margin-bottom: 9px;
+    padding-bottom: 5px;
+    border-bottom: 1px solid #333;
+
+    .value {
+      font-size: 24px;
+
+      small {
+        font-size: 13px;
+      }
+    }
+  }
+}
+
+.talent-aggregate-bar {
   padding-left: 0px;
   line-height: 1;
 
@@ -21,8 +39,8 @@
   }
 
   .bar-label {
-    padding-right: 5px;
-    width: 40%;
+    padding: 7.5px 0;
+    width: 35%;
     text-align: left;
     vertical-align: middle;
     font-size: 15px;

--- a/src/parser/ui/TalentAggregateStatistic.scss
+++ b/src/parser/ui/TalentAggregateStatistic.scss
@@ -1,0 +1,30 @@
+.multi-source-contribution-bar {
+  padding-left: 0px;
+  line-height: 1;
+
+  .main-bar {
+    padding: 5px;
+    height: 40px;
+    font-size: 20px;
+  }
+
+  .main-bar-big {
+    padding: 10px;
+    height: 65px;
+    font-size: 20px; /* bigger? */
+  }
+
+  .sub-bar {
+    padding: 5px 10px;
+    height: 25px;
+    font-size: 15px;
+  }
+
+  .bar-label {
+    padding-right: 5px;
+    width: 40%;
+    text-align: left;
+    vertical-align: middle;
+    font-size: 15px;
+  }
+}

--- a/src/parser/ui/TalentAggregateStatistic.tsx
+++ b/src/parser/ui/TalentAggregateStatistic.tsx
@@ -36,15 +36,7 @@ export default function talentAggregateBars(
         <div key={spec.spell.name} className="flex-main talent-aggregate-bar">
           <div className="flex main-bar">
             <div className="flex-sub bar-label">
-              {getSpellLink(spec)}{' '}
-              <small>
-                {formatNumber(
-                  spec.amount +
-                    (spec.subSpecs
-                      ? spec.subSpecs?.reduce((sum, subSpec) => sum + (subSpec?.amount || 0), 0)
-                      : 0),
-                )}{' '}
-              </small>
+              {getSpellLink(spec)} <small>{formatNumber(getSpecSubtotal(spec))} </small>
             </div>
             <div className="flex-main chart">
               <TalentAggregateBar
@@ -66,16 +58,15 @@ export default function talentAggregateBars(
   );
 }
 
-function getPercentContribution(currentAmount: number, bars: TalentAggregateBarSpec[]) {
-  const total = bars.reduce(
-    (sum, item) =>
-      sum +
-      item.amount +
-      (item.subSpecs
-        ? item.subSpecs?.reduce((sum, subSpec) => sum + (subSpec?.amount || 0), 0)
-        : 0),
-    0,
+export function getSpecSubtotal(spec: TalentAggregateBarSpec) {
+  return (
+    spec.amount +
+    (spec.subSpecs ? spec.subSpecs?.reduce((sum, subSpec) => sum + (subSpec?.amount || 0), 0) : 0)
   );
+}
+
+function getPercentContribution(currentAmount: number, bars: TalentAggregateBarSpec[]) {
+  const total = bars.reduce((sum, item) => sum + getSpecSubtotal(item), 0);
   return currentAmount / total;
 }
 

--- a/src/parser/ui/TalentAggregateStatistic.tsx
+++ b/src/parser/ui/TalentAggregateStatistic.tsx
@@ -20,12 +20,10 @@ export type TalentAggregateBarSpec = {
 
 /**
  * A JSX element that creates and graphs a collection of data points based on the given input data
- * @param bars the object data to be turned into an item on the chart
+ * @param bars an array of type TalentAggregateBarSpec
  * @param scaleFactor optional param used to control the scale of the graph within the statistic box.
  * Can be set manually or calculated using the ratios of specs to total
- *
  */
-
 export default function talentAggregateBars(
   bars: TalentAggregateBarSpec[],
   scaleFactor?: number,
@@ -58,6 +56,12 @@ export default function talentAggregateBars(
   );
 }
 
+/**
+ * Function to get the sum of all amounts for parent and children TalentAggregateBarSpec
+ * (Sum of TalentAggregateBarSpec.amount and all TalentAggregateBarSpec.subSpec[].amount)
+ * @param spec the TalentAggregateBarSpec being iterated on
+ * @returns the sum of all amount parameters for parent and children TalentAggregateBarSpec
+ */
 export function getSpecSubtotal(spec: TalentAggregateBarSpec) {
   return (
     spec.amount +
@@ -65,11 +69,22 @@ export function getSpecSubtotal(spec: TalentAggregateBarSpec) {
   );
 }
 
-function getPercentContribution(currentAmount: number, bars: TalentAggregateBarSpec[]) {
+/**
+ * Function to get the percentage contribution for an individual TalentAggregateBarSpec amount
+ * relative to the total summed amount of all provided TalentAggregateBarSpecs
+ * @param amount the amount property on a given TalentAggregateBarSpec
+ * @param bars the input TalentAggregateBarSpec array
+ * @returns   percentage contribution for an individual TalentAggregateBarSpec amount
+ */
+function getPercentContribution(amount: number, bars: TalentAggregateBarSpec[]) {
   const total = bars.reduce((sum, item) => sum + getSpecSubtotal(item), 0);
-  return currentAmount / total;
+  return amount / total;
 }
 
+/**
+ * @param spec TalentAggregateBarSpec
+ * @returns the SpellLink component for the given spec's spell
+ */
 function getSpellLink(spec: TalentAggregateBarSpec) {
   return (
     <>

--- a/src/parser/ui/TalentAggregateStatistic.tsx
+++ b/src/parser/ui/TalentAggregateStatistic.tsx
@@ -1,4 +1,4 @@
-import { formatNumber, formatPercentage } from 'common/format';
+import { formatNumber } from 'common/format';
 import Spell from 'common/SPELLS/Spell';
 import { SpellLink } from 'interface';
 import { ReactNode } from 'react';
@@ -33,7 +33,7 @@ export default function talentAggregateBars(
   return (
     <>
       {bars.map((spec) => (
-        <div key={spec.spell.name} className="flex-main multi-source-contribution-bar">
+        <div key={spec.spell.name} className="flex-main talent-aggregate-bar">
           <div className="flex main-bar">
             <div className="flex-sub bar-label">
               {getSpellLink(spec)}{' '}
@@ -44,17 +44,6 @@ export default function talentAggregateBars(
                       ? spec.subSpecs?.reduce((sum, subSpec) => sum + (subSpec?.amount || 0), 0)
                       : 0),
                 )}{' '}
-                -{' '}
-                {formatPercentage(
-                  getPercentContribution(
-                    spec.amount +
-                      (spec.subSpecs
-                        ? spec.subSpecs?.reduce((sum, subSpec) => sum + (subSpec?.amount || 0), 0)
-                        : 0),
-                    bars,
-                  ),
-                )}
-                %
               </small>
             </div>
             <div className="flex-main chart">

--- a/src/parser/ui/TalentAggregateStatistic.tsx
+++ b/src/parser/ui/TalentAggregateStatistic.tsx
@@ -1,0 +1,87 @@
+import { formatNumber } from 'common/format';
+import Spell from 'common/SPELLS/Spell';
+import { SpellLink } from 'interface';
+import { ReactNode } from 'react';
+import TalentAggregateBar from './TalentAggregateBar';
+import './TalentAggregateStatistic.scss';
+
+export type TalentAggregateBarSpec = {
+  /** spell */
+  spell: Spell;
+  /** amount contributed by spell**/
+  amount: number;
+  /** Color to render the bar */
+  color?: string;
+  /* Content that will be displayed when mousing over the graph bar*/
+  tooltip?: ReactNode | string;
+  /* Secondary contribution from the same source - rendered to the same bar*/
+  subSpecs?: TalentAggregateBarSpec[];
+};
+
+/**
+ * A JSX element that creates and graphs a collection of data points based on the given input data
+ * @param bars the object data to be turned into an item on the chart
+ * @param scaleFactor optional param used to control the scale of the graph within the statistic box
+ *
+ */
+
+export default function sourceContributionBars(
+  bars: TalentAggregateBarSpec[],
+  scaleFactor?: number,
+): React.ReactNode {
+  return (
+    <>
+      {bars.map((spec) => (
+        <div key={spec.spell.name} className="flex-main multi-source-contribution-bar">
+          <div className="flex main-bar">
+            <div className="flex-sub bar-label">
+              {getSpellLink(spec)}{' '}
+              <small>
+                {formatNumber(
+                  spec.amount +
+                    (spec.subSpecs
+                      ? spec.subSpecs?.reduce((sum, subSpec) => sum + (subSpec?.amount || 0), 0)
+                      : 0),
+                )}
+              </small>
+            </div>
+            <div className="flex-main chart">
+              <TalentAggregateBar
+                amount={spec.amount}
+                percentTotal={getPercentContribution(spec.amount, bars)}
+                barColor={spec.color}
+                barTooltip={spec.tooltip}
+                scaleFactor={scaleFactor}
+                subSpecs={spec.subSpecs}
+                subSpecPercents={spec.subSpecs?.map((subSpec) => {
+                  return getPercentContribution(subSpec.amount || 0, bars);
+                })}
+              />
+            </div>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}
+
+function getPercentContribution(currentAmount: number, bars: TalentAggregateBarSpec[]) {
+  const total = bars.reduce(
+    (sum, item) =>
+      sum +
+      item.amount +
+      (item.subSpecs
+        ? item.subSpecs?.reduce((sum, subSpec) => sum + (subSpec?.amount || 0), 0)
+        : 0),
+    0,
+  );
+  return currentAmount / total;
+}
+
+function getSpellLink(spec: TalentAggregateBarSpec) {
+  return (
+    <>
+      <SpellLink id={spec.spell.id} />{' '}
+    </>
+  );
+}

--- a/src/parser/ui/TalentAggregateStatistic.tsx
+++ b/src/parser/ui/TalentAggregateStatistic.tsx
@@ -25,7 +25,7 @@ export type TalentAggregateBarSpec = {
  *
  */
 
-export default function sourceContributionBars(
+export default function talentAggregateBars(
   bars: TalentAggregateBarSpec[],
   scaleFactor?: number,
 ): React.ReactNode {

--- a/src/parser/ui/TalentAggregateStatistic.tsx
+++ b/src/parser/ui/TalentAggregateStatistic.tsx
@@ -1,4 +1,4 @@
-import { formatNumber } from 'common/format';
+import { formatNumber, formatPercentage } from 'common/format';
 import Spell from 'common/SPELLS/Spell';
 import { SpellLink } from 'interface';
 import { ReactNode } from 'react';
@@ -21,7 +21,8 @@ export type TalentAggregateBarSpec = {
 /**
  * A JSX element that creates and graphs a collection of data points based on the given input data
  * @param bars the object data to be turned into an item on the chart
- * @param scaleFactor optional param used to control the scale of the graph within the statistic box
+ * @param scaleFactor optional param used to control the scale of the graph within the statistic box.
+ * Can be set manually or calculated using the ratios of specs to total
  *
  */
 
@@ -42,7 +43,18 @@ export default function talentAggregateBars(
                     (spec.subSpecs
                       ? spec.subSpecs?.reduce((sum, subSpec) => sum + (subSpec?.amount || 0), 0)
                       : 0),
+                )}{' '}
+                -{' '}
+                {formatPercentage(
+                  getPercentContribution(
+                    spec.amount +
+                      (spec.subSpecs
+                        ? spec.subSpecs?.reduce((sum, subSpec) => sum + (subSpec?.amount || 0), 0)
+                        : 0),
+                    bars,
+                  ),
                 )}
+                %
               </small>
             </div>
             <div className="flex-main chart">

--- a/src/parser/ui/TalentAggregateStatisticContainer.tsx
+++ b/src/parser/ui/TalentAggregateStatisticContainer.tsx
@@ -1,0 +1,38 @@
+import { ReactNode } from 'react';
+import Statistic from './Statistic';
+import STATISTIC_CATEGORY from './STATISTIC_CATEGORY';
+
+type Props = {
+  children: ReactNode;
+  title: ReactNode;
+  smallTitle?: boolean;
+  footer?: ReactNode;
+  smallFooter?: boolean;
+  category?: STATISTIC_CATEGORY;
+  position?: number;
+  tooltip?: ReactNode | string;
+};
+
+/**Statistic container for the collection of SourceContributionBarSubStatistics */
+const TalentAggregateStatisticContainer = ({
+  children,
+  title,
+  smallTitle,
+  footer,
+  smallFooter,
+  ...others
+}: Props) => (
+  <Statistic wide size="flexible" {...others}>
+    <div className="pad">
+      <div className="boring-value">{smallTitle ? <strong>{title}</strong> : <h3>{title}</h3>}</div>
+      {children}
+      {footer && (
+        <div className="boring-value">
+          {smallFooter ? <small>{footer}</small> : <h3>{footer}</h3>}
+        </div>
+      )}
+    </div>
+  </Statistic>
+);
+
+export default TalentAggregateStatisticContainer;

--- a/src/parser/ui/TalentAggregateStatisticContainer.tsx
+++ b/src/parser/ui/TalentAggregateStatisticContainer.tsx
@@ -37,7 +37,15 @@ const TalentAggregateStatisticContainer = ({
       {children}
       {footer && (
         <div className="boring-value">
-          {smallFooter ? <small>{footer}</small> : <h3>{footer}</h3>}
+          {smallFooter ? (
+            <small>
+              *{footer}.<br /> *Labels are hidden for trivial amounts
+            </small>
+          ) : (
+            <h3>
+              {footer}.<br /> Labels are hidden for trivial amounts
+            </h3>
+          )}
         </div>
       )}
     </div>

--- a/src/parser/ui/TalentAggregateStatisticContainer.tsx
+++ b/src/parser/ui/TalentAggregateStatisticContainer.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import Statistic from './Statistic';
 import STATISTIC_CATEGORY from './STATISTIC_CATEGORY';
+import './TalentAggregateStatistic.scss';
 
 type Props = {
   children: ReactNode;
@@ -24,7 +25,7 @@ const TalentAggregateStatisticContainer = ({
 }: Props) => (
   <Statistic wide size="flexible" {...others}>
     <div className="pad">
-      <div className="boring-value">
+      <div className="talent-aggregate-container">
         {smallTitle ? (
           <strong>{title}</strong>
         ) : (

--- a/src/parser/ui/TalentAggregateStatisticContainer.tsx
+++ b/src/parser/ui/TalentAggregateStatisticContainer.tsx
@@ -24,7 +24,15 @@ const TalentAggregateStatisticContainer = ({
 }: Props) => (
   <Statistic wide size="flexible" {...others}>
     <div className="pad">
-      <div className="boring-value">{smallTitle ? <strong>{title}</strong> : <h3>{title}</h3>}</div>
+      <div className="boring-value">
+        {smallTitle ? (
+          <strong>{title}</strong>
+        ) : (
+          <h3>
+            <div className="value">{title}</div>
+          </h3>
+        )}
+      </div>
       {children}
       {footer && (
         <div className="boring-value">


### PR DESCRIPTION
### Description
Fixed a few bugs in the Mistweaver Hot Tracker and Hot Attributor that was causing the Rising Mist analysis to be innaccurate
Refactored RisingMist to typescript
Added a new component TalentAggregateStatistic 
Added a new RisingMistBreakdown module to show a more detailed breakdown of all the various sources of contribution to the talents' value
Fixes to the affected modules caused by the Hot Tracker/Attributor bug fixes

### Motivation

Rising Mist is one of the most important and impactful talents in the mistweaver tree, it has been around since BFA but the Dragonflight talent tree has created so many synergies that a tooltip in a standard statistic don't capture very well
I created the TalentAggregateStatistic as a way to show a much more detailed breakdown for the talent, which has multiple spell sources contributing to its HPS and even different types of contributions from the same sources. Its my hope that the component can be used by other specs that may have a similar need.

- Test report URL: `/report/PM3bBGDxHa7J4qXk/11-Mythic+Kurog+Grimtotem+-+Kill+(8:41)/Vohrr/standard/statistics
- Screenshot(s):
![image](https://user-images.githubusercontent.com/26779541/221339788-17ef897e-5b33-4dba-a001-fa134b277b94.png)
![image](https://user-images.githubusercontent.com/26779541/221339782-905465f4-2216-4e31-b1fa-2b1aac74cad7.png)
![image](https://user-images.githubusercontent.com/26779541/221339811-1c94a15e-be88-4ed4-b773-320cac92415d.png)
![image](https://user-images.githubusercontent.com/26779541/221339823-6f3def09-62ba-452d-ad7a-dc4cbf2fc9a0.png)
![image](https://user-images.githubusercontent.com/26779541/221339837-59200684-8cbd-46b0-b481-159a3d6a3517.png)
![image](https://user-images.githubusercontent.com/26779541/221339843-f15abc1c-f6f5-4b4d-aee3-bd22b01bb329.png)

