### PR TITLE
Disc Revamp - update the Schism talent for the 10.2 changes

### DIFF
--- a/src/analysis/retail/priest/discipline/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/discipline/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 10, 7), <>Added <SpellLink spell={TALENTS_PRIEST.SCHISM_TALENT}/></>, Hana),
   change(date(2023, 9, 15), <>Added new atonement damage sources which will appear in the new patch. Can be merged now as it doesn't break any old functionality.</>, Hana),
   change(date(2023, 8, 18), <>Cleared some console logs, updated some spells for cast efficiency, updated some mana costs</>, Hana),
   change(date(2023, 8, 12), <>'Add <SpellLink spell={TALENTS_PRIEST.WORDS_OF_THE_PIOUS_TALENT}/>'</>, Hana),

--- a/src/analysis/retail/priest/discipline/modules/spells/Schism.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/Schism.tsx
@@ -35,9 +35,8 @@ class Schism extends Analyzer {
     atonementDamageSource: AtonementDamageSource,
   };
 
-  static bonus = 0.15;
+  static bonus = 0.1;
 
-  private directDamage = 0;
   private damageFromBuff = 0;
   private healing = 0;
 
@@ -67,13 +66,6 @@ class Schism extends Analyzer {
     ) {
       return;
     }
-
-    // Schism isn't buffed by itself, so requires a different path
-    if (damageEvent.ability.guid === TALENTS_PRIEST.SCHISM_TALENT.id) {
-      this.healing += event.amount;
-      return;
-    }
-
     this.healing += calculateEffectiveHealing(event, Schism.bonus);
   }
 
@@ -82,15 +74,9 @@ class Schism extends Analyzer {
    * @param event The damage event being considered
    */
   private onDamage(event: DamageEvent) {
-    const spellId = event.ability.guid;
     const target = this.enemies.getEntity(event);
 
     if (!SCHISM_DAMAGE_IDS.includes(event.ability.guid)) {
-      return;
-    }
-
-    if (spellId === TALENTS_PRIEST.SCHISM_TALENT.id) {
-      this.directDamage += event.amount + (event.absorbed || 0);
       return;
     }
     if (target?.hasBuff(TALENTS_PRIEST.SCHISM_TALENT.id)) {
@@ -112,10 +98,6 @@ class Schism extends Analyzer {
             {formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing))}% of total
             healing done.
             <br />
-            The direct damage contributed by the Schism talent was{' '}
-            {formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.directDamage))}% of
-            total damage done.
-            <br />
             The effective damage contributed by the Schism bonus was{' '}
             {formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.damageFromBuff))}% of
             total damage done. <br />
@@ -124,7 +106,7 @@ class Schism extends Analyzer {
       >
         <BoringSpellValueText spell={TALENTS_PRIEST.SCHISM_TALENT}>
           <ItemHealingDone amount={this.healing} /> <br />
-          <ItemDamageDone amount={this.directDamage + this.damageFromBuff} />
+          <ItemDamageDone amount={this.damageFromBuff} />
         </BoringSpellValueText>
       </Statistic>
     );


### PR DESCRIPTION
### Description

A quick one, lowering the amp and removing the direct damage portion
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/80196301/cc81d966-74fa-405a-b203-f51bd6a6a6ce)