### PR TITLE
inspect more stack trace lines for external scripts

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -33,6 +33,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 2, 7), 'Inspect more stack trace lines for external script sources.', ToppleTheNun),
   change(date(2024, 2, 7), 'Mark 10.2.0 as an old patch.', ToppleTheNun),
   change(date(2024, 2, 7), 'Fix a crash caused by bad ads.', ToppleTheNun),
   change(date(2024, 1, 19), 'Fix Dreaming Devotion showing as a cheap enchant.', emallson),

--- a/src/interface/RootErrorBoundary.tsx
+++ b/src/interface/RootErrorBoundary.tsx
@@ -41,6 +41,14 @@ const isTriggeredByExternalScript = (error: HandledError) => {
   if (firstPath[1] !== window.location.origin) {
     return true;
   }
+  // Sometimes the second line can cause it (relevant for ads).
+  const secondPath = paths[1];
+  if (!secondPath) {
+    return true;
+  }
+  if (secondPath[1] !== window.location.origin) {
+    return true;
+  }
 
   return false;
 };


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Inspect the third line of an unhandled global promise rejection to see if it might come from an external script.