### PR TITLE
[Resto Shaman] Add Tier 30 module and bump resto to 10.1.0

### DIFF
--- a/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Arlie, Fassbrause, niseko, Vetyst, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 5, 1), <>Added Tier 30 module</>, Vohrr),
   change(date(2023, 5, 1), <> Updated <SpellLink id={TALENTS.EARTH_SHIELD_TALENT.id}/> to show talent contribution breakdown</>, Vohrr),
   change(date(2023, 4, 30), <>Added <SpellLink id={TALENTS.FLOW_OF_THE_TIDES_TALENT.id}/> module</>, Vohrr),
   change(date(2023, 3, 16), <>Fixed <SpellLink id={TALENTS.ANCESTRAL_VIGOR_TALENT.id}/> to work for each talent rank</>, Vohrr),

--- a/src/analysis/retail/shaman/restoration/CONFIG.tsx
+++ b/src/analysis/retail/shaman/restoration/CONFIG.tsx
@@ -12,7 +12,7 @@ const CONFIG: Config = {
   contributors: [niseko, Arlie, Vohrr],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.7',
+  patchCompatibility: '10.1.0',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/shaman/restoration/CombatLogParser.tsx
+++ b/src/analysis/retail/shaman/restoration/CombatLogParser.tsx
@@ -64,6 +64,8 @@ import EarthShieldBreakdown from './modules/features/EarthShieldBreakdown';
 import EarthenHarmony from './modules/talents/EarthenHarmony';
 import ElementalOrbit from '../shared/talents/ElementalOrbit';
 import SurgingShields from '../shared/talents/SurgingShields';
+import Tier30 from './modules/dragonflight/Tier30';
+import Tier30Normalizer from './normalizers/Tier30Normalizer';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -141,6 +143,10 @@ class CombatLogParser extends CoreCombatLogParser {
     chainHealNormalizer: ChainHealNormalizer,
     riptideTracker: RiptideTracker,
     riptideAttributor: RiptideAttributor,
+
+    //Tier Sets
+    tier30: Tier30,
+    tier30Normalizer: Tier30Normalizer,
   };
 }
 

