### PR TITLE
[Classic] Add a missed realm to the CLASSIC_REALMS const

### DIFF
--- a/scripts/realms/output.ts
+++ b/scripts/realms/output.ts
@@ -954,6 +954,7 @@ export const REALMS: Record<Region, Realm[]> = {
 
 export const CLASSIC_REALMS: Record<ClassicRegion, Realm[]> = {
   EU: [
+    { name: 'Earthshaker', slug: 'earthshaker' },
     { name: 'Amnennar', slug: 'amnennar' },
     { name: 'Auberdine', slug: 'auberdine' },
     { name: 'Everlook', slug: 'everlook' },

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -33,6 +33,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 2, 17), 'Add a missed realm for Classic.', Putro),
   change(date(2024, 2, 7), 'Inspect more stack trace lines for external script sources.', ToppleTheNun),
   change(date(2024, 2, 7), 'Mark 10.2.0 as an old patch.', ToppleTheNun),
   change(date(2024, 2, 7), 'Fix a crash caused by bad ads.', ToppleTheNun),


### PR DESCRIPTION
Just a missed realm. 
I went through this list and we have all the other realms: https://www.warcrafttavern.com/population/wotlk