### PR TITLE
[Mage] Add Temporal Warp to Bloodlust Buffs

### DIFF
--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -1,16 +1,18 @@
 import { change, date } from 'common/changelog';
-import talents from 'common/TALENTS/mage';
+import TALENTS from 'common/TALENTS/mage';
 import { Sharrq, emallson, SyncSubaru } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
-  change(date(2023, 3, 19), <>Fixed utilisation percentage for <SpellLink id={talents.TOUCH_OF_THE_MAGI_TALENT} /> under <SpellLink id={talents.ARCANE_ECHO_TALENT} />.</>, SyncSubaru),
-  change(date(2023, 3, 26), <>Renamed old <SpellLink id={talents.ARCANE_POWER_TALENT} /> into <SpellLink id={talents.ARCANE_SURGE_TALENT} /> in preparation for new analysis modules.</>, SyncSubaru),
-  change(date(2023, 3, 25), <><SpellLink id={talents.ARCANE_SURGE_TALENT} /> now shows on the timeline when active.</>, SyncSubaru),
-  change(date(2023, 3, 19), <>Created anaylser for <SpellLink id={talents.RADIANT_SPARK_TALENT} /> ramp phases.</>, SyncSubaru),
-  change(date(2023, 3, 14), <><SpellLink id={talents.ARCANE_HARMONY_TALENT} /> now shows Bonus Damage under Statistics.</>, SyncSubaru),
-  change(date(2023, 3, 13), <>Updated bonus damage multiplier of <SpellLink id={talents.ARCANE_HARMONY_TALENT} />.</>, SyncSubaru),
-  change(date(2023, 1, 17), <>Fixed outdated reference to the Shadowlands version of <SpellLink id={talents.RADIANT_SPARK_TALENT} />.</>, emallson),
+  change(date(2023, 6, 27), <>Added <SpellLink id={TALENTS.TEMPORAL_WARP_TALENT.id} /> to list of Bloodlust Buffs.</>, Sharrq),
+  change(date(2023, 1, 17), <>Fixed outdated reference to the Shadowlands version of <SpellLink id={TALENTS.RADIANT_SPARK_TALENT} />.</>, emallson),
+  change(date(2023, 3, 19), <>Fixed utilisation percentage for <SpellLink id={TALENTS.TOUCH_OF_THE_MAGI_TALENT} /> under <SpellLink id={TALENTS.ARCANE_ECHO_TALENT} />.</>, SyncSubaru),
+  change(date(2023, 3, 26), <>Renamed old <SpellLink id={TALENTS.ARCANE_POWER_TALENT} /> into <SpellLink id={TALENTS.ARCANE_SURGE_TALENT} /> in preparation for new analysis modules.</>, SyncSubaru),
+  change(date(2023, 3, 25), <><SpellLink id={TALENTS.ARCANE_SURGE_TALENT} /> now shows on the timeline when active.</>, SyncSubaru),
+  change(date(2023, 3, 19), <>Created anaylser for <SpellLink id={TALENTS.RADIANT_SPARK_TALENT} /> ramp phases.</>, SyncSubaru),
+  change(date(2023, 3, 14), <><SpellLink id={TALENTS.ARCANE_HARMONY_TALENT} /> now shows Bonus Damage under Statistics.</>, SyncSubaru),
+  change(date(2023, 3, 13), <>Updated bonus damage multiplier of <SpellLink id={TALENTS.ARCANE_HARMONY_TALENT} />.</>, SyncSubaru),
+  change(date(2023, 1, 17), <>Fixed outdated reference to the Shadowlands version of <SpellLink id={TALENTS.RADIANT_SPARK_TALENT} />.</>, emallson),
   change(date(2022, 10, 30), `Update Dragonflight SPELLS, Abilities, and Buffs`, Sharrq),
   change(date(2022, 9, 29), 'Initial Dragonflight support', Sharrq),
 ];

--- a/src/analysis/retail/mage/fire/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/fire/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Sharrq, ToppleTheNun } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2023, 6, 27), <>Added <SpellLink id={TALENTS.TEMPORAL_WARP_TALENT.id} /> to list of Bloodlust Buffs.</>, Sharrq),
   change(date(2023, 2, 12), <>Marked the spec supported for 10.0.5</>, Sharrq),
   change(date(2022, 12, 13), <>Removed references to Infernal Cascade and replaced with <SpellLink id={TALENTS.FEEL_THE_BURN_TALENT} /> functionality.</>, Sharrq),
   change(date(2022, 12, 13), <>Fixed <SpellLink id={TALENTS.SHIFTING_POWER_TALENT} /> functionality.</>, Sharrq),

--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 import { Sharrq } from 'CONTRIBUTORS';
 
 export default [
+	change(date(2023, 6, 27), <>Added <SpellLink id={TALENTS.TEMPORAL_WARP_TALENT.id} /> to list of Bloodlust Buffs.</>, Sharrq),
 	change(date(2023, 2, 12), <>Bumped support up to 10.0.5 and fixed an issue that could cause every <SpellLink id={TALENTS.RUNE_OF_POWER_TALENT} /> cast to count as overlapped.</>, Sharrq),
 	change(date(2023, 1, 14), `Added a link to Toegrinder's Mage Hub guide on the About page. Removed link to Icy Veins and Altered Time forums.`, Sharrq),
 	change(date(2023, 1, 14), `Upgraded Frost Mage support to 10.0.2 and marked as Supported. Also removed Dambroda from spec maintainers.`, Sharrq),

--- a/src/analysis/retail/mage/shared/SPELLS.ts
+++ b/src/analysis/retail/mage/shared/SPELLS.ts
@@ -179,6 +179,11 @@ const spells = spellIndexableList({
     name: 'Tempest Barrier',
     icon: 'inv_shield_1h_artifactstormfist_d_04',
   },
+  TEMPORAL_WARP_BUFF: {
+    id: 386540,
+    name: 'Temporal Warp',
+    icon: 'ability_bossmagistrix_timewarp2',
+  },
 });
 
 export default spells;

--- a/src/game/BLOODLUST_BUFFS.ts
+++ b/src/game/BLOODLUST_BUFFS.ts
@@ -6,6 +6,7 @@ const BLOODLUST_BUFFS: {
   [SPELLS.BLOODLUST.id]: 0.3,
   [SPELLS.HEROISM.id]: 0.3, // Alliance Bloodlust
   [SPELLS.TIME_WARP.id]: 0.3, // Mage
+  [SPELLS.TEMPORAL_WARP_BUFF.id]: 0.3, //Mage
   [SPELLS.PRIMAL_RAGE_1.id]: 0.3, // Hunter pet BL
   [SPELLS.PRIMAL_RAGE_2.id]: 0.3, // Hunter pet BL
   [SPELLS.FURY_OF_THE_ASPECTS.id]: 0.3, // Evoker


### PR DESCRIPTION
The Mage Personal Lust is not included in the list of Bloodlust buffs, which was causing haste to be pretty far off for most mages.

