### PR TITLE
Add "Shield Size" line item to Celestial Brew breakdown

### DIFF
--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2024, 2, 11), <>Add shield size to <SpellLink spell={talents.CELESTIAL_BREW_TALENT} /> mitigation breakdown.</>, emallson),
   change(date(2024, 1, 17), 'Update Brewmaster compatibility to 10.2.5', emallson),
   change(date(2023, 11, 13), <>Add <strong>Always Be Casting</strong> section to the guide and improve handling of the <strong>Spend Cooldowns</strong> block of the <SpellLink spell={talents.BLACKOUT_COMBO_TALENT}>BoC</SpellLink> rotation.</>, emallson),
   change(date(2023, 11, 13), <>Fix display issues in the <SpellLink spell={talents.IMPROVED_INVOKE_NIUZAO_THE_BLACK_OX_TALENT} /> section.</>, emallson),

--- a/src/analysis/retail/monk/brewmaster/modules/spells/CelestialBrew/index.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/spells/CelestialBrew/index.tsx
@@ -53,6 +53,11 @@ class CelestialBrew extends MajorDefensiveBuff {
     this.active = this.selectedCombatant.hasTalent(talents.CELESTIAL_BREW_TALENT);
 
     this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(talents.CELESTIAL_BREW_TALENT),
+      this.updateMaxAbsorb,
+    );
+
+    this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(talents.CELESTIAL_BREW_TALENT),
       this._resetAbsorb,
     );
@@ -182,6 +187,17 @@ class CelestialBrew extends MajorDefensiveBuff {
         </BoringValue>
       </Statistic>
     );
+  }
+
+  maxMitigationDescription(): ReactNode {
+    return <>Shield Size</>;
+  }
+
+  private updateMaxAbsorb(event: ApplyBuffEvent) {
+    if (!event.absorb) {
+      return;
+    }
+    this.setMaxMitigation(event, event.absorb);
   }
 
   private _expirePurifiedChi(event: RemoveBuffEvent) {

--- a/src/interface/guide/components/MajorDefensives/AllCooldownUsagesList.tsx
+++ b/src/interface/guide/components/MajorDefensives/AllCooldownUsagesList.tsx
@@ -154,7 +154,7 @@ const CooldownDetails = ({
     damageTakenRows.map(([, events]) => events.reduce((a, b) => a + b.mitigatedAmount, 0)),
   );
 
-  const maxValue = Math.max(analyzer.firstSeenMaxHp, mit.amount);
+  const maxValue = Math.max(analyzer.firstSeenMaxHp, mit.amount, mit.maxAmount ?? 0);
 
   return (
     <CooldownDetailsContainer>
@@ -171,6 +171,19 @@ const CooldownDetails = ({
               />
             </td>
           </tr>
+          {mit.maxAmount && (
+            <tr>
+              <td>{analyzer.maxMitigationDescription()}</td>
+              <NumericColumn>{formatNumber(mit.maxAmount)}</NumericColumn>
+              <TableSegmentContainer>
+                <MitigationTooltipSegment
+                  color="rgba(255, 255, 255, 0.25)"
+                  maxWidth={100}
+                  width={mit.maxAmount / maxValue}
+                />
+              </TableSegmentContainer>
+            </tr>
+          )}
           <tr>
             <td colSpan={3}>
               <strong>Mitigation by Talent</strong>
@@ -184,13 +197,19 @@ const CooldownDetails = ({
                 {ix > 0 && (
                   <MitigationTooltipSegment
                     color="rgba(255, 255, 255, 0.05)"
+                    maxWidth={100}
                     width={segments.slice(0, ix).reduce((a, b) => a + b.amount, 0) / maxValue}
                   />
                 )}
-                <MitigationTooltipSegment color={seg.color} width={seg.amount / maxValue} />
+                <MitigationTooltipSegment
+                  color={seg.color}
+                  width={seg.amount / maxValue}
+                  maxWidth={100}
+                />
                 {ix < segments.length - 1 && (
                   <MitigationTooltipSegment
                     color="rgba(255, 255, 255, 0.05)"
+                    maxWidth={100}
                     width={segments.slice(ix + 1).reduce((a, b) => a + b.amount, 0) / maxValue}
                   />
                 )}

--- a/src/interface/guide/components/MajorDefensives/MajorDefensiveAnalyzer.tsx
+++ b/src/interface/guide/components/MajorDefensives/MajorDefensiveAnalyzer.tsx
@@ -89,11 +89,15 @@ export type Mitigation<Apply extends EventType = any, Remove extends EventType =
   end: AnyEvent<Remove> | FightEndEvent;
   mitigated: MitigatedEvent[];
   amount: number;
+  /**
+   * For effects that have a maximum mitigation amount (like absorbs), this represents the total possible amount mitigated. If there is no max (like most DR effects), this should be omitted.
+   */
+  maxAmount?: number;
 };
 
 type InProgressMitigation<Apply extends EventType, Remove extends EventType> = Pick<
   Mitigation<Apply, Remove>,
-  'start' | 'mitigated'
+  'start' | 'mitigated' | 'maxAmount'
 >;
 
 /**
@@ -242,6 +246,17 @@ export default class MajorDefensive<
     key && this.currentMitigations.get(key)?.mitigated.push(mitigation);
   }
 
+  /**
+   * Set the maximum amount that could be mitigated by a cast.
+   */
+  protected setMaxMitigation(event: AnyEvent, amount: number): void {
+    const key = this.getKeyForMitigation(event);
+    const current = key && this.currentMitigations.get(key);
+    if (current) {
+      current.maxAmount = amount;
+    }
+  }
+
   protected defensiveActive(event: AnyEvent): boolean {
     const key = this.getKeyForMitigation(event);
 
@@ -360,6 +375,10 @@ export default class MajorDefensive<
    */
   description(): ReactNode {
     return <>TODO</>;
+  }
+
+  maxMitigationDescription(): ReactNode {
+    return <>Max Mitigation</>;
   }
 
   /**

--- a/src/interface/guide/components/MajorDefensives/MitigationSegments.tsx
+++ b/src/interface/guide/components/MajorDefensives/MitigationSegments.tsx
@@ -28,9 +28,18 @@ const MitigationSegmentContainer = styled.div<{ rounded?: boolean }>`
 `;
 
 // we use content-box sizing with a border because that makes the hitbox bigger, so it is easier to read the tooltips.
-export const MitigationTooltipSegment = styled.div<{ color: string; width: number }>`
+export const MitigationTooltipSegment = styled.div<{
+  color: string;
+  width: number;
+  maxWidth?: number;
+}>`
   background-color: ${(props) => props.color};
-  width: calc(${(props) => Math.max(2, props.width * 100)}% - 1px);
+  width: calc(
+    ${(props) =>
+        props.maxWidth
+          ? `${Math.max(0.02, props.width)} * ${props.maxWidth}px`
+          : `${Math.max(2, props.width * 100)}%`} - 1px
+  );
   height: 100%;
   display: inline-block;
   box-sizing: content-box;


### PR DESCRIPTION
per request from Kate in peak. This shows the absorb shield size for Celestial Brew in the mitigation breakdown. This is implemented in a way that it can be used for other defensives as well (including non-absorbs that may have caps---which are usually implemented as absorbs but don't always have the cap represented in the `absorb` field of the `applybuff` event).

### Testing

Log: http://localhost:3000/report/928p6NYCnBTrwX7q/33-Mythic++Black+Rook+Hold+-+Kill+(30:33)/Bellicosus/standard

![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/4909458/bf824f8a-2300-4b4e-bb99-b4903a292c67)
