### PR TITLE
mark 10.1.5 as an old patch

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -32,6 +32,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 12, 20), 'Mark 10.1.5 as an old patch.', ToppleTheNun),
   change(date(2023, 12, 20), 'Bring over a few of the changes from the vite migration branch.', ToppleTheNun),
   change(date(2023, 12, 5), 'Update Classic Mana Values to activate based on config role.', jazminite),
   change(date(2023, 12, 3),'Convert GlobalCooldown to TS', Seriousnes),

--- a/src/interface/report/PATCHES.ts
+++ b/src/interface/report/PATCHES.ts
@@ -141,7 +141,7 @@ const PATCHES: Patch[] = [
     name: '10.1.5',
     timestamp: 1689112800000, // GMT: Tuesday, 11 July 2023 22:00:00
     urlPrefix: '',
-    isCurrent: true, // TODO: mark as false on 11/8/2023
+    isCurrent: false,
     gameVersion: 1, // retail
     expansion: Expansion.Dragonflight,
   },


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Forgor to make 10.1.5 not current on 11/8/23.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/RFwbnM4JcfvjNtmg/40-Mythic+Rashok,+the+Elder+-+Kill+(6:25)/Paoanii/standard/overview`
