### PR TITLE
[Evoker] Implement Source of Magic & Potent Mana modules

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SPELLS from 'common/SPELLS/evoker';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 export default [
+    change(date(2024, 2, 3), <>Implement <SpellLink spell={TALENTS.SOURCE_OF_MAGIC_TALENT} /> and <SpellLink spell={TALENTS.POTENT_MANA_TALENT} /> modules.</>, Vollmer),
     change(date(2024, 1, 26), <>Show 4 default targets instead of 2 for Buff Helper MRT note.</>, Vollmer),
     change(date(2024, 1, 17), <>Mark as updated for 10.2.5.</>, Vollmer),
     change(date(2024, 1, 9), <>Update Buff Helper module Prescience Helper MRT note to support the new logic of the WA.</>, Vollmer),

--- a/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
@@ -41,6 +41,8 @@ import {
   SpellEssenceCost,
   EssenceTracker,
   EssenceGraph,
+  SourceOfMagic,
+  PotentMana,
 } from 'analysis/retail/evoker/shared';
 
 class CombatLogParser extends MainCombatLogParser {
@@ -51,6 +53,8 @@ class CombatLogParser extends MainCombatLogParser {
     spellEssenceCost: SpellEssenceCost,
     essenceTracker: EssenceTracker,
     essenceGraph: EssenceGraph,
+    sourceOfMagic: SourceOfMagic,
+    potentMana: PotentMana,
 
     // Normalizers
     castLinkNormalizer: CastLinkNormalizer,

--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SPELLS from 'common/SPELLS/evoker';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 export default [
+  change(date(2024, 2, 3), <>Implement <SpellLink spell={TALENTS.SOURCE_OF_MAGIC_TALENT} /> and <SpellLink spell={TALENTS.POTENT_MANA_TALENT} /> modules.</>, Vollmer),
   change(date(2024, 1, 17), <>Mark as updated for 10.2.5.</>, Vollmer),
   change(date(2023, 12, 31), <>Improved tracking of <ResourceLink id={RESOURCE_TYPES.ESSENCE.id}/> for a more precise representation on the <ResourceLink id={RESOURCE_TYPES.ESSENCE.id}/> Graph.</>, Vollmer),
   change(date(2023, 12, 6), <>Update APL Check.</>, Vollmer),

--- a/src/analysis/retail/evoker/devastation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/devastation/CombatLogParser.ts
@@ -37,6 +37,8 @@ import {
   SpellEssenceCost,
   EssenceTracker,
   EssenceGraph,
+  SourceOfMagic,
+  PotentMana,
 } from 'analysis/retail/evoker/shared';
 
 class CombatLogParser extends MainCombatLogParser {
@@ -47,6 +49,8 @@ class CombatLogParser extends MainCombatLogParser {
     spellEssenceCost: SpellEssenceCost,
     essenceTracker: EssenceTracker,
     essenceGraph: EssenceGraph,
+    sourceOfMagic: SourceOfMagic,
+    potentMana: PotentMana,
 
     // Core
     abilities: Abilities,

--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { ResourceLink, SpellLink } from 'interface';
 
 export default [
+  change(date(2024, 2, 3), <>Implement <SpellLink spell={TALENTS_EVOKER.SOURCE_OF_MAGIC_TALENT} /> and <SpellLink spell={TALENTS_EVOKER.POTENT_MANA_TALENT} /> modules.</>, Vollmer),
   change(date(2024, 1, 30), <>Fix more bugs in <SpellLink spell={TALENTS_EVOKER.ESSENCE_BURST_PRESERVATION_TALENT}/> source breakdown module</>, Trevor),
   change(date(2024, 1, 26), <>Fix bug in <SpellLink spell={TALENTS_EVOKER.ESSENCE_BURST_PRESERVATION_TALENT}/> source breakdown module and adjust mana costs</>, Trevor),
   change(date(2024, 1, 20), <>Add module for <SpellLink spell={TALENTS_EVOKER.ESSENCE_BURST_PRESERVATION_TALENT}/> source breakdown</>, Trevor),

--- a/src/analysis/retail/evoker/preservation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/preservation/CombatLogParser.ts
@@ -53,6 +53,8 @@ import {
   LeapingFlames,
   SpellEssenceCost,
   EssenceTracker,
+  SourceOfMagic,
+  PotentMana,
 } from '../shared';
 import EBRefreshNormalizer from './normalizers/EBRefreshNormalizer';
 
@@ -90,6 +92,8 @@ class CombatLogParser extends CoreCombatLogParser {
     // Shared talents
     leapingFlamesNormalizer: LeapingFlamesNormalizer,
     leapingFlames: LeapingFlames,
+    sourceOfMagic: SourceOfMagic,
+    potentMana: PotentMana,
 
     //talents
     ancientFlame: AncientFlame,

--- a/src/analysis/retail/evoker/shared/constants.ts
+++ b/src/analysis/retail/evoker/shared/constants.ts
@@ -3,3 +3,5 @@ export const BASE_ESSENCE_REGEN = 0.2;
 export const INNATE_MAGIC_REGEN = 0.05;
 
 export const BASE_MAX_ESSENCE = 5;
+
+export const POTENT_MANA_MULTIPLIER = 0.03;

--- a/src/analysis/retail/evoker/shared/index.ts
+++ b/src/analysis/retail/evoker/shared/index.ts
@@ -12,4 +12,6 @@ export { default as LeapingFlames } from './modules/talents/LeapingFlames';
 export { default as SpellEssenceCost } from './modules/core/essence/SpellEssenceCost';
 export { default as EssenceTracker } from './modules/core/essence/EssenceTracker';
 export { default as EssenceGraph } from './modules/core/essence/EssenceGraph';
+export { default as SourceOfMagic } from './modules/talents/SourceOfMagic';
+export { default as PotentMana } from './modules/talents/PotentMana';
 export * from './constants';

--- a/src/analysis/retail/evoker/shared/modules/talents/PotentMana.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/PotentMana.tsx
@@ -1,0 +1,146 @@
+import { Options } from 'parser/core/Analyzer';
+import TALENTS from 'common/TALENTS/evoker';
+import fetchWcl from 'common/fetchWclApi';
+import { WCLDamageDoneTableResponse, WCLHealing, WCLHealingTableResponse } from 'common/WCL_TYPES';
+import SourceOfMagic from './SourceOfMagic';
+import { POTENT_MANA_MULTIPLIER } from '../../constants';
+import LazyLoadStatisticBox from 'parser/ui/LazyLoadStatisticBox';
+import { SpellIcon, SpellLink } from 'interface';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import { formatNumber } from 'common/format';
+
+class PotentMana extends SourceOfMagic {
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.POTENT_MANA_TALENT);
+  }
+
+  totalHealingFromPotentMana = 0;
+  totalDamageFromPotentMana = 0;
+
+  getDamageFilter(): string {
+    const filter = this.sourceOfMagicWindows
+      .map((window) => {
+        const filter = `
+        ((source.name='${window.player}' OR source.owner.name='${window.player}') AND
+        timestamp>=${window.start - this.owner.fight.start_time} AND 
+        timestamp<=${window.end - this.owner.fight.start_time})
+        `;
+        return filter;
+      })
+      .join(' OR ');
+
+    return filter;
+  }
+
+  getHealingFilter(): string {
+    let filter = this.sourceOfMagicWindows
+      .map((window) => {
+        const filter = `
+        ((source.name='${window.player}' OR source.owner.name='${window.player}') AND
+        timestamp>=${window.start - this.owner.fight.start_time} AND 
+        timestamp<=${window.end - this.owner.fight.start_time})
+        `;
+        return filter;
+      })
+      .join(' OR ');
+
+    filter = String(filter) + 'AND effectiveHealing > 0';
+    return filter;
+  }
+
+  async load() {
+    const fetchPromises = {
+      healingTable: await fetchWcl<WCLHealingTableResponse>(
+        `report/tables/healing/${this.owner.report.code}`,
+        {
+          start: this.owner.fight.start_time,
+          end: this.owner.fight.end_time,
+          filter: this.getHealingFilter(),
+        },
+      ),
+      damageTable: await fetchWcl<WCLDamageDoneTableResponse>(
+        `report/tables/damage-done/${this.owner.report.code}`,
+        {
+          start: this.owner.fight.start_time,
+          end: this.owner.fight.end_time,
+          filter: this.getDamageFilter(),
+        },
+      ),
+    };
+
+    const [healingTable, damageTable] = await Promise.all([
+      fetchPromises.healingTable,
+      fetchPromises.damageTable,
+    ]);
+
+    this.totalHealingFromPotentMana = healingTable.entries.reduce(
+      // Because this is a % healing increase and we are unable to parse each healing event individually for its effective healing,
+      // we need to do some "approximations" using the total overheal in tandem with the total healing. We do not want to naively
+      // assume all healing was fully effective, as this would drastically overweight the power of the buff in situations where a
+      // lot of overhealing occurs.
+
+      // We increase the accuracy by only including events that had effective healing.
+      // Tested this against fetching all events and calculating the effective healing of each event and it ended up being
+      // within ~1-2% of the approximation (m+ has higher variance but w/e)
+      // The approximation is always on the lower end, so we won't be overvaluing.
+      (healingFromBuff, entry: WCLHealing) =>
+        healingFromBuff +
+        (entry.total - entry.total / (1 + POTENT_MANA_MULTIPLIER)) *
+          (entry.total / (entry.total + (entry.overheal || 0))),
+      0,
+    );
+    this.totalDamageFromPotentMana = damageTable.entries.reduce(
+      (damageFromBuff, entry) =>
+        damageFromBuff + (entry.total - entry.total / (1 + POTENT_MANA_MULTIPLIER)),
+      0,
+    );
+  }
+
+  statistic() {
+    if (!this.active) {
+      return null;
+    }
+
+    return (
+      <>
+        <LazyLoadStatisticBox
+          loader={this.load.bind(this)}
+          icon={<SpellIcon spell={TALENTS.POTENT_MANA_TALENT} />}
+          value={
+            <>
+              <div>
+                <ItemHealingDone
+                  amount={this.totalHealingFromPotentMana}
+                  displayPercentage={false}
+                  approximate
+                />
+              </div>
+              <div>
+                <ItemDamageDone
+                  amount={this.totalDamageFromPotentMana}
+                  displayPercentage={false}
+                  approximate
+                />
+              </div>
+            </>
+          }
+          label={<SpellLink spell={TALENTS.POTENT_MANA_TALENT} icon={false} />}
+          tooltip={
+            <>
+              <SpellLink spell={TALENTS.POTENT_MANA_TALENT} /> contributed ≈
+              {formatNumber(this.totalHealingFromPotentMana)} healing and ≈
+              {formatNumber(this.totalDamageFromPotentMana)} damage.
+              <br />
+              NOTE: This metric uses an approximation to calculate contribution from the buff due to
+              technical limitations.
+            </>
+          }
+        />
+      </>
+    );
+  }
+}
+
+export default PotentMana;

--- a/src/analysis/retail/evoker/shared/modules/talents/SourceOfMagic.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/SourceOfMagic.tsx
@@ -1,0 +1,148 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import TALENTS from 'common/TALENTS/evoker';
+import SPELLS from 'common/SPELLS/evoker';
+import Events, { ApplyBuffEvent, RemoveBuffEvent, ResourceChangeEvent } from 'parser/core/Events';
+import { formatNumber, formatPercentage } from 'common/format';
+import Combatants from 'parser/shared/modules/Combatants';
+import Soup from 'interface/icons/Soup';
+import { InformationIcon } from 'interface/icons';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+
+type SourceOfMagicWindow = {
+  start: number;
+  end: number;
+  player: string;
+};
+
+const MANA_POOL_SIZE = 250_000;
+
+class SourceOfMagic extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+  protected combatants!: Combatants;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.SOURCE_OF_MAGIC_TALENT);
+
+    this.addEventListener(
+      Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.SOURCE_OF_MAGIC_MANA_GAIN),
+      (event) => this.onResourceChange(event),
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(TALENTS.SOURCE_OF_MAGIC_TALENT),
+      (event) => this.onRemoveBuff(event),
+    );
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(TALENTS.SOURCE_OF_MAGIC_TALENT),
+      (event) => this.onApplyBuff(event),
+    );
+    this.addEventListener(Events.fightend, () => {
+      if (this.sourceOfMagicActive && this.sourceOfMagicWindows.length) {
+        this.sourceOfMagicWindows[this.sourceOfMagicWindows.length - 1].end =
+          this.owner.fight.end_time;
+      }
+    });
+  }
+
+  totalManaGainedFromSourceOfMagic = 0;
+  totalManaWastedFromSourceOfMagic = 0;
+
+  sourceOfMagicActive = false;
+
+  sourceOfMagicWindows: SourceOfMagicWindow[] = [];
+
+  onResourceChange(event: ResourceChangeEvent) {
+    // Just incase the applybuff didn't get fabricated properly
+    if (!this.sourceOfMagicActive) {
+      this.addSourceOfMagicWindow(event);
+      this.sourceOfMagicActive = true;
+    }
+
+    this.totalManaGainedFromSourceOfMagic += event.resourceChange - event.waste;
+    this.totalManaWastedFromSourceOfMagic += event.waste;
+  }
+
+  onApplyBuff(event: ApplyBuffEvent) {
+    this.addSourceOfMagicWindow(event);
+    this.sourceOfMagicActive = true;
+  }
+
+  onRemoveBuff(event: RemoveBuffEvent) {
+    // Just incase the applybuff didn't get fabricated properly
+    if (!this.sourceOfMagicWindows.length) {
+      this.addSourceOfMagicWindow(event, true);
+    }
+
+    const activeWindow = this.sourceOfMagicWindows.find(
+      (windows) => windows.player === this.getPlayerName(event) && windows.end === -1,
+    );
+    if (activeWindow) {
+      activeWindow.end = event.timestamp;
+    }
+
+    this.sourceOfMagicActive = false;
+  }
+
+  addSourceOfMagicWindow(
+    event: ApplyBuffEvent | ResourceChangeEvent | RemoveBuffEvent,
+    isInitial = false,
+  ) {
+    const playerName = this.getPlayerName(event);
+
+    /** Due to Source of Magic normally being applied pre-combat we usually don't
+     * have applybuff events, since we work around this by "pretending" our first
+     * resourceChange event is an applybuff event, we then need to make sure if the
+     * buff is refreshed on the same player that we don't add a new window.
+     * Since the combatlog will treat it as a new buff instead of a refresh. */
+    if (
+      this.sourceOfMagicWindows.length &&
+      this.sourceOfMagicActive &&
+      this.sourceOfMagicWindows[this.sourceOfMagicWindows.length - 1].player === playerName
+    ) {
+      return;
+    }
+
+    this.sourceOfMagicWindows.push({
+      start: isInitial ? this.owner.fight.start_time : event.timestamp,
+      end: -1,
+      player: playerName,
+    });
+  }
+
+  getPlayerName(event: ApplyBuffEvent | ResourceChangeEvent | RemoveBuffEvent): string {
+    return this.combatants.players[event.targetID].name;
+  }
+
+  statistic() {
+    if (!this.active || !this.sourceOfMagicWindows.length) {
+      return null;
+    }
+
+    return (
+      <Statistic size="flexible" category={STATISTIC_CATEGORY.TALENTS}>
+        <TalentSpellText talent={TALENTS.SOURCE_OF_MAGIC_TALENT}>
+          <div>
+            <Soup /> {formatNumber(this.totalManaGainedFromSourceOfMagic)}
+            <small>
+              {' '}
+              mana generated (
+              {formatPercentage(this.totalManaGainedFromSourceOfMagic / MANA_POOL_SIZE)}%)
+            </small>
+          </div>
+          {this.totalManaWastedFromSourceOfMagic > 0 && (
+            <div>
+              <InformationIcon /> {formatNumber(this.totalManaWastedFromSourceOfMagic)}
+              <small> mana generation wasted</small>
+            </div>
+          )}
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}
+
+export default SourceOfMagic;

--- a/src/common/SPELLS/evoker.ts
+++ b/src/common/SPELLS/evoker.ts
@@ -171,6 +171,11 @@ const spells = {
     name: 'Blessing of the Bronze',
     icon: 'ability_evoker_blessingofthebronze',
   },
+  SOURCE_OF_MAGIC_MANA_GAIN: {
+    id: 372571,
+    name: 'Source of Magic',
+    icon: 'ability_evoker_blue_01',
+  },
   LIVING_FLAME_DAMAGE: {
     id: 361500,
     name: 'Living Flame',

--- a/src/parser/ui/ItemDamageDone.tsx
+++ b/src/parser/ui/ItemDamageDone.tsx
@@ -5,15 +5,21 @@ import DamageIcon from 'interface/icons/Damage';
 interface Props {
   amount: number;
   approximate?: boolean;
+  /**
+   * @default {true}
+   */
+  displayPercentage?: boolean;
 }
 
-const ItemDamageDone = ({ amount, approximate }: Props) => {
+const ItemDamageDone = ({ amount, approximate, displayPercentage = true }: Props) => {
   const { combatLogParser: parser } = useCombatLogParser();
   return (
     <>
       <DamageIcon /> {approximate && '≈'}
       {formatNumber((amount / parser.fightDuration) * 1000)} DPS{' '}
-      <small>{formatPercentage(parser.getPercentageOfTotalDamageDone(amount))} % of total</small>
+      {displayPercentage && (
+        <small>{formatPercentage(parser.getPercentageOfTotalDamageDone(amount))} % of total</small>
+      )}
     </>
   );
 };


### PR DESCRIPTION
### Description
Implemented statistics modules for the shared Evoker talents `Source of Magic` and `Potent Mana`.

Percentage for `Source of Magic` mana gain is just the amount of a mana bar it has provided.

Enabled for all specs, tagging @trevorm4 since it includes Preservation.

- Test report URL: `/report/ZdMWQn9DvKr8HVJB/9-Mythic+Fyrakk+the+Blazing+-+Kill+(9:38)/Vollmer/standard/statistics`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/94c2fb38-4353-4e4e-9f87-417ac9b97f69)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/ab501982-f5fd-48dd-903b-83ad6a721434)
