### PR TITLE
[Items] Correctly hide Voice of the Silent Star if not equipped

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -25,6 +25,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 6, 25), <>Correctly hide <ItemLink id={ITEMS.VOICE_OF_THE_SILENT_STAR.id}/> if it isn't equipped.</>, Putro),
   change(date(2023, 6, 25), 'Added many Aberrus DoTs to the ignore list for tank hit tracking', emallson),
   change(date(2023, 6, 22), 'Added Thousandbone Tongueslicer to list of high tier foods.', Sref),
   change(date(2023, 6, 22), 'Remove ESLint disable from probability module.', ToppleTheNun),

--- a/src/parser/retail/modules/items/dragonflight/VoiceOfTheSilentStar.tsx
+++ b/src/parser/retail/modules/items/dragonflight/VoiceOfTheSilentStar.tsx
@@ -21,7 +21,8 @@ class VoiceOfTheSilentStar extends Analyzer {
   constructor(options: Options) {
     super(options);
 
-    if (!this.selectedCombatant.hasBack(ITEMS.VOICE_OF_THE_SILENT_STAR.id)) {
+    this.active = this.selectedCombatant.hasBack(ITEMS.VOICE_OF_THE_SILENT_STAR.id);
+    if (!this.active) {
       return;
     }
     const cloak = this.selectedCombatant.back;


### PR DESCRIPTION
On live it shows up like this when not equipped: 
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/29204244/6eb770d8-9fa4-4467-85cf-83b6c29edc90)
