### PR TITLE
windwalker: add guide

### DIFF
--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Durpn, Hursti, nullDozzer, Tenooki, ToppleTheNun } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 11, 1), <>Add Guide, and set it to default for Windwalker</>, Durpn),
   change(date(2023, 10, 27), <>Add graphs for <SpellLink spell={spells.FISTS_OF_FURY_CAST}/> to show charts of tick distribution</>, Durpn),
   change(date(2023, 10, 27), <>Add <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT} /> to core abilities when talented</>, Durpn),
   change(date(2023, 10, 26), <>Re-enable <SpellLink spell={spells.FISTS_OF_FURY_CAST}/> being a channel, and fix associated incorrect APL failures</>, Durpn),

--- a/src/analysis/retail/monk/windwalker/CONFIG.tsx
+++ b/src/analysis/retail/monk/windwalker/CONFIG.tsx
@@ -10,8 +10,8 @@ const config: Config = {
   contributors: [Durpn, Tenooki],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.1.0',
-  isPartial: true,
+  patchCompatibility: '10.1.7',
+  isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
@@ -48,6 +48,7 @@ const config: Config = {
     ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
+  guideDefault: true,
 };
 
 export default config;

--- a/src/analysis/retail/monk/windwalker/CombatLogParser.ts
+++ b/src/analysis/retail/monk/windwalker/CombatLogParser.ts
@@ -36,8 +36,15 @@ import AplCheck from 'analysis/retail/monk/windwalker/modules/apl/AplCheck';
 import DanceOfChiJiNormalizer from 'analysis/retail/monk/windwalker/modules/core/DanceOfChiJiNormalizer';
 import SpellUsable from 'analysis/retail/monk/windwalker/modules/core/SpellUsable';
 import CallToDominance from 'parser/retail/modules/items/dragonflight/CallToDominance';
+import Guide from './Guide';
+import ChiBurst from './modules/spells/ChiBurst';
+import RisingSunKick from './modules/spells/RisingSunKick';
+import StrikeoftheWindlord from './modules/spells/StrikeoftheWindlord';
 import DanceOfChiJi from './modules/talents/DanceOfChiJi';
 import HitCombo from './modules/talents/HitCombo';
+import HitComboGraph from './modules/talents/HitComboGraph';
+import HitComboTracker from './modules/talents/HitComboTracker';
+import InvokeXuen from './modules/talents/InvokeXuen';
 import Serenity from './modules/talents/Serenity';
 import {
   FistsOfFuryLinkNormalizer,
@@ -75,6 +82,12 @@ class CombatLogParser extends CoreCombatLogParser {
     danceOfChiJi: DanceOfChiJi,
     hitCombo: HitCombo,
     serenity: Serenity,
+    strikeoftheWindlord: StrikeoftheWindlord,
+    chiBurst: ChiBurst,
+
+    // Guide helpers
+    hitComboTracker: HitComboTracker,
+    hitComboGraph: HitComboGraph,
 
     // Spells;
     comboBreaker: ComboBreaker,
@@ -86,6 +99,8 @@ class CombatLogParser extends CoreCombatLogParser {
     blackoutKick: BlackoutKick,
     dampenHarm: DampenHarm,
     faelineStomp: FaelineStomp,
+    risingSunKick: RisingSunKick,
+    invokeXuen: InvokeXuen,
 
     // Items:
     lastEmperorsCapacitor: LastEmperorsCapacitor,
@@ -97,6 +112,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // apl
     apl: AplCheck,
   };
+  static guide = Guide;
 }
 
 export default CombatLogParser;

--- a/src/analysis/retail/monk/windwalker/Guide.tsx
+++ b/src/analysis/retail/monk/windwalker/Guide.tsx
@@ -1,0 +1,95 @@
+import SPELLS from 'common/SPELLS';
+import { TALENTS_MONK } from 'common/TALENTS';
+import { SpellLink } from 'interface';
+import { GuideProps, Section, SubSection } from 'interface/guide';
+import { AplSectionData } from 'interface/guide/components/Apl';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
+import CombatLogParser from './CombatLogParser';
+import * as AplCheck from './modules/apl/AplCheck';
+
+export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
+  return (
+    <>
+      <Section title="Core Spells and Buffs">
+        <MasteryGraph modules={modules} events={events} info={info} />
+        {modules.risingSunKick.guideSubsection}
+        {modules.fistsofFury.guideSubsection}
+        {modules.strikeoftheWindlord.guideSubsection}
+      </Section>
+      <Section title="Major cooldowns">
+        {modules.invokeXuen.guideSubsection}
+        {modules.serenity.guideSubsection}
+      </Section>
+      <Section title="Core Rotation">
+        The current iteration of Windwalker forces multiple different playstyles based on talents
+        chosen, and whether you are inside or outside of a{' '}
+        <SpellLink spell={TALENTS_MONK.SERENITY_TALENT} /> window.
+        {info.combatant.hasTalent(TALENTS_MONK.SERENITY_TALENT) && (
+          <SubSection title="During Serenity">
+            <AplSectionData checker={AplCheck.checkSerenity} apl={AplCheck.serenityApl} />
+          </SubSection>
+        )}
+        <SubSection title="Outside of Serenity">
+          <AplSectionData checker={AplCheck.checkNonSerenity} apl={AplCheck.nonSerenityApl} />
+        </SubSection>
+      </Section>
+      <Section title="Other cooldowns, buffs and procs">
+        {modules.chiBurst.guideSubsection}
+        {modules.comboBreaker.guideSubsection}
+        {modules.touchOfKarma.guideSubsection}
+      </Section>
+      <PreparationSection />
+    </>
+  );
+}
+
+function MasteryGraph({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
+  const styleObj = {
+    fontSize: 20,
+  };
+  const explanation = (
+    <>
+      <p>
+        <b>
+          <SpellLink spell={SPELLS.COMBO_STRIKES} />
+        </b>{' '}
+        is an extremely important part of playing Windwalker effectively. Dropping stacks of your
+        mastery is particularly dangerous when also running{' '}
+        <SpellLink spell={TALENTS_MONK.HIT_COMBO_TALENT} /> as it causes the mastery drop to double
+        dip.
+        {info.combatant.hasTalent(TALENTS_MONK.HIT_COMBO_TALENT) && (
+          <>
+            <br />
+            <br />
+            The graph visualizes all drops, and the time it takes to get back to the full effect.
+          </>
+        )}
+      </p>
+    </>
+  );
+
+  const data = (
+    <div>
+      <div>
+        <RoundedPanel>
+          <strong>
+            <SpellLink spell={SPELLS.COMBO_STRIKES} /> maintenance
+          </strong>
+          <div style={styleObj}>{modules.comboStrikes.subStatistic}</div>
+          {info.combatant.hasTalent(TALENTS_MONK.HIT_COMBO_TALENT) && (
+            <>
+              <strong>
+                <SpellLink spell={SPELLS.HIT_COMBO_BUFF} /> maintenance
+              </strong>
+              {modules.hitComboGraph.plot}
+            </>
+          )}
+        </RoundedPanel>
+      </div>
+    </div>
+  );
+
+  return <SubSection>{explanationAndDataSubsection(explanation, data)}</SubSection>;
+}

--- a/src/analysis/retail/monk/windwalker/modules/apl/AplCheck.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/apl/AplCheck.tsx
@@ -4,7 +4,13 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { SpellLink } from 'interface';
 import { suggestion } from 'parser/core/Analyzer';
 import { AnyEvent } from 'parser/core/Events';
-import aplCheck, { build, Condition, PlayerInfo, Rule } from 'parser/shared/metrics/apl';
+import aplCheck, {
+  build,
+  CheckResult,
+  Condition,
+  PlayerInfo,
+  Rule,
+} from 'parser/shared/metrics/apl';
 import annotateTimeline from 'parser/shared/metrics/apl/annotate';
 import { AplRuleProps } from 'parser/shared/metrics/apl/ChecklistRule';
 import {
@@ -140,6 +146,16 @@ export const nonSerenityProps = (events: AnyEvent[], info: PlayerInfo): AplRuleP
     apl: nonSerenityApl,
     checkResults: check(events, info),
   };
+};
+
+export const checkNonSerenity = (events: AnyEvent[], info: PlayerInfo): CheckResult => {
+  const check = aplCheck(nonSerenityApl);
+  return check(events, info);
+};
+
+export const checkSerenity = (events: AnyEvent[], info: PlayerInfo): CheckResult => {
+  const check = aplCheck(serenityApl);
+  return check(events, info);
 };
 
 export default suggestion((events, info) => {

--- a/src/analysis/retail/monk/windwalker/modules/spells/ChiBurst.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/spells/ChiBurst.tsx
@@ -1,0 +1,58 @@
+import { TALENTS_MONK } from 'common/TALENTS';
+import { SpellLink } from 'interface';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import Analyzer from 'parser/core/Analyzer';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
+import { GapHighlight } from 'parser/ui/CooldownBar';
+
+class ChiBurst extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+  };
+
+  protected spellUsable!: SpellUsable;
+
+  get guideSubsection(): JSX.Element {
+    const explanation = (
+      <p>
+        <b>
+          <SpellLink spell={TALENTS_MONK.CHI_BURST_TALENT} />
+        </b>{' '}
+        is a filler spell that is also very good at resetting{' '}
+        <SpellLink spell={TALENTS_MONK.FAELINE_STOMP_TALENT} />.{' '}
+        <SpellLink spell={TALENTS_MONK.CHI_BURST_TALENT} /> ideally should be used when anything
+        else would break mastery, or when movement is required and you are at risk of not being able
+        to reset your <SpellLink spell={TALENTS_MONK.FAELINE_HARMONY_TALENT} /> cooldown.
+      </p>
+    );
+
+    const data = (
+      <div>
+        <RoundedPanel>
+          <strong>
+            <SpellLink spell={TALENTS_MONK.CHI_BURST_TALENT} /> cast efficiency
+          </strong>
+          {this.guideSubStatistic()}
+        </RoundedPanel>
+      </div>
+    );
+
+    return explanationAndDataSubsection(explanation, data);
+  }
+
+  guideSubStatistic() {
+    return (
+      <CastEfficiencyBar
+        spellId={TALENTS_MONK.CHI_BURST_TALENT.id}
+        gapHighlightMode={GapHighlight.FullCooldown}
+        minimizeIcons
+        slimLines
+        useThresholds
+      />
+    );
+  }
+}
+
+export default ChiBurst;

--- a/src/analysis/retail/monk/windwalker/modules/spells/ComboStrikes.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/spells/ComboStrikes.tsx
@@ -1,15 +1,14 @@
 import { defineMessage } from '@lingui/macro';
-import { formatDuration, formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
-import { SpellIcon } from 'interface';
-import { SpellLink } from 'interface';
+import { TALENTS_MONK } from 'common/TALENTS';
+import { formatDuration, formatNumber } from 'common/format';
+import { SpellIcon, SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
-import { TALENTS_MONK } from 'common/TALENTS';
 
 import { ABILITIES_AFFECTED_BY_MASTERY } from '../../constants';
 
@@ -149,6 +148,14 @@ class ComboStrikes extends Analyzer {
           {formatNumber(this.masteryDropEvents)} <small>Mastery benefit mistakes</small>
         </BoringSpellValueText>
       </Statistic>
+    );
+  }
+
+  get subStatistic() {
+    return (
+      <>
+        {formatNumber(this.masteryDropEvents)} <small>Mastery benefit mistakes</small>
+      </>
     );
   }
 }

--- a/src/analysis/retail/monk/windwalker/modules/spells/RisingSunKick.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/spells/RisingSunKick.tsx
@@ -1,0 +1,57 @@
+import { TALENTS_MONK } from 'common/TALENTS';
+import { SpellLink } from 'interface';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import Analyzer from 'parser/core/Analyzer';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
+import { GapHighlight } from 'parser/ui/CooldownBar';
+
+class RisingSunKick extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+  };
+
+  protected spellUsable!: SpellUsable;
+
+  get guideSubsection(): JSX.Element {
+    const explanation = (
+      <p>
+        <b>
+          <SpellLink spell={TALENTS_MONK.RISING_SUN_KICK_TALENT} />
+        </b>{' '}
+        is one of your primary dps skills and should be used immediately in most cases, as dictated
+        by the APL. When <SpellLink spell={TALENTS_MONK.XUENS_BATTLEGEAR_TALENT} /> is talented,{' '}
+        <SpellLink spell={TALENTS_MONK.RISING_SUN_KICK_TALENT} /> reduces the cooldown of{' '}
+        <SpellLink spell={TALENTS_MONK.FISTS_OF_FURY_TALENT} /> by 4 seconds.
+      </p>
+    );
+
+    const data = (
+      <div>
+        <RoundedPanel>
+          <strong>
+            <SpellLink spell={TALENTS_MONK.RISING_SUN_KICK_TALENT} /> cast efficiency
+          </strong>
+          {this.guideSubStatistic()}
+        </RoundedPanel>
+      </div>
+    );
+
+    return explanationAndDataSubsection(explanation, data);
+  }
+
+  guideSubStatistic() {
+    return (
+      <CastEfficiencyBar
+        spellId={TALENTS_MONK.RISING_SUN_KICK_TALENT.id}
+        gapHighlightMode={GapHighlight.FullCooldown}
+        minimizeIcons
+        slimLines
+        useThresholds
+      />
+    );
+  }
+}
+
+export default RisingSunKick;

