### PR TITLE
[Classic] Demo Warlock Guide 3

### DIFF
--- a/src/analysis/classic/warlock/demonology/CHANGELOG.tsx
+++ b/src/analysis/classic/warlock/demonology/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { change, date } from 'common/changelog';
 import { jazminite } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2023, 6, 9), 'Add Guide Cooldowns Graph subsection.', jazminite),
   change(date(2023, 5, 7), 'Updates to Guide Core section + added Spells subsection.', jazminite),
   change(date(2023, 4, 23), 'Started Guide and added Core and Preparation sections.', jazminite),
   change(date(2023, 4, 2), 'Remove static entries for Healthstone use in favor of HealthstoneChecker.', jazminite),

--- a/src/analysis/classic/warlock/demonology/Guide.tsx
+++ b/src/analysis/classic/warlock/demonology/Guide.tsx
@@ -3,6 +3,7 @@ import Expansion from 'game/Expansion';
 import CombatLogParser from './CombatLogParser';
 import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
 import CastingSubsection from './modules/guide/CastingSubsection';
+import CooldownGraphSubsection from './modules/guide/CooldownGraphSubsection';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -15,7 +16,9 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
         </SubSection>
       </Section>
 
-      <Section title="Cooldowns"></Section>
+      <Section title="Cooldowns">
+        <CooldownGraphSubsection />
+      </Section>
 
       <Section title="Procs"></Section>
 

