### PR TITLE
disable Fiery Brand due to Burning Alive weirdness

### DIFF
--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import SHARED_CHANGELOG from 'analysis/retail/demonhunter/shared/CHANGELOG';
 
 // prettier-ignore
 export default [
+  change(date(2023, 8, 18), 'Temporarily disable Fiery Brand analysis due to Burning Alive shenanigans.', ToppleTheNun),
   change(date(2023, 7, 11), 'Update for 10.1.5.', ToppleTheNun),
   change(date(2023, 7, 9), <>Add statistic about amount of <SpellLink spell={SPELLS.DEMON_SPIKES} /> wasted.</>, ToppleTheNun),
   change(date(2023, 7, 8), <>Fix determination of <SpellLink spell={TALENTS.FRACTURE_TALENT} /> quality based on Fury amounts.</>, ToppleTheNun),

--- a/src/analysis/retail/demonhunter/vengeance/modules/core/MajorDefensives/config.ts
+++ b/src/analysis/retail/demonhunter/vengeance/modules/core/MajorDefensives/config.ts
@@ -1,6 +1,5 @@
 import DemonSpikes from './DemonSpikes';
-import FieryBrand from './FieryBrand';
 import Metamorphosis from './Metamorphosis';
 
-export const MAJOR_ANALYZERS = [DemonSpikes, FieryBrand, Metamorphosis] as const;
+export const MAJOR_ANALYZERS = [DemonSpikes, Metamorphosis] as const;
 export const TIMELINE_ANALYZERS = [DemonSpikes, Metamorphosis] as const;


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Disable Fiery Brand because Burning Alive is causing each spread brand to make a new box and I don't have time atm to fix it.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/HDYxNfAhdyGcFZX6/1-Mythic++The+Underrot+-+Kill+(25:37)/Berén/standard/overview`
- Screenshot(s):