--- a/src/analysis/retail/monk/windwalker/modules/spells/StrikeoftheWindlord.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/spells/StrikeoftheWindlord.tsx
@@ -1,0 +1,55 @@
+import { TALENTS_MONK } from 'common/TALENTS';
+import { SpellLink } from 'interface';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import Analyzer from 'parser/core/Analyzer';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
+import { GapHighlight } from 'parser/ui/CooldownBar';
+
+class StrikeoftheWindlord extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+  };
+
+  protected spellUsable!: SpellUsable;
+
+  get guideSubsection(): JSX.Element {
+    const explanation = (
+      <p>
+        <b>
+          <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT} />
+        </b>{' '}
+        is one of your strongest medium-length cooldown dps abilities. When possible, it should be
+        lined up with your <SpellLink spell={TALENTS_MONK.SKYREACH_TALENT} /> window.
+      </p>
+    );
+
+    const data = (
+      <div>
+        <RoundedPanel>
+          <strong>
+            <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT} /> cast efficiency
+          </strong>
+          {this.guideSubStatistic()}
+        </RoundedPanel>
+      </div>
+    );
+
+    return explanationAndDataSubsection(explanation, data);
+  }
+
+  guideSubStatistic() {
+    return (
+      <CastEfficiencyBar
+        spellId={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT.id}
+        gapHighlightMode={GapHighlight.FullCooldown}
+        minimizeIcons
+        slimLines
+        useThresholds
+      />
+    );
+  }
+}
+
+export default StrikeoftheWindlord;

