### PR TITLE
[Paladin] Retribution 10.1

### DIFF
--- a/src/analysis/retail/paladin/retribution/modules/Abilities.tsx
+++ b/src/analysis/retail/paladin/retribution/modules/Abilities.tsx
@@ -129,7 +129,8 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
-        castEfficiency: {
+        enabled: !combatant.hasTalent(TALENTS_PALADIN.CONSECRATED_BLADE_TALENT),
+        castEfficiency: combatant.hasTalent(TALENTS_PALADIN.CONSECRATED_BLADE_TALENT) ? {} : {
           suggestion: true,
           recommendedEfficiency: 0.25,
           importance: ISSUE_IMPORTANCE.MINOR,

--- a/src/analysis/retail/paladin/retribution/modules/Abilities.tsx
+++ b/src/analysis/retail/paladin/retribution/modules/Abilities.tsx
@@ -58,6 +58,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        enabled: !combatant.hasTalent(TALENTS_PALADIN.CRUSADING_STRIKES_TALENT),
         castEfficiency: {
           suggestion: true,
         },

--- a/src/analysis/retail/paladin/retribution/modules/core/Consecration.tsx
+++ b/src/analysis/retail/paladin/retribution/modules/core/Consecration.tsx
@@ -4,6 +4,7 @@ import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
 import Events, { DamageEvent } from 'parser/core/Events';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import StatisticBox, { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
+import TALENTS from 'common/TALENTS/paladin';
 
 class Consecration extends Analyzer {
   static dependencies = {
@@ -16,6 +17,9 @@ class Consecration extends Analyzer {
 
   constructor(options: Options) {
     super(options);
+
+    this.active = !this.selectedCombatant.hasTalent(TALENTS.CONSECRATED_BLADE_TALENT);
+
     this.addEventListener(
       Events.damage.by(SELECTED_PLAYER).spell(SPELLS.CONSECRATION_DAMAGE),
       this.onConsecrationDamage,

--- a/src/analysis/retail/paladin/retribution/modules/core/CrusaderStrike.tsx
+++ b/src/analysis/retail/paladin/retribution/modules/core/CrusaderStrike.tsx
@@ -9,7 +9,7 @@ class CrusaderStrike extends Analyzer {
   constructor(options: Options) {
     super(options);
 
-    this.active = !this.selectedCombatant.hasTalent(TALENTS.CONSECRATED_BLADE_TALENT);
+    this.active = !this.selectedCombatant.hasTalent(TALENTS.CRUSADING_STRIKES_TALENT);
 
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.CRUSADER_STRIKE),

--- a/src/analysis/retail/paladin/retribution/modules/core/CrusaderStrike.tsx
+++ b/src/analysis/retail/paladin/retribution/modules/core/CrusaderStrike.tsx
@@ -1,12 +1,16 @@
 import SPELLS from 'common/SPELLS';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
 import Events, { ResourceChangeEvent, CastEvent } from 'parser/core/Events';
+import TALENTS from 'common/TALENTS/paladin';
 
 class CrusaderStrike extends Analyzer {
   wasteHP = false;
 
   constructor(options: Options) {
     super(options);
+
+    this.active = !this.selectedCombatant.hasTalent(TALENTS.CONSECRATED_BLADE_TALENT);
+
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.CRUSADER_STRIKE),
       this.onCrusaderStrikeCast,

--- a/src/analysis/retail/paladin/retribution/modules/features/Checklist/Component.js
+++ b/src/analysis/retail/paladin/retribution/modules/features/Checklist/Component.js
@@ -49,7 +49,9 @@ const RetributionPaladinChecklist = ({ combatant, castEfficiency, thresholds }) 
         <AbilityRequirement spell={SPELLS.CRUSADER_STRIKE.id} />
         <AbilityRequirement spell={SPELLS.JUDGMENT_CAST.id} />
         <AbilityRequirement spell={SPELLS.BLADE_OF_JUSTICE.id} />
-        <AbilityRequirement spell={SPELLS.CONSECRATION_CAST.id} />
+        {!combatant.hasTalent(TALENTS_PALADIN.CONSECRATED_BLADE_TALENT) && (
+          <AbilityRequirement spell={SPELLS.CONSECRATION_CAST.id} />
+        )}
       </Rule>
       <Rule
         name="Use your cooldowns"

--- a/src/analysis/retail/paladin/retribution/modules/features/Checklist/Component.js
+++ b/src/analysis/retail/paladin/retribution/modules/features/Checklist/Component.js
@@ -46,7 +46,9 @@ const RetributionPaladinChecklist = ({ combatant, castEfficiency, thresholds }) 
           </>
         }
       >
-        <AbilityRequirement spell={SPELLS.CRUSADER_STRIKE.id} />
+        {!combatant.hasTalent(TALENTS_PALADIN.CRUSADING_STRIKES_TALENT) && (
+          <AbilityRequirement spell={SPELLS.CRUSADER_STRIKE.id} />
+        )}
         <AbilityRequirement spell={SPELLS.JUDGMENT_CAST.id} />
         <AbilityRequirement spell={SPELLS.BLADE_OF_JUSTICE.id} />
         {!combatant.hasTalent(TALENTS_PALADIN.CONSECRATED_BLADE_TALENT) && (


### PR DESCRIPTION
### Description

So far only two changes:
1. Do not recommend Consecration when Consecrated Blade is talented. Consecration cannot be cast.
2. Do not recommend Crusader Strike when Crusading Strikes is talented. Crusader Strike cannot be cast.

This is my first contribution and I have kept it small, simply hiding things that may confuse new ret players. I am slowly reviewing the ret module to look for more easy changes.

### Testing

Report with Consecrating Blade talented **and** Crusading Strikes talented. Should **not** recommend Consecration or Crusader Strike: `/report/PM3VFBAxJ9D8fmzd/1-Mythic++Neltharus+-+Kill+(28:07)/Thanaell/standard/overview`

Report with Consecrating Blade talented but **not** Crusading Strikes talented. Should **not** recommend Consecration, but **should** recommend Crusader Strike: `/report/QagAVZ93yH8rnNxR/1-Normal+Kazzara,+the+Hellforged+-+Kill+(2:13)/Thanaell/standard/overview`

Report with neither talented: Does anyone play like this? 🤔 

Screenshot showing neither Crusader Strike nor Consecration being recommended in core abilities (when talented). The top help text still recommends Crusader Strike. I didn't feel that was necessary to change.
<img width="1301" alt="Screenshot 2023-06-25 at 6 41 23 PM" src="https://github.com/WoWAnalyzer/WoWAnalyzer/assets/511506/73b99c52-ab23-4995-8293-ad9996e9e7d7">
