### PR TITLE
10.1 Version Updates

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -23,6 +23,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 5, 2), 'Bumped game version to 10.1', emallson),
   change(date(2023, 4, 24), 'Add ability to filter M+ analysis by dungeon pulls.', ToppleTheNun),
   change(date(2023, 4, 24), 'Additions and updates for Classic Potions (guide and checklist).', jazminite),
   change(date(2023, 4, 20), 'Add M+ season 2 images.', ToppleTheNun),

--- a/src/analysis/retail/deathknight/blood/CONFIG.tsx
+++ b/src/analysis/retail/deathknight/blood/CONFIG.tsx
@@ -3,10 +3,11 @@ import { Yajinni, joshinator } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import { SpellLink } from 'interface';
+import Config from 'parser/Config';
 
 import CHANGELOG from './CHANGELOG';
 
-export default {
+const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Yajinni, joshinator],
   expansion: Expansion.Dragonflight,
@@ -63,3 +64,5 @@ export default {
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };
+
+export default config;

--- a/src/analysis/retail/deathknight/blood/CONFIG.tsx
+++ b/src/analysis/retail/deathknight/blood/CONFIG.tsx
@@ -11,8 +11,8 @@ export default {
   contributors: [Yajinni, joshinator],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0',
-  isPartial: false,
+  patchCompatibility: '10.0.7',
+  isPartial: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (

--- a/src/analysis/retail/deathknight/frost/CONFIG.tsx
+++ b/src/analysis/retail/deathknight/frost/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Khazak],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.7',
+  patchCompatibility: '10.1.0',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/deathknight/frost/CONFIG.tsx
+++ b/src/analysis/retail/deathknight/frost/CONFIG.tsx
@@ -1,10 +1,11 @@
 import { Khazak } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
+import Config from 'parser/Config';
 
 import CHANGELOG from './CHANGELOG';
 
-export default {
+const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Khazak],
   expansion: Expansion.Dragonflight,
@@ -63,3 +64,5 @@ export default {
   path: __dirname,
   guideDefault: true,
 };
+
+export default config;

--- a/src/analysis/retail/deathknight/unholy/CONFIG.tsx
+++ b/src/analysis/retail/deathknight/unholy/CONFIG.tsx
@@ -1,10 +1,11 @@
 import { AlexanderJKremer, Khazak, Bicepspump } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
+import Config from 'parser/Config';
 
 import CHANGELOG from './CHANGELOG';
 
-export default {
+const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Khazak, AlexanderJKremer, Bicepspump],
   expansion: Expansion.Dragonflight,
@@ -69,3 +70,5 @@ export default {
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };
+
+export default config;

--- a/src/analysis/retail/deathknight/unholy/CONFIG.tsx
+++ b/src/analysis/retail/deathknight/unholy/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Khazak, AlexanderJKremer, Bicepspump],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.5',
+  patchCompatibility: '10.1.0',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/demonhunter/havoc/CONFIG.tsx
+++ b/src/analysis/retail/demonhunter/havoc/CONFIG.tsx
@@ -10,7 +10,7 @@ const CONFIG: Config = {
   contributors: [ToppleTheNun],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.7',
+  patchCompatibility: '10.1.0',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/demonhunter/vengeance/CONFIG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CONFIG.tsx
@@ -17,7 +17,7 @@ const config: Config = {
   contributors: [ToppleTheNun],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.7',
+  patchCompatibility: '10.1.0',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/druid/balance/CONFIG.tsx
+++ b/src/analysis/retail/druid/balance/CONFIG.tsx
@@ -1,10 +1,11 @@
 import { Hartra344, Sref } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
+import Config from 'parser/Config';
 
 import CHANGELOG from './CHANGELOG';
 
-export default {
+const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Sref, Hartra344],
   expansion: Expansion.Dragonflight,
@@ -60,3 +61,5 @@ export default {
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };
+
+export default config;

--- a/src/analysis/retail/druid/feral/CONFIG.tsx
+++ b/src/analysis/retail/druid/feral/CONFIG.tsx
@@ -9,7 +9,7 @@ export default {
   contributors: [Sref],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.7',
+  patchCompatibility: '10.1.0',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/druid/feral/CONFIG.tsx
+++ b/src/analysis/retail/druid/feral/CONFIG.tsx
@@ -1,10 +1,11 @@
 import { Sref } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
+import Config from 'parser/Config';
 
 import CHANGELOG from './CHANGELOG';
 
-export default {
+const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Sref],
   expansion: Expansion.Dragonflight,
@@ -50,3 +51,5 @@ export default {
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };
+
+export default config;

--- a/src/analysis/retail/druid/guardian/CONFIG.tsx
+++ b/src/analysis/retail/druid/guardian/CONFIG.tsx
@@ -1,10 +1,11 @@
 import { Sref } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
+import Config from 'parser/Config';
 
 import CHANGELOG from './CHANGELOG';
 
-export default {
+const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Sref],
   expansion: Expansion.Dragonflight,
@@ -54,3 +55,5 @@ export default {
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };
+
+export default config;

--- a/src/analysis/retail/druid/guardian/CONFIG.tsx
+++ b/src/analysis/retail/druid/guardian/CONFIG.tsx
@@ -9,7 +9,7 @@ export default {
   contributors: [Sref],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.7',
+  patchCompatibility: '10.1.0',
   isPartial: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/druid/restoration/CONFIG.tsx
+++ b/src/analysis/retail/druid/restoration/CONFIG.tsx
@@ -1,10 +1,11 @@
 import { Sref } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
+import Config from 'parser/Config';
 
 import CHANGELOG from './CHANGELOG';
 
-export default {
+const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Sref],
   expansion: Expansion.Dragonflight,
@@ -45,3 +46,5 @@ export default {
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };
+
+export default config;

--- a/src/analysis/retail/druid/restoration/CONFIG.tsx
+++ b/src/analysis/retail/druid/restoration/CONFIG.tsx
@@ -9,7 +9,7 @@ export default {
   contributors: [Sref],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.7',
+  patchCompatibility: '10.1.0',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/evoker/devastation/CONFIG.tsx
+++ b/src/analysis/retail/evoker/devastation/CONFIG.tsx
@@ -1,10 +1,11 @@
 import { Tyndi, Vireve } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
+import Config from 'parser/Config';
 
 import CHANGELOG from './CHANGELOG';
 
-export default {
+const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Vireve, Tyndi],
   expansion: Expansion.Dragonflight,
@@ -43,3 +44,5 @@ export default {
   path: __dirname,
   guideDefault: true,
 };
+
+export default config;

--- a/src/analysis/retail/evoker/preservation/CONFIG.tsx
+++ b/src/analysis/retail/evoker/preservation/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Trevor, Vohrr],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.7',
+  patchCompatibility: '10.1.0',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/evoker/preservation/CONFIG.tsx
+++ b/src/analysis/retail/evoker/preservation/CONFIG.tsx
@@ -1,10 +1,11 @@
 import { Trevor, Vohrr } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
+import Config from 'parser/Config';
 
 import CHANGELOG from './CHANGELOG';
 
-export default {
+const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Trevor, Vohrr],
   expansion: Expansion.Dragonflight,
@@ -38,3 +39,5 @@ export default {
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };
+
+export default config;

--- a/src/analysis/retail/mage/arcane/CONFIG.tsx
+++ b/src/analysis/retail/mage/arcane/CONFIG.tsx
@@ -1,10 +1,11 @@
 import { Sharrq, Dambroda, SyncSubaru } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
+import Config from 'parser/Config';
 
 import CHANGELOG from './CHANGELOG';
 
-export default {
+const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Sharrq, Dambroda, SyncSubaru],
   expansion: Expansion.Dragonflight,
@@ -59,3 +60,5 @@ export default {
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };
+
+export default config;

--- a/src/analysis/retail/mage/fire/CONFIG.tsx
+++ b/src/analysis/retail/mage/fire/CONFIG.tsx
@@ -1,10 +1,11 @@
 import { Sharrq } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
+import Config from 'parser/Config';
 
 import CHANGELOG from './CHANGELOG';
 
-export default {
+const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Sharrq],
   expansion: Expansion.Dragonflight,
@@ -47,3 +48,5 @@ export default {
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };
+
+export default config;

--- a/src/analysis/retail/mage/fire/CONFIG.tsx
+++ b/src/analysis/retail/mage/fire/CONFIG.tsx
@@ -9,7 +9,7 @@ export default {
   contributors: [Sharrq],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.5',
+  patchCompatibility: '10.1.0',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/mage/frost/CONFIG.tsx
+++ b/src/analysis/retail/mage/frost/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Sharrq],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.5',
+  patchCompatibility: '10.1.0',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more. If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (

--- a/src/analysis/retail/monk/brewmaster/CONFIG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CONFIG.tsx
@@ -9,7 +9,7 @@ export default {
   contributors: [emallson],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.7',
+  patchCompatibility: '10.1.0',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/monk/brewmaster/CONFIG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CONFIG.tsx
@@ -1,10 +1,11 @@
 import { emallson } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
+import Config from 'parser/Config';
 
 import CHANGELOG from './CHANGELOG';
 
-export default {
+const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [emallson],
   expansion: Expansion.Dragonflight,
@@ -61,3 +62,5 @@ export default {
   //This will also default to the guide
   guideOnly: true,
 };
+
+export default config;

--- a/src/analysis/retail/monk/mistweaver/CONFIG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CONFIG.tsx
@@ -9,7 +9,7 @@ const config: Config = {
   contributors: [Trevor, Vohrr],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.7',
+  patchCompatibility: '10.1.0',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/paladin/holy/CONFIG.tsx
+++ b/src/analysis/retail/paladin/holy/CONFIG.tsx
@@ -11,7 +11,7 @@ import CHANGELOG from './CHANGELOG';
 const config: Config = {
   contributors: [CamClark],
   expansion: Expansion.Dragonflight,
-  patchCompatibility: '10.0.0',
+  patchCompatibility: '10.1.0',
   isPartial: true,
   description: (
     <>

--- a/src/analysis/retail/priest/discipline/CONFIG.tsx
+++ b/src/analysis/retail/priest/discipline/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Hana],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.1',
+  patchCompatibility: '10.1.0',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/priest/shadow/CONFIG.tsx
+++ b/src/analysis/retail/priest/shadow/CONFIG.tsx
@@ -1,10 +1,11 @@
 import { DoxAshe } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
+import Config from 'parser/Config';
 
 import CHANGELOG from './CHANGELOG';
 
-export default {
+const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [DoxAshe],
   expansion: Expansion.Dragonflight,
@@ -55,3 +56,5 @@ export default {
   //The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };
+
+export default config;

--- a/src/analysis/retail/rogue/assassination/CONFIG.tsx
+++ b/src/analysis/retail/rogue/assassination/CONFIG.tsx
@@ -9,7 +9,7 @@ export default {
   contributors: [ToppleTheNun],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.7',
+  patchCompatibility: '10.1.0',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/rogue/assassination/CONFIG.tsx
+++ b/src/analysis/retail/rogue/assassination/CONFIG.tsx
@@ -3,8 +3,9 @@ import SPECS from 'game/SPECS';
 import { ToppleTheNun } from 'CONTRIBUTORS';
 
 import CHANGELOG from './CHANGELOG';
+import Config from 'parser/Config';
 
-export default {
+const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [ToppleTheNun],
   expansion: Expansion.Dragonflight,
@@ -46,3 +47,5 @@ export default {
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };
+
+export default config;

--- a/src/analysis/retail/rogue/outlaw/CONFIG.tsx
+++ b/src/analysis/retail/rogue/outlaw/CONFIG.tsx
@@ -4,8 +4,9 @@ import { AlertWarning } from 'interface';
 import { Anty } from 'CONTRIBUTORS';
 
 import CHANGELOG from './CHANGELOG';
+import Config from 'parser/Config';
 
-export default {
+const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Anty],
   expansion: Expansion.Dragonflight,
@@ -46,3 +47,5 @@ export default {
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };
+
+export default config;

--- a/src/analysis/retail/rogue/subtlety/CONFIG.tsx
+++ b/src/analysis/retail/rogue/subtlety/CONFIG.tsx
@@ -2,8 +2,9 @@ import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import CHANGELOG from './CHANGELOG';
 import { Anty } from 'CONTRIBUTORS';
+import Config from 'parser/Config';
 
-export default {
+const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Anty],
   expansion: Expansion.Dragonflight,
@@ -44,3 +45,5 @@ export default {
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };
+
+export default config;

--- a/src/analysis/retail/warrior/fury/CONFIG.tsx
+++ b/src/analysis/retail/warrior/fury/CONFIG.tsx
@@ -1,10 +1,11 @@
 import { Listefano, Tyndi } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
+import Config from 'parser/Config';
 
 import CHANGELOG from './CHANGELOG';
 
-export default {
+const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Tyndi, Listefano],
   expansion: Expansion.Dragonflight,
@@ -43,3 +44,5 @@ export default {
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };
+
+export default config;

--- a/src/game/VERSIONS.ts
+++ b/src/game/VERSIONS.ts
@@ -3,7 +3,7 @@ import Expansion from './Expansion';
 // The current version of the game. Used to check spec patch compatibility and as a caching key.
 const VERSIONS: Partial<{ [expansion in Expansion]: string }> = {
   [Expansion.WrathOfTheLichKing]: '3.4.0',
-  [Expansion.Dragonflight]: '10.0.7',
+  [Expansion.Dragonflight]: '10.1.0',
 };
 
 export default VERSIONS;

--- a/src/parser/Config.ts
+++ b/src/parser/Config.ts
@@ -23,6 +23,11 @@ export type Build = {
 };
 export type Builds = { [name: string]: Build };
 
+type VaultPatchCycle = `0.${0 | 2 | 5 | 7}`;
+type AberrusPatchCycle = `1.${0 | 5}`;
+export type DragonflightPatchVersion = `10.${VaultPatchCycle | AberrusPatchCycle}`;
+export type WrathPatchVersion = `3.4.0`;
+
 interface Config {
   /**
    * The people that have contributed to this spec recently. People don't have
@@ -36,7 +41,7 @@ interface Config {
   /**
    * The WoW client patch this spec is compatible with.
    */
-  patchCompatibility: null | '10.0.0' | '10.0.2' | '10.0.5' | '10.0.7' | string;
+  patchCompatibility: null | DragonflightPatchVersion | WrathPatchVersion;
   /**
    * Whether support for the spec is only partial and some important elements
    * are still missing. Note: you do not need to support every possible


### PR DESCRIPTION
### Description

This sets the default game version to 10.1 for retail WoW and bumps the supported versions for the following specs:

- Havoc DH
- Veng DH
- MW Monk
- BrM Monk
- Assa Rogue
- Fire Mage
- Frost Mage
- Feral Druid
- Resto Druid
- Guardian Druid
