### PR TITLE
add SoF to Rotation section of Guide

### DIFF
--- a/src/analysis/retail/demonhunter/shared/index.ts
+++ b/src/analysis/retail/demonhunter/shared/index.ts
@@ -13,4 +13,9 @@ export { default as DisruptingFury } from './modules/talents/DisruptingFury';
 export { default as DemonSoulBuff } from './modules/spells/DemonSoulBuff';
 export { default as FodderToTheFlame } from './modules/talents/FodderToTheFlame';
 export { default as TheHuntNormalizer, getChargeImpact } from './normalizers/TheHuntNormalizer';
+export {
+  default as SigilOfFlameNormalizer,
+  getSigilOfFlameDamages,
+} from './normalizers/SigilOfFlameNormalizer';
+export { default as SigilOfFlame } from './modules/talents/SigilOfFlame';
 export * from './constants';

--- a/src/analysis/retail/demonhunter/shared/modules/Abilities.tsx
+++ b/src/analysis/retail/demonhunter/shared/modules/Abilities.tsx
@@ -141,12 +141,9 @@ export default class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: [
-          SPELLS.SIGIL_OF_FLAME_CONCENTRATED.id,
-          TALENTS_DEMON_HUNTER.SIGIL_OF_FLAME_TALENT.id,
-          SPELLS.SIGIL_OF_FLAME_PRECISE.id,
-        ],
+        spell: TALENTS_DEMON_HUNTER.SIGIL_OF_FLAME_TALENT.id,
         category: SPELL_CATEGORY.ROTATIONAL_AOE,
