### PR TITLE
[elemental] Add a section on the spender window

### DIFF
--- a/src/analysis/retail/shaman/elemental/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/elemental/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { HawkCorrigan, Putro, Zeboot, Maximaw, Zea, emallson, Vetyst, Periodic, 
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 8, 6), <>Add a section on proper use of single target spenders.</>, Awildfivreld),
   change(date(2023, 7, 26), <>Adds Flame Shock Guide section</>, Periodic),
   change(date(2023, 7, 16), <>Add a section on usage of Stormkeeper</>, Awildfivreld),
   change(date(2023, 7, 13), <>Fix a bug where the timeline showed too many abilities as empowered by <SpellLink spell={TALENTS.SURGE_OF_POWER_TALENT} /></>, Awildfivreld),

--- a/src/analysis/retail/shaman/elemental/CombatLogParser.tsx
+++ b/src/analysis/retail/shaman/elemental/CombatLogParser.tsx
@@ -35,6 +35,7 @@ import CallToDominance from 'parser/retail/modules/items/dragonflight/CallToDomi
 import ManaSpring from 'analysis/retail/shaman/shared/talents/ManaSpring';
 import ElementalGuide from './guide/ElementalGuide';
 import SpellMaelstromCost from './modules/core/SpellMaelstromCost';
