### PR TITLE
Druid Feral - Added guide logic for T31 set

### DIFF
--- a/src/analysis/retail/druid/feral/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/feral/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS/druid';
 
 export default [
+  change(date(2023, 10, 12), <>Added Guide items for the Amirdrassil tier set</>, Sref),
   change(date(2023, 10, 7), <>Updated flow of the guide's rotation section, and added a subsection for <SpellLink spell={TALENTS_DRUID.SUDDEN_AMBUSH_TALENT}/></>, Sref),
   change(date(2023, 7, 31), <>Added a guide entry and a statistic for <SpellLink spell={TALENTS_DRUID.DIRE_FIXATION_TALENT}/>. Bumped support to 10.1.5</>, Sref),
   change(date(2023, 6, 21), <>Fixed an issue where parried <SpellLink spell={SPELLS.FEROCIOUS_BITE}/> casts were counted as 0 CP casts.</>, Sref),

--- a/src/analysis/retail/druid/feral/modules/Abilities.ts
+++ b/src/analysis/retail/druid/feral/modules/Abilities.ts
@@ -3,6 +3,7 @@ import SPELLS from 'common/SPELLS';
 import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
 import { TALENTS_DRUID } from 'common/TALENTS';
 import { SpellbookAbility } from 'parser/core/modules/Ability';
+import { TIERS } from 'game/TIERS';
 
 class Abilities extends CoreAbilities {
   spellbook(): SpellbookAbility[] {
@@ -192,7 +193,7 @@ class Abilities extends CoreAbilities {
         spell: TALENTS_DRUID.FERAL_FRENZY_TALENT.id,
         category: SPELL_CATEGORY.COOLDOWNS,
         enabled: combatant.hasTalent(TALENTS_DRUID.FERAL_FRENZY_TALENT),
-        cooldown: 45,
+        cooldown: combatant.has4PieceByTier(TIERS.T31) ? 30 : 45,
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.9,

--- a/src/analysis/retail/druid/feral/modules/spells/FeralFrenzy.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/FeralFrenzy.tsx
@@ -11,6 +11,10 @@ import CooldownExpandable, {
   CooldownExpandableItem,
 } from 'interface/guide/components/CooldownExpandable';
 import { PassFailCheckmark, PerformanceMark } from 'interface/guide';
+import { TIERS } from 'game/TIERS';
+import { DRUID_T31_ID } from 'common/ITEMS/dragonflight';
+import ItemSetLink from 'interface/ItemSetLink';
+import EnergyTracker from 'analysis/retail/druid/feral/modules/core/energy/EnergyTracker';
 
 /**
  * **Feral Frenzy**
@@ -22,13 +26,16 @@ import { PassFailCheckmark, PerformanceMark } from 'interface/guide';
 export default class FeralFrenzy extends Analyzer {
   static dependencies = {
     comboPointTracker: ComboPointTracker,
+    energyTracker: EnergyTracker,
     enemies: Enemies,
   };
 
   protected comboPointTracker!: ComboPointTracker;
+  protected energyTracker!: EnergyTracker;
   protected enemies!: Enemies;
 
   hasSwarm: boolean;
+  hasT31: boolean;
 
   /** Tracker for each Feral Frenzy cast */
   ffTrackers: FeralFrenzyCast[] = [];
@@ -38,6 +45,7 @@ export default class FeralFrenzy extends Analyzer {
 
     this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.FERAL_FRENZY_TALENT);
     this.hasSwarm = this.selectedCombatant.hasTalent(TALENTS_DRUID.ADAPTIVE_SWARM_TALENT);
+    this.hasT31 = this.selectedCombatant.has2PieceByTier(TIERS.T31);
 
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(TALENTS_DRUID.FERAL_FRENZY_TALENT),
@@ -48,6 +56,7 @@ export default class FeralFrenzy extends Analyzer {
   onCastFf(event: CastEvent) {
     const tfOnCast = this.selectedCombatant.hasBuff(SPELLS.TIGERS_FURY.id);
     const cpsOnCast = this.comboPointTracker.current;
+    const energyOnCast = this.energyTracker.current;
     let swarmOnTarget = false;
     if (this.hasSwarm) {
       const target = this.enemies.getEntity(event);
@@ -60,6 +69,7 @@ export default class FeralFrenzy extends Analyzer {
       timestamp: event.timestamp,
       tfOnCast,
       cpsOnCast,
+      energyOnCast,
       swarmOnTarget,
     });
   }
@@ -67,23 +77,31 @@ export default class FeralFrenzy extends Analyzer {
   /** Guide fragment showing a breakdown of each Feral Frenzy cast */
   get guideCastBreakdown() {
     const explanation = (
-      <p>
-        <strong>
-          <SpellLink spell={TALENTS_DRUID.FERAL_FRENZY_TALENT} />
-        </strong>{' '}
-        is a brief but extremely powerful bleed. It's best used soon after becoming available, but
-        can be held a few seconds to line up with damage boosts. Always use with{' '}
-        <SpellLink spell={SPELLS.TIGERS_FURY} /> active
-        {this.hasSwarm && (
-          <>
-            {' '}
-            and with <SpellLink spell={SPELLS.ADAPTIVE_SWARM_DAMAGE} /> on the target (most of Feral
-            Frenzy's damage is the bleed)
-          </>
+      <>
+        <p>
+          <strong>
+            <SpellLink spell={TALENTS_DRUID.FERAL_FRENZY_TALENT} />
+          </strong>{' '}
+          is a brief but extremely powerful bleed. It's best used soon after becoming available, but
+          can be held a few seconds to line up with damage boosts. Always use with{' '}
+          <SpellLink spell={SPELLS.TIGERS_FURY} /> active
+          {this.hasSwarm && (
+            <>
+              {' '}
+              and if possible with <SpellLink spell={SPELLS.ADAPTIVE_SWARM_DAMAGE} /> on the target
+            </>
+          )}
+          . As it also gives 5 combo points, it's best used at low combo points in order not to
+          waste them.
+        </p>
+        {this.hasT31 && (
+          <p>
+            Because you have the <ItemSetLink id={DRUID_T31_ID}>Amirdrassil Tier Set</ItemSetLink>,
+            it's also important to pool energy before using Feral Frezy in order to maximize your
+            abilities used during <SpellLink spell={SPELLS.SMOLDERING_FRENZY} />.
+          </p>
         )}
-        . As it also gives 5 combo points, it's best used at low combo points in order not to waste
-        them.
-      </p>
+      </>
     );
 
     const data = (
@@ -105,10 +123,24 @@ export default class FeralFrenzy extends Analyzer {
             cpsPerf = QualitativePerformance.Ok;
           }
 
-          const overallPerf =
-            cast.cpsOnCast <= 2 && cast.tfOnCast && (!this.hasSwarm || cast.swarmOnTarget)
-              ? QualitativePerformance.Good
-              : QualitativePerformance.Fail;
+          const percentMaxEnergyOnCast = cast.energyOnCast / this.energyTracker.maxResource;
+          let energyPerf = QualitativePerformance.Good;
+          if (percentMaxEnergyOnCast < 0.4) {
+            energyPerf = QualitativePerformance.Fail;
+          } else if (percentMaxEnergyOnCast < 0.7) {
+            energyPerf = QualitativePerformance.Ok;
+          }
+
+          let overallPerf = QualitativePerformance.Good;
+          if (
+            (this.hasSwarm && !cast.swarmOnTarget) ||
+            (this.hasT31 && percentMaxEnergyOnCast < 0.4)
+          ) {
+            overallPerf = QualitativePerformance.Ok;
+          }
+          if (cast.cpsOnCast > 2 || !cast.tfOnCast) {
+            overallPerf = QualitativePerformance.Fail;
+          }
 
           const checklistItems: CooldownExpandableItem[] = [];
           checklistItems.push({
@@ -124,6 +156,16 @@ export default class FeralFrenzy extends Analyzer {
             result: <PerformanceMark perf={cpsPerf} />,
             details: <>({cast.cpsOnCast} CPs)</>,
           });
+          this.hasT31 &&
+            checklistItems.push({
+              label: 'Energy on cast',
+              result: <PerformanceMark perf={energyPerf} />,
+              details: (
+                <>
+                  ({cast.energyOnCast} / {this.energyTracker.maxResource} energy)
+                </>
+              ),
+            });
           this.hasSwarm &&
             checklistItems.push({
               label: (
@@ -154,5 +196,6 @@ interface FeralFrenzyCast {
   timestamp: number;
   tfOnCast: boolean;
   cpsOnCast: number;
+  energyOnCast: number;
   swarmOnTarget: boolean;
 }

--- a/src/common/SPELLS/druid.ts
+++ b/src/common/SPELLS/druid.ts
@@ -1189,6 +1189,12 @@ const spells = {
     name: 'Sharpened Claws',
     icon: 'inv_misc_monsterfang_01',
   },
+  // Buff procced by T31 2pc
+  SMOLDERING_FRENZY: {
+    id: 422751,
+    name: 'Smoldering Frenzy',
+    icon: 'inv_staff_99',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;


### PR DESCRIPTION
### Description

Handling for Feral Druid's T31 set. It's difficult to make a damage statistic for it due to the 4pc CD change, but the set does cause some rotation alterations so I updated Guide logic to handle that.

It was also brought to my attention that you shouldn't delay Feral Frenzy much even if you're missing Adaptive Swarm, so I updated the text for that and also changed the overall evaluation of FF to "ok" instead of "fail" when missing Swarm

### Testing

- Test report URL: `/report/drDPqpk28TgFZbvV/16/443`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/7143486/741e8128-6dfb-497d-a78e-76701625b69f)

