### PR TITLE
only enable GA if REACT_APP_ENABLE_GA is true

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -88,7 +88,7 @@
         color: #e45a5a;
       }
     </style>
-    <% if (process.env.REACT_APP_ENABLE_GA !== undefined) { %>
+    <% if (process.env.REACT_APP_ENABLE_GA === 'true') { %>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-MW95W6NHVC"></script>
     <script>
       var ramp = {


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

`process.env.REACT_APP_ENABLE_GA !== undefined` evaluates to `true` when `process.env.REACT_APP_ENABLE_GA` is set to `false` by the build.

Alternative is to just remove the env variable from the GHA file.
