### PR TITLE
Fix ToM apl and mark rem/envm as both acceptable for ToM TFT

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 12, 20), <>Update APL to mark ToM as unsupported and update <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT}/> for ToM</>, Trevor),
   change(date(2023, 12, 5), <>Fix <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> coefficient</>, Trevor),
   change(date(2023, 12, 5), <>Changes for Dec 5 tuning</>, Trevor),
   change(date(2023, 11, 27), <>Update <SpellLink spell={SPELLS.VIVIFY}/> thresholds for <SpellLink spell={TALENTS_MONK.TEAR_OF_MORNING_TALENT}/></>, Trevor),

--- a/src/analysis/retail/monk/mistweaver/modules/core/apl/AplCheck.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/apl/AplCheck.tsx
@@ -4,7 +4,7 @@ import aplCheck, { Apl, build, CheckResult, PlayerInfo, tenseAlt } from 'parser/
 import annotateTimeline from 'parser/shared/metrics/apl/annotate';
 import * as cnd from 'parser/shared/metrics/apl/conditions';
 import * as mwCnd from './conditions';
-import talents from 'common/TALENTS/monk';
+import talents, { TALENTS_MONK } from 'common/TALENTS/monk';
 import { AnyEvent } from 'parser/core/Events';
 import { SpellLink } from 'interface';
 
@@ -86,11 +86,15 @@ const commonTop = [
       cnd.and(
         cnd.spellCharges(talents.RENEWING_MIST_TALENT, { atLeast: 2 }),
         cnd.spellAvailable(talents.RENEWING_MIST_TALENT),
+        cnd.hasTalent(talents.RISING_MIST_TALENT),
       ),
       (tense) => <>you {tenseAlt(tense, 'have', 'had')} 2 charges</>,
     ),
   },
-  talents.RISING_SUN_KICK_TALENT,
+  {
+    spell: talents.RISING_SUN_KICK_TALENT,
+    condition: cnd.hasTalent(TALENTS_MONK.RISING_MIST_TALENT),
+  },
   {
     spell: talents.RENEWING_MIST_TALENT,
     condition: cnd.optionalRule(cnd.spellAvailable(talents.RENEWING_MIST_TALENT)),
@@ -200,6 +204,7 @@ export enum MistweaverApl {
   RisingMistAncientTeachingsUpwellFls,
   RisingMistCloudedFocusShaohaos,
   AwakenedFaeline,
+  TearOfMorning,
   Fallback,
 }
 
@@ -230,6 +235,8 @@ export const chooseApl = (info: PlayerInfo): MistweaverApl => {
     info.combatant.hasTalent(talents.ANCIENT_TEACHINGS_TALENT)
   ) {
     return MistweaverApl.AwakenedFaeline;
+  } else if (info.combatant.hasTalent(TALENTS_MONK.TEAR_OF_MORNING_TALENT)) {
+    return MistweaverApl.TearOfMorning;
   }
   return MistweaverApl.Fallback;
 };
@@ -239,6 +246,7 @@ const apls: Record<MistweaverApl, Apl> = {
   [MistweaverApl.RisingMistAncientTeachingsUpwellFls]: rotation_rm_at_upw,
   [MistweaverApl.RisingMistCloudedFocusShaohaos]: rotation_rm_cf_shaohaos,
   [MistweaverApl.AwakenedFaeline]: rotation_fallback,
+  [MistweaverApl.TearOfMorning]: rotation_fallback,
   [MistweaverApl.Fallback]: rotation_fallback,
 };
 

--- a/src/analysis/retail/monk/mistweaver/modules/core/apl/AplChoiceDescription.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/apl/AplChoiceDescription.tsx
@@ -1,6 +1,6 @@
 import SPELLS from 'common/SPELLS';
 import talents from 'common/TALENTS/monk';
-import { AlertWarning, SpellLink } from 'interface';
+import { SpellLink } from 'interface';
 import { useInfo } from 'interface/guide';
 import { MistweaverApl } from './AplCheck';
 
