### PR TITLE
fix crash w/ lingui in suggestions

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -26,6 +26,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 7, 25), 'Fix crash when using certain i18n functions.', ToppleTheNun),
   change(date(2023, 7, 22), 'Update i18n library version.', [ToppleTheNun, emallson]),
   change(date(2023, 7, 22), 'Update Classic Enchants', jazminite),
   change(date(2023, 7, 21), 'Add scrollability to Buff count graphs', Vollmer),

--- a/src/parser/core/ParseResults.tsx
+++ b/src/parser/core/ParseResults.tsx
@@ -34,7 +34,7 @@ abstract class SuggestionAssertion<T extends number | boolean> {
   addSuggestion(func: (suggest: SuggestionFactory, actual: T, recommended: T) => Suggestion) {
     if (this._isApplicable()) {
       const suggestion = func(
-        (suggestionText: React.ReactNode) => new Suggestion(suggestionText),
+        (suggestionText: React.ReactNode | MessageDescriptor) => new Suggestion(suggestionText),
         this._actual,
         this._triggerThreshold,
       );
@@ -225,7 +225,7 @@ export class BoolSuggestionAssertion extends SuggestionAssertion<boolean> {
   }
 }
 
-export type SuggestionFactory = (suggest: React.ReactNode) => Suggestion;
+export type SuggestionFactory = (suggest: React.ReactNode | MessageDescriptor) => Suggestion;
 
 class Suggestion {
   _text: React.ReactNode;
@@ -238,9 +238,10 @@ class Suggestion {
   _staticImportance: ISSUE_IMPORTANCE | null = null;
   _details: (() => React.ReactNode) | null = null;
 
-  constructor(text: React.ReactNode) {
-    this._text = text;
+  constructor(text: React.ReactNode | MessageDescriptor) {
+    this._text = isMessageDescriptor(text) ? i18n._(text) : text;
   }
+
   icon(icon: string) {
     this._icon = icon;
     return this;


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Allow usage of `defineMessage` in the root of a suggestion tree.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/2MKJqXGvdPk9rwCy/9-Mythic+Magmorax+-+Kill+(5:43)/Guidoeskawai/standard/overview`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/13a8f820-9999-4c76-b940-19637b88318e)
