### PR TITLE
[Preservation] Remove damage statistic from tier set and implement 2 set nerf

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { ToppleTheNun, Trevor, Tyndi, Vohrr } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 10, 27), <>Update T31 tier set module</>, Trevor),
   change(date(2023, 10, 14), <>Add T31 tier set module</>, Trevor),
   change(date(2023, 7, 23), <>Add <SpellLink spell={TALENTS_EVOKER.ANCIENT_FLAME_TALENT}/> module and guide section</>, Trevor),
   change(date(2023, 7, 13), <>Fix <SpellLink spell={TALENTS_EVOKER.REGENERATIVE_MAGIC_TALENT}/></>, Trevor),

--- a/src/analysis/retail/evoker/preservation/modules/dragonflight/tier/T31TierSet.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/dragonflight/tier/T31TierSet.tsx
@@ -2,8 +2,6 @@ import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, {
   ApplyBuffEvent,
-  DamageEvent,
-  EventType,
   HealEvent,
   RefreshBuffEvent,
   RemoveBuffEvent,
@@ -27,7 +25,6 @@ import Soup from 'interface/icons/Soup';
 import { SpellLink, TooltipElement } from 'interface';
 import { TALENTS_EVOKER } from 'common/TALENTS';
 import { formatNumber } from 'common/format';
-import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import { TIERS } from 'game/TIERS';
 import Echo from '../../talents/Echo';
 import { ECHO_HEALS } from '../../../constants';
@@ -41,8 +38,6 @@ class T31PrevokerSet extends Analyzer {
   totalEbProcs: number = 0;
   lfHealingHits: number = 0;
   lfHealing: number = 0;
-  lfDamage: number = 0;
-  lfDamageHits: number = 0;
   echoProcs: number = 0;
   echoHealing: number = 0;
   protected echo!: Echo;
@@ -67,10 +62,6 @@ class T31PrevokerSet extends Analyzer {
       Events.heal.by(SELECTED_PLAYER).spell(SPELLS.LIVING_FLAME_HEAL),
       this.onLfHit,
     );
-    this.addEventListener(
-      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.LIVING_FLAME_DAMAGE),
-      this.onLfHit,
-    );
     this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(ECHO_HEALS), this.onEchoHeal);
     this.addEventListener(
       Events.heal.by(SELECTED_PLAYER).spell(TALENTS_EVOKER.ECHO_TALENT),
@@ -82,18 +73,12 @@ class T31PrevokerSet extends Analyzer {
     );
   }
 
