### PR TITLE
mark 10.0.5 logs as not current

### DIFF
--- a/e2e/report-selection.spec.ts
+++ b/e2e/report-selection.spec.ts
@@ -3,53 +3,56 @@ import { expect, test } from './fixtures';
 test('report selection', async ({ page, homePage, fightSelectionPage }) => {
   await homePage.goto();
 
-  await homePage.fillInReportInputWithCode('QnGVYqCkHxcwzrpX');
+  await homePage.fillInReportInputWithCode('zkBJfC4PVLM9ar2G');
 
   await fightSelectionPage.expectFightSelectionHeaderToBeVisible();
-  await fightSelectionPage.expectUrlToHaveReportCode('QnGVYqCkHxcwzrpX');
-  await expect(page).toHaveTitle('Vault of the Incarnates');
+  await fightSelectionPage.expectUrlToHaveReportCode('zkBJfC4PVLM9ar2G');
+  await expect(page).toHaveTitle('2023 March 27');
 });
 
 test('fight selection', async ({ page, fightSelectionPage, playerSelectionPage }) => {
-  await fightSelectionPage.goto('QnGVYqCkHxcwzrpX');
+  await fightSelectionPage.goto('zkBJfC4PVLM9ar2G');
 
-  await page.getByRole('link', { name: 'Kill 3:35' }).click();
+  await page.getByRole('link', { name: 'Kill 12:35' }).click();
 
   await playerSelectionPage.expectPlayerSelectionHeaderToBeVisible();
   await playerSelectionPage.expectUrlToHaveReportCodeAndFight(
-    'QnGVYqCkHxcwzrpX',
-    '7-Mythic+The+Primal+Council+-+Kill+(3:35)',
+    'zkBJfC4PVLM9ar2G',
+    '16-Mythic+Raszageth+the+Storm-Eater+-+Kill+(12:35)',
   );
   await expect(page).toHaveTitle(
-    'Mythic The Primal Council - Kill (3:35) in Vault of the Incarnates',
+    'Mythic Raszageth the Storm-Eater - Kill (12:35) in 2023 March 27',
   );
 });
 
 test('player selection', async ({ page, playerSelectionPage, reportPage }) => {
-  await playerSelectionPage.goto('QnGVYqCkHxcwzrpX', '7-Mythic+The+Primal+Council+-+Kill+(3:35)');
+  await playerSelectionPage.goto(
+    'zkBJfC4PVLM9ar2G',
+    '16-Mythic+Raszageth+the+Storm-Eater+-+Kill+(12:35)',
+  );
 
   await page
-    .getByRole('link', { name: 'Sigilweaver Vengeance Demon Hunter Vengeance Demon Hunter 411' })
+    .getByRole('link', { name: 'Toppledh Vengeance Demon Hunter Vengeance Demon Hunter 418' })
     .click();
 
   await reportPage.expectBossDifficultyAndNameHeaderToBeVisible();
-  await reportPage.expectBossDifficultyAndNameHeaderToHaveText('MythicThe Primal Council');
+  await reportPage.expectBossDifficultyAndNameHeaderToHaveText('MythicRaszageth the Storm-Eater');
   await reportPage.expectUrlToHave(
-    'QnGVYqCkHxcwzrpX',
-    '7-Mythic+The+Primal+Council+-+Kill+(3:35)',
-    'Sigilweaver',
+    'zkBJfC4PVLM9ar2G',
+    '16-Mythic+Raszageth+the+Storm-Eater+-+Kill+(12:35)',
+    'Toppledh',
   );
   await expect(page).toHaveTitle(
-    'Mythic The Primal Council - Kill (3:35) by Sigilweaver in Vault of the Incarnates',
+    'Mythic Raszageth the Storm-Eater - Kill (12:35) by Toppledh in 2023 March 27',
   );
 });
 
 test.describe('tab selection', () => {
   test.beforeEach(async ({ reportPage }) => {
     await reportPage.goto({
-      reportCode: 'QnGVYqCkHxcwzrpX',
-      fightCode: '7-Mythic+The+Primal+Council+-+Kill+(3:35)',
-      playerName: 'Sigilweaver',
+      reportCode: 'zkBJfC4PVLM9ar2G',
+      fightCode: '16-Mythic+Raszageth+the+Storm-Eater+-+Kill+(12:35)',
+      playerName: 'Toppledh',
     });
   });
 
@@ -57,7 +60,7 @@ test.describe('tab selection', () => {
     await reportPage.clickOnStatisticsTab();
 
     await expect(page).toHaveURL(
-      '/report/QnGVYqCkHxcwzrpX/7-Mythic+The+Primal+Council+-+Kill+(3:35)/Sigilweaver/standard/statistics',
+      '/report/zkBJfC4PVLM9ar2G/16-Mythic+Raszageth+the+Storm-Eater+-+Kill+(12:35)/Toppledh/standard/statistics',
     );
   });
 
@@ -65,7 +68,7 @@ test.describe('tab selection', () => {
     await reportPage.clickOnTimelineTab();
 
     await expect(page).toHaveURL(
-      '/report/QnGVYqCkHxcwzrpX/7-Mythic+The+Primal+Council+-+Kill+(3:35)/Sigilweaver/standard/timeline',
+      '/report/zkBJfC4PVLM9ar2G/16-Mythic+Raszageth+the+Storm-Eater+-+Kill+(12:35)/Toppledh/standard/timeline',
     );
   });
 
@@ -73,7 +76,7 @@ test.describe('tab selection', () => {
     await reportPage.clickOnCooldownsTab();
 
     await expect(page).toHaveURL(
-      '/report/QnGVYqCkHxcwzrpX/7-Mythic+The+Primal+Council+-+Kill+(3:35)/Sigilweaver/standard/cooldowns',
+      '/report/zkBJfC4PVLM9ar2G/16-Mythic+Raszageth+the+Storm-Eater+-+Kill+(12:35)/Toppledh/standard/cooldowns',
     );
   });
 
@@ -81,7 +84,7 @@ test.describe('tab selection', () => {
     await reportPage.clickOnCharacterTab();
 
     await expect(page).toHaveURL(
-      '/report/QnGVYqCkHxcwzrpX/7-Mythic+The+Primal+Council+-+Kill+(3:35)/Sigilweaver/standard/character',
+      '/report/zkBJfC4PVLM9ar2G/16-Mythic+Raszageth+the+Storm-Eater+-+Kill+(12:35)/Toppledh/standard/character',
     );
   });
 
@@ -89,7 +92,7 @@ test.describe('tab selection', () => {
     await reportPage.clickOnAboutTab('Vengeance Demon Hunter');
 
     await expect(page).toHaveURL(
-      '/report/QnGVYqCkHxcwzrpX/7-Mythic+The+Primal+Council+-+Kill+(3:35)/Sigilweaver/standard/about',
+      '/report/zkBJfC4PVLM9ar2G/16-Mythic+Raszageth+the+Storm-Eater+-+Kill+(12:35)/Toppledh/standard/about',
     );
   });
 });
