### PR TITLE
fix eventlink bug and dont break everything this time

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -27,6 +27,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 8, 8), 'Fix bug in EventLinkNormalizer', Trevor),
   change(date(2023, 8, 8), 'Deduplicate the dependencies of the project', Putro),
   change(date(2023, 8, 7), 'Remove some deprecated code.', ToppleTheNun),
   change(date(2023, 7, 31), <>Add enchantment check for <ItemLink id={ITEMS.SHADOWED_BELT_CLASP_R3.id} />.</>,  ToppleTheNun),

--- a/src/parser/core/EventLinkNormalizer.ts
+++ b/src/parser/core/EventLinkNormalizer.ts
@@ -156,6 +156,12 @@ abstract class EventLinkNormalizer extends EventsNormalizer {
       if (!el.isActive || el.isActive(this.selectedCombatant)) {
         // loop through all events in order
         events.forEach((event: AnyEvent, eventIndex: number) => {
+          if (event._processedLinks == null) {
+            event._processedLinks = new Set<EventLink>();
+          } else if (event._processedLinks?.has(el)) {
+            return;
+          }
+          event._processedLinks!.add(el);
           // if we find a match of a linking ability
           if (this._isLinking(el, event)) {
             let linksMade = 0;

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -5,6 +5,7 @@ import * as React from 'react';
 import EventFilter from './EventFilter';
 import { PetInfo } from './Pet';
 import { PlayerInfo } from './Player';
+import { EventLink } from './EventLinkNormalizer';
 
 export enum EventType {
   Destroy = 'destroy', // super rare, apparently happens on dausegne, no idea what it is?
@@ -330,6 +331,8 @@ export interface Event<T extends string> {
   prepull?: boolean;
   /** Other events associated with this event. Added by WoWA normalizers. Meaning is context sensitive */
   _linkedEvents?: LinkedEvent[];
+  // true if links have been processed for this event to prevent duplicate linking
+  _processedLinks?: Set<EventLink>;
   /** True iff the event was created by WoWA */
   __fabricated?: boolean;
   /** True iff the event's content was modified by WoWA */

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -331,7 +331,7 @@ export interface Event<T extends string> {
   prepull?: boolean;
   /** Other events associated with this event. Added by WoWA normalizers. Meaning is context sensitive */
   _linkedEvents?: LinkedEvent[];
-  // true if links have been processed for this event to prevent duplicate linking
+  /** Set of eventLinks that have been processed already to avoid duplicated linking */
   _processedLinks?: Set<EventLink>;
   /** True iff the event was created by WoWA */
   __fabricated?: boolean;


### PR DESCRIPTION
### Description

Caches which eventlinks we've processed for a specific event to avoid double prcoessing an event link.

### Testing

Tested fix on MW and verified that disc/brew did not break manually

- Screenshot(s):
- Before
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/af19776b-fed3-4506-b5bd-bc98199e29f8)

After
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/22e49e47-d5a3-4f96-9d05-1a5facce2b32)

