### PR TITLE
Add Voice of the Silent Star tracking

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -24,6 +24,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 6, 19), <>Implement <ItemLink id={ITEMS.VOICE_OF_THE_SILENT_STAR.id}/> stat tracking</>, Jundarer),
   change(date(2023, 6, 18), 'Add Vessel, Spoils and Wafting Devotion haste buffs and update item scaling data.', Jundarer),
   change(date(2023, 6, 17), 'Update core directories to use new spell link format.', ToppleTheNun),
   change(date(2023, 6, 17), 'Update articles to use new spell link format.', ToppleTheNun),

--- a/src/common/ITEMS/dragonflight/others.ts
+++ b/src/common/ITEMS/dragonflight/others.ts
@@ -51,6 +51,11 @@ const others = itemIndexableList({
     name: 'Manic Grieftorch',
     icon: 'shaman_talent_unleashedfury',
   },
+  VOICE_OF_THE_SILENT_STAR: {
+    id: 204465,
+    name: 'Voice of the Silent Star',
+    icon: 'inv_cloth_raidpriestdragon_d_01_cape',
+  },
 });
 
 export default others;

--- a/src/common/SPELLS/dragonflight/others.ts
+++ b/src/common/SPELLS/dragonflight/others.ts
@@ -11,6 +11,11 @@ const others = spellIndexableList({
     name: 'Wafting Devotion',
     icon: 'inv_10_elementalcombinedfoozles_air',
   },
+  POWER_BEYOND_IMAGINATION: {
+    id: 409447,
+    name: 'Power Beyond Imagination',
+    icon: 'inv_cosmicvoid_debuff',
+  },
 });
 
 export default others;

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -90,6 +90,7 @@ import { PetInfo } from './Pet';
 import { PlayerInfo } from './Player';
 import Report from './Report';
 import { SpellUsageContextProvider } from 'parser/core/SpellUsage/core';
+import VoiceOfTheSilentStar from 'parser/retail/modules/items/dragonflight/VoiceOfTheSilentStar';
 
 // This prints to console anything that the DI has to do
 const debugDependencyInjection = false;
@@ -205,6 +206,7 @@ class CombatLogParser {
     bloodFury: BloodFury,
 
     // Items:
+    voiceOfTheSilentStar: VoiceOfTheSilentStar,
 
     // Enchants
 

--- a/src/parser/retail/modules/items/dragonflight/VoiceOfTheSilentStar.tsx
+++ b/src/parser/retail/modules/items/dragonflight/VoiceOfTheSilentStar.tsx
@@ -1,0 +1,79 @@
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import { formatNumber } from 'common/format';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import BoringItemValueText from 'parser/ui/BoringItemValueText';
+import { calculateSecondaryStatDefault } from 'parser/core/stats';
+import StatTracker from 'parser/shared/modules/StatTracker';
+import ITEMS from 'common/ITEMS';
+import SPELLS from 'common/SPELLS';
+
+class VoiceOfTheSilentStar extends Analyzer {
+  static dependencies = {
+    statTracker: StatTracker,
+  };
+  protected statTracker!: StatTracker;
+
+  secondaryValue: number = 0;
+  highestSecondary: string | number = 'none';
+
+  constructor(options: Options) {
+    super(options);
+
+    if (!this.selectedCombatant.hasBack(ITEMS.VOICE_OF_THE_SILENT_STAR.id)) {
+      return;
+    }
+    const cloak = this.selectedCombatant.back;
+    this.secondaryValue = calculateSecondaryStatDefault(431, 2235.71, cloak.itemLevel);
+
+    const statTracker = options.statTracker as StatTracker;
+    const statList = [
+      { name: 'haste', value: statTracker.currentHasteRating },
+      { name: 'mastery', value: statTracker.currentMasteryRating },
+      { name: 'crit', value: statTracker.currentCritRating },
+      { name: 'vers', value: statTracker.currentVersatilityRating },
+    ];
+    statList.sort((a, b) => b.value - a.value);
+    this.highestSecondary = statList[0].name;
+    if (this.highestSecondary === 'haste') {
+      statTracker.add(SPELLS.POWER_BEYOND_IMAGINATION.id, {
+        haste: this.secondaryValue,
+      });
+    } else if (this.highestSecondary === 'crit') {
+      statTracker.add(SPELLS.POWER_BEYOND_IMAGINATION.id, {
+        crit: this.secondaryValue,
+      });
+    } else if (this.highestSecondary === 'vers') {
+      statTracker.add(SPELLS.POWER_BEYOND_IMAGINATION.id, {
+        versatility: this.secondaryValue,
+      });
+    } else {
+      statTracker.add(SPELLS.POWER_BEYOND_IMAGINATION.id, {
+        mastery: this.secondaryValue,
+      });
+    }
+  }
+  get uptime() {
+    return (
+      this.selectedCombatant.getBuffUptime(SPELLS.POWER_BEYOND_IMAGINATION.id) /
+      this.owner.fightDuration
+    );
+  }
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE(8)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.ITEMS}
+      >
+        <BoringItemValueText item={ITEMS.VOICE_OF_THE_SILENT_STAR}>
+          {formatNumber(this.secondaryValue * this.uptime)} {this.highestSecondary}
+          <small> gained on average</small>
+        </BoringItemValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default VoiceOfTheSilentStar;


### PR DESCRIPTION
### Description

Adds stat tracking and a module for Voice of the Silent Star. Does not include the small debuff yet.

### Testing
https://wowanalyzer.com/report/hAjtTgVWczvnDpyC/23-Heroic+Magmorax+-+Kill+(3:23)/Dsune/standard/statistics
This report for example had above 100% uptime beforehand
