### PR TITLE
[Hunter] Workaround for Volcoross having weird events

### DIFF
--- a/src/analysis/retail/evoker/augmentation/modules/talents/BlisteringScalesStackTracker.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/BlisteringScalesStackTracker.tsx
@@ -39,6 +39,11 @@ export default class BlisteringScalesStackTracker extends Analyzer {
     ? 20
     : 15;
 
+  //Unused in this module but exists because this is a custom implementation of BuffStackTracker that is used to render a graph that relies on these values being present
+  static workaroundWeirdBuffEvents_experimental = false;
+  buffDuration = 0;
+  buffActive = false;
+
   constructor(options: Options) {
     super(options);
     this.addEventListener(
@@ -68,6 +73,11 @@ export default class BlisteringScalesStackTracker extends Analyzer {
   get trackedBuff() {
     const ctor = this.constructor as typeof BlisteringScalesStackTracker;
     return ctor.trackedBuff;
+  }
+
+  get workaroundWeirdBuffEvents_experimental() {
+    const ctor = this.constructor as typeof BlisteringScalesStackTracker;
+    return ctor.workaroundWeirdBuffEvents_experimental;
   }
 
   /** The player's buff stack amount at the current timestamp */

--- a/src/analysis/retail/hunter/beastmastery/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/beastmastery/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/hunter';
 import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 export default [
+  change(date(2024, 2, 15), <>Try to workaround weird buff events on bosses like Volcoross for <SpellLink spell={SPELLS.BARBED_SHOT_PET_BUFF} /> </>, Putro),
   change(date(2023, 11, 21), <>Update when <SpellLink spell={TALENTS.BARBED_SHOT_TALENT}  /> are marked as good or bad casts. </>, Putro),
   change(date(2023, 11, 21), <>Add <SpellLink spell={TALENTS.CALL_OF_THE_WILD_TALENT} /> to the spellbook specifying cooldown and global cooldown. </>, Putro),
   change(date(2023, 10, 18), <>Enable spec with 10.2 changes</>,Arlie),

--- a/src/analysis/retail/hunter/beastmastery/modules/guide/sections/rotation/FrenzyBuffStackTracker.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/guide/sections/rotation/FrenzyBuffStackTracker.tsx
@@ -1,13 +1,22 @@
+import {
+  ORIGINAL_FRENZY_DURATION,
+  SAVAGERY_FRENZY_DURATION,
+} from 'analysis/retail/hunter/beastmastery/constants';
 import SPELLS from 'common/SPELLS';
+import { TALENTS_HUNTER } from 'common/TALENTS';
 import { Options } from 'parser/core/Analyzer';
 import BuffStackTracker from 'parser/shared/modules/BuffStackTracker';
 
 export default class FrenzyBuffStackTracker extends BuffStackTracker {
   static trackPets = true;
   static trackedBuff = SPELLS.BARBED_SHOT_PET_BUFF;
+  static workaroundWeirdBuffEvents_experimental = true;
 
   // eslint-disable-next-line @typescript-eslint/no-useless-constructor
   constructor(options: Options) {
     super(options);
+    this.buffDuration = this.selectedCombatant.hasTalent(TALENTS_HUNTER.SAVAGERY_TALENT)
+      ? SAVAGERY_FRENZY_DURATION
+      : ORIGINAL_FRENZY_DURATION;
   }
 }

--- a/src/analysis/retail/hunter/beastmastery/modules/talents/BarbedShot.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/talents/BarbedShot.tsx
@@ -20,7 +20,6 @@ import Events, {
 } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import { currentStacks } from 'parser/shared/modules/helpers/Stacks';
-import Pets from 'parser/shared/modules/Pets';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import Statistic from 'parser/ui/Statistic';
@@ -44,12 +43,10 @@ import SpellUsable from '../core/SpellUsable';
 class BarbedShot extends Analyzer {
   static dependencies = {
     spellUsable: SpellUsable,
-    pets: Pets,
     globalCooldown: GlobalCooldown,
   };
 
   protected spellUsable!: SpellUsable;
-  protected pets!: Pets;
   protected globalCooldown!: GlobalCooldown;
 
   barbedShotStacks: number[][] = [];
@@ -162,6 +159,13 @@ class BarbedShot extends Analyzer {
       return;
     }
     this.lastBarbedShotUpdate = event.timestamp;
+    //Bosses like Volcoross are shit and will trigger ApplyBuffEvents without the buff having expired, and it should have been RefreshBuffEvent instead
+    if (
+      event.type === EventType.ApplyBuff &&
+      event.timestamp < this.lastBarbedShotUpdate + this.frenzyBuffDuration
+    ) {
+      return;
+    }
     this.lastBarbedShotStack = currentStacks(event);
   }
 


### PR DESCRIPTION
Volcoross is notoriously bad at having events that make no sense, e.g. https://www.warcraftlogs.com/reports/qpJ4tV8aYZ6CRGrL#fight=10&type=auras&source=45&ability=272790&view=events where Apply Buff events are going out without the buff expiring. This adds a new flag to the buff tracker labelled as experimental because it might have other adverse side effects and uses that to try and work around the weird events.

I'm not at all personally  convinced this is worth having in because it's one boss and the events are super scuffed for this boss in particular, so maybe this doesn't even make it analyzable on it's own... 

# Before:
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/29204244/490d0df5-76f6-450f-928d-4feae1c77eda)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/29204244/a8c838c4-edd9-4c89-a8b0-38a02c52543f)


# After 
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/29204244/988b43dd-328d-4cca-9fe3-2a821218e1d2)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/29204244/3b1d47af-8754-41a6-bd01-e886ec276b1b)
