### PR TITLE
create Sentry release after docker-image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,8 @@ jobs:
     env:
       YARN_CACHE_FOLDER: .yarn-cache
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - name: Restore "node_modules" from cache
@@ -61,8 +61,8 @@ jobs:
     name: 'Typecheck'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - name: Restore "node_modules" from cache
@@ -73,13 +73,14 @@ jobs:
           key: ${{ runner.os }}-node_modules-${{ hashFiles('package.json', 'yarn.lock') }}-v3
           required: true
       - run: yarn typecheck
+
   linting:
     needs: [prepare]
     name: 'ESLint'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - name: Restore "node_modules" from cache
@@ -90,13 +91,14 @@ jobs:
           key: ${{ runner.os }}-node_modules-${{ hashFiles('package.json', 'yarn.lock') }}-v3
           required: true
       - run: yarn lint --max-warnings=0
+
   prettier:
     needs: [prepare]
     name: 'Prettier'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - name: Restore "node_modules" from cache
@@ -107,14 +109,15 @@ jobs:
           key: ${{ runner.os }}-node_modules-${{ hashFiles('package.json', 'yarn.lock') }}-v3
           required: true
       - run: yarn prettier . --check
+
   test-interface:
     needs: [prepare]
     # This should actually include anything but parser and integration tests
     name: 'Interface tests'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - name: Restore "node_modules" from cache
@@ -125,13 +128,14 @@ jobs:
           key: ${{ runner.os }}-node_modules-${{ hashFiles('package.json', 'yarn.lock') }}-v3
           required: true
       - run: yarn test:interface --runInBand
+
   test-parser:
     needs: [prepare]
     name: 'Parser tests'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - name: Restore "node_modules" from cache
@@ -142,13 +146,14 @@ jobs:
           key: ${{ runner.os }}-node_modules-${{ hashFiles('package.json', 'yarn.lock') }}-v3
           required: true
       - run: yarn test:parser --runInBand
+
   test-integration:
     needs: [prepare]
     name: 'Integration tests'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - name: Restore "node_modules" from cache
@@ -159,14 +164,17 @@ jobs:
           key: ${{ runner.os }}-node_modules-${{ hashFiles('package.json', 'yarn.lock') }}-v3
           required: true
       - run: yarn test:integration --runInBand
+
   build:
     needs: [prepare]
     name: 'Build'
     runs-on: ubuntu-latest
     if: github.repository == 'wowanalyzer/wowanalyzer'
+    outputs:
+      environment_name: ${{ steps.environment-name.outputs.environment_name }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - name: Restore "node_modules" from cache
@@ -191,26 +199,21 @@ jobs:
           REACT_APP_ENABLE_GA: true
           REACT_APP_ENVIRONMENT_NAME: ${{ steps.environment-name.outputs.environment_name }}
           REACT_APP_VERSION: ${{ github.sha }}
-      - name: Upload Sourcemaps to Sentry
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/dragonflight' && github.repository == 'wowanalyzer/wowanalyzer'
+      - name: Inject debug info into sourcemaps
         run: yarn sourcemaps
-        env:
-          SENTRY_ORG: wowanalyzer
-          SENTRY_PROJECT: wowanalyzer-app
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_RELEASE: ${{ github.sha }}
       - run: tar -czf build.tar.gz build
       - uses: actions/upload-artifact@v3
         with:
           name: build
           path: build.tar.gz
+
   e2e-build:
     needs: [prepare]
     name: 'e2e-build'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - name: Restore "node_modules" from cache
@@ -253,8 +256,8 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - name: Restore "node_modules" from cache
@@ -288,8 +291,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - name: Restore "node_modules" from cache
@@ -309,9 +312,9 @@ jobs:
       [typecheck, linting, prettier, test-interface, test-parser, test-integration, e2e-test, build]
     name: 'Publish Docker image'
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.repository == 'wowanalyzer/wowanalyzer' && !contains(github.event.head_commit.message, '[skip ci]')
+    if: github.event_name == 'push' && github.repository == 'wowanalyzer/wowanalyzer'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v1
         with:
           name: build
@@ -343,8 +346,15 @@ jobs:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-
-  # TODO: Sentry releases https://blog.sentry.io/2019/12/17/using-github-actions-to-create-sentry-releases
+      - uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: wowanalyzer
+          SENTRY_PROJECT: wowanalyzer-app
+        with:
+          environment: ${{ needs.build.outputs.environment_name }}
+          sourcemaps: './build/static/js'
+          url_prefix: '~/static/js'
 
   require-changelog-entry:
     name: 'Has new changelog entry'
@@ -353,9 +363,9 @@ jobs:
     env:
       YARN_CACHE_FOLDER: .yarn-cache
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: git fetch --no-tags --depth=1 origin $GITHUB_BASE_REF:$GITHUB_BASE_REF
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '18.x'
       - run: node scripts/require-changelog-entry.js

--- a/package.json
+++ b/package.json
@@ -115,9 +115,7 @@
     "e2e": "yarn e2e:setup && playwright test",
     "e2e:codegen": "playwright codegen http://localhost:3000",
     "e2e:report": "playwright show-report",
-    "sourcemaps": "yarn sourcemaps:inject && yarn sourcemaps:upload",
-    "sourcemaps:inject": "sentry-cli sourcemaps inject build",
-    "sourcemaps:upload": "sentry-cli sourcemaps upload build --release \"$SENTRY_RELEASE\""
+    "sourcemaps": "sentry-cli sourcemaps inject build"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,json,md,mdx,yml,graphql,scss,css}": [

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -32,6 +32,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 11, 28), 'Actually populate Sentry releases.', ToppleTheNun),
   change(date(2023, 11, 28), 'Update Sentry release naming.', ToppleTheNun),
   change(date(2023, 11, 28), 'Remove deprecated Shadowlands combatantinfo that was breaking the Holy Priest analyzer.', emallson),
   change(date(2023, 11, 27), <>Fix inaccurate tooltip for <ItemLink id={ITEMS.ELEMENTAL_LARIAT.id}/>.</>, Trevor),


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Create Sentry release after creating the Docker image.

Requires https://github.com/marketplace/actions/sentry-release#create-a-sentry-internal-integration to be done first.

Updates a couple of GHA versions as well since they were being touched.