### PR TITLE
Bugfix/login buttons

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -29,6 +29,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 9, 25), 'Fix Patreon / GitHub login buttons', emallson),
   change(date(2023, 9, 24), 'Fix lots of react rendering errors', nullDozzer),
   change(date(2023, 9, 24), 'Change to e2e tests to fail explicitly when there are unexpected errors in the console.', nullDozzer),
   change(date(2023, 9, 23), 'Make sure that the Shadowflame Wreathe icon can be displayed.', ToppleTheNun),

--- a/src/interface/PremiumLoginPanel.tsx
+++ b/src/interface/PremiumLoginPanel.tsx
@@ -38,6 +38,13 @@ const INITIAL_BACKGROUNDS = [
 const LoggedIn = () => {
   const dispatch = useWaDispatch();
   const user = useWaSelector((state) => state.user);
+
+  // this is only intended to be rendered if we have a user, but some quirks of oauth
+  // can get you a user-without-a-user when doing local development
+  if (!user) {
+    return null;
+  }
+
   const hasPremium = user.premium;
   const platform = user.github && user.github.premium ? 'github' : 'patreon';
 

--- a/src/interface/PremiumLoginPanel.tsx
+++ b/src/interface/PremiumLoginPanel.tsx
@@ -91,7 +91,7 @@ const PremiumLoginPanel = () => {
   return (
     <div className="panel">
       <div className="panel-body" style={{ padding: '0 15px', position: 'relative' }}>
-        <TransitionGroup className="logged-in" timeout={{ enter: 1000, exit: 1000 }}>
+        <TransitionGroup classNames="logged-in" timeout={1000}>
           {user && <LoggedIn />}
         </TransitionGroup>
 


### PR DESCRIPTION
The actual fix is the `className` to `classNames` rename. The `timeout` change is just a shorthand, and the `!user` check can only realistically occur in local development (if you trigger the login from local, oauth will redirect to production).

context: https://discord.com/channels/316864121536512000/360770373454659585/1155807289274535987