### PR TITLE
Update ignored abilities for Aberrus

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -18,12 +18,14 @@ import {
   Pilsung,
   HerzBlutRaffy,
   Abelito75,
-  Jundarer
+  Jundarer,
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
+// prettier-ignore
 export default [
+  change(date(2023, 6, 25), 'Added many Aberrus DoTs to the ignore list for tank hit tracking', emallson),
   change(date(2023, 6, 22), 'Added Thousandbone Tongueslicer to list of high tier foods.', Sref),
   change(date(2023, 6, 22), 'Remove ESLint disable from probability module.', ToppleTheNun),
   change(date(2023, 6, 19), <>Implement <ItemLink id={ITEMS.VOICE_OF_THE_SILENT_STAR.id}/> stat tracking</>, Jundarer),

--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2023, 6, 25), <>Fixed <SpellLink spell={talents.CHARRED_PASSIONS_TALENT} /> buff checking in rotational tools.</>, emallson),
   change(date(2023, 6, 3), <>Fixed <SpellLink spell={talents.BREATH_OF_FIRE_TALENT} /> cast efficiency when using <SpellLink spell={talents.BREATH_OF_FIRE_TALENT} />.</>, emallson),
   change(date(2023, 6, 3), <>Added basic <SpellLink spell={talents.BLACKOUT_COMBO_TALENT} /> section.</>, emallson),
   change(date(2023, 6, 3), <>Update rotation for patch 10.1.</>, emallson),

--- a/src/analysis/retail/monk/brewmaster/modules/core/AplCheck.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/AplCheck.tsx
@@ -23,7 +23,7 @@ const SCK_CHP_WWTO = {
   spell: SPELLS.SPINNING_CRANE_KICK_BRM,
   condition: cnd.and(
     cnd.hasTalent(talents.WALK_WITH_THE_OX_TALENT),
-    cnd.buffPresent(talents.CHARRED_PASSIONS_TALENT),
+    cnd.buffPresent(SPELLS.CHARRED_PASSIONS_BUFF),
   ),
 };
 
@@ -48,7 +48,7 @@ const applyRjw = {
 
 const refreshChp: Rule = {
   spell: talents.BREATH_OF_FIRE_TALENT,
-  condition: cnd.buffMissing(talents.CHARRED_PASSIONS_TALENT, {
+  condition: cnd.buffMissing(SPELLS.CHARRED_PASSIONS_BUFF, {
     timeRemaining: 2000,
     duration: 8000,
     pandemicCap: 1,

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -630,6 +630,11 @@ const spells = spellIndexableList({
     name: 'Chi Surge',
     icon: 'ability_monk_chiexplosion',
   },
+  CHARRED_PASSIONS_BUFF: {
+    id: 386963,
+    name: 'Charred Passions',
+    icon: 'ability_monk_mightyoxkick',
+  },
   // Tier 29 2-set bonus
   BREWMASTERS_RHYTHM_BUFF: {
     id: 394797,

--- a/src/parser/shared/modules/hit-tracking/IgnoredAbilities.ts
+++ b/src/parser/shared/modules/hit-tracking/IgnoredAbilities.ts
@@ -17,6 +17,25 @@ const IGNORED: number[] = [
   395907, // Electrified Jaws (DoT)
   391282, // Crackling Energy
   395930, // Storm's Spite
+  // Kazzara
+  401898, // Terror Claws DoT
+  408370, // Infernal Heart (pulsing raid AoE)
+  // Assault of the Zaq'ali
+  405618, // Ignara's Fury (pulsing raid AoE)
+  // Rashok
+  404448, // Scorching Heatwave (pulsing raid AoE)
+  // Magmorax
+  408966, // Incinerating Maws DoT
+  413546, // Igniting Roar DoT
+  // Neltharion
+  407048, // Surrender to Corruption (pulsing raid AoE)
+  // Sarkareth
+  401339, // Burning Claws DoT
+  402053, // Seared DoT
+  401801, // Disintigrated DoT
+  401952, // Oblivion DoT
+  411240, // Void Claws DoT
+  408431, // Void Slash DoT
 ];
 
 export default IGNORED;


### PR DESCRIPTION
This list of ignored abilities is used for tank hit tracking for mitigation. These are either dots or raidwide passive aoe---things with many many small hits that can skew hit %s.