### PR TITLE
[Shadow]Fix Shadow Word: Death Max Casts, and Fix Deathspeaker's Cooldown Rest

### DIFF
--- a/src/analysis/retail/priest/shadow/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/shadow/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { DoxAshe, Havoc, Sref, ToppleTheNun } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 12, 1), <>Fix <SpellLink spell={TALENTS.SHADOW_WORD_DEATH_TALENT}/> maximum number of casts</>,DoxAshe),
   change(date(2023, 11, 28), <>Update guide for <SpellLink spell={TALENTS.SHADOW_WORD_DEATH_TALENT}/> with Tier 31 four piece equppied</>,DoxAshe),
   change(date(2023, 11, 8), <>Add statistics for Tier 31 four piece</>,DoxAshe),
   change(date(2023, 11, 12), <>Updated Active Time Graph to use a rolling average instead of cumulative average.</>, Sref),

--- a/src/analysis/retail/priest/shadow/modules/spells/ShadowWordDeath.tsx
+++ b/src/analysis/retail/priest/shadow/modules/spells/ShadowWordDeath.tsx
@@ -70,7 +70,7 @@ class ShadowWordDeath extends ExecuteHelper {
 
     //console.log("SWD Totals:",ExecuteCasts,"NE",this.totalNonExecuteCasts,"DM",DeathAndMadnessCasts,"DS",DeathSpeakerCasts);
 
-    this.maxCasts +=
+    this.maxCasts =
       ExecuteCasts + this.totalNonExecuteCasts + DeathAndMadnessCasts + DeathSpeakerCasts;
   }
 }

--- a/src/analysis/retail/priest/shadow/modules/talents/DeathAndMadness.tsx
+++ b/src/analysis/retail/priest/shadow/modules/talents/DeathAndMadness.tsx
@@ -79,6 +79,10 @@ class DeathAndMadness extends Analyzer {
     this.kills += 1;
   }
 
