### PR TITLE
add "Hide Good Casts" toggle

### DIFF
--- a/src/analysis/retail/demonhunter/havoc/Guide.tsx
+++ b/src/analysis/retail/demonhunter/havoc/Guide.tsx
@@ -16,6 +16,7 @@ import {
   PERFECT_TIME_AT_FURY_CAP,
 } from './modules/resourcetracker/FuryTracker';
 import FuryCapWaste from './guide/FuryCapWaste';
+import HideGoodCastsToggle from 'interface/guide/components/HideGoodCastsToggle';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -75,6 +76,7 @@ function CooldownSection({ modules, info }: GuideProps<typeof CombatLogParser>) 
       })}
     >
       <HideExplanationsToggle id="hide-explanations-cooldowns" />
+      <HideGoodCastsToggle id="hide-good-casts-cooldowns" />
       <CooldownGraphSubsection />
       <CooldownUsage analyzer={modules.essenceBreak} title="Essence Break" />
       <CooldownUsage analyzer={modules.eyeBeam} title="Eye Beam" />
@@ -112,6 +114,7 @@ function RotationSection({ modules }: GuideProps<typeof CombatLogParser>) {
       })}
     >
       <HideExplanationsToggle id="hide-explanations-rotations" />
+      <HideGoodCastsToggle id="hide-good-casts-rotations" />
       {modules.throwGlaive.guideSubsection()}
       {modules.momentum.guideSubsection()}
     </Section>

--- a/src/analysis/retail/demonhunter/shared/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/shared/CHANGELOG.tsx
@@ -8,6 +8,7 @@ import { ResourceLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2023, 3, 19), 'Add "Hide Good Casts" toggle to Core Rotation and Cooldown sections of the Guide.', ToppleTheNun),
   change(date(2023, 2, 8), <>Improve <ResourceLink id={RESOURCE_TYPES.FURY.id} /> waste display in Guide.</>, ToppleTheNun),
   change(date(2023, 1, 25), 'Bump support to 10.0.5.', ToppleTheNun),
   change(date(2023, 1, 7), 'Add wasted Fury to Resource Usage section of Guide.', ToppleTheNun),

