### PR TITLE
Druid Resto - Added Grove Guardians / Wild Synthesis module

### DIFF
--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { TALENTS_DRUID } from 'common/TALENTS';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2023, 9, 6), <>Added guide section and statistic for <SpellLink spell={TALENTS_DRUID.GROVE_GUARDIANS_TALENT}/>.</>, Sref),
   change(date(2023, 8, 2), <>Bump resto to 10.1.5</>, Vohrr),
   change(date(2023, 6, 26), <>Added statistic for <SpellLink spell={TALENTS_DRUID.WAKING_DREAM_TALENT}/>.</>, Sref),
   change(date(2023, 6, 20), 'Update SpellLink usage.', ToppleTheNun),

--- a/src/analysis/retail/druid/restoration/CombatLogParser.ts
+++ b/src/analysis/retail/druid/restoration/CombatLogParser.ts
@@ -61,6 +61,7 @@ import Tier29 from 'analysis/retail/druid/restoration/modules/dragonflight/Tier2
 import Tier30 from 'analysis/retail/druid/restoration/modules/dragonflight/Tier30';
 import WildGrowthPrecastOrderNormalizer from 'analysis/retail/druid/restoration/normalizers/WildGrowthPrecastOrderNormalizer';
 import WakingDream from 'analysis/retail/druid/restoration/modules/spells/WakingDream';
