### PR TITLE
tier 30 support for holy priest

### DIFF
--- a/src/analysis/retail/priest/holy/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/holy/CHANGELOG.tsx
@@ -5,6 +5,11 @@ import { SpellLink } from 'interface';
 
 export default [
   change(
+    date(2023, 4, 20),
+    <>Add support for Aberrus, the Shadowed Crucible tier set.</>,
+    Squided
+  ),
+  change(
     date(2023, 3, 27),
     <>Fix bugs in <SpellLink id={TALENTS_PRIEST.DIVINE_IMAGE_TALENT.id}/> and <SpellLink id={TALENTS_PRIEST.ENLIGHTENMENT_TALENT.id}/>t modules.</>,
     Squided

--- a/src/analysis/retail/priest/holy/CombatLogParser.tsx
+++ b/src/analysis/retail/priest/holy/CombatLogParser.tsx
@@ -34,8 +34,9 @@ import PrayerOfMending from './modules/spells/PrayerOfMending';
 import Renew from './modules/spells/Renew';
 import SpiritOfRedemption from './modules/spells/SpiritOfRedemption';
 import Talents from './modules/talents';
-import TwoSet from './modules/dragonflight/tier/Tier29HolyPriest2Set';
-import FourSet from './modules/dragonflight/tier/Tier29HolyPriest4Set';
+import T29TwoSet from './modules/dragonflight/tier/tier29/Tier29HolyPriest2Set';
+import T29FourSet from './modules/dragonflight/tier/tier29/Tier29HolyPriest4Set';
+import T30FourSet from './modules/dragonflight/tier/tier30/Tier30HolyPriest4Set';
 import ProtectiveLight from '../shared/ProtectiveLight';
 import PrayerOfHealing from './modules/spells/PrayerOfHealing';
 import CastLinkNormalizer from './normalizers/CastLinkNormalizer';
@@ -86,8 +87,9 @@ class CombatLogParser extends CoreCombatLogParser {
     renew: Renew,
     prayerOfMending: PrayerOfMending,
 
-    TwoSet: TwoSet,
-    FourSet: FourSet,
+    T29TwoSet: T29TwoSet,
+    T29FourSet: T29FourSet,
+    T30FourSet: T30FourSet,
     // Talents
     Enlightenment: Talents.MiddleRow.Enlightenment,
     TrailOfLight: Talents.MiddleRow.TrailOfLight,

--- a/src/analysis/retail/priest/holy/modules/dragonflight/tier/tier29/Tier29HolyPriest2Set.tsx
+++ b/src/analysis/retail/priest/holy/modules/dragonflight/tier/tier29/Tier29HolyPriest2Set.tsx
@@ -27,7 +27,7 @@ class HolyPriestTier2Set extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    if (this.selectedCombatant.has2PieceByTier(TIERS.T28)) {
+    if (!this.selectedCombatant.has2PieceByTier(TIERS.T29)) {
       this.active = false;
       return;
     }

--- a/src/analysis/retail/priest/holy/modules/dragonflight/tier/tier29/Tier29HolyPriest4Set.tsx
+++ b/src/analysis/retail/priest/holy/modules/dragonflight/tier/tier29/Tier29HolyPriest4Set.tsx
@@ -32,7 +32,7 @@ class HolyPriestTier4Set extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    if (this.selectedCombatant.has4PieceByTier(TIERS.T28)) {
+    if (!this.selectedCombatant.has4PieceByTier(TIERS.T29)) {
       this.active = false;
       return;
     }

--- a/src/analysis/retail/priest/holy/modules/dragonflight/tier/tier30/Tier30HolyPriest4Set.tsx
+++ b/src/analysis/retail/priest/holy/modules/dragonflight/tier/tier30/Tier30HolyPriest4Set.tsx
@@ -1,0 +1,147 @@
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/priest';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import Events, { CastEvent, HealEvent } from 'parser/core/Events';
+import {
+  calculateEffectiveHealing,
+  calculateOverhealing,
+  calculateEffectiveDamage,
+} from 'parser/core/EventCalculateLib';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import {
+  getSerenityHealEvent,
+  getChastiseDamageEvent,
+  getSalvationHealEvents,
+  getSanctifyHealEvents,
+} from 'analysis/retail/priest/holy/normalizers/CastLinkNormalizer';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import { formatNumber, formatPercentage } from 'common/format';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+
+const TIER_BONUS = 0.04;
+const FALL_BUFFER = 100;
+
+class HolyPriestAbberus4Set extends Analyzer {
+  healing = 0;
+  overhealing = 0;
+  damage = 0;
+  stacksOnCast: number[] = [];
+
+  constructor(options: Options) {
+    super(options);
+
+    // bonus set id for tier 30 logs not loading properly
+    // if (!this.selectedCombatant.has4PieceByTier(TIERS.T30)) {
+    //   this.active = false;
+    //   return;
+    // }
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell([TALENTS.HOLY_WORD_SERENITY_TALENT]),
+      this.onSerenityCast,
+    );
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell([TALENTS.HOLY_WORD_SANCTIFY_TALENT]),
+      this.onSanctifyCast,
+    );
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell([TALENTS.HOLY_WORD_SALVATION_TALENT]),
+      this.onSalvationCast,
+    );
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell([TALENTS.HOLY_WORD_CHASTISE_TALENT]),
+      this.onChastiseCast,
+    );
+  }
+
+  get tierStacks() {
+    return this.selectedCombatant.getBuffStacks(
+      SPELLS.HOLY_PRIEST_TIER_30_4_SET_BUFF.id,
+      null,
+      FALL_BUFFER,
+    );
+  }
+
+  onSerenityCast(event: CastEvent) {
+    const stacks = this.tierStacks;
+    console.log(stacks);
+    if (stacks > 0) {
+      this.stacksOnCast.push(stacks);
+      const healEvent = getSerenityHealEvent(event);
+      this.healing += calculateEffectiveHealing(healEvent, stacks * TIER_BONUS);
+      this.overhealing += calculateOverhealing(healEvent, stacks * TIER_BONUS);
+    }
+  }
+
+  onSanctifyCast(event: CastEvent) {
+    const stacks = this.tierStacks;
+    if (stacks > 0) {
+      this.stacksOnCast.push(stacks);
+      const healEvents = getSanctifyHealEvents(event);
+      healEvents.forEach((healEvent: HealEvent) => {
+        this.healing += calculateEffectiveHealing(healEvent, stacks * TIER_BONUS);
+        this.overhealing += calculateOverhealing(healEvent, stacks * TIER_BONUS);
+      });
+    }
+  }
+
+  onSalvationCast(event: CastEvent) {
+    const stacks = this.tierStacks;
+    if (stacks > 0) {
+      this.stacksOnCast.push(stacks);
+      const healEvents = getSalvationHealEvents(event);
+      console.log(healEvents);
+      healEvents.forEach((healEvent: HealEvent) => {
+        this.healing += calculateEffectiveHealing(healEvent, stacks * TIER_BONUS);
+        this.overhealing += calculateOverhealing(healEvent, stacks * TIER_BONUS);
+      });
+    }
+  }
+
+  onChastiseCast(event: CastEvent) {
+    const stacks = this.tierStacks;
+    if (stacks > 0) {
+      this.stacksOnCast.push(stacks);
+      const damageEvent = getChastiseDamageEvent(event);
+      this.damage += calculateEffectiveDamage(damageEvent, stacks * TIER_BONUS);
+    }
+  }
+
+  get averageTierStacks() {
+    return this.stacksOnCast.reduce((a, b) => a + b) / this.stacksOnCast.length;
+  }
+
+  statistic() {
+    // adding this check here as checking if tier is equipped is buggy atm
+    if (this.healing > 0 || this.overhealing > 0 || this.damage > 0) {
+      return (
+        <Statistic
+          size="flexible"
+          position={STATISTIC_ORDER.OPTIONAL(0)}
+          category={STATISTIC_CATEGORY.ITEMS}
+          tooltip={
+            <>
+              Average stacks on Holy Word cast: {formatNumber(this.averageTierStacks)}
+              <br />
+              Bonus Healing Done: {formatNumber(this.healing)} (
+              {formatPercentage(this.overhealing / (this.healing + this.overhealing))}% OH)
+            </>
+          }
+        >
+          <BoringSpellValueText spellId={SPELLS.HOLY_PRIEST_TIER_30_4_SET_BUFF.id}>
+            <ItemHealingDone amount={this.healing} />
+            {this.damage > 0 && <ItemDamageDone amount={this.damage} />}
+          </BoringSpellValueText>
+        </Statistic>
+      );
+    }
+  }
+}
+
+export default HolyPriestAbberus4Set;

--- a/src/analysis/retail/priest/holy/modules/dragonflight/tier/tier30/Tier30HolyPriest4Set.tsx
+++ b/src/analysis/retail/priest/holy/modules/dragonflight/tier/tier30/Tier30HolyPriest4Set.tsx
@@ -70,7 +70,6 @@ class HolyPriestAbberus4Set extends Analyzer {
 
   onSerenityCast(event: CastEvent) {
     const stacks = this.tierStacks;
-    console.log(stacks);
     if (stacks > 0) {
       this.stacksOnCast.push(stacks);
       const healEvent = getSerenityHealEvent(event);
@@ -96,7 +95,6 @@ class HolyPriestAbberus4Set extends Analyzer {
     if (stacks > 0) {
       this.stacksOnCast.push(stacks);
       const healEvents = getSalvationHealEvents(event);
-      console.log(healEvents);
       healEvents.forEach((healEvent: HealEvent) => {
         this.healing += calculateEffectiveHealing(healEvent, stacks * TIER_BONUS);
         this.overhealing += calculateOverhealing(healEvent, stacks * TIER_BONUS);

--- a/src/analysis/retail/priest/holy/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/priest/holy/normalizers/CastLinkNormalizer.ts
@@ -1,6 +1,7 @@
 import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
 import {
   CastEvent,
+  DamageEvent,
   EventType,
   GetRelatedEvents,
   HasRelatedEvent,
@@ -14,9 +15,13 @@ const CAST_BUFFER_MS = 100;
 
 export const FROM_HARDCAST = 'FromHardcast'; // for linking a heal to its cast
 export const LIGHTWEAVER_APPLY = 'LightweaverApplication'; // link flash heal cast to applying the lightweaver buff
-export const LIGHTWEAVER_CONSUME = 'LightweaverConumption'; // link heal cast to removing the lightweaver buff
+export const LIGHTWEAVER_CONSUME = 'LightweaverConsumption'; // link heal cast to removing the lightweaver buff
 export const POH_CAST = 'PrayerOfHealingCast';
 export const COH_CAST = 'CircleOfHealingCast';
+export const SERENITY_CAST = 'HolyWordSerenityCast';
+export const SANCTIFY_CAST = 'HolyWordSanctifyCast';
+export const SALVATION_CAST = 'HolyWordSalvationCast';
+export const CHASTISE_CAST = 'HolyWordChastiseCast';
 
 const EVENT_LINKS: EventLink[] = [
   // Link single target heal casts to their heal events.
@@ -69,6 +74,52 @@ const EVENT_LINKS: EventLink[] = [
       return c.hasTalent(TALENTS_PRIEST.LIGHTWEAVER_TALENT);
     },
   },
+  // Link Holy Word Serenity casts to heal event
+  {
+    linkRelation: SERENITY_CAST,
+    reverseLinkRelation: SERENITY_CAST,
+    linkingEventId: TALENTS_PRIEST.HOLY_WORD_SERENITY_TALENT.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: TALENTS_PRIEST.HOLY_WORD_SERENITY_TALENT.id,
+    referencedEventType: EventType.Heal,
+    forwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: CAST_BUFFER_MS,
+  },
+  // Link Holy Word Sanctify casts to heal events
+  {
+    linkRelation: SANCTIFY_CAST,
+    reverseLinkRelation: SANCTIFY_CAST,
+    linkingEventId: TALENTS_PRIEST.HOLY_WORD_SANCTIFY_TALENT.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: TALENTS_PRIEST.HOLY_WORD_SANCTIFY_TALENT.id,
+    referencedEventType: EventType.Heal,
+    forwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: CAST_BUFFER_MS,
+    anyTarget: true,
+  },
+  // Link Holy Word Salvation casts to heal events
+  {
+    linkRelation: SALVATION_CAST,
+    reverseLinkRelation: SALVATION_CAST,
+    linkingEventId: TALENTS_PRIEST.HOLY_WORD_SALVATION_TALENT.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: TALENTS_PRIEST.HOLY_WORD_SALVATION_TALENT.id,
+    referencedEventType: EventType.Heal,
+    forwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: CAST_BUFFER_MS,
+    anyTarget: true,
+  },
+  // Link Holy Word Chastise casts to damage events
+  {
+    linkRelation: CHASTISE_CAST,
+    reverseLinkRelation: CHASTISE_CAST,
+    linkingEventId: TALENTS_PRIEST.HOLY_WORD_CHASTISE_TALENT.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: TALENTS_PRIEST.HOLY_WORD_CHASTISE_TALENT.id,
+    referencedEventType: EventType.Damage,
+    forwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: CAST_BUFFER_MS,
+  },
 ];
 
 class CastLinkNormalizer extends EventLinkNormalizer {
@@ -89,6 +140,30 @@ export function getHeal(event: CastEvent): HealEvent | undefined {
   return GetRelatedEvents(event, FROM_HARDCAST)
     .filter((e): e is HealEvent => e.type === EventType.Heal)
     .pop();
+}
+
+export function getSerenityHealEvent(event: CastEvent): HealEvent {
+  return GetRelatedEvents(event, SERENITY_CAST).filter(
+    (e): e is HealEvent => e.type === EventType.Heal,
+  )[0];
+}
+
+export function getSanctifyHealEvents(event: CastEvent): HealEvent[] {
+  return GetRelatedEvents(event, SANCTIFY_CAST).filter(
+    (e): e is HealEvent => e.type === EventType.Heal,
+  );
+}
+
+export function getSalvationHealEvents(event: CastEvent): HealEvent[] {
+  return GetRelatedEvents(event, SALVATION_CAST).filter(
+    (e): e is HealEvent => e.type === EventType.Heal,
+  );
+}
+
+export function getChastiseDamageEvent(event: CastEvent): DamageEvent {
+  return GetRelatedEvents(event, CHASTISE_CAST).filter(
+    (e): e is DamageEvent => e.type === EventType.Damage,
+  )[0];
 }
 
 export function isCastBuffedByLightweaver(event: CastEvent) {

--- a/src/common/SPELLS/priest.ts
+++ b/src/common/SPELLS/priest.ts
@@ -517,6 +517,11 @@ const spells = spellIndexableList({
     name: 'Seize the moment',
     icon: 'inv_mace_1h_artifactheartofkure_d_03',
   },
+  HOLY_PRIEST_TIER_30_4_SET_BUFF: {
+    id: 409479,
+    name: 'Inspired Word',
+    icon: 'ability_paladin_sacredcleansing',
+  },
   // Talents
   BINDING_HEALS_TALENT_HEAL: {
     id: 368276,


### PR DESCRIPTION
### Description

Add support for the Tier 30 4 set for holy priest. I don't think it is possible to track 2 piece because of the way that PoM is logged to the combat log. It would not be clear if a PoM application is tied to 2 piece proc or is just from an existing PoM bouncing.

### Testing
Test report from PTR:
https://www.warcraftlogs.com/reports/AkdM1wpqKVTrLYFG#fight=17
<img width="377" alt="image" src="https://user-images.githubusercontent.com/6947753/233866494-3e765b37-c80a-41d1-80e5-5324e28929a1.png">

