### PR TITLE
add intermission data to phase configs, fix instance counting

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -32,6 +32,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 12, 28), 'Improve internal handling of phases', emallson),
   change(date(2023, 12, 21), <>Mark <ItemLink id={ITEMS.ENCHANT_WEAPON_DREAMING_DEVOTION_R3.id} /> as a max rank enchant.</>, ToppleTheNun),
   change(date(2023, 12, 20), 'Mark 10.1.5 as an old patch.', ToppleTheNun),
   change(date(2023, 12, 20), 'Bring over a few of the changes from the vite migration branch.', ToppleTheNun),

--- a/src/parser/core/PhaseConfig.ts
+++ b/src/parser/core/PhaseConfig.ts
@@ -61,4 +61,5 @@ export default interface PhaseConfig {
   filter?: PhaseFilter;
   multiple?: boolean;
   instance?: number;
+  intermission?: boolean;
 }

--- a/src/parser/core/Report.ts
+++ b/src/parser/core/Report.ts
@@ -38,6 +38,7 @@ export interface WCLReportPhases {
    * Phase names.
    */
   phases: Record<number, string>;
+  intermissions?: number[];
 }
 
 export interface Report extends WCLReport {


### PR DESCRIPTION
This has a couple of improvements for phase configs based on some discussion in discord:

1. We now use the `intermissions` property of the report phase metadata to mark phases as intermissions.
2. Phase `instance` counter is now incremented per-phase instead of globally, which is less confusing.

Tested on https://wowanalyzer.com/report/b4jYgT3VmXk8AvN1

- Nymue has repeating phases, but neither phase is marked as an intermission by WCL (allows testing multiple repeated phases)
- Igira has repeating phases with an intermission
- Tindral does not have repeating phases because each intermission is labelled separately