### PR TITLE
add Dreamwalker's Healing Potion

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -26,12 +26,14 @@ import {
   Seriousnes,
   Arlie,
   LucasLevyOB,
+  dub
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2023, 2, 9), <>Add <ItemLink id={ITEMS.DREAMWALKERS_HEALING_POTION_R3.id} /> to healing potion list.</>, dub),
   change(date(2024, 1, 7), <>Add checklist support for <ItemLink id={ITEMS.FYRALATH.id} />.</>, ToppleTheNun),
   change(date(2024, 1, 4), <>Add statistics for <ItemLink id={ITEMS.ECHOING_TYRSTONE.id}/>.</>, Arbixal),
   change(date(2024, 1, 2), 'Remove Shadowlands food and augment rune support.', ToppleTheNun),

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2334,3 +2334,9 @@ export const Pants: Contributor = {
   github: 'Smetz42',
   discord: 'pants_of_silver',
 };
+
+export const dub: Contributor = {
+  nickname: 'wes/dub',
+  github: 'wtodom',
+  discord: 'its_me_dub',
+};

--- a/src/common/ITEMS/dragonflight/potions.ts
+++ b/src/common/ITEMS/dragonflight/potions.ts
@@ -95,6 +95,21 @@ const potions = {
   //endregion
 
   //region Frost Potions
+  DREAMWALKERS_HEALING_POTION_R1: {
+    id: 207021,
+    name: "Dreamwalker's Healing Potion",
+    icon: 'Inv_10_alchemy_bottle_shape4_pink',
+  },
+  DREAMWALKERS_HEALING_POTION_R2: {
+    id: 207022,
+    name: "Dreamwalker's Healing Potion",
+    icon: 'Inv_10_alchemy_bottle_shape4_pink',
+  },
+  DREAMWALKERS_HEALING_POTION_R3: {
+    id: 207023,
+    name: "Dreamwalker's Healing Potion",
+    icon: 'Inv_10_alchemy_bottle_shape4_pink',
+  },
   REFRESHING_HEALING_POTION_R1: {
     id: 191378,
     name: 'Refreshing Healing Potion',

--- a/src/common/SPELLS/dragonflight/potions.ts
+++ b/src/common/SPELLS/dragonflight/potions.ts
@@ -35,6 +35,11 @@ const spells = {
   //endregion
 
   //region Frost Potions
+  DREAMWALKERS_HEALING_POTION: {
+    id: 415569,
+    name: "Dreamwalker's Healing Potion",
+    icon: 'inv_10_alchemy_bottle_shape4_pink',
+  },
   REFRESHING_HEALING_POTION: {
     id: 370511,
     name: 'Refreshing Healing Potion',

--- a/src/parser/retail/modules/items/HealthPotion.ts
+++ b/src/parser/retail/modules/items/HealthPotion.ts
@@ -6,7 +6,11 @@ import Potion from './Potion';
  * Tracks health potion cooldown.
  */
 class HealthPotion extends Potion {
-  static spells = [SPELLS.REFRESHING_HEALING_POTION.id, SPELLS.POTION_OF_WITHERING_VITALITY.id];
+  static spells = [
+    SPELLS.DREAMWALKERS_HEALING_POTION.id,
+    SPELLS.REFRESHING_HEALING_POTION.id,
+    SPELLS.POTION_OF_WITHERING_VITALITY.id,
+  ];
   static recommendedEfficiency = 0;
   static extraAbilityInfo = {
     isDefensive: true,


### PR DESCRIPTION
### Description

This PR simply adds the "new" healing potion introduced in 10.2. It shows up at the bottom of the `Statistics` tab in a report summary.

### Testing

I verified that the change worked as expected manually by running the site locally and checking one of my own logs. I also ran tests with `yarn test` and all pass. Given the simplicity of this change I don't think additional testing is needed, but I'm down to add more if anyone disagrees. 

Report used for testing (including screenshots below): https://wowanalyzer.com/report/ajVgABpt6ZyRkhvM/9-Mythic+Council+of+Dreams+-+Kill+(8:02)/Vymndy/standard/statistics

### Screenshot(s):

Current live site:
<img width="1234" alt="Screenshot 2024-01-09 at 4 27 24 PM" src="https://github.com/WoWAnalyzer/WoWAnalyzer/assets/690431/fac3de47-c024-48ef-be26-a03f92a95c4f">

With this PR:
<img width="1252" alt="Screenshot 2024-01-09 at 4 27 04 PM" src="https://github.com/WoWAnalyzer/WoWAnalyzer/assets/690431/4e3750c7-9744-49c0-b73b-dec698b450c4">
