### PR TITLE
[Hunter] Add support for BM Tier 30

### DIFF
--- a/src/analysis/retail/hunter/beastmastery/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/beastmastery/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/hunter';
 import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 export default [
+  change(date(2023, 7, 3), 'Added support for Tier 30 2piece and 4piece', Putro),
   change(date(2023, 5, 8), <>Fixed an issue with <SpellLink spell={TALENTS.BLOODSHED_TALENT} />. </>, Putro),
   change(date(2023, 5, 8), <>Added support for T29 tier sets.</>, Putro),
   change(date(2023, 5, 8), <>Fixed another issue with <SpellLink id={TALENTS.DIRE_BEAST_TALENT.id} /> when using a glyph. </>, Putro),

--- a/src/analysis/retail/hunter/beastmastery/CombatLogParser.ts
+++ b/src/analysis/retail/hunter/beastmastery/CombatLogParser.ts
@@ -55,6 +55,8 @@ import DirePack from './modules/talents/DirePack';
 import T29BMTier2P from './modules/items/T29BMTier2P';
 import T29BMTier4P from './modules/items/T29BMTier4P';
 import CallToDominance from 'parser/retail/modules/items/dragonflight/CallToDominance';
+import T30BMTier2P from './modules/items/T30BMTier2P';
+import T30BMTier4P from './modules/items/T30BMTier4P';
 
 class CombatLogParser extends CoreCombatLogParser {
   static guide = Guide;
@@ -129,6 +131,8 @@ class CombatLogParser extends CoreCombatLogParser {
     //Items
     t292p: T29BMTier2P,
     t294p: T29BMTier4P,
+    t302p: T30BMTier2P,
+    t304p: T30BMTier4P,
     callToDominance: CallToDominance,
   };
 }

--- a/src/analysis/retail/hunter/beastmastery/modules/Abilities.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/Abilities.tsx
@@ -78,9 +78,9 @@ class Abilities extends CoreAbilities {
           recommendedEfficiency: 0.9,
           extraSuggestion: (
             <>
-              <SpellLink id={TALENTS.BESTIAL_WRATH_TALENT.id} /> should be cast on cooldown as its
+              <SpellLink spell={TALENTS.BESTIAL_WRATH_TALENT} /> should be cast on cooldown as its
               cooldown is quickly reset again through{' '}
-              <SpellLink id={TALENTS.BARBED_SHOT_TALENT.id} />.
+              <SpellLink spell={TALENTS.BARBED_SHOT_TALENT} />.
             </>
           ),
         },

--- a/src/analysis/retail/hunter/beastmastery/modules/guide/sections/resources/ResourceUseSection.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/guide/sections/resources/ResourceUseSection.tsx
@@ -35,7 +35,7 @@ export default function ResourceUseSection(modules: ModulesOf<typeof CombatLogPa
           - like while handling mechanics or during intermission phases.
         </p>
         The chart below shows your <ResourceLink id={RESOURCE_TYPES.FOCUS.id} /> over the course of
-        the encounter. You spent{' '}
+        the encounter. You wasted{' '}
         <PerformanceStrongWithTooltip
           performance={modules.focusTracker.percentAtCapPerformance}
           tooltip={
@@ -54,8 +54,7 @@ export default function ResourceUseSection(modules: ModulesOf<typeof CombatLogPa
           {formatNumber(modules.focusTracker.wasted)} (
           {formatPercentage(modules.focusTracker.percentAtCap, 1)}%)
         </PerformanceStrongWithTooltip>{' '}
-        <ResourceLink id={RESOURCE_TYPES.FOCUS.id} /> wasted.
-        {modules.focusGraph.plot}
+        <ResourceLink id={RESOURCE_TYPES.FOCUS.id} />.{modules.focusGraph.plot}
       </SubSection>
     </Section>
   );

--- a/src/analysis/retail/hunter/beastmastery/modules/items/T30BMTier2P.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/items/T30BMTier2P.tsx
@@ -1,0 +1,62 @@
+import SPELLS from 'common/SPELLS';
+import { TALENTS_HUNTER } from 'common/TALENTS';
+import { formatNumber } from 'common/format';
+import { TIERS } from 'game/TIERS';
+import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
+import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
+import Events, { DamageEvent } from 'parser/core/Events';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import Statistic from 'parser/ui/Statistic';
+
+const DAMAGE_AMP = 0.15;
+/**
+ * https://www.wowhead.com/spell=405524/hunter-beast-mastery-10-1-class-set-2pc
+ * Cobra Shot and Kill Command damage increased by 15%.
+ */
+export default class T30BMTier2P extends Analyzer {
+  killCommandDamage: number = 0;
+  cobraShotDamage: number = 0;
+  totalDamage: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.has2PieceByTier(TIERS.T30);
+
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER_PET).spell(SPELLS.KILL_COMMAND_SHARED_DAMAGE),
+      this.onKillCommandDamage,
+    );
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(TALENTS_HUNTER.COBRA_SHOT_TALENT),
+      this.onCobraShotDamage,
+    );
+  }
+
+  onCobraShotDamage(event: DamageEvent) {
+    this.cobraShotDamage += calculateEffectiveDamage(event, DAMAGE_AMP);
+  }
+  onKillCommandDamage(event: DamageEvent) {
+    this.killCommandDamage += calculateEffectiveDamage(event, DAMAGE_AMP);
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        category={STATISTIC_CATEGORY.ITEMS}
+        tooltip={
+          <>
+            Cobra Shot damage: {formatNumber(this.cobraShotDamage)}
+            <br />
+            Kill Command damage: {formatNumber(this.killCommandDamage)}
+          </>
+        }
+      >
+        <BoringSpellValueText spell={SPELLS.T30_2P_BONUS_BEAST_MASTERY}>
+          <ItemDamageDone amount={this.cobraShotDamage + this.killCommandDamage} />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}

