### PR TITLE
(WW): Remove pandemic window from Faeline Stomp APL

### DIFF
--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { Durpn, Hursti, Tenooki } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 5, 9), <>Adjusted Faeline Stomp in APL</>, Tenooki),
   change(date(2023, 5, 3), <>Updated Serenity/Non-Serenity APls, cooldown/ability tracking improvements</>, Tenooki),
   change(date(2023, 5, 3), <>Fixes to cooldown tracking on various abilities</>, Tenooki),
   change(date(2023, 5, 2), <>Fixed a bug in WW reports with Chi Wave talented</>, Tenooki),

--- a/src/analysis/retail/monk/windwalker/CONFIG.tsx
+++ b/src/analysis/retail/monk/windwalker/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Durpn, Tenooki],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: null,
+  patchCompatibility: '10.1.0',
   isPartial: true,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/monk/windwalker/CONFIG.tsx
+++ b/src/analysis/retail/monk/windwalker/CONFIG.tsx
@@ -1,4 +1,4 @@
-import { Durpn } from 'CONTRIBUTORS';
+import { Durpn, Tenooki } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import Config from 'parser/Config';
@@ -7,7 +7,7 @@ import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Durpn],
+  contributors: [Durpn, Tenooki],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
   patchCompatibility: null,

--- a/src/analysis/retail/monk/windwalker/modules/apl/AplCheck.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/apl/AplCheck.tsx
@@ -36,11 +36,7 @@ const andNotSerenity = (cond: Condition<any>) => {
 
 const needsFaelineHarmony = and(
   hasTalent(TALENTS.FAELINE_HARMONY_TALENT),
-  buffMissing(SPELLS.FAELINE_HARMONY_BUFF, {
-    duration: 10000,
-    timeRemaining: 2000,
-    pandemicCap: 1,
-  }),
+  buffMissing(SPELLS.FAELINE_HARMONY_BUFF),
 );
 
 inSerenity.describe = (tense) => '';


### PR DESCRIPTION
### Description

On second thought I realized this pandemic window isn't appropriate, if you can cast any time when the debuff is up its better to just do your dps cast and apply the debuff again next global.

Also updated WW config, set patch to 10.1


### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/f6AtKD1y8Pg9Vwmc/29-Normal+Magmorax+-+Kill+(3:06)/Tenooki/standard`
- Screenshot(s):