-  onLfHit(event: DamageEvent | HealEvent) {
+  onLfHit(event: HealEvent) {
     if (!isLfFromT31Tier(event)) {
       return;
     }
-
-    if (event.type === EventType.Damage) {
-      this.lfDamage += event.amount;
-      this.lfDamageHits += 1;
-    } else {
-      this.lfHealing += event.amount + (event.absorbed || 0);
-      this.lfHealingHits += 1;
-    }
+    this.lfHealing += event.amount + (event.absorbed || 0);
+    this.lfHealingHits += 1;
   }
 
   onEbProc(event: RemoveBuffEvent | RemoveBuffStackEvent) {
@@ -175,18 +160,6 @@ class T31PrevokerSet extends Analyzer {
                   }
                 >
                   <ItemHealingDone amount={this.lfHealing} />
-                </TooltipElement>
-              </div>
-              <div>
-                <TooltipElement
-                  content={
-                    <>
-                      <div>Total hits: {this.lfDamageHits}</div>
-                      <div>Total damage: {formatNumber(this.lfDamage)}</div>
-                    </>
-                  }
-                >
-                  <ItemDamageDone amount={this.lfDamage} />
                 </TooltipElement>
               </div>
             </div>

--- a/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
@@ -56,7 +56,6 @@ export const STASIS = 'Stasis';
 export const STASIS_FOR_RAMP = 'ForRamp';
 export const ESSENCE_RUSH = 'EssenceRush';
 export const T31_2PC = 'T31LFProc';
-export const TIER_ECHO_HEAL = 'TierEchoHeal';
 
 export enum ECHO_TYPE {
   NONE,
@@ -74,7 +73,7 @@ const MAX_ECHO_DURATION = 20000; // 15s with 30% inc = 19s
 const MAX_ESSENCE_BURST_DURATION = 32000; // 15s duration can refresh to 30s with 2s of buffer
 const TA_BUFFER_MS = 6000 + CAST_BUFFER_MS; //TA pulses over 6s at 0% haste
 const STASIS_BUFFER = 1000;
-const T31_LF_AMOUNT = 5;
+const T31_LF_AMOUNT = 3;
 
 /*
   This file is for attributing echo applications to hard casts or to temporal anomaly.
@@ -157,12 +156,8 @@ const EVENT_LINKS: EventLink[] = [
   {
     linkRelation: FROM_TIER,
     reverseLinkRelation: FROM_TIER,
-    linkingEventId: [
-      SPELLS.LIVING_FLAME_CAST.id,
-      SPELLS.LIVING_FLAME_DAMAGE.id,
-      SPELLS.LIVING_FLAME_HEAL.id,
-    ],
-    linkingEventType: [EventType.Heal, EventType.Damage, EventType.Cast],
+    linkingEventId: [SPELLS.LIVING_FLAME_CAST.id, SPELLS.LIVING_FLAME_HEAL.id],
+    linkingEventType: [EventType.Heal, EventType.Cast],
     referencedEventId: [TALENTS_EVOKER.ECHO_TALENT.id],
     referencedEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
     forwardBufferMs: STASIS_BUFFER * 3,
@@ -174,26 +169,6 @@ const EVENT_LINKS: EventLink[] = [
         !HasRelatedEvent(referencedEvent, FROM_TEMPORAL_ANOMALY) &&
         !HasRelatedEvent(referencedEvent, FROM_TIER)
       );
-    },
-    isActive(c) {
-      return c.has4PieceByTier(TIERS.T31);
-    },
-  },
-  {
-    linkRelation: TIER_ECHO_HEAL,
-    reverseLinkRelation: TIER_ECHO_HEAL,
-    linkingEventId: [
-      SPELLS.LIVING_FLAME_CAST.id,
-      SPELLS.LIVING_FLAME_DAMAGE.id,
-      SPELLS.LIVING_FLAME_HEAL.id,
-    ],
-    linkingEventType: [EventType.Heal, EventType.Damage, EventType.Cast],
-    referencedEventId: [TALENTS_EVOKER.ECHO_TALENT.id],
-    referencedEventType: EventType.Heal,
-    forwardBufferMs: STASIS_BUFFER * 3,
-    anyTarget: true,
-    additionalCondition(linkingEvent, referencedEvent) {
-      return HasRelatedEvent(linkingEvent, FROM_TIER);
     },
     isActive(c) {
       return c.has4PieceByTier(TIERS.T31);
@@ -852,10 +827,7 @@ export function isFromTAEcho(event: ApplyBuffEvent | RefreshBuffEvent | HealEven
 }
 
 export function isEchoFromT314PC(event: ApplyBuffEvent | RefreshBuffEvent | HealEvent) {
-  if (event.ability.guid === TALENTS_EVOKER.ECHO_TALENT.id) {
-    return HasRelatedEvent(event, FROM_TIER) || HasRelatedEvent(event, TIER_ECHO_HEAL);
-  }
-  return HasRelatedEvent(event, ECHO_TIER);
+  return HasRelatedEvent(event, ECHO_TIER) || HasRelatedEvent(event, FROM_TIER);
 }
 
 export function isFromDreamBreathCallOfYsera(event: ApplyBuffEvent | RefreshBuffEvent | HealEvent) {


### PR DESCRIPTION
### Description

Damage statistic is not accurate and should always be 0 in raids, so just removing it since I dont plan on fixing it.
Reduces num living flames from 2pc to 3 bc of nerf
