### PR TITLE
disable specs broken by 10.2 talent regeneration

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -30,6 +30,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 10, 9), 'Disable specs broken by talent regeneration for 10.2.', ToppleTheNun),
   change(date(2023, 10, 9), 'Regenerate talents for 10.2.', ToppleTheNun),
   change(date(2023, 10, 9), 'Add Amirdrassil raid data.', ToppleTheNun),
   change(date(2023, 10, 9), 'Remove Burning Crusade raid data.', ToppleTheNun),

--- a/src/analysis/retail/druid/restoration/CONFIG.tsx
+++ b/src/analysis/retail/druid/restoration/CONFIG.tsx
@@ -3,7 +3,7 @@ import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import Config from 'parser/Config';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
@@ -37,12 +37,12 @@ const config: Config = {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.RESTORATION_DRUID,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [], // CHANGELOG,
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "RestorationDruid" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "RestorationDruid" */).then(
+  //     (exports) => exports.default,
+  //   ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };

--- a/src/analysis/retail/hunter/beastmastery/CONFIG.tsx
+++ b/src/analysis/retail/hunter/beastmastery/CONFIG.tsx
@@ -2,7 +2,7 @@ import { Arlie, Putro } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import Config from 'parser/Config';
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
@@ -57,12 +57,12 @@ const config: Config = {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.BEAST_MASTERY_HUNTER,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [], // CHANGELOG,
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "BeastMasteryHunter" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "BeastMasteryHunter" */).then(
+  //     (exports) => exports.default,
+  //   ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 

--- a/src/analysis/retail/monk/brewmaster/CONFIG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CONFIG.tsx
@@ -3,7 +3,7 @@ import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import Config from 'parser/Config';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
@@ -51,12 +51,12 @@ const config: Config = {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.BREWMASTER_MONK,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [], // CHANGELOG,
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "BrewmasterMonk" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "BrewmasterMonk" */).then(
+  //     (exports) => exports.default,
+  //   ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
   //Only show the guide since brewmaster no longer has a supported checklist

--- a/src/analysis/retail/monk/mistweaver/CONFIG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CONFIG.tsx
@@ -2,7 +2,7 @@ import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import Config from 'parser/Config';
 import { Trevor, Vohrr } from 'CONTRIBUTORS';
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
@@ -34,12 +34,12 @@ const config: Config = {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.MISTWEAVER_MONK,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [], // CHANGELOG,
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "MistweaverMonk" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "MistweaverMonk" */).then(
+  //     (exports) => exports.default,
+  //   ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
   guideDefault: true,

--- a/src/analysis/retail/priest/discipline/CONFIG.tsx
+++ b/src/analysis/retail/priest/discipline/CONFIG.tsx
@@ -3,7 +3,7 @@ import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import Config from 'parser/Config';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
@@ -42,12 +42,12 @@ const config: Config = {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.DISCIPLINE_PRIEST,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [], // CHANGELOG,
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "DisciplinePriest" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "DisciplinePriest" */).then(
+  //     (exports) => exports.default,
+  //   ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };

--- a/src/analysis/retail/priest/holy/CONFIG.tsx
+++ b/src/analysis/retail/priest/holy/CONFIG.tsx
@@ -2,7 +2,7 @@ import { Litena, Squided } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import Config from 'parser/Config';
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 //Description not accurate as of Dragonflight update
 const config: Config = {
@@ -39,12 +39,12 @@ const config: Config = {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.HOLY_PRIEST,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [], // CHANGELOG,
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "HolyPriest" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "HolyPriest" */).then(
+  //     (exports) => exports.default,
+  //   ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };

--- a/src/analysis/retail/priest/shadow/CONFIG.tsx
+++ b/src/analysis/retail/priest/shadow/CONFIG.tsx
@@ -3,7 +3,7 @@ import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import Config from 'parser/Config';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
@@ -48,12 +48,12 @@ const config: Config = {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.SHADOW_PRIEST,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [], // CHANGELOG,
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "ShadowPriest" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "ShadowPriest" */).then(
+  //     (exports) => exports.default,
+  //   ),
   //The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };

--- a/src/analysis/retail/shaman/elemental/CONFIG.tsx
+++ b/src/analysis/retail/shaman/elemental/CONFIG.tsx
@@ -2,7 +2,7 @@ import { Awildfivreld, Periodic } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
@@ -59,12 +59,12 @@ export default {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.ELEMENTAL_SHAMAN,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [], // CHANGELOG,
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "ElementalShaman" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "ElementalShaman" */).then(
+  //     (exports) => exports.default,
+  //   ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };

--- a/src/analysis/retail/shaman/enhancement/CONFIG.tsx
+++ b/src/analysis/retail/shaman/enhancement/CONFIG.tsx
@@ -4,7 +4,7 @@ import SPECS from 'game/SPECS';
 import { AlertWarning } from 'interface';
 import Config from 'parser/Config';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   contributors: [Seriousnes],
@@ -26,12 +26,12 @@ const config: Config = {
   exampleReport:
     '/report/p4MjCghDVP6TGvfQ/1-Heroic+Rashok,+the+Elder+-+Kill+(2:36)/Seriousnes/standard',
   spec: SPECS.ENHANCEMENT_SHAMAN,
-  changelog: CHANGELOG,
+  changelog: [], // CHANGELOG,
   guideDefault: true,
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "EnhancementShaman" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "EnhancementShaman" */).then(
+  //     (exports) => exports.default,
+  //   ),
 
   path: __dirname,
 };

--- a/src/analysis/retail/shaman/restoration/CONFIG.tsx
+++ b/src/analysis/retail/shaman/restoration/CONFIG.tsx
@@ -5,7 +5,7 @@ import SPECS from 'game/SPECS';
 import { AlertWarning } from 'interface';
 import Config from 'parser/Config';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 const CONFIG: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
@@ -45,12 +45,12 @@ const CONFIG: Config = {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.RESTORATION_SHAMAN,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [], // CHANGELOG,
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "RestorationShaman" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "RestorationShaman" */).then(
+  //     (exports) => exports.default,
+  //   ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
   guideDefault: false,

--- a/src/analysis/retail/warlock/destruction/CONFIG.tsx
+++ b/src/analysis/retail/warlock/destruction/CONFIG.tsx
@@ -1,7 +1,7 @@
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 
-import CHANGELOG from './CHANGELOG';
+// import CHANGELOG from './CHANGELOG';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
@@ -44,12 +44,12 @@ export default {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.DESTRUCTION_WARLOCK,
   // The contents of your changelog.
-  changelog: CHANGELOG,
+  changelog: [], // CHANGELOG,
   // The CombatLogParser class for your spec.
-  parser: () =>
-    import('./CombatLogParser' /* webpackChunkName: "DestructionWarlock" */).then(
-      (exports) => exports.default,
-    ),
+  // parser: () =>
+  //   import('./CombatLogParser' /* webpackChunkName: "DestructionWarlock" */).then(
+  //     (exports) => exports.default,
+  //   ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,12 +20,40 @@
   "include": ["./types", "./src"],
   // analysis is currently excluded to prevent parsing files that reference dead talents
   // all files that are imported are processed even if excluded here, so this only excludes unimported files
-  "exclude": ["src/analysis/retail/druid/guardian", "src/analysis/retail/paladin/protection"],
+  "exclude": [
+    "src/analysis/retail/druid/guardian",
+    "src/analysis/retail/druid/restoration",
+    "src/analysis/retail/hunter/beastmastery",
+    "src/analysis/retail/monk/brewmaster",
+    "src/analysis/retail/monk/mistweaver",
+    "src/analysis/retail/paladin/protection",
+    "src/analysis/retail/priest/discipline",
+    "src/analysis/retail/priest/shared",
+    "src/analysis/retail/priest/holy",
+    "src/analysis/retail/priest/shadow",
+    "src/analysis/retail/shaman/elemental",
+    "src/analysis/retail/shaman/enhancement",
+    "src/analysis/retail/shaman/restoration",
+    "src/analysis/retail/shaman/shared",
+    "src/analysis/retail/warlock/destruction"
+  ],
   "files": [
     "src/analysis/retail/druid/guardian/CONFIG.tsx",
     "src/analysis/retail/druid/guardian/CHANGELOG.tsx",
+    "src/analysis/retail/druid/restoration/CONFIG.tsx",
+    "src/analysis/retail/hunter/beastmastery/CONFIG.tsx",
+    "src/analysis/retail/monk/brewmaster/CONFIG.tsx",
+    "src/analysis/retail/monk/mistweaver/CONFIG.tsx",
     "src/analysis/retail/paladin/protection/CONFIG.tsx",
-    "src/analysis/retail/paladin/protection/CHANGELOG.tsx"
+    "src/analysis/retail/paladin/protection/CHANGELOG.tsx",
+    "src/analysis/retail/paladin/protection/CHANGELOG.tsx",
+    "src/analysis/retail/priest/discipline/CONFIG.tsx",
+    "src/analysis/retail/priest/holy/CONFIG.tsx",
+    "src/analysis/retail/priest/shadow/CONFIG.tsx",
+    "src/analysis/retail/shaman/elemental/CONFIG.tsx",
+    "src/analysis/retail/shaman/enhancement/CONFIG.tsx",
+    "src/analysis/retail/shaman/restoration/CONFIG.tsx",
+    "src/analysis/retail/warlock/destruction/CONFIG.tsx"
   ],
   "ts-node": {
     // these options are overrides used only by ts-node


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Disable specs broken by 10.2 talent regeneration so that the app compiles:
- druid/restoration
- hunter/beastmastery
- monk/brewmaster
- monk/mistweaver
- paladin/protection
- priest/discipline
- priest/holy
- priest/shadow
- shaman/elemental
- shaman/enhancement
- shaman/restoration
- warlock/destruction
