### PR TITLE
Fix fortifying brew spell usage

### DIFF
--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2023, 10, 22), <>Fix <SpellLink spell={SPELLS.FORTIFYING_BREW_BRM} /> spell id</>, emallson),
   change(date(2023, 9, 10), <>Fix bug in <SpellLink spell={SPELLS.CELESTIAL_FORTUNE_HEAL} /> analysis related to <SpellLink spell={talents.BONEDUST_BREW_TALENT} /> triggers.</>, emallson),
   change(date(2023, 9, 10), <>Added <SpellLink spell={talents.DAMPEN_HARM_TALENT} /> DR % Statistic</>, emallson),
   change(date(2023, 7, 25), <>Update example report to be a 10.1.5 log</>, emallson),

--- a/src/analysis/retail/monk/brewmaster/modules/Abilities.ts
+++ b/src/analysis/retail/monk/brewmaster/modules/Abilities.ts
@@ -183,7 +183,7 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: talents.FORTIFYING_BREW_TALENT.id,
+        spell: SPELLS.FORTIFYING_BREW_BRM.id,
         buffSpellId: SPELLS.FORTIFYING_BREW_BRM_BUFF.id,
         category: SPELL_CATEGORY.DEFENSIVE,
         cooldown: combatant.hasTalent(talents.EXPEDITIOUS_FORTIFICATION_TALENT) ? 300 : 420,

--- a/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/FortifyingBrew.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/FortifyingBrew.tsx
@@ -28,7 +28,7 @@ export class FortifyingBrew extends MajorDefensiveBuff {
   private hasGaiPlins = false;
 
   constructor(options: Options) {
-    super(talents.FORTIFYING_BREW_TALENT, buff(SPELLS.FORTIFYING_BREW_BRM_BUFF), options);
+    super(SPELLS.FORTIFYING_BREW_BRM, buff(SPELLS.FORTIFYING_BREW_BRM_BUFF), options);
 
     this.addEventListener(Events.damage.to(SELECTED_PLAYER), this.recordDamage);
 


### PR DESCRIPTION
Fort Brew (the talent) has a different spell ID for MW/WW and also for the talent, so using the talent is broken for brew. This means that we track the buff correctly for major defensives, but not the cast (so it doesn't show correctly on the timeline or in the abilities statistics on spell usage). This fixes that.