### PR TITLE
add support for Unbound Chaos

### DIFF
--- a/src/analysis/retail/demonhunter/havoc/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/havoc/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import SHARED_CHANGELOG from 'analysis/retail/demonhunter/shared/CHANGELOG';
 
 // prettier-ignore
 export default [
+  change(date(2023, 4, 20), <>Add support for <SpellLink spell={TALENTS.UNBOUND_CHAOS_TALENT}/>.</>, ToppleTheNun),
   change(date(2023, 4, 6), <>Fix ordering of abilities in <SpellLink spell={TALENTS.ESSENCE_BREAK_TALENT} /> window.</>, ToppleTheNun),
   change(date(2023, 3, 16), <>Add tooltip explaining <SpellLink spell={TALENTS.BLIND_FURY_TALENT} />'s contribution to Fury waste.</>, ToppleTheNun),
   change(date(2023, 3, 12), <>Add <SpellLink spell={TALENTS.MOMENTUM_TALENT} /> to rotation section.</>, ToppleTheNun),

--- a/src/analysis/retail/demonhunter/havoc/CombatLogParser.tsx
+++ b/src/analysis/retail/demonhunter/havoc/CombatLogParser.tsx
@@ -62,6 +62,8 @@ import TheHuntVengefulRetreatNormalizer from './normalizers/TheHuntVengefulRetre
 import FuriousGazeNormalizer from './normalizers/FuriousGazeNormalizer';
 import { EyeBeam } from './modules/talents/EyeBeam';
 import { ThrowGlaive } from './modules/spells/ThrowGlaive';
+import UnboundChaosNormalizer from './normalizers/UnboundChaosNormalizer';
+import UnboundChaos from './modules/talents/UnboundChaos';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -77,6 +79,7 @@ class CombatLogParser extends CoreCombatLogParser {
     theHuntNormalizer: TheHuntNormalizer,
     theHuntVengefulRetreatNormalizer: TheHuntVengefulRetreatNormalizer,
     furiousGazeEventLinkNormalizer: FuriousGazeNormalizer,
+    unboundChaosNormalizer: UnboundChaosNormalizer,
 
     // Features
     alwaysBeCasting: AlwaysBeCasting,
@@ -130,6 +133,7 @@ class CombatLogParser extends CoreCombatLogParser {
     disruptingFury: DisruptingFury,
     fodderToTheFlame: FodderToTheFlame,
     eyeBeam: EyeBeam,
+    unboundChaos: UnboundChaos,
 
     // Resources
     furyTracker: FuryTracker,

--- a/src/analysis/retail/demonhunter/havoc/Guide.tsx
+++ b/src/analysis/retail/demonhunter/havoc/Guide.tsx
@@ -117,6 +117,7 @@ function RotationSection({ modules }: GuideProps<typeof CombatLogParser>) {
       <HideGoodCastsToggle id="hide-good-casts-rotations" />
       {modules.throwGlaive.guideSubsection()}
       {modules.momentum.guideSubsection()}
+      {modules.unboundChaos.guideSubsection()}
     </Section>
   );
 }

--- a/src/analysis/retail/demonhunter/havoc/constants.ts
+++ b/src/analysis/retail/demonhunter/havoc/constants.ts
@@ -2,7 +2,7 @@ export const CRITICAL_CHAOS_SCALING = [0, 0.25, 0.5];
 
 export const FELFIRE_HEART_SCALING = [0, 1, 2];
 
-export const UNBOUND_CHAOS_SCALING = [0, 2.5, 5];
+export const UNBOUND_CHAOS_SCALING = [0, 2, 4];
 
 export const BLIND_FURY_FURY_SCALING = [0, 20, 40];
 

--- a/src/analysis/retail/demonhunter/havoc/modules/Abilities.tsx
+++ b/src/analysis/retail/demonhunter/havoc/modules/Abilities.tsx
@@ -27,6 +27,10 @@ class Abilities extends SharedAbilities {
           extraSuggestion:
             'This is an important Fury generator spell. Try to always cast on cooldown, but beware to not waste the Fury generation it provides.',
         },
+        damageSpellIds: [
+          SPELLS.IMMOLATION_AURA_INITIAL_HIT_DAMAGE.id,
+          SPELLS.IMMOLATION_AURA_BUFF_DAMAGE.id,
+        ],
       },
       {
         spell: SPELLS.DEMONS_BITE.id,

--- a/src/analysis/retail/demonhunter/havoc/modules/talents/UnboundChaos.tsx
+++ b/src/analysis/retail/demonhunter/havoc/modules/talents/UnboundChaos.tsx
@@ -1,0 +1,222 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import SPELLS from 'common/SPELLS/demonhunter';
+import TALENTS from 'common/TALENTS/demonhunter';
+import Events, { ApplyBuffEvent, RefreshBuffEvent, RemoveBuffEvent } from 'parser/core/Events';
+import { getUnboundChaosConsumption } from 'analysis/retail/demonhunter/havoc/normalizers/UnboundChaosNormalizer';
+import { Uptime } from 'parser/ui/UptimeBar';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import { ReactNode } from 'react';
+import { SpellLink } from 'interface';
+import { formatPercentage } from 'common/format';
+import { UNBOUND_CHAOS_SCALING } from 'analysis/retail/demonhunter/havoc/constants';
+import { ChecklistUsageInfo, SpellUse } from 'parser/core/SpellUsage/core';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import HideGoodCastsSpellUsageSubSection from 'parser/core/SpellUsage/HideGoodCastsSpellUsageSubSection';
+import { logSpellUseEvent } from 'parser/core/SpellUsage/SpellUsageSubSection';
+import CastPerformanceSummary from 'analysis/retail/demonhunter/shared/guide/CastPerformanceSummary';
+import { combineQualitativePerformances } from 'common/combineQualitativePerformances';
+
+type UnboundChaosUptime = Uptime & {
+  event: ApplyBuffEvent | RefreshBuffEvent | RemoveBuffEvent;
+  consumed: boolean;
+};
+
+export default class UnboundChaos extends Analyzer {
+  private uses: SpellUse[] = [];
+  private uptime: UnboundChaosUptime[] = [];
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.UNBOUND_CHAOS_TALENT);
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.UNBOUND_CHAOS_BUFF),
+      this.onApplyBuff,
+    );
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.UNBOUND_CHAOS_BUFF),
+      this.onRefreshBuff,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.UNBOUND_CHAOS_BUFF),
+      this.onRemoveBuff,
+    );
+    this.addEventListener(Events.fightend, this.finalize);
+  }
+
+  guideSubsection(): JSX.Element | null {
+    if (!this.active) {
+      return null;
+    }
+
+    const explanation = (
+      <section>
+        <strong>
+          <SpellLink spell={TALENTS.UNBOUND_CHAOS_TALENT} />
+        </strong>{' '}
+        provides a{' '}
+        {formatPercentage(
+          UNBOUND_CHAOS_SCALING[this.selectedCombatant.getTalentRank(TALENTS.UNBOUND_CHAOS_TALENT)],
+          0,
+        )}
+        % damage increase to your next <SpellLink spell={SPELLS.FEL_RUSH_CAST} /> after casting{' '}
+        <SpellLink spell={SPELLS.IMMOLATION_AURA} />. You should ensure that every buff gets
+        consumed.
+      </section>
+    );
+
+    const goodCasts = this.uses.filter(
+      (it) => it.performance === QualitativePerformance.Good,
+    ).length;
+    const totalCasts = this.uses.length;
+
+    return (
+      <HideGoodCastsSpellUsageSubSection
+        title="Unbound Chaos"
+        explanation={explanation}
+        uses={this.uses}
+        castBreakdownSmallText={<> - Green is a good cast, Red is a bad cast.</>}
+        onPerformanceBoxClick={logSpellUseEvent}
+        abovePerformanceDetails={
+          <div style={{ marginBottom: 10 }}>
+            <CastPerformanceSummary
+              spell={TALENTS.UNBOUND_CHAOS_TALENT}
+              casts={goodCasts}
+              performance={QualitativePerformance.Good}
+              totalCasts={totalCasts}
+            />
+          </div>
+        }
+      />
+    );
+  }
+
+  statistic(): ReactNode {
+    const wastedProcs = this.uptime.reduce((acc, item) => acc + (item.consumed ? 0 : 1), 0);
+
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE(3)}
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
+      >
+        <TalentSpellText talent={TALENTS.UNBOUND_CHAOS_TALENT}>
+          {wastedProcs} wasted procs
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+
+  private onApplyBuff(event: ApplyBuffEvent) {
+    const uptime: UnboundChaosUptime = {
+      start: event.timestamp,
+      end: event.timestamp,
+      event: event,
+      consumed: false,
+    };
+
+    this.uptime.push(uptime);
+  }
+
+  private onRefreshBuff(event: RefreshBuffEvent) {
+    let oldUptime = this.uptime.at(-1);
+    if (!oldUptime) {
+      oldUptime = {
+        start: this.owner.fight.start_time,
+        end: event.timestamp,
+        event: event,
+        consumed: false,
+      };
+
+      this.uptime.push(oldUptime);
+    } else {
+      oldUptime.end = event.timestamp;
+      oldUptime.consumed = false;
+    }
+
+    const newUptime: UnboundChaosUptime = {
+      start: event.timestamp,
+      end: event.timestamp,
+      event: event,
+      consumed: false,
+    };
+
+    this.uptime.push(newUptime);
+  }
+
+  private onRemoveBuff(event: RemoveBuffEvent) {
+    const cast = getUnboundChaosConsumption(event);
+    let oldUptime = this.uptime.at(-1);
+    if (!oldUptime) {
+      oldUptime = {
+        start: this.owner.fight.start_time,
+        end: event.timestamp,
+        event: event,
+        consumed: Boolean(cast),
+      };
+
+      this.uptime.push(oldUptime);
+    } else {
+      oldUptime.end = event.timestamp;
+      oldUptime.consumed = Boolean(cast);
+    }
+  }
+
+  private finalize() {
+    // finalize uptime
+    const uptime = this.uptime.at(-1);
+    if (uptime && uptime.end === uptime.start) {
+      uptime.end = this.owner.fight.end_time;
+    }
+
+    // finalize performances
+    this.uses = this.uptime.map(this.unboundChaosUptimeToSpellUse);
+  }
+
+  private unboundChaosUptimeToSpellUse(unboundChaosUptime: UnboundChaosUptime): SpellUse {
+    const consumed = unboundChaosUptime.consumed;
+    const performance = consumed ? QualitativePerformance.Good : QualitativePerformance.Fail;
+    const summary = (
+      <div>
+        Consumed with <SpellLink spell={SPELLS.FEL_RUSH_CAST} />
+      </div>
+    );
+    const details = consumed ? (
+      <div>
+        You consumed your <SpellLink spell={TALENTS.UNBOUND_CHAOS_TALENT} /> buff by casting{' '}
+        <SpellLink spell={SPELLS.FEL_RUSH_CAST} />. Good job!
+      </div>
+    ) : (
+      <div>
+        You did not consume your <SpellLink spell={TALENTS.UNBOUND_CHAOS_TALENT} /> buff. Ensure
+        that every time you get <SpellLink spell={TALENTS.UNBOUND_CHAOS_TALENT} /> buff, you consume
+        it by casting <SpellLink spell={SPELLS.FEL_RUSH_CAST} />.
+      </div>
+    );
+
+    const checklistItems: ChecklistUsageInfo[] = [
+      {
+        check: 'consumption',
+        timestamp: unboundChaosUptime.start,
+        performance,
+        summary,
+        details,
+      },
+    ];
+    const actualPerformance = combineQualitativePerformances(
+      checklistItems.map((item) => item.performance),
+    );
+
+    return {
+      event: unboundChaosUptime.event,
+      performance: actualPerformance,
+      checklistItems,
+      performanceExplanation:
+        actualPerformance !== QualitativePerformance.Fail
+          ? `${actualPerformance} Usage`
+          : 'Bad Usage',
+    };
+  }
+}

