### PR TITLE
[Classic] Realms 3

### DIFF
--- a/scripts/realms/data/classicKR.json
+++ b/scripts/realms/data/classicKR.json
@@ -37,14 +37,6 @@
     },
     {
       "key": {
-        "href": "https://kr.api.blizzard.com/data/wow/realm/4693?namespace=dynamic-classic-kr"
-      },
-      "name": "KR1 CWOW GMSS 1",
-      "id": 4693,
-      "slug": "kr1-cwow-gmss-1"
-    },
-    {
-      "key": {
         "href": "https://kr.api.blizzard.com/data/wow/realm/4840?namespace=dynamic-classic-kr"
       },
       "name": "서리한",

--- a/scripts/realms/output.ts
+++ b/scripts/realms/output.ts
@@ -981,7 +981,6 @@ export const CLASSIC_REALMS: Record<ClassicRegion, Realm[]> = {
     { name: 'Хроми', slug: 'chromie' },
   ],
   KR: [
-    { name: 'KR1 CWOW GMSS 1', slug: 'kr1-cwow-gmss-1' },
     { name: '라그나로스', slug: 'ragnaros' },
     { name: '로크홀라', slug: 'lokholar' },
     { name: '서리한', slug: 'frostmourne' },

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -25,10 +25,11 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 7, 19), 'Update NameSearch to swap between Retail and Classic Realm lists', jazminite),
   change(date(2023, 7, 17), 'Update spell registration to use `satisfies` keyword', ToppleTheNun),
   change(date(2023, 7, 17), 'Make patch incompatibility warning more clear.', ToppleTheNun),
   change(date(2023, 7, 17), 'Add ability to support talents that cost resources per second; regenerate talents.', ToppleTheNun),
-  change(date(2023, 7, 14), 'Updates Classic Realms', jazminite),
+  change(date(2023, 7, 14), 'Updates for Classic Realms', jazminite),
   change(date(2023, 7, 13), 'Mark 10.1.5 as the active patch.', ToppleTheNun),
   change(date(2023, 7, 10), 'Regenerate talents for 10.1.5.', ToppleTheNun),
   change(date(2023, 7, 10), 'Update remaining SpellLink usage.', ToppleTheNun),

--- a/src/game/REALMS.ts
+++ b/src/game/REALMS.ts
@@ -981,7 +981,6 @@ export const CLASSIC_REALMS: Record<ClassicRegion, Realm[]> = {
     { name: 'Хроми', slug: 'chromie' },
   ],
   KR: [
-    { name: 'KR1 CWOW GMSS 1', slug: 'kr1-cwow-gmss-1' },
     { name: '라그나로스', slug: 'ragnaros' },
     { name: '로크홀라', slug: 'lokholar' },
     { name: '서리한', slug: 'frostmourne' },

--- a/src/game/RealmList.ts
+++ b/src/game/RealmList.ts
@@ -1,4 +1,4 @@
-import { REALMS } from './REALMS';
+import { REALMS, CLASSIC_REALMS } from './REALMS';
 
 interface RealmList {
   [region: string]: Realm[];
@@ -9,4 +9,5 @@ interface Realm {
   slug: string;
 }
 
-export default REALMS as RealmList;
+export const REALM_LIST: RealmList = REALMS;
+export const CLASSIC_REALM_LIST: RealmList = CLASSIC_REALMS;

--- a/src/interface/GuildReports.tsx
+++ b/src/interface/GuildReports.tsx
@@ -19,7 +19,7 @@ import ALLIANCE_PICTURE from './images/ally_guild_banner_bwl.jpg';
 import HORDE_PICTURE from './images/horde_guild_banner_onyx.jpg';
 
 const loadRealms = () =>
-  retryingPromise(() => import('game/RealmList').then((exports) => exports.default));
+  retryingPromise(() => import('game/RealmList').then((exports) => exports.REALM_LIST));
 
 const ZONE_ALL = -1;
 const ZONE_DEFAULT = ZONE_ALL;

--- a/src/interface/Header.scss
+++ b/src/interface/Header.scss
@@ -60,6 +60,9 @@ header.report-selection .about {
   margin-bottom: 10px;
   height: 42px;
 
+  .game {
+    width: auto;
+  }
   .region {
     width: 70px;
   }


### PR DESCRIPTION
### Description

- Add the ability to swap between Retail and Classic Realm Lists for Character search
- Remove Classic KR test realm
- Misc updates for Retail Realms import

### Testing
- I've hidden the Classic select option for now since the pages after clicking "Search" don't work yet.
- Only Dragonflight is displayed and the search still works for it. 

DEMO:
![wowa-realms-swap](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/65823478/203448f4-fff8-461a-8c34-111c52e36062)

### Related
#6054 #6213 