### PR TITLE
Fix bug in stasis module due to damaging living flame casts

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { ToppleTheNun, Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 3, 23), <>Fix bug in <SpellLink id={TALENTS_EVOKER.STASIS_TALENT}/> due to poor logging</>, Trevor),
   change(date(2023, 3, 22), <>Update average stacks in <SpellLink id={TALENTS_EVOKER.OUROBOROS_TALENT}/> module</>, Trevor),
   change(date(2023, 3, 22), <>Add average stacks to <SpellLink id={TALENTS_EVOKER.OUROBOROS_TALENT}/> module</>, Trevor),
   change(date(2023, 3, 22), <>Update <SpellLink id={TALENTS_EVOKER.LIFEBIND_TALENT}/> suggestions based on nerfs</>, Trevor),

--- a/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
@@ -489,6 +489,11 @@ const EVENT_LINKS: EventLink[] = [
     anyTarget: true,
     maximumLinks: 1,
     additionalCondition(linkingEvent, referencedEvent) {
+      const refEvent = referencedEvent as CastEvent;
+      // need to ignore living flame casts on enemy
+      if (!refEvent.targetIsFriendly && (!refEvent.target || refEvent.target.guid !== 0)) {
+        return false;
+      }
       return (
         !HasRelatedEvent(referencedEvent, EMPOWERED_CAST) &&
         !HasRelatedEvent(referencedEvent, STASIS)


### PR DESCRIPTION
Filtering out damage living flames cast during stasis as they aren't actually stored