+        enabled: this.selectedCombatant.hasTalent(TALENTS_DEMON_HUNTER.SIGIL_OF_FLAME_TALENT),
         cooldown:
           30 * (1 - (combatant.hasTalent(TALENTS_DEMON_HUNTER.QUICKENED_SIGILS_TALENT) ? 0.2 : 0)),
         gcd: {
@@ -157,6 +154,43 @@ export default class Abilities extends CoreAbilities {
           recommendedEfficiency: 0.9,
           extraSuggestion: `Cast on cooldown for a dps increase.`,
         },
+        damageSpellIds: [SPELLS.SIGIL_OF_FLAME_DEBUFF.id],
+      },
+      {
+        spell: SPELLS.SIGIL_OF_FLAME_PRECISE.id,
+        category: SPELL_CATEGORY.ROTATIONAL_AOE,
+        enabled:
+          this.selectedCombatant.hasTalent(TALENTS_DEMON_HUNTER.SIGIL_OF_FLAME_TALENT) &&
+          this.selectedCombatant.hasTalent(TALENTS_DEMON_HUNTER.PRECISE_SIGILS_TALENT),
+        cooldown:
+          30 * (1 - (combatant.hasTalent(TALENTS_DEMON_HUNTER.QUICKENED_SIGILS_TALENT) ? 0.2 : 0)),
+        gcd: {
+          base: 1500,
+        },
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.9,
+          extraSuggestion: `Cast on cooldown for a dps increase.`,
+        },
+        damageSpellIds: [SPELLS.SIGIL_OF_FLAME_DEBUFF.id],
+      },
+      {
+        spell: SPELLS.SIGIL_OF_FLAME_CONCENTRATED.id,
+        category: SPELL_CATEGORY.ROTATIONAL_AOE,
+        enabled:
+          this.selectedCombatant.hasTalent(TALENTS_DEMON_HUNTER.SIGIL_OF_FLAME_TALENT) &&
+          this.selectedCombatant.hasTalent(TALENTS_DEMON_HUNTER.CONCENTRATED_SIGILS_TALENT),
+        cooldown:
+          30 * (1 - (combatant.hasTalent(TALENTS_DEMON_HUNTER.QUICKENED_SIGILS_TALENT) ? 0.2 : 0)),
+        gcd: {
+          base: 1500,
+        },
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.9,
+          extraSuggestion: `Cast on cooldown for a dps increase.`,
+        },
+        damageSpellIds: [SPELLS.SIGIL_OF_FLAME_DEBUFF.id],
       },
       {
         spell: [

--- a/src/analysis/retail/demonhunter/shared/modules/talents/SigilOfFlame.tsx
+++ b/src/analysis/retail/demonhunter/shared/modules/talents/SigilOfFlame.tsx
@@ -1,0 +1,144 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import SPELLS from 'common/SPELLS/demonhunter';
+import TALENTS from 'common/TALENTS/demonhunter';
+import { ChecklistUsageInfo, SpellUse, spellUseToBoxRowEntry } from 'parser/core/SpellUsage/core';
+import Events, { CastEvent } from 'parser/core/Events';
+import { Trans } from '@lingui/macro';
+import { SpellLink } from 'interface';
+import ResourceLink from 'interface/ResourceLink';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import SpellUsageSubSection, {
+  logSpellUseEvent,
+} from 'parser/core/SpellUsage/SpellUsageSubSection';
+import CastPerformanceSummary from 'analysis/retail/demonhunter/shared/guide/CastPerformanceSummary';
+import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
+import { GapHighlight } from 'parser/ui/CooldownBar';
+import { combineQualitativePerformances } from 'common/combineQualitativePerformances';
+import { getSigilOfFlameDamages } from 'analysis/retail/demonhunter/shared/normalizers/SigilOfFlameNormalizer';
+import Spell from 'common/SPELLS/Spell';
+
+export default class SigilOfFlame extends Analyzer {
+  private cooldownUses: SpellUse[] = [];
+  private readonly spell: Spell;
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.SIGIL_OF_FLAME_TALENT);
+    if (this.selectedCombatant.hasTalent(TALENTS.CONCENTRATED_SIGILS_TALENT)) {
+      this.spell = SPELLS.SIGIL_OF_FLAME_CONCENTRATED;
+    } else if (this.selectedCombatant.hasTalent(TALENTS.PRECISE_SIGILS_TALENT)) {
+      this.spell = SPELLS.SIGIL_OF_FLAME_PRECISE;
+    } else {
+      this.spell = TALENTS.SIGIL_OF_FLAME_TALENT;
+    }
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(this.spell), this.onCast);
+  }
+
+  guideSubsection(): JSX.Element {
+    const explanation = (
+      <p>
+        <Trans id="guide.demonhunter.vengeance.sections.rotation.sigilOfFlame.explanation">
+          <strong>
+            <SpellLink id={TALENTS.SIGIL_OF_FLAME_TALENT} />
+          </strong>{' '}
+          is one of your <strong>builders</strong>. It generates{' '}
+          <ResourceLink id={RESOURCE_TYPES.FURY.id} /> places a Sigil on the ground that activates
+          after a delay, dealing fire damage immediately and applying a DoT to any targets hit.
+        </Trans>
+      </p>
+    );
+
+    const performances = this.cooldownUses.map((it) =>
+      spellUseToBoxRowEntry(it, this.owner.fight.start_time),
+    );
+
+    const goodCasts = performances.filter((it) => it.value === QualitativePerformance.Good).length;
+    const totalCasts = performances.length;
+
+    return (
+      <SpellUsageSubSection
+        explanation={explanation}
+        performance={performances}
+        uses={this.cooldownUses}
+        castBreakdownSmallText={<> - Green is a good cast, Red is a bad cast.</>}
+        onPerformanceBoxClick={logSpellUseEvent}
+        abovePerformanceDetails={
+          <div style={{ marginBottom: 10 }}>
+            <CastPerformanceSummary
+              spell={TALENTS.SIGIL_OF_FLAME_TALENT}
+              casts={goodCasts}
+              performance={QualitativePerformance.Good}
+              totalCasts={totalCasts}
+            />
+            <strong>
+              <SpellLink id={TALENTS.SIGIL_OF_FLAME_TALENT} />{' '}
+              <Trans id="guide.castEfficiency">cast efficiency</Trans>
+            </strong>
+            <CastEfficiencyBar
+              spellId={this.spell.id}
+              gapHighlightMode={GapHighlight.FullCooldown}
+              minimizeIcons
+              useThresholds
+            />
+          </div>
+        }
+      />
+    );
+  }
+
+  private onCast(event: CastEvent) {
+    const damages = getSigilOfFlameDamages(event);
+    const performance =
+      damages.length > 0 ? QualitativePerformance.Good : QualitativePerformance.Fail;
+    const details =
+      damages.length > 0 ? (
+        <div>
+          You hit at least one target with your <SpellLink id={TALENTS.SIGIL_OF_FLAME_TALENT} />{' '}
+          cast. Good job!
+        </div>
+      ) : (
+        <div>
+          You did not hit any targets with your <SpellLink id={TALENTS.SIGIL_OF_FLAME_TALENT} />{' '}
+          cast. Try to always hit at least one target with{' '}
+          <SpellLink id={TALENTS.SIGIL_OF_FLAME_TALENT} />.
+        </div>
+      );
+    const isPrepull = event.prepull;
+
+    const checklistItems: ChecklistUsageInfo[] = [];
+    if (isPrepull) {
+      checklistItems.push({
+        check: 'prepull',
+        timestamp: event.timestamp,
+        performance: QualitativePerformance.Good,
+        summary: <div>Cast before pull</div>,
+        details: (
+          <div>
+            You cast <SpellLink id={TALENTS.SIGIL_OF_FLAME_TALENT} /> before pulling the boss. Good
+            job!
+          </div>
+        ),
+      });
+    } else {
+      checklistItems.push({
+        check: 'initial-hit',
+        timestamp: event.timestamp,
+        performance,
+        summary: <div>Hit at least 1 target with cast</div>,
+        details,
+      });
+    }
+    const actualPerformance = combineQualitativePerformances(
+      checklistItems.map((item) => item.performance),
+    );
+    this.cooldownUses.push({
+      event,
+      performance: actualPerformance,
+      checklistItems,
+      performanceExplanation:
+        actualPerformance !== QualitativePerformance.Fail
+          ? `${actualPerformance} Usage`
+          : 'Bad Usage',
+    });
+  }
+}

