### PR TITLE
[Evoker] Leaping Flames module

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+    change(date(2023, 8, 25), <>Add <SpellLink spell={TALENTS.LEAPING_FLAMES_TALENT} /> module.</>, Vollmer),
     change(date(2023, 8, 17), <>Add statistics for <SpellLink spell={TALENTS.SYMBIOTIC_BLOOM_TALENT} />.</>, Vollmer),
     change(date(2023, 8, 17), <>Add statistics for <SpellLink spell={TALENTS.BLISTERING_SCALES_TALENT} />, <SpellLink spell={TALENTS.REGENERATIVE_CHITIN_TALENT} /> & <SpellLink spell={TALENTS.REACTIVE_HIDE_TALENT} />.</>, Vollmer),
     change(date(2023, 8, 17), <>Add statistics for <SpellLink spell={TALENTS.TECTONIC_LOCUS_TALENT} />.</>, Vollmer),

--- a/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
@@ -31,8 +31,15 @@ import CastLinkNormalizer from './modules/normalizers/CastLinkNormalizer';
 import EmpowerNormalizer from './modules/normalizers/EmpowerNormalizer';
 import EbonMightNormalizer from './modules/normalizers/EbonMightNormalizer';
 
+//Shared
+import { LeapingFlamesNormalizer, LeapingFlames } from 'analysis/retail/evoker/shared';
+
 class CombatLogParser extends MainCombatLogParser {
   static specModules = {
+    // Shared
+    leapingFlamesNormalizer: LeapingFlamesNormalizer,
+    leapingFlames: LeapingFlames,
+
     // Normalizers
     castLinkNormalizer: CastLinkNormalizer,
     prescienceNormalizer: PrescienceNormalizer,

--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+  change(date(2023, 8, 25), <>Add <SpellLink spell={TALENTS.LEAPING_FLAMES_TALENT} /> module.</>, Vollmer),
   change(date(2023, 7, 26), <>Update <SpellLink spell={TALENTS.CAUSALITY_TALENT} /> module & CDR calculation.</>, Vollmer),
   change(date(2023, 7, 24), <>Added <SpellLink spell={SPELLS.DEEP_BREATH} /> to channel list.</>, Vollmer),
   change(date(2023, 7, 24), 'Update APL Check.', Vollmer),

--- a/src/analysis/retail/evoker/devastation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/devastation/CombatLogParser.ts
@@ -31,8 +31,16 @@ import EngulfingBlaze from './modules/talents/EngulfingBlaze';
 import LayWaste from './modules/talents/LayWaste';
 import Iridescence from './modules/talents/Iridescence';
 
+// Shared
+import { LeapingFlamesNormalizer, LeapingFlames } from 'analysis/retail/evoker/shared';
+
 class CombatLogParser extends MainCombatLogParser {
   static specModules = {
+    // Shared
+    leapingFlamesNormalizer: LeapingFlamesNormalizer,
+    leapingFlames: LeapingFlames,
+
+    // Core
     abilities: Abilities,
     buffs: Buffs,
 

--- a/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
@@ -5,7 +5,6 @@ import { TALENTS_EVOKER } from 'common/TALENTS';
 import { CastEvent, EventType, HasRelatedEvent } from 'parser/core/Events';
 
 export const ESSENCE_BURST_CONSUME = 'EssenceBurstConsumption';
-export const ESSENCE_BURST_GENERATED = 'EssenceBurstGenerated';
 export const BURNOUT_CONSUME = 'BurnoutConsumption';
 export const SNAPFIRE_CONSUME = 'SnapfireConsumption';
 export const IRIDESCENCE_RED_CONSUME = 'IridescentRedConsumption';
@@ -31,21 +30,6 @@ const EVENT_LINKS: EventLink[] = [
     linkingEventId: [TALENTS_EVOKER.RUBY_ESSENCE_BURST_TALENT.id, SPELLS.ESSENCE_BURST_DEV_BUFF.id],
     linkingEventType: [EventType.RemoveBuff, EventType.RemoveBuffStack],
     referencedEventId: [SPELLS.PYRE.id, SPELLS.PYRE_DENSE_TALENT.id],
-    referencedEventType: EventType.Cast,
-    anyTarget: true,
-    forwardBufferMs: CAST_BUFFER_MS,
-    backwardBufferMs: CAST_BUFFER_MS,
-  },
-  {
-    linkRelation: ESSENCE_BURST_GENERATED,
-    reverseLinkRelation: ESSENCE_BURST_GENERATED,
-    linkingEventId: [TALENTS_EVOKER.RUBY_ESSENCE_BURST_TALENT.id, SPELLS.ESSENCE_BURST_DEV_BUFF.id],
-    linkingEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack],
-    referencedEventId: [
-      SPELLS.LIVING_FLAME_DAMAGE.id,
-      SPELLS.LIVING_FLAME_HEAL.id,
-      SPELLS.AZURE_STRIKE.id,
-    ],
     referencedEventType: EventType.Cast,
     anyTarget: true,
     forwardBufferMs: CAST_BUFFER_MS,

--- a/src/analysis/retail/evoker/shared/index.ts
+++ b/src/analysis/retail/evoker/shared/index.ts
@@ -3,6 +3,8 @@ export {
   getLeapingDamageEvents,
   getLeapingHealEvents,
   generatedEssenceBurst,
+  getCastedGeneratedEssenceBurst,
+  isFromLeapingFlames,
 } from './modules/normalizers/LeapingFlamesNormalizer';
 export { default as LeapingFlames } from './modules/talents/LeapingFlames';
 export * from './constants';

--- a/src/analysis/retail/evoker/shared/index.ts
+++ b/src/analysis/retail/evoker/shared/index.ts
@@ -5,6 +5,7 @@ export {
   generatedEssenceBurst,
   getCastedGeneratedEssenceBurst,
   isFromLeapingFlames,
+  getWastedEssenceBurst,
 } from './modules/normalizers/LeapingFlamesNormalizer';
 export { default as LeapingFlames } from './modules/talents/LeapingFlames';
 export * from './constants';

--- a/src/analysis/retail/evoker/shared/index.ts
+++ b/src/analysis/retail/evoker/shared/index.ts
@@ -1,1 +1,8 @@
+export {
+  default as LeapingFlamesNormalizer,
+  getLeapingDamageEvents,
+  getLeapingHealEvents,
+  generatedEssenceBurst,
+} from './modules/normalizers/LeapingFlamesNormalizer';
+export { default as LeapingFlames } from './modules/talents/LeapingFlames';
 export * from './constants';

--- a/src/analysis/retail/evoker/shared/modules/normalizers/LeapingFlamesNormalizer.ts
+++ b/src/analysis/retail/evoker/shared/modules/normalizers/LeapingFlamesNormalizer.ts
@@ -11,16 +11,18 @@ import {
   GetRelatedEvents,
   HasRelatedEvent,
   HealEvent,
+  RefreshBuffEvent,
 } from 'parser/core/Events';
 
 export const LEAPING_FLAMES_HITS = 'leapingFlamesHits';
 export const LEAPING_FLAMES_CONSUME = 'leapingFlamesConsume';
 export const ESSENCE_BURST_GENERATED = 'essenceBurstGenerated';
 export const ESSENCE_BURST_CAST_GENERATED = 'essenceBurstCastGenerated';
+export const ESSENCE_BURST_WASTED = 'essenceBurstWasted';
 
 const LEAPING_FLAMES_HIT_BUFFER = 1000;
 const ESSENCE_BURST_BUFFER = 20;
-const LEAPING_FLAMES_CONSUME_BUFFER = 10;
+const LEAPING_FLAMES_CONSUME_BUFFER = 35;
 
 const EVENT_LINKS: EventLink[] = [
   {
@@ -81,6 +83,23 @@ const EVENT_LINKS: EventLink[] = [
     linkingEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack],
     referencedEventId: SPELLS.LIVING_FLAME_CAST.id,
     referencedEventType: EventType.Cast,
+    forwardBufferMs: ESSENCE_BURST_BUFFER,
+    backwardBufferMs: ESSENCE_BURST_BUFFER,
+    anyTarget: true,
+  },
+  {
+    linkRelation: ESSENCE_BURST_WASTED,
+    reverseLinkRelation: ESSENCE_BURST_WASTED,
+    linkingEventId: [
+      TALENTS_EVOKER.RUBY_ESSENCE_BURST_TALENT.id,
+      SPELLS.ESSENCE_BURST_DEV_BUFF.id,
+      SPELLS.ESSENCE_BURST_AUGMENTATION_BUFF.id,
+    ],
+    linkingEventType: EventType.RefreshBuff,
+    referencedEventId: SPELLS.LIVING_FLAME_CAST.id,
+    referencedEventType: EventType.Cast,
+    forwardBufferMs: ESSENCE_BURST_BUFFER,
+    backwardBufferMs: ESSENCE_BURST_BUFFER,
     anyTarget: true,
   },
 ];
@@ -109,6 +128,12 @@ export function getCastedGeneratedEssenceBurst(
   return GetRelatedEvents(event, ESSENCE_BURST_CAST_GENERATED).filter(
     (e): e is ApplyBuffEvent | ApplyBuffStackEvent =>
       e.type === EventType.ApplyBuff || e.type === EventType.ApplyBuffStack,
+  );
+}
+
+export function getWastedEssenceBurst(event: CastEvent): RefreshBuffEvent[] {
+  return GetRelatedEvents(event, ESSENCE_BURST_WASTED).filter(
+    (e): e is RefreshBuffEvent => e.type === EventType.RefreshBuff,
   );
 }
 

--- a/src/analysis/retail/evoker/shared/modules/normalizers/LeapingFlamesNormalizer.ts
+++ b/src/analysis/retail/evoker/shared/modules/normalizers/LeapingFlamesNormalizer.ts
@@ -18,7 +18,9 @@ export const LEAPING_FLAMES_CONSUME = 'leapingFlamesConsume';
 export const ESSENCE_BURST_GENERATED = 'essenceBurstGenerated';
 export const ESSENCE_BURST_CAST_GENERATED = 'essenceBurstCastGenerated';
 
-const LEAPING_FLAMES_BUFFER = 1000;
+const LEAPING_FLAMES_HIT_BUFFER = 1000;
+const ESSENCE_BURST_BUFFER = 20;
+const LEAPING_FLAMES_CONSUME_BUFFER = 10;
 
 const EVENT_LINKS: EventLink[] = [
   {
@@ -29,7 +31,7 @@ const EVENT_LINKS: EventLink[] = [
     referencedEventId: [SPELLS.LIVING_FLAME_DAMAGE.id, SPELLS.LIVING_FLAME_HEAL.id],
     referencedEventType: [EventType.Damage, EventType.Heal],
     anyTarget: true,
-    forwardBufferMs: LEAPING_FLAMES_BUFFER,
+    forwardBufferMs: LEAPING_FLAMES_HIT_BUFFER,
     isActive(c) {
       return c.hasTalent(TALENTS_EVOKER.LEAPING_FLAMES_TALENT);
     },
@@ -42,6 +44,8 @@ const EVENT_LINKS: EventLink[] = [
     referencedEventId: SPELLS.LEAPING_FLAMES_BUFF.id,
     referencedEventType: EventType.RemoveBuff,
     anyTarget: true,
+    forwardBufferMs: LEAPING_FLAMES_CONSUME_BUFFER,
+    backwardBufferMs: LEAPING_FLAMES_CONSUME_BUFFER,
     isActive(c) {
       return c.hasTalent(TALENTS_EVOKER.LEAPING_FLAMES_TALENT);
     },
@@ -62,8 +66,8 @@ const EVENT_LINKS: EventLink[] = [
     ],
     referencedEventType: [EventType.Damage, EventType.Heal],
     anyTarget: true,
-    forwardBufferMs: 20,
-    backwardBufferMs: 20, // Sometimes the EB comes a bit early/late
+    forwardBufferMs: ESSENCE_BURST_BUFFER,
+    backwardBufferMs: ESSENCE_BURST_BUFFER, // Sometimes the EB comes a bit early/late
     maximumLinks: 1,
   },
   {

--- a/src/analysis/retail/evoker/shared/modules/normalizers/LeapingFlamesNormalizer.ts
+++ b/src/analysis/retail/evoker/shared/modules/normalizers/LeapingFlamesNormalizer.ts
@@ -34,9 +34,6 @@ const EVENT_LINKS: EventLink[] = [
     referencedEventType: [EventType.Damage, EventType.Heal],
     anyTarget: true,
     forwardBufferMs: LEAPING_FLAMES_HIT_BUFFER,
-    isActive(c) {
-      return c.hasTalent(TALENTS_EVOKER.LEAPING_FLAMES_TALENT);
-    },
   },
   {
     linkRelation: LEAPING_FLAMES_CONSUME,
@@ -48,9 +45,6 @@ const EVENT_LINKS: EventLink[] = [
     anyTarget: true,
     forwardBufferMs: LEAPING_FLAMES_CONSUME_BUFFER,
     backwardBufferMs: LEAPING_FLAMES_CONSUME_BUFFER,
-    isActive(c) {
-      return c.hasTalent(TALENTS_EVOKER.LEAPING_FLAMES_TALENT);
-    },
   },
   {
     linkRelation: ESSENCE_BURST_GENERATED,
@@ -107,6 +101,7 @@ const EVENT_LINKS: EventLink[] = [
 class LeapingFlamesNormalizer extends EventLinkNormalizer {
   constructor(options: Options) {
     super(options, EVENT_LINKS);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_EVOKER.LEAPING_FLAMES_TALENT);
   }
 }
 

--- a/src/analysis/retail/evoker/shared/modules/normalizers/LeapingFlamesNormalizer.ts
+++ b/src/analysis/retail/evoker/shared/modules/normalizers/LeapingFlamesNormalizer.ts
@@ -1,0 +1,73 @@
+import SPELLS from 'common/SPELLS';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import { Options } from 'parser/core/Module';
+import { TALENTS_EVOKER } from 'common/TALENTS';
+import {
+  CastEvent,
+  DamageEvent,
+  EventType,
+  GetRelatedEvents,
+  HasRelatedEvent,
+  HealEvent,
+} from 'parser/core/Events';
+
+export const LEAPING_FLAMES_CONSUME = 'leapingFlamesConsume';
+export const ESSENCE_BURST_GENERATED = 'EssenceBurstGenerated';
+
+const LEAPING_FLAMES_BUFFER = 1000;
+
+const EVENT_LINKS: EventLink[] = [
+  {
+    linkRelation: LEAPING_FLAMES_CONSUME,
+    reverseLinkRelation: LEAPING_FLAMES_CONSUME,
+    linkingEventId: SPELLS.LIVING_FLAME_CAST.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: [SPELLS.LIVING_FLAME_DAMAGE.id, SPELLS.LIVING_FLAME_HEAL.id],
+    referencedEventType: [EventType.Damage, EventType.Heal],
+    anyTarget: true,
+    forwardBufferMs: LEAPING_FLAMES_BUFFER,
+    isActive(c) {
+      return c.hasTalent(TALENTS_EVOKER.LEAPING_FLAMES_TALENT);
+    },
+  },
+  {
+    linkRelation: ESSENCE_BURST_GENERATED,
+    reverseLinkRelation: ESSENCE_BURST_GENERATED,
+    linkingEventId: [TALENTS_EVOKER.RUBY_ESSENCE_BURST_TALENT.id, SPELLS.ESSENCE_BURST_DEV_BUFF.id],
+    linkingEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack],
+    referencedEventId: [
+      SPELLS.LIVING_FLAME_DAMAGE.id,
+      SPELLS.LIVING_FLAME_HEAL.id,
+      SPELLS.AZURE_STRIKE.id,
+    ],
+    referencedEventType: [EventType.Damage, EventType.Heal],
+    anyTarget: true,
+    forwardBufferMs: 20,
+    backwardBufferMs: 20, // Sometimes the EB comes a bit early/late
+    maximumLinks: 1,
+  },
+];
+
+class LeapingFlamesNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_LINKS);
+  }
+}
+
+export function getLeapingDamageEvents(event: CastEvent): DamageEvent[] {
+  return GetRelatedEvents(event, LEAPING_FLAMES_CONSUME).filter(
+    (e): e is DamageEvent => e.type === EventType.Damage,
+  );
+}
+
+export function getLeapingHealEvents(event: CastEvent): HealEvent[] {
+  return GetRelatedEvents(event, LEAPING_FLAMES_CONSUME).filter(
+    (e): e is HealEvent => e.type === EventType.Heal,
+  );
+}
+
+export function generatedEssenceBurst(event: DamageEvent | HealEvent) {
+  return HasRelatedEvent(event, ESSENCE_BURST_GENERATED);
+}
+
+export default LeapingFlamesNormalizer;

--- a/src/analysis/retail/evoker/shared/modules/normalizers/LeapingFlamesNormalizer.ts
+++ b/src/analysis/retail/evoker/shared/modules/normalizers/LeapingFlamesNormalizer.ts
@@ -3,6 +3,8 @@ import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer'
 import { Options } from 'parser/core/Module';
 import { TALENTS_EVOKER } from 'common/TALENTS';
 import {
+  ApplyBuffEvent,
+  ApplyBuffStackEvent,
   CastEvent,
   DamageEvent,
   EventType,
@@ -11,15 +13,17 @@ import {
   HealEvent,
 } from 'parser/core/Events';
 
+export const LEAPING_FLAMES_HITS = 'leapingFlamesHits';
 export const LEAPING_FLAMES_CONSUME = 'leapingFlamesConsume';
-export const ESSENCE_BURST_GENERATED = 'EssenceBurstGenerated';
+export const ESSENCE_BURST_GENERATED = 'essenceBurstGenerated';
+export const ESSENCE_BURST_CAST_GENERATED = 'essenceBurstCastGenerated';
 
 const LEAPING_FLAMES_BUFFER = 1000;
 
 const EVENT_LINKS: EventLink[] = [
   {
-    linkRelation: LEAPING_FLAMES_CONSUME,
-    reverseLinkRelation: LEAPING_FLAMES_CONSUME,
+    linkRelation: LEAPING_FLAMES_HITS,
+    reverseLinkRelation: LEAPING_FLAMES_HITS,
     linkingEventId: SPELLS.LIVING_FLAME_CAST.id,
     linkingEventType: EventType.Cast,
     referencedEventId: [SPELLS.LIVING_FLAME_DAMAGE.id, SPELLS.LIVING_FLAME_HEAL.id],
@@ -31,9 +35,25 @@ const EVENT_LINKS: EventLink[] = [
     },
   },
   {
+    linkRelation: LEAPING_FLAMES_CONSUME,
+    reverseLinkRelation: LEAPING_FLAMES_CONSUME,
+    linkingEventId: SPELLS.LIVING_FLAME_CAST.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: SPELLS.LEAPING_FLAMES_BUFF.id,
+    referencedEventType: EventType.RemoveBuff,
+    anyTarget: true,
+    isActive(c) {
+      return c.hasTalent(TALENTS_EVOKER.LEAPING_FLAMES_TALENT);
+    },
+  },
+  {
     linkRelation: ESSENCE_BURST_GENERATED,
     reverseLinkRelation: ESSENCE_BURST_GENERATED,
-    linkingEventId: [TALENTS_EVOKER.RUBY_ESSENCE_BURST_TALENT.id, SPELLS.ESSENCE_BURST_DEV_BUFF.id],
+    linkingEventId: [
+      TALENTS_EVOKER.RUBY_ESSENCE_BURST_TALENT.id,
+      SPELLS.ESSENCE_BURST_DEV_BUFF.id,
+      SPELLS.ESSENCE_BURST_AUGMENTATION_BUFF.id,
+    ],
     linkingEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack],
     referencedEventId: [
       SPELLS.LIVING_FLAME_DAMAGE.id,
@@ -46,6 +66,19 @@ const EVENT_LINKS: EventLink[] = [
     backwardBufferMs: 20, // Sometimes the EB comes a bit early/late
     maximumLinks: 1,
   },
+  {
+    linkRelation: ESSENCE_BURST_CAST_GENERATED,
+    reverseLinkRelation: ESSENCE_BURST_CAST_GENERATED,
+    linkingEventId: [
+      TALENTS_EVOKER.RUBY_ESSENCE_BURST_TALENT.id,
+      SPELLS.ESSENCE_BURST_DEV_BUFF.id,
+      SPELLS.ESSENCE_BURST_AUGMENTATION_BUFF.id,
+    ],
+    linkingEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack],
+    referencedEventId: SPELLS.LIVING_FLAME_CAST.id,
+    referencedEventType: EventType.Cast,
+    anyTarget: true,
+  },
 ];
 
 class LeapingFlamesNormalizer extends EventLinkNormalizer {
@@ -55,19 +88,32 @@ class LeapingFlamesNormalizer extends EventLinkNormalizer {
 }
 
 export function getLeapingDamageEvents(event: CastEvent): DamageEvent[] {
-  return GetRelatedEvents(event, LEAPING_FLAMES_CONSUME).filter(
+  return GetRelatedEvents(event, LEAPING_FLAMES_HITS).filter(
     (e): e is DamageEvent => e.type === EventType.Damage,
   );
 }
 
 export function getLeapingHealEvents(event: CastEvent): HealEvent[] {
-  return GetRelatedEvents(event, LEAPING_FLAMES_CONSUME).filter(
+  return GetRelatedEvents(event, LEAPING_FLAMES_HITS).filter(
     (e): e is HealEvent => e.type === EventType.Heal,
+  );
+}
+
+export function getCastedGeneratedEssenceBurst(
+  event: CastEvent,
+): (ApplyBuffEvent | ApplyBuffStackEvent)[] {
+  return GetRelatedEvents(event, ESSENCE_BURST_CAST_GENERATED).filter(
+    (e): e is ApplyBuffEvent | ApplyBuffStackEvent =>
+      e.type === EventType.ApplyBuff || e.type === EventType.ApplyBuffStack,
   );
 }
 
 export function generatedEssenceBurst(event: DamageEvent | HealEvent) {
   return HasRelatedEvent(event, ESSENCE_BURST_GENERATED);
+}
+
+export function isFromLeapingFlames(event: CastEvent) {
+  return HasRelatedEvent(event, LEAPING_FLAMES_CONSUME);
 }
 
 export default LeapingFlamesNormalizer;

--- a/src/analysis/retail/evoker/shared/modules/talents/LeapingFlames.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/LeapingFlames.tsx
@@ -166,6 +166,8 @@ class LeapingFlames extends Analyzer {
             <li>Damage: {formatNumber(this.leapingFlamesDamage)}</li>
             <li>Healing: {formatNumber(this.leapingFlamesHealing)}</li>
             <li>Overhealing: {formatNumber(this.leapingFlamesOverHealing)}</li>
+            Wasted <SpellLink spell={SPELLS.ESSENCE_BURST_BUFF} /> represent the amount you lost out
+            on due to overcapping.
           </>
         }
       >

--- a/src/analysis/retail/evoker/shared/modules/talents/LeapingFlames.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/LeapingFlames.tsx
@@ -1,0 +1,133 @@
+import SPELLS from 'common/SPELLS/evoker';
+import TALENTS from 'common/TALENTS/evoker';
+import { formatNumber } from 'common/format';
+
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import Events, { CastEvent } from 'parser/core/Events';
+import {
+  getLeapingDamageEvents,
+  getLeapingHealEvents,
+  generatedEssenceBurst,
+} from '../normalizers/LeapingFlamesNormalizer';
+
+import { getPupilDamageEvents } from 'analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer';
+
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import Soup from 'interface/icons/Soup';
+import { SpellLink } from 'interface';
+import SPECS from 'game/SPECS';
+
+const SHOW_EB_GEN = false; // Needs more work before it can be shown
+/**
+ * Fire Breath causes your next Living Flame to strike 1 additional target per empower level.
+ */
+class LeapingFlames extends Analyzer {
+  leapingFlamesDamage: number = 0;
+  leapingFlamesHealing: number = 0;
+  leapingFlamesOverHealing: number = 0;
+  essenceBurstGenerated: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.LEAPING_FLAMES_TALENT);
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.LIVING_FLAME_CAST),
+      this.onCast,
+    );
+  }
+
+  onCast(event: CastEvent) {
+    const damageEvents = getLeapingDamageEvents(event);
+
+    /** Logic needed to account for Pupil of Alexstraza for Augmentation
+     * Pupil also sends out a cleave LF */
+    let pupilDamage = 0;
+    if (
+      this.selectedCombatant.spec === SPECS.AUGMENTATION_EVOKER &&
+      this.selectedCombatant.hasTalent(TALENTS.PUPIL_OF_ALEXSTRASZA_TALENT)
+    ) {
+      const pupilDamageEvents = getPupilDamageEvents(event);
+      pupilDamageEvents.forEach((pupilDamageEvent) => {
+        // Look for non maintarget pupil damage and keep track of it
+        if (pupilDamageEvent.targetID !== event.targetID) {
+          pupilDamage += pupilDamageEvent.amount + (pupilDamageEvent.absorbed ?? 0);
+        }
+      });
+    }
+
+    if (damageEvents.length > 0) {
+      damageEvents.forEach((damEvent) => {
+        // If the target hit wasn't the main target we can safely assume it came from Leaping Flames
+        if (damEvent.targetID !== event.targetID) {
+          this.leapingFlamesDamage += damEvent.amount + (damEvent.absorbed ?? 0);
+          // This solution is slightly broken for damage events due to
+          // Blizzard sometimes giving the EB on hit, and sometimes on cast
+          // Blizz pls fix
+          if (generatedEssenceBurst(damEvent)) {
+            this.essenceBurstGenerated += 1;
+          }
+        }
+      });
+      // Remove pupil damage from the total damage
+      this.leapingFlamesDamage -= pupilDamage;
+    }
+
+    const healEvent = getLeapingHealEvents(event);
+    if (healEvent.length > 0) {
+      healEvent.forEach((healEvent) => {
+        // If the target hit wasn't the main target we can safely assume it came from Leaping Flames
+        if (healEvent.targetID !== event.targetID) {
+          this.leapingFlamesHealing += healEvent.amount;
+          this.leapingFlamesOverHealing += healEvent.overheal ?? 0;
+          if (generatedEssenceBurst(healEvent)) {
+            this.essenceBurstGenerated += 1;
+          }
+        }
+      });
+    }
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(13)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            <li>Damage: {formatNumber(this.leapingFlamesDamage)}</li>
+            <li>Healing: {formatNumber(this.leapingFlamesHealing)}</li>
+            <li>Overhealing: {formatNumber(this.leapingFlamesOverHealing)}</li>
+            {SHOW_EB_GEN && <li>Essence Burst Generated: {this.essenceBurstGenerated}</li>}
+          </>
+        }
+      >
+        <TalentSpellText talent={TALENTS.LEAPING_FLAMES_TALENT}>
+          <div>
+            <ItemDamageDone amount={this.leapingFlamesDamage} />
+          </div>
+          <div>
+            <ItemHealingDone amount={this.leapingFlamesHealing} />
+          </div>
+          {SHOW_EB_GEN && (
+            <div>
+              <Soup /> {this.essenceBurstGenerated}
+              <small>
+                {' '}
+                <SpellLink spell={SPELLS.ESSENCE_BURST_BUFF} /> generated
+              </small>
+            </div>
+          )}
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}
+
+export default LeapingFlames;


### PR DESCRIPTION
### Description

Added module for the Leaping Flames talent for Evoker.
Shows Damage, Healing and Essence Burst generation.

I've enabled it for Devastation & Augmentation for now. I'll let @trevorm4 decide if they want it enabled on Preservation.

### Testing

- Test report URL: 
Devastation: 
`/report/RMKJ6kwcLfBVG3gm/8-Heroic+Scalecommander+Sarkareth+-+Kill+(5:17)/Algo/standard/statistics`
Augmentation: 
`/report/RMKJ6kwcLfBVG3gm/8-Heroic+Scalecommander+Sarkareth+-+Kill+(5:17)/Ryllev/standard/statistics`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/ddd2a857-9345-4ea7-a6f2-7d99e3b93dd0)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/387d0867-ede2-450b-bcfa-927320026b1a)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/029c5a11-df45-4bc1-8ff7-fc9bc5ebb8c2)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/8e8d74f5-eb55-454d-a847-d47effb71dac)

