### PR TITLE
Druid Resto - added Waking Dream statistic

### DIFF
--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { TALENTS_DRUID } from 'common/TALENTS';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2023, 6, 26), <>Added statistic for <SpellLink spell={TALENTS_DRUID.WAKING_DREAM_TALENT}/>.</>, Sref),
   change(date(2023, 6, 20), 'Update SpellLink usage.', ToppleTheNun),
   change(date(2023, 5, 17), <>Added <SpellLink spell={TALENTS_DRUID.NOURISH_TALENT}/> to HPM and HPCT charts.</>, Sref),
   change(date(2023, 5, 4), <>Updated T30 (Aberrus) set to account for April 28 patch.</>, Sref),

--- a/src/analysis/retail/druid/restoration/CombatLogParser.ts
+++ b/src/analysis/retail/druid/restoration/CombatLogParser.ts
@@ -60,6 +60,7 @@ import Dreamstate from 'analysis/retail/druid/restoration/modules/spells/Dreamst
 import Tier29 from 'analysis/retail/druid/restoration/modules/dragonflight/Tier29';
 import Tier30 from 'analysis/retail/druid/restoration/modules/dragonflight/Tier30';
 import WildGrowthPrecastOrderNormalizer from 'analysis/retail/druid/restoration/normalizers/WildGrowthPrecastOrderNormalizer';
+import WakingDream from 'analysis/retail/druid/restoration/modules/spells/WakingDream';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -124,6 +125,7 @@ class CombatLogParser extends CoreCombatLogParser {
     overgrowth: Overgrowth,
     buddingLeaves: BuddingLeaves,
     dreamstate: Dreamstate,
+    wakingDream: WakingDream,
 
     // Mana Tab
     manaTracker: ManaTracker,

--- a/src/analysis/retail/druid/restoration/modules/spells/WakingDream.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/WakingDream.tsx
@@ -1,0 +1,67 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { TALENTS_DRUID } from 'common/TALENTS';
+import SPELLS from 'common/SPELLS';
+import Events, { HealEvent } from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import HotTrackerRestoDruid from 'analysis/retail/druid/restoration/modules/core/hottracking/HotTrackerRestoDruid';
+import { calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
+
+const BOOST_PER_REJUV = 0.08;
+const RATE_MULT = 1.25; // Ticks every 4 seconds instead of every 5
+
+/**
+ * **Waking Dream**
+ * Spec Talent
+ *
+ * Ysera's Gift now heals every 4 sec and its healing is increased by 8% for each of your active Rejuvenations.
+ */
+export default class WakingDream extends Analyzer {
+  static dependencies = {
+    hotTracker: HotTrackerRestoDruid,
+  };
+
+  hotTracker!: HotTrackerRestoDruid;
+
+  totalHealing = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.WAKING_DREAM_TALENT);
+    this.addEventListener(
+      Events.heal.by(SELECTED_PLAYER).spell([SPELLS.YSERAS_GIFT_SELF, SPELLS.YSERAS_GIFT_OTHERS]),
+      this.onYserasGiftHeal,
+    );
+  }
+
+  onYserasGiftHeal(event: HealEvent) {
+    const rejuvCount =
+      this.hotTracker.getHotCount(SPELLS.REJUVENATION.id) +
+      this.hotTracker.getHotCount(SPELLS.REJUVENATION_GERMINATION.id);
+    this.totalHealing += calculateEffectiveHealing(event, rejuvCount * BOOST_PER_REJUV) * RATE_MULT;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(4)} // number based on talent row
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
+        tooltip={
+          <>
+            This value is calculated from the healing boost due to Rejuvs out and estimates the
+            effect of faster tick rate by assuming a linear increase in healing.
+          </>
+        }
+      >
+        <BoringSpellValueText spell={TALENTS_DRUID.WAKING_DREAM_TALENT}>
+          <ItemPercentHealingDone amount={this.totalHealing} />
+          <br />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}


### PR DESCRIPTION
### Description

A simple healing done statistic for Waking Dream talent

### Testing

- Test report URL: `/report/RAmWt2bjkdrqPy4a/8-Mythic+Rashok,+the+Elder+-+Wipe+6+(6:42)/Squishses/standard/statistics`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/7143486/026e2a98-1c15-4f98-b833-4cffa3bff6d4)

