### PR TITLE
Fix/classic shadow priest Vampiric touch uptime

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2257,3 +2257,16 @@ export const Melnais: Contributor = {
   nickname: 'Melnais',
   github: 'agrabovskis',
 };
+
+export const beckeeh: Contributor = {
+  nickname: 'beckeeh',
+  github: 'lavjamanxd',
+  discord: 'beckeeh',
+  mains: [
+    {
+      name: 'Beckeeh',
+      spec: SPECS.SHADOW_PRIEST,
+      link: 'https://classic.warcraftlogs.com/character/eu/nethergarde-keep/beckeeh',
+    },
+  ],
+};

--- a/src/analysis/classic/priest/shadow/CHANGELOG.tsx
+++ b/src/analysis/classic/priest/shadow/CHANGELOG.tsx
@@ -1,8 +1,10 @@
 import { change, date } from 'common/changelog';
-import { jazminite, HerzBlutRaffy } from 'CONTRIBUTORS';
+import { jazminite, HerzBlutRaffy, beckeeh } from 'CONTRIBUTORS';
+import SpellLink from 'interface/SpellLink';
+import SPELLS from 'common/SPELLS/classic/priest';
 
 export default [
-  // Remove this entry and add your own
+  change(date(2023, 8, 12), <>Show correct uptime percent for <SpellLink spell={SPELLS.VAMPIRIC_TOUCH}/>.</>, beckeeh),
   change(date(2023, 2, 25), 'Add Shadow Priest by using _template/caster. Update Priest Spells and lowerRank Spells', HerzBlutRaffy),
   change(date(2023, 1, 13), 'Add Classic Caster spec template.', jazminite),
 ];

--- a/src/analysis/classic/priest/shadow/modules/features/VampiricTouch.tsx
+++ b/src/analysis/classic/priest/shadow/modules/features/VampiricTouch.tsx
@@ -15,7 +15,7 @@ class VampiricTouch extends Analyzer {
   protected enemies!: Enemies;
 
   get uptime() {
-    return this.enemies.getBuffUptime(SPELLS.DEVOURING_PLAGUE.id) / this.owner.fightDuration;
+    return this.enemies.getBuffUptime(SPELLS.VAMPIRIC_TOUCH.id) / this.owner.fightDuration;
   }
 
   get suggestionThresholds() {


### PR DESCRIPTION
### Description
Vampiric Touch had the same uptime percent as Devouring Plague, because a wrong spellID was used in the analyzer.

### Testing
- Test report URL: any report which has a classic shadow priest in
