### PR TITLE
detect if 0 targets were hit by Fel Devastation

### DIFF
--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -9,7 +9,8 @@ import { DEMON_HUNTER_T31_ID } from 'common/ITEMS/dragonflight';
 
 // prettier-ignore
 export default [
-  change(date(2023, 12, 10), <>Add CDR calculations for <ItemSetLink id={DEMON_HUNTER_T31_ID} />.</>, ToppleTheNun),
+  change(date(2023, 12, 14), <>Detect if no targets were hit by <SpellLink spell={TALENTS.FEL_DEVASTATION_TALENT} />.</>, ToppleTheNun),
+  change(date(2023, 12, 10), <>Add CDR calculations for <ItemSetLink id={DEMON_HUNTER_T31_ID}>Screaming Torchfiend&apos;s Brutality.</ItemSetLink>.</>, ToppleTheNun),
   change(date(2023, 11, 19), <>Revise <SpellLink spell={TALENTS.SPIRIT_BOMB_TALENT} /> guidance in single target and fix bug with <SpellLink spell={SPELLS.SOUL_FRAGMENT_STACK} /> consumption.</>, ToppleTheNun),
   change(date(2023, 11, 15), <>Fix <SpellLink spell={TALENTS.FEL_DEVASTATION_TALENT} /> cooldown.</>, ToppleTheNun),
   change(date(2023, 10, 24), <>Make <SpellLink spell={SPELLS.SOUL_FRAGMENT} /> not count as a cast.</>, ToppleTheNun),

--- a/src/analysis/retail/demonhunter/vengeance/modules/talents/FelDevastation.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/talents/FelDevastation.tsx
@@ -1,5 +1,5 @@
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import { TALENTS_DEMON_HUNTER } from 'common/TALENTS/demonhunter';
+import TALENTS from 'common/TALENTS/demonhunter';
 import { SpellLink } from 'interface';
 import SPELLS from 'common/SPELLS/demonhunter';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
@@ -10,7 +10,11 @@ import VulnerabilityExplanation from 'analysis/retail/demonhunter/vengeance/modu
 import FieryDemiseExplanation from 'analysis/retail/demonhunter/vengeance/modules/core/FieryDemiseExplanation';
 import DemonicExplanation from 'analysis/retail/demonhunter/vengeance/modules/core/DemonicExplanation';
 import { ChecklistUsageInfo, SpellUse, UsageInfo } from 'parser/core/SpellUsage/core';
-import MajorCooldown, { CooldownTrigger } from 'parser/core/MajorCooldowns/MajorCooldown';
+import MajorCooldown, {
+  CooldownTrigger,
+  createChecklistItem,
+  createSpellUse,
+} from 'parser/core/MajorCooldowns/MajorCooldown';
 import { getDamageEvents } from 'analysis/retail/demonhunter/vengeance/normalizers/FelDevastationNormalizer';
 import { isDefined } from 'common/typeGuards';
 
@@ -36,10 +40,10 @@ export default class FelDevastation extends MajorCooldown<FelDevastationCooldown
   protected enemies!: Enemies;
 
   constructor(options: Options) {
-    super({ spell: TALENTS_DEMON_HUNTER.FEL_DEVASTATION_TALENT }, options);
-    this.active = this.selectedCombatant.hasTalent(TALENTS_DEMON_HUNTER.FEL_DEVASTATION_TALENT);
+    super({ spell: TALENTS.FEL_DEVASTATION_TALENT }, options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.FEL_DEVASTATION_TALENT);
     this.addEventListener(
-      Events.cast.by(SELECTED_PLAYER).spell(TALENTS_DEMON_HUNTER.FEL_DEVASTATION_TALENT),
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.FEL_DEVASTATION_TALENT),
       this.onCast,
     );
   }
@@ -49,7 +53,7 @@ export default class FelDevastation extends MajorCooldown<FelDevastationCooldown
       <>
         <section style={{ marginBottom: 20 }}>
           <strong>
-            <SpellLink spell={TALENTS_DEMON_HUNTER.FEL_DEVASTATION_TALENT} />
+            <SpellLink spell={TALENTS.FEL_DEVASTATION_TALENT} />
           </strong>{' '}
           is a large burst of damage and healing.
         </section>
