### PR TITLE
[Resto Shaman] Earth Shield Talents, Bug Fixes, New Breakdown Module

### DIFF
--- a/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Arlie, Fassbrause, niseko, Vetyst, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 5, 1), <> Updated <SpellLink id={TALENTS.EARTH_SHIELD_TALENT.id}/> to show talent contribution breakdown</>, Vohrr),
   change(date(2023, 4, 30), <>Added <SpellLink id={TALENTS.FLOW_OF_THE_TIDES_TALENT.id}/> module</>, Vohrr),
   change(date(2023, 3, 16), <>Fixed <SpellLink id={TALENTS.ANCESTRAL_VIGOR_TALENT.id}/> to work for each talent rank</>, Vohrr),
   change(date(2023, 3, 8), <>Fixed <SpellLink id={TALENTS.HIGH_TIDE_TALENT.id}/> module and mark Resto Shaman as supported for 10.0.7</>, Vohrr),

--- a/src/analysis/retail/shaman/restoration/CONFIG.tsx
+++ b/src/analysis/retail/shaman/restoration/CONFIG.tsx
@@ -12,7 +12,7 @@ const CONFIG: Config = {
   contributors: [niseko, Arlie, Vohrr],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.5',
+  patchCompatibility: '10.0.7',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
@@ -39,8 +39,7 @@ const CONFIG: Config = {
     </Trans>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport:
-    'report/H9VDyfZ4FKABNtGk/36-Mythic+Kurog+Grimtotem+-+Kill+(8:49)/Fakeblonde/standard',
+  exampleReport: 'report/nLqjdwhyG4r7FxJW/19-Mythic+Terros+-+Kill+(4:22)/Fakeblonde/standard',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/shaman/restoration/CombatLogParser.tsx
+++ b/src/analysis/retail/shaman/restoration/CombatLogParser.tsx
@@ -60,6 +60,10 @@ import PrimalTideCore from './modules/talents/PrimalTideCore';
 import WavespeakersBlessing from './modules/talents/WavespeakersBlessing';
 import AncestralReach from './modules/talents/AncestralReach';
 import FlowOfTheTides from './modules/talents/FlowOfTheTides';
+import EarthShieldBreakdown from './modules/features/EarthShieldBreakdown';
+import EarthenHarmony from './modules/talents/EarthenHarmony';
+import ElementalOrbit from '../shared/talents/ElementalOrbit';
+import SurgingShields from '../shared/talents/SurgingShields';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -84,6 +88,7 @@ class CombatLogParser extends CoreCombatLogParser {
     castBehavior: CastBehavior,
     checklist: Checklist,
     spellUsable: SpellUsable,
+    earthShieldBreakdown: EarthShieldBreakdown,
 
     // Talents
     torrent: Torrent,
@@ -107,6 +112,7 @@ class CombatLogParser extends CoreCombatLogParser {
     wavespeakersBlessing: WavespeakersBlessing,
     ancestralReach: AncestralReach,
     flowOfTheTides: FlowOfTheTides,
+    earthenHarmony: EarthenHarmony,
 
     // Spells
     chainHeal: ChainHeal,
@@ -124,6 +130,8 @@ class CombatLogParser extends CoreCombatLogParser {
     staticCharge: StaticCharge,
     astralShift: AstralShift,
     earthShield: EarthShield,
+    elementalOrbit: ElementalOrbit,
+    surgingShields: SurgingShields,
 
     // Normalizers
     cloudburstNormalizer: CloudburstNormalizer,

--- a/src/analysis/retail/shaman/restoration/modules/features/EarthShieldBreakdown.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/features/EarthShieldBreakdown.tsx
@@ -1,0 +1,223 @@
+import { EarthShield } from 'analysis/retail/shaman/shared';
+import EarthenHarmony from '../talents/EarthenHarmony';
+import ElementalOrbit from 'analysis/retail/shaman/shared/talents/ElementalOrbit';
+import SurgingShields from 'analysis/retail/shaman/shared/talents/SurgingShields';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import TalentAggregateBars, { TalentAggregateBarSpec } from 'parser/ui/TalentAggregateStatistic';
+import talents from 'common/TALENTS/shaman';
+import { RESTORATION_COLORS } from '../../constants';
+import { SpellLink } from 'interface';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import TalentAggregateStatisticContainer from 'parser/ui/TalentAggregateStatisticContainer';
+import UptimeIcon from 'interface/icons/Uptime';
+import { formatNumber, formatPercentage } from 'common/format';
+
+class EarthShieldBreakdown extends Analyzer {
+  static dependencies = {
+    earthShield: EarthShield,
+    earthenHarmony: EarthenHarmony,
+    elementalOrbit: ElementalOrbit,
+    surgingShields: SurgingShields,
+  };
+  wide: boolean = false;
+  earthShieldItems: TalentAggregateBarSpec[] = [];
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(talents.EARTH_SHIELD_TALENT);
+    this.wide =
+      this.selectedCombatant.hasTalent(talents.ELEMENTAL_ORBIT_TALENT) &&
+      this.selectedCombatant.hasTalent(talents.EARTHEN_HARMONY_TALENT);
+  }
+
+  protected earthShield!: EarthShield;
+  protected earthenHarmony!: EarthenHarmony;
+  protected elementalOrbit!: ElementalOrbit;
+  protected surgingShields!: SurgingShields;
+
+  get totalHealing() {
+    return (
+      this.earthShield.healing +
+      this.earthShield.buffHealing +
+      this.elementalOrbit.healing +
+      this.elementalOrbit.buffHealing
+    );
+  }
+
+  getEarthShieldDataItems() {
+    this.earthShieldItems = [
+      //base earth shield
+      {
+        spell: talents.EARTH_SHIELD_TALENT,
+        amount: this.earthShield.healing,
+        color: RESTORATION_COLORS.CHAIN_HEAL,
+        tooltip: this.baseTooltip(this.earthShield.uptimePercent, this.earthShield.healing),
+        subSpecs: [
+          {
+            //bonus healing from heal amp
+            spell: talents.EARTH_SHIELD_TALENT,
+            amount: this.earthShield.buffHealing,
+            color: RESTORATION_COLORS.RIPTIDE,
+            tooltip: this.bonusHealingTooltip(this.earthShield.buffHealing),
+          },
+        ],
+      },
+      //elemental orbit
+      {
+        spell: talents.ELEMENTAL_ORBIT_TALENT,
+        amount: this.elementalOrbit.healing,
+        color: RESTORATION_COLORS.HEALING_RAIN,
+        tooltip: this.baseTooltip(this.elementalOrbit.uptimePercent, this.elementalOrbit.healing),
+        subSpecs: [
+          {
+            //bonus healing from heal amp
+            spell: talents.ELEMENTAL_ORBIT_TALENT,
+            amount: this.elementalOrbit.buffHealing,
+            color: RESTORATION_COLORS.RIPTIDE,
+            tooltip: this.bonusHealingTooltip(this.elementalOrbit.buffHealing),
+          },
+        ],
+      },
+      //earthen harmony
+      {
+        //targeted earth shield
+        spell: talents.EARTHEN_HARMONY_TALENT,
+        amount: this.earthenHarmony.earthShieldHealing,
+        color: RESTORATION_COLORS.CHAIN_HEAL,
+        tooltip: this.earthenHarmonyBaseTooltip(),
+        subSpecs: [
+          {
+            //elemental orbit earth shield
+            spell: talents.EARTHEN_HARMONY_TALENT,
+            amount: this.earthenHarmony.elementalOrbitEarthShieldHealing,
+            color: RESTORATION_COLORS.HEALING_RAIN,
+            tooltip: this.earthenHarmonyEOTooltip(),
+          },
+        ],
+      },
+      //surging shields
+      {
+        //targeted earth shield
+        spell: talents.SURGING_SHIELDS_TALENT,
+        amount: this.surgingShields.earthShieldHealing,
+        color: RESTORATION_COLORS.CHAIN_HEAL,
+        tooltip: this.surgingShieldsTooltip(),
+        subSpecs: [
+          {
+            //elemental orbit earth shield
+            spell: talents.SURGING_SHIELDS_TALENT,
+            amount: this.surgingShields.elementalOrbitEarthShieldHealing,
+            color: RESTORATION_COLORS.HEALING_RAIN,
+            tooltip: this.surgingShieldsEOTooltip(),
+          },
+        ],
+      },
+    ];
+    return this.earthShieldItems;
+  }
+
+  baseTooltip(uptime: number, amount: number) {
+    return (
+      <>
+        <UptimeIcon /> {formatPercentage(uptime)}% uptime
+        <br />
+        {this.healingIcon()} <strong>{formatNumber(amount)}</strong> direct healing
+      </>
+    );
+  }
+
+  bonusHealingTooltip(amount: number) {
+    return (
+      <>
+        {this.healingIcon()} <strong>{formatNumber(amount)}</strong> bonus healing from the buff
+      </>
+    );
+  }
+
+  earthenHarmonyBaseTooltip() {
+    return (
+      <>
+        <SpellLink id={talents.EARTH_SHIELD_TALENT} />:
+        <br />
+        {this.shieldIcon()}{' '}
+        <strong>{formatNumber(this.earthenHarmony.earthShielddamageReduced)}</strong> damage
+        mitigated
+        <br />
+        {this.healingIcon()} <strong>{formatNumber(this.earthenHarmony.earthShieldHealing)}</strong>{' '}
+        additional healing
+      </>
+    );
+  }
+
+  earthenHarmonyEOTooltip() {
+    return (
+      <>
+        <SpellLink id={talents.EARTH_SHIELD_TALENT} /> from{' '}
+        <SpellLink id={talents.ELEMENTAL_ORBIT_TALENT} />:
+        <br />
+        {this.shieldIcon()}{' '}
+        <strong>{formatNumber(this.earthenHarmony.elementalOrbitDamageReduced)}</strong> damage
+        mitigated
+        <br />
+        {this.healingIcon()}{' '}
+        <strong>{formatNumber(this.earthenHarmony.elementalOrbitEarthShieldHealing)}</strong>{' '}
+        additional healing
+      </>
+    );
+  }
+
+  surgingShieldsTooltip() {
+    return (
+      <>
+        {this.healingIcon()} <strong>{formatNumber(this.surgingShields.earthShieldHealing)}</strong>{' '}
+        additional <SpellLink id={talents.EARTH_SHIELD_TALENT} /> healing
+      </>
+    );
+  }
+
+  surgingShieldsEOTooltip() {
+    return (
+      <>
+        {this.healingIcon()}{' '}
+        <strong>{formatNumber(this.surgingShields.elementalOrbitEarthShieldHealing)}</strong>{' '}
+        additional <SpellLink id={talents.EARTH_SHIELD_TALENT} /> healing from{' '}
+        <SpellLink id={talents.ELEMENTAL_ORBIT_TALENT} />
+      </>
+    );
+  }
+
+  healingIcon() {
+    return <img alt="Healing" src="/img/healing.png" className="icon" />;
+  }
+
+  shieldIcon() {
+    return <img alt="Damage Mitigated" src="/img/shield.png" className="icon" />;
+  }
+
+  statistic() {
+    return (
+      <TalentAggregateStatisticContainer
+        title={
+          <>
+            <SpellLink id={talents.EARTH_SHIELD_TALENT.id} /> -{' '}
+            <ItemHealingDone amount={this.totalHealing} displayPercentage={this.wide} />
+          </>
+        }
+        smallTitle={!this.wide}
+        category={STATISTIC_CATEGORY.TALENTS}
+        position={STATISTIC_ORDER.CORE(1)}
+        footer={this.wide && <>Mouseover each section for additional details</>}
+        smallFooter
+        wide={this.wide}
+      >
+        <TalentAggregateBars
+          bars={this.getEarthShieldDataItems()}
+          wide={this.wide}
+        ></TalentAggregateBars>
+      </TalentAggregateStatisticContainer>
+    );
+  }
+}
+
+export default EarthShieldBreakdown;

--- a/src/analysis/retail/shaman/restoration/modules/talents/EarthenHarmony.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/talents/EarthenHarmony.tsx
@@ -68,12 +68,12 @@ class EarthenHarmony extends Analyzer {
       return;
     }
     const combatant = this.combatants.getEntity(event);
-    if (combatant && combatant.hasBuff(talents.EARTH_SHIELD_TALENT.id, event.timestamp)) {
+    if (!combatant) {
+      return;
+    }
+    if (combatant.hasBuff(talents.EARTH_SHIELD_TALENT.id, event.timestamp)) {
       this.earthShieldHealing += calculateEffectiveHealing(event, this.healingIncrease);
-    } else if (
-      combatant &&
-      combatant.hasBuff(SPELLS.EARTH_SHIELD_ELEMENTAL_ORBIT_BUFF.id, event.timestamp)
-    ) {
+    } else if (combatant.hasBuff(SPELLS.EARTH_SHIELD_ELEMENTAL_ORBIT_BUFF.id, event.timestamp)) {
       this.elementalOrbitEarthShieldHealing += calculateEffectiveHealing(
         event,
         this.healingIncrease,

--- a/src/analysis/retail/shaman/restoration/modules/talents/EarthenHarmony.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/talents/EarthenHarmony.tsx
@@ -52,10 +52,13 @@ class EarthenHarmony extends Analyzer {
     return this.earthShieldHealing + this.elementalOrbitEarthShieldHealing;
   }
 
-  get damageReduced() {
+  get earthShielddamageReduced() {
+    return (this.damageTakenWithEarthShield / (1 - this.damageReduction)) * this.damageReduction;
+  }
+
+  get elementalOrbitDamageReduced() {
     return (
-      ((this.damageTakenWithEarthShield + this.damageTakenWithElementalOrbitEarthShield) /
-        (1 - this.damageReduction)) *
+      (this.damageTakenWithElementalOrbitEarthShield / (1 - this.damageReduction)) *
       this.damageReduction
     );
   }

--- a/src/analysis/retail/shaman/restoration/modules/talents/EarthenHarmony.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/talents/EarthenHarmony.tsx
@@ -1,0 +1,126 @@
+import SPELLS from 'common/SPELLS';
+import talents from 'common/TALENTS/shaman';
+import { WCLDamageTaken, WCLDamageTakenTableResponse } from 'common/WCL_TYPES';
+import fetchWcl from 'common/fetchWclApi';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
+import Events, { EventType, HealEvent } from 'parser/core/Events';
+import Combatants from 'parser/shared/modules/Combatants';
+
+const DAMAGE_REDUCTION_PER_POINT = 0.03;
+const HEALING_INCREASE_PER_POINT = 0.5;
+const HEALTH_THRESHOLD = 0.75;
+
+class EarthenHarmony extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  protected combatants!: Combatants;
+  damageReduction;
+  damageTakenWithEarthShield: number = 0;
+  damageTakenWithElementalOrbitEarthShield: number = 0;
+  healingIncrease;
+  earthShieldHealing: number = 0;
+  elementalOrbitEarthShieldHealing: number = 0;
+  elementalOrbitActive: boolean = false;
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(talents.EARTHEN_HARMONY_TALENT);
+    this.elementalOrbitActive = this.selectedCombatant.hasTalent(talents.ELEMENTAL_ORBIT_TALENT);
+    this.damageReduction =
+      DAMAGE_REDUCTION_PER_POINT *
+      this.selectedCombatant.getTalentRank(talents.EARTHEN_HARMONY_TALENT);
+    this.healingIncrease =
+      HEALING_INCREASE_PER_POINT *
+      this.selectedCombatant.getTalentRank(talents.EARTHEN_HARMONY_TALENT);
+
+    if (!this.active) {
+      return;
+    }
+    this.addEventListener(
+      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.EARTH_SHIELD_HEAL),
+      this.onEarthShieldHeal,
+    );
+    this.loadDamageTakenDuringEarthShield();
+    if (this.elementalOrbitActive) {
+      this.loadDamageTakenDuringEarthShieldElementalOrbit();
+    }
+  }
+
+  get totalHealing() {
+    return this.earthShieldHealing + this.elementalOrbitEarthShieldHealing;
+  }
+
+  get damageReduced() {
+    return (
+      ((this.damageTakenWithEarthShield + this.damageTakenWithElementalOrbitEarthShield) /
+        (1 - this.damageReduction)) *
+      this.damageReduction
+    );
+  }
+
+  onEarthShieldHeal(event: HealEvent) {
+    if (!this.targetIsBelowHpThreshold(event)) {
+      return;
+    }
+    const combatant = this.combatants.getEntity(event);
+    if (combatant && combatant.hasBuff(talents.EARTH_SHIELD_TALENT.id, event.timestamp)) {
+      this.earthShieldHealing += calculateEffectiveHealing(event, this.healingIncrease);
+    } else if (
+      combatant &&
+      combatant.hasBuff(SPELLS.EARTH_SHIELD_ELEMENTAL_ORBIT_BUFF.id, event.timestamp)
+    ) {
+      this.elementalOrbitEarthShieldHealing += calculateEffectiveHealing(
+        event,
+        this.healingIncrease,
+      );
+    }
+  }
+
+  /** We need the damage taken by the target during Earth Shield in order to calculate the damage
+   *  reduction, which isn't present in the main event stream we have. This forms and sends the
+   *  required custom query */
+  loadDamageTakenDuringEarthShield() {
+    fetchWcl(`report/tables/damage-taken/${this.owner.report.code}`, {
+      start: this.owner.fight.start_time,
+      end: this.owner.fight.end_time,
+      filter: `(IN RANGE FROM type='${EventType.ApplyBuff}' AND ability.id=${talents.EARTH_SHIELD_TALENT.id} AND source.name='${this.selectedCombatant.name}' TO type='${EventType.RemoveBuff}' AND ability.id=${talents.EARTH_SHIELD_TALENT.id} AND source.name='${this.selectedCombatant.name}' GROUP BY target ON target END)`,
+    })
+      .then((json) => {
+        json = json as WCLDamageTakenTableResponse;
+        this.damageTakenWithEarthShield = (json.entries as WCLDamageTaken[]).reduce(
+          (damageTaken: number, entry: { total: number }) => damageTaken + entry.total,
+          0,
+        );
+      })
+      .catch((err) => {
+        throw err;
+      });
+  }
+
+  loadDamageTakenDuringEarthShieldElementalOrbit() {
+    fetchWcl(`report/tables/damage-taken/${this.owner.report.code}`, {
+      start: this.owner.fight.start_time,
+      end: this.owner.fight.end_time,
+      filter: `(IN RANGE FROM type='${EventType.ApplyBuff}' AND ability.id=${SPELLS.EARTH_SHIELD_ELEMENTAL_ORBIT_BUFF.id} AND source.name='${this.selectedCombatant.name}' TO type='${EventType.RemoveBuff}' AND ability.id=${SPELLS.EARTH_SHIELD_ELEMENTAL_ORBIT_BUFF.id} AND source.name='${this.selectedCombatant.name}' GROUP BY target ON target END)`,
+    })
+      .then((json) => {
+        json = json as WCLDamageTakenTableResponse;
+        this.damageTakenWithElementalOrbitEarthShield = (json.entries as WCLDamageTaken[]).reduce(
+          (damageTaken: number, entry: { total: number }) => damageTaken + entry.total,
+          0,
+        );
+      })
+      .catch((err) => {
+        throw err;
+      });
+  }
+
+  targetIsBelowHpThreshold(event: HealEvent) {
+    const hpPercent = (event.hitPoints - event.amount) / event.maxHitPoints;
+    return hpPercent < HEALTH_THRESHOLD;
+  }
+}
+
+export default EarthenHarmony;

--- a/src/analysis/retail/shaman/shared/talents/EarthShield.tsx
+++ b/src/analysis/retail/shaman/shared/talents/EarthShield.tsx
@@ -2,7 +2,6 @@ import { Trans } from '@lingui/macro';
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_SHAMAN } from 'common/TALENTS';
-import SPECS from 'game/SPECS';
 import { SpellLink } from 'interface';
 import UptimeIcon from 'interface/icons/Uptime';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
@@ -31,8 +30,7 @@ class EarthShield extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    const isRsham = this.selectedCombatant.specId === SPECS.RESTORATION_SHAMAN.id;
-    this.active = isRsham || this.selectedCombatant.hasTalent(TALENTS_SHAMAN.EARTH_SHIELD_TALENT);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_SHAMAN.EARTH_SHIELD_TALENT);
 
     if (!this.active) {
       return;
@@ -77,7 +75,10 @@ class EarthShield extends Analyzer {
   }
 
   onEarthShieldHeal(event: HealEvent) {
-    this.healing += event.amount + (event.absorbed || 0);
+    const combatant = this.combatants.getEntity(event);
+    if (combatant && combatant.hasBuff(TALENTS_SHAMAN.EARTH_SHIELD_TALENT.id, event.timestamp)) {
+      this.healing += event.amount + (event.absorbed || 0);
+    }
   }
 
   onEarthShieldAmpSpellHeal(event: HealEvent) {
@@ -107,8 +108,9 @@ class EarthShield extends Analyzer {
         tooltip={
           <Trans id="shaman.shared.earthShield.statistic.tooltip">
             {formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing))}% from the
-            HoT and {formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.buffHealing))}
-            % from the healing increase.
+            direct heal and{' '}
+            {formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.buffHealing))}% from
+            the healing increase.
           </Trans>
         }
         value={

--- a/src/analysis/retail/shaman/shared/talents/ElementalOrbit.tsx
+++ b/src/analysis/retail/shaman/shared/talents/ElementalOrbit.tsx
@@ -1,16 +1,12 @@
-import { Trans } from '@lingui/macro';
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_SHAMAN } from 'common/TALENTS';
 import { SpellLink } from 'interface';
