### PR TITLE
[Shadow] Improve Inescapable Torment Talent

### DIFF
--- a/src/analysis/retail/priest/shadow/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/shadow/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { DoxAshe, Havoc, ToppleTheNun } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 8, 8), <>Improve <SpellLink spell={TALENTS.INESCAPABLE_TORMENT_TALENT}/> duration extension tracking and guide view,</>,DoxAshe),
   change(date(2023, 8, 2), <>Add statistic for <SpellLink spell={TALENTS.ANCIENT_MADNESS_TALENT}/> damage contribution,</>,DoxAshe),
   change(date(2023, 7, 26), <>Update suggestions for spell usage in guide view for 10.1.5</>,DoxAshe),
   change(date(2023, 7, 3), 'Update SpellLink usage.', ToppleTheNun),

--- a/src/analysis/retail/priest/shadow/Guide.tsx
+++ b/src/analysis/retail/priest/shadow/Guide.tsx
@@ -37,6 +37,8 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
           <CooldownGraphSubsection.LongCooldownsGraph />
           {info.combatant.hasTalent(TALENTS.VOID_ERUPTION_TALENT) &&
             modules.voidform.guideSubsection}
+          {info.combatant.hasTalent(TALENTS.INESCAPABLE_TORMENT_TALENT) &&
+            modules.inescapableTorment.guideSubsection}
           {info.combatant.hasTalent(TALENTS.TWINS_OF_THE_SUN_PRIESTESS_TALENT) &&
             modules.twinsOfTheSunPriestess.guideSubsection}
         </Section>

--- a/src/analysis/retail/priest/shadow/modules/talents/InescapableTorment.tsx
+++ b/src/analysis/retail/priest/shadow/modules/talents/InescapableTorment.tsx
@@ -36,9 +36,7 @@ class InescapableTorment extends Analyzer {
     this.addEventListener(Events.fightend, this.onEnd);
   }
 
