### PR TITLE
Fix example links not working in some situations

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -29,6 +29,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 9, 2), 'Fix some spec links not working in some scenarions', nullDozzer),
   change(date(2023, 8, 30), 'Update SpellLinks to automatically support talents.', ToppleTheNun),
   change(date(2023, 8, 27), 'Fixed broken Warcraft Logs link on the character page.', Bigsxy),
   change(date(2023, 8, 24), 'Stop showing warning of limited support while developing locally', nullDozzer),

--- a/src/interface/SpecListItem.tsx
+++ b/src/interface/SpecListItem.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { Trans } from '@lingui/macro';
 import { isCurrentExpansion } from 'game/Expansion';
 import Contributor from 'interface/ContributorButton';
@@ -23,7 +24,7 @@ const SpecListItem = ({
   const displayName = [i18nSpecName, i18nClassName].filter(isDefined).join(' ');
 
   const className = i18n._(spec.className).replace(/ /g, '');
-  const Component = exampleReport && isCurrentExpansion(expansion) ? 'a' : 'div';
+  const Component = exampleReport && isCurrentExpansion(expansion) ? Link : 'div';
 
   const maintainers = (
     <ReadableListing>
@@ -36,7 +37,7 @@ const SpecListItem = ({
   return (
     <Component
       key={spec.id}
-      href={exampleReport}
+      to={exampleReport?.replace(/^\/*/, '/')}
       title={exampleReport ? 'Open example report' : undefined}
       className="spec-card"
     >


### PR DESCRIPTION
### Description

While running locally, going in to a spec from the `/specs` page would lead to https://wowanalyzer.com/specs/ with a trailing slash, and then some spec-links would not work because they lack a leading slash so would become relative `/specs/report/...` which leads to a 404. 

I can see now that simply going back does not cause this on wowanalyzer.com, so I guess it might be some configuration in the webserver that the local dev server does not correctly reflect. I think it would be good to configure the router to always/never use trailing slashes, but I do not know enough about react-router to try to configure that.

Either way, I think it's a good thing if we ensure that example report links should work by simply ensuring that they have exactly one leading slash.

<!-- A brief description of the changes made with this pull request.-->

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

1. Go to specs page
2. Click any spec
3. Hit back in the browser
4. Click Guardian Druid
5. Do not get a `404`
