### PR TITLE
[core] update resourcetracker include tooltip and optional wasted line

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -45,7 +45,6 @@ export default [
   change(date(2023, 8, 18), 'Update dependencies.', ToppleTheNun),
   change(date(2023, 8, 16), 'Add Classic buffs that effect haste rating', jazminite),
   change(date(2023, 8, 12), 'Add Classic character parse page', jazminite),
-  change(date(2023, 8, 9), 'Fix combatant count in M+.', ToppleTheNun),
   change(date(2023, 8, 9), 'Disable Augmentation Evoker analysis in M+.', ToppleTheNun),
   change(date(2023, 8, 8), 'Fix bug in EventLinkNormalizer', Trevor),
   change(date(2023, 8, 8), 'Deduplicate the dependencies of the project', Putro),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -45,6 +45,7 @@ export default [
   change(date(2023, 8, 18), 'Update dependencies.', ToppleTheNun),
   change(date(2023, 8, 16), 'Add Classic buffs that effect haste rating', jazminite),
   change(date(2023, 8, 12), 'Add Classic character parse page', jazminite),
+  change(date(2023, 8, 9), 'Fix combatant count in M+.', ToppleTheNun),
   change(date(2023, 8, 9), 'Disable Augmentation Evoker analysis in M+.', ToppleTheNun),
   change(date(2023, 8, 8), 'Fix bug in EventLinkNormalizer', Trevor),
   change(date(2023, 8, 8), 'Deduplicate the dependencies of the project', Putro),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -29,11 +29,12 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 9, 17), 'Introduce hover tooltip in resource tracker graphs, and optional wasted resources line.', Awildfivreld),
   change(date(2023, 9, 12), 'Disable M+ logs containing Augmentation Evokers temporarily.', ToppleTheNun),
   change(date(2023, 9, 6), "Reworked getRepeatedTalentCount to use getTalentRank behind the scenes, and renamed it to getMultipleTalentRanks.", Putro),
   change(date(2023, 9, 5), 'Add Classic Guild page', jazminite),
   change(date(2023, 9, 5), 'Update talent data for patch 10.1.7', emallson),
-  change(date(2023, 9, 4), <>Add module for tracking of <ItemLink id={ITEMS.ACCELERATING_SANDGLASS.id}/>.</>, nullDozzer),
+  change(date(2023, 9, 4), <>Add module for tracking of <ItemLink id={ITEMS.ACCELERATING_SANDGLASS.id} />.</>, nullDozzer),
   change(date(2023, 9, 2), 'Refactor haste buffs to be more understandable. Implements some haste buffs that were non-functional.', nullDozzer),
   change(date(2023, 9, 2), 'Fix some spec links not working in some scenarions', nullDozzer),
   change(date(2023, 8, 30), 'Update SpellLinks to automatically support talents.', ToppleTheNun),