--- a/src/analysis/classic/warlock/demonology/modules/features/Abilities.ts
+++ b/src/analysis/classic/warlock/demonology/modules/features/Abilities.ts
@@ -3,8 +3,21 @@ import CoreAbilities from 'parser/core/modules/Abilities';
 import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
 
 class Abilities extends CoreAbilities {
+  nemesisCD(spellId: number, demoPoints: number, cooldown: number) {
+    if (spellId === SPELLS.FEL_DOMINATION.id || SPELLS.DEMONIC_EMPOWERMENT.id) {
+      if (demoPoints >= 43) {return cooldown * 0.7;}
+      if (demoPoints === 42) {return cooldown * 0.8;}
+      if (demoPoints === 41) {return cooldown * 0.9;}
+    }
+    if (spellId === SPELLS.METAMORPHOSIS.id) {
+      if (demoPoints >= 54) {return cooldown * 0.7;}
+      if (demoPoints === 53) {return cooldown * 0.8;}
+      if (demoPoints === 52) {return cooldown * 0.9;}
+    }
+    return cooldown;
+  }
   spellbook() {
-    const combatant = this.selectedCombatant;
+    const demoPoints = this.selectedCombatant.talentPoints[1];
     return [
       // Rotational
       {
@@ -56,27 +69,27 @@ class Abilities extends CoreAbilities {
       // Cooldowns
       {
         spell: [SPELLS.DEMONIC_EMPOWERMENT.id],
-        enabled: combatant.talentPoints[1] >= 30,
+        enabled: demoPoints >= 30,
         category: SPELL_CATEGORY.COOLDOWNS,
         gcd: null,
-        cooldown: 60,
+        cooldown: this.nemesisCD(SPELLS.DEMONIC_EMPOWERMENT.id, demoPoints, 60),
       },
       {
         spell: [SPELLS.METAMORPHOSIS.id],
-        enabled: combatant.talentPoints[1] >= 50,
+        enabled: demoPoints >= 50,
         category: SPELL_CATEGORY.COOLDOWNS,
         gcd: null,
-        cooldown: 120,
+        cooldown: this.nemesisCD(SPELLS.METAMORPHOSIS.id, demoPoints, 180),
       },
       {
         spell: [SPELLS.IMMOLATION_AURA.id],
-        enabled: combatant.talentPoints[1] >= 50,
+        enabled: demoPoints >= 50,
         category: SPELL_CATEGORY.COOLDOWNS,
         gcd: { base: 1500 },
       },
       {
         spell: [SPELLS.SHADOW_CLEAVE.id],
-        enabled: combatant.talentPoints[1] >= 50,
+        enabled: demoPoints >= 50,
         category: SPELL_CATEGORY.COOLDOWNS,
         gcd: null,
       },
@@ -160,20 +173,20 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: [SPELLS.SOUL_LINK.id],
-        enabled: combatant.talentPoints[1] >= 10,
+        enabled: demoPoints >= 10,
         category: SPELL_CATEGORY.UTILITY,
         gcd: { base: 1500 },
       },
       {
         spell: [SPELLS.CHALLENGING_HOWL.id],
-        enabled: combatant.talentPoints[1] >= 50,
+        enabled: demoPoints >= 50,
         category: SPELL_CATEGORY.UTILITY,
         gcd: { base: 1500 },
       },
       // Pet Related
       {
         spell: [SPELLS.FEL_DOMINATION.id],
-        enabled: combatant.talentPoints[1] >= 10,
+        enabled: demoPoints >= 10,
         category: SPELL_CATEGORY.UTILITY,
         gcd: null,
       },
@@ -184,7 +197,7 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: [SPELLS.SUMMON_FELGUARD.id],
-        enabled: combatant.talentPoints[1] >= 40,
+        enabled: demoPoints >= 40,
         category: SPELL_CATEGORY.UTILITY,
         gcd: { base: 1500 },
       },

--- a/src/analysis/classic/warlock/demonology/modules/features/Abilities.ts
+++ b/src/analysis/classic/warlock/demonology/modules/features/Abilities.ts
@@ -5,14 +5,26 @@ import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
 class Abilities extends CoreAbilities {
   nemesisCD(spellId: number, demoPoints: number, cooldown: number) {
     if (spellId === SPELLS.FEL_DOMINATION.id || SPELLS.DEMONIC_EMPOWERMENT.id) {
-      if (demoPoints >= 43) {return cooldown * 0.7;}
-      if (demoPoints === 42) {return cooldown * 0.8;}
-      if (demoPoints === 41) {return cooldown * 0.9;}
+      if (demoPoints >= 43) {
+        return cooldown * 0.7;
+      }
+      if (demoPoints === 42) {
+        return cooldown * 0.8;
+      }
+      if (demoPoints === 41) {
+        return cooldown * 0.9;
+      }
     }
     if (spellId === SPELLS.METAMORPHOSIS.id) {
-      if (demoPoints >= 54) {return cooldown * 0.7;}
-      if (demoPoints === 53) {return cooldown * 0.8;}
-      if (demoPoints === 52) {return cooldown * 0.9;}
+      if (demoPoints >= 54) {
+        return cooldown * 0.7;
+      }
+      if (demoPoints === 53) {
+        return cooldown * 0.8;
+      }
+      if (demoPoints === 52) {
+        return cooldown * 0.9;
+      }
     }
     return cooldown;
   }

--- a/src/analysis/classic/warlock/demonology/modules/features/Abilities.ts
+++ b/src/analysis/classic/warlock/demonology/modules/features/Abilities.ts
@@ -16,6 +16,7 @@ class Abilities extends CoreAbilities {
     }
     return cooldown;
   }
+
   spellbook() {
     const demoPoints = this.selectedCombatant.talentPoints[1];
     return [

--- a/src/analysis/classic/warlock/demonology/modules/guide/CooldownGraphSubsection.tsx
+++ b/src/analysis/classic/warlock/demonology/modules/guide/CooldownGraphSubsection.tsx
@@ -1,0 +1,66 @@
+import Spell from 'common/SPELLS/Spell';
+import {
+  AvailableColor,
+  BadColor,
+  OkColor,
+  SubSection,
+  useAnalyzer,
+  useInfo,
+} from 'interface/guide';
+import CastEfficiency from 'parser/shared/modules/CastEfficiency';
+import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
+import { CooldownWindow, GapHighlight } from 'parser/ui/CooldownBar';
+import { Highlight } from 'interface/Highlight';
+
+import SPELLS from 'common/SPELLS/classic/warlock';
+
+type SpellCooldown = {
+  spell: Spell;
+  activeWindows?: CooldownWindow[];
+};
+
+const cooldowns: SpellCooldown[] = [
+  { spell: SPELLS.DEMONIC_EMPOWERMENT },
+  { spell: SPELLS.METAMORPHOSIS },
+];
+
+const CooldownGraphSubsection = () => {
+  const info = useInfo();
+  const castEfficiency = useAnalyzer(CastEfficiency);
+  if (!info || !castEfficiency) {
+    return null;
+  }
+
+  return (
+    <SubSection>
+      <>
+        <strong>Cooldown Graph</strong>
+        <div>
+          <small>
+            <Highlight color={AvailableColor} textColor="black">
+              Grey
+            </Highlight>{' '}
+            segments show when the spell was available to cast.{' '}
+            <Highlight color={OkColor} textColor="black">
+              Yellow
+            </Highlight>{' '}
+            segments show when the spell was cooling down.{' '}
+            <Highlight color={BadColor} textColor="black">
+              Red
+            </Highlight>{' '}
+            segments show when you could have used a whole extra cooldown.
+          </small>
+        </div>
+      </>
+      {cooldowns.map((cooldownCheck) => (
+        <CastEfficiencyBar
+          key={cooldownCheck.spell.id}
+          spellId={cooldownCheck.spell.id}
+          gapHighlightMode={GapHighlight.FullCooldown}
+        />
+      ))}
+    </SubSection>
+  );
+};
+
+export default CooldownGraphSubsection;

--- a/src/interface/guide/Guide.scss
+++ b/src/interface/guide/Guide.scss
@@ -8,6 +8,7 @@ $bad-perf-color: #ac1f39;
 // extra colors for some special case stuff
 $very-bad-perf-color: #661111;
 $mediocre-perf-color: #dd5533;
+$available-cd-color: #696864;
 
 // for export
 :root {
@@ -17,6 +18,7 @@ $mediocre-perf-color: #dd5533;
   --guide-bad-color: #{$bad-perf-color};
   --guide-very-bad-color: #{$very-bad-perf-color};
   --guide-mediocre-color: #{$mediocre-perf-color};
+  --guide-available-color: #{$available-cd-color};
 }
 
 .guide-container {

--- a/src/interface/guide/index.tsx
+++ b/src/interface/guide/index.tsx
@@ -335,6 +335,9 @@ export const VeryBadColor = getComputedStyle(document.documentElement).getProper
 export const MediocreColor = getComputedStyle(document.documentElement).getPropertyValue(
   '--guide-mediocre-color',
 );
+export const AvailableColor = getComputedStyle(document.documentElement).getPropertyValue(
+  '--guide-available-color',
+);
 
 /** Shows a glyph - either a green checkmark or a red X depending on if 'pass' is true */
 export const PassFailCheckmark = ({ pass }: { pass: boolean }) =>


### PR DESCRIPTION
### Description

Round 3 for the Demo Warlock Guide - viewable under the `Prototype View`. This guide isn't finished yet.

- Demo Warlock files:
  - Abilities.ts - Add `nemesisCD` helper for determining CD of Fel Domination, Demonic Empowerment, and Metamorphosis.
  - Added Cooldown Graph Subsection
 
- Core files:
  - Added Guide Available Color to use as a Highlight color

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/BZj17n6XTYCLaQPN/37-Hardmode+Thorim+-+Kill+(2:53)/Jazl`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/65823478/b3ed8368-5783-49d2-be69-e6772bb5ead4)

