### PR TITLE
[FROST DK] KM out-of-gcd Fix

### DIFF
--- a/src/analysis/retail/deathknight/frost/modules/features/KillingMachine.tsx
+++ b/src/analysis/retail/deathknight/frost/modules/features/KillingMachine.tsx
@@ -97,7 +97,8 @@ class KillingMachineEfficiency extends Analyzer {
     // 3/24/23, trying out disabling lag tolerance for km refreshes if the player has fatal fixation talented, may need more work
     if (
       (!this.fatalFixation || (this.fatalFixation && this.currentStacks === 2)) &&
-      timeSinceGCD < this.lastGCDDuration + LAG_BUFFER_MS
+      timeSinceGCD < this.lastGCDDuration + LAG_BUFFER_MS &&
+      timeSinceGCD > 1
     ) {
       this.procsWithinGcd += 1;
       return;


### PR DESCRIPTION
### Description

The code currently counts Killing Machine generations that are out-of-GCD, categorising them as minor mistakes due to the player not being able to prevent them. However, this is also currently catching manually generated KM procs that do not occur outside the GCD. The reason for this is that the KM buff event occurs just after the actual GCD (0 or 1 MS) and is therefore caught as inside a GCD.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: https://www.warcraftlogs.com/reports/ZqFVTL8Q9AwBgf7M#fight=17&type=damage-done&source=430
- Screenshot(s):
New -> ![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/34515306/3951de7b-1526-482f-b0cf-973488b8aa06)
Old -> ![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/34515306/503d9344-9bf4-401b-add3-bfd1aa0e3a07)

