### PR TITLE
fix crash in mw hotattributor

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 3, 17), <>Fix crash in HotAttributor</>, Trevor),
   change(date(2023, 3, 8), <>Fix <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT}/> module</>, Trevor),
   change(date(2023, 3, 8), <>Visual updates to the Guide to be more user friendly</>, Vohrr),
   change(date(2023, 3, 7), <>Update styling for <SpellLink id={TALENTS_MONK.RISING_MIST_TALENT.id}/> tab to not interefere with guide styling.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/modules/core/HotAttributor.ts
+++ b/src/analysis/retail/monk/mistweaver/modules/core/HotAttributor.ts
@@ -269,6 +269,9 @@ class HotAttributor extends Analyzer {
       //set the data from the sourceRem if we can find it
       const spellID = event.ability.guid;
       const dmHot = this.hotTracker.hots[event.targetID][spellID];
+      if (!this.hotTracker.hots[sourceRem.targetID]) {
+        return;
+      }
       const sourceHot = this.hotTracker.hots[sourceRem.targetID][spellID];
       if (sourceHot) {
         dmHot.attributions = [];


### PR DESCRIPTION
Not sure why the hotmap doesn't have the target id (it's a player) but this is a safety check that prevents crash for the time being