### PR TITLE
Adding Glacial Spike, Brain Freeze and Fingers of Frost to Frost Mage Guide

### DIFF
--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -2,10 +2,11 @@ import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/mage';
 import { SpellLink } from 'interface';
-import { Raistlinn, Sharrq, Sref, ToppleTheNun } from 'CONTRIBUTORS';
+import { Earosselot, Raistlinn, Sharrq, Sref, ToppleTheNun } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2024, 2, 2), <>Added <SpellLink spell={TALENTS.GLACIAL_SPIKE_TALENT} />, <SpellLink spell={TALENTS.BRAIN_FREEZE_TALENT} /> and <SpellLink spell={TALENTS.FINGERS_OF_FROST_TALENT} /> to Guide view</>, Earosselot),
   change(date(2024, 1, 23), <>Added Winter's Chill to Guide View</>, Raistlinn),
   change(date(2024, 1, 23), 'Fix Ray of Frost Channeling.', Raistlinn),
   change(date(2024, 1, 20), <>Fixed an issue where guide sections for Ray of Frost and Comet Storm would be active even when player doesn't have those talents.</>, Sref),

--- a/src/analysis/retail/mage/frost/Guide.tsx
+++ b/src/analysis/retail/mage/frost/Guide.tsx
@@ -51,7 +51,15 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
       <Section title="Core">
         {modules.wintersChill.guideSubsection}
         {modules.flurry.guideSubsection}
+        {info.combatant.hasTalent(TALENTS.GLACIAL_SPIKE_TALENT) &&
+          modules.glacialSpike.guideSubsection}
         {alwaysBeCastingSubsection}
+      </Section>
+      <Section title="Procs">
+        {info.combatant.hasTalent(TALENTS.BRAIN_FREEZE_TALENT) &&
+          modules.brainFreeze.guideSubsection}
+        {info.combatant.hasTalent(TALENTS.FINGERS_OF_FROST_TALENT) &&
+          modules.fingersOfFrost.guideSubsection}
       </Section>
       <Section title="Cooldowns">
         {modules.icyVeins.guideSubsection}

--- a/src/analysis/retail/mage/frost/checklist/Module.tsx
+++ b/src/analysis/retail/mage/frost/checklist/Module.tsx
@@ -57,7 +57,7 @@ class Checklist extends BaseChecklist {
           icyVeinsActiveTime: this.icyVeins.icyVeinsActiveTimeThresholds,
           munchedProcs: this.fingersOfFrost.munchedProcsThresholds,
           brainFreezeUtilization: this.brainFreeze.brainFreezeUtilizationThresholds,
-          brainFreezeOverwrites: this.brainFreeze.brainFreezeOverwritenThresholds,
+          brainFreezeOverwrites: this.brainFreeze.brainFreezeOverwrittenThresholds,
           brainFreezeExpired: this.brainFreeze.brainFreezeExpiredThresholds,
           fingersOfFrostUtilization: this.fingersOfFrost.fingersProcUtilizationThresholds,
           iceLanceNotShattered: this.iceLance.nonShatteredIceLanceThresholds,

--- a/src/analysis/retail/mage/frost/core/BrainFreeze.tsx
+++ b/src/analysis/retail/mage/frost/core/BrainFreeze.tsx
@@ -94,13 +94,12 @@ class BrainFreeze extends Analyzer {
   }
 
   get utilizationPerformance() {
-    const thresholds = this.brainFreezeUtilizationThresholds;
     let performance = QualitativePerformance.Perfect;
-    if (thresholds.actual < thresholds.isLessThan.major) {
+    if (this.utilPercent < 0.8) {
       performance = QualitativePerformance.Fail;
-    } else if (thresholds.actual < thresholds.isLessThan.average) {
+    } else if (this.utilPercent < 0.9) {
       performance = QualitativePerformance.Ok;
-    } else if (thresholds.actual < thresholds.isLessThan.minor) {
+    } else if (this.utilPercent < 0.95) {
       performance = QualitativePerformance.Good;
     }
     return performance;
@@ -124,8 +123,15 @@ class BrainFreeze extends Analyzer {
   }
 
   get overwrittenPerformance() {
-    const thresholds = this.brainFreezeOverwrittenThresholds;
-    return this.thresholdsGreaterThanToQualitativePerformance(thresholds);
+    let performance = QualitativePerformance.Perfect;
+    if (this.overwrittenPercentage > 0.1) {
+      performance = QualitativePerformance.Fail;
+    } else if (this.overwrittenPercentage > 0.05) {
+      performance = QualitativePerformance.Ok;
+    } else if (this.overwrittenPercentage > 0.0) {
+      performance = QualitativePerformance.Good;
+    }
+    return performance;
   }
 
   get expiredPercentage() {
@@ -146,21 +152,12 @@ class BrainFreeze extends Analyzer {
   }
 
   get expiredPerformance() {
-    const thresholds = this.brainFreezeExpiredThresholds;
-    return this.thresholdsGreaterThanToQualitativePerformance(thresholds);
-  }
-
-  private thresholdsGreaterThanToQualitativePerformance(thresholds: {
-    actual: number;
-    isGreaterThan: { average: number; minor: number; major: number };
-    style: ThresholdStyle;
-  }) {
     let performance = QualitativePerformance.Perfect;
-    if (thresholds.actual > thresholds.isGreaterThan.major) {
+    if (this.expiredPercentage > 0.06) {
       performance = QualitativePerformance.Fail;
-    } else if (thresholds.actual > thresholds.isGreaterThan.average) {
+    } else if (this.expiredPercentage > 0.03) {
       performance = QualitativePerformance.Ok;
-    } else if (thresholds.actual > thresholds.isGreaterThan.minor) {
+    } else if (this.expiredPercentage > 0.0) {
       performance = QualitativePerformance.Good;
     }
     return performance;

--- a/src/analysis/retail/mage/frost/core/BrainFreeze.tsx
+++ b/src/analysis/retail/mage/frost/core/BrainFreeze.tsx
@@ -1,4 +1,4 @@
-import { formatNumber, formatPercentage } from 'common/format';
+import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/mage';
 import { SpellIcon, SpellLink, TooltipElement } from 'interface';
@@ -59,10 +59,6 @@ class BrainFreeze extends Analyzer {
 
   onBrainFreezeRefresh(event: RefreshBuffEvent) {
     this.brainFreezeRefreshes += 1;
-  }
-
-  get overlappedFlurries() {
-    return this.flurry.flurryEvents.filter((f) => f.overlapped).length;
   }
 
   get expiredProcs() {
@@ -170,17 +166,6 @@ class BrainFreeze extends Analyzer {
     return performance;
   }
 
-  get overlappedFlurryThresholds() {
-    return {
-      actual: this.overlappedFlurries,
-      isGreaterThan: {
-        average: 0,
-        major: 3,
-      },
-      style: ThresholdStyle.NUMBER,
-    };
-  }
-
   suggestions(when: When) {
     when(this.brainFreezeOverwrittenThresholds).addSuggestion((suggest, actual, recommended) =>
       suggest(
@@ -208,22 +193,6 @@ class BrainFreeze extends Analyzer {
         .icon(TALENTS.BRAIN_FREEZE_TALENT.icon)
         .actual(`${formatPercentage(actual)}% expired`)
         .recommended(`Letting none expire is recommended`),
-    );
-    when(this.overlappedFlurryThresholds).addSuggestion((suggest, actual, recommended) =>
-      suggest(
-        <>
-          You cast <SpellLink spell={TALENTS.FLURRY_TALENT} /> and applied{' '}
-          <SpellLink spell={SPELLS.WINTERS_CHILL} /> while the target still had the{' '}
-          <SpellLink spell={SPELLS.WINTERS_CHILL} /> debuff on them {this.overlappedFlurries} times.
-          Casting <SpellLink spell={TALENTS.FLURRY_TALENT} /> applies 2 stacks of{' '}
-          <SpellLink spell={SPELLS.WINTERS_CHILL} /> to the target so you should always ensure you
-          are spending both stacks before you cast <SpellLink spell={TALENTS.FLURRY_TALENT} /> and
-          apply <SpellLink spell={SPELLS.WINTERS_CHILL} /> again.
-        </>,
-      )
-        .icon(TALENTS.FLURRY_TALENT.icon)
-        .actual(`${formatNumber(actual)} casts`)
-        .recommended(`Casting none is recommended`),
     );
   }
 

--- a/src/analysis/retail/mage/frost/core/FingersOfFrost.tsx
+++ b/src/analysis/retail/mage/frost/core/FingersOfFrost.tsx
@@ -1,7 +1,7 @@
 import { formatPercentage, formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/mage';
-import { SpellLink } from 'interface';
+import { SpellIcon, SpellLink, TooltipElement } from 'interface';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
 import Events, {
   DamageEvent,
@@ -17,6 +17,11 @@ import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import { SHATTER_DEBUFFS } from '../../shared';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import { qualitativePerformanceToColor } from 'interface/guide';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { GUIDE_CORE_EXPLANATION_PERCENT } from 'analysis/retail/mage/frost/Guide';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 
 class FingersOfFrost extends Analyzer {
   static dependencies = {
@@ -99,9 +104,18 @@ class FingersOfFrost extends Analyzer {
     };
   }
 
+  get munchedPerformance() {
+    const thresholds = this.munchedProcsThresholds;
+    return this.thresholdsGreaterThanToQualitativePerformance(thresholds);
+  }
+
+  get utilizationPercentage() {
+    return 1 - this.expiredProcs / this.totalProcs || 0;
+  }
+
   get fingersProcUtilizationThresholds() {
     return {
-      actual: 1 - this.expiredProcs / this.totalProcs || 0,
+      actual: this.utilizationPercentage,
       isLessThan: {
         minor: 0.95,
         average: 0.85,
@@ -109,6 +123,35 @@ class FingersOfFrost extends Analyzer {
       },
       style: ThresholdStyle.PERCENTAGE,
     };
+  }
+
+  get utilizationPerformance() {
+    const thresholds = this.fingersProcUtilizationThresholds;
+    let performance = QualitativePerformance.Perfect;
+    if (thresholds.actual < thresholds.isLessThan.major) {
+      performance = QualitativePerformance.Fail;
+    } else if (thresholds.actual < thresholds.isLessThan.average) {
+      performance = QualitativePerformance.Ok;
+    } else if (thresholds.actual < thresholds.isLessThan.minor) {
+      performance = QualitativePerformance.Good;
+    }
+    return performance;
+  }
+
+  private thresholdsGreaterThanToQualitativePerformance(thresholds: {
+    actual: number;
+    isGreaterThan: { average: number; minor: number; major: number };
+    style: ThresholdStyle;
+  }) {
+    let performance = QualitativePerformance.Perfect;
+    if (thresholds.actual > thresholds.isGreaterThan.major) {
+      performance = QualitativePerformance.Fail;
+    } else if (thresholds.actual > thresholds.isGreaterThan.average) {
+      performance = QualitativePerformance.Ok;
+    } else if (thresholds.actual > thresholds.isGreaterThan.minor) {
+      performance = QualitativePerformance.Good;
+    }
+    return performance;
   }
 
   suggestions(when: When) {
@@ -158,6 +201,68 @@ class FingersOfFrost extends Analyzer {
           {formatNumber(this.averageSpendDelaySeconds)}s <small>Avg. delay to spend procs</small>
         </BoringSpellValueText>
       </Statistic>
+    );
+  }
+
+  get guideSubsection() {
+    const fingersOfFrost = <SpellLink spell={TALENTS.FINGERS_OF_FROST_TALENT} />;
+    const brainFreeze = <SpellLink spell={TALENTS.BRAIN_FREEZE_TALENT} />;
+    const wintersChill = <SpellLink spell={SPELLS.WINTERS_CHILL} />;
+
+    const fingersOfFrostIcon = <SpellIcon spell={TALENTS.FINGERS_OF_FROST_TALENT} />;
+
+    const explanation = (
+      <>
+        Try to utilize {fingersOfFrost} procs before {brainFreeze} if you have both of them.
+        "Munching" a proc refers to a situation where you have a {fingersOfFrost} proc at the same
+        time that {wintersChill} is on the target. This essentially leads to a wasted
+        {fingersOfFrost} proc since {fingersOfFrost} and {wintersChill} both do the same thing.
+        Because of the way {fingersOfFrost} works, this is sometimes unavoidable.
+      </>
+    );
+
+    const utilizationTooltip = (
+      <>
+        {this.totalProcs - this.expiredProcs} / {this.totalProcs} procs
+      </>
+    );
+
+    const munchedTooltip = <>{this.munchedProcs} procs</>;
+
+    const data = (
+      <div>
+        <RoundedPanel>
+          <div
+            style={{
+              color: qualitativePerformanceToColor(this.utilizationPerformance),
+              fontSize: '20px',
+            }}
+          >
+            {fingersOfFrostIcon}{' '}
+            <TooltipElement content={utilizationTooltip}>
+              {formatPercentage(this.utilizationPercentage, 0)} % <small>utilization</small>
+            </TooltipElement>
+          </div>
+          <div
+            style={{
+              color: qualitativePerformanceToColor(this.munchedPerformance),
+              fontSize: '20px',
+            }}
+          >
+            {fingersOfFrostIcon}{' '}
+            <TooltipElement content={munchedTooltip}>
+              {formatPercentage(this.munchedPercent, 0)} % <small>munched</small>
+            </TooltipElement>
+          </div>
+        </RoundedPanel>
+      </div>
+    );
+
+    return explanationAndDataSubsection(
+      explanation,
+      data,
+      GUIDE_CORE_EXPLANATION_PERCENT,
+      'Fingers of Frost',
     );
   }
 }

--- a/src/analysis/retail/mage/frost/core/FingersOfFrost.tsx
+++ b/src/analysis/retail/mage/frost/core/FingersOfFrost.tsx
@@ -212,13 +212,18 @@ class FingersOfFrost extends Analyzer {
     const fingersOfFrostIcon = <SpellIcon spell={TALENTS.FINGERS_OF_FROST_TALENT} />;
 
     const explanation = (
-      <>
-        Try to utilize {fingersOfFrost} procs before {brainFreeze} if you have both of them.
-        "Munching" a proc refers to a situation where you have a {fingersOfFrost} proc at the same
-        time that {wintersChill} is on the target. This essentially leads to a wasted
-        {fingersOfFrost} proc since {fingersOfFrost} and {wintersChill} both do the same thing.
-        Because of the way {fingersOfFrost} works, this is sometimes unavoidable.
-      </>
+      <div>
+        <p>
+          Try to utilize {fingersOfFrost} procs before {brainFreeze} if you have both of them. By
+          doing this you will avoid "munching" {fingersOfFrost} procs.
+        </p>
+        <p>
+          "Munching" a proc refers to a situation where you have a {fingersOfFrost} proc at the same
+          time that {wintersChill} is on the target. This essentially leads to a wasted
+          {fingersOfFrost} proc since {fingersOfFrost} and {wintersChill} both do the same thing.
+          Because of the way {fingersOfFrost} works, this is sometimes unavoidable.
+        </p>
+      </div>
     );
 
     const utilizationTooltip = (

--- a/src/analysis/retail/mage/frost/core/FingersOfFrost.tsx
+++ b/src/analysis/retail/mage/frost/core/FingersOfFrost.tsx
@@ -105,8 +105,15 @@ class FingersOfFrost extends Analyzer {
   }
 
   get munchedPerformance() {
-    const thresholds = this.munchedProcsThresholds;
-    return this.thresholdsGreaterThanToQualitativePerformance(thresholds);
+    let performance = QualitativePerformance.Perfect;
+    if (this.munchedPercent > 0.3) {
+      performance = QualitativePerformance.Fail;
+    } else if (this.munchedPercent > 0.2) {
+      performance = QualitativePerformance.Ok;
+    } else if (this.munchedPercent > 0.1) {
+      performance = QualitativePerformance.Good;
+    }
+    return performance;
   }
 
   get utilizationPercentage() {
@@ -126,29 +133,12 @@ class FingersOfFrost extends Analyzer {
   }
 
   get utilizationPerformance() {
-    const thresholds = this.fingersProcUtilizationThresholds;
     let performance = QualitativePerformance.Perfect;
-    if (thresholds.actual < thresholds.isLessThan.major) {
+    if (this.utilizationPercentage < 0.7) {
       performance = QualitativePerformance.Fail;
-    } else if (thresholds.actual < thresholds.isLessThan.average) {
+    } else if (this.utilizationPercentage < 0.85) {
       performance = QualitativePerformance.Ok;
-    } else if (thresholds.actual < thresholds.isLessThan.minor) {
-      performance = QualitativePerformance.Good;
-    }
-    return performance;
-  }
-
-  private thresholdsGreaterThanToQualitativePerformance(thresholds: {
-    actual: number;
-    isGreaterThan: { average: number; minor: number; major: number };
-    style: ThresholdStyle;
-  }) {
-    let performance = QualitativePerformance.Perfect;
-    if (thresholds.actual > thresholds.isGreaterThan.major) {
-      performance = QualitativePerformance.Fail;
-    } else if (thresholds.actual > thresholds.isGreaterThan.average) {
-      performance = QualitativePerformance.Ok;
-    } else if (thresholds.actual > thresholds.isGreaterThan.minor) {
+    } else if (this.utilizationPercentage < 0.95) {
       performance = QualitativePerformance.Good;
     }
     return performance;

--- a/src/analysis/retail/mage/frost/core/WintersChill.tsx
+++ b/src/analysis/retail/mage/frost/core/WintersChill.tsx
@@ -58,6 +58,15 @@ class WintersChill extends Analyzer {
     this.addEventListener(Events.fightend, this.analyzeCasts);
   }
 
+  wasShattered(event: DamageEvent | undefined): boolean {
+    if (event === undefined) {
+      return false;
+    }
+    return this.wintersChill.some((wintersChillEvent) =>
+      wintersChillEvent.damageEvents.includes(event),
+    );
+  }
+
   onWintersChill(event: ApplyDebuffEvent) {
     const remove: RemoveDebuffEvent | undefined = GetRelatedEvent(event, 'DebuffRemove');
     const flurry: CastEvent | undefined = GetRelatedEvent(event, 'SpellCast');

--- a/src/analysis/retail/mage/frost/talents/Flurry.tsx
+++ b/src/analysis/retail/mage/frost/talents/Flurry.tsx
@@ -12,6 +12,8 @@ import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import DonutChart from 'parser/ui/DonutChart';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { GUIDE_CORE_EXPLANATION_PERCENT } from 'analysis/retail/mage/frost/Guide';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import { formatNumber } from 'common/format';
 
 const REDUCTION_MS = 30000;
 const colors = ['#3a91c2', '#5fc047', '#a51c37'];
@@ -75,6 +77,40 @@ class Flurry extends Analyzer {
     });
 
     return flurryCasts;
+  }
+
+  get overlapped() {
+    return this.flurryEvents.filter((f) => f.overlapped).length;
+  }
+
+  get overlappedThresholds() {
+    return {
+      actual: this.overlapped,
+      isGreaterThan: {
+        average: 0,
+        major: 3,
+      },
+      style: ThresholdStyle.NUMBER,
+    };
+  }
+
+  suggestions(when: When) {
+    when(this.overlappedThresholds).addSuggestion((suggest, actual, recommended) =>
+      suggest(
+        <>
+          You cast <SpellLink spell={TALENTS.FLURRY_TALENT} /> and applied{' '}
+          <SpellLink spell={SPELLS.WINTERS_CHILL} /> while the target still had the{' '}
+          <SpellLink spell={SPELLS.WINTERS_CHILL} /> debuff on them {this.overlapped} times. Casting{' '}
+          <SpellLink spell={TALENTS.FLURRY_TALENT} /> applies 2 stacks of{' '}
+          <SpellLink spell={SPELLS.WINTERS_CHILL} /> to the target so you should always ensure you
+          are spending both stacks before you cast <SpellLink spell={TALENTS.FLURRY_TALENT} /> and
+          apply <SpellLink spell={SPELLS.WINTERS_CHILL} /> again.
+        </>,
+      )
+        .icon(TALENTS.FLURRY_TALENT.icon)
+        .actual(`${formatNumber(actual)} casts`)
+        .recommended(`Casting none is recommended`),
+    );
   }
 
   _gainCharge() {

--- a/src/analysis/retail/mage/frost/talents/GlacialSpike.tsx
+++ b/src/analysis/retail/mage/frost/talents/GlacialSpike.tsx
@@ -10,7 +10,7 @@ import { explanationAndDataSubsection } from 'interface/guide/components/Explana
 import { GUIDE_CORE_EXPLANATION_PERCENT } from 'analysis/retail/mage/frost/Guide';
 import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
-import { BadColor, GoodColor, OkColor, PerformanceMark } from 'interface/guide';
+import { PerformanceMark, qualitativePerformanceToColor } from 'interface/guide';
 import { formatNumber, formatPercentage } from 'common/format';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { SpellIcon, SpellLink, TooltipElement } from 'interface';
@@ -94,15 +94,6 @@ class GlacialSpike extends Analyzer {
     });
   }
 
-  private textColor() {
-    if (this.performance === QualitativePerformance.Fail) {
-      return BadColor;
-    } else if (this.performance === QualitativePerformance.Ok) {
-      return OkColor;
-    }
-    return GoodColor;
-  }
-
   get performance() {
     let performance = QualitativePerformance.Fail;
     if (this.shatterPercentage > 0.8) {
@@ -161,15 +152,14 @@ class GlacialSpike extends Analyzer {
       </div>
     );
     const tooltip = (
-      <small>
-        {' '}
+      <>
         {this.shatteredCasts}/{this.totalCasts} casts
-      </small>
+      </>
     );
     const data = (
       <div>
         <RoundedPanel>
-          <div style={{ color: this.textColor(), fontSize: '20px' }}>
+          <div style={{ color: qualitativePerformanceToColor(this.performance), fontSize: '20px' }}>
             {glacialSpikeIcon}{' '}
             <TooltipElement content={tooltip}>
               {formatPercentage(this.shatterPercentage, 0)} % <small>shattered</small>

--- a/src/analysis/retail/mage/frost/talents/GlacialSpike.tsx
+++ b/src/analysis/retail/mage/frost/talents/GlacialSpike.tsx
@@ -1,17 +1,29 @@
 import { SHATTER_DEBUFFS } from 'analysis/retail/mage/shared';
 import TALENTS from 'common/TALENTS/mage';
-import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
-import Events, { CastEvent, DamageEvent, GetRelatedEvent } from 'parser/core/Events';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent, DamageEvent, FightEndEvent, GetRelatedEvent } from 'parser/core/Events';
 import Enemies from 'parser/shared/modules/Enemies';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { GUIDE_CORE_EXPLANATION_PERCENT } from 'analysis/retail/mage/frost/Guide';
+import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import { BadColor, GoodColor, OkColor, PerformanceMark } from 'interface/guide';
+import { formatNumber, formatPercentage } from 'common/format';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import { SpellIcon, SpellLink, TooltipElement } from 'interface';
+import WintersChill from 'analysis/retail/mage/frost/core/WintersChill';
 
 class GlacialSpike extends Analyzer {
   static dependencies = {
     enemies: Enemies,
+    wintersChill: WintersChill,
   };
   protected enemies!: Enemies;
+  protected wintersChill!: WintersChill;
+  castEntries: BoxRowEntry[] = [];
 
   glacialSpike: {
     timestamp: number;
@@ -28,20 +40,81 @@ class GlacialSpike extends Analyzer {
       Events.cast.by(SELECTED_PLAYER).spell(TALENTS.GLACIAL_SPIKE_TALENT),
       this.onGlacialSpikeCast,
     );
+    this.addEventListener(Events.fightend, this.onFightEnd);
   }
 
   onGlacialSpikeCast(event: CastEvent) {
     const damage: DamageEvent | undefined = GetRelatedEvent(event, 'SpellDamage');
     const enemy = damage && this.enemies.getEntity(damage);
     const cleave: DamageEvent | undefined = GetRelatedEvent(event, 'CleaveDamage');
-    this.glacialSpike.push({
+    const glacialSpikeDetails = {
       timestamp: event.timestamp,
       shattered:
-        (enemy && SHATTER_DEBUFFS.some((effect) => enemy.hasBuff(effect.id, event.timestamp))) ||
+        (enemy && SHATTER_DEBUFFS.some((effect) => enemy.hasBuff(effect.id, damage.timestamp))) ||
         false,
       damage: damage,
       cleave: cleave,
+    };
+    this.glacialSpike.push(glacialSpikeDetails);
+  }
+
+  onFightEnd(event: FightEndEvent) {
+    this.amendShatters();
+    this.analyzeGlacialSpikes();
+  }
+
+  amendShatters() {
+    this.glacialSpike.forEach((glacialSpike) => {
+      if (glacialSpike.shattered !== this.wintersChill.wasShattered(glacialSpike.damage)) {
+        console.log('not consistent');
+        glacialSpike.shattered = this.wintersChill.wasShattered(glacialSpike.damage);
+      }
     });
+  }
+
+  analyzeGlacialSpikes() {
+    this.glacialSpike.forEach((glacialSpike) => {
+      let performance = QualitativePerformance.Fail;
+      const number = glacialSpike.damage?.amount || 0;
+      const count = `${formatNumber(number)}`;
+      if (glacialSpike.shattered) {
+        performance = QualitativePerformance.Good;
+      }
+      const tooltip = (
+        <>
+          <div>
+            <b>@ {this.owner.formatTimestamp(glacialSpike.timestamp)}</b>
+          </div>
+          <div>
+            <PerformanceMark perf={performance} /> {performance}: {count}
+          </div>
+        </>
+      );
+      this.castEntries.push({ value: performance, tooltip });
+    });
+  }
+
+  private textColor() {
+    if (this.performance === QualitativePerformance.Fail) {
+      return BadColor;
+    } else if (this.performance === QualitativePerformance.Ok) {
+      return OkColor;
+    }
+    return GoodColor;
+  }
+
+  get performance() {
+    let performance = QualitativePerformance.Fail;
+    if (this.shatterPercentage > 0.8) {
+      performance = QualitativePerformance.Good;
+    } else if (this.shatterPercentage > 0.7) {
+      performance = QualitativePerformance.Ok;
+    }
+    return performance;
+  }
+
+  get shatterPercentage() {
+    return this.shatteredCasts / this.totalCasts;
   }
 
   get shatteredCasts() {
@@ -70,6 +143,49 @@ class GlacialSpike extends Analyzer {
           {this.totalCasts - this.shatteredCasts} <small>Non-Shattered Casts</small>
         </BoringSpellValueText>
       </Statistic>
+    );
+  }
+
+  get guideSubsection(): JSX.Element {
+    const glacialSpike = <SpellLink spell={TALENTS.GLACIAL_SPIKE_TALENT} />;
+    const flurry = <SpellLink spell={TALENTS.FLURRY_TALENT} />;
+
+    const glacialSpikeIcon = (
+      <SpellIcon spell={TALENTS.GLACIAL_SPIKE_TALENT} style={{ height: '28px' }} />
+    );
+
+    const explanation = (
+      <div>
+        You want to shatter {glacialSpike} as much as you can. Try to use {flurry} as indicated to
+        increase the chances of having shatter available for {glacialSpike}.
+      </div>
+    );
+    const tooltip = (
+      <small>
+        {' '}
+        {this.shatteredCasts}/{this.totalCasts} casts
+      </small>
+    );
+    const data = (
+      <div>
+        <RoundedPanel>
+          <div style={{ color: this.textColor(), fontSize: '20px' }}>
+            {glacialSpikeIcon}{' '}
+            <TooltipElement content={tooltip}>
+              {formatPercentage(this.shatterPercentage, 0)} % <small>shattered</small>
+            </TooltipElement>
+          </div>
+          <strong>{glacialSpike} cast details</strong>
+          <PerformanceBoxRow values={this.castEntries} />
+        </RoundedPanel>
+      </div>
+    );
+
+    return explanationAndDataSubsection(
+      explanation,
+      data,
+      GUIDE_CORE_EXPLANATION_PERCENT,
+      'Glacial Spike',
     );
   }
 }

--- a/src/analysis/retail/mage/frost/talents/GlacialSpike.tsx
+++ b/src/analysis/retail/mage/frost/talents/GlacialSpike.tsx
@@ -15,6 +15,7 @@ import { formatNumber, formatPercentage } from 'common/format';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { SpellIcon, SpellLink, TooltipElement } from 'interface';
 import WintersChill from 'analysis/retail/mage/frost/core/WintersChill';
+import SPELLS from 'common/SPELLS';
 
 class GlacialSpike extends Analyzer {
   static dependencies = {
@@ -140,16 +141,18 @@ class GlacialSpike extends Analyzer {
   get guideSubsection(): JSX.Element {
     const glacialSpike = <SpellLink spell={TALENTS.GLACIAL_SPIKE_TALENT} />;
     const flurry = <SpellLink spell={TALENTS.FLURRY_TALENT} />;
+    const wintersChill = <SpellLink spell={SPELLS.WINTERS_CHILL} />;
 
     const glacialSpikeIcon = (
       <SpellIcon spell={TALENTS.GLACIAL_SPIKE_TALENT} style={{ height: '28px' }} />
     );
 
     const explanation = (
-      <div>
-        You want to shatter {glacialSpike} as much as you can. Try to use {flurry} as indicated to
-        increase the chances of having shatter available for {glacialSpike}.
-      </div>
+      <p>
+        You want to shatter {glacialSpike} as much as you can. Try to use {flurry} as indicated
+        above to increase your chances of having a {wintersChill} charge available for{' '}
+        {glacialSpike}.
+      </p>
     );
     const tooltip = (
       <>


### PR DESCRIPTION
### Description

Adding these new modules to the frost mage guide: Glacial Spike, Brain Freeze and Fingers of Frost.
Fixed a bug where Glacial Spike where not analyzed as shattered even tough they were shattered.

With this PR I think the Guide is complete (imo), but let me know if you find anything that should be included.
If nothing else is needed I will send a new PR setting guide view to default. There we can correct the typos or grammatical issues of the complete guide as we agreed with @Sharrq in the first guide PR. 

- Screenshot(s):

![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/32552126/407f41c1-12d9-4e25-b4ed-d4a29f048b0e)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/32552126/f8211263-3152-4295-aa25-92ff6f2f21a6)

