### PR TITLE
[Enhancement Shaman] Update to 10.2

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -37,6 +37,7 @@ export default [
   change(date(2023, 11, 28), 'Remove deprecated Shadowlands combatantinfo that was breaking the Holy Priest analyzer.', emallson),
   change(date(2023, 11, 27), <>Fix inaccurate tooltip for <ItemLink id={ITEMS.ELEMENTAL_LARIAT.id}/>.</>, Trevor),
   change(date(2023, 11, 27), 'Change trinket obj structure and add Classic WotLK trinkets', jazminite),
+  change(date(2023, 11, 25), <>Change range check shortcut from 'less than' to 'less than or equal to'</>, Seriousnes),
   change(date(2023, 11, 23), 'Refactor Code Smell Missing Union Type.', LucasLevyOB),
   change(date(2023, 11, 19), 'Improve error reporting integration.', ToppleTheNun),
   change(date(2023, 11, 19), 'Remove warning for 10.2 logs.', ToppleTheNun),

--- a/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
@@ -1,23 +1,26 @@
 import { change, date } from 'common/changelog';
-import SPELLS from 'common/SPELLS';
-import { TALENTS_SHAMAN } from 'common/TALENTS';
+import SPELLS from 'common/SPELLS/shaman';
+import TALENTS from 'common/TALENTS/shaman';
 import { Taum, Vetyst, Vohrr, xunni, Seriousnes, ToppleTheNun, Putro } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 11, 29), <>Defensives added to guide, <SpellLink spell={TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT} /> usage analysis, <SpellLink spell={TALENTS.ELEMENTAL_ASSAULT_TALENT} /> statistics</>, Seriousnes),
   change(date(2023, 11, 26), 'Resolve errors for unhandled abilities in the MealstromWeaponSpenders module.', Vetyst),
-  change(date(2023, 9, 22), <>Minor ajustment to APL for <SpellLink spell={TALENTS_SHAMAN.ICE_STRIKE_TALENT} />, added <SpellLink spell={SPELLS.MAELSTROM_WEAPON} /> usage and efficiency tables</>, Seriousnes),
+  change(date(2023, 11, 25), <>Updating APL to support 10.2, <SpellLink spell={TALENTS.HOT_HAND_TALENT} /> analysis, tier bonus statistics</>, Seriousnes),
+  change(date(2023, 11, 22), <>Added detailed statistics for <SpellLink spell={TALENTS.MAELSTROM_WEAPON_TALENT} /> source</>, Seriousnes),
+  change(date(2023, 9, 22), <>Minor ajustment to APL for <SpellLink spell={TALENTS.ICE_STRIKE_TALENT} />, added <SpellLink spell={SPELLS.MAELSTROM_WEAPON} /> usage and efficiency tables</>, Seriousnes),
   change(date(2023, 9, 7), <>Updated to 10.1.7 compatibility</>, Seriousnes),
   change(date(2023, 9, 6), <>Reworked maelstrom tracker, added spender link and analyzer. Added maelstrom efficiency details</>, Seriousnes),
-  change(date(2023, 9, 6), <>Fixed <SpellLink spell={TALENTS_SHAMAN.DEEPLY_ROOTED_ELEMENTS_TALENT} /> statistic having one more proc than actually occured</>, Seriousnes),
-  change(date(2023, 9, 6), <>Fix <SpellLink spell={TALENTS_SHAMAN.ELEMENTAL_BLAST_ENHANCEMENT_TALENT} /> not working after 10.1.7.</>, Putro),
+  change(date(2023, 9, 6), <>Fixed <SpellLink spell={TALENTS.DEEPLY_ROOTED_ELEMENTS_TALENT} /> statistic having one more proc than actually occured</>, Seriousnes),
+  change(date(2023, 9, 6), <>Fix <SpellLink spell={TALENTS.ELEMENTAL_BLAST_ENHANCEMENT_TALENT} /> not working after 10.1.7.</>, Putro),
   change(date(2023, 8, 4), <>Added filler spell details to Ascendance analyzer</>, Seriousnes),
   change(date(2023, 7, 31), <>Updated example report</>, Seriousnes),
   change(date(2023, 7, 31), <>Reordered guide sections</>, Seriousnes),
-  change(date(2023, 7, 30), <>Added <SpellLink spell={TALENTS_SHAMAN.DEEPLY_ROOTED_ELEMENTS_TALENT} /> statistic</>, Seriousnes),
-  change(date(2023, 7, 26), <>Swapped <SpellLink spell={TALENTS_SHAMAN.ICE_STRIKE_TALENT} /> and <SpellLink spell={TALENTS_SHAMAN.LAVA_LASH_TALENT} /> order in APL</>, Seriousnes),
-  change(date(2023, 7, 26), <><SpellLink spell={TALENTS_SHAMAN.ELEMENTAL_BLAST_ENHANCEMENT_TALENT} /> cooldown should not be reduced by haste</>, Seriousnes),
-  change(date(2023, 7, 25), <>Adding <SpellLink spell={TALENTS_SHAMAN.ASCENDANCE_ENHANCEMENT_TALENT} /> cooldown analysis</>, Seriousnes),
+  change(date(2023, 7, 30), <>Added <SpellLink spell={TALENTS.DEEPLY_ROOTED_ELEMENTS_TALENT} /> statistic</>, Seriousnes),
+  change(date(2023, 7, 26), <>Swapped <SpellLink spell={TALENTS.ICE_STRIKE_TALENT} /> and <SpellLink spell={TALENTS.LAVA_LASH_TALENT} /> order in APL</>, Seriousnes),
+  change(date(2023, 7, 26), <><SpellLink spell={TALENTS.ELEMENTAL_BLAST_ENHANCEMENT_TALENT} /> cooldown should not be reduced by haste</>, Seriousnes),
+  change(date(2023, 7, 25), <>Adding <SpellLink spell={TALENTS.ASCENDANCE_ENHANCEMENT_TALENT} /> cooldown analysis</>, Seriousnes),
   change(date(2023, 7, 24), <>Added Windstrike analyzer for max casts</>, Seriousnes),
   change(date(2023, 7, 11), <>Added patch 10.1.5 details.</>, Seriousnes),
   change(date(2023, 7, 8), 'Update SpellLink usage.', ToppleTheNun),

