### PR TITLE
[Devastation] Improve clarity for Disintegrate graph module

### DIFF
--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SPELLS from 'common/SPELLS/evoker';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 export default [
+  change(date(2024, 3, 6), <>Make it more apparent that you can mouseover points in the <SpellLink spell={SPELLS.DISINTEGRATE} /> graph.</>, Vollmer),
   change(date(2024, 2, 10), <>Fix crash in <SpellLink spell={TALENTS.SOURCE_OF_MAGIC_TALENT} /> module.</>, Trevor),
   change(date(2024, 2, 3), <>Implement <SpellLink spell={TALENTS.SOURCE_OF_MAGIC_TALENT} /> and <SpellLink spell={TALENTS.POTENT_MANA_TALENT} /> modules.</>, Vollmer),
   change(date(2024, 1, 17), <>Mark as updated for 10.2.5.</>, Vollmer),

--- a/src/analysis/retail/evoker/devastation/modules/abilities/Disintegrate.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/abilities/Disintegrate.tsx
@@ -21,6 +21,7 @@ import ExplanationGraph, {
 import { SpellLink } from 'interface';
 import { DISINTEGRATE_REMOVE_APPLY } from '../normalizers/CastLinkNormalizer';
 import { isMythicPlus } from 'common/isMythicPlus';
+import { InformationIcon } from 'interface/icons';
 
 const { DISINTEGRATE } = SPELLS;
 
@@ -436,7 +437,10 @@ class Disintegrate extends Analyzer {
               <SpellLink spell={DRAGONRAGE_TALENT} /> is shown as a filled in background.
             </li>
           </ul>
-          Mouseover each point for more detailed explanations.
+          <br />
+          <b>
+            <InformationIcon /> Mouseover each point on the graph for more detailed explanations.
+          </b>
         </div>
         <ExplanationGraph
           fightStartTime={this.owner.fight.start_time}


### PR DESCRIPTION
### Description

It was pointed out that it was easy to miss the fact that you could mouseover points on the Disintegrate graph, as such I've made changes to make it more apparent.

Before:
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/5b2ac53a-e53d-4c53-8d6f-d4b7d5e8a3cb)

After:
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/a566e0d0-ae39-41f5-8ff1-c1c0d1d74aad)

