### PR TITLE
Frost Mage: Fixed an issue where Comet Storm and Ray of Frost guide subsections were active even when player doesn't have those talents

### DIFF
--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -2,10 +2,11 @@ import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/mage';
 import { SpellLink } from 'interface';
-import { Raistlinn, Sharrq, ToppleTheNun } from 'CONTRIBUTORS';
+import { Raistlinn, Sharrq, Sref, ToppleTheNun } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2024, 1, 20), <>Fixed an issue where guide sections for Ray of Frost and Comet Storm would be active even when player doesn't have those talents.</>, Sref),
   change(date(2024, 1, 17), <>Added Icy Veins, Ray of Frost and Comet Storm to Guide View</>, Raistlinn),
   change(date(2024, 1, 17), 'Bump to 10.2.5 support.', ToppleTheNun),
   change(date(2024, 1, 12), <>Added Guide view and Always be Casting graph.</>, Raistlinn),

--- a/src/analysis/retail/mage/frost/Guide.tsx
+++ b/src/analysis/retail/mage/frost/Guide.tsx
@@ -50,8 +50,9 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
       <Section title="Core">
         {alwaysBeCastingSubsection}
         {modules.icyVeins.guideSubsection}
-        {modules.rayOfFrost.guideSubsection}
-        {modules.cometStorm.guideSubsection}
+        {info.combatant.hasTalent(TALENTS.RAY_OF_FROST_TALENT) &&
+          modules.rayOfFrost.guideSubsection}
+        {info.combatant.hasTalent(TALENTS.COMET_STORM_TALENT) && modules.cometStorm.guideSubsection}
       </Section>
     </>
   );


### PR DESCRIPTION
- Test report URL: `/report/d23LNg8XqhFZKWGk/17-Heroic+Terros+-+Kill+(5:42)/Critsangel/standard/overview`
