### PR TITLE
[Core] Fix double processing of event links

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -27,6 +27,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 8, 7), 'Refactor EventLinkNormalizer', Trevor),
   change(date(2023, 8, 7), 'Remove some deprecated code.', ToppleTheNun),
   change(date(2023, 7, 31), <>Add enchantment check for <ItemLink id={ITEMS.SHADOWED_BELT_CLASP_R3.id} />.</>,  ToppleTheNun),
   change(date(2023, 7, 29), 'Fix another issue loading parses using character search', emallson),

--- a/src/parser/core/EventLinkNormalizer.ts
+++ b/src/parser/core/EventLinkNormalizer.ts
@@ -151,12 +151,12 @@ abstract class EventLinkNormalizer extends EventsNormalizer {
   }
 
   normalize(events: AnyEvent[]): AnyEvent[] {
-    // check each event link directive
+    // loop through all events in order
     events.forEach((event: AnyEvent, eventIndex: number) => {
       if (event._processedLinks) {
         return;
       }
-      // loop through all events in order
+      // check each event link directive
       this.eventLinks.forEach((el: EventLink) => {
         // if we find a match of a linking ability
         if (!el.isActive || el.isActive(this.selectedCombatant)) {

--- a/src/parser/core/EventLinkNormalizer.ts
+++ b/src/parser/core/EventLinkNormalizer.ts
@@ -152,11 +152,14 @@ abstract class EventLinkNormalizer extends EventsNormalizer {
 
   normalize(events: AnyEvent[]): AnyEvent[] {
     // check each event link directive
-    this.eventLinks.forEach((el: EventLink) => {
-      if (!el.isActive || el.isActive(this.selectedCombatant)) {
-        // loop through all events in order
-        events.forEach((event: AnyEvent, eventIndex: number) => {
-          // if we find a match of a linking ability
+    events.forEach((event: AnyEvent, eventIndex: number) => {
+      if (event._processedLinks) {
+        return;
+      }
+      // loop through all events in order
+      this.eventLinks.forEach((el: EventLink) => {
+        // if we find a match of a linking ability
+        if (!el.isActive || el.isActive(this.selectedCombatant)) {
           if (this._isLinking(el, event)) {
             let linksMade = 0;
             const maxLinks =
@@ -192,8 +195,9 @@ abstract class EventLinkNormalizer extends EventsNormalizer {
               }
             }
           }
-        });
-      }
+        }
+      });
+      event._processedLinks = true;
     });
     return events;
   }

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -330,7 +330,7 @@ export interface Event<T extends string> {
   prepull?: boolean;
   /** Other events associated with this event. Added by WoWA normalizers. Meaning is context sensitive */
   _linkedEvents?: LinkedEvent[];
-  // true if links have been processed for this
+  // true if links have been processed for this event to prevent duplicate linking
   _processedLinks?: boolean;
   /** True iff the event was created by WoWA */
   __fabricated?: boolean;

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -330,6 +330,8 @@ export interface Event<T extends string> {
   prepull?: boolean;
   /** Other events associated with this event. Added by WoWA normalizers. Meaning is context sensitive */
   _linkedEvents?: LinkedEvent[];
+  // true if links have been processed for this
+  _processedLinks?: boolean;
   /** True iff the event was created by WoWA */
   __fabricated?: boolean;
   /** True iff the event's content was modified by WoWA */


### PR DESCRIPTION
We have an issue where we process an event multiple times in the eventlinknormalizer. This PR adds a field to the event to mark it as processed so we don't accidentally process it multiple times. 

Before:

![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/a81699ca-3dd2-4b24-b113-fa0afee694ff)

After

![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/d5b720d9-4573-4f90-a033-c337debb0e83)
