### PR TITLE
add uptime graph to Guides

### DIFF
--- a/src/analysis/retail/demonhunter/havoc/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/havoc/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import SHARED_CHANGELOG from 'analysis/retail/demonhunter/shared/CHANGELOG';
 
 // prettier-ignore
 export default [
+  change(date(2024, 1, 4), <>Update explanation for <SpellLink spell={TALENTS.ACCELERATED_BLADE_TALENT} /> to match 10.2 logic.</>, ToppleTheNun),
   change(date(2023, 7, 13), 'Disable checklist.', ToppleTheNun),
   change(date(2023, 7, 11), 'Update for 10.1.5.', ToppleTheNun),
   change(date(2023, 6, 17), <>Fix damage calculations for <SpellLink spell={TALENTS.COLLECTIVE_ANGUISH_TALENT} />.</>, ToppleTheNun),

--- a/src/analysis/retail/demonhunter/havoc/Guide.tsx
+++ b/src/analysis/retail/demonhunter/havoc/Guide.tsx
@@ -16,6 +16,9 @@ import {
 } from './modules/resourcetracker/FuryTracker';
 import FuryCapWaste from './guide/FuryCapWaste';
 import HideGoodCastsToggle from 'interface/guide/components/HideGoodCastsToggle';
+import { PerformanceStrong } from 'analysis/retail/priest/shadow/modules/guide/ExtraComponents';
+import { formatPercentage } from 'common/format';
+import ActiveTimeGraph from 'parser/ui/ActiveTimeGraph';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -28,12 +31,12 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
   );
 }
 