--- a/src/analysis/retail/shaman/enhancement/CombatLogParser.tsx
+++ b/src/analysis/retail/shaman/enhancement/CombatLogParser.tsx
@@ -42,8 +42,9 @@ import GlobalCooldown from 'parser/shared/modules/GlobalCooldown';
 import CallToDominance from 'parser/retail/modules/items/dragonflight/CallToDominance';
 import AshenCatalyst from './modules/talents/AshenCatalyst';
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
-import AscendanceNormalizer from 'analysis/retail/shaman/enhancement/modules/normalizers/AscendanceNormalizer';
-import Ascendance from 'analysis/retail/shaman/enhancement/modules/talents/Ascendance';
+import AscendanceNormalizer from './modules/normalizers/AscendanceNormalizer';
+import Ascendance from './modules/talents/Ascendance';
+import SplinteredElements from '../shared/talents/SplinteredElements';
 import {
   MaelstromWeaponDetails,
   MaelstromWeaponGraph,
@@ -105,6 +106,7 @@ class CombatLogParser extends CoreCombatLogParser {
     legacyOfTheFrostWitch: LegacyOfTheFrostWitch,
     thorimsInvocation: ThorimsInvocation,
     ashenCatalyst: AshenCatalyst,
+    splinteredElements: SplinteredElements,
 
     // Tier
     tier28TwoSet: Tier28TwoSet,

--- a/src/analysis/retail/shaman/enhancement/CombatLogParser.tsx
+++ b/src/analysis/retail/shaman/enhancement/CombatLogParser.tsx
@@ -45,6 +45,9 @@ import CooldownThroughputTracker from './modules/features/CooldownThroughputTrac
 import ProcNormalizer from './modules/normalizers/ProcNormalizer';
 import Ascendance from './modules/talents/Ascendance';
 import SplinteredElements from '../shared/talents/SplinteredElements';
+import SwirlingMaelstrom from './modules/talents/SwirlingMaelstrom';
+import MaelstromWeaponBuffNormalizer from './modules/normalizers/MaelstromWeaponBuffNormalizer';
+import MaelstromWeaponGeneratorLinkNormalizer from './modules/normalizers/MaelstromWeaponGeneratorLinkNormalizer';
 import {
   MaelstromWeaponDetails,
   MaelstromWeaponGraph,
@@ -107,6 +110,7 @@ class CombatLogParser extends CoreCombatLogParser {
     thorimsInvocation: ThorimsInvocation,
     ashenCatalyst: AshenCatalyst,
     splinteredElements: SplinteredElements,
+    swirlingMaelstrom: SwirlingMaelstrom,
 
     // Tier
     tier28TwoSet: Tier28TwoSet,
@@ -117,6 +121,8 @@ class CombatLogParser extends CoreCombatLogParser {
     callToDominance: CallToDominance,
 
     // Normalizers
+    maelstromWeaponBuffNormalizer: MaelstromWeaponBuffNormalizer,
+    maelstromWeaponGeneratorLinkNormalizer: MaelstromWeaponGeneratorLinkNormalizer,
     eventLinkNormalizer: EventLinkNormalizer,
     eventOrderNormalizer: EventOrderNormalizer,
     maelstromWeaponCastNormalizer: MaelstromWeaponCastNormalizer,

--- a/src/analysis/retail/shaman/enhancement/CombatLogParser.tsx
+++ b/src/analysis/retail/shaman/enhancement/CombatLogParser.tsx
@@ -28,9 +28,10 @@ import ElementalOrbit from '../shared/talents/ElementalOrbit';
 import EarthenHarmony from '../restoration/modules/talents/EarthenHarmony';
 import Guide from './Guide';
 import StormBlast from './modules/talents/Stormblast';
+import TempestStrikes from './modules/talents/TempestStrikes';
 import WitchDoctorsAncestry from './modules/talents/WitchDoctorsAncestry';
 import LegacyOfTheFrostWitch from './modules/talents/LegacyOfTheFrostWitch';
-import Tier30 from './modules/dragonflight/Tier30';
+import * as Tiers from './modules/dragonflight/TierSets';
 import { EventOrderNormalizer } from './modules/normalizers/EventOrderNormalizer';
 import SpellUsable from './modules/core/SpellUsable';
 import ManaSpring from '../shared/talents/ManaSpring';
@@ -90,6 +91,7 @@ class CombatLogParser extends CoreCombatLogParser {
     forcefulWinds: ForcefulWinds,
     elementalBlast: ElementalBlast,
     stormflurry: Stormflurry,
+    tempestStrikes: TempestStrikes,
     hotHand: HotHand,
     elementalAssault: ElementalAssault,
     stormBlast: StormBlast,
@@ -106,7 +108,8 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Tier
     tier28TwoSet: Tier28TwoSet,
-    tier30: Tier30,
+    tier30: Tiers.T30,
+    tier31: Tiers.T31,
 
     // Items
     callToDominance: CallToDominance,

--- a/src/analysis/retail/shaman/enhancement/CombatLogParser.tsx
+++ b/src/analysis/retail/shaman/enhancement/CombatLogParser.tsx
@@ -1,7 +1,7 @@
 import { AnkhNormalizer, AstralShift, StaticCharge } from 'analysis/retail/shaman/shared';
 import CoreCombatLogParser from 'parser/core/CombatLogParser';
 
-import FlameShock from 'analysis/retail/shaman/enhancement/modules/spells/FlameShock';
+import FlameShock from './modules/spells/FlameShock';
 import Abilities from './modules/Abilities';
 import Buffs from './modules/Buffs';
 import Checklist from './modules/checklist/Module';
@@ -9,7 +9,7 @@ import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import WindfuryTotem from './modules/talents/WindfuryTotem';
 import ForcefulWinds from './modules/talents/ForcefulWinds';
 import Stormflurry from './modules/talents/Stormflurry';
-import ElementalBlast from 'analysis/retail/shaman/shared/ElementalBlast';
+import ElementalBlast from './modules/talents/ElementalBlast';
 import HotHand from './modules/talents/HotHand';
 import SpiritWolf from 'analysis/retail/shaman/shared/talents/SpiritWolf';
 import EarthShield from 'analysis/retail/shaman/shared/talents/EarthShield';

--- a/src/analysis/retail/shaman/enhancement/CombatLogParser.tsx
+++ b/src/analysis/retail/shaman/enhancement/CombatLogParser.tsx
@@ -42,7 +42,7 @@ import GlobalCooldown from 'parser/shared/modules/GlobalCooldown';
 import CallToDominance from 'parser/retail/modules/items/dragonflight/CallToDominance';
 import AshenCatalyst from './modules/talents/AshenCatalyst';
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
-import AscendanceNormalizer from './modules/normalizers/AscendanceNormalizer';
+import ProcNormalizer from './modules/normalizers/ProcNormalizer';
 import Ascendance from './modules/talents/Ascendance';
 import SplinteredElements from '../shared/talents/SplinteredElements';
 import {
@@ -120,7 +120,7 @@ class CombatLogParser extends CoreCombatLogParser {
     eventLinkNormalizer: EventLinkNormalizer,
     eventOrderNormalizer: EventOrderNormalizer,
     maelstromWeaponCastNormalizer: MaelstromWeaponCastNormalizer,
-    ascendanceNormalizer: AscendanceNormalizer,
+    procNormalizer: ProcNormalizer,
 
     aplCheck: AplCheck,
   };

--- a/src/analysis/retail/shaman/enhancement/Guide.tsx
+++ b/src/analysis/retail/shaman/enhancement/Guide.tsx
@@ -4,12 +4,14 @@ import PreparationSection from 'interface/guide/components/Preparation/Preparati
 import MaelstromUsage from './modules/guide/MaelstromUsage';
 import Rotation from './modules/guide/Rotation';
 import Cooldowns from './modules/guide/Cooldowns';
+import DefensiveAndUtility from '../shared/guide/DefensiveAndUtility';
 
 export default function Guide(props: GuideProps<typeof CombatLogParser>) {
   return (
     <>
       <Rotation {...props} />
       <Cooldowns {...props} />
+      <DefensiveAndUtility />
       <MaelstromUsage {...props} />
       <PreparationSection />
     </>

--- a/src/analysis/retail/shaman/enhancement/modules/Abilities.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/Abilities.tsx
@@ -42,6 +42,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        range: 40,
       },
       {
         spell: SPELLS.GHOST_WOLF.id,
@@ -391,6 +392,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        range: 5,
       },
       {
         spell: TALENTS_SHAMAN.FERAL_SPIRIT_TALENT.id,
@@ -424,6 +426,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        range: 40,
       },
       {
         spell: TALENTS_SHAMAN.STORMSTRIKE_TALENT.id,
@@ -432,6 +435,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        range: 5,
       },
       {
         spell: TALENTS_SHAMAN.CRASH_LIGHTNING_TALENT.id,
@@ -477,6 +481,7 @@ class Abilities extends CoreAbilities {
         },
         enabled: combatant.hasTalent(TALENTS_SHAMAN.ICE_STRIKE_TALENT),
         cooldown: (haste) => 15 / (1 + haste),
+        range: 5,
       },
       {
         spell: SPELLS.LIGHTNING_SHIELD.id,
@@ -490,7 +495,7 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.PRIMORDIAL_WAVE.id,
+        spell: [SPELLS.PRIMORDIAL_WAVE.id, SPELLS.PRIMORDIAL_WAVE_DAMAGE.id],
         category: SPELL_CATEGORY.COOLDOWNS,
         cooldown: 45,
         gcd: {
@@ -501,6 +506,7 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: 1,
         },
+        range: 40,
       },
       {
         spell: TALENTS_SHAMAN.WINDFURY_TOTEM_TALENT.id,

--- a/src/analysis/retail/shaman/enhancement/modules/Abilities.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/Abilities.tsx
@@ -145,7 +145,6 @@ class Abilities extends CoreAbilities {
         spell: TALENTS_SHAMAN.EARTH_SHIELD_TALENT.id,
         enabled: combatant.hasTalent(TALENTS_SHAMAN.EARTH_SHIELD_TALENT),
         category: SPELL_CATEGORY.OTHERS,
-        cooldown: (haste) => 6 / (1 + haste),
         gcd: {
           base: 1500,
         },

--- a/src/analysis/retail/shaman/enhancement/modules/Buffs.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/Buffs.tsx
@@ -61,6 +61,11 @@ class Buffs extends CoreAuras {
         enabled: combatant.hasTalent(TALENTS.LEGACY_OF_THE_FROST_WITCH_TALENT),
         timelineHighlight: true,
       },
+      {
+        spellId: SPELLS.SPLINTERED_ELEMENTS_BUFF.id,
+        enabled: combatant.hasTalent(TALENTS.SPLINTERED_ELEMENTS_TALENT),
+        triggeredBySpellId: TALENTS.PRIMORDIAL_WAVE_SPEC_TALENT.id,
+      },
     ];
   }
 }

--- a/src/analysis/retail/shaman/enhancement/modules/apl/AplCheck.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/apl/AplCheck.tsx
@@ -6,7 +6,6 @@ import {
   and,
   or,
   buffPresent,
-  buffStacks,
   debuffMissing,
   spellCharges,
   describe,
@@ -15,13 +14,11 @@ import {
 import annotateTimeline from 'parser/shared/metrics/apl/annotate';
 import { SpellLink } from 'interface';
 import SPELLS from 'common/SPELLS';
+import { AtLeastFiveMSW, MaxStacksMSW } from './Conditions';
 
 /**
  * Based on https://www.icy-veins.com/wow/enhancement-shaman-pve-dps-guide
  */
-
-const atLeastFiveMSW = buffStacks(SPELLS.MAELSTROM_WEAPON_BUFF, { atLeast: 5 });
-const maxStacksMSW = buffStacks(SPELLS.MAELSTROM_WEAPON_BUFF, { atLeast: 10, atMost: 10 });
 
 export const apl = (info: PlayerInfo): Apl => {
   const combatant = info.combatant;
@@ -49,40 +46,40 @@ export const apl = (info: PlayerInfo): Apl => {
   if (combatant.hasTalent(TALENTS.DOOM_WINDS_TALENT)) {
     rules.push({
       spell: TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT,
-      condition: atLeastFiveMSW,
+      condition: AtLeastFiveMSW,
     });
     !combatant.hasTalent(TALENTS.STATIC_ACCUMULATION_TALENT) &&
       rules.push({
         spell: TALENTS.LAVA_BURST_TALENT,
-        condition: atLeastFiveMSW,
+        condition: AtLeastFiveMSW,
       });
     rules.push({
       spell: SPELLS.LIGHTNING_BOLT,
       condition: combatant.hasTalent(TALENTS.STATIC_ACCUMULATION_TALENT)
-        ? atLeastFiveMSW
-        : maxStacksMSW,
+        ? AtLeastFiveMSW
+        : MaxStacksMSW,
     });
   } else {
     rules.push(
       {
         spell: TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT,
         condition: and(
-          atLeastFiveMSW,
+          AtLeastFiveMSW,
           spellCharges(TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT, { atLeast: 2, atMost: 2 }),
         ),
       },
       {
         spell: SPELLS.LIGHTNING_BOLT,
-        condition: and(atLeastFiveMSW, buffPresent(SPELLS.PRIMORDIAL_WAVE_BUFF)),
+        condition: and(AtLeastFiveMSW, buffPresent(SPELLS.PRIMORDIAL_WAVE_BUFF)),
       },
       {
         spell: TALENTS.CHAIN_LIGHTNING_TALENT,
-        condition: and(atLeastFiveMSW, buffPresent(SPELLS.CRACKLING_THUNDER_TIER_BUFF)),
+        condition: and(AtLeastFiveMSW, buffPresent(SPELLS.CRACKLING_THUNDER_TIER_BUFF)),
       },
       {
         spell: TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT,
         condition: and(
-          atLeastFiveMSW,
+          AtLeastFiveMSW,
           describe(
             or(
               buffPresent(SPELLS.ELEMENTAL_SPIRITS_BUFF_MOLTEN_WEAPON),
@@ -99,11 +96,11 @@ export const apl = (info: PlayerInfo): Apl => {
       },
       {
         spell: TALENTS.LAVA_BURST_TALENT,
-        condition: atLeastFiveMSW,
+        condition: AtLeastFiveMSW,
       },
       {
         spell: SPELLS.LIGHTNING_BOLT,
-        condition: maxStacksMSW,
+        condition: MaxStacksMSW,
       },
     );
   }
@@ -146,7 +143,7 @@ export const apl = (info: PlayerInfo): Apl => {
   combatant.hasTalent(TALENTS.HAILSTORM_TALENT) &&
     rules.push({
       spell: SPELLS.LIGHTNING_BOLT,
-      condition: describe(and(atLeastFiveMSW, buffMissing(TALENTS.HAILSTORM_TALENT)), () => (
+      condition: describe(and(AtLeastFiveMSW, buffMissing(TALENTS.HAILSTORM_TALENT)), () => (
         <>
           you have at least 5 <SpellLink spell={SPELLS.MAELSTROM_WEAPON_BUFF} /> stacks to generate{' '}
           <SpellLink spell={TALENTS.HAILSTORM_TALENT} /> stacks
@@ -160,7 +157,7 @@ export const apl = (info: PlayerInfo): Apl => {
     !combatant.hasTalent(TALENTS.HAILSTORM_TALENT) &&
     rules.push({
       spell: SPELLS.LIGHTNING_BOLT,
-      condition: atLeastFiveMSW,
+      condition: AtLeastFiveMSW,
     });
 
   const apl = build(rules);

--- a/src/analysis/retail/shaman/enhancement/modules/apl/AplCheck.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/apl/AplCheck.tsx
@@ -1,20 +1,25 @@
-import TALENTS, { TALENTS_SHAMAN } from 'common/TALENTS/shaman';
+import TALENTS from 'common/TALENTS/shaman';
 import { suggestion } from 'parser/core/Analyzer';
 import { AnyEvent } from 'parser/core/Events';
 import aplCheck, { Apl, build, CheckResult, PlayerInfo, Rule } from 'parser/shared/metrics/apl';
 import {
   and,
-  or,
+  buffMissing,
   buffPresent,
   debuffMissing,
-  spellCharges,
   describe,
-  buffMissing,
+  or,
+  spellCharges,
 } from 'parser/shared/metrics/apl/conditions';
 import annotateTimeline from 'parser/shared/metrics/apl/annotate';
 import { SpellLink } from 'interface';
 import SPELLS from 'common/SPELLS';
 import { AtLeastFiveMSW, MaxStacksMSW } from './Conditions';
+import { TIERS } from 'game/TIERS';
+import {
+  getTier31ElementalistApl,
+  getTier31StormApl,
+} from 'analysis/retail/shaman/enhancement/modules/apl/Tier31';
 
 /**
  * Based on https://www.icy-veins.com/wow/enhancement-shaman-pve-dps-guide
@@ -22,6 +27,14 @@ import { AtLeastFiveMSW, MaxStacksMSW } from './Conditions';
 
 export const apl = (info: PlayerInfo): Apl => {
   const combatant = info.combatant;
+
+  if (combatant.has4PieceByTier(TIERS.T31)) {
+    return build(
+      combatant.hasTalent(TALENTS.HOT_HAND_TALENT)
+        ? getTier31ElementalistApl()
+        : getTier31StormApl(),
+    );
+  }
   const rules: Rule[] = [];
 
   combatant.hasTalent(TALENTS.LASHING_FLAMES_TALENT) &&
@@ -105,7 +118,7 @@ export const apl = (info: PlayerInfo): Apl => {
     );
   }
 
-  if (combatant.hasTalent(TALENTS_SHAMAN.DOOM_WINDS_TALENT)) {
+  if (combatant.hasTalent(TALENTS.DOOM_WINDS_TALENT)) {
     rules.push(
       {
         spell: TALENTS.ICE_STRIKE_TALENT,

--- a/src/analysis/retail/shaman/enhancement/modules/apl/Conditions.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/apl/Conditions.tsx
@@ -1,5 +1,12 @@
 import { buffStacks } from 'parser/shared/metrics/apl/conditions';
 import SPELLS from 'common/SPELLS';
+import { Condition } from 'parser/shared/metrics/apl';
 
 export const AtLeastFiveMSW = buffStacks(SPELLS.MAELSTROM_WEAPON_BUFF, { atLeast: 5 });
 export const MaxStacksMSW = buffStacks(SPELLS.MAELSTROM_WEAPON_BUFF, { atLeast: 10, atMost: 10 });
+export function MinimumMaelstromWeaponStacks(minStacks: number): Condition<number> {
+  return buffStacks(SPELLS.MAELSTROM_WEAPON_BUFF, {
+    atLeast: minStacks,
+    atMost: minStacks === 10 ? minStacks : undefined,
+  });
+}

--- a/src/analysis/retail/shaman/enhancement/modules/apl/Conditions.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/apl/Conditions.tsx
@@ -1,0 +1,5 @@
+import { buffStacks } from 'parser/shared/metrics/apl/conditions';
+import SPELLS from 'common/SPELLS';
+
+export const AtLeastFiveMSW = buffStacks(SPELLS.MAELSTROM_WEAPON_BUFF, { atLeast: 5 });
+export const MaxStacksMSW = buffStacks(SPELLS.MAELSTROM_WEAPON_BUFF, { atLeast: 10, atMost: 10 });

--- a/src/analysis/retail/shaman/enhancement/modules/apl/Tier31.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/apl/Tier31.tsx
@@ -1,7 +1,13 @@
 import { Rule } from 'parser/shared/metrics/apl';
 import SPELLS from 'common/SPELLS/shaman';
 import TALENTS from 'common/TALENTS/shaman';
-import * as cnd from 'parser/shared/metrics/apl/conditions';
+import {
+  and,
+  buffPresent,
+  debuffMissing,
+  describe,
+  spellCharges,
+} from 'parser/shared/metrics/apl/conditions';
 import { MinimumMaelstromWeaponStacks } from 'analysis/retail/shaman/enhancement/modules/apl/Conditions';
 import SpellLink from 'interface/SpellLink';
 
@@ -9,31 +15,28 @@ export function getTier31ElementalistApl(): Rule[] {
   return [
     {
       spell: SPELLS.FLAME_SHOCK,
-      condition: cnd.debuffMissing(SPELLS.FLAME_SHOCK),
+      condition: debuffMissing(SPELLS.FLAME_SHOCK),
     },
     {
       spell: TALENTS.LAVA_LASH_TALENT,
-      condition: cnd.buffPresent(SPELLS.HOT_HAND_BUFF),
+      condition: buffPresent(SPELLS.HOT_HAND_BUFF),
     },
     {
       spell: TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT,
-      condition: cnd.and(
+      condition: and(
         MinimumMaelstromWeaponStacks(5),
-        cnd.spellCharges(TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT, { atLeast: 2, atMost: 2 }),
+        spellCharges(TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT, { atLeast: 2, atMost: 2 }),
       ),
     },
     {
       spell: SPELLS.LIGHTNING_BOLT,
-      condition: cnd.and(
-        cnd.buffPresent(SPELLS.PRIMORDIAL_WAVE_BUFF),
-        MinimumMaelstromWeaponStacks(5),
-      ),
+      condition: and(buffPresent(SPELLS.PRIMORDIAL_WAVE_BUFF), MinimumMaelstromWeaponStacks(5)),
     },
     {
       spell: TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT,
-      condition: cnd.and(
+      condition: and(
         MinimumMaelstromWeaponStacks(8),
-        cnd.buffPresent(SPELLS.FERAL_SPIRIT_MAELSTROM_BUFF),
+        buffPresent(SPELLS.FERAL_SPIRIT_MAELSTROM_BUFF),
       ),
     },
     {
@@ -43,13 +46,13 @@ export function getTier31ElementalistApl(): Rule[] {
     TALENTS.ICE_STRIKE_TALENT,
     {
       spell: TALENTS.FROST_SHOCK_TALENT,
-      condition: cnd.buffPresent(SPELLS.HAILSTORM_BUFF),
+      condition: buffPresent(SPELLS.HAILSTORM_BUFF),
     },
     TALENTS.LAVA_LASH_TALENT,
     TALENTS.STORMSTRIKE_TALENT,
     {
       spell: SPELLS.LIGHTNING_BOLT,
-      condition: cnd.describe(MinimumMaelstromWeaponStacks(5), () => (
+      condition: describe(MinimumMaelstromWeaponStacks(5), () => (
         <>
           you have at least 5 <SpellLink spell={SPELLS.MAELSTROM_WEAPON_BUFF} /> stacks for{' '}
           <SpellLink spell={TALENTS.HAILSTORM_TALENT} />
@@ -62,5 +65,31 @@ export function getTier31ElementalistApl(): Rule[] {
 }
 
 export function getTier31StormApl(): Rule[] {
-  return [];
+  return [
+    {
+      spell: SPELLS.WINDSTRIKE_CAST,
+      condition: buffPresent(TALENTS.ASCENDANCE_ENHANCEMENT_TALENT),
+    },
+    TALENTS.STORMSTRIKE_TALENT,
+    {
+      spell: SPELLS.LIGHTNING_BOLT,
+      condition: MinimumMaelstromWeaponStacks(5),
+    },
+    {
+      spell: TALENTS.ICE_STRIKE_TALENT,
+      condition: buffPresent(TALENTS.DOOM_WINDS_TALENT),
+    },
+    {
+      spell: TALENTS.CRASH_LIGHTNING_TALENT,
+      condition: buffPresent(TALENTS.DOOM_WINDS_TALENT),
+    },
+    {
+      spell: SPELLS.FLAME_SHOCK,
+      condition: debuffMissing(SPELLS.FLAME_SHOCK),
+    },
+    TALENTS.LAVA_LASH_TALENT,
+    TALENTS.ICE_STRIKE_TALENT,
+    TALENTS.CRASH_LIGHTNING_TALENT,
+    TALENTS.FROST_SHOCK_TALENT,
+  ];
 }

--- a/src/analysis/retail/shaman/enhancement/modules/apl/Tier31.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/apl/Tier31.tsx
@@ -49,9 +49,10 @@ export function getTier31ElementalistApl(): Rule[] {
     TALENTS.STORMSTRIKE_TALENT,
     {
       spell: SPELLS.LIGHTNING_BOLT,
-      condition: cnd.describe(MinimumMaelstromWeaponStacks(10), () => (
+      condition: cnd.describe(MinimumMaelstromWeaponStacks(5), () => (
         <>
-          for <SpellLink spell={TALENTS.HAILSTORM_TALENT} />
+          you have at least 5 <SpellLink spell={SPELLS.MAELSTROM_WEAPON_BUFF} /> stacks for{' '}
+          <SpellLink spell={TALENTS.HAILSTORM_TALENT} />
         </>
       )),
     },

--- a/src/analysis/retail/shaman/enhancement/modules/apl/Tier31.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/apl/Tier31.tsx
@@ -1,0 +1,7 @@
+import { Rule } from 'parser/shared/metrics/apl';
+
+export function getTier31Apl(): Rule[] {
+  const rules: Rule[] = [];
+
+  return rules;
+}

--- a/src/analysis/retail/shaman/enhancement/modules/apl/Tier31.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/apl/Tier31.tsx
@@ -1,7 +1,65 @@
 import { Rule } from 'parser/shared/metrics/apl';
+import SPELLS from 'common/SPELLS/shaman';
+import TALENTS from 'common/TALENTS/shaman';
+import * as cnd from 'parser/shared/metrics/apl/conditions';
+import { MinimumMaelstromWeaponStacks } from 'analysis/retail/shaman/enhancement/modules/apl/Conditions';
+import SpellLink from 'interface/SpellLink';
 
-export function getTier31Apl(): Rule[] {
-  const rules: Rule[] = [];
+export function getTier31ElementalistApl(): Rule[] {
+  return [
+    {
+      spell: SPELLS.FLAME_SHOCK,
+      condition: cnd.debuffMissing(SPELLS.FLAME_SHOCK),
+    },
+    {
+      spell: TALENTS.LAVA_LASH_TALENT,
+      condition: cnd.buffPresent(SPELLS.HOT_HAND_BUFF),
+    },
+    {
+      spell: TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT,
+      condition: cnd.and(
+        MinimumMaelstromWeaponStacks(5),
+        cnd.spellCharges(TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT, { atLeast: 2, atMost: 2 }),
+      ),
+    },
+    {
+      spell: SPELLS.LIGHTNING_BOLT,
+      condition: cnd.and(
+        cnd.buffPresent(SPELLS.PRIMORDIAL_WAVE_BUFF),
+        MinimumMaelstromWeaponStacks(5),
+      ),
+    },
+    {
+      spell: TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT,
+      condition: cnd.and(
+        MinimumMaelstromWeaponStacks(8),
+        cnd.buffPresent(SPELLS.FERAL_SPIRIT_MAELSTROM_BUFF),
+      ),
+    },
+    {
+      spell: SPELLS.LIGHTNING_BOLT,
+      condition: MinimumMaelstromWeaponStacks(10),
+    },
+    TALENTS.ICE_STRIKE_TALENT,
+    {
+      spell: TALENTS.FROST_SHOCK_TALENT,
+      condition: cnd.buffPresent(SPELLS.HAILSTORM_BUFF),
+    },
+    TALENTS.LAVA_LASH_TALENT,
+    TALENTS.STORMSTRIKE_TALENT,
+    {
+      spell: SPELLS.LIGHTNING_BOLT,
+      condition: cnd.describe(MinimumMaelstromWeaponStacks(10), () => (
+        <>
+          for <SpellLink spell={TALENTS.HAILSTORM_TALENT} />
+        </>
+      )),
+    },
+    TALENTS.FROST_SHOCK_TALENT,
+    TALENTS.CRASH_LIGHTNING_TALENT,
+  ];
+}
 
-  return rules;
+export function getTier31StormApl(): Rule[] {
+  return [];
 }

--- a/src/analysis/retail/shaman/enhancement/modules/dragonflight/Tier30.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/dragonflight/Tier30.tsx
@@ -21,7 +21,7 @@ const ADDITIONAL_DAMAGE_RATIO = {
   CHAIN_LIGHTNING: 0.2,
 };
 
-export default class extends Analyzer {
+class Tier30 extends Analyzer {
   static dependencies = {
     abilities: Abilities,
   };
@@ -150,3 +150,5 @@ export default class extends Analyzer {
     );
   }
 }
+
+export default Tier30;

--- a/src/analysis/retail/shaman/enhancement/modules/dragonflight/Tier30.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/dragonflight/Tier30.tsx
@@ -21,7 +21,7 @@ const ADDITIONAL_DAMAGE_RATIO = {
   CHAIN_LIGHTNING: 0.2,
 };
 
-export default class Tier30 extends Analyzer {
+export default class extends Analyzer {
   static dependencies = {
     abilities: Abilities,
   };

--- a/src/analysis/retail/shaman/enhancement/modules/dragonflight/Tier31.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/dragonflight/Tier31.tsx
@@ -1,0 +1,116 @@
+import { TIERS } from 'game/TIERS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import Statistic from 'parser/ui/Statistic';
+import Abilities from 'parser/core/modules/Abilities';
+import { TALENTS_SHAMAN } from 'common/TALENTS';
+import Events, { CastEvent } from 'parser/core/Events';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import ItemSetLink from 'interface/ItemSetLink';
+import { SHAMAN_T31_ID } from 'common/ITEMS/dragonflight';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+import { UptimeIcon } from 'interface/icons';
+import { formatNumber, formatPercentage } from 'common/format';
+
+const PRIMORDIAL_WAVE_COOLDOWN_PER_SUMMON = 7000;
+
+export default class extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+    spellUsable: SpellUsable,
+  };
+  protected abilities!: Abilities;
+  protected spellUsable!: SpellUsable;
+  protected primordialWaveTotalCooldownReduction: number = 0;
+  protected primordialWaveCooldownEffectiveReduction: number = 0;
+  protected primordialWaveCasts: number = 0;
+  protected twoSetDamageBonus: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active =
+      this.selectedCombatant.has4PieceByTier(TIERS.T31) &&
+      this.selectedCombatant.hasTalent(TALENTS_SHAMAN.PRIMORDIAL_WAVE_SPEC_TALENT);
+    if (!this.active) {
+      return;
+    }
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS_SHAMAN.FERAL_SPIRIT_TALENT),
+      (e) => this.onFeralSpiritSummoned(e.timestamp, 2),
+    );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS_SHAMAN.PRIMORDIAL_WAVE_SPEC_TALENT),
+      this.onPrimordialWaveCast,
+    );
+  }
+
+  onPrimordialWaveCast(event: CastEvent) {
+    this.primordialWaveCasts += 1;
+    this.onFeralSpiritSummoned(event.timestamp + 1, 1);
+  }
+
+  onFeralSpiritSummoned(timestamp: number, count: number) {
+    this.primordialWaveTotalCooldownReduction += PRIMORDIAL_WAVE_COOLDOWN_PER_SUMMON * count;
+    this.primordialWaveCooldownEffectiveReduction += this.spellUsable.reduceCooldown(
+      TALENTS_SHAMAN.PRIMORDIAL_WAVE_SPEC_TALENT.id,
+      PRIMORDIAL_WAVE_COOLDOWN_PER_SUMMON * count,
+      timestamp,
+    );
+  }
+
+  get wasted() {
+    return (
+      this.primordialWaveTotalCooldownReduction - this.primordialWaveCooldownEffectiveReduction
+    );
+  }
+
+  get averageReduction() {
+    return this.primordialWaveCooldownEffectiveReduction / 1000 / this.primordialWaveCasts || 0;
+  }
+
+  get wastedPercent() {
+    return this.wasted / (this.wasted + this.primordialWaveTotalCooldownReduction);
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(0)}
+        category={STATISTIC_CATEGORY.ITEMS}
+        size="flexible"
+        tooltip={
+          <>
+            {formatNumber(this.primordialWaveCooldownEffectiveReduction / 1000)} sec total effective
+            reduction
+            <br />
+            {formatNumber(this.wasted / 1000)} sec ({formatPercentage(this.wastedPercent)}%) wasted
+            reduction.
+          </>
+        }
+      >
+        <div className="pad boring-text">
+          <label>
+            <ItemSetLink id={SHAMAN_T31_ID}>
+              <>
+                Vision of the Greatwolf Outcast
+                <br />
+                (Tier-31 Set)
+              </>
+            </ItemSetLink>
+          </label>
+        </div>
+        <div className="value">
+          <TalentSpellText talent={TALENTS_SHAMAN.PRIMORDIAL_WAVE_SPEC_TALENT}>
+            <>
+              <UptimeIcon /> {formatNumber(this.averageReduction)} sec{' '}
+              <small>average reduction</small>
+            </>
+          </TalentSpellText>
+        </div>
+      </Statistic>
+    );
+  }
+}

--- a/src/analysis/retail/shaman/enhancement/modules/dragonflight/Tier31.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/dragonflight/Tier31.tsx
@@ -15,7 +15,7 @@ import { formatNumber, formatPercentage } from 'common/format';
 
 const PRIMORDIAL_WAVE_COOLDOWN_PER_SUMMON = 7000;
 
-export default class extends Analyzer {
+class Tier31 extends Analyzer {
   static dependencies = {
     abilities: Abilities,
     spellUsable: SpellUsable,
@@ -114,3 +114,5 @@ export default class extends Analyzer {
     );
   }
 }
+
+export default Tier31;

--- a/src/analysis/retail/shaman/enhancement/modules/dragonflight/Tier31.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/dragonflight/Tier31.tsx
@@ -68,7 +68,9 @@ class Tier31 extends Analyzer {
   }
 
   get averageReduction() {
-    return this.primordialWaveCooldownEffectiveReduction / 1000 / this.primordialWaveCasts || 0;
+    return this.primordialWaveCasts
+      ? this.primordialWaveCooldownEffectiveReduction / 1000 / this.primordialWaveCasts
+      : 0;
   }
 
   get wastedPercent() {

--- a/src/analysis/retail/shaman/enhancement/modules/dragonflight/TierSets.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/dragonflight/TierSets.tsx
@@ -1,0 +1,2 @@
+export { default as T30 } from './Tier30';
+export { default as T31 } from './Tier31';

--- a/src/analysis/retail/shaman/enhancement/modules/guide/Cooldowns.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/guide/Cooldowns.tsx
@@ -42,7 +42,8 @@ function Cooldowns({ info, modules }: GuideProps<typeof CombatLogParser>) {
           <CooldownUsage analyzer={modules.ascendance} />
         </SubSection>
       )}
-      {info.combatant.hasTalent(TALENTS.HOT_HAND_TALENT) && modules.hotHand.guideSubsection()}
+      {info.combatant.hasTalent(TALENTS.HOT_HAND_TALENT) && modules.hotHand.guideSubsection}
+      {modules.elementalBlast.guideSubsection}
     </Section>
   );
 }

--- a/src/analysis/retail/shaman/enhancement/modules/guide/Cooldowns.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/guide/Cooldowns.tsx
@@ -6,14 +6,20 @@ import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
 import { GapHighlight } from 'parser/ui/CooldownBar';
 import CombatLogParser from 'analysis/retail/shaman/enhancement/CombatLogParser';
 import CooldownUsage from 'parser/core/MajorCooldowns/CooldownUsage';
+import Combatant from 'parser/core/Combatant';
+import { TIERS } from 'game/TIERS';
 
 interface Props {
-  checklist: Talent[];
+  checklist: TalentWithCondition[];
 }
 
-const COOLDOWNS: Talent[] = [
+interface TalentWithCondition extends Talent {
+  condition?: (combatant: Combatant) => boolean;
+}
+
+const COOLDOWNS: TalentWithCondition[] = [
   TALENTS.FERAL_SPIRIT_TALENT,
-  TALENTS.SUNDERING_TALENT,
+  { ...TALENTS.SUNDERING_TALENT, condition: (c) => c.has4PieceByTier(TIERS.T30) }, // sundering only considered a cooldown when using 4pc T30. Remove entirely further into 10.2
   TALENTS.DOOM_WINDS_TALENT,
   TALENTS.PRIMORDIAL_WAVE_SPEC_TALENT,
   TALENTS.ASCENDANCE_ENHANCEMENT_TALENT,
@@ -50,7 +56,12 @@ const CooldownGraphSubsection = ({ checklist }: Props) => {
   return (
     <SubSection>
       {checklist
-        .filter((talent) => info.combatant.hasTalent(talent))
+        .filter((talent) => {
+          if (talent.condition && !talent.condition(info.combatant)) {
+            return false;
+          }
+          return info.combatant.hasTalent(talent);
+        })
         .map((talent) => (
           <CastEfficiencyBar
             key={talent.id}

--- a/src/analysis/retail/shaman/enhancement/modules/guide/Cooldowns.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/guide/Cooldowns.tsx
@@ -42,6 +42,7 @@ function Cooldowns({ info, modules }: GuideProps<typeof CombatLogParser>) {
           <CooldownUsage analyzer={modules.ascendance} />
         </SubSection>
       )}
+      {info.combatant.hasTalent(TALENTS.HOT_HAND_TALENT) && modules.hotHand.guideSubsection()}
     </Section>
   );
 }

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
@@ -98,10 +98,10 @@ const splinteredElements: EventLink = {
   linkRelation: SPLINTERED_ELEMENTS_LINK,
   linkingEventId: SPELLS.SPLINTERED_ELEMENTS_BUFF.id,
   linkingEventType: EventType.ApplyBuff,
-  referencedEventId: TALENTS.PRIMORDIAL_WAVE_SPEC_TALENT.id,
+  referencedEventId: SPELLS.LIGHTNING_BOLT.id,
   referencedEventType: EventType.Cast,
   anyTarget: true,
-  backwardBufferMs: 15500,
+  forwardBufferMs: 5,
   maximumLinks: 1,
 };
 

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
@@ -76,7 +76,7 @@ const maelstromWeaponSpenderLink: EventLink = {
   linkingEventType: [EventType.RemoveBuff, EventType.RemoveBuffStack],
   referencedEventId: MAELSTROM_WEAPON_ELIGIBLE_SPELL_IDS,
   referencedEventType: [EventType.Cast, EventType.FreeCast],
-  backwardBufferMs: 25,
+  backwardBufferMs: 50,
   anyTarget: true,
 };
 
@@ -115,21 +115,22 @@ const lightningBoltLink: EventLink = {
 
 const maelstromGeneratorLink: EventLink = {
   linkRelation: MAELSTROM_GENERATOR_LINK,
-  linkingEventId: SPELLS.MAELSTROM_WEAPON_BUFF.id,
-  linkingEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack, EventType.RefreshBuff],
-  referencedEventId: [
+  linkingEventId: [
     TALENTS.STORMSTRIKE_TALENT.id,
     TALENTS.LAVA_LASH_TALENT.id,
     TALENTS.ICE_STRIKE_TALENT.id,
     SPELLS.WINDSTRIKE_CAST.id,
     TALENTS.FROST_SHOCK_TALENT.id,
     TALENTS.FIRE_NOVA_TALENT.id,
+    TALENTS.PRIMORDIAL_WAVE_SPEC_TALENT.id,
   ],
-  referencedEventType: EventType.Cast,
-  forwardBufferMs: 5,
-  backwardBufferMs: 5,
+  linkingEventType: EventType.Cast,
+  referencedEventId: SPELLS.MAELSTROM_WEAPON_BUFF.id,
+  referencedEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack, EventType.RefreshBuff],
+  forwardBufferMs: 25,
+  backwardBufferMs: 25,
   anyTarget: true,
-  maximumLinks: 1,
+  reverseLinkRelation: MAELSTROM_GENERATOR_LINK,
 };
 
 const feralSpiritLink: EventLink = {

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
@@ -17,6 +17,7 @@ export const CHAIN_LIGHTNING_LINK = 'chain-lightning';
 export const MAELSTROM_WEAPON_SPEND_LINK = 'maelstrom-spender';
 export const PRIMORIDAL_WAVE_END_LINK = 'primordial-wave-end';
 export const LIGHTNING_BOLT_PRIMORDIAL_WAVE_LINK = 'lightning-bolt-primoridal-wave';
+export const MAELSTROM_GENERATOR_LINK = 'maelstrom-generator';
 
 const MAELSTROM_WEAPON_ELIGIBLE_SPELL_IDS = MAELSTROM_WEAPON_ELIGIBLE_SPELLS.map(
   (spell) => spell.id,
@@ -96,6 +97,25 @@ const lightningBoltDamageLink: EventLink = {
   anyTarget: true,
 };
 
+const maelstromGeneratorLink: EventLink = {
+  linkRelation: MAELSTROM_GENERATOR_LINK,
+  linkingEventId: SPELLS.MAELSTROM_WEAPON_BUFF.id,
+  linkingEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack, EventType.RefreshBuff],
+  referencedEventId: [
+    TALENTS.STORMSTRIKE_TALENT.id,
+    TALENTS.LAVA_LASH_TALENT.id,
+    TALENTS.ICE_STRIKE_TALENT.id,
+    SPELLS.WINDSTRIKE_CAST.id,
+    TALENTS.FROST_SHOCK_TALENT.id,
+    TALENTS.FIRE_NOVA_TALENT.id,
+  ],
+  referencedEventType: EventType.Cast,
+  forwardBufferMs: 5,
+  backwardBufferMs: 5,
+  anyTarget: true,
+  maximumLinks: 1,
+};
+
 class EventLinkNormalizer extends BaseEventLinkNormalizer {
   constructor(options: Options) {
     super(options, [
@@ -106,6 +126,7 @@ class EventLinkNormalizer extends BaseEventLinkNormalizer {
       maelstromWeaponSpenderLink,
       primordialWaveLink,
       lightningBoltDamageLink,
+      maelstromGeneratorLink,
     ]);
   }
 }

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
@@ -21,7 +21,6 @@ export const CHAIN_LIGHTNING_LINK = 'chain-lightning';
 export const MAELSTROM_SPENDER_LINK = 'maelstrom-spender';
 export const LIGHTNING_BOLT_LINK = 'lightning-bolt';
 export const MAELSTROM_GENERATOR_LINK = 'maelstrom-generator';
-export const FERAL_SPIRIT_LINK = 'feral-spirit';
 
 const MAELSTROM_WEAPON_ELIGIBLE_SPELL_IDS = MAELSTROM_WEAPON_ELIGIBLE_SPELLS.map(
   (spell) => spell.id,
@@ -116,16 +115,6 @@ const lightningBoltLink: EventLink = {
   anyTarget: true,
 };
 
-const feralSpiritLink: EventLink = {
-  linkRelation: FERAL_SPIRIT_LINK,
-  linkingEventId: TALENTS.FERAL_SPIRIT_TALENT.id,
-  linkingEventType: EventType.Cast,
-  referencedEventId: [SPELLS.ELEMENTAL_BLAST.id],
-  referencedEventType: EventType.Damage,
-  anyTarget: true,
-  forwardBufferMs: 15000,
-};
-
 class EventLinkNormalizer extends BaseEventLinkNormalizer {
   constructor(options: Options) {
     super(options, [
@@ -137,7 +126,6 @@ class EventLinkNormalizer extends BaseEventLinkNormalizer {
       primordialWaveLink,
       splinteredElements,
       lightningBoltLink,
-      feralSpiritLink,
     ]);
 
     this.priority = -80;

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
@@ -9,14 +9,17 @@ import {
   STORMSTRIKE_CAST_SPELLS,
   STORMSTRIKE_DAMAGE_SPELLS,
 } from '../../constants';
+import {
+  SPLINTERED_ELEMENTS_LINK,
+  PRIMORDIAL_WAVE_LINK,
+} from 'analysis/retail/shaman/shared/constants';
 
 export const MAELSTROM_WEAPON_INSTANT_CAST = 'maelstrom-weapon-instant-cast';
 export const THORIMS_INVOCATION_LINK = 'thorims-invocation';
 export const STORMSTRIKE_LINK = 'stormstrike';
 export const CHAIN_LIGHTNING_LINK = 'chain-lightning';
 export const MAELSTROM_WEAPON_SPEND_LINK = 'maelstrom-spender';
-export const PRIMORIDAL_WAVE_END_LINK = 'primordial-wave-end';
-export const LIGHTNING_BOLT_PRIMORDIAL_WAVE_LINK = 'lightning-bolt-primoridal-wave';
+export const LIGHTNING_BOLT_LINK = 'lightning-bolt';
 export const MAELSTROM_GENERATOR_LINK = 'maelstrom-generator';
 
 const MAELSTROM_WEAPON_ELIGIBLE_SPELL_IDS = MAELSTROM_WEAPON_ELIGIBLE_SPELLS.map(
@@ -77,23 +80,46 @@ const maelstromWeaponSpenderLink: EventLink = {
 };
 
 const primordialWaveLink: EventLink = {
-  linkRelation: PRIMORIDAL_WAVE_END_LINK,
-  linkingEventId: SPELLS.PRIMORDIAL_WAVE_BUFF.id,
-  linkingEventType: EventType.RemoveBuff,
+  linkRelation: PRIMORDIAL_WAVE_LINK,
+  linkingEventId: TALENTS.PRIMORDIAL_WAVE_SPEC_TALENT.id,
+  linkingEventType: EventType.Cast,
   referencedEventId: SPELLS.LIGHTNING_BOLT.id,
   referencedEventType: EventType.Cast,
-  backwardBufferMs: 50,
-  forwardBufferMs: 50,
   anyTarget: true,
+  forwardBufferMs: 15500,
+  maximumLinks: 1,
+  reverseLinkRelation: PRIMORDIAL_WAVE_LINK,
 };
 
-const lightningBoltDamageLink: EventLink = {
-  linkRelation: LIGHTNING_BOLT_PRIMORDIAL_WAVE_LINK,
+const splinteredElements: EventLink = {
+  linkRelation: SPLINTERED_ELEMENTS_LINK,
+  linkingEventId: SPELLS.SPLINTERED_ELEMENTS_BUFF.id,
+  linkingEventType: EventType.ApplyBuff,
+  referencedEventId: TALENTS.PRIMORDIAL_WAVE_SPEC_TALENT.id,
+  referencedEventType: EventType.Cast,
+  anyTarget: true,
+  backwardBufferMs: 15500,
+  maximumLinks: 1,
+};
+
+// const primordialWaveDamageLink: EventLink = {
+//   linkRelation: PRIMORIDAL_WAVE_DAMAGE_LINK,
+//   linkingEventId: SPELLS.PRIMORDIAL_WAVE_BUFF.id,
+//   linkingEventType: EventType.RemoveBuff,
+//   referencedEventId: SPELLS.LIGHTNING_BOLT.id,
+//   referencedEventType: EventType.Cast,
+//   backwardBufferMs: 50,
+//   forwardBufferMs: 50,
+//   anyTarget: true,
+// };
+
+const lightningBoltLink: EventLink = {
+  linkRelation: LIGHTNING_BOLT_LINK,
   linkingEventId: SPELLS.LIGHTNING_BOLT.id,
   linkingEventType: EventType.Cast,
   referencedEventId: SPELLS.LIGHTNING_BOLT.id,
   referencedEventType: EventType.Damage,
-  forwardBufferMs: 50,
+  forwardBufferMs: 150,
   anyTarget: true,
 };
 
@@ -125,7 +151,8 @@ class EventLinkNormalizer extends BaseEventLinkNormalizer {
       chainLightningDamageLink,
       maelstromWeaponSpenderLink,
       primordialWaveLink,
-      lightningBoltDamageLink,
+      splinteredElements,
+      lightningBoltLink,
       maelstromGeneratorLink,
     ]);
   }

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
@@ -18,7 +18,7 @@ export const MAELSTROM_WEAPON_INSTANT_CAST = 'maelstrom-weapon-instant-cast';
 export const THORIMS_INVOCATION_LINK = 'thorims-invocation';
 export const STORMSTRIKE_LINK = 'stormstrike';
 export const CHAIN_LIGHTNING_LINK = 'chain-lightning';
-export const MAELSTROM_WEAPON_SPEND_LINK = 'maelstrom-spender';
+export const MAELSTROM_SPENDER_LINK = 'maelstrom-spender';
 export const LIGHTNING_BOLT_LINK = 'lightning-bolt';
 export const MAELSTROM_GENERATOR_LINK = 'maelstrom-generator';
 export const FERAL_SPIRIT_LINK = 'feral-spirit';
@@ -71,13 +71,16 @@ const chainLightningDamageLink: EventLink = {
 };
 
 const maelstromWeaponSpenderLink: EventLink = {
-  linkRelation: MAELSTROM_WEAPON_SPEND_LINK,
-  linkingEventId: SPELLS.MAELSTROM_WEAPON_BUFF.id,
-  linkingEventType: [EventType.RemoveBuff, EventType.RemoveBuffStack],
-  referencedEventId: MAELSTROM_WEAPON_ELIGIBLE_SPELL_IDS,
-  referencedEventType: [EventType.Cast, EventType.FreeCast],
+  linkRelation: MAELSTROM_SPENDER_LINK,
+  linkingEventId: MAELSTROM_WEAPON_ELIGIBLE_SPELL_IDS,
+  linkingEventType: [EventType.Cast, EventType.FreeCast],
+  referencedEventId: SPELLS.MAELSTROM_WEAPON_BUFF.id,
+  referencedEventType: [EventType.RemoveBuff, EventType.RemoveBuffStack],
+  forwardBufferMs: 25,
   backwardBufferMs: 50,
   anyTarget: true,
+  reverseLinkRelation: MAELSTROM_SPENDER_LINK,
+  maximumLinks: 1,
 };
 
 const primordialWaveLink: EventLink = {
@@ -113,26 +116,6 @@ const lightningBoltLink: EventLink = {
   anyTarget: true,
 };
 
-const maelstromGeneratorLink: EventLink = {
-  linkRelation: MAELSTROM_GENERATOR_LINK,
-  linkingEventId: [
-    TALENTS.STORMSTRIKE_TALENT.id,
-    TALENTS.LAVA_LASH_TALENT.id,
-    TALENTS.ICE_STRIKE_TALENT.id,
-    SPELLS.WINDSTRIKE_CAST.id,
-    TALENTS.FROST_SHOCK_TALENT.id,
-    TALENTS.FIRE_NOVA_TALENT.id,
-    TALENTS.PRIMORDIAL_WAVE_SPEC_TALENT.id,
-  ],
-  linkingEventType: EventType.Cast,
-  referencedEventId: SPELLS.MAELSTROM_WEAPON_BUFF.id,
-  referencedEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack, EventType.RefreshBuff],
-  forwardBufferMs: 25,
-  backwardBufferMs: 25,
-  anyTarget: true,
-  reverseLinkRelation: MAELSTROM_GENERATOR_LINK,
-};
-
 const feralSpiritLink: EventLink = {
   linkRelation: FERAL_SPIRIT_LINK,
   linkingEventId: TALENTS.FERAL_SPIRIT_TALENT.id,
@@ -154,9 +137,10 @@ class EventLinkNormalizer extends BaseEventLinkNormalizer {
       primordialWaveLink,
       splinteredElements,
       lightningBoltLink,
-      maelstromGeneratorLink,
       feralSpiritLink,
     ]);
+
+    this.priority = -80;
   }
 }
 

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
@@ -10,8 +10,8 @@ import {
   STORMSTRIKE_DAMAGE_SPELLS,
 } from '../../constants';
 import {
-  SPLINTERED_ELEMENTS_LINK,
   PRIMORDIAL_WAVE_LINK,
+  SPLINTERED_ELEMENTS_LINK,
 } from 'analysis/retail/shaman/shared/constants';
 
 export const MAELSTROM_WEAPON_INSTANT_CAST = 'maelstrom-weapon-instant-cast';
@@ -21,6 +21,7 @@ export const CHAIN_LIGHTNING_LINK = 'chain-lightning';
 export const MAELSTROM_WEAPON_SPEND_LINK = 'maelstrom-spender';
 export const LIGHTNING_BOLT_LINK = 'lightning-bolt';
 export const MAELSTROM_GENERATOR_LINK = 'maelstrom-generator';
+export const FERAL_SPIRIT_LINK = 'feral-spirit';
 
 const MAELSTROM_WEAPON_ELIGIBLE_SPELL_IDS = MAELSTROM_WEAPON_ELIGIBLE_SPELLS.map(
   (spell) => spell.id,
@@ -102,17 +103,6 @@ const splinteredElements: EventLink = {
   maximumLinks: 1,
 };
 
-// const primordialWaveDamageLink: EventLink = {
-//   linkRelation: PRIMORIDAL_WAVE_DAMAGE_LINK,
-//   linkingEventId: SPELLS.PRIMORDIAL_WAVE_BUFF.id,
-//   linkingEventType: EventType.RemoveBuff,
-//   referencedEventId: SPELLS.LIGHTNING_BOLT.id,
-//   referencedEventType: EventType.Cast,
-//   backwardBufferMs: 50,
-//   forwardBufferMs: 50,
-//   anyTarget: true,
-// };
-
 const lightningBoltLink: EventLink = {
   linkRelation: LIGHTNING_BOLT_LINK,
   linkingEventId: SPELLS.LIGHTNING_BOLT.id,
@@ -142,6 +132,16 @@ const maelstromGeneratorLink: EventLink = {
   maximumLinks: 1,
 };
 
+const feralSpiritLink: EventLink = {
+  linkRelation: FERAL_SPIRIT_LINK,
+  linkingEventId: TALENTS.FERAL_SPIRIT_TALENT.id,
+  linkingEventType: EventType.Cast,
+  referencedEventId: [SPELLS.ELEMENTAL_BLAST.id],
+  referencedEventType: EventType.Damage,
+  anyTarget: true,
+  forwardBufferMs: 15000,
+};
+
 class EventLinkNormalizer extends BaseEventLinkNormalizer {
   constructor(options: Options) {
     super(options, [
@@ -154,6 +154,7 @@ class EventLinkNormalizer extends BaseEventLinkNormalizer {
       splinteredElements,
       lightningBoltLink,
       maelstromGeneratorLink,
+      feralSpiritLink,
     ]);
   }
 }

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/EventOrderNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/EventOrderNormalizer.tsx
@@ -18,6 +18,19 @@ const thorimsInvocationEventOrder: EventOrder = {
   updateTimestamp: true,
 };
 
+/**
+ * In some instances, the comes before the cast, so normalize to force it after
+ */
+const healingOrder: EventOrder = {
+  afterEventId: [SPELLS.HEALING_SURGE.id, TALENTS.CHAIN_HEAL_TALENT.id],
+  afterEventType: [EventType.Heal, EventType.HealAbsorbed],
+  beforeEventId: [SPELLS.HEALING_SURGE.id, TALENTS.CHAIN_HEAL_TALENT.id],
+  beforeEventType: EventType.Cast,
+  anyTarget: true,
+  bufferMs: MAELSTROM_WEAPON_MS,
+  updateTimestamp: true,
+};
+
 /** The primordial wave buff is consumed before the lightning bolt it buffs is cast. The APL requires
  * the buff to be present when checking for the lightning bolt casts */
 const primordialWaveEventOrder: EventOrder = {
@@ -32,7 +45,7 @@ const primordialWaveEventOrder: EventOrder = {
 
 export class EventOrderNormalizer extends BaseEventOrderNormalizer {
   constructor(options: Options) {
-    super(options, [thorimsInvocationEventOrder, primordialWaveEventOrder]);
+    super(options, [thorimsInvocationEventOrder, healingOrder, primordialWaveEventOrder]);
   }
 
   /** After the base normalize is done, we're changing all auto-casts of Lightning Bolt

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/EventOrderNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/EventOrderNormalizer.tsx
@@ -25,6 +25,7 @@ const primordialWaveEventOrder: EventOrder = {
   afterEventType: EventType.RemoveBuff,
   beforeEventId: SPELLS.LIGHTNING_BOLT.id,
   beforeEventType: EventType.Cast,
+  anyTarget: true,
   bufferMs: 100,
   updateTimestamp: true,
 };

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/MaelstromWeaponBuffNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/MaelstromWeaponBuffNormalizer.tsx
@@ -24,7 +24,7 @@ class MaelstromWeaponBuffNormalizer extends EventsNormalizer {
           // look for a refresh event following this one
           for (let forwardIndex = idx; forwardIndex < events.length; forwardIndex += 1) {
             const forwardEvent = events[forwardIndex];
-            if (forwardEvent.timestamp - event.timestamp > 5) {
+            if (forwardEvent.timestamp - event.timestamp > 10) {
               break;
             }
             if (

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/MaelstromWeaponBuffNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/MaelstromWeaponBuffNormalizer.tsx
@@ -1,0 +1,55 @@
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+import { AnyEvent, EventType, HasAbility } from 'parser/core/Events';
+import SPELLS from 'common/SPELLS/shaman';
+import { Options } from 'parser/core/Analyzer';
+
+/**
+ * This normalizer removes the duplicate 'refreshbuff' events that immediately follow
+ * every 'applybuff' and 'applybuffstack' event, leaving 'refreshbuff' events exclusively for
+ * gains at cap
+ */
+class MaelstromWeaponBuffNormalizer extends EventsNormalizer {
+  constructor(options: Options) {
+    super(options);
+    this.priority = -100;
+  }
+
+  normalize(events: AnyEvent[]): AnyEvent[] {
+    const fixedEvents: AnyEvent[] = [];
+    const skipEvents: number[] = [];
+    events.forEach((event: AnyEvent, idx: number) => {
+      if (HasAbility(event) && event.ability.guid === SPELLS.MAELSTROM_WEAPON_BUFF.id) {
+        if (event.type === EventType.ApplyBuff || event.type === EventType.ApplyBuffStack) {
+          fixedEvents.push(event);
+          // look for a refresh event following this one
+          for (let forwardIndex = idx; forwardIndex < events.length; forwardIndex += 1) {
+            const forwardEvent = events[forwardIndex];
+            if (forwardEvent.timestamp - event.timestamp > 5) {
+              break;
+            }
+            if (
+              forwardEvent.type === EventType.RefreshBuff &&
+              forwardEvent.ability.guid === SPELLS.MAELSTROM_WEAPON_BUFF.id
+            ) {
+              skipEvents.push(forwardIndex);
+              break;
+            }
+          }
+        } else if (event.type === EventType.RefreshBuff && !skipEvents.includes(idx)) {
+          fixedEvents.push(event);
+        } else if (
+          event.type === EventType.RemoveBuff ||
+          event.type === EventType.RemoveBuffStack
+        ) {
+          fixedEvents.push(event);
+        }
+      } else {
+        fixedEvents.push(event);
+      }
+    });
+
+    return fixedEvents;
+  }
+}
+
+export default MaelstromWeaponBuffNormalizer;

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/MaelstromWeaponBuffNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/MaelstromWeaponBuffNormalizer.tsx
@@ -16,7 +16,7 @@ class MaelstromWeaponBuffNormalizer extends EventsNormalizer {
 
   normalize(events: AnyEvent[]): AnyEvent[] {
     const fixedEvents: AnyEvent[] = [];
-    const skipEvents: number[] = [];
+    const skipEvents = new Set<number>();
     events.forEach((event: AnyEvent, idx: number) => {
       if (HasAbility(event) && event.ability.guid === SPELLS.MAELSTROM_WEAPON_BUFF.id) {
         if (event.type === EventType.ApplyBuff || event.type === EventType.ApplyBuffStack) {
@@ -31,11 +31,11 @@ class MaelstromWeaponBuffNormalizer extends EventsNormalizer {
               forwardEvent.type === EventType.RefreshBuff &&
               forwardEvent.ability.guid === SPELLS.MAELSTROM_WEAPON_BUFF.id
             ) {
-              skipEvents.push(forwardIndex);
+              skipEvents.add(forwardIndex);
               break;
             }
           }
-        } else if (event.type === EventType.RefreshBuff && !skipEvents.includes(idx)) {
+        } else if (event.type === EventType.RefreshBuff && !skipEvents.has(idx)) {
           fixedEvents.push(event);
         } else if (
           event.type === EventType.RemoveBuff ||

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/MaelstromWeaponGeneratorLinkNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/MaelstromWeaponGeneratorLinkNormalizer.tsx
@@ -1,0 +1,80 @@
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import { Options } from 'parser/core/Analyzer';
+import TALENTS from 'common/TALENTS/shaman';
+import SPELLS from 'common/SPELLS/shaman';
+import { EventType } from 'parser/core/Events';
+import Combatant from 'parser/core/Combatant';
+
+const MAELSTROM_GENERATOR_LINK = 'maelstrom-generator';
+
+/**
+ * This normalizer links eligible maelstrom generators to the maelstrom weapon buff
+ * 'applybuff', 'applybuffstack', and 'refreshbuff' events. This normalizer has a lower
+ * priority than {@link MaelstromWeaponBuffNormalizer}, and relies on the redundant
+ * 'refreshbuff' events being removed
+ */
+class MaelstromWeaponGeneratorLinkNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, [primordialWave, iceStrike, frostShock, otherGenerator]);
+
+    this.priority = -90;
+  }
+}
+
+const linkTemplate = {
+  linkRelation: MAELSTROM_GENERATOR_LINK,
+  linkingEventType: EventType.Cast,
+  referencedEventId: SPELLS.MAELSTROM_WEAPON_BUFF.id,
+  referencedEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack, EventType.RefreshBuff],
+  anyTarget: true,
+  reverseLinkRelation: MAELSTROM_GENERATOR_LINK,
+};
+
+/**
+ * primordial wave can generate up to 10 maelstrom, events are always prior to cast
+ */
+const primordialWave: EventLink = {
+  ...linkTemplate,
+  linkingEventId: TALENTS.PRIMORDIAL_WAVE_SPEC_TALENT.id,
+  backwardBufferMs: 25,
+  anySource: false,
+  maximumLinks: (c) => c.getTalentRank(TALENTS.PRIMAL_MAELSTROM_TALENT) * 5,
+};
+
+const iceStrike: EventLink = {
+  ...linkTemplate,
+  linkingEventId: TALENTS.ICE_STRIKE_TALENT.id,
+  forwardBufferMs: 25,
+  maximumLinks: (c: Combatant) => {
+    let max = 0;
+    if (c.hasTalent(TALENTS.ELEMENTAL_ASSAULT_TALENT)) {
+      max += 1;
+    }
+    if (c.hasTalent(TALENTS.SWIRLING_MAELSTROM_TALENT)) {
+      max += 1;
+    }
+    return max;
+  },
+};
+
+const frostShock: EventLink = {
+  ...linkTemplate,
+  linkingEventId: TALENTS.FROST_SHOCK_TALENT.id,
+  forwardBufferMs: 25,
+  anySource: false,
+  maximumLinks: (c) => (c.hasTalent(TALENTS.SWIRLING_MAELSTROM_TALENT) ? 1 : 0),
+};
+
+const otherGenerator: EventLink = {
+  ...linkTemplate,
+  linkingEventId: [
+    TALENTS.LAVA_LASH_TALENT.id,
+    TALENTS.STORMSTRIKE_TALENT.id,
+    SPELLS.WINDSTRIKE_CAST.id,
+  ],
+  forwardBufferMs: 25,
+  anySource: false,
+  maximumLinks: 1,
+};
+
+export default MaelstromWeaponGeneratorLinkNormalizer;

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/ProcNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/ProcNormalizer.tsx
@@ -2,22 +2,28 @@ import EventsNormalizer from 'parser/core/EventsNormalizer';
 import { AnyEvent, EventType } from 'parser/core/Events';
 import { Options } from 'parser/core/Analyzer';
 import { TALENTS_SHAMAN } from 'common/TALENTS';
+import SPELLS from 'common/SPELLS';
 
-/** This normalizer adds a fabricated cast event when deeply rooted elements procs
- * to simulate a cast of Ascendance for the major cooldown analyzer */
+/** This normalizer adds a fabricated cast event when deeply rooted elements or hot hand procs
+ * to simulate a cast for the major cooldown analyzers */
 
-const ASCENDANCE_ID = TALENTS_SHAMAN.ASCENDANCE_ENHANCEMENT_TALENT.id;
+const PROC_IDS = [TALENTS_SHAMAN.ASCENDANCE_ENHANCEMENT_TALENT.id, SPELLS.HOT_HAND_BUFF.id];
 
-class AscendanceNormalizer extends EventsNormalizer {
+class ProcNormalizer extends EventsNormalizer {
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasTalent(TALENTS_SHAMAN.DEEPLY_ROOTED_ELEMENTS_TALENT);
+    this.active =
+      this.selectedCombatant.hasTalent(TALENTS_SHAMAN.DEEPLY_ROOTED_ELEMENTS_TALENT) ||
+      this.selectedCombatant.hasTalent(TALENTS_SHAMAN.HOT_HAND_TALENT);
   }
 
   normalize(events: AnyEvent[]): AnyEvent[] {
     const fixedEvents: AnyEvent[] = [];
-    events.forEach((event: AnyEvent, idx: number) => {
-      if (event.type === EventType.ApplyBuff && event.ability.guid === ASCENDANCE_ID) {
+    events.forEach((event: AnyEvent) => {
+      if (
+        (event.type === EventType.ApplyBuff || event.type === EventType.RefreshBuff) &&
+        PROC_IDS.includes(event.ability.guid)
+      ) {
         fixedEvents.push({
           type: EventType.Cast,
           ability: event.ability,
@@ -36,4 +42,4 @@ class AscendanceNormalizer extends EventsNormalizer {
   }
 }
 
-export default AscendanceNormalizer;
+export default ProcNormalizer;

--- a/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponDetails.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponDetails.tsx
@@ -5,7 +5,7 @@ import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import TALENTS from 'common/TALENTS/shaman';
 
-export default class extends Analyzer {
+class MaelstromWeaponDetails extends Analyzer {
   static dependencies = {
     maelstromWeaponTracker: MaelstromWeaponTracker,
   };
@@ -36,3 +36,5 @@ export default class extends Analyzer {
     );
   }
 }
+
+export default MaelstromWeaponDetails;

--- a/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponGraph.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponGraph.tsx
@@ -1,7 +1,7 @@
 import ResourceGraph from 'parser/shared/modules/ResourceGraph';
 import MaelstromWeaponTracker from './MaelstromWeaponTracker';
 
-export default class extends ResourceGraph {
+class MaelstromWeaponGraph extends ResourceGraph {
   static dependencies = {
     ...ResourceGraph.dependencies,
     maelstromWeaponTracker: MaelstromWeaponTracker,
@@ -13,3 +13,5 @@ export default class extends ResourceGraph {
     return this.maelstromWeaponTracker;
   }
 }
+
+export default MaelstromWeaponGraph;

--- a/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponSpenders.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponSpenders.tsx
@@ -21,7 +21,7 @@ import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import { LIGHTNING_BOLT_LINK, MAELSTROM_SPENDER_LINK } from '../normalizers/EventLinkNormalizer';
 import { PRIMORDIAL_WAVE_LINK } from 'analysis/retail/shaman/shared/constants';
 
-export default class extends Analyzer {
+class MaelstromWeaponSpenders extends Analyzer {
   static dependencies = {
     maelstromWeaponTracker: MaelstromWeaponTracker,
     abilities: Abilities,
@@ -166,3 +166,5 @@ export default class extends Analyzer {
     ];
   }
 }
+
+export default MaelstromWeaponSpenders;

--- a/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponSpenders.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponSpenders.tsx
@@ -65,7 +65,8 @@ export default class extends Analyzer {
           this.spenderValues[spellId] =
             (this.spenderValues[spellId] ?? 0) +
             damageEvents.reduce((total: number, de: DamageEvent) => (total += de.amount), 0);
-          this.maelstromSpendWithPrimordialWave += this.maelstromWeaponTracker.current;
+          this.maelstromSpendWithPrimordialWave +=
+            this.maelstromWeaponTracker.lastSpenderInfo?.amount ?? 0;
         }
       }
     }

--- a/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponSpenders.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponSpenders.tsx
@@ -144,16 +144,9 @@ export default class extends Analyzer {
                 casts = ability.casts;
                 spent = this.maelstromSpendWithPrimordialWave;
               } else {
-                const spenderObj = this.maelstromWeaponTracker.spendersObj[spellId];
-                if (spenderObj) {
-                  casts = spenderObj.casts;
-                  spent = spenderObj.spent;
-                } else {
-                  // Hotfix: Resolves this module from loading if unhandled in
-                  // MaelstromWeaponTracker. Will show 0 casts instead.
-                  casts = 0;
-                  spent = 0;
-                }
+                const spender = this.maelstromWeaponTracker.spendersObj[spellId];
+                casts = spender?.casts || 0;
+                spent = spender?.spent || 0;
               }
 
               const amount = this.spenderValues[spellId];

--- a/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponSpenders.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponSpenders.tsx
@@ -6,7 +6,6 @@ import { MAELSTROM_WEAPON_ELIGIBLE_SPELLS } from '../../constants';
 import Events, {
   DamageEvent,
   HealEvent,
-  RemoveBuffEvent,
   GetRelatedEvents,
   CastEvent,
   GetRelatedEvent,
@@ -72,33 +71,6 @@ export default class extends Analyzer {
     }
   }
 
-  onPrimoridalWaveEnd(event: RemoveBuffEvent) {
-    // const primordialWaveLightningBolt = event._linkedEvents?.find(
-    //   (le) => le.relation === PRIMORIDAL_WAVE_DAMAGE_LINK,
-    // )?.event;
-    // if (primordialWaveLightningBolt) {
-    //   const spent = this.maelstromWeaponTracker.current;
-    //   /**
-    //    * this is a bit of a hack to handle instances where the resource tracker's `current` isn't the actual
-    //    * current maelstrom, and is a "best guess" that the majority of the time lightning bolt
-    //    * will be cast at 10 maelstrom with PW
-    //    */
-    //   this.maelstromSpendWithPrimordialWave +=
-    //     spent === 0 ? 10 : this.maelstromWeaponTracker.current;
-    //   const damageEvents: DamageEvent[] = GetRelatedEvents(
-    //     primordialWaveLightningBolt,
-    //     LIGHTNING_BOLT_LINK,
-    //   ) as DamageEvent[];
-    //   if (damageEvents.length > 1) {
-    //     const spellId = TALENTS_SHAMAN.PRIMORDIAL_WAVE_SPEC_TALENT.id;
-    //     damageEvents?.splice(0, 1);
-    //     this.spenderValues[spellId] =
-    //       (this.spenderValues[spellId] ?? 0) +
-    //       damageEvents.reduce((total: number, de: DamageEvent) => (total += de.amount), 0);
-    //   }
-    // }
-  }
-
   onSpender(event: DamageEvent | HealEvent) {
     if (!this.recordNextSpenderAmount) {
       return;
@@ -138,15 +110,12 @@ export default class extends Analyzer {
               const spellId = Number(value);
               const spell = maybeGetSpell(spellId);
               const ability = this.abilityTracker.getAbility(spellId);
-              let casts: number;
+              const casts = ability.casts;
               let spent: number;
               if (spellId === TALENTS_SHAMAN.PRIMORDIAL_WAVE_SPEC_TALENT.id) {
-                casts = ability.casts;
                 spent = this.maelstromSpendWithPrimordialWave;
               } else {
-                const spender = this.maelstromWeaponTracker.spendersObj[spellId];
-                casts = spender?.casts || 0;
-                spent = spender?.spent || 0;
+                spent = this.maelstromWeaponTracker.spendersObj[spellId]?.spent || 0;
               }
 
               const amount = this.spenderValues[spellId];

--- a/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponTracker.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponTracker.tsx
@@ -3,33 +3,43 @@ import TALENTS from 'common/TALENTS/shaman';
 import { Resource } from 'game/RESOURCE_TYPES';
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, {
-  RefreshBuffEvent,
-  ChangeBuffStackEvent,
-  EventType,
-  CastEvent,
-  FreeCastEvent,
   ApplyBuffEvent,
   ApplyBuffStackEvent,
+  CastEvent,
+  ChangeBuffStackEvent,
+  ClassResources,
+  EventType,
+  GetRelatedEvents,
+  HasRelatedEvent,
+  RefreshBuffEvent,
   RemoveBuffEvent,
   RemoveBuffStackEvent,
-  ClassResources,
-  GetRelatedEvent,
 } from 'parser/core/Events';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import ResourceTracker from 'parser/shared/modules/resources/resourcetracker/ResourceTracker';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import {
   MAELSTROM_GENERATOR_LINK,
-  MAELSTROM_WEAPON_SPEND_LINK,
+  MAELSTROM_SPENDER_LINK,
 } from '../normalizers/EventLinkNormalizer';
+import { MAELSTROM_WEAPON_ELIGIBLE_SPELLS } from 'analysis/retail/shaman/enhancement/constants';
 
-const DEBUG = false;
+const DEBUG = true;
 
 export const PERFECT_WASTED_PERCENT = 0.1;
 export const GOOD_WASTED_PERCENT = 0.2;
 export const OK_WASTED_PERCENT = 0.3;
 
 const WITCH_DOCTORS_ANCESTRY_REDUCTION_MS: Record<number, number> = { 1: 1000, 2: 2000 };
+const MAELSTROM_SPENDERS = MAELSTROM_WEAPON_ELIGIBLE_SPELLS.map((spell) => spell.id);
+const MAELSTROM_GENERATORS = [
+  TALENTS.STORMSTRIKE_TALENT.id,
+  TALENTS.LAVA_LASH_TALENT.id,
+  TALENTS.ICE_STRIKE_TALENT.id,
+  TALENTS.FROST_SHOCK_TALENT.id,
+  TALENTS.FIRE_NOVA_TALENT.id,
+  TALENTS.PRIMORDIAL_WAVE_SPEC_TALENT.id,
+];
 
 const MaelstromWeaponResource: Resource = {
   id: -99,
@@ -51,7 +61,7 @@ export default class extends ResourceTracker {
 
   spellUsable!: SpellUsable;
 
-  ignoreNextRefresh = true;
+  //ignoreNextRefresh = true;
   isDead: boolean = false;
   lastAppliedTime = 0;
   expiredWaste = 0;
@@ -69,6 +79,8 @@ export default class extends ResourceTracker {
 
     const rank = this.selectedCombatant.getTalentRank(TALENTS.WITCH_DOCTORS_ANCESTRY_TALENT);
     this.cooldownPerMaelstromGained = WITCH_DOCTORS_ANCESTRY_REDUCTION_MS[rank];
+
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onCastSpell);
 
     this.addEventListener(
       Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.FERAL_SPIRIT_MAELSTROM_BUFF),
@@ -131,9 +143,55 @@ export default class extends ResourceTracker {
     return QualitativePerformance.Fail;
   }
 
+  onCastSpell(event: CastEvent) {
+    if (MAELSTROM_SPENDERS.includes(event.ability.guid)) {
+      if (HasRelatedEvent(event, MAELSTROM_SPENDER_LINK)) {
+        const cost = event.resourceCost ?? {};
+        event.resourceCost = {
+          ...cost,
+          [this.resource.id]: this.current,
+        };
+        this._applySpender(event, this.current, {
+          amount: this.current,
+          max: this.maxResource,
+          type: this.resource.id,
+        });
+      } else {
+        DEBUG && console.warn(`Cast is not linked to a spender`, event);
+      }
+    } else if (MAELSTROM_GENERATORS.includes(event.ability.guid)) {
+      const gain = GetRelatedEvents(
+        event,
+        MAELSTROM_GENERATOR_LINK,
+        (e) => e.type === EventType.ApplyBuff || e.type === EventType.ApplyBuffStack,
+      ).length;
+      const waste = GetRelatedEvents(
+        event,
+        MAELSTROM_GENERATOR_LINK,
+        (e) => e.type === EventType.RefreshBuff,
+      ).length;
+
+      if (gain || waste) {
+        this._applyBuilder(event.ability.guid, gain, waste, event.timestamp, {
+          amount: this.current + gain,
+          max: this.maxResource,
+          type: this.resource.id,
+        });
+        this.reduceFeralSpiritCooldown(gain + waste);
+      }
+    }
+  }
+
   onChangeStack(
     event: ApplyBuffEvent | ApplyBuffStackEvent | RemoveBuffEvent | RemoveBuffStackEvent,
   ) {
+    if (
+      HasRelatedEvent(event, MAELSTROM_GENERATOR_LINK) ||
+      HasRelatedEvent(event, MAELSTROM_SPENDER_LINK)
+    ) {
+      return;
+    }
+
     let newStacks = 0;
     if (event.type === EventType.ApplyBuff) {
       newStacks = 1;
@@ -159,66 +217,56 @@ export default class extends ResourceTracker {
     };
 
     if (change > 0) {
-      this.ignoreNextRefresh = true;
-      const generator = GetRelatedEvent<CastEvent>(event, MAELSTROM_GENERATOR_LINK);
-      this._applyBuilder(
-        generator?.ability.guid ?? event.ability.guid,
-        change,
-        0,
-        event.timestamp,
-        resource,
-      );
+      this._applyBuilder(event.ability.guid, change, 0, event.timestamp, resource);
       this.reduceFeralSpiritCooldown();
     } else {
-      const spenderEvent = GetRelatedEvent<CastEvent | FreeCastEvent>(
-        event,
-        MAELSTROM_WEAPON_SPEND_LINK,
-      );
-      if (spenderEvent) {
-        this._applySpender(spenderEvent, -change, resource);
-      } else {
-        DEBUG &&
-          console.warn(
-            `Resource change @ ${this.owner.formatTimestamp(
-              event.timestamp,
-              1,
-            )} is not linked to a maelstrom spender`,
-            event,
-          );
-        // if there is no linked event, the stacks expired naturally or death
-        this._logAndPushUpdate(
-          {
-            type: 'drain',
-            timestamp: event.timestamp,
-            current: 0,
-            max: this.maxResource,
-            rate: 0,
-            atCap: false,
-          },
-          this.current,
-          newStacks,
-          false,
+      DEBUG &&
+        console.warn(
+          `Resource change @ ${this.owner.formatTimestamp(
+            event.timestamp,
+            1,
+          )} is not linked to a maelstrom spender`,
+          event,
         );
-      }
+      // if there is no linked event, the stacks expired naturally or death
+      this._logAndPushUpdate(
+        {
+          type: 'drain',
+          timestamp: event.timestamp,
+          current: 0,
+          max: this.maxResource,
+          rate: 0,
+          atCap: false,
+        },
+        this.current,
+        newStacks,
+        false,
+      );
     }
   }
 
   onRefresh(event: RefreshBuffEvent) {
-    if (this.ignoreNextRefresh) {
-      this.ignoreNextRefresh = false;
+    if (HasRelatedEvent(event, MAELSTROM_GENERATOR_LINK)) {
       return;
     }
 
     if (this.current === 10) {
-      const generator = GetRelatedEvent<CastEvent>(event, MAELSTROM_GENERATOR_LINK);
       this._applyBuilder(
-        generator?.ability.guid ?? event.ability.guid,
+        event.ability.guid,
         0,
         1,
         event.timestamp,
         this.getMaelstromResource(event),
       );
       this.reduceFeralSpiritCooldown();
+    } else {
+      DEBUG &&
+        console.warn(
+          `Refresh event @ ${this.owner.formatTimestamp(event.timestamp, 3)} at ${
+            this.current
+          } maelstrom`,
+          event,
+        );
     }
   }
 
@@ -226,7 +274,7 @@ export default class extends ResourceTracker {
     this.outOfOrderCooldownReduction += this.cooldownPerMaelstromGained;
   }
 
-  reduceFeralSpiritCooldown() {
+  reduceFeralSpiritCooldown(maelstromGained: number = 1) {
     if (!this.selectedCombatant.hasTalent(TALENTS.WITCH_DOCTORS_ANCESTRY_TALENT)) {
       return;
     }
@@ -234,15 +282,15 @@ export default class extends ResourceTracker {
     if (this.spellUsable.isOnCooldown(TALENTS.FERAL_SPIRIT_TALENT.id)) {
       const effectiveReduction = this.spellUsable.reduceCooldown(
         TALENTS.FERAL_SPIRIT_TALENT.id,
-        this.cooldownPerMaelstromGained + this.outOfOrderCooldownReduction,
+        this.cooldownPerMaelstromGained * maelstromGained + this.outOfOrderCooldownReduction,
       );
       this.feralSpiritTotalCooldownReduction += effectiveReduction;
       this.feralSpiritCooldownReductionWasted +=
-        this.cooldownPerMaelstromGained - effectiveReduction;
+        this.cooldownPerMaelstromGained * maelstromGained - effectiveReduction;
       this.outOfOrderCooldownReduction = 0;
     } else {
       this.feralSpiritCooldownReductionWasted += Math.max(
-        this.cooldownPerMaelstromGained - this.outOfOrderCooldownReduction,
+        this.cooldownPerMaelstromGained * maelstromGained - this.outOfOrderCooldownReduction,
         0,
       );
     }

--- a/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponTracker.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponTracker.tsx
@@ -14,11 +14,15 @@ import Events, {
   RemoveBuffEvent,
   RemoveBuffStackEvent,
   ClassResources,
+  GetRelatedEvent,
 } from 'parser/core/Events';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import ResourceTracker from 'parser/shared/modules/resources/resourcetracker/ResourceTracker';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
-import { MAELSTROM_WEAPON_SPEND_LINK } from '../normalizers/EventLinkNormalizer';
+import {
+  MAELSTROM_GENERATOR_LINK,
+  MAELSTROM_WEAPON_SPEND_LINK,
+} from '../normalizers/EventLinkNormalizer';
 
 const DEBUG = false;
 
@@ -157,7 +161,14 @@ export default class extends ResourceTracker {
 
     if (change > 0) {
       this.ignoreNextRefresh = true;
-      this._applyBuilder(event.ability.guid, change, 0, event.timestamp, resource);
+      const generator = GetRelatedEvent<CastEvent>(event, MAELSTROM_GENERATOR_LINK);
+      this._applyBuilder(
+        generator?.ability.guid ?? event.ability.guid,
+        change,
+        0,
+        event.timestamp,
+        resource,
+      );
       this.reduceFeralSpiritCooldown();
     } else {
       const spenderEvent = event._linkedEvents?.find(
@@ -199,8 +210,9 @@ export default class extends ResourceTracker {
     }
 
     if (this.current === 10) {
+      const generator = GetRelatedEvent<CastEvent>(event, MAELSTROM_GENERATOR_LINK);
       this._applyBuilder(
-        event.ability.guid,
+        generator?.ability.guid ?? event.ability.guid,
         0,
         1,
         event.timestamp,

--- a/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponTracker.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponTracker.tsx
@@ -8,7 +8,6 @@ import Events, {
   EventType,
   CastEvent,
   FreeCastEvent,
-  LinkedEvent,
   ApplyBuffEvent,
   ApplyBuffStackEvent,
   RemoveBuffEvent,
@@ -171,9 +170,10 @@ export default class extends ResourceTracker {
       );
       this.reduceFeralSpiritCooldown();
     } else {
-      const spenderEvent = event._linkedEvents?.find(
-        (le: LinkedEvent) => le.relation === MAELSTROM_WEAPON_SPEND_LINK,
-      )?.event as CastEvent | FreeCastEvent | undefined;
+      const spenderEvent = GetRelatedEvent<CastEvent | FreeCastEvent>(
+        event,
+        MAELSTROM_WEAPON_SPEND_LINK,
+      );
       if (spenderEvent) {
         this._applySpender(spenderEvent, -change, resource);
       } else {
@@ -195,7 +195,7 @@ export default class extends ResourceTracker {
             rate: 0,
             atCap: false,
           },
-          newStacks,
+          this.current,
           newStacks,
           false,
         );

--- a/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponTracker.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponTracker.tsx
@@ -48,7 +48,7 @@ const MaelstromWeaponResource: Resource = {
   url: 'maelstrom_weapon',
 };
 
-export default class extends ResourceTracker {
+class MaelstromWeaponTracker extends ResourceTracker {
   static dependencies = {
     ...ResourceTracker.dependencies,
     spellUsable: SpellUsable,
@@ -318,3 +318,5 @@ export default class extends ResourceTracker {
     };
   }
 }
+
+export default MaelstromWeaponTracker;

--- a/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponTracker.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponTracker.tsx
@@ -24,7 +24,7 @@ import {
 } from '../normalizers/EventLinkNormalizer';
 import { MAELSTROM_WEAPON_ELIGIBLE_SPELLS } from 'analysis/retail/shaman/enhancement/constants';
 
-const DEBUG = true;
+const DEBUG = false;
 
 export const PERFECT_WASTED_PERCENT = 0.1;
 export const GOOD_WASTED_PERCENT = 0.2;
@@ -157,7 +157,14 @@ export default class extends ResourceTracker {
           type: this.resource.id,
         });
       } else {
-        DEBUG && console.warn(`Cast is not linked to a spender`, event);
+        DEBUG &&
+          console.warn(
+            `${event.ability.name} cast @ ${this.owner.formatTimestamp(
+              event.timestamp,
+              3,
+            )} is not linked to a spender`,
+            event,
+          );
       }
     } else if (MAELSTROM_GENERATORS.includes(event.ability.guid)) {
       const gain = GetRelatedEvents(

--- a/src/analysis/retail/shaman/enhancement/modules/talents/AshenCatalyst.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/AshenCatalyst.tsx
@@ -47,12 +47,10 @@ class AshenCatalyst extends Analyzer {
     if (!event.tick) {
       return;
     }
-    if (this.spellUsable.isOnCooldown(TALENTS.LAVA_LASH_TALENT.id)) {
-      this.effectiveCooldownReduction += this.spellUsable.reduceCooldown(
-        TALENTS.LAVA_LASH_TALENT.id,
-        ASHEN_CATALYST_COOLDOWN_REDUCTION_MS,
-      );
-    }
+    this.effectiveCooldownReduction += this.spellUsable.reduceCooldown(
+      TALENTS.LAVA_LASH_TALENT.id,
+      ASHEN_CATALYST_COOLDOWN_REDUCTION_MS,
+    );
   }
 
   onLavaLash(event: DamageEvent) {

--- a/src/analysis/retail/shaman/enhancement/modules/talents/ElementalAssault.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/ElementalAssault.tsx
@@ -128,7 +128,7 @@ class ElementalAssault extends Analyzer {
             <ItemDamageDone amount={this.damageGained} />
           </>
         }
-        position={STATISTIC_ORDER.OPTIONAL()}
+        position={STATISTIC_ORDER.DEFAULT}
         category={STATISTIC_CATEGORY.TALENTS}
         wide
       >

--- a/src/analysis/retail/shaman/enhancement/modules/talents/ElementalAssault.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/ElementalAssault.tsx
@@ -3,13 +3,17 @@ import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
 import Events, { DamageEvent } from 'parser/core/Events';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
-import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
 import { STORMSTRIKE_DAMAGE_SPELLS } from '../../constants';
-import TalentSpellText from 'parser/ui/TalentSpellText';
 import { MaelstromWeaponTracker } from '../resourcetracker';
+import TalentAggregateStatisticContainer from 'parser/ui/TalentAggregateStatisticContainer';
+import { SpellLink } from 'interface';
+import TalentAggregateBars, { TalentAggregateBarSpec } from 'parser/ui/TalentAggregateStatistic';
+import { maybeGetSpell } from 'common/SPELLS';
+import { TalentRankTooltip } from 'parser/ui/TalentSpellText';
+import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 
 const ELEMENTAL_ASSAULT_RANKS: Record<number, number> = {
   1: 0.1,
@@ -22,6 +26,12 @@ const ELEMENTAL_ASSAULT_SPELLS: number[] = [
   TALENTS_SHAMAN.ICE_STRIKE_TALENT.id,
 ];
 
+const BAR_COLORS: Record<number, string> = {
+  [TALENTS_SHAMAN.STORMSTRIKE_TALENT.id]: '#3b7fb0',
+  [TALENTS_SHAMAN.LAVA_LASH_TALENT.id]: '#f37735',
+  [TALENTS_SHAMAN.ICE_STRIKE_TALENT.id]: '#94d3ec',
+};
+
 /**
  * Stormstrike damage is increased by [10/20]%, and Stormstrike, Lava Lash, and Ice Strike
  * have a [50/100]% chance to generate 1 stack of Maelstrom Weapon.
@@ -31,9 +41,12 @@ const ELEMENTAL_ASSAULT_SPELLS: number[] = [
  */
 class ElementalAssault extends Analyzer {
   static dependencies = {
-    tracker: MaelstromWeaponTracker,
+    maelstromTracker: MaelstromWeaponTracker,
+    abilityTracker: AbilityTracker,
   };
-  protected tracker!: MaelstromWeaponTracker;
+  protected maelstromTracker!: MaelstromWeaponTracker;
+  protected abilityTracker!: AbilityTracker;
+
   protected damageIncrease: number = 0;
   protected damageGained: number = 0;
 
@@ -62,20 +75,25 @@ class ElementalAssault extends Analyzer {
   }
 
   get maelstromGenerators() {
-    const elementalAssaultBuilders = Object.keys(this.tracker.buildersObj)
+    const elementalAssaultBuilders = Object.keys(this.maelstromTracker.buildersObj)
       .map((abilityId) => {
         const id = Number(abilityId);
+        const ability = this.abilityTracker.getAbility(id);
         return {
           abilityId: id,
-          casts: this.tracker.buildersObj[id].casts,
-          total: this.tracker.buildersObj[id].generated + this.tracker.buildersObj[id].wasted,
+          casts: ability.casts,
+          total:
+            this.maelstromTracker.buildersObj[id].generated +
+            this.maelstromTracker.buildersObj[id].wasted,
         };
       })
       .filter((ability) => ELEMENTAL_ASSAULT_SPELLS.includes(ability.abilityId));
 
-    // if the combatant has the swirling maelstrom, assume SW generated the first stack.
+    // if the combatant has the swirling maelstrom, assume SW generated the first stack as it's guaranteed. EA is only guaranteed with 2 points
     if (this.selectedCombatant.hasTalent(TALENTS_SHAMAN.SWIRLING_MAELSTROM_TALENT)) {
-      const iceStrike = elementalAssaultBuilders[TALENTS_SHAMAN.ICE_STRIKE_TALENT.id];
+      const iceStrike = elementalAssaultBuilders.find(
+        (x) => x.abilityId === TALENTS_SHAMAN.ICE_STRIKE_TALENT.id,
+      );
       if (iceStrike) {
         iceStrike.total -= iceStrike.casts;
       }
@@ -87,19 +105,35 @@ class ElementalAssault extends Analyzer {
     return this.maelstromGenerators.reduce((total, ability) => (total += ability.total), 0);
   }
 
+  makeBars(): TalentAggregateBarSpec[] {
+    return this.maelstromGenerators.map((generator) => {
+      const spell = maybeGetSpell(generator.abilityId);
+      return {
+        spell: spell!,
+        amount: generator.total,
+        color: BAR_COLORS[generator.abilityId],
+        subSpecs: [],
+      };
+    });
+  }
+
   statistic() {
+    const eaRanks = this.selectedCombatant.getTalentRank(TALENTS_SHAMAN.ELEMENTAL_ASSAULT_TALENT);
     return (
-      <Statistic
-        position={STATISTIC_ORDER.OPTIONAL()}
-        category={STATISTIC_CATEGORY.TALENTS}
-        size="flexible"
-      >
-        <TalentSpellText talent={TALENTS_SHAMAN.ELEMENTAL_ASSAULT_TALENT}>
+      <TalentAggregateStatisticContainer
+        title={
           <>
+            <SpellLink spell={TALENTS_SHAMAN.ELEMENTAL_ASSAULT_TALENT} />
+            <TalentRankTooltip rank={eaRanks} maxRanks={2} /> -{' '}
             <ItemDamageDone amount={this.damageGained} />
           </>
-        </TalentSpellText>
-      </Statistic>
+        }
+        position={STATISTIC_ORDER.OPTIONAL()}
+        category={STATISTIC_CATEGORY.TALENTS}
+        wide
+      >
+        <TalentAggregateBars bars={this.makeBars()} wide />
+      </TalentAggregateStatisticContainer>
     );
   }
 }

--- a/src/analysis/retail/shaman/enhancement/modules/talents/ElementalBlast.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/ElementalBlast.tsx
@@ -225,13 +225,6 @@ class ElementalBlast extends BaseElementalBlast {
           rare cases up to nearly 250% with five{' '}
           <SpellLink spell={TALENTS.ELEMENTAL_SPIRITS_TALENT} />
         </p>
-        <p>
-          As such, you only want to use{' '}
-          <SpellLink spell={TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT} /> when you have one or more{' '}
-          <SpellLink spell={TALENTS.ELEMENTAL_SPIRITS_TALENT} /> active, or you have two charges.{' '}
-          <SpellLink spell={TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT} /> is still your most
-          efficient maelstrom spender, so sitting on two charges is a DPS loss.
-        </p>
       </>,
       // details/data
       <>

--- a/src/analysis/retail/shaman/enhancement/modules/talents/ElementalBlast.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/ElementalBlast.tsx
@@ -1,0 +1,271 @@
+import BaseElementalBlast from '../../../shared/ElementalBlast';
+import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, {
+  ApplyBuffEvent,
+  CastEvent,
+  RemoveBuffEvent,
+  UpdateSpellUsableEvent,
+  UpdateSpellUsableType,
+} from 'parser/core/Events';
+import TALENTS from 'common/TALENTS/shaman';
+import SPELLS from 'common/SPELLS/shaman';
+import Spell from 'common/SPELLS/Spell';
+import { MaelstromWeaponTracker } from '../resourcetracker';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import { ChecklistUsageInfo, SpellUse, spellUseToBoxRowEntry } from 'parser/core/SpellUsage/core';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { SpellLink } from 'interface';
+import { PanelHeader } from 'interface/guide/components/GuideDivs';
+import { PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+
+const ELEMENTAL_SPIRIT_BUFFS: Spell[] = [
+  SPELLS.ELEMENTAL_SPIRITS_BUFF_MOLTEN_WEAPON,
+  SPELLS.ELEMENTAL_SPIRITS_BUFF_ICY_EDGE,
+  SPELLS.ELEMENTAL_SPIRITS_BUFF_CRACKLING_SURGE,
+];
+
+interface ElementalBlastCastDetails {
+  event: CastEvent;
+  chargesBeforeCast: number;
+  elementalSpiritsActive: number;
+  maelstromUsed: number;
+}
+
+class ElementalBlast extends BaseElementalBlast {
+  static dependencies = {
+    ...BaseElementalBlast.dependencies,
+    maelstromTracker: MaelstromWeaponTracker,
+  };
+  protected maelstromTracker!: MaelstromWeaponTracker;
+
+  protected elementalSpritsActive: Record<number, number> = {};
+  protected elementalBlastCasts: ElementalBlastCastDetails[] = [];
+  protected maxCharges: number = 0;
+  protected currentCharges: number = 0;
+
+  protected guideActive: boolean = false;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.guideActive =
+      this.active &&
+      this.selectedCombatant.hasTalent(TALENTS.ELEMENTAL_BLAST_ENHANCEMENT_TALENT) &&
+      this.selectedCombatant.hasTalent(TALENTS.ELEMENTAL_SPIRITS_TALENT);
+    if (!this.guideActive) {
+      return;
+    }
+
+    this.elementalSpritsActive = ELEMENTAL_SPIRIT_BUFFS.reduce(
+      (rec: Record<number, number>, spell: Spell) => {
+        rec[spell.id] = 0;
+        return rec;
+      },
+      {},
+    );
+
+    this.maxCharges = this.selectedCombatant.getMultipleTalentRanks(
+      TALENTS.ELEMENTAL_BLAST_ENHANCEMENT_TALENT,
+      TALENTS.LAVA_BURST_TALENT,
+    );
+    this.currentCharges = this.maxCharges;
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT),
+      this.onCast,
+    );
+    this.addEventListener(
+      Events.applybuff.spell(ELEMENTAL_SPIRIT_BUFFS),
+      this.onApplyElementalSpiritBuff,
+    );
+    this.addEventListener(
+      Events.removebuff.spell(ELEMENTAL_SPIRIT_BUFFS),
+      this.onRemoveElementalSpiritBuff,
+    );
+    this.addEventListener(
+      Events.UpdateSpellUsable.to(SELECTED_PLAYER).spell(TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT),
+      this.onUpdateSpellUsable,
+    );
+  }
+
+  onCast(event: CastEvent) {
+    this.elementalBlastCasts.push({
+      chargesBeforeCast: this.currentCharges,
+      elementalSpiritsActive: this.activeElementalSpirits,
+      maelstromUsed: this.maelstromTracker.current,
+      event: event,
+    });
+    this.currentCharges -= 1;
+  }
+
+  onUpdateSpellUsable(event: UpdateSpellUsableEvent) {
+    if (
+      event.updateType === UpdateSpellUsableType.RestoreCharge ||
+      event.updateType === UpdateSpellUsableType.EndCooldown
+    ) {
+      this.currentCharges += 1;
+    }
+  }
+
+  onApplyElementalSpiritBuff(event: ApplyBuffEvent) {
+    this.elementalSpritsActive[event.ability.guid] += 1;
+  }
+
+  onRemoveElementalSpiritBuff(event: RemoveBuffEvent) {
+    this.elementalSpritsActive[event.ability.guid] -= 1;
+  }
+
+  get activeElementalSpirits(): number {
+    return Object.keys(this.elementalSpritsActive).reduce(
+      (total: number, buffId: string) => (total += this.elementalSpritsActive[Number(buffId)]),
+      0,
+    );
+  }
+
+  getElementalSpiritsPerformance(cast: ElementalBlastCastDetails) {
+    return cast.elementalSpiritsActive >= 3
+      ? QualitativePerformance.Perfect
+      : cast.elementalSpiritsActive >= 2
+      ? QualitativePerformance.Good
+      : cast.elementalSpiritsActive >= 1
+      ? QualitativePerformance.Ok
+      : QualitativePerformance.Fail;
+  }
+
+  getMaelstromUsagePerformance(cast: ElementalBlastCastDetails) {
+    return cast.maelstromUsed === 10
+      ? QualitativePerformance.Perfect
+      : cast.maelstromUsed >= 8
+      ? QualitativePerformance.Good
+      : cast.maelstromUsed >= 5
+      ? QualitativePerformance.Ok
+      : QualitativePerformance.Fail;
+  }
+
+  getOverallCastPerformance(cast: ElementalBlastCastDetails) {
+    if (cast.chargesBeforeCast === 2 && cast.maelstromUsed >= 5) {
+      return QualitativePerformance.Perfect;
+    } else if (cast.elementalSpiritsActive >= 1) {
+      return cast.maelstromUsed >= 8
+        ? QualitativePerformance.Perfect
+        : cast.maelstromUsed >= 5
+        ? QualitativePerformance.Ok
+        : QualitativePerformance.Fail;
+    }
+    return QualitativePerformance.Fail;
+  }
+
+  get guideSubsection() {
+    if (!this.guideActive) {
+      return null;
+    }
+
+    const casts: SpellUse[] = this.elementalBlastCasts.map((cast) => {
+      const checklistItems: ChecklistUsageInfo[] = [];
+
+      const mswPerf = this.getMaelstromUsagePerformance(cast);
+      checklistItems.push({
+        check: 'elemental-blast-maelstrom',
+        timestamp: cast.event.timestamp,
+        performance: mswPerf,
+        summary: (
+          <>
+            {cast.maelstromUsed} <SpellLink spell={SPELLS.MAELSTROM_WEAPON_BUFF} /> used
+          </>
+        ),
+        details: <></>,
+      });
+
+      checklistItems.push({
+        check: 'elemental-blast-elemental-spirits',
+        timestamp: cast.event.timestamp,
+        performance: this.getElementalSpiritsPerformance(cast),
+        summary: (
+          <>
+            {cast.elementalSpiritsActive === 0 ? 'No' : cast.elementalSpiritsActive}{' '}
+            <SpellLink spell={TALENTS.ELEMENTAL_SPIRITS_TALENT} /> active
+          </>
+        ),
+        details: <></>,
+      });
+
+      cast.elementalSpiritsActive === 0 &&
+        checklistItems.push({
+          check: 'elemental-blast-charges',
+          timestamp: cast.event.timestamp,
+          performance:
+            cast.chargesBeforeCast === 2 && cast.maelstromUsed >= 5
+              ? QualitativePerformance.Perfect
+              : QualitativePerformance.Fail,
+          summary: (
+            <>{cast.chargesBeforeCast === 2 ? 'Used at max charges' : 'Not at max charges'}</>
+          ),
+          details: <></>,
+        });
+
+      return {
+        _key: `elemental-blast-${cast.event.timestamp}`,
+        event: cast.event,
+        performance: this.getOverallCastPerformance(cast), // performance box should be colored according to APL rules, not on checklists
+        checklistItems: checklistItems,
+      };
+    });
+
+    const performance = casts.map((cast) =>
+      spellUseToBoxRowEntry(cast, this.owner.fight.start_time),
+    );
+
+    return explanationAndDataSubsection(
+      // description
+      <>
+        <p>
+          <SpellLink spell={TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT} /> damage is multiplicatively
+          increased for each <SpellLink spell={TALENTS.ELEMENTAL_SPIRITS_TALENT} /> that is
+          currently active, typically ranging from a 20% increase with one to 78% with three, and in
+          rare cases up to nearly 250% with five{' '}
+          <SpellLink spell={TALENTS.ELEMENTAL_SPIRITS_TALENT} />
+        </p>
+        <p>
+          As such, you only want to use{' '}
+          <SpellLink spell={TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT} /> when you have one or more{' '}
+          <SpellLink spell={TALENTS.ELEMENTAL_SPIRITS_TALENT} /> active, or you have two charges.{' '}
+          <SpellLink spell={TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT} /> is still your most
+          efficient maelstrom spender, so sitting on two charges is a DPS loss.
+        </p>
+      </>,
+      // details/data
+      <>
+        <div>
+          <PanelHeader>
+            <strong>Elemental Blast cast breakdown</strong> -{' '}
+            <small>
+              Proper usage of <SpellLink spell={TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT} /> with{' '}
+              <SpellLink spell={TALENTS.ELEMENTAL_SPIRITS_TALENT} /> active is crucial
+            </small>
+          </PanelHeader>
+          <PerformanceBoxRow values={performance} />
+        </div>
+      </>,
+      undefined,
+      'Elemental Blast',
+    );
+  }
+
+  getCastPerformance(cast: ElementalBlastCastDetails): QualitativePerformance {
+    if (cast.chargesBeforeCast === 2 && cast.maelstromUsed >= 5) {
+      return QualitativePerformance.Perfect;
+    }
+
+    if (cast.elementalSpiritsActive > 0) {
+      return cast.maelstromUsed >= 8
+        ? QualitativePerformance.Perfect
+        : cast.maelstromUsed >= 5
+        ? QualitativePerformance.Good
+        : QualitativePerformance.Fail;
+    }
+
+    return cast.maelstromUsed >= 5 ? QualitativePerformance.Ok : QualitativePerformance.Fail;
+  }
+}
+
+export default ElementalBlast;

--- a/src/analysis/retail/shaman/enhancement/modules/talents/ElementalBlast.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/ElementalBlast.tsx
@@ -18,6 +18,8 @@ import { SpellLink } from 'interface';
 import { PanelHeader } from 'interface/guide/components/GuideDivs';
 import { PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
 
+const DEBUG = false;
+
 const ELEMENTAL_SPIRIT_BUFFS: Spell[] = [
   SPELLS.ELEMENTAL_SPIRITS_BUFF_MOLTEN_WEAPON,
   SPELLS.ELEMENTAL_SPIRITS_BUFF_ICY_EDGE,
@@ -89,10 +91,18 @@ class ElementalBlast extends BaseElementalBlast {
   }
 
   onCast(event: CastEvent) {
+    if (this.maelstromTracker.lastSpenderInfo?.spellId !== event.ability.guid) {
+      DEBUG &&
+        console.warn(
+          `Last spender is not an elemental blast`,
+          this.maelstromTracker.lastSpenderInfo,
+          event,
+        );
+    }
     this.elementalBlastCasts.push({
       chargesBeforeCast: this.currentCharges,
       elementalSpiritsActive: this.activeElementalSpirits,
-      maelstromUsed: this.maelstromTracker.current,
+      maelstromUsed: this.maelstromTracker.lastSpenderInfo?.amount ?? 0,
       event: event,
     });
     this.currentCharges -= 1;

--- a/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
@@ -8,6 +8,7 @@ import Events, {
   ApplyBuffEvent,
   CastEvent,
   DamageEvent,
+  RefreshBuffEvent,
   RemoveBuffEvent,
 } from 'parser/core/Events';
 import Haste from 'parser/shared/modules/Haste';
@@ -37,7 +38,7 @@ class HotHandRank {
 }
 
 const HOT_HAND: Record<number, HotHandRank> = {
-  1: new HotHandRank(0.5, 0.4),
+  1: new HotHandRank(0.6, 0.4),
   2: new HotHandRank(0.75, 0.6),
 };
 
@@ -112,9 +113,9 @@ class HotHand extends MajorCooldown<HotHandProc> {
     this.hotHandActive.startInterval(event.timestamp);
   }
 
-  refreshHotHand() {
+  refreshHotHand(event: RefreshBuffEvent) {
     // on refresh, we only need to reset the CD, since we've already applied the mod rate
-    this.spellUsable.endCooldown(TALENTS_SHAMAN.LAVA_LASH_TALENT.id);
+    this.spellUsable.endCooldown(TALENTS_SHAMAN.LAVA_LASH_TALENT.id, event.timestamp, true);
   }
 
   removeHotHand(event: RemoveBuffEvent) {

--- a/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
@@ -5,11 +5,12 @@ import { SpellLink } from 'interface';
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
 import Events, {
-  ApplyBuffEvent,
   CastEvent,
   DamageEvent,
-  RefreshBuffEvent,
+  FightEndEvent,
   RemoveBuffEvent,
+  UpdateSpellUsableEvent,
+  UpdateSpellUsableType,
 } from 'parser/core/Events';
 import Haste from 'parser/shared/modules/Haste';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
@@ -19,9 +20,18 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import { Intervals } from '../core/Intervals';
 import MajorCooldown, { SpellCast } from 'parser/core/MajorCooldowns/MajorCooldown';
-import { SpellUse } from 'parser/core/SpellUsage/core';
+import { ChecklistUsageInfo, SpellUse } from 'parser/core/SpellUsage/core';
 import { ReactNode } from 'react';
 import TalentSpellText from 'parser/ui/TalentSpellText';
+import { QualitativePerformance, getLowestPerf } from 'parser/ui/QualitativePerformance';
+import Abilities from '../Abilities';
+import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
+import EmbeddedTimelineContainer, {
+  SpellTimeline,
+} from 'interface/report/Results/Timeline/EmbeddedTimeline';
+import Casts from 'interface/report/Results/Timeline/Casts';
+import CooldownUsage from 'parser/core/MajorCooldowns/CooldownUsage';
+import { SubSection } from 'interface/guide';
 
 class HotHandRank {
   modRate: number;
@@ -42,9 +52,16 @@ const HOT_HAND: Record<number, HotHandRank> = {
   2: new HotHandRank(0.75, 0.6),
 };
 
+interface HotHandTimeline {
+  start: number;
+  end?: number | null;
+  events: CastEvent[];
+  performance?: QualitativePerformance | null;
+}
+
 interface HotHandProc extends SpellCast {
-  buffedCasts: number;
-  fillerSpells: CastEvent[];
+  timeline: HotHandTimeline;
+  missedCasts: number;
 }
 
 /**
@@ -56,19 +73,18 @@ interface HotHandProc extends SpellCast {
  *
  */
 class HotHand extends MajorCooldown<HotHandProc> {
-  description(): ReactNode {
-    throw new Error('Method not implemented.');
-  }
-  explainPerformance(cast: HotHandProc): SpellUse {
-    throw new Error('Method not implemented.');
-  }
   static dependencies = {
     ...MajorCooldown.dependencies,
     spellUsable: SpellUsable,
     haste: Haste,
+    abilities: Abilities,
   };
   protected spellUsable!: SpellUsable;
   protected haste!: Haste;
+  protected abilities!: Abilities;
+
+  activeWindow: HotHandProc | null = null;
+  lavaLashOnCooldown: boolean = false;
 
   protected hotHand!: HotHandRank;
   protected buffedLavaLashDamage: number = 0;
@@ -76,7 +92,7 @@ class HotHand extends MajorCooldown<HotHandProc> {
   protected buffedCasts: number = 0;
 
   constructor(options: Options) {
-    super({ spell: TALENTS_SHAMAN.LAVA_LASH_TALENT }, options);
+    super({ spell: TALENTS_SHAMAN.HOT_HAND_TALENT }, options);
     this.active = this.selectedCombatant.hasTalent(TALENTS_SHAMAN.HOT_HAND_TALENT);
     if (!this.active) {
       return;
@@ -84,20 +100,26 @@ class HotHand extends MajorCooldown<HotHandProc> {
 
     this.hotHand = HOT_HAND[this.selectedCombatant.getTalentRank(TALENTS_SHAMAN.HOT_HAND_TALENT)];
 
-    this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.HOT_HAND_BUFF),
-      this.applyHotHand,
-    );
+    const abilities = options.abilities as Abilities;
+    abilities.add({
+      spell: SPELLS.HOT_HAND_BUFF.id,
+      category: SPELL_CATEGORY.COOLDOWNS,
+      gcd: null,
+      enabled: true,
+    });
 
-    // Very unlikely to happen but it does.
     this.addEventListener(
-      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.HOT_HAND_BUFF),
-      this.refreshHotHand,
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.HOT_HAND_BUFF),
+      this.startOrRefreshWindow,
     );
-
     this.addEventListener(
       Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.HOT_HAND_BUFF),
       this.removeHotHand,
+    );
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onCast);
+    this.addEventListener(
+      Events.UpdateSpellUsable.by(SELECTED_PLAYER).spell(TALENTS_SHAMAN.LAVA_LASH_TALENT),
+      this.updateSpellUsable,
     );
 
     this.addEventListener(
@@ -106,25 +128,58 @@ class HotHand extends MajorCooldown<HotHandProc> {
     );
   }
 
-  applyHotHand(event: ApplyBuffEvent) {
+  updateSpellUsable(event: UpdateSpellUsableEvent) {
+    this.lavaLashOnCooldown = event.updateType === UpdateSpellUsableType.EndCooldown;
+  }
+
+  startOrRefreshWindow(event: CastEvent) {
     // on application both resets the CD and applies a mod rate
-    this.spellUsable.endCooldown(TALENTS_SHAMAN.LAVA_LASH_TALENT.id);
-    this.spellUsable.applyCooldownRateChange(TALENTS_SHAMAN.LAVA_LASH_TALENT.id, this.hotHand.rate);
-    this.hotHandActive.startInterval(event.timestamp);
-  }
-
-  refreshHotHand(event: RefreshBuffEvent) {
-    // on refresh, we only need to reset the CD, since we've already applied the mod rate
     this.spellUsable.endCooldown(TALENTS_SHAMAN.LAVA_LASH_TALENT.id, event.timestamp, true);
+
+    if (!this.activeWindow) {
+      this.spellUsable.applyCooldownRateChange(
+        TALENTS_SHAMAN.LAVA_LASH_TALENT.id,
+        this.hotHand.rate,
+      );
+      this.hotHandActive.startInterval(event.timestamp);
+
+      this.activeWindow = {
+        event: event,
+        timeline: {
+          start: event.timestamp,
+          end: -1,
+          events: [],
+        },
+        missedCasts: 0,
+      };
+    }
   }
 
-  removeHotHand(event: RemoveBuffEvent) {
+  removeHotHand(event: RemoveBuffEvent | FightEndEvent) {
     this.spellUsable.removeCooldownRateChange(
       TALENTS_SHAMAN.LAVA_LASH_TALENT.id,
       this.hotHand.rate,
     );
 
     this.hotHandActive.endInterval(event.timestamp);
+
+    if (this.activeWindow) {
+      this.activeWindow.timeline.end = event.timestamp;
+      this.recordCooldown(this.activeWindow);
+      this.activeWindow = null;
+    }
+  }
+
+  onCast(event: CastEvent) {
+    if (this.activeWindow && event.globalCooldown) {
+      this.activeWindow.timeline.events.push(event);
+      if (
+        event.ability.guid !== TALENTS_SHAMAN.LAVA_LASH_TALENT.id &&
+        this.spellUsable.isAvailable(TALENTS_SHAMAN.LAVA_LASH_TALENT.id)
+      ) {
+        this.activeWindow.missedCasts += 1;
+      }
+    }
   }
 
   onLavaLashDamage(event: DamageEvent) {
@@ -142,6 +197,99 @@ class HotHand extends MajorCooldown<HotHandProc> {
 
   get castsPerSecond() {
     return this.buffedCasts / this.hotHandActive.intervalsCount;
+  }
+
+  description(): ReactNode {
+    return (
+      <>
+        <p>
+          <strong>
+            <SpellLink spell={TALENTS_SHAMAN.HOT_HAND_TALENT} />
+          </strong>{' '}
+          greatly increases the damage of <SpellLink spell={TALENTS_SHAMAN.LAVA_LASH_TALENT} /> and
+          significantly reduces it's cooldown. While active,{' '}
+          <SpellLink spell={TALENTS_SHAMAN.LAVA_LASH_TALENT} /> should be cast every other GCD with
+          your regular rotation as fillers.
+        </p>
+      </>
+    );
+  }
+
+  private explainTimelineWithDetails(cast: HotHandProc) {
+    const checklistItem = {
+      performance: QualitativePerformance.Perfect,
+      summary: <span>Spell order</span>,
+      details: <span>Spell order: See below</span>,
+      check: 'hothand-timeline',
+      timestamp: cast.event.timestamp,
+    };
+
+    const extraDetails = (
+      <div
+        style={{
+          overflowX: 'scroll',
+        }}
+      >
+        <EmbeddedTimelineContainer
+          secondWidth={60}
+          secondsShown={(cast.timeline.end! - cast.timeline.start) / 1000}
+        >
+          <SpellTimeline>
+            <Casts
+              start={cast.event.timestamp}
+              movement={undefined}
+              secondWidth={60}
+              events={cast.timeline.events}
+            />
+          </SpellTimeline>
+        </EmbeddedTimelineContainer>
+      </div>
+    );
+
+    return { extraDetails, checklistItem };
+  }
+
+  private explainUsagePerformance(cast: HotHandProc): ChecklistUsageInfo {
+    const lavaLashCasts = cast.timeline.events.filter(
+      (x) => x.ability.guid === TALENTS_SHAMAN.LAVA_LASH_TALENT.id,
+    ).length;
+    const missedCasts = cast.missedCasts;
+
+    return {
+      check: 'lava-lash-casts',
+      timestamp: cast.event.timestamp,
+      performance:
+        cast.missedCasts === 0
+          ? QualitativePerformance.Perfect
+          : cast.missedCasts === 1
+          ? QualitativePerformance.Good
+          : cast.missedCasts === 2
+          ? QualitativePerformance.Ok
+          : QualitativePerformance.Fail,
+      summary: (
+        <span>
+          {lavaLashCasts} <SpellLink spell={TALENTS_SHAMAN.LAVA_LASH_TALENT} /> cast(s)
+        </span>
+      ),
+      details: (
+        <span>
+          Cast <SpellLink spell={TALENTS_SHAMAN.LAVA_LASH_TALENT} /> {lavaLashCasts} time(s)
+          {missedCasts > 0 ? <> when you could have cast {lavaLashCasts + missedCasts}</> : <></>}.
+        </span>
+      ),
+    };
+  }
+
+  explainPerformance(cast: HotHandProc): SpellUse {
+    const timeline = this.explainTimelineWithDetails(cast);
+    const usage = this.explainUsagePerformance(cast);
+
+    return {
+      event: cast.event,
+      performance: getLowestPerf([usage.performance, timeline.checklistItem.performance]),
+      checklistItems: [usage, timeline.checklistItem],
+      extraDetails: timeline.extraDetails,
+    };
   }
 
   statistic() {
@@ -172,6 +320,14 @@ class HotHand extends MajorCooldown<HotHandProc> {
           </>
         </TalentSpellText>
       </Statistic>
+    );
+  }
+
+  guideSubsection(): JSX.Element {
+    return (
+      <SubSection title="Hot Hand">
+        <CooldownUsage analyzer={this} title="Hot Hand" />
+      </SubSection>
     );
   }
 }

--- a/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
@@ -26,7 +26,6 @@ import { ReactNode } from 'react';
 import TalentSpellText from 'parser/ui/TalentSpellText';
 import { QualitativePerformance, getLowestPerf } from 'parser/ui/QualitativePerformance';
 import Abilities from '../Abilities';
-import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
 import EmbeddedTimelineContainer, {
   SpellTimeline,
 } from 'interface/report/Results/Timeline/EmbeddedTimeline';
@@ -109,14 +108,6 @@ class HotHand extends MajorCooldown<HotHandProc> {
     }
 
     this.hotHand = HOT_HAND[this.selectedCombatant.getTalentRank(TALENTS_SHAMAN.HOT_HAND_TALENT)];
-
-    const abilities = options.abilities as Abilities;
-    abilities.add({
-      spell: SPELLS.HOT_HAND_BUFF.id,
-      category: SPELL_CATEGORY.COOLDOWNS,
-      gcd: null,
-      enabled: true,
-    });
 
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.HOT_HAND_BUFF),

--- a/src/analysis/retail/shaman/enhancement/modules/talents/LegacyOfTheFrostWitch.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/LegacyOfTheFrostWitch.tsx
@@ -26,6 +26,13 @@ import typedKeys from 'common/typedKeys';
 const DAMAGE_AMP_PERCENTAGE: Record<number, number> = { 1: 0.05, 2: 0.25 };
 const debug = false;
 
+/**
+ * Consuming 10 stacks of Maelstrom Weapon will reset the cooldown of Stormstrike
+ * and increases the damage of your Physical and Frost abilities by [5/25]% for 5 sec.
+ *
+ * Example Log:
+ *
+ */
 class LegacyOfTheFrostWitch extends Analyzer {
   static dependencies = {
     spellUsable: SpellUsable,
@@ -82,7 +89,8 @@ class LegacyOfTheFrostWitch extends Analyzer {
     }
     if (
       this.selectedCombatant.hasBuff(SPELLS.LEGACY_OF_THE_FROST_WITCH_BUFF.id) &&
-      isMatchingDamageType(event.ability.type, MAGIC_SCHOOLS.ids.PHYSICAL)
+      (isMatchingDamageType(event.ability.type, MAGIC_SCHOOLS.ids.PHYSICAL) ||
+        isMatchingDamageType(event.ability.type, MAGIC_SCHOOLS.ids.FROST))
     ) {
       if (event.amount > 0) {
         const spellId =

--- a/src/analysis/retail/shaman/enhancement/modules/talents/SwirlingMaelstrom.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/SwirlingMaelstrom.tsx
@@ -1,0 +1,85 @@
+import TALENTS from 'common/TALENTS/shaman';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent, GetRelatedEvents } from 'parser/core/Events';
+import { MAELSTROM_GENERATOR_LINK } from '../normalizers/EventLinkNormalizer';
+import TalentAggregateStatisticContainer from 'parser/ui/TalentAggregateStatisticContainer';
+import { SpellLink } from 'interface';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import TalentAggregateBars from 'parser/ui/TalentAggregateStatistic';
+
+const BAR_COLORS: Record<number, string> = {
+  [TALENTS.FROST_SHOCK_TALENT.id]: '#3b7fb0',
+  [TALENTS.FIRE_NOVA_TALENT.id]: '#f37735', // placeholder for when fire nova is implemented
+  [TALENTS.ICE_STRIKE_TALENT.id]: '#94d3ec',
+};
+
+/**
+ * Consuming at least 2 stacks of Hailstorm, using Ice Strike, and each explosion
+ * from Fire Nova now also grants you 1 stack of Maelstrom Weapon.
+ */
+
+class SwirlingMaelstrom extends Analyzer {
+  protected frostShock: number = 0;
+  protected iceStrike: number = 0;
+  protected fireNova: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS.SWIRLING_MAELSTROM_TALENT);
+    if (!this.active) {
+      return;
+    }
+
+    this.addEventListener(
+      Events.cast
+        .by(SELECTED_PLAYER)
+        .spell([TALENTS.FROST_SHOCK_TALENT, TALENTS.ICE_STRIKE_TALENT]),
+      this.onCast,
+    );
+  }
+
+  onCast(event: CastEvent) {
+    if (GetRelatedEvents(event, MAELSTROM_GENERATOR_LINK)) {
+      if (event.ability.guid === TALENTS.FROST_SHOCK_TALENT.id) {
+        this.frostShock += 1;
+      } else if (event.ability.guid === TALENTS.ICE_STRIKE_TALENT.id) {
+        this.iceStrike += 1;
+      }
+    }
+  }
+
+  statistic() {
+    const bars = [
+      {
+        spell: TALENTS.FROST_SHOCK_TALENT,
+        amount: this.frostShock,
+        color: BAR_COLORS[TALENTS.FROST_SHOCK_TALENT.id],
+        subSpecs: [],
+      },
+      {
+        spell: TALENTS.ICE_STRIKE_TALENT,
+        amount: this.iceStrike,
+        color: BAR_COLORS[TALENTS.ICE_STRIKE_TALENT.id],
+        subSpecs: [],
+      },
+    ];
+    return (
+      <TalentAggregateStatisticContainer
+        title={
+          <>
+            <SpellLink spell={TALENTS.SWIRLING_MAELSTROM_TALENT} />
+          </>
+        }
+        position={STATISTIC_ORDER.DEFAULT}
+        category={STATISTIC_CATEGORY.TALENTS}
+        wide
+      >
+        <TalentAggregateBars bars={bars} wide />
+      </TalentAggregateStatisticContainer>
+    );
+  }
+}
+
+export default SwirlingMaelstrom;

--- a/src/analysis/retail/shaman/enhancement/modules/talents/TempestStrikes.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/TempestStrikes.tsx
@@ -1,0 +1,47 @@
+import SPELLS from 'common/SPELLS';
+import { TALENTS_SHAMAN } from 'common/TALENTS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { DamageEvent } from 'parser/core/Events';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import Statistic from 'parser/ui/Statistic';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+
+class TempestStrikes extends Analyzer {
+  damage = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS_SHAMAN.TEMPEST_STRIKES_TALENT);
+    if (!this.active) {
+      return;
+    }
+
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.TEMPEST_STRIKES_DAMAGE),
+      this.onDamageEvent,
+    );
+  }
+
+  onDamageEvent(event: DamageEvent) {
+    this.damage += event.amount;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL()}
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
+      >
+        <TalentSpellText talent={TALENTS_SHAMAN.TEMPEST_STRIKES_TALENT}>
+          <ItemDamageDone amount={this.damage} />
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}
+
+export default TempestStrikes;

--- a/src/analysis/retail/shaman/shared/constants.ts
+++ b/src/analysis/retail/shaman/shared/constants.ts
@@ -17,3 +17,7 @@ export const GWTF_SW_SCALING = [0, 7.5, 15];
 
 // Go with the flow - Gust of Wind
 export const GWTF_GOW_SCALING = [0, 5, 10];
+
+// event links for Splintered Elements
+export const PRIMORDIAL_WAVE_LINK = 'primoridal-wave';
+export const SPLINTERED_ELEMENTS_LINK = 'splintered-elements';

--- a/src/analysis/retail/shaman/shared/guide/DefensiveAndUtility.tsx
+++ b/src/analysis/retail/shaman/shared/guide/DefensiveAndUtility.tsx
@@ -1,0 +1,49 @@
+import TALENTS from 'common/TALENTS/shaman';
+import { Section } from 'interface/guide';
+import CooldownGraphSubsection, {
+  Cooldown,
+} from 'interface/guide/components/CooldownGraphSubSection';
+
+const defensiveTalents: Cooldown[] = [
+  { spell: TALENTS.ASTRAL_SHIFT_TALENT, isActive: (c) => c.hasTalent(TALENTS.ASTRAL_SHIFT_TALENT) },
+  {
+    spell: TALENTS.EARTH_ELEMENTAL_TALENT,
+    isActive: (c) => c.hasTalent(TALENTS.EARTH_ELEMENTAL_TALENT),
+  },
+  {
+    spell: TALENTS.NATURES_SWIFTNESS_TALENT,
+    isActive: (c) => c.hasTalent(TALENTS.NATURES_SWIFTNESS_TALENT),
+  },
+  {
+    spell: TALENTS.ANCESTRAL_GUIDANCE_TALENT,
+    isActive: (c) => c.hasTalent(TALENTS.ANCESTRAL_GUIDANCE_TALENT),
+  },
+  {
+    spell: TALENTS.EARTHEN_WALL_TOTEM_TALENT,
+    isActive: (c) => c.hasTalent(TALENTS.EARTHEN_WALL_TOTEM_TALENT),
+  },
+  {
+    spell: TALENTS.SPIRITWALKERS_GRACE_TALENT,
+    isActive: (c) => c.hasTalent(TALENTS.SPIRITWALKERS_GRACE_TALENT),
+  },
+];
+
+export default function DefensiveAndUtility() {
+  return (
+    <>
+      <Section title="Defensive and utility">
+        <CooldownGraphSubsection
+          cooldowns={defensiveTalents}
+          description={
+            <p>
+              <strong>Defensives and utility</strong> - Defensive and utility talent usage may vary
+              from fight to fight. They may need to be delayed for specific mechanics. In general,
+              any amount of usage is good, but anywhere you could fit in another usage is a
+              theoretical loss.
+            </p>
+          }
+        />
+      </Section>
+    </>
+  );
+}

--- a/src/analysis/retail/shaman/shared/talents/SplinteredElements.tsx
+++ b/src/analysis/retail/shaman/shared/talents/SplinteredElements.tsx
@@ -1,0 +1,74 @@
+import SPELLS from 'common/SPELLS';
+import { Options } from 'parser/core/Module';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, {
+  ApplyBuffEvent,
+  CastEvent,
+  DamageEvent,
+  GetRelatedEvent,
+  GetRelatedEvents,
+  RemoveBuffEvent,
+} from 'parser/core/Events';
+import {
+  PRIMORDIAL_WAVE_LINK,
+  SPLINTERED_ELEMENTS_LINK,
+} from 'analysis/retail/shaman/shared/constants';
+import { LIGHTNING_BOLT_LINK } from 'analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer';
+import Haste from 'parser/shared/modules/Haste';
+
+export default class SplinteredElements extends Analyzer {
+  static dependencies = {
+    haste: Haste,
+  };
+
+  protected haste!: Haste;
+  protected hasteGain: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.SPLINTERED_ELEMENTS_BUFF),
+      this.onApplySplinteredElements,
+    );
+
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.SPLINTERED_ELEMENTS_BUFF),
+      this.onRemoveSplinteredElements,
+    );
+  }
+
+  onApplySplinteredElements(event: ApplyBuffEvent) {
+    this.hasteGain = 0;
+    const primordialWave = GetRelatedEvent<CastEvent>(event, SPLINTERED_ELEMENTS_LINK);
+    if (!primordialWave) {
+      console.error(
+        'Event link error - Splintered Elements is missing a link to a Primordial Wave cast. ' +
+          `Current Time: ${event.timestamp} (${this.owner.formatTimestamp(event.timestamp, 3)})`,
+      );
+      return;
+    }
+
+    // primordial wave boosted cast
+    const castEvent = GetRelatedEvent<CastEvent>(primordialWave, PRIMORDIAL_WAVE_LINK);
+    if (!castEvent) {
+      console.error(
+        'Event link error - Primordial Wave is missing a link to a related cast. This could be a bug or the buff timed out.',
+      );
+      return;
+    }
+    const damageEvents = GetRelatedEvents<DamageEvent>(castEvent, LIGHTNING_BOLT_LINK);
+    if (!damageEvents) {
+      console.error(
+        `Event link error - ${castEvent.ability.name} is missing related damage events`,
+      );
+      return;
+    }
+    this.hasteGain = (20 + (damageEvents.length - 2) * 4) / 100;
+    this.haste._applyHasteGain(event, this.hasteGain);
+  }
+
+  onRemoveSplinteredElements(event: RemoveBuffEvent) {
+    this.haste._applyHasteLoss(event, this.hasteGain);
+  }
+}

--- a/src/analysis/retail/shaman/shared/talents/SplinteredElements.tsx
+++ b/src/analysis/retail/shaman/shared/talents/SplinteredElements.tsx
@@ -4,15 +4,12 @@ import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, {
   ApplyBuffEvent,
   CastEvent,
-  DamageEvent,
+  EventType,
   GetRelatedEvent,
   GetRelatedEvents,
   RemoveBuffEvent,
 } from 'parser/core/Events';
-import {
-  PRIMORDIAL_WAVE_LINK,
-  SPLINTERED_ELEMENTS_LINK,
-} from 'analysis/retail/shaman/shared/constants';
+import { SPLINTERED_ELEMENTS_LINK } from 'analysis/retail/shaman/shared/constants';
 import { LIGHTNING_BOLT_LINK } from 'analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer';
 import Haste from 'parser/shared/modules/Haste';
 
@@ -40,31 +37,26 @@ export default class SplinteredElements extends Analyzer {
 
   onApplySplinteredElements(event: ApplyBuffEvent) {
     this.hasteGain = 0;
-    const primordialWave = GetRelatedEvent<CastEvent>(event, SPLINTERED_ELEMENTS_LINK);
-    if (!primordialWave) {
-      console.error(
-        'Event link error - Splintered Elements is missing a link to a Primordial Wave cast. ' +
-          `Current Time: ${event.timestamp} (${this.owner.formatTimestamp(event.timestamp, 3)})`,
-      );
-      return;
-    }
-
     // primordial wave boosted cast
-    const castEvent = GetRelatedEvent<CastEvent>(primordialWave, PRIMORDIAL_WAVE_LINK);
+    const castEvent = GetRelatedEvent<CastEvent>(event, SPLINTERED_ELEMENTS_LINK);
     if (!castEvent) {
       console.error(
         'Event link error - Primordial Wave is missing a link to a related cast. This could be a bug or the buff timed out.',
       );
       return;
     }
-    const damageEvents = GetRelatedEvents<DamageEvent>(castEvent, LIGHTNING_BOLT_LINK);
+    const damageEvents = GetRelatedEvents(
+      castEvent,
+      LIGHTNING_BOLT_LINK,
+      (e) => e.type === EventType.Damage,
+    );
     if (!damageEvents) {
       console.error(
         `Event link error - ${castEvent.ability.name} is missing related damage events`,
       );
       return;
     }
-    this.hasteGain = (20 + (damageEvents.length - 2) * 4) / 100;
+    this.hasteGain = (20 + Math.max(damageEvents.length - 2, 0) * 4) / 100;
     this.haste._applyHasteGain(event, this.hasteGain);
   }
 

--- a/src/common/SPELLS/shaman.ts
+++ b/src/common/SPELLS/shaman.ts
@@ -629,6 +629,11 @@ const spells = {
     name: 'Stormblast',
     icon: 'spell_shaman_focusedstrikes',
   },
+  TEMPEST_STRIKES_DAMAGE: {
+    id: 428078,
+    name: 'Tempest Strikes',
+    icon: 'spell_nature_thunderclap',
+  },
   // Restoration Shaman
   HEALING_SURGE: {
     id: 8004,

--- a/src/common/SPELLS/shaman.ts
+++ b/src/common/SPELLS/shaman.ts
@@ -812,6 +812,11 @@ const spells = {
     name: 'Primordial Wave',
     icon: 'ability_maldraxxus_shaman',
   },
+  SPLINTERED_ELEMENTS_BUFF: {
+    id: 382043,
+    name: 'Splintered Elements',
+    icon: 'spell_nature_elementalprecision_1',
+  },
   MANA_SPRING_RESTORATION: {
     id: 404551,
     name: 'Mana Spring',

--- a/src/common/SPELLS/shaman.ts
+++ b/src/common/SPELLS/shaman.ts
@@ -191,7 +191,7 @@ const spells = {
     icon: 'spell_nature_lightning',
   },
   ELEMENTAL_BLAST: {
-    id: 344645,
+    id: 117014,
     name: 'Elemental Blast',
     icon: 'shaman_talent_elementalblast',
   },

--- a/src/parser/core/MajorCooldowns/MajorCooldown.tsx
+++ b/src/parser/core/MajorCooldowns/MajorCooldown.tsx
@@ -18,7 +18,7 @@ export interface SpellCast {
   event: CastEvent;
 }
 
-interface CooldownOptions {
+export interface CooldownOptions {
   spell: Talent;
 }
 

--- a/src/parser/shared/metrics/apl/range.ts
+++ b/src/parser/shared/metrics/apl/range.ts
@@ -237,7 +237,7 @@ export function isInRange(state: LocationState, event: AnyEvent, spell: Spell): 
   const range = spellRange(spell.id, state.info);
   const actualCastRange = spellRange(event.ability.guid, state.info, true);
 
-  if (actualCastRange && actualCastRange < range) {
+  if (actualCastRange && actualCastRange <= range) {
     // shortcut: if we know the real range of the spell that was actually cast
     // *and* it was shorter range than the spell we're examining, then we know
     // we're in range.

--- a/src/parser/ui/TalentSpellText.tsx
+++ b/src/parser/ui/TalentSpellText.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react';
 import { Talent } from 'common/TALENTS/types';
 import { useCombatLogParser } from 'interface/report/CombatLogParserContext';
 
-const TalentRankTooltip = ({ rank, maxRanks }: { rank: number; maxRanks: number }) => (
+export const TalentRankTooltip = ({ rank, maxRanks }: { rank: number; maxRanks: number }) => (
   <>
     {' '}
     -{' '}


### PR DESCRIPTION
### Description

- Support talent changes
- New APL
- Guide section for Hot Hand, and Elemental Blast usage
- Continuing improvements to maelstrom tracker
- Statistic for Elemental Assault improved to show which talents generate the maelstrom

### Testing

- Test report URL: `/report/ZFvVn37a6HP2YCLN/39-Mythic+Igira+the+Cruel+-+Kill+(6:26)/Seriousnes/standard/overview`
- Screenshot(s): 

**Hot Hand**
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/6109344/44339047-8b0f-4982-addc-84256981a09c)

**Elemental Blast**
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/6109344/a761a6ce-1440-482a-8a48-4af7b718237c)

**Elemental Assault**
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/6109344/f23602c2-0ac8-4798-ad9e-4ed8948a1e79)
