### PR TITLE
fix Collective Anguish DPS calculation

### DIFF
--- a/src/analysis/retail/demonhunter/havoc/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/havoc/CHANGELOG.tsx
@@ -7,7 +7,8 @@ import SHARED_CHANGELOG from 'analysis/retail/demonhunter/shared/CHANGELOG';
 
 // prettier-ignore
 export default [
-  change(date(2023, 4, 20), <>Add support for <SpellLink spell={TALENTS.UNBOUND_CHAOS_TALENT}/>.</>, ToppleTheNun),
+  change(date(2023, 6, 17), <>Fix damage calculations for <SpellLink spell={TALENTS.COLLECTIVE_ANGUISH_TALENT} />.</>, ToppleTheNun),
+  change(date(2023, 4, 20), <>Add support for <SpellLink spell={TALENTS.UNBOUND_CHAOS_TALENT} />.</>, ToppleTheNun),
   change(date(2023, 4, 6), <>Fix ordering of abilities in <SpellLink spell={TALENTS.ESSENCE_BREAK_TALENT} /> window.</>, ToppleTheNun),
   change(date(2023, 3, 16), <>Add tooltip explaining <SpellLink spell={TALENTS.BLIND_FURY_TALENT} />'s contribution to Fury waste.</>, ToppleTheNun),
   change(date(2023, 3, 12), <>Add <SpellLink spell={TALENTS.MOMENTUM_TALENT} /> to rotation section.</>, ToppleTheNun),

--- a/src/analysis/retail/demonhunter/shared/modules/talents/CollectiveAnguish.tsx
+++ b/src/analysis/retail/demonhunter/shared/modules/talents/CollectiveAnguish.tsx
@@ -20,8 +20,8 @@ class CollectiveAnguish extends Analyzer {
     }
     const spell =
       this.selectedCombatant.specId === SPECS.HAVOC_DEMON_HUNTER.id
-        ? TALENTS_DEMON_HUNTER.FEL_DEVASTATION_TALENT
-        : SPELLS.COLLECTIVE_ANGUISH;
+        ? SPELLS.COLLECTIVE_ANGUISH_FEL_DEVASTATION
+        : SPELLS.COLLECTIVE_ANGUISH_EYE_BEAM;
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(spell), this.onDamageEvent);
   }
 

--- a/src/common/SPELLS/demonhunter.ts
+++ b/src/common/SPELLS/demonhunter.ts
@@ -292,10 +292,15 @@ const spells = spellIndexableList({
     name: 'Spirit Bomb',
     icon: 'inv_icon_shadowcouncilorb_purple',
   },
-  COLLECTIVE_ANGUISH: {
+  COLLECTIVE_ANGUISH_EYE_BEAM: {
     id: 391058,
     name: 'Collective Anguish',
     icon: 'artifactability_havocdemonhunter_anguishofthedeceiver',
+  },
+  COLLECTIVE_ANGUISH_FEL_DEVASTATION: {
+    id: 393834,
+    name: 'Fel Devastation',
+    icon: 'ability_demonhunter_feldevastation',
   },
   PAINBRINGER_BUFF: {
     id: 212988,


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Fix Collective Anguish DPS showing as 0 due to spell ID differences.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/C1qY3tWbBXM7KvJf/6-Mythic+Rashok,+the+Elder+-+Kill+(6:17)/Pleau/standard/statistics`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/f70906f0-716c-4a11-b35f-49e5051d19e9)
