### PR TITLE
[Mistweaver] Update Ancient Teachings Module

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 2, 26), <>Updated <SpellLink id={TALENTS_MONK.ANCIENT_TEACHINGS_TALENT.id}/> to use new component and added more detail to the breadown</>, Vohrr),
   change(date(2023, 2, 25), <>Added TalentAggregateStatictic, added new <SpellLink id={TALENTS_MONK.RISING_MIST_TALENT.id}/> healing breakdown module. Fixed bugs in the HotTracker</>, Vohrr),
   change(date(2023, 2, 24), <>Clarify <SpellLink id={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT}/> wording</>, Trevor),
   change(date(2023, 2, 24), <>Bug fix in the Hot Tracker to improve the accuracy of <SpellLink id={TALENTS_MONK.RISING_MIST_TALENT.id}/>, <SpellLink id={TALENTS_MONK.DANCING_MISTS_TALENT.id}/>, <SpellLink id={TALENTS_MONK.MISTY_PEAKS_TALENT.id}/>, <SpellLink id={TALENTS_MONK.MIST_WRAP_TALENT.id}/> and <SpellLink id={TALENTS_MONK.RAPID_DIFFUSION_TALENT.id}/>.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
+++ b/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
@@ -32,7 +32,7 @@ import JadeBond from './modules/spells/JadeBond';
 import NourishingChi from './modules/spells/NourishingChi';
 import RisingSunRevival from './modules/spells/UpliftedSpirits';
 import FaelineStompHealing from './modules/spells/FaelineStompHealing';
-import AncientTeachingsoftheMonastery from './modules/spells/AncientTeachingsoftheMonastery';
+import AncientTeachings from './modules/spells/AncientTeachings';
 import CloudedFocus from './modules/spells/CloudedFocus';
 import EnvelopingBreath from './modules/spells/EnvelopingBreath';
 import EnvelopingMists from './modules/spells/EnvelopingMists';
@@ -136,7 +136,7 @@ class CombatLogParser extends CoreCombatLogParser {
     vivaciousVivification: VivaciousVivification,
 
     // MW Talents
-    ancientTeachingsoftheMonastery: AncientTeachingsoftheMonastery,
+    ancientTeachings: AncientTeachings,
     cloudedFocus: CloudedFocus,
     envelopingBreath: EnvelopingBreath,
     envelopingMists: EnvelopingMists,

--- a/src/analysis/retail/monk/mistweaver/Guide.tsx
+++ b/src/analysis/retail/monk/mistweaver/Guide.tsx
@@ -39,7 +39,7 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
         {info.combatant.hasTalent(TALENTS_MONK.VIVACIOUS_VIVIFICATION_TALENT) &&
           modules.vivaciousVivification.guideSubsection}
         {info.combatant.hasTalent(TALENTS_MONK.ANCIENT_TEACHINGS_TALENT) &&
-          modules.ancientTeachingsoftheMonastery.guideSubsection}
+          modules.ancientTeachings.guideSubsection}
         {info.combatant.hasTalent(TALENTS_MONK.SHEILUNS_GIFT_TALENT) && (
           <SheilunsGraph modules={modules} events={events} info={info} />
         )}

--- a/src/analysis/retail/monk/mistweaver/modules/features/Checklist/Module.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/Checklist/Module.tsx
@@ -19,7 +19,7 @@ import SpiritOfTheCrane from '../../spells/SpiritOfTheCrane';
 import AlwaysBeCasting from '../AlwaysBeCasting';
 import Component from './Component';
 import VivaciousVivification from '../../spells/VivaciousVivify';
-import AncientTeachingsoftheMonastery from '../../spells/AncientTeachingsoftheMonastery';
+import AncientTeachings from '../../spells/AncientTeachings';
 import SheilunsGift from '../../spells/SheilunsGift';
 import EssenceFont from '../../spells/EssenceFont';
 
@@ -46,7 +46,7 @@ class Checklist extends BaseChecklist {
     envelopingBreath: EnvelopingBreath,
     essenceFont: EssenceFont,
     vivaciousVivification: VivaciousVivification,
-    ancientTeachingsoftheMonastery: AncientTeachingsoftheMonastery,
+    ancientTeachings: AncientTeachings,
     sheiluns: SheilunsGift,
   };
   protected combatants!: Combatants;
@@ -69,7 +69,7 @@ class Checklist extends BaseChecklist {
   protected envelopingBreath!: EnvelopingBreath;
   protected essenceFont!: EssenceFont;
   protected vivaciousVivification!: VivaciousVivification;
-  protected ancientTeachingsoftheMonastery!: AncientTeachingsoftheMonastery;
+  protected ancientTeachings!: AncientTeachings;
   protected sheiluns!: SheilunsGift;
 
   render() {
@@ -99,7 +99,7 @@ class Checklist extends BaseChecklist {
           soothingMist: this.soothingMist.suggestionThresholdsCasting,
           essenceFontCancelled: this.essenceFont.suggestionThresholds,
           vivaciousVivification: this.vivaciousVivification.suggestionThresholds,
-          ancientTeachings: this.ancientTeachingsoftheMonastery.suggestionThresholds,
+          ancientTeachings: this.ancientTeachings.suggestionThresholds,
           sheiluns: this.sheiluns.suggestionThresholds,
         }}
       />

--- a/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
@@ -4,15 +4,13 @@ import talents, { TALENTS_MONK } from 'common/TALENTS/monk';
 import { SpellLink } from 'interface';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
-import talentAggregateBars, {
-  getSpecSubtotal,
-  TalentAggregateBarSpec,
-} from 'parser/ui/TalentAggregateStatistic';
+import { getSpecSubtotal, TalentAggregateBarSpec } from 'parser/ui/TalentAggregateStatistic';
 import SPELLS from 'common/SPELLS';
 import { SPELL_COLORS } from '../../constants';
 import TalentAggregateStatisticContainer from 'parser/ui/TalentAggregateStatisticContainer';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
 import { formatNumber } from 'common/format';
+import TalentAggregateBars from 'parser/ui/TalentAggregateStatistic';
 
 class RisingMistBreakdown extends Analyzer {
   static dependencies = {
@@ -229,12 +227,13 @@ class RisingMistBreakdown extends Analyzer {
   }
 
   statistic() {
+    const wide = true;
     return (
       <TalentAggregateStatisticContainer
         title={
           <>
             <SpellLink id={talents.RISING_MIST_TALENT.id} /> -{' '}
-            <ItemHealingDone amount={this.risingMist.totalHealing} />
+            <ItemHealingDone amount={this.risingMist.totalHealing} displayPercentage={wide} />
           </>
         }
         category={STATISTIC_CATEGORY.TALENTS}
@@ -242,11 +241,13 @@ class RisingMistBreakdown extends Analyzer {
         footer={<>Mouseover for a detailed breakdown of each spell's contribution</>}
         smallFooter
         tooltip={this.risingMist.toolTip()}
+        wide={wide}
       >
-        {talentAggregateBars(
-          this.sortedRisingMistItems().sortedRisingMistItems,
-          this.sortedRisingMistItems().scaleFactor,
-        )}
+        <TalentAggregateBars
+          bars={this.sortedRisingMistItems().sortedRisingMistItems}
+          scaleFactor={this.sortedRisingMistItems().scaleFactor}
+          wide={wide}
+        ></TalentAggregateBars>
       </TalentAggregateStatisticContainer>
     );
   }

--- a/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
@@ -227,13 +227,12 @@ class RisingMistBreakdown extends Analyzer {
   }
 
   statistic() {
-    const wide = true;
     return (
       <TalentAggregateStatisticContainer
         title={
           <>
             <SpellLink id={talents.RISING_MIST_TALENT.id} /> -{' '}
-            <ItemHealingDone amount={this.risingMist.totalHealing} displayPercentage={wide} />
+            <ItemHealingDone amount={this.risingMist.totalHealing} />
           </>
         }
         category={STATISTIC_CATEGORY.TALENTS}
@@ -241,12 +240,12 @@ class RisingMistBreakdown extends Analyzer {
         footer={<>Mouseover for a detailed breakdown of each spell's contribution</>}
         smallFooter
         tooltip={this.risingMist.toolTip()}
-        wide={wide}
+        wide
       >
         <TalentAggregateBars
           bars={this.sortedRisingMistItems().sortedRisingMistItems}
           scaleFactor={this.sortedRisingMistItems().scaleFactor}
-          wide={wide}
+          wide
         ></TalentAggregateBars>
       </TalentAggregateStatisticContainer>
     );

--- a/src/analysis/retail/monk/mistweaver/modules/spells/AncientTeachings.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/AncientTeachings.tsx
@@ -260,24 +260,21 @@ class AncientTeachings extends Analyzer {
   }
 
   statistic() {
-    const wide = false;
     return (
       <TalentAggregateStatisticContainer
         title={
           <>
             <SpellLink id={TALENTS_MONK.ANCIENT_TEACHINGS_TALENT.id} /> -{' '}
-            <ItemHealingDone amount={this.totalHealing} displayPercentage={wide} />
+            <ItemHealingDone amount={this.totalHealing} displayPercentage={false} />
           </>
         }
         category={STATISTIC_CATEGORY.TALENTS}
-        position={STATISTIC_ORDER.CORE(1)}
+        position={STATISTIC_ORDER.OPTIONAL(1)}
         smallFooter
-        wide={wide}
       >
         <TalentAggregateBars
           bars={this.sortedAncientTeachingsItems().sortedItems}
           scaleFactor={this.sortedAncientTeachingsItems().scaleFactor}
-          wide={wide}
         ></TalentAggregateBars>
       </TalentAggregateStatisticContainer>
     );

--- a/src/analysis/retail/monk/mistweaver/modules/spells/AncientTeachings.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/AncientTeachings.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro';
-import { formatPercentage, formatThousands } from 'common/format';
+import { formatNumber, formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
 import { SpellLink } from 'interface';
@@ -14,27 +14,30 @@ import Events, {
 } from 'parser/core/Events';
 import { mergeTimePeriods, OpenTimePeriod } from 'parser/core/mergeTimePeriods';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
-import DonutChart from 'parser/ui/DonutChart';
-import Statistic from 'parser/ui/Statistic';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import TalentAggregateBars, { getSpecSubtotal } from 'parser/ui/TalentAggregateStatistic';
+import TalentAggregateStatisticContainer from 'parser/ui/TalentAggregateStatisticContainer';
 import uptimeBarSubStatistic from 'parser/ui/UptimeBarSubStatistic';
 
 import { SPELL_COLORS } from '../../constants';
 import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
 
-class AncientTeachingsoftheMonastery extends Analyzer {
+class AncientTeachings extends Analyzer {
   damageSpellToHealing: Map<number, number> = new Map();
+  damageSpellsCount: Map<number, number> = new Map();
+  missedDamageSpells: Map<number, number> = new Map();
+  damageSpellsToHealingCount: Map<number, number> = new Map();
   lastDamageSpellID: number = 0;
   uptimeWindows: OpenTimePeriod[] = [];
 
   /**
-   * After you cast Essence Font, Tiger Palm, Blackout Kick, and Rising Sun Kick heal an injured ally within 20 yards for 250% of the damage done. Lasts 15s.
+   * After you cast Essence Font, Tiger Palm, Blackout Kick, and Rising Sun Kick heal an injured ally within 20 yards for 150% of the damage done. Lasts 15s.
    */
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.ANCIENT_TEACHINGS_TALENT);
-
     this.addEventListener(
       Events.damage
         .by(SELECTED_PLAYER)
@@ -62,13 +65,18 @@ class AncientTeachingsoftheMonastery extends Analyzer {
   }
 
   lastDamageEvent(event: DamageEvent) {
-    if (!this.selectedCombatant.hasBuff(SPELLS.AT_BUFF.id)) {
-      return;
-    }
     this.lastDamageSpellID = event.ability.guid;
-    if (!this.damageSpellToHealing.has(this.lastDamageSpellID)) {
-      this.damageSpellToHealing.set(this.lastDamageSpellID, 0);
+
+    if (!this.selectedCombatant.hasBuff(SPELLS.AT_BUFF.id)) {
+      const oldMissedTotal = this.missedDamageSpells.get(this.lastDamageSpellID) || 0;
+      this.missedDamageSpells.set(this.lastDamageSpellID, oldMissedTotal + 1);
+    } else {
+      if (!this.damageSpellToHealing.has(this.lastDamageSpellID)) {
+        this.damageSpellToHealing.set(this.lastDamageSpellID, 0);
+      }
     }
+    const oldTotal = this.damageSpellsCount.get(this.lastDamageSpellID) || 0;
+    this.damageSpellsCount.set(this.lastDamageSpellID, oldTotal + 1);
   }
 
   calculateEffectiveHealing(event: HealEvent) {
@@ -124,45 +132,70 @@ class AncientTeachingsoftheMonastery extends Analyzer {
     });
   }
 
-  renderDonutChart() {
-    const rskHealing = this.damageSpellToHealing.get(SPELLS.RISING_SUN_KICK_DAMAGE.id) || 0;
-    const bokHealing = this.damageSpellToHealing.get(SPELLS.BLACKOUT_KICK.id) || 0;
-    const totmHealing = this.damageSpellToHealing.get(SPELLS.BLACKOUT_KICK_TOTM.id) || 0;
-    const tpHealing = this.damageSpellToHealing.get(SPELLS.TIGER_PALM.id) || 0;
-    const totalHealing = rskHealing + bokHealing + totmHealing + tpHealing;
+  get rskHealing() {
+    return this.damageSpellToHealing.get(SPELLS.RISING_SUN_KICK_DAMAGE.id) || 0;
+  }
 
+  get bokHealing() {
+    return this.damageSpellToHealing.get(SPELLS.BLACKOUT_KICK.id) || 0;
+  }
+
+  get totmHealing() {
+    return this.damageSpellToHealing.get(SPELLS.BLACKOUT_KICK_TOTM.id) || 0;
+  }
+
+  get tpHealing() {
+    return this.damageSpellToHealing.get(SPELLS.TIGER_PALM.id) || 0;
+  }
+
+  get totalHealing() {
+    return this.rskHealing + this.bokHealing + this.totmHealing + this.tpHealing;
+  }
+
+  sortedAncientTeachingsItems() {
     const items = [
       {
+        spell: TALENTS_MONK.RISING_SUN_KICK_TALENT,
+        amount: this.rskHealing,
         color: SPELL_COLORS.RISING_SUN_KICK,
-        label: 'Rising Sun Kick',
-        spellId: TALENTS_MONK.RISING_SUN_KICK_TALENT.id,
-        value: rskHealing / totalHealing,
-        valueTooltip: formatThousands(rskHealing),
+        tooltip: this.getTooltip(SPELLS.RISING_SUN_KICK_DAMAGE.id),
       },
       {
+        spell: SPELLS.BLACKOUT_KICK,
         color: SPELL_COLORS.BLACKOUT_KICK,
-        label: 'Blackout Kick',
-        spellId: SPELLS.BLACKOUT_KICK.id,
-        value: bokHealing / totalHealing,
-        valueTooltip: formatThousands(bokHealing),
+        amount: this.bokHealing,
+        tooltip: this.getTooltip(SPELLS.BLACKOUT_KICK.id),
+        subSpecs: [
+          {
+            spell: SPELLS.BLACKOUT_KICK_TOTM,
+            color: SPELL_COLORS.BLACKOUT_KICK_TOTM,
+            amount: this.totmHealing,
+            tooltip: this.getTooltip(
+              SPELLS.BLACKOUT_KICK_TOTM.id,
+              SPELLS.TEACHINGS_OF_THE_MONASTERY.id,
+            ),
+          },
+        ],
       },
       {
-        color: SPELL_COLORS.BLACKOUT_KICK_TOTM,
-        label: 'Teachings of the Monastery',
-        spellId: SPELLS.BLACKOUT_KICK_TOTM.id,
-        value: totmHealing / totalHealing,
-        valueTooltip: formatThousands(totmHealing),
-      },
-      {
+        spell: SPELLS.TIGER_PALM,
         color: SPELL_COLORS.TIGER_PALM,
-        label: 'Tiger Palm',
-        spellId: SPELLS.TIGER_PALM.id,
-        value: tpHealing / totalHealing,
-        valueTooltip: formatThousands(tpHealing),
+        amount: this.tpHealing,
+        tooltip: this.getTooltip(SPELLS.TIGER_PALM.id),
       },
     ];
 
-    return <DonutChart items={items} />;
+    const sortedItems = items.sort((a, b) => getSpecSubtotal(b) - getSpecSubtotal(a));
+
+    const scaleFactor = sortedItems.reduce(
+      (factor, item) =>
+        factor < this.totalHealing / getSpecSubtotal(item)
+          ? factor
+          : this.totalHealing / getSpecSubtotal(item),
+      100,
+    );
+
+    return { sortedItems, scaleFactor };
   }
 
   get suggestionThresholds() {
@@ -175,6 +208,34 @@ class AncientTeachingsoftheMonastery extends Analyzer {
       },
       style: ThresholdStyle.PERCENTAGE,
     };
+  }
+
+  getTooltip(spellId: number, secondarySourceId?: number) {
+    return (
+      <>
+        From your {this.damageSpellsCount.get(spellId) || 0} <SpellLink id={spellId} />{' '}
+        {secondarySourceId && (
+          <>
+            from <SpellLink id={secondarySourceId} />
+          </>
+        )}
+        :
+        <ul>
+          <li>
+            {secondarySourceId && <SpellLink id={secondarySourceId} />} <SpellLink id={spellId} />{' '}
+            did damage {this.missedDamageSpells.get(spellId) || 0} times without the{' '}
+            <SpellLink id={TALENTS_MONK.ANCIENT_TEACHINGS_TALENT} /> buff active
+          </li>
+          <li>
+            {secondarySourceId && <SpellLink id={secondarySourceId} />} <SpellLink id={spellId} />{' '}
+            converted to healing{' '}
+            {(this.damageSpellsCount.get(spellId) || 0) -
+              (this.missedDamageSpells.get(spellId) || 0)}{' '}
+            times for a total of {formatNumber(this.damageSpellToHealing.get(spellId) || 0)} healing
+          </li>
+        </ul>
+      </>
+    );
   }
 
   suggestions(when: When) {
@@ -199,21 +260,28 @@ class AncientTeachingsoftheMonastery extends Analyzer {
   }
 
   statistic() {
+    const wide = false;
     return (
-      <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(13)}
-        size="flexible"
+      <TalentAggregateStatisticContainer
+        title={
+          <>
+            <SpellLink id={TALENTS_MONK.ANCIENT_TEACHINGS_TALENT.id} /> -{' '}
+            <ItemHealingDone amount={this.totalHealing} displayPercentage={wide} />
+          </>
+        }
         category={STATISTIC_CATEGORY.TALENTS}
+        position={STATISTIC_ORDER.CORE(1)}
+        smallFooter
+        wide={wide}
       >
-        <div className="pad">
-          <label>
-            <SpellLink id={SPELLS.AT_HEAL.id}>Ancient Teachings</SpellLink> breakdown
-          </label>
-          {this.renderDonutChart()}
-        </div>
-      </Statistic>
+        <TalentAggregateBars
+          bars={this.sortedAncientTeachingsItems().sortedItems}
+          scaleFactor={this.sortedAncientTeachingsItems().scaleFactor}
+          wide={wide}
+        ></TalentAggregateBars>
+      </TalentAggregateStatisticContainer>
     );
   }
 }
 
-export default AncientTeachingsoftheMonastery;
+export default AncientTeachings;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/CloudedFocus.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/CloudedFocus.tsx
@@ -105,7 +105,7 @@ class CloudedFocus extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(13)}
+        position={STATISTIC_ORDER.OPTIONAL(1)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
       >

--- a/src/analysis/retail/monk/mistweaver/modules/spells/DancingMists.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/DancingMists.tsx
@@ -185,7 +185,7 @@ class DancingMists extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(13)}
+        position={STATISTIC_ORDER.CORE(3)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={

--- a/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
@@ -414,7 +414,7 @@ class InvokeChiJi extends BaseCelestialAnalyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.DEFAULT}
+        position={STATISTIC_ORDER.OPTIONAL(2)}
         category={STATISTIC_CATEGORY.TALENTS}
         size="flexible"
         tooltip={

--- a/src/analysis/retail/monk/mistweaver/modules/spells/InvokeYulon.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/InvokeYulon.tsx
@@ -165,7 +165,7 @@ class InvokeYulon extends BaseCelestialAnalyzer {
     return (
       <Statistic
         category={STATISTIC_CATEGORY.TALENTS}
-        position={STATISTIC_ORDER.DEFAULT}
+        position={STATISTIC_ORDER.OPTIONAL(2)}
         size="flexible"
         tooltip={
           <>

--- a/src/analysis/retail/monk/mistweaver/modules/spells/JadeBond.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/JadeBond.tsx
@@ -86,7 +86,7 @@ class JadeBond extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(13)}
+        position={STATISTIC_ORDER.UNIMPORTANT(0)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
       >

--- a/src/analysis/retail/monk/mistweaver/modules/spells/MistWrap.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/MistWrap.tsx
@@ -135,7 +135,7 @@ class MistWrap extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(20)}
+        position={STATISTIC_ORDER.CORE(5)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={

--- a/src/analysis/retail/monk/mistweaver/modules/spells/MistyPeaks.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/MistyPeaks.tsx
@@ -111,7 +111,7 @@ class MistyPeaks extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.DEFAULT}
+        position={STATISTIC_ORDER.CORE(4)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RapidDiffusion.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RapidDiffusion.tsx
@@ -190,7 +190,7 @@ class RapidDiffusion extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(13)}
+        position={STATISTIC_ORDER.CORE(2)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ShaohaosLessons.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ShaohaosLessons.tsx
@@ -199,7 +199,7 @@ class ShaohaosLessons extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(4)}
+        position={STATISTIC_ORDER.OPTIONAL(0)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={

--- a/src/analysis/retail/monk/mistweaver/modules/spells/SheilunsGift.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/SheilunsGift.tsx
@@ -112,7 +112,7 @@ class SheilunsGift extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(4)}
+        position={STATISTIC_ORDER.OPTIONAL(0)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
       >

--- a/src/analysis/retail/monk/mistweaver/modules/spells/SpiritOfTheCrane.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/SpiritOfTheCrane.tsx
@@ -142,7 +142,7 @@ class SpiritOfTheCrane extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(30)}
+        position={STATISTIC_ORDER.UNIMPORTANT(1)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={

--- a/src/analysis/retail/monk/mistweaver/modules/spells/UpliftedSpirits.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/UpliftedSpirits.tsx
@@ -88,7 +88,7 @@ class UpliftedSpirits extends Analyzer {
     const healing = this.usHealing;
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(13)}
+        position={STATISTIC_ORDER.UNIMPORTANT(2)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={

--- a/src/analysis/retail/monk/mistweaver/modules/spells/YulonsWhisper.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/YulonsWhisper.tsx
@@ -86,7 +86,7 @@ class YulonsWhisper extends Analyzer {
       <Statistic
         position={STATISTIC_ORDER.OPTIONAL(20)}
         size="flexible"
-        category={STATISTIC_CATEGORY.TALENTS}
+        category={STATISTIC_CATEGORY.THEORYCRAFT}
       >
         <BoringValueText
           label={

--- a/src/analysis/retail/monk/shared/FaelineStomp.tsx
+++ b/src/analysis/retail/monk/shared/FaelineStomp.tsx
@@ -74,7 +74,7 @@ class FaelineStomp extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL()}
+        position={STATISTIC_ORDER.OPTIONAL(99)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
       >

--- a/src/analysis/retail/monk/shared/SaveThemAll.tsx
+++ b/src/analysis/retail/monk/shared/SaveThemAll.tsx
@@ -49,7 +49,7 @@ class SaveThemAll extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(10)}
+        position={STATISTIC_ORDER.OPTIONAL(4)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={

--- a/src/analysis/retail/monk/shared/TeachingsOfTheMonestary.tsx
+++ b/src/analysis/retail/monk/shared/TeachingsOfTheMonestary.tsx
@@ -31,7 +31,7 @@ class TeachingsOfTheMonestary extends Analyzer {
       <Statistic
         position={STATISTIC_ORDER.OPTIONAL(10)}
         size="flexible"
-        category={STATISTIC_CATEGORY.TALENTS}
+        category={STATISTIC_CATEGORY.THEORYCRAFT}
       >
         <TalentSpellText talent={TALENTS_MONK.TEACHINGS_OF_THE_MONASTERY_TALENT}>
           {this.averageStacks.toFixed(2)} <small> average stacks</small>

--- a/src/parser/ui/TalentAggregateBar.tsx
+++ b/src/parser/ui/TalentAggregateBar.tsx
@@ -24,7 +24,7 @@ const TalentAggregateBar = ({
   scaleFactor = 1,
   subSpecs,
   subSpecPercents,
-  wide = true,
+  wide = false,
   ...others
 }: Props) => {
   return (

--- a/src/parser/ui/TalentAggregateBar.tsx
+++ b/src/parser/ui/TalentAggregateBar.tsx
@@ -13,6 +13,7 @@ type Props = {
   scaleFactor?: number;
   subSpecs?: TalentAggregateBarSpec[];
   subSpecPercents?: number[];
+  wide: boolean;
 };
 
 const TalentAggregateBar = ({
@@ -20,16 +21,17 @@ const TalentAggregateBar = ({
   percentTotal,
   barColor,
   barTooltip,
-  scaleFactor,
+  scaleFactor = 1,
   subSpecs,
   subSpecPercents,
+  wide = true,
   ...others
 }: Props) => {
   return (
     <div className="source-bar" {...others}>
-      <Tooltip content={barTooltip ? barTooltip : percentTotal + '%'}>
+      <Tooltip content={barTooltip || formatPercentage(percentTotal) + '%'}>
         <div style={getSegment(percentTotal, barColor, scaleFactor)}>
-          {showLabel(percentTotal, scaleFactor) && (
+          {showLabel(percentTotal, scaleFactor, wide) && (
             <span>
               <strong>{formatPercentage(percentTotal, 1)}%</strong>
             </span>
@@ -44,7 +46,7 @@ const TalentAggregateBar = ({
             content={subSpec.tooltip || formatPercentage(subSpecPercents[idx]) + '%'}
           >
             <div style={getSegment(subSpecPercents[idx], subSpec.color, scaleFactor)}>
-              {showLabel(subSpecPercents[idx], scaleFactor) && (
+              {showLabel(subSpecPercents[idx], scaleFactor, wide) && (
                 <span>
                   <strong>{formatPercentage(subSpecPercents[idx], 1)}%</strong>
                 </span>
@@ -63,8 +65,8 @@ const TalentAggregateBar = ({
  * @param scaleFactor the provided scale factor the component uses to size the chart
  * @returns true or false
  */
-function showLabel(percentTotal: number, scaleFactor?: number): boolean {
-  return 1 / percentTotal / 10 < (scaleFactor || 1);
+function showLabel(percentTotal: number, scaleFactor: number, wide: boolean): boolean {
+  return 1 / percentTotal / (wide ? 10 : 5) < (scaleFactor || 1);
 }
 
 /**
@@ -77,18 +79,18 @@ function showLabel(percentTotal: number, scaleFactor?: number): boolean {
 function getSegment(
   percentTotal: number,
   barColor: string | undefined,
-  scaleFactor?: number,
+  scaleFactor: number,
 ): React.CSSProperties {
   return barColor !== undefined
     ? {
         //borderRadius: `2px`,
         left: `0%`,
-        width: `${percentTotal * 100 * (scaleFactor || 1)}%`,
+        width: `${percentTotal * 100 * scaleFactor}%`,
         background: `${barColor}`,
       }
     : {
         left: `0%`,
-        width: `${percentTotal * 100 * (scaleFactor || 1)}%`,
+        width: `${percentTotal * 100 * scaleFactor}%`,
       };
 }
 

--- a/src/parser/ui/TalentAggregateStatistic.scss
+++ b/src/parser/ui/TalentAggregateStatistic.scss
@@ -8,10 +8,19 @@
 
     .value {
       font-size: 24px;
-
       small {
         font-size: 13px;
       }
+    }
+    .small {
+      font-size: 14px !important;
+    }
+  }
+  small {
+    font-family: 'Open Sans', 'Century Gothic', sans-serif;
+    font-size: 14px;
+    .img.icon {
+      border: 0 !important;
     }
   }
 }
@@ -29,7 +38,7 @@
   .main-bar-big {
     padding: 10px;
     height: 65px;
-    font-size: 20px; /* bigger? */
+    font-size: 20px;
   }
 
   .sub-bar {

--- a/src/parser/ui/TalentAggregateStatistic.scss
+++ b/src/parser/ui/TalentAggregateStatistic.scss
@@ -49,7 +49,7 @@
 
   .bar-label {
     padding: 7.5px 0;
-    width: 35%;
+    width: 33%;
     text-align: left;
     vertical-align: middle;
     font-size: 15px;

--- a/src/parser/ui/TalentAggregateStatistic.tsx
+++ b/src/parser/ui/TalentAggregateStatistic.tsx
@@ -1,6 +1,6 @@
 import { formatNumber } from 'common/format';
 import Spell from 'common/SPELLS/Spell';
-import { SpellLink } from 'interface';
+import { SpellIcon, SpellLink } from 'interface';
 import { ReactNode } from 'react';
 import TalentAggregateBar from './TalentAggregateBar';
 import './TalentAggregateStatistic.scss';
@@ -18,23 +18,26 @@ export type TalentAggregateBarSpec = {
   subSpecs?: TalentAggregateBarSpec[];
 };
 
+type Props = {
+  bars: TalentAggregateBarSpec[];
+  scaleFactor?: number;
+  wide: boolean;
+};
+
 /**
  * A JSX element that creates and graphs a collection of data points based on the given input data
  * @param bars an array of type TalentAggregateBarSpec
  * @param scaleFactor optional param used to control the scale of the graph within the statistic box.
  * Can be set manually or calculated using the ratios of specs to total
  */
-export default function talentAggregateBars(
-  bars: TalentAggregateBarSpec[],
-  scaleFactor?: number,
-): React.ReactNode {
+const TalentAggregateBars = ({ bars, scaleFactor, wide = true }: Props) => {
   return (
     <>
       {bars.map((spec) => (
         <div key={spec.spell.name} className="flex-main talent-aggregate-bar">
           <div className="flex main-bar">
             <div className="flex-sub bar-label">
-              {getSpellLink(spec)} <small>{formatNumber(getSpecSubtotal(spec))} </small>
+              {getSpellLink(spec, wide)} <small>{formatNumber(getSpecSubtotal(spec))} </small>
             </div>
             <div className="flex-main chart">
               <TalentAggregateBar
@@ -43,6 +46,7 @@ export default function talentAggregateBars(
                 barColor={spec.color}
                 barTooltip={spec.tooltip}
                 scaleFactor={scaleFactor}
+                wide={wide}
                 subSpecs={spec.subSpecs}
                 subSpecPercents={spec.subSpecs?.map((subSpec) => {
                   return getPercentContribution(subSpec.amount || 0, bars);
@@ -54,7 +58,7 @@ export default function talentAggregateBars(
       ))}
     </>
   );
-}
+};
 
 /**
  * Function to get the sum of all amounts for parent and children TalentAggregateBarSpec
@@ -85,10 +89,8 @@ function getPercentContribution(amount: number, bars: TalentAggregateBarSpec[]) 
  * @param spec TalentAggregateBarSpec
  * @returns the SpellLink component for the given spec's spell
  */
-function getSpellLink(spec: TalentAggregateBarSpec) {
-  return (
-    <>
-      <SpellLink id={spec.spell.id} />{' '}
-    </>
-  );
+function getSpellLink(spec: TalentAggregateBarSpec, wide?: boolean) {
+  return <>{wide ? <SpellLink id={spec.spell.id} /> : <SpellIcon id={spec.spell.id} />} </>;
 }
+
+export default TalentAggregateBars;

--- a/src/parser/ui/TalentAggregateStatistic.tsx
+++ b/src/parser/ui/TalentAggregateStatistic.tsx
@@ -21,7 +21,7 @@ export type TalentAggregateBarSpec = {
 type Props = {
   bars: TalentAggregateBarSpec[];
   scaleFactor?: number;
-  wide: boolean;
+  wide?: boolean;
 };
 
 /**
@@ -30,7 +30,7 @@ type Props = {
  * @param scaleFactor optional param used to control the scale of the graph within the statistic box.
  * Can be set manually or calculated using the ratios of specs to total
  */
-const TalentAggregateBars = ({ bars, scaleFactor, wide = true }: Props) => {
+const TalentAggregateBars = ({ bars, scaleFactor, wide = false }: Props) => {
   return (
     <>
       {bars.map((spec) => (

--- a/src/parser/ui/TalentAggregateStatisticContainer.tsx
+++ b/src/parser/ui/TalentAggregateStatisticContainer.tsx
@@ -25,7 +25,7 @@ const TalentAggregateStatisticContainer = ({
   smallTitle,
   footer,
   smallFooter,
-  wide = true,
+  wide = false,
   ...others
 }: Props) => (
   <Statistic wide={wide} size="flexible" {...others}>
@@ -40,19 +40,23 @@ const TalentAggregateStatisticContainer = ({
         )}
       </div>
       {children}
-      {footer && (
-        <div className="boring-value">
-          {smallFooter ? (
-            <small>
-              *{footer}.<br /> *Labels are hidden for trivial amounts
-            </small>
-          ) : (
-            <h3>
-              {footer}.<br /> Labels are hidden for trivial amounts
-            </h3>
-          )}
-        </div>
-      )}
+      <div className="boring-value">
+        {footer && (
+          <>
+            {smallFooter ? (
+              <small>
+                *{footer}
+                <br />
+              </small>
+            ) : (
+              <h3>
+                {footer}
+                <br />
+              </h3>
+            )}
+          </>
+        )}
+      </div>
     </div>
   </Statistic>
 );

--- a/src/parser/ui/TalentAggregateStatisticContainer.tsx
+++ b/src/parser/ui/TalentAggregateStatisticContainer.tsx
@@ -9,6 +9,10 @@ type Props = {
   smallTitle?: boolean;
   footer?: ReactNode;
   smallFooter?: boolean;
+  /**
+   * @default {true}
+   */
+  wide?: boolean;
   category?: STATISTIC_CATEGORY;
   position?: number;
   tooltip?: ReactNode | string;
@@ -21,13 +25,14 @@ const TalentAggregateStatisticContainer = ({
   smallTitle,
   footer,
   smallFooter,
+  wide = true,
   ...others
 }: Props) => (
-  <Statistic wide size="flexible" {...others}>
+  <Statistic wide={wide} size="flexible" {...others}>
     <div className="pad">
       <div className="talent-aggregate-container">
-        {smallTitle ? (
-          <strong>{title}</strong>
+        {smallTitle || !wide ? (
+          <small>{title}</small>
         ) : (
           <h3>
             <div className="value">{title}</div>


### PR DESCRIPTION
### Description
Updated the ancient teachings module to use the new TalentAggregateStatistic and added more analysis including healing contribution per spell, total hps, and hit/miss gcds tally
Updated the TalentAggregateStatistic to accomodate a wide toggle 

Test report URL: `/report/78wDFA4aYJj2NxLf/28-Mythic+Kurog+Grimtotem+-+Kill+(7:41)/Sweggles/standard/statistics` - standard build
Test report URL: `report/TmGv1ntrLy4HgXNw/5-Mythic+Kurog+Grimtotem+-+Kill+(8:43)/1-Matty/standard` - cleave build
Screenshots:
![image](https://user-images.githubusercontent.com/26779541/221394808-f17d7013-8d8b-4774-a6e1-18542d9d20c2.png)
Standard build tooltip:
![image](https://user-images.githubusercontent.com/26779541/221394840-15ceae90-f30d-4bd0-b51c-7ddcfc43a59c.png)
Cleave build tooltip:
![image](https://user-images.githubusercontent.com/26779541/221394887-08a623c7-9a04-46e1-a8bb-b84ab54e7918.png)


