### PR TITLE
[Classic] Haste rating buffs

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -27,6 +27,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 8, 16), 'Add Classic buffs that effect haste rating', jazminite),
   change(date(2023, 8, 9), 'Fix combatant count in M+.', ToppleTheNun),
   change(date(2023, 8, 9), 'Disable Augmentation Evoker analysis in M+.', ToppleTheNun),
   change(date(2023, 8, 8), 'Fix bug in EventLinkNormalizer', Trevor),

--- a/src/common/SPELLS/classic/index.ts
+++ b/src/common/SPELLS/classic/index.ts
@@ -33,6 +33,7 @@ import Raids from './raids';
 import Tailoring from './tailoring';
 import Food from './food';
 import Alchemy from './alchemy';
+import Potions from './potions';
 
 const ABILITIES = {
   ...DEATH_KNIGHT,
@@ -51,6 +52,7 @@ const ABILITIES = {
   ...Tailoring,
   ...Food,
   ...Alchemy,
+  ...Potions,
 } as const;
 
 const InternalSpellTable = indexById<Spell | Enchant, typeof ABILITIES>(ABILITIES);

--- a/src/parser/shared/modules/StatTracker.ts
+++ b/src/parser/shared/modules/StatTracker.ts
@@ -1,5 +1,6 @@
 import { formatMilliseconds } from 'common/format';
 import SPELLS from 'common/SPELLS';
+import CLASSIC_SPELLS from 'common/SPELLS/classic';
 import ITEMS from 'common/ITEMS';
 import RACES from 'game/RACES';
 import SPECS, { isRetailSpec, specMasteryCoefficient } from 'game/SPECS';
@@ -20,7 +21,7 @@ import Events, {
 import EventEmitter from 'parser/core/modules/EventEmitter';
 import STAT from 'parser/shared/modules/features/STAT';
 
-import Expansion from '../../../game/Expansion';
+import { CLASSIC_EXPANSION } from 'game/Expansion';
 import { calculateSecondaryStatDefault } from 'parser/core/stats';
 
 const ARMOR_INT_BONUS = 0.05;
@@ -118,6 +119,11 @@ class StatTracker extends Analyzer {
     [SPELLS.FEROCITY_OF_THE_FROSTWOLF.id]: { mastery: 125 },
     [SPELLS.MIGHT_OF_THE_BLACKROCK.id]: { versatility: 125 },
     // endregion
+
+    // region Classic WotLK
+    [CLASSIC_SPELLS.HYPERSPEED_ACCELERATION.id]: { haste: 340 },
+    [CLASSIC_SPELLS.POTION_OF_SPEED.id]: { haste: 500 },
+    // endregion
   };
 
   // all known stat buffs
@@ -198,7 +204,7 @@ class StatTracker extends Analyzer {
 
   get activeStats(): STAT[] {
     switch (this.owner.config.expansion) {
-      case Expansion.TheBurningCrusade:
+      case CLASSIC_EXPANSION:
         return [
           STAT.HEALTH,
           STAT.STAMINA,


### PR DESCRIPTION
### Description

- Add Classic buffs that effect haste rating
- Fix static reference to TBC

### Motivation
Better downtime accuracy

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/gfPdYCMaRKF2V8ZD/3-Heroic+Lord+Jaraxxus+-+Kill+(2:31)/Jazminites`
- Screenshot(s):

BEFORE
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/65823478/eff39729-b8af-4ce0-af1b-9d8b837ea653)

AFTER
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/65823478/0f340a74-5c67-4d0d-be6c-eafa5e9fde3e)
