### PR TITLE
[Augmentation] Increase clarity in SandsOfTime module cast breakdown

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+    change(date(2023, 9, 21), <>Give Sands of Time module cast breakdown flavor text some color for clarity.</>, Vollmer),
     change(date(2023, 9, 15), <>Implement a buff helper module.</>, Vollmer),
     change(date(2023, 9, 10), <>Fix issue with buff graph showing wrong amount of active <SpellLink spell={SPELLS.EBON_MIGHT_BUFF_EXTERNAL} />.</>, Vollmer),
     change(date(2023, 9, 2), <>Fix issue with <SpellLink spell={SPELLS.SHIFTING_SANDS_BUFF} /> module when targets wasn't defined.</>, Vollmer),

--- a/src/analysis/retail/evoker/augmentation/modules/abilities/SandsOfTime.scss
+++ b/src/analysis/retail/evoker/augmentation/modules/abilities/SandsOfTime.scss
@@ -1,0 +1,11 @@
+.goodCast {
+  background-color: #4ec04e;
+  color: black;
+  padding: 0 3px;
+}
+
+.badCast {
+  background-color: #ac1f39;
+  color: white;
+  padding: 0 3px;
+}

--- a/src/analysis/retail/evoker/augmentation/modules/abilities/SandsOfTime.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/abilities/SandsOfTime.tsx
@@ -11,6 +11,7 @@ import { combineQualitativePerformances } from 'common/combineQualitativePerform
 import HideGoodCastsSpellUsageSubSection from 'parser/core/SpellUsage/HideGoodCastsSpellUsageSubSection';
 import { logSpellUseEvent } from 'parser/core/SpellUsage/SpellUsageSubSection';
 import { failedEbonMightExtention } from '../normalizers/CastLinkNormalizer';
+import './SandsOfTime.scss';
 
 /**
  * Sands of time is an innate ability for Augmentation.
@@ -146,9 +147,9 @@ class SandsOfTime extends Analyzer {
         castBreakdownSmallText={
           <>
             {' '}
-            - Green is a good cast where you extended you{' '}
-            <SpellLink spell={TALENTS.EBON_MIGHT_TALENT} /> window, Red is a bad cast where you
-            didn't extend.
+            - <span className="goodCast">Green</span> is a good cast where you extended you{' '}
+            <SpellLink spell={TALENTS.EBON_MIGHT_TALENT} /> window,{' '}
+            <span className="badCast">red</span> is a bad cast where you didn't extend.
           </>
         }
         onPerformanceBoxClick={logSpellUseEvent}


### PR DESCRIPTION
### Description

Added some colored boxes to give more clarity to what the different colors means. Some people apparently missed that the red casts indicated missed extentions.

### Testing


- Test report URL: `/report/Hpf2xmwzWNyQqA94/29-Mythic+Scalecommander+Sarkareth+-+Kill+(7:26)/Bervoker/standard/overview`
- Screenshot(s):
- 
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/fc8ad7ee-8b60-4425-91da-0bf2eb8d382b)

