### PR TITLE
Added Thousandbone Tongueslicer (crit / mastery) food to list of high tier foods

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -24,6 +24,7 @@ import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2023, 6, 22), 'Added Thousandbone Tongueslicer to list of high tier foods.', Sref),
   change(date(2023, 6, 22), 'Remove ESLint disable from probability module.', ToppleTheNun),
   change(date(2023, 6, 19), <>Implement <ItemLink id={ITEMS.VOICE_OF_THE_SILENT_STAR.id}/> stat tracking</>, Jundarer),
   change(date(2023, 6, 18), 'Add Vessel, Spoils and Wafting Devotion haste buffs and update item scaling data.', Jundarer),

--- a/src/common/SPELLS/dragonflight/food.ts
+++ b/src/common/SPELLS/dragonflight/food.ts
@@ -109,6 +109,11 @@ const spells = spellIndexableList({
     name: 'Sizzling Seafood Medley',
     icon: 'inv_misc_food_draenor_sturgeonstew',
   },
+  THOUSANDBONE_TONGUESLICER: {
+    id: 382156,
+    name: 'Thousandbone Tongueslicer',
+    icon: 'inv_misc_food_154_fish_77',
+  },
   //endregion
 
   //region Great Feasts

--- a/src/parser/retail/modules/items/FoodChecker.ts
+++ b/src/parser/retail/modules/items/FoodChecker.ts
@@ -46,6 +46,7 @@ const HIGHER_FOOD_IDS: number[] = [
   SPELLS.SIZZLING_SEAFOOD_MEDLEY.id,
   // SPELLS.YUSAS_HEARTY_STEW.id,
   SPELLS.FATED_FORTUNE_COOKIE.id,
+  SPELLS.THOUSANDBONE_TONGUESLICER.id,
 ].filter((id) => id !== 0);
 
 class FoodChecker extends BaseFoodChecker {


### PR DESCRIPTION
### Description

This is one of the two-stat foods that is becoming best for classes now that secondaries are becoming stronger with more gear (specifically this is the recommended food for Feral Druids)

### Testing

- Test report URL: `/report/kBF2dbK8ZN3c9fRx/24-Heroic+Rashok,+the+Elder+-+Kill+(3:20)/Azlann/standard/overview`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/7143486/dd562b24-8067-4718-bfb6-9666b26a7064)
