### PR TITLE
Refactor `GetRelatedEvents` and usage

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -23,12 +23,14 @@ import {
   Awildfivreld,
   nullDozzer,
   Bigsxy,
+  Seriousnes,
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 10, 3), <>Refactor code for related event retrieval.</>, Seriousnes),
   change(date(2023, 10, 1), <>Improve code for coloring texts and backgrounds by <span className='Paladin'>player</span> <span className='Warrior'>classes</span>.</>, nullDozzer),
   change(date(2023, 10, 1), <>Refactor of effects that grant "Primary Stat" such as <ItemLink id={ITEMS.ELEMENTAL_POTION_OF_ULTIMATE_POWER_R3.id} /> and <ItemLink id={ITEMS.DRACONIC_AUGMENT_RUNE.id} /> to only provide current stat and thus match logged values better.</>, nullDozzer),
   change(date(2023, 9, 30), "Removed `shownSpell` from Ability type as it's no longer used.", Putro),

--- a/src/analysis/classic/druid/restoration/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/classic/druid/restoration/modules/normalizers/CastLinkNormalizer.ts
@@ -151,9 +151,11 @@ export function isFromHardcast(event: AbilityEvent<any>): boolean {
 
 /** Returns the hardcast event that caused this buff or heal, if there is one */
 export function getHardcast(event: AbilityEvent<any>): CastEvent | undefined {
-  return GetRelatedEvents(event, FROM_HARDCAST)
-    .filter((e): e is CastEvent => e.type === EventType.Cast)
-    .pop();
+  return GetRelatedEvents<CastEvent>(
+    event,
+    FROM_HARDCAST,
+    (e): e is CastEvent => e.type === EventType.Cast,
+  ).pop();
 }
 
 /** Returns the buff application and direct heal events caused by the given hardcast */
@@ -186,15 +188,19 @@ export function getTranquilityTicks(event: CastEvent): AnyEvent[] {
 }
 
 export function getBloomCausingRegen(event: ResourceChangeEvent): RemoveBuffEvent | undefined {
-  return GetRelatedEvents(event, REGEN_FROM_LIFEBLOOM)
-    .filter((e): e is RemoveBuffEvent => e.type === EventType.RemoveBuff)
-    .pop();
+  return GetRelatedEvents<RemoveBuffEvent>(
+    event,
+    REGEN_FROM_LIFEBLOOM,
+    (e): e is RemoveBuffEvent => e.type === EventType.RemoveBuff,
+  ).pop();
 }
 
 export function getClearcastConsumer(event: RemoveBuffEvent): CastEvent | undefined {
-  return GetRelatedEvents(event, FROM_CLEARCAST)
-    .filter((e): e is CastEvent => e.type === EventType.Cast)
-    .pop();
+  return GetRelatedEvents<CastEvent>(
+    event,
+    FROM_CLEARCAST,
+    (e): e is CastEvent => e.type === EventType.Cast,
+  ).pop();
 }
 
 export default CastLinkNormalizer;

--- a/src/analysis/classic/druid/restoration/modules/normalizers/SwiftmendNormalizer.ts
+++ b/src/analysis/classic/druid/restoration/modules/normalizers/SwiftmendNormalizer.ts
@@ -2,10 +2,9 @@ import SPELLS from 'common/SPELLS/classic/druid';
 import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
 import {
   AbilityEvent,
-  AnyEvent,
   CastEvent,
   EventType,
-  GetRelatedEvents,
+  GetRelatedEvent,
   HasAbility,
 } from 'parser/core/Events';
 import { Options } from 'parser/core/Module';
@@ -32,8 +31,7 @@ class SwiftmendNormalizer extends EventLinkNormalizer {
 }
 
 export function getRemovedHot(event: CastEvent): AbilityEvent<any> | undefined {
-  const removedHots: AnyEvent[] = GetRelatedEvents(event, CONSUMED_HOT);
-  return removedHots.length !== 0 && HasAbility(removedHots[0]) ? removedHots[0] : undefined;
+  return GetRelatedEvent(event, CONSUMED_HOT, HasAbility);
 }
 
 export default SwiftmendNormalizer;

--- a/src/analysis/retail/deathknight/blood/modules/spells/DeathStrike/DeathStrikeSection.tsx
+++ b/src/analysis/retail/deathknight/blood/modules/spells/DeathStrike/DeathStrikeSection.tsx
@@ -29,8 +29,8 @@ import {
   HealEvent,
   HitpointsEvent,
   ResourceActor,
-  GetRelatedEvents,
   CastEvent,
+  GetRelatedEvent,
 } from 'parser/core/Events';
 import { Info } from 'parser/core/metric';
 import DamageTaken from 'parser/shared/modules/throughput/DamageTaken';
@@ -271,10 +271,7 @@ const DeathStrikeProblemChart = ({
   );
 
   const deathStrikeData = useMemo(() => {
-    const problemEvent = GetRelatedEvents(problem.data.cast, DEATH_STRIKE_HEAL)?.[0] as
-      | HealEvent
-      | undefined;
-
+    const problemEvent = GetRelatedEvent<HealEvent>(problem.data.cast, DEATH_STRIKE_HEAL);
     const problemDeathStrike = problemEvent
       ? [
           {
@@ -287,9 +284,11 @@ const DeathStrikeProblemChart = ({
 
     return {
       otherDeathStrikes: deathStrikeEvents
-        .filter((event) => event !== GetRelatedEvents(problem.data.cast, DEATH_STRIKE_HEAL)?.[0])
+        .filter(
+          (event) => event !== GetRelatedEvent<HealEvent>(problem.data.cast, DEATH_STRIKE_HEAL),
+        )
         .map((event) => {
-          const cast = GetRelatedEvents(event, DEATH_STRIKE_CAST)![0] as CastEvent;
+          const cast: CastEvent = GetRelatedEvent(event, DEATH_STRIKE_CAST)!;
           const rp = Math.floor(
             (getResource(cast.classResources, RESOURCE_TYPES.RUNIC_POWER.id)?.amount ?? 0) / 10,
           );

--- a/src/analysis/retail/demonhunter/havoc/normalizers/EssenceBreakNormalizer.ts
+++ b/src/analysis/retail/demonhunter/havoc/normalizers/EssenceBreakNormalizer.ts
@@ -57,19 +57,25 @@ export default class EssenceBreakNormalizer extends EventLinkNormalizer {
 }
 
 export function getBuffedCasts(event: CastEvent): CastEvent[] {
-  return GetRelatedEvents(event, ESSENCE_BREAK_BUFFED).filter(
+  return GetRelatedEvents(
+    event,
+    ESSENCE_BREAK_BUFFED,
     (e): e is CastEvent => e.type === EventType.Cast,
   );
 }
 
 export function getPreviousVengefulRetreat(event: CastEvent): CastEvent | undefined {
-  return GetRelatedEvents(event, ESSENCE_BREAK_AFTER_VENGEFUL_RETREAT)
-    .filter((e): e is CastEvent => e.type === EventType.Cast)
-    .find(Boolean);
+  return GetRelatedEvents<CastEvent>(
+    event,
+    ESSENCE_BREAK_AFTER_VENGEFUL_RETREAT,
+    (e): e is CastEvent => e.type === EventType.Cast,
+  ).find(Boolean);
 }
 
 export function getPreviousEyeBeam(event: CastEvent): CastEvent | undefined {
-  return GetRelatedEvents(event, ESSENCE_BREAK_AFTER_EYE_BEAM)
-    .filter((e): e is CastEvent => e.type === EventType.Cast)
-    .find(Boolean);
+  return GetRelatedEvents<CastEvent>(
+    event,
+    ESSENCE_BREAK_AFTER_EYE_BEAM,
+    (e): e is CastEvent => e.type === EventType.Cast,
+  ).find(Boolean);
 }

--- a/src/analysis/retail/demonhunter/havoc/normalizers/FuriousGazeNormalizer.ts
+++ b/src/analysis/retail/demonhunter/havoc/normalizers/FuriousGazeNormalizer.ts
@@ -4,7 +4,7 @@ import {
   ApplyBuffEvent,
   CastEvent,
   EventType,
-  GetRelatedEvents,
+  GetRelatedEvent,
   RefreshBuffEvent,
 } from 'parser/core/Events';
 import { Options } from 'parser/core/Module';
@@ -35,10 +35,5 @@ export default class FuriousGazeNormalizer extends EventLinkNormalizer {
 export function getFuriousGazeBuffApplication(
   event: CastEvent,
 ): ApplyBuffEvent | RefreshBuffEvent | undefined {
-  return GetRelatedEvents(event, EYE_BEAM_FURIOUS_GAZE)
-    .filter(
-      (e): e is ApplyBuffEvent | RefreshBuffEvent =>
-        e.type === EventType.ApplyBuff || e.type === EventType.RefreshBuff,
-    )
-    .at(0);
+  return GetRelatedEvent<ApplyBuffEvent | RefreshBuffEvent>(event, EYE_BEAM_FURIOUS_GAZE);
 }

--- a/src/analysis/retail/demonhunter/havoc/normalizers/TheHuntVengefulRetreatNormalizer.ts
+++ b/src/analysis/retail/demonhunter/havoc/normalizers/TheHuntVengefulRetreatNormalizer.ts
@@ -27,7 +27,9 @@ export default class TheHuntVengefulRetreatNormalizer extends EventLinkNormalize
 }
 
 export function getPreviousVengefulRetreat(event: CastEvent): CastEvent | undefined {
-  return GetRelatedEvents(event, THE_HUNT_AFTER_VENGEFUL_RETREAT)
-    .filter((e): e is CastEvent => e.type === EventType.Cast)
-    .find(Boolean);
+  return GetRelatedEvents<CastEvent>(
+    event,
+    THE_HUNT_AFTER_VENGEFUL_RETREAT,
+    (e): e is CastEvent => e.type === EventType.Cast,
+  ).find(Boolean);
 }

--- a/src/analysis/retail/demonhunter/havoc/normalizers/UnboundChaosNormalizer.ts
+++ b/src/analysis/retail/demonhunter/havoc/normalizers/UnboundChaosNormalizer.ts
@@ -3,7 +3,7 @@ import {
   ApplyBuffEvent,
   CastEvent,
   EventType,
-  GetRelatedEvents,
+  GetRelatedEvent,
   RefreshBuffEvent,
   RemoveBuffEvent,
 } from 'parser/core/Events';
@@ -50,13 +50,17 @@ export default class UnboundChaosNormalizer extends EventLinkNormalizer {
 export function getUnboundChaosApplication(
   event: ApplyBuffEvent | RefreshBuffEvent,
 ): CastEvent | undefined {
-  return GetRelatedEvents(event, UNBOUND_CHAOS_APPLICATION)
-    .filter((e): e is CastEvent => e.type === EventType.Cast)
-    .at(0);
+  return GetRelatedEvent(
+    event,
+    UNBOUND_CHAOS_APPLICATION,
+    (e): e is CastEvent => e.type === EventType.Cast,
+  );
 }
 
 export function getUnboundChaosConsumption(event: RemoveBuffEvent): CastEvent | undefined {
-  return GetRelatedEvents(event, UNBOUND_CHAOS_CONSUMPTION)
-    .filter((e): e is CastEvent => e.type === EventType.Cast)
-    .at(0);
+  return GetRelatedEvent(
+    event,
+    UNBOUND_CHAOS_CONSUMPTION,
+    (e): e is CastEvent => e.type === EventType.Cast,
+  );
 }

--- a/src/analysis/retail/demonhunter/shared/normalizers/SigilOfFlameNormalizer.ts
+++ b/src/analysis/retail/demonhunter/shared/normalizers/SigilOfFlameNormalizer.ts
@@ -48,7 +48,9 @@ export default class SigilOfFlameNormalizer extends EventLinkNormalizer {
 }
 
 export function getSigilOfFlameDamages(event: CastEvent): DamageEvent[] {
-  return GetRelatedEvents(event, SIGIL_OF_FLAME_DAMAGE).filter(
+  return GetRelatedEvents(
+    event,
+    SIGIL_OF_FLAME_DAMAGE,
     (e): e is DamageEvent => e.type === EventType.Damage,
   );
 }

--- a/src/analysis/retail/demonhunter/shared/normalizers/TheHuntNormalizer.ts
+++ b/src/analysis/retail/demonhunter/shared/normalizers/TheHuntNormalizer.ts
@@ -58,19 +58,25 @@ export default class TheHuntVengefulRetreatNormalizer extends EventLinkNormalize
 }
 
 export function getChargeImpact(event: CastEvent): DamageEvent | undefined {
-  return GetRelatedEvents(event, THE_HUNT_CHARGE)
-    .filter((e): e is DamageEvent => e.type === EventType.Damage)
-    .find(Boolean);
+  return GetRelatedEvents<DamageEvent>(
+    event,
+    THE_HUNT_CHARGE,
+    (e): e is DamageEvent => e.type === EventType.Damage,
+  ).find(Boolean);
 }
 
 export function getDamageEvents(event: CastEvent): DamageEvent[] {
-  return GetRelatedEvents(event, THE_HUNT_CHARGE).filter(
+  return GetRelatedEvents(
+    event,
+    THE_HUNT_CHARGE,
     (e): e is DamageEvent => e.type === EventType.Damage,
   );
 }
 
 export function getAppliedDots(event: CastEvent): ApplyDebuffEvent[] {
-  return GetRelatedEvents(event, THE_HUNT_CHARGE).filter(
+  return GetRelatedEvents(
+    event,
+    THE_HUNT_CHARGE,
     (e): e is ApplyDebuffEvent => e.type === EventType.ApplyDebuff,
   );
 }

--- a/src/analysis/retail/demonhunter/vengeance/modules/core/MajorDefensives/DefensiveBuffLinkNormalizer.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/core/MajorDefensives/DefensiveBuffLinkNormalizer.tsx
@@ -1,6 +1,6 @@
 import { Options } from 'parser/core/Analyzer';
 import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
-import { ApplyBuffEvent, EventType, GetRelatedEvents, RemoveBuffEvent } from 'parser/core/Events';
+import { ApplyBuffEvent, EventType, GetRelatedEvent, RemoveBuffEvent } from 'parser/core/Events';
 import { buffId, MAJOR_DEFENSIVES } from './DefensiveBuffs';
 import { isTalent } from 'common/TALENTS/types';
 
@@ -29,9 +29,9 @@ export default class DefensiveBuffLinkNormalizer extends EventLinkNormalizer {
 }
 
 export function defensiveApplication(event: RemoveBuffEvent): ApplyBuffEvent | undefined {
-  return GetRelatedEvents(event, reverseRelation)[0] as ApplyBuffEvent | undefined;
+  return GetRelatedEvent(event, reverseRelation);
 }
 
 export function defensiveExpiration(event: ApplyBuffEvent): RemoveBuffEvent | undefined {
-  return GetRelatedEvents(event, relation)[0] as RemoveBuffEvent | undefined;
+  return GetRelatedEvent(event, relation);
 }

--- a/src/analysis/retail/demonhunter/vengeance/normalizers/FelDevastationNormalizer.ts
+++ b/src/analysis/retail/demonhunter/vengeance/normalizers/FelDevastationNormalizer.ts
@@ -28,7 +28,9 @@ export default class FelDevastationNormalizer extends EventLinkNormalizer {
 }
 
 export function getDamageEvents(event: CastEvent): DamageEvent[] {
-  return GetRelatedEvents(event, FEL_DEVASTATION_DAMAGE).filter(
+  return GetRelatedEvents(
+    event,
+    FEL_DEVASTATION_DAMAGE,
     (e): e is DamageEvent => e.type === EventType.Damage,
   );
 }

--- a/src/analysis/retail/demonhunter/vengeance/normalizers/ImmolationAuraLinker.ts
+++ b/src/analysis/retail/demonhunter/vengeance/normalizers/ImmolationAuraLinker.ts
@@ -31,7 +31,9 @@ export default class ImmolationAuraLinker extends EventLinkNormalizer {
 }
 
 export function getImmolationAuraInitialHits(event: CastEvent): DamageEvent[] {
-  return GetRelatedEvents(event, IMMOLATION_AURA_INITIAL_HIT).filter(
+  return GetRelatedEvents(
+    event,
+    IMMOLATION_AURA_INITIAL_HIT,
     (e): e is DamageEvent => e.type === EventType.Damage,
   );
 }

--- a/src/analysis/retail/demonhunter/vengeance/normalizers/ShearFractureNormalizer.ts
+++ b/src/analysis/retail/demonhunter/vengeance/normalizers/ShearFractureNormalizer.ts
@@ -3,6 +3,7 @@ import TALENTS from 'common/TALENTS/demonhunter';
 import {
   CastEvent,
   EventType,
+  GetRelatedEvent,
   GetRelatedEvents,
   RemoveBuffStackEvent,
   ResourceChangeEvent,
@@ -76,19 +77,25 @@ export default class ShearFractureNormalizer extends EventLinkNormalizer {
 }
 
 export function getGeneratingCast(event: CastEvent): CastEvent | undefined {
-  return GetRelatedEvents(event, GENERATED_SOUL_FRAGMENT)
-    .filter((e): e is CastEvent => e.type === EventType.Cast)
-    .pop();
+  return GetRelatedEvents<CastEvent>(
+    event,
+    GENERATED_SOUL_FRAGMENT,
+    (e): e is CastEvent => e.type === EventType.Cast,
+  ).pop();
 }
 
 export function getWastedSoulFragment(event: RemoveBuffStackEvent): CastEvent | undefined {
-  return GetRelatedEvents(event, WASTED_SOUL_FRAGMENT)
-    .filter((e): e is CastEvent => e.type === EventType.Cast)
-    .pop();
+  return GetRelatedEvents<CastEvent>(
+    event,
+    WASTED_SOUL_FRAGMENT,
+    (e): e is CastEvent => e.type === EventType.Cast,
+  ).pop();
 }
 
 export function getResourceChange(event: CastEvent): ResourceChangeEvent | undefined {
-  return GetRelatedEvents(event, RESOURCE_CHANGE)
-    .filter((e): e is ResourceChangeEvent => e.type === EventType.ResourceChange)
-    .at(0);
+  return GetRelatedEvent(
+    event,
+    RESOURCE_CHANGE,
+    (e): e is ResourceChangeEvent => e.type === EventType.ResourceChange,
+  );
 }

--- a/src/analysis/retail/demonhunter/vengeance/normalizers/SoulCleaveEventLinkNormalizer.ts
+++ b/src/analysis/retail/demonhunter/vengeance/normalizers/SoulCleaveEventLinkNormalizer.ts
@@ -48,13 +48,17 @@ export default class SoulCleaveEventLinkNormalizer extends EventLinkNormalizer {
 }
 
 export function getSoulCleaveSoulConsumptions(event: CastEvent): RemoveBuffStackEvent[] {
-  return GetRelatedEvents(event, SOUL_CLEAVE_SOUL_CONSUME).filter(
+  return GetRelatedEvents(
+    event,
+    SOUL_CLEAVE_SOUL_CONSUME,
     (e): e is RemoveBuffStackEvent => e.type === EventType.RemoveBuffStack,
   );
 }
 
 export function getSoulCleaveDamages(event: CastEvent): DamageEvent[] {
-  return GetRelatedEvents(event, SOUL_CLEAVE_DAMAGE).filter(
+  return GetRelatedEvents(
+    event,
+    SOUL_CLEAVE_DAMAGE,
     (e): e is DamageEvent => e.type === EventType.Damage,
   );
 }

--- a/src/analysis/retail/demonhunter/vengeance/normalizers/SpiritBombEventLinkNormalizer.ts
+++ b/src/analysis/retail/demonhunter/vengeance/normalizers/SpiritBombEventLinkNormalizer.ts
@@ -63,14 +63,18 @@ export default class SpiritBombEventLinkNormalizer extends EventLinkNormalizer {
 export function getSpiritBombSoulConsumptions(
   event: CastEvent,
 ): (RemoveBuffStackEvent | RemoveBuffEvent)[] {
-  return GetRelatedEvents(event, SPIRIT_BOMB_SOUL_CONSUME).filter(
+  return GetRelatedEvents(
+    event,
+    SPIRIT_BOMB_SOUL_CONSUME,
     (e): e is RemoveBuffStackEvent | RemoveBuffEvent =>
       e.type === EventType.RemoveBuffStack || e.type === EventType.RemoveBuff,
   );
 }
 
 export function getSpiritBombDamages(event: CastEvent): DamageEvent[] {
-  return GetRelatedEvents(event, SPIRIT_BOMB_DAMAGE).filter(
+  return GetRelatedEvents(
+    event,
+    SPIRIT_BOMB_DAMAGE,
     (e): e is DamageEvent => e.type === EventType.Damage,
   );
 }

--- a/src/analysis/retail/druid/feral/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/druid/feral/normalizers/CastLinkNormalizer.ts
@@ -8,6 +8,7 @@ import {
   CastEvent,
   DamageEvent,
   EventType,
+  GetRelatedEvent,
   GetRelatedEvents,
   HasAbility,
   HasRelatedEvent,
@@ -161,8 +162,7 @@ export function isFromDoubleClawedRake(event: AnyEvent): boolean {
 export function getHardcast(
   event: ApplyDebuffEvent | RefreshDebuffEvent | DamageEvent,
 ): CastEvent | undefined {
-  const events: AnyEvent[] = GetRelatedEvents(event, FROM_HARDCAST);
-  return events.length === 0 ? undefined : (events[0] as CastEvent);
+  return GetRelatedEvent(event, FROM_HARDCAST);
 }
 
 // TODO get hardcast energy / cp?
@@ -174,8 +174,7 @@ export function isFromPrimalWrath(event: ApplyDebuffEvent | RefreshDebuffEvent):
 export function getPrimalWrath(
   event: ApplyDebuffEvent | RefreshDebuffEvent | DamageEvent,
 ): CastEvent | undefined {
-  const events: AnyEvent[] = GetRelatedEvents(event, FROM_PRIMAL_WRATH);
-  return events.length === 0 ? undefined : (events[0] as CastEvent);
+  return GetRelatedEvent(event, FROM_PRIMAL_WRATH);
 }
 
 /** Only works for the AoE casts Primal Wrath, Brutal Slash, Swipe, and (Cat) Thrash */
@@ -184,9 +183,7 @@ export function getHitCount(aoeCastEvent: CastEvent): number {
 }
 
 export function getHits(castEvent: CastEvent): AbilityEvent<any>[] {
-  return GetRelatedEvents(castEvent, HIT_TARGET).filter((e): e is AbilityEvent<any> =>
-    HasAbility(e),
-  );
+  return GetRelatedEvents(castEvent, HIT_TARGET, HasAbility);
 }
 
 export default CastLinkNormalizer;

--- a/src/analysis/retail/druid/feral/normalizers/FerociousBiteDrainLinkNormalizer.ts
+++ b/src/analysis/retail/druid/feral/normalizers/FerociousBiteDrainLinkNormalizer.ts
@@ -1,6 +1,6 @@
 import SPELLS from 'common/SPELLS';
 import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
-import { AnyEvent, CastEvent, DrainEvent, EventType, GetRelatedEvents } from 'parser/core/Events';
+import { CastEvent, DrainEvent, EventType, GetRelatedEvent } from 'parser/core/Events';
 import { Options } from 'parser/core/Module';
 
 export const ADDITIONAL_ENERGY_USED = 'AdditionalEnergyUsed';
@@ -33,8 +33,8 @@ class FerociousBiteDrainLinkNormalizer extends EventLinkNormalizer {
 
 /** Gets the additional energy used by the given Ferocious Bite cast, or 0 if no related Drain event can be found */
 export function getAdditionalEnergyUsed(event: CastEvent): number {
-  const events: AnyEvent[] = GetRelatedEvents(event, ADDITIONAL_ENERGY_USED);
-  return events.length === 0 ? 0 : -(events[0] as DrainEvent).resourceChange;
+  const drainEvent = GetRelatedEvent<DrainEvent>(event, ADDITIONAL_ENERGY_USED);
+  return drainEvent ? -drainEvent.resourceChange : 0;
 }
 
 export default FerociousBiteDrainLinkNormalizer;

--- a/src/analysis/retail/druid/feral/normalizers/FerociousBiteDrainLinkNormalizer.ts
+++ b/src/analysis/retail/druid/feral/normalizers/FerociousBiteDrainLinkNormalizer.ts
@@ -1,6 +1,6 @@
 import SPELLS from 'common/SPELLS';
 import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
-import { AnyEvent, CastEvent, DrainEvent, EventType, GetRelatedEvents } from 'parser/core/Events';
+import { CastEvent, DrainEvent, EventType, GetRelatedEvent } from 'parser/core/Events';
 import { Options } from 'parser/core/Module';
 
 export const ADDITIONAL_ENERGY_USED = 'AdditionalEnergyUsed';
@@ -33,8 +33,8 @@ class FerociousBiteDrainLinkNormalizer extends EventLinkNormalizer {
 
 /** Gets the additional energy used by the given Ferocious Bite cast, or 0 if no related Drain event can be found */
 export function getAdditionalEnergyUsed(event: CastEvent): number {
-  const events: AnyEvent[] = GetRelatedEvents(event, ADDITIONAL_ENERGY_USED);
-  return events.length === 0 ? 0 : -(events[0] as DrainEvent).resourceChange;
+  const drainEvent = GetRelatedEvent<DrainEvent>(event, ADDITIONAL_ENERGY_USED);
+  return drainEvent ? 0 : -drainEvent!.resourceChange;
 }
 
 export default FerociousBiteDrainLinkNormalizer;

--- a/src/analysis/retail/druid/feral/normalizers/RampantFerocityLinkNormalizer.ts
+++ b/src/analysis/retail/druid/feral/normalizers/RampantFerocityLinkNormalizer.ts
@@ -37,7 +37,9 @@ export default RampantFerocityLinkNormalizer;
 
 /** Gets the Rampant Ferocity hits procced by this Bite hit */
 export function getRampantFerocityHits(event: DamageEvent): DamageEvent[] {
-  return GetRelatedEvents(event, CAUSED_RAMPANT_FEROCITY_HIT).filter(
+  return GetRelatedEvents(
+    event,
+    CAUSED_RAMPANT_FEROCITY_HIT,
     (e): e is DamageEvent => e.type === EventType.Damage,
   );
 }

--- a/src/analysis/retail/druid/feral/normalizers/SuddenAmbushLinkNormalizer.ts
+++ b/src/analysis/retail/druid/feral/normalizers/SuddenAmbushLinkNormalizer.ts
@@ -54,14 +54,18 @@ class SuddenAmbushLinkNormalizer extends EventLinkNormalizer {
 export default SuddenAmbushLinkNormalizer;
 
 export function getSuddenAmbushBoostedBleeds(event: RemoveBuffEvent): BuffEvent<any>[] {
-  return GetRelatedEvents(event, BOOSTED_BLEED).filter(
+  return GetRelatedEvents(
+    event,
+    BOOSTED_BLEED,
     (e): e is BuffEvent<any> =>
       e.type === EventType.ApplyDebuff || e.type === EventType.RefreshDebuff,
   );
 }
 
 export function getSuddenAmbushBoostedDamage(event: RemoveBuffEvent): DamageEvent[] {
-  return GetRelatedEvents(event, BOOSTED_DAMAGE).filter(
+  return GetRelatedEvents(
+    event,
+    BOOSTED_DAMAGE,
     (e): e is DamageEvent => e.type === EventType.Damage,
   );
 }

--- a/src/analysis/retail/druid/restoration/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/druid/restoration/normalizers/CastLinkNormalizer.ts
@@ -161,9 +161,11 @@ export function isFromHardcast(event: AbilityEvent<any>): boolean {
 
 /** Returns the hardcast event that caused this buff or heal, if there is one */
 export function getHardcast(event: AbilityEvent<any>): CastEvent | undefined {
-  return GetRelatedEvents(event, FROM_HARDCAST)
-    .filter((e): e is CastEvent => e.type === EventType.Cast)
-    .pop();
+  return GetRelatedEvents<CastEvent>(
+    event,
+    FROM_HARDCAST,
+    (e): e is CastEvent => e.type === EventType.Cast,
+  ).pop();
 }
 
 /** Returns true iff the given buff application can be matched to an Overgrowth cast */

--- a/src/analysis/retail/druid/restoration/normalizers/SoulOfTheForestLinkNormalizer.ts
+++ b/src/analysis/retail/druid/restoration/normalizers/SoulOfTheForestLinkNormalizer.ts
@@ -101,8 +101,7 @@ class SoulOfTheForestLinkNormalizer extends EventLinkNormalizer {
 }
 
 export function getSotfBuffs(event: RemoveBuffEvent): Array<AbilityEvent<any>> {
-  const buffedHeals = GetRelatedEvents(event, SOTF_BUFFS_HEAL);
-  return buffedHeals.filter((e): e is AbilityEvent<any> => HasAbility(e));
+  return GetRelatedEvents(event, SOTF_BUFFS_HEAL, HasAbility);
 }
 
 export function buffedBySotf(

--- a/src/analysis/retail/druid/restoration/normalizers/SwiftmendNormalizer.ts
+++ b/src/analysis/retail/druid/restoration/normalizers/SwiftmendNormalizer.ts
@@ -2,10 +2,9 @@ import SPELLS from 'common/SPELLS';
 import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
 import {
   AbilityEvent,
-  AnyEvent,
   CastEvent,
   EventType,
-  GetRelatedEvents,
+  GetRelatedEvent,
   HasAbility,
 } from 'parser/core/Events';
 import { Options } from 'parser/core/Module';
@@ -41,8 +40,7 @@ class SwiftmendNormalizer extends EventLinkNormalizer {
 }
 
 export function getRemovedHot(event: CastEvent): AbilityEvent<any> | undefined {
-  const removedHots: AnyEvent[] = GetRelatedEvents(event, CONSUMED_HOT);
-  return removedHots.length !== 0 && HasAbility(removedHots[0]) ? removedHots[0] : undefined;
+  return GetRelatedEvent(event, CONSUMED_HOT, HasAbility);
 }
 
 export default SwiftmendNormalizer;

--- a/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
@@ -231,43 +231,57 @@ class CastLinkNormalizer extends EventLinkNormalizer {
 }
 
 export function getPrescienceBuffEvents(event: CastEvent): ApplyBuffEvent[] {
-  return GetRelatedEvents(event, PRESCIENCE_BUFF_CAST_LINK).filter(
+  return GetRelatedEvents(
+    event,
+    PRESCIENCE_BUFF_CAST_LINK,
     (e): e is ApplyBuffEvent => e.type === EventType.ApplyBuff || e.type === EventType.RefreshBuff,
   );
 }
 
 export function getEbonMightBuffEvents(event: ApplyBuffEvent | RefreshBuffEvent): ApplyBuffEvent[] {
-  return GetRelatedEvents(event, EBON_MIGHT_BUFF_LINKS).filter(
+  return GetRelatedEvents(
+    event,
+    EBON_MIGHT_BUFF_LINKS,
     (e): e is ApplyBuffEvent => e.type === EventType.ApplyBuff || e.type === EventType.RefreshBuff,
   );
 }
 
 export function getBreathOfEonsDebuffApplyEvents(event: CastEvent): ApplyDebuffEvent[] {
-  return GetRelatedEvents(event, BREATH_OF_EONS_CAST_DEBUFF_APPLY_LINK).filter(
+  return GetRelatedEvents(
+    event,
+    BREATH_OF_EONS_CAST_DEBUFF_APPLY_LINK,
     (e): e is ApplyDebuffEvent => e.type === EventType.ApplyDebuff,
   );
 }
 
 export function getBreathOfEonsBuffEvents(event: CastEvent): ApplyBuffEvent[] {
-  return GetRelatedEvents(event, BREATH_OF_EONS_CAST_BUFF_LINK).filter(
+  return GetRelatedEvents(
+    event,
+    BREATH_OF_EONS_CAST_BUFF_LINK,
     (e): e is ApplyBuffEvent => e.type === EventType.ApplyBuff || e.type === EventType.RemoveBuff,
   );
 }
 
 export function getBreathOfEonsDamageEvents(event: RemoveDebuffEvent): DamageEvent[] {
-  return GetRelatedEvents(event, BREATH_OF_EONS_DAMAGE_LINK).filter(
+  return GetRelatedEvents(
+    event,
+    BREATH_OF_EONS_DAMAGE_LINK,
     (e): e is DamageEvent => e.type === EventType.Damage,
   );
 }
 
 export function getEruptionDamageEvents(event: CastEvent): DamageEvent[] {
-  return GetRelatedEvents(event, ERUPTION_CAST_DAM_LINK).filter(
+  return GetRelatedEvents(
+    event,
+    ERUPTION_CAST_DAM_LINK,
     (e): e is DamageEvent => e.type === EventType.Damage,
   );
 }
 
 export function getPupilDamageEvents(event: CastEvent): DamageEvent[] {
-  return GetRelatedEvents(event, PUPIL_OF_ALEXSTRASZA_LINK).filter(
+  return GetRelatedEvents(
+    event,
+    PUPIL_OF_ALEXSTRASZA_LINK,
     (e): e is DamageEvent => e.type === EventType.Damage,
   );
 }

--- a/src/analysis/retail/evoker/shared/modules/normalizers/LeapingFlamesNormalizer.ts
+++ b/src/analysis/retail/evoker/shared/modules/normalizers/LeapingFlamesNormalizer.ts
@@ -106,13 +106,17 @@ class LeapingFlamesNormalizer extends EventLinkNormalizer {
 }
 
 export function getLeapingDamageEvents(event: CastEvent): DamageEvent[] {
-  return GetRelatedEvents(event, LEAPING_FLAMES_HITS).filter(
+  return GetRelatedEvents(
+    event,
+    LEAPING_FLAMES_HITS,
     (e): e is DamageEvent => e.type === EventType.Damage,
   );
 }
 
 export function getLeapingHealEvents(event: CastEvent): HealEvent[] {
-  return GetRelatedEvents(event, LEAPING_FLAMES_HITS).filter(
+  return GetRelatedEvents(
+    event,
+    LEAPING_FLAMES_HITS,
     (e): e is HealEvent => e.type === EventType.Heal,
   );
 }
@@ -120,14 +124,18 @@ export function getLeapingHealEvents(event: CastEvent): HealEvent[] {
 export function getCastedGeneratedEssenceBurst(
   event: CastEvent,
 ): (ApplyBuffEvent | ApplyBuffStackEvent)[] {
-  return GetRelatedEvents(event, ESSENCE_BURST_CAST_GENERATED).filter(
+  return GetRelatedEvents(
+    event,
+    ESSENCE_BURST_CAST_GENERATED,
     (e): e is ApplyBuffEvent | ApplyBuffStackEvent =>
       e.type === EventType.ApplyBuff || e.type === EventType.ApplyBuffStack,
   );
 }
 
 export function getWastedEssenceBurst(event: CastEvent): RefreshBuffEvent[] {
-  return GetRelatedEvents(event, ESSENCE_BURST_WASTED).filter(
+  return GetRelatedEvents(
+    event,
+    ESSENCE_BURST_WASTED,
     (e): e is RefreshBuffEvent => e.type === EventType.RefreshBuff,
   );
 }

--- a/src/analysis/retail/evoker/shared/modules/talents/LeapingFlames.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/LeapingFlames.tsx
@@ -4,7 +4,7 @@ import { formatNumber } from 'common/format';
 
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
-import Events, { CastEvent, GetRelatedEvents, HasRelatedEvent } from 'parser/core/Events';
+import Events, { CastEvent, GetRelatedEvent, HasRelatedEvent } from 'parser/core/Events';
 import {
   getLeapingDamageEvents,
   getLeapingHealEvents,
@@ -143,7 +143,7 @@ class LeapingFlames extends Analyzer {
             // Events are weird but this solution works
             if (
               !HasRelatedEvent(
-                GetRelatedEvents(healEvent, ESSENCE_BURST_GENERATED)[0],
+                GetRelatedEvent(healEvent, ESSENCE_BURST_GENERATED)!,
                 ESSENCE_BURST_CAST_GENERATED,
               )
             ) {

--- a/src/analysis/retail/mage/arcane/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/mage/arcane/normalizers/CastLinkNormalizer.ts
@@ -2,11 +2,11 @@ import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/mage';
 import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
 import {
-  AnyEvent,
   ApplyDebuffEvent,
   CastEvent,
   DamageEvent,
   EventType,
+  GetRelatedEvent,
   GetRelatedEvents,
   HasRelatedEvent,
   RefreshDebuffEvent,
@@ -74,8 +74,7 @@ export function isFromHardcast(
 export function getHardcast(
   event: ApplyDebuffEvent | RefreshDebuffEvent | DamageEvent,
 ): CastEvent | undefined {
-  const events: AnyEvent[] = GetRelatedEvents(event, FROM_HARDCAST);
-  return events.length === 0 ? undefined : (events[0] as CastEvent);
+  return GetRelatedEvent(event, FROM_HARDCAST);
 }
 
 export function getHitCount(aoeCastEvent: CastEvent): number {

--- a/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/DefensiveBuffLinkNormalizer.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/DefensiveBuffLinkNormalizer.tsx
@@ -1,6 +1,6 @@
 import { Options } from 'parser/core/Analyzer';
 import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
-import { ApplyBuffEvent, EventType, GetRelatedEvents, RemoveBuffEvent } from 'parser/core/Events';
+import { ApplyBuffEvent, EventType, GetRelatedEvent, RemoveBuffEvent } from 'parser/core/Events';
 import { buffId, MAJOR_DEFENSIVES } from './DefensiveBuffs';
 
 const relation = 'defensive-buff-remove';
@@ -28,9 +28,9 @@ export default class DefensiveBuffLinkNormalizer extends EventLinkNormalizer {
 }
 
 export function defensiveApplication(event: RemoveBuffEvent): ApplyBuffEvent | undefined {
-  return GetRelatedEvents(event, reverseRelation)[0] as ApplyBuffEvent | undefined;
+  return GetRelatedEvent(event, reverseRelation);
 }
 
 export function defensiveExpiration(event: ApplyBuffEvent): RemoveBuffEvent | undefined {
-  return GetRelatedEvents(event, relation)[0] as RemoveBuffEvent | undefined;
+  return GetRelatedEvent(event, relation);
 }

--- a/src/analysis/retail/monk/brewmaster/modules/talents/PressTheAdvantage/normalizer.ts
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/PressTheAdvantage/normalizer.ts
@@ -7,6 +7,7 @@ import {
   CastEvent,
   DamageEvent,
   EventType,
+  GetRelatedEvent,
   GetRelatedEvents,
   RemoveBuffEvent,
 } from 'parser/core/Events';
@@ -76,7 +77,7 @@ export function isPtaBonusCast(event: CastEvent): boolean {
 }
 
 export function ptaBonusCast(event: RemoveBuffEvent): CastEvent | undefined {
-  return GetRelatedEvents(event, PTA_BONUS_CAST)?.[0] as CastEvent | undefined;
+  return GetRelatedEvent(event, PTA_BONUS_CAST);
 }
 
 export function ptaBonusDamage(event: RemoveBuffEvent): DamageEvent[] {
@@ -86,9 +87,7 @@ export function ptaBonusDamage(event: RemoveBuffEvent): DamageEvent[] {
     return [];
   }
 
-  return GetRelatedEvents(cast, RSK_DAMAGE).concat(
-    GetRelatedEvents(cast, KS_DAMAGE),
-  ) as DamageEvent[];
+  return GetRelatedEvents<DamageEvent>(cast, RSK_DAMAGE).concat(GetRelatedEvents(cast, KS_DAMAGE));
 }
 
 export default class PressTheAdvantageNormalizer extends EventLinkNormalizer {

--- a/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
@@ -14,6 +14,7 @@ import {
   HealEvent,
   CastEvent,
   ApplyBuffStackEvent,
+  GetRelatedEvent,
 } from 'parser/core/Events';
 
 export const APPLIED_HEAL = 'AppliedHeal';
@@ -507,10 +508,10 @@ export function isFromRapidDiffusionRisingSunKick(event: ApplyBuffEvent | Refres
   if (!HasRelatedEvent(event, FROM_RAPID_DIFFUSION)) {
     return false;
   }
-  const rdSourceEvent = GetRelatedEvents(event, FROM_RAPID_DIFFUSION);
+  const rdSourceEvent = GetRelatedEvent(event, FROM_RAPID_DIFFUSION)!;
   return (
-    rdSourceEvent[0].type === EventType.Cast &&
-    rdSourceEvent[0].ability.guid === TALENTS_MONK.RISING_SUN_KICK_TALENT.id
+    rdSourceEvent.type === EventType.Cast &&
+    rdSourceEvent.ability.guid === TALENTS_MONK.RISING_SUN_KICK_TALENT.id
   );
 }
 
@@ -582,7 +583,7 @@ export function isFromLifeCocoon(event: RemoveBuffEvent) {
 }
 
 export function getSheilunsGiftHits(event: CastEvent): HealEvent[] {
-  return GetRelatedEvents(event, SHEILUNS_GIFT) as HealEvent[];
+  return GetRelatedEvents<HealEvent>(event, SHEILUNS_GIFT);
 }
 
 export function getVivifiesPerCast(event: CastEvent) {
@@ -601,11 +602,11 @@ export function getManaTeaStacksConsumed(event: ApplyBuffEvent) {
 }
 
 export function getManaTeaChannelDuration(event: ApplyBuffEvent) {
-  const castEvent = GetRelatedEvents(event, MANA_TEA_CAST_LINK)[0];
+  const castEvent = GetRelatedEvent(event, MANA_TEA_CAST_LINK);
   if (castEvent === undefined) {
     return undefined;
   }
-  return GetRelatedEvents(castEvent, MANA_TEA_CHANNEL)[0].timestamp - castEvent.timestamp;
+  return GetRelatedEvent(castEvent, MANA_TEA_CHANNEL)!.timestamp - castEvent.timestamp;
 }
 
 export function isMTStackFromLifeCycles(

--- a/src/analysis/retail/paladin/holy/modules/features/HolyPaladinHealingEfficiencyTracker.ts
+++ b/src/analysis/retail/paladin/holy/modules/features/HolyPaladinHealingEfficiencyTracker.ts
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/paladin';
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { AbilityEvent, GetRelatedEvents, HealEvent } from 'parser/core/Events';
+import Events, { AbilityEvent, GetRelatedEvent, HealEvent } from 'parser/core/Events';
 import HealingEfficiencyTracker, {
   SpellInfoDetails,
 } from 'parser/core/healingEfficiency/HealingEfficiencyTracker';
@@ -18,16 +18,16 @@ class HolyPaladinHealingEfficiencyTracker extends HealingEfficiencyTracker {
 
   onHeal(event: HealEvent) {
     if (event.ability.guid === SPELLS.GLIMMER_OF_LIGHT_HEAL_TALENT.id) {
-      const source = GetRelatedEvents(event, GLIMMER_PROC);
-      if (source.length > 0) {
-        const triggerID = (source[0] as AbilityEvent<any>).ability.guid;
+      const source = GetRelatedEvent<AbilityEvent<any>>(event, GLIMMER_PROC);
+      if (source) {
+        const triggerID = source.ability.guid;
         this.glimmerHealing[triggerID] =
           (this.glimmerHealing[triggerID] || 0) + event.amount + (event.absorbed || 0);
       }
     } else if (event.ability.guid === SPELLS.HOLY_SHOCK_HEAL.id) {
-      const source = GetRelatedEvents(event, HOLY_SHOCK_SOURCE);
-      if (source.length > 0) {
-        const triggerID = (source[0] as AbilityEvent<any>).ability.guid;
+      const source = GetRelatedEvent<AbilityEvent<any>>(event, HOLY_SHOCK_SOURCE);
+      if (source) {
+        const triggerID = source.ability.guid;
         this.holyShockHealing[triggerID] =
           (this.holyShockHealing[triggerID] || 0) + event.amount + (event.absorbed || 0);
       }

--- a/src/analysis/retail/paladin/holy/modules/talents/GlimmerOfLight/GlimmerOfLight.tsx
+++ b/src/analysis/retail/paladin/holy/modules/talents/GlimmerOfLight/GlimmerOfLight.tsx
@@ -8,7 +8,7 @@ import Events, {
   ApplyDebuffEvent,
   BeaconHealEvent,
   DamageEvent,
-  GetRelatedEvents,
+  GetRelatedEvent,
   HasRelatedEvent,
   HealEvent,
   RemoveBuffEvent,
@@ -159,8 +159,8 @@ class GlimmerOfLight extends Analyzer {
 
   getGlimmerSource(event: HealEvent | DamageEvent) {
     if (HasRelatedEvent(event, GLIMMER_PROC)) {
-      const sourceEvent = GetRelatedEvents(event, GLIMMER_PROC)[0];
-      const sourceID = (sourceEvent as AbilityEvent<string>).ability.guid;
+      const sourceEvent = GetRelatedEvent<AbilityEvent<any>>(event, GLIMMER_PROC)!;
+      const sourceID = sourceEvent.ability.guid;
       const fixedID = GLISTENING_RADIANCE_IDS[sourceID] ?? sourceID;
 
       return fixedID;

--- a/src/analysis/retail/paladin/holy/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/paladin/holy/normalizers/CastLinkNormalizer.ts
@@ -196,7 +196,7 @@ class CastLinkNormalizer extends EventLinkNormalizer {
 }
 
 export function getLightsHammerHeals(event: HealEvent) {
-  return [event].concat(GetRelatedEvents(event, LIGHTS_HAMMER_HEAL) as HealEvent[]);
+  return [event].concat(GetRelatedEvents<HealEvent>(event, LIGHTS_HAMMER_HEAL));
 }
 
 export default CastLinkNormalizer;

--- a/src/analysis/retail/paladin/protection/modules/CastLinkNormalizer.ts
+++ b/src/analysis/retail/paladin/protection/modules/CastLinkNormalizer.ts
@@ -160,15 +160,19 @@ class MyAbilityNormalizer extends EventLinkNormalizer {
 }
 
 export function gcJudgmentCrit(event: ApplyBuffEvent | RefreshBuffEvent): DamageEvent | undefined {
-  return GetRelatedEvents(event, GRAND_CRUSADER_JUDGMENT_CRIT)
-    .filter((e): e is DamageEvent => e.type === EventType.Damage)
-    .at(-1);
+  return GetRelatedEvents<DamageEvent>(
+    event,
+    GRAND_CRUSADER_JUDGMENT_CRIT,
+    (e): e is DamageEvent => e.type === EventType.Damage,
+  ).at(-1);
 }
 
 export function getHardcast(event: DamageEvent): CastEvent | undefined {
-  return GetRelatedEvents(event, FROM_HARDCAST)
-    .filter((e): e is CastEvent => e.type === EventType.Cast)
-    .at(-1);
+  return GetRelatedEvents<CastEvent>(
+    event,
+    FROM_HARDCAST,
+    (e): e is CastEvent => e.type === EventType.Cast,
+  ).at(-1);
 }
 
 export function consumedProc(event: DamageEvent): boolean {

--- a/src/analysis/retail/priest/discipline/modules/spells/Aberrus2p.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/Aberrus2p.tsx
@@ -67,7 +67,7 @@ class Aberrus2p extends Analyzer {
       return;
     }
 
-    const damageEvent = getDamageEvent(event);
+    const damageEvent = getDamageEvent(event)!;
     const damageSpellId = damageEvent.ability.guid;
 
     if (

--- a/src/analysis/retail/priest/discipline/modules/spells/AbyssalReverie.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/AbyssalReverie.tsx
@@ -37,11 +37,10 @@ class AbyssalReverie extends Analyzer {
   }
 
   onAtoneHeal(event: HealEvent) {
-    if (!getDamageEvent(event)) {
+    const damageEvent = getDamageEvent(event);
+    if (!damageEvent) {
       return;
     }
-    const damageEvent = getDamageEvent(event);
-
     if (
       // Shadow spells only
       damageEvent.ability.type !== MAGIC_SCHOOLS.ids.SHADOW ||

--- a/src/analysis/retail/priest/discipline/modules/spells/BlazeOfLight/BlazeOfLight.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/BlazeOfLight/BlazeOfLight.tsx
@@ -57,10 +57,10 @@ class BlazeOfLight extends Analyzer {
   }
 
   onAtoneHeal(event: HealEvent) {
-    if (!getDamageEvent(event)) {
+    const damageEvent = getDamageEvent(event);
+    if (!damageEvent) {
       return;
     }
-    const damageEvent = getDamageEvent(event);
     if (!BLAZE_OF_LIGHT_SPELLS.includes(damageEvent.ability.guid)) {
       return;
     }

--- a/src/analysis/retail/priest/discipline/modules/spells/Castigation.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/Castigation.tsx
@@ -38,10 +38,10 @@ class Castigation extends Analyzer {
   }
 
   onAtoneHeal(event: HealEvent) {
-    if (!getDamageEvent(event)) {
+    const damageEvent = getDamageEvent(event);
+    if (!damageEvent) {
       return;
     }
-    const damageEvent = getDamageEvent(event);
     if (!IsPenanceDamageEvent(damageEvent)) {
       return;
     }

--- a/src/analysis/retail/priest/discipline/modules/spells/Mindgames.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/Mindgames.tsx
@@ -42,10 +42,10 @@ class Mindgames extends Analyzer {
   }
 
   onAtoneHeal(event: any) {
-    if (!getDamageEvent(event)) {
+    const damageEvent = getDamageEvent(event);
+    if (!damageEvent) {
       return;
     }
-    const damageEvent = getDamageEvent(event);
 
     if (
       damageEvent.ability.guid !== TALENTS_PRIEST.MINDGAMES_TALENT.id &&

--- a/src/analysis/retail/priest/discipline/modules/spells/Schism.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/Schism.tsx
@@ -55,10 +55,10 @@ class Schism extends Analyzer {
   }
 
   onHeal(event: HealEvent) {
-    if (!getDamageEvent(event)) {
+    const damageEvent = getDamageEvent(event);
+    if (!damageEvent) {
       return;
     }
-    const damageEvent = getDamageEvent(event);
     const target = this.enemies.getEntity(damageEvent);
 
     if (

--- a/src/analysis/retail/priest/discipline/modules/spells/ShadowCovenant/ShadowCovenant.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/ShadowCovenant/ShadowCovenant.tsx
@@ -55,10 +55,10 @@ class ShadowCovenant extends Analyzer {
   }
 
   onAtoneHeal(event: HealEvent) {
-    if (!getDamageEvent(event)) {
+    const damageEvent = getDamageEvent(event);
+    if (!damageEvent) {
       return;
     }
-    const damageEvent = getDamageEvent(event);
 
     // Shadow covenant only buffs expiation if you aren't talented into PTW
     if (damageEvent.ability.guid === SPELLS.EXPIATION_DAMAGE.id && this.hasPtw) {

--- a/src/analysis/retail/priest/discipline/modules/spells/TwilightEquilibrium/TwilightEquilibrium.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/TwilightEquilibrium/TwilightEquilibrium.tsx
@@ -73,8 +73,11 @@ class TwilightEquilibrium extends Analyzer {
     }
 
     const damageEvent = getDamageEvent(event);
+    if (!damageEvent) {
+      return;
+    }
 
-    if (damageEvent?.ability.guid === SPELLS.PURGE_THE_WICKED_BUFF.id) {
+    if (damageEvent.ability.guid === SPELLS.PURGE_THE_WICKED_BUFF.id) {
       if (this.ptwTargets.has(encodeEventTargetString(damageEvent) || '')) {
         const increase = calculateEffectiveHealing(event, TE_INCREASE);
         this.healing += increase;

--- a/src/analysis/retail/priest/discipline/modules/spells/WealAndWoe.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/WealAndWoe.tsx
@@ -62,7 +62,7 @@ class WealAndWoe extends Analyzer {
       return;
     }
 
-    const castEvent = getCastAbility(event);
+    const castEvent = getCastAbility(event)!;
     const WEAL_AND_WOE_STACKS = this.selectedCombatant.getBuffStacks(
       SPELLS.WEAL_AND_WOE_BUFF.id,
       castEvent.timestamp,
@@ -76,12 +76,10 @@ class WealAndWoe extends Analyzer {
   }
 
   onAtoneHeal(event: HealEvent) {
-    if (!getDamageEvent(event)) {
+    const damageEvent = getDamageEvent(event);
+    if (!damageEvent) {
       return;
     }
-
-    const damageEvent = getDamageEvent(event);
-
     if (
       damageEvent.ability.guid !== SPELLS.SMITE.id &&
       damageEvent.ability.guid !== TALENTS_PRIEST.POWER_WORD_SOLACE_TALENT.id
@@ -89,7 +87,7 @@ class WealAndWoe extends Analyzer {
       return;
     }
 
-    const castEvent = getCastAbility(damageEvent);
+    const castEvent = getCastAbility(damageEvent)!;
     const WEAL_AND_WOE_STACKS = this.selectedCombatant.getBuffStacks(
       SPELLS.WEAL_AND_WOE_BUFF.id,
       castEvent.timestamp,

--- a/src/analysis/retail/priest/discipline/modules/spells/WordsOfThePious.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/WordsOfThePious.tsx
@@ -37,14 +37,15 @@ class WordsOfThePious extends Analyzer {
   }
 
   onAtoneHeal(event: HealEvent) {
-    if (!getDamageEvent(event)) {
+    const damageEvent = getDamageEvent(event);
+
+    if (!damageEvent) {
       return;
     }
 
     if (!this.selectedCombatant.hasBuff(SPELLS.WORDS_OF_THE_PIOUS_BUFF.id)) {
       return;
     }
-    const damageEvent = getDamageEvent(event);
 
     if (
       damageEvent.ability.guid !== TALENTS_PRIEST.HOLY_NOVA_TALENT.id &&

--- a/src/analysis/retail/priest/discipline/normalizers/AtonementTracker.ts
+++ b/src/analysis/retail/priest/discipline/normalizers/AtonementTracker.ts
@@ -55,14 +55,14 @@ export function hasAtonementDamageEvent(event: HealEvent): boolean {
 }
 
 export function getDamageEvent(event: HealEvent) {
-  return GetRelatedEvents(event, ATONEMENT_DAMAGE_EVENT).at(-1) as DamageEvent;
+  return GetRelatedEvents<DamageEvent>(event, ATONEMENT_DAMAGE_EVENT).at(-1);
 }
 
 export function getHealEvents(event: DamageEvent) {
-  return GetRelatedEvents(event, ATONEMENT_HEAL_EVENT) as HealEvent[];
+  return GetRelatedEvents<HealEvent>(event, ATONEMENT_HEAL_EVENT);
 }
 
 export function getAtonementHealEvents(event: DamageEvent) {
-  return GetRelatedEvents(event, ATONEMENT_HEAL_EVENT) as HealEvent[];
+  return GetRelatedEvents<HealEvent>(event, ATONEMENT_HEAL_EVENT);
 }
 export default AtonementNormalizer;

--- a/src/analysis/retail/priest/discipline/normalizers/DamageCastLink.ts
+++ b/src/analysis/retail/priest/discipline/normalizers/DamageCastLink.ts
@@ -1,5 +1,11 @@
 import SPELLS from 'common/SPELLS';
-import { CastEvent, DamageEvent, EventType, GetRelatedEvents } from 'parser/core/Events';
+import {
+  CastEvent,
+  DamageEvent,
+  EventType,
+  GetRelatedEvent,
+  GetRelatedEvents,
+} from 'parser/core/Events';
 import { Options } from 'parser/core/Module';
 import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
 import { TALENTS_PRIEST } from 'common/TALENTS';
@@ -102,11 +108,11 @@ class DamageCastLink extends EventLinkNormalizer {
 }
 
 export function getDamageAbility(event: CastEvent) {
-  return GetRelatedEvents(event, DAMAGE)[0] as DamageEvent;
+  return GetRelatedEvent<DamageEvent>(event, DAMAGE);
 }
 
 export function getCastAbility(event: DamageEvent) {
-  return GetRelatedEvents(event, CAST)[0] as CastEvent;
+  return GetRelatedEvent<CastEvent>(event, CAST);
 }
 
 export default DamageCastLink;

--- a/src/analysis/retail/priest/holy/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/priest/holy/normalizers/CastLinkNormalizer.ts
@@ -3,6 +3,7 @@ import {
   CastEvent,
   DamageEvent,
   EventType,
+  GetRelatedEvent,
   GetRelatedEvents,
   HasRelatedEvent,
   HealEvent,
@@ -129,41 +130,39 @@ class CastLinkNormalizer extends EventLinkNormalizer {
 }
 
 export function getPrayerOfHealingEvents(event: CastEvent): HealEvent[] {
-  return GetRelatedEvents(event, POH_CAST).filter((e): e is HealEvent => e.type === EventType.Heal);
+  return GetRelatedEvents(event, POH_CAST, (e): e is HealEvent => e.type === EventType.Heal);
 }
 
 export function getCircleOfHealingEvents(event: CastEvent): HealEvent[] {
-  return GetRelatedEvents(event, COH_CAST).filter((e): e is HealEvent => e.type === EventType.Heal);
+  return GetRelatedEvents(event, COH_CAST, (e): e is HealEvent => e.type === EventType.Heal);
 }
 
 export function getHeal(event: CastEvent): HealEvent | undefined {
-  return GetRelatedEvents(event, FROM_HARDCAST)
-    .filter((e): e is HealEvent => e.type === EventType.Heal)
-    .pop();
+  return GetRelatedEvents<HealEvent>(
+    event,
+    FROM_HARDCAST,
+    (e): e is HealEvent => e.type === EventType.Heal,
+  ).pop();
 }
 
 export function getSerenityHealEvent(event: CastEvent): HealEvent {
-  return GetRelatedEvents(event, SERENITY_CAST).filter(
-    (e): e is HealEvent => e.type === EventType.Heal,
-  )[0];
+  return GetRelatedEvent(event, SERENITY_CAST, (e): e is HealEvent => e.type === EventType.Heal)!;
 }
 
 export function getSanctifyHealEvents(event: CastEvent): HealEvent[] {
-  return GetRelatedEvents(event, SANCTIFY_CAST).filter(
-    (e): e is HealEvent => e.type === EventType.Heal,
-  );
+  return GetRelatedEvents(event, SANCTIFY_CAST, (e): e is HealEvent => e.type === EventType.Heal);
 }
 
 export function getSalvationHealEvents(event: CastEvent): HealEvent[] {
-  return GetRelatedEvents(event, SALVATION_CAST).filter(
-    (e): e is HealEvent => e.type === EventType.Heal,
-  );
+  return GetRelatedEvents(event, SALVATION_CAST, (e): e is HealEvent => e.type === EventType.Heal);
 }
 
 export function getChastiseDamageEvent(event: CastEvent): DamageEvent {
-  return GetRelatedEvents(event, CHASTISE_CAST).filter(
+  return GetRelatedEvent(
+    event,
+    CHASTISE_CAST,
     (e): e is DamageEvent => e.type === EventType.Damage,
-  )[0];
+  )!;
 }
 
 export function isCastBuffedByLightweaver(event: CastEvent) {

--- a/src/analysis/retail/rogue/assassination/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/rogue/assassination/normalizers/CastLinkNormalizer.ts
@@ -7,6 +7,7 @@ import {
   CastEvent,
   DamageEvent,
   EventType,
+  GetRelatedEvent,
   GetRelatedEvents,
   HasAbility,
   HasRelatedEvent,
@@ -97,8 +98,7 @@ export function isFromHardcast(event: AnyEvent): boolean {
 export function getHardcast(
   event: ApplyDebuffEvent | RefreshDebuffEvent | DamageEvent,
 ): CastEvent | undefined {
-  const events: AnyEvent[] = GetRelatedEvents(event, FROM_HARDCAST);
-  return events.length === 0 ? undefined : (events[0] as CastEvent);
+  return GetRelatedEvent<CastEvent>(event, FROM_HARDCAST);
 }
 
 export function getHitCount(aoeCastEvent: CastEvent): number {
@@ -106,7 +106,5 @@ export function getHitCount(aoeCastEvent: CastEvent): number {
 }
 
 export function getHits(castEvent: CastEvent): AbilityEvent<any>[] {
-  return GetRelatedEvents(castEvent, HIT_TARGET).filter((e): e is AbilityEvent<any> =>
-    HasAbility(e),
-  );
+  return GetRelatedEvents(castEvent, HIT_TARGET, HasAbility);
 }

--- a/src/analysis/retail/rogue/assassination/normalizers/SepsisLinkNormalizer.ts
+++ b/src/analysis/retail/rogue/assassination/normalizers/SepsisLinkNormalizer.ts
@@ -8,7 +8,7 @@ import {
   ApplyDebuffEvent,
   CastEvent,
   EventType,
-  GetRelatedEvents,
+  GetRelatedEvent,
   RemoveBuffEvent,
   RemoveDebuffEvent,
 } from 'parser/core/Events';
@@ -104,9 +104,11 @@ export default class SepsisLinkNormalizer extends EventLinkNormalizer {
 export const getDebuffApplicationFromHardcast = (
   event: CastEvent,
 ): ApplyDebuffEvent | undefined => {
-  return GetRelatedEvents(event, INSTANT_APPLICATION)
-    .filter((e): e is ApplyDebuffEvent => e.type === EventType.ApplyDebuff)
-    .at(0);
+  return GetRelatedEvent(
+    event,
+    INSTANT_APPLICATION,
+    (e): e is ApplyDebuffEvent => e.type === EventType.ApplyDebuff,
+  );
 };
 /** Returns the ApplyBuffEvent for the given Sepsis cast with the relation given by,
  * @param {string} relation either `"InstantAuraApplication"` or `"DelayedAuraApplication"`
@@ -115,9 +117,11 @@ export const getRelatedBuffApplicationFromHardcast = (
   event: CastEvent,
   relation: typeof INSTANT_APPLICATION | typeof DELAYED_APPLICATION,
 ): ApplyBuffEvent | undefined => {
-  return GetRelatedEvents(event, relation)
-    .filter((e): e is ApplyBuffEvent => e.type === EventType.ApplyBuff)
-    .at(0);
+  return GetRelatedEvent(
+    event,
+    relation,
+    (e): e is ApplyBuffEvent => e.type === EventType.ApplyBuff,
+  );
 };
 
 /** Returns the stealth ability `CastEvent` for the given Sepsis `BuffEvent` if any exists, and `undefined` otherwise.
@@ -130,9 +134,11 @@ export const getSepsisConsumptionCastForBuffEvent = (
     const removeBuffEvent = getAuraLifetimeEvent(event);
     event = removeBuffEvent ? removeBuffEvent : event;
   }
-  return GetRelatedEvents(event, BUFF_CONSUMPTION_EVENT)
-    .filter((e): e is CastEvent => e.type === EventType.Cast)
-    .at(0);
+  return GetRelatedEvent(
+    event,
+    BUFF_CONSUMPTION_EVENT,
+    (e): e is CastEvent => e.type === EventType.Cast,
+  );
 };
 
 type MatchedLifetimeEvent<
@@ -150,13 +156,13 @@ type MatchedLifetimeEvent<
 export function getAuraLifetimeEvent<
   T extends ApplyBuffEvent | RemoveBuffEvent | ApplyDebuffEvent | RemoveDebuffEvent,
 >(event: T): MatchedLifetimeEvent<T> | undefined {
-  return GetRelatedEvents(event, AURA_LIFETIME_EVENT)
-    .filter(
-      (matchedEvent): matchedEvent is MatchedLifetimeEvent<T> =>
-        matchedEvent.type === EventType.ApplyBuff ||
-        matchedEvent.type === EventType.RemoveBuff ||
-        matchedEvent.type === EventType.ApplyDebuff ||
-        matchedEvent.type === EventType.RemoveDebuff,
-    )
-    .at(0);
+  return GetRelatedEvent(
+    event,
+    AURA_LIFETIME_EVENT,
+    (matchedEvent): matchedEvent is MatchedLifetimeEvent<T> =>
+      matchedEvent.type === EventType.ApplyBuff ||
+      matchedEvent.type === EventType.RemoveBuff ||
+      matchedEvent.type === EventType.ApplyDebuff ||
+      matchedEvent.type === EventType.RemoveDebuff,
+  );
 }

--- a/src/analysis/retail/rogue/outlaw/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/rogue/outlaw/normalizers/CastLinkNormalizer.ts
@@ -7,6 +7,7 @@ import {
   CastEvent,
   DamageEvent,
   EventType,
+  GetRelatedEvent,
   GetRelatedEvents,
   HasAbility,
   HasRelatedEvent,
@@ -64,8 +65,7 @@ export function isFromHardcast(event: AnyEvent): boolean {
 export function getHardcast(
   event: ApplyDebuffEvent | RefreshDebuffEvent | DamageEvent,
 ): CastEvent | undefined {
-  const events: AnyEvent[] = GetRelatedEvents(event, FROM_HARDCAST);
-  return events.length === 0 ? undefined : (events[0] as CastEvent);
+  return GetRelatedEvent(event, FROM_HARDCAST);
 }
 
 export function getHitCount(aoeCastEvent: CastEvent): number {
@@ -73,7 +73,5 @@ export function getHitCount(aoeCastEvent: CastEvent): number {
 }
 
 export function getHits(castEvent: CastEvent): AbilityEvent<any>[] {
-  return GetRelatedEvents(castEvent, HIT_TARGET).filter((e): e is AbilityEvent<any> =>
-    HasAbility(e),
-  );
+  return GetRelatedEvents(castEvent, HIT_TARGET, HasAbility);
 }

--- a/src/analysis/retail/rogue/shared/talents/ThistleTeaCastLinkNormalizer.tsx
+++ b/src/analysis/retail/rogue/shared/talents/ThistleTeaCastLinkNormalizer.tsx
@@ -3,7 +3,7 @@ import {
   AnyEvent,
   CastEvent,
   EventType,
-  GetRelatedEvents,
+  GetRelatedEvent,
   HasRelatedEvent,
   ResourceChangeEvent,
 } from 'parser/core/Events';
@@ -40,13 +40,13 @@ export function isFromHardcast(event: AnyEvent): boolean {
 }
 
 export function getHardcast(event: ResourceChangeEvent): CastEvent | undefined {
-  const events: AnyEvent[] = GetRelatedEvents(event, FROM_HARDCAST);
-  return events.length === 0 ? undefined : (events[0] as CastEvent);
+  return GetRelatedEvent(event, FROM_HARDCAST);
 }
 
 export function getResourceChange(event: CastEvent): ResourceChangeEvent | undefined {
-  const events = GetRelatedEvents(event, RESOURCE_CHANGE).filter(
+  return GetRelatedEvent(
+    event,
+    RESOURCE_CHANGE,
     (it): it is ResourceChangeEvent => it.type === EventType.ResourceChange,
   );
-  return events.length === 0 ? undefined : events[0];
 }

--- a/src/analysis/retail/shaman/restoration/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/shaman/restoration/normalizers/CastLinkNormalizer.ts
@@ -1,10 +1,10 @@
 import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
 import {
   AbilityEvent,
-  AnyEvent,
   ApplyBuffEvent,
   CastEvent,
   EventType,
+  GetRelatedEvent,
   GetRelatedEvents,
   HasAbility,
   HasRelatedEvent,
@@ -309,27 +309,27 @@ export function getRiptideCastEvent(
   event: ApplyBuffEvent | RefreshBuffEvent | HealEvent,
 ): CastEvent | null {
   if (isFromHardcast(event)) {
-    return GetRelatedEvents(event, HARDCAST)[0] as CastEvent;
+    return GetRelatedEvent<CastEvent>(event, HARDCAST) ?? null;
   } else if (isRiptideFromPrimordialWave(event)) {
-    return GetRelatedEvents(event, RIPTIDE_PWAVE)[0] as CastEvent;
+    return GetRelatedEvent<CastEvent>(event, RIPTIDE_PWAVE) ?? null;
   }
   return null;
 }
 
 export function getHealingRainEvents(event: CastEvent) {
-  return GetRelatedEvents(event, HEALING_RAIN) as HealEvent[];
+  return GetRelatedEvents<HealEvent>(event, HEALING_RAIN);
 }
 
 export function getHealingRainHealEventsForTick(event: HealEvent) {
-  return [event].concat(GetRelatedEvents(event, HEALING_RAIN_GROUPING) as HealEvent[]);
+  return [event].concat(GetRelatedEvents(event, HEALING_RAIN_GROUPING));
 }
 
 export function getOverflowingShoresEvents(event: CastEvent) {
-  return GetRelatedEvents(event, OVERFLOWING_SHORES) as HealEvent[];
+  return GetRelatedEvents<HealEvent>(event, OVERFLOWING_SHORES);
 }
 
 export function getDownPourEvents(event: CastEvent) {
-  return GetRelatedEvents(event, DOWNPOUR) as HealEvent[];
+  return GetRelatedEvents<HealEvent>(event, DOWNPOUR);
 }
 
 export function wasRiptideConsumed(event: CastEvent | RemoveBuffEvent): boolean {
@@ -337,8 +337,7 @@ export function wasRiptideConsumed(event: CastEvent | RemoveBuffEvent): boolean 
 }
 
 export function getConsumedRiptide(event: CastEvent): AbilityEvent<any> | undefined {
-  const removedHots: AnyEvent[] = GetRelatedEvents(event, FLOW_OF_THE_TIDES);
-  return removedHots.length !== 0 && HasAbility(removedHots[0]) ? removedHots[0] : undefined;
+  return GetRelatedEvent<AbilityEvent<any>>(event, FLOW_OF_THE_TIDES, HasAbility);
 }
 
 export function getChainHeals(event: CastEvent): HealEvent[] {
@@ -346,7 +345,7 @@ export function getChainHeals(event: CastEvent): HealEvent[] {
 }
 
 export function getChainHealGrouping(event: HealEvent) {
-  return [event].concat(GetRelatedEvents(event, CHAIN_HEAL_GROUPING) as HealEvent[]);
+  return [event].concat(GetRelatedEvents(event, CHAIN_HEAL_GROUPING));
 }
 
 export function isBuffedByHighTide(event: CastEvent) {

--- a/src/analysis/retail/shaman/restoration/normalizers/Tier30Normalizer.ts
+++ b/src/analysis/retail/shaman/restoration/normalizers/Tier30Normalizer.ts
@@ -85,9 +85,9 @@ export function getSwellingRainHealingWaves(event: CastEvent): HealEvent[] {
   if (!HasRelatedEvent(event, SWELLING_RAIN_REMOVE)) {
     return [];
   }
-  return GetRelatedEvents(event, SWELLING_RAIN_HEALING_WAVE) as HealEvent[];
+  return GetRelatedEvents(event, SWELLING_RAIN_HEALING_WAVE);
 }
 
 export function getTidewatersHealingEvents(event: CastEvent): HealEvent[] {
-  return GetRelatedEvents(event, TIDEWATERS_HEAL) as HealEvent[];
+  return GetRelatedEvents(event, TIDEWATERS_HEAL);
 }

--- a/src/analysis/retail/shaman/restoration/normalizers/UnleashLifeNormalizer.ts
+++ b/src/analysis/retail/shaman/restoration/normalizers/UnleashLifeNormalizer.ts
@@ -3,6 +3,7 @@ import {
   ApplyBuffEvent,
   CastEvent,
   EventType,
+  GetRelatedEvent,
   GetRelatedEvents,
   HasRelatedEvent,
   HealEvent,
@@ -111,7 +112,7 @@ class UnleashLifeNormalizer extends EventLinkNormalizer {
 }
 
 export function getCastEvent(event: HealEvent): CastEvent {
-  return GetRelatedEvents(event, HARDCAST)[0] as CastEvent;
+  return GetRelatedEvent(event, HARDCAST)!;
 }
 
 export function isBuffedByUnleashLife(
@@ -128,7 +129,7 @@ export function getUnleashLifeHealingWaves(event: CastEvent): HealEvent[] {
   if (!HasRelatedEvent(event, UNLEASH_LIFE_REMOVE)) {
     return [];
   }
-  return GetRelatedEvents(event, UNLEASH_LIFE_HEALING_WAVE) as HealEvent[];
+  return GetRelatedEvents(event, UNLEASH_LIFE_HEALING_WAVE);
 }
 
 export default UnleashLifeNormalizer;

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -297,8 +297,46 @@ export function HasLocation<T extends EventType>(event: Event<T>): event is Loca
 
 /** Gets the events related to the given event with the given relation (key). Events will not
  *  by default have any relations, you must add them with an {@link EventLinkNormalizer}. */
-export function GetRelatedEvents(event: AnyEvent, relation: string): AnyEvent[] {
-  return event?._linkedEvents?.filter((le) => le.relation === relation).map((le) => le.event) ?? [];
+export function GetRelatedEvents<T extends AnyEvent>(event: AnyEvent, relation: string): T[];
+export function GetRelatedEvents<T extends AnyEvent>(
+  event: AnyEvent,
+  relation: string,
+  filter: ((e: AnyEvent) => boolean) | undefined,
+): T[];
+export function GetRelatedEvents<T extends AnyEvent>(
+  event: AnyEvent,
+  relation: string,
+  filter?: (e: AnyEvent) => boolean,
+): T[] {
+  const relatedEvents =
+    event?._linkedEvents?.filter((le) => le.relation === relation).map((le) => le.event as T) ?? [];
+  if (filter) {
+    return relatedEvents.filter(filter);
+  } else {
+    return relatedEvents;
+  }
+}
+
+/** Gets the first event related to the given event with the given relation (key). Events will not
+ * by default have any relations, you must hadd them with an {@link EventLinkNormalizer}. */
+export function GetRelatedEvent<T extends AnyEvent>(
+  event: AnyEvent,
+  relation: string,
+): T | undefined;
+export function GetRelatedEvent<T extends AnyEvent>(
+  event: AnyEvent,
+  relation: string,
+  filter: ((e: AnyEvent) => boolean) | undefined,
+): T | undefined;
+export function GetRelatedEvent<T extends AnyEvent>(
+  event: AnyEvent,
+  relation: string,
+  filter?: (e: AnyEvent) => boolean,
+): T | undefined {
+  const relatedEvents = GetRelatedEvents<T>(event, relation, filter);
+  if (relatedEvents.length >= 1) {
+    return relatedEvents.at(0);
+  }
 }
 
 /** Returns true iff the given event has a relation with the given relation (key). Events will not


### PR DESCRIPTION
### Description

I have updated the `GetRelatedEvents` helper with a number of changes.

1. The function now has includes a generic type parameter of type `AnyEvent`, and the results are cast back to the generic type parameter. This removes nearly all the typecasting currently used.
2. There is an additional overload where a filter callback function can be provided, which consolidates the `filter` appended to most calls to `GetRelatedEvents` into a single function call.
3. A new `GetRelatedEvent` function (with the same signature as `GetRelatedEvents`) to assist in retrieving a single linked event (typically either the first or only event).