### PR TITLE
[Resto Shaman] More guide updates

### DIFF
--- a/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Arlie, Fassbrause, niseko, Vetyst, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 5, 4), <>Fixed bug with <SpellLink spell={TALENTS.EARTH_SHIELD_TALENT}/> uptime segments on the guide. Added <SpellLink spell={TALENTS.UNLEASH_LIFE_TALENT}/> cast entry row, reformatted <SpellLink spell={TALENTS.PRIMORDIAL_WAVE_TALENT}/> module for visual consistency</>, Vohrr),
   change(date(2023, 5, 4), <>Add <SpellLink spell={TALENTS.EARTH_SHIELD_TALENT}/> uptime to core section of the Guide</>, Vohrr),
   change(date(2023, 5, 3), <><SpellLink spell={TALENTS.EARTHEN_HARMONY_TALENT}/> code review cleanup</>, Vohrr),
   change(date(2023, 5, 3), <>Fixed a bug with <SpellLink spell={TALENTS.EARTHEN_HARMONY_TALENT}/> not calculating the damage mitigated from <SpellLink spell={TALENTS.EARTH_SHIELD_TALENT}/> that were applied pre-pull</>, Vohrr),

--- a/src/analysis/retail/shaman/restoration/modules/talents/EarthenHarmony.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/talents/EarthenHarmony.tsx
@@ -79,6 +79,10 @@ class EarthenHarmony extends Analyzer {
     );
   }
 
