### PR TITLE
[hpal] fix daybreak

### DIFF
--- a/src/analysis/retail/paladin/holy/CHANGELOG.tsx
+++ b/src/analysis/retail/paladin/holy/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { CamClark, Tialyss, ToppleTheNun, xizbow, Trevor, Abelito75 } from 'CONT
 import SPELLS from 'common/SPELLS/paladin';
 
 export default [
+  change(date(2023, 7, 17), <>Fixex innacuracy in <SpellLink spell={TALENTS.DAYBREAK_TALENT} /></>, Tialyss),
   change(date(2023, 7, 16), <>Fixed inaccuracy in <SpellLink spell={TALENTS_PALADIN.RECLAMATION_TALENT}/></>, Trevor),
   change(date(2023, 7, 15), <>Removing Dumb Overhealing statistics I caused</>, Abelito75),
   change(date(2023, 7, 14), <>Added <SpellLink spell={SPELLS.JUDGMENT_CAST_HOLY} /> to Infusion of Light usage</>, Tialyss),

--- a/src/analysis/retail/paladin/holy/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/paladin/holy/normalizers/CastLinkNormalizer.ts
@@ -54,6 +54,8 @@ const EVENT_LINKS: EventLink[] = [
     referencedEventType: [EventType.ResourceChange],
     anyTarget: true,
     reverseLinkRelation: FROM_DAYBREAK,
+    forwardBufferMs: 100,
+    backwardBufferMs: 100,
   },
 ];
 


### PR DESCRIPTION
before: # = 0, mana gain undercounted
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/229650/f84ffbeb-f9dd-4fc5-8b8c-0e159bf8ac70)
after:
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/229650/72d5a0ff-c0ce-45e4-a8b1-6b0dff622fe3)