--- a/src/analysis/retail/shaman/restoration/modules/dragonflight/Tier30.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/dragonflight/Tier30.tsx
@@ -1,0 +1,240 @@
+import ITEMS from 'common/ITEMS';
+import SPELLS from 'common/SPELLS';
+import talents from 'common/TALENTS/shaman';
+import { TIERS } from 'game/TIERS';
+import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
+import { calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
+import Events, { CastEvent, HealEvent } from 'parser/core/Events';
+import {
+  getSwellingRainHealingWaves,
+  getTidewatersHealingEvents,
+} from '../../normalizers/Tier30Normalizer';
+import ChainHealNormalizer from '../../normalizers/ChainHealNormalizer';
+import { SHAMAN_T30_ID } from 'common/ITEMS/dragonflight';
+import { SpellLink } from 'interface';
+import ItemSetLink from 'interface/ItemSetLink';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import Statistic from 'parser/ui/Statistic';
+import { formatNumber, formatPercentage } from 'common/format';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import { CAST_BUFFER_MS } from '../../constants';
+
+const TIER_4PC_RAINSTORM_PER_STACK = 0.01;
+const TIER_4PC_SWELLING_RAIN_CHAINHEAL_PER_STACK = 0.02;
+const TIER_4PC_SWELLING_RAIN_HSHW_PER_STACK = 0.1;
+const debug = false;
+/**
+ * **Resto Shaman T30 (Aberrus)**
+ *
+ * 2pc: When you cast Healing Rain, each ally with your Riptide on them is area healed by Tidewaters for (175% of Spell power).
+ *
+ * 4pc: Each ally healed by Tidewaters increases your healing done by 1% for 6 sec and increases the healing of your next Healing Wave or Healing Surge by 10%,
+ *      or your next Chain Heal by 2%.
+ */
+
+export default class Tier30 extends Analyzer {
+  static dependencies = {
+    chainHealNormalizer: ChainHealNormalizer,
+  };
+  chainHealNormalizer!: ChainHealNormalizer;
+  has4pc: boolean;
+  tidewatersHealing: number = 0;
+  tidewatersOverheal: number = 0;
+  current4pcStacks: number = 0;
+  rainstormHealing: number = 0;
+  swellingRainHealingSurge: number = 0;
+  swellingRainHealingWave: number = 0;
+  swellingRainChainheal: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.has2PieceByTier(TIERS.T30);
+    this.has4pc = this.selectedCombatant.has4PieceByTier(TIERS.T30);
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(talents.HEALING_RAIN_TALENT),
+      this.onHealingRainCast,
+    );
+    this.addEventListener(
+      Events.heal.by(SELECTED_PLAYER).spell(ITEMS.T30_TIDEWATERS_HEAL),
+      this.on2pcHeal,
+    );
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER | SELECTED_PLAYER_PET), this.on4pcHeal);
+    this.addEventListener(
+      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.HEALING_SURGE),
+      this.handleHealingSurge,
+    );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(talents.HEALING_WAVE_TALENT),
+      this.handleHealingWave,
+    );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(talents.CHAIN_HEAL_TALENT),
+      this.handleChainHeal,
+    );
+  }
+
+  get twoPieceOverhealPercent() {
+    return formatPercentage(
+      this.tidewatersOverheal / (this.tidewatersHealing + this.tidewatersOverheal),
+    );
+  }
+
+  get fourPieceTotalHealing() {
+    return (
+      this.swellingRainChainheal +
+      this.swellingRainHealingSurge +
+      this.swellingRainHealingWave +
+      this.rainstormHealing
+    );
+  }
+
+  onHealingRainCast(event: CastEvent) {
+    //apparently these 'stacks' for each buff don't appear in logs so we have to manually tally the number of tidewaters hits to know how potent our current buff is
+    this.current4pcStacks = getTidewatersHealingEvents(event).length;
+  }
+
+  on2pcHeal(event: HealEvent) {
+    this.tidewatersHealing += event.amount + (event.absorbed || 0);
+    this.tidewatersOverheal += event.overheal || 0;
+  }
+
+  on4pcHeal(event: HealEvent) {
+    if (!this.selectedCombatant.hasBuff(ITEMS.T30_RAINSTORM_BUFF.id)) {
+      return;
+    }
+    const healIncrease = this.current4pcStacks * TIER_4PC_RAINSTORM_PER_STACK;
+    this.rainstormHealing += calculateEffectiveHealing(event, healIncrease);
+  }
+
+  handleHealingWave(event: CastEvent) {
+    if (
+      !this.selectedCombatant.hasBuff(
+        ITEMS.T30_SWELLING_RAIN_BUFF.id,
+        event.timestamp,
+        CAST_BUFFER_MS,
+      )
+    ) {
+      return;
+    }
+    const healIncrease = this.current4pcStacks * TIER_4PC_SWELLING_RAIN_HSHW_PER_STACK;
+    const swellingRainHealingWaves = getSwellingRainHealingWaves(event);
+    debug && console.log('healing wave', swellingRainHealingWaves, healIncrease);
+    if (swellingRainHealingWaves.length > 0) {
+      this.swellingRainHealingWave += this._tallyHealingIncrease(
+        swellingRainHealingWaves,
+        healIncrease,
+      );
+      debug && console.log(this.swellingRainHealingWave);
+    }
+  }
+
+  handleHealingSurge(event: HealEvent) {
+    if (
+      !this.selectedCombatant.hasBuff(
+        ITEMS.T30_SWELLING_RAIN_BUFF.id,
+        event.timestamp,
+        CAST_BUFFER_MS,
+      )
+    ) {
+      return;
+    }
+    const healIncrease = this.current4pcStacks * TIER_4PC_SWELLING_RAIN_HSHW_PER_STACK;
+    this.swellingRainHealingSurge += calculateEffectiveHealing(event, healIncrease);
+  }
+
+  handleChainHeal(event: CastEvent) {
+    if (
+      !this.selectedCombatant.hasBuff(
+        ITEMS.T30_SWELLING_RAIN_BUFF.id,
+        event.timestamp,
+        CAST_BUFFER_MS,
+      )
+    ) {
+      return;
+    }
+    const healIncrease = this.current4pcStacks * TIER_4PC_SWELLING_RAIN_CHAINHEAL_PER_STACK;
+    const orderedChainHeal = this.chainHealNormalizer.normalizeChainHealOrder(event);
+    debug && console.log('chain heal: ', orderedChainHeal, healIncrease);
+    if (orderedChainHeal.length > 0) {
+      this.swellingRainChainheal += this._tallyHealingIncrease(orderedChainHeal, healIncrease);
+      debug && console.log(this.swellingRainChainheal);
+    }
+  }
+
+  private _tallyHealingIncrease(events: HealEvent[], healIncrease: number): number {
+    if (events.length > 0) {
+      return events.reduce(
+        (amount, event) => amount + calculateEffectiveHealing(event, healIncrease),
+        0,
+      );
+    }
+    return 0;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        size="flexible"
+        position={STATISTIC_ORDER.OPTIONAL(0)}
+        category={STATISTIC_CATEGORY.ITEMS}
+        tooltip={
+          <>
+            <ul>
+              <li>
+                <SpellLink id={ITEMS.T30_TIDEWATERS_HEAL.id} />:{' '}
+                <strong>{formatNumber(this.tidewatersHealing)}</strong> (
+                {this.twoPieceOverhealPercent}% Overheal)
+              </li>
+              {this.has4pc && (
+                <>
+                  <li>
+                    <SpellLink id={ITEMS.T30_RAINSTORM_BUFF.id} />:{' '}
+                    <strong>{formatNumber(this.rainstormHealing)}</strong>
+                  </li>
+                  <SpellLink id={ITEMS.T30_SWELLING_RAIN_BUFF.id} />:
+                  <li>
+                    <SpellLink id={talents.HEALING_WAVE_TALENT.id} />:{' '}
+                    <strong>{formatNumber(this.swellingRainHealingWave)}</strong>
+                  </li>
+                  <li>
+                    <SpellLink id={talents.CHAIN_HEAL_TALENT.id} />:{' '}
+                    <strong>{formatNumber(this.swellingRainChainheal)}</strong>
+                  </li>
+                  <li>
+                    <SpellLink id={SPELLS.HEALING_SURGE.id} />:{' '}
+                    <strong>{formatNumber(this.swellingRainHealingSurge)}</strong>
+                  </li>
+                </>
+              )}
+            </ul>
+          </>
+        }
+      >
+        <div className="pad boring-text">
+          <label>
+            <ItemSetLink id={SHAMAN_T30_ID}>
+              <>
+                Runes of the Cinderwolf
+                <br />
+                (Aberrus Tier)
+              </>
+            </ItemSetLink>
+          </label>
+          <div className="value">
+            <h4>2 Piece</h4>
+            <ItemHealingDone amount={this.tidewatersHealing} />
+          </div>
+          <hr />
+          {this.has4pc && (
+            <div className="value">
+              <h4>4 Piece</h4>
+              <ItemHealingDone amount={this.fourPieceTotalHealing} />
+            </div>
+          )}
+        </div>
+      </Statistic>
+    );
+  }
+}

