### PR TITLE
Add scrollability to BuffCountGraph

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -19,12 +19,14 @@ import {
   HerzBlutRaffy,
   Abelito75,
   Jundarer,
+  Vollmer,
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 7, 21), 'Add scrollability to Buff count graphs', Vollmer),
   change(date(2023, 7, 19), 'Update NameSearch to swap between Retail and Classic Realm lists', jazminite),
   change(date(2023, 7, 17), 'Update spell registration to use `satisfies` keyword', ToppleTheNun),
   change(date(2023, 7, 17), 'Make patch incompatibility warning more clear.', ToppleTheNun),

--- a/src/parser/shared/modules/BuffCountGraph.tsx
+++ b/src/parser/shared/modules/BuffCountGraph.tsx
@@ -309,6 +309,13 @@ abstract class BuffCountGraph extends Analyzer {
   }
 
   get plot() {
+    // If the x-axis is too long, we enable horizontal scrolling, for better readability
+    const graphLenght = this.lastTimestamp - this.owner.fight.start_time;
+    const threshold = 8 * 60 * 1000;
+
+    // If we go above threshold make a tick each 20s
+    const tickCount = graphLenght > threshold ? Math.floor(graphLenght / 20000) : 25;
+
     const spec: VisualizationSpec = {
       data: {
         name: 'graphData',
@@ -328,7 +335,7 @@ abstract class BuffCountGraph extends Analyzer {
           type: 'quantitative' as const,
           axis: {
             labelExpr: formatTime('datum.value'),
-            tickCount: 25,
+            tickCount: tickCount,
             grid: false,
           },
           scale: {
@@ -344,26 +351,38 @@ abstract class BuffCountGraph extends Analyzer {
       ],
     };
 
+    // Calculate the width percentage so the graph has consistent size
+    const widthPercentage = graphLenght > threshold ? (graphLenght / threshold) * 100 : 100;
+
     return (
       <div
         className="graph-container"
         style={{
           width: '100%',
-          minHeight: 200,
+          overflowX: graphLenght > threshold ? 'auto' : 'hidden', // Enable horizontal scrolling if the data length exceeds the threshold
         }}
       >
-        <AutoSizer>
-          {({ width, height }) => (
-            <BaseChart
-              spec={spec}
-              data={{
-                graphData: this.graphData,
-              }}
-              width={width}
-              height={height}
-            />
-          )}
-        </AutoSizer>
+        <div
+          style={{
+            padding: graphLenght > threshold ? '0 0 30px' : '0 0 0px', // Add padding so scrollbar doesn't overlap x-axis
+            width: `${widthPercentage}%`,
+            overflowY: 'hidden',
+            minHeight: 200,
+          }}
+        >
+          <AutoSizer>
+            {({ width, height }) => (
+              <BaseChart
+                spec={spec}
+                data={{
+                  graphData: this.graphData,
+                }}
+                width={width}
+                height={height}
+              />
+            )}
+          </AutoSizer>
+        </div>
       </div>
     );
   }

--- a/src/parser/shared/modules/BuffCountGraph.tsx
+++ b/src/parser/shared/modules/BuffCountGraph.tsx
@@ -310,11 +310,11 @@ abstract class BuffCountGraph extends Analyzer {
 
   get plot() {
     // If the x-axis is too long, we enable horizontal scrolling, for better readability
-    const graphLenght = this.lastTimestamp - this.owner.fight.start_time;
+    const graphLength = this.lastTimestamp - this.owner.fight.start_time;
     const threshold = 8 * 60 * 1000;
 
     // If we go above threshold make a tick each 20s
-    const tickCount = graphLenght > threshold ? Math.floor(graphLenght / 20000) : 25;
+    const tickCount = graphLength > threshold ? Math.floor(graphLength / 20000) : 25;
 
     const spec: VisualizationSpec = {
       data: {
@@ -352,19 +352,19 @@ abstract class BuffCountGraph extends Analyzer {
     };
 
     // Calculate the width percentage so the graph has consistent size
-    const widthPercentage = graphLenght > threshold ? (graphLenght / threshold) * 100 : 100;
+    const widthPercentage = graphLength > threshold ? (graphLength / threshold) * 100 : 100;
 
     return (
       <div
         className="graph-container"
         style={{
           width: '100%',
-          overflowX: graphLenght > threshold ? 'auto' : 'hidden', // Enable horizontal scrolling if the data length exceeds the threshold
+          overflowX: graphLength > threshold ? 'auto' : 'hidden', // Enable horizontal scrolling if the data length exceeds the threshold
         }}
       >
         <div
           style={{
-            padding: graphLenght > threshold ? '0 0 30px' : '0 0 0px', // Add padding so scrollbar doesn't overlap x-axis
+            padding: graphLength > threshold ? '0 0 30px' : '0 0 0px', // Add padding so scrollbar doesn't overlap x-axis
             width: `${widthPercentage}%`,
             overflowY: 'hidden',
             minHeight: 200,


### PR DESCRIPTION
### Description

Currently when the BuffCountGraph becomes too long(eg. in Dungeon runs) it becomes heavily unreadable. This change makes it so once the graph exceeeds a threshold (currently 8 minutes) it will become scrollable, which makes it readable regardless of length.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/4jyT7CqbAmn6xPDF/1-Mythic++Brackenhide+Hollow+-+Kill+(31:48)/1-Hughdrakman/standard`
- Screenshot(s):
Current:
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/50344adc-953f-4ecd-9e3e-5aab4a8c97e0)
Changed version:

![NVIDIA_Share_mdpqT5M2hA](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/69345f5c-64e2-458b-926c-ec6720c884fe)
