### PR TITLE
Fixed reclamation module

### DIFF
--- a/src/analysis/retail/monk/mistweaver/modules/spells/ShaohaosLessons.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ShaohaosLessons.tsx
@@ -143,7 +143,7 @@ class ShaohaosLessons extends Analyzer {
     ) {
       return;
     }
-    const enemyHealthPercent = (event.hitPoints - event.amount) / event.maxHitPoints;
+    const enemyHealthPercent = (event.hitPoints + event.amount) / event.maxHitPoints;
     const damageIncrease = (1 - enemyHealthPercent) * DOUBT_INCREASE;
     this.doubtDamage += calculateEffectiveDamage(event, damageIncrease);
   }

--- a/src/analysis/retail/paladin/holy/CHANGELOG.tsx
+++ b/src/analysis/retail/paladin/holy/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
-import TALENTS from 'common/TALENTS/paladin';
+import TALENTS, { TALENTS_PALADIN } from 'common/TALENTS/paladin';
 import { SpellLink } from 'interface';
 import { CamClark, Tialyss, ToppleTheNun, xizbow, Trevor, Abelito75 } from 'CONTRIBUTORS';
 import SPELLS from 'common/SPELLS/paladin';
 
 export default [
+  change(date(2023, 7, 16), <>Fixed inaccuracy in <SpellLink spell={TALENTS_PALADIN.RECLAMATION_TALENT}/></>, Abelito75),
   change(date(2023, 7, 15), <>Removing Dumb Overhealing statistics I caused</>, Abelito75),
   change(date(2023, 7, 14), <>Added <SpellLink spell={SPELLS.JUDGMENT_CAST_HOLY} /> to Infusion of Light usage</>, Tialyss),
   change(date(2023, 7, 14), <>Added <SpellLink spell={TALENTS.DIVINE_REVELATIONS_TALENT} /></>, Tialyss),

--- a/src/analysis/retail/paladin/holy/modules/talents/GlimmerOfLight/GlimmerOfLight.tsx
+++ b/src/analysis/retail/paladin/holy/modules/talents/GlimmerOfLight/GlimmerOfLight.tsx
@@ -23,6 +23,8 @@ import TalentAggregateBars from 'parser/ui/TalentAggregateStatistic';
 import TalentAggregateStatisticContainer from 'parser/ui/TalentAggregateStatisticContainer';
 import { formatNumber } from 'common/format';
 
+const DEBUG = false;
+
 /**
  * Glimmer of Light
  * Requires Paladin (Holy, Holy)
@@ -167,7 +169,7 @@ class GlimmerOfLight extends Analyzer {
   onGlimmerHeal(event: HealEvent) {
     this.updateGR(event);
     const amount = event.amount + (event.absorbed || 0);
-    if (this.lastCast === TALENTS.GLISTENING_RADIANCE_TALENT.id) {
+    if (DEBUG && this.lastCast === TALENTS.GLISTENING_RADIANCE_TALENT.id) {
       console.log(
         `amount: ${event.amount} absorbed: ${event.absorbed || 0} overheal: ${event.overheal || 0}`,
       );
@@ -180,7 +182,7 @@ class GlimmerOfLight extends Analyzer {
 
     toUpdate.healing += amount;
     toUpdate.hits += 1;
-    if (this.lastCast === TALENTS.GLISTENING_RADIANCE_TALENT.id) {
+    if (DEBUG && this.lastCast === TALENTS.GLISTENING_RADIANCE_TALENT.id) {
       console.log(toUpdate);
     }
   }

--- a/src/analysis/retail/paladin/holy/modules/talents/Reclamation.tsx
+++ b/src/analysis/retail/paladin/holy/modules/talents/Reclamation.tsx
@@ -82,12 +82,16 @@ class Reclamation extends Analyzer {
         size="flexible"
         tooltip={
           <>
-            Healing Done: {formatNumber(this.healing)} <br />
-            Damage Done: {formatNumber(this.damageDone)} <br />
-            Mana from <SpellLink spell={TALENTS_PALADIN.HOLY_SHOCK_TALENT} />:{' '}
-            {this.resourceGained.get(TALENTS.HOLY_SHOCK_TALENT.id) || 0} <br />
-            Mana from <SpellLink spell={SPELLS.CRUSADER_STRIKE} />:{' '}
-            {this.resourceGained.get(SPELLS.CRUSADER_STRIKE.id) || 0} <br />
+            <div>Healing Done: {formatNumber(this.healing)}</div>
+            <div>Damage Done: {formatNumber(this.damageDone)}</div>
+            <div>
+              Mana from <SpellLink spell={TALENTS_PALADIN.HOLY_SHOCK_TALENT} />:{' '}
+              {formatNumber(this.resourceGained.get(TALENTS.HOLY_SHOCK_TALENT.id) || 0)}
+            </div>
+            <div>
+              Mana from <SpellLink spell={SPELLS.CRUSADER_STRIKE} />:{' '}
+              {formatNumber(this.resourceGained.get(SPELLS.CRUSADER_STRIKE.id) || 0)}
+            </div>
           </>
         }
       >

--- a/src/analysis/retail/paladin/holy/modules/talents/Reclamation.tsx
+++ b/src/analysis/retail/paladin/holy/modules/talents/Reclamation.tsx
@@ -56,7 +56,7 @@ class Reclamation extends Analyzer {
       return;
     }
 
-    const ratio = (1 - (event.hitPoints - event.amount) / event.maxHitPoints) * MAX_BOOST;
+    const ratio = (1 - (event.hitPoints + event.amount) / event.maxHitPoints) * MAX_BOOST;
     this.damageDone += calculateEffectiveDamage(event, ratio);
   }
 

--- a/src/analysis/retail/paladin/holy/modules/talents/Reclamation.tsx
+++ b/src/analysis/retail/paladin/holy/modules/talents/Reclamation.tsx
@@ -1,13 +1,14 @@
+import { formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
-import TALENTS from 'common/TALENTS/paladin';
+import TALENTS, { TALENTS_PALADIN } from 'common/TALENTS/paladin';
 import { SpellLink } from 'interface';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
 import { calculateEffectiveDamage, calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
 import Events, { CastEvent, DamageEvent, HealEvent, ResourceChangeEvent } from 'parser/core/Events';
-import BoringValueText from 'parser/ui/BoringValueText';
 import ItemManaGained from 'parser/ui/ItemManaGained';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import TalentSpellText from 'parser/ui/TalentSpellText';
 
 const MAX_BOOST = 0.5;
 
@@ -31,7 +32,7 @@ class Reclamation extends Analyzer {
     );
     this.addEventListener(Events.heal.spell(SPELLS.HOLY_SHOCK_HEAL).by(SELECTED_PLAYER), this.heal);
     this.addEventListener(
-      Events.damage.spell(SPELLS.CRUSADER_STRIKE).by(SELECTED_PLAYER),
+      Events.damage.spell([SPELLS.CRUSADER_STRIKE, SPELLS.HOLY_SHOCK_DAMAGE]).by(SELECTED_PLAYER),
       this.damage,
     );
     this.addEventListener(
@@ -55,8 +56,8 @@ class Reclamation extends Analyzer {
       return;
     }
 
-    const ratio = ((event.hitPoints - event.amount) / event.maxHitPoints) * MAX_BOOST;
-    this.damageDone = +Number(calculateEffectiveDamage(event, ratio));
+    const ratio = (1 - (event.hitPoints - event.amount) / event.maxHitPoints) * MAX_BOOST;
+    this.damageDone += calculateEffectiveDamage(event, ratio);
   }
 
   mana(event: ResourceChangeEvent) {
@@ -81,27 +82,22 @@ class Reclamation extends Analyzer {
         size="flexible"
         tooltip={
           <>
-            Healing Done: {this.healing.toFixed(2)} <br />
-            Damage Done: {this.damageDone.toFixed(2)} <br />
-            Mana from Holy Shock: {this.resourceGained.get(TALENTS.HOLY_SHOCK_TALENT.id) || 0}{' '}
-            <br />
-            Mana from Crusader Strike: {this.resourceGained.get(SPELLS.CRUSADER_STRIKE.id) ||
-              0}{' '}
-            <br />
+            Healing Done: {formatNumber(this.healing)} <br />
+            Damage Done: {formatNumber(this.damageDone)} <br />
+            Mana from <SpellLink spell={TALENTS_PALADIN.HOLY_SHOCK_TALENT} />:{' '}
+            {this.resourceGained.get(TALENTS.HOLY_SHOCK_TALENT.id) || 0} <br />
+            Mana from <SpellLink spell={SPELLS.CRUSADER_STRIKE} />:{' '}
+            {this.resourceGained.get(SPELLS.CRUSADER_STRIKE.id) || 0} <br />
           </>
         }
       >
-        <BoringValueText
-          label={
-            <>
-              <SpellLink spell={TALENTS.RECLAMATION_TALENT} />
-            </>
-          }
-        >
-          {this.owner.formatItemHealingDone(this.healing)} <br />
-          {this.owner.formatItemDamageDone(this.damageDone)} <br />
-          <ItemManaGained amount={totalMana} />
-        </BoringValueText>
+        <TalentSpellText talent={TALENTS_PALADIN.RECLAMATION_TALENT}>
+          <div>{this.owner.formatItemHealingDone(this.healing)}</div>
+          <div>{this.owner.formatItemDamageDone(this.damageDone)}</div>
+          <div>
+            <ItemManaGained amount={totalMana} />
+          </div>
+        </TalentSpellText>
       </Statistic>
     );
   }


### PR DESCRIPTION
### Description

Fixed math and added tracking for offensive holy shocks and cleaned up the code in general. Also fixed bug in shaohaos doubt damage module. Changed br to div to make the html more portable as recommended.

Before
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/44d1c9ab-72f1-471a-aafb-3abb567c0e91)


After
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/13d1d7b8-a1db-4853-a0fc-df405808341e)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/deb6e045-2ef7-4ae7-ae2a-b8fc0ca58270)