+import SpenderWindow from './modules/features/SpenderWindow';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -46,6 +47,7 @@ class CombatLogParser extends CoreCombatLogParser {
     cancelledCasts: CancelledCasts,
     alwaysBeCasting: AlwaysBeCasting,
     subOptimalChainLightning: SubOptimalChainLightning,
+    spenderWindow: SpenderWindow,
 
     // Talents
     aftershock: Aftershock,

--- a/src/analysis/retail/shaman/elemental/guide/ElementalGuide.tsx
+++ b/src/analysis/retail/shaman/elemental/guide/ElementalGuide.tsx
@@ -51,10 +51,9 @@ const CoreSection = (props: GuideProps<typeof CombatLogParser>) => {
     <Section title="Core Abilities">
       {info.combatant.hasTalent(TALENTS_SHAMAN.STORMKEEPER_1_ELEMENTAL_TALENT) &&
         modules.stormkeeper.guideSubsection()}
+      {modules.spenderWindow.enabled && modules.spenderWindow.guideSubsection()}
       {info.combatant.hasTalent(TALENTS_SHAMAN.MASTER_OF_THE_ELEMENTS_TALENT) &&
         modules.masterOfTheElements.guideSubsection()}
-      {info.combatant.hasTalent(TALENTS_SHAMAN.SURGE_OF_POWER_TALENT) &&
-        modules.surgeOfPower.guideSubsection()}
       <FlameShockSubSection {...props} />
     </Section>
   );

--- a/src/analysis/retail/shaman/elemental/guide/ElementalGuide.tsx
+++ b/src/analysis/retail/shaman/elemental/guide/ElementalGuide.tsx
@@ -51,7 +51,7 @@ const CoreSection = (props: GuideProps<typeof CombatLogParser>) => {
     <Section title="Core Abilities">
       {info.combatant.hasTalent(TALENTS_SHAMAN.STORMKEEPER_1_ELEMENTAL_TALENT) &&
         modules.stormkeeper.guideSubsection()}
-      {modules.spenderWindow.enabled && modules.spenderWindow.guideSubsection()}
+      {modules.spenderWindow.active && modules.spenderWindow.guideSubsection()}
       {info.combatant.hasTalent(TALENTS_SHAMAN.MASTER_OF_THE_ELEMENTS_TALENT) &&
         modules.masterOfTheElements.guideSubsection()}
       <FlameShockSubSection {...props} />

--- a/src/analysis/retail/shaman/elemental/modules/features/SpenderWindow.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/features/SpenderWindow.tsx
@@ -101,6 +101,9 @@ class SpenderWindow extends Analyzer {
     }
   }
 
+  /**
+   * Start a new spender window if one is not already active.
+   */
   onMSSpender(event: CastEvent) {
     if (this.activeSpenderWindow) {
       return;
@@ -118,6 +121,9 @@ class SpenderWindow extends Analyzer {
     };
   }
 
+  /**
+   * End a spender window if there is an active one.
+   */
   onSopConsumer(event: CastEvent) {
     if (
       !this.activeSpenderWindow ||
@@ -143,6 +149,14 @@ class SpenderWindow extends Analyzer {
     this.activeSpenderWindow = null;
   }
 
+  /**
+   * Create a single row for the spender window section.
+   * @param subWindow The windows that applies for this row.
+   * @param header The text preceeding the performance mark
+   * @param performanceThresholds Which thresholds to use to calculate performance
+   * @param windowTimestampCallable The fucntion to render the timestamps list for the window. Defaults to show '@ 0:01, 0:34' etc.
+   * @returns
+   */
   private spenderWindowsRow(
     subWindow: FinishedSpenderWindow[],
     header: JSX.Element,

--- a/src/analysis/retail/shaman/elemental/modules/features/SpenderWindow.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/features/SpenderWindow.tsx
@@ -1,0 +1,295 @@
+import ThresholdPerformancePercentage, {
+  LTEThreshold,
+  GTEThreshold,
+} from './shared/ThresholdPerformancePercentage';
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/shaman';
+import { Talent } from 'common/TALENTS/types';
+import { formatDuration } from 'common/format';
+import { SpellIcon, SpellLink, TooltipElement } from 'interface';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent } from 'parser/core/Events';
+import Enemies from 'parser/shared/modules/Enemies';
+import { ON_CAST_BUFF_REMOVAL_GRACE_MS } from '../../constants';
+
+interface ActiveSpenderWindow {
+  timestamp: number;
+  motePresent: boolean;
+  flameshockPresent: boolean;
+}
+
+interface FinishedSpenderWindow extends ActiveSpenderWindow {
+  elshocksPresent: boolean;
+  sopUse: CastEvent;
+}
+
+const SOP_SPENDERS = [
+  SPELLS.LIGHTNING_BOLT,
+  TALENTS.CHAIN_LIGHTNING_TALENT,
+  SPELLS.FLAME_SHOCK,
+  TALENTS.FROST_SHOCK_TALENT,
+  TALENTS.LAVA_BURST_TALENT,
+];
+
+const GOOD_SOP_SPENDERS = [SPELLS.LIGHTNING_BOLT.id, TALENTS.CHAIN_LIGHTNING_TALENT.id];
+
+const PERFECT_WINDOWS_THRESHOLD: GTEThreshold = {
+  type: 'gte',
+  perfect: 0.9,
+  good: 0.8,
+  ok: 0.7,
+};
+const WRONG_SOP_THRESHOLD: LTEThreshold = {
+  type: 'lte',
+  perfect: 0,
+  good: 0.1,
+  ok: 0.15,
+};
+const MISSING_ELSHOCKS_THRESHOLD: LTEThreshold = {
+  type: 'lte',
+  perfect: 0,
+  good: 0.2,
+  ok: 0.3,
+};
+const MISSING_MOTE_THRESHOLD: LTEThreshold = {
+  type: 'lte',
+  perfect: 0,
+  good: 0.2,
+  ok: 0.3,
+};
+const MISSING_FLAMESHOCK_THRESHOLD: LTEThreshold = {
+  type: 'lte',
+  perfect: 0,
+  good: 0.2,
+  ok: 0.3,
+};
+
+class SpenderWindow extends Analyzer {
+  static dependencies = {
+    enemies: Enemies,
+  };
+
+  enabled: boolean;
+
+  protected enemies!: Enemies;
+
+  activeSpenderWindow: ActiveSpenderWindow | null;
+  spenderWindows: FinishedSpenderWindow[];
+
+  private stSpender: Talent = TALENTS.EARTH_SHOCK_TALENT;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.activeSpenderWindow = null;
+    this.spenderWindows = [];
+
+    if (this.selectedCombatant.hasTalent(TALENTS.ELEMENTAL_BLAST_TALENT)) {
+      this.stSpender = TALENTS.ELEMENTAL_BLAST_TALENT;
+    }
+
+    this.enabled = this.selectedCombatant.hasTalent(TALENTS.SURGE_OF_POWER_TALENT);
+
+    /* There is no point in tracking this at all if the player doesn't have SoP */
+    if (!this.enabled) {
+      return;
+    }
+
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(this.stSpender), this.onSpender);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SOP_SPENDERS), this.onSopSpender);
+  }
+
+  onSpender(event: CastEvent) {
+    if (this.activeSpenderWindow) {
+      return;
+    }
+
+    this.activeSpenderWindow = {
+      timestamp: event.timestamp,
+      motePresent: this.selectedCombatant.hasBuff(
+        SPELLS.MASTER_OF_THE_ELEMENTS_BUFF.id,
+        null,
+        ON_CAST_BUFF_REMOVAL_GRACE_MS,
+      ),
+      flameshockPresent:
+        this.enemies.getEntity(event)?.hasBuff(SPELLS.FLAME_SHOCK.id, event.timestamp) || false,
+    };
+  }
+
+  onSopSpender(event: CastEvent) {
+    if (!this.activeSpenderWindow) {
+      return;
+    }
+    if (
+      !this.selectedCombatant.hasBuff(
+        SPELLS.SURGE_OF_POWER_BUFF.id,
+        null,
+        ON_CAST_BUFF_REMOVAL_GRACE_MS,
+      )
+    ) {
+      return;
+    }
+
+    const elshocksPresent =
+      this.enemies
+        .getEntity(event)
+        ?.hasBuff(SPELLS.ELECTRIFIED_SHOCKS_DEBUFF.id, event.timestamp) || false;
+
+    this.spenderWindows.push({
+      ...this.activeSpenderWindow,
+      elshocksPresent,
+      sopUse: event,
+    });
+    this.activeSpenderWindow = null;
+  }
+
+  private spenderWindowsRow(
+    subWindow: FinishedSpenderWindow[],
+    header: JSX.Element,
+    performanceThresholds: LTEThreshold | GTEThreshold,
+    windowTimestampCallable: (windows: FinishedSpenderWindow[]) => JSX.Element[] = (windows) =>
+      windows.map((w) => <>{formatDuration(w.timestamp - this.owner.fight.start_time)}, </>),
+  ) {
+    return (
+      <p style={{ padding: 0, margin: 0 }}>
+        {header}
+        <ThresholdPerformancePercentage
+          threshold={performanceThresholds}
+          percentage={subWindow.length / this.spenderWindows.length}
+          flatAmount={subWindow.length}
+        />{' '}
+        <TooltipElement content={<>@ {windowTimestampCallable(subWindow)}</>}>@</TooltipElement>
+      </p>
+    );
+  }
+
+  guideSubsection() {
+    const explanation = (
+      <>
+        <p>
+          In single target, when you intend to cast <SpellLink spell={this.stSpender} />
+          , you should perform the following cast sequence (sometimes called the "Spender window"):
+          <br />
+          <small>For more information, see the written guides</small>
+        </p>
+        <p>
+          (<SpellIcon spell={SPELLS.FLAME_SHOCK} />
+          <SpellIcon spell={TALENTS.ELECTRIFIED_SHOCKS_TALENT} /> &rarr;)
+          <SpellIcon spell={TALENTS.LAVA_BURST_TALENT} /> &rarr;
+          <SpellIcon spell={this.stSpender} /> &rarr;
+          <SpellIcon spell={SPELLS.LIGHTNING_BOLT} />
+        </p>
+        <p>
+          <small>
+            Note: This subsection does not exclude data from &gt; 1 targets automatically. You have
+            to account for this yourself if relevant.
+          </small>
+        </p>
+      </>
+    );
+
+    const hasMote = this.selectedCombatant.hasTalent(TALENTS.MASTER_OF_THE_ELEMENTS_TALENT);
+    const hasElshocks = this.selectedCombatant.hasTalent(TALENTS.ELECTRIFIED_SHOCKS_TALENT);
+
+    type WindowBreakdown = {
+      perfect: FinishedSpenderWindow[];
+      wrongSop: FinishedSpenderWindow[];
+      missingElshocks: FinishedSpenderWindow[];
+      missingMote: FinishedSpenderWindow[];
+      missingFlameshock: FinishedSpenderWindow[];
+    };
+
+    const windowBreakdown: WindowBreakdown = {
+      perfect: [],
+      wrongSop: [],
+      missingElshocks: [],
+      missingMote: [],
+      missingFlameshock: [],
+    };
+
+    this.spenderWindows.forEach((w) => {
+      let perfect = true;
+      if (!GOOD_SOP_SPENDERS.includes(w.sopUse?.ability.guid || 0)) {
+        windowBreakdown.wrongSop.push(w);
+        perfect = false;
+      }
+
+      if (hasElshocks && !w.elshocksPresent) {
+        windowBreakdown.missingElshocks.push(w);
+        perfect = false;
+      }
+
+      if (hasMote && !w.motePresent) {
+        windowBreakdown.missingMote.push(w);
+        perfect = false;
+      }
+
+      if (!w.flameshockPresent) {
+        windowBreakdown.missingFlameshock.push(w);
+        perfect = false;
+      }
+
+      if (perfect) {
+        windowBreakdown.perfect.push(w);
+      }
+    });
+    const data = (
+      <div>
+        <p>
+          {this.spenderWindowsRow(
+            windowBreakdown.perfect,
+            <>Perfect spender windows: </>,
+            PERFECT_WINDOWS_THRESHOLD,
+          )}
+        </p>
+        <p style={{ paddingBottom: 0, marginBottom: 0 }}>
+          <strong>Imperfect window breakdown</strong>
+          <small>- Note: One window might be included multiple times. </small>
+        </p>
+        {this.spenderWindowsRow(
+          windowBreakdown.wrongSop,
+          <>
+            <SpellLink spell={TALENTS.SURGE_OF_POWER_TALENT} /> used on inefficient spell:{' '}
+          </>,
+          WRONG_SOP_THRESHOLD,
+          (windows) =>
+            windows.map((w) => (
+              <>
+                {formatDuration(w.sopUse.timestamp - this.owner.fight.start_time)}
+                <SpellIcon spell={w.sopUse.ability.guid} />,
+              </>
+            )),
+        )}
+        {hasElshocks &&
+          this.spenderWindowsRow(
+            windowBreakdown.missingElshocks,
+            <>
+              <SpellLink spell={TALENTS.ELECTRIFIED_SHOCKS_TALENT} /> missing:{' '}
+            </>,
+            MISSING_ELSHOCKS_THRESHOLD,
+          )}
+        {hasMote &&
+          this.spenderWindowsRow(
+            windowBreakdown.missingMote,
+            <>
+              <SpellLink spell={this.stSpender} /> cast without{' '}
+              <SpellLink spell={TALENTS.MASTER_OF_THE_ELEMENTS_TALENT} />:{' '}
+            </>,
+            MISSING_MOTE_THRESHOLD,
+          )}
+        {this.spenderWindowsRow(
+          windowBreakdown.missingFlameshock,
+          <>
+            <SpellLink spell={SPELLS.FLAME_SHOCK} /> missing:{' '}
+          </>,
+          MISSING_FLAMESHOCK_THRESHOLD,
+        )}
+      </div>
+    );
+
+    return explanationAndDataSubsection(explanation, data);
+  }
+}
+
+export default SpenderWindow;

