### PR TITLE
simplify raid/dungeon types, fix M+ S3 icons

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -33,6 +33,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 1, 17), 'Simplify raid types and fix M+ S3 icons not showing on fight selection.',ToppleTheNun),
   change(date(2024, 1, 16), 'Add Ruby Sanctum raid and images for Classic WotLK.', jazminite),
   change(date(2024, 1, 16), 'Add patch 10.2.5.', ToppleTheNun),
   change(date(2024, 1, 11), <>Add <ItemLink id={ITEMS.POTION_OF_WITHERING_DREAMS_R3.id} /> to healing potion list.</>, ToppleTheNun),

--- a/src/game/raids/aberrus/AmalgamationChamber.ts
+++ b/src/game/raids/aberrus/AmalgamationChamber.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/AmalgamationChamber.jpg';
 import Headshot from './headshots/AmalgamationChamber.jpg';

--- a/src/game/raids/aberrus/AssaultOfTheZaqali.ts
+++ b/src/game/raids/aberrus/AssaultOfTheZaqali.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/AssaultOfTheZaqali.jpg';
 import Headshot from './headshots/AssaultOfTheZaqali.jpg';

--- a/src/game/raids/aberrus/EchoOfNeltharion.ts
+++ b/src/game/raids/aberrus/EchoOfNeltharion.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/EchoOfNeltharion.jpg';
 import Headshot from './headshots/EchoOfNeltharion.jpg';

--- a/src/game/raids/aberrus/ForgottenExperiments.ts
+++ b/src/game/raids/aberrus/ForgottenExperiments.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/ForgottenExperiments.jpg';
 import Headshot from './headshots/ForgottenExperiments.jpg';

--- a/src/game/raids/aberrus/Kazzara.ts
+++ b/src/game/raids/aberrus/Kazzara.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/Kazzara.jpg';
 import Headshot from './headshots/Kazzara.jpg';

--- a/src/game/raids/aberrus/Magmorax.ts
+++ b/src/game/raids/aberrus/Magmorax.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/Magmorax.jpg';
 import Headshot from './headshots/Magmorax.jpg';

--- a/src/game/raids/aberrus/Rashok.ts
+++ b/src/game/raids/aberrus/Rashok.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/Rashok.jpg';
 import Headshot from './headshots/Rashok.jpg';

--- a/src/game/raids/aberrus/Sarkareth.ts
+++ b/src/game/raids/aberrus/Sarkareth.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/Sarkareth.jpg';
 import Headshot from './headshots/Sarkareth.jpg';

--- a/src/game/raids/aberrus/Zskarn.ts
+++ b/src/game/raids/aberrus/Zskarn.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/Zskarn.jpg';
 import Headshot from './headshots/Zskarn.jpg';

--- a/src/game/raids/aberrus/index.ts
+++ b/src/game/raids/aberrus/index.ts
@@ -7,6 +7,7 @@ import Zskarn from 'game/raids/aberrus/Zskarn';
 import Magmorax from 'game/raids/aberrus/Magmorax';
 import EchoOfNeltharion from 'game/raids/aberrus/EchoOfNeltharion';
 import Sarkareth from 'game/raids/aberrus/Sarkareth';
+import type { Raid } from 'game/raids';
 
 import Background from './backgrounds/overview.jpg';
 
@@ -24,4 +25,4 @@ export default {
     EchoOfNeltharion,
     Sarkareth,
   },
-};
+} satisfies Raid;

--- a/src/game/raids/amirdrassil/CouncilOfDreams.ts
+++ b/src/game/raids/amirdrassil/CouncilOfDreams.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/CouncilOfDreams.png';
 import Headshot from './headshots/CouncilOfDreams.jpg';

--- a/src/game/raids/amirdrassil/Fyrakk.ts
+++ b/src/game/raids/amirdrassil/Fyrakk.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/Fyrakk.png';
 import Headshot from './headshots/Fyrakk.jpg';

--- a/src/game/raids/amirdrassil/Gnarlroot.ts
+++ b/src/game/raids/amirdrassil/Gnarlroot.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/Gnarlroot.png';
 import Headshot from './headshots/Gnarlroot.jpg';

