### PR TITLE
add an ICON_RENAME map to handle mismatching PW:R names

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -34,6 +34,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 3, 2), 'Correct an issue with the Power Word: Radiance icon.', emallson),
   change(date(2024, 3, 2), 'Correct incorrect tertiary stat scaling above 25% raw and 19% character sheet rating', Putro),
   change(date(2024, 2, 26), <>Added checklist support for <ItemLink id={ITEMS.IRIDAL_THE_EARTHS_MASTER.id}/>, <ItemLink id={ITEMS.DREAMBINDER_LOOM_OF_THE_GREAT_CYCLE.id}/>, <ItemLink id={ITEMS.BELORRELOS_THE_SUNCALLER.id}/>, <ItemLink id={ITEMS.NYMUES_UNRAVELING_SPINDLE.id}/></>, Zyer),
   change(date(2024, 2, 26), 'Switch icon source to the WCL CDN.', emallson),

--- a/src/interface/BAD_ICONS.ts
+++ b/src/interface/BAD_ICONS.ts
@@ -7,3 +7,7 @@
 
 const BAD_ICONS: string[] = [];
 export default BAD_ICONS;
+
+export const ICON_RENAME: Record<string, string> = {
+  spell_priest_power_word: 'spell_priest_power-word',
+};

--- a/src/interface/Icon.tsx
+++ b/src/interface/Icon.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import BAD_ICONS from './BAD_ICONS';
+import BAD_ICONS, { ICON_RENAME } from './BAD_ICONS';
 
 export interface IconProps extends React.HTMLAttributes<HTMLImageElement> {
   icon?: string;
@@ -18,6 +18,10 @@ const Icon = ({ icon, className, alt = '', ...others }: IconProps) => {
     return null;
   }
   icon = icon.replace('.jpg', '');
+
+  if (ICON_RENAME[icon]) {
+    icon = ICON_RENAME[icon];
+  }
 
   let baseURL = `https://assets.rpglogs.com/img/warcraft/abilities`;
   if (BAD_ICONS.includes(icon)) {


### PR DESCRIPTION
the actual icon path in-game has a space in it. Raidbots data fills with a `_`, while WCL & Wowhead both fill with a `-`.

I've reported the situation in the raidbots discord, will see what they say.

This adds a general map that we can use to fix cases like this.

In 11.0, maybe we also use the WCL talent data files to make sure the icon names match?

### Testing

Tested on the example log for Disc Priest
