### PR TITLE
disable augvoker M+ analysis

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -27,6 +27,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 8, 9), 'Disable Augmentation Evoker analysis in M+.', ToppleTheNun),
   change(date(2023, 8, 8), 'Fix bug in EventLinkNormalizer', Trevor),
   change(date(2023, 8, 8), 'Deduplicate the dependencies of the project', Putro),
   change(date(2023, 8, 7), 'Remove some deprecated code.', ToppleTheNun),

--- a/src/common/isFightDungeon.ts
+++ b/src/common/isFightDungeon.ts
@@ -1,0 +1,14 @@
+import { WCLFight } from 'parser/core/Fight';
+import mythicplusseasonone from 'game/raids/mythicplusseasonone';
+import mythicplusseasontwo from 'game/raids/mythicplusseasontwo';
+import typedKeys from 'common/typedKeys';
+
+const mythicPlusSeasonOneDungeons = typedKeys(mythicplusseasonone.bosses).map(
+  (key) => mythicplusseasonone.bosses[key].id,
+);
+const mythicPlusSeasonTwoDungeons = typedKeys(mythicplusseasontwo.bosses).map(
+  (key) => mythicplusseasontwo.bosses[key].id,
+);
+const dungeons = [...mythicPlusSeasonOneDungeons, ...mythicPlusSeasonTwoDungeons];
+
+export const isFightDungeon = (fight: WCLFight) => dungeons.includes(fight.boss);

--- a/src/interface/report/PlayerTile.tsx
+++ b/src/interface/report/PlayerTile.tsx
@@ -16,6 +16,9 @@ import { useWaDispatch } from 'interface/utils/useWaDispatch';
 import { useWaSelector } from 'interface/utils/useWaSelector';
 import { makeThumbnailUrl } from 'interface/makeAnalyzerUrl';
 import { useLingui } from '@lingui/react';
