### PR TITLE
[Mistweaver] more Rising Mist updates

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 2, 27), <>Updated <SpellLink id={TALENTS_MONK.RISING_MIST_TALENT.id}/> tooltips and some spell colors</>, Vohrr),
   change(date(2023, 2, 26), <>Added <SpellLink id={TALENTS_MONK.UPLIFTED_SPIRITS_TALENT.id}/> cooldown reduction to the <SpellLink id={SPELLS.VIVIFY.id}/> cast breakdown tooltips</>, Vohrr),
   change(date(2023, 2, 26), <>Refactor Talent Aggregate Statistic to handle scale and sorting in the component instead of having to do it before sending in the parameters</>, Vohrr),
   change(date(2023, 2, 26), <>Updated <SpellLink id={TALENTS_MONK.ANCIENT_TEACHINGS_TALENT.id}/> to use new component and added more detail to the breadown</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/constants.ts
+++ b/src/analysis/retail/monk/mistweaver/constants.ts
@@ -71,13 +71,15 @@ export const LESSONS_BUFFS = [
 ];
 
 export const SPELL_COLORS = {
+  MISTY_PEAKS: '#c8fadb',
   DANCING_MIST: '#42e7fc',
-  RAPID_DIFFUSION: '#127847',
+  RAPID_DIFFUSION: '#1c9c4d',
+  DANCING_MISTS: '#38ffdb',
   ESSENCE_FONT: '#1f77b4',
   ESSENCE_FONT_BUFF: '#aec7e8',
   GUSTS_OF_MISTS: '#ff7f0e',
-  VIVIFY: '#ffbb78',
-  RENEWING_MIST: '#2ca02c',
+  VIVIFY: '#00FF98',
+  RENEWING_MIST: '#14522c',
   ENVELOPING_MIST: '#98df8a',
   SOOTHING_MIST: '#d62728',
   EXPEL_HARM: '#ff9896',

--- a/src/analysis/retail/monk/mistweaver/modules/features/MistyPeaksHealingBreakdown.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/MistyPeaksHealingBreakdown.tsx
@@ -43,7 +43,7 @@ class MistyPeaksHealingBreakdown extends Analyzer {
   renderMistyPeaksChart() {
     const items = [
       {
-        color: SPELL_COLORS.ENVELOPING_MIST,
+        color: SPELL_COLORS.DANCING_MISTS,
         label: 'Dancing Mists',
         spellId: TALENTS_MONK.DANCING_MISTS_TALENT.id,
         value: this.dancingMists.mistyPeaksHealingFromDancingMist,

--- a/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/RisingMistBreakdown.tsx
@@ -1,6 +1,6 @@
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import RisingMist from '../spells/RisingMist';
-import talents, { TALENTS_MONK } from 'common/TALENTS/monk';
+import talents from 'common/TALENTS/monk';
 import { SpellLink } from 'interface';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
@@ -11,6 +11,7 @@ import TalentAggregateStatisticContainer from 'parser/ui/TalentAggregateStatisti
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
 import { formatNumber } from 'common/format';
 import TalentAggregateBars from 'parser/ui/TalentAggregateStatistic';
+import DonutChart from 'parser/ui/DonutChart';
 
 class RisingMistBreakdown extends Analyzer {
   static dependencies = {
@@ -82,56 +83,88 @@ class RisingMistBreakdown extends Analyzer {
   }
 
   envelopingMistTooltip() {
+    const items = [
+      {
+        color: SPELL_COLORS.ENVELOPING_MIST,
+        label: 'Hardcast',
+        spellId: talents.ENVELOPING_MIST_TALENT.id,
+        value: this.risingMist.envHardcastExtensionHealing,
+        valuePercent: false,
+      },
+      {
+        color: SPELL_COLORS.MISTY_PEAKS,
+        label: 'Misty Peaks',
+        spellId: talents.MISTY_PEAKS_TALENT.id,
+        value: this.risingMist.envMistyPeaksExtensionHealing,
+        valuePercent: false,
+      },
+    ];
     return (
       <>
-        <SpellLink id={talents.ENVELOPING_MIST_TALENT} /> extension healing
-        <ul>
-          <li>
-            {formatNumber(this.risingMist.envMistyPeaksExtensionHealing)} from extended{' '}
-            <SpellLink id={talents.MISTY_PEAKS_TALENT} /> procs
-          </li>
-          <li>
-            {formatNumber(this.risingMist.envHardcastExtensionHealing)} from extended hardcasts
-          </li>
-        </ul>
+        <SpellLink id={talents.ENVELOPING_MIST_TALENT} /> extension healing by source:
+        <hr />
+        <DonutChart items={items} />
       </>
     );
   }
 
   envelopingMistBonusHealingTooltip() {
+    const items = [
+      {
+        color: SPELL_COLORS.ENVELOPING_MIST,
+        label: 'Hardcast',
+        spellId: talents.ENVELOPING_MIST_TALENT.id,
+        value: this.risingMist.extraEnvBonusHardcast,
+        valuePercent: false,
+      },
+      {
+        color: SPELL_COLORS.MISTY_PEAKS,
+        label: 'Misty Peaks',
+        spellId: talents.MISTY_PEAKS_TALENT.id,
+        value: this.risingMist.extraEnvBonusMistyPeaks,
+        valuePercent: false,
+      },
+    ];
     return (
       <>
-        Additional bonus healing from the extra <SpellLink id={talents.ENVELOPING_MIST_TALENT} />{' '}
-        buff uptime
-        <ul>
-          <li>
-            {formatNumber(this.risingMist.extraEnvBonusMistyPeaks)} from extended{' '}
-            <SpellLink id={talents.MISTY_PEAKS_TALENT} /> procs
-          </li>
-          <li>{formatNumber(this.risingMist.extraEnvBonusHardcast)} from extended hardcasts</li>
-        </ul>
+        Additional bonus healing from the extra
+        <br />
+        <SpellLink id={talents.ENVELOPING_MIST_TALENT} /> buff uptime by source:
+        <hr />
+        <DonutChart items={items} />
       </>
     );
   }
 
   renewingMistTooltip() {
+    const items = [
+      {
+        color: SPELL_COLORS.DANCING_MISTS,
+        label: 'Dancing Mists',
+        spellId: talents.DANCING_MISTS_TALENT.id,
+        value: this.risingMist.renewingMistDancingMistExtensionHealing,
+        valuePercent: false,
+      },
+      {
+        color: SPELL_COLORS.RAPID_DIFFUSION,
+        label: 'Rapid Diffusion',
+        spellId: talents.RAPID_DIFFUSION_TALENT.id,
+        value: this.risingMist.renewingMistRapidDiffusionExtensionHealing,
+        valuePercent: false,
+      },
+      {
+        color: SPELL_COLORS.RENEWING_MIST,
+        label: 'Hardcast',
+        spellId: SPELLS.RENEWING_MIST_HEAL.id,
+        value: this.risingMist.renewingMistHardcastExtensionHealing,
+        valuePercent: false,
+      },
+    ];
     return (
       <>
-        <SpellLink id={talents.RENEWING_MIST_TALENT} /> extension healing
-        <ul>
-          <li>
-            {formatNumber(this.risingMist.renewingMistDancingMistExtensionHealing)} from extended{' '}
-            <SpellLink id={talents.DANCING_MISTS_TALENT} /> procs
-          </li>
-          <li>
-            {formatNumber(this.risingMist.renewingMistHardcastExtensionHealing)} from extended
-            hardcasts
-          </li>
-          <li>
-            {formatNumber(this.risingMist.renewingMistRapidDiffusionExtensionHealing)} from extended{' '}
-            <SpellLink id={talents.RAPID_DIFFUSION_TALENT} /> procs
-          </li>
-        </ul>
+        <SpellLink id={talents.RENEWING_MIST_TALENT} /> extension healing by source:
+        <hr />
+        <DonutChart items={items} />
       </>
     );
   }
@@ -144,11 +177,11 @@ class RisingMistBreakdown extends Analyzer {
         <ul>
           <li>
             {formatNumber(this.risingMist.averageHealing)} average healing per{' '}
-            <SpellLink id={TALENTS_MONK.RISING_SUN_KICK_TALENT} />
+            <SpellLink id={talents.RISING_SUN_KICK_TALENT} />
           </li>
           <li>
             {this.risingMist.averageTargetsPerRSKCast()} average hits per{' '}
-            <SpellLink id={TALENTS_MONK.RISING_SUN_KICK_TALENT} />
+            <SpellLink id={talents.RISING_SUN_KICK_TALENT} />
           </li>
         </ul>
       </>
@@ -156,28 +189,40 @@ class RisingMistBreakdown extends Analyzer {
   }
 
   vivifyTooltip() {
+    const items = [
+      {
+        color: SPELL_COLORS.DANCING_MISTS,
+        label: 'Dancing Mists',
+        spellId: talents.DANCING_MISTS_TALENT.id,
+        value: this.risingMist.extraVivhealingFromDancingMistRems,
+        valuePercent: false,
+      },
+      {
+        color: SPELL_COLORS.RAPID_DIFFUSION,
+        label: 'Rapid Diffusion',
+        spellId: talents.RAPID_DIFFUSION_TALENT.id,
+        value: this.risingMist.extraVivHealingFromRapidDiffusionRems,
+        valuePercent: false,
+      },
+      {
+        color: SPELL_COLORS.RENEWING_MIST,
+        label: 'Hardcast',
+        spellId: SPELLS.RENEWING_MIST_HEAL.id,
+        value: this.risingMist.extraVivHealingFromHardcastRems,
+        valuePercent: false,
+      },
+    ];
     return (
       <>
-        <SpellLink id={SPELLS.VIVIFY} /> healing from extended{' '}
+        <strong>{this.risingMist.extraVivCleaves}</strong> total extra cleaves via{' '}
+        <SpellLink id={talents.INVIGORATING_MISTS_TALENT} />
+        <br />
+        <SpellLink id={SPELLS.VIVIFY} /> healing via extended{' '}
         <SpellLink id={talents.RENEWING_MIST_TALENT} />
-        <ul>
-          <li>
-            {this.risingMist.extraVivCleaves} extra cleave hits via{' '}
-            <SpellLink id={talents.INVIGORATING_MISTS_TALENT} />
-          </li>
-          <li>
-            {formatNumber(this.risingMist.extraVivhealingFromDancingMistRems)} from extended{' '}
-            <SpellLink id={talents.DANCING_MISTS_TALENT} /> procs
-          </li>
-          <li>
-            {formatNumber(this.risingMist.extraVivHealingFromHardcastRems)} from extended hardcast{' '}
-            <SpellLink id={talents.RENEWING_MIST_TALENT} />
-          </li>
-          <li>
-            {formatNumber(this.risingMist.extraVivHealingFromRapidDiffusionRems)} from extended{' '}
-            <SpellLink id={talents.RAPID_DIFFUSION_TALENT} /> procs
-          </li>
-        </ul>
+        <br />
+        by source:
+        <hr />
+        <DonutChart items={items} />
       </>
     );
   }

--- a/src/parser/ui/DonutChart.tsx
+++ b/src/parser/ui/DonutChart.tsx
@@ -1,4 +1,4 @@
-import { formatPercentage } from 'common/format';
+import { formatNumber, formatPercentage } from 'common/format';
 import { SpellLink } from 'interface';
 import { TooltipElement } from 'interface';
 import BaseChart from 'parser/ui/BaseChart';
@@ -12,6 +12,7 @@ export type Item = {
   tooltip?: React.ReactNode;
   color: string;
   value: number;
+  valuePercent?: boolean;
   spellId?: number;
   itemLevel?: number;
   valueTooltip?: React.ReactNode;
@@ -34,29 +35,38 @@ class DonutChart extends PureComponent<Props> {
 
     return (
       <div className="legend">
-        {items.map(({ color, label, tooltip, value, spellId, valueTooltip, itemLevel }, index) => {
-          label = tooltip ? <TooltipElement content={tooltip}>{label}</TooltipElement> : label;
-          label = spellId ? (
-            <SpellLink id={spellId} ilvl={itemLevel}>
-              {label}
-            </SpellLink>
-          ) : (
-            label
-          );
-          return (
-            <div key={index} className="flex">
-              <div className="flex-sub">
-                <div className="circle" style={{ background: color }} />
+        {items.map(
+          (
+            { color, label, tooltip, value, valuePercent = true, spellId, valueTooltip, itemLevel },
+            index,
+          ) => {
+            label = tooltip ? <TooltipElement content={tooltip}>{label}</TooltipElement> : label;
+            label = spellId ? (
+              <SpellLink id={spellId} ilvl={itemLevel}>
+                {label}
+              </SpellLink>
+            ) : (
+              label
+            );
+            return (
+              <div key={index} className="flex">
+                <div className="flex-sub">
+                  <div className="circle" style={{ background: color }} />
+                </div>
+                <div className="flex-main">{label}</div>
+                <div className="flex-sub">
+                  {valuePercent ? (
+                    <TooltipElement content={valueTooltip ? valueTooltip : value}>
+                      {formatPercentage(value / total, 0)}%
+                    </TooltipElement>
+                  ) : (
+                    <>{formatNumber(value)}</>
+                  )}
+                </div>
               </div>
-              <div className="flex-main">{label}</div>
-              <div className="flex-sub">
-                <TooltipElement content={valueTooltip ? valueTooltip : value}>
-                  {formatPercentage(value / total, 0)}%
-                </TooltipElement>
-              </div>
-            </div>
-          );
-        })}
+            );
+          },
+        )}
       </div>
     );
   }


### PR DESCRIPTION
### Description
Added and updated some spell colors
Updated the RisingMistBreakdown Tooltips to use donut charts.
Updated the DonutChart component to include an option to show raw value instead of percent total

### Motivation

Visual Clarity

### Screenshot(s):
Before:
![image](https://user-images.githubusercontent.com/26779541/221480584-cba341aa-243c-431b-9ae0-b15ee8a6bf5c.png)


After:
![image](https://user-images.githubusercontent.com/26779541/221480393-4bcf54e2-d6eb-48ac-b0cb-8e0766605ecf.png)

