### PR TITLE
[Augmentation] Fix issue with buff graph show wrong amount of Ebon Mights

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+    change(date(2023, 9, 10), <>Fix issue with buff graph showing wrong amount of active <SpellLink spell={SPELLS.EBON_MIGHT_BUFF_EXTERNAL} />.</>, Vollmer),
     change(date(2023, 9, 2), <>Fix issue with <SpellLink spell={SPELLS.SHIFTING_SANDS_BUFF} /> module when targets wasn't defined.</>, Vollmer),
     change(date(2023, 8, 31), <>Fix issue with <SpellLink spell={SPELLS.SHIFTING_SANDS_BUFF} /> module when targets buffs wasn't defined.</>, Vollmer),
     change(date(2023, 8, 30), <>Fix issue with <SpellLink spell={TALENTS.EBON_MIGHT_TALENT} /> module when buff target spec wasn't defined.</>, Vollmer),

--- a/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
@@ -115,7 +115,7 @@ const EVENT_LINKS: EventLink[] = [
     linkingEventType: [EventType.ApplyBuff],
     referencedEventId: SPELLS.EBON_MIGHT_BUFF_EXTERNAL.id,
     referencedEventType: [EventType.RemoveBuff],
-    anyTarget: true,
+    anyTarget: false,
   },
   {
     linkRelation: BREATH_OF_EONS_CAST_DEBUFF_APPLY_LINK,


### PR DESCRIPTION
### Description

CastLink was set to `anyTarget=true` when it should have been `anyTarget=false`
Gave weird behaviour with buff count being inaccurate with player deaths.

### Testing

- Test report URL: `/report/QVaCpdhHnbrRfwgP/24-Mythic+Scalecommander+Sarkareth+-+Kill+(6:08)/Bervoker/standard/overview`
