### PR TITLE
Update emerald communion module to account for reso sphere nerfs and bump rdruid

### DIFF
--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { TALENTS_DRUID } from 'common/TALENTS';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2023, 3, 22), <>Bump Restoration Druid to 10.0.7</>, Trevor),
   change(date(2023, 3, 17), <>Fixed an issue where Wild Growth cast just before a Flourish or Convoke wouldn't be counted in the cooldown breakdown.</>, Sref),
   change(date(2023, 3, 14), <>Updated <SpellLink id={TALENTS_DRUID.NATURES_VIGIL_TALENT.id} /> module to account for changes to single target heal list.</>, Sref),
   change(date(2023, 2, 16), <>Corrected Typo in the <SpellLink id={TALENTS_DRUID.LIFEBLOOM_TALENT.id}/> uptimes efficiency guide section.</>, Vohrr),

--- a/src/analysis/retail/druid/restoration/CONFIG.tsx
+++ b/src/analysis/retail/druid/restoration/CONFIG.tsx
@@ -9,7 +9,7 @@ export default {
   contributors: [Sref],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.5',
+  patchCompatibility: '10.0.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import { ToppleTheNun, Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
-  change(date(2023, 3, 21), <>Update <SpellLink id={TALENTS_EVOKER.LIFEBIND_TALENT}/> suggestions based on nerfs</>, Trevor),
+  change(date(2023, 3, 22), <>Update <SpellLink id={TALENTS_EVOKER.LIFEBIND_TALENT}/> suggestions based on nerfs</>, Trevor),
   change(date(2023, 3, 21), <>Add <SpellLink id={SPELLS.EMERALD_BLOSSOM_CAST}/> healing to <SpellLink id={TALENTS_EVOKER.OUROBOROS_TALENT}/> module</>, Trevor),
   change(date(2023, 3, 21), <>Bump support to 10.0.7</>, Trevor),
   change(date(2023, 3, 21), <>Add <SpellLink id={TALENTS_EVOKER.OUROBOROS_TALENT}/> talent</>, Trevor),

--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { ToppleTheNun, Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 3, 21), <>Update <SpellLink id={TALENTS_EVOKER.LIFEBIND_TALENT}/> suggestions based on nerfs</>, Trevor),
   change(date(2023, 3, 21), <>Add <SpellLink id={SPELLS.EMERALD_BLOSSOM_CAST}/> healing to <SpellLink id={TALENTS_EVOKER.OUROBOROS_TALENT}/> module</>, Trevor),
   change(date(2023, 3, 21), <>Bump support to 10.0.7</>, Trevor),
   change(date(2023, 3, 21), <>Add <SpellLink id={TALENTS_EVOKER.OUROBOROS_TALENT}/> talent</>, Trevor),

--- a/src/analysis/retail/evoker/preservation/modules/talents/EmeraldCommunion.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/EmeraldCommunion.tsx
@@ -26,7 +26,8 @@ class EmeraldCommunion extends Analyzer {
     super(options);
     this.active =
       this.selectedCombatant.hasTalent(TALENTS_EVOKER.EMERALD_COMMUNION_TALENT) &&
-      this.selectedCombatant.hasTalent(TALENTS_EVOKER.LIFEBIND_TALENT);
+      this.selectedCombatant.hasTalent(TALENTS_EVOKER.LIFEBIND_TALENT) &&
+      this.selectedCombatant.hasTalent(TALENTS_EVOKER.RESONATING_SPHERE_TALENT);
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(TALENTS_EVOKER.EMERALD_COMMUNION_TALENT),
       this.onCast,
@@ -67,9 +68,9 @@ class EmeraldCommunion extends Analyzer {
     return {
       actual: this.percentWithLifebindOnCast,
       isLessThan: {
-        major: 0.6,
-        average: 0.7,
-        minor: 0.8,
+        major: 0.4,
+        average: 0.5,
+        minor: 0.6,
       },
       style: ThresholdStyle.PERCENTAGE,
     };


### PR DESCRIPTION
Reso sphere only applies 4 echo's so EC ramps should have less targets now