### PR TITLE
Fix yulon crash when player died

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 
 export default [
+  change(date(2023, 12, 26), <>Fix crash in <SpellLink spell={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT}/> module</>, Trevor),
   change(date(2023, 12, 20), <>Update APL to mark ToM as unsupported and update <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT}/> for ToM</>, Trevor),
   change(date(2023, 12, 5), <>Fix <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> coefficient</>, Trevor),
   change(date(2023, 12, 5), <>Changes for Dec 5 tuning</>, Trevor),

--- a/src/analysis/retail/monk/mistweaver/modules/features/Buffs.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/Buffs.tsx
@@ -32,10 +32,16 @@ class Buffs extends CoreAuras {
       {
         spellId: SPELLS.INVOKE_CHIJI_THE_RED_CRANE_BUFF.id,
         enabled: combatant.hasTalent(TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT),
+        triggeredBySpellId: TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT.id,
+      },
+      {
+        spellId: SPELLS.INVOKE_YULON_BUFF.id,
+        enabled: combatant.hasTalent(TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT),
+        triggeredBySpellId: TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id,
       },
       // Throughput Cooldown
       {
-        spellId: TALENTS_MONK.MANA_TEA_TALENT.id,
+        spellId: SPELLS.MANA_TEA_BUFF.id,
         enabled: combatant.hasTalent(TALENTS_MONK.MANA_TEA_TALENT),
         timelineHighlight: true,
       },

--- a/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
@@ -11,6 +11,7 @@ import Events, {
   HealEvent,
   DamageEvent,
   EndChannelEvent,
+  EventType,
 } from 'parser/core/Events';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { SECRET_INFUSION_BUFFS, LESSONS_BUFFS } from '../../constants';
@@ -175,9 +176,12 @@ class BaseCelestialAnalyzer extends Analyzer {
   }
 
   handleCelestialDeath(event: DeathEvent | RemoveBuffEvent) {
-    const pet = this.pets.getEntityFromEvent(event, true);
-    if (!pet || !pet.name) {
-      return;
+    // only chiji logs death events
+    if (event.type === EventType.Death) {
+      const pet = this.pets.getEntityFromEvent(event, true);
+      if (!pet || !pet.name) {
+        return;
+      }
     }
     (lessonsDebug || siDebug) &&
       console.log('Celestial Death: ', this.owner.formatTimestamp(event.timestamp));

--- a/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
@@ -176,10 +176,7 @@ class BaseCelestialAnalyzer extends Analyzer {
 
   handleCelestialDeath(event: DeathEvent | RemoveBuffEvent) {
     const pet = this.pets.getEntityFromEvent(event, true);
-    if (
-      (!pet || !pet.name) &&
-      this.selectedCombatant.hasTalent(TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT)
-    ) {
+    if (!pet || !pet.name) {
       return;
     }
     (lessonsDebug || siDebug) &&

--- a/src/parser/shared/normalizers/PrePullCooldowns.jsx
+++ b/src/parser/shared/normalizers/PrePullCooldowns.jsx
@@ -47,7 +47,6 @@ class PrePullCooldowns extends EventsNormalizer {
     const buffSpells = [];
     const damageSpells = [];
     const addBuff = (buff, buffId) => {
-      console.log(buff, buffId);
       if (!buff.triggeredBySpellId) {
         // This normalizer is to fabricate prepull cast events that can be detected from buffs (and damage). If a buff isn't triggered by a spell, then there's nothing to fabricate.
         return;

--- a/src/parser/shared/normalizers/PrePullCooldowns.jsx
+++ b/src/parser/shared/normalizers/PrePullCooldowns.jsx
@@ -47,6 +47,7 @@ class PrePullCooldowns extends EventsNormalizer {
     const buffSpells = [];
     const damageSpells = [];
     const addBuff = (buff, buffId) => {
+      console.log(buff, buffId);
       if (!buff.triggeredBySpellId) {
         // This normalizer is to fabricate prepull cast events that can be detected from buffs (and damage). If a buff isn't triggered by a spell, then there's nothing to fabricate.
         return;


### PR DESCRIPTION
Our checks to see if a pet actually died were not sufficient if the player died before they cast yulon in the fight