### PR TITLE
[Augmentation] Performance check & Normalization update

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -2,8 +2,12 @@ import { change, date } from 'common/changelog';
 import { Vollmer } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import TALENTS from 'common/TALENTS/evoker';
+import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+    change(date(2023, 7, 22), <>Update performance check for <SpellLink spell={TALENTS.EBON_MIGHT_TALENT} />, <SpellLink spell={TALENTS.PRESCIENCE_TALENT} /> and <SpellLink spell={SPELLS.SHIFTING_SANDS_BUFF} /> .</>, Vollmer),
+    change(date(2023, 7, 22), <>Fix <SpellLink spell={TALENTS.EBON_MIGHT_TALENT} /> sometimes being applied twice.</>, Vollmer),
+    change(date(2023, 7, 22), <>Fix edgecase for pre-pull cast of <SpellLink spell={TALENTS.PRESCIENCE_TALENT} /> not being properly found.</>, Vollmer),
     change(date(2023, 7, 20), <>Add <SpellLink spell={TALENTS.PRESCIENCE_TALENT} /> to Cooldown Graph.</>, Vollmer),
     change(date(2023, 7, 20), <>Add support for pre-pull casts of <SpellLink spell={TALENTS.PRESCIENCE_TALENT} /> and <SpellLink spell={TALENTS.EBON_MIGHT_TALENT} />.</>, Vollmer),
     change(date(2023, 7, 19), <>Initial implementation of Augmentation</>, Vollmer),

--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+    change(date(2023, 7, 22), <>Add <SpellLink spell={TALENTS.TIME_SKIP_TALENT} /> to channeled spells to fix downtime and timeline.</>, Vollmer),
     change(date(2023, 7, 22), <>Update performance check for <SpellLink spell={TALENTS.EBON_MIGHT_TALENT} />, <SpellLink spell={TALENTS.PRESCIENCE_TALENT} /> and <SpellLink spell={SPELLS.SHIFTING_SANDS_BUFF} /> .</>, Vollmer),
     change(date(2023, 7, 22), <>Fix <SpellLink spell={TALENTS.EBON_MIGHT_TALENT} /> sometimes being applied twice.</>, Vollmer),
     change(date(2023, 7, 22), <>Fix edgecase for pre-pull cast of <SpellLink spell={TALENTS.PRESCIENCE_TALENT} /> not being properly found.</>, Vollmer),

--- a/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
@@ -21,6 +21,7 @@ import BlisteringScalesStackTracker from './modules/talents/BlisteringScalesStac
 import PrescienceNormalizer from './modules/normalizers/PrescienceNormalizer';
 import CastLinkNormalizer from './modules/normalizers/CastLinkNormalizer';
 import EmpowerNormalizer from './modules/normalizers/EmpowerNormalizer';
