### PR TITLE
Port the Shuffle chart to the core Guide code

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -23,6 +23,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 4, 16), 'Ported Shuffle chart to core code so other tank specs can use it.', emallson),
   change(date(2023, 4, 8), 'Improve support for older browsers', emallson),
   change(date(2023, 4, 2), 'Add Healthstone Checker for Classic WotLK.', jazminite),
   change(date(2023, 4, 1), 'Classic WotLK - Add phases to Ulduar bosses.', jazminite),

--- a/src/analysis/retail/monk/brewmaster/Guide.tsx
+++ b/src/analysis/retail/monk/brewmaster/Guide.tsx
@@ -1,6 +1,6 @@
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
-import ShuffleSection, { Highlight } from './modules/spells/Shuffle/GuideSection';
+import ShuffleSection from './modules/spells/Shuffle/GuideSection';
 import CastEfficiency from 'parser/shared/modules/CastEfficiency';
 import CombatLogParser from './CombatLogParser';
 import { GuideProps, Section, SubSection } from 'interface/guide';
@@ -16,6 +16,7 @@ import AplChoiceDescription from './modules/core/AplCheck/AplChoiceDescription';
 import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
 import { GapHighlight } from 'parser/ui/CooldownBar';
 import Explanation from 'interface/guide/components/Explanation';
