### PR TITLE
Rolling Average Active Time

### DIFF
--- a/src/analysis/retail/druid/guardian/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/guardian/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2023, 11, 11), <>Added active time graph to Guide.</>, Sref),
   change(date(2023, 11, 9), <>Added simple spell usage stats for <SpellLink spell={SPELLS.MANGLE_BEAR} />, <SpellLink spell={SPELLS.THRASH_BEAR} />, and <SpellLink spell={SPELLS.MOONFIRE_CAST} />. Marked as updated for 10.2.</>, Sref),
   change(date(2023, 6, 20), 'Update SpellLink usage.', ToppleTheNun),
   change(date(2023, 4, 24), <>Fixed a bug where <SpellLink spell={TALENTS_DRUID.PULVERIZE_TALENT} /> uses weren't being correctly detected.</>, Sref),

--- a/src/analysis/retail/druid/guardian/Guide.tsx
+++ b/src/analysis/retail/druid/guardian/Guide.tsx
@@ -95,6 +95,7 @@ function RotationSection({ modules, events, info }: GuideProps<typeof CombatLogP
           </PerformanceStrong>{' '}
         </strong>
       </p>
+      <p>{modules.alwaysBeCasting.rollingAverageUptimeGraph}</p>
       {modules.mangle.guideSubsection}
       {modules.thrash.guideSubsection}
       {modules.moonfire.guideSubsection}

--- a/src/parser/shared/modules/AlwaysBeCasting.tsx
+++ b/src/parser/shared/modules/AlwaysBeCasting.tsx
@@ -17,7 +17,7 @@ import getUptimeGraph, { UptimeHistoryEntry } from 'parser/shared/modules/getUpt
 const DEBUG = false;
 
 /** For graphing the active time rolling average, this is the length of the window used */
-export const ACTIVE_TIME_ROLLING_WINDOW_DURATION = 15000;
+export const ACTIVE_TIME_ROLLING_WINDOW_DURATION = 10_000;
 
 class AlwaysBeCasting extends Analyzer {
   static dependencies = {

--- a/src/parser/shared/modules/AlwaysBeCasting.tsx
+++ b/src/parser/shared/modules/AlwaysBeCasting.tsx
@@ -74,6 +74,15 @@ class AlwaysBeCasting extends Analyzer {
       // Only add active time for this channel, we do this when the channel is finished and use the highest of the GCD and channel time
       return false;
     }
+
+    // check if previous GCD overlaps the beginning of this one. If it does, we don't want to double-count.
+    const lastEntry = this.activeTimeSegments.at(-1);
+    if (lastEntry && lastEntry.end > event.timestamp) {
+      const overlap = lastEntry.end - event.timestamp;
+      this.activeTime -= overlap;
+      lastEntry.end = event.timestamp;
+    }
+
     this.activeTime += event.duration;
     this._handleNewUptimeSegment(event.timestamp, event.timestamp + event.duration);
     DEBUG &&

--- a/src/parser/shared/modules/getUptimeGraph.tsx
+++ b/src/parser/shared/modules/getUptimeGraph.tsx
@@ -69,6 +69,7 @@ export default function getUptimeGraph(
         encoding: {
           y: {
             field: 'activeTimePercentage',
+            title: 'Active Time',
             type: 'quantitative' as const,
             axis: {
               grid: true,
@@ -98,7 +99,7 @@ export default function getUptimeGraph(
             {
               field: 'activeTimePercentage',
               type: 'quantitative',
-              title: 'Active time %',
+              title: 'Active Time',
               format: '.0%',
             },
           ],


### PR DESCRIPTION
### Description

Added data collection and a graph getter convenience to AlwaysBeCasting in order to generate the rolling average active time over the course of the encounter. In a later PR I intend to extend this to also enable getting ActiveTime within a defined time period.

### Testing

- Test report URL: `/report/VWt9ZTmxfhQyLw14/9-Mythic+Igira+the+Cruel+-+Kill+(6:44)/11-Kirabear/standard`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/7143486/0549bcff-417a-47b2-a6b3-f87b7b321fcf)