--- a/src/analysis/retail/shaman/elemental/modules/features/SpenderWindow.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/features/SpenderWindow.tsx
@@ -70,7 +70,7 @@ class SpenderWindow extends Analyzer {
     enemies: Enemies,
   };
 
-  enabled: boolean;
+  active: boolean;
 
   protected enemies!: Enemies;
 
@@ -86,19 +86,17 @@ class SpenderWindow extends Analyzer {
       this.stMSSpender = TALENTS.ELEMENTAL_BLAST_TALENT;
     }
 
-    this.enabled = this.selectedCombatant.hasTalent(TALENTS.SURGE_OF_POWER_TALENT);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.SURGE_OF_POWER_TALENT);
 
     /* There is no point in tracking this at all if the player doesn't have SoP */
-    if (!this.enabled) {
-      this.addEventListener(
-        Events.cast.by(SELECTED_PLAYER).spell(this.stMSSpender),
-        this.onMSSpender,
-      );
-      this.addEventListener(
-        Events.cast.by(SELECTED_PLAYER).spell(SOP_CONSUME_SPELLS),
-        this.onSopConsumer,
-      );
-    }
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(this.stMSSpender),
+      this.onMSSpender,
+    );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SOP_CONSUME_SPELLS),
+      this.onSopConsumer,
+    );
   }
 
   /**

--- a/src/analysis/retail/shaman/elemental/modules/features/SpenderWindow.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/features/SpenderWindow.tsx
@@ -70,8 +70,6 @@ class SpenderWindow extends Analyzer {
     enemies: Enemies,
   };
 
-  active: boolean;
-
   protected enemies!: Enemies;
 
   activeSpenderWindow: ActiveSpenderWindow | null = null;

--- a/src/analysis/retail/shaman/elemental/modules/features/shared/ThresholdPerformancePercentage.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/features/shared/ThresholdPerformancePercentage.tsx
@@ -1,0 +1,76 @@
+import { PerformanceMark } from 'interface/guide';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import { formatNumber, formatPercentage } from 'common/format';
+import PerformanceStrongWithTooltip from 'interface/PerformanceStrongWithTooltip';
+
+export interface LTEThreshold {
+  type: 'lte';
+  perfect: number;
+  good: number;
+  ok: number;
+}
+
+export interface GTEThreshold {
+  type: 'gte';
+  perfect: number;
+  good: number;
+  ok: number;
+}
+
+interface Props {
+  threshold: LTEThreshold | GTEThreshold;
+  percentage: number;
+  flatAmount: number;
+}
+/**
+ * Element that shows a performance percentage with a tooltip.
+ *
+ * The performance is computed based on the given threshold.
+ */
+const ThresoldPerformancePercentage = ({ threshold, percentage, flatAmount }: Props) => {
+  let signJsx;
+  if (threshold.type === 'lte') {
+    signJsx = <>&lt;</>;
+  } else {
+    signJsx = <>&gt;</>;
+  }
+
+  const ops = {
+    lte: (a: number, b: number) => a <= b,
+    gte: (a: number, b: number) => a >= b,
+  };
+
+  let performance;
+  if (ops[threshold.type](percentage, threshold.perfect)) {
+    performance = QualitativePerformance.Perfect;
+  } else if (ops[threshold.type](percentage, threshold.good)) {
+    performance = QualitativePerformance.Good;
+  } else if (ops[threshold.type](percentage, threshold.ok)) {
+    performance = QualitativePerformance.Ok;
+  } else {
+    performance = QualitativePerformance.Fail;
+  }
+
+  const perfectSign = threshold.perfect > 0 ? <>{signJsx}=</> : <>=</>;
+  return (
+    <PerformanceStrongWithTooltip
+      performance={performance}
+      tooltip={
+        <>
+          <PerformanceMark perf={QualitativePerformance.Perfect} /> Perfect usage {perfectSign}{' '}
+          {formatPercentage(threshold.perfect, 0)}%
+          <br />
+          <PerformanceMark perf={QualitativePerformance.Good} /> Good usage {signJsx}={' '}
+          {formatPercentage(threshold.good, 0)}%
+          <br />
+          <PerformanceMark perf={QualitativePerformance.Ok} /> OK usage {signJsx}={' '}
+          {formatPercentage(threshold.ok, 0)}%
+        </>
+      }
+    >
+      {formatNumber(flatAmount)} ({formatPercentage(percentage)}%)
+    </PerformanceStrongWithTooltip>
+  );
+};
+
+export default ThresoldPerformancePercentage;

