### PR TITLE
[Augmentation] Fix undefined error when trying to draw graph without data

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+    change(date(2023, 10, 18), <>Fix an error with trying to display graphs without data.</>, Vollmer),
     change(date(2023, 10, 17), <>Update styling for Buff Helper module.</>, Vollmer),
     change(date(2023, 10, 6), <>Add a new guide section for Helper modules.</>, Vollmer),
     change(date(2023, 10, 6), <>Implement a Breath Helper module.</>, Vollmer),

--- a/src/analysis/retail/evoker/shared/modules/components/ExplanationGraph.tsx
+++ b/src/analysis/retail/evoker/shared/modules/components/ExplanationGraph.tsx
@@ -187,6 +187,14 @@ const ExplanationGraph: React.FC<Props> = ({
     setCurrentWindowIndex((prevIndex) => (prevIndex - 1 + graphData.length) % graphData.length);
   };
 
+  if (graphData.length === 0) {
+    return (
+      <div>
+        <big>No data to display.</big>
+      </div>
+    );
+  }
+
   const currentWindow = graphData[currentWindowIndex];
   let currentGraph: GraphData;
   let colorRange: string[] = [];


### PR DESCRIPTION
### Description
If `graphData` input is an empty array `ExplanationGraph` will throw a hissy fit over the data you are trying to display being undefined. This fixes that.

### Testing
- Test report URL: `/report/Jct2fVH9Nyx46BCF/47-Mythic+Scalecommander+Sarkareth+-+Wipe+20+(0:24)/Bruggagos/standard`
