### PR TITLE
[Outlaw] Core rotation section with finisher subsection

### DIFF
--- a/src/analysis/retail/rogue/outlaw/CHANGELOG.tsx
+++ b/src/analysis/retail/rogue/outlaw/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SHARED_CHANGELOG from 'analysis/retail/rogue/shared/CHANGELOG';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2023, 3, 12), <>Add core rotation section with finishers subsection.</>, zac),
   change(date(2023, 3, 8), <>Small updates to the APL section.</>, zac),
   change(date(2023, 3, 5), <>First pass at APL section.</>, zac),
   change(date(2023, 2, 26), <>First pass at guide with resource section.</>, zac),

--- a/src/analysis/retail/rogue/outlaw/Guide.tsx
+++ b/src/analysis/retail/rogue/outlaw/Guide.tsx
@@ -14,6 +14,7 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
   return (
     <>
       <ResourceUsageSection modules={modules} events={events} info={info} />
+      <CoreRotationSection modules={modules} events={events} info={info} />
       <ActionPriorityList modules={modules} events={events} info={info} />
       <PreparationSection />
     </>
@@ -83,6 +84,19 @@ function ResourceUsageSection({ modules, info }: GuideProps<typeof CombatLogPars
           </Trans>
         </p>
       </SubSection>
+    </Section>
+  );
+}
+
+function CoreRotationSection({ modules, info }: GuideProps<typeof CombatLogParser>) {
+  return (
+    <Section
+      title={t({
+        id: 'guide.rogue.outlaw.sections.coreRotation.title',
+        message: 'Core rotation',
+      })}
+    >
+      {modules.finisherUse.guide}
     </Section>
   );
 }

--- a/src/analysis/retail/rogue/outlaw/modules/Abilities.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/Abilities.tsx
@@ -216,9 +216,9 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.RIPOSTE.id,
+        spell: TALENTS.EVASION_TALENT.id,
         category: SPELL_CATEGORY.DEFENSIVE,
-        buffSpellId: SPELLS.RIPOSTE.id,
+        buffSpellId: TALENTS.EVASION_TALENT.id,
         cooldown: 120,
         gcd: null,
       },

