### PR TITLE
[Fire Mage] Living Bomb, Meteor, Combustion Active Time

### DIFF
--- a/src/analysis/retail/mage/fire/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/fire/CHANGELOG.tsx
@@ -6,6 +6,9 @@ import { Sharrq, ToppleTheNun } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2023, 12, 31), <><SpellLink spell={TALENTS.COMBUSTION_TALENT} /> Active Time had one job, and it now does it properly. And counts in seconds instead of milliseconds.</>, Sharrq),
+  change(date(2023, 12, 31), <>Adjusted <SpellLink spell={TALENTS.LIVING_BOMB_TALENT} /> to be acceptable to cast in AOE at 5+ targets.</>, Sharrq),
+  change(date(2023, 12, 31), <>Fixed the wording on <SpellLink spell={TALENTS.METEOR_TALENT} /> to specify that it has to land during <SpellLink spell={TALENTS.COMBUSTION_TALENT} />.</>, Sharrq),
   change(date(2023, 12, 2), <>Fixed an issue that was causing <SpellLink spell={TALENTS.SUN_KINGS_BLESSING_TALENT} /> to not calculate expirations and wasted <SpellLink spell={SPELLS.HOT_STREAK} /> properly.</>, Sharrq),
   change(date(2023, 11, 30), 'Rewrote a number of modules to vastly increase performance in M+ dungeons and prevent crashes from especially long dungeon logs.', Sharrq),
   change(date(2023, 8, 20), <>Added <SpellLink spell={SPELLS.CHARRING_EMBERS_DEBUFF} />, <SpellLink spell={TALENTS.IMPROVED_SCORCH_TALENT} />, and <SpellLink spell={TALENTS.LIVING_BOMB_TALENT} /> to the Checklist.</>, Sharrq),

--- a/src/analysis/retail/mage/fire/SPELLS.ts
+++ b/src/analysis/retail/mage/fire/SPELLS.ts
@@ -103,6 +103,21 @@ const spells = {
     name: 'Improved Scorch',
     icon: 'ability_mage_fierypayback',
   },
