### PR TITLE
rapture analysis now ignores off gcd spells

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -21,12 +21,14 @@ import {
   Jundarer,
   Vollmer,
   Awildfivreld,
+  Tapir,
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 8, 3), 'Update Rapture analysis now ignores off GCD spells and enchants', Tapir),
   change(date(2023, 7, 31), <>Add enchantment check for <ItemLink id={ITEMS.SHADOWED_BELT_CLASP_R3.id} />.</>,  ToppleTheNun),
   change(date(2023, 7, 29), 'Fix another issue loading parses using character search', emallson),
   change(date(2023, 7, 29), 'Fix an issue loading parses using character search', Putro),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -21,14 +21,12 @@ import {
   Jundarer,
   Vollmer,
   Awildfivreld,
-  Tapir,
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
-  change(date(2023, 8, 3), 'Update Rapture analysis now ignores off GCD spells and enchants', Tapir),
   change(date(2023, 7, 31), <>Add enchantment check for <ItemLink id={ITEMS.SHADOWED_BELT_CLASP_R3.id} />.</>,  ToppleTheNun),
   change(date(2023, 7, 29), 'Fix another issue loading parses using character search', emallson),
   change(date(2023, 7, 29), 'Fix an issue loading parses using character search', Putro),

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2239,3 +2239,15 @@ export const Awildfivreld: Contributor = {
   nickname: 'Awildfivreld',
   github: 'awildfivreld',
 };
+export const Tapir: Contributor = {
+  nickname: 'Tapir',
+  github: 'Tapir42',
+  discord: 'Tapir#8523',
+  mains: [
+    {
+      name: 'Tapriest',
+      spec: SPECS.DISCIPLINE_PRIEST,
+      link: 'https://worldofwarcraft.blizzard.com/en-gb/character/eu/sylvanas/tapriest',
+    },
+  ],
+};

--- a/src/analysis/retail/priest/discipline/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/discipline/CHANGELOG.tsx
@@ -1,11 +1,12 @@
 import { change, date } from 'common/changelog';
 import { TALENTS_PRIEST } from 'common/TALENTS';
 import SPELLS  from 'common/SPELLS'
-import { Hana, ToppleTheNun } from 'CONTRIBUTORS';
+import { Hana, Tapir, ToppleTheNun } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 8, 3), 'Update Rapture analysis now ignores off GCD spells and enchants', Tapir),
   change(date(2023, 8, 1), <>Add <SpellLink spell={TALENTS_PRIEST.BENEVOLENCE_TALENT}/></>, Hana),
   change(date(2023, 7, 3), 'Update SpellLink usage.', ToppleTheNun),
   change(date(2023, 5, 29), 'Fix Evangelism ramp crash.', ToppleTheNun),

--- a/src/analysis/retail/priest/discipline/modules/guide/RaptureAnalysis.tsx
+++ b/src/analysis/retail/priest/discipline/modules/guide/RaptureAnalysis.tsx
@@ -93,6 +93,9 @@ class RaptureAnalysis extends Analyzer {
     if (this.ramps.length < 1) {
       return;
     }
+    if (!this.globalCooldown.isOnGlobalCooldown(event.ability.guid)) {
+      return;
+    }
 
     if (
       event.ability.guid === TALENTS_PRIEST.POWER_WORD_RADIANCE_TALENT.id &&


### PR DESCRIPTION
"Rapture analysis" module now ignores off gcd spells like Fade, Pots, or enchants (healing darts).