### PR TITLE
[Enhancement Shaman] Normalizer order fix

### DIFF
--- a/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Taum, Vetyst, Vohrr, xunni, Seriousnes, ToppleTheNun, Putro } from 'CON
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2023, 12, 3), <>Fix for normalizer priority, update Ascendance analyzer to include cast timeline.</>, Seriousnes),
   change(date(2023, 12, 2), <>Marked as updated for 10.2</>, Seriousnes),
   change(date(2023, 11, 29), <>Defensives added to guide, <SpellLink spell={TALENTS.ELEMENTAL_BLAST_ELEMENTAL_TALENT} /> usage analysis, <SpellLink spell={TALENTS.ELEMENTAL_ASSAULT_TALENT} /> statistics</>, Seriousnes),
   change(date(2023, 11, 26), 'Resolve errors for unhandled abilities in the MealstromWeaponSpenders module.', Vetyst),

--- a/src/analysis/retail/shaman/enhancement/modules/guide/Cooldowns.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/guide/Cooldowns.tsx
@@ -5,7 +5,6 @@ import { Talent } from 'common/TALENTS/types';
 import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
 import { GapHighlight } from 'parser/ui/CooldownBar';
 import CombatLogParser from 'analysis/retail/shaman/enhancement/CombatLogParser';
-import CooldownUsage from 'parser/core/MajorCooldowns/CooldownUsage';
 import Combatant from 'parser/core/Combatant';
 import { TIERS } from 'game/TIERS';
 
