### PR TITLE
[Shadow] Add Statistic for Ancient Madness Talent

### DIFF
--- a/src/analysis/retail/priest/shadow/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/shadow/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { DoxAshe, Havoc, ToppleTheNun } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 8, 2), <>Add statistic for <SpellLink spell={TALENTS.ANCIENT_MADNESS_TALENT}/> damage contribution,</>,DoxAshe),
   change(date(2023, 7, 26), <>Update suggestions for spell usage in guide view for 10.1.5</>,DoxAshe),
   change(date(2023, 7, 3), 'Update SpellLink usage.', ToppleTheNun),
   change(date(2023, 6, 29), <>Add <SpellLink spell={TALENTS.VOID_TORRENT_TALENT}/>, <SpellLink spell={SPELLS.MIND_FLAY}/>, and <SpellLink spell={SPELLS.MIND_FLAY_INSANITY_TALENT_DAMAGE}/> to channeled spells to fix downtime and timeline</>,DoxAshe),

--- a/src/analysis/retail/priest/shadow/CombatLogParser.tsx
+++ b/src/analysis/retail/priest/shadow/CombatLogParser.tsx
@@ -40,6 +40,7 @@ import InescapableTorment from './modules/talents/InescapableTorment';
 import UnfurlingDarkness from './modules/talents/UnfurlingDarkness';
 import Deathspeaker from './modules/talents/Deathspeaker';
 import MindSpikeInsanity from './modules/talents/MindSpikeInsanity';
+import AncientMadness from './modules/talents/AncientMadness';
 import VoidTorrent from './modules/talents/VoidTorrent';
 import MindFlayInsanity from './modules/talents/MindFlayInsanity';
 import MindDevourer from './modules/talents/MindDevourer';
@@ -88,6 +89,7 @@ class CombatLogParser extends MainCombatLogParser {
     darkEvangelism: DarkEvangelism,
 
     // talents:
+    ancientMadness: AncientMadness,
     deathAndMadness: DeathAndMadness,
     unfurlingDarkness: UnfurlingDarkness,
     twistOfFate: TwistOfFate,

--- a/src/analysis/retail/priest/shadow/modules/spells/Voidbolt.tsx
+++ b/src/analysis/retail/priest/shadow/modules/spells/Voidbolt.tsx
@@ -111,8 +111,13 @@ class Voidbolt extends ExecuteHelper {
     }
 
     const averagecd = totalCD / castCount;
+    const bolts = Math.floor(waiting / averagecd);
 
-    this.miss = this.miss + Math.floor(waiting / averagecd); //Any remainder is not a possible cast, so it is floored.
+    if (!isNaN(bolts)) {
+      //if a character dies very early in voidform, the bolts calculation can be NaN, and we don't count that Voidform.
+      this.miss = this.miss + bolts; //Any remainder is not a possible cast, so it is floored.
+    }
+
     this.VB = [0]; //After calcuating the missed VB, removed them so they cannot be added again.
   }
 