+import EbonMightNormalizer from './modules/normalizers/EbonMightNormalizer';
 
 class CombatLogParser extends MainCombatLogParser {
   static specModules = {
@@ -28,6 +29,7 @@ class CombatLogParser extends MainCombatLogParser {
     castLinkNormalizer: CastLinkNormalizer,
     prescienceNormalizer: PrescienceNormalizer,
     empowerNormalizer: EmpowerNormalizer,
+    ebonMightNormalizer: EbonMightNormalizer,
 
     // Core
     abilities: Abilities,

--- a/src/analysis/retail/evoker/augmentation/modules/abilities/EbonMight.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/abilities/EbonMight.tsx
@@ -24,8 +24,11 @@ import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { combineQualitativePerformances } from 'common/combineQualitativePerformances';
 import HideGoodCastsSpellUsageSubSection from 'parser/core/SpellUsage/HideGoodCastsSpellUsageSubSection';
 import { logSpellUseEvent } from 'parser/core/SpellUsage/SpellUsageSubSection';
-import { ebonIsFromBreath } from '../normalizers/CastLinkNormalizer';
+import { ebonIsFromBreath, getEbonMightBuffEvents } from '../normalizers/CastLinkNormalizer';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
+import Combatants from 'parser/shared/modules/Combatants';
+import SPECS from 'game/SPECS';
+import ROLES from 'game/ROLES';
 
 const PANDEMIC_WINDOW = 0.3;
 
@@ -46,6 +49,7 @@ interface EbonMightCooldownCast {
   event: AnyEvent;
   oldBuffRemainder: number;
   currentMastery: number;
+  buffedTargets: ApplyBuffEvent[] | RefreshBuffEvent[];
 }
 interface PrescienceBuffs {
   event: ApplyBuffEvent | RemoveBuffEvent;
@@ -55,9 +59,11 @@ class EbonMight extends Analyzer {
   static dependencies = {
     stats: StatTracker,
     spellUsable: SpellUsable,
+    combatants: Combatants,
   };
   protected stats!: StatTracker;
   protected spellUsable!: SpellUsable;
+  protected combatants!: Combatants;
 
   private uses: SpellUse[] = [];
   private ebonMightCasts: EbonMightCooldownCast[] = [];
@@ -102,10 +108,12 @@ class EbonMight extends Analyzer {
   }
 
   private onEbonApply(event: ApplyBuffEvent) {
+    const buffedTargets = getEbonMightBuffEvents(event);
     this.ebonMightCasts.push({
       event: event,
       oldBuffRemainder: this.ebonMightTimeLeft(event),
       currentMastery: this.stats.currentMasteryPercentage,
+      buffedTargets,
     });
     this.currentEbonMightDuration = ebonIsFromBreath(event)
       ? 5
@@ -126,10 +134,12 @@ class EbonMight extends Analyzer {
   }
 
   private onEbonRefresh(event: RefreshBuffEvent) {
+    const buffedTargets = getEbonMightBuffEvents(event);
     this.ebonMightCasts.push({
       event: event,
       oldBuffRemainder: this.ebonMightTimeLeft(event),
       currentMastery: this.stats.currentMasteryPercentage,
+      buffedTargets,
     });
     this.currentEbonMightDuration = this.calculateEbonMightDuration(event);
     this.currentEbonMightCastTime = event.timestamp;
@@ -220,6 +230,48 @@ class EbonMight extends Analyzer {
     ebonMightCooldownCast: EbonMightCooldownCast,
     prescienceCasts: PrescienceBuffs[],
   ): SpellUse {
+    const presciencePerformanceCheck = this.getPresciencePerformance(
+      ebonMightCooldownCast,
+      prescienceCasts,
+    );
+
+    const rolePerformanceCheck = this.getRolePerformance(ebonMightCooldownCast);
+
+    const checklistItems: ChecklistUsageInfo[] = [
+      {
+        check: 'prescience-performance',
+        timestamp: ebonMightCooldownCast.event.timestamp,
+        ...presciencePerformanceCheck,
+      },
+    ];
+    if (rolePerformanceCheck) {
+      checklistItems.push({
+        check: 'role-performance',
+        timestamp: ebonMightCooldownCast.event.timestamp,
+        ...rolePerformanceCheck,
+      });
+    }
+
+    const actualPerformance = combineQualitativePerformances(
+      checklistItems.map((item) => item.performance),
+    );
+
+    return {
+      event: ebonMightCooldownCast.event,
+      performance: actualPerformance,
+      checklistItems,
+      performanceExplanation:
+        actualPerformance !== QualitativePerformance.Fail
+          ? `${actualPerformance} Usage`
+          : 'Bad Usage',
+    };
+  }
+
+  /** Do Performance check for amount of prescience active on cast */
+  private getPresciencePerformance(
+    ebonMightCooldownCast: EbonMightCooldownCast,
+    prescienceCasts: PrescienceBuffs[],
+  ) {
     const oldDuration = ebonMightCooldownCast.oldBuffRemainder;
     const ebonMightPandemicAmount =
       EBON_MIGHT_BASE_DURATION_MS *
@@ -230,6 +282,8 @@ class EbonMight extends Analyzer {
     let summary;
     let details;
     let prescienceBuffsActive = 0;
+    const PERFECT_PRESCIENCE_BUFFS = 2;
+    const OK_PRESCIENCE_BUFFS = 1;
 
     prescienceCasts.forEach((event) => {
       if (
@@ -247,7 +301,7 @@ class EbonMight extends Analyzer {
     if (oldDuration > 0) {
       performance =
         oldDuration < ebonMightPandemicAmount
-          ? QualitativePerformance.Perfect
+          ? QualitativePerformance.Good
           : QualitativePerformance.Fail;
       summary = (
         <div>
@@ -276,8 +330,7 @@ class EbonMight extends Analyzer {
           cast.
         </div>
       );
-      // Case 1: 2 buffed targets
-      if (prescienceBuffsActive >= 2) {
+      if (prescienceBuffsActive >= PERFECT_PRESCIENCE_BUFFS) {
         performance = QualitativePerformance.Perfect;
         details = (
           <div>
@@ -285,19 +338,16 @@ class EbonMight extends Analyzer {
             on cast. Good job!
           </div>
         );
-      }
-      // Case 2: 1 buffed target
-      else if (prescienceBuffsActive === 1) {
+      } else if (prescienceBuffsActive === OK_PRESCIENCE_BUFFS) {
         performance = QualitativePerformance.Ok;
         details = (
           <div>
             You had {prescienceBuffsActive} <SpellLink spell={TALENTS.PRESCIENCE_TALENT} /> active
-            on cast. Try to line it up so you have two active.
+            on cast. Try to line it up so you have two active, so you can better control who your{' '}
+            <SpellLink spell={TALENTS.EBON_MIGHT_TALENT} /> goes on.
           </div>
         );
-      }
-      // Case 3: 0 buffed targets
-      else {
+      } else {
         performance = QualitativePerformance.Fail;
         details = (
           <div>
@@ -310,29 +360,68 @@ class EbonMight extends Analyzer {
       }
     }
 
-    const checklistItems: ChecklistUsageInfo[] = [
-      {
-        check: 'buffed-targets',
-        timestamp: ebonMightCooldownCast.event.timestamp,
-        performance,
-        summary,
-        details,
-      },
-    ];
-
-    const actualPerformance = combineQualitativePerformances(
-      checklistItems.map((item) => item.performance),
-    );
-
-    return {
-      event: ebonMightCooldownCast.event,
-      performance: actualPerformance,
-      checklistItems,
-      performanceExplanation:
-        actualPerformance !== QualitativePerformance.Fail
-          ? `${actualPerformance} Usage`
-          : 'Bad Usage',
+    const performanceCheck = {
+      performance: performance,
+      summary: summary,
+      details: details,
     };
+
+    return performanceCheck;
+  }
+
+  /** Do role/spec Performance check for players
+   * getting buffed are DPS (excluding Aug this one is a crime!) */
+  private getRolePerformance(ebonMightCooldownCast: EbonMightCooldownCast) {
+    // Only run the check if there is actually 4 dps players amongus
+    const enoughDPSFound =
+      (ebonMightCooldownCast.buffedTargets as (ApplyBuffEvent | RefreshBuffEvent)[]).reduce(
+        (dpsCount, buffedTarget) =>
+          this.combatants.players[buffedTarget.targetID]?.spec?.role === ROLES.DPS.RANGED ||
+          this.combatants.players[buffedTarget.targetID]?.spec?.role === ROLES.DPS.MELEE
+            ? dpsCount + 1
+            : dpsCount,
+        0,
+      ) >= 4;
+
+    if (!enoughDPSFound || !ebonMightCooldownCast.buffedTargets) {
+      return;
+    }
+
+    let rolePerformance = QualitativePerformance.Perfect;
+    const buffedPlayers: JSX.Element[] = [];
+
+    ebonMightCooldownCast.buffedTargets.forEach((player) => {
+      const currentPlayer = this.combatants.players[player.targetID];
+      const className = currentPlayer.spec?.className.replace(/\s/g, '') ?? '';
+      let currentPlayerRole = 'DPS';
+      if (
+        currentPlayer.spec?.role === ROLES.HEALER ||
+        currentPlayer.spec?.role === ROLES.TANK ||
+        currentPlayer.spec === SPECS.AUGMENTATION_EVOKER
+      ) {
+        if (currentPlayer.spec?.role === ROLES.HEALER) {
+          currentPlayerRole = 'Healer';
+        } else if (currentPlayer.spec?.role === ROLES.TANK) {
+          currentPlayerRole = 'Tank';
+        } else {
+          currentPlayerRole = 'Augmentation';
+        }
+        rolePerformance = QualitativePerformance.Fail;
+      }
+      buffedPlayers.push(
+        <div>
+          Buffed {currentPlayerRole}: <span className={className}>{currentPlayer.name}</span>
+        </div>,
+      );
+    });
+
+    const performanceCheck = {
+      performance: rolePerformance,
+      summary: <div>Buffed 4 DPS</div>,
+      details: <div>{buffedPlayers}</div>,
+    };
+
+    return performanceCheck;
   }
 
   guideSubsection(): JSX.Element | null {

--- a/src/analysis/retail/evoker/augmentation/modules/abilities/EbonMight.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/abilities/EbonMight.tsx
@@ -373,15 +373,19 @@ class EbonMight extends Analyzer {
    * getting buffed are DPS (excluding Aug this one is a crime!) */
   private getRolePerformance(ebonMightCooldownCast: EbonMightCooldownCast) {
     // Only run the check if there is actually 4 dps players amongus
+    const players = Object.values(this.combatants.players);
+
     const enoughDPSFound =
-      (ebonMightCooldownCast.buffedTargets as (ApplyBuffEvent | RefreshBuffEvent)[]).reduce(
-        (dpsCount, buffedTarget) =>
-          this.combatants.players[buffedTarget.targetID]?.spec?.role === ROLES.DPS.RANGED ||
-          this.combatants.players[buffedTarget.targetID]?.spec?.role === ROLES.DPS.MELEE
-            ? dpsCount + 1
-            : dpsCount,
-        0,
-      ) >= 4;
+      players.reduce((dpsCount, player) => {
+        const targetID = player._combatantInfo.sourceID;
+
+        const isRangedDPS = this.combatants.players[targetID]?.spec?.role === ROLES.DPS.RANGED;
+        const isMeleeDPS = this.combatants.players[targetID]?.spec?.role === ROLES.DPS.MELEE;
+        const isAugmentation =
+          this.combatants.players[targetID]?.spec === SPECS.AUGMENTATION_EVOKER;
+
+        return (isRangedDPS || isMeleeDPS) && !isAugmentation ? dpsCount + 1 : dpsCount;
+      }, 0) >= 4;
 
     if (!enoughDPSFound || !ebonMightCooldownCast.buffedTargets) {
       return;

--- a/src/analysis/retail/evoker/augmentation/modules/abilities/SandsOfTime.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/abilities/SandsOfTime.tsx
@@ -72,7 +72,7 @@ class SandsOfTime extends Analyzer {
     const spell = possibleExtends.event.ability.guid;
     let performance = extended ? QualitativePerformance.Good : QualitativePerformance.Fail;
     if (spell === TALENTS.ERUPTION_TALENT.id && !extended) {
-      performance = QualitativePerformance.Ok;
+      performance = QualitativePerformance.Fail;
     }
     const summary = (
       <div>
@@ -140,7 +140,12 @@ class SandsOfTime extends Analyzer {
         explanation={explanation}
         uses={this.uses}
         castBreakdownSmallText={
-          <> - These boxes represent each cast, colored by how good the usage was.</>
+          <>
+            {' '}
+            - Green is a good cast where you extended you{' '}
+            <SpellLink spell={TALENTS.EBON_MIGHT_TALENT} /> window, Red is a bad cast where you
+            didn't extend.
+          </>
         }
         onPerformanceBoxClick={logSpellUseEvent}
         abovePerformanceDetails={<div style={{ marginBottom: 10 }}></div>}

--- a/src/analysis/retail/evoker/augmentation/modules/abilities/ShiftingSands.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/abilities/ShiftingSands.tsx
@@ -11,6 +11,7 @@ import { logSpellUseEvent } from 'parser/core/SpellUsage/SpellUsageSubSection';
 import Combatants from 'parser/shared/modules/Combatants';
 import ROLES from 'game/ROLES';
 import Combatant from 'parser/core/Combatant';
+import SPECS from 'game/SPECS';
 
 interface ShiftingSandsApplications {
   event: ApplyBuffEvent;
@@ -54,30 +55,52 @@ class ShiftingSands extends Analyzer {
 
   private finalize() {
     // finalize performances
-    this.uses = this.shiftingSandsApplications.map(this.explainPerformance);
+    this.uses = this.shiftingSandsApplications.map((application) =>
+      this.explainPerformance(application),
+    );
   }
 
   private explainPerformance(application: ShiftingSandsApplications): SpellUse {
-    const className = application.combatant.spec?.className.replace(/\s/g, '') ?? '';
-    let ebonMightPerformance;
-    let presciencePerformance;
-    let rolePerformance;
-    let performance = QualitativePerformance.Fail;
+    let performance = QualitativePerformance.Perfect;
 
-    if (application.ebonMightOn && application.prescienceOn) {
-      performance = QualitativePerformance.Perfect;
-    } else if (application.ebonMightOn && !application.prescienceOn) {
+    const ebonMightPerformance = this.getEbonMightPerformance(application);
+    const presciencePerformance = this.getPresciencePerformance(application);
+    const rolePerformance = this.getRolePerformance(application);
+
+    if (
+      ebonMightPerformance.performance === QualitativePerformance.Fail ||
+      rolePerformance.performance === QualitativePerformance.Fail
+    ) {
+      performance = QualitativePerformance.Fail;
+    } else if (presciencePerformance.performance === QualitativePerformance.Fail) {
       performance = QualitativePerformance.Good;
     }
-    if (application.combatant.spec?.role === ROLES.HEALER) {
-      performance = QualitativePerformance.Fail;
-    } else if (
-      application.combatant.spec?.role === ROLES.TANK &&
-      performance !== QualitativePerformance.Fail
-    ) {
-      performance = QualitativePerformance.Ok;
-    }
 
+    const checklistItems: ChecklistUsageInfo[] = [
+      {
+        check: 'ebon-might-active',
+        timestamp: application.event.timestamp,
+        ...ebonMightPerformance,
+      },
+      {
+        check: 'prescience-active',
+        timestamp: application.event.timestamp,
+        ...presciencePerformance,
+      },
+      { check: 'role-performance', timestamp: application.event.timestamp, ...rolePerformance },
+    ];
+
+    return {
+      event: application.event,
+      performance: performance,
+      checklistItems,
+      performanceExplanation:
+        performance !== QualitativePerformance.Fail ? `${performance} Usage` : 'Bad Usage',
+    };
+  }
+
+  private getEbonMightPerformance(application: ShiftingSandsApplications) {
+    let ebonMightPerformance;
     const ebonSummary = (
       <div>
         Have <SpellLink spell={SPELLS.EBON_MIGHT_BUFF_EXTERNAL} /> active
@@ -106,7 +129,11 @@ class ShiftingSands extends Analyzer {
         ),
       };
     }
+    return ebonMightPerformance;
+  }
 
+  private getPresciencePerformance(application: ShiftingSandsApplications) {
+    let presciencePerformance;
     const prescienceSummary = (
       <div>
         Have <SpellLink spell={SPELLS.PRESCIENCE_BUFF} /> active
@@ -134,8 +161,13 @@ class ShiftingSands extends Analyzer {
         ),
       };
     }
+    return presciencePerformance;
+  }
 
+  private getRolePerformance(application: ShiftingSandsApplications) {
+    const className = application.combatant.spec?.className.replace(/\s/g, '') ?? '';
     const roleSummary = <div>Buffed DPS player.</div>;
+    let rolePerformance;
 
     if (
       !(application.combatant.spec?.role === ROLES.DPS.RANGED) &&
@@ -159,6 +191,18 @@ class ShiftingSands extends Analyzer {
             </div>
           ),
       };
+    } else if (application.combatant.spec === SPECS.AUGMENTATION_EVOKER) {
+      rolePerformance = {
+        performance: QualitativePerformance.Fail,
+        summary: roleSummary,
+        details: (
+          <div>
+            Buffed Augmentation: <span className={className}>{application.combatant.name}</span>{' '}
+            with <SpellLink spell={SPELLS.SHIFTING_SANDS_BUFF} />. This should never happen! Make
+            sure you position yourself better to avoid this.
+          </div>
+        ),
+      };
     } else {
       rolePerformance = {
         performance: QualitativePerformance.Good,
@@ -171,28 +215,7 @@ class ShiftingSands extends Analyzer {
         ),
       };
     }
-
-    const checklistItems: ChecklistUsageInfo[] = [
-      {
-        check: 'ebon-might-active',
-        timestamp: application.event.timestamp,
-        ...ebonMightPerformance,
-      },
-      {
-        check: 'prescience-active',
-        timestamp: application.event.timestamp,
-        ...presciencePerformance,
-      },
-      { check: 'role-performance', timestamp: application.event.timestamp, ...rolePerformance },
-    ];
-
-    return {
-      event: application.event,
-      performance: performance,
-      checklistItems,
-      performanceExplanation:
-        performance !== QualitativePerformance.Fail ? `${performance} Usage` : 'Bad Usage',
-    };
+    return rolePerformance;
   }
 
   guideSubsection(): JSX.Element | null {

--- a/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
@@ -6,6 +6,7 @@ import {
   EventType,
   GetRelatedEvents,
   HasRelatedEvent,
+  RefreshBuffEvent,
 } from 'parser/core/Events';
 import { Options } from 'parser/core/Module';
 import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
@@ -90,6 +91,12 @@ class CastLinkNormalizer extends EventLinkNormalizer {
 
 export function getPrescienceBuffEvents(event: CastEvent): ApplyBuffEvent[] {
   return GetRelatedEvents(event, PRESCIENCE_BUFF_CAST_LINK).filter(
+    (e): e is ApplyBuffEvent => e.type === EventType.ApplyBuff || e.type === EventType.RefreshBuff,
+  );
+}
+
+export function getEbonMightBuffEvents(event: ApplyBuffEvent | RefreshBuffEvent): ApplyBuffEvent[] {
+  return GetRelatedEvents(event, EBON_MIGHT_BUFF_LINKS).filter(
     (e): e is ApplyBuffEvent => e.type === EventType.ApplyBuff || e.type === EventType.RefreshBuff,
   );
 }

--- a/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
@@ -14,10 +14,12 @@ export const PRESCIENCE_BUFF_CAST_LINK = 'prescienceBuffCastLink';
 export const PRESCIENCE_APPLY_REMOVE_LINK = 'prescienceApplyRemoveLink';
 export const TIP_THE_SCALES_CONSUME = 'tipTheScalesConsume';
 export const BREATH_EBON_APPLY_LINK = 'breathEbonApplyLink';
+export const EBON_MIGHT_BUFF_LINKS = 'ebonMightBuffLinks';
 
 export const PRESCIENCE_BUFFER = 150;
 export const CAST_BUFFER_MS = 100;
 export const BREATH_EBON_BUFFER = 250;
+export const EBON_MIGHT_BUFFER = 150;
 
 const EVENT_LINKS: EventLink[] = [
   {
@@ -66,6 +68,17 @@ const EVENT_LINKS: EventLink[] = [
     referencedEventType: EventType.ApplyBuff,
     anyTarget: true,
     forwardBufferMs: BREATH_EBON_BUFFER,
+  },
+  {
+    linkRelation: EBON_MIGHT_BUFF_LINKS,
+    reverseLinkRelation: EBON_MIGHT_BUFF_LINKS,
+    linkingEventId: SPELLS.EBON_MIGHT_BUFF_EXTERNAL.id,
+    linkingEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+    referencedEventId: SPELLS.EBON_MIGHT_BUFF_PERSONAL.id,
+    referencedEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+    anyTarget: true,
+    forwardBufferMs: EBON_MIGHT_BUFFER,
+    backwardBufferMs: EBON_MIGHT_BUFFER,
   },
 ];
 

--- a/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
@@ -36,9 +36,9 @@ const EVENT_LINKS: EventLink[] = [
   {
     linkRelation: PRESCIENCE_APPLY_REMOVE_LINK,
     linkingEventId: SPELLS.PRESCIENCE_BUFF.id,
-    linkingEventType: [EventType.ApplyBuff, EventType.RemoveBuff],
+    linkingEventType: [EventType.ApplyBuff, EventType.RemoveBuff, EventType.RefreshBuff],
     referencedEventId: SPELLS.PRESCIENCE_BUFF.id,
-    referencedEventType: [EventType.ApplyBuff, EventType.RemoveBuff],
+    referencedEventType: [EventType.ApplyBuff, EventType.RemoveBuff, EventType.RefreshBuff],
     anyTarget: true,
     forwardBufferMs: 5000,
     backwardBufferMs: 5000,

--- a/src/analysis/retail/evoker/augmentation/modules/normalizers/EbonMightNormalizer.ts
+++ b/src/analysis/retail/evoker/augmentation/modules/normalizers/EbonMightNormalizer.ts
@@ -1,0 +1,44 @@
+import { AnyEvent, EventType } from 'parser/core/Events';
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+import { EBON_MIGHT_BUFF_LINKS } from './CastLinkNormalizer';
+import SPELLS from 'common/SPELLS/evoker';
+
+/** This Normalizer fixes an issue that happens very rarely, where external Ebon Might
+ * buffs gets applied twice, this leaves us with twice the amount of ApplyBuffEvents
+ * that should be possible.
+ *
+ * The solution used here is to grab these extra events and turn them into RefreshBuffEvents.
+ *
+ * The issue described above can be seen here:
+ * https://www.warcraftlogs.com/reports/hXcYL7yBrMzKA4Qd/#fight=8&type=auras&pins=0%24Separate%24%23244F4B%24casts%240%240.0.0.Any%24173872654.0.0.Evoker%24true%240.0.0.Any%24false%24395152%5E0%24Separate%24%23909049%24casts%240%240.0.0.Any%24173872654.0.0.Evoker%24true%240.0.0.Any%24false%24403631&target=1&ability=395152&view=events&start=5145354&end=5162301 */
+
+class EbonMightNormalizer extends EventsNormalizer {
+  static dependencies = {
+    ...EventsNormalizer.dependencies,
+  };
+  normalize(events: any[]): any[] {
+    const fixedEvents: any[] = [];
+    events.forEach((event: AnyEvent, idx: number) => {
+      const linkedEvents = event._linkedEvents?.find((x) => x.relation === EBON_MIGHT_BUFF_LINKS);
+      /** for now I haven't seen the personal buff being applied twice, so we can easily
+       * check if the personal and external events are linked, if not change the event. */
+      if (
+        !linkedEvents &&
+        event.type === EventType.ApplyBuff &&
+        event.ability.guid === SPELLS.EBON_MIGHT_BUFF_EXTERNAL.id
+      ) {
+        const fabricatedBuffEvent = {
+          ...event,
+          type: EventType.RefreshBuff,
+          _fabricated: true,
+        };
+        fixedEvents.push(fabricatedBuffEvent);
+      } else {
+        fixedEvents.push(event);
+      }
+    });
+    return fixedEvents;
+  }
+}
+
+export default EbonMightNormalizer;

--- a/src/analysis/retail/evoker/augmentation/modules/normalizers/PrescienceNormalizer.ts
+++ b/src/analysis/retail/evoker/augmentation/modules/normalizers/PrescienceNormalizer.ts
@@ -47,7 +47,7 @@ class PrescienceNormalizer extends EventsNormalizer {
           ) {
             targetStatus[event.targetID] = true;
             fixedEvents.push(event);
-          } else if (event.type === EventType.RemoveBuff) {
+          } else if (event.type === EventType.RemoveBuff || EventType.RefreshBuff) {
             targetStatus[event.targetID] = false;
             fixedEvents.push(event);
             /**Check if the buff was applied pre-combat

--- a/src/analysis/retail/evoker/augmentation/modules/talents/Prescience.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/Prescience.tsx
@@ -11,6 +11,7 @@ import ROLES from 'game/ROLES';
 import Combatants from 'parser/shared/modules/Combatants';
 import { getPrescienceBuffEvents } from '../normalizers/CastLinkNormalizer';
 import Combatant from 'parser/core/Combatant';
+import SPECS from 'game/SPECS';
 
 /**
  * Prescience is a core talent that buffs the target with 3% crit, as well
@@ -89,6 +90,7 @@ class Prescience extends MajorCooldown<PrescienceCooldownCast> {
   }
 
   private prescienceWindowCastPerformance(cast: PrescienceCooldownCast): UsageInfo {
+    console.log(cast);
     const className = this.currentBuffedPlayer?.spec?.className.replace(/\s/g, '') ?? '';
     let performance = QualitativePerformance.Fail;
     const summary = <div>Buffed a DPS</div>;
@@ -99,13 +101,25 @@ class Prescience extends MajorCooldown<PrescienceCooldownCast> {
     );
 
     if (cast.onDPS) {
-      performance = QualitativePerformance.Good;
-      details = (
-        <div>
-          Buffed DPS: <span className={className}>{this.currentBuffedPlayer?.name}</span> with{' '}
-          <SpellLink spell={TALENTS.PRESCIENCE_TALENT} />. Good job!
-        </div>
-      );
+      // Bonk players for buffing other Augs
+      if (this.currentBuffedPlayer?.spec === SPECS.AUGMENTATION_EVOKER) {
+        performance = QualitativePerformance.Fail;
+        details = (
+          <div>
+            Buffed Augmentation: <span className={className}>{this.currentBuffedPlayer?.name}</span>{' '}
+            with <SpellLink spell={TALENTS.PRESCIENCE_TALENT} />. This should never happen! Make
+            sure you position yourself better to avoid this.
+          </div>
+        );
+      } else {
+        performance = QualitativePerformance.Good;
+        details = (
+          <div>
+            Buffed DPS: <span className={className}>{this.currentBuffedPlayer?.name}</span> with{' '}
+            <SpellLink spell={TALENTS.PRESCIENCE_TALENT} />. Good job!
+          </div>
+        );
+      }
     } else if (cast.onTank) {
       performance = QualitativePerformance.Ok;
       details = (
@@ -127,7 +141,7 @@ class Prescience extends MajorCooldown<PrescienceCooldownCast> {
       details = (
         <div>
           Buffed: yourself with <SpellLink spell={TALENTS.PRESCIENCE_TALENT} />. You should always
-          try and buff DPS players.
+          try and buff DPS players. Make sure to position yourself so you buff the intended players.
         </div>
       );
     } else {
@@ -148,6 +162,7 @@ class Prescience extends MajorCooldown<PrescienceCooldownCast> {
   private onCast(event: CastEvent) {
     let buffTarget;
     const relatedBuffEvents = getPrescienceBuffEvents(event);
+    console.log(event);
 
     for (let i = 0; i < relatedBuffEvents.length; i = i + 1) {
       const targetID = relatedBuffEvents[i].targetID;

--- a/src/analysis/retail/evoker/augmentation/modules/talents/Prescience.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/Prescience.tsx
@@ -90,7 +90,6 @@ class Prescience extends MajorCooldown<PrescienceCooldownCast> {
   }
 
   private prescienceWindowCastPerformance(cast: PrescienceCooldownCast): UsageInfo {
-    console.log(cast);
     const className = this.currentBuffedPlayer?.spec?.className.replace(/\s/g, '') ?? '';
     let performance = QualitativePerformance.Fail;
     const summary = <div>Buffed a DPS</div>;
@@ -162,7 +161,6 @@ class Prescience extends MajorCooldown<PrescienceCooldownCast> {
   private onCast(event: CastEvent) {
     let buffTarget;
     const relatedBuffEvents = getPrescienceBuffEvents(event);
-    console.log(event);
 
     for (let i = 0; i < relatedBuffEvents.length; i = i + 1) {
       const targetID = relatedBuffEvents[i].targetID;

--- a/src/parser/shared/normalizers/Channeling.ts
+++ b/src/parser/shared/normalizers/Channeling.ts
@@ -66,6 +66,7 @@ class Channeling extends EventsNormalizer {
     empowerChannelSpec(SPELLS.UPHEAVAL_FONT.id),
     buffChannelSpec(SPELLS.DISINTEGRATE.id),
     buffChannelSpec(TALENTS_EVOKER.BREATH_OF_EONS_TALENT.id),
+    buffChannelSpec(TALENTS_EVOKER.TIME_SKIP_TALENT.id),
     // Rogue
     // Druid
     buffChannelSpec(SPELLS.CONVOKE_SPIRITS.id),


### PR DESCRIPTION
### Description

1. By demand from Saeldur the performance check for Buffs (Prescience, Ebon Might & Shifting Sands) will now be more ruthless.  
   - Added role/spec performance checks to enable checking if another Augmentation was buffed. Buffing another Augmentation is pretty much on par if not worse than buffing a healer.
   - Along with this is also a small refactor to Ebon Might & Shifting Sands module to make it more maintainable.
2. Updated Prescience pre-pull normalizer to also look for RefreshBuffEvents.
3. Added Ebon Might normalizer to fix an inconsistency much like what happens with Prescience, where extra BuffApply events are being pushed right before BuffRemove events, which results in us having 2x the amount of buffs out than we actually do.

### Testing

- Test report URL: `/report/k4x6TM7K1XLG3p9V/27-Mythic+Scalecommander+Sarkareth+-+Kill+(7:28)/Vollmer/standard`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/dc96a0db-73cb-42d8-8cd4-5dfe328db510)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/2fe87f8b-b928-4762-a74d-0fba8c5509b4)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/703a5163-552a-43e4-a63a-bde04a590eaa)

