### PR TITLE
Add RSK check to yulon celestial analysis

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 5, 6), <>Added check for casting <SpellLink spell={TALENTS_MONK.RISING_SUN_KICK_TALENT}/> during <SpellLink spell={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT}/></>, Trevor),
   change(date(2023, 5, 6), <>Added additional analysis to the <SpellLink spell={TALENTS_MONK.DANCING_MISTS_TALENT}/> module.</>, Vohrr),
   change(date(2023, 5, 5), <>Added per-stack breakdowns for each spell affected in the <SpellLink spell={TALENTS_MONK.CLOUDED_FOCUS_TALENT}/> module.</>, Vohrr),
   change(date(2023, 5, 2), <>Re-enable <SpellLink id={TALENTS_MONK.LIFE_COCOON_TALENT.id}/> module and add Cast Efficieny subsection to the Guide</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
@@ -152,6 +152,7 @@ class InvokeChiJi extends BaseCelestialAnalyzer {
       totalEnvM: 0,
       averageHaste: 0,
       deathTimestamp: 0,
+      castRsk: false,
     });
   }
 

--- a/src/analysis/retail/monk/mistweaver/modules/spells/InvokeYulon.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/InvokeYulon.tsx
@@ -66,6 +66,7 @@ class InvokeYulon extends BaseCelestialAnalyzer {
       numEfHots: this.ef.curBuffs,
       recastEf: false,
       deathTimestamp: 0,
+      castRsk: false,
     });
   }
 
@@ -141,7 +142,7 @@ class InvokeYulon extends BaseCelestialAnalyzer {
         s.
       </p>
     );
-    /* Disabled for 10.1 sinec we will want to use TFT at the end of the ramp to ensure 4pc */
+    /* Disabled for 10.1 since we will want to use TFT at the end of the ramp to ensure 4pc */
     /* <ul>
           <li>
             If <SpellLink id={TALENTS_MONK.SECRET_INFUSION_TALENT} /> talented, use{' '}
@@ -169,6 +170,12 @@ class InvokeYulon extends BaseCelestialAnalyzer {
             allPerfs.push(rval[0]);
             checklistItems.push(rval[1]);
           }
+          if (this.selectedCombatant.hasTalent(TALENTS_MONK.RISING_MIST_TALENT)) {
+            const rval = this.getRskCastPerfAndItem(cast);
+            allPerfs.push(rval[0]);
+            checklistItems.push(rval[1]);
+          }
+
           const avgPerf = getAveragePerf(allPerfs);
           return (
             <CooldownExpandable

--- a/src/parser/ui/QualitativePerformance.ts
+++ b/src/parser/ui/QualitativePerformance.ts
@@ -33,10 +33,10 @@ export function getAveragePerf(perfs: QualitativePerformance[]) {
   const orderArr = perfs.map((perf) => {
     return order.indexOf(perf);
   });
-  orderArr.forEach((idx) => {
-    total += orderArr[idx];
+  orderArr.forEach((i) => {
+    total += i;
   });
-  const average = Math.round(total / orderArr.length);
+  const average = Math.floor(total / orderArr.length);
   return order[average];
 }
 


### PR DESCRIPTION
### Description

Checks that player casts RSK during yulon to extend hots
Also fixes bug in getAveragePerf

### Testing

![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/f38d9c29-3dd3-4ca9-be3b-9cae9b71774b)
