### PR TITLE
fix crash caused by bad ad provider links

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -33,8 +33,9 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 2, 7), 'Fix a crash caused by bad ads.', ToppleTheNun),
   change(date(2024, 1, 19), 'Fix Dreaming Devotion showing as a cheap enchant.', emallson),
-  change(date(2024, 1, 17), 'Simplify raid types and fix M+ S3 icons not showing on fight selection.',ToppleTheNun),
+  change(date(2024, 1, 17), 'Simplify raid types and fix M+ S3 icons not showing on fight selection.', ToppleTheNun),
   change(date(2024, 1, 16), 'Add Ruby Sanctum raid and images for Classic WotLK.', jazminite),
   change(date(2024, 1, 16), 'Add patch 10.2.5.', ToppleTheNun),
   change(date(2024, 1, 11), <>Add <ItemLink id={ITEMS.POTION_OF_WITHERING_DREAMS_R3.id} /> to healing potion list.</>, ToppleTheNun),

--- a/src/interface/Ad.tsx
+++ b/src/interface/Ad.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useCallback, useState } from 'react';
+import React, { useEffect, useCallback, useState, Component, ReactNode, ErrorInfo } from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import { captureException } from 'common/errorLogger';
 
 import styles from './Ad.module.scss';
 import usePremium from './usePremium';
@@ -113,5 +114,35 @@ export function destroyAds() {
 
   if (destroy) {
     destroy('all');
+  }
+}
+
+interface AdErrorBoundaryProps {
+  children: ReactNode;
+}
+interface AdErrorBoundaryState {
+  hasError: boolean;
+}
+// Error Boundaries must be written as class components
+// eslint-disable-next-line react/prefer-stateless-function
+export class AdErrorBoundary extends Component<AdErrorBoundaryProps, AdErrorBoundaryState> {
+  public state: AdErrorBoundaryState = {
+    hasError: false,
+  };
+
+  public static getDerivedStateFromError(_: Error): AdErrorBoundaryState {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    captureException(error);
+  }
+
+  public render() {
+    if (this.state.hasError) {
+      return null;
+    }
+    return this.props.children;
   }
 }

--- a/src/interface/Home.tsx
+++ b/src/interface/Home.tsx
@@ -1,5 +1,5 @@
 import { Trans } from '@lingui/macro';
-import Ad, { Location } from 'interface/Ad';
+import Ad, { AdErrorBoundary, Location } from 'interface/Ad';
 import ErrorBoundary from 'interface/ErrorBoundary';
 import FingerprintFilledIcon from 'interface/icons/FingerprintFilled';
 import HelpWantedIcon from 'interface/icons/Information';
@@ -57,7 +57,11 @@ const Home = () => {
 
       <ReportSelectionHeader />
 
-      {premium === false && <Ad location={Location.Top} style={{ marginTop: '-20px' }} />}
+      {premium === false && (
+        <AdErrorBoundary>
+          <Ad location={Location.Top} style={{ marginTop: '-20px' }} />
+        </AdErrorBoundary>
+      )}
 
       <main className="container">
         <nav>

--- a/src/interface/report/Results/Header.tsx
+++ b/src/interface/report/Results/Header.tsx
@@ -2,7 +2,7 @@
 import getBossName from 'common/getBossName';
 import { getLabel as getDifficultyLabel } from 'game/DIFFICULTIES';
 import { Boss, Phase } from 'game/raids';
-import Ad, { Location } from 'interface/Ad';
+import Ad, { AdErrorBoundary, Location } from 'interface/Ad';
 import Config from 'parser/Config';
 import { ParseResultsTab } from 'parser/core/Analyzer';
 import CharacterProfile from 'parser/core/CharacterProfile';
@@ -71,7 +71,9 @@ const Header = ({
     <header>
       <HeaderBackground boss={boss} expansion={expansion} />
 
-      <Ad location={Location.Top} />
+      <AdErrorBoundary>
+        <Ad location={Location.Top} />
+      </AdErrorBoundary>
 
       <div className="subnavigation container">
         {phases && Object.keys(phases).length > 0 && (


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Fix a crash caused by bad ad provider links.

Crash stack trace:
```
TypeError: Failed to fetch
    at E.e (https://wowanalyzer.com/static/js/main.19aa4111.js:4:1485698)
    at t.<anonymous> (https://c.amazon-adsystem.com/aax2/apstag.js:2:9756)
    at https://c.amazon-adsystem.com/aax2/apstag.js:2:2039
    at Object.next (https://c.amazon-adsystem.com/aax2/apstag.js:2:2144)
    at https://c.amazon-adsystem.com/aax2/apstag.js:2:1060
    at new Promise (<anonymous>)
    at u (https://c.amazon-adsystem.com/aax2/apstag.js:2:805)
    at t.sendRecords (https://c.amazon-adsystem.com/aax2/apstag.js:2:9664)
    at t.processEventRecords (https://c.amazon-adsystem.com/aax2/apstag.js:2:9578)
    at https://c.amazon-adsystem.com/aax2/apstag.js:2:8959
    at d (https://wowanalyzer.com/static/js/main.19aa4111.js:4:1414861)
```
