### PR TITLE
fix Fracture Fury calculations in Guide

### DIFF
--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import SHARED_CHANGELOG from 'analysis/retail/demonhunter/shared/CHANGELOG';
 
 // prettier-ignore
 export default [
+  change(date(2023, 7, 8), <>Fix determination of <SpellLink spell={TALENTS.FRACTURE_TALENT} /> quality based on Fury amounts.</>, ToppleTheNun),
   change(date(2023, 3, 21), <>Fix some good <SpellLink spell={TALENTS.SPIRIT_BOMB_TALENT} /> casts showing as bad.</>, ToppleTheNun),
   change(date(2023, 3, 16), 'Update the default log.', ToppleTheNun),
   change(date(2023, 3, 9), <>Add <SpellLink spell={TALENTS.SIGIL_OF_FLAME_TALENT} /> to Rotation section in guide.</>, ToppleTheNun),


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Fix Fracture Fury calculations due to Fracture event ordering. Had to drop using `FuryTracker` and do some manual calculations due to Fracture event ordering.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/agLc4D8nNydjWxb3/1-Mythic++Neltharion's+Lair+-+Kill+(21:04)/Toppledh/standard/overview`
- Screenshot(s):
**Before**
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/a50c0d6a-bd49-481f-afae-05635a4b2e29)
**After**
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/d6541c03-0a5c-499d-b8e3-f6c0e387404a)
