### PR TITLE
Add ancient flame module to Preservation Evoker guide

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import { ToppleTheNun, Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
-  change(date(2023, 7, 13), <>Add <SpellLink spell={TALENTS_EVOKER.ANCIENT_FLAME_TALENT}/> module and guide section</>, Trevor),
+  change(date(2023, 7, 23), <>Add <SpellLink spell={TALENTS_EVOKER.ANCIENT_FLAME_TALENT}/> module and guide section</>, Trevor),
   change(date(2023, 7, 13), <>Fix <SpellLink spell={TALENTS_EVOKER.REGENERATIVE_MAGIC_TALENT}/></>, Trevor),
   change(date(2023, 7, 11), <>Fix <SpellLink spell={TALENTS_EVOKER.FIELD_OF_DREAMS_TALENT}/></>, Trevor),
   change(date(2023, 7, 11), <>Fix <SpellLink spell={TALENTS_EVOKER.REGENERATIVE_MAGIC_TALENT}/></>, Trevor),

--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { ToppleTheNun, Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 7, 13), <>Add <SpellLink spell={TALENTS_EVOKER.ANCIENT_FLAME_TALENT}/> module and guide section</>, Trevor),
   change(date(2023, 7, 13), <>Fix <SpellLink spell={TALENTS_EVOKER.REGENERATIVE_MAGIC_TALENT}/></>, Trevor),
   change(date(2023, 7, 11), <>Fix <SpellLink spell={TALENTS_EVOKER.FIELD_OF_DREAMS_TALENT}/></>, Trevor),
   change(date(2023, 7, 11), <>Fix <SpellLink spell={TALENTS_EVOKER.REGENERATIVE_MAGIC_TALENT}/></>, Trevor),

--- a/src/analysis/retail/evoker/preservation/CONFIG.tsx
+++ b/src/analysis/retail/evoker/preservation/CONFIG.tsx
@@ -1,4 +1,4 @@
-import { Trevor, Vohrr } from 'CONTRIBUTORS';
+import { Trevor } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import Config from 'parser/Config';
@@ -7,7 +7,7 @@ import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Trevor, Vohrr],
+  contributors: [Trevor],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
   patchCompatibility: '10.1.5',

--- a/src/analysis/retail/evoker/preservation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/preservation/CombatLogParser.ts
@@ -45,6 +45,7 @@ import Guide from 'analysis/retail/evoker/preservation/Guide';
 import NozTeachings from './modules/talents/NozTeachings';
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
 import RegenerativeMagic from '../shared/modules/talents/RegenerativeMagic';
+import AncientFlame from './modules/talents/AncientFlame';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -75,6 +76,7 @@ class CombatLogParser extends CoreCombatLogParser {
     hotAttributor: HotAttributor,
 
     //talents
+    ancientFlame: AncientFlame,
     echo: Echo,
     echoBreakdown: EchoBreakdown,
     dreamBreath: DreamBreath,

--- a/src/analysis/retail/evoker/preservation/Guide.tsx
+++ b/src/analysis/retail/evoker/preservation/Guide.tsx
@@ -19,7 +19,8 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
   const isEbBuild = info.combatant.hasTalent(TALENTS_EVOKER.FIELD_OF_DREAMS_TALENT);
   const includeTalentSection =
     info.combatant.hasTalent(TALENTS_EVOKER.OUROBOROS_TALENT) ||
-    info.combatant.hasTalent(TALENTS_EVOKER.STASIS_TALENT);
+    info.combatant.hasTalent(TALENTS_EVOKER.STASIS_TALENT) ||
+    isEbBuild;
   return (
     <>
       <Section title="Core Spells and Buffs">
@@ -42,6 +43,9 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
           {info.combatant.hasTalent(TALENTS_EVOKER.OUROBOROS_TALENT) &&
             modules.ouroboros.guideSubsection}
           {info.combatant.hasTalent(TALENTS_EVOKER.STASIS_TALENT) && modules.stasis.guideSubsection}
+          {isEbBuild &&
+            info.combatant.hasTalent(TALENTS_EVOKER.ANCIENT_FLAME_TALENT) &&
+            modules.ancientFlame.guideSubsection}
         </Section>
       )}
       <PreparationSection />

