### PR TITLE
Affliction 10.0.5

### DIFF
--- a/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
@@ -1,10 +1,14 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
-import { Arlie, Jonfanz, ToppleTheNun } from 'CONTRIBUTORS';
+import { Arlie, Jonfanz, ToppleTheNun, dodse } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 3, 9), "Update Soul Conduit to take into account being a 2 rank talent and different scaling", dodse),
+  change(date(2023, 3, 9), 'Update Vile Taint to track the right debuff id and rework hit tracking', dodse),
+  change(date(2023, 3, 9), 'Add statistics for Pandemic Invocation, Inevitable Demise, Malefic Affliction and Wrath of Consumption', dodse),
+  change(date(2023, 3, 9), 'Update Darkglare, Nightfall, Shadow Embrace for Dragonflight changes', dodse),
   change(date(2022, 11, 10), <>Fix <SpellLink id={TALENTS.DRAIN_SOUL_TALENT.id} /> not showing as intended and add <SpellLink id={SPELLS.IMP_SINGE_MAGIC} />.</>, Arlie),
   change(date(2022, 11, 9), 'Remove Shadowlands covenant abilities from checklist.', ToppleTheNun),
   change(date(2022, 10, 20), <>Fix <SpellLink id={TALENTS.DRAIN_SOUL_TALENT.id} /> damage calculations and add initial support for <SpellLink id={TALENTS.DREAD_TOUCH_TALENT.id} />.</>, Jonfanz),

--- a/src/analysis/retail/warlock/affliction/CombatLogParser.ts
+++ b/src/analysis/retail/warlock/affliction/CombatLogParser.ts
@@ -23,6 +23,7 @@ import CorruptionUptime from './modules/spells/Corruption';
 import DrainSoul from './modules/spells/DrainSoul';
 import DreadTouch from './modules/spells/DreadTouch';
 import Haunt from './modules/spells/Haunt';
+import MaleficAffliction from './modules/spells/MaleficAffliction';
 import Nightfall from './modules/spells/Nightfall';
 import PhantomSingularity from './modules/spells/PhantomSingularity';
 import ShadowEmbrace from './modules/spells/ShadowEmbrace';
