### PR TITLE
[Stats] Update Leech to 10.1 values

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -23,6 +23,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 5, 8), 'Update leech rating per 1% to 10.1 values', Putro),
   change(date(2023, 5, 5), 'Fix Playwright tests.', ToppleTheNun),
   change(date(2023, 5, 4), 'Add 10.1 patch.', ToppleTheNun),
   change(date(2023, 5, 2), 'Bumped game version to 10.1', emallson),

--- a/src/parser/shared/modules/StatTracker.ts
+++ b/src/parser/shared/modules/StatTracker.ts
@@ -136,7 +136,6 @@ class StatTracker extends Analyzer {
 
   //Values taken from https://github.com/simulationcraft/simc/blob/dragonflight/engine/dbc/generated/sc_scale_data.inc
   statBaselineRatingPerPercent = {
-    //TODO Update to level 70 values once DF has launched as we will need the old values during prepatch
     /** Secondaries */
     [STAT.CRITICAL_STRIKE]: 180,
     [STAT.HASTE]: 170,
@@ -144,7 +143,7 @@ class StatTracker extends Analyzer {
     [STAT.VERSATILITY]: 205,
     /** Tertiaries */
     [STAT.AVOIDANCE]: 72,
-    [STAT.LEECH]: 110,
+    [STAT.LEECH]: 148,
     [STAT.SPEED]: 50,
   };
 


### PR DESCRIPTION
### Description

As per 10.1 patch
Leech rating now gives 25% less Leech stat.
Developers’ note: Leech is proving to be a very strong sustain stat in Dragonflight. To keep it at an appropriate level of power, and avoid marginalizing the importance of the Healer role to a group’s survival, we are reducing the value of Leech rating by 25%. Leech percent granted by talents remains unchanged.
