### PR TITLE
[Devastation] Remove rogue points in Disintegrate graph

### DIFF
--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+  change(date(2023, 10, 30), <>Removed rogue points in <SpellLink spell={SPELLS.DISINTEGRATE}/> graph.</>, Vollmer),
   change(date(2023, 10, 21), <>Added stats for T31 4pc buff <SpellLink spell={SPELLS.EMERALD_TRANCE_T31_2PC_BUFF}/>.</>, Vollmer),
   change(date(2023, 10, 20), <>Added stats for T31 2pc buff <SpellLink spell={SPELLS.EMERALD_TRANCE_T31_2PC_BUFF}/>.</>, Vollmer),
   change(date(2023, 9, 8), <>Add graph for <SpellLink spell={SPELLS.DISINTEGRATE}/> module for more in-depth analysis.</>, Vollmer),

--- a/src/analysis/retail/evoker/devastation/modules/abilities/Disintegrate.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/abilities/Disintegrate.tsx
@@ -34,12 +34,12 @@ const TICKS_PER_DISINTEGRATE = 4;
  * you have in your rotation is very important.
  *
  * This module aims to provide the user with a simple, easy and detailed way to analysis their overall
- * effeciency, as well as the ability to deepdive into individual casts.
+ * efficiency, as well as the ability to deep dive into individual casts.
  *
- * The first part of the module provides quick feedback regarding cast effeciencies based on current APL.
+ * The first part of the module provides quick feedback regarding cast efficiencies based on current APL.
  * This part provides feedback on on dropped ticks inside and outside of Dragonrage.
  *
- * The second part is a graph that shows individual Disintegrate casts aswell as the ticks.
+ * The second part is a graph that shows individual Disintegrate casts as well as the ticks.
  * This part produces a detailed overview over their entire cast history of Disintegrate.
  * Along with points pointing out good and bad casts, along with explanations.
  *
@@ -49,7 +49,7 @@ const TICKS_PER_DISINTEGRATE = 4;
  */
 
 class Disintegrate extends Analyzer {
-  /** Variables used for Clipping/Chaining effeciency */
+  /** Variables used for Clipping/Chaining efficiency */
   totalCasts: number = 0;
   totalTicks: number = 0;
   dragonRageTicks: number = 0;
@@ -114,7 +114,7 @@ class Disintegrate extends Analyzer {
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(DISINTEGRATE), this.onCast);
 
     /**
-     * We use debuff events for Disintegrate for consistentcy
+     * We use debuff events for Disintegrate for consistency
      * Since the only way to know when a disintegrate ended is on removed debuff
      * and the first damage tick happens on application not cast.
      */
@@ -164,7 +164,7 @@ class Disintegrate extends Analyzer {
       this.dragonRageTicks += 1;
     }
 
-    // This shouldnt happen but w/e
+    // This should not happen but w/e
     if (this.currentRemainingTicks === 0) {
       return;
     }
@@ -412,19 +412,19 @@ class Disintegrate extends Analyzer {
     return (
       <SubSection title="Disintegrate">
         <div>
-          Use the graph below to deepdive into your <SpellLink spell={DISINTEGRATE} /> casts.
+          Use the graph below to deep dive into your <SpellLink spell={DISINTEGRATE} /> casts.
           <ul>
             <li>
               Casts are highlighted in <span style={{ color: '#2ecc71' }}>green</span>
             </li>
             <li>
-              Chained casts are highligted in <span style={{ color: 'orange' }}>orange</span>
+              Chained casts are highlighted in <span style={{ color: 'orange' }}>orange</span>
             </li>
             <li>
-              Clipped casts are highligted in <span style={{ color: '#9b59b6' }}>purple</span>
+              Clipped casts are highlighted in <span style={{ color: '#9b59b6' }}>purple</span>
             </li>
             <li>
-              Problem points are highligted in <span style={{ color: 'red' }}>red</span>
+              Problem points are highlighted in <span style={{ color: 'red' }}>red</span>
             </li>
             <li>
               <SpellLink spell={DRAGONRAGE_TALENT} /> is shown as a filled in background.

--- a/src/analysis/retail/evoker/shared/modules/components/ExplanationGraph.tsx
+++ b/src/analysis/retail/evoker/shared/modules/components/ExplanationGraph.tsx
@@ -110,7 +110,7 @@ export const generateGraphData = (
       const timestamp = entry.timestamp;
       const count = entry.count;
 
-      if (timestamp < startTime) {
+      if (timestamp < startTime && series.type !== 'point') {
         filteredSpellTracker[0] = { timestamp: startTime, count: count };
         prevEntry = entry;
       }


### PR DESCRIPTION
### Description

Accidentally fabricated points resulting in rogue undefined points - not so good. Now those have been given some OxiClean (courtesy of Billy Mays).

### Testing

- Test report URL: `/report/H3ZDcQYNgXvpBTmL/54-Mythic++Halls+of+Infusion+-+Kill+(32:15)/Vollmer/standard/overview`

Before OxiClean 
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/b2f4360c-45c2-414b-bf09-edbe8a4d0b36)

After OxiClean
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/3dd9d8ce-90ac-421b-8c7d-8c6334769c52)
