### PR TITLE
[Hunter] Fix issues with registering Coordinated Assault casts

### DIFF
--- a/src/analysis/retail/hunter/survival/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/survival/CHANGELOG.tsx
@@ -1,7 +1,10 @@
 import { change, date } from 'common/changelog';
+import { TALENTS_HUNTER } from 'common/TALENTS';
 import { Putro, Arlie, ToppleTheNun } from 'CONTRIBUTORS';
+import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 9, 25), <>Fix issues with registering <SpellLink spell={TALENTS_HUNTER.COORDINATED_ASSAULT_TALENT} /> casts.</>, Putro),
   change(date(2023, 7, 3), 'Update SpellLink usage.', ToppleTheNun),
   change(date(2022, 12, 16), 'Re-enable log parser.', ToppleTheNun),
   change(date(2022, 11, 11), 'Initial transition of Survival to Dragonflight', [Arlie, Putro]),

--- a/src/analysis/retail/hunter/survival/modules/Abilities.tsx
+++ b/src/analysis/retail/hunter/survival/modules/Abilities.tsx
@@ -70,8 +70,8 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.COORDINATED_ASSAULT.id,
-        buffSpellId: SPELLS.COORDINATED_ASSAULT.id,
+        spell: TALENTS.COORDINATED_ASSAULT_TALENT.id,
+        buffSpellId: TALENTS.COORDINATED_ASSAULT_TALENT.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         cooldown: 120,
         gcd: {
@@ -141,19 +141,6 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.85,
-        },
-      },
-      {
-        spell: TALENTS.DEATH_CHAKRAM_TALENT.id,
-        category: SPELL_CATEGORY.ROTATIONAL,
-        enabled: combatant.hasTalent(TALENTS.DEATH_CHAKRAM_TALENT),
-        cooldown: 20,
-        gcd: {
-          base: 1500,
-        },
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: 0.9,
         },
       },
       {

--- a/src/analysis/retail/hunter/survival/modules/Buffs.tsx
+++ b/src/analysis/retail/hunter/survival/modules/Buffs.tsx
@@ -1,4 +1,5 @@
 import SPELLS from 'common/SPELLS';
+import { TALENTS_HUNTER } from 'common/TALENTS';
 import BLOODLUST_BUFFS from 'game/BLOODLUST_BUFFS';
 import CoreAuras from 'parser/core/modules/Auras';
 
@@ -6,9 +7,9 @@ class Buffs extends CoreAuras {
   auras() {
     return [
       {
-        spellId: SPELLS.COORDINATED_ASSAULT.id,
+        spellId: TALENTS_HUNTER.COORDINATED_ASSAULT_TALENT.id,
         timelineHighlight: true,
-        triggeredBySpellId: SPELLS.COORDINATED_ASSAULT.id,
+        triggeredBySpellId: TALENTS_HUNTER.COORDINATED_ASSAULT_TALENT.id,
       },
       {
         spellId: SPELLS.ASPECT_OF_THE_TURTLE.id,

--- a/src/analysis/retail/hunter/survival/modules/checklist/Component.tsx
+++ b/src/analysis/retail/hunter/survival/modules/checklist/Component.tsx
@@ -43,8 +43,9 @@ const SurvivalChecklist = ({ combatant, castEfficiency, thresholds }: ChecklistP
         }
       >
         <AbilityRequirement spell={SPELLS.KILL_COMMAND_CAST_SV.id} />
-        <AbilityRequirement spell={SPELLS.COORDINATED_ASSAULT.id} />
-
+        {combatant.hasTalent(TALENTS.COORDINATED_ASSAULT_TALENT) && (
+          <AbilityRequirement spell={TALENTS.COORDINATED_ASSAULT_TALENT.id} />
+        )}
         {combatant.hasTalent(TALENTS.FLANKING_STRIKE_TALENT) && (
           <AbilityRequirement spell={TALENTS.FLANKING_STRIKE_TALENT.id} />
         )}

--- a/src/analysis/retail/hunter/survival/modules/features/CooldownThroughputTracker.tsx
+++ b/src/analysis/retail/hunter/survival/modules/features/CooldownThroughputTracker.tsx
@@ -1,4 +1,5 @@
 import SPELLS from 'common/SPELLS';
+import { TALENTS_HUNTER } from 'common/TALENTS';
 import { RETAIL_EXPANSION } from 'game/Expansion';
 import CoreCooldownThroughputTracker, {
   BUILT_IN_SUMMARY_TYPES,
@@ -8,7 +9,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
   static cooldownSpells = [
     ...CoreCooldownThroughputTracker.cooldownSpells,
     {
-      spell: SPELLS.COORDINATED_ASSAULT.id,
+      spell: TALENTS_HUNTER.COORDINATED_ASSAULT_TALENT.id,
       summary: [BUILT_IN_SUMMARY_TYPES.DAMAGE],
       expansion: RETAIL_EXPANSION,
     },

--- a/src/analysis/retail/hunter/survival/modules/spells/CoordinatedAssault.tsx
+++ b/src/analysis/retail/hunter/survival/modules/spells/CoordinatedAssault.tsx
@@ -1,6 +1,6 @@
 import { COORDINATED_ASSAULT_DMG_MOD } from 'analysis/retail/hunter/survival/constants';
 import { formatNumber, formatPercentage } from 'common/format';
-import SPELLS from 'common/SPELLS';
+import { TALENTS_HUNTER } from 'common/TALENTS';
 import UptimeIcon from 'interface/icons/Uptime';
 import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
 import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
@@ -32,6 +32,7 @@ class CoordinatedAssault extends Analyzer {
   constructor(options: Options) {
     super(options);
 
+    this.active = this.selectedCombatant.hasTalent(TALENTS_HUNTER.COORDINATED_ASSAULT_TALENT);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onPlayerDamage);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER_PET), this.onPetDamage);
   }
@@ -42,19 +43,20 @@ class CoordinatedAssault extends Analyzer {
 
   get percentUptime() {
     return (
-      this.selectedCombatant.getBuffUptime(SPELLS.COORDINATED_ASSAULT.id) / this.owner.fightDuration
+      this.selectedCombatant.getBuffUptime(TALENTS_HUNTER.COORDINATED_ASSAULT_TALENT.id) /
+      this.owner.fightDuration
     );
   }
 
   onPetDamage(event: DamageEvent) {
-    if (!this.selectedCombatant.hasBuff(SPELLS.COORDINATED_ASSAULT.id)) {
+    if (!this.selectedCombatant.hasBuff(TALENTS_HUNTER.COORDINATED_ASSAULT_TALENT.id)) {
       return;
     }
     this.petDamage += calculateEffectiveDamage(event, COORDINATED_ASSAULT_DMG_MOD);
   }
 
   onPlayerDamage(event: DamageEvent) {
-    if (!this.selectedCombatant.hasBuff(SPELLS.COORDINATED_ASSAULT.id)) {
+    if (!this.selectedCombatant.hasBuff(TALENTS_HUNTER.COORDINATED_ASSAULT_TALENT.id)) {
       return;
     }
     this.playerDamage += calculateEffectiveDamage(event, COORDINATED_ASSAULT_DMG_MOD);
@@ -68,9 +70,10 @@ class CoordinatedAssault extends Analyzer {
         tooltip={
           <>
             Over the course of the encounter you had Coordinated Assault up for a total of{' '}
-            {(this.selectedCombatant.getBuffUptime(SPELLS.COORDINATED_ASSAULT.id) / 1000).toFixed(
-              1,
-            )}{' '}
+            {(
+              this.selectedCombatant.getBuffUptime(TALENTS_HUNTER.COORDINATED_ASSAULT_TALENT.id) /
+              1000
+            ).toFixed(1)}{' '}
             seconds.
             <br />
             Total damage breakdown:
@@ -89,7 +92,7 @@ class CoordinatedAssault extends Analyzer {
           </>
         }
       >
-        <BoringSpellValueText spell={SPELLS.COORDINATED_ASSAULT}>
+        <BoringSpellValueText spell={TALENTS_HUNTER.COORDINATED_ASSAULT_TALENT}>
           <>
             <ItemDamageDone amount={this.totalDamage} />
             <br />

--- a/src/analysis/retail/hunter/survival/modules/talents/BirdOfPrey.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/BirdOfPrey.tsx
@@ -6,7 +6,7 @@ import {
 } from 'analysis/retail/hunter/survival/constants';
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
-import TALENTS from 'common/TALENTS/hunter';
+import TALENTS, { TALENTS_HUNTER } from 'common/TALENTS/hunter';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
 import Events, { DamageEvent } from 'parser/core/Events';
@@ -94,7 +94,7 @@ class BirdOfPrey extends Analyzer {
     ) {
       this.aoeCheck();
     }
-    if (!this.selectedCombatant.hasBuff(SPELLS.COORDINATED_ASSAULT.id)) {
+    if (!this.selectedCombatant.hasBuff(TALENTS_HUNTER.COORDINATED_ASSAULT_TALENT.id)) {
       return;
     }
     const spellId = event.ability.guid;

--- a/src/analysis/retail/hunter/survival/modules/talents/WildfireInfusion/VolatileBomb.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/WildfireInfusion/VolatileBomb.tsx
@@ -1,4 +1,3 @@
-import { defineMessage } from '@lingui/macro';
 import {
   SERPENT_STING_SV_BASE_DURATION,
   SV_SERPENT_STING_COST,
@@ -211,12 +210,9 @@ class VolatileBomb extends Analyzer {
       )
         .icon(SPELLS.VOLATILE_BOMB_WFI.icon)
         .actual(
-          defineMessage({
-            id: 'hunter.survival.suggestions.wildfireInfusion.castsWithoutSerpentSting',
-            message: `${actual} casts without ${(
-              <SpellLink spell={SPELLS.SERPENT_STING_SV} />
-            )} on`,
-          }),
+          <>
+            {actual} casts without <SpellLink spell={SPELLS.SERPENT_STING_SV} /> on target
+          </>,
         )
         .recommended(`<${recommended} is recommended`),
     );

--- a/src/common/SPELLS/hunter.ts
+++ b/src/common/SPELLS/hunter.ts
@@ -248,11 +248,6 @@ const spells = {
     name: 'Carve',
     icon: 'ability_hunter_carve',
   },
-  COORDINATED_ASSAULT: {
-    id: 266779,
-    name: 'Coordinated Assault',
-    icon: 'inv_coordinatedassault',
-  },
   HARPOON: {
     id: 190925,
     name: 'Harpoon',


### PR DESCRIPTION
Fixes a couple of issues with Coordinated Assault spell ids being incorrect, and an issue with defineMessage() that stringifies <SpellLink /> as [object object]. 