--- a/src/analysis/retail/shaman/elemental/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/elemental/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import { HawkCorrigan, Putro, Zeboot, Maximaw, Zea, emallson, Vetyst, Periodic, 
 import { SpellLink } from 'interface';
 
 export default [
-  change(date(2023, 8, 16), <>Use core ResourceTracker logic now that it is available.</>, Awildfivreld),
+  change(date(2023, 9, 17), <>Use core ResourceTracker logic now that it is available.</>, Awildfivreld),
   change(date(2023, 9, 30), <>Use the correct spell id for <SpellLink spell={TALENTS.STORMKEEPER_1_ELEMENTAL_TALENT} /> casts.</>, Putro),
   change(date(2023, 8, 30), <>Add section on electrified shocks.</>, Awildfivreld),
   change(date(2023, 8, 13), <>Add section on always be casting, with graph.</>, Awildfivreld),

--- a/src/analysis/retail/shaman/elemental/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/elemental/CHANGELOG.tsx
@@ -5,7 +5,8 @@ import { HawkCorrigan, Putro, Zeboot, Maximaw, Zea, emallson, Vetyst, Periodic, 
 import { SpellLink } from 'interface';
 
 export default [
-  change(date(2023, 9, 30), <>Use the correct spell id for <SpellLink spell={TALENTS.STORMKEEPER_1_ELEMENTAL_TALENT}/> casts.</>, Putro),
+  change(date(2023, 8, 16), <>Use core ResourceTracker logic now that it is available.</>, Awildfivreld),
+  change(date(2023, 9, 30), <>Use the correct spell id for <SpellLink spell={TALENTS.STORMKEEPER_1_ELEMENTAL_TALENT} /> casts.</>, Putro),
   change(date(2023, 8, 30), <>Add section on electrified shocks.</>, Awildfivreld),
   change(date(2023, 8, 13), <>Add section on always be casting, with graph.</>, Awildfivreld),
   change(date(2023, 8, 12), <>Fix and improve the resource graph, and add a section on it in the guide section.</>, Awildfivreld),

--- a/src/analysis/retail/shaman/elemental/modules/resources/MaelstromGraph.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/resources/MaelstromGraph.tsx
@@ -3,167 +3,28 @@
 
 import { Panel } from 'interface';
 import MaelstromTracker from './MaelstromTracker';
-import ResourceGraph, { GraphData } from 'parser/shared/modules/ResourceGraph';
-import { VisualizationSpec } from 'react-vega';
-import { formatTime } from 'parser/ui/BaseChart';
-import SpellMaelstromCost from '../core/SpellMaelstromCost';
+import ResourceGraph from 'parser/shared/modules/ResourceGraph';
 
 const COLORS = {
   MAELSTROM_BORDER: 'rgba(0, 145, 255, 1)',
-  WASTED_MAELSTROM_BORDER: 'rgba(255, 90, 160, 1)',
 };
 
 export default class MaelstromGraph extends ResourceGraph {
   static dependencies = {
     ...ResourceGraph.dependencies,
     maelstromTracker: MaelstromTracker,
-    spellMaelstromCost: SpellMaelstromCost,
   };
 
   protected maelstromTracker!: MaelstromTracker;
-  protected spellMaelstromCost!: SpellMaelstromCost;
+
+  includeWasted: boolean = true;
+
+  lineColor(): string | undefined {
+    return COLORS.MAELSTROM_BORDER;
+  }
 
   tracker() {
     return this.maelstromTracker;
-  }
-
-  get graphData() {
-    const graphData: GraphData[] = [];
-    const tracker = this.tracker();
-    const scaleFactor = this.scaleFactor();
-    tracker.resourceUpdates.forEach((u) => {
-      graphData.push({
-        timestamp: u.timestamp,
-        maelstrom: u.current * scaleFactor,
-        wasted: (u.changeWaste || 0) * scaleFactor,
-      });
-    });
-    return { graphData };
-  }
-
-  get vegaSpec(): VisualizationSpec {
-    return {
-      data: {
-        name: 'graphData',
-      },
-      transform: [
-        {
-          filter: 'isValid(datum.timestamp)',
-        },
-        {
-          calculate: `datum.timestamp - ${this.owner.fight.start_time}`,
-          as: 'timestamp_shifted',
-        },
-        {
-          // Tooltips cant have calculated fields, so we need to calculate this here.
-          calculate: formatTime('datum.timestamp_shifted'),
-          as: 'timestamp_humanized',
-        },
-      ],
-      encoding: {
-        x: {
-          field: 'timestamp_shifted',
-          type: 'quantitative' as const,
-          axis: {
-            labelExpr: formatTime('datum.value'),
-            tickCount: 25,
-            grid: false,
-          },
-          scale: {
-            nice: false,
-          },
-          title: null,
-        },
-      },
-      layer: [
-        {
-          layer: [
-            // First layer always applies
-            {
-              mark: {
-                type: 'line' as const,
-                //stroke: COLORS.MAELSTROM_BORDER,
-                //color: COLORS.MAELSTROM_FILL,
-                interpolate: 'step-after' as const,
-              },
-            },
-            // Makes a visual point if the "hover" signal defined further down is active for this point.
-            { transform: [{ filter: { param: 'hover', empty: false } }], mark: 'point' },
-          ],
-          encoding: {
-            y: {
-              field: 'maelstrom',
-              type: 'quantitative' as const,
-              axis: {
-                grid: true,
-              },
-            },
-          },
-        },
-        {
-          layer: [
-            {
-              // First layer always applies
-              mark: {
-                type: 'line' as const,
-                color: COLORS.WASTED_MAELSTROM_BORDER,
-                interpolate: 'step-before' as const,
-              },
-            },
-            // Makes a visual point if the "hover" signal defined further down is active for this point.
-            { transform: [{ filter: { param: 'hover', empty: false } }], mark: 'point' },
-          ],
-          encoding: {
-            y: {
-              field: 'wasted',
-              type: 'quantitative' as const,
-              axis: {
-                grid: true,
-              },
-            },
-          },
-        },
-        {
-          // Define one vertical line (type=rule) per datapoint that is white.
-          mark: {
-            type: 'rule',
-            color: 'white',
-          },
-          encoding: {
-            opacity: {
-              // If the "hover" signal is active, make the line slightly opaque, else invisible.
-              condition: {
-                value: 0.3,
-                param: 'hover',
-                empty: false,
-              },
-              value: 0,
-            },
-            tooltip: [
-              { field: 'timestamp_humanized', type: 'nominal', title: 'Time' },
-              { field: 'maelstrom', type: 'quantitative', title: 'Maelstrom' },
-              { field: 'wasted', type: 'quantitative', title: 'Wasted Maelstrom' },
-            ],
-          },
-          // Activate the "hover" signal on the closest datapoint to the mouse cursor.
-          params: [
-            {
-              name: 'hover',
-              select: {
-                type: 'point',
-                fields: ['timestamp_shifted'],
-                nearest: true,
-                on: 'mouseover',
-                clear: 'mouseout',
-              },
-            },
-          ],
-        },
-      ],
-      config: {
-        view: {},
-      },
-    };
   }
 
   tab() {

--- a/src/parser/shared/modules/ResourceGraph.tsx
+++ b/src/parser/shared/modules/ResourceGraph.tsx
@@ -3,6 +3,7 @@ import Analyzer from 'parser/core/Analyzer';
 import BaseChart, { formatTime } from 'parser/ui/BaseChart';
 import { AutoSizer } from 'react-virtualized';
 import { VisualizationSpec } from 'react-vega';
+import { Color } from 'vega';
 
 abstract class ResourceGraph extends Analyzer {
   /** Implementer must override this to return the ResourceTracker for the resource to graph */
@@ -14,13 +15,22 @@ abstract class ResourceGraph extends Analyzer {
   includeWasted: boolean = false;
 
   /** Implementer may override this to give the graph line a custom color.
-   *  Color must be in format '#rrggbb', where rr gg and bb are hex values. */
-  lineColor(): string | undefined {
+   *
+   * Accepts a valid CSS color string. For example: #f304d3, #ccc, rgb(253, 12, 134), steelblue.
+   *
+   * Ref https://vega.github.io/vega-lite/docs/types.html#color
+   */
+  lineColor(): Color | undefined {
     return undefined;
   }
 
-  /** Implementer may override this to give the wasted line a custom color. */
-  wastedColor(): string {
+  /** Implementer may override this to give the wasted line a custom color.
+   *
+   * Accepts a valid CSS color string. For example: #f304d3, #ccc, rgb(253, 12, 134), steelblue.
+   *
+   * Ref https://vega.github.io/vega-lite/docs/types.html#color
+   */
+  wastedColor(): Color {
     return 'rgba(255,90,160,1)';
   }
 

--- a/src/parser/shared/modules/ResourceGraph.tsx
+++ b/src/parser/shared/modules/ResourceGraph.tsx
@@ -25,7 +25,7 @@ abstract class ResourceGraph extends Analyzer {
   }
 
   resourceName(): string {
-    return 'Resources';
+    return this.tracker().resource.name;
   }
 
   /** Some are scaled differently in events vs the user facing value. Implementer may override


### PR DESCRIPTION
### Description

Improves the core ResourceTracker to include a tooltip with information at the timestamp under the cursor, and an optional boolean flag to enable a line for wasted resources. You can enable the wasted line by setting `includeWasted = true` on the class. This defaults to `False`, and must be manually enabled in each graph.

You can change the color of the wasted line by overriding `get wastedColor()`. 

### Testing

There are currently 15 specs that subclass the ResourceTracker module at least once.

* Frost DK
* Havoc DH
* Vengeance DH
* Balance druid
* Feral druid
* Guardian druid
* Devestation evoker
* BM hunter
* Shadow priest
* All rouge specs (in your `shared/`)
* Elemental shaman
* Enhancement shaman
* Demo warlock

I'm including one visual example in this, but the same functionality is currently live in the elemental shaman analyzer if you want see it for yourself. https://wowanalyzer.com/report/L1R2zVKY8ZDxCTNb/15-Mythic+Scalecommander+Sarkareth+-+Kill+(7:21)/Nerdshockz/standard/overview#prototype

Before:
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/12049229/fd850b72-5d32-41b2-9bd5-ecf9b58fe6c0)


After, without wasted line:
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/12049229/49766e0c-2189-45f1-b0bc-a5a433e1b7e0)

After, with wasted line:
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/12049229/22e4110a-3752-4713-9bef-364a2f097a73)