--- a/src/analysis/retail/monk/windwalker/modules/spells/TouchOfKarma.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/spells/TouchOfKarma.tsx
@@ -1,12 +1,17 @@
 import { defineMessage } from '@lingui/macro';
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
+import { TALENTS_MONK } from 'common/TALENTS';
 import { SpellLink } from 'interface';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import HealingDone from 'parser/shared/modules/throughput/HealingDone';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
+import { GapHighlight } from 'parser/ui/CooldownBar';
 import Statistic from 'parser/ui/Statistic';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 
@@ -85,6 +90,43 @@ class TouchOfKarma extends Analyzer {
           {formatPercentage(this.absorbUsed, 0)}% <small>Absorb used</small>
         </BoringSpellValueText>
       </Statistic>
+    );
+  }
+
+  get guideSubsection(): JSX.Element {
+    const explanation = (
+      <p>
+        <b>
+          <SpellLink spell={TALENTS_MONK.TOUCH_OF_KARMA_TALENT} />
+        </b>{' '}
+        is both a defensive and offensive cooldown, although it is mostly used offensively. It
+        should be used any time enough damage will be taken to break the shield.
+      </p>
+    );
+
+    const data = (
+      <div>
+        <RoundedPanel>
+          <strong>
+            <SpellLink spell={TALENTS_MONK.TOUCH_OF_KARMA_TALENT} /> cast efficiency
+          </strong>
+          {this.guideSubStatistic()}
+        </RoundedPanel>
+      </div>
+    );
+
+    return explanationAndDataSubsection(explanation, data);
+  }
+
+  guideSubStatistic() {
+    return (
+      <CastEfficiencyBar
+        spellId={TALENTS_MONK.TOUCH_OF_KARMA_TALENT.id}
+        gapHighlightMode={GapHighlight.FullCooldown}
+        minimizeIcons
+        slimLines
+        useThresholds
+      />
     );
   }
 }

