### PR TITLE
[Augmentation] Fix undefined issue in Shifting Sands module

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+    change(date(2023, 8, 31), <>Fix issue with <SpellLink spell={SPELLS.SHIFTING_SANDS_BUFF} /> module when targets buffs wasn't defined.</>, Vollmer),
     change(date(2023, 8, 30), <>Fix issue with <SpellLink spell={TALENTS.EBON_MIGHT_TALENT} /> module when buff target spec wasn't defined.</>, Vollmer),
     change(date(2023, 8, 25), <>Add <SpellLink spell={TALENTS.LEAPING_FLAMES_TALENT} /> module.</>, Vollmer),
     change(date(2023, 8, 17), <>Add statistics for <SpellLink spell={TALENTS.SYMBIOTIC_BLOOM_TALENT} />.</>, Vollmer),

--- a/src/analysis/retail/evoker/augmentation/modules/abilities/ShiftingSands.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/abilities/ShiftingSands.tsx
@@ -42,16 +42,16 @@ class ShiftingSands extends Analyzer {
   }
 
   private onCast(event: ApplyBuffEvent) {
-    const shiftingSandsApplications: ShiftingSandsApplications = {
+    const target = this.combatants.players[event.targetID];
+
+    const shiftingSandsApplication: ShiftingSandsApplications = {
       event: event,
-      ebonMightOn: this.combatants.players[event.targetID].hasBuff(
-        SPELLS.EBON_MIGHT_BUFF_EXTERNAL.id,
-      ),
-      prescienceOn: this.combatants.players[event.targetID].hasBuff(SPELLS.PRESCIENCE_BUFF.id),
-      combatant: this.combatants.players[event.targetID],
+      ebonMightOn: target.hasBuff(SPELLS.EBON_MIGHT_BUFF_EXTERNAL.id) ?? false,
+      prescienceOn: target.hasBuff(SPELLS.PRESCIENCE_BUFF.id) ?? false,
+      combatant: target,
     };
 
-    this.shiftingSandsApplications.push(shiftingSandsApplications);
+    this.shiftingSandsApplications.push(shiftingSandsApplication);
   }
 
   private finalize() {


### PR DESCRIPTION
### Description

Some guy found a target with undefined buffs, now we default to `false` if that happens again.

### Testing

- Test report URL: `/report/qymghkvXH93fat4x/18-Mythic+Scalecommander+Sarkareth+-+Wipe+18+(7:30)/Dragoproject/standard/overview`
