### PR TITLE
[Augmentation] Buff helper default target for MRT note logic update

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+    change(date(2023, 10, 1), <>Update default target criteria for Buff Helper module.</>, Vollmer),
     change(date(2023, 9, 29), <>Update blacklist for Buff Helper module.</>, Vollmer),
     change(date(2023, 9, 26), <>Update Buff Helper module MRT note to support Prescience helper WeakAura.</>, Vollmer),
     change(date(2023, 9, 21), <>Give Sands of Time module cast breakdown flavor text some color for clarity.</>, Vollmer),

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
@@ -435,7 +435,11 @@ class BuffTargetHelper extends Analyzer {
               Phases are also not accounted for for now.
             </p>
             <p>
-              This module will also produce a MRT note for prescience timings.
+              This module will also produce a note for{' '}
+              <a href="https://www.curseforge.com/wow/addons/method-raid-tools">
+                Method Raid Tools
+              </a>
+              , that helps with <SpellLink spell={TALENTS.PRESCIENCE_TALENT} /> timings.
               <br />
               The note fully supports the <a href="https://wago.io/yrmx6ZQSG">
                 Prescience Helper

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
@@ -258,11 +258,17 @@ class BuffTargetHelper extends Analyzer {
   }
 
   getDefaultTargets(top4PumpersData: [string, number[]][][]) {
-    const nameCounts = new Map();
-    top4PumpersData.flat().forEach(([name]) => {
-      nameCounts.set(name, (nameCounts.get(name) || 0) + 1);
+    const nameSums = new Map();
+
+    top4PumpersData.flat().forEach(([name, values]) => {
+      const currentSum = nameSums.get(name) || 0;
+      const sum = currentSum + values.reduce((a, b) => a + b, 0);
+
+      nameSums.set(name, sum);
     });
-    const sortedNames = [...nameCounts.entries()].sort((a, b) => b[1] - a[1]);
+
+    const sortedNames = [...nameSums.entries()].sort((a, b) => b[1] - a[1]);
+
     return sortedNames.slice(0, 2).map((entry) => entry[0]);
   }
 


### PR DESCRIPTION
### Description

So before we were deciding default targets based on how often they showed up, this isn't inherently wrong, but if multiple names in the top two count showed up, it would pick the default targets based on who showed up first.

This means that a potentially worse target could be choosen since we weren't looking at throughput. In situations where the damage output of individual players is close it doesn't really matter too much, but in more volatile situations it could be choosing supbar targets - which in turn could lead to more lines being marked as important than should be neccessary.

New way is to look at total throughput instead of entry count. This produces a better result for all scenarios.

### Testing

- Test report URL: `/report/gfjptA4HWKQ3DrPJ/15-Mythic+Echo+of+Neltharion+-+Kill+(6:12)/Evozerg/standard`