--- a/src/analysis/retail/demonhunter/shared/normalizers/SigilOfFlameNormalizer.ts
+++ b/src/analysis/retail/demonhunter/shared/normalizers/SigilOfFlameNormalizer.ts
@@ -1,0 +1,54 @@
+import { CastEvent, DamageEvent, EventType, GetRelatedEvents } from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import SPELLS from 'common/SPELLS/demonhunter';
+import TALENTS from 'common/TALENTS/demonhunter';
+
+const DAMAGE_BUFFER = 2500;
+
+const SIGIL_OF_FLAME_DAMAGE = 'SigilOfFlameDamage';
+
+const EVENT_LINKS: EventLink[] = [
+  {
+    linkRelation: SIGIL_OF_FLAME_DAMAGE,
+    referencedEventId: SPELLS.SIGIL_OF_FLAME_DEBUFF.id,
+    referencedEventType: EventType.Damage,
+    linkingEventId: TALENTS.SIGIL_OF_FLAME_TALENT.id,
+    linkingEventType: EventType.Cast,
+    forwardBufferMs: DAMAGE_BUFFER,
+    backwardBufferMs: DAMAGE_BUFFER,
+    anyTarget: true,
+  },
+  {
+    linkRelation: SIGIL_OF_FLAME_DAMAGE,
+    referencedEventId: SPELLS.SIGIL_OF_FLAME_DEBUFF.id,
+    referencedEventType: EventType.Damage,
+    linkingEventId: SPELLS.SIGIL_OF_FLAME_PRECISE.id,
+    linkingEventType: EventType.Cast,
+    forwardBufferMs: DAMAGE_BUFFER,
+    backwardBufferMs: DAMAGE_BUFFER,
+    anyTarget: true,
+  },
+  {
+    linkRelation: SIGIL_OF_FLAME_DAMAGE,
+    referencedEventId: SPELLS.SIGIL_OF_FLAME_DEBUFF.id,
+    referencedEventType: EventType.Damage,
+    linkingEventId: SPELLS.SIGIL_OF_FLAME_CONCENTRATED.id,
+    linkingEventType: EventType.Cast,
+    forwardBufferMs: DAMAGE_BUFFER,
+    backwardBufferMs: DAMAGE_BUFFER,
+    anyTarget: true,
+  },
+];
+
+export default class SigilOfFlameNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_LINKS);
+  }
+}
+
+export function getSigilOfFlameDamages(event: CastEvent): DamageEvent[] {
+  return GetRelatedEvents(event, SIGIL_OF_FLAME_DAMAGE).filter(
+    (e): e is DamageEvent => e.type === EventType.Damage,
+  );
+}

