### PR TITLE
[Devastation] Split T31 stats into 2pc/4pc

### DIFF
--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+  change(date(2023, 10, 21), <>Added stats for T31 4pc buff <SpellLink spell={SPELLS.EMERALD_TRANCE_T31_2PC_BUFF}/>.</>, Vollmer),
   change(date(2023, 10, 20), <>Added stats for T31 2pc buff <SpellLink spell={SPELLS.EMERALD_TRANCE_T31_2PC_BUFF}/>.</>, Vollmer),
   change(date(2023, 9, 8), <>Add graph for <SpellLink spell={SPELLS.DISINTEGRATE}/> module for more in-depth analysis.</>, Vollmer),
   change(date(2023, 8, 25), <>Add <SpellLink spell={TALENTS.LEAPING_FLAMES_TALENT} /> module.</>, Vollmer),

--- a/src/analysis/retail/evoker/devastation/modules/dragonflight/tier/T31DevaTier.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/dragonflight/tier/T31DevaTier.tsx
@@ -40,23 +40,21 @@ class T31DevaTier extends Analyzer {
 
   onHit(event: DamageEvent) {
     if (
-      !this.selectedCombatant.hasBuff(SPELLS.EMERALD_TRANCE_T31_2PC_BUFF_STACKING.id) &&
-      !this.selectedCombatant.hasBuff(SPELLS.EMERALD_TRANCE_T31_2PC_BUFF.id)
+      !this.selectedCombatant.hasBuff(SPELLS.EMERALD_TRANCE_T31_2PC_BUFF.id) &&
+      !this.selectedCombatant.hasBuff(SPELLS.EMERALD_TRANCE_T31_4PC_BUFF.id)
     ) {
       return;
     }
-    // Post Dragonrage Buff
-    if (this.selectedCombatant.hasBuff(SPELLS.EMERALD_TRANCE_T31_2PC_BUFF.id)) {
+
+    if (this.selectedCombatant.hasBuff(SPELLS.EMERALD_TRANCE_T31_4PC_BUFF.id)) {
       this.ampedDamage4pc += calculateEffectiveDamage(
         event,
         DEVA_T31_2PC_MULTIPLER * this.buffStacks,
       );
       return;
     }
-    // During Dragonrage Buff
-    this.buffStacks = this.selectedCombatant.getBuffStacks(
-      SPELLS.EMERALD_TRANCE_T31_2PC_BUFF_STACKING.id,
-    );
+
+    this.buffStacks = this.selectedCombatant.getBuffStacks(SPELLS.EMERALD_TRANCE_T31_2PC_BUFF.id);
     this.ampedDamage2pc += calculateEffectiveDamage(
       event,
       DEVA_T31_2PC_MULTIPLER * this.buffStacks,

--- a/src/analysis/retail/evoker/devastation/modules/dragonflight/tier/T31DevaTier.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/dragonflight/tier/T31DevaTier.tsx
@@ -22,7 +22,8 @@ import { TIERS } from 'game/TIERS';
  * and grants you Essence Burst every 5 sec.
  */
 class T31DevaTier extends Analyzer {
-  ampedDamage: number = 0;
+  ampedDamage2pc: number = 0;
+  ampedDamage4pc: number = 0;
   /** We need this so we don't assume always 5 stacks
    * Since technically you can drop Dragonrage early
    * and then the buff won't be fully stacked */
@@ -46,14 +47,20 @@ class T31DevaTier extends Analyzer {
     }
     // Post Dragonrage Buff
     if (this.selectedCombatant.hasBuff(SPELLS.EMERALD_TRANCE_T31_2PC_BUFF.id)) {
-      this.ampedDamage += calculateEffectiveDamage(event, DEVA_T31_2PC_MULTIPLER * this.buffStacks);
+      this.ampedDamage4pc += calculateEffectiveDamage(
+        event,
+        DEVA_T31_2PC_MULTIPLER * this.buffStacks,
+      );
       return;
     }
     // During Dragonrage Buff
     this.buffStacks = this.selectedCombatant.getBuffStacks(
       SPELLS.EMERALD_TRANCE_T31_2PC_BUFF_STACKING.id,
     );
-    this.ampedDamage += calculateEffectiveDamage(event, DEVA_T31_2PC_MULTIPLER * this.buffStacks);
+    this.ampedDamage2pc += calculateEffectiveDamage(
+      event,
+      DEVA_T31_2PC_MULTIPLER * this.buffStacks,
+    );
   }
 
   statistic() {
@@ -65,7 +72,9 @@ class T31DevaTier extends Analyzer {
       >
         <BoringValueText label="Emerald Dream (T31 Set Bonus)">
           <h4>2 Piece</h4>
-          <ItemDamageDone amount={this.ampedDamage} />
+          <ItemDamageDone amount={this.ampedDamage2pc} />
+          <h4>4 Piece</h4>
+          <ItemDamageDone amount={this.ampedDamage4pc} />
         </BoringValueText>
       </Statistic>
     );

--- a/src/common/SPELLS/evoker.ts
+++ b/src/common/SPELLS/evoker.ts
@@ -149,13 +149,13 @@ const spells = {
     icon: 'ability_evoker_essenceburst',
   },
   // Buff during Dragonrage
-  EMERALD_TRANCE_T31_2PC_BUFF_STACKING: {
+  EMERALD_TRANCE_T31_2PC_BUFF: {
     id: 424155,
     name: 'Emerald Trance',
     icon: 'inv_legion_faction_dreamweavers',
   },
   // Buff after Dragonrage
-  EMERALD_TRANCE_T31_2PC_BUFF: {
+  EMERALD_TRANCE_T31_4PC_BUFF: {
     id: 424402,
     name: 'Emerald Trance',
     icon: 'inv_legion_faction_dreamweavers',


### PR DESCRIPTION
### Description

Had bundled 2pc/4pc damage together, now it's split it up properly.

### Testing

- Test report URL: `/report/y1CX4ZDa3WpkAmzT/19-Heroic+Igira+the+Cruel+-+Wipe+6+(5:06)/Vollmer/standard/statistics`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/b57435fd-ae23-41ea-a996-ee8ce0ff230d)
