### PR TITLE
Fix a bunch of stuff in Eb Source Module

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { ResourceLink, SpellLink } from 'interface';
 
 export default [
+  change(date(2024, 1, 30), <>Fix more bugs in <SpellLink spell={TALENTS_EVOKER.ESSENCE_BURST_PRESERVATION_TALENT}/> source breakdown module</>, Trevor),
   change(date(2024, 1, 26), <>Fix bug in <SpellLink spell={TALENTS_EVOKER.ESSENCE_BURST_PRESERVATION_TALENT}/> source breakdown module and adjust mana costs</>, Trevor),
   change(date(2024, 1, 20), <>Add module for <SpellLink spell={TALENTS_EVOKER.ESSENCE_BURST_PRESERVATION_TALENT}/> source breakdown</>, Trevor),
   change(date(2024, 1, 20), <>Add <SpellLink spell={TALENTS_EVOKER.LIFEBIND_TALENT}/> attribution to <SpellLink spell={TALENTS_EVOKER.GRACE_PERIOD_TALENT}/> module</>, Trevor),

--- a/src/analysis/retail/evoker/preservation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/preservation/CombatLogParser.ts
@@ -49,10 +49,12 @@ import T31PrevokerSet from './modules/dragonflight/tier/T31TierSet';
 import EchoTypeBreakdown from './modules/talents/EchoTypeBreakdown';
 import {
   LeapingFlamesNormalizer,
+  LivingFlameNormalizer,
   LeapingFlames,
   SpellEssenceCost,
   EssenceTracker,
 } from '../shared';
+import EBRefreshNormalizer from './normalizers/EBRefreshNormalizer';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -61,6 +63,8 @@ class CombatLogParser extends CoreCombatLogParser {
     cooldowns: CooldownThroughputTracker,
 
     // Normalizer
+    ebRefreshNormalizer: EBRefreshNormalizer,
+    livingFlameNormalizer: LivingFlameNormalizer,
     castLinkNormalizer: CastLinkNormalizer,
     hotApplicationNormalizer: HotApplicationNormalizer,
     hotRemovalNormalizer: HotRemovalNormalizer,

--- a/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
@@ -13,6 +13,7 @@ import Events, {
 import {
   didSparkProcEssenceBurst,
   getEssenceBurstConsumeAbility,
+  isEbFromHardcast,
   isEbFromReversion,
   isEbFromT31Tier,
 } from '../../normalizers/CastLinkNormalizer';
@@ -95,7 +96,7 @@ class EssenceBurst extends Analyzer {
       source = EB_SOURCE.T31_LF;
     } else if (isEbFromReversion(event)) {
       source = EB_SOURCE.REVERSION;
-    } else {
+    } else if (isEbFromHardcast(event)) {
       source = EB_SOURCE.LF_HARDCAST;
     }
     return source;

--- a/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/CastLinkNormalizer.ts
@@ -811,8 +811,8 @@ const EVENT_LINKS: EventLink[] = [
       SPELLS.LIVING_FLAME_CAST.id,
     ],
     referencedEventType: [EventType.Cast, EventType.Damage, EventType.Heal],
-    backwardBufferMs: 1500, // very large delay between application and lf event sometimes
-    forwardBufferMs: 1500, // ordering
+    backwardBufferMs: EB_BUFFER_MS, // very large delay between application and lf event sometimes
+    forwardBufferMs: EB_BUFFER_MS,
     anyTarget: true,
     maximumLinks: 1,
     additionalCondition(linkingEvent, referencedEvent) {

--- a/src/analysis/retail/evoker/preservation/normalizers/EBRefreshNormalizer.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/EBRefreshNormalizer.ts
@@ -1,0 +1,48 @@
+import SPELLS from 'common/SPELLS';
+import { AnyEvent, EventType } from 'parser/core/Events';
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+
+const MAX_DELAY = 25;
+
+class EBRefreshNormalizer extends EventsNormalizer {
+  isEbEvent(event: AnyEvent) {
+    return (
+      (event.type === EventType.RemoveBuffStack || event.type === EventType.RefreshBuff) &&
+      event.ability.guid === SPELLS.ESSENCE_BURST_BUFF.id
+    );
+  }
+  normalize(events: AnyEvent[]) {
+    const fixedEvents: AnyEvent[] = [];
+    let skipNext = false;
+    events.forEach((event, eventIndex) => {
+      if (skipNext) {
+        skipNext = false;
+      } else if (this.isEbEvent(event)) {
+        const castTimestamp = event.timestamp;
+        // Look ahead through the events to see if there is a Refresh/RemoveStack at nearly same timestamp
+        for (
+          let nextEventIndex = eventIndex;
+          nextEventIndex < events.length - 1;
+          nextEventIndex += 1
+        ) {
+          const nextEvent = events[nextEventIndex];
+          if (this.isEbEvent(nextEvent) && nextEvent.timestamp - castTimestamp <= MAX_DELAY) {
+            // Only keep the RemoveBuffStack event
+            if (nextEvent.type === EventType.RemoveBuffStack) {
+              fixedEvents.push(nextEvent);
+            } else {
+              fixedEvents.push(event);
+            }
+            skipNext = true;
+            break;
+          }
+        }
+      } else {
+        fixedEvents.push(event);
+      }
+    });
+
+    return fixedEvents;
+  }
+}
+export default EBRefreshNormalizer;

--- a/src/analysis/retail/evoker/preservation/normalizers/EBRefreshNormalizer.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/EBRefreshNormalizer.ts
@@ -4,6 +4,10 @@ import EventsNormalizer from 'parser/core/EventsNormalizer';
 
 const MAX_DELAY = 25;
 
+/**
+ * When an EB stack is removed, a refresh buff event is generated.
+ * This normalizer removes the refresh event because it messes up analysis.
+ */
 class EBRefreshNormalizer extends EventsNormalizer {
   isEbEvent(event: AnyEvent) {
     return (

--- a/src/analysis/retail/evoker/shared/index.ts
+++ b/src/analysis/retail/evoker/shared/index.ts
@@ -1,5 +1,6 @@
 export {
   default as LeapingFlamesNormalizer,
+  default as LivingFlameNormalizer,
   getLeapingDamageEvents,
   getLeapingHealEvents,
   generatedEssenceBurst,

--- a/src/analysis/retail/evoker/shared/modules/normalizers/LivingFlameNormalizer.ts
+++ b/src/analysis/retail/evoker/shared/modules/normalizers/LivingFlameNormalizer.ts
@@ -1,0 +1,24 @@
+import SPELLS from 'common/SPELLS';
+import { AnyEvent, EventType } from 'parser/core/Events';
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+
+/**
+ * Sometimes the game generates duplicate cast events, 1 for cast spell id
+ * and the other for heal/damage id. This normalizer deletes the heal/damage id and keeps the cast id event.
+ */
+class LivingFlameNormalizer extends EventsNormalizer {
+  normalize(events: AnyEvent[]) {
+    const fixedEvents: AnyEvent[] = [];
+    events.forEach((event, eventIndex) => {
+      if (
+        event.type !== EventType.Cast ||
+        (event.ability.guid !== SPELLS.LIVING_FLAME_HEAL.id &&
+          event.ability.guid !== SPELLS.LIVING_FLAME_DAMAGE.id)
+      ) {
+        fixedEvents.push(event);
+      }
+    });
+    return fixedEvents;
+  }
+}
+export default LivingFlameNormalizer;

--- a/src/parser/retail/modules/items/dragonflight/ElementalLariat.tsx
+++ b/src/parser/retail/modules/items/dragonflight/ElementalLariat.tsx
@@ -145,7 +145,6 @@ class ElementalLariat extends Analyzer.withDependencies(deps) {
       this.gemCounts.fire,
       this.gemCounts.frost,
     ].reduce((prev, cur) => prev + (cur ? 1 : 0), 0);
-    console.log(uniqueGemTypes);
     const gemChance = [
       {
         type: 'Air',


### PR DESCRIPTION
### Description

This is a bit of doozie, but there were a few issues with the eb source module. 

- Detection for T31 2PC procs was not accurate so we change a few things around in the CastLinkNormalizer to make distinction between hardcast/tier set proc more accurate.
- Fixes detection for EB from reversion echo
- Adds normalizer to delete extra refresh events generated when a stack of EB is removed (why is this a thing???)
- Adds normalizer to delete cast events with the damage/heal living flame spell id (they are duplicates)

### Testing

- Test report URL: `report/H8LkfaYjdKVhy1v3/13-Heroic+Fyrakk+the+Blazing+-+Kill+(6:59)/Evoulker/standard/statistics`
