### PR TITLE
[Feral] Dire Fixation + 10.1.5

### DIFF
--- a/src/analysis/retail/druid/feral/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/feral/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS/druid';
 
 export default [
+  change(date(2023, 7, 31), <>Added a guide entry and a statistic for <SpellLink spell={TALENTS_DRUID.DIRE_FIXATION_TALENT}/>. Bumped support to 10.1.5</>, Sref),
   change(date(2023, 6, 21), <>Fixed an issue where parried <SpellLink spell={SPELLS.FEROCIOUS_BITE}/> casts were counted as 0 CP casts.</>, Sref),
   change(date(2023, 6, 20), 'Update SpellLink usage.', ToppleTheNun),
   change(date(2023, 6, 6), <>Fixed an issue where the analyzer was overstating the amount of cooldown reduction from <SpellLink spell={TALENTS_DRUID.BERSERK_HEART_OF_THE_LION_TALENT}/></>, Sref),

--- a/src/analysis/retail/druid/feral/CONFIG.tsx
+++ b/src/analysis/retail/druid/feral/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Sref],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.1.0',
+  patchCompatibility: '10.1.5',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/druid/feral/CombatLogParser.ts
+++ b/src/analysis/retail/druid/feral/CombatLogParser.ts
@@ -46,6 +46,7 @@ import BrutalSlash from 'analysis/retail/druid/feral/modules/spells/BrutalSlash'
 import OmenAndMomentOfClarity from 'analysis/retail/druid/feral/modules/spells/OmenAndMomentOfClarity';
 import FeralFrenzy from 'analysis/retail/druid/feral/modules/spells/FeralFrenzy';
 import Tier29 from 'analysis/retail/druid/feral/modules/dragonflight/Tier29';
+import DireFixation from 'analysis/retail/druid/feral/modules/spells/DireFixation';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -108,6 +109,7 @@ class CombatLogParser extends CoreCombatLogParser {
     brutalSlash: BrutalSlash,
     omenAndMomentOfClarity: OmenAndMomentOfClarity,
     feralFrenzy: FeralFrenzy,
+    direFixation: DireFixation,
 
     // tier
     tier29: Tier29,

--- a/src/analysis/retail/druid/feral/Guide.tsx
+++ b/src/analysis/retail/druid/feral/Guide.tsx
@@ -96,6 +96,8 @@ function CoreRotationSection({ modules, events, info }: GuideProps<typeof Combat
         modules.adaptiveSwarm.guideSubsection}
       {info.combatant.hasTalent(TALENTS_DRUID.BRUTAL_SLASH_TALENT) &&
         modules.brutalSlash.guideSubsection}
+      {info.combatant.hasTalent(TALENTS_DRUID.DIRE_FIXATION_TALENT) &&
+        modules.direFixation.guideSubsection}
       {modules.hitCountAoe.guideSubsection}
     </Section>
   );

--- a/src/analysis/retail/druid/feral/modules/spells/DireFixation.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/DireFixation.tsx
@@ -1,0 +1,97 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import SPELLS from 'common/SPELLS';
+import { TALENTS_DRUID } from 'common/TALENTS';
+import Events, { DamageEvent } from 'parser/core/Events';
+import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
+import Enemies from 'parser/shared/modules/Enemies';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentDamageDone from 'parser/ui/ItemPercentDamageDone';
+import { formatPercentage } from 'common/format';
+
+const DIRE_FIXATION_BOOST = 0.08;
+// from spell data
+const AFFECTED_SPELLS = [
+  SPELLS.SHRED,
+  SPELLS.FEROCIOUS_BITE,
+  SPELLS.THRASH_FERAL,
+  SPELLS.THRASH_FERAL_BLEED,
+  SPELLS.RIP,
+  SPELLS.MAIM,
+  SPELLS.RAKE,
+  SPELLS.RAKE,
+  TALENTS_DRUID.BRUTAL_SLASH_TALENT,
+  TALENTS_DRUID.PRIMAL_WRATH_TALENT,
+  SPELLS.SWIPE_CAT,
+  SPELLS.MOONFIRE_FERAL,
+  TALENTS_DRUID.FERAL_FRENZY_TALENT,
+  TALENTS_DRUID.RAMPANT_FEROCITY_TALENT,
+];
+
+const deps = {
+  enemies: Enemies,
+};
+
+/**
+ * **Dire Fixation**
+ * Spec Talent
+ *
+ * Attacking an enemy with Shred fixates your attention on it for 10 sec.
+ * You can fixate on a single target at once.
+ * Your attacks deal 8% increased damage to your fixated target.
+ */
+export default class DireFixation extends Analyzer.withDependencies(deps) {
+  /** Damage due to the increase from Dire Fixation */
+  damage = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.DIRE_FIXATION_TALENT);
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(AFFECTED_SPELLS),
+      this.onAffectedDamage,
+    );
+  }
+
+  onAffectedDamage(event: DamageEvent) {
+    const target = this.deps.enemies.getEntity(event);
+    if (!target) {
+      return;
+    }
+    if (target.hasBuff(SPELLS.DIRE_FIXATION_DEBUFF.id)) {
+      this.damage += calculateEffectiveDamage(event, DIRE_FIXATION_BOOST);
+    }
+  }
+
+  get uptime(): number {
+    return this.deps.enemies.getBuffUptime(SPELLS.DIRE_FIXATION_DEBUFF.id);
+  }
+
+  get uptimePercent(): number {
+    return this.uptime / this.owner.fightDuration;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(2)} // number based on talent row
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
+        tooltip={
+          <>
+            Uptime on at least one target:{' '}
+            <strong>{formatPercentage(this.uptimePercent, 1)}%</strong>
+          </>
+        }
+      >
+        <BoringSpellValueText spell={TALENTS_DRUID.DIRE_FIXATION_TALENT}>
+          <ItemPercentDamageDone amount={damage} />
+          <br />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}