--- a/src/analysis/retail/evoker/preservation/modules/features/Abilities.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/features/Abilities.tsx
@@ -30,7 +30,7 @@ class Abilities extends CoreAbilities {
         category: SPELL_CATEGORY.ROTATIONAL_AOE,
         cooldown: 30,
         gcd: {
-          base: 1500,
+          base: 500,
         },
         castEfficiency: {
           suggestion: true,
@@ -61,7 +61,7 @@ class Abilities extends CoreAbilities {
         category: SPELL_CATEGORY.ROTATIONAL_AOE,
         cooldown: combatant.hasTalent(TALENTS.SPIRITUAL_CLARITY_TALENT) ? 20 : 30,
         gcd: {
-          base: 1500,
+          base: 500,
         },
         enabled: combatant.hasTalent(TALENTS.SPIRITBLOOM_TALENT),
         castEfficiency: {

--- a/src/analysis/retail/evoker/preservation/modules/talents/AncientFlame.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/AncientFlame.tsx
@@ -94,7 +94,7 @@ class AncientFlame extends Analyzer {
         important to weave in casts of <SpellLink spell={SPELLS.LIVING_FLAME_CAST} /> between casts
         of <SpellLink spell={SPELLS.EMERALD_BLOSSOM} /> in order to generate{' '}
         <SpellLink spell={TALENTS_EVOKER.ESSENCE_BURST_PRESERVATION_TALENT} />. Not utilizing this
-        talent will lead to both an HPS and DPS loss, while also making the build more mana starved
+        talent will lead to both an HPS and DPS loss, while also making the build more mana-starved
         than it should be.
       </p>
     );

--- a/src/analysis/retail/evoker/preservation/modules/talents/AncientFlame.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/AncientFlame.tsx
@@ -1,0 +1,143 @@
+import { formatDuration } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import { TALENTS_EVOKER } from 'common/TALENTS';
+import { SpellLink } from 'interface';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { ApplyBuffEvent, RefreshBuffEvent, RemoveBuffEvent } from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import { reduce } from 'vega-lite/build/src/encoding';
+import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+
+class AncientFlame extends Analyzer {
+  consumptions: BoxRowEntry[] = [];
+  lastApply: ApplyBuffEvent | null = null;
+  consumeTimes: number[] = [];
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_EVOKER.ANCIENT_FLAME_TALENT);
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.ANCIENT_FLAME_BUFF),
+      this.onRefresh,
+    );
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.ANCIENT_FLAME_BUFF),
+      this.onApply,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.ANCIENT_FLAME_BUFF),
+      this.onConsume,
+    );
+  }
+
+  onApply(event: ApplyBuffEvent) {
+    this.lastApply = event;
+  }
+
+  get applyTime() {
+    return this.lastApply?.timestamp || this.owner.fight.start_time;
+  }
+
+  onRefresh(event: RefreshBuffEvent) {
+    const tooltip = (
+      <>
+        <div>
+          <SpellLink spell={TALENTS_EVOKER.ANCIENT_FLAME_TALENT} /> applied @{' '}
+          {this.owner.formatTimestamp(this.applyTime)}
+        </div>
+        <div>
+          You wasted this buff by casting another <SpellLink spell={SPELLS.EMERALD_BLOSSOM} /> or{' '}
+          <SpellLink spell={TALENTS_EVOKER.VERDANT_EMBRACE_TALENT} /> @{' '}
+          {this.owner.formatTimestamp(event.timestamp)} before casting{' '}
+          <SpellLink spell={SPELLS.LIVING_FLAME_CAST} />
+        </div>
+      </>
+    );
+    const value = QualitativePerformance.Fail;
+    this.consumptions.push({ value, tooltip });
+  }
+
+  onConsume(event: RemoveBuffEvent) {
+    const tooltip = (
+      <>
+        <div>
+          <SpellLink spell={TALENTS_EVOKER.ANCIENT_FLAME_TALENT} /> applied @{' '}
+          {this.owner.formatTimestamp(this.applyTime)}
+        </div>
+        <div>Consumed @ {this.owner.formatTimestamp(event.timestamp)}</div>
+      </>
+    );
+    const value = QualitativePerformance.Good;
+    this.consumptions.push({ value, tooltip });
+    this.consumeTimes.push(event.timestamp - this.applyTime);
+  }
+
+  get averageTimeToConsume() {
+    return formatDuration(
+      reduce(this.consumeTimes, (prev, cur) => prev + cur, 0) / this.consumeTimes.length,
+    );
+  }
+
+  get guideSubsection(): JSX.Element {
+    const styleObj = {
+      fontSize: 20,
+    };
+    const styleObjInner = {
+      fontSize: 15,
+    };
+    const explanation = (
+      <p>
+        When playing an <SpellLink spell={SPELLS.EMERALD_BLOSSOM} /> focused build, it is extremely
+        important to weave in casts of <SpellLink spell={SPELLS.LIVING_FLAME_CAST} /> between casts
+        of <SpellLink spell={SPELLS.EMERALD_BLOSSOM} /> in order to generate{' '}
+        <SpellLink spell={TALENTS_EVOKER.ESSENCE_BURST_PRESERVATION_TALENT} />. Not utilizing this
+        talent will lead to both an HPS and DPS loss, while also making the build more mana starved
+        than it should be.
+      </p>
+    );
+    const data = (
+      <div>
+        <RoundedPanel>
+          <div>
+            <strong>
+              <SpellLink spell={TALENTS_EVOKER.ANCIENT_FLAME_TALENT} /> consumptions
+            </strong>{' '}
+            <small>
+              {' '}
+              - Green indicates a buff that was consumed, while red indicates a buff that was wasted
+              by refreshing.
+            </small>
+            <PerformanceBoxRow values={this.consumptions} />
+          </div>
+          <div style={styleObj}>
+            <small style={styleObjInner}>
+              <SpellLink spell={TALENTS_EVOKER.ANCIENT_FLAME_TALENT} /> -{' '}
+            </small>
+            <strong>{this.averageTimeToConsume}s</strong> <small>avg time to consume buff</small>
+          </div>
+        </RoundedPanel>
+      </div>
+    );
+
+    return explanationAndDataSubsection(explanation, data, GUIDE_CORE_EXPLANATION_PERCENT);
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(5)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={<ul></ul>}
+      ></Statistic>
+    );
+  }
+}
+
+export default AncientFlame;

