### PR TITLE
add resource costs to talent generation

### DIFF
--- a/scripts/talents/generate-talents.ts
+++ b/scripts/talents/generate-talents.ts
@@ -5,6 +5,7 @@ import {
   createTalentKey,
   csvToObject,
   findResourceCost,
+  findResourceCostPerSecond,
   printTalents,
   readCsvFromUrl,
   readJsonFromUrl,
@@ -14,16 +15,17 @@ import {
   GenericTalentInterface,
   ISpellpower,
   ITalentTree,
+  ResourceCostPerSecondType,
   ResourceCostType,
   ResourceTypes,
   TalentEntry,
   TalentNode,
 } from './talent-tree-types';
 
-const LIVE_WOW_BUILD_NUMBER = '10.1.5.50401';
+const LIVE_WOW_BUILD_NUMBER = '10.1.5.50469';
 const LIVE_TALENT_DATA_URL = 'https://www.raidbots.com/static/data/live/talents.json';
 const LIVE_SPELLPOWER_DATA_URL = `https://wago.tools/db2/SpellPower/csv?build=${LIVE_WOW_BUILD_NUMBER}`;
-const PTR_WOW_BUILD_NUMBER = '10.1.5.50401';
+const PTR_WOW_BUILD_NUMBER = '10.1.5.50469';
 const PTR_TALENT_DATA_URL = 'https://www.raidbots.com/static/data/ptr/talents.json';
 const PTR_SPELLPOWER_DATA_URL = `https://wago.tools/db2/SpellPower/csv?build=${PTR_WOW_BUILD_NUMBER}`;
 
@@ -59,23 +61,39 @@ const withResources = (
       continue;
     }
     const resourceCostKey = `${camalize(resourceName)}Cost` as ResourceCostType;
+    const resourceCostPerSecondKey = `${camalize(
+      resourceName,
+    )}CostPerSecond` as ResourceCostPerSecondType;
     const cost = findResourceCost(
       entryInSpellPowerTable,
       resourceId,
       classes[classId].baseMaxResource,
     );
+    const costPerSecond = findResourceCostPerSecond(
+      entryInSpellPowerTable,
+      resourceId,
+      classes[classId].baseMaxResource,
+    );
 
-    if (cost === 0) {
-      // some 0 costs are included in the SpellPower table. skip them
-      continue;
+    if (cost !== 0) {
+      updatedTalent = {
+        ...updatedTalent,
+        // use the lowest observed non-zero cost.
+        // note: this is non-zero because we never reach this point with a 0 cost
+        [resourceCostKey]: Math.min(cost, updatedTalent[resourceCostKey] ?? Infinity),
+      };
     }
-
-    updatedTalent = {
-      ...updatedTalent,
-      // use the lowest observed non-zero cost.
-      // note: this is non-zero because we never reach this point with a 0 cost
-      [resourceCostKey]: Math.min(cost, updatedTalent[resourceCostKey] ?? Infinity),
-    };
+    if (costPerSecond !== 0) {
+      updatedTalent = {
+        ...updatedTalent,
+        // use the lowest observed non-zero cost.
+        // note: this is non-zero because we never reach this point with a 0 cost
+        [resourceCostPerSecondKey]: Math.min(
+          costPerSecond,
+          updatedTalent[resourceCostPerSecondKey] ?? Infinity,
+        ),
+      };
+    }
   }
 
   return updatedTalent;

--- a/scripts/talents/talent-tree-helpers.ts
+++ b/scripts/talents/talent-tree-helpers.ts
@@ -143,3 +143,24 @@ export function findResourceCost(
     return Number(entryInSpellPowerTable.ManaCost);
   }
 }
+
+export function findResourceCostPerSecond(
+  entryInSpellPowerTable: ISpellpower,
+  resourceId: number,
+  baseMaxResource: number,
+) {
+  if (parseFloat(entryInSpellPowerTable.PowerPctPerSecond) > 0) {
+    return Math.round((Number(entryInSpellPowerTable.PowerPctPerSecond) / 100) * baseMaxResource);
+  } else if (
+    [
+      ResourceTypes.RunicPower,
+      ResourceTypes.Rage,
+      ResourceTypes.SoulShards,
+      ResourceTypes.Pain,
+    ].includes(resourceId)
+  ) {
+    return Number(entryInSpellPowerTable.ManaPerSecond) / 10;
+  } else {
+    return Number(entryInSpellPowerTable.ManaPerSecond);
+  }
+}

--- a/scripts/talents/talent-tree-types.ts
+++ b/scripts/talents/talent-tree-types.ts
@@ -22,6 +22,7 @@ export enum ResourceTypes {
 }
 
 export type ResourceCostType = Uncapitalize<`${keyof typeof ResourceTypes}Cost`>;