@@ -36,13 +35,8 @@ function Cooldowns({ info, modules }: GuideProps<typeof CombatLogParser>) {
         </p>
         <CooldownGraphSubsection checklist={COOLDOWNS} />
       </SubSection>
-      {(info.combatant.hasTalent(TALENTS.ASCENDANCE_ENHANCEMENT_TALENT) ||
-        info.combatant.hasTalent(TALENTS.DEEPLY_ROOTED_ELEMENTS_TALENT)) && (
-        <SubSection title="Ascendance">
-          <CooldownUsage analyzer={modules.ascendance} />
-        </SubSection>
-      )}
-      {info.combatant.hasTalent(TALENTS.HOT_HAND_TALENT) && modules.hotHand.guideSubsection}
+      {modules.ascendance.guideSubsection}
+      {modules.hotHand.guideSubsection}
       {modules.elementalBlast.guideSubsection}
     </Section>
   );

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
@@ -37,6 +37,8 @@ const maelstromWeaponInstantCastLink: EventLink = {
   forwardBufferMs: MAELSTROM_WEAPON_MS,
   backwardBufferMs: MAELSTROM_WEAPON_MS,
   anyTarget: true,
+  reverseLinkRelation: MAELSTROM_WEAPON_INSTANT_CAST,
+  maximumLinks: 1,
 };
 
 const thorimsInvocationCastLink: EventLink = {
@@ -101,7 +103,7 @@ const splinteredElements: EventLink = {
   referencedEventId: SPELLS.LIGHTNING_BOLT.id,
   referencedEventType: EventType.Cast,
   anyTarget: true,
-  forwardBufferMs: 5,
+  forwardBufferMs: 20,
   maximumLinks: 1,
 };
 

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
@@ -28,6 +28,14 @@ const MAELSTROM_WEAPON_ELIGIBLE_SPELL_IDS = MAELSTROM_WEAPON_ELIGIBLE_SPELLS.map
 const stormStrikeSpellIds = STORMSTRIKE_CAST_SPELLS.map((spell) => spell.id);
 const stormStrikeDamageIds = STORMSTRIKE_DAMAGE_SPELLS.map((spell) => spell.id);
 
+const PRIMORDIAL_WAVE_BUFFER = 15500;
+const MAELSTROM_SPENDER_FORWARD_BUFFER = 25;
+const MAELSTROM_SPENDER_BACKWARD_BUFFER = 50;
+const STORMSTRIKE_BUFFER = 900;
+const CHAIN_LIGHTNING_BUFFER = 100;
+const SPLINTERED_ELEMENTS_BUFFER = 20;
+const LIGHTNING_BOLT_BUFFER = 150;
+
 const maelstromWeaponInstantCastLink: EventLink = {
   linkRelation: MAELSTROM_WEAPON_INSTANT_CAST,
   linkingEventId: MAELSTROM_WEAPON_ELIGIBLE_SPELL_IDS,
@@ -40,7 +48,6 @@ const maelstromWeaponInstantCastLink: EventLink = {
   reverseLinkRelation: MAELSTROM_WEAPON_INSTANT_CAST,
   maximumLinks: 1,
 };
-
 const thorimsInvocationCastLink: EventLink = {
   linkRelation: THORIMS_INVOCATION_LINK,
   linkingEventId: SPELLS.WINDSTRIKE_CAST.id,
@@ -50,40 +57,36 @@ const thorimsInvocationCastLink: EventLink = {
   forwardBufferMs: MAELSTROM_WEAPON_MS,
   anyTarget: true,
 };
-
 const stormStrikeLink: EventLink = {
   linkRelation: STORMSTRIKE_LINK,
   linkingEventId: stormStrikeSpellIds,
   linkingEventType: EventType.Cast,
   referencedEventId: stormStrikeDamageIds,
   referencedEventType: EventType.Damage,
-  forwardBufferMs: 900,
+  forwardBufferMs: STORMSTRIKE_BUFFER,
   anyTarget: true,
 };
-
 const chainLightningDamageLink: EventLink = {
   linkRelation: CHAIN_LIGHTNING_LINK,
   linkingEventId: TALENTS.CHAIN_LIGHTNING_TALENT.id,
   linkingEventType: [EventType.Cast, EventType.FreeCast],
   referencedEventId: TALENTS.CHAIN_LIGHTNING_TALENT.id,
   referencedEventType: EventType.Damage,
-  forwardBufferMs: 100,
+  forwardBufferMs: CHAIN_LIGHTNING_BUFFER,
   anyTarget: true,
 };
-
 const maelstromWeaponSpenderLink: EventLink = {
   linkRelation: MAELSTROM_SPENDER_LINK,
   linkingEventId: MAELSTROM_WEAPON_ELIGIBLE_SPELL_IDS,
   linkingEventType: [EventType.Cast, EventType.FreeCast],
   referencedEventId: SPELLS.MAELSTROM_WEAPON_BUFF.id,
   referencedEventType: [EventType.RemoveBuff, EventType.RemoveBuffStack],
-  forwardBufferMs: 25,
-  backwardBufferMs: 50,
+  forwardBufferMs: MAELSTROM_SPENDER_FORWARD_BUFFER,
+  backwardBufferMs: MAELSTROM_SPENDER_BACKWARD_BUFFER,
   anyTarget: true,
   reverseLinkRelation: MAELSTROM_SPENDER_LINK,
   maximumLinks: 1,
 };
-
 const primordialWaveLink: EventLink = {
   linkRelation: PRIMORDIAL_WAVE_LINK,
   linkingEventId: TALENTS.PRIMORDIAL_WAVE_SPEC_TALENT.id,
@@ -91,11 +94,10 @@ const primordialWaveLink: EventLink = {
   referencedEventId: SPELLS.LIGHTNING_BOLT.id,
   referencedEventType: EventType.Cast,
   anyTarget: true,
-  forwardBufferMs: 15500,
+  forwardBufferMs: PRIMORDIAL_WAVE_BUFFER,
   maximumLinks: 1,
   reverseLinkRelation: PRIMORDIAL_WAVE_LINK,
 };
-
 const splinteredElements: EventLink = {
   linkRelation: SPLINTERED_ELEMENTS_LINK,
   linkingEventId: SPELLS.SPLINTERED_ELEMENTS_BUFF.id,
@@ -103,17 +105,16 @@ const splinteredElements: EventLink = {
   referencedEventId: SPELLS.LIGHTNING_BOLT.id,
   referencedEventType: EventType.Cast,
   anyTarget: true,
-  forwardBufferMs: 20,
+  forwardBufferMs: SPLINTERED_ELEMENTS_BUFFER,
   maximumLinks: 1,
 };
-
 const lightningBoltLink: EventLink = {
   linkRelation: LIGHTNING_BOLT_LINK,
   linkingEventId: SPELLS.LIGHTNING_BOLT.id,
   linkingEventType: EventType.Cast,
   referencedEventId: SPELLS.LIGHTNING_BOLT.id,
   referencedEventType: EventType.Damage,
-  forwardBufferMs: 150,
+  forwardBufferMs: LIGHTNING_BOLT_BUFFER,
   anyTarget: true,
 };
 

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/MaelstromWeaponCastNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/MaelstromWeaponCastNormalizer.tsx
@@ -15,12 +15,13 @@ class MaelstromWeaponCastNormalizer extends EventsNormalizer {
   constructor(options: Options) {
     super(options);
 
+    // this normalizer depends on the event link normalizer to have already run, so setting a lower priority to enforce later execution (higher value = lower priority)
     this.priority = 10;
   }
 
   normalize(events: AnyEvent[]): AnyEvent[] {
     const fixedEvents: AnyEvent[] = [];
-    events.forEach((event: AnyEvent, idx: number) => {
+    events.forEach((event: AnyEvent) => {
       if (HasAbility(event) && MAELSTROM_WEAPON_ELIGIBLE_SPELL_IDs.includes(event.ability.guid)) {
         if (
           event.type === EventType.BeginCast ||

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/MaelstromWeaponCastNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/MaelstromWeaponCastNormalizer.tsx
@@ -1,19 +1,36 @@
-import { AnyEvent, EventType } from 'parser/core/Events';
+import { AnyEvent, EventType, HasAbility, HasRelatedEvent } from 'parser/core/Events';
 import EventsNormalizer from 'parser/core/EventsNormalizer';
 import { MAELSTROM_WEAPON_INSTANT_CAST } from './EventLinkNormalizer';
+import { MAELSTROM_WEAPON_ELIGIBLE_SPELLS } from '../../constants';
+import { Options } from 'parser/core/Analyzer';
 
 /** This normalizer removes the begincast event, and fabricated beginchannel and endchannel
  * events for instant cast enhancement spells */
 
+const MAELSTROM_WEAPON_ELIGIBLE_SPELL_IDs = MAELSTROM_WEAPON_ELIGIBLE_SPELLS.map(
+  (spell) => spell.id,
+);
+
 class MaelstromWeaponCastNormalizer extends EventsNormalizer {
+  constructor(options: Options) {
+    super(options);
+
+    this.priority = 10;
+  }
+
   normalize(events: AnyEvent[]): AnyEvent[] {
     const fixedEvents: AnyEvent[] = [];
     events.forEach((event: AnyEvent, idx: number) => {
-      const linkedEvents = event._linkedEvents?.find(
-        (x) => x.relation === MAELSTROM_WEAPON_INSTANT_CAST,
-      );
-      if (linkedEvents) {
-        if (event.type === EventType.Cast || event.type === EventType.FreeCast) {
+      if (HasAbility(event) && MAELSTROM_WEAPON_ELIGIBLE_SPELL_IDs.includes(event.ability.guid)) {
+        if (
+          event.type === EventType.BeginCast ||
+          event.type === EventType.BeginChannel ||
+          event.type === EventType.EndChannel
+        ) {
+          if (!HasRelatedEvent(event, MAELSTROM_WEAPON_INSTANT_CAST)) {
+            fixedEvents.push(event);
+          }
+        } else {
           fixedEvents.push(event);
         }
       } else {

--- a/src/analysis/retail/shaman/enhancement/modules/talents/Ascendance.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/Ascendance.tsx
@@ -3,7 +3,10 @@ import Events, {
   ApplyBuffEvent,
   CastEvent,
   DamageEvent,
+  EventType,
   FightEndEvent,
+  GetRelatedEvents,
+  GlobalCooldownEvent,
   RefreshBuffEvent,
   UpdateSpellUsableEvent,
   UpdateSpellUsableType,
@@ -15,7 +18,7 @@ import SpellUsable from 'analysis/retail/shaman/enhancement/modules/core/SpellUs
 import { ChecklistUsageInfo, SpellUse, UsageInfo } from 'parser/core/SpellUsage/core';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { SpellLink } from 'interface';
-import SPELLS, { maybeGetSpell } from 'common/SPELLS';
+import SPELLS from 'common/SPELLS';
 import Abilities from '../Abilities';
 import Haste from 'parser/shared/modules/Haste';
 import { THORIMS_INVOCATION_LINK } from 'analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer';
@@ -26,8 +29,12 @@ import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import Statistic from 'parser/ui/Statistic';
 import Uptime from 'interface/icons/Uptime';
-import typedKeys from 'common/typedKeys';
 import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
+import CooldownUsage from 'parser/core/MajorCooldowns/CooldownUsage';
+import EmbeddedTimelineContainer, {
+  SpellTimeline,
+} from 'interface/report/Results/Timeline/EmbeddedTimeline';
+import Casts from 'interface/report/Results/Timeline/Casts';
 
 const NonMissedCastSpells = [
   TALENTS_SHAMAN.SUNDERING_TALENT.id,
@@ -37,18 +44,23 @@ const NonMissedCastSpells = [
 ];
 const SIMULATED_MEDIAN_CASTS_PER_DRE = 13;
 
-interface Casts {
+interface StormstrikeCasts {
   count: number;
   noProcBeforeEnd?: boolean | undefined;
 }
 
+interface AscendanceTimeline {
+  start: number;
+  end?: number | null;
+  events: AnyEvent[];
+  performance?: QualitativePerformance | null;
+}
+
 interface AscendanceCooldownCast
   extends CooldownTrigger<CastEvent | ApplyBuffEvent | RefreshBuffEvent> {
-  casts: CastEvent[];
   extraDamage: number;
-  startTime: number;
-  endTime: number;
   hasteAdjustedWastedCooldown: number;
+  timeline: AscendanceTimeline;
 }
 
 class Ascendance extends MajorCooldown<AscendanceCooldownCast> {
@@ -67,7 +79,8 @@ class Ascendance extends MajorCooldown<AscendanceCooldownCast> {
   protected windstrikeOnCooldown: boolean = true;
   protected lastCooldownWasteCheck: number = 0;
 
-  protected castsBeforeAscendanceProc: Casts[] = [{ count: 0 }];
+  protected castsBeforeAscendanceProc: StormstrikeCasts[] = [{ count: 0 }];
+  protected globalCooldownEnds: number = 0;
 
   constructor(options: Options) {
     super({ spell: TALENTS_SHAMAN.ASCENDANCE_ENHANCEMENT_TALENT }, options);
@@ -128,6 +141,12 @@ class Ascendance extends MajorCooldown<AscendanceCooldownCast> {
         this.onProcEligibleCast,
       );
     }
+    this.addEventListener(Events.GlobalCooldown.by(SELECTED_PLAYER), this.onGlobalCooldown);
+  }
+
+  onGlobalCooldown(event: GlobalCooldownEvent) {
+    this.globalCooldownEnds = event.duration + event.timestamp;
+    this.currentCooldown?.timeline.events?.push(event);
   }
 
   detectWindstrikeCasts(event: UpdateSpellUsableEvent) {
@@ -144,8 +163,9 @@ class Ascendance extends MajorCooldown<AscendanceCooldownCast> {
     return this.casts.reduce(
       (total: number, cast: AscendanceCooldownCast) =>
         (total +=
-          cast.casts.filter((c) => c.ability.guid === SPELLS.WINDSTRIKE_CAST.id).length +
-          this.getMissedWindstrikes(cast)),
+          cast.timeline.events.filter(
+            (c) => c.type === EventType.Cast && c.ability.guid === SPELLS.WINDSTRIKE_CAST.id,
+          ).length + this.getMissedWindstrikes(cast)),
       0,
     );
   }
@@ -159,10 +179,11 @@ class Ascendance extends MajorCooldown<AscendanceCooldownCast> {
     this.castsBeforeAscendanceProc.push({ count: 0 });
     this.currentCooldown ??= {
       event: event,
-      casts: [],
+      timeline: {
+        start: Math.max(event.timestamp, this.globalCooldownEnds),
+        events: [],
+      },
       extraDamage: 0,
-      startTime: event.timestamp,
-      endTime: 0,
       hasteAdjustedWastedCooldown: 0,
     };
     this.lastCooldownWasteCheck = event.timestamp;
@@ -181,7 +202,7 @@ class Ascendance extends MajorCooldown<AscendanceCooldownCast> {
         this.hasteAdjustedCooldownWasteSinceLastWasteCheck(event);
     }
     this.lastCooldownWasteCheck = event.timestamp;
-    this.currentCooldown!.casts.push(event);
+    this.currentCooldown!.timeline.events.push(event);
   }
 
   onDamage(event: DamageEvent) {
@@ -192,7 +213,7 @@ class Ascendance extends MajorCooldown<AscendanceCooldownCast> {
 
   onAscendanceEnd(event: AnyEvent) {
     if (this.currentCooldown) {
-      this.currentCooldown.endTime = event.timestamp;
+      this.currentCooldown.timeline.end = event.timestamp;
       this.currentCooldown.hasteAdjustedWastedCooldown +=
         this.hasteAdjustedCooldownWasteSinceLastWasteCheck(event);
       this.recordCooldown(this.currentCooldown);
@@ -250,8 +271,8 @@ class Ascendance extends MajorCooldown<AscendanceCooldownCast> {
   }
 
   windstrikePerformance(cast: AscendanceCooldownCast): UsageInfo {
-    const windstrikesCasts = cast.casts.filter(
-      (c) => c.ability.guid === SPELLS.WINDSTRIKE_CAST.id,
+    const windstrikesCasts = cast.timeline.events.filter(
+      (c) => c.type === EventType.Cast && c.ability.guid === SPELLS.WINDSTRIKE_CAST.id,
     ).length;
     const missedWindstrikes = this.getMissedWindstrikes(cast);
     const maximumNumberOfWindstrikesPossible = windstrikesCasts + missedWindstrikes;
@@ -297,11 +318,15 @@ class Ascendance extends MajorCooldown<AscendanceCooldownCast> {
 
   thorimsInvocationPerformance(cast: AscendanceCooldownCast): UsageInfo[] | undefined {
     const result: UsageInfo[] = [];
-    const windstrikes = cast.casts.filter((c) => c.ability.guid === SPELLS.WINDSTRIKE_CAST.id);
-    const thorimsInvocationFreeCasts = windstrikes.map((event: CastEvent) => {
-      return event._linkedEvents
-        ?.filter((le) => le.relation === THORIMS_INVOCATION_LINK)
-        .map((le) => le.event as DamageEvent);
+    const windstrikes = cast.timeline.events.filter(
+      (c) => c.type === EventType.Cast && c.ability.guid === SPELLS.WINDSTRIKE_CAST.id,
+    ) as CastEvent[];
+    const thorimsInvocationFreeCasts = windstrikes.map((event) => {
+      return GetRelatedEvents<DamageEvent>(
+        event,
+        THORIMS_INVOCATION_LINK,
+        (e) => e.type === EventType.Damage,
+      );
     });
 
     // casts without any maelstrom are bad casts, only relevant for elementalist builds that pick the Ascendance talent rather than storm using DRE
@@ -356,11 +381,46 @@ class Ascendance extends MajorCooldown<AscendanceCooldownCast> {
     return result.length > 0 ? result : undefined;
   }
 
+  private explainTimelineWithDetails(cast: AscendanceCooldownCast) {
+    const checklistItem = {
+      performance: QualitativePerformance.Perfect,
+      summary: <span>Spell order</span>,
+      details: <span>Spell order: See below</span>,
+      check: 'ascendance-timeline',
+      timestamp: cast.event.timestamp,
+    };
+
+    const extraDetails = (
+      <div
+        style={{
+          overflowX: 'scroll',
+        }}
+      >
+        <EmbeddedTimelineContainer
+          secondWidth={60}
+          secondsShown={(cast.timeline.end! - cast.timeline.start) / 1000}
+        >
+          <SpellTimeline>
+            <Casts
+              start={cast.timeline.start}
+              movement={undefined}
+              secondWidth={60}
+              events={cast.timeline.events}
+            />
+          </SpellTimeline>
+        </EmbeddedTimelineContainer>
+      </div>
+    );
+
+    return { extraDetails, checklistItem };
+  }
+
   explainPerformance(cast: AscendanceCooldownCast): SpellUse {
     const checklistItems: ChecklistUsageInfo[] = [];
 
     const windstrikePerformance = this.windstrikePerformance(cast);
     const thorimsInvocationPerformance = this.thorimsInvocationPerformance(cast);
+    const timeline = this.explainTimelineWithDetails(cast);
 
     checklistItems.push({
       check: 'windstrike',
@@ -382,30 +442,6 @@ class Ascendance extends MajorCooldown<AscendanceCooldownCast> {
       checklistItems.map((item) => item.performance),
     );
 
-    const fillerSpells = cast.casts
-      .filter((c) => c.ability.guid !== SPELLS.WINDSTRIKE_CAST.id)
-      .reduce((group: Record<number, number>, castEvent: CastEvent) => {
-        group[castEvent.ability.guid] = group[castEvent.ability.guid] || 0;
-        group[castEvent.ability.guid] += 1;
-        return group;
-      }, {});
-
-    const fillerSpellsList = typedKeys(fillerSpells).map((spellId) => {
-      const casts = fillerSpells[spellId];
-      const spell = maybeGetSpell(spellId);
-      return (
-        spell && (
-          <>
-            <li key={`${cast.startTime}-${spellId}`}>
-              <div>
-                {casts} x <SpellLink spell={spell} />
-              </div>
-            </li>
-          </>
-        )
-      );
-    });
-
     return {
       event: cast.event,
       checklistItems: checklistItems,
@@ -414,12 +450,7 @@ class Ascendance extends MajorCooldown<AscendanceCooldownCast> {
         actualPerformance !== QualitativePerformance.Fail
           ? `${actualPerformance} Usage`
           : 'Bad Usage',
-      extraDetails: fillerSpellsList.length > 0 && (
-        <>
-          Filler spells cast
-          <ul>{fillerSpellsList}</ul>
-        </>
-      ),
+      extraDetails: timeline.extraDetails,
     };
   }
 
@@ -427,14 +458,14 @@ class Ascendance extends MajorCooldown<AscendanceCooldownCast> {
     if (this.selectedCombatant.hasTalent(TALENTS_SHAMAN.DEEPLY_ROOTED_ELEMENTS_TALENT)) {
       // don't include casts that didn't lead to a proc in casts per proc statistic
       const castsBeforeAscendanceProc = this.castsBeforeAscendanceProc
-        .filter((cast: Casts) => !cast.noProcBeforeEnd)
-        .map((cast: Casts) => cast.count);
+        .filter((cast: StormstrikeCasts) => !cast.noProcBeforeEnd)
+        .map((cast: StormstrikeCasts) => cast.count);
       const minToProc = Math.min(...castsBeforeAscendanceProc);
       const maxToProc = Math.max(...castsBeforeAscendanceProc);
       const median = getMedian(castsBeforeAscendanceProc)!;
       // do include them in overall casts to get the expected procs based on simulation results
       const totalCasts = this.castsBeforeAscendanceProc.reduce(
-        (total, current: Casts) => (total += current.count),
+        (total, current: StormstrikeCasts) => (total += current.count),
         0,
       );
       return (
@@ -477,6 +508,23 @@ class Ascendance extends MajorCooldown<AscendanceCooldownCast> {
         </Statistic>
       );
     }
+  }
+
+  get guideSubsection() {
+    return (
+      this.active && (
+        <>
+          <CooldownUsage
+            analyzer={this}
+            title={
+              this.selectedCombatant.hasTalent(TALENTS_SHAMAN.ASCENDANCE_ENHANCEMENT_TALENT)
+                ? 'Ascendance'
+                : 'Deeply Rooted Elements'
+            }
+          />
+        </>
+      )
+    );
   }
 }
 

--- a/src/analysis/retail/shaman/enhancement/modules/talents/ElementalAssault.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/ElementalAssault.tsx
@@ -11,7 +11,7 @@ import { MaelstromWeaponTracker } from '../resourcetracker';
 import TalentAggregateStatisticContainer from 'parser/ui/TalentAggregateStatisticContainer';
 import { SpellLink } from 'interface';
 import TalentAggregateBars, { TalentAggregateBarSpec } from 'parser/ui/TalentAggregateStatistic';
-import { maybeGetSpell } from 'common/SPELLS';
+import SPELLS, { maybeGetSpell } from 'common/SPELLS';
 import { TalentRankTooltip } from 'parser/ui/TalentSpellText';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 
@@ -49,6 +49,7 @@ class ElementalAssault extends Analyzer {
 
   protected damageIncrease: number = 0;
   protected damageGained: number = 0;
+  protected talentRanks: number = 0;
 
   constructor(options: Options) {
     super(options);
@@ -59,10 +60,10 @@ class ElementalAssault extends Analyzer {
       return;
     }
 
-    this.damageIncrease =
-      ELEMENTAL_ASSAULT_RANKS[
-        this.selectedCombatant.getTalentRank(TALENTS_SHAMAN.ELEMENTAL_ASSAULT_TALENT)
-      ];
+    this.talentRanks = this.selectedCombatant.getTalentRank(
+      TALENTS_SHAMAN.ELEMENTAL_ASSAULT_TALENT,
+    );
+    this.damageIncrease = ELEMENTAL_ASSAULT_RANKS[this.talentRanks];
 
     this.addEventListener(
       Events.damage.by(SELECTED_PLAYER).spell(STORMSTRIKE_DAMAGE_SPELLS),
@@ -118,16 +119,23 @@ class ElementalAssault extends Analyzer {
   }
 
   statistic() {
-    const eaRanks = this.selectedCombatant.getTalentRank(TALENTS_SHAMAN.ELEMENTAL_ASSAULT_TALENT);
+    const totalMaelstrom = this.maelstromWeaponGained;
     return (
       <TalentAggregateStatisticContainer
         title={
           <>
             <SpellLink spell={TALENTS_SHAMAN.ELEMENTAL_ASSAULT_TALENT} />
-            <TalentRankTooltip rank={eaRanks} maxRanks={2} /> -{' '}
+            <TalentRankTooltip rank={this.talentRanks} maxRanks={2} /> -{' '}
             <ItemDamageDone amount={this.damageGained} />
           </>
         }
+        footer={
+          <>
+            Total <SpellLink spell={SPELLS.MAELSTROM_WEAPON_BUFF} />: {totalMaelstrom}
+            {this.talentRanks === 2 ? <> ({totalMaelstrom / 2} per point)</> : null}
+          </>
+        }
+        smallFooter
         position={STATISTIC_ORDER.DEFAULT}
         category={STATISTIC_CATEGORY.TALENTS}
         wide

--- a/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
@@ -34,7 +34,7 @@ import EmbeddedTimelineContainer, {
 import Casts from 'interface/report/Results/Timeline/Casts';
 import CooldownUsage from 'parser/core/MajorCooldowns/CooldownUsage';
 
-const GCD_TOLERANCE = 50;
+const GCD_TOLERANCE = 25;
 
 class HotHandRank {
   modRate: number;
@@ -181,8 +181,8 @@ class HotHand extends MajorCooldown<HotHandProc> {
   }
 
   onCast(event: CastEvent) {
-    if (this.activeWindow && event.globalCooldown) {
-      this.activeWindow.unusedGcdTime += event.timestamp - this.globalCooldownEnds;
+    if (this.activeWindow && event.ability.guid > SPELLS.MELEE.id) {
+      this.activeWindow.unusedGcdTime += Math.max(event.timestamp - this.globalCooldownEnds, 0);
       this.activeWindow.timeline.events.push(event);
       if (
         event.ability.guid !== TALENTS_SHAMAN.LAVA_LASH_TALENT.id &&
@@ -312,7 +312,7 @@ class HotHand extends MajorCooldown<HotHandProc> {
 
   private getAverageGcdOfWindow(cast: HotHandProc) {
     return (
-      cast.globalCooldowns.reduce((t, v) => (t += v + GCD_TOLERANCE), 0) /
+      cast.globalCooldowns.reduce((t, gcdDuration) => (t += gcdDuration + GCD_TOLERANCE), 0) /
       (cast.globalCooldowns.length ?? 1)
     );
   }

--- a/src/analysis/retail/shaman/enhancement/modules/talents/SwirlingMaelstrom.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/SwirlingMaelstrom.tsx
@@ -7,6 +7,7 @@ import { SpellLink } from 'interface';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import TalentAggregateBars from 'parser/ui/TalentAggregateStatistic';
+import SPELLS from 'common/SPELLS';
 
 const BAR_COLORS: Record<number, string> = {
   [TALENTS.FROST_SHOCK_TALENT.id]: '#3b7fb0',
@@ -72,6 +73,13 @@ class SwirlingMaelstrom extends Analyzer {
             <SpellLink spell={TALENTS.SWIRLING_MAELSTROM_TALENT} />
           </>
         }
+        footer={
+          <>
+            Total <SpellLink spell={SPELLS.MAELSTROM_WEAPON_BUFF} />:{' '}
+            {this.frostShock + this.iceStrike}
+          </>
+        }
+        smallFooter
         position={STATISTIC_ORDER.DEFAULT}
         category={STATISTIC_CATEGORY.TALENTS}
         wide


### PR DESCRIPTION
### Description

* Priority of `MaelstromWeaponCastNormalizer` was not defined, sometimes running before the event link normalizer, causing `beginchannel` events to be present and interfering with later analysis.
* Added total maelstrom generated detail EA and SW talent statistic boxes
* Deeply Rooted Elements/Ascendance updated to use the same timeline style as Hot Hand instead of just listing filler spells

### Testing
#### Test report URL: 
* EA/SW - `/report/ZFvVn37a6HP2YCLN/39-Mythic+Igira+the+Cruel+-+Kill+(6:26)/Seriousnes/standard/statistics`
* DRE/Asc - `/report/hmYPaqzpDMJxgKNA/107-LFR+Volcoross+-+Kill+(1:09)/Zulrín/standard/overview`

- Screenshot(s):

Elemental Assault
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/6109344/387e58fe-1124-4ee9-ac03-da6d8cfff67f)

Swirling Maelstrom
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/6109344/147fd319-1fd3-4d18-9cd5-45651835ff68)

Deeply Rooted Elements/Ascendance
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/6109344/3f4b563e-dd9d-4005-b520-d5eb7c2453c1)