-function ResourceUsageSection({ modules }: GuideProps<typeof CombatLogParser>) {
+function ResourceUsageSection({ info, modules }: GuideProps<typeof CombatLogParser>) {
   const percentAtFuryCap = modules.furyTracker.percentAtCap;
   const percentAtFuryCapPerformance = modules.furyTracker.percentAtCapPerformance;
   const furyWasted = modules.furyTracker.wasted;
   return (
-    <Section title="Resource Use">
+    <Section title="Core">
       <SubSection title="Fury">
         <p>
           Havoc's primary resource is <ResourceLink id={RESOURCE_TYPES.FURY.id} />. You should avoid
@@ -49,6 +52,28 @@ function ResourceUsageSection({ modules }: GuideProps<typeof CombatLogParser>) {
           okTimeAtFuryCap={OK_TIME_AT_FURY_CAP}
         />
         {modules.furyGraph.plot}
+      </SubSection>
+      <SubSection title="Active Time">
+        <p>
+          <b>
+            Continuously casting throughout an encounter is the single most important thing for
+            achieving good DPS.
+          </b>
+          <br />
+          Some fights have unavoidable downtime due to phase transitions and the like, so in these
+          cases 0% downtime will not be possible - do the best you can.
+        </p>
+        <p>
+          Active Time:{' '}
+          <PerformanceStrong performance={modules.alwaysBeCasting.DowntimePerformance}>
+            {formatPercentage(modules.alwaysBeCasting.activeTimePercentage, 1)}%
+          </PerformanceStrong>{' '}
+        </p>
+        <ActiveTimeGraph
+          activeTimeSegments={modules.alwaysBeCasting.activeTimeSegments}
+          fightStart={info.fightStart}
+          fightEnd={info.fightEnd}
+        />
       </SubSection>
     </Section>
   );

--- a/src/analysis/retail/demonhunter/havoc/constants.ts
+++ b/src/analysis/retail/demonhunter/havoc/constants.ts
@@ -22,6 +22,4 @@ export const GROWING_INFERNO_SCALING = [0, 0.08, 0.15];
 
 export const BURNING_WOUND_SCALING = [0, 0.4];
 
-export const ACCELERATING_BLADE_SCALING = [0, 0.2];
-
 export const MOMENTUM_SCALING = [0, 0.08];

--- a/src/analysis/retail/demonhunter/havoc/modules/spells/ThrowGlaive/AcceleratingBladeExplanation.tsx
+++ b/src/analysis/retail/demonhunter/havoc/modules/spells/ThrowGlaive/AcceleratingBladeExplanation.tsx
@@ -2,9 +2,11 @@ import { useInfo } from 'interface/guide';
 import TALENTS from 'common/TALENTS/demonhunter';
 import SpellLink from 'interface/SpellLink';
 import { formatPercentage } from 'common/format';
-import { ACCELERATING_BLADE_SCALING } from 'analysis/retail/demonhunter/havoc/constants';
 import Tooltip from 'interface/Tooltip';
 import InformationIcon from 'interface/icons/Information';
+
+export const SCALING_PER_TARGET_HIT = 0.3;
+export const INITIAL_HIT_SCALING = 0.6;
 
 export const AcceleratingBladeExplanation = () => {
   const info = useInfo();
@@ -12,17 +14,14 @@ export const AcceleratingBladeExplanation = () => {
     return null;
   }
 
-  const scaling =
-    ACCELERATING_BLADE_SCALING[info.combatant.getTalentRank(TALENTS.ACCELERATED_BLADE_TALENT)];
-  const perTargetScaling = 1 + scaling;
+  const primaryTargetScalingValue = 1 + INITIAL_HIT_SCALING;
+  const secondaryTargetScalingValue = primaryTargetScalingValue * (1 - SCALING_PER_TARGET_HIT);
+  const tertiaryTargetScalingValue = secondaryTargetScalingValue * (1 - SCALING_PER_TARGET_HIT);
 
   // multiplicative scaling
-  const primaryTargetScaling = formatPercentage(perTargetScaling, 0);
-  const secondaryTargetScaling = formatPercentage(perTargetScaling * perTargetScaling, 0);
-  const tertiaryTargetScaling = formatPercentage(
-    perTargetScaling * perTargetScaling * perTargetScaling,
-    0,
-  );
+  const primaryTargetScaling = formatPercentage(primaryTargetScalingValue, 0);
+  const secondaryTargetScaling = formatPercentage(secondaryTargetScalingValue, 0);
+  const tertiaryTargetScaling = formatPercentage(tertiaryTargetScalingValue, 0);
 
   return (
     <li>

--- a/src/analysis/retail/demonhunter/shared/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/shared/CHANGELOG.tsx
@@ -8,6 +8,7 @@ import { ResourceLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2024, 1, 4), 'Add uptime graph.', ToppleTheNun),
   change(date(2023, 11, 6), 'Mark as updated for 10.2.', ToppleTheNun),
   change(date(2023, 10, 9), 'Update ability cooldowns and scaling in spellbooks.', ToppleTheNun),
   change(date(2023, 10, 9), 'Start updating for 10.2.', ToppleTheNun),

--- a/src/analysis/retail/demonhunter/vengeance/Guide.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/Guide.tsx
@@ -19,11 +19,14 @@ import {
   OK_TIME_AT_FURY_CAP,
   PERFECT_TIME_AT_FURY_CAP,
 } from './modules/resourcetracker/FuryTracker';
+import { PerformanceStrong } from 'analysis/retail/priest/shadow/modules/guide/ExtraComponents';
+import { formatPercentage } from 'common/format';
+import ActiveTimeGraph from 'parser/ui/ActiveTimeGraph';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
     <>
-      <ResourceUsageSection modules={modules} events={events} info={info} />
+      <CoreSection modules={modules} events={events} info={info} />
       <RotationSection modules={modules} events={events} info={info} />
       <MitigationSection />
       <CooldownSection modules={modules} events={events} info={info} />
@@ -32,13 +35,13 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
   );
 }
 
-function ResourceUsageSection({ modules }: GuideProps<typeof CombatLogParser>) {
+function CoreSection({ modules, info }: GuideProps<typeof CombatLogParser>) {
   const percentAtFuryCap = modules.furyTracker.percentAtCap;
   const percentAtFuryCapPerformance = modules.furyTracker.percentAtCapPerformance;
   const furyWasted = modules.furyTracker.wasted;
 
   return (
-    <Section title="Resource Use">
+    <Section title="Core">
       <SubSection title="Fury">
         <p>
           Vengeance's primary resource is <ResourceLink id={RESOURCE_TYPES.FURY.id} />. You should
@@ -67,6 +70,28 @@ function ResourceUsageSection({ modules }: GuideProps<typeof CombatLogParser>) {
           the encounter.
         </p>
         {modules.soulFragmentsGraph.plot}
+      </SubSection>
+      <SubSection title="Active Time">
+        <p>
+          <b>
+            Continuously casting throughout an encounter is the single most important thing for
+            achieving good DPS.
+          </b>
+          <br />
+          Some fights have unavoidable downtime due to phase transitions and the like, so in these
+          cases 0% downtime will not be possible - do the best you can.
+        </p>
+        <p>
+          Active Time:{' '}
+          <PerformanceStrong performance={modules.alwaysBeCasting.DowntimePerformance}>
+            {formatPercentage(modules.alwaysBeCasting.activeTimePercentage, 1)}%
+          </PerformanceStrong>{' '}
+        </p>
+        <ActiveTimeGraph
+          activeTimeSegments={modules.alwaysBeCasting.activeTimeSegments}
+          fightStart={info.fightStart}
+          fightEnd={info.fightEnd}
+        />
       </SubSection>
     </Section>
   );


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Add casting uptime graph to DH Guides.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/KPwMavygnVd6CNzT/51/312`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/1532c85f-bc04-47e3-b7ea-1710cb3fb1d7)
