### PR TITLE
Add SpellManaCost module to MW and change MT/CF modules accordingly

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 9, 7), <>Improve mana reduction logic in all modules</>, Trevor),
   change(date(2023, 9, 6), <>Disable <SpellLink spell={TALENTS_MONK.LIFECYCLES_TALENT}/> and implement <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> statistic</>, Trevor),
   change(date(2023, 9, 5), <>Disable <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> modules until new implementation is added</>, Vohrr),
   change(date(2023, 7, 29), <>Fixed bug in healing per time spent calculation for <SpellLink spell={TALENTS_MONK.ESSENCE_FONT_TALENT}/></>, Trevor),

--- a/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
+++ b/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
@@ -88,6 +88,7 @@ import CalmingCoalescence from './modules/spells/CalmingCoalescence';
 import LifeCocoon from './modules/spells/LifeCocoon';
 import SecretInfusion from './modules/spells/SecretInfusion';
 import CallToDominance from '../../../../parser/retail/modules/items/dragonflight/CallToDominance';
+import MWSpellManaCost from './modules/core/SpellManaCost';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -97,6 +98,7 @@ class CombatLogParser extends CoreCombatLogParser {
     hotRemovalNormalizer: HotRemovalNormalizer,
 
     // Core
+    mwSpellManaCost: MWSpellManaCost,
     lowHealthHealing: LowHealthHealing,
     channeling: CoreChanneling,
     globalCooldown: GlobalCooldown,

--- a/src/analysis/retail/monk/mistweaver/constants.ts
+++ b/src/analysis/retail/monk/mistweaver/constants.ts
@@ -43,6 +43,7 @@ export const RAPID_DIFFUSION_DURATION = 3000; // per rank
 export const RISING_MIST_EXTENSION = 4000;
 export const ENVELOPING_MIST_INCREASE = 0.3;
 export const MISTWRAP_INCREASE = 0.1;
+export const YULON_REDUCTION = 0.5;
 
 export const LIFECYCLES_MANA_PERC_REDUCTION = 0.25;
 

--- a/src/analysis/retail/monk/mistweaver/constants.ts
+++ b/src/analysis/retail/monk/mistweaver/constants.ts
@@ -32,9 +32,10 @@ export const LIFE_COCOON_HEALING_BOOST = 0.5;
 export const TEACHINGS_OF_THE_MONASTERY_DURATION = 20000;
 
 // Talent Constants
+export const CF_BUFF_PER_STACK = 0.2;
 export const MAX_CHIJI_STACKS = 3;
 export const LIFECYCLES_MANA_REDUCTION_PERCENT = 0.25;
-export const MANA_TEA_DURATION = 10000;
+export const MANA_TEA_REDUCTION = 0.5;
 export const JADE_BOND_INC = 0.4;
 export const NOURISHING_CHI_INC = 0.2;
 export const DANCING_MIST_CHANCE = 0.05; // per rank

--- a/src/analysis/retail/monk/mistweaver/modules/core/SpellManaCost.ts
+++ b/src/analysis/retail/monk/mistweaver/modules/core/SpellManaCost.ts
@@ -1,0 +1,72 @@
+import SPELLS from 'common/SPELLS';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import { SELECTED_PLAYER } from 'parser/core/EventFilter';
+import Events, { ApplyBuffStackEvent, CastEvent, RemoveBuffEvent } from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+import SpellResourceCost from 'parser/shared/modules/SpellResourceCost';
+import { TALENTS_MONK } from 'common/TALENTS';
+import { CF_BUFF_PER_STACK } from '../../constants';
+
+const CF_SPELLS: Set<number> = new Set([SPELLS.VIVIFY.id, TALENTS_MONK.ENVELOPING_MIST_TALENT.id]);
+
+class MWSpellManaCost extends SpellResourceCost {
+  static resourceType = RESOURCE_TYPES.MANA;
+  currentBuffs: Set<number> = new Set();
+  hasCF: boolean = false;
+  hasChiji: boolean = false;
+  cfStacks: number = 0;
+  constructor(options: Options) {
+    super(options);
+    this.addEventListener(
+      Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.CLOUDED_FOCUS_BUFF),
+      this.onCfApply,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.CLOUDED_FOCUS_BUFF),
+      this.onCfRemove,
+    );
+    this.hasChiji = this.selectedCombatant.hasTalent(
+      TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT,
+    );
+    this.hasCF = this.selectedCombatant.hasTalent(TALENTS_MONK.CLOUDED_FOCUS_TALENT);
+  }
+
+  onCfApply(event: ApplyBuffStackEvent) {
+    this.cfStacks = event.stack - 1;
+  }
+
+  onCfRemove(event: RemoveBuffEvent) {
+    this.cfStacks = 0;
+  }
+
+  findAdjustedSpellResourceCost(spellID: number, originalCost: number) {
+    return originalCost * this.getCurrentMultiplierForSpell(spellID);
+  }
+
+  getResourceCost(event: CastEvent): number {
+    const cost = super.getResourceCost(event);
+    return this.findAdjustedSpellResourceCost(event.ability.guid, cost);
+  }
+
+  getCurrentMultiplierForSpell(spellID: number): number {
+    if (this.selectedCombatant.hasBuff(SPELLS.INNERVATE.id)) {
+      return 0;
+    }
+    const cloudedFocusMultiplier =
+      this.hasCF && CF_SPELLS.has(spellID) ? 1 - this.cfStacks * CF_BUFF_PER_STACK : 1;
+    const chijiMultiplier =
+      this.hasChiji && spellID === TALENTS_MONK.ENVELOPING_MIST_TALENT.id
+        ? 1 - this.selectedCombatant.getBuffStacks(SPELLS.INVOKE_CHIJI_THE_RED_CRANE_BUFF.id) / 3
+        : 1;
+    const yulonMultiplier =
+      !this.hasChiji &&
+      spellID === TALENTS_MONK.ENVELOPING_MIST_TALENT.id &&
+      this.selectedCombatant.hasBuff(SPELLS.INVOKE_YULON_BUFF.id)
+        ? 0.5
+        : 1;
+    const manaTeaMultiplier = this.selectedCombatant.hasBuff(SPELLS.MANA_TEA_BUFF.id) ? 0.5 : 1;
+    return manaTeaMultiplier * cloudedFocusMultiplier * chijiMultiplier * yulonMultiplier;
+  }
+}
+
+export default MWSpellManaCost;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/CloudedFocus.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/CloudedFocus.tsx
@@ -21,11 +21,11 @@ import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import TalentSpellText from 'parser/ui/TalentSpellText';
 import { getVivifiesPerCast } from '../../normalizers/CastLinkNormalizer';
 import DonutChart from 'parser/ui/DonutChart';
