### PR TITLE
mark 10.2.0 as not current

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -33,6 +33,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 2, 7), 'Mark 10.2.0 as an old patch.', ToppleTheNun),
   change(date(2024, 2, 7), 'Fix a crash caused by bad ads.', ToppleTheNun),
   change(date(2024, 1, 19), 'Fix Dreaming Devotion showing as a cheap enchant.', emallson),
   change(date(2024, 1, 17), 'Simplify raid types and fix M+ S3 icons not showing on fight selection.', ToppleTheNun),

--- a/src/interface/report/PATCHES.ts
+++ b/src/interface/report/PATCHES.ts
@@ -149,7 +149,7 @@ const PATCHES: Patch[] = [
     name: '10.2.0',
     timestamp: 1699387200000, // GMT: Tuesday, 7 November 2023 22:00:00
     urlPrefix: '',
-    isCurrent: true,
+    isCurrent: false,
     gameVersion: 1, // retail
     expansion: Expansion.Dragonflight,
   },


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Mark 10.2.0 as not current.