--- a/src/game/raids/amirdrassil/Igira.ts
+++ b/src/game/raids/amirdrassil/Igira.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/Igira.png';
 import Headshot from './headshots/Igira.jpg';

--- a/src/game/raids/amirdrassil/Larodar.ts
+++ b/src/game/raids/amirdrassil/Larodar.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/Larodar.png';
 import Headshot from './headshots/Larodar.jpg';

--- a/src/game/raids/amirdrassil/Nymue.ts
+++ b/src/game/raids/amirdrassil/Nymue.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/Nymue.png';
 import Headshot from './headshots/Nymue.jpg';

--- a/src/game/raids/amirdrassil/Smolderon.ts
+++ b/src/game/raids/amirdrassil/Smolderon.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/Smolderon.png';
 import Headshot from './headshots/Smolderon.jpg';

--- a/src/game/raids/amirdrassil/Tindral.ts
+++ b/src/game/raids/amirdrassil/Tindral.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/Tindral.png';
 import Headshot from './headshots/Tindral.jpg';

--- a/src/game/raids/amirdrassil/Volcoross.ts
+++ b/src/game/raids/amirdrassil/Volcoross.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/Volcoross.png';
 import Headshot from './headshots/Volcoross.jpg';

--- a/src/game/raids/amirdrassil/index.ts
+++ b/src/game/raids/amirdrassil/index.ts
@@ -8,6 +8,7 @@ import Nymue from 'game/raids/amirdrassil/Nymue';
 import Smolderon from 'game/raids/amirdrassil/Smolderon';
 import Tindral from 'game/raids/amirdrassil/Tindral';
 import Fyrakk from 'game/raids/amirdrassil/Fyrakk';
+import type { Raid } from 'game/raids';
 
 export default {
   name: "Amirdrassil, the Dream's Hope",
@@ -23,4 +24,4 @@ export default {
     Tindral,
     Fyrakk,
   },
-};
+} satisfies Raid;

--- a/src/game/raids/icc/BloodCouncil.ts
+++ b/src/game/raids/icc/BloodCouncil.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/BloodCouncilHeadshot.jpg';
 import Background from './images/BloodCouncil.jpg';

--- a/src/game/raids/icc/BloodQueen.ts
+++ b/src/game/raids/icc/BloodQueen.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/BloodQueenHeadshot.jpg';
 import Background from './images/BloodQueen.jpg';

--- a/src/game/raids/icc/Deathwhisper.ts
+++ b/src/game/raids/icc/Deathwhisper.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/DeathwhisperHeadshot.jpg';
 import Background from './images/Deathwhisper.jpg';

--- a/src/game/raids/icc/Dreamwalker.ts
+++ b/src/game/raids/icc/Dreamwalker.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/DreamwalkerHeadshot.jpg';
 import Background from './images/Dreamwalker.jpg';

--- a/src/game/raids/icc/Festergut.ts
+++ b/src/game/raids/icc/Festergut.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/FestergutHeadshot.jpg';
 import Background from './images/Festergut.jpg';

--- a/src/game/raids/icc/Gunship.ts
+++ b/src/game/raids/icc/Gunship.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/GunshipHeadshot.jpg';
 import Background from './images/Gunship.jpg';

--- a/src/game/raids/icc/LichKing.ts
+++ b/src/game/raids/icc/LichKing.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/LichKingHeadshot.jpg';
 import Background from './images/LichKing.jpg';

--- a/src/game/raids/icc/Marrowgar.ts
+++ b/src/game/raids/icc/Marrowgar.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/MarrowgarHeadshot.jpg';
 import Background from './images/Marrowgar.jpg';

--- a/src/game/raids/icc/Putricide.ts
+++ b/src/game/raids/icc/Putricide.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/PutricideHeadshot.jpg';
 import Background from './images/Putricide.jpg';

--- a/src/game/raids/icc/Rotface.ts
+++ b/src/game/raids/icc/Rotface.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/RotfaceHeadshot.jpg';
 import Background from './images/Rotface.jpg';

--- a/src/game/raids/icc/Saurfang.ts
+++ b/src/game/raids/icc/Saurfang.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/SaurfangHeadshot.jpg';
 import Background from './images/Saurfang.jpg';

