### PR TITLE
add patch info for 10.0.7

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -23,6 +23,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 3, 21), 'Add patch info for 10.0.7.', ToppleTheNun),
   change(date(2023, 3, 20), 'Fix an issue where APL rules could mistakenly mismatch, causing weird UI issues.', emallson),
   change(date(2023, 3, 18), 'Add T30 set IDs.', ToppleTheNun),
   change(date(2023, 3, 18), 'Add Classic WotLK Rogue spells', jazminite),

--- a/src/game/VERSIONS.ts
+++ b/src/game/VERSIONS.ts
@@ -3,7 +3,7 @@ import Expansion from './Expansion';
 // The current version of the game. Used to check spec patch compatibility and as a caching key.
 const VERSIONS: Partial<{ [expansion in Expansion]: string }> = {
   [Expansion.WrathOfTheLichKing]: '3.4.0',
-  [Expansion.Dragonflight]: '10.0.5',
+  [Expansion.Dragonflight]: '10.0.7',
 };
 
 export default VERSIONS;

--- a/src/game/ZONES.ts
+++ b/src/game/ZONES.ts
@@ -56,11 +56,11 @@ const ZONES: Zone[] = [
       {
         name: '10.0',
         compact: '10.0',
-        default: true,
       },
       {
-        name: '10.0.5',
-        compact: '10.0.5',
+        name: '10.0.7',
+        compact: '10.0.7',
+        default: true,
       },
     ],
   },

--- a/src/interface/report/PATCHES.ts
+++ b/src/interface/report/PATCHES.ts
@@ -117,6 +117,14 @@ const PATCHES: Patch[] = [
     name: '10.0.5',
     timestamp: 1674597600000, // GMT: Tuesday, 24 January 2023 22:00:00
     urlPrefix: '',
+    isCurrent: true, // TODO: set to false after EU reset
+    gameVersion: 1, // retail
+    expansion: Expansion.Dragonflight,
+  },
+  {
+    name: '10.0.7',
+    timestamp: 1679436000000, // GMT: Tuesday, 21 March 2023 22:00:00
+    urlPrefix: '',
     isCurrent: true,
     gameVersion: 1, // retail
     expansion: Expansion.Dragonflight,

--- a/src/parser/Config.ts
+++ b/src/parser/Config.ts
@@ -36,7 +36,7 @@ interface Config {
   /**
    * The WoW client patch this spec is compatible with.
    */
-  patchCompatibility: null | '10.0.0' | '10.0.2' | string;
+  patchCompatibility: null | '10.0.0' | '10.0.2' | '10.0.5' | '10.0.7' | string;
   /**
    * Whether support for the spec is only partial and some important elements
    * are still missing. Note: you do not need to support every possible


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Add patch info for 10.0.7.

### Motivation

<!-- Why are you submitting this pull request?-->

We need patch info for 10.0.7 so we can show information about out-of-date analyzers.
