### PR TITLE
[Dwarf] Fix dwarf racial with pets

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -30,6 +30,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 10, 26), <>Correct <SpellLink spell={SPELLS.MIGHT_OF_THE_MOUNTAIN} /> to work with pets and count them twice as the effect is effectively doubled in-game.</>, Putro),
   change(date(2023, 10, 22), 'Rename all .js files to .jsx.', ToppleTheNun),
   change(date(2023, 10, 22), 'Remove articles.', ToppleTheNun),
   change(date(2023, 10, 22), 'Fix statistic ordering on the stats page.', emallson),

--- a/src/parser/shared/modules/racials/dwarf/MightOfTheMountain.tsx
+++ b/src/parser/shared/modules/racials/dwarf/MightOfTheMountain.tsx
@@ -4,13 +4,14 @@ import HIT_TYPES from 'game/HIT_TYPES';
 import RACES from 'game/RACES';
 import ROLES from 'game/ROLES';
 import { SpellIcon } from 'interface';
-import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
 import Events, { DamageEvent, EventType, HealEvent } from 'parser/core/Events';
 import Abilities from 'parser/core/modules/Abilities';
 import CritEffectBonus, { ValidEvents } from 'parser/shared/modules/helpers/CritEffectBonus';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
 import StatisticBox from 'parser/ui/StatisticBox';
+import { isPermanentPet } from '../../pets/helpers';
 
 export const CRIT_EFFECT = 0.02;
 
@@ -37,6 +38,7 @@ class MightOfTheMountain extends Analyzer {
     (options.critEffectBonus as CritEffectBonus).hook(this.getCritEffectBonus.bind(this));
     this.addEventListener(Events.heal.by(SELECTED_PLAYER), this.onHeal);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDamage);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER_PET), this.onPetDamage);
   }
 
   isApplicableHeal(event: HealEvent) {
@@ -82,6 +84,24 @@ class MightOfTheMountain extends Analyzer {
       return;
     }
 
+    this.damage += this.critEffectBonus.getDamageContribution(event, CRIT_EFFECT);
+  }
+
+  onPetDamage(event: DamageEvent) {
+    if (!this.isApplicableDamage(event)) {
+      return;
+    }
+    const sourcePet = this.owner.playerPets.find(
+      (pet: { id: number | undefined }) => pet.id === event.sourceID,
+    );
+
+    if (!sourcePet || !isPermanentPet(sourcePet.guid)) {
+      return;
+    }
+
+    //These effects (dwarf & tauren crit mod) apply to both the player and the pet via Apply Player/Pet Aura (202) and the pet inherits from the
+    // player, effectively getting double the mod.
+    this.damage += this.critEffectBonus.getDamageContribution(event, CRIT_EFFECT);
     this.damage += this.critEffectBonus.getDamageContribution(event, CRIT_EFFECT);
   }
 

--- a/src/parser/shared/modules/racials/dwarf/MightOfTheMountain.tsx
+++ b/src/parser/shared/modules/racials/dwarf/MightOfTheMountain.tsx
@@ -11,7 +11,6 @@ import CritEffectBonus, { ValidEvents } from 'parser/shared/modules/helpers/Crit
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
 import StatisticBox from 'parser/ui/StatisticBox';
-import { isPermanentPet } from '../../pets/helpers';
 
 export const CRIT_EFFECT = 0.02;
 
@@ -89,13 +88,6 @@ class MightOfTheMountain extends Analyzer {
 
   onPetDamage(event: DamageEvent) {
     if (!this.isApplicableDamage(event)) {
-      return;
-    }
-    const sourcePet = this.owner.playerPets.find(
-      (pet: { id: number | undefined }) => pet.id === event.sourceID,
-    );
-
-    if (!sourcePet || !isPermanentPet(sourcePet.guid)) {
       return;
     }
 


### PR DESCRIPTION
Might of the Mountain didn't count pet damage, and in fact in-game the effect is provided (effectively) twice to pets (this is also the case for the tauren version of the crit damage mod) 

More info: https://github.com/simulationcraft/simc/blob/dragonflight/engine/player/pet.cpp#L514-L524 