### PR TITLE
[Devastation] Implement T31 module for 10.2

### DIFF
--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+  change(date(2023, 10, 20), <>Added stats for T31 2pc buff <SpellLink spell={SPELLS.EMERALD_TRANCE_T31_2PC_BUFF}/>.</>, Vollmer),
   change(date(2023, 9, 8), <>Add graph for <SpellLink spell={SPELLS.DISINTEGRATE}/> module for more in-depth analysis.</>, Vollmer),
   change(date(2023, 8, 25), <>Add <SpellLink spell={TALENTS.LEAPING_FLAMES_TALENT} /> module.</>, Vollmer),
   change(date(2023, 7, 26), <>Update <SpellLink spell={TALENTS.CAUSALITY_TALENT} /> module & CDR calculation.</>, Vollmer),

--- a/src/analysis/retail/evoker/devastation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/devastation/CombatLogParser.ts
@@ -30,6 +30,7 @@ import EyeOfInfinity from './modules/talents/EyeOfInfinity';
 import EngulfingBlaze from './modules/talents/EngulfingBlaze';
 import LayWaste from './modules/talents/LayWaste';
 import Iridescence from './modules/talents/Iridescence';
+import T31DevaTier from './modules/dragonflight/tier/T31DevaTier';
 
 // Shared
 import { LeapingFlamesNormalizer, LeapingFlames } from 'analysis/retail/evoker/shared';
@@ -79,6 +80,7 @@ class CombatLogParser extends MainCombatLogParser {
 
     // tier
     T30devaTier4P: T30DevaTier4P,
+    T31devaTier: T31DevaTier,
   };
 
   static guide = Guide;

--- a/src/analysis/retail/evoker/devastation/constants.tsx
+++ b/src/analysis/retail/evoker/devastation/constants.tsx
@@ -27,3 +27,5 @@ export const DISINTEGRATE_CHAINED_TICKS = 5;
 
 export const CAUSALITY_DISINTEGRATE_CDR_MS = 500;
 export const CAUSALITY_PYRE_CDR_MS = 400;
+
+export const DEVA_T31_2PC_MULTIPLER = 0.05;

--- a/src/analysis/retail/evoker/devastation/modules/dragonflight/tier/T30DevaTier4P.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/dragonflight/tier/T30DevaTier4P.tsx
@@ -22,6 +22,7 @@ import BoringValueText from 'parser/ui/BoringValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import { SpellLink } from 'interface';
 import { BLAZING_SHARDS_DURATION } from 'analysis/retail/evoker/devastation/constants';
+import { TIERS } from 'game/TIERS';
 
 const { BLAZING_SHARDS, OBSIDIAN_SHARDS } = SPELLS;
 
