### PR TITLE
remove integration-test from GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
 
   test-interface:
     needs: [prepare]
-    # This should actually include anything but parser and integration tests
+    # This should actually include anything but parser tests
     name: 'Interface tests'
     runs-on: ubuntu-latest
     steps:
@@ -146,24 +146,6 @@ jobs:
           key: ${{ runner.os }}-node_modules-${{ hashFiles('package.json', 'yarn.lock') }}-v3
           required: true
       - run: yarn test:parser --runInBand
-
-  test-integration:
-    needs: [prepare]
-    name: 'Integration tests'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-      - name: Restore "node_modules" from cache
-        uses: martijnhols/actions-cache/restore@v3
-        with:
-          path: |
-            node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('package.json', 'yarn.lock') }}-v3
-          required: true
-      - run: yarn test:integration --runInBand
 
   build:
     needs: [prepare]
@@ -308,7 +290,7 @@ jobs:
         run: yarn lingui compile
 
   docker-image:
-    needs: [typecheck, linting, prettier, test-interface, test-parser, test-integration, build]
+    needs: [typecheck, linting, prettier, test-interface, test-parser, build]
     name: 'Publish Docker image'
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.repository == 'wowanalyzer/wowanalyzer'

--- a/src/analysis/retail/mage/fire/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/fire/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { Sharrq, ToppleTheNun } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2024, 1, 17), 'Bump to 10.2.5 support.', ToppleTheNun),
   change(date(2024, 1, 3), <>Updated <SpellLink spell={SPELLS.FIREBALL} /> during <SpellLink spell={TALENTS.COMBUSTION_TALENT} /> to disregard casts where the player had a <SpellLink spell={TALENTS.FLAME_ACCELERANT_TALENT} /> proc. Reworded the suggestion to include Double Lust and Flame Accelerant.</>, Sharrq),
   change(date(2023, 12, 31), <><SpellLink spell={TALENTS.COMBUSTION_TALENT} /> Active Time had one job, and it now does it properly. And counts in seconds instead of milliseconds.</>, Sharrq),
   change(date(2023, 12, 31), <>Adjusted <SpellLink spell={TALENTS.LIVING_BOMB_TALENT} /> to be acceptable to cast in AOE at 5+ targets.</>, Sharrq),

--- a/src/analysis/retail/mage/fire/CONFIG.tsx
+++ b/src/analysis/retail/mage/fire/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Sharrq],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.2.0',
+  patchCompatibility: '10.2.5',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { Raistlinn, Sharrq, ToppleTheNun } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2024, 1, 17), 'Bump to 10.2.5 support.', ToppleTheNun),
   change(date(2024, 1, 12), <>Added Guide view and Always be Casting graph.</>, Raistlinn),
   change(date(2024, 1, 6), <>Fixed a crash in <SpellLink spell={SPELLS.WINTERS_CHILL} />.</>, Sharrq),
   change(date(2024, 1, 5), 'Updated spec support to full 10.2 support.', Sharrq),

--- a/src/analysis/retail/mage/frost/CONFIG.tsx
+++ b/src/analysis/retail/mage/frost/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Sharrq],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.2.0',
+  patchCompatibility: '10.2.5',
   isPartial: false,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more. If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Remove integration-test from GHA. Bump fire and frost mage to 10.2.5 per Sharrq's request in Discord.
