### PR TITLE
Fixed an issue where Relentless Predator values werent updated for 10.1

### DIFF
--- a/src/analysis/retail/druid/feral/constants.ts
+++ b/src/analysis/retail/druid/feral/constants.ts
@@ -64,7 +64,7 @@ export const TIGERS_FURY_BOOSTED: Spell[] = [
 /** Multiplier to energy costs from having Incarnation: Avatar of Ashamane active */
 export const INCARN_ENERGY_MULT = 0.8;
 /** Multiplier to Ferocious Bite's energy cost and drain from the Relentless Predator talent */
-export const RELENTLESS_PREDATOR_FB_ENERGY_MULT = 0.6;
+export const RELENTLESS_PREDATOR_FB_ENERGY_MULT = 0.8;
 
 /** Shred's energy cost (before modifiers) */
 export const SHRED_ENERGY = 40;

--- a/src/analysis/retail/druid/feral/modules/spells/FerociousBite.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/FerociousBite.tsx
@@ -68,7 +68,7 @@ class FerociousBite extends Analyzer {
       (this.selectedCombatant.hasBuff(TALENTS_DRUID.INCARNATION_AVATAR_OF_ASHAMANE_TALENT.id)
         ? INCARN_ENERGY_MULT
         : 1);
-    const usedMax = extraEnergyUsed === maxExtraEnergy;
+    const usedMax = extraEnergyUsed >= maxExtraEnergy;
 
     if (!duringBerserkAndSotf && usedMax) {
       event.meta = event.meta || {};

--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { TALENTS_DRUID } from 'common/TALENTS';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2023, 5, 17), <>Fixed an issue where the <SpellLink id={TALENTS_DRUID.RELENTLESS_PREDATOR_TALENT.id}/> value wasn't updated for 10.1</>, Sref),
   change(date(2023, 5, 4), <>Updated T30 (Aberrus) set to account for April 28 patch.</>, Sref),
   change(date(2023, 3, 30), <>Updated T30 (Aberrus) set to account for March 28 patch.</>, Sref),
   change(date(2023, 3, 20), <>Added support for T30 (Aberrus) set statistics, check it out with your PTR logs!</>, Sref),


### PR DESCRIPTION
### Description

Unupdated value

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/..](https://www.warcraftlogs.com/reports/D6gnAmr3TNpF8QhJ/#type=summary&fight=40&source=26`