-import UptimeIcon from 'interface/icons/Uptime';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import { calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
 import Events, { HealEvent } from 'parser/core/Events';
 import Combatants from 'parser/shared/modules/Combatants';
-import ItemHealingDone from 'parser/ui/ItemHealingDone';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
-import StatisticBox, { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
 
 export const EARTHSHIELD_HEALING_INCREASE = 0.2;
@@ -85,31 +81,6 @@ class ElementalOrbit extends Analyzer {
         value={`${formatPercentage(
           this.owner.getPercentageOfTotalHealingDone(this.healing + this.buffHealing),
         )} %`}
-      />
-    );
-  }
-
-  statistic() {
-    return (
-      <StatisticBox
-        label={<SpellLink id={TALENTS_SHAMAN.ELEMENTAL_ORBIT_TALENT.id} />}
-        category={this.category}
-        position={STATISTIC_ORDER.OPTIONAL(45)}
-        tooltip={
-          <Trans id="shaman.shared.earthShield.statistic.tooltip">
-            {formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing))}% from the
-            direct heal and{' '}
-            {formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.buffHealing))}% from
-            the healing increase.
-          </Trans>
-        }
-        value={
-          <div>
-            <UptimeIcon /> {formatPercentage(this.uptimePercent)}% <small>uptime</small>
-            <br />
-            <ItemHealingDone amount={this.healing + this.buffHealing} />
-          </div>
-        }
       />
     );
   }