+export type ResourceCostPerSecondType = Uncapitalize<`${keyof typeof ResourceTypes}CostPerSecond`>;
 
 export type GenericTalentDefinitionId = {
   id: number;
@@ -30,6 +31,8 @@ export type GenericTalentDefinitionId = {
 
 export type GenericTalentInterface = {
   [key in ResourceCostType]?: number;
+} & {
+  [key in ResourceCostPerSecondType]?: number;
 } & {
   id: number;
   name: string;

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -25,6 +25,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 7, 17), 'Add ability to support talents that cost resources per second; regenerate talents.', ToppleTheNun),
   change(date(2023, 7, 13), 'Mark 10.1.5 as the active patch.', ToppleTheNun),
   change(date(2023, 7, 10), 'Regenerate talents for 10.1.5.', ToppleTheNun),
   change(date(2023, 7, 10), 'Update remaining SpellLink usage.', ToppleTheNun),

--- a/src/analysis/retail/monk/mistweaver/modules/features/MistweaverHealingEfficiencyTracker.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/MistweaverHealingEfficiencyTracker.tsx
@@ -108,7 +108,8 @@ class MistweaverHealingEfficiencyTracker extends HealingEfficiencyTracker {
 
   getSoothingMistDetails(spellInfo: SpellInfoDetails) {
     // the default tracker gets the healing of the soothing mists, but only the mana for the first cast. Every tick costs mana.
-    spellInfo.manaSpent = this.soothingMist.soomTicks * TALENTS_MONK.SOOTHING_MIST_TALENT.manaCost!;
+    spellInfo.manaSpent =
+      this.soothingMist.soomTicks * (TALENTS_MONK.SOOTHING_MIST_TALENT.manaCostPerSecond ?? 0);
     spellInfo.healingDone = spellInfo.healingDone + this.soothingMist.gustsHealing;
     return spellInfo;
   }

--- a/src/common/SPELLS/Spell.ts
+++ b/src/common/SPELLS/Spell.ts
@@ -6,33 +6,49 @@ export default interface Spell {
   icon: string;
   //Death Knights
   runesCost?: number;
+  runesCostPerSecond?: number;
   runicPowerCost?: number;
+  runicPowerCostPerSecond?: number;
   //Demon Hunter
   furyCost?: number;
+  furyCostPerSecond?: number;
   painCost?: number;
+  painCostPerSecond?: number;
   //Druid
   lunarPowerCost?: number;
+  lunarPowerCostPerSecond?: number;
   //Feral Druid & Rogue
   energyCost?: number;
+  energyCostPerSecond?: number;
   comboPointsCost?: number;
+  comboPointsCostPerSecond?: number;
   //Hunter
   focusCost?: number;
-  //Mage, Healers & Warlock
+  focusCostPerSecond?: number;
+  //Mage, Paladin, Evoker, Healers & Warlock
   manaCost?: number;
+  manaCostPerSecond?: number;
   //Monk
   chiCost?: number;
+  chiCostPerSecond?: number;
   //Paladin
   holyPowerCost?: number;
+  holyPowerCostPerSecond?: number;
   //Priest
   insanityCost?: number;
+  insanityCostPerSecond?: number;
   // Shaman
   maelstromCost?: number;
+  maelstromCostPerSecond?: number;
   //Warlock
   soulShardsCost?: number;
+  soulShardsCostPerSecond?: number;
   //Warrior
   rageCost?: number;
+  rageCostPerSecond?: number;
   //Evoker
   essenceCost?: number;
+  essenceCostPerSecond?: number;
   //Classic
   lowRanks?: Array<number>;
 }

--- a/src/common/TALENTS/deathknight.ts
+++ b/src/common/TALENTS/deathknight.ts
@@ -214,6 +214,7 @@ const talents = createTalentList({
     maxRanks: 1,
     entryIds: [96222],
     definitionIds: [{ id: 101224, specId: 251 }],
+    runicPowerCostPerSecond: 18,
   },
   BRITTLE_TALENT: {
     id: 374504,

--- a/src/common/TALENTS/monk.ts
+++ b/src/common/TALENTS/monk.ts
@@ -1265,6 +1265,8 @@ const talents = createTalentList({
     maxRanks: 1,
     entryIds: [101509],
     definitionIds: [{ id: 106511, specId: 269 }],
+    manaCostPerSecond: 1000,
+    energyCostPerSecond: 15,
   },
   SPEAR_HAND_STRIKE_TALENT: {
     id: 116705,

--- a/src/common/TALENTS/warlock.ts
+++ b/src/common/TALENTS/warlock.ts
@@ -419,6 +419,7 @@ const talents = createTalentList({
     maxRanks: 1,
     entryIds: [91566],
     definitionIds: [{ id: 96568, specId: 265 }],
+    manaCostPerSecond: 2500,
   },
   DREADLASH_TALENT: {
     id: 264078,


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Add resource costs to talent generation. Specifically to resolve the `manaCost!` in the below line not being valid:
```ts
spellInfo.manaSpent = this.soothingMist.soomTicks * TALENTS_MONK.SOOTHING_MIST_TALENT.manaCost!;
```

This is a precursor to a bigger/better PR. :)