@@ -53,6 +54,7 @@ class T30DevaTier4P extends Analyzer {
 
   constructor(options: Options) {
     super(options);
+    this.active = this.selectedCombatant.has2PieceByTier(TIERS.T30);
 
     this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(OBSIDIAN_SHARDS), (event) => {
       this.onObsidianShardsDamage(event);
@@ -285,6 +287,7 @@ class T30DevaTier4P extends Analyzer {
   statistic() {
     const damageFrom4Set =
       this.obsidianShardsDamDuringBlazing - this.obsidianShardsDamDuringBlazing / 3;
+    const has4Piece = this.selectedCombatant.has4PieceByTier(TIERS.T30);
     return (
       <Statistic
         position={STATISTIC_ORDER.OPTIONAL(5)}
@@ -293,24 +296,34 @@ class T30DevaTier4P extends Analyzer {
         tooltip={
           <>
             <li>
-              Wasted <SpellLink spell={BLAZING_SHARDS} /> uptime: {this.totalLostUptime.toFixed(2)}
-              s.
-            </li>
-            <li>
               <SpellLink spell={OBSIDIAN_SHARDS} /> damage:{' '}
               {formatNumber(this.obsidianShardsDam - damageFrom4Set)}
             </li>
-            <li>
-              <SpellLink spell={BLAZING_SHARDS} /> damage: {formatNumber(damageFrom4Set)}
-            </li>
+            {has4Piece && (
+              <>
+                <li>
+                  Wasted <SpellLink spell={BLAZING_SHARDS} /> uptime:{' '}
+                  {this.totalLostUptime.toFixed(2)}
+                  s.
+                </li>
+
+                <li>
+                  <SpellLink spell={BLAZING_SHARDS} /> damage: {formatNumber(damageFrom4Set)}
+                </li>
+              </>
+            )}
           </>
         }
       >
         <BoringValueText label="Obsidian Secrets (T30 Set Bonus)">
           <h4>2 Piece</h4>
           <ItemDamageDone amount={this.obsidianShardsDam - damageFrom4Set} />
-          <h4>4 Piece</h4>
-          <ItemDamageDone amount={damageFrom4Set} />
+          {has4Piece && (
+            <>
+              <h4>4 Piece</h4>
+              <ItemDamageDone amount={damageFrom4Set} />
+            </>
+          )}
         </BoringValueText>
       </Statistic>
     );

--- a/src/analysis/retail/evoker/devastation/modules/dragonflight/tier/T31DevaTier.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/dragonflight/tier/T31DevaTier.tsx
@@ -63,7 +63,7 @@ class T31DevaTier extends Analyzer {
         size="flexible"
         category={STATISTIC_CATEGORY.ITEMS}
       >
-        <BoringValueText label="Emerald Trance (T31 Set Bonus)">
+        <BoringValueText label="Emerald Dream (T31 Set Bonus)">
           <h4>2 Piece</h4>
           <ItemDamageDone amount={this.ampedDamage} />
         </BoringValueText>

--- a/src/analysis/retail/evoker/devastation/modules/dragonflight/tier/T31DevaTier.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/dragonflight/tier/T31DevaTier.tsx
@@ -23,6 +23,10 @@ import { TIERS } from 'game/TIERS';
  */
 class T31DevaTier extends Analyzer {
   ampedDamage: number = 0;
+  /** We need this so we don't assume always 5 stacks
+   * Since technically you can drop Dragonrage early
+   * and then the buff won't be fully stacked */
+  buffStacks: number = 0;
 
   constructor(options: Options) {
     super(options);
@@ -34,11 +38,22 @@ class T31DevaTier extends Analyzer {
   }
 
   onHit(event: DamageEvent) {
-    if (!this.selectedCombatant.hasBuff(SPELLS.EMERALD_TRANCE_T31_2PC_BUFF.id)) {
+    if (
+      !this.selectedCombatant.hasBuff(SPELLS.EMERALD_TRANCE_T31_2PC_BUFF_STACKING.id) &&
+      !this.selectedCombatant.hasBuff(SPELLS.EMERALD_TRANCE_T31_2PC_BUFF.id)
+    ) {
       return;
     }
-    const buffStacks = this.selectedCombatant.getBuffStacks(SPELLS.EMERALD_TRANCE_T31_2PC_BUFF.id);
-    this.ampedDamage += calculateEffectiveDamage(event, DEVA_T31_2PC_MULTIPLER * buffStacks);
+    // Post Dragonrage Buff
+    if (this.selectedCombatant.hasBuff(SPELLS.EMERALD_TRANCE_T31_2PC_BUFF.id)) {
+      this.ampedDamage += calculateEffectiveDamage(event, DEVA_T31_2PC_MULTIPLER * this.buffStacks);
+      return;
+    }
+    // During Dragonrage Buff
+    this.buffStacks = this.selectedCombatant.getBuffStacks(
+      SPELLS.EMERALD_TRANCE_T31_2PC_BUFF_STACKING.id,
+    );
+    this.ampedDamage += calculateEffectiveDamage(event, DEVA_T31_2PC_MULTIPLER * this.buffStacks);
   }
 
   statistic() {

--- a/src/analysis/retail/evoker/devastation/modules/dragonflight/tier/T31DevaTier.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/dragonflight/tier/T31DevaTier.tsx
@@ -1,0 +1,60 @@
+import SPELLS from 'common/SPELLS/evoker';
+
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { DamageEvent } from 'parser/core/Events';
+
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { DEVA_T31_2PC_MULTIPLER } from '../../../constants';
+import BoringValueText from 'parser/ui/BoringValueText';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
+import { TIERS } from 'game/TIERS';
+
+/**
+ * (2) Set Devastation: While Dragonrage is active
+ * you gain Emerald Trance every 6 sec, increasing your
+ * damage done by 5%, stacking up to 5 times.
+ *
+ * (4) Set Devastation: When Dragonrage ends,
+ * Emerald Trance persists for 5 sec per stack
+ * and grants you Essence Burst every 5 sec.
+ */
+class T31DevaTier extends Analyzer {
+  ampedDamage: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.has2PieceByTier(TIERS.T31);
+
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER), (event) => {
+      this.onHit(event);
+    });
+  }
+
+  onHit(event: DamageEvent) {
+    if (!this.selectedCombatant.hasBuff(SPELLS.EMERALD_TRANCE_T31_2PC_BUFF.id)) {
+      return;
+    }
+    const buffStacks = this.selectedCombatant.getBuffStacks(SPELLS.EMERALD_TRANCE_T31_2PC_BUFF.id);
+    this.ampedDamage += calculateEffectiveDamage(event, DEVA_T31_2PC_MULTIPLER * buffStacks);
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(5)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.ITEMS}
+      >
+        <BoringValueText label="Emerald Trance (T31 Set Bonus)">
+          <h4>2 Piece</h4>
+          <ItemDamageDone amount={this.ampedDamage} />
+        </BoringValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default T31DevaTier;

--- a/src/common/SPELLS/evoker.ts
+++ b/src/common/SPELLS/evoker.ts
@@ -148,12 +148,18 @@ const spells = {
     name: 'Essence Burst',
     icon: 'ability_evoker_essenceburst',
   },
-  EMERALD_TRANCE_T31_2PC_BUFF: {
+  // Buff during Dragonrage
+  EMERALD_TRANCE_T31_2PC_BUFF_STACKING: {
     id: 424155,
     name: 'Emerald Trance',
     icon: 'inv_legion_faction_dreamweavers',
   },
-
+  // Buff after Dragonrage
+  EMERALD_TRANCE_T31_2PC_BUFF: {
+    id: 424402,
+    name: 'Emerald Trance',
+    icon: 'inv_legion_faction_dreamweavers',
+  },
   // Shared
   BLESSING_OF_THE_BRONZE: {
     id: 364342,

--- a/src/common/SPELLS/evoker.ts
+++ b/src/common/SPELLS/evoker.ts
@@ -107,7 +107,7 @@ const spells = {
     name: 'Lifebind',
     icon: 'ability_evoker_hoverred',
   },
-  // Devestation Spells
+  // Devastation Spells
   ETERNITY_SURGE: {
     id: 359073,
     name: 'Eternity Surge',
@@ -147,6 +147,11 @@ const spells = {
     id: 359618,
     name: 'Essence Burst',
     icon: 'ability_evoker_essenceburst',
+  },
+  EMERALD_TRANCE_T31_2PC_BUFF: {
+    id: 424155,
+    name: 'Emerald Trance',
+    icon: 'inv_legion_faction_dreamweavers',
   },
 
   // Shared


### PR DESCRIPTION
### Description

Implemented stats module for T31 2pc. Proper events aren't given for 4pc so prolly won't end up with implementing that due to complexity.

There aren't really any other changes to Deva besides number tuning so this makes Deva 10.2 ready :)

### Testing

- Test report URL: `/report/y1CX4ZDa3WpkAmzT/19-Heroic+Igira+the+Cruel+-+Wipe+6+(5:06)/Vollmer/standard/statistics`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/7dd78711-b930-4f32-b38a-930455c877f4)
