### PR TITLE
Show Dampen Harm DR %

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,4 +12,4 @@ indent_style = space
 indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
-max_line_length = null
+max_line_length = off

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.direnv
 
 # eslint
 .eslintcache

--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2023, 9, 10), <>Added <SpellLink spell={talents.DAMPEN_HARM_TALENT} /> DR % Statistic</>, emallson),
   change(date(2023, 7, 25), <>Update example report to be a 10.1.5 log</>, emallson),
   change(date(2023, 7, 24), <>Update rotational support for 10.1.5</>, emallson),
   change(date(2023, 7, 22), <>Added support for <SpellLink spell={talents.PRESS_THE_ADVANTAGE_TALENT} />.</>, emallson),

--- a/src/analysis/retail/monk/shared/DampenHarm.tsx
+++ b/src/analysis/retail/monk/shared/DampenHarm.tsx
@@ -16,14 +16,18 @@ import Events, {
   HealEvent,
 } from 'parser/core/Events';
 import BoringValue from 'parser/ui/BoringValueText';
+import FooterChart, { Spec } from 'parser/ui/FooterChart';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import { ReactNode } from 'react';
 
 type Hit = {
   amount: number;
+  preAmount: number;
   relativeAmount: number;
+  preRelativeAmount: number;
   drPercent: number;
+  timestamp: number;
 };
 
 class DampenHarm extends MajorDefensiveBuff {
@@ -59,19 +63,24 @@ class DampenHarm extends MajorDefensiveBuff {
     const a = event.absorbed || 0;
     const o = event.overkill || 0;
     const hitSize = h + a + o;
-    let drdh = 0;
-    // given 1 - u / h = 0.2 + 0.3 * u, where u = hit size after all other dr effecs, h = current max hp
-    // the following can be then produced algebraically:
-    if (hitSize >= maxHP / 2) {
-      drdh = 0.5;
-    } else {
-      drdh = 0.6 - 0.5 * Math.sqrt(0.64 - (6 * hitSize) / (5 * maxHP));
-    }
+    // the formula is:
+    // dr = 1 - (0.2 + 0.3 * preHitSize / maxHp)
+    // hitSize = preHitSize * dr
+    //
+    // we want to solve for dr, which requires finding preHitSize. plugging this into a solver because i cba to triple check my math, we have:
+    //
+    // preHitSize ~= 1/3 (4 * maxHp ± sqrt((2 * maxHp) * (8 * maxHp - 15 * hitSize)))
+    const preHitSize =
+      (4 * maxHP - Math.sqrt(2 * maxHP * Math.max(0, 8 * maxHP - 15 * hitSize))) / 3;
+    const drdh = Math.min(0.5, 0.2 + (0.3 * preHitSize) / maxHP);
 
     this.hitsMitigated.push({
       amount: hitSize,
+      preAmount: preHitSize,
       relativeAmount: hitSize / maxHP,
+      preRelativeAmount: preHitSize / maxHP,
       drPercent: drdh,
+      timestamp: event.timestamp,
     });
 
     const mitigatedAmount = absoluteMitigation(event, drdh);
@@ -83,6 +92,53 @@ class DampenHarm extends MajorDefensiveBuff {
 
   updateMaxHP(event: DamageEvent | ResourceChangeEvent | DrainEvent | HealEvent) {
     this.currentMaxHP = event.maxHitPoints || this.currentMaxHP;
+  }
+
+  private get spec() {
+    const scale = 0.025;
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const spec = {
+      layer: [
+        {
+          mark: { type: 'bar', tooltip: true },
+          transform: [
+            { calculate: `floor(datum.drPercent / ${scale})`, as: 'binIndex' },
+            {
+              aggregate: [{ op: 'count', as: 'count' }],
+              groupby: ['binIndex'],
+            },
+            {
+              calculate: `datum.binIndex * ${scale}`,
+              as: 'drPercent',
+            },
+          ],
+          encoding: {
+            x: {
+              field: 'drPercent',
+              type: 'quantitative' as const,
+              title: 'DR %',
+              scale: { zero: true, domain: [scale, 0.5 + scale] },
+              axis: {
+                format: '~%',
+              },
+            },
+            y: {
+              field: 'count',
+              type: 'quantitative' as const,
+              title: '# of Hits',
+              axis: {
+                grid: false,
+                format: '~k',
+              },
+              scale: {
+                zero: true,
+              },
+            },
+          },
+        },
+      ],
+    } as Spec;
+    return spec;
   }
 
   description(): ReactNode {
@@ -122,28 +178,32 @@ class DampenHarm extends MajorDefensiveBuff {
     const trueAvgDr =
       this.hitsMitigated.reduce((total, hit) => total + hit.drPercent, 0) /
       this.hitsMitigated.length;
+
     return (
       <>
         <MajorDefensiveStatistic analyzer={this} category={STATISTIC_CATEGORY.TALENTS} />
         {relevantHits.length > 0 && (
           <Statistic
+            category={STATISTIC_CATEGORY.TALENTS}
             size="flexible"
             tooltip={
               <>
                 Mitigated {relevantHits.length} hits. Hits for less than 5% of max HP are excluded
-                from average. When they are included, avg DR is {formatPercentage(trueAvgDr)}%
+                from average. When they are included, average damage reduction is{' '}
+                {formatPercentage(trueAvgDr)}%
               </>
             }
           >
             <BoringValue
               label={
                 <>
-                  Average <SpellLink spell={talents.DAMPEN_HARM_TALENT} /> Damage Reduction
+                  Avg <SpellLink spell={talents.DAMPEN_HARM_TALENT} /> DR
                 </>
               }
             >
               {formatPercentage(avgDr)}%
             </BoringValue>
+            <FooterChart spec={this.spec} data={relevantHits} />
           </Statistic>
         )}
       </>


### PR DESCRIPTION
### Description

Requested by Kate.

Dampen Harm has a variable DR % depending on hit size. This shows the amount DR on avg, with a basic histogram chart showing the distribution.

### Testing
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/4909458/1eb4c95c-767f-480f-81a9-55daa6a5e58d)