### PR TITLE
Windwalker: fix checklist error when using chi wave

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -17,12 +17,14 @@ import {
   Vireve,
   Pilsung,
   HerzBlutRaffy,
-  Abelito75
+  Abelito75,
+  awiss
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 5, 2), 'Fixed a bug in WW reports with Chi Wave talented', awiss),
   change(date(2023, 5, 2), 'Bumped game version to 10.1', emallson),
   change(date(2023, 4, 24), 'Add ability to filter M+ analysis by dungeon pulls.', ToppleTheNun),
   change(date(2023, 4, 24), 'Additions and updates for Classic Potions (guide and checklist).', jazminite),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -17,14 +17,12 @@ import {
   Vireve,
   Pilsung,
   HerzBlutRaffy,
-  Abelito75,
-  awiss
+  Abelito75
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
-  change(date(2023, 5, 2), 'Fixed a bug in WW reports with Chi Wave talented', awiss),
   change(date(2023, 5, 2), 'Bumped game version to 10.1', emallson),
   change(date(2023, 4, 24), 'Add ability to filter M+ analysis by dungeon pulls.', ToppleTheNun),
   change(date(2023, 4, 24), 'Additions and updates for Classic Potions (guide and checklist).', jazminite),

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2138,3 +2138,8 @@ export const attluh: Contributor = {
   github: 'attluh',
   discord: 'attluh#3373',
 };
+export const awiss: Contributor = {
+  nickname: 'awiss',
+  github: 'awiss',
+  discord: 'dubya#6711',
+};

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2138,8 +2138,8 @@ export const attluh: Contributor = {
   github: 'attluh',
   discord: 'attluh#3373',
 };
-export const awiss: Contributor = {
-  nickname: 'awiss',
+export const Tenooki: Contributor = {
+  nickname: 'Tenooki',
   github: 'awiss',
   discord: 'dubya#6711',
 };

--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -1,9 +1,10 @@
 import { change, date } from 'common/changelog';
 import talents from 'common/TALENTS/monk';
-import { Durpn, Hursti } from 'CONTRIBUTORS';
+import { Durpn, Hursti, Tenooki } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 5, 2), 'Fixed a bug in WW reports with Chi Wave talented', Tenooki),
   change(date(2023, 2, 13), <>Initial APL Added</>, Durpn),
   change(date(2022, 1, 15), <>Clean up Changelog and Include <SpellLink id={talents.INNER_PEACE_TALENT.id} /> to the Energycap</>, Hursti),
   change(date(2022, 1, 14), <>Initial Update for Dragonflight</>, Durpn),

--- a/src/analysis/retail/monk/windwalker/modules/Abilities.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/Abilities.tsx
@@ -76,7 +76,7 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.CHI_WAVE_TALENT_DAMAGE.id,
+        spell: TALENTS_MONK.CHI_WAVE_TALENT.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         cooldown: 15,
         gcd: {


### PR DESCRIPTION
### Description

I encountered this error during development when I attempted to load a log where I had chi wave talented.
```
Error: GenericCastEfficiencyRequirement requires that you pass the castEfficiency object yourself. Spell: 115098
    at get thresholds [as thresholds] (http://localhost:3000/static/js/src_parser_retail_modules_features_Checklist_PreparationRule_tsx-src_parser_shared_modules_fe-65291a.chunk.js:288:76)
    at GenericCastEfficiencyRequirement.render (http://localhost:3000/static/js/src_parser_retail_modules_features_Checklist_PreparationRule_tsx-src_parser_shared_modules_fe-65291a.chunk.js:333:29)
    at finishClassComponent (http://localhost:3000/static/js/bundle.js:157697:35)
    at updateClassComponent (http://localhost:3000/static/js/bundle.js:157650:28)
    at beginWork (http://localhost:3000/static/js/bundle.js:159235:20)
    at HTMLUnknownElement.callCallback (http://localhost:3000/static/js/bundle.js:144200:18)
    at Object.invokeGuardedCallbackDev (http://localhost:3000/static/js/bundle.js:144249:20)
    at invokeGuardedCallback (http://localhost:3000/static/js/bundle.js:144309:35)
    at beginWork$1 (http://localhost:3000/static/js/bundle.js:164051:11)
    at performUnitOfWork (http://localhost:3000/static/js/bundle.js:162887:16)
```

My fix is changing the spell ID in Abilities.tsx from `SPELLS.CHI_WAVE_TALENT_DAMAGE.id` to `TALENTS_MONK.CHI_WAVE_TALENT.id`.

Not 100% sure if this is the right fix or if I'm missing something here but it does resolve the error and the checklist counts the casts correctly.

### Testing

This report errors on the `dragonflight` branch, does not on this branch.

- Test report URL: `/report/vkb8nPmxa1BNKq6t/3-Heroic+Terros+-+Kill+(3:34)/Tenooki/standard/overview`
- Screenshot(s):