@@ -34,6 +34,12 @@ const aplTitle = (choice: MistweaverApl) => {
       return (
         <>
           <SpellLink spell={talents.AWAKENED_FAELINE_TALENT} />
+        </>
+      );
+    case MistweaverApl.TearOfMorning:
+      return (
+        <>
+          <SpellLink spell={talents.TEAR_OF_MORNING_TALENT} />
         </>
       );
     default:
@@ -176,8 +182,20 @@ const CleaveBuildNotYetSupportedDescription = () => {
   );
 };
 
+const TomDescription = () => {
+  return (
+    <>
+      <p>
+        <strong>
+          The <SpellLink spell={talents.TEAR_OF_MORNING_TALENT} /> rotation is not currently
+          supported.
+        </strong>
+      </p>
+    </>
+  );
+};
+
 const FallbackDescription = () => {
-  const info = useInfo();
   return (
     <>
       <p>
@@ -187,13 +205,6 @@ const FallbackDescription = () => {
         the simplest rotation, but practicing it will build good habits that work with the other
         variations.
       </p>
-
-      {!info?.combatant.hasTalent(talents.RISING_MIST_TALENT) && (
-        <AlertWarning>
-          Using <SpellLink spell={talents.RISING_MIST_TALENT} /> is recommended, as it brings the
-          entire spec's toolkit together by creating multiple synergies between talents.
-        </AlertWarning>
-      )}
     </>
   );
 };
@@ -208,6 +219,8 @@ const Description = ({ aplChoice }: { aplChoice: MistweaverApl }) => {
       return <RisingMistCloudedFocusShaohaosDescription />;
     case MistweaverApl.AwakenedFaeline:
       return <CleaveBuildNotYetSupportedDescription />;
+    case MistweaverApl.TearOfMorning:
+      return <TomDescription />;
     default:
       return <FallbackDescription />;
   }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
@@ -77,8 +77,14 @@ class ThunderFocusTea extends Analyzer {
       this.correctCapstoneSpells = [TALENTS_MONK.RENEWING_MIST_TALENT.id];
       this.okCapstoneSpells = [TALENTS_MONK.RISING_SUN_KICK_TALENT.id];
     } else if (this.selectedCombatant.hasTalent(TALENTS_MONK.TEAR_OF_MORNING_TALENT)) {
-      this.correctCapstoneSpells = [TALENTS_MONK.ENVELOPING_MIST_TALENT.id];
-      this.okCapstoneSpells = [TALENTS_MONK.RENEWING_MIST_TALENT.id];
+      this.correctCapstoneSpells = [
+        TALENTS_MONK.ENVELOPING_MIST_TALENT.id,
+        TALENTS_MONK.RENEWING_MIST_TALENT.id,
+      ];
+      this.okCapstoneSpells = [
+        TALENTS_MONK.ENVELOPING_MIST_TALENT.id,
+        TALENTS_MONK.RENEWING_MIST_TALENT.id,
+      ];
     } else {
       this.correctCapstoneSpells = [TALENTS_MONK.RENEWING_MIST_TALENT.id];
     }
@@ -101,7 +107,9 @@ class ThunderFocusTea extends Analyzer {
     } else if (this.selectedCombatant.hasTalent(TALENTS_MONK.UPWELLING_TALENT)) {
       return spellId === TALENTS_MONK.ESSENCE_FONT_TALENT.id;
     } else if (this.selectedCombatant.hasTalent(TALENTS_MONK.SECRET_INFUSION_TALENT)) {
-      return spellId === TALENTS_MONK.RENEWING_MIST_TALENT.id;
+      return isOk && this.selectedCombatant.hasTalent(TALENTS_MONK.TEAR_OF_MORNING_TALENT)
+        ? spellId === TALENTS_MONK.ENVELOPING_MIST_TALENT.id
+        : spellId === TALENTS_MONK.RENEWING_MIST_TALENT.id;
     } else {
       return spellMap.includes(spellId);
     }


### PR DESCRIPTION
### Description

This PR adds a APL for ToM that marks it as unsupported and adds a condition to RSK to only recommend it when talented into Rising MIst. It also updates TFT to mark envm as an "ok" cast when buffed by first cast of tft with SI. It also changes TFT module to allow tft with any combination of {REM, ENV} with replacement.
