### PR TITLE
Druid Guardian - fixed an issue where maul ability definition is disabled when Raze is talented (Raze no longer replaces Maul as of 10.1.5)

### DIFF
--- a/src/analysis/retail/druid/guardian/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/guardian/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2024, 2, 6), <>Fixed an issue where <SpellLink spell={SPELLS.MAUL} /> would show as not having a GCD when player is talented for <SpellLink spell={TALENTS_DRUID.RAZE_TALENT} /></>, Sref),
   change(date(2024, 1, 19), <>Marked up to date for 10.2.5</>, Sref),
   change(date(2023, 11, 11), <>Added active time graph to Guide.</>, Sref),
   change(date(2023, 11, 9), <>Added simple spell usage stats for <SpellLink spell={SPELLS.MANGLE_BEAR} />, <SpellLink spell={SPELLS.THRASH_BEAR} />, and <SpellLink spell={SPELLS.MOONFIRE_CAST} />. Marked as updated for 10.2.</>, Sref),

--- a/src/analysis/retail/druid/guardian/modules/Abilities.ts
+++ b/src/analysis/retail/druid/guardian/modules/Abilities.ts
@@ -72,7 +72,6 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.MAUL.id,
-        enabled: !combatant.hasTalent(TALENTS_DRUID.RAZE_TALENT),
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: {
           base: 1500,


### PR DESCRIPTION
This was causing Maul to show as not having a GCD when Raze is talented, with consequences in active time calculation and timeline
