### PR TITLE
Add Tracking of Elemental Lariat

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -31,6 +31,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 11, 13), <>Add stat tracking and statistics for <ItemLink id={ITEMS.ELEMENTAL_LARIAT.id}/>.</>, nullDozzer),
   change(date(2023, 11, 7), 'Fix Classic class / spec ranking ids.', jazminite),
   change(date(2023, 11, 7), 'Add warning for 10.2 logs.', ToppleTheNun),
   change(date(2023, 11, 1), 'Add support for Dragonflight Season 3 dungeons.', Arlie),

--- a/src/common/ITEMS/dragonflight/crafted/index.ts
+++ b/src/common/ITEMS/dragonflight/crafted/index.ts
@@ -4,7 +4,8 @@ import Alchemy from './alchemy';
 import Inscription from './inscription';
 import Leatherworking from './leatherworking';
 import Engineering from './engineering';
+import Jewelcrafting from './jewelcrafting';
 
-const items = safeMerge(Alchemy, Engineering, Inscription, Leatherworking);
+const items = safeMerge(Alchemy, Engineering, Inscription, Leatherworking, Jewelcrafting);
 
 export default items;

--- a/src/common/ITEMS/dragonflight/crafted/jewelcrafting/index.ts
+++ b/src/common/ITEMS/dragonflight/crafted/jewelcrafting/index.ts
@@ -1,0 +1,17 @@
+/**
+ * NAME: {
+ *   id: number,
+ *   name: string,
+ *   icon: string,
+ * },
+ */
+import Item from 'common/ITEMS/Item';
+
+const items = {
+  ELEMENTAL_LARIAT: {
+    id: 193001,
+    name: 'Elemental Lariat',
+    icon: 'inv_10_jewelcrafting_necklace_necklace1_color3',
+  },
+} satisfies Record<string, Item>;
+export default items;

--- a/src/common/SPELLS/dragonflight/trinkets.ts
+++ b/src/common/SPELLS/dragonflight/trinkets.ts
@@ -51,6 +51,26 @@ const spells = {
     name: 'Accelerating Sandglass',
     icon: 'ability_bossmagistrix_timewarp2',
   },
