### PR TITLE
[Shadow] Add missing spells to Channeling

### DIFF
--- a/src/analysis/retail/priest/shadow/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/shadow/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { DoxAshe, Havoc } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 6, 29), <>Add <SpellLink id={TALENTS.VOID_TORRENT_TALENT}/>, <SpellLink id={SPELLS.MIND_FLAY}/>, amd <SpellLink id={SPELLS.MIND_FLAY_INSANITY_TALENT_DAMAGE}/> to channeled spells to fix downtime and timeline</>,DoxAshe),
   change(date(2023, 6, 27), <>Add <SpellLink id={TALENTS.SHADOWFIEND_TALENT}/> cooldown tracking to guide view</>,DoxAshe),
   change(date(2023, 6, 22), <>Track <SpellLink id={SPELLS.VOIDFORM}/> duration extension</>,DoxAshe),
   change(date(2023, 6, 7), <>Fix <SpellLink id={SPELLS.VOID_BOLT}/> cooldown tracking</>,DoxAshe),

--- a/src/analysis/retail/priest/shadow/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/shadow/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import { DoxAshe, Havoc } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
-  change(date(2023, 6, 29), <>Add <SpellLink id={TALENTS.VOID_TORRENT_TALENT}/>, <SpellLink id={SPELLS.MIND_FLAY}/>, amd <SpellLink id={SPELLS.MIND_FLAY_INSANITY_TALENT_DAMAGE}/> to channeled spells to fix downtime and timeline</>,DoxAshe),
+  change(date(2023, 6, 29), <>Add <SpellLink id={TALENTS.VOID_TORRENT_TALENT}/>, <SpellLink id={SPELLS.MIND_FLAY}/>, and <SpellLink id={SPELLS.MIND_FLAY_INSANITY_TALENT_DAMAGE}/> to channeled spells to fix downtime and timeline</>,DoxAshe),
   change(date(2023, 6, 27), <>Add <SpellLink id={TALENTS.SHADOWFIEND_TALENT}/> cooldown tracking to guide view</>,DoxAshe),
   change(date(2023, 6, 22), <>Track <SpellLink id={SPELLS.VOIDFORM}/> duration extension</>,DoxAshe),
   change(date(2023, 6, 7), <>Fix <SpellLink id={SPELLS.VOID_BOLT}/> cooldown tracking</>,DoxAshe),

--- a/src/parser/shared/normalizers/Channeling.ts
+++ b/src/parser/shared/normalizers/Channeling.ts
@@ -53,7 +53,8 @@ class Channeling extends EventsNormalizer {
     buffChannelSpec(TALENTS_PRIEST.DIVINE_HYMN_TALENT.id),
     nextCastChannelSpec(SPELLS.PENANCE_CAST.id),
     buffChannelSpec(SPELLS.MIND_FLAY.id), // TODO double check ID
-    buffChannelSpec(SPELLS.MIND_SEAR.id), // TODO double check ID
+    buffChannelSpec(SPELLS.MIND_FLAY_INSANITY_TALENT_DAMAGE.id), // TODO double check ID
+    buffChannelSpec(TALENTS_PRIEST.VOID_TORRENT_TALENT.id), // TODO double check ID
     // Rogue
     // Druid
     buffChannelSpec(SPELLS.CONVOKE_SPIRITS.id),


### PR DESCRIPTION
### Description

Some of shadow's channeled spells were not added to Channeling.  This adds them to it, to fix issues with downtime calculations and the timeline view.

- Screenshot(s):
![VTchannel](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/103148620/a88fd814-3b2a-4af2-8b59-933253214960)
