### PR TITLE
[common] Classcolor helper

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -29,6 +29,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 10, 1), <>Improve code for coloring texts and backgrounds by <span className='Paladin'>player</span> <span className='Warrior'>classes</span>.</>, nullDozzer),
   change(date(2023, 9, 25), 'Reset scrollposition to top of window when navigating within app except when switching tabs. This fixes a scenario where you would end up staring at the pages footer after clicking a spec on the Specs page.', nullDozzer),
   change(date(2023, 9, 25), 'Fix broken drilldown link in always be casting module that is used my multiple specs', nullDozzer),
   change(date(2023, 9, 25), 'Fix Patreon / GitHub login buttons', emallson),

--- a/src/analysis/retail/evoker/augmentation/modules/abilities/EbonMight.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/abilities/EbonMight.tsx
@@ -28,9 +28,9 @@ import { logSpellUseEvent } from 'parser/core/SpellUsage/SpellUsageSubSection';
 import { ebonIsFromBreath, getEbonMightBuffEvents } from '../normalizers/CastLinkNormalizer';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import Combatants from 'parser/shared/modules/Combatants';
+import classColor from 'game/classColor';
 import SPECS from 'game/SPECS';
 import ROLES from 'game/ROLES';
-import { i18n } from '@lingui/core';
 
 const PANDEMIC_WINDOW = 0.3;
 
