### PR TITLE
[Mistweaver] Bug Fixes & Updated Guide for 10.1

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 4, 28), <>Updated Guide sections for 10.1</>, Vohrr),
   change(date(2023, 4, 27), <>Added <SpellLink id={TALENTS_MONK.CALMING_COALESCENCE_TALENT.id}/> module.</>, Vohrr),
   change(date(2023, 4, 27), <>Conditionally load <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT.id}/> guide metrics based on talent selection.</>, Vohrr),
   change(date(2023, 4, 27), <>Fixed <SpellLink id={TALENTS_MONK.CLOUDED_FOCUS_TALENT.id}/> MP5 tally</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/Guide.tsx
+++ b/src/analysis/retail/monk/mistweaver/Guide.tsx
@@ -45,7 +45,9 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
         {info.combatant.hasTalent(TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT)
           ? modules.invokeChiJi.guideCastBreakdown
           : modules.invokeYulon.guideCastBreakdown}
-        {modules.revival.guideCastBreakdown}
+        {(info.combatant.hasTalent(TALENTS_MONK.JADE_BOND_TALENT) ||
+          info.combatant.hasTalent(TALENTS_MONK.SHAOHAOS_LESSONS_TALENT)) &&
+          modules.revival.guideCastBreakdown}
         {info.combatant.hasTalent(TALENTS_MONK.MANA_TEA_TALENT) &&
           modules.manaTea.guideCastBreakdown}
         <HotGraphSubsection modules={modules} events={events} info={info} />

--- a/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
@@ -252,7 +252,7 @@ class BaseCelestialAnalyzer extends Analyzer {
     this.lessonsApplyTime = event.timestamp;
   }
 
-  removeSi(event: RemoveBuffEvent | DeathEvent) {
+  removeSi(event: RemoveBuffEvent) {
     this.secretInfusionActive = false;
     if (this.celestialActive) {
       this.castTrackers.at(-1)!.infusionDuration = event.timestamp - this.siApplyTime;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
@@ -35,8 +35,8 @@ export interface BaseCelestialTracker {
   recastEf: boolean; // whether player recast ef during celestial
   deathTimestamp: number; // when pet died
 }
-const lessonsDebug = true;
-const siDebug = true;
+const lessonsDebug = false;
+const siDebug = false;
 const ENVM_HASTE_FACTOR = 0.55; // this factor determines how harsh to be for ideal envm casts
 const CHIJI_GIFT_ENVMS = 2.5;
 const YULON_GIFT_ENVMS = 4;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/CalmingCoalescence.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/CalmingCoalescence.tsx
@@ -75,13 +75,11 @@ class CalmingCoalescence extends Analyzer {
   onApplyLifeCocoon(event: ApplyBuffEvent) {
     this.totalShieldSize += event.absorb || 0;
     this.shieldSize = event.absorb || 0;
-    console.log(this.stacks, this.shieldSize);
     this.baseShield = this.stacks > 0 ? this.calculateBaseShield(event.absorb!) : this.shieldSize;
     this.currentShieldAbsorbed = 0;
   }
 
   onAbsorbed(event: AbsorbedEvent) {
-    console.log(event);
     this.currentShieldAbsorbed += event.amount;
   }
 

--- a/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
@@ -7,7 +7,7 @@ import CooldownExpandable, {
   CooldownExpandableItem,
 } from 'interface/guide/components/CooldownExpandable';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
-import { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
+import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, {
   AbsorbedEvent,
   CastEvent,
@@ -130,7 +130,6 @@ class InvokeChiJi extends BaseCelestialAnalyzer {
       Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.TEACHINGS_OF_THE_MONASTERY),
       this.onTotmRefresh,
     );
-    this.addEventListener(Events.death.to(SELECTED_PLAYER_PET), this.removeSi);
   }
 
   //missed gcd mangement

--- a/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
@@ -405,12 +405,12 @@ class InvokeChiJi extends BaseCelestialAnalyzer {
             allPerfs.push(rval[0]);
             checklistItems.push(rval[1]);
           }
-          const lowestPerf = getAveragePerf(allPerfs);
+          const avgPerf = getAveragePerf(allPerfs);
           return (
             <CooldownExpandable
               header={header}
               checklistItems={checklistItems}
-              perf={lowestPerf}
+              perf={avgPerf}
               key={ix}
             />
           );

--- a/src/analysis/retail/monk/mistweaver/modules/spells/InvokeYulon.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/InvokeYulon.tsx
@@ -113,7 +113,7 @@ class InvokeYulon extends BaseCelestialAnalyzer {
         <br />
         {this.selectedCombatant.hasTalent(TALENTS_MONK.SHAOHAOS_LESSONS_TALENT) && (
           <>
-            <SpellLink id={TALENTS_MONK.SHAOHAOS_LESSONS_TALENT} />, cast{' '}
+            With <SpellLink id={TALENTS_MONK.SHAOHAOS_LESSONS_TALENT} />, cast{' '}
             <SpellLink id={TALENTS_MONK.SHEILUNS_GIFT_TALENT} /> with enough clouds to cover the
             entire duration of <SpellLink id={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT} />
             <br />
@@ -138,6 +138,7 @@ class InvokeYulon extends BaseCelestialAnalyzer {
         <SpellLink id={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT} /> with casts of{' '}
         <SpellLink id={SPELLS.VIVIFY} /> to make use of your low duration{' '}
         <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT} />
+        s.
       </p>
     );
     /* Disabled for 10.1 sinec we will want to use TFT at the end of the ramp to ensure 4pc */

--- a/src/analysis/retail/monk/mistweaver/modules/spells/InvokeYulon.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/InvokeYulon.tsx
@@ -10,7 +10,7 @@ import { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analy
 import Events, { AbsorbedEvent, CastEvent, HealEvent } from 'parser/core/Events';
 import BoringValueText from 'parser/ui/BoringValueText';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
-import { getLowestPerf } from 'parser/ui/QualitativePerformance';
+import { getAveragePerf } from 'parser/ui/QualitativePerformance';
 import Statistic from 'parser/ui/Statistic';
 import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -168,12 +168,12 @@ class InvokeYulon extends BaseCelestialAnalyzer {
             allPerfs.push(rval[0]);
             checklistItems.push(rval[1]);
           }
-          const lowestPerf = getLowestPerf(allPerfs);
+          const avgPerf = getAveragePerf(allPerfs);
           return (
             <CooldownExpandable
               header={header}
               checklistItems={checklistItems}
-              perf={lowestPerf}
+              perf={avgPerf}
               key={ix}
             />
           );

--- a/src/analysis/retail/monk/mistweaver/modules/spells/InvokeYulon.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/InvokeYulon.tsx
@@ -100,40 +100,54 @@ class InvokeYulon extends BaseCelestialAnalyzer {
           <SpellLink id={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id} />
         </strong>
         <br />
-        Before casting <SpellLink id={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT} />, it is
-        essential to prepare by doing the following
-        <ul>
-          <li>
-            Cast <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT} /> to do extra healing during the
-            duration of <SpellLink id={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT} />
-          </li>
-          <li>
-            If talented into <SpellLink id={TALENTS_MONK.SHAOHAOS_LESSONS_TALENT} />, cast{' '}
+        Before casting <SpellLink id={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT} />, make
+        sure that <SpellLink id={TALENTS_MONK.RISING_SUN_KICK_TALENT} /> is on cooldown, and make to
+        sure cast{' '}
+        {this.selectedCombatant.hasTalent(TALENTS_MONK.GIFT_OF_THE_CELESTIALS_TALENT) ? (
+          <>at least one </>
+        ) : (
+          <>all </>
+        )}{' '}
+        <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT} />
+        (s) to prevent overcapping charges Yulon's duration.
+        <br />
+        {this.selectedCombatant.hasTalent(TALENTS_MONK.SHAOHAOS_LESSONS_TALENT) && (
+          <>
+            <SpellLink id={TALENTS_MONK.SHAOHAOS_LESSONS_TALENT} />, cast{' '}
             <SpellLink id={TALENTS_MONK.SHEILUNS_GIFT_TALENT} /> with enough clouds to cover the
             entire duration of <SpellLink id={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT} />
-          </li>
-        </ul>
-        During the duration of <SpellLink id={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT} />,
-        it is important to do the following
-        <ul>
+            <br />
+          </>
+        )}
+        During <SpellLink id={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT} />, it is important
+        to cast <SpellLink id={TALENTS_MONK.ENVELOPING_MIST_TALENT} /> on allies that are near other
+        allies (e.g. not ranged players standing alone) to maximize targets hit by{' '}
+        <SpellLink id={SPELLS.ENVELOPING_BREATH_HEAL} />. Be sure to cast{' '}
+        <SpellLink id={TALENTS_MONK.RISING_SUN_KICK_TALENT} /> before your first{' '}
+        <SpellLink id={TALENTS_MONK.ENVELOPING_MIST_TALENT} /> and{' '}
+        <SpellLink id={TALENTS_MONK.RAPID_DIFFUSION_TALENT} />{' '}
+        <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT} /> falls off to extend their duration.
+        {this.selectedCombatant.hasTalent(TALENTS_MONK.JADE_BOND_TALENT) && (
+          <>
+            Recast <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT} /> if talented into{' '}
+            <SpellLink id={TALENTS_MONK.JADE_BOND_TALENT} />
+          </>
+        )}{' '}
+        <br />
+        Be sure to follow up your{' '}
+        <SpellLink id={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT} /> with casts of{' '}
+        <SpellLink id={SPELLS.VIVIFY} /> to make use of your low duration{' '}
+        <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT} />
+      </p>
+    );
+    /* Disabled for 10.1 sinec we will want to use TFT at the end of the ramp to ensure 4pc */
+    /* <ul>
           <li>
             If <SpellLink id={TALENTS_MONK.SECRET_INFUSION_TALENT} /> talented, use{' '}
             <SpellLink id={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT} /> with{' '}
-            <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT} /> or{' '}
-            <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT} /> for a multiplicative haste bonus
+            <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT} /> for a multiplicative haste bonus
           </li>
-          <li>
-            Recast <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT} /> if talented into{' '}
-            <SpellLink id={TALENTS_MONK.JADE_BOND_TALENT} />
-          </li>
-          <li>
-            Cast <SpellLink id={TALENTS_MONK.ENVELOPING_MIST_TALENT} /> on allies that are near
-            other allies (e.g. not ranged players standing alone) to maximize targets hit by{' '}
-            <SpellLink id={SPELLS.ENVELOPING_BREATH_HEAL} />
-          </li>
-        </ul>
-      </p>
-    );
+        </ul> */
 
     const data = (
       <div>

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ManaTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ManaTea.tsx
@@ -220,21 +220,19 @@ class ManaTea extends Analyzer {
         <strong>
           <SpellLink id={TALENTS_MONK.MANA_TEA_TALENT.id} />
         </strong>{' '}
-        is a powerful buff that can save a large amount of mana. Aim to use{' '}
-        <SpellLink id={TALENTS_MONK.MANA_TEA_TALENT} /> in the following ways
-        <ul>
-          <li>
-            If you have at least 8 <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT} /> HoTs out on
-            the raid and the raid is taking significant damage, then use{' '}
-            <SpellLink id={TALENTS_MONK.MANA_TEA_TALENT} /> and spam{' '}
-            <SpellLink id={SPELLS.VIVIFY} />
-          </li>
-          <li>
-            If talented into <SpellLink id={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT} />,
-            use <SpellLink id={TALENTS_MONK.MANA_TEA_TALENT} /> during your celestial and spam
-            <SpellLink id={TALENTS_MONK.ENVELOPING_MIST_TALENT} />
-          </li>
-        </ul>
+        is a powerful buff that can save a large amount of mana and doubles as a throughput cooldown
+        once you obtain your 4 piece tier set bonus. Aim to maximize effectiveness of{' '}
+        <SpellLink id={TALENTS_MONK.MANA_TEA_TALENT} /> by spamming <SpellLink id={SPELLS.VIVIFY} />{' '}
+        during damage moments when you have at least 8{' '}
+        <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT} /> HoTs out on the raid.
+        <br />
+        Alternatively, If talented into{' '}
+        <SpellLink id={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT} /> and{' '}
+        <SpellLink id={TALENTS_MONK.CLOUDED_FOCUS_TALENT} />, use{' '}
+        <SpellLink id={TALENTS_MONK.MANA_TEA_TALENT} /> toward the end of your celestial for a
+        guaranteed proc of <SpellLink id={SPELLS.SOULFANG_VITALITY} /> and spam
+        <SpellLink id={SPELLS.VIVIFY} /> while channeling{' '}
+        <SpellLink id={TALENTS_MONK.SOOTHING_MIST_TALENT} />.
       </p>
     );
 

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Revival.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Revival.tsx
@@ -147,10 +147,15 @@ class Revival extends Analyzer {
           <SpellLink id={this.getRevivalTalent()} />
         </strong>{' '}
         is a fairly straightforward cooldown, however there are a few things you should always aim
-        to do prior to casting it to maximize its healing. Always pre-cast{' '}
-        <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT} /> to get as many duplicated{' '}
-        <SpellLink id={SPELLS.GUSTS_OF_MISTS} /> heals as possible. If talented into{' '}
-        <SpellLink id={TALENTS_MONK.SHAOHAOS_LESSONS_TALENT} />, always pre-cast{' '}
+        to do prior to casting it to maximize its healing.
+        {!this.selectedCombatant.hasTalent(TALENTS_MONK.CLOUDED_FOCUS_TALENT) && (
+          <>
+            {' '}
+            Always pre-cast <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT} /> to get as many
+            duplicated <SpellLink id={SPELLS.GUSTS_OF_MISTS} /> heals as possible.{' '}
+          </>
+        )}{' '}
+        If talented into <SpellLink id={TALENTS_MONK.SHAOHAOS_LESSONS_TALENT} />, always pre-cast{' '}
         <SpellLink id={TALENTS_MONK.SHEILUNS_GIFT_TALENT} /> if your next buff is not{' '}
         <SpellLink spell={SPELLS.LESSON_OF_FEAR_BUFF} />.
       </p>
@@ -167,22 +172,26 @@ class Revival extends Analyzer {
             </>
           );
           const checklistItems: CooldownExpandableItem[] = [];
-          let efPerf = QualitativePerformance.Good;
-          if (cast.numEfHots < Math.floor(this.minEfHotsBeforeCast * 0.75)) {
-            efPerf = QualitativePerformance.Fail;
-          } else if (cast.numEfHots < Math.floor(this.minEfHotsBeforeCast * 0.9)) {
-            efPerf = QualitativePerformance.Ok;
+          const allPerfs: QualitativePerformance[] = [];
+          if (this.selectedCombatant.hasTalent(TALENTS_MONK.JADE_BOND_TALENT)) {
+            let efPerf = QualitativePerformance.Good;
+            if (cast.numEfHots < Math.floor(this.minEfHotsBeforeCast * 0.75)) {
+              efPerf = QualitativePerformance.Fail;
+            } else if (cast.numEfHots < Math.floor(this.minEfHotsBeforeCast * 0.9)) {
+              efPerf = QualitativePerformance.Ok;
+            }
+            checklistItems.push({
+              label: (
+                <>
+                  <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT} /> HoTs active on cast
+                </>
+              ),
+              result: <PerformanceMark perf={efPerf} />,
+              details: <>{cast.numEfHots}</>,
+            });
+            allPerfs.push(efPerf);
           }
-          checklistItems.push({
-            label: (
-              <>
-                <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT} /> HoTs active on cast
-              </>
-            ),
-            result: <PerformanceMark perf={efPerf} />,
-            details: <>{cast.numEfHots}</>,
-          });
-          const allPerfs = [efPerf];
+
           if (this.selectedCombatant.hasTalent(TALENTS_MONK.SHAOHAOS_LESSONS_TALENT)) {
             let lessonPerf = QualitativePerformance.Fail;
             if (

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
@@ -38,6 +38,7 @@ class ThunderFocusTea extends Analyzer {
   castBufferTimestamp: number = 0;
   ftActive: boolean = false;
   correctSpells: number[] = [];
+  okSpells: number[] = [];
 
   constructor(options: Options) {
     super(options);
@@ -69,6 +70,9 @@ class ThunderFocusTea extends Analyzer {
         TALENTS_MONK.RENEWING_MIST_TALENT.id,
         TALENTS_MONK.ESSENCE_FONT_TALENT.id,
       ]; // only haste buff
+      if (this.ftActive) {
+        this.okSpells = [TALENTS_MONK.RISING_SUN_KICK_TALENT.id];
+      }
     } else if (this.selectedCombatant.hasTalent(TALENTS_MONK.RISING_MIST_TALENT)) {
       this.correctSpells = [
         TALENTS_MONK.RISING_SUN_KICK_TALENT.id,
@@ -76,6 +80,9 @@ class ThunderFocusTea extends Analyzer {
       ];
     } else {
       this.correctSpells = [TALENTS_MONK.RENEWING_MIST_TALENT.id];
+      if (this.ftActive) {
+        this.okSpells = [TALENTS_MONK.RISING_SUN_KICK_TALENT.id];
+      }
     }
   }
 
@@ -145,6 +152,13 @@ class ThunderFocusTea extends Analyzer {
         </>
       );
       this.correctCasts += 1;
+    } else if (this.okSpells.includes(spellId)) {
+      value = QualitativePerformance.Ok;
+      tooltip = (
+        <>
+          Ok cast: buffed <SpellLink id={spellId} />
+        </>
+      );
     } else {
       value = QualitativePerformance.Fail;
       tooltip = (
@@ -204,13 +218,16 @@ class ThunderFocusTea extends Analyzer {
         times and the spell that you use it on depends on your talent selection. If you have{' '}
         <SpellLink id={TALENTS_MONK.SECRET_INFUSION_TALENT} />, then you should always use{' '}
         <SpellLink id={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT.id} /> on{' '}
-        <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT.id} /> or{' '}
-        <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT} /> (when talented into{' '}
-        <SpellLink id={TALENTS_MONK.UPWELLING_TALENT} />
-        ). If you aren't talented into <SpellLink id={TALENTS_MONK.SECRET_INFUSION_TALENT.id} />,
-        then always use it on <SpellLink id={TALENTS_MONK.RISING_SUN_KICK_TALENT.id} /> (if talented
-        into <SpellLink id={TALENTS_MONK.RISING_MIST_TALENT.id} />
-        ) or <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT.id} />.
+        <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT.id} />{' '}
+        {this.selectedCombatant.hasTalent(TALENTS_MONK.UPWELLING_TALENT) && (
+          <>
+            or <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT} /> (when talented into{' '}
+            <SpellLink id={TALENTS_MONK.UPWELLING_TALENT} />)
+          </>
+        )}
+        . If you aren't talented into <SpellLink id={TALENTS_MONK.SECRET_INFUSION_TALENT.id} />,
+        then always use it on <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT.id} /> or{' '}
+        <SpellLink id={TALENTS_MONK.RISING_SUN_KICK_TALENT.id} />.
       </p>
     );
     const data = (


### PR DESCRIPTION
### Description

- Bug fixes in BaseCelestialAnalyzer from not registering Yulon ending and refactored cast/buff tracking in celestial window
- Updated and reformatted Guide Sections for Yulon, Mana Tea, Revival to conditionally load and account for talent builds that won't press essence font in 10.1
- Updated Thunder Focus Tea cast perfs to include an 'Ok' metric for Rising Sun Kick when Focused Thunder is talented

### Screenshot(s):
**Yulon** 
Before:
![image](https://user-images.githubusercontent.com/26779541/235206318-1b9cfd64-99c9-4c91-9711-965b4f63a065.png)
After:
![image](https://user-images.githubusercontent.com/26779541/235208380-d89fc9dc-9101-40e3-9ee6-9f9f7bf3e89c.png)

**Revival** 
Before:
![image](https://user-images.githubusercontent.com/26779541/235207126-2643c494-78d1-4460-b149-4f06b9c1433b.png)
After: 
![image](https://user-images.githubusercontent.com/26779541/235207000-25708101-1fc7-4a93-aa87-d8760bc49cc9.png)

**Mana Tea**
Before: 
![image](https://user-images.githubusercontent.com/26779541/235207204-3527d1e2-c33b-4f08-9e3e-51d42a1f0f54.png)
After:
![image](https://user-images.githubusercontent.com/26779541/235207314-b4c82950-8413-41ec-98d8-297a69a41047.png)

**Thunder Focus Tea**
Before:
![image](https://user-images.githubusercontent.com/26779541/235209122-0ddf29f2-08d5-4d56-999b-681c4928c085.png)
After:
![image](https://user-images.githubusercontent.com/26779541/235209190-1f4f4165-ea96-4b93-9483-6ae3f89398a2.png)


