### PR TITLE
[Hunter] Bump BM to 10.1.5

### DIFF
--- a/src/analysis/retail/hunter/beastmastery/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/beastmastery/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/hunter';
 import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 export default [
+  change(date(2023, 7, 29), 'Mark Beast Mastery as compatible for 10.1.5', Putro),
   change(date(2023, 7, 3), 'Update SpellLink usage.', ToppleTheNun),
   change(date(2023, 7, 3), 'Added support for Tier 30 2piece and 4piece', Putro),
   change(date(2023, 5, 8), <>Fixed an issue with <SpellLink spell={TALENTS.BLOODSHED_TALENT} />. </>, Putro),

--- a/src/analysis/retail/hunter/beastmastery/CONFIG.tsx
+++ b/src/analysis/retail/hunter/beastmastery/CONFIG.tsx
@@ -9,7 +9,7 @@ const config: Config = {
   contributors: [Putro, Arlie],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.7',
+  patchCompatibility: '10.1.5',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
@@ -51,7 +51,7 @@ const config: Config = {
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/Dd4mA7LtyGqhCanN/10-Heroic+Hungering+Destroyer+-+Kill+(4:04)/Sucker',
+  exampleReport: '/report/zrb9CRPkhn2TpFyK/4-Heroic+Kazzara,+the+Hellforged+-+Kill+(2:00)/Ispase',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/parser/shared/modules/Entities.ts
+++ b/src/parser/shared/modules/Entities.ts
@@ -162,7 +162,7 @@ abstract class Entities<T extends Entity> extends Analyzer {
       existingBuff.refreshHistory.push(event.timestamp);
     } else {
       console.error(
-        "Buff refreshed while active buff wasn't known. Was this buff applied pre-combat? Maybe we should register the buff with start time as fight start when this happens, but it might also be a basic case of erroneous combatlog ordering.",
+        `${event.ability.name} buff was refreshed while active buff wasn't known. Was this buff applied pre-combat? Maybe we should register the buff with start time as fight start when this happens, but it might also be a basic case of erroneous combatlog ordering.`,
       );
     }
   }


### PR DESCRIPTION
No real changes has happened to beast mastery to warrant any major changes. 

Unused talents are the unimplemented things, and guide could use a bit more work in the future.

Update example log to aberrus log.

Update entities error to provide which buff is being refreshed for easier debugging
