### PR TITLE
add experimental Kingsbane analysis

### DIFF
--- a/src/analysis/retail/rogue/assassination/CHANGELOG.tsx
+++ b/src/analysis/retail/rogue/assassination/CHANGELOG.tsx
@@ -1,11 +1,12 @@
 import { change, date } from 'common/changelog';
-import { ToppleTheNun, Bigsxy, Whispyr} from 'CONTRIBUTORS';
+import { Bigsxy, ToppleTheNun, Whispyr } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 import SPELLS from 'common/SPELLS/rogue';
 import TALENTS from 'common/TALENTS/rogue';
 import SHARED_CHANGELOG from 'analysis/retail/rogue/shared/CHANGELOG';
 
 export default [
+  change(date(2023, 12, 10), <>Add experimental <SpellLink spell={TALENTS.KINGSBANE_TALENT} /> support behind a toggle.</>, ToppleTheNun),
   change(date(2023, 12, 10), <>Mark as partially updated for 10.2 and add note about <SpellLink spell={TALENTS.KINGSBANE_TALENT} /> analysis coming soon.</>, ToppleTheNun),
   change(date(2023, 12, 10), <>Add analysis for <SpellLink spell={SPELLS.MUTILATE} /> during <SpellLink spell={SPELLS.BLINDSIDE_BUFF} />, <SpellLink spell={SPELLS.SHADOW_DANCE_BUFF} />, <SpellLink spell={SPELLS.SUBTERFUGE_BUFF} />, and <SpellLink spell={SPELLS.VANISH_BUFF} />.</>, ToppleTheNun),
   change(date(2023, 11, 22), <>Update analysis for <SpellLink spell={SPELLS.ENVENOM} /> and general finisher usage.</>, ToppleTheNun),

--- a/src/analysis/retail/rogue/assassination/CombatLogParser.ts
+++ b/src/analysis/retail/rogue/assassination/CombatLogParser.ts
@@ -30,6 +30,9 @@ import ThistleTea from './modules/talents/ThistleTea';
 import Guide from './Guide';
 import Mutilate from './modules/spells/Mutilate';
 import MutilateVanishLinkNormalizer from './normalizers/MutilateVanishLinkNormalizer';
+import KingsbaneLinkNormalizer from './normalizers/KingsbaneLinkNormalizer';
+import Kingsbane from './modules/talents/Kingsbane';
+import BlindsideEventOrderNormalizer from './normalizers/BlindsideEventOrderNormalizer';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -43,6 +46,8 @@ class CombatLogParser extends CoreCombatLogParser {
     thistleTeaCastLinkNormalizer: ThistleTeaCastLinkNormalizer,
     sepsisLinkNormalizer: SepsisLinkNormalizer,
     mutilateVanishLinkNormalizer: MutilateVanishLinkNormalizer,
+    kingsbaneNormalizer: KingsbaneLinkNormalizer,
+    blindsideEventOrderNormalizer: BlindsideEventOrderNormalizer,
 
     // Resource
     comboPointTracker: ComboPointTracker,
@@ -70,6 +75,7 @@ class CombatLogParser extends CoreCombatLogParser {
     crimsonTempestUptimeAndSnapshots: CrimsonTempestUptimeAndSnapshots,
     sepsis: Sepsis,
     thistleTea: ThistleTea,
+    kingsbane: Kingsbane,
 
     // Racials
     arcaneTorrent: [ArcaneTorrent, { gcd: 1000 }] as const,

--- a/src/analysis/retail/rogue/assassination/Guide.tsx
+++ b/src/analysis/retail/rogue/assassination/Guide.tsx
@@ -13,7 +13,10 @@ import CombatLogParser from './CombatLogParser';
 import CooldownGraphSubsection from './guide/CooldownGraphSubsection';
 import HideGoodCastsToggle from 'interface/guide/components/HideGoodCastsToggle';
 import { getTargetComboPoints } from 'analysis/retail/rogue/assassination/constants';
-import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import {
+  ExperimentalKingsbaneContextProvider,
+  ExperimentalKingsbaneToggle,
+} from 'analysis/retail/rogue/assassination/guide/ExperimentalKingsbaneContext';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -98,26 +101,23 @@ function CoreRotationSection({ modules, info }: GuideProps<typeof CombatLogParse
 
 function CooldownSection({ info, modules }: GuideProps<typeof CombatLogParser>) {
   return (
-    <Section title="Cooldowns">
-      <p>
-        Assassination's cooldowns are decently powerful but should not be held on to for long. In
-        order to maximize usages over the course of an encounter, you should aim to send the
-        cooldown as soon as it becomes available (as long as it can do damage on target). It is
-        particularly important to use <SpellLink spell={SPELLS.VANISH} /> as often as possible.
-      </p>
-      <HideExplanationsToggle id="hide-explanations-rotation" />
-      <HideGoodCastsToggle id="hide-good-casts-rotation" />
-      <CooldownGraphSubsection />
-      {info.combatant.hasTalent(TALENTS.SEPSIS_TALENT) && (
-        <CooldownUsage analyzer={modules.sepsis} />
-      )}
-      {info.combatant.hasTalent(TALENTS.KINGSBANE_TALENT) &&
-        explanationAndDataSubsection(
-          <div>
-            Per-cast breakdown for <SpellLink spell={TALENTS.KINGSBANE_TALENT} /> coming soon!
-          </div>,
-          <></>,
+    <ExperimentalKingsbaneContextProvider>
+      <Section title="Cooldowns">
+        <p>
+          Assassination's cooldowns are decently powerful but should not be held on to for long. In
+          order to maximize usages over the course of an encounter, you should aim to send the
+          cooldown as soon as it becomes available (as long as it can do damage on target). It is
+          particularly important to use <SpellLink spell={SPELLS.VANISH} /> as often as possible.
+        </p>
+        <HideExplanationsToggle id="hide-explanations-rotation" />
+        <HideGoodCastsToggle id="hide-good-casts-rotation" />
+        <ExperimentalKingsbaneToggle />
+        <CooldownGraphSubsection />
+        {info.combatant.hasTalent(TALENTS.SEPSIS_TALENT) && (
+          <CooldownUsage analyzer={modules.sepsis} />
         )}
-    </Section>
+        {info.combatant.hasTalent(TALENTS.KINGSBANE_TALENT) && modules.kingsbane.guideSubsection}
+      </Section>
+    </ExperimentalKingsbaneContextProvider>
   );
 }

--- a/src/analysis/retail/rogue/assassination/constants.tsx
+++ b/src/analysis/retail/rogue/assassination/constants.tsx
@@ -97,7 +97,7 @@ export const getCrimsonTempestFullDuration = (c: Combatant) => {
 /** Max time left on a DoT for us to not yell if snapshot is downgraded */
 export const SNAPSHOT_DOWNGRADE_BUFFER = 2000;
 
-export const OPENER_MAX_DURATION_MS = 15000;
+export const OPENER_MAX_DURATION_MS = 30000;
 
 export const BUILDERS: Spell[] = [
   SPELLS.MUTILATE,

--- a/src/analysis/retail/rogue/assassination/guide/ExperimentalKingsbaneContext.tsx
+++ b/src/analysis/retail/rogue/assassination/guide/ExperimentalKingsbaneContext.tsx
@@ -1,0 +1,61 @@
+import useAssassinationFeatureFlag from 'analysis/retail/rogue/assassination/guide/useAssassinationFeatureFlag';
+import VerticallyAlignedToggle from 'interface/VerticallyAlignedToggle';
+import { createContext, ReactNode, useContext } from 'react';
+
+interface ExperimentalKingsbaneContext {
+  isExplanationEnabled: boolean;
+  setExplanationEnabled: (enabled: boolean) => void;
+}
+const ExperimentalKingsbaneCtx = createContext<ExperimentalKingsbaneContext>({
+  isExplanationEnabled: false,
+  setExplanationEnabled: () => {
+    // no op
+  },
+});
+
+export const useExperimentalKingsbane = () => useContext(ExperimentalKingsbaneCtx);
+
+export const ExperimentalKingsbaneToggle = () => {
+  const { isExplanationEnabled, setExplanationEnabled } = useExperimentalKingsbane();
+
+  return (
+    <div className="flex">
+      <div className="flex-main" />
+      <div className="flex-sub">
+        <VerticallyAlignedToggle
+          id="experimental-kingsbane-explanation-toggle"
+          enabled={isExplanationEnabled}
+          setEnabled={setExplanationEnabled}
+          label="Enable Kingsbane analysis"
+          tooltipContent="Enabling this feature will turn on our Kingsbane analysis. It's still a work-in-progress, so don't worry too much about what it says."
+        />
+      </div>
+    </div>
+  );
+};
+
+export const ExperimentalKingsbaneContextProvider = ({ children }: { children: ReactNode }) => {
+  const [isExplanationEnabled, setExplanationEnabled] = useAssassinationFeatureFlag(
+    'experimental-kingsbane-explanation-enabled',
+  );
+
+  return (
+    <ExperimentalKingsbaneCtx.Provider value={{ isExplanationEnabled, setExplanationEnabled }}>
+      {children}
+    </ExperimentalKingsbaneCtx.Provider>
+  );
+};
+
+export const ExperimentalKingsbaneHider = ({
+  children,
+  fallback,
+}: {
+  children: ReactNode;
+  fallback: ReactNode;
+}) => {
+  const { isExplanationEnabled } = useExperimentalKingsbane();
+  if (isExplanationEnabled) {
+    return <>{children}</>;
+  }
+  return <>{fallback}</>;
+};

--- a/src/analysis/retail/rogue/assassination/guide/useAssassinationFeatureFlag.ts
+++ b/src/analysis/retail/rogue/assassination/guide/useAssassinationFeatureFlag.ts
@@ -1,0 +1,10 @@
+import useSessionFeatureFlag from 'interface/useSessionFeatureFlag';
+
+const useAssassinationFeatureFlag = (featureFlag: string, featureFlagDefault: boolean = false) => {
+  return useSessionFeatureFlag(
+    ['sin', featureFlag].filter((it) => it).join('-'),
+    featureFlagDefault,
+  );
+};
+
+export default useAssassinationFeatureFlag;

--- a/src/analysis/retail/rogue/assassination/modules/spells/Envenom.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/spells/Envenom.tsx
@@ -17,6 +17,8 @@ import { combineQualitativePerformances } from 'common/combineQualitativePerform
 import Enemies from 'parser/shared/modules/Enemies';
 import ContextualSpellUsageSubSection from 'parser/core/SpellUsage/HideGoodCastsSpellUsageSubSection';
 import { addInefficientCastReason } from 'parser/core/EventMetaLib';
+import uptimeBarSubStatistic from 'parser/ui/UptimeBarSubStatistic';
+import { RoundedPanelWithBottomMargin } from 'analysis/retail/rogue/shared/styled-components';
 
 const MIN_ACCEPTABLE_TIME_LEFT_ON_RUPTURE_MS = 3000;
 
@@ -54,6 +56,20 @@ export default class Envenom extends Analyzer {
       <ContextualSpellUsageSubSection
         explanation={explanation}
         uses={this.cooldownUses}
+        abovePerformanceDetails={
+          <RoundedPanelWithBottomMargin>
+            <div>
+              <strong>
+                <SpellLink spell={SPELLS.ENVENOM} /> uptime
+              </strong>
+              <small> - Try to get as close to 100% as the encounter allows!</small>
+            </div>
+            {uptimeBarSubStatistic(this.owner.fight, {
+              spells: [SPELLS.ENVENOM],
+              uptimes: this.envenomBuffUptimes,
+            })}
+          </RoundedPanelWithBottomMargin>
+        }
         castBreakdownSmallText={
           <>
             {' '}
@@ -63,6 +79,13 @@ export default class Envenom extends Analyzer {
         }
       />
     );
+  }
+
+  private get envenomBuffUptimes() {
+    return this.selectedCombatant.getBuffHistory(SPELLS.ENVENOM.id).map((buff) => ({
+      start: buff.start,
+      end: buff.end ?? this.owner.fight.end_time,
+    }));
   }
 
   private onCast(event: CastEvent) {

--- a/src/analysis/retail/rogue/assassination/modules/spells/GarroteUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/spells/GarroteUptimeAndSnapshots.tsx
@@ -14,11 +14,11 @@ import { getHardcast } from 'analysis/retail/druid/feral/normalizers/CastLinkNor
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import TALENTS from 'common/TALENTS/rogue';
 import uptimeBarSubStatistic, { SubPercentageStyle } from 'parser/ui/UptimeBarSubStatistic';
-import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { formatDurationMillisMinSec } from 'common/format';
 import { ChecklistUsageInfo, SpellUse } from 'parser/core/SpellUsage/core';
 import { combineQualitativePerformances } from 'common/combineQualitativePerformances';
 import ContextualSpellUsageSubSection from 'parser/core/SpellUsage/HideGoodCastsSpellUsageSubSection';
+import { RoundedPanelWithBottomMargin } from 'analysis/retail/rogue/shared/styled-components';
 
 export default class GarroteUptimeAndSnapshots extends DotSnapshots {
   static dependencies = {
@@ -237,13 +237,13 @@ export default class GarroteUptimeAndSnapshots extends DotSnapshots {
         explanation={explanation}
         uses={this.cooldownUses}
         abovePerformanceDetails={
-          <RoundedPanel>
+          <RoundedPanelWithBottomMargin>
             <div>
               <strong>Garrote uptime / snapshots</strong>
               <small> - Try to get as close to 100% as the encounter allows!</small>
             </div>
             {this.subStatistic()}
-          </RoundedPanel>
+          </RoundedPanelWithBottomMargin>
         }
         castBreakdownSmallText={
           <>

--- a/src/analysis/retail/rogue/assassination/modules/spells/Mutilate.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/spells/Mutilate.tsx
@@ -27,8 +27,8 @@ export default class Mutilate extends Analyzer {
           <SpellLink spell={SPELLS.MUTILATE} />
         </strong>
         . You should never use <SpellLink spell={SPELLS.MUTILATE} /> during{' '}
-        <SpellLink spell={SPELLS.BLINDSIDE_BUFF} />, <SpellLink spell={SPELLS.SHADOW_DANCE_BUFF} />,{' '}
-        <SpellLink spell={SPELLS.SUBTERFUGE_BUFF} />, or <SpellLink spell={SPELLS.VANISH_BUFF} />.
+        <SpellLink spell={SPELLS.SHADOW_DANCE_BUFF} />, <SpellLink spell={SPELLS.SUBTERFUGE_BUFF} />
+        , or <SpellLink spell={SPELLS.VANISH_BUFF} />.
       </p>
     );
 
@@ -54,6 +54,9 @@ export default class Mutilate extends Analyzer {
             />
           </div>
         }
+        noCastsTexts={{
+          noCastsOverride: 'All of your casts of this spell were good!',
+        }}
       />
     );
   }
@@ -61,39 +64,10 @@ export default class Mutilate extends Analyzer {
   private onCast(event: CastEvent) {
     this.cooldownUses.push(
       createSpellUse({ event }, [
-        this.blindsidePerformance(event),
         this.shadowDancePerformance(event),
         this.subterfugePerformance(event),
         this.vanishPerformance(event),
       ]),
-    );
-  }
-
-  private blindsidePerformance(event: CastEvent): ChecklistUsageInfo | undefined {
-    if (!this.selectedCombatant.hasTalent(TALENTS.BLINDSIDE_TALENT)) {
-      return undefined;
-    }
-    const isBuffActive = this.selectedCombatant.hasBuff(SPELLS.BLINDSIDE_BUFF.id, event.timestamp);
-    const summary = <div>Do not have Blindside active</div>;
-    const details = isBuffActive ? (
-      <div>
-        You cast <SpellLink spell={SPELLS.MUTILATE} /> when you should have cast{' '}
-        <SpellLink spell={SPELLS.AMBUSH} /> due to having{' '}
-        <SpellLink spell={SPELLS.BLINDSIDE_BUFF} /> active.
-      </div>
-    ) : (
-      <div>
-        You did not have <SpellLink spell={SPELLS.BLINDSIDE_BUFF} /> active. Good job!
-      </div>
-    );
-    return createChecklistItem(
-      'blindside',
-      { event },
-      {
-        performance: isBuffActive ? QualitativePerformance.Fail : QualitativePerformance.Good,
-        summary,
-        details,
-      },
     );
   }
 

--- a/src/analysis/retail/rogue/assassination/modules/spells/RuptureUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/spells/RuptureUptimeAndSnapshots.tsx
@@ -14,13 +14,13 @@ import {
 } from 'analysis/retail/rogue/assassination/constants';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import uptimeBarSubStatistic, { SubPercentageStyle } from 'parser/ui/UptimeBarSubStatistic';
-import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { formatDurationMillisMinSec } from 'common/format';
 import { SpellUse } from 'parser/core/SpellUsage/core';
 
 import { getHardcast } from '../../normalizers/CastLinkNormalizer';
 import { combineQualitativePerformances } from 'common/combineQualitativePerformances';
 import ContextualSpellUsageSubSection from 'parser/core/SpellUsage/HideGoodCastsSpellUsageSubSection';
+import { RoundedPanelWithBottomMargin } from 'analysis/retail/rogue/shared/styled-components';
 
 export default class RuptureUptimeAndSnapshots extends DotSnapshots {
   static dependencies = {
@@ -159,13 +159,13 @@ export default class RuptureUptimeAndSnapshots extends DotSnapshots {
         explanation={explanation}
         uses={this.cooldownUses}
         abovePerformanceDetails={
-          <RoundedPanel>
+          <RoundedPanelWithBottomMargin>
             <div>
               <strong>Rupture uptime / snapshots</strong>
               <small> - Try to get as close to 100% as the encounter allows!</small>
             </div>
             {this.subStatistic()}
-          </RoundedPanel>
+          </RoundedPanelWithBottomMargin>
         }
         castBreakdownSmallText={
           <>

--- a/src/analysis/retail/rogue/assassination/modules/talents/CrimsonTempestUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/talents/CrimsonTempestUptimeAndSnapshots.tsx
@@ -13,13 +13,13 @@ import {
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import TALENTS from 'common/TALENTS/rogue';
 import uptimeBarSubStatistic, { SubPercentageStyle } from 'parser/ui/UptimeBarSubStatistic';
-import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { formatDurationMillisMinSec } from 'common/format';
 import { SpellUse } from 'parser/core/SpellUsage/core';
 
 import { getHardcast } from '../../normalizers/CastLinkNormalizer';
 import { combineQualitativePerformances } from 'common/combineQualitativePerformances';
 import ContextualSpellUsageSubSection from 'parser/core/SpellUsage/HideGoodCastsSpellUsageSubSection';
+import { RoundedPanelWithBottomMargin } from 'analysis/retail/rogue/shared/styled-components';
 
 export default class CrimsonTempestUptimeAndSnapshots extends DotSnapshots {
   static dependencies = {
@@ -158,13 +158,13 @@ export default class CrimsonTempestUptimeAndSnapshots extends DotSnapshots {
         explanation={explanation}
         uses={this.cooldownUses}
         abovePerformanceDetails={
-          <RoundedPanel>
+          <RoundedPanelWithBottomMargin>
             <div>
               <strong>Crimson Tempest uptime / snapshots</strong>
               <small> - Try to get as close to 100% as the encounter allows!</small>
             </div>
             {this.subStatistic()}
-          </RoundedPanel>
+          </RoundedPanelWithBottomMargin>
         }
         castBreakdownSmallText={
           <>

--- a/src/analysis/retail/rogue/assassination/modules/talents/Kingsbane.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/talents/Kingsbane.tsx
@@ -1,0 +1,477 @@
+import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import MajorCooldown, {
+  CooldownTrigger,
+  createChecklistItem,
+  createSpellUse,
+} from 'parser/core/MajorCooldowns/MajorCooldown';
+import SPELLS from 'common/SPELLS/rogue';
+import TALENTS from 'common/TALENTS/rogue';
+import Events, { CastEvent } from 'parser/core/Events';
+import { ChecklistUsageInfo, SpellUse } from 'parser/core/SpellUsage/core';
+import { ReactNode } from 'react';
+import SpellLink from 'interface/SpellLink';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import Enemies from 'parser/shared/modules/Enemies';
+import Enemy from 'parser/core/Enemy';
+import {
+  getMatchingDeathmarkOrKingsbaneCast,
+  getMatchingShivOrKingsbaneCast,
+  SHIV_KINGSBANE_BUFFER_MS,
+} from 'analysis/retail/rogue/assassination/normalizers/KingsbaneLinkNormalizer';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import CooldownUsage from 'parser/core/MajorCooldowns/CooldownUsage';
+import { formatDurationMillisMinSec } from 'common/format';
+import uptimeBarSubStatistic from 'parser/ui/UptimeBarSubStatistic';
+import {
+  ExplanationSection,
+  RoundedPanelWithBottomMargin,
+} from 'analysis/retail/rogue/shared/styled-components';
+import { ExperimentalKingsbaneHider } from 'analysis/retail/rogue/assassination/guide/ExperimentalKingsbaneContext';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+
+interface KingsbaneCooldownTrigger extends CooldownTrigger<CastEvent> {
+  enemy: Enemy | null;
+}
+
+interface KingsbaneCooldownTriggerWithEnemy extends KingsbaneCooldownTrigger {
+  enemy: Enemy;
+}
+
+function hasEnemy(trigger: KingsbaneCooldownTrigger): trigger is KingsbaneCooldownTriggerWithEnemy {
+  return Boolean(trigger.enemy);
+}
+
+export default class Kingsbane extends MajorCooldown<KingsbaneCooldownTrigger> {
+  static dependencies = {
+    ...MajorCooldown.dependencies,
+    enemies: Enemies,
+    spellUsable: SpellUsable,
+  };
+
+  protected enemies!: Enemies;
+  protected spellUsable!: SpellUsable;
+
+  constructor(options: Options) {
+    super({ spell: TALENTS.KINGSBANE_TALENT }, options);
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.KINGSBANE_TALENT),
+      this.onCast,
+    );
+  }
+
+  description(): ReactNode {
+    return (
+      <>
+        <ExplanationSection>
+          <p>
+            <strong>
+              <SpellLink spell={TALENTS.KINGSBANE_TALENT} />
+            </strong>{' '}
+            is one of your core burst cooldowns that gets stronger with every Lethal Poison applied.
+          </p>
+        </ExplanationSection>
+        <ExplanationSection>
+          <p>
+            <strong>
+              <SpellLink spell={SPELLS.ENVENOM} />
+            </strong>{' '}
+            uptime is very important for your Kingsbane windows. Try to maintain 100% uptime on{' '}
+            <SpellLink spell={SPELLS.ENVENOM} /> during your windows.
+          </p>
+        </ExplanationSection>
+        {this.selectedCombatant.hasTalent(TALENTS.IMPROVED_SHIV_TALENT) && (
+          <ExplanationSection>
+            <p>
+              <strong>
+                <SpellLink spell={TALENTS.IMPROVED_SHIV_TALENT} />
+              </strong>{' '}
+              makes any cast of <SpellLink spell={SPELLS.SHIV} /> cause your target to take{' '}
+              <strong>30%</strong> increased nature damage from you. This is incredibly important to
+              apply before you cast <SpellLink spell={TALENTS.KINGSBANE_TALENT} />.
+            </p>
+          </ExplanationSection>
+        )}
+        {this.selectedCombatant.hasTalent(TALENTS.LIGHTWEIGHT_SHIV_TALENT) ? (
+          <ExplanationSection>
+            <p>
+              <strong>
+                <SpellLink spell={TALENTS.LIGHTWEIGHT_SHIV_TALENT} />
+              </strong>{' '}
+              gives you a second charge of <SpellLink spell={SPELLS.SHIV} />, which is an easy way
+              to apply another poison that buffs your <SpellLink spell={TALENTS.KINGSBANE_TALENT} />
+              .
+            </p>
+          </ExplanationSection>
+        ) : (
+          <ExplanationSection>
+            <p>
+              <strong>
+                <SpellLink spell={TALENTS.LIGHTWEIGHT_SHIV_TALENT} />
+              </strong>{' '}
+              gives you a second charge of <SpellLink spell={SPELLS.SHIV} />, which is an easy way
+              to apply another poison that buffs your <SpellLink spell={TALENTS.KINGSBANE_TALENT} />
+              . You are not currently talented into it, but you should{' '}
+              <strong>very strongly</strong> consider it. All analysis here assumes that you will
+              take it.
+            </p>
+          </ExplanationSection>
+        )}
+      </>
+    );
+  }
+
+  explainPerformance(trigger: KingsbaneCooldownTrigger): SpellUse {
+    if (!this.selectedCombatant.hasTalent(TALENTS.LIGHTWEIGHT_SHIV_TALENT)) {
+      return createSpellUse(trigger, [
+        createChecklistItem('lightweight-shiv', trigger, {
+          performance: QualitativePerformance.Fail,
+          summary: (
+            <div>
+              Talented into <SpellLink spell={TALENTS.LIGHTWEIGHT_SHIV_TALENT} />
+            </div>
+          ),
+          details: (
+            <div>
+              Did not have <SpellLink spell={TALENTS.LIGHTWEIGHT_SHIV_TALENT} /> talented. In order
+              to get the maximum amount of damage possible out of{' '}
+              <SpellLink spell={TALENTS.KINGSBANE_TALENT} />, you should use{' '}
+              <SpellLink spell={TALENTS.LIGHTWEIGHT_SHIV_TALENT} />.
+            </div>
+          ),
+        }),
+      ]);
+    }
+    if (!hasEnemy(trigger)) {
+      return createSpellUse(trigger, [
+        createChecklistItem('hit-a-valid-target', trigger, {
+          performance: QualitativePerformance.Fail,
+          summary: <div>Hit a Valid Target</div>,
+          details: (
+            <div>
+              Did not hit a valid target. Try to ensure that you hit a valid target with your
+              important casts.
+            </div>
+          ),
+        }),
+      ]);
+    }
+
+    return createSpellUse(trigger, [
+      this.explainDeathmarkPerformance(trigger),
+      this.explainShadowDancePerformance(trigger),
+      this.explainEnvenomPerformance(trigger),
+      this.explainImprovedShivPerformance(trigger),
+      this.explainShivPerformance(trigger),
+    ]);
+  }
+
+  get guideSubsection(): ReactNode {
+    return (
+      <ExperimentalKingsbaneHider
+        fallback={explanationAndDataSubsection(
+          <div>
+            <strong>
+              <SpellLink spell={TALENTS.KINGSBANE_TALENT} />
+            </strong>{' '}
+            cast breakdown coming soon!
+          </div>,
+          <></>,
+        )}
+      >
+        <CooldownUsage
+          analyzer={this}
+          abovePerformanceDetails={
+            <RoundedPanelWithBottomMargin>
+              <div>
+                <strong>
+                  <SpellLink spell={SPELLS.ENVENOM} /> uptime
+                </strong>
+                <small> - Try to get as close to 100% as the encounter allows!</small>
+              </div>
+              {uptimeBarSubStatistic(this.owner.fight, {
+                spells: [SPELLS.ENVENOM],
+                uptimes: this.envenomBuffUptimes,
+              })}
+            </RoundedPanelWithBottomMargin>
+          }
+          warning={{
+            children: (
+              <>
+                <p>
+                  <strong>
+                    <SpellLink spell={TALENTS.KINGSBANE_TALENT} />
+                  </strong>{' '}
+                  analysis is experimental and should be taken with a grain of salt. Thanks for
+                  being willing to try it out!
+                </p>
+                <p>The below items are not yet implemented:</p>
+                <ul>
+                  <li>
+                    <SpellLink spell={TALENTS.DEATHMARK_TALENT} /> usage
+                  </li>
+                  <li>
+                    <SpellLink spell={TALENTS.SHADOW_DANCE_TALENT} /> usage
+                  </li>
+                  <li>
+                    Fully accurate <SpellLink spell={TALENTS.SHIV_TALENT} /> usage
+                    <ul>
+                      <li>
+                        Current implementation requires <SpellLink spell={TALENTS.SHIV_TALENT} />{' '}
+                        within {formatDurationMillisMinSec(SHIV_KINGSBANE_BUFFER_MS)} of casting{' '}
+                        <SpellLink spell={TALENTS.KINGSBANE_TALENT} />
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </>
+            ),
+            style: { marginBottom: '30px' },
+          }}
+        />
+      </ExperimentalKingsbaneHider>
+    );
+  }
+
+  private get envenomBuffUptimes() {
+    return this.selectedCombatant.getBuffHistory(SPELLS.ENVENOM.id).map((buff) => ({
+      start: buff.start,
+      end: buff.end ?? this.owner.fight.end_time,
+    }));
+  }
+
+  private onCast(event: CastEvent) {
+    const enemy = this.enemies.getEntity(event);
+
+    this.recordCooldown({
+      event,
+      enemy,
+    });
+  }
+
+  /*
+  Kingsbane should be cast ~2s after Deathmark when Deathmark is available.
+  Entirety of Kingsbane should fit within a Deathmark window.
+   */
+  /*
+    TODO: implement the below behavior
+    Whispyr — Yesterday at 11:38 PM
+    :Cat_Nod:
+    Envenom
+    Deathmark
+    Shiv
+    Shadow dance + kingsbane (in that order)
+    Garrote
+    Envenom
+    Is basically a set in stone sequence
+    Topple — Yesterday at 11:40 PM
+    :BearNotesTaking:
+    Whispyr — Yesterday at 11:41 PM
+    Sometimes garrote will be on cd
+    But typically something like that
+    Topple — Yesterday at 11:44 PM
+    shadow dance + kingsbane is like a macro?
+    Whispyr — Yesterday at 11:44 PM
+    Yeah
+    As long as the dance is before the kingsbane
+    Even a microsecond after and it doesn’t snapshot
+    So it’s doomed
+     */
+  private explainDeathmarkPerformance(
+    trigger: KingsbaneCooldownTriggerWithEnemy,
+  ): ChecklistUsageInfo | undefined {
+    if (!this.selectedCombatant.hasTalent(TALENTS.DEATHMARK_TALENT)) {
+      return undefined;
+    }
+
+    const summary = (
+      <div>
+        Fit within <SpellLink spell={TALENTS.DEATHMARK_TALENT} /> window
+      </div>
+    );
+
+    const isDeathmarkAvailable = this.spellUsable.isAvailable(TALENTS.DEATHMARK_TALENT.id);
+
+    const deathmarkCast = getMatchingDeathmarkOrKingsbaneCast(trigger.event);
+    if (!deathmarkCast && isDeathmarkAvailable) {
+      return createChecklistItem('deathmark', trigger, {
+        performance: QualitativePerformance.Fail,
+        summary,
+        details: (
+          <div>
+            You cast <SpellLink spell={TALENTS.KINGSBANE_TALENT} /> while{' '}
+            <SpellLink spell={TALENTS.DEATHMARK_TALENT} /> was available and off cooldown. Try to
+            always cast <SpellLink spell={TALENTS.DEATHMARK_TALENT} /> before{' '}
+            <SpellLink spell={TALENTS.KINGSBANE_TALENT} /> when it&apos;s available.
+          </div>
+        ),
+      });
+    }
+
+    const anyEnemyHasDeathMark = Object.values(this.enemies.getEntities()).some(
+      (it) => it.hasBuff(TALENTS.DEATHMARK_TALENT.id),
+      trigger.event.timestamp,
+    );
+    const enemyHasDeathmark = trigger.enemy.hasBuff(
+      TALENTS.DEATHMARK_TALENT.id,
+      trigger.event.timestamp,
+    );
+    if (anyEnemyHasDeathMark && !enemyHasDeathmark) {
+      return createChecklistItem('deathmark', trigger, {
+        performance: QualitativePerformance.Fail,
+        summary,
+        details: (
+          <div>
+            You cast <SpellLink spell={TALENTS.KINGSBANE_TALENT} /> on a different target than you
+            cast <SpellLink spell={TALENTS.DEATHMARK_TALENT} />. Always try to cast them on the same
+            target.
+          </div>
+        ),
+      });
+    }
+
+    // TODO: finish
+    return undefined;
+  }
+
+  /*
+  TODO: implement the below behavior
+  Whispyr — Yesterday at 11:38 PM
+  :Cat_Nod:
+  Envenom
+  Deathmark
+  Shiv
+  Shadow dance + kingsbane (in that order)
+  Garrote
+  Envenom
+  Is basically a set in stone sequence
+  Topple — Yesterday at 11:40 PM
+  :BearNotesTaking:
+  Whispyr — Yesterday at 11:41 PM
+  Sometimes garrote will be on cd
+  But typically something like that
+  Topple — Yesterday at 11:44 PM
+  shadow dance + kingsbane is like a macro?
+  Whispyr — Yesterday at 11:44 PM
+  Yeah
+  As long as the dance is before the kingsbane
+  Even a microsecond after and it doesn’t snapshot
+  So it’s doomed
+   */
+  private explainShadowDancePerformance(
+    trigger: KingsbaneCooldownTrigger,
+  ): ChecklistUsageInfo | undefined {
+    if (!this.selectedCombatant.hasTalent(TALENTS.SHADOW_DANCE_TALENT)) {
+      return undefined;
+    }
+    return undefined;
+  }
+
+  /*
+  TODO: implement the below behavior
+  Topple — Today at 12:06 AM
+  for the shiv in Kingsbane
+  does the timing matter as long as it's during Kingsbane?
+  Whispyr — Today at 12:06 AM
+  Kinda? Should be as close to the expiration of the first as possible
+  But if it’s like a gcd apart or whatever it’s not the end of the world
+  Topple — Today at 12:07 AM
+  okay, so tied to expiration of buff, got it
+  is refreshing okay?
+  Whispyr — Today at 12:07 AM
+  Generally would want to avoid
+  It doesn’t pandemic
+  You just wanna back to back them
+   */
+  private explainShivPerformance(
+    trigger: KingsbaneCooldownTriggerWithEnemy,
+  ): ChecklistUsageInfo | undefined {
+    const summary = (
+      <div>
+        <SpellLink spell={TALENTS.SHIV_TALENT} /> within{' '}
+        {formatDurationMillisMinSec(SHIV_KINGSBANE_BUFFER_MS)} after cast
+      </div>
+    );
+    const matchingShiv = getMatchingShivOrKingsbaneCast(trigger.event);
+
+    if (!matchingShiv) {
+      return createChecklistItem('shiv-after', trigger, {
+        performance: QualitativePerformance.Fail,
+        summary,
+        details: (
+          <div>
+            You did not cast <SpellLink spell={TALENTS.SHIV_TALENT} /> within{' '}
+            {formatDurationMillisMinSec(SHIV_KINGSBANE_BUFFER_MS)} after casting{' '}
+            <SpellLink spell={TALENTS.KINGSBANE_TALENT} />. Try to always cast{' '}
+            <SpellLink spell={TALENTS.SHIV_TALENT} /> within{' '}
+            {formatDurationMillisMinSec(SHIV_KINGSBANE_BUFFER_MS)} after casting{' '}
+            <SpellLink spell={TALENTS.KINGSBANE_TALENT} /> so that your poison application buffs
+            your <SpellLink spell={TALENTS.KINGSBANE_TALENT} />.
+          </div>
+        ),
+      });
+    }
+
+    return createChecklistItem('shiv-after', trigger, {
+      performance: QualitativePerformance.Good,
+      summary,
+      details: (
+        <div>
+          You cast <SpellLink spell={TALENTS.SHIV_TALENT} /> within{' '}
+          {formatDurationMillisMinSec(SHIV_KINGSBANE_BUFFER_MS)} after casting{' '}
+          <SpellLink spell={TALENTS.KINGSBANE_TALENT} />. Good job!
+        </div>
+      ),
+    });
+  }
+
+  private explainImprovedShivPerformance(
+    trigger: KingsbaneCooldownTriggerWithEnemy,
+  ): ChecklistUsageInfo | undefined {
+    if (!this.selectedCombatant.hasTalent(TALENTS.IMPROVED_SHIV_TALENT)) {
+      return undefined;
+    }
+
+    const summary = (
+      <div>
+        Target has <SpellLink spell={SPELLS.SHIV_DEBUFF} />
+      </div>
+    );
+    const hasShivDebuff = trigger.enemy.hasBuff(SPELLS.SHIV_DEBUFF.id, trigger.event.timestamp);
+
+    if (!hasShivDebuff) {
+      return createChecklistItem('improved-shiv', trigger, {
+        performance: QualitativePerformance.Fail,
+        summary,
+        details: (
+          <div>
+            You cast <SpellLink spell={TALENTS.KINGSBANE_TALENT} /> while the target did not have
+            the <SpellLink spell={SPELLS.SHIV_DEBUFF} /> debuff. Try to always cast{' '}
+            <SpellLink spell={TALENTS.KINGSBANE_TALENT} /> after casting{' '}
+            <SpellLink spell={TALENTS.SHIV_TALENT} /> because of the nature damage amplification it
+            provides due to <SpellLink spell={TALENTS.IMPROVED_SHIV_TALENT} />.
+          </div>
+        ),
+      });
+    }
+
+    return createChecklistItem('improved-shiv', trigger, {
+      performance: QualitativePerformance.Good,
+      summary,
+      details: (
+        <div>
+          You cast <SpellLink spell={TALENTS.KINGSBANE_TALENT} /> after casting{' '}
+          <SpellLink spell={TALENTS.SHIV_TALENT} /> and benefited from the nature damage
+          amplification it provides due to <SpellLink spell={TALENTS.IMPROVED_SHIV_TALENT} />. Good
+          job!
+        </div>
+      ),
+    });
+  }
+
+  private explainEnvenomPerformance(
+    trigger: KingsbaneCooldownTrigger,
+  ): ChecklistUsageInfo | undefined {
+    return undefined;
+  }
+}

--- a/src/analysis/retail/rogue/assassination/modules/talents/Sepsis.tsx
+++ b/src/analysis/retail/rogue/assassination/modules/talents/Sepsis.tsx
@@ -1,6 +1,6 @@
 import MajorCooldown, {
-  createChecklistItem,
   CooldownTrigger,
+  createChecklistItem,
 } from 'parser/core/MajorCooldowns/MajorCooldown';
 import { SpellUse, UsageInfo } from 'parser/core/SpellUsage/core';
 import React from 'react';
@@ -14,16 +14,13 @@ import { isDefined } from 'common/typeGuards';
 import { combineQualitativePerformances } from 'common/combineQualitativePerformances';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import {
-  getRelatedBuffApplicationFromHardcast,
-  getDebuffApplicationFromHardcast,
-  getSepsisConsumptionCastForBuffEvent,
   getAuraLifetimeEvent,
-} from '../../normalizers/SepsisLinkNormalizer';
-import {
-  SEPSIS_DEBUFF_DURATION,
+  getDebuffApplicationFromHardcast,
+  getRelatedBuffApplicationFromHardcast,
+  getSepsisConsumptionCastForBuffEvent,
   SEPSIS_BUFF_DURATION,
+  SEPSIS_DEBUFF_DURATION,
 } from '../../normalizers/SepsisLinkNormalizer';
-import { ExplanationSection } from 'analysis/retail/demonhunter/shared/guide/CommonComponents';
 import { Expandable } from 'interface';
 import { SectionHeader } from 'interface/guide';
 import { BUFF_DROP_BUFFER } from 'parser/core/DotSnapshots';
@@ -31,6 +28,7 @@ import { formatPercentage } from 'common/format';
 import { GARROTE_BASE_DURATION, isInOpener } from '../../constants';
 import { CAST_BUFFER_MS } from '../../normalizers/CastLinkNormalizer';
 import { TrackedBuffEvent } from 'parser/core/Entity';
+import { ExplanationSection } from 'analysis/retail/rogue/shared/styled-components';
 
 const SHIV_DURATION = 8 * 1000;
 const BASE_ROGUE_GCD = 1000;
@@ -342,8 +340,7 @@ export default class Sepsis extends MajorCooldown<SepsisCast> {
         </>
       );
       if (overlapPercent < 0.85) {
-        let additionalDetails: React.ReactNode = <></>;
-        additionalDetails = (
+        let additionalDetails = (
           <>
             Aim to have all {formatSeconds(SHIV_DURATION)} seconds of the Shiv debuff line up with
             the {formatSeconds(SEPSIS_DEBUFF_DURATION)}s Sepsis DoT.

--- a/src/analysis/retail/rogue/assassination/normalizers/BlindsideEventOrderNormalizer.ts
+++ b/src/analysis/retail/rogue/assassination/normalizers/BlindsideEventOrderNormalizer.ts
@@ -1,0 +1,29 @@
+import EventOrderNormalizer, { EventOrder } from 'parser/core/EventOrderNormalizer';
+import { Options } from 'parser/core/Analyzer';
+import { EventType } from 'parser/core/Events';
+import SPELLS from 'common/SPELLS/rogue';
+
+const EVENT_ORDERS: EventOrder[] = [
+  {
+    beforeEventId: SPELLS.MUTILATE_OFFHAND.id,
+    beforeEventType: EventType.Cast,
+    afterEventId: SPELLS.MUTILATE.id,
+    afterEventType: EventType.Cast,
+    bufferMs: 50,
+  },
+  {
+    beforeEventId: SPELLS.MUTILATE.id,
+    beforeEventType: EventType.Cast,
+    afterEventId: SPELLS.BLINDSIDE_BUFF.id,
+    afterEventType: EventType.ApplyBuff,
+    bufferMs: 50,
+    anyTarget: true,
+    updateTimestamp: true,
+  },
+];
+
+export default class BlindsideEventOrderNormalizer extends EventOrderNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_ORDERS);
+  }
+}

--- a/src/analysis/retail/rogue/assassination/normalizers/KingsbaneLinkNormalizer.ts
+++ b/src/analysis/retail/rogue/assassination/normalizers/KingsbaneLinkNormalizer.ts
@@ -1,0 +1,130 @@
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import { Options } from 'parser/core/Module';
+import TALENTS from 'common/TALENTS/rogue';
+import {
+  ApplyDebuffEvent,
+  CastEvent,
+  EventType,
+  GetRelatedEvents,
+  RemoveDebuffEvent,
+} from 'parser/core/Events';
+import SPELLS from 'common/SPELLS/rogue';
+
+export const SHIV_KINGSBANE_BUFFER_MS = 2000;
+const SHIV_KINGSBANE = 'ShivKingsbane';
+
+const DEATHMARK_KINGSBANE_APPLY_BUFFER_MS = 2000;
+const DEATHMARK_KINGSBANE_APPLY = 'DeathmarkKingsbaneApply';
+
+const DEATHMARK_KINGSBANE_REMOVE_BUFFER_MS = 2000;
+const DEATHMARK_KINGSBANE_REMOVE = 'DeathmarkKingsbaneRemove';
+
+const DEATHMARK_KINGSBANE_CAST_BUFFER_MS = 2000;
+const DEATHMARK_KINGSBANE_CAST = 'DeathmarkKingsbaneCast';
+
+const SHADOW_DANCE_KINGSBANE_CAST_BUFFER_MS = 1250;
+const SHADOW_DANCE_DANCE_KINGSBANE_CAST = 'ShadowDanceKingsbaneCast';
+
+const EVENT_LINKS: EventLink[] = [
+  // Link a Shiv and Kingsbane cast
+  {
+    linkingEventType: EventType.Cast,
+    linkingEventId: SPELLS.SHIV.id,
+    linkRelation: SHIV_KINGSBANE,
+    reverseLinkRelation: SHIV_KINGSBANE,
+    referencedEventType: EventType.Cast,
+    referencedEventId: TALENTS.KINGSBANE_TALENT.id,
+    forwardBufferMs: SHIV_KINGSBANE_BUFFER_MS,
+    backwardBufferMs: SHIV_KINGSBANE_BUFFER_MS,
+    anyTarget: true,
+    maximumLinks: (c) => 1 + c.getTalentRank(TALENTS.LIGHTWEIGHT_SHIV_TALENT),
+  },
+
+  // Link Deathmark and Kingsbane
+  {
+    linkingEventType: EventType.Cast,
+    linkingEventId: TALENTS.DEATHMARK_TALENT.id,
+    linkRelation: DEATHMARK_KINGSBANE_CAST,
+    reverseLinkRelation: DEATHMARK_KINGSBANE_CAST,
+    referencedEventType: EventType.Cast,
+    referencedEventId: TALENTS.KINGSBANE_TALENT.id,
+    forwardBufferMs: DEATHMARK_KINGSBANE_CAST_BUFFER_MS,
+    backwardBufferMs: DEATHMARK_KINGSBANE_CAST_BUFFER_MS,
+    anyTarget: true,
+    maximumLinks: 1,
+    isActive: (c) => c.hasTalent(TALENTS.DEATHMARK_TALENT),
+  },
+  {
+    linkingEventType: EventType.ApplyDebuff,
+    linkingEventId: TALENTS.DEATHMARK_TALENT.id,
+    linkRelation: DEATHMARK_KINGSBANE_APPLY,
+    reverseLinkRelation: DEATHMARK_KINGSBANE_APPLY,
+    referencedEventType: EventType.ApplyDebuff,
+    referencedEventId: TALENTS.KINGSBANE_TALENT.id,
+    forwardBufferMs: DEATHMARK_KINGSBANE_APPLY_BUFFER_MS,
+    backwardBufferMs: DEATHMARK_KINGSBANE_APPLY_BUFFER_MS,
+    anyTarget: true,
+    maximumLinks: 1,
+    isActive: (c) => c.hasTalent(TALENTS.DEATHMARK_TALENT),
+  },
+  {
+    linkingEventType: EventType.RemoveDebuff,
+    linkingEventId: TALENTS.DEATHMARK_TALENT.id,
+    linkRelation: DEATHMARK_KINGSBANE_REMOVE,
+    reverseLinkRelation: DEATHMARK_KINGSBANE_REMOVE,
+    referencedEventType: EventType.RemoveDebuff,
+    referencedEventId: TALENTS.KINGSBANE_TALENT.id,
+    forwardBufferMs: DEATHMARK_KINGSBANE_REMOVE_BUFFER_MS,
+    backwardBufferMs: DEATHMARK_KINGSBANE_REMOVE_BUFFER_MS,
+    anyTarget: true,
+    maximumLinks: 1,
+    isActive: (c) => c.hasTalent(TALENTS.DEATHMARK_TALENT),
+  },
+
+  // Link Shadow Dance and Kingsbane
+  {
+    linkingEventType: EventType.Cast,
+    linkingEventId: TALENTS.SHADOW_DANCE_TALENT.id,
+    linkRelation: SHADOW_DANCE_DANCE_KINGSBANE_CAST,
+    reverseLinkRelation: SHADOW_DANCE_DANCE_KINGSBANE_CAST,
+    referencedEventType: EventType.Cast,
+    referencedEventId: TALENTS.KINGSBANE_TALENT.id,
+    forwardBufferMs: SHADOW_DANCE_KINGSBANE_CAST_BUFFER_MS,
+    backwardBufferMs: SHADOW_DANCE_KINGSBANE_CAST_BUFFER_MS,
+    anyTarget: true,
+    maximumLinks: 1,
+    isActive: (c) => c.hasTalent(TALENTS.SHADOW_DANCE_TALENT),
+  },
+];
+
+export default class KingsbaneLinkNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_LINKS);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.KINGSBANE_TALENT);
+  }
+}
+
+export const getMatchingShivOrKingsbaneCast = (event: CastEvent) =>
+  GetRelatedEvents(event, SHIV_KINGSBANE)
+    .filter((e): e is CastEvent => e.type === EventType.Cast)
+    .at(0);
+
+export const getMatchingDeathmarkOrKingsbaneCast = (event: CastEvent) =>
+  GetRelatedEvents(event, DEATHMARK_KINGSBANE_CAST)
+    .filter((e): e is CastEvent => e.type === EventType.Cast)
+    .at(0);
+
+export const getMatchingDeathmarkOrKingsbaneApplyDebuff = (event: ApplyDebuffEvent) =>
+  GetRelatedEvents(event, DEATHMARK_KINGSBANE_APPLY)
+    .filter((e): e is ApplyDebuffEvent => e.type === EventType.ApplyDebuff)
+    .at(0);
+
+export const getMatchingDeathmarkOrKingsbaneRemoveDebuff = (event: ApplyDebuffEvent) =>
+  GetRelatedEvents(event, DEATHMARK_KINGSBANE_REMOVE)
+    .filter((e): e is RemoveDebuffEvent => e.type === EventType.RemoveDebuff)
+    .at(0);
+
+export const getMatchingShadowDanceOrKingsbaneCast = (event: CastEvent) =>
+  GetRelatedEvents(event, SHADOW_DANCE_DANCE_KINGSBANE_CAST)
+    .filter((e): e is CastEvent => e.type === EventType.Cast)
+    .at(0);

--- a/src/analysis/retail/rogue/shared/styled-components.ts
+++ b/src/analysis/retail/rogue/shared/styled-components.ts
@@ -1,0 +1,10 @@
+import styled from '@emotion/styled';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+
+export const RoundedPanelWithBottomMargin = styled(RoundedPanel)`
+  margin-bottom: 20px;
+`;
+
+export const ExplanationSection = styled.section`
+  margin-bottom: 20px;
+`;

--- a/src/parser/core/SpellUsage/SpellUsageSubSection.tsx
+++ b/src/parser/core/SpellUsage/SpellUsageSubSection.tsx
@@ -18,6 +18,7 @@ import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { formatDuration } from 'common/format';
 import { Highlight } from 'interface/Highlight';
+import AlertWarning from 'interface/AlertWarning';
 
 const NoData = styled.div`
   color: #999;
@@ -160,18 +161,24 @@ const CastPerformanceDefaultCastBreakdownSmallText = () => (
   </>
 );
 
-const NoCastsDisplay = () => {
+const NoCastsDisplay = ({
+  hideGoodCastsOverride,
+  noCastsOverride,
+}: {
+  hideGoodCastsOverride?: ReactNode;
+  noCastsOverride?: ReactNode;
+}) => {
   const { hideGoodCasts } = useSpellUsageContext();
   if (hideGoodCasts) {
     return (
       <SpellDetailsContainer>
-        <NoData>All of your casts of this spell were good!</NoData>
+        <NoData>{hideGoodCastsOverride ?? 'All of your casts of this spell were good!'}</NoData>
       </SpellDetailsContainer>
     );
   }
   return (
     <SpellDetailsContainer>
-      <NoData>You did not cast this spell at all.</NoData>
+      <NoData>{noCastsOverride ?? 'You did not cast this spell at all.'}</NoData>
     </SpellDetailsContainer>
   );
 };
@@ -185,6 +192,8 @@ type SpellUsageSubSectionProps = Omit<ComponentPropsWithoutRef<typeof SubSection
   uses: SpellUse[];
   onPerformanceBoxClick?: (use: SpellUse | undefined) => void;
   spellUseToPerformance?: (use: SpellUse) => BoxRowEntry;
+  noCastsTexts?: ComponentPropsWithoutRef<typeof NoCastsDisplay>;
+  warning?: ComponentPropsWithoutRef<typeof AlertWarning>;
 };
 
 /**
@@ -201,6 +210,8 @@ const SpellUsageSubSection = ({
   uses,
   onPerformanceBoxClick,
   spellUseToPerformance,
+  noCastsTexts,
+  warning,
   ...others
 }: SpellUsageSubSectionProps) => {
   const [selectedUse, setSelectedUse] = useState<number | undefined>();
@@ -234,6 +245,7 @@ const SpellUsageSubSection = ({
 
   return (
     <SubSection style={{ paddingBottom: 20 }} {...others}>
+      {warning ? <AlertWarning {...warning} /> : null}
       <ExplanationRow>
         <Explanation>{explanation}</Explanation>
         <SpellUsageDetailsContainer>
@@ -255,7 +267,7 @@ const SpellUsageSubSection = ({
             onClickBox={onClickBox}
           />
           {uses.length === 0 ? (
-            <NoCastsDisplay />
+            <NoCastsDisplay {...noCastsTexts} />
           ) : (
             <SpellUseDetails
               spellUse={


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Add experimental Kingsbane analysis behind an opt-in toggle.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/AaPbkVRGQ3KFLjHZ/68-Mythic+Larodar,+Keeper+of+the+Flame+-+Kill+(6:20)/Whíspyr/standard/overview`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/055bb9a0-8073-40f2-ada8-066a6b64f8f6)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/10df8a61-06bb-446a-850f-fb4315da098b)
