### PR TITLE
improve upwelling module to account for 10.2 hotfixes

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 11, 25), <>Update <SpellLink spell={TALENTS_MONK.UPWELLING_TALENT}/> module</>, Trevor),
   change(date(2023, 11, 24), <>Change load conditions for <SpellLink spell={TALENTS_MONK.RISING_SUN_KICK_TALENT}/> guide section</>, Trevor),
   change(date(2023, 11, 22), <>Update explanation of colors in <SpellLink spell={SPELLS.VIVIFY}/> guide section</>, Trevor),
   change(date(2023, 11, 21), <>Fix performance calculations for <SpellLink spell={SPELLS.VIVIFY}/> when not talented into <SpellLink spell={TALENTS_MONK.UPLIFTED_SPIRITS_TALENT}/></>, Trevor),

--- a/src/analysis/retail/monk/mistweaver/Guide.tsx
+++ b/src/analysis/retail/monk/mistweaver/Guide.tsx
@@ -30,7 +30,8 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
           modules.risingSunKick.guideSubsection}
         {modules.thunderFocusTea.guideSubsection}
         {modules.vivify.guideSubsection}
-        {info.combatant.hasTalent(TALENTS_MONK.ANCIENT_TEACHINGS_TALENT) &&
+        {(info.combatant.hasTalent(TALENTS_MONK.ANCIENT_TEACHINGS_TALENT) ||
+          info.combatant.hasTalent(TALENTS_MONK.UPWELLING_TALENT)) &&
           modules.essenceFont.guideSubsection}
         {info.combatant.hasTalent(TALENTS_MONK.ANCIENT_TEACHINGS_TALENT) &&
           modules.ancientTeachings.guideSubsection}

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
@@ -32,7 +32,7 @@ import { ThresholdStyle, When } from 'parser/core/ParseResults';
 
 const debug = false;
 const NUM_EF_BOLTS = 15;
-const NUM_EF_BOLTS_UW = 33;
+const MAX_EXTRA_BOLTS = 18;
 
 class EssenceFont extends Analyzer {
   static dependencies = {
@@ -229,7 +229,7 @@ class EssenceFont extends Analyzer {
     }
     // Every second that Essence Font is ready to be cast but isn't, another bolt gets added to its next cast, up to 18
     return Math.min(
-      NUM_EF_BOLTS_UW,
+      NUM_EF_BOLTS + MAX_EXTRA_BOLTS,
       NUM_EF_BOLTS + Math.floor((event.timestamp - this.lastCdEnd) / 1000),
     );
   }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EssenceFont.tsx
@@ -239,6 +239,9 @@ class EssenceFont extends Analyzer {
     const expected = Math.max(this.getExpectedApplies(event), totalHit);
     let cancelledPerf = QualitativePerformance.Good;
     let tftPerf = QualitativePerformance.Good;
+    const manaTeaPerf = this.selectedCombatant.hasBuff(SPELLS.MANA_TEA_BUFF.id)
+      ? QualitativePerformance.Good
+      : QualitativePerformance.Fail;
     if (totalHit !== expected) {
       this.numCancelled += 1;
       cancelledPerf = QualitativePerformance.Fail;
@@ -266,9 +269,13 @@ class EssenceFont extends Analyzer {
           )}{' '}
           <PerformanceMark perf={tftPerf} />
         </div>
+        <div>
+          Reduced mana cost with <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT} />{' '}
+          <PerformanceMark perf={manaTeaPerf} />
+        </div>
       </>
     );
-    const value = getAveragePerf([cancelledPerf, tftPerf]);
+    const value = getAveragePerf([cancelledPerf, tftPerf, manaTeaPerf]);
     this.castEntries.push({ value, tooltip });
   }
 


### PR DESCRIPTION
### Description

Changes load condition for guide section to load if you have UW or ATOTM. Changes performance mark to check if you used TFT (or not) depending on build. Also updates bolt

<img width="319" alt="Screenshot 2023-11-25 at 7 13 11 PM" src="https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/c14baddf-3909-4c5e-b93a-f7ff6c15e84e">
<img width="319" alt="Screenshot 2023-11-25 at 7 14 20 PM" src="https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/a4bce848-1943-4ba5-a4d6-f7bc1e498fe3">

