### PR TITLE
Bugfix/disc 10.2 cleanup

### DIFF
--- a/src/analysis/retail/priest/discipline/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/discipline/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 12, 17), <>Updated <SpellLink spell={TALENTS_PRIEST.HARSH_DISCIPLINE_TALENT}/>. No longer shows mana, and damage is now displayed. </>, Hana),
   change(date(2023, 12, 11), <>Fixed <SpellLink spell={TALENTS_PRIEST.SCHISM_TALENT}/>.</>, Hana),
   change(date(2023, 11, 23), <><SpellLink spell={SPELLS.DARK_REPRIMAND_CAST}/> and <SpellLink spell={TALENTS_PRIEST.ULTIMATE_PENITENCE_TALENT}/> should now properly show as casting time in the timeline.</>, Sref),
   change(date(2023, 11, 14), <>Add tracker for <SpellLink spell={TALENTS_PRIEST.TRAIN_OF_THOUGHT_TALENT} /> CDR.</>, Arlie),

--- a/src/analysis/retail/priest/discipline/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/discipline/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 12, 17), <>Re enabled <SpellLink spell={TALENTS_PRIEST.TRANSLUCENT_IMAGE_TALENT}/>.</>, Hana),
   change(date(2023, 12, 17), <>Updated <SpellLink spell={TALENTS_PRIEST.HARSH_DISCIPLINE_TALENT}/>. No longer shows mana, and damage is now displayed. </>, Hana),
   change(date(2023, 12, 11), <>Fixed <SpellLink spell={TALENTS_PRIEST.SCHISM_TALENT}/>.</>, Hana),
   change(date(2023, 11, 23), <><SpellLink spell={SPELLS.DARK_REPRIMAND_CAST}/> and <SpellLink spell={TALENTS_PRIEST.ULTIMATE_PENITENCE_TALENT}/> should now properly show as casting time in the timeline.</>, Sref),

--- a/src/analysis/retail/priest/discipline/CONFIG.tsx
+++ b/src/analysis/retail/priest/discipline/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Hana],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.1.7',
+  patchCompatibility: '10.2.0',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/priest/discipline/CombatLogParser.ts
+++ b/src/analysis/retail/priest/discipline/CombatLogParser.ts
@@ -1,6 +1,7 @@
 import {
   DesperatePrayer,
   ShadowfiendNormalizer,
+  TranslucentImage,
   TwinsOfTheSunPriestess,
   TwistOfFate,
 } from 'analysis/retail/priest/shared';
@@ -149,6 +150,7 @@ class CombatLogParser extends CoreCombatLogParser {
     amirdrassil4p: Amirdrassil4p,
     trainOfThought: TrainOfThought,
     voidSummoner: VoidSummoner,
+    translucentImage: TranslucentImage,
 
     // Items:
     radiantProvidence: RadiantProvidence,

--- a/src/analysis/retail/priest/discipline/modules/spells/HarshDiscipline.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/HarshDiscipline.tsx
@@ -1,9 +1,8 @@
 import { formatThousands } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_PRIEST } from 'common/TALENTS';
-import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { HealEvent } from 'parser/core/Events';
+import Events, { DamageEvent, HealEvent } from 'parser/core/Events';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -11,9 +10,13 @@ import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import { PenanceDamageEvent } from './Helper';
 import { getDamageEvent } from '../../normalizers/AtonementTracker';
 import TalentSpellText from 'parser/ui/TalentSpellText';
-import ItemManaGained from 'parser/ui/ItemManaGained';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
 
 interface DirtyHealEvent extends HealEvent {
+  penanceBoltNumber?: number;
+}
+
+interface DirtyDamageEvent extends DamageEvent {
   penanceBoltNumber?: number;
 }
 
@@ -21,7 +24,7 @@ class HarshDiscipline extends Analyzer {
   private expectedBolts = 3;
   private harshAtonement = 0;
   private harshDirect = 0;
-  private harshPenances = 0;
+  private damage = 0;
 
   constructor(options: Options) {
     super(options);
@@ -44,16 +47,7 @@ class HarshDiscipline extends Analyzer {
       Events.heal.by(SELECTED_PLAYER).spell([SPELLS.PENANCE_HEAL, SPELLS.DARK_REPRIMAND_HEAL]),
       this.onHeal,
     );
-    this.addEventListener(
-      Events.cast.by(SELECTED_PLAYER).spell([SPELLS.PENANCE_CAST, SPELLS.DARK_REPRIMAND_CAST]),
-      this.checkHarsh,
-    );
-  }
-
-  checkHarsh() {
-    if (this.selectedCombatant.hasBuff(SPELLS.HARSH_DISCIPLINE_BUFF.id)) {
-      this.harshPenances += 1;
-    }
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDamage);
   }
 
   onAtoneHeal(event: HealEvent) {
@@ -75,6 +69,18 @@ class HarshDiscipline extends Analyzer {
     this.harshAtonement += event.amount;
   }
 
+  onDamage(event: DamageEvent) {
+    const { penanceBoltNumber } = event as DirtyDamageEvent;
+    if (typeof penanceBoltNumber !== 'number') {
+      return;
+    }
+    if (penanceBoltNumber < this.expectedBolts) {
+      return;
+    }
+
+    this.damage += event.amount;
+  }
+
   onHeal(event: HealEvent) {
     const { penanceBoltNumber } = event as DirtyHealEvent;
     if (typeof penanceBoltNumber !== 'number') {
@@ -88,7 +94,6 @@ class HarshDiscipline extends Analyzer {
   }
 
   statistic() {
-    const manaSaved = this.harshPenances * SPELLS.PENANCE.manaCost;
     return (
       <Statistic
         position={STATISTIC_ORDER.CORE(3)}
@@ -96,23 +101,17 @@ class HarshDiscipline extends Analyzer {
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={
           <>
-            <span>
-              Penance consumed <SpellLink spell={TALENTS_PRIEST.HARSH_DISCIPLINE_TALENT} />{' '}
-              {this.harshPenances} times.{' '}
-            </span>
             <br />
             <strong>Atonement healing:</strong> {formatThousands(this.harshAtonement)}
             <br />
             <strong>Direct healing:</strong> {formatThousands(this.harshDirect)}
-            <br />
-            <strong>Mana saved:</strong> {formatThousands(manaSaved)}
           </>
         }
       >
         <>
           <TalentSpellText talent={TALENTS_PRIEST.HARSH_DISCIPLINE_TALENT}>
             <ItemHealingDone amount={this.harshAtonement + this.harshDirect} /> <br />
-            <ItemManaGained amount={manaSaved} useAbbrev />
+            <ItemDamageDone amount={this.damage} />
           </TalentSpellText>
         </>
       </Statistic>


### PR DESCRIPTION
### Description

Harsh discipline updated to no longer show mana as it doesn't cause penance to be free anymore. Also added a damage statistic for it.

Translucent image was not enabled for disc, so I've added it to the combat log parser for disc.

Updated disc as ready for 10.2