### PR TITLE
[Shadow]  Add Shadowfiend to guide view cooldowns.  

### DIFF
--- a/src/analysis/retail/priest/shadow/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/shadow/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { DoxAshe, Havoc } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 6, 27), <>Add <SpellLink id={TALENTS.SHADOWFIEND_TALENT}/> cooldown tracking to guide view</>,DoxAshe),
   change(date(2023, 6, 22), <>Track <SpellLink id={SPELLS.VOIDFORM}/> duration extension</>,DoxAshe),
   change(date(2023, 6, 7), <>Fix <SpellLink id={SPELLS.VOID_BOLT}/> cooldown tracking</>,DoxAshe),
   change(date(2023, 5, 29), <>Added <SpellLink id={TALENTS.MANIPULATION_TALENT}/> cooldown reduction</>,DoxAshe),

--- a/src/analysis/retail/priest/shadow/modules/guide/CooldownGraphSubsection.tsx
+++ b/src/analysis/retail/priest/shadow/modules/guide/CooldownGraphSubsection.tsx
@@ -38,12 +38,17 @@ const shortCooldowns: Cooldown[] = [
   { talent: TALENTS.MINDGAMES_TALENT },
 ];
 
-const longCooldowns: Cooldown[] = [
+const longCooldownsMB: Cooldown[] = [
   { talent: TALENTS.POWER_INFUSION_TALENT },
   { talent: TALENTS.DARK_ASCENSION_TALENT },
   { talent: TALENTS.VOID_ERUPTION_TALENT },
   { talent: TALENTS.MINDBENDER_SHADOW_TALENT },
-  //{ talent: TALENTS.SHADOWFIEND_TALENT }, TODO: Fix Shadowfiend when in this list
+];
+const longCooldownsSF: Cooldown[] = [
+  { talent: TALENTS.POWER_INFUSION_TALENT },
+  { talent: TALENTS.DARK_ASCENSION_TALENT },
+  { talent: TALENTS.VOID_ERUPTION_TALENT },
+  { talent: TALENTS.SHADOWFIEND_TALENT },
 ];
 
 const CoreCooldownsGraph = () => {
@@ -126,6 +131,12 @@ const ShortCooldownsGraph = () => {
 };
 
 const LongCooldownsGraph = () => {
+  const info = useInfo();
+  let longCooldowns = longCooldownsSF;
+  if (info!.combatant.hasTalent(TALENTS.MINDBENDER_SHADOW_TALENT)) {
+    longCooldowns = longCooldownsMB;
+  }
+
   const message = (
     <Trans id="guide.priest.shadow.sections.longcooldowns.graph">
       <strong>Major Cooldowns</strong> - this graph shows when you used your cooldowns and how long


### PR DESCRIPTION
### Description

The guide view for shadow priest wasn't showing Shadowfiend.  As one of our major cooldowns, it is important to show it here.

![shadowfiend](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/103148620/84d7cbd5-9409-4c70-83b0-2de2e561446b)
