### PR TITLE
windwalker: add SOTW to core abilities, and more FoF info

### DIFF
--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -1,10 +1,12 @@
 import { change, date } from 'common/changelog';
 import spells from 'common/SPELLS/monk';
-import talents from 'common/TALENTS/monk';
+import talents, { TALENTS_MONK } from 'common/TALENTS/monk';
 import { Durpn, Hursti, nullDozzer, Tenooki, ToppleTheNun } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 10, 27), <>Add graphs for <SpellLink spell={spells.FISTS_OF_FURY_CAST}/> to show charts of tick distribution</>, Durpn),
+  change(date(2023, 10, 27), <>Add <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT} /> to core abilities when talented</>, Durpn),
   change(date(2023, 10, 26), <>Re-enable <SpellLink spell={spells.FISTS_OF_FURY_CAST}/> being a channel, and fix associated incorrect APL failures</>, Durpn),
   change(date(2023, 9, 25), 'Fix drilldown link for Chi details', nullDozzer),
   change(date(2023, 7, 3), 'Update SpellLink usage.', ToppleTheNun),

--- a/src/analysis/retail/monk/windwalker/CombatLogParser.ts
+++ b/src/analysis/retail/monk/windwalker/CombatLogParser.ts
@@ -1,9 +1,9 @@
 import {
-  TouchOfDeath,
-  InvokersDelight,
-  MysticTouch,
   DampenHarm,
   FaelineStomp,
+  InvokersDelight,
+  MysticTouch,
+  TouchOfDeath,
 } from 'analysis/retail/monk/shared';
 import CoreCombatLogParser from 'parser/core/CombatLogParser';
 
@@ -32,14 +32,17 @@ import FistsofFury from './modules/spells/FistsofFury';
 import SpinningCraneKick from './modules/spells/SpinningCraneKick';
 import TouchOfKarma from './modules/spells/TouchOfKarma';
 // Talents
+import AplCheck from 'analysis/retail/monk/windwalker/modules/apl/AplCheck';
+import DanceOfChiJiNormalizer from 'analysis/retail/monk/windwalker/modules/core/DanceOfChiJiNormalizer';
+import SpellUsable from 'analysis/retail/monk/windwalker/modules/core/SpellUsable';
+import CallToDominance from 'parser/retail/modules/items/dragonflight/CallToDominance';
 import DanceOfChiJi from './modules/talents/DanceOfChiJi';
 import HitCombo from './modules/talents/HitCombo';
 import Serenity from './modules/talents/Serenity';
-import AplCheck from 'analysis/retail/monk/windwalker/modules/apl/AplCheck';
-import SpellUsable from 'analysis/retail/monk/windwalker/modules/core/SpellUsable';
-import DanceOfChiJiNormalizer from 'analysis/retail/monk/windwalker/modules/core/DanceOfChiJiNormalizer';
-import CallToDominance from 'parser/retail/modules/items/dragonflight/CallToDominance';
-import FistsOfFuryNormalizer from './normalizers/FistsOfFuryNormalizer';
+import {
+  FistsOfFuryLinkNormalizer,
+  FistsOfFuryNormalizer,
+} from './normalizers/FistsOfFuryNormalizer';
 
 // Tier Set Bonuses
 // todo: add t29 tier sets
