### PR TITLE
fix Spirit Bomb Soul Fragment credits

### DIFF
--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import SHARED_CHANGELOG from 'analysis/retail/demonhunter/shared/CHANGELOG';
 
 // prettier-ignore
 export default [
+  change(date(2023, 2, 25), <>Fixed  consuming the last stack of <SpellLink id={SPELLS.SOUL_FRAGMENT_STACK.id} /> not granting credit on casting <SpellLink id={TALENTS.SPIRIT_BOMB_TALENT} />.</>, ToppleTheNun),
   change(date(2023, 1, 30), <>Fixed an issue where the graph for <SpellLink id={SPELLS.SOUL_FRAGMENT_STACK.id} /> would show incorrect values for a given point in time.</>, Putro),
   change(date(2023, 1, 11), 'Log cast summary and breakdown events when clicked.', ToppleTheNun),
   change(date(2023, 1, 3), <>Fix Soul Fragment detection for <SpellLink id={TALENTS.SPIRIT_BOMB_TALENT} />.</>, ToppleTheNun),

--- a/src/analysis/retail/demonhunter/vengeance/Guide.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/Guide.tsx
@@ -1,7 +1,7 @@
 import { GuideProps, Section, SubSection, useInfo } from 'interface/guide';
 import { TALENTS_DEMON_HUNTER } from 'common/TALENTS/demonhunter';
 import SPELLS from 'common/SPELLS/demonhunter';
-import { AlertWarning, ResourceLink, SpellLink } from 'interface';
+import { ResourceLink, SpellLink } from 'interface';
 import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
 import ImmolationAuraVengeanceGuideSection from 'analysis/retail/demonhunter/shared/modules/spells/ImmolationAura/VengeanceGuideSection';
 import { t, Trans } from '@lingui/macro';
@@ -150,12 +150,6 @@ function RotationSection({ modules, info }: GuideProps<typeof CombatLogParser>) 
         message: 'Rotation',
       })}
     >
-      <AlertWarning>
-        This section is under heavy development as work on the Vengeance rotation continues during
-        the Dragonflight launch. It is currently a reasonable starting point, but may not match the
-        optimal rotation yet.
-      </AlertWarning>
-      <br />
       <p>
         <Trans id="guide.demonhunter.vengeance.sections.rotation.summary">
           Vengeance's core rotation involves <strong>building</strong> and then{' '}

--- a/src/analysis/retail/demonhunter/vengeance/normalizers/SpiritBombEventLinkNormalizer.ts
+++ b/src/analysis/retail/demonhunter/vengeance/normalizers/SpiritBombEventLinkNormalizer.ts
@@ -4,6 +4,7 @@ import {
   DamageEvent,
   EventType,
   GetRelatedEvents,
+  RemoveBuffEvent,
   RemoveBuffStackEvent,
 } from 'parser/core/Events';
 import { Options } from 'parser/core/Module';
@@ -30,6 +31,18 @@ const EVENT_LINKS: EventLink[] = [
     reverseLinkRelation: SPIRIT_BOMB_SOUL_CONSUME,
   },
   {
+    linkRelation: SPIRIT_BOMB_SOUL_CONSUME,
+    referencedEventId: SPELLS.SOUL_FRAGMENT_STACK.id,
+    referencedEventType: EventType.RemoveBuff,
+    linkingEventId: TALENTS_DEMON_HUNTER.SPIRIT_BOMB_TALENT.id,
+    linkingEventType: EventType.Cast,
+    forwardBufferMs: SOUL_CONSUME_BUFFER,
+    backwardBufferMs: SOUL_CONSUME_BUFFER,
+    anyTarget: true,
+    maximumLinks: 1,
+    reverseLinkRelation: SPIRIT_BOMB_SOUL_CONSUME,
+  },
+  {
     linkRelation: SPIRIT_BOMB_DAMAGE,
     referencedEventId: SPELLS.SPIRIT_BOMB_DAMAGE.id,
     referencedEventType: EventType.Damage,
@@ -47,9 +60,12 @@ export default class SpiritBombEventLinkNormalizer extends EventLinkNormalizer {
   }
 }
 
-export function getSpiritBombSoulConsumptions(event: CastEvent): RemoveBuffStackEvent[] {
+export function getSpiritBombSoulConsumptions(
+  event: CastEvent,
+): (RemoveBuffStackEvent | RemoveBuffEvent)[] {
   return GetRelatedEvents(event, SPIRIT_BOMB_SOUL_CONSUME).filter(
-    (e): e is RemoveBuffStackEvent => e.type === EventType.RemoveBuffStack,
+    (e): e is RemoveBuffStackEvent | RemoveBuffEvent =>
+      e.type === EventType.RemoveBuffStack || e.type === EventType.RemoveBuff,
   );
 }
 


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Make consuming the last Soul Fragment with Spirit Bomb count as a consumed Soul Fragment.

### Motivation

<!-- Why are you submitting this pull request?-->

Consuming the last Soul Fragment results in a `RemoveBuff` event, not a `RemoveBuffStack` event. This was causing the amount of souls consumed to be under reported.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/Rnqk8tZQBadFyAXv/52-Mythic++Ruby+Life+Pools+-+Kill+(29:50)/Linadh/standard/overview`
- Screenshot(s):
**Before**
![image](https://user-images.githubusercontent.com/1672786/221368179-0b12d7a1-aa88-48a8-86d0-9d5b4d70230d.png)
**After**
![image](https://user-images.githubusercontent.com/1672786/221368211-c35ec13b-230a-46d1-914f-3134db71d561.png)
