### PR TITLE
normalize Berserkers/Blademasters Torment extra casts

### DIFF
--- a/src/analysis/retail/warrior/arms/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/arms/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Abelito75, carglass, Carrottopp, Otthopsy, bandit, Toreole, emallson, T
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 7, 23), <>Normalize extra casts from <SpellLink spell={TALENTS.BLADEMASTERS_TORMENT_TALENT}/>.</>, ToppleTheNun),
   change(date(2023, 7, 8), 'Update SpellLink usage.', ToppleTheNun),
   change(date(2023, 1, 30), 'Fixed a crashing bug in the rage tracker.', emallson),
   change(date(2023, 1, 27), <>Updated Ability list for 10.0.5; Added Skullsplitter bleed damage contribution</>, Toreole),

--- a/src/analysis/retail/warrior/arms/CombatLogParser.tsx
+++ b/src/analysis/retail/warrior/arms/CombatLogParser.tsx
@@ -21,14 +21,12 @@ import CooldownThroughputTracker from './modules/features/CooldownThroughputTrac
 import RageDetail from './modules/features/RageDetails';
 import RageTracker from './modules/features/RageTracker';
 import SpellUsable from './modules/features/SpellUsable';
-//import Talents from './modules/talents';
 import AngerManagement from './modules/talents/AngerManagement';
 import Avatar from './modules/talents/Avatar';
 import Cleave from './modules/talents/Cleave';
 import DefensiveStance from './modules/talents/DefensiveStance';
 import FervorOfBattle from './modules/talents/FervorOfBattle';
 import ImpendingVictory from '../shared/modules/talents/ImpendingVictory';
-//import Ravager from './modules/talents/Ravager';
 import SecondWind from './modules/talents/SecondWind';
 import Skullsplitter from './modules/talents/Skullsplitter';
 import StormBolt from './modules/talents/StormBolt';
@@ -41,6 +39,7 @@ import SpellReflection from '../shared/modules/talents/SpellReflection';
 import FatalMark from './modules/talents/FatalMark';
 import ExecuteNormalizer from './normalizers/ExecuteNormalizer';
 import SkullsplitterDotNormalizer from './normalizers/SkullsplitterExpiredDots';
