### PR TITLE
Fixed an issue that would cause clearcast consumes to not be caught in high lag. Added proper handling for Tranquil Mind.

### DIFF
--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { TALENTS_DRUID } from 'common/TALENTS';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2023, 9, 15), <>Added handling for <SpellLink spell={TALENTS_DRUID.TRANQUIL_MIND_TALENT}/> in the Regrowth/Clearcasting statistic. Fixed an issue that could cause misattribution of Clearcasts during high lag.</>, Sref),
   change(date(2023, 9, 6), <>Added guide section and statistic for <SpellLink spell={TALENTS_DRUID.GROVE_GUARDIANS_TALENT}/>.</>, Sref),
   change(date(2023, 8, 2), <>Bump resto to 10.1.5</>, Vohrr),
   change(date(2023, 6, 26), <>Added statistic for <SpellLink spell={TALENTS_DRUID.WAKING_DREAM_TALENT}/>.</>, Sref),

--- a/src/analysis/retail/druid/restoration/modules/spells/RegrowthAndClearcasting.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/RegrowthAndClearcasting.tsx
@@ -57,11 +57,13 @@ class RegrowthAndClearcasting extends Analyzer {
   castEntries: BoxRowEntry[] = [];
 
   hasAbundance: boolean;
+  hasTranquilMind: boolean;
 
   constructor(options: Options) {
     super(options);
 
     this.hasAbundance = this.selectedCombatant.hasTalent(TALENTS_DRUID.ABUNDANCE_TALENT);
+    this.hasTranquilMind = this.selectedCombatant.hasTalent(TALENTS_DRUID.TRANQUIL_MIND_TALENT);
 
     this.addEventListener(
       Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.CLEARCASTING_BUFF),
@@ -84,6 +86,16 @@ class RegrowthAndClearcasting extends Analyzer {
   }
 
   onRefreshClearcast() {
+    if (
+      this.hasTranquilMind &&
+      this.selectedCombatant.getBuffStacks(SPELLS.CLEARCASTING_BUFF.id) === 1
+    ) {
+      // With Tranquil Mind talent, a refreshbuff occurs when player USES a clearcast at 2 stacks -
+      // we don't want to count that as an overwrite or a clearcast gained.
+      // The refresh happens after the 2nd stack is lost, so we can tell this happened by stack count
+      return;
+    }
+
     this.totalClearcasts += 1;
     this.overwrittenClearcasts += 1;
   }

--- a/src/analysis/retail/druid/restoration/normalizers/ClearcastingNormalizer.ts
+++ b/src/analysis/retail/druid/restoration/normalizers/ClearcastingNormalizer.ts
@@ -3,7 +3,7 @@ import { CastEvent, EventType, HasRelatedEvent, RemoveBuffEvent } from 'parser/c
 import { Options } from 'parser/core/Module';
 import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
 
-const BUFFER_MS = 50;
+const BUFFER_MS = 200;
 const BUFFED_REGROWTH = 'BuffedRegrowth';
 const BUFFED_BY_CLEARCAST = 'BuffedByClearcast';
 
@@ -12,7 +12,7 @@ const EVENT_LINKS: EventLink[] = [
     linkRelation: BUFFED_REGROWTH,
     reverseLinkRelation: BUFFED_BY_CLEARCAST,
     linkingEventId: SPELLS.CLEARCASTING_BUFF.id,
-    linkingEventType: EventType.RemoveBuff,
+    linkingEventType: [EventType.RemoveBuff, EventType.RemoveBuffStack],
     referencedEventId: SPELLS.REGROWTH.id,
     referencedEventType: EventType.Cast,
     forwardBufferMs: BUFFER_MS,


### PR DESCRIPTION
### Description

Tranquil Mind talent allows Clearcasting to stack to 2, which breaks existing handling. This PR fixes the handling when player takes Tranquil Mind.

I also discovered that the gap between Regrowth cast and Clearcast fade could be a lot longer than the normalizer's buffer, so I increased the buffer. This should be safe, because the only other way a Clearcast fades is expiration, which is likely to be far away from a Regrowth cast and doesn't happen often - I don't think misattribution is a risk here.

### Testing

- Test report URL: `/report/BbKztwdMApfnrTLy/2-Heroic+Council+of+Dreams+-+Kill+(8:02)/Vrocas/standard/statistics`