### PR TITLE
[Disc] Void Summoner analyzer

### DIFF
--- a/src/analysis/retail/priest/discipline/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/discipline/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 11, 14), <>Add tracker for <SpellLink spell={TALENTS_PRIEST.VOID_SUMMONER_TALENT} /> CDR.</>, Arlie),
   change(date(2023, 11, 1), 'Added Amirdrassil 4p tracker.', Arlie),
   change(date(2023, 10, 27), <>Enable spec with 10.2 changes.</>, Arlie),
   change(date(2023, 10, 8), <>Updated <SpellLink spell={TALENTS_PRIEST.SHADOW_COVENANT_TALENT}/> for revamp - the heal has been removed and has various amps depending on talents selected.</>, Hana),

--- a/src/analysis/retail/priest/discipline/CombatLogParser.ts
+++ b/src/analysis/retail/priest/discipline/CombatLogParser.ts
@@ -68,6 +68,7 @@ import Benevolence from '../shared/Benevolence';
 import WordsOfThePious from './modules/spells/WordsOfThePious';
 import HeavensWrath from './modules/spells/HeavensWrath';
 import Amirdrassil4p from './modules/spells/Amirdrassil4p';
+import VoidSummoner from './modules/spells/VoidSummoner';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -145,6 +146,7 @@ class CombatLogParser extends CoreCombatLogParser {
     wordsOfThePious: WordsOfThePious,
     heavensWrath: HeavensWrath,
     amirdrassil4p: Amirdrassil4p,
+    voidSummoner: VoidSummoner,
 
     // Items:
     radiantProvidence: RadiantProvidence,

--- a/src/analysis/retail/priest/discipline/modules/spells/VoidSummoner.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/VoidSummoner.tsx
@@ -1,0 +1,45 @@
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/priest';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent } from 'parser/core/Events';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+
+const REDUCTION_SHADOWFIEND = 4000;
+const REDUCTION_MINDBENDER = 2000;
+
+class VoidSummoner extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+  };
+
+  protected spellUsable!: SpellUsable;
+
+  spellID: number = SPELLS.SHADOWFIEND.id;
+  cdrAmount: number = REDUCTION_SHADOWFIEND;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS.VOID_SUMMONER_TALENT);
+
+    if (this.selectedCombatant.hasTalent(TALENTS.MINDBENDER_DISCIPLINE_TALENT)) {
+      this.spellID = TALENTS.MINDBENDER_DISCIPLINE_TALENT.id;
+      this.cdrAmount = REDUCTION_MINDBENDER;
+    }
+
+    this.addEventListener(
+      Events.cast
+        .by(SELECTED_PLAYER)
+        .spell([SPELLS.SMITE, SPELLS.MIND_BLAST, SPELLS.PENANCE_CAST, SPELLS.DARK_REPRIMAND_CAST]),
+      this.onCdrCast,
+    );
+  }
+
+  onCdrCast(event: CastEvent) {
+    if (this.spellUsable.isOnCooldown(this.spellID)) {
+      this.spellUsable.reduceCooldown(this.spellID, this.cdrAmount, event.timestamp);
+    }
+  }
+}
+
+export default VoidSummoner;


### PR DESCRIPTION
### Description

This fixes the CDR tracking for Shadowfiend / Mindbender when having the Void Summoner talent. (errors in console)
<!-- A brief description of the changes made with this pull request.-->

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/bA1c23ZvaWnPNjM8/15-Heroic+Gnarlroot+-+Kill+(4:00)/Yevo/standard/character`