@@ -100,16 +103,16 @@ test('perform analysis', async ({ page }) => {
   await page.getByPlaceholder('https://www.warcraftlogs.com/reports/<report code>').click();
   await page
     .getByPlaceholder('https://www.warcraftlogs.com/reports/<report code>')
-    .fill('https://www.warcraftlogs.com/reports/QnGVYqCkHxcwzrpX');
+    .fill('https://www.warcraftlogs.com/reports/zkBJfC4PVLM9ar2G');
   await page.getByRole('heading', { name: 'Fight selection' }).waitFor();
-  await page.getByRole('link', { name: 'Kill 3:35' }).click();
+  await page.getByRole('link', { name: 'Kill 12:35' }).click();
   await page.getByRole('heading', { name: 'Player selection' }).waitFor();
   await page
-    .getByRole('link', { name: 'Sigilweaver Vengeance Demon Hunter Vengeance Demon Hunter 411' })
+    .getByRole('link', { name: 'Toppledh Vengeance Demon Hunter Vengeance Demon Hunter 418' })
     .click();
-  await page.getByText('MythicThe Primal Council').waitFor();
+  await page.getByText('MythicRaszageth the Storm-Eater').waitFor();
 
   await expect(page).toHaveURL(
-    '/report/QnGVYqCkHxcwzrpX/7-Mythic+The+Primal+Council+-+Kill+(3:35)/Sigilweaver/standard',
+    '/report/zkBJfC4PVLM9ar2G/16-Mythic+Raszageth+the+Storm-Eater+-+Kill+(12:35)/Toppledh/standard',
   );
 });

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -23,6 +23,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 3, 29), 'Mark 10.0.5 logs as not current.', ToppleTheNun),
   change(date(2023, 3, 21), 'Add Ulduar raid and images for Classic WotLK.', jazminite),
   change(date(2023, 3, 21), 'Add patch info for 10.0.7.', ToppleTheNun),
   change(date(2023, 3, 20), 'Fix an issue where APL rules could mistakenly mismatch, causing weird UI issues.', emallson),

--- a/src/interface/report/PATCHES.ts
+++ b/src/interface/report/PATCHES.ts
@@ -117,7 +117,7 @@ const PATCHES: Patch[] = [
     name: '10.0.5',
     timestamp: 1674597600000, // GMT: Tuesday, 24 January 2023 22:00:00
     urlPrefix: '',
-    isCurrent: true, // TODO: set to false after EU reset
+    isCurrent: false,
     gameVersion: 1, // retail
     expansion: Expansion.Dragonflight,
   },


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Mark 10.0.5 logs as not current and update report selection Playwright test report.

### Motivation

<!-- Why are you submitting this pull request?-->

10.0.5 isn't the current patch and the report selection Playwright test is broken due to using an old report.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/r4JtW9hxdzwc3G6q/8-Mythic+The+Primal+Council+-+Kill+(3:00)/22-Toppledh/standard`