+  get totalDamageReduction() {
+    return this.earthShielddamageReduced + this.elementalOrbitDamageReduced;
+  }
+
   onEarthShieldApply(event: ApplyBuffEvent) {
     if (event.ability.guid === talents.EARTH_SHIELD_TALENT.id) {
       this.eSApply = event.timestamp;

--- a/src/analysis/retail/shaman/restoration/modules/talents/PrimordialWave.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/talents/PrimordialWave.tsx
@@ -16,7 +16,6 @@ import {
 import RiptideTracker from '../core/RiptideTracker';
 import DonutChart from 'parser/ui/DonutChart';
 import { SpellLink, TooltipElement } from 'interface';
-import BoringValue from 'parser/ui/BoringValueText';
 import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
 import WarningIcon from 'interface/icons/Warning';
 import CheckmarkIcon from 'interface/icons/Checkmark';
@@ -27,6 +26,7 @@ import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
 import { GapHighlight } from 'parser/ui/CooldownBar';
 import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
 import ITEMS from 'common/ITEMS';
+import TalentSpellText from 'parser/ui/TalentSpellText';
 
 class PrimordialWave extends Analyzer {
   static dependencies = {
@@ -237,13 +237,7 @@ class PrimordialWave extends Analyzer {
           </>
         }
       >
-        <div className="pad">
-          <label>
-            <SpellLink id={TALENTS.PRIMORDIAL_WAVE_TALENT} /> Breakdown
-          </label>
-          {this.renderPrimoridalWaveChart()}
-        </div>
-        <BoringValue label="">
+        <TalentSpellText talent={TALENTS.PRIMORDIAL_WAVE_TALENT}>
           <ItemHealingDone amount={this.totalHealing} />
           <br />
           <TooltipElement
@@ -258,7 +252,14 @@ class PrimordialWave extends Analyzer {
             {this.buffIcon} {this.wastedBuffs}
             <small> wasted buffs</small>
           </TooltipElement>
-        </BoringValue>
+        </TalentSpellText>
+        <aside className="pad">
+          <hr />
+          <header>
+            <label>Breakdown of Primordial Wave Healing</label>
+          </header>
+          {this.renderPrimoridalWaveChart()}
+        </aside>
       </Statistic>
     );
   }

--- a/src/analysis/retail/shaman/restoration/modules/talents/UnleashLife.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/talents/UnleashLife.tsx
@@ -634,7 +634,9 @@ class UnleashLife extends Analyzer {
         from the potent buff it provides that can be consumed by a number of different abilities.
         This spell is best used in preparation for incoming damage to combo with one of your
         stronger abilities like a <SpellLink id={TALENTS.HIGH_TIDE_TALENT} />
-        -buffed <SpellLink id={TALENTS.CHAIN_HEAL_TALENT} /> or{' '}
+        -buffed <SpellLink id={TALENTS.CHAIN_HEAL_TALENT} />, a{' '}
+        <SpellLink spell={TALENTS.PRIMORDIAL_WAVE_TALENT} />
+        -buffed <SpellLink spell={TALENTS.HEALING_WAVE_TALENT} />, or{' '}
         <SpellLink id={TALENTS.HEALING_RAIN_TALENT} />
       </p>
     );

--- a/src/analysis/retail/shaman/restoration/modules/talents/UnleashLife.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/talents/UnleashLife.tsx
@@ -55,6 +55,8 @@ import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
 import { GapHighlight } from 'parser/ui/CooldownBar';
 import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
+import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 
 const debug = false;
 
@@ -150,6 +152,11 @@ class UnleashLife extends Analyzer {
   lastUlSpellId: number = -1;
   lastRemoved: number = -1;
 
+  //guide vars
+  castEntries: BoxRowEntry[] = [];
+  goodSpells: number[] = [];
+  okSpells: number[] = [];
+
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS.UNLEASH_LIFE_TALENT);
@@ -191,6 +198,15 @@ class UnleashLife extends Analyzer {
       Events.removebuff.by(SELECTED_PLAYER).spell(TALENTS.UNLEASH_LIFE_TALENT),
       this._onRemoveUL,
     );
+    this.goodSpells.push(TALENTS.HEALING_RAIN_TALENT.id);
+    if (this.pwaveActive) {
+      this.goodSpells.push(TALENTS.HEALING_WAVE_TALENT.id);
+    }
+    if (this.selectedCombatant.hasTalent(TALENTS.HIGH_TIDE_TALENT)) {
+      this.goodSpells.push(TALENTS.CHAIN_HEAL_TALENT.id);
+    } else {
+      this.okSpells.push(TALENTS.CHAIN_HEAL_TALENT.id);
+    }
   }
   //necessary because riptide can be spellqued into the spell that actually consumed UL and event linking will match both
   _wasAlreadyConsumed(event: CastEvent | HealEvent) {
@@ -215,6 +231,7 @@ class UnleashLife extends Analyzer {
     const spellId = event.ability.guid;
     if (isBuffedByUnleashLife(event) && !this._wasAlreadyConsumed(event)) {
       this.healingMap[spellId].casts += 1;
+      this.tallyCastEntry(spellId);
       debug &&
         console.log(
           'Unleash Life ' +
@@ -251,6 +268,7 @@ class UnleashLife extends Analyzer {
       return;
     }
     this.wastedBuffs += 1;
+    this.tallyCastEntry(-1);
   }
 
   private _onWellspring(event: AbsorbedEvent) {
@@ -260,6 +278,7 @@ class UnleashLife extends Analyzer {
   private _onHealingSurge(event: HealEvent) {
     const castEvent = getCastEvent(event);
     if (castEvent && isBuffedByUnleashLife(castEvent)) {
+      this.tallyCastEntry(event.ability.guid);
       this.healingMap[event.ability.guid].amount += calculateEffectiveHealing(
         event,
         UNLEASH_LIFE_HEALING_INCREASE,
@@ -288,6 +307,7 @@ class UnleashLife extends Analyzer {
     //we use initial hit heal event here instead of cast because primordial wave riptide can also consume UL
     if (isBuffedByUnleashLife(event) && !this._wasAlreadyConsumed(event)) {
       this.healingMap[spellId].casts += 1;
+      this.tallyCastEntry(spellId);
       debug &&
         console.log(
           'Unleash Life ' +
@@ -335,6 +355,7 @@ class UnleashLife extends Analyzer {
   }
 
   private _onHealingWave(event: CastEvent) {
+    const spellId = event.ability.guid;
     const ulHealingWaves = getUnleashLifeHealingWaves(event);
     if (ulHealingWaves.length > 0) {
       //if used in combo with pwave, tally healing separately
@@ -352,7 +373,7 @@ class UnleashLife extends Analyzer {
         );
       }
       //tally subtotal regardless
-      this.healingMap[event.ability.guid].amount += this._tallyHealingIncrease(
+      this.healingMap[spellId].amount += this._tallyHealingIncrease(
         ulHealingWaves,
         UNLEASH_LIFE_HEALING_INCREASE,
       );
@@ -648,7 +669,13 @@ class UnleashLife extends Analyzer {
             <SpellLink id={TALENTS.UNLEASH_LIFE_TALENT} /> cast efficiency
           </strong>
           <div className="flex-main chart" style={{ padding: 15 }}>
-            {this.guideSubStatistic()}
+            {this.guideSubStatistic()} <br />
+            <strong>Casts </strong>
+            <small>
+              - Green indicates a good use of the <SpellLink spell={TALENTS.UNLEASH_LIFE_TALENT} />{' '}
+              buff, Yellow indicates an ok use, and Red is an incorrect use or the buff expired.
+            </small>
+            <PerformanceBoxRow values={this.castEntries} />
           </div>
         </RoundedPanel>
       </div>
@@ -666,6 +693,42 @@ class UnleashLife extends Analyzer {
         minimizeIcons
       />
     );
+  }
+
+  tallyCastEntry(spellId: number) {
+    let value = null;
+    let tooltip = null;
+    if (this.goodSpells.includes(spellId)) {
+      value = QualitativePerformance.Good;
+      tooltip = (
+        <>
+          Correct cast: buffed <SpellLink id={spellId} />
+        </>
+      );
+    } else if (this.okSpells.includes(spellId)) {
+      value = QualitativePerformance.Ok;
+      tooltip = (
+        <>
+          Ok cast: buffed <SpellLink id={spellId} />
+        </>
+      );
+    } else {
+      value = QualitativePerformance.Fail;
+      tooltip = (
+        <>
+          Incorrect cast:{' '}
+          {spellId === -1 ? (
+            <>Unused Buff!</>
+          ) : (
+            <>
+              {' '}
+              buffed <SpellLink id={spellId} />
+            </>
+          )}
+        </>
+      );
+    }
+    this.castEntries.push({ value, tooltip });
   }
 
   subStatistic() {

--- a/src/analysis/retail/shaman/shared/talents/EarthShield.tsx
+++ b/src/analysis/retail/shaman/shared/talents/EarthShield.tsx
@@ -129,8 +129,8 @@ class EarthShield extends Analyzer {
         <b>
           <SpellLink id={TALENTS_SHAMAN.EARTH_SHIELD_TALENT.id} />
         </b>{' '}
-        is the only shield shaman can place on allies and provides very strong
-        throughput when combined with affecting talents in the class and spec tree.{' '}
+        is the only shield shaman can place on allies and provides very strong throughput when
+        combined with affecting talents in the class and spec tree.{' '}
         <SpellLink id={TALENTS_SHAMAN.EARTH_SHIELD_TALENT.id} /> should be applied prior to the
         fight starting and maintained as it falls off throughout the encounter
         <br />

--- a/src/analysis/retail/shaman/shared/talents/EarthShield.tsx
+++ b/src/analysis/retail/shaman/shared/talents/EarthShield.tsx
@@ -129,7 +129,7 @@ class EarthShield extends Analyzer {
         <b>
           <SpellLink id={TALENTS_SHAMAN.EARTH_SHIELD_TALENT.id} />
         </b>{' '}
-        is the only shield shaman has that can be placed on allies and provides very strong
+        is the only shield shaman can place on allies and provides very strong
         throughput when combined with affecting talents in the class and spec tree.{' '}
         <SpellLink id={TALENTS_SHAMAN.EARTH_SHIELD_TALENT.id} /> should be applied prior to the
         fight starting and maintained as it falls off throughout the encounter

--- a/src/analysis/retail/shaman/shared/talents/EarthShield.tsx
+++ b/src/analysis/retail/shaman/shared/talents/EarthShield.tsx
@@ -1,4 +1,4 @@
-import { formatPercentage } from 'common/format';
+import { formatNumber, formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_SHAMAN } from 'common/TALENTS';
 import { SpellLink } from 'interface';
@@ -16,6 +16,7 @@ import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../restoration/Guide';
 import uptimeBarSubStatistic from 'parser/ui/UptimeBarSubStatistic';
 import { Uptime } from 'parser/ui/UptimeBar';
 import { RESTORATION_COLORS } from '../../restoration/constants';
+import EarthenHarmony from '../../restoration/modules/talents/EarthenHarmony';
 
 export const EARTHSHIELD_HEALING_INCREASE = 0.2;
 
@@ -23,10 +24,12 @@ class EarthShield extends Analyzer {
   static dependencies = {
     combatants: Combatants,
     elementalOrbit: ElementalOrbit,
+    earthenHarmony: EarthenHarmony,
   };
 
   protected combatants!: Combatants;
   protected elementalOrbit!: ElementalOrbit;
+  protected earthenHarmony!: EarthenHarmony;
 
   healing = 0;
   buffHealing = 0;
@@ -147,8 +150,13 @@ class EarthShield extends Analyzer {
               <SpellLink id={TALENTS_SHAMAN.EARTHEN_HARMONY_TALENT.id} />
             </b>{' '}
             augments <SpellLink id={TALENTS_SHAMAN.EARTH_SHIELD_TALENT.id} /> even further by
-            providing damage reduction (TODO METRIC HERE FOR DAMAGE REDUCED)
-            <br />
+            providing damage reduction
+            <br />(
+            <b>
+              {formatNumber(this.earthenHarmony.totalDamageReduction)} was mitigated from{' '}
+              <SpellLink id={TALENTS_SHAMAN.EARTHEN_HARMONY_TALENT.id} />
+            </b>
+            )
           </>
         )}
       </>
@@ -174,8 +182,8 @@ class EarthShield extends Analyzer {
     let current: Uptime;
     Object.values(this.combatants.players).forEach((player) => {
       player.getBuffHistory(spellId, this.owner.playerId).forEach((trackedBuff) => {
-        console.log(trackedBuff);
-        current = { start: trackedBuff.start, end: trackedBuff.end! };
+        const end = trackedBuff.end ? trackedBuff.end : this.owner.fight.end_time;
+        current = { start: trackedBuff.start, end: end };
         uptimeHistory.push(current);
       });
     });


### PR DESCRIPTION
### Description

Fixed a bug with the uptime segments for earth shield when the fight ended with the buff active
Added damage mitigated metric to earth shield guide blurb when earthen harmony is talented
Added performance box row metric for unleash life
Reformatted Primordial Wave module for visual consistency

### Screenshot(s):
New guide sections:
![image](https://user-images.githubusercontent.com/26779541/236314009-3104ecdf-01fd-4a2c-9d0c-39effb15f2b5.png)
PWave Before: 
![image](https://user-images.githubusercontent.com/26779541/236314226-f81a50b8-ff25-44ec-a8e0-70f005179fe3.png)
After:
![image](https://user-images.githubusercontent.com/26779541/236314089-83e1d920-f509-4999-a727-724ad7f2c800.png)

