### PR TITLE
fix performance for SpB casts

### DIFF
--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import SHARED_CHANGELOG from 'analysis/retail/demonhunter/shared/CHANGELOG';
 
 // prettier-ignore
 export default [
+  change(date(2023, 3, 21), <>Fix some good <SpellLink id={TALENTS.SPIRIT_BOMB_TALENT} /> casts showing as bad.</>, ToppleTheNun),
   change(date(2023, 3, 16), 'Update the default log.', ToppleTheNun),
   change(date(2023, 3, 9), <>Add <SpellLink id={TALENTS.SIGIL_OF_FLAME_TALENT} /> to Rotation section in guide.</>, ToppleTheNun),
   change(date(2023, 3, 9), <>Re-add <SpellLink id={SPELLS.IMMOLATION_AURA} /> cast efficiency to guide.</>, ToppleTheNun),

--- a/src/analysis/retail/demonhunter/vengeance/modules/talents/SpiritBomb.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/talents/SpiritBomb.tsx
@@ -231,7 +231,7 @@ export default class SpiritBomb extends Analyzer {
       };
     }
     return {
-      performance: QualitativePerformance.Fail,
+      performance: QualitativePerformance.Good,
       summary: <div>Cast in Single Target with Fiery Demise</div>,
       details: (
         <div>


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Fix fallback case for SpB casts showing as `QualitativePerformance.Fail`.

### Motivation

<!-- Why are you submitting this pull request?-->

Fallback case is `QualitativePerformance.Good`, not `QualitativePerformance.Fail`.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/MPARK1D9qVG7CN84/1-Mythic++Ruby+Life+Pools+-+Kill+(44:45)/Ayladae/standard`
- Screenshot(s):
**Before**
![image](https://user-images.githubusercontent.com/1672786/226749420-b97286b0-819b-4f88-86fa-e49ca3d90ff5.png)
**After**
![image](https://user-images.githubusercontent.com/1672786/226750474-15834922-f2c0-436d-b30f-025ccdfbc90f.png)
