### PR TITLE
couple of small brewmaster updates

### DIFF
--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2023, 3, 19), <>Improved Shuffle & Damage Taken displays on Raszageth.</>, emallson),
   change(date(2023, 3, 12), <>Update APL to handle <SpellLink id={talents.EXPLODING_KEG_TALENT} /> tech and add basic major cooldown list.</>, emallson),
   change(date(2023, 1, 30), <>Fix calculation of haste bonus from <SpellLink id={talents.HIGH_TOLERANCE_TALENT} /></>, emallson),
   change(date(2023, 1, 30), <>Support T29 buff to <SpellLink id={talents.PURIFYING_BREW_TALENT} /></>, emallson),

--- a/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/components/DamageMitigationChart.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/components/DamageMitigationChart.tsx
@@ -116,7 +116,7 @@ export const DamageMitigationChart = React.memo(({ onHover }: { onHover: SignalL
           interpolate: 'monotone',
           color: color(MAGIC_SCHOOLS.ids.PHYSICAL),
           stroke: 'black',
-          strokeWidth: 1.5,
+          strokeWidth: 0.5,
         },
         data: {
           name: 'events',

--- a/src/parser/shared/modules/hit-tracking/IgnoredAbilities.ts
+++ b/src/parser/shared/modules/hit-tracking/IgnoredAbilities.ts
@@ -12,6 +12,11 @@ const IGNORED: number[] = [
   360288, // Lords of Dread, Anguishing Strike DoT
   360302, // Lords of Dread, Swarm of Decay
   360303, // Lords of Dread, Swarm of Darkness
+  // Raszageth
+  381250, // Electric Scales
+  395907, // Electrified Jaws (DoT)
+  391282, // Crackling Energy
+  395930, // Storm's Spite
 ];
 
 export default IGNORED;


### PR DESCRIPTION
- added Rasz dots to ignore list. they don't log as dot ticks (unfortunately)
- reduced size of the stroke effect on the damage taken chart to improve rendering on long fights (like rasz)