+  LIVING_BOMB_TICK_DAMAGE: {
+    id: 217694,
+    name: 'Living Bomb',
+    icon: 'ability_mage_livingbomb',
+  },
+  LIVING_BOMB_EXPLODE_DAMAGE: {
+    id: 244813,
+    name: 'Living Bomb',
+    icon: 'ability_mage_livingbomb',
+  },
+  LIVING_BOMB_EXPLODE_DEBUFF: {
+    id: 244813,
+    name: 'Living Bomb',
+    icon: 'ability_mage_livingbomb',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/analysis/retail/mage/fire/SPELLS.ts
+++ b/src/analysis/retail/mage/fire/SPELLS.ts
@@ -109,7 +109,7 @@ const spells = {
     icon: 'ability_mage_livingbomb',
   },
   LIVING_BOMB_EXPLODE_DAMAGE: {
-    id: 244813,
+    id: 44461,
     name: 'Living Bomb',
     icon: 'ability_mage_livingbomb',
   },

--- a/src/analysis/retail/mage/fire/core/CombustionActiveTime.tsx
+++ b/src/analysis/retail/mage/fire/core/CombustionActiveTime.tsx
@@ -88,7 +88,7 @@ class CombustionActiveTime extends Analyzer {
   }
 
   get downtimeSeconds() {
-    return this.buffUptime - this.combustionActiveTime();
+    return (this.buffUptime - this.combustionActiveTime()) / 1000;
   }
 
   get percentActiveTime() {
@@ -111,8 +111,8 @@ class CombustionActiveTime extends Analyzer {
     when(this.combustionActiveTimeThresholds).addSuggestion((suggest, actual, recommended) =>
       suggest(
         <>
-          You spent {formatNumber(this.downtimeSeconds)} (
-          {formatNumber(this.downtimeSeconds / this.buffApplies)} average per{' '}
+          You spent {formatNumber(this.downtimeSeconds)}s (
+          {formatNumber(this.downtimeSeconds / this.buffApplies)}s average per{' '}
           <SpellLink spell={TALENTS.COMBUSTION_TALENT} />
           ), not casting anything while <SpellLink spell={TALENTS.COMBUSTION_TALENT} /> was active.
           Because a large portion of your damage comes from Combustion, you should ensure that you

--- a/src/analysis/retail/mage/fire/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/mage/fire/normalizers/CastLinkNormalizer.ts
@@ -24,6 +24,7 @@ export const CAST_BEGIN = 'CastBegin';
 export const SPELL_CAST = 'SpellCast';
 export const PRE_CAST = 'PreCast';
 export const SPELL_DAMAGE = 'SpellDamage';
+export const EXPLODE_DEBUFF = 'ExplosionDebuff';
 
 const EVENT_LINKS: EventLink[] = [
   {
@@ -124,6 +125,15 @@ const EVENT_LINKS: EventLink[] = [
     referencedEventType: EventType.RemoveBuff,
     maximumLinks: 1,
     forwardBufferMs: 600_000, //If you manage your charges, you can keep the buff up pretty much the whole fight, so 10min just in case.
+    backwardBufferMs: CAST_BUFFER_MS,
+  },
+  {
+    linkingEventId: TALENTS.LIVING_BOMB_TALENT.id,
+    linkingEventType: EventType.Cast,
+    linkRelation: EXPLODE_DEBUFF,
+    referencedEventId: SPELLS.LIVING_BOMB_EXPLODE_DEBUFF.id,
+    referencedEventType: EventType.ApplyDebuff,
+    forwardBufferMs: 7_000,
     backwardBufferMs: CAST_BUFFER_MS,
   },
   {

--- a/src/analysis/retail/mage/fire/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/mage/fire/normalizers/CastLinkNormalizer.ts
@@ -128,12 +128,14 @@ const EVENT_LINKS: EventLink[] = [
     backwardBufferMs: CAST_BUFFER_MS,
   },
   {
+    reverseLinkRelation: SPELL_CAST,
     linkingEventId: TALENTS.LIVING_BOMB_TALENT.id,
     linkingEventType: EventType.Cast,
     linkRelation: EXPLODE_DEBUFF,
     referencedEventId: SPELLS.LIVING_BOMB_EXPLODE_DEBUFF.id,
     referencedEventType: EventType.ApplyDebuff,
-    forwardBufferMs: 7_000,
+    anyTarget: true,
+    forwardBufferMs: 7000,
     backwardBufferMs: CAST_BUFFER_MS,
   },
   {

--- a/src/analysis/retail/mage/fire/talents/LivingBomb.tsx
+++ b/src/analysis/retail/mage/fire/talents/LivingBomb.tsx
@@ -1,7 +1,8 @@
 import { Trans } from '@lingui/macro';
 import TALENTS from 'common/TALENTS/mage';
 import { SpellLink } from 'interface';
-import Analyzer, { Options } from 'parser/core/Analyzer';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent } from 'parser/core/Events';
 import { When, ThresholdStyle } from 'parser/core/ParseResults';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 
@@ -11,10 +12,18 @@ class LivingBomb extends Analyzer {
   };
   protected abilityTracker!: AbilityTracker;
 
+  livingBombs: { timestamp: number; targetsHit: number }[] = [];
+
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS.LIVING_BOMB_TALENT);
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.LIVING_BOMB_TALENT),
+      this.onLivingBomb,
+    );
   }
+
+  onLivingBomb(event: CastEvent) {}
 
   get livingBombCasts() {
     return this.abilityTracker.getAbility(TALENTS.LIVING_BOMB_TALENT.id).casts;
@@ -38,11 +47,12 @@ class LivingBomb extends Analyzer {
         <>
           You cast <SpellLink spell={TALENTS.LIVING_BOMB_TALENT} /> {this.livingBombCasts} times.
           Although it is worth it to take the <SpellLink spell={TALENTS.LIVING_BOMB_TALENT} />{' '}
-          talent, this is only to get to the <SpellLink spell={TALENTS.FIREFALL_TALENT} /> talent.
-          On Single Target there is no benefit to casting{' '}
-          <SpellLink spell={TALENTS.LIVING_BOMB_TALENT} /> and is overall considered a DPS loss. On
-          AOE fights, it is not worth taking the <SpellLink spell={TALENTS.LIVING_BOMB_TALENT} />{' '}
-          talent at all.
+          talent in Single Target, this is only to get to the{' '}
+          <SpellLink spell={TALENTS.FIREFALL_TALENT} /> talent. On Single Target there is no benefit
+          to casting <SpellLink spell={TALENTS.LIVING_BOMB_TALENT} /> and is overall considered a
+          DPS loss. On AOE fights, you can get a very minor DPS increase from casting{' '}
+          <SpellLink spell={TALENTS.LIVING_BOMB_TALENT} /> as filler if it will hit at least 5
+          targets.
         </>,
       )
         .icon(TALENTS.LIVING_BOMB_TALENT.icon)

--- a/src/analysis/retail/mage/fire/talents/LivingBomb.tsx
+++ b/src/analysis/retail/mage/fire/talents/LivingBomb.tsx
@@ -1,10 +1,12 @@
-import { Trans } from '@lingui/macro';
 import TALENTS from 'common/TALENTS/mage';
+import { formatPercentage } from 'common/format';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent } from 'parser/core/Events';
+import Events, { CastEvent, GetRelatedEvents } from 'parser/core/Events';
 import { When, ThresholdStyle } from 'parser/core/ParseResults';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
+
+const AOE_THRESHOLD = 5;
 
 class LivingBomb extends Analyzer {
   static dependencies = {
@@ -23,21 +25,33 @@ class LivingBomb extends Analyzer {
     );
   }
 
-  onLivingBomb(event: CastEvent) {}
+  onLivingBomb(event: CastEvent) {
+    const debuffs = GetRelatedEvents(event, 'ExplosionDebuff');
+    this.livingBombs.push({
+      timestamp: event.timestamp,
+      targetsHit: debuffs.length,
+    });
+  }
 
-  get livingBombCasts() {
+  get badCasts() {
+    return this.livingBombs.filter((c) => c.targetsHit < AOE_THRESHOLD).length || 0;
+  }
+
+  get castUtilization() {
+    return 1 - this.badCasts / this.totalCasts;
+  }
+
+  get totalCasts() {
     return this.abilityTracker.getAbility(TALENTS.LIVING_BOMB_TALENT.id).casts;
   }
 
   get livingBombCastThresholds() {
     return {
-      actual: this.livingBombCasts,
-      isGreaterThan: {
-        minor: 0,
+      actual: this.castUtilization,
+      isLessThan: {
         average: 1,
-        major: 2,
       },
-      style: ThresholdStyle.NUMBER,
+      style: ThresholdStyle.PERCENTAGE,
     };
   }
 
@@ -45,21 +59,20 @@ class LivingBomb extends Analyzer {
     when(this.livingBombCastThresholds).addSuggestion((suggest, actual, recommended) =>
       suggest(
         <>
-          You cast <SpellLink spell={TALENTS.LIVING_BOMB_TALENT} /> {this.livingBombCasts} times.
+          You misused <SpellLink spell={TALENTS.LIVING_BOMB_TALENT} /> {this.badCasts} times.
           Although it is worth it to take the <SpellLink spell={TALENTS.LIVING_BOMB_TALENT} />{' '}
           talent in Single Target, this is only to get to the{' '}
           <SpellLink spell={TALENTS.FIREFALL_TALENT} /> talent. On Single Target there is no benefit
-          to casting <SpellLink spell={TALENTS.LIVING_BOMB_TALENT} /> and is overall considered a
+          to casting <SpellLink spell={TALENTS.LIVING_BOMB_TALENT} /> and it is overall considered a
           DPS loss. On AOE fights, you can get a very minor DPS increase from casting{' '}
-          <SpellLink spell={TALENTS.LIVING_BOMB_TALENT} /> as filler if it will hit at least 5
+          <SpellLink spell={TALENTS.LIVING_BOMB_TALENT} /> as filler if it will hit at least{' '}
+          {AOE_THRESHOLD}
           targets.
         </>,
       )
         .icon(TALENTS.LIVING_BOMB_TALENT.icon)
-        .actual(
-          <Trans id="mage.fire.suggestions.livingBomb.casts">{this.livingBombCasts} casts</Trans>,
-        )
-        .recommended(`${this.livingBombCasts} is recommended`),
+        .actual(`${formatPercentage(actual)}% utilization`)
+        .recommended(`${formatPercentage(recommended)}% is recommended`),
     );
   }
 }

--- a/src/analysis/retail/mage/fire/talents/LivingBomb.tsx
+++ b/src/analysis/retail/mage/fire/talents/LivingBomb.tsx
@@ -66,8 +66,7 @@ class LivingBomb extends Analyzer {
           to casting <SpellLink spell={TALENTS.LIVING_BOMB_TALENT} /> and it is overall considered a
           DPS loss. On AOE fights, you can get a very minor DPS increase from casting{' '}
           <SpellLink spell={TALENTS.LIVING_BOMB_TALENT} /> as filler if it will hit at least{' '}
-          {AOE_THRESHOLD}
-          targets.
+          {AOE_THRESHOLD} targets.
         </>,
       )
         .icon(TALENTS.LIVING_BOMB_TALENT.icon)

--- a/src/analysis/retail/mage/fire/talents/MeteorCombustion.tsx
+++ b/src/analysis/retail/mage/fire/talents/MeteorCombustion.tsx
@@ -121,8 +121,8 @@ class MeteorCombustion extends Analyzer {
           You failed to cast <SpellLink spell={TALENTS.METEOR_TALENT} /> during{' '}
           <SpellLink spell={TALENTS.COMBUSTION_TALENT} /> {this.combustionWithoutMeteor} times. In
           order to make the most of Combustion and <SpellLink spell={SPELLS.IGNITE} />, you should
-          always cast Meteor during Combustion. If Meteor will not come off cooldown before
-          Combustion is available, then you should hold Meteor for Combustion.
+          always ensure Meteor hits the target during Combustion. If Meteor will not come off
+          cooldown before Combustion is available, then you should hold Meteor for Combustion.
         </>,
       )
         .icon(TALENTS.METEOR_TALENT.icon)

--- a/src/parser/shared/modules/AlwaysBeCasting.tsx
+++ b/src/parser/shared/modules/AlwaysBeCasting.tsx
@@ -46,6 +46,13 @@ class AlwaysBeCasting extends Analyzer {
   /** Gets active time percentage within a specified time segment.
    *  This will not work properly unless the current timestamp advances past the end time. */
   getActiveTimePercentageInWindow(start: number, end: number): number {
+    const windowDuration = end - start;
+    return this.getActiveTimeMillisecondsInWindow(start, end) / windowDuration;
+  }
+
+  /** Gets active time milliseconds within a specified time segment.
+   *  This will not work properly unless the current timestamp advances past the end time. */
+  getActiveTimeMillisecondsInWindow(start: number, end: number): number {
     let activeTime = 0;
     for (let i = 0; i < this.activeTimeSegments.length; i += 1) {
       const seg = this.activeTimeSegments[i];
@@ -58,8 +65,7 @@ class AlwaysBeCasting extends Analyzer {
       const overlapEnd = Math.min(end, seg.end);
       activeTime += Math.max(0, overlapEnd - overlapStart);
     }
-    const windowDuration = end - start;
-    return activeTime / windowDuration;
+    return activeTime;
   }
 
   activeTime = 0;


### PR DESCRIPTION
- Adjusted Living Bomb to count casts that hit 5+ targets as ok, and adjust wording accordingly
- Adjusted Combustion Active Time so it actually counts properly and in seconds instead of milliseconds
- Adjusted wording of Meteor to indicate that it needs to land during Combustion.

Also adjusted AlwaysBeCasting in Core to be able to get the Active Time in milliseconds as well as percent, and adjusted the percent function to call the milliseconds one to avoid duplicating the entire function.