### PR TITLE
Link fixes

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -29,6 +29,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 9, 25), 'Fix broken drilldown link in always be casting module that is used my multiple specs', nullDozzer),
   change(date(2023, 9, 24), 'Fix lots of react rendering errors', nullDozzer),
   change(date(2023, 9, 24), 'Change to e2e tests to fail explicitly when there are unexpected errors in the console.', nullDozzer),
   change(date(2023, 9, 23), 'Make sure that the Shadowflame Wreathe icon can be displayed.', ToppleTheNun),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -29,6 +29,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 9, 25), 'Reset scrollposition to top of window when navigating within app except when switching tabs. This fixes a scenario where you would end up staring at the pages footer after clicking a spec on the Specs page.', nullDozzer),
   change(date(2023, 9, 25), 'Fix broken drilldown link in always be casting module that is used my multiple specs', nullDozzer),
   change(date(2023, 9, 24), 'Fix lots of react rendering errors', nullDozzer),
   change(date(2023, 9, 24), 'Change to e2e tests to fail explicitly when there are unexpected errors in the console.', nullDozzer),

--- a/src/Root.test.tsx
+++ b/src/Root.test.tsx
@@ -5,6 +5,9 @@ jest.unmock('react-router-dom');
 
 describe('App', () => {
   it('renders without crashing', async () => {
+    // Add mock for window.scrollTo so that ScrollRestoration can be rendered
+    window.scrollTo = jest.fn();
+
     render(<Root />);
 
     // At least the code input field should be visible

--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import spells from 'common/SPELLS/monk';
 import talents from 'common/TALENTS/monk';
-import { Durpn, Hursti, Tenooki, ToppleTheNun } from 'CONTRIBUTORS';
+import { Durpn, Hursti, nullDozzer, Tenooki, ToppleTheNun } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 9, 25), 'Fix drilldown link for Chi details', nullDozzer),
   change(date(2023, 7, 3), 'Update SpellLink usage.', ToppleTheNun),
   change(date(2023, 5, 18), <>Fixed <SpellLink spell={spells.BLACKOUT_KICK}/> being flagged as an incorrect cast in the APL/Timeline when it reset <SpellLink spell={talents.RISING_SUN_KICK_TALENT} /></>, Durpn),
   change(date(2023, 5, 9), <>Adjusted Faeline Stomp in APL</>, Tenooki),

--- a/src/analysis/retail/monk/windwalker/modules/resources/ChiDetails.js
+++ b/src/analysis/retail/monk/windwalker/modules/resources/ChiDetails.js
@@ -62,7 +62,7 @@ class ChiDetails extends Analyzer {
         size="small"
         position={STATISTIC_ORDER.CORE(1)}
         tooltip={<>{formatPercentage(this.chiWastedPercent)}% wasted</>}
-        drilldown="chi"
+        drilldown="../chi"
       >
         <BoringResourceValue
           resource={RESOURCE_TYPES.CHI}

--- a/src/interface/AppLayout.tsx
+++ b/src/interface/AppLayout.tsx
@@ -7,7 +7,7 @@ import { internetExplorer } from 'interface/actions/internetExplorer';
 import { fetchUser } from 'interface/actions/user';
 import FullscreenError from 'interface/FullscreenError';
 import { t } from '@lingui/macro';
-import { Outlet } from 'react-router-dom';
+import { Outlet, ScrollRestoration } from 'react-router-dom';
 import Footer from 'interface/Footer';
 import PortalTarget from 'interface/PortalTarget';
 import Hotkeys from 'interface/Hotkeys';
@@ -63,6 +63,7 @@ const AppLayout = () => {
 
       <PortalTarget />
       <Hotkeys />
+      <ScrollRestoration />
     </>
   );
 };

--- a/src/interface/Home.tsx
+++ b/src/interface/Home.tsx
@@ -75,7 +75,9 @@ const Home = () => {
               return (
                 <li key={page.url} className={page.url === url ? 'active' : undefined}>
                   {isRelativeLink ? (
-                    <Link to={page.url}>{content}</Link>
+                    <Link to={page.url} preventScrollReset>
+                      {content}
+                    </Link>
                   ) : (
                     <a href={page.url}>{content}</a>
                   )}

--- a/src/interface/report/Results/NavigationBar.tsx
+++ b/src/interface/report/Results/NavigationBar.tsx
@@ -75,7 +75,7 @@ const NavigationBar = ({ makeTabUrl, tabs, selectedTab }: Props) => {
         <ul>
           {pages.map(({ icon: Icon, name, url }) => (
             <li key={url} className={url === selectedTab ? 'active' : undefined}>
-              <Link to={makeTabUrl(url)}>
+              <Link to={makeTabUrl(url)} preventScrollReset>
                 <Icon />
                 {name}
               </Link>

--- a/src/parser/shared/modules/AlwaysBeCastingHealing.tsx
+++ b/src/parser/shared/modules/AlwaysBeCastingHealing.tsx
@@ -80,7 +80,7 @@ class AlwaysBeCastingHealing extends CoreAlwaysBeCasting {
             See the timeline for details.
           </Trans>
         }
-        drilldown="timeline"
+        drilldown="../timeline"
       >
         <div className="pad">
           <label>


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

- Fix broken "drilldown" links for Chi Details and ABC. The links where not succesfully relative and just added /details to the URL which was broken state.
  ![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/13413409/46c99f46-c572-4d52-be01-6c02b539a20b) ![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/13413409/620ceaa7-57b6-4d87-8a4e-d7090e49fd98)
  This was fixed by using the correct relative link syntax as documented in [React Router documentation](https://reactrouter.com/en/main/components/link#relative)
  
- Clicking a Spec on the [Specs](https://wowanalyzer.com/specs) page will not reset the scroll of the browser. This means that if you clicked a spec where the log is previous patch, you will end up staring at the footer of the page rather than looking at the report.
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/13413409/c464cc96-b683-4d9d-848a-0511dc19ba99)
Clicking on Windwalker Monk for example, requires me to scroll down a bit on the page.
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/13413409/db659e2e-9a4e-40c9-884e-d8f42ed8fe9a)
When the navigation is completed, we remain at the original scrollposition, meaning we don't even see the message about the report being outdated.

This was fixed by using the new [`ScrollRestoration`](https://reactrouter.com/en/main/components/scroll-restoration). I added it to the Root component as that seems to be recommended in the documentation.

This means that all navigations will default to reset the scroll position, just like native navigations would. I've specifically opted the tabs on the Home page and Reports page to not reset the scroll position.