### PR TITLE
[Warrior] reduce CDs when Honed Reflexes is skilled

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2213,3 +2213,8 @@ export const Seriousnes: Contributor = {
     },
   ],
 };
+
+export const codersKitchen: Contributor = {
+  nickname: 'coders-kitchen',
+  github: 'coders-kitchen',
+};

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2214,7 +2214,7 @@ export const Seriousnes: Contributor = {
   ],
 };
 
-export const codersKitchen: Contributor = {
+export const CodersKitchen: Contributor = {
   nickname: 'coders-kitchen',
   github: 'coders-kitchen',
 };

--- a/src/analysis/retail/warrior/fury/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/fury/CHANGELOG.tsx
@@ -1,6 +1,7 @@
 import { change, date } from 'common/changelog';
-import { Listefano } from 'CONTRIBUTORS';
+import { Listefano, CodersKitchen } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2023, 6, 25), 'Reduce CD of Raging Blow, when Honed Reflexes is skilled.', CodersKitchen),
   change(date(2022, 10, 1), 'Dragonflight initial cleanup', Listefano),
 ];

--- a/src/analysis/retail/warrior/fury/modules/Abilities.ts
+++ b/src/analysis/retail/warrior/fury/modules/Abilities.ts
@@ -3,6 +3,7 @@ import talents from 'common/TALENTS/warrior';
 import ISSUE_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
 import CoreAbilities from 'parser/core/modules/Abilities';
 import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
+import TALENTS from 'common/TALENTS/warrior';
 import { TIERS } from 'game/TIERS';
 
 //https://www.warcraftlogs.com/reports/9Vw8TvjHNfXgWyP7#fight=19&type=summary&source=21 2+ cold steel hot blood
@@ -27,7 +28,12 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.RAGING_BLOW.id,
         category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: (haste: number) => 8 / (1 + haste),
+        cooldown: (haste: number) => {
+          if (combatant.hasTalent(TALENTS.HONED_REFLEXES_FURY_TALENT)) {
+            return 8 / (1 + haste);
+          }
+          return 9 / (1 + haste);
+        },
         charges: combatant.has2PieceByTier(TIERS.T28) ? 3 : 2,
         gcd: {
           base: 1500,

--- a/src/analysis/retail/warrior/protection/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/protection/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import { TALENTS_WARRIOR } from 'common/TALENTS';
 import { SpellLink } from 'interface';
-import { Abelito75, Greedyhugs, ToppleTheNun } from 'CONTRIBUTORS';
+import { Abelito75, Greedyhugs, ToppleTheNun, CodersKitchen } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2023, 6, 25), 'Reduce CD of Shield Slam, when Honed Reflexes is skilled.', CodersKitchen),
   change(date(2022, 3, 11), 'Initial pass to make sure everything is cash money. ', Abelito75),
   change(date(2022, 3, 11), 'We back. ', Abelito75),
   change(date(2023, 1, 5), <>Updated cooldown timers for accuracy and added <SpellLink id={TALENTS_WARRIOR.SHIELD_CHARGE_TALENT}/>, <SpellLink id={TALENTS_WARRIOR.SPEAR_OF_BASTION_TALENT}/>, and <SpellLink id={TALENTS_WARRIOR.SHOCKWAVE_TALENT}/> (when <SpellLink id={TALENTS_WARRIOR.SONIC_BOOM_TALENT}/> talented) to offensive cooldowns</>, Greedyhugs),

--- a/src/analysis/retail/warrior/protection/modules/Abilities.ts
+++ b/src/analysis/retail/warrior/protection/modules/Abilities.ts
@@ -58,7 +58,12 @@ class Abilities extends CoreAbilities {
         },
         category: SPELL_CATEGORY.ROTATIONAL,
         buffSpellId: SPELLS.PUNISH_DEBUFF.id,
-        cooldown: (haste) => 9 / (1 + haste),
+        cooldown: (haste) => {
+          if (combatant.hasTalent(TALENTS.HONED_REFLEXES_PROTECTION_TALENT)) {
+            return 8 / (1 + haste);
+          }
+          return 9 / (1 + haste);
+        },
         timelineSortIndex: 1,
       },
       {

--- a/src/analysis/retail/warrior/protection/modules/spells/ShieldSlam.tsx
+++ b/src/analysis/retail/warrior/protection/modules/spells/ShieldSlam.tsx
@@ -7,6 +7,7 @@ import Events, { CastEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import StatTracker from 'parser/shared/modules/StatTracker';
+import TALENTS from 'common/TALENTS/warrior';
 
 const debug = false;
 
@@ -25,10 +26,14 @@ class ShieldBlock extends Analyzer {
   averageCd = 0;
   actualCasts = 0;
   totalCastsAssumed = 0;
+  baseCd = 9;
 
   constructor(options: Options) {
     super(options);
     this.lastCast = this.owner.fight.start_time / 1000;
+
+    this.baseCd = this.selectedCombatant.hasTalent(TALENTS.AVATAR_PROTECTION_TALENT) ? 8 : 9;
+
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.SHIELD_SLAM),
       this.onSlamCast,
@@ -52,7 +57,7 @@ class ShieldBlock extends Analyzer {
     }
 
     this.currentCd =
-      9 / (1 + this.statTracker.hastePercentage(this.statTracker.currentHasteRating));
+      this.baseCd / (1 + this.statTracker.hastePercentage(this.statTracker.currentHasteRating));
     this.lastCast = event.timestamp / 1000;
 
     this.totalCastsAssumed += 1;


### PR DESCRIPTION
### Description

Reflects on CD calculation of Raging Blow (Fury) and Shield Slam (Protection) the reduction by 1 second when Honed Reflexes is skilled.

### Testing

Verify that the number of possible casts has gone up, when Honed Reflexes is skilled.

- Test report URL: `/report/GKYbJcRFntrTQH2z/3-Mythic++Neltharus+-+Kill+(41:39)/Caranor/standard/overview`
- Screenshot(s):

Protection Current: ![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1186163/9921a1f3-cf8f-42f0-b2af-96855db68fa5)

Protection Pull Request: ![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1186163/7e27d36a-2e4c-456d-a0d7-fc827cfb147b)

Sadly no logs / screenshots available for Fury