### PR TITLE
[Devastation] Update APL check

### DIFF
--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -6,7 +6,7 @@ import SPELLS from 'common/SPELLS/evoker';
 
 export default [
   change(date(2023, 12, 6), <>Update APL Check.</>, Vollmer),
-  change(date(2023, 11, 32), <>Update <SpellLink spell={SPELLS.DISINTEGRATE}/> guide section.</>, Vollmer),
+  change(date(2023, 11, 30), <>Update <SpellLink spell={SPELLS.DISINTEGRATE}/> guide section.</>, Vollmer),
   change(date(2023, 11, 12), <>Properly track dropped ticks when only 1 tick is remaining for <SpellLink spell={SPELLS.DISINTEGRATE}/> graph.</>, Vollmer),
   change(date(2023, 10, 30), <>Removed rogue points in <SpellLink spell={SPELLS.DISINTEGRATE}/> graph.</>, Vollmer),
   change(date(2023, 10, 21), <>Added stats for T31 4pc buff <SpellLink spell={SPELLS.EMERALD_TRANCE_T31_2PC_BUFF}/>.</>, Vollmer),

--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+  change(date(2023, 12, 6), <>Update APL Check.</>, Vollmer),
   change(date(2023, 11, 32), <>Update <SpellLink spell={SPELLS.DISINTEGRATE}/> guide section.</>, Vollmer),
   change(date(2023, 11, 12), <>Properly track dropped ticks when only 1 tick is remaining for <SpellLink spell={SPELLS.DISINTEGRATE}/> graph.</>, Vollmer),
   change(date(2023, 10, 30), <>Removed rogue points in <SpellLink spell={SPELLS.DISINTEGRATE}/> graph.</>, Vollmer),

--- a/src/analysis/retail/evoker/devastation/modules/AplCheck/index.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/AplCheck/index.tsx
@@ -50,14 +50,14 @@ const COMMON_TOP: Rule[] = [
     spell: SPELLS.FIRE_BREATH,
     condition: cnd.or(
       cnd.buffPresent(TALENTS.DRAGONRAGE_TALENT),
-      cnd.and(cnd.buffMissing(SPELLS.BLAZING_SHARDS), avoidIfDragonRageSoon(13000)),
+      cnd.and(cnd.buffMissing(SPELLS.POWER_SWELL_BUFF), avoidIfDragonRageSoon(13000)),
     ),
   },
   {
     spell: SPELLS.FIRE_BREATH_FONT,
     condition: cnd.or(
       cnd.buffPresent(TALENTS.DRAGONRAGE_TALENT),
-      cnd.and(cnd.buffMissing(SPELLS.BLAZING_SHARDS), avoidIfDragonRageSoon(13000)),
+      cnd.and(cnd.buffMissing(SPELLS.POWER_SWELL_BUFF), avoidIfDragonRageSoon(13000)),
     ),
   },
   // Use ES over star in AoE
@@ -70,7 +70,7 @@ const COMMON_TOP: Rule[] = [
       ),
       cnd.or(
         cnd.buffPresent(TALENTS.DRAGONRAGE_TALENT),
-        cnd.and(cnd.buffMissing(SPELLS.BLAZING_SHARDS), avoidIfDragonRageSoon(13000)),
+        cnd.and(cnd.buffMissing(SPELLS.POWER_SWELL_BUFF), avoidIfDragonRageSoon(13000)),
       ),
     ),
   },
@@ -83,7 +83,7 @@ const COMMON_TOP: Rule[] = [
       ),
       cnd.or(
         cnd.buffPresent(TALENTS.DRAGONRAGE_TALENT),
-        cnd.and(cnd.buffMissing(SPELLS.BLAZING_SHARDS), avoidIfDragonRageSoon(13000)),
+        cnd.and(cnd.buffMissing(SPELLS.POWER_SWELL_BUFF), avoidIfDragonRageSoon(13000)),
       ),
     ),
   },
@@ -141,14 +141,14 @@ const COMMON_TOP: Rule[] = [
     spell: SPELLS.ETERNITY_SURGE,
     condition: cnd.or(
       cnd.buffPresent(TALENTS.DRAGONRAGE_TALENT),
-      cnd.and(cnd.buffMissing(SPELLS.BLAZING_SHARDS), avoidIfDragonRageSoon(13000)),
+      cnd.and(cnd.buffMissing(SPELLS.POWER_SWELL_BUFF), avoidIfDragonRageSoon(13000)),
     ),
   },
   {
     spell: SPELLS.ETERNITY_SURGE_FONT,
     condition: cnd.or(
       cnd.buffPresent(TALENTS.DRAGONRAGE_TALENT),
-      cnd.and(cnd.buffMissing(SPELLS.BLAZING_SHARDS), avoidIfDragonRageSoon(13000)),
+      cnd.and(cnd.buffMissing(SPELLS.POWER_SWELL_BUFF), avoidIfDragonRageSoon(13000)),
     ),
   },
   // Hard cast only Firestorm in AoE

--- a/src/analysis/retail/evoker/devastation/modules/Buffs.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/Buffs.tsx
@@ -18,9 +18,9 @@ class Buffs extends CoreAuras {
         triggeredBySpellId: SPELLS.HOVER.id,
       },
       {
-        spellId: SPELLS.BLAZING_SHARDS.id, // T30 4pc
+        spellId: SPELLS.POWER_SWELL_BUFF.id,
         timelineHighlight: true,
-        triggeredBySpellId: SPELLS.BLAZING_SHARDS.id,
+        triggeredBySpellId: SPELLS.POWER_SWELL_BUFF.id,
       },
       {
         spellId: SPELLS.IRIDESCENCE_RED.id,

--- a/src/common/SPELLS/evoker.ts
+++ b/src/common/SPELLS/evoker.ts
@@ -395,6 +395,11 @@ const spells = {
     name: 'Unravel',
     icon: 'ability_evoker_unravel',
   },
+  POWER_SWELL_BUFF: {
+    id: 376850,
+    name: 'Power Swell',
+    icon: 'ability_evoker_powernexus2',
+  },
   // Augmentation Spells
   UPHEAVAL: {
     id: 396286,


### PR DESCRIPTION
### Description

T30 is long past us, so now we are playing around `✨Power Swell✨` instead of `Blazing Shards (T30 4pc)` - They both trigger off Empower casts, only difference is that `✨Power Swell✨` lasts 1 second less than Blazing Shards.

Also added `✨Power Swell✨` to timeline instead of `Blazing Shards`.

Also changed an impossible date on my last changelog entry.

### Testing

- Test report URL: `/report/Z6AQHxfvRJdqBFkP/41-Heroic+Tindral+Sageswift,+Seer+of+the+Flame+-+Kill+(6:09)/Drgndeesnutz/standard/overview`
