### PR TITLE
hotfix: MaelstromWeaponSpenders unhandled abilities error

### DIFF
--- a/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Taum, Vetyst, Vohrr, xunni, Seriousnes, ToppleTheNun, Putro } from 'CON
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 11, 26), 'Resolve errors for unhandled abilities in the MealstromWeaponSpenders module.', Vetyst),
   change(date(2023, 9, 22), <>Minor ajustment to APL for <SpellLink spell={TALENTS_SHAMAN.ICE_STRIKE_TALENT} />, added <SpellLink spell={SPELLS.MAELSTROM_WEAPON} /> usage and efficiency tables</>, Seriousnes),
   change(date(2023, 9, 7), <>Updated to 10.1.7 compatibility</>, Seriousnes),
   change(date(2023, 9, 6), <>Reworked maelstrom tracker, added spender link and analyzer. Added maelstrom efficiency details</>, Seriousnes),

--- a/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponSpenders.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponSpenders.tsx
@@ -128,9 +128,18 @@ export default class extends Analyzer {
                 casts = ability.casts;
                 spent = this.maelstromSpendWithPrimordialWave;
               } else {
-                casts = this.maelstromWeaponTracker.spendersObj[spellId].casts;
-                spent = this.maelstromWeaponTracker.spendersObj[spellId].spent;
+                const spenderObj = this.maelstromWeaponTracker.spendersObj[spellId];
+                if (spenderObj) {
+                  casts = spenderObj.casts;
+                  spent = spenderObj.spent;
+                } else {
+                  // Hotfix: Resolves this module from loading if unhandled in
+                  // MaelstromWeaponTracker. Will show 0 casts instead.
+                  casts = 0;
+                  spent = 0;
+                }
               }
+
               const amount = this.spenderValues[spellId];
               return (
                 spell && (


### PR DESCRIPTION
As reported by Hysteriix, MaelstromWeaponSpenders is disabled under specific conditions.

I identified this to certain abilities are not handles by the MaelstromWeaponTracker causing errors. This hotfix focuses on just getting the module to stay loaded by allowing MaelstromWeaponSpender to ignore these exceptions. Any of the exceptions will show 0 casts and spend instead so this still requires some love after it has been applied.

This can be tested with the following log;
 `/report/3d9RAc8qYfmL72KV/41-Normal+Tindral+Sageswift,+Seer+of+the+Flame+-+Kill+(5:31)/Hysteriix/standard/statistics`

![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3527340/cc93bae6-4f0c-4ea2-9759-2c497b4f9bae)