### PR TITLE
add warning about raz range issues

### DIFF
--- a/src/game/raids/vaultoftheincarnates/Raszageth.ts
+++ b/src/game/raids/vaultoftheincarnates/Raszageth.ts
@@ -7,7 +7,10 @@ const Raszageth: Boss = {
   name: 'Raszageth the Storm-Eater',
   background: Background,
   icon: 'achievement_raidprimalist_raszageth',
-  fight: {},
+  fight: {
+    resultsWarning:
+      "During the first intermission, the two teams are briefly out of logging range of each other. This can cause errors in analysis. You can work around this by using a log uploaded by a person that is on the same side platform as the player you're analyzing.",
+  },
 };
 
 export default Raszageth;


### PR DESCRIPTION
raz has logging range issues during the first intermission. adds a warning about that.
