### PR TITLE
[Augmentation] Update Buff Helper module to support new logic for Prescience Helper WA

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SPELLS from 'common/SPELLS/evoker';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 export default [
+    change(date(2024, 1, 9), <>Update Buff Helper module Prescience Helper MRT note to support the new logic of the WA.</>, Vollmer),
     change(date(2023, 12, 31), <>Implemented <ResourceLink id={RESOURCE_TYPES.ESSENCE.id}/> Graph.</>, Vollmer),
     change(date(2023, 12, 22), <>Update blacklist for Helpers to increase accuracy.</>, Vollmer),
     change(date(2023, 12, 13), <>Added Boss filter button for Buff Helper, and improved loading speed.</>, Vollmer),

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
@@ -362,7 +362,6 @@ class BuffTargetHelper extends Analyzer {
         isImportant = true;
       }
 
-      //this.addEntryToTwoTargetMRTNote(top2Entries, i, intervalStart, isImportant);
       this.addEntryToFourTargetMRTNote(top4Entries, i, intervalStart, isImportant);
     }
 

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
@@ -464,9 +464,6 @@ class BuffTargetHelper extends Analyzer {
       const hasLongPrescience = prescienceCount === 3 && this.has4Pc;
       let intervalToCheck = hasLongPrescience ? curInterval + 2 : curInterval + 1;
 
-      // Why did I make the data structure like this again?
-      // Like it doesn't even make sense to me anymore, but it works so I'm not touching it
-      // Next season I'll make it better, I promise, maybe
       let target: string | undefined;
       while (!target && intervalToCheck >= 0) {
         // If the interval we want to check is empty, keep going to previous

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
@@ -95,6 +95,7 @@ class BuffTargetHelper extends Analyzer {
     30 * 1000 * (this.selectedCombatant.hasTalent(TALENTS.INTERWOVEN_THREADS_TALENT) ? 0.9 : 1);
 
   fightStart: number = this.owner.fight.start_time;
+  fightStartDelay: number = 4_000;
   fightEnd: number = this.owner.fight.end_time;
   prescienceHelperMrtNote: string = '';
   mrtFourTargetPrescienceHelperNote: string = '';
@@ -167,7 +168,7 @@ class BuffTargetHelper extends Analyzer {
 
     // Start 4 seconds in since you start the fight with 2x Prescience -> Ebon Might
     // This will also show MUCH better value targets
-    let currentTime = this.fightStart + 4_000;
+    let currentTime = this.fightStart + this.fightStartDelay;
 
     const fetchPromises: Promise<DamageTables>[] = [];
     while (currentTime < this.fightEnd) {
@@ -313,9 +314,9 @@ class BuffTargetHelper extends Analyzer {
     );
 
     for (let i = 0; i < topPumpersData.length; i += 1) {
-      const intervalStart = formatDuration(i * this.interval);
+      const intervalStart = formatDuration(i * this.interval + this.fightStartDelay);
       const intervalEnd = formatDuration(
-        Math.min((i + 1) * this.interval, this.fightEnd - this.fightStart),
+        Math.min((i + 1) * this.interval + this.fightStartDelay, this.fightEnd - this.fightStart),
       );
 
       const formattedEntriesTable = top4PumpersData[i].map(([name, values]) => (

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
@@ -426,16 +426,6 @@ class BuffTargetHelper extends Analyzer {
       defaultTargets[1] +
       '|r \n';
 
-    // Grab the top 2 pumpers for the pull
-    newNote +=
-      'PULL - ' +
-      mrtColorMap.get(this.playerWhitelist.get(top4Pumpers[0][0][0]) ?? '') +
-      top4Pumpers[0][0][0] +
-      '|r ' +
-      mrtColorMap.get(this.playerWhitelist.get(top4Pumpers[0][1][0]) ?? '') +
-      top4Pumpers[0][1][0] +
-      '|r \n';
-
     const prescienceCooldown =
       12_000 * (this.selectedCombatant.hasTalent(TALENTS.INTERWOVEN_THREADS_TALENT) ? 0.9 : 1);
     // First two casts in fight should be 2x Prescience
@@ -455,6 +445,20 @@ class BuffTargetHelper extends Analyzer {
 
     /** Playername, expiration time */
     const prescienceMap = new Map<string, number>();
+
+    // Grab the top 2 pumpers for the pull
+    newNote +=
+      'PULL - ' +
+      mrtColorMap.get(this.playerWhitelist.get(top4Pumpers[0][0][0]) ?? '') +
+      top4Pumpers[0][0][0] +
+      '|r ' +
+      mrtColorMap.get(this.playerWhitelist.get(top4Pumpers[0][1][0]) ?? '') +
+      top4Pumpers[0][1][0] +
+      '|r \n';
+
+    // Add them to the map
+    prescienceMap.set(top4Pumpers[0][0][0], prescienceDuration * (this.has4Pc ? 2 : 1));
+    prescienceMap.set(top4Pumpers[0][1][0], 1_000 + prescienceDuration); // Takes roughly 1 second to cast 2nd Prescience
 
     while (curTime < fightLength) {
       const curInterval = intervals - Math.round((fightLength - curTime) / this.interval);

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
@@ -386,7 +386,7 @@ class BuffTargetHelper extends Analyzer {
           </table>
         </div>
         <div className="button-container">
-          <button className="button" onClick={this.handleTwoTargetCopyClick}>
+          <button className="button" onClick={this.handlePrescienceHelperCopyClick}>
             Copy Prescience Helper MRT note
           </button>
           <button className="button" onClick={this.handleFourTargetCopyClick}>
@@ -554,7 +554,7 @@ class BuffTargetHelper extends Analyzer {
     this.mrtFourTargetPrescienceHelperNote += '\n';
   }
 
-  handleTwoTargetCopyClick = () => {
+  handlePrescienceHelperCopyClick = () => {
     navigator.clipboard.writeText(this.prescienceHelperMrtNote);
   };
   handleFourTargetCopyClick = () => {

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
@@ -460,8 +460,9 @@ class BuffTargetHelper extends Analyzer {
     prescienceMap.set(top4Pumpers[0][1][0], 1_000 + prescienceDuration); // Takes roughly 1 second to cast 2nd Prescience
 
     while (curTime < fightLength) {
-      const curInterval = intervals - Math.round((fightLength - curTime) / this.interval);
-      let intervalToCheck = this.has4Pc && prescienceCount === 3 ? curInterval + 1 : curInterval;
+      const curInterval = intervals - Math.round((fightLength - curTime) / this.interval) - 1;
+      const hasLongPrescience = prescienceCount === 3 && this.has4Pc;
+      let intervalToCheck = hasLongPrescience ? curInterval + 2 : curInterval + 1;
 
       // Why did I make the data structure like this again?
       // Like it doesn't even make sense to me anymore, but it works so I'm not touching it
@@ -493,7 +494,7 @@ class BuffTargetHelper extends Analyzer {
             ); */
             prescienceMap.set(
               nextTarget,
-              curTime + prescienceDuration * (prescienceCount === 3 && this.has4Pc ? 2 : 1),
+              curTime + prescienceDuration * (hasLongPrescience ? 2 : 1),
             );
             target = nextTarget;
             break;

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
@@ -18,6 +18,7 @@ import BuffTargetHelperWarningLabel from './BuffTargetHelperWarningLabel';
 import Toggle from 'react-toggle';
 import { TIERS } from 'game/TIERS';
 import StatTracker from 'parser/shared/modules/StatTracker';
+import BuffTargetHelperInfoLabel from './BuffTargetHelperInfoLabel';
 
 /**
  * @key ClassName
@@ -604,6 +605,8 @@ class BuffTargetHelper extends Analyzer {
               <b>HenryG</b> or the <a href="https://wago.io/KP-BlDV58">Frame Glows</a> WeakAura made
               by <b>Zephy</b> based on which Weak Aura you use.
             </p>
+
+            <BuffTargetHelperInfoLabel has4Pc={this.has4Pc} />
           </div>
           <div>
             <BuffTargetHelperWarningLabel />

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
@@ -494,7 +494,7 @@ class BuffTargetHelper extends Analyzer {
             ); */
             prescienceMap.set(
               nextTarget,
-              curTime + prescienceDuration * (prescienceCount === 3 ? 2 : 1),
+              curTime + prescienceDuration * (prescienceCount === 3 && this.has4Pc ? 2 : 1),
             );
             target = nextTarget;
             break;

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
@@ -281,7 +281,7 @@ class BuffTargetHelper extends Analyzer {
     return top4PumpersData;
   }
 
-  getDefaultTargets(top4PumpersData: [string, number[]][][]) {
+  getDefaultTargets(top4PumpersData: [string, number[]][][]): string[] {
     const nameSums = new Map();
 
     top4PumpersData.flat().forEach(([name, values]) => {
@@ -298,7 +298,7 @@ class BuffTargetHelper extends Analyzer {
 
   renderTableContent(
     topPumpersData: [string, number[]][][],
-    defaultTargets: any[],
+    defaultTargets: string[],
     top4PumpersData: [string, number[]][][],
   ) {
     const tableRows = [];
@@ -413,7 +413,7 @@ class BuffTargetHelper extends Analyzer {
    * ...etc...
    * prescGlowsEnd
    */
-  generateMRTNoteHenryG(top4Pumpers: [string, number[]][][], defaultTargets: any[]) {
+  generateMRTNoteHenryG(top4Pumpers: [string, number[]][][], defaultTargets: string[]) {
     // Initialize the note with the default targets
     let newNote =
       'prescGlowsStart \n' +

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
@@ -506,9 +506,9 @@ class BuffTargetHelper extends Analyzer {
         newNote += `${formatDuration(curTime)} - ${
           mrtColorMap.get(this.playerWhitelist.get(target) ?? '') + target + '|r'
         } \n`;
+        prescienceCount = prescienceCount === 3 ? 1 : prescienceCount + 1;
       }
 
-      prescienceCount = prescienceCount === 3 ? 1 : prescienceCount + 1;
       curTime += prescienceCooldown;
     }
 

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelperInfoLabel.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelperInfoLabel.tsx
@@ -1,0 +1,36 @@
+import { AlertInfo, SpellLink } from 'interface';
+import TALENTS from 'common/TALENTS/evoker';
+
+type Props = {
+  has4Pc: boolean;
+};
+
+const BuffTargetHelperInfoLabel: React.FC<Props> = ({ has4Pc }) => {
+  return (
+    <div className="container">
+      <AlertInfo style={{ marginBottom: 30 }}>
+        <b>
+          Note for <a href="https://wago.io/yrmx6ZQSG">Prescience Helper</a> users
+        </b>
+        <p>
+          <b>HenryG</b> has updated the logic for his Prescience Helper WeakAura on <b>January 7</b>
+          . This module has been updated to support the new logic.
+        </p>
+        <p>
+          Please update your Prescience Helper WeakAura to the latest version. If you do not, this
+          module will not work correctly.
+        </p>
+        {has4Pc && (
+          <p>
+            <b>
+              Because you have T31 4pc, the note generated assumes the first{' '}
+              <SpellLink spell={TALENTS.PRESCIENCE_TALENT} /> you cast on pull is a long one.
+            </b>
+          </p>
+        )}
+      </AlertInfo>
+    </div>
+  );
+};
+
+export default BuffTargetHelperInfoLabel;


### PR DESCRIPTION
### Description
**HenryG** updated the logic for his [Prescience Helper](https://wago.io/yrmx6ZQSG) WA, so I've updated the logic here to support that.

Logic is pretty basic, basically just a simple forward check for which targets would be best for upcoming intervals based on current T31 2pc count (One interval ahead for short Prescience, two intervals ahead for long Prescience). Only counting targets that don't already have Prescience active.

New output eg. looks like this:
```
prescGlowsStart 
defaultTargets - |cff8788eeOlgey|r |cfffff468Zylv|r 
PULL - |cffc41e3aDérp|r |cffff7c0aMckulling|r 
0:12 - |cff8788eeOlgey|r 
0:23 - |cff0070ddMalkrok|r 
0:34 - |cfffff468Zylv|r 
...etc
prescGlowsEnd
```

Also added an info box to make sure people are aware they need to update their WA to the new version.

Also introduced a start of fight delay to mimic proper opener with 10.2 changes. This also increases the value of proper breath targets for pull EM window.

### Testing

- Test report URL: `/report/47D1bq9Tyagp6AXV/42-Mythic+Tindral+Sageswift,+Seer+of+the+Flame+-+Kill+(7:01)/Vollmer/standard/overview`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/4cf34f8a-6f9c-4fa0-ada4-86646b6068e4)