--- a/src/analysis/retail/priest/shadow/modules/talents/AncientMadness.tsx
+++ b/src/analysis/retail/priest/shadow/modules/talents/AncientMadness.tsx
@@ -66,7 +66,7 @@ class AncientMadness extends Analyzer {
         size="flexible"
         tooltip="The damage displayed is the additional damage you gained from taking this talent."
       >
-        <BoringSpellValueText spell={TALENTS.ANCIENT_MADNESS_TALENT}>
+        <BoringSpellValueText spell={SPELLS.ANCIENT_MADNESS_TALENT}>
           <ItemDamageDone amount={this.totalDamage} />
         </BoringSpellValueText>
       </Statistic>

--- a/src/analysis/retail/priest/shadow/modules/talents/AncientMadness.tsx
+++ b/src/analysis/retail/priest/shadow/modules/talents/AncientMadness.tsx
@@ -1,0 +1,76 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import TALENTS from 'common/TALENTS/priest';
+import SPELLS from 'common/SPELLS';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import Events, { ApplyBuffEvent, DamageEvent } from 'parser/core/Events';
+import { calculateEffectiveDamageFromCritIncrease } from 'parser/core/EventCalculateLib';
+import StatTracker from 'parser/shared/modules/StatTracker';
+
+const ANCIENT_MADNESS_CRIT_INCREASE = 0.1; //Starts by giving 10% crit
+const ANCEINT_MADNESS_CRIT_DECREASE_PER_SECOND = 0.005; //Reduces by 0.5% per second
+/**
+ * Ranged auto-attacks have a 15% chance to increase the critical strike chance of your next Arcane Shot or Multi-Shot by 100%.
+ */
+class AncientMadness extends Analyzer {
+  static dependencies = {
+    statTracker: StatTracker,
+  };
+
+  totalDamage: number = 0;
+  startTime = 0;
+
+  protected statTracker!: StatTracker;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.ANCIENT_MADNESS_TALENT);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDamage);
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.VOIDFORM_BUFF),
+      this.buffStart,
+    );
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(TALENTS.DARK_ASCENSION_TALENT),
+      this.buffStart,
+    );
+  }
+
+  buffStart(event: ApplyBuffEvent) {
+    this.startTime = event.timestamp;
+  }
+
+  onDamage(event: DamageEvent) {
+    if (event.hitType === 2) {
+      //only crit events should be sent to effectiveDamageFromCritIncrease,
+      const timeSinceCast = Math.floor((event.timestamp - this.startTime) / 1000); //time since buff activation rounded to nearest second.
+      const currentCritIncrease =
+        ANCIENT_MADNESS_CRIT_INCREASE - timeSinceCast * ANCEINT_MADNESS_CRIT_DECREASE_PER_SECOND;
+      if (currentCritIncrease > 0) {
+        const effectiveDamgeFromCritIncrease = calculateEffectiveDamageFromCritIncrease(
+          event,
+          this.statTracker.currentCritPercentage,
+          currentCritIncrease,
+        );
+        this.totalDamage += effectiveDamgeFromCritIncrease;
+      }
+    }
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
+        tooltip="The damage displayed is the additional damage you gained from taking this talent."
+      >
+        <BoringSpellValueText spell={TALENTS.ANCIENT_MADNESS_TALENT}>
+          <ItemDamageDone amount={this.totalDamage} />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+export default AncientMadness;

--- a/src/analysis/retail/priest/shadow/modules/talents/AncientMadness.tsx
+++ b/src/analysis/retail/priest/shadow/modules/talents/AncientMadness.tsx
@@ -8,19 +8,18 @@ import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Events, { ApplyBuffEvent, DamageEvent } from 'parser/core/Events';
 import { calculateEffectiveDamageFromCritIncrease } from 'parser/core/EventCalculateLib';
 import StatTracker from 'parser/shared/modules/StatTracker';
+import HIT_TYPES from 'game/HIT_TYPES';
 
 const ANCIENT_MADNESS_CRIT_INCREASE = 0.1; //Starts by giving 10% crit
 const ANCEINT_MADNESS_CRIT_DECREASE_PER_SECOND = 0.005; //Reduces by 0.5% per second
-/**
- * Ranged auto-attacks have a 15% chance to increase the critical strike chance of your next Arcane Shot or Multi-Shot by 100%.
- */
+
 class AncientMadness extends Analyzer {
   static dependencies = {
     statTracker: StatTracker,
   };
 
   totalDamage: number = 0;
-  startTime = 0;
+  startTime: number = 0;
 
   protected statTracker!: StatTracker;
 
@@ -43,7 +42,7 @@ class AncientMadness extends Analyzer {
   }
 
   onDamage(event: DamageEvent) {
-    if (event.hitType === 2) {
+    if (event.hitType === HIT_TYPES.CRIT) {
       //only crit events should be sent to effectiveDamageFromCritIncrease,
       const timeSinceCast = Math.floor((event.timestamp - this.startTime) / 1000); //time since buff activation rounded to nearest second.
       const currentCritIncrease =
@@ -61,11 +60,7 @@ class AncientMadness extends Analyzer {
 
   statistic() {
     return (
-      <Statistic
-        category={STATISTIC_CATEGORY.TALENTS}
-        size="flexible"
-        tooltip="The damage displayed is the additional damage you gained from taking this talent."
-      >
+      <Statistic category={STATISTIC_CATEGORY.TALENTS} size="flexible">
         <BoringSpellValueText spell={SPELLS.ANCIENT_MADNESS_TALENT}>
           <ItemDamageDone amount={this.totalDamage} />
         </BoringSpellValueText>

--- a/src/common/SPELLS/priest.ts
+++ b/src/common/SPELLS/priest.ts
@@ -824,6 +824,13 @@ const spells = {
     name: 'Devoured Violence',
     icon: 'sha_spell_warlock_demonsoul',
   },
+
+  ANCIENT_MADNESS_TALENT: {
+    id: 341240,
+    name: 'Ancient Madness',
+    icon: 'spell_priest_void-flay',
+  },
+
   //Shadow Tier
   SHADOW_PRIEST_TIER_29_4_SET_BUFF: {
     id: 394963,


### PR DESCRIPTION
### Description

This adds a statistic box that shows the damage gained with Shadow's ancient madness talent.   This talent grants 10% critical strike chance when we use our cooldown, decreasing by 0.5% every second.
Separately, this fixes an uncommon issue with Voidbolt when a character dies very early into Voidform.

### Testing

I think I have used calculateEffectiveDamageFromCritIncrease correctly, and the numbers look right, but I'm worried I've missed something.

- Screenshot(s):
![AM](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/103148620/94d9eb21-400e-40a0-9f7d-e711b5fa2720)
