### PR TITLE
refactor spellId to spell on SpellLink

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -23,6 +23,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 3, 31), 'Refactor SpellLink props to use "spell" instead of "id".', ToppleTheNun),
   change(date(2023, 3, 31), 'Add Dragonflight season 1 M+ dungeon images.', ToppleTheNun),
   change(date(2023, 3, 30), 'Add ability to use PTR tooltips based on report zone.', ToppleTheNun),
   change(date(2023, 3, 29), 'Mark 10.0.5 logs as not current.', ToppleTheNun),

--- a/src/interface/SpellIcon.tsx
+++ b/src/interface/SpellIcon.tsx
@@ -5,15 +5,33 @@ import SpellLink from './SpellLink';
 import useSpellInfo from './useSpellInfo';
 import Spell from 'common/SPELLS/Spell';
 
-interface Props extends Omit<React.ComponentProps<typeof Icon>, 'id' | 'icon'> {
-  id: number | Spell;
+interface BaseProps extends Omit<React.ComponentProps<typeof Icon>, 'id' | 'icon'> {
   noLink?: boolean;
   alt?: string;
   ilvl?: number;
 }
 
-const SpellIcon = ({ id: spell, noLink, alt, ilvl, ...others }: Props) => {
-  const spellInfo = useSpellInfo(spell);
+interface PropsWithId extends BaseProps {
+  /**
+   * @deprecated use {@link spell} instead.
+   */
+  id: number | Spell;
+  spell?: never;
+}
+
+interface PropsWithSpell extends BaseProps {
+  /**
+   * @deprecated use {@link spell} instead.
+   */
+  id?: never;
+  spell: number | Spell;
+}
+
+type Props = PropsWithId | PropsWithSpell;
+
+const SpellIcon = ({ id, spell, noLink, alt, ilvl, ...others }: Props) => {
+  const spellData = spell ?? id;
+  const spellInfo = useSpellInfo(spellData);
 
   const spellWithFallback = spellInfo || {
     name: 'Spell not recognized',
@@ -33,7 +51,7 @@ const SpellIcon = ({ id: spell, noLink, alt, ilvl, ...others }: Props) => {
   }
 
   return (
-    <SpellLink id={spell} ilvl={ilvl} icon={false}>
+    <SpellLink spell={spellData} ilvl={ilvl} icon={false}>
       {icon}
     </SpellLink>
   );

--- a/src/interface/SpellLink.tsx
+++ b/src/interface/SpellLink.tsx
@@ -6,8 +6,7 @@ import SpellIcon from './SpellIcon';
 import useSpellInfo from './useSpellInfo';
 import useTooltip from './useTooltip';
 
-interface Props extends Omit<React.HTMLAttributes<HTMLAnchorElement>, 'id'> {
-  id: number | Spell;
+interface BaseProps extends Omit<React.HTMLAttributes<HTMLAnchorElement>, 'id'> {
   children?: React.ReactNode;
   icon?: boolean;
   iconStyle?: CSSProperties;
@@ -15,10 +14,29 @@ interface Props extends Omit<React.HTMLAttributes<HTMLAnchorElement>, 'id'> {
   rank?: number;
 }
 
+interface PropsWithId extends BaseProps {
+  /**
+   * @deprecated use {@link spell} instead.
+   */
+  id: number | Spell;
+  spell?: never;
+}
+
+interface PropsWithSpell extends BaseProps {
+  /**
+   * @deprecated use {@link spell} instead.
+   */
+  id?: never;
+  spell: number | Spell;
+}
+
+type Props = PropsWithId | PropsWithSpell;
+
 const SpellLink = React.forwardRef<HTMLAnchorElement, Props>(
-  ({ id: spell, children, icon = true, iconStyle, ilvl, rank, ...other }: Props, ref) => {
-    const spellId = typeof spell === 'number' ? spell : spell.id;
-    const spellInfo = useSpellInfo(spell);
+  ({ id, spell, children, icon = true, iconStyle, ilvl, rank, ...other }: Props, ref) => {
+    const spellData = spell ?? id;
+    const spellId = typeof spellData === 'number' ? spellData : spellData.id;
+    const spellInfo = useSpellInfo(spellData);
     const { spell: spellTooltip } = useTooltip();
 
     return (
@@ -32,7 +50,7 @@ const SpellLink = React.forwardRef<HTMLAnchorElement, Props>(
       >
         {icon && (
           <>
-            <SpellIcon id={spell} noLink style={iconStyle} alt="" />{' '}
+            <SpellIcon spell={spellData} noLink style={iconStyle} alt="" />{' '}
           </>
         )}
         {children || (spellInfo?.name ? spellInfo.name : `Unknown spell: ${spellId}`)}

--- a/src/parser/ui/BoringSpellValueText.tsx
+++ b/src/parser/ui/BoringSpellValueText.tsx
@@ -7,17 +7,35 @@ import { SpellIcon } from 'interface';
 import { SpellLink } from 'interface';
 import { ReactNode } from 'react';
 
-interface Props {
-  spellId: number | Spell;
+interface BaseProps {
   children: ReactNode;
   className?: string;
   ilvl?: number;
 }
 
-const BoringSpellValueText = ({ spellId, children, className, ilvl }: Props) => (
+interface PropsWithSpellId extends BaseProps {
+  /**
+   * @deprecated use {@link spell} instead.
+   */
+  spellId: number | Spell;
+  spell?: never;
+}
+
+interface PropsWithSpell extends BaseProps {
+  /**
+   * @deprecated use {@link spell} instead.
+   */
+  spellId?: never;
+  spell: number | Spell;
+}
+
+type Props = PropsWithSpellId | PropsWithSpell;
+
+const BoringSpellValueText = ({ spellId, spell, children, className, ilvl }: Props) => (
   <div className={`pad boring-text ${className || ''}`}>
     <label>
-      <SpellIcon id={spellId} /> <SpellLink id={spellId} ilvl={ilvl} icon={false} />
+      <SpellIcon spell={spell ?? spellId} />{' '}
+      <SpellLink spell={spell ?? spellId} ilvl={ilvl} icon={false} />
     </label>
     <div className="value">{children}</div>
   </div>


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Update SpellIcon and SpellLink's `spellId`/`id` prop to just `spell` to indicate that it takes more than just a spell ID.

### Motivation

<!-- Why are you submitting this pull request?-->

It being `spellId`/`id` was confusing as to what values it could take as a property.
