### PR TITLE
Add event fabrication for TFT when talented into secret infusion and add support for passing spell object to CastEfficiencyBar

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 5, 23), <>Add event fabrication for <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT}/> cast prepull</>, Trevor),
   change(date(2023, 5, 23), <>Fix crash in celestial analysis due to pre-pull celestial cast</>, Trevor),
   change(date(2023, 5, 21), <>Fix uptime calculations when using <SpellLink spell={TALENTS_MONK.SOOTHING_MIST_TALENT}/></>, Trevor),
   change(date(2023, 5, 20), <>Fix <SpellLink spell={TALENTS_MONK.VEIL_OF_PRIDE_TALENT}/> math</>, Trevor),

--- a/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
+++ b/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
@@ -87,6 +87,7 @@ import RisingMistBreakdown from './modules/features/RisingMistBreakdown';
 import T30TierSet from './modules/dragonflight/tier/T30MWTier';
 import CalmingCoalescence from './modules/spells/CalmingCoalescence';
 import LifeCocoon from './modules/spells/LifeCocoon';
+import SecretInfusion from './modules/spells/SecretInfusion';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -183,6 +184,7 @@ class CombatLogParser extends CoreCombatLogParser {
     legacyOfWisdom: LegacyOfWisdom,
     calmingCoalescence: CalmingCoalescence,
     lifeCocoon: LifeCocoon,
+    secretInfusion: SecretInfusion,
 
     apl: AplCheck,
 

--- a/src/analysis/retail/monk/mistweaver/modules/spells/SecretInfusion.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/SecretInfusion.tsx
@@ -1,0 +1,27 @@
+import { TALENTS_MONK } from 'common/TALENTS';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import Buffs from 'parser/core/modules/Auras';
+import { SECRET_INFUSION_BUFFS } from '../../constants';
+
+class SecretInfusion extends Analyzer {
+  static dependencies = {
+    buffs: Buffs,
+  };
+  protected buffs!: Buffs;
+
+  constructor(options: Options & { buffs: Buffs }) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.SECRET_INFUSION_TALENT);
+
+    SECRET_INFUSION_BUFFS.forEach((spell) => {
+      options.buffs.add({
+        spellId: spell.id,
+        timelineHighlight: true,
+        triggeredBySpellId: TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT.id,
+      });
+    });
+  }
+}
+
+export default SecretInfusion;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/SecretInfusion.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/SecretInfusion.tsx
@@ -17,7 +17,6 @@ class SecretInfusion extends Analyzer {
     SECRET_INFUSION_BUFFS.forEach((spell) => {
       options.buffs.add({
         spellId: spell.id,
-        timelineHighlight: true,
         triggeredBySpellId: TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT.id,
       });
     });

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
@@ -212,13 +212,13 @@ class ThunderFocusTea extends Analyzer {
     const explanation = (
       <p>
         <b>
-          <SpellLink id={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT.id} />
+          <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT} />
         </b>{' '}
         is an important spell used to empower other abilities. It should be used on cooldown at all
         times and the spell that you use it on depends on your talent selection. If you have{' '}
-        <SpellLink id={TALENTS_MONK.SECRET_INFUSION_TALENT} />, then you should always use{' '}
-        <SpellLink id={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT.id} /> on{' '}
-        <SpellLink id={TALENTS_MONK.RENEWING_MIST_TALENT.id} />{' '}
+        <SpellLink spell={TALENTS_MONK.SECRET_INFUSION_TALENT} />, then you should always use{' '}
+        <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT} /> on{' '}
+        <SpellLink spell={TALENTS_MONK.RENEWING_MIST_TALENT} />{' '}
         {this.selectedCombatant.hasTalent(TALENTS_MONK.UPWELLING_TALENT) && (
           <>
             or <SpellLink id={TALENTS_MONK.ESSENCE_FONT_TALENT} /> (when talented into{' '}
@@ -234,14 +234,15 @@ class ThunderFocusTea extends Analyzer {
       <div>
         <RoundedPanel>
           <strong>
-            <SpellLink id={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT.id} /> cast efficiency
+            <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT} /> cast efficiency
           </strong>
           <div>
             {this.subStatistic()} <br />
             <strong>Casts </strong>
             <small>
-              - Green indicates a correct <SpellLink id={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT} />{' '}
-              cast, while red indicates an incorrect cast.
+              - Green indicates a correct{' '}
+              <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT} /> cast, while red indicates
+              an incorrect cast.
             </small>
             <PerformanceBoxRow values={this.castEntries} />
           </div>
@@ -256,7 +257,7 @@ class ThunderFocusTea extends Analyzer {
   subStatistic() {
     return (
       <CastEfficiencyBar
-        spellId={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT.id}
+        spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT}
         gapHighlightMode={GapHighlight.FullCooldown}
         minimizeIcons
         useThresholds

--- a/src/parser/ui/CastEfficiencyBar.tsx
+++ b/src/parser/ui/CastEfficiencyBar.tsx
@@ -89,7 +89,7 @@ export default function CastEfficiencyBar({
   return (
     <CooldownUtilBarContainer>
       <div style={{ color: textColor }}>
-        <SpellIcon spell={rawSpellId} style={{ height: '28px' }} />{' '}
+        <SpellIcon spell={spellObj} style={{ height: '28px' }} />{' '}
         <TooltipElement content={tooltip}>
           {utilDisplay} <small>effic</small>
         </TooltipElement>

--- a/src/parser/ui/CastEfficiencyBar.tsx
+++ b/src/parser/ui/CastEfficiencyBar.tsx
@@ -47,9 +47,9 @@ export default function CastEfficiencyBar({
 }: Props & {
   useThresholds?: boolean;
 }): JSX.Element {
-  const castEffic = useAnalyzer(CastEfficiency)?.getCastEfficiencyForSpellId(
-    spell ? spell.id : spellId!,
-  );
+  const rawSpellId = spell ? spell.id : spellId!;
+  const spellObj = spell ? spell : spellId!;
+  const castEffic = useAnalyzer(CastEfficiency)?.getCastEfficiencyForSpellId(rawSpellId);
   let tooltip: ReactNode = `Couldn't get cast efficiency info!`;
   let utilDisplay = `N/A`;
   let textColor: string | undefined;
@@ -75,8 +75,8 @@ export default function CastEfficiencyBar({
     utilDisplay = formatPercentage(effectiveUtil, 0) + '%';
     tooltip = (
       <>
-        You cast <SpellLink spell={spell ? spell : spellId!} /> <strong>{castEffic.casts}</strong>{' '}
-        out of <strong>{castEffic.maxCasts}</strong> possible times.
+        You cast <SpellLink spell={spellObj} /> <strong>{castEffic.casts}</strong> out of{' '}
+        <strong>{castEffic.maxCasts}</strong> possible times.
         <br />
         It was on cooldown for <strong>{formatPercentage(castEffic.efficiency, 0)}%</strong> of{' '}
         {windowName}.
@@ -89,14 +89,14 @@ export default function CastEfficiencyBar({
   return (
     <CooldownUtilBarContainer>
       <div style={{ color: textColor }}>
-        <SpellIcon spell={spell ? spell : spellId!} style={{ height: '28px' }} />{' '}
+        <SpellIcon spell={rawSpellId} style={{ height: '28px' }} />{' '}
         <TooltipElement content={tooltip}>
           {utilDisplay} <small>effic</small>
         </TooltipElement>
       </div>
       <CooldownBar
         activeWindows={activeWindows}
-        spellId={spell ? spell.id : spellId!}
+        spellId={rawSpellId}
         gapHighlightMode={gapHighlightMode}
         minimizeIcons={minimizeIcons}
         slimLines={slimLines}

--- a/src/parser/ui/CooldownBar.tsx
+++ b/src/parser/ui/CooldownBar.tsx
@@ -295,7 +295,7 @@ function iconOrChip(spellId: number, minimizeIcons?: boolean, slimLines?: boolea
   return minimizeIcons ? (
     <div className="cast-chip" style={{ width: w, height: '100%' }} />
   ) : (
-    <SpellIcon noLink id={spellId} />
+    <SpellIcon noLink spell={spellId} />
   );
 }
 


### PR DESCRIPTION
### Description

Fabricates cast event for tft when used prepull so it doesnt show tft on cd when used right before pull (standard opener)
Only really possible when talented into secret infusion, but you should be talented into it on every fight.

This diff also adds support for passing a spell object to CastEfficiencyBar to get around the issue of the bar showing the wrong id/name when passing the raw spellId
