### PR TITLE
[Warlock] Fix an issue where it was trying to access a talent spell inside regular spells object

### DIFF
--- a/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_WARLOCK } from 'common/TALENTS';
-import { Sharrq, Zeboot, Meldris, ToppleTheNun, Jonfanz, Mae, dodse, Arlie } from 'CONTRIBUTORS';
+import { Sharrq, Zeboot, Meldris, ToppleTheNun, Jonfanz, Mae, dodse, Arlie, Putro } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2024, 1, 6), <>Fix a crash related to <SpellLink spell={TALENTS_WARLOCK.GRIMOIRE_FELGUARD_TALENT} />.</>, Putro),
   change(date(2023, 7, 31), <>Add support for Aberrus 2set CDR on <SpellLink spell={TALENTS_WARLOCK.GRIMOIRE_FELGUARD_TALENT} /></>, Arlie),
   change(date(2023, 7, 31), 'Update CDR on Dark Pact and Unending Resolve', Arlie),
   change(date(2023, 7, 8), 'Update SpellLink usage.', ToppleTheNun),

--- a/src/analysis/retail/warlock/demonology/modules/pets/PETS.ts
+++ b/src/analysis/retail/warlock/demonology/modules/pets/PETS.ts
@@ -1,4 +1,6 @@
 import SPELLS from 'common/SPELLS';
+import Spell from 'common/SPELLS/Spell';
+import { Talent } from 'common/TALENTS/types';
 import TALENTS from 'common/TALENTS/warlock';
 
 const INNER_DEMON_NETHER_PORTAL_DURATION = 15000;
@@ -6,7 +8,7 @@ const INNER_DEMON_NETHER_PORTAL_DURATION = 15000;
 type PetRecord = {
   guid: number;
   duration: number;
-  summonAbility: number;
+  summonAbility: Spell | Talent;
   isRandom?: boolean;
 };
 
@@ -22,92 +24,92 @@ const PETS = {
   WILD_IMP_HOG: {
     guid: 55659,
     duration: 15000, // maximum duration, realistically is handled differently
-    summonAbility: SPELLS.WILD_IMP_HOG_SUMMON.id,
+    summonAbility: SPELLS.WILD_IMP_HOG_SUMMON,
   },
   DREADSTALKER: {
     guid: 98035,
     duration: 12000,
-    summonAbility: SPELLS.DREADSTALKER_SUMMON_1.id,
+    summonAbility: SPELLS.DREADSTALKER_SUMMON_1,
   },
   VILEFIEND: {
     guid: 135816,
     duration: 15000,
-    summonAbility: TALENTS.SUMMON_VILEFIEND_TALENT.id,
+    summonAbility: TALENTS.SUMMON_VILEFIEND_TALENT,
   },
   GRIMOIRE_FELGUARD: {
     guid: 17252,
     duration: 15000,
-    summonAbility: TALENTS.GRIMOIRE_FELGUARD_TALENT.id,
+    summonAbility: TALENTS.GRIMOIRE_FELGUARD_TALENT,
   },
   DEMONIC_TYRANT: {
     guid: 135002,
     duration: 15000,
-    summonAbility: SPELLS.SUMMON_DEMONIC_TYRANT.id,
+    summonAbility: SPELLS.SUMMON_DEMONIC_TYRANT,
   },
   // Inner Demons and Nether Portal demons
   WILD_IMP_INNER_DEMONS: {
     guid: 143622,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
-    summonAbility: SPELLS.WILD_IMP_ID_SUMMON.id,
+    summonAbility: SPELLS.WILD_IMP_ID_SUMMON,
   },
   BILESCOURGE: {
     guid: 136404,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
-    summonAbility: SPELLS.BILESCOURGE_SUMMON.id,
+    summonAbility: SPELLS.BILESCOURGE_SUMMON,
     isRandom: true,
   },
   VICIOUS_HELLHOUND: {
     guid: 136399,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
-    summonAbility: SPELLS.VICIOUS_HELLHOUND_SUMMON.id,
+    summonAbility: SPELLS.VICIOUS_HELLHOUND_SUMMON,
     isRandom: true,
   },
   SHIVARRA: {
     guid: 136406,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
-    summonAbility: SPELLS.SHIVARRA_SUMMON.id,
+    summonAbility: SPELLS.SHIVARRA_SUMMON,
     isRandom: true,
   },
   DARKHOUND: {
     guid: 136408,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
-    summonAbility: SPELLS.DARKHOUND_SUMMON.id,
+    summonAbility: SPELLS.DARKHOUND_SUMMON,
     isRandom: true,
   },
   ILLIDARI_SATYR: {
     guid: 136398,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
-    summonAbility: SPELLS.ILLIDARI_SATYR_SUMMON.id,
+    summonAbility: SPELLS.ILLIDARI_SATYR_SUMMON,
     isRandom: true,
   },
   VOID_TERROR: {
     guid: 136403,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
-    summonAbility: SPELLS.VOID_TERROR_SUMMON.id,
+    summonAbility: SPELLS.VOID_TERROR_SUMMON,
     isRandom: true,
   },
   URZUL: {
     guid: 136402,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
-    summonAbility: SPELLS.URZUL_SUMMON.id,
+    summonAbility: SPELLS.URZUL_SUMMON,
     isRandom: true,
   },
   WRATHGUARD: {
     guid: 136407,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
-    summonAbility: SPELLS.WRATHGUARD_SUMMON.id,
+    summonAbility: SPELLS.WRATHGUARD_SUMMON,
     isRandom: true,
   },
   EYE_OF_GULDAN: {
     guid: 136401,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
-    summonAbility: SPELLS.EYE_OF_GULDAN_SUMMON.id,
+    summonAbility: SPELLS.EYE_OF_GULDAN_SUMMON,
     isRandom: true,
   },
   PRINCE_MALCHEZAAR: {
     guid: 136397,
     duration: INNER_DEMON_NETHER_PORTAL_DURATION,
-    summonAbility: SPELLS.PRINCE_MALCHEZAAR_SUMMON.id,
+    summonAbility: SPELLS.PRINCE_MALCHEZAAR_SUMMON,
     isRandom: true,
   },
 };

--- a/src/analysis/retail/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.ts
+++ b/src/analysis/retail/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.ts
@@ -94,7 +94,7 @@ class PrepullPetNormalizer extends EventsNormalizer {
                 );
               continue;
             }
-            spell = SPELLS[PETS[petGUID].summonAbility];
+            spell = PETS[petGUID].summonAbility;
           }
           const fabricatedEvent: SummonEvent = {
             target: {


### PR DESCRIPTION
The PrepullPetNormalizer could do with some better typing as it would have caught this issue, but for now it's fine as this fixes the crash