+import GroveGuardians from 'analysis/retail/druid/restoration/modules/spells/GroveGuardians';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -126,6 +127,7 @@ class CombatLogParser extends CoreCombatLogParser {
     buddingLeaves: BuddingLeaves,
     dreamstate: Dreamstate,
     wakingDream: WakingDream,
+    groveGuardians: GroveGuardians,
 
     // Mana Tab
     manaTracker: ManaTracker,

--- a/src/analysis/retail/druid/restoration/Guide.tsx
+++ b/src/analysis/retail/druid/restoration/Guide.tsx
@@ -21,6 +21,8 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
         {modules.lifebloom.guideSubsection}
         {modules.efflorescence.guideSubsection}
         {modules.swiftmend.guideSubsection}
+        {info.combatant.hasTalent(TALENTS_DRUID.GROVE_GUARDIANS_TALENT) &&
+          modules.groveGuardians.guideSubsection}
         {info.combatant.hasTalent(TALENTS_DRUID.SOUL_OF_THE_FOREST_RESTORATION_TALENT) &&
           modules.soulOfTheForest.guideSubsection}
         {info.combatant.hasTalent(TALENTS_DRUID.CENARION_WARD_TALENT) &&

--- a/src/analysis/retail/druid/restoration/constants.ts
+++ b/src/analysis/retail/druid/restoration/constants.ts
@@ -36,6 +36,9 @@ export const ABILITIES_AFFECTED_BY_HEALING_INCREASES: number[] = [
   SPELLS.ADAPTIVE_SWARM_HEAL.id,
   SPELLS.GROVE_TENDING.id,
   SPELLS.VERDANCY.id,
+  SPELLS.GROVE_GUARDIANS_SWIFTMEND.id,
+  SPELLS.GROVE_GUARDIANS_NOURISH.id,
+  SPELLS.GROVE_GUARDIANS_WILD_GROWTH.id,
 ];
 
 // procs Nature's Vigil
@@ -53,10 +56,17 @@ export const SINGLE_TARGET_HEALING: Spell[] = [
   SPELLS.SWIFTMEND,
   SPELLS.ADAPTIVE_SWARM_HEAL,
   SPELLS.GROVE_TENDING,
+  // Grove Guardians don't count ):
 ];
 
 export const ABILITIES_AFFECTED_BY_HEALING_INCREASES_SPELL_OBJECTS =
   ABILITIES_AFFECTED_BY_HEALING_INCREASES.map((id) => SPELLS[id]);
+
+/** IDs of heals that get triple benefit from mastery */
+export const TRIPLE_MASTERY_BENEFIT_IDS: number[] = [
+  TALENTS_DRUID.NOURISH_TALENT.id,
+  SPELLS.GROVE_GUARDIANS_NOURISH.id,
+];
 
 /** IDs of all buffs that give a mastery stack */
 export const MASTERY_STACK_BUFF_IDS: number[] = [

--- a/src/analysis/retail/druid/restoration/modules/Abilities.tsx
+++ b/src/analysis/retail/druid/restoration/modules/Abilities.tsx
@@ -109,6 +109,19 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
       },
+      {
+        spell: TALENTS_DRUID.GROVE_GUARDIANS_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS_DRUID.GROVE_GUARDIANS_TALENT),
+        category: SPELL_CATEGORY.ROTATIONAL,
+        gcd: null, // odd that it's off GCD, but it is
+        cooldown: 20,
+        charges: 3,
+        castEfficiency: {
+          recommendedEfficiency: 0.8,
+          averageIssueEfficiency: 0.6,
+          majorIssueEfficiency: 0.3,
+        },
+      },
       // Cooldowns
       {
         spell: SPELLS.TRANQUILITY_CAST.id,

--- a/src/analysis/retail/druid/restoration/modules/core/Mastery.ts
+++ b/src/analysis/retail/druid/restoration/modules/core/Mastery.ts
@@ -12,6 +12,7 @@ import SPELLS from 'common/SPELLS';
 import {
   ABILITIES_AFFECTED_BY_HEALING_INCREASES,
   MASTERY_STACK_BUFF_IDS,
+  TRIPLE_MASTERY_BENEFIT_IDS,
 } from 'analysis/retail/druid/restoration/constants';
 import { specMasteryCoefficient } from 'game/SPECS';
 
@@ -88,7 +89,8 @@ class Mastery extends Analyzer {
 
     if (ABILITIES_AFFECTED_BY_HEALING_INCREASES.includes(spellId)) {
       const hotsOn = this.getHotsOn(target);
-      const numHotsOn = hotsOn.length;
+      const hasTripleMasteryBenefit = TRIPLE_MASTERY_BENEFIT_IDS.includes(spellId);
+      const numHotsOn = hotsOn.length * (hasTripleMasteryBenefit ? 3 : 1);
       const decomposedHeal = this._decompHeal(healVal, numHotsOn);
 
       this.totalNoMasteryHealing += decomposedHeal.noMastery;

--- a/src/analysis/retail/druid/restoration/modules/spells/GroveGuardians.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/GroveGuardians.tsx
@@ -1,0 +1,108 @@
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import { TALENTS_DRUID } from 'common/TALENTS';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { GUIDE_CORE_EXPLANATION_PERCENT } from 'analysis/retail/druid/restoration/Guide';
+import { SpellLink } from 'interface';
+import CastEfficiencyPanel from 'interface/guide/components/CastEfficiencyPanel';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
+import AbilityTracker from 'parser/shared/modules/AbilityTracker';
+import SPELLS from 'common/SPELLS';
+
+const deps = {
+  abilityTracker: AbilityTracker,
+};
+
+/**
+ * **Grove Guardians**
+ * Spec Talent Tier 6
+ *
+ * Summons a Treant which will immediately cast Swiftmend on your current target, healing for X.
+ * The Treant will cast Nourish on that target or a nearby ally periodically,
+ * healing for X. Lasts 15 sec.
+ *
+ * **Wild Synthesis**
+ * Spec Talent Tier 7
+ *
+ * Treants from Grove Guardians also cast Wild Growth immediately when summoned,
+ * healing 5 allies within 40 yds for X over 7 sec.
+ */
+export default class GroveGuardians extends Analyzer.withDependencies(deps) {
+  hasWildSynthesis: boolean;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.GROVE_GUARDIANS_TALENT);
+    this.hasWildSynthesis = this.selectedCombatant.hasTalent(TALENTS_DRUID.WILD_SYNTHESIS_TALENT);
+  }
+
+  get guideSubsection(): JSX.Element {
+    const explanation = (
+      <p>
+        <b>
+          <SpellLink spell={TALENTS_DRUID.GROVE_GUARDIANS_TALENT} />
+        </b>{' '}
+        is an off-GCD heal that interacts minimally with the rest of your kit. Use it whenever extra
+        throughput is needed, but also it's very efficient so you should avoid overcapping on
+        charges.
+      </p>
+    );
+
+    const data = <CastEfficiencyPanel spell={TALENTS_DRUID.GROVE_GUARDIANS_TALENT} useThresholds />;
+
+    return explanationAndDataSubsection(explanation, data, GUIDE_CORE_EXPLANATION_PERCENT);
+  }
+
+  get groveGuardiansHealing() {
+    return (
+      this.deps.abilityTracker.getAbility(SPELLS.GROVE_GUARDIANS_SWIFTMEND.id).healingEffective +
+      this.deps.abilityTracker.getAbility(SPELLS.GROVE_GUARDIANS_NOURISH.id).healingEffective
+    );
+  }
+
+  get wildSynthesisHealing() {
+    return this.deps.abilityTracker.getAbility(SPELLS.GROVE_GUARDIANS_WILD_GROWTH.id)
+      .healingEffective;
+  }
+
+  get totalHealing() {
+    return this.groveGuardiansHealing + this.wildSynthesisHealing;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(6)} // number based on talent row
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
+        tooltip={
+          this.hasWildSynthesis ? (
+            <>
+              This is the sum of the direct healing from the base Grove Guardians (Swiftmend +
+              Nourish) and the extra spell added by Wild Synthesis (Wild Growth).
+              <ul>
+                <li>
+                  <SpellLink spell={TALENTS_DRUID.GROVE_GUARDIANS_TALENT} />:{' '}
+                  <strong>{this.owner.formatItemHealingDone(this.groveGuardiansHealing)}</strong>
+                </li>
+                <li>
+                  <SpellLink spell={TALENTS_DRUID.WILD_SYNTHESIS_TALENT} />:{' '}
+                  <strong>{this.owner.formatItemHealingDone(this.wildSynthesisHealing)}</strong>
+                </li>
+              </ul>
+            </>
+          ) : undefined
+        }
+      >
+        <BoringSpellValueText spell={TALENTS_DRUID.GROVE_GUARDIANS_TALENT}>
+          <ItemPercentHealingDone amount={this.totalHealing} />
+          <br />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}

--- a/src/analysis/retail/druid/restoration/modules/spells/LuxuriantSoil.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/LuxuriantSoil.tsx
@@ -46,7 +46,7 @@ class LuxuriantSoil extends Analyzer {
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={
           <>
-            This is the healing attributable to rejuvenations spawned by the Unending Growth talent.
+            This is the healing attributable to rejuvenations spawned by the Luxuriant Soil talent.
             This amount includes the mastery benefit.
             <ul>
               <li>

--- a/src/common/SPELLS/dragonflight/others.ts
+++ b/src/common/SPELLS/dragonflight/others.ts
@@ -16,6 +16,12 @@ const others = {
     name: 'Power Beyond Imagination',
     icon: 'inv_cosmicvoid_debuff',
   },
+  // 'Disintegrate' ability from The Forgotten Experiements encounter
+  RIONTHUS_DISINTEGRATE: {
+    id: 405457,
+    name: 'Disintegrate',
+    icon: 'ability_evoker_disintegrate',
+  },
 } satisfies Record<string, Spell>;
 
 export default others;

--- a/src/common/SPELLS/druid.ts
+++ b/src/common/SPELLS/druid.ts
@@ -463,6 +463,24 @@ const spells = {
     name: 'Tenacious Flourishing',
     icon: 'talentspec_druid_restoration',
   },
+  // 'Swiftmend' cast by Grove Guardians
+  GROVE_GUARDIANS_SWIFTMEND: {
+    id: 422094,
+    name: 'Swiftmend',
+    icon: 'inv_relics_idolofrejuvenation',
+  },
+  // 'Nourish' cast by Grove Guardians
+  GROVE_GUARDIANS_NOURISH: {
+    id: 422090,
+    name: 'Nourish',
+    icon: 'ability_druid_nourish',
+  },
+  // 'Wild Growth' cast by Grove Guardians
+  GROVE_GUARDIANS_WILD_GROWTH: {
+    id: 422382,
+    name: 'Wild Growth',
+    icon: 'ability_druid_flourish',
+  },
 
   /////////////////////////////////////////////////////////////////////////////
   // GUARDIAN / BEAR

--- a/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
+++ b/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
@@ -23,6 +23,10 @@ const spells: number[] = [
   SPELLS.CLOUDBURST_TOTEM_RECALL.id, // Cloudburst reactivation
   TALENTS_SHAMAN.SPIRITWALKERS_GRACE_TALENT.id,
 
+  //region Boss abilities
+  SPELLS.RIONTHUS_DISINTEGRATE.id, // targeted player is shown as 'casting' this spell
+  //endregion
+
   //region Consumables
   //endregion
 


### PR DESCRIPTION
### Description

Guide subsection + Statistic for the new Resto Druid talent.

Also includes a trivial tooltip correction, and adds to CASTS_THAT_ARENT_CASTS a boss ability that causes spurious player casts to be shown.

### Testing

- Test report URL: `/report/CzbqaJWAcXyjF3NQ/5-Mythic+Kazzara,+the+Hellforged+-+Kill+(5:06)/Azlann/standard`
- Screenshot(s): 
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/7143486/eeba744a-5795-4997-a92f-f0e77d8926cf)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/7143486/cece2836-68e5-41fb-8c98-fdc9c12cbe46)
![wowa_gg](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/7143486/3378740b-4bf7-47f9-b034-da8b2c42c5e7)

Before adding Disintegrate to `CASTS_THAT_ARENT_CASTS`:
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/7143486/92731b34-908c-4b0e-87d8-b175b06376e8)

After:
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/7143486/da61bcb7-bacf-4e42-a7e2-a93adae71901)


