### PR TITLE
switch to assets.rpglogs.com for WoW Icons

### DIFF
--- a/scripts/talents/generate-talents.ts
+++ b/scripts/talents/generate-talents.ts
@@ -107,7 +107,7 @@ const entryToSpell = (
 ): GenericTalentInterface => ({
   id: entry.spellId!,
   name: entry.name!,
-  icon: entry.icon,
+  icon: entry.icon.replace(/\.(tga|jpg)$/, ''),
   //additional DF tree information
   maxRanks: entry.maxRanks,
   //reqPoints: classTalent.reqPoints ?? 0,

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -33,6 +33,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 2, 26), 'Switch icon source to the WCL CDN.', emallson),
   change(date(2024, 2, 18), <>Fix crash in QualitativePerformance</>, Trevor),
   change(date(2024, 2, 17), 'Add a missed realm for Classic.', Putro),
   change(date(2024, 2, 7), 'Inspect more stack trace lines for external script sources.', ToppleTheNun),

--- a/src/analysis/retail/deathknight/blood/modules/Abilities.ts
+++ b/src/analysis/retail/deathknight/blood/modules/Abilities.ts
@@ -203,7 +203,7 @@ class Abilities extends CoreAbilities {
         timelineSortIndex: 9,
       },
       {
-        spell: TALENTS.EMPOWER_RUNE_WEAPON_SHARED_TALENT.id,
+        spell: SPELLS.EMPOWER_RUNE_WEAPON.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         //buff spell id later?
         enabled: combatant.hasTalent(TALENTS.EMPOWER_RUNE_WEAPON_SHARED_TALENT),

--- a/src/common/SPELLS/others.ts
+++ b/src/common/SPELLS/others.ts
@@ -316,7 +316,7 @@ const spells = {
   HEALTHSTONE: {
     id: 6262,
     name: 'Healthstone',
-    icon: 'warlock_healthstone',
+    icon: 'warlock_-healthstone',
   },
   ANCIENT_REJUVENATION_POTION: {
     id: 188018,

--- a/src/common/SPELLS/warlock.ts
+++ b/src/common/SPELLS/warlock.ts
@@ -22,7 +22,7 @@ const spells = {
   CREATE_HEALTHSTONE: {
     id: 6201,
     name: 'Create Healthstone',
-    icon: 'warlock_healthstone',
+    icon: 'warlock_-healthstone',
   },
   CREATE_SOULWELL: {
     id: 29893,

--- a/src/common/TALENTS/deathknight.ts
+++ b/src/common/TALENTS/deathknight.ts
@@ -446,7 +446,7 @@ const talents = {
     definitionIds: [{ id: 101231, specId: 251 }],
   },
   EMPOWER_RUNE_WEAPON_SHARED_TALENT: {
-    id: 47568,
+    id: 392962,
     name: 'Empower Rune Weapon',
     icon: 'inv_sword_62',
     maxRanks: 1,

--- a/src/common/TALENTS/druid.ts
+++ b/src/common/TALENTS/druid.ts
@@ -840,7 +840,7 @@ const talents = {
   MAIM_TALENT: {
     id: 22570,
     name: 'Maim',
-    icon: 'ability_druid_mangle.tga',
+    icon: 'ability_druid_mangle',
     maxRanks: 1,
     entryIds: [103299],
     definitionIds: [{ id: 108304, specId: 102 }],

--- a/src/interface/BAD_ICONS.ts
+++ b/src/interface/BAD_ICONS.ts
@@ -5,25 +5,5 @@
 // or https://media-azeroth.cursecdn.com/wow/icons/large/????????.jpg
 // some icons have in their corners lighter pixels, might require some photoshop-skills
 
-const BAD_ICONS = [
-  'spell_deathknight_bloodboil',
-  'spell_deathknight_butcher2',
-  'spell_shadow_abominationexplosion',
-  'talentspec_druid_feral_cat',
-  'talentspec_druid_feral_bear',
-  'inv_cosmicvoid_debuff',
-  'inv_misc_bone_skull_01',
-  'inv_10_elementalshardfoozles_shadowflame',
-  'spell_animarevendreth_beam',
-  'ability_ardenweald_paladin_autumn',
-  'ability_ardenweald_paladin_spring',
-  'ability_ardenweald_paladin_summer',
-  'ability_ardenweald_paladin_winter',
-  'ability_ardenweald_paladin_winter',
-  'inv_10_elementalshardfoozles_shadowflame',
-  'spell_priest_void_flay',
-  'spell_priest_shadow_mend',
-  'spell_priest_void_blast',
-  'inv_axe_2h_fyrakk_d_01_shadowflame',
-];
+const BAD_ICONS: string[] = [];
 export default BAD_ICONS;

--- a/src/interface/Icon.tsx
+++ b/src/interface/Icon.tsx
@@ -17,17 +17,9 @@ const Icon = ({ icon, className, alt = '', ...others }: IconProps) => {
   if (!icon) {
     return null;
   }
-  icon = icon.replace('.jpg', '').replace(/-/g, '');
-  if (icon === 'petbattle_healthdown') {
-    // Blizzard seems to have forgotten to remove the dash for this one... or something
-    icon = 'petbattle_health-down';
-  }
-  if (icon === 'class_demonhunter') {
-    // Blizzard seems to have forgotten to remove the dash for this one too
-    icon = 'class_demon-hunter';
-  }
+  icon = icon.replace('.jpg', '');
 
-  let baseURL = `//render-us.worldofwarcraft.com/icons/56`;
+  let baseURL = `https://assets.rpglogs.com/img/warcraft/abilities`;
   if (BAD_ICONS.includes(icon)) {
     baseURL = `/img/Icons`;
   }

--- a/src/parser/shared/metrics/apl/annotate.test.tsx.snap
+++ b/src/parser/shared/metrics/apl/annotate.test.tsx.snap
@@ -14,7 +14,7 @@ Array [
     <img
       alt=""
       className="icon game "
-      src="//render-us.worldofwarcraft.com/icons/56/inv_misc_questionmark.jpg"
+      src="https://assets.rpglogs.com/img/warcraft/abilities/inv_misc_questionmark.jpg"
     />
      
     Unknown spell: 2


### PR DESCRIPTION
the WoW CDN is notoriously flaky with icon names. this also nukes the BAD_ICONS list, which should (hopefully) be fine.

I went through a few different specs that had exceptions in the list and checked them:

- DK (Blood)
- DH (Havoc)
- Druid (Guardian, Resto)

things generally look fine. Worth loading up on your local and double-checking, since this impacts all specs.

The one I know that is messed up is the Chi Surge icon for Brewmaster, which is also messed up on WCL (sigh)