-  onCast(event: CastEvent) {
-    //Since there is no way to tell when mindbender ends, we resolve the previous Mindbender when a new one is cast.
-    //If this is not the first mindbender cast, then we generate the extension.
+  private finalizeMindBenderCast() {
     if (this.castTime !== 0) {
       const tooltip = (
         <>
@@ -57,6 +55,12 @@ class InescapableTorment extends Analyzer {
 
       this.MBExtension.push({ value, tooltip });
     }
+  }
+
+  onCast(event: CastEvent) {
+    //Since there is no way to tell when mindbender ends, we resolve the previous Mindbender when a new one is cast.
+    //If this is not the first mindbender cast, then we generate the extension.
+    this.finalizeMindBenderCast();
 
     this.totalTime += this.extension; // add previous extension to total time.
     this.castTime = event.timestamp; //get cast time for current mindbender.
@@ -66,24 +70,7 @@ class InescapableTorment extends Analyzer {
   onEnd(event: FightEndEvent) {
     //Since there is no way to tell when mindbender ends, we resolve the last Mindbender when the fight is over.
     //So long as a mindbender was cast, we generate the extension.
-    if (this.castTime !== 0) {
-      const tooltip = (
-        <>
-          @<strong>{this.owner.formatTimestamp(this.castTime)}</strong>, Extension:
-          <strong>{this.extension.toFixed(1)}</strong>
-        </>
-      );
-
-      let value = QualitativePerformance.Good;
-      if (this.extension <= 6) {
-        value = QualitativePerformance.Ok;
-      }
-      if (this.extension <= 3) {
-        value = QualitativePerformance.Fail;
-      }
-
-      this.MBExtension.push({ value, tooltip });
-    }
+    this.finalizeMindBenderCast();
 
     this.totalTime += this.extension; // add previous extension to total time.
   }

--- a/src/analysis/retail/priest/shadow/modules/talents/InescapableTorment.tsx
+++ b/src/analysis/retail/priest/shadow/modules/talents/InescapableTorment.tsx
@@ -1,18 +1,25 @@
 import TALENTS from 'common/TALENTS/priest';
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options } from 'parser/core/Analyzer';
-import { SELECTED_PLAYER_PET } from 'parser/core/EventFilter';
-import Events, { DamageEvent } from 'parser/core/Events';
+import { SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/EventFilter';
+import Events, { CastEvent, DamageEvent, FightEndEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import UptimeIcon from 'interface/icons/Uptime';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import { INESCAPABLE_TORMENT_EXTENSION } from '../../constants';
+import { SpellLink } from 'interface';
+import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 
 class InescapableTorment extends Analyzer {
-  damage = 0;
-  time = 0;
+  damage: number = 0;
+  totalTime: number = 0;
+  extension: number = 0;
+  castTime: number = 0;
+  MBExtension: BoxRowEntry[] = [];
 
   constructor(options: Options) {
     super(options);
@@ -21,11 +28,68 @@ class InescapableTorment extends Analyzer {
       Events.damage.by(SELECTED_PLAYER_PET).spell(SPELLS.INESCAPABLE_TORMENT_TALENT_DAMAGE),
       this.onDamage,
     );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.MINDBENDER_SHADOW_TALENT),
+      this.onCast,
+    );
+    this.addEventListener(Events.fightend, this.onEnd);
+  }
+
+  onCast(event: CastEvent) {
+    //Since there is no way to tell when mindbender ends, we resolve the previous Mindbender when a new one is cast.
+    //If this is not the first mindbender cast, then we generate the extension.
+    if (this.castTime !== 0) {
+      const tooltip = (
+        <>
+          @<strong>{this.owner.formatTimestamp(this.castTime)}</strong>, Extension:
+          <strong>{this.extension.toFixed(1)}</strong>
+        </>
+      );
+
+      let value = QualitativePerformance.Good;
+      if (this.extension <= 7) {
+        value = QualitativePerformance.Ok;
+      }
+      if (this.extension <= 4) {
+        value = QualitativePerformance.Fail;
+      }
+
+      this.MBExtension.push({ value, tooltip });
+    }
+
+    this.totalTime += this.extension; // add previous extension to total time.
+    this.castTime = event.timestamp; //get cast time for current mindbender.
+    this.extension = 0; // reset extension.
+  }
+
+  onEnd(event: FightEndEvent) {
+    //Since there is no way to tell when mindbender ends, we resolve the last Mindbender when the fight is over.
+    //So long as a mindbender was cast, we generate the extension.
+    if (this.castTime !== 0) {
+      const tooltip = (
+        <>
+          @<strong>{this.owner.formatTimestamp(this.castTime)}</strong>, Extension:
+          <strong>{this.extension.toFixed(1)}</strong>
+        </>
+      );
+
+      let value = QualitativePerformance.Good;
+      if (this.extension <= 7) {
+        value = QualitativePerformance.Ok;
+      }
+      if (this.extension <= 4) {
+        value = QualitativePerformance.Fail;
+      }
+
+      this.MBExtension.push({ value, tooltip });
+    }
+
+    this.totalTime += this.extension; // add previous extension to total time.
   }
 
   onDamage(event: DamageEvent) {
     this.damage += event.amount + (event.absorbed || 0);
-    this.time +=
+    this.extension +=
       INESCAPABLE_TORMENT_EXTENSION *
       this.selectedCombatant.getTalentRank(TALENTS.INESCAPABLE_TORMENT_TALENT);
   }
@@ -38,11 +102,38 @@ class InescapableTorment extends Analyzer {
             <ItemDamageDone amount={this.damage} />{' '}
           </div>
           <div>
-            <UptimeIcon /> {this.time}s <small>of mindbender extension</small>{' '}
+            <UptimeIcon /> {this.totalTime.toFixed(1)}s <small>of mindbender extension</small>{' '}
           </div>
         </BoringSpellValueText>
       </Statistic>
     );
+  }
+
+  get guideSubsection(): JSX.Element {
+    const explanation = (
+      <p>
+        <b>
+          <SpellLink spell={TALENTS.MINDBENDER_SHADOW_TALENT} />
+        </b>{' '}
+        is a powerful cooldown when talented into{' '}
+        <SpellLink spell={TALENTS.INESCAPABLE_TORMENT_TALENT} />.
+        <br />
+        Casting <SpellLink spell={SPELLS.MIND_BLAST} /> or{' '}
+        <SpellLink spell={TALENTS.SHADOW_WORD_DEATH_TALENT} /> during{' '}
+        <SpellLink spell={TALENTS.MINDBENDER_SHADOW_TALENT} /> extends its duration by 0.7 seconds
+        and deals damage. Try to use these spells as much as possible in this window.
+      </p>
+    );
+
+    const data = (
+      <div>
+        <strong>Mindbender Extension</strong>
+        <br />
+        <UptimeIcon /> <strong>{this.totalTime.toFixed(1)}</strong> <small> seconds</small>
+        <PerformanceBoxRow values={this.MBExtension} />
+      </div>
+    );
+    return explanationAndDataSubsection(explanation, data, 50);
   }
 }
 

--- a/src/analysis/retail/priest/shadow/modules/talents/InescapableTorment.tsx
+++ b/src/analysis/retail/priest/shadow/modules/talents/InescapableTorment.tsx
@@ -126,7 +126,7 @@ class InescapableTorment extends Analyzer {
         Casting <SpellLink spell={SPELLS.MIND_BLAST} /> or{' '}
         <SpellLink spell={TALENTS.SHADOW_WORD_DEATH_TALENT} /> during{' '}
         <SpellLink spell={TALENTS.MINDBENDER_SHADOW_TALENT} /> extends its duration by 0.7 seconds
-        and deals damage. Try to use these spells as much as possible in this window.
+        and deals damage.
       </p>
     );
 

--- a/src/analysis/retail/priest/shadow/modules/talents/InescapableTorment.tsx
+++ b/src/analysis/retail/priest/shadow/modules/talents/InescapableTorment.tsx
@@ -20,6 +20,7 @@ class InescapableTorment extends Analyzer {
   extension: number = 0;
   castTime: number = 0;
   MBExtension: BoxRowEntry[] = [];
+  recentIT: number = 0;
 
   constructor(options: Options) {
     super(options);
@@ -89,9 +90,13 @@ class InescapableTorment extends Analyzer {
 
   onDamage(event: DamageEvent) {
     this.damage += event.amount + (event.absorbed || 0);
-    this.extension +=
-      INESCAPABLE_TORMENT_EXTENSION *
-      this.selectedCombatant.getTalentRank(TALENTS.INESCAPABLE_TORMENT_TALENT);
+    //Inescapable Torment can hit 5 targets at once, but it only gives the extension for the first one hit.
+    if (event.timestamp !== this.recentIT) {
+      this.extension +=
+        INESCAPABLE_TORMENT_EXTENSION *
+        this.selectedCombatant.getTalentRank(TALENTS.INESCAPABLE_TORMENT_TALENT);
+    }
+    this.recentIT = event.timestamp;
   }
 
   statistic() {

--- a/src/analysis/retail/priest/shadow/modules/talents/InescapableTorment.tsx
+++ b/src/analysis/retail/priest/shadow/modules/talents/InescapableTorment.tsx
@@ -48,10 +48,10 @@ class InescapableTorment extends Analyzer {
       );
 
       let value = QualitativePerformance.Good;
-      if (this.extension <= 7) {
+      if (this.extension <= 6) {
         value = QualitativePerformance.Ok;
       }
-      if (this.extension <= 4) {
+      if (this.extension <= 3) {
         value = QualitativePerformance.Fail;
       }
 
@@ -75,10 +75,10 @@ class InescapableTorment extends Analyzer {
       );
 
       let value = QualitativePerformance.Good;
-      if (this.extension <= 7) {
+      if (this.extension <= 6) {
         value = QualitativePerformance.Ok;
       }
-      if (this.extension <= 4) {
+      if (this.extension <= 3) {
         value = QualitativePerformance.Fail;
       }
 


### PR DESCRIPTION
### Description

With the most recent balance patch, shadow's best build has changed to include the Inescapable Torment Talent.  This adds additional analysis to the talent in the guide view and breaks down the amount of mindbender extension the talent gives per cast instead of only the total extension.
This also fixes the talent showing more extension than it should when hitting multiple targets.

### Testing

It is difficult to track the duration of mindbender since it is a pet, so I directly calculated the amount of extension based upon each damage instance of inescapable torment.  I think using the next cast or end of fight is the only way to tell which damage events go with what cast of mindbender, but if there is a better way to do this I can change it.

- Test report URL: `/report/T9cKJWvgy7V2fD4n/1-Heroic+Kazzara,+the+Hellforged+-+Kill+(2:19)/Mollify/standard/overview`
- Screenshot(s):

![InescapleTorment](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/103148620/d714b5b3-f2be-4586-a5ae-df99c939bf28)

