### PR TITLE
Fix crash in getLowestPerf

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -33,6 +33,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 2, 18), <>Fix crash in QualitativePerformance</>, Trevor),
   change(date(2024, 2, 17), 'Add a missed realm for Classic.', Putro),
   change(date(2024, 2, 7), 'Inspect more stack trace lines for external script sources.', ToppleTheNun),
   change(date(2024, 2, 7), 'Mark 10.2.0 as an old patch.', ToppleTheNun),

--- a/src/parser/ui/QualitativePerformance.ts
+++ b/src/parser/ui/QualitativePerformance.ts
@@ -24,6 +24,9 @@ export const enum QualitativePerformance {
  */
 export function getAveragePerf(perfs: QualitativePerformance[]) {
   let total = 0;
+  if (perfs.length === 0) {
+    return QualitativePerformance.Fail;
+  }
   const order = [
     QualitativePerformance.Fail,
     QualitativePerformance.Ok,
@@ -45,7 +48,10 @@ export function getAveragePerf(perfs: QualitativePerformance[]) {
  * @param perfs array of QualitativePerformance enums
  * @returns lowest QualitativePerformance in array
  */
-export function getLowestPerf(perfs: QualitativePerformance[]) {
+export function getLowestPerf(perfs: QualitativePerformance[]): QualitativePerformance {
+  if (perfs.length === 0) {
+    return QualitativePerformance.Fail;
+  }
   const order = [
     QualitativePerformance.Fail,
     QualitativePerformance.Ok,

--- a/src/parser/ui/QualitativePerformance.ts
+++ b/src/parser/ui/QualitativePerformance.ts
@@ -23,10 +23,10 @@ export const enum QualitativePerformance {
  * @returns average QualitativePerformance in array
  */
 export function getAveragePerf(perfs: QualitativePerformance[]) {
-  let total = 0;
   if (perfs.length === 0) {
     return QualitativePerformance.Fail;
   }
+  let total = 0;
   const order = [
     QualitativePerformance.Fail,
     QualitativePerformance.Ok,


### PR DESCRIPTION
We weren't checking if passed in perf list was present which led to crash, this PR changes it to just return fail. Fixes #6508 