### PR TITLE
[Prevoker] fix in emerald communion part of guide

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { ToppleTheNun, Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 5, 8), <>Fix bug in guide for <SpellLink spell={TALENTS_EVOKER.EMERALD_COMMUNION_TALENT}/> checks</>, Trevor),
   change(date(2023, 5, 6), <>Add complete version of guide</>, Trevor),
   change(date(2023, 5, 6), <>Add basic guide</>, Trevor),
   change(date(2023, 4, 27), <>Change load conditions for <SpellLink spell={TALENTS_EVOKER.REVERSION_TALENT}/> efficiency bar</>, Trevor),

--- a/src/analysis/retail/evoker/preservation/modules/talents/EmeraldCommunion.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/EmeraldCommunion.tsx
@@ -68,6 +68,9 @@ class EmeraldCommunion extends Analyzer {
   }
 
   onAlly(event: ApplyBuffEvent | RefreshBuffEvent | HealEvent) {
+    if (!this.combatants.getEntity(event)) {
+      return;
+    }
     this.potentialEchoTargets.set(event.targetID, event.timestamp);
   }
 

--- a/src/analysis/retail/evoker/preservation/modules/talents/Lifebind.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/Lifebind.tsx
@@ -11,10 +11,15 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import { SPELL_COLORS } from '../../constants';
 import { getHealForLifebindHeal } from '../../normalizers/CastLinkNormalizer';
+import Combatants from 'parser/shared/modules/Combatants';
 
 class Lifebind extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
   healingBySpell: Map<number, number> = new Map<number, number>();
   curNumLifebinds: number = 0;
+  protected combatants!: Combatants;
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS_EVOKER.LIFEBIND_TALENT);
@@ -39,6 +44,9 @@ class Lifebind extends Analyzer {
   }
 
   onApply(event: ApplyBuffEvent) {
+    if (!this.combatants.getEntity(event)) {
+      return;
+    }
     this.curNumLifebinds += 1;
   }
 

--- a/src/analysis/retail/evoker/preservation/modules/talents/Stasis.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/Stasis.tsx
@@ -390,7 +390,7 @@ class Stasis extends Analyzer {
               content={
                 <>
                   <SpellLink spell={TALENTS_EVOKER.SPIRITBLOOM_TALENT} /> is not a high value spell
-                  to store when not doing an{' '}
+                  to store when doing an{' '}
                   <SpellLink spell={TALENTS_EVOKER.EMERALD_COMMUNION_TALENT} /> ramp as it
                   interferes by consuming <SpellLink spell={TALENTS_EVOKER.ECHO_TALENT} /> buffs.
                 </>


### PR DESCRIPTION
### Description

We were counting pets when tracking number of lifebinds, which is not something we want to do

### Testing
Before
![image](https://user-images.githubusercontent.com/11250934/237010042-94aa2a88-1444-4a9c-8f58-04a8a5c4dc17.png)
After
![image](https://user-images.githubusercontent.com/11250934/237010093-94121b38-ff9a-44a3-908f-e16625dc98a0.png)

