### PR TITLE
[Prot Warrior] Ravager Hit Check + small updates

### DIFF
--- a/src/analysis/retail/warrior/protection/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/protection/CHANGELOG.tsx
@@ -2,9 +2,13 @@ import { change, date } from 'common/changelog';
 import { TALENTS_WARRIOR } from 'common/TALENTS';
 import { SpellLink } from 'interface';
 import { Abelito75, Greedyhugs, ToppleTheNun, CodersKitchen } from 'CONTRIBUTORS';
+import SPELLS from 'common/SPELLS';
 
 // prettier-ignore
 export default [
+  change(date(2023, 8, 6), <>Updated <SpellLink spell={TALENTS_WARRIOR.HEAVY_REPERCUSSIONS_TALENT}/> rage generation</>, Abelito75),
+  change(date(2023, 8, 6), <>Added <SpellLink spell={TALENTS_WARRIOR.RAVAGER_TALENT}/> hit checker</>, Abelito75),
+  change(date(2023, 8, 6), <>Hide <SpellLink spell={TALENTS_WARRIOR.BATTLE_STANCE_TALENT}/>, <SpellLink spell={SPELLS.HEROIC_THROW}/>, <SpellLink spell={SPELLS.HAMSTRING}/>, <SpellLink spell={SPELLS.BATTLE_SHOUT}/>, <SpellLink spell={TALENTS_WARRIOR.HEROIC_LEAP_TALENT}/> and <SpellLink spell={TALENTS_WARRIOR.CHALLENGING_SHOUT_TALENT}/> </>, Abelito75),
   change(date(2023, 7, 18), 'Update abilities', Abelito75),
   change(date(2023, 7, 8), 'Update SpellLink usage.', ToppleTheNun),
   change(date(2023, 6, 25), 'Reduce CD of Shield Slam, when Honed Reflexes is skilled.', CodersKitchen),

--- a/src/analysis/retail/warrior/protection/CombatLogParser.ts
+++ b/src/analysis/retail/warrior/protection/CombatLogParser.ts
@@ -31,6 +31,7 @@ import Punish from './modules/spells/Punish';
 import WarMachine from './modules/spells/WarMachine';
 import SpellReflection from '../shared/modules/talents/SpellReflection';
 import ImpendingVictory from '../shared/modules/talents/ImpendingVictory';
+import RavagerHitCheck from './modules/spells/RavagerHitCheck';
 
 //legendaries
 
@@ -73,6 +74,7 @@ class CombatLogParser extends CoreCombatLogParser {
     violentOutburstTimeBetweenBuffs: ViolentOutburstTimeBetweenBuffs,
     spellReflection: SpellReflection,
     impendingVictory: ImpendingVictory,
+    ravagerHitCheck: RavagerHitCheck,
   };
 }
 

