### PR TITLE
[UI] Small bugfix in CharacterParses.tsx

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -21,12 +21,14 @@ import {
   Jundarer,
   Vollmer,
   Awildfivreld,
+  Bigsxy,
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 8, 27), 'Fixed broken Warcraft Logs link on the character page.', Bigsxy),
   change(date(2023, 8, 23), 'Revert upgrade of charting library to fix area charts.', emallson),
   change(date(2023, 8, 19), 'Add support for Warcraft Logs\' phase data in new logs.', emallson),
   change(date(2023, 8, 18), 'Update dependencies.', ToppleTheNun),

--- a/src/interface/CharacterParses.tsx
+++ b/src/interface/CharacterParses.tsx
@@ -480,7 +480,7 @@ class CharacterParses extends Component<CharacterParsesProps, CharacterParsesSta
   }
 
   formattedCharacterLink() {
-    return `${this.wclDomain}.warcraftlogs.com/character/${this.props.region}/${this.state.realmSlug}/${this.props.name}`;
+    return `${this.wclDomain}/character/${this.props.region}/${this.state.realmSlug}/${this.props.name}`;
   }
 
   render() {


### PR DESCRIPTION
Quick fix to issue #6333. 
- Unnecessary `.warcraftlogs.com` removed from the url template to WCL.