### PR TITLE
handle negative stat values in StatTracker

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -23,6 +23,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 5, 17), 'Fix issue with negative Haste values.', emallson),
   change(date(2023, 5, 11), 'Fix multi-rank talent tooltip links.', ToppleTheNun),
   change(date(2023, 5, 10), 'Add Classic Character Thumbnails to PlayerSelection page.', jazminite),
   change(date(2023, 5, 10), 'Speed up e2e tests.', ToppleTheNun),

--- a/src/parser/shared/modules/StatTracker.ts
+++ b/src/parser/shared/modules/StatTracker.ts
@@ -588,6 +588,13 @@ class StatTracker extends Analyzer {
         //We are at the maximum % so we use the maximum scaled value and multiply it by the coefficient
         return penaltyThresholds[penaltyThresholds.length - 1].scaled * coef;
       }
+    } else if (baselinePercent < 0) {
+      // if we have negative stat (yes, that has been observed in the wild), we use the knowledge that there are no penalties to take the easy path
+      if (returnRatingForNextPercent) {
+        return baselineRatingPerPercent;
+      } else {
+        return baselinePercent;
+      }
     }
     // TODO surely there's a prettier way than an indexed for loop
     //Loop through each of our penaltythresholds until we find the first one where we have more baseline stats than that curvepoint


### PR DESCRIPTION
This fixes a crash when you have negative stat values (such as haste), which has been observed on this log: https://wowanalyzer.com/report/yM16hbc7qazmLDV2/1-Heroic+Kazzara,+the+Hellforged+-+Kill+(3:42)