--- a/src/analysis/retail/monk/windwalker/modules/talents/HitCombo.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/talents/HitCombo.tsx
@@ -12,8 +12,8 @@ import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 
-import { ABILITIES_AFFECTED_BY_DAMAGE_INCREASES } from '../../constants';
 import { TALENTS_MONK } from 'common/TALENTS';
+import { ABILITIES_AFFECTED_BY_DAMAGE_INCREASES } from '../../constants';
 
 const MOD_PER_STACK = 0.01;
 const MAX_STACKS = 6;

--- a/src/analysis/retail/monk/windwalker/modules/talents/HitComboGraph.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/talents/HitComboGraph.tsx
@@ -1,0 +1,14 @@
+import BuffStackGraph from 'parser/shared/modules/BuffStackGraph';
+import HitComboTracker from './HitComboTracker';
+
+export default class HitComboGraph extends BuffStackGraph {
+  static dependencies = {
+    ...BuffStackGraph.dependencies,
+    hitComboTracker: HitComboTracker,
+  };
+  hitComboTracker!: HitComboTracker;
+
+  tracker(): HitComboTracker {
+    return this.hitComboTracker;
+  }
+}

--- a/src/analysis/retail/monk/windwalker/modules/talents/HitComboTracker.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/talents/HitComboTracker.tsx
@@ -1,0 +1,12 @@
+import SPELLS from 'common/SPELLS';
+import { Options } from 'parser/core/Analyzer';
+import BuffStackTracker from 'parser/shared/modules/BuffStackTracker';
+
+export default class HitComboTracker extends BuffStackTracker {
+  static trackedBuff = SPELLS.HIT_COMBO_BUFF;
+
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+  constructor(options: Options) {
+    super(options);
+  }
+}

