### PR TITLE
don't include GA/ad code in dev mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,10 +185,11 @@ jobs:
         run: |
           REACT_APP_ENVIRONMENT_NAME=${GITHUB_REF##*/}
           REACT_APP_VERSION=$GITHUB_SHA
-          REACT_APP_ENABLE_GA=true
           # We already ran ESLint in a separate step
           DISABLE_AUTOMATIC_ESLINT=true
           yarn build
+        env:
+          REACT_APP_ENABLE_GA: true
       - run: tar -czf build.tar.gz build
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,6 +185,7 @@ jobs:
         run: |
           REACT_APP_ENVIRONMENT_NAME=${GITHUB_REF##*/}
           REACT_APP_VERSION=$GITHUB_SHA
+          REACT_APP_ENABLE_GA=true
           # We already ran ESLint in a separate step
           DISABLE_AUTOMATIC_ESLINT=true
           yarn build

--- a/public/index.html
+++ b/public/index.html
@@ -88,7 +88,7 @@
         color: #e45a5a;
       }
     </style>
-    <% if (process.env.NODE_ENV === 'production') { %>
+    <% if (process.env.REACT_APP_ENABLE_GA !== undefined) { %>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-MW95W6NHVC"></script>
     <script>
       var ramp = {

--- a/public/index.html
+++ b/public/index.html
@@ -88,6 +88,7 @@
         color: #e45a5a;
       }
     </style>
+    <% if (process.env.NODE_ENV === 'production') { %>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-MW95W6NHVC"></script>
     <script>
       var ramp = {
@@ -116,6 +117,9 @@
       gtag('config', 'G-E0TKKBEXVD', { send_page_view: false });
       gtag('event', 'ramp_js', { send_to: 'G-E0TKKBEXVD', pageview_id: window._pwGA4PageviewId });
     </script>
+    <% } else { %>
+    <!-- GA and ad code is not included in development mode. Check the HTML template if you need to test either. -->
+    <% } %>
   </head>
 
   <body>


### PR DESCRIPTION
while useful for some purposes, dev-mode hot reload generates a ton of events and is skewing things (who knew that Topple's DH was so popular?!)