### PR TITLE
[ele shaman] fix a bug where surge of power were double counted

### DIFF
--- a/src/analysis/retail/shaman/elemental/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/elemental/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/shaman';
-import { HawkCorrigan, Putro, Zeboot, Maximaw, Zea, emallson, Vetyst, Periodic, ToppleTheNun } from 'CONTRIBUTORS';
+import { HawkCorrigan, Putro, Zeboot, Maximaw, Zea, emallson, Vetyst, Periodic, ToppleTheNun, Awildfivreld } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 7, 13), <>Fix a bug where the timeline showed too many abilities as empowered by <SpellLink spell={TALENTS.SURGE_OF_POWER_TALENT} /></>, Awildfivreld),
   change(date(2023, 7, 8), <>Add guide skeleton</>, Periodic),
   change(date(2023, 7, 8), 'Update SpellLink usage.', ToppleTheNun),
   change(date(2022, 7, 7), <>Basic cleanup for 10.1.0.</>, Periodic),


### PR DESCRIPTION
### Description

There is a bug in the current implementation that causes the Surge of Power module to show multiple spells as being empowered, if the first has a cast time and the second is instant. In reality, only the first spell should be empowered. Not 100% sure why this happens, but all of the events have the same timestamp, so there is probably something there.

The existing module has a grace time built in when checking for buff presence, where it comments that the removebuff event might come at an earlier timestamp, and I figured I did not want to touch that. I've therefore added a small boolean that will override when there are multiple cast events in a row, without a Surge of power applybuff event in-between. 

This logic relies on the order of the events within the same timestamp being consistent, and that the correct event always comes first. This assumption seeeems to be valid at the moment for the edge cases I've found, but if you think I should make a more thorough check (say by finding the beginchannel event of the spell with cast time), then I can look into that. 

### Testing

https://www.wowanalyzer.com/report/tnLg84dqxX1ZcTYC/15-Heroic+Rashok,+the+Elder+-+Kill+(3:33)/Fivreld/standard/timeline

Before: 
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/12049229/bd53c653-e955-46eb-9098-2927fb4c5522)
The flameshock here should not have been marked as empowered.

After:
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/12049229/1ba3cac9-5eb7-41cb-a5f6-085b8e601d08)
It is no longer marked, but the lightning bolt still is.
