### PR TITLE
[Core] Adjust tertiary stat penalty

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -33,6 +33,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 2, 29), 'Correct incorrect tertiary stat scaling above 25% raw and 19% character sheet rating', Putro),
   change(date(2024, 2, 26), 'Switch icon source to the WCL CDN.', emallson),
   change(date(2024, 2, 18), <>Fix crash in QualitativePerformance</>, Trevor),
   change(date(2024, 2, 17), 'Add a missed realm for Classic.', Putro),

--- a/src/parser/shared/modules/StatTracker.ts
+++ b/src/parser/shared/modules/StatTracker.ts
@@ -214,7 +214,7 @@ class StatTracker extends Analyzer {
     { base: 0.1, scaled: 0.1, penaltyAboveThis: 0.2 },
     { base: 0.15, scaled: 0.14, penaltyAboveThis: 0.4 },
     { base: 0.2, scaled: 0.17, penaltyAboveThis: 0.6 },
-    { base: 0.25, scaled: 0.19, penaltyAboveThis: 0.8 },
+    { base: 0.25, scaled: 0.19, penaltyAboveThis: 0.6 },
     { base: 1, scaled: 0.49, penaltyAboveThis: 1 },
   ];
 


### PR DESCRIPTION
I guess I forgot to math at some point or the values were different once upon a time, either way the penalty above having 25% raw of a given tertiary was incorrect and has been adjusted. 

1-(49-19)/(100-25) = 0.6 not 0.8

2022 me couldn't math in this commit https://github.com/WoWAnalyzer/WoWAnalyzer/commit/225d3821ef07b4e8c292763a8217c3b860d5e8d5 