### PR TITLE
[Shadow] Improve VoidBolt CD tracking

### DIFF
--- a/src/analysis/retail/priest/shadow/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/shadow/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { DoxAshe, Havoc } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 6, 7), <>Fix <SpellLink id={SPELLS.VOID_BOLT}/> cooldown tracking</>,DoxAshe),
   change(date(2023, 5, 29), <>Added <SpellLink id={TALENTS.MANIPULATION_TALENT}/> cooldown reduction</>,DoxAshe),
   change(date(2023, 5, 24), <>Added <SpellLink id={TALENTS.INSIDIOUS_IRE_TALENT}/> efficiency and damage</>,Havoc),
   change(date(2023, 5, 20), <>Updated <SpellLink id={TALENTS.VOID_TORRENT_TALENT}/> insanity waste</>,DoxAshe),

--- a/src/analysis/retail/priest/shadow/modules/spells/Voidbolt.tsx
+++ b/src/analysis/retail/priest/shadow/modules/spells/Voidbolt.tsx
@@ -2,7 +2,11 @@ import SPELLS from 'common/SPELLS';
 import Spell from 'common/SPELLS/Spell';
 import TALENTS from 'common/TALENTS/priest';
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events from 'parser/core/Events';
+import Events, {
+  ApplyBuffEvent,
+  RemoveBuffEvent,
+  UpdateSpellUsableEvent,
+} from 'parser/core/Events';
 import Abilities from 'parser/core/modules/Abilities';
 import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
 import ExecuteHelper from 'parser/shared/modules/helpers/ExecuteHelper';
@@ -26,12 +30,32 @@ class Voidbolt extends ExecuteHelper {
   };
 
   maxCasts: number = 0;
+  castVB = 0; //casts of Voidbolt
+  miss = 0; //missed potential casts of Void Bolt
+  VB = [0]; //timestamps of voidbolt spellusable updates
 
   protected abilities!: Abilities;
 
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS.VOID_ERUPTION_TALENT);
+
+    this.addEventListener(
+      Events.UpdateSpellUsable.by(SELECTED_PLAYER).spell(SPELLS.VOID_BOLT),
+      this.onVBUpdate,
+    );
+
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.VOID_BOLT), this.onVBCast);
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.VOIDFORM_BUFF),
+      this.enterVoidform,
+    );
+
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.VOIDFORM_BUFF),
+      this.leaveVoidform,
+    );
 
     this.addEventListener(Events.fightend, this.adjustMaxCasts);
 
@@ -53,9 +77,73 @@ class Voidbolt extends ExecuteHelper {
     });
   }
 
+  onVBUpdate(event: UpdateSpellUsableEvent) {
+    //this adds timestamps of voidbolt spellusable updates
+    this.VB.push(event.timestamp);
+  }
+
+  onVBCast() {
+    this.castVB += 1;
+  }
+
+  //VB is an unusal spell. It is likely that using ExecuteHelper would be better than this for most spells.
+  getVB() {
+    //console.log("VoidformArray", this.VB)
+    //convert raw timestamps of spellusables to time between them
+    const diff = [];
+
+    // start at 2, so first calc is [2]-[1]
+    //because [0] = 0, [1] = enterVF timestamp, [2] is first VB timestamp.
+    for (let i = 2; i < this.VB.length; i += 1) {
+      diff[i - 2] = this.VB[i] - this.VB[i - 1];
+    }
+
+    let waste = 0;
+    const cd = [];
+    let total = 0;
+
+    //even diff is time between available and cast
+    //odd diff is time waiting on cooldown.
+
+    //the last timestamp occurs when VF ends, and VB updates to no longer be usable
+    //If VB is off cooldown at this time, we want to add this time to the waste time
+    //if VB is on cooldown at this time, we do not want to add this time into the average recharge time.
+    for (let i = 0; i < diff.length; i += 1) {
+      if (i % 2 === 0) {
+        //even
+        waste = waste + diff[i];
+      }
+      if (i % 2 !== 0 && i !== diff.length - 1) {
+        //odd and not include final if it is odd.
+        cd.push(diff[i]);
+      }
+    }
+
+    //find the average CD during this voidform
+    for (let i = 0; i < cd.length; i += 1) {
+      total = total + cd[i];
+    }
+    const averagecd = total / cd.length;
+
+    this.miss = this.miss + Math.floor(waste / averagecd); //Any remainder is not a possible cast, so it is floored.
+  }
+
+  enterVoidform(event: ApplyBuffEvent) {
+    //reset the tracker of VB update timestamps.
+    this.VB = [0];
+    //to find the time between the first voidbolt update and start of voidform we need to add it in here.
+    this.VB.push(event.timestamp);
+  }
+
+  leaveVoidform(event: RemoveBuffEvent) {
+    //to find the time between the last voidbolt update and end of voidform we need to add it in here.
+    this.VB.push(event.timestamp);
+    //Calculate missed potential casts of Void Bolt during this voidform.
+    this.getVB();
+  }
+
   adjustMaxCasts() {
-    const cooldown = this.abilities.getAbility(SPELLS.VOID_BOLT.id)!.cooldown * 1000; //this is not perfectly accurate to voidbolts cooldown
-    this.maxCasts += Math.ceil(this.totalExecuteDuration / cooldown);
+    this.maxCasts = this.miss + this.castVB;
   }
 
   statistic() {

--- a/src/analysis/retail/priest/shadow/modules/spells/Voidbolt.tsx
+++ b/src/analysis/retail/priest/shadow/modules/spells/Voidbolt.tsx
@@ -87,7 +87,7 @@ class Voidbolt extends ExecuteHelper {
   }
 
   //VB is an unusal spell. It is likely that using ExecuteHelper would be better than this for most spells.
-  getVB() {
+  calculateMissedVB() {
     //console.log("VoidformArray", this.VB)
     //convert raw timestamps of spellusables to time between them
     const diff = [];
@@ -139,7 +139,7 @@ class Voidbolt extends ExecuteHelper {
     //to find the time between the last voidbolt update and end of voidform we need to add it in here.
     this.VB.push(event.timestamp);
     //Calculate missed potential casts of Void Bolt during this voidform.
-    this.getVB();
+    this.calculateMissedVB();
   }
 
   adjustMaxCasts() {

--- a/src/analysis/retail/priest/shadow/modules/spells/Voidbolt.tsx
+++ b/src/analysis/retail/priest/shadow/modules/spells/Voidbolt.tsx
@@ -126,6 +126,7 @@ class Voidbolt extends ExecuteHelper {
     const averagecd = total / cd.length;
 
     this.miss = this.miss + Math.floor(waste / averagecd); //Any remainder is not a possible cast, so it is floored.
+    this.VB = [0]; //After calcuating the missed VB, removed them so they cannot be added again.
   }
 
   enterVoidform(event: ApplyBuffEvent) {


### PR DESCRIPTION
### Description

Void Bolt's cast efficiency has been incorrect.  Instead of using the average cooldown from getAbility, I track every update to its spell usable to get a more accurate calculation during each voidform.
This still uses Execute helper to make the graph hide the sections outside voidform.

### Testing

In the test report void bolt was cast 25 times, but the old method gives a maximum of 23.  With the new calculation, it correctly shows a maximum of 27.

- Test report URL: `/report/xy3RCn7w1FLpqmvV/4/Solaqt`
