### PR TITLE
stop treating React Elements as MessageDescriptors

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -26,6 +26,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 7, 27), 'Fix i18n in suggestions.', ToppleTheNun),
   change(date(2023, 7, 25), 'Improve consistency when fetching talents for tables.', ToppleTheNun),
   change(date(2023, 7, 25), 'Fix crash when using certain i18n functions.', ToppleTheNun),
   change(date(2023, 7, 23), 'Tooltip on Timeline Improvements', Abelito75),

--- a/src/localization/isMessageDescriptor.ts
+++ b/src/localization/isMessageDescriptor.ts
@@ -1,4 +1,5 @@
 import { MessageDescriptor } from '@lingui/core';
+import { isValidElement } from 'react';
 
 // This is kind of ugly but I generated it, so I'm keeping it for now.
 export const isMessageDescriptor = (obj: unknown): obj is MessageDescriptor => {
@@ -12,6 +13,9 @@ export const isMessageDescriptor = (obj: unknown): obj is MessageDescriptor => {
     (typeof typedObj['values'] === 'undefined' ||
       (((typedObj['values'] !== null && typeof typedObj['values'] === 'object') ||
         typeof typedObj['values'] === 'function') &&
-        Object.entries<any>(typedObj['values']).every(([key, _value]) => typeof key === 'string')))
+        Object.entries<any>(typedObj['values']).every(
+          ([key, _value]) => typeof key === 'string',
+        ))) &&
+    !isValidElement(typedObj)
   );
 };


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Valid React elements like the below were being treated as lingui `MessageDescriptor`s due to being objects.

```jsx
        <>
          You cast the wrong filler spell {this.badFillerCasts} times -{' '}
          {formatPercentage(actual, 1)}% of total filler casts. You should cast{' '}
          <SpellLink spell={SPELLS.WRATH_MOONKIN} /> during and after{' '}
          <SpellLink spell={SPELLS.ECLIPSE_SOLAR} />, and you should cast{' '}
          <SpellLink spell={SPELLS.STARFIRE} /> during and after{' '}
          <SpellLink spell={SPELLS.ECLIPSE_LUNAR} />.
          <br />
        </>,
```

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/rGN84WHjg72LqzFc/23-Mythic+Terros+-+Kill+(5:56)/Wardaalsahra/standard/overview`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/0e24afc9-5998-440a-afbb-b16721b659a0)
