### PR TITLE
[Classic] Demo Warlock Guide 4

### DIFF
--- a/src/analysis/classic/warlock/demonology/CHANGELOG.tsx
+++ b/src/analysis/classic/warlock/demonology/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { change, date } from 'common/changelog';
 import { jazminite } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2023, 7, 6), 'Add Guide Procs subsection + set guide to default view.', jazminite),
   change(date(2023, 6, 9), 'Add Guide Cooldowns Graph subsection.', jazminite),
   change(date(2023, 5, 7), 'Updates to Guide Core section + added Spells subsection.', jazminite),
   change(date(2023, 4, 23), 'Started Guide and added Core and Preparation sections.', jazminite),

--- a/src/analysis/classic/warlock/demonology/CONFIG.tsx
+++ b/src/analysis/classic/warlock/demonology/CONFIG.tsx
@@ -38,8 +38,8 @@ const CONFIG: Config = {
     },
   },
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/BZj17n6XTYCLaQPN/37-Hardmode+Thorim+-+Kill+(2:53)/Jazl',
-  guideDefault: false,
+  exampleReport: "/report/BMT7atLzGvV9R8FJ/11-Heroic+Twin+Val'kyr+-+Kill+(2:51)/Jazminites",
+  guideDefault: true,
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/classic/warlock/demonology/CombatLogParser.ts
+++ b/src/analysis/classic/warlock/demonology/CombatLogParser.ts
@@ -28,6 +28,7 @@ import CurseOfAgony from './modules/spells/CurseOfAgony';
 import CurseOfDoom from './modules/spells/CurseOfDoom';
 import CurseOfTheElements from './modules/spells/CurseOfTheElements';
 import Immolate from './modules/spells/Immolate';
+import MoltenCore from './modules/spells/MoltenCore';
 import ShadowMastery from './modules/spells/ShadowMastery';
 
 class CombatLogParser extends BaseCombatLogParser {
@@ -56,6 +57,7 @@ class CombatLogParser extends BaseCombatLogParser {
     curseOfDoom: CurseOfDoom,
     curseOfTheElements: CurseOfTheElements,
     immolate: Immolate,
+    moltenCore: MoltenCore,
     shadowMastery: ShadowMastery,
   };
   static guide = Guide;

--- a/src/analysis/classic/warlock/demonology/Guide.tsx
+++ b/src/analysis/classic/warlock/demonology/Guide.tsx
@@ -20,7 +20,7 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
         <CooldownGraphSubsection />
       </Section>
 
-      <Section title="Procs"></Section>
+      <Section title="Procs">{modules.moltenCore.guideSubsection}</Section>
 
       <PreparationSection expansion={Expansion.WrathOfTheLichKing} />
     </>

--- a/src/analysis/classic/warlock/demonology/modules/checklist/Module.tsx
+++ b/src/analysis/classic/warlock/demonology/modules/checklist/Module.tsx
@@ -12,6 +12,7 @@ import CurseOfAgony from '../spells/CurseOfAgony';
 import CurseOfDoom from '../spells/CurseOfDoom';
 import CurseOfTheElements from '../spells/CurseOfTheElements';
 import Immolate from '../spells/Immolate';
+import MoltenCore from '../spells/MoltenCore';
 import ShadowMastery from '../spells/ShadowMastery';
 
 import Component from './Component';
@@ -32,6 +33,7 @@ class Checklist extends BaseChecklist {
     curseOfDoom: CurseOfDoom,
     curseOfTheElements: CurseOfTheElements,
     immolate: Immolate,
+    moltenCore: MoltenCore,
     shadowMastery: ShadowMastery,
   };
   protected castEfficiency!: CastEfficiency;
@@ -43,6 +45,7 @@ class Checklist extends BaseChecklist {
   protected curseOfDoom!: CurseOfDoom;
   protected curseOfTheElements!: CurseOfTheElements;
   protected immolate!: Immolate;
+  protected moltenCore!: MoltenCore;
   protected preparationRuleAnalyzer!: PreparationRuleAnalyzer;
   protected shadowMastery!: ShadowMastery;
 
@@ -59,6 +62,7 @@ class Checklist extends BaseChecklist {
           curseOfTheElements: this.curseOfTheElements.suggestionThresholds,
           curseUptime: this.curseUptime.suggestionThresholds,
           immolate: this.immolate.suggestionThresholds,
+          moltenCore: this.moltenCore.suggestionThresholds,
           shadowMastery: this.shadowMastery.suggestionThresholds,
           downtimeSuggestionThresholds: this.alwaysBeCasting.downtimeSuggestionThresholds,
         }}

--- a/src/analysis/classic/warlock/demonology/modules/features/DotUptimes.tsx
+++ b/src/analysis/classic/warlock/demonology/modules/features/DotUptimes.tsx
@@ -46,12 +46,10 @@ class DotUptimes extends Analyzer {
           increases damage done by <SpellLink spell={SPELLS.SHADOW_BOLT} /> and increases spell
           critical strike chance against the target for all casters in the raid.
         </p>
-        <p>
-          <strong>Uptimes</strong>
-          {this.corruptionUptime.subStatistic()}
-          {this.immolateUptime.subStatistic()}
-          {this.shadowMasteryUptime.subStatistic()}
-        </p>
+        <strong>Uptimes</strong>
+        {this.corruptionUptime.subStatistic()}
+        {this.immolateUptime.subStatistic()}
+        {this.shadowMasteryUptime.subStatistic()}
       </>
     );
   }