+import { Highlight } from 'interface/Highlight';
 
 const explainers = {
   explainSCK,

--- a/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/components/AllCooldownUsagesList.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/components/AllCooldownUsagesList.tsx
@@ -18,12 +18,12 @@ import Explanation from 'interface/guide/components/Explanation';
 import ExplanationRow from 'interface/guide/components/ExplanationRow';
 import PassFailBar from 'interface/guide/components/PassFailBar';
 import { PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+import { Highlight } from 'interface/Highlight';
 import { AbilityEvent, HasAbility, HasSource } from 'parser/core/Events';
 import CastEfficiency from 'parser/shared/modules/CastEfficiency';
 import { encodeTargetString } from 'parser/shared/modules/Enemies';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { useCallback, useState } from 'react';
-import { Highlight } from '../../../spells/Shuffle/GuideSection';
 import { MAJOR_ANALYZERS } from '../config';
 import {
   MajorDefensive,

--- a/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/components/AllCooldownUsagesList.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/components/AllCooldownUsagesList.tsx
@@ -10,6 +10,10 @@ import {
   useAnalyzer,
   useAnalyzers,
 } from 'interface/guide';
+import {
+  damageBreakdown,
+  DamageSourceLink,
+} from 'interface/guide/components/DamageTakenPointChart';
 import Explanation from 'interface/guide/components/Explanation';
 import ExplanationRow from 'interface/guide/components/ExplanationRow';
 import PassFailBar from 'interface/guide/components/PassFailBar';
@@ -19,7 +23,7 @@ import CastEfficiency from 'parser/shared/modules/CastEfficiency';
 import { encodeTargetString } from 'parser/shared/modules/Enemies';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { useCallback, useState } from 'react';
-import { damageBreakdown, DamageSourceLink, Highlight } from '../../../spells/Shuffle/GuideSection';
+import { Highlight } from '../../../spells/Shuffle/GuideSection';
 import { MAJOR_ANALYZERS } from '../config';
 import {
   MajorDefensive,

--- a/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/index.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/index.tsx
@@ -1,7 +1,7 @@
 import { TooltipElement } from 'interface';
 import { GoodColor, Section, SubSection } from 'interface/guide';
 import Explanation from 'interface/guide/components/Explanation';
-import { Highlight } from '../../spells/Shuffle/GuideSection';
+import { Highlight } from 'interface/Highlight';
 import AllCooldownUsagesList from './components/AllCooldownUsagesList';
 import Timeline from './components/Timeline';
 

--- a/src/analysis/retail/monk/brewmaster/modules/spells/Shuffle/GuideSection.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/spells/Shuffle/GuideSection.tsx
@@ -1,8 +1,7 @@
-import styled from '@emotion/styled';
 import colorForPerformance from 'common/colorForPerformance';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
-import { SubSection, useAnalyzer, useInfo } from 'interface/guide';
+import { BadColor, SubSection, useAnalyzer, useInfo } from 'interface/guide';
 import { Info } from 'parser/core/metric';
 import uptimeBarSubStatistic from 'parser/ui/UptimeBarSubStatistic';
 import Shuffle from './index';
@@ -14,14 +13,7 @@ import { MAGIC_STAGGER_EFFECTIVENESS } from '../../../constants';
 import DamageTakenPointChart, {
   TrackedHit,
 } from 'interface/guide/components/DamageTakenPointChart';
-
-export const Highlight = styled.span<{ color: string; textColor?: string }>`
-  background-color: ${(props) => props.color};
-  padding: 0 3px;
-  ${(props) => (props.textColor ? `color: ${props.textColor};` : '')}
-`;
-
-const red = colorForPerformance(0);
+import { Highlight } from 'interface/Highlight';
 
 function HitTooltipContent({ hit }: { hit: TrackedHit }) {
   const info = useInfo()!;
@@ -75,7 +67,7 @@ function ShuffleOverview({ shuffle, info }: { shuffle: Shuffle; info: Info }): J
       <strong>Damage Taken</strong>{' '}
       <small>
         - Hits without Shuffle are shown in{' '}
-        <Highlight color={red} textColor="white">
+        <Highlight color={BadColor} textColor="white">
           red
         </Highlight>
         .
@@ -103,7 +95,7 @@ export default function ShuffleSection(): JSX.Element {
             This chart shows your <SpellLink id={SPELLS.SHUFFLE} /> uptime along with the damage
             that you took. <strong>You do not need 100% uptime!</strong> However, damage taken
             without <SpellLink id={SPELLS.SHUFFLE} /> active (shown in{' '}
-            <Highlight color={red}>red</Highlight>) is very dangerous!
+            <Highlight color={BadColor}>red</Highlight>) is very dangerous!
           </p>
         </Explanation>
         <ShuffleOverview info={info} shuffle={shuffle} />

--- a/src/analysis/retail/monk/brewmaster/modules/spells/Shuffle/index.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/spells/Shuffle/index.tsx
@@ -1,17 +1,13 @@
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
+import { TrackedHit } from 'interface/guide/components/DamageTakenPointChart';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { ApplyBuffEvent, DamageEvent, RemoveBuffEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import Enemies from 'parser/shared/modules/Enemies';
 import { shouldIgnore } from 'parser/shared/modules/hit-tracking/utilities';
 import { Uptime } from 'parser/ui/UptimeBar';
-
-export type TrackedHit = {
-  mitigated: boolean;
-  event: DamageEvent;
-};
 
 export default class Shuffle extends Analyzer {
   static dependencies = {
@@ -70,7 +66,7 @@ export default class Shuffle extends Analyzer {
 
   private finalize() {
     const uptime = this.uptime[this.uptime.length - 1];
-    if (!uptime) {
+    if (!uptime || uptime.end !== uptime.start) {
       return;
     }
 

--- a/src/interface/Highlight.tsx
+++ b/src/interface/Highlight.tsx
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled';
+
+/**
+ * An inline text highlight. Like using the highlight functionality in Word or Docs.
+ *
+ * Or like using a highlighter, I guess.
+ */
+export const Highlight = styled.span<{ color: string; textColor?: string }>`
+  background-color: ${(props) => props.color};
+  padding: 0 3px;
+  ${(props) => (props.textColor ? `color: ${props.textColor};` : '')}
+`;

--- a/src/interface/guide/components/DamageTakenPointChart.tsx
+++ b/src/interface/guide/components/DamageTakenPointChart.tsx
@@ -1,0 +1,218 @@
+/**
+ * This component implements the damage taken "point" chart. The points are boxes,
+ * but it has more in common with a point type than a "boxplot", so it is named a
+ * point chart to avoid confusion on that front.
+ *
+ * To use this in your guide, collect an array of `TrackedHit`s in one of your analyzers,
+ * then pass it here.
+ * @module
+ */
+import { useMemo } from 'react';
+import styled from '@emotion/styled';
+import colorForPerformance from 'common/colorForPerformance';
+import * as MAGIC_SCHOOLS from 'game/MAGIC_SCHOOLS';
+import SpellLink from 'interface/SpellLink';
+import Tooltip from 'interface/Tooltip';
+import useTooltip from 'interface/useTooltip';
+import { AbilityEvent, DamageEvent, SourcedEvent } from 'parser/core/Events';
+import Enemies, { encodeTargetString } from 'parser/shared/modules/Enemies';
+import { useAnalyzer, useInfo } from '../index';
+
+export type TrackedHit = {
+  mitigated: boolean;
+  event: DamageEvent;
+};
+
+/**
+ * Calculate the damage breakdown by source for the set of data `T`.
+ *
+ * The result is a map from `spellId -> sourceKey -> T`.
+ *
+ * This is used by the chart with preset values for `TrackedHit`, but
+ * may be used elsewhere as well.
+ */
+export function damageBreakdown<T>(
+  data: T[],
+  selectSpellId: (datum: T) => number,
+  selectSource: (datum: T) => string,
+): Map<number, Map<string, T[]>> {
+  const bySpell = new Map();
+  for (const datum of data) {
+    const ability = selectSpellId(datum);
+    let bySource = bySpell.get(ability);
+    if (!bySource) {
+      bySource = new Map();
+      bySpell.set(ability, bySource);
+    }
+
+    const source = selectSource(datum);
+    let hits = bySource.get(source);
+    if (!hits) {
+      hits = [];
+      bySource.set(source, hits);
+    }
+
+    hits.push(datum);
+  }
+
+  return bySpell;
+}
+
+export type DamageTakenPointChartProps = {
+  hits: TrackedHit[];
+  tooltip: React.FC<{ hit: TrackedHit }>;
+};
+
+type Props = DamageTakenPointChartProps;
+
+const HitTimelineContainer = styled.div`
+  display: grid;
+  grid-template-columns: calc(150px - 1rem) 1fr;
+  gap: 1rem;
+  height: 20px;
+  padding: 0 10px;
+  margin: 5px 0;
+
+  & > :first-child {
+    justify-self: start;
+    align-self: start;
+    padding-left: 1rem;
+  }
+`;
+
+const HitTimelineBar = styled.div`
+  position: relative;
+  width: 100%;
+  height: 20px;
+`;
+
+const HitTimelineSlice = styled.div<{
+  color: string;
+  widthPct: number;
+}>`
+  width: max(1px, ${(props) => props.widthPct * 100}%);
+  background-color: ${(props) => props.color};
+  height: 100%;
+  position: absolute;
+  top: 0;
+  border: 1px solid black;
+  box-sizing: content-box;
+`;
+
+const damageSourceStyle: React.CSSProperties = {
+  overflowX: 'hidden',
+  textOverflow: 'ellipsis',
+  maxWidth: '100%',
+  whiteSpace: 'nowrap',
+};
+
+/**
+ * A `SpellLink` wrapper that knows how to include the source name.
+ *
+ * Only works within the `Guide` context current, as it relies on
+ * `useAnalyzer` and needs the `Enemies` analyzer to be present.
+ */
+export function DamageSourceLink({
+  event,
+  showSourceName,
+}: {
+  event: AbilityEvent<any> & Partial<SourcedEvent<any>>;
+  showSourceName?: boolean;
+}): JSX.Element | null {
+  const enemies = useAnalyzer(Enemies);
+
+  const ability = event.ability;
+  const color = MAGIC_SCHOOLS.color(ability.type);
+
+  // this prevents unneeded re-renders of child components due to object identity differences
+  const style = useMemo(() => ({ ...damageSourceStyle, color }), [color]);
+  const { npc: npcTooltip } = useTooltip();
+
+  if (showSourceName) {
+    const enemy = enemies?.getSourceEntity(event);
+    return (
+      <a href={npcTooltip(enemy?.guid ?? 0)} style={style}>
+        {enemy?.name ?? 'Unknown'} ({ability.name})
+      </a>
+    );
+  } else {
+    return (
+      <SpellLink spell={ability.guid} style={style}>
+        {ability.name}
+      </SpellLink>
+    );
+  }
+}
+
+function HitTimeline({
+  hits,
+  showSourceName,
+  tooltip: TooltipContent,
+}: Props & { showSourceName?: boolean }) {
+  const info = useInfo()!;
+  const enemies = useAnalyzer(Enemies);
+
+  if (!enemies || hits.length === 0) {
+    return null;
+  }
+  const blockWidth = 1 / 120;
+
+  return (
+    <HitTimelineContainer>
+      <DamageSourceLink showSourceName={showSourceName} event={hits[0].event} />
+      <HitTimelineBar>
+        {hits.map((hit, ix) => {
+          return (
+            <Tooltip hoverable content={<TooltipContent hit={hit} />} key={ix} direction="up">
+              <HitTimelineSlice
+                color={colorForPerformance(Number(hit.mitigated))}
+                widthPct={blockWidth}
+                style={{
+                  left: `${((hit.event.timestamp - info.fightStart) / info.fightDuration) * 100}%`,
+                }}
+              />
+            </Tooltip>
+          );
+        })}
+      </HitTimelineBar>
+    </HitTimelineContainer>
+  );
+}
+
+/**
+ * Damage Taken chart shown as a single point for each hit. See the Brewmaster Shuffle section
+ * for an example of what this looks like.
+ *
+ * This chart must be rendered within a `Guide` context and have the `Enemies` core analyzer
+ * present. If you haven't explicitly removed `Enemies` from your analyzer (which you probably
+ * haven't and shouldn't!) then it should Just Work:tm:.
+ *
+ * Note that the `tooltip` component is *required* and that this is intentional.
+ */
+export default function DamageTakenPointChart({ hits, tooltip }: Props): JSX.Element {
+  const hitsBySpellRaw = damageBreakdown(
+    hits,
+    (hit: TrackedHit) => hit.event.ability.guid,
+    (hit: TrackedHit) => encodeTargetString(hit.event.sourceID ?? 0),
+  );
+
+  const meleesBySource = hitsBySpellRaw.get(1) ?? new Map();
+
+  return (
+    <div>
+      {Array.from(meleesBySource.entries()).map(([id, hits]) => (
+        <HitTimeline
+          hits={hits}
+          key={id}
+          showSourceName={meleesBySource.size > 1}
+          tooltip={tooltip}
+        />
+      ))}
+      {Array.from(hitsBySpellRaw.entries())
+        .filter(([id]) => id !== 1)
+        .map(([id, hits]) => (
+          <HitTimeline hits={Array.from(hits.values()).flat()} key={id} tooltip={tooltip} />
+        ))}
+    </div>
+  );
+}

--- a/src/parser/core/SpellUsage/SpellUsageSubSection.tsx
+++ b/src/parser/core/SpellUsage/SpellUsageSubSection.tsx
@@ -1,6 +1,5 @@
 import { BadColor, OkColor, PerformanceMark, SubSection, useInfo } from 'interface/guide';
 import styled from '@emotion/styled';
-import { Highlight } from 'analysis/retail/monk/brewmaster/modules/spells/Shuffle/GuideSection';
 import {
   ComponentPropsWithoutRef,
   Fragment,
@@ -18,6 +17,7 @@ import { SpellUse, useSpellUsageContext } from './core';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { formatDuration } from 'common/format';
+import { Highlight } from 'interface/Highlight';
 
 const NoData = styled.div`
   color: #999;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4909458/232321619-497abf8e-34c1-485f-aef5-9cf12dd54204.png)


### Description

This moves the "box chart" part of the Shuffle section to core Guide code and makes it generic so that it is easier to use for other contributors.

### Motivation

@kfinch was asking about it, some interest from other authors too.