@@ -51,7 +54,8 @@ class CombatLogParser extends CoreCombatLogParser {
     mysticTouch: MysticTouch,
     spellUsable: SpellUsable,
     chiJiNormalizer: DanceOfChiJiNormalizer,
-    fofNormalizser: FistsOfFuryNormalizer,
+    fofNormalizer: FistsOfFuryNormalizer,
+    fofLinkNormalizer: FistsOfFuryLinkNormalizer,
 
     // Features
     alwaysBeCasting: AlwaysBeCasting,

--- a/src/analysis/retail/monk/windwalker/modules/apl/AplCheck.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/apl/AplCheck.tsx
@@ -1,4 +1,12 @@
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/monk';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import { SpellLink } from 'interface';
+import { suggestion } from 'parser/core/Analyzer';
+import { AnyEvent } from 'parser/core/Events';
 import aplCheck, { build, Condition, PlayerInfo, Rule } from 'parser/shared/metrics/apl';
+import annotateTimeline from 'parser/shared/metrics/apl/annotate';
+import { AplRuleProps } from 'parser/shared/metrics/apl/ChecklistRule';
 import {
   and,
   buffMissing,
@@ -9,15 +17,6 @@ import {
   lastSpellCast,
   not,
 } from 'parser/shared/metrics/apl/conditions';
-import SPELLS from 'common/SPELLS';
-import { suggestion } from 'parser/core/Analyzer';
-import annotateTimeline from 'parser/shared/metrics/apl/annotate';
-import TALENTS from 'common/TALENTS/monk';
-import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
-import { SpellLink } from 'interface';
-import { AnyEvent } from 'parser/core/Events';
-import { serenityDurationRemainingLT } from 'analysis/retail/monk/windwalker/modules/apl/serenityDurationRemaining';
-import { AplRuleProps } from 'parser/shared/metrics/apl/ChecklistRule';
 
 const inSerenity = buffPresent(TALENTS.SERENITY_TALENT);
 inSerenity.describe = (tense) => '';
@@ -44,10 +43,6 @@ const hasChi = (min: number) => hasResource(RESOURCE_TYPES.CHI, { atLeast: min }
 
 export const serenityApl = build(
   [
-    {
-      spell: TALENTS.FISTS_OF_FURY_TALENT,
-      condition: serenityDurationRemainingLT(1500),
-    },
     {
       spell: TALENTS.FAELINE_STOMP_TALENT,
       condition: needsFaelineHarmony,

--- a/src/analysis/retail/monk/windwalker/modules/features/checklist/Component.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/features/checklist/Component.tsx
@@ -43,11 +43,8 @@ const WindwalkerMonkChecklist = (props: ChecklistProps & WWAplProps) => {
         {combatant.hasTalent(TALENTS_MONK.WHIRLING_DRAGON_PUNCH_TALENT) && (
           <AbilityRequirement spell={SPELLS.WHIRLING_DRAGON_PUNCH_TALENT.id} />
         )}
-        {combatant.hasTalent(TALENTS_MONK.CHI_WAVE_TALENT) && (
-          <AbilityRequirement spell={TALENTS_MONK.CHI_WAVE_TALENT.id} />
-        )}
-        {combatant.hasTalent(TALENTS_MONK.CHI_BURST_TALENT) && (
-          <AbilityRequirement spell={TALENTS_MONK.CHI_BURST_TALENT.id} />
+        {combatant.hasTalent(TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT) && (
+          <AbilityRequirement spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT.id} />
         )}
       </Rule>
       <Rule

--- a/src/analysis/retail/monk/windwalker/normalizers/FistsOfFuryNormalizer.tsx
+++ b/src/analysis/retail/monk/windwalker/normalizers/FistsOfFuryNormalizer.tsx
@@ -1,4 +1,5 @@
 import SPELLS from 'common/SPELLS';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
 import EventOrderNormalizer, { EventOrder } from 'parser/core/EventOrderNormalizer';
 import { EventType } from 'parser/core/Events';
 import { Options } from 'parser/core/Module';
@@ -15,12 +16,37 @@ const EVENT_ORDERS: EventOrder[] = [
     anyTarget: true,
     updateTimestamp: true,
   },
+  {
+    beforeEventId: SPELLS.FISTS_OF_FURY_DAMAGE.id,
+    beforeEventType: EventType.Damage,
+    afterEventId: SPELLS.FISTS_OF_FURY_CAST.id,
+    afterEventType: EventType.EndChannel,
+    bufferMs: MAX_DELAY,
+    anyTarget: true,
+    updateTimestamp: true,
+  },
 ];
 
-class FistsOfFuryNormalizer extends EventOrderNormalizer {
+export class FistsOfFuryNormalizer extends EventOrderNormalizer {
   constructor(options: Options) {
     super(options, EVENT_ORDERS);
   }
 }
 
-export default FistsOfFuryNormalizer;
+const castLink: EventLink = {
+  linkRelation: 'fof-cast',
+  linkingEventId: SPELLS.FISTS_OF_FURY_CAST.id,
+  linkingEventType: EventType.EndChannel,
+  referencedEventType: EventType.Cast,
+  referencedEventId: null,
+  forwardBufferMs: 100,
+  anySource: false,
+  anyTarget: true,
+  maximumLinks: 1,
+};
+
+export class FistsOfFuryLinkNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, [castLink]);
+  }
+}


### PR DESCRIPTION
### Description

Add SOTW to core abilities, and also add graphs to show Fists of Fury hit-ticks distribution under statistics frame.

### Testing

- Test report URL: `/report/rHN8xwnbBDV67zFc/16-Mythic+Magmorax+-+Kill+(5:33)/Chiggma/standard/overview`
- Screenshot(s):

Live:
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1350045/2983cf12-e1ba-4879-bbbe-67fb3d2cbddc)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1350045/6e0b1755-1686-45f0-9856-99975abf51e9)

New:
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1350045/aefff827-039d-4a70-aa61-ced7f6ce1bd7)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1350045/83468b3c-50bf-44ba-a485-7383bc4d2f52)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1350045/87f3b5af-b34e-49f7-9dc8-d53484058b72)