--- a/src/analysis/retail/shaman/shared/talents/SurgingShields.tsx
+++ b/src/analysis/retail/shaman/shared/talents/SurgingShields.tsx
@@ -1,0 +1,100 @@
+import SPELLS from 'common/SPELLS';
+import talents from 'common/TALENTS/shaman';
+import SPECS from 'game/SPECS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { calculateEffectiveDamage, calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
+import Events, { DamageEvent, HealEvent, ResourceChangeEvent } from 'parser/core/Events';
+import Combatants from 'parser/shared/modules/Combatants';
+
+export const EARTHSHIELD_HEALING_BONUS_PER_POINT = 0.125;
+const WATERSHIELD_MANA_INCREASE_PER_POINT = 0.25;
+const LIGHTNINGSHIELD_DMG_INCREASE_PER_POINT = 0.5;
+
+class SurgingShields extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+
+  protected combatants!: Combatants;
+  //earth shield vars
+  earthShieldIncrease;
+  earthShieldHealing: number = 0;
+  elementalOrbitEarthShieldHealing: number = 0;
+
+  //water shield vars
+  waterShieldIncrease;
+  waterShieldMana: number = 0;
+
+  //lightning shield vars
+  lightningShieldIncrease;
+  lightningShieldDamage: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(talents.SURGING_SHIELDS_TALENT);
+
+    this.earthShieldIncrease =
+      EARTHSHIELD_HEALING_BONUS_PER_POINT *
+      this.selectedCombatant.getTalentRank(talents.SURGING_SHIELDS_TALENT);
+    this.waterShieldIncrease =
+      WATERSHIELD_MANA_INCREASE_PER_POINT *
+      this.selectedCombatant.getTalentRank(talents.SURGING_SHIELDS_TALENT);
+    this.lightningShieldIncrease =
+      LIGHTNINGSHIELD_DMG_INCREASE_PER_POINT *
+      this.selectedCombatant.getTalentRank(talents.SURGING_SHIELDS_TALENT);
+    const isEle = this.selectedCombatant.specId === SPECS.ELEMENTAL_SHAMAN.id;
+    if (!this.active) {
+      return;
+    }
+    this.addEventListener(
+      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.EARTH_SHIELD_HEAL),
+      this.onEarthShieldHeal,
+    );
+
+    this.addEventListener(
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.WATER_SHIELD_ENERGIZE),
+      this.onWaterShieldEnergize,
+    );
+
+    if (!isEle) {
+      this.addEventListener(
+        Events.damage.by(SELECTED_PLAYER).spell(SPELLS.LIGHTNING_SHIELD),
+        this.onLightningShieldDmg,
+      );
+    } else {
+      this.addEventListener(
+        Events.damage.by(SELECTED_PLAYER).spell(SPELLS.LIGHTNING_SHIELD_ELEMENTAL),
+        this.onLightningShieldDmg,
+      );
+    }
+  }
+
+  get totalHealing() {
+    return;
+  }
+
+  onEarthShieldHeal(event: HealEvent) {
+    const combatant = this.combatants.getEntity(event);
+    if (combatant && combatant.hasBuff(talents.EARTH_SHIELD_TALENT.id, event.timestamp)) {
+      this.earthShieldHealing += calculateEffectiveHealing(event, this.earthShieldIncrease);
+    } else if (
+      combatant &&
+      combatant.hasBuff(SPELLS.EARTH_SHIELD_ELEMENTAL_ORBIT_BUFF.id, event.timestamp)
+    ) {
+      this.elementalOrbitEarthShieldHealing += calculateEffectiveHealing(
+        event,
+        this.earthShieldIncrease,
+      );
+    }
+  }
+
+  onWaterShieldEnergize(event: ResourceChangeEvent) {
+    this.waterShieldMana += event.resourceChange - event.resourceChange / this.waterShieldIncrease;
+  }
+
+  onLightningShieldDmg(event: DamageEvent) {
+    this.lightningShieldDamage += calculateEffectiveDamage(event, this.lightningShieldIncrease);
+  }
+}
+
+export default SurgingShields;

