### PR TITLE
Add mana tea statistic

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 9, 6), <>Disable <SpellLink spell={TALENTS_MONK.LIFECYCLES_TALENT}/> and implement <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> statistic</>, Trevor),
   change(date(2023, 9, 5), <>Disable <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> modules until new implementation is added</>, Vohrr),
   change(date(2023, 7, 29), <>Fixed bug in healing per time spent calculation for <SpellLink spell={TALENTS_MONK.ESSENCE_FONT_TALENT}/></>, Trevor),
   change(date(2023, 7, 16), <>Fixed bug in damage calculation for <SpellLink spell={SPELLS.LESSON_OF_DOUBT_BUFF}/></>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
+++ b/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
@@ -52,12 +52,12 @@ import AverageTimeBetweenRSKSs from './modules/spells/AverageTimeBetweenRSKs';
 import ChiBurst from './modules/spells/ChiBurst';
 import InvokeChiJi from './modules/spells/InvokeChiJi';
 import JadeSerpentStatue from './modules/spells/JadeSerpentStatue';
-import Lifecycles from './modules/spells/Lifecycles';
-//import ManaTea from './modules/spells/ManaTea';
+//import Lifecycles from './modules/spells/Lifecycles';
+import ManaTea from './modules/spells/ManaTea';
 import MistyPeaks from './modules/spells/MistyPeaks';
 import MistsOfLife from './modules/spells/MistsOfLife';
 import RefreshingJadeWind from './modules/spells/RefreshingJadeWind';
-//import RenewingMistDuringManaTea from './modules/spells/RenewingMistDuringManaTea';
+import RenewingMistDuringManaTea from './modules/spells/RenewingMistDuringManaTea';
 import RisingMist from './modules/spells/RisingMist';
 import VivaciousVivification from './modules/spells/VivaciousVivify';
 import Upwelling from './modules/spells/Upwelling';
@@ -156,15 +156,15 @@ class CombatLogParser extends CoreCombatLogParser {
     invokeYulon: InvokeYulon,
     jadeSerpentStatue: JadeSerpentStatue,
     jadeBond: JadeBond,
-    lifecycles: Lifecycles,
+    //lifecycles: Lifecycles,
     mistWrap: MistWrap,
-    //manaTea: ManaTea,
+    manaTea: ManaTea,
     mistsOfLife: MistsOfLife,
     mistyPeaks: MistyPeaks,
     nourishingCh: NourishingChi,
     refreshingJadeWind: RefreshingJadeWind,
     renewingMist: RenewingMist,
-    //renewingMistDuringManaTea: RenewingMistDuringManaTea,
+    renewingMistDuringManaTea: RenewingMistDuringManaTea,
     revival: Revival,
     risingMist: RisingMist,
     risingSunRevival: RisingSunRevival,

--- a/src/analysis/retail/monk/mistweaver/modules/features/Checklist/Module.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/Checklist/Module.tsx
@@ -11,7 +11,7 @@ import ThunderFocusTea from '../../spells/ThunderFocusTea';
 import Vivify from '../../spells/Vivify';
 import ChiBurst from '../../spells/ChiBurst';
 import JadeSerpentStatue from '../../spells/JadeSerpentStatue';
-import Lifecycles from '../../spells/Lifecycles';
+//import Lifecycles from '../../spells/Lifecycles';
 //import ManaTea from '../../spells/ManaTea';
 import RefreshingJadeWind from '../../spells/RefreshingJadeWind';
 //import RenewingMistDuringManaTea from '../../spells/RenewingMistDuringManaTea';
@@ -34,7 +34,7 @@ class Checklist extends BaseChecklist {
     refreshingJadeWind: RefreshingJadeWind,
     chiBurst: ChiBurst,
     //manaTea: ManaTea,
-    lifecycles: Lifecycles,
+    //lifecycles: Lifecycles,
     thunderFocusTea: ThunderFocusTea,
     //renewingMistDuringManaTea: RenewingMistDuringManaTea,
     spinningCraneKick: SpinningCraneKick,
@@ -56,7 +56,7 @@ class Checklist extends BaseChecklist {
   protected refreshingJadeWind!: RefreshingJadeWind;
   protected chiBurst!: ChiBurst;
   //protected manaTea!: ManaTea;
-  protected lifecycles!: Lifecycles;
+  //protected lifecycles!: Lifecycles;
   protected thunderFocusTea!: ThunderFocusTea;
   //protected renewingMistDuringManaTea!: RenewingMistDuringManaTea;
   protected spinningCraneKick!: SpinningCraneKick;
@@ -85,7 +85,7 @@ class Checklist extends BaseChecklist {
           refreshingJadeWind: this.refreshingJadeWind.suggestionThresholds,
           chiBurst: this.chiBurst.suggestionThresholds,
           spinningCraneKick: this.spinningCraneKick.suggestionThresholds,
-          lifecycles: this.lifecycles.suggestionThresholds,
+          //lifecycles: this.lifecycles.suggestionThresholds,
           thunderFocusTea: this.thunderFocusTea.suggestionThresholds,
           vivify: this.vivify.suggestionThresholds,
           jadeSerpentStatue: this.jadeSerpentStatue.suggestionThresholds,

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ManaTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ManaTea.tsx
@@ -12,6 +12,7 @@ import Events, {
   ApplyBuffEvent,
   CastEvent,
   HealEvent,
+  RefreshBuffEvent,
   ResourceChangeEvent,
 } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
@@ -58,6 +59,7 @@ class ManaTea extends Analyzer {
   effectiveHealing: number = 0;
   manaPerManaTeaGoal: number = 0;
   overhealing: number = 0;
+  stacksWasted: number = 0;
   manaRestoredSinceLastApply: number = 0;
   protected abilityTracker!: AbilityTracker;
 
@@ -78,6 +80,10 @@ class ManaTea extends Analyzer {
     this.addEventListener(
       Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.MANA_TEA_BUFF),
       this.onApplyBuff,
+    );
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.MANA_TEA_STACK),
+      this.onStackWaste,
     );
     this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.VIVIFY), this.onVivHeal);
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.VIVIFY), this.onVivCast);
@@ -158,6 +164,10 @@ class ManaTea extends Analyzer {
   onManaRestored(event: ResourceChangeEvent) {
     this.manaRestoredSinceLastApply += event.resourceChange;
     this.manaRestoredMT += event.resourceChange;
+  }
+
+  onStackWaste(event: RefreshBuffEvent) {
+    this.stacksWasted += 1;
   }
 
   get avgMtSaves() {
@@ -388,6 +398,7 @@ class ManaTea extends Analyzer {
               {this.avgStacks.toFixed(1)}
             </div>
             <div>Average channel duration: {(this.avgChannelDuration / 1000).toFixed(1)}s</div>
+            <div>Total wasted stacks: {this.stacksWasted}</div>
           </>
         }
       >

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ManaTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ManaTea.tsx
@@ -25,7 +25,10 @@ import TalentSpellText from 'parser/ui/TalentSpellText';
 import RenewingMistDuringManaTea from './RenewingMistDuringManaTea';
 import { PerformanceMark } from 'interface/guide';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
-import { getManaTeaStacksConsumed } from '../../normalizers/CastLinkNormalizer';
+import {
+  getManaTeaChannelDuration,
+  getManaTeaStacksConsumed,
+} from '../../normalizers/CastLinkNormalizer';
 
 interface ManaTeaTracker {
   timestamp: number;
@@ -36,6 +39,7 @@ interface ManaTeaTracker {
   healing: number;
   stacksConsumed: number;
   manaRestored: number;
+  channelTime: number;
 }
 
 class ManaTea extends Analyzer {
@@ -94,6 +98,7 @@ class ManaTea extends Analyzer {
       overhealing: 0,
       stacksConsumed: getManaTeaStacksConsumed(event),
       manaRestored: this.manaRestoredSinceLastApply,
+      channelTime: getManaTeaChannelDuration(event),
     });
     this.manaRestoredSinceLastApply = 0;
   }
@@ -161,6 +166,13 @@ class ManaTea extends Analyzer {
 
   get avgManaRestored() {
     return this.manaRestoredMT / this.manateaCount || 0;
+  }
+
+  get avgChannelDuration() {
+    return (
+      this.castTrackers.reduce((prev: number, cur: ManaTeaTracker) => prev + cur.channelTime, 0) /
+      this.castTrackers.length
+    );
   }
 
   get suggestionThresholds() {
@@ -370,6 +382,7 @@ class ManaTea extends Analyzer {
               Average <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT} /> stacks:{' '}
               {formatNumber(this.avgStacks)}
             </div>
+            <div>Average channel duration: {(this.avgChannelDuration / 1000).toFixed(1)}s</div>
           </>
         }
       >

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ManaTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ManaTea.tsx
@@ -39,7 +39,7 @@ interface ManaTeaTracker {
   healing: number;
   stacksConsumed: number;
   manaRestored: number;
-  channelTime: number;
+  channelTime: number | undefined;
 }
 
 class ManaTea extends Analyzer {
@@ -169,10 +169,15 @@ class ManaTea extends Analyzer {
   }
 
   get avgChannelDuration() {
-    return (
-      this.castTrackers.reduce((prev: number, cur: ManaTeaTracker) => prev + cur.channelTime, 0) /
-      this.castTrackers.length
-    );
+    let totalValid = 0;
+    let totalDuration = 0;
+    this.castTrackers.forEach((tracker) => {
+      if (tracker !== undefined) {
+        totalValid += 1;
+        totalDuration += tracker.channelTime!;
+      }
+    });
+    return totalDuration / totalValid;
   }
 
   get suggestionThresholds() {
@@ -380,7 +385,7 @@ class ManaTea extends Analyzer {
             <div>Total mana restored: {formatNumber(this.manaRestoredMT)}</div>
             <div>
               Average <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT} /> stacks:{' '}
-              {formatNumber(this.avgStacks)}
+              {this.avgStacks.toFixed(1)}
             </div>
             <div>Average channel duration: {(this.avgChannelDuration / 1000).toFixed(1)}s</div>
           </>

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RenewingMistDuringManaTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RenewingMistDuringManaTea.tsx
@@ -26,11 +26,11 @@ class RenewingMistDuringManaTea extends Analyzer {
     }
 
     this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(TALENTS_MONK.MANA_TEA_TALENT),
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.MANA_TEA_BUFF),
       this.manaTeaStart,
     );
     this.addEventListener(
-      Events.removebuff.by(SELECTED_PLAYER).spell(TALENTS_MONK.MANA_TEA_TALENT),
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.MANA_TEA_BUFF),
       this.manaTeaEnd,
     );
 

--- a/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
@@ -38,6 +38,7 @@ export const SOOM_GOM = 'SoomGOM';
 export const VIVIFY = 'Vivify';
 export const CALMING_COALESCENCE = 'Calming Coalescence';
 export const MANA_TEA_CHANNEL = 'MTChannel';
+export const MANA_TEA_CAST_LINK = 'MTLink';
 export const MT_BUFF_REMOVAL = 'MTStack';
 
 const RAPID_DIFFUSION_BUFFER_MS = 300;
@@ -342,6 +343,21 @@ const EVENT_LINKS: EventLink[] = [
     referencedEventType: EventType.RemoveBuff,
     forwardBufferMs: MAX_MT_CHANNEL,
     maximumLinks: 1,
+    anyTarget: true,
+    isActive(c) {
+      return c.hasTalent(TALENTS_MONK.MANA_TEA_TALENT);
+    },
+  },
+  {
+    linkRelation: MANA_TEA_CAST_LINK,
+    reverseLinkRelation: MANA_TEA_CAST_LINK,
+    linkingEventId: SPELLS.MANA_TEA_CAST.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: SPELLS.MANA_TEA_BUFF.id,
+    referencedEventType: EventType.ApplyBuff,
+    forwardBufferMs: MAX_MT_CHANNEL,
+    maximumLinks: 1,
+    anyTarget: true,
     isActive(c) {
       return c.hasTalent(TALENTS_MONK.MANA_TEA_TALENT);
     },
@@ -559,7 +575,11 @@ export function getManaTeaStacksConsumed(event: ApplyBuffEvent) {
 }
 
 export function getManaTeaChannelDuration(event: ApplyBuffEvent) {
-  return GetRelatedEvents(event, MT_BUFF_REMOVAL)[0].timestamp - event.timestamp;
+  const castEvent = GetRelatedEvents(event, MANA_TEA_CAST_LINK)[0];
+  if (castEvent === undefined) {
+    return undefined;
+  }
+  return GetRelatedEvents(castEvent, MANA_TEA_CHANNEL)[0].timestamp - castEvent.timestamp;
 }
 
 export default CastLinkNormalizer;

--- a/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
@@ -558,4 +558,8 @@ export function getManaTeaStacksConsumed(event: ApplyBuffEvent) {
   return Math.round(diff / 1000);
 }
 
+export function getManaTeaChannelDuration(event: ApplyBuffEvent) {
+  return GetRelatedEvents(event, MT_BUFF_REMOVAL)[0].timestamp - event.timestamp;
+}
+
 export default CastLinkNormalizer;

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -178,6 +178,21 @@ const spells = {
     name: 'Enveloping Breath',
     icon: 'ability_monk_jadeserpentbreath',
   },
+  MANA_TEA_STACK: {
+    id: 115867,
+    name: 'Mana Tea',
+    icon: 'inv_misc_herb_jadetealeaf',
+  },
+  MANA_TEA_CAST: {
+    id: 115294,
+    name: 'Mana Tea',
+    icon: 'monk_ability_cherrymanatea',
+  },
+  MANA_TEA_BUFF: {
+    id: 197908,
+    name: 'Mana Tea',
+    icon: 'monk_ability_cherrymanatea',
+  },
   SOOTHING_BREATH: {
     id: 343737,
     name: 'Soothing Breath',


### PR DESCRIPTION
### Description

Adds statistic and scaffolding for guide part (but not guide section quite yet). Also disables lifecycles for now

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `report/ghkWqFVA8tBP92c1/50-Mythic+Magmorax+-+Kill+(4:54)/Livingmist/standard/statistics`
- Screenshot(s): 
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/713d22ac-3476-4f1c-bc3b-6ecd8eebaf69)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/ee315b72-0dda-4e56-83b5-53028ec24e53)

