### PR TITLE
Fix Cast Efficiency key generation

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -21,6 +21,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 2, 25), 'Fix development issue with CastEfficiency dumping large errors in the console.', emallson),
   change(date(2023, 2, 25), 'Fix spell ID for classic Bloodthirst.', ToppleTheNun),
   change(date(2023, 2, 21), 'Add Classic Warrior spells', Pilsung),
   change(date(2023, 2, 20), 'Fixed missing food buffs for WotLK Classic.', Arbixal),

--- a/src/parser/ui/CastEfficiency.tsx
+++ b/src/parser/ui/CastEfficiency.tsx
@@ -63,7 +63,7 @@ const CastEfficiency = ({ abilities }: Props) => (
               .map(({ ability, cpm, casts, maxCasts, efficiency, canBeImproved }) => {
                 const name = ability.castEfficiency.name || ability.name;
                 return (
-                  <tr key={name}>
+                  <tr key={ability.primarySpell}>
                     <td style={{ width: '35%' }}>
                       <SpellLink
                         id={ability.primarySpell}


### PR DESCRIPTION
Fixes the large error dumped in the console by React for the CastEfficiency component.

This still occurs in a few other components (notably `ShuffleOverview` for brewmaster...which then immediately disappears, so likely related to the initial state with nothing present but I'm not fixing that one right now)