### PR TITLE
Fix statistic ordering on stats page

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -30,6 +30,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 10, 22), 'Fix statistic ordering on the stats page.', emallson),
   change(date(2023, 10, 20), <>Refactor <ItemLink id={ITEMS.VOICE_OF_THE_SILENT_STAR.id}/> module to correcly grant and steal the correct stats depending on your current stats.</>, nullDozzer),
   change(date(2023, 10, 20), <>Add stat tracking and statistics for all Dragonflight Weapon Enchants such as <SpellLink spell={SPELLS.WAFTING_DEVOTION_ENCHANT}/> and <SpellLink spell={SPELLS.SPORE_TENDER_ENCHANT} />.</>, nullDozzer),
   change(date(2023, 10, 16), 'Fix some variable capitalizations', Trevor),

--- a/src/parser/ui/ItemStatistic.tsx
+++ b/src/parser/ui/ItemStatistic.tsx
@@ -15,4 +15,10 @@ const ItemStatistic = (props: React.ComponentProps<typeof Statistic>) => (
   />
 );
 
+// this is needed for the Masonry wrapper
+ItemStatistic.defaultProps = {
+  category: STATISTIC_CATEGORY.ITEMS,
+  position: STATISTIC_ORDER.OPTIONAL(0),
+};
+
 export default ItemStatistic;

--- a/src/parser/ui/Panel.tsx
+++ b/src/parser/ui/Panel.tsx
@@ -13,4 +13,9 @@ const Panel = ({ category = STATISTIC_CATEGORY.PANELS, position, ...others }: Pr
   </ErrorBoundary>
 );
 
+// this is needed for the Masonry wrapper
+Panel.defaultProps = {
+  category: STATISTIC_CATEGORY.PANELS,
+};
+
 export default Panel;


### PR DESCRIPTION
The stats page uses a Masonry component that expects to be able to read props, and requires `defaultProps` for that purpose.