--- a/src/analysis/retail/rogue/outlaw/modules/Abilities.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/Abilities.tsx
@@ -256,6 +256,14 @@ class Abilities extends CoreAbilities {
         category: SPELL_CATEGORY.UTILITY,
         cooldown: 60 - (combatant.hasTalent(TALENTS.RETRACTABLE_HOOK_TALENT) ? 30 : 0),
         gcd: null,
+        enabled: combatant.hasTalent(TALENTS.GRAPPLING_HOOK_TALENT),
+      },
+      {
+        spell: TALENTS.SHADOWSTEP_SHARED_TALENT.id,
+        category: SPELL_CATEGORY.UTILITY,
+        cooldown: 30,
+        gcd: null,
+        enabled: combatant.hasTalent(TALENTS.SHADOWSTEP_SHARED_TALENT),
       },
       {
         spell: SPELLS.SPRINT.id,

--- a/src/analysis/retail/rogue/outlaw/modules/Buffs.ts
+++ b/src/analysis/retail/rogue/outlaw/modules/Buffs.ts
@@ -28,6 +28,10 @@ class Buffs extends CoreAuras {
         timelineHighlight: true,
       },
 
+      {
+        spellId: SPELLS.SLICE_AND_DICE.id,
+      },
+
       // Talents
       {
         spellId: TALENTS.ALACRITY_TALENT.id,

--- a/src/analysis/retail/rogue/outlaw/modules/apl/AplCheck.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/apl/AplCheck.tsx
@@ -71,6 +71,10 @@ const rtbCondition = () => {
           buffMissing(SPELLS.SHADOW_DANCE_BUFF),
           optionalRule(buffPresent(SPELLS.SHADOW_DANCE_BUFF)),
         ),
+        // allow not rerolling during subterfuge window
+        or(buffMissing(SPELLS.SUBTERFUGE_BUFF), optionalRule(buffPresent(SPELLS.SUBTERFUGE_BUFF))),
+        // same for vanish buff
+        or(buffMissing(SPELLS.VANISH_BUFF), optionalRule(buffPresent(SPELLS.VANISH_BUFF))),
       ),
       (tense) => (
         <>

--- a/src/analysis/retail/rogue/outlaw/modules/apl/betweenTheEyesMissing.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/apl/betweenTheEyesMissing.tsx
@@ -36,7 +36,14 @@ export function betweenTheEyesMissing(): Condition<{ [key: string]: DurationData
           if (event.ability.guid === BTE_ID) {
             const encodedTargetString = encodeTargetString(event.targetID, event.targetInstance);
             const castEvent = getHardcast(event)!;
-            const cpSpent = getResourceSpent(castEvent, RESOURCE_TYPES.COMBO_POINTS);
+            if (castEvent == null) {
+              console.log(event);
+              console.log(castEvent);
+              console.warn('Linked between the eyes cast missing, incomplete log?');
+            }
+            const cpSpent = castEvent
+              ? getResourceSpent(castEvent, RESOURCE_TYPES.COMBO_POINTS)
+              : 7;
             state[encodedTargetString] = {
               referenceTime: event.timestamp,
               timeRemaining: cpSpent * BTE_TIME_PER_CP_SPENT,

--- a/src/analysis/retail/rogue/outlaw/modules/apl/betweenTheEyesMissing.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/apl/betweenTheEyesMissing.tsx
@@ -37,9 +37,7 @@ export function betweenTheEyesMissing(): Condition<{ [key: string]: DurationData
             const encodedTargetString = encodeTargetString(event.targetID, event.targetInstance);
             const castEvent = getHardcast(event)!;
             if (castEvent == null) {
-              console.log(event);
-              console.log(castEvent);
-              console.warn('Linked between the eyes cast missing, incomplete log?');
+              console.warn('Linked between the eyes cast missing, incomplete log?', event);
             }
             const cpSpent = castEvent
               ? getResourceSpent(castEvent, RESOURCE_TYPES.COMBO_POINTS)

--- a/src/analysis/retail/rogue/outlaw/modules/core/FinisherUse.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/core/FinisherUse.tsx
@@ -1,24 +1,53 @@
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent } from 'parser/core/Events';
+import Events, { CastEvent, TargettedEvent } from 'parser/core/Events';
 import { BadColor, GoodColor } from 'interface/guide';
-import { ResourceLink } from 'interface';
+import { SpellLink } from 'interface';
 import DonutChart from 'parser/ui/DonutChart';
-import Statistic from 'parser/ui/Statistic';
-import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import getResourceSpent from 'parser/core/getResourceSpent';
 import { FINISHERS, getMaxComboPoints } from '../../constants';
 import Finishers from '../features/Finishers';
+import SPELLS from 'common/SPELLS';
+import TALENTS, { TALENTS_ROGUE } from 'common/TALENTS/rogue';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import BetweenTheEyes from '../spells/BetweenTheEyes';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import { ChecklistUsageInfo, SpellUse, spellUseToBoxRowEntry } from 'parser/core/SpellUsage/core';
+import { ReactNode } from 'react';
+import { combineQualitativePerformances } from 'common/combineQualitativePerformances';
+import SpellUsageSubSection from 'parser/core/SpellUsage/SpellUsageSubSection';
+import { formatDurationMillisMinSec } from 'common/format';
+
+const BTE_ACCEPTABLE_REFRESH_TIME = 6000;
+const BTE_FLAG_REFRESH_TIME = 4000;
+
+//-- TODO: Add a slice and dice module to track buff remaining duration, not really necessary as of now since we barely press the spell
+//         Find a log that actually plays with improved between the eyes to check if everything is correct
 
 export default class FinisherUse extends Analyzer {
   static dependencies = {
     finishers: Finishers,
+    spellUsable: SpellUsable,
+    betweenTheEyes: BetweenTheEyes,
   };
 
   protected finishers!: Finishers;
+  protected spellUsable!: SpellUsable;
+  protected betweenTheEyes!: BetweenTheEyes;
+
+  protected hasImprovedBteTalent = this.selectedCombatant.hasTalent(
+    TALENTS_ROGUE.IMPROVED_BETWEEN_THE_EYES_TALENT,
+  );
+  protected hasCountTheOddsTalent = this.selectedCombatant.hasTalent(
+    TALENTS_ROGUE.COUNT_THE_ODDS_TALENT,
+  );
+  protected hasGreenskinTalent = this.selectedCombatant.hasTalent(
+    TALENTS_ROGUE.GREENSKINS_WICKERS_TALENT,
+  );
 
   totalFinisherCasts = 0;
   lowCpFinisherCasts = 0;
+  spellUses: SpellUse[] = [];
 
   constructor(options: Options) {
     super(options);
@@ -49,28 +78,318 @@ export default class FinisherUse extends Analyzer {
     return <DonutChart items={items} />;
   }
 
-  statistic() {
-    return (
-      <Statistic position={STATISTIC_ORDER.CORE(6)}>
-        <div className="pad">
-          <label>
-            <ResourceLink id={RESOURCE_TYPES.COMBO_POINTS.id} /> spender usage
-          </label>
-          {this.chart}
-        </div>
-      </Statistic>
-    );
-  }
-
   private onCast(event: CastEvent) {
     const cpsSpent = getResourceSpent(event, RESOURCE_TYPES.COMBO_POINTS);
+    const spellId = event.ability.guid;
+
     if (cpsSpent === 0) {
       return;
     }
 
+    //- CP performance
+
+    const targetCps = this.finishers.recommendedFinisherPoints();
+    let cpsPerformance = QualitativePerformance.Good;
+    let cpsSummary: ReactNode;
+    let cpsDetails: ReactNode;
+
     this.totalFinisherCasts += 1;
-    if (cpsSpent < this.finishers.recommendedFinisherPoints()) {
+    if (cpsSpent < targetCps) {
       this.lowCpFinisherCasts += 1;
+
+      cpsPerformance = QualitativePerformance.Fail;
+      cpsSummary = <div>Spend &gt;= {targetCps} CPs</div>;
+      cpsDetails = (
+        <div>
+          You spent {cpsSpent} CPs. Try to always spend at least {targetCps} CPs when casting a
+          finisher.
+        </div>
+      );
+    } else {
+      cpsSummary = <div>Spent &gt;= {targetCps} CPs</div>;
+      cpsDetails = <div>You spent {cpsSpent} CPs.</div>;
     }
+
+    //- Finisher choice performance
+    const checklistFinisherChoice: ChecklistUsageInfo = {
+      check: 'finisher choice',
+      timestamp: event.timestamp,
+      performance: QualitativePerformance.Good,
+      summary: <></>,
+      details: (
+        <>
+          You cast <SpellLink id={spellId} />{' '}
+        </>
+      ),
+    };
+
+    const bteDebuffRemainingTime = this.betweenTheEyes.getTimeRemaining(
+      event as TargettedEvent<any>,
+    );
+    const bteCDRemainingTime = this.spellUsable.cooldownRemaining(SPELLS.BETWEEN_THE_EYES.id);
+    const hasSnD = this.selectedCombatant.getBuff(
+      SPELLS.SLICE_AND_DICE.id,
+      event.timestamp,
+      0,
+      200,
+    );
+
+    if (this.hasGreenskinTalent) {
+      checklistFinisherChoice.summary = (
+        <div>
+          Time remaining on between the eyes cooldown:{' '}
+          {formatDurationMillisMinSec(bteCDRemainingTime)}
+        </div>
+      );
+    } else {
+      checklistFinisherChoice.summary = (
+        <div>
+          Time remaining on between the eyes debuff:{' '}
+          {formatDurationMillisMinSec(bteDebuffRemainingTime)}
+        </div>
+      );
+    }
+
+    switch (spellId) {
+      case SPELLS.BETWEEN_THE_EYES.id:
+        {
+          const hasGreenskinBuff = this.selectedCombatant.hasBuff(
+            TALENTS_ROGUE.GREENSKINS_WICKERS_TALENT.id,
+          );
+
+          if (this.hasGreenskinTalent) {
+            if (hasGreenskinBuff) {
+              checklistFinisherChoice.performance = QualitativePerformance.Ok;
+              checklistFinisherChoice.summary = (
+                <div>Greenskin Wickers buff was already present</div>
+              );
+              checklistFinisherChoice.details = (
+                <div>
+                  You used <SpellLink id={SPELLS.BETWEEN_THE_EYES.id} /> with a{' '}
+                  <SpellLink id={TALENTS_ROGUE.GREENSKINS_WICKERS_TALENT.id} /> buff already
+                  present, try to not override your{' '}
+                  <SpellLink id={TALENTS_ROGUE.GREENSKINS_WICKERS_TALENT.id} /> buffs.
+                </div>
+              );
+            } else {
+              checklistFinisherChoice.summary = <div>Between the eyes used</div>;
+              checklistFinisherChoice.details = (
+                <div>
+                  You used <SpellLink id={SPELLS.BETWEEN_THE_EYES.id} /> and gained a{' '}
+                  <SpellLink id={TALENTS_ROGUE.GREENSKINS_WICKERS_TALENT.id} /> buff.
+                </div>
+              );
+            }
+          } else if (
+            bteDebuffRemainingTime > BTE_ACCEPTABLE_REFRESH_TIME &&
+            !this.hasImprovedBteTalent
+          ) {
+            checklistFinisherChoice.performance = QualitativePerformance.Ok;
+            checklistFinisherChoice.details = (
+              <div>
+                You used <SpellLink id={SPELLS.BETWEEN_THE_EYES.id} /> with{' '}
+                {formatDurationMillisMinSec(bteDebuffRemainingTime)} left on the debuff, since you
+                aren't playing <SpellLink id={TALENTS_ROGUE.GREENSKINS_WICKERS_TALENT.id} /> talent,
+                you do not need to refresh the debuff this early, try to instead keep the cooldown
+                ready in case of target swapping for example. Refreshing the debuff early before a{' '}
+                <SpellLink id={TALENTS_ROGUE.SHADOW_DANCE_TALENT.id} /> window is however fine.
+              </div>
+            );
+          } else if (bteDebuffRemainingTime === 0) {
+            checklistFinisherChoice.summary = <div>Between the eyes debuff applied</div>;
+            checklistFinisherChoice.details = (
+              <div>
+                You applied <SpellLink id={SPELLS.BETWEEN_THE_EYES.id} /> debuff.
+              </div>
+            );
+          } else {
+            checklistFinisherChoice.details = (
+              <div>
+                You used <SpellLink id={SPELLS.BETWEEN_THE_EYES.id} /> with{' '}
+                {formatDurationMillisMinSec(bteDebuffRemainingTime)} left on the debuff.
+              </div>
+            );
+          }
+        }
+        break;
+      case SPELLS.SLICE_AND_DICE.id:
+        // Add SnD remaining time here
+        checklistFinisherChoice.details = <div>{checklistFinisherChoice.details}.</div>;
+
+        if (!this.bteCondition(event, checklistFinisherChoice)) {
+          if (!hasSnD) {
+            checklistFinisherChoice.summary = <div>No slice and dice buff running</div>;
+          }
+        }
+        break;
+      case SPELLS.DISPATCH.id:
+        if (!this.bteCondition(event, checklistFinisherChoice)) {
+          if (!hasSnD && !this.selectedCombatant.hasBuff(SPELLS.GRAND_MELEE.id)) {
+            checklistFinisherChoice.performance = QualitativePerformance.Fail;
+            checklistFinisherChoice.summary = <div>Slice and dice buff was missing</div>;
+            checklistFinisherChoice.details = (
+              <div>
+                {checklistFinisherChoice.details} with <SpellLink id={SPELLS.SLICE_AND_DICE.id} />{' '}
+                buff down, try to maintain the buff at all time.
+              </div>
+            );
+          } else if (this.hasGreenskinTalent) {
+            checklistFinisherChoice.details = (
+              <div>
+                {checklistFinisherChoice.details} with{' '}
+                {formatDurationMillisMinSec(bteCDRemainingTime)} left on{' '}
+                <SpellLink id={SPELLS.BETWEEN_THE_EYES.id} /> cooldown.
+              </div>
+            );
+          } else {
+            checklistFinisherChoice.details = (
+              <div>
+                {checklistFinisherChoice.details} with{' '}
+                {formatDurationMillisMinSec(bteDebuffRemainingTime)} left on{' '}
+                <SpellLink id={SPELLS.BETWEEN_THE_EYES.id} /> debuff.
+              </div>
+            );
+          }
+        }
+        break;
+      default:
+        checklistFinisherChoice.details = <div>{checklistFinisherChoice.details}.</div>;
+        break;
+    }
+
+    const checklistItems: ChecklistUsageInfo[] = [
+      checklistFinisherChoice,
+      {
+        check: 'cps',
+        timestamp: event.timestamp,
+        performance: cpsPerformance,
+        summary: cpsSummary,
+        details: cpsDetails,
+      },
+    ];
+
+    const performance = combineQualitativePerformances(checklistItems.map((it) => it.performance));
+
+    this.spellUses.push({
+      event,
+      performance: performance,
+      checklistItems: checklistItems,
+      performanceExplanation:
+        performance !== QualitativePerformance.Fail ? `${performance} Usage` : 'Bad Usage',
+    });
+  }
+
+  get guide(): JSX.Element {
+    const explanation = (
+      <p>
+        <strong>Finishers</strong> should typically be used at 1 below max combo points or higher.
+        You want to maintain as close to possible 100% uptime on both{' '}
+        <SpellLink id={SPELLS.BETWEEN_THE_EYES} /> and <SpellLink id={SPELLS.SLICE_AND_DICE} />{' '}
+        buff.
+        {this.hasGreenskinTalent && (
+          <p>
+            {' '}
+            Since you are talented into <SpellLink id={TALENTS.GREENSKINS_WICKERS_TALENT} /> you
+            want to cast <SpellLink id={SPELLS.BETWEEN_THE_EYES} /> as close to on cd as possible to
+            maximise the proc uptime.
+          </p>
+        )}
+      </p>
+    );
+
+    const performances = this.spellUses.map((it) =>
+      spellUseToBoxRowEntry(it, this.owner.fight.start_time),
+    );
+
+    return (
+      <SpellUsageSubSection
+        explanation={explanation}
+        performance={performances}
+        uses={this.spellUses}
+        castBreakdownSmallText={
+          <> - Green is a good cast, Yellow is an ok cast, Red is a bad cast.</>
+        }
+      />
+    );
+  }
+
+  private bteCondition(event: CastEvent, checkListFinisher: ChecklistUsageInfo): boolean {
+    const wasBtEReady = this.spellUsable.isAvailable(SPELLS.BETWEEN_THE_EYES.id);
+
+    if (!wasBtEReady) {
+      return false;
+    }
+
+    const hasRuthlessPrecisionBuff = this.selectedCombatant.hasBuff(SPELLS.RUTHLESS_PRECISION.id);
+    const hasGreenskinBuff = this.selectedCombatant.hasBuff(
+      TALENTS_ROGUE.GREENSKINS_WICKERS_TALENT.id,
+    );
+    const hasShadowDanceBuff = this.selectedCombatant.hasBuff(SPELLS.SHADOW_DANCE_BUFF.id);
+    const bteRemainingTime = this.betweenTheEyes.getTimeRemaining(event as TargettedEvent<any>);
+
+    if (this.hasGreenskinTalent && !hasGreenskinBuff) {
+      checkListFinisher.performance = QualitativePerformance.Fail;
+      checkListFinisher.summary = <div>Between the eyes was ready</div>;
+      checkListFinisher.details = (
+        <div>
+          {checkListFinisher.details} with <SpellLink id={SPELLS.BETWEEN_THE_EYES} /> off cooldown,
+          when talented into <SpellLink id={TALENTS_ROGUE.GREENSKINS_WICKERS_TALENT} /> you should
+          try to use <SpellLink id={SPELLS.BETWEEN_THE_EYES} /> as much on cd as possible.
+        </div>
+      );
+      return true;
+    }
+
+    if (this.hasCountTheOddsTalent && hasShadowDanceBuff) {
+      return false;
+    }
+
+    if (this.hasImprovedBteTalent && hasRuthlessPrecisionBuff) {
+      checkListFinisher.performance = QualitativePerformance.Fail;
+      checkListFinisher.summary = <div>Between the eyes was ready</div>;
+      checkListFinisher.details = (
+        <div>
+          {checkListFinisher.details} with <SpellLink id={SPELLS.BETWEEN_THE_EYES.id} /> off
+          cooldown, when talented into{' '}
+          <SpellLink id={TALENTS_ROGUE.IMPROVED_BETWEEN_THE_EYES_TALENT.id} /> try to use{' '}
+          <SpellLink id={SPELLS.BETWEEN_THE_EYES.id} /> on cooldown with{' '}
+          <SpellLink id={SPELLS.RUTHLESS_PRECISION.id} /> buff up.
+        </div>
+      );
+      return true;
+    }
+
+    if (!bteRemainingTime) {
+      checkListFinisher.performance = QualitativePerformance.Fail;
+      checkListFinisher.summary = <div>Between the eyes debuff was missing from the target</div>;
+      checkListFinisher.details = (
+        <div>
+          {checkListFinisher.details} with no <SpellLink id={SPELLS.BETWEEN_THE_EYES.id} /> debuff
+          up and the spell ready to use, never let <SpellLink id={SPELLS.BETWEEN_THE_EYES.id} />{' '}
+          debuff fall off.
+        </div>
+      );
+      return true;
+    }
+
+    if (bteRemainingTime < BTE_FLAG_REFRESH_TIME) {
+      checkListFinisher.performance = QualitativePerformance.Ok;
+      checkListFinisher.summary = (
+        <div>
+          Time remaining on between the eyes: {formatDurationMillisMinSec(bteRemainingTime)}
+        </div>
+      );
+      checkListFinisher.details = (
+        <div>
+          You cast <SpellLink id={SPELLS.DISPATCH.id} /> with{' '}
+          <SpellLink id={SPELLS.BETWEEN_THE_EYES.id} /> off cooldown and{' '}
+          {formatDurationMillisMinSec(bteRemainingTime)} left on its debuff, try to refresh{' '}
+          <SpellLink id={SPELLS.BETWEEN_THE_EYES.id} /> debuff early to not let it fall off.
+        </div>
+      );
+      return true;
+    }
+
+    return false;
   }
 }

--- a/src/analysis/retail/rogue/outlaw/modules/talents/BladeRush.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/talents/BladeRush.tsx
@@ -81,6 +81,9 @@ class BladeRush extends Analyzer {
   private onBladeRush(event: CastEvent) {
     let value = QualitativePerformance.Good;
     const energy = getResource(event.classResources, RESOURCE_TYPES.ENERGY.id);
+    if (!energy) {
+      return;
+    }
     const tooltip = (
       <>
         At {this.owner.formatTimestamp(event.timestamp)} you cast{' '}

--- a/src/analysis/retail/rogue/outlaw/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/rogue/outlaw/normalizers/CastLinkNormalizer.ts
@@ -30,6 +30,16 @@ const EVENT_LINKS: EventLink[] = [
     forwardBufferMs: CAST_BUFFER_MS,
     backwardBufferMs: CAST_BUFFER_MS,
   },
+  {
+    linkRelation: FROM_HARDCAST,
+    reverseLinkRelation: HIT_TARGET,
+    linkingEventId: SPELLS.SLICE_AND_DICE.id,
+    linkingEventType: [EventType.ApplyDebuff, EventType.RefreshDebuff],
+    referencedEventId: SPELLS.SLICE_AND_DICE.id,
+    referencedEventType: EventType.Cast,
+    forwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: CAST_BUFFER_MS,
+  },
 ];
 
 /**


### PR DESCRIPTION
### Description

First subsection of the core rotation section that tracks finisher usage.

Getting this error since I added this new subsection, not exactly sure what causes this
![image](https://user-images.githubusercontent.com/109383107/224540004-7ddb4b73-a270-4631-8627-5accb7f387ee.png)
Also very rarely after making a change? (not exactly sure when it actually happens, haven't been able to reproduce the issue) the boxes aren't all getting rendered, not sure if that would be linked to this error

<!-- A brief description of the changes made with this pull request.-->

### Testing

**Without Greenskin wickers talent:** `https://www.warcraftlogs.com/reports/kGZzydbhQrpMDLvw#fight=3&type=damage-done&source=16`
![image](https://user-images.githubusercontent.com/109383107/224539740-2dc42575-3f0b-4c48-a6c5-63c3abe1e356.png)

**With Greenskin wickers talent:** `https://www.warcraftlogs.com/reports/ADQxzVR9NvLt8rc4#fight=13&type=damage-done&source=111`
![image](https://user-images.githubusercontent.com/109383107/224539666-163f8769-24d1-4e4f-b8aa-1e589dc1f580.png)
