### PR TITLE
stop publishing merge queue as tagged docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,7 +300,7 @@ jobs:
       [typecheck, linting, prettier, test-interface, test-parser, test-integration, e2e-test, build]
     name: 'Publish Docker image'
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' && github.repository == 'wowanalyzer/wowanalyzer' && !contains(github.event.head_commit.message, '[skip ci]')
+    if: github.event_name == 'push' && github.repository == 'wowanalyzer/wowanalyzer' && !contains(github.event.head_commit.message, '[skip ci]')
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v1


### PR DESCRIPTION
Was looking at what we need to do for deploying the vite version to a subdomain. tldr is nothing, but i did notice that all of our merge queues are going up as docker versions so that is exciting.

See: https://hub.docker.com/r/wowanalyzer/wowanalyzer/tags

The `merge_group` event is for merge queues. We run CI on it, but missed that we're deploying the docker containers for it.