### PR TITLE
force premium for e2e tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,9 +235,10 @@ jobs:
         run: yarn build
         env:
           DISABLE_AUTOMATIC_ESLINT: true
-          REACT_APP_ENABLE_GA: true
+          REACT_APP_ENABLE_GA: false
           REACT_APP_ENVIRONMENT_NAME: ${{ steps.environment-name.outputs.environment_name }}
           REACT_APP_VERSION: ${{ github.sha }}
+          REACT_APP_FORCE_PREMIUM: true
       - run: tar -czf build.tar.gz build
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Force premium and disable Google Analytics for e2e builds.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

```
  1) [chromium] › configs.test.tsx:7:9 › supported spec configs › Classic Assassination Rogue example report loads 

    "Access to XMLHttpRequest at 'https://securepubads.g.doubleclick.net/pagead/ppub_config?ippd=http%3A%2F%2Flocalhost%3A3000%2Freport%2FcLYx4tpqNwT9Q3zX%2F10-Normal%2BKologarn%2B-%2BKill%2B(1%3A03)%2FTricksgiver' from origin 'http://localhost:3000' has been blocked by CORS policy: The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'. The credentials mode of requests initiated by the XMLHttpRequest is controlled by the withCredentials attribute."
```