--- a/src/analysis/retail/demonhunter/havoc/normalizers/UnboundChaosNormalizer.ts
+++ b/src/analysis/retail/demonhunter/havoc/normalizers/UnboundChaosNormalizer.ts
@@ -1,0 +1,62 @@
+import SPELLS from 'common/SPELLS/demonhunter';
+import {
+  ApplyBuffEvent,
+  CastEvent,
+  EventType,
+  GetRelatedEvents,
+  RefreshBuffEvent,
+  RemoveBuffEvent,
+} from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import TALENTS from 'common/TALENTS/demonhunter';
+
+const UNBOUND_CHAOS_BUFFER = 100;
+
+const UNBOUND_CHAOS_APPLICATION = 'UnboundChaosApplication';
+const UNBOUND_CHAOS_CONSUMPTION = 'UnboundChaosConsumption';
+
+const EVENT_LINKS: EventLink[] = [
+  {
+    linkRelation: UNBOUND_CHAOS_CONSUMPTION,
+    referencedEventId: SPELLS.FEL_RUSH_CAST.id,
+    referencedEventType: EventType.Cast,
+    linkingEventId: SPELLS.UNBOUND_CHAOS_BUFF.id,
+    linkingEventType: EventType.RemoveBuff,
+    forwardBufferMs: UNBOUND_CHAOS_BUFFER,
+    backwardBufferMs: UNBOUND_CHAOS_BUFFER,
+    anyTarget: true,
+    isActive: (c) => c.hasTalent(TALENTS.UNBOUND_CHAOS_TALENT),
+  },
+  {
+    linkRelation: UNBOUND_CHAOS_APPLICATION,
+    referencedEventId: SPELLS.IMMOLATION_AURA.id,
+    referencedEventType: EventType.Cast,
+    linkingEventId: SPELLS.UNBOUND_CHAOS_BUFF.id,
+    linkingEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+    forwardBufferMs: UNBOUND_CHAOS_BUFFER,
+    backwardBufferMs: UNBOUND_CHAOS_BUFFER,
+    anyTarget: true,
+    isActive: (c) => c.hasTalent(TALENTS.UNBOUND_CHAOS_TALENT),
+  },
+];
+
+export default class UnboundChaosNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_LINKS);
+  }
+}
+
+export function getUnboundChaosApplication(
+  event: ApplyBuffEvent | RefreshBuffEvent,
+): CastEvent | undefined {
+  return GetRelatedEvents(event, UNBOUND_CHAOS_APPLICATION)
+    .filter((e): e is CastEvent => e.type === EventType.Cast)
+    .at(0);
+}
+
+export function getUnboundChaosConsumption(event: RemoveBuffEvent): CastEvent | undefined {
+  return GetRelatedEvents(event, UNBOUND_CHAOS_CONSUMPTION)
+    .filter((e): e is CastEvent => e.type === EventType.Cast)
+    .at(0);
+}

