### PR TITLE
[Classic] Healthstone Checker

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -23,6 +23,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 4, 2), 'Add Healthstone Checker for Classic WotLK.', jazminite),
   change(date(2023, 4, 1), 'Remove unnecessary console log.', ToppleTheNun),
   change(date(2023, 3, 31), 'Add Dragonflight season 1 M+ dungeon images.', ToppleTheNun),
   change(date(2023, 3, 30), 'Add ability to use PTR tooltips based on report zone.', ToppleTheNun),

--- a/src/analysis/classic/warlock/affliction/CHANGELOG.tsx
+++ b/src/analysis/classic/warlock/affliction/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { change, date } from 'common/changelog';
 import { jazminite } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2023, 4, 2), 'Remove static entries for Healthstone use in favor of HealthstoneChecker.', jazminite),
   change(date(2022, 12, 30), 'Add trinkets to Buffs for timeline highlight.', jazminite),
   change(date(2022, 11, 14), 'Add channeling spells to improve downtime detection.', jazminite),
   change(date(2022, 11, 13), 'Separate out Classic Affliction Warlock.', jazminite),

--- a/src/analysis/classic/warlock/affliction/modules/features/Abilities.ts
+++ b/src/analysis/classic/warlock/affliction/modules/features/Abilities.ts
@@ -188,13 +188,7 @@ class Abilities extends CoreAbilities {
         category: SPELL_CATEGORY.UTILITY,
         gcd: { base: 1500 },
       },
-
       // Consumable
-      {
-        spell: [SPELLS.HEALTHSTONE_USE.id, ...SPELLS.HEALTHSTONE_USE.lowRanks],
-        category: SPELL_CATEGORY.CONSUMABLE,
-        gcd: { base: 1500 },
-      },
     ];
   }
 }

--- a/src/analysis/classic/warlock/demonology/CHANGELOG.tsx
+++ b/src/analysis/classic/warlock/demonology/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { change, date } from 'common/changelog';
 import { jazminite } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2023, 4, 2), 'Remove static entries for Healthstone use in favor of HealthstoneChecker.', jazminite),
   change(date(2022, 2, 24), 'Add Molten Core buff to timeline + GCD reduction. Track Shadow Mastery debuff uptime.', jazminite),
   change(date(2022, 12, 30), 'Add trinkets to Buffs for timeline highlight.', jazminite),
   change(date(2022, 11, 21), 'Update example report and set partial to false.', jazminite),

--- a/src/analysis/classic/warlock/demonology/modules/features/Abilities.ts
+++ b/src/analysis/classic/warlock/demonology/modules/features/Abilities.ts
@@ -188,13 +188,7 @@ class Abilities extends CoreAbilities {
         category: SPELL_CATEGORY.UTILITY,
         gcd: { base: 1500 },
       },
-
       // Consumable
-      {
-        spell: [SPELLS.HEALTHSTONE_USE.id, ...SPELLS.HEALTHSTONE_USE.lowRanks],
-        category: SPELL_CATEGORY.CONSUMABLE,
-        gcd: { base: 1500 },
-      },
     ];
   }
 }

--- a/src/analysis/classic/warlock/shared/lowRankSpells.ts
+++ b/src/analysis/classic/warlock/shared/lowRankSpells.ts
@@ -11,7 +11,6 @@ export default lowRankSpells;
 
 export const whitelist = {
   [SPELLS.LIFE_TAP.id]: [1454],
-  [SPELLS.HEALTHSTONE_USE.id]: [47875],
 };
 
 export interface LowRankSpells {

--- a/src/common/SPELLS/classic/warlock.ts
+++ b/src/common/SPELLS/classic/warlock.ts
@@ -145,12 +145,6 @@ const spells = spellIndexableList({
     icon: 'inv_stone_04',
     lowRanks: [47871, 27230, 11730, 11729, 5699, 6202, 6201],
   },
-  HEALTHSTONE_USE: {
-    id: 47877,
-    name: 'Healthstone',
-    icon: 'inv_stone_04',
-    lowRanks: [47876, 47875],
-  },
   HELLFIRE: {
     id: 47823,
     name: 'Hellfire',

--- a/src/parser/classic/CombatLogParser.ts
+++ b/src/parser/classic/CombatLogParser.ts
@@ -40,6 +40,7 @@ import PrePullCooldownsNormalizer from '../shared/normalizers/PrePullCooldowns';
 import ManaValues from './modules/ManaValues';
 import PreparationRuleAnalyzer from './modules/features/Checklist/PreparationRuleAnalyzer';
 import CombatPotionChecker from './modules/items/CombatPotionChecker';
+import HealthstoneChecker from './modules/items/HealthstoneChecker';
 import EnchantChecker from './modules/items/EnchantChecker';
 import ManaGained from './statistic/ManaGained';
 // Engineering
@@ -72,6 +73,7 @@ class CombatLogParser extends BaseCombatLogParser {
     flaskChecker: FlaskChecker,
     preparationRuleAnalyzer: PreparationRuleAnalyzer,
     combatPotionChecker: CombatPotionChecker,
+    healthstoneChecker: HealthstoneChecker,
 
     enemies: Enemies,
     pets: Pets,

--- a/src/parser/classic/modules/items/HealthstoneChecker.tsx
+++ b/src/parser/classic/modules/items/HealthstoneChecker.tsx
@@ -1,5 +1,22 @@
-import InFightConsumablesChecker from 'parser/classic/modules/items/InFightConsumablesChecker';
+import Potion from 'parser/retail/modules/items/Potion';
 
-class HealthstoneChecker extends InFightConsumablesChecker {}
+const HEALTH_STONE_IDS = [
+  47877, // Master Healthstone
+  47875, // Master Healthstone
+  47876, // Master Healthstone
+  47872, // Master Healthstone
+  47873, // Master Healthstone
+  47874, // Master Healthstone
+  27235, // Master Healthstone
+  27236, // Master Healthstone
+  27237, // Master Healthstone
+];
+
+class HealthstoneChecker extends Potion {
+  static spells = HEALTH_STONE_IDS;
+  static extraAbilityInfo = {
+    name: 'Healthstone',
+  };
+}
 
 export default HealthstoneChecker;


### PR DESCRIPTION
### Description

- Add Healthstone Checker for Classic WotLK
- Remove static entries for Warlocks using Healthstones

### Motivation

Better statistics + all classes use Healthstones

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/zVPGW3J678mavnZc/37-Hardmode+Mimiron+-+Kill+(8:12)/Jazl/standard/statistics`
- Screenshot(s):
![image](https://user-images.githubusercontent.com/65823478/229344728-820dafd3-9b6c-411d-ae02-412fc9678fb6.png)
