### PR TITLE
polyfill Array.prototype.at successfully

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -23,6 +23,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 4, 8), 'Improve support for older browsers', emallson),
   change(date(2023, 4, 2), 'Add Healthstone Checker for Classic WotLK.', jazminite),
   change(date(2023, 4, 1), 'Classic WotLK - Add phases to Ulduar bosses.', jazminite),
   change(date(2023, 4, 1), 'Remove unnecessary console log.', ToppleTheNun),

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,17 @@
 import { render } from 'react-dom';
 
-import 'core-js/actual/array/at';
+// @ts-expect-error types/core-js doesn't include the type for this i guess
+import at from 'core-js/actual/array/at';
 
 import 'interface/static/bootstrap/css/bootstrap.css';
 
 import Root from './Root';
+
+// we are intentionally polyfilling `at` here when missing because we use
+// it frequently and its addition to browsers is quite recent
+if (Array.prototype.at === undefined) {
+  // eslint-disable-next-line no-extend-native
+  Array.prototype.at = at;
+}
 
 render(<Root />, document.getElementById('app-mount'));


### PR DESCRIPTION
confirmed on Chrome 91, which lemme tell ya was a pain in the ass to track down

this should fix the .at errors that occur on many updated spec analyzers.