### PR TITLE
[Holy Paladin]

### DIFF
--- a/src/analysis/retail/paladin/holy/CHANGELOG.tsx
+++ b/src/analysis/retail/paladin/holy/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import TALENTS from 'common/TALENTS/paladin';
 import { SpellLink } from 'interface';
-import { CamClark, Tialyss, ToppleTheNun, xizbow, Trevor } from 'CONTRIBUTORS';
+import { CamClark, Tialyss, ToppleTheNun, xizbow, Trevor, Abelito75 } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS/paladin';
 
 export default [
+  change(date(2023, 6, 16), <>Average Light of Dawn Distance.</>, Abelito75),
   change(date(2023, 5, 15), <>Bump to full support</>, Trevor),
   change(date(2023, 4, 28), <>Add module for T30 Tier set</>, Trevor),
   change(date(2023, 3, 30), <>Update icons for <SpellLink id={SPELLS.BLESSING_OF_SUMMER_TALENT} />, <SpellLink id={SPELLS.BLESSING_OF_AUTUMN_TALENT} />, <SpellLink id={SPELLS.BLESSING_OF_WINTER_TALENT} />, and <SpellLink id={SPELLS.BLESSING_OF_SPRING_TALENT} />.</>, ToppleTheNun),

--- a/src/analysis/retail/paladin/holy/CombatLogParser.ts
+++ b/src/analysis/retail/paladin/holy/CombatLogParser.ts
@@ -46,6 +46,7 @@ import LightOfDawnNormalizer from './normalizers/LightOfDawn';
 import { BlessingOfTheSeasons } from './modules/talents/BlessingOfTheSeasons';
 import T30HpalTierSet from './modules/dragonflight/tier/T30TierSet';
 import CastLinkNormalizer from './normalizers/CastLinkNormalizer';
+import AverageLODDistance from './modules/features/AverageLODDistance';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -108,6 +109,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Tier Sets
     t30TierSet: T30HpalTierSet,
+    AverageLODDistance: AverageLODDistance,
   };
 }
 

--- a/src/analysis/retail/paladin/holy/modules/features/AverageLODDistance.tsx
+++ b/src/analysis/retail/paladin/holy/modules/features/AverageLODDistance.tsx
@@ -1,0 +1,70 @@
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent, HealEvent } from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import TALENTS from 'common/TALENTS/paladin';
+import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
+import BoringValueText from 'parser/ui/BoringValueText';
+
+class FillerFlashOfLight extends Analyzer {
+  distanceSum = 0;
+  distanceCount = 0;
+
+  maxDistance = 0;
+
+  sourceX: number | undefined;
+  sourceY: number | undefined;
+
+  constructor(options: Options) {
+    super(options);
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.LIGHT_OF_DAWN_TALENT),
+      this.cast,
+    );
+    this.addEventListener(
+      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.LIGHT_OF_DAWN_HEAL),
+      this.onHeal,
+    );
+  }
+
+  cast(event: CastEvent) {
+    this.sourceX = event.x;
+    this.sourceY = event.y;
+  }
+
+  onHeal(event: HealEvent) {
+    if (!this.sourceX && !this.sourceY) {
+      return;
+    }
+
+    this.distanceSum += this.calculateDistance(
+      this.sourceX as number,
+      this.sourceY as number,
+      event.x,
+      event.y,
+    );
+    this.distanceCount += 1;
+  }
+
+  calculateDistance(x1: number, y1: number, x2: number, y2: number) {
+    return Math.sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2)) / 100;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        key="Statistic"
+        position={STATISTIC_ORDER.CORE(10)}
+        tooltip={
+          <>This is the average distance between you and the person healed with Light of Dawn.</>
+        }
+      >
+        <BoringValueText label={<>Average LoD Distance</>}>
+          <>{(this.distanceSum / this.distanceCount).toFixed(2)} Yards</>
+        </BoringValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default FillerFlashOfLight;


### PR DESCRIPTION
### Description

Added a new stat for average distance between you and the targeted healed by Light of Dawn.
This is done because there is a talent that increases the range of LoD, currently its a 1 point talent but in 10.1.5 it becomes 2 points which means we need real statistics to determine if 2 points is really needed

![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/25177817/871d8254-fe3a-4ff4-a683-8cafa7beb6b3)
