### PR TITLE
Add cooldowns tab for prevoker

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { ToppleTheNun, Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 6, 9), <>Add Cooldowns tab</>, Trevor),
   change(date(2023, 5, 24), <>Add <SpellLink spell={TALENTS_EVOKER.NOZDORMUS_TEACHINGS_TALENT}/> module</>, Trevor),
   change(date(2023, 5, 23), <>Improve accuracy of 4 piece module</>, Trevor),
   change(date(2023, 5, 19), <>Fix mana cost for <SpellLink spell={TALENTS_EVOKER.ECHO_TALENT}/></>, Trevor),

--- a/src/analysis/retail/evoker/preservation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/preservation/CombatLogParser.ts
@@ -43,11 +43,13 @@ import Ouroboros from './modules/talents/Ouroboros';
 import T30PrevokerSet from './modules/dragonflight/tier/T30TierSet';
 import Guide from 'analysis/retail/evoker/preservation/Guide';
 import NozTeachings from './modules/talents/NozTeachings';
+import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     lowHealthHealing: LowHealthHealing,
     abilities: Abilities,
+    cooldowns: CooldownThroughputTracker,
 
     // Normalizer
     castLinkNormalizer: CastLinkNormalizer,

--- a/src/analysis/retail/evoker/preservation/modules/features/CooldownThroughputTracker.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/features/CooldownThroughputTracker.tsx
@@ -1,0 +1,45 @@
+import { TALENTS_EVOKER } from 'common/TALENTS';
+import { RETAIL_EXPANSION } from 'game/Expansion';
+import CoreCooldownThroughputTracker, {
+  BUILT_IN_SUMMARY_TYPES,
+} from 'parser/shared/modules/CooldownThroughputTracker';
+
+class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
+  static cooldownSpells = [
+    ...CoreCooldownThroughputTracker.cooldownSpells,
+    {
+      spell: TALENTS_EVOKER.DREAM_FLIGHT_TALENT.id,
+      summary: [
+        BUILT_IN_SUMMARY_TYPES.HEALING,
+        BUILT_IN_SUMMARY_TYPES.OVERHEALING,
+        BUILT_IN_SUMMARY_TYPES.MANA,
+      ],
+      expansion: RETAIL_EXPANSION,
+    },
+    {
+      spell: TALENTS_EVOKER.REWIND_TALENT.id,
+      summary: [
+        BUILT_IN_SUMMARY_TYPES.HEALING,
+        BUILT_IN_SUMMARY_TYPES.OVERHEALING,
+        BUILT_IN_SUMMARY_TYPES.MANA,
+      ],
+      expansion: RETAIL_EXPANSION,
+    },
+  ];
+  static castCooldowns = [
+    ...CoreCooldownThroughputTracker.castCooldowns,
+    {
+      spell: TALENTS_EVOKER.EMERALD_COMMUNION_TALENT.id,
+      summary: [
+        BUILT_IN_SUMMARY_TYPES.HEALING,
+        BUILT_IN_SUMMARY_TYPES.OVERHEALING,
+        BUILT_IN_SUMMARY_TYPES.MANA,
+      ],
+      expansion: RETAIL_EXPANSION,
+    },
+  ];
+
+  static ignoredSpells = [...CoreCooldownThroughputTracker.ignoredSpells];
+}
+
+export default CooldownThroughputTracker;

--- a/src/common/ITEMS/dragonflight/crafted/engineering/index.ts
+++ b/src/common/ITEMS/dragonflight/crafted/engineering/index.ts
@@ -1,0 +1,17 @@
+/**
+ * NAME: {
+ *   id: number,
+ *   name: string,
+ *   icon: string,
+ * },
+ */
+import { itemIndexableList } from 'common/ITEMS/Item';
+
+const items = itemIndexableList({
+  HEALING_DART_CAST: {
+    id: 385350,
+    name: 'Healing Dart',
+    icon: 'inv_gizmo_runichealthinjector',
+  },
+});
+export default items;

--- a/src/common/ITEMS/dragonflight/crafted/index.ts
+++ b/src/common/ITEMS/dragonflight/crafted/index.ts
@@ -3,7 +3,8 @@ import safeMerge from 'common/safeMerge';
 import Alchemy from './alchemy';
 import Inscription from './inscription';
 import Leatherworking from './leatherworking';
+import Engineering from './engineering';
 
-const items = safeMerge(Alchemy, Inscription, Leatherworking);
+const items = safeMerge(Alchemy, Engineering, Inscription, Leatherworking);
 
 export default items;

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -396,6 +396,11 @@ const spells = spellIndexableList({
     name: 'Calming Coalescence',
     icon: 'ability_monk_healthsphere',
   },
+  ESCAPE_FROM_REALITY_CAST: {
+    id: 343539,
+    name: 'Escape from Reality',
+    icon: 'inv_enchant_essencecosmicgreater',
+  },
   //Tier 30 2pc Buff
   SOULFANG_INFUSION: {
     id: 410007,

--- a/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
+++ b/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
@@ -1,3 +1,4 @@
+import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_SHAMAN } from 'common/TALENTS';
 
@@ -62,7 +63,14 @@ const spells: number[] = [
   SPELLS.TRANQUILITY_HEAL.id,
   //endregion
 
+  //region monk
+  SPELLS.ESCAPE_FROM_REALITY_CAST.id,
+  //endregion
+
   //region trinket
+  //endregion
+  //region Embellishments
+  ITEMS.HEALING_DART_CAST.id,
   //endregion
 ];
 


### PR DESCRIPTION
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/3e1ecfee-ac67-4920-a072-a6e868383461)
Adds cooldown tab and marks healing dart and efr as non-casts