### PR TITLE
Implement PPala T30 4pc and update GC tracking

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -1908,6 +1908,19 @@ export const xepheris: Contributor = {
   ],
 };
 
+export const Woliance: Contributor = {
+  nickname: 'Woliance',
+  github: 'Woliance',
+  discord: 'Woliance',
+  mains: [
+    {
+      name: 'Woliance',
+      spec: SPECS.PROTECTION_PALADIN,
+      link: 'https://worldofwarcraft.blizzard.com/en-gb/character/eu/tarren-mill/Woliance',
+    },
+  ],
+};
+
 export const Hana: Contributor = {
   nickname: 'Hana',
   github: 'OisinOD',

--- a/src/analysis/retail/paladin/protection/CHANGELOG.tsx
+++ b/src/analysis/retail/paladin/protection/CHANGELOG.tsx
@@ -1,8 +1,9 @@
 import { change, date } from 'common/changelog';
-import { emallson, Heisenburger, ToppleTheNun } from 'CONTRIBUTORS';
+import { emallson, Heisenburger, ToppleTheNun, Woliance } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2023, 7, 9), 'Updating Grand Crusader and Implementing the Tier 30 4 set bonus', Woliance),
   change(date(2023, 7, 3), 'Update SpellLink usage.', ToppleTheNun),
   change(date(2023, 3, 26), 'Fix crashes related to 10.0.7 talent changes', emallson),
   change(date(2023, 1, 13), <>Initial updates to support dragonflight talent/spell changes, if I couldn't make it work or it didn't seem needed I took it out for now. Mostly basic updates to accomodate for baseline spells that became talents, etc. Truncated changelog.</>, Heisenburger),

--- a/src/analysis/retail/paladin/protection/CombatLogParser.ts
+++ b/src/analysis/retail/paladin/protection/CombatLogParser.ts
@@ -10,7 +10,7 @@ import ArcaneTorrent from 'parser/shared/modules/racials/bloodelf/ArcaneTorrent'
 
 import Abilities from './modules/Abilities';
 import AplCheck from './modules/core/AplCheck';
-import GrandCrusader from './modules/core/GrandCrusader';
+import GrandCrusader from './modules/talents/GrandCrusader';
 import Haste from './modules/core/Haste';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import Checklist from './modules/features/Checklist/Module';
@@ -31,12 +31,16 @@ import MomentOfGlory from './modules/talents/MomentOfGlory';
 import Redoubt from './modules/talents/Redoubt';
 import RighteousProtector from './modules/talents/RighteousProtector';
 import SanctifiedWrathProtJudgement from './modules/talents/SanctifiedWrathProtJudgement';
+import ProtPaladinT304P from './modules/core/ProtPaladinT304P';
+import MyAbilityNormalizer from './modules/CastLinkNormalizer';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     // Core
     grandCrusader: GrandCrusader,
     haste: Haste,
+    protPaladinT304P: ProtPaladinT304P,
+    myAbilityNormalizer: MyAbilityNormalizer,
 
     // Spells
     lightOfTheProtector: LightOfTheProtector,

--- a/src/analysis/retail/paladin/protection/modules/CastLinkNormalizer.ts
+++ b/src/analysis/retail/paladin/protection/modules/CastLinkNormalizer.ts
@@ -23,7 +23,8 @@ const GRAND_CRUSADER_PARRY = 'FromHardCast';
 const FROM_HARDCAST = 'FromHardcast';
 const CONSUMED_PROC = 'ConsumedProc';
 
