### PR TITLE
Feral Druid - Updated check logic and text to allow 4 CP finishers when not specced for Bloodtalons.

### DIFF
--- a/src/analysis/retail/druid/feral/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/feral/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS/druid';
 
 export default [
+  change(date(2023, 3, 14), <>Updated CP check logic to allow 4 CP finishers when not specced for Bloodtalons.</>, Sref),
   change(date(2023, 1, 25), <>Updated numbers for 10.0.5 changes.</>, Sref),
   change(date(2023, 1, 20), <>Fixed a bug where the Guide could crash when Berserk is pre-cast.</>, Sref),
   change(date(2023, 1, 8), <>Added statistics for VotI tier set</>, Sref),

--- a/src/analysis/retail/druid/feral/Guide.tsx
+++ b/src/analysis/retail/druid/feral/Guide.tsx
@@ -8,6 +8,7 @@ import { formatPercentage } from 'common/format';
 import { RoundedPanel, SideBySidePanels } from 'interface/guide/components/GuideDivs';
 import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
 import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
+import { getAcceptableCps } from 'analysis/retail/druid/feral/constants';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -37,9 +38,18 @@ function ResourceUseSection({ modules, events, info }: GuideProps<typeof CombatL
       </SubSection>
       <SubSection title="Combo Points">
         <p>
+          <i>
+            As of patch 10.0.5, sims show it is acceptable to use finishers at 4 CPs when
+            <strong> not</strong> specced for Bloodtalons. Still always go on 5 CPs with
+            Bloodtalons. This may change again in 10.1.
+          </i>
+        </p>
+        <p>
           Most of your abilities either <strong>build</strong> or <strong>spend</strong> Combo
-          Points. Never use a builder at max CPs, and always wait until max CPs to use a spender
-          (with the exception of your opening <SpellLink id={SPELLS.RIP.id} />
+          Points. Never use a builder at max CPs, and always wait until (4 with{' '}
+          <SpellLink id={TALENTS_DRUID.LIONS_STRENGTH_TALENT.id} />, 5 with{' '}
+          <SpellLink id={TALENTS_DRUID.BLOODTALONS_TALENT.id} />) CPs to use a spender (with the
+          exception of your opening <SpellLink id={SPELLS.RIP.id} />
           ).
         </p>
         <SideBySidePanels>
@@ -55,9 +65,10 @@ function CoreRotationSection({ modules, events, info }: GuideProps<typeof Combat
   return (
     <Section title="Core Rotation">
       <p>
-        Feral's core rotation involves performing <strong>builder</strong> abilites up to 5 combo
-        points, then using a <strong>spender</strong> ability. Maintain your damage over time
-        effects on targets, then fill with your direct damage abilities. Refer to the spec guide for{' '}
+        Feral's core rotation involves performing <strong>builder</strong> abilites up to{' '}
+        {getAcceptableCps(info.combatant)} combo points, then using a <strong>spender</strong>{' '}
+        ability. Maintain your damage over time effects on targets, then fill with your direct
+        damage abilities. Refer to the spec guide for{' '}
         <a
           href="https://www.wowhead.com/feral-druid-rotation-guide"
           target="_blank"

--- a/src/analysis/retail/druid/feral/constants.ts
+++ b/src/analysis/retail/druid/feral/constants.ts
@@ -186,6 +186,14 @@ export function directAoeBuilder(c: Combatant): Spell {
 // MISC
 //
 
+/** Minimum acceptable number of CPs to use with a finisher.
+ *  TODO this might go back to 5 in 10.1 - pay attention to theorycraft */
+export function getAcceptableCps(c: Combatant): number {
+  return c.hasTalent(TALENTS_DRUID.BLOODTALONS_TALENT) ? ACCEPTABLE_BT_CPS : ACCEPTABLE_NO_BT_CPS;
+}
+export const ACCEPTABLE_BT_CPS = 5;
+export const ACCEPTABLE_NO_BT_CPS = 4;
+
 /** Effective combo points used by a Convoke'd Ferocious Bite */
 export const CONVOKE_FB_CPS = 4;
 

--- a/src/analysis/retail/druid/feral/modules/core/combopoints/FinisherUse.tsx
+++ b/src/analysis/retail/druid/feral/modules/core/combopoints/FinisherUse.tsx
@@ -6,7 +6,7 @@ import Events, { CastEvent, EventType } from 'parser/core/Events';
 import Statistic from 'parser/ui/Statistic';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 
-import { FINISHERS, MAX_CPS } from 'analysis/retail/druid/feral/constants';
+import { FINISHERS, getAcceptableCps } from 'analysis/retail/druid/feral/constants';
 import getResourceSpent from 'parser/core/getResourceSpent';
 import { TALENTS_DRUID } from 'common/TALENTS';
 import { getHits } from 'analysis/retail/druid/feral/normalizers/CastLinkNormalizer';
@@ -41,7 +41,7 @@ class FinisherUse extends Analyzer {
 
     this.totalFinisherCasts += 1;
 
-    if (cpsSpent < MAX_CPS) {
+    if (cpsSpent < getAcceptableCps(this.selectedCombatant)) {
       if (
         event.ability.guid === SPELLS.RIP.id ||
         event.ability.guid === TALENTS_DRUID.PRIMAL_WRATH_TALENT.id
@@ -67,7 +67,7 @@ class FinisherUse extends Analyzer {
     const items = [
       {
         color: GoodColor,
-        label: 'Max CP Finishers',
+        label: 'High CP Finishers',
         value: this.maxCpFinishers,
         tooltip: (
           <>

--- a/src/analysis/retail/druid/feral/modules/spells/FerociousBite.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/FerociousBite.tsx
@@ -13,8 +13,8 @@ import {
   cdSpell,
   FEROCIOUS_BITE_ENERGY,
   FEROCIOUS_BITE_MAX_DRAIN,
+  getAcceptableCps,
   INCARN_ENERGY_MULT,
-  MAX_CPS,
   RELENTLESS_PREDATOR_FB_ENERGY_MULT,
 } from 'analysis/retail/druid/feral/constants';
 import getResourceSpent from 'parser/core/getResourceSpent';
@@ -85,7 +85,7 @@ class FerociousBite extends Analyzer {
     const acceptableTimeLeftOnRip = timeLeftOnRip >= MIN_ACCEPTABLE_TIME_LEFT_ON_RIP_MS;
 
     let value: QualitativePerformance = QualitativePerformance.Good;
-    if (cpsUsed < MAX_CPS) {
+    if (cpsUsed < getAcceptableCps(this.selectedCombatant)) {
       value = QualitativePerformance.Fail;
     } else if (!usedMax && !duringBerserkAndSotf) {
       value = QualitativePerformance.Fail;
@@ -132,8 +132,9 @@ class FerociousBite extends Analyzer {
           <SpellLink id={SPELLS.FEROCIOUS_BITE.id} />
         </strong>{' '}
         is your direct damage finisher. Use it when you've already applied Rip to enemies. Always
-        use Bite at maximum CPs. Bite can consume up to {FEROCIOUS_BITE_MAX_DRAIN} extra energy to
-        do increased damage - this boost is very efficient and you should always wait until{' '}
+        use Bite with at least {getAcceptableCps(this.selectedCombatant)} CPs. Bite can consume up
+        to {FEROCIOUS_BITE_MAX_DRAIN} extra energy to do increased damage - this boost is very
+        efficient and you should always wait until{' '}
         {FEROCIOUS_BITE_MAX_DRAIN + FEROCIOUS_BITE_ENERGY} energy to use Bite.{' '}
         {this.hasSotf && (
           <>
@@ -160,8 +161,8 @@ class FerociousBite extends Analyzer {
         <small>
           {' '}
           - Green is a good cast , Yellow is an questionable cast (used on target with low duration
-          Rip), Red is a bad cast (&lt;25 extra energy + not during Berserk). Mouseover for more
-          details.
+          Rip), Red is a bad cast (&lt;25 extra energy + not during Berserk, or low CPs). Mouseover
+          for more details.
         </small>
         <PerformanceBoxRow values={this.castEntries} />
       </div>

--- a/src/analysis/retail/druid/feral/modules/spells/RipUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/RipUptimeAndSnapshots.tsx
@@ -5,10 +5,10 @@ import Enemies from 'parser/shared/modules/Enemies';
 import uptimeBarSubStatistic, { SubPercentageStyle } from 'parser/ui/UptimeBarSubStatistic';
 
 import {
+  getAcceptableCps,
   getPrimalWrathDuration,
   getRipDuration,
   getRipFullDuration,
-  MAX_CPS,
   RIP_DURATION_BASE,
 } from 'analysis/retail/druid/feral/constants';
 import {
@@ -91,7 +91,7 @@ class RipUptimeAndSnapshots extends Snapshots {
       const wasUpgrade = prevPower < power;
 
       /** Perf logic:
-       *  < 5 CPs (and not initial cast) -> Red
+       *  < 4 or 5 CPs (and not initial cast) -> Red
        *  Missing BT -> Red
        *  Missing TF -> Yellow
        *  Clip Duration (but upgrade Snapshot) -> Yellow
@@ -99,7 +99,7 @@ class RipUptimeAndSnapshots extends Snapshots {
        *  None of the Above -> Green
        */
       let value: QualitativePerformance = QualitativePerformance.Good;
-      if (cpsUsed < MAX_CPS && this.castEntries.length > 0) {
+      if (cpsUsed < getAcceptableCps(this.selectedCombatant) && this.castEntries.length > 0) {
         value = QualitativePerformance.Fail;
       } else if (this.hasBt && !hasSpec(snapshots, BLOODTALONS_SPEC)) {
         value = QualitativePerformance.Fail;


### PR DESCRIPTION
### Description

Recent theorycraft suggests it's a slight gain for Feral Druids to use finishers on 4 CPs when specced Lions Strength (common these days). This PR updates the logic and guide text to account for this.

### Testing

- Test report URL: `/report/wCdRDFYaMpr16zGA/3-Mythic+Eranog+-+Kill+(4:28)/Azlann/standard`
- Screenshot(s): 
![image](https://user-images.githubusercontent.com/7143486/225033374-a9d7a8d0-215e-48d0-bf40-807dfef0f1fd.png)

