### PR TITLE
[Mistweaver] Add T30 Module

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 3, 27), <>Add Tier 30 Set Bonus Module.</>, Vohrr),
   change(date(2023, 3, 23), <>Add <SpellLink id={TALENTS_MONK.CELESTIAL_HARMONY_TALENT.id}/> and renamed where appropriate.</>, Vohrr),
   change(date(2023, 3, 21), <>Bump spec config to 10.0.7</>, Trevor),
   change(date(2023, 3, 21), <>10.0.7 Updates, added <SpellLink id={TALENTS_MONK.LEGACY_OF_WISDOM_TALENT.id}/> module.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
+++ b/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
@@ -84,6 +84,7 @@ import SheilunsGiftCloudGraph from './modules/spells/SheilunsGiftCloudGraph';
 import HotCountGraph from './modules/features/HotCountGraph';
 import AplCheck from './modules/core/apl/AplCheck';
 import RisingMistBreakdown from './modules/features/RisingMistBreakdown';
+import T30TierSet from './modules/dragonflight/tier/T30MWTier';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -183,6 +184,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Borrowed Power
     t29TierSet: T29TierSet,
+    t30TierSet: T30TierSet,
 
     // Mana Tab
     manaTracker: ManaTracker,

--- a/src/analysis/retail/monk/mistweaver/modules/dragonflight/tier/T30MWTier.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/dragonflight/tier/T30MWTier.tsx
@@ -1,0 +1,121 @@
+import { formatNumber, formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import { TIERS } from 'game/TIERS';
+import { SpellLink } from 'interface';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
+import Events, { HealEvent, ResourceChangeEvent } from 'parser/core/Events';
+import BoringValueText from 'parser/ui/BoringValueText';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import ItemManaGained from 'parser/ui/ItemManaGained';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+
+const FOUR_PIECE_BONUS = 0.4;
+const FOUR_PIECE_SPELLS = [SPELLS.RENEWING_MIST_HEAL, SPELLS.VIVIFY];
+
+class T30TierSet extends Analyzer {
+  has2Piece: boolean = true;
+  has4Piece: boolean = true;
+  vivHealing: number = 0;
+  renewingMistHealing: number = 0;
+  manaGain: number = 0;
+  wastedManaGain: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.has2Piece = this.selectedCombatant.has2PieceByTier(TIERS.T29);
+    this.has4Piece = this.selectedCombatant.has4PieceByTier(TIERS.T29) && this.has2Piece;
+    this.active = this.has2Piece;
+    if (!this.active) {
+      return;
+    }
+    // 2pc do energized for mana gain value and show uptime
+    this.addEventListener(
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.SOULFANG_INFUSION),
+      this.handle2pcMana,
+    );
+    //4pc do uptime and effective healing increase
+    if (this.has4Piece) {
+      this.addEventListener(
+        Events.heal.by(SELECTED_PLAYER).spell(FOUR_PIECE_SPELLS),
+        this.handle4PcHeal,
+      );
+    }
+  }
+
+  get total4PieceHealing() {
+    return this.renewingMistHealing + this.vivHealing;
+  }
+  get twoSetUptime() {
+    return (
+      this.selectedCombatant.getBuffUptime(SPELLS.SOULFANG_INFUSION.id) / this.owner.fightDuration
+    );
+  }
+
+  get fourSetUptime() {
+    return (
+      this.selectedCombatant.getBuffUptime(SPELLS.SOULFANG_VITALITY.id) / this.owner.fightDuration
+    );
+  }
+
+  handle2pcMana(event: ResourceChangeEvent) {
+    if (event.resourceChangeType !== RESOURCE_TYPES.MANA.id) {
+      return;
+    }
+    this.manaGain += event.resourceChange - event.waste;
+    this.wastedManaGain += event.waste;
+  }
+
+  handle4PcHeal(event: HealEvent) {
+    const spellId = event.ability.guid;
+    if (this.selectedCombatant.hasBuff(SPELLS.SOULFANG_VITALITY.id)) {
+      if (spellId === SPELLS.RENEWING_MIST_HEAL.id) {
+        this.renewingMistHealing += calculateEffectiveHealing(event, FOUR_PIECE_BONUS);
+      } else if (spellId === SPELLS.VIVIFY.id) {
+        this.vivHealing += calculateEffectiveHealing(event, FOUR_PIECE_BONUS);
+      }
+    }
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        size="flexible"
+        position={STATISTIC_ORDER.OPTIONAL(0)}
+        category={STATISTIC_CATEGORY.ITEMS}
+        tooltip={
+          <ul>
+            <li>
+              {formatNumber(this.renewingMistHealing)} extra{' '}
+              <SpellLink id={SPELLS.RENEWING_MIST_HEAL.id} /> healing
+            </li>
+            <li>
+              {formatNumber(this.vivHealing)} extra <SpellLink id={SPELLS.VIVIFY.id} /> healing
+            </li>
+          </ul>
+        }
+      >
+        <BoringValueText label="T29 Tier Set">
+          <h4>2 Piece</h4>
+          <ItemManaGained amount={this.manaGain} useAbbrev />
+          <br />
+          {formatPercentage(this.twoSetUptime)}%<small> uptime</small>
+          <hr />
+          {this.has4Piece && (
+            <>
+              <h4>4 Piece</h4>
+              <ItemHealingDone amount={this.total4PieceHealing} />
+              <br />
+              {formatPercentage(this.fourSetUptime)}%<small> uptime</small>
+            </>
+          )}
+        </BoringValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default T30TierSet;

--- a/src/analysis/retail/monk/mistweaver/modules/dragonflight/tier/T30MWTier.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/dragonflight/tier/T30MWTier.tsx
@@ -102,7 +102,7 @@ class T30TierSet extends Analyzer {
           </ul>
         }
       >
-        <BoringValueText label="T29 Tier Set">
+        <BoringValueText label="Fangs of Forged Vermillion (T30 Set Bonus)">
           <h4>2 Piece</h4>
           <ItemManaGained amount={this.manaGain} useAbbrev />
           <br />

--- a/src/analysis/retail/monk/mistweaver/modules/dragonflight/tier/T30MWTier.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/dragonflight/tier/T30MWTier.tsx
@@ -89,11 +89,15 @@ class T30TierSet extends Analyzer {
         tooltip={
           <ul>
             <li>
-              {formatNumber(this.renewingMistHealing)} extra{' '}
+              <strong>{formatNumber(this.renewingMistHealing)}</strong> extra{' '}
               <SpellLink id={SPELLS.RENEWING_MIST_HEAL.id} /> healing
             </li>
             <li>
-              {formatNumber(this.vivHealing)} extra <SpellLink id={SPELLS.VIVIFY.id} /> healing
+              <strong>{formatNumber(this.vivHealing)}</strong> extra{' '}
+              <SpellLink id={SPELLS.VIVIFY.id} /> healing
+            </li>
+            <li>
+              <strong>{formatNumber(this.wastedManaGain)}</strong> mana wasted from overcapping
             </li>
           </ul>
         }

--- a/src/analysis/retail/monk/mistweaver/modules/dragonflight/tier/T30MWTier.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/dragonflight/tier/T30MWTier.tsx
@@ -26,8 +26,8 @@ class T30TierSet extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.has2Piece = this.selectedCombatant.has2PieceByTier(TIERS.T29);
-    this.has4Piece = this.selectedCombatant.has4PieceByTier(TIERS.T29) && this.has2Piece;
+    this.has2Piece = this.selectedCombatant.has2PieceByTier(TIERS.T30);
+    this.has4Piece = this.selectedCombatant.has4PieceByTier(TIERS.T30) && this.has2Piece;
     this.active = this.has2Piece;
     if (!this.active) {
       return;
@@ -49,6 +49,7 @@ class T30TierSet extends Analyzer {
   get total4PieceHealing() {
     return this.renewingMistHealing + this.vivHealing;
   }
+
   get twoSetUptime() {
     return (
       this.selectedCombatant.getBuffUptime(SPELLS.SOULFANG_INFUSION.id) / this.owner.fightDuration
@@ -72,11 +73,10 @@ class T30TierSet extends Analyzer {
   handle4PcHeal(event: HealEvent) {
     const spellId = event.ability.guid;
     if (this.selectedCombatant.hasBuff(SPELLS.SOULFANG_VITALITY.id)) {
-      if (spellId === SPELLS.RENEWING_MIST_HEAL.id) {
-        this.renewingMistHealing += calculateEffectiveHealing(event, FOUR_PIECE_BONUS);
-      } else if (spellId === SPELLS.VIVIFY.id) {
-        this.vivHealing += calculateEffectiveHealing(event, FOUR_PIECE_BONUS);
-      }
+      const healing = calculateEffectiveHealing(event, FOUR_PIECE_BONUS);
+      spellId === SPELLS.RENEWING_MIST_HEAL.id
+        ? (this.renewingMistHealing += healing)
+        : (this.vivHealing += healing);
     }
   }
 

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -361,7 +361,18 @@ const spells = spellIndexableList({
     name: 'Nourishing Chi',
     icon: 'inv_misc_gem_pearl_06',
   },
-
+  //Tier 30 2pc Buff
+  SOULFANG_INFUSION: {
+    id: 410007,
+    name: 'Soulfang Infusion',
+    icon: 'inv_glove_leather_raidmonkdragon_d_01',
+  },
+  //Tier 30 4pc Buff
+  SOULFANG_VITALITY: {
+    id: 410082,
+    name: 'Soulfang Vitality',
+    icon: 'nv_helm_leather_raidmonkdragon_d_01',
+  },
   // Brewmaster
   NIUZAO_STOMP_DAMAGE: {
     id: 227291,


### PR DESCRIPTION
### Description
Add mistweaver's tier set module for the 10.1 raid
Does not need to wait to be merged since it wont be active unless you're wearing tier

### Screenshot
![image](https://user-images.githubusercontent.com/26779541/228055080-2c7460da-323e-4876-aa46-1b431f2d826e.png)

### Testing

Test Report: https://www.warcraftlogs.com/reports/Kpkfv92CYR8Vr6LG#type=healing&source=21&fight=9
