### PR TITLE
added Dark Reprimand to castigation

### DIFF
--- a/src/analysis/retail/priest/discipline/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/discipline/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 3, 7), <><SpellLink id={TALENTS_PRIEST.CASTIGATION_TALENT.id}/> working with <SpellLink id={SPELLS.DARK_REPRIMAND_CAST.id}/></>, Hana),
   change(date(2023, 2, 6), <><SpellLink id={TALENTS_PRIEST.TWILIGHT_EQUILIBRIUM_TALENT.id}/> re enabled.</>, Hana),
   change(date(2023, 2, 2), <><SpellLink id={TALENTS_PRIEST.ATONEMENT_TALENT.id}/> graph updated.</>, Hana),
   change(date(2023, 1, 29), <><SpellLink id={TALENTS_PRIEST.ABYSSAL_REVERIE_TALENT.id}/> module added.</>, Hana),

--- a/src/analysis/retail/priest/discipline/modules/spells/Castigation.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/Castigation.tsx
@@ -46,7 +46,11 @@ class Castigation extends Analyzer {
       return;
     }
 
-    if (damageEvent.ability.guid !== SPELLS.PENANCE.id || damageEvent.penanceBoltNumber !== 3) {
+    if (
+      (damageEvent.ability.guid !== SPELLS.PENANCE.id &&
+        damageEvent.ability.guid !== SPELLS.DARK_REPRIMAND_DAMAGE.id) ||
+      damageEvent.penanceBoltNumber !== 3
+    ) {
       return;
     }
     this.healing += event.amount;
@@ -57,7 +61,11 @@ class Castigation extends Analyzer {
       return;
     }
 
-    if (event.ability.guid !== SPELLS.PENANCE.id || event.penanceBoltNumber !== 3) {
+    if (
+      (event.ability.guid !== SPELLS.PENANCE.id &&
+        event.ability.guid !== SPELLS.DARK_REPRIMAND_DAMAGE.id) ||
+      event.penanceBoltNumber !== 3
+    ) {
       return;
     }
 
@@ -72,7 +80,7 @@ class Castigation extends Analyzer {
     const spellId = event.ability.guid;
 
     // Friendly Penance Healing
-    if (spellId === SPELLS.PENANCE_HEAL.id) {
+    if (spellId === SPELLS.PENANCE_HEAL.id || spellId === SPELLS.DARK_REPRIMAND_HEAL.id) {
       if (event.penanceBoltNumber === 3) {
         this.healing += event.amount;
       }


### PR DESCRIPTION
### Description

Castigation now also tracks damage and healing done from bolts of dark reprimand generated by the talent.
### Testing

<!-- How can the reviewer test your changes (if applicable)? -->
https://wowanalyzer.com/report/VpzmTdNgyGFbcfvH/48-Mythic+Terros+-+Kill+(4:28)/K%C3%A4rryy/standard/statistics
- Test report URL: `/report/...`
- Screenshot(s):
![image](https://user-images.githubusercontent.com/80196301/223511388-4049c1d1-309c-447a-bf65-55f5f5302f2b.png)

![image](https://user-images.githubusercontent.com/80196301/223511463-6cbe2ac7-20b6-4f7e-b65d-522fe4a6220d.png)