--- a/src/analysis/retail/demonhunter/shared/modules/talents/SigilOfFlame.tsx
+++ b/src/analysis/retail/demonhunter/shared/modules/talents/SigilOfFlame.tsx
@@ -58,7 +58,6 @@ export default class SigilOfFlame extends Analyzer {
     return (
       <SpellUsageSubSection
         explanation={explanation}
-        performance={performances}
         uses={this.cooldownUses}
         castBreakdownSmallText={<> - Green is a good cast, Red is a bad cast.</>}
         onPerformanceBoxClick={logSpellUseEvent}

--- a/src/analysis/retail/demonhunter/vengeance/Guide.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/Guide.tsx
@@ -17,6 +17,7 @@ import {
   PERFECT_TIME_AT_FURY_CAP,
 } from './modules/resourcetracker/FuryTracker';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import HideGoodCastsToggle from 'interface/guide/components/HideGoodCastsToggle';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -127,6 +128,7 @@ function RotationSection({ modules, info }: GuideProps<typeof CombatLogParser>) 
       </p>
       <br />
       <HideExplanationsToggle id="hide-explanations-rotation" />
+      <HideGoodCastsToggle id="hide-good-casts-rotation" />
       {info.combatant.hasTalent(TALENTS_DEMON_HUNTER.FRACTURE_TALENT) &&
         modules.fracture.guideSubsection()}
       {modules.immolationAura.vengeanceGuideSubsection()}
@@ -157,6 +159,7 @@ function CooldownSection({ modules, info }: GuideProps<typeof CombatLogParser>) 
         </Trans>
       </p>
       <HideExplanationsToggle id="hide-explanations-cooldowns" />
+      <HideGoodCastsToggle id="hide-good-casts-cooldowns" />
       <CooldownGraphSubsection />
       {info.combatant.hasTalent(TALENTS_DEMON_HUNTER.FEL_DEVASTATION_TALENT) && (
         <CooldownUsage analyzer={modules.felDevastation} />

--- a/src/analysis/retail/demonhunter/vengeance/modules/spells/SoulCleave.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/spells/SoulCleave.tsx
@@ -77,7 +77,6 @@ export default class SoulCleave extends Analyzer {
     return (
       <SpellUsageSubSection
         explanation={explanation}
-        performance={performances}
         uses={this.cooldownUses}
         castBreakdownSmallText={<> - Green is a good cast, Red is a bad cast.</>}
         onPerformanceBoxClick={logSpellUseEvent}

--- a/src/analysis/retail/demonhunter/vengeance/modules/talents/Fracture.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/talents/Fracture.tsx
@@ -107,7 +107,6 @@ export default class Fracture extends Analyzer {
     return (
       <SpellUsageSubSection
         explanation={explanation}
-        performance={performances}
         uses={this.cooldownUses}
         castBreakdownSmallText={<> - Green is a good cast, Red is a bad cast.</>}
         onPerformanceBoxClick={logSpellUseEvent}

--- a/src/analysis/retail/demonhunter/vengeance/modules/talents/SpiritBomb.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/talents/SpiritBomb.tsx
@@ -136,7 +136,6 @@ export default class SpiritBomb extends Analyzer {
     return (
       <SpellUsageSubSection
         explanation={explanation}
-        performance={performances}
         uses={this.cooldownUses}
         castBreakdownSmallText={<> - Green is a good cast, Red is a bad cast.</>}
         onPerformanceBoxClick={logSpellUseEvent}

--- a/src/analysis/retail/rogue/assassination/CHANGELOG.tsx
+++ b/src/analysis/retail/rogue/assassination/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import TALENTS from 'common/TALENTS/rogue';
 import SHARED_CHANGELOG from 'analysis/retail/rogue/shared/CHANGELOG';
 
 export default [
+  change(date(2023, 3, 19), 'Add "Hide Good Casts" toggle to Core Rotation and Cooldown sections of the Guide.', ToppleTheNun),
   change(date(2023, 2, 3), <>Fix some bugs related to log ordering/latency with <SpellLink id={SPELLS.ENVENOM} />.</>, ToppleTheNun),
   change(date(2023, 1, 28), 'Fix reference to Fury in Guide.', ToppleTheNun),
   change(date(2023, 1, 28), <>Update <SpellLink id={TALENTS.EXSANGUINATE_TALENT} /> to check duration of <SpellLink id={SPELLS.GARROTE} /> and <SpellLink id={SPELLS.RUPTURE} />.</>, ToppleTheNun),

--- a/src/analysis/retail/rogue/assassination/Guide.tsx
+++ b/src/analysis/retail/rogue/assassination/Guide.tsx
@@ -12,6 +12,7 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 import CombatLogParser from './CombatLogParser';
 import CooldownGraphSubsection from './guide/CooldownGraphSubsection';
+import HideGoodCastsToggle from 'interface/guide/components/HideGoodCastsToggle';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -106,6 +107,7 @@ function CoreRotationSection({ modules, info }: GuideProps<typeof CombatLogParse
         . See below for spell usage details.
       </p>
       <HideExplanationsToggle id="hide-explanations-rotation" />
+      <HideGoodCastsToggle id="hide-good-casts-rotation" />
       {modules.ruptureUptimeAndSnapshots.guideSubsection}
       {modules.envenom.guideSubsection}
       {info.combatant.hasTalent(TALENTS.CRIMSON_TEMPEST_TALENT) &&
@@ -131,6 +133,8 @@ function CooldownSection({ info, modules }: GuideProps<typeof CombatLogParser>) 
         cooldown as soon as it becomes available (as long as it can do damage on target). It is
         particularly important to use <SpellLink id={SPELLS.VANISH.id} /> as often as possible.
       </p>
+      <HideExplanationsToggle id="hide-explanations-rotation" />
+      <HideGoodCastsToggle id="hide-good-casts-rotation" />
       <CooldownGraphSubsection />
       {info.combatant.hasTalent(TALENTS.EXSANGUINATE_TALENT) && (
         <CooldownUsage analyzer={modules.exsanguinate} />

--- a/src/analysis/retail/rogue/assassination/modules/spells/Envenom.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/spells/Envenom.tsx
@@ -1,7 +1,7 @@
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS/rogue';
 import Events, { CastEvent, TargettedEvent } from 'parser/core/Events';
-import { ChecklistUsageInfo, SpellUse, spellUseToBoxRowEntry } from 'parser/core/SpellUsage/core';
+import { ChecklistUsageInfo, SpellUse } from 'parser/core/SpellUsage/core';
 import getResourceSpent from 'parser/core/getResourceSpent';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import RuptureUptimeAndSnapshots from 'analysis/retail/rogue/assassination/modules/spells/RuptureUptimeAndSnapshots';
@@ -50,14 +50,9 @@ export default class Envenom extends Analyzer {
       </p>
     );
 
-    const performances = this.cooldownUses.map((it) =>
-      spellUseToBoxRowEntry(it, this.owner.fight.start_time),
-    );
-
     return (
       <SpellUsageSubSection
         explanation={explanation}
-        performance={performances}
         uses={this.cooldownUses}
         castBreakdownSmallText={
           <>

--- a/src/analysis/retail/rogue/assassination/modules/spells/GarroteUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/spells/GarroteUptimeAndSnapshots.tsx
@@ -16,7 +16,7 @@ import TALENTS from 'common/TALENTS/rogue';
 import uptimeBarSubStatistic, { SubPercentageStyle } from 'parser/ui/UptimeBarSubStatistic';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { formatDurationMillisMinSec } from 'common/format';
-import { ChecklistUsageInfo, SpellUse, spellUseToBoxRowEntry } from 'parser/core/SpellUsage/core';
+import { ChecklistUsageInfo, SpellUse } from 'parser/core/SpellUsage/core';
 import SpellUsageSubSection from 'parser/core/SpellUsage/SpellUsageSubSection';
 import { combineQualitativePerformances } from 'common/combineQualitativePerformances';
 
@@ -204,14 +204,9 @@ export default class GarroteUptimeAndSnapshots extends DotSnapshots {
       </p>
     );
 
-    const performances = this.cooldownUses.map((it) =>
-      spellUseToBoxRowEntry(it, this.owner.fight.start_time),
-    );
-
     return (
       <SpellUsageSubSection
         explanation={explanation}
-        performance={performances}
         uses={this.cooldownUses}
         abovePerformanceDetails={
           <RoundedPanel>

--- a/src/analysis/retail/rogue/assassination/modules/spells/RuptureUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/spells/RuptureUptimeAndSnapshots.tsx
@@ -16,7 +16,7 @@ import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import uptimeBarSubStatistic, { SubPercentageStyle } from 'parser/ui/UptimeBarSubStatistic';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { formatDurationMillisMinSec } from 'common/format';
-import { SpellUse, spellUseToBoxRowEntry } from 'parser/core/SpellUsage/core';
+import { SpellUse } from 'parser/core/SpellUsage/core';
 import SpellUsageSubSection from 'parser/core/SpellUsage/SpellUsageSubSection';
 
 import { getHardcast } from '../../normalizers/CastLinkNormalizer';
@@ -154,14 +154,9 @@ export default class RuptureUptimeAndSnapshots extends DotSnapshots {
       </p>
     );
 
-    const performances = this.cooldownUses.map((it) =>
-      spellUseToBoxRowEntry(it, this.owner.fight.start_time),
-    );
-
     return (
       <SpellUsageSubSection
         explanation={explanation}
-        performance={performances}
         uses={this.cooldownUses}
         abovePerformanceDetails={
           <RoundedPanel>

--- a/src/analysis/retail/rogue/assassination/modules/talents/CrimsonTempestUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/talents/CrimsonTempestUptimeAndSnapshots.tsx
@@ -15,7 +15,7 @@ import TALENTS from 'common/TALENTS/rogue';
 import uptimeBarSubStatistic, { SubPercentageStyle } from 'parser/ui/UptimeBarSubStatistic';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { formatDurationMillisMinSec } from 'common/format';
-import { SpellUse, spellUseToBoxRowEntry } from 'parser/core/SpellUsage/core';
+import { SpellUse } from 'parser/core/SpellUsage/core';
 import SpellUsageSubSection from 'parser/core/SpellUsage/SpellUsageSubSection';
 
 import { getHardcast } from '../../normalizers/CastLinkNormalizer';
@@ -153,14 +153,9 @@ export default class CrimsonTempestUptimeAndSnapshots extends DotSnapshots {
       </p>
     );
 
-    const performances = this.cooldownUses.map((it) =>
-      spellUseToBoxRowEntry(it, this.owner.fight.start_time),
-    );
-
     return (
       <SpellUsageSubSection
         explanation={explanation}
-        performance={performances}
         uses={this.cooldownUses}
         abovePerformanceDetails={
           <RoundedPanel>

--- a/src/analysis/retail/rogue/assassination/modules/talents/ThistleTea.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/talents/ThistleTea.tsx
@@ -1,7 +1,7 @@
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import TALENTS from 'common/TALENTS/rogue';
 import EnergyTracker from 'analysis/retail/rogue/shared/EnergyTracker';
-import { SpellUse, spellUseToBoxRowEntry } from 'parser/core/SpellUsage/core';
+import { SpellUse } from 'parser/core/SpellUsage/core';
 import Events, { CastEvent } from 'parser/core/Events';
 import { getResourceChange } from 'analysis/retail/rogue/shared/talents/ThistleTeaCastLinkNormalizer';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
@@ -44,14 +44,9 @@ export default class ThistleTea extends Analyzer {
       </p>
     );
 
-    const performances = this.cooldownUses.map((it) =>
-      spellUseToBoxRowEntry(it, this.owner.fight.start_time),
-    );
-
     return (
       <SpellUsageSubSection
         explanation={explanation}
-        performance={performances}
         uses={this.cooldownUses}
         abovePerformanceDetails={
           <SideBySidePanels>

--- a/src/interface/guide/components/HideGoodCastsToggle.tsx
+++ b/src/interface/guide/components/HideGoodCastsToggle.tsx
@@ -1,0 +1,30 @@
+import VerticallyAlignedToggle from 'interface/VerticallyAlignedToggle';
+import { useSpellUsageContext } from 'parser/core/SpellUsage/core';
+
+interface HideGoodCastsToggleProps {
+  id: string;
+  label?: string;
+  tooltipContent?: string;
+}
+export const HideGoodCasts = ({ id, label, tooltipContent }: HideGoodCastsToggleProps) => {
+  const { hideGoodCasts, setHideGoodCasts } = useSpellUsageContext();
+  return (
+    <div className="flex">
+      <div className="flex-main" />
+      <div className="flex-sub">
+        <VerticallyAlignedToggle
+          id={id}
+          enabled={hideGoodCasts}
+          setEnabled={setHideGoodCasts}
+          label={label ?? 'Hide Good Casts'}
+          tooltipContent={
+            tooltipContent ??
+            "Enabling this feature will hide good and perfect casts throughout the Guide. Don't worry, you can always bring them back."
+          }
+        />
+      </div>
+    </div>
+  );
+};
+
+export default HideGoodCasts;

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -23,6 +23,7 @@ import ManaValues from 'parser/shared/modules/ManaValues';
 import StatTracker from 'parser/shared/modules/StatTracker';
 import EnergizeCompat from 'parser/shared/normalizers/EnergizeCompat';
 import * as React from 'react';
+import { ExplanationContextProvider } from 'interface/guide/components/Explanation';
 
 import Config from '../Config';
 import AugmentRuneChecker from '../retail/modules/items/AugmentRuneChecker';
@@ -88,7 +89,7 @@ import ParseResults from './ParseResults';
 import { PetInfo } from './Pet';
 import { PlayerInfo } from './Player';
 import Report from './Report';
-import { ExplanationContextProvider } from 'interface/guide/components/Explanation';
+import { SpellUsageContextProvider } from 'parser/core/SpellUsage/core';
 
 // This prints to console anything that the DI has to do
 const debugDependencyInjection = false;
@@ -763,7 +764,9 @@ class CombatLogParser {
       <GuideContainer>
         <GuideContext.Provider value={props}>
           <ExplanationContextProvider>
-            <Component {...props} />
+            <SpellUsageContextProvider>
+              <Component {...props} />
+            </SpellUsageContextProvider>
           </ExplanationContextProvider>
         </GuideContext.Provider>
       </GuideContainer>

--- a/src/parser/core/MajorCooldowns/CooldownUsage.tsx
+++ b/src/parser/core/MajorCooldowns/CooldownUsage.tsx
@@ -77,14 +77,7 @@ const CooldownUsage = <Cast extends SpellCast>({
 
   const uses = analyzer.uses;
 
-  return (
-    <SpellUsageSubSection
-      explanation={analyzer.description()}
-      performance={performance}
-      uses={uses}
-      {...others}
-    />
-  );
+  return <SpellUsageSubSection explanation={analyzer.description()} uses={uses} {...others} />;
 };
 
 export default CooldownUsage;

--- a/src/parser/core/SpellUsage/core.tsx
+++ b/src/parser/core/SpellUsage/core.tsx
@@ -1,10 +1,11 @@
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
-import { ReactNode } from 'react';
+import { createContext, ReactNode, useContext } from 'react';
 import { CastEvent } from 'parser/core/Events';
 import styled from '@emotion/styled';
 import { formatDuration } from 'common/format';
 import { PerformanceMark } from 'interface/guide';
 import { BoxRowEntry } from 'interface/guide/components/PerformanceBoxRow';
+import useSessionFeatureFlag from 'interface/useSessionFeatureFlag';
 
 /**
  * Contains data about one aspect of the quality of a cast and the reasoning.
@@ -103,3 +104,26 @@ export const spellUseToBoxRowEntry = (
     </>
   ),
 });
+
+interface SpellUsageContextValue {
+  hideGoodCasts: boolean;
+  setHideGoodCasts: (p: boolean) => void;
+}
+
+export const SpellUsageContext = createContext<SpellUsageContextValue>({
+  hideGoodCasts: false,
+  setHideGoodCasts: () => {
+    // no-op
+  },
+});
+
+export const SpellUsageContextProvider = ({ children }: { children: ReactNode }) => {
+  const [hideGoodCasts, setHideGoodCasts] = useSessionFeatureFlag('hide-good-casts');
+  return (
+    <SpellUsageContext.Provider value={{ hideGoodCasts, setHideGoodCasts }}>
+      {children}
+    </SpellUsageContext.Provider>
+  );
+};
+
+export const useSpellUsageContext = () => useContext(SpellUsageContext);


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Add a "Hide Good Casts" toggle.

### Motivation

<!-- Why are you submitting this pull request?-->

emallson commented the below on #5897, which got me thinking about ways to still give the dopamine hit of seeing a sea of green when you do well, but also allow focus on just things that you can improve.
> I am not 100% sold on using the box grids for these kinds of very frequent spells. It works (and there is something nice about seeing a sea of green) but there may be better options.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/r4JtW9hxdzwc3G6q/8-Mythic+The+Primal+Council+-+Kill+(3:00)/22-Toppledh/standard`, `/report/Fdfk6LPncg17BHAr/13-Heroic+Raszageth+the+Storm-Eater+-+Kill+(9:24)/Xanq/standard/overview`
- Screenshot(s):
![hide-good-casts](https://user-images.githubusercontent.com/1672786/226153674-ececf9e4-51f9-488b-9de7-956bc89f47be.gif)
