### PR TITLE
[Augmentation] Re-enable Breath of Eons helper module

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+    change(date(2023, 11, 14), <>Update blacklist for new non-class abilities and re-enable Breath Helper module.</>, Vollmer),
     change(date(2023, 10, 21), <>Add statistics for T31 4pc.</>, Vollmer),
     change(date(2023, 10, 20), <>Update <SpellLink spell={SPELLS.EBON_MIGHT_BUFF_EXTERNAL} /> module to account for T31 2pc.</>, Vollmer),
     change(date(2023, 10, 18), <>Fix an error with trying to display graphs without data.</>, Vollmer),

--- a/src/analysis/retail/evoker/augmentation/constants.tsx
+++ b/src/analysis/retail/evoker/augmentation/constants.tsx
@@ -35,6 +35,7 @@ export const TREMBLING_EART_STACK_LIMIT = 5;
 
 /** SpellIds to blacklist, ie. trinkets that doesnt add contribution */
 export const ABILITY_BLACKLIST: number[] = [
+  409632, // Breath of Eons
   402583, // Beacon
   408682, // Dragonfire Bomb Dispenser
   408694, // Dragonfire Bomb Dispenser

--- a/src/analysis/retail/evoker/augmentation/constants.tsx
+++ b/src/analysis/retail/evoker/augmentation/constants.tsx
@@ -37,6 +37,7 @@ export const TREMBLING_EART_STACK_LIMIT = 5;
 export const ABILITY_BLACKLIST: number[] = [
   402583, // Beacon
   408682, // Dragonfire Bomb Dispenser
+  408694, // Dragonfire Bomb Dispenser
   401324, // Pocket Anvil (Echoed Flare)
   401306, // Pocket Anvil (Anvil Strike)
   401422, // Vessel of Searing Shadow (Shadow Spike)
@@ -47,10 +48,6 @@ export const ABILITY_BLACKLIST: number[] = [
   418607, // Mirror of Fractured Tomorrows (Sand Bolt)
   406251, // Roiling Shadowflame
   406889, // Roiling Shadowflame (Self Harm)
-  400223, // Thorns of Iron
-  322109, // Touch of Death
-  124280, // Touch of Karma
-  184689, // Shield of Vengeance
   379403, // Toxic Thorn Footwraps (Launched Thorns)
   408791, // Ashkandur, Fall of the Brotherhood
   378426, // Slimy Expulsion Boots boots (Corrosive Slime)
@@ -65,5 +62,38 @@ export const ABILITY_BLACKLIST: number[] = [
   281721, // Bile-Stained Crawg Tusks (Vile Bile)
   214397, // Mark of Dargrul (Landslide)
   408469, // Call to Suffering (Self Harm)
-  409632, // Breath of Eons
+  374087, // Glacial Fury
+  370817, // Shocking Disclosure
+  426564, // Augury of the Primal Flame (Annihilating Flame)
+  417458, // Accelerating Sandglass
+  424965, // Thorn Spirit
+  425181, // Thorn Blast
+  419737, // Timestrike
+  265953, // Touch of Gold
+  425154, // Vicious Brand
+  425156, // Radiating Brand
+  422146, // Solar Maelstrom
+  426341, // Tindral's Fowl Fantasia
+  426431, // Denizen Of The Flame
+  426486, // Denizen Of The Flame Final
+  426339, // Igiras Cruel Nightmare
+  426527, // Flaying Torment
+  259756, // Entropic Embrace
+  427209, // Web of Dreams
+  422956, // Essence Splice
+  424324, // Hungering Shadowflame
+  419279, // Extinction Blast
+  215444, // Dark Blast
+  214168, // Brutal Haymaker
+  214169, // Brutal Haymaker
+  228784, // Brutal Haymaker Vulnerability
+  214350, // Nightmare Essence
+  422750, // Shadowflame Rage
+  425701, // Shadowflame Lash Enemy
+  422750, // Tainted Heart
+  425461, // Tainted Heart Enemy Damage
+  417458, // Accelerating Sandglass
+  215407, // Dark Blast
+  270827, // Webweavers Soul Gem
+  213785, // Nightfall
 ];

--- a/src/analysis/retail/evoker/augmentation/modules/breahtofeons/BreathOfEonsRotational.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/breahtofeons/BreathOfEonsRotational.tsx
@@ -29,7 +29,7 @@ import trinkets from 'common/ITEMS/dragonflight/trinkets';
 import Combatant from 'parser/core/Combatant';
 import Combatants from 'parser/shared/modules/Combatants';
 import { SpellTracker } from 'analysis/retail/evoker/shared/modules/components/ExplanationGraph';
-//import BreathOfEonsHelper from './BreathOfEonsHelper';
+import BreathOfEonsHelper from './BreathOfEonsHelper';
 
 export type BreathOfEonsWindows = {
   flightData: SpellTracker[];
@@ -575,7 +575,7 @@ class BreathOfEonsRotational extends Analyzer {
       />
     );
   }
-  /* helperSection(): JSX.Element | null {
+  helperSection(): JSX.Element | null {
     if (!this.active) {
       return null;
     }
@@ -587,7 +587,7 @@ class BreathOfEonsRotational extends Analyzer {
         owner={this.owner}
       />
     );
-  } */
+  }
 }
 
 export default BreathOfEonsRotational;

--- a/src/analysis/retail/evoker/augmentation/modules/guide/Helpers.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/guide/Helpers.tsx
@@ -5,14 +5,6 @@ import CombatLogParser from '../../CombatLogParser';
 import { SpellLink } from 'interface';
 
 export function Helpers({ modules }: GuideProps<typeof CombatLogParser>) {
-  /* return (
-    <Section title="Helper Modules">
-      <big>
-        <p>Disabled for now until we can ensure proper combat log hooks are implemented.</p>
-        <p>Will hopefully return soon!</p>
-      </big>
-    </Section>
-  ); */
   return (
     <Section title="Helper Modules">
       <p>

--- a/src/analysis/retail/evoker/augmentation/modules/guide/Helpers.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/guide/Helpers.tsx
@@ -1,4 +1,4 @@
-import { GuideProps, Section } from 'interface/guide';
+import { GuideProps, Section, SubSection } from 'interface/guide';
 import { TALENTS_EVOKER } from 'common/TALENTS';
 import SPELLS from 'common/SPELLS';
 import CombatLogParser from '../../CombatLogParser';
@@ -31,6 +31,14 @@ export function Helpers({ modules }: GuideProps<typeof CombatLogParser>) {
       </p>
       {/* {modules.buffTargetHelper.guideSubsection()} */}
       {modules.breathOfEonsRotational.helperSection()}
+      <SubSection>
+        <p>
+          <strong>
+            Buff Helper module remains disabled for now due to its current implementation relying
+            heavily on proper combat log hooks.
+          </strong>
+        </p>
+      </SubSection>
     </Section>
   );
 }

--- a/src/analysis/retail/evoker/augmentation/modules/guide/Helpers.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/guide/Helpers.tsx
@@ -1,19 +1,19 @@
 import { GuideProps, Section } from 'interface/guide';
-//import { TALENTS_EVOKER } from 'common/TALENTS';
-//import SPELLS from 'common/SPELLS';
+import { TALENTS_EVOKER } from 'common/TALENTS';
+import SPELLS from 'common/SPELLS';
 import CombatLogParser from '../../CombatLogParser';
-//import { SpellLink } from 'interface';
+import { SpellLink } from 'interface';
 
 export function Helpers({ modules }: GuideProps<typeof CombatLogParser>) {
-  return (
+  /* return (
     <Section title="Helper Modules">
       <big>
         <p>Disabled for now until we can ensure proper combat log hooks are implemented.</p>
         <p>Will hopefully return soon!</p>
       </big>
     </Section>
-  );
-  /* return (
+  ); */
+  return (
     <Section title="Helper Modules">
       <p>
         Determining the optimal targets for your buffs, such as{' '}
@@ -29,8 +29,8 @@ export function Helpers({ modules }: GuideProps<typeof CombatLogParser>) {
           until you click the <span className="clickToLoad">Click to load</span> buttons.
         </strong>
       </p>
-      {modules.buffTargetHelper.guideSubsection()}
+      {/* {modules.buffTargetHelper.guideSubsection()} */}
       {modules.breathOfEonsRotational.helperSection()}
     </Section>
-  ); */
+  );
 }


### PR DESCRIPTION
### Description

Got a hold of the new abilities without `Allow Class Ability Procs` and was able to update the blacklist; therefore this helper can be re-enabled :)
Extended reasoning as to why Breath of Eons can be enabled with broken hooks: Breath of Eons is based entirely on *actual* damage done, so even if everything is broken it will always be accurate, as long as we blacklist/ignore non class abilities.

Current implementation of the buff helper makes it unrealiable for now, so it remains disbaled. Need to revisit it at a later point.

### Testing

- Test report URL: `/report/tqw2Y8hLf41PmMAV/21-Heroic+Rashok,+the+Elder+-+Kill+(4:01)/Helaug/standard/overview`

