### PR TITLE
[Arcane Mage] Arcane Harmony damage multiplier not updated from Shadowlands #5894

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2129,3 +2129,7 @@ export const dodse: Contributor = {
   github: 'dsnam',
   discord: 'dsn#4942',
 };
+export const SyncSubaru: Contributor = {
+  nickname: 'SyncSubaru',
+  github: 'cameronstubber',
+};

--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -1,9 +1,10 @@
 import { change, date } from 'common/changelog';
 import talents from 'common/TALENTS/mage';
-import { Sharrq, emallson } from 'CONTRIBUTORS';
+import { Sharrq, emallson, SyncSubaru } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 3, 13), <>Updated bonus damage multiplier of <SpellLink id={talents.ARCANE_HARMONY_TALENT} />.</>, SyncSubaru),
   change(date(2023, 1, 17), <>Fixed outdated reference to the Shadowlands version of <SpellLink id={talents.RADIANT_SPARK_TALENT} />.</>, emallson),
   change(date(2022, 10, 30), `Update Dragonflight SPELLS, Abilities, and Buffs`, Sharrq),
   change(date(2022, 9, 29), 'Initial Dragonflight support', Sharrq),

--- a/src/analysis/retail/mage/arcane/talents/ArcaneHarmony.tsx
+++ b/src/analysis/retail/mage/arcane/talents/ArcaneHarmony.tsx
@@ -10,7 +10,7 @@ import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 
-const DAMAGE_BONUS_PER_STACK = 0.08;
+const DAMAGE_BONUS_PER_STACK = 0.05;
 
 class ArcaneHarmony extends Analyzer {
   static dependencies = {


### PR DESCRIPTION
### Description

fixes #5894 

Simply updating the constant for Arcane Harmony damage per stack from 8% to 5%

### Motivation

To make bonus damage calculations for Arcane Harmony more accurate.

### Testing

Comparing an Arcane Mage before and after should have a different bonus damage total for the parse.