### PR TITLE
[Evoker] Fix an issue with Potent Magic module when no Source of Magic was active

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SPELLS from 'common/SPELLS/evoker';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 export default [
+    change(date(2024, 3, 7), <>Fix an issue with <SpellLink spell={TALENTS.POTENT_MANA_TALENT} /> module when no <SpellLink spell={TALENTS.SOURCE_OF_MAGIC_TALENT} /> was active during the fight.</>, Vollmer),
     change(date(2024, 2, 10), <>Fix crash in <SpellLink spell={TALENTS.SOURCE_OF_MAGIC_TALENT} /> module.</>, Trevor),
     change(date(2024, 2, 3), <>Implement <SpellLink spell={TALENTS.SOURCE_OF_MAGIC_TALENT} /> and <SpellLink spell={TALENTS.POTENT_MANA_TALENT} /> modules.</>, Vollmer),
     change(date(2024, 1, 26), <>Show 4 default targets instead of 2 for Buff Helper MRT note.</>, Vollmer),

--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SPELLS from 'common/SPELLS/evoker';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 export default [
+  change(date(2024, 3, 7), <>Fix an issue with <SpellLink spell={TALENTS.POTENT_MANA_TALENT} /> module when no <SpellLink spell={TALENTS.SOURCE_OF_MAGIC_TALENT} /> was active during the fight.</>, Vollmer),
   change(date(2024, 2, 10), <>Fix crash in <SpellLink spell={TALENTS.SOURCE_OF_MAGIC_TALENT} /> module.</>, Trevor),
   change(date(2024, 2, 3), <>Implement <SpellLink spell={TALENTS.SOURCE_OF_MAGIC_TALENT} /> and <SpellLink spell={TALENTS.POTENT_MANA_TALENT} /> modules.</>, Vollmer),
   change(date(2024, 1, 17), <>Mark as updated for 10.2.5.</>, Vollmer),

--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { ResourceLink, SpellLink } from 'interface';
 
 export default [
+  change(date(2024, 3, 7), <>Fix an issue with <SpellLink spell={TALENTS_EVOKER.POTENT_MANA_TALENT} /> module when no <SpellLink spell={TALENTS_EVOKER.SOURCE_OF_MAGIC_TALENT} /> was active during the fight.</>, Vollmer),
   change(date(2024, 2, 18), <>Add spell cast time to <SpellLink spell={TALENTS_EVOKER.STASIS_TALENT}/> module</>, Trevor),
   change(date(2024, 2, 10), <>Fix crash in <SpellLink spell={TALENTS_EVOKER.SOURCE_OF_MAGIC_TALENT} /> module.</>, Trevor),
   change(date(2024, 2, 3), <>Implement <SpellLink spell={TALENTS_EVOKER.SOURCE_OF_MAGIC_TALENT} /> and <SpellLink spell={TALENTS_EVOKER.POTENT_MANA_TALENT} /> modules.</>, Vollmer),

--- a/src/analysis/retail/evoker/shared/modules/talents/PotentMana.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/PotentMana.tsx
@@ -51,6 +51,10 @@ class PotentMana extends SourceOfMagic {
   }
 
   async load() {
+    if (!this.sourceOfMagicWindows.length) {
+      return;
+    }
+
     const fetchPromises = {
       healingTable: await fetchWcl<WCLHealingTableResponse>(
         `report/tables/healing/${this.owner.report.code}`,

--- a/src/analysis/retail/evoker/shared/modules/talents/SourceOfMagic.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/SourceOfMagic.tsx
@@ -121,7 +121,7 @@ class SourceOfMagic extends Analyzer {
   }
 
   statistic() {
-    if (!this.active || !this.sourceOfMagicWindows.length) {
+    if (!this.active) {
       return null;
     }
 


### PR DESCRIPTION
### Description
Potent Magic stat module would grab raid dps when no `Source of Magic` was active, this is now fixed.

### Testing

- Test report URL: `/report/DgK2WX6aM9HL7rqp/114-Mythic+Volcoross+-+Kill+(3:58)/Anaella/standard/statistics`
