### PR TITLE
add ability to use PTR tooltips

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -23,6 +23,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 3, 30), 'Add ability to use PTR tooltips based on report zone.', ToppleTheNun),
   change(date(2023, 3, 29), 'Mark 10.0.5 logs as not current.', ToppleTheNun),
   change(date(2023, 3, 21), 'Add Ulduar raid and images for Classic WotLK.', jazminite),
   change(date(2023, 3, 21), 'Add patch info for 10.0.7.', ToppleTheNun),

--- a/src/game/ZONES.ts
+++ b/src/game/ZONES.ts
@@ -29,6 +29,7 @@ interface Zone {
   encounters: Encounter[];
   brackets: Bracket;
   partitions?: Partition[];
+  usePtrTooltips?: boolean;
 }
 
 const ZONES: Zone[] = [
@@ -63,6 +64,26 @@ const ZONES: Zone[] = [
         default: true,
       },
     ],
+  },
+  {
+    id: 33,
+    name: 'Aberrus',
+    frozen: false,
+    encounters: [],
+    brackets: {
+      min: 402,
+      max: 450,
+      bucket: 3,
+      type: 'Item Level',
+    },
+    partitions: [
+      {
+        name: '10.1',
+        compact: '10.1',
+        default: true,
+      },
+    ],
+    usePtrTooltips: true, // TODO: Mark this as false once Aberrus goes live
   },
 ];
 

--- a/src/interface/report/Results/index.tsx
+++ b/src/interface/report/Results/index.tsx
@@ -36,6 +36,7 @@ import DegradedExperience from './DegradedExperience';
 import Header from './Header';
 import ItemWarning from './ItemWarning';
 import ScrollToTop from './ScrollToTop';
+import ZONES from 'game/ZONES';
 
 interface PassedProps {
   parser: CombatLogParser;
@@ -121,7 +122,8 @@ const Results = (props: PassedProps) => {
 
   // on game version change
   useEffect(() => {
-    // Kind of ugly but also very working. We should replace the TooltipProvider class with a context that is used by SpellLink to make this easier to manipulate.
+    const zone = ZONES.find((zone) => zone.id === props.report.zone);
+
     switch (wclGameVersionToExpansion(props.report.gameVersion)) {
       case Expansion.WrathOfTheLichKing:
         dispatch(setBaseUrl('https://www.wowhead.com/wotlk/'));
@@ -130,10 +132,14 @@ const Results = (props: PassedProps) => {
         dispatch(setBaseUrl('https://tbc.wowhead.com/'));
         break;
       default:
-        dispatch(reset());
+        if (zone?.usePtrTooltips) {
+          dispatch(setBaseUrl('https://wowhead.com/ptr/'));
+        } else {
+          dispatch(reset());
+        }
         break;
     }
-  }, [dispatch, props.report.gameVersion]);
+  }, [dispatch, props.report.gameVersion, props.report.zone]);
 
   // on tab change
   useEffect(() => {


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Add ability to use PTR tooltips.

### Motivation

<!-- Why are you submitting this pull request?-->

WCL has support for 10.1 PTR Aberrus logs in zone ID 33 and 10.1 PTR M+ keystone logs in zone ID 34. This enables people working on things that use PTR logs (like T30 tier set support) to see accurate tooltips for the log that they are working on.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/CA3DaQvTdJ6x1PqL/9-Mythic+Kazzara,+the+Hellforged+-+Wipe+9+(4:18)/Tjuanbeam/standard/character`
- Screenshot(s):

**Before**
![image](https://user-images.githubusercontent.com/1672786/229014753-961fdf0e-84e3-4830-8e89-fad98777e625.png)

**After**
![image](https://user-images.githubusercontent.com/1672786/229014573-31cd26e4-d2e2-475f-a186-37c45b3bf60e.png)
![image](https://user-images.githubusercontent.com/1672786/229014629-7e0b1c3c-631a-4b19-82dd-458abfe9b95f.png)
