### PR TITLE
[elemental, small core] Reorder sections and make guide default. 

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -29,11 +29,12 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 9, 17), 'CooldownGraphSubsection now takes an optional parameter "description", which will be used instead of the default one if given.', Awildfivreld),
   change(date(2023, 9, 12), 'Disable M+ logs containing Augmentation Evokers temporarily.', ToppleTheNun),
   change(date(2023, 9, 6), "Reworked getRepeatedTalentCount to use getTalentRank behind the scenes, and renamed it to getMultipleTalentRanks.", Putro),
   change(date(2023, 9, 5), 'Add Classic Guild page', jazminite),
   change(date(2023, 9, 5), 'Update talent data for patch 10.1.7', emallson),
-  change(date(2023, 9, 4), <>Add module for tracking of <ItemLink id={ITEMS.ACCELERATING_SANDGLASS.id}/>.</>, nullDozzer),
+  change(date(2023, 9, 4), <>Add module for tracking of <ItemLink id={ITEMS.ACCELERATING_SANDGLASS.id} />.</>, nullDozzer),
   change(date(2023, 9, 2), 'Refactor haste buffs to be more understandable. Implements some haste buffs that were non-functional.', nullDozzer),
   change(date(2023, 9, 2), 'Fix some spec links not working in some scenarions', nullDozzer),
   change(date(2023, 8, 30), 'Update SpellLinks to automatically support talents.', ToppleTheNun),