+import BlademastersTormentNormalizer from './modules/talents/BlademastersTorment';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -49,6 +48,7 @@ class CombatLogParser extends CoreCombatLogParser {
     battlelordBuff: BattlelordBuff,
     executeNormalizer: ExecuteNormalizer,
     skullsplitterDotNormalizer: SkullsplitterDotNormalizer,
+    blademaastersTormetNormalizer: BlademastersTormentNormalizer,
 
     // WarriorCore
     abilities: Abilities,
@@ -83,7 +83,6 @@ class CombatLogParser extends CoreCombatLogParser {
     rendRefreshes: RendRefreshes,
 
     // Talents
-    //talents: Talents,
     angerManagement: AngerManagement,
     defensiveStance: DefensiveStance,
     skullsplitter: Skullsplitter,
@@ -96,7 +95,6 @@ class CombatLogParser extends CoreCombatLogParser {
     cleave: Cleave,
     warbreaker: Warbreaker,
     avatar: Avatar,
-    //ravager: Ravager,
     spellReflection: SpellReflection,
     fatalMark: FatalMark,
 

--- a/src/analysis/retail/warrior/arms/modules/talents/BlademastersTorment.tsx
+++ b/src/analysis/retail/warrior/arms/modules/talents/BlademastersTorment.tsx
@@ -1,0 +1,84 @@
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+import { AnyEvent, EventType } from 'parser/core/Events';
+import TALENTS from 'common/TALENTS/warrior';
+import { Options } from 'parser/core/Module';
+
+export default class BlademastersTormentNormalizer extends EventsNormalizer {
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.BLADEMASTERS_TORMENT_TALENT);
+  }
+
+  normalize(events: AnyEvent[]): AnyEvent[] {
+    const fixedEvents: AnyEvent[] = [];
+
+    const bladestormId = TALENTS.BLADESTORM_TALENT.id;
+    const avatarId = TALENTS.AVATAR_SHARED_TALENT.id;
+    const relevantIds = [bladestormId, avatarId];
+    const bufferMs = 50;
+
+    events.forEach((event: AnyEvent, idx: number) => {
+      //We are only interested in Kill Command and Dire Beast casts
+      fixedEvents.push(event);
+      if (event.type !== EventType.Cast) {
+        return;
+      }
+      const spellId = event.ability.guid;
+      if (!relevantIds.includes(spellId)) {
+        return;
+      }
+
+      // if it's a Bladestorm cast, we need to check before it to see if there was an Avatar cast
+      if (spellId === bladestormId) {
+        for (let backwardsIndex = idx; backwardsIndex >= 0; backwardsIndex -= 1) {
+          const backwardsEvent = events[backwardsIndex];
+          if (event.timestamp - backwardsEvent.timestamp > bufferMs) {
+            continue;
+          }
+          if (
+            backwardsEvent.type !== EventType.Cast &&
+            backwardsEvent.type !== EventType.FreeCast
+          ) {
+            continue;
+          }
+          if (backwardsEvent.ability.guid !== avatarId) {
+            continue;
+          }
+          fixedEvents.splice(idx, 1);
+          fixedEvents.push({
+            ...event,
+            type: EventType.FreeCast,
+            __modified: true,
+          });
+        }
+      }
+
+      // if it's an Avatar cast, we need to check before it to see if there was a Bladestorm cast
+      if (spellId === avatarId) {
+        for (let backwardsIndex = idx; backwardsIndex >= 0; backwardsIndex -= 1) {
+          const backwardsEvent = events[backwardsIndex];
+          if (event.timestamp - backwardsEvent.timestamp > bufferMs) {
+            continue;
+          }
+          if (
+            backwardsEvent.type !== EventType.Cast &&
+            backwardsEvent.type !== EventType.FreeCast
+          ) {
+            continue;
+          }
+          if (backwardsEvent.ability.guid !== bladestormId) {
+            continue;
+          }
+          fixedEvents.splice(idx, 1);
+          fixedEvents.push({
+            ...event,
+            type: EventType.FreeCast,
+            __modified: true,
+          });
+        }
+      }
+    });
+
+    return fixedEvents;
+  }
+}

--- a/src/analysis/retail/warrior/fury/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/fury/CHANGELOG.tsx
@@ -1,7 +1,10 @@
 import { change, date } from 'common/changelog';
 import { Listefano, CodersKitchen, ToppleTheNun, Ahri } from 'CONTRIBUTORS';
+import SpellLink from 'interface/SpellLink';
+import TALENTS from 'common/TALENTS/warrior';
 
 export default [
+  change(date(2023, 7, 23), <>Normalize extra casts from <SpellLink spell={TALENTS.BERSERKERS_TORMENT_TALENT}/>.</>, ToppleTheNun),
   change(date(2023, 7, 22), 'Update default Fury Warrior log.', Ahri),
   change(date(2023, 7, 8), 'Update SpellLink usage.', ToppleTheNun),
   change(date(2023, 6, 25), 'Reduce CD of Raging Blow, when Honed Reflexes is skilled.', CodersKitchen),

--- a/src/analysis/retail/warrior/fury/CombatLogParser.ts
+++ b/src/analysis/retail/warrior/fury/CombatLogParser.ts
@@ -16,13 +16,13 @@ import MissedRampage from './modules/spells/MissedRampage';
 import Recklessness from './modules/spells/Recklessness';
 import WhirlWind from './modules/spells/Whirlwind';
 import AngerManagement from './modules/talents/AngerManagement';
-//import ImpendingVicory from './modules/talents/ImpendingVictory';
 import MeatCleaver from './modules/talents/MeatCleaver';
 import RecklessAbandon from './modules/talents/RecklessAbandon';
 import SuddenDeath from './modules/talents/SuddenDeath';
 import Warpaint from './modules/talents/Warpaint';
 import SpellReflection from '../shared/modules/talents/SpellReflection';
 import ImpendingVictory from '../shared/modules/talents/ImpendingVictory';
+import BerserkersTormentNormalizer from './modules/talents/BerserkersTorment';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -39,6 +39,7 @@ class CombatLogParser extends CoreCombatLogParser {
     rageDetails: RageDetails,
 
     enrageNormalizer: EnrageNormalizer,
+    berserkersTormentNormalizer: BerserkersTormentNormalizer,
 
     enrageUptime: Enrage,
 
@@ -47,7 +48,6 @@ class CombatLogParser extends CoreCombatLogParser {
 
     //talents
     angerManagement: AngerManagement,
-    //impendingVictory: ImpendingVicory,
     meatCleaver: MeatCleaver,
     recklessAbandon: RecklessAbandon,
     suddenDeath: SuddenDeath,

--- a/src/analysis/retail/warrior/fury/modules/talents/BerserkersTorment.tsx
+++ b/src/analysis/retail/warrior/fury/modules/talents/BerserkersTorment.tsx
@@ -1,0 +1,84 @@
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+import { AnyEvent, EventType } from 'parser/core/Events';
+import TALENTS from 'common/TALENTS/warrior';
+import { Options } from 'parser/core/Module';
+
+export default class BerserkersTormentNormalizer extends EventsNormalizer {
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.BERSERKERS_TORMENT_TALENT);
+  }
+
+  normalize(events: AnyEvent[]): AnyEvent[] {
+    const fixedEvents: AnyEvent[] = [];
+
+    const recklessnessId = TALENTS.RECKLESSNESS_TALENT.id;
+    const avatarId = TALENTS.AVATAR_SHARED_TALENT.id;
+    const relevantIds = [recklessnessId, avatarId];
+    const bufferMs = 50;
+
+    events.forEach((event: AnyEvent, idx: number) => {
+      //We are only interested in Kill Command and Dire Beast casts
+      fixedEvents.push(event);
+      if (event.type !== EventType.Cast) {
+        return;
+      }
+      const spellId = event.ability.guid;
+      if (!relevantIds.includes(spellId)) {
+        return;
+      }
+
+      // if it's a Recklessness cast, we need to check before it to see if there was an Avatar cast
+      if (spellId === recklessnessId) {
+        for (let backwardsIndex = idx; backwardsIndex >= 0; backwardsIndex -= 1) {
+          const backwardsEvent = events[backwardsIndex];
+          if (event.timestamp - backwardsEvent.timestamp > bufferMs) {
+            continue;
+          }
+          if (
+            backwardsEvent.type !== EventType.Cast &&
+            backwardsEvent.type !== EventType.FreeCast
+          ) {
+            continue;
+          }
+          if (backwardsEvent.ability.guid !== avatarId) {
+            continue;
+          }
+          fixedEvents.splice(idx, 1);
+          fixedEvents.push({
+            ...event,
+            type: EventType.FreeCast,
+            __modified: true,
+          });
+        }
+      }
+
+      // if it's an Avatar cast, we need to check before it to see if there was a Recklessness cast
+      if (spellId === avatarId) {
+        for (let backwardsIndex = idx; backwardsIndex >= 0; backwardsIndex -= 1) {
+          const backwardsEvent = events[backwardsIndex];
+          if (event.timestamp - backwardsEvent.timestamp > bufferMs) {
+            continue;
+          }
+          if (
+            backwardsEvent.type !== EventType.Cast &&
+            backwardsEvent.type !== EventType.FreeCast
+          ) {
+            continue;
+          }
+          if (backwardsEvent.ability.guid !== recklessnessId) {
+            continue;
+          }
+          fixedEvents.splice(idx, 1);
+          fixedEvents.push({
+            ...event,
+            type: EventType.FreeCast,
+            __modified: true,
+          });
+        }
+      }
+    });
+
+    return fixedEvents;
+  }
+}

--- a/src/common/SPELLS/warrior.ts
+++ b/src/common/SPELLS/warrior.ts
@@ -376,6 +376,16 @@ const spells = {
     name: 'Raging Blow',
     icon: 'warrior_wild_strike',
   },
+  HACK_AND_SLASH: {
+    id: 383873,
+    name: 'Hack and Slash',
+    icon: 'ability_warrior_savageblow',
+  },
+  WRATH_AND_FURY: {
+    id: 392937,
+    name: 'Wrath and Fury',
+    icon: 'warrior_wild_strike',
+  },
   RAMPAGE: {
     id: 184367,
     name: 'Rampage',

--- a/src/interface/EventsTab.css
+++ b/src/interface/EventsTab.css
@@ -45,7 +45,8 @@
   color: orange;
 }
 .events-tab .cast,
-.events-tab .begincast {
+.events-tab .begincast,
+.events-tab .freecast {
   color: hotpink;
 }
 .events-tab .applybuff,

--- a/src/interface/EventsTab.js
+++ b/src/interface/EventsTab.js
@@ -44,6 +44,10 @@ const FILTERABLE_TYPES = {
     explanation:
       'Triggered whenever a cast was successful. Blizzard also sometimes uses this event type for mechanics and spell ticks or bolts.',
   },
+  freecast: {
+    name: 'Free Cast',
+    explanation: 'Casts that we have detected might have been cast "for free."',
+  },
   empowerstart: {
     name: 'Empower Start',
   },

--- a/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
+++ b/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
@@ -70,6 +70,15 @@ const spells: number[] = [
   SPELLS.RECLAMATION_CAST.id,
   //endregion
 
+  //region warrior
+  SPELLS.RAMPAGE_1.id,
+  SPELLS.RAMPAGE_2.id,
+  SPELLS.RAMPAGE_3.id,
+  SPELLS.RAMPAGE_4.id,
+  SPELLS.HACK_AND_SLASH.id,
+  SPELLS.WRATH_AND_FURY.id,
+  //endregion
+
   //region trinket
   //endregion
   //region Embellishments


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Berserker's Torment makes casting Avatar "cast" Recklessness and vice-versa; this makes it so that the "cast" is appropriately marked as a "free cast".
Blademaster's Torment does the same but for Arms.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/RBX8qMdLjQvgYz6y/69-Mythic+Magmorax+-+Kill+(5:08)/Metajunkie/standard/events`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/80858515-1d96-49a7-9419-11207cb05bb9)