--- a/src/analysis/retail/shaman/restoration/modules/dragonflight/Tier30.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/dragonflight/Tier30.tsx
@@ -20,9 +20,9 @@ import { formatNumber, formatPercentage } from 'common/format';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
 import { CAST_BUFFER_MS } from '../../constants';
 
-const TIER_4PC_RAINSTORM_PER_STACK = 0.01;
-const TIER_4PC_SWELLING_RAIN_CHAINHEAL_PER_STACK = 0.02;
-const TIER_4PC_SWELLING_RAIN_HSHW_PER_STACK = 0.1;
+const RAINSTORM_PER_STACK = 0.01;
+const SWELLING_RAIN_CHAINHEAL_PER_STACK = 0.02;
+const SWELLING_RAIN_HSHW_PER_STACK = 0.1;
 const debug = false;
 /**
  * **Resto Shaman T30 (Aberrus)**
@@ -104,7 +104,7 @@ export default class Tier30 extends Analyzer {
     if (!this.selectedCombatant.hasBuff(ITEMS.T30_RAINSTORM_BUFF.id)) {
       return;
     }
-    const healIncrease = this.current4pcStacks * TIER_4PC_RAINSTORM_PER_STACK;
+    const healIncrease = this.current4pcStacks * RAINSTORM_PER_STACK;
     this.rainstormHealing += calculateEffectiveHealing(event, healIncrease);
   }
 
@@ -118,7 +118,7 @@ export default class Tier30 extends Analyzer {
     ) {
       return;
     }
-    const healIncrease = this.current4pcStacks * TIER_4PC_SWELLING_RAIN_HSHW_PER_STACK;
+    const healIncrease = this.current4pcStacks * SWELLING_RAIN_HSHW_PER_STACK;
     const swellingRainHealingWaves = getSwellingRainHealingWaves(event);
     debug && console.log('healing wave', swellingRainHealingWaves, healIncrease);
     if (swellingRainHealingWaves.length > 0) {
@@ -140,7 +140,7 @@ export default class Tier30 extends Analyzer {
     ) {
       return;
     }
-    const healIncrease = this.current4pcStacks * TIER_4PC_SWELLING_RAIN_HSHW_PER_STACK;
+    const healIncrease = this.current4pcStacks * SWELLING_RAIN_HSHW_PER_STACK;
     this.swellingRainHealingSurge += calculateEffectiveHealing(event, healIncrease);
   }
 
@@ -154,7 +154,7 @@ export default class Tier30 extends Analyzer {
     ) {
       return;
     }
-    const healIncrease = this.current4pcStacks * TIER_4PC_SWELLING_RAIN_CHAINHEAL_PER_STACK;
+    const healIncrease = this.current4pcStacks * SWELLING_RAIN_CHAINHEAL_PER_STACK;
     const orderedChainHeal = this.chainHealNormalizer.normalizeChainHealOrder(event);
     debug && console.log('chain heal: ', orderedChainHeal, healIncrease);
     if (orderedChainHeal.length > 0) {
@@ -164,13 +164,10 @@ export default class Tier30 extends Analyzer {
   }
 
   private _tallyHealingIncrease(events: HealEvent[], healIncrease: number): number {
-    if (events.length > 0) {
-      return events.reduce(
-        (amount, event) => amount + calculateEffectiveHealing(event, healIncrease),
-        0,
-      );
-    }
-    return 0;
+    return events.reduce(
+      (amount, event) => amount + calculateEffectiveHealing(event, healIncrease),
+      0,
+    );
   }
 
   statistic() {
@@ -218,7 +215,7 @@ export default class Tier30 extends Analyzer {
               <>
                 Runes of the Cinderwolf
                 <br />
-                (Aberrus Tier)
+                (T30 Tier Set)
               </>
             </ItemSetLink>
           </label>

--- a/src/analysis/retail/shaman/restoration/normalizers/Tier30Normalizer.ts
+++ b/src/analysis/retail/shaman/restoration/normalizers/Tier30Normalizer.ts
@@ -1,0 +1,93 @@
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import {
+  CastEvent,
+  EventType,
+  GetRelatedEvents,
+  HasRelatedEvent,
+  HealEvent,
+} from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+import talents from 'common/TALENTS/shaman';
+import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS';
+import { TIERS } from 'game/TIERS';
+import { CAST_BUFFER_MS, PWAVE_TRAVEL_MS } from '../constants';
+
+/*
+  This file is for normalizing event links the various events to the two buffs associated with Resto Shamans Tier 30 set bonus
+  Mainly needed because of primordial wave healing waves latency, the others can use this.selectedCombatant.hasBuff()
+  */
+const SWELLING_RAIN_REMOVE = 'Swelling Rain Removed';
+const SWELLING_RAIN_HEALING_WAVE = 'Swelling Rain Healing Rain';
+const TIDEWATERS_HEAL = 'Tidewaters Heal';
+const EVENT_LINKS: EventLink[] = [
+  {
+    linkRelation: SWELLING_RAIN_REMOVE,
+    reverseLinkRelation: SWELLING_RAIN_REMOVE,
+    linkingEventId: [ITEMS.T30_SWELLING_RAIN_BUFF.id],
+    linkingEventType: [EventType.RemoveBuff],
+    referencedEventId: [
+      talents.HEALING_WAVE_TALENT.id,
+      SPELLS.HEALING_SURGE.id,
+      talents.CHAIN_HEAL_TALENT.id,
+    ],
+    referencedEventType: [EventType.Cast],
+    backwardBufferMs: 255,
+    forwardBufferMs: 255,
+    anyTarget: true,
+    isActive(c) {
+      return c.has4PieceByTier(TIERS.T30);
+    },
+  },
+  {
+    linkRelation: SWELLING_RAIN_HEALING_WAVE,
+    reverseLinkRelation: SWELLING_RAIN_HEALING_WAVE,
+    linkingEventId: [talents.HEALING_WAVE_TALENT.id],
+    linkingEventType: [EventType.Heal],
+    referencedEventId: [talents.HEALING_WAVE_TALENT.id],
+    referencedEventType: [EventType.Cast],
+    backwardBufferMs: PWAVE_TRAVEL_MS,
+    forwardBufferMs: CAST_BUFFER_MS,
+    anyTarget: true,
+    isActive(c) {
+      return c.has4PieceByTier(TIERS.T30);
+    },
+    additionalCondition(linkingEvent, referencedEvent) {
+      return (
+        HasRelatedEvent(referencedEvent, SWELLING_RAIN_REMOVE) &&
+        (linkingEvent as HealEvent).ability.guid === (referencedEvent as CastEvent).ability.guid
+      );
+    },
+  },
+  {
+    linkRelation: TIDEWATERS_HEAL,
+    reverseLinkRelation: TIDEWATERS_HEAL,
+    linkingEventId: [ITEMS.T30_TIDEWATERS_HEAL.id],
+    linkingEventType: [EventType.Heal],
+    referencedEventId: [talents.HEALING_RAIN_TALENT.id],
+    referencedEventType: [EventType.Cast],
+    backwardBufferMs: CAST_BUFFER_MS,
+    forwardBufferMs: CAST_BUFFER_MS,
+    anyTarget: true,
+    isActive(c) {
+      return c.has2PieceByTier(TIERS.T30);
+    },
+  },
+];
+
+export default class Tier30Normalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_LINKS);
+  }
+}
+
+export function getSwellingRainHealingWaves(event: CastEvent): HealEvent[] {
+  if (!HasRelatedEvent(event, SWELLING_RAIN_REMOVE)) {
+    return [];
+  }
+  return GetRelatedEvents(event, SWELLING_RAIN_HEALING_WAVE) as HealEvent[];
+}
+
+export function getTidewatersHealingEvents(event: CastEvent): HealEvent[] {
+  return GetRelatedEvents(event, TIDEWATERS_HEAL) as HealEvent[];
+}