--- a/src/analysis/retail/monk/windwalker/modules/talents/InvokeXuen.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/talents/InvokeXuen.tsx
@@ -1,0 +1,57 @@
+import SpellUsable from 'analysis/retail/monk/windwalker/modules/core/SpellUsable';
+import { SpellLink } from 'interface';
+import Analyzer from 'parser/core/Analyzer';
+
+import { TALENTS_MONK } from 'common/TALENTS';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
+import { GapHighlight } from 'parser/ui/CooldownBar';
+
+class InvokeXuen extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+  };
+
+  protected spellUsable!: SpellUsable;
+
+  get guideSubsection(): JSX.Element {
+    const explanation = (
+      <p>
+        <b>
+          <SpellLink spell={TALENTS_MONK.INVOKE_XUEN_THE_WHITE_TIGER_TALENT} />
+        </b>{' '}
+        is one of your strongest cooldowns. When{' '}
+        <SpellLink spell={TALENTS_MONK.INVOKERS_DELIGHT_TALENT} /> is taken, you get a personal
+        bloodlust for 20 seconds, making Windwalker a very powerful two minute class.
+      </p>
+    );
+
+    const data = (
+      <div>
+        <RoundedPanel>
+          <strong>
+            <SpellLink spell={TALENTS_MONK.INVOKE_XUEN_THE_WHITE_TIGER_TALENT} /> cast efficiency
+          </strong>
+          {this.guideSubStatistic()}
+        </RoundedPanel>
+      </div>
+    );
+
+    return explanationAndDataSubsection(explanation, data);
+  }
+
+  guideSubStatistic() {
+    return (
+      <CastEfficiencyBar
+        spellId={TALENTS_MONK.INVOKE_XUEN_THE_WHITE_TIGER_TALENT.id}
+        gapHighlightMode={GapHighlight.FullCooldown}
+        minimizeIcons
+        slimLines
+        useThresholds
+      />
+    );
+  }
+}
+
+export default InvokeXuen;