--- a/src/analysis/retail/evoker/preservation/modules/talents/AncientFlame.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/AncientFlame.tsx
@@ -114,7 +114,9 @@ class AncientFlame extends Analyzer {
         of <SpellLink spell={SPELLS.EMERALD_BLOSSOM} /> in order to generate{' '}
         <SpellLink spell={TALENTS_EVOKER.ESSENCE_BURST_PRESERVATION_TALENT} />. Not utilizing this
         talent will lead to both an HPS and DPS loss, while also making the build more mana-starved
-        than it should be.
+        than it should be. It is okay to cast multiple <SpellLink spell={SPELLS.EMERALD_BLOSSOM} />s
+        in a row and waste the buff at times, but this should not be consistent occurrence
+        throughout a fight.
       </p>
     );
     const data = (

--- a/src/analysis/retail/evoker/preservation/modules/talents/AncientFlame.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/AncientFlame.tsx
@@ -42,21 +42,40 @@ class AncientFlame extends Analyzer {
   }
 
   onRefresh(event: RefreshBuffEvent) {
-    const tooltip = (
-      <>
-        <div>
-          <SpellLink spell={TALENTS_EVOKER.ANCIENT_FLAME_TALENT} /> applied @{' '}
-          {this.owner.formatTimestamp(this.applyTime)}
-        </div>
-        <div>
-          You wasted this buff by casting another <SpellLink spell={SPELLS.EMERALD_BLOSSOM} /> or{' '}
-          <SpellLink spell={TALENTS_EVOKER.VERDANT_EMBRACE_TALENT} /> @{' '}
-          {this.owner.formatTimestamp(event.timestamp)} before casting{' '}
-          <SpellLink spell={SPELLS.LIVING_FLAME_CAST} />
-        </div>
-      </>
-    );
-    const value = QualitativePerformance.Fail;
+    let tooltip = null;
+    let value = QualitativePerformance.Good;
+    // 1 stack after cast = they were at 2 so not a waste
+    if (this.selectedCombatant.getBuffStacks(SPELLS.ESSENCE_BURST_BUFF.id) === 1) {
+      tooltip = (
+        <>
+          <div>
+            <SpellLink spell={TALENTS_EVOKER.ANCIENT_FLAME_TALENT} /> applied @{' '}
+            {this.owner.formatTimestamp(this.applyTime)}
+          </div>
+          <div>
+            You refreshed this buff but you were capped on{' '}
+            <SpellLink spell={TALENTS_EVOKER.ESSENCE_BURST_PRESERVATION_TALENT} /> stacks, which
+            makes this refresh not a misplay.
+          </div>
+        </>
+      );
+    } else {
+      tooltip = (
+        <>
+          <div>
+            <SpellLink spell={TALENTS_EVOKER.ANCIENT_FLAME_TALENT} /> applied @{' '}
+            {this.owner.formatTimestamp(this.applyTime)}
+          </div>
+          <div>
+            You wasted this buff by casting another <SpellLink spell={SPELLS.EMERALD_BLOSSOM} /> or{' '}
+            <SpellLink spell={TALENTS_EVOKER.VERDANT_EMBRACE_TALENT} /> @{' '}
+            {this.owner.formatTimestamp(event.timestamp)} before casting{' '}
+            <SpellLink spell={SPELLS.LIVING_FLAME_CAST} />
+          </div>
+        </>
+      );
+      value = QualitativePerformance.Fail;
+    }
     this.consumptions.push({ value, tooltip });
   }
 

--- a/src/analysis/retail/evoker/preservation/modules/talents/AncientFlame.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/AncientFlame.tsx
@@ -4,9 +4,6 @@ import { TALENTS_EVOKER } from 'common/TALENTS';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { ApplyBuffEvent, RefreshBuffEvent, RemoveBuffEvent } from 'parser/core/Events';
-import Statistic from 'parser/ui/Statistic';
-import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
-import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
@@ -126,17 +123,6 @@ class AncientFlame extends Analyzer {
     );
 
     return explanationAndDataSubsection(explanation, data, GUIDE_CORE_EXPLANATION_PERCENT);
-  }
-
-  statistic() {
-    return (
-      <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(5)}
-        size="flexible"
-        category={STATISTIC_CATEGORY.TALENTS}
-        tooltip={<ul></ul>}
-      ></Statistic>
-    );
   }
 }
 