-import { SPELL_COLORS } from '../../constants';
+import { CF_BUFF_PER_STACK, SPELL_COLORS } from '../../constants';
 import WarningIcon from 'interface/icons/Warning';
 import CheckmarkIcon from 'interface/icons/Checkmark';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
-const BUFF_AMOUNT_PER_STACK = 0.2;
 const debug = false;
 /**
  * Whenever you cast a vivify or enveloping mist during soothing mist's channel you gain a stack of clouded focus which increases their healing by 20% and descreases their
@@ -143,13 +143,10 @@ class CloudedFocus extends Analyzer {
     }
     debug && console.log('Current Stacks: ', this.stacks, 'Mana Stacks: ', this.manaStacks, event);
 
-    let cost = event.rawResourceCost ? event.rawResourceCost[0] : 0;
-    if (this.selectedCombatant.hasBuff(TALENTS_MONK.MANA_TEA_TALENT.id)) {
-      cost /= 2;
-    }
-
+    const cost = event.resourceCost ? event.resourceCost[RESOURCE_TYPES.MANA.id] : 0;
     this.addManaToStackMap(spellId, cost);
-    this.manaSaved += cost - cost * (1 - this.manaStacks * BUFF_AMOUNT_PER_STACK);
+    const preCFCost = cost / (1 - CF_BUFF_PER_STACK * this.manaStacks);
+    this.manaSaved += preCFCost - cost;
   }
 
   calculateHealingEffect(event: HealEvent) {
@@ -158,7 +155,7 @@ class CloudedFocus extends Analyzer {
       return;
     }
     this.addHealingToStackMap(spellId, event);
-    this.healingDone += calculateEffectiveHealing(event, this.stacks * BUFF_AMOUNT_PER_STACK);
+    this.healingDone += calculateEffectiveHealing(event, this.stacks * CF_BUFF_PER_STACK);
   }
 
   applyBuff(event: ApplyBuffEvent) {
@@ -199,7 +196,7 @@ class CloudedFocus extends Analyzer {
   }
 
   addManaToStackMap(spellId: number, cost: number) {
-    const mana = cost - cost * (1 - this.manaStacks * BUFF_AMOUNT_PER_STACK);
+    const mana = cost - cost * (1 - this.manaStacks * CF_BUFF_PER_STACK);
     const current = this.stackMap.get(this.makeKey(spellId, this.stacks));
     if (current) {
       current.manaSaved += mana;
@@ -216,8 +213,8 @@ class CloudedFocus extends Analyzer {
 
   addHealingToStackMap(spellId: number, event: HealEvent) {
     const current = this.stackMap.get(this.makeKey(spellId, this.stacks));
-    const effectiveHealing = calculateEffectiveHealing(event, this.stacks * BUFF_AMOUNT_PER_STACK);
-    const overHealing = calculateOverhealing(event, this.stacks * BUFF_AMOUNT_PER_STACK);
+    const effectiveHealing = calculateEffectiveHealing(event, this.stacks * CF_BUFF_PER_STACK);
+    const overHealing = calculateOverhealing(event, this.stacks * CF_BUFF_PER_STACK);
     if (current) {
       current.healing += effectiveHealing;
       current.overhealing += overHealing;


### PR DESCRIPTION
### Description

Adds module to update mana costs properly based on stacking mana multipliers.


- Test report URL:  `report/ghkWqFVA8tBP92c1/50-Mythic+Magmorax+-+Kill+(4:54)/Livingmist/standard/statistics`
- Screenshot(s):
Before
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/262d00d2-8656-4606-b9cc-b8add4be126e)

After
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/2260c817-2b61-49b8-82a6-62ae9c8992a9)