-const EVENT_LINKGCCS: EventLink[] = [
+const EVENT_LINKS: EventLink[] = [
+  // Crusader Strike Cast
   {
     linkRelation: GRAND_CRUSADER_CAST,
     referencedEventId: TALENTS.GRAND_CRUSADER_TALENT.id,
@@ -45,9 +46,8 @@ const EVENT_LINKGCCS: EventLink[] = [
     backwardBufferMs: BUFFER_MS,
     anyTarget: true,
   },
-];
 
-const EVENT_LINKGCHOTR: EventLink[] = [
+  // Hammer of the Righteous Cast
   {
     linkRelation: GRAND_CRUSADER_CAST,
     referencedEventId: TALENTS.GRAND_CRUSADER_TALENT.id,
@@ -69,9 +69,8 @@ const EVENT_LINKGCHOTR: EventLink[] = [
     backwardBufferMs: BUFFER_MS,
     anyTarget: true,
   },
-];
 
-const EVENT_LINKGCBH: EventLink[] = [
+  // Blessed Hammer Cast
   {
     linkRelation: GRAND_CRUSADER_CAST,
     reverseLinkRelation: GRAND_CRUSADER_CAST,
@@ -95,9 +94,8 @@ const EVENT_LINKGCBH: EventLink[] = [
     backwardBufferMs: BUFFER_MS,
     anyTarget: true,
   },
-];
 
-const EVENT_LINKGCP: EventLink[] = [
+  // Parry
   {
     linkRelation: GRAND_CRUSADER_CAST,
     reverseLinkRelation: GRAND_CRUSADER_CAST,
@@ -125,9 +123,8 @@ const EVENT_LINKGCP: EventLink[] = [
     additionalCondition: (linkingEvent) =>
       linkingEvent.type === EventType.Damage && linkingEvent.hitType === HIT_TYPES.PARRY,
   },
-];
 
-const EVENT_LINKGCJ: EventLink[] = [
+  // Judgement Crit - Tier 30 4pc
   {
     linkRelation: GRAND_CRUSADER_CAST,
     reverseLinkRelation: GRAND_CRUSADER_CAST,
@@ -158,13 +155,7 @@ const EVENT_LINKGCJ: EventLink[] = [
 
 class MyAbilityNormalizer extends EventLinkNormalizer {
   constructor(options: Options) {
-    super(options, [
-      ...EVENT_LINKGCCS,
-      ...EVENT_LINKGCHOTR,
-      ...EVENT_LINKGCBH,
-      ...EVENT_LINKGCJ,
-      ...EVENT_LINKGCP,
-    ]);
+    super(options, [...EVENT_LINKS]);
   }
 }
 
@@ -177,7 +168,7 @@ export function gcJudgmentCrit(event: ApplyBuffEvent | RefreshBuffEvent): Damage
 export function getHardcast(event: DamageEvent): CastEvent | undefined {
   return GetRelatedEvents(event, FROM_HARDCAST)
     .filter((e): e is CastEvent => e.type === EventType.Cast)
-    .pop();
+    .at(-1);
 }
 
 export function consumedProc(event: DamageEvent): boolean {

--- a/src/analysis/retail/paladin/protection/modules/CastLinkNormalizer.ts
+++ b/src/analysis/retail/paladin/protection/modules/CastLinkNormalizer.ts
@@ -1,0 +1,187 @@
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/paladin';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import {
+  CastEvent,
+  EventType,
+  DamageEvent,
+  GetRelatedEvents,
+  HasRelatedEvent,
+  ApplyBuffEvent,
+  RefreshBuffEvent,
+} from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+import HIT_TYPES from '../../../../../game/HIT_TYPES';
+
+const BUFFER_MS = 100;
+const GRAND_CRUSADER_CAST = 'FromHardcast';
+const GRAND_CRUSADER_CRUSADER_STRIKE_CAST = 'FromHardcast';
+const GRAND_CRUSADER_HAMMER_OF_THE_RIGHTEOUS_CAST = 'FromHardcast';
+const GRAND_CRUSADER_BLESSED_HAMMER_CAST = 'FromHardCast';
+const GRAND_CRUSADER_JUDGMENT_CRIT = 'FromHardCast';
+const GRAND_CRUSADER_PARRY = 'FromHardCast';
+const FROM_HARDCAST = 'FromHardcast';
+const CONSUMED_PROC = 'ConsumedProc';
+
+const EVENT_LINKGCCS: EventLink[] = [
+  {
+    linkRelation: GRAND_CRUSADER_CAST,
+    referencedEventId: TALENTS.GRAND_CRUSADER_TALENT.id,
+    referencedEventType: EventType.ApplyBuff,
+    linkingEventId: SPELLS.CRUSADER_STRIKE.id,
+    linkingEventType: EventType.Cast,
+    forwardBufferMs: BUFFER_MS,
+    backwardBufferMs: BUFFER_MS,
+    anyTarget: true,
+    isActive: (c) => c.hasTalent(TALENTS.GRAND_CRUSADER_TALENT),
+  },
+  {
+    linkRelation: GRAND_CRUSADER_CRUSADER_STRIKE_CAST,
+    referencedEventId: SPELLS.CRUSADER_STRIKE.id,
+    referencedEventType: EventType.Cast,
+    linkingEventId: TALENTS.GRAND_CRUSADER_TALENT.id,
+    linkingEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+    forwardBufferMs: BUFFER_MS,
+    backwardBufferMs: BUFFER_MS,
+    anyTarget: true,
+  },
+];
+
+const EVENT_LINKGCHOTR: EventLink[] = [
+  {
+    linkRelation: GRAND_CRUSADER_CAST,
+    referencedEventId: TALENTS.GRAND_CRUSADER_TALENT.id,
+    referencedEventType: EventType.ApplyBuff,
+    linkingEventId: TALENTS.HAMMER_OF_THE_RIGHTEOUS_TALENT.id,
+    linkingEventType: EventType.Cast,
+    forwardBufferMs: BUFFER_MS,
+    backwardBufferMs: BUFFER_MS,
+    anyTarget: true,
+    isActive: (c) => c.hasTalent(TALENTS.GRAND_CRUSADER_TALENT),
+  },
+  {
+    linkRelation: GRAND_CRUSADER_HAMMER_OF_THE_RIGHTEOUS_CAST,
+    referencedEventId: TALENTS.HAMMER_OF_THE_RIGHTEOUS_TALENT.id,
+    referencedEventType: EventType.Cast,
+    linkingEventId: TALENTS.GRAND_CRUSADER_TALENT.id,
+    linkingEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+    forwardBufferMs: BUFFER_MS,
+    backwardBufferMs: BUFFER_MS,
+    anyTarget: true,
+  },
+];
+
+const EVENT_LINKGCBH: EventLink[] = [
+  {
+    linkRelation: GRAND_CRUSADER_CAST,
+    reverseLinkRelation: GRAND_CRUSADER_CAST,
+    referencedEventId: SPELLS.GRAND_CRUSADER_BUFF.id,
+    referencedEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+    linkingEventId: TALENTS.BLESSED_HAMMER_TALENT.id,
+    linkingEventType: EventType.Cast,
+    forwardBufferMs: BUFFER_MS,
+    backwardBufferMs: BUFFER_MS,
+    anyTarget: true,
+    isActive: (c) => c.hasTalent(TALENTS.GRAND_CRUSADER_TALENT),
+  },
+  {
+    linkRelation: GRAND_CRUSADER_BLESSED_HAMMER_CAST,
+    reverseLinkRelation: GRAND_CRUSADER_BLESSED_HAMMER_CAST,
+    referencedEventId: SPELLS.GRAND_CRUSADER_BUFF.id,
+    referencedEventType: EventType.Cast,
+    linkingEventId: SPELLS.GRAND_CRUSADER_BUFF.id,
+    linkingEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+    forwardBufferMs: BUFFER_MS,
+    backwardBufferMs: BUFFER_MS,
+    anyTarget: true,
+  },
+];
+
+const EVENT_LINKGCP: EventLink[] = [
+  {
+    linkRelation: GRAND_CRUSADER_CAST,
+    reverseLinkRelation: GRAND_CRUSADER_CAST,
+    referencedEventId: TALENTS.GRAND_CRUSADER_TALENT.id,
+    referencedEventType: [EventType.ApplyBuff, EventType.ApplyBuff],
+    linkingEventId: TALENTS.BLESSED_HAMMER_TALENT.id,
+    linkingEventType: EventType.Cast,
+    forwardBufferMs: BUFFER_MS,
+    backwardBufferMs: BUFFER_MS,
+    anyTarget: true,
+    isActive: (c) => c.hasTalent(TALENTS.GRAND_CRUSADER_TALENT),
+  },
+  {
+    linkRelation: GRAND_CRUSADER_PARRY,
+    reverseLinkRelation: GRAND_CRUSADER_PARRY,
+    referencedEventId: SPELLS.GRAND_CRUSADER_BUFF.id,
+    referencedEventType: [EventType.ApplyBuff, EventType.ApplyBuff],
+    linkingEventId: null,
+    linkingEventType: EventType.Damage,
+    forwardBufferMs: 100,
+    backwardBufferMs: 100,
+    anyTarget: true,
+    anySource: true,
+    isActive: (c) => c.hasTalent(TALENTS.GRAND_CRUSADER_TALENT),
+    additionalCondition: (linkingEvent) =>
+      linkingEvent.type === EventType.Damage && linkingEvent.hitType === HIT_TYPES.PARRY,
+  },
+];
+
+const EVENT_LINKGCJ: EventLink[] = [
+  {
+    linkRelation: GRAND_CRUSADER_CAST,
+    reverseLinkRelation: GRAND_CRUSADER_CAST,
+    referencedEventId: SPELLS.GRAND_CRUSADER_BUFF.id,
+    referencedEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+    linkingEventId: SPELLS.JUDGMENT_CAST_PROTECTION.id,
+    linkingEventType: EventType.Damage,
+    forwardBufferMs: BUFFER_MS,
+    backwardBufferMs: BUFFER_MS,
+    anyTarget: true,
+    isActive: (c) => c.hasTalent(TALENTS.GRAND_CRUSADER_TALENT),
+  },
+  {
+    linkRelation: GRAND_CRUSADER_JUDGMENT_CRIT,
+    reverseLinkRelation: GRAND_CRUSADER_JUDGMENT_CRIT,
+    referencedEventId: SPELLS.GRAND_CRUSADER_BUFF.id,
+    referencedEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+    linkingEventId: SPELLS.JUDGMENT_CAST_PROTECTION.id,
+    linkingEventType: EventType.Damage,
+    forwardBufferMs: 100,
+    backwardBufferMs: 100,
+    anyTarget: true,
+    isActive: (c) => c.hasTalent(TALENTS.GRAND_CRUSADER_TALENT),
+    additionalCondition: (linkingEvent) =>
+      linkingEvent.type === EventType.Damage && linkingEvent.hitType === HIT_TYPES.CRIT,
+  },
+];
+
+class MyAbilityNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, [
+      ...EVENT_LINKGCCS,
+      ...EVENT_LINKGCHOTR,
+      ...EVENT_LINKGCBH,
+      ...EVENT_LINKGCJ,
+      ...EVENT_LINKGCP,
+    ]);
+  }
+}
+
+export function gcJudgmentCrit(event: ApplyBuffEvent | RefreshBuffEvent): DamageEvent | undefined {
+  return GetRelatedEvents(event, GRAND_CRUSADER_JUDGMENT_CRIT)
+    .filter((e): e is DamageEvent => e.type === EventType.Damage)
+    .at(-1);
+}
+
+export function getHardcast(event: DamageEvent): CastEvent | undefined {
+  return GetRelatedEvents(event, FROM_HARDCAST)
+    .filter((e): e is CastEvent => e.type === EventType.Cast)
+    .pop();
+}
+
+export function consumedProc(event: DamageEvent): boolean {
+  return HasRelatedEvent(event, CONSUMED_PROC);
+}
+
+export default MyAbilityNormalizer;

--- a/src/analysis/retail/paladin/protection/modules/core/ProtPaladinT304P.tsx
+++ b/src/analysis/retail/paladin/protection/modules/core/ProtPaladinT304P.tsx
@@ -1,0 +1,140 @@
+import { formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/paladin';
+import HIT_TYPES from 'game/HIT_TYPES';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, {
+  ApplyBuffEvent,
+  CastEvent,
+  DamageEvent,
+  RefreshBuffEvent,
+} from 'parser/core/Events';
+import { plotOneVariableBinomChart } from 'parser/shared/modules/helpers/Probability';
+import BoringSpellValue from 'parser/ui/BoringSpellValue';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { TIERS } from '../../../../../../game/TIERS';
+import { gcJudgmentCrit } from '../CastLinkNormalizer';
+import Abilities from '../Abilities';
+
+const JUDGM_PROC_CHANCE = 0.5;
+
+class ProtPaladinT304P extends Analyzer {
+  private gcJudgmentCrits: number = 0;
+  procs() {
+    return this.gcJudgmentCrits;
+  }
+
+  static dependencies = {
+    abilities: Abilities,
+  };
+  jResetChances: number = 0;
+  abilities!: Abilities;
+  constructor(options: Options) {
+    super(options);
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.JUDGMENT_CAST_PROTECTION),
+      this.trackGrandCrusaderChanceCrits,
+    );
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.GRAND_CRUSADER_BUFF),
+      this.onApplyBuff,
+    );
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.GRAND_CRUSADER_BUFF),
+      this.onRefreshBuff,
+    );
+  }
+
+  get jProcChance(): number {
+    if (TALENTS.INSPIRING_VANGUARD_TALENT) {
+      return JUDGM_PROC_CHANCE + 0.1;
+    } else {
+      return JUDGM_PROC_CHANCE;
+    }
+  }
+
+  // If judgment crit within last 100ms, count it as a t304p proc
+  // If not, count it as a GC proc, and have inverse counter in GC.tsx
+  _lastResetSource: CastEvent | DamageEvent | null = null;
+
+  private onApplyBuff(event: ApplyBuffEvent) {
+    // If no Judgment crit for apply buff, T30 4p isn't why we got GC
+    if (gcJudgmentCrit(event)) {
+      console.log('NoProc APPLY BUFF');
+      this.gcJudgmentCrits += 1;
+    }
+    return;
+  }
+
+  private onRefreshBuff(event: RefreshBuffEvent) {
+    // const gcjudgmentCrit = gcJudgmentCrit(event);
+    // If no Judgment crit for apply buff, T30 4p isn't why we got GC
+    if (gcJudgmentCrit(event)) {
+      console.log('NoProc Refresh BUFF');
+      this.gcJudgmentCrits += 1;
+    }
+    return;
+  }
+
+  trackGrandCrusaderChanceCrits(event: DamageEvent) {
+    if (
+      event.ability.guid !== SPELLS.JUDGMENT_CAST_PROTECTION.id ||
+      !this.selectedCombatant.has4PieceByTier(TIERS.T30) ||
+      event.hitType !== HIT_TYPES.CRIT
+    ) {
+      return;
+    }
+    this.jResetChances += 1;
+    this._lastResetSource = event;
+  }
+
+  statistic() {
+    //As we use a different formula than the standard one for XAxis, we send it along as a parameter
+    const binomChartXAxis = {
+      title: 'Reset %',
+      tickFormat: (value: number) => `${formatPercentage(value / this.jResetChances, 0)}%`,
+      style: {
+        fill: 'white',
+      },
+    };
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.DEFAULT}
+        size="flexible"
+        tooltip={
+          <>
+            Your 4 set reset the cooldown of Avenger's Shield {this.gcJudgmentCrits} times.
+            <br />
+            You had {this.jResetChances} chances for 4 set to trigger with a{' '}
+            {formatPercentage(this.jProcChance, 0)}% chance to trigger.
+          </>
+        }
+        dropdown={
+          <div style={{ padding: '8px' }}>
+            {plotOneVariableBinomChart(
+              this.gcJudgmentCrits,
+              this.jResetChances,
+              this.jProcChance,
+              'Reset %',
+              'Actual Resets',
+              [0, 0.2],
+              binomChartXAxis,
+            )}
+            <p>
+              Likelihood of having <em>exactly</em> as many resets as you did with your talents.
+            </p>
+          </div>
+        }
+      >
+        <BoringSpellValue
+          spellId={TALENTS.GRAND_CRUSADER_TALENT.id}
+          value={`${this.gcJudgmentCrits} Resets`}
+          label="Tier Bonus"
+        />
+      </Statistic>
+    );
+  }
+}
+
+export default ProtPaladinT304P;

