### PR TITLE
[mw] extend cd window for celestials

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -1,11 +1,12 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
-import { emallson, Trevor, ToppleTheNun, Vetyst, Vohrr } from 'CONTRIBUTORS';
+import { emallson, Trevor, ToppleTheNun, Vetyst, Vohrr, Tialyss } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 10, 15), <>Extend <SpellLink spell={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT}/> tracking duration in the Cooldowns tab to include the full duration of any <SpellLink spell={TALENTS_MONK.ENVELOPING_MIST_TALENT} /> and <SpellLink spell={TALENTS_MONK.RENEWING_MIST_TALENT} /> cast during the ramp.</>, Tialyss),
   change(date(2023, 9, 28), <>Change <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> statistic formatting</>, Trevor),
   change(date(2023, 9, 20), <>Fixed another <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> crash/ </>, Vohrr),
   change(date(2023, 9, 10), <>Fixed <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> crash from encounter phasing.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/constants.ts
+++ b/src/analysis/retail/monk/mistweaver/constants.ts
@@ -63,7 +63,7 @@ export const ATTRIBUTION_STRINGS = {
     RD_SOURCE_RSK: 'Rapid Diffusion Source - Rising Sun Kick',
     RD_SOURCE_ENV: 'Rapid Diffusion Source - Enveloping Mist',
   },
-  YULON: "Hardcast During Yu'Lon",
+  YULON: "Hardcast During Yu'lon",
 };
 
 export const SECRET_INFUSION_BUFFS = [

--- a/src/analysis/retail/monk/mistweaver/constants.ts
+++ b/src/analysis/retail/monk/mistweaver/constants.ts
@@ -63,7 +63,7 @@ export const ATTRIBUTION_STRINGS = {
     RD_SOURCE_RSK: 'Rapid Diffusion Source - Rising Sun Kick',
     RD_SOURCE_ENV: 'Rapid Diffusion Source - Enveloping Mist',
   },
-  CELESTIAL: 'Hardcast During Celestial',
+  YULON: "Hardcast During Yu'Lon",
 };
 
 export const SECRET_INFUSION_BUFFS = [

--- a/src/analysis/retail/monk/mistweaver/constants.ts
+++ b/src/analysis/retail/monk/mistweaver/constants.ts
@@ -63,6 +63,7 @@ export const ATTRIBUTION_STRINGS = {
     RD_SOURCE_RSK: 'Rapid Diffusion Source - Rising Sun Kick',
     RD_SOURCE_ENV: 'Rapid Diffusion Source - Enveloping Mist',
   },
+  CELESTIAL: 'Hardcast During Celestial',
 };
 
 export const SECRET_INFUSION_BUFFS = [

--- a/src/analysis/retail/monk/mistweaver/modules/core/HotAttributor.ts
+++ b/src/analysis/retail/monk/mistweaver/modules/core/HotAttributor.ts
@@ -64,7 +64,7 @@ class HotAttributor extends Analyzer {
     ATTRIBUTION_STRINGS.RAPID_DIFFUSION_SOURCES.RD_SOURCE_ENV,
   );
   EFAttrib = HotTracker.getNewAttribution(ATTRIBUTION_STRINGS.HARDCAST_ESSENCE_FONT);
-  CelestialAttrib = HotTracker.getNewAttribution(ATTRIBUTION_STRINGS.CELESTIAL);
+  YulonAttrib = HotTracker.getNewAttribution(ATTRIBUTION_STRINGS.YULON);
 
   constructor(options: Options) {
     super(options);
@@ -152,8 +152,8 @@ class HotAttributor extends Analyzer {
       this.hotTracker.addAttributionFromApply(this.MistsOfLifeAttrib, event);
     } else if (event.prepull || isFromHardcast(event)) {
       this.hotTracker.addAttributionFromApply(this.envMistHardcastAttrib, event);
-      if (this._celestialActive()) {
-        this.hotTracker.addAttributionFromApply(this.CelestialAttrib, event);
+      if (this.selectedCombatant.hasBuff(TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id)) {
+        this.hotTracker.addAttributionFromApply(this.YulonAttrib, event);
       }
       debug &&
         console.log(
@@ -287,8 +287,8 @@ class HotAttributor extends Analyzer {
           this.hotTracker.addAttributionFromApply(this.dmSourceMoLAttrib, event);
         }
 
-        if (this.hotTracker.fromCelestial(sourceHot)) {
-          this.hotTracker.addAttributionFromApply(this.CelestialAttrib, event);
+        if (this.hotTracker.fromYuLon(sourceHot)) {
+          this.hotTracker.addAttributionFromApply(this.YulonAttrib, event);
         }
 
         dmHot.healingAfterOriginalEnd = 0;
@@ -308,21 +308,14 @@ class HotAttributor extends Analyzer {
       this.hotTracker.addAttributionFromApply(this.rdSourceRSKAttrib, event);
     } else if (isFromRapidDiffusionEnvelopingMist(event)) {
       this.hotTracker.addAttributionFromApply(this.rdSourceENVAttrib, event);
-      if (this._celestialActive()) {
-        this.hotTracker.addAttributionFromApply(this.CelestialAttrib, event);
+      if (this.selectedCombatant.hasBuff(TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id)) {
+        this.hotTracker.addAttributionFromApply(this.YulonAttrib, event);
       }
     }
     hot.maxDuration = this.hotTracker._getRapidDiffusionMaxDuration(this.selectedCombatant);
     hot.end = hot.originalEnd =
       event.timestamp + Number(this.hotTracker._getRapidDiffusionDuration(this.selectedCombatant));
     rdDebug && this._newReMAttributionLogging(event, this.rapidDiffusionAttrib);
-  }
-
-  private _celestialActive() {
-    return (
-      this.selectedCombatant.hasBuff(TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id) ||
-      this.selectedCombatant.hasBuff(TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT.id)
-    );
   }
 }
 

--- a/src/analysis/retail/monk/mistweaver/modules/core/HotAttributor.ts
+++ b/src/analysis/retail/monk/mistweaver/modules/core/HotAttributor.ts
@@ -64,6 +64,7 @@ class HotAttributor extends Analyzer {
     ATTRIBUTION_STRINGS.RAPID_DIFFUSION_SOURCES.RD_SOURCE_ENV,
   );
   EFAttrib = HotTracker.getNewAttribution(ATTRIBUTION_STRINGS.HARDCAST_ESSENCE_FONT);
+  CelestialAttrib = HotTracker.getNewAttribution(ATTRIBUTION_STRINGS.CELESTIAL);
 
   constructor(options: Options) {
     super(options);
@@ -151,6 +152,9 @@ class HotAttributor extends Analyzer {
       this.hotTracker.addAttributionFromApply(this.MistsOfLifeAttrib, event);
     } else if (event.prepull || isFromHardcast(event)) {
       this.hotTracker.addAttributionFromApply(this.envMistHardcastAttrib, event);
+      if (this._celestialActive()) {
+        this.hotTracker.addAttributionFromApply(this.CelestialAttrib, event);
+      }
       debug &&
         console.log(
           'Attributed Enveloping Mist hardcast at ' +
@@ -282,6 +286,11 @@ class HotAttributor extends Analyzer {
         } else if (this.hotTracker.fromMistsOfLife(sourceHot)) {
           this.hotTracker.addAttributionFromApply(this.dmSourceMoLAttrib, event);
         }
+
+        if (this.hotTracker.fromCelestial(sourceHot)) {
+          this.hotTracker.addAttributionFromApply(this.CelestialAttrib, event);
+        }
+
         dmHot.healingAfterOriginalEnd = 0;
         dmHot.maxDuration = sourceHot.maxDuration;
         dmHot.end = sourceHot.end;
@@ -299,11 +308,21 @@ class HotAttributor extends Analyzer {
       this.hotTracker.addAttributionFromApply(this.rdSourceRSKAttrib, event);
     } else if (isFromRapidDiffusionEnvelopingMist(event)) {
       this.hotTracker.addAttributionFromApply(this.rdSourceENVAttrib, event);
+      if (this._celestialActive()) {
+        this.hotTracker.addAttributionFromApply(this.CelestialAttrib, event);
+      }
     }
     hot.maxDuration = this.hotTracker._getRapidDiffusionMaxDuration(this.selectedCombatant);
     hot.end = hot.originalEnd =
       event.timestamp + Number(this.hotTracker._getRapidDiffusionDuration(this.selectedCombatant));
     rdDebug && this._newReMAttributionLogging(event, this.rapidDiffusionAttrib);
+  }
+
+  private _celestialActive() {
+    return (
+      this.selectedCombatant.hasBuff(TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id) ||
+      this.selectedCombatant.hasBuff(TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT.id)
+    );
   }
 }
 

--- a/src/analysis/retail/monk/mistweaver/modules/core/HotTrackerMW.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/HotTrackerMW.tsx
@@ -104,6 +104,12 @@ class HotTrackerMW extends HotTracker {
     });
   }
 
+  fromCelestial(hot: Tracker): boolean {
+    return hot.attributions.some(function (attr) {
+      return attr.name === ATTRIBUTION_STRINGS.CELESTIAL;
+    });
+  }
+
   // Decide which extension is responsible for allowing this extra vivify cleave
   getRemExtensionForTimestamp(hot: Tracker, timestamp: number): Extension | null {
     if (timestamp <= hot.originalEnd) {

--- a/src/analysis/retail/monk/mistweaver/modules/core/HotTrackerMW.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/HotTrackerMW.tsx
@@ -104,9 +104,9 @@ class HotTrackerMW extends HotTracker {
     });
   }
 
-  fromCelestial(hot: Tracker): boolean {
+  fromYuLon(hot: Tracker): boolean {
     return hot.attributions.some(function (attr) {
-      return attr.name === ATTRIBUTION_STRINGS.CELESTIAL;
+      return attr.name === ATTRIBUTION_STRINGS.YULON;
     });
   }
 

--- a/src/analysis/retail/monk/mistweaver/modules/features/CooldownThroughputTracker.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/CooldownThroughputTracker.tsx
@@ -1,11 +1,37 @@
 import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
 import { RETAIL_EXPANSION } from 'game/Expansion';
+import {
+  ApplyBuffEvent,
+  ApplyDebuffEvent,
+  CastEvent,
+  EventType,
+  HealEvent,
+  RemoveBuffEvent,
+  RemoveDebuffEvent,
+} from 'parser/core/Events';
 import CoreCooldownThroughputTracker, {
   BUILT_IN_SUMMARY_TYPES,
+  TrackedCooldown,
+  TrackedEvent,
 } from 'parser/shared/modules/CooldownThroughputTracker';
+import HotTrackerMW from '../core/HotTrackerMW';
+
+const CELESTIAL_SPELL_IDS = [
+  TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT.id,
+  TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id,
+];
+
+type HotAttributedTrackedEvent = TrackedCooldown & { lastAttributedIndex: number };
 
 class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
+  static dependencies = {
+    ...CoreCooldownThroughputTracker.dependencies,
+    hotTracker: HotTrackerMW,
+  };
+
+  protected hotTracker!: HotTrackerMW;
+
   static cooldownSpells = [
     ...CoreCooldownThroughputTracker.cooldownSpells,
     {
@@ -46,6 +72,85 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     SPELLS.REFRESHING_JADE_WIND_HEAL.id,
     TALENTS_MONK.TRANSCENDENCE_TALENT.id,
   ];
+
+  private _hasCelestialAttribution(event: HealEvent) {
+    const tracker = this.hotTracker.hots[event.targetID]?.[event.ability.guid];
+    return tracker && this.hotTracker.fromCelestial(tracker);
+  }
+
+  private _prune(cooldown: HotAttributedTrackedEvent) {
+    cooldown.events.splice(
+      cooldown.lastAttributedIndex + 1,
+      cooldown.events.length - cooldown.lastAttributedIndex,
+    );
+    cooldown.end = cooldown.events[cooldown.events.length - 1].timestamp;
+  }
+
+  startCooldown(event: CastEvent | ApplyBuffEvent | ApplyDebuffEvent, isCastCooldown?: boolean) {
+    if (CELESTIAL_SPELL_IDS.includes(event.ability.guid)) {
+      const index = this.activeCooldowns.findIndex((cooldown) => cooldown.spell === 0);
+      if (index >= 0) {
+        const cd = this.activeCooldowns.splice(index, 1)[0];
+        this._prune(cd as HotAttributedTrackedEvent);
+      }
+    }
+
+    super.startCooldown(event, isCastCooldown);
+  }
+
+  endCooldown(event: RemoveDebuffEvent | RemoveBuffEvent) {
+    const spellId = event.ability.guid;
+    const cd = this.activeCooldowns.find((cooldown) => cooldown.spell === spellId);
+
+    super.endCooldown(event);
+
+    // If we just ended a Yu'Lon or Chi-Ji cooldown, then add a fake cooldown to track
+    // that will accumulate all events until the next Yu'Lon or Chi-Ji is cast. Once
+    // the next celestial is cast, we'll prune out any events that happened after all
+    // the hots applied during the celestial have expired.
+    if (!(cd && CELESTIAL_SPELL_IDS.includes(spellId))) {
+      return;
+    }
+
+    const newCd: HotAttributedTrackedEvent = {
+      spell: 0,
+      summary: cd.summary,
+      start: event.timestamp,
+      cdStart: event.timestamp,
+      end: null,
+      events: [],
+      lastAttributedIndex: 0,
+    };
+
+    const index = this.pastCooldowns.indexOf(cd);
+    this.pastCooldowns.splice(index + 1, 0, newCd);
+    this.activeCooldowns.push(newCd);
+  }
+
+  onFightend() {
+    const cd = this.activeCooldowns.find((cooldown) => cooldown.spell === 0);
+    if (cd) {
+      this._prune(cd as HotAttributedTrackedEvent);
+    }
+
+    super.onFightend();
+  }
+
+  trackEvent(event: TrackedEvent) {
+    super.trackEvent(event);
+
+    // HotTracker is stateful so we have to track whether the hot was applied during YU'Lon or Chi-Ji
+    // during event handling rather than during _prune().
+    this.activeCooldowns.forEach((cooldown) => {
+      if (
+        cooldown.spell === 0 &&
+        event.type === EventType.Heal &&
+        this._hasCelestialAttribution(event)
+      ) {
+        (cooldown as HotAttributedTrackedEvent).lastAttributedIndex = cooldown.events.length - 1;
+      }
+    });
+  }
 }
 
 export default CooldownThroughputTracker;

--- a/src/interface/Tooltip.tsx
+++ b/src/interface/Tooltip.tsx
@@ -65,3 +65,17 @@ export const TooltipElement = ({
     </ReactTooltip>
   );
 };
+
+type MaybeTooltipProps = Partial<Pick<TooltipElementProps, 'content'>> &
+  Omit<TooltipElementProps, 'content'>;
+
+export const MaybeTooltip = ({ content, children, ...rest }: MaybeTooltipProps) => {
+  if (content) {
+    return (
+      <TooltipElement content={content} {...rest}>
+        {children}
+      </TooltipElement>
+    );
+  }
+  return children;
+};

--- a/src/parser/shared/modules/CooldownThroughputTracker.tsx
+++ b/src/parser/shared/modules/CooldownThroughputTracker.tsx
@@ -51,6 +51,7 @@ export type CooldownSpell = {
   petID?: number;
   duration?: number;
   expansion?: number;
+  durationTooltip?: string;
 };
 
 export type BuffCooldownSpell = CooldownSpell & {

--- a/src/parser/shared/modules/CooldownThroughputTracker.tsx
+++ b/src/parser/shared/modules/CooldownThroughputTracker.tsx
@@ -34,7 +34,7 @@ export enum BUILT_IN_SUMMARY_TYPES {
   DAMAGE = 'DAMAGE',
 }
 
-type TrackedEvent = CastEvent | HealEvent | AbsorbedEvent | DamageEvent | ApplyBuffEvent;
+export type TrackedEvent = CastEvent | HealEvent | AbsorbedEvent | DamageEvent | ApplyBuffEvent;
 
 export type SummaryDef = {
   label: string;

--- a/src/parser/shared/modules/CooldownThroughputTracker.tsx
+++ b/src/parser/shared/modules/CooldownThroughputTracker.tsx
@@ -22,6 +22,7 @@ import Events, {
 } from 'parser/core/Events';
 import EventHistory from 'parser/shared/modules/EventHistory';
 import CooldownOverview from 'parser/ui/CooldownOverview';
+import { ReactNode } from 'react';
 
 const debug = false;
 
@@ -51,7 +52,7 @@ export type CooldownSpell = {
   petID?: number;
   duration?: number;
   expansion?: number;
-  durationTooltip?: string;
+  durationTooltip?: ReactNode;
 };
 
 export type BuffCooldownSpell = CooldownSpell & {

--- a/src/parser/ui/Cooldown.js
+++ b/src/parser/ui/Cooldown.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 
 import './Cooldown.css';
+import { MaybeTooltip } from 'interface/Tooltip';
 
 class Cooldown extends Component {
   static propTypes = {
@@ -44,7 +45,7 @@ class Cooldown extends Component {
           timestamp: PropTypes.number.isRequired,
         }),
       ),
-      lastAttributedHeal: PropTypes.number,
+      durationTooltip: PropTypes.string,
     }).isRequired,
     applyTimeFilter: PropTypes.func,
   };
@@ -133,13 +134,6 @@ class Cooldown extends Component {
   render() {
     const { cooldown, fightStart, fightEnd } = this.props;
 
-    if (cooldown.lastAttributedHeal && cooldown.lateEvents) {
-      cooldown.lateEvents.splice(
-        cooldown.lastAttributedHeal,
-        cooldown.lateEvents.length - cooldown.lastAttributedHeal,
-      );
-    }
-
     const fakeSummaryCooldown = { events: cooldown.lateEvents ?? [] };
 
     let healingStatistics = null;
@@ -165,8 +159,11 @@ class Cooldown extends Component {
                 {(cooldown.spell && <SpellLink spell={cooldown.spell} icon={false} />) || (
                   <span>Remaining HoT duration</span>
                 )}{' '}
-                ({formatDuration(cdStart - fightStart)} -&gt; {formatDuration(end - fightStart)})
-                &nbsp;
+                (
+                <MaybeTooltip content={cooldown.durationTooltip}>
+                  {formatDuration(cdStart - fightStart)} -&gt; {formatDuration(end - fightStart)}
+                </MaybeTooltip>
+                ) &nbsp;
                 <TooltipElement
                   content={
                     <Trans id="shared.cooldownThroughputTracker.cooldown.events.tooltip">

--- a/src/parser/ui/Cooldown.js
+++ b/src/parser/ui/Cooldown.js
@@ -38,6 +38,13 @@ class Cooldown extends Component {
         }),
         PropTypes.number,
       ]),
+      lateEvents: PropTypes.arrayOf(
+        PropTypes.shape({
+          type: PropTypes.string.isRequired,
+          timestamp: PropTypes.number.isRequired,
+        }),
+      ),
+      lastAttributedHeal: PropTypes.number,
     }).isRequired,
     applyTimeFilter: PropTypes.func,
   };
@@ -126,7 +133,17 @@ class Cooldown extends Component {
   render() {
     const { cooldown, fightStart, fightEnd } = this.props;
 
+    if (cooldown.lastAttributedHeal && cooldown.lateEvents) {
+      cooldown.lateEvents.splice(
+        cooldown.lastAttributedHeal,
+        cooldown.lateEvents.length - cooldown.lastAttributedHeal,
+      );
+    }
+
+    const fakeSummaryCooldown = { events: cooldown.lateEvents ?? [] };
+
     let healingStatistics = null;
+    let extendedHealingStatistics = null;
 
     const start = cooldown.start;
     const cdStart = cooldown.cdStart;
@@ -135,347 +152,603 @@ class Cooldown extends Component {
     /* eslint-disable no-script-url */
     /* eslint-disable jsx-a11y/anchor-is-valid */
     return (
-      <article>
-        <figure>
-          <SpellIcon spell={cooldown.spell} />
-        </figure>
-        <div className="row" style={{ width: '100%' }}>
-          <div className={this.state.showAllEvents ? 'col-md-12' : 'col-md-6'}>
-            <header style={{ marginTop: 5, fontSize: '1.25em', marginBottom: '.1em' }}>
-              <SpellLink spell={cooldown.spell} icon={false} /> (
-              {formatDuration(cdStart - fightStart)} -&gt; {formatDuration(end - fightStart)})
-              &nbsp;
-              <TooltipElement
-                content={
-                  <Trans id="shared.cooldownThroughputTracker.cooldown.events.tooltip">
-                    Filter events to the cooldown window.
-                  </Trans>
-                }
-              >
-                <a
-                  href="#"
-                  onClick={() => this.props.applyTimeFilter(start - fightStart, end - fightStart)}
+      <>
+        <article>
+          <figure>
+            {(cooldown.spell && <SpellIcon spell={cooldown.spell} />) || (
+              <div style={{ width: '60px' }} />
+            )}
+          </figure>
+          <div className="row" style={{ width: '100%' }}>
+            <div className={this.state.showAllEvents ? 'col-md-12' : 'col-md-6'}>
+              <header style={{ marginTop: 5, fontSize: '1.25em', marginBottom: '.1em' }}>
+                {(cooldown.spell && <SpellLink spell={cooldown.spell} icon={false} />) || (
+                  <span>Remaining HoT duration</span>
+                )}{' '}
+                ({formatDuration(cdStart - fightStart)} -&gt; {formatDuration(end - fightStart)})
+                &nbsp;
+                <TooltipElement
+                  content={
+                    <Trans id="shared.cooldownThroughputTracker.cooldown.events.tooltip">
+                      Filter events to the cooldown window.
+                    </Trans>
+                  }
                 >
-                  <Trans id="shared.cooldownThroughputTracker.cooldown.events">Filter events</Trans>
-                </a>
-              </TooltipElement>
-            </header>
+                  <a
+                    href="#"
+                    onClick={() => this.props.applyTimeFilter(start - fightStart, end - fightStart)}
+                  >
+                    <Trans id="shared.cooldownThroughputTracker.cooldown.events">
+                      Filter events
+                    </Trans>
+                  </a>
+                </TooltipElement>
+              </header>
 
-            {!this.state.showCastEvents && (
-              <div>
-                {cooldown.events
-                  .filter((event) => event.type === EventType.Cast && event.ability.guid !== 1)
-                  .map((event, i) => (
-                    <SpellLink
-                      key={`${event.ability.guid}-${event.timestamp}-${i}`}
-                      spell={event.ability.guid}
-                      icon={false}
-                    >
-                      <Icon
-                        icon={event.ability.abilityIcon}
-                        alt={event.ability.name}
-                        style={{ height: 23, marginRight: 4 }}
-                      />
-                    </SpellLink>
-                  ))}
-                <div className="row">
-                  <div className="col-xs-12">
-                    {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                    <a href="#" onClick={this.handleExpandClick} style={{ marginTop: '.2em' }}>
-                      <Trans id="shared.cooldownThroughputTracker.cooldown.expand">More</Trans>
-                    </a>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {this.state.showCastEvents && !this.state.showAllEvents && (
-              <div className="container-fluid">
-                {cooldown.events
-                  .filter((event) => event.type === EventType.Cast && event.ability.guid !== 1)
-                  .map((event, i) => (
-                    <div className="row" key={i}>
-                      <div className="col-xs-2 text-right" style={{ padding: 0 }}>
-                        {this.formatRelativeTimestamp(event, cooldown)}
-                      </div>
-                      <div className="col-xs-10">
-                        <SpellLink
-                          key={`${event.ability.guid}-${event.timestamp}-${i}`}
-                          spell={event.ability.guid}
-                          icon={false}
-                        >
-                          <Icon
-                            icon={event.ability.abilityIcon}
-                            alt={event.ability.name}
-                            style={{ height: 23, marginRight: 4 }}
-                          />{' '}
-                          {event.ability.name}
-                        </SpellLink>
-                      </div>
+              {!this.state.showCastEvents && (
+                <div>
+                  <div className="row">
+                    <div className="col-xs-12">
+                      {cooldown.events
+                        .filter(
+                          (event) => event.type === EventType.Cast && event.ability.guid !== 1,
+                        )
+                        .map((event, i) => (
+                          <SpellLink
+                            key={`${event.ability.guid}-${event.timestamp}-${i}`}
+                            spell={event.ability.guid}
+                            icon={false}
+                          >
+                            <Icon
+                              icon={event.ability.abilityIcon}
+                              alt={event.ability.name}
+                              style={{ height: 23, marginRight: 4 }}
+                            />
+                          </SpellLink>
+                        ))}
                     </div>
-                  ))}
-                <div className="row">
-                  <div className="col-xs-12">
-                    <a href="#" onClick={this.handleShowHealsClick} style={{ marginTop: '.2em' }}>
-                      <Trans id="shared.cooldownThroughputTracker.cooldown.expand.again">
-                        Even more
-                      </Trans>
-                    </a>
-                    {' | '}
-                    {/* eslint-disable-line jsx-a11y/anchor-is-valid */}
-                    <a href="#" onClick={this.handleExpandClick} style={{ marginTop: '.2em' }}>
-                      <Trans id="shared.cooldownThroughputTracker.cooldown.shrink">Show less</Trans>
-                    </a>
-                    {/* eslint-disable-line jsx-a11y/anchor-is-valid */}
+                  </div>
+                  <div className="row">
+                    <div className="col-xs-12">
+                      {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                      <a href="#" onClick={this.handleExpandClick} style={{ marginTop: '.2em' }}>
+                        <Trans id="shared.cooldownThroughputTracker.cooldown.expand">More</Trans>
+                      </a>
+                    </div>
                   </div>
                 </div>
-              </div>
-            )}
-            {this.state.showCastEvents && this.state.showAllEvents && (
-              <div className="container-fluid">
-                {this.groupHeals(
-                  cooldown.events.filter(
-                    (event) =>
-                      (event.type === EventType.Cast || event.type === EventType.Heal) &&
-                      event.ability.guid !== 1,
-                  ),
-                ).map((heal, i) => {
-                  const event = heal.event || heal;
-                  return (
-                    <div className="row" key={i}>
-                      <div className="col-xs-1 text-right" style={{ padding: 0 }}>
-                        {this.formatRelativeTimestamp(event, cooldown)}
+              )}
+
+              {this.state.showCastEvents && !this.state.showAllEvents && (
+                <div className="container-fluid">
+                  {cooldown.events
+                    .filter((event) => event.type === EventType.Cast && event.ability.guid !== 1)
+                    .map((event, i) => (
+                      <div className="row" key={i}>
+                        <div className="col-xs-2 text-right" style={{ padding: 0 }}>
+                          {this.formatRelativeTimestamp(event, cooldown)}
+                        </div>
+                        <div className="col-xs-10">
+                          <SpellLink
+                            key={`${event.ability.guid}-${event.timestamp}-${i}`}
+                            spell={event.ability.guid}
+                            icon={false}
+                          >
+                            <Icon
+                              icon={event.ability.abilityIcon}
+                              alt={event.ability.name}
+                              style={{ height: 23, marginRight: 4 }}
+                            />{' '}
+                            {event.ability.name}
+                          </SpellLink>
+                        </div>
                       </div>
-                      <div
-                        className={`col-xs-4 ${
-                          event.type === EventType.Heal ? 'col-xs-offset-1' : ''
-                        }`}
-                      >
-                        <SpellLink
-                          key={`${event.ability.guid}-${event.timestamp}-${i}`}
-                          spell={event.ability.guid}
-                          icon={false}
+                    ))}
+                  <div className="row">
+                    <div className="col-xs-12">
+                      <a href="#" onClick={this.handleShowHealsClick} style={{ marginTop: '.2em' }}>
+                        <Trans id="shared.cooldownThroughputTracker.cooldown.expand.again">
+                          Even more
+                        </Trans>
+                      </a>
+                      {' | '}
+                      {/* eslint-disable-line jsx-a11y/anchor-is-valid */}
+                      <a href="#" onClick={this.handleExpandClick} style={{ marginTop: '.2em' }}>
+                        <Trans id="shared.cooldownThroughputTracker.cooldown.shrink">
+                          Show less
+                        </Trans>
+                      </a>
+                      {/* eslint-disable-line jsx-a11y/anchor-is-valid */}
+                    </div>
+                  </div>
+                </div>
+              )}
+              {this.state.showCastEvents && this.state.showAllEvents && (
+                <div className="container-fluid">
+                  {this.groupHeals(
+                    cooldown.events.filter(
+                      (event) =>
+                        (event.type === EventType.Cast || event.type === EventType.Heal) &&
+                        event.ability.guid !== 1,
+                    ),
+                  ).map((heal, i) => {
+                    const event = heal.event || heal;
+                    return (
+                      <div className="row" key={i}>
+                        <div className="col-xs-1 text-right" style={{ padding: 0 }}>
+                          {this.formatRelativeTimestamp(event, cooldown)}
+                        </div>
+                        <div
+                          className={`col-xs-4 ${
+                            event.type === EventType.Heal ? 'col-xs-offset-1' : ''
+                          }`}
                         >
-                          <Icon
-                            icon={event.ability.abilityIcon}
-                            alt={event.ability.name}
-                            style={{ height: 23, marginRight: 4 }}
-                          />{' '}
-                          {event.ability.name}
-                        </SpellLink>
+                          <SpellLink
+                            key={`${event.ability.guid}-${event.timestamp}-${i}`}
+                            spell={event.ability.guid}
+                            icon={false}
+                          >
+                            <Icon
+                              icon={event.ability.abilityIcon}
+                              alt={event.ability.name}
+                              style={{ height: 23, marginRight: 4 }}
+                            />{' '}
+                            {event.ability.name}
+                          </SpellLink>
+                          {event.type === EventType.Heal && (
+                            <span>
+                              <span className="grouped-heal-meta amount"> x {heal.count}</span>
+                            </span>
+                          )}
+                        </div>
                         {event.type === EventType.Heal && (
-                          <span>
-                            <span className="grouped-heal-meta amount"> x {heal.count}</span>
-                          </span>
+                          <div className="col-xs-4">
+                            <span className="grouped-heal-meta healing">
+                              {' '}
+                              +{formatThousands(heal.amount + heal.absorbed)}
+                            </span>
+                            <span className="grouped-heal-meta overhealing">
+                              {' '}
+                              (O: {formatThousands(heal.overheal)})
+                            </span>
+                          </div>
                         )}
                       </div>
-                      {event.type === EventType.Heal && (
-                        <div className="col-xs-4">
-                          <span className="grouped-heal-meta healing">
-                            {' '}
-                            +{formatThousands(heal.amount + heal.absorbed)}
-                          </span>
-                          <span className="grouped-heal-meta overhealing">
-                            {' '}
-                            (O: {formatThousands(heal.overheal)})
-                          </span>
-                        </div>
-                      )}
-                    </div>
-                  );
-                })}
-                <a href="#" onClick={this.handleShowHealsClick} style={{ marginTop: '.2em' }}>
-                  <Trans id="shared.cooldownThroughputTracker.cooldown.shrink">Show less</Trans>
-                </a>
-                {' | '}
-                {/* eslint-disable-line jsx-a11y/anchor-is-valid */}
-                <a href="#" onClick={this.handleExpandClick} style={{ marginTop: '.2em' }}>
-                  <Trans id="shared.cooldownThroughputTracker.cooldown.simple">Show simple</Trans>
-                </a>
-                {/* eslint-disable-line jsx-a11y/anchor-is-valid */}
+                    );
+                  })}
+                  <a href="#" onClick={this.handleShowHealsClick} style={{ marginTop: '.2em' }}>
+                    <Trans id="shared.cooldownThroughputTracker.cooldown.shrink">Show less</Trans>
+                  </a>
+                  {' | '}
+                  {/* eslint-disable-line jsx-a11y/anchor-is-valid */}
+                  <a href="#" onClick={this.handleExpandClick} style={{ marginTop: '.2em' }}>
+                    <Trans id="shared.cooldownThroughputTracker.cooldown.simple">Show simple</Trans>
+                  </a>
+                  {/* eslint-disable-line jsx-a11y/anchor-is-valid */}
+                </div>
+              )}
+            </div>
+            {!this.state.showAllEvents && (
+              <div className="col-md-6">
+                <div className="row">
+                  {cooldown.summary.map((item) => {
+                    switch (item) {
+                      case BUILT_IN_SUMMARY_TYPES.HEALING:
+                        healingStatistics =
+                          healingStatistics || this.calculateHealingStatistics(cooldown);
+                        return (
+                          <div className="col-md-4 text-center" key="healing">
+                            <div style={{ fontSize: '2em' }}>
+                              {formatNumber(healingStatistics.healingDone)}
+                            </div>
+                            <TooltipElement
+                              content={
+                                <Trans id="shared.cooldownThroughputTracker.cooldown.healing.tooltip">
+                                  This includes all healing that occurred while the buff was up,
+                                  even if it was not triggered by spells cast inside the buff
+                                  duration. Any delayed healing such as HOTs, Absorbs and Atonements
+                                  will stop contributing to the healing done when the cooldown buff
+                                  expires, so this value is lower for any specs with such abilities.
+                                </Trans>
+                              }
+                            >
+                              <Trans id="shared.cooldownThroughputTracker.cooldown.healing">
+                                healing (
+                                {formatNumber(
+                                  (healingStatistics.healingDone / (end - start)) * 1000,
+                                )}{' '}
+                                HPS)
+                              </Trans>
+                            </TooltipElement>
+                          </div>
+                        );
+                      case BUILT_IN_SUMMARY_TYPES.OVERHEALING:
+                        healingStatistics =
+                          healingStatistics || this.calculateHealingStatistics(cooldown);
+                        return (
+                          <div className="col-md-4 text-center" key="overhealing">
+                            <div style={{ fontSize: '2em' }}>
+                              {formatPercentage(
+                                healingStatistics.overhealingDone /
+                                  (healingStatistics.healingDone +
+                                    healingStatistics.overhealingDone),
+                              )}
+                              %
+                            </div>
+                            <TooltipElement
+                              content={
+                                <Trans id="shared.cooldownThroughputTracker.cooldown.overhealing.tooltip">
+                                  This includes all healing that occurred while the buff was up,
+                                  even if it was not triggered by spells cast inside the buff
+                                  duration. Any delayed healing such as HOTs, Absorbs and Atonements
+                                  will stop contributing to the healing done when the cooldown buff
+                                  expires, so this value is lower for any specs with such abilities.
+                                </Trans>
+                              }
+                            >
+                              <Trans id="shared.cooldownThroughputTracker.cooldown.overhealing">
+                                overhealing
+                              </Trans>
+                            </TooltipElement>
+                          </div>
+                        );
+                      case BUILT_IN_SUMMARY_TYPES.ABSORBED: {
+                        const total = cooldown.events
+                          .filter((event) => event.type === EventType.Absorbed)
+                          .reduce((total, event) => total + (event.amount || 0), 0);
+                        return (
+                          <div className="col-md-4 text-center" key="absorbed">
+                            <div style={{ fontSize: '2em' }}>{formatNumber(total)}</div>
+                            <TooltipElement
+                              content={
+                                <Trans id="shared.cooldownThroughputTracker.cooldown.absorbed.tooltip">
+                                  This includes all damage absorbed that occurred while the buff was
+                                  up, even if it was not triggered by spells cast inside the buff
+                                  duration.
+                                </Trans>
+                              }
+                            >
+                              <Trans id="shared.cooldownThroughputTracker.cooldown.absorbed">
+                                damage absorbed
+                              </Trans>
+                            </TooltipElement>
+                          </div>
+                        );
+                      }
+                      case BUILT_IN_SUMMARY_TYPES.ABSORBS_APPLIED: {
+                        const total = cooldown.events
+                          .filter((event) => event.type === EventType.ApplyBuff)
+                          .reduce((total, event) => total + (event.absorb || 0), 0);
+                        return (
+                          <div className="col-md-4 text-center" key="absorbs-applied">
+                            <div style={{ fontSize: '2em' }}>{formatNumber(total)}</div>
+                            <TooltipElement
+                              content={
+                                <Trans id="shared.cooldownThroughputTracker.cooldown.absorbApplied.tooltip">
+                                  The total amount of absorb shields applied during the buff.
+                                </Trans>
+                              }
+                            >
+                              <Trans id="shared.cooldownThroughputTracker.cooldown.absorbApplied">
+                                absorb applied
+                              </Trans>
+                            </TooltipElement>
+                          </div>
+                        );
+                      }
+                      case BUILT_IN_SUMMARY_TYPES.MANA: {
+                        let manaUsed = 0;
+                        if (cooldown.spell === SPELLS.INNERVATE.id) {
+                          manaUsed = cooldown.events
+                            .filter((event) => event.type === EventType.Cast)
+                            .reduce(
+                              (total, event) =>
+                                total + (event.rawResourceCost[RESOURCE_TYPES.MANA.id] || 0),
+                              0,
+                            );
+                        } else {
+                          manaUsed = cooldown.events
+                            .filter((event) => event.type === EventType.Cast)
+                            .reduce(
+                              (total, event) =>
+                                total + (event.resourceCost[RESOURCE_TYPES.MANA.id] || 0),
+                              0,
+                            );
+                        }
+                        return (
+                          <div>
+                            <Trans
+                              id="shared.cooldownThroughputTracker.cooldown.manaUsed"
+                              className="col-md-4 text-center"
+                              key="mana"
+                            >
+                              <div style={{ fontSize: '2em' }}>{formatNumber(manaUsed)}</div>
+                              mana used
+                            </Trans>
+                          </div>
+                        );
+                      }
+                      case BUILT_IN_SUMMARY_TYPES.DAMAGE: {
+                        const damageStatistics = this.calculateDamageStatistics(cooldown);
+                        return (
+                          <div className="col-md-4 text-center" key="damage">
+                            <div style={{ fontSize: '2em' }}>
+                              {formatNumber(damageStatistics.damageDone)}
+                            </div>
+                            <TooltipElement
+                              content={
+                                <Trans id="shared.cooldownThroughputTracker.cooldown.damageDone.tooltip">
+                                  This number represents the total amount of damage done during the
+                                  duration of this cooldown, any damage done by DOTs after the
+                                  effect of this cooldown has exprired will not be included in this
+                                  statistic.
+                                </Trans>
+                              }
+                            >
+                              <Trans id="shared.cooldownThroughputTracker.cooldown.damageDone">
+                                damage (
+                                {formatNumber((damageStatistics.damageDone / (end - start)) * 1000)}{' '}
+                                DPS)
+                              </Trans>
+                            </TooltipElement>
+                          </div>
+                        );
+                      }
+                      default:
+                        // Custom
+                        return (
+                          <div className="col-md-4 text-center" key={item.label}>
+                            <div style={{ fontSize: '2em' }}>
+                              {typeof item.value === 'string'
+                                ? item.value
+                                : formatNumber(item.value)}
+                            </div>
+                            <TooltipElement content={item.tooltip}>{item.label}</TooltipElement>
+                          </div>
+                        );
+                    }
+                  })}
+                </div>
               </div>
             )}
           </div>
-          {!this.state.showAllEvents && (
-            <div className="col-md-6">
-              <div className="row">
-                {cooldown.summary.map((item) => {
-                  switch (item) {
-                    case BUILT_IN_SUMMARY_TYPES.HEALING:
-                      healingStatistics =
-                        healingStatistics || this.calculateHealingStatistics(cooldown);
-                      return (
-                        <div className="col-md-4 text-center" key="healing">
-                          <div style={{ fontSize: '2em' }}>
-                            {formatNumber(healingStatistics.healingDone)}
-                          </div>
-                          <TooltipElement
-                            content={
-                              <Trans id="shared.cooldownThroughputTracker.cooldown.healing.tooltip">
-                                This includes all healing that occurred while the buff was up, even
-                                if it was not triggered by spells cast inside the buff duration. Any
-                                delayed healing such as HOTs, Absorbs and Atonements will stop
-                                contributing to the healing done when the cooldown buff expires, so
-                                this value is lower for any specs with such abilities.
-                              </Trans>
-                            }
+        </article>
+        {cooldown.lateEvents && cooldown.lateEvents.length > 0 && (
+          <>
+            <hr />
+            <article style={{ filter: 'grayscale(80%)' }}>
+              <figure style={{ visibility: 'hidden' }}>
+                <SpellIcon spell={cooldown.spell} />
+              </figure>
+              <div className="row" style={{ width: '100%' }}>
+                <div className="col-md-6">
+                  <div className="row">
+                    <div className="col-md-12">
+                      <header style={{ marginTop: 5, fontSize: '1.25em', marginBottom: '.1em' }}>
+                        Remaining HoT Duration ({formatDuration(end - fightStart)} -&gt;{' '}
+                        {formatDuration(
+                          cooldown.lateEvents[cooldown.lateEvents.length - 1].timestamp -
+                            fightStart,
+                        )}
+                        )
+                      </header>
+                    </div>
+                  </div>
+                  <div className="row">
+                    <div className="col-md-12">
+                      {cooldown.lateEvents
+                        .filter(
+                          (event) => event.type === EventType.Cast && event.ability.guid !== 1,
+                        )
+                        .map((event, i) => (
+                          <SpellLink
+                            key={`${event.ability.guid}-${event.timestamp}-${i}`}
+                            spell={event.ability.guid}
+                            icon={false}
                           >
-                            <Trans id="shared.cooldownThroughputTracker.cooldown.healing">
-                              healing (
-                              {formatNumber((healingStatistics.healingDone / (end - start)) * 1000)}{' '}
-                              HPS)
-                            </Trans>
-                          </TooltipElement>
-                        </div>
-                      );
-                    case BUILT_IN_SUMMARY_TYPES.OVERHEALING:
-                      healingStatistics =
-                        healingStatistics || this.calculateHealingStatistics(cooldown);
-                      return (
-                        <div className="col-md-4 text-center" key="overhealing">
-                          <div style={{ fontSize: '2em' }}>
-                            {formatPercentage(
-                              healingStatistics.overhealingDone /
-                                (healingStatistics.healingDone + healingStatistics.overhealingDone),
-                            )}
-                            %
-                          </div>
-                          <TooltipElement
-                            content={
-                              <Trans id="shared.cooldownThroughputTracker.cooldown.overhealing.tooltip">
-                                This includes all healing that occurred while the buff was up, even
-                                if it was not triggered by spells cast inside the buff duration. Any
-                                delayed healing such as HOTs, Absorbs and Atonements will stop
-                                contributing to the healing done when the cooldown buff expires, so
-                                this value is lower for any specs with such abilities.
-                              </Trans>
-                            }
-                          >
-                            <Trans id="shared.cooldownThroughputTracker.cooldown.overhealing">
-                              overhealing
-                            </Trans>
-                          </TooltipElement>
-                        </div>
-                      );
-                    case BUILT_IN_SUMMARY_TYPES.ABSORBED: {
-                      const total = cooldown.events
-                        .filter((event) => event.type === EventType.Absorbed)
-                        .reduce((total, event) => total + (event.amount || 0), 0);
-                      return (
-                        <div className="col-md-4 text-center" key="absorbed">
-                          <div style={{ fontSize: '2em' }}>{formatNumber(total)}</div>
-                          <TooltipElement
-                            content={
-                              <Trans id="shared.cooldownThroughputTracker.cooldown.absorbed.tooltip">
-                                This includes all damage absorbed that occurred while the buff was
-                                up, even if it was not triggered by spells cast inside the buff
-                                duration.
-                              </Trans>
-                            }
-                          >
-                            <Trans id="shared.cooldownThroughputTracker.cooldown.absorbed">
-                              damage absorbed
-                            </Trans>
-                          </TooltipElement>
-                        </div>
-                      );
-                    }
-                    case BUILT_IN_SUMMARY_TYPES.ABSORBS_APPLIED: {
-                      const total = cooldown.events
-                        .filter((event) => event.type === EventType.ApplyBuff)
-                        .reduce((total, event) => total + (event.absorb || 0), 0);
-                      return (
-                        <div className="col-md-4 text-center" key="absorbs-applied">
-                          <div style={{ fontSize: '2em' }}>{formatNumber(total)}</div>
-                          <TooltipElement
-                            content={
-                              <Trans id="shared.cooldownThroughputTracker.cooldown.absorbApplied.tooltip">
-                                The total amount of absorb shields applied during the buff.
-                              </Trans>
-                            }
-                          >
-                            <Trans id="shared.cooldownThroughputTracker.cooldown.absorbApplied">
-                              absorb applied
-                            </Trans>
-                          </TooltipElement>
-                        </div>
-                      );
-                    }
-                    case BUILT_IN_SUMMARY_TYPES.MANA: {
-                      let manaUsed = 0;
-                      if (cooldown.spell === SPELLS.INNERVATE.id) {
-                        manaUsed = cooldown.events
-                          .filter((event) => event.type === EventType.Cast)
-                          .reduce(
-                            (total, event) =>
-                              total + (event.rawResourceCost[RESOURCE_TYPES.MANA.id] || 0),
-                            0,
+                            <Icon
+                              icon={event.ability.abilityIcon}
+                              alt={event.ability.name}
+                              style={{ height: 23, marginRight: 4 }}
+                            />
+                          </SpellLink>
+                        ))}
+                    </div>
+                  </div>
+                </div>
+                <div className="col-md-6">
+                  <div className="row">
+                    {cooldown.summary.map((item) => {
+                      switch (item) {
+                        case BUILT_IN_SUMMARY_TYPES.HEALING:
+                          extendedHealingStatistics =
+                            extendedHealingStatistics ||
+                            this.calculateHealingStatistics(fakeSummaryCooldown);
+                          return (
+                            <div className="col-md-4 text-center" key="healing">
+                              <div style={{ fontSize: '2em' }}>
+                                {formatNumber(extendedHealingStatistics.healingDone)}
+                              </div>
+                              <TooltipElement
+                                content={
+                                  <Trans id="shared.cooldownThroughputTracker.cooldown.healing.tooltip">
+                                    This includes all healing that occurred while the buff was up,
+                                    even if it was not triggered by spells cast inside the buff
+                                    duration. Any delayed healing such as HOTs, Absorbs and
+                                    Atonements will stop contributing to the healing done when the
+                                    cooldown buff expires, so this value is lower for any specs with
+                                    such abilities.
+                                  </Trans>
+                                }
+                              >
+                                <Trans id="shared.cooldownThroughputTracker.cooldown.healing">
+                                  healing (
+                                  {formatNumber(
+                                    (extendedHealingStatistics.healingDone / (end - start)) * 1000,
+                                  )}{' '}
+                                  HPS)
+                                </Trans>
+                              </TooltipElement>
+                            </div>
                           );
-                      } else {
-                        manaUsed = cooldown.events
-                          .filter((event) => event.type === EventType.Cast)
-                          .reduce(
-                            (total, event) =>
-                              total + (event.resourceCost[RESOURCE_TYPES.MANA.id] || 0),
-                            0,
+                        case BUILT_IN_SUMMARY_TYPES.OVERHEALING:
+                          extendedHealingStatistics =
+                            extendedHealingStatistics ||
+                            this.calculateHealingStatistics(fakeSummaryCooldown);
+                          return (
+                            <div className="col-md-4 text-center" key="overhealing">
+                              <div style={{ fontSize: '2em' }}>
+                                {formatPercentage(
+                                  extendedHealingStatistics.overhealingDone /
+                                    (extendedHealingStatistics.healingDone +
+                                      extendedHealingStatistics.overhealingDone),
+                                )}
+                                %
+                              </div>
+                              <TooltipElement
+                                content={
+                                  <Trans id="shared.cooldownThroughputTracker.cooldown.overhealing.tooltip">
+                                    This includes all healing that occurred while the buff was up,
+                                    even if it was not triggered by spells cast inside the buff
+                                    duration. Any delayed healing such as HOTs, Absorbs and
+                                    Atonements will stop contributing to the healing done when the
+                                    cooldown buff expires, so this value is lower for any specs with
+                                    such abilities.
+                                  </Trans>
+                                }
+                              >
+                                <Trans id="shared.cooldownThroughputTracker.cooldown.overhealing">
+                                  overhealing
+                                </Trans>
+                              </TooltipElement>
+                            </div>
+                          );
+                        case BUILT_IN_SUMMARY_TYPES.ABSORBED: {
+                          const total = fakeSummaryCooldown.events
+                            .filter((event) => event.type === EventType.Absorbed)
+                            .reduce((total, event) => total + (event.amount || 0), 0);
+                          return (
+                            <div className="col-md-4 text-center" key="absorbed">
+                              <div style={{ fontSize: '2em' }}>{formatNumber(total)}</div>
+                              <TooltipElement
+                                content={
+                                  <Trans id="shared.cooldownThroughputTracker.cooldown.absorbed.tooltip">
+                                    This includes all damage absorbed that occurred while the buff
+                                    was up, even if it was not triggered by spells cast inside the
+                                    buff duration.
+                                  </Trans>
+                                }
+                              >
+                                <Trans id="shared.cooldownThroughputTracker.cooldown.absorbed">
+                                  damage absorbed
+                                </Trans>
+                              </TooltipElement>
+                            </div>
+                          );
+                        }
+                        case BUILT_IN_SUMMARY_TYPES.ABSORBS_APPLIED: {
+                          const total = fakeSummaryCooldown.events
+                            .filter((event) => event.type === EventType.ApplyBuff)
+                            .reduce((total, event) => total + (event.absorb || 0), 0);
+                          return (
+                            <div className="col-md-4 text-center" key="absorbs-applied">
+                              <div style={{ fontSize: '2em' }}>{formatNumber(total)}</div>
+                              <TooltipElement
+                                content={
+                                  <Trans id="shared.cooldownThroughputTracker.cooldown.absorbApplied.tooltip">
+                                    The total amount of absorb shields applied during the buff.
+                                  </Trans>
+                                }
+                              >
+                                <Trans id="shared.cooldownThroughputTracker.cooldown.absorbApplied">
+                                  absorb applied
+                                </Trans>
+                              </TooltipElement>
+                            </div>
+                          );
+                        }
+                        case BUILT_IN_SUMMARY_TYPES.MANA: {
+                          let manaUsed = 0;
+                          if (cooldown.spell === SPELLS.INNERVATE.id) {
+                            manaUsed = fakeSummaryCooldown.events
+                              .filter((event) => event.type === EventType.Cast)
+                              .reduce(
+                                (total, event) =>
+                                  total + (event.rawResourceCost[RESOURCE_TYPES.MANA.id] || 0),
+                                0,
+                              );
+                          } else {
+                            manaUsed = fakeSummaryCooldown.events
+                              .filter((event) => event.type === EventType.Cast)
+                              .reduce(
+                                (total, event) =>
+                                  total + (event.resourceCost[RESOURCE_TYPES.MANA.id] || 0),
+                                0,
+                              );
+                          }
+                          return (
+                            <div>
+                              <Trans
+                                id="shared.cooldownThroughputTracker.cooldown.manaUsed"
+                                className="col-md-4 text-center"
+                                key="mana"
+                              >
+                                <div style={{ fontSize: '2em' }}>{formatNumber(manaUsed)}</div>
+                                mana used
+                              </Trans>
+                            </div>
+                          );
+                        }
+                        case BUILT_IN_SUMMARY_TYPES.DAMAGE: {
+                          const damageStatistics =
+                            this.calculateDamageStatistics(fakeSummaryCooldown);
+                          return (
+                            <div className="col-md-4 text-center" key="damage">
+                              <div style={{ fontSize: '2em' }}>
+                                {formatNumber(damageStatistics.damageDone)}
+                              </div>
+                              <TooltipElement
+                                content={
+                                  <Trans id="shared.cooldownThroughputTracker.cooldown.damageDone.tooltip">
+                                    This number represents the total amount of damage done during
+                                    the duration of this cooldown, any damage done by DOTs after the
+                                    effect of this cooldown has exprired will not be included in
+                                    this statistic.
+                                  </Trans>
+                                }
+                              >
+                                <Trans id="shared.cooldownThroughputTracker.cooldown.damageDone">
+                                  damage (
+                                  {formatNumber(
+                                    (damageStatistics.damageDone / (end - start)) * 1000,
+                                  )}{' '}
+                                  DPS)
+                                </Trans>
+                              </TooltipElement>
+                            </div>
+                          );
+                        }
+                        default:
+                          // Custom
+                          return (
+                            <div className="col-md-4 text-center" key={item.label}>
+                              <div style={{ fontSize: '2em' }}>
+                                {typeof item.value === 'string'
+                                  ? item.value
+                                  : formatNumber(item.value)}
+                              </div>
+                              <TooltipElement content={item.tooltip}>{item.label}</TooltipElement>
+                            </div>
                           );
                       }
-                      return (
-                        <div>
-                          <Trans
-                            id="shared.cooldownThroughputTracker.cooldown.manaUsed"
-                            className="col-md-4 text-center"
-                            key="mana"
-                          >
-                            <div style={{ fontSize: '2em' }}>{formatNumber(manaUsed)}</div>
-                            mana used
-                          </Trans>
-                        </div>
-                      );
-                    }
-                    case BUILT_IN_SUMMARY_TYPES.DAMAGE: {
-                      const damageStatistics = this.calculateDamageStatistics(cooldown);
-                      return (
-                        <div className="col-md-4 text-center" key="damage">
-                          <div style={{ fontSize: '2em' }}>
-                            {formatNumber(damageStatistics.damageDone)}
-                          </div>
-                          <TooltipElement
-                            content={
-                              <Trans id="shared.cooldownThroughputTracker.cooldown.damageDone.tooltip">
-                                This number represents the total amount of damage done during the
-                                duration of this cooldown, any damage done by DOTs after the effect
-                                of this cooldown has exprired will not be included in this
-                                statistic.
-                              </Trans>
-                            }
-                          >
-                            <Trans id="shared.cooldownThroughputTracker.cooldown.damageDone">
-                              damage (
-                              {formatNumber((damageStatistics.damageDone / (end - start)) * 1000)}{' '}
-                              DPS)
-                            </Trans>
-                          </TooltipElement>
-                        </div>
-                      );
-                    }
-                    default:
-                      // Custom
-                      return (
-                        <div className="col-md-4 text-center" key={item.label}>
-                          <div style={{ fontSize: '2em' }}>
-                            {typeof item.value === 'string' ? item.value : formatNumber(item.value)}
-                          </div>
-                          <TooltipElement content={item.tooltip}>{item.label}</TooltipElement>
-                        </div>
-                      );
-                  }
-                })}
+                    })}
+                  </div>
+                </div>
               </div>
-            </div>
-          )}
-        </div>
-      </article>
+            </article>
+          </>
+        )}
+      </>
     );
   }
 }


### PR DESCRIPTION
### Description
show a separate section with casts/healing done after celestial duration but while hots applied during the celestial are still active.
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/229650/3dece329-a6ac-490d-81d4-7110e6dcc2bf)

Especially looking for feedback on `<Cooldown>` and presentation/clarity. Don't really like `cooldown.spell === 0` being a weird sentinel value.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/...`
- Screenshot(s):