@@ -409,11 +409,7 @@ class EbonMight extends Analyzer {
     ebonMightCooldownCast.buffedTargets.forEach((player) => {
       const currentPlayer = this.combatants.players[player.targetID];
       if (currentPlayer.spec) {
-        const i18nClassName = currentPlayer.spec.className
-          ? i18n._(currentPlayer.spec.className)
-          : undefined;
-
-        const className = i18nClassName?.replace(/\s/g, '') ?? '';
+        const className = classColor(currentPlayer);
         let currentPlayerRole = 'DPS';
         if (
           currentPlayer.spec.role === ROLES.HEALER ||

--- a/src/analysis/retail/evoker/augmentation/modules/abilities/ShiftingSands.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/abilities/ShiftingSands.tsx
@@ -9,10 +9,10 @@ import { SpellLink } from 'interface';
 import HideGoodCastsSpellUsageSubSection from 'parser/core/SpellUsage/HideGoodCastsSpellUsageSubSection';
 import { logSpellUseEvent } from 'parser/core/SpellUsage/SpellUsageSubSection';
 import Combatants from 'parser/shared/modules/Combatants';
+import classColor from 'game/classColor';
 import ROLES from 'game/ROLES';
 import Combatant from 'parser/core/Combatant';
 import SPECS from 'game/SPECS';
-import { i18n } from '@lingui/core';
 
 interface ShiftingSandsApplications {
   event: ApplyBuffEvent;
@@ -176,10 +176,7 @@ class ShiftingSands extends Analyzer {
   }
 
   private getRolePerformance(application: ShiftingSandsApplications) {
-    const i18nClassName = application.combatant.spec?.className
-      ? i18n._(application.combatant.spec?.className)
-      : undefined;
-    const className = i18nClassName?.replace(/\s/g, '') ?? '';
+    const className = classColor(application.combatant);
     const roleSummary = <div>Buffed DPS player.</div>;
     let rolePerformance;
 

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
@@ -1,8 +1,8 @@
-import { i18n } from '@lingui/core';
 import TALENTS from 'common/TALENTS/evoker';
 import { WCLDamageDoneTableResponse } from 'common/WCL_TYPES';
 import fetchWcl from 'common/fetchWclApi';
 import { formatDuration, formatNumber } from 'common/format';
+import classColor from 'game/classColor';
 import ROLES from 'game/ROLES';
 import SPECS from 'game/SPECS';
 import Analyzer, { Options } from 'parser/core/Analyzer';
@@ -118,10 +118,7 @@ class BuffTargetHelper extends Analyzer {
           player.spec.role !== ROLES.TANK &&
           player.spec !== SPECS.AUGMENTATION_EVOKER
         ) {
-          const i18nClassName = player.spec.className ? i18n._(player.spec.className) : '';
-          const className = i18nClassName?.replace(/\s/g, '') ?? '';
-
-          this.playerWhitelist.set(player.name, className);
+          this.playerWhitelist.set(player.name, classColor(player));
         }
       });
     });

--- a/src/analysis/retail/evoker/augmentation/modules/talents/Prescience.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/Prescience.tsx
@@ -1,6 +1,7 @@
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import MajorCooldown, { SpellCast } from 'parser/core/MajorCooldowns/MajorCooldown';
 import TALENTS from 'common/TALENTS/evoker';
+import classColor from 'game/classColor';
 import Events, { CastEvent } from 'parser/core/Events';
 import { ReactNode } from 'react';
 import { SpellLink } from 'interface';
@@ -12,7 +13,6 @@ import Combatants from 'parser/shared/modules/Combatants';
 import { getPrescienceBuffEvents } from '../normalizers/CastLinkNormalizer';
 import Combatant from 'parser/core/Combatant';
 import SPECS from 'game/SPECS';
-import { i18n } from '@lingui/core';
 
 /**
  * Prescience is a core talent that buffs the target with 3% crit, as well
@@ -91,10 +91,7 @@ class Prescience extends MajorCooldown<PrescienceCooldownCast> {
   }
 
   private prescienceWindowCastPerformance(cast: PrescienceCooldownCast): UsageInfo {
-    const i18nClassName = this.currentBuffedPlayer?.spec?.className
-      ? i18n._(this.currentBuffedPlayer.spec.className)
-      : undefined;
-    const className = i18nClassName?.replace(/\s/g, '') ?? '';
+    const className = this.currentBuffedPlayer ? classColor(this.currentBuffedPlayer) : '';
     let performance = QualitativePerformance.Fail;
     const summary = <div>Buffed a DPS</div>;
     let details = (

--- a/src/game/classColor.ts
+++ b/src/game/classColor.ts
@@ -1,0 +1,40 @@
+import { Spec, isRetailSpec } from 'game/SPECS';
+import Combatant from 'parser/core/Combatant';
+
+/**
+ * Takes name of a player class, {@link Spec}, or {@link Combatant} and
+ * returns a `className` that can be used to color the text in the
+ * appropiate class color.
+ *
+ * > The css classes themselves are defined in
+ * > [src\interface\Game.scss](../interface/Game.scss#L1-L39)
+ */
+export default function classColor(input: string | Combatant | Spec): string {
+  if (typeof input === 'string') {
+    return input.replace(' ', '');
+  } else if (input instanceof Combatant) {
+    if (input.spec == null) {
+      throw new Error(`[classColor] Combatant ${input.name} has no spec`);
+    }
+    return classColor(input.spec);
+  } else {
+    const base = isRetailSpec(input) ? input.wclClassName : input.type;
+    if (!base) {
+      console.error('Spec has nothing to base class color on', input);
+      return '';
+    }
+    return classColor(base);
+  }
+}
+
+/**
+ * Takes name of a player class, {@link Spec}, or {@link Combatant} and
+ * returns a `className` that can be used to color the background in the
+ * appropiate class color.
+ *
+ * > The css classes themselves are defined in
+ * > [src\interface\Game.scss](../interface/Game.scss#L41-L79)
+ */
+export function classBgColor(input: string | Combatant | Spec): string {
+  return `${classColor(input)}-bg`;
+}

--- a/src/interface/SpecListItem.tsx
+++ b/src/interface/SpecListItem.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { Trans } from '@lingui/macro';
+import classColor from 'game/classColor';
 import { isCurrentExpansion } from 'game/Expansion';
 import Contributor from 'interface/ContributorButton';
 import ReadableListing from 'interface/ReadableListing';
@@ -23,7 +24,7 @@ const SpecListItem = ({
   const i18nClassName = i18n._(spec.className);
   const displayName = [i18nSpecName, i18nClassName].filter(isDefined).join(' ');
 
-  const className = i18n._(spec.className).replace(/ /g, '');
+  const className = classColor(spec);
   const Component = exampleReport && isCurrentExpansion(expansion) ? Link : 'div';
 
   const maintainers = (

--- a/src/interface/report/PlayerTile.tsx
+++ b/src/interface/report/PlayerTile.tsx
@@ -1,3 +1,4 @@
+import classColor from 'game/classColor';
 import getAverageItemLevel from 'game/getAverageItemLevel';
 import { getClassName } from 'game/ROLES';
 import { fetchCharacter } from 'interface/actions/characters';
@@ -69,7 +70,7 @@ const PlayerTileContents = ({ avatar, player, spec }: PlayerTileContentsProps) =
         <div className="avatar" style={{ backgroundImage: `url(${avatar})` }} />
         <div className="about">
           <h1
-            className={i18n._(spec.className).replace(' ', '')}
+            className={classColor(spec)}
             // The name can't always fit so use a tooltip. We use title instead of the tooltip library for this because we don't want it to be distracting and the tooltip library would popup when hovering just to click an item, while this has a delay.
             title={player.name}
           >


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Created a small helper which you can pass a combatant or spec into and it will return a css classname which will color the text or bg by the class of the player.

Ping @Krealle since it's mostly used in Aug Evo

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: http://localhost:3000/report/hVB6FZNgPpTDMW3Y/21-Mythic+Rashok,+the+Elder+-+Kill+(6:28)/Streptil/standard/overview
- Screenshot(s): 
  ![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/13413409/b2fdfadd-f4ab-4455-b980-6ab783a88176)

