### PR TITLE
Fix evoker 4 piece module inaccuracies

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { ToppleTheNun, Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 5, 23), <>Improve accuracy of 4 piece module</>, Trevor),
   change(date(2023, 5, 19), <>Fix mana cost for <SpellLink spell={TALENTS_EVOKER.ECHO_TALENT}/></>, Trevor),
   change(date(2023, 5, 12), <>Fix bug in guide for <SpellLink spell={TALENTS_EVOKER.LIFEBIND_TALENT}/> checks</>, Trevor),
   change(date(2023, 5, 11), <>Fix <SpellLink spell={TALENTS_EVOKER.DREAM_BREATH_TALENT}/> and <SpellLink spell={TALENTS_EVOKER.SPIRITBLOOM_TALENT}/> modules</>, Trevor),

--- a/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
@@ -1,4 +1,5 @@
 import SPELLS from 'common/SPELLS';
+import ITEMS from 'common/ITEMS/evoker';
 import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
 import { Options } from 'parser/core/Module';
 import { TALENTS_EVOKER } from 'common/TALENTS';
@@ -42,6 +43,7 @@ export const SHIELD_FROM_TA_CAST = 'ShieldFromTACast';
 export const SPARK_OF_INSIGHT = 'SparkOfInsight'; // link TC stack removals to Spark
 export const STASIS = 'Stasis';
 export const STASIS_FOR_RAMP = 'ForRamp';
+export const ESSENCE_RUSH = 'EssenceRush';
 
 export enum ECHO_TYPE {
   NONE,
@@ -586,13 +588,31 @@ const EVENT_LINKS: EventLink[] = [
     },
   },
   {
+    linkRelation: ESSENCE_RUSH,
+    reverseLinkRelation: ESSENCE_RUSH,
+    linkingEventId: SPELLS.ESSENCE_BURST_BUFF.id,
+    linkingEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack, EventType.RefreshBuff],
+    referencedEventId: ITEMS.T30_ESSENCE_RUSH.id,
+    referencedEventType: EventType.ApplyBuff,
+    backwardBufferMs: 5000,
+  },
+  {
     linkRelation: FROM_HARDCAST,
     reverseLinkRelation: FROM_HARDCAST,
     linkingEventId: SPELLS.ESSENCE_BURST_BUFF.id,
     linkingEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack, EventType.RefreshBuff],
-    referencedEventId: [SPELLS.LIVING_FLAME_HEAL.id, SPELLS.LIVING_FLAME_DAMAGE.id],
-    referencedEventType: EventType.Cast,
-    backwardBufferMs: CAST_BUFFER_MS,
+    referencedEventId: [
+      SPELLS.LIVING_FLAME_HEAL.id,
+      SPELLS.LIVING_FLAME_DAMAGE.id,
+      SPELLS.LIVING_FLAME_CAST.id,
+    ],
+    referencedEventType: [EventType.Cast, EventType.Damage, EventType.Heal],
+    backwardBufferMs: 1500, // very large delay between application and lf event sometimes
+    forwardBufferMs: 10, // ordering
+    anyTarget: true,
+    additionalCondition(linkingEvent, referencedEvent) {
+      return !HasRelatedEvent(linkingEvent, ESSENCE_RUSH);
+    },
   },
   {
     linkRelation: STASIS_FOR_RAMP,

--- a/src/common/ITEMS/evoker.ts
+++ b/src/common/ITEMS/evoker.ts
@@ -9,6 +9,11 @@ const items: ItemList = {
     name: 'Spiritbloom',
     icon: 'ability_evoker_spiritbloom2',
   },
+  T30_ESSENCE_RUSH: {
+    id: 409899,
+    name: 'Essence Rush',
+    icon: 'ability_evoker_essenceburststacks',
+  },
   //endregion
   //region Shared
   //endregion


### PR DESCRIPTION
### Description

Linking for living flame events to essence burst procs was not accurate leading to unattributed refreshes being counted as 4 piece procs leading to overcounting procs from tier set
