### PR TITLE
[Mistweaver] Mana Tea Bug Fixes

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 9, 9), <>Fixed Wasted stacks and prepull casts of <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> causing average channel duration to be NaN</>, Vohrr),
   change(date(2023, 9, 7), <>Improve mana reduction logic in all modules</>, Trevor),
   change(date(2023, 9, 6), <>Disable <SpellLink spell={TALENTS_MONK.LIFECYCLES_TALENT}/> and implement <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> statistic</>, Trevor),
   change(date(2023, 9, 5), <>Disable <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> modules until new implementation is added</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/constants.ts
+++ b/src/analysis/retail/monk/mistweaver/constants.ts
@@ -35,6 +35,7 @@ export const TEACHINGS_OF_THE_MONASTERY_DURATION = 20000;
 export const CF_BUFF_PER_STACK = 0.2;
 export const MAX_CHIJI_STACKS = 3;
 export const LIFECYCLES_MANA_REDUCTION_PERCENT = 0.25;
+export const MANA_TEA_MAX_STACKS = 20;
 export const MANA_TEA_REDUCTION = 0.5;
 export const JADE_BOND_INC = 0.4;
 export const NOURISHING_CHI_INC = 0.2;

--- a/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
@@ -40,6 +40,7 @@ export const CALMING_COALESCENCE = 'Calming Coalescence';
 export const MANA_TEA_CHANNEL = 'MTChannel';
 export const MANA_TEA_CAST_LINK = 'MTLink';
 export const MT_BUFF_REMOVAL = 'MTStack';
+export const MT_STACK_CHANGE = 'MTStackChange';
 
 const RAPID_DIFFUSION_BUFFER_MS = 300;
 const DANCING_MIST_BUFFER_MS = 250;
@@ -373,6 +374,16 @@ const EVENT_LINKS: EventLink[] = [
       return c.hasTalent(TALENTS_MONK.MANA_TEA_TALENT);
     },
   },
+  {
+    linkRelation: MT_STACK_CHANGE,
+    linkingEventId: SPELLS.MANA_TEA_STACK.id,
+    linkingEventType: EventType.RefreshBuff,
+    referencedEventId: SPELLS.MANA_TEA_STACK.id,
+    referencedEventType: [EventType.RemoveBuffStack, EventType.ApplyBuffStack],
+    isActive(c) {
+      return c.hasTalent(TALENTS_MONK.MANA_TEA_TALENT);
+    },
+  },
 ];
 
 /**
@@ -580,6 +591,10 @@ export function getManaTeaChannelDuration(event: ApplyBuffEvent) {
     return undefined;
   }
   return GetRelatedEvents(castEvent, MANA_TEA_CHANNEL)[0].timestamp - castEvent.timestamp;
+}
+
+export function HasStackChange(event: RefreshBuffEvent): boolean {
+  return HasRelatedEvent(event, MT_STACK_CHANGE);
 }
 
 export default CastLinkNormalizer;


### PR DESCRIPTION
### Description

Fixed Wasted Stacks Tally
Band-aid for  Average Channel Duration showing NaN when mana tea is cast pre pull

- Test report URL: `report/xmL1dAnFKVkqgfhj/51-Mythic+Scalecommander+Sarkareth+-+Kill+(6:52)/16-Toixic/standard`

### Screenshot(s):

Before: 
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/26779541/7f83c65f-d05c-4520-84c5-bb8753fe136a)

After: 
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/26779541/7c32fbd4-7dbc-46c4-8a47-8c8df4b141d4)