+  ELEMENTAL_LARIAT_EMPOWERED_AIR: {
+    id: 375342,
+    name: 'Elemental Lariat - Empowered Air',
+    icon: 'inv_10_elementalcombinedfoozles_air',
+  },
+  ELEMENTAL_LARIAT_EMPOWERED_EARTH: {
+    id: 375345,
+    name: 'Elemental Lariat - Empowered Earth',
+    icon: 'inv_10_elementalcombinedfoozles_earth',
+  },
+  ELEMENTAL_LARIAT_EMPOWERED_FLAME: {
+    id: 375335,
+    name: 'Elemental Lariat - Empowered Flame',
+    icon: 'inv_10_elementalcombinedfoozles_fire',
+  },
+  ELEMENTAL_LARIAT_EMPOWERED_FROST: {
+    id: 375343,
+    name: 'Elemental Lariat - Empowered Frost',
+    icon: 'inv_10_elementalcombinedfoozles_frost',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -105,6 +105,7 @@ import AcceleratingSandglass from 'parser/retail/modules/items/dragonflight/Acce
 import UsurpedFromBeyond from 'parser/retail/modules/items/dragonflight/UsurpedFromBeyond';
 import VoiceOfTheSilentStar from 'parser/retail/modules/items/dragonflight/VoiceOfTheSilentStar';
 import AmalgamsSeventhSpine from 'parser/retail/modules/items/dragonflight/AmalgamsSeventhSpine';
+import ElementalLariat from 'parser/retail/modules/items/dragonflight/ElementalLariat';
 
 // This prints to console anything that the DI has to do
 const debugDependencyInjection = false;
@@ -223,6 +224,7 @@ class CombatLogParser {
     usurpedFromBeyond: UsurpedFromBeyond,
     voiceOfTheSilentStar: VoiceOfTheSilentStar,
     amalgamsSeventhSpine: AmalgamsSeventhSpine,
+    elementalLariat: ElementalLariat,
 
     // Enchants
     burningDevotion: BurningDevotion,

--- a/src/parser/retail/modules/items/dragonflight/ElementalLariat.tsx
+++ b/src/parser/retail/modules/items/dragonflight/ElementalLariat.tsx
@@ -1,0 +1,249 @@
+import ITEMS from 'common/ITEMS/dragonflight';
+import SPELLS from 'common/SPELLS/dragonflight';
+import { ItemLink } from 'interface';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import { Item } from 'parser/core/Events';
+import { calculateSecondaryStatDefault } from 'parser/core/stats';
+import StatTracker from 'parser/shared/modules/StatTracker';
+import { SECONDARY_STAT, getIcon, getName } from 'parser/shared/modules/features/STAT';
+import BoringItemValueText from 'parser/ui/BoringItemValueText';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import Statistic from 'parser/ui/Statistic';
+import { Fragment } from 'react';
+
+const deps = {
+  statTracker: StatTracker,
+};
+
+class ElementalLariat extends Analyzer.withDependencies(deps) {
+  item!: Item;
+  value!: number;
+  gemCounts = {
+    total: 0,
+    air: 0,
+    earth: 0,
+    fire: 0,
+    frost: 0,
+  };
+
+  constructor(options: Options) {
+    super(options);
+
+    const item = this.selectedCombatant.getItem(ITEMS.ELEMENTAL_LARIAT.id);
+    if (item == null) {
+      this.active = false;
+      return;
+    }
+    this.item = item;
+
+    this.value = calculateSecondaryStatDefault(350, 330, this.item.itemLevel);
+    this.deps.statTracker.add(SPELLS.ELEMENTAL_LARIAT_EMPOWERED_AIR.id, {
+      haste: this.value,
+    });
+    this.deps.statTracker.add(SPELLS.ELEMENTAL_LARIAT_EMPOWERED_EARTH.id, {
+      mastery: this.value,
+    });
+    this.deps.statTracker.add(SPELLS.ELEMENTAL_LARIAT_EMPOWERED_FLAME.id, {
+      crit: this.value,
+    });
+    this.deps.statTracker.add(SPELLS.ELEMENTAL_LARIAT_EMPOWERED_FROST.id, {
+      versatility: this.value,
+    });
+
+    const allGems = this.selectedCombatant.gear.flatMap(({ gems }) => gems ?? []);
+
+    for (const gem of allGems) {
+      switch (gem.id) {
+        case ITEMS.CRAFTY_ALEXSTRASZITE_R1.id:
+        case ITEMS.CRAFTY_ALEXSTRASZITE_R2.id:
+        case ITEMS.CRAFTY_ALEXSTRASZITE_R3.id:
+        case ITEMS.ENERGIZED_MALYGITE_R1.id:
+        case ITEMS.ENERGIZED_MALYGITE_R2.id:
+        case ITEMS.ENERGIZED_MALYGITE_R3.id:
+        case ITEMS.QUICK_YSEMERALD_R1.id:
+        case ITEMS.QUICK_YSEMERALD_R2.id:
+        case ITEMS.QUICK_YSEMERALD_R3.id:
+        case ITEMS.KEEN_NELTHARITE_R1.id:
+        case ITEMS.KEEN_NELTHARITE_R2.id:
+        case ITEMS.KEEN_NELTHARITE_R3.id:
+        case ITEMS.FORCEFUL_NOZDORITE_R1.id:
+        case ITEMS.FORCEFUL_NOZDORITE_R2.id:
+        case ITEMS.FORCEFUL_NOZDORITE_R3.id:
+          this.gemCounts.total += 1;
+          this.gemCounts.air += 1;
+          break;
+        case ITEMS.SENSEIS_ALEXSTRASZITE_R1.id:
+        case ITEMS.SENSEIS_ALEXSTRASZITE_R2.id:
+        case ITEMS.SENSEIS_ALEXSTRASZITE_R3.id:
+        case ITEMS.ZEN_MALYGITE_R1.id:
+        case ITEMS.ZEN_MALYGITE_R2.id:
+        case ITEMS.ZEN_MALYGITE_R3.id:
+        case ITEMS.KEEN_YSEMERALD_R1.id:
+        case ITEMS.KEEN_YSEMERALD_R2.id:
+        case ITEMS.KEEN_YSEMERALD_R3.id:
+        case ITEMS.FRACTURED_NELTHARITE_R1.id:
+        case ITEMS.FRACTURED_NELTHARITE_R2.id:
+        case ITEMS.FRACTURED_NELTHARITE_R3.id:
+        case ITEMS.PUISSANT_NOZDORITE_R1.id:
+        case ITEMS.PUISSANT_NOZDORITE_R2.id:
+        case ITEMS.PUISSANT_NOZDORITE_R3.id:
+          this.gemCounts.total += 1;
+          this.gemCounts.earth += 1;
+          break;
+        case ITEMS.DEADLY_ALEXSTRASZITE_R1.id:
+        case ITEMS.DEADLY_ALEXSTRASZITE_R2.id:
+        case ITEMS.DEADLY_ALEXSTRASZITE_R3.id:
+        case ITEMS.RADIANT_MALYGITE_R1.id:
+        case ITEMS.RADIANT_MALYGITE_R2.id:
+        case ITEMS.RADIANT_MALYGITE_R3.id:
+        case ITEMS.CRAFTY_YSEMERALD_R1.id:
+        case ITEMS.CRAFTY_YSEMERALD_R2.id:
+        case ITEMS.CRAFTY_YSEMERALD_R3.id:
+        case ITEMS.SENSEIS_NELTHARITE_R1.id:
+        case ITEMS.SENSEIS_NELTHARITE_R2.id:
+        case ITEMS.SENSEIS_NELTHARITE_R3.id:
+        case ITEMS.JAGGED_NOZDORITE_R1.id:
+        case ITEMS.JAGGED_NOZDORITE_R2.id:
+        case ITEMS.JAGGED_NOZDORITE_R3.id:
+          this.gemCounts.total += 1;
+          this.gemCounts.fire += 1;
+          break;
+        case ITEMS.RADIANT_ALEXSTRASZITE_R1.id:
+        case ITEMS.RADIANT_ALEXSTRASZITE_R2.id:
+        case ITEMS.RADIANT_ALEXSTRASZITE_R3.id:
+        case ITEMS.STORMY_MALYGITE_R1.id:
+        case ITEMS.STORMY_MALYGITE_R2.id:
+        case ITEMS.STORMY_MALYGITE_R3.id:
+        case ITEMS.ENERGIZED_YSEMERALD_R1.id:
+        case ITEMS.ENERGIZED_YSEMERALD_R2.id:
+        case ITEMS.ENERGIZED_YSEMERALD_R3.id:
+        case ITEMS.ZEN_NELTHARITE_R1.id:
+        case ITEMS.ZEN_NELTHARITE_R2.id:
+        case ITEMS.ZEN_NELTHARITE_R3.id:
+        case ITEMS.STEADY_NOZDORITE_R1.id:
+        case ITEMS.STEADY_NOZDORITE_R2.id:
+        case ITEMS.STEADY_NOZDORITE_R3.id:
+          this.gemCounts.total += 1;
+          this.gemCounts.frost += 1;
+          break;
+        default:
+          break;
+      }
+    }
+
+    console.log(this.gemCounts);
+  }
+
+  tooltip(averageBenefits: { stat: SECONDARY_STAT; averageBenefit: number }[]) {
+    const totalTriggers =
+      this.selectedCombatant.getBuffTriggerCount(SPELLS.ELEMENTAL_LARIAT_EMPOWERED_AIR.id) +
+      this.selectedCombatant.getBuffTriggerCount(SPELLS.ELEMENTAL_LARIAT_EMPOWERED_EARTH.id) +
+      this.selectedCombatant.getBuffTriggerCount(SPELLS.ELEMENTAL_LARIAT_EMPOWERED_FLAME.id) +
+      this.selectedCombatant.getBuffTriggerCount(SPELLS.ELEMENTAL_LARIAT_EMPOWERED_FROST.id);
+
+    const gemChance = [
+      {
+        type: 'Air',
+        stat: SECONDARY_STAT.HASTE,
+        count: this.gemCounts.air,
+        chance: this.gemCounts.air / this.gemCounts.total,
+      },
+      {
+        type: 'Earth',
+        stat: SECONDARY_STAT.MASTERY,
+        count: this.gemCounts.earth,
+        chance: this.gemCounts.earth / this.gemCounts.total,
+      },
+      {
+        type: 'Fire',
+        stat: SECONDARY_STAT.CRITICAL_STRIKE,
+        count: this.gemCounts.fire,
+        chance: this.gemCounts.fire / this.gemCounts.total,
+      },
+      {
+        type: 'Frost',
+        stat: SECONDARY_STAT.VERSATILITY,
+        count: this.gemCounts.frost,
+        chance: this.gemCounts.frost / this.gemCounts.total,
+      },
+    ]
+      .filter(({ count }) => count > 0)
+      .sort((a, b) => b.chance - a.chance)
+      .map(({ type, stat, count, chance }, index, list) => (
+        <Fragment key={type}>
+          {index > 0 && ', '}
+          {index === list.length - 1 && 'and '}
+          {count} {type} gems resulting in a {Math.round(chance * 100)}% chance to proc{' '}
+          {getName(stat)}
+        </Fragment>
+      ));
+
+    return (
+      <>
+        <div>
+          <ItemLink id={this.item.id} quality={this.item.quality} details={this.item} /> proced{' '}
+          {totalTriggers} times, this means you benefited an average of{' '}
+          {averageBenefits
+            .map(({ stat, averageBenefit }) => `${Math.round(averageBenefit)} ${getName(stat)}`)
+            .join(', ')}{' '}
+          over the duration of the fight.
+        </div>
+
+        <div>
+          You have {gemChance}. You have {this.gemCounts.total} elemental gems, resulting in a buff
+          duration of {5 + this.gemCounts.total} seconds.
+        </div>
+      </>
+    );
+  }
+
+  statistic() {
+    const averageBenefits = [
+      {
+        stat: SECONDARY_STAT.HASTE,
+        uptime: this.selectedCombatant.getBuffUptime(SPELLS.ELEMENTAL_LARIAT_EMPOWERED_AIR.id),
+      },
+      {
+        stat: SECONDARY_STAT.MASTERY,
+        uptime: this.selectedCombatant.getBuffUptime(SPELLS.ELEMENTAL_LARIAT_EMPOWERED_EARTH.id),
+      },
+      {
+        stat: SECONDARY_STAT.CRITICAL_STRIKE,
+        uptime: this.selectedCombatant.getBuffUptime(SPELLS.ELEMENTAL_LARIAT_EMPOWERED_FLAME.id),
+      },
+      {
+        stat: SECONDARY_STAT.VERSATILITY,
+        uptime: this.selectedCombatant.getBuffUptime(SPELLS.ELEMENTAL_LARIAT_EMPOWERED_FROST.id),
+      },
+    ]
+      .filter(({ uptime }) => uptime > 0)
+      .sort((a, b) => b.uptime - a.uptime)
+      .map(({ stat, uptime }) => ({
+        stat,
+        averageBenefit: (uptime / this.owner.fightDuration) * this.value,
+      }));
+
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE(1)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.ITEMS}
+        tooltip={this.tooltip(averageBenefits)}
+      >
+        <BoringItemValueText item={this.item}>
+          {averageBenefits.map(({ stat, averageBenefit }) => {
+            const StatIcon = getIcon(stat);
+            return (
+              <div key={stat}>
+                <StatIcon /> {Math.round(averageBenefit)} <small>{getName(stat)} over time</small>
+              </div>
+            );
+          })}
+        </BoringItemValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default ElementalLariat;

--- a/src/parser/retail/modules/items/dragonflight/ElementalLariat.tsx
+++ b/src/parser/retail/modules/items/dragonflight/ElementalLariat.tsx
@@ -132,7 +132,6 @@ class ElementalLariat extends Analyzer.withDependencies(deps) {
       }
     }
 
-    console.log(this.gemCounts);
   }
 
   tooltip(averageBenefits: { stat: SECONDARY_STAT; averageBenefit: number }[]) {

--- a/src/parser/retail/modules/items/dragonflight/ElementalLariat.tsx
+++ b/src/parser/retail/modules/items/dragonflight/ElementalLariat.tsx
@@ -183,7 +183,8 @@ class ElementalLariat extends Analyzer.withDependencies(deps) {
       <>
         <div>
           <ItemLink id={this.item.id} quality={this.item.quality} details={this.item} /> proced{' '}
-          {totalTriggers} times, this means you benefited an average of{' '}
+          {totalTriggers} times, giving {this.value} secondary stat every time, this resulted with
+          an average of{' '}
           {averageBenefits
             .map(({ stat, averageBenefit }) => `${Math.round(averageBenefit)} ${getName(stat)}`)
             .join(', ')}{' '}

--- a/src/parser/retail/modules/items/dragonflight/ElementalLariat.tsx
+++ b/src/parser/retail/modules/items/dragonflight/ElementalLariat.tsx
@@ -232,6 +232,7 @@ class ElementalLariat extends Analyzer.withDependencies(deps) {
         tooltip={this.tooltip(averageBenefits)}
       >
         <BoringItemValueText item={this.item}>
+          {averageBenefits.length < 1 && 'No procs'}
           {averageBenefits.map(({ stat, averageBenefit }) => {
             const StatIcon = getIcon(stat);
             return (

--- a/src/parser/retail/modules/items/dragonflight/ElementalLariat.tsx
+++ b/src/parser/retail/modules/items/dragonflight/ElementalLariat.tsx
@@ -131,7 +131,6 @@ class ElementalLariat extends Analyzer.withDependencies(deps) {
           break;
       }
     }
-
   }
 
   tooltip(averageBenefits: { stat: SECONDARY_STAT; averageBenefit: number }[]) {

--- a/src/parser/shared/modules/StatTracker.ts
+++ b/src/parser/shared/modules/StatTracker.ts
@@ -990,8 +990,12 @@ class StatTracker extends Analyzer {
     );
   }
 
-  _statPrint(stats: PlayerStats) {
-    return `STR=${stats.strength} AGI=${stats.agility} INT=${stats.intellect} STM=${stats.stamina} CRT=${stats.crit} HST=${stats.haste} MST=${stats.mastery} VRS=${stats.versatility} AVD=${this._currentStats.avoidance} LCH=${stats.leech} SPD=${stats.speed} ARMOR=${this._currentStats.armor}`;
+  _statPrint(stats: PlayerStats): string {
+    return Object.entries(stats)
+      .filter(([, value]) => value !== 0)
+      .map(([key, value]) => [key.slice(0, 3).toUpperCase(), value.toFixed(0)])
+      .map(([key, value]) => `${key}=${value}`)
+      .join(' ');
   }
 }
 


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

In my crusade for hunting down missing haste stats, I've found another victim in Elemental Lariat. 

Added the buffs to the StatTracker so that it can keep track of it. Also added statistical average benefit of the stats in question.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: http://localhost:3000/report/nvkB37Napb6VyJdF/4-Mythic+Kazzara,+the+Hellforged+-+Kill+(3:57)/Ouroborus/standard/statistics
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/13413409/d7a5b5b0-90b7-4817-b5d0-36d08f70a67f) ![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/13413409/b18b86be-78e5-4f20-8d01-89e1711b5582)

As a small bonus, I updated the debug-logging in the StatTracker. When printing out all stats for all changes, made it hard to read, it also ouput the current stats for some stats rather than the delta, making it harder to parse.
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/13413409/9f8ae69e-7f8a-408b-909b-75151abeafc8)


