### PR TITLE
[Classic] Mage LB GCD

### DIFF
--- a/src/analysis/classic/mage/fire/CHANGELOG.tsx
+++ b/src/analysis/classic/mage/fire/CHANGELOG.tsx
@@ -2,5 +2,6 @@ import { change, date } from 'common/changelog';
 import { jazminite } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2023, 8, 21), 'Update GCD of Living bomb.', jazminite),
   change(date(2023, 3, 17), 'Add Classic Fire Mage stub.', jazminite),
 ];

--- a/src/analysis/classic/mage/fire/modules/features/Abilities.ts
+++ b/src/analysis/classic/mage/fire/modules/features/Abilities.ts
@@ -11,7 +11,7 @@ class Abilities extends CoreAbilities {
       {
         spell: [SPELLS.LIVING_BOMB.id, ...SPELLS.LIVING_BOMB.lowRanks],
         category: SPELL_CATEGORY.ROTATIONAL,
-        gcd: null,
+        gcd: { base: 1500 },
       },
       {
         spell: [SPELLS.FIREBALL.id, ...SPELLS.FIREBALL.lowRanks],


### PR DESCRIPTION
### Description

- Add GCD to Living Bomb

### Motivation
According to [wowhead](https://www.wowhead.com/wotlk/spell=55360/living-bomb), the Living Bomb cast has a normal GCD.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/aRZLHWAPwjncxtDQ/7-Heroic+Anub'arak+-+Kill+(4:37)/Idiotbox/standard/timeline`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/65823478/95c137e2-5383-489f-871f-8cbe7bae7b64)

