### PR TITLE
[Hunter] Add Call of the Wild to the spellbook and update Barbed Shot cast evaluation

### DIFF
--- a/src/analysis/retail/hunter/beastmastery/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/beastmastery/CHANGELOG.tsx
@@ -5,6 +5,8 @@ import TALENTS from 'common/TALENTS/hunter';
 import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 export default [
+  change(date(2023, 11, 21), <>Update when <SpellLink spell={TALENTS.BARBED_SHOT_TALENT}  /> are marked as good or bad casts. </>, Putro),
+  change(date(2023, 11, 21), <>Add <SpellLink spell={TALENTS.CALL_OF_THE_WILD_TALENT} /> to the spellbook specifying cooldown and global cooldown. </>, Putro),
   change(date(2023, 10, 18), <>Enable spec with 10.2 changes</>,Arlie),
   change(date(2023, 10, 3), <>Add <SpellLink spell={TALENTS.STEEL_TRAP_TALENT} /> as a trackable talent. </>, Putro),
   change(date(2023, 7, 29), 'Mark Beast Mastery as compatible for 10.1.5', Putro),

--- a/src/analysis/retail/hunter/beastmastery/modules/Abilities.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/Abilities.tsx
@@ -172,6 +172,15 @@ class Abilities extends CoreAbilities {
           recommendedEfficiency: 0.85,
         },
       },
+      {
+        spell: TALENTS.CALL_OF_THE_WILD_TALENT.id,
+        category: SPELL_CATEGORY.ROTATIONAL,
+        cooldown: 120,
+        enabled: combatant.hasTalent(TALENTS.CALL_OF_THE_WILD_TALENT),
+        gcd: {
+          base: 1500,
+        },
+      },
       //endregion
 
       //region Baseline Defensives

--- a/src/analysis/retail/hunter/beastmastery/modules/talents/BarbedShot.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/talents/BarbedShot.tsx
@@ -322,17 +322,19 @@ class BarbedShot extends Analyzer {
         <br />
       </>
     );
+
     if (frenzyBuffRemaining > 0 && frenzyBuffRemaining < currentGCDWithBuffer) {
       const tooltip = (
         <>
           {baseTooltip}
-          You refreshed <SpellLink spell={SPELLS.BARBED_SHOT_PET_BUFF} /> with
+          You refreshed <SpellLink spell={SPELLS.BARBED_SHOT_PET_BUFF} /> with{' '}
           {(frenzyBuffRemaining / 1000).toFixed(2)} seconds remaining.
         </>
       );
       this.castEntries.push({ value: QualitativePerformance.Good, tooltip, event });
       return;
     }
+
     if (
       currentBarbedShotStacks < MAX_FRENZY_STACKS &&
       this.selectedCombatant.hasTalent(TALENTS.SCENT_OF_BLOOD_TALENT) &&
@@ -348,22 +350,6 @@ class BarbedShot extends Analyzer {
           <br />
           Pet had {currentBarbedShotStacks} stacks of{' '}
           <SpellLink spell={SPELLS.BARBED_SHOT_PET_BUFF} />.
-        </>
-      );
-      this.castEntries.push({ value: QualitativePerformance.Good, tooltip, event });
-      return;
-    }
-
-    if (
-      this.selectedCombatant.hasTalent(TALENTS.WILD_INSTINCTS_TALENT) &&
-      this.selectedCombatant.hasBuff(TALENTS.CALL_OF_THE_WILD_TALENT.id)
-    ) {
-      const tooltip = (
-        <>
-          {baseTooltip}
-          You had <SpellLink spell={TALENTS.CALL_OF_THE_WILD_TALENT} /> running with{' '}
-          <SpellLink spell={TALENTS.WILD_INSTINCTS_TALENT} /> talented giving you a large amount of
-          resets to offset more aggressive usage of <SpellLink spell={TALENTS.BARBED_SHOT_TALENT} />
         </>
       );
       this.castEntries.push({ value: QualitativePerformance.Good, tooltip, event });
@@ -401,6 +387,7 @@ class BarbedShot extends Analyzer {
       this.castEntries.push({ value: QualitativePerformance.Good, tooltip, event });
       return;
     }
+
     if (
       this.selectedCombatant.hasTalent(TALENTS.SCENT_OF_BLOOD_TALENT) &&
       bestialWrathOnCooldown &&
@@ -418,6 +405,20 @@ class BarbedShot extends Analyzer {
       this.castEntries.push({ value: QualitativePerformance.Good, tooltip, event });
       return;
     }
+
+    if (this.selectedCombatant.hasTalent(TALENTS.SAVAGERY_TALENT)) {
+      const tooltip = (
+        <>
+          {baseTooltip}
+          You used <SpellLink spell={TALENTS.BARBED_SHOT_TALENT} /> while talented into{' '}
+          <SpellLink spell={TALENTS.SAVAGERY_TALENT} /> giving your{' '}
+          <SpellLink spell={SPELLS.BARBED_SHOT_PET_BUFF} /> a longer duration.
+        </>
+      );
+      this.castEntries.push({ value: QualitativePerformance.Good, tooltip, event });
+      return;
+    }
+
     const badTooltip = (
       <>
         {baseTooltip} You didn't fulfill any of the criteria of casting a good{' '}


### PR DESCRIPTION
This talent was never used before so it was missed in the spellbook.
Updating some barbed shot logic based on new talents. 