### PR TITLE
10.0.7 Holy Priest Updates

### DIFF
--- a/src/analysis/retail/priest/holy/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/holy/CHANGELOG.tsx
@@ -5,6 +5,11 @@ import { SpellLink } from 'interface';
 
 export default [
   change(
+    date(2023, 3, 21),
+    <>Updated for patch 10.0.7. Temporarily disabled Divine Image due to combat log issues.</>,
+    Squided
+  ),
+  change(
     date(2023, 1, 24),
     <>Updated for patch 10.0.5.</>,
     Squided

--- a/src/analysis/retail/priest/holy/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/holy/CHANGELOG.tsx
@@ -6,7 +6,7 @@ import { SpellLink } from 'interface';
 export default [
   change(
     date(2023, 3, 21),
-    <>Updated for patch 10.0.7. Temporarily disabled Divine Image due to combat log issues.</>,
+    <>Updated for patch 10.0.7. Temporarily disabled Divine Image due to combat log issues. Fix Divine Word module.</>,
     Squided
   ),
   change(

--- a/src/analysis/retail/priest/holy/CONFIG.tsx
+++ b/src/analysis/retail/priest/holy/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Litena, Squided],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.5',
+  patchCompatibility: '10.0.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/priest/holy/CombatLogParser.tsx
+++ b/src/analysis/retail/priest/holy/CombatLogParser.tsx
@@ -126,7 +126,9 @@ class CombatLogParser extends CoreCombatLogParser {
     Pontifex: Talents.BottomRow.Pontifex,
     Lightweaver: Talents.BottomRow.Lightweaver,
 
-    divineImage: Talents.BottomRow.DivineImage,
+    // disabling due to combat logging issues, module is not working and i dont know how to fix it
+    // with current blizzard implementation of combat log :D
+    // divineImage: Talents.BottomRow.DivineImage,
     lightOfTheNaaru: Talents.BottomRow.LightOfTheNaaru,
     harmoniousApparatus: Talents.BottomRow.HarmoniousApparatus,
     resonantWords: Talents.BottomRow.ResonantWords,

--- a/src/analysis/retail/priest/holy/modules/talents/BottomRow/DivineWord.tsx
+++ b/src/analysis/retail/priest/holy/modules/talents/BottomRow/DivineWord.tsx
@@ -18,11 +18,11 @@ import { formatPercentage } from 'common/format';
 import { ABILITIES_THAT_WORK_WITH_DIVINE_FAVOR_CHASTISE } from 'analysis/retail/priest/holy/constants';
 import { SpellIcon } from 'interface';
 
-const DAMAGE_INCREASE_FROM_CHASTISE = 0.5;
+const DAMAGE_INCREASE_FROM_CHASTISE = 0.3;
 const HOLY_FIRE_APPLICATION_DURATION = 7;
 const HEALING_INCREASE_FROM_SERENITY = 0.3;
 const CRIT_INCREASE_FROM_SERENITY = 0.2;
-const ACTIVATOR_SPELL_INCREASE = 0.3;
+const ACTIVATOR_SPELL_INCREASE = 0.5;
 
 // Example Logs: /report/VXr2kgALF3Rj6Q4M/11-Mythic+Anduin+Wrynn+-+Kill+(5:12)/Litena/standard/statistics
 // /report/xq2FvfVCJh6YLjzZ/2-Mythic+Vigilant+Guardian+-+Kill+(4:40)/Ashelya/standard/statistics
@@ -59,12 +59,19 @@ class DivineWord extends Analyzer {
     this.addEventListener(
       Events.heal
         .by(SELECTED_PLAYER)
-        .spell([SPELLS.FLASH_HEAL, TALENTS.RENEW_TALENT, SPELLS.GREATER_HEAL]),
+        .spell([
+          TALENTS.HOLY_WORD_SERENITY_TALENT,
+          SPELLS.FLASH_HEAL,
+          TALENTS.RENEW_TALENT,
+          SPELLS.GREATER_HEAL,
+        ]),
       this.onHeal,
     );
     // The heal from casting sanctify
     this.addEventListener(
-      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.DIVINE_WORD_SANCTIFY_TALENT_HEAL),
+      Events.heal
+        .by(SELECTED_PLAYER)
+        .spell([TALENTS.HOLY_WORD_SANCTIFY_TALENT, SPELLS.DIVINE_WORD_SANCTIFY_TALENT_HEAL]),
       this.onHeal,
     );
     //Keeping track of which divine word is activated
@@ -146,6 +153,7 @@ class DivineWord extends Analyzer {
       this.sanctifyOverhealing += calculateOverhealing(event, ACTIVATOR_SPELL_INCREASE);
     }
   }
+
   onActivatorCast(event: CastEvent) {
     const spellId = event.ability.guid;
     if (this.selectedCombatant.hasBuff(TALENTS.DIVINE_WORD_TALENT.id)) {

--- a/src/analysis/retail/priest/holy/modules/talents/TopRow/BurningVehemence.tsx
+++ b/src/analysis/retail/priest/holy/modules/talents/TopRow/BurningVehemence.tsx
@@ -9,7 +9,7 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
 
-const DAMAGE_INCREASE_PER_RANK = [0, 0.15, 0.3];
+const DAMAGE_INCREASE_PER_RANK = [0, 0.3, 0.6];
 
 class BurningVehemence extends Analyzer {
   damageBonus = 0;


### PR DESCRIPTION
### Description

Updating holy priest for 10.0.7. There are some issues with how Divine Image is being logged in the combat log that I am not sure how to resolve, so disabling that module in the mean time. Also fixed bug with Divine Word module that was not including the 50% healing buff to initial cast. This module needs some general cleanup that I plan on doing in future, but it works for now.

### Motivation

Keep spec up to date.

### Testing

https://www.warcraftlogs.com/reports/GyCngwZhNqbYTaXK#fight=25&type=healing

