### PR TITLE
[Mistweaver] Rapid diffusion source attribution & Update Modules to new component

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 2, 28), <>Updates to <SpellLink id={TALENTS_MONK.DANCING_MISTS_TALENT.id}/> and <SpellLink id={TALENTS_MONK.RAPID_DIFFUSION_TALENT.id}/> to show a more detailed breakdown</>, Vohrr),
   change(date(2023, 2, 28), <>Refactored Hot Attributor for readability and increased <SpellLink id={TALENTS_MONK.DANCING_MISTS_TALENT.id}/> event link threshold</>, Vohrr),
   change(date(2023, 2, 27), <>Updated <SpellLink id={TALENTS_MONK.DANCING_MISTS_TALENT.id}/> to show proc source breakdown</>, Vohrr),
   change(date(2023, 2, 27), <>Fix crash when <SpellLink id={TALENTS_MONK.UPLIFTED_SPIRITS_TALENT.id}/> is not talented</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/constants.ts
+++ b/src/analysis/retail/monk/mistweaver/constants.ts
@@ -59,6 +59,10 @@ export const ATTRIBUTION_STRINGS = {
     DM_SOURCE_HC: 'Dancing Mist Source - Hardcast',
     DM_SOURCE_MOL: 'Dancing Mist Source - Mists of Life',
   },
+  RAPID_DIFFUSION_SOURCES: {
+    RD_SOURCE_RSK: 'Rapid Diffusion Source - Rising Sun Kick',
+    RD_SOURCE_ENV: 'Rapid Diffusion Source - Enveloping Mist',
+  },
 };
 
 export const SECRET_INFUSION_BUFFS = [

--- a/src/analysis/retail/monk/mistweaver/modules/core/HotAttributor.ts
+++ b/src/analysis/retail/monk/mistweaver/modules/core/HotAttributor.ts
@@ -291,7 +291,6 @@ class HotAttributor extends Analyzer {
   }
 
   private _attributeRapidDiffusionRem(event: ApplyBuffEvent | RefreshBuffEvent, hot: Tracker) {
-    //rapid diffusion rem
     this.hotTracker.addAttributionFromApply(this.rapidDiffusionAttrib, event);
     if (isFromRapidDiffusionRisingSunKick(event)) {
       this.hotTracker.addAttributionFromApply(this.rdSourceRSKAttrib, event);

--- a/src/analysis/retail/monk/mistweaver/modules/core/HotAttributor.ts
+++ b/src/analysis/retail/monk/mistweaver/modules/core/HotAttributor.ts
@@ -8,7 +8,7 @@ import Events, {
   RemoveBuffEvent,
 } from 'parser/core/Events';
 import Combatants from 'parser/shared/modules/Combatants';
-import HotTracker, { Attribution } from 'parser/shared/modules/HotTracker';
+import HotTracker, { Attribution, Tracker } from 'parser/shared/modules/HotTracker';
 import { ATTRIBUTION_STRINGS } from '../../constants';
 import {
   isFromHardcast,
@@ -17,6 +17,8 @@ import {
   isFromMistsOfLife,
   isFromDancingMists,
   getSourceRem,
+  isFromRapidDiffusionEnvelopingMist,
+  isFromRapidDiffusionRisingSunKick,
 } from '../../normalizers/CastLinkNormalizer';
 import HotTrackerMW from '../core/HotTrackerMW';
 
@@ -54,6 +56,12 @@ class HotAttributor extends Analyzer {
   );
   dmSourceMoLAttrib = HotTracker.getNewAttribution(
     ATTRIBUTION_STRINGS.DANCING_MIST_SOURCES.DM_SOURCE_MOL,
+  );
+  rdSourceRSKAttrib = HotTracker.getNewAttribution(
+    ATTRIBUTION_STRINGS.RAPID_DIFFUSION_SOURCES.RD_SOURCE_RSK,
+  );
+  rdSourceENVAttrib = HotTracker.getNewAttribution(
+    ATTRIBUTION_STRINGS.RAPID_DIFFUSION_SOURCES.RD_SOURCE_ENV,
   );
   EFAttrib = HotTracker.getNewAttribution(ATTRIBUTION_STRINGS.HARDCAST_ESSENCE_FONT);
 
@@ -117,22 +125,10 @@ class HotAttributor extends Analyzer {
       this.hotTracker.addAttributionFromApply(this.REMHardcastAttrib, event);
     } else if (isFromRapidDiffusion(event)) {
       //rapid diffusion rem
-      this.hotTracker.addAttributionFromApply(this.rapidDiffusionAttrib, event);
-      hot.maxDuration = this.hotTracker._getRapidDiffusionMaxDuration(this.selectedCombatant);
-      hot.end = hot.originalEnd =
-        event.timestamp +
-        Number(this.hotTracker._getRapidDiffusionDuration(this.selectedCombatant));
-      rdDebug && this._newReMAttributionLogging(event, this.rapidDiffusionAttrib);
+      this._attributeRapidDiffusionRem(event, hot);
     } else if (isFromDancingMists(event)) {
       //dancing mists rem
-
-      const sourceRem = getSourceRem(event);
-      if (sourceRem) {
-        //set the data from the sourceRem if we can find it
-        this._setRemDataFromSource(sourceRem, event);
-      }
-      this.hotTracker.addAttributionFromApply(this.dancingMistAttrib, event);
-      dmDebug && this._newReMAttributionLogging(event, this.dancingMistAttrib);
+      this._attributeDancingMistRem(event);
     }
   }
 
@@ -238,10 +234,12 @@ class HotAttributor extends Analyzer {
           'on ' + this.combatants.getEntity(event)?.name,
           ' expected expiration: ' +
             this.owner.formatTimestamp(
-              event.timestamp + Number(this.hotTracker.hotInfo[event.ability.guid].procDuration),
+              event.timestamp +
+                Number(this.hotTracker._getRapidDiffusionDuration(this.selectedCombatant)),
               3,
             ),
           this.hotTracker.hots[event.targetID][event.ability.guid],
+          event,
         );
         break;
       }
@@ -265,28 +263,45 @@ class HotAttributor extends Analyzer {
     }
   }
 
-  private _setRemDataFromSource(
-    sourceRem: ApplyBuffEvent | RefreshBuffEvent,
-    event: ApplyBuffEvent | RefreshBuffEvent,
-  ) {
-    const spellID = event.ability.guid;
-    const dmHot = this.hotTracker.hots[event.targetID][spellID];
-    const sourceHot = this.hotTracker.hots[sourceRem.targetID][spellID];
-    if (sourceHot) {
-      dmHot.attributions = [];
-      if (this.hotTracker.fromRapidDiffusion(sourceHot)) {
-        this.hotTracker.addAttributionFromApply(this.dmSourceRDAttrib, event);
-      } else if (this.hotTracker.fromHardcast(sourceHot)) {
-        this.hotTracker.addAttributionFromApply(this.dmSourceHCAttrib, event);
-      } else if (this.hotTracker.fromMistsOfLife(sourceHot)) {
-        this.hotTracker.addAttributionFromApply(this.dmSourceMoLAttrib, event);
+  private _attributeDancingMistRem(event: ApplyBuffEvent | RefreshBuffEvent) {
+    const sourceRem = getSourceRem(event);
+    if (sourceRem) {
+      //set the data from the sourceRem if we can find it
+      const spellID = event.ability.guid;
+      const dmHot = this.hotTracker.hots[event.targetID][spellID];
+      const sourceHot = this.hotTracker.hots[sourceRem.targetID][spellID];
+      if (sourceHot) {
+        dmHot.attributions = [];
+        if (this.hotTracker.fromRapidDiffusion(sourceHot)) {
+          this.hotTracker.addAttributionFromApply(this.dmSourceRDAttrib, event);
+        } else if (this.hotTracker.fromHardcast(sourceHot)) {
+          this.hotTracker.addAttributionFromApply(this.dmSourceHCAttrib, event);
+        } else if (this.hotTracker.fromMistsOfLife(sourceHot)) {
+          this.hotTracker.addAttributionFromApply(this.dmSourceMoLAttrib, event);
+        }
+        dmHot.healingAfterOriginalEnd = 0;
+        dmHot.maxDuration = sourceHot.maxDuration;
+        dmHot.end = sourceHot.end;
+        dmHot.originalEnd = sourceHot.originalEnd;
+        dmHot.extensions = sourceHot.extensions;
       }
-      dmHot.healingAfterOriginalEnd = 0;
-      dmHot.maxDuration = sourceHot.maxDuration;
-      dmHot.end = sourceHot.end;
-      dmHot.originalEnd = sourceHot.originalEnd;
-      dmHot.extensions = sourceHot.extensions;
     }
+    this.hotTracker.addAttributionFromApply(this.dancingMistAttrib, event);
+    dmDebug && this._newReMAttributionLogging(event, this.dancingMistAttrib);
+  }
+
+  private _attributeRapidDiffusionRem(event: ApplyBuffEvent | RefreshBuffEvent, hot: Tracker) {
+    //rapid diffusion rem
+    this.hotTracker.addAttributionFromApply(this.rapidDiffusionAttrib, event);
+    if (isFromRapidDiffusionRisingSunKick(event)) {
+      this.hotTracker.addAttributionFromApply(this.rdSourceRSKAttrib, event);
+    } else if (isFromRapidDiffusionEnvelopingMist(event)) {
+      this.hotTracker.addAttributionFromApply(this.rdSourceENVAttrib, event);
+    }
+    hot.maxDuration = this.hotTracker._getRapidDiffusionMaxDuration(this.selectedCombatant);
+    hot.end = hot.originalEnd =
+      event.timestamp + Number(this.hotTracker._getRapidDiffusionDuration(this.selectedCombatant));
+    rdDebug && this._newReMAttributionLogging(event, this.rapidDiffusionAttrib);
   }
 }
 

--- a/src/analysis/retail/monk/mistweaver/modules/core/HotTrackerMW.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/HotTrackerMW.tsx
@@ -38,6 +38,18 @@ class HotTrackerMW extends HotTracker {
     this.risingMistActive = this.owner.selectedCombatant.hasTalent(TALENTS_MONK.RISING_MIST_TALENT);
   }
 
+  fromRapidDiffusionRisingSunKick(hot: Tracker): boolean {
+    return hot.attributions.some(function (attr) {
+      return attr.name === ATTRIBUTION_STRINGS.RAPID_DIFFUSION_SOURCES.RD_SOURCE_RSK;
+    });
+  }
+
+  fromRapidDiffusionEnvelopingMist(hot: Tracker): boolean {
+    return hot.attributions.some(function (attr) {
+      return attr.name === ATTRIBUTION_STRINGS.RAPID_DIFFUSION_SOURCES.RD_SOURCE_ENV;
+    });
+  }
+
   fromDancingMistRapidDiffusion(hot: Tracker): boolean {
     return hot.attributions.some(function (attr) {
       return attr.name === ATTRIBUTION_STRINGS.DANCING_MIST_SOURCES.DM_SOURCE_RD;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/AncientTeachings.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/AncientTeachings.tsx
@@ -259,7 +259,7 @@ class AncientTeachings extends Analyzer {
           </>
         }
         category={STATISTIC_CATEGORY.TALENTS}
-        position={STATISTIC_ORDER.OPTIONAL(1)}
+        position={STATISTIC_ORDER.OPTIONAL(0)}
         smallFooter
       >
         <TalentAggregateBars bars={this.getAncientTeachingsDataItems()}></TalentAggregateBars>

--- a/src/analysis/retail/monk/mistweaver/modules/spells/DancingMists.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/DancingMists.tsx
@@ -42,7 +42,7 @@ class DancingMists extends Analyzer {
   extraMistyPeaksAbsorb: number = 0;
 
   get totalHealing() {
-    return this.dancingMistReMHealing + this.dancingMistVivifyHealing;
+    return this.dancingMistReMHealing + this.dancingMistVivifyHealing + this.mistyPeaksHealingFromDancingMist;
   }
   get dancingMistReMHealing() {
     return this.dancingMistHealing + this.dancingMistAbsorbed;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/DancingMists.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/DancingMists.tsx
@@ -1,16 +1,17 @@
-import { formatNumber, formatPercentage } from 'common/format';
+import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
+import Spell from 'common/SPELLS/Spell';
 import { TALENTS_MONK } from 'common/TALENTS';
 import { SpellLink, TooltipElement } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { ApplyBuffEvent, HealEvent, RefreshBuffEvent } from 'parser/core/Events';
 import DonutChart from 'parser/ui/DonutChart';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
-import Statistic from 'parser/ui/Statistic';
 import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
-import TalentSpellText from 'parser/ui/TalentSpellText';
+import TalentAggregateBars from 'parser/ui/TalentAggregateStatistic';
+import TalentAggregateStatisticContainer from 'parser/ui/TalentAggregateStatisticContainer';
 import { SPELL_COLORS } from '../../constants';
 import { isFromMistyPeaks } from '../../normalizers/CastLinkNormalizer';
 import HotTrackerMW from '../core/HotTrackerMW';
@@ -23,45 +24,69 @@ class DancingMists extends Analyzer {
   };
   protected vivify!: Vivify;
   hotTracker!: HotTrackerMW;
+  //totals
   dancingMistCount: number = 0;
-  dancingMist_RapidDiffusion: number = 0;
-  dancingMist_HardCast: number = 0;
-  dancingMist_MistsOfLife: number = 0;
-  dancingMistHealing: number = 0;
-  dancingMistAbsorbed: number = 0;
+  dancingMistReMHealing: number = 0;
   dancingMistOverhealing: number = 0;
-  dancingMistVivifyCleaveHits: number = 0;
-  dancingMistMistyPeaksProcs: number = 0;
   extraVivCleaves: number = 0;
-  extraVivHealing: number = 0;
-  extraVivOverhealing: number = 0;
-  extraVivAbsorbed: number = 0;
   extraMistyPeaksProcs: number = 0;
   countedMainVivifyHit: boolean = false;
-  extraMistyPeaksHealing: number = 0;
-  extraMistyPeaksAbsorb: number = 0;
+  dancingMistVivifyHealing: number = 0;
+  extraVivOverhealing: number = 0;
+  mistyPeaksHealingFromDancingMist: number = 0;
+  //rapid diffusion
+  dancingMistRapidDiffusionCount: number = 0;
+  vivHealingFromRD: number = 0;
+  mpHealingFromRD: number = 0;
+  remHealingFromRD: number = 0;
+  //hard casts
+  dancingMistHardCastCount: number = 0;
+  vivHealingFromHardcast: number = 0;
+  mpHealingFromHardcast: number = 0;
+  remHealingFromHardcast: number = 0;
+  //mists of life
+  dancingMistMistsOfLifeCount: number = 0;
+  vivHealingFromMoL: number = 0;
+  mpHealingFromMoL: number = 0;
+  remHealingFromMol: number = 0;
+
+  get dancingMistItems() {
+    return [
+      {
+        spell: TALENTS_MONK.MISTY_PEAKS_TALENT,
+        amount: this.mistyPeaksHealingFromDancingMist,
+        color: SPELL_COLORS.MISTY_PEAKS,
+        tooltip: this.getBarTooltip(TALENTS_MONK.MISTY_PEAKS_TALENT),
+      },
+      {
+        spell: SPELLS.VIVIFY,
+        amount: this.dancingMistVivifyHealing,
+        color: SPELL_COLORS.VIVIFY,
+        tooltip: this.getBarTooltip(SPELLS.VIVIFY),
+      },
+      {
+        spell: TALENTS_MONK.RENEWING_MIST_TALENT,
+        amount: this.dancingMistReMHealing,
+        color: SPELL_COLORS.RENEWING_MIST,
+        tooltip: this.getBarTooltip(TALENTS_MONK.RENEWING_MIST_TALENT),
+      },
+    ];
+  }
 
   get totalHealing() {
-    return this.dancingMistReMHealing + this.dancingMistVivifyHealing + this.mistyPeaksHealingFromDancingMist;
-  }
-  get dancingMistReMHealing() {
-    return this.dancingMistHealing + this.dancingMistAbsorbed;
-  }
-
-  get dancingMistVivifyHealing() {
-    return this.extraVivHealing + this.extraVivAbsorbed;
-  }
-
-  get mistyPeaksHealingFromDancingMist() {
-    return this.extraMistyPeaksHealing + this.extraMistyPeaksAbsorb;
+    return (
+      this.dancingMistReMHealing +
+      this.dancingMistVivifyHealing +
+      this.mistyPeaksHealingFromDancingMist
+    );
   }
 
   get bounceProcs() {
     return (
       this.dancingMistCount -
-      this.dancingMist_HardCast -
-      this.dancingMist_RapidDiffusion -
-      this.dancingMist_MistsOfLife
+      this.dancingMistHardCastCount -
+      this.dancingMistRapidDiffusionCount -
+      this.dancingMistMistsOfLifeCount
     );
   }
 
@@ -71,21 +96,21 @@ class DancingMists extends Analyzer {
         color: SPELL_COLORS.RENEWING_MIST,
         label: 'Hardcast',
         spellId: TALENTS_MONK.RENEWING_MIST_TALENT.id,
-        value: this.dancingMist_HardCast,
+        value: this.dancingMistHardCastCount,
         valuePercent: false,
       },
       {
         color: SPELL_COLORS.RAPID_DIFFUSION,
         label: 'Rapid Diffusion',
         spellId: TALENTS_MONK.RAPID_DIFFUSION_TALENT.id,
-        value: this.dancingMist_RapidDiffusion,
+        value: this.dancingMistRapidDiffusionCount,
         valuePercent: false,
       },
       {
         color: SPELL_COLORS.ENVELOPING_MIST,
         label: 'Mists of Life',
         spellId: TALENTS_MONK.MISTS_OF_LIFE_TALENT.id,
-        value: this.dancingMist_MistsOfLife,
+        value: this.dancingMistMistsOfLifeCount,
         valuePercent: false,
       },
       {
@@ -129,6 +154,91 @@ class DancingMists extends Analyzer {
     );
   }
 
+  getBarTooltip(spell: Spell) {
+    let rdSourceHealing = 0;
+    let hardcastSourceHealing = 0;
+    let molSourceHealing = 0;
+    let bounceHealing = 0;
+    let procs = 0;
+    switch (spell.id) {
+      case TALENTS_MONK.RENEWING_MIST_TALENT.id:
+        rdSourceHealing = this.remHealingFromRD;
+        hardcastSourceHealing = this.remHealingFromHardcast;
+        molSourceHealing = this.remHealingFromMol;
+        bounceHealing =
+          this.dancingMistReMHealing -
+          this.remHealingFromRD -
+          this.remHealingFromHardcast -
+          this.remHealingFromMol;
+        procs = this.dancingMistCount;
+        break;
+      case TALENTS_MONK.MISTY_PEAKS_TALENT.id:
+        rdSourceHealing = this.mpHealingFromRD;
+        hardcastSourceHealing = this.mpHealingFromHardcast;
+        molSourceHealing = this.mpHealingFromMoL;
+        bounceHealing =
+          this.mistyPeaksHealingFromDancingMist -
+          this.mpHealingFromHardcast -
+          this.mpHealingFromRD -
+          this.mpHealingFromMoL;
+        procs = this.extraMistyPeaksProcs;
+        break;
+      case SPELLS.VIVIFY.id:
+        rdSourceHealing = this.vivHealingFromRD;
+        hardcastSourceHealing = this.vivHealingFromHardcast;
+        molSourceHealing = this.vivHealingFromMoL;
+        bounceHealing =
+          this.dancingMistVivifyHealing -
+          this.vivHealingFromHardcast -
+          this.vivHealingFromMoL -
+          this.vivHealingFromRD;
+        procs = this.extraVivCleaves;
+        break;
+    }
+    const items = [
+      {
+        color: SPELL_COLORS.RAPID_DIFFUSION,
+        label: 'Rapid Diffusion',
+        spellId: TALENTS_MONK.RAPID_DIFFUSION_TALENT.id,
+        value: rdSourceHealing,
+        valuePercent: false,
+      },
+      {
+        color: SPELL_COLORS.RENEWING_MIST,
+        label: 'Hardcast',
+        spellId: TALENTS_MONK.RENEWING_MIST_TALENT.id,
+        value: hardcastSourceHealing,
+        valuePercent: false,
+      },
+      {
+        color: SPELL_COLORS.ENVELOPING_MIST,
+        label: 'Mists of Life',
+        spellId: TALENTS_MONK.MISTS_OF_LIFE_TALENT.id,
+        value: molSourceHealing,
+        valuePercent: false,
+      },
+      {
+        color: SPELL_COLORS.DANCING_MIST,
+        label: 'Bounces',
+        spellId: TALENTS_MONK.RENEWING_MIST_TALENT.id,
+        value: bounceHealing,
+        valuePercent: false,
+      },
+    ].filter((item) => {
+      return item.value > 0;
+    });
+
+    return (
+      <>
+        <strong>{procs}</strong> additional <SpellLink id={spell.id} />{' '}
+        {spell.id === SPELLS.VIVIFY.id ? <>cleaves</> : <>procs</>} from <br />
+        <SpellLink id={TALENTS_MONK.DANCING_MISTS_TALENT} /> by duplication source:
+        <hr />
+        <DonutChart items={items} />
+      </>
+    );
+  }
+
   onApplyRem(event: ApplyBuffEvent) {
     const playerId = event.targetID;
     if (
@@ -139,9 +249,11 @@ class DancingMists extends Analyzer {
     }
     const hot = this.hotTracker.hots[playerId][SPELLS.RENEWING_MIST_HEAL.id];
     if (this.hotTracker.fromDancingMists(hot) && !this.hotTracker.fromBounce(hot)) {
-      this.dancingMist_HardCast += this.hotTracker.fromDancingMistHardCast(hot) ? 1 : 0;
-      this.dancingMist_RapidDiffusion += this.hotTracker.fromDancingMistRapidDiffusion(hot) ? 1 : 0;
-      this.dancingMist_MistsOfLife += this.hotTracker.fromDancingMistMistsOfLife(hot) ? 1 : 0;
+      this.dancingMistHardCastCount += this.hotTracker.fromDancingMistHardCast(hot) ? 1 : 0;
+      this.dancingMistRapidDiffusionCount += this.hotTracker.fromDancingMistRapidDiffusion(hot)
+        ? 1
+        : 0;
+      this.dancingMistMistsOfLifeCount += this.hotTracker.fromDancingMistMistsOfLife(hot) ? 1 : 0;
       this.dancingMistCount += 1;
     }
   }
@@ -156,8 +268,14 @@ class DancingMists extends Analyzer {
     }
     const hot = this.hotTracker.hots[playerId][SPELLS.RENEWING_MIST_HEAL.id];
     if (this.hotTracker.fromDancingMists(hot)) {
-      this.dancingMistHealing += event.amount || 0;
-      this.dancingMistAbsorbed += event.absorbed || 0;
+      if (this.hotTracker.fromDancingMistRapidDiffusion(hot)) {
+        this.remHealingFromRD += event.amount + (event.absorbed || 0);
+      } else if (this.hotTracker.fromDancingMistHardCast(hot)) {
+        this.remHealingFromHardcast += event.amount + (event.absorbed || 0);
+      } else if (this.hotTracker.fromDancingMistMistsOfLife(hot)) {
+        this.remHealingFromMol += event.amount + (event.absorbed || 0);
+      }
+      this.dancingMistReMHealing += event.amount + (event.absorbed || 0);
       this.dancingMistOverhealing += event.overheal || 0;
     }
   }
@@ -177,10 +295,16 @@ class DancingMists extends Analyzer {
     }
     const hot = this.hotTracker.hots[targetId][SPELLS.RENEWING_MIST_HEAL.id];
     if (this.hotTracker.fromDancingMists(hot)) {
+      if (this.hotTracker.fromDancingMistRapidDiffusion(hot)) {
+        this.vivHealingFromRD += event.amount + (event.absorbed || 0);
+      } else if (this.hotTracker.fromDancingMistHardCast(hot)) {
+        this.vivHealingFromHardcast += event.amount + (event.absorbed || 0);
+      } else if (this.hotTracker.fromDancingMistMistsOfLife(hot)) {
+        this.vivHealingFromMoL += event.amount + (event.absorbed || 0);
+      }
       this.extraVivCleaves += 1;
-      this.extraVivHealing += event.amount || 0;
       this.extraVivOverhealing += event.overheal || 0;
-      this.extraVivAbsorbed += event.absorbed || 0;
+      this.dancingMistVivifyHealing += event.amount + (event.absorbed || 0);
     }
   }
 
@@ -217,8 +341,14 @@ class DancingMists extends Analyzer {
       }
       const hot = this.hotTracker.hots[playerId][TALENTS_MONK.ENVELOPING_MIST_TALENT.id];
       if (this.hotTracker.fromMistyPeaks(hot)) {
-        this.extraMistyPeaksHealing += event.amount || 0;
-        this.extraMistyPeaksAbsorb += event.absorbed || 0;
+        if (this.hotTracker.fromDancingMistRapidDiffusion(remHot)) {
+          this.mpHealingFromRD += event.amount + (event.absorbed || 0);
+        } else if (this.hotTracker.fromDancingMistHardCast(remHot)) {
+          this.mpHealingFromHardcast += event.amount + (event.absorbed || 0);
+        } else if (this.hotTracker.fromDancingMistMistsOfLife(remHot)) {
+          this.mpHealingFromMoL += event.amount + (event.absorbed || 0);
+        }
+        this.mistyPeaksHealingFromDancingMist += event.amount + (event.absorbed || 0);
       }
     }
   }
@@ -236,41 +366,17 @@ class DancingMists extends Analyzer {
 
   statistic() {
     return (
-      <Statistic
-        position={STATISTIC_ORDER.CORE(3)}
-        size="flexible"
-        category={STATISTIC_CATEGORY.TALENTS}
-        tooltip={
-          <ul>
-            {this.selectedCombatant.hasTalent(TALENTS_MONK.MISTY_PEAKS_TALENT) && (
-              <li>
-                Extra <SpellLink id={TALENTS_MONK.MISTY_PEAKS_TALENT.id} /> procs:{' '}
-                {formatNumber(this.extraMistyPeaksProcs)}
-              </li>
-            )}
-            {this.selectedCombatant.hasTalent(TALENTS_MONK.MISTY_PEAKS_TALENT) && (
-              <li>
-                Extra <SpellLink id={TALENTS_MONK.MISTY_PEAKS_TALENT.id} /> healing:{' '}
-                {formatNumber(this.mistyPeaksHealingFromDancingMist)}
-              </li>
-            )}
-            <li>
-              Extra <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT.id} /> direct healing:{' '}
-              {formatNumber(this.dancingMistReMHealing)}
-            </li>
-            <li>
-              Extra <SpellLink id={SPELLS.VIVIFY.id} /> cleaves: {this.extraVivCleaves}
-            </li>
-            <li>
-              Extra <SpellLink id={SPELLS.VIVIFY.id} /> healing:{' '}
-              {formatNumber(this.extraVivHealing)}
-            </li>
-          </ul>
+      <TalentAggregateStatisticContainer
+        title={
+          <>
+            <SpellLink id={TALENTS_MONK.DANCING_MISTS_TALENT} /> -{' '}
+            <ItemHealingDone amount={this.totalHealing} displayPercentage={false} />
+          </>
         }
-      >
-        <TalentSpellText talent={TALENTS_MONK.DANCING_MISTS_TALENT}>
-          <ItemHealingDone amount={this.totalHealing} />
-          <br />
+        category={STATISTIC_CATEGORY.TALENTS}
+        position={STATISTIC_ORDER.CORE(3)}
+        smallFooter
+        footer={
           <TooltipElement
             content={
               <>
@@ -287,8 +393,10 @@ class DancingMists extends Analyzer {
               duplicated <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT} />
             </small>
           </TooltipElement>
-        </TalentSpellText>
-      </Statistic>
+        }
+      >
+        <TalentAggregateBars bars={this.dancingMistItems} />
+      </TalentAggregateStatisticContainer>
     );
   }
 }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
@@ -414,7 +414,7 @@ class InvokeChiJi extends BaseCelestialAnalyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(2)}
+        position={STATISTIC_ORDER.OPTIONAL(1)}
         category={STATISTIC_CATEGORY.TALENTS}
         size="flexible"
         tooltip={

--- a/src/analysis/retail/monk/mistweaver/modules/spells/MistyPeaks.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/MistyPeaks.tsx
@@ -117,6 +117,9 @@ class MistyPeaks extends Analyzer {
         tooltip={
           <ul>
             <li>
+              <SpellLink id={TALENTS_MONK.MISTY_PEAKS_TALENT.id}/> procs: {this.numHots}
+            </li>
+            <li>
               <SpellLink id={TALENTS_MONK.ENVELOPING_MIST_TALENT.id} /> extra hits: {this.extraHits}
             </li>
             <li>

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RapidDiffusion.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RapidDiffusion.tsx
@@ -34,7 +34,11 @@ class RapidDiffusion extends Analyzer {
   }
 
   get totalHealing() {
-    return this.totalRemThroughput + this.totalVivifyThroughput + this.mistyPeaksHealingFromRapidDiffusion;
+    return (
+      this.totalRemThroughput +
+      this.totalVivifyThroughput +
+      this.mistyPeaksHealingFromRapidDiffusion
+    );
   }
 
   get rapidDiffusionItems() {
@@ -156,7 +160,8 @@ class RapidDiffusion extends Analyzer {
     ];
     return (
       <>
-        <strong>{procs}</strong> additional <SpellLink id={spell.id} /> from <br />
+        <strong>{procs}</strong> additional <SpellLink id={spell.id} />{' '}
+        {spell.id === SPELLS.VIVIFY.id ? <>cleaves</> : <>procs</>} from <br />
         <SpellLink id={TALENTS_MONK.RAPID_DIFFUSION_TALENT} />{' '}
         {spell.id !== TALENTS_MONK.RENEWING_MIST_TALENT.id && (
           <>

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RapidDiffusion.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RapidDiffusion.tsx
@@ -124,7 +124,7 @@ class RapidDiffusion extends Analyzer {
   getBarTooltip(spell: Spell) {
     let rskSourceHealing = 0;
     let envSourceHealing = 0;
-    let procs;
+    let procs = 0;
     switch (spell.id) {
       case TALENTS_MONK.RENEWING_MIST_TALENT.id:
         rskSourceHealing = this.remHealingFromRSK;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RapidDiffusion.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RapidDiffusion.tsx
@@ -34,7 +34,7 @@ class RapidDiffusion extends Analyzer {
   }
 
   get totalHealing() {
-    return this.totalRemThroughput + this.totalVivifyThroughput;
+    return this.totalRemThroughput + this.totalVivifyThroughput + this.mistyPeaksHealingFromRapidDiffusion;
   }
 
   get rapidDiffusionItems() {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RapidDiffusion.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RapidDiffusion.tsx
@@ -5,17 +5,20 @@ import Events, { ApplyBuffEvent, HealEvent, RefreshBuffEvent } from 'parser/core
 import HotTrackerMW from '../core/HotTrackerMW';
 import MistyPeaks from './MistyPeaks';
 import Vivify from './Vivify';
-import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
-import TalentSpellText from 'parser/ui/TalentSpellText';
 import SpellLink from 'interface/SpellLink';
 import Combatants from 'parser/shared/modules/Combatants';
-import { formatNumber, formatPercentage } from 'common/format';
+import { formatPercentage } from 'common/format';
 import { TooltipElement } from 'interface';
 import { isFromMistyPeaks } from '../../normalizers/CastLinkNormalizer';
 import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
+import TalentAggregateStatisticContainer from 'parser/ui/TalentAggregateStatisticContainer';
+import TalentAggregateBars from 'parser/ui/TalentAggregateStatistic';
+import { SPELL_COLORS } from '../../constants';
+import DonutChart from 'parser/ui/DonutChart';
+import Spell from 'common/SPELLS/Spell';
 
 class RapidDiffusion extends Analyzer {
   get totalRemThroughput() {
@@ -34,6 +37,29 @@ class RapidDiffusion extends Analyzer {
     return this.totalRemThroughput + this.totalVivifyThroughput;
   }
 
+  get rapidDiffusionItems() {
+    return [
+      {
+        spell: TALENTS_MONK.MISTY_PEAKS_TALENT,
+        amount: this.mistyPeaksHealingFromRapidDiffusion,
+        color: SPELL_COLORS.MISTY_PEAKS,
+        tooltip: this.getBarTooltip(TALENTS_MONK.MISTY_PEAKS_TALENT),
+      },
+      {
+        spell: SPELLS.VIVIFY,
+        amount: this.totalVivifyThroughput,
+        color: SPELL_COLORS.VIVIFY,
+        tooltip: this.getBarTooltip(SPELLS.VIVIFY),
+      },
+      {
+        spell: TALENTS_MONK.RENEWING_MIST_TALENT,
+        amount: this.totalRemThroughput,
+        color: SPELL_COLORS.RENEWING_MIST,
+        tooltip: this.getBarTooltip(TALENTS_MONK.RENEWING_MIST_TALENT),
+      },
+    ];
+  }
+
   static dependencies = {
     hotTracker: HotTrackerMW,
     combatants: Combatants,
@@ -46,15 +72,21 @@ class RapidDiffusion extends Analyzer {
   vivify!: Vivify;
   remCount: number = 0;
   remHealing: number = 0;
+  remHealingFromRSK: number = 0;
+  remHealingFromEnv: number = 0;
   remAbsorbed: number = 0;
   remOverHealing: number = 0;
   extraMistyPeaksProcs: number = 0;
   extraVivCleaves: number = 0;
   extraVivHealing: number = 0;
+  vivHealingFromRskRem: number = 0;
+  vivHealingFromEnvRem: number = 0;
   extraVivOverhealing: number = 0;
   extraVivAbsorbed: number = 0;
   extraMistyPeaksHealing: number = 0;
   extraMistyPeaksAbsorb: number = 0;
+  mistyPeakHealingFromRskRem: number = 0;
+  mistyPeakHealingFromEnvRem: number = 0;
 
   constructor(options: Options) {
     super(options);
@@ -85,6 +117,59 @@ class RapidDiffusion extends Analyzer {
     );
   }
 
+  getBarTooltip(spell: Spell) {
+    let rskSourceHealing = 0;
+    let envSourceHealing = 0;
+    let procs;
+    switch (spell.id) {
+      case TALENTS_MONK.RENEWING_MIST_TALENT.id:
+        rskSourceHealing = this.remHealingFromRSK;
+        envSourceHealing = this.remHealingFromEnv;
+        procs = this.remCount;
+        break;
+      case TALENTS_MONK.MISTY_PEAKS_TALENT.id:
+        rskSourceHealing = this.mistyPeakHealingFromRskRem;
+        envSourceHealing = this.mistyPeakHealingFromEnvRem;
+        procs = this.extraMistyPeaksProcs;
+        break;
+      case SPELLS.VIVIFY.id:
+        rskSourceHealing = this.vivHealingFromRskRem;
+        envSourceHealing = this.vivHealingFromEnvRem;
+        procs = this.extraVivCleaves;
+        break;
+    }
+    const items = [
+      {
+        color: SPELL_COLORS.RISING_SUN_KICK,
+        label: 'Rising Sun Kick',
+        spellId: TALENTS_MONK.RISING_SUN_KICK_TALENT.id,
+        value: rskSourceHealing,
+        valuePercent: false,
+      },
+      {
+        color: SPELL_COLORS.ENVELOPING_MIST,
+        label: 'Enveloping Mist',
+        spellId: TALENTS_MONK.ENVELOPING_MIST_TALENT.id,
+        value: envSourceHealing,
+        valuePercent: false,
+      },
+    ];
+    return (
+      <>
+        <strong>{procs}</strong> additional <SpellLink id={spell.id} /> from <br />
+        <SpellLink id={TALENTS_MONK.RAPID_DIFFUSION_TALENT} />{' '}
+        {spell.id !== TALENTS_MONK.RENEWING_MIST_TALENT.id && (
+          <>
+            <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT} />s<br />
+          </>
+        )}{' '}
+        by source ability:
+        <hr />
+        <DonutChart items={items} />
+      </>
+    );
+  }
+
   handleReMApply(event: ApplyBuffEvent) {
     const playerId = event.targetID;
     if (
@@ -109,6 +194,11 @@ class RapidDiffusion extends Analyzer {
     }
     const hot = this.hotTracker.hots[playerId][SPELLS.RENEWING_MIST_HEAL.id];
     if (this.hotTracker.fromRapidDiffusion(hot)) {
+      if (this.hotTracker.fromRapidDiffusionRisingSunKick(hot)) {
+        this.remHealingFromRSK += event.amount + (event.absorbed || 0);
+      } else if (this.hotTracker.fromRapidDiffusionEnvelopingMist(hot)) {
+        this.remHealingFromEnv += event.amount + (event.absorbed || 0);
+      }
       this.remHealing += event.amount || 0;
       this.remAbsorbed += event.absorbed || 0;
       this.remOverHealing += event.overheal || 0;
@@ -130,6 +220,11 @@ class RapidDiffusion extends Analyzer {
     }
     const hot = this.hotTracker.hots[targetId][SPELLS.RENEWING_MIST_HEAL.id];
     if (this.hotTracker.fromRapidDiffusion(hot)) {
+      if (this.hotTracker.fromRapidDiffusionRisingSunKick(hot)) {
+        this.vivHealingFromRskRem += event.amount + (event.absorbed || 0);
+      } else if (this.hotTracker.fromRapidDiffusionEnvelopingMist(hot)) {
+        this.vivHealingFromEnvRem += event.amount + (event.absorbed || 0);
+      }
       this.extraVivCleaves += 1;
       this.extraVivHealing += event.amount || 0;
       this.extraVivOverhealing += event.overheal || 0;
@@ -170,6 +265,11 @@ class RapidDiffusion extends Analyzer {
       }
       const hot = this.hotTracker.hots[playerId][TALENTS_MONK.ENVELOPING_MIST_TALENT.id];
       if (this.hotTracker.fromMistyPeaks(hot)) {
+        if (this.hotTracker.fromRapidDiffusionRisingSunKick(remHot)) {
+          this.mistyPeakHealingFromRskRem += event.amount + (event.absorbed || 0);
+        } else if (this.hotTracker.fromRapidDiffusionEnvelopingMist(remHot)) {
+          this.mistyPeakHealingFromEnvRem += event.amount + (event.absorbed || 0);
+        }
         this.extraMistyPeaksHealing += event.amount || 0;
         this.extraMistyPeaksAbsorb += event.absorbed || 0;
       }
@@ -189,36 +289,17 @@ class RapidDiffusion extends Analyzer {
 
   statistic() {
     return (
-      <Statistic
-        position={STATISTIC_ORDER.CORE(2)}
-        size="flexible"
-        category={STATISTIC_CATEGORY.TALENTS}
-        tooltip={
-          <ul>
-            {this.selectedCombatant.hasTalent(TALENTS_MONK.MISTY_PEAKS_TALENT) && (
-              <li>
-                Extra <SpellLink id={TALENTS_MONK.MISTY_PEAKS_TALENT.id} /> procs:{' '}
-                {formatNumber(this.extraMistyPeaksProcs)}
-              </li>
-            )}
-            {this.selectedCombatant.hasTalent(TALENTS_MONK.MISTY_PEAKS_TALENT) && (
-              <li>
-                Extra <SpellLink id={TALENTS_MONK.MISTY_PEAKS_TALENT.id} /> healing:{' '}
-                {formatNumber(this.mistyPeaksHealingFromRapidDiffusion)}
-              </li>
-            )}
-            <li>
-              Additional <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT.id} /> Total Throughput:{' '}
-              {formatNumber(this.totalRemThroughput)}
-            </li>
-            <li>Extra Vivify Cleaves: {this.extraVivCleaves}</li>
-            <li>Extra Vivify Healing: {formatNumber(this.totalVivifyThroughput)}</li>
-          </ul>
+      <TalentAggregateStatisticContainer
+        title={
+          <>
+            <SpellLink id={TALENTS_MONK.RAPID_DIFFUSION_TALENT} /> -{' '}
+            <ItemHealingDone amount={this.totalHealing} displayPercentage={false} />
+          </>
         }
-      >
-        <TalentSpellText talent={TALENTS_MONK.RAPID_DIFFUSION_TALENT}>
-          <ItemHealingDone amount={this.totalHealing} />
-          <br />
+        category={STATISTIC_CATEGORY.TALENTS}
+        position={STATISTIC_ORDER.CORE(2)}
+        smallFooter
+        footer={
           <TooltipElement
             content={
               <>
@@ -234,8 +315,10 @@ class RapidDiffusion extends Analyzer {
               additional <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT} />
             </small>
           </TooltipElement>
-        </TalentSpellText>
-      </Statistic>
+        }
+      >
+        <TalentAggregateBars bars={this.rapidDiffusionItems} />
+      </TalentAggregateStatisticContainer>
     );
   }
 }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ShaohaosLessons.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ShaohaosLessons.tsx
@@ -199,7 +199,7 @@ class ShaohaosLessons extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(0)}
+        position={STATISTIC_ORDER.OPTIONAL(2)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={

--- a/src/analysis/retail/monk/mistweaver/modules/spells/SheilunsGift.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/SheilunsGift.tsx
@@ -112,7 +112,7 @@ class SheilunsGift extends Analyzer {
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(0)}
+        position={STATISTIC_ORDER.OPTIONAL(2)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
       >

--- a/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
@@ -388,6 +388,9 @@ export function isFromRapidDiffusion(event: ApplyBuffEvent | RefreshBuffEvent) {
 }
 
 export function isFromRapidDiffusionRisingSunKick(event: ApplyBuffEvent | RefreshBuffEvent) {
+   if(!HasRelatedEvent(event, FROM_RAPID_DIFFUSION)){
+    return false;
+  }
   const rdSourceEvent = GetRelatedEvents(event, FROM_RAPID_DIFFUSION);
   return (
     rdSourceEvent[0].type === EventType.Cast &&
@@ -396,6 +399,9 @@ export function isFromRapidDiffusionRisingSunKick(event: ApplyBuffEvent | Refres
 }
 
 export function isFromRapidDiffusionEnvelopingMist(event: ApplyBuffEvent | RefreshBuffEvent) {
+  if(!HasRelatedEvent(event, FROM_RAPID_DIFFUSION)){
+    return false;
+  }
   const rdSourceEvent = GetRelatedEvents(event, FROM_RAPID_DIFFUSION);
   return (
     rdSourceEvent[0].type === EventType.Cast &&

--- a/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
@@ -387,6 +387,22 @@ export function isFromRapidDiffusion(event: ApplyBuffEvent | RefreshBuffEvent) {
   return HasRelatedEvent(event, FROM_RAPID_DIFFUSION);
 }
 
+export function isFromRapidDiffusionRisingSunKick(event: ApplyBuffEvent | RefreshBuffEvent) {
+  const rdSourceEvent = GetRelatedEvents(event, FROM_RAPID_DIFFUSION);
+  return (
+    rdSourceEvent[0].type === EventType.Cast &&
+    rdSourceEvent[0].ability.guid === TALENTS_MONK.RISING_SUN_KICK_TALENT.id
+  );
+}
+
+export function isFromRapidDiffusionEnvelopingMist(event: ApplyBuffEvent | RefreshBuffEvent) {
+  const rdSourceEvent = GetRelatedEvents(event, FROM_RAPID_DIFFUSION);
+  return (
+    rdSourceEvent[0].type === EventType.Cast &&
+    rdSourceEvent[0].ability.guid === TALENTS_MONK.ENVELOPING_MIST_TALENT.id
+  );
+}
+
 export function isFromMistsOfLife(event: ApplyBuffEvent | RefreshBuffEvent): boolean {
   return HasRelatedEvent(event, FROM_MISTS_OF_LIFE);
 }


### PR DESCRIPTION
### Description

Added source attribution to rapid diffusion in the hot attributor
Updated Rapid Diffusion to use the Talent Aggregate component for more detail
Updated Dancing Mist to use the Talent Aggregate component for more detail
Added Misty Peaks healing into the overall HPS for both talents now that the breakdown is more detailed to avoid confusion
### Testing

- Test report URL: `/report/...`
### Screenshot(s):
Before: 
![image](https://user-images.githubusercontent.com/26779541/221983417-88cfa69f-1c27-4135-914f-98ef1dabf542.png)
![image](https://user-images.githubusercontent.com/26779541/221983522-b9c911f2-23c4-4067-bbbd-43611d56d04c.png)
![image](https://user-images.githubusercontent.com/26779541/221983599-52afc964-4176-4f8b-9488-41ed7ba8ea65.png)

After: 
![image](https://user-images.githubusercontent.com/26779541/221983742-e56d2bad-12ce-47e5-b324-773f3c640336.png)
![image](https://user-images.githubusercontent.com/26779541/221983912-6c56bee2-57cf-410f-8ff9-0814e04a1549.png)
![image](https://user-images.githubusercontent.com/26779541/221983954-59084701-da71-4896-bf0c-d7ae6857c0d6.png)