--- a/src/analysis/retail/shaman/elemental/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/elemental/CHANGELOG.tsx
@@ -5,7 +5,8 @@ import { HawkCorrigan, Putro, Zeboot, Maximaw, Zea, emallson, Vetyst, Periodic, 
 import { SpellLink } from 'interface';
 
 export default [
-  change(date(2023, 9, 30), <>Use the correct spell id for <SpellLink spell={TALENTS.STORMKEEPER_1_ELEMENTAL_TALENT}/> casts.</>, Putro),
+  change(date(2023, 9, 17), <>Reorder guide sections and make the guide default.</>, Awildfivreld),
+  change(date(2023, 9, 30), <>Use the correct spell id for <SpellLink spell={TALENTS.STORMKEEPER_1_ELEMENTAL_TALENT} /> casts.</>, Putro),
   change(date(2023, 8, 30), <>Add section on electrified shocks.</>, Awildfivreld),
   change(date(2023, 8, 13), <>Add section on always be casting, with graph.</>, Awildfivreld),
   change(date(2023, 8, 12), <>Fix and improve the resource graph, and add a section on it in the guide section.</>, Awildfivreld),

--- a/src/analysis/retail/shaman/elemental/CONFIG.tsx
+++ b/src/analysis/retail/shaman/elemental/CONFIG.tsx
@@ -53,6 +53,7 @@ export default {
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
   exampleReport:
     '/report/L1R2zVKY8ZDxCTNb/15-Mythic+Scalecommander+Sarkareth+-+Kill+(7:21)/Nerdshockz/standard',
+  guideDefault: true,
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/shaman/elemental/guide/ElementalGuide.tsx
+++ b/src/analysis/retail/shaman/elemental/guide/ElementalGuide.tsx
@@ -117,14 +117,12 @@ export default function ElementalGuide(props: GuideProps<typeof CombatLogParser>
         <CooldownGraphSubsection
           cooldowns={defensiveTalents}
           description={
-            <>
-              <p>
-                <strong>Defensives and utility</strong> - Defensive and utility talent usage may
-                vary from fight to fight. They may need to be delayed for specific mechanics. In
-                general, any amount of usage is good, but anywhere you could fit in another usage is
-                a theoretical loss.
-              </p>
-            </>
+            <p>
+              <strong>Defensives and utility</strong> - Defensive and utility talent usage may vary
+              from fight to fight. They may need to be delayed for specific mechanics. In general,
+              any amount of usage is good, but anywhere you could fit in another usage is a
+              theoretical loss.
+            </p>
           }
         />
       </Section>

--- a/src/analysis/retail/shaman/elemental/guide/ElementalGuide.tsx
+++ b/src/analysis/retail/shaman/elemental/guide/ElementalGuide.tsx
@@ -2,24 +2,11 @@ import { GuideProps, Section } from 'interface/guide';
 import TALENTS, { TALENTS_SHAMAN } from 'common/TALENTS/shaman';
 import CombatLogParser from '../CombatLogParser';
 import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
-import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
-import { GapHighlight } from 'parser/ui/CooldownBar';
 import { FlameShockSubSection } from './FlameShockSubSection';
-import { MaelstromSubSection } from './MaelstromSubSection';
-
-/** The guide for Elemental Shamans. */
-export default function ElementalGuide(props: GuideProps<typeof CombatLogParser>) {
-  return (
-    <>
-      <PrefaceSection />
-      <CoreSection {...props} />
-      <CooldownSection {...props} />
-      <ResourceSection {...props} />
-      <DefensiveSection {...props} />
-      <PreparationSection />
-    </>
-  );
-}
+import CooldownGraphSubsection, {
+  Cooldown,
+} from 'interface/guide/components/CooldownGraphSubSection';
+import SPELLS from 'common/SPELLS';
 
 const PrefaceSection = () => {
   return (
@@ -44,6 +31,16 @@ const PrefaceSection = () => {
   );
 };
 
+const ResourcesSection = (props: GuideProps<typeof CombatLogParser>) => {
+  const { modules } = props;
+  return (
+    <Section title="Resource usage">
+      {modules.maelstromDetails.guideSubsection}
+      {modules.alwaysBeCasting.guideSubsection}
+    </Section>
+  );
+};
+
 /** A section for the core combo, abilities and buffs. */
 const CoreSection = (props: GuideProps<typeof CombatLogParser>) => {
   const { info, modules } = props;
@@ -53,80 +50,85 @@ const CoreSection = (props: GuideProps<typeof CombatLogParser>) => {
         info.combatant.hasTalent(TALENTS_SHAMAN.STORMKEEPER_2_ELEMENTAL_TALENT)) &&
         modules.stormkeeper.guideSubsection()}
       {modules.spenderWindow.active && modules.spenderWindow.guideSubsection()}
-      {modules.maelstromDetails.guideSubsection}
-      {modules.alwaysBeCasting.guideSubsection}
       {modules.electrifiedShocks.active && modules.electrifiedShocks.guideSubsection}
-      {info.combatant.hasTalent(TALENTS_SHAMAN.MASTER_OF_THE_ELEMENTS_TALENT) &&
-        modules.masterOfTheElements.guideSubsection()}
       <FlameShockSubSection {...props} />
     </Section>
   );
 };
 
-/** The list of cooldowns to show. */
-const cooldownTalents = [
-  TALENTS.STORMKEEPER_1_ELEMENTAL_TALENT,
-  TALENTS.NATURES_SWIFTNESS_TALENT,
-  TALENTS.LIQUID_MAGMA_TOTEM_TALENT,
-  TALENTS.STORM_ELEMENTAL_TALENT,
-  TALENTS.FIRE_ELEMENTAL_TALENT,
+const cooldownTalents: Cooldown[] = [
+  {
+    spell: SPELLS.STORMKEEPER_BUFF_AND_CAST,
+    isActive: (c) => c.hasTalent(TALENTS.STORMKEEPER_1_ELEMENTAL_TALENT),
+  },
+  {
+    spell: TALENTS.LIQUID_MAGMA_TOTEM_TALENT,
+    isActive: (c) => c.hasTalent(TALENTS.LIQUID_MAGMA_TOTEM_TALENT),
+  },
+  {
+    spell: TALENTS.STORM_ELEMENTAL_TALENT,
+    isActive: (c) => c.hasTalent(TALENTS.STORM_ELEMENTAL_TALENT),
+  },
+  {
+    spell: TALENTS.FIRE_ELEMENTAL_TALENT,
+    isActive: (c) => c.hasTalent(TALENTS.FIRE_ELEMENTAL_TALENT),
+  },
+  { spell: TALENTS.ICEFURY_TALENT, isActive: (c) => c.hasTalent(TALENTS.ICEFURY_TALENT) },
 ];
 
-/** A section with basic cooldown efficiency information. */
-const CooldownSection = ({ info }: GuideProps<typeof CombatLogParser>) => (
-  <Section title="Cooldowns">
-    <p>
-      You should endeavor to use your offensive cooldowns whenever possible as they will increase
-      your overall DPS.
-    </p>
-    {cooldownTalents.map(
-      (talent) =>
-        info.combatant.hasTalent(talent) && (
-          <CastEfficiencyBar
-            spellId={talent.id}
-            gapHighlightMode={GapHighlight.FullCooldown}
-            useThresholds
-          />
-        ),
-    )}
-  </Section>
-);
+const defensiveTalents: Cooldown[] = [
+  { spell: TALENTS.ASTRAL_SHIFT_TALENT, isActive: (c) => c.hasTalent(TALENTS.ASTRAL_SHIFT_TALENT) },
+  {
+    spell: TALENTS.EARTH_ELEMENTAL_TALENT,
+    isActive: (c) => c.hasTalent(TALENTS.EARTH_ELEMENTAL_TALENT),
+  },
+  {
+    spell: TALENTS.NATURES_SWIFTNESS_TALENT,
+    isActive: (c) => c.hasTalent(TALENTS.NATURES_SWIFTNESS_TALENT),
+  },
+  {
+    spell: TALENTS.ANCESTRAL_GUIDANCE_TALENT,
+    isActive: (c) => c.hasTalent(TALENTS.ANCESTRAL_GUIDANCE_TALENT),
+  },
+  {
+    spell: TALENTS.EARTHEN_WALL_TOTEM_TALENT,
+    isActive: (c) => c.hasTalent(TALENTS.EARTHEN_WALL_TOTEM_TALENT),
+  },
+  {
+    spell: TALENTS.SPIRITWALKERS_GRACE_TALENT,
+    isActive: (c) => c.hasTalent(TALENTS.SPIRITWALKERS_GRACE_TALENT),
+  },
+];
 
-/** A section for information on resource usage. */
-const ResourceSection = (props: GuideProps<typeof CombatLogParser>) => {
+/**
+ */
+
+/** The guide for Elemental Shamans. */
+export default function ElementalGuide(props: GuideProps<typeof CombatLogParser>) {
   return (
-    <Section title="Resources">
-      <MaelstromSubSection {...props} />
-    </Section>
+    <>
+      <PrefaceSection />
+      <ResourcesSection {...props} />
+      <Section title="Cooldown">
+        <CooldownGraphSubsection cooldowns={cooldownTalents} />
+      </Section>
+      <CoreSection {...props} />
+      <Section title="Defensive and utility">
+        <CooldownGraphSubsection
+          cooldowns={defensiveTalents}
+          description={
+            <>
+              <p>
+                <strong>Defensives and utility</strong> - Defensive and utility talent usage may
+                vary from fight to fight. They may need to be delayed for specific mechanics. In
+                general, any amount of usage is good, but anywhere you could fit in another usage is
+                a theoretical loss.
+              </p>
+            </>
+          }
+        />
+      </Section>
+      <PreparationSection />
+    </>
   );
-};
-
-/** The list of defensive/utility cooldowns to track. */
-const defensiveTalents = [
-  TALENTS.ASTRAL_SHIFT_TALENT,
-  TALENTS.EARTH_ELEMENTAL_TALENT,
-  TALENTS.ANCESTRAL_GUIDANCE_TALENT,
-  TALENTS.EARTHEN_WALL_TOTEM_TALENT,
-  TALENTS.SPIRITWALKERS_GRACE_TALENT,
-];
-
-/** A section with basic defensives efficiency information. */
-const DefensiveSection = ({ info }: GuideProps<typeof CombatLogParser>) => (
-  <Section title="Defensives">
-    <p>
-      Defensive talent usage may vary from fight to fight. They may need to be delayed for specific
-      mechanics. In general, any amount of usage is good, but anywhere you could fit in another
-      usage is a loss.
-    </p>
-    {defensiveTalents.map(
-      (talent) =>
-        info.combatant.hasTalent(talent) && (
-          <CastEfficiencyBar
-            spellId={talent.id}
-            gapHighlightMode={GapHighlight.FullCooldown}
-            useThresholds
-          />
-        ),
-    )}
-  </Section>
-);
+}

--- a/src/analysis/retail/shaman/elemental/modules/talents/MasterOfTheElements.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/talents/MasterOfTheElements.tsx
@@ -2,7 +2,6 @@ import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/shaman';
 import { isTalent } from 'common/TALENTS/types';
 import { SpellLink } from 'interface';
-import { ExplanationAndDataSubSection } from 'interface/guide/components/ExplanationRow';
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
 import { SELECTED_PLAYER } from 'parser/core/EventFilter';
@@ -11,7 +10,6 @@ import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import TalentSpellText from 'parser/ui/TalentSpellText';
-import { GUIDE_EXPLANATION_PERCENT_WIDTH } from '../../constants';
 
 const MASTER_OF_THE_ELEMENTS = {
   INCREASE: 0.2,
@@ -149,20 +147,6 @@ class MasterOfTheElements extends Analyzer {
           </>
         </TalentSpellText>
       </Statistic>
-    );
-  }
-
-  guideSubsection(): JSX.Element {
-    const explanation = <>TODO</>;
-    const data = this.statistic();
-
-    return (
-      <ExplanationAndDataSubSection
-        title="Master of the Elements"
-        explanationPercent={GUIDE_EXPLANATION_PERCENT_WIDTH}
-        explanation={explanation}
-        data={data}
-      />
     );
   }
 }

--- a/src/interface/guide/components/CooldownGraphSubSection.tsx
+++ b/src/interface/guide/components/CooldownGraphSubSection.tsx
@@ -29,6 +29,10 @@ type CooldownGraphSubsectionProps = {
    */
   title?: string;
   /**
+   * A description that we may want to render as part of the subsection.
+   */
+  description?: JSX.Element;
+  /**
    * How many casts of a spell will remove its icon from the graph? Defaults to 10.
    */
   tooManyCasts?: number;
@@ -43,6 +47,7 @@ type CooldownGraphSubsectionProps = {
 const CooldownGraphSubsection = ({
   cooldowns,
   title,
+  description,
   tooManyCasts = 10,
 }: CooldownGraphSubsectionProps) => {
   const info = useInfo();
@@ -59,12 +64,18 @@ const CooldownGraphSubsection = ({
     return casts >= tooManyCasts;
   });
 
-  return (
-    <SubSection title={title}>
+  description = description ?? (
+    <>
       <strong>Cooldown Graph</strong> - this graph shows when you used your cooldowns and how long
       you waited to use them again. Grey segments show when the spell was available, yellow segments
       show when the spell was cooling down. Red segments highlight times when you could have fit a
       whole extra use of the cooldown.
+    </>
+  );
+
+  return (
+    <SubSection title={title}>
+      {description}
       {activeCooldowns.map((cooldownCheck) => (
         <CastEfficiencyBar
           key={cooldownCheck.spell.id}


### PR DESCRIPTION
### Description

This PR reorders the sections in the elemental guide, and a slight refactor to use the cooldown graph from core.

Since the ele guide uses two instances of the cooldown efficiency subsection, I wanted to tailor the description for them. I've therefore made a change to the core module to allow users to optionally pass the description, or use the existing one as default.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/L1R2zVKY8ZDxCTNb/15-Mythic+Scalecommander+Sarkareth+-+Kill+(7:21)/Nerdshockz/standard`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/12049229/853c9033-96e1-4b71-bcf6-37a9f0f7dae1)
