### PR TITLE
re-add Immolation Aura cast effic

### DIFF
--- a/src/analysis/retail/demonhunter/shared/modules/spells/ImmolationAura/index.tsx
+++ b/src/analysis/retail/demonhunter/shared/modules/spells/ImmolationAura/index.tsx
@@ -22,6 +22,8 @@ import { combineQualitativePerformances } from 'common/combineQualitativePerform
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import ResourceLink from 'interface/ResourceLink';
 import { TALENTS_DEMON_HUNTER } from 'common/TALENTS';
+import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
+import { GapHighlight } from 'parser/ui/CooldownBar';
 
 class ImmolationAura extends Analyzer {
   static dependencies = {
@@ -98,12 +100,24 @@ class ImmolationAura extends Analyzer {
         castBreakdownSmallText={<> - Green is a good cast, Red is a bad cast.</>}
         onPerformanceBoxClick={logSpellUseEvent}
         abovePerformanceDetails={
-          <CastPerformanceSummary
-            spell={SPELLS.IMMOLATION_AURA}
-            casts={goodCasts}
-            performance={QualitativePerformance.Good}
-            totalCasts={totalCasts}
-          />
+          <div style={{ marginBottom: 10 }}>
+            <CastPerformanceSummary
+              spell={SPELLS.IMMOLATION_AURA}
+              casts={goodCasts}
+              performance={QualitativePerformance.Good}
+              totalCasts={totalCasts}
+            />
+            <strong>
+              <SpellLink id={SPELLS.IMMOLATION_AURA} />{' '}
+              <Trans id="guide.castEfficiency">cast efficiency</Trans>
+            </strong>
+            <CastEfficiencyBar
+              spellId={SPELLS.IMMOLATION_AURA.id}
+              gapHighlightMode={GapHighlight.FullCooldown}
+              minimizeIcons
+              useThresholds
+            />
+          </div>
         }
       />
     );

--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import SHARED_CHANGELOG from 'analysis/retail/demonhunter/shared/CHANGELOG';
 
 // prettier-ignore
 export default [
+  change(date(2023, 3, 9), <>Re-add <SpellLink id={SPELLS.IMMOLATION_AURA} /> cast efficiency to guide.</>, ToppleTheNun),
   change(date(2023, 3, 9), 'Update Rotation section.', ToppleTheNun),
   change(date(2023, 2, 25), <>Fixed  consuming the last stack of <SpellLink id={SPELLS.SOUL_FRAGMENT_STACK.id} /> not granting credit on casting <SpellLink id={TALENTS.SPIRIT_BOMB_TALENT} />.</>, ToppleTheNun),
   change(date(2023, 1, 30), <>Fixed an issue where the graph for <SpellLink id={SPELLS.SOUL_FRAGMENT_STACK.id} /> would show incorrect values for a given point in time.</>, Putro),

--- a/src/analysis/retail/demonhunter/vengeance/guide/CooldownGraphSubSection.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/guide/CooldownGraphSubSection.tsx
@@ -65,6 +65,7 @@ const CooldownGraphSubsection = () => {
           spellId={cooldownCheck.talent.id}
           gapHighlightMode={GapHighlight.FullCooldown}
           minimizeIcons={hasTooManyCasts}
+          useThresholds
         />
       ))}
     </SubSection>

--- a/src/analysis/retail/demonhunter/vengeance/modules/spells/SoulCleave.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/spells/SoulCleave.tsx
@@ -106,6 +106,7 @@ export default class SoulCleave extends Analyzer {
     }
     const actualPerformance = combineQualitativePerformances(
       checklistItems.map((item) => item.performance),
+      QualitativePerformance.Good,
     );
     this.cooldownUses.push({
       event,

--- a/src/analysis/retail/demonhunter/vengeance/modules/talents/SpiritBomb.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/talents/SpiritBomb.tsx
@@ -174,6 +174,7 @@ export default class SpiritBomb extends Analyzer {
     ];
     const actualPerformance = combineQualitativePerformances(
       checklistItems.map((item) => item.performance),
+      QualitativePerformance.Good,
     );
     this.cooldownUses.push({
       event,

--- a/src/common/combineQualitativePerformances.ts
+++ b/src/common/combineQualitativePerformances.ts
@@ -44,13 +44,17 @@ export const numberToQualitativePerformance = (performance: number) => {
  * {@link QualitativePerformance.Perfect} if the array is empty.
  *
  * @param {QualitativePerformance[]} performances Performances to combine
+ * @param {QualitativePerformance} defaultPerformance Default performance if no values are present in performances
  * @returns {QualitativePerformance} Lowest performance value from the given array
  */
-export const combineQualitativePerformances = (performances: QualitativePerformance[]) =>
+export const combineQualitativePerformances = (
+  performances: QualitativePerformance[],
+  defaultPerformance: QualitativePerformance = QualitativePerformance.Perfect,
+) =>
   performances.reduce(
     (prev, curr) =>
       numberToQualitativePerformance(
         Math.min(qualitativePerformanceToNumber(prev), qualitativePerformanceToNumber(curr)),
       ),
-    QualitativePerformance.Perfect,
+    defaultPerformance,
   );


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Re-add Immolation Aura cast efficiency in VDH Guide.

### Motivation

<!-- Why are you submitting this pull request?-->

I wanted cast efficiency reporting back for Immolation Aura.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/r4JtW9hxdzwc3G6q/8-Mythic+The+Primal+Council+-+Kill+(3:00)/22-Toppledh/standard`
- Screenshot(s):
![image](https://user-images.githubusercontent.com/1672786/224116916-0c306142-6513-4164-b965-3d1de829373e.png)