--- a/src/analysis/retail/hunter/beastmastery/modules/items/T30BMTier4P.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/items/T30BMTier4P.tsx
@@ -1,0 +1,66 @@
+import SPELLS from 'common/SPELLS';
+import { TIERS } from 'game/TIERS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import SpellUsable from '../core/SpellUsable';
+import { TALENTS_HUNTER } from 'common/TALENTS';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import Statistic from 'parser/ui/Statistic';
+import { formatNumber } from 'common/format';
+
+const REDUCTION_MS = 2000;
+/**
+ * https://www.wowhead.com/spell=405525/hunter-beast-mastery-10-1-class-set-4pc
+ * Cobra Shot, Kill Command, and Multi-Shot reduce the cooldown of Bestial Wrath by 2.0 sec.
+ */
+export default class T30BMTier4P extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+  };
+
+  protected spellUsable!: SpellUsable;
+  effectiveBWReduction = 0;
+  wastedBWReduction = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.has4PieceByTier(TIERS.T30);
+
+    this.addEventListener(
+      Events.cast
+        .by(SELECTED_PLAYER)
+        .spell([
+          TALENTS_HUNTER.MULTI_SHOT_BEAST_MASTERY_TALENT,
+          TALENTS_HUNTER.COBRA_SHOT_TALENT,
+          TALENTS_HUNTER.KILL_COMMAND_SHARED_TALENT,
+        ]),
+      this.onCast,
+    );
+  }
+
+  onCast() {
+    if (this.spellUsable.isOnCooldown(TALENTS_HUNTER.BESTIAL_WRATH_TALENT.id)) {
+      const reductionMs = this.spellUsable.reduceCooldown(
+        TALENTS_HUNTER.BESTIAL_WRATH_TALENT.id,
+        REDUCTION_MS,
+      );
+      this.effectiveBWReduction += reductionMs;
+      this.wastedBWReduction += REDUCTION_MS - reductionMs;
+    } else {
+      this.wastedBWReduction += REDUCTION_MS;
+    }
+  }
+
+  statistic() {
+    return (
+      <Statistic category={STATISTIC_CATEGORY.ITEMS}>
+        <BoringSpellValueText spell={SPELLS.T30_4P_BONUS_BEAST_MASTERY}>
+          {formatNumber(this.effectiveBWReduction / 1000)}/
+          {formatNumber((this.wastedBWReduction + this.effectiveBWReduction) / 1000)}s{' '}
+          <small>Effective BW Reduction</small>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}

--- a/src/common/SPELLS/hunter.ts
+++ b/src/common/SPELLS/hunter.ts
@@ -745,6 +745,20 @@ const spells = spellIndexableList({
     name: 'Focusing Aim',
     icon: 'ability_impalingbolt',
   },
+  //T30 2P
+  T30_2P_BONUS_BEAST_MASTERY: {
+    id: 405524,
+    name: 'T30 2P',
+    icon: 'ability_hunter_killcommand',
+  },
+  //T30 4P
+
+  T30_4P_BONUS_BEAST_MASTERY: {
+    id: 405525,
+    name: 'T30 4P',
+    icon: 'ability_druid_ferociousbite',
+  },
+  //endregion
 });
 
 export default spells;

--- a/src/interface/useGoogleAnalytics.ts
+++ b/src/interface/useGoogleAnalytics.ts
@@ -41,7 +41,6 @@ export function usePageView(componentName: string, key?: unknown) {
       fight_difficulty: fight?.fight.difficulty,
       fight_boss: fight?.fight.boss,
     };
-    console.info('page view', props, componentName);
     if (window.gtag) {
       window.gtag('event', 'page_view', props);
     }


### PR DESCRIPTION
Adds support for Beast Mastery T30. It alleviates some of the efficiency issues for Beast Masterys Bestial Wrath. 

![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/29204244/62f9d881-a73e-4b06-9c6a-07822baeb8d6)


Before: 
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/29204244/e1237167-202b-4412-a649-eb7ac209248e)

After: 
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/29204244/aa7e2784-38e8-4219-bd86-a1b408e73d7e)