--- a/src/analysis/retail/shaman/elemental/modules/features/shared/ThresholdPerformancePercentage.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/features/shared/ThresholdPerformancePercentage.tsx
@@ -3,6 +3,10 @@ import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { formatNumber, formatPercentage } from 'common/format';
 import PerformanceStrongWithTooltip from 'interface/PerformanceStrongWithTooltip';
 
+/**
+ * Thresholds for a performance percentage, where the actual value is compared
+ * using the <= operator.
+ */
 export interface LTEThreshold {
   type: 'lte';
   perfect: number;
@@ -10,6 +14,10 @@ export interface LTEThreshold {
   ok: number;
 }
 
+/**
+ * Thresholds for a performance percentage, where the actual value is compared
+ * using the >= operator.
+ */
 export interface GTEThreshold {
   type: 'gte';
   perfect: number;
@@ -18,14 +26,15 @@ export interface GTEThreshold {
 }
 
 interface Props {
-  threshold: LTEThreshold | GTEThreshold;
-  percentage: number;
-  flatAmount: number;
+  threshold: LTEThreshold | GTEThreshold /** The threshold to compare against. */;
+  percentage: number /** The actual percentage value to compare against the threshold */;
+  flatAmount: number /** The flat amount of the percentage (the numerator) */;
 }
 /**
  * Element that shows a performance percentage with a tooltip.
  *
- * The performance is computed based on the given threshold.
+ * The performance is computed based on the given threshold. Computation starts
+ * by comparing against perfect, good and ok thresholds in order, returning the first one that matched.
  */
 const ThresoldPerformancePercentage = ({ threshold, percentage, flatAmount }: Props) => {
   let signJsx;


### PR DESCRIPTION
### Description

This adds a section on properly using the single target spender. I looked into expanding it for 2-3-4 targets, but I chose to delay that as each increase introduces subtle changes in the rotation.

### Testing

- Test report URL: `/report/tnLg84dqxX1ZcTYC/15-Heroic+Rashok,+the+Elder+-+Kill+(3:33)/Fivreld/standard`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/12049229/ada3f87d-2cc1-4c6b-b40f-8cc8afa46afa)

Hovering on the @ 's reveal the times when the spender was cast. 