### PR TITLE
update Envenom and finisher analysis

### DIFF
--- a/src/analysis/retail/rogue/assassination/CHANGELOG.tsx
+++ b/src/analysis/retail/rogue/assassination/CHANGELOG.tsx
@@ -6,7 +6,8 @@ import TALENTS from 'common/TALENTS/rogue';
 import SHARED_CHANGELOG from 'analysis/retail/rogue/shared/CHANGELOG';
 
 export default [
-  change(date(2023, 8, 24), `Improved support for Sepsis with Coooldown breakdown + Snapshoting`, [Bigsxy,Whispyr]),
+  change(date(2023, 11, 22), <>Update analysis for <SpellLink spell={SPELLS.ENVENOM} /> and general finisher usage.</>, ToppleTheNun),
+  change(date(2023, 8, 24), `Improved support for Sepsis with Coooldown breakdown + Snapshoting`, [Bigsxy, Whispyr]),
   change(date(2023, 8, 21), 'Add support for usage of Sepsis with Improved Garrote.', Bigsxy),
   change(date(2023, 8, 7), 'Mark Assassination as supported for 10.1.5.', ToppleTheNun),
   change(date(2023, 7, 8), 'Update SpellLink usage.', ToppleTheNun),

--- a/src/analysis/retail/rogue/assassination/Guide.tsx
+++ b/src/analysis/retail/rogue/assassination/Guide.tsx
@@ -12,6 +12,7 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import CombatLogParser from './CombatLogParser';
 import CooldownGraphSubsection from './guide/CooldownGraphSubsection';
 import HideGoodCastsToggle from 'interface/guide/components/HideGoodCastsToggle';
+import { getTargetComboPoints } from 'analysis/retail/rogue/assassination/constants';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -24,7 +25,7 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
   );
 }
 
