### PR TITLE
[BrM] Stagger Statistics + Cat Statue fixup

### DIFF
--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -6,6 +6,8 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2023, 7, 3), <>Fixed handling of pre-pull <SpellLink spell={talents.SUMMON_WHITE_TIGER_STATUE_TALENT} /> casts.</>, emallson),
+  change(date(2023, 7, 3), <>Added statistics for <SpellLink spell={talents.QUICK_SIP_TALENT} />, <SpellLink spell={talents.STAGGERING_STRIKES_TALENT} />, and <SpellLink spell={talents.TRANQUIL_SPIRIT_TALENT} />.</>, emallson),
   change(date(2023, 6, 25), <>Fixed <SpellLink spell={talents.CHARRED_PASSIONS_TALENT} /> buff checking in rotational tools.</>, emallson),
   change(date(2023, 6, 3), <>Fixed <SpellLink spell={talents.BREATH_OF_FIRE_TALENT} /> cast efficiency when using <SpellLink spell={talents.BREATH_OF_FIRE_TALENT} />.</>, emallson),
   change(date(2023, 6, 3), <>Added basic <SpellLink spell={talents.BLACKOUT_COMBO_TALENT} /> section.</>, emallson),

--- a/src/analysis/retail/monk/brewmaster/modules/Abilities.ts
+++ b/src/analysis/retail/monk/brewmaster/modules/Abilities.ts
@@ -276,6 +276,7 @@ class Abilities extends CoreAbilities {
         spell: talents.SUMMON_WHITE_TIGER_STATUE_TALENT.id,
         category: SPELL_CATEGORY.COOLDOWNS,
         enabled: combatant.hasTalent(talents.SUMMON_WHITE_TIGER_STATUE_TALENT),
+        damageSpellIds: [SPELLS.CLAW_OF_THE_WHITE_TIGER.id],
         gcd: {
           static: 1000,
         },

--- a/src/analysis/retail/monk/brewmaster/modules/talents/QuickSip.ts
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/QuickSip.ts
@@ -1,8 +1,8 @@
 import SPELLS from 'common/SPELLS';
 import talents from 'common/TALENTS/monk';
-import Analyzer, { Options } from 'parser/core/Analyzer';
+import { Options } from 'parser/core/Analyzer';
 import Events, { DamageEvent } from 'parser/core/Events';
-import StaggerFabricator from '../core/StaggerFabricator';
+import StaggerStatistic from '../tools/StaggerAnalyzer';
 
 const QUICK_SIP_RATE = 0.01 / 3;
 const DAMAGE_BUFFER = 150; // for SCK to break this, you need over 150% haste. good luck.
@@ -13,16 +13,11 @@ const SHUFFLE_DURATION = {
   [SPELLS.SPINNING_CRANE_KICK_BRM.id]: 1,
 };
 
-export default class QuickSip extends Analyzer {
-  static dependencies = {
-    staggerFab: StaggerFabricator,
-  };
-
-  protected staggerFab!: StaggerFabricator;
+export default class QuickSip extends StaggerStatistic {
   protected rank: number;
 
   constructor(options: Options) {
-    super(options);
+    super(talents.QUICK_SIP_TALENT, options);
 
     this.rank = this.selectedCombatant.getTalentRank(talents.QUICK_SIP_TALENT);
     this.active = this.rank > 0;
@@ -59,9 +54,9 @@ export default class QuickSip extends Analyzer {
   private onDamage(event: DamageEvent) {
     if (this.isFirstHit(event)) {
       const pct = SHUFFLE_DURATION[event.ability.guid] * this.rank * QUICK_SIP_RATE;
-      const amount = this.staggerFab.staggerPool * pct;
+      const amount = this.fab.staggerPool * pct;
 
-      this.staggerFab.removeStagger(event, amount);
+      this.removeStagger(event, amount);
     }
 
     this.recordHit(event);

--- a/src/analysis/retail/monk/brewmaster/modules/talents/StaggeringStrikes.ts
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/StaggeringStrikes.ts
@@ -1,20 +1,14 @@
 import SPELLS from 'common/SPELLS';
 import talents from 'common/TALENTS/monk';
-import Analyzer, { Options } from 'parser/core/Analyzer';
+import { Options } from 'parser/core/Analyzer';
 import Events, { CastEvent } from 'parser/core/Events';
-import StaggerFabricator from '../core/StaggerFabricator';
+import StaggerStatistic from '../tools/StaggerAnalyzer';
 
-export default class StaggeringStrikes extends Analyzer {
-  static dependencies = {
-    staggerFab: StaggerFabricator,
-  };
-
-  protected staggerFab!: StaggerFabricator;
-
+export default class StaggeringStrikes extends StaggerStatistic {
   protected rank: number;
 
   constructor(options: Options) {
-    super(options);
+    super(talents.STAGGERING_STRIKES_TALENT, options);
 
     this.rank = this.selectedCombatant.getTalentRank(talents.STAGGERING_STRIKES_TALENT);
     this.active = this.rank > 0;
@@ -28,6 +22,6 @@ export default class StaggeringStrikes extends Analyzer {
 
     const amount = ((event.attackPower ?? 0) * this.rank) / 2;
 
-    this.staggerFab.removeStagger(event, amount);
+    this.removeStagger(event, amount);
   }
 }

--- a/src/analysis/retail/monk/brewmaster/modules/talents/TranquilSpirit.ts
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/TranquilSpirit.ts
@@ -1,20 +1,15 @@
 import SPELLS from 'common/SPELLS';
 import talents from 'common/TALENTS/monk';
-import Analyzer, { Options } from 'parser/core/Analyzer';
+import { Options } from 'parser/core/Analyzer';
 import Events, { HealEvent } from 'parser/core/Events';
 import { GIFT_OF_THE_OX_SPELLS } from '../../constants';
-import StaggerFabricator from '../core/StaggerFabricator';
+import StaggerAnalyzer from '../tools/StaggerAnalyzer';
 
 const TRANQUIL_SPIRIT_RATE = 0.05;
 
-export default class TranquilSpirit extends Analyzer {
-  static dependencies = {
-    staggerFab: StaggerFabricator,
-  };
-
-  protected staggerFab!: StaggerFabricator;
+export default class TranquilSpirit extends StaggerAnalyzer {
   constructor(options: Options) {
-    super(options);
+    super(talents.TRANQUIL_SPIRIT_TALENT, options);
 
     this.active = this.selectedCombatant.hasTalent(talents.TRANQUIL_SPIRIT_TALENT);
 
@@ -25,7 +20,7 @@ export default class TranquilSpirit extends Analyzer {
   }
 
   private triggerTranquilSpirit(event: HealEvent) {
-    const amount = this.staggerFab.staggerPool * TRANQUIL_SPIRIT_RATE;
-    this.staggerFab.removeStagger(event, amount);
+    const amount = this.fab.staggerPool * TRANQUIL_SPIRIT_RATE;
+    this.removeStagger(event, amount);
   }
 }

--- a/src/analysis/retail/monk/brewmaster/modules/tools/StaggerAnalyzer.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/tools/StaggerAnalyzer.tsx
@@ -1,6 +1,5 @@
 import { formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
-import Spell from 'common/SPELLS/Spell';
 import { Talent } from 'common/TALENTS/types';
 import { SpellLink } from 'interface';
 import Analyzer, { Options } from 'parser/core/Analyzer';
@@ -10,11 +9,6 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import TalentSpellText from 'parser/ui/TalentSpellText';
 import StaggerFabricator from '../core/StaggerFabricator';
-
-export interface StaggerStatisticProps {
-  talent: Talent;
-  triggerSpells: Spell[];
-}
 
 export default abstract class StaggerStatistic extends Analyzer {
   static dependencies = { fab: StaggerFabricator };

--- a/src/analysis/retail/monk/brewmaster/modules/tools/StaggerAnalyzer.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/tools/StaggerAnalyzer.tsx
@@ -1,0 +1,60 @@
+import { formatNumber } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import Spell from 'common/SPELLS/Spell';
+import { Talent } from 'common/TALENTS/types';
+import { SpellLink } from 'interface';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import { AnyEvent } from 'parser/core/Events';
+import ItemDamageTaken from 'parser/ui/ItemDamageTaken';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+import StaggerFabricator from '../core/StaggerFabricator';
+
+export interface StaggerStatisticProps {
+  talent: Talent;
+  triggerSpells: Spell[];
+}
+
+export default abstract class StaggerStatistic extends Analyzer {
+  static dependencies = { fab: StaggerFabricator };
+  protected fab!: StaggerFabricator;
+
+  private staggerRemoved = 0;
+  private removalEventCount = 0;
+  private talent: Talent;
+
+  protected removeStagger(event: AnyEvent, amount: number) {
+    this.staggerRemoved += this.fab.removeStagger(event, amount);
+    this.removalEventCount += 1;
+  }
+
+  constructor(talent: Talent, options: Options) {
+    super(options);
+    this.talent = talent;
+
+    this.active = this.selectedCombatant.hasTalent(talent);
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            Removed <strong>{formatNumber(this.staggerRemoved)}</strong>{' '}
+            <SpellLink spell={SPELLS.STAGGER} /> over <strong>{this.removalEventCount}</strong>{' '}
+            clears (an average of{' '}
+            <strong>{formatNumber(this.staggerRemoved / this.removalEventCount)}</strong> per
+            clear).
+          </>
+        }
+      >
+        <TalentSpellText talent={this.talent}>
+          <ItemDamageTaken amount={this.staggerRemoved} hideTotal />
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -206,6 +206,11 @@ const spells = spellIndexableList({
     name: 'Blackout Kick',
     icon: 'ability_monk_roundhousekick',
   },
+  CLAW_OF_THE_WHITE_TIGER: {
+    id: 389541,
+    name: 'Claw of the White Tiger',
+    icon: 'ability_monk_summonwhitetigerstatue',
+  },
 
   // Utility / Other
   DETOX: {

--- a/src/parser/shared/normalizers/PrePullCooldowns.js
+++ b/src/parser/shared/normalizers/PrePullCooldowns.js
@@ -7,7 +7,7 @@ import Buffs from 'parser/core/modules/Auras';
 
 import ApplyBuff from './ApplyBuff';
 
-const debug = false;
+const debug = true;
 
 /**
  * This normalizer attempts to track all potentially relevant casts that
@@ -95,6 +95,8 @@ class PrePullCooldowns extends EventsNormalizer {
     const firstEventIndex = this.getFightStartIndex(events);
     const firstTimestamp = events[firstEventIndex].timestamp;
     const playerId = this.owner.playerId;
+    const petIds = new Set(this.owner.playerPets.map((pet) => pet.id));
+    console.log('pets', this.owner.playerPets, petIds);
 
     for (let i = 0; i < events.length; i += 1) {
       const event = events[i];
@@ -114,9 +116,11 @@ class PrePullCooldowns extends EventsNormalizer {
               buffSpells[i].castId.includes(event.ability.guid)
             ) {
               //try to find corresponding cast, otherwise pass list of casts
-              prepullCasts.push(this.constructor._fabricateCastEvent(event));
+              prepullCasts.push(this.constructor._fabricateCastEvent(event, playerId));
             } else {
-              prepullCasts.push(this.constructor._fabricateCastEvent(event, buffSpells[i].castId));
+              prepullCasts.push(
+                this.constructor._fabricateCastEvent(event, playerId, buffSpells[i].castId),
+              );
             }
             buffSpells.splice(i, 1);
             break;
@@ -125,7 +129,7 @@ class PrePullCooldowns extends EventsNormalizer {
         continue;
       }
 
-      if (sourceId !== playerId) {
+      if (sourceId !== playerId && !petIds.has(sourceId)) {
         continue;
       }
 
@@ -167,7 +171,9 @@ class PrePullCooldowns extends EventsNormalizer {
         for (let i = 0; i < damageSpells.length; i += 1) {
           if (damageSpells[i].damageIds.some((id) => id === event.ability.guid)) {
             debug && console.debug(`Detected a precast damage cooldown: ${event.ability.name}`);
-            prepullCasts.push(this.constructor._fabricateCastEvent(event, damageSpells[i].castId));
+            prepullCasts.push(
+              this.constructor._fabricateCastEvent(event, playerId, damageSpells[i].castId),
+            );
             damageSpells.splice(i, 1);
             break;
           }
@@ -221,7 +227,7 @@ class PrePullCooldowns extends EventsNormalizer {
     return 1500;
   }
 
-  static _fabricateCastEvent(event, castId = null) {
+  static _fabricateCastEvent(event, sourceId, castId = null) {
     let ability = event.ability;
     if (castId) {
       if (castId instanceof Array) {
@@ -239,7 +245,7 @@ class PrePullCooldowns extends EventsNormalizer {
     return {
       type: EventType.Cast,
       ability: ability,
-      sourceID: event.sourceID,
+      sourceID: sourceId,
       sourceIsFriendly: event.sourceIsFriendly,
       targetID: event.targetID,
       targetIsFriendly: event.targetIsFriendly,

--- a/src/parser/shared/normalizers/PrePullCooldowns.js
+++ b/src/parser/shared/normalizers/PrePullCooldowns.js
@@ -7,7 +7,7 @@ import Buffs from 'parser/core/modules/Auras';
 
 import ApplyBuff from './ApplyBuff';
 
-const debug = true;
+const debug = false;
 
 /**
  * This normalizer attempts to track all potentially relevant casts that
@@ -96,7 +96,6 @@ class PrePullCooldowns extends EventsNormalizer {
     const firstTimestamp = events[firstEventIndex].timestamp;
     const playerId = this.owner.playerId;
     const petIds = new Set(this.owner.playerPets.map((pet) => pet.id));
-    console.log('pets', this.owner.playerPets, petIds);
 
     for (let i = 0; i < events.length; i += 1) {
       const event = events[i];


### PR DESCRIPTION
### Description

- Add stagger stats for 3 talents that remove clear stagger. The calculation for these is already in, just wasn't showing a statbox for them.
- Support pre-pull Cat Statue. This requires doing a little work in the `PrePullNormalizer` since the source of the in-pull damage/casts is *not* the player, but the statue.

### Testing

Log: https://www.warcraftlogs.com/reports/3HabqrdxDzngFP2L#fight=36&type=damage-done&phase=3&source=30&ability=389541

**Cat Statue**
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/4909458/3f18a70d-d48d-495e-90cf-cbf6d136fc9d)

**Stagger Stats**
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/4909458/51b78e24-679a-417c-aa3a-83972ec9c0e3)

(There aren't really SS/TS logs that i can find. they don't log any casts, buffs, etc that can be searched for and WCL doesn't support talent build search. These are SUPER off-meta talents)