--- a/src/analysis/retail/evoker/shared/modules/Abilities.tsx
+++ b/src/analysis/retail/evoker/shared/modules/Abilities.tsx
@@ -52,7 +52,7 @@ class Abilities extends CoreAbilities {
             : SPELL_CATEGORY.ROTATIONAL,
         cooldown: 30 * intervowenThreadsMultiplier,
         gcd: {
-          base: 1500,
+          base: 500,
         },
         ...(combatant.spec === (SPECS.DEVASTATION_EVOKER || SPECS.AUGMENTATION_EVOKER) && {
           castEfficiency: {
@@ -62,7 +62,7 @@ class Abilities extends CoreAbilities {
         }),
       },
       {
-        spell: [SPELLS.LIVING_FLAME_CAST.id, SPELLS.LIVING_FLAME_HEAL.id],
+        spell: SPELLS.LIVING_FLAME_CAST.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: {
           base: 1500,
@@ -81,7 +81,7 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: [TALENTS.VERDANT_EMBRACE_TALENT.id, SPELLS.VERDANT_EMBRACE_HEAL.id],
+        spell: TALENTS.VERDANT_EMBRACE_TALENT.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         cooldown: 24 * intervowenThreadsMultiplier,
         enabled: combatant.hasTalent(TALENTS.VERDANT_EMBRACE_TALENT),

--- a/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
+++ b/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
@@ -38,6 +38,10 @@ const spells: number[] = [
   SPELLS.ABOMINATION_LIMB_GRIP_TICK.id,
   //endregion
 
+  //region Evoker
+  SPELLS.VERDANT_EMBRACE_HEAL.id,
+  //endregion
+
   //region Hunter
   SPELLS.BARBED_SHOT_PET_BUFF.id, //The buff applied to BM Hunter pet when casting Barbed Shot
   SPELLS.DIRE_BEAST_SUMMON.id, //Additional cast event associated with summoning a Dire Beast


### PR DESCRIPTION
### Description

Adds module/guide section for ancient flame when spec'd into eb talents since its very useful for dps and generating eb procs. Also fixes the gcd configurations for empowered abilities (they have a .5 gcd) and fixes gcd error with living flame.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `report/f2MTV1hH3zZjWk47/28-Mythic+Rashok,+the+Elder+-+Kill+(5:47)/Widdeldwagon/standard/overview`
- Screenshot(s):

![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/d87f18a2-1e5a-4c2d-9748-2e5faf1375b7)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/9c92d0f5-9423-4563-993e-bbe1d4773d50)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/5ff5a503-9aac-45d8-b8d5-23ec2fef948d)

