### PR TITLE
add M+ dungeon pull filter

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -23,6 +23,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 4, 24), 'Add ability to filter M+ analysis by dungeon pulls.', ToppleTheNun),
   change(date(2023, 4, 24), 'Additions and updates for Classic Potions (guide and checklist).', jazminite),
   change(date(2023, 4, 20), 'Add M+ season 2 images.', ToppleTheNun),
   change(date(2023, 4, 19), 'Add Aberrus raid images.', ToppleTheNun),

--- a/src/interface/report/Results/DungeonPullSelector.tsx
+++ b/src/interface/report/Results/DungeonPullSelector.tsx
@@ -1,0 +1,62 @@
+import Fight from 'parser/core/Fight';
+import { ChangeEventHandler } from 'react';
+import { SELECTION_ALL_PHASES, SELECTION_CUSTOM_PHASE } from 'interface/report/hooks/usePhases';
+import { formatDuration } from 'common/format';
+
+interface DungeonPullSelectorProps {
+  fight: Fight;
+  selectedPull: string;
+  handlePullSelection: (pull: string) => void;
+  isLoading: boolean;
+}
+
+const DungeonPullSelector = ({
+  fight,
+  handlePullSelection,
+  isLoading,
+  selectedPull,
+}: DungeonPullSelectorProps) => {
+  const dungeonPulls = fight.dungeonPulls ?? [];
+
+  const handleChange: ChangeEventHandler<HTMLSelectElement> = (event) => {
+    const pullById = dungeonPulls.find((pull) => String(pull.id) === event.target.value);
+    if (pullById) {
+      handlePullSelection(String(pullById.id));
+    } else {
+      handlePullSelection(SELECTION_ALL_PHASES);
+    }
+  };
+
+  let currentValue: string;
+  if (fight.filtered && !fight.phase) {
+    currentValue = SELECTION_CUSTOM_PHASE;
+  } else if (selectedPull === SELECTION_ALL_PHASES) {
+    currentValue = SELECTION_ALL_PHASES;
+  } else {
+    currentValue = selectedPull;
+  }
+
+  return (
+    <select
+      className="form-control phase"
+      disabled={isLoading}
+      onChange={handleChange}
+      value={currentValue}
+    >
+      {fight.filtered && !fight.phase && (
+        <option key={SELECTION_CUSTOM_PHASE} value={SELECTION_CUSTOM_PHASE}>
+          Custom
+        </option>
+      )}
+      <option key={SELECTION_ALL_PHASES} value={SELECTION_ALL_PHASES}>
+        All Pulls
+      </option>
+      {dungeonPulls.map((pull) => (
+        <option key={pull.id} value={`${pull.id}`}>
+          {pull.name} ({formatDuration(pull.start_time - fight.start_time)})
+        </option>
+      ))}
+    </select>
+  );
+};
+export default DungeonPullSelector;

--- a/src/interface/report/Results/Header.tsx
+++ b/src/interface/report/Results/Header.tsx
@@ -14,6 +14,7 @@ import HeaderBackground from './HeaderBackground';
 import NavigationBar from './NavigationBar';
 import PhaseSelector from './PhaseSelector';
 import TimeFilter from './TimeFilter';
+import DungeonPullSelector from './DungeonPullSelector';
 
 import './Header.scss';
 
