### PR TITLE
[Resto Shaman] Fix Flow of the Tides Module

### DIFF
--- a/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Arlie, Fassbrause, niseko, Vetyst, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 5, 8), <><SpellLink spell={TALENTS.FLOW_OF_THE_TIDES_TALENT}/> fix to tally additional hit healing regardless of riptides being consumed.</>, Vohrr),
   change(date(2023, 5, 4), <>Fixed bug with <SpellLink spell={TALENTS.EARTH_SHIELD_TALENT}/> uptime segments on the guide. Added <SpellLink spell={TALENTS.UNLEASH_LIFE_TALENT}/> cast entry row, reformatted <SpellLink spell={TALENTS.PRIMORDIAL_WAVE_TALENT}/> module for visual consistency</>, Vohrr),
   change(date(2023, 5, 4), <>Add <SpellLink spell={TALENTS.EARTH_SHIELD_TALENT}/> uptime to core section of the Guide</>, Vohrr),
   change(date(2023, 5, 3), <><SpellLink spell={TALENTS.EARTHEN_HARMONY_TALENT}/> code review cleanup</>, Vohrr),

--- a/src/analysis/retail/shaman/restoration/modules/talents/FlowOfTheTides.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/talents/FlowOfTheTides.tsx
@@ -47,6 +47,7 @@ class FlowOfTheTides extends Analyzer {
   riptideEnd: number = 0;
   lostRiptides: number = 0;
   lostRiptideDuration: number = 0;
+  healIncrease: number = 0;
 
   constructor(options: Options) {
     super(options);
@@ -71,13 +72,15 @@ class FlowOfTheTides extends Analyzer {
   }
 
   onChainHeal(event: CastEvent) {
-    if (!wasRiptideConsumed(event)) {
-      return;
+    this.healIncrease = 0;
+    if (wasRiptideConsumed(event)) {
+      this.healIncrease = FLOW_OF_THE_TIDES_INCREASE;
+      if (this.chainHealTarget === event.targetID) {
+        this.lostRiptideDuration += this.riptideEnd - event.timestamp;
+      }
+      this.lostRiptides += 1;
     }
-    if (this.chainHealTarget === event.targetID) {
-      this.lostRiptideDuration += this.riptideEnd - event.timestamp;
-    }
-    this.lostRiptides += 1;
+
     let expectedTargetCount = this.maxTargets;
     let index = -1;
     if (this.ulActive && this.unleashLife._isBuffedByUnleashLife(event)) {
@@ -126,7 +129,7 @@ class FlowOfTheTides extends Analyzer {
       debug && console.log('Extra Hit: ', extraHit, index);
     }
     this.bonusHealing += events.reduce(
-      (amount, event) => amount + calculateEffectiveHealing(event, FLOW_OF_THE_TIDES_INCREASE),
+      (amount, event) => amount + calculateEffectiveHealing(event, this.healIncrease),
       0,
     );
   }


### PR DESCRIPTION
### Description

Fixed flow of the tides to track healing from extra bounces regardless of riptide being consumed per the talent's functionality

