### PR TITLE
fix combatant count in M+

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -27,6 +27,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 8, 9), 'Fix combatant count in M+.', ToppleTheNun),
   change(date(2023, 8, 9), 'Disable Augmentation Evoker analysis in M+.', ToppleTheNun),
   change(date(2023, 8, 8), 'Fix bug in EventLinkNormalizer', Trevor),
   change(date(2023, 8, 8), 'Deduplicate the dependencies of the project', Putro),

--- a/src/common/uniqueBy.ts
+++ b/src/common/uniqueBy.ts
@@ -1,0 +1,7 @@
+export const uniqueBy = <T, U>(arr: T[], selector: (item: T) => U): T[] => {
+  return arr.filter(
+    (toCheck, currentIdx) =>
+      arr.findIndex((possiblyFirst) => selector(possiblyFirst) === selector(toCheck)) ===
+      currentIdx,
+  );
+};


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Fix combatant count in M+ logs being wrong due to both:
- Double counting classes that have classic support
- Multiple combatantinfo events being logged in M+

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/Hd38L4fCYXjZ7yVR/1-Mythic++Freehold+-+Wipe+1+(17:50)`
- Screenshot(s):

**Before**
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/4d87ca0f-69f5-4214-93f6-a5ba96553950)

**After**
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/f0939ee1-29ec-4068-b4a8-1872764a2349)