--- a/src/analysis/retail/shaman/shared/talents/SurgingShields.tsx
+++ b/src/analysis/retail/shaman/shared/talents/SurgingShields.tsx
@@ -69,18 +69,14 @@ class SurgingShields extends Analyzer {
     }
   }
 
-  get totalHealing() {
-    return;
-  }
-
   onEarthShieldHeal(event: HealEvent) {
     const combatant = this.combatants.getEntity(event);
-    if (combatant && combatant.hasBuff(talents.EARTH_SHIELD_TALENT.id, event.timestamp)) {
+    if (!combatant) {
+      return;
+    }
+    if (combatant.hasBuff(talents.EARTH_SHIELD_TALENT.id, event.timestamp)) {
       this.earthShieldHealing += calculateEffectiveHealing(event, this.earthShieldIncrease);
-    } else if (
-      combatant &&
-      combatant.hasBuff(SPELLS.EARTH_SHIELD_ELEMENTAL_ORBIT_BUFF.id, event.timestamp)
-    ) {
+    } else if (combatant.hasBuff(SPELLS.EARTH_SHIELD_ELEMENTAL_ORBIT_BUFF.id, event.timestamp)) {
       this.elementalOrbitEarthShieldHealing += calculateEffectiveHealing(
         event,
         this.earthShieldIncrease,

--- a/src/common/SPELLS/shaman.ts
+++ b/src/common/SPELLS/shaman.ts
@@ -64,6 +64,11 @@ const spells = spellIndexableList({
     name: 'Earth Shield',
     icon: 'spell_nature_skinofearth',
   },
+  EARTH_SHIELD_ELEMENTAL_ORBIT_BUFF: {
+    id: 383648,
+    name: 'Earth Shield',
+    icon: 'spell_nature_skinofearth',
+  },
   LIGHTNING_SHIELD: {
     id: 192106,
     name: 'Lightning Shield',


### PR DESCRIPTION
### Description

Added analysis Elemental Orbit, Surging Shields, and Earthen Harmony
Added an Earth Shield Breakdown module in place of the existing Earth Shield module to detail the contribution of each talent to the overall hps in addition to other metrics (damage mitigated, uptime, etc)

Module will resize depending on the number of earth shield related talents are active

### Screenshot(s):

![image](https://user-images.githubusercontent.com/26779541/235516241-0f6e2d76-3a48-497f-86e7-b6ccfe311dec.png)
![image](https://user-images.githubusercontent.com/26779541/235516281-c5305a56-6171-44f4-851d-c820345e0fb5.png)
![image](https://user-images.githubusercontent.com/26779541/235516315-cb8cfd9b-16e7-4e61-b699-26fa2446df33.png)
Minified example: 
![image](https://user-images.githubusercontent.com/26779541/235516433-b2ddf6aa-b9c3-4c4a-a439-26202ca405dc.png)
![image](https://user-images.githubusercontent.com/26779541/235516463-fa3f3a14-c797-4a94-908f-6e623e5acc27.png)