+  getResets(): number {
+    return this.resets;
+  }
+
   statistic() {
     return (
       <Statistic

--- a/src/analysis/retail/priest/shadow/modules/talents/Deathspeaker.tsx
+++ b/src/analysis/retail/priest/shadow/modules/talents/Deathspeaker.tsx
@@ -3,7 +3,14 @@ import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/priest';
 import { SpellLink } from 'interface';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
-import Events, { CastEvent, ApplyBuffEvent, RemoveBuffEvent } from 'parser/core/Events';
+import Events, {
+  EventType,
+  CastEvent,
+  ApplyBuffEvent,
+  RemoveBuffEvent,
+  MaxChargesIncreasedEvent,
+  MaxChargesDecreasedEvent,
+} from 'parser/core/Events';
 import Abilities from 'parser/core/modules/Abilities';
 import { When, ThresholdStyle } from 'parser/core/ParseResults';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
@@ -34,6 +41,22 @@ class Deathspeaker extends Analyzer {
   procsWasted: number = 0;
   lastProcTime: number = 0;
 
+  deathspeakerChargeIncreaseEvent: MaxChargesIncreasedEvent = {
+    type: EventType.MaxChargesIncreased,
+    timestamp: 0,
+    spellId: TALENTS.SHADOW_WORD_DEATH_TALENT.id,
+    by: 1,
+    __fabricated: true,
+  };
+
+  deathspeakerChargeDecreaseEvent: MaxChargesDecreasedEvent = {
+    type: EventType.MaxChargesDecreased,
+    timestamp: 0,
+    spellId: TALENTS.SHADOW_WORD_DEATH_TALENT.id,
+    by: 1,
+    __fabricated: true,
+  };
+
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS.DEATHSPEAKER_TALENT);
@@ -55,6 +78,14 @@ class Deathspeaker extends Analyzer {
     );
   }
 
+  updateMaxChargeIncreaseEvent(event: ApplyBuffEvent) {
+    this.deathspeakerChargeIncreaseEvent.timestamp = event.timestamp;
+  }
+
+  updateMaxChargeDecreaseEvent(event: RemoveBuffEvent) {
+    this.deathspeakerChargeDecreaseEvent.timestamp = event.timestamp;
+  }
+
   onCast(event: CastEvent) {
     //for debuging. Sometimes chargesAvailable, and chargesOnCooldown don't correctly add up to getMaxCharges.
     DEBUG &&
@@ -71,7 +102,13 @@ class Deathspeaker extends Analyzer {
 
   onBuffApplied(event: ApplyBuffEvent) {
     this.procsGained += 1; // Add a proc to the counter
-    this.abilities.increaseMaxCharges(event, TALENTS.SHADOW_WORD_DEATH_TALENT.id, 1);
+
+    //abilites.maxCharge increase does not increase the maxCharge for spellUsable
+    //So endCooldown still thinks it only has 1 max charge, so it restores all charges.
+    //In order to work around this, I use spllUsable to increase the maxCharges of the spell, instead of abilities.
+    //To do this, I pass this event into spellUsables.OnMaxChargesIncrease
+    this.updateMaxChargeIncreaseEvent(event);
+    this.spellUsable.onMaxChargesIncreased(this.deathspeakerChargeIncreaseEvent);
     this.spellUsable.endCooldown(
       TALENTS.SHADOW_WORD_DEATH_TALENT.id,
       event.timestamp,
@@ -81,7 +118,7 @@ class Deathspeaker extends Analyzer {
     this.lastProcTime = event.timestamp;
     DEBUG &&
       console.log(
-        'Shadow Word: Death buff apply',
+        'Shadow Word: Death buff applied',
         this.spellUsable.chargesAvailable(TALENTS.SHADOW_WORD_DEATH_TALENT.id),
         '/',
         this.spellUsable.chargesOnCooldown(TALENTS.SHADOW_WORD_DEATH_TALENT.id),
@@ -92,10 +129,15 @@ class Deathspeaker extends Analyzer {
   }
 
   onBuffRemoved(event: RemoveBuffEvent) {
-    this.abilities.decreaseMaxCharges(event, TALENTS.SHADOW_WORD_DEATH_TALENT.id, 1);
+    this.updateMaxChargeDecreaseEvent(event);
+    this.spellUsable.onMaxChargesDecreased(this.deathspeakerChargeDecreaseEvent);
+    //abilites.decreaseMaxCharge seems to work fine here,
+    //I have only used spellUsable to match what is done for onBuffApplied, either method works
+
     if (this.spellUsable.chargesAvailable(TALENTS.SHADOW_WORD_DEATH_TALENT.id) === 1) {
       // In certain circumstances, if you have 1 charge available after the buff, you can end up having negative charges spellUsable.onCooldown
       // Resting the cooldown entirely fixes the issue.
+      // this occurs with both abilites.decreaseMaxCharge and spellUsable
       this.spellUsable.endCooldown(
         TALENTS.SHADOW_WORD_DEATH_TALENT.id,
         event.timestamp,

--- a/src/analysis/retail/priest/shadow/modules/talents/Deathspeaker.tsx
+++ b/src/analysis/retail/priest/shadow/modules/talents/Deathspeaker.tsx
@@ -93,12 +93,33 @@ class Deathspeaker extends Analyzer {
   }
 
   onBuffRemoved(event: RemoveBuffEvent) {
+    DEBUG &&
+      console.log(
+        'Shadow Word: Death buff remove Before',
+        this.spellUsable.chargesAvailable(TALENTS.SHADOW_WORD_DEATH_TALENT.id),
+        '/',
+        this.spellUsable.chargesOnCooldown(TALENTS.SHADOW_WORD_DEATH_TALENT.id),
+        'max:',
+        this.abilities.getMaxCharges(TALENTS.SHADOW_WORD_DEATH_TALENT.id),
+        this.owner.formatTimestamp(event.timestamp, 1),
+      );
+
     this.abilities.decreaseMaxCharges(event, TALENTS.SHADOW_WORD_DEATH_TALENT.id, 1);
 
-    if (this.spellUsable.chargesAvailable(TALENTS.SHADOW_WORD_DEATH_TALENT.id) === 1) {
+    DEBUG &&
+      console.log(
+        'Shadow Word: Death buff remove After Charge Decrease',
+        this.spellUsable.chargesAvailable(TALENTS.SHADOW_WORD_DEATH_TALENT.id),
+        '/',
+        this.spellUsable.chargesOnCooldown(TALENTS.SHADOW_WORD_DEATH_TALENT.id),
+        'max:',
+        this.abilities.getMaxCharges(TALENTS.SHADOW_WORD_DEATH_TALENT.id),
+        this.owner.formatTimestamp(event.timestamp, 1),
+      );
+
+    if (this.spellUsable.chargesOnCooldown(TALENTS.SHADOW_WORD_DEATH_TALENT.id) < 0) {
       // In certain circumstances, if you have 1 charge available after the buff, you can end up having negative charges spellUsable.onCooldown
       // Resting the cooldown entirely fixes the issue.
-      // this occurs with both abilites.decreaseMaxCharge and spellUsable
       this.spellUsable.endCooldown(
         TALENTS.SHADOW_WORD_DEATH_TALENT.id,
         event.timestamp,
@@ -112,7 +133,7 @@ class Deathspeaker extends Analyzer {
     }
     DEBUG &&
       console.log(
-        'Shadow Word: Death buff remove',
+        'Shadow Word: Death buff After negative check',
         this.spellUsable.chargesAvailable(TALENTS.SHADOW_WORD_DEATH_TALENT.id),
         '/',
         this.spellUsable.chargesOnCooldown(TALENTS.SHADOW_WORD_DEATH_TALENT.id),

--- a/src/parser/core/modules/Abilities.ts
+++ b/src/parser/core/modules/Abilities.ts
@@ -3,6 +3,7 @@ import SPECS from 'game/SPECS';
 import Module, { Options } from 'parser/core/Module';
 import EventEmitter from 'parser/core/modules/EventEmitter';
 import Haste from 'parser/shared/modules/Haste';
+import type SpellUsable from 'parser/shared/modules/SpellUsable';
 
 import AbilityTracker from '../../shared/modules/AbilityTracker';
 import { AnyEvent, EventType } from '../Events';
@@ -172,7 +173,7 @@ class Abilities extends Module {
 
     this.updateMaxCharges(spellId, currentCharges + increaseBy);
 
-    this.eventEmitter.fabricateEvent(
+    const fabricatedEvent = this.eventEmitter.fabricateEvent(
       {
         type: EventType.MaxChargesIncreased,
         timestamp: event.timestamp,
@@ -181,6 +182,8 @@ class Abilities extends Module {
       },
       event,
     );
+
+    this.spellUsable.onMaxChargesIncreased(fabricatedEvent);
   }
 
   decreaseMaxCharges(event: AnyEvent, spellId: number, decreaseBy: number) {
@@ -192,7 +195,7 @@ class Abilities extends Module {
 
     this.updateMaxCharges(spellId, currentCharges - decreaseBy);
 
-    this.eventEmitter.fabricateEvent(
+    const fabricatedEvent = this.eventEmitter.fabricateEvent(
       {
         type: EventType.MaxChargesDecreased,
         timestamp: event.timestamp,
@@ -201,6 +204,12 @@ class Abilities extends Module {
       },
       event,
     );
+
+    this.spellUsable.onMaxChargesDecreased(fabricatedEvent);
+  }
+
+  private get spellUsable(): SpellUsable {
+    return this.owner._modules.spellUsable as SpellUsable;
   }
 
   /**

--- a/src/parser/core/modules/EventEmitter.ts
+++ b/src/parser/core/modules/EventEmitter.ts
@@ -295,19 +295,19 @@ class EventEmitter extends Module {
     }
   }
   // todo double check this 'event' shape... seems wrong
-  fabricateEvent(
-    event: { type: EventFilter<any> | string; [additionalProperties: string]: any },
+  fabricateEvent<T extends EventType>(
+    event: { type: T; [additionalProperties: string]: any },
     trigger: any = null,
-  ) {
-    const fabricatedEvent = {
+  ): AnyEvent<T> {
+    const fabricatedEvent: AnyEvent<T> = {
       // When no timestamp is provided in the event (you should always try to), the current timestamp will be used by default.
       timestamp: this.owner.currentTimestamp,
       // If this event was triggered you should pass it along
       trigger: trigger ? trigger : undefined,
       ...event,
-      type: event.type instanceof EventFilter ? event.type.eventType : event.type,
+      type: event.type,
       __fabricated: true,
-    };
+    } as unknown as AnyEvent<T>;
     if (this._isHandlingEvent) {
       this.finally(() => {
         this.triggerEvent(fabricatedEvent);

--- a/src/parser/shared/modules/SpellUsable.ts
+++ b/src/parser/shared/modules/SpellUsable.ts
@@ -75,8 +75,6 @@ class SpellUsable extends Analyzer {
     this.addEventListener(Events.prefiltercd.by(SELECTED_PLAYER), this.onCast);
     this.addEventListener(Events.ChangeHaste, this.onChangeHaste);
     this.addEventListener(Events.fightend, this.onFightEnd);
-    this.addEventListener(Events.MaxChargesIncreased, this.onMaxChargesIncreased);
-    this.addEventListener(Events.MaxChargesDescreased, this.onMaxChargesDecreased);
   }
 
   /////////////////////////////////////////////////////////////////////////////
@@ -505,7 +503,12 @@ class SpellUsable extends Analyzer {
     });
   }
 
-  /** Update cooldown info for changed number of max charges */
+  /** Update cooldown info for changed number of max charges.
+   *
+   *  Note that unlike most event listeners, this is called from Abilities instead
+   *  of using an event listener. This prevents the charge count in Abilities
+   *  from becoming desynced from the charge count in SpellUsable.
+   **/
   public onMaxChargesIncreased(event: MaxChargesIncreasedEvent) {
     const cdInfo = this._currentCooldowns[this._getCanonicalId(event.spellId)];
     if (cdInfo) {
@@ -513,7 +516,12 @@ class SpellUsable extends Analyzer {
     }
   }
 
-  /** Update cooldown info for changed number of max charges */
+  /** Update cooldown info for changed number of max charges
+   *
+   *  Note that unlike most event listeners, this is called from Abilities instead
+   *  of using an event listener. This prevents the charge count in Abilities
+   *  from becoming desynced from the charge count in SpellUsable.
+   **/
   public onMaxChargesDecreased(event: MaxChargesDecreasedEvent) {
     const cdInfo = this._currentCooldowns[this._getCanonicalId(event.spellId)];
     if (cdInfo) {

--- a/src/parser/shared/modules/SpellUsable.ts
+++ b/src/parser/shared/modules/SpellUsable.ts
@@ -506,7 +506,7 @@ class SpellUsable extends Analyzer {
   }
 
   /** Update cooldown info for changed number of max charges */
-  protected onMaxChargesIncreased(event: MaxChargesIncreasedEvent) {
+  public onMaxChargesIncreased(event: MaxChargesIncreasedEvent) {
     const cdInfo = this._currentCooldowns[this._getCanonicalId(event.spellId)];
     if (cdInfo) {
       cdInfo.maxCharges += event.by;
@@ -514,7 +514,7 @@ class SpellUsable extends Analyzer {
   }
 
   /** Update cooldown info for changed number of max charges */
-  protected onMaxChargesDecreased(event: MaxChargesDecreasedEvent) {
+  public onMaxChargesDecreased(event: MaxChargesDecreasedEvent) {
     const cdInfo = this._currentCooldowns[this._getCanonicalId(event.spellId)];
     if (cdInfo) {
       cdInfo.maxCharges -= event.by;


### PR DESCRIPTION
### Description

Shadow Word Death's maximum casts have been incorrect, and even off by double the correct amount with Deathspeaker talented.  I have updated Shadow Word Death's maxCast calculation, and fixed issues with Deathspeaker.
Deathspeaker has been resetting all charges of shadow word: death instead of only giving one charge back.  The reason this is happening is because `abilities.increaseMaxCharges` does not update the maxCharges with `spellUsable.endCooldown`.  This causes both charges to be reset, instead of only one.

To work around this issue, I have used `spellUsable.OnMaxChargesIncrease` to increase the charges, which fixes the issue.  I did it this way because this fix should not impact other specs.

### Testing

I have tested this with combinations of deathspeaker and the four piece, and in all situations this now calculates the maximum casts correctly.  However, when a player without the four piece is facing multiple targets, the guide graph does not always properly show the casts or available segments.  This was occuring before this change, and is something that I plan on fixing later.

Test report URL: 

- With Deathspeaker and 4 piece: '/report/32hnqfXN6ZVkQPLG/4-Normal+Volcoross+-+Kill+(2:22)/Doxashe/standard'
- With Deathspeaker and no 4 piece: '/report/X6kmRCdHvNWAQzZF/15-Normal+Volcoross+-+Kill+(1:25)/Anàtéma/standard/overview'
- Without either: 'report/MQphqtvxW13wj4Yf/64-Normal+Volcoross+-+Kill+(2:00)/Mentalistwo/standard/overview'

