### PR TITLE
Druid Feral - 10.0.7 + Guide Updates

### DIFF
--- a/src/analysis/retail/druid/feral/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/feral/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS/druid';
 
 export default [
+  change(date(2023, 4, 15), <>Update to indicate support for 10.0.7, and updates to cast evaluation logic in Guide view.</>, Sref),
   change(date(2023, 3, 14), <>Updated CP check logic to allow 4 CP finishers when not specced for Bloodtalons.</>, Sref),
   change(date(2023, 1, 25), <>Updated numbers for 10.0.5 changes.</>, Sref),
   change(date(2023, 1, 20), <>Fixed a bug where the Guide could crash when Berserk is pre-cast.</>, Sref),

--- a/src/analysis/retail/druid/feral/CONFIG.tsx
+++ b/src/analysis/retail/druid/feral/CONFIG.tsx
@@ -9,7 +9,7 @@ export default {
   contributors: [Sref],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.5',
+  patchCompatibility: '10.0.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/druid/feral/Guide.tsx
+++ b/src/analysis/retail/druid/feral/Guide.tsx
@@ -27,9 +27,10 @@ function ResourceUseSection({ modules, events, info }: GuideProps<typeof CombatL
       <SubSection title="Energy">
         <p>
           Your primary resource is Energy. Typically, ability use will be limited by energy, not
-          time. Avoid capping energy - lost energy regeneration is lost DPS. It will occasionally be
-          impossible to avoid capping energy - like while handling mechanics or during intermission
-          phases.
+          time. Avoid capping energy - lost energy regeneration is lost DPS. High-end gear combined
+          with more energy talents than in previous expansions causes it to be occasionally
+          impossible to avoid capping energy, particularly during cooldowns. During these periods,
+          it's important to send abilities as fast as possible to maximize DPS.
         </p>
         The chart below shows your energy over the course of the encounter. You spent{' '}
         <strong>{formatPercentage(modules.energyTracker.percentAtCap, 1)}%</strong> of the encounter
@@ -98,10 +99,10 @@ function CooldownSection({ modules, events, info }: GuideProps<typeof CombatLogP
   return (
     <Section title="Cooldowns">
       <p>
-        Feral's cooldowns are decently powerful but should not be held on to for long. In order to
-        maximize usages over the course of an encounter, you should aim to send the cooldown as soon
-        as it becomes available (as long as it can do damage on target). It is particularly
-        important to use <SpellLink id={SPELLS.TIGERS_FURY.id} /> as often as possible.
+        Feral's cooldowns are powerful and should not be held on to for long. In order to maximize
+        usages over the course of an encounter, you should aim to send the cooldown as soon as it
+        becomes available (as long as it can do damage on target). It is particularly important to
+        use <SpellLink id={SPELLS.TIGERS_FURY.id} /> as often as possible.
       </p>
       <CooldownGraphSubsection modules={modules} events={events} info={info} />
       <CooldownBreakdownSubsection modules={modules} events={events} info={info} />

--- a/src/analysis/retail/druid/feral/constants.ts
+++ b/src/analysis/retail/druid/feral/constants.ts
@@ -162,6 +162,9 @@ export const PROWL_RAKE_DAMAGE_BONUS = 0.6;
 /** Max time left on a DoT for us to not yell if snapshot is downgraded */
 export const SNAPSHOT_DOWNGRADE_BUFFER = 2000;
 
+/** Max time a DoT's duration can be clipped before we yell */
+export const CLIP_BUFFER = 2000;
+
 export const PANDEMIC_FRACTION = 0.3;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/analysis/retail/druid/feral/modules/spells/Berserk.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/Berserk.tsx
@@ -82,6 +82,8 @@ class Berserk extends Analyzer {
   hasBoth: boolean;
   /** If player has Convoke the Spirits talent */
   hasConvoke: boolean;
+  /** If player has Incarnation talent */
+  hasIncarn: boolean;
   /** Either Berserk or Incarnation depending on talent */
   cdSpell: Spell;
   /** The total raw amount the CD was reduced */
@@ -103,11 +105,10 @@ class Berserk extends Analyzer {
     this.hasFrenzy = this.selectedCombatant.hasTalent(TALENTS_DRUID.BERSERK_FRENZY_TALENT);
     this.hasBoth = this.hasHeartOfTheLion && this.hasFrenzy;
     this.hasConvoke = this.selectedCombatant.hasTalent(TALENTS_DRUID.CONVOKE_THE_SPIRITS_TALENT);
-    this.hardcastDuration = this.selectedCombatant.hasTalent(
+    this.hasIncarn = this.selectedCombatant.hasTalent(
       TALENTS_DRUID.INCARNATION_AVATAR_OF_ASHAMANE_TALENT,
-    )
-      ? INCARN_HARDCAST_DURATION
-      : BERSERK_HARDCAST_DURATION;
+    );
+    this.hardcastDuration = this.hasIncarn ? INCARN_HARDCAST_DURATION : BERSERK_HARDCAST_DURATION;
     this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.BERSERK_TALENT);
 
     this.cdSpell = cdSpell(this.selectedCombatant);
@@ -193,8 +194,14 @@ class Berserk extends Analyzer {
         </strong>{' '}
         is our primary damage cooldown. It's best used as soon as it's available, but can be held to
         ensure you'll have full target uptime during its duration (don't use it when it will be
-        interrupted by a fight mechanic). Aim to cast at high energy, but spend fast enough to never
-        cap.
+        interrupted by a fight mechanic).{' '}
+        {this.hasIncarn && (
+          <>
+            With <SpellLink id={TALENTS_DRUID.INCARNATION_AVATAR_OF_ASHAMANE_TALENT} />, it's likely
+            you will be generating energy faster than you can spend it, so energy capping may be
+            unavoidable - just make sure you're using every GCD.
+          </>
+        )}
       </p>
     );
 
@@ -207,26 +214,8 @@ class Berserk extends Analyzer {
           const cdEnd = Math.min(this.owner.fight.end_time, cast.timestamp + this.hardcastDuration);
           const segmentEnergy = this.energyTracker.generateSegmentData(cast.timestamp, cdEnd);
           const percentAtCap = segmentEnergy.percentAtCap;
-          const energyPercentOnCast = cast.energyOnCast / this.energyTracker.maxResource;
-
           const percentAtCapPerf =
-            percentAtCap > 0.1
-              ? QualitativePerformance.Fail
-              : percentAtCap > 0
-              ? QualitativePerformance.Ok
-              : QualitativePerformance.Good;
-          const energyPercentOnCastPerf =
-            energyPercentOnCast > 0.5
-              ? QualitativePerformance.Good
-              : energyPercentOnCast > 0.25
-              ? QualitativePerformance.Ok
-              : QualitativePerformance.Fail;
-
-          const overallPerf =
-            percentAtCapPerf === QualitativePerformance.Fail ||
-            energyPercentOnCastPerf === QualitativePerformance.Fail
-              ? QualitativePerformance.Fail
-              : QualitativePerformance.Good;
+            percentAtCap > 0.1 ? QualitativePerformance.Ok : QualitativePerformance.Good;
 
           const header = (
             <>
@@ -236,11 +225,6 @@ class Berserk extends Analyzer {
           );
 
           const checklistItems: CooldownExpandableItem[] = [];
-          checklistItems.push({
-            label: <>Pool Energy for cast</>,
-            result: <PerformanceMark perf={energyPercentOnCastPerf} />,
-            details: <>({cast.energyOnCast} Energy)</>,
-          });
           checklistItems.push({
             label: <>Don't cap on energy</>,
             result: <PerformanceMark perf={percentAtCapPerf} />,
@@ -256,8 +240,7 @@ class Berserk extends Analyzer {
                     content={
                       <>
                         Berserking without Convoke is fine, but it's optimal to wait a few seconds
-                        if it will mean you can line them up. Awaiting sims to determine exactly how
-                        long.
+                        if it will mean you can line them up.
                       </>
                     }
                   >
@@ -274,7 +257,7 @@ class Berserk extends Analyzer {
             <CooldownExpandable
               header={header}
               checklistItems={checklistItems}
-              perf={overallPerf}
+              perf={percentAtCapPerf}
               key={ix}
             />
           );
@@ -285,7 +268,6 @@ class Berserk extends Analyzer {
     return explanationAndDataSubsection(explanation, data);
   }
 
-  // TODO probably want to update this display, but talents might change more in DF beta so gonna wait
   statistic() {
     return (
       <Statistic

--- a/src/analysis/retail/druid/feral/modules/spells/FerociousBite.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/FerociousBite.tsx
@@ -19,6 +19,7 @@ import {
 } from 'analysis/retail/druid/feral/constants';
 import getResourceSpent from 'parser/core/getResourceSpent';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { BadColor, OkColor } from 'interface/guide';
 
 const MIN_ACCEPTABLE_TIME_LEFT_ON_RIP_MS = 5000;
 
@@ -85,17 +86,36 @@ class FerociousBite extends Analyzer {
     const acceptableTimeLeftOnRip = timeLeftOnRip >= MIN_ACCEPTABLE_TIME_LEFT_ON_RIP_MS;
 
     let value: QualitativePerformance = QualitativePerformance.Good;
+    let perfExplanation: React.ReactNode = undefined;
     if (cpsUsed < getAcceptableCps(this.selectedCombatant)) {
       value = QualitativePerformance.Fail;
+      perfExplanation = (
+        <h5 style={{ color: BadColor }}>
+          Bad because you used less than {getAcceptableCps(this.selectedCombatant)} CPs
+          <br />
+        </h5>
+      );
     } else if (!usedMax && !duringBerserkAndSotf) {
       value = QualitativePerformance.Fail;
+      perfExplanation = (
+        <h5 style={{ color: BadColor }}>
+          Bad because you cast at too low energy
+          <br />
+        </h5>
+      );
     } else if (!acceptableTimeLeftOnRip) {
       value = QualitativePerformance.Ok;
+      perfExplanation = (
+        <h5 style={{ color: OkColor }}>
+          Questionable because you cast when Rip was close to expiring
+          <br />
+        </h5>
+      );
     }
 
     const tooltip = (
       <>
-        @ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong> targetting{' '}
+        {perfExplanation}@ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong> targetting{' '}
         <strong>{this.owner.getTargetName(event)}</strong> using <strong>{cpsUsed} CPs</strong>
         <br />
         Extra energy used:{' '}

--- a/src/analysis/retail/druid/feral/modules/spells/RakeUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/RakeUptimeAndSnapshots.tsx
@@ -90,7 +90,7 @@ class RakeUptimeAndSnapshots extends Snapshots {
           value = QualitativePerformance.Ok;
           perfExplanation = (
             <h5 style={{ color: OkColor }}>
-              You refreshed this too way early, but upgraded the snapshot
+              You refreshed this too early, but upgraded the snapshot
               <br />
             </h5>
           );

--- a/src/analysis/retail/druid/feral/modules/spells/RipUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/RipUptimeAndSnapshots.tsx
@@ -106,7 +106,7 @@ class RipUptimeAndSnapshots extends Snapshots {
         value = QualitativePerformance.Fail;
         perfExplanation = (
           <h5 style={{ color: BadColor }}>
-            Bad because you used less than {getAcceptableCps(this.selectedCombatant)} CPs!
+            Bad because you used less than {getAcceptableCps(this.selectedCombatant)} CPs
             <br />
           </h5>
         );
@@ -114,7 +114,7 @@ class RipUptimeAndSnapshots extends Snapshots {
         value = QualitativePerformance.Fail;
         perfExplanation = (
           <h5 style={{ color: BadColor }}>
-            Bad because no Bloodtalons snapshot!
+            Bad because no Bloodtalons snapshot
             <br />
           </h5>
         );
@@ -123,7 +123,7 @@ class RipUptimeAndSnapshots extends Snapshots {
           value = QualitativePerformance.Ok;
           perfExplanation = (
             <h5 style={{ color: OkColor }}>
-              You upgraded the snapshot at the cost of refreshing early.
+              You upgraded the snapshot at the cost of refreshing early
               <br />
             </h5>
           );
@@ -131,7 +131,7 @@ class RipUptimeAndSnapshots extends Snapshots {
           value = QualitativePerformance.Fail;
           perfExplanation = (
             <h5 style={{ color: BadColor }}>
-              Bad because you refreshed too early!
+              Bad because you refreshed too early
               <br />
             </h5>
           );
@@ -140,7 +140,7 @@ class RipUptimeAndSnapshots extends Snapshots {
         value = QualitativePerformance.Ok;
         perfExplanation = (
           <h5 style={{ color: OkColor }}>
-            Careful, you refreshed this a little early!
+            Careful, you refreshed this a little early
             <br />
           </h5>
         );
@@ -148,7 +148,7 @@ class RipUptimeAndSnapshots extends Snapshots {
         value = QualitativePerformance.Ok;
         perfExplanation = (
           <h5 style={{ color: BadColor }}>
-            Questionable because no Tiger's Fury snapshot!
+            Bad because no Tiger's Fury snapshot
             <br />
           </h5>
         );


### PR DESCRIPTION
### Description

Marks Feral Druid analyzer as updated for 10.0.7 and also updates some out of date evaluations in the Guide:
* Update Incarn guidance to show that energy capping is often unavoidable, and to be less harsh when player caps
* Update 'per cast box' elements in the Guide to show in the tooltip why a cast was rated 'ok' or 'bad'.
* Update Rake / Rip refresh evaluation to be less harsh when a very small amount is clipped.

### Testing

- Test report URL: `/reports/tqnrDQ4PpkfzbvGL#fight=14&type=damage-done&source=81`
- Screenshot(s): 
![refresh_early_tooltip](https://user-images.githubusercontent.com/7143486/232222102-34f306ae-802c-4fab-a525-47987f617b5a.png)