@@ -63,6 +67,21 @@ export default class FelDevastation extends MajorCooldown<FelDevastationCooldown
   }
 
   explainPerformance(cast: FelDevastationCooldownCast): SpellUse {
+    if (cast.damage.length === 0) {
+      return createSpellUse(cast, [
+        createChecklistItem('hit-targets', cast, {
+          performance: QualitativePerformance.Fail,
+          summary: <div>Hit 1+ target</div>,
+          details: (
+            <div>
+              You hit 0 targets with your <SpellLink spell={TALENTS.FEL_DEVASTATION_TALENT} />. To
+              maximize damage, always try to hit targets with it.
+            </div>
+          ),
+        }),
+      ]);
+    }
+
     const {
       performance: frailtyPerf,
       summary: frailtyLabel,
@@ -139,7 +158,7 @@ export default class FelDevastation extends MajorCooldown<FelDevastationCooldown
   }
 
   private fieryDemisePerformance(cast: FelDevastationCooldownCast): UsageInfo | undefined {
-    if (!this.selectedCombatant.hasTalent(TALENTS_DEMON_HUNTER.FIERY_DEMISE_TALENT)) {
+    if (!this.selectedCombatant.hasTalent(TALENTS.FIERY_DEMISE_TALENT)) {
       return undefined;
     }
     if (!cast.damage.some((it) => it.hasFieryBrandDebuff)) {
@@ -147,15 +166,15 @@ export default class FelDevastation extends MajorCooldown<FelDevastationCooldown
         performance: QualitativePerformance.Fail,
         summary: (
           <div>
-            <SpellLink spell={TALENTS_DEMON_HUNTER.FIERY_BRAND_TALENT} /> not applied to target
+            <SpellLink spell={TALENTS.FIERY_BRAND_TALENT} /> not applied to target
           </div>
         ),
         details: (
           <div>
-            <SpellLink spell={TALENTS_DEMON_HUNTER.FIERY_BRAND_TALENT} /> not applied to target.
-            Make sure to apply <SpellLink spell={TALENTS_DEMON_HUNTER.FIERY_BRAND_TALENT} /> before
-            casting <SpellLink spell={TALENTS_DEMON_HUNTER.SOUL_CARVER_TALENT} /> so that you
-            benefit from <SpellLink spell={TALENTS_DEMON_HUNTER.FIERY_DEMISE_TALENT} />.
+            <SpellLink spell={TALENTS.FIERY_BRAND_TALENT} /> not applied to target. Make sure to
+            apply <SpellLink spell={TALENTS.FIERY_BRAND_TALENT} /> before casting{' '}
+            <SpellLink spell={TALENTS.FEL_DEVASTATION_TALENT} /> so that you benefit from{' '}
+            <SpellLink spell={TALENTS.FIERY_DEMISE_TALENT} />.
           </div>
         ),
       };
@@ -164,22 +183,22 @@ export default class FelDevastation extends MajorCooldown<FelDevastationCooldown
       performance: QualitativePerformance.Perfect,
       summary: (
         <div>
-          <SpellLink spell={TALENTS_DEMON_HUNTER.FIERY_BRAND_TALENT} /> applied to target
+          <SpellLink spell={TALENTS.FIERY_BRAND_TALENT} /> applied to target
         </div>
       ),
       details: (
         <div>
-          <SpellLink spell={TALENTS_DEMON_HUNTER.FIERY_BRAND_TALENT} /> applied to target.
+          <SpellLink spell={TALENTS.FIERY_BRAND_TALENT} /> applied to target.
         </div>
       ),
     };
   }
 
   private frailtyPerformance(cast: FelDevastationCooldownCast): UsageInfo | undefined {
-    if (!this.selectedCombatant.hasTalent(TALENTS_DEMON_HUNTER.VULNERABILITY_TALENT)) {
+    if (!this.selectedCombatant.hasTalent(TALENTS.VULNERABILITY_TALENT)) {
       return undefined;
     }
-    if (!this.selectedCombatant.hasTalent(TALENTS_DEMON_HUNTER.SOULCRUSH_TALENT)) {
+    if (!this.selectedCombatant.hasTalent(TALENTS.SOULCRUSH_TALENT)) {
       const atLeastOneTargetHasFrailty = cast.damage.some((it) => it.targetStacksOfFrailty > 0);
       if (atLeastOneTargetHasFrailty) {
         return {
@@ -207,7 +226,7 @@ export default class FelDevastation extends MajorCooldown<FelDevastationCooldown
           <div>
             <SpellLink spell={SPELLS.FRAILTY} /> not applied to target(s). Make sure to apply{' '}
             <SpellLink spell={SPELLS.FRAILTY} /> before casting{' '}
-            <SpellLink spell={TALENTS_DEMON_HUNTER.SOUL_CARVER_TALENT} />.
+            <SpellLink spell={TALENTS.SOUL_CARVER_TALENT} />.
           </div>
         ),
       };
@@ -222,7 +241,7 @@ export default class FelDevastation extends MajorCooldown<FelDevastationCooldown
     const atLeastOneTargetHasOkFrailty = cast.damage.find(
       (it) => it.targetStacksOfFrailty >= OK_FRAILTY_STACKS,
     );
-    const mostStacksOfFrailty = Math.max(...cast.damage.map((it) => it.targetStacksOfFrailty));
+    const mostStacksOfFrailty = Math.max(...cast.damage.map((it) => it.targetStacksOfFrailty), 0);
 
     if (atLeastOneTargetHasPerfectFrailty) {
       return {
@@ -255,7 +274,7 @@ export default class FelDevastation extends MajorCooldown<FelDevastationCooldown
             Only {atLeastOneTargetHasGoodFrailty.targetStacksOfFrailty} stack(s) of{' '}
             <SpellLink spell={SPELLS.FRAILTY} /> applied to 1+ target(s). Try applying at least{' '}
             {PERFECT_FRAILTY_STACKS} stack(s) of <SpellLink spell={SPELLS.FRAILTY} /> before casting{' '}
-            <SpellLink spell={TALENTS_DEMON_HUNTER.SOUL_CARVER_TALENT} />.
+            <SpellLink spell={TALENTS.SOUL_CARVER_TALENT} />.
           </div>
         ),
       };
@@ -274,7 +293,7 @@ export default class FelDevastation extends MajorCooldown<FelDevastationCooldown
             Only {atLeastOneTargetHasOkFrailty.targetStacksOfFrailty} stack(s) of{' '}
             <SpellLink spell={SPELLS.FRAILTY} /> applied to 1+ target(s). Try applying at least{' '}
             {PERFECT_FRAILTY_STACKS} stack(s) of <SpellLink spell={SPELLS.FRAILTY} /> before casting{' '}
-            <SpellLink spell={TALENTS_DEMON_HUNTER.FEL_DEVASTATION_TALENT} />.
+            <SpellLink spell={TALENTS.FEL_DEVASTATION_TALENT} />.
           </div>
         ),
       };
@@ -291,7 +310,7 @@ export default class FelDevastation extends MajorCooldown<FelDevastationCooldown
           Only {mostStacksOfFrailty} stack(s) of <SpellLink spell={SPELLS.FRAILTY} /> applied to
           target. Try applying at least {PERFECT_FRAILTY_STACKS} stack(s) of{' '}
           <SpellLink spell={SPELLS.FRAILTY} /> before casting{' '}
-          <SpellLink spell={TALENTS_DEMON_HUNTER.FEL_DEVASTATION_TALENT} />.
+          <SpellLink spell={TALENTS.FEL_DEVASTATION_TALENT} />.
         </div>
       ),
     };

--- a/src/parser/core/SpellUsage/SpellUsageSubSection.tsx
+++ b/src/parser/core/SpellUsage/SpellUsageSubSection.tsx
@@ -225,10 +225,10 @@ const SpellUsageSubSection = ({
         onPerformanceBoxClick?.(undefined);
       } else {
         setSelectedUse(index);
-        onPerformanceBoxClick?.(index);
+        onPerformanceBoxClick?.(uses.at(index));
       }
     },
-    [onPerformanceBoxClick, performances.length],
+    [onPerformanceBoxClick, performances.length, uses],
   );
 
   // hideGoodCasts is in the dependency list because we want this to run whenever


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Previously, you could get the below issue if you didn't hit anything with your Fel Devastation.
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/d20c37a3-68c0-41a5-b5c4-47959ee4167c)

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/pDkHMLNBYaWT2XZ1/19-Mythic+Igira+the+Cruel+-+Kill+(6:45)/Femboyfatale/standard`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/7052200a-8f91-45d0-adb7-f6800458f8f9)
