### PR TITLE
[Hunter] Add deathblow buff to the timeline

### DIFF
--- a/src/analysis/retail/hunter/marksmanship/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/marksmanship/CHANGELOG.tsx
@@ -4,7 +4,8 @@ import { ItemLink, SpellLink } from 'interface';
 import TALENTS from 'common/TALENTS/hunter';
 import ITEMS from 'common/ITEMS';
 export default [
-  change(date(2023, 10, 3), <>Add <SpellLink spell={TALENTS.STEEL_TRAP_TALENT} /> as a trackable talent. </>, Putro),
+  change(date(2023, 10, 24), <>Add <SpellLink spell={TALENTS.DEATHBLOW_TALENT} /> buff to the timeline.</>, Putro),
+  change(date(2023, 10, 3), <>Add <SpellLink spell={TALENTS.STEEL_TRAP_TALENT} /> as a trackable talent.</>, Putro),
   change(date(2023, 7, 3), 'Update SpellLink usage.', ToppleTheNun),
   change(date(2023, 6, 4), <>Add <ItemLink id={ITEMS.CALL_TO_DOMINANCE.id}/> module to hunter</>, Trevor),
   change(date(2023, 5, 9), <>Added support for T29 tier sets</>, Swolorno),

--- a/src/analysis/retail/hunter/marksmanship/modules/Buffs.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/Buffs.tsx
@@ -22,6 +22,10 @@ class Buffs extends CoreAuras {
         triggeredBySpellId: TALENTS_HUNTER.LOCK_AND_LOAD_TALENT.id,
       },
       {
+        spellId: SPELLS.DEATHBLOW_BUFF.id,
+        timelineHighlight: true,
+      },
+      {
         spellId: SPELLS.ASPECT_OF_THE_TURTLE.id,
         timelineHighlight: true, // showing because it's relevant to know when we couldn't attack (this could explain some downtime)
         triggeredBySpellId: SPELLS.ASPECT_OF_THE_TURTLE.id,


### PR DESCRIPTION
Simple little tweak to add deathblow to the timeline for some easier analysis of missing kill shots (and help discover if the ExecuteHelper needs a bugfix)