### PR TITLE
add 10.1 patch info

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -23,6 +23,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 5, 4), 'Add 10.1 patch.', ToppleTheNun),
   change(date(2023, 5, 2), 'Bumped game version to 10.1', emallson),
   change(date(2023, 4, 24), 'Add ability to filter M+ analysis by dungeon pulls.', ToppleTheNun),
   change(date(2023, 4, 24), 'Additions and updates for Classic Potions (guide and checklist).', jazminite),

--- a/src/interface/report/PATCHES.ts
+++ b/src/interface/report/PATCHES.ts
@@ -125,6 +125,14 @@ const PATCHES: Patch[] = [
     name: '10.0.7',
     timestamp: 1679436000000, // GMT: Tuesday, 21 March 2023 22:00:00
     urlPrefix: '',
+    isCurrent: false,
+    gameVersion: 1, // retail
+    expansion: Expansion.Dragonflight,
+  },
+  {
+    name: '10.1.0',
+    timestamp: 1683064800000, // GMT: Tuesday, 2 May 2023 22:00:00
+    urlPrefix: '',
     isCurrent: true,
     gameVersion: 1, // retail
     expansion: Expansion.Dragonflight,


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Add 10.1 patch info, which will mark reports from older patches as being out of date.
