### PR TITLE
[Devastation] Properly track dropping singular ticks in Disintegrate graph

### DIFF
--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
-  change(date(2023, 11, 12), <>Properly track dropped ticks when only 1 tick was remaining for <SpellLink spell={SPELLS.DISINTEGRATE}/> graph.</>, Vollmer),
+  change(date(2023, 11, 12), <>Properly track dropped ticks when only 1 tick is remaining for <SpellLink spell={SPELLS.DISINTEGRATE}/> graph.</>, Vollmer),
   change(date(2023, 10, 30), <>Removed rogue points in <SpellLink spell={SPELLS.DISINTEGRATE}/> graph.</>, Vollmer),
   change(date(2023, 10, 21), <>Added stats for T31 4pc buff <SpellLink spell={SPELLS.EMERALD_TRANCE_T31_2PC_BUFF}/>.</>, Vollmer),
   change(date(2023, 10, 20), <>Added stats for T31 2pc buff <SpellLink spell={SPELLS.EMERALD_TRANCE_T31_2PC_BUFF}/>.</>, Vollmer),

--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+  change(date(2023, 11, 12), <>Properly track dropped ticks when 1 tick was remaining <SpellLink spell={SPELLS.DISINTEGRATE}/> graph.</>, Vollmer),
   change(date(2023, 10, 30), <>Removed rogue points in <SpellLink spell={SPELLS.DISINTEGRATE}/> graph.</>, Vollmer),
   change(date(2023, 10, 21), <>Added stats for T31 4pc buff <SpellLink spell={SPELLS.EMERALD_TRANCE_T31_2PC_BUFF}/>.</>, Vollmer),
   change(date(2023, 10, 20), <>Added stats for T31 2pc buff <SpellLink spell={SPELLS.EMERALD_TRANCE_T31_2PC_BUFF}/>.</>, Vollmer),

--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
-  change(date(2023, 11, 12), <>Properly track dropped ticks when 1 tick was remaining <SpellLink spell={SPELLS.DISINTEGRATE}/> graph.</>, Vollmer),
+  change(date(2023, 11, 12), <>Properly track dropped ticks when only 1 tick was remaining for <SpellLink spell={SPELLS.DISINTEGRATE}/> graph.</>, Vollmer),
   change(date(2023, 10, 30), <>Removed rogue points in <SpellLink spell={SPELLS.DISINTEGRATE}/> graph.</>, Vollmer),
   change(date(2023, 10, 21), <>Added stats for T31 4pc buff <SpellLink spell={SPELLS.EMERALD_TRANCE_T31_2PC_BUFF}/>.</>, Vollmer),
   change(date(2023, 10, 20), <>Added stats for T31 2pc buff <SpellLink spell={SPELLS.EMERALD_TRANCE_T31_2PC_BUFF}/>.</>, Vollmer),

--- a/src/analysis/retail/evoker/devastation/modules/abilities/Disintegrate.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/abilities/Disintegrate.tsx
@@ -297,7 +297,7 @@ class Disintegrate extends Analyzer {
         });
       }
     } // We clipped outside of Dragonrage, bad
-    else if (this.currentRemainingTicks > 1) {
+    else if (this.currentRemainingTicks >= 1) {
       if (this.disintegrateClipSpell) {
         this.problemPoints.push({
           timestamp: event.timestamp,


### PR DESCRIPTION
### Description

Changed `>1` into `>=1` so when 1 tick is being dropped it will properly track it.

### Testing

- Test report URL: `/report/tqw2Y8hLf41PmMAV/21-Heroic+Rashok,+the+Elder+-+Kill+(4:01)/Johnnydragon/standard/overview`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/bae4ffcf-fe60-4bb0-8876-6b607b599924)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/fff27b25-d4fb-44f3-b0c3-a0925ba5d880)

