### PR TITLE
Improve accuracy of veil of pride module

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 3, 29), <>Improve accuracy of <SpellLink id={TALENTS_MONK.VEIL_OF_PRIDE_TALENT}/> module</>, Trevor),
   change(date(2023, 3, 27), <>Add Tier 30 Set Bonus Module.</>, Vohrr),
   change(date(2023, 3, 23), <>Add <SpellLink id={TALENTS_MONK.CELESTIAL_HARMONY_TALENT.id}/> and renamed where appropriate.</>, Vohrr),
   change(date(2023, 3, 21), <>Bump spec config to 10.0.7</>, Trevor),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/LegacyOfWisdom.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/LegacyOfWisdom.tsx
@@ -65,7 +65,7 @@ class LegacyOfWisdom extends Analyzer {
         <TalentSpellText talent={talents.LEGACY_OF_WISDOM_TALENT}>
           <ItemHealingDone amount={this.healing} />
           <br />
-          {this.buffIcon} {this.missedHits} <small> missed hits</small>
+          {this.buffIcon} {this.missedHits} <small> missed hits</small> <br />
           {this.extraGcds} <small>saved GCDs</small>
         </TalentSpellText>
       </Statistic>

--- a/src/analysis/retail/monk/mistweaver/modules/spells/LegacyOfWisdom.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/LegacyOfWisdom.tsx
@@ -10,6 +10,7 @@ import TalentSpellText from 'parser/ui/TalentSpellText';
 import { getSheilunsGiftHits } from '../../normalizers/CastLinkNormalizer';
 import WarningIcon from 'interface/icons/Warning';
 import CheckmarkIcon from 'interface/icons/Checkmark';
+import Uptime from 'interface/icons/Uptime';
 
 const LEGACY_OF_WISDOM_TARGETS = 2;
 const SHEILUNS_GIFT_TARGETS = 3;
@@ -65,8 +66,8 @@ class LegacyOfWisdom extends Analyzer {
         <TalentSpellText talent={talents.LEGACY_OF_WISDOM_TALENT}>
           <ItemHealingDone amount={this.healing} />
           <br />
-          {this.buffIcon} {this.missedHits} <small> missed hits</small> <br />
-          {this.extraGcds} <small>saved GCDs</small>
+          {this.buffIcon} {this.missedHits.toFixed(2)} <small> missed hits</small> <br />
+          <Uptime /> {this.extraGcds.toFixed(2)} <small>saved GCDs</small>
         </TalentSpellText>
       </Statistic>
     );

--- a/src/analysis/retail/monk/mistweaver/modules/spells/SheilunsGift.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/SheilunsGift.tsx
@@ -19,6 +19,7 @@ class SheilunsGift extends Analyzer {
   baseHealing: number = 0;
   gomHealing: number = 0;
   cloudsLost: number = 0;
+  cloudsLostSinceLastCast: number = 0;
   curClouds: number = 0;
   overhealing: number = 0;
 
@@ -48,6 +49,7 @@ class SheilunsGift extends Analyzer {
 
   onCast(event: CastEvent) {
     this.totalStacks += this.selectedCombatant.getBuffStacks(SPELLS.SHEILUN_CLOUD_BUFF.id);
+    this.cloudsLostSinceLastCast = 0;
     this.numCasts += 1;
   }
 
@@ -59,6 +61,7 @@ class SheilunsGift extends Analyzer {
   onBuffRefresh(event: RefreshBuffEvent) {
     if (this.curClouds === 10) {
       this.cloudsLost += 1;
+      this.cloudsLostSinceLastCast += 1;
     }
     this.curClouds = this.selectedCombatant.getBuffStacks(SPELLS.SHEILUN_CLOUD_BUFF.id);
   }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/SheilunsGift.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/SheilunsGift.tsx
@@ -20,6 +20,7 @@ class SheilunsGift extends Analyzer {
   gomHealing: number = 0;
   cloudsLost: number = 0;
   curClouds: number = 0;
+  overhealing: number = 0;
 
   constructor(options: Options) {
     super(options);
@@ -51,7 +52,8 @@ class SheilunsGift extends Analyzer {
   }
 
   onHeal(event: HealEvent) {
-    this.baseHealing += event.amount;
+    this.baseHealing += event.amount + (event.absorbed || 0);
+    this.overhealing += event.overheal || 0;
   }
 
   onBuffRefresh(event: RefreshBuffEvent) {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/VeilOfPride.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/VeilOfPride.tsx
@@ -12,8 +12,6 @@ import SheilunsGift from './SheilunsGift';
 import Events, { CastEvent, HealEvent } from 'parser/core/Events';
 import { calculateEffectiveHealing, calculateOverhealing } from 'parser/core/EventCalculateLib';
 
-const MAX_STACKS = 10;
-
 class VeilOfPride extends Analyzer {
   static dependencies = {
     sheilunsGift: SheilunsGift,
@@ -45,7 +43,8 @@ class VeilOfPride extends Analyzer {
     // double clouds = 100% increase -> 2x / x - 1 = 1
     const veilStacksLost = Math.ceil(this.sheilunsGift.cloudsLostSinceLastCast / 2);
     const extraStacks = Math.max(0, Math.ceil(this.sheilunsGift.curClouds / 2) + veilStacksLost);
-    const increase = this.sheilunsGift.curClouds / (MAX_STACKS - extraStacks);
+    const baseStacks = this.sheilunsGift.curClouds - extraStacks;
+    const increase = this.sheilunsGift.curClouds / baseStacks - 1;
     this.totalHealing += calculateEffectiveHealing(event, increase);
     this.totalOverhealing += calculateOverhealing(event, increase);
     this.totalExtraClouds += extraStacks;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/VeilOfPride.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/VeilOfPride.tsx
@@ -81,6 +81,10 @@ class VeilOfPride extends Analyzer {
     return this.totalExtraClouds / this.totalCasts;
   }
 
+  get percentOfSgOverhealing() {
+    return this.totalOverhealing / this.sheilunsGift.overhealing;
+  }
+
   subStatistic() {
     return (
       <StatisticListBoxItem
@@ -103,6 +107,10 @@ class VeilOfPride extends Analyzer {
             <ul>
               <li>Total Healing : {formatNumber(this.totalHealing)}</li>
               <li>Total overhealing: {formatNumber(this.totalOverhealing)}</li>
+              <li>
+                Percent of <SpellLink id={TALENTS_MONK.SHEILUNS_GIFT_TALENT} /> overhealing:{' '}
+                {formatPercentage(this.percentOfSgOverhealing)}%
+              </li>
             </ul>
           </>
         }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/VeilOfPride.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/VeilOfPride.tsx
@@ -41,7 +41,7 @@ class VeilOfPride extends Analyzer {
 
   onHeal(event: HealEvent) {
     // double clouds = 100% increase -> 2x / x - 1 = 1
-    const veilStacksLost = Math.ceil(this.sheilunsGift.cloudsLostSinceLastCast / 2);
+    const veilStacksLost = Math.floor(this.sheilunsGift.cloudsLostSinceLastCast / 2);
     const extraStacks = Math.max(0, Math.ceil(this.sheilunsGift.curClouds / 2) + veilStacksLost);
     const baseStacks = this.sheilunsGift.curClouds - extraStacks;
     if (baseStacks === 0) {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/VeilOfPride.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/VeilOfPride.tsx
@@ -44,6 +44,11 @@ class VeilOfPride extends Analyzer {
     const veilStacksLost = Math.ceil(this.sheilunsGift.cloudsLostSinceLastCast / 2);
     const extraStacks = Math.max(0, Math.ceil(this.sheilunsGift.curClouds / 2) + veilStacksLost);
     const baseStacks = this.sheilunsGift.curClouds - extraStacks;
+    if (baseStacks === 0) {
+      this.totalHealing += event.amount + (event.absorbed || 0);
+      this.totalOverhealing += event.overheal || 0;
+      return;
+    }
     const increase = this.sheilunsGift.curClouds / baseStacks - 1;
     this.totalHealing += calculateEffectiveHealing(event, increase);
     this.totalOverhealing += calculateOverhealing(event, increase);

--- a/src/analysis/retail/monk/mistweaver/modules/spells/VeilOfPride.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/VeilOfPride.tsx
@@ -1,7 +1,7 @@
-import { formatPercentage } from 'common/format';
+import { formatNumber, formatPercentage } from 'common/format';
 import { TALENTS_MONK } from 'common/TALENTS';
 import { SpellLink } from 'interface';
-import Analyzer, { Options } from 'parser/core/Analyzer';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
 import Statistic from 'parser/ui/Statistic';
 import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
@@ -9,19 +9,76 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import TalentSpellText from 'parser/ui/TalentSpellText';
 import SheilunsGift from './SheilunsGift';
+import Events, { CastEvent, HealEvent } from 'parser/core/Events';
+import { calculateEffectiveHealing, calculateOverhealing } from 'parser/core/EventCalculateLib';
+
+const SECONDS_PER_CLOUD = 8000;
+const MAX_STACKS = 10;
+const VEIL_SECONDS_PER_CLOUD = 4000;
 
 class VeilOfPride extends Analyzer {
   static dependencies = {
     sheilunsGift: SheilunsGift,
   };
   protected sheilunsGift!: SheilunsGift;
+  lastCast: number = 0;
+  stacksOnCast: number = 0;
+  totalExtraClouds: number = 0;
+  totalCasts: number = 0;
+  totalHealing: number = 0;
+  totalOverhealing: number = 0;
+  extraStacksOnCast: number = 0;
+
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.VEIL_OF_PRIDE_TALENT);
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS_MONK.SHEILUNS_GIFT_TALENT),
+      this.onCast,
+    );
+    this.addEventListener(
+      Events.heal.by(SELECTED_PLAYER).spell(TALENTS_MONK.SHEILUNS_GIFT_TALENT),
+      this.onHeal,
+    );
   }
 
-  get totalHealing() {
-    return this.sheilunsGift.totalHealing / 2;
+  onCast(event: CastEvent) {
+    this.stacksOnCast = this.sheilunsGift.curClouds;
+    this.extraStacksOnCast = this.getExtraClouds(event.timestamp);
+    this.lastCast = event.timestamp;
+    this.totalCasts += 1;
+  }
+
+  getExtraStacks(baseStacks: number, totalStacks: number) {
+    if (totalStacks < MAX_STACKS) {
+      return totalStacks - baseStacks;
+    } else if (totalStacks < MAX_STACKS * 2) {
+      return Math.max(0, MAX_STACKS - baseStacks);
+    }
+    return 0;
+  }
+
+  getExtraClouds(timestamp: number) {
+    if (this.lastCast === 0) {
+      this.lastCast = this.owner.fight.start_time;
+    }
+    const timeDiff = timestamp - this.lastCast;
+    const nonVeilStacks = Math.floor(timeDiff / SECONDS_PER_CLOUD);
+    const rawVeilStacks = Math.floor(timeDiff / VEIL_SECONDS_PER_CLOUD);
+    return this.getExtraStacks(nonVeilStacks, rawVeilStacks);
+  }
+
+  onHeal(event: HealEvent) {
+    // double clouds = 100% increase -> 2x / x - 1 = 1
+    const baseStacks = this.stacksOnCast - this.extraStacksOnCast;
+    const effectiveIncrease = this.stacksOnCast / baseStacks - 1;
+    this.totalHealing += calculateEffectiveHealing(event, effectiveIncrease);
+    this.totalOverhealing += calculateOverhealing(event, effectiveIncrease);
+    this.totalExtraClouds += this.stacksOnCast - this.extraStacksOnCast;
+  }
+
+  get avgExtraClouds() {
+    return this.totalExtraClouds / this.totalCasts;
   }
 
   subStatistic() {
@@ -41,6 +98,14 @@ class VeilOfPride extends Analyzer {
         position={STATISTIC_ORDER.OPTIONAL(4)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            <ul>
+              <li>Total Healing : {formatNumber(this.totalHealing)}</li>
+              <li>Total overhealing: {formatNumber(this.totalOverhealing)}</li>
+            </ul>
+          </>
+        }
       >
         <TalentSpellText talent={TALENTS_MONK.VEIL_OF_PRIDE_TALENT}>
           <ItemHealingDone amount={this.totalHealing} /> <br />


### PR DESCRIPTION
Before we blindly took half of all Sheilun's healing but in reality a majority of the overhealing is going to come from the veil of pride stacks. This PR tries to attribute overhealing/healing to non-pride vs pride stacks.

Before
![image](https://user-images.githubusercontent.com/11250934/228736044-7328b521-3117-4094-bea7-bd0792ab2e68.png)
After
![image](https://user-images.githubusercontent.com/11250934/228736077-e30b8170-2e84-4801-a6db-709111a59b4d.png)
![image](https://user-images.githubusercontent.com/11250934/228741861-345b6df4-52f0-4a90-bd4f-d05c12406210.png)


In this log, roughly 71% of the overhealing was from extra veil stacks so it makes sense that veil is not directly half of sheilun's healing

Also updated visuals of legacy to have precision and icon for alignment
![image](https://user-images.githubusercontent.com/11250934/228741910-5092f519-e5b0-4bbe-bcc8-fd4d12b2f4ce.png)


report/1qcwTk7dBmz8LQF6/14-Mythic+Broodkeeper+Diurna+-+Kill+(8:17)/Livingmist/standard/statistics