### PR TITLE
Re enable holy

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -32,6 +32,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 11, 28), 'Remove deprecated Shadowlands combatantinfo that was breaking the Holy Priest analyzer.', emallson),
   change(date(2023, 11, 27), <>Fix inaccurate tooltip for <ItemLink id={ITEMS.ELEMENTAL_LARIAT.id}/>.</>, Trevor),
   change(date(2023, 11, 23), 'Refactor Code Smell Missing Union Type.', LucasLevyOB),
   change(date(2023, 11, 19), 'Remove warning for 10.2 logs.', ToppleTheNun),

--- a/src/analysis/retail/priest/holy/CONFIG.tsx
+++ b/src/analysis/retail/priest/holy/CONFIG.tsx
@@ -33,7 +33,8 @@ const config: Config = {
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/xq2FvfVCJh6YLjzZ/2/8',
+  exampleReport:
+    '/report/myZRBCM19TtWjQxD/6-Heroic+Council+of+Dreams+-+Kill+(6:29)/Ahaux/standard/overview',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/priest/holy/CONFIG.tsx
+++ b/src/analysis/retail/priest/holy/CONFIG.tsx
@@ -41,10 +41,10 @@ const config: Config = {
   // The contents of your changelog.
   changelog: [], // CHANGELOG,
   // The CombatLogParser class for your spec.
-  // parser: () =>
-  //   import('./CombatLogParser' /* webpackChunkName: "HolyPriest" */).then(
-  //     (exports) => exports.default,
-  //   ),
+  parser: () =>
+    import('./CombatLogParser' /* webpackChunkName: "HolyPriest" */).then(
+      (exports) => exports.default,
+    ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: __dirname,
 };

--- a/src/interface/report/CombatantInfoFaker.ts
+++ b/src/interface/report/CombatantInfoFaker.ts
@@ -9,8 +9,6 @@ const debugGear = false;
 type FakeInfo = {
   covenantID: CombatantInfo['covenantID'];
   soulbindID: CombatantInfo['soulbindID'];
-  conduits: CombatantInfo['conduits'];
-  soulbindTraits: CombatantInfo['soulbindTraits'];
   legendaryInfo: { slotId: number; bonusId: number }; //slotId 0 would be head slot, and bonusID is the bonusID that is added to an item with the given legendary effect
 };
 
@@ -18,23 +16,17 @@ const SPEC_CONFIGS: { [specId: number]: FakeInfo } = {
   [SPECS.MARKSMANSHIP_HUNTER.id]: {
     covenantID: COVENANTS.VENTHYR.id,
     soulbindID: SOULBINDS.GENERAL_DRAVEN.id,
-    conduits: [{ traitID: 199, rank: 1, spellID: 340033, icon: 'ability_hunter_markedshot' }],
     legendaryInfo: { slotId: 0, bonusId: 7003 },
-    soulbindTraits: [],
   },
   [SPECS.BEAST_MASTERY_HUNTER.id]: {
     covenantID: COVENANTS.NIGHT_FAE.id,
     soulbindID: SOULBINDS.NIYA.id,
-    conduits: [{ traitID: 185, rank: 1, spellID: 339750, icon: 'spell_winston_rage' }],
     legendaryInfo: { slotId: 0, bonusId: 7003 },
-    soulbindTraits: [],
   },
   [SPECS.FROST_MAGE.id]: {
     covenantID: COVENANTS.VENTHYR.id,
     soulbindID: SOULBINDS.NADJIA_THE_MISTBLADE.id,
-    conduits: [{ traitID: 21, rank: 1, spellID: 336569, icon: 'spell_frost_frostblast' }],
     legendaryInfo: { slotId: 14, bonusId: 6828 },
-    soulbindTraits: [],
   },
 };
 
@@ -48,8 +40,6 @@ export function generateFakeCombatantInfo(player: any) {
   fakedPlayer.auras = fakeBuffGenerator();
   fakedPlayer.covenantID = SPEC_CONFIGS[player.specID]?.covenantID;
   fakedPlayer.soulbindID = SPEC_CONFIGS[player.specID]?.soulbindID;
-  fakedPlayer.conduits = SPEC_CONFIGS[player.specID]?.conduits;
-  fakedPlayer.soulbindTraits = SPEC_CONFIGS[player.specID]?.soulbindTraits;
   fakedPlayer.error = null;
   return fakedPlayer;
 }

--- a/src/parser/core/Combatant.ts
+++ b/src/parser/core/Combatant.ts
@@ -100,11 +100,6 @@ class Combatant extends Entity {
       (player: PlayerInfo) => player.id === combatantInfo.sourceID,
     );
 
-    if (combatantInfo.expansion === 'shadowlands') {
-      combatantInfo.soulbindTraits = combatantInfo.customPowerSet;
-      combatantInfo.conduits = combatantInfo.secondaryCustomPowerSet;
-    }
-
     this._combatantInfo = {
       // In super rare cases `playerInfo` can be undefined, not taking this
       // into account would cause the log to be unparsable

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -1183,10 +1183,6 @@ export interface CombatantInfoEvent extends Event<EventType.CombatantInfo> {
    * Shadowlands: Anima Powers
    */
   tertiaryCustomPowerSet?: any[]; // will be copied into field with better name / type depending on expansion
-  /** Filled from customPowerSet for Shadowlands logs */
-  soulbindTraits?: SoulbindTrait[];
-  /** Filled from secondaryCustomPowerSet for Shadowlands logs */
-  conduits?: Conduit[];
   error?: any; //TODO: Verify, is this a bool? string?
 }
 


### PR DESCRIPTION
Holy Priest was broken in tests because the report pointed to a Shadowlands report that triggered broken soulbind/conduit handling code. I've removed the offending code, re-enabled the holy priest  analyzer, and updated the example log so that e2e tests (and users on the site) get a recent, functioning report.