### PR TITLE
improve death strike problem stuff

### DIFF
--- a/src/analysis/retail/deathknight/blood/CHANGELOG.tsx
+++ b/src/analysis/retail/deathknight/blood/CHANGELOG.tsx
@@ -5,6 +5,8 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 4, 8), <><SpellLink spell={talents.DEATH_STRIKE_TALENT} /> casts while not tanking within the next 6 seconds now count as dumping RP.</>, emallson),
+  change(date(2023, 4, 8), <><SpellLink spell={talents.DEATH_STRIKE_TALENT} /> problems are now ordered by amount of damage taken.</>, emallson),
   change(date(2023, 4, 1), <>First stab at <SpellLink id={talents.DEATH_STRIKE_TALENT} /> guide section.</>, emallson),
   change(date(2022, 10, 21), 'Initial Dragonflight version', Tialyss),
   change(date(2022, 8, 21), 'Rewrote all modules to Typescript', Chizu),

--- a/src/analysis/retail/deathknight/blood/modules/spells/DeathStrike/DeathStrikeSection.tsx
+++ b/src/analysis/retail/deathknight/blood/modules/spells/DeathStrike/DeathStrikeSection.tsx
@@ -109,8 +109,19 @@ const DeathStrikeProblemDescription = ({ data }: { data: DeathStrikeProblem['dat
     <ActualCastDescription event={data.cast} omitTarget /> while at{' '}
     <strong>{Math.floor(data.runicPower / 10)}</strong>{' '}
     <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id} /> and{' '}
-    <strong>{formatPercentage(data.hitPoints / data.maxHitPoints, 0)}%</strong> Health. This left
-    you low on resources and vulnerable to upcoming damage.
+    <strong>{formatPercentage(data.hitPoints / data.maxHitPoints, 0)}%</strong> Health.{' '}
+    {data.followupDamageTaken ? (
+      <>
+        In the next few seconds, you took{' '}
+        <strong>
+          {formatNumber(data.followupDamageTaken + (data.followupAbsorbedDamage ?? 0))}
+        </strong>{' '}
+        damage that this <SpellLink spell={talents.DEATH_STRIKE_TALENT} /> could have helped
+        mitigate.
+      </>
+    ) : (
+      <>This left you low on resources and vulnerable to upcoming damage.</>
+    )}
   </div>
 );
 


### PR DESCRIPTION
### Description

Sorts Death Strike problems by the amount of damage taken after the hit, and counts death strikes that are cast while non-active tank as dumping RP even if you're not high RP to reduce false positives. 