--- a/src/game/raids/icc/Sindragosa.ts
+++ b/src/game/raids/icc/Sindragosa.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/SindragosaHeadshot.jpg';
 import Background from './images/Sindragosa.jpg';

--- a/src/game/raids/icc/index.ts
+++ b/src/game/raids/icc/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+import type { Raid } from 'game/raids';
 
 export default {
   name: 'Icecrown Citadel',
@@ -16,4 +17,4 @@ export default {
     Sindragosa: require('./Sindragosa').default,
     LichKing: require('./LichKing').default,
   },
-};
+} satisfies Raid;

--- a/src/game/raids/index.ts
+++ b/src/game/raids/index.ts
@@ -16,6 +16,7 @@ interface EncounterConfig {
   disableDowntimeSuggestion?: boolean;
   disableDowntimeStatistic?: boolean;
 }
+
 export interface Boss {
   id: number;
   name: string;
@@ -25,27 +26,23 @@ export interface Boss {
   icon?: string;
   fight: EncounterConfig;
 }
-interface Raid {
-  bosses: Boss[];
+
+export interface Raid {
+  name: string;
+  background?: string;
+  bosses: Record<string, Boss>;
 }
+
 export interface Phase extends PhaseConfig {
   start: number[];
   end: number[];
-}
-export interface Dungeon {
-  id: number;
-  name: string;
-  background?: string;
-  backgroundPosition?: string;
-  headshot?: string;
-  icon?: string;
-  fight: unknown;
 }
 
 const raids = {
   // Dragonflight
   MythicPlusSeasonOne: require('./mythicplusseasonone').default,
   MythicPlusSeasonTwo: require('./mythicplusseasontwo').default,
+  MythicPlusSeasonThree: require('./mythicplusseasonthree').default,
   VaultOfTheIncarnates: require('./vaultoftheincarnates').default, // tier 29
   Aberrus: require('./aberrus').default, // tier 30
   Amirdrassil: require('./amirdrassil').default, // tier 31
@@ -53,8 +50,9 @@ const raids = {
   Ulduar: require('./ulduar').default, // tier 8
   TrialOfTheGrandCrusader: require('./trialofthegrandcrusader').default, // tier 9
   IcecrownCitadel: require('./icc').default, // tier 10
-  RubySanctum: require('./rubysanctum').default,
+  RubySanctum: require('./rubysanctum').default, // tier 11
 };
+
 export default raids;
 
 export function findByBossId(id: number): Boss | null {

--- a/src/game/raids/mythicplusseasonone/AlgetharAcademy.ts
+++ b/src/game/raids/mythicplusseasonone/AlgetharAcademy.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/AlgetharAcademy.jpg';
 import Headshot from './headshots/AlgetharAcademy.jpg';
 
-const AlgetharAcademy: Dungeon = {
+const AlgetharAcademy: Boss = {
   id: 12526,
   name: "Algeth'ar Academy",
   background: Background,

--- a/src/game/raids/mythicplusseasonone/AzureVault.ts
+++ b/src/game/raids/mythicplusseasonone/AzureVault.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/AzureVault.jpg';
 import Headshot from './headshots/AzureVault.jpg';
 
-const AzureVault: Dungeon = {
+const AzureVault: Boss = {
   id: 12515,
   name: 'The Azure Vault',
   background: Background,

--- a/src/game/raids/mythicplusseasonone/CourtOfStars.ts
+++ b/src/game/raids/mythicplusseasonone/CourtOfStars.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/CourtOfStars.jpg';
 import Headshot from './headshots/CourtOfStars.jpg';
 
-const CourtOfStars: Dungeon = {
+const CourtOfStars: Boss = {
   id: 61571,
   name: 'Court of Stars',
   background: Background,

--- a/src/game/raids/mythicplusseasonone/HallsOfValor.ts
+++ b/src/game/raids/mythicplusseasonone/HallsOfValor.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/HallsOfValor.jpg';
 import Headshot from './headshots/HallsOfValor.jpg';
 
-const HallsOfValor: Dungeon = {
+const HallsOfValor: Boss = {
   id: 61477,
   name: 'Halls of Valor',
   background: Background,

--- a/src/game/raids/mythicplusseasonone/NokhudOffensive.ts
+++ b/src/game/raids/mythicplusseasonone/NokhudOffensive.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/NokhudOffensive.jpg';
 import Headshot from './headshots/NokhudOffensive.jpg';
 
-const NokhudOffensive: Dungeon = {
+const NokhudOffensive: Boss = {
   id: 12516,
   name: 'The Nokhud Offensive',
   background: Background,

--- a/src/game/raids/mythicplusseasonone/RubyLifePools.ts
+++ b/src/game/raids/mythicplusseasonone/RubyLifePools.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/RubyLifePools.jpg';
 import Headshot from './headshots/RubyLifePools.jpg';
 
-const RubyLifePools: Dungeon = {
+const RubyLifePools: Boss = {
   id: 12521,
   name: 'Ruby Life Pools',
   background: Background,

--- a/src/game/raids/mythicplusseasonone/ShadowmoonBurialGrounds.ts
+++ b/src/game/raids/mythicplusseasonone/ShadowmoonBurialGrounds.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/ShadowmoonBurialGrounds.jpg';
 import Headshot from './headshots/ShadowmoonBurialGrounds.jpg';
 
-const ShadowmoonBurialGrounds: Dungeon = {
+const ShadowmoonBurialGrounds: Boss = {
   id: 61176,
   name: 'Shadowmoon Burial Grounds',
   background: Background,

--- a/src/game/raids/mythicplusseasonone/TempleOfTheJadeSerpent.ts
+++ b/src/game/raids/mythicplusseasonone/TempleOfTheJadeSerpent.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/TempleOfTheJadeSerpent.jpg';
 import Headshot from './headshots/TempleOfTheJadeSerpent.jpg';
 
-const TempleOfTheJadeSerpent: Dungeon = {
+const TempleOfTheJadeSerpent: Boss = {
   id: 10960,
   name: 'Temple of the Jade Serpent',
   background: Background,

--- a/src/game/raids/mythicplusseasonone/index.ts
+++ b/src/game/raids/mythicplusseasonone/index.ts
@@ -6,10 +6,11 @@ import NokhudOffensive from 'game/raids/mythicplusseasonone/NokhudOffensive';
 import RubyLifePools from 'game/raids/mythicplusseasonone/RubyLifePools';
 import ShadowmoonBurialGrounds from 'game/raids/mythicplusseasonone/ShadowmoonBurialGrounds';
 import TempleOfTheJadeSerpent from 'game/raids/mythicplusseasonone/TempleOfTheJadeSerpent';
+import type { Raid } from 'game/raids';
 
 export default {
   name: 'Mythic+ Season 1',
-  background: undefined, // TODO: Set up
+  background: undefined,
   bosses: {
     AlgetharAcademy,
     AzureVault,
@@ -20,4 +21,4 @@ export default {
     ShadowmoonBurialGrounds,
     TempleOfTheJadeSerpent,
   },
-};
+} satisfies Raid;

--- a/src/game/raids/mythicplusseasonthree/AtalDazar.ts
+++ b/src/game/raids/mythicplusseasonthree/AtalDazar.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/AtalDazar.jpg';
 import Headshot from './headshots/AtalDazar.jpg';
 
-const AtalDazar: Dungeon = {
+const AtalDazar: Boss = {
   id: 61763,
   name: "Atal'Dazar",
   background: Background,

--- a/src/game/raids/mythicplusseasonthree/BlackRookHold.ts
+++ b/src/game/raids/mythicplusseasonthree/BlackRookHold.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/BlackRookHold.jpg';
 import Headshot from './headshots/BlackRookHold.jpg';
 
-const BlackRookHold: Dungeon = {
+const BlackRookHold: Boss = {
   id: 61501,
   name: 'Black Rook Hold',
   background: Background,

--- a/src/game/raids/mythicplusseasonthree/DarkheartThicket.ts
+++ b/src/game/raids/mythicplusseasonthree/DarkheartThicket.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/DarkheartThicket.jpg';
 import Headshot from './headshots/DarkheartThicket.jpg';
 
-const DarkheartThicket: Dungeon = {
+const DarkheartThicket: Boss = {
   id: 61466,
   name: 'Darkheart Thicket',
   background: Background,

--- a/src/game/raids/mythicplusseasonthree/Everbloom.ts
+++ b/src/game/raids/mythicplusseasonthree/Everbloom.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/Everbloom.png';
 import Headshot from './headshots/Everbloom.jpg';
 
-const Everbloom: Dungeon = {
+const Everbloom: Boss = {
   id: 61279,
   name: 'The Everbloom',
   background: Background,

--- a/src/game/raids/mythicplusseasonthree/GalakrondsFall.ts
+++ b/src/game/raids/mythicplusseasonthree/GalakrondsFall.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/DawnOfTheInfinite.png';
 import Headshot from './headshots/GalakrondsFall.jpg';
 
-const GalakrondsFall: Dungeon = {
+const GalakrondsFall: Boss = {
   id: 12579,
   name: "DOTI: Galakrond's Fall",
   background: Background,

--- a/src/game/raids/mythicplusseasonthree/MurozondsRise.ts
+++ b/src/game/raids/mythicplusseasonthree/MurozondsRise.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/DawnOfTheInfinite.png';
 import Headshot from './headshots/MurozondsRise.jpg';
 
-const MurozondsRise: Dungeon = {
+const MurozondsRise: Boss = {
   id: 12580,
   name: "DOTI: Murozond's Rise",
   background: Background,

--- a/src/game/raids/mythicplusseasonthree/ThroneOfTheTides.ts
+++ b/src/game/raids/mythicplusseasonthree/ThroneOfTheTides.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/ThroneOfTheTides.png';
 import Headshot from './headshots/ThroneOfTheTides.jpg';
 
-const ThroneOfTheTides: Dungeon = {
+const ThroneOfTheTides: Boss = {
   id: 10643,
   name: 'Throne of the Tides',
   background: Background,

--- a/src/game/raids/mythicplusseasonthree/WaycrestManor.ts
+++ b/src/game/raids/mythicplusseasonthree/WaycrestManor.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/WaycrestManor.jpg';
 import Headshot from './headshots/WaycrestManor.jpg';
 
-const WaycrestManor: Dungeon = {
+const WaycrestManor: Boss = {
   id: 61862,
   name: 'Waycrest Manor',
   background: Background,

--- a/src/game/raids/mythicplusseasonthree/index.ts
+++ b/src/game/raids/mythicplusseasonthree/index.ts
@@ -6,6 +6,7 @@ import GalakrondsFall from 'game/raids/mythicplusseasonthree/GalakrondsFall';
 import MurozondsRise from 'game/raids/mythicplusseasonthree/MurozondsRise';
 import ThroneOfTheTides from 'game/raids/mythicplusseasonthree/ThroneOfTheTides';
 import WaycrestManor from 'game/raids/mythicplusseasonthree/WaycrestManor';
+import type { Raid } from 'game/raids';
 
 export default {
   name: 'Mythic+ Season 3',
@@ -20,4 +21,4 @@ export default {
     ThroneOfTheTides,
     WaycrestManor,
   },
-};
+} satisfies Raid;

--- a/src/game/raids/mythicplusseasontwo/BrackenhideHollow.ts
+++ b/src/game/raids/mythicplusseasontwo/BrackenhideHollow.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/BrackenhideHollow.jpg';
 import Headshot from './headshots/BrackenhideHollow.jpg';
 
-const BrackenhideHollow: Dungeon = {
+const BrackenhideHollow: Boss = {
   id: 12520,
   name: 'Brackenhide Hollow',
   background: Background,

--- a/src/game/raids/mythicplusseasontwo/Freehold.ts
+++ b/src/game/raids/mythicplusseasontwo/Freehold.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/Freehold.jpg';
 import Headshot from './headshots/Freehold.jpg';
 
-const Freehold: Dungeon = {
+const Freehold: Boss = {
   id: 61754,
   name: 'Freehold',
   background: Background,

--- a/src/game/raids/mythicplusseasontwo/HallsOfInfusion.ts
+++ b/src/game/raids/mythicplusseasontwo/HallsOfInfusion.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/HallsOfInfusion.jpg';
 import Headshot from './headshots/HallsOfInfusion.jpg';
 
-const HallsOfInfusion: Dungeon = {
+const HallsOfInfusion: Boss = {
   id: 12527,
   name: 'Halls of Infusion',
   background: Background,

--- a/src/game/raids/mythicplusseasontwo/NeltharionsLair.ts
+++ b/src/game/raids/mythicplusseasontwo/NeltharionsLair.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/NeltharionsLair.jpg';
 import Headshot from './headshots/NeltharionsLair.jpg';
 
-const NeltharionsLair: Dungeon = {
+const NeltharionsLair: Boss = {
   id: 61458,
   name: "Neltharion's Lair",
   background: Background,

--- a/src/game/raids/mythicplusseasontwo/Neltharus.ts
+++ b/src/game/raids/mythicplusseasontwo/Neltharus.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/Neltharus.jpg';
 import Headshot from './headshots/Neltharus.jpg';
 
-const Neltharus: Dungeon = {
+const Neltharus: Boss = {
   id: 12519,
   name: 'Neltharus',
   background: Background,

--- a/src/game/raids/mythicplusseasontwo/Uldaman.ts
+++ b/src/game/raids/mythicplusseasontwo/Uldaman.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/Uldaman.jpg';
 import Headshot from './headshots/Uldaman.jpg';
 
-const Uldaman: Dungeon = {
+const Uldaman: Boss = {
   id: 12451,
   name: 'Uldaman: Legacy of Tyr',
   background: Background,

--- a/src/game/raids/mythicplusseasontwo/Underrot.ts
+++ b/src/game/raids/mythicplusseasontwo/Underrot.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/Underrot.jpg';
 import Headshot from './headshots/Underrot.jpg';
 
-const Underrot: Dungeon = {
+const Underrot: Boss = {
   id: 61841,
   name: 'The Underrot',
   background: Background,

--- a/src/game/raids/mythicplusseasontwo/VortexPinnacle.ts
+++ b/src/game/raids/mythicplusseasontwo/VortexPinnacle.ts
@@ -1,9 +1,9 @@
-import { Dungeon } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './backgrounds/VortexPinnacle.jpg';
 import Headshot from './headshots/VortexPinnacle.jpg';
 
-const VortexPinnacle: Dungeon = {
+const VortexPinnacle: Boss = {
   id: 10657,
   name: 'The Vortex Pinnacle',
   background: Background,

--- a/src/game/raids/mythicplusseasontwo/index.ts
+++ b/src/game/raids/mythicplusseasontwo/index.ts
@@ -6,6 +6,7 @@ import Uldaman from 'game/raids/mythicplusseasontwo/Uldaman';
 import Underrot from 'game/raids/mythicplusseasontwo/Underrot';
 import NeltharionsLair from 'game/raids/mythicplusseasontwo/NeltharionsLair';
 import VortexPinnacle from 'game/raids/mythicplusseasontwo/VortexPinnacle';
+import type { Raid } from 'game/raids';
 
 export default {
   name: 'Mythic+ Season 2',
@@ -20,4 +21,4 @@ export default {
     Underrot,
     VortexPinnacle,
   },
-};
+} satisfies Raid;

--- a/src/game/raids/rubysanctum/Halion.ts
+++ b/src/game/raids/rubysanctum/Halion.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/HalionHeadshot.jpg';
 import Background from './images/Halion.jpg';

--- a/src/game/raids/rubysanctum/index.ts
+++ b/src/game/raids/rubysanctum/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import RubySanctum from './images/RubySanctum.jpg';
+import { Raid } from 'game/raids';
 
 export default {
   name: 'Ruby Sanctum',
@@ -7,4 +8,4 @@ export default {
   bosses: {
     Halion: require('./Halion').default,
   },
-};
+} satisfies Raid;

--- a/src/game/raids/trialofthegrandcrusader/Anubarak.ts
+++ b/src/game/raids/trialofthegrandcrusader/Anubarak.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/AnubarakHeadshot.jpg';
 import Background from './images/Anubarak.jpg';

--- a/src/game/raids/trialofthegrandcrusader/FactionChampions.ts
+++ b/src/game/raids/trialofthegrandcrusader/FactionChampions.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/FactionChampionsHeadshot.jpg';
 import Background from './images/FactionChampions.jpg';

--- a/src/game/raids/trialofthegrandcrusader/LordJaraxxus.ts
+++ b/src/game/raids/trialofthegrandcrusader/LordJaraxxus.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/LordJaraxxusHeadshot.jpg';
 import Background from './images/LordJaraxxus.jpg';

--- a/src/game/raids/trialofthegrandcrusader/NorthrendBeasts.ts
+++ b/src/game/raids/trialofthegrandcrusader/NorthrendBeasts.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/NorthrendBeastsHeadshot.jpg';
 import Background from './images/NorthrendBeasts.jpg';

--- a/src/game/raids/trialofthegrandcrusader/ValkyrTwins.ts
+++ b/src/game/raids/trialofthegrandcrusader/ValkyrTwins.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/ValkyrTwinsHeadshot.jpg';
 import Background from './images/ValkyrTwins.jpg';

--- a/src/game/raids/trialofthegrandcrusader/index.ts
+++ b/src/game/raids/trialofthegrandcrusader/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+import type { Raid } from 'game/raids';
 
 export default {
   name: 'Trial of the Grand Crusader', // T9
@@ -9,4 +10,4 @@ export default {
     ValkyrTwins: require('./ValkyrTwins').default, // 4
     Anubarak: require('./Anubarak').default, // 5
   },
-};
+} satisfies Raid;

--- a/src/game/raids/ulduar/Algalon.ts
+++ b/src/game/raids/ulduar/Algalon.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/AlgalonHeadshot.jpg';
 import Background from './images/Algalon.jpg';

--- a/src/game/raids/ulduar/Auriaya.ts
+++ b/src/game/raids/ulduar/Auriaya.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/AuriayaHeadshot.jpg';
 import Background from './images/Auriaya.jpg';

--- a/src/game/raids/ulduar/FlameLeviathan.ts
+++ b/src/game/raids/ulduar/FlameLeviathan.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/FlameLeviathanHeadshot.jpg';
 import Background from './images/FlameLeviathan.jpg';

--- a/src/game/raids/ulduar/Freya.ts
+++ b/src/game/raids/ulduar/Freya.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 import DIFFICULTIES from 'game/DIFFICULTIES';
 import { EventType } from 'parser/core/Events';
 import SPELLS from 'common/SPELLS/classic/raids';

--- a/src/game/raids/ulduar/GeneralVezax.ts
+++ b/src/game/raids/ulduar/GeneralVezax.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/GeneralVezaxHeadshot.jpg';
 import Background from './images/GeneralVezax.jpg';

--- a/src/game/raids/ulduar/Hodir.ts
+++ b/src/game/raids/ulduar/Hodir.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/HodirHeadshot.jpg';
 import Background from './images/Hodir.jpg';

--- a/src/game/raids/ulduar/Ignis.ts
+++ b/src/game/raids/ulduar/Ignis.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/IgnisHeadshot.jpg';
 import Background from './images/Ignis.jpg';

--- a/src/game/raids/ulduar/IronCouncil.ts
+++ b/src/game/raids/ulduar/IronCouncil.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/IronCouncilHeadshot.jpg';
 import Background from './images/IronCouncil.jpg';

--- a/src/game/raids/ulduar/Kologarn.ts
+++ b/src/game/raids/ulduar/Kologarn.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/KologarnHeadshot.jpg';
 import Background from './images/Kologarn.jpg';

--- a/src/game/raids/ulduar/Mimiron.ts
+++ b/src/game/raids/ulduar/Mimiron.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 import DIFFICULTIES from 'game/DIFFICULTIES';
 import { EventType } from 'parser/core/Events';
 import SPELLS from 'common/SPELLS/classic/raids';

--- a/src/game/raids/ulduar/Razorscale.ts
+++ b/src/game/raids/ulduar/Razorscale.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 import DIFFICULTIES from 'game/DIFFICULTIES';
 import { EventType } from 'parser/core/Events';
 

--- a/src/game/raids/ulduar/Thorim.ts
+++ b/src/game/raids/ulduar/Thorim.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/ThorimHeadshot.jpg';
 import Background from './images/Thorim.jpg';

--- a/src/game/raids/ulduar/XT002.ts
+++ b/src/game/raids/ulduar/XT002.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Headshot from './images/XT002Headshot.jpg';
 import Background from './images/XT002.jpg';

--- a/src/game/raids/ulduar/YoggSaron.ts
+++ b/src/game/raids/ulduar/YoggSaron.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 import DIFFICULTIES from 'game/DIFFICULTIES';
 import { EventType } from 'parser/core/Events';
 import SPELLS from 'common/SPELLS/classic/raids';

--- a/src/game/raids/ulduar/index.ts
+++ b/src/game/raids/ulduar/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import Ulduar from './images/Ulduar.jpg';
+import type { Raid } from 'game/raids';
 
 export default {
   name: 'Ulduar', // T8
@@ -20,4 +21,4 @@ export default {
     YoggSaron: require('./YoggSaron').default, // 13
     Algalon: require('./Algalon').default, // 14
   },
-};
+} satisfies Raid;

--- a/src/game/raids/vaultoftheincarnates/BroodkeeperDiurna.ts
+++ b/src/game/raids/vaultoftheincarnates/BroodkeeperDiurna.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './images/broodkeeper.jpg';
 

--- a/src/game/raids/vaultoftheincarnates/Dathea.ts
+++ b/src/game/raids/vaultoftheincarnates/Dathea.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './images/dathea.jpg';
 

--- a/src/game/raids/vaultoftheincarnates/Eranog.ts
+++ b/src/game/raids/vaultoftheincarnates/Eranog.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './images/eranog.jpg';
 

--- a/src/game/raids/vaultoftheincarnates/KurogGrimtotem.ts
+++ b/src/game/raids/vaultoftheincarnates/KurogGrimtotem.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './images/kurog.jpg';
 

--- a/src/game/raids/vaultoftheincarnates/PrimalCouncil.ts
+++ b/src/game/raids/vaultoftheincarnates/PrimalCouncil.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './images/primalcouncil.jpg';
 

--- a/src/game/raids/vaultoftheincarnates/Raszageth.ts
+++ b/src/game/raids/vaultoftheincarnates/Raszageth.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './images/raszageth.jpg';
 

--- a/src/game/raids/vaultoftheincarnates/Sennarth.ts
+++ b/src/game/raids/vaultoftheincarnates/Sennarth.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './images/sennarth.jpg';
 

--- a/src/game/raids/vaultoftheincarnates/Terros.ts
+++ b/src/game/raids/vaultoftheincarnates/Terros.ts
@@ -1,4 +1,4 @@
-import { Boss } from 'game/raids';
+import type { Boss } from 'game/raids';
 
 import Background from './images/terros.jpg';
 

--- a/src/game/raids/vaultoftheincarnates/index.ts
+++ b/src/game/raids/vaultoftheincarnates/index.ts
@@ -7,6 +7,7 @@ import Dathea from 'game/raids/vaultoftheincarnates/Dathea';
 import KurogGrimtotem from 'game/raids/vaultoftheincarnates/KurogGrimtotem';
 import BroodkeeperDiurna from 'game/raids/vaultoftheincarnates/BroodkeeperDiurna';
 import Raszageth from 'game/raids/vaultoftheincarnates/Raszageth';
+import type { Raid } from 'game/raids';
 
 export default {
   name: 'Vault of the Incarnates',
@@ -21,4 +22,4 @@ export default {
     BroodkeeperDiurna,
     Raszageth,
   },
-};
+} satisfies Raid;


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Fix/simplify types for raid/dungeons, fix M+ S3 icons not showing in fight selection page.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/kWdhJw3FfzL1VbZt`
- Screenshot(s):
**Before**
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/8420f76a-71bc-4237-afbe-333dfa8745bd)
**After**
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/1675d7ae-0d8c-497c-af82-11217556bc8f)