--- a/src/analysis/retail/warrior/protection/modules/Abilities.ts
+++ b/src/analysis/retail/warrior/protection/modules/Abilities.ts
@@ -40,7 +40,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
-        category: SPELL_CATEGORY.UTILITY,
+        category: SPELL_CATEGORY.HIDDEN,
       },
       {
         spell: SPELLS.VICTORY_RUSH.id,
@@ -78,7 +78,7 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.BATTLE_SHOUT.id,
-        category: SPELL_CATEGORY.UTILITY,
+        category: SPELL_CATEGORY.HIDDEN,
         gcd: {
           base: 1500,
         },
@@ -98,7 +98,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
-        category: SPELL_CATEGORY.OTHERS,
+        category: SPELL_CATEGORY.HIDDEN,
       },
       {
         spell: SPELLS.DEVASTATE.id,
@@ -115,7 +115,7 @@ class Abilities extends CoreAbilities {
         enabled:
           combatant.hasTalent(TALENTS.BATTLE_STANCE_TALENT) ||
           combatant.hasTalent(TALENTS.DEFENSIVE_STANCE_TALENT),
-        category: SPELL_CATEGORY.OTHERS,
+        category: SPELL_CATEGORY.HIDDEN,
         cooldown: 3000,
       },
       {
@@ -178,7 +178,7 @@ class Abilities extends CoreAbilities {
       {
         spell: TALENTS.HEROIC_LEAP_TALENT.id,
         enabled: combatant.hasTalent(TALENTS.HEROIC_LEAP_TALENT),
-        category: SPELL_CATEGORY.UTILITY,
+        category: SPELL_CATEGORY.HIDDEN,
         cooldown: 45 - (combatant.hasTalent(TALENTS.BOUNDING_STRIDE_TALENT) ? 15 : 0),
       },
       {
@@ -325,7 +325,7 @@ class Abilities extends CoreAbilities {
           combatant.hasTalent(TALENTS.CHALLENGING_SHOUT_TALENT) &&
           !combatant.hasTalent(TALENTS.DISRUPTING_SHOUT_TALENT),
 
-        category: SPELL_CATEGORY.UTILITY,
+        category: SPELL_CATEGORY.HIDDEN,
         cooldown: 90,
       },
       {

--- a/src/analysis/retail/warrior/protection/modules/features/Checklist/Component.tsx
+++ b/src/analysis/retail/warrior/protection/modules/features/Checklist/Component.tsx
@@ -54,9 +54,6 @@ const ProtectionWarriorChecklist = ({ combatant, castEfficiency, thresholds }: C
           combatant.hasTalent(TALENTS.DEMORALIZING_SHOUT_TALENT) && (
             <AbilityRequirement spell={SPELLS.DEMORALIZING_SHOUT.id} />
           )}
-        {combatant.hasTalent(TALENTS.THUNDEROUS_ROAR_TALENT) && (
-          <AbilityRequirement spell={TALENTS.THUNDEROUS_ROAR_TALENT.id} />
-        )}
       </Rule>
 
       <Rule
@@ -90,7 +87,7 @@ const ProtectionWarriorChecklist = ({ combatant, castEfficiency, thresholds }: C
         description={
           <>
             Using <SpellLink spell={TALENTS.AVATAR_PROTECTION_TALENT} /> as often as possible is
-            very important because it will increase your overall damage a lot and provides 30{' '}
+            very important because it will increase your overall damage a lot and provides 10{' '}
             <ResourceLink id={RESOURCE_TYPES.RAGE.id} />.<br /> If you are also using{' '}
             <SpellLink spell={TALENTS.UNSTOPPABLE_FORCE_TALENT} /> remember that{' '}
             <SpellLink spell={TALENTS.THUNDER_CLAP_PROTECTION_TALENT} /> will have a reduced
@@ -101,10 +98,23 @@ const ProtectionWarriorChecklist = ({ combatant, castEfficiency, thresholds }: C
         <TalentCastEfficiencyRequirement talent={TALENTS.AVATAR_PROTECTION_TALENT} />
         <TalentCastEfficiencyRequirement talent={TALENTS.DEMORALIZING_SHOUT_TALENT} />
         <TalentCastEfficiencyRequirement talent={TALENTS.RAVAGER_TALENT} />
+        {combatant.hasTalent(TALENTS.RAVAGER_TALENT) && (
+          <Requirement
+            name={
+              <>
+                <SpellLink spell={TALENTS.RAVAGER_TALENT} /> Effective Hits
+              </>
+            }
+            thresholds={thresholds.ravagerHitCheck}
+          />
+        )}
         <TalentCastEfficiencyRequirement talent={TALENTS.SHIELD_CHARGE_TALENT} />
         <TalentCastEfficiencyRequirement talent={TALENTS.SPEAR_OF_BASTION_TALENT} />
         {combatant.hasTalent(TALENTS.SONIC_BOOM_TALENT) && (
           <AbilityRequirement spell={TALENTS.SHOCKWAVE_TALENT.id} />
+        )}
+        {combatant.hasTalent(TALENTS.THUNDEROUS_ROAR_TALENT) && (
+          <AbilityRequirement spell={TALENTS.THUNDEROUS_ROAR_TALENT.id} />
         )}
       </Rule>
 

--- a/src/analysis/retail/warrior/protection/modules/features/Checklist/Module.tsx
+++ b/src/analysis/retail/warrior/protection/modules/features/Checklist/Module.tsx
@@ -12,6 +12,7 @@ import SpellReflect from '../../spells/SpellReflect';
 import AlwaysBeCasting from '../AlwaysBeCasting';
 import BlockCheck from '../BlockCheck';
 import Component from './Component';
+import RavagerHitCheck from '../../spells/RavagerHitCheck';
 
 class Checklist extends BaseChecklist {
   static dependencies = {
@@ -27,6 +28,7 @@ class Checklist extends BaseChecklist {
     shieldBlock: ShieldBlock,
     blockCheck: BlockCheck,
     spellReflect: SpellReflect,
+    ravagerHitCheck: RavagerHitCheck,
   };
   protected combatants!: Combatants;
   protected castEfficiency!: CastEfficiency;
@@ -39,6 +41,7 @@ class Checklist extends BaseChecklist {
   protected shieldBlock!: ShieldBlock;
   protected blockCheck!: BlockCheck;
   protected spellReflect!: SpellReflect;
+  protected ravagerHitCheck!: RavagerHitCheck;
 
   render() {
     return (
@@ -53,6 +56,7 @@ class Checklist extends BaseChecklist {
           shieldBlock: this.shieldBlock.suggestionThresholds,
           blockCheck: this.blockCheck.suggestionThresholds,
           spellReflect: this.spellReflect.suggestionThresholds,
+          ravagerHitCheck: this.ravagerHitCheck.averageHitSuggestionThresholds,
         }}
       />
     );

--- a/src/analysis/retail/warrior/protection/modules/spells/HeavyRepercussions.tsx
+++ b/src/analysis/retail/warrior/protection/modules/spells/HeavyRepercussions.tsx
@@ -14,6 +14,8 @@ import TALENTS from 'common/TALENTS/warrior';
 import RageTracker from '../core/RageTracker';
 
 const HEAVY_REPERCUSSIONS_SHIELD_BLOCK_EXTEND_MS = 1000;
+const RAGE_FROM_BASE = 15;
+const EXTRA_RAGE_PER_SLAM = 2;
 
 class HeavyRepercussions extends Analyzer {
   static dependencies = {
@@ -87,7 +89,10 @@ class HeavyRepercussions extends Analyzer {
 
     const rageByShieldSlam = this.rageTracker.getGeneratedBySpell(SPELLS.SHIELD_SLAM.id);
     const rageWastedByShieldSlam = this.rageTracker.getWastedBySpell(SPELLS.SHIELD_SLAM.id);
-    const rageFromTalent = ((rageByShieldSlam + rageWastedByShieldSlam) / 18) * 3;
+    const rageFromTalent = (
+      ((rageByShieldSlam + rageWastedByShieldSlam) / (RAGE_FROM_BASE + EXTRA_RAGE_PER_SLAM)) *
+      EXTRA_RAGE_PER_SLAM
+    ).toFixed(0);
 
     return (
       <Statistic

--- a/src/analysis/retail/warrior/protection/modules/spells/RavagerHitCheck.tsx
+++ b/src/analysis/retail/warrior/protection/modules/spells/RavagerHitCheck.tsx
@@ -1,0 +1,120 @@
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import TALENTS from 'common/TALENTS/warrior';
+import BoringValue from 'parser/ui/BoringValueText';
+import { SpellLink } from 'interface';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
+
+const HIT_BUFFER = 200;
+const DANCE_OF_DEATH_BUGGED = true;
+
+/**
+ * Ravager can hit up to 6 times per cast but since its a ground based ability targets can leave the area.
+ * Make sure it hits all times.
+ * This is an AoE ability so we need to do timestamp checking... Hate everything
+ *
+ * Bug: Ravager casted from range will only hit 5 times. This is bad and should only be cast in melee so showing 5/6 is fine (also not checkable)
+ * Bug: Dance of Death extends the duration by 2 seconds but doesn't actually proc an extra hit (is checkable so will add boolean flag for when fixed)
+ */
+class RavagerHitCheck extends Analyzer {
+  casts: number = 0;
+  ticksHit: number = 0;
+
+  lastHit: number = 0;
+
+  expectedHitsPerCast: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.RAVAGER_TALENT);
+    if (!this.active) {
+      return;
+    }
+
+    this.expectedHitsPerCast = DANCE_OF_DEATH_BUGGED
+      ? 6
+      : this.selectedCombatant.hasTalent(TALENTS.DANCE_OF_DEATH_PROTECTION_TALENT)
+      ? 7
+      : 6;
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.RAVAGER_TALENT),
+      this.onCast,
+    );
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.RAVAGER_DAMAGE),
+      this.onDamage,
+    );
+  }
+
+  onCast(event: CastEvent) {
+    this.casts += 1;
+  }
+
+  onDamage(event: DamageEvent) {
+    // Since this is an AoE ability we have to make sure we aren't counting duplicate hits on the same tick
+    if (this.lastHit + HIT_BUFFER > event.timestamp) {
+      return;
+    }
+
+    this.lastHit = event.timestamp;
+    this.ticksHit += 1;
+  }
+
+  get averageTargetsHit() {
+    return this.ticksHit / this.casts;
+  }
+
+  get averageHitSuggestionThresholds() {
+    return {
+      actual: this.averageTargetsHit,
+      isLessThan: {
+        major: this.expectedHitsPerCast - 1,
+        average: this.expectedHitsPerCast - 0.5,
+        minor: this.expectedHitsPerCast - 0.25,
+      },
+      style: ThresholdStyle.DECIMAL,
+    };
+  }
+
+  suggestions(when: When) {
+    when(this.averageHitSuggestionThresholds).addSuggestion((suggest, actual, recommended) =>
+      suggest(
+        <>
+          <SpellLink spell={TALENTS.RAVAGER_TALENT} /> works in "pulses" where each pulse will do
+          damage and generate rage. You should try to make every pulse hit at least 1 target as this
+          will increase your damage and rage.
+        </>,
+      )
+        .icon(TALENTS.RAVAGER_TALENT.icon)
+        .actual(`${actual} pulses with a hit`)
+        .recommended(`${recommended} is recommended`),
+    );
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(13)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+      >
+        <BoringValue
+          label={
+            <>
+              <SpellLink spell={TALENTS.RAVAGER_TALENT} /> Hits per Cast
+            </>
+          }
+        >
+          {this.averageTargetsHit}
+        </BoringValue>
+      </Statistic>
+    );
+  }
+}
+
+export default RavagerHitCheck;


### PR DESCRIPTION
### Description

Ravager hit check
Ravager pulses 6 times per cast, we want to make sure each pulse has 1 target
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/25177817/3a165bd6-c05b-4f22-bb59-f029548c7d53)

Changed the category of a few spells per Mwahi's request
Some 10.1.0 -> 10.1.5 updates