-function ResourceUsageSection({ modules }: GuideProps<typeof CombatLogParser>) {
+function ResourceUsageSection({ info, modules }: GuideProps<typeof CombatLogParser>) {
   const percentAtCap = modules.energyTracker.percentAtCap;
   const energyWasted = modules.energyTracker.wasted;
 
@@ -52,7 +53,7 @@ function ResourceUsageSection({ modules }: GuideProps<typeof CombatLogParser>) {
         <p>
           Most of your abilities either <strong>build</strong> or <strong>spend</strong>{' '}
           <ResourceLink id={RESOURCE_TYPES.COMBO_POINTS.id} />. Never use a builder at max CPs, and
-          always wait until max CPs to use a spender.
+          always wait until {getTargetComboPoints(info.combatant)}+ CPs to use a spender.
         </p>
         <SideBySidePanels>
           <RoundedPanel>{modules.builderUse.chart}</RoundedPanel>

--- a/src/analysis/retail/rogue/assassination/constants.tsx
+++ b/src/analysis/retail/rogue/assassination/constants.tsx
@@ -53,6 +53,10 @@ export const getMaxComboPoints = (c: Combatant) => {
   return 5 + c.getTalentRank(TALENTS.DEEPER_STRATAGEM_TALENT);
 };
 
+export const getTargetComboPoints = (c: Combatant) => {
+  return 4;
+};
+
 export const RUPTURE_BASE_DURATION = 4000;
 export const RUPTURE_DURATION_PR_CP_SPENT = 4000;
 export const getRuptureDuration = (c: Combatant, cast: CastEvent): number => {

--- a/src/analysis/retail/rogue/assassination/modules/core/FinisherUse.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/core/FinisherUse.tsx
@@ -8,15 +8,15 @@ import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import getResourceSpent from 'parser/core/getResourceSpent';
 import TALENTS from 'common/TALENTS/rogue';
+import { formatDurationMillisMinSec } from 'common/format';
 
 import {
   FINISHERS,
-  getMaxComboPoints,
+  getTargetComboPoints,
   isAnimachargedFinisherCast,
   isInOpener,
   OPENER_MAX_DURATION_MS,
 } from '../../constants';
-import { formatDurationMillisMinSec } from 'common/format';
 
 export default class FinisherUse extends Analyzer {
   totalFinisherCasts = 0;
@@ -45,7 +45,7 @@ export default class FinisherUse extends Analyzer {
         label: 'Max CP Finishers',
         value: this.maxCpFinishers,
         tooltip: (
-          <>This includes finishers cast at {getMaxComboPoints(this.selectedCombatant) - 1} CPs.</>
+          <>This includes finishers cast at {getTargetComboPoints(this.selectedCombatant)}+ CPs.</>
         ),
       },
       {
@@ -105,7 +105,7 @@ export default class FinisherUse extends Analyzer {
     this.totalFinisherCasts += 1;
     if (isAnimachargedFinisherCast(this.selectedCombatant, event)) {
       this.animachargedCasts += 1;
-    } else if (cpsSpent < getMaxComboPoints(this.selectedCombatant) - 1) {
+    } else if (cpsSpent < getTargetComboPoints(this.selectedCombatant)) {
       if (isInOpener(event, this.owner.fight)) {
         this.openerLowCpFinisherCasts += 1;
       } else {

--- a/src/analysis/retail/rogue/assassination/modules/spells/Envenom.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/spells/Envenom.tsx
@@ -11,11 +11,12 @@ import { ReactNode } from 'react';
 import SpellLink from 'interface/SpellLink';
 import {
   animachargedCheckedUsageInfo,
-  getMaxComboPoints,
+  getTargetComboPoints,
 } from 'analysis/retail/rogue/assassination/constants';
 import { combineQualitativePerformances } from 'common/combineQualitativePerformances';
 import Enemies from 'parser/shared/modules/Enemies';
 import HideGoodCastsSpellUsageSubSection from 'parser/core/SpellUsage/HideGoodCastsSpellUsageSubSection';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 const MIN_ACCEPTABLE_TIME_LEFT_ON_RUPTURE_MS = 3000;
 
@@ -37,8 +38,7 @@ export default class Envenom extends Analyzer {
 
   /** Subsection explaining the use of Envenom and providing performance statistics */
   get guideSubsection(): JSX.Element {
-    const maxCps = getMaxComboPoints(this.selectedCombatant);
-    const targetCps = maxCps - 1;
+    const targetCps = getTargetComboPoints(this.selectedCombatant);
     const explanation = (
       <p>
         <strong>
@@ -46,7 +46,7 @@ export default class Envenom extends Analyzer {
         </strong>{' '}
         is your direct damage finisher. Use it when you've already applied{' '}
         <SpellLink spell={SPELLS.RUPTURE} /> to enemies. Always use{' '}
-        <SpellLink spell={SPELLS.ENVENOM} /> at {targetCps}-{maxCps} CPs.
+        <SpellLink spell={SPELLS.ENVENOM} /> at {targetCps}+ CPs.
       </p>
     );
 
@@ -66,101 +66,9 @@ export default class Envenom extends Analyzer {
   }
 
   private onCast(event: CastEvent) {
-    let timeLeftOnRupture = 0;
-    // target is optional in cast event, but we know Envenom cast will always have it
-    if (event.targetID !== undefined && event.targetIsFriendly !== undefined) {
-      timeLeftOnRupture = this.ruptureUptimeAndSnapshots.getTimeRemaining(
-        event as TargettedEvent<any>,
-      );
-    }
-    const acceptableTimeLeftOnRupture = timeLeftOnRupture >= MIN_ACCEPTABLE_TIME_LEFT_ON_RUPTURE_MS;
-
-    const rupturePerformance = acceptableTimeLeftOnRupture
-      ? QualitativePerformance.Good
-      : QualitativePerformance.Fail;
-    const ruptureSummary =
-      timeLeftOnRupture > 0 ? (
-        <div>Time remaining on Rupture: {formatDurationMillisMinSec(timeLeftOnRupture)}</div>
-      ) : (
-        <div>No Rupture on target</div>
-      );
-    let ruptureDetails: ReactNode;
-    if (acceptableTimeLeftOnRupture) {
-      ruptureDetails = (
-        <div>
-          You cast <SpellLink spell={SPELLS.ENVENOM} /> with{' '}
-          {formatDurationMillisMinSec(timeLeftOnRupture)} left on{' '}
-          <SpellLink spell={SPELLS.RUPTURE} />.
-        </div>
-      );
-    } else if (timeLeftOnRupture > 1000) {
-      ruptureDetails = (
-        <div>
-          You cast <SpellLink spell={SPELLS.ENVENOM} /> with{' '}
-          {formatDurationMillisMinSec(timeLeftOnRupture)} left on{' '}
-          <SpellLink spell={SPELLS.RUPTURE} />. Try not to cast <SpellLink spell={SPELLS.ENVENOM} />{' '}
-          with less than {formatDurationMillisMinSec(MIN_ACCEPTABLE_TIME_LEFT_ON_RUPTURE_MS)} left
-          on <SpellLink spell={SPELLS.RUPTURE} />, as it may cause you to miss pandemic-ing{' '}
-          <SpellLink spell={SPELLS.RUPTURE} />.
-        </div>
-      );
-    } else if (timeLeftOnRupture > 0) {
-      ruptureDetails = (
-        <div>
-          You cast <SpellLink spell={SPELLS.ENVENOM} /> with less than 1s left on{' '}
-          <SpellLink spell={SPELLS.RUPTURE} />. Try not to cast <SpellLink spell={SPELLS.ENVENOM} />{' '}
-          with less than {formatDurationMillisMinSec(MIN_ACCEPTABLE_TIME_LEFT_ON_RUPTURE_MS)} left
-          on <SpellLink spell={SPELLS.RUPTURE} />, as it may cause you to miss pandemic-ing{' '}
-          <SpellLink spell={SPELLS.RUPTURE} />.
-        </div>
-      );
-    } else {
-      ruptureDetails = (
-        <div>
-          You cast <SpellLink spell={SPELLS.ENVENOM} /> with no <SpellLink spell={SPELLS.RUPTURE} />{' '}
-          applied to the target. Always ensure that your target has{' '}
-          <SpellLink spell={SPELLS.RUPTURE} /> applied before casting{' '}
-          <SpellLink spell={SPELLS.ENVENOM} />.
-        </div>
-      );
-    }
-
-    const cpsSpent = getResourceSpent(event, RESOURCE_TYPES.COMBO_POINTS);
-    const targetCps = getMaxComboPoints(this.selectedCombatant) - 1;
-    const appropriateCpsSpent = cpsSpent >= targetCps;
-    const cpsPerformance = appropriateCpsSpent
-      ? QualitativePerformance.Good
-      : QualitativePerformance.Fail;
-    let cpsSummary: ReactNode;
-    let cpsDetails: ReactNode;
-    if (appropriateCpsSpent) {
-      cpsSummary = <div>Spent &gt;= {targetCps} CPs</div>;
-      cpsDetails = <div>You spent {cpsSpent} CPs.</div>;
-    } else {
-      cpsSummary = <div>Spend &gt;= {targetCps} CPs</div>;
-      cpsDetails = (
-        <div>
-          You spent {cpsSpent} CPs. Try to always spend at least {targetCps} CPs when casting{' '}
-          <SpellLink spell={SPELLS.ENVENOM} />.
-        </div>
-      );
-    }
-
     const checklistItems: ChecklistUsageInfo[] = [
-      {
-        check: 'rupture',
-        timestamp: event.timestamp,
-        performance: rupturePerformance,
-        summary: ruptureSummary,
-        details: ruptureDetails,
-      },
-      {
-        check: 'cps',
-        timestamp: event.timestamp,
-        performance: cpsPerformance,
-        summary: cpsSummary,
-        details: cpsDetails,
-      },
+      this.determineEnvenomDuringRupturePerformance(event),
+      this.determineComboPointsPerformance(event),
     ];
 
     const actualChecklistItems = animachargedCheckedUsageInfo(
@@ -181,7 +89,106 @@ export default class Envenom extends Analyzer {
           ? `${actualPerformance} Usage`
           : 'Bad Usage',
     });
+  }
 
-    // TODO also highlight 'bad' Envenoms in the timeline
+  private determineEnvenomDuringRupturePerformance(event: CastEvent): ChecklistUsageInfo {
+    let timeLeftOnRupture = 0;
+    // target is optional in cast event, but we know Envenom cast will always have it
+    if (event.targetID !== undefined && event.targetIsFriendly !== undefined) {
+      timeLeftOnRupture = this.ruptureUptimeAndSnapshots.getTimeRemaining(
+        event as TargettedEvent<any>,
+      );
+    }
+    const acceptableTimeLeftOnRupture = timeLeftOnRupture >= MIN_ACCEPTABLE_TIME_LEFT_ON_RUPTURE_MS;
+
+    const performance = acceptableTimeLeftOnRupture
+      ? QualitativePerformance.Good
+      : QualitativePerformance.Fail;
+    const summary = <div>Don&apos;t need to pandemic Rupture</div>;
+    let details: ReactNode;
+    if (acceptableTimeLeftOnRupture) {
+      details = (
+        <div>
+          You cast <SpellLink spell={SPELLS.ENVENOM} /> with{' '}
+          {formatDurationMillisMinSec(timeLeftOnRupture)} left on{' '}
+          <SpellLink spell={SPELLS.RUPTURE} />.
+        </div>
+      );
+    } else if (timeLeftOnRupture > 1000) {
+      details = (
+        <div>
+          You cast <SpellLink spell={SPELLS.ENVENOM} /> with{' '}
+          {formatDurationMillisMinSec(timeLeftOnRupture)} left on{' '}
+          <SpellLink spell={SPELLS.RUPTURE} />. Try not to cast <SpellLink spell={SPELLS.ENVENOM} />{' '}
+          with less than {formatDurationMillisMinSec(MIN_ACCEPTABLE_TIME_LEFT_ON_RUPTURE_MS)} left
+          on <SpellLink spell={SPELLS.RUPTURE} />, as it may cause you to miss pandemic-ing{' '}
+          <SpellLink spell={SPELLS.RUPTURE} />.
+        </div>
+      );
+    } else if (timeLeftOnRupture > 0) {
+      details = (
+        <div>
+          You cast <SpellLink spell={SPELLS.ENVENOM} /> with less than 1s left on{' '}
+          <SpellLink spell={SPELLS.RUPTURE} />. Try not to cast <SpellLink spell={SPELLS.ENVENOM} />{' '}
+          with less than {formatDurationMillisMinSec(MIN_ACCEPTABLE_TIME_LEFT_ON_RUPTURE_MS)} left
+          on <SpellLink spell={SPELLS.RUPTURE} />, as it may cause you to miss pandemic-ing{' '}
+          <SpellLink spell={SPELLS.RUPTURE} />.
+        </div>
+      );
+    } else {
+      details = (
+        <div>
+          You cast <SpellLink spell={SPELLS.ENVENOM} /> with no <SpellLink spell={SPELLS.RUPTURE} />{' '}
+          applied to the target. Always ensure that your target has{' '}
+          <SpellLink spell={SPELLS.RUPTURE} /> applied before casting{' '}
+          <SpellLink spell={SPELLS.ENVENOM} />.
+        </div>
+      );
+    }
+
+    if (performance === QualitativePerformance.Fail) {
+      addInefficientCastReason(event, details);
+    }
+
+    return {
+      check: 'rupture',
+      timestamp: event.timestamp,
+      performance,
+      summary,
+      details,
+    };
+  }
+
+  private determineComboPointsPerformance(event: CastEvent): ChecklistUsageInfo {
+    const cpsSpent = getResourceSpent(event, RESOURCE_TYPES.COMBO_POINTS);
+    const targetCps = getTargetComboPoints(this.selectedCombatant);
+    const appropriateCpsSpent = cpsSpent >= targetCps;
+    const performance = appropriateCpsSpent
+      ? QualitativePerformance.Good
+      : QualitativePerformance.Fail;
+    const summary: ReactNode = <div>Spend {targetCps}+ CPs</div>;
+    let details: ReactNode;
+    if (appropriateCpsSpent) {
+      details = <div>You spent {cpsSpent} CPs.</div>;
+    } else {
+      details = (
+        <div>
+          You spent {cpsSpent} CPs. Try to always spend {targetCps}+ CPs when casting{' '}
+          <SpellLink spell={SPELLS.ENVENOM} />.
+        </div>
+      );
+    }
+
+    if (performance === QualitativePerformance.Fail) {
+      addInefficientCastReason(event, details);
+    }
+
+    return {
+      check: 'cps',
+      timestamp: event.timestamp,
+      performance,
+      summary,
+      details,
+    };
   }
 }


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

As of 10.2, you aim to use finishers at 4 combo points.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/...`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/3fd23470-d782-47a1-b1c9-525d76105d52)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/917c384f-a00a-4fca-9cff-504b18d9a90f)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/7d5f0fe8-3d06-4eb0-b71f-8203bfdc2f3e)