--- a/src/analysis/retail/demonhunter/shared/modules/talents/SigilOfFlame.tsx
+++ b/src/analysis/retail/demonhunter/shared/modules/talents/SigilOfFlame.tsx
@@ -1,7 +1,7 @@
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS/demonhunter';
 import TALENTS from 'common/TALENTS/demonhunter';
-import { ChecklistUsageInfo, SpellUse, spellUseToBoxRowEntry } from 'parser/core/SpellUsage/core';
+import { ChecklistUsageInfo, SpellUse } from 'parser/core/SpellUsage/core';
 import Events, { CastEvent } from 'parser/core/Events';
 import { Trans } from '@lingui/macro';
 import { SpellLink } from 'interface';
@@ -47,12 +47,10 @@ export default class SigilOfFlame extends Analyzer {
       </p>
     );
 
-    const performances = this.cooldownUses.map((it) =>
-      spellUseToBoxRowEntry(it, this.owner.fight.start_time),
-    );
-
-    const goodCasts = performances.filter((it) => it.value === QualitativePerformance.Good).length;
-    const totalCasts = performances.length;
+    const goodCasts = this.cooldownUses.filter(
+      (it) => it.performance === QualitativePerformance.Good,
+    ).length;
+    const totalCasts = this.cooldownUses.length;
 
     return (
       <HideGoodCastsSpellUsageSubSection

--- a/src/parser/core/SpellUsage/core.tsx
+++ b/src/parser/core/SpellUsage/core.tsx
@@ -1,6 +1,6 @@
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { createContext, ReactNode, useContext } from 'react';
-import { CastEvent } from 'parser/core/Events';
+import { AnyEvent } from 'parser/core/Events';
 import styled from '@emotion/styled';
 import { formatDuration } from 'common/format';
 import { PerformanceMark } from 'interface/guide';
@@ -29,7 +29,7 @@ export interface ChecklistUsageInfo extends UsageInfo {
  * up said quality.
  */
 export interface SpellUse {
-  event: CastEvent;
+  event: AnyEvent;
   checklistItems: ChecklistUsageInfo[];
   performance: QualitativePerformance;
   extraDetails?: ReactNode;


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Add support for Unbound Chaos in Havoc Guide. Also slight change to SpellUse to allow reuse of existing components without needing to use a CastEvent.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/PdG3Mn4ZhCmpzWFA/28-Heroic+Scalecommander+Sarkareth+-+Kill+(6:23)/Toppledh/standard/overview`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/4cd73d8c-f4f9-4076-96a2-467f291abf6a)