--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import SHARED_CHANGELOG from 'analysis/retail/demonhunter/shared/CHANGELOG';
 
 // prettier-ignore
 export default [
+  change(date(2023, 3, 9), <>Add <SpellLink id={TALENTS.SIGIL_OF_FLAME_TALENT} /> to Rotation section in guide.</>, ToppleTheNun),
   change(date(2023, 3, 9), <>Re-add <SpellLink id={SPELLS.IMMOLATION_AURA} /> cast efficiency to guide.</>, ToppleTheNun),
   change(date(2023, 3, 9), 'Update Rotation section.', ToppleTheNun),
   change(date(2023, 2, 25), <>Fixed  consuming the last stack of <SpellLink id={SPELLS.SOUL_FRAGMENT_STACK.id} /> not granting credit on casting <SpellLink id={TALENTS.SPIRIT_BOMB_TALENT} />.</>, ToppleTheNun),

--- a/src/analysis/retail/demonhunter/vengeance/CombatLogParser.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CombatLogParser.tsx
@@ -14,6 +14,8 @@ import {
   UnnaturalMalice,
   DemonSoulBuff,
   FodderToTheFlame,
+  SigilOfFlameNormalizer,
+  SigilOfFlame,
 } from 'analysis/retail/demonhunter/shared';
 import CoreCombatLogParser from 'parser/core/CombatLogParser';
 
@@ -90,6 +92,7 @@ class CombatLogParser extends CoreCombatLogParser {
     defensiveBuffLinkNormalizer: DefensiveBuffLinkNormalizer,
     theHuntNormalizer: TheHuntNormalizer,
     felDevastationNormalizer: FelDevastationNormalizer,
+    sigilOfFlamesNormalizer: SigilOfFlameNormalizer,
 
     // Spell
     immolationAura: ImmolationAura,
@@ -133,6 +136,7 @@ class CombatLogParser extends CoreCombatLogParser {
     felDevastation: FelDevastation,
     fieryBrand2: FieryBrand2,
     fodderToTheFlame: FodderToTheFlame,
+    sigilOfFlame: SigilOfFlame,
 
     // Stats
     soulsOvercap: SoulsOvercap,

--- a/src/analysis/retail/demonhunter/vengeance/Guide.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/Guide.tsx
@@ -130,6 +130,8 @@ function RotationSection({ modules, info }: GuideProps<typeof CombatLogParser>) 
       {info.combatant.hasTalent(TALENTS_DEMON_HUNTER.FRACTURE_TALENT) &&
         modules.fracture.guideSubsection()}
       {modules.immolationAura.vengeanceGuideSubsection()}
+      {info.combatant.hasTalent(TALENTS_DEMON_HUNTER.SIGIL_OF_FLAME_TALENT) &&
+        modules.sigilOfFlame.guideSubsection()}
       {info.combatant.hasTalent(TALENTS_DEMON_HUNTER.SPIRIT_BOMB_TALENT) &&
         modules.spiritBomb.guideSubsection()}
       {modules.soulCleave.guideSubsection()}

--- a/src/analysis/retail/demonhunter/vengeance/modules/Abilities.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/Abilities.tsx
@@ -35,6 +35,10 @@ class Abilities extends SharedAbilities {
             </>
           ),
         },
+        damageSpellIds: [
+          SPELLS.IMMOLATION_AURA_INITIAL_HIT_DAMAGE.id,
+          SPELLS.IMMOLATION_AURA_BUFF_DAMAGE.id,
+        ],
       },
       {
         spell: [

--- a/src/parser/ui/CastEfficiencyBar.tsx
+++ b/src/parser/ui/CastEfficiencyBar.tsx
@@ -1,5 +1,6 @@
-import { CooldownBar, GapHighlight } from 'parser/ui/CooldownBar';
 import styled from '@emotion/styled';
+import { ReactNode } from 'react';
+import { CooldownBar, GapHighlight } from 'parser/ui/CooldownBar';
 import { SpellIcon, SpellLink, TooltipElement } from 'interface';
 import { BadColor, GoodColor, MediocreColor, OkColor, useAnalyzer } from 'interface/guide';
 import CastEfficiency from 'parser/shared/modules/CastEfficiency';
@@ -29,7 +30,7 @@ export default function CastEfficiencyBar({
   useThresholds?: boolean;
 }): JSX.Element {
   const castEffic = useAnalyzer(CastEfficiency)?.getCastEfficiencyForSpellId(spellId);
-  let tooltip: React.ReactNode = `Couldn't get cast efficiency info!`;
+  let tooltip: ReactNode = `Couldn't get cast efficiency info!`;
   let utilDisplay = `N/A`;
   let textColor: string | undefined;
   if (castEffic && castEffic.efficiency !== null) {


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Add Sigil of Flame to the VDH guide.

### Motivation

<!-- Why are you submitting this pull request?-->

Sigil of Flame is part of the rotation and wasn't included originally.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/r4JtW9hxdzwc3G6q/8-Mythic+The+Primal+Council+-+Kill+(3:00)/Toppledh/standard/overview`
- Screenshot(s):
![image](https://user-images.githubusercontent.com/1672786/224164818-98e75796-092e-499b-8942-08b792cfc9bd.png)
