### PR TITLE
windwalker: fix FoF channeling and APL

### DIFF
--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Durpn, Hursti, nullDozzer, Tenooki, ToppleTheNun } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 10, 26), <>Re-enable <SpellLink spell={spells.FISTS_OF_FURY_CAST}/> being a channel, and fix associated incorrect APL failures</>, Durpn),
   change(date(2023, 9, 25), 'Fix drilldown link for Chi details', nullDozzer),
   change(date(2023, 7, 3), 'Update SpellLink usage.', ToppleTheNun),
   change(date(2023, 5, 18), <>Fixed <SpellLink spell={spells.BLACKOUT_KICK}/> being flagged as an incorrect cast in the APL/Timeline when it reset <SpellLink spell={talents.RISING_SUN_KICK_TALENT} /></>, Durpn),

--- a/src/analysis/retail/monk/windwalker/CombatLogParser.ts
+++ b/src/analysis/retail/monk/windwalker/CombatLogParser.ts
@@ -39,6 +39,7 @@ import AplCheck from 'analysis/retail/monk/windwalker/modules/apl/AplCheck';
 import SpellUsable from 'analysis/retail/monk/windwalker/modules/core/SpellUsable';
 import DanceOfChiJiNormalizer from 'analysis/retail/monk/windwalker/modules/core/DanceOfChiJiNormalizer';
 import CallToDominance from 'parser/retail/modules/items/dragonflight/CallToDominance';
+import FistsOfFuryNormalizer from './normalizers/FistsOfFuryNormalizer';
 
 // Tier Set Bonuses
 // todo: add t29 tier sets
@@ -50,6 +51,7 @@ class CombatLogParser extends CoreCombatLogParser {
     mysticTouch: MysticTouch,
     spellUsable: SpellUsable,
     chiJiNormalizer: DanceOfChiJiNormalizer,
+    fofNormalizser: FistsOfFuryNormalizer,
 
     // Features
     alwaysBeCasting: AlwaysBeCasting,

--- a/src/analysis/retail/monk/windwalker/normalizers/FistsOfFuryNormalizer.tsx
+++ b/src/analysis/retail/monk/windwalker/normalizers/FistsOfFuryNormalizer.tsx
@@ -1,0 +1,26 @@
+import SPELLS from 'common/SPELLS';
+import EventOrderNormalizer, { EventOrder } from 'parser/core/EventOrderNormalizer';
+import { EventType } from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+
+const MAX_DELAY = 500;
+
+const EVENT_ORDERS: EventOrder[] = [
+  {
+    beforeEventId: SPELLS.FISTS_OF_FURY_DAMAGE.id,
+    beforeEventType: EventType.Damage,
+    afterEventId: SPELLS.FISTS_OF_FURY_CAST.id,
+    afterEventType: EventType.RemoveBuff,
+    bufferMs: MAX_DELAY,
+    anyTarget: true,
+    updateTimestamp: true,
+  },
+];
+
+class FistsOfFuryNormalizer extends EventOrderNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_ORDERS);
+  }
+}
+
+export default FistsOfFuryNormalizer;

--- a/src/parser/shared/metrics/apl/index.ts
+++ b/src/parser/shared/metrics/apl/index.ts
@@ -240,6 +240,7 @@ export interface CheckState {
   conditionState: ConditionState;
   abilityState: AbilityState;
   mostRecentBeginCast?: BeginChannelEvent;
+  mostRecentCast?: CastEvent;
   locationState: LocationState;
 }
 
@@ -408,7 +409,8 @@ export function aplProcessesEvent(
   playerId: number,
 ): event is BeginChannelEvent | CastEvent {
   return (
-    (event.type === EventType.BeginChannel ||
+    ((event.type === EventType.BeginChannel &&
+      event.ability.guid !== result.mostRecentCast?.ability.guid) ||
       (event.type === EventType.Cast &&
         event.ability.guid !== result.mostRecentBeginCast?.ability.guid)) &&
     applicableSpells.has(event.ability.guid) &&
@@ -433,6 +435,10 @@ export function knownSpells(
 }
 
 export function updateCheckState(result: CheckState, apl: Apl, event: AnyEvent): CheckState {
+  if (event.type === EventType.Cast) {
+    result.mostRecentCast = event;
+  }
+
   if (event.type === EventType.BeginChannel) {
     result.mostRecentBeginCast = event;
   } else if (event.type === EventType.EndChannel) {

--- a/src/parser/shared/normalizers/Channeling.ts
+++ b/src/parser/shared/normalizers/Channeling.ts
@@ -76,6 +76,7 @@ class Channeling extends EventsNormalizer {
     buffChannelSpec(TALENTS_MONK.ESSENCE_FONT_TALENT.id),
     buffChannelSpec(TALENTS_MONK.SOOTHING_MIST_TALENT.id),
     buffChannelSpec(SPELLS.CRACKLING_JADE_LIGHTNING.id),
+    buffChannelSpec(SPELLS.FISTS_OF_FURY_CAST.id),
     // Demon Hunter
     buffChannelSpec(TALENTS_DEMON_HUNTER.EYE_BEAM_TALENT.id), // TODO special handling because of the two buffs?
     // Shaman


### PR DESCRIPTION
### Description

FoF was breaking the APL due to both the cast and `beginchannel` being checked, causing the second one to raise a failure. Add property to track the previous cast in the APL as well as previous `beginchannel` so that we can watch for duplicates that happen in either direction.

### Testing

- Test report URL: `report/cLWkGhMRyXKN1BdT/6-Mythic+Magmorax+-+Kill+(5:37)/Durpn/standard`
- Screenshot(s):

Channel now tracked:
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1350045/f3f55547-5e29-4d6b-8e14-4c7a055a2b40)