### PR TITLE
fix combatants not being dispatched

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -21,6 +21,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 3, 6), 'Fix combatants not being dispatched to the Redux store.', ToppleTheNun),
   change(date(2023, 3, 4), 'Add Playwright tests for validating application behavior.', ToppleTheNun),
   change(date(2023, 3, 3), 'Fix "leech" event throwing errors during development for classic logs.', ToppleTheNun),
   change(date(2023, 2, 25), 'Fix development issue with CastEfficiency dumping large errors in the console.', emallson),

--- a/src/interface/report/PlayerLoader.tsx
+++ b/src/interface/report/PlayerLoader.tsx
@@ -34,6 +34,7 @@ import PlayerSelection from './PlayerSelection';
 import { getPlayerIdFromParam } from 'interface/selectors/url/report/getPlayerId';
 import { getPlayerNameFromParam } from 'interface/selectors/url/report/getPlayerName';
 import { isClassicExpansion } from 'game/Expansion';
+import { useWaDispatch } from 'interface/utils/useWaDispatch';
 
 const FAKE_PLAYER_IF_DEV_ENV = false;
 
@@ -136,6 +137,7 @@ const PlayerLoader = ({ children }: Props) => {
   const { fight: selectedFight } = useFight();
   const { player: playerParam } = useParams();
   const navigate = useNavigate();
+  const dispatch = useWaDispatch();
   const playerId = getPlayerIdFromParam(playerParam);
   const playerName = getPlayerNameFromParam(playerParam);
 
@@ -209,7 +211,7 @@ const PlayerLoader = ({ children }: Props) => {
         }
         dispatchFC({ type: 'set_combatants', combatants, combatantsFightId: fight.id });
         // We need to set the combatants in the global state so the NavigationBar, which is not a child of this component, can also use it
-        setCombatants(combatants);
+        dispatch(setCombatants(combatants));
       } catch (error) {
         const isCommonError = error instanceof LogNotFoundError;
         if (!isCommonError) {
@@ -217,10 +219,10 @@ const PlayerLoader = ({ children }: Props) => {
         }
         dispatchFC({ type: 'set_error', error: error as Error });
         // We need to set the combatants in the global state so the NavigationBar, which is not a child of this component, can also use it
-        setCombatants(null);
+        dispatch(setCombatants(null));
       }
     },
-    [selectedFight, selectedReport],
+    [dispatch, selectedFight, selectedReport],
   );
 
   useEffect(() => {

--- a/src/parser/core/Combatant.ts
+++ b/src/parser/core/Combatant.ts
@@ -190,11 +190,12 @@ class Combatant extends Entity {
       });
 
     gear.forEach((item, index) => {
-      if (item.setID !== undefined && equipedSets[item.setID] !== undefined) {
-        item.setItemIDs = equipedSets[item.setID];
+      const equippedItem = { ...item };
+      if (equippedItem.setID !== undefined && equipedSets[equippedItem.setID] !== undefined) {
+        equippedItem.setItemIDs = equipedSets[equippedItem.setID];
       }
 
-      this._gearItemsBySlotId[index] = item;
+      this._gearItemsBySlotId[index] = equippedItem;
     });
   }
 


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Dispatch combatants to the Redux store.

### Motivation

<!-- Why are you submitting this pull request?-->

Uncovered a fun bug that was nested two layers deep. Turns out that after the change to make the PlayerLoader an FC, it wasn't dispatching the combatants to the Redux store like it was previously - this didn't cause issues because nowhere is reading it. I fixed that bug and then started getting crashes when trying to look at a report. After doing some investigation, it's because of this line in Combatants.ts:
```
item.setItemIDs = equipedSets[item.setID];
```

It modifies the `Item` passed to it, which has the side effect of modifying the Redux store. The solution was to make a copy of the item before modifying it.

The crash in question:
![image](https://user-images.githubusercontent.com/1672786/223227250-4c1301a2-a06a-4409-82ed-2bd4faa5272e.png)