### PR TITLE
removed demonic circle from checklist

### DIFF
--- a/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Arlie, Jonfanz, Meldris, ToppleTheNun, dodse } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 7, 8), "Removed Demonic Circle use tracker in utility and defensive spells", Meldris),
   change(date(2023, 6, 29), "Updated ABOUT with current guide links", Meldris),
   change(date(2023, 3, 9), "Update Soul Conduit to take into account being a 2 rank talent and different scaling", dodse),
   change(date(2023, 3, 9), 'Update Vile Taint to track the right debuff id and rework hit tracking', dodse),

--- a/src/analysis/retail/warlock/affliction/modules/checklist/Component.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/checklist/Component.tsx
@@ -90,7 +90,6 @@ const AfflictionWarlockChecklist = ({ combatant, castEfficiency, thresholds }: C
           </>
         }
       >
-        <AbilityRequirement spell={SPELLS.DEMONIC_CIRCLE_TELEPORT.id} />
         {combatant.hasTalent(TALENTS.DARK_PACT_TALENT) && (
           <AbilityRequirement spell={TALENTS.DARK_PACT_TALENT.id} />
         )}

--- a/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { Sharrq, Zeboot, Meldris, ToppleTheNun, Jonfanz, Mae, dodse } from 'CONT
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 7, 8), "Removed Demonic Circle use tracker in utility and defensive spells", Meldris),
   change(date(2023, 6, 29), "Updated ABOUT with current guide links", Meldris),
   change(date(2023, 3, 9), "Update Soul Conduit to take into account being a 2 rank talent and different scaling", dodse),
   change(date(2023, 1, 4), "Add support for Shadow's Bite and Dread Calling talents", Mae),

--- a/src/analysis/retail/warlock/demonology/modules/features/Checklist/Component.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/features/Checklist/Component.tsx
@@ -117,7 +117,6 @@ const DemonologyWarlockChecklist = ({ combatant, castEfficiency, thresholds }: C
           </>
         }
       >
-        <AbilityRequirement spell={SPELLS.DEMONIC_CIRCLE_TELEPORT.id} />
         {combatant.hasTalent(TALENTS.DARK_PACT_TALENT) && (
           <AbilityRequirement spell={TALENTS.DARK_PACT_TALENT.id} />
         )}

--- a/src/analysis/retail/warlock/destruction/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/destruction/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2023, 7, 8), "Removed Demonic Circle use tracker in utility and defensive spells", Meldris),
   change(date(2023, 6, 29), "Updated ABOUT with current guide links", Meldris),
   change(date(2023, 3, 9), "Update Soul Conduit to take into account being a 2 rank talent and different scaling", dodse),
   change(date(2023, 3, 5), "Update Havoc module to also work with Mayhem and try to identify damage from Havoc more accurately.", dodse),

--- a/src/analysis/retail/warlock/destruction/modules/features/Checklist/Component.tsx
+++ b/src/analysis/retail/warlock/destruction/modules/features/Checklist/Component.tsx
@@ -116,7 +116,6 @@ const DestructionWarlockChecklist = ({
           </>
         }
       >
-        <AbilityRequirement spell={SPELLS.DEMONIC_CIRCLE_TELEPORT.id} />
         {combatant.hasTalent(TALENTS.DARK_PACT_TALENT) && (
           <AbilityRequirement spell={TALENTS.DARK_PACT_TALENT.id} />
         )}


### PR DESCRIPTION
### Description

Removed Demonic Circle: Teleport usage % tracker from utility and defensive spell section.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/zAqDmaj9hpPf7xyV/8-Heroic+Assault+of+the+Zaqali+-+Kill+(0:49)/Meldot/standard`
- Screenshot(s):
