### PR TITLE
Stop showing dialog for unsupported specs while developing

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -21,12 +21,14 @@ import {
   Jundarer,
   Vollmer,
   Awildfivreld,
+  nullDozzer,
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 8, 24), 'Stop showing warning of limited support while developing locally', nullDozzer),
   change(date(2023, 8, 23), 'Revert upgrade of charting library to fix area charts.', emallson),
   change(date(2023, 8, 19), 'Add support for Warcraft Logs\' phase data in new logs.', emallson),
   change(date(2023, 8, 18), 'Update dependencies.', ToppleTheNun),

--- a/src/interface/report/SupportChecker.tsx
+++ b/src/interface/report/SupportChecker.tsx
@@ -29,7 +29,9 @@ const SupportChecker = ({ children }: Props) => {
     dispatch(ignoreSpecNotSupportedWarning(config.spec.id));
   };
 
-  const isIgnored = ignored.includes(config.spec.id);
+  const isIgnored =
+    // Avoid the support-warning modal while developing to ease testing.
+    process.env.NODE_ENV === 'development' || ignored.includes(config.spec.id);
 
   return (
     <>


### PR DESCRIPTION
### Description

When loading an analyzer that is either not updated for the current patch, or marked as "partial", a warning is shown to the user.

![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/13413409/12c2be6f-db6d-46b2-89b1-1090e8697d17)

This dialog can be ignored on a session basis (not cookie or localStorage) which is an intentional choice with good reasoning. However, this dialog can quickly become quite frustrating for a developer since it will show up whenever you do a full reload of the page. 

The developer could configure the current spec to be fully supported, but some developments projects will improve the partial support without feeling confident enough to mark it as fully supported.

My suggestion is to check if the current environment is development, and if that is the case, always "ignore" the warnings. 
This let's the developer refresh without seeing the warning everytime, and can safely push without accidentally removing the support check from production.

I used NODE_ENV to detect development environment.

<!-- A brief description of the changes made with this pull request.-->

### Testing

Run the development server locally, and load a partially suported spec, such as http://localhost:3000/report/RVwcm3bNzJaXAMqW/4-Mythic+Kazzara,+the+Hellforged+-+Kill+(3:24)/Gajeel/standard/overview

and note that there is no warning
