### PR TITLE
[Core] EventLinknormalizer Re-added events Fix

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -27,6 +27,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 8, 4), <>Added additional checks to make sure EventLinkedNormalizer doens't re-add the same events.</>,  Abelito75),
   change(date(2023, 7, 31), <>Add enchantment check for <ItemLink id={ITEMS.SHADOWED_BELT_CLASP_R3.id} />.</>,  ToppleTheNun),
   change(date(2023, 7, 29), 'Fix another issue loading parses using character search', emallson),
   change(date(2023, 7, 29), 'Fix an issue loading parses using character search', Putro),

--- a/src/parser/core/EventLinkNormalizer.ts
+++ b/src/parser/core/EventLinkNormalizer.ts
@@ -131,10 +131,35 @@ abstract class EventLinkNormalizer extends EventsNormalizer {
     );
   }
 
+  /**
+   * Prevents the relinking of an event that is already linked for a given reason
+   * @returns True if event is already linked
+   */
+  private _alreadyLinked(
+    el: EventLink,
+    linkingEvent: AnyEvent,
+    referencedEvent: AnyEvent,
+  ): boolean {
+    return Boolean(
+      linkingEvent._linkedEvents?.find((alreadyLinkedEvent) => {
+        // Do a reference check. If its the same refernece, its already linked
+        return (
+          alreadyLinkedEvent.event === referencedEvent &&
+          el.linkRelation === alreadyLinkedEvent.relation
+        );
+      }),
+    );
+  }
+
   /** checks that the referenced event matches the criteria and that the linking and
    * referenced events match each other, then adds the link(s).
    * Returns 1 iff a link is added, and 0 if not. */
   private _checkAndLink(el: EventLink, linkingEvent: AnyEvent, referencedEvent: AnyEvent): number {
+    // Make sure we don't already have this event linked
+    if (this._alreadyLinked(el, linkingEvent, referencedEvent)) {
+      return 0;
+    }
+
     if (
       this._isReferenced(el, referencedEvent) &&
       this._sourceCheck(el, linkingEvent, referencedEvent) &&


### PR DESCRIPTION
### Description
The current EventLinkNormalizer would from time to time on initial load randomly fire twice and re-add the same events to the _linkedEventsArray

This causes an issue where statistics that depend on this just are 2x the value as expected

You can test this with applying a Time Filter as it will retrigger event normalization (for some reason) causing the bug

Personally, I don't like this approach as it just adds a lot of un-needed looping of events but I couldn't think of another way to do this without making events themselves more complex