@@ -22,12 +23,14 @@ interface Props {
   player: PlayerInfo;
   characterProfile: CharacterProfile;
   boss: Boss | null;
+  handleDungeonPullSelection: (dungeonPull: string) => void;
   handlePhaseSelection: (phase: string, instance: number) => void;
   applyFilter: (start: number, end: number) => void;
   phases: { [key: string]: Phase } | null;
   build?: string;
   selectedPhase: string;
   selectedInstance: number;
+  selectedDungeonPull: string;
   isLoading: boolean;
   fight: Fight;
   makeTabUrl: (tab: string, build?: string) => string;
@@ -44,6 +47,8 @@ const Header = ({
   handlePhaseSelection,
   selectedPhase,
   selectedInstance,
+  selectedDungeonPull,
+  handleDungeonPullSelection,
   phases,
   isLoading,
   applyFilter,
@@ -74,6 +79,16 @@ const Header = ({
               handlePhaseSelection={handlePhaseSelection}
               selectedPhase={selectedPhase}
               selectedInstance={selectedInstance}
+              isLoading={isLoading}
+            />
+          </div>
+        )}
+        {fight.dungeonPulls && fight.dungeonPulls.length > 0 && (
+          <div className="phaseselector">
+            <DungeonPullSelector
+              fight={fight}
+              selectedPull={selectedDungeonPull}
+              handlePullSelection={handleDungeonPullSelection}
               isLoading={isLoading}
             />
           </div>

--- a/src/interface/report/Results/index.tsx
+++ b/src/interface/report/Results/index.tsx
@@ -46,6 +46,8 @@ interface PassedProps {
   selectedPhase: string;
   selectedInstance: number;
   handlePhaseSelection: (phase: string, instance: number) => void;
+  selectedDungeonPull: string;
+  handleDungeonPullSelection: (pull: string) => void;
   applyFilter: (start: number, end: number) => void;
   timeFilter?: Filter;
   build?: string;
@@ -193,8 +195,10 @@ const Results = (props: PassedProps) => {
           selectedTab={selectedTab}
           selectedPhase={props.selectedPhase}
           selectedInstance={props.selectedInstance}
+          selectedDungeonPull={props.selectedDungeonPull}
           phases={props.phases}
           handlePhaseSelection={props.handlePhaseSelection}
+          handleDungeonPullSelection={props.handleDungeonPullSelection}
           applyFilter={props.applyFilter}
           build={props.build}
           isLoading={isLoading}

--- a/src/interface/report/index.tsx
+++ b/src/interface/report/index.tsx
@@ -33,6 +33,7 @@ const ResultsLoader = () => {
   const [timeFilter, setTimeFilter] = useState<Filter | null>(null);
   const [selectedPhase, setSelectedPhase] = useState<string>(SELECTION_ALL_PHASES);
   const [selectedInstance, setSelectedInstance] = useState<number>(0);
+  const [selectedDungeonPull, setSelectedDungeonPull] = useState<string>(SELECTION_ALL_PHASES);
 
   const parserClass = useParser(config);
   const isLoadingParser = parserClass == null;
@@ -89,6 +90,21 @@ const ResultsLoader = () => {
     // TODO: I don't think we need to re-render whenever phases changes.. this callback should work the same.
     // this is here because of react-hooks/exhaustive-deps
     [fight.end_time, fight.start_time],
+  );
+  const applyDungeonPullFilter = useCallback(
+    (dungeonPull: string) => {
+      setSelectedDungeonPull(dungeonPull);
+      const matchingDungeonPull = fight.dungeonPulls?.find(
+        (pull) => String(pull.id) === dungeonPull,
+      );
+      if (dungeonPull === SELECTION_ALL_PHASES || !matchingDungeonPull) {
+        setTimeFilter(null);
+      } else {
+        setTimeFilter({ start: matchingDungeonPull.start_time, end: matchingDungeonPull.end_time });
+      }
+      return null;
+    },
+    [fight.dungeonPulls],
   );
 
   // Original code only rendered TimeEventFilter if
@@ -169,7 +185,9 @@ const ResultsLoader = () => {
       phases={phases}
       selectedPhase={selectedPhase}
       selectedInstance={selectedInstance}
+      selectedDungeonPull={selectedDungeonPull}
       handlePhaseSelection={applyPhaseFilter}
+      handleDungeonPullSelection={applyDungeonPullFilter}
       applyFilter={applyTimeFilter}
       timeFilter={timeFilter!}
       build={build}

--- a/src/parser/core/Fight.ts
+++ b/src/parser/core/Fight.ts
@@ -1,4 +1,14 @@
 // WCL properties
+export interface WCLDungeonPull {
+  id: number;
+  boss: number;
+  start_time: number;
+  end_time: number;
+  name: string;
+  kill?: boolean;
+  enemies?: number[][];
+}
+
 export interface WCLFight {
   id: number;
   start_time: number;
@@ -16,6 +26,7 @@ export interface WCLFight {
   bossPercentage?: number;
   fightPercentage?: number;
   hardModeLevel?: number;
+  dungeonPulls?: WCLDungeonPull[];
 }
 
 //generated or applied properties


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Add ability to filter M+ logs by dungeon pull.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/BcPn3RYvHjD8dKQp/4-Mythic++Shadowmoon+Burial+Grounds+-+Kill+(25:39)/3-Toppledh/standard`
- Screenshot(s):
![image](https://user-images.githubusercontent.com/1672786/234067136-919a1de0-b564-4af5-b51d-c30b4f5442c6.png)
![dungeon-pull-filter](https://user-images.githubusercontent.com/1672786/234067108-652af66e-dcb4-4f3f-9bc9-d614d9a31926.gif)
