### PR TITLE
Fix bug in calculation for time spent casting EF

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 7, 29), <>Fixed bug in healing per time spent calculation for <SpellLink spell={TALENTS_MONK.ESSENCE_FONT_TALENT}/></>, Trevor),
   change(date(2023, 7, 16), <>Fixed bug in damage calculation for <SpellLink spell={SPELLS.LESSON_OF_DOUBT_BUFF}/></>, Vohrr),
   change(date(2023, 7, 3), 'Update SpellLink usage.', ToppleTheNun),
   change(date(2023, 6, 30), <>Bump sample report to current raid</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/modules/features/MistweaverHealingEfficiencyTracker.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/MistweaverHealingEfficiencyTracker.tsx
@@ -135,7 +135,7 @@ class MistweaverHealingEfficiencyTracker extends HealingEfficiencyTracker {
     spellInfo.overhealingDone = this.essenceFont.totalOverhealing;
     spellInfo.healingDone += this.ancientTeachings.totalHealing;
     spellInfo.overhealingDone += this.ancientTeachings.overhealing;
-    spellInfo.timeSpentCasting = this.essenceFont.timeSpent;
+    spellInfo.timeSpentCasting = this.essenceFont.timeSpentCasting;
     return spellInfo;
   }
 

--- a/src/analysis/retail/monk/mistweaver/modules/features/MistweaverHealingEfficiencyTracker.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/MistweaverHealingEfficiencyTracker.tsx
@@ -131,10 +131,11 @@ class MistweaverHealingEfficiencyTracker extends HealingEfficiencyTracker {
   }
 
   getEssenceFontDetails(spellInfo: SpellInfoDetails) {
-    spellInfo.healingDone += this.essenceFont.totalHealing;
+    spellInfo.healingDone = this.essenceFont.totalHealing;
     spellInfo.overhealingDone += this.essenceFont.totalOverhealing;
     spellInfo.healingDone += this.ancientTeachings.totalHealing;
     spellInfo.overhealingDone += this.ancientTeachings.overhealing;
+    spellInfo.timeSpentCasting = this.essenceFont.timeSpent;
     return spellInfo;
   }
 

--- a/src/analysis/retail/monk/mistweaver/modules/features/MistweaverHealingEfficiencyTracker.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/MistweaverHealingEfficiencyTracker.tsx
@@ -132,7 +132,7 @@ class MistweaverHealingEfficiencyTracker extends HealingEfficiencyTracker {
 
   getEssenceFontDetails(spellInfo: SpellInfoDetails) {
     spellInfo.healingDone = this.essenceFont.totalHealing;
-    spellInfo.overhealingDone += this.essenceFont.totalOverhealing;
+    spellInfo.overhealingDone = this.essenceFont.totalOverhealing;
     spellInfo.healingDone += this.ancientTeachings.totalHealing;
     spellInfo.overhealingDone += this.ancientTeachings.overhealing;
     spellInfo.timeSpentCasting = this.essenceFont.timeSpent;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
@@ -4,9 +4,7 @@ import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, {
   ApplyBuffEvent,
-  BeginChannelEvent,
   CastEvent,
-  EndChannelEvent,
   HealEvent,
   RemoveBuffEvent,
   UpdateSpellUsableEvent,
@@ -61,8 +59,6 @@ class EssenceFont extends Analyzer {
   chijiGomEFHits: number = 0;
   lastCdEnd: number = 0;
   numCancelled: number = 0;
-  lastStart: number = 0;
-  timeSpent: number = 0;
 
   totalHealing: number = 0;
   totalOverhealing: number = 0;
@@ -102,14 +98,6 @@ class EssenceFont extends Analyzer {
         this.chijiGustHealing,
       );
     }
-    this.addEventListener(
-      Events.BeginChannel.by(SELECTED_PLAYER).spell(TALENTS_MONK.ESSENCE_FONT_TALENT),
-      this.onBeginChannel,
-    );
-    this.addEventListener(
-      Events.EndChannel.by(SELECTED_PLAYER).spell(TALENTS_MONK.ESSENCE_FONT_TALENT),
-      this.onEndChannel,
-    );
   }
 
   get efProcRatio() {
@@ -120,12 +108,8 @@ class EssenceFont extends Analyzer {
     );
   }
 
-  onBeginChannel(event: BeginChannelEvent) {
-    this.lastStart = event.timestamp;
-  }
-
-  onEndChannel(event: EndChannelEvent) {
-    this.timeSpent += event.timestamp - this.lastStart;
+  get timeSpentCasting() {
+    return this.selectedCombatant.getBuffUptime(SPELLS.ESSENCE_FONT_CHANNELING_BUFF.id);
   }
 
   isValidEFEvent(event: HealEvent) {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
@@ -4,7 +4,9 @@ import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, {
   ApplyBuffEvent,
+  BeginChannelEvent,
   CastEvent,
+  EndChannelEvent,
   HealEvent,
   RemoveBuffEvent,
   UpdateSpellUsableEvent,
@@ -59,6 +61,8 @@ class EssenceFont extends Analyzer {
   chijiGomEFHits: number = 0;
   lastCdEnd: number = 0;
   numCancelled: number = 0;
+  lastStart: number = 0;
+  timeSpent: number = 0;
 
   totalHealing: number = 0;
   totalOverhealing: number = 0;
@@ -98,6 +102,14 @@ class EssenceFont extends Analyzer {
         this.chijiGustHealing,
       );
     }
+    this.addEventListener(
+      Events.BeginChannel.by(SELECTED_PLAYER).spell(TALENTS_MONK.ESSENCE_FONT_TALENT),
+      this.onBeginChannel,
+    );
+    this.addEventListener(
+      Events.EndChannel.by(SELECTED_PLAYER).spell(TALENTS_MONK.ESSENCE_FONT_TALENT),
+      this.onEndChannel,
+    );
   }
 
   get efProcRatio() {
@@ -106,6 +118,14 @@ class EssenceFont extends Analyzer {
         (this.gomHits - this.gomEFHits - this.chijiGomEFHits) +
       1
     );
+  }
+
+  onBeginChannel(event: BeginChannelEvent) {
+    this.lastStart = event.timestamp;
+  }
+
+  onEndChannel(event: EndChannelEvent) {
+    this.timeSpent += event.timestamp - this.lastStart;
   }
 
   isValidEFEvent(event: HealEvent) {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
@@ -109,7 +109,7 @@ class EssenceFont extends Analyzer {
   }
 
   get timeSpentCasting() {
-    return this.selectedCombatant.getBuffUptime(SPELLS.ESSENCE_FONT_CHANNELING_BUFF.id);
+    return this.selectedCombatant.getBuffUptime(TALENTS_MONK.ESSENCE_FONT_TALENT.id);
   }
 
   isValidEFEvent(event: HealEvent) {

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -107,11 +107,6 @@ const spells = {
     name: 'Essence Font',
     icon: 'ability_monk_essencefont',
   },
-  ESSENCE_FONT_CHANNELING_BUFF: {
-    id: 191837,
-    name: 'Essence Font',
-    icon: 'ability_monk_essencefont',
-  },
   SECRET_INFUSION_CRIT_BUFF: {
     id: 388498,
     name: 'Secret infusion',

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -107,6 +107,11 @@ const spells = {
     name: 'Essence Font',
     icon: 'ability_monk_essencefont',
   },
+  ESSENCE_FONT_CHANNELING_BUFF: {
+    id: 191837,
+    name: 'Essence Font',
+    icon: 'ability_monk_essencefont',
+  },
   SECRET_INFUSION_CRIT_BUFF: {
     id: 388498,
     name: 'Secret infusion',

--- a/src/parser/core/healingEfficiency/HealingEfficiencyTracker.ts
+++ b/src/parser/core/healingEfficiency/HealingEfficiencyTracker.ts
@@ -106,6 +106,8 @@ class HealingEfficiencyTracker extends Analyzer {
     };
 
     spellInfo.manaSpent = spenders[spellId] ? spenders[spellId].spent : 0;
+    const timeSpentCasting = this.castEfficiency.getTimeSpentCasting(spellId);
+    spellInfo.timeSpentCasting = timeSpentCasting.timeSpentCasting + timeSpentCasting.gcdSpent;
 
     // All of the following information can be derived from the data in SpellInfo.
     // Now we can add custom logic for spells.
@@ -120,8 +122,6 @@ class HealingEfficiencyTracker extends Analyzer {
     spellInfo.hpm = spellInfo.healingDone / spellInfo.manaSpent || 0;
     spellInfo.dpm = spellInfo.damageDone / spellInfo.manaSpent || 0;
 
-    const timeSpentCasting = this.castEfficiency.getTimeSpentCasting(spellId);
-    spellInfo.timeSpentCasting = timeSpentCasting.timeSpentCasting + timeSpentCasting.gcdSpent;
     spellInfo.percentTimeSpentCasting = spellInfo.timeSpentCasting / this.owner.fightDuration;
 
     spellInfo.hpet = spellInfo.healingDone / spellInfo.timeSpentCasting || 0;


### PR DESCRIPTION
### Description

Changes logic in base HealingEfficiencyTracker to allow child classes to override the timeSpentCasting. It's relatively difficult to override the CastEfficiency module (0 places do it for good reason). This diff then changes the logic in the MW cast efficiency tracker to override time spent casting EF since we do some event fabrication with begin/end channel instead of relying on BeginCast/Cast

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `report/m7XYK3yc8xf2rHDn/35-Mythic+Rashok,+the+Elder+-+Kill+(5:34)/Sweggles/standard/statistics`
- Screenshot(s):

Before
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/5051ac12-6a30-4e91-b707-9d3a8d12bc44)

After
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/4c875545-fc1e-407a-b86d-0a67cc9f9e63)