+import SPECS from 'game/SPECS';
+import { isFightDungeon } from 'common/isFightDungeon';
+import { useFight } from 'interface/report/context/FightContext';
 
 interface Props {
   player: Player;
@@ -28,6 +31,7 @@ const PlayerTile = ({ player, makeUrl, config }: Props) => {
   const characterInfo = useWaSelector((state) => getCharacterById(state, player.guid));
   const dispatch = useWaDispatch();
   const { i18n } = useLingui();
+  const { fight } = useFight();
 
   useEffect(() => {
     const load = async () => {
@@ -98,6 +102,41 @@ const PlayerTile = ({ player, makeUrl, config }: Props) => {
           <div className="avatar" style={{ backgroundImage: `url(${avatar})` }} />
           <div className="about">
             <h1>{player.name}</h1>
+          </div>
+        </div>
+      </span>
+    );
+  }
+  if (spec.id === SPECS.AUGMENTATION_EVOKER.id && isFightDungeon(fight)) {
+    return (
+      <span
+        className="player"
+        onClick={() => {
+          alert(
+            `Augmentation Evoker is not currently supported for M+ logs due to issues with retrieving the appropriate data for analysis. Augmentation is still supported for raid and we hope to re-enable it for M+ soon.`,
+          );
+        }}
+      >
+        <div className="role" />
+        <div className="card">
+          <div className="avatar" style={{ backgroundImage: `url(${avatar})` }} />
+          <div className="about">
+            <h1
+              className={i18n._(spec.className).replace(' ', '')}
+              // The name can't always fit so use a tooltip. We use title instead of the tooltip library for this because we don't want it to be distracting and the tooltip library would popup when hovering just to click an item, while this has a delay.
+              title={player.name}
+            >
+              {player.name}
+            </h1>
+            <small title={`${specName} ${className}`}>
+              <SpecIcon spec={spec} /> {specName} {className}
+            </small>
+            <div className="flex text-muted text-small">
+              <div className="flex-main">
+                <Icon icon="inv_helmet_03" />{' '}
+                {Math.round(getAverageItemLevel(player.combatant.gear))}
+              </div>
+            </div>
           </div>
         </div>
       </span>

--- a/src/interface/report/PlayerTile.tsx
+++ b/src/interface/report/PlayerTile.tsx
@@ -7,7 +7,7 @@ import SpecIcon from 'interface/SpecIcon';
 import Config from 'parser/Config';
 import Player from 'parser/core/Player';
 import getBuild from 'parser/getBuild';
-import { useEffect } from 'react';
+import { ReactNode, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { isSupportedRegion } from 'common/regions';
 import { CLASSIC_EXPANSION, CLASSIC_EXPANSION_NAME } from 'game/Expansion';
@@ -16,21 +16,89 @@ import { useWaDispatch } from 'interface/utils/useWaDispatch';
 import { useWaSelector } from 'interface/utils/useWaSelector';
 import { makeThumbnailUrl } from 'interface/makeAnalyzerUrl';
 import { useLingui } from '@lingui/react';
-import SPECS from 'game/SPECS';
+import SPECS, { Spec } from 'game/SPECS';
 import { isFightDungeon } from 'common/isFightDungeon';
 import { useFight } from 'interface/report/context/FightContext';
 
-interface Props {
+interface BlockLoadingProps {
+  children: ReactNode;
+  message: string;
+}
+const BlockLoading = ({ children, message }: BlockLoadingProps) => (
+  <span
+    className="player"
+    onClick={() => {
+      alert(message);
+    }}
+  >
+    {children}
+  </span>
+);
+
+interface BasicBlockLoadingProps extends Omit<BlockLoadingProps, 'children'> {
+  avatar: string;
+  player: Player;
+}
+const BasicBlockLoading = ({ avatar, player, ...props }: BasicBlockLoadingProps) => (
+  <BlockLoading {...props}>
+    <div className="role" />
+    <div className="card">
+      <div className="avatar" style={{ backgroundImage: `url(${avatar})` }} />
+      <div className="about">
+        <h1>{player.name}</h1>
+      </div>
+    </div>
+  </BlockLoading>
+);
+
+interface PlayerTileContentsProps {
+  avatar: string;
+  player: Player;
+  spec: Spec;
+}
+const PlayerTileContents = ({ avatar, player, spec }: PlayerTileContentsProps) => {
+  const { i18n } = useLingui();
+
+  const specName = spec?.specName ? i18n._(spec.specName) : undefined;
+  const className = spec?.className ? i18n._(spec.className) : undefined;
+
+  return (
+    <>
+      <div className="role" />
+      <div className="card">
+        <div className="avatar" style={{ backgroundImage: `url(${avatar})` }} />
+        <div className="about">
+          <h1
+            className={i18n._(spec.className).replace(' ', '')}
+            // The name can't always fit so use a tooltip. We use title instead of the tooltip library for this because we don't want it to be distracting and the tooltip library would popup when hovering just to click an item, while this has a delay.
+            title={player.name}
+          >
+            {player.name}
+          </h1>
+          <small title={`${specName} ${className}`}>
+            <SpecIcon spec={spec} /> {specName} {className}
+          </small>
+          <div className="flex text-muted text-small">
+            <div className="flex-main">
+              <Icon icon="inv_helmet_03" /> {Math.round(getAverageItemLevel(player.combatant.gear))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+interface PlayerTileProps {
   player: Player;
   makeUrl: (playerId: number, build?: string) => string;
   config?: Config;
 }
 
-const PlayerTile = ({ player, makeUrl, config }: Props) => {
+const PlayerTile = ({ player, makeUrl, config }: PlayerTileProps) => {
   const classic = player.combatant.expansion === CLASSIC_EXPANSION_NAME;
   const characterInfo = useWaSelector((state) => getCharacterById(state, player.guid));
   const dispatch = useWaDispatch();
-  const { i18n } = useLingui();
   const { fight } = useFight();
 
   useEffect(() => {
@@ -64,108 +132,36 @@ const PlayerTile = ({ player, makeUrl, config }: Props) => {
   const spec = config?.spec;
   const build = getBuild(config, player.combatant);
   const missingBuild = config?.builds && !build;
-  const specName = spec?.specName ? i18n._(spec.specName) : undefined;
-  const className = spec?.className ? i18n._(spec.className) : undefined;
 
   if (!config || missingBuild) {
     return (
-      <span
-        className="player"
-        onClick={() => {
-          alert(
-            `This player's spec is not currently supported for this expansion. WoWAnalyzer is a community project and requires volunteers to provide support for each spec. See GitHub for more information.`,
-          );
-        }}
-      >
-        <div className="role" />
-        <div className="card">
-          <div className="avatar" style={{ backgroundImage: `url(${avatar})` }} />
-          <div className="about">
-            <h1>{player.name}</h1>
-          </div>
-        </div>
-      </span>
+      <BasicBlockLoading
+        avatar={avatar}
+        message="This player's spec is not currently supported for this expansion. WoWAnalyzer is a community project and requires volunteers to provide support for each spec. See GitHub for more information."
+        player={player}
+      />
     );
   }
   if (player.combatant.error || !spec) {
     return (
-      <span
-        className="player"
-        onClick={() => {
-          alert(
-            `This player can not be parsed. Warcraft Logs ran into an error parsing the log and is not giving us all the necessary information. Please update your Warcraft Logs Uploader and reupload your log to try again.`,
-          );
-        }}
-      >
-        <div className="role" />
-        <div className="card">
-          <div className="avatar" style={{ backgroundImage: `url(${avatar})` }} />
-          <div className="about">
-            <h1>{player.name}</h1>
-          </div>
-        </div>
-      </span>
+      <BasicBlockLoading
+        avatar={avatar}
+        message="This player can not be parsed. Warcraft Logs ran into an error parsing the log and is not giving us all the necessary information. Please update your Warcraft Logs Uploader and reupload your log to try again."
+        player={player}
+      />
     );
   }
   if (spec.id === SPECS.AUGMENTATION_EVOKER.id && isFightDungeon(fight)) {
     return (
-      <span
-        className="player"
-        onClick={() => {
-          alert(
-            `Augmentation Evoker is not currently supported for M+ logs due to issues with retrieving the appropriate data for analysis. Augmentation is still supported for raid and we hope to re-enable it for M+ soon.`,
-          );
-        }}
-      >
-        <div className="role" />
-        <div className="card">
-          <div className="avatar" style={{ backgroundImage: `url(${avatar})` }} />
-          <div className="about">
-            <h1
-              className={i18n._(spec.className).replace(' ', '')}
-              // The name can't always fit so use a tooltip. We use title instead of the tooltip library for this because we don't want it to be distracting and the tooltip library would popup when hovering just to click an item, while this has a delay.
-              title={player.name}
-            >
-              {player.name}
-            </h1>
-            <small title={`${specName} ${className}`}>
-              <SpecIcon spec={spec} /> {specName} {className}
-            </small>
-            <div className="flex text-muted text-small">
-              <div className="flex-main">
-                <Icon icon="inv_helmet_03" />{' '}
-                {Math.round(getAverageItemLevel(player.combatant.gear))}
-              </div>
-            </div>
-          </div>
-        </div>
-      </span>
+      <BlockLoading message="Augmentation Evoker is not currently supported for M+ logs due to issues with retrieving the appropriate data for analysis. Augmentation is still supported for raid and we hope to re-enable it for M+ soon.">
+        <PlayerTileContents avatar={avatar} player={player} spec={spec} />
+      </BlockLoading>
     );
   }
 
   return (
-    <Link to={makeUrl(player.id, build?.url)} className={`player ${getClassName(spec?.role)}`}>
-      <div className="role" />
-      <div className="card">
-        <div className="avatar" style={{ backgroundImage: `url(${avatar})` }} />
-        <div className="about">
-          <h1
-            className={i18n._(spec.className).replace(' ', '')}
-            // The name can't always fit so use a tooltip. We use title instead of the tooltip library for this because we don't want it to be distracting and the tooltip library would popup when hovering just to click an item, while this has a delay.
-            title={player.name}
-          >
-            {player.name}
-          </h1>
-          <small title={`${specName} ${className}`}>
-            <SpecIcon spec={spec} /> {specName} {className}
-          </small>
-          <div className="flex text-muted text-small">
-            <div className="flex-main">
-              <Icon icon="inv_helmet_03" /> {Math.round(getAverageItemLevel(player.combatant.gear))}
-            </div>
-          </div>
-        </div>
-      </div>
+    <Link to={makeUrl(player.id, build?.url)} className={`player ${getClassName(spec.role)}`}>
+      <PlayerTileContents avatar={avatar} player={player} spec={spec} />
     </Link>
   );
 };


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Disable Augmentation Evoker analysis in M+ due to issues with retrieving events in a timely manner.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/Hd38L4fCYXjZ7yVR/10-Mythic++Neltharion's+Lair+-+Wipe+1+(41:28)`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/e3fcb6ad-608a-4115-9dde-5e36ef06c9db)
