### PR TITLE
[Classic] Raid Buffs

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -23,6 +23,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 4, 2), 'Add Classic WotLK Raid Buffs to Fight Report page.', jazminite),
   change(date(2023, 4, 8), 'Improve support for older browsers', emallson),
   change(date(2023, 4, 2), 'Add Healthstone Checker for Classic WotLK.', jazminite),
   change(date(2023, 4, 1), 'Classic WotLK - Add phases to Ulduar bosses.', jazminite),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -23,7 +23,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
-  change(date(2023, 4, 2), 'Add Classic WotLK Raid Buffs to Fight Report page.', jazminite),
+  change(date(2023, 4, 15), 'Add Classic WotLK Raid Buffs to Fight Report page.', jazminite),
   change(date(2023, 4, 8), 'Improve support for older browsers', emallson),
   change(date(2023, 4, 2), 'Add Healthstone Checker for Classic WotLK.', jazminite),
   change(date(2023, 4, 1), 'Classic WotLK - Add phases to Ulduar bosses.', jazminite),

--- a/src/common/SPELLS/classic/druid.ts
+++ b/src/common/SPELLS/classic/druid.ts
@@ -381,6 +381,11 @@ const spells = spellIndexableList({
     name: 'Feral Charge - Cat',
     icon: 'spell_druid_feralchargecat',
   },
+  LEADER_OF_THE_PACK: {
+    id: 24932,
+    name: 'Leader of the Pack',
+    icon: 'spell_nature_unyeildingstamina',
+  },
   MANGLE_BEAR: {
     id: 48564,
     name: 'Mangle (Bear)',

--- a/src/common/SPELLS/classic/paladin.ts
+++ b/src/common/SPELLS/classic/paladin.ts
@@ -378,7 +378,6 @@ const spells = spellIndexableList({
     icon: 'classic_spell_holy_blessingofprotection',
     lowRanks: [48951, 27179, 20928, 20927, 20925],
   },
-
   // Retribution
   CRUSADER_STRIKE: {
     id: 35395,
@@ -394,6 +393,11 @@ const spells = spellIndexableList({
     id: 20066,
     name: 'Repentance',
     icon: 'spell_holy_prayerofhealing',
+  },
+  SANCTIFIED_RETRIBUTION: {
+    id: 31869,
+    name: 'Sanctified Retribution',
+    icon: 'spell_holy_mindvision',
   },
   SEAL_OF_COMMAND: {
     id: 20375,

--- a/src/common/SPELLS/classic/priest.ts
+++ b/src/common/SPELLS/classic/priest.ts
@@ -105,6 +105,11 @@ const spells = spellIndexableList({
     name: 'Shadow Protection',
     icon: 'spell_shadow_antishadow',
   },
+  DIVINE_HYMN: {
+    id: 64843,
+    name: 'Divine Hymn',
+    icon: 'spell_holy_divinehymn',
+  },
   DIVINE_SPIRIT: {
     id: 48073,
     name: 'Divine Spirit',

--- a/src/common/SPELLS/classic/rogue.ts
+++ b/src/common/SPELLS/classic/rogue.ts
@@ -190,6 +190,11 @@ const spells = spellIndexableList({
     name: 'Riposte',
     icon: 'ability_warrior_challange',
   },
+  SAVAGE_COMBAT: {
+    id: 58683,
+    name: 'Savage Combat',
+    icon: 'ability_creature_disease_03',
+  },
   // Subtlety
   GHOSTLY_STRIKE: {
     id: 14278,

--- a/src/common/SPELLS/classic/shaman.ts
+++ b/src/common/SPELLS/classic/shaman.ts
@@ -336,7 +336,6 @@ const spells = spellIndexableList({
     icon: 'spell_fire_totemofwrath',
     lowRanks: [57721, 57720, 30706],
   },
-
   // Enhancement
   FERAL_SPIRIT: {
     id: 51533,
@@ -358,7 +357,11 @@ const spells = spellIndexableList({
     name: 'Stormstrike',
     icon: 'ability_shaman_stormstrike',
   },
-
+  UNLEASHED_RAGE: {
+    id: 30809,
+    name: 'Unleashed Rage',
+    icon: 'spell_nature_unleashedrage',
+  },
   // Restoration
   CLEANSE_SPIRIT: {
     id: 51886,

--- a/src/common/SPELLS/classic/warlock.ts
+++ b/src/common/SPELLS/classic/warlock.ts
@@ -370,6 +370,11 @@ const spells = spellIndexableList({
     name: 'Demonic Empowerment',
     icon: 'ability_warlock_demonicempowerment',
   },
+  DEMONIC_PACT: {
+    id: 47240,
+    name: 'Demonic Pact',
+    icon: 'spell_shadow_demonicpact',
+  },
   FEL_DOMINATION: {
     id: 18708,
     name: 'Fel Domination',

--- a/src/interface/ReportRaidBuffList.tsx
+++ b/src/interface/ReportRaidBuffList.tsx
@@ -1,15 +1,21 @@
+// Shared
+import Report from 'parser/core/Report';
+import { wclGameVersionToExpansion } from 'game/VERSIONS';
+import { isRetailExpansion } from 'game/Expansion';
+import ReportRaidBuffListItem from './ReportRaidBuffListItem';
+import SPECS from 'game/SPECS';
+import getConfig from 'parser/getConfig';
+import { Class, CombatantInfoEvent } from 'parser/core/Events';
+import './ReportRaidBuffList.scss';
+// Retail
 import SPELLS from 'common/SPELLS';
 import { TALENTS_PRIEST, TALENTS_SHAMAN } from 'common/TALENTS';
-import SPECS from 'game/SPECS';
-import { Class, CombatantInfoEvent } from 'parser/core/Events';
-
-import './ReportRaidBuffList.scss';
-
-import ReportRaidBuffListItem from './ReportRaidBuffListItem';
 import { TALENTS_DEMON_HUNTER, TALENTS_MONK, TALENTS_DEATH_KNIGHT } from 'common/TALENTS';
+// Classic
+import CLASSIC_SPELLS from 'common/SPELLS/classic';
 
 // eslint-disable-next-line
-const AVAILABLE_RAID_BUFFS = new Map<number, Array<Class | object>>([
+const RETAIL_RAID_BUFFS = new Map<number, Array<Class | object>>([
   // Buffs
   //  Stamina
   [SPELLS.POWER_WORD_FORTITUDE.id, [Class.Priest]],
@@ -41,35 +47,112 @@ const AVAILABLE_RAID_BUFFS = new Map<number, Array<Class | object>>([
   [SPELLS.TRANQUILITY_CAST.id, [SPECS.RESTORATION_DRUID]],
 ]);
 
-const getCompositionBreakdown = (combatants: CombatantInfoEvent[]) => {
-  const results = new Map<number, number>();
-  AVAILABLE_RAID_BUFFS.forEach((providedBy, spellId) => {
-    results.set(spellId, 0);
-  });
-
-  return combatants.reduce((map, combatant) => {
-    const spec = SPECS[combatant.specID];
-    if (!spec) {
-      return map;
-    }
-    const className = spec.className as Class;
-
-    AVAILABLE_RAID_BUFFS.forEach((providedBy, spellId) => {
-      if (providedBy.includes(className) || providedBy.includes(spec)) {
-        map.set(spellId, map.get(spellId)! + 1);
-      }
-    });
-    return map;
-  }, results);
-};
+// eslint-disable-next-line
+const CLASSIC_RAID_BUFFS = new Map<number, Array<Class | object>>([
+  // BUFFS
+  // Stamina
+  [CLASSIC_SPELLS.PRAYER_OF_FORTITUDE.id, [Class.Priest]],
+  // Spirit
+  [CLASSIC_SPELLS.PRAYER_OF_SPIRIT.id, [Class.Priest]],
+  // Intellect
+  [CLASSIC_SPELLS.ARCANE_BRILLIANCE.id, [Class.Mage]],
+  // Stats
+  [CLASSIC_SPELLS.GIFT_OF_THE_WILD.id, [Class.Druid]],
+  // Stats %
+  [CLASSIC_SPELLS.GREATER_BLESSING_OF_KINGS.id, [Class.Paladin]],
+  // Attack Power
+  [CLASSIC_SPELLS.GREATER_BLESSING_OF_MIGHT.id, [Class.Paladin]],
+  // MP5
+  [CLASSIC_SPELLS.GREATER_BLESSING_OF_WISDOM.id, [Class.Paladin]],
+  // Melee Crit
+  [
+    CLASSIC_SPELLS.LEADER_OF_THE_PACK.id,
+    [SPECS.CLASSIC_DRUID_FERAL_COMBAT, SPECS.CLASSIC_DRUID_GUARDIAN],
+  ],
+  // Attack Power %
+  [CLASSIC_SPELLS.UNLEASHED_RAGE.id, [SPECS.CLASSIC_SHAMAN_ENHANCEMENT]],
+  // Strength & Agility
+  [CLASSIC_SPELLS.STRENGTH_OF_EARTH_TOTEM.id, [Class.Shaman]],
+  // Melee Haste
+  [CLASSIC_SPELLS.ICY_TALONS_BUFF.id, [SPECS.CLASSIC_DEATH_KNIGHT_FROST]],
+  // All Damage %
+  [CLASSIC_SPELLS.SANCTIFIED_RETRIBUTION.id, [SPECS.CLASSIC_PALADIN_RETRIBUTION]],
+  // Haste %
+  [CLASSIC_SPELLS.MOONKIN_FORM.id, [SPECS.CLASSIC_DRUID_BALANCE]],
+  // Lust
+  [CLASSIC_SPELLS.BLOODLUST.id, [Class.Shaman]],
+  // Spell Power
+  [CLASSIC_SPELLS.DEMONIC_PACT.id, [SPECS.CLASSIC_WARLOCK_DEMONOLOGY]],
+  // Spell Crit
+  [CLASSIC_SPELLS.MOONKIN_AURA.id, [SPECS.CLASSIC_DRUID_BALANCE]],
+  // Spell Haste
+  [CLASSIC_SPELLS.WRATH_OF_AIR_TOTEM.id, [Class.Shaman]],
+  // Replenishment
+  [CLASSIC_SPELLS.VAMPIRIC_TOUCH.id, [SPECS.CLASSIC_PRIEST_SHADOW]],
+  // Healing %
+  [CLASSIC_SPELLS.DIVINE_HYMN.id, [Class.Priest]],
+  // DEBUFFS
+  // Bleed Damage
+  [CLASSIC_SPELLS.MANGLE_CAT.id, [SPECS.CLASSIC_DRUID_FERAL_COMBAT]],
+  // Physical Damage
+  [CLASSIC_SPELLS.SAVAGE_COMBAT.id, [SPECS.CLASSIC_ROGUE_COMBAT, SPECS.CLASSIC_WARRIOR_ARMS]],
+  // Spell Crit Chance %
+  [
+    CLASSIC_SPELLS.SHADOW_MASTERY_DEBUFF.id,
+    [SPECS.CLASSIC_WARLOCK_DEMONOLOGY, SPECS.CLASSIC_WARLOCK_DESTRUCTION],
+  ],
+  // Spell Hit Chance %
+  [CLASSIC_SPELLS.FAERIE_FIRE.id, [SPECS.CLASSIC_DRUID_BALANCE]],
+  // Spell Damage
+  [CLASSIC_SPELLS.EBON_PLAGUE.id, [SPECS.CLASSIC_DEATH_KNIGHT_UNHOLY]],
+  // Armor Reduction
+  [CLASSIC_SPELLS.SUNDER_ARMOR.id, [Class.Warrior]],
+  // UTILITY
+  // Battle Res
+  [CLASSIC_SPELLS.REBIRTH.id, [Class.Druid]],
+  // Immune to Silence and Interrupts
+  [CLASSIC_SPELLS.AURA_MASTERY.id, [SPECS.CLASSIC_PALADIN_HOLY]],
+]);
 
 interface Props {
+  report: Report;
   combatants: CombatantInfoEvent[];
 }
 
-const ReportRaidBuffList = ({ combatants }: Props) => {
-  const buffs = getCompositionBreakdown(combatants);
+const ReportRaidBuffList = ({ report, combatants }: Props) => {
+  const isRetail = isRetailExpansion(wclGameVersionToExpansion(report.gameVersion));
+  const getCompositionBreakdown = (combatants: CombatantInfoEvent[]) => {
+    const results = new Map<number, number>();
 
+    const AVAILABLE_RAID_BUFFS = isRetail ? RETAIL_RAID_BUFFS : CLASSIC_RAID_BUFFS;
+
+    AVAILABLE_RAID_BUFFS.forEach((providedBy, spellId) => {
+      results.set(spellId, 0);
+    });
+
+    return combatants.reduce((map, combatant) => {
+      const config = getConfig(
+        wclGameVersionToExpansion(report.gameVersion),
+        combatant.specID,
+        combatant.player,
+        combatant,
+      );
+
+      if (!config) {
+        return map;
+      }
+      const className = config.spec.className as Class;
+
+      AVAILABLE_RAID_BUFFS.forEach((providedBy, spellId) => {
+        if (providedBy.includes(className) || providedBy.includes(config.spec)) {
+          map.set(spellId, map.get(spellId)! + 1);
+        }
+      });
+      return map;
+    }, results);
+  };
+
+  const buffs = getCompositionBreakdown(combatants);
   return (
     <div className="raidbuffs">
       <h1>Raid Buffs</h1>

--- a/src/interface/ReportRaidBuffList.tsx
+++ b/src/interface/ReportRaidBuffList.tsx
@@ -9,8 +9,13 @@ import { Class, CombatantInfoEvent } from 'parser/core/Events';
 import './ReportRaidBuffList.scss';
 // Retail
 import SPELLS from 'common/SPELLS';
-import { TALENTS_PRIEST, TALENTS_SHAMAN } from 'common/TALENTS';
-import { TALENTS_DEMON_HUNTER, TALENTS_MONK, TALENTS_DEATH_KNIGHT } from 'common/TALENTS';
+import {
+  TALENTS_PRIEST,
+  TALENTS_SHAMAN,
+  TALENTS_DEMON_HUNTER,
+  TALENTS_MONK,
+  TALENTS_DEATH_KNIGHT,
+} from 'common/TALENTS';
 // Classic
 import CLASSIC_SPELLS from 'common/SPELLS/classic';
 

--- a/src/interface/report/PlayerLoader.tsx
+++ b/src/interface/report/PlayerLoader.tsx
@@ -429,7 +429,7 @@ const PlayerLoader = ({ children }: Props) => {
             makeAnalyzerUrl(selectedReport, selectedFight.id, playerId, undefined, build)
           }
         />
-        <ReportRaidBuffList combatants={combatants} />
+        <ReportRaidBuffList report={selectedReport} combatants={combatants} />
       </div>
     );
   }


### PR DESCRIPTION
### Description

- Add Classic WotLK Raid Buffs to Fight Report pages.
- Add missing buff spell objects to appropriate classes.

### Motivation

Fight report pages were only displaying Retail Buffs.

### Testing

- Test report URL: `/report/VCJvq89BT1pdKRzL/4-Normal+Ignis+the+Furnace+Master+-+Kill+(2:16)`
- Screenshot(s):
![image](https://user-images.githubusercontent.com/65823478/232202413-920f0781-5b84-4cc1-9a1a-bc7f96c1c37e.png)