--- a/src/analysis/retail/monk/windwalker/modules/talents/Serenity.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/talents/Serenity.tsx
@@ -1,6 +1,6 @@
 import { formatNumber, formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
-import { SpellIcon } from 'interface';
+import { SpellIcon, SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
 import Events, { DamageEvent } from 'parser/core/Events';
@@ -11,6 +11,10 @@ import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 
 import { ABILITIES_AFFECTED_BY_DAMAGE_INCREASES } from '../../constants';
 import { TALENTS_MONK } from 'common/TALENTS';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
+import { GapHighlight } from 'parser/ui/CooldownBar';
 
 const DAMAGE_MULTIPLIER = 0.15;
 
@@ -139,6 +143,45 @@ class Serenity extends Analyzer {
           </span>
         </BoringSpellValueText>
       </Statistic>
+    );
+  }
+
+  get guideSubsection(): JSX.Element {
+    const explanation = (
+      <p>
+        <b>
+          <SpellLink spell={TALENTS_MONK.SERENITY_TALENT} />
+        </b>{' '}
+        makes all of your abilities do amplified damage and all spenders are free for the duration.
+        This should be synced with{' '}
+        <SpellLink spell={TALENTS_MONK.INVOKE_XUEN_THE_WHITE_TIGER_TALENT} /> unless an entire cast
+        would be missed for doing so.
+      </p>
+    );
+
+    const data = (
+      <div>
+        <RoundedPanel>
+          <strong>
+            <SpellLink spell={TALENTS_MONK.SERENITY_TALENT} /> cast efficiency
+          </strong>
+          {this.guideSubStatistic()}
+        </RoundedPanel>
+      </div>
+    );
+
+    return explanationAndDataSubsection(explanation, data);
+  }
+
+  guideSubStatistic() {
+    return (
+      <CastEfficiencyBar
+        spellId={TALENTS_MONK.SERENITY_TALENT.id}
+        gapHighlightMode={GapHighlight.FullCooldown}
+        minimizeIcons
+        slimLines
+        useThresholds
+      />
     );
   }
 }


### PR DESCRIPTION
### Description

Guide also adds many new features, including:

* Graphs for FoF ticks and what clipped
* Graphs for mastery / Hit combo uptime
* Identifying when a tiger palm could have overwritten a proc but didn't (and as such, was risky)

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/bP8L6gFNTrHf9Xhz/22-Mythic+The+Amalgamation+Chamber+-+Kill+(4:11)/Durpn/standard/overview`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1350045/94902b6f-d0c2-4291-8419-2795cea7d8a5)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1350045/772dbab6-590c-4990-939e-d898273b0d21)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1350045/1b8ded79-5581-42de-afe8-8fb2461780b7)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1350045/1a772d17-c84f-445d-b9d2-f4f2ee6881cb)