--- a/src/analysis/classic/warlock/demonology/modules/guide/CastingSubsection.tsx
+++ b/src/analysis/classic/warlock/demonology/modules/guide/CastingSubsection.tsx
@@ -12,20 +12,20 @@ function CastingSubsection({ modules }: GuideProps<typeof CombatLogParser>) {
   const cancelledPercent = formatPercentage(cancelledMod.cancelledPercentage, 1);
   return (
     <>
-      <p>
-        <div>
-          <b>
-            <SpellLink spell={SPELLS.SHADOW_BOLT} />
-          </b>{' '}
-          |{' '}
-          <b>
-            <SpellLink spell={SPELLS.INCINERATE} />
-          </b>{' '}
-          |{' '}
-          <b>
-            <SpellLink spell={SPELLS.SOUL_FIRE} />
-          </b>
-        </div>
+      <div>
+        <b>
+          <SpellLink spell={SPELLS.SHADOW_BOLT} />
+        </b>{' '}
+        |{' '}
+        <b>
+          <SpellLink spell={SPELLS.INCINERATE} />
+        </b>{' '}
+        |{' '}
+        <b>
+          <SpellLink spell={SPELLS.SOUL_FIRE} />
+        </b>
+      </div>
+      <div>
         Demo Warlocks use filler spells when all DoTs and Debuffs are applied. Your go-to filler
         spell is <SpellLink spell={SPELLS.SHADOW_BOLT} />. It should be used to provide{' '}
         <SpellLink spell={SPELLS.SHADOW_MASTERY_DEBUFF} /> for the raid. When{' '}
@@ -34,22 +34,20 @@ function CastingSubsection({ modules }: GuideProps<typeof CombatLogParser>) {
         your target falls below 35% health, you receive <SpellLink spell={SPELLS.DECIMATION} />{' '}
         which is used to cast <SpellLink spell={SPELLS.SOUL_FIRE} /> faster and without the cost of
         a Soul Shard.
-      </p>
+      </div>
       <hr />
-      <p>
-        <div>
-          <b>Always Be Casting (ABC)</b> throughout the encounter. When moving, use your instant
-          abilities or set up{' '}
-          <SpellLink spell={SPELLS.DEMONIC_CIRCLE_TELEPORT} icon>
-            Demonic Circle{' '}
-          </SpellLink>{' '}
-          to reduce your movement.
-        </div>
-        <small>
-          Some fights have unavoidable downtime due to events like phase transitions. In these
-          cases, keep active as much as possible.
-        </small>
-      </p>
+      <div>
+        <b>Always Be Casting (ABC)</b> throughout the encounter. When moving, use your instant
+        abilities or set up{' '}
+        <SpellLink spell={SPELLS.DEMONIC_CIRCLE_TELEPORT} icon>
+          Demonic Circle{' '}
+        </SpellLink>{' '}
+        to reduce your movement.
+      </div>
+      <small>
+        Some fights have unavoidable downtime due to events like phase transitions. In these cases,
+        keep active as much as possible.
+      </small>
       <div>
         <b>Active Time</b>:{' '}
         <PerformanceLabel performance={abcMod.DowntimePerformance}>

--- a/src/analysis/classic/warlock/demonology/modules/spells/MoltenCore.tsx
+++ b/src/analysis/classic/warlock/demonology/modules/spells/MoltenCore.tsx
@@ -15,8 +15,6 @@ class MoltenCore extends Analyzer {
   procsExpired: number = 0; // Procs lost to time
   procsOver: number = 0; // Procs lost to overwriting them
 
-  lastProcTime: number = 0;
-  lastCastTime: number = 0;
   currentStacks: number = 0;
 
   constructor(options: Options) {
@@ -103,17 +101,17 @@ class MoltenCore extends Analyzer {
   get guideSubsection(): JSX.Element {
     const usedMC = {
       count: this.procsUsed,
-      label: 'Buffs Used',
+      label: 'Procs Used',
     };
 
     const overMC = {
       count: this.procsOver,
-      label: 'Buffs Overwritten',
+      label: 'Procs Overwritten',
     };
 
     const expiredMC = {
       count: this.procsExpired,
-      label: 'Buffs Expired',
+      label: 'Procs Expired',
     };
 
     const explanation = (

--- a/src/analysis/classic/warlock/demonology/modules/spells/MoltenCore.tsx
+++ b/src/analysis/classic/warlock/demonology/modules/spells/MoltenCore.tsx
@@ -1,0 +1,144 @@
+import { t } from '@lingui/macro';
+import SPELLS from 'common/SPELLS/classic/warlock';
+import { SpellLink } from 'interface';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { ApplyBuffEvent, CastEvent, RemoveBuffEvent } from 'parser/core/Events';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import GradiatedPerformanceBar from 'interface/guide/components/GradiatedPerformanceBar';
+
+class MoltenCore extends Analyzer {
+  procsGained: number = 0; // Total gained procs (including refreshed)
+  procsExpired: number = 0; // Procs lost to time
+  procsOver: number = 0; // Procs lost to overwriting them
+
+  lastProcTime: number = 0;
+  lastCastTime: number = 0;
+  currentStacks: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.INCINERATE), this.onCast);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.SOUL_FIRE), this.onCast);
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.MOLTEN_CORE_BUFF),
+      this.onBuff,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.MOLTEN_CORE_BUFF),
+      this.onRemove,
+    );
+  }
+  get procsWasted() {
+    return this.procsExpired + this.procsOver;
+  }
+
+  get procsUsed() {
+    return this.procsGained - this.procsExpired - this.procsOver;
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.procsWasted,
+      isGreaterThan: {
+        minor: 0.0,
+        average: 0.5,
+        major: 1.1,
+      },
+      style: ThresholdStyle.NUMBER,
+    };
+  }
+
+  onCast(event: CastEvent) {
+    if (this.currentStacks) {
+      this.currentStacks -= 1;
+    }
+  }
+
+  onBuff(event: ApplyBuffEvent) {
+    if (this.currentStacks) {
+      this.procsOver += this.currentStacks;
+    }
+    this.currentStacks = 3;
+    this.procsGained += 3;
+  }
+
+  onRemove(event: RemoveBuffEvent) {
+    if (this.currentStacks) {
+      this.procsExpired += this.currentStacks;
+    }
+    this.currentStacks = 0;
+  }
+
+  suggestions(when: When) {
+    when(this.suggestionThresholds).addSuggestion((suggest) =>
+      suggest(
+        <>
+          You lost {this.procsWasted} casts of <SpellLink spell={SPELLS.INCINERATE} />
+        </>,
+      )
+        .icon(SPELLS.MOLTEN_CORE_BUFF.icon)
+        .actual(
+          t({
+            id: 'priest.shadow.suggestions.mindSpikeInsanity.castLost',
+            message: `Lost ${this.procsWasted} casts of Mind Spike: Insanity.`,
+          }),
+        )
+        .recommended('No lost casts is recommended.'),
+    );
+  }
+
+  statistic() {
+    return (
+      <Statistic category={STATISTIC_CATEGORY.GENERAL} size="flexible">
+        <BoringSpellValueText spell={SPELLS.MOLTEN_CORE_BUFF}>
+          <>
+            {this.procsUsed}/{this.procsGained} <small>Procs Used</small>
+          </>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+
+  get guideSubsection(): JSX.Element {
+    const usedMC = {
+      count: this.procsUsed,
+      label: 'Buffs Used',
+    };
+
+    const overMC = {
+      count: this.procsOver,
+      label: 'Buffs Overwritten',
+    };
+
+    const expiredMC = {
+      count: this.procsExpired,
+      label: 'Buffs Expired',
+    };
+
+    const explanation = (
+      <>
+        <b>
+          <SpellLink spell={SPELLS.MOLTEN_CORE_BUFF} />
+        </b>{' '}
+        is gained randomly from <SpellLink spell={SPELLS.CORRUPTION} /> damage. <br />
+        Cast <SpellLink spell={SPELLS.INCINERATE} /> or <SpellLink spell={SPELLS.SOUL_FIRE} /> while
+        the buff is active to avoid wasting procs.
+      </>
+    );
+    const data = (
+      <div>
+        <strong>Molten Core Procs</strong>
+        <GradiatedPerformanceBar good={usedMC} ok={overMC} bad={expiredMC} />
+      </div>
+    );
+    return explanationAndDataSubsection(explanation, data, 50);
+  }
+}
+
+export default MoltenCore;

--- a/src/analysis/classic/warlock/demonology/modules/spells/MoltenCore.tsx
+++ b/src/analysis/classic/warlock/demonology/modules/spells/MoltenCore.tsx
@@ -1,4 +1,3 @@
-import { t } from '@lingui/macro';
 import SPELLS from 'common/SPELLS/classic/warlock';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
@@ -79,17 +78,13 @@ class MoltenCore extends Analyzer {
     when(this.suggestionThresholds).addSuggestion((suggest) =>
       suggest(
         <>
-          You lost {this.procsWasted} casts of <SpellLink spell={SPELLS.INCINERATE} />
+          You lost {this.procsWasted} buffed casts of <SpellLink spell={SPELLS.INCINERATE} /> or{' '}
+          <SpellLink spell={SPELLS.SOUL_FIRE} />
         </>,
       )
         .icon(SPELLS.MOLTEN_CORE_BUFF.icon)
-        .actual(
-          t({
-            id: 'priest.shadow.suggestions.mindSpikeInsanity.castLost',
-            message: `Lost ${this.procsWasted} casts of Mind Spike: Insanity.`,
-          }),
-        )
-        .recommended('No lost casts is recommended.'),
+        .actual(`${this.procsWasted} Molten Core buff procs wasted.`)
+        .recommended('No lost procs is recommended.'),
     );
   }
 


### PR DESCRIPTION
### Description

Round 4 for the Demo Warlock Guide - viewable under the `Normal View`.

- CONFIG - Update example report and set guide to default view
- MoltenCore - File added to track Molten Core buff procs
- Guide - Added MoltenCore to procs section
- Misc - Cleanup instances where `<div>` tags were inside of `<p>` tags

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL:  `/report/BMT7atLzGvV9R8FJ/11-Heroic+Twin+Val'kyr+-+Kill+(2:51)/Jazminites`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/65823478/ca7224d4-68a5-4429-b64f-0864675336ab)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/65823478/2c9f45b2-711d-4faf-a121-25457395daa2)



