### PR TITLE
update useSpellInfo to use maybeGetTalentOrSpell

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -29,6 +29,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 8, 30), 'Update SpellLinks to automatically support talents.', ToppleTheNun),
   change(date(2023, 8, 27), 'Fixed broken Warcraft Logs link on the character page.', Bigsxy),
   change(date(2023, 8, 24), 'Stop showing warning of limited support while developing locally', nullDozzer),
   change(date(2023, 8, 23), 'Revert upgrade of charting library to fix area charts.', emallson),

--- a/src/interface/useSpellInfo.ts
+++ b/src/interface/useSpellInfo.ts
@@ -1,18 +1,20 @@
 import * as Sentry from '@sentry/browser';
 import makeApiUrl from 'common/makeApiUrl';
-import SPELLS, { maybeGetSpell } from 'common/SPELLS';
+import SPELLS from 'common/SPELLS';
 import { useEffect } from 'react';
 import useSWR from 'swr';
 import Spell from 'common/SPELLS/Spell';
 import { useExpansionContext } from 'interface/report/ExpansionContext';
 import { getSpellId } from 'common/getSpellId';
+import { maybeGetTalentOrSpell } from 'common/maybeGetTalentOrSpell';
 
 const fetcher = (...args: Parameters<typeof fetch>) => fetch(...args).then((res) => res.json());
 
 const useSpellInfo = (spell: number | Spell) => {
   const { expansion } = useExpansionContext();
   const spellId = getSpellId(spell);
-  const argumentAsSpell = typeof spell === 'number' ? maybeGetSpell(spellId, expansion) : spell;
+  const argumentAsSpell =
+    typeof spell === 'number' ? maybeGetTalentOrSpell(spellId, expansion) : spell;
 
   const { data, error } = useSWR<Spell>(makeApiUrl(`spell/${spellId}`), {
     fetcher,


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Update `useSpellInfo` to also retrieve talents, which should reduce the amount of duplication necessary to make `SpellLink`s work well for tables.

### Testing

This snippet will not cause an API request to go out to retrieve the spell info:
```tsx
<>Check issues with <SpellLink spell={117014} />.</>
```