@@ -66,6 +67,7 @@ class CombatLogParser extends CoreCombatLogParser {
     dreadTouch: DreadTouch,
     grimoireOfSacrifice: GrimoireOfSacrifice,
     haunt: Haunt,
+    maleficAffliction: MaleficAffliction,
     nightfall: Nightfall,
     phantomSingularity: PhantomSingularity,
     siphonLifeUptime: SiphonLifeUptime,

--- a/src/analysis/retail/warlock/affliction/CombatLogParser.ts
+++ b/src/analysis/retail/warlock/affliction/CombatLogParser.ts
@@ -23,6 +23,7 @@ import CorruptionUptime from './modules/spells/Corruption';
 import DrainSoul from './modules/spells/DrainSoul';
 import DreadTouch from './modules/spells/DreadTouch';
 import Haunt from './modules/spells/Haunt';
+import InevitableDemise from './modules/spells/InevitableDemise';
 import MaleficAffliction from './modules/spells/MaleficAffliction';
 import Nightfall from './modules/spells/Nightfall';
 import PandemicInvocation from './modules/spells/PandemicInvocation';
@@ -68,6 +69,7 @@ class CombatLogParser extends CoreCombatLogParser {
     absoluteCorruption: AbsoluteCorruption,
     drainSoul: DrainSoul,
     dreadTouch: DreadTouch,
+    inevitableDemise: InevitableDemise,
     grimoireOfSacrifice: GrimoireOfSacrifice,
     haunt: Haunt,
     maleficAffliction: MaleficAffliction,

--- a/src/analysis/retail/warlock/affliction/CombatLogParser.ts
+++ b/src/analysis/retail/warlock/affliction/CombatLogParser.ts
@@ -25,6 +25,7 @@ import DreadTouch from './modules/spells/DreadTouch';
 import Haunt from './modules/spells/Haunt';
 import MaleficAffliction from './modules/spells/MaleficAffliction';
 import Nightfall from './modules/spells/Nightfall';
+import PandemicInvocation from './modules/spells/PandemicInvocation';
 import PhantomSingularity from './modules/spells/PhantomSingularity';
 import ShadowEmbrace from './modules/spells/ShadowEmbrace';
 import SiphonLifeUptime from './modules/spells/SiphonLife';
@@ -69,6 +70,7 @@ class CombatLogParser extends CoreCombatLogParser {
     haunt: Haunt,
     maleficAffliction: MaleficAffliction,
     nightfall: Nightfall,
+    pandemicInvocation: PandemicInvocation,
     phantomSingularity: PhantomSingularity,
     siphonLifeUptime: SiphonLifeUptime,
     soulConduit: SoulConduit,

--- a/src/analysis/retail/warlock/affliction/CombatLogParser.ts
+++ b/src/analysis/retail/warlock/affliction/CombatLogParser.ts
@@ -30,6 +30,7 @@ import PhantomSingularity from './modules/spells/PhantomSingularity';
 import ShadowEmbrace from './modules/spells/ShadowEmbrace';
 import SiphonLifeUptime from './modules/spells/SiphonLife';
 import SoulConduit from './modules/spells/SoulConduit';
+import TormentedCrescendo from './modules/spells/TormentedCrescendo';
 import UnstableAfflictionUptime from './modules/spells/UnstableAffliction';
 import VileTaint from './modules/spells/VileTaint';
 
@@ -74,6 +75,7 @@ class CombatLogParser extends CoreCombatLogParser {
     phantomSingularity: PhantomSingularity,
     siphonLifeUptime: SiphonLifeUptime,
     soulConduit: SoulConduit,
+    tormentedCrescendo: TormentedCrescendo,
     vileTaint: VileTaint,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown

--- a/src/analysis/retail/warlock/affliction/CombatLogParser.ts
+++ b/src/analysis/retail/warlock/affliction/CombatLogParser.ts
@@ -33,6 +33,7 @@ import SoulConduit from './modules/spells/SoulConduit';
 import TormentedCrescendo from './modules/spells/TormentedCrescendo';
 import UnstableAfflictionUptime from './modules/spells/UnstableAffliction';
 import VileTaint from './modules/spells/VileTaint';
+import WrathOfConsumption from './modules/spells/WrathOfConsumption';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -77,6 +78,7 @@ class CombatLogParser extends CoreCombatLogParser {
     soulConduit: SoulConduit,
     tormentedCrescendo: TormentedCrescendo,
     vileTaint: VileTaint,
+    wrathOfConsumption: WrathOfConsumption,
 
     // There's no throughput benefit from casting Arcane Torrent on cooldown
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,

--- a/src/analysis/retail/warlock/affliction/modules/features/Abilities.ts
+++ b/src/analysis/retail/warlock/affliction/modules/features/Abilities.ts
@@ -142,6 +142,7 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: 0.9,
         },
+        enabled: combatant.hasTalent(TALENTS.SUMMON_DARKGLARE_TALENT),
       },
       // Defensive
       {

--- a/src/analysis/retail/warlock/affliction/modules/features/Darkglare.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/features/Darkglare.tsx
@@ -70,6 +70,7 @@ class Darkglare extends Analyzer {
 
   constructor(options: Options) {
     super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.SUMMON_DARKGLARE_TALENT);
     this._dotDurations = getDotDurations(this.selectedCombatant);
     // if player has Absolute Corruption, disregard the Corruption duration (it's permanent debuff then)
     this._hasAC = this.selectedCombatant.hasTalent(TALENTS.ABSOLUTE_CORRUPTION_TALENT);
@@ -230,8 +231,9 @@ class Darkglare extends Analyzer {
     Object.values(this.casts).forEach((cast) => {
       Object.values(cast.targets).forEach((targetDots) => {
         if (this._hasAC) {
-          totalExtendedDots += targetDots.dots.filter((id) => id !== SPELLS.CORRUPTION_DEBUFF.id)
-            .length;
+          totalExtendedDots += targetDots.dots.filter(
+            (id) => id !== SPELLS.CORRUPTION_DEBUFF.id,
+          ).length;
         } else {
           totalExtendedDots += targetDots.dots.length;
         }

--- a/src/analysis/retail/warlock/affliction/modules/spells/DreadTouch.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/spells/DreadTouch.tsx
@@ -8,6 +8,7 @@ import Enemies from 'parser/shared/modules/Enemies';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import UptimeIcon from 'interface/icons/Uptime';
 
 export default class DreadTouch extends Analyzer {
   static dependencies = {
@@ -58,7 +59,7 @@ export default class DreadTouch extends Analyzer {
         }
       >
         <BoringSpellValueText spellId={TALENTS.DREAD_TOUCH_TALENT.id}>
-          {formatPercentage(this.uptime)} % <small>uptime</small>
+          <UptimeIcon /> {formatPercentage(this.uptime)} % <small>uptime</small>
         </BoringSpellValueText>
       </Statistic>
     );

--- a/src/analysis/retail/warlock/affliction/modules/spells/InevitableDemise.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/spells/InevitableDemise.tsx
@@ -1,0 +1,75 @@
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/warlock';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, {
+  ApplyBuffEvent,
+  ApplyBuffStackEvent,
+  RefreshBuffEvent,
+  RemoveBuffEvent,
+} from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+
+const BUFF_DURATION = 20000;
+const BUFFER = 100;
+const MAX_STACKS = 50;
+
+class InevitableDemise extends Analyzer {
+  wastedStacks = 0;
+  stacks = 0;
+  private buffApplyTimestamp: number | null = null;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.INEVITABLE_DEMISE_TALENT);
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.INEVITABLE_DEMISE_BUFF),
+      this.onInevitableDemiseApplyRefresh,
+    );
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.INEVITABLE_DEMISE_BUFF),
+      this.onInevitableDemiseApplyRefresh,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.INEVITABLE_DEMISE_BUFF),
+      this.onInevitableDemiseRemove,
+    );
+    this.addEventListener(
+      Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.INEVITABLE_DEMISE_BUFF),
+      this.onInevitableDemiseApplyStack,
+    );
+  }
+
+  onInevitableDemiseApplyRefresh(event: ApplyBuffEvent | RefreshBuffEvent) {
+    if (this.stacks === MAX_STACKS) {
+      this.wastedStacks += 1;
+    }
+    this.buffApplyTimestamp = event.timestamp;
+  }
+
+  onInevitableDemiseApplyStack(event: ApplyBuffStackEvent) {
+    this.stacks = event.stack;
+  }
+
+  onInevitableDemiseRemove(event: RemoveBuffEvent) {
+    const expectedEnd = this.buffApplyTimestamp || 0 + BUFF_DURATION;
+    if (expectedEnd - BUFFER <= event.timestamp && event.timestamp <= expectedEnd + BUFFER) {
+      this.wastedStacks += this.stacks;
+    }
+    this.stacks = 0;
+    this.buffApplyTimestamp = null;
+  }
+
+  statistic() {
+    return (
+      <Statistic category={STATISTIC_CATEGORY.TALENTS} size="flexible">
+        <TalentSpellText talent={TALENTS.INEVITABLE_DEMISE_TALENT}>
+          {this.wastedStacks} <small>wasted stacks</small>
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}
+
+export default InevitableDemise;

--- a/src/analysis/retail/warlock/affliction/modules/spells/MaleficAffliction.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/spells/MaleficAffliction.tsx
@@ -1,0 +1,66 @@
+import { formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/warlock';
+import { TooltipElement } from 'interface';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import UptimeIcon from 'interface/icons/Uptime';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+
+export default class MaleficAffliction extends Analyzer {
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.MALEFIC_AFFLICTION_TALENT);
+  }
+
+  get uptime() {
+    return (
+      this.selectedCombatant.getBuffUptime(SPELLS.MALEFIC_AFFLICTION_BUFF.id) /
+      this.owner.fightDuration
+    );
+  }
+
+  get stackUptimesPercentages() {
+    const uptimePercentages: { [key: string]: number } = {};
+    Object.entries(
+      this.selectedCombatant.getStackBuffUptimes(SPELLS.MALEFIC_AFFLICTION_BUFF.id),
+    ).forEach(([stackCount, uptime]) =>
+      Number(stackCount) > 0
+        ? (uptimePercentages[stackCount] = uptime / this.owner.fightDuration)
+        : {},
+    );
+    return uptimePercentages;
+  }
+
+  statistic() {
+    const stackUptimes = this.stackUptimesPercentages;
+    return (
+      <Statistic
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
+        tooltip={
+          <>
+            {formatPercentage(this.uptime)} uptime
+            <br />
+          </>
+        }
+      >
+        <TalentSpellText talent={TALENTS.MALEFIC_AFFLICTION_TALENT}>
+          <UptimeIcon /> {formatPercentage(this.uptime)} %
+          <TooltipElement
+            content={
+              <>
+                1 stack: {formatPercentage(stackUptimes[1])} %<br />2 stacks:{' '}
+                {formatPercentage(stackUptimes[2])} % <br />3 stacks:{' '}
+                {formatPercentage(stackUptimes[3])} %
+              </>
+            }
+          >
+            <small>uptime</small>
+          </TooltipElement>
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}

--- a/src/analysis/retail/warlock/affliction/modules/spells/Nightfall.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/spells/Nightfall.tsx
@@ -1,16 +1,23 @@
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { ApplyBuffEvent, RefreshBuffEvent, RemoveBuffEvent } from 'parser/core/Events';
+import Events, {
+  ApplyBuffEvent,
+  ApplyBuffStackEvent,
+  RefreshBuffEvent,
+  RemoveBuffEvent,
+} from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 
 const BUFF_DURATION = 12000;
 const BUFFER = 100;
+const MAX_STACKS = 2;
 
 class Nightfall extends Analyzer {
   wastedProcs = 0;
+  stacks = 0;
   private buffApplyTimestamp: number | null = null;
 
   constructor(options: Options) {
@@ -28,13 +35,32 @@ class Nightfall extends Analyzer {
       Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.NIGHTFALL_BUFF),
       this.onNightfallRemove,
     );
+    this.addEventListener(
+      Events.removebuffstack.by(SELECTED_PLAYER).spell(SPELLS.NIGHTFALL_BUFF),
+      this.onNightfallRemoveStack,
+    );
+    this.addEventListener(
+      Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.NIGHTFALL_BUFF),
+      this.onNightfallApplyStack,
+    );
   }
 
   onNightfallApplyRefresh(event: ApplyBuffEvent | RefreshBuffEvent) {
-    if (this.buffApplyTimestamp !== null) {
+    if (this.stacks === MAX_STACKS) {
       this.wastedProcs += 1;
+    } else {
+      this.stacks += 1;
     }
     this.buffApplyTimestamp = event.timestamp;
+  }
+
+  onNightfallApplyStack(event: ApplyBuffStackEvent) {
+    this.stacks += 1;
+    this.buffApplyTimestamp = event.timestamp;
+  }
+
+  onNightfallRemoveStack() {
+    this.stacks -= 1;
   }
 
   onNightfallRemove(event: RemoveBuffEvent) {
@@ -43,6 +69,7 @@ class Nightfall extends Analyzer {
       // buff fell off naturally
       this.wastedProcs += 1;
     }
+    this.stacks = 0;
     this.buffApplyTimestamp = null;
   }
 

--- a/src/analysis/retail/warlock/affliction/modules/spells/PandemicInvocation.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/spells/PandemicInvocation.tsx
@@ -1,0 +1,80 @@
+import { formatPercentage, formatNumber } from 'common/format';
+import TALENTS from 'common/TALENTS/warlock';
+import SPELLS from 'common/SPELLS/warlock';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import AbilityTracker from 'parser/shared/modules/AbilityTracker';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+
+import SoulShardTracker from '../resources/SoulShardTracker';
+import { TooltipElement } from 'interface';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+
+const PANDEMIC_INVOCATION_DOTS = [
+  SPELLS.AGONY,
+  SPELLS.CORRUPTION_DEBUFF,
+  TALENTS.SIPHON_LIFE_TALENT,
+  TALENTS.UNSTABLE_AFFLICTION_TALENT,
+];
+
+class PandemicInvocation extends Analyzer {
+  static dependencies = {
+    soulShardTracker: SoulShardTracker,
+    abilityTracker: AbilityTracker,
+  };
+
+  protected soulShardTracker!: SoulShardTracker;
+  protected abilityTracker!: AbilityTracker;
+
+  refreshes: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.PANDEMIC_INVOCATION_TALENT);
+    this.addEventListener(
+      Events.refreshdebuff.by(SELECTED_PLAYER).spell(PANDEMIC_INVOCATION_DOTS),
+      this.onRefreshDot,
+    );
+  }
+
+  onRefreshDot() {
+    this.refreshes += 1;
+  }
+
+  statistic() {
+    const shardsGained = this.soulShardTracker.getGeneratedBySpell(
+      SPELLS.PANDEMIC_INVOCATION_SHARD_GEN.id,
+    );
+    // this might be a bit off if it didn't actually manage to hit as something died,
+    // but it is simpler than tracking buff apply/refresh timestamps
+    const hits = this.abilityTracker.getAbility(SPELLS.PANDEMIC_INVOCATION_HIT.id).damageHits;
+    const pandemicRefreshPercent = hits / this.refreshes;
+    return (
+      <Statistic
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
+        tooltip={
+          <>
+            The % PI refreshes metric only counts DoT refreshes without corresponding PI hits as
+            "misses", it does not include reapplications of a dropped DoT. If your DoT uptime wasn't
+            close to 100% then you missed out on even more PI hits. If you know mechanics/range
+            won't interfere with refreshing a DoT inside the PI window, hold off on refreshing it
+            until then, especially on single target.
+          </>
+        }
+      >
+        <TalentSpellText talent={TALENTS.PANDEMIC_INVOCATION_TALENT}>
+          {formatNumber(shardsGained)} <small>Soul Shards generated</small>
+          <br />
+          {formatPercentage(pandemicRefreshPercent)} %{' '}
+          <TooltipElement content={`${hits} hits for ${this.refreshes} refreshes`}>
+            <small>DoT refreshes triggered PI</small>
+          </TooltipElement>
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}
+
+export default PandemicInvocation;

--- a/src/analysis/retail/warlock/affliction/modules/spells/ShadowEmbrace.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/spells/ShadowEmbrace.tsx
@@ -13,7 +13,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import UptimeBar from 'parser/ui/UptimeBar';
 
-const BONUS_PER_STACK = 0.03;
+const BONUS_PER_STACK_BASE = 0.015;
 const BUFFER = 50; // for some reason, changedebuffstack triggers twice on the same timestamp for each event, ignore an event if it happened < BUFFER ms after another
 const debug = false;
 
@@ -29,6 +29,9 @@ class ShadowEmbrace extends Analyzer {
     enemies: Enemies,
   };
   protected enemies!: Enemies;
+
+  BONUS_PER_STACK =
+    BONUS_PER_STACK_BASE * this.selectedCombatant.getTalentRank(TALENTS.SHADOW_EMBRACE_TALENT);
 
   damage = 0;
   private _lastEventTimestamp: number | null = null;
@@ -75,7 +78,7 @@ class ShadowEmbrace extends Analyzer {
     if (!shadowEmbrace) {
       return;
     }
-    this.damage += calculateEffectiveDamage(event, shadowEmbrace.stacks * BONUS_PER_STACK);
+    this.damage += calculateEffectiveDamage(event, shadowEmbrace.stacks * this.BONUS_PER_STACK);
   }
 
   onChangeDebuffStack(event: ChangeDebuffStackEvent) {
@@ -200,7 +203,7 @@ class ShadowEmbrace extends Analyzer {
           <TooltipElement
             content={
               <>
-                No stacks: {formatPercentage(uptimes[0])} %<br />1 stack:
+                No stacks: {formatPercentage(uptimes[0])} %<br />1 stack:{' '}
                 {formatPercentage(uptimes[1])} %<br />2 stacks: {formatPercentage(uptimes[2])} %
                 <br />3 stacks: {formatPercentage(uptimes[3])} %
               </>

--- a/src/analysis/retail/warlock/affliction/modules/spells/ShadowEmbrace.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/spells/ShadowEmbrace.tsx
@@ -8,9 +8,9 @@ import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
 import Events, { ChangeDebuffStackEvent, DamageEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import Enemies, { encodeTargetString } from 'parser/shared/modules/Enemies';
-import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import TalentSpellText from 'parser/ui/TalentSpellText';
 import UptimeBar from 'parser/ui/UptimeBar';
 
 const BONUS_PER_STACK_BASE = 0.015;
@@ -198,7 +198,7 @@ class ShadowEmbrace extends Analyzer {
         size="flexible"
         tooltip={`${formatThousands(this.damage)} bonus damage`}
       >
-        <BoringSpellValueText spellId={TALENTS.SHADOW_EMBRACE_TALENT.id}>
+        <TalentSpellText talent={TALENTS.SHADOW_EMBRACE_TALENT}>
           {formatPercentage(this.totalUptimePercentage)} %{' '}
           <TooltipElement
             content={
@@ -218,7 +218,7 @@ class ShadowEmbrace extends Analyzer {
           <small>
             {formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.damage))} % of total
           </small>
-        </BoringSpellValueText>
+        </TalentSpellText>
       </Statistic>
     );
   }

--- a/src/analysis/retail/warlock/affliction/modules/spells/TormentedCrescendo.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/spells/TormentedCrescendo.tsx
@@ -1,0 +1,86 @@
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/warlock';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, {
+  ApplyBuffEvent,
+  ApplyBuffStackEvent,
+  RefreshBuffEvent,
+  RemoveBuffEvent,
+} from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+
+const BUFF_DURATION = 10000;
+const BUFFER = 100;
+const MAX_STACKS = 2;
+
+class TormentedCrescendo extends Analyzer {
+  wastedProcs = 0;
+  stacks = 0;
+  private buffApplyTimestamp: number | null = null;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.TORMENTED_CRESCENDO_TALENT);
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.TORMENTED_CRESCENDO_BUFF),
+      this.onTormentedCrescendoApplyRefresh,
+    );
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.TORMENTED_CRESCENDO_BUFF),
+      this.onTormentedCrescendoApplyRefresh,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.TORMENTED_CRESCENDO_BUFF),
+      this.onTormentedCrescendoRemove,
+    );
+    this.addEventListener(
+      Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.TORMENTED_CRESCENDO_BUFF),
+      this.onTormentedCrescendoApplyStack,
+    );
+    this.addEventListener(
+      Events.removebuffstack.by(SELECTED_PLAYER).spell(SPELLS.TORMENTED_CRESCENDO_BUFF),
+      this.onTormentedCrescendoRemoveStack,
+    );
+  }
+
+  onTormentedCrescendoApplyRefresh(event: ApplyBuffEvent | RefreshBuffEvent) {
+    if (this.stacks === MAX_STACKS) {
+      this.wastedProcs += 1;
+    } else {
+      this.stacks += 1;
+    }
+    this.buffApplyTimestamp = event.timestamp;
+  }
+
+  onTormentedCrescendoApplyStack(event: ApplyBuffStackEvent) {
+    this.stacks += 1;
+    this.buffApplyTimestamp = event.timestamp;
+  }
+
+  onTormentedCrescendoRemoveStack() {
+    this.stacks -= 1;
+  }
+
+  onTormentedCrescendoRemove(event: RemoveBuffEvent) {
+    const expectedEnd = this.buffApplyTimestamp || 0 + BUFF_DURATION;
+    if (expectedEnd - BUFFER <= event.timestamp && event.timestamp <= expectedEnd + BUFFER) {
+      this.wastedProcs += 1;
+    }
+    this.stacks = 0;
+    this.buffApplyTimestamp = null;
+  }
+
+  statistic() {
+    return (
+      <Statistic category={STATISTIC_CATEGORY.TALENTS} size="flexible">
+        <TalentSpellText talent={TALENTS.TORMENTED_CRESCENDO_TALENT}>
+          {this.wastedProcs} <small>wasted procs</small>
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}
+
+export default TormentedCrescendo;

--- a/src/analysis/retail/warlock/affliction/modules/spells/VileTaint.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/spells/VileTaint.tsx
@@ -1,16 +1,12 @@
 import { formatThousands, formatPercentage, formatNumber } from 'common/format';
 import TALENTS from 'common/TALENTS/warlock';
+import SPELLS from 'common/SPELLS/warlock';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { ApplyDebuffEvent, CastEvent } from 'parser/core/Events';
+import Events from 'parser/core/Events';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
-
-// the application of the debuff (and first tick of damage) is instant after the cast, but seems to have a little bit of leeway across multiple enemies
-// this example log: /report/mvK3PYrbcwfj9qTG/15-LFR+Zul+-+Kill+(3:49)/16-Residentevil shows around +15ms, so setting 100ms buffer to account for lags
-const BUFFER = 100;
-const debug = false;
 
 class VileTaint extends Analyzer {
   static dependencies = {
@@ -18,9 +14,8 @@ class VileTaint extends Analyzer {
   };
   protected abilityTracker!: AbilityTracker;
 
-  _castTimestamp: number | null = null;
-  _currentCastCount = 0;
-  casts: number[] = [];
+  hits: number = 0;
+  casts: number = 0;
 
   constructor(options: Options) {
     super(options);
@@ -30,39 +25,23 @@ class VileTaint extends Analyzer {
       this.onVileTaintCast,
     );
     this.addEventListener(
-      Events.applydebuff.by(SELECTED_PLAYER).spell(TALENTS.VILE_TAINT_TALENT),
+      Events.applydebuff.by(SELECTED_PLAYER).spell(SPELLS.VILE_TAINT_DEBUFF),
       this.onVileTaintApplyDebuff,
     );
-    this.addEventListener(Events.fightend, this.onFinished);
   }
 
-  onVileTaintCast(event: CastEvent) {
-    if (this._castTimestamp !== null) {
-      // we've casted VT at least once, so we should add the current (at this time the previous) cast first before resetting the counter
-      this.casts.push(this._currentCastCount);
-    }
-    this._castTimestamp = event.timestamp;
-    this._currentCastCount = 0;
+  onVileTaintCast() {
+    this.casts += 1;
   }
 
-  onVileTaintApplyDebuff(event: ApplyDebuffEvent) {
-    if (event.timestamp <= (this._castTimestamp || 0) + BUFFER) {
-      this._currentCastCount += 1;
-    } else {
-      debug && console.log('Vile Taint debuff applied outside of the 100ms buffer after cast');
-    }
-  }
-
-  onFinished() {
-    // on each cast, the previous one is saved, so the "results" of the last VT cast in fight aren't saved, so do it on fight end
-    this.casts.push(this._currentCastCount);
+  onVileTaintApplyDebuff() {
+    this.hits += 1;
   }
 
   statistic() {
-    const spell = this.abilityTracker.getAbility(TALENTS.VILE_TAINT_TALENT.id);
-    const damage = spell.damageEffective + spell.damageAbsorbed;
-    const averageTargetsHit =
-      this.casts.reduce((total, current) => total + current, 0) / spell.casts || 0;
+    const debuff = this.abilityTracker.getAbility(SPELLS.VILE_TAINT_DEBUFF.id);
+    const damage = debuff.damageEffective + debuff.damageAbsorbed;
+    const averageTargetsHit = this.hits / this.casts;
     const dps = (damage / this.owner.fightDuration) * 1000;
     return (
       <Statistic

--- a/src/analysis/retail/warlock/affliction/modules/spells/WrathOfConsumption.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/spells/WrathOfConsumption.tsx
@@ -1,0 +1,62 @@
+import { formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/warlock';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+import UptimeIcon from 'interface/icons/Uptime';
+import { TooltipElement } from 'interface';
+
+class WrathOfConsumption extends Analyzer {
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.WRATH_OF_CONSUMPTION_TALENT);
+  }
+
+  get totalUptimePercent() {
+    return (
+      this.selectedCombatant.getBuffUptime(SPELLS.WRATH_OF_CONSUMPTION_BUFF.id) /
+      this.owner.fightDuration
+    );
+  }
+
+  get stackUptimesPercentages() {
+    const uptimePercentages: { [key: string]: number } = {};
+    Object.entries(
+      this.selectedCombatant.getStackBuffUptimes(SPELLS.WRATH_OF_CONSUMPTION_BUFF.id),
+    ).forEach(([stackCount, uptime]) =>
+      Number(stackCount) > 0
+        ? (uptimePercentages[stackCount] = uptime / this.owner.fightDuration)
+        : {},
+    );
+    return uptimePercentages;
+  }
+
+  statistic() {
+    const stackUptimes = this.stackUptimesPercentages;
+    return (
+      <Statistic category={STATISTIC_CATEGORY.TALENTS} size="flexible">
+        <TalentSpellText talent={TALENTS.WRATH_OF_CONSUMPTION_TALENT}>
+          <UptimeIcon /> {formatPercentage(this.totalUptimePercent, 0)} %{' '}
+          <TooltipElement
+            content={
+              <>
+                0 stacks: {formatPercentage(1 - this.totalUptimePercent)} %<br />1 stack:{' '}
+                {formatPercentage(stackUptimes[1])} %<br />2 stacks:{' '}
+                {formatPercentage(stackUptimes[2])} %<br />3 stacks:{' '}
+                {formatPercentage(stackUptimes[3])} % <br />4 stacks:{' '}
+                {formatPercentage(stackUptimes[4])} %<br />5 stacks:{' '}
+                {formatPercentage(stackUptimes[5])} %
+              </>
+            }
+          >
+            <small>uptime</small>
+          </TooltipElement>
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}
+
+export default WrathOfConsumption;

--- a/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
@@ -1,9 +1,10 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
-import { Sharrq, Zeboot, ToppleTheNun, Jonfanz, Mae } from 'CONTRIBUTORS';
+import { Sharrq, Zeboot, ToppleTheNun, Jonfanz, Mae, dodse } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 3, 9), "Update Soul Conduit to take into account being a 2 rank talent and different scaling", dodse),
   change(date(2023, 1, 4), "Add support for Shadow's Bite and Dread Calling talents", Mae),
   change(date(2022, 12, 29), 'Add support for Fel Covenant and 4 piece set bonus', Mae),
   change(date(2022, 12, 15), 'Fix crash caused by no Power Siphon casts being present in a log.', ToppleTheNun),

--- a/src/analysis/retail/warlock/demonology/modules/talents/SoulConduit.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/talents/SoulConduit.tsx
@@ -3,14 +3,14 @@ import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import { findMax, binomialPMF } from 'parser/shared/modules/helpers/Probability';
-import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import TalentSpellText from 'parser/ui/TalentSpellText';
 
 import SoulShardTracker from '../resources/SoulShardTracker';
 
 const SHARDS_PER_HOG = 3;
-const SC_PROC_CHANCE = 0.15;
+const SC_PROC_CHANCE_BASE = 0.05;
 
 class SoulConduit extends Analyzer {
   static dependencies = {
@@ -18,6 +18,9 @@ class SoulConduit extends Analyzer {
   };
 
   soulShardTracker!: SoulShardTracker;
+
+  SC_PROC_CHANCE =
+    SC_PROC_CHANCE_BASE * this.selectedCombatant.getTalentRank(TALENTS.SOUL_CONDUIT_TALENT);
 
   constructor(options: Options) {
     super(options);
@@ -29,7 +32,7 @@ class SoulConduit extends Analyzer {
     const extraHogs = Math.floor(generated / SHARDS_PER_HOG);
     const totalSpent = this.soulShardTracker.spent;
     // find number of Shards we were MOST LIKELY to get in the fight
-    const { max } = findMax(totalSpent, (k, n) => binomialPMF(k, n, SC_PROC_CHANCE));
+    const { max } = findMax(totalSpent, (k, n) => binomialPMF(k, n, this.SC_PROC_CHANCE));
     return (
       <Statistic
         category={STATISTIC_CATEGORY.TALENTS}
@@ -50,9 +53,9 @@ class SoulConduit extends Analyzer {
           </>
         }
       >
-        <BoringSpellValueText spellId={TALENTS.SOUL_CONDUIT_TALENT.id}>
+        <TalentSpellText talent={TALENTS.SOUL_CONDUIT_TALENT}>
           {generated} <small>Shards generated</small>
-        </BoringSpellValueText>
+        </TalentSpellText>
       </Statistic>
     );
   }

--- a/src/analysis/retail/warlock/destruction/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/destruction/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2023, 3, 9), "Update Soul Conduit to take into account being a 2 rank talent and different scaling", dodse),
   change(date(2023, 3, 5), "Update Havoc module to also work with Mayhem and try to identify damage from Havoc more accurately.", dodse),
   change(date(2023, 3, 5), "Update Madness module to track buffed RoF and Shadowburn.", dodse),
   change(date(2023, 3, 5), "Add Burn to Ashes buffed Incinerates statistic.", dodse),

--- a/src/analysis/retail/warlock/destruction/modules/talents/SoulConduit.tsx
+++ b/src/analysis/retail/warlock/destruction/modules/talents/SoulConduit.tsx
@@ -4,14 +4,14 @@ import TALENTS from 'common/TALENTS/warlock';
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import { findMax, binomialPMF } from 'parser/shared/modules/helpers/Probability';
-import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import TalentSpellText from 'parser/ui/TalentSpellText';
 
 import SoulShardTracker from '../soulshards/SoulShardTracker';
 
 const FRAGMENTS_PER_SHARD = 10;
-const SC_PROC_CHANCE = 0.15;
+const SC_PROC_CHANCE_BASE = 0.05;
 
 class SoulConduit extends Analyzer {
   get averageChaosBoltDamage() {
@@ -27,6 +27,9 @@ class SoulConduit extends Analyzer {
   protected soulShardTracker!: SoulShardTracker;
   protected abilityTracker!: AbilityTracker;
 
+  SC_PROC_CHANCE =
+    SC_PROC_CHANCE_BASE * this.selectedCombatant.getTalentRank(TALENTS.SOUL_CONDUIT_TALENT);
+
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS.SOUL_CONDUIT_TALENT);
@@ -39,7 +42,7 @@ class SoulConduit extends Analyzer {
     const estimatedDamage = Math.floor(generatedShards / 2) * this.averageChaosBoltDamage; // Chaos Bolt costs 2 shards to cast
     const totalSpent = this.soulShardTracker.spent / FRAGMENTS_PER_SHARD; // Destruction Soul Shard Tracker tracks fragments (10 fragments per shard)
     // find number of Shards we were MOST LIKELY to get in the fight
-    const { max } = findMax(totalSpent, (k, n) => binomialPMF(k, n, SC_PROC_CHANCE));
+    const { max } = findMax(totalSpent, (k, n) => binomialPMF(k, n, this.SC_PROC_CHANCE));
     return (
       <Statistic
         category={STATISTIC_CATEGORY.TALENTS}
@@ -65,9 +68,9 @@ class SoulConduit extends Analyzer {
           </>
         }
       >
-        <BoringSpellValueText spellId={TALENTS.SOUL_CONDUIT_TALENT.id}>
+        <TalentSpellText talent={TALENTS.SOUL_CONDUIT_TALENT}>
           {generatedShards} <small>generated Shards</small>
-        </BoringSpellValueText>
+        </TalentSpellText>
       </Statistic>
     );
   }

--- a/src/common/SPELLS/warlock.ts
+++ b/src/common/SPELLS/warlock.ts
@@ -295,6 +295,11 @@ const spells = spellIndexableList({
     name: 'Shadow Embrace',
     icon: 'spell_shadow_shadowembrace',
   },
+  TORMENTED_CRESCENDO_BUFF: {
+    id: 387079,
+    name: 'Tormented Crescendo',
+    icon: 'warlock_curse_shadow',
+  },
   VILE_TAINT_DEBUFF: {
     id: 386931,
     name: 'Vile Taint',

--- a/src/common/SPELLS/warlock.ts
+++ b/src/common/SPELLS/warlock.ts
@@ -280,6 +280,11 @@ const spells = spellIndexableList({
     name: 'Shadow Embrace',
     icon: 'spell_shadow_shadowembrace',
   },
+  VILE_TAINT_DEBUFF: {
+    id: 386931,
+    name: 'Vile Taint',
+    icon: 'sha_spell_shadow_shadesofdarkness_nightborne',
+  },
 
   // Affliction shard generating effects
   AGONY_SHARD_GEN: {

--- a/src/common/SPELLS/warlock.ts
+++ b/src/common/SPELLS/warlock.ts
@@ -265,6 +265,11 @@ const spells = spellIndexableList({
     name: 'Dread Touch',
     icon: 'ability_priest_touchofdecay',
   },
+  MALEFIC_AFFLICTION_BUFF: {
+    id: 389845,
+    name: 'Malefic Affliction',
+    icon: 'spell_shadow_unstableaffliction_3_purple',
+  },
   NIGHTFALL_BUFF: {
     id: 264571,
     name: 'Nightfall',

--- a/src/common/SPELLS/warlock.ts
+++ b/src/common/SPELLS/warlock.ts
@@ -275,6 +275,16 @@ const spells = spellIndexableList({
     name: 'Nightfall',
     icon: 'spell_shadow_twilight',
   },
+  PANDEMIC_INVOCATION_HIT: {
+    id: 386760,
+    name: 'Pandemic Invocation',
+    icon: 'spell_shadow_unsummonbuilding',
+  },
+  PANDEMIC_INVOCATION_SHARD_GEN: {
+    id: 386762,
+    name: 'Pandemic Invocation',
+    icon: 'spell_shadow_unsummonbuilding',
+  },
   PHANTOM_SINGULARITY_DAMAGE_HEAL: {
     id: 205246,
     name: 'Phantom Singularity',

--- a/src/common/SPELLS/warlock.ts
+++ b/src/common/SPELLS/warlock.ts
@@ -305,6 +305,11 @@ const spells = spellIndexableList({
     name: 'Vile Taint',
     icon: 'sha_spell_shadow_shadesofdarkness_nightborne',
   },
+  WRATH_OF_CONSUMPTION_BUFF: {
+    id: 387066,
+    name: 'Wrath of Consumption',
+    icon: 'spell_nature_drowsy',
+  },
 
   // Affliction shard generating effects
   AGONY_SHARD_GEN: {

--- a/src/common/SPELLS/warlock.ts
+++ b/src/common/SPELLS/warlock.ts
@@ -265,6 +265,11 @@ const spells = spellIndexableList({
     name: 'Dread Touch',
     icon: 'ability_priest_touchofdecay',
   },
+  INEVITABLE_DEMISE_BUFF: {
+    id: 334320,
+    name: 'Inevitable Demise',
+    icon: 'spell_warlock_harvestoflife',
+  },
   MALEFIC_AFFLICTION_BUFF: {
     id: 389845,
     name: 'Malefic Affliction',

--- a/src/common/SPELLS/warlock.ts
+++ b/src/common/SPELLS/warlock.ts
@@ -285,11 +285,6 @@ const spells = spellIndexableList({
     name: 'Pandemic Invocation',
     icon: 'spell_shadow_unsummonbuilding',
   },
-  PANDEMIC_INVOCATION_SHARD_GEN: {
-    id: 386762,
-    name: 'Pandemic Invocation',
-    icon: 'spell_shadow_unsummonbuilding',
-  },
   PHANTOM_SINGULARITY_DAMAGE_HEAL: {
     id: 205246,
     name: 'Phantom Singularity',
@@ -341,6 +336,11 @@ const spells = spellIndexableList({
     id: 215942,
     name: 'Soul Conduit',
     icon: 'spell_shadow_soulleech_2',
+  },
+  PANDEMIC_INVOCATION_SHARD_GEN: {
+    id: 386762,
+    name: 'Pandemic Invocation',
+    icon: 'spell_shadow_unsummonbuilding',
   },
 
   // -----------


### PR DESCRIPTION
### Description

- updated Soul Conduit for all specs to take into account talent rank scaling, and updated Affliction's module to use rapture as the example spender instead of UA.
- added some hasTalent checks for Darkglare so certain components don't try to render when you don't have it talented
- fixed Vile Taint not checking for the right debuff id
- updated Shadow Embrace and Nightfall to take into account stacking and talent scaling
- Added modules for Wrath of Consumption, Inevitable Demise, Pandemic Invocation, and Tormented Crescendo

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: 
Log showing Wrath and Vile Taint: `report/4TZ7hgKVbw2jk8Pz/30-Mythic+Sennarth,+The+Cold+Breath+-+Kill+(6:41)/Omenity/standard/statistics`
Log showing Inevitable Demise, Pandemic Invocation, Tormented Crescendo: `report/z3qaHpWNC4JKVYjf/18-Mythic+Terros+-+Kill+(5:34)/Dodse/standard/statistics`
- Screenshot(s):
![image](https://user-images.githubusercontent.com/473389/224214904-e5dd9046-5a61-415d-b184-3f843e35a516.png)
![image](https://user-images.githubusercontent.com/473389/224215160-ed2e7329-e7d5-4a9f-88bc-a9bcfe682441.png)