--- a/src/analysis/retail/druid/feral/modules/spells/DireFixation.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/DireFixation.tsx
@@ -10,6 +10,10 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemPercentDamageDone from 'parser/ui/ItemPercentDamageDone';
 import { formatPercentage } from 'common/format';
+import { SpellLink } from 'interface';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import uptimeBarSubStatistic, { SubPercentageStyle } from 'parser/ui/UptimeBarSubStatistic';
 
 const DIRE_FIXATION_BOOST = 0.08;
 // from spell data
@@ -88,10 +92,45 @@ export default class DireFixation extends Analyzer.withDependencies(deps) {
         }
       >
         <BoringSpellValueText spell={TALENTS_DRUID.DIRE_FIXATION_TALENT}>
-          <ItemPercentDamageDone amount={damage} />
+          <ItemPercentDamageDone amount={this.damage} />
           <br />
         </BoringSpellValueText>
       </Statistic>
     );
+  }
+
+  get uptimeBar() {
+    return uptimeBarSubStatistic(
+      this.owner.fight,
+      {
+        spells: [TALENTS_DRUID.DIRE_FIXATION_TALENT],
+        uptimes: this.deps.enemies.getDebuffHistory(SPELLS.DIRE_FIXATION_DEBUFF.id),
+      },
+      [],
+      SubPercentageStyle.RELATIVE,
+    );
+  }
+
+  get guideSubsection(): JSX.Element {
+    const explanation = (
+      <p>
+        <b>
+          <SpellLink spell={TALENTS_DRUID.DIRE_FIXATION_TALENT} />
+        </b>{' '}
+        is important to maintain in Single Target situations and even worthwhile to maintain in low
+        target count AoE. You should be close to 100% just be playing your rotation normally.
+      </p>
+    );
+
+    const data = (
+      <div>
+        <RoundedPanel>
+          <strong>Dire Fixation uptime</strong>
+          {this.uptimeBar}
+        </RoundedPanel>
+      </div>
+    );
+
+    return explanationAndDataSubsection(explanation, data);
   }
 }

--- a/src/common/SPELLS/druid.ts
+++ b/src/common/SPELLS/druid.ts
@@ -1083,6 +1083,12 @@ const spells = {
     name: "Cat's Curiosity",
     icon: 'inv_jewelcrafting_gem_30',
   },
+  // debuff from Dire Fixation
+  DIRE_FIXATION_DEBUFF: {
+    id: 417713,
+    name: 'Dire Fixation',
+    icon: 'ability_druid_primalprecision',
+  },
   // feral legion tier sets
   FERAL_DRUID_T19_2SET_BONUS_BUFF: {
     id: 211140,


### PR DESCRIPTION
### Description

Added a simple statistic and guide section for Dire Fixation. Bumped support to 10.1.5

### Testing

- Test report URL: `/report/a6MNkCTyvFAmqpr7/3-Heroic+Kazzara,+the+Hellforged+-+Kill+(2:48)/Azlann/standard`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/7143486/ef6aec37-083e-4fb8-9e9f-0fd0cd094ebf)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/7143486/857295dd-dc10-4dfd-9968-309f766c02bf)
