### PR TITLE
fix CF bugs

### DIFF
--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2023, 9, 10), <>Fix bug in <SpellLink spell={SPELLS.CELESTIAL_FORTUNE_HEAL} /> analysis related to <SpellLink spell={talents.BONEDUST_BREW_TALENT} /> triggers.</>, emallson),
   change(date(2023, 9, 10), <>Added <SpellLink spell={talents.DAMPEN_HARM_TALENT} /> DR % Statistic</>, emallson),
   change(date(2023, 7, 25), <>Update example report to be a 10.1.5 log</>, emallson),
   change(date(2023, 7, 24), <>Update rotational support for 10.1.5</>, emallson),


### PR DESCRIPTION
1. forgot to update coefficient based on spell changes from 10.1
2. fixed interaction with BDB where both BDB and CF can trigger from a heal at timestamp X, but the CF could be related to the BDB *or* the heal
