### PR TITLE
Arcane harmony stats

### DIFF
--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { Sharrq, emallson, SyncSubaru } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 3, 14), <><SpellLink id={talents.ARCANE_HARMONY_TALENT} /> now shows Bonus Damage under Statistics.</>, SyncSubaru),
   change(date(2023, 3, 13), <>Updated bonus damage multiplier of <SpellLink id={talents.ARCANE_HARMONY_TALENT} />.</>, SyncSubaru),
   change(date(2023, 1, 17), <>Fixed outdated reference to the Shadowlands version of <SpellLink id={talents.RADIANT_SPARK_TALENT} />.</>, emallson),
   change(date(2022, 10, 30), `Update Dragonflight SPELLS, Abilities, and Buffs`, Sharrq),

--- a/src/analysis/retail/mage/arcane/talents/ArcaneHarmony.tsx
+++ b/src/analysis/retail/mage/arcane/talents/ArcaneHarmony.tsx
@@ -6,9 +6,9 @@ import { SELECTED_PLAYER } from 'parser/core/EventFilter';
 import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
-import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import { formatNumber } from 'common/format';
 
 const DAMAGE_BONUS_PER_STACK = 0.05;
 
@@ -24,7 +24,7 @@ class ArcaneHarmony extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = false;
+    this.active = this.selectedCombatant.hasTalent(TALENTS.ARCANE_HARMONY_TALENT);
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(TALENTS.ARCANE_BARRAGE_TALENT),
       this.onBarrageCast,
@@ -56,13 +56,22 @@ class ArcaneHarmony extends Analyzer {
     );
   }
 
+  get dpsIncrease() {
+    const fight = this.owner.fight;
+    const totalFightTime = fight.end_time - fight.start_time;
+
+    return (this.bonusDamage / totalFightTime) * 1000;
+  }
+
   statistic() {
     return (
-      <Statistic category={STATISTIC_CATEGORY.ITEMS} size="flexible">
+      <Statistic category={STATISTIC_CATEGORY.TALENTS} size="flexible">
         <BoringSpellValueText spellId={SPELLS.ARCANE_HARMONY_BUFF.id}>
-          <ItemDamageDone amount={this.bonusDamage} />
+          {formatNumber(this.bonusDamage)} <small>Bonus Damage</small>
           <br />
-          {this.averageStacks.toFixed(2)} <small>Avg. stacks per Barrage</small>
+          {formatNumber(this.dpsIncrease)} <small>DPS</small>
+          <br />
+          {formatNumber(this.averageStacks)} <small>Avg. stacks per Barrage</small>
         </BoringSpellValueText>
       </Statistic>
     );

--- a/src/analysis/retail/mage/arcane/talents/ArcaneHarmony.tsx
+++ b/src/analysis/retail/mage/arcane/talents/ArcaneHarmony.tsx
@@ -65,7 +65,11 @@ class ArcaneHarmony extends Analyzer {
 
   statistic() {
     return (
-      <Statistic category={STATISTIC_CATEGORY.TALENTS} size="flexible">
+      <Statistic
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
+        tooltip="Arcane Harmony makes Arcane Barrage do extra damage with more stacks. Try to hold Arcane Barrage until you reach 20 stacks of Arcane Harmony. You can spam Arcane Missiles to build stacks during Hero/Bloodlust/Timewarp while standing in your Rune of Power before starting the Radiant Spark Ramp."
+      >
         <BoringSpellValueText spellId={SPELLS.ARCANE_HARMONY_BUFF.id}>
           {formatNumber(this.bonusDamage)} <small>Bonus Damage</small>
           <br />


### PR DESCRIPTION
### Description

fixes #5893 

Takes the existing Arcane Harmony Statistics Module (from SL Legendary) and makes it work again.

- Activates when the player has the talent
- Shows the Bonus Damage
- Shows the Calculated DPS
- Shows the average number of stacks of Harmony per Barrage
- Moved from Item Stats to Talent Stats

### Motivation

To provide insight into how much damage is provided by the talent and if it is being used well.

### Testing

- Test report URL: /report/njZRvap9hNDgxy7T/3-Normal+Terros+-+Kill+(3:42)/Subamario/standard/statistics
- Screenshot(s): 

![image](https://user-images.githubusercontent.com/18435180/224930502-8272c2ea-a6fa-409a-8965-dd483d6429c3.png)