--- a/src/analysis/retail/paladin/protection/modules/core/ProtPaladinT304P.tsx
+++ b/src/analysis/retail/paladin/protection/modules/core/ProtPaladinT304P.tsx
@@ -20,10 +20,7 @@ import Abilities from '../Abilities';
 const JUDGM_PROC_CHANCE = 0.5;
 
 class ProtPaladinT304P extends Analyzer {
-  private gcJudgmentCrits: number = 0;
-  procs() {
-    return this.gcJudgmentCrits;
-  }
+  gcJudgmentCrits: number = 0;
 
   static dependencies = {
     abilities: Abilities,
@@ -38,11 +35,11 @@ class ProtPaladinT304P extends Analyzer {
     );
     this.addEventListener(
       Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.GRAND_CRUSADER_BUFF),
-      this.onApplyBuff,
+      this.trackGrandCrusaderProcs,
     );
     this.addEventListener(
       Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.GRAND_CRUSADER_BUFF),
-      this.onRefreshBuff,
+      this.trackGrandCrusaderProcs,
     );
   }
 
@@ -58,20 +55,10 @@ class ProtPaladinT304P extends Analyzer {
   // If not, count it as a GC proc, and have inverse counter in GC.tsx
   _lastResetSource: CastEvent | DamageEvent | null = null;
 
-  private onApplyBuff(event: ApplyBuffEvent) {
-    // If no Judgment crit for apply buff, T30 4p isn't why we got GC
-    if (gcJudgmentCrit(event)) {
-      console.log('NoProc APPLY BUFF');
-      this.gcJudgmentCrits += 1;
-    }
-    return;
-  }
-
-  private onRefreshBuff(event: RefreshBuffEvent) {
+  private trackGrandCrusaderProcs(event: RefreshBuffEvent | ApplyBuffEvent) {
     // const gcjudgmentCrit = gcJudgmentCrit(event);
     // If no Judgment crit for apply buff, T30 4p isn't why we got GC
     if (gcJudgmentCrit(event)) {
-      console.log('NoProc Refresh BUFF');
       this.gcJudgmentCrits += 1;
     }
     return;

--- a/src/analysis/retail/paladin/protection/modules/features/SpellUsable.tsx
+++ b/src/analysis/retail/paladin/protection/modules/features/SpellUsable.tsx
@@ -1,9 +1,8 @@
-import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/paladin';
 import { Options } from 'parser/core/Analyzer';
 import { CastEvent, EventType, FreeCastEvent } from 'parser/core/Events';
-import CoreSpellUsable, { COOLDOWN_LAG_MARGIN } from 'parser/shared/modules/SpellUsable';
-import GrandCrusader from '../core/GrandCrusader';
+import CoreSpellUsable from 'parser/shared/modules/SpellUsable';
+import GrandCrusader from '../talents/GrandCrusader';
 class SpellUsable extends CoreSpellUsable {
   static dependencies = {
     ...CoreSpellUsable.dependencies,
@@ -24,19 +23,6 @@ class SpellUsable extends CoreSpellUsable {
       // ignore the event
       return;
     }
-
-    const validSpell =
-      spellId === TALENTS.AVENGERS_SHIELD_TALENT.id ||
-      spellId === SPELLS.JUDGMENT_CAST_PROTECTION.id;
-
-    if (
-      validSpell &&
-      !this.isAvailable(spellId) &&
-      this.cooldownRemaining(spellId) > COOLDOWN_LAG_MARGIN
-    ) {
-      this.gc.triggerInferredReset(this, triggeringEvent);
-    }
-
     super.beginCooldown(triggeringEvent, spellId);
   }
 }

--- a/src/analysis/retail/paladin/protection/modules/talents/GrandCrusader.tsx
+++ b/src/analysis/retail/paladin/protection/modules/talents/GrandCrusader.tsx
@@ -85,7 +85,7 @@ class GrandCrusader extends Analyzer {
   }
 
   statistic() {
-    const gcJProcs = this.protPaladinT304p.procs();
+    const gcJProcs = this.protPaladinT304p.gcJudgmentCrits;
     //As we use a different formula than the standard one for XAxis, we send it along as a parameter
     const binomChartXAxis = {
       title: 'Reset %',

--- a/src/common/SPELLS/paladin.ts
+++ b/src/common/SPELLS/paladin.ts
@@ -457,6 +457,16 @@ const spells = spellIndexableList({
     name: 'Sacrifice of the Just',
     icon: 'spell_holy_divineshield',
   },
+  INSPIRING_VANGUARD_BUFF: {
+    id: 393019,
+    name: 'Inspiring Vanguard',
+    icon: 'inv_helmet_74',
+  },
+  GRAND_CRUSADER_BUFF: {
+    id: 85416,
+    name: 'Grand Crusader',
+    icon: 'inv_helmet_74',
+  },
 
   // Buffs
   SHIELD_OF_THE_RIGHTEOUS_BUFF: {


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->
Changing the method of gathering info regarding Grand Crusader procs from an inferred guess based on casts while a spell should be on cooldown, to a buff related method, introduced in 10.0.

Additionally implemented the T30 4pc by checking for Grand crusader procs which happened as a result of Judgment Crits.


### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: '/report/phvLQmnwyKPCAkcH/18-Heroic+Rashok,+the+Elder+-+Kill+(3:01)/18-Mfkay/standard'
- Screenshot(s): ![PPalaWowAnalT30pc4](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/34073843/5dae80c6-ee69-4716-a598-66ac30cbab89)