--- a/src/common/ITEMS/shaman.ts
+++ b/src/common/ITEMS/shaman.ts
@@ -6,6 +6,21 @@ const items = itemIndexableList({
   //region Elemental
   //endregion
   //region Restoration
+  T30_TIDEWATERS_HEAL: {
+    id: 409354,
+    name: 'Tidewaters',
+    icon: 'ability_mage_waterjet',
+  },
+  T30_RAINSTORM_BUFF: {
+    id: 409386,
+    name: 'Rainstorm',
+    icon: 'ability_mage_waterjet',
+  },
+  T30_SWELLING_RAIN_BUFF: {
+    id: 409391,
+    name: 'Swelling Rain',
+    icon: 'spell_frost_wisp',
+  },
   //endregion
   //region Shared
   //endregion


### PR DESCRIPTION
### Description

Added Tier 30 module for resto shaman 
`https://www.wowhead.com/ptr/item-set=1550/runes-of-the-cinderwolf`
Testing log used: `https://www.warcraftlogs.com/reports/jxP7gka8fJ1m6WQF`
### Screenshot(s):
![image](https://user-images.githubusercontent.com/26779541/235575211-a85a8464-098e-429c-922c-ef37da9af317.png)
![image](https://user-images.githubusercontent.com/26779541/235575234-cd24f542-3171-4c40-982a-2